### PR TITLE
monster_sbin clean-up

### DIFF
--- a/data/ax/abra.inc
+++ b/data/ax/abra.inc
@@ -1,0 +1,2723 @@
+.global gAxAbra
+gAxAbra:
+ax_siro sAxMainAbra
+sAbraPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose4:
+ax_pose 3, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose5:
+ax_pose 4, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose7:
+ax_pose 6, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose8:
+ax_pose 7, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose9:
+ax_pose 8, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose10:
+ax_pose 9, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose11:
+ax_pose 10, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose12:
+ax_pose 11, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose14:
+ax_pose 13, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose15:
+ax_pose 14, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose19:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose20:
+ax_pose 7, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose21:
+ax_pose 8, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose22:
+ax_pose 3, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose23:
+ax_pose 4, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose24:
+ax_pose 5, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose28:
+ax_pose 3, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose29:
+ax_pose 4, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose30:
+ax_pose 5, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose31:
+ax_pose 6, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose32:
+ax_pose 7, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose33:
+ax_pose 8, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose34:
+ax_pose 9, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose35:
+ax_pose 10, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose36:
+ax_pose 11, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose37:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose38:
+ax_pose 13, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose39:
+ax_pose 14, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose40:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose41:
+ax_pose 10, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose42:
+ax_pose 11, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose43:
+ax_pose 6, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose44:
+ax_pose 7, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose45:
+ax_pose 8, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose46:
+ax_pose 3, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose47:
+ax_pose 4, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose48:
+ax_pose 5, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose49:
+ax_pose 0, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose50:
+ax_pose 15, 0x01e8, 0x80f6, 0x4c00
+ax_pose_terminator
+sAbraPose51:
+ax_pose 16, 0x81e8, 0x80f4, 0x4c00
+ax_pose 17, 0x01e8, 0x80f4, 0x4c08
+ax_pose_terminator
+sAbraPose52:
+ax_pose 17, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose53:
+ax_pose 3, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose54:
+ax_pose 18, 0x01e9, 0x90e9, 0x4c00
+ax_pose_terminator
+sAbraPose55:
+ax_pose 19, 0x81e7, 0x90fb, 0x4c00
+ax_pose 20, 0x01e9, 0x90eb, 0x4c08
+ax_pose_terminator
+sAbraPose56:
+ax_pose 20, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose57:
+ax_pose 6, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose58:
+ax_pose 21, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sAbraPose59:
+ax_pose 22, 0x41eb, 0x90f0, 0x4c00
+ax_pose 23, 0x01e8, 0x90f0, 0x4c08
+ax_pose_terminator
+sAbraPose60:
+ax_pose 23, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sAbraPose61:
+ax_pose 9, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose62:
+ax_pose 24, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose63:
+ax_pose 25, 0x81e7, 0x90ee, 0x4c00
+ax_pose 26, 0x01e8, 0x90ec, 0x4c08
+ax_pose_terminator
+sAbraPose64:
+ax_pose 26, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose65:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose66:
+ax_pose 27, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose67:
+ax_pose 28, 0x81e9, 0x8104, 0x4c00
+ax_pose 29, 0x01e9, 0x80f4, 0x4c08
+ax_pose_terminator
+sAbraPose68:
+ax_pose 29, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose69:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose70:
+ax_pose 24, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose71:
+ax_pose 25, 0x81e7, 0x8102, 0x4c00
+ax_pose 26, 0x01e8, 0x80f4, 0x4c08
+ax_pose_terminator
+sAbraPose72:
+ax_pose 26, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose73:
+ax_pose 6, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose74:
+ax_pose 21, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sAbraPose75:
+ax_pose 22, 0x41eb, 0x80f0, 0x4c00
+ax_pose 23, 0x01e8, 0x80f0, 0x4c08
+ax_pose_terminator
+sAbraPose76:
+ax_pose 23, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sAbraPose77:
+ax_pose 3, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose78:
+ax_pose 18, 0x01e9, 0x80f7, 0x4c00
+ax_pose_terminator
+sAbraPose79:
+ax_pose 19, 0x81e7, 0x80f5, 0x4c00
+ax_pose 20, 0x01e9, 0x80f5, 0x4c08
+ax_pose_terminator
+sAbraPose80:
+ax_pose 20, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose81:
+ax_pose 30, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose82:
+ax_pose 31, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose83:
+ax_pose 32, 0x81e3, 0x80fb, 0x4c00
+ax_pose_terminator
+sAbraPose84:
+ax_pose 33, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sAbraPose85:
+ax_pose 34, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose86:
+ax_pose 33, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sAbraPose87:
+ax_pose 32, 0x81e3, 0x90f5, 0x4c00
+ax_pose_terminator
+sAbraPose88:
+ax_pose 31, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose89:
+ax_pose 0, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose90:
+ax_pose 30, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose91:
+ax_pose 35, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose92:
+ax_pose 3, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose93:
+ax_pose 31, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose94:
+ax_pose 36, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose95:
+ax_pose 6, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose96:
+ax_pose 32, 0x81e3, 0x90f6, 0x4c00
+ax_pose_terminator
+sAbraPose97:
+ax_pose 37, 0x01e8, 0x90ea, 0x4c00
+ax_pose_terminator
+sAbraPose98:
+ax_pose 9, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose99:
+ax_pose 33, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose100:
+ax_pose 38, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose101:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose102:
+ax_pose 34, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose103:
+ax_pose 39, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose104:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose105:
+ax_pose 33, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose106:
+ax_pose 38, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose107:
+ax_pose 6, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose108:
+ax_pose 32, 0x81e3, 0x80fa, 0x4c00
+ax_pose_terminator
+sAbraPose109:
+ax_pose 37, 0x01e8, 0x80f6, 0x4c00
+ax_pose_terminator
+sAbraPose110:
+ax_pose 3, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose111:
+ax_pose 31, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose112:
+ax_pose 36, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose113:
+ax_pose 40, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose114:
+ax_pose 41, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose115:
+ax_pose 42, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sAbraPose116:
+ax_pose 43, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose117:
+ax_pose 44, 0x01e2, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose118:
+ax_pose 45, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sAbraPose119:
+ax_pose 46, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAbraPose120:
+ax_pose 45, 0x01e3, 0x80f3, 0x4c00
+ax_pose_terminator
+sAbraPose121:
+ax_pose 44, 0x01e2, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose122:
+ax_pose 43, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose123:
+ax_pose 0, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose124:
+ax_pose 30, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose125:
+ax_pose 3, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose126:
+ax_pose 31, 0x01e9, 0x90ed, 0x4c00
+ax_pose_terminator
+sAbraPose127:
+ax_pose 6, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose128:
+ax_pose 32, 0x81e3, 0x90f5, 0x4c00
+ax_pose_terminator
+sAbraPose129:
+ax_pose 9, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose130:
+ax_pose 33, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sAbraPose131:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose132:
+ax_pose 34, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose133:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose134:
+ax_pose 33, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sAbraPose135:
+ax_pose 6, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose136:
+ax_pose 32, 0x81e3, 0x80fb, 0x4c00
+ax_pose_terminator
+sAbraPose137:
+ax_pose 3, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose138:
+ax_pose 31, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sAbraPose139:
+ax_pose 35, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose140:
+ax_pose 36, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose141:
+ax_pose 37, 0x01e8, 0x80f6, 0x4c00
+ax_pose_terminator
+sAbraPose142:
+ax_pose 38, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose143:
+ax_pose 39, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose144:
+ax_pose 38, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose145:
+ax_pose 37, 0x01e8, 0x90ea, 0x4c00
+ax_pose_terminator
+sAbraPose146:
+ax_pose 36, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose147:
+ax_pose 30, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose148:
+ax_pose 31, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose149:
+ax_pose 32, 0x81e3, 0x90f5, 0x4c00
+ax_pose_terminator
+sAbraPose150:
+ax_pose 33, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sAbraPose151:
+ax_pose 34, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose152:
+ax_pose 33, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sAbraPose153:
+ax_pose 32, 0x81e3, 0x80fb, 0x4c00
+ax_pose_terminator
+sAbraPose154:
+ax_pose 31, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose155:
+ax_pose 0, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose156:
+ax_pose 30, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose157:
+ax_pose 35, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose158:
+ax_pose 3, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose159:
+ax_pose 31, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose160:
+ax_pose 36, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sAbraPose161:
+ax_pose 6, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose162:
+ax_pose 32, 0x81e3, 0x90f6, 0x4c00
+ax_pose_terminator
+sAbraPose163:
+ax_pose 37, 0x01e8, 0x90ea, 0x4c00
+ax_pose_terminator
+sAbraPose164:
+ax_pose 9, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose165:
+ax_pose 33, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sAbraPose166:
+ax_pose 38, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose167:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose168:
+ax_pose 34, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose169:
+ax_pose 39, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose170:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose171:
+ax_pose 33, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sAbraPose172:
+ax_pose 38, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose173:
+ax_pose 6, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose174:
+ax_pose 32, 0x81e3, 0x80fa, 0x4c00
+ax_pose_terminator
+sAbraPose175:
+ax_pose 37, 0x01e8, 0x80f6, 0x4c00
+ax_pose_terminator
+sAbraPose176:
+ax_pose 3, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose177:
+ax_pose 31, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose178:
+ax_pose 36, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose179:
+ax_pose 30, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose180:
+ax_pose 31, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose181:
+ax_pose 32, 0x81e3, 0x80fb, 0x4c00
+ax_pose_terminator
+sAbraPose182:
+ax_pose 33, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sAbraPose183:
+ax_pose 34, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose184:
+ax_pose 33, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sAbraPose185:
+ax_pose 32, 0x81e3, 0x90f5, 0x4c00
+ax_pose_terminator
+sAbraPose186:
+ax_pose 31, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose187:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose188:
+ax_pose 3, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sAbraPose189:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose190:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose191:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sAbraPose192:
+ax_pose 9, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose193:
+ax_pose 6, 0x01e7, 0x90ec, 0x4c00
+ax_pose_terminator
+sAbraPose194:
+ax_pose 3, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+.align 2
+sAbraAnims_1_1:
+ax_anim 8, 0, 0, 0, -4, 0, 0,
+ax_anim 10, 0, 1, 0, -5, 0, 0,
+ax_anim 8, 0, 0, 0, -6, 0, 0,
+ax_anim 10, 0, 2, 0, -6, 0, 0,
+ax_anim 8, 0, 0, 0, -5, 0, 0,
+ax_anim 10, 0, 1, 0, -4, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 10, 0, 2, 0, -3, 0, 0,
+ax_anim_terminator
+sAbraAnims_1_2:
+ax_anim 8, 0, 3, 0, -4, 0, 0,
+ax_anim 10, 0, 4, 0, -5, 0, 0,
+ax_anim 8, 0, 3, 0, -6, 0, 0,
+ax_anim 10, 0, 5, 0, -6, 0, 0,
+ax_anim 8, 0, 3, 0, -5, 0, 0,
+ax_anim 10, 0, 4, 0, -4, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 10, 0, 5, 0, -3, 0, 0,
+ax_anim_terminator
+sAbraAnims_1_3:
+ax_anim 8, 0, 6, 0, -4, 0, 0,
+ax_anim 10, 0, 7, 0, -5, 0, 0,
+ax_anim 8, 0, 6, 0, -6, 0, 0,
+ax_anim 10, 0, 8, 0, -6, 0, 0,
+ax_anim 8, 0, 6, 0, -5, 0, 0,
+ax_anim 10, 0, 7, 0, -4, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 10, 0, 8, 0, -3, 0, 0,
+ax_anim_terminator
+sAbraAnims_1_4:
+ax_anim 8, 0, 9, 0, -4, 0, 0,
+ax_anim 10, 0, 10, 0, -5, 0, 0,
+ax_anim 8, 0, 9, 0, -6, 0, 0,
+ax_anim 10, 0, 11, 0, -6, 0, 0,
+ax_anim 8, 0, 9, 0, -5, 0, 0,
+ax_anim 10, 0, 10, 0, -4, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 10, 0, 11, 0, -3, 0, 0,
+ax_anim_terminator
+sAbraAnims_1_5:
+ax_anim 8, 0, 12, 0, -4, 0, 0,
+ax_anim 10, 0, 13, 0, -5, 0, 0,
+ax_anim 8, 0, 12, 0, -6, 0, 0,
+ax_anim 10, 0, 14, 0, -6, 0, 0,
+ax_anim 8, 0, 12, 0, -5, 0, 0,
+ax_anim 10, 0, 13, 0, -4, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 10, 0, 14, 0, -3, 0, 0,
+ax_anim_terminator
+sAbraAnims_1_6:
+ax_anim 8, 0, 15, 0, -4, 0, 0,
+ax_anim 10, 0, 16, 0, -5, 0, 0,
+ax_anim 8, 0, 15, 0, -6, 0, 0,
+ax_anim 10, 0, 17, 0, -6, 0, 0,
+ax_anim 8, 0, 15, 0, -5, 0, 0,
+ax_anim 10, 0, 16, 0, -4, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 10, 0, 17, 0, -3, 0, 0,
+ax_anim_terminator
+sAbraAnims_1_7:
+ax_anim 8, 0, 18, 0, -4, 0, 0,
+ax_anim 10, 0, 19, 0, -5, 0, 0,
+ax_anim 8, 0, 18, 0, -6, 0, 0,
+ax_anim 10, 0, 20, 0, -6, 0, 0,
+ax_anim 8, 0, 18, 0, -5, 0, 0,
+ax_anim 10, 0, 19, 0, -4, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 10, 0, 20, 0, -3, 0, 0,
+ax_anim_terminator
+sAbraAnims_1_8:
+ax_anim 8, 0, 21, 0, -4, 0, 0,
+ax_anim 10, 0, 22, 0, -5, 0, 0,
+ax_anim 8, 0, 21, 0, -6, 0, 0,
+ax_anim 10, 0, 23, 0, -6, 0, 0,
+ax_anim 8, 0, 21, 0, -5, 0, 0,
+ax_anim 10, 0, 22, 0, -4, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 10, 0, 23, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 24, 0, 23,
+ax_anim 2, 1, 25, 1, 24, 1, 23,
+ax_anim 2, 0, 25, 0, 24, 0, 23,
+ax_anim 2, 0, 25, 1, 24, 1, 23,
+ax_anim 4, 0, 24, 0, 8, 0, 8,
+ax_anim_terminator
+sAbraAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 13, 10, 10,
+ax_anim 2, 0, 28, 20, 24, 20, 21,
+ax_anim 2, 1, 28, 21, 23, 21, 20,
+ax_anim 2, 0, 28, 20, 24, 20, 21,
+ax_anim 2, 0, 28, 21, 23, 21, 20,
+ax_anim 4, 0, 27, 8, 10, 6, 6,
+ax_anim_terminator
+sAbraAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 2, 10, 0,
+ax_anim 2, 0, 31, 22, 2, 22, 0,
+ax_anim 2, 1, 31, 22, 3, 22, 1,
+ax_anim 2, 0, 31, 22, 2, 22, 0,
+ax_anim 2, 0, 31, 22, 3, 22, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sAbraAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 10, -8, 10, -10,
+ax_anim 2, 0, 34, 20, -16, 18, -18,
+ax_anim 2, 1, 34, 21, -15, 19, -17,
+ax_anim 2, 0, 34, 20, -16, 18, -18,
+ax_anim 2, 0, 34, 21, -15, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sAbraAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sAbraAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -10, -8, -10, -10,
+ax_anim 2, 0, 40, -20, -16, -18, -18,
+ax_anim 2, 1, 40, -21, -15, -19, -17,
+ax_anim 2, 0, 40, -20, -16, -18, -18,
+ax_anim 2, 0, 40, -21, -15, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sAbraAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 2, -10, 0,
+ax_anim 2, 0, 43, -22, 2, -22, 0,
+ax_anim 2, 1, 43, -22, 3, -22, 1,
+ax_anim 2, 0, 43, -22, 2, -22, 0,
+ax_anim 2, 0, 43, -22, 3, -22, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sAbraAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, -1, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 13, -10, 10,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 1, 46, -21, 18, -21, 18,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sAbraAnims_3_1:
+ax_anim 4, 0, 49, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 24, 0, 22,
+ax_anim 2, 1, 51, 1, 24, 1, 22,
+ax_anim 2, 0, 51, 0, 24, 0, 22,
+ax_anim 2, 0, 51, 1, 24, 1, 22,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim_terminator
+sAbraAnims_3_2:
+ax_anim 4, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 2, 54, 10, 10, 10, 10,
+ax_anim 2, 0, 54, 22, 22, 22, 22,
+ax_anim 2, 1, 55, 23, 21, 23, 21,
+ax_anim 2, 0, 55, 22, 22, 22, 22,
+ax_anim 2, 0, 55, 23, 21, 23, 21,
+ax_anim 2, 0, 52, 8, 8, 8, 8,
+ax_anim_terminator
+sAbraAnims_3_3:
+ax_anim 4, 0, 57, -1, 0, -1, 0,
+ax_anim 6, 0, 57, -3, 0, -3, 0,
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 2, 58, 7, 1, 7, 0,
+ax_anim 2, 0, 58, 16, 2, 16, 0,
+ax_anim 2, 1, 59, 16, 1, 16, -1,
+ax_anim 2, 0, 59, 16, 2, 16, 0,
+ax_anim 2, 0, 59, 16, 1, 16, -1,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim_terminator
+sAbraAnims_3_4:
+ax_anim 4, 0, 61, -1, 1, -1, 1,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 2, 0, 61, 3, 0, 3, -3,
+ax_anim 2, 2, 62, 8, -2, 8, -5,
+ax_anim 2, 0, 62, 20, -11, 20, -13,
+ax_anim 2, 1, 63, 21, -10, 21, -12,
+ax_anim 2, 0, 63, 20, -11, 20, -13,
+ax_anim 2, 0, 63, 21, -10, 21, -12,
+ax_anim 2, 0, 60, 8, -8, 8, -8,
+ax_anim_terminator
+sAbraAnims_3_5:
+ax_anim 4, 0, 65, 0, 1, 0, 1,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 66, 0, -2, 0, -4,
+ax_anim 2, 0, 66, 0, -11, 0, -14,
+ax_anim 2, 1, 67, 1, -11, 1, -14,
+ax_anim 2, 0, 67, 0, -11, 0, -14,
+ax_anim 2, 0, 67, 1, -11, 1, -14,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim_terminator
+sAbraAnims_3_6:
+ax_anim 4, 0, 69, 1, 1, 1, 1,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 2, 0, 69, -3, 0, -3, -3,
+ax_anim 2, 2, 70, -8, -2, -8, -5,
+ax_anim 2, 0, 70, -20, -11, -20, -13,
+ax_anim 2, 1, 71, -21, -10, -21, -12,
+ax_anim 2, 0, 71, -20, -11, -20, -13,
+ax_anim 2, 0, 71, -21, -10, -21, -12,
+ax_anim 2, 0, 68, -8, -8, -8, -8,
+ax_anim_terminator
+sAbraAnims_3_7:
+ax_anim 4, 0, 73, 1, 0, 1, 0,
+ax_anim 6, 0, 73, 3, 0, 3, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 74, -7, 1, -7, 0,
+ax_anim 2, 0, 74, -16, 2, -16, 0,
+ax_anim 2, 1, 75, -16, 1, -16, -1,
+ax_anim 2, 0, 75, -16, 2, -16, 0,
+ax_anim 2, 0, 75, -16, 1, -16, -1,
+ax_anim 2, 0, 72, -6, 0, -6, 0,
+ax_anim_terminator
+sAbraAnims_3_8:
+ax_anim 4, 0, 77, 1, -1, 1, -1,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 78, -10, 10, -10, 10,
+ax_anim 2, 0, 78, -22, 22, -22, 22,
+ax_anim 2, 1, 79, -23, 21, -23, 21,
+ax_anim 2, 0, 79, -22, 22, -22, 22,
+ax_anim 2, 0, 79, -23, 21, -23, 21,
+ax_anim 2, 0, 76, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sAbraAnims_4_1:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_4_2:
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_4_3:
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_4_4:
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_4_5:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_4_6:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_4_7:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_4_8:
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_5_1:
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 89, 1, -3, 1, -3,
+ax_anim 2, 0, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 89, 1, -3, 1, -3,
+ax_anim 6, 0, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, -3, 0, -3,
+ax_anim 1, 2, 90, 0, 1, 0, 1,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim_terminator
+sAbraAnims_5_2:
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -4, -2, -4, -2,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim 6, 0, 92, -4, -2, -4, -2,
+ax_anim 1, 0, 93, -3, -3, -3, -3,
+ax_anim 1, 2, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 91, 4, 4, 4, 4,
+ax_anim_terminator
+sAbraAnims_5_3:
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 95, -3, -1, -3, -1,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 95, -3, -1, -3, -1,
+ax_anim 6, 0, 95, -3, 0, -3, 0,
+ax_anim 1, 0, 96, -3, 0, -3, 0,
+ax_anim 1, 2, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim_terminator
+sAbraAnims_5_4:
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 98, -4, 2, -4, 2,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim 6, 0, 98, -4, 2, -4, 2,
+ax_anim 1, 0, 99, -3, 3, -3, 3,
+ax_anim 1, 2, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 97, 4, -4, 4, -4,
+ax_anim_terminator
+sAbraAnims_5_5:
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 2, 0, 101, -1, 3, -1, 3,
+ax_anim 2, 0, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 101, -1, 3, -1, 3,
+ax_anim 6, 0, 101, 0, 3, 0, 3,
+ax_anim 1, 0, 102, 0, 3, 0, 3,
+ax_anim 1, 2, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim_terminator
+sAbraAnims_5_6:
+ax_anim 2, 0, 104, 1, 1, 1, 1,
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 104, 4, 2, 4, 2,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 6, 0, 104, 4, 2, 4, 2,
+ax_anim 1, 0, 105, 3, 3, 3, 3,
+ax_anim 1, 2, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 103, -4, -4, -4, -4,
+ax_anim_terminator
+sAbraAnims_5_7:
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 6, 0, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 108, 3, 0, 3, 0,
+ax_anim 1, 2, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 0, 106, -4, 0, -4, 0,
+ax_anim_terminator
+sAbraAnims_5_8:
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 110, 4, -2, 4, -2,
+ax_anim 2, 0, 110, 3, -3, 3, -3,
+ax_anim 6, 0, 110, 4, -2, 4, -2,
+ax_anim 1, 0, 111, 3, -3, 3, -3,
+ax_anim 1, 2, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sAbraAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sAbraAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sAbraAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sAbraAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sAbraAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sAbraAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sAbraAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sAbraAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sAbraAnims_8_1:
+ax_anim 24, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, -2, 0, 0,
+ax_anim 24, 0, 122, 0, -3, 0, 0,
+ax_anim 8, 0, 122, 0, -2, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sAbraAnims_8_2:
+ax_anim 24, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 24, 0, 124, 0, -3, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim_terminator
+sAbraAnims_8_3:
+ax_anim 24, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim 8, 0, 126, 0, -2, 0, 0,
+ax_anim 24, 0, 126, 0, -3, 0, 0,
+ax_anim 8, 0, 126, 0, -2, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim_terminator
+sAbraAnims_8_4:
+ax_anim 24, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, -2, 0, 0,
+ax_anim 24, 0, 128, 0, -3, 0, 0,
+ax_anim 8, 0, 128, 0, -2, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim_terminator
+sAbraAnims_8_5:
+ax_anim 24, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, -1, 0, 0,
+ax_anim 8, 0, 130, 0, -2, 0, 0,
+ax_anim 24, 0, 130, 0, -3, 0, 0,
+ax_anim 8, 0, 130, 0, -2, 0, 0,
+ax_anim 8, 0, 130, 0, -1, 0, 0,
+ax_anim_terminator
+sAbraAnims_8_6:
+ax_anim 24, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, -1, 0, 0,
+ax_anim 8, 0, 132, 0, -2, 0, 0,
+ax_anim 24, 0, 132, 0, -3, 0, 0,
+ax_anim 8, 0, 132, 0, -2, 0, 0,
+ax_anim 8, 0, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sAbraAnims_8_7:
+ax_anim 24, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, -2, 0, 0,
+ax_anim 24, 0, 134, 0, -3, 0, 0,
+ax_anim 8, 0, 134, 0, -2, 0, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sAbraAnims_8_8:
+ax_anim 24, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim 8, 0, 136, 0, -2, 0, 0,
+ax_anim 24, 0, 136, 0, -3, 0, 0,
+ax_anim 8, 0, 136, 0, -2, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 4, 6, 4,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 21, 7, 19,
+ax_anim 3, 0, 142, 1, 26, 1, 23,
+ax_anim 2, 3, 143, -7, 21, -7, 19,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 4, -6, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 23, 11, 23, 11,
+ax_anim 3, 0, 141, 23, 26, 23, 23,
+ax_anim 2, 3, 142, 12, 28, 12, 26,
+ax_anim 2, 0, 143, 0, 17, 0, 17,
+ax_anim 1, 0, 144, -1, 7, -1, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 17, -4, 17, -4,
+ax_anim 3, 0, 140, 22, 4, 22, 2,
+ax_anim 2, 3, 141, 17, 7, 17, 4,
+ax_anim 2, 0, 142, 12, 8, 12, 6,
+ax_anim 1, 0, 143, 1, 5, 1, 3,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -6, -1, -6,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 11, -20, 11, -20,
+ax_anim 3, 0, 139, 20, -20, 20, -20,
+ax_anim 2, 3, 140, 18, -13, 18, -13,
+ax_anim 2, 0, 141, 16, -6, 16, -6,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -6, -4, -6, -4,
+ax_anim 2, 0, 144, -8, -9, -8, -9,
+ax_anim 2, 0, 145, -7, -15, -7, -13,
+ax_anim 3, 0, 138, -1, -21, -1, -19,
+ax_anim 2, 3, 139, 7, -15, 7, -13,
+ax_anim 2, 0, 140, 8, -9, 8, -9,
+ax_anim 1, 0, 141, 6, -4, 6, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -1, -6, -1, -6,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -11, -20, -11, -20,
+ax_anim 3, 0, 145, -20, -20, -20, -20,
+ax_anim 2, 3, 144, -18, -13, -19, -13,
+ax_anim 2, 0, 143, -16, -6, -16, -6,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -17, -4, -17, -4,
+ax_anim 3, 0, 144, -22, 4, -22, 2,
+ax_anim 2, 3, 143, -17, 7, -17, 4,
+ax_anim 2, 0, 142, -12, 8, -12, 6,
+ax_anim 1, 0, 141, -1, 5, -1, 3,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -23, 9, -23, 9,
+ax_anim 3, 0, 143, -23, 26, -23, 23,
+ax_anim 2, 3, 142, -12, 28, -12, 26,
+ax_anim 2, 0, 141, 0, 17, 0, 17,
+ax_anim 1, 0, 140, 1, 7, 1, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 2, 0, 0,
+ax_anim_terminator
+sAbraAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 2, 0, 0,
+ax_anim_terminator
+sAbraAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 4, 0, 0,
+ax_anim_terminator
+sAbraAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 6, 0, 0,
+ax_anim_terminator
+sAbraAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 7, 0, 0,
+ax_anim_terminator
+sAbraAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 6, 0, 0,
+ax_anim_terminator
+sAbraAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 4, 0, 0,
+ax_anim_terminator
+sAbraAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbraAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sAbraGfx1:
+.incbin "baserom.gba", 0x7BBB6C, 0x200
+sAbraSprites1:
+ax_sprite sAbraGfx1, 0x200
+ax_sprite_terminator
+sAbraGfx2:
+.incbin "baserom.gba", 0x7BBD7C, 0x200
+sAbraSprites2:
+ax_sprite sAbraGfx2, 0x200
+ax_sprite_terminator
+sAbraGfx3:
+.incbin "baserom.gba", 0x7BBF8C, 0x200
+sAbraSprites3:
+ax_sprite sAbraGfx3, 0x200
+ax_sprite_terminator
+sAbraGfx4:
+.incbin "baserom.gba", 0x7BC19C, 0x200
+sAbraSprites4:
+ax_sprite sAbraGfx4, 0x200
+ax_sprite_terminator
+sAbraGfx5:
+.incbin "baserom.gba", 0x7BC3AC, 0x200
+sAbraSprites5:
+ax_sprite sAbraGfx5, 0x200
+ax_sprite_terminator
+sAbraGfx6:
+.incbin "baserom.gba", 0x7BC5BC, 0x200
+sAbraSprites6:
+ax_sprite sAbraGfx6, 0x200
+ax_sprite_terminator
+sAbraGfx7:
+.incbin "baserom.gba", 0x7BC7CC, 0x200
+sAbraSprites7:
+ax_sprite sAbraGfx7, 0x200
+ax_sprite_terminator
+sAbraGfx8:
+.incbin "baserom.gba", 0x7BC9DC, 0x200
+sAbraSprites8:
+ax_sprite sAbraGfx8, 0x200
+ax_sprite_terminator
+sAbraGfx9:
+.incbin "baserom.gba", 0x7BCBEC, 0x200
+sAbraSprites9:
+ax_sprite sAbraGfx9, 0x200
+ax_sprite_terminator
+sAbraGfx10:
+.incbin "baserom.gba", 0x7BCDFC, 0x200
+sAbraSprites10:
+ax_sprite sAbraGfx10, 0x200
+ax_sprite_terminator
+sAbraGfx11:
+.incbin "baserom.gba", 0x7BD00C, 0x200
+sAbraSprites11:
+ax_sprite sAbraGfx11, 0x200
+ax_sprite_terminator
+sAbraGfx12:
+.incbin "baserom.gba", 0x7BD21C, 0x200
+sAbraSprites12:
+ax_sprite sAbraGfx12, 0x200
+ax_sprite_terminator
+sAbraGfx13:
+.incbin "baserom.gba", 0x7BD42C, 0x200
+sAbraSprites13:
+ax_sprite sAbraGfx13, 0x200
+ax_sprite_terminator
+sAbraGfx14:
+.incbin "baserom.gba", 0x7BD63C, 0x200
+sAbraSprites14:
+ax_sprite sAbraGfx14, 0x200
+ax_sprite_terminator
+sAbraGfx15:
+.incbin "baserom.gba", 0x7BD84C, 0x200
+sAbraSprites15:
+ax_sprite sAbraGfx15, 0x200
+ax_sprite_terminator
+sAbraGfx16:
+.incbin "baserom.gba", 0x7BDA5C, 0x60
+sAbraGfx16_1:
+.incbin "baserom.gba", 0x7BDABC, 0x60
+sAbraGfx16_2:
+.incbin "baserom.gba", 0x7BDB1C, 0x60
+sAbraSprites16:
+ax_sprite sAbraGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx17:
+.incbin "baserom.gba", 0x7BDBB4, 0x20
+sAbraGfx17_1:
+.incbin "baserom.gba", 0x7BDBD4, 0x20
+sAbraGfx17_2:
+.incbin "baserom.gba", 0x7BDBF4, 0x40
+sAbraSprites17:
+ax_sprite sAbraGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx17_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx17_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAbraGfx18:
+.incbin "baserom.gba", 0x7BDC6C, 0x60
+sAbraGfx18_1:
+.incbin "baserom.gba", 0x7BDCCC, 0x60
+sAbraGfx18_2:
+.incbin "baserom.gba", 0x7BDD2C, 0x60
+sAbraSprites18:
+ax_sprite sAbraGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx19:
+.incbin "baserom.gba", 0x7BDDC4, 0x60
+sAbraGfx19_1:
+.incbin "baserom.gba", 0x7BDE24, 0x60
+sAbraGfx19_2:
+.incbin "baserom.gba", 0x7BDE84, 0x60
+sAbraSprites19:
+ax_sprite sAbraGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx20:
+.incbin "baserom.gba", 0x7BDF1C, 0x40
+sAbraGfx20_1:
+.incbin "baserom.gba", 0x7BDF5C, 0x20
+sAbraSprites20:
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx20_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sAbraGfx21:
+.incbin "baserom.gba", 0x7BDFAC, 0x40
+sAbraGfx21_1:
+.incbin "baserom.gba", 0x7BDFEC, 0x60
+sAbraGfx21_2:
+.incbin "baserom.gba", 0x7BE04C, 0x60
+sAbraSprites21:
+ax_sprite sAbraGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAbraGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx22:
+.incbin "baserom.gba", 0x7BE0E4, 0x60
+sAbraGfx22_1:
+.incbin "baserom.gba", 0x7BE144, 0x60
+sAbraGfx22_2:
+.incbin "baserom.gba", 0x7BE1A4, 0x60
+sAbraSprites22:
+ax_sprite sAbraGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx23:
+.incbin "baserom.gba", 0x7BE23C, 0x20
+sAbraGfx23_1:
+.incbin "baserom.gba", 0x7BE25C, 0x60
+sAbraSprites23:
+ax_sprite sAbraGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx23_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sAbraGfx24:
+.incbin "baserom.gba", 0x7BE2E4, 0x60
+sAbraGfx24_1:
+.incbin "baserom.gba", 0x7BE344, 0x60
+sAbraGfx24_2:
+.incbin "baserom.gba", 0x7BE3A4, 0x60
+sAbraSprites24:
+ax_sprite sAbraGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx25:
+.incbin "baserom.gba", 0x7BE43C, 0x60
+sAbraGfx25_1:
+.incbin "baserom.gba", 0x7BE49C, 0x60
+sAbraGfx25_2:
+.incbin "baserom.gba", 0x7BE4FC, 0x60
+sAbraSprites25:
+ax_sprite sAbraGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx26:
+.incbin "baserom.gba", 0x7BE594, 0x20
+sAbraGfx26_1:
+.incbin "baserom.gba", 0x7BE5B4, 0x40
+sAbraSprites26:
+ax_sprite sAbraGfx26, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx26_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAbraGfx27:
+.incbin "baserom.gba", 0x7BE61C, 0x60
+sAbraGfx27_1:
+.incbin "baserom.gba", 0x7BE67C, 0x60
+sAbraGfx27_2:
+.incbin "baserom.gba", 0x7BE6DC, 0x60
+sAbraSprites27:
+ax_sprite sAbraGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx28:
+.incbin "baserom.gba", 0x7BE774, 0x60
+sAbraGfx28_1:
+.incbin "baserom.gba", 0x7BE7D4, 0x60
+sAbraGfx28_2:
+.incbin "baserom.gba", 0x7BE834, 0x60
+sAbraSprites28:
+ax_sprite sAbraGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx29:
+.incbin "baserom.gba", 0x7BE8CC, 0x20
+sAbraGfx29_1:
+.incbin "baserom.gba", 0x7BE8EC, 0x20
+sAbraGfx29_2:
+.incbin "baserom.gba", 0x7BE90C, 0x20
+sAbraSprites29:
+ax_sprite sAbraGfx29, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx29_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sAbraGfx30:
+.incbin "baserom.gba", 0x7BE964, 0x60
+sAbraGfx30_1:
+.incbin "baserom.gba", 0x7BE9C4, 0x60
+sAbraGfx30_2:
+.incbin "baserom.gba", 0x7BEA24, 0x60
+sAbraSprites30:
+ax_sprite sAbraGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx31:
+.incbin "baserom.gba", 0x7BEABC, 0x60
+sAbraGfx31_1:
+.incbin "baserom.gba", 0x7BEB1C, 0x60
+sAbraGfx31_2:
+.incbin "baserom.gba", 0x7BEB7C, 0x60
+sAbraSprites31:
+ax_sprite sAbraGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx32:
+.incbin "baserom.gba", 0x7BEC14, 0x60
+sAbraGfx32_1:
+.incbin "baserom.gba", 0x7BEC74, 0x60
+sAbraGfx32_2:
+.incbin "baserom.gba", 0x7BECD4, 0x60
+sAbraSprites32:
+ax_sprite sAbraGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx33:
+.incbin "baserom.gba", 0x7BED6C, 0x100
+sAbraSprites33:
+ax_sprite sAbraGfx33, 0x100
+ax_sprite_terminator
+sAbraGfx34:
+.incbin "baserom.gba", 0x7BEE7C, 0x40
+sAbraGfx34_1:
+.incbin "baserom.gba", 0x7BEEBC, 0x60
+sAbraGfx34_2:
+.incbin "baserom.gba", 0x7BEF1C, 0x40
+sAbraGfx34_3:
+.incbin "baserom.gba", 0x7BEF5C, 0x20
+sAbraSprites34:
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAbraGfx34_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sAbraGfx34_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbraGfx35:
+.incbin "baserom.gba", 0x7BEFCC, 0x60
+sAbraGfx35_1:
+.incbin "baserom.gba", 0x7BF02C, 0x60
+sAbraGfx35_2:
+.incbin "baserom.gba", 0x7BF08C, 0x60
+sAbraSprites35:
+ax_sprite sAbraGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx36:
+.incbin "baserom.gba", 0x7BF124, 0x20
+sAbraGfx36_1:
+.incbin "baserom.gba", 0x7BF144, 0x60
+sAbraGfx36_2:
+.incbin "baserom.gba", 0x7BF1A4, 0x60
+sAbraSprites36:
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sAbraGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx37:
+.incbin "baserom.gba", 0x7BF244, 0x60
+sAbraGfx37_1:
+.incbin "baserom.gba", 0x7BF2A4, 0x60
+sAbraGfx37_2:
+.incbin "baserom.gba", 0x7BF304, 0x60
+sAbraSprites37:
+ax_sprite sAbraGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx38:
+.incbin "baserom.gba", 0x7BF39C, 0x60
+sAbraGfx38_1:
+.incbin "baserom.gba", 0x7BF3FC, 0x60
+sAbraGfx38_2:
+.incbin "baserom.gba", 0x7BF45C, 0x60
+sAbraSprites38:
+ax_sprite sAbraGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx39:
+.incbin "baserom.gba", 0x7BF4F4, 0x60
+sAbraGfx39_1:
+.incbin "baserom.gba", 0x7BF554, 0x60
+sAbraGfx39_2:
+.incbin "baserom.gba", 0x7BF5B4, 0x60
+sAbraSprites39:
+ax_sprite sAbraGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx39_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx40:
+.incbin "baserom.gba", 0x7BF64C, 0x60
+sAbraGfx40_1:
+.incbin "baserom.gba", 0x7BF6AC, 0x60
+sAbraGfx40_2:
+.incbin "baserom.gba", 0x7BF70C, 0x60
+sAbraSprites40:
+ax_sprite sAbraGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbraGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAbraGfx41:
+.incbin "baserom.gba", 0x7BF7A4, 0x200
+sAbraSprites41:
+ax_sprite sAbraGfx41, 0x200
+ax_sprite_terminator
+sAbraGfx42:
+.incbin "baserom.gba", 0x7BF9B4, 0x200
+sAbraSprites42:
+ax_sprite sAbraGfx42, 0x200
+ax_sprite_terminator
+sAbraGfx43:
+.incbin "baserom.gba", 0x7BFBC4, 0x200
+sAbraSprites43:
+ax_sprite sAbraGfx43, 0x200
+ax_sprite_terminator
+sAbraGfx44:
+.incbin "baserom.gba", 0x7BFDD4, 0x200
+sAbraSprites44:
+ax_sprite sAbraGfx44, 0x200
+ax_sprite_terminator
+sAbraGfx45:
+.incbin "baserom.gba", 0x7BFFE4, 0x200
+sAbraSprites45:
+ax_sprite sAbraGfx45, 0x200
+ax_sprite_terminator
+sAbraGfx46:
+.incbin "baserom.gba", 0x7C01F4, 0x200
+sAbraSprites46:
+ax_sprite sAbraGfx46, 0x200
+ax_sprite_terminator
+sAbraGfx47:
+.incbin "baserom.gba", 0x7C0404, 0x200
+sAbraSprites47:
+ax_sprite sAbraGfx47, 0x200
+ax_sprite_terminator
+sAxPosesAbra:
+.4byte sAbraPose1
+.4byte sAbraPose2
+.4byte sAbraPose3
+.4byte sAbraPose4
+.4byte sAbraPose5
+.4byte sAbraPose6
+.4byte sAbraPose7
+.4byte sAbraPose8
+.4byte sAbraPose9
+.4byte sAbraPose10
+.4byte sAbraPose11
+.4byte sAbraPose12
+.4byte sAbraPose13
+.4byte sAbraPose14
+.4byte sAbraPose15
+.4byte sAbraPose16
+.4byte sAbraPose17
+.4byte sAbraPose18
+.4byte sAbraPose19
+.4byte sAbraPose20
+.4byte sAbraPose21
+.4byte sAbraPose22
+.4byte sAbraPose23
+.4byte sAbraPose24
+.4byte sAbraPose25
+.4byte sAbraPose26
+.4byte sAbraPose27
+.4byte sAbraPose28
+.4byte sAbraPose29
+.4byte sAbraPose30
+.4byte sAbraPose31
+.4byte sAbraPose32
+.4byte sAbraPose33
+.4byte sAbraPose34
+.4byte sAbraPose35
+.4byte sAbraPose36
+.4byte sAbraPose37
+.4byte sAbraPose38
+.4byte sAbraPose39
+.4byte sAbraPose40
+.4byte sAbraPose41
+.4byte sAbraPose42
+.4byte sAbraPose43
+.4byte sAbraPose44
+.4byte sAbraPose45
+.4byte sAbraPose46
+.4byte sAbraPose47
+.4byte sAbraPose48
+.4byte sAbraPose49
+.4byte sAbraPose50
+.4byte sAbraPose51
+.4byte sAbraPose52
+.4byte sAbraPose53
+.4byte sAbraPose54
+.4byte sAbraPose55
+.4byte sAbraPose56
+.4byte sAbraPose57
+.4byte sAbraPose58
+.4byte sAbraPose59
+.4byte sAbraPose60
+.4byte sAbraPose61
+.4byte sAbraPose62
+.4byte sAbraPose63
+.4byte sAbraPose64
+.4byte sAbraPose65
+.4byte sAbraPose66
+.4byte sAbraPose67
+.4byte sAbraPose68
+.4byte sAbraPose69
+.4byte sAbraPose70
+.4byte sAbraPose71
+.4byte sAbraPose72
+.4byte sAbraPose73
+.4byte sAbraPose74
+.4byte sAbraPose75
+.4byte sAbraPose76
+.4byte sAbraPose77
+.4byte sAbraPose78
+.4byte sAbraPose79
+.4byte sAbraPose80
+.4byte sAbraPose81
+.4byte sAbraPose82
+.4byte sAbraPose83
+.4byte sAbraPose84
+.4byte sAbraPose85
+.4byte sAbraPose86
+.4byte sAbraPose87
+.4byte sAbraPose88
+.4byte sAbraPose89
+.4byte sAbraPose90
+.4byte sAbraPose91
+.4byte sAbraPose92
+.4byte sAbraPose93
+.4byte sAbraPose94
+.4byte sAbraPose95
+.4byte sAbraPose96
+.4byte sAbraPose97
+.4byte sAbraPose98
+.4byte sAbraPose99
+.4byte sAbraPose100
+.4byte sAbraPose101
+.4byte sAbraPose102
+.4byte sAbraPose103
+.4byte sAbraPose104
+.4byte sAbraPose105
+.4byte sAbraPose106
+.4byte sAbraPose107
+.4byte sAbraPose108
+.4byte sAbraPose109
+.4byte sAbraPose110
+.4byte sAbraPose111
+.4byte sAbraPose112
+.4byte sAbraPose113
+.4byte sAbraPose114
+.4byte sAbraPose115
+.4byte sAbraPose116
+.4byte sAbraPose117
+.4byte sAbraPose118
+.4byte sAbraPose119
+.4byte sAbraPose120
+.4byte sAbraPose121
+.4byte sAbraPose122
+.4byte sAbraPose123
+.4byte sAbraPose124
+.4byte sAbraPose125
+.4byte sAbraPose126
+.4byte sAbraPose127
+.4byte sAbraPose128
+.4byte sAbraPose129
+.4byte sAbraPose130
+.4byte sAbraPose131
+.4byte sAbraPose132
+.4byte sAbraPose133
+.4byte sAbraPose134
+.4byte sAbraPose135
+.4byte sAbraPose136
+.4byte sAbraPose137
+.4byte sAbraPose138
+.4byte sAbraPose139
+.4byte sAbraPose140
+.4byte sAbraPose141
+.4byte sAbraPose142
+.4byte sAbraPose143
+.4byte sAbraPose144
+.4byte sAbraPose145
+.4byte sAbraPose146
+.4byte sAbraPose147
+.4byte sAbraPose148
+.4byte sAbraPose149
+.4byte sAbraPose150
+.4byte sAbraPose151
+.4byte sAbraPose152
+.4byte sAbraPose153
+.4byte sAbraPose154
+.4byte sAbraPose155
+.4byte sAbraPose156
+.4byte sAbraPose157
+.4byte sAbraPose158
+.4byte sAbraPose159
+.4byte sAbraPose160
+.4byte sAbraPose161
+.4byte sAbraPose162
+.4byte sAbraPose163
+.4byte sAbraPose164
+.4byte sAbraPose165
+.4byte sAbraPose166
+.4byte sAbraPose167
+.4byte sAbraPose168
+.4byte sAbraPose169
+.4byte sAbraPose170
+.4byte sAbraPose171
+.4byte sAbraPose172
+.4byte sAbraPose173
+.4byte sAbraPose174
+.4byte sAbraPose175
+.4byte sAbraPose176
+.4byte sAbraPose177
+.4byte sAbraPose178
+.4byte sAbraPose179
+.4byte sAbraPose180
+.4byte sAbraPose181
+.4byte sAbraPose182
+.4byte sAbraPose183
+.4byte sAbraPose184
+.4byte sAbraPose185
+.4byte sAbraPose186
+.4byte sAbraPose187
+.4byte sAbraPose188
+.4byte sAbraPose189
+.4byte sAbraPose190
+.4byte sAbraPose191
+.4byte sAbraPose192
+.4byte sAbraPose193
+.4byte sAbraPose194
+sAxPositionsAbra:
+.2byte    0,   -7, 	  -8,   -4, 	   7,   -4, 	   0,   -8
+.2byte   -1,   -7, 	  -8,   -6, 	   6,   -2, 	   0,   -8
+.2byte    0,   -7, 	  -7,   -2, 	   7,   -6, 	  -1,   -8
+.2byte    0,   -7, 	   7,   -6, 	  -3,   -2, 	  -1,   -8
+.2byte    2,   -8, 	   5,   -6, 	   0,   -1, 	  -1,   -8
+.2byte    0,   -7, 	   7,   -3, 	  -5,   -2, 	  -1,   -8
+.2byte    3,   -7, 	   5,   -8, 	   3,   -2, 	  -1,   -8
+.2byte    4,   -7, 	   3,   -7, 	   5,   -2, 	   0,   -8
+.2byte    2,   -7, 	   7,   -7, 	   1,   -2, 	  -1,   -8
+.2byte    1,  -10, 	  -5,  -10, 	   7,   -6, 	  -1,   -8
+.2byte    0,  -11, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    2,  -10, 	  -2,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    0,  -10, 	   8,   -7, 	  -9,   -7, 	   0,   -8
+.2byte    1,  -10, 	   8,   -6, 	  -7,   -9, 	   0,   -8
+.2byte   -2,  -10, 	   6,   -9, 	  -9,   -6, 	  -1,   -8
+.2byte   -2,  -10, 	   4,  -10, 	  -8,   -6, 	   0,   -8
+.2byte   -1,  -11, 	   4,   -8, 	  -9,   -8, 	   0,   -9
+.2byte   -3,  -10, 	   1,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -4,   -7, 	  -6,   -8, 	  -4,   -2, 	   0,   -8
+.2byte   -5,   -7, 	  -4,   -7, 	  -6,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -8,   -7, 	  -2,   -2, 	   0,   -8
+.2byte   -1,   -7, 	  -8,   -6, 	   2,   -2, 	   0,   -8
+.2byte   -3,   -8, 	  -6,   -6, 	  -1,   -1, 	   0,   -8
+.2byte   -1,   -7, 	  -8,   -3, 	   4,   -2, 	   0,   -8
+.2byte    0,  -11, 	  -8,   -8, 	   7,   -8, 	   0,  -12
+.2byte   -1,  -11, 	  -8,  -10, 	   6,   -6, 	   0,  -12
+.2byte    0,  -11, 	  -7,   -6, 	   7,  -10, 	  -1,  -12
+.2byte    0,  -11, 	   7,  -10, 	  -3,   -6, 	  -1,  -12
+.2byte    2,  -12, 	   5,  -10, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -11, 	   7,   -7, 	  -5,   -6, 	  -1,  -12
+.2byte    3,  -11, 	   5,  -12, 	   3,   -6, 	  -1,  -12
+.2byte    4,  -11, 	   3,  -11, 	   5,   -6, 	   0,  -12
+.2byte    2,  -11, 	   7,  -11, 	   1,   -6, 	  -1,  -12
+.2byte    1,  -14, 	  -5,  -14, 	   7,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -5,  -12, 	   8,  -12, 	  -1,  -13
+.2byte    2,  -14, 	  -2,  -14, 	   6,  -10, 	  -1,  -12
+.2byte    0,  -14, 	   8,  -11, 	  -9,  -11, 	   0,  -12
+.2byte    1,  -14, 	   8,  -10, 	  -7,  -13, 	   0,  -12
+.2byte   -2,  -14, 	   6,  -13, 	  -9,  -10, 	  -1,  -12
+.2byte   -2,  -14, 	   4,  -14, 	  -8,  -10, 	   0,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -9,  -12, 	   0,  -13
+.2byte   -3,  -14, 	   1,  -14, 	  -7,  -10, 	   0,  -12
+.2byte   -4,  -11, 	  -6,  -12, 	  -4,   -6, 	   0,  -12
+.2byte   -5,  -11, 	  -4,  -11, 	  -6,   -6, 	  -1,  -12
+.2byte   -3,  -11, 	  -8,  -11, 	  -2,   -6, 	   0,  -12
+.2byte   -1,  -11, 	  -8,  -10, 	   2,   -6, 	   0,  -12
+.2byte   -3,  -12, 	  -6,  -10, 	  -1,   -5, 	   0,  -12
+.2byte   -1,  -11, 	  -8,   -7, 	   4,   -6, 	   0,  -12
+.2byte    0,  -11, 	  -8,   -8, 	   7,   -8, 	   0,  -12
+.2byte    1,  -11, 	  -7,  -13, 	   1,   -6, 	   1,  -12
+.2byte   -1,  -10, 	  -3,   -3, 	   7,  -13, 	  -1,  -12
+.2byte   -1,  -10, 	  -3,   -3, 	   7,  -13, 	  -1,  -12
+.2byte    0,  -11, 	   7,  -10, 	  -3,   -6, 	  -1,  -12
+.2byte   -1,  -12, 	   0,  -15, 	   3,   -9, 	  -3,  -10
+.2byte    0,  -10, 	   7,   -8, 	  -9,  -13, 	  -1,  -12
+.2byte    0,  -10, 	   7,   -8, 	  -9,  -13, 	  -1,  -12
+.2byte    3,  -11, 	   5,  -12, 	   3,   -6, 	  -1,  -12
+.2byte    3,  -12, 	  -2,  -15, 	   8,  -11, 	   0,  -11
+.2byte    5,  -11, 	  13,  -10, 	  -2,   -5, 	   3,  -10
+.2byte    5,  -11, 	  13,  -10, 	  -2,   -5, 	   3,  -10
+.2byte    1,  -14, 	  -5,  -14, 	   7,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	  -8,  -13, 	   5,  -14, 	  -2,  -11
+.2byte    2,  -14, 	   2,  -17, 	   6,   -9, 	   0,  -13
+.2byte    2,  -14, 	   2,  -17, 	   6,   -9, 	   0,  -13
+.2byte    0,  -14, 	   8,  -11, 	  -9,  -11, 	   0,  -12
+.2byte    0,  -12, 	   6,   -6, 	  -1,  -14, 	   0,  -11
+.2byte   -1,  -15, 	   1,  -19, 	  -8,  -10, 	   0,  -14
+.2byte   -1,  -15, 	   1,  -19, 	  -8,  -10, 	   0,  -14
+.2byte   -2,  -14, 	   4,  -14, 	  -8,  -10, 	   0,  -12
+.2byte    0,  -14, 	   7,  -13, 	  -6,  -14, 	   1,  -11
+.2byte   -3,  -14, 	  -3,  -17, 	  -7,   -9, 	  -1,  -13
+.2byte   -3,  -14, 	  -3,  -17, 	  -7,   -9, 	  -1,  -13
+.2byte   -4,  -11, 	  -6,  -12, 	  -4,   -6, 	   0,  -12
+.2byte   -4,  -12, 	   1,  -15, 	  -9,  -11, 	  -1,  -11
+.2byte   -6,  -11, 	 -14,  -10, 	   1,   -5, 	  -4,  -10
+.2byte   -6,  -11, 	 -14,  -10, 	   1,   -5, 	  -4,  -10
+.2byte   -1,  -11, 	  -8,  -10, 	   2,   -6, 	   0,  -12
+.2byte    0,  -12, 	  -1,  -15, 	  -4,   -9, 	   2,  -10
+.2byte   -1,  -10, 	  -8,   -8, 	   8,  -13, 	   0,  -12
+.2byte   -1,  -10, 	  -8,   -8, 	   8,  -13, 	   0,  -12
+.2byte    0,  -13, 	 -10,  -17, 	   9,  -17, 	   0,  -12
+.2byte    0,  -15, 	  -5,  -22, 	   8,  -15, 	   1,  -11
+.2byte   -1,  -15, 	   4,  -21, 	   3,  -11, 	   1,  -11
+.2byte   -4,  -16, 	   6,  -21, 	  -7,  -12, 	   0,  -12
+.2byte    0,  -17, 	   9,  -16, 	 -10,  -16, 	   0,  -11
+.2byte    3,  -16, 	  -7,  -21, 	   6,  -12, 	  -1,  -12
+.2byte    0,  -15, 	  -5,  -21, 	  -4,  -11, 	  -2,  -11
+.2byte   -1,  -15, 	   4,  -22, 	  -9,  -15, 	  -2,  -11
+.2byte    0,  -11, 	  -8,   -8, 	   7,   -8, 	   0,  -12
+.2byte    0,  -13, 	 -10,  -17, 	   9,  -17, 	   0,  -12
+.2byte    0,   -6, 	  -5,   -2, 	   4,   -2, 	   0,   -9
+.2byte    0,  -11, 	   7,  -10, 	  -3,   -6, 	  -1,  -12
+.2byte   -2,  -15, 	   3,  -22, 	 -10,  -15, 	  -3,  -11
+.2byte    1,   -8, 	   8,   -5, 	   1,   -3, 	  -1,   -9
+.2byte    3,  -11, 	   5,  -12, 	   3,   -6, 	  -1,  -12
+.2byte    1,  -15, 	  -4,  -21, 	  -3,  -11, 	  -1,  -11
+.2byte    3,  -10, 	   7,  -12, 	   6,   -8, 	  -1,  -10
+.2byte    1,  -14, 	  -5,  -14, 	   7,  -10, 	  -1,  -12
+.2byte    0,  -16, 	 -10,  -21, 	   3,  -12, 	  -4,  -12
+.2byte    2,  -13, 	  -2,  -18, 	   9,  -15, 	  -1,  -13
+.2byte    0,  -14, 	   8,  -11, 	  -9,  -11, 	   0,  -12
+.2byte    0,  -17, 	   9,  -16, 	 -10,  -16, 	   0,  -11
+.2byte    0,  -15, 	   2,  -20, 	  -3,  -20, 	   0,  -14
+.2byte   -2,  -14, 	   4,  -14, 	  -8,  -10, 	   0,  -12
+.2byte   -1,  -16, 	   9,  -21, 	  -4,  -12, 	   3,  -12
+.2byte   -3,  -13, 	   1,  -18, 	 -10,  -15, 	   0,  -13
+.2byte   -4,  -11, 	  -6,  -12, 	  -4,   -6, 	   0,  -12
+.2byte   -2,  -15, 	   3,  -21, 	   2,  -11, 	   0,  -11
+.2byte   -4,  -10, 	  -8,  -12, 	  -7,   -8, 	   0,  -10
+.2byte   -1,  -11, 	  -8,  -10, 	   2,   -6, 	   0,  -12
+.2byte    1,  -15, 	  -4,  -22, 	   9,  -15, 	   2,  -11
+.2byte   -2,   -8, 	  -9,   -5, 	  -2,   -3, 	   0,   -9
+.2byte   -3,   -6, 	  -8,   -3, 	   6,    1, 	   0,   -5
+.2byte   -2,   -7, 	  -8,   -4, 	   6,    0, 	   1,   -6
+.2byte    0,  -11, 	  -6,   -6, 	   5,   -6, 	   0,  -12
+.2byte    1,  -13, 	   8,  -10, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -14, 	   6,  -10, 	   1,   -6, 	  -3,  -10
+.2byte    3,  -15, 	   0,  -12, 	   7,   -9, 	  -2,  -10
+.2byte    0,  -14, 	   7,  -12, 	  -8,  -12, 	   0,   -9
+.2byte   -4,  -15, 	  -1,  -12, 	  -8,   -9, 	   1,  -10
+.2byte   -1,  -14, 	  -7,  -10, 	  -2,   -6, 	   2,  -10
+.2byte   -2,  -13, 	  -9,  -10, 	  -1,   -5, 	   0,  -12
+.2byte    0,  -11, 	  -8,   -8, 	   7,   -8, 	   0,  -12
+.2byte    0,  -14, 	 -10,  -18, 	   9,  -18, 	   0,  -13
+.2byte    0,  -11, 	   7,  -10, 	  -3,   -6, 	  -1,  -12
+.2byte    0,  -15, 	   5,  -22, 	  -8,  -15, 	  -1,  -11
+.2byte    3,  -11, 	   5,  -12, 	   3,   -6, 	  -1,  -12
+.2byte    0,  -15, 	  -5,  -21, 	  -4,  -11, 	  -2,  -11
+.2byte    1,  -14, 	  -5,  -14, 	   7,  -10, 	  -1,  -12
+.2byte    3,  -16, 	  -7,  -21, 	   6,  -12, 	  -1,  -12
+.2byte    0,  -14, 	   8,  -11, 	  -9,  -11, 	   0,  -12
+.2byte    0,  -17, 	   9,  -16, 	 -10,  -16, 	   0,  -11
+.2byte   -2,  -14, 	   4,  -14, 	  -8,  -10, 	   0,  -12
+.2byte   -4,  -16, 	   6,  -21, 	  -7,  -12, 	   0,  -12
+.2byte   -4,  -11, 	  -6,  -12, 	  -4,   -6, 	   0,  -12
+.2byte   -1,  -15, 	   4,  -21, 	   3,  -11, 	   1,  -11
+.2byte   -1,  -11, 	  -8,  -10, 	   2,   -6, 	   0,  -12
+.2byte   -1,  -15, 	  -6,  -22, 	   7,  -15, 	   0,  -11
+.2byte    0,   -6, 	  -5,   -2, 	   4,   -2, 	   0,   -9
+.2byte   -2,   -8, 	  -9,   -5, 	  -2,   -3, 	   0,   -9
+.2byte   -4,  -10, 	  -8,  -12, 	  -7,   -8, 	   0,  -10
+.2byte   -3,  -12, 	   1,  -17, 	 -10,  -14, 	   0,  -12
+.2byte    0,  -13, 	   2,  -18, 	  -3,  -18, 	   0,  -12
+.2byte    2,  -12, 	  -2,  -17, 	   9,  -14, 	  -1,  -12
+.2byte    3,  -10, 	   7,  -12, 	   6,   -8, 	  -1,  -10
+.2byte    1,   -8, 	   8,   -5, 	   1,   -3, 	  -1,   -9
+.2byte    0,  -13, 	 -10,  -17, 	   9,  -17, 	   0,  -12
+.2byte   -1,  -15, 	   4,  -22, 	  -9,  -15, 	  -2,  -11
+.2byte    0,  -15, 	  -5,  -21, 	  -4,  -11, 	  -2,  -11
+.2byte    3,  -16, 	  -7,  -21, 	   6,  -12, 	  -1,  -12
+.2byte    0,  -17, 	   9,  -16, 	 -10,  -16, 	   0,  -11
+.2byte   -4,  -16, 	   6,  -21, 	  -7,  -12, 	   0,  -12
+.2byte   -1,  -15, 	   4,  -21, 	   3,  -11, 	   1,  -11
+.2byte    0,  -15, 	  -5,  -22, 	   8,  -15, 	   1,  -11
+.2byte    0,  -11, 	  -8,   -8, 	   7,   -8, 	   0,  -12
+.2byte    0,  -13, 	 -10,  -17, 	   9,  -17, 	   0,  -12
+.2byte    0,   -6, 	  -5,   -2, 	   4,   -2, 	   0,   -9
+.2byte    0,  -11, 	   7,  -10, 	  -3,   -6, 	  -1,  -12
+.2byte   -2,  -15, 	   3,  -22, 	 -10,  -15, 	  -3,  -11
+.2byte    1,   -8, 	   8,   -5, 	   1,   -3, 	  -1,   -9
+.2byte    3,  -11, 	   5,  -12, 	   3,   -6, 	  -1,  -12
+.2byte    1,  -15, 	  -4,  -21, 	  -3,  -11, 	  -1,  -11
+.2byte    3,  -10, 	   7,  -12, 	   6,   -8, 	  -1,  -10
+.2byte    1,  -14, 	  -5,  -14, 	   7,  -10, 	  -1,  -12
+.2byte    1,  -16, 	  -9,  -21, 	   4,  -12, 	  -3,  -12
+.2byte    2,  -13, 	  -2,  -18, 	   9,  -15, 	  -1,  -13
+.2byte    0,  -14, 	   8,  -11, 	  -9,  -11, 	   0,  -12
+.2byte    0,  -17, 	   9,  -16, 	 -10,  -16, 	   0,  -11
+.2byte    0,  -15, 	   2,  -20, 	  -3,  -20, 	   0,  -14
+.2byte   -2,  -14, 	   4,  -14, 	  -8,  -10, 	   0,  -12
+.2byte   -2,  -16, 	   8,  -21, 	  -5,  -12, 	   2,  -12
+.2byte   -3,  -13, 	   1,  -18, 	 -10,  -15, 	   0,  -13
+.2byte   -4,  -11, 	  -6,  -12, 	  -4,   -6, 	   0,  -12
+.2byte   -2,  -15, 	   3,  -21, 	   2,  -11, 	   0,  -11
+.2byte   -4,  -10, 	  -8,  -12, 	  -7,   -8, 	   0,  -10
+.2byte   -1,  -11, 	  -8,  -10, 	   2,   -6, 	   0,  -12
+.2byte    1,  -15, 	  -4,  -22, 	   9,  -15, 	   2,  -11
+.2byte   -2,   -8, 	  -9,   -5, 	  -2,   -3, 	   0,   -9
+.2byte    0,  -13, 	 -10,  -17, 	   9,  -17, 	   0,  -12
+.2byte    0,  -15, 	  -5,  -22, 	   8,  -15, 	   1,  -11
+.2byte   -1,  -15, 	   4,  -21, 	   3,  -11, 	   1,  -11
+.2byte   -4,  -16, 	   6,  -21, 	  -7,  -12, 	   0,  -12
+.2byte    0,  -17, 	   9,  -16, 	 -10,  -16, 	   0,  -11
+.2byte    3,  -16, 	  -7,  -21, 	   6,  -12, 	  -1,  -12
+.2byte    0,  -15, 	  -5,  -21, 	  -4,  -11, 	  -2,  -11
+.2byte   -1,  -15, 	   4,  -22, 	  -9,  -15, 	  -2,  -11
+.2byte    0,   -7, 	  -8,   -4, 	   7,   -4, 	   0,   -8
+.2byte   -1,   -7, 	  -8,   -6, 	   2,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -6,   -8, 	  -4,   -2, 	   0,   -8
+.2byte   -2,  -10, 	   4,  -10, 	  -8,   -6, 	   0,   -8
+.2byte    0,  -10, 	   8,   -7, 	  -9,   -7, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -10, 	   7,   -6, 	  -1,   -8
+.2byte    3,   -7, 	   5,   -8, 	   3,   -2, 	  -1,   -8
+.2byte    0,   -7, 	   7,   -6, 	  -3,   -2, 	  -1,   -8
+sAbraAnimTable1:
+.4byte sAbraAnims_1_1
+.4byte sAbraAnims_1_2
+.4byte sAbraAnims_1_3
+.4byte sAbraAnims_1_4
+.4byte sAbraAnims_1_5
+.4byte sAbraAnims_1_6
+.4byte sAbraAnims_1_7
+.4byte sAbraAnims_1_8
+sAbraAnimTable2:
+.4byte sAbraAnims_2_1
+.4byte sAbraAnims_2_2
+.4byte sAbraAnims_2_3
+.4byte sAbraAnims_2_4
+.4byte sAbraAnims_2_5
+.4byte sAbraAnims_2_6
+.4byte sAbraAnims_2_7
+.4byte sAbraAnims_2_8
+sAbraAnimTable3:
+.4byte sAbraAnims_3_1
+.4byte sAbraAnims_3_2
+.4byte sAbraAnims_3_3
+.4byte sAbraAnims_3_4
+.4byte sAbraAnims_3_5
+.4byte sAbraAnims_3_6
+.4byte sAbraAnims_3_7
+.4byte sAbraAnims_3_8
+sAbraAnimTable4:
+.4byte sAbraAnims_4_1
+.4byte sAbraAnims_4_2
+.4byte sAbraAnims_4_3
+.4byte sAbraAnims_4_4
+.4byte sAbraAnims_4_5
+.4byte sAbraAnims_4_6
+.4byte sAbraAnims_4_7
+.4byte sAbraAnims_4_8
+sAbraAnimTable5:
+.4byte sAbraAnims_5_1
+.4byte sAbraAnims_5_2
+.4byte sAbraAnims_5_3
+.4byte sAbraAnims_5_4
+.4byte sAbraAnims_5_5
+.4byte sAbraAnims_5_6
+.4byte sAbraAnims_5_7
+.4byte sAbraAnims_5_8
+sAbraAnimTable6:
+.4byte sAbraAnims_6_1
+.4byte sAbraAnims_6_1
+.4byte sAbraAnims_6_1
+.4byte sAbraAnims_6_1
+.4byte sAbraAnims_6_1
+.4byte sAbraAnims_6_1
+.4byte sAbraAnims_6_1
+.4byte sAbraAnims_6_1
+sAbraAnimTable7:
+.4byte sAbraAnims_7_1
+.4byte sAbraAnims_7_2
+.4byte sAbraAnims_7_3
+.4byte sAbraAnims_7_4
+.4byte sAbraAnims_7_5
+.4byte sAbraAnims_7_6
+.4byte sAbraAnims_7_7
+.4byte sAbraAnims_7_8
+sAbraAnimTable8:
+.4byte sAbraAnims_8_1
+.4byte sAbraAnims_8_2
+.4byte sAbraAnims_8_3
+.4byte sAbraAnims_8_4
+.4byte sAbraAnims_8_5
+.4byte sAbraAnims_8_6
+.4byte sAbraAnims_8_7
+.4byte sAbraAnims_8_8
+sAbraAnimTable9:
+.4byte sAbraAnims_9_1
+.4byte sAbraAnims_9_2
+.4byte sAbraAnims_9_3
+.4byte sAbraAnims_9_4
+.4byte sAbraAnims_9_5
+.4byte sAbraAnims_9_6
+.4byte sAbraAnims_9_7
+.4byte sAbraAnims_9_8
+sAbraAnimTable10:
+.4byte sAbraAnims_10_1
+.4byte sAbraAnims_10_2
+.4byte sAbraAnims_10_3
+.4byte sAbraAnims_10_4
+.4byte sAbraAnims_10_5
+.4byte sAbraAnims_10_6
+.4byte sAbraAnims_10_7
+.4byte sAbraAnims_10_8
+sAbraAnimTable11:
+.4byte sAbraAnims_11_1
+.4byte sAbraAnims_11_2
+.4byte sAbraAnims_11_3
+.4byte sAbraAnims_11_4
+.4byte sAbraAnims_11_5
+.4byte sAbraAnims_11_6
+.4byte sAbraAnims_11_7
+.4byte sAbraAnims_11_8
+sAbraAnimTable12:
+.4byte sAbraAnims_12_1
+.4byte sAbraAnims_12_2
+.4byte sAbraAnims_12_3
+.4byte sAbraAnims_12_4
+.4byte sAbraAnims_12_5
+.4byte sAbraAnims_12_6
+.4byte sAbraAnims_12_7
+.4byte sAbraAnims_12_8
+sAbraAnimTable13:
+.4byte sAbraAnims_13_1
+.4byte sAbraAnims_13_2
+.4byte sAbraAnims_13_3
+.4byte sAbraAnims_13_4
+.4byte sAbraAnims_13_5
+.4byte sAbraAnims_13_6
+.4byte sAbraAnims_13_7
+.4byte sAbraAnims_13_8
+sAxAnimationsAbra:
+.4byte sAbraAnimTable1
+.4byte sAbraAnimTable2
+.4byte sAbraAnimTable3
+.4byte sAbraAnimTable4
+.4byte sAbraAnimTable5
+.4byte sAbraAnimTable6
+.4byte sAbraAnimTable7
+.4byte sAbraAnimTable8
+.4byte sAbraAnimTable9
+.4byte sAbraAnimTable10
+.4byte sAbraAnimTable11
+.4byte sAbraAnimTable12
+.4byte sAbraAnimTable13
+sAxSpritesAbra:
+.4byte sAbraSprites1
+.4byte sAbraSprites2
+.4byte sAbraSprites3
+.4byte sAbraSprites4
+.4byte sAbraSprites5
+.4byte sAbraSprites6
+.4byte sAbraSprites7
+.4byte sAbraSprites8
+.4byte sAbraSprites9
+.4byte sAbraSprites10
+.4byte sAbraSprites11
+.4byte sAbraSprites12
+.4byte sAbraSprites13
+.4byte sAbraSprites14
+.4byte sAbraSprites15
+.4byte sAbraSprites16
+.4byte sAbraSprites17
+.4byte sAbraSprites18
+.4byte sAbraSprites19
+.4byte sAbraSprites20
+.4byte sAbraSprites21
+.4byte sAbraSprites22
+.4byte sAbraSprites23
+.4byte sAbraSprites24
+.4byte sAbraSprites25
+.4byte sAbraSprites26
+.4byte sAbraSprites27
+.4byte sAbraSprites28
+.4byte sAbraSprites29
+.4byte sAbraSprites30
+.4byte sAbraSprites31
+.4byte sAbraSprites32
+.4byte sAbraSprites33
+.4byte sAbraSprites34
+.4byte sAbraSprites35
+.4byte sAbraSprites36
+.4byte sAbraSprites37
+.4byte sAbraSprites38
+.4byte sAbraSprites39
+.4byte sAbraSprites40
+.4byte sAbraSprites41
+.4byte sAbraSprites42
+.4byte sAbraSprites43
+.4byte sAbraSprites44
+.4byte sAbraSprites45
+.4byte sAbraSprites46
+.4byte sAbraSprites47
+sAxMainAbra:
+ax_main sAxPosesAbra, sAxAnimationsAbra, 13, sAxSpritesAbra, sAxPositionsAbra

--- a/data/ax/absol.inc
+++ b/data/ax/absol.inc
@@ -1,0 +1,3238 @@
+.global gAxAbsol
+gAxAbsol:
+ax_siro sAxMainAbsol
+sAbsolPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose3:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose4:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose5:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose6:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose7:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose8:
+ax_pose 7, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose9:
+ax_pose 8, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose10:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose11:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose12:
+ax_pose 11, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose14:
+ax_pose 13, 0x81e4, 0x80f8, 0x5c00
+ax_pose 14, 0x81e4, 0x0108, 0x5c08
+ax_pose 15, 0x0204, 0x0100, 0x5c0a
+ax_pose_terminator
+sAbsolPose15:
+ax_pose 16, 0x81e4, 0x80f8, 0x5c00
+ax_pose 17, 0x81e4, 0x0108, 0x5c08
+ax_pose 18, 0x0204, 0x00f8, 0x5c0a
+ax_pose_terminator
+sAbsolPose16:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose17:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose18:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose19:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose20:
+ax_pose 23, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose21:
+ax_pose 24, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose22:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose23:
+ax_pose 26, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose24:
+ax_pose 27, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose26:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose27:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose28:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose29:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose30:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose31:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose32:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose33:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose34:
+ax_pose 7, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose35:
+ax_pose 8, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose36:
+ax_pose 30, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose37:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose38:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose39:
+ax_pose 11, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose40:
+ax_pose 31, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose41:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose42:
+ax_pose 13, 0x81e4, 0x80f8, 0x5c00
+ax_pose 14, 0x81e4, 0x0108, 0x5c08
+ax_pose 15, 0x0204, 0x0100, 0x5c0a
+ax_pose_terminator
+sAbsolPose43:
+ax_pose 16, 0x81e4, 0x80f8, 0x5c00
+ax_pose 17, 0x81e4, 0x0108, 0x5c08
+ax_pose 18, 0x0204, 0x00f8, 0x5c0a
+ax_pose_terminator
+sAbsolPose44:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose45:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose46:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose47:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose48:
+ax_pose 33, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose49:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose50:
+ax_pose 23, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose51:
+ax_pose 24, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose52:
+ax_pose 34, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose53:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose54:
+ax_pose 26, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose55:
+ax_pose 27, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose56:
+ax_pose 35, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose57:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose58:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose59:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose60:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose61:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose62:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose63:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose64:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose65:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose66:
+ax_pose 7, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose67:
+ax_pose 8, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose68:
+ax_pose 30, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose69:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose70:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose71:
+ax_pose 11, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose72:
+ax_pose 31, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose73:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose74:
+ax_pose 13, 0x81e4, 0x80f8, 0x5c00
+ax_pose 14, 0x81e4, 0x0108, 0x5c08
+ax_pose 15, 0x0204, 0x0100, 0x5c0a
+ax_pose_terminator
+sAbsolPose75:
+ax_pose 16, 0x81e4, 0x80f8, 0x5c00
+ax_pose 17, 0x81e4, 0x0108, 0x5c08
+ax_pose 18, 0x0204, 0x00f8, 0x5c0a
+ax_pose_terminator
+sAbsolPose76:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose77:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose78:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose79:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose80:
+ax_pose 33, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose81:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose82:
+ax_pose 23, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose83:
+ax_pose 24, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose84:
+ax_pose 34, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose85:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose86:
+ax_pose 26, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose87:
+ax_pose 27, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose88:
+ax_pose 35, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose89:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose90:
+ax_pose 36, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose91:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose92:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose93:
+ax_pose 37, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose94:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose95:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose96:
+ax_pose 38, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sAbsolPose97:
+ax_pose 30, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose98:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose99:
+ax_pose 39, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose100:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose101:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose102:
+ax_pose 40, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose103:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose104:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose105:
+ax_pose 41, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose106:
+ax_pose 33, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose107:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose108:
+ax_pose 42, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sAbsolPose109:
+ax_pose 34, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose110:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose111:
+ax_pose 43, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose112:
+ax_pose 35, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose113:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose114:
+ax_pose 36, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose115:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose116:
+ax_pose 44, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose117:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose118:
+ax_pose 37, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose119:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose120:
+ax_pose 45, 0x01e2, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose121:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose122:
+ax_pose 38, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sAbsolPose123:
+ax_pose 30, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose124:
+ax_pose 46, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose125:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose126:
+ax_pose 39, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose127:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose128:
+ax_pose 47, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose129:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose130:
+ax_pose 40, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose131:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose132:
+ax_pose 48, 0x81e6, 0x80f4, 0x5c00
+ax_pose 49, 0x81f6, 0x0104, 0x5c08
+ax_pose 50, 0x01ee, 0x0104, 0x5c0a
+ax_pose 51, 0x41de, 0x00f4, 0x5c0b
+ax_pose_terminator
+sAbsolPose133:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose134:
+ax_pose 41, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose135:
+ax_pose 33, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose136:
+ax_pose 52, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose137:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose138:
+ax_pose 42, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sAbsolPose139:
+ax_pose 34, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose140:
+ax_pose 53, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose141:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose142:
+ax_pose 43, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose143:
+ax_pose 35, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose144:
+ax_pose 54, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose145:
+ax_pose 55, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose146:
+ax_pose 56, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose147:
+ax_pose 57, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose148:
+ax_pose 58, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose149:
+ax_pose 59, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose150:
+ax_pose 60, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose151:
+ax_pose 61, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose152:
+ax_pose 62, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose153:
+ax_pose 63, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose154:
+ax_pose 64, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose155:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose156:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose157:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose158:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose159:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose160:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose161:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose162:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose163:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose164:
+ax_pose 7, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose165:
+ax_pose 8, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose166:
+ax_pose 30, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose167:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose168:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose169:
+ax_pose 11, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose170:
+ax_pose 31, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose171:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose172:
+ax_pose 13, 0x81e4, 0x80f8, 0x5c00
+ax_pose 14, 0x81e4, 0x0108, 0x5c08
+ax_pose 15, 0x0204, 0x0100, 0x5c0a
+ax_pose_terminator
+sAbsolPose173:
+ax_pose 16, 0x81e4, 0x80f8, 0x5c00
+ax_pose 17, 0x81e4, 0x0108, 0x5c08
+ax_pose 18, 0x0204, 0x00f8, 0x5c0a
+ax_pose_terminator
+sAbsolPose174:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose175:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose176:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose177:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAbsolPose178:
+ax_pose 33, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose179:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose180:
+ax_pose 23, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose181:
+ax_pose 24, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose182:
+ax_pose 34, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose183:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose184:
+ax_pose 26, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose185:
+ax_pose 27, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose186:
+ax_pose 35, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose187:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose188:
+ax_pose 35, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose189:
+ax_pose 34, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose190:
+ax_pose 33, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose191:
+ax_pose 32, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose192:
+ax_pose 31, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose193:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose194:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose195:
+ax_pose 36, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose196:
+ax_pose 37, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose197:
+ax_pose 38, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sAbsolPose198:
+ax_pose 39, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose199:
+ax_pose 40, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose200:
+ax_pose 41, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose201:
+ax_pose 42, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose202:
+ax_pose 43, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sAbsolPose203:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose204:
+ax_pose 36, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose205:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose206:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose207:
+ax_pose 37, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose208:
+ax_pose 29, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose209:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose210:
+ax_pose 38, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sAbsolPose211:
+ax_pose 30, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose212:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose213:
+ax_pose 39, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose214:
+ax_pose 31, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose215:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose216:
+ax_pose 40, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose217:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose218:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose219:
+ax_pose 41, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose220:
+ax_pose 33, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose221:
+ax_pose 22, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose222:
+ax_pose 42, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose223:
+ax_pose 34, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sAbsolPose224:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose225:
+ax_pose 43, 0x01e3, 0x80ed, 0x5c00
+ax_pose_terminator
+sAbsolPose226:
+ax_pose 35, 0x01e6, 0x80ed, 0x5c00
+ax_pose_terminator
+sAbsolPose227:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose228:
+ax_pose 35, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose229:
+ax_pose 34, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose230:
+ax_pose 33, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose231:
+ax_pose 32, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose232:
+ax_pose 31, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAbsolPose233:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose234:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose235:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose236:
+ax_pose 25, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAbsolPose237:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAbsolPose238:
+ax_pose 19, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose239:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose240:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose241:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose242:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose243:
+ax_pose 65, 0x41f0, 0x80ee, 0x5c00
+ax_pose 66, 0x41e8, 0x00fe, 0x5c08
+ax_pose 67, 0x81e8, 0x410e, 0x5c0a
+ax_pose_terminator
+sAbsolPose244:
+ax_pose 68, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose245:
+ax_pose 65, 0x41f0, 0x80ee, 0x5c00
+ax_pose 66, 0x41e8, 0x00fe, 0x5c08
+ax_pose 67, 0x81e8, 0x410e, 0x5c0a
+ax_pose_terminator
+sAbsolPose246:
+ax_pose 68, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose247:
+ax_pose 65, 0x41f0, 0x80ee, 0x5c00
+ax_pose 66, 0x41e8, 0x00fe, 0x5c08
+ax_pose 67, 0x81e8, 0x410e, 0x5c0a
+ax_pose_terminator
+sAbsolPose248:
+ax_pose 68, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose249:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAbsolPose250:
+ax_pose 69, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAbsolPose251:
+ax_pose 70, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+.align 2
+sAbsolAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sAbsolAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 17, 18, 17, 18,
+ax_anim 2, 1, 31, 18, 17, 18, 17,
+ax_anim 2, 0, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 31, 18, 17, 18, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sAbsolAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 2, 0, 2, 0,
+ax_anim 1, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 1, 35, 13, 1, 13, 1,
+ax_anim 2, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 0, 35, 13, 1, 13, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sAbsolAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -5, 5, -5,
+ax_anim 1, 0, 38, 11, -11, 11, -11,
+ax_anim 2, 0, 39, 17, -18, 17, -18,
+ax_anim 2, 1, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 39, 17, -18, 17, -18,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sAbsolAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -3, 0, -3,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sAbsolAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -5, -5, -5,
+ax_anim 1, 0, 46, -11, -11, -11, -11,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 1, 47, -20, -18, -20, -16,
+ax_anim 2, 0, 47, -19, -19, -19, -17,
+ax_anim 2, 0, 47, -20, -18, -20, -16,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sAbsolAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -2, 0, -2, 0,
+ax_anim 1, 0, 50, -8, 0, -8, 0,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 1, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sAbsolAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -16, 17, -16, 17,
+ax_anim 2, 1, 55, -17, 16, -17, 16,
+ax_anim 2, 0, 55, -16, 17, -16, 17,
+ax_anim 2, 0, 55, -17, 16, -17, 16,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sAbsolAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 8, 0, 8,
+ax_anim 1, 0, 58, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 0, 42, 0, 42,
+ax_anim 2, 1, 59, 1, 42, 1, 42,
+ax_anim 2, 0, 59, 0, 42, 0, 42,
+ax_anim 2, 0, 59, 1, 42, 1, 42,
+ax_anim 2, 0, 56, 0, 20, 0, 20,
+ax_anim 1, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sAbsolAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 9, 8, 9, 8,
+ax_anim 1, 0, 62, 20, 20, 20, 20,
+ax_anim 2, 0, 63, 41, 43, 41, 43,
+ax_anim 2, 1, 63, 42, 42, 42, 42,
+ax_anim 2, 0, 63, 41, 43, 41, 43,
+ax_anim 2, 0, 63, 42, 42, 42, 42,
+ax_anim 2, 0, 60, 20, 20, 20, 20,
+ax_anim 1, 0, 60, 7, 5, 7, 5,
+ax_anim_terminator
+sAbsolAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 16, 0, 16, 0,
+ax_anim 2, 0, 67, 37, 0, 37, 0,
+ax_anim 2, 1, 67, 37, 1, 37, 1,
+ax_anim 2, 0, 67, 37, 0, 37, 0,
+ax_anim 2, 0, 67, 37, 1, 37, 1,
+ax_anim 2, 0, 64, 14, 0, 14, 0,
+ax_anim 1, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sAbsolAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 8, -8, 8, -8,
+ax_anim 1, 0, 70, 20, -20, 20, -20,
+ax_anim 2, 0, 71, 41, -42, 41, -42,
+ax_anim 2, 1, 71, 42, -41, 42, -41,
+ax_anim 2, 0, 71, 41, -42, 41, -42,
+ax_anim 2, 0, 71, 42, -41, 42, -41,
+ax_anim 2, 0, 68, 16, -16, 16, -16,
+ax_anim 1, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sAbsolAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -6, 0, -6,
+ax_anim 1, 0, 74, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 0, -39, 0, -39,
+ax_anim 2, 1, 75, 1, -39, 1, -39,
+ax_anim 2, 0, 75, 0, -39, 0, -39,
+ax_anim 2, 0, 75, 1, -39, 1, -39,
+ax_anim 2, 0, 72, 0, -18, 0, -18,
+ax_anim 1, 0, 72, 0, -8, 0, -8,
+ax_anim_terminator
+sAbsolAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -8, -8, -8, -8,
+ax_anim 1, 0, 78, -21, -19, -21, -19,
+ax_anim 2, 0, 79, -45, -43, -45, -43,
+ax_anim 2, 1, 79, -46, -42, -46, -42,
+ax_anim 2, 0, 79, -45, -43, -45, -43,
+ax_anim 2, 0, 79, -46, -42, -46, -42,
+ax_anim 2, 0, 76, -16, -16, -16, -16,
+ax_anim 1, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sAbsolAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -16, 0, -16, 0,
+ax_anim 2, 0, 83, -39, 0, -39, 0,
+ax_anim 2, 1, 83, -39, 1, -39, 1,
+ax_anim 2, 0, 83, -39, 0, -39, 0,
+ax_anim 2, 0, 83, -39, 1, -39, 1,
+ax_anim 2, 0, 80, -14, 0, -14, 0,
+ax_anim 1, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sAbsolAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -9, 8, -9, 8,
+ax_anim 1, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 87, -41, 43, -41, 43,
+ax_anim 2, 1, 87, -42, 42, -42, 42,
+ax_anim 2, 0, 87, -41, 43, -41, 43,
+ax_anim 2, 0, 87, -42, 42, -42, 42,
+ax_anim 2, 0, 84, -20, 20, -20, 20,
+ax_anim 1, 0, 84, -7, 5, -7, 5,
+ax_anim_terminator
+.align 2
+sAbsolAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sAbsolAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sAbsolAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sAbsolAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sAbsolAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sAbsolAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sAbsolAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sAbsolAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sAbsolAnims_5_1:
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 0, 143, -2, -1, -2, -1,
+ax_anim 6, 2, 115, 0, -4, 0, -4,
+ax_anim 1, 0, 114, 0, -2, 0, -2,
+ax_anim 1, 0, 114, 0, 3, 0, 3,
+ax_anim 2, 1, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 1, 5, 1, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 1, 5, 1, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 1, 5, 1, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim_terminator
+sAbsolAnims_5_2:
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 6, 2, 119, -4, -4, -4, -4,
+ax_anim 1, 0, 118, -2, -2, -2, -2,
+ax_anim 1, 0, 118, 3, 3, 3, 3,
+ax_anim 2, 1, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 118, 6, 4, 6, 4,
+ax_anim 2, 0, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 118, 6, 4, 6, 4,
+ax_anim 2, 0, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 118, 6, 4, 6, 4,
+ax_anim 2, 0, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 116, 2, 2, 2, 2,
+ax_anim_terminator
+sAbsolAnims_5_3:
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 0, 119, -2, 1, -2, 1,
+ax_anim 6, 2, 123, -4, 0, -4, 0,
+ax_anim 1, 0, 122, -2, 0, -2, 0,
+ax_anim 1, 0, 122, 3, 0, 3, 0,
+ax_anim 2, 1, 122, 5, 0, 5, 0,
+ax_anim 2, 0, 122, 5, 1, 5, 1,
+ax_anim 2, 0, 122, 5, 0, 5, 0,
+ax_anim 2, 0, 122, 5, 1, 5, 1,
+ax_anim 2, 0, 122, 5, 0, 5, 0,
+ax_anim 2, 0, 122, 5, 1, 5, 1,
+ax_anim 2, 0, 122, 5, 0, 5, 0,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim_terminator
+sAbsolAnims_5_4:
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim 2, 0, 123, -1, 3, -1, 3,
+ax_anim 6, 2, 127, -4, 4, -4, 4,
+ax_anim 1, 0, 126, -2, 2, -2, 2,
+ax_anim 1, 0, 126, 3, -3, 3, -3,
+ax_anim 2, 1, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 126, 6, -4, 6, -4,
+ax_anim 2, 0, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 126, 6, -4, 6, -4,
+ax_anim 2, 0, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 126, 6, -4, 6, -4,
+ax_anim 2, 0, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 124, 2, -2, 2, -2,
+ax_anim_terminator
+sAbsolAnims_5_5:
+ax_anim 2, 0, 129, 0, 1, 0, 1,
+ax_anim 2, 0, 127, 0, 3, 0, 3,
+ax_anim 6, 2, 131, 0, 4, 0, 4,
+ax_anim 1, 0, 130, 0, 2, 0, 2,
+ax_anim 1, 0, 130, 0, -3, 0, -3,
+ax_anim 2, 1, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 130, 1, -5, 1, -5,
+ax_anim 2, 0, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 130, 1, -5, 1, -5,
+ax_anim 2, 0, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 130, 1, -5, 1, -5,
+ax_anim 2, 0, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 128, 0, -2, 0, -2,
+ax_anim_terminator
+sAbsolAnims_5_6:
+ax_anim 2, 0, 133, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 6, 1, 4, 1,
+ax_anim 6, 2, 135, 4, 4, 4, 4,
+ax_anim 1, 0, 134, 2, 2, 2, 2,
+ax_anim 1, 0, 134, -3, -3, -3, -3,
+ax_anim 2, 1, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 134, -6, -4, -6, -4,
+ax_anim 2, 0, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 134, -6, -4, -6, -4,
+ax_anim 2, 0, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 134, -6, -4, -6, -4,
+ax_anim 2, 0, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 132, -2, -2, -2, -2,
+ax_anim_terminator
+sAbsolAnims_5_7:
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim 2, 0, 135, 3, 0, 3, 0,
+ax_anim 6, 2, 139, 4, 0, 4, 0,
+ax_anim 1, 0, 138, 2, 0, 2, 0,
+ax_anim 1, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 1, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -5, 1, -5, 1,
+ax_anim 2, 0, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -5, 1, -5, 1,
+ax_anim 2, 0, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -5, 1, -5, 1,
+ax_anim 2, 0, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim_terminator
+sAbsolAnims_5_8:
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 6, 2, 143, 6, -4, 6, -4,
+ax_anim 1, 0, 142, 2, -2, 2, -2,
+ax_anim 1, 0, 142, -3, 3, -3, 3,
+ax_anim 2, 1, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -6, 4, -6, 4,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -6, 4, -6, 4,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -6, 4, -6, 4,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 140, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sAbsolAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sAbsolAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sAbsolAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sAbsolAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sAbsolAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sAbsolAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sAbsolAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sAbsolAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sAbsolAnims_8_1:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 30, 0, 157, 0, 3, 0, 3,
+ax_anim_terminator
+sAbsolAnims_8_2:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 30, 0, 161, 2, 2, 2, 2,
+ax_anim_terminator
+sAbsolAnims_8_3:
+ax_anim 30, 0, 162, 0, 0, 0, 0,
+ax_anim 30, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_8_4:
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim 30, 0, 169, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_8_5:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 30, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_8_6:
+ax_anim 30, 0, 174, 0, 0, 0, 0,
+ax_anim 30, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_8_7:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 30, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_8_8:
+ax_anim 30, 0, 182, 0, 0, 0, 0,
+ax_anim 30, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 4, 6, 4,
+ax_anim 2, 0, 188, 7, 11, 7, 11,
+ax_anim 2, 0, 189, 5, 17, 5, 17,
+ax_anim 3, 0, 190, 0, 19, 0, 19,
+ax_anim 2, 3, 191, -5, 17, -5, 17,
+ax_anim 2, 0, 192, -7, 11, -7, 11,
+ax_anim 1, 0, 193, -6, 4, -6, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 12, 1, 12, 1,
+ax_anim 2, 0, 187, 20, 7, 20, 7,
+ax_anim 2, 0, 188, 21, 14, 21, 14,
+ax_anim 3, 0, 189, 18, 19, 18, 19,
+ax_anim 2, 3, 190, 11, 19, 11, 19,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -4, 3, -4,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 16, -5, 16, -5,
+ax_anim 3, 0, 188, 18, -2, 18, -2,
+ax_anim 2, 3, 189, 16, 3, 16, 3,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 4, 3, 4, 3,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -20, 12, -20,
+ax_anim 3, 0, 187, 18, -22, 18, -22,
+ax_anim 2, 3, 188, 20, -15, 20, -15,
+ax_anim 2, 0, 189, 16, -5, 16, -5,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -7, -4, -7, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -22, 0, -22,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 9, -10, 9, -10,
+ax_anim 1, 0, 189, 7, -4, 7, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -6, 1, -6,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -20, -12, -20,
+ax_anim 3, 0, 193, -18, -22, -18, -22,
+ax_anim 2, 3, 192, -20, -15, -20, -15,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -4, -3, -4,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -16, -5, -16, -5,
+ax_anim 3, 0, 192, -18, -2, -18, -2,
+ax_anim 2, 3, 191, -17, 2, -17, 2,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -5, 3, -5, 3,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -19, 10, -19, 10,
+ax_anim 3, 0, 191, -18, 19, -18, 19,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -4, 14, -4, 14,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -19, 0, 0,
+ax_anim 4, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -19, 0, 0,
+ax_anim 4, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -19, 0, 0,
+ax_anim 4, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -22, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -19, 0, 0,
+ax_anim 4, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_14_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_14_2:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_14_3:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_14_4:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_14_5:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_14_6:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_14_7:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_14_8:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_15_1:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_15_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_15_3:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_15_4:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_15_5:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_15_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_15_7:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sAbsolAnims_15_8:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAbsolAnims_16_1:
+ax_anim 3, 0, 247, 0, 0, 0, 0,
+ax_anim 3, 0, 250, -1, 0, 0, 0,
+ax_anim 3, 0, 249, 0, -1, 0, 0,
+ax_anim 3, 0, 246, 0, -1, 0, 0,
+ax_anim 3, 0, 246, 1, -3, 0, 0,
+ax_anim 3, 0, 246, 1, -5, 0, 0,
+ax_anim 3, 0, 246, 1, -7, 0, 0,
+ax_anim 3, 0, 246, 1, -9, 0, 0,
+ax_anim 6, 0, 246, 1, -10, 0, 0,
+ax_anim 3, 0, 246, 1, -9, 0, 0,
+ax_anim 3, 0, 246, 1, -7, 0, 0,
+ax_anim 3, 0, 246, 1, -5, 0, 0,
+ax_anim 3, 0, 246, 1, -3, 0, 0,
+ax_anim 3, 0, 246, 1, -1, 0, 0,
+ax_anim_terminator
+sAbsolGfx1:
+.incbin "baserom.gba", 0x14D5490, 0x200
+sAbsolSprites1:
+ax_sprite sAbsolGfx1, 0x200
+ax_sprite_terminator
+sAbsolGfx2:
+.incbin "baserom.gba", 0x14D56A0, 0x200
+sAbsolSprites2:
+ax_sprite sAbsolGfx2, 0x200
+ax_sprite_terminator
+sAbsolGfx3:
+.incbin "baserom.gba", 0x14D58B0, 0x200
+sAbsolSprites3:
+ax_sprite sAbsolGfx3, 0x200
+ax_sprite_terminator
+sAbsolGfx4:
+.incbin "baserom.gba", 0x14D5AC0, 0x200
+sAbsolSprites4:
+ax_sprite sAbsolGfx4, 0x200
+ax_sprite_terminator
+sAbsolGfx5:
+.incbin "baserom.gba", 0x14D5CD0, 0x200
+sAbsolSprites5:
+ax_sprite sAbsolGfx5, 0x200
+ax_sprite_terminator
+sAbsolGfx6:
+.incbin "baserom.gba", 0x14D5EE0, 0x200
+sAbsolSprites6:
+ax_sprite sAbsolGfx6, 0x200
+ax_sprite_terminator
+sAbsolGfx7:
+.incbin "baserom.gba", 0x14D60F0, 0x200
+sAbsolSprites7:
+ax_sprite sAbsolGfx7, 0x200
+ax_sprite_terminator
+sAbsolGfx8:
+.incbin "baserom.gba", 0x14D6300, 0x200
+sAbsolSprites8:
+ax_sprite sAbsolGfx8, 0x200
+ax_sprite_terminator
+sAbsolGfx9:
+.incbin "baserom.gba", 0x14D6510, 0x200
+sAbsolSprites9:
+ax_sprite sAbsolGfx9, 0x200
+ax_sprite_terminator
+sAbsolGfx10:
+.incbin "baserom.gba", 0x14D6720, 0x200
+sAbsolSprites10:
+ax_sprite sAbsolGfx10, 0x200
+ax_sprite_terminator
+sAbsolGfx11:
+.incbin "baserom.gba", 0x14D6930, 0x200
+sAbsolSprites11:
+ax_sprite sAbsolGfx11, 0x200
+ax_sprite_terminator
+sAbsolGfx12:
+.incbin "baserom.gba", 0x14D6B40, 0x200
+sAbsolSprites12:
+ax_sprite sAbsolGfx12, 0x200
+ax_sprite_terminator
+sAbsolGfx13:
+.incbin "baserom.gba", 0x14D6D50, 0x200
+sAbsolSprites13:
+ax_sprite sAbsolGfx13, 0x200
+ax_sprite_terminator
+sAbsolGfx14:
+.incbin "baserom.gba", 0x14D6F60, 0x100
+sAbsolSprites14:
+ax_sprite sAbsolGfx14, 0x100
+ax_sprite_terminator
+sAbsolGfx15:
+.incbin "baserom.gba", 0x14D7070, 0x40
+sAbsolSprites15:
+ax_sprite sAbsolGfx15, 0x40
+ax_sprite_terminator
+sAbsolGfx16:
+.incbin "baserom.gba", 0x14D70C0, 0x20
+sAbsolSprites16:
+ax_sprite sAbsolGfx16, 0x20
+ax_sprite_terminator
+sAbsolGfx17:
+.incbin "baserom.gba", 0x14D70F0, 0x100
+sAbsolSprites17:
+ax_sprite sAbsolGfx17, 0x100
+ax_sprite_terminator
+sAbsolGfx18:
+.incbin "baserom.gba", 0x14D7200, 0x40
+sAbsolSprites18:
+ax_sprite sAbsolGfx18, 0x40
+ax_sprite_terminator
+sAbsolGfx19:
+.incbin "baserom.gba", 0x14D7250, 0x20
+sAbsolSprites19:
+ax_sprite sAbsolGfx19, 0x20
+ax_sprite_terminator
+sAbsolGfx20:
+.incbin "baserom.gba", 0x14D7280, 0x200
+sAbsolSprites20:
+ax_sprite sAbsolGfx20, 0x200
+ax_sprite_terminator
+sAbsolGfx21:
+.incbin "baserom.gba", 0x14D7490, 0x200
+sAbsolSprites21:
+ax_sprite sAbsolGfx21, 0x200
+ax_sprite_terminator
+sAbsolGfx22:
+.incbin "baserom.gba", 0x14D76A0, 0x200
+sAbsolSprites22:
+ax_sprite sAbsolGfx22, 0x200
+ax_sprite_terminator
+sAbsolGfx23:
+.incbin "baserom.gba", 0x14D78B0, 0x200
+sAbsolSprites23:
+ax_sprite sAbsolGfx23, 0x200
+ax_sprite_terminator
+sAbsolGfx24:
+.incbin "baserom.gba", 0x14D7AC0, 0x200
+sAbsolSprites24:
+ax_sprite sAbsolGfx24, 0x200
+ax_sprite_terminator
+sAbsolGfx25:
+.incbin "baserom.gba", 0x14D7CD0, 0x200
+sAbsolSprites25:
+ax_sprite sAbsolGfx25, 0x200
+ax_sprite_terminator
+sAbsolGfx26:
+.incbin "baserom.gba", 0x14D7EE0, 0x200
+sAbsolSprites26:
+ax_sprite sAbsolGfx26, 0x200
+ax_sprite_terminator
+sAbsolGfx27:
+.incbin "baserom.gba", 0x14D80F0, 0x200
+sAbsolSprites27:
+ax_sprite sAbsolGfx27, 0x200
+ax_sprite_terminator
+sAbsolGfx28:
+.incbin "baserom.gba", 0x14D8300, 0x200
+sAbsolSprites28:
+ax_sprite sAbsolGfx28, 0x200
+ax_sprite_terminator
+sAbsolGfx29:
+.incbin "baserom.gba", 0x14D8510, 0x60
+sAbsolGfx29_1:
+.incbin "baserom.gba", 0x14D8570, 0x60
+sAbsolGfx29_2:
+.incbin "baserom.gba", 0x14D85D0, 0x60
+sAbsolGfx29_3:
+.incbin "baserom.gba", 0x14D8630, 0x60
+sAbsolSprites29:
+ax_sprite sAbsolGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx30:
+.incbin "baserom.gba", 0x14D86D8, 0x40
+sAbsolGfx30_1:
+.incbin "baserom.gba", 0x14D8718, 0x160
+sAbsolSprites30:
+ax_sprite sAbsolGfx30, 0x40
+ax_sprite 0, 0x60
+ax_sprite sAbsolGfx30_1, 0x160
+ax_sprite_terminator
+sAbsolGfx31:
+.incbin "baserom.gba", 0x14D8898, 0x20
+sAbsolGfx31_1:
+.incbin "baserom.gba", 0x14D88B8, 0x180
+sAbsolSprites31:
+ax_sprite sAbsolGfx31, 0x20
+ax_sprite 0, 0x60
+ax_sprite sAbsolGfx31_1, 0x180
+ax_sprite_terminator
+sAbsolGfx32:
+.incbin "baserom.gba", 0x14D8A58, 0x200
+sAbsolSprites32:
+ax_sprite sAbsolGfx32, 0x200
+ax_sprite_terminator
+sAbsolGfx33:
+.incbin "baserom.gba", 0x14D8C68, 0x60
+sAbsolGfx33_1:
+.incbin "baserom.gba", 0x14D8CC8, 0x60
+sAbsolGfx33_2:
+.incbin "baserom.gba", 0x14D8D28, 0x40
+sAbsolGfx33_3:
+.incbin "baserom.gba", 0x14D8D68, 0x40
+sAbsolSprites33:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAbsolGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx34:
+.incbin "baserom.gba", 0x14D8DF8, 0x1E0
+sAbsolSprites34:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx34, 0x1e0
+ax_sprite_terminator
+sAbsolGfx35:
+.incbin "baserom.gba", 0x14D8FF0, 0x20
+sAbsolGfx35_1:
+.incbin "baserom.gba", 0x14D9010, 0x1A0
+sAbsolSprites35:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx35, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx35_1, 0x1a0
+ax_sprite_terminator
+sAbsolGfx36:
+.incbin "baserom.gba", 0x14D91D8, 0x200
+sAbsolSprites36:
+ax_sprite sAbsolGfx36, 0x200
+ax_sprite_terminator
+sAbsolGfx37:
+.incbin "baserom.gba", 0x14D93E8, 0x60
+sAbsolGfx37_1:
+.incbin "baserom.gba", 0x14D9448, 0x60
+sAbsolGfx37_2:
+.incbin "baserom.gba", 0x14D94A8, 0x40
+sAbsolGfx37_3:
+.incbin "baserom.gba", 0x14D94E8, 0x40
+sAbsolSprites37:
+ax_sprite sAbsolGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx37_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAbsolGfx37_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAbsolGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx38:
+.incbin "baserom.gba", 0x14D9570, 0x60
+sAbsolGfx38_1:
+.incbin "baserom.gba", 0x14D95D0, 0x100
+sAbsolGfx38_2:
+.incbin "baserom.gba", 0x14D96D0, 0x60
+sAbsolSprites38:
+ax_sprite sAbsolGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx38_2, 0x60
+ax_sprite_terminator
+sAbsolGfx39:
+.incbin "baserom.gba", 0x14D9760, 0x160
+sAbsolGfx39_1:
+.incbin "baserom.gba", 0x14D98C0, 0x60
+sAbsolSprites39:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx39, 0x160
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx39_1, 0x60
+ax_sprite_terminator
+sAbsolGfx40:
+.incbin "baserom.gba", 0x14D9948, 0x60
+sAbsolGfx40_1:
+.incbin "baserom.gba", 0x14D99A8, 0xC0
+sAbsolGfx40_2:
+.incbin "baserom.gba", 0x14D9A68, 0x80
+sAbsolSprites40:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx40_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx40_2, 0x80
+ax_sprite_terminator
+sAbsolGfx41:
+.incbin "baserom.gba", 0x14D9B20, 0x60
+sAbsolGfx41_1:
+.incbin "baserom.gba", 0x14D9B80, 0x60
+sAbsolGfx41_2:
+.incbin "baserom.gba", 0x14D9BE0, 0x40
+sAbsolGfx41_3:
+.incbin "baserom.gba", 0x14D9C20, 0x40
+sAbsolSprites41:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx41_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAbsolGfx41_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx42:
+.incbin "baserom.gba", 0x14D9CB0, 0x40
+sAbsolGfx42_1:
+.incbin "baserom.gba", 0x14D9CF0, 0x80
+sAbsolGfx42_2:
+.incbin "baserom.gba", 0x14D9D70, 0xE0
+sAbsolSprites42:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx42_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx42_2, 0xe0
+ax_sprite_terminator
+sAbsolGfx43:
+.incbin "baserom.gba", 0x14D9E88, 0x60
+sAbsolGfx43_1:
+.incbin "baserom.gba", 0x14D9EE8, 0x160
+sAbsolSprites43:
+ax_sprite sAbsolGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx43_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx44:
+.incbin "baserom.gba", 0x14DA070, 0x60
+sAbsolGfx44_1:
+.incbin "baserom.gba", 0x14DA0D0, 0x60
+sAbsolGfx44_2:
+.incbin "baserom.gba", 0x14DA130, 0x60
+sAbsolGfx44_3:
+.incbin "baserom.gba", 0x14DA190, 0x60
+sAbsolSprites44:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx44_3, 0x60
+ax_sprite_terminator
+sAbsolGfx45:
+.incbin "baserom.gba", 0x14DA238, 0x180
+sAbsolGfx45_1:
+.incbin "baserom.gba", 0x14DA3B8, 0x60
+sAbsolSprites45:
+ax_sprite sAbsolGfx45, 0x180
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx45_1, 0x60
+ax_sprite_terminator
+sAbsolGfx46:
+.incbin "baserom.gba", 0x14DA438, 0x1C0
+sAbsolSprites46:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx46, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx47:
+.incbin "baserom.gba", 0x14DA618, 0xC0
+sAbsolGfx47_1:
+.incbin "baserom.gba", 0x14DA6D8, 0x60
+sAbsolGfx47_2:
+.incbin "baserom.gba", 0x14DA738, 0x60
+sAbsolSprites47:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx47, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx47_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx48:
+.incbin "baserom.gba", 0x14DA7D8, 0x60
+sAbsolGfx48_1:
+.incbin "baserom.gba", 0x14DA838, 0x60
+sAbsolGfx48_2:
+.incbin "baserom.gba", 0x14DA898, 0x60
+sAbsolGfx48_3:
+.incbin "baserom.gba", 0x14DA8F8, 0x40
+sAbsolSprites48:
+ax_sprite sAbsolGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx48_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAbsolGfx48_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAbsolGfx49:
+.incbin "baserom.gba", 0x14DA980, 0xC0
+sAbsolGfx49_1:
+.incbin "baserom.gba", 0x14DAA40, 0x20
+sAbsolSprites49:
+ax_sprite sAbsolGfx49, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx49_1, 0x20
+ax_sprite_terminator
+sAbsolGfx50:
+.incbin "baserom.gba", 0x14DAA80, 0x40
+sAbsolSprites50:
+ax_sprite sAbsolGfx50, 0x40
+ax_sprite_terminator
+sAbsolGfx51:
+.incbin "baserom.gba", 0x14DAAD0, 0x20
+sAbsolSprites51:
+ax_sprite sAbsolGfx51, 0x20
+ax_sprite_terminator
+sAbsolGfx52:
+.incbin "baserom.gba", 0x14DAB00, 0x40
+sAbsolSprites52:
+ax_sprite sAbsolGfx52, 0x40
+ax_sprite_terminator
+sAbsolGfx53:
+.incbin "baserom.gba", 0x14DAB50, 0x60
+sAbsolGfx53_1:
+.incbin "baserom.gba", 0x14DABB0, 0x100
+sAbsolGfx53_2:
+.incbin "baserom.gba", 0x14DACB0, 0x60
+sAbsolSprites53:
+ax_sprite sAbsolGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx53_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx53_2, 0x60
+ax_sprite_terminator
+sAbsolGfx54:
+.incbin "baserom.gba", 0x14DAD40, 0x180
+sAbsolGfx54_1:
+.incbin "baserom.gba", 0x14DAEC0, 0x60
+sAbsolSprites54:
+ax_sprite sAbsolGfx54, 0x180
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx54_1, 0x60
+ax_sprite_terminator
+sAbsolGfx55:
+.incbin "baserom.gba", 0x14DAF40, 0x60
+sAbsolGfx55_1:
+.incbin "baserom.gba", 0x14DAFA0, 0x60
+sAbsolGfx55_2:
+.incbin "baserom.gba", 0x14DB000, 0x60
+sAbsolGfx55_3:
+.incbin "baserom.gba", 0x14DB060, 0x60
+sAbsolSprites55:
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx55_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAbsolGfx55_3, 0x60
+ax_sprite_terminator
+sAbsolGfx56:
+.incbin "baserom.gba", 0x14DB108, 0x200
+sAbsolSprites56:
+ax_sprite sAbsolGfx56, 0x200
+ax_sprite_terminator
+sAbsolGfx57:
+.incbin "baserom.gba", 0x14DB318, 0x200
+sAbsolSprites57:
+ax_sprite sAbsolGfx57, 0x200
+ax_sprite_terminator
+sAbsolGfx58:
+.incbin "baserom.gba", 0x14DB528, 0x200
+sAbsolSprites58:
+ax_sprite sAbsolGfx58, 0x200
+ax_sprite_terminator
+sAbsolGfx59:
+.incbin "baserom.gba", 0x14DB738, 0x200
+sAbsolSprites59:
+ax_sprite sAbsolGfx59, 0x200
+ax_sprite_terminator
+sAbsolGfx60:
+.incbin "baserom.gba", 0x14DB948, 0x200
+sAbsolSprites60:
+ax_sprite sAbsolGfx60, 0x200
+ax_sprite_terminator
+sAbsolGfx61:
+.incbin "baserom.gba", 0x14DBB58, 0x200
+sAbsolSprites61:
+ax_sprite sAbsolGfx61, 0x200
+ax_sprite_terminator
+sAbsolGfx62:
+.incbin "baserom.gba", 0x14DBD68, 0x200
+sAbsolSprites62:
+ax_sprite sAbsolGfx62, 0x200
+ax_sprite_terminator
+sAbsolGfx63:
+.incbin "baserom.gba", 0x14DBF78, 0x200
+sAbsolSprites63:
+ax_sprite sAbsolGfx63, 0x200
+ax_sprite_terminator
+sAbsolGfx64:
+.incbin "baserom.gba", 0x14DC188, 0x200
+sAbsolSprites64:
+ax_sprite sAbsolGfx64, 0x200
+ax_sprite_terminator
+sAbsolGfx65:
+.incbin "baserom.gba", 0x14DC398, 0x200
+sAbsolSprites65:
+ax_sprite sAbsolGfx65, 0x200
+ax_sprite_terminator
+sAbsolGfx66:
+.incbin "baserom.gba", 0x14DC5A8, 0x100
+sAbsolSprites66:
+ax_sprite sAbsolGfx66, 0x100
+ax_sprite_terminator
+sAbsolGfx67:
+.incbin "baserom.gba", 0x14DC6B8, 0x40
+sAbsolSprites67:
+ax_sprite sAbsolGfx67, 0x40
+ax_sprite_terminator
+sAbsolGfx68:
+.incbin "baserom.gba", 0x14DC708, 0x80
+sAbsolSprites68:
+ax_sprite sAbsolGfx68, 0x80
+ax_sprite_terminator
+sAbsolGfx69:
+.incbin "baserom.gba", 0x14DC798, 0x200
+sAbsolSprites69:
+ax_sprite sAbsolGfx69, 0x200
+ax_sprite_terminator
+sAbsolGfx70:
+.incbin "baserom.gba", 0x14DC9A8, 0x200
+sAbsolSprites70:
+ax_sprite sAbsolGfx70, 0x200
+ax_sprite_terminator
+sAbsolGfx71:
+.incbin "baserom.gba", 0x14DCBB8, 0x200
+sAbsolSprites71:
+ax_sprite sAbsolGfx71, 0x200
+ax_sprite_terminator
+sAxPosesAbsol:
+.4byte sAbsolPose1
+.4byte sAbsolPose2
+.4byte sAbsolPose3
+.4byte sAbsolPose4
+.4byte sAbsolPose5
+.4byte sAbsolPose6
+.4byte sAbsolPose7
+.4byte sAbsolPose8
+.4byte sAbsolPose9
+.4byte sAbsolPose10
+.4byte sAbsolPose11
+.4byte sAbsolPose12
+.4byte sAbsolPose13
+.4byte sAbsolPose14
+.4byte sAbsolPose15
+.4byte sAbsolPose16
+.4byte sAbsolPose17
+.4byte sAbsolPose18
+.4byte sAbsolPose19
+.4byte sAbsolPose20
+.4byte sAbsolPose21
+.4byte sAbsolPose22
+.4byte sAbsolPose23
+.4byte sAbsolPose24
+.4byte sAbsolPose25
+.4byte sAbsolPose26
+.4byte sAbsolPose27
+.4byte sAbsolPose28
+.4byte sAbsolPose29
+.4byte sAbsolPose30
+.4byte sAbsolPose31
+.4byte sAbsolPose32
+.4byte sAbsolPose33
+.4byte sAbsolPose34
+.4byte sAbsolPose35
+.4byte sAbsolPose36
+.4byte sAbsolPose37
+.4byte sAbsolPose38
+.4byte sAbsolPose39
+.4byte sAbsolPose40
+.4byte sAbsolPose41
+.4byte sAbsolPose42
+.4byte sAbsolPose43
+.4byte sAbsolPose44
+.4byte sAbsolPose45
+.4byte sAbsolPose46
+.4byte sAbsolPose47
+.4byte sAbsolPose48
+.4byte sAbsolPose49
+.4byte sAbsolPose50
+.4byte sAbsolPose51
+.4byte sAbsolPose52
+.4byte sAbsolPose53
+.4byte sAbsolPose54
+.4byte sAbsolPose55
+.4byte sAbsolPose56
+.4byte sAbsolPose57
+.4byte sAbsolPose58
+.4byte sAbsolPose59
+.4byte sAbsolPose60
+.4byte sAbsolPose61
+.4byte sAbsolPose62
+.4byte sAbsolPose63
+.4byte sAbsolPose64
+.4byte sAbsolPose65
+.4byte sAbsolPose66
+.4byte sAbsolPose67
+.4byte sAbsolPose68
+.4byte sAbsolPose69
+.4byte sAbsolPose70
+.4byte sAbsolPose71
+.4byte sAbsolPose72
+.4byte sAbsolPose73
+.4byte sAbsolPose74
+.4byte sAbsolPose75
+.4byte sAbsolPose76
+.4byte sAbsolPose77
+.4byte sAbsolPose78
+.4byte sAbsolPose79
+.4byte sAbsolPose80
+.4byte sAbsolPose81
+.4byte sAbsolPose82
+.4byte sAbsolPose83
+.4byte sAbsolPose84
+.4byte sAbsolPose85
+.4byte sAbsolPose86
+.4byte sAbsolPose87
+.4byte sAbsolPose88
+.4byte sAbsolPose89
+.4byte sAbsolPose90
+.4byte sAbsolPose91
+.4byte sAbsolPose92
+.4byte sAbsolPose93
+.4byte sAbsolPose94
+.4byte sAbsolPose95
+.4byte sAbsolPose96
+.4byte sAbsolPose97
+.4byte sAbsolPose98
+.4byte sAbsolPose99
+.4byte sAbsolPose100
+.4byte sAbsolPose101
+.4byte sAbsolPose102
+.4byte sAbsolPose103
+.4byte sAbsolPose104
+.4byte sAbsolPose105
+.4byte sAbsolPose106
+.4byte sAbsolPose107
+.4byte sAbsolPose108
+.4byte sAbsolPose109
+.4byte sAbsolPose110
+.4byte sAbsolPose111
+.4byte sAbsolPose112
+.4byte sAbsolPose113
+.4byte sAbsolPose114
+.4byte sAbsolPose115
+.4byte sAbsolPose116
+.4byte sAbsolPose117
+.4byte sAbsolPose118
+.4byte sAbsolPose119
+.4byte sAbsolPose120
+.4byte sAbsolPose121
+.4byte sAbsolPose122
+.4byte sAbsolPose123
+.4byte sAbsolPose124
+.4byte sAbsolPose125
+.4byte sAbsolPose126
+.4byte sAbsolPose127
+.4byte sAbsolPose128
+.4byte sAbsolPose129
+.4byte sAbsolPose130
+.4byte sAbsolPose131
+.4byte sAbsolPose132
+.4byte sAbsolPose133
+.4byte sAbsolPose134
+.4byte sAbsolPose135
+.4byte sAbsolPose136
+.4byte sAbsolPose137
+.4byte sAbsolPose138
+.4byte sAbsolPose139
+.4byte sAbsolPose140
+.4byte sAbsolPose141
+.4byte sAbsolPose142
+.4byte sAbsolPose143
+.4byte sAbsolPose144
+.4byte sAbsolPose145
+.4byte sAbsolPose146
+.4byte sAbsolPose147
+.4byte sAbsolPose148
+.4byte sAbsolPose149
+.4byte sAbsolPose150
+.4byte sAbsolPose151
+.4byte sAbsolPose152
+.4byte sAbsolPose153
+.4byte sAbsolPose154
+.4byte sAbsolPose155
+.4byte sAbsolPose156
+.4byte sAbsolPose157
+.4byte sAbsolPose158
+.4byte sAbsolPose159
+.4byte sAbsolPose160
+.4byte sAbsolPose161
+.4byte sAbsolPose162
+.4byte sAbsolPose163
+.4byte sAbsolPose164
+.4byte sAbsolPose165
+.4byte sAbsolPose166
+.4byte sAbsolPose167
+.4byte sAbsolPose168
+.4byte sAbsolPose169
+.4byte sAbsolPose170
+.4byte sAbsolPose171
+.4byte sAbsolPose172
+.4byte sAbsolPose173
+.4byte sAbsolPose174
+.4byte sAbsolPose175
+.4byte sAbsolPose176
+.4byte sAbsolPose177
+.4byte sAbsolPose178
+.4byte sAbsolPose179
+.4byte sAbsolPose180
+.4byte sAbsolPose181
+.4byte sAbsolPose182
+.4byte sAbsolPose183
+.4byte sAbsolPose184
+.4byte sAbsolPose185
+.4byte sAbsolPose186
+.4byte sAbsolPose187
+.4byte sAbsolPose188
+.4byte sAbsolPose189
+.4byte sAbsolPose190
+.4byte sAbsolPose191
+.4byte sAbsolPose192
+.4byte sAbsolPose193
+.4byte sAbsolPose194
+.4byte sAbsolPose195
+.4byte sAbsolPose196
+.4byte sAbsolPose197
+.4byte sAbsolPose198
+.4byte sAbsolPose199
+.4byte sAbsolPose200
+.4byte sAbsolPose201
+.4byte sAbsolPose202
+.4byte sAbsolPose203
+.4byte sAbsolPose204
+.4byte sAbsolPose205
+.4byte sAbsolPose206
+.4byte sAbsolPose207
+.4byte sAbsolPose208
+.4byte sAbsolPose209
+.4byte sAbsolPose210
+.4byte sAbsolPose211
+.4byte sAbsolPose212
+.4byte sAbsolPose213
+.4byte sAbsolPose214
+.4byte sAbsolPose215
+.4byte sAbsolPose216
+.4byte sAbsolPose217
+.4byte sAbsolPose218
+.4byte sAbsolPose219
+.4byte sAbsolPose220
+.4byte sAbsolPose221
+.4byte sAbsolPose222
+.4byte sAbsolPose223
+.4byte sAbsolPose224
+.4byte sAbsolPose225
+.4byte sAbsolPose226
+.4byte sAbsolPose227
+.4byte sAbsolPose228
+.4byte sAbsolPose229
+.4byte sAbsolPose230
+.4byte sAbsolPose231
+.4byte sAbsolPose232
+.4byte sAbsolPose233
+.4byte sAbsolPose234
+.4byte sAbsolPose235
+.4byte sAbsolPose236
+.4byte sAbsolPose237
+.4byte sAbsolPose238
+.4byte sAbsolPose239
+.4byte sAbsolPose240
+.4byte sAbsolPose241
+.4byte sAbsolPose242
+.4byte sAbsolPose243
+.4byte sAbsolPose244
+.4byte sAbsolPose245
+.4byte sAbsolPose246
+.4byte sAbsolPose247
+.4byte sAbsolPose248
+.4byte sAbsolPose249
+.4byte sAbsolPose250
+.4byte sAbsolPose251
+sAxPositionsAbsol:
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte    0,   -7, 	  -4,    3, 	   3,    0, 	   0,   -5
+.2byte   -2,   -7, 	  -5,    0, 	   2,    3, 	  -1,   -5
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte    9,   -8, 	   3,    2, 	   3,   -2, 	  -1,   -8
+.2byte    8,   -8, 	  -2,    0, 	   9,    0, 	  -1,   -9
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte   13,  -11, 	   8,    0, 	   2,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,    0, 	   7,   -2, 	   1,   -7
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte    7,  -14, 	   6,   -5, 	   0,   -7, 	  -2,   -8
+.2byte    8,  -13, 	   2,   -2, 	   1,  -10, 	  -2,   -8
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -2,  -19, 	   2,  -10, 	  -4,   -7, 	  -1,   -9
+.2byte    0,  -19, 	   3,   -6, 	  -4,   -9, 	  -1,   -9
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte   -6,  -15, 	   1,   -6, 	  -7,   -5, 	   1,   -8
+.2byte   -7,  -14, 	  -2,   -8, 	  -3,   -1, 	   1,   -8
+.2byte  -11,  -12, 	  -5,   -3, 	  -4,    0, 	   0,   -9
+.2byte  -12,  -11, 	  -2,   -2, 	  -7,    0, 	   0,   -8
+.2byte  -11,  -10, 	  -7,   -1, 	  -1,    0, 	   0,   -8
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte  -10,   -8, 	  -4,   -3, 	  -4,    3, 	   0,   -9
+.2byte   -9,   -8, 	 -10,    0, 	   1,    0, 	   0,   -9
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte    0,   -7, 	  -4,    3, 	   3,    0, 	   0,   -5
+.2byte   -2,   -7, 	  -5,    0, 	   2,    3, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte    9,   -8, 	   3,    2, 	   3,   -2, 	  -1,   -8
+.2byte    8,   -8, 	  -2,    0, 	   9,    0, 	  -1,   -9
+.2byte   10,   -5, 	  -2,    0, 	   6,   -2, 	   0,  -11
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte   13,  -11, 	   8,    0, 	   2,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,    0, 	   7,   -2, 	   1,   -7
+.2byte   16,   -7, 	   4,    1, 	   5,   -4, 	   4,   -9
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte    7,  -14, 	   6,   -5, 	   0,   -7, 	  -2,   -8
+.2byte    8,  -13, 	   2,   -2, 	   1,  -10, 	  -2,   -8
+.2byte    9,  -13, 	   6,   -2, 	   1,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -2,  -19, 	   2,  -10, 	  -4,   -7, 	  -1,   -9
+.2byte    0,  -19, 	   3,   -6, 	  -4,   -9, 	  -1,   -9
+.2byte   -1,  -18, 	   3,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte   -6,  -15, 	   1,   -6, 	  -7,   -5, 	   1,   -8
+.2byte   -7,  -14, 	  -2,   -8, 	  -3,   -1, 	   1,   -8
+.2byte   -8,  -13, 	  -1,   -6, 	  -6,   -2, 	   0,   -9
+.2byte  -11,  -12, 	  -5,   -3, 	  -4,    0, 	   0,   -9
+.2byte  -12,  -11, 	  -2,   -2, 	  -7,    0, 	   0,   -8
+.2byte  -11,  -10, 	  -7,   -1, 	  -1,    0, 	   0,   -8
+.2byte  -15,   -7, 	  -4,   -2, 	  -3,    1, 	  -2,   -8
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte  -10,   -8, 	  -4,   -3, 	  -4,    3, 	   0,   -9
+.2byte   -9,   -8, 	 -10,    0, 	   1,    0, 	   0,   -9
+.2byte  -12,   -4, 	  -8,   -1, 	   0,    2, 	  -2,   -8
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte    0,   -7, 	  -4,    3, 	   3,    0, 	   0,   -5
+.2byte   -2,   -7, 	  -5,    0, 	   2,    3, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte    9,   -8, 	   3,    2, 	   3,   -2, 	  -1,   -8
+.2byte    8,   -8, 	  -2,    0, 	   9,    0, 	  -1,   -9
+.2byte   10,   -5, 	  -2,    0, 	   6,   -2, 	   0,  -11
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte   13,  -11, 	   8,    0, 	   2,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,    0, 	   7,   -2, 	   1,   -7
+.2byte   16,   -7, 	   4,    1, 	   5,   -4, 	   4,   -9
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte    7,  -14, 	   6,   -5, 	   0,   -7, 	  -2,   -8
+.2byte    8,  -13, 	   2,   -2, 	   1,  -10, 	  -2,   -8
+.2byte    9,  -13, 	   6,   -2, 	   1,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -2,  -19, 	   2,  -10, 	  -4,   -7, 	  -1,   -9
+.2byte    0,  -19, 	   3,   -6, 	  -4,   -9, 	  -1,   -9
+.2byte   -1,  -18, 	   3,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte   -6,  -15, 	   1,   -6, 	  -7,   -5, 	   1,   -8
+.2byte   -7,  -14, 	  -2,   -8, 	  -3,   -1, 	   1,   -8
+.2byte   -8,  -13, 	  -1,   -6, 	  -6,   -2, 	   0,   -9
+.2byte  -11,  -12, 	  -5,   -3, 	  -4,    0, 	   0,   -9
+.2byte  -12,  -11, 	  -2,   -2, 	  -7,    0, 	   0,   -8
+.2byte  -11,  -10, 	  -7,   -1, 	  -1,    0, 	   0,   -8
+.2byte  -15,   -7, 	  -4,   -2, 	  -3,    1, 	  -2,   -8
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte  -10,   -8, 	  -4,   -3, 	  -4,    3, 	   0,   -9
+.2byte   -9,   -8, 	 -10,    0, 	   1,    0, 	   0,   -9
+.2byte  -12,   -4, 	  -8,   -1, 	   0,    2, 	  -2,   -8
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte    6,  -13, 	   1,    0, 	   7,   -2, 	  -2,  -11
+.2byte   10,   -5, 	  -2,    0, 	   6,   -2, 	   0,  -11
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte    7,  -17, 	   5,   -1, 	   5,   -3, 	  -2,   -8
+.2byte   16,   -7, 	   4,    1, 	   5,   -4, 	   4,   -9
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte    5,  -16, 	   5,   -4, 	  -2,   -7, 	  -3,   -9
+.2byte   10,  -14, 	   7,   -3, 	   2,   -8, 	   0,  -10
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -1,  -20, 	   2,   -4, 	  -4,   -4, 	  -1,  -10
+.2byte   -1,  -18, 	   3,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte   -1,  -19, 	   2,   -6, 	  -5,   -4, 	   3,  -10
+.2byte   -8,  -14, 	  -1,   -7, 	  -6,   -3, 	   0,  -10
+.2byte  -11,  -12, 	  -5,   -3, 	  -4,    0, 	   0,   -9
+.2byte   -6,  -17, 	  -4,   -2, 	  -5,    0, 	   3,   -9
+.2byte  -15,   -7, 	  -4,   -2, 	  -3,    1, 	  -2,   -8
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte   -6,  -13, 	  -8,   -1, 	  -1,    1, 	   2,  -10
+.2byte  -12,   -4, 	  -8,   -1, 	   0,    2, 	  -2,   -8
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte    8,  -15, 	   0,   -1, 	   8,   -2, 	   0,   -9
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte    6,  -13, 	   1,    0, 	   7,   -2, 	  -2,  -11
+.2byte   10,   -5, 	  -2,    0, 	   6,   -2, 	   0,  -11
+.2byte    0,  -23, 	   6,  -11, 	   0,  -15, 	  -2,  -12
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte    7,  -17, 	   5,   -1, 	   5,   -3, 	  -2,   -8
+.2byte   16,   -7, 	   4,    1, 	   5,   -4, 	   4,   -9
+.2byte   -2,  -21, 	  -1,  -14, 	  -7,  -14, 	  -3,  -12
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte    5,  -16, 	   5,   -4, 	  -2,   -7, 	  -3,   -9
+.2byte   10,  -14, 	   7,   -3, 	   2,   -8, 	   0,  -10
+.2byte   -8,  -14, 	  -3,  -12, 	  -9,  -10, 	  -3,   -9
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -1,  -20, 	   2,   -4, 	  -4,   -4, 	  -1,  -10
+.2byte   -1,  -18, 	   3,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte   -8,  -14, 	  -7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte   -1,  -19, 	   2,   -6, 	  -5,   -4, 	   3,  -10
+.2byte   -8,  -14, 	  -1,   -7, 	  -6,   -3, 	   0,  -10
+.2byte   -1,  -15, 	  -7,  -10, 	  -3,   -6, 	   2,  -10
+.2byte  -11,  -12, 	  -5,   -3, 	  -4,    0, 	   0,   -9
+.2byte   -6,  -17, 	  -4,   -2, 	  -5,    0, 	   3,   -9
+.2byte  -15,   -7, 	  -4,   -2, 	  -3,    1, 	  -2,   -8
+.2byte    2,  -15, 	  -7,   -8, 	  -1,   -5, 	   3,  -10
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte   -6,  -13, 	  -8,   -1, 	  -1,    1, 	   2,  -10
+.2byte  -12,   -4, 	  -8,   -1, 	   0,    2, 	  -2,   -8
+.2byte    6,  -14, 	  -2,   -4, 	   6,   -3, 	   1,  -11
+.2byte   -8,   -5, 	  -8,   -2, 	  -6,    0, 	   2,   -6
+.2byte   -8,   -5, 	  -8,   -2, 	  -6,    0, 	   2,   -7
+.2byte    2,   -7, 	  -6,   -1, 	   6,   -1, 	   0,   -8
+.2byte    7,   -8, 	   1,    0, 	   9,   -1, 	  -1,   -8
+.2byte    6,  -11, 	   7,    0, 	   2,   -3, 	  -1,   -8
+.2byte    2,  -11, 	   6,   -2, 	  -1,   -4, 	  -1,   -7
+.2byte   -2,  -13, 	   0,   -7, 	  -4,   -6, 	   0,   -8
+.2byte   -7,   -9, 	  -2,   -5, 	  -6,   -2, 	   2,   -7
+.2byte   -5,   -6, 	  -6,   -2, 	  -4,    0, 	   2,   -6
+.2byte   -2,   -7, 	 -10,   -2, 	   0,    0, 	   2,   -8
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte    0,   -7, 	  -4,    3, 	   3,    0, 	   0,   -5
+.2byte   -2,   -7, 	  -5,    0, 	   2,    3, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte    9,   -8, 	   3,    2, 	   3,   -2, 	  -1,   -8
+.2byte    8,   -8, 	  -2,    0, 	   9,    0, 	  -1,   -9
+.2byte   10,   -5, 	  -2,    0, 	   6,   -2, 	   0,  -11
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte   13,  -11, 	   8,    0, 	   2,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,    0, 	   7,   -2, 	   1,   -7
+.2byte   16,   -7, 	   4,    1, 	   5,   -4, 	   4,   -9
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte    7,  -14, 	   6,   -5, 	   0,   -7, 	  -2,   -8
+.2byte    8,  -13, 	   2,   -2, 	   1,  -10, 	  -2,   -8
+.2byte    9,  -13, 	   6,   -2, 	   1,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -2,  -19, 	   2,  -10, 	  -4,   -7, 	  -1,   -9
+.2byte    0,  -19, 	   3,   -6, 	  -4,   -9, 	  -1,   -9
+.2byte   -1,  -18, 	   3,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte   -6,  -15, 	   1,   -6, 	  -7,   -5, 	   1,   -8
+.2byte   -7,  -14, 	  -2,   -8, 	  -3,   -1, 	   1,   -8
+.2byte   -8,  -13, 	  -1,   -6, 	  -6,   -2, 	   0,   -9
+.2byte  -11,  -12, 	  -5,   -3, 	  -4,    0, 	   0,   -9
+.2byte  -12,  -11, 	  -2,   -2, 	  -7,    0, 	   0,   -8
+.2byte  -11,  -10, 	  -7,   -1, 	  -1,    0, 	   0,   -8
+.2byte  -15,   -7, 	  -4,   -2, 	  -3,    1, 	  -2,   -8
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte  -10,   -8, 	  -4,   -3, 	  -4,    3, 	   0,   -9
+.2byte   -9,   -8, 	 -10,    0, 	   1,    0, 	   0,   -9
+.2byte  -12,   -4, 	  -8,   -1, 	   0,    2, 	  -2,   -8
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte  -11,   -4, 	  -7,   -1, 	   1,    2, 	  -1,   -8
+.2byte  -13,   -8, 	  -2,   -3, 	  -1,    0, 	   0,   -9
+.2byte   -7,  -13, 	   0,   -6, 	  -5,   -2, 	   1,   -9
+.2byte   -1,  -17, 	   3,   -6, 	  -5,   -6, 	  -1,  -10
+.2byte    9,  -13, 	   6,   -2, 	   1,   -7, 	  -1,   -9
+.2byte   12,   -8, 	   0,    0, 	   1,   -5, 	   0,  -10
+.2byte   10,   -5, 	  -2,    0, 	   6,   -2, 	   0,  -11
+.2byte   -1,  -10, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte    5,  -12, 	   0,    1, 	   6,   -1, 	  -3,  -10
+.2byte    7,  -17, 	   5,   -1, 	   5,   -3, 	  -2,   -8
+.2byte    5,  -15, 	   5,   -3, 	  -2,   -6, 	  -3,   -8
+.2byte   -1,  -18, 	   2,   -2, 	  -4,   -2, 	  -1,   -8
+.2byte   -2,  -18, 	   1,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -8,  -17, 	  -6,   -2, 	  -7,    0, 	   1,   -9
+.2byte   -6,  -12, 	  -8,    0, 	  -1,    2, 	   2,   -9
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte    7,  -14, 	   2,   -1, 	   8,   -3, 	  -1,  -12
+.2byte   12,   -4, 	   0,    1, 	   8,   -1, 	   2,  -10
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte    7,  -17, 	   5,   -1, 	   5,   -3, 	  -2,   -8
+.2byte   15,   -7, 	   3,    1, 	   4,   -4, 	   3,   -9
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte    5,  -15, 	   5,   -3, 	  -2,   -6, 	  -3,   -8
+.2byte    9,  -13, 	   6,   -2, 	   1,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -1,  -20, 	   2,   -4, 	  -4,   -4, 	  -1,  -10
+.2byte   -1,  -18, 	   3,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte    0,  -18, 	   3,   -5, 	  -4,   -3, 	   4,   -9
+.2byte   -7,  -13, 	   0,   -6, 	  -5,   -2, 	   1,   -9
+.2byte  -13,  -12, 	  -7,   -3, 	  -6,    0, 	  -2,   -9
+.2byte   -8,  -17, 	  -6,   -2, 	  -7,    0, 	   1,   -9
+.2byte  -16,   -7, 	  -5,   -2, 	  -4,    1, 	  -3,   -8
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte   -7,  -14, 	  -9,   -2, 	  -2,    0, 	   1,  -11
+.2byte  -13,   -3, 	  -9,    0, 	  -1,    3, 	  -3,   -7
+.2byte   -1,   -4, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte  -11,   -4, 	  -7,   -1, 	   1,    2, 	  -1,   -8
+.2byte  -13,   -8, 	  -2,   -3, 	  -1,    0, 	   0,   -9
+.2byte   -7,  -13, 	   0,   -6, 	  -5,   -2, 	   1,   -9
+.2byte   -1,  -17, 	   3,   -6, 	  -5,   -6, 	  -1,  -10
+.2byte    9,  -13, 	   6,   -2, 	   1,   -7, 	  -1,   -9
+.2byte   12,   -8, 	   0,    0, 	   1,   -5, 	   0,  -10
+.2byte   10,   -5, 	  -2,    0, 	   6,   -2, 	   0,  -11
+.2byte   -1,   -8, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte   -9,  -10, 	  -8,   -1, 	  -1,    0, 	   1,  -10
+.2byte  -11,  -12, 	  -5,   -3, 	  -4,    0, 	   0,   -9
+.2byte   -7,  -17, 	  -1,   -7, 	  -5,   -4, 	   1,   -9
+.2byte   -1,  -19, 	   2,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte    8,  -15, 	   5,   -4, 	   1,   -7, 	   0,   -9
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte    9,  -10, 	   1,    0, 	   8,   -1, 	   1,  -10
+.2byte   13,  -13, 	  13,   -7, 	  14,  -10, 	   0,  -10
+.2byte   13,   -8, 	   0,    0, 	   1,   -2, 	  -1,   -6
+.2byte   13,  -13, 	  13,   -7, 	  14,  -10, 	   0,  -10
+.2byte   13,   -8, 	   0,    0, 	   1,   -2, 	  -1,   -6
+.2byte   13,  -13, 	  13,   -7, 	  14,  -10, 	   0,  -10
+.2byte   13,   -8, 	   0,    0, 	   1,   -2, 	  -1,   -6
+.2byte   12,  -12, 	   5,    0, 	   6,   -3, 	   0,   -9
+.2byte   10,  -11, 	   6,   -3, 	  10,   -3, 	   0,   -8
+.2byte   12,   -7, 	   0,    1, 	   0,   -2, 	   0,   -8
+sAbsolAnimTable1:
+.4byte sAbsolAnims_1_1
+.4byte sAbsolAnims_1_2
+.4byte sAbsolAnims_1_3
+.4byte sAbsolAnims_1_4
+.4byte sAbsolAnims_1_5
+.4byte sAbsolAnims_1_6
+.4byte sAbsolAnims_1_7
+.4byte sAbsolAnims_1_8
+sAbsolAnimTable2:
+.4byte sAbsolAnims_2_1
+.4byte sAbsolAnims_2_2
+.4byte sAbsolAnims_2_3
+.4byte sAbsolAnims_2_4
+.4byte sAbsolAnims_2_5
+.4byte sAbsolAnims_2_6
+.4byte sAbsolAnims_2_7
+.4byte sAbsolAnims_2_8
+sAbsolAnimTable3:
+.4byte sAbsolAnims_3_1
+.4byte sAbsolAnims_3_2
+.4byte sAbsolAnims_3_3
+.4byte sAbsolAnims_3_4
+.4byte sAbsolAnims_3_5
+.4byte sAbsolAnims_3_6
+.4byte sAbsolAnims_3_7
+.4byte sAbsolAnims_3_8
+sAbsolAnimTable4:
+.4byte sAbsolAnims_4_1
+.4byte sAbsolAnims_4_2
+.4byte sAbsolAnims_4_3
+.4byte sAbsolAnims_4_4
+.4byte sAbsolAnims_4_5
+.4byte sAbsolAnims_4_6
+.4byte sAbsolAnims_4_7
+.4byte sAbsolAnims_4_8
+sAbsolAnimTable5:
+.4byte sAbsolAnims_5_1
+.4byte sAbsolAnims_5_2
+.4byte sAbsolAnims_5_3
+.4byte sAbsolAnims_5_4
+.4byte sAbsolAnims_5_5
+.4byte sAbsolAnims_5_6
+.4byte sAbsolAnims_5_7
+.4byte sAbsolAnims_5_8
+sAbsolAnimTable6:
+.4byte sAbsolAnims_6_1
+.4byte sAbsolAnims_6_1
+.4byte sAbsolAnims_6_1
+.4byte sAbsolAnims_6_1
+.4byte sAbsolAnims_6_1
+.4byte sAbsolAnims_6_1
+.4byte sAbsolAnims_6_1
+.4byte sAbsolAnims_6_1
+sAbsolAnimTable7:
+.4byte sAbsolAnims_7_1
+.4byte sAbsolAnims_7_2
+.4byte sAbsolAnims_7_3
+.4byte sAbsolAnims_7_4
+.4byte sAbsolAnims_7_5
+.4byte sAbsolAnims_7_6
+.4byte sAbsolAnims_7_7
+.4byte sAbsolAnims_7_8
+sAbsolAnimTable8:
+.4byte sAbsolAnims_8_1
+.4byte sAbsolAnims_8_2
+.4byte sAbsolAnims_8_3
+.4byte sAbsolAnims_8_4
+.4byte sAbsolAnims_8_5
+.4byte sAbsolAnims_8_6
+.4byte sAbsolAnims_8_7
+.4byte sAbsolAnims_8_8
+sAbsolAnimTable9:
+.4byte sAbsolAnims_9_1
+.4byte sAbsolAnims_9_2
+.4byte sAbsolAnims_9_3
+.4byte sAbsolAnims_9_4
+.4byte sAbsolAnims_9_5
+.4byte sAbsolAnims_9_6
+.4byte sAbsolAnims_9_7
+.4byte sAbsolAnims_9_8
+sAbsolAnimTable10:
+.4byte sAbsolAnims_10_1
+.4byte sAbsolAnims_10_2
+.4byte sAbsolAnims_10_3
+.4byte sAbsolAnims_10_4
+.4byte sAbsolAnims_10_5
+.4byte sAbsolAnims_10_6
+.4byte sAbsolAnims_10_7
+.4byte sAbsolAnims_10_8
+sAbsolAnimTable11:
+.4byte sAbsolAnims_11_1
+.4byte sAbsolAnims_11_2
+.4byte sAbsolAnims_11_3
+.4byte sAbsolAnims_11_4
+.4byte sAbsolAnims_11_5
+.4byte sAbsolAnims_11_6
+.4byte sAbsolAnims_11_7
+.4byte sAbsolAnims_11_8
+sAbsolAnimTable12:
+.4byte sAbsolAnims_12_1
+.4byte sAbsolAnims_12_2
+.4byte sAbsolAnims_12_3
+.4byte sAbsolAnims_12_4
+.4byte sAbsolAnims_12_5
+.4byte sAbsolAnims_12_6
+.4byte sAbsolAnims_12_7
+.4byte sAbsolAnims_12_8
+sAbsolAnimTable13:
+.4byte sAbsolAnims_13_1
+.4byte sAbsolAnims_13_2
+.4byte sAbsolAnims_13_3
+.4byte sAbsolAnims_13_4
+.4byte sAbsolAnims_13_5
+.4byte sAbsolAnims_13_6
+.4byte sAbsolAnims_13_7
+.4byte sAbsolAnims_13_8
+sAbsolAnimTable14:
+.4byte sAbsolAnims_14_1
+.4byte sAbsolAnims_14_2
+.4byte sAbsolAnims_14_3
+.4byte sAbsolAnims_14_4
+.4byte sAbsolAnims_14_5
+.4byte sAbsolAnims_14_6
+.4byte sAbsolAnims_14_7
+.4byte sAbsolAnims_14_8
+sAbsolAnimTable15:
+.4byte sAbsolAnims_15_1
+.4byte sAbsolAnims_15_2
+.4byte sAbsolAnims_15_3
+.4byte sAbsolAnims_15_4
+.4byte sAbsolAnims_15_5
+.4byte sAbsolAnims_15_6
+.4byte sAbsolAnims_15_7
+.4byte sAbsolAnims_15_8
+sAbsolAnimTable16:
+.4byte sAbsolAnims_16_1
+.4byte sAbsolAnims_16_1
+.4byte sAbsolAnims_16_1
+.4byte sAbsolAnims_16_1
+.4byte sAbsolAnims_16_1
+.4byte sAbsolAnims_16_1
+.4byte sAbsolAnims_16_1
+.4byte sAbsolAnims_16_1
+sAxAnimationsAbsol:
+.4byte sAbsolAnimTable1
+.4byte sAbsolAnimTable2
+.4byte sAbsolAnimTable3
+.4byte sAbsolAnimTable4
+.4byte sAbsolAnimTable5
+.4byte sAbsolAnimTable6
+.4byte sAbsolAnimTable7
+.4byte sAbsolAnimTable8
+.4byte sAbsolAnimTable9
+.4byte sAbsolAnimTable10
+.4byte sAbsolAnimTable11
+.4byte sAbsolAnimTable12
+.4byte sAbsolAnimTable13
+.4byte sAbsolAnimTable14
+.4byte sAbsolAnimTable15
+.4byte sAbsolAnimTable16
+sAxSpritesAbsol:
+.4byte sAbsolSprites1
+.4byte sAbsolSprites2
+.4byte sAbsolSprites3
+.4byte sAbsolSprites4
+.4byte sAbsolSprites5
+.4byte sAbsolSprites6
+.4byte sAbsolSprites7
+.4byte sAbsolSprites8
+.4byte sAbsolSprites9
+.4byte sAbsolSprites10
+.4byte sAbsolSprites11
+.4byte sAbsolSprites12
+.4byte sAbsolSprites13
+.4byte sAbsolSprites14
+.4byte sAbsolSprites15
+.4byte sAbsolSprites16
+.4byte sAbsolSprites17
+.4byte sAbsolSprites18
+.4byte sAbsolSprites19
+.4byte sAbsolSprites20
+.4byte sAbsolSprites21
+.4byte sAbsolSprites22
+.4byte sAbsolSprites23
+.4byte sAbsolSprites24
+.4byte sAbsolSprites25
+.4byte sAbsolSprites26
+.4byte sAbsolSprites27
+.4byte sAbsolSprites28
+.4byte sAbsolSprites29
+.4byte sAbsolSprites30
+.4byte sAbsolSprites31
+.4byte sAbsolSprites32
+.4byte sAbsolSprites33
+.4byte sAbsolSprites34
+.4byte sAbsolSprites35
+.4byte sAbsolSprites36
+.4byte sAbsolSprites37
+.4byte sAbsolSprites38
+.4byte sAbsolSprites39
+.4byte sAbsolSprites40
+.4byte sAbsolSprites41
+.4byte sAbsolSprites42
+.4byte sAbsolSprites43
+.4byte sAbsolSprites44
+.4byte sAbsolSprites45
+.4byte sAbsolSprites46
+.4byte sAbsolSprites47
+.4byte sAbsolSprites48
+.4byte sAbsolSprites49
+.4byte sAbsolSprites50
+.4byte sAbsolSprites51
+.4byte sAbsolSprites52
+.4byte sAbsolSprites53
+.4byte sAbsolSprites54
+.4byte sAbsolSprites55
+.4byte sAbsolSprites56
+.4byte sAbsolSprites57
+.4byte sAbsolSprites58
+.4byte sAbsolSprites59
+.4byte sAbsolSprites60
+.4byte sAbsolSprites61
+.4byte sAbsolSprites62
+.4byte sAbsolSprites63
+.4byte sAbsolSprites64
+.4byte sAbsolSprites65
+.4byte sAbsolSprites66
+.4byte sAbsolSprites67
+.4byte sAbsolSprites68
+.4byte sAbsolSprites69
+.4byte sAbsolSprites70
+.4byte sAbsolSprites71
+sAxMainAbsol:
+ax_main sAxPosesAbsol, sAxAnimationsAbsol, 16, sAxSpritesAbsol, sAxPositionsAbsol

--- a/data/ax/aerodactyl.inc
+++ b/data/ax/aerodactyl.inc
@@ -1,0 +1,3077 @@
+.global gAxAerodactyl
+gAxAerodactyl:
+ax_siro sAxMainAerodactyl
+sAerodactylPose1:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose2:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose3:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose4:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose5:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose6:
+ax_pose 5, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose7:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose8:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose9:
+ax_pose 8, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose10:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose11:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose12:
+ax_pose 11, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose13:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose14:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose15:
+ax_pose 14, 0x81e2, 0x80f0, 0x2c00
+ax_pose 15, 0x81e2, 0x4100, 0x2c08
+ax_pose 16, 0x01ea, 0x0108, 0x2c0c
+ax_pose 17, 0x81f2, 0x0108, 0x2c0d
+ax_pose 18, 0x0202, 0x00fc, 0x2c0f
+ax_pose_terminator
+sAerodactylPose16:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose17:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose18:
+ax_pose 11, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose19:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose20:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose21:
+ax_pose 8, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose22:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose23:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose24:
+ax_pose 5, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose25:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose26:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose27:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose28:
+ax_pose 19, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose29:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose30:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose31:
+ax_pose 5, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose32:
+ax_pose 20, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose33:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose34:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose35:
+ax_pose 8, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose36:
+ax_pose 21, 0x01ec, 0x1110, 0x2c00
+ax_pose 22, 0x81e3, 0x90f0, 0x2c01
+ax_pose 23, 0x81e3, 0x5100, 0x2c09
+ax_pose 24, 0x81eb, 0x1108, 0x2c0d
+ax_pose 25, 0x01fb, 0x1108, 0x2c0f
+ax_pose_terminator
+sAerodactylPose37:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose38:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose39:
+ax_pose 11, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose40:
+ax_pose 26, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose41:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose42:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose43:
+ax_pose 14, 0x81e2, 0x80f0, 0x2c00
+ax_pose 15, 0x81e2, 0x4100, 0x2c08
+ax_pose 16, 0x01ea, 0x0108, 0x2c0c
+ax_pose 17, 0x81f2, 0x0108, 0x2c0d
+ax_pose 18, 0x0202, 0x00fc, 0x2c0f
+ax_pose_terminator
+sAerodactylPose44:
+ax_pose 27, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose45:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose46:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose47:
+ax_pose 11, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose48:
+ax_pose 26, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose49:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose50:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose51:
+ax_pose 8, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose52:
+ax_pose 21, 0x01ec, 0x00e8, 0x2c00
+ax_pose 22, 0x81e3, 0x8100, 0x2c01
+ax_pose 23, 0x81e3, 0x40f8, 0x2c09
+ax_pose 24, 0x81eb, 0x00f0, 0x2c0d
+ax_pose 25, 0x01fb, 0x00f0, 0x2c0f
+ax_pose_terminator
+sAerodactylPose53:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose54:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose55:
+ax_pose 5, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose56:
+ax_pose 20, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose57:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose58:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose59:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose60:
+ax_pose 19, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose61:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose62:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose63:
+ax_pose 5, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose64:
+ax_pose 20, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose65:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose66:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose67:
+ax_pose 8, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose68:
+ax_pose 21, 0x01ec, 0x1110, 0x2c00
+ax_pose 22, 0x81e3, 0x90f0, 0x2c01
+ax_pose 23, 0x81e3, 0x5100, 0x2c09
+ax_pose 24, 0x81eb, 0x1108, 0x2c0d
+ax_pose 25, 0x01fb, 0x1108, 0x2c0f
+ax_pose_terminator
+sAerodactylPose69:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose70:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose71:
+ax_pose 11, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose72:
+ax_pose 26, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose73:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose74:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose75:
+ax_pose 14, 0x81e2, 0x80f0, 0x2c00
+ax_pose 15, 0x81e2, 0x4100, 0x2c08
+ax_pose 16, 0x01ea, 0x0108, 0x2c0c
+ax_pose 17, 0x81f2, 0x0108, 0x2c0d
+ax_pose 18, 0x0202, 0x00fc, 0x2c0f
+ax_pose_terminator
+sAerodactylPose76:
+ax_pose 27, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose77:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose78:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose79:
+ax_pose 11, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose80:
+ax_pose 26, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose81:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose82:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose83:
+ax_pose 8, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose84:
+ax_pose 21, 0x01ec, 0x00e8, 0x2c00
+ax_pose 22, 0x81e3, 0x8100, 0x2c01
+ax_pose 23, 0x81e3, 0x40f8, 0x2c09
+ax_pose 24, 0x81eb, 0x00f0, 0x2c0d
+ax_pose 25, 0x01fb, 0x00f0, 0x2c0f
+ax_pose_terminator
+sAerodactylPose85:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose86:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose87:
+ax_pose 5, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose88:
+ax_pose 20, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose89:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose90:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose91:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose92:
+ax_pose 28, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose93:
+ax_pose 29, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose94:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose95:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose96:
+ax_pose 5, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose97:
+ax_pose 30, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose98:
+ax_pose 31, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose99:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose100:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose101:
+ax_pose 8, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose102:
+ax_pose 32, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose103:
+ax_pose 33, 0x81e0, 0x9100, 0x2c00
+ax_pose 34, 0x01f0, 0x50f0, 0x2c08
+ax_pose 35, 0x41e8, 0x10f0, 0x2c0c
+ax_pose 36, 0x01e0, 0x10f8, 0x2c0e
+ax_pose 37, 0x01ef, 0x1110, 0x2c0f
+ax_pose_terminator
+sAerodactylPose104:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose105:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose106:
+ax_pose 11, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose107:
+ax_pose 38, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose108:
+ax_pose 39, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose109:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose110:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose111:
+ax_pose 27, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose112:
+ax_pose 40, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose113:
+ax_pose 41, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose114:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose115:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose116:
+ax_pose 11, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose117:
+ax_pose 38, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose118:
+ax_pose 39, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose119:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose120:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose121:
+ax_pose 8, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose122:
+ax_pose 32, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose123:
+ax_pose 33, 0x81e0, 0x80f0, 0x2c00
+ax_pose 34, 0x01f0, 0x4100, 0x2c08
+ax_pose 35, 0x41e8, 0x0100, 0x2c0c
+ax_pose 36, 0x01e0, 0x0100, 0x2c0e
+ax_pose 37, 0x01ef, 0x00e8, 0x2c0f
+ax_pose_terminator
+sAerodactylPose124:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose125:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose126:
+ax_pose 5, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose127:
+ax_pose 30, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose128:
+ax_pose 31, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose129:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose130:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose131:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose132:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose133:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose134:
+ax_pose 5, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose135:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose136:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose137:
+ax_pose 8, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose138:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose139:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose140:
+ax_pose 11, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose141:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose142:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose143:
+ax_pose 14, 0x81e2, 0x80f0, 0x2c00
+ax_pose 15, 0x81e2, 0x4100, 0x2c08
+ax_pose 16, 0x01ea, 0x0108, 0x2c0c
+ax_pose 17, 0x81f2, 0x0108, 0x2c0d
+ax_pose 18, 0x0202, 0x00fc, 0x2c0f
+ax_pose_terminator
+sAerodactylPose144:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose145:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose146:
+ax_pose 11, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose147:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose148:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose149:
+ax_pose 8, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose150:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose151:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose152:
+ax_pose 5, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose153:
+ax_pose 42, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose154:
+ax_pose 43, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose155:
+ax_pose 44, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose156:
+ax_pose 45, 0x01df, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose157:
+ax_pose 46, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose158:
+ax_pose 47, 0x01df, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose159:
+ax_pose 48, 0x01e0, 0x80f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose160:
+ax_pose 47, 0x01df, 0x80f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose161:
+ax_pose 46, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose162:
+ax_pose 45, 0x01df, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose163:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose164:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose165:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose166:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose167:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose168:
+ax_pose 5, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose169:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose170:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose171:
+ax_pose 8, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose172:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose173:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose174:
+ax_pose 11, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose175:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose176:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose177:
+ax_pose 14, 0x81e2, 0x80f0, 0x2c00
+ax_pose 15, 0x81e2, 0x4100, 0x2c08
+ax_pose 16, 0x01ea, 0x0108, 0x2c0c
+ax_pose 17, 0x81f2, 0x0108, 0x2c0d
+ax_pose 18, 0x0202, 0x00fc, 0x2c0f
+ax_pose_terminator
+sAerodactylPose178:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose179:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose180:
+ax_pose 11, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose181:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose182:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose183:
+ax_pose 8, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose184:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose185:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose186:
+ax_pose 5, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose187:
+ax_pose 19, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose188:
+ax_pose 20, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose189:
+ax_pose 21, 0x01ea, 0x00e9, 0x2c00
+ax_pose 22, 0x81e1, 0x8101, 0x2c01
+ax_pose 23, 0x81e1, 0x40f9, 0x2c09
+ax_pose 24, 0x81e9, 0x00f1, 0x2c0d
+ax_pose 25, 0x01f9, 0x00f1, 0x2c0f
+ax_pose_terminator
+sAerodactylPose190:
+ax_pose 26, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose191:
+ax_pose 27, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose192:
+ax_pose 26, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose193:
+ax_pose 21, 0x01ea, 0x110f, 0x2c00
+ax_pose 22, 0x81e1, 0x90ef, 0x2c01
+ax_pose 23, 0x81e1, 0x50ff, 0x2c09
+ax_pose 24, 0x81e9, 0x1107, 0x2c0d
+ax_pose 25, 0x01f9, 0x1107, 0x2c0f
+ax_pose_terminator
+sAerodactylPose194:
+ax_pose 20, 0x01e1, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose195:
+ax_pose 29, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose196:
+ax_pose 31, 0x01df, 0x90ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose197:
+ax_pose 33, 0x81e0, 0x90ff, 0x2c00
+ax_pose 34, 0x01f0, 0x50ef, 0x2c08
+ax_pose 35, 0x41e8, 0x10ef, 0x2c0c
+ax_pose 36, 0x01e0, 0x10f7, 0x2c0e
+ax_pose 37, 0x01ef, 0x110f, 0x2c0f
+ax_pose_terminator
+sAerodactylPose198:
+ax_pose 39, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose199:
+ax_pose 41, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose200:
+ax_pose 39, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose201:
+ax_pose 33, 0x81e0, 0x80f2, 0x2c00
+ax_pose 34, 0x01f0, 0x4102, 0x2c08
+ax_pose 35, 0x41e8, 0x0102, 0x2c0c
+ax_pose 36, 0x01e0, 0x0102, 0x2c0e
+ax_pose 37, 0x01ef, 0x00ea, 0x2c0f
+ax_pose_terminator
+sAerodactylPose202:
+ax_pose 31, 0x01df, 0x80f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose203:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose204:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose205:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose206:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose207:
+ax_pose 5, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose208:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose209:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose210:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose211:
+ax_pose 8, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose212:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose213:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose214:
+ax_pose 11, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose215:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose216:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose217:
+ax_pose 14, 0x81e2, 0x80f0, 0x2c00
+ax_pose 15, 0x81e2, 0x4100, 0x2c08
+ax_pose 16, 0x01ea, 0x0108, 0x2c0c
+ax_pose 17, 0x81f2, 0x0108, 0x2c0d
+ax_pose 18, 0x0202, 0x00fc, 0x2c0f
+ax_pose_terminator
+sAerodactylPose218:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose219:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose220:
+ax_pose 11, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose221:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose222:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose223:
+ax_pose 8, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose224:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose225:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose226:
+ax_pose 5, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose227:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose228:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose229:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose230:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose231:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose232:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose233:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose234:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose235:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose236:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose237:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose238:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose239:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose240:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose241:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose242:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose243:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose244:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose245:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose246:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose247:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose248:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose249:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose250:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose251:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose252:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose253:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose254:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose255:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose256:
+ax_pose 4, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose257:
+ax_pose 7, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose258:
+ax_pose 10, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose259:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose260:
+ax_pose 10, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose261:
+ax_pose 7, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose262:
+ax_pose 4, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose263:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose264:
+ax_pose 3, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose265:
+ax_pose 6, 0x01e0, 0x80ef, 0x2c00
+ax_pose_terminator
+sAerodactylPose266:
+ax_pose 9, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose267:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose268:
+ax_pose 9, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sAerodactylPose269:
+ax_pose 6, 0x01e0, 0x90f1, 0x2c00
+ax_pose_terminator
+sAerodactylPose270:
+ax_pose 3, 0x01df, 0x90f0, 0x2c00
+ax_pose_terminator
+.align 2
+sAerodactylAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_2_1:
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 6, 0, 24, 0, -5, 0, -5,
+ax_anim 1, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 2, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 1, 27, -1, 23, -1, 23,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 0, 27, -1, 23, -1, 23,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 0, 27, -1, 23, -1, 23,
+ax_anim 2, 0, 24, 0, 11, 0, 11,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sAerodactylAnims_2_2:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 6, 0, 28, -5, -5, -5, -5,
+ax_anim 1, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 2, 31, 9, 11, 9, 11,
+ax_anim 2, 0, 31, 18, 23, 18, 23,
+ax_anim 2, 1, 31, 17, 24, 17, 24,
+ax_anim 2, 0, 31, 18, 23, 18, 23,
+ax_anim 2, 0, 31, 17, 24, 17, 24,
+ax_anim 2, 0, 31, 18, 23, 18, 23,
+ax_anim 2, 0, 31, 17, 24, 17, 24,
+ax_anim 2, 0, 28, 10, 12, 10, 12,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sAerodactylAnims_2_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 6, 0, 32, -5, 0, -5, 0,
+ax_anim 1, 0, 33, -2, 0, -2, 0,
+ax_anim 2, 2, 35, 7, 1, 7, 0,
+ax_anim 2, 0, 35, 12, 3, 12, 0,
+ax_anim 2, 1, 35, 12, 4, 12, 1,
+ax_anim 2, 0, 35, 12, 3, 12, 0,
+ax_anim 2, 0, 35, 12, 4, 12, 1,
+ax_anim 2, 0, 35, 12, 3, 12, 0,
+ax_anim 2, 0, 35, 12, 4, 12, 1,
+ax_anim 2, 0, 32, 8, 2, 8, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sAerodactylAnims_2_4:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, -2, 2, -2, 2,
+ax_anim 6, 0, 36, -5, 5, -5, 5,
+ax_anim 1, 0, 37, -2, 2, -2, 2,
+ax_anim 2, 2, 39, 9, -7, 9, -7,
+ax_anim 2, 0, 39, 15, -10, 15, -10,
+ax_anim 2, 1, 39, 14, -11, 14, -11,
+ax_anim 2, 0, 39, 15, -10, 15, -10,
+ax_anim 2, 0, 39, 14, -11, 14, -11,
+ax_anim 2, 0, 39, 15, -10, 15, -10,
+ax_anim 2, 0, 39, 14, -11, 14, -11,
+ax_anim 2, 0, 36, 11, -9, 11, -9,
+ax_anim 2, 0, 36, 4, -4, 4, -4,
+ax_anim_terminator
+sAerodactylAnims_2_5:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 2, 0, 2,
+ax_anim 6, 0, 40, 0, 4, 0, 4,
+ax_anim 1, 0, 41, 0, 1, 0, 1,
+ax_anim 2, 2, 43, 0, -4, 0, -4,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 1, 43, -1, -11, -1, -11,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, -1, -11, -1, -11,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, -1, -11, -1, -11,
+ax_anim 2, 0, 40, 0, -7, 0, -7,
+ax_anim 2, 0, 40, 0, -2, 0, -2,
+ax_anim_terminator
+sAerodactylAnims_2_6:
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 6, 0, 44, 5, 5, 5, 5,
+ax_anim 1, 0, 45, 2, 2, 2, 2,
+ax_anim 2, 2, 47, -9, -7, -9, -7,
+ax_anim 2, 0, 47, -15, -10, -15, -10,
+ax_anim 2, 1, 47, -14, -11, -14, -11,
+ax_anim 2, 0, 47, -15, -10, -15, -10,
+ax_anim 2, 0, 47, -14, -11, -14, -11,
+ax_anim 2, 0, 47, -15, -10, -15, -10,
+ax_anim 2, 0, 47, -14, -11, -14, -11,
+ax_anim 2, 0, 44, -11, -9, -11, -9,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim_terminator
+sAerodactylAnims_2_7:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 2, 0, 2, 0,
+ax_anim 6, 0, 48, 5, 0, 5, 0,
+ax_anim 1, 0, 49, 2, 0, 2, 0,
+ax_anim 2, 2, 51, -7, 1, -7, 0,
+ax_anim 2, 0, 51, -12, 3, -12, 0,
+ax_anim 2, 1, 51, -12, 4, -12, 1,
+ax_anim 2, 0, 51, -12, 3, -12, 0,
+ax_anim 2, 0, 51, -12, 4, -12, 1,
+ax_anim 2, 0, 51, -12, 3, -12, 0,
+ax_anim 2, 0, 51, -12, 4, -12, 1,
+ax_anim 2, 0, 48, -8, 2, -8, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sAerodactylAnims_2_8:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 2, -2, 2, -2,
+ax_anim 6, 0, 52, 5, -5, 5, -5,
+ax_anim 1, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 2, 55, -9, 11, -9, 11,
+ax_anim 2, 0, 55, -18, 23, -18, 23,
+ax_anim 2, 1, 55, -17, 24, -17, 24,
+ax_anim 2, 0, 55, -18, 23, -18, 23,
+ax_anim 2, 0, 55, -17, 24, -17, 24,
+ax_anim 2, 0, 55, -18, 23, -18, 23,
+ax_anim 2, 0, 55, -17, 24, -17, 24,
+ax_anim 2, 0, 52, -10, 12, -10, 12,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 84, 0, -3, 0, -3,
+ax_anim 6, 0, 84, 0, -5, 0, -5,
+ax_anim 1, 2, 59, 0, 2, 0, 2,
+ax_anim 1, 0, 63, 0, 14, 0, 14,
+ax_anim 2, 1, 67, 0, 22, 0, 22,
+ax_anim 2, 0, 71, 0, 22, 0, 22,
+ax_anim 2, 0, 75, 0, 22, 0, 22,
+ax_anim 2, 0, 79, 0, 22, 0, 22,
+ax_anim 2, 0, 83, 0, 22, 0, 22,
+ax_anim 2, 0, 87, 0, 13, 0, 13,
+ax_anim 2, 0, 58, 0, 4, 0, 4,
+ax_anim_terminator
+sAerodactylAnims_3_2:
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 56, -3, -3, -3, -3,
+ax_anim 6, 0, 56, -5, -5, -5, -5,
+ax_anim 1, 2, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 67, 11, 15, 11, 15,
+ax_anim 2, 1, 71, 16, 22, 16, 22,
+ax_anim 2, 0, 75, 16, 22, 16, 22,
+ax_anim 2, 0, 79, 16, 22, 16, 22,
+ax_anim 2, 0, 83, 16, 22, 16, 22,
+ax_anim 2, 0, 87, 16, 22, 16, 22,
+ax_anim 2, 0, 59, 10, 14, 10, 14,
+ax_anim 2, 0, 62, 3, 4, 3, 4,
+ax_anim_terminator
+sAerodactylAnims_3_3:
+ax_anim 2, 0, 64, -2, 0, -2, 0,
+ax_anim 2, 0, 60, -3, 0, -3, 0,
+ax_anim 6, 0, 60, -5, 0, -5, 0,
+ax_anim 1, 2, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 71, 9, 0, 9, 0,
+ax_anim 2, 1, 75, 16, 0, 16, 0,
+ax_anim 2, 0, 79, 16, 0, 16, 0,
+ax_anim 2, 0, 83, 16, 0, 16, 0,
+ax_anim 2, 0, 87, 16, 0, 16, 0,
+ax_anim 2, 0, 59, 16, 0, 16, 0,
+ax_anim 2, 0, 63, 8, 0, 8, 0,
+ax_anim 2, 0, 66, 3, 0, 3, 0,
+ax_anim_terminator
+sAerodactylAnims_3_4:
+ax_anim 2, 0, 68, -2, 2, -2, 2,
+ax_anim 2, 0, 64, -3, 3, -3, 3,
+ax_anim 6, 0, 64, -5, 5, -5, 5,
+ax_anim 1, 2, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 75, 13, -10, 13, -10,
+ax_anim 2, 1, 79, 16, -12, 16, -12,
+ax_anim 2, 0, 83, 16, -12, 16, -12,
+ax_anim 2, 0, 87, 16, -12, 16, -12,
+ax_anim 2, 0, 59, 16, -12, 16, -12,
+ax_anim 2, 0, 63, 16, -12, 16, -12,
+ax_anim 2, 0, 67, 12, -9, 12, -9,
+ax_anim 2, 0, 70, 4, -4, 4, -4,
+ax_anim_terminator
+sAerodactylAnims_3_5:
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 68, 0, 3, 0, 3,
+ax_anim 6, 0, 68, 0, 5, 0, 5,
+ax_anim 1, 2, 75, 0, -2, 0, -2,
+ax_anim 1, 0, 79, 0, -10, 0, -10,
+ax_anim 2, 1, 83, 0, -12, 0, -12,
+ax_anim 2, 0, 87, 0, -12, 0, -12,
+ax_anim 2, 0, 59, 0, -12, 0, -12,
+ax_anim 2, 0, 63, 0, -12, 0, -12,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 2, 0, 71, 0, -9, 0, -9,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim_terminator
+sAerodactylAnims_3_6:
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 0, 72, 3, 3, 3, 3,
+ax_anim 6, 0, 72, 5, 5, 5, 5,
+ax_anim 1, 2, 79, -2, -2, -2, -2,
+ax_anim 1, 0, 83, -13, -10, -13, -10,
+ax_anim 2, 1, 87, -16, -12, -16, -12,
+ax_anim 2, 0, 59, -16, -12, -16, -12,
+ax_anim 2, 0, 63, -16, -12, -16, -12,
+ax_anim 2, 0, 67, -16, -12, -16, -12,
+ax_anim 2, 0, 71, -16, -12, -16, -12,
+ax_anim 2, 0, 75, -12, -9, -12, -9,
+ax_anim 2, 0, 78, -4, -4, -4, -4,
+ax_anim_terminator
+sAerodactylAnims_3_7:
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 3, 0, 3, 0,
+ax_anim 6, 0, 76, 5, 0, 5, 0,
+ax_anim 1, 2, 83, -2, 0, -2, 0,
+ax_anim 1, 0, 87, -9, 0, -9, 0,
+ax_anim 2, 1, 59, -16, 0, -16, 0,
+ax_anim 2, 0, 63, -16, 0, -16, 0,
+ax_anim 2, 0, 67, -16, 0, -16, 0,
+ax_anim 2, 0, 71, -16, 0, -16, 0,
+ax_anim 2, 0, 75, -16, 0, -16, 0,
+ax_anim 2, 0, 79, -8, 0, -8, 0,
+ax_anim 2, 0, 82, -3, 0, -3, 0,
+ax_anim_terminator
+sAerodactylAnims_3_8:
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim 2, 0, 80, 3, -3, 3, -3,
+ax_anim 6, 0, 80, 5, -5, 5, -5,
+ax_anim 1, 2, 87, -2, 2, -2, 2,
+ax_anim 1, 0, 59, -11, 15, -11, 15,
+ax_anim 2, 1, 63, -16, 22, -16, 22,
+ax_anim 2, 0, 67, -16, 22, -16, 22,
+ax_anim 2, 0, 71, -16, 22, -16, 22,
+ax_anim 2, 0, 75, -16, 22, -16, 22,
+ax_anim 2, 0, 79, -16, 22, -16, 22,
+ax_anim 2, 0, 83, -10, 14, -10, 14,
+ax_anim 2, 0, 86, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_4_1:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 6, 2, 91, 0, -4, 0, -4,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 4, 0, 4,
+ax_anim 2, 1, 92, 0, 6, 0, 6,
+ax_anim 2, 0, 92, 1, 6, 1, 6,
+ax_anim 2, 0, 92, 0, 6, 0, 6,
+ax_anim 2, 0, 92, 1, 6, 1, 6,
+ax_anim 2, 0, 92, 0, 6, 0, 6,
+ax_anim 2, 0, 92, 1, 6, 1, 6,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sAerodactylAnims_4_2:
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 96, -3, -3, -3, -3,
+ax_anim 6, 2, 96, -4, -4, -4, -4,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 4, 4, 4, 4,
+ax_anim 2, 1, 97, 6, 6, 6, 6,
+ax_anim 2, 0, 97, 7, 5, 7, 5,
+ax_anim 2, 0, 97, 6, 6, 6, 6,
+ax_anim 2, 0, 97, 7, 5, 7, 5,
+ax_anim 2, 0, 97, 6, 6, 6, 6,
+ax_anim 2, 0, 97, 7, 5, 7, 5,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sAerodactylAnims_4_3:
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 6, 2, 101, -4, 0, -4, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 4, 0, 4, 0,
+ax_anim 2, 1, 102, 6, 0, 6, 0,
+ax_anim 2, 0, 102, 6, 1, 6, 1,
+ax_anim 2, 0, 102, 6, 0, 6, 0,
+ax_anim 2, 0, 102, 6, 1, 6, 1,
+ax_anim 2, 0, 102, 6, 0, 6, 0,
+ax_anim 2, 0, 102, 6, 1, 6, 1,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sAerodactylAnims_4_4:
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 106, -3, 3, -3, 3,
+ax_anim 6, 2, 106, -4, 4, -4, 4,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 4, -4, 4, -4,
+ax_anim 2, 1, 107, 6, -6, 6, -6,
+ax_anim 2, 0, 107, 7, -5, 7, -5,
+ax_anim 2, 0, 107, 6, -6, 6, -6,
+ax_anim 2, 0, 107, 7, -5, 7, -5,
+ax_anim 2, 0, 107, 6, -6, 6, -6,
+ax_anim 2, 0, 107, 7, -5, 7, -5,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sAerodactylAnims_4_5:
+ax_anim 2, 0, 110, 0, 1, 0, 1,
+ax_anim 2, 0, 111, 0, 3, 0, 3,
+ax_anim 6, 2, 111, 0, 4, 0, 4,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, -4,
+ax_anim 2, 1, 112, 0, -6, 0, -6,
+ax_anim 2, 0, 112, 1, -6, 1, -6,
+ax_anim 2, 0, 112, 0, -6, 0, -6,
+ax_anim 2, 0, 112, 1, -6, 1, -6,
+ax_anim 2, 0, 112, 0, -6, 0, -6,
+ax_anim 2, 0, 112, 1, -6, 1, -6,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim_terminator
+sAerodactylAnims_4_6:
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 116, 3, 3, 3, 3,
+ax_anim 6, 2, 116, 4, 4, 4, 4,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 117, -4, -4, -4, -4,
+ax_anim 2, 1, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, -7, -5, -7, -5,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, -7, -5, -7, -5,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, -7, -5, -7, -5,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sAerodactylAnims_4_7:
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 3, 0, 3, 0,
+ax_anim 6, 2, 121, 4, 0, 4, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -4, 0, -4, 0,
+ax_anim 2, 1, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, -6, 1, -6, 1,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, -6, 1, -6, 1,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, -6, 1, -6, 1,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sAerodactylAnims_4_8:
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 126, 3, -3, 3, -3,
+ax_anim 6, 2, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -4, 4, -4, 4,
+ax_anim 2, 1, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, -7, 5, -7, 5,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, -7, 5, -7, 5,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, -7, 5, -7, 5,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_5_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_5_4:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_5_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_5_7:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_5_8:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sAerodactylAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sAerodactylAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sAerodactylAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sAerodactylAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sAerodactylAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sAerodactylAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sAerodactylAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_8_1:
+ax_anim 8, 0, 162, 0, 1, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 1, 0, 0,
+ax_anim 8, 0, 163, 0, 2, 0, 0,
+ax_anim 8, 0, 162, 0, 3, 0, 0,
+ax_anim 8, 0, 164, 0, 3, 0, 0,
+ax_anim 8, 0, 164, 0, 2, 0, 0,
+ax_anim 8, 0, 164, 0, 1, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_8_2:
+ax_anim 8, 0, 165, 0, 1, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 1, 0, 0,
+ax_anim 8, 0, 166, 0, 2, 0, 0,
+ax_anim 8, 0, 165, 0, 3, 0, 0,
+ax_anim 8, 0, 167, 0, 3, 0, 0,
+ax_anim 8, 0, 167, 0, 2, 0, 0,
+ax_anim 8, 0, 167, 0, 1, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_8_3:
+ax_anim 8, 0, 168, 0, 1, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 1, 0, 0,
+ax_anim 8, 0, 169, 0, 2, 0, 0,
+ax_anim 8, 0, 168, 0, 3, 0, 0,
+ax_anim 8, 0, 170, 0, 3, 0, 0,
+ax_anim 8, 0, 170, 0, 2, 0, 0,
+ax_anim 8, 0, 170, 0, 1, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_8_4:
+ax_anim 8, 0, 171, 0, 1, 0, 0,
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, 1, 0, 0,
+ax_anim 8, 0, 172, 0, 2, 0, 0,
+ax_anim 8, 0, 171, 0, 3, 0, 0,
+ax_anim 8, 0, 173, 0, 3, 0, 0,
+ax_anim 8, 0, 173, 0, 2, 0, 0,
+ax_anim 8, 0, 173, 0, 1, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_8_5:
+ax_anim 8, 0, 174, 0, 1, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 1, 0, 0,
+ax_anim 8, 0, 175, 0, 2, 0, 0,
+ax_anim 8, 0, 174, 0, 3, 0, 0,
+ax_anim 8, 0, 176, 0, 3, 0, 0,
+ax_anim 8, 0, 176, 0, 2, 0, 0,
+ax_anim 8, 0, 176, 0, 1, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_8_6:
+ax_anim 8, 0, 177, 0, 1, 0, 0,
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 178, 0, 1, 0, 0,
+ax_anim 8, 0, 178, 0, 2, 0, 0,
+ax_anim 8, 0, 177, 0, 3, 0, 0,
+ax_anim 8, 0, 179, 0, 3, 0, 0,
+ax_anim 8, 0, 179, 0, 2, 0, 0,
+ax_anim 8, 0, 179, 0, 1, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_8_7:
+ax_anim 8, 0, 180, 0, 1, 0, 0,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 181, 0, 1, 0, 0,
+ax_anim 8, 0, 181, 0, 2, 0, 0,
+ax_anim 8, 0, 180, 0, 3, 0, 0,
+ax_anim 8, 0, 182, 0, 3, 0, 0,
+ax_anim 8, 0, 182, 0, 2, 0, 0,
+ax_anim 8, 0, 182, 0, 1, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_8_8:
+ax_anim 8, 0, 183, 0, 1, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 1, 0, 0,
+ax_anim 8, 0, 184, 0, 2, 0, 0,
+ax_anim 8, 0, 183, 0, 3, 0, 0,
+ax_anim 8, 0, 185, 0, 3, 0, 0,
+ax_anim 8, 0, 185, 0, 2, 0, 0,
+ax_anim 8, 0, 185, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 4, 7, 4,
+ax_anim 2, 0, 188, 12, 12, 12, 12,
+ax_anim 2, 0, 189, 12, 21, 12, 21,
+ax_anim 3, 0, 190, 0, 24, 0, 24,
+ax_anim 2, 3, 191, -12, 21, -12, 21,
+ax_anim 2, 0, 192, -12, 12, -12, 12,
+ax_anim 1, 0, 193, -7, 4, -7, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 9, 1, 9, 1,
+ax_anim 2, 0, 187, 17, 6, 17, 6,
+ax_anim 2, 0, 188, 24, 17, 24, 17,
+ax_anim 3, 0, 189, 21, 25, 21, 22,
+ax_anim 2, 3, 190, 10, 24, 10, 24,
+ax_anim 2, 0, 191, -1, 18, -1, 18,
+ax_anim 1, 0, 192, -4, 8, -4, 8,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 6, -2, 6, -3,
+ax_anim 2, 0, 186, 12, 1, 11, -2,
+ax_anim 2, 0, 187, 15, 4, 17, -2,
+ax_anim 3, 0, 188, 16, 9, 16, 2,
+ax_anim 2, 3, 189, 15, 12, 15, 7,
+ax_anim 2, 0, 190, 8, 9, 9, 7,
+ax_anim 1, 0, 191, 2, 6, 2, 6,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, -8,
+ax_anim 2, 0, 193, 6, -15, 6, -16,
+ax_anim 2, 0, 186, 14, -15, 14, -20,
+ax_anim 3, 0, 187, 20, -13, 23, -20,
+ax_anim 2, 3, 188, 25, -8, 25, -11,
+ax_anim 2, 0, 189, 22, 0, 22, -2,
+ax_anim 1, 0, 190, 11, 0, 11, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -7, -1, -7, -1,
+ax_anim 2, 0, 192, -9, -6, -9, -8,
+ax_anim 2, 0, 193, -5, -11, -5, -16,
+ax_anim 3, 0, 186, 0, -11, 0, -21,
+ax_anim 2, 3, 187, 5, -11, 5, -16,
+ax_anim 2, 0, 188, 9, -6, 9, -8,
+ax_anim 1, 0, 189, 7, -1, 7, -1,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -8, 0, -8,
+ax_anim 2, 0, 187, -6, -15, -6, -16,
+ax_anim 2, 0, 186, -14, -15, -14, -20,
+ax_anim 3, 0, 193, -20, -13, -22, -20,
+ax_anim 2, 3, 192, -25, -8, -25, -11,
+ax_anim 2, 0, 191, -22, 0, -22, -2,
+ax_anim 1, 0, 190, -11, 0, -11, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -6, -2, -6, -3,
+ax_anim 2, 0, 186, -12, 1, -11, -2,
+ax_anim 2, 0, 193, -15, 4, -17, -2,
+ax_anim 3, 0, 192, -16, 9, -16, 2,
+ax_anim 2, 3, 191, -15, 12, -15, 7,
+ax_anim 2, 0, 190, -8, 9, -9, 7,
+ax_anim 1, 0, 189, -2, 6, -2, 6,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -9, 1, -9, 1,
+ax_anim 2, 0, 193, -17, 6, -17, 6,
+ax_anim 2, 0, 192, -24, 17, -24, 17,
+ax_anim 3, 0, 191, -21, 25, -21, 22,
+ax_anim 2, 3, 190, -10, 24, -10, 24,
+ax_anim 2, 0, 189, 1, 18, 1, 18,
+ax_anim 1, 0, 188, 4, 8, 4, 8,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -24, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -8, 0, 0,
+ax_anim 2, 2, 202, 0, 5, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -8, 0, 0,
+ax_anim 2, 2, 205, 0, 5, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -24, 0, 0,
+ax_anim 3, 0, 209, 0, -23, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -8, 0, 0,
+ax_anim 2, 2, 208, 0, 5, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -24, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -17, 0, 0,
+ax_anim 1, 0, 212, 0, -7, 0, 0,
+ax_anim 2, 2, 211, 0, 5, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -23, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -8, 0, 0,
+ax_anim 2, 2, 214, 0, 6, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -24, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -17, 0, 0,
+ax_anim 1, 0, 218, 0, -7, 0, 0,
+ax_anim 2, 2, 217, 0, 5, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -24, 0, 0,
+ax_anim 3, 0, 221, 0, -23, 0, 0,
+ax_anim 2, 0, 221, 0, -18, 0, 0,
+ax_anim 1, 0, 221, 0, -8, 0, 0,
+ax_anim 2, 2, 220, 0, 5, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -22, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -8, 0, 0,
+ax_anim 2, 2, 223, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAerodactylAnims_13_1:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_13_2:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_13_3:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_13_4:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_13_5:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_13_6:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_13_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylAnims_13_8:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sAerodactylGfx1:
+.incbin "baserom.gba", 0xB1EED8, 0x200
+sAerodactylSprites1:
+ax_sprite sAerodactylGfx1, 0x200
+ax_sprite_terminator
+sAerodactylGfx2:
+.incbin "baserom.gba", 0xB1F0E8, 0x200
+sAerodactylSprites2:
+ax_sprite sAerodactylGfx2, 0x200
+ax_sprite_terminator
+sAerodactylGfx3:
+.incbin "baserom.gba", 0xB1F2F8, 0x200
+sAerodactylSprites3:
+ax_sprite sAerodactylGfx3, 0x200
+ax_sprite_terminator
+sAerodactylGfx4:
+.incbin "baserom.gba", 0xB1F508, 0x200
+sAerodactylSprites4:
+ax_sprite sAerodactylGfx4, 0x200
+ax_sprite_terminator
+sAerodactylGfx5:
+.incbin "baserom.gba", 0xB1F718, 0x200
+sAerodactylSprites5:
+ax_sprite sAerodactylGfx5, 0x200
+ax_sprite_terminator
+sAerodactylGfx6:
+.incbin "baserom.gba", 0xB1F928, 0x200
+sAerodactylSprites6:
+ax_sprite sAerodactylGfx6, 0x200
+ax_sprite_terminator
+sAerodactylGfx7:
+.incbin "baserom.gba", 0xB1FB38, 0x200
+sAerodactylSprites7:
+ax_sprite sAerodactylGfx7, 0x200
+ax_sprite_terminator
+sAerodactylGfx8:
+.incbin "baserom.gba", 0xB1FD48, 0x200
+sAerodactylSprites8:
+ax_sprite sAerodactylGfx8, 0x200
+ax_sprite_terminator
+sAerodactylGfx9:
+.incbin "baserom.gba", 0xB1FF58, 0x200
+sAerodactylSprites9:
+ax_sprite sAerodactylGfx9, 0x200
+ax_sprite_terminator
+sAerodactylGfx10:
+.incbin "baserom.gba", 0xB20168, 0x200
+sAerodactylSprites10:
+ax_sprite sAerodactylGfx10, 0x200
+ax_sprite_terminator
+sAerodactylGfx11:
+.incbin "baserom.gba", 0xB20378, 0x200
+sAerodactylSprites11:
+ax_sprite sAerodactylGfx11, 0x200
+ax_sprite_terminator
+sAerodactylGfx12:
+.incbin "baserom.gba", 0xB20588, 0x200
+sAerodactylSprites12:
+ax_sprite sAerodactylGfx12, 0x200
+ax_sprite_terminator
+sAerodactylGfx13:
+.incbin "baserom.gba", 0xB20798, 0x200
+sAerodactylSprites13:
+ax_sprite sAerodactylGfx13, 0x200
+ax_sprite_terminator
+sAerodactylGfx14:
+.incbin "baserom.gba", 0xB209A8, 0x200
+sAerodactylSprites14:
+ax_sprite sAerodactylGfx14, 0x200
+ax_sprite_terminator
+sAerodactylGfx15:
+.incbin "baserom.gba", 0xB20BB8, 0x100
+sAerodactylSprites15:
+ax_sprite sAerodactylGfx15, 0x100
+ax_sprite_terminator
+sAerodactylGfx16:
+.incbin "baserom.gba", 0xB20CC8, 0x80
+sAerodactylSprites16:
+ax_sprite sAerodactylGfx16, 0x80
+ax_sprite_terminator
+sAerodactylGfx17:
+.incbin "baserom.gba", 0xB20D58, 0x20
+sAerodactylSprites17:
+ax_sprite sAerodactylGfx17, 0x20
+ax_sprite_terminator
+sAerodactylGfx18:
+.incbin "baserom.gba", 0xB20D88, 0x40
+sAerodactylSprites18:
+ax_sprite sAerodactylGfx18, 0x40
+ax_sprite_terminator
+sAerodactylGfx19:
+.incbin "baserom.gba", 0xB20DD8, 0x20
+sAerodactylSprites19:
+ax_sprite sAerodactylGfx19, 0x20
+ax_sprite_terminator
+sAerodactylGfx20:
+.incbin "baserom.gba", 0xB20E08, 0x100
+sAerodactylGfx20_1:
+.incbin "baserom.gba", 0xB20F08, 0x40
+sAerodactylGfx20_2:
+.incbin "baserom.gba", 0xB20F48, 0x40
+sAerodactylSprites20:
+ax_sprite sAerodactylGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAerodactylGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAerodactylGfx21:
+.incbin "baserom.gba", 0xB20FC0, 0x1C0
+sAerodactylSprites21:
+ax_sprite sAerodactylGfx21, 0x1c0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAerodactylGfx22:
+.incbin "baserom.gba", 0xB21198, 0x20
+sAerodactylSprites22:
+ax_sprite sAerodactylGfx22, 0x20
+ax_sprite_terminator
+sAerodactylGfx23:
+.incbin "baserom.gba", 0xB211C8, 0xE0
+sAerodactylSprites23:
+ax_sprite sAerodactylGfx23, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAerodactylGfx24:
+.incbin "baserom.gba", 0xB212C0, 0x60
+sAerodactylSprites24:
+ax_sprite sAerodactylGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAerodactylGfx25:
+.incbin "baserom.gba", 0xB21338, 0x40
+sAerodactylSprites25:
+ax_sprite sAerodactylGfx25, 0x40
+ax_sprite_terminator
+sAerodactylGfx26:
+.incbin "baserom.gba", 0xB21388, 0x20
+sAerodactylSprites26:
+ax_sprite sAerodactylGfx26, 0x20
+ax_sprite_terminator
+sAerodactylGfx27:
+.incbin "baserom.gba", 0xB213B8, 0x60
+sAerodactylGfx27_1:
+.incbin "baserom.gba", 0xB21418, 0x180
+sAerodactylSprites27:
+ax_sprite sAerodactylGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx27_1, 0x180
+ax_sprite_terminator
+sAerodactylGfx28:
+.incbin "baserom.gba", 0xB215B8, 0x40
+sAerodactylGfx28_1:
+.incbin "baserom.gba", 0xB215F8, 0x180
+sAerodactylSprites28:
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx28_1, 0x180
+ax_sprite_terminator
+sAerodactylGfx29:
+.incbin "baserom.gba", 0xB217A0, 0x40
+sAerodactylGfx29_1:
+.incbin "baserom.gba", 0xB217E0, 0x180
+sAerodactylSprites29:
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx29_1, 0x180
+ax_sprite_terminator
+sAerodactylGfx30:
+.incbin "baserom.gba", 0xB21988, 0x180
+sAerodactylGfx30_1:
+.incbin "baserom.gba", 0xB21B08, 0x40
+sAerodactylSprites30:
+ax_sprite sAerodactylGfx30, 0x180
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAerodactylGfx31:
+.incbin "baserom.gba", 0xB21B70, 0x1C0
+sAerodactylSprites31:
+ax_sprite 0, 0x40
+ax_sprite sAerodactylGfx31, 0x1c0
+ax_sprite_terminator
+sAerodactylGfx32:
+.incbin "baserom.gba", 0xB21D48, 0x20
+sAerodactylGfx32_1:
+.incbin "baserom.gba", 0xB21D68, 0x20
+sAerodactylGfx32_2:
+.incbin "baserom.gba", 0xB21D88, 0x140
+sAerodactylGfx32_3:
+.incbin "baserom.gba", 0xB21EC8, 0x20
+sAerodactylSprites32:
+ax_sprite sAerodactylGfx32, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx32_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx32_2, 0x140
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx32_3, 0x20
+ax_sprite_terminator
+sAerodactylGfx33:
+.incbin "baserom.gba", 0xB21F28, 0x160
+sAerodactylGfx33_1:
+.incbin "baserom.gba", 0xB22088, 0x60
+sAerodactylSprites33:
+ax_sprite sAerodactylGfx33, 0x160
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAerodactylGfx34:
+.incbin "baserom.gba", 0xB22110, 0xE0
+sAerodactylSprites34:
+ax_sprite sAerodactylGfx34, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAerodactylGfx35:
+.incbin "baserom.gba", 0xB22208, 0x80
+sAerodactylSprites35:
+ax_sprite sAerodactylGfx35, 0x80
+ax_sprite_terminator
+sAerodactylGfx36:
+.incbin "baserom.gba", 0xB22298, 0x40
+sAerodactylSprites36:
+ax_sprite sAerodactylGfx36, 0x40
+ax_sprite_terminator
+sAerodactylGfx37:
+.incbin "baserom.gba", 0xB222E8, 0x20
+sAerodactylSprites37:
+ax_sprite sAerodactylGfx37, 0x20
+ax_sprite_terminator
+sAerodactylGfx38:
+.incbin "baserom.gba", 0xB22318, 0x20
+sAerodactylSprites38:
+ax_sprite sAerodactylGfx38, 0x20
+ax_sprite_terminator
+sAerodactylGfx39:
+.incbin "baserom.gba", 0xB22348, 0x40
+sAerodactylGfx39_1:
+.incbin "baserom.gba", 0xB22388, 0x100
+sAerodactylGfx39_2:
+.incbin "baserom.gba", 0xB22488, 0x60
+sAerodactylSprites39:
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx39_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx39_2, 0x60
+ax_sprite_terminator
+sAerodactylGfx40:
+.incbin "baserom.gba", 0xB22520, 0x1C0
+sAerodactylSprites40:
+ax_sprite 0, 0x40
+ax_sprite sAerodactylGfx40, 0x1c0
+ax_sprite_terminator
+sAerodactylGfx41:
+.incbin "baserom.gba", 0xB226F8, 0x20
+sAerodactylGfx41_1:
+.incbin "baserom.gba", 0xB22718, 0x120
+sAerodactylGfx41_2:
+.incbin "baserom.gba", 0xB22838, 0x40
+sAerodactylSprites41:
+ax_sprite sAerodactylGfx41, 0x20
+ax_sprite 0, 0x40
+ax_sprite sAerodactylGfx41_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sAerodactylGfx41_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAerodactylGfx42:
+.incbin "baserom.gba", 0xB228B0, 0x200
+sAerodactylSprites42:
+ax_sprite sAerodactylGfx42, 0x200
+ax_sprite_terminator
+sAerodactylGfx43:
+.incbin "baserom.gba", 0xB22AC0, 0x200
+sAerodactylSprites43:
+ax_sprite sAerodactylGfx43, 0x200
+ax_sprite_terminator
+sAerodactylGfx44:
+.incbin "baserom.gba", 0xB22CD0, 0x200
+sAerodactylSprites44:
+ax_sprite sAerodactylGfx44, 0x200
+ax_sprite_terminator
+sAerodactylGfx45:
+.incbin "baserom.gba", 0xB22EE0, 0x200
+sAerodactylSprites45:
+ax_sprite sAerodactylGfx45, 0x200
+ax_sprite_terminator
+sAerodactylGfx46:
+.incbin "baserom.gba", 0xB230F0, 0x200
+sAerodactylSprites46:
+ax_sprite sAerodactylGfx46, 0x200
+ax_sprite_terminator
+sAerodactylGfx47:
+.incbin "baserom.gba", 0xB23300, 0x200
+sAerodactylSprites47:
+ax_sprite sAerodactylGfx47, 0x200
+ax_sprite_terminator
+sAerodactylGfx48:
+.incbin "baserom.gba", 0xB23510, 0x200
+sAerodactylSprites48:
+ax_sprite sAerodactylGfx48, 0x200
+ax_sprite_terminator
+sAerodactylGfx49:
+.incbin "baserom.gba", 0xB23720, 0x200
+sAerodactylSprites49:
+ax_sprite sAerodactylGfx49, 0x200
+ax_sprite_terminator
+sAxPosesAerodactyl:
+.4byte sAerodactylPose1
+.4byte sAerodactylPose2
+.4byte sAerodactylPose3
+.4byte sAerodactylPose4
+.4byte sAerodactylPose5
+.4byte sAerodactylPose6
+.4byte sAerodactylPose7
+.4byte sAerodactylPose8
+.4byte sAerodactylPose9
+.4byte sAerodactylPose10
+.4byte sAerodactylPose11
+.4byte sAerodactylPose12
+.4byte sAerodactylPose13
+.4byte sAerodactylPose14
+.4byte sAerodactylPose15
+.4byte sAerodactylPose16
+.4byte sAerodactylPose17
+.4byte sAerodactylPose18
+.4byte sAerodactylPose19
+.4byte sAerodactylPose20
+.4byte sAerodactylPose21
+.4byte sAerodactylPose22
+.4byte sAerodactylPose23
+.4byte sAerodactylPose24
+.4byte sAerodactylPose25
+.4byte sAerodactylPose26
+.4byte sAerodactylPose27
+.4byte sAerodactylPose28
+.4byte sAerodactylPose29
+.4byte sAerodactylPose30
+.4byte sAerodactylPose31
+.4byte sAerodactylPose32
+.4byte sAerodactylPose33
+.4byte sAerodactylPose34
+.4byte sAerodactylPose35
+.4byte sAerodactylPose36
+.4byte sAerodactylPose37
+.4byte sAerodactylPose38
+.4byte sAerodactylPose39
+.4byte sAerodactylPose40
+.4byte sAerodactylPose41
+.4byte sAerodactylPose42
+.4byte sAerodactylPose43
+.4byte sAerodactylPose44
+.4byte sAerodactylPose45
+.4byte sAerodactylPose46
+.4byte sAerodactylPose47
+.4byte sAerodactylPose48
+.4byte sAerodactylPose49
+.4byte sAerodactylPose50
+.4byte sAerodactylPose51
+.4byte sAerodactylPose52
+.4byte sAerodactylPose53
+.4byte sAerodactylPose54
+.4byte sAerodactylPose55
+.4byte sAerodactylPose56
+.4byte sAerodactylPose57
+.4byte sAerodactylPose58
+.4byte sAerodactylPose59
+.4byte sAerodactylPose60
+.4byte sAerodactylPose61
+.4byte sAerodactylPose62
+.4byte sAerodactylPose63
+.4byte sAerodactylPose64
+.4byte sAerodactylPose65
+.4byte sAerodactylPose66
+.4byte sAerodactylPose67
+.4byte sAerodactylPose68
+.4byte sAerodactylPose69
+.4byte sAerodactylPose70
+.4byte sAerodactylPose71
+.4byte sAerodactylPose72
+.4byte sAerodactylPose73
+.4byte sAerodactylPose74
+.4byte sAerodactylPose75
+.4byte sAerodactylPose76
+.4byte sAerodactylPose77
+.4byte sAerodactylPose78
+.4byte sAerodactylPose79
+.4byte sAerodactylPose80
+.4byte sAerodactylPose81
+.4byte sAerodactylPose82
+.4byte sAerodactylPose83
+.4byte sAerodactylPose84
+.4byte sAerodactylPose85
+.4byte sAerodactylPose86
+.4byte sAerodactylPose87
+.4byte sAerodactylPose88
+.4byte sAerodactylPose89
+.4byte sAerodactylPose90
+.4byte sAerodactylPose91
+.4byte sAerodactylPose92
+.4byte sAerodactylPose93
+.4byte sAerodactylPose94
+.4byte sAerodactylPose95
+.4byte sAerodactylPose96
+.4byte sAerodactylPose97
+.4byte sAerodactylPose98
+.4byte sAerodactylPose99
+.4byte sAerodactylPose100
+.4byte sAerodactylPose101
+.4byte sAerodactylPose102
+.4byte sAerodactylPose103
+.4byte sAerodactylPose104
+.4byte sAerodactylPose105
+.4byte sAerodactylPose106
+.4byte sAerodactylPose107
+.4byte sAerodactylPose108
+.4byte sAerodactylPose109
+.4byte sAerodactylPose110
+.4byte sAerodactylPose111
+.4byte sAerodactylPose112
+.4byte sAerodactylPose113
+.4byte sAerodactylPose114
+.4byte sAerodactylPose115
+.4byte sAerodactylPose116
+.4byte sAerodactylPose117
+.4byte sAerodactylPose118
+.4byte sAerodactylPose119
+.4byte sAerodactylPose120
+.4byte sAerodactylPose121
+.4byte sAerodactylPose122
+.4byte sAerodactylPose123
+.4byte sAerodactylPose124
+.4byte sAerodactylPose125
+.4byte sAerodactylPose126
+.4byte sAerodactylPose127
+.4byte sAerodactylPose128
+.4byte sAerodactylPose129
+.4byte sAerodactylPose130
+.4byte sAerodactylPose131
+.4byte sAerodactylPose132
+.4byte sAerodactylPose133
+.4byte sAerodactylPose134
+.4byte sAerodactylPose135
+.4byte sAerodactylPose136
+.4byte sAerodactylPose137
+.4byte sAerodactylPose138
+.4byte sAerodactylPose139
+.4byte sAerodactylPose140
+.4byte sAerodactylPose141
+.4byte sAerodactylPose142
+.4byte sAerodactylPose143
+.4byte sAerodactylPose144
+.4byte sAerodactylPose145
+.4byte sAerodactylPose146
+.4byte sAerodactylPose147
+.4byte sAerodactylPose148
+.4byte sAerodactylPose149
+.4byte sAerodactylPose150
+.4byte sAerodactylPose151
+.4byte sAerodactylPose152
+.4byte sAerodactylPose153
+.4byte sAerodactylPose154
+.4byte sAerodactylPose155
+.4byte sAerodactylPose156
+.4byte sAerodactylPose157
+.4byte sAerodactylPose158
+.4byte sAerodactylPose159
+.4byte sAerodactylPose160
+.4byte sAerodactylPose161
+.4byte sAerodactylPose162
+.4byte sAerodactylPose163
+.4byte sAerodactylPose164
+.4byte sAerodactylPose165
+.4byte sAerodactylPose166
+.4byte sAerodactylPose167
+.4byte sAerodactylPose168
+.4byte sAerodactylPose169
+.4byte sAerodactylPose170
+.4byte sAerodactylPose171
+.4byte sAerodactylPose172
+.4byte sAerodactylPose173
+.4byte sAerodactylPose174
+.4byte sAerodactylPose175
+.4byte sAerodactylPose176
+.4byte sAerodactylPose177
+.4byte sAerodactylPose178
+.4byte sAerodactylPose179
+.4byte sAerodactylPose180
+.4byte sAerodactylPose181
+.4byte sAerodactylPose182
+.4byte sAerodactylPose183
+.4byte sAerodactylPose184
+.4byte sAerodactylPose185
+.4byte sAerodactylPose186
+.4byte sAerodactylPose187
+.4byte sAerodactylPose188
+.4byte sAerodactylPose189
+.4byte sAerodactylPose190
+.4byte sAerodactylPose191
+.4byte sAerodactylPose192
+.4byte sAerodactylPose193
+.4byte sAerodactylPose194
+.4byte sAerodactylPose195
+.4byte sAerodactylPose196
+.4byte sAerodactylPose197
+.4byte sAerodactylPose198
+.4byte sAerodactylPose199
+.4byte sAerodactylPose200
+.4byte sAerodactylPose201
+.4byte sAerodactylPose202
+.4byte sAerodactylPose203
+.4byte sAerodactylPose204
+.4byte sAerodactylPose205
+.4byte sAerodactylPose206
+.4byte sAerodactylPose207
+.4byte sAerodactylPose208
+.4byte sAerodactylPose209
+.4byte sAerodactylPose210
+.4byte sAerodactylPose211
+.4byte sAerodactylPose212
+.4byte sAerodactylPose213
+.4byte sAerodactylPose214
+.4byte sAerodactylPose215
+.4byte sAerodactylPose216
+.4byte sAerodactylPose217
+.4byte sAerodactylPose218
+.4byte sAerodactylPose219
+.4byte sAerodactylPose220
+.4byte sAerodactylPose221
+.4byte sAerodactylPose222
+.4byte sAerodactylPose223
+.4byte sAerodactylPose224
+.4byte sAerodactylPose225
+.4byte sAerodactylPose226
+.4byte sAerodactylPose227
+.4byte sAerodactylPose228
+.4byte sAerodactylPose229
+.4byte sAerodactylPose230
+.4byte sAerodactylPose231
+.4byte sAerodactylPose232
+.4byte sAerodactylPose233
+.4byte sAerodactylPose234
+.4byte sAerodactylPose235
+.4byte sAerodactylPose236
+.4byte sAerodactylPose237
+.4byte sAerodactylPose238
+.4byte sAerodactylPose239
+.4byte sAerodactylPose240
+.4byte sAerodactylPose241
+.4byte sAerodactylPose242
+.4byte sAerodactylPose243
+.4byte sAerodactylPose244
+.4byte sAerodactylPose245
+.4byte sAerodactylPose246
+.4byte sAerodactylPose247
+.4byte sAerodactylPose248
+.4byte sAerodactylPose249
+.4byte sAerodactylPose250
+.4byte sAerodactylPose251
+.4byte sAerodactylPose252
+.4byte sAerodactylPose253
+.4byte sAerodactylPose254
+.4byte sAerodactylPose255
+.4byte sAerodactylPose256
+.4byte sAerodactylPose257
+.4byte sAerodactylPose258
+.4byte sAerodactylPose259
+.4byte sAerodactylPose260
+.4byte sAerodactylPose261
+.4byte sAerodactylPose262
+.4byte sAerodactylPose263
+.4byte sAerodactylPose264
+.4byte sAerodactylPose265
+.4byte sAerodactylPose266
+.4byte sAerodactylPose267
+.4byte sAerodactylPose268
+.4byte sAerodactylPose269
+.4byte sAerodactylPose270
+sAxPositionsAerodactyl:
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte   -1,  -11, 	 -12,   -8, 	  11,   -8, 	   0,  -14
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    5,  -15, 	   9,   -9, 	  -8,   -7, 	   0,  -14
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    9,  -16, 	   0,  -12, 	  -4,   -4, 	  -2,  -15
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte    8,  -21, 	 -10,  -14, 	  10,   -3, 	  -1,  -15
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    0,  -22, 	  11,   -5, 	 -12,   -6, 	   0,  -16
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -9,  -21, 	   9,  -14, 	 -11,   -3, 	   0,  -15
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -16, 	  -1,  -12, 	   3,   -4, 	   1,  -15
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte   -6,  -15, 	 -10,   -9, 	   7,   -7, 	  -1,  -14
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte   -1,  -11, 	 -12,   -8, 	  11,   -8, 	   0,  -14
+.2byte   -1,   -6, 	 -11,  -25, 	  10,  -25, 	  -1,  -17
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    5,  -15, 	   9,   -9, 	  -8,   -7, 	   0,  -14
+.2byte    5,   -7, 	   5,  -24, 	 -15,  -19, 	   0,  -15
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    9,  -16, 	   0,  -12, 	  -4,   -4, 	  -2,  -15
+.2byte   10,  -11, 	  -6,  -23, 	 -14,  -10, 	   0,  -13
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte    8,  -21, 	 -10,  -14, 	  10,   -3, 	  -1,  -15
+.2byte    9,  -21, 	 -13,  -19, 	   5,   -4, 	   1,  -15
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    0,  -22, 	  11,   -5, 	 -12,   -6, 	   0,  -16
+.2byte    0,  -22, 	  13,  -10, 	 -14,  -10, 	   0,  -15
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -9,  -21, 	   9,  -14, 	 -11,   -3, 	   0,  -15
+.2byte  -10,  -21, 	  12,  -19, 	  -6,   -4, 	  -2,  -15
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -16, 	  -1,  -12, 	   3,   -4, 	   1,  -15
+.2byte  -11,  -11, 	   5,  -23, 	  13,  -10, 	  -1,  -13
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte   -6,  -15, 	 -10,   -9, 	   7,   -7, 	  -1,  -14
+.2byte   -6,   -7, 	  -6,  -24, 	  14,  -19, 	  -1,  -15
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte   -1,  -11, 	 -12,   -8, 	  11,   -8, 	   0,  -14
+.2byte   -1,   -6, 	 -11,  -25, 	  10,  -25, 	  -1,  -17
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    5,  -15, 	   9,   -9, 	  -8,   -7, 	   0,  -14
+.2byte    5,   -7, 	   5,  -24, 	 -15,  -19, 	   0,  -15
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    9,  -16, 	   0,  -12, 	  -4,   -4, 	  -2,  -15
+.2byte   10,  -11, 	  -6,  -23, 	 -14,  -10, 	   0,  -13
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte    8,  -21, 	 -10,  -14, 	  10,   -3, 	  -1,  -15
+.2byte    9,  -21, 	 -13,  -19, 	   5,   -4, 	   1,  -15
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    0,  -22, 	  11,   -5, 	 -12,   -6, 	   0,  -16
+.2byte    0,  -22, 	  13,  -10, 	 -14,  -10, 	   0,  -15
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -9,  -21, 	   9,  -14, 	 -11,   -3, 	   0,  -15
+.2byte  -10,  -21, 	  12,  -19, 	  -6,   -4, 	  -2,  -15
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -16, 	  -1,  -12, 	   3,   -4, 	   1,  -15
+.2byte  -11,  -11, 	   5,  -23, 	  13,  -10, 	  -1,  -13
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte   -6,  -15, 	 -10,   -9, 	   7,   -7, 	  -1,  -14
+.2byte   -6,   -7, 	  -6,  -24, 	  14,  -19, 	  -1,  -15
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte   -1,  -11, 	 -12,   -8, 	  11,   -8, 	   0,  -14
+.2byte    0,  -29, 	 -11,  -11, 	  10,  -11, 	  -1,  -16
+.2byte    0,   -5, 	 -13,  -23, 	  12,  -23, 	   0,  -14
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    5,  -15, 	   9,   -9, 	  -8,   -7, 	   0,  -14
+.2byte   -9,  -31, 	  11,  -14, 	  -7,   -5, 	  -1,  -18
+.2byte    8,   -8, 	  14,  -29, 	 -12,  -23, 	   1,  -16
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    9,  -16, 	   0,  -12, 	  -4,   -4, 	  -2,  -15
+.2byte  -14,  -23, 	  10,  -21, 	   7,  -12, 	   0,  -18
+.2byte   11,  -10, 	   1,  -31, 	  -4,  -21, 	   0,  -13
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte    8,  -21, 	 -10,  -14, 	  10,   -3, 	  -1,  -15
+.2byte  -11,  -11, 	   2,  -28, 	  12,  -16, 	  -1,  -16
+.2byte    8,  -16, 	 -11,  -29, 	  13,   -8, 	   0,  -15
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    0,  -22, 	  13,  -10, 	 -14,  -10, 	   0,  -15
+.2byte    0,   -6, 	  10,  -23, 	 -11,  -23, 	   0,  -13
+.2byte   -1,  -22, 	  13,  -23, 	 -14,  -23, 	   0,  -16
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -9,  -21, 	   9,  -14, 	 -11,   -3, 	   0,  -15
+.2byte   10,  -11, 	  -3,  -28, 	 -13,  -16, 	   0,  -16
+.2byte   -9,  -16, 	  10,  -29, 	 -14,   -8, 	  -1,  -15
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -16, 	  -1,  -12, 	   3,   -4, 	   1,  -15
+.2byte   13,  -23, 	 -11,  -21, 	  -8,  -12, 	  -1,  -18
+.2byte  -12,  -10, 	  -2,  -31, 	   3,  -21, 	  -1,  -13
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte   -6,  -15, 	 -10,   -9, 	   7,   -7, 	  -1,  -14
+.2byte    8,  -31, 	 -12,  -14, 	   6,   -5, 	   0,  -18
+.2byte   -9,   -8, 	 -15,  -29, 	  11,  -23, 	  -2,  -16
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte   -1,  -11, 	 -12,   -8, 	  11,   -8, 	   0,  -14
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    5,  -15, 	   9,   -9, 	  -8,   -7, 	   0,  -14
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    9,  -16, 	   0,  -12, 	  -4,   -4, 	  -2,  -15
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte    8,  -21, 	 -10,  -14, 	  10,   -3, 	  -1,  -15
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    0,  -22, 	  11,   -5, 	 -12,   -6, 	   0,  -16
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -9,  -21, 	   9,  -14, 	 -11,   -3, 	   0,  -15
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -16, 	  -1,  -12, 	   3,   -4, 	   1,  -15
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte   -6,  -15, 	 -10,   -9, 	   7,   -7, 	  -1,  -14
+.2byte   -6,   -7, 	 -11,   -3, 	   7,    1, 	  -1,   -7
+.2byte   -7,   -6, 	 -11,   -1, 	   6,    3, 	  -1,   -6
+.2byte    3,   -8, 	 -13,  -22, 	   5,  -29, 	   2,  -12
+.2byte    2,   -9, 	  14,  -23, 	  -8,  -30, 	  -1,  -14
+.2byte    5,   -6, 	   7,  -27, 	  -2,  -30, 	   0,  -14
+.2byte    8,   -9, 	  -6,  -27, 	   6,  -29, 	   0,  -14
+.2byte    2,  -18, 	  14,  -25, 	  -8,  -29, 	   1,  -15
+.2byte   -7,   -9, 	   7,  -27, 	  -5,  -29, 	   1,  -14
+.2byte   -6,   -6, 	  -8,  -27, 	   1,  -30, 	  -1,  -14
+.2byte   -3,   -9, 	 -15,  -23, 	   7,  -30, 	   0,  -14
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte   -1,  -11, 	 -12,   -8, 	  11,   -8, 	   0,  -14
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    5,  -15, 	   9,   -9, 	  -8,   -7, 	   0,  -14
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    9,  -16, 	   0,  -12, 	  -4,   -4, 	  -2,  -15
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte    8,  -21, 	 -10,  -14, 	  10,   -3, 	  -1,  -15
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    0,  -22, 	  11,   -5, 	 -12,   -6, 	   0,  -16
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -9,  -21, 	   9,  -14, 	 -11,   -3, 	   0,  -15
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -16, 	  -1,  -12, 	   3,   -4, 	   1,  -15
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte   -6,  -15, 	 -10,   -9, 	   7,   -7, 	  -1,  -14
+.2byte   -1,   -6, 	 -11,  -25, 	  10,  -25, 	  -1,  -17
+.2byte   -6,   -8, 	  -6,  -25, 	  14,  -20, 	  -1,  -16
+.2byte  -10,  -13, 	   6,  -25, 	  14,  -12, 	   0,  -15
+.2byte  -10,  -21, 	  12,  -19, 	  -6,   -4, 	  -2,  -15
+.2byte    0,  -22, 	  13,  -10, 	 -14,  -10, 	   0,  -15
+.2byte    9,  -21, 	 -13,  -19, 	   5,   -4, 	   1,  -15
+.2byte    9,  -13, 	  -7,  -25, 	 -15,  -12, 	  -1,  -15
+.2byte    5,   -8, 	   5,  -25, 	 -15,  -20, 	   0,  -16
+.2byte    0,   -5, 	 -13,  -23, 	  12,  -23, 	   0,  -14
+.2byte    7,   -8, 	  13,  -29, 	 -13,  -23, 	   0,  -16
+.2byte   10,  -10, 	   0,  -31, 	  -5,  -21, 	  -1,  -13
+.2byte    8,  -16, 	 -11,  -29, 	  13,   -8, 	   0,  -15
+.2byte   -1,  -20, 	  13,  -21, 	 -14,  -21, 	   0,  -14
+.2byte   -9,  -16, 	  10,  -29, 	 -14,   -8, 	  -1,  -15
+.2byte  -10,  -10, 	   0,  -31, 	   5,  -21, 	   1,  -13
+.2byte   -8,   -8, 	 -14,  -29, 	  12,  -23, 	  -1,  -16
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -1,  -11, 	 -12,   -8, 	  11,   -8, 	   0,  -14
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+.2byte    5,  -15, 	   9,   -9, 	  -8,   -7, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    9,  -16, 	   0,  -12, 	  -4,   -4, 	  -2,  -15
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte    8,  -21, 	 -10,  -14, 	  10,   -3, 	  -1,  -15
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    0,  -22, 	  11,   -5, 	 -12,   -6, 	   0,  -16
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -9,  -21, 	   9,  -14, 	 -11,   -3, 	   0,  -15
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -16, 	  -1,  -12, 	   3,   -4, 	   1,  -15
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte   -6,  -15, 	 -10,   -9, 	   7,   -7, 	  -1,  -14
+.2byte   -1,   -7, 	  -8,  -27, 	   7,  -27, 	   0,  -10
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte   -8,  -10, 	  -2,  -29, 	   8,  -26, 	   0,  -12
+.2byte  -13,  -12, 	   7,  -30, 	   7,  -23, 	  -1,  -14
+.2byte  -10,  -18, 	  10,  -29, 	  -5,  -20, 	   0,  -13
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,  -14
+.2byte    9,  -18, 	 -11,  -29, 	   4,  -20, 	  -1,  -13
+.2byte   12,  -12, 	  -8,  -30, 	  -8,  -23, 	   0,  -14
+.2byte    7,  -10, 	   1,  -29, 	  -9,  -26, 	  -1,  -12
+.2byte   -1,   -9, 	 -11,  -25, 	  11,  -26, 	   0,  -13
+.2byte   -6,  -13, 	  -3,  -30, 	  11,  -22, 	  -1,  -14
+.2byte  -10,  -15, 	   6,  -30, 	   9,  -19, 	   0,  -16
+.2byte   -8,  -18, 	  11,  -27, 	  -5,  -15, 	   0,  -14
+.2byte   -1,  -20, 	  13,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte    7,  -18, 	 -12,  -27, 	   4,  -15, 	  -1,  -14
+.2byte    9,  -15, 	  -7,  -30, 	 -10,  -19, 	  -1,  -16
+.2byte    5,  -13, 	   2,  -30, 	 -12,  -22, 	   0,  -14
+sAerodactylAnimTable1:
+.4byte sAerodactylAnims_1_1
+.4byte sAerodactylAnims_1_2
+.4byte sAerodactylAnims_1_3
+.4byte sAerodactylAnims_1_4
+.4byte sAerodactylAnims_1_5
+.4byte sAerodactylAnims_1_6
+.4byte sAerodactylAnims_1_7
+.4byte sAerodactylAnims_1_8
+sAerodactylAnimTable2:
+.4byte sAerodactylAnims_2_1
+.4byte sAerodactylAnims_2_2
+.4byte sAerodactylAnims_2_3
+.4byte sAerodactylAnims_2_4
+.4byte sAerodactylAnims_2_5
+.4byte sAerodactylAnims_2_6
+.4byte sAerodactylAnims_2_7
+.4byte sAerodactylAnims_2_8
+sAerodactylAnimTable3:
+.4byte sAerodactylAnims_3_1
+.4byte sAerodactylAnims_3_2
+.4byte sAerodactylAnims_3_3
+.4byte sAerodactylAnims_3_4
+.4byte sAerodactylAnims_3_5
+.4byte sAerodactylAnims_3_6
+.4byte sAerodactylAnims_3_7
+.4byte sAerodactylAnims_3_8
+sAerodactylAnimTable4:
+.4byte sAerodactylAnims_4_1
+.4byte sAerodactylAnims_4_2
+.4byte sAerodactylAnims_4_3
+.4byte sAerodactylAnims_4_4
+.4byte sAerodactylAnims_4_5
+.4byte sAerodactylAnims_4_6
+.4byte sAerodactylAnims_4_7
+.4byte sAerodactylAnims_4_8
+sAerodactylAnimTable5:
+.4byte sAerodactylAnims_5_1
+.4byte sAerodactylAnims_5_2
+.4byte sAerodactylAnims_5_3
+.4byte sAerodactylAnims_5_4
+.4byte sAerodactylAnims_5_5
+.4byte sAerodactylAnims_5_6
+.4byte sAerodactylAnims_5_7
+.4byte sAerodactylAnims_5_8
+sAerodactylAnimTable6:
+.4byte sAerodactylAnims_6_1
+.4byte sAerodactylAnims_6_1
+.4byte sAerodactylAnims_6_1
+.4byte sAerodactylAnims_6_1
+.4byte sAerodactylAnims_6_1
+.4byte sAerodactylAnims_6_1
+.4byte sAerodactylAnims_6_1
+.4byte sAerodactylAnims_6_1
+sAerodactylAnimTable7:
+.4byte sAerodactylAnims_7_1
+.4byte sAerodactylAnims_7_2
+.4byte sAerodactylAnims_7_3
+.4byte sAerodactylAnims_7_4
+.4byte sAerodactylAnims_7_5
+.4byte sAerodactylAnims_7_6
+.4byte sAerodactylAnims_7_7
+.4byte sAerodactylAnims_7_8
+sAerodactylAnimTable8:
+.4byte sAerodactylAnims_8_1
+.4byte sAerodactylAnims_8_2
+.4byte sAerodactylAnims_8_3
+.4byte sAerodactylAnims_8_4
+.4byte sAerodactylAnims_8_5
+.4byte sAerodactylAnims_8_6
+.4byte sAerodactylAnims_8_7
+.4byte sAerodactylAnims_8_8
+sAerodactylAnimTable9:
+.4byte sAerodactylAnims_9_1
+.4byte sAerodactylAnims_9_2
+.4byte sAerodactylAnims_9_3
+.4byte sAerodactylAnims_9_4
+.4byte sAerodactylAnims_9_5
+.4byte sAerodactylAnims_9_6
+.4byte sAerodactylAnims_9_7
+.4byte sAerodactylAnims_9_8
+sAerodactylAnimTable10:
+.4byte sAerodactylAnims_10_1
+.4byte sAerodactylAnims_10_2
+.4byte sAerodactylAnims_10_3
+.4byte sAerodactylAnims_10_4
+.4byte sAerodactylAnims_10_5
+.4byte sAerodactylAnims_10_6
+.4byte sAerodactylAnims_10_7
+.4byte sAerodactylAnims_10_8
+sAerodactylAnimTable11:
+.4byte sAerodactylAnims_11_1
+.4byte sAerodactylAnims_11_2
+.4byte sAerodactylAnims_11_3
+.4byte sAerodactylAnims_11_4
+.4byte sAerodactylAnims_11_5
+.4byte sAerodactylAnims_11_6
+.4byte sAerodactylAnims_11_7
+.4byte sAerodactylAnims_11_8
+sAerodactylAnimTable12:
+.4byte sAerodactylAnims_12_1
+.4byte sAerodactylAnims_12_2
+.4byte sAerodactylAnims_12_3
+.4byte sAerodactylAnims_12_4
+.4byte sAerodactylAnims_12_5
+.4byte sAerodactylAnims_12_6
+.4byte sAerodactylAnims_12_7
+.4byte sAerodactylAnims_12_8
+sAerodactylAnimTable13:
+.4byte sAerodactylAnims_13_1
+.4byte sAerodactylAnims_13_2
+.4byte sAerodactylAnims_13_3
+.4byte sAerodactylAnims_13_4
+.4byte sAerodactylAnims_13_5
+.4byte sAerodactylAnims_13_6
+.4byte sAerodactylAnims_13_7
+.4byte sAerodactylAnims_13_8
+sAxAnimationsAerodactyl:
+.4byte sAerodactylAnimTable1
+.4byte sAerodactylAnimTable2
+.4byte sAerodactylAnimTable3
+.4byte sAerodactylAnimTable4
+.4byte sAerodactylAnimTable5
+.4byte sAerodactylAnimTable6
+.4byte sAerodactylAnimTable7
+.4byte sAerodactylAnimTable8
+.4byte sAerodactylAnimTable9
+.4byte sAerodactylAnimTable10
+.4byte sAerodactylAnimTable11
+.4byte sAerodactylAnimTable12
+.4byte sAerodactylAnimTable13
+sAxSpritesAerodactyl:
+.4byte sAerodactylSprites1
+.4byte sAerodactylSprites2
+.4byte sAerodactylSprites3
+.4byte sAerodactylSprites4
+.4byte sAerodactylSprites5
+.4byte sAerodactylSprites6
+.4byte sAerodactylSprites7
+.4byte sAerodactylSprites8
+.4byte sAerodactylSprites9
+.4byte sAerodactylSprites10
+.4byte sAerodactylSprites11
+.4byte sAerodactylSprites12
+.4byte sAerodactylSprites13
+.4byte sAerodactylSprites14
+.4byte sAerodactylSprites15
+.4byte sAerodactylSprites16
+.4byte sAerodactylSprites17
+.4byte sAerodactylSprites18
+.4byte sAerodactylSprites19
+.4byte sAerodactylSprites20
+.4byte sAerodactylSprites21
+.4byte sAerodactylSprites22
+.4byte sAerodactylSprites23
+.4byte sAerodactylSprites24
+.4byte sAerodactylSprites25
+.4byte sAerodactylSprites26
+.4byte sAerodactylSprites27
+.4byte sAerodactylSprites28
+.4byte sAerodactylSprites29
+.4byte sAerodactylSprites30
+.4byte sAerodactylSprites31
+.4byte sAerodactylSprites32
+.4byte sAerodactylSprites33
+.4byte sAerodactylSprites34
+.4byte sAerodactylSprites35
+.4byte sAerodactylSprites36
+.4byte sAerodactylSprites37
+.4byte sAerodactylSprites38
+.4byte sAerodactylSprites39
+.4byte sAerodactylSprites40
+.4byte sAerodactylSprites41
+.4byte sAerodactylSprites42
+.4byte sAerodactylSprites43
+.4byte sAerodactylSprites44
+.4byte sAerodactylSprites45
+.4byte sAerodactylSprites46
+.4byte sAerodactylSprites47
+.4byte sAerodactylSprites48
+.4byte sAerodactylSprites49
+sAxMainAerodactyl:
+ax_main sAxPosesAerodactyl, sAxAnimationsAerodactyl, 13, sAxSpritesAerodactyl, sAxPositionsAerodactyl

--- a/data/ax/aggron.inc
+++ b/data/ax/aggron.inc
@@ -1,0 +1,2916 @@
+.global gAxAggron
+gAxAggron:
+ax_siro sAxMainAggron
+sAggronPose1:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose2:
+ax_pose 1, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose3:
+ax_pose 2, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose4:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose5:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose6:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose7:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose8:
+ax_pose 7, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose9:
+ax_pose 8, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose10:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose11:
+ax_pose 10, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose12:
+ax_pose 11, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose16:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose17:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose18:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose19:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose20:
+ax_pose 7, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose21:
+ax_pose 8, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose22:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose23:
+ax_pose 4, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose24:
+ax_pose 5, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose25:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose26:
+ax_pose 1, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose27:
+ax_pose 2, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose28:
+ax_pose 15, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose29:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose30:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose31:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose32:
+ax_pose 16, 0x41ee, 0x90f3, 0x5c00
+ax_pose 17, 0x41fe, 0x50f3, 0x5c08
+ax_pose 18, 0x01e6, 0x10f3, 0x5c0c
+ax_pose 19, 0x01e6, 0x10eb, 0x5c0d
+ax_pose 20, 0x01ee, 0x10eb, 0x5c0e
+ax_pose_terminator
+sAggronPose33:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose34:
+ax_pose 7, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose35:
+ax_pose 8, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose36:
+ax_pose 21, 0x41ec, 0x90f6, 0x5c00
+ax_pose 22, 0x41fc, 0x10f6, 0x5c08
+ax_pose 23, 0x01fc, 0x1106, 0x5c0a
+ax_pose 24, 0x41e4, 0x1106, 0x5c0b
+ax_pose 25, 0x41f4, 0x10e6, 0x5c0d
+ax_pose 26, 0x01fc, 0x10ee, 0x5c0f
+ax_pose_terminator
+sAggronPose37:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose38:
+ax_pose 10, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose39:
+ax_pose 11, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose40:
+ax_pose 27, 0x81e5, 0x9100, 0x5c00
+ax_pose 28, 0x81e5, 0x50f8, 0x5c08
+ax_pose 29, 0x81f5, 0x10f0, 0x5c0c
+ax_pose 30, 0x01fd, 0x10e8, 0x5c0e
+ax_pose_terminator
+sAggronPose41:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose42:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose43:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose44:
+ax_pose 31, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose45:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose46:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose47:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose48:
+ax_pose 27, 0x81e5, 0x80f1, 0x5c00
+ax_pose 28, 0x81e5, 0x4101, 0x5c08
+ax_pose 29, 0x81f5, 0x0109, 0x5c0c
+ax_pose 30, 0x01fd, 0x0111, 0x5c0e
+ax_pose_terminator
+sAggronPose49:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose50:
+ax_pose 7, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose51:
+ax_pose 8, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose52:
+ax_pose 21, 0x41ec, 0x80e9, 0x5c00
+ax_pose 22, 0x41fc, 0x00f9, 0x5c08
+ax_pose 23, 0x01fc, 0x00f1, 0x5c0a
+ax_pose 24, 0x41e4, 0x00e9, 0x5c0b
+ax_pose 25, 0x41f4, 0x0109, 0x5c0d
+ax_pose 26, 0x01fc, 0x0109, 0x5c0f
+ax_pose_terminator
+sAggronPose53:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose54:
+ax_pose 4, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose55:
+ax_pose 5, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose56:
+ax_pose 16, 0x41ee, 0x80ec, 0x5c00
+ax_pose 17, 0x41fe, 0x40ec, 0x5c08
+ax_pose 18, 0x01e6, 0x0104, 0x5c0c
+ax_pose 19, 0x01e6, 0x010c, 0x5c0d
+ax_pose 20, 0x01ee, 0x010c, 0x5c0e
+ax_pose_terminator
+sAggronPose57:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose58:
+ax_pose 1, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose59:
+ax_pose 2, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose60:
+ax_pose 15, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose61:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose62:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose63:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose64:
+ax_pose 16, 0x41ee, 0x90f3, 0x5c00
+ax_pose 17, 0x41fe, 0x50f3, 0x5c08
+ax_pose 18, 0x01e6, 0x10f3, 0x5c0c
+ax_pose 19, 0x01e6, 0x10eb, 0x5c0d
+ax_pose 20, 0x01ee, 0x10eb, 0x5c0e
+ax_pose_terminator
+sAggronPose65:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose66:
+ax_pose 7, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose67:
+ax_pose 8, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose68:
+ax_pose 21, 0x41ec, 0x90f6, 0x5c00
+ax_pose 22, 0x41fc, 0x10f6, 0x5c08
+ax_pose 23, 0x01fc, 0x1106, 0x5c0a
+ax_pose 24, 0x41e4, 0x1106, 0x5c0b
+ax_pose 25, 0x41f4, 0x10e6, 0x5c0d
+ax_pose 26, 0x01fc, 0x10ee, 0x5c0f
+ax_pose_terminator
+sAggronPose69:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose70:
+ax_pose 10, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose71:
+ax_pose 11, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose72:
+ax_pose 27, 0x81e5, 0x9100, 0x5c00
+ax_pose 28, 0x81e5, 0x50f8, 0x5c08
+ax_pose 29, 0x81f5, 0x10f0, 0x5c0c
+ax_pose 30, 0x01fd, 0x10e8, 0x5c0e
+ax_pose_terminator
+sAggronPose73:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose74:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose75:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose76:
+ax_pose 31, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose77:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose78:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose79:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose80:
+ax_pose 27, 0x81e5, 0x80f1, 0x5c00
+ax_pose 28, 0x81e5, 0x4101, 0x5c08
+ax_pose 29, 0x81f5, 0x0109, 0x5c0c
+ax_pose 30, 0x01fd, 0x0111, 0x5c0e
+ax_pose_terminator
+sAggronPose81:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose82:
+ax_pose 7, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose83:
+ax_pose 8, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose84:
+ax_pose 21, 0x41ec, 0x80e9, 0x5c00
+ax_pose 22, 0x41fc, 0x00f9, 0x5c08
+ax_pose 23, 0x01fc, 0x00f1, 0x5c0a
+ax_pose 24, 0x41e4, 0x00e9, 0x5c0b
+ax_pose 25, 0x41f4, 0x0109, 0x5c0d
+ax_pose 26, 0x01fc, 0x0109, 0x5c0f
+ax_pose_terminator
+sAggronPose85:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose86:
+ax_pose 4, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose87:
+ax_pose 5, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose88:
+ax_pose 16, 0x41ee, 0x80ec, 0x5c00
+ax_pose 17, 0x41fe, 0x40ec, 0x5c08
+ax_pose 18, 0x01e6, 0x0104, 0x5c0c
+ax_pose 19, 0x01e6, 0x010c, 0x5c0d
+ax_pose 20, 0x01ee, 0x010c, 0x5c0e
+ax_pose_terminator
+sAggronPose89:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose90:
+ax_pose 32, 0x01e6, 0x80ef, 0x5c00
+ax_pose 33, 0x41de, 0x00f7, 0x5c10
+ax_pose_terminator
+sAggronPose91:
+ax_pose 15, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose92:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose93:
+ax_pose 34, 0x01e6, 0x90f0, 0x5c00
+ax_pose 35, 0x41de, 0x10f8, 0x5c10
+ax_pose_terminator
+sAggronPose94:
+ax_pose 16, 0x41ee, 0x90f3, 0x5c00
+ax_pose 17, 0x41fe, 0x50f3, 0x5c08
+ax_pose 18, 0x01e6, 0x10f3, 0x5c0c
+ax_pose 19, 0x01e6, 0x10eb, 0x5c0d
+ax_pose 20, 0x01ee, 0x10eb, 0x5c0e
+ax_pose_terminator
+sAggronPose95:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose96:
+ax_pose 36, 0x01e4, 0x90f1, 0x5c00
+ax_pose 37, 0x41dc, 0x10f9, 0x5c10
+ax_pose_terminator
+sAggronPose97:
+ax_pose 21, 0x41ec, 0x90f6, 0x5c00
+ax_pose 22, 0x41fc, 0x10f6, 0x5c08
+ax_pose 23, 0x01fc, 0x1106, 0x5c0a
+ax_pose 24, 0x41e4, 0x1106, 0x5c0b
+ax_pose 25, 0x41f4, 0x10e6, 0x5c0d
+ax_pose 26, 0x01fc, 0x10ee, 0x5c0f
+ax_pose_terminator
+sAggronPose98:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose99:
+ax_pose 38, 0x01e5, 0x90f0, 0x5c00
+ax_pose 39, 0x41dd, 0x10f8, 0x5c10
+ax_pose_terminator
+sAggronPose100:
+ax_pose 27, 0x81e5, 0x9100, 0x5c00
+ax_pose 28, 0x81e5, 0x50f8, 0x5c08
+ax_pose 29, 0x81f5, 0x10f0, 0x5c0c
+ax_pose 30, 0x01fd, 0x10e8, 0x5c0e
+ax_pose_terminator
+sAggronPose101:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose102:
+ax_pose 40, 0x01e5, 0x80f0, 0x5c00
+ax_pose 41, 0x41dd, 0x00f8, 0x5c10
+ax_pose_terminator
+sAggronPose103:
+ax_pose 31, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose104:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose105:
+ax_pose 38, 0x01e5, 0x80f1, 0x5c00
+ax_pose 39, 0x41dd, 0x00f9, 0x5c10
+ax_pose_terminator
+sAggronPose106:
+ax_pose 27, 0x81e5, 0x80f1, 0x5c00
+ax_pose 28, 0x81e5, 0x4101, 0x5c08
+ax_pose 29, 0x81f5, 0x0109, 0x5c0c
+ax_pose 30, 0x01fd, 0x0111, 0x5c0e
+ax_pose_terminator
+sAggronPose107:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose108:
+ax_pose 36, 0x01e4, 0x80ee, 0x5c00
+ax_pose 37, 0x41dc, 0x00f6, 0x5c10
+ax_pose_terminator
+sAggronPose109:
+ax_pose 21, 0x41ec, 0x80e9, 0x5c00
+ax_pose 22, 0x41fc, 0x00f9, 0x5c08
+ax_pose 23, 0x01fc, 0x00f1, 0x5c0a
+ax_pose 24, 0x41e4, 0x00e9, 0x5c0b
+ax_pose 25, 0x41f4, 0x0109, 0x5c0d
+ax_pose 26, 0x01fc, 0x0109, 0x5c0f
+ax_pose_terminator
+sAggronPose110:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose111:
+ax_pose 34, 0x01e6, 0x80ef, 0x5c00
+ax_pose 35, 0x41de, 0x00f7, 0x5c10
+ax_pose_terminator
+sAggronPose112:
+ax_pose 16, 0x41ee, 0x80ec, 0x5c00
+ax_pose 17, 0x41fe, 0x40ec, 0x5c08
+ax_pose 18, 0x01e6, 0x0104, 0x5c0c
+ax_pose 19, 0x01e6, 0x010c, 0x5c0d
+ax_pose 20, 0x01ee, 0x010c, 0x5c0e
+ax_pose_terminator
+sAggronPose113:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose114:
+ax_pose 42, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose115:
+ax_pose 43, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose116:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose117:
+ax_pose 44, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose118:
+ax_pose 45, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose119:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose120:
+ax_pose 46, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose121:
+ax_pose 47, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose122:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose123:
+ax_pose 48, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose124:
+ax_pose 49, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose125:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose126:
+ax_pose 50, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose127:
+ax_pose 51, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose128:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose129:
+ax_pose 48, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose130:
+ax_pose 49, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose131:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose132:
+ax_pose 46, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose133:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose134:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose135:
+ax_pose 44, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose136:
+ax_pose 45, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose137:
+ax_pose 52, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose138:
+ax_pose 53, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose139:
+ax_pose 54, 0x01df, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose140:
+ax_pose 55, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sAggronPose141:
+ax_pose 56, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sAggronPose142:
+ax_pose 57, 0x81e5, 0x50ff, 0x5c00
+ax_pose 58, 0x81e5, 0x10e7, 0x5c04
+ax_pose 59, 0x81ed, 0x1107, 0x5c06
+ax_pose 60, 0x81e5, 0x90ef, 0x5c08
+ax_pose_terminator
+sAggronPose143:
+ax_pose 61, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose144:
+ax_pose 57, 0x81e5, 0x40f9, 0x5c00
+ax_pose 58, 0x81e5, 0x0111, 0x5c04
+ax_pose 59, 0x81ed, 0x00f1, 0x5c06
+ax_pose 60, 0x81e5, 0x8101, 0x5c08
+ax_pose_terminator
+sAggronPose145:
+ax_pose 56, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sAggronPose146:
+ax_pose 55, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose147:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose148:
+ax_pose 42, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose149:
+ax_pose 43, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose150:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose151:
+ax_pose 44, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose152:
+ax_pose 45, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose153:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose154:
+ax_pose 46, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose155:
+ax_pose 47, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose156:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose157:
+ax_pose 48, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose158:
+ax_pose 49, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose159:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose160:
+ax_pose 50, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose161:
+ax_pose 51, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose162:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose163:
+ax_pose 48, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose164:
+ax_pose 49, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose165:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose166:
+ax_pose 46, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose167:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose168:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose169:
+ax_pose 44, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose170:
+ax_pose 45, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose171:
+ax_pose 15, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose172:
+ax_pose 16, 0x41ee, 0x80ec, 0x5c00
+ax_pose 17, 0x41fe, 0x40ec, 0x5c08
+ax_pose 18, 0x01e6, 0x0104, 0x5c0c
+ax_pose 19, 0x01e6, 0x010c, 0x5c0d
+ax_pose 20, 0x01ee, 0x010c, 0x5c0e
+ax_pose_terminator
+sAggronPose173:
+ax_pose 21, 0x41ed, 0x80e9, 0x5c00
+ax_pose 22, 0x41fd, 0x00f9, 0x5c08
+ax_pose 23, 0x01fd, 0x00f1, 0x5c0a
+ax_pose 24, 0x41e5, 0x00e9, 0x5c0b
+ax_pose 25, 0x41f5, 0x0109, 0x5c0d
+ax_pose 26, 0x01fd, 0x0109, 0x5c0f
+ax_pose_terminator
+sAggronPose174:
+ax_pose 27, 0x81e5, 0x80f1, 0x5c00
+ax_pose 28, 0x81e5, 0x4101, 0x5c08
+ax_pose 29, 0x81f5, 0x0109, 0x5c0c
+ax_pose 30, 0x01fd, 0x0111, 0x5c0e
+ax_pose_terminator
+sAggronPose175:
+ax_pose 31, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose176:
+ax_pose 27, 0x81e5, 0x9100, 0x5c00
+ax_pose 28, 0x81e5, 0x50f8, 0x5c08
+ax_pose 29, 0x81f5, 0x10f0, 0x5c0c
+ax_pose 30, 0x01fd, 0x10e8, 0x5c0e
+ax_pose_terminator
+sAggronPose177:
+ax_pose 21, 0x41ed, 0x90f6, 0x5c00
+ax_pose 22, 0x41fd, 0x10f6, 0x5c08
+ax_pose 23, 0x01fd, 0x1106, 0x5c0a
+ax_pose 24, 0x41e5, 0x1106, 0x5c0b
+ax_pose 25, 0x41f5, 0x10e6, 0x5c0d
+ax_pose 26, 0x01fd, 0x10ee, 0x5c0f
+ax_pose_terminator
+sAggronPose178:
+ax_pose 16, 0x41ee, 0x90f3, 0x5c00
+ax_pose 17, 0x41fe, 0x50f3, 0x5c08
+ax_pose 18, 0x01e6, 0x10f3, 0x5c0c
+ax_pose 19, 0x01e6, 0x10eb, 0x5c0d
+ax_pose 20, 0x01ee, 0x10eb, 0x5c0e
+ax_pose_terminator
+sAggronPose179:
+ax_pose 15, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose180:
+ax_pose 16, 0x41ee, 0x90f3, 0x5c00
+ax_pose 17, 0x41fe, 0x50f3, 0x5c08
+ax_pose 18, 0x01e6, 0x10f3, 0x5c0c
+ax_pose 19, 0x01e6, 0x10eb, 0x5c0d
+ax_pose 20, 0x01ee, 0x10eb, 0x5c0e
+ax_pose_terminator
+sAggronPose181:
+ax_pose 21, 0x41ec, 0x90f6, 0x5c00
+ax_pose 22, 0x41fc, 0x10f6, 0x5c08
+ax_pose 23, 0x01fc, 0x1106, 0x5c0a
+ax_pose 24, 0x41e4, 0x1106, 0x5c0b
+ax_pose 25, 0x41f4, 0x10e6, 0x5c0d
+ax_pose 26, 0x01fc, 0x10ee, 0x5c0f
+ax_pose_terminator
+sAggronPose182:
+ax_pose 27, 0x81e5, 0x9100, 0x5c00
+ax_pose 28, 0x81e5, 0x50f8, 0x5c08
+ax_pose 29, 0x81f5, 0x10f0, 0x5c0c
+ax_pose 30, 0x01fd, 0x10e8, 0x5c0e
+ax_pose_terminator
+sAggronPose183:
+ax_pose 31, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose184:
+ax_pose 27, 0x81e5, 0x80f1, 0x5c00
+ax_pose 28, 0x81e5, 0x4101, 0x5c08
+ax_pose 29, 0x81f5, 0x0109, 0x5c0c
+ax_pose 30, 0x01fd, 0x0111, 0x5c0e
+ax_pose_terminator
+sAggronPose185:
+ax_pose 21, 0x41ec, 0x80e9, 0x5c00
+ax_pose 22, 0x41fc, 0x00f9, 0x5c08
+ax_pose 23, 0x01fc, 0x00f1, 0x5c0a
+ax_pose 24, 0x41e4, 0x00e9, 0x5c0b
+ax_pose 25, 0x41f4, 0x0109, 0x5c0d
+ax_pose 26, 0x01fc, 0x0109, 0x5c0f
+ax_pose_terminator
+sAggronPose186:
+ax_pose 16, 0x41ee, 0x80ec, 0x5c00
+ax_pose 17, 0x41fe, 0x40ec, 0x5c08
+ax_pose 18, 0x01e6, 0x0104, 0x5c0c
+ax_pose 19, 0x01e6, 0x010c, 0x5c0d
+ax_pose 20, 0x01ee, 0x010c, 0x5c0e
+ax_pose_terminator
+sAggronPose187:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose188:
+ax_pose 1, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose189:
+ax_pose 2, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose190:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose191:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose192:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose193:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose194:
+ax_pose 7, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose195:
+ax_pose 8, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose196:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose197:
+ax_pose 10, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose198:
+ax_pose 11, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose199:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose200:
+ax_pose 13, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose201:
+ax_pose 14, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose202:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose203:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose204:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose205:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose206:
+ax_pose 7, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose207:
+ax_pose 8, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose208:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose209:
+ax_pose 4, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose210:
+ax_pose 5, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose211:
+ax_pose 15, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose212:
+ax_pose 16, 0x41ee, 0x90f3, 0x5c00
+ax_pose 17, 0x41fe, 0x50f3, 0x5c08
+ax_pose 18, 0x01e6, 0x10f3, 0x5c0c
+ax_pose 19, 0x01e6, 0x10eb, 0x5c0d
+ax_pose 20, 0x01ee, 0x10eb, 0x5c0e
+ax_pose_terminator
+sAggronPose213:
+ax_pose 21, 0x41ec, 0x90f6, 0x5c00
+ax_pose 22, 0x41fc, 0x10f6, 0x5c08
+ax_pose 23, 0x01fc, 0x1106, 0x5c0a
+ax_pose 24, 0x41e4, 0x1106, 0x5c0b
+ax_pose 25, 0x41f4, 0x10e6, 0x5c0d
+ax_pose 26, 0x01fc, 0x10ee, 0x5c0f
+ax_pose_terminator
+sAggronPose214:
+ax_pose 27, 0x81e5, 0x9100, 0x5c00
+ax_pose 28, 0x81e5, 0x50f8, 0x5c08
+ax_pose 29, 0x81f5, 0x10f0, 0x5c0c
+ax_pose 30, 0x01fd, 0x10e8, 0x5c0e
+ax_pose_terminator
+sAggronPose215:
+ax_pose 31, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose216:
+ax_pose 27, 0x81e5, 0x80f1, 0x5c00
+ax_pose 28, 0x81e5, 0x4101, 0x5c08
+ax_pose 29, 0x81f5, 0x0109, 0x5c0c
+ax_pose 30, 0x01fd, 0x0111, 0x5c0e
+ax_pose_terminator
+sAggronPose217:
+ax_pose 21, 0x41ec, 0x80e9, 0x5c00
+ax_pose 22, 0x41fc, 0x00f9, 0x5c08
+ax_pose 23, 0x01fc, 0x00f1, 0x5c0a
+ax_pose 24, 0x41e4, 0x00e9, 0x5c0b
+ax_pose 25, 0x41f4, 0x0109, 0x5c0d
+ax_pose 26, 0x01fc, 0x0109, 0x5c0f
+ax_pose_terminator
+sAggronPose218:
+ax_pose 16, 0x41ee, 0x80ec, 0x5c00
+ax_pose 17, 0x41fe, 0x40ec, 0x5c08
+ax_pose 18, 0x01e6, 0x0104, 0x5c0c
+ax_pose 19, 0x01e6, 0x010c, 0x5c0d
+ax_pose 20, 0x01ee, 0x010c, 0x5c0e
+ax_pose_terminator
+sAggronPose219:
+ax_pose 0, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose220:
+ax_pose 3, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAggronPose221:
+ax_pose 6, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sAggronPose222:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAggronPose223:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAggronPose224:
+ax_pose 9, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAggronPose225:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAggronPose226:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sAggronAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sAggronAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 9, 11, 9, 11,
+ax_anim 2, 0, 31, 15, 17, 15, 17,
+ax_anim 2, 1, 31, 16, 16, 16, 16,
+ax_anim 2, 0, 31, 15, 17, 15, 17,
+ax_anim 2, 0, 31, 16, 16, 16, 16,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sAggronAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 8, 0, 8, 0,
+ax_anim 2, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 1, 35, 13, 1, 13, 1,
+ax_anim 2, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 0, 35, 13, 1, 13, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sAggronAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -1, 0, -1,
+ax_anim 1, 2, 38, 5, -6, 5, -6,
+ax_anim 1, 0, 37, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 16, -15, 16, -15,
+ax_anim 2, 1, 39, 17, -14, 17, -14,
+ax_anim 2, 0, 39, 16, -15, 16, -15,
+ax_anim 2, 0, 39, 17, -14, 17, -14,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sAggronAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 41, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 1, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sAggronAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -1, 0, -1,
+ax_anim 1, 2, 46, -5, -6, -5, -6,
+ax_anim 1, 0, 45, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -16, -15, -16, -15,
+ax_anim 2, 1, 47, -17, -14, -17, -14,
+ax_anim 2, 0, 47, -16, -15, -16, -15,
+ax_anim 2, 0, 47, -17, -14, -17, -14,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sAggronAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 49, -8, 0, -8, 0,
+ax_anim 2, 0, 51, -13, 0, -13, 0,
+ax_anim 2, 1, 51, -13, 1, -13, 1,
+ax_anim 2, 0, 51, -13, 0, -13, 0,
+ax_anim 2, 0, 51, -13, 1, -13, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sAggronAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 53, -9, 11, -9, 11,
+ax_anim 2, 0, 55, -15, 17, -15, 17,
+ax_anim 2, 1, 55, -16, 16, -16, 16,
+ax_anim 2, 0, 55, -15, 17, -15, 17,
+ax_anim 2, 0, 55, -16, 16, -16, 16,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sAggronAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sAggronAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 4, 4, 4, 4,
+ax_anim 1, 0, 61, 9, 11, 9, 11,
+ax_anim 2, 0, 63, 15, 17, 15, 17,
+ax_anim 2, 1, 63, 16, 16, 16, 16,
+ax_anim 2, 0, 63, 15, 17, 15, 17,
+ax_anim 2, 0, 63, 16, 16, 16, 16,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sAggronAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 4, 0, 4, 0,
+ax_anim 1, 0, 65, 8, 0, 8, 0,
+ax_anim 2, 0, 67, 13, 0, 13, 0,
+ax_anim 2, 1, 67, 13, 1, 13, 1,
+ax_anim 2, 0, 67, 13, 0, 13, 0,
+ax_anim 2, 0, 67, 13, 1, 13, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sAggronAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -1, 0, -1,
+ax_anim 1, 2, 70, 5, -6, 5, -6,
+ax_anim 1, 0, 69, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 16, -15, 16, -15,
+ax_anim 2, 1, 71, 17, -14, 17, -14,
+ax_anim 2, 0, 71, 16, -15, 16, -15,
+ax_anim 2, 0, 71, 17, -14, 17, -14,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sAggronAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, -4, 0, -4,
+ax_anim 1, 0, 73, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 1, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 0, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sAggronAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -1, 0, -1,
+ax_anim 1, 2, 78, -5, -6, -5, -6,
+ax_anim 1, 0, 77, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -16, -15, -16, -15,
+ax_anim 2, 1, 79, -17, -14, -17, -14,
+ax_anim 2, 0, 79, -16, -15, -16, -15,
+ax_anim 2, 0, 79, -17, -14, -17, -14,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sAggronAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 81, -8, 0, -8, 0,
+ax_anim 2, 0, 83, -13, 0, -13, 0,
+ax_anim 2, 1, 83, -13, 1, -13, 1,
+ax_anim 2, 0, 83, -13, 0, -13, 0,
+ax_anim 2, 0, 83, -13, 1, -13, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sAggronAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 86, -4, 4, -4, 4,
+ax_anim 1, 0, 85, -9, 11, -9, 11,
+ax_anim 2, 0, 87, -15, 17, -15, 17,
+ax_anim 2, 1, 87, -16, 16, -16, 16,
+ax_anim 2, 0, 87, -15, 17, -15, 17,
+ax_anim 2, 0, 87, -16, 16, -16, 16,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sAggronAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 1, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sAggronAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 1, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sAggronAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 1, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sAggronAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 1, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sAggronAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 1, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sAggronAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 1, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sAggronAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 1, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sAggronAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 1, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sAggronAnims_5_1:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_5_2:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_5_3:
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_5_4:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 2, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_5_5:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_5_6:
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_5_7:
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_5_8:
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sAggronAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sAggronAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sAggronAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sAggronAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sAggronAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sAggronAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sAggronAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sAggronAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 11, 9, 11, 9,
+ax_anim 2, 0, 173, 7, 15, 7, 15,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -7, 15, -7, 15,
+ax_anim 2, 0, 176, -11, 9, -11, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 2, 8, 2,
+ax_anim 2, 0, 171, 14, 5, 14, 5,
+ax_anim 2, 0, 172, 17, 12, 17, 12,
+ax_anim 3, 0, 173, 11, 19, 11, 19,
+ax_anim 2, 3, 174, 6, 17, 6, 17,
+ax_anim 2, 0, 175, 2, 14, 2, 14,
+ax_anim 1, 0, 176, -4, 7, -4, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 1, -3, 1, -3,
+ax_anim 2, 0, 170, 6, -5, 6, -5,
+ax_anim 2, 0, 171, 10, -4, 10, -4,
+ax_anim 3, 0, 172, 12, 0, 12, 0,
+ax_anim 2, 3, 173, 8, 3, 8, 3,
+ax_anim 2, 0, 174, 5, 3, 5, 3,
+ax_anim 1, 0, 175, 3, 3, 3, 3,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -18, 12, -18,
+ax_anim 3, 0, 171, 17, -17, 17, -17,
+ax_anim 2, 3, 172, 18, -12, 18, -12,
+ax_anim 2, 0, 173, 13, -6, 13, -6,
+ax_anim 1, 0, 174, 8, -2, 8, -2,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -2, -8, -2,
+ax_anim 2, 0, 176, -13, -8, -13, -8,
+ax_anim 2, 0, 177, -8, -15, -8, -15,
+ax_anim 3, 0, 170, 0, -17, 0, -17,
+ax_anim 2, 3, 171, 8, -15, 8, -15,
+ax_anim 2, 0, 172, 13, -8, 13, -8,
+ax_anim 1, 0, 173, 8, -2, 8, -2,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -18, -12, -18,
+ax_anim 3, 0, 177, -17, -17, -17, -17,
+ax_anim 2, 3, 176, -18, -12, -18, -12,
+ax_anim 2, 0, 175, -13, -6, -13, -6,
+ax_anim 1, 0, 174, -8, -2, -8, -2,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -1, -3, -1, -3,
+ax_anim 2, 0, 170, -6, -5, -6, -5,
+ax_anim 2, 0, 177, -10, -4, -10, -4,
+ax_anim 3, 0, 176, -12, 0, -12, 0,
+ax_anim 2, 3, 175, -8, 3, -8, 3,
+ax_anim 2, 0, 174, -5, 3, -5, 3,
+ax_anim 1, 0, 173, -3, 3, -3, 3,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 2, -8, 2,
+ax_anim 2, 0, 177, -14, 5, -14, 5,
+ax_anim 2, 0, 176, -17, 12, -17, 12,
+ax_anim 3, 0, 175, -11, 19, -11, 19,
+ax_anim 2, 3, 174, -6, 17, -6, 17,
+ax_anim 2, 0, 173, -2, 14, -2, 14,
+ax_anim 1, 0, 172, 4, 7, 4, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -9, 0, 0,
+ax_anim 2, 0, 196, 0, -15, 0, 0,
+ax_anim 3, 0, 196, 0, -19, 0, 0,
+ax_anim 4, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -9, 0, 0,
+ax_anim 2, 0, 202, 0, -15, 0, 0,
+ax_anim 3, 0, 202, 0, -19, 0, 0,
+ax_anim 4, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -22, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_12_2:
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_12_3:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_12_4:
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_12_6:
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_12_7:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_12_8:
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAggronAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sAggronGfx1:
+.incbin "baserom.gba", 0x1272EBC, 0x200
+sAggronSprites1:
+ax_sprite sAggronGfx1, 0x200
+ax_sprite_terminator
+sAggronGfx2:
+.incbin "baserom.gba", 0x12730CC, 0x200
+sAggronSprites2:
+ax_sprite sAggronGfx2, 0x200
+ax_sprite_terminator
+sAggronGfx3:
+.incbin "baserom.gba", 0x12732DC, 0x200
+sAggronSprites3:
+ax_sprite sAggronGfx3, 0x200
+ax_sprite_terminator
+sAggronGfx4:
+.incbin "baserom.gba", 0x12734EC, 0x200
+sAggronSprites4:
+ax_sprite sAggronGfx4, 0x200
+ax_sprite_terminator
+sAggronGfx5:
+.incbin "baserom.gba", 0x12736FC, 0x200
+sAggronSprites5:
+ax_sprite sAggronGfx5, 0x200
+ax_sprite_terminator
+sAggronGfx6:
+.incbin "baserom.gba", 0x127390C, 0x200
+sAggronSprites6:
+ax_sprite sAggronGfx6, 0x200
+ax_sprite_terminator
+sAggronGfx7:
+.incbin "baserom.gba", 0x1273B1C, 0x200
+sAggronSprites7:
+ax_sprite sAggronGfx7, 0x200
+ax_sprite_terminator
+sAggronGfx8:
+.incbin "baserom.gba", 0x1273D2C, 0x200
+sAggronSprites8:
+ax_sprite sAggronGfx8, 0x200
+ax_sprite_terminator
+sAggronGfx9:
+.incbin "baserom.gba", 0x1273F3C, 0x200
+sAggronSprites9:
+ax_sprite sAggronGfx9, 0x200
+ax_sprite_terminator
+sAggronGfx10:
+.incbin "baserom.gba", 0x127414C, 0x200
+sAggronSprites10:
+ax_sprite sAggronGfx10, 0x200
+ax_sprite_terminator
+sAggronGfx11:
+.incbin "baserom.gba", 0x127435C, 0x200
+sAggronSprites11:
+ax_sprite sAggronGfx11, 0x200
+ax_sprite_terminator
+sAggronGfx12:
+.incbin "baserom.gba", 0x127456C, 0x200
+sAggronSprites12:
+ax_sprite sAggronGfx12, 0x200
+ax_sprite_terminator
+sAggronGfx13:
+.incbin "baserom.gba", 0x127477C, 0x200
+sAggronSprites13:
+ax_sprite sAggronGfx13, 0x200
+ax_sprite_terminator
+sAggronGfx14:
+.incbin "baserom.gba", 0x127498C, 0x200
+sAggronSprites14:
+ax_sprite sAggronGfx14, 0x200
+ax_sprite_terminator
+sAggronGfx15:
+.incbin "baserom.gba", 0x1274B9C, 0x200
+sAggronSprites15:
+ax_sprite sAggronGfx15, 0x200
+ax_sprite_terminator
+sAggronGfx16:
+.incbin "baserom.gba", 0x1274DAC, 0x40
+sAggronGfx16_1:
+.incbin "baserom.gba", 0x1274DEC, 0x180
+sAggronSprites16:
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx16_1, 0x180
+ax_sprite_terminator
+sAggronGfx17:
+.incbin "baserom.gba", 0x1274F94, 0x100
+sAggronSprites17:
+ax_sprite sAggronGfx17, 0x100
+ax_sprite_terminator
+sAggronGfx18:
+.incbin "baserom.gba", 0x12750A4, 0x80
+sAggronSprites18:
+ax_sprite sAggronGfx18, 0x80
+ax_sprite_terminator
+sAggronGfx19:
+.incbin "baserom.gba", 0x1275134, 0x20
+sAggronSprites19:
+ax_sprite sAggronGfx19, 0x20
+ax_sprite_terminator
+sAggronGfx20:
+.incbin "baserom.gba", 0x1275164, 0x20
+sAggronSprites20:
+ax_sprite sAggronGfx20, 0x20
+ax_sprite_terminator
+sAggronGfx21:
+.incbin "baserom.gba", 0x1275194, 0x20
+sAggronSprites21:
+ax_sprite sAggronGfx21, 0x20
+ax_sprite_terminator
+sAggronGfx22:
+.incbin "baserom.gba", 0x12751C4, 0x100
+sAggronSprites22:
+ax_sprite sAggronGfx22, 0x100
+ax_sprite_terminator
+sAggronGfx23:
+.incbin "baserom.gba", 0x12752D4, 0x40
+sAggronSprites23:
+ax_sprite sAggronGfx23, 0x40
+ax_sprite_terminator
+sAggronGfx24:
+.incbin "baserom.gba", 0x1275324, 0x20
+sAggronSprites24:
+ax_sprite sAggronGfx24, 0x20
+ax_sprite_terminator
+sAggronGfx25:
+.incbin "baserom.gba", 0x1275354, 0x40
+sAggronSprites25:
+ax_sprite sAggronGfx25, 0x40
+ax_sprite_terminator
+sAggronGfx26:
+.incbin "baserom.gba", 0x12753A4, 0x40
+sAggronSprites26:
+ax_sprite sAggronGfx26, 0x40
+ax_sprite_terminator
+sAggronGfx27:
+.incbin "baserom.gba", 0x12753F4, 0x20
+sAggronSprites27:
+ax_sprite sAggronGfx27, 0x20
+ax_sprite_terminator
+sAggronGfx28:
+.incbin "baserom.gba", 0x1275424, 0x100
+sAggronSprites28:
+ax_sprite sAggronGfx28, 0x100
+ax_sprite_terminator
+sAggronGfx29:
+.incbin "baserom.gba", 0x1275534, 0x80
+sAggronSprites29:
+ax_sprite sAggronGfx29, 0x80
+ax_sprite_terminator
+sAggronGfx30:
+.incbin "baserom.gba", 0x12755C4, 0x40
+sAggronSprites30:
+ax_sprite sAggronGfx30, 0x40
+ax_sprite_terminator
+sAggronGfx31:
+.incbin "baserom.gba", 0x1275614, 0x20
+sAggronSprites31:
+ax_sprite sAggronGfx31, 0x20
+ax_sprite_terminator
+sAggronGfx32:
+.incbin "baserom.gba", 0x1275644, 0x40
+sAggronGfx32_1:
+.incbin "baserom.gba", 0x1275684, 0x180
+sAggronSprites32:
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx32_1, 0x180
+ax_sprite_terminator
+sAggronGfx33:
+.incbin "baserom.gba", 0x127582C, 0x200
+sAggronSprites33:
+ax_sprite sAggronGfx33, 0x200
+ax_sprite_terminator
+sAggronGfx34:
+.incbin "baserom.gba", 0x1275A3C, 0x40
+sAggronSprites34:
+ax_sprite sAggronGfx34, 0x40
+ax_sprite_terminator
+sAggronGfx35:
+.incbin "baserom.gba", 0x1275A8C, 0x200
+sAggronSprites35:
+ax_sprite sAggronGfx35, 0x200
+ax_sprite_terminator
+sAggronGfx36:
+.incbin "baserom.gba", 0x1275C9C, 0x40
+sAggronSprites36:
+ax_sprite sAggronGfx36, 0x40
+ax_sprite_terminator
+sAggronGfx37:
+.incbin "baserom.gba", 0x1275CEC, 0x60
+sAggronGfx37_1:
+.incbin "baserom.gba", 0x1275D4C, 0x100
+sAggronGfx37_2:
+.incbin "baserom.gba", 0x1275E4C, 0x60
+sAggronSprites37:
+ax_sprite sAggronGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx37_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx37_2, 0x60
+ax_sprite_terminator
+sAggronGfx38:
+.incbin "baserom.gba", 0x1275EDC, 0x40
+sAggronSprites38:
+ax_sprite sAggronGfx38, 0x40
+ax_sprite_terminator
+sAggronGfx39:
+.incbin "baserom.gba", 0x1275F2C, 0x40
+sAggronGfx39_1:
+.incbin "baserom.gba", 0x1275F6C, 0x40
+sAggronGfx39_2:
+.incbin "baserom.gba", 0x1275FAC, 0x100
+sAggronSprites39:
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAggronGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx39_2, 0x100
+ax_sprite_terminator
+sAggronGfx40:
+.incbin "baserom.gba", 0x12760E4, 0x40
+sAggronSprites40:
+ax_sprite sAggronGfx40, 0x40
+ax_sprite_terminator
+sAggronGfx41:
+.incbin "baserom.gba", 0x1276134, 0x1E0
+sAggronSprites41:
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx41, 0x1e0
+ax_sprite_terminator
+sAggronGfx42:
+.incbin "baserom.gba", 0x127632C, 0x40
+sAggronSprites42:
+ax_sprite sAggronGfx42, 0x40
+ax_sprite_terminator
+sAggronGfx43:
+.incbin "baserom.gba", 0x127637C, 0x200
+sAggronSprites43:
+ax_sprite sAggronGfx43, 0x200
+ax_sprite_terminator
+sAggronGfx44:
+.incbin "baserom.gba", 0x127658C, 0x200
+sAggronSprites44:
+ax_sprite sAggronGfx44, 0x200
+ax_sprite_terminator
+sAggronGfx45:
+.incbin "baserom.gba", 0x127679C, 0x200
+sAggronSprites45:
+ax_sprite sAggronGfx45, 0x200
+ax_sprite_terminator
+sAggronGfx46:
+.incbin "baserom.gba", 0x12769AC, 0x60
+sAggronGfx46_1:
+.incbin "baserom.gba", 0x1276A0C, 0x180
+sAggronSprites46:
+ax_sprite sAggronGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx46_1, 0x180
+ax_sprite_terminator
+sAggronGfx47:
+.incbin "baserom.gba", 0x1276BAC, 0x60
+sAggronGfx47_1:
+.incbin "baserom.gba", 0x1276C0C, 0x180
+sAggronSprites47:
+ax_sprite sAggronGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx47_1, 0x180
+ax_sprite_terminator
+sAggronGfx48:
+.incbin "baserom.gba", 0x1276DAC, 0x60
+sAggronGfx48_1:
+.incbin "baserom.gba", 0x1276E0C, 0x100
+sAggronGfx48_2:
+.incbin "baserom.gba", 0x1276F0C, 0x60
+sAggronSprites48:
+ax_sprite sAggronGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx48_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx48_2, 0x60
+ax_sprite_terminator
+sAggronGfx49:
+.incbin "baserom.gba", 0x1276F9C, 0x60
+sAggronGfx49_1:
+.incbin "baserom.gba", 0x1276FFC, 0x180
+sAggronSprites49:
+ax_sprite sAggronGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx49_1, 0x180
+ax_sprite_terminator
+sAggronGfx50:
+.incbin "baserom.gba", 0x127719C, 0x60
+sAggronGfx50_1:
+.incbin "baserom.gba", 0x12771FC, 0x180
+sAggronSprites50:
+ax_sprite sAggronGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAggronGfx50_1, 0x180
+ax_sprite_terminator
+sAggronGfx51:
+.incbin "baserom.gba", 0x127739C, 0x200
+sAggronSprites51:
+ax_sprite sAggronGfx51, 0x200
+ax_sprite_terminator
+sAggronGfx52:
+.incbin "baserom.gba", 0x12775AC, 0x200
+sAggronSprites52:
+ax_sprite sAggronGfx52, 0x200
+ax_sprite_terminator
+sAggronGfx53:
+.incbin "baserom.gba", 0x12777BC, 0x200
+sAggronSprites53:
+ax_sprite sAggronGfx53, 0x200
+ax_sprite_terminator
+sAggronGfx54:
+.incbin "baserom.gba", 0x12779CC, 0x200
+sAggronSprites54:
+ax_sprite sAggronGfx54, 0x200
+ax_sprite_terminator
+sAggronGfx55:
+.incbin "baserom.gba", 0x1277BDC, 0x200
+sAggronSprites55:
+ax_sprite sAggronGfx55, 0x200
+ax_sprite_terminator
+sAggronGfx56:
+.incbin "baserom.gba", 0x1277DEC, 0x200
+sAggronSprites56:
+ax_sprite sAggronGfx56, 0x200
+ax_sprite_terminator
+sAggronGfx57:
+.incbin "baserom.gba", 0x1277FFC, 0x200
+sAggronSprites57:
+ax_sprite sAggronGfx57, 0x200
+ax_sprite_terminator
+sAggronGfx58:
+.incbin "baserom.gba", 0x127820C, 0x80
+sAggronSprites58:
+ax_sprite sAggronGfx58, 0x80
+ax_sprite_terminator
+sAggronGfx59:
+.incbin "baserom.gba", 0x127829C, 0x40
+sAggronSprites59:
+ax_sprite sAggronGfx59, 0x40
+ax_sprite_terminator
+sAggronGfx60:
+.incbin "baserom.gba", 0x12782EC, 0x40
+sAggronSprites60:
+ax_sprite sAggronGfx60, 0x40
+ax_sprite_terminator
+sAggronGfx61:
+.incbin "baserom.gba", 0x127833C, 0x100
+sAggronSprites61:
+ax_sprite sAggronGfx61, 0x100
+ax_sprite_terminator
+sAggronGfx62:
+.incbin "baserom.gba", 0x127844C, 0x200
+sAggronSprites62:
+ax_sprite sAggronGfx62, 0x200
+ax_sprite_terminator
+sAxPosesAggron:
+.4byte sAggronPose1
+.4byte sAggronPose2
+.4byte sAggronPose3
+.4byte sAggronPose4
+.4byte sAggronPose5
+.4byte sAggronPose6
+.4byte sAggronPose7
+.4byte sAggronPose8
+.4byte sAggronPose9
+.4byte sAggronPose10
+.4byte sAggronPose11
+.4byte sAggronPose12
+.4byte sAggronPose13
+.4byte sAggronPose14
+.4byte sAggronPose15
+.4byte sAggronPose16
+.4byte sAggronPose17
+.4byte sAggronPose18
+.4byte sAggronPose19
+.4byte sAggronPose20
+.4byte sAggronPose21
+.4byte sAggronPose22
+.4byte sAggronPose23
+.4byte sAggronPose24
+.4byte sAggronPose25
+.4byte sAggronPose26
+.4byte sAggronPose27
+.4byte sAggronPose28
+.4byte sAggronPose29
+.4byte sAggronPose30
+.4byte sAggronPose31
+.4byte sAggronPose32
+.4byte sAggronPose33
+.4byte sAggronPose34
+.4byte sAggronPose35
+.4byte sAggronPose36
+.4byte sAggronPose37
+.4byte sAggronPose38
+.4byte sAggronPose39
+.4byte sAggronPose40
+.4byte sAggronPose41
+.4byte sAggronPose42
+.4byte sAggronPose43
+.4byte sAggronPose44
+.4byte sAggronPose45
+.4byte sAggronPose46
+.4byte sAggronPose47
+.4byte sAggronPose48
+.4byte sAggronPose49
+.4byte sAggronPose50
+.4byte sAggronPose51
+.4byte sAggronPose52
+.4byte sAggronPose53
+.4byte sAggronPose54
+.4byte sAggronPose55
+.4byte sAggronPose56
+.4byte sAggronPose57
+.4byte sAggronPose58
+.4byte sAggronPose59
+.4byte sAggronPose60
+.4byte sAggronPose61
+.4byte sAggronPose62
+.4byte sAggronPose63
+.4byte sAggronPose64
+.4byte sAggronPose65
+.4byte sAggronPose66
+.4byte sAggronPose67
+.4byte sAggronPose68
+.4byte sAggronPose69
+.4byte sAggronPose70
+.4byte sAggronPose71
+.4byte sAggronPose72
+.4byte sAggronPose73
+.4byte sAggronPose74
+.4byte sAggronPose75
+.4byte sAggronPose76
+.4byte sAggronPose77
+.4byte sAggronPose78
+.4byte sAggronPose79
+.4byte sAggronPose80
+.4byte sAggronPose81
+.4byte sAggronPose82
+.4byte sAggronPose83
+.4byte sAggronPose84
+.4byte sAggronPose85
+.4byte sAggronPose86
+.4byte sAggronPose87
+.4byte sAggronPose88
+.4byte sAggronPose89
+.4byte sAggronPose90
+.4byte sAggronPose91
+.4byte sAggronPose92
+.4byte sAggronPose93
+.4byte sAggronPose94
+.4byte sAggronPose95
+.4byte sAggronPose96
+.4byte sAggronPose97
+.4byte sAggronPose98
+.4byte sAggronPose99
+.4byte sAggronPose100
+.4byte sAggronPose101
+.4byte sAggronPose102
+.4byte sAggronPose103
+.4byte sAggronPose104
+.4byte sAggronPose105
+.4byte sAggronPose106
+.4byte sAggronPose107
+.4byte sAggronPose108
+.4byte sAggronPose109
+.4byte sAggronPose110
+.4byte sAggronPose111
+.4byte sAggronPose112
+.4byte sAggronPose113
+.4byte sAggronPose114
+.4byte sAggronPose115
+.4byte sAggronPose116
+.4byte sAggronPose117
+.4byte sAggronPose118
+.4byte sAggronPose119
+.4byte sAggronPose120
+.4byte sAggronPose121
+.4byte sAggronPose122
+.4byte sAggronPose123
+.4byte sAggronPose124
+.4byte sAggronPose125
+.4byte sAggronPose126
+.4byte sAggronPose127
+.4byte sAggronPose128
+.4byte sAggronPose129
+.4byte sAggronPose130
+.4byte sAggronPose131
+.4byte sAggronPose132
+.4byte sAggronPose133
+.4byte sAggronPose134
+.4byte sAggronPose135
+.4byte sAggronPose136
+.4byte sAggronPose137
+.4byte sAggronPose138
+.4byte sAggronPose139
+.4byte sAggronPose140
+.4byte sAggronPose141
+.4byte sAggronPose142
+.4byte sAggronPose143
+.4byte sAggronPose144
+.4byte sAggronPose145
+.4byte sAggronPose146
+.4byte sAggronPose147
+.4byte sAggronPose148
+.4byte sAggronPose149
+.4byte sAggronPose150
+.4byte sAggronPose151
+.4byte sAggronPose152
+.4byte sAggronPose153
+.4byte sAggronPose154
+.4byte sAggronPose155
+.4byte sAggronPose156
+.4byte sAggronPose157
+.4byte sAggronPose158
+.4byte sAggronPose159
+.4byte sAggronPose160
+.4byte sAggronPose161
+.4byte sAggronPose162
+.4byte sAggronPose163
+.4byte sAggronPose164
+.4byte sAggronPose165
+.4byte sAggronPose166
+.4byte sAggronPose167
+.4byte sAggronPose168
+.4byte sAggronPose169
+.4byte sAggronPose170
+.4byte sAggronPose171
+.4byte sAggronPose172
+.4byte sAggronPose173
+.4byte sAggronPose174
+.4byte sAggronPose175
+.4byte sAggronPose176
+.4byte sAggronPose177
+.4byte sAggronPose178
+.4byte sAggronPose179
+.4byte sAggronPose180
+.4byte sAggronPose181
+.4byte sAggronPose182
+.4byte sAggronPose183
+.4byte sAggronPose184
+.4byte sAggronPose185
+.4byte sAggronPose186
+.4byte sAggronPose187
+.4byte sAggronPose188
+.4byte sAggronPose189
+.4byte sAggronPose190
+.4byte sAggronPose191
+.4byte sAggronPose192
+.4byte sAggronPose193
+.4byte sAggronPose194
+.4byte sAggronPose195
+.4byte sAggronPose196
+.4byte sAggronPose197
+.4byte sAggronPose198
+.4byte sAggronPose199
+.4byte sAggronPose200
+.4byte sAggronPose201
+.4byte sAggronPose202
+.4byte sAggronPose203
+.4byte sAggronPose204
+.4byte sAggronPose205
+.4byte sAggronPose206
+.4byte sAggronPose207
+.4byte sAggronPose208
+.4byte sAggronPose209
+.4byte sAggronPose210
+.4byte sAggronPose211
+.4byte sAggronPose212
+.4byte sAggronPose213
+.4byte sAggronPose214
+.4byte sAggronPose215
+.4byte sAggronPose216
+.4byte sAggronPose217
+.4byte sAggronPose218
+.4byte sAggronPose219
+.4byte sAggronPose220
+.4byte sAggronPose221
+.4byte sAggronPose222
+.4byte sAggronPose223
+.4byte sAggronPose224
+.4byte sAggronPose225
+.4byte sAggronPose226
+sAxPositionsAggron:
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte   -2,  -12, 	  -8,   -4, 	  12,   -9, 	  -2,   -9
+.2byte    0,  -12, 	 -14,   -9, 	   6,   -5, 	   0,   -9
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    7,  -15, 	  10,   -8, 	  -8,   -8, 	   0,  -11
+.2byte    6,  -14, 	   8,  -11, 	   0,   -5, 	  -1,  -10
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -15, 	   8,   -9, 	   3,   -7, 	  -1,  -13
+.2byte    8,  -14, 	   0,   -9, 	   9,   -7, 	   0,  -11
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte    8,  -18, 	   3,  -15, 	  12,   -8, 	   0,  -13
+.2byte   10,  -18, 	  -3,  -14, 	  13,  -12, 	   2,  -13
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte    0,  -19, 	  10,  -14, 	 -11,  -11, 	   0,  -11
+.2byte   -2,  -19, 	  10,  -11, 	 -12,  -14, 	  -2,  -11
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte   -8,  -18, 	  -3,  -15, 	 -12,   -8, 	   0,  -13
+.2byte  -10,  -18, 	   3,  -14, 	 -13,  -12, 	  -2,  -13
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte  -11,  -15, 	 -10,   -9, 	  -5,   -7, 	  -1,  -13
+.2byte  -10,  -14, 	  -2,   -9, 	 -11,   -7, 	  -2,  -11
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte   -9,  -15, 	 -12,   -8, 	   6,   -8, 	  -2,  -11
+.2byte   -8,  -14, 	 -10,  -11, 	  -2,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte   -2,  -12, 	  -8,   -4, 	  12,   -9, 	  -2,   -9
+.2byte    0,  -12, 	 -14,   -9, 	   6,   -5, 	   0,   -9
+.2byte   -1,   -3, 	 -13,   -1, 	  11,   -2, 	  -1,  -10
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    7,  -15, 	  10,   -8, 	  -8,   -8, 	   0,  -11
+.2byte    6,  -14, 	   8,  -11, 	   0,   -5, 	  -1,  -10
+.2byte    9,   -5, 	  16,   -3, 	  -6,    1, 	  -1,  -10
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -15, 	   8,   -9, 	   3,   -7, 	  -1,  -13
+.2byte    8,  -14, 	   0,   -9, 	   9,   -7, 	   0,  -11
+.2byte   13,  -11, 	   9,  -12, 	   8,   -4, 	   1,  -10
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte    8,  -18, 	   3,  -15, 	  12,   -8, 	   0,  -13
+.2byte   10,  -18, 	  -3,  -14, 	  13,  -12, 	   2,  -13
+.2byte    9,  -17, 	   3,  -11, 	  13,   -5, 	  -1,  -12
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte    0,  -19, 	  10,  -14, 	 -11,  -11, 	   0,  -11
+.2byte   -2,  -19, 	  10,  -11, 	 -12,  -14, 	  -2,  -11
+.2byte   -1,  -19, 	  11,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte   -8,  -18, 	  -3,  -15, 	 -12,   -8, 	   0,  -13
+.2byte  -10,  -18, 	   3,  -14, 	 -13,  -12, 	  -2,  -13
+.2byte   -9,  -17, 	  -3,  -11, 	 -13,   -5, 	   1,  -12
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte  -11,  -15, 	 -10,   -9, 	  -5,   -7, 	  -1,  -13
+.2byte  -10,  -14, 	  -2,   -9, 	 -11,   -7, 	  -2,  -11
+.2byte  -15,  -11, 	 -11,  -12, 	 -10,   -4, 	  -3,  -10
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte   -9,  -15, 	 -12,   -8, 	   6,   -8, 	  -2,  -11
+.2byte   -8,  -14, 	 -10,  -11, 	  -2,   -5, 	  -1,  -10
+.2byte  -11,   -5, 	 -18,   -3, 	   4,    1, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte   -2,  -12, 	  -8,   -4, 	  12,   -9, 	  -2,   -9
+.2byte    0,  -12, 	 -14,   -9, 	   6,   -5, 	   0,   -9
+.2byte   -1,   -3, 	 -13,   -1, 	  11,   -2, 	  -1,  -10
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    7,  -15, 	  10,   -8, 	  -8,   -8, 	   0,  -11
+.2byte    6,  -14, 	   8,  -11, 	   0,   -5, 	  -1,  -10
+.2byte    9,   -5, 	  16,   -3, 	  -6,    1, 	  -1,  -10
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -15, 	   8,   -9, 	   3,   -7, 	  -1,  -13
+.2byte    8,  -14, 	   0,   -9, 	   9,   -7, 	   0,  -11
+.2byte   13,  -11, 	   9,  -12, 	   8,   -4, 	   1,  -10
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte    8,  -18, 	   3,  -15, 	  12,   -8, 	   0,  -13
+.2byte   10,  -18, 	  -3,  -14, 	  13,  -12, 	   2,  -13
+.2byte    9,  -17, 	   3,  -11, 	  13,   -5, 	  -1,  -12
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte    0,  -19, 	  10,  -14, 	 -11,  -11, 	   0,  -11
+.2byte   -2,  -19, 	  10,  -11, 	 -12,  -14, 	  -2,  -11
+.2byte   -1,  -19, 	  11,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte   -8,  -18, 	  -3,  -15, 	 -12,   -8, 	   0,  -13
+.2byte  -10,  -18, 	   3,  -14, 	 -13,  -12, 	  -2,  -13
+.2byte   -9,  -17, 	  -3,  -11, 	 -13,   -5, 	   1,  -12
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte  -11,  -15, 	 -10,   -9, 	  -5,   -7, 	  -1,  -13
+.2byte  -10,  -14, 	  -2,   -9, 	 -11,   -7, 	  -2,  -11
+.2byte  -15,  -11, 	 -11,  -12, 	 -10,   -4, 	  -3,  -10
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte   -9,  -15, 	 -12,   -8, 	   6,   -8, 	  -2,  -11
+.2byte   -8,  -14, 	 -10,  -11, 	  -2,   -5, 	  -1,  -10
+.2byte  -11,   -5, 	 -18,   -3, 	   4,    1, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte   -1,  -23, 	 -13,   -6, 	  10,  -15, 	  -2,  -13
+.2byte   -1,   -3, 	 -13,   -1, 	  11,   -2, 	  -1,  -10
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    2,  -23, 	  13,  -10, 	 -12,  -13, 	   0,  -13
+.2byte    9,   -5, 	  16,   -3, 	  -6,    1, 	  -1,  -10
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    2,  -22, 	  12,  -18, 	  -8,   -8, 	   0,  -14
+.2byte   13,  -11, 	   9,  -12, 	   8,   -4, 	   1,  -10
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte    1,  -21, 	  -5,  -10, 	   7,   -7, 	  -2,   -9
+.2byte    9,  -17, 	   3,  -11, 	  13,   -5, 	  -1,  -12
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte   -4,  -26, 	   2,  -15, 	 -13,   -9, 	   0,  -11
+.2byte   -1,  -19, 	  11,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte   -1,  -21, 	   5,  -10, 	  -7,   -7, 	   2,   -9
+.2byte   -9,  -17, 	  -3,  -11, 	 -13,   -5, 	   1,  -12
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte   -4,  -22, 	 -14,  -18, 	   6,   -8, 	  -2,  -14
+.2byte  -15,  -11, 	 -11,  -12, 	 -10,   -4, 	  -3,  -10
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte   -4,  -23, 	 -15,  -10, 	  10,  -13, 	  -2,  -13
+.2byte  -11,   -5, 	 -18,   -3, 	   4,    1, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte    0,  -13, 	 -12,  -10, 	  11,   -7, 	   0,  -10
+.2byte   -2,  -13, 	 -13,   -6, 	  10,  -11, 	  -2,  -10
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    5,  -15, 	  11,  -11, 	  -6,   -5, 	  -1,  -11
+.2byte    7,  -16, 	  12,   -9, 	  -4,   -7, 	   1,  -11
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    7,  -15, 	   8,  -10, 	   8,   -6, 	  -1,  -11
+.2byte    9,  -17, 	  -2,  -10, 	   8,   -9, 	  -1,  -13
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte   11,  -19, 	   1,  -15, 	  13,  -10, 	   0,  -13
+.2byte    7,  -19, 	  -1,  -16, 	  12,  -12, 	  -1,  -13
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte   -2,  -20, 	   9,  -14, 	 -13,  -12, 	  -2,  -13
+.2byte    0,  -20, 	  11,  -12, 	 -11,  -14, 	   0,  -12
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte  -11,  -19, 	  -1,  -15, 	 -13,  -10, 	   0,  -13
+.2byte   -7,  -19, 	   1,  -16, 	 -12,  -12, 	   1,  -13
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -15, 	 -10,  -10, 	 -10,   -6, 	  -1,  -11
+.2byte  -11,  -17, 	   0,  -10, 	 -10,   -9, 	  -1,  -13
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte   -7,  -15, 	 -13,  -11, 	   4,   -5, 	  -1,  -11
+.2byte   -9,  -16, 	 -14,   -9, 	   2,   -7, 	  -3,  -11
+.2byte   -1,  -10, 	 -13,   -6, 	  11,   -6, 	  -1,   -7
+.2byte   -1,  -11, 	 -13,   -7, 	  11,   -7, 	  -1,   -8
+.2byte    0,  -15, 	 -11,  -21, 	  11,  -21, 	   0,  -11
+.2byte    2,  -18, 	  10,  -24, 	  -8,  -14, 	   0,  -12
+.2byte    1,  -16, 	  -3,  -23, 	  -4,  -15, 	  -2,  -13
+.2byte    3,  -17, 	 -11,  -23, 	   9,  -15, 	  -1,  -11
+.2byte    0,  -14, 	  12,  -18, 	 -12,  -18, 	   0,   -9
+.2byte   -4,  -17, 	  10,  -23, 	 -10,  -15, 	   0,  -11
+.2byte   -2,  -16, 	   2,  -23, 	   3,  -15, 	   1,  -13
+.2byte   -3,  -18, 	 -11,  -24, 	   7,  -14, 	  -1,  -12
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte    0,  -13, 	 -12,  -10, 	  11,   -7, 	   0,  -10
+.2byte   -2,  -13, 	 -13,   -6, 	  10,  -11, 	  -2,  -10
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    5,  -15, 	  11,  -11, 	  -6,   -5, 	  -1,  -11
+.2byte    7,  -16, 	  12,   -9, 	  -4,   -7, 	   1,  -11
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    7,  -15, 	   8,  -10, 	   8,   -6, 	  -1,  -11
+.2byte    9,  -17, 	  -2,  -10, 	   8,   -9, 	  -1,  -13
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte   11,  -19, 	   1,  -15, 	  13,  -10, 	   0,  -13
+.2byte    7,  -19, 	  -1,  -16, 	  12,  -12, 	  -1,  -13
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte   -2,  -20, 	   9,  -14, 	 -13,  -12, 	  -2,  -13
+.2byte    0,  -20, 	  11,  -12, 	 -11,  -14, 	   0,  -12
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte  -11,  -19, 	  -1,  -15, 	 -13,  -10, 	   0,  -13
+.2byte   -7,  -19, 	   1,  -16, 	 -12,  -12, 	   1,  -13
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -15, 	 -10,  -10, 	 -10,   -6, 	  -1,  -11
+.2byte  -11,  -17, 	   0,  -10, 	 -10,   -9, 	  -1,  -13
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte   -7,  -15, 	 -13,  -11, 	   4,   -5, 	  -1,  -11
+.2byte   -9,  -16, 	 -14,   -9, 	   2,   -7, 	  -3,  -11
+.2byte   -1,   -3, 	 -13,   -1, 	  11,   -2, 	  -1,  -10
+.2byte  -11,   -5, 	 -18,   -3, 	   4,    1, 	  -1,  -10
+.2byte  -15,  -10, 	 -11,  -11, 	 -10,   -3, 	  -3,   -9
+.2byte   -9,  -17, 	  -3,  -11, 	 -13,   -5, 	   1,  -12
+.2byte   -1,  -19, 	  11,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte    9,  -17, 	   3,  -11, 	  13,   -5, 	  -1,  -12
+.2byte   13,  -10, 	   9,  -11, 	   8,   -3, 	   1,   -9
+.2byte    9,   -5, 	  16,   -3, 	  -6,    1, 	  -1,  -10
+.2byte   -1,   -3, 	 -13,   -1, 	  11,   -2, 	  -1,  -10
+.2byte    9,   -5, 	  16,   -3, 	  -6,    1, 	  -1,  -10
+.2byte   13,  -11, 	   9,  -12, 	   8,   -4, 	   1,  -10
+.2byte    9,  -17, 	   3,  -11, 	  13,   -5, 	  -1,  -12
+.2byte   -1,  -19, 	  11,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte   -9,  -17, 	  -3,  -11, 	 -13,   -5, 	   1,  -12
+.2byte  -15,  -11, 	 -11,  -12, 	 -10,   -4, 	  -3,  -10
+.2byte  -11,   -5, 	 -18,   -3, 	   4,    1, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte   -2,  -12, 	  -8,   -4, 	  12,   -9, 	  -2,   -9
+.2byte    0,  -12, 	 -14,   -9, 	   6,   -5, 	   0,   -9
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    7,  -15, 	  10,   -8, 	  -8,   -8, 	   0,  -11
+.2byte    6,  -14, 	   8,  -11, 	   0,   -5, 	  -1,  -10
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -15, 	   8,   -9, 	   3,   -7, 	  -1,  -13
+.2byte    8,  -14, 	   0,   -9, 	   9,   -7, 	   0,  -11
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte    8,  -18, 	   3,  -15, 	  12,   -8, 	   0,  -13
+.2byte   10,  -18, 	  -3,  -14, 	  13,  -12, 	   2,  -13
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte   -1,  -19, 	   9,  -14, 	 -12,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	  11,  -11, 	 -11,  -14, 	  -1,  -11
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte   -8,  -18, 	  -3,  -15, 	 -12,   -8, 	   0,  -13
+.2byte  -10,  -18, 	   3,  -14, 	 -13,  -12, 	  -2,  -13
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte  -11,  -15, 	 -10,   -9, 	  -5,   -7, 	  -1,  -13
+.2byte  -10,  -14, 	  -2,   -9, 	 -11,   -7, 	  -2,  -11
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte   -9,  -15, 	 -12,   -8, 	   6,   -8, 	  -2,  -11
+.2byte   -8,  -14, 	 -10,  -11, 	  -2,   -5, 	  -1,  -10
+.2byte   -1,   -3, 	 -13,   -1, 	  11,   -2, 	  -1,  -10
+.2byte    9,   -5, 	  16,   -3, 	  -6,    1, 	  -1,  -10
+.2byte   13,  -11, 	   9,  -12, 	   8,   -4, 	   1,  -10
+.2byte    9,  -17, 	   3,  -11, 	  13,   -5, 	  -1,  -12
+.2byte   -1,  -19, 	  11,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte   -9,  -17, 	  -3,  -11, 	 -13,   -5, 	   1,  -12
+.2byte  -15,  -11, 	 -11,  -12, 	 -10,   -4, 	  -3,  -10
+.2byte  -11,   -5, 	 -18,   -3, 	   4,    1, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,   -8, 	  11,   -8, 	  -1,  -10
+.2byte   -8,  -16, 	 -13,  -10, 	   3,   -5, 	  -3,  -12
+.2byte  -10,  -16, 	 -10,  -15, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -19, 	   2,  -16, 	 -13,  -11, 	   0,  -13
+.2byte   -1,  -20, 	  10,  -13, 	 -12,  -13, 	  -1,  -12
+.2byte    9,  -19, 	  -2,  -16, 	  13,  -11, 	   0,  -13
+.2byte    8,  -16, 	   8,  -15, 	   8,   -8, 	  -1,  -13
+.2byte    6,  -16, 	  11,  -10, 	  -5,   -5, 	   1,  -12
+sAggronAnimTable1:
+.4byte sAggronAnims_1_1
+.4byte sAggronAnims_1_2
+.4byte sAggronAnims_1_3
+.4byte sAggronAnims_1_4
+.4byte sAggronAnims_1_5
+.4byte sAggronAnims_1_6
+.4byte sAggronAnims_1_7
+.4byte sAggronAnims_1_8
+sAggronAnimTable2:
+.4byte sAggronAnims_2_1
+.4byte sAggronAnims_2_2
+.4byte sAggronAnims_2_3
+.4byte sAggronAnims_2_4
+.4byte sAggronAnims_2_5
+.4byte sAggronAnims_2_6
+.4byte sAggronAnims_2_7
+.4byte sAggronAnims_2_8
+sAggronAnimTable3:
+.4byte sAggronAnims_3_1
+.4byte sAggronAnims_3_2
+.4byte sAggronAnims_3_3
+.4byte sAggronAnims_3_4
+.4byte sAggronAnims_3_5
+.4byte sAggronAnims_3_6
+.4byte sAggronAnims_3_7
+.4byte sAggronAnims_3_8
+sAggronAnimTable4:
+.4byte sAggronAnims_4_1
+.4byte sAggronAnims_4_2
+.4byte sAggronAnims_4_3
+.4byte sAggronAnims_4_4
+.4byte sAggronAnims_4_5
+.4byte sAggronAnims_4_6
+.4byte sAggronAnims_4_7
+.4byte sAggronAnims_4_8
+sAggronAnimTable5:
+.4byte sAggronAnims_5_1
+.4byte sAggronAnims_5_2
+.4byte sAggronAnims_5_3
+.4byte sAggronAnims_5_4
+.4byte sAggronAnims_5_5
+.4byte sAggronAnims_5_6
+.4byte sAggronAnims_5_7
+.4byte sAggronAnims_5_8
+sAggronAnimTable6:
+.4byte sAggronAnims_6_1
+.4byte sAggronAnims_6_1
+.4byte sAggronAnims_6_1
+.4byte sAggronAnims_6_1
+.4byte sAggronAnims_6_1
+.4byte sAggronAnims_6_1
+.4byte sAggronAnims_6_1
+.4byte sAggronAnims_6_1
+sAggronAnimTable7:
+.4byte sAggronAnims_7_1
+.4byte sAggronAnims_7_2
+.4byte sAggronAnims_7_3
+.4byte sAggronAnims_7_4
+.4byte sAggronAnims_7_5
+.4byte sAggronAnims_7_6
+.4byte sAggronAnims_7_7
+.4byte sAggronAnims_7_8
+sAggronAnimTable8:
+.4byte sAggronAnims_8_1
+.4byte sAggronAnims_8_2
+.4byte sAggronAnims_8_3
+.4byte sAggronAnims_8_4
+.4byte sAggronAnims_8_5
+.4byte sAggronAnims_8_6
+.4byte sAggronAnims_8_7
+.4byte sAggronAnims_8_8
+sAggronAnimTable9:
+.4byte sAggronAnims_9_1
+.4byte sAggronAnims_9_2
+.4byte sAggronAnims_9_3
+.4byte sAggronAnims_9_4
+.4byte sAggronAnims_9_5
+.4byte sAggronAnims_9_6
+.4byte sAggronAnims_9_7
+.4byte sAggronAnims_9_8
+sAggronAnimTable10:
+.4byte sAggronAnims_10_1
+.4byte sAggronAnims_10_2
+.4byte sAggronAnims_10_3
+.4byte sAggronAnims_10_4
+.4byte sAggronAnims_10_5
+.4byte sAggronAnims_10_6
+.4byte sAggronAnims_10_7
+.4byte sAggronAnims_10_8
+sAggronAnimTable11:
+.4byte sAggronAnims_11_1
+.4byte sAggronAnims_11_2
+.4byte sAggronAnims_11_3
+.4byte sAggronAnims_11_4
+.4byte sAggronAnims_11_5
+.4byte sAggronAnims_11_6
+.4byte sAggronAnims_11_7
+.4byte sAggronAnims_11_8
+sAggronAnimTable12:
+.4byte sAggronAnims_12_1
+.4byte sAggronAnims_12_2
+.4byte sAggronAnims_12_3
+.4byte sAggronAnims_12_4
+.4byte sAggronAnims_12_5
+.4byte sAggronAnims_12_6
+.4byte sAggronAnims_12_7
+.4byte sAggronAnims_12_8
+sAggronAnimTable13:
+.4byte sAggronAnims_13_1
+.4byte sAggronAnims_13_2
+.4byte sAggronAnims_13_3
+.4byte sAggronAnims_13_4
+.4byte sAggronAnims_13_5
+.4byte sAggronAnims_13_6
+.4byte sAggronAnims_13_7
+.4byte sAggronAnims_13_8
+sAxAnimationsAggron:
+.4byte sAggronAnimTable1
+.4byte sAggronAnimTable2
+.4byte sAggronAnimTable3
+.4byte sAggronAnimTable4
+.4byte sAggronAnimTable5
+.4byte sAggronAnimTable6
+.4byte sAggronAnimTable7
+.4byte sAggronAnimTable8
+.4byte sAggronAnimTable9
+.4byte sAggronAnimTable10
+.4byte sAggronAnimTable11
+.4byte sAggronAnimTable12
+.4byte sAggronAnimTable13
+sAxSpritesAggron:
+.4byte sAggronSprites1
+.4byte sAggronSprites2
+.4byte sAggronSprites3
+.4byte sAggronSprites4
+.4byte sAggronSprites5
+.4byte sAggronSprites6
+.4byte sAggronSprites7
+.4byte sAggronSprites8
+.4byte sAggronSprites9
+.4byte sAggronSprites10
+.4byte sAggronSprites11
+.4byte sAggronSprites12
+.4byte sAggronSprites13
+.4byte sAggronSprites14
+.4byte sAggronSprites15
+.4byte sAggronSprites16
+.4byte sAggronSprites17
+.4byte sAggronSprites18
+.4byte sAggronSprites19
+.4byte sAggronSprites20
+.4byte sAggronSprites21
+.4byte sAggronSprites22
+.4byte sAggronSprites23
+.4byte sAggronSprites24
+.4byte sAggronSprites25
+.4byte sAggronSprites26
+.4byte sAggronSprites27
+.4byte sAggronSprites28
+.4byte sAggronSprites29
+.4byte sAggronSprites30
+.4byte sAggronSprites31
+.4byte sAggronSprites32
+.4byte sAggronSprites33
+.4byte sAggronSprites34
+.4byte sAggronSprites35
+.4byte sAggronSprites36
+.4byte sAggronSprites37
+.4byte sAggronSprites38
+.4byte sAggronSprites39
+.4byte sAggronSprites40
+.4byte sAggronSprites41
+.4byte sAggronSprites42
+.4byte sAggronSprites43
+.4byte sAggronSprites44
+.4byte sAggronSprites45
+.4byte sAggronSprites46
+.4byte sAggronSprites47
+.4byte sAggronSprites48
+.4byte sAggronSprites49
+.4byte sAggronSprites50
+.4byte sAggronSprites51
+.4byte sAggronSprites52
+.4byte sAggronSprites53
+.4byte sAggronSprites54
+.4byte sAggronSprites55
+.4byte sAggronSprites56
+.4byte sAggronSprites57
+.4byte sAggronSprites58
+.4byte sAggronSprites59
+.4byte sAggronSprites60
+.4byte sAggronSprites61
+.4byte sAggronSprites62
+sAxMainAggron:
+ax_main sAxPosesAggron, sAxAnimationsAggron, 13, sAxSpritesAggron, sAxPositionsAggron

--- a/data/ax/aipom.inc
+++ b/data/ax/aipom.inc
@@ -1,0 +1,2541 @@
+.global gAxAipom
+gAxAipom:
+ax_siro sAxMainAipom
+sAipomPose1:
+ax_pose 0, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose2:
+ax_pose 1, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose3:
+ax_pose 2, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose4:
+ax_pose 3, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose5:
+ax_pose 4, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose6:
+ax_pose 5, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose7:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose8:
+ax_pose 7, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose9:
+ax_pose 8, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose10:
+ax_pose 9, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose11:
+ax_pose 10, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose12:
+ax_pose 11, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose13:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose14:
+ax_pose 13, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose15:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose16:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose17:
+ax_pose 16, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose18:
+ax_pose 17, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose19:
+ax_pose 18, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose20:
+ax_pose 19, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose21:
+ax_pose 20, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose22:
+ax_pose 21, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose23:
+ax_pose 22, 0x01e8, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose24:
+ax_pose 23, 0x01e8, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose25:
+ax_pose 0, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose26:
+ax_pose 1, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose27:
+ax_pose 2, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose28:
+ax_pose 3, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose29:
+ax_pose 4, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose30:
+ax_pose 5, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose31:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose32:
+ax_pose 7, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose33:
+ax_pose 8, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose34:
+ax_pose 9, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose35:
+ax_pose 10, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose36:
+ax_pose 11, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose37:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose38:
+ax_pose 13, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose39:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose40:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose41:
+ax_pose 16, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose42:
+ax_pose 17, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose43:
+ax_pose 18, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose44:
+ax_pose 19, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose45:
+ax_pose 20, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose46:
+ax_pose 21, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose47:
+ax_pose 22, 0x01e8, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose48:
+ax_pose 23, 0x01e8, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose49:
+ax_pose 0, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose50:
+ax_pose 1, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose51:
+ax_pose 2, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose52:
+ax_pose 3, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose53:
+ax_pose 4, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose54:
+ax_pose 5, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose55:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose56:
+ax_pose 7, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose57:
+ax_pose 8, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose58:
+ax_pose 9, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose59:
+ax_pose 10, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose60:
+ax_pose 11, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose61:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose62:
+ax_pose 13, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose63:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose64:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose65:
+ax_pose 16, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose66:
+ax_pose 17, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose67:
+ax_pose 18, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose68:
+ax_pose 19, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose69:
+ax_pose 20, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose70:
+ax_pose 21, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose71:
+ax_pose 22, 0x01e8, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose72:
+ax_pose 23, 0x01e8, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose73:
+ax_pose 24, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose74:
+ax_pose 25, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose75:
+ax_pose 26, 0x01ea, 0x80f6, 0x7c00
+ax_pose_terminator
+sAipomPose76:
+ax_pose 27, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose77:
+ax_pose 28, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose78:
+ax_pose 27, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sAipomPose79:
+ax_pose 26, 0x01ea, 0x90e9, 0x7c00
+ax_pose_terminator
+sAipomPose80:
+ax_pose 25, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose81:
+ax_pose 0, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose82:
+ax_pose 29, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose83:
+ax_pose 24, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose84:
+ax_pose 3, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose85:
+ax_pose 30, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose86:
+ax_pose 25, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose87:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose88:
+ax_pose 31, 0x01e9, 0x90e8, 0x7c00
+ax_pose_terminator
+sAipomPose89:
+ax_pose 26, 0x01ea, 0x90e9, 0x7c00
+ax_pose_terminator
+sAipomPose90:
+ax_pose 9, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose91:
+ax_pose 32, 0x01e9, 0x90ed, 0x7c00
+ax_pose_terminator
+sAipomPose92:
+ax_pose 27, 0x01e7, 0x90ee, 0x7c00
+ax_pose_terminator
+sAipomPose93:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose94:
+ax_pose 33, 0x01e9, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose95:
+ax_pose 28, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose96:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose97:
+ax_pose 32, 0x01e9, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose98:
+ax_pose 27, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose99:
+ax_pose 18, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose100:
+ax_pose 31, 0x01e9, 0x80f7, 0x7c00
+ax_pose_terminator
+sAipomPose101:
+ax_pose 26, 0x01ea, 0x80f6, 0x7c00
+ax_pose_terminator
+sAipomPose102:
+ax_pose 21, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose103:
+ax_pose 30, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose104:
+ax_pose 25, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose105:
+ax_pose 34, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose106:
+ax_pose 35, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose107:
+ax_pose 36, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose108:
+ax_pose 37, 0x01e8, 0x90f0, 0x7c00
+ax_pose_terminator
+sAipomPose109:
+ax_pose 38, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sAipomPose110:
+ax_pose 39, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose111:
+ax_pose 40, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sAipomPose112:
+ax_pose 39, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose113:
+ax_pose 38, 0x01e5, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose114:
+ax_pose 37, 0x01e8, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose115:
+ax_pose 24, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose116:
+ax_pose 41, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose117:
+ax_pose 25, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose118:
+ax_pose 42, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose119:
+ax_pose 26, 0x01ea, 0x90ea, 0x7c00
+ax_pose_terminator
+sAipomPose120:
+ax_pose 43, 0x01ea, 0x90ea, 0x7c00
+ax_pose_terminator
+sAipomPose121:
+ax_pose 27, 0x01e8, 0x90ed, 0x7c00
+ax_pose_terminator
+sAipomPose122:
+ax_pose 44, 0x01e8, 0x90ed, 0x7c00
+ax_pose_terminator
+sAipomPose123:
+ax_pose 28, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose124:
+ax_pose 45, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose125:
+ax_pose 27, 0x01e8, 0x80f1, 0x7c00
+ax_pose_terminator
+sAipomPose126:
+ax_pose 44, 0x01e8, 0x80f1, 0x7c00
+ax_pose_terminator
+sAipomPose127:
+ax_pose 26, 0x01ea, 0x80f5, 0x7c00
+ax_pose_terminator
+sAipomPose128:
+ax_pose 43, 0x01ea, 0x80f5, 0x7c00
+ax_pose_terminator
+sAipomPose129:
+ax_pose 25, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose130:
+ax_pose 42, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose131:
+ax_pose 24, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose132:
+ax_pose 25, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose133:
+ax_pose 26, 0x01ea, 0x80f6, 0x7c00
+ax_pose_terminator
+sAipomPose134:
+ax_pose 27, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose135:
+ax_pose 28, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose136:
+ax_pose 27, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sAipomPose137:
+ax_pose 26, 0x01ea, 0x90e9, 0x7c00
+ax_pose_terminator
+sAipomPose138:
+ax_pose 25, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose139:
+ax_pose 29, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose140:
+ax_pose 30, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose141:
+ax_pose 31, 0x01e9, 0x90e8, 0x7c00
+ax_pose_terminator
+sAipomPose142:
+ax_pose 32, 0x01e9, 0x90ee, 0x7c00
+ax_pose_terminator
+sAipomPose143:
+ax_pose 33, 0x01e9, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose144:
+ax_pose 32, 0x01e9, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose145:
+ax_pose 31, 0x01e9, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose146:
+ax_pose 30, 0x01e9, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose147:
+ax_pose 0, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose148:
+ax_pose 29, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose149:
+ax_pose 24, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose150:
+ax_pose 3, 0x01e9, 0x80f1, 0x7c00
+ax_pose_terminator
+sAipomPose151:
+ax_pose 30, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose152:
+ax_pose 25, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose153:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose154:
+ax_pose 31, 0x01e9, 0x90e8, 0x7c00
+ax_pose_terminator
+sAipomPose155:
+ax_pose 26, 0x01ea, 0x90e7, 0x7c00
+ax_pose_terminator
+sAipomPose156:
+ax_pose 15, 0x01e7, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose157:
+ax_pose 32, 0x01e9, 0x90ed, 0x7c00
+ax_pose_terminator
+sAipomPose158:
+ax_pose 27, 0x01e7, 0x90eb, 0x7c00
+ax_pose_terminator
+sAipomPose159:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose160:
+ax_pose 33, 0x01e9, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose161:
+ax_pose 28, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose162:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose163:
+ax_pose 32, 0x01e9, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose164:
+ax_pose 27, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose165:
+ax_pose 18, 0x01ea, 0x80f9, 0x7c00
+ax_pose_terminator
+sAipomPose166:
+ax_pose 31, 0x01e9, 0x80f7, 0x7c00
+ax_pose_terminator
+sAipomPose167:
+ax_pose 26, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose168:
+ax_pose 21, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose169:
+ax_pose 30, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose170:
+ax_pose 25, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose171:
+ax_pose 24, 0x01e9, 0x80ec, 0x7c00
+ax_pose_terminator
+sAipomPose172:
+ax_pose 25, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose173:
+ax_pose 26, 0x01ea, 0x80f6, 0x7c00
+ax_pose_terminator
+sAipomPose174:
+ax_pose 27, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose175:
+ax_pose 28, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sAipomPose176:
+ax_pose 27, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sAipomPose177:
+ax_pose 26, 0x01ea, 0x90e9, 0x7c00
+ax_pose_terminator
+sAipomPose178:
+ax_pose 25, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sAipomPose179:
+ax_pose 0, 0x01ea, 0x80ed, 0x7c00
+ax_pose_terminator
+sAipomPose180:
+ax_pose 21, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose181:
+ax_pose 18, 0x01ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sAipomPose182:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose183:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sAipomPose184:
+ax_pose 9, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sAipomPose185:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sAipomPose186:
+ax_pose 3, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+.align 2
+sAipomAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sAipomAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sAipomAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sAipomAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sAipomAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sAipomAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -3, 0, 0,
+ax_anim 4, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 4, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sAipomAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 4, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sAipomAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 22, 0, -3, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 4, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sAipomAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 11, 9, 11, 9,
+ax_anim 2, 0, 28, 24, 21, 24, 21,
+ax_anim 2, 1, 28, 25, 20, 25, 20,
+ax_anim 2, 0, 28, 24, 21, 24, 21,
+ax_anim 2, 0, 28, 25, 20, 25, 20,
+ax_anim 2, 0, 27, 7, 5, 7, 5,
+ax_anim_terminator
+sAipomAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 12, 0, 12, 0,
+ax_anim 2, 0, 32, 23, 0, 23, 0,
+ax_anim 2, 1, 32, 23, 1, 23, 1,
+ax_anim 2, 0, 32, 23, 0, 23, 0,
+ax_anim 2, 0, 32, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 8, 0, 8, 0,
+ax_anim_terminator
+sAipomAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 6, -5, 6, -5,
+ax_anim 1, 0, 35, 13, -12, 13, -12,
+ax_anim 2, 0, 34, 21, -18, 21, -18,
+ax_anim 2, 1, 34, 22, -17, 22, -17,
+ax_anim 2, 0, 34, 21, -18, 21, -18,
+ax_anim 2, 0, 34, 22, -17, 22, -17,
+ax_anim 2, 0, 33, 7, -6, 7, -6,
+ax_anim_terminator
+sAipomAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sAipomAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -6, -5, -6, -5,
+ax_anim 1, 0, 40, -13, -12, -13, -12,
+ax_anim 2, 0, 41, -21, -18, -21, -18,
+ax_anim 2, 1, 41, -22, -17, -22, -17,
+ax_anim 2, 0, 41, -21, -18, -21, -18,
+ax_anim 2, 0, 41, -22, -17, -22, -17,
+ax_anim 2, 0, 39, -7, -6, -7, -6,
+ax_anim_terminator
+sAipomAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 1, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 0, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -8, 0, -8, 0,
+ax_anim_terminator
+sAipomAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 9, -10, 9,
+ax_anim 2, 0, 46, -22, 21, -22, 21,
+ax_anim 2, 1, 46, -23, 20, -23, 20,
+ax_anim 2, 0, 46, -22, 21, -22, 21,
+ax_anim 2, 0, 46, -23, 20, -23, 20,
+ax_anim 2, 0, 45, -7, 5, -7, 5,
+ax_anim_terminator
+.align 2
+sAipomAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 1, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sAipomAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 11, 9, 11, 9,
+ax_anim 2, 0, 52, 24, 21, 24, 21,
+ax_anim 2, 1, 52, 25, 20, 25, 20,
+ax_anim 2, 0, 52, 24, 21, 24, 21,
+ax_anim 2, 0, 52, 25, 20, 25, 20,
+ax_anim 2, 0, 51, 7, 5, 7, 5,
+ax_anim_terminator
+sAipomAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 12, 0, 12, 0,
+ax_anim 2, 0, 56, 23, 0, 23, 0,
+ax_anim 2, 1, 56, 23, 1, 23, 1,
+ax_anim 2, 0, 56, 23, 0, 23, 0,
+ax_anim 2, 0, 56, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 8, 0, 8, 0,
+ax_anim_terminator
+sAipomAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 6, -5, 6, -5,
+ax_anim 1, 0, 59, 13, -12, 13, -12,
+ax_anim 2, 0, 58, 21, -18, 21, -18,
+ax_anim 2, 1, 58, 22, -17, 22, -17,
+ax_anim 2, 0, 58, 21, -18, 21, -18,
+ax_anim 2, 0, 58, 22, -17, 22, -17,
+ax_anim 2, 0, 57, 7, -6, 7, -6,
+ax_anim_terminator
+sAipomAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 1, 61, 1, -18, 1, -18,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 0, 61, 1, -18, 1, -18,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sAipomAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 65, -6, -5, -6, -5,
+ax_anim 1, 0, 64, -13, -12, -13, -12,
+ax_anim 2, 0, 65, -21, -18, -21, -18,
+ax_anim 2, 1, 65, -22, -17, -22, -17,
+ax_anim 2, 0, 65, -21, -18, -21, -18,
+ax_anim 2, 0, 65, -22, -17, -22, -17,
+ax_anim 2, 0, 63, -7, -6, -7, -6,
+ax_anim_terminator
+sAipomAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -12, 0, -12, 0,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 1, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 0, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 66, -8, 0, -8, 0,
+ax_anim_terminator
+sAipomAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 9, -10, 9,
+ax_anim 2, 0, 70, -22, 21, -22, 21,
+ax_anim 2, 1, 70, -23, 20, -23, 20,
+ax_anim 2, 0, 70, -22, 21, -22, 21,
+ax_anim 2, 0, 70, -23, 20, -23, 20,
+ax_anim 2, 0, 69, -7, 5, -7, 5,
+ax_anim_terminator
+.align 2
+sAipomAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_5_1:
+ax_anim 1, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 3, 0, 81, 0, -5, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 1, 0, 81, 0, -2, 0, 0,
+ax_anim 6, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 2, 81, 0, -4, 0, 0,
+ax_anim 3, 0, 81, 0, -5, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 1, 0, 81, 0, -2, 0, 0,
+ax_anim 6, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_5_2:
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 3, 0, 84, 0, -5, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 2, 84, 0, -4, 0, 0,
+ax_anim 3, 0, 84, 0, -5, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_5_3:
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 3, 0, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 2, 87, 0, -4, 0, 0,
+ax_anim 3, 0, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_5_4:
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 3, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 2, 90, 0, -4, 0, 0,
+ax_anim 3, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_5_5:
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 3, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 2, 93, 0, -4, 0, 0,
+ax_anim 3, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_5_6:
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 3, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 2, 96, 0, -4, 0, 0,
+ax_anim 3, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_5_7:
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 3, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 2, 99, 0, -4, 0, 0,
+ax_anim 3, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_5_8:
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 3, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 2, 102, 0, -4, 0, 0,
+ax_anim 3, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sAipomAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sAipomAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sAipomAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sAipomAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sAipomAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sAipomAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sAipomAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sAipomAnims_8_1:
+ax_anim 30, 0, 114, 0, 0, 0, 0,
+ax_anim 18, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_8_2:
+ax_anim 30, 0, 116, 0, 0, 0, 0,
+ax_anim 18, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_8_3:
+ax_anim 30, 0, 118, 0, 0, 0, 0,
+ax_anim 18, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_8_4:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 18, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_8_5:
+ax_anim 30, 0, 122, 0, 0, 0, 0,
+ax_anim 18, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_8_6:
+ax_anim 30, 0, 124, 0, 0, 0, 0,
+ax_anim 18, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_8_7:
+ax_anim 30, 0, 126, 0, 0, 0, 0,
+ax_anim 18, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_8_8:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 18, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 8, 3, 8, 3,
+ax_anim 2, 0, 132, 10, 10, 10, 10,
+ax_anim 2, 0, 133, 9, 19, 9, 19,
+ax_anim 3, 0, 134, 0, 21, 0, 21,
+ax_anim 2, 3, 135, -9, 19, -9, 19,
+ax_anim 2, 0, 136, -10, 10, -10, 10,
+ax_anim 1, 0, 137, -8, 3, -8, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 9, 0, 9, 0,
+ax_anim 2, 0, 131, 18, 4, 18, 4,
+ax_anim 2, 0, 132, 23, 13, 23, 13,
+ax_anim 3, 0, 133, 22, 20, 22, 20,
+ax_anim 2, 3, 134, 10, 20, 10, 20,
+ax_anim 2, 0, 135, 3, 15, 3, 15,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 2, -5, 2, -5,
+ax_anim 2, 0, 130, 13, -7, 13, -7,
+ax_anim 2, 0, 131, 21, -5, 21, -5,
+ax_anim 3, 0, 132, 24, 0, 24, 0,
+ax_anim 2, 3, 133, 18, 5, 18, 5,
+ax_anim 2, 0, 134, 11, 7, 11, 7,
+ax_anim 1, 0, 135, 3, 5, 3, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 2, -15, 2, -15,
+ax_anim 2, 0, 130, 11, -22, 11, -22,
+ax_anim 3, 0, 131, 23, -24, 23, -24,
+ax_anim 2, 3, 132, 24, -16, 24, -16,
+ax_anim 2, 0, 133, 19, -6, 19, -6,
+ax_anim 1, 0, 134, 9, -1, 9, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -8, -3, -8, -3,
+ax_anim 2, 0, 136, -11, -10, -11, -10,
+ax_anim 2, 0, 137, -9, -19, -9, -19,
+ax_anim 3, 0, 130, 0, -24, 0, -24,
+ax_anim 2, 3, 131, 10, -19, 10, -19,
+ax_anim 2, 0, 132, 11, -10, 11, -10,
+ax_anim 1, 0, 133, 8, -3, 8, -3,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -8, 1, -8,
+ax_anim 2, 0, 131, -2, -15, -2, -15,
+ax_anim 2, 0, 130, -11, -22, -11, -22,
+ax_anim 3, 0, 137, -23, -24, -23, -24,
+ax_anim 2, 3, 136, -24, -16, -24, -16,
+ax_anim 2, 0, 135, -19, -6, -19, -6,
+ax_anim 1, 0, 134, -9, -1, -9, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -2, -5, -2, -5,
+ax_anim 2, 0, 130, -13, -7, -13, -7,
+ax_anim 2, 0, 137, -21, -5, -21, -5,
+ax_anim 3, 0, 136, -24, 0, -24, 0,
+ax_anim 2, 3, 135, -18, 5, -18, 5,
+ax_anim 2, 0, 134, -11, 7, -11, 7,
+ax_anim 1, 0, 133, -3, 5, -3, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -9, 0, -9, 0,
+ax_anim 2, 0, 137, -18, 4, -18, 4,
+ax_anim 2, 0, 136, -23, 13, -23, 13,
+ax_anim 3, 0, 135, -22, 20, -22, 20,
+ax_anim 2, 3, 134, -10, 20, -10, 20,
+ax_anim 2, 0, 133, -3, 15, -3, 15,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -24, 0, 0,
+ax_anim 3, 0, 148, 0, -25, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 149, 0, -24, 0, 0,
+ax_anim 3, 0, 151, 0, -27, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -24, 0, 0,
+ax_anim 3, 0, 154, 0, -26, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 155, 0, -24, 0, 0,
+ax_anim 3, 0, 157, 0, -26, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 158, 0, -24, 0, 0,
+ax_anim 3, 0, 160, 0, -26, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -24, 0, 0,
+ax_anim 3, 0, 163, 0, -26, 0, 0,
+ax_anim 2, 0, 163, 0, -17, 0, 0,
+ax_anim 1, 0, 163, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -24, 0, 0,
+ax_anim 3, 0, 166, 0, -26, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -24, 0, 0,
+ax_anim 3, 0, 169, 0, -27, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAipomAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sAipomGfx1:
+.incbin "baserom.gba", 0xD2F214, 0x200
+sAipomSprites1:
+ax_sprite sAipomGfx1, 0x200
+ax_sprite_terminator
+sAipomGfx2:
+.incbin "baserom.gba", 0xD2F424, 0x200
+sAipomSprites2:
+ax_sprite sAipomGfx2, 0x200
+ax_sprite_terminator
+sAipomGfx3:
+.incbin "baserom.gba", 0xD2F634, 0x200
+sAipomSprites3:
+ax_sprite sAipomGfx3, 0x200
+ax_sprite_terminator
+sAipomGfx4:
+.incbin "baserom.gba", 0xD2F844, 0x200
+sAipomSprites4:
+ax_sprite sAipomGfx4, 0x200
+ax_sprite_terminator
+sAipomGfx5:
+.incbin "baserom.gba", 0xD2FA54, 0x200
+sAipomSprites5:
+ax_sprite sAipomGfx5, 0x200
+ax_sprite_terminator
+sAipomGfx6:
+.incbin "baserom.gba", 0xD2FC64, 0x200
+sAipomSprites6:
+ax_sprite sAipomGfx6, 0x200
+ax_sprite_terminator
+sAipomGfx7:
+.incbin "baserom.gba", 0xD2FE74, 0x200
+sAipomSprites7:
+ax_sprite sAipomGfx7, 0x200
+ax_sprite_terminator
+sAipomGfx8:
+.incbin "baserom.gba", 0xD30084, 0x200
+sAipomSprites8:
+ax_sprite sAipomGfx8, 0x200
+ax_sprite_terminator
+sAipomGfx9:
+.incbin "baserom.gba", 0xD30294, 0x200
+sAipomSprites9:
+ax_sprite sAipomGfx9, 0x200
+ax_sprite_terminator
+sAipomGfx10:
+.incbin "baserom.gba", 0xD304A4, 0x200
+sAipomSprites10:
+ax_sprite sAipomGfx10, 0x200
+ax_sprite_terminator
+sAipomGfx11:
+.incbin "baserom.gba", 0xD306B4, 0x200
+sAipomSprites11:
+ax_sprite sAipomGfx11, 0x200
+ax_sprite_terminator
+sAipomGfx12:
+.incbin "baserom.gba", 0xD308C4, 0x200
+sAipomSprites12:
+ax_sprite sAipomGfx12, 0x200
+ax_sprite_terminator
+sAipomGfx13:
+.incbin "baserom.gba", 0xD30AD4, 0x200
+sAipomSprites13:
+ax_sprite sAipomGfx13, 0x200
+ax_sprite_terminator
+sAipomGfx14:
+.incbin "baserom.gba", 0xD30CE4, 0x200
+sAipomSprites14:
+ax_sprite sAipomGfx14, 0x200
+ax_sprite_terminator
+sAipomGfx15:
+.incbin "baserom.gba", 0xD30EF4, 0x200
+sAipomSprites15:
+ax_sprite sAipomGfx15, 0x200
+ax_sprite_terminator
+sAipomGfx16:
+.incbin "baserom.gba", 0xD31104, 0x200
+sAipomSprites16:
+ax_sprite sAipomGfx16, 0x200
+ax_sprite_terminator
+sAipomGfx17:
+.incbin "baserom.gba", 0xD31314, 0x200
+sAipomSprites17:
+ax_sprite sAipomGfx17, 0x200
+ax_sprite_terminator
+sAipomGfx18:
+.incbin "baserom.gba", 0xD31524, 0x200
+sAipomSprites18:
+ax_sprite sAipomGfx18, 0x200
+ax_sprite_terminator
+sAipomGfx19:
+.incbin "baserom.gba", 0xD31734, 0x200
+sAipomSprites19:
+ax_sprite sAipomGfx19, 0x200
+ax_sprite_terminator
+sAipomGfx20:
+.incbin "baserom.gba", 0xD31944, 0x200
+sAipomSprites20:
+ax_sprite sAipomGfx20, 0x200
+ax_sprite_terminator
+sAipomGfx21:
+.incbin "baserom.gba", 0xD31B54, 0x200
+sAipomSprites21:
+ax_sprite sAipomGfx21, 0x200
+ax_sprite_terminator
+sAipomGfx22:
+.incbin "baserom.gba", 0xD31D64, 0x200
+sAipomSprites22:
+ax_sprite sAipomGfx22, 0x200
+ax_sprite_terminator
+sAipomGfx23:
+.incbin "baserom.gba", 0xD31F74, 0x200
+sAipomSprites23:
+ax_sprite sAipomGfx23, 0x200
+ax_sprite_terminator
+sAipomGfx24:
+.incbin "baserom.gba", 0xD32184, 0x200
+sAipomSprites24:
+ax_sprite sAipomGfx24, 0x200
+ax_sprite_terminator
+sAipomGfx25:
+.incbin "baserom.gba", 0xD32394, 0x40
+sAipomGfx25_1:
+.incbin "baserom.gba", 0xD323D4, 0x60
+sAipomGfx25_2:
+.incbin "baserom.gba", 0xD32434, 0x60
+sAipomGfx25_3:
+.incbin "baserom.gba", 0xD32494, 0x60
+sAipomSprites25:
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx25_3, 0x60
+ax_sprite_terminator
+sAipomGfx26:
+.incbin "baserom.gba", 0xD3253C, 0x60
+sAipomGfx26_1:
+.incbin "baserom.gba", 0xD3259C, 0x60
+sAipomGfx26_2:
+.incbin "baserom.gba", 0xD325FC, 0x60
+sAipomGfx26_3:
+.incbin "baserom.gba", 0xD3265C, 0x40
+sAipomSprites26:
+ax_sprite sAipomGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAipomGfx27:
+.incbin "baserom.gba", 0xD326E4, 0x60
+sAipomGfx27_1:
+.incbin "baserom.gba", 0xD32744, 0x60
+sAipomGfx27_2:
+.incbin "baserom.gba", 0xD327A4, 0x60
+sAipomGfx27_3:
+.incbin "baserom.gba", 0xD32804, 0x40
+sAipomSprites27:
+ax_sprite sAipomGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx27_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAipomGfx28:
+.incbin "baserom.gba", 0xD3288C, 0x40
+sAipomGfx28_1:
+.incbin "baserom.gba", 0xD328CC, 0x60
+sAipomGfx28_2:
+.incbin "baserom.gba", 0xD3292C, 0x60
+sAipomGfx28_3:
+.incbin "baserom.gba", 0xD3298C, 0x40
+sAipomSprites28:
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAipomGfx29:
+.incbin "baserom.gba", 0xD32A1C, 0x40
+sAipomGfx29_1:
+.incbin "baserom.gba", 0xD32A5C, 0xE0
+sAipomGfx29_2:
+.incbin "baserom.gba", 0xD32B3C, 0x40
+sAipomSprites29:
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx29_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAipomGfx30:
+.incbin "baserom.gba", 0xD32BBC, 0x60
+sAipomGfx30_1:
+.incbin "baserom.gba", 0xD32C1C, 0xC0
+sAipomGfx30_2:
+.incbin "baserom.gba", 0xD32CDC, 0x60
+sAipomSprites30:
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx30_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAipomGfx31:
+.incbin "baserom.gba", 0xD32D7C, 0x60
+sAipomGfx31_1:
+.incbin "baserom.gba", 0xD32DDC, 0x60
+sAipomGfx31_2:
+.incbin "baserom.gba", 0xD32E3C, 0x40
+sAipomGfx31_3:
+.incbin "baserom.gba", 0xD32E7C, 0x40
+sAipomSprites31:
+ax_sprite sAipomGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAipomGfx32:
+.incbin "baserom.gba", 0xD32F04, 0x40
+sAipomGfx32_1:
+.incbin "baserom.gba", 0xD32F44, 0x60
+sAipomGfx32_2:
+.incbin "baserom.gba", 0xD32FA4, 0x60
+sAipomGfx32_3:
+.incbin "baserom.gba", 0xD33004, 0x60
+sAipomSprites32:
+ax_sprite sAipomGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAipomGfx33:
+.incbin "baserom.gba", 0xD330AC, 0x60
+sAipomGfx33_1:
+.incbin "baserom.gba", 0xD3310C, 0x60
+sAipomGfx33_2:
+.incbin "baserom.gba", 0xD3316C, 0x60
+sAipomGfx33_3:
+.incbin "baserom.gba", 0xD331CC, 0x60
+sAipomSprites33:
+ax_sprite sAipomGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx33_3, 0x60
+ax_sprite_terminator
+sAipomGfx34:
+.incbin "baserom.gba", 0xD3326C, 0x60
+sAipomGfx34_1:
+.incbin "baserom.gba", 0xD332CC, 0x60
+sAipomGfx34_2:
+.incbin "baserom.gba", 0xD3332C, 0x60
+sAipomGfx34_3:
+.incbin "baserom.gba", 0xD3338C, 0x60
+sAipomSprites34:
+ax_sprite sAipomGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAipomGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAipomGfx34_3, 0x60
+ax_sprite_terminator
+sAipomGfx35:
+.incbin "baserom.gba", 0xD3342C, 0x200
+sAipomSprites35:
+ax_sprite sAipomGfx35, 0x200
+ax_sprite_terminator
+sAipomGfx36:
+.incbin "baserom.gba", 0xD3363C, 0x200
+sAipomSprites36:
+ax_sprite sAipomGfx36, 0x200
+ax_sprite_terminator
+sAipomGfx37:
+.incbin "baserom.gba", 0xD3384C, 0x200
+sAipomSprites37:
+ax_sprite sAipomGfx37, 0x200
+ax_sprite_terminator
+sAipomGfx38:
+.incbin "baserom.gba", 0xD33A5C, 0x200
+sAipomSprites38:
+ax_sprite sAipomGfx38, 0x200
+ax_sprite_terminator
+sAipomGfx39:
+.incbin "baserom.gba", 0xD33C6C, 0x200
+sAipomSprites39:
+ax_sprite sAipomGfx39, 0x200
+ax_sprite_terminator
+sAipomGfx40:
+.incbin "baserom.gba", 0xD33E7C, 0x200
+sAipomSprites40:
+ax_sprite sAipomGfx40, 0x200
+ax_sprite_terminator
+sAipomGfx41:
+.incbin "baserom.gba", 0xD3408C, 0x200
+sAipomSprites41:
+ax_sprite sAipomGfx41, 0x200
+ax_sprite_terminator
+sAipomGfx42:
+.incbin "baserom.gba", 0xD3429C, 0x200
+sAipomSprites42:
+ax_sprite sAipomGfx42, 0x200
+ax_sprite_terminator
+sAipomGfx43:
+.incbin "baserom.gba", 0xD344AC, 0x200
+sAipomSprites43:
+ax_sprite sAipomGfx43, 0x200
+ax_sprite_terminator
+sAipomGfx44:
+.incbin "baserom.gba", 0xD346BC, 0x200
+sAipomSprites44:
+ax_sprite sAipomGfx44, 0x200
+ax_sprite_terminator
+sAipomGfx45:
+.incbin "baserom.gba", 0xD348CC, 0x200
+sAipomSprites45:
+ax_sprite sAipomGfx45, 0x200
+ax_sprite_terminator
+sAipomGfx46:
+.incbin "baserom.gba", 0xD34ADC, 0x200
+sAipomSprites46:
+ax_sprite sAipomGfx46, 0x200
+ax_sprite_terminator
+sAxPosesAipom:
+.4byte sAipomPose1
+.4byte sAipomPose2
+.4byte sAipomPose3
+.4byte sAipomPose4
+.4byte sAipomPose5
+.4byte sAipomPose6
+.4byte sAipomPose7
+.4byte sAipomPose8
+.4byte sAipomPose9
+.4byte sAipomPose10
+.4byte sAipomPose11
+.4byte sAipomPose12
+.4byte sAipomPose13
+.4byte sAipomPose14
+.4byte sAipomPose15
+.4byte sAipomPose16
+.4byte sAipomPose17
+.4byte sAipomPose18
+.4byte sAipomPose19
+.4byte sAipomPose20
+.4byte sAipomPose21
+.4byte sAipomPose22
+.4byte sAipomPose23
+.4byte sAipomPose24
+.4byte sAipomPose25
+.4byte sAipomPose26
+.4byte sAipomPose27
+.4byte sAipomPose28
+.4byte sAipomPose29
+.4byte sAipomPose30
+.4byte sAipomPose31
+.4byte sAipomPose32
+.4byte sAipomPose33
+.4byte sAipomPose34
+.4byte sAipomPose35
+.4byte sAipomPose36
+.4byte sAipomPose37
+.4byte sAipomPose38
+.4byte sAipomPose39
+.4byte sAipomPose40
+.4byte sAipomPose41
+.4byte sAipomPose42
+.4byte sAipomPose43
+.4byte sAipomPose44
+.4byte sAipomPose45
+.4byte sAipomPose46
+.4byte sAipomPose47
+.4byte sAipomPose48
+.4byte sAipomPose49
+.4byte sAipomPose50
+.4byte sAipomPose51
+.4byte sAipomPose52
+.4byte sAipomPose53
+.4byte sAipomPose54
+.4byte sAipomPose55
+.4byte sAipomPose56
+.4byte sAipomPose57
+.4byte sAipomPose58
+.4byte sAipomPose59
+.4byte sAipomPose60
+.4byte sAipomPose61
+.4byte sAipomPose62
+.4byte sAipomPose63
+.4byte sAipomPose64
+.4byte sAipomPose65
+.4byte sAipomPose66
+.4byte sAipomPose67
+.4byte sAipomPose68
+.4byte sAipomPose69
+.4byte sAipomPose70
+.4byte sAipomPose71
+.4byte sAipomPose72
+.4byte sAipomPose73
+.4byte sAipomPose74
+.4byte sAipomPose75
+.4byte sAipomPose76
+.4byte sAipomPose77
+.4byte sAipomPose78
+.4byte sAipomPose79
+.4byte sAipomPose80
+.4byte sAipomPose81
+.4byte sAipomPose82
+.4byte sAipomPose83
+.4byte sAipomPose84
+.4byte sAipomPose85
+.4byte sAipomPose86
+.4byte sAipomPose87
+.4byte sAipomPose88
+.4byte sAipomPose89
+.4byte sAipomPose90
+.4byte sAipomPose91
+.4byte sAipomPose92
+.4byte sAipomPose93
+.4byte sAipomPose94
+.4byte sAipomPose95
+.4byte sAipomPose96
+.4byte sAipomPose97
+.4byte sAipomPose98
+.4byte sAipomPose99
+.4byte sAipomPose100
+.4byte sAipomPose101
+.4byte sAipomPose102
+.4byte sAipomPose103
+.4byte sAipomPose104
+.4byte sAipomPose105
+.4byte sAipomPose106
+.4byte sAipomPose107
+.4byte sAipomPose108
+.4byte sAipomPose109
+.4byte sAipomPose110
+.4byte sAipomPose111
+.4byte sAipomPose112
+.4byte sAipomPose113
+.4byte sAipomPose114
+.4byte sAipomPose115
+.4byte sAipomPose116
+.4byte sAipomPose117
+.4byte sAipomPose118
+.4byte sAipomPose119
+.4byte sAipomPose120
+.4byte sAipomPose121
+.4byte sAipomPose122
+.4byte sAipomPose123
+.4byte sAipomPose124
+.4byte sAipomPose125
+.4byte sAipomPose126
+.4byte sAipomPose127
+.4byte sAipomPose128
+.4byte sAipomPose129
+.4byte sAipomPose130
+.4byte sAipomPose131
+.4byte sAipomPose132
+.4byte sAipomPose133
+.4byte sAipomPose134
+.4byte sAipomPose135
+.4byte sAipomPose136
+.4byte sAipomPose137
+.4byte sAipomPose138
+.4byte sAipomPose139
+.4byte sAipomPose140
+.4byte sAipomPose141
+.4byte sAipomPose142
+.4byte sAipomPose143
+.4byte sAipomPose144
+.4byte sAipomPose145
+.4byte sAipomPose146
+.4byte sAipomPose147
+.4byte sAipomPose148
+.4byte sAipomPose149
+.4byte sAipomPose150
+.4byte sAipomPose151
+.4byte sAipomPose152
+.4byte sAipomPose153
+.4byte sAipomPose154
+.4byte sAipomPose155
+.4byte sAipomPose156
+.4byte sAipomPose157
+.4byte sAipomPose158
+.4byte sAipomPose159
+.4byte sAipomPose160
+.4byte sAipomPose161
+.4byte sAipomPose162
+.4byte sAipomPose163
+.4byte sAipomPose164
+.4byte sAipomPose165
+.4byte sAipomPose166
+.4byte sAipomPose167
+.4byte sAipomPose168
+.4byte sAipomPose169
+.4byte sAipomPose170
+.4byte sAipomPose171
+.4byte sAipomPose172
+.4byte sAipomPose173
+.4byte sAipomPose174
+.4byte sAipomPose175
+.4byte sAipomPose176
+.4byte sAipomPose177
+.4byte sAipomPose178
+.4byte sAipomPose179
+.4byte sAipomPose180
+.4byte sAipomPose181
+.4byte sAipomPose182
+.4byte sAipomPose183
+.4byte sAipomPose184
+.4byte sAipomPose185
+.4byte sAipomPose186
+sAxPositionsAipom:
+.2byte    0,   -9, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    0,  -10, 	  -6,   -9, 	   5,   -8, 	   0,   -8
+.2byte   -1,  -10, 	  -6,   -9, 	   5,   -9, 	  -1,   -8
+.2byte    1,   -9, 	  -7,   -5, 	   3,   -7, 	  -1,   -7
+.2byte    2,  -10, 	  -1,   -6, 	   1,   -7, 	  -1,   -8
+.2byte    1,  -10, 	  -7,   -8, 	   4,  -10, 	  -1,   -8
+.2byte    3,  -10, 	  -4,   -5, 	  -2,   -8, 	  -1,   -7
+.2byte    3,  -11, 	   1,   -8, 	   0,  -11, 	   0,   -9
+.2byte    3,  -11, 	  -5,   -8, 	   3,   -9, 	  -1,   -8
+.2byte   -1,  -11, 	   2,   -5, 	  -6,   -8, 	  -2,   -9
+.2byte   -1,  -12, 	   4,   -9, 	  -7,  -10, 	  -2,   -9
+.2byte    0,  -12, 	  -1,   -9, 	  -4,  -12, 	  -2,   -9
+.2byte   -1,  -11, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -11, 	   4,   -9, 	  -7,   -9, 	   0,   -8
+.2byte    0,  -11, 	   6,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -2,  -12, 	   4,   -8, 	  -5,   -5, 	   0,   -9
+.2byte   -2,  -12, 	   3,  -11, 	  -2,   -9, 	   1,  -11
+.2byte    0,  -13, 	   5,  -10, 	  -6,   -9, 	   0,   -9
+.2byte   -5,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -7
+.2byte   -5,  -11, 	  -5,   -9, 	   3,   -8, 	  -1,   -8
+.2byte   -5,  -11, 	   3,   -9, 	  -3,   -8, 	   0,   -8
+.2byte   -4,   -9, 	  -5,   -7, 	   5,   -6, 	   0,   -8
+.2byte   -3,  -10, 	  -6,   -9, 	   5,   -8, 	  -1,   -9
+.2byte   -4,  -10, 	  -2,  -12, 	  -1,   -6, 	   0,   -9
+.2byte    0,   -9, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    0,  -10, 	  -6,   -9, 	   5,   -8, 	   0,   -8
+.2byte   -1,  -10, 	  -6,   -9, 	   5,   -9, 	  -1,   -8
+.2byte    1,   -9, 	  -7,   -5, 	   3,   -7, 	  -1,   -7
+.2byte    2,  -10, 	  -1,   -6, 	   1,   -7, 	  -1,   -8
+.2byte    1,  -10, 	  -7,   -8, 	   4,  -10, 	  -1,   -8
+.2byte    3,  -10, 	  -4,   -5, 	  -2,   -8, 	  -1,   -7
+.2byte    3,  -11, 	   1,   -8, 	   0,  -11, 	   0,   -9
+.2byte    3,  -11, 	  -5,   -8, 	   3,   -9, 	  -1,   -8
+.2byte   -1,  -11, 	   2,   -5, 	  -6,   -8, 	  -2,   -9
+.2byte   -1,  -12, 	   4,   -9, 	  -7,  -10, 	  -2,   -9
+.2byte    0,  -12, 	  -1,   -9, 	  -4,  -12, 	  -2,   -9
+.2byte   -1,  -11, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -11, 	   4,   -9, 	  -7,   -9, 	   0,   -8
+.2byte    0,  -11, 	   6,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -2,  -12, 	   4,   -8, 	  -5,   -5, 	   0,   -9
+.2byte   -2,  -12, 	   3,  -11, 	  -2,   -9, 	   1,  -11
+.2byte    0,  -13, 	   5,  -10, 	  -6,   -9, 	   0,   -9
+.2byte   -5,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -7
+.2byte   -5,  -11, 	  -5,   -9, 	   3,   -8, 	  -1,   -8
+.2byte   -5,  -11, 	   3,   -9, 	  -3,   -8, 	   0,   -8
+.2byte   -4,   -9, 	  -5,   -7, 	   5,   -6, 	   0,   -8
+.2byte   -3,  -10, 	  -6,   -9, 	   5,   -8, 	  -1,   -9
+.2byte   -4,  -10, 	  -2,  -12, 	  -1,   -6, 	   0,   -9
+.2byte    0,   -9, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    0,  -10, 	  -6,   -9, 	   5,   -8, 	   0,   -8
+.2byte   -1,  -10, 	  -6,   -9, 	   5,   -9, 	  -1,   -8
+.2byte    1,   -9, 	  -7,   -5, 	   3,   -7, 	  -1,   -7
+.2byte    2,  -10, 	  -1,   -6, 	   1,   -7, 	  -1,   -8
+.2byte    1,  -10, 	  -7,   -8, 	   4,  -10, 	  -1,   -8
+.2byte    3,  -10, 	  -4,   -5, 	  -2,   -8, 	  -1,   -7
+.2byte    3,  -11, 	   1,   -8, 	   0,  -11, 	   0,   -9
+.2byte    3,  -11, 	  -5,   -8, 	   3,   -9, 	  -1,   -8
+.2byte   -1,  -11, 	   2,   -5, 	  -6,   -8, 	  -2,   -9
+.2byte   -1,  -12, 	   4,   -9, 	  -7,  -10, 	  -2,   -9
+.2byte    0,  -12, 	  -1,   -9, 	  -4,  -12, 	  -2,   -9
+.2byte   -1,  -11, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -11, 	   4,   -9, 	  -7,   -9, 	   0,   -8
+.2byte    0,  -11, 	   6,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -2,  -12, 	   4,   -8, 	  -5,   -5, 	   0,   -9
+.2byte   -2,  -12, 	   3,  -11, 	  -2,   -9, 	   1,  -11
+.2byte    0,  -13, 	   5,  -10, 	  -6,   -9, 	   0,   -9
+.2byte   -5,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -7
+.2byte   -5,  -11, 	  -5,   -9, 	   3,   -8, 	  -1,   -8
+.2byte   -5,  -11, 	   3,   -9, 	  -3,   -8, 	   0,   -8
+.2byte   -4,   -9, 	  -5,   -7, 	   5,   -6, 	   0,   -8
+.2byte   -3,  -10, 	  -6,   -9, 	   5,   -8, 	  -1,   -9
+.2byte   -4,  -10, 	  -2,  -12, 	  -1,   -6, 	   0,   -9
+.2byte   -1,   -6, 	  -5,    0, 	   4,    0, 	   0,   -4
+.2byte   -5,   -5, 	  -4,    0, 	   3,    1, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,    0, 	  -3,    1, 	  -2,   -4
+.2byte   -3,   -7, 	   1,   -2, 	  -4,    0, 	  -1,   -6
+.2byte    0,   -7, 	   4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte    2,   -7, 	  -2,   -2, 	   3,    0, 	   0,   -6
+.2byte    6,   -6, 	   1,    0, 	   1,    1, 	   0,   -4
+.2byte    3,   -5, 	   2,    0, 	  -5,    1, 	  -1,   -4
+.2byte    0,   -9, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -1,  -11, 	  -6,  -11, 	   5,  -11, 	   0,   -9
+.2byte   -1,   -6, 	  -5,    0, 	   4,    0, 	   0,   -4
+.2byte    1,   -9, 	  -7,   -5, 	   3,   -7, 	  -1,   -7
+.2byte    1,  -11, 	   3,  -12, 	  -5,  -11, 	  -1,   -9
+.2byte    3,   -5, 	   2,    0, 	  -5,    1, 	  -1,   -4
+.2byte    3,  -10, 	  -4,   -5, 	  -2,   -8, 	  -1,   -7
+.2byte    3,  -12, 	   0,  -13, 	  -1,  -11, 	  -1,  -10
+.2byte    6,   -6, 	   1,    0, 	   1,    1, 	   0,   -4
+.2byte   -1,  -11, 	   2,   -5, 	  -6,   -8, 	  -2,   -9
+.2byte   -1,  -13, 	  -5,  -12, 	   3,  -10, 	  -2,   -9
+.2byte    2,   -8, 	  -2,   -3, 	   3,   -1, 	   0,   -7
+.2byte   -1,  -11, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -10, 	  -5,  -10, 	  -1,   -9
+.2byte    0,   -7, 	   4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte   -2,  -12, 	   4,   -8, 	  -5,   -5, 	   0,   -9
+.2byte   -1,  -13, 	   3,  -12, 	  -5,  -10, 	   0,   -9
+.2byte   -3,   -8, 	   1,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -5,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -7
+.2byte   -5,  -12, 	  -2,  -13, 	  -1,  -11, 	  -1,  -10
+.2byte   -8,   -6, 	  -3,    0, 	  -3,    1, 	  -2,   -4
+.2byte   -4,   -9, 	  -5,   -7, 	   5,   -6, 	   0,   -8
+.2byte   -3,  -10, 	  -5,  -11, 	   3,  -10, 	  -1,   -8
+.2byte   -5,   -5, 	  -4,    0, 	   3,    1, 	  -1,   -4
+.2byte    1,   -7, 	  -6,   -3, 	   2,   -4, 	  -1,   -6
+.2byte    2,   -7, 	  -5,   -2, 	   2,   -3, 	  -1,   -5
+.2byte    0,    0, 	  -7,   -4, 	   6,   -4, 	   0,   -4
+.2byte    2,    1, 	   5,   -7, 	  -3,    4, 	   0,   -3
+.2byte    4,    0, 	   0,   -1, 	  -2,    2, 	   0,   -2
+.2byte    2,   -4, 	  -6,   -5, 	   5,   -1, 	   0,   -4
+.2byte    0,   -4, 	   7,   -2, 	  -9,   -2, 	   0,   -3
+.2byte   -3,   -4, 	   5,   -5, 	  -6,   -1, 	  -1,   -4
+.2byte   -5,    0, 	  -1,   -1, 	   1,    2, 	  -1,   -2
+.2byte   -3,    1, 	  -6,   -7, 	   2,    4, 	  -1,   -3
+.2byte   -1,   -6, 	  -5,    0, 	   4,    0, 	   0,   -4
+.2byte   -1,   -6, 	  -5,    0, 	   4,    0, 	   0,   -4
+.2byte    3,   -5, 	   2,    0, 	  -5,    1, 	  -1,   -4
+.2byte    3,   -5, 	   2,    0, 	  -5,    1, 	  -1,   -4
+.2byte    7,   -6, 	   2,    0, 	   2,    1, 	   1,   -4
+.2byte    7,   -6, 	   2,    0, 	   2,    1, 	   0,   -4
+.2byte    1,   -7, 	  -3,   -2, 	   2,    0, 	  -1,   -6
+.2byte    0,   -8, 	  -3,   -3, 	   2,    0, 	  -1,   -6
+.2byte    0,   -7, 	   4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte    0,   -8, 	   4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte   -4,   -7, 	   0,   -2, 	  -5,    0, 	  -2,   -6
+.2byte   -3,   -8, 	   0,   -3, 	  -5,    0, 	  -2,   -6
+.2byte   -9,   -6, 	  -4,    0, 	  -4,    1, 	  -3,   -4
+.2byte   -9,   -6, 	  -4,    0, 	  -4,    1, 	  -2,   -4
+.2byte   -5,   -5, 	  -4,    0, 	   3,    1, 	  -1,   -4
+.2byte   -5,   -5, 	  -4,    0, 	   3,    1, 	  -1,   -4
+.2byte   -1,   -6, 	  -5,    0, 	   4,    0, 	   0,   -4
+.2byte   -5,   -5, 	  -4,    0, 	   3,    1, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,    0, 	  -3,    1, 	  -2,   -4
+.2byte   -3,   -7, 	   1,   -2, 	  -4,    0, 	  -1,   -6
+.2byte    0,   -7, 	   4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte    2,   -7, 	  -2,   -2, 	   3,    0, 	   0,   -6
+.2byte    6,   -6, 	   1,    0, 	   1,    1, 	   0,   -4
+.2byte    3,   -5, 	   2,    0, 	  -5,    1, 	  -1,   -4
+.2byte   -1,  -11, 	  -6,  -11, 	   5,  -11, 	   0,   -9
+.2byte    1,  -11, 	   3,  -12, 	  -5,  -11, 	  -1,   -9
+.2byte    3,  -12, 	   0,  -13, 	  -1,  -11, 	  -1,  -10
+.2byte    0,  -13, 	  -4,  -12, 	   4,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   4,  -10, 	  -5,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   3,  -12, 	  -5,  -10, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -13, 	   0,  -11, 	   0,  -10
+.2byte   -2,  -11, 	  -4,  -12, 	   4,  -11, 	   0,   -9
+.2byte    0,   -9, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -1,  -11, 	  -6,  -11, 	   5,  -11, 	   0,   -9
+.2byte   -1,   -6, 	  -5,    0, 	   4,    0, 	   0,   -4
+.2byte    2,   -9, 	  -6,   -5, 	   4,   -7, 	   0,   -7
+.2byte    1,  -11, 	   3,  -12, 	  -5,  -11, 	  -1,   -9
+.2byte    3,   -5, 	   2,    0, 	  -5,    1, 	  -1,   -4
+.2byte    3,  -10, 	  -4,   -5, 	  -2,   -8, 	  -1,   -7
+.2byte    3,  -12, 	   0,  -13, 	  -1,  -11, 	  -1,  -10
+.2byte    4,   -6, 	  -1,    0, 	  -1,    1, 	  -2,   -4
+.2byte    0,  -12, 	  -6,   -8, 	   3,   -5, 	  -2,   -9
+.2byte   -1,  -13, 	  -5,  -12, 	   3,  -10, 	  -2,   -9
+.2byte   -1,   -8, 	  -5,   -3, 	   0,   -1, 	  -3,   -7
+.2byte   -1,  -11, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -10, 	  -5,  -10, 	  -1,   -9
+.2byte    0,   -7, 	   4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte   -2,  -12, 	   4,   -8, 	  -5,   -5, 	   0,   -9
+.2byte   -1,  -13, 	   3,  -12, 	  -5,  -10, 	   0,   -9
+.2byte   -1,   -8, 	   3,   -3, 	  -2,   -1, 	   1,   -7
+.2byte   -4,  -10, 	   2,   -9, 	   3,   -5, 	   1,   -7
+.2byte   -5,  -12, 	  -2,  -13, 	  -1,  -11, 	  -1,  -10
+.2byte   -6,   -6, 	  -1,    0, 	  -1,    1, 	   0,   -4
+.2byte   -4,   -9, 	  -5,   -7, 	   5,   -6, 	   0,   -8
+.2byte   -3,  -10, 	  -5,  -11, 	   3,  -10, 	  -1,   -8
+.2byte   -4,   -5, 	  -3,    0, 	   4,    1, 	   0,   -4
+.2byte   -1,   -6, 	  -5,    0, 	   4,    0, 	   0,   -4
+.2byte   -5,   -5, 	  -4,    0, 	   3,    1, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,    0, 	  -3,    1, 	  -2,   -4
+.2byte   -3,   -7, 	   1,   -2, 	  -4,    0, 	  -1,   -6
+.2byte    0,   -7, 	   4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte    2,   -7, 	  -2,   -2, 	   3,    0, 	   0,   -6
+.2byte    6,   -6, 	   1,    0, 	   1,    1, 	   0,   -4
+.2byte    3,   -5, 	   2,    0, 	  -5,    1, 	  -1,   -4
+.2byte    0,   -9, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -4,   -9, 	  -5,   -7, 	   5,   -6, 	   0,   -8
+.2byte   -5,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -7
+.2byte   -2,  -12, 	   4,   -8, 	  -5,   -5, 	   0,   -9
+.2byte   -1,  -11, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -11, 	   2,   -5, 	  -6,   -8, 	  -2,   -9
+.2byte    3,  -10, 	  -4,   -5, 	  -2,   -8, 	  -1,   -7
+.2byte    1,   -9, 	  -7,   -5, 	   3,   -7, 	  -1,   -7
+sAipomAnimTable1:
+.4byte sAipomAnims_1_1
+.4byte sAipomAnims_1_2
+.4byte sAipomAnims_1_3
+.4byte sAipomAnims_1_4
+.4byte sAipomAnims_1_5
+.4byte sAipomAnims_1_6
+.4byte sAipomAnims_1_7
+.4byte sAipomAnims_1_8
+sAipomAnimTable2:
+.4byte sAipomAnims_2_1
+.4byte sAipomAnims_2_2
+.4byte sAipomAnims_2_3
+.4byte sAipomAnims_2_4
+.4byte sAipomAnims_2_5
+.4byte sAipomAnims_2_6
+.4byte sAipomAnims_2_7
+.4byte sAipomAnims_2_8
+sAipomAnimTable3:
+.4byte sAipomAnims_3_1
+.4byte sAipomAnims_3_2
+.4byte sAipomAnims_3_3
+.4byte sAipomAnims_3_4
+.4byte sAipomAnims_3_5
+.4byte sAipomAnims_3_6
+.4byte sAipomAnims_3_7
+.4byte sAipomAnims_3_8
+sAipomAnimTable4:
+.4byte sAipomAnims_4_1
+.4byte sAipomAnims_4_2
+.4byte sAipomAnims_4_3
+.4byte sAipomAnims_4_4
+.4byte sAipomAnims_4_5
+.4byte sAipomAnims_4_6
+.4byte sAipomAnims_4_7
+.4byte sAipomAnims_4_8
+sAipomAnimTable5:
+.4byte sAipomAnims_5_1
+.4byte sAipomAnims_5_2
+.4byte sAipomAnims_5_3
+.4byte sAipomAnims_5_4
+.4byte sAipomAnims_5_5
+.4byte sAipomAnims_5_6
+.4byte sAipomAnims_5_7
+.4byte sAipomAnims_5_8
+sAipomAnimTable6:
+.4byte sAipomAnims_6_1
+.4byte sAipomAnims_6_1
+.4byte sAipomAnims_6_1
+.4byte sAipomAnims_6_1
+.4byte sAipomAnims_6_1
+.4byte sAipomAnims_6_1
+.4byte sAipomAnims_6_1
+.4byte sAipomAnims_6_1
+sAipomAnimTable7:
+.4byte sAipomAnims_7_1
+.4byte sAipomAnims_7_2
+.4byte sAipomAnims_7_3
+.4byte sAipomAnims_7_4
+.4byte sAipomAnims_7_5
+.4byte sAipomAnims_7_6
+.4byte sAipomAnims_7_7
+.4byte sAipomAnims_7_8
+sAipomAnimTable8:
+.4byte sAipomAnims_8_1
+.4byte sAipomAnims_8_2
+.4byte sAipomAnims_8_3
+.4byte sAipomAnims_8_4
+.4byte sAipomAnims_8_5
+.4byte sAipomAnims_8_6
+.4byte sAipomAnims_8_7
+.4byte sAipomAnims_8_8
+sAipomAnimTable9:
+.4byte sAipomAnims_9_1
+.4byte sAipomAnims_9_2
+.4byte sAipomAnims_9_3
+.4byte sAipomAnims_9_4
+.4byte sAipomAnims_9_5
+.4byte sAipomAnims_9_6
+.4byte sAipomAnims_9_7
+.4byte sAipomAnims_9_8
+sAipomAnimTable10:
+.4byte sAipomAnims_10_1
+.4byte sAipomAnims_10_2
+.4byte sAipomAnims_10_3
+.4byte sAipomAnims_10_4
+.4byte sAipomAnims_10_5
+.4byte sAipomAnims_10_6
+.4byte sAipomAnims_10_7
+.4byte sAipomAnims_10_8
+sAipomAnimTable11:
+.4byte sAipomAnims_11_1
+.4byte sAipomAnims_11_2
+.4byte sAipomAnims_11_3
+.4byte sAipomAnims_11_4
+.4byte sAipomAnims_11_5
+.4byte sAipomAnims_11_6
+.4byte sAipomAnims_11_7
+.4byte sAipomAnims_11_8
+sAipomAnimTable12:
+.4byte sAipomAnims_12_1
+.4byte sAipomAnims_12_2
+.4byte sAipomAnims_12_3
+.4byte sAipomAnims_12_4
+.4byte sAipomAnims_12_5
+.4byte sAipomAnims_12_6
+.4byte sAipomAnims_12_7
+.4byte sAipomAnims_12_8
+sAipomAnimTable13:
+.4byte sAipomAnims_13_1
+.4byte sAipomAnims_13_2
+.4byte sAipomAnims_13_3
+.4byte sAipomAnims_13_4
+.4byte sAipomAnims_13_5
+.4byte sAipomAnims_13_6
+.4byte sAipomAnims_13_7
+.4byte sAipomAnims_13_8
+sAxAnimationsAipom:
+.4byte sAipomAnimTable1
+.4byte sAipomAnimTable2
+.4byte sAipomAnimTable3
+.4byte sAipomAnimTable4
+.4byte sAipomAnimTable5
+.4byte sAipomAnimTable6
+.4byte sAipomAnimTable7
+.4byte sAipomAnimTable8
+.4byte sAipomAnimTable9
+.4byte sAipomAnimTable10
+.4byte sAipomAnimTable11
+.4byte sAipomAnimTable12
+.4byte sAipomAnimTable13
+sAxSpritesAipom:
+.4byte sAipomSprites1
+.4byte sAipomSprites2
+.4byte sAipomSprites3
+.4byte sAipomSprites4
+.4byte sAipomSprites5
+.4byte sAipomSprites6
+.4byte sAipomSprites7
+.4byte sAipomSprites8
+.4byte sAipomSprites9
+.4byte sAipomSprites10
+.4byte sAipomSprites11
+.4byte sAipomSprites12
+.4byte sAipomSprites13
+.4byte sAipomSprites14
+.4byte sAipomSprites15
+.4byte sAipomSprites16
+.4byte sAipomSprites17
+.4byte sAipomSprites18
+.4byte sAipomSprites19
+.4byte sAipomSprites20
+.4byte sAipomSprites21
+.4byte sAipomSprites22
+.4byte sAipomSprites23
+.4byte sAipomSprites24
+.4byte sAipomSprites25
+.4byte sAipomSprites26
+.4byte sAipomSprites27
+.4byte sAipomSprites28
+.4byte sAipomSprites29
+.4byte sAipomSprites30
+.4byte sAipomSprites31
+.4byte sAipomSprites32
+.4byte sAipomSprites33
+.4byte sAipomSprites34
+.4byte sAipomSprites35
+.4byte sAipomSprites36
+.4byte sAipomSprites37
+.4byte sAipomSprites38
+.4byte sAipomSprites39
+.4byte sAipomSprites40
+.4byte sAipomSprites41
+.4byte sAipomSprites42
+.4byte sAipomSprites43
+.4byte sAipomSprites44
+.4byte sAipomSprites45
+.4byte sAipomSprites46
+sAxMainAipom:
+ax_main sAxPosesAipom, sAxAnimationsAipom, 13, sAxSpritesAipom, sAxPositionsAipom

--- a/data/ax/alakazam.inc
+++ b/data/ax/alakazam.inc
@@ -1,0 +1,3298 @@
+.global gAxAlakazam
+gAxAlakazam:
+ax_siro sAxMainAlakazam
+sAlakazamPose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose9:
+ax_pose 8, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose10:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose11:
+ax_pose 10, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose12:
+ax_pose 11, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose19:
+ax_pose 6, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose20:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose21:
+ax_pose 8, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose22:
+ax_pose 3, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose23:
+ax_pose 4, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose24:
+ax_pose 5, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose25:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose28:
+ax_pose 3, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose29:
+ax_pose 4, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose30:
+ax_pose 5, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose31:
+ax_pose 6, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose32:
+ax_pose 7, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose33:
+ax_pose 8, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose34:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose35:
+ax_pose 10, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose36:
+ax_pose 11, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose37:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose38:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose39:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose40:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose41:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose42:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose43:
+ax_pose 6, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose44:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose45:
+ax_pose 8, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose46:
+ax_pose 3, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose47:
+ax_pose 4, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose48:
+ax_pose 5, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose49:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose52:
+ax_pose 3, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose53:
+ax_pose 4, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose54:
+ax_pose 5, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose55:
+ax_pose 6, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose56:
+ax_pose 7, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose57:
+ax_pose 8, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose58:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose59:
+ax_pose 10, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose60:
+ax_pose 11, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose61:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose62:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose63:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose64:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose65:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose66:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose67:
+ax_pose 6, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose68:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose69:
+ax_pose 8, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose70:
+ax_pose 3, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose71:
+ax_pose 4, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose72:
+ax_pose 5, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose73:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose74:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose75:
+ax_pose 16, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose76:
+ax_pose 3, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose77:
+ax_pose 17, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose78:
+ax_pose 18, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose79:
+ax_pose 6, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose80:
+ax_pose 19, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose81:
+ax_pose 20, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sAlakazamPose82:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose83:
+ax_pose 21, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose84:
+ax_pose 22, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose85:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose86:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose87:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose88:
+ax_pose 9, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose89:
+ax_pose 21, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose90:
+ax_pose 22, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose91:
+ax_pose 6, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose92:
+ax_pose 19, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose93:
+ax_pose 20, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose94:
+ax_pose 3, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose95:
+ax_pose 17, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose96:
+ax_pose 18, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose97:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose98:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose99:
+ax_pose 16, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose100:
+ax_pose 3, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose101:
+ax_pose 17, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose102:
+ax_pose 18, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose103:
+ax_pose 6, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose104:
+ax_pose 19, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose105:
+ax_pose 20, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sAlakazamPose106:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose107:
+ax_pose 21, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose108:
+ax_pose 22, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose109:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose110:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose111:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose112:
+ax_pose 9, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose113:
+ax_pose 21, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose114:
+ax_pose 22, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose115:
+ax_pose 6, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose116:
+ax_pose 19, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose117:
+ax_pose 20, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose118:
+ax_pose 3, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose119:
+ax_pose 17, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose120:
+ax_pose 18, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose121:
+ax_pose 25, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose122:
+ax_pose 26, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose123:
+ax_pose 27, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose124:
+ax_pose 28, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose125:
+ax_pose 29, 0x01e4, 0x90eb, 0x4c00
+ax_pose_terminator
+sAlakazamPose126:
+ax_pose 30, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sAlakazamPose127:
+ax_pose 31, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose128:
+ax_pose 30, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose129:
+ax_pose 29, 0x01e4, 0x80f5, 0x4c00
+ax_pose_terminator
+sAlakazamPose130:
+ax_pose 28, 0x01e3, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose131:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose132:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose133:
+ax_pose 16, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose134:
+ax_pose 3, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose135:
+ax_pose 17, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose136:
+ax_pose 18, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose137:
+ax_pose 6, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose138:
+ax_pose 19, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose139:
+ax_pose 20, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sAlakazamPose140:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose141:
+ax_pose 21, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose142:
+ax_pose 22, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose143:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose144:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose145:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose146:
+ax_pose 9, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose147:
+ax_pose 21, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose148:
+ax_pose 22, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose149:
+ax_pose 6, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose150:
+ax_pose 19, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose151:
+ax_pose 20, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose152:
+ax_pose 3, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose153:
+ax_pose 17, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose154:
+ax_pose 18, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose155:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose156:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose157:
+ax_pose 19, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose158:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose159:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose160:
+ax_pose 21, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose161:
+ax_pose 19, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose162:
+ax_pose 17, 0x01e9, 0x90f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose163:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose164:
+ax_pose 17, 0x01e9, 0x90f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose165:
+ax_pose 19, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose166:
+ax_pose 21, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose167:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose168:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose169:
+ax_pose 19, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose170:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose171:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose172:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose173:
+ax_pose 16, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose174:
+ax_pose 3, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose175:
+ax_pose 17, 0x01e9, 0x90f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose176:
+ax_pose 18, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose177:
+ax_pose 6, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose178:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose179:
+ax_pose 20, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose180:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose181:
+ax_pose 21, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose182:
+ax_pose 22, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose183:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose184:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose185:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose186:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose187:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose188:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose189:
+ax_pose 6, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose190:
+ax_pose 19, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose191:
+ax_pose 20, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sAlakazamPose192:
+ax_pose 3, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose193:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose194:
+ax_pose 18, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose195:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose196:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose197:
+ax_pose 19, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose198:
+ax_pose 21, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose199:
+ax_pose 23, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose200:
+ax_pose 21, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose201:
+ax_pose 19, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose202:
+ax_pose 17, 0x01e9, 0x90f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose203:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose204:
+ax_pose 3, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose205:
+ax_pose 6, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose206:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose207:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose208:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose209:
+ax_pose 6, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose210:
+ax_pose 3, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose211:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose212:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose213:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose214:
+ax_pose 3, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose215:
+ax_pose 4, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose216:
+ax_pose 5, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose217:
+ax_pose 6, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose218:
+ax_pose 7, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose219:
+ax_pose 8, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose220:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose221:
+ax_pose 10, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose222:
+ax_pose 11, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose223:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose224:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose225:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose226:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose227:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose228:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose229:
+ax_pose 6, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose230:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose231:
+ax_pose 8, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose232:
+ax_pose 3, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose233:
+ax_pose 4, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose234:
+ax_pose 5, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sAlakazamPose235:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose236:
+ax_pose 32, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose237:
+ax_pose 33, 0x01e7, 0x80f0, 0x4c00
+ax_pose 34, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sAlakazamPose238:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose239:
+ax_pose 35, 0x01e7, 0x80f0, 0x4c00
+ax_pose 36, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sAlakazamPose240:
+ax_pose 36, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose241:
+ax_pose 37, 0x01f5, 0x44f8, 0x3c00
+ax_pose 38, 0x01e7, 0x80f0, 0x4c04
+ax_pose_terminator
+sAlakazamPose242:
+ax_pose 39, 0x01f5, 0x44f8, 0x3c00
+ax_pose 38, 0x01e7, 0x80f0, 0x4c04
+ax_pose_terminator
+sAlakazamPose243:
+ax_pose 40, 0x01f4, 0x44f8, 0x3c00
+ax_pose 38, 0x01e7, 0x80f0, 0x4c04
+ax_pose_terminator
+sAlakazamPose244:
+ax_pose 41, 0x01f4, 0x44f8, 0x3c00
+ax_pose 38, 0x01e7, 0x80f0, 0x4c04
+ax_pose_terminator
+sAlakazamPose245:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose246:
+ax_pose 42, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sAlakazamPose247:
+ax_pose 42, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sAlakazamPose248:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sAlakazamPose249:
+ax_pose 43, 0x01e3, 0x80ef, 0x4c00
+ax_pose_terminator
+sAlakazamPose250:
+ax_pose 44, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+.align 2
+sAlakazamAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 2, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 1, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sAlakazamAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 2, 28, 0, -1, 0, 0,
+ax_anim 1, 0, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 1, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 1, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 0, 28, 21, 19, 21, 19,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sAlakazamAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 2, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 1, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sAlakazamAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 2, 34, 0, -1, 0, -1,
+ax_anim 1, 0, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 34, 10, -10, 10, -10,
+ax_anim 1, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 1, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sAlakazamAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 2, 37, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -10, 0, -10,
+ax_anim 1, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sAlakazamAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 2, 40, 0, 0, 0, -1,
+ax_anim 1, 0, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 40, -10, -10, -10, -10,
+ax_anim 1, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 1, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sAlakazamAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 2, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 1, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sAlakazamAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 2, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 1, 0, 46, -20, 22, -20, 22,
+ax_anim 2, 1, 46, -21, 21, -21, 21,
+ax_anim 2, 0, 46, -20, 22, -20, 22,
+ax_anim 2, 0, 46, -20, 22, -20, 22,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 2, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 1, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 1, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 49, 1, 20, 1, 20,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sAlakazamAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 2, 52, 0, -1, 0, 0,
+ax_anim 1, 0, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 1, 0, 52, 20, 20, 20, 20,
+ax_anim 2, 1, 52, 21, 19, 21, 19,
+ax_anim 2, 0, 52, 20, 20, 20, 20,
+ax_anim 2, 0, 52, 21, 19, 21, 19,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sAlakazamAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 2, 55, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 1, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 1, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sAlakazamAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 2, 58, 0, -1, 0, -1,
+ax_anim 1, 0, 58, 4, -4, 4, -4,
+ax_anim 1, 0, 58, 10, -10, 10, -10,
+ax_anim 1, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 1, 58, 19, -17, 19, -17,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 0, 58, 19, -17, 19, -17,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sAlakazamAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 2, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -10, 0, -10,
+ax_anim 1, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 1, 61, 1, -18, 1, -18,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 0, 61, 1, -18, 1, -18,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sAlakazamAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 2, 64, 0, 0, 0, -1,
+ax_anim 1, 0, 64, -4, -4, -4, -4,
+ax_anim 1, 0, 64, -10, -10, -10, -10,
+ax_anim 1, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 1, 64, -19, -17, -19, -17,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 0, 64, -19, -17, -19, -17,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sAlakazamAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 2, 67, 0, 0, 0, 0,
+ax_anim 1, 0, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 1, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 1, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 67, -20, 1, -20, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sAlakazamAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 2, 70, 0, 0, 0, 0,
+ax_anim 1, 0, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 1, 0, 70, -20, 22, -20, 22,
+ax_anim 2, 1, 70, -21, 21, -21, 21,
+ax_anim 2, 0, 70, -20, 22, -20, 22,
+ax_anim 2, 0, 70, -20, 22, -20, 22,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 4, 0, 73, 0, -4, 0, 0,
+ax_anim 6, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -2, 0, 1,
+ax_anim 2, 2, 74, 1, -2, 0, 1,
+ax_anim 2, 0, 74, 0, -2, 0, 1,
+ax_anim 2, 0, 74, 1, -2, 0, 1,
+ax_anim 2, 0, 74, 0, -2, 0, 1,
+ax_anim 2, 1, 74, 1, -2, 0, 1,
+ax_anim 4, 0, 72, 0, -2, 0, 1,
+ax_anim_terminator
+sAlakazamAnims_4_2:
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 4, 0, 76, 0, -4, 0, 0,
+ax_anim 6, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -4, 0, 0,
+ax_anim 2, 0, 77, 1, -3, 1, 1,
+ax_anim 2, 2, 77, 2, -3, 1, 1,
+ax_anim 2, 0, 77, 1, -3, 1, 1,
+ax_anim 2, 0, 77, 2, -3, 1, 1,
+ax_anim 2, 0, 77, 1, -3, 1, 1,
+ax_anim 2, 1, 77, 2, -3, 1, 1,
+ax_anim 4, 0, 75, 1, -3, 1, 1,
+ax_anim_terminator
+sAlakazamAnims_4_3:
+ax_anim 2, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 4, 0, 79, 0, -4, 0, 0,
+ax_anim 6, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 1, -4, 1, 0,
+ax_anim 2, 2, 80, 2, -4, 1, 0,
+ax_anim 2, 0, 80, 1, -4, 1, 0,
+ax_anim 2, 0, 80, 2, -4, 1, 0,
+ax_anim 2, 0, 80, 1, -4, 1, 0,
+ax_anim 2, 1, 80, 2, -4, 1, 0,
+ax_anim 4, 0, 78, 1, -4, 1, 0,
+ax_anim_terminator
+sAlakazamAnims_4_4:
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 4, 0, 82, 0, -4, 0, 0,
+ax_anim 6, 0, 82, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 1, -5, 1, -1,
+ax_anim 2, 2, 83, 2, -4, 1, -1,
+ax_anim 2, 0, 83, 1, -5, 1, -1,
+ax_anim 2, 0, 83, 2, -4, 1, -1,
+ax_anim 2, 0, 83, 1, -5, 1, -1,
+ax_anim 2, 1, 83, 2, -4, 1, -1,
+ax_anim 4, 0, 81, 1, -5, 1, -1,
+ax_anim_terminator
+sAlakazamAnims_4_5:
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 4, 0, 85, 0, -4, 0, 0,
+ax_anim 6, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 2, 0, 86, 0, -6, 0, -1,
+ax_anim 2, 2, 86, 1, -5, 0, -1,
+ax_anim 2, 0, 86, 0, -5, 0, -1,
+ax_anim 2, 0, 86, 1, -5, 0, -1,
+ax_anim 2, 0, 86, 0, -5, 0, -1,
+ax_anim 2, 1, 86, 1, -5, 0, -1,
+ax_anim 4, 0, 84, 0, -5, 0, -1,
+ax_anim_terminator
+sAlakazamAnims_4_6:
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 4, 0, 88, 0, -4, 0, 0,
+ax_anim 6, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 89, -1, -5, -1, -1,
+ax_anim 2, 2, 89, -2, -4, -1, -1,
+ax_anim 2, 0, 89, -1, -5, -1, -1,
+ax_anim 2, 0, 89, -2, -4, -1, -1,
+ax_anim 2, 0, 89, -1, -5, -1, -1,
+ax_anim 2, 1, 89, -2, -4, -1, -1,
+ax_anim 4, 0, 87, -1, -5, -1, -1,
+ax_anim_terminator
+sAlakazamAnims_4_7:
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 4, 0, 91, 0, -4, 0, 0,
+ax_anim 6, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 92, -1, -4, -1, 0,
+ax_anim 2, 2, 92, -2, -4, -1, 0,
+ax_anim 2, 0, 92, -1, -4, -1, 0,
+ax_anim 2, 0, 92, -2, -4, -1, 0,
+ax_anim 2, 0, 92, -1, -4, -1, 0,
+ax_anim 2, 1, 92, -2, -4, -1, 0,
+ax_anim 4, 0, 90, -1, -4, -1, 0,
+ax_anim_terminator
+sAlakazamAnims_4_8:
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 4, 0, 94, 0, -4, 0, 0,
+ax_anim 6, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 95, -1, -3, -1, 1,
+ax_anim 2, 2, 95, -2, -3, -1, 1,
+ax_anim 2, 0, 95, -1, -3, -1, 1,
+ax_anim 2, 0, 95, -2, -3, -1, 1,
+ax_anim 2, 0, 95, -1, -3, -1, 1,
+ax_anim 2, 1, 95, -2, -3, -1, 1,
+ax_anim 4, 0, 93, -1, -3, -1, 1,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_5_1:
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 6, 2, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 4, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 4, 0, 96, 0, -4, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_5_2:
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 6, 2, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 4, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 4, 0, 99, 0, -4, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_5_3:
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 6, 2, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 4, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 4, 0, 102, 0, -4, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_5_4:
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 6, 2, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 4, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 4, 0, 105, 0, -4, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_5_5:
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 6, 2, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 4, 0, 108, 0, -4, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_5_6:
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 6, 2, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 4, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 4, 0, 111, 0, -4, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_5_7:
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 6, 2, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 4, 0, 114, 0, -4, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_5_8:
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 6, 2, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 4, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 4, 0, 117, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_7_1:
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 8, 0, 122, 0, -4, 0, -4,
+ax_anim_terminator
+sAlakazamAnims_7_2:
+ax_anim 2, 0, 123, -3, -3, -3, -3,
+ax_anim 8, 0, 123, -4, -4, -4, -4,
+ax_anim_terminator
+sAlakazamAnims_7_3:
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 8, 0, 124, -4, 0, -4, 0,
+ax_anim_terminator
+sAlakazamAnims_7_4:
+ax_anim 2, 0, 125, -3, 3, -3, 3,
+ax_anim 8, 0, 125, -4, 4, -4, 4,
+ax_anim_terminator
+sAlakazamAnims_7_5:
+ax_anim 2, 0, 126, 0, 3, 0, 3,
+ax_anim 8, 0, 126, 0, 4, 0, 4,
+ax_anim_terminator
+sAlakazamAnims_7_6:
+ax_anim 2, 0, 127, 3, 3, 3, 3,
+ax_anim 8, 0, 127, 4, 4, 4, 4,
+ax_anim_terminator
+sAlakazamAnims_7_7:
+ax_anim 2, 0, 128, 3, 0, 3, 0,
+ax_anim 8, 0, 128, 4, 0, 4, 0,
+ax_anim_terminator
+sAlakazamAnims_7_8:
+ax_anim 2, 0, 129, 3, -3, 3, -3,
+ax_anim 8, 0, 129, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_8_1:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, -1, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 131, 0, -3, 0, 0,
+ax_anim 6, 0, 131, 0, -3, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 131, 0, -1, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_8_2:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, -1, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 134, 0, -3, 0, 0,
+ax_anim 6, 0, 134, 0, -3, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 134, 0, -1, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_8_3:
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, -1, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 137, 0, -3, 0, 0,
+ax_anim 6, 0, 137, 0, -3, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 137, 0, -1, 0, 0,
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_8_4:
+ax_anim 6, 0, 140, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, -1, 0, 0,
+ax_anim 6, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 140, 0, -3, 0, 0,
+ax_anim 6, 0, 140, 0, -3, 0, 0,
+ax_anim 6, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 140, 0, -1, 0, 0,
+ax_anim 6, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_8_5:
+ax_anim 6, 0, 143, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, -1, 0, 0,
+ax_anim 6, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 143, 0, -3, 0, 0,
+ax_anim 6, 0, 143, 0, -3, 0, 0,
+ax_anim 6, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 143, 0, -1, 0, 0,
+ax_anim 6, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_8_6:
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 0, -1, 0, 0,
+ax_anim 6, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 146, 0, -3, 0, 0,
+ax_anim 6, 0, 146, 0, -3, 0, 0,
+ax_anim 6, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 146, 0, -1, 0, 0,
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_8_7:
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -1, 0, 0,
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 149, 0, -3, 0, 0,
+ax_anim 6, 0, 149, 0, -3, 0, 0,
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 149, 0, -1, 0, 0,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_8_8:
+ax_anim 6, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, 0,
+ax_anim 6, 0, 152, 0, -2, 0, 0,
+ax_anim 6, 0, 152, 0, -3, 0, 0,
+ax_anim 6, 0, 152, 0, -3, 0, 0,
+ax_anim 6, 0, 152, 0, -2, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, 0,
+ax_anim 6, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 11, 9, 11, 9,
+ax_anim 2, 0, 157, 9, 21, 9, 21,
+ax_anim 3, 0, 158, 1, 26, 1, 23,
+ax_anim 2, 3, 159, -9, 21, -9, 21,
+ax_anim 2, 0, 160, -11, 9, -11, 9,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 23, 11, 23, 11,
+ax_anim 3, 0, 157, 23, 26, 23, 23,
+ax_anim 2, 3, 158, 12, 28, 12, 26,
+ax_anim 2, 0, 159, 0, 17, 0, 17,
+ax_anim 1, 0, 160, -1, 7, -1, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -4, 17, -4,
+ax_anim 3, 0, 156, 22, 2, 22, 2,
+ax_anim 2, 3, 157, 17, 7, 17, 4,
+ax_anim 2, 0, 158, 12, 8, 12, 6,
+ax_anim 1, 0, 159, 1, 5, 1, 3,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 11, -20, 11, -20,
+ax_anim 3, 0, 155, 20, -20, 20, -20,
+ax_anim 2, 3, 156, 18, -13, 18, -13,
+ax_anim 2, 0, 157, 16, -6, 16, -6,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -10, -9, -10, -9,
+ax_anim 2, 0, 161, -9, -15, -9, -13,
+ax_anim 3, 0, 154, -1, -21, -1, -19,
+ax_anim 2, 3, 155, 9, -15, 9, -13,
+ax_anim 2, 0, 156, 10, -9, 10, -9,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, -1, -6, -1, -6,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -11, -20, -11, -20,
+ax_anim 3, 0, 161, -20, -20, -20, -20,
+ax_anim 2, 3, 160, -18, -13, -19, -13,
+ax_anim 2, 0, 159, -16, -6, -16, -6,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -4, -17, -4,
+ax_anim 3, 0, 160, -22, 2, -22, 2,
+ax_anim 2, 3, 159, -17, 7, -17, 4,
+ax_anim 2, 0, 158, -12, 8, -12, 6,
+ax_anim 1, 0, 157, -1, 5, -1, 3,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -23, 9, -23, 9,
+ax_anim 3, 0, 159, -23, 26, -23, 23,
+ax_anim 2, 3, 158, -12, 28, -12, 26,
+ax_anim 2, 0, 157, 0, 17, 0, 17,
+ax_anim 1, 0, 156, 1, 7, 1, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_14_1:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_14_2:
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_14_3:
+ax_anim 8, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_14_4:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 12, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 12, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_14_5:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_14_6:
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 12, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_14_7:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 12, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 12, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_14_8:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_15_1:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_15_2:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_15_3:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_15_4:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_15_5:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_15_6:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_15_7:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_15_8:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 6, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 12, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 6, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_16_1:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, 1, 1, 1,
+ax_anim_terminator
+sAlakazamAnims_16_2:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, -1, 1, -1, 1,
+ax_anim_terminator
+sAlakazamAnims_16_3:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, 1, 1, 1,
+ax_anim_terminator
+sAlakazamAnims_16_4:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, 1, 1, 1,
+ax_anim_terminator
+sAlakazamAnims_16_5:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, 1, 1, 1,
+ax_anim_terminator
+sAlakazamAnims_16_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, 1, 1, 1,
+ax_anim_terminator
+sAlakazamAnims_16_7:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, 1, 1, 1,
+ax_anim_terminator
+sAlakazamAnims_16_8:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_17_1:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_17_2:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_17_3:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_17_4:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_17_5:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_17_6:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_17_7:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamAnims_17_8:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 1, 0, 248, 0, -3, 0, 0,
+ax_anim 6, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 0, 248, 0, -3, 0, 0,
+ax_anim 1, 0, 248, 0, -2, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAlakazamAnims_18_1:
+ax_anim 4, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sAlakazamGfx1:
+.incbin "baserom.gba", 0x7D1410, 0x200
+sAlakazamSprites1:
+ax_sprite sAlakazamGfx1, 0x200
+ax_sprite_terminator
+sAlakazamGfx2:
+.incbin "baserom.gba", 0x7D1620, 0x200
+sAlakazamSprites2:
+ax_sprite sAlakazamGfx2, 0x200
+ax_sprite_terminator
+sAlakazamGfx3:
+.incbin "baserom.gba", 0x7D1830, 0x200
+sAlakazamSprites3:
+ax_sprite sAlakazamGfx3, 0x200
+ax_sprite_terminator
+sAlakazamGfx4:
+.incbin "baserom.gba", 0x7D1A40, 0x200
+sAlakazamSprites4:
+ax_sprite sAlakazamGfx4, 0x200
+ax_sprite_terminator
+sAlakazamGfx5:
+.incbin "baserom.gba", 0x7D1C50, 0x200
+sAlakazamSprites5:
+ax_sprite sAlakazamGfx5, 0x200
+ax_sprite_terminator
+sAlakazamGfx6:
+.incbin "baserom.gba", 0x7D1E60, 0x200
+sAlakazamSprites6:
+ax_sprite sAlakazamGfx6, 0x200
+ax_sprite_terminator
+sAlakazamGfx7:
+.incbin "baserom.gba", 0x7D2070, 0x200
+sAlakazamSprites7:
+ax_sprite sAlakazamGfx7, 0x200
+ax_sprite_terminator
+sAlakazamGfx8:
+.incbin "baserom.gba", 0x7D2280, 0x200
+sAlakazamSprites8:
+ax_sprite sAlakazamGfx8, 0x200
+ax_sprite_terminator
+sAlakazamGfx9:
+.incbin "baserom.gba", 0x7D2490, 0x200
+sAlakazamSprites9:
+ax_sprite sAlakazamGfx9, 0x200
+ax_sprite_terminator
+sAlakazamGfx10:
+.incbin "baserom.gba", 0x7D26A0, 0x200
+sAlakazamSprites10:
+ax_sprite sAlakazamGfx10, 0x200
+ax_sprite_terminator
+sAlakazamGfx11:
+.incbin "baserom.gba", 0x7D28B0, 0x200
+sAlakazamSprites11:
+ax_sprite sAlakazamGfx11, 0x200
+ax_sprite_terminator
+sAlakazamGfx12:
+.incbin "baserom.gba", 0x7D2AC0, 0x200
+sAlakazamSprites12:
+ax_sprite sAlakazamGfx12, 0x200
+ax_sprite_terminator
+sAlakazamGfx13:
+.incbin "baserom.gba", 0x7D2CD0, 0x200
+sAlakazamSprites13:
+ax_sprite sAlakazamGfx13, 0x200
+ax_sprite_terminator
+sAlakazamGfx14:
+.incbin "baserom.gba", 0x7D2EE0, 0x200
+sAlakazamSprites14:
+ax_sprite sAlakazamGfx14, 0x200
+ax_sprite_terminator
+sAlakazamGfx15:
+.incbin "baserom.gba", 0x7D30F0, 0x200
+sAlakazamSprites15:
+ax_sprite sAlakazamGfx15, 0x200
+ax_sprite_terminator
+sAlakazamGfx16:
+.incbin "baserom.gba", 0x7D3300, 0x40
+sAlakazamGfx16_1:
+.incbin "baserom.gba", 0x7D3340, 0x100
+sAlakazamSprites16:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx16_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAlakazamGfx17:
+.incbin "baserom.gba", 0x7D3470, 0x40
+sAlakazamGfx17_1:
+.incbin "baserom.gba", 0x7D34B0, 0x60
+sAlakazamGfx17_2:
+.incbin "baserom.gba", 0x7D3510, 0x40
+sAlakazamSprites17:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAlakazamGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAlakazamGfx18:
+.incbin "baserom.gba", 0x7D3590, 0x40
+sAlakazamGfx18_1:
+.incbin "baserom.gba", 0x7D35D0, 0x60
+sAlakazamGfx18_2:
+.incbin "baserom.gba", 0x7D3630, 0x80
+sAlakazamSprites18:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx18_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAlakazamGfx19:
+.incbin "baserom.gba", 0x7D36F0, 0x60
+sAlakazamGfx19_1:
+.incbin "baserom.gba", 0x7D3750, 0x60
+sAlakazamGfx19_2:
+.incbin "baserom.gba", 0x7D37B0, 0x60
+sAlakazamSprites19:
+ax_sprite sAlakazamGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAlakazamGfx20:
+.incbin "baserom.gba", 0x7D3848, 0x40
+sAlakazamGfx20_1:
+.incbin "baserom.gba", 0x7D3888, 0x60
+sAlakazamGfx20_2:
+.incbin "baserom.gba", 0x7D38E8, 0x60
+sAlakazamGfx20_3:
+.incbin "baserom.gba", 0x7D3948, 0x60
+sAlakazamSprites20:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAlakazamGfx21:
+.incbin "baserom.gba", 0x7D39F8, 0x40
+sAlakazamGfx21_1:
+.incbin "baserom.gba", 0x7D3A38, 0x60
+sAlakazamGfx21_2:
+.incbin "baserom.gba", 0x7D3A98, 0x60
+sAlakazamSprites21:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAlakazamGfx22:
+.incbin "baserom.gba", 0x7D3B38, 0x40
+sAlakazamGfx22_1:
+.incbin "baserom.gba", 0x7D3B78, 0xE0
+sAlakazamSprites22:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx22_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAlakazamGfx23:
+.incbin "baserom.gba", 0x7D3C88, 0x60
+sAlakazamGfx23_1:
+.incbin "baserom.gba", 0x7D3CE8, 0x60
+sAlakazamGfx23_2:
+.incbin "baserom.gba", 0x7D3D48, 0x40
+sAlakazamSprites23:
+ax_sprite sAlakazamGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAlakazamGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAlakazamGfx24:
+.incbin "baserom.gba", 0x7D3DC0, 0x40
+sAlakazamGfx24_1:
+.incbin "baserom.gba", 0x7D3E00, 0x60
+sAlakazamGfx24_2:
+.incbin "baserom.gba", 0x7D3E60, 0x80
+sAlakazamSprites24:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx24_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAlakazamGfx25:
+.incbin "baserom.gba", 0x7D3F20, 0x40
+sAlakazamGfx25_1:
+.incbin "baserom.gba", 0x7D3F60, 0x60
+sAlakazamGfx25_2:
+.incbin "baserom.gba", 0x7D3FC0, 0x40
+sAlakazamSprites25:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAlakazamGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAlakazamGfx26:
+.incbin "baserom.gba", 0x7D4040, 0x200
+sAlakazamSprites26:
+ax_sprite sAlakazamGfx26, 0x200
+ax_sprite_terminator
+sAlakazamGfx27:
+.incbin "baserom.gba", 0x7D4250, 0x200
+sAlakazamSprites27:
+ax_sprite sAlakazamGfx27, 0x200
+ax_sprite_terminator
+sAlakazamGfx28:
+.incbin "baserom.gba", 0x7D4460, 0x200
+sAlakazamSprites28:
+ax_sprite sAlakazamGfx28, 0x200
+ax_sprite_terminator
+sAlakazamGfx29:
+.incbin "baserom.gba", 0x7D4670, 0x200
+sAlakazamSprites29:
+ax_sprite sAlakazamGfx29, 0x200
+ax_sprite_terminator
+sAlakazamGfx30:
+.incbin "baserom.gba", 0x7D4880, 0x200
+sAlakazamSprites30:
+ax_sprite sAlakazamGfx30, 0x200
+ax_sprite_terminator
+sAlakazamGfx31:
+.incbin "baserom.gba", 0x7D4A90, 0x200
+sAlakazamSprites31:
+ax_sprite sAlakazamGfx31, 0x200
+ax_sprite_terminator
+sAlakazamGfx32:
+.incbin "baserom.gba", 0x7D4CA0, 0x200
+sAlakazamSprites32:
+ax_sprite sAlakazamGfx32, 0x200
+ax_sprite_terminator
+sAlakazamGfx33:
+.incbin "baserom.gba", 0x7D4EB0, 0x40
+sAlakazamGfx33_1:
+.incbin "baserom.gba", 0x7D4EF0, 0x60
+sAlakazamGfx33_2:
+.incbin "baserom.gba", 0x7D4F50, 0xE0
+sAlakazamSprites33:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx33_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAlakazamGfx34:
+.incbin "baserom.gba", 0x7D5070, 0xA0
+sAlakazamGfx34_1:
+.incbin "baserom.gba", 0x7D5110, 0x40
+sAlakazamGfx34_2:
+.incbin "baserom.gba", 0x7D5150, 0x20
+sAlakazamSprites34:
+ax_sprite sAlakazamGfx34, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sAlakazamGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAlakazamGfx34_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAlakazamGfx35:
+.incbin "baserom.gba", 0x7D51A8, 0x100
+sAlakazamGfx35_1:
+.incbin "baserom.gba", 0x7D52A8, 0x40
+sAlakazamGfx35_2:
+.incbin "baserom.gba", 0x7D52E8, 0x80
+sAlakazamSprites35:
+ax_sprite sAlakazamGfx35, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx35_2, 0x80
+ax_sprite_terminator
+sAlakazamGfx36:
+.incbin "baserom.gba", 0x7D5398, 0x60
+sAlakazamGfx36_1:
+.incbin "baserom.gba", 0x7D53F8, 0x100
+sAlakazamSprites36:
+ax_sprite sAlakazamGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx36_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAlakazamGfx37:
+.incbin "baserom.gba", 0x7D5520, 0x40
+sAlakazamGfx37_1:
+.incbin "baserom.gba", 0x7D5560, 0x60
+sAlakazamGfx37_2:
+.incbin "baserom.gba", 0x7D55C0, 0x100
+sAlakazamSprites37:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx37_2, 0x100
+ax_sprite_terminator
+sAlakazamGfx38:
+.incbin "baserom.gba", 0x7D56F8, 0x60
+sAlakazamSprites38:
+ax_sprite sAlakazamGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAlakazamGfx39:
+.incbin "baserom.gba", 0x7D5770, 0x40
+sAlakazamGfx39_1:
+.incbin "baserom.gba", 0x7D57B0, 0x60
+sAlakazamGfx39_2:
+.incbin "baserom.gba", 0x7D5810, 0x60
+sAlakazamGfx39_3:
+.incbin "baserom.gba", 0x7D5870, 0x60
+sAlakazamSprites39:
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAlakazamGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAlakazamGfx40:
+.incbin "baserom.gba", 0x7D5920, 0x80
+sAlakazamSprites40:
+ax_sprite sAlakazamGfx40, 0x80
+ax_sprite_terminator
+sAlakazamGfx41:
+.incbin "baserom.gba", 0x7D59B0, 0x80
+sAlakazamSprites41:
+ax_sprite sAlakazamGfx41, 0x80
+ax_sprite_terminator
+sAlakazamGfx42:
+.incbin "baserom.gba", 0x7D5A40, 0x80
+sAlakazamSprites42:
+ax_sprite sAlakazamGfx42, 0x80
+ax_sprite_terminator
+sAlakazamGfx43:
+.incbin "baserom.gba", 0x7D5AD0, 0x200
+sAlakazamSprites43:
+ax_sprite sAlakazamGfx43, 0x200
+ax_sprite_terminator
+sAlakazamGfx44:
+.incbin "baserom.gba", 0x7D5CE0, 0x200
+sAlakazamSprites44:
+ax_sprite sAlakazamGfx44, 0x200
+ax_sprite_terminator
+sAlakazamGfx45:
+.incbin "baserom.gba", 0x7D5EF0, 0x200
+sAlakazamSprites45:
+ax_sprite sAlakazamGfx45, 0x200
+ax_sprite_terminator
+sAxPosesAlakazam:
+.4byte sAlakazamPose1
+.4byte sAlakazamPose2
+.4byte sAlakazamPose3
+.4byte sAlakazamPose4
+.4byte sAlakazamPose5
+.4byte sAlakazamPose6
+.4byte sAlakazamPose7
+.4byte sAlakazamPose8
+.4byte sAlakazamPose9
+.4byte sAlakazamPose10
+.4byte sAlakazamPose11
+.4byte sAlakazamPose12
+.4byte sAlakazamPose13
+.4byte sAlakazamPose14
+.4byte sAlakazamPose15
+.4byte sAlakazamPose16
+.4byte sAlakazamPose17
+.4byte sAlakazamPose18
+.4byte sAlakazamPose19
+.4byte sAlakazamPose20
+.4byte sAlakazamPose21
+.4byte sAlakazamPose22
+.4byte sAlakazamPose23
+.4byte sAlakazamPose24
+.4byte sAlakazamPose25
+.4byte sAlakazamPose26
+.4byte sAlakazamPose27
+.4byte sAlakazamPose28
+.4byte sAlakazamPose29
+.4byte sAlakazamPose30
+.4byte sAlakazamPose31
+.4byte sAlakazamPose32
+.4byte sAlakazamPose33
+.4byte sAlakazamPose34
+.4byte sAlakazamPose35
+.4byte sAlakazamPose36
+.4byte sAlakazamPose37
+.4byte sAlakazamPose38
+.4byte sAlakazamPose39
+.4byte sAlakazamPose40
+.4byte sAlakazamPose41
+.4byte sAlakazamPose42
+.4byte sAlakazamPose43
+.4byte sAlakazamPose44
+.4byte sAlakazamPose45
+.4byte sAlakazamPose46
+.4byte sAlakazamPose47
+.4byte sAlakazamPose48
+.4byte sAlakazamPose49
+.4byte sAlakazamPose50
+.4byte sAlakazamPose51
+.4byte sAlakazamPose52
+.4byte sAlakazamPose53
+.4byte sAlakazamPose54
+.4byte sAlakazamPose55
+.4byte sAlakazamPose56
+.4byte sAlakazamPose57
+.4byte sAlakazamPose58
+.4byte sAlakazamPose59
+.4byte sAlakazamPose60
+.4byte sAlakazamPose61
+.4byte sAlakazamPose62
+.4byte sAlakazamPose63
+.4byte sAlakazamPose64
+.4byte sAlakazamPose65
+.4byte sAlakazamPose66
+.4byte sAlakazamPose67
+.4byte sAlakazamPose68
+.4byte sAlakazamPose69
+.4byte sAlakazamPose70
+.4byte sAlakazamPose71
+.4byte sAlakazamPose72
+.4byte sAlakazamPose73
+.4byte sAlakazamPose74
+.4byte sAlakazamPose75
+.4byte sAlakazamPose76
+.4byte sAlakazamPose77
+.4byte sAlakazamPose78
+.4byte sAlakazamPose79
+.4byte sAlakazamPose80
+.4byte sAlakazamPose81
+.4byte sAlakazamPose82
+.4byte sAlakazamPose83
+.4byte sAlakazamPose84
+.4byte sAlakazamPose85
+.4byte sAlakazamPose86
+.4byte sAlakazamPose87
+.4byte sAlakazamPose88
+.4byte sAlakazamPose89
+.4byte sAlakazamPose90
+.4byte sAlakazamPose91
+.4byte sAlakazamPose92
+.4byte sAlakazamPose93
+.4byte sAlakazamPose94
+.4byte sAlakazamPose95
+.4byte sAlakazamPose96
+.4byte sAlakazamPose97
+.4byte sAlakazamPose98
+.4byte sAlakazamPose99
+.4byte sAlakazamPose100
+.4byte sAlakazamPose101
+.4byte sAlakazamPose102
+.4byte sAlakazamPose103
+.4byte sAlakazamPose104
+.4byte sAlakazamPose105
+.4byte sAlakazamPose106
+.4byte sAlakazamPose107
+.4byte sAlakazamPose108
+.4byte sAlakazamPose109
+.4byte sAlakazamPose110
+.4byte sAlakazamPose111
+.4byte sAlakazamPose112
+.4byte sAlakazamPose113
+.4byte sAlakazamPose114
+.4byte sAlakazamPose115
+.4byte sAlakazamPose116
+.4byte sAlakazamPose117
+.4byte sAlakazamPose118
+.4byte sAlakazamPose119
+.4byte sAlakazamPose120
+.4byte sAlakazamPose121
+.4byte sAlakazamPose122
+.4byte sAlakazamPose123
+.4byte sAlakazamPose124
+.4byte sAlakazamPose125
+.4byte sAlakazamPose126
+.4byte sAlakazamPose127
+.4byte sAlakazamPose128
+.4byte sAlakazamPose129
+.4byte sAlakazamPose130
+.4byte sAlakazamPose131
+.4byte sAlakazamPose132
+.4byte sAlakazamPose133
+.4byte sAlakazamPose134
+.4byte sAlakazamPose135
+.4byte sAlakazamPose136
+.4byte sAlakazamPose137
+.4byte sAlakazamPose138
+.4byte sAlakazamPose139
+.4byte sAlakazamPose140
+.4byte sAlakazamPose141
+.4byte sAlakazamPose142
+.4byte sAlakazamPose143
+.4byte sAlakazamPose144
+.4byte sAlakazamPose145
+.4byte sAlakazamPose146
+.4byte sAlakazamPose147
+.4byte sAlakazamPose148
+.4byte sAlakazamPose149
+.4byte sAlakazamPose150
+.4byte sAlakazamPose151
+.4byte sAlakazamPose152
+.4byte sAlakazamPose153
+.4byte sAlakazamPose154
+.4byte sAlakazamPose155
+.4byte sAlakazamPose156
+.4byte sAlakazamPose157
+.4byte sAlakazamPose158
+.4byte sAlakazamPose159
+.4byte sAlakazamPose160
+.4byte sAlakazamPose161
+.4byte sAlakazamPose162
+.4byte sAlakazamPose163
+.4byte sAlakazamPose164
+.4byte sAlakazamPose165
+.4byte sAlakazamPose166
+.4byte sAlakazamPose167
+.4byte sAlakazamPose168
+.4byte sAlakazamPose169
+.4byte sAlakazamPose170
+.4byte sAlakazamPose171
+.4byte sAlakazamPose172
+.4byte sAlakazamPose173
+.4byte sAlakazamPose174
+.4byte sAlakazamPose175
+.4byte sAlakazamPose176
+.4byte sAlakazamPose177
+.4byte sAlakazamPose178
+.4byte sAlakazamPose179
+.4byte sAlakazamPose180
+.4byte sAlakazamPose181
+.4byte sAlakazamPose182
+.4byte sAlakazamPose183
+.4byte sAlakazamPose184
+.4byte sAlakazamPose185
+.4byte sAlakazamPose186
+.4byte sAlakazamPose187
+.4byte sAlakazamPose188
+.4byte sAlakazamPose189
+.4byte sAlakazamPose190
+.4byte sAlakazamPose191
+.4byte sAlakazamPose192
+.4byte sAlakazamPose193
+.4byte sAlakazamPose194
+.4byte sAlakazamPose195
+.4byte sAlakazamPose196
+.4byte sAlakazamPose197
+.4byte sAlakazamPose198
+.4byte sAlakazamPose199
+.4byte sAlakazamPose200
+.4byte sAlakazamPose201
+.4byte sAlakazamPose202
+.4byte sAlakazamPose203
+.4byte sAlakazamPose204
+.4byte sAlakazamPose205
+.4byte sAlakazamPose206
+.4byte sAlakazamPose207
+.4byte sAlakazamPose208
+.4byte sAlakazamPose209
+.4byte sAlakazamPose210
+.4byte sAlakazamPose211
+.4byte sAlakazamPose212
+.4byte sAlakazamPose213
+.4byte sAlakazamPose214
+.4byte sAlakazamPose215
+.4byte sAlakazamPose216
+.4byte sAlakazamPose217
+.4byte sAlakazamPose218
+.4byte sAlakazamPose219
+.4byte sAlakazamPose220
+.4byte sAlakazamPose221
+.4byte sAlakazamPose222
+.4byte sAlakazamPose223
+.4byte sAlakazamPose224
+.4byte sAlakazamPose225
+.4byte sAlakazamPose226
+.4byte sAlakazamPose227
+.4byte sAlakazamPose228
+.4byte sAlakazamPose229
+.4byte sAlakazamPose230
+.4byte sAlakazamPose231
+.4byte sAlakazamPose232
+.4byte sAlakazamPose233
+.4byte sAlakazamPose234
+.4byte sAlakazamPose235
+.4byte sAlakazamPose236
+.4byte sAlakazamPose237
+.4byte sAlakazamPose238
+.4byte sAlakazamPose239
+.4byte sAlakazamPose240
+.4byte sAlakazamPose241
+.4byte sAlakazamPose242
+.4byte sAlakazamPose243
+.4byte sAlakazamPose244
+.4byte sAlakazamPose245
+.4byte sAlakazamPose246
+.4byte sAlakazamPose247
+.4byte sAlakazamPose248
+.4byte sAlakazamPose249
+.4byte sAlakazamPose250
+sAxPositionsAlakazam:
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -10,   -5, 	   8,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -10,   -3, 	   8,   -6, 	  -1,   -9
+.2byte    5,   -9, 	  10,   -7, 	  -5,   -3, 	   2,  -10
+.2byte    5,   -8, 	   9,   -6, 	  -2,   -3, 	   1,   -8
+.2byte    5,   -8, 	  10,   -7, 	  -6,   -4, 	   1,   -9
+.2byte    8,  -10, 	   8,   -7, 	  -1,   -2, 	   1,   -9
+.2byte    8,   -9, 	   7,   -6, 	   1,   -1, 	   1,   -8
+.2byte    8,   -9, 	   8,   -6, 	  -3,   -1, 	   0,   -8
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	  -2,   -8, 	   9,   -6, 	   0,   -8
+.2byte    2,  -12, 	   0,  -12, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   8,   -6, 	 -10,   -9, 	  -1,   -9
+.2byte   -1,  -12, 	   8,   -9, 	 -10,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	   2,  -13, 	  -9,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	   0,   -8, 	 -11,   -6, 	  -2,   -8
+.2byte   -4,  -12, 	  -2,  -12, 	  -8,   -5, 	  -1,   -8
+.2byte   -8,  -10, 	  -8,   -7, 	   1,   -2, 	  -1,   -9
+.2byte   -8,   -9, 	  -7,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte   -8,   -9, 	  -8,   -6, 	   3,   -1, 	   0,   -8
+.2byte   -5,   -9, 	 -10,   -7, 	   5,   -3, 	  -2,  -10
+.2byte   -5,   -8, 	  -9,   -6, 	   2,   -3, 	  -1,   -8
+.2byte   -5,   -8, 	 -10,   -7, 	   6,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -10,   -5, 	   8,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -10,   -3, 	   8,   -6, 	  -1,   -9
+.2byte    5,   -9, 	  10,   -7, 	  -5,   -3, 	   2,  -10
+.2byte    5,   -8, 	   9,   -6, 	  -2,   -3, 	   1,   -8
+.2byte    5,   -8, 	  10,   -7, 	  -6,   -4, 	   1,   -9
+.2byte    8,  -10, 	   8,   -7, 	  -1,   -2, 	   1,   -9
+.2byte    8,   -9, 	   7,   -6, 	   1,   -1, 	   1,   -8
+.2byte    8,   -9, 	   8,   -6, 	  -3,   -1, 	   0,   -8
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	  -2,   -8, 	   9,   -6, 	   0,   -8
+.2byte    2,  -12, 	   0,  -12, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   8,   -6, 	 -10,   -9, 	  -1,   -9
+.2byte   -1,  -12, 	   8,   -9, 	 -10,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	   2,  -13, 	  -9,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	   0,   -8, 	 -11,   -6, 	  -2,   -8
+.2byte   -4,  -12, 	  -2,  -12, 	  -8,   -5, 	  -1,   -8
+.2byte   -8,  -10, 	  -8,   -7, 	   1,   -2, 	  -1,   -9
+.2byte   -8,   -9, 	  -7,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte   -8,   -9, 	  -8,   -6, 	   3,   -1, 	   0,   -8
+.2byte   -5,   -9, 	 -10,   -7, 	   5,   -3, 	  -2,  -10
+.2byte   -5,   -8, 	  -9,   -6, 	   2,   -3, 	  -1,   -8
+.2byte   -5,   -8, 	 -10,   -7, 	   6,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -10,   -5, 	   8,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -10,   -3, 	   8,   -6, 	  -1,   -9
+.2byte    5,   -9, 	  10,   -7, 	  -5,   -3, 	   2,  -10
+.2byte    5,   -8, 	   9,   -6, 	  -2,   -3, 	   1,   -8
+.2byte    5,   -8, 	  10,   -7, 	  -6,   -4, 	   1,   -9
+.2byte    8,  -10, 	   8,   -7, 	  -1,   -2, 	   1,   -9
+.2byte    8,   -9, 	   7,   -6, 	   1,   -1, 	   1,   -8
+.2byte    8,   -9, 	   8,   -6, 	  -3,   -1, 	   0,   -8
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	  -2,   -8, 	   9,   -6, 	   0,   -8
+.2byte    2,  -12, 	   0,  -12, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   8,   -6, 	 -10,   -9, 	  -1,   -9
+.2byte   -1,  -12, 	   8,   -9, 	 -10,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	   2,  -13, 	  -9,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	   0,   -8, 	 -11,   -6, 	  -2,   -8
+.2byte   -4,  -12, 	  -2,  -12, 	  -8,   -5, 	  -1,   -8
+.2byte   -8,  -10, 	  -8,   -7, 	   1,   -2, 	  -1,   -9
+.2byte   -8,   -9, 	  -7,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte   -8,   -9, 	  -8,   -6, 	   3,   -1, 	   0,   -8
+.2byte   -5,   -9, 	 -10,   -7, 	   5,   -3, 	  -2,  -10
+.2byte   -5,   -8, 	  -9,   -6, 	   2,   -3, 	  -1,   -8
+.2byte   -5,   -8, 	 -10,   -7, 	   6,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -8
+.2byte    3,   -9, 	   8,   -7, 	  -7,   -3, 	   0,  -10
+.2byte    3,   -9, 	  11,  -11, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -7, 	   6,   -6, 	   4,   -5, 	   0,   -8
+.2byte    6,  -10, 	   6,   -7, 	  -3,   -2, 	  -1,   -9
+.2byte    6,  -10, 	   0,   -5, 	  -5,   -1, 	  -2,   -9
+.2byte    6,   -9, 	  10,   -8, 	   8,   -7, 	  -1,   -9
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	 -10,  -11, 	  10,   -5, 	  -1,  -11
+.2byte    5,  -11, 	   7,  -13, 	  10,  -12, 	   0,  -11
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -14, 	   9,   -8, 	 -11,   -8, 	  -1,  -11
+.2byte   -1,  -14, 	   3,  -15, 	  -5,  -15, 	  -1,  -11
+.2byte   -3,  -13, 	   3,  -13, 	  -8,   -6, 	   0,   -9
+.2byte   -4,  -12, 	   9,  -11, 	 -11,   -5, 	   0,  -11
+.2byte   -6,  -11, 	  -8,  -13, 	 -11,  -12, 	  -1,  -11
+.2byte   -7,  -10, 	  -7,   -7, 	   2,   -2, 	   0,   -9
+.2byte   -7,  -10, 	  -1,   -5, 	   4,   -1, 	   1,   -9
+.2byte   -7,   -9, 	 -11,   -8, 	  -9,   -7, 	   0,   -9
+.2byte   -4,   -9, 	  -9,   -7, 	   6,   -3, 	  -1,  -10
+.2byte   -4,   -9, 	 -12,  -11, 	   8,   -3, 	   0,   -9
+.2byte   -5,   -7, 	  -7,   -6, 	  -5,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -8
+.2byte    3,   -9, 	   8,   -7, 	  -7,   -3, 	   0,  -10
+.2byte    3,   -9, 	  11,  -11, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -7, 	   6,   -6, 	   4,   -5, 	   0,   -8
+.2byte    6,  -10, 	   6,   -7, 	  -3,   -2, 	  -1,   -9
+.2byte    6,  -10, 	   0,   -5, 	  -5,   -1, 	  -2,   -9
+.2byte    6,   -9, 	  10,   -8, 	   8,   -7, 	  -1,   -9
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	 -10,  -11, 	  10,   -5, 	  -1,  -11
+.2byte    5,  -11, 	   7,  -13, 	  10,  -12, 	   0,  -11
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -14, 	   9,   -8, 	 -11,   -8, 	  -1,  -11
+.2byte   -1,  -14, 	   3,  -15, 	  -5,  -15, 	  -1,  -11
+.2byte   -3,  -13, 	   3,  -13, 	  -8,   -6, 	   0,   -9
+.2byte   -4,  -12, 	   9,  -11, 	 -11,   -5, 	   0,  -11
+.2byte   -6,  -11, 	  -8,  -13, 	 -11,  -12, 	  -1,  -11
+.2byte   -7,  -10, 	  -7,   -7, 	   2,   -2, 	   0,   -9
+.2byte   -7,  -10, 	  -1,   -5, 	   4,   -1, 	   1,   -9
+.2byte   -7,   -9, 	 -11,   -8, 	  -9,   -7, 	   0,   -9
+.2byte   -4,   -9, 	  -9,   -7, 	   6,   -3, 	  -1,  -10
+.2byte   -4,   -9, 	 -12,  -11, 	   8,   -3, 	   0,   -9
+.2byte   -5,   -7, 	  -7,   -6, 	  -5,   -5, 	  -1,   -8
+.2byte   -5,   -6, 	  -9,   -4, 	   7,    1, 	  -1,   -6
+.2byte   -5,   -5, 	  -9,   -3, 	   7,    2, 	  -1,   -6
+.2byte    0,  -11, 	 -12,  -13, 	  12,  -13, 	   0,  -10
+.2byte    0,  -12, 	  11,  -18, 	 -14,   -5, 	  -1,  -10
+.2byte    0,  -14, 	   6,  -17, 	  -9,   -9, 	  -3,  -11
+.2byte    0,  -15, 	 -12,  -16, 	   8,   -8, 	  -2,   -9
+.2byte    0,  -15, 	  12,  -12, 	 -12,  -12, 	   0,   -9
+.2byte   -1,  -15, 	  11,  -16, 	  -9,   -8, 	   1,   -9
+.2byte   -1,  -14, 	  -7,  -17, 	   8,   -9, 	   2,  -11
+.2byte   -1,  -12, 	 -12,  -18, 	  13,   -5, 	   0,  -10
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -8
+.2byte    3,   -9, 	   8,   -7, 	  -7,   -3, 	   0,  -10
+.2byte    3,   -9, 	  11,  -11, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -7, 	   6,   -6, 	   4,   -5, 	   0,   -8
+.2byte    6,  -10, 	   6,   -7, 	  -3,   -2, 	  -1,   -9
+.2byte    6,  -10, 	   0,   -5, 	  -5,   -1, 	  -2,   -9
+.2byte    6,   -9, 	  10,   -8, 	   8,   -7, 	  -1,   -9
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	 -10,  -11, 	  10,   -5, 	  -1,  -11
+.2byte    5,  -11, 	   7,  -13, 	  10,  -12, 	   0,  -11
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -14, 	   9,   -8, 	 -11,   -8, 	  -1,  -11
+.2byte   -1,  -14, 	   3,  -15, 	  -5,  -15, 	  -1,  -11
+.2byte   -3,  -13, 	   3,  -13, 	  -8,   -6, 	   0,   -9
+.2byte   -4,  -12, 	   9,  -11, 	 -11,   -5, 	   0,  -11
+.2byte   -6,  -11, 	  -8,  -13, 	 -11,  -12, 	  -1,  -11
+.2byte   -7,  -10, 	  -7,   -7, 	   2,   -2, 	   0,   -9
+.2byte   -7,  -10, 	  -1,   -5, 	   4,   -1, 	   1,   -9
+.2byte   -7,   -9, 	 -11,   -8, 	  -9,   -7, 	   0,   -9
+.2byte   -4,   -9, 	  -9,   -7, 	   6,   -3, 	  -1,  -10
+.2byte   -4,   -9, 	 -12,  -11, 	   8,   -3, 	   0,   -9
+.2byte   -5,   -7, 	  -7,   -6, 	  -5,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,   -9
+.2byte   -5,   -9, 	 -13,  -11, 	   7,   -3, 	  -1,   -9
+.2byte   -8,  -11, 	  -2,   -6, 	   3,   -2, 	   0,  -10
+.2byte   -5,  -12, 	   8,  -11, 	 -12,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	   9,   -8, 	 -11,   -8, 	  -1,  -11
+.2byte    4,  -12, 	  -9,  -11, 	  11,   -5, 	   0,  -11
+.2byte    9,  -11, 	   3,   -6, 	  -2,   -2, 	   1,  -10
+.2byte    6,   -9, 	  14,  -11, 	  -6,   -3, 	   2,   -9
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,   -9
+.2byte    6,   -9, 	  14,  -11, 	  -6,   -3, 	   2,   -9
+.2byte    9,  -11, 	   3,   -6, 	  -2,   -2, 	   1,  -10
+.2byte    4,  -12, 	  -9,  -11, 	  11,   -5, 	   0,  -11
+.2byte   -1,  -14, 	   9,   -8, 	 -11,   -8, 	  -1,  -11
+.2byte   -5,  -12, 	   8,  -11, 	 -12,   -5, 	  -1,  -11
+.2byte   -8,  -11, 	  -2,   -6, 	   3,   -2, 	   0,  -10
+.2byte   -5,   -9, 	 -13,  -11, 	   7,   -3, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -8
+.2byte    5,   -9, 	  10,   -7, 	  -5,   -3, 	   2,  -10
+.2byte    5,   -9, 	  13,  -11, 	  -7,   -3, 	   1,   -9
+.2byte    6,   -7, 	   8,   -6, 	   6,   -5, 	   2,   -8
+.2byte    8,  -10, 	   8,   -7, 	  -1,   -2, 	   1,   -9
+.2byte    8,  -10, 	   2,   -5, 	  -3,   -1, 	   0,   -9
+.2byte    8,   -9, 	  12,   -8, 	  10,   -7, 	   1,   -9
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	 -10,  -11, 	  10,   -5, 	  -1,  -11
+.2byte    5,  -11, 	   7,  -13, 	  10,  -12, 	   0,  -11
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -14, 	   9,   -8, 	 -11,   -8, 	  -1,  -11
+.2byte   -1,  -14, 	   3,  -15, 	  -5,  -15, 	  -1,  -11
+.2byte   -4,  -13, 	   2,  -13, 	  -9,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	   8,  -11, 	 -12,   -5, 	  -1,  -11
+.2byte   -7,  -11, 	  -9,  -13, 	 -12,  -12, 	  -2,  -11
+.2byte   -8,  -10, 	  -8,   -7, 	   1,   -2, 	  -1,   -9
+.2byte   -8,  -10, 	  -2,   -5, 	   3,   -1, 	   0,   -9
+.2byte   -8,   -9, 	 -12,   -8, 	 -10,   -7, 	  -1,   -9
+.2byte   -5,   -9, 	 -10,   -7, 	   5,   -3, 	  -2,  -10
+.2byte   -5,   -9, 	 -13,  -11, 	   7,   -3, 	  -1,   -9
+.2byte   -6,   -7, 	  -8,   -6, 	  -6,   -5, 	  -2,   -8
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,   -9
+.2byte   -5,   -9, 	 -13,  -11, 	   7,   -3, 	  -1,   -9
+.2byte   -8,  -11, 	  -2,   -6, 	   3,   -2, 	   0,  -10
+.2byte   -5,  -13, 	   8,  -12, 	 -12,   -6, 	  -1,  -12
+.2byte   -1,  -15, 	   9,   -9, 	 -11,   -9, 	  -1,  -12
+.2byte    4,  -13, 	  -9,  -12, 	  11,   -6, 	   0,  -12
+.2byte    9,  -11, 	   3,   -6, 	  -2,   -2, 	   1,  -10
+.2byte    6,   -9, 	  14,  -11, 	  -6,   -3, 	   2,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -5,   -9, 	 -10,   -7, 	   5,   -3, 	  -2,  -10
+.2byte   -8,  -10, 	  -8,   -7, 	   1,   -2, 	  -1,   -9
+.2byte   -4,  -13, 	   2,  -13, 	  -9,   -6, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    8,  -10, 	   8,   -7, 	  -1,   -2, 	   1,   -9
+.2byte    5,   -9, 	  10,   -7, 	  -5,   -3, 	   2,  -10
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -10,   -5, 	   8,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -10,   -3, 	   8,   -6, 	  -1,   -9
+.2byte    5,   -9, 	  10,   -7, 	  -5,   -3, 	   2,  -10
+.2byte    5,   -8, 	   9,   -6, 	  -2,   -3, 	   1,   -8
+.2byte    5,   -8, 	  10,   -7, 	  -6,   -4, 	   1,   -9
+.2byte    8,  -10, 	   8,   -7, 	  -1,   -2, 	   1,   -9
+.2byte    8,   -9, 	   7,   -6, 	   1,   -1, 	   1,   -8
+.2byte    8,   -9, 	   8,   -6, 	  -3,   -1, 	   0,   -8
+.2byte    2,  -13, 	  -4,  -13, 	   7,   -6, 	  -1,   -9
+.2byte    3,  -12, 	  -2,   -8, 	   9,   -6, 	   0,   -8
+.2byte    2,  -12, 	   0,  -12, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   8,   -6, 	 -10,   -9, 	  -1,   -9
+.2byte   -1,  -12, 	   8,   -9, 	 -10,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	   2,  -13, 	  -9,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	   0,   -8, 	 -11,   -6, 	  -2,   -8
+.2byte   -4,  -12, 	  -2,  -12, 	  -8,   -5, 	  -1,   -8
+.2byte   -8,  -10, 	  -8,   -7, 	   1,   -2, 	  -1,   -9
+.2byte   -8,   -9, 	  -7,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte   -8,   -9, 	  -8,   -6, 	   3,   -1, 	   0,   -8
+.2byte   -5,   -9, 	 -10,   -7, 	   5,   -3, 	  -2,  -10
+.2byte   -5,   -8, 	  -9,   -6, 	   2,   -3, 	  -1,   -8
+.2byte   -5,   -8, 	 -10,   -7, 	   6,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,  -10
+.2byte   -1,   -5, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,  -10, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,  -10, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -5, 	  -6,   -2, 	   4,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -2, 	   4,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,  -10, 	  -7,  -10, 	   2,   -3, 	   0,   -9
+.2byte    0,  -10, 	   6,  -10, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   -4,  -15, 	   9,  -22, 	 -13,  -17, 	  -1,  -14
+.2byte  -12,   -1, 	  -8,   -4, 	  -7,    3, 	  -1,   -4
+sAlakazamAnimTable1:
+.4byte sAlakazamAnims_1_1
+.4byte sAlakazamAnims_1_2
+.4byte sAlakazamAnims_1_3
+.4byte sAlakazamAnims_1_4
+.4byte sAlakazamAnims_1_5
+.4byte sAlakazamAnims_1_6
+.4byte sAlakazamAnims_1_7
+.4byte sAlakazamAnims_1_8
+sAlakazamAnimTable2:
+.4byte sAlakazamAnims_2_1
+.4byte sAlakazamAnims_2_2
+.4byte sAlakazamAnims_2_3
+.4byte sAlakazamAnims_2_4
+.4byte sAlakazamAnims_2_5
+.4byte sAlakazamAnims_2_6
+.4byte sAlakazamAnims_2_7
+.4byte sAlakazamAnims_2_8
+sAlakazamAnimTable3:
+.4byte sAlakazamAnims_3_1
+.4byte sAlakazamAnims_3_2
+.4byte sAlakazamAnims_3_3
+.4byte sAlakazamAnims_3_4
+.4byte sAlakazamAnims_3_5
+.4byte sAlakazamAnims_3_6
+.4byte sAlakazamAnims_3_7
+.4byte sAlakazamAnims_3_8
+sAlakazamAnimTable4:
+.4byte sAlakazamAnims_4_1
+.4byte sAlakazamAnims_4_2
+.4byte sAlakazamAnims_4_3
+.4byte sAlakazamAnims_4_4
+.4byte sAlakazamAnims_4_5
+.4byte sAlakazamAnims_4_6
+.4byte sAlakazamAnims_4_7
+.4byte sAlakazamAnims_4_8
+sAlakazamAnimTable5:
+.4byte sAlakazamAnims_5_1
+.4byte sAlakazamAnims_5_2
+.4byte sAlakazamAnims_5_3
+.4byte sAlakazamAnims_5_4
+.4byte sAlakazamAnims_5_5
+.4byte sAlakazamAnims_5_6
+.4byte sAlakazamAnims_5_7
+.4byte sAlakazamAnims_5_8
+sAlakazamAnimTable6:
+.4byte sAlakazamAnims_6_1
+.4byte sAlakazamAnims_6_1
+.4byte sAlakazamAnims_6_1
+.4byte sAlakazamAnims_6_1
+.4byte sAlakazamAnims_6_1
+.4byte sAlakazamAnims_6_1
+.4byte sAlakazamAnims_6_1
+.4byte sAlakazamAnims_6_1
+sAlakazamAnimTable7:
+.4byte sAlakazamAnims_7_1
+.4byte sAlakazamAnims_7_2
+.4byte sAlakazamAnims_7_3
+.4byte sAlakazamAnims_7_4
+.4byte sAlakazamAnims_7_5
+.4byte sAlakazamAnims_7_6
+.4byte sAlakazamAnims_7_7
+.4byte sAlakazamAnims_7_8
+sAlakazamAnimTable8:
+.4byte sAlakazamAnims_8_1
+.4byte sAlakazamAnims_8_2
+.4byte sAlakazamAnims_8_3
+.4byte sAlakazamAnims_8_4
+.4byte sAlakazamAnims_8_5
+.4byte sAlakazamAnims_8_6
+.4byte sAlakazamAnims_8_7
+.4byte sAlakazamAnims_8_8
+sAlakazamAnimTable9:
+.4byte sAlakazamAnims_9_1
+.4byte sAlakazamAnims_9_2
+.4byte sAlakazamAnims_9_3
+.4byte sAlakazamAnims_9_4
+.4byte sAlakazamAnims_9_5
+.4byte sAlakazamAnims_9_6
+.4byte sAlakazamAnims_9_7
+.4byte sAlakazamAnims_9_8
+sAlakazamAnimTable10:
+.4byte sAlakazamAnims_10_1
+.4byte sAlakazamAnims_10_2
+.4byte sAlakazamAnims_10_3
+.4byte sAlakazamAnims_10_4
+.4byte sAlakazamAnims_10_5
+.4byte sAlakazamAnims_10_6
+.4byte sAlakazamAnims_10_7
+.4byte sAlakazamAnims_10_8
+sAlakazamAnimTable11:
+.4byte sAlakazamAnims_11_1
+.4byte sAlakazamAnims_11_2
+.4byte sAlakazamAnims_11_3
+.4byte sAlakazamAnims_11_4
+.4byte sAlakazamAnims_11_5
+.4byte sAlakazamAnims_11_6
+.4byte sAlakazamAnims_11_7
+.4byte sAlakazamAnims_11_8
+sAlakazamAnimTable12:
+.4byte sAlakazamAnims_12_1
+.4byte sAlakazamAnims_12_2
+.4byte sAlakazamAnims_12_3
+.4byte sAlakazamAnims_12_4
+.4byte sAlakazamAnims_12_5
+.4byte sAlakazamAnims_12_6
+.4byte sAlakazamAnims_12_7
+.4byte sAlakazamAnims_12_8
+sAlakazamAnimTable13:
+.4byte sAlakazamAnims_13_1
+.4byte sAlakazamAnims_13_2
+.4byte sAlakazamAnims_13_3
+.4byte sAlakazamAnims_13_4
+.4byte sAlakazamAnims_13_5
+.4byte sAlakazamAnims_13_6
+.4byte sAlakazamAnims_13_7
+.4byte sAlakazamAnims_13_8
+sAlakazamAnimTable14:
+.4byte sAlakazamAnims_14_1
+.4byte sAlakazamAnims_14_2
+.4byte sAlakazamAnims_14_3
+.4byte sAlakazamAnims_14_4
+.4byte sAlakazamAnims_14_5
+.4byte sAlakazamAnims_14_6
+.4byte sAlakazamAnims_14_7
+.4byte sAlakazamAnims_14_8
+sAlakazamAnimTable15:
+.4byte sAlakazamAnims_15_1
+.4byte sAlakazamAnims_15_2
+.4byte sAlakazamAnims_15_3
+.4byte sAlakazamAnims_15_4
+.4byte sAlakazamAnims_15_5
+.4byte sAlakazamAnims_15_6
+.4byte sAlakazamAnims_15_7
+.4byte sAlakazamAnims_15_8
+sAlakazamAnimTable16:
+.4byte sAlakazamAnims_16_1
+.4byte sAlakazamAnims_16_2
+.4byte sAlakazamAnims_16_3
+.4byte sAlakazamAnims_16_4
+.4byte sAlakazamAnims_16_5
+.4byte sAlakazamAnims_16_6
+.4byte sAlakazamAnims_16_7
+.4byte sAlakazamAnims_16_8
+sAlakazamAnimTable17:
+.4byte sAlakazamAnims_17_1
+.4byte sAlakazamAnims_17_2
+.4byte sAlakazamAnims_17_3
+.4byte sAlakazamAnims_17_4
+.4byte sAlakazamAnims_17_5
+.4byte sAlakazamAnims_17_6
+.4byte sAlakazamAnims_17_7
+.4byte sAlakazamAnims_17_8
+sAlakazamAnimTable18:
+.4byte sAlakazamAnims_18_1
+.4byte sAlakazamAnims_18_1
+.4byte sAlakazamAnims_18_1
+.4byte sAlakazamAnims_18_1
+.4byte sAlakazamAnims_18_1
+.4byte sAlakazamAnims_18_1
+.4byte sAlakazamAnims_18_1
+.4byte sAlakazamAnims_18_1
+sAxAnimationsAlakazam:
+.4byte sAlakazamAnimTable1
+.4byte sAlakazamAnimTable2
+.4byte sAlakazamAnimTable3
+.4byte sAlakazamAnimTable4
+.4byte sAlakazamAnimTable5
+.4byte sAlakazamAnimTable6
+.4byte sAlakazamAnimTable7
+.4byte sAlakazamAnimTable8
+.4byte sAlakazamAnimTable9
+.4byte sAlakazamAnimTable10
+.4byte sAlakazamAnimTable11
+.4byte sAlakazamAnimTable12
+.4byte sAlakazamAnimTable13
+.4byte sAlakazamAnimTable14
+.4byte sAlakazamAnimTable15
+.4byte sAlakazamAnimTable16
+.4byte sAlakazamAnimTable17
+.4byte sAlakazamAnimTable18
+sAxSpritesAlakazam:
+.4byte sAlakazamSprites1
+.4byte sAlakazamSprites2
+.4byte sAlakazamSprites3
+.4byte sAlakazamSprites4
+.4byte sAlakazamSprites5
+.4byte sAlakazamSprites6
+.4byte sAlakazamSprites7
+.4byte sAlakazamSprites8
+.4byte sAlakazamSprites9
+.4byte sAlakazamSprites10
+.4byte sAlakazamSprites11
+.4byte sAlakazamSprites12
+.4byte sAlakazamSprites13
+.4byte sAlakazamSprites14
+.4byte sAlakazamSprites15
+.4byte sAlakazamSprites16
+.4byte sAlakazamSprites17
+.4byte sAlakazamSprites18
+.4byte sAlakazamSprites19
+.4byte sAlakazamSprites20
+.4byte sAlakazamSprites21
+.4byte sAlakazamSprites22
+.4byte sAlakazamSprites23
+.4byte sAlakazamSprites24
+.4byte sAlakazamSprites25
+.4byte sAlakazamSprites26
+.4byte sAlakazamSprites27
+.4byte sAlakazamSprites28
+.4byte sAlakazamSprites29
+.4byte sAlakazamSprites30
+.4byte sAlakazamSprites31
+.4byte sAlakazamSprites32
+.4byte sAlakazamSprites33
+.4byte sAlakazamSprites34
+.4byte sAlakazamSprites35
+.4byte sAlakazamSprites36
+.4byte sAlakazamSprites37
+.4byte sAlakazamSprites38
+.4byte sAlakazamSprites39
+.4byte sAlakazamSprites40
+.4byte sAlakazamSprites41
+.4byte sAlakazamSprites42
+.4byte sAlakazamSprites43
+.4byte sAlakazamSprites44
+.4byte sAlakazamSprites45
+sAxMainAlakazam:
+ax_main sAxPosesAlakazam, sAxAnimationsAlakazam, 18, sAxSpritesAlakazam, sAxPositionsAlakazam

--- a/data/ax/altaria.inc
+++ b/data/ax/altaria.inc
@@ -1,0 +1,3292 @@
+.global gAxAltaria
+gAxAltaria:
+ax_siro sAxMainAltaria
+sAltariaPose1:
+ax_pose 0, 0x01ec, 0x00e8, 0x5c00
+ax_pose 1, 0x01ec, 0x0110, 0x5c01
+ax_pose 2, 0x41e5, 0x80f0, 0x5c02
+ax_pose 3, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose2:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose3:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose4:
+ax_pose 6, 0x01ee, 0x10e7, 0x5c00
+ax_pose 7, 0x41e5, 0x90ef, 0x5c01
+ax_pose 8, 0x41f5, 0x50ef, 0x5c09
+ax_pose_terminator
+sAltariaPose5:
+ax_pose 9, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose6:
+ax_pose 10, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose7:
+ax_pose 11, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose8:
+ax_pose 12, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose9:
+ax_pose 13, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose10:
+ax_pose 14, 0x01f2, 0x1111, 0x5c00
+ax_pose 15, 0x41e5, 0x90f1, 0x5c01
+ax_pose 16, 0x41f5, 0x50f1, 0x5c09
+ax_pose 17, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose11:
+ax_pose 18, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose12:
+ax_pose 19, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose13:
+ax_pose 20, 0x01ed, 0x0110, 0x5c00
+ax_pose 21, 0x41e9, 0x40f0, 0x5c01
+ax_pose 22, 0x41e1, 0x00f8, 0x5c05
+ax_pose 23, 0x41f1, 0x80f0, 0x5c07
+ax_pose 24, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose14:
+ax_pose 25, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose15:
+ax_pose 26, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose16:
+ax_pose 14, 0x01f2, 0x00e7, 0x5c00
+ax_pose 15, 0x41e5, 0x80ef, 0x5c01
+ax_pose 16, 0x41f5, 0x40ef, 0x5c09
+ax_pose 17, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose17:
+ax_pose 18, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose18:
+ax_pose 19, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose19:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose20:
+ax_pose 12, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose21:
+ax_pose 13, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose22:
+ax_pose 6, 0x01ee, 0x0111, 0x5c00
+ax_pose 7, 0x41e5, 0x80f1, 0x5c01
+ax_pose 8, 0x41f5, 0x40f1, 0x5c09
+ax_pose_terminator
+sAltariaPose23:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose24:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose25:
+ax_pose 0, 0x01ec, 0x00e8, 0x5c00
+ax_pose 1, 0x01ec, 0x0110, 0x5c01
+ax_pose 2, 0x41e5, 0x80f0, 0x5c02
+ax_pose 3, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose26:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose27:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose28:
+ax_pose 6, 0x01ee, 0x10e7, 0x5c00
+ax_pose 7, 0x41e5, 0x90ef, 0x5c01
+ax_pose 8, 0x41f5, 0x50ef, 0x5c09
+ax_pose_terminator
+sAltariaPose29:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose30:
+ax_pose 10, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose31:
+ax_pose 11, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose32:
+ax_pose 12, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose33:
+ax_pose 13, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose34:
+ax_pose 14, 0x01f2, 0x1111, 0x5c00
+ax_pose 15, 0x41e5, 0x90f1, 0x5c01
+ax_pose 16, 0x41f5, 0x50f1, 0x5c09
+ax_pose 17, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose35:
+ax_pose 18, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose36:
+ax_pose 19, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose37:
+ax_pose 20, 0x01ed, 0x0110, 0x5c00
+ax_pose 21, 0x41e9, 0x40f0, 0x5c01
+ax_pose 22, 0x41e1, 0x00f8, 0x5c05
+ax_pose 23, 0x41f1, 0x80f0, 0x5c07
+ax_pose 24, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose38:
+ax_pose 25, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose39:
+ax_pose 26, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose40:
+ax_pose 14, 0x01f2, 0x00e7, 0x5c00
+ax_pose 15, 0x41e5, 0x80ef, 0x5c01
+ax_pose 16, 0x41f5, 0x40ef, 0x5c09
+ax_pose 17, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose41:
+ax_pose 18, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose42:
+ax_pose 19, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose43:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose44:
+ax_pose 12, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose45:
+ax_pose 13, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose46:
+ax_pose 6, 0x01ee, 0x0111, 0x5c00
+ax_pose 7, 0x41e5, 0x80f1, 0x5c01
+ax_pose 8, 0x41f5, 0x40f1, 0x5c09
+ax_pose_terminator
+sAltariaPose47:
+ax_pose 9, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose48:
+ax_pose 10, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose49:
+ax_pose 0, 0x01ec, 0x00e8, 0x5c00
+ax_pose 1, 0x01ec, 0x0110, 0x5c01
+ax_pose 2, 0x41e5, 0x80f0, 0x5c02
+ax_pose 3, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose50:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose51:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose52:
+ax_pose 6, 0x01ee, 0x10e7, 0x5c00
+ax_pose 7, 0x41e5, 0x90ef, 0x5c01
+ax_pose 8, 0x41f5, 0x50ef, 0x5c09
+ax_pose_terminator
+sAltariaPose53:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose54:
+ax_pose 10, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose55:
+ax_pose 11, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose56:
+ax_pose 12, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose57:
+ax_pose 13, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose58:
+ax_pose 14, 0x01f2, 0x1111, 0x5c00
+ax_pose 15, 0x41e5, 0x90f1, 0x5c01
+ax_pose 16, 0x41f5, 0x50f1, 0x5c09
+ax_pose 17, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose59:
+ax_pose 18, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose60:
+ax_pose 19, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose61:
+ax_pose 20, 0x01ed, 0x0110, 0x5c00
+ax_pose 21, 0x41e9, 0x40f0, 0x5c01
+ax_pose 22, 0x41e1, 0x00f8, 0x5c05
+ax_pose 23, 0x41f1, 0x80f0, 0x5c07
+ax_pose 24, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose62:
+ax_pose 25, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose63:
+ax_pose 26, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose64:
+ax_pose 14, 0x01f2, 0x00e7, 0x5c00
+ax_pose 15, 0x41e5, 0x80ef, 0x5c01
+ax_pose 16, 0x41f5, 0x40ef, 0x5c09
+ax_pose 17, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose65:
+ax_pose 18, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose66:
+ax_pose 19, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose67:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose68:
+ax_pose 12, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose69:
+ax_pose 13, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose70:
+ax_pose 6, 0x01ee, 0x0111, 0x5c00
+ax_pose 7, 0x41e5, 0x80f1, 0x5c01
+ax_pose 8, 0x41f5, 0x40f1, 0x5c09
+ax_pose_terminator
+sAltariaPose71:
+ax_pose 9, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose72:
+ax_pose 10, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose73:
+ax_pose 0, 0x01ec, 0x00e8, 0x5c00
+ax_pose 1, 0x01ec, 0x0110, 0x5c01
+ax_pose 2, 0x41e5, 0x80f0, 0x5c02
+ax_pose 3, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose74:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose75:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose76:
+ax_pose 27, 0x01ec, 0x00e8, 0x5c00
+ax_pose 28, 0x01ec, 0x0110, 0x5c01
+ax_pose 29, 0x41e5, 0x80f0, 0x5c02
+ax_pose 30, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose77:
+ax_pose 31, 0x41e4, 0x80f0, 0x5c00
+ax_pose 32, 0x41f4, 0x40f0, 0x5c08
+ax_pose_terminator
+sAltariaPose78:
+ax_pose 33, 0x41f7, 0x80f0, 0x5c00
+ax_pose 34, 0x01e7, 0x40f8, 0x5c08
+ax_pose_terminator
+sAltariaPose79:
+ax_pose 6, 0x01ee, 0x10e7, 0x5c00
+ax_pose 7, 0x41e5, 0x90ef, 0x5c01
+ax_pose 8, 0x41f5, 0x50ef, 0x5c09
+ax_pose_terminator
+sAltariaPose80:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose81:
+ax_pose 10, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose82:
+ax_pose 35, 0x41f5, 0x50ef, 0x5c00
+ax_pose 36, 0x41e5, 0x90ef, 0x5c04
+ax_pose 37, 0x01ee, 0x10e7, 0x5c0c
+ax_pose_terminator
+sAltariaPose83:
+ax_pose 38, 0x41e4, 0x90ef, 0x5c00
+ax_pose 39, 0x41f4, 0x50ef, 0x5c08
+ax_pose_terminator
+sAltariaPose84:
+ax_pose 40, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose85:
+ax_pose 11, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose86:
+ax_pose 12, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose87:
+ax_pose 13, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose88:
+ax_pose 41, 0x41f5, 0x50ef, 0x5c00
+ax_pose 42, 0x41e5, 0x90ef, 0x5c04
+ax_pose_terminator
+sAltariaPose89:
+ax_pose 43, 0x41e3, 0x90ef, 0x5c00
+ax_pose 44, 0x41f3, 0x50ef, 0x5c08
+ax_pose_terminator
+sAltariaPose90:
+ax_pose 45, 0x41ea, 0x90ef, 0x5c00
+ax_pose 46, 0x41e2, 0x10ff, 0x5c08
+ax_pose 47, 0x41fa, 0x10f7, 0x5c0a
+ax_pose_terminator
+sAltariaPose91:
+ax_pose 14, 0x01f2, 0x1111, 0x5c00
+ax_pose 15, 0x41e5, 0x90f1, 0x5c01
+ax_pose 16, 0x41f5, 0x50f1, 0x5c09
+ax_pose 17, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose92:
+ax_pose 18, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose93:
+ax_pose 19, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose94:
+ax_pose 48, 0x01f2, 0x1111, 0x5c00
+ax_pose 49, 0x41e5, 0x90f1, 0x5c01
+ax_pose 50, 0x41f5, 0x50f1, 0x5c09
+ax_pose 51, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose95:
+ax_pose 52, 0x41e4, 0x90f1, 0x5c00
+ax_pose 53, 0x41f4, 0x50f1, 0x5c08
+ax_pose 54, 0x01fc, 0x10f1, 0x5c0c
+ax_pose_terminator
+sAltariaPose96:
+ax_pose 55, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose97:
+ax_pose 20, 0x01ed, 0x0110, 0x5c00
+ax_pose 21, 0x41e9, 0x40f0, 0x5c01
+ax_pose 22, 0x41e1, 0x00f8, 0x5c05
+ax_pose 23, 0x41f1, 0x80f0, 0x5c07
+ax_pose 24, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose98:
+ax_pose 25, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose99:
+ax_pose 26, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose100:
+ax_pose 56, 0x01ed, 0x0110, 0x5c00
+ax_pose 57, 0x41e9, 0x40f0, 0x5c01
+ax_pose 58, 0x41e1, 0x00f8, 0x5c05
+ax_pose 59, 0x41f1, 0x80f0, 0x5c07
+ax_pose 60, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose101:
+ax_pose 61, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose102:
+ax_pose 62, 0x01e2, 0x40f8, 0x5c00
+ax_pose 63, 0x41f2, 0x80f0, 0x5c04
+ax_pose_terminator
+sAltariaPose103:
+ax_pose 14, 0x01f2, 0x00e7, 0x5c00
+ax_pose 15, 0x41e5, 0x80ef, 0x5c01
+ax_pose 16, 0x41f5, 0x40ef, 0x5c09
+ax_pose 17, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose104:
+ax_pose 18, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose105:
+ax_pose 19, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose106:
+ax_pose 48, 0x01f2, 0x00e7, 0x5c00
+ax_pose 49, 0x41e5, 0x80ef, 0x5c01
+ax_pose 50, 0x41f5, 0x40ef, 0x5c09
+ax_pose 51, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose107:
+ax_pose 52, 0x41e4, 0x80ef, 0x5c00
+ax_pose 53, 0x41f4, 0x40ef, 0x5c08
+ax_pose 54, 0x01fc, 0x0107, 0x5c0c
+ax_pose_terminator
+sAltariaPose108:
+ax_pose 55, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose109:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose110:
+ax_pose 12, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose111:
+ax_pose 13, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose112:
+ax_pose 41, 0x41f5, 0x40f1, 0x5c00
+ax_pose 42, 0x41e5, 0x80f1, 0x5c04
+ax_pose_terminator
+sAltariaPose113:
+ax_pose 43, 0x41e3, 0x80f1, 0x5c00
+ax_pose 44, 0x41f3, 0x40f1, 0x5c08
+ax_pose_terminator
+sAltariaPose114:
+ax_pose 45, 0x41ea, 0x80f1, 0x5c00
+ax_pose 46, 0x41e2, 0x00f1, 0x5c08
+ax_pose 47, 0x41fa, 0x00f9, 0x5c0a
+ax_pose_terminator
+sAltariaPose115:
+ax_pose 6, 0x01ee, 0x0111, 0x5c00
+ax_pose 7, 0x41e5, 0x80f1, 0x5c01
+ax_pose 8, 0x41f5, 0x40f1, 0x5c09
+ax_pose_terminator
+sAltariaPose116:
+ax_pose 9, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose117:
+ax_pose 10, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose118:
+ax_pose 35, 0x41f5, 0x40f1, 0x5c00
+ax_pose 36, 0x41e5, 0x80f1, 0x5c04
+ax_pose 37, 0x01ee, 0x0111, 0x5c0c
+ax_pose_terminator
+sAltariaPose119:
+ax_pose 38, 0x41e4, 0x80f1, 0x5c00
+ax_pose 39, 0x41f4, 0x40f1, 0x5c08
+ax_pose_terminator
+sAltariaPose120:
+ax_pose 40, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose121:
+ax_pose 0, 0x01ec, 0x00e8, 0x5c00
+ax_pose 1, 0x01ec, 0x0110, 0x5c01
+ax_pose 2, 0x41e5, 0x80f0, 0x5c02
+ax_pose 3, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose122:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose123:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose124:
+ax_pose 6, 0x01ee, 0x10e7, 0x5c00
+ax_pose 7, 0x41e5, 0x90ef, 0x5c01
+ax_pose 8, 0x41f5, 0x50ef, 0x5c09
+ax_pose_terminator
+sAltariaPose125:
+ax_pose 9, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose126:
+ax_pose 10, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose127:
+ax_pose 11, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose128:
+ax_pose 12, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose129:
+ax_pose 13, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose130:
+ax_pose 14, 0x01f2, 0x1111, 0x5c00
+ax_pose 15, 0x41e5, 0x90f1, 0x5c01
+ax_pose 16, 0x41f5, 0x50f1, 0x5c09
+ax_pose 17, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose131:
+ax_pose 18, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose132:
+ax_pose 19, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose133:
+ax_pose 20, 0x01ed, 0x0110, 0x5c00
+ax_pose 21, 0x41e9, 0x40f0, 0x5c01
+ax_pose 22, 0x41e1, 0x00f8, 0x5c05
+ax_pose 23, 0x41f1, 0x80f0, 0x5c07
+ax_pose 24, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose134:
+ax_pose 25, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose135:
+ax_pose 26, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose136:
+ax_pose 14, 0x01f2, 0x00e7, 0x5c00
+ax_pose 15, 0x41e5, 0x80ef, 0x5c01
+ax_pose 16, 0x41f5, 0x40ef, 0x5c09
+ax_pose 17, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose137:
+ax_pose 18, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose138:
+ax_pose 19, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose139:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose140:
+ax_pose 12, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose141:
+ax_pose 13, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose142:
+ax_pose 6, 0x01ee, 0x0111, 0x5c00
+ax_pose 7, 0x41e5, 0x80f1, 0x5c01
+ax_pose 8, 0x41f5, 0x40f1, 0x5c09
+ax_pose_terminator
+sAltariaPose143:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose144:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose145:
+ax_pose 64, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sAltariaPose146:
+ax_pose 65, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sAltariaPose147:
+ax_pose 66, 0x81e6, 0x40fe, 0x5c00
+ax_pose 67, 0x01f4, 0x010e, 0x5c04
+ax_pose 68, 0x01f6, 0x0106, 0x5c05
+ax_pose 69, 0x81e6, 0x0106, 0x5c06
+ax_pose 70, 0x81e6, 0x80ee, 0x5c08
+ax_pose_terminator
+sAltariaPose148:
+ax_pose 71, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sAltariaPose149:
+ax_pose 72, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sAltariaPose150:
+ax_pose 73, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sAltariaPose151:
+ax_pose 74, 0x01e7, 0x0107, 0x5c00
+ax_pose 75, 0x81ef, 0x00ef, 0x5c01
+ax_pose 76, 0x01e7, 0x00ef, 0x5c03
+ax_pose 77, 0x01ef, 0x010f, 0x5c04
+ax_pose 78, 0x01f7, 0x010f, 0x5c05
+ax_pose 79, 0x81ef, 0x0107, 0x5c06
+ax_pose 80, 0x81df, 0x80f7, 0x5c08
+ax_pose_terminator
+sAltariaPose152:
+ax_pose 73, 0x01e2, 0x80f4, 0x5c00
+ax_pose_terminator
+sAltariaPose153:
+ax_pose 72, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sAltariaPose154:
+ax_pose 71, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose155:
+ax_pose 0, 0x01ec, 0x00e8, 0x5c00
+ax_pose 1, 0x01ec, 0x0110, 0x5c01
+ax_pose 2, 0x41e5, 0x80f0, 0x5c02
+ax_pose 3, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose156:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose157:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose158:
+ax_pose 81, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAltariaPose159:
+ax_pose 6, 0x01ee, 0x10e7, 0x5c00
+ax_pose 7, 0x41e5, 0x90ef, 0x5c01
+ax_pose 8, 0x41f5, 0x50ef, 0x5c09
+ax_pose_terminator
+sAltariaPose160:
+ax_pose 9, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose161:
+ax_pose 10, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose162:
+ax_pose 82, 0x01e5, 0x90ea, 0x5c00
+ax_pose_terminator
+sAltariaPose163:
+ax_pose 11, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose164:
+ax_pose 12, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose165:
+ax_pose 13, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose166:
+ax_pose 83, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose167:
+ax_pose 14, 0x01f2, 0x1111, 0x5c00
+ax_pose 15, 0x41e5, 0x90f1, 0x5c01
+ax_pose 16, 0x41f5, 0x50f1, 0x5c09
+ax_pose 17, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose168:
+ax_pose 18, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose169:
+ax_pose 19, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose170:
+ax_pose 84, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose171:
+ax_pose 20, 0x01ed, 0x0110, 0x5c00
+ax_pose 21, 0x41e9, 0x40f0, 0x5c01
+ax_pose 22, 0x41e1, 0x00f8, 0x5c05
+ax_pose 23, 0x41f1, 0x80f0, 0x5c07
+ax_pose 24, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose172:
+ax_pose 25, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose173:
+ax_pose 26, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose174:
+ax_pose 85, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAltariaPose175:
+ax_pose 14, 0x01f2, 0x00e7, 0x5c00
+ax_pose 15, 0x41e5, 0x80ef, 0x5c01
+ax_pose 16, 0x41f5, 0x40ef, 0x5c09
+ax_pose 17, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose176:
+ax_pose 18, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose177:
+ax_pose 19, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose178:
+ax_pose 84, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose179:
+ax_pose 11, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose180:
+ax_pose 12, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose181:
+ax_pose 13, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose182:
+ax_pose 83, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose183:
+ax_pose 6, 0x01ee, 0x0111, 0x5c00
+ax_pose 7, 0x41e5, 0x80f1, 0x5c01
+ax_pose 8, 0x41f5, 0x40f1, 0x5c09
+ax_pose_terminator
+sAltariaPose184:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose185:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose186:
+ax_pose 82, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sAltariaPose187:
+ax_pose 31, 0x41e4, 0x80f0, 0x5c00
+ax_pose 32, 0x41f4, 0x40f0, 0x5c08
+ax_pose_terminator
+sAltariaPose188:
+ax_pose 38, 0x41e4, 0x80f1, 0x5c00
+ax_pose 39, 0x41f4, 0x40f1, 0x5c08
+ax_pose_terminator
+sAltariaPose189:
+ax_pose 43, 0x41e4, 0x80f1, 0x5c00
+ax_pose 44, 0x41f4, 0x40f1, 0x5c08
+ax_pose_terminator
+sAltariaPose190:
+ax_pose 52, 0x41e4, 0x80f0, 0x5c00
+ax_pose 53, 0x41f4, 0x40f0, 0x5c08
+ax_pose 54, 0x01fc, 0x0108, 0x5c0c
+ax_pose_terminator
+sAltariaPose191:
+ax_pose 61, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose192:
+ax_pose 52, 0x41e4, 0x90f0, 0x5c00
+ax_pose 53, 0x41f4, 0x50f0, 0x5c08
+ax_pose 54, 0x01fc, 0x10f0, 0x5c0c
+ax_pose_terminator
+sAltariaPose193:
+ax_pose 43, 0x41e4, 0x90ef, 0x5c00
+ax_pose 44, 0x41f4, 0x50ef, 0x5c08
+ax_pose_terminator
+sAltariaPose194:
+ax_pose 38, 0x41e4, 0x90ef, 0x5c00
+ax_pose 39, 0x41f4, 0x50ef, 0x5c08
+ax_pose_terminator
+sAltariaPose195:
+ax_pose 27, 0x01ec, 0x00e8, 0x5c00
+ax_pose 28, 0x01ec, 0x0110, 0x5c01
+ax_pose 29, 0x41e5, 0x80f0, 0x5c02
+ax_pose 30, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose196:
+ax_pose 35, 0x41f5, 0x50ef, 0x5c00
+ax_pose 36, 0x41e5, 0x90ef, 0x5c04
+ax_pose 37, 0x01ee, 0x10e7, 0x5c0c
+ax_pose_terminator
+sAltariaPose197:
+ax_pose 41, 0x41f6, 0x50ef, 0x5c00
+ax_pose 42, 0x41e6, 0x90ef, 0x5c04
+ax_pose_terminator
+sAltariaPose198:
+ax_pose 48, 0x01f2, 0x1111, 0x5c00
+ax_pose 49, 0x41e5, 0x90f1, 0x5c01
+ax_pose 50, 0x41f5, 0x50f1, 0x5c09
+ax_pose 51, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose199:
+ax_pose 56, 0x01ed, 0x0110, 0x5c00
+ax_pose 57, 0x41e9, 0x40f0, 0x5c01
+ax_pose 58, 0x41e1, 0x00f8, 0x5c05
+ax_pose 59, 0x41f1, 0x80f0, 0x5c07
+ax_pose 60, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose200:
+ax_pose 48, 0x01f2, 0x00e7, 0x5c00
+ax_pose 49, 0x41e5, 0x80ef, 0x5c01
+ax_pose 50, 0x41f5, 0x40ef, 0x5c09
+ax_pose 51, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose201:
+ax_pose 41, 0x41f6, 0x40f1, 0x5c00
+ax_pose 42, 0x41e6, 0x80f1, 0x5c04
+ax_pose_terminator
+sAltariaPose202:
+ax_pose 35, 0x41f5, 0x40f1, 0x5c00
+ax_pose 36, 0x41e5, 0x80f1, 0x5c04
+ax_pose 37, 0x01ee, 0x0111, 0x5c0c
+ax_pose_terminator
+sAltariaPose203:
+ax_pose 27, 0x01ec, 0x00e8, 0x5c00
+ax_pose 28, 0x01ec, 0x0110, 0x5c01
+ax_pose 29, 0x41e5, 0x80f0, 0x5c02
+ax_pose 30, 0x41f5, 0x40f0, 0x5c0a
+ax_pose_terminator
+sAltariaPose204:
+ax_pose 31, 0x41e4, 0x80f0, 0x5c00
+ax_pose 32, 0x41f4, 0x40f0, 0x5c08
+ax_pose_terminator
+sAltariaPose205:
+ax_pose 33, 0x41f7, 0x80f0, 0x5c00
+ax_pose 34, 0x01e7, 0x40f8, 0x5c08
+ax_pose_terminator
+sAltariaPose206:
+ax_pose 35, 0x41f5, 0x50ef, 0x5c00
+ax_pose 36, 0x41e5, 0x90ef, 0x5c04
+ax_pose 37, 0x01ee, 0x10e7, 0x5c0c
+ax_pose_terminator
+sAltariaPose207:
+ax_pose 38, 0x41e4, 0x90ef, 0x5c00
+ax_pose 39, 0x41f4, 0x50ef, 0x5c08
+ax_pose_terminator
+sAltariaPose208:
+ax_pose 40, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose209:
+ax_pose 41, 0x41f5, 0x50ef, 0x5c00
+ax_pose 42, 0x41e5, 0x90ef, 0x5c04
+ax_pose_terminator
+sAltariaPose210:
+ax_pose 43, 0x41e3, 0x90ef, 0x5c00
+ax_pose 44, 0x41f3, 0x50ef, 0x5c08
+ax_pose_terminator
+sAltariaPose211:
+ax_pose 45, 0x41ea, 0x90ef, 0x5c00
+ax_pose 46, 0x41e2, 0x10ff, 0x5c08
+ax_pose 47, 0x41fa, 0x10f7, 0x5c0a
+ax_pose_terminator
+sAltariaPose212:
+ax_pose 48, 0x01f2, 0x1111, 0x5c00
+ax_pose 49, 0x41e5, 0x90f1, 0x5c01
+ax_pose 50, 0x41f5, 0x50f1, 0x5c09
+ax_pose 51, 0x01fd, 0x10f1, 0x5c0d
+ax_pose_terminator
+sAltariaPose213:
+ax_pose 52, 0x41e4, 0x90f1, 0x5c00
+ax_pose 53, 0x41f4, 0x50f1, 0x5c08
+ax_pose 54, 0x01fc, 0x10f1, 0x5c0c
+ax_pose_terminator
+sAltariaPose214:
+ax_pose 55, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAltariaPose215:
+ax_pose 56, 0x01ed, 0x0110, 0x5c00
+ax_pose 57, 0x41e9, 0x40f0, 0x5c01
+ax_pose 58, 0x41e1, 0x00f8, 0x5c05
+ax_pose 59, 0x41f1, 0x80f0, 0x5c07
+ax_pose 60, 0x01ed, 0x00e8, 0x5c0f
+ax_pose_terminator
+sAltariaPose216:
+ax_pose 61, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose217:
+ax_pose 62, 0x01e2, 0x40f8, 0x5c00
+ax_pose 63, 0x41f2, 0x80f0, 0x5c04
+ax_pose_terminator
+sAltariaPose218:
+ax_pose 48, 0x01f2, 0x00e7, 0x5c00
+ax_pose 49, 0x41e5, 0x80ef, 0x5c01
+ax_pose 50, 0x41f5, 0x40ef, 0x5c09
+ax_pose 51, 0x01fd, 0x0107, 0x5c0d
+ax_pose_terminator
+sAltariaPose219:
+ax_pose 52, 0x41e4, 0x80ef, 0x5c00
+ax_pose 53, 0x41f4, 0x40ef, 0x5c08
+ax_pose 54, 0x01fc, 0x0107, 0x5c0c
+ax_pose_terminator
+sAltariaPose220:
+ax_pose 55, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAltariaPose221:
+ax_pose 41, 0x41f5, 0x40f1, 0x5c00
+ax_pose 42, 0x41e5, 0x80f1, 0x5c04
+ax_pose_terminator
+sAltariaPose222:
+ax_pose 43, 0x41e3, 0x80f1, 0x5c00
+ax_pose 44, 0x41f3, 0x40f1, 0x5c08
+ax_pose_terminator
+sAltariaPose223:
+ax_pose 45, 0x41ea, 0x80f1, 0x5c00
+ax_pose 46, 0x41e2, 0x00f1, 0x5c08
+ax_pose 47, 0x41fa, 0x00f9, 0x5c0a
+ax_pose_terminator
+sAltariaPose224:
+ax_pose 35, 0x41f5, 0x40f1, 0x5c00
+ax_pose 36, 0x41e5, 0x80f1, 0x5c04
+ax_pose 37, 0x01ee, 0x0111, 0x5c0c
+ax_pose_terminator
+sAltariaPose225:
+ax_pose 38, 0x41e4, 0x80f1, 0x5c00
+ax_pose 39, 0x41f4, 0x40f1, 0x5c08
+ax_pose_terminator
+sAltariaPose226:
+ax_pose 40, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAltariaPose227:
+ax_pose 81, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAltariaPose228:
+ax_pose 82, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sAltariaPose229:
+ax_pose 83, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose230:
+ax_pose 84, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose231:
+ax_pose 85, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAltariaPose232:
+ax_pose 84, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose233:
+ax_pose 83, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose234:
+ax_pose 82, 0x01e5, 0x90ea, 0x5c00
+ax_pose_terminator
+sAltariaPose235:
+ax_pose 81, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAltariaPose236:
+ax_pose 82, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sAltariaPose237:
+ax_pose 83, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose238:
+ax_pose 84, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAltariaPose239:
+ax_pose 85, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sAltariaPose240:
+ax_pose 84, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose241:
+ax_pose 83, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sAltariaPose242:
+ax_pose 82, 0x01e5, 0x90ea, 0x5c00
+ax_pose_terminator
+.align 2
+sAltariaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 9,
+ax_anim 2, 0, 26, 0, 24, 0, 21,
+ax_anim 2, 1, 26, 1, 24, 1, 21,
+ax_anim 2, 0, 26, 0, 24, 0, 21,
+ax_anim 2, 0, 26, 1, 24, 1, 21,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim_terminator
+sAltariaAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 6, 4, 4,
+ax_anim 1, 0, 29, 10, 13, 10, 10,
+ax_anim 2, 0, 29, 19, 25, 19, 19,
+ax_anim 2, 1, 29, 20, 24, 20, 18,
+ax_anim 2, 0, 29, 19, 25, 19, 20,
+ax_anim 2, 0, 29, 20, 24, 20, 18,
+ax_anim 2, 0, 27, 8, 11, 8, 8,
+ax_anim_terminator
+sAltariaAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 2, 10, 0,
+ax_anim 2, 0, 32, 19, 3, 19, 0,
+ax_anim 2, 1, 32, 19, 4, 19, 1,
+ax_anim 2, 0, 32, 19, 3, 19, 0,
+ax_anim 2, 0, 32, 19, 4, 19, 1,
+ax_anim 2, 0, 30, 8, 2, 8, 0,
+ax_anim_terminator
+sAltariaAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 5, -3, 5, -5,
+ax_anim 1, 0, 35, 11, -8, 11, -11,
+ax_anim 2, 0, 35, 18, -12, 18, -18,
+ax_anim 2, 1, 35, 19, -11, 19, -17,
+ax_anim 2, 0, 35, 18, -12, 18, -18,
+ax_anim 2, 0, 35, 19, -11, 19, -17,
+ax_anim 2, 0, 33, 8, -6, 8, -8,
+ax_anim_terminator
+sAltariaAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -2, 0, -2,
+ax_anim 1, 0, 38, 0, -6, 0, -10,
+ax_anim 2, 0, 38, 0, -12, 0, -20,
+ax_anim 2, 1, 38, 1, -12, 1, -20,
+ax_anim 2, 0, 38, 0, -12, 0, -20,
+ax_anim 2, 0, 38, 1, -12, 1, -20,
+ax_anim 2, 0, 36, 0, -5, 0, -7,
+ax_anim_terminator
+sAltariaAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -5, -3, -5, -5,
+ax_anim 1, 0, 41, -11, -8, -11, -11,
+ax_anim 2, 0, 41, -18, -12, -18, -18,
+ax_anim 2, 1, 41, -19, -11, -19, -17,
+ax_anim 2, 0, 41, -18, -12, -18, -18,
+ax_anim 2, 0, 41, -19, -11, -19, -17,
+ax_anim 2, 0, 39, -8, -6, -8, -8,
+ax_anim_terminator
+sAltariaAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 2, -10, 0,
+ax_anim 2, 0, 44, -19, 3, -19, 0,
+ax_anim 2, 1, 44, -19, 4, -19, 1,
+ax_anim 2, 0, 44, -19, 3, -19, 0,
+ax_anim 2, 0, 44, -19, 4, -19, 1,
+ax_anim 2, 0, 42, -8, 2, -8, 0,
+ax_anim_terminator
+sAltariaAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 6, -4, 4,
+ax_anim 1, 0, 47, -10, 13, -10, 10,
+ax_anim 2, 0, 47, -19, 25, -19, 19,
+ax_anim 2, 1, 47, -20, 24, -20, 18,
+ax_anim 2, 0, 47, -19, 25, -19, 19,
+ax_anim 2, 0, 47, -20, 24, -20, 18,
+ax_anim 2, 0, 45, -8, 11, -8, 8,
+ax_anim_terminator
+.align 2
+sAltariaAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 9,
+ax_anim 2, 0, 50, 0, 24, 0, 21,
+ax_anim 2, 1, 50, 1, 24, 1, 21,
+ax_anim 2, 0, 50, 0, 24, 0, 21,
+ax_anim 2, 0, 50, 1, 24, 1, 21,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim_terminator
+sAltariaAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 6, 4, 4,
+ax_anim 1, 0, 53, 10, 13, 10, 10,
+ax_anim 2, 0, 53, 19, 25, 19, 19,
+ax_anim 2, 1, 53, 20, 24, 20, 18,
+ax_anim 2, 0, 53, 19, 25, 19, 20,
+ax_anim 2, 0, 53, 20, 24, 20, 18,
+ax_anim 2, 0, 51, 8, 11, 8, 8,
+ax_anim_terminator
+sAltariaAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 2, 10, 0,
+ax_anim 2, 0, 56, 19, 3, 19, 0,
+ax_anim 2, 1, 56, 19, 4, 19, 1,
+ax_anim 2, 0, 56, 19, 3, 19, 0,
+ax_anim 2, 0, 56, 19, 4, 19, 1,
+ax_anim 2, 0, 54, 8, 2, 8, 0,
+ax_anim_terminator
+sAltariaAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 5, -3, 5, -5,
+ax_anim 1, 0, 59, 11, -8, 11, -11,
+ax_anim 2, 0, 59, 18, -12, 18, -18,
+ax_anim 2, 1, 59, 19, -11, 19, -17,
+ax_anim 2, 0, 59, 18, -12, 18, -18,
+ax_anim 2, 0, 59, 19, -11, 19, -17,
+ax_anim 2, 0, 57, 8, -6, 8, -8,
+ax_anim_terminator
+sAltariaAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -2, 0, -2,
+ax_anim 1, 0, 62, 0, -6, 0, -10,
+ax_anim 2, 0, 62, 0, -12, 0, -20,
+ax_anim 2, 1, 62, 1, -12, 1, -20,
+ax_anim 2, 0, 62, 0, -12, 0, -20,
+ax_anim 2, 0, 62, 1, -12, 1, -20,
+ax_anim 2, 0, 60, 0, -5, 0, -7,
+ax_anim_terminator
+sAltariaAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -5, -3, -5, -5,
+ax_anim 1, 0, 65, -11, -8, -11, -11,
+ax_anim 2, 0, 65, -18, -12, -18, -18,
+ax_anim 2, 1, 65, -19, -11, -19, -17,
+ax_anim 2, 0, 65, -18, -12, -18, -18,
+ax_anim 2, 0, 65, -19, -11, -19, -17,
+ax_anim 2, 0, 63, -8, -6, -8, -8,
+ax_anim_terminator
+sAltariaAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 2, -10, 0,
+ax_anim 2, 0, 68, -19, 3, -19, 0,
+ax_anim 2, 1, 68, -19, 4, -19, 1,
+ax_anim 2, 0, 68, -19, 3, -19, 0,
+ax_anim 2, 0, 68, -19, 4, -19, 1,
+ax_anim 2, 0, 66, -8, 2, -8, 0,
+ax_anim_terminator
+sAltariaAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 6, -4, 4,
+ax_anim 1, 0, 71, -10, 13, -10, 10,
+ax_anim 2, 0, 71, -19, 25, -19, 19,
+ax_anim 2, 1, 71, -20, 24, -20, 18,
+ax_anim 2, 0, 71, -19, 25, -19, 19,
+ax_anim 2, 0, 71, -20, 24, -20, 18,
+ax_anim 2, 0, 69, -8, 11, -8, 8,
+ax_anim_terminator
+.align 2
+sAltariaAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 74, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 1, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 4, 0, 4,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 4, 0, 4,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 4, 0, 4,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sAltariaAnims_4_2:
+ax_anim 2, 0, 79, -2, -2, -2, -2,
+ax_anim 6, 2, 80, -3, -3, -3, -3,
+ax_anim 2, 0, 78, -1, -1, -1, -1,
+ax_anim 2, 1, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 82, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 82, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 82, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim_terminator
+sAltariaAnims_4_3:
+ax_anim 2, 0, 85, -2, 0, -2, 0,
+ax_anim 6, 2, 86, -3, 0, -3, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 2, 1, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim_terminator
+sAltariaAnims_4_4:
+ax_anim 2, 0, 91, -2, 2, -2, 2,
+ax_anim 6, 2, 92, -3, 3, -3, 3,
+ax_anim 2, 0, 90, -1, 1, -1, 1,
+ax_anim 2, 1, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 90, 1, -1, 1, -1,
+ax_anim_terminator
+sAltariaAnims_4_5:
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 6, 2, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 2, 1, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim_terminator
+sAltariaAnims_4_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 102, 1, 1, 1, 1,
+ax_anim 2, 1, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -1, -3, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -1, -3, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -1, -3, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 102, -1, -1, -1, -1,
+ax_anim_terminator
+sAltariaAnims_4_7:
+ax_anim 2, 0, 109, 2, 0, 2, 0,
+ax_anim 6, 2, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 1, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim_terminator
+sAltariaAnims_4_8:
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 6, 2, 116, 3, -3, 3, -3,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 114, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sAltariaAnims_5_1:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_5_2:
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_5_3:
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_5_4:
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 1, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 1, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 1, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 1, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_5_5:
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_5_6:
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_5_7:
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_5_8:
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sAltariaAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sAltariaAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sAltariaAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sAltariaAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sAltariaAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sAltariaAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sAltariaAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sAltariaAnims_8_1:
+ax_anim 60, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -4, 0, 0,
+ax_anim 4, 0, 156, 0, -6, 0, 0,
+ax_anim 4, 0, 154, 0, -7, 0, 0,
+ax_anim 4, 0, 155, 0, -7, 0, 0,
+ax_anim 4, 0, 154, 0, -7, 0, 0,
+ax_anim 4, 0, 156, 0, -7, 0, 0,
+ax_anim 4, 0, 154, 0, -7, 0, 0,
+ax_anim 4, 0, 155, 0, -7, 0, 0,
+ax_anim 4, 0, 154, 0, -7, 0, 0,
+ax_anim 4, 0, 156, 0, -6, 0, 0,
+ax_anim 4, 0, 154, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_8_2:
+ax_anim 60, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -4, 0, 0,
+ax_anim 4, 0, 160, 0, -6, 0, 0,
+ax_anim 4, 0, 158, 0, -7, 0, 0,
+ax_anim 4, 0, 159, 0, -7, 0, 0,
+ax_anim 4, 0, 158, 0, -7, 0, 0,
+ax_anim 4, 0, 160, 0, -7, 0, 0,
+ax_anim 4, 0, 158, 0, -7, 0, 0,
+ax_anim 4, 0, 159, 0, -7, 0, 0,
+ax_anim 4, 0, 158, 0, -7, 0, 0,
+ax_anim 4, 0, 160, 0, -6, 0, 0,
+ax_anim 4, 0, 158, 0, -4, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_8_3:
+ax_anim 60, 0, 165, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, -4, 0, 0,
+ax_anim 4, 0, 164, 0, -6, 0, 0,
+ax_anim 4, 0, 162, 0, -7, 0, 0,
+ax_anim 4, 0, 163, 0, -7, 0, 0,
+ax_anim 4, 0, 162, 0, -7, 0, 0,
+ax_anim 4, 0, 164, 0, -7, 0, 0,
+ax_anim 4, 0, 162, 0, -7, 0, 0,
+ax_anim 4, 0, 163, 0, -7, 0, 0,
+ax_anim 4, 0, 162, 0, -7, 0, 0,
+ax_anim 4, 0, 164, 0, -6, 0, 0,
+ax_anim 4, 0, 162, 0, -4, 0, 0,
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_8_4:
+ax_anim 60, 0, 169, 0, 0, 0, 0,
+ax_anim 6, 0, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, -4, 0, 0,
+ax_anim 4, 0, 168, 0, -6, 0, 0,
+ax_anim 4, 0, 166, 0, -7, 0, 0,
+ax_anim 4, 0, 167, 0, -7, 0, 0,
+ax_anim 4, 0, 166, 0, -7, 0, 0,
+ax_anim 4, 0, 168, 0, -7, 0, 0,
+ax_anim 4, 0, 166, 0, -7, 0, 0,
+ax_anim 4, 0, 167, 0, -7, 0, 0,
+ax_anim 4, 0, 166, 0, -7, 0, 0,
+ax_anim 4, 0, 168, 0, -6, 0, 0,
+ax_anim 4, 0, 166, 0, -4, 0, 0,
+ax_anim 4, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_8_5:
+ax_anim 60, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -4, 0, 0,
+ax_anim 4, 0, 172, 0, -6, 0, 0,
+ax_anim 4, 0, 170, 0, -7, 0, 0,
+ax_anim 4, 0, 171, 0, -7, 0, 0,
+ax_anim 4, 0, 170, 0, -7, 0, 0,
+ax_anim 4, 0, 172, 0, -7, 0, 0,
+ax_anim 4, 0, 170, 0, -7, 0, 0,
+ax_anim 4, 0, 171, 0, -7, 0, 0,
+ax_anim 4, 0, 170, 0, -7, 0, 0,
+ax_anim 4, 0, 172, 0, -6, 0, 0,
+ax_anim 4, 0, 170, 0, -4, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_8_6:
+ax_anim 60, 0, 177, 0, 0, 0, 0,
+ax_anim 6, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 174, 0, -4, 0, 0,
+ax_anim 4, 0, 176, 0, -6, 0, 0,
+ax_anim 4, 0, 174, 0, -7, 0, 0,
+ax_anim 4, 0, 175, 0, -7, 0, 0,
+ax_anim 4, 0, 174, 0, -7, 0, 0,
+ax_anim 4, 0, 176, 0, -7, 0, 0,
+ax_anim 4, 0, 174, 0, -7, 0, 0,
+ax_anim 4, 0, 175, 0, -7, 0, 0,
+ax_anim 4, 0, 174, 0, -7, 0, 0,
+ax_anim 4, 0, 176, 0, -6, 0, 0,
+ax_anim 4, 0, 174, 0, -4, 0, 0,
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_8_7:
+ax_anim 60, 0, 181, 0, 0, 0, 0,
+ax_anim 6, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, -4, 0, 0,
+ax_anim 4, 0, 180, 0, -6, 0, 0,
+ax_anim 4, 0, 178, 0, -7, 0, 0,
+ax_anim 4, 0, 179, 0, -7, 0, 0,
+ax_anim 4, 0, 178, 0, -7, 0, 0,
+ax_anim 4, 0, 180, 0, -7, 0, 0,
+ax_anim 4, 0, 178, 0, -7, 0, 0,
+ax_anim 4, 0, 179, 0, -7, 0, 0,
+ax_anim 4, 0, 178, 0, -7, 0, 0,
+ax_anim 4, 0, 180, 0, -6, 0, 0,
+ax_anim 4, 0, 178, 0, -4, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_8_8:
+ax_anim 60, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, -4, 0, 0,
+ax_anim 4, 0, 184, 0, -6, 0, 0,
+ax_anim 4, 0, 182, 0, -7, 0, 0,
+ax_anim 4, 0, 183, 0, -7, 0, 0,
+ax_anim 4, 0, 182, 0, -7, 0, 0,
+ax_anim 4, 0, 184, 0, -7, 0, 0,
+ax_anim 4, 0, 182, 0, -7, 0, 0,
+ax_anim 4, 0, 183, 0, -7, 0, 0,
+ax_anim 4, 0, 182, 0, -7, 0, 0,
+ax_anim 4, 0, 184, 0, -6, 0, 0,
+ax_anim 4, 0, 182, 0, -4, 0, 0,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 2, 6, 2,
+ax_anim 2, 0, 188, 8, 12, 8, 12,
+ax_anim 2, 0, 189, 4, 21, 4, 19,
+ax_anim 3, 0, 190, 0, 25, 0, 21,
+ax_anim 2, 3, 191, -4, 21, -4, 19,
+ax_anim 2, 0, 192, -8, 12, -8, 12,
+ax_anim 1, 0, 193, -6, 2, -6, 2,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 11, 1, 8, 0,
+ax_anim 2, 0, 187, 20, 5, 17, 3,
+ax_anim 2, 0, 188, 24, 14, 21, 10,
+ax_anim 3, 0, 189, 20, 24, 17, 19,
+ax_anim 2, 3, 190, 13, 25, 13, 21,
+ax_anim 2, 0, 191, 4, 20, 3, 15,
+ax_anim 1, 0, 192, 0, 10, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 4, -5, 4, -5,
+ax_anim 2, 0, 186, 12, -5, 12, -5,
+ax_anim 2, 0, 187, 18, -2, 18, -3,
+ax_anim 3, 0, 188, 20, 5, 20, 1,
+ax_anim 2, 3, 189, 17, 10, 17, 8,
+ax_anim 2, 0, 190, 11, 12, 11, 12,
+ax_anim 1, 0, 191, 4, 8, 4, 8,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -5, 0, -5,
+ax_anim 2, 0, 193, 2, -11, 3, -11,
+ax_anim 2, 0, 186, 11, -14, 10, -16,
+ax_anim 3, 0, 187, 17, -14, 16, -18,
+ax_anim 2, 3, 188, 20, -9, 20, -11,
+ax_anim 2, 0, 189, 17, -2, 17, -2,
+ax_anim 1, 0, 190, 9, 2, 9, 2,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -4, -2, -4, -2,
+ax_anim 2, 0, 192, -8, -9, -8, -9,
+ax_anim 2, 0, 193, -6, -13, -6, -15,
+ax_anim 3, 0, 186, 0, -14, 0, -17,
+ax_anim 2, 3, 187, 6, -13, 6, -15,
+ax_anim 2, 0, 188, 8, -9, 8, -9,
+ax_anim 1, 0, 189, 4, -2, 4, -2,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -5, 0, -5,
+ax_anim 2, 0, 187, -3, -11, -3, -11,
+ax_anim 2, 0, 186, -10, -14, -10, -16,
+ax_anim 3, 0, 193, -17, -14, -16, -18,
+ax_anim 2, 3, 192, -20, -9, -20, -11,
+ax_anim 2, 0, 191, -17, -2, -17, -2,
+ax_anim 1, 0, 190, -9, 2, -9, 2,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -4, -5, -4, -5,
+ax_anim 2, 0, 186, -12, -5, -12, -5,
+ax_anim 2, 0, 193, -18, -2, -18, -3,
+ax_anim 3, 0, 192, -20, 5, -20, -1,
+ax_anim 2, 3, 191, -17, 10, -17, 8,
+ax_anim 2, 0, 190, -11, 12, -11, 12,
+ax_anim 1, 0, 189, -4, 8, -4, 8,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -11, 1, -11, 1,
+ax_anim 2, 0, 193, -20, 5, -20, 5,
+ax_anim 2, 0, 192, -24, 14, -21, 10,
+ax_anim 3, 0, 191, -20, 24, -17, 19,
+ax_anim 2, 3, 190, -13, 25, -13, 21,
+ax_anim 2, 0, 189, -4, 20, -4, 20,
+ax_anim 1, 0, 188, 0, 10, 0, 10,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -18, 0, 0,
+ax_anim 1, 0, 203, 0, -12, 0, 0,
+ax_anim 2, 2, 203, 0, 5, 0, 0,
+ax_anim_terminator
+sAltariaAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 5, 0, 0,
+ax_anim_terminator
+sAltariaAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 6, 0, 0,
+ax_anim_terminator
+sAltariaAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -17, 0, 0,
+ax_anim 1, 0, 212, 0, -11, 0, 0,
+ax_anim 2, 2, 212, 0, 7, 0, 0,
+ax_anim_terminator
+sAltariaAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 215, 0, -21, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 7, 0, 0,
+ax_anim_terminator
+sAltariaAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -21, 0, 0,
+ax_anim 2, 0, 218, 0, -17, 0, 0,
+ax_anim 1, 0, 218, 0, -11, 0, 0,
+ax_anim 2, 2, 218, 0, 7, 0, 0,
+ax_anim_terminator
+sAltariaAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -18, 0, 0,
+ax_anim 1, 0, 221, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 6, 0, 0,
+ax_anim_terminator
+sAltariaAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAltariaAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sAltariaGfx1:
+.incbin "baserom.gba", 0x13A22D4, 0x20
+sAltariaSprites1:
+ax_sprite sAltariaGfx1, 0x20
+ax_sprite_terminator
+sAltariaGfx2:
+.incbin "baserom.gba", 0x13A2304, 0x20
+sAltariaSprites2:
+ax_sprite sAltariaGfx2, 0x20
+ax_sprite_terminator
+sAltariaGfx3:
+.incbin "baserom.gba", 0x13A2334, 0x100
+sAltariaSprites3:
+ax_sprite sAltariaGfx3, 0x100
+ax_sprite_terminator
+sAltariaGfx4:
+.incbin "baserom.gba", 0x13A2444, 0x80
+sAltariaSprites4:
+ax_sprite sAltariaGfx4, 0x80
+ax_sprite_terminator
+sAltariaGfx5:
+.incbin "baserom.gba", 0x13A24D4, 0x200
+sAltariaSprites5:
+ax_sprite sAltariaGfx5, 0x200
+ax_sprite_terminator
+sAltariaGfx6:
+.incbin "baserom.gba", 0x13A26E4, 0x200
+sAltariaSprites6:
+ax_sprite sAltariaGfx6, 0x200
+ax_sprite_terminator
+sAltariaGfx7:
+.incbin "baserom.gba", 0x13A28F4, 0x20
+sAltariaSprites7:
+ax_sprite sAltariaGfx7, 0x20
+ax_sprite_terminator
+sAltariaGfx8:
+.incbin "baserom.gba", 0x13A2924, 0x100
+sAltariaSprites8:
+ax_sprite sAltariaGfx8, 0x100
+ax_sprite_terminator
+sAltariaGfx9:
+.incbin "baserom.gba", 0x13A2A34, 0x80
+sAltariaSprites9:
+ax_sprite sAltariaGfx9, 0x80
+ax_sprite_terminator
+sAltariaGfx10:
+.incbin "baserom.gba", 0x13A2AC4, 0x200
+sAltariaSprites10:
+ax_sprite sAltariaGfx10, 0x200
+ax_sprite_terminator
+sAltariaGfx11:
+.incbin "baserom.gba", 0x13A2CD4, 0x200
+sAltariaSprites11:
+ax_sprite sAltariaGfx11, 0x200
+ax_sprite_terminator
+sAltariaGfx12:
+.incbin "baserom.gba", 0x13A2EE4, 0x200
+sAltariaSprites12:
+ax_sprite sAltariaGfx12, 0x200
+ax_sprite_terminator
+sAltariaGfx13:
+.incbin "baserom.gba", 0x13A30F4, 0x200
+sAltariaSprites13:
+ax_sprite sAltariaGfx13, 0x200
+ax_sprite_terminator
+sAltariaGfx14:
+.incbin "baserom.gba", 0x13A3304, 0x200
+sAltariaSprites14:
+ax_sprite sAltariaGfx14, 0x200
+ax_sprite_terminator
+sAltariaGfx15:
+.incbin "baserom.gba", 0x13A3514, 0x20
+sAltariaSprites15:
+ax_sprite sAltariaGfx15, 0x20
+ax_sprite_terminator
+sAltariaGfx16:
+.incbin "baserom.gba", 0x13A3544, 0x100
+sAltariaSprites16:
+ax_sprite sAltariaGfx16, 0x100
+ax_sprite_terminator
+sAltariaGfx17:
+.incbin "baserom.gba", 0x13A3654, 0x80
+sAltariaSprites17:
+ax_sprite sAltariaGfx17, 0x80
+ax_sprite_terminator
+sAltariaGfx18:
+.incbin "baserom.gba", 0x13A36E4, 0x20
+sAltariaSprites18:
+ax_sprite sAltariaGfx18, 0x20
+ax_sprite_terminator
+sAltariaGfx19:
+.incbin "baserom.gba", 0x13A3714, 0x200
+sAltariaSprites19:
+ax_sprite sAltariaGfx19, 0x200
+ax_sprite_terminator
+sAltariaGfx20:
+.incbin "baserom.gba", 0x13A3924, 0x200
+sAltariaSprites20:
+ax_sprite sAltariaGfx20, 0x200
+ax_sprite_terminator
+sAltariaGfx21:
+.incbin "baserom.gba", 0x13A3B34, 0x20
+sAltariaSprites21:
+ax_sprite sAltariaGfx21, 0x20
+ax_sprite_terminator
+sAltariaGfx22:
+.incbin "baserom.gba", 0x13A3B64, 0x80
+sAltariaSprites22:
+ax_sprite sAltariaGfx22, 0x80
+ax_sprite_terminator
+sAltariaGfx23:
+.incbin "baserom.gba", 0x13A3BF4, 0x40
+sAltariaSprites23:
+ax_sprite sAltariaGfx23, 0x40
+ax_sprite_terminator
+sAltariaGfx24:
+.incbin "baserom.gba", 0x13A3C44, 0x100
+sAltariaSprites24:
+ax_sprite sAltariaGfx24, 0x100
+ax_sprite_terminator
+sAltariaGfx25:
+.incbin "baserom.gba", 0x13A3D54, 0x20
+sAltariaSprites25:
+ax_sprite sAltariaGfx25, 0x20
+ax_sprite_terminator
+sAltariaGfx26:
+.incbin "baserom.gba", 0x13A3D84, 0x200
+sAltariaSprites26:
+ax_sprite sAltariaGfx26, 0x200
+ax_sprite_terminator
+sAltariaGfx27:
+.incbin "baserom.gba", 0x13A3F94, 0x200
+sAltariaSprites27:
+ax_sprite sAltariaGfx27, 0x200
+ax_sprite_terminator
+sAltariaGfx28:
+.incbin "baserom.gba", 0x13A41A4, 0x20
+sAltariaSprites28:
+ax_sprite sAltariaGfx28, 0x20
+ax_sprite_terminator
+sAltariaGfx29:
+.incbin "baserom.gba", 0x13A41D4, 0x20
+sAltariaSprites29:
+ax_sprite sAltariaGfx29, 0x20
+ax_sprite_terminator
+sAltariaGfx30:
+.incbin "baserom.gba", 0x13A4204, 0x100
+sAltariaSprites30:
+ax_sprite sAltariaGfx30, 0x100
+ax_sprite_terminator
+sAltariaGfx31:
+.incbin "baserom.gba", 0x13A4314, 0x80
+sAltariaSprites31:
+ax_sprite sAltariaGfx31, 0x80
+ax_sprite_terminator
+sAltariaGfx32:
+.incbin "baserom.gba", 0x13A43A4, 0x100
+sAltariaSprites32:
+ax_sprite sAltariaGfx32, 0x100
+ax_sprite_terminator
+sAltariaGfx33:
+.incbin "baserom.gba", 0x13A44B4, 0x80
+sAltariaSprites33:
+ax_sprite sAltariaGfx33, 0x80
+ax_sprite_terminator
+sAltariaGfx34:
+.incbin "baserom.gba", 0x13A4544, 0x100
+sAltariaSprites34:
+ax_sprite sAltariaGfx34, 0x100
+ax_sprite_terminator
+sAltariaGfx35:
+.incbin "baserom.gba", 0x13A4654, 0x80
+sAltariaSprites35:
+ax_sprite sAltariaGfx35, 0x80
+ax_sprite_terminator
+sAltariaGfx36:
+.incbin "baserom.gba", 0x13A46E4, 0x80
+sAltariaSprites36:
+ax_sprite sAltariaGfx36, 0x80
+ax_sprite_terminator
+sAltariaGfx37:
+.incbin "baserom.gba", 0x13A4774, 0x60
+sAltariaGfx37_1:
+.incbin "baserom.gba", 0x13A47D4, 0x80
+sAltariaSprites37:
+ax_sprite sAltariaGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx37_1, 0x80
+ax_sprite_terminator
+sAltariaGfx38:
+.incbin "baserom.gba", 0x13A4874, 0x20
+sAltariaSprites38:
+ax_sprite sAltariaGfx38, 0x20
+ax_sprite_terminator
+sAltariaGfx39:
+.incbin "baserom.gba", 0x13A48A4, 0x100
+sAltariaSprites39:
+ax_sprite sAltariaGfx39, 0x100
+ax_sprite_terminator
+sAltariaGfx40:
+.incbin "baserom.gba", 0x13A49B4, 0x80
+sAltariaSprites40:
+ax_sprite sAltariaGfx40, 0x80
+ax_sprite_terminator
+sAltariaGfx41:
+.incbin "baserom.gba", 0x13A4A44, 0x60
+sAltariaGfx41_1:
+.incbin "baserom.gba", 0x13A4AA4, 0x120
+sAltariaGfx41_2:
+.incbin "baserom.gba", 0x13A4BC4, 0x40
+sAltariaSprites41:
+ax_sprite sAltariaGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx41_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx41_2, 0x40
+ax_sprite_terminator
+sAltariaGfx42:
+.incbin "baserom.gba", 0x13A4C34, 0x80
+sAltariaSprites42:
+ax_sprite sAltariaGfx42, 0x80
+ax_sprite_terminator
+sAltariaGfx43:
+.incbin "baserom.gba", 0x13A4CC4, 0x60
+sAltariaGfx43_1:
+.incbin "baserom.gba", 0x13A4D24, 0x80
+sAltariaSprites43:
+ax_sprite sAltariaGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx43_1, 0x80
+ax_sprite_terminator
+sAltariaGfx44:
+.incbin "baserom.gba", 0x13A4DC4, 0x60
+sAltariaGfx44_1:
+.incbin "baserom.gba", 0x13A4E24, 0x80
+sAltariaSprites44:
+ax_sprite sAltariaGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx44_1, 0x80
+ax_sprite_terminator
+sAltariaGfx45:
+.incbin "baserom.gba", 0x13A4EC4, 0x80
+sAltariaSprites45:
+ax_sprite sAltariaGfx45, 0x80
+ax_sprite_terminator
+sAltariaGfx46:
+.incbin "baserom.gba", 0x13A4F54, 0x60
+sAltariaGfx46_1:
+.incbin "baserom.gba", 0x13A4FB4, 0x80
+sAltariaSprites46:
+ax_sprite sAltariaGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx46_1, 0x80
+ax_sprite_terminator
+sAltariaGfx47:
+.incbin "baserom.gba", 0x13A5054, 0x40
+sAltariaSprites47:
+ax_sprite sAltariaGfx47, 0x40
+ax_sprite_terminator
+sAltariaGfx48:
+.incbin "baserom.gba", 0x13A50A4, 0x40
+sAltariaSprites48:
+ax_sprite sAltariaGfx48, 0x40
+ax_sprite_terminator
+sAltariaGfx49:
+.incbin "baserom.gba", 0x13A50F4, 0x20
+sAltariaSprites49:
+ax_sprite sAltariaGfx49, 0x20
+ax_sprite_terminator
+sAltariaGfx50:
+.incbin "baserom.gba", 0x13A5124, 0x100
+sAltariaSprites50:
+ax_sprite sAltariaGfx50, 0x100
+ax_sprite_terminator
+sAltariaGfx51:
+.incbin "baserom.gba", 0x13A5234, 0x80
+sAltariaSprites51:
+ax_sprite sAltariaGfx51, 0x80
+ax_sprite_terminator
+sAltariaGfx52:
+.incbin "baserom.gba", 0x13A52C4, 0x20
+sAltariaSprites52:
+ax_sprite sAltariaGfx52, 0x20
+ax_sprite_terminator
+sAltariaGfx53:
+.incbin "baserom.gba", 0x13A52F4, 0x100
+sAltariaSprites53:
+ax_sprite sAltariaGfx53, 0x100
+ax_sprite_terminator
+sAltariaGfx54:
+.incbin "baserom.gba", 0x13A5404, 0x80
+sAltariaSprites54:
+ax_sprite sAltariaGfx54, 0x80
+ax_sprite_terminator
+sAltariaGfx55:
+.incbin "baserom.gba", 0x13A5494, 0x20
+sAltariaSprites55:
+ax_sprite sAltariaGfx55, 0x20
+ax_sprite_terminator
+sAltariaGfx56:
+.incbin "baserom.gba", 0x13A54C4, 0x60
+sAltariaGfx56_1:
+.incbin "baserom.gba", 0x13A5524, 0x120
+sAltariaGfx56_2:
+.incbin "baserom.gba", 0x13A5644, 0x20
+sAltariaSprites56:
+ax_sprite sAltariaGfx56, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAltariaGfx56_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx56_2, 0x20
+ax_sprite_terminator
+sAltariaGfx57:
+.incbin "baserom.gba", 0x13A5694, 0x20
+sAltariaSprites57:
+ax_sprite sAltariaGfx57, 0x20
+ax_sprite_terminator
+sAltariaGfx58:
+.incbin "baserom.gba", 0x13A56C4, 0x80
+sAltariaSprites58:
+ax_sprite sAltariaGfx58, 0x80
+ax_sprite_terminator
+sAltariaGfx59:
+.incbin "baserom.gba", 0x13A5754, 0x40
+sAltariaSprites59:
+ax_sprite sAltariaGfx59, 0x40
+ax_sprite_terminator
+sAltariaGfx60:
+.incbin "baserom.gba", 0x13A57A4, 0x80
+sAltariaGfx60_1:
+.incbin "baserom.gba", 0x13A5824, 0x40
+sAltariaSprites60:
+ax_sprite sAltariaGfx60, 0x80
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx60_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAltariaGfx61:
+.incbin "baserom.gba", 0x13A588C, 0x20
+sAltariaSprites61:
+ax_sprite sAltariaGfx61, 0x20
+ax_sprite_terminator
+sAltariaGfx62:
+.incbin "baserom.gba", 0x13A58BC, 0x180
+sAltariaGfx62_1:
+.incbin "baserom.gba", 0x13A5A3C, 0x40
+sAltariaSprites62:
+ax_sprite sAltariaGfx62, 0x180
+ax_sprite 0, 0x20
+ax_sprite sAltariaGfx62_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAltariaGfx63:
+.incbin "baserom.gba", 0x13A5AA4, 0x80
+sAltariaSprites63:
+ax_sprite sAltariaGfx63, 0x80
+ax_sprite_terminator
+sAltariaGfx64:
+.incbin "baserom.gba", 0x13A5B34, 0x100
+sAltariaSprites64:
+ax_sprite sAltariaGfx64, 0x100
+ax_sprite_terminator
+sAltariaGfx65:
+.incbin "baserom.gba", 0x13A5C44, 0x200
+sAltariaSprites65:
+ax_sprite sAltariaGfx65, 0x200
+ax_sprite_terminator
+sAltariaGfx66:
+.incbin "baserom.gba", 0x13A5E54, 0x200
+sAltariaSprites66:
+ax_sprite sAltariaGfx66, 0x200
+ax_sprite_terminator
+sAltariaGfx67:
+.incbin "baserom.gba", 0x13A6064, 0x80
+sAltariaSprites67:
+ax_sprite sAltariaGfx67, 0x80
+ax_sprite_terminator
+sAltariaGfx68:
+.incbin "baserom.gba", 0x13A60F4, 0x20
+sAltariaSprites68:
+ax_sprite sAltariaGfx68, 0x20
+ax_sprite_terminator
+sAltariaGfx69:
+.incbin "baserom.gba", 0x13A6124, 0x20
+sAltariaSprites69:
+ax_sprite sAltariaGfx69, 0x20
+ax_sprite_terminator
+sAltariaGfx70:
+.incbin "baserom.gba", 0x13A6154, 0x40
+sAltariaSprites70:
+ax_sprite sAltariaGfx70, 0x40
+ax_sprite_terminator
+sAltariaGfx71:
+.incbin "baserom.gba", 0x13A61A4, 0x100
+sAltariaSprites71:
+ax_sprite sAltariaGfx71, 0x100
+ax_sprite_terminator
+sAltariaGfx72:
+.incbin "baserom.gba", 0x13A62B4, 0x200
+sAltariaSprites72:
+ax_sprite sAltariaGfx72, 0x200
+ax_sprite_terminator
+sAltariaGfx73:
+.incbin "baserom.gba", 0x13A64C4, 0x200
+sAltariaSprites73:
+ax_sprite sAltariaGfx73, 0x200
+ax_sprite_terminator
+sAltariaGfx74:
+.incbin "baserom.gba", 0x13A66D4, 0x200
+sAltariaSprites74:
+ax_sprite sAltariaGfx74, 0x200
+ax_sprite_terminator
+sAltariaGfx75:
+.incbin "baserom.gba", 0x13A68E4, 0x20
+sAltariaSprites75:
+ax_sprite sAltariaGfx75, 0x20
+ax_sprite_terminator
+sAltariaGfx76:
+.incbin "baserom.gba", 0x13A6914, 0x40
+sAltariaSprites76:
+ax_sprite sAltariaGfx76, 0x40
+ax_sprite_terminator
+sAltariaGfx77:
+.incbin "baserom.gba", 0x13A6964, 0x20
+sAltariaSprites77:
+ax_sprite sAltariaGfx77, 0x20
+ax_sprite_terminator
+sAltariaGfx78:
+.incbin "baserom.gba", 0x13A6994, 0x20
+sAltariaSprites78:
+ax_sprite sAltariaGfx78, 0x20
+ax_sprite_terminator
+sAltariaGfx79:
+.incbin "baserom.gba", 0x13A69C4, 0x20
+sAltariaSprites79:
+ax_sprite sAltariaGfx79, 0x20
+ax_sprite_terminator
+sAltariaGfx80:
+.incbin "baserom.gba", 0x13A69F4, 0x40
+sAltariaSprites80:
+ax_sprite sAltariaGfx80, 0x40
+ax_sprite_terminator
+sAltariaGfx81:
+.incbin "baserom.gba", 0x13A6A44, 0x100
+sAltariaSprites81:
+ax_sprite sAltariaGfx81, 0x100
+ax_sprite_terminator
+sAltariaGfx82:
+.incbin "baserom.gba", 0x13A6B54, 0x200
+sAltariaSprites82:
+ax_sprite sAltariaGfx82, 0x200
+ax_sprite_terminator
+sAltariaGfx83:
+.incbin "baserom.gba", 0x13A6D64, 0x200
+sAltariaSprites83:
+ax_sprite sAltariaGfx83, 0x200
+ax_sprite_terminator
+sAltariaGfx84:
+.incbin "baserom.gba", 0x13A6F74, 0x200
+sAltariaSprites84:
+ax_sprite sAltariaGfx84, 0x200
+ax_sprite_terminator
+sAltariaGfx85:
+.incbin "baserom.gba", 0x13A7184, 0x200
+sAltariaSprites85:
+ax_sprite sAltariaGfx85, 0x200
+ax_sprite_terminator
+sAltariaGfx86:
+.incbin "baserom.gba", 0x13A7394, 0x200
+sAltariaSprites86:
+ax_sprite sAltariaGfx86, 0x200
+ax_sprite_terminator
+sAxPosesAltaria:
+.4byte sAltariaPose1
+.4byte sAltariaPose2
+.4byte sAltariaPose3
+.4byte sAltariaPose4
+.4byte sAltariaPose5
+.4byte sAltariaPose6
+.4byte sAltariaPose7
+.4byte sAltariaPose8
+.4byte sAltariaPose9
+.4byte sAltariaPose10
+.4byte sAltariaPose11
+.4byte sAltariaPose12
+.4byte sAltariaPose13
+.4byte sAltariaPose14
+.4byte sAltariaPose15
+.4byte sAltariaPose16
+.4byte sAltariaPose17
+.4byte sAltariaPose18
+.4byte sAltariaPose19
+.4byte sAltariaPose20
+.4byte sAltariaPose21
+.4byte sAltariaPose22
+.4byte sAltariaPose23
+.4byte sAltariaPose24
+.4byte sAltariaPose25
+.4byte sAltariaPose26
+.4byte sAltariaPose27
+.4byte sAltariaPose28
+.4byte sAltariaPose29
+.4byte sAltariaPose30
+.4byte sAltariaPose31
+.4byte sAltariaPose32
+.4byte sAltariaPose33
+.4byte sAltariaPose34
+.4byte sAltariaPose35
+.4byte sAltariaPose36
+.4byte sAltariaPose37
+.4byte sAltariaPose38
+.4byte sAltariaPose39
+.4byte sAltariaPose40
+.4byte sAltariaPose41
+.4byte sAltariaPose42
+.4byte sAltariaPose43
+.4byte sAltariaPose44
+.4byte sAltariaPose45
+.4byte sAltariaPose46
+.4byte sAltariaPose47
+.4byte sAltariaPose48
+.4byte sAltariaPose49
+.4byte sAltariaPose50
+.4byte sAltariaPose51
+.4byte sAltariaPose52
+.4byte sAltariaPose53
+.4byte sAltariaPose54
+.4byte sAltariaPose55
+.4byte sAltariaPose56
+.4byte sAltariaPose57
+.4byte sAltariaPose58
+.4byte sAltariaPose59
+.4byte sAltariaPose60
+.4byte sAltariaPose61
+.4byte sAltariaPose62
+.4byte sAltariaPose63
+.4byte sAltariaPose64
+.4byte sAltariaPose65
+.4byte sAltariaPose66
+.4byte sAltariaPose67
+.4byte sAltariaPose68
+.4byte sAltariaPose69
+.4byte sAltariaPose70
+.4byte sAltariaPose71
+.4byte sAltariaPose72
+.4byte sAltariaPose73
+.4byte sAltariaPose74
+.4byte sAltariaPose75
+.4byte sAltariaPose76
+.4byte sAltariaPose77
+.4byte sAltariaPose78
+.4byte sAltariaPose79
+.4byte sAltariaPose80
+.4byte sAltariaPose81
+.4byte sAltariaPose82
+.4byte sAltariaPose83
+.4byte sAltariaPose84
+.4byte sAltariaPose85
+.4byte sAltariaPose86
+.4byte sAltariaPose87
+.4byte sAltariaPose88
+.4byte sAltariaPose89
+.4byte sAltariaPose90
+.4byte sAltariaPose91
+.4byte sAltariaPose92
+.4byte sAltariaPose93
+.4byte sAltariaPose94
+.4byte sAltariaPose95
+.4byte sAltariaPose96
+.4byte sAltariaPose97
+.4byte sAltariaPose98
+.4byte sAltariaPose99
+.4byte sAltariaPose100
+.4byte sAltariaPose101
+.4byte sAltariaPose102
+.4byte sAltariaPose103
+.4byte sAltariaPose104
+.4byte sAltariaPose105
+.4byte sAltariaPose106
+.4byte sAltariaPose107
+.4byte sAltariaPose108
+.4byte sAltariaPose109
+.4byte sAltariaPose110
+.4byte sAltariaPose111
+.4byte sAltariaPose112
+.4byte sAltariaPose113
+.4byte sAltariaPose114
+.4byte sAltariaPose115
+.4byte sAltariaPose116
+.4byte sAltariaPose117
+.4byte sAltariaPose118
+.4byte sAltariaPose119
+.4byte sAltariaPose120
+.4byte sAltariaPose121
+.4byte sAltariaPose122
+.4byte sAltariaPose123
+.4byte sAltariaPose124
+.4byte sAltariaPose125
+.4byte sAltariaPose126
+.4byte sAltariaPose127
+.4byte sAltariaPose128
+.4byte sAltariaPose129
+.4byte sAltariaPose130
+.4byte sAltariaPose131
+.4byte sAltariaPose132
+.4byte sAltariaPose133
+.4byte sAltariaPose134
+.4byte sAltariaPose135
+.4byte sAltariaPose136
+.4byte sAltariaPose137
+.4byte sAltariaPose138
+.4byte sAltariaPose139
+.4byte sAltariaPose140
+.4byte sAltariaPose141
+.4byte sAltariaPose142
+.4byte sAltariaPose143
+.4byte sAltariaPose144
+.4byte sAltariaPose145
+.4byte sAltariaPose146
+.4byte sAltariaPose147
+.4byte sAltariaPose148
+.4byte sAltariaPose149
+.4byte sAltariaPose150
+.4byte sAltariaPose151
+.4byte sAltariaPose152
+.4byte sAltariaPose153
+.4byte sAltariaPose154
+.4byte sAltariaPose155
+.4byte sAltariaPose156
+.4byte sAltariaPose157
+.4byte sAltariaPose158
+.4byte sAltariaPose159
+.4byte sAltariaPose160
+.4byte sAltariaPose161
+.4byte sAltariaPose162
+.4byte sAltariaPose163
+.4byte sAltariaPose164
+.4byte sAltariaPose165
+.4byte sAltariaPose166
+.4byte sAltariaPose167
+.4byte sAltariaPose168
+.4byte sAltariaPose169
+.4byte sAltariaPose170
+.4byte sAltariaPose171
+.4byte sAltariaPose172
+.4byte sAltariaPose173
+.4byte sAltariaPose174
+.4byte sAltariaPose175
+.4byte sAltariaPose176
+.4byte sAltariaPose177
+.4byte sAltariaPose178
+.4byte sAltariaPose179
+.4byte sAltariaPose180
+.4byte sAltariaPose181
+.4byte sAltariaPose182
+.4byte sAltariaPose183
+.4byte sAltariaPose184
+.4byte sAltariaPose185
+.4byte sAltariaPose186
+.4byte sAltariaPose187
+.4byte sAltariaPose188
+.4byte sAltariaPose189
+.4byte sAltariaPose190
+.4byte sAltariaPose191
+.4byte sAltariaPose192
+.4byte sAltariaPose193
+.4byte sAltariaPose194
+.4byte sAltariaPose195
+.4byte sAltariaPose196
+.4byte sAltariaPose197
+.4byte sAltariaPose198
+.4byte sAltariaPose199
+.4byte sAltariaPose200
+.4byte sAltariaPose201
+.4byte sAltariaPose202
+.4byte sAltariaPose203
+.4byte sAltariaPose204
+.4byte sAltariaPose205
+.4byte sAltariaPose206
+.4byte sAltariaPose207
+.4byte sAltariaPose208
+.4byte sAltariaPose209
+.4byte sAltariaPose210
+.4byte sAltariaPose211
+.4byte sAltariaPose212
+.4byte sAltariaPose213
+.4byte sAltariaPose214
+.4byte sAltariaPose215
+.4byte sAltariaPose216
+.4byte sAltariaPose217
+.4byte sAltariaPose218
+.4byte sAltariaPose219
+.4byte sAltariaPose220
+.4byte sAltariaPose221
+.4byte sAltariaPose222
+.4byte sAltariaPose223
+.4byte sAltariaPose224
+.4byte sAltariaPose225
+.4byte sAltariaPose226
+.4byte sAltariaPose227
+.4byte sAltariaPose228
+.4byte sAltariaPose229
+.4byte sAltariaPose230
+.4byte sAltariaPose231
+.4byte sAltariaPose232
+.4byte sAltariaPose233
+.4byte sAltariaPose234
+.4byte sAltariaPose235
+.4byte sAltariaPose236
+.4byte sAltariaPose237
+.4byte sAltariaPose238
+.4byte sAltariaPose239
+.4byte sAltariaPose240
+.4byte sAltariaPose241
+.4byte sAltariaPose242
+sAxPositionsAltaria:
+.2byte   -1,  -13, 	 -19,  -17, 	  18,  -17, 	  -1,  -10
+.2byte   -1,  -11, 	 -13,  -22, 	  11,  -22, 	  -1,   -9
+.2byte   -1,  -14, 	 -13,    2, 	  11,    2, 	  -1,  -10
+.2byte    8,  -13, 	  12,  -21, 	 -17,  -13, 	   0,  -11
+.2byte    8,  -12, 	   8,  -24, 	 -10,  -20, 	   1,   -9
+.2byte    8,  -14, 	  11,   -6, 	  -8,    1, 	   1,  -11
+.2byte   12,  -17, 	  -3,  -22, 	  -7,  -14, 	  -1,  -12
+.2byte   12,  -16, 	  -1,  -24, 	  -6,  -18, 	   0,  -12
+.2byte   12,  -18, 	  -1,  -11, 	  -2,   -3, 	   0,  -13
+.2byte   11,  -21, 	 -12,  -22, 	  15,  -10, 	  -1,  -13
+.2byte   11,  -20, 	  -6,  -23, 	  12,  -16, 	  -1,  -12
+.2byte   11,  -22, 	 -10,  -11, 	   8,   -1, 	  -1,  -13
+.2byte   -1,  -22, 	  17,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -21, 	  11,  -22, 	 -13,  -22, 	  -1,  -12
+.2byte   -1,  -23, 	  11,   -3, 	 -13,   -2, 	  -1,  -14
+.2byte  -12,  -21, 	  11,  -22, 	 -16,  -10, 	   0,  -13
+.2byte  -12,  -20, 	   5,  -23, 	 -13,  -16, 	   0,  -12
+.2byte  -12,  -22, 	   9,  -11, 	  -9,   -1, 	   0,  -13
+.2byte  -13,  -17, 	   2,  -22, 	   6,  -14, 	   0,  -12
+.2byte  -13,  -16, 	   0,  -24, 	   5,  -18, 	  -1,  -12
+.2byte  -13,  -18, 	   0,  -11, 	   1,   -3, 	  -1,  -13
+.2byte   -9,  -13, 	 -13,  -21, 	  16,  -13, 	  -1,  -11
+.2byte   -9,  -12, 	  -9,  -24, 	   9,  -20, 	  -2,   -9
+.2byte   -9,  -14, 	 -12,   -6, 	   7,    1, 	  -2,  -11
+.2byte   -1,  -13, 	 -19,  -17, 	  18,  -17, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,  -24, 	  11,  -24, 	  -1,  -11
+.2byte   -1,  -13, 	 -13,    3, 	  11,    3, 	  -1,   -9
+.2byte    8,  -13, 	  12,  -21, 	 -17,  -13, 	   0,  -11
+.2byte    8,  -13, 	   8,  -25, 	 -10,  -21, 	   1,  -10
+.2byte    8,  -13, 	  11,   -5, 	  -8,    2, 	   1,  -10
+.2byte   12,  -17, 	  -3,  -22, 	  -7,  -14, 	  -1,  -12
+.2byte   12,  -17, 	  -1,  -25, 	  -6,  -19, 	   0,  -13
+.2byte   12,  -17, 	  -1,  -10, 	  -2,   -2, 	   0,  -12
+.2byte   11,  -21, 	 -12,  -22, 	  15,  -10, 	  -1,  -13
+.2byte   11,  -21, 	  -6,  -24, 	  12,  -17, 	  -1,  -13
+.2byte   11,  -21, 	 -10,  -10, 	   8,    0, 	  -1,  -12
+.2byte   -1,  -22, 	  17,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -22, 	  11,  -23, 	 -13,  -23, 	  -1,  -13
+.2byte   -1,  -22, 	  11,   -2, 	 -13,   -1, 	  -1,  -13
+.2byte  -12,  -21, 	  11,  -22, 	 -16,  -10, 	   0,  -13
+.2byte  -12,  -21, 	   5,  -24, 	 -13,  -17, 	   0,  -13
+.2byte  -12,  -21, 	   9,  -10, 	  -9,    0, 	   0,  -12
+.2byte  -13,  -17, 	   2,  -22, 	   6,  -14, 	   0,  -12
+.2byte  -13,  -17, 	   0,  -25, 	   5,  -19, 	  -1,  -13
+.2byte  -13,  -17, 	   0,  -10, 	   1,   -2, 	  -1,  -12
+.2byte   -9,  -13, 	 -13,  -21, 	  16,  -13, 	  -1,  -11
+.2byte   -9,  -13, 	  -9,  -25, 	   9,  -21, 	  -2,  -10
+.2byte   -9,  -13, 	 -12,   -5, 	   7,    2, 	  -2,  -10
+.2byte   -1,  -13, 	 -19,  -17, 	  18,  -17, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,  -24, 	  11,  -24, 	  -1,  -11
+.2byte   -1,  -13, 	 -13,    3, 	  11,    3, 	  -1,   -9
+.2byte    8,  -13, 	  12,  -21, 	 -17,  -13, 	   0,  -11
+.2byte    8,  -13, 	   8,  -25, 	 -10,  -21, 	   1,  -10
+.2byte    8,  -13, 	  11,   -5, 	  -8,    2, 	   1,  -10
+.2byte   12,  -17, 	  -3,  -22, 	  -7,  -14, 	  -1,  -12
+.2byte   12,  -17, 	  -1,  -25, 	  -6,  -19, 	   0,  -13
+.2byte   12,  -17, 	  -1,  -10, 	  -2,   -2, 	   0,  -12
+.2byte   11,  -21, 	 -12,  -22, 	  15,  -10, 	  -1,  -13
+.2byte   11,  -21, 	  -6,  -24, 	  12,  -17, 	  -1,  -13
+.2byte   11,  -21, 	 -10,  -10, 	   8,    0, 	  -1,  -12
+.2byte   -1,  -22, 	  17,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -22, 	  11,  -23, 	 -13,  -23, 	  -1,  -13
+.2byte   -1,  -22, 	  11,   -2, 	 -13,   -1, 	  -1,  -13
+.2byte  -12,  -21, 	  11,  -22, 	 -16,  -10, 	   0,  -13
+.2byte  -12,  -21, 	   5,  -24, 	 -13,  -17, 	   0,  -13
+.2byte  -12,  -21, 	   9,  -10, 	  -9,    0, 	   0,  -12
+.2byte  -13,  -17, 	   2,  -22, 	   6,  -14, 	   0,  -12
+.2byte  -13,  -17, 	   0,  -25, 	   5,  -19, 	  -1,  -13
+.2byte  -13,  -17, 	   0,  -10, 	   1,   -2, 	  -1,  -12
+.2byte   -9,  -13, 	 -13,  -21, 	  16,  -13, 	  -1,  -11
+.2byte   -9,  -13, 	  -9,  -25, 	   9,  -21, 	  -2,  -10
+.2byte   -9,  -13, 	 -12,   -5, 	   7,    2, 	  -2,  -10
+.2byte   -1,  -13, 	 -19,  -17, 	  18,  -17, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,  -24, 	  11,  -24, 	  -1,  -11
+.2byte   -1,  -13, 	 -13,    3, 	  11,    3, 	  -1,   -9
+.2byte   -1,  -14, 	 -19,  -17, 	  17,  -17, 	  -1,  -10
+.2byte   -1,  -14, 	 -13,  -24, 	  11,  -24, 	  -1,  -11
+.2byte   -1,  -14, 	 -12,    3, 	  11,    3, 	  -1,   -8
+.2byte    8,  -13, 	  12,  -21, 	 -17,  -13, 	   0,  -11
+.2byte    8,  -13, 	   8,  -25, 	 -10,  -21, 	   1,  -10
+.2byte    8,  -13, 	  11,   -5, 	  -8,    2, 	   1,  -10
+.2byte    7,  -12, 	  11,  -21, 	 -16,  -13, 	   1,  -11
+.2byte    7,  -12, 	   8,  -24, 	 -10,  -21, 	   1,  -11
+.2byte    7,  -12, 	  11,   -4, 	  -8,    2, 	   0,  -10
+.2byte   12,  -17, 	  -3,  -22, 	  -7,  -14, 	  -1,  -12
+.2byte   12,  -17, 	  -1,  -25, 	  -6,  -19, 	   0,  -13
+.2byte   12,  -17, 	  -1,  -10, 	  -2,   -2, 	   0,  -12
+.2byte   12,  -17, 	  -2,  -21, 	  -7,  -14, 	   0,  -13
+.2byte   12,  -17, 	  -1,  -25, 	  -6,  -20, 	  -1,  -13
+.2byte   12,  -17, 	  -2,  -10, 	  -2,   -2, 	  -1,  -13
+.2byte   11,  -21, 	 -12,  -22, 	  15,  -10, 	  -1,  -13
+.2byte   11,  -21, 	  -6,  -24, 	  12,  -17, 	  -1,  -13
+.2byte   11,  -21, 	 -10,  -10, 	   8,    0, 	  -1,  -12
+.2byte   11,  -22, 	 -11,  -21, 	  15,  -11, 	  -1,  -13
+.2byte   11,  -22, 	  -7,  -24, 	  12,  -18, 	  -1,  -13
+.2byte   11,  -22, 	  -9,  -10, 	   8,    0, 	  -1,  -13
+.2byte   -1,  -22, 	  17,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -22, 	  11,  -23, 	 -13,  -23, 	  -1,  -13
+.2byte   -1,  -22, 	  11,   -2, 	 -13,   -1, 	  -1,  -13
+.2byte   -1,  -22, 	  18,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -22, 	  11,  -23, 	 -13,  -22, 	  -1,  -13
+.2byte   -1,  -22, 	  11,   -2, 	 -13,   -2, 	  -1,  -13
+.2byte  -12,  -21, 	  11,  -22, 	 -16,  -10, 	   0,  -13
+.2byte  -12,  -21, 	   5,  -24, 	 -13,  -17, 	   0,  -13
+.2byte  -12,  -21, 	   9,  -10, 	  -9,    0, 	   0,  -12
+.2byte  -12,  -22, 	  10,  -21, 	 -16,  -11, 	   0,  -13
+.2byte  -12,  -22, 	   6,  -24, 	 -13,  -18, 	   0,  -13
+.2byte  -12,  -22, 	   8,  -10, 	  -9,    0, 	   0,  -13
+.2byte  -13,  -17, 	   2,  -22, 	   6,  -14, 	   0,  -12
+.2byte  -13,  -17, 	   0,  -25, 	   5,  -19, 	  -1,  -13
+.2byte  -13,  -17, 	   0,  -10, 	   1,   -2, 	  -1,  -12
+.2byte  -13,  -17, 	   1,  -21, 	   6,  -14, 	  -1,  -13
+.2byte  -13,  -17, 	   0,  -25, 	   5,  -20, 	   0,  -13
+.2byte  -13,  -17, 	   1,  -10, 	   1,   -2, 	   0,  -13
+.2byte   -9,  -13, 	 -13,  -21, 	  16,  -13, 	  -1,  -11
+.2byte   -9,  -13, 	  -9,  -25, 	   9,  -21, 	  -2,  -10
+.2byte   -9,  -13, 	 -12,   -5, 	   7,    2, 	  -2,  -10
+.2byte   -8,  -12, 	 -12,  -21, 	  15,  -13, 	  -2,  -11
+.2byte   -8,  -12, 	  -9,  -24, 	   9,  -21, 	  -2,  -11
+.2byte   -8,  -12, 	 -12,   -4, 	   7,    2, 	  -1,  -10
+.2byte   -1,  -13, 	 -19,  -17, 	  18,  -17, 	  -1,  -10
+.2byte   -1,  -11, 	 -13,  -22, 	  11,  -22, 	  -1,   -9
+.2byte   -1,  -14, 	 -13,    2, 	  11,    2, 	  -1,  -10
+.2byte    8,  -13, 	  12,  -21, 	 -17,  -13, 	   0,  -11
+.2byte    8,  -12, 	   8,  -24, 	 -10,  -20, 	   1,   -9
+.2byte    8,  -14, 	  11,   -6, 	  -8,    1, 	   1,  -11
+.2byte   12,  -17, 	  -3,  -22, 	  -7,  -14, 	  -1,  -12
+.2byte   12,  -16, 	  -1,  -24, 	  -6,  -18, 	   0,  -12
+.2byte   12,  -18, 	  -1,  -11, 	  -2,   -3, 	   0,  -13
+.2byte   11,  -21, 	 -12,  -22, 	  15,  -10, 	  -1,  -13
+.2byte   11,  -20, 	  -6,  -23, 	  12,  -16, 	  -1,  -12
+.2byte   11,  -22, 	 -10,  -11, 	   8,   -1, 	  -1,  -13
+.2byte   -1,  -22, 	  17,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -21, 	  11,  -22, 	 -13,  -22, 	  -1,  -12
+.2byte   -1,  -23, 	  11,   -3, 	 -13,   -2, 	  -1,  -14
+.2byte  -12,  -21, 	  11,  -22, 	 -16,  -10, 	   0,  -13
+.2byte  -12,  -20, 	   5,  -23, 	 -13,  -16, 	   0,  -12
+.2byte  -12,  -22, 	   9,  -11, 	  -9,   -1, 	   0,  -13
+.2byte  -13,  -17, 	   2,  -22, 	   6,  -14, 	   0,  -12
+.2byte  -13,  -16, 	   0,  -24, 	   5,  -18, 	  -1,  -12
+.2byte  -13,  -18, 	   0,  -11, 	   1,   -3, 	  -1,  -13
+.2byte   -9,  -13, 	 -13,  -21, 	  16,  -13, 	  -1,  -11
+.2byte   -9,  -12, 	  -9,  -24, 	   9,  -20, 	  -2,   -9
+.2byte   -9,  -14, 	 -12,   -6, 	   7,    1, 	  -2,  -11
+.2byte   -4,   -9, 	   2,  -10, 	   7,   -7, 	   1,   -4
+.2byte   -5,   -8, 	   2,  -10, 	   7,   -6, 	   1,   -4
+.2byte   -1,    3, 	 -14,   -8, 	  12,   -7, 	  -1,  -11
+.2byte    9,    0, 	  11,  -13, 	 -12,   -3, 	   0,  -11
+.2byte   11,   -9, 	   2,   -9, 	   0,   -1, 	  -2,  -12
+.2byte   10,  -15, 	 -11,  -12, 	   6,   -3, 	  -2,  -12
+.2byte    0,  -17, 	  14,   -9, 	 -13,   -9, 	   0,  -11
+.2byte  -11,  -15, 	  10,  -12, 	  -7,   -3, 	   1,  -12
+.2byte  -12,   -9, 	  -3,   -9, 	  -1,   -1, 	   1,  -12
+.2byte  -10,    0, 	 -12,  -13, 	  11,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	 -19,  -17, 	  18,  -17, 	  -1,  -10
+.2byte   -1,  -11, 	 -13,  -22, 	  11,  -22, 	  -1,   -9
+.2byte   -1,  -14, 	 -13,    2, 	  11,    2, 	  -1,  -10
+.2byte   -1,  -13, 	  -7,  -13, 	   6,  -13, 	  -1,   -7
+.2byte    8,  -13, 	  12,  -21, 	 -17,  -13, 	   0,  -11
+.2byte    8,  -12, 	   8,  -24, 	 -10,  -20, 	   1,   -9
+.2byte    8,  -14, 	  11,   -6, 	  -8,    1, 	   1,  -11
+.2byte    4,  -14, 	  -2,  -15, 	  -8,  -12, 	  -1,   -8
+.2byte   12,  -17, 	  -3,  -22, 	  -7,  -14, 	  -1,  -12
+.2byte   12,  -16, 	  -1,  -24, 	  -6,  -18, 	   0,  -12
+.2byte   12,  -18, 	  -1,  -11, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -16, 	  -6,  -12, 	  -8,   -9, 	  -1,   -7
+.2byte   11,  -21, 	 -12,  -22, 	  15,  -10, 	  -1,  -13
+.2byte   11,  -20, 	  -6,  -23, 	  12,  -16, 	  -1,  -12
+.2byte   11,  -22, 	 -10,  -11, 	   8,   -1, 	  -1,  -13
+.2byte    6,  -18, 	  -8,   -9, 	  -4,   -6, 	  -2,   -8
+.2byte   -1,  -22, 	  17,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -21, 	  11,  -22, 	 -13,  -22, 	  -1,  -12
+.2byte   -1,  -23, 	  11,   -3, 	 -13,   -2, 	  -1,  -14
+.2byte   -1,  -18, 	   3,   -6, 	  -4,   -7, 	  -1,   -8
+.2byte  -12,  -21, 	  11,  -22, 	 -16,  -10, 	   0,  -13
+.2byte  -12,  -20, 	   5,  -23, 	 -13,  -16, 	   0,  -12
+.2byte  -12,  -22, 	   9,  -11, 	  -9,   -1, 	   0,  -13
+.2byte   -8,  -18, 	   6,   -9, 	   2,   -6, 	   0,   -8
+.2byte  -13,  -17, 	   2,  -22, 	   6,  -14, 	   0,  -12
+.2byte  -13,  -16, 	   0,  -24, 	   5,  -18, 	  -1,  -12
+.2byte  -13,  -18, 	   0,  -11, 	   1,   -3, 	  -1,  -13
+.2byte   -9,  -16, 	   4,  -12, 	   6,   -9, 	  -1,   -7
+.2byte   -9,  -13, 	 -13,  -21, 	  16,  -13, 	  -1,  -11
+.2byte   -9,  -12, 	  -9,  -24, 	   9,  -20, 	  -2,   -9
+.2byte   -9,  -14, 	 -12,   -6, 	   7,    1, 	  -2,  -11
+.2byte   -6,  -14, 	   0,  -15, 	   6,  -12, 	  -1,   -8
+.2byte   -1,  -14, 	 -13,  -24, 	  11,  -24, 	  -1,  -11
+.2byte   -8,  -12, 	  -9,  -24, 	   9,  -21, 	  -2,  -11
+.2byte  -13,  -16, 	   0,  -24, 	   5,  -19, 	   0,  -12
+.2byte  -11,  -22, 	   7,  -24, 	 -12,  -18, 	   1,  -13
+.2byte   -1,  -22, 	  11,  -23, 	 -13,  -22, 	  -1,  -13
+.2byte   10,  -22, 	  -8,  -24, 	  11,  -18, 	  -2,  -13
+.2byte   12,  -16, 	  -1,  -24, 	  -6,  -19, 	  -1,  -12
+.2byte    7,  -12, 	   8,  -24, 	 -10,  -21, 	   1,  -11
+.2byte   -1,  -14, 	 -19,  -17, 	  17,  -17, 	  -1,  -10
+.2byte    7,  -12, 	  11,  -21, 	 -16,  -13, 	   1,  -11
+.2byte   12,  -16, 	  -2,  -20, 	  -7,  -13, 	   0,  -12
+.2byte   11,  -22, 	 -11,  -21, 	  15,  -11, 	  -1,  -13
+.2byte   -1,  -22, 	  18,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte  -12,  -22, 	  10,  -21, 	 -16,  -11, 	   0,  -13
+.2byte  -13,  -16, 	   1,  -20, 	   6,  -13, 	  -1,  -12
+.2byte   -8,  -12, 	 -12,  -21, 	  15,  -13, 	  -2,  -11
+.2byte   -1,  -14, 	 -19,  -17, 	  17,  -17, 	  -1,  -10
+.2byte   -1,  -14, 	 -13,  -24, 	  11,  -24, 	  -1,  -11
+.2byte   -1,  -14, 	 -12,    3, 	  11,    3, 	  -1,   -8
+.2byte    7,  -12, 	  11,  -21, 	 -16,  -13, 	   1,  -11
+.2byte    7,  -12, 	   8,  -24, 	 -10,  -21, 	   1,  -11
+.2byte    7,  -12, 	  11,   -4, 	  -8,    2, 	   0,  -10
+.2byte   12,  -17, 	  -2,  -21, 	  -7,  -14, 	   0,  -13
+.2byte   12,  -17, 	  -1,  -25, 	  -6,  -20, 	  -1,  -13
+.2byte   12,  -17, 	  -2,  -10, 	  -2,   -2, 	  -1,  -13
+.2byte   11,  -22, 	 -11,  -21, 	  15,  -11, 	  -1,  -13
+.2byte   11,  -22, 	  -7,  -24, 	  12,  -18, 	  -1,  -13
+.2byte   11,  -22, 	  -9,  -10, 	   8,    0, 	  -1,  -13
+.2byte   -1,  -22, 	  18,  -15, 	 -19,  -15, 	  -1,  -13
+.2byte   -1,  -22, 	  11,  -23, 	 -13,  -22, 	  -1,  -13
+.2byte   -1,  -22, 	  11,   -2, 	 -13,   -2, 	  -1,  -13
+.2byte  -12,  -22, 	  10,  -21, 	 -16,  -11, 	   0,  -13
+.2byte  -12,  -22, 	   6,  -24, 	 -13,  -18, 	   0,  -13
+.2byte  -12,  -22, 	   8,  -10, 	  -9,    0, 	   0,  -13
+.2byte  -13,  -17, 	   1,  -21, 	   6,  -14, 	  -1,  -13
+.2byte  -13,  -17, 	   0,  -25, 	   5,  -20, 	   0,  -13
+.2byte  -13,  -17, 	   1,  -10, 	   1,   -2, 	   0,  -13
+.2byte   -8,  -12, 	 -12,  -21, 	  15,  -13, 	  -2,  -11
+.2byte   -8,  -12, 	  -9,  -24, 	   9,  -21, 	  -2,  -11
+.2byte   -8,  -12, 	 -12,   -4, 	   7,    2, 	  -1,  -10
+.2byte   -1,  -13, 	  -7,  -13, 	   6,  -13, 	  -1,   -7
+.2byte   -6,  -14, 	   0,  -15, 	   6,  -12, 	  -1,   -8
+.2byte   -9,  -16, 	   4,  -12, 	   6,   -9, 	  -1,   -7
+.2byte   -8,  -18, 	   6,   -9, 	   2,   -6, 	   0,   -8
+.2byte   -1,  -18, 	   3,   -6, 	  -4,   -7, 	  -1,   -8
+.2byte    6,  -18, 	  -8,   -9, 	  -4,   -6, 	  -2,   -8
+.2byte    7,  -16, 	  -6,  -12, 	  -8,   -9, 	  -1,   -7
+.2byte    4,  -14, 	  -2,  -15, 	  -8,  -12, 	  -1,   -8
+.2byte   -1,  -13, 	  -7,  -13, 	   6,  -13, 	  -1,   -7
+.2byte   -6,  -14, 	   0,  -15, 	   6,  -12, 	  -1,   -8
+.2byte   -9,  -16, 	   4,  -12, 	   6,   -9, 	  -1,   -7
+.2byte   -8,  -18, 	   6,   -9, 	   2,   -6, 	   0,   -8
+.2byte   -1,  -18, 	   3,   -6, 	  -4,   -7, 	  -1,   -8
+.2byte    6,  -18, 	  -8,   -9, 	  -4,   -6, 	  -2,   -8
+.2byte    7,  -16, 	  -6,  -12, 	  -8,   -9, 	  -1,   -7
+.2byte    4,  -14, 	  -2,  -15, 	  -8,  -12, 	  -1,   -8
+sAltariaAnimTable1:
+.4byte sAltariaAnims_1_1
+.4byte sAltariaAnims_1_2
+.4byte sAltariaAnims_1_3
+.4byte sAltariaAnims_1_4
+.4byte sAltariaAnims_1_5
+.4byte sAltariaAnims_1_6
+.4byte sAltariaAnims_1_7
+.4byte sAltariaAnims_1_8
+sAltariaAnimTable2:
+.4byte sAltariaAnims_2_1
+.4byte sAltariaAnims_2_2
+.4byte sAltariaAnims_2_3
+.4byte sAltariaAnims_2_4
+.4byte sAltariaAnims_2_5
+.4byte sAltariaAnims_2_6
+.4byte sAltariaAnims_2_7
+.4byte sAltariaAnims_2_8
+sAltariaAnimTable3:
+.4byte sAltariaAnims_3_1
+.4byte sAltariaAnims_3_2
+.4byte sAltariaAnims_3_3
+.4byte sAltariaAnims_3_4
+.4byte sAltariaAnims_3_5
+.4byte sAltariaAnims_3_6
+.4byte sAltariaAnims_3_7
+.4byte sAltariaAnims_3_8
+sAltariaAnimTable4:
+.4byte sAltariaAnims_4_1
+.4byte sAltariaAnims_4_2
+.4byte sAltariaAnims_4_3
+.4byte sAltariaAnims_4_4
+.4byte sAltariaAnims_4_5
+.4byte sAltariaAnims_4_6
+.4byte sAltariaAnims_4_7
+.4byte sAltariaAnims_4_8
+sAltariaAnimTable5:
+.4byte sAltariaAnims_5_1
+.4byte sAltariaAnims_5_2
+.4byte sAltariaAnims_5_3
+.4byte sAltariaAnims_5_4
+.4byte sAltariaAnims_5_5
+.4byte sAltariaAnims_5_6
+.4byte sAltariaAnims_5_7
+.4byte sAltariaAnims_5_8
+sAltariaAnimTable6:
+.4byte sAltariaAnims_6_1
+.4byte sAltariaAnims_6_1
+.4byte sAltariaAnims_6_1
+.4byte sAltariaAnims_6_1
+.4byte sAltariaAnims_6_1
+.4byte sAltariaAnims_6_1
+.4byte sAltariaAnims_6_1
+.4byte sAltariaAnims_6_1
+sAltariaAnimTable7:
+.4byte sAltariaAnims_7_1
+.4byte sAltariaAnims_7_2
+.4byte sAltariaAnims_7_3
+.4byte sAltariaAnims_7_4
+.4byte sAltariaAnims_7_5
+.4byte sAltariaAnims_7_6
+.4byte sAltariaAnims_7_7
+.4byte sAltariaAnims_7_8
+sAltariaAnimTable8:
+.4byte sAltariaAnims_8_1
+.4byte sAltariaAnims_8_2
+.4byte sAltariaAnims_8_3
+.4byte sAltariaAnims_8_4
+.4byte sAltariaAnims_8_5
+.4byte sAltariaAnims_8_6
+.4byte sAltariaAnims_8_7
+.4byte sAltariaAnims_8_8
+sAltariaAnimTable9:
+.4byte sAltariaAnims_9_1
+.4byte sAltariaAnims_9_2
+.4byte sAltariaAnims_9_3
+.4byte sAltariaAnims_9_4
+.4byte sAltariaAnims_9_5
+.4byte sAltariaAnims_9_6
+.4byte sAltariaAnims_9_7
+.4byte sAltariaAnims_9_8
+sAltariaAnimTable10:
+.4byte sAltariaAnims_10_1
+.4byte sAltariaAnims_10_2
+.4byte sAltariaAnims_10_3
+.4byte sAltariaAnims_10_4
+.4byte sAltariaAnims_10_5
+.4byte sAltariaAnims_10_6
+.4byte sAltariaAnims_10_7
+.4byte sAltariaAnims_10_8
+sAltariaAnimTable11:
+.4byte sAltariaAnims_11_1
+.4byte sAltariaAnims_11_2
+.4byte sAltariaAnims_11_3
+.4byte sAltariaAnims_11_4
+.4byte sAltariaAnims_11_5
+.4byte sAltariaAnims_11_6
+.4byte sAltariaAnims_11_7
+.4byte sAltariaAnims_11_8
+sAltariaAnimTable12:
+.4byte sAltariaAnims_12_1
+.4byte sAltariaAnims_12_2
+.4byte sAltariaAnims_12_3
+.4byte sAltariaAnims_12_4
+.4byte sAltariaAnims_12_5
+.4byte sAltariaAnims_12_6
+.4byte sAltariaAnims_12_7
+.4byte sAltariaAnims_12_8
+sAltariaAnimTable13:
+.4byte sAltariaAnims_13_1
+.4byte sAltariaAnims_13_2
+.4byte sAltariaAnims_13_3
+.4byte sAltariaAnims_13_4
+.4byte sAltariaAnims_13_5
+.4byte sAltariaAnims_13_6
+.4byte sAltariaAnims_13_7
+.4byte sAltariaAnims_13_8
+sAxAnimationsAltaria:
+.4byte sAltariaAnimTable1
+.4byte sAltariaAnimTable2
+.4byte sAltariaAnimTable3
+.4byte sAltariaAnimTable4
+.4byte sAltariaAnimTable5
+.4byte sAltariaAnimTable6
+.4byte sAltariaAnimTable7
+.4byte sAltariaAnimTable8
+.4byte sAltariaAnimTable9
+.4byte sAltariaAnimTable10
+.4byte sAltariaAnimTable11
+.4byte sAltariaAnimTable12
+.4byte sAltariaAnimTable13
+sAxSpritesAltaria:
+.4byte sAltariaSprites1
+.4byte sAltariaSprites2
+.4byte sAltariaSprites3
+.4byte sAltariaSprites4
+.4byte sAltariaSprites5
+.4byte sAltariaSprites6
+.4byte sAltariaSprites7
+.4byte sAltariaSprites8
+.4byte sAltariaSprites9
+.4byte sAltariaSprites10
+.4byte sAltariaSprites11
+.4byte sAltariaSprites12
+.4byte sAltariaSprites13
+.4byte sAltariaSprites14
+.4byte sAltariaSprites15
+.4byte sAltariaSprites16
+.4byte sAltariaSprites17
+.4byte sAltariaSprites18
+.4byte sAltariaSprites19
+.4byte sAltariaSprites20
+.4byte sAltariaSprites21
+.4byte sAltariaSprites22
+.4byte sAltariaSprites23
+.4byte sAltariaSprites24
+.4byte sAltariaSprites25
+.4byte sAltariaSprites26
+.4byte sAltariaSprites27
+.4byte sAltariaSprites28
+.4byte sAltariaSprites29
+.4byte sAltariaSprites30
+.4byte sAltariaSprites31
+.4byte sAltariaSprites32
+.4byte sAltariaSprites33
+.4byte sAltariaSprites34
+.4byte sAltariaSprites35
+.4byte sAltariaSprites36
+.4byte sAltariaSprites37
+.4byte sAltariaSprites38
+.4byte sAltariaSprites39
+.4byte sAltariaSprites40
+.4byte sAltariaSprites41
+.4byte sAltariaSprites42
+.4byte sAltariaSprites43
+.4byte sAltariaSprites44
+.4byte sAltariaSprites45
+.4byte sAltariaSprites46
+.4byte sAltariaSprites47
+.4byte sAltariaSprites48
+.4byte sAltariaSprites49
+.4byte sAltariaSprites50
+.4byte sAltariaSprites51
+.4byte sAltariaSprites52
+.4byte sAltariaSprites53
+.4byte sAltariaSprites54
+.4byte sAltariaSprites55
+.4byte sAltariaSprites56
+.4byte sAltariaSprites57
+.4byte sAltariaSprites58
+.4byte sAltariaSprites59
+.4byte sAltariaSprites60
+.4byte sAltariaSprites61
+.4byte sAltariaSprites62
+.4byte sAltariaSprites63
+.4byte sAltariaSprites64
+.4byte sAltariaSprites65
+.4byte sAltariaSprites66
+.4byte sAltariaSprites67
+.4byte sAltariaSprites68
+.4byte sAltariaSprites69
+.4byte sAltariaSprites70
+.4byte sAltariaSprites71
+.4byte sAltariaSprites72
+.4byte sAltariaSprites73
+.4byte sAltariaSprites74
+.4byte sAltariaSprites75
+.4byte sAltariaSprites76
+.4byte sAltariaSprites77
+.4byte sAltariaSprites78
+.4byte sAltariaSprites79
+.4byte sAltariaSprites80
+.4byte sAltariaSprites81
+.4byte sAltariaSprites82
+.4byte sAltariaSprites83
+.4byte sAltariaSprites84
+.4byte sAltariaSprites85
+.4byte sAltariaSprites86
+sAxMainAltaria:
+ax_main sAxPosesAltaria, sAxAnimationsAltaria, 13, sAxSpritesAltaria, sAxPositionsAltaria

--- a/data/ax/ampharos.inc
+++ b/data/ax/ampharos.inc
@@ -1,0 +1,2980 @@
+.global gAxAmpharos
+gAxAmpharos:
+ax_siro sAxMainAmpharos
+sAmpharosPose1:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose2:
+ax_pose 1, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose3:
+ax_pose 2, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose4:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose5:
+ax_pose 4, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose6:
+ax_pose 5, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose7:
+ax_pose 6, 0x01e2, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose8:
+ax_pose 7, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose9:
+ax_pose 8, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose10:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose11:
+ax_pose 10, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose12:
+ax_pose 11, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose13:
+ax_pose 12, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose14:
+ax_pose 13, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose15:
+ax_pose 14, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose16:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose17:
+ax_pose 10, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose18:
+ax_pose 11, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose19:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose20:
+ax_pose 7, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose21:
+ax_pose 8, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose22:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose23:
+ax_pose 4, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose24:
+ax_pose 5, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose25:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose26:
+ax_pose 15, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose27:
+ax_pose 16, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose28:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose29:
+ax_pose 17, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose30:
+ax_pose 18, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose31:
+ax_pose 6, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose32:
+ax_pose 19, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose33:
+ax_pose 20, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose34:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose35:
+ax_pose 21, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose36:
+ax_pose 22, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose37:
+ax_pose 12, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose38:
+ax_pose 23, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose39:
+ax_pose 24, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose40:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose41:
+ax_pose 21, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose42:
+ax_pose 22, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose43:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose44:
+ax_pose 19, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose45:
+ax_pose 20, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose46:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose47:
+ax_pose 17, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose48:
+ax_pose 18, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sAmpharosPose49:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose50:
+ax_pose 15, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose51:
+ax_pose 16, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose52:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose53:
+ax_pose 17, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose54:
+ax_pose 18, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose55:
+ax_pose 6, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose56:
+ax_pose 19, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose57:
+ax_pose 20, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose58:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose59:
+ax_pose 21, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose60:
+ax_pose 22, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose61:
+ax_pose 12, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose62:
+ax_pose 23, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose63:
+ax_pose 24, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose64:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose65:
+ax_pose 21, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose66:
+ax_pose 22, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose67:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose68:
+ax_pose 19, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose69:
+ax_pose 20, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose70:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose71:
+ax_pose 17, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose72:
+ax_pose 18, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sAmpharosPose73:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose74:
+ax_pose 25, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose75:
+ax_pose 26, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose76:
+ax_pose 27, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose77:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose78:
+ax_pose 28, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose79:
+ax_pose 29, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose80:
+ax_pose 30, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose81:
+ax_pose 6, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose82:
+ax_pose 31, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose83:
+ax_pose 32, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sAmpharosPose84:
+ax_pose 33, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sAmpharosPose85:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose86:
+ax_pose 34, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose87:
+ax_pose 35, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose88:
+ax_pose 36, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose89:
+ax_pose 12, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose90:
+ax_pose 37, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose91:
+ax_pose 38, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose92:
+ax_pose 39, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose93:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose94:
+ax_pose 34, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose95:
+ax_pose 35, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose96:
+ax_pose 36, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose97:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose98:
+ax_pose 31, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose99:
+ax_pose 32, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sAmpharosPose100:
+ax_pose 33, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sAmpharosPose101:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose102:
+ax_pose 28, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose103:
+ax_pose 29, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose104:
+ax_pose 30, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose105:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose106:
+ax_pose 25, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose107:
+ax_pose 26, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose108:
+ax_pose 27, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose109:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose110:
+ax_pose 28, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose111:
+ax_pose 29, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose112:
+ax_pose 30, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose113:
+ax_pose 6, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose114:
+ax_pose 31, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose115:
+ax_pose 32, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sAmpharosPose116:
+ax_pose 33, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sAmpharosPose117:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose118:
+ax_pose 34, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose119:
+ax_pose 35, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose120:
+ax_pose 36, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose121:
+ax_pose 12, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose122:
+ax_pose 37, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose123:
+ax_pose 38, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose124:
+ax_pose 39, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose125:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose126:
+ax_pose 34, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose127:
+ax_pose 35, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose128:
+ax_pose 36, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose129:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose130:
+ax_pose 31, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose131:
+ax_pose 32, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sAmpharosPose132:
+ax_pose 33, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sAmpharosPose133:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose134:
+ax_pose 28, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose135:
+ax_pose 29, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose136:
+ax_pose 30, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose137:
+ax_pose 40, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sAmpharosPose138:
+ax_pose 41, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sAmpharosPose139:
+ax_pose 42, 0x01de, 0x80f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose140:
+ax_pose 43, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose141:
+ax_pose 44, 0x01e3, 0x90e8, 0x2c00
+ax_pose_terminator
+sAmpharosPose142:
+ax_pose 45, 0x01e4, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose143:
+ax_pose 46, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose144:
+ax_pose 45, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose145:
+ax_pose 44, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose146:
+ax_pose 43, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sAmpharosPose147:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose148:
+ax_pose 16, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose149:
+ax_pose 15, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose150:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose151:
+ax_pose 18, 0x01e4, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose152:
+ax_pose 17, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose153:
+ax_pose 6, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose154:
+ax_pose 20, 0x01e3, 0x90e9, 0x2c00
+ax_pose_terminator
+sAmpharosPose155:
+ax_pose 19, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sAmpharosPose156:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose157:
+ax_pose 22, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sAmpharosPose158:
+ax_pose 21, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose159:
+ax_pose 12, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose160:
+ax_pose 24, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose161:
+ax_pose 23, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose162:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose163:
+ax_pose 22, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sAmpharosPose164:
+ax_pose 21, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose165:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose166:
+ax_pose 20, 0x01e3, 0x80f7, 0x2c00
+ax_pose_terminator
+sAmpharosPose167:
+ax_pose 19, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose168:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose169:
+ax_pose 18, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sAmpharosPose170:
+ax_pose 17, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose171:
+ax_pose 16, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose172:
+ax_pose 18, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sAmpharosPose173:
+ax_pose 20, 0x01e4, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose174:
+ax_pose 22, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose175:
+ax_pose 24, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose176:
+ax_pose 22, 0x01e4, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose177:
+ax_pose 20, 0x01e4, 0x90e8, 0x2c00
+ax_pose_terminator
+sAmpharosPose178:
+ax_pose 18, 0x01e4, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose179:
+ax_pose 16, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose180:
+ax_pose 18, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose181:
+ax_pose 20, 0x01e3, 0x90e8, 0x2c00
+ax_pose_terminator
+sAmpharosPose182:
+ax_pose 22, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose183:
+ax_pose 24, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose184:
+ax_pose 22, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose185:
+ax_pose 20, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose186:
+ax_pose 18, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sAmpharosPose187:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose188:
+ax_pose 15, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose189:
+ax_pose 16, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose190:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose191:
+ax_pose 17, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose192:
+ax_pose 18, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sAmpharosPose193:
+ax_pose 6, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose194:
+ax_pose 19, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose195:
+ax_pose 20, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose196:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose197:
+ax_pose 21, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose198:
+ax_pose 22, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose199:
+ax_pose 12, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose200:
+ax_pose 23, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose201:
+ax_pose 24, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose202:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose203:
+ax_pose 21, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose204:
+ax_pose 22, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose205:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose206:
+ax_pose 19, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose207:
+ax_pose 20, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose208:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose209:
+ax_pose 17, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose210:
+ax_pose 18, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sAmpharosPose211:
+ax_pose 26, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose212:
+ax_pose 29, 0x01e4, 0x80f6, 0x2c00
+ax_pose_terminator
+sAmpharosPose213:
+ax_pose 32, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sAmpharosPose214:
+ax_pose 35, 0x01e3, 0x80ef, 0x2c00
+ax_pose_terminator
+sAmpharosPose215:
+ax_pose 38, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose216:
+ax_pose 35, 0x01e3, 0x90f0, 0x2c00
+ax_pose_terminator
+sAmpharosPose217:
+ax_pose 32, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sAmpharosPose218:
+ax_pose 29, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sAmpharosPose219:
+ax_pose 0, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose220:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose221:
+ax_pose 6, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sAmpharosPose222:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose223:
+ax_pose 12, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sAmpharosPose224:
+ax_pose 9, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sAmpharosPose225:
+ax_pose 6, 0x01e3, 0x90e7, 0x2c00
+ax_pose_terminator
+sAmpharosPose226:
+ax_pose 3, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+.align 2
+sAmpharosAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 6, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 26, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, -4, 0, -1,
+ax_anim 2, 2, 26, 0, 1, 0, 5,
+ax_anim 2, 0, 26, 0, 5, 0, 14,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 1, 26, 0, 22, 0, 22,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 0, 26, 0, 22, 0, 22,
+ax_anim 2, 0, 25, 0, 1, 0, 1,
+ax_anim_terminator
+sAmpharosAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, -3, -3, -3, -3,
+ax_anim 6, 0, 28, -4, -4, -4, -4,
+ax_anim 2, 0, 29, 1, -5, 1, -1,
+ax_anim 2, 0, 29, 4, -6, 4, 4,
+ax_anim 2, 0, 29, 8, -3, 8, 8,
+ax_anim 2, 2, 29, 15, 7, 15, 15,
+ax_anim 2, 0, 29, 21, 21, 21, 21,
+ax_anim 2, 1, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 21, 21, 21, 21,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 28, 6, 1, 6, 6,
+ax_anim_terminator
+sAmpharosAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 6, 0, 31, -4, 0, -4, 0,
+ax_anim 2, 0, 32, 1, -4, 1, 0,
+ax_anim 2, 0, 32, 5, -7, 5, 0,
+ax_anim 2, 2, 32, 10, -8, 8, 0,
+ax_anim 2, 0, 32, 15, -6, 15, 0,
+ax_anim 2, 0, 32, 21, 0, 21, 0,
+ax_anim 2, 1, 32, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 21, 0, 21, 0,
+ax_anim 2, 0, 32, 21, 1, 21, 1,
+ax_anim 2, 0, 31, 6, -5, 6, 0,
+ax_anim_terminator
+sAmpharosAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 33, -3, 3, -3, 3,
+ax_anim 6, 0, 34, -4, 4, -4, 4,
+ax_anim 2, 0, 35, 1, -5, 1, -1,
+ax_anim 2, 0, 35, 5, -13, 3, -3,
+ax_anim 2, 2, 35, 10, -17, 8, -8,
+ax_anim 2, 0, 35, 15, -18, 15, -15,
+ax_anim 2, 0, 35, 21, -19, 21, -20,
+ax_anim 2, 1, 35, 20, -20, 20, -21,
+ax_anim 2, 0, 35, 21, -19, 21, -20,
+ax_anim 2, 0, 35, 20, -20, 20, -21,
+ax_anim 2, 0, 34, 6, -6, 6, -5,
+ax_anim_terminator
+sAmpharosAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 3, 0, 3,
+ax_anim 6, 0, 37, 0, 4, 0, 4,
+ax_anim 2, 0, 38, 0, -5, 0, -1,
+ax_anim 2, 0, 38, 0, -13, 0, -3,
+ax_anim 2, 2, 38, 0, -17, 0, -8,
+ax_anim 2, 0, 38, 0, -18, 0, -15,
+ax_anim 2, 0, 38, 0, -19, 0, -20,
+ax_anim 2, 1, 38, 0, -20, 0, -21,
+ax_anim 2, 0, 38, 0, -19, 0, -20,
+ax_anim 2, 0, 38, 0, -20, 0, -21,
+ax_anim 2, 0, 37, 0, -6, 0, -5,
+ax_anim_terminator
+sAmpharosAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 3, 3, 3, 3,
+ax_anim 6, 0, 40, 4, 4, 4, 4,
+ax_anim 2, 0, 41, -1, -5, -1, -1,
+ax_anim 2, 0, 41, -5, -13, -3, -3,
+ax_anim 2, 2, 41, -10, -17, -8, -8,
+ax_anim 2, 0, 41, -15, -18, -15, -15,
+ax_anim 2, 0, 41, -21, -19, -21, -20,
+ax_anim 2, 1, 41, -20, -20, -20, -21,
+ax_anim 2, 0, 41, -21, -19, -21, -20,
+ax_anim 2, 0, 41, -20, -20, -20, -21,
+ax_anim 2, 0, 40, -6, -6, -6, -5,
+ax_anim_terminator
+sAmpharosAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 6, 0, 43, 4, 0, 4, 0,
+ax_anim 2, 0, 44, -1, -4, -1, 0,
+ax_anim 2, 0, 44, -5, -7, -5, 0,
+ax_anim 2, 2, 44, -10, -8, -8, 0,
+ax_anim 2, 0, 44, -15, -6, -15, 0,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 1, 44, -21, 1, -21, 1,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 0, 44, -21, 1, -21, 1,
+ax_anim 2, 0, 43, -6, -5, -6, 0,
+ax_anim_terminator
+sAmpharosAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 45, 3, -3, 3, -3,
+ax_anim 6, 0, 46, 4, -4, 4, -4,
+ax_anim 2, 0, 47, -1, -5, -1, -1,
+ax_anim 2, 0, 47, -4, -6, -4, 4,
+ax_anim 2, 0, 47, -8, -3, -8, 8,
+ax_anim 2, 2, 47, -15, 7, -15, 15,
+ax_anim 2, 0, 47, -21, 21, -21, 21,
+ax_anim 2, 1, 47, -19, 22, -19, 22,
+ax_anim 2, 0, 47, -21, 21, -21, 21,
+ax_anim 2, 0, 47, -19, 22, -19, 22,
+ax_anim 2, 0, 46, -6, 1, -6, 6,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 48, 0, -3, 0, -3,
+ax_anim 6, 0, 49, 0, -4, 0, -4,
+ax_anim 2, 0, 50, 0, -3, 0, -3,
+ax_anim 2, 0, 50, 0, -4, 0, -1,
+ax_anim 2, 2, 50, 0, 1, 0, 5,
+ax_anim 2, 0, 50, 0, 5, 0, 14,
+ax_anim 2, 0, 50, 0, 21, 0, 21,
+ax_anim 2, 1, 50, 0, 22, 0, 22,
+ax_anim 2, 0, 50, 0, 21, 0, 21,
+ax_anim 2, 0, 50, 0, 22, 0, 22,
+ax_anim 2, 0, 49, 0, 1, 0, 1,
+ax_anim_terminator
+sAmpharosAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 51, -3, -3, -3, -3,
+ax_anim 6, 0, 52, -4, -4, -4, -4,
+ax_anim 2, 0, 53, 1, -5, 1, -1,
+ax_anim 2, 0, 53, 4, -6, 4, 4,
+ax_anim 2, 0, 53, 8, -3, 8, 8,
+ax_anim 2, 2, 53, 15, 7, 15, 15,
+ax_anim 2, 0, 53, 21, 21, 21, 21,
+ax_anim 2, 1, 53, 19, 22, 19, 22,
+ax_anim 2, 0, 53, 21, 21, 21, 21,
+ax_anim 2, 0, 53, 19, 22, 19, 22,
+ax_anim 2, 0, 52, 6, 1, 6, 6,
+ax_anim_terminator
+sAmpharosAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 2, 0, 54, -3, 0, -3, 0,
+ax_anim 6, 0, 55, -4, 0, -4, 0,
+ax_anim 2, 0, 56, 1, -4, 1, 0,
+ax_anim 2, 0, 56, 5, -7, 5, 0,
+ax_anim 2, 2, 56, 10, -8, 8, 0,
+ax_anim 2, 0, 56, 15, -6, 15, 0,
+ax_anim 2, 0, 56, 21, 0, 21, 0,
+ax_anim 2, 1, 56, 21, 1, 21, 1,
+ax_anim 2, 0, 56, 21, 0, 21, 0,
+ax_anim 2, 0, 56, 21, 1, 21, 1,
+ax_anim 2, 0, 55, 6, -5, 6, 0,
+ax_anim_terminator
+sAmpharosAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 2, 0, 57, -3, 3, -3, 3,
+ax_anim 6, 0, 58, -4, 4, -4, 4,
+ax_anim 2, 0, 59, 1, -5, 1, -1,
+ax_anim 2, 0, 59, 5, -13, 3, -3,
+ax_anim 2, 2, 59, 10, -17, 8, -8,
+ax_anim 2, 0, 59, 15, -18, 15, -15,
+ax_anim 2, 0, 59, 21, -19, 21, -20,
+ax_anim 2, 1, 59, 20, -20, 20, -21,
+ax_anim 2, 0, 59, 21, -19, 21, -20,
+ax_anim 2, 0, 59, 20, -20, 20, -21,
+ax_anim 2, 0, 58, 6, -6, 6, -5,
+ax_anim_terminator
+sAmpharosAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 60, 0, 3, 0, 3,
+ax_anim 6, 0, 61, 0, 4, 0, 4,
+ax_anim 2, 0, 62, 0, -5, 0, -1,
+ax_anim 2, 0, 62, 0, -13, 0, -3,
+ax_anim 2, 2, 62, 0, -17, 0, -8,
+ax_anim 2, 0, 62, 0, -18, 0, -15,
+ax_anim 2, 0, 62, 0, -19, 0, -20,
+ax_anim 2, 1, 62, 0, -20, 0, -21,
+ax_anim 2, 0, 62, 0, -19, 0, -20,
+ax_anim 2, 0, 62, 0, -20, 0, -21,
+ax_anim 2, 0, 61, 0, -6, 0, -5,
+ax_anim_terminator
+sAmpharosAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 2, 0, 63, 3, 3, 3, 3,
+ax_anim 6, 0, 64, 4, 4, 4, 4,
+ax_anim 2, 0, 65, -1, -5, -1, -1,
+ax_anim 2, 0, 65, -5, -13, -3, -3,
+ax_anim 2, 2, 65, -10, -17, -8, -8,
+ax_anim 2, 0, 65, -15, -18, -15, -15,
+ax_anim 2, 0, 65, -21, -19, -21, -20,
+ax_anim 2, 1, 65, -20, -20, -20, -21,
+ax_anim 2, 0, 65, -21, -19, -21, -20,
+ax_anim 2, 0, 65, -20, -20, -20, -21,
+ax_anim 2, 0, 64, -6, -6, -6, -5,
+ax_anim_terminator
+sAmpharosAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 2, 0, 66, 3, 0, 3, 0,
+ax_anim 6, 0, 67, 4, 0, 4, 0,
+ax_anim 2, 0, 68, -1, -4, -1, 0,
+ax_anim 2, 0, 68, -5, -7, -5, 0,
+ax_anim 2, 2, 68, -10, -8, -8, 0,
+ax_anim 2, 0, 68, -15, -6, -15, 0,
+ax_anim 2, 0, 68, -21, 0, -21, 0,
+ax_anim 2, 1, 68, -21, 1, -21, 1,
+ax_anim 2, 0, 68, -21, 0, -21, 0,
+ax_anim 2, 0, 68, -21, 1, -21, 1,
+ax_anim 2, 0, 67, -6, -5, -6, 0,
+ax_anim_terminator
+sAmpharosAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 2, 0, 69, 3, -3, 3, -3,
+ax_anim 6, 0, 70, 4, -4, 4, -4,
+ax_anim 2, 0, 71, -1, -5, -1, -1,
+ax_anim 2, 0, 71, -4, -6, -4, 4,
+ax_anim 2, 0, 71, -8, -3, -8, 8,
+ax_anim 2, 2, 71, -15, 7, -15, 15,
+ax_anim 2, 0, 71, -21, 21, -21, 21,
+ax_anim 2, 1, 71, -19, 22, -19, 22,
+ax_anim 2, 0, 71, -21, 21, -21, 21,
+ax_anim 2, 0, 71, -19, 22, -19, 22,
+ax_anim 2, 0, 70, -6, 1, -6, 6,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 1, 0, 72, 0, 1, 0, 1,
+ax_anim 2, 1, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sAmpharosAnims_4_2:
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 6, 2, 77, -3, -3, -3, -3,
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim 1, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 1, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sAmpharosAnims_4_3:
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 6, 2, 81, -3, 0, -3, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 1, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sAmpharosAnims_4_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 6, 2, 85, -3, 3, -3, 3,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 1, 0, 84, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sAmpharosAnims_4_5:
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 6, 2, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 1, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 90, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 90, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 90, 0, -5, 0, -5,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sAmpharosAnims_4_6:
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 6, 2, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 1, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 1, 94, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 94, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 94, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 94, -5, -5, -5, -5,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sAmpharosAnims_4_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 6, 2, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 1, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 1, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sAmpharosAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 6, 2, 101, 3, -3, 3, -3,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 1, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 1, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_5_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 1, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 1, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sAmpharosAnims_5_2:
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 6, 2, 109, -3, -3, -3, -3,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 1, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 1, 110, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 110, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 110, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 110, 5, 5, 5, 5,
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim_terminator
+sAmpharosAnims_5_3:
+ax_anim 2, 0, 113, -2, 0, -2, 0,
+ax_anim 6, 2, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim 1, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 114, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim_terminator
+sAmpharosAnims_5_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 6, 2, 117, -3, 3, -3, 3,
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim 1, 0, 116, 1, -1, 1, -1,
+ax_anim 2, 1, 118, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 118, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 118, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 118, 5, -5, 5, -5,
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim_terminator
+sAmpharosAnims_5_5:
+ax_anim 2, 0, 121, 0, 2, 0, 2,
+ax_anim 6, 2, 121, 0, 3, 0, 3,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 1, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 1, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim_terminator
+sAmpharosAnims_5_6:
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 6, 2, 125, 3, 3, 3, 3,
+ax_anim 2, 0, 124, 1, 1, 1, 1,
+ax_anim 1, 0, 124, -1, -1, -1, -1,
+ax_anim 2, 1, 126, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 126, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 126, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 126, -5, -5, -5, -5,
+ax_anim 2, 0, 124, -2, -2, -2, -2,
+ax_anim_terminator
+sAmpharosAnims_5_7:
+ax_anim 2, 0, 129, 2, 0, 2, 0,
+ax_anim 6, 2, 129, 3, 0, 3, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 1, 0, 128, -1, 0, -1, 0,
+ax_anim 2, 1, 130, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 130, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 130, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 130, -5, 0, -5, 0,
+ax_anim 2, 0, 128, -2, 0, -2, 0,
+ax_anim_terminator
+sAmpharosAnims_5_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 6, 2, 133, 3, -3, 3, -3,
+ax_anim 2, 0, 132, 1, -1, 1, -1,
+ax_anim 1, 0, 132, -1, 1, -1, 1,
+ax_anim 2, 1, 134, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 134, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 134, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 134, -5, 5, -5, 5,
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sAmpharosAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sAmpharosAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sAmpharosAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sAmpharosAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sAmpharosAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sAmpharosAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sAmpharosAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_8_1:
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, -3, 0, 0,
+ax_anim 6, 0, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 147, 0, -3, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_8_2:
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, -4, 0, 0,
+ax_anim 6, 0, 150, 0, -5, 0, 0,
+ax_anim 4, 0, 150, 0, -4, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_8_3:
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, -4, 0, 0,
+ax_anim 6, 0, 153, 0, -5, 0, 0,
+ax_anim 4, 0, 153, 0, -4, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_8_4:
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, -4, 0, 0,
+ax_anim 6, 0, 156, 0, -5, 0, 0,
+ax_anim 4, 0, 156, 0, -4, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_8_5:
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -4, 0, 0,
+ax_anim 6, 0, 159, 0, -5, 0, 0,
+ax_anim 4, 0, 159, 0, -4, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_8_6:
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, -4, 0, 0,
+ax_anim 6, 0, 162, 0, -5, 0, 0,
+ax_anim 4, 0, 162, 0, -4, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_8_7:
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 165, 0, -4, 0, 0,
+ax_anim 6, 0, 165, 0, -5, 0, 0,
+ax_anim 4, 0, 165, 0, -4, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_8_8:
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 168, 0, -4, 0, 0,
+ax_anim 6, 0, 168, 0, -5, 0, 0,
+ax_anim 4, 0, 168, 0, -4, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 11, 8, 11, 8,
+ax_anim 2, 0, 173, 8, 16, 8, 16,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -8, 16, -8, 16,
+ax_anim 2, 0, 176, -11, 8, -11, 8,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 12, 0, 12, 0,
+ax_anim 2, 0, 171, 22, 4, 22, 4,
+ax_anim 2, 0, 172, 26, 12, 26, 12,
+ax_anim 3, 0, 173, 22, 19, 22, 19,
+ax_anim 2, 3, 174, 12, 19, 12, 19,
+ax_anim 2, 0, 175, 3, 16, 3, 16,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 5, -2, 5, -2,
+ax_anim 2, 0, 170, 12, -5, 12, -5,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 23, 0, 23, 0,
+ax_anim 2, 3, 173, 19, 6, 19, 6,
+ax_anim 2, 0, 174, 14, 7, 14, 7,
+ax_anim 1, 0, 175, 8, 5, 8, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -20, 11, -20,
+ax_anim 3, 0, 171, 23, -20, 23, -20,
+ax_anim 2, 3, 172, 25, -13, 25, -13,
+ax_anim 2, 0, 173, 22, -5, 22, -5,
+ax_anim 1, 0, 174, 13, 0, 13, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -9, -3, -9, -3,
+ax_anim 2, 0, 176, -12, -9, -12, -9,
+ax_anim 2, 0, 177, -9, -18, -9, -18,
+ax_anim 3, 0, 170, 0, -20, 0, -20,
+ax_anim 2, 3, 171, 9, -18, 9, -18,
+ax_anim 2, 0, 172, 12, -9, 12, -9,
+ax_anim 1, 0, 173, 9, -3, 9, -3,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -20, -11, -20,
+ax_anim 3, 0, 177, -23, -20, -23, -20,
+ax_anim 2, 3, 176, -25, -13, -25, -13,
+ax_anim 2, 0, 175, -22, -5, -22, -5,
+ax_anim 1, 0, 174, -13, 0, -13, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -5, -2, -5, -2,
+ax_anim 2, 0, 170, -12, -5, -12, -5,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -23, 0, -23, 0,
+ax_anim 2, 3, 175, -19, 6, -19, 6,
+ax_anim 2, 0, 174, -14, 7, -14, 7,
+ax_anim 1, 0, 173, -8, 5, -8, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 177, -22, 4, -22, 4,
+ax_anim 2, 0, 176, -26, 12, -26, 12,
+ax_anim 3, 0, 175, -22, 19, -22, 19,
+ax_anim 2, 3, 174, -12, 19, -12, 19,
+ax_anim 2, 0, 173, -3, 16, -3, 16,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -24, 0, 0,
+ax_anim 2, 0, 187, 0, -20, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -23, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -20, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 199, 0, -23, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -20, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 208, 0, -23, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAmpharosAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sAmpharosGfx1:
+.incbin "baserom.gba", 0xCD5B98, 0x200
+sAmpharosSprites1:
+ax_sprite sAmpharosGfx1, 0x200
+ax_sprite_terminator
+sAmpharosGfx2:
+.incbin "baserom.gba", 0xCD5DA8, 0x200
+sAmpharosSprites2:
+ax_sprite sAmpharosGfx2, 0x200
+ax_sprite_terminator
+sAmpharosGfx3:
+.incbin "baserom.gba", 0xCD5FB8, 0x200
+sAmpharosSprites3:
+ax_sprite sAmpharosGfx3, 0x200
+ax_sprite_terminator
+sAmpharosGfx4:
+.incbin "baserom.gba", 0xCD61C8, 0x200
+sAmpharosSprites4:
+ax_sprite sAmpharosGfx4, 0x200
+ax_sprite_terminator
+sAmpharosGfx5:
+.incbin "baserom.gba", 0xCD63D8, 0x200
+sAmpharosSprites5:
+ax_sprite sAmpharosGfx5, 0x200
+ax_sprite_terminator
+sAmpharosGfx6:
+.incbin "baserom.gba", 0xCD65E8, 0x200
+sAmpharosSprites6:
+ax_sprite sAmpharosGfx6, 0x200
+ax_sprite_terminator
+sAmpharosGfx7:
+.incbin "baserom.gba", 0xCD67F8, 0x200
+sAmpharosSprites7:
+ax_sprite sAmpharosGfx7, 0x200
+ax_sprite_terminator
+sAmpharosGfx8:
+.incbin "baserom.gba", 0xCD6A08, 0x200
+sAmpharosSprites8:
+ax_sprite sAmpharosGfx8, 0x200
+ax_sprite_terminator
+sAmpharosGfx9:
+.incbin "baserom.gba", 0xCD6C18, 0x200
+sAmpharosSprites9:
+ax_sprite sAmpharosGfx9, 0x200
+ax_sprite_terminator
+sAmpharosGfx10:
+.incbin "baserom.gba", 0xCD6E28, 0x200
+sAmpharosSprites10:
+ax_sprite sAmpharosGfx10, 0x200
+ax_sprite_terminator
+sAmpharosGfx11:
+.incbin "baserom.gba", 0xCD7038, 0x200
+sAmpharosSprites11:
+ax_sprite sAmpharosGfx11, 0x200
+ax_sprite_terminator
+sAmpharosGfx12:
+.incbin "baserom.gba", 0xCD7248, 0x200
+sAmpharosSprites12:
+ax_sprite sAmpharosGfx12, 0x200
+ax_sprite_terminator
+sAmpharosGfx13:
+.incbin "baserom.gba", 0xCD7458, 0x200
+sAmpharosSprites13:
+ax_sprite sAmpharosGfx13, 0x200
+ax_sprite_terminator
+sAmpharosGfx14:
+.incbin "baserom.gba", 0xCD7668, 0x200
+sAmpharosSprites14:
+ax_sprite sAmpharosGfx14, 0x200
+ax_sprite_terminator
+sAmpharosGfx15:
+.incbin "baserom.gba", 0xCD7878, 0x200
+sAmpharosSprites15:
+ax_sprite sAmpharosGfx15, 0x200
+ax_sprite_terminator
+sAmpharosGfx16:
+.incbin "baserom.gba", 0xCD7A88, 0x60
+sAmpharosGfx16_1:
+.incbin "baserom.gba", 0xCD7AE8, 0x60
+sAmpharosGfx16_2:
+.incbin "baserom.gba", 0xCD7B48, 0x60
+sAmpharosSprites16:
+ax_sprite 0, 0x80
+ax_sprite sAmpharosGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx17:
+.incbin "baserom.gba", 0xCD7BE8, 0x60
+sAmpharosGfx17_1:
+.incbin "baserom.gba", 0xCD7C48, 0x60
+sAmpharosGfx17_2:
+.incbin "baserom.gba", 0xCD7CA8, 0x60
+sAmpharosGfx17_3:
+.incbin "baserom.gba", 0xCD7D08, 0x60
+sAmpharosSprites17:
+ax_sprite sAmpharosGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx18:
+.incbin "baserom.gba", 0xCD7DB0, 0x60
+sAmpharosGfx18_1:
+.incbin "baserom.gba", 0xCD7E10, 0x60
+sAmpharosGfx18_2:
+.incbin "baserom.gba", 0xCD7E70, 0x60
+sAmpharosSprites18:
+ax_sprite 0, 0x80
+ax_sprite sAmpharosGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx19:
+.incbin "baserom.gba", 0xCD7F10, 0x40
+sAmpharosGfx19_1:
+.incbin "baserom.gba", 0xCD7F50, 0x60
+sAmpharosGfx19_2:
+.incbin "baserom.gba", 0xCD7FB0, 0x60
+sAmpharosGfx19_3:
+.incbin "baserom.gba", 0xCD8010, 0x60
+sAmpharosSprites19:
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx20:
+.incbin "baserom.gba", 0xCD80C0, 0x40
+sAmpharosGfx20_1:
+.incbin "baserom.gba", 0xCD8100, 0x80
+sAmpharosGfx20_2:
+.incbin "baserom.gba", 0xCD8180, 0x60
+sAmpharosSprites20:
+ax_sprite 0, 0x80
+ax_sprite sAmpharosGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx20_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx20_2, 0x60
+ax_sprite_terminator
+sAmpharosGfx21:
+.incbin "baserom.gba", 0xCD8218, 0x40
+sAmpharosGfx21_1:
+.incbin "baserom.gba", 0xCD8258, 0x40
+sAmpharosGfx21_2:
+.incbin "baserom.gba", 0xCD8298, 0x60
+sAmpharosGfx21_3:
+.incbin "baserom.gba", 0xCD82F8, 0x60
+sAmpharosSprites21:
+ax_sprite sAmpharosGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx22:
+.incbin "baserom.gba", 0xCD83A0, 0x40
+sAmpharosGfx22_1:
+.incbin "baserom.gba", 0xCD83E0, 0x60
+sAmpharosGfx22_2:
+.incbin "baserom.gba", 0xCD8440, 0x60
+sAmpharosSprites22:
+ax_sprite 0, 0x80
+ax_sprite sAmpharosGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx23:
+.incbin "baserom.gba", 0xCD84E0, 0x40
+sAmpharosGfx23_1:
+.incbin "baserom.gba", 0xCD8520, 0x60
+sAmpharosGfx23_2:
+.incbin "baserom.gba", 0xCD8580, 0x60
+sAmpharosGfx23_3:
+.incbin "baserom.gba", 0xCD85E0, 0x60
+sAmpharosSprites23:
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx24:
+.incbin "baserom.gba", 0xCD8690, 0x60
+sAmpharosGfx24_1:
+.incbin "baserom.gba", 0xCD86F0, 0x60
+sAmpharosGfx24_2:
+.incbin "baserom.gba", 0xCD8750, 0x60
+sAmpharosSprites24:
+ax_sprite 0, 0x80
+ax_sprite sAmpharosGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx25:
+.incbin "baserom.gba", 0xCD87F0, 0x40
+sAmpharosGfx25_1:
+.incbin "baserom.gba", 0xCD8830, 0x60
+sAmpharosGfx25_2:
+.incbin "baserom.gba", 0xCD8890, 0x60
+sAmpharosGfx25_3:
+.incbin "baserom.gba", 0xCD88F0, 0x60
+sAmpharosSprites25:
+ax_sprite sAmpharosGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx26:
+.incbin "baserom.gba", 0xCD8998, 0x60
+sAmpharosGfx26_1:
+.incbin "baserom.gba", 0xCD89F8, 0x60
+sAmpharosGfx26_2:
+.incbin "baserom.gba", 0xCD8A58, 0x60
+sAmpharosGfx26_3:
+.incbin "baserom.gba", 0xCD8AB8, 0x60
+sAmpharosSprites26:
+ax_sprite sAmpharosGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx27:
+.incbin "baserom.gba", 0xCD8B60, 0x60
+sAmpharosGfx27_1:
+.incbin "baserom.gba", 0xCD8BC0, 0x60
+sAmpharosGfx27_2:
+.incbin "baserom.gba", 0xCD8C20, 0x60
+sAmpharosSprites27:
+ax_sprite 0, 0x80
+ax_sprite sAmpharosGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx28:
+.incbin "baserom.gba", 0xCD8CC0, 0x60
+sAmpharosGfx28_1:
+.incbin "baserom.gba", 0xCD8D20, 0x60
+sAmpharosGfx28_2:
+.incbin "baserom.gba", 0xCD8D80, 0x60
+sAmpharosSprites28:
+ax_sprite 0, 0x80
+ax_sprite sAmpharosGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx29:
+.incbin "baserom.gba", 0xCD8E20, 0x40
+sAmpharosGfx29_1:
+.incbin "baserom.gba", 0xCD8E60, 0x60
+sAmpharosGfx29_2:
+.incbin "baserom.gba", 0xCD8EC0, 0x60
+sAmpharosGfx29_3:
+.incbin "baserom.gba", 0xCD8F20, 0x60
+sAmpharosSprites29:
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx30:
+.incbin "baserom.gba", 0xCD8FD0, 0x20
+sAmpharosGfx30_1:
+.incbin "baserom.gba", 0xCD8FF0, 0x60
+sAmpharosGfx30_2:
+.incbin "baserom.gba", 0xCD9050, 0x60
+sAmpharosGfx30_3:
+.incbin "baserom.gba", 0xCD90B0, 0x40
+sAmpharosSprites30:
+ax_sprite sAmpharosGfx30, 0x20
+ax_sprite 0, 0x60
+ax_sprite sAmpharosGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx30_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAmpharosGfx31:
+.incbin "baserom.gba", 0xCD9138, 0x20
+sAmpharosGfx31_1:
+.incbin "baserom.gba", 0xCD9158, 0x60
+sAmpharosGfx31_2:
+.incbin "baserom.gba", 0xCD91B8, 0x60
+sAmpharosGfx31_3:
+.incbin "baserom.gba", 0xCD9218, 0x40
+sAmpharosSprites31:
+ax_sprite sAmpharosGfx31, 0x20
+ax_sprite 0, 0x60
+ax_sprite sAmpharosGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAmpharosGfx32:
+.incbin "baserom.gba", 0xCD92A0, 0x40
+sAmpharosGfx32_1:
+.incbin "baserom.gba", 0xCD92E0, 0x40
+sAmpharosGfx32_2:
+.incbin "baserom.gba", 0xCD9320, 0x60
+sAmpharosGfx32_3:
+.incbin "baserom.gba", 0xCD9380, 0x60
+sAmpharosSprites32:
+ax_sprite sAmpharosGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx33:
+.incbin "baserom.gba", 0xCD9428, 0x40
+sAmpharosGfx33_1:
+.incbin "baserom.gba", 0xCD9468, 0x40
+sAmpharosGfx33_2:
+.incbin "baserom.gba", 0xCD94A8, 0xA0
+sAmpharosGfx33_3:
+.incbin "baserom.gba", 0xCD9548, 0x60
+sAmpharosSprites33:
+ax_sprite sAmpharosGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx33_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx33_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx33_3, 0x60
+ax_sprite_terminator
+sAmpharosGfx34:
+.incbin "baserom.gba", 0xCD95E8, 0x40
+sAmpharosGfx34_1:
+.incbin "baserom.gba", 0xCD9628, 0x100
+sAmpharosGfx34_2:
+.incbin "baserom.gba", 0xCD9728, 0x60
+sAmpharosSprites34:
+ax_sprite sAmpharosGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx34_2, 0x60
+ax_sprite_terminator
+sAmpharosGfx35:
+.incbin "baserom.gba", 0xCD97B8, 0x60
+sAmpharosGfx35_1:
+.incbin "baserom.gba", 0xCD9818, 0x60
+sAmpharosGfx35_2:
+.incbin "baserom.gba", 0xCD9878, 0x40
+sAmpharosGfx35_3:
+.incbin "baserom.gba", 0xCD98B8, 0x60
+sAmpharosSprites35:
+ax_sprite sAmpharosGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx35_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx36:
+.incbin "baserom.gba", 0xCD9960, 0x20
+sAmpharosGfx36_1:
+.incbin "baserom.gba", 0xCD9980, 0x60
+sAmpharosGfx36_2:
+.incbin "baserom.gba", 0xCD99E0, 0x60
+sAmpharosGfx36_3:
+.incbin "baserom.gba", 0xCD9A40, 0x60
+sAmpharosSprites36:
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx36_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx36_3, 0x60
+ax_sprite_terminator
+sAmpharosGfx37:
+.incbin "baserom.gba", 0xCD9AE8, 0x20
+sAmpharosGfx37_1:
+.incbin "baserom.gba", 0xCD9B08, 0x60
+sAmpharosGfx37_2:
+.incbin "baserom.gba", 0xCD9B68, 0x60
+sAmpharosGfx37_3:
+.incbin "baserom.gba", 0xCD9BC8, 0x60
+sAmpharosSprites37:
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx37, 0x20
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx37_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAmpharosGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx37_3, 0x60
+ax_sprite_terminator
+sAmpharosGfx38:
+.incbin "baserom.gba", 0xCD9C70, 0x60
+sAmpharosGfx38_1:
+.incbin "baserom.gba", 0xCD9CD0, 0x60
+sAmpharosGfx38_2:
+.incbin "baserom.gba", 0xCD9D30, 0x60
+sAmpharosGfx38_3:
+.incbin "baserom.gba", 0xCD9D90, 0x60
+sAmpharosSprites38:
+ax_sprite sAmpharosGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx39:
+.incbin "baserom.gba", 0xCD9E38, 0x60
+sAmpharosGfx39_1:
+.incbin "baserom.gba", 0xCD9E98, 0x60
+sAmpharosGfx39_2:
+.incbin "baserom.gba", 0xCD9EF8, 0x60
+sAmpharosGfx39_3:
+.incbin "baserom.gba", 0xCD9F58, 0x60
+sAmpharosSprites39:
+ax_sprite sAmpharosGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx40:
+.incbin "baserom.gba", 0xCDA000, 0x60
+sAmpharosGfx40_1:
+.incbin "baserom.gba", 0xCDA060, 0x60
+sAmpharosGfx40_2:
+.incbin "baserom.gba", 0xCDA0C0, 0x60
+sAmpharosGfx40_3:
+.incbin "baserom.gba", 0xCDA120, 0x60
+sAmpharosSprites40:
+ax_sprite sAmpharosGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAmpharosGfx40_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAmpharosGfx41:
+.incbin "baserom.gba", 0xCDA1C8, 0x200
+sAmpharosSprites41:
+ax_sprite sAmpharosGfx41, 0x200
+ax_sprite_terminator
+sAmpharosGfx42:
+.incbin "baserom.gba", 0xCDA3D8, 0x200
+sAmpharosSprites42:
+ax_sprite sAmpharosGfx42, 0x200
+ax_sprite_terminator
+sAmpharosGfx43:
+.incbin "baserom.gba", 0xCDA5E8, 0x200
+sAmpharosSprites43:
+ax_sprite sAmpharosGfx43, 0x200
+ax_sprite_terminator
+sAmpharosGfx44:
+.incbin "baserom.gba", 0xCDA7F8, 0x200
+sAmpharosSprites44:
+ax_sprite sAmpharosGfx44, 0x200
+ax_sprite_terminator
+sAmpharosGfx45:
+.incbin "baserom.gba", 0xCDAA08, 0x200
+sAmpharosSprites45:
+ax_sprite sAmpharosGfx45, 0x200
+ax_sprite_terminator
+sAmpharosGfx46:
+.incbin "baserom.gba", 0xCDAC18, 0x200
+sAmpharosSprites46:
+ax_sprite sAmpharosGfx46, 0x200
+ax_sprite_terminator
+sAmpharosGfx47:
+.incbin "baserom.gba", 0xCDAE28, 0x200
+sAmpharosSprites47:
+ax_sprite sAmpharosGfx47, 0x200
+ax_sprite_terminator
+sAxPosesAmpharos:
+.4byte sAmpharosPose1
+.4byte sAmpharosPose2
+.4byte sAmpharosPose3
+.4byte sAmpharosPose4
+.4byte sAmpharosPose5
+.4byte sAmpharosPose6
+.4byte sAmpharosPose7
+.4byte sAmpharosPose8
+.4byte sAmpharosPose9
+.4byte sAmpharosPose10
+.4byte sAmpharosPose11
+.4byte sAmpharosPose12
+.4byte sAmpharosPose13
+.4byte sAmpharosPose14
+.4byte sAmpharosPose15
+.4byte sAmpharosPose16
+.4byte sAmpharosPose17
+.4byte sAmpharosPose18
+.4byte sAmpharosPose19
+.4byte sAmpharosPose20
+.4byte sAmpharosPose21
+.4byte sAmpharosPose22
+.4byte sAmpharosPose23
+.4byte sAmpharosPose24
+.4byte sAmpharosPose25
+.4byte sAmpharosPose26
+.4byte sAmpharosPose27
+.4byte sAmpharosPose28
+.4byte sAmpharosPose29
+.4byte sAmpharosPose30
+.4byte sAmpharosPose31
+.4byte sAmpharosPose32
+.4byte sAmpharosPose33
+.4byte sAmpharosPose34
+.4byte sAmpharosPose35
+.4byte sAmpharosPose36
+.4byte sAmpharosPose37
+.4byte sAmpharosPose38
+.4byte sAmpharosPose39
+.4byte sAmpharosPose40
+.4byte sAmpharosPose41
+.4byte sAmpharosPose42
+.4byte sAmpharosPose43
+.4byte sAmpharosPose44
+.4byte sAmpharosPose45
+.4byte sAmpharosPose46
+.4byte sAmpharosPose47
+.4byte sAmpharosPose48
+.4byte sAmpharosPose49
+.4byte sAmpharosPose50
+.4byte sAmpharosPose51
+.4byte sAmpharosPose52
+.4byte sAmpharosPose53
+.4byte sAmpharosPose54
+.4byte sAmpharosPose55
+.4byte sAmpharosPose56
+.4byte sAmpharosPose57
+.4byte sAmpharosPose58
+.4byte sAmpharosPose59
+.4byte sAmpharosPose60
+.4byte sAmpharosPose61
+.4byte sAmpharosPose62
+.4byte sAmpharosPose63
+.4byte sAmpharosPose64
+.4byte sAmpharosPose65
+.4byte sAmpharosPose66
+.4byte sAmpharosPose67
+.4byte sAmpharosPose68
+.4byte sAmpharosPose69
+.4byte sAmpharosPose70
+.4byte sAmpharosPose71
+.4byte sAmpharosPose72
+.4byte sAmpharosPose73
+.4byte sAmpharosPose74
+.4byte sAmpharosPose75
+.4byte sAmpharosPose76
+.4byte sAmpharosPose77
+.4byte sAmpharosPose78
+.4byte sAmpharosPose79
+.4byte sAmpharosPose80
+.4byte sAmpharosPose81
+.4byte sAmpharosPose82
+.4byte sAmpharosPose83
+.4byte sAmpharosPose84
+.4byte sAmpharosPose85
+.4byte sAmpharosPose86
+.4byte sAmpharosPose87
+.4byte sAmpharosPose88
+.4byte sAmpharosPose89
+.4byte sAmpharosPose90
+.4byte sAmpharosPose91
+.4byte sAmpharosPose92
+.4byte sAmpharosPose93
+.4byte sAmpharosPose94
+.4byte sAmpharosPose95
+.4byte sAmpharosPose96
+.4byte sAmpharosPose97
+.4byte sAmpharosPose98
+.4byte sAmpharosPose99
+.4byte sAmpharosPose100
+.4byte sAmpharosPose101
+.4byte sAmpharosPose102
+.4byte sAmpharosPose103
+.4byte sAmpharosPose104
+.4byte sAmpharosPose105
+.4byte sAmpharosPose106
+.4byte sAmpharosPose107
+.4byte sAmpharosPose108
+.4byte sAmpharosPose109
+.4byte sAmpharosPose110
+.4byte sAmpharosPose111
+.4byte sAmpharosPose112
+.4byte sAmpharosPose113
+.4byte sAmpharosPose114
+.4byte sAmpharosPose115
+.4byte sAmpharosPose116
+.4byte sAmpharosPose117
+.4byte sAmpharosPose118
+.4byte sAmpharosPose119
+.4byte sAmpharosPose120
+.4byte sAmpharosPose121
+.4byte sAmpharosPose122
+.4byte sAmpharosPose123
+.4byte sAmpharosPose124
+.4byte sAmpharosPose125
+.4byte sAmpharosPose126
+.4byte sAmpharosPose127
+.4byte sAmpharosPose128
+.4byte sAmpharosPose129
+.4byte sAmpharosPose130
+.4byte sAmpharosPose131
+.4byte sAmpharosPose132
+.4byte sAmpharosPose133
+.4byte sAmpharosPose134
+.4byte sAmpharosPose135
+.4byte sAmpharosPose136
+.4byte sAmpharosPose137
+.4byte sAmpharosPose138
+.4byte sAmpharosPose139
+.4byte sAmpharosPose140
+.4byte sAmpharosPose141
+.4byte sAmpharosPose142
+.4byte sAmpharosPose143
+.4byte sAmpharosPose144
+.4byte sAmpharosPose145
+.4byte sAmpharosPose146
+.4byte sAmpharosPose147
+.4byte sAmpharosPose148
+.4byte sAmpharosPose149
+.4byte sAmpharosPose150
+.4byte sAmpharosPose151
+.4byte sAmpharosPose152
+.4byte sAmpharosPose153
+.4byte sAmpharosPose154
+.4byte sAmpharosPose155
+.4byte sAmpharosPose156
+.4byte sAmpharosPose157
+.4byte sAmpharosPose158
+.4byte sAmpharosPose159
+.4byte sAmpharosPose160
+.4byte sAmpharosPose161
+.4byte sAmpharosPose162
+.4byte sAmpharosPose163
+.4byte sAmpharosPose164
+.4byte sAmpharosPose165
+.4byte sAmpharosPose166
+.4byte sAmpharosPose167
+.4byte sAmpharosPose168
+.4byte sAmpharosPose169
+.4byte sAmpharosPose170
+.4byte sAmpharosPose171
+.4byte sAmpharosPose172
+.4byte sAmpharosPose173
+.4byte sAmpharosPose174
+.4byte sAmpharosPose175
+.4byte sAmpharosPose176
+.4byte sAmpharosPose177
+.4byte sAmpharosPose178
+.4byte sAmpharosPose179
+.4byte sAmpharosPose180
+.4byte sAmpharosPose181
+.4byte sAmpharosPose182
+.4byte sAmpharosPose183
+.4byte sAmpharosPose184
+.4byte sAmpharosPose185
+.4byte sAmpharosPose186
+.4byte sAmpharosPose187
+.4byte sAmpharosPose188
+.4byte sAmpharosPose189
+.4byte sAmpharosPose190
+.4byte sAmpharosPose191
+.4byte sAmpharosPose192
+.4byte sAmpharosPose193
+.4byte sAmpharosPose194
+.4byte sAmpharosPose195
+.4byte sAmpharosPose196
+.4byte sAmpharosPose197
+.4byte sAmpharosPose198
+.4byte sAmpharosPose199
+.4byte sAmpharosPose200
+.4byte sAmpharosPose201
+.4byte sAmpharosPose202
+.4byte sAmpharosPose203
+.4byte sAmpharosPose204
+.4byte sAmpharosPose205
+.4byte sAmpharosPose206
+.4byte sAmpharosPose207
+.4byte sAmpharosPose208
+.4byte sAmpharosPose209
+.4byte sAmpharosPose210
+.4byte sAmpharosPose211
+.4byte sAmpharosPose212
+.4byte sAmpharosPose213
+.4byte sAmpharosPose214
+.4byte sAmpharosPose215
+.4byte sAmpharosPose216
+.4byte sAmpharosPose217
+.4byte sAmpharosPose218
+.4byte sAmpharosPose219
+.4byte sAmpharosPose220
+.4byte sAmpharosPose221
+.4byte sAmpharosPose222
+.4byte sAmpharosPose223
+.4byte sAmpharosPose224
+.4byte sAmpharosPose225
+.4byte sAmpharosPose226
+sAxPositionsAmpharos:
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -1,  -16, 	  -7,  -11, 	   6,   -8, 	  -1,   -9
+.2byte   -1,  -16, 	  -8,   -8, 	   5,  -11, 	  -1,   -9
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    1,  -16, 	   4,  -11, 	  -4,   -9, 	  -1,   -9
+.2byte    2,  -16, 	   5,   -9, 	  -7,  -11, 	   0,   -9
+.2byte    5,  -20, 	  -1,  -10, 	  -2,   -9, 	  -1,  -11
+.2byte    5,  -17, 	   2,   -8, 	   0,   -6, 	  -1,   -8
+.2byte    5,  -18, 	   3,  -12, 	  -3,   -9, 	  -1,   -8
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    3,  -17, 	  -6,  -11, 	   5,   -8, 	  -1,   -9
+.2byte    2,  -18, 	  -5,  -11, 	   2,   -9, 	  -1,   -9
+.2byte   -1,  -22, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -2,  -20, 	   5,  -12, 	  -8,  -11, 	  -1,  -10
+.2byte    0,  -20, 	   5,  -11, 	  -7,  -12, 	  -1,  -10
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -5,  -17, 	   4,  -11, 	  -7,   -8, 	  -1,   -9
+.2byte   -4,  -18, 	   3,  -11, 	  -4,   -9, 	  -1,   -9
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -7,  -17, 	  -4,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte   -7,  -18, 	  -5,  -12, 	   1,   -9, 	  -1,   -8
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -3,  -16, 	  -6,  -11, 	   2,   -9, 	  -1,   -9
+.2byte   -4,  -16, 	  -7,   -9, 	   5,  -11, 	  -2,   -9
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -1,  -10, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -1,  -24, 	  -6,  -19, 	   4,  -19, 	  -1,  -11
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    5,   -9, 	   5,   -7, 	  -3,   -6, 	   1,   -8
+.2byte    0,  -24, 	   3,  -19, 	  -5,  -17, 	   0,  -10
+.2byte    5,  -19, 	  -1,   -9, 	  -2,   -8, 	  -1,  -10
+.2byte    6,   -9, 	   1,   -6, 	   0,   -5, 	   0,   -7
+.2byte    0,  -24, 	  -2,  -18, 	  -3,  -15, 	   1,  -10
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    5,  -11, 	  -5,   -8, 	   4,   -6, 	  -1,   -9
+.2byte    0,  -24, 	  -7,  -18, 	   0,  -16, 	  -1,  -10
+.2byte   -1,  -21, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,  -26, 	   5,  -18, 	  -7,  -18, 	  -1,  -12
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -11, 	   3,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte   -2,  -24, 	   5,  -18, 	  -2,  -16, 	  -1,  -10
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -8,   -9, 	  -3,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte   -2,  -24, 	   0,  -18, 	   1,  -15, 	  -3,  -10
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -7,   -9, 	  -7,   -7, 	   1,   -6, 	  -3,   -8
+.2byte   -2,  -24, 	  -5,  -19, 	   3,  -17, 	  -2,  -10
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -1,  -10, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -1,  -24, 	  -6,  -19, 	   4,  -19, 	  -1,  -11
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    5,   -9, 	   5,   -7, 	  -3,   -6, 	   1,   -8
+.2byte    0,  -24, 	   3,  -19, 	  -5,  -17, 	   0,  -10
+.2byte    5,  -19, 	  -1,   -9, 	  -2,   -8, 	  -1,  -10
+.2byte    6,   -9, 	   1,   -6, 	   0,   -5, 	   0,   -7
+.2byte    0,  -24, 	  -2,  -18, 	  -3,  -15, 	   1,  -10
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    5,  -11, 	  -5,   -8, 	   4,   -6, 	  -1,   -9
+.2byte    0,  -24, 	  -7,  -18, 	   0,  -16, 	  -1,  -10
+.2byte   -1,  -21, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,  -26, 	   5,  -18, 	  -7,  -18, 	  -1,  -12
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -11, 	   3,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte   -2,  -24, 	   5,  -18, 	  -2,  -16, 	  -1,  -10
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -8,   -9, 	  -3,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte   -2,  -24, 	   0,  -18, 	   1,  -15, 	  -3,  -10
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -7,   -9, 	  -7,   -7, 	   1,   -6, 	  -3,   -8
+.2byte   -2,  -24, 	  -5,  -19, 	   3,  -17, 	  -2,  -10
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -1,  -19, 	  -7,  -16, 	   5,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	  -7,   -8, 	   5,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    0,  -19, 	   2,  -18, 	  -7,  -16, 	  -1,   -9
+.2byte    5,  -11, 	   6,  -11, 	  -4,   -8, 	   0,  -10
+.2byte    5,  -12, 	   5,   -8, 	   1,   -8, 	   0,  -10
+.2byte    5,  -19, 	  -1,   -9, 	  -2,   -8, 	  -1,  -10
+.2byte    1,  -22, 	  -5,  -18, 	  -5,  -14, 	   0,  -10
+.2byte    5,  -14, 	   1,   -9, 	   0,   -8, 	  -2,   -9
+.2byte    5,  -14, 	   4,  -12, 	   4,  -10, 	  -1,   -9
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    2,  -25, 	  -6,  -17, 	   0,  -17, 	   0,  -10
+.2byte    4,  -13, 	  -4,   -8, 	   3,   -7, 	  -3,   -8
+.2byte    4,  -13, 	   1,  -11, 	   4,  -10, 	  -2,   -9
+.2byte   -1,  -21, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -23, 	   5,  -18, 	  -7,  -18, 	  -1,  -10
+.2byte   -1,  -15, 	   5,  -10, 	  -7,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	   2,  -15, 	  -4,  -15, 	  -1,  -10
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -4,  -25, 	   4,  -17, 	  -2,  -17, 	  -2,  -10
+.2byte   -6,  -13, 	   2,   -8, 	  -5,   -7, 	   1,   -8
+.2byte   -6,  -13, 	  -3,  -11, 	  -6,  -10, 	   0,   -9
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -3,  -22, 	   3,  -18, 	   3,  -14, 	  -2,  -10
+.2byte   -7,  -14, 	  -3,   -9, 	  -2,   -8, 	   0,   -9
+.2byte   -7,  -14, 	  -6,  -12, 	  -6,  -10, 	  -1,   -9
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -2,  -19, 	  -4,  -18, 	   5,  -16, 	  -1,   -9
+.2byte   -7,  -11, 	  -8,  -11, 	   2,   -8, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,   -8, 	  -3,   -8, 	  -2,  -10
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -1,  -19, 	  -7,  -16, 	   5,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	  -7,   -8, 	   5,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    0,  -19, 	   2,  -18, 	  -7,  -16, 	  -1,   -9
+.2byte    5,  -11, 	   6,  -11, 	  -4,   -8, 	   0,  -10
+.2byte    5,  -12, 	   5,   -8, 	   1,   -8, 	   0,  -10
+.2byte    5,  -19, 	  -1,   -9, 	  -2,   -8, 	  -1,  -10
+.2byte    1,  -22, 	  -5,  -18, 	  -5,  -14, 	   0,  -10
+.2byte    5,  -14, 	   1,   -9, 	   0,   -8, 	  -2,   -9
+.2byte    5,  -14, 	   4,  -12, 	   4,  -10, 	  -1,   -9
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    2,  -25, 	  -6,  -17, 	   0,  -17, 	   0,  -10
+.2byte    4,  -13, 	  -4,   -8, 	   3,   -7, 	  -3,   -8
+.2byte    4,  -13, 	   1,  -11, 	   4,  -10, 	  -2,   -9
+.2byte   -1,  -21, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -23, 	   5,  -18, 	  -7,  -18, 	  -1,  -10
+.2byte   -1,  -15, 	   5,  -10, 	  -7,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	   2,  -15, 	  -4,  -15, 	  -1,  -10
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -4,  -25, 	   4,  -17, 	  -2,  -17, 	  -2,  -10
+.2byte   -6,  -13, 	   2,   -8, 	  -5,   -7, 	   1,   -8
+.2byte   -6,  -13, 	  -3,  -11, 	  -6,  -10, 	   0,   -9
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -3,  -22, 	   3,  -18, 	   3,  -14, 	  -2,  -10
+.2byte   -7,  -14, 	  -3,   -9, 	  -2,   -8, 	   0,   -9
+.2byte   -7,  -14, 	  -6,  -12, 	  -6,  -10, 	  -1,   -9
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -2,  -19, 	  -4,  -18, 	   5,  -16, 	  -1,   -9
+.2byte   -7,  -11, 	  -8,  -11, 	   2,   -8, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,   -8, 	  -3,   -8, 	  -2,  -10
+.2byte   -3,  -15, 	  -5,   -8, 	   2,   -6, 	  -1,   -7
+.2byte   -4,  -14, 	  -5,   -7, 	   2,   -5, 	  -1,   -7
+.2byte    0,  -19, 	  -5,  -17, 	   5,  -17, 	   0,  -11
+.2byte   -4,  -20, 	   0,  -19, 	  -9,  -17, 	  -3,  -12
+.2byte   -4,  -20, 	  -2,  -20, 	  -5,  -17, 	  -1,  -11
+.2byte    0,  -22, 	  -4,  -20, 	   3,  -18, 	  -1,  -12
+.2byte   -1,  -24, 	   5,  -18, 	  -7,  -18, 	  -1,  -10
+.2byte   -1,  -22, 	   3,  -20, 	  -4,  -18, 	   0,  -12
+.2byte    3,  -20, 	   1,  -20, 	   4,  -17, 	   0,  -11
+.2byte    3,  -20, 	  -1,  -19, 	   8,  -17, 	   2,  -12
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -1,  -24, 	  -6,  -19, 	   4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    0,  -23, 	   3,  -18, 	  -5,  -16, 	   0,   -9
+.2byte    5,   -9, 	   5,   -7, 	  -3,   -6, 	   1,   -8
+.2byte    5,  -19, 	  -1,   -9, 	  -2,   -8, 	  -1,  -10
+.2byte    2,  -24, 	   0,  -18, 	  -1,  -15, 	   3,  -10
+.2byte    5,   -9, 	   0,   -6, 	  -1,   -5, 	  -1,   -7
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    2,  -24, 	  -5,  -18, 	   2,  -16, 	   1,  -10
+.2byte    5,  -11, 	  -5,   -8, 	   4,   -6, 	  -1,   -9
+.2byte   -1,  -21, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -27, 	   5,  -19, 	  -7,  -19, 	  -1,  -13
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -3,  -25, 	   4,  -19, 	  -3,  -17, 	  -2,  -11
+.2byte   -7,  -11, 	   3,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -3,  -24, 	  -1,  -18, 	   0,  -15, 	  -4,  -10
+.2byte   -8,   -9, 	  -3,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -2,  -23, 	  -5,  -18, 	   3,  -16, 	  -2,   -9
+.2byte   -7,   -9, 	  -7,   -7, 	   1,   -6, 	  -3,   -8
+.2byte   -1,  -23, 	  -6,  -18, 	   4,  -18, 	  -1,  -10
+.2byte   -2,  -23, 	  -5,  -18, 	   3,  -16, 	  -2,   -9
+.2byte   -2,  -23, 	   0,  -17, 	   1,  -14, 	  -3,   -9
+.2byte   -2,  -23, 	   5,  -17, 	  -2,  -15, 	  -1,   -9
+.2byte   -1,  -25, 	   5,  -17, 	  -7,  -17, 	  -1,  -11
+.2byte    1,  -23, 	  -6,  -17, 	   1,  -15, 	   0,   -9
+.2byte    1,  -23, 	  -1,  -17, 	  -2,  -14, 	   2,   -9
+.2byte    0,  -23, 	   3,  -18, 	  -5,  -16, 	   0,   -9
+.2byte   -1,  -23, 	  -6,  -18, 	   4,  -18, 	  -1,  -10
+.2byte    0,  -24, 	   3,  -19, 	  -5,  -17, 	   0,  -10
+.2byte    1,  -24, 	  -1,  -18, 	  -2,  -15, 	   2,  -10
+.2byte    1,  -24, 	  -6,  -18, 	   1,  -16, 	   0,  -10
+.2byte   -1,  -26, 	   5,  -18, 	  -7,  -18, 	  -1,  -12
+.2byte   -2,  -24, 	   5,  -18, 	  -2,  -16, 	  -1,  -10
+.2byte   -2,  -24, 	   0,  -18, 	   1,  -15, 	  -3,  -10
+.2byte   -2,  -24, 	  -5,  -19, 	   3,  -17, 	  -2,  -10
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -1,  -10, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -1,  -24, 	  -6,  -19, 	   4,  -19, 	  -1,  -11
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    5,   -9, 	   5,   -7, 	  -3,   -6, 	   1,   -8
+.2byte    0,  -24, 	   3,  -19, 	  -5,  -17, 	   0,  -10
+.2byte    5,  -19, 	  -1,   -9, 	  -2,   -8, 	  -1,  -10
+.2byte    6,   -9, 	   1,   -6, 	   0,   -5, 	   0,   -7
+.2byte    0,  -24, 	  -2,  -18, 	  -3,  -15, 	   1,  -10
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    5,  -11, 	  -5,   -8, 	   4,   -6, 	  -1,   -9
+.2byte    0,  -24, 	  -7,  -18, 	   0,  -16, 	  -1,  -10
+.2byte   -1,  -21, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,  -26, 	   5,  -18, 	  -7,  -18, 	  -1,  -12
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -11, 	   3,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte   -2,  -24, 	   5,  -18, 	  -2,  -16, 	  -1,  -10
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -8,   -9, 	  -3,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte   -2,  -24, 	   0,  -18, 	   1,  -15, 	  -3,  -10
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -7,   -9, 	  -7,   -7, 	   1,   -6, 	  -3,   -8
+.2byte   -2,  -24, 	  -5,  -19, 	   3,  -17, 	  -2,  -10
+.2byte   -1,  -11, 	  -7,   -8, 	   5,   -8, 	  -1,   -8
+.2byte   -5,  -11, 	  -6,  -11, 	   4,   -8, 	   0,  -10
+.2byte   -6,  -14, 	  -2,   -9, 	  -1,   -8, 	   1,   -9
+.2byte   -6,  -14, 	   2,   -9, 	  -5,   -8, 	   1,   -9
+.2byte   -1,  -15, 	   5,  -10, 	  -7,  -10, 	  -1,  -10
+.2byte    4,  -14, 	  -4,   -9, 	   3,   -8, 	  -3,   -9
+.2byte    5,  -14, 	   1,   -9, 	   0,   -8, 	  -2,   -9
+.2byte    4,  -11, 	   5,  -11, 	  -5,   -8, 	  -1,  -10
+.2byte   -1,  -18, 	  -8,  -11, 	   6,  -11, 	  -1,  -10
+.2byte   -4,  -18, 	  -7,  -12, 	   4,  -11, 	  -1,  -11
+.2byte   -7,  -19, 	  -1,   -9, 	   0,   -8, 	  -1,  -10
+.2byte   -5,  -20, 	   4,  -12, 	  -6,   -9, 	  -1,  -10
+.2byte   -1,  -21, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte    3,  -20, 	  -6,  -12, 	   4,   -9, 	  -1,  -10
+.2byte    5,  -19, 	  -1,   -9, 	  -2,   -8, 	  -1,  -10
+.2byte    2,  -18, 	   5,  -12, 	  -6,  -11, 	  -1,  -11
+sAmpharosAnimTable1:
+.4byte sAmpharosAnims_1_1
+.4byte sAmpharosAnims_1_2
+.4byte sAmpharosAnims_1_3
+.4byte sAmpharosAnims_1_4
+.4byte sAmpharosAnims_1_5
+.4byte sAmpharosAnims_1_6
+.4byte sAmpharosAnims_1_7
+.4byte sAmpharosAnims_1_8
+sAmpharosAnimTable2:
+.4byte sAmpharosAnims_2_1
+.4byte sAmpharosAnims_2_2
+.4byte sAmpharosAnims_2_3
+.4byte sAmpharosAnims_2_4
+.4byte sAmpharosAnims_2_5
+.4byte sAmpharosAnims_2_6
+.4byte sAmpharosAnims_2_7
+.4byte sAmpharosAnims_2_8
+sAmpharosAnimTable3:
+.4byte sAmpharosAnims_3_1
+.4byte sAmpharosAnims_3_2
+.4byte sAmpharosAnims_3_3
+.4byte sAmpharosAnims_3_4
+.4byte sAmpharosAnims_3_5
+.4byte sAmpharosAnims_3_6
+.4byte sAmpharosAnims_3_7
+.4byte sAmpharosAnims_3_8
+sAmpharosAnimTable4:
+.4byte sAmpharosAnims_4_1
+.4byte sAmpharosAnims_4_2
+.4byte sAmpharosAnims_4_3
+.4byte sAmpharosAnims_4_4
+.4byte sAmpharosAnims_4_5
+.4byte sAmpharosAnims_4_6
+.4byte sAmpharosAnims_4_7
+.4byte sAmpharosAnims_4_8
+sAmpharosAnimTable5:
+.4byte sAmpharosAnims_5_1
+.4byte sAmpharosAnims_5_2
+.4byte sAmpharosAnims_5_3
+.4byte sAmpharosAnims_5_4
+.4byte sAmpharosAnims_5_5
+.4byte sAmpharosAnims_5_6
+.4byte sAmpharosAnims_5_7
+.4byte sAmpharosAnims_5_8
+sAmpharosAnimTable6:
+.4byte sAmpharosAnims_6_1
+.4byte sAmpharosAnims_6_1
+.4byte sAmpharosAnims_6_1
+.4byte sAmpharosAnims_6_1
+.4byte sAmpharosAnims_6_1
+.4byte sAmpharosAnims_6_1
+.4byte sAmpharosAnims_6_1
+.4byte sAmpharosAnims_6_1
+sAmpharosAnimTable7:
+.4byte sAmpharosAnims_7_1
+.4byte sAmpharosAnims_7_2
+.4byte sAmpharosAnims_7_3
+.4byte sAmpharosAnims_7_4
+.4byte sAmpharosAnims_7_5
+.4byte sAmpharosAnims_7_6
+.4byte sAmpharosAnims_7_7
+.4byte sAmpharosAnims_7_8
+sAmpharosAnimTable8:
+.4byte sAmpharosAnims_8_1
+.4byte sAmpharosAnims_8_2
+.4byte sAmpharosAnims_8_3
+.4byte sAmpharosAnims_8_4
+.4byte sAmpharosAnims_8_5
+.4byte sAmpharosAnims_8_6
+.4byte sAmpharosAnims_8_7
+.4byte sAmpharosAnims_8_8
+sAmpharosAnimTable9:
+.4byte sAmpharosAnims_9_1
+.4byte sAmpharosAnims_9_2
+.4byte sAmpharosAnims_9_3
+.4byte sAmpharosAnims_9_4
+.4byte sAmpharosAnims_9_5
+.4byte sAmpharosAnims_9_6
+.4byte sAmpharosAnims_9_7
+.4byte sAmpharosAnims_9_8
+sAmpharosAnimTable10:
+.4byte sAmpharosAnims_10_1
+.4byte sAmpharosAnims_10_2
+.4byte sAmpharosAnims_10_3
+.4byte sAmpharosAnims_10_4
+.4byte sAmpharosAnims_10_5
+.4byte sAmpharosAnims_10_6
+.4byte sAmpharosAnims_10_7
+.4byte sAmpharosAnims_10_8
+sAmpharosAnimTable11:
+.4byte sAmpharosAnims_11_1
+.4byte sAmpharosAnims_11_2
+.4byte sAmpharosAnims_11_3
+.4byte sAmpharosAnims_11_4
+.4byte sAmpharosAnims_11_5
+.4byte sAmpharosAnims_11_6
+.4byte sAmpharosAnims_11_7
+.4byte sAmpharosAnims_11_8
+sAmpharosAnimTable12:
+.4byte sAmpharosAnims_12_1
+.4byte sAmpharosAnims_12_2
+.4byte sAmpharosAnims_12_3
+.4byte sAmpharosAnims_12_4
+.4byte sAmpharosAnims_12_5
+.4byte sAmpharosAnims_12_6
+.4byte sAmpharosAnims_12_7
+.4byte sAmpharosAnims_12_8
+sAmpharosAnimTable13:
+.4byte sAmpharosAnims_13_1
+.4byte sAmpharosAnims_13_2
+.4byte sAmpharosAnims_13_3
+.4byte sAmpharosAnims_13_4
+.4byte sAmpharosAnims_13_5
+.4byte sAmpharosAnims_13_6
+.4byte sAmpharosAnims_13_7
+.4byte sAmpharosAnims_13_8
+sAxAnimationsAmpharos:
+.4byte sAmpharosAnimTable1
+.4byte sAmpharosAnimTable2
+.4byte sAmpharosAnimTable3
+.4byte sAmpharosAnimTable4
+.4byte sAmpharosAnimTable5
+.4byte sAmpharosAnimTable6
+.4byte sAmpharosAnimTable7
+.4byte sAmpharosAnimTable8
+.4byte sAmpharosAnimTable9
+.4byte sAmpharosAnimTable10
+.4byte sAmpharosAnimTable11
+.4byte sAmpharosAnimTable12
+.4byte sAmpharosAnimTable13
+sAxSpritesAmpharos:
+.4byte sAmpharosSprites1
+.4byte sAmpharosSprites2
+.4byte sAmpharosSprites3
+.4byte sAmpharosSprites4
+.4byte sAmpharosSprites5
+.4byte sAmpharosSprites6
+.4byte sAmpharosSprites7
+.4byte sAmpharosSprites8
+.4byte sAmpharosSprites9
+.4byte sAmpharosSprites10
+.4byte sAmpharosSprites11
+.4byte sAmpharosSprites12
+.4byte sAmpharosSprites13
+.4byte sAmpharosSprites14
+.4byte sAmpharosSprites15
+.4byte sAmpharosSprites16
+.4byte sAmpharosSprites17
+.4byte sAmpharosSprites18
+.4byte sAmpharosSprites19
+.4byte sAmpharosSprites20
+.4byte sAmpharosSprites21
+.4byte sAmpharosSprites22
+.4byte sAmpharosSprites23
+.4byte sAmpharosSprites24
+.4byte sAmpharosSprites25
+.4byte sAmpharosSprites26
+.4byte sAmpharosSprites27
+.4byte sAmpharosSprites28
+.4byte sAmpharosSprites29
+.4byte sAmpharosSprites30
+.4byte sAmpharosSprites31
+.4byte sAmpharosSprites32
+.4byte sAmpharosSprites33
+.4byte sAmpharosSprites34
+.4byte sAmpharosSprites35
+.4byte sAmpharosSprites36
+.4byte sAmpharosSprites37
+.4byte sAmpharosSprites38
+.4byte sAmpharosSprites39
+.4byte sAmpharosSprites40
+.4byte sAmpharosSprites41
+.4byte sAmpharosSprites42
+.4byte sAmpharosSprites43
+.4byte sAmpharosSprites44
+.4byte sAmpharosSprites45
+.4byte sAmpharosSprites46
+.4byte sAmpharosSprites47
+sAxMainAmpharos:
+ax_main sAxPosesAmpharos, sAxAnimationsAmpharos, 13, sAxSpritesAmpharos, sAxPositionsAmpharos

--- a/data/ax/anorith.inc
+++ b/data/ax/anorith.inc
@@ -1,0 +1,2757 @@
+.global gAxAnorith
+gAxAnorith:
+ax_siro sAxMainAnorith
+sAnorithPose1:
+ax_pose 0, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose2:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose3:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose4:
+ax_pose 3, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose5:
+ax_pose 4, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose6:
+ax_pose 5, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose7:
+ax_pose 6, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose8:
+ax_pose 7, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose9:
+ax_pose 8, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose10:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose11:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose12:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose13:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose14:
+ax_pose 13, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose15:
+ax_pose 14, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose16:
+ax_pose 9, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose17:
+ax_pose 10, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose18:
+ax_pose 11, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose19:
+ax_pose 6, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose20:
+ax_pose 7, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose21:
+ax_pose 8, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose22:
+ax_pose 3, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose23:
+ax_pose 4, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose24:
+ax_pose 5, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose25:
+ax_pose 0, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose26:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose27:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose28:
+ax_pose 15, 0x01ee, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose29:
+ax_pose 3, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose30:
+ax_pose 4, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose31:
+ax_pose 5, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose32:
+ax_pose 16, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose33:
+ax_pose 6, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose34:
+ax_pose 7, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose35:
+ax_pose 8, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose36:
+ax_pose 17, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose37:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose38:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose39:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose40:
+ax_pose 18, 0x01e5, 0x90f3, 0x5c00
+ax_pose_terminator
+sAnorithPose41:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose42:
+ax_pose 13, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose43:
+ax_pose 14, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose44:
+ax_pose 19, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose45:
+ax_pose 9, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose46:
+ax_pose 10, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose47:
+ax_pose 11, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose48:
+ax_pose 18, 0x01e5, 0x80ec, 0x5c00
+ax_pose_terminator
+sAnorithPose49:
+ax_pose 6, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose50:
+ax_pose 7, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose51:
+ax_pose 8, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose52:
+ax_pose 17, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose53:
+ax_pose 3, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose54:
+ax_pose 4, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose55:
+ax_pose 5, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose56:
+ax_pose 16, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose57:
+ax_pose 0, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose58:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose59:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose60:
+ax_pose 15, 0x01ee, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose61:
+ax_pose 20, 0x01ec, 0x80ef, 0x5c00
+ax_pose 21, 0x01ec, 0x80ef, 0x5c10
+ax_pose_terminator
+sAnorithPose62:
+ax_pose 21, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose63:
+ax_pose 3, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose64:
+ax_pose 4, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose65:
+ax_pose 5, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose66:
+ax_pose 16, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose67:
+ax_pose 22, 0x01ec, 0x90f6, 0x5c00
+ax_pose 23, 0x01ec, 0x90f0, 0x5c10
+ax_pose_terminator
+sAnorithPose68:
+ax_pose 23, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose69:
+ax_pose 6, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose70:
+ax_pose 7, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose71:
+ax_pose 8, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose72:
+ax_pose 17, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose73:
+ax_pose 24, 0x01e4, 0x90fc, 0x5c00
+ax_pose 25, 0x01ec, 0x90f4, 0x5c10
+ax_pose_terminator
+sAnorithPose74:
+ax_pose 25, 0x01ec, 0x90f4, 0x5c00
+ax_pose_terminator
+sAnorithPose75:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose76:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose77:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose78:
+ax_pose 18, 0x01e5, 0x90f3, 0x5c00
+ax_pose_terminator
+sAnorithPose79:
+ax_pose 26, 0x01e5, 0x90f6, 0x5c00
+ax_pose 27, 0x01ec, 0x90f3, 0x5c10
+ax_pose_terminator
+sAnorithPose80:
+ax_pose 27, 0x01ec, 0x90f3, 0x5c00
+ax_pose_terminator
+sAnorithPose81:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose82:
+ax_pose 13, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose83:
+ax_pose 14, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose84:
+ax_pose 19, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose85:
+ax_pose 28, 0x01e5, 0x80f0, 0x5c00
+ax_pose 29, 0x01eb, 0x80ef, 0x5c10
+ax_pose_terminator
+sAnorithPose86:
+ax_pose 29, 0x01eb, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose87:
+ax_pose 9, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose88:
+ax_pose 10, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose89:
+ax_pose 11, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose90:
+ax_pose 18, 0x01e5, 0x80ec, 0x5c00
+ax_pose_terminator
+sAnorithPose91:
+ax_pose 26, 0x01e5, 0x80e9, 0x5c00
+ax_pose 27, 0x01ec, 0x80ec, 0x5c10
+ax_pose_terminator
+sAnorithPose92:
+ax_pose 27, 0x01ec, 0x80ec, 0x5c00
+ax_pose_terminator
+sAnorithPose93:
+ax_pose 6, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose94:
+ax_pose 7, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose95:
+ax_pose 8, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose96:
+ax_pose 17, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose97:
+ax_pose 24, 0x01e4, 0x80e3, 0x5c00
+ax_pose 25, 0x01ec, 0x80eb, 0x5c10
+ax_pose_terminator
+sAnorithPose98:
+ax_pose 25, 0x01ec, 0x80eb, 0x5c00
+ax_pose_terminator
+sAnorithPose99:
+ax_pose 3, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose100:
+ax_pose 4, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose101:
+ax_pose 5, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose102:
+ax_pose 16, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose103:
+ax_pose 22, 0x01ec, 0x80e9, 0x5c00
+ax_pose 23, 0x01ec, 0x80ef, 0x5c10
+ax_pose_terminator
+sAnorithPose104:
+ax_pose 23, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose105:
+ax_pose 0, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose106:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose107:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose108:
+ax_pose 15, 0x01ee, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose109:
+ax_pose 3, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose110:
+ax_pose 4, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose111:
+ax_pose 5, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose112:
+ax_pose 16, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose113:
+ax_pose 6, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose114:
+ax_pose 7, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose115:
+ax_pose 8, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose116:
+ax_pose 17, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose117:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose118:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose119:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose120:
+ax_pose 18, 0x01e5, 0x90f3, 0x5c00
+ax_pose_terminator
+sAnorithPose121:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose122:
+ax_pose 13, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose123:
+ax_pose 14, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose124:
+ax_pose 19, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose125:
+ax_pose 9, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose126:
+ax_pose 10, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose127:
+ax_pose 11, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose128:
+ax_pose 18, 0x01e5, 0x80ec, 0x5c00
+ax_pose_terminator
+sAnorithPose129:
+ax_pose 6, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose130:
+ax_pose 7, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose131:
+ax_pose 8, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose132:
+ax_pose 17, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose133:
+ax_pose 3, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose134:
+ax_pose 4, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose135:
+ax_pose 5, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose136:
+ax_pose 16, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose137:
+ax_pose 0, 0x01f0, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose138:
+ax_pose 3, 0x01f1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose139:
+ax_pose 6, 0x01f1, 0x80f1, 0x5c00
+ax_pose_terminator
+sAnorithPose140:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose141:
+ax_pose 12, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose142:
+ax_pose 9, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sAnorithPose143:
+ax_pose 6, 0x01f1, 0x90ee, 0x5c00
+ax_pose_terminator
+sAnorithPose144:
+ax_pose 3, 0x01f1, 0x90ef, 0x5c00
+ax_pose_terminator
+sAnorithPose145:
+ax_pose 30, 0x01f0, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose146:
+ax_pose 31, 0x01f0, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose147:
+ax_pose 32, 0x01de, 0x80f4, 0x5c00
+ax_pose_terminator
+sAnorithPose148:
+ax_pose 33, 0x01df, 0x90ec, 0x5c00
+ax_pose_terminator
+sAnorithPose149:
+ax_pose 34, 0x01df, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose150:
+ax_pose 35, 0x01df, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose151:
+ax_pose 36, 0x01dd, 0x80f4, 0x5c00
+ax_pose_terminator
+sAnorithPose152:
+ax_pose 35, 0x01df, 0x80ee, 0x5c00
+ax_pose_terminator
+sAnorithPose153:
+ax_pose 34, 0x01df, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose154:
+ax_pose 33, 0x01df, 0x80f4, 0x5c00
+ax_pose_terminator
+sAnorithPose155:
+ax_pose 0, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose156:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose157:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose158:
+ax_pose 3, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose159:
+ax_pose 4, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose160:
+ax_pose 5, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose161:
+ax_pose 6, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose162:
+ax_pose 7, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose163:
+ax_pose 8, 0x01ef, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose164:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose165:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose166:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose167:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose168:
+ax_pose 13, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose169:
+ax_pose 14, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose170:
+ax_pose 9, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose171:
+ax_pose 10, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose172:
+ax_pose 11, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose173:
+ax_pose 6, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose174:
+ax_pose 7, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose175:
+ax_pose 8, 0x01ef, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose176:
+ax_pose 3, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose177:
+ax_pose 4, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose178:
+ax_pose 5, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose179:
+ax_pose 21, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose180:
+ax_pose 23, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose181:
+ax_pose 25, 0x01ec, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose182:
+ax_pose 27, 0x01ed, 0x80ee, 0x5c00
+ax_pose_terminator
+sAnorithPose183:
+ax_pose 29, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose184:
+ax_pose 27, 0x01ed, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose185:
+ax_pose 25, 0x01ec, 0x90f3, 0x5c00
+ax_pose_terminator
+sAnorithPose186:
+ax_pose 23, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose187:
+ax_pose 15, 0x01f1, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose188:
+ax_pose 16, 0x01f0, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose189:
+ax_pose 17, 0x01e8, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose190:
+ax_pose 18, 0x01e8, 0x90f3, 0x5c00
+ax_pose_terminator
+sAnorithPose191:
+ax_pose 19, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose192:
+ax_pose 18, 0x01e8, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose193:
+ax_pose 17, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose194:
+ax_pose 16, 0x01f0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose195:
+ax_pose 0, 0x01ee, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose196:
+ax_pose 15, 0x01f0, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose197:
+ax_pose 21, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose198:
+ax_pose 3, 0x01f0, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose199:
+ax_pose 16, 0x01ef, 0x90f1, 0x5c00
+ax_pose_terminator
+sAnorithPose200:
+ax_pose 23, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose201:
+ax_pose 6, 0x01ef, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose202:
+ax_pose 17, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sAnorithPose203:
+ax_pose 25, 0x01ec, 0x90f4, 0x5c00
+ax_pose_terminator
+sAnorithPose204:
+ax_pose 9, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose205:
+ax_pose 18, 0x01e6, 0x90f4, 0x5c00
+ax_pose_terminator
+sAnorithPose206:
+ax_pose 27, 0x01ed, 0x90f3, 0x5c00
+ax_pose_terminator
+sAnorithPose207:
+ax_pose 12, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose208:
+ax_pose 19, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose209:
+ax_pose 29, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose210:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose211:
+ax_pose 18, 0x01e6, 0x80ec, 0x5c00
+ax_pose_terminator
+sAnorithPose212:
+ax_pose 27, 0x01ed, 0x80ed, 0x5c00
+ax_pose_terminator
+sAnorithPose213:
+ax_pose 6, 0x01ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose214:
+ax_pose 17, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose215:
+ax_pose 25, 0x01ec, 0x80ec, 0x5c00
+ax_pose_terminator
+sAnorithPose216:
+ax_pose 3, 0x01f0, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose217:
+ax_pose 16, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose218:
+ax_pose 23, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose219:
+ax_pose 21, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose220:
+ax_pose 23, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose221:
+ax_pose 25, 0x01eb, 0x80ec, 0x5c00
+ax_pose_terminator
+sAnorithPose222:
+ax_pose 27, 0x01ed, 0x80ee, 0x5c00
+ax_pose_terminator
+sAnorithPose223:
+ax_pose 29, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sAnorithPose224:
+ax_pose 27, 0x01ed, 0x90f2, 0x5c00
+ax_pose_terminator
+sAnorithPose225:
+ax_pose 25, 0x01eb, 0x90f4, 0x5c00
+ax_pose_terminator
+sAnorithPose226:
+ax_pose 23, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sAnorithPose227:
+ax_pose 0, 0x01f0, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose228:
+ax_pose 3, 0x01f1, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose229:
+ax_pose 6, 0x01f1, 0x80f1, 0x5c00
+ax_pose_terminator
+sAnorithPose230:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAnorithPose231:
+ax_pose 12, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sAnorithPose232:
+ax_pose 9, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sAnorithPose233:
+ax_pose 6, 0x01f1, 0x90ee, 0x5c00
+ax_pose_terminator
+sAnorithPose234:
+ax_pose 3, 0x01f1, 0x90ef, 0x5c00
+ax_pose_terminator
+.align 2
+sAnorithAnims_1_1:
+ax_anim 8, 0, 0, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sAnorithAnims_1_2:
+ax_anim 8, 0, 3, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sAnorithAnims_1_3:
+ax_anim 8, 0, 6, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sAnorithAnims_1_4:
+ax_anim 8, 0, 9, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 1, 0, 0,
+ax_anim_terminator
+sAnorithAnims_1_5:
+ax_anim 8, 0, 12, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sAnorithAnims_1_6:
+ax_anim 8, 0, 15, 0, 1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 1, 0, 0,
+ax_anim_terminator
+sAnorithAnims_1_7:
+ax_anim 8, 0, 18, 0, 1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sAnorithAnims_1_8:
+ax_anim 8, 0, 21, 0, 1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 22, 0, 22,
+ax_anim 2, 1, 27, 1, 22, 1, 22,
+ax_anim 2, 0, 27, 0, 22, 0, 22,
+ax_anim 2, 0, 27, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sAnorithAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 5, 4, 5,
+ax_anim 1, 0, 30, 9, 11, 9, 11,
+ax_anim 2, 0, 31, 19, 23, 19, 23,
+ax_anim 2, 1, 31, 20, 22, 20, 22,
+ax_anim 2, 0, 31, 19, 23, 19, 23,
+ax_anim 2, 0, 31, 20, 22, 20, 22,
+ax_anim 2, 0, 28, 6, 7, 6, 7,
+ax_anim_terminator
+sAnorithAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sAnorithAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -5, 6, -5,
+ax_anim 1, 0, 38, 11, -10, 11, -10,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 1, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sAnorithAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 1, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sAnorithAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -5, -6, -5,
+ax_anim 1, 0, 46, -11, -10, -11, -10,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 1, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sAnorithAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sAnorithAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 5, -4, 5,
+ax_anim 1, 0, 54, -9, 11, -9, 11,
+ax_anim 2, 0, 55, -19, 23, -19, 23,
+ax_anim 2, 1, 55, -20, 22, -20, 22,
+ax_anim 2, 0, 55, -19, 23, -19, 23,
+ax_anim 2, 0, 55, -20, 22, -20, 22,
+ax_anim 2, 0, 52, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sAnorithAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, -3, 0, -3,
+ax_anim 6, 0, 59, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, -1, 0, -1,
+ax_anim 1, 0, 59, 0, 6, 0, 6,
+ax_anim 2, 0, 60, 0, 11, 0, 11,
+ax_anim 2, 1, 61, 1, 11, 1, 11,
+ax_anim 2, 0, 61, 0, 11, 0, 11,
+ax_anim 2, 0, 61, 1, 11, 1, 11,
+ax_anim 2, 0, 61, 0, 11, 0, 11,
+ax_anim 2, 0, 61, 1, 11, 1, 11,
+ax_anim 2, 0, 56, 0, 5, 0, 5,
+ax_anim_terminator
+sAnorithAnims_3_2:
+ax_anim 2, 0, 63, -2, -2, -2, -2,
+ax_anim 2, 0, 64, -3, -3, -3, -3,
+ax_anim 6, 0, 65, -4, -4, -4, -4,
+ax_anim 1, 2, 65, -1, -1, -1, -1,
+ax_anim 1, 0, 65, 6, 6, 6, 6,
+ax_anim 2, 0, 66, 14, 15, 14, 15,
+ax_anim 2, 1, 67, 15, 14, 15, 14,
+ax_anim 2, 0, 67, 14, 15, 14, 15,
+ax_anim 2, 0, 67, 15, 14, 15, 14,
+ax_anim 2, 0, 67, 14, 15, 14, 15,
+ax_anim 2, 0, 67, 15, 14, 15, 14,
+ax_anim 2, 0, 62, 7, 7, 7, 7,
+ax_anim_terminator
+sAnorithAnims_3_3:
+ax_anim 2, 0, 69, -2, 0, -2, 0,
+ax_anim 2, 0, 70, -3, 0, -3, 0,
+ax_anim 6, 0, 71, -4, 0, -4, 0,
+ax_anim 1, 2, 71, -1, 0, -1, 0,
+ax_anim 1, 0, 71, 6, 0, 6, 0,
+ax_anim 2, 0, 72, 12, 0, 12, 0,
+ax_anim 2, 1, 73, 12, 1, 12, 1,
+ax_anim 2, 0, 73, 12, 0, 12, 0,
+ax_anim 2, 0, 73, 12, 1, 12, 1,
+ax_anim 2, 0, 73, 12, 0, 12, 0,
+ax_anim 2, 0, 73, 12, 1, 12, 1,
+ax_anim 2, 0, 68, 7, 0, 7, 0,
+ax_anim_terminator
+sAnorithAnims_3_4:
+ax_anim 2, 0, 75, -2, 2, -2, 2,
+ax_anim 2, 0, 76, -3, 3, -3, 3,
+ax_anim 6, 0, 77, -4, 4, -4, 4,
+ax_anim 1, 2, 77, -1, 1, -1, 1,
+ax_anim 1, 0, 77, 6, -6, 6, -6,
+ax_anim 2, 0, 78, 14, -17, 14, -17,
+ax_anim 2, 1, 79, 15, -16, 15, -16,
+ax_anim 2, 0, 79, 14, -17, 14, -17,
+ax_anim 2, 0, 79, 15, -16, 15, -16,
+ax_anim 2, 0, 79, 14, -17, 14, -17,
+ax_anim 2, 0, 79, 15, -16, 15, -16,
+ax_anim 2, 0, 74, 6, -8, 6, -8,
+ax_anim_terminator
+sAnorithAnims_3_5:
+ax_anim 2, 0, 81, 0, 2, 0, 2,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 6, 0, 83, 0, 4, 0, 4,
+ax_anim 1, 2, 83, 0, 1, 0, 1,
+ax_anim 1, 0, 83, 0, -6, 0, -6,
+ax_anim 2, 0, 84, 0, -17, 0, -17,
+ax_anim 2, 1, 85, 1, -17, 1, -17,
+ax_anim 2, 0, 85, 0, -17, 0, -17,
+ax_anim 2, 0, 85, 1, -17, 1, -17,
+ax_anim 2, 0, 85, 0, -17, 0, -17,
+ax_anim 2, 0, 85, 1, -17, 1, -17,
+ax_anim 2, 0, 80, 0, -7, 0, -7,
+ax_anim_terminator
+sAnorithAnims_3_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 88, 3, 3, 3, 3,
+ax_anim 6, 0, 89, 4, 4, 4, 4,
+ax_anim 1, 2, 89, 1, 1, 1, 1,
+ax_anim 1, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 90, -14, -17, -14, -17,
+ax_anim 2, 1, 91, -15, -16, -15, -16,
+ax_anim 2, 0, 91, -14, -17, -14, -17,
+ax_anim 2, 0, 91, -15, -16, -15, -16,
+ax_anim 2, 0, 91, -14, -17, -14, -17,
+ax_anim 2, 0, 91, -15, -16, -15, -16,
+ax_anim 2, 0, 86, -6, -8, -6, -8,
+ax_anim_terminator
+sAnorithAnims_3_7:
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 3, 0, 3, 0,
+ax_anim 6, 0, 95, 4, 0, 4, 0,
+ax_anim 1, 2, 95, 1, 0, 1, 0,
+ax_anim 1, 0, 95, -6, 0, -6, 0,
+ax_anim 2, 0, 96, -12, 0, -12, 0,
+ax_anim 2, 1, 97, -12, 1, -12, 1,
+ax_anim 2, 0, 97, -12, 0, -12, 0,
+ax_anim 2, 0, 97, -12, 1, -12, 1,
+ax_anim 2, 0, 97, -12, 0, -12, 0,
+ax_anim 2, 0, 97, -12, 1, -12, 1,
+ax_anim 2, 0, 92, -7, 0, -7, 0,
+ax_anim_terminator
+sAnorithAnims_3_8:
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 6, 0, 101, 4, -4, 4, -4,
+ax_anim 1, 2, 101, 1, -1, 1, -1,
+ax_anim 1, 0, 101, -6, 6, -6, 6,
+ax_anim 2, 0, 102, -14, 15, -14, 15,
+ax_anim 2, 1, 103, -15, 14, -15, 14,
+ax_anim 2, 0, 103, -14, 15, -14, 15,
+ax_anim 2, 0, 103, -15, 14, -15, 14,
+ax_anim 2, 0, 103, -14, 15, -14, 15,
+ax_anim 2, 0, 103, -15, 14, -15, 14,
+ax_anim 2, 0, 98, -7, 7, -7, 7,
+ax_anim_terminator
+.align 2
+sAnorithAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 0, 104, 0, -5, 0, -5,
+ax_anim 6, 2, 104, 0, -5, 0, -5,
+ax_anim 1, 0, 107, 0, -2, 0, -2,
+ax_anim 1, 0, 107, 0, 1, 0, 1,
+ax_anim 2, 1, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sAnorithAnims_4_2:
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 0, 108, -5, -5, -5, -5,
+ax_anim 6, 2, 108, -5, -5, -5, -5,
+ax_anim 1, 0, 111, -2, -2, -2, -2,
+ax_anim 1, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 1, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 6, 4, 6, 4,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 6, 4, 6, 4,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 6, 4, 6, 4,
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim_terminator
+sAnorithAnims_4_3:
+ax_anim 2, 0, 113, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 0, 112, -5, 0, -5, 0,
+ax_anim 6, 2, 112, -5, 0, -5, 0,
+ax_anim 1, 0, 115, -2, 0, -2, 0,
+ax_anim 1, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 1, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 1, 5, 1,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 1, 5, 1,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 1, 5, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim_terminator
+sAnorithAnims_4_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 116, -5, 5, -5, 5,
+ax_anim 6, 2, 116, -5, 5, -5, 5,
+ax_anim 1, 0, 119, -2, 2, -2, 2,
+ax_anim 1, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 1, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 6, -4, 6, -4,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 6, -4, 6, -4,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 6, -4, 6, -4,
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim_terminator
+sAnorithAnims_4_5:
+ax_anim 2, 0, 121, 0, 2, 0, 2,
+ax_anim 2, 0, 122, 0, 4, 0, 4,
+ax_anim 2, 0, 120, 0, 5, 0, 5,
+ax_anim 6, 2, 120, 0, 5, 0, 5,
+ax_anim 1, 0, 123, 0, 2, 0, 2,
+ax_anim 1, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 1, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 1, -5, 1, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 1, -5, 1, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 1, -5, 1, -5,
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim_terminator
+sAnorithAnims_4_6:
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 126, 4, 4, 4, 4,
+ax_anim 2, 0, 124, 5, 5, 5, 5,
+ax_anim 6, 2, 124, 5, 5, 5, 5,
+ax_anim 1, 0, 127, 2, 2, 2, 2,
+ax_anim 1, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 1, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 124, -2, -2, -2, -2,
+ax_anim_terminator
+sAnorithAnims_4_7:
+ax_anim 2, 0, 129, 2, 0, 2, 0,
+ax_anim 2, 0, 130, 4, 0, 4, 0,
+ax_anim 2, 0, 128, 5, 0, 5, 0,
+ax_anim 6, 2, 128, 5, 0, 5, 0,
+ax_anim 1, 0, 131, 2, 0, 2, 0,
+ax_anim 1, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 1, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 1, -5, 1,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 1, -5, 1,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 1, -5, 1,
+ax_anim 2, 0, 128, -2, 0, -2, 0,
+ax_anim_terminator
+sAnorithAnims_4_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 134, 4, -4, 4, -4,
+ax_anim 2, 0, 132, 5, -5, 5, -5,
+ax_anim 6, 2, 132, 5, -5, 5, -5,
+ax_anim 1, 0, 135, 2, -2, 2, -2,
+ax_anim 1, 0, 135, -1, 1, -1, 1,
+ax_anim 2, 1, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sAnorithAnims_5_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_5_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_5_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_5_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_6_1:
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 144, 0, -1, 0, 0,
+ax_anim 16, 0, 144, 0, -2, 0, 0,
+ax_anim 16, 0, 145, 0, -2, 0, 0,
+ax_anim 12, 0, 145, 0, -1, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sAnorithAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sAnorithAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sAnorithAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sAnorithAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sAnorithAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sAnorithAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sAnorithAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sAnorithAnims_8_1:
+ax_anim 10, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_8_2:
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_8_3:
+ax_anim 10, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 10, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_8_4:
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim 10, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_8_5:
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_8_6:
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_8_7:
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_8_8:
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 7, 5, 7, 5,
+ax_anim 2, 0, 180, 10, 11, 10, 11,
+ax_anim 2, 0, 181, 8, 18, 8, 18,
+ax_anim 3, 0, 182, 0, 20, 0, 20,
+ax_anim 2, 3, 183, -8, 18, -8, 18,
+ax_anim 2, 0, 184, -10, 11, -10, 11,
+ax_anim 1, 0, 185, -7, 5, -7, 5,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 11, 0, 11, 0,
+ax_anim 2, 0, 179, 18, 5, 18, 5,
+ax_anim 2, 0, 180, 21, 13, 21, 13,
+ax_anim 3, 0, 181, 20, 19, 21, 19,
+ax_anim 2, 3, 182, 11, 20, 11, 20,
+ax_anim 2, 0, 183, 2, 15, 2, 15,
+ax_anim 1, 0, 184, 0, 8, 0, 8,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 5, -4, 5, -4,
+ax_anim 2, 0, 178, 13, -5, 13, -5,
+ax_anim 2, 0, 179, 17, -3, 17, -3,
+ax_anim 3, 0, 180, 21, 2, 21, 2,
+ax_anim 2, 3, 181, 18, 7, 18, 7,
+ax_anim 2, 0, 182, 10, 8, 10, 8,
+ax_anim 1, 0, 183, 4, 6, 4, 6,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -7, -1, -7,
+ax_anim 2, 0, 185, 4, -15, 4, -15,
+ax_anim 2, 0, 178, 11, -21, 11, -21,
+ax_anim 3, 0, 179, 20, -21, 20, -21,
+ax_anim 2, 3, 180, 23, -13, 23, -13,
+ax_anim 2, 0, 181, 19, -5, 19, -5,
+ax_anim 1, 0, 182, 9, -1, 9, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -9, -4, -9, -4,
+ax_anim 2, 0, 184, -10, -11, -10, -11,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 10, -11, 10, -11,
+ax_anim 1, 0, 181, 9, -4, 9, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -7, 1, -7,
+ax_anim 2, 0, 179, -4, -15, -4, -15,
+ax_anim 2, 0, 178, -11, -21, -11, -21,
+ax_anim 3, 0, 185, -20, -21, -20, -21,
+ax_anim 2, 3, 184, -23, -13, -23, -13,
+ax_anim 2, 0, 183, -19, -5, -19, -5,
+ax_anim 1, 0, 182, -9, -1, -9, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -5, -4, -5, -4,
+ax_anim 2, 0, 178, -13, -5, -13, -5,
+ax_anim 2, 0, 185, -17, -3, -17, -3,
+ax_anim 3, 0, 184, -21, 2, -21, 2,
+ax_anim 2, 3, 183, -18, 7, -18, 7,
+ax_anim 2, 0, 182, -10, 8, -10, 8,
+ax_anim 1, 0, 181, -4, 6, -4, 6,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -11, 0, -11, 0,
+ax_anim 2, 0, 185, -18, 5, -18, 5,
+ax_anim 2, 0, 184, -21, 13, -21, 13,
+ax_anim 3, 0, 183, -20, 19, -20, 19,
+ax_anim 2, 3, 182, -11, 20, -11, 20,
+ax_anim 2, 0, 181, -2, 15, -2, 15,
+ax_anim 1, 0, 180, 0, 8, 0, 8,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -19, 0, 0,
+ax_anim 3, 0, 196, 0, -17, 0, 0,
+ax_anim 2, 0, 196, 0, -13, 0, 0,
+ax_anim 1, 0, 196, 0, -8, 0, 0,
+ax_anim 2, 2, 196, 0, 4, 0, 0,
+ax_anim_terminator
+sAnorithAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 2, 0, 199, 0, -17, 0, 0,
+ax_anim 1, 0, 199, 0, -11, 0, 0,
+ax_anim 2, 2, 199, 0, 3, 0, 0,
+ax_anim_terminator
+sAnorithAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 202, 0, 4, 0, 0,
+ax_anim_terminator
+sAnorithAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 3, 0, 0,
+ax_anim_terminator
+sAnorithAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -24, 0, 0,
+ax_anim 3, 0, 208, 0, -23, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 4, 0, 0,
+ax_anim_terminator
+sAnorithAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -22, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 3, 0, 0,
+ax_anim_terminator
+sAnorithAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 2, 0, 214, 0, -17, 0, 0,
+ax_anim 1, 0, 214, 0, -11, 0, 0,
+ax_anim 2, 2, 214, 0, 4, 0, 0,
+ax_anim_terminator
+sAnorithAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 2, 0, 217, 0, -17, 0, 0,
+ax_anim 1, 0, 217, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAnorithAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sAnorithGfx1:
+.incbin "baserom.gba", 0x1428D98, 0x200
+sAnorithSprites1:
+ax_sprite sAnorithGfx1, 0x200
+ax_sprite_terminator
+sAnorithGfx2:
+.incbin "baserom.gba", 0x1428FA8, 0x200
+sAnorithSprites2:
+ax_sprite sAnorithGfx2, 0x200
+ax_sprite_terminator
+sAnorithGfx3:
+.incbin "baserom.gba", 0x14291B8, 0x200
+sAnorithSprites3:
+ax_sprite sAnorithGfx3, 0x200
+ax_sprite_terminator
+sAnorithGfx4:
+.incbin "baserom.gba", 0x14293C8, 0x200
+sAnorithSprites4:
+ax_sprite sAnorithGfx4, 0x200
+ax_sprite_terminator
+sAnorithGfx5:
+.incbin "baserom.gba", 0x14295D8, 0x200
+sAnorithSprites5:
+ax_sprite sAnorithGfx5, 0x200
+ax_sprite_terminator
+sAnorithGfx6:
+.incbin "baserom.gba", 0x14297E8, 0x200
+sAnorithSprites6:
+ax_sprite sAnorithGfx6, 0x200
+ax_sprite_terminator
+sAnorithGfx7:
+.incbin "baserom.gba", 0x14299F8, 0x200
+sAnorithSprites7:
+ax_sprite sAnorithGfx7, 0x200
+ax_sprite_terminator
+sAnorithGfx8:
+.incbin "baserom.gba", 0x1429C08, 0x200
+sAnorithSprites8:
+ax_sprite sAnorithGfx8, 0x200
+ax_sprite_terminator
+sAnorithGfx9:
+.incbin "baserom.gba", 0x1429E18, 0x200
+sAnorithSprites9:
+ax_sprite sAnorithGfx9, 0x200
+ax_sprite_terminator
+sAnorithGfx10:
+.incbin "baserom.gba", 0x142A028, 0x200
+sAnorithSprites10:
+ax_sprite sAnorithGfx10, 0x200
+ax_sprite_terminator
+sAnorithGfx11:
+.incbin "baserom.gba", 0x142A238, 0x200
+sAnorithSprites11:
+ax_sprite sAnorithGfx11, 0x200
+ax_sprite_terminator
+sAnorithGfx12:
+.incbin "baserom.gba", 0x142A448, 0x200
+sAnorithSprites12:
+ax_sprite sAnorithGfx12, 0x200
+ax_sprite_terminator
+sAnorithGfx13:
+.incbin "baserom.gba", 0x142A658, 0x200
+sAnorithSprites13:
+ax_sprite sAnorithGfx13, 0x200
+ax_sprite_terminator
+sAnorithGfx14:
+.incbin "baserom.gba", 0x142A868, 0x200
+sAnorithSprites14:
+ax_sprite sAnorithGfx14, 0x200
+ax_sprite_terminator
+sAnorithGfx15:
+.incbin "baserom.gba", 0x142AA78, 0x200
+sAnorithSprites15:
+ax_sprite sAnorithGfx15, 0x200
+ax_sprite_terminator
+sAnorithGfx16:
+.incbin "baserom.gba", 0x142AC88, 0x100
+sAnorithSprites16:
+ax_sprite sAnorithGfx16, 0x100
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sAnorithGfx17:
+.incbin "baserom.gba", 0x142ADA0, 0x100
+sAnorithGfx17_1:
+.incbin "baserom.gba", 0x142AEA0, 0x60
+sAnorithSprites17:
+ax_sprite sAnorithGfx17, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx17_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAnorithGfx18:
+.incbin "baserom.gba", 0x142AF28, 0x40
+sAnorithGfx18_1:
+.incbin "baserom.gba", 0x142AF68, 0x60
+sAnorithGfx18_2:
+.incbin "baserom.gba", 0x142AFC8, 0x80
+sAnorithGfx18_3:
+.incbin "baserom.gba", 0x142B048, 0x40
+sAnorithSprites18:
+ax_sprite sAnorithGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx18_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAnorithGfx19:
+.incbin "baserom.gba", 0x142B0D0, 0x20
+sAnorithGfx19_1:
+.incbin "baserom.gba", 0x142B0F0, 0x20
+sAnorithGfx19_2:
+.incbin "baserom.gba", 0x142B110, 0x100
+sAnorithGfx19_3:
+.incbin "baserom.gba", 0x142B210, 0x60
+sAnorithSprites19:
+ax_sprite sAnorithGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx19_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx19_2, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx19_3, 0x60
+ax_sprite_terminator
+sAnorithGfx20:
+.incbin "baserom.gba", 0x142B2B0, 0x40
+sAnorithGfx20_1:
+.incbin "baserom.gba", 0x142B2F0, 0x120
+sAnorithGfx20_2:
+.incbin "baserom.gba", 0x142B410, 0x60
+sAnorithSprites20:
+ax_sprite sAnorithGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx20_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx20_2, 0x60
+ax_sprite_terminator
+sAnorithGfx21:
+.incbin "baserom.gba", 0x142B4A0, 0x20
+sAnorithGfx21_1:
+.incbin "baserom.gba", 0x142B4C0, 0x40
+sAnorithGfx21_2:
+.incbin "baserom.gba", 0x142B500, 0x40
+sAnorithGfx21_3:
+.incbin "baserom.gba", 0x142B540, 0xA0
+sAnorithSprites21:
+ax_sprite sAnorithGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx21_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx21_3, 0xa0
+ax_sprite_terminator
+sAnorithGfx22:
+.incbin "baserom.gba", 0x142B620, 0x40
+sAnorithGfx22_1:
+.incbin "baserom.gba", 0x142B660, 0x100
+sAnorithGfx22_2:
+.incbin "baserom.gba", 0x142B760, 0x40
+sAnorithSprites22:
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAnorithGfx23:
+.incbin "baserom.gba", 0x142B7E0, 0x40
+sAnorithGfx23_1:
+.incbin "baserom.gba", 0x142B820, 0x40
+sAnorithGfx23_2:
+.incbin "baserom.gba", 0x142B860, 0x100
+sAnorithSprites23:
+ax_sprite sAnorithGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx23_2, 0x100
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAnorithGfx24:
+.incbin "baserom.gba", 0x142B998, 0x180
+sAnorithSprites24:
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx24, 0x180
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sAnorithGfx25:
+.incbin "baserom.gba", 0x142BB38, 0x40
+sAnorithGfx25_1:
+.incbin "baserom.gba", 0x142BB78, 0x40
+sAnorithGfx25_2:
+.incbin "baserom.gba", 0x142BBB8, 0x20
+sAnorithGfx25_3:
+.incbin "baserom.gba", 0x142BBD8, 0x60
+sAnorithSprites25:
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx25_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sAnorithGfx25_3, 0x60
+ax_sprite_terminator
+sAnorithGfx26:
+.incbin "baserom.gba", 0x142BC80, 0x160
+sAnorithSprites26:
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx26, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAnorithGfx27:
+.incbin "baserom.gba", 0x142BE00, 0xC0
+sAnorithGfx27_1:
+.incbin "baserom.gba", 0x142BEC0, 0x40
+sAnorithGfx27_2:
+.incbin "baserom.gba", 0x142BF00, 0x20
+sAnorithSprites27:
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx27, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx27_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sAnorithGfx27_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAnorithGfx28:
+.incbin "baserom.gba", 0x142BF60, 0x100
+sAnorithGfx28_1:
+.incbin "baserom.gba", 0x142C060, 0x60
+sAnorithSprites28:
+ax_sprite sAnorithGfx28, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx28_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAnorithGfx29:
+.incbin "baserom.gba", 0x142C0E8, 0x120
+sAnorithGfx29_1:
+.incbin "baserom.gba", 0x142C208, 0x20
+sAnorithSprites29:
+ax_sprite sAnorithGfx29, 0x120
+ax_sprite 0, 0x40
+ax_sprite sAnorithGfx29_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAnorithGfx30:
+.incbin "baserom.gba", 0x142C250, 0x160
+sAnorithSprites30:
+ax_sprite 0, 0x20
+ax_sprite sAnorithGfx30, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAnorithGfx31:
+.incbin "baserom.gba", 0x142C3D0, 0x200
+sAnorithSprites31:
+ax_sprite sAnorithGfx31, 0x200
+ax_sprite_terminator
+sAnorithGfx32:
+.incbin "baserom.gba", 0x142C5E0, 0x200
+sAnorithSprites32:
+ax_sprite sAnorithGfx32, 0x200
+ax_sprite_terminator
+sAnorithGfx33:
+.incbin "baserom.gba", 0x142C7F0, 0x200
+sAnorithSprites33:
+ax_sprite sAnorithGfx33, 0x200
+ax_sprite_terminator
+sAnorithGfx34:
+.incbin "baserom.gba", 0x142CA00, 0x200
+sAnorithSprites34:
+ax_sprite sAnorithGfx34, 0x200
+ax_sprite_terminator
+sAnorithGfx35:
+.incbin "baserom.gba", 0x142CC10, 0x200
+sAnorithSprites35:
+ax_sprite sAnorithGfx35, 0x200
+ax_sprite_terminator
+sAnorithGfx36:
+.incbin "baserom.gba", 0x142CE20, 0x200
+sAnorithSprites36:
+ax_sprite sAnorithGfx36, 0x200
+ax_sprite_terminator
+sAnorithGfx37:
+.incbin "baserom.gba", 0x142D030, 0x200
+sAnorithSprites37:
+ax_sprite sAnorithGfx37, 0x200
+ax_sprite_terminator
+sAxPosesAnorith:
+.4byte sAnorithPose1
+.4byte sAnorithPose2
+.4byte sAnorithPose3
+.4byte sAnorithPose4
+.4byte sAnorithPose5
+.4byte sAnorithPose6
+.4byte sAnorithPose7
+.4byte sAnorithPose8
+.4byte sAnorithPose9
+.4byte sAnorithPose10
+.4byte sAnorithPose11
+.4byte sAnorithPose12
+.4byte sAnorithPose13
+.4byte sAnorithPose14
+.4byte sAnorithPose15
+.4byte sAnorithPose16
+.4byte sAnorithPose17
+.4byte sAnorithPose18
+.4byte sAnorithPose19
+.4byte sAnorithPose20
+.4byte sAnorithPose21
+.4byte sAnorithPose22
+.4byte sAnorithPose23
+.4byte sAnorithPose24
+.4byte sAnorithPose25
+.4byte sAnorithPose26
+.4byte sAnorithPose27
+.4byte sAnorithPose28
+.4byte sAnorithPose29
+.4byte sAnorithPose30
+.4byte sAnorithPose31
+.4byte sAnorithPose32
+.4byte sAnorithPose33
+.4byte sAnorithPose34
+.4byte sAnorithPose35
+.4byte sAnorithPose36
+.4byte sAnorithPose37
+.4byte sAnorithPose38
+.4byte sAnorithPose39
+.4byte sAnorithPose40
+.4byte sAnorithPose41
+.4byte sAnorithPose42
+.4byte sAnorithPose43
+.4byte sAnorithPose44
+.4byte sAnorithPose45
+.4byte sAnorithPose46
+.4byte sAnorithPose47
+.4byte sAnorithPose48
+.4byte sAnorithPose49
+.4byte sAnorithPose50
+.4byte sAnorithPose51
+.4byte sAnorithPose52
+.4byte sAnorithPose53
+.4byte sAnorithPose54
+.4byte sAnorithPose55
+.4byte sAnorithPose56
+.4byte sAnorithPose57
+.4byte sAnorithPose58
+.4byte sAnorithPose59
+.4byte sAnorithPose60
+.4byte sAnorithPose61
+.4byte sAnorithPose62
+.4byte sAnorithPose63
+.4byte sAnorithPose64
+.4byte sAnorithPose65
+.4byte sAnorithPose66
+.4byte sAnorithPose67
+.4byte sAnorithPose68
+.4byte sAnorithPose69
+.4byte sAnorithPose70
+.4byte sAnorithPose71
+.4byte sAnorithPose72
+.4byte sAnorithPose73
+.4byte sAnorithPose74
+.4byte sAnorithPose75
+.4byte sAnorithPose76
+.4byte sAnorithPose77
+.4byte sAnorithPose78
+.4byte sAnorithPose79
+.4byte sAnorithPose80
+.4byte sAnorithPose81
+.4byte sAnorithPose82
+.4byte sAnorithPose83
+.4byte sAnorithPose84
+.4byte sAnorithPose85
+.4byte sAnorithPose86
+.4byte sAnorithPose87
+.4byte sAnorithPose88
+.4byte sAnorithPose89
+.4byte sAnorithPose90
+.4byte sAnorithPose91
+.4byte sAnorithPose92
+.4byte sAnorithPose93
+.4byte sAnorithPose94
+.4byte sAnorithPose95
+.4byte sAnorithPose96
+.4byte sAnorithPose97
+.4byte sAnorithPose98
+.4byte sAnorithPose99
+.4byte sAnorithPose100
+.4byte sAnorithPose101
+.4byte sAnorithPose102
+.4byte sAnorithPose103
+.4byte sAnorithPose104
+.4byte sAnorithPose105
+.4byte sAnorithPose106
+.4byte sAnorithPose107
+.4byte sAnorithPose108
+.4byte sAnorithPose109
+.4byte sAnorithPose110
+.4byte sAnorithPose111
+.4byte sAnorithPose112
+.4byte sAnorithPose113
+.4byte sAnorithPose114
+.4byte sAnorithPose115
+.4byte sAnorithPose116
+.4byte sAnorithPose117
+.4byte sAnorithPose118
+.4byte sAnorithPose119
+.4byte sAnorithPose120
+.4byte sAnorithPose121
+.4byte sAnorithPose122
+.4byte sAnorithPose123
+.4byte sAnorithPose124
+.4byte sAnorithPose125
+.4byte sAnorithPose126
+.4byte sAnorithPose127
+.4byte sAnorithPose128
+.4byte sAnorithPose129
+.4byte sAnorithPose130
+.4byte sAnorithPose131
+.4byte sAnorithPose132
+.4byte sAnorithPose133
+.4byte sAnorithPose134
+.4byte sAnorithPose135
+.4byte sAnorithPose136
+.4byte sAnorithPose137
+.4byte sAnorithPose138
+.4byte sAnorithPose139
+.4byte sAnorithPose140
+.4byte sAnorithPose141
+.4byte sAnorithPose142
+.4byte sAnorithPose143
+.4byte sAnorithPose144
+.4byte sAnorithPose145
+.4byte sAnorithPose146
+.4byte sAnorithPose147
+.4byte sAnorithPose148
+.4byte sAnorithPose149
+.4byte sAnorithPose150
+.4byte sAnorithPose151
+.4byte sAnorithPose152
+.4byte sAnorithPose153
+.4byte sAnorithPose154
+.4byte sAnorithPose155
+.4byte sAnorithPose156
+.4byte sAnorithPose157
+.4byte sAnorithPose158
+.4byte sAnorithPose159
+.4byte sAnorithPose160
+.4byte sAnorithPose161
+.4byte sAnorithPose162
+.4byte sAnorithPose163
+.4byte sAnorithPose164
+.4byte sAnorithPose165
+.4byte sAnorithPose166
+.4byte sAnorithPose167
+.4byte sAnorithPose168
+.4byte sAnorithPose169
+.4byte sAnorithPose170
+.4byte sAnorithPose171
+.4byte sAnorithPose172
+.4byte sAnorithPose173
+.4byte sAnorithPose174
+.4byte sAnorithPose175
+.4byte sAnorithPose176
+.4byte sAnorithPose177
+.4byte sAnorithPose178
+.4byte sAnorithPose179
+.4byte sAnorithPose180
+.4byte sAnorithPose181
+.4byte sAnorithPose182
+.4byte sAnorithPose183
+.4byte sAnorithPose184
+.4byte sAnorithPose185
+.4byte sAnorithPose186
+.4byte sAnorithPose187
+.4byte sAnorithPose188
+.4byte sAnorithPose189
+.4byte sAnorithPose190
+.4byte sAnorithPose191
+.4byte sAnorithPose192
+.4byte sAnorithPose193
+.4byte sAnorithPose194
+.4byte sAnorithPose195
+.4byte sAnorithPose196
+.4byte sAnorithPose197
+.4byte sAnorithPose198
+.4byte sAnorithPose199
+.4byte sAnorithPose200
+.4byte sAnorithPose201
+.4byte sAnorithPose202
+.4byte sAnorithPose203
+.4byte sAnorithPose204
+.4byte sAnorithPose205
+.4byte sAnorithPose206
+.4byte sAnorithPose207
+.4byte sAnorithPose208
+.4byte sAnorithPose209
+.4byte sAnorithPose210
+.4byte sAnorithPose211
+.4byte sAnorithPose212
+.4byte sAnorithPose213
+.4byte sAnorithPose214
+.4byte sAnorithPose215
+.4byte sAnorithPose216
+.4byte sAnorithPose217
+.4byte sAnorithPose218
+.4byte sAnorithPose219
+.4byte sAnorithPose220
+.4byte sAnorithPose221
+.4byte sAnorithPose222
+.4byte sAnorithPose223
+.4byte sAnorithPose224
+.4byte sAnorithPose225
+.4byte sAnorithPose226
+.4byte sAnorithPose227
+.4byte sAnorithPose228
+.4byte sAnorithPose229
+.4byte sAnorithPose230
+.4byte sAnorithPose231
+.4byte sAnorithPose232
+.4byte sAnorithPose233
+.4byte sAnorithPose234
+sAxPositionsAnorith:
+.2byte   -1,   -5, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,    4, 	   5,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,    1, 	   4,    4, 	  -1,   -7
+.2byte    2,   -7, 	  12,   -3, 	   4,    3, 	   0,   -8
+.2byte    2,   -6, 	  13,   -3, 	   2,    1, 	   0,   -8
+.2byte    3,   -6, 	  11,   -4, 	   5,    3, 	   0,   -8
+.2byte    2,   -8, 	  13,  -10, 	  12,   -4, 	   0,   -8
+.2byte    2,   -8, 	  14,  -10, 	  10,   -4, 	   0,   -8
+.2byte    2,   -8, 	  11,  -10, 	  13,   -4, 	  -1,   -8
+.2byte    0,  -10, 	   3,  -17, 	  11,  -13, 	  -2,   -8
+.2byte    0,  -10, 	   4,  -18, 	  10,  -12, 	  -2,   -8
+.2byte    1,  -10, 	   2,  -16, 	  11,  -14, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -17, 	  -5,  -17, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -18, 	  -5,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -16, 	  -5,  -18, 	  -1,   -8
+.2byte   -2,  -10, 	  -5,  -17, 	 -13,  -13, 	   0,   -8
+.2byte   -2,  -10, 	  -6,  -18, 	 -12,  -12, 	   0,   -8
+.2byte   -3,  -10, 	  -4,  -16, 	 -13,  -14, 	  -1,   -8
+.2byte   -4,   -8, 	 -15,  -10, 	 -14,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -16,  -10, 	 -12,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -13,  -10, 	 -15,   -4, 	  -1,   -8
+.2byte   -4,   -7, 	 -14,   -3, 	  -6,    3, 	  -2,   -8
+.2byte   -4,   -6, 	 -15,   -3, 	  -4,    1, 	  -2,   -8
+.2byte   -5,   -6, 	 -13,   -4, 	  -7,    3, 	  -2,   -8
+.2byte   -1,   -5, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,    4, 	   5,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,    1, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -4, 	 -10,  -12, 	   9,  -12, 	  -1,   -7
+.2byte    2,   -7, 	  12,   -3, 	   4,    3, 	   0,   -8
+.2byte    2,   -6, 	  13,   -3, 	   2,    1, 	   0,   -8
+.2byte    3,   -6, 	  11,   -4, 	   5,    3, 	   0,   -8
+.2byte    1,   -6, 	   8,  -16, 	  -5,   -9, 	  -2,   -8
+.2byte    2,   -8, 	  13,  -10, 	  12,   -4, 	   0,   -8
+.2byte    2,   -8, 	  14,  -10, 	  10,   -4, 	   0,   -8
+.2byte    2,   -8, 	  11,  -10, 	  13,   -4, 	  -1,   -8
+.2byte    1,   -9, 	   8,  -20, 	   6,   -5, 	  -2,   -9
+.2byte    0,  -10, 	   3,  -17, 	  11,  -13, 	  -2,   -8
+.2byte    0,  -10, 	   4,  -18, 	  10,  -12, 	  -2,   -8
+.2byte    1,  -10, 	   2,  -16, 	  11,  -14, 	  -1,   -8
+.2byte    0,   -9, 	  -2,  -23, 	  13,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -17, 	  -5,  -17, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -18, 	  -5,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -16, 	  -5,  -18, 	  -1,   -8
+.2byte   -1,  -10, 	   9,  -21, 	 -11,  -21, 	  -1,   -8
+.2byte   -2,  -10, 	  -5,  -17, 	 -13,  -13, 	   0,   -8
+.2byte   -2,  -10, 	  -6,  -18, 	 -12,  -12, 	   0,   -8
+.2byte   -3,  -10, 	  -4,  -16, 	 -13,  -14, 	  -1,   -8
+.2byte   -2,   -9, 	   0,  -23, 	 -15,  -16, 	  -1,   -8
+.2byte   -4,   -8, 	 -15,  -10, 	 -14,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -16,  -10, 	 -12,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -13,  -10, 	 -15,   -4, 	  -1,   -8
+.2byte   -3,   -9, 	 -10,  -20, 	  -8,   -5, 	   0,   -9
+.2byte   -4,   -7, 	 -14,   -3, 	  -6,    3, 	  -2,   -8
+.2byte   -4,   -6, 	 -15,   -3, 	  -4,    1, 	  -2,   -8
+.2byte   -5,   -6, 	 -13,   -4, 	  -7,    3, 	  -2,   -8
+.2byte   -3,   -6, 	 -10,  -16, 	   3,   -9, 	   0,   -8
+.2byte   -1,   -5, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,    4, 	   5,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,    1, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -4, 	 -10,  -12, 	   9,  -12, 	  -1,   -7
+.2byte   -1,   -7, 	   1,    5, 	  -3,    5, 	  -1,   -6
+.2byte   -1,   -7, 	   1,    5, 	  -3,    5, 	  -1,   -6
+.2byte    2,   -7, 	  12,   -3, 	   4,    3, 	   0,   -8
+.2byte    2,   -6, 	  13,   -3, 	   2,    1, 	   0,   -8
+.2byte    3,   -6, 	  11,   -4, 	   5,    3, 	   0,   -8
+.2byte    1,   -6, 	   8,  -16, 	  -5,   -9, 	  -2,   -8
+.2byte    1,   -7, 	  10,    2, 	  11,    2, 	   2,   -7
+.2byte    1,   -7, 	  10,    2, 	  11,    2, 	   2,   -7
+.2byte    2,   -8, 	  13,  -10, 	  12,   -4, 	   0,   -8
+.2byte    2,   -8, 	  14,  -10, 	  10,   -4, 	   0,   -8
+.2byte    2,   -8, 	  11,  -10, 	  13,   -4, 	  -1,   -8
+.2byte    1,   -9, 	   8,  -20, 	   6,   -5, 	  -2,   -9
+.2byte    2,   -8, 	  15,   -5, 	  14,   -7, 	  -1,   -9
+.2byte    2,   -8, 	  15,   -5, 	  14,   -7, 	  -1,   -9
+.2byte    0,  -10, 	   3,  -17, 	  11,  -13, 	  -2,   -8
+.2byte    0,  -10, 	   4,  -18, 	  10,  -12, 	  -2,   -8
+.2byte    1,  -10, 	   2,  -16, 	  11,  -14, 	  -1,   -8
+.2byte    0,   -9, 	  -2,  -23, 	  13,  -16, 	  -1,   -8
+.2byte    2,  -11, 	  12,  -12, 	  10,  -14, 	   0,   -9
+.2byte    2,  -11, 	  12,  -12, 	  10,  -14, 	   0,   -9
+.2byte   -1,  -10, 	   3,  -17, 	  -5,  -17, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -18, 	  -5,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -16, 	  -5,  -18, 	  -1,   -8
+.2byte   -1,  -10, 	   9,  -21, 	 -11,  -21, 	  -1,   -8
+.2byte   -1,  -10, 	  -3,  -18, 	   1,  -17, 	  -1,   -8
+.2byte   -1,  -10, 	  -3,  -18, 	   1,  -17, 	  -1,   -8
+.2byte   -2,  -10, 	  -5,  -17, 	 -13,  -13, 	   0,   -8
+.2byte   -2,  -10, 	  -6,  -18, 	 -12,  -12, 	   0,   -8
+.2byte   -3,  -10, 	  -4,  -16, 	 -13,  -14, 	  -1,   -8
+.2byte   -2,   -9, 	   0,  -23, 	 -15,  -16, 	  -1,   -8
+.2byte   -4,  -11, 	 -14,  -12, 	 -12,  -14, 	  -2,   -9
+.2byte   -4,  -11, 	 -14,  -12, 	 -12,  -14, 	  -2,   -9
+.2byte   -4,   -8, 	 -15,  -10, 	 -14,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -16,  -10, 	 -12,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -13,  -10, 	 -15,   -4, 	  -1,   -8
+.2byte   -3,   -9, 	 -10,  -20, 	  -8,   -5, 	   0,   -9
+.2byte   -4,   -8, 	 -17,   -5, 	 -16,   -7, 	  -1,   -9
+.2byte   -4,   -8, 	 -17,   -5, 	 -16,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	 -14,   -3, 	  -6,    3, 	  -2,   -8
+.2byte   -4,   -6, 	 -15,   -3, 	  -4,    1, 	  -2,   -8
+.2byte   -5,   -6, 	 -13,   -4, 	  -7,    3, 	  -2,   -8
+.2byte   -3,   -6, 	 -10,  -16, 	   3,   -9, 	   0,   -8
+.2byte   -3,   -7, 	 -12,    2, 	 -13,    2, 	  -4,   -7
+.2byte   -3,   -7, 	 -12,    2, 	 -13,    2, 	  -4,   -7
+.2byte   -1,   -5, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,    4, 	   5,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,    1, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -4, 	 -10,  -12, 	   9,  -12, 	  -1,   -7
+.2byte    2,   -7, 	  12,   -3, 	   4,    3, 	   0,   -8
+.2byte    2,   -6, 	  13,   -3, 	   2,    1, 	   0,   -8
+.2byte    3,   -6, 	  11,   -4, 	   5,    3, 	   0,   -8
+.2byte    1,   -6, 	   8,  -16, 	  -5,   -9, 	  -2,   -8
+.2byte    2,   -8, 	  13,  -10, 	  12,   -4, 	   0,   -8
+.2byte    2,   -8, 	  14,  -10, 	  10,   -4, 	   0,   -8
+.2byte    2,   -8, 	  11,  -10, 	  13,   -4, 	  -1,   -8
+.2byte    1,   -9, 	   8,  -20, 	   6,   -5, 	  -2,   -9
+.2byte    0,  -10, 	   3,  -17, 	  11,  -13, 	  -2,   -8
+.2byte    0,  -10, 	   4,  -18, 	  10,  -12, 	  -2,   -8
+.2byte    1,  -10, 	   2,  -16, 	  11,  -14, 	  -1,   -8
+.2byte    0,   -9, 	  -2,  -23, 	  13,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -17, 	  -5,  -17, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -18, 	  -5,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -16, 	  -5,  -18, 	  -1,   -8
+.2byte   -1,  -10, 	   9,  -21, 	 -11,  -21, 	  -1,   -8
+.2byte   -2,  -10, 	  -5,  -17, 	 -13,  -13, 	   0,   -8
+.2byte   -2,  -10, 	  -6,  -18, 	 -12,  -12, 	   0,   -8
+.2byte   -3,  -10, 	  -4,  -16, 	 -13,  -14, 	  -1,   -8
+.2byte   -2,   -9, 	   0,  -23, 	 -15,  -16, 	  -1,   -8
+.2byte   -4,   -8, 	 -15,  -10, 	 -14,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -16,  -10, 	 -12,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -13,  -10, 	 -15,   -4, 	  -1,   -8
+.2byte   -3,   -9, 	 -10,  -20, 	  -8,   -5, 	   0,   -9
+.2byte   -4,   -7, 	 -14,   -3, 	  -6,    3, 	  -2,   -8
+.2byte   -4,   -6, 	 -15,   -3, 	  -4,    1, 	  -2,   -8
+.2byte   -5,   -6, 	 -13,   -4, 	  -7,    3, 	  -2,   -8
+.2byte   -3,   -6, 	 -10,  -16, 	   3,   -9, 	   0,   -8
+.2byte   -1,   -4, 	  -6,    4, 	   4,    4, 	  -1,   -6
+.2byte   -3,   -5, 	 -13,   -1, 	  -5,    5, 	  -1,   -6
+.2byte   -2,   -6, 	 -13,   -8, 	 -12,   -2, 	   0,   -6
+.2byte   -1,   -8, 	  -4,  -15, 	 -12,  -11, 	   1,   -6
+.2byte   -1,   -8, 	   3,  -15, 	  -5,  -15, 	  -1,   -6
+.2byte   -1,   -8, 	   2,  -15, 	  10,  -11, 	  -3,   -6
+.2byte    0,   -6, 	  11,   -8, 	  10,   -2, 	  -2,   -6
+.2byte    1,   -5, 	  11,   -1, 	   3,    5, 	  -1,   -6
+.2byte   -1,   -6, 	  -6,    5, 	   4,    5, 	  -1,   -7
+.2byte   -1,   -6, 	  -6,    4, 	   4,    5, 	  -1,   -7
+.2byte    0,  -14, 	  -5,  -24, 	   5,  -24, 	   0,  -13
+.2byte    1,  -15, 	   3,  -27, 	  -6,  -24, 	  -1,  -14
+.2byte    1,  -15, 	   0,  -28, 	  -3,  -26, 	  -1,  -14
+.2byte    0,  -15, 	  -1,  -27, 	   6,  -24, 	  -1,  -13
+.2byte    0,  -14, 	   6,  -25, 	  -6,  -24, 	   0,  -12
+.2byte   -1,  -15, 	   0,  -27, 	  -7,  -24, 	   0,  -13
+.2byte   -2,  -15, 	  -1,  -28, 	   2,  -26, 	   0,  -14
+.2byte   -2,  -15, 	  -4,  -27, 	   5,  -24, 	   0,  -14
+.2byte   -1,   -5, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,    4, 	   5,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,    1, 	   4,    4, 	  -1,   -7
+.2byte    2,   -7, 	  12,   -3, 	   4,    3, 	   0,   -8
+.2byte    2,   -6, 	  13,   -3, 	   2,    1, 	   0,   -8
+.2byte    3,   -6, 	  11,   -4, 	   5,    3, 	   0,   -8
+.2byte    2,   -8, 	  13,  -10, 	  12,   -4, 	   0,   -8
+.2byte    2,   -8, 	  14,  -10, 	  10,   -4, 	   0,   -8
+.2byte    2,   -8, 	  11,  -10, 	  13,   -4, 	  -1,   -8
+.2byte    0,  -10, 	   3,  -17, 	  11,  -13, 	  -2,   -8
+.2byte    0,  -10, 	   4,  -18, 	  10,  -12, 	  -2,   -8
+.2byte    1,  -10, 	   2,  -16, 	  11,  -14, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -17, 	  -5,  -17, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -18, 	  -5,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   3,  -16, 	  -5,  -18, 	  -1,   -8
+.2byte   -2,  -10, 	  -5,  -17, 	 -13,  -13, 	   0,   -8
+.2byte   -2,  -10, 	  -6,  -18, 	 -12,  -12, 	   0,   -8
+.2byte   -3,  -10, 	  -4,  -16, 	 -13,  -14, 	  -1,   -8
+.2byte   -4,   -8, 	 -15,  -10, 	 -14,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -16,  -10, 	 -12,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	 -13,  -10, 	 -15,   -4, 	  -1,   -8
+.2byte   -4,   -7, 	 -14,   -3, 	  -6,    3, 	  -2,   -8
+.2byte   -4,   -6, 	 -15,   -3, 	  -4,    1, 	  -2,   -8
+.2byte   -5,   -6, 	 -13,   -4, 	  -7,    3, 	  -2,   -8
+.2byte   -1,   -7, 	   1,    5, 	  -3,    5, 	  -1,   -6
+.2byte   -2,   -7, 	 -11,    2, 	 -12,    2, 	  -3,   -7
+.2byte   -2,   -8, 	 -15,   -5, 	 -14,   -7, 	   1,   -9
+.2byte   -2,  -10, 	 -12,  -11, 	 -10,  -13, 	   0,   -8
+.2byte   -1,   -9, 	  -3,  -17, 	   1,  -16, 	  -1,   -7
+.2byte    1,  -10, 	  11,  -11, 	   9,  -13, 	  -1,   -8
+.2byte    1,   -8, 	  14,   -5, 	  13,   -7, 	  -2,   -9
+.2byte    1,   -7, 	  10,    2, 	  11,    2, 	   2,   -7
+.2byte   -1,   -1, 	 -10,   -9, 	   9,   -9, 	  -1,   -4
+.2byte    1,   -2, 	   8,  -12, 	  -5,   -5, 	  -2,   -4
+.2byte    1,   -6, 	   8,  -17, 	   6,   -2, 	  -2,   -6
+.2byte    0,   -6, 	  -2,  -20, 	  13,  -13, 	  -1,   -5
+.2byte   -1,   -7, 	   9,  -18, 	 -11,  -18, 	  -1,   -5
+.2byte   -1,   -6, 	   1,  -20, 	 -14,  -13, 	   0,   -5
+.2byte   -2,   -6, 	  -9,  -17, 	  -7,   -2, 	   1,   -6
+.2byte   -2,   -2, 	  -9,  -12, 	   4,   -5, 	   1,   -4
+.2byte   -1,   -6, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -1,   -2, 	 -10,  -10, 	   9,  -10, 	  -1,   -5
+.2byte   -1,   -7, 	   1,    5, 	  -3,    5, 	  -1,   -6
+.2byte    2,   -6, 	  12,   -2, 	   4,    4, 	   0,   -7
+.2byte    2,   -3, 	   9,  -13, 	  -4,   -6, 	  -1,   -5
+.2byte    1,   -6, 	  10,    3, 	  11,    3, 	   2,   -6
+.2byte    2,   -8, 	  13,  -10, 	  12,   -4, 	   0,   -8
+.2byte    2,   -7, 	   9,  -18, 	   7,   -3, 	  -1,   -7
+.2byte    2,   -8, 	  15,   -5, 	  14,   -7, 	  -1,   -9
+.2byte    0,   -9, 	   3,  -16, 	  11,  -12, 	  -2,   -7
+.2byte    1,   -8, 	  -1,  -22, 	  14,  -15, 	   0,   -7
+.2byte    2,  -10, 	  12,  -11, 	  10,  -13, 	   0,   -8
+.2byte   -1,   -9, 	   3,  -16, 	  -5,  -16, 	  -1,   -7
+.2byte   -1,   -9, 	   9,  -20, 	 -11,  -20, 	  -1,   -7
+.2byte   -1,   -9, 	  -3,  -17, 	   1,  -16, 	  -1,   -7
+.2byte   -1,   -9, 	  -4,  -16, 	 -12,  -12, 	   1,   -7
+.2byte   -2,   -8, 	   0,  -22, 	 -15,  -15, 	  -1,   -7
+.2byte   -3,  -10, 	 -13,  -11, 	 -11,  -13, 	  -1,   -8
+.2byte   -3,   -8, 	 -14,  -10, 	 -13,   -4, 	  -1,   -8
+.2byte   -3,   -7, 	 -10,  -18, 	  -8,   -3, 	   0,   -7
+.2byte   -3,   -8, 	 -16,   -5, 	 -15,   -7, 	   0,   -9
+.2byte   -3,   -6, 	 -13,   -2, 	  -5,    4, 	  -1,   -7
+.2byte   -3,   -3, 	 -10,  -13, 	   3,   -6, 	   0,   -5
+.2byte   -2,   -6, 	 -11,    3, 	 -12,    3, 	  -3,   -6
+.2byte   -1,   -7, 	   1,    5, 	  -3,    5, 	  -1,   -6
+.2byte   -2,   -7, 	 -11,    2, 	 -12,    2, 	  -3,   -7
+.2byte   -3,   -9, 	 -16,   -6, 	 -15,   -8, 	   0,  -10
+.2byte   -2,  -10, 	 -12,  -11, 	 -10,  -13, 	   0,   -8
+.2byte   -1,   -9, 	  -3,  -17, 	   1,  -16, 	  -1,   -7
+.2byte    1,  -10, 	  11,  -11, 	   9,  -13, 	  -1,   -8
+.2byte    2,   -9, 	  15,   -6, 	  14,   -8, 	  -1,  -10
+.2byte    1,   -7, 	  10,    2, 	  11,    2, 	   2,   -7
+.2byte   -1,   -4, 	  -6,    4, 	   4,    4, 	  -1,   -6
+.2byte   -3,   -5, 	 -13,   -1, 	  -5,    5, 	  -1,   -6
+.2byte   -2,   -6, 	 -13,   -8, 	 -12,   -2, 	   0,   -6
+.2byte   -1,   -8, 	  -4,  -15, 	 -12,  -11, 	   1,   -6
+.2byte   -1,   -8, 	   3,  -15, 	  -5,  -15, 	  -1,   -6
+.2byte   -1,   -8, 	   2,  -15, 	  10,  -11, 	  -3,   -6
+.2byte    0,   -6, 	  11,   -8, 	  10,   -2, 	  -2,   -6
+.2byte    1,   -5, 	  11,   -1, 	   3,    5, 	  -1,   -6
+sAnorithAnimTable1:
+.4byte sAnorithAnims_1_1
+.4byte sAnorithAnims_1_2
+.4byte sAnorithAnims_1_3
+.4byte sAnorithAnims_1_4
+.4byte sAnorithAnims_1_5
+.4byte sAnorithAnims_1_6
+.4byte sAnorithAnims_1_7
+.4byte sAnorithAnims_1_8
+sAnorithAnimTable2:
+.4byte sAnorithAnims_2_1
+.4byte sAnorithAnims_2_2
+.4byte sAnorithAnims_2_3
+.4byte sAnorithAnims_2_4
+.4byte sAnorithAnims_2_5
+.4byte sAnorithAnims_2_6
+.4byte sAnorithAnims_2_7
+.4byte sAnorithAnims_2_8
+sAnorithAnimTable3:
+.4byte sAnorithAnims_3_1
+.4byte sAnorithAnims_3_2
+.4byte sAnorithAnims_3_3
+.4byte sAnorithAnims_3_4
+.4byte sAnorithAnims_3_5
+.4byte sAnorithAnims_3_6
+.4byte sAnorithAnims_3_7
+.4byte sAnorithAnims_3_8
+sAnorithAnimTable4:
+.4byte sAnorithAnims_4_1
+.4byte sAnorithAnims_4_2
+.4byte sAnorithAnims_4_3
+.4byte sAnorithAnims_4_4
+.4byte sAnorithAnims_4_5
+.4byte sAnorithAnims_4_6
+.4byte sAnorithAnims_4_7
+.4byte sAnorithAnims_4_8
+sAnorithAnimTable5:
+.4byte sAnorithAnims_5_1
+.4byte sAnorithAnims_5_2
+.4byte sAnorithAnims_5_3
+.4byte sAnorithAnims_5_4
+.4byte sAnorithAnims_5_5
+.4byte sAnorithAnims_5_6
+.4byte sAnorithAnims_5_7
+.4byte sAnorithAnims_5_8
+sAnorithAnimTable6:
+.4byte sAnorithAnims_6_1
+.4byte sAnorithAnims_6_1
+.4byte sAnorithAnims_6_1
+.4byte sAnorithAnims_6_1
+.4byte sAnorithAnims_6_1
+.4byte sAnorithAnims_6_1
+.4byte sAnorithAnims_6_1
+.4byte sAnorithAnims_6_1
+sAnorithAnimTable7:
+.4byte sAnorithAnims_7_1
+.4byte sAnorithAnims_7_2
+.4byte sAnorithAnims_7_3
+.4byte sAnorithAnims_7_4
+.4byte sAnorithAnims_7_5
+.4byte sAnorithAnims_7_6
+.4byte sAnorithAnims_7_7
+.4byte sAnorithAnims_7_8
+sAnorithAnimTable8:
+.4byte sAnorithAnims_8_1
+.4byte sAnorithAnims_8_2
+.4byte sAnorithAnims_8_3
+.4byte sAnorithAnims_8_4
+.4byte sAnorithAnims_8_5
+.4byte sAnorithAnims_8_6
+.4byte sAnorithAnims_8_7
+.4byte sAnorithAnims_8_8
+sAnorithAnimTable9:
+.4byte sAnorithAnims_9_1
+.4byte sAnorithAnims_9_2
+.4byte sAnorithAnims_9_3
+.4byte sAnorithAnims_9_4
+.4byte sAnorithAnims_9_5
+.4byte sAnorithAnims_9_6
+.4byte sAnorithAnims_9_7
+.4byte sAnorithAnims_9_8
+sAnorithAnimTable10:
+.4byte sAnorithAnims_10_1
+.4byte sAnorithAnims_10_2
+.4byte sAnorithAnims_10_3
+.4byte sAnorithAnims_10_4
+.4byte sAnorithAnims_10_5
+.4byte sAnorithAnims_10_6
+.4byte sAnorithAnims_10_7
+.4byte sAnorithAnims_10_8
+sAnorithAnimTable11:
+.4byte sAnorithAnims_11_1
+.4byte sAnorithAnims_11_2
+.4byte sAnorithAnims_11_3
+.4byte sAnorithAnims_11_4
+.4byte sAnorithAnims_11_5
+.4byte sAnorithAnims_11_6
+.4byte sAnorithAnims_11_7
+.4byte sAnorithAnims_11_8
+sAnorithAnimTable12:
+.4byte sAnorithAnims_12_1
+.4byte sAnorithAnims_12_2
+.4byte sAnorithAnims_12_3
+.4byte sAnorithAnims_12_4
+.4byte sAnorithAnims_12_5
+.4byte sAnorithAnims_12_6
+.4byte sAnorithAnims_12_7
+.4byte sAnorithAnims_12_8
+sAnorithAnimTable13:
+.4byte sAnorithAnims_13_1
+.4byte sAnorithAnims_13_2
+.4byte sAnorithAnims_13_3
+.4byte sAnorithAnims_13_4
+.4byte sAnorithAnims_13_5
+.4byte sAnorithAnims_13_6
+.4byte sAnorithAnims_13_7
+.4byte sAnorithAnims_13_8
+sAxAnimationsAnorith:
+.4byte sAnorithAnimTable1
+.4byte sAnorithAnimTable2
+.4byte sAnorithAnimTable3
+.4byte sAnorithAnimTable4
+.4byte sAnorithAnimTable5
+.4byte sAnorithAnimTable6
+.4byte sAnorithAnimTable7
+.4byte sAnorithAnimTable8
+.4byte sAnorithAnimTable9
+.4byte sAnorithAnimTable10
+.4byte sAnorithAnimTable11
+.4byte sAnorithAnimTable12
+.4byte sAnorithAnimTable13
+sAxSpritesAnorith:
+.4byte sAnorithSprites1
+.4byte sAnorithSprites2
+.4byte sAnorithSprites3
+.4byte sAnorithSprites4
+.4byte sAnorithSprites5
+.4byte sAnorithSprites6
+.4byte sAnorithSprites7
+.4byte sAnorithSprites8
+.4byte sAnorithSprites9
+.4byte sAnorithSprites10
+.4byte sAnorithSprites11
+.4byte sAnorithSprites12
+.4byte sAnorithSprites13
+.4byte sAnorithSprites14
+.4byte sAnorithSprites15
+.4byte sAnorithSprites16
+.4byte sAnorithSprites17
+.4byte sAnorithSprites18
+.4byte sAnorithSprites19
+.4byte sAnorithSprites20
+.4byte sAnorithSprites21
+.4byte sAnorithSprites22
+.4byte sAnorithSprites23
+.4byte sAnorithSprites24
+.4byte sAnorithSprites25
+.4byte sAnorithSprites26
+.4byte sAnorithSprites27
+.4byte sAnorithSprites28
+.4byte sAnorithSprites29
+.4byte sAnorithSprites30
+.4byte sAnorithSprites31
+.4byte sAnorithSprites32
+.4byte sAnorithSprites33
+.4byte sAnorithSprites34
+.4byte sAnorithSprites35
+.4byte sAnorithSprites36
+.4byte sAnorithSprites37
+sAxMainAnorith:
+ax_main sAxPosesAnorith, sAxAnimationsAnorith, 13, sAxSpritesAnorith, sAxPositionsAnorith

--- a/data/ax/arbok.inc
+++ b/data/ax/arbok.inc
@@ -1,0 +1,3141 @@
+.global gAxArbok
+gAxArbok:
+ax_siro sAxMainArbok
+sArbokPose1:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose2:
+ax_pose 1, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose3:
+ax_pose 2, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose4:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose5:
+ax_pose 4, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose6:
+ax_pose 5, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose7:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose8:
+ax_pose 7, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose9:
+ax_pose 8, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose10:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose11:
+ax_pose 10, 0x81e6, 0x80f7, 0x2c00
+ax_pose 11, 0x81f6, 0x00ef, 0x2c08
+ax_pose 12, 0x81e6, 0x0107, 0x2c0a
+ax_pose 13, 0x01de, 0x00f7, 0x2c0c
+ax_pose 14, 0x01de, 0x00ff, 0x2c0d
+ax_pose 15, 0x01de, 0x0107, 0x2c0e
+ax_pose 16, 0x01e6, 0x00ef, 0x2c0f
+ax_pose_terminator
+sArbokPose12:
+ax_pose 17, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose13:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose14:
+ax_pose 19, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose15:
+ax_pose 20, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose16:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose17:
+ax_pose 22, 0x81e2, 0x80f0, 0x2c00
+ax_pose 23, 0x81e2, 0x4100, 0x2c08
+ax_pose 24, 0x81f2, 0x0108, 0x2c0c
+ax_pose 25, 0x0202, 0x0100, 0x2c0e
+ax_pose 26, 0x0202, 0x00f8, 0x2c0f
+ax_pose_terminator
+sArbokPose18:
+ax_pose 27, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose19:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose20:
+ax_pose 29, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose21:
+ax_pose 30, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose22:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose23:
+ax_pose 32, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose24:
+ax_pose 33, 0x81e4, 0x80fe, 0x2c00
+ax_pose 34, 0x81e4, 0x40f6, 0x2c08
+ax_pose 35, 0x81f4, 0x00ee, 0x2c0c
+ax_pose 36, 0x01dc, 0x00fc, 0x2c0e
+ax_pose_terminator
+sArbokPose25:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose26:
+ax_pose 37, 0x01e4, 0x80ef, 0x2c00
+ax_pose 38, 0x41dc, 0x40ef, 0x2c10
+ax_pose_terminator
+sArbokPose27:
+ax_pose 39, 0x41f4, 0x80ef, 0x2c00
+ax_pose 40, 0x41ec, 0x40ef, 0x2c08
+ax_pose_terminator
+sArbokPose28:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose29:
+ax_pose 41, 0x81e3, 0x80ef, 0x2c00
+ax_pose 42, 0x81e3, 0x40ff, 0x2c08
+ax_pose 43, 0x81f3, 0x0107, 0x2c0c
+ax_pose 44, 0x01db, 0x00f6, 0x2c0e
+ax_pose 45, 0x01db, 0x00fe, 0x2c0f
+ax_pose_terminator
+sArbokPose30:
+ax_pose 46, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sArbokPose31:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose32:
+ax_pose 47, 0x81e4, 0x80ef, 0x2c00
+ax_pose 48, 0x81e4, 0x40ff, 0x2c08
+ax_pose 49, 0x01dc, 0x00f3, 0x2c0c
+ax_pose 50, 0x01dc, 0x00fb, 0x2c0d
+ax_pose_terminator
+sArbokPose33:
+ax_pose 51, 0x81e3, 0x80ff, 0x2c00
+ax_pose 52, 0x81e3, 0x40f7, 0x2c08
+ax_pose 53, 0x81f3, 0x00ef, 0x2c0c
+ax_pose 54, 0x01e6, 0x010f, 0x2c0e
+ax_pose_terminator
+sArbokPose34:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose35:
+ax_pose 55, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose36:
+ax_pose 56, 0x01e4, 0x80f3, 0x2c00
+ax_pose 57, 0x41dc, 0x0101, 0x2c10
+ax_pose_terminator
+sArbokPose37:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose38:
+ax_pose 58, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose39:
+ax_pose 59, 0x01e4, 0x80f1, 0x2c00
+ax_pose 60, 0x41dc, 0x40f1, 0x2c10
+ax_pose_terminator
+sArbokPose40:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose41:
+ax_pose 61, 0x81e5, 0x80f1, 0x2c00
+ax_pose 62, 0x01e5, 0x4101, 0x2c08
+ax_pose 63, 0x41f5, 0x0101, 0x2c0c
+ax_pose 64, 0x01fd, 0x0101, 0x2c0e
+ax_pose 65, 0x01dd, 0x00ff, 0x2c0f
+ax_pose_terminator
+sArbokPose42:
+ax_pose 66, 0x01e5, 0x80f1, 0x2c00
+ax_pose 67, 0x41dd, 0x40e9, 0x2c10
+ax_pose 68, 0x81e5, 0x00e9, 0x2c14
+ax_pose_terminator
+sArbokPose43:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose44:
+ax_pose 69, 0x81e4, 0x8100, 0x2c00
+ax_pose 70, 0x81e4, 0x40f8, 0x2c08
+ax_pose 71, 0x01dc, 0x00fc, 0x2c0c
+ax_pose 72, 0x01dc, 0x0104, 0x2c0d
+ax_pose_terminator
+sArbokPose45:
+ax_pose 73, 0x81e4, 0x80f0, 0x2c00
+ax_pose 74, 0x81e4, 0x4100, 0x2c08
+ax_pose 75, 0x81e4, 0x00e8, 0x2c0c
+ax_pose 76, 0x81f4, 0x0108, 0x2c0e
+ax_pose_terminator
+sArbokPose46:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose47:
+ax_pose 77, 0x01e4, 0x80f0, 0x2c00
+ax_pose 78, 0x41dc, 0x40f0, 0x2c10
+ax_pose_terminator
+sArbokPose48:
+ax_pose 79, 0x81e4, 0x80f0, 0x2c00
+ax_pose 80, 0x81e4, 0x4100, 0x2c08
+ax_pose 81, 0x81ec, 0x00e8, 0x2c0c
+ax_pose 82, 0x81f4, 0x0108, 0x2c0e
+ax_pose_terminator
+sArbokPose49:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose50:
+ax_pose 37, 0x01e4, 0x80ef, 0x2c00
+ax_pose 38, 0x41dc, 0x40ef, 0x2c10
+ax_pose_terminator
+sArbokPose51:
+ax_pose 39, 0x41f4, 0x80ef, 0x2c00
+ax_pose 40, 0x41ec, 0x40ef, 0x2c08
+ax_pose_terminator
+sArbokPose52:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose53:
+ax_pose 41, 0x81e3, 0x80ef, 0x2c00
+ax_pose 42, 0x81e3, 0x40ff, 0x2c08
+ax_pose 43, 0x81f3, 0x0107, 0x2c0c
+ax_pose 44, 0x01db, 0x00f6, 0x2c0e
+ax_pose 45, 0x01db, 0x00fe, 0x2c0f
+ax_pose_terminator
+sArbokPose54:
+ax_pose 46, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sArbokPose55:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose56:
+ax_pose 47, 0x81e4, 0x80ef, 0x2c00
+ax_pose 48, 0x81e4, 0x40ff, 0x2c08
+ax_pose 49, 0x01dc, 0x00f3, 0x2c0c
+ax_pose 50, 0x01dc, 0x00fb, 0x2c0d
+ax_pose_terminator
+sArbokPose57:
+ax_pose 51, 0x81e3, 0x80ff, 0x2c00
+ax_pose 52, 0x81e3, 0x40f7, 0x2c08
+ax_pose 53, 0x81f3, 0x00ef, 0x2c0c
+ax_pose 54, 0x01e6, 0x010f, 0x2c0e
+ax_pose_terminator
+sArbokPose58:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose59:
+ax_pose 55, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose60:
+ax_pose 56, 0x01e4, 0x80f3, 0x2c00
+ax_pose 57, 0x41dc, 0x0101, 0x2c10
+ax_pose_terminator
+sArbokPose61:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose62:
+ax_pose 58, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose63:
+ax_pose 59, 0x01e4, 0x80f1, 0x2c00
+ax_pose 60, 0x41dc, 0x40f1, 0x2c10
+ax_pose_terminator
+sArbokPose64:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose65:
+ax_pose 61, 0x81e5, 0x80f1, 0x2c00
+ax_pose 62, 0x01e5, 0x4101, 0x2c08
+ax_pose 63, 0x41f5, 0x0101, 0x2c0c
+ax_pose 64, 0x01fd, 0x0101, 0x2c0e
+ax_pose 65, 0x01dd, 0x00ff, 0x2c0f
+ax_pose_terminator
+sArbokPose66:
+ax_pose 66, 0x01e5, 0x80f1, 0x2c00
+ax_pose 67, 0x41dd, 0x40e9, 0x2c10
+ax_pose 68, 0x81e5, 0x00e9, 0x2c14
+ax_pose_terminator
+sArbokPose67:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose68:
+ax_pose 69, 0x81e4, 0x8100, 0x2c00
+ax_pose 70, 0x81e4, 0x40f8, 0x2c08
+ax_pose 71, 0x01dc, 0x00fc, 0x2c0c
+ax_pose 72, 0x01dc, 0x0104, 0x2c0d
+ax_pose_terminator
+sArbokPose69:
+ax_pose 73, 0x81e4, 0x80f0, 0x2c00
+ax_pose 74, 0x81e4, 0x4100, 0x2c08
+ax_pose 75, 0x81e4, 0x00e8, 0x2c0c
+ax_pose 76, 0x81f4, 0x0108, 0x2c0e
+ax_pose_terminator
+sArbokPose70:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose71:
+ax_pose 77, 0x01e4, 0x80f0, 0x2c00
+ax_pose 78, 0x41dc, 0x40f0, 0x2c10
+ax_pose_terminator
+sArbokPose72:
+ax_pose 79, 0x81e4, 0x80f0, 0x2c00
+ax_pose 80, 0x81e4, 0x4100, 0x2c08
+ax_pose 81, 0x81ec, 0x00e8, 0x2c0c
+ax_pose 82, 0x81f4, 0x0108, 0x2c0e
+ax_pose_terminator
+sArbokPose73:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose74:
+ax_pose 37, 0x01e4, 0x80ef, 0x2c00
+ax_pose 38, 0x41dc, 0x40ef, 0x2c10
+ax_pose_terminator
+sArbokPose75:
+ax_pose 39, 0x41f4, 0x80ef, 0x2c00
+ax_pose 40, 0x41ec, 0x40ef, 0x2c08
+ax_pose_terminator
+sArbokPose76:
+ax_pose 83, 0x41ec, 0x40ef, 0x2c00
+ax_pose 84, 0x41f4, 0x80ef, 0x2c04
+ax_pose_terminator
+sArbokPose77:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose78:
+ax_pose 41, 0x81e3, 0x80ef, 0x2c00
+ax_pose 42, 0x81e3, 0x40ff, 0x2c08
+ax_pose 43, 0x81f3, 0x0107, 0x2c0c
+ax_pose 44, 0x01db, 0x00f6, 0x2c0e
+ax_pose 45, 0x01db, 0x00fe, 0x2c0f
+ax_pose_terminator
+sArbokPose79:
+ax_pose 46, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sArbokPose80:
+ax_pose 85, 0x81e3, 0x80ff, 0x2c00
+ax_pose 86, 0x01eb, 0x410f, 0x2c08
+ax_pose 87, 0x01f3, 0x40ef, 0x2c0c
+ax_pose_terminator
+sArbokPose81:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose82:
+ax_pose 47, 0x81e4, 0x80ef, 0x2c00
+ax_pose 48, 0x81e4, 0x40ff, 0x2c08
+ax_pose 49, 0x01dc, 0x00f3, 0x2c0c
+ax_pose 50, 0x01dc, 0x00fb, 0x2c0d
+ax_pose_terminator
+sArbokPose83:
+ax_pose 51, 0x81e3, 0x80ff, 0x2c00
+ax_pose 52, 0x81e3, 0x40f7, 0x2c08
+ax_pose 53, 0x81f3, 0x00ef, 0x2c0c
+ax_pose 54, 0x01e6, 0x010f, 0x2c0e
+ax_pose_terminator
+sArbokPose84:
+ax_pose 88, 0x81e4, 0x80ff, 0x2c00
+ax_pose 89, 0x01e8, 0x410f, 0x2c08
+ax_pose 90, 0x01f4, 0x40ef, 0x2c0c
+ax_pose_terminator
+sArbokPose85:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose86:
+ax_pose 55, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose87:
+ax_pose 56, 0x01e4, 0x80f3, 0x2c00
+ax_pose 57, 0x41dc, 0x0101, 0x2c10
+ax_pose_terminator
+sArbokPose88:
+ax_pose 91, 0x01e5, 0x80f5, 0x2c00
+ax_pose 92, 0x41dd, 0x40fd, 0x2c10
+ax_pose 93, 0x81e5, 0x0115, 0x2c14
+ax_pose_terminator
+sArbokPose89:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose90:
+ax_pose 58, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose91:
+ax_pose 59, 0x01e4, 0x80f1, 0x2c00
+ax_pose 60, 0x41dc, 0x40f1, 0x2c10
+ax_pose_terminator
+sArbokPose92:
+ax_pose 94, 0x01e4, 0x80f1, 0x2c00
+ax_pose 95, 0x41dc, 0x40f1, 0x2c10
+ax_pose_terminator
+sArbokPose93:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose94:
+ax_pose 61, 0x81e5, 0x80f1, 0x2c00
+ax_pose 62, 0x01e5, 0x4101, 0x2c08
+ax_pose 63, 0x41f5, 0x0101, 0x2c0c
+ax_pose 64, 0x01fd, 0x0101, 0x2c0e
+ax_pose 65, 0x01dd, 0x00ff, 0x2c0f
+ax_pose_terminator
+sArbokPose95:
+ax_pose 66, 0x01e5, 0x80f1, 0x2c00
+ax_pose 67, 0x41dd, 0x40e9, 0x2c10
+ax_pose 68, 0x81e5, 0x00e9, 0x2c14
+ax_pose_terminator
+sArbokPose96:
+ax_pose 96, 0x81e5, 0x80f1, 0x2c00
+ax_pose 97, 0x01f5, 0x4101, 0x2c08
+ax_pose 98, 0x01e5, 0x40e1, 0x2c0c
+ax_pose 99, 0x41dd, 0x40e1, 0x2c10
+ax_pose_terminator
+sArbokPose97:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose98:
+ax_pose 69, 0x81e4, 0x8100, 0x2c00
+ax_pose 70, 0x81e4, 0x40f8, 0x2c08
+ax_pose 71, 0x01dc, 0x00fc, 0x2c0c
+ax_pose 72, 0x01dc, 0x0104, 0x2c0d
+ax_pose_terminator
+sArbokPose99:
+ax_pose 73, 0x81e4, 0x80f0, 0x2c00
+ax_pose 74, 0x81e4, 0x4100, 0x2c08
+ax_pose 75, 0x81e4, 0x00e8, 0x2c0c
+ax_pose 76, 0x81f4, 0x0108, 0x2c0e
+ax_pose_terminator
+sArbokPose100:
+ax_pose 100, 0x81e4, 0x40f1, 0x2c00
+ax_pose 101, 0x41ec, 0x00f9, 0x2c04
+ax_pose 102, 0x01f4, 0x40f9, 0x2c06
+ax_pose 103, 0x81f4, 0x0109, 0x2c0a
+ax_pose 104, 0x41e8, 0x00e1, 0x2c0c
+ax_pose 105, 0x01f0, 0x00e1, 0x2c0e
+ax_pose 106, 0x01f0, 0x00e9, 0x2c0f
+ax_pose_terminator
+sArbokPose101:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose102:
+ax_pose 77, 0x01e4, 0x80f0, 0x2c00
+ax_pose 78, 0x41dc, 0x40f0, 0x2c10
+ax_pose_terminator
+sArbokPose103:
+ax_pose 79, 0x81e4, 0x80f0, 0x2c00
+ax_pose 80, 0x81e4, 0x4100, 0x2c08
+ax_pose 81, 0x81ec, 0x00e8, 0x2c0c
+ax_pose 82, 0x81f4, 0x0108, 0x2c0e
+ax_pose_terminator
+sArbokPose104:
+ax_pose 107, 0x81ec, 0x00e8, 0x2c00
+ax_pose 108, 0x81f4, 0x0108, 0x2c02
+ax_pose 109, 0x81e4, 0x80f8, 0x2c04
+ax_pose 110, 0x01ec, 0x00f0, 0x2c0c
+ax_pose 111, 0x81f4, 0x00f0, 0x2c0d
+ax_pose 112, 0x01fc, 0x00e8, 0x2c0f
+ax_pose_terminator
+sArbokPose105:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose106:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose107:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose108:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose109:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose110:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose111:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose112:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose113:
+ax_pose 113, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sArbokPose114:
+ax_pose 114, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sArbokPose115:
+ax_pose 115, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose116:
+ax_pose 116, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sArbokPose117:
+ax_pose 117, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sArbokPose118:
+ax_pose 118, 0x01e4, 0x90ed, 0x2c00
+ax_pose_terminator
+sArbokPose119:
+ax_pose 119, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sArbokPose120:
+ax_pose 118, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sArbokPose121:
+ax_pose 117, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sArbokPose122:
+ax_pose 116, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sArbokPose123:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose124:
+ax_pose 1, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose125:
+ax_pose 2, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose126:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose127:
+ax_pose 4, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose128:
+ax_pose 5, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose129:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose130:
+ax_pose 7, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose131:
+ax_pose 8, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose132:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose133:
+ax_pose 10, 0x81e6, 0x80f7, 0x2c00
+ax_pose 11, 0x81f6, 0x00ef, 0x2c08
+ax_pose 12, 0x81e6, 0x0107, 0x2c0a
+ax_pose 13, 0x01de, 0x00f7, 0x2c0c
+ax_pose 14, 0x01de, 0x00ff, 0x2c0d
+ax_pose 15, 0x01de, 0x0107, 0x2c0e
+ax_pose 16, 0x01e6, 0x00ef, 0x2c0f
+ax_pose_terminator
+sArbokPose134:
+ax_pose 17, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose135:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose136:
+ax_pose 19, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose137:
+ax_pose 20, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose138:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose139:
+ax_pose 22, 0x81e2, 0x80f0, 0x2c00
+ax_pose 23, 0x81e2, 0x4100, 0x2c08
+ax_pose 24, 0x81f2, 0x0108, 0x2c0c
+ax_pose 25, 0x0202, 0x0100, 0x2c0e
+ax_pose 26, 0x0202, 0x00f8, 0x2c0f
+ax_pose_terminator
+sArbokPose140:
+ax_pose 27, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose141:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose142:
+ax_pose 29, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose143:
+ax_pose 30, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose144:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose145:
+ax_pose 32, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose146:
+ax_pose 33, 0x81e4, 0x80fe, 0x2c00
+ax_pose 34, 0x81e4, 0x40f6, 0x2c08
+ax_pose 35, 0x81f4, 0x00ee, 0x2c0c
+ax_pose 36, 0x01dc, 0x00fc, 0x2c0e
+ax_pose_terminator
+sArbokPose147:
+ax_pose 1, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose148:
+ax_pose 32, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose149:
+ax_pose 29, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose150:
+ax_pose 22, 0x81e2, 0x80f0, 0x2c00
+ax_pose 23, 0x81e2, 0x4100, 0x2c08
+ax_pose 24, 0x81f2, 0x0108, 0x2c0c
+ax_pose 25, 0x0202, 0x0100, 0x2c0e
+ax_pose 26, 0x0202, 0x00f8, 0x2c0f
+ax_pose_terminator
+sArbokPose151:
+ax_pose 19, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose152:
+ax_pose 10, 0x81e6, 0x80f7, 0x2c00
+ax_pose 11, 0x81f6, 0x00ef, 0x2c08
+ax_pose 12, 0x81e6, 0x0107, 0x2c0a
+ax_pose 13, 0x01de, 0x00f7, 0x2c0c
+ax_pose 14, 0x01de, 0x00ff, 0x2c0d
+ax_pose 15, 0x01de, 0x0107, 0x2c0e
+ax_pose 16, 0x01e6, 0x00ef, 0x2c0f
+ax_pose_terminator
+sArbokPose153:
+ax_pose 7, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose154:
+ax_pose 4, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose155:
+ax_pose 2, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose156:
+ax_pose 5, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose157:
+ax_pose 8, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose158:
+ax_pose 17, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sArbokPose159:
+ax_pose 20, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose160:
+ax_pose 27, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose161:
+ax_pose 30, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose162:
+ax_pose 33, 0x81e4, 0x80fe, 0x2c00
+ax_pose 34, 0x81e4, 0x40f6, 0x2c08
+ax_pose 35, 0x81f4, 0x00ee, 0x2c0c
+ax_pose 36, 0x01dc, 0x00fc, 0x2c0e
+ax_pose_terminator
+sArbokPose163:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose164:
+ax_pose 1, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose165:
+ax_pose 2, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose166:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose167:
+ax_pose 4, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose168:
+ax_pose 5, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose169:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose170:
+ax_pose 7, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose171:
+ax_pose 8, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose172:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose173:
+ax_pose 10, 0x81e6, 0x80f7, 0x2c00
+ax_pose 11, 0x81f6, 0x00ef, 0x2c08
+ax_pose 12, 0x81e6, 0x0107, 0x2c0a
+ax_pose 13, 0x01de, 0x00f7, 0x2c0c
+ax_pose 14, 0x01de, 0x00ff, 0x2c0d
+ax_pose 15, 0x01de, 0x0107, 0x2c0e
+ax_pose 16, 0x01e6, 0x00ef, 0x2c0f
+ax_pose_terminator
+sArbokPose174:
+ax_pose 17, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose175:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose176:
+ax_pose 19, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose177:
+ax_pose 20, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose178:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose179:
+ax_pose 22, 0x81e2, 0x80f0, 0x2c00
+ax_pose 23, 0x81e2, 0x4100, 0x2c08
+ax_pose 24, 0x81f2, 0x0108, 0x2c0c
+ax_pose 25, 0x0202, 0x0100, 0x2c0e
+ax_pose 26, 0x0202, 0x00f8, 0x2c0f
+ax_pose_terminator
+sArbokPose180:
+ax_pose 27, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose181:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose182:
+ax_pose 29, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose183:
+ax_pose 30, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose184:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose185:
+ax_pose 32, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose186:
+ax_pose 33, 0x81e4, 0x80fe, 0x2c00
+ax_pose 34, 0x81e4, 0x40f6, 0x2c08
+ax_pose 35, 0x81f4, 0x00ee, 0x2c0c
+ax_pose 36, 0x01dc, 0x00fc, 0x2c0e
+ax_pose_terminator
+sArbokPose187:
+ax_pose 1, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose188:
+ax_pose 32, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose189:
+ax_pose 29, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose190:
+ax_pose 22, 0x81e2, 0x80f0, 0x2c00
+ax_pose 23, 0x81e2, 0x4100, 0x2c08
+ax_pose 24, 0x81f2, 0x0108, 0x2c0c
+ax_pose 25, 0x0202, 0x0100, 0x2c0e
+ax_pose 26, 0x0202, 0x00f8, 0x2c0f
+ax_pose_terminator
+sArbokPose191:
+ax_pose 19, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose192:
+ax_pose 10, 0x81e6, 0x80f7, 0x2c00
+ax_pose 11, 0x81f6, 0x00ef, 0x2c08
+ax_pose 12, 0x81e6, 0x0107, 0x2c0a
+ax_pose 13, 0x01de, 0x00f7, 0x2c0c
+ax_pose 14, 0x01de, 0x00ff, 0x2c0d
+ax_pose 15, 0x01de, 0x0107, 0x2c0e
+ax_pose 16, 0x01e6, 0x00ef, 0x2c0f
+ax_pose_terminator
+sArbokPose193:
+ax_pose 7, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose194:
+ax_pose 4, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose195:
+ax_pose 0, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose196:
+ax_pose 31, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose197:
+ax_pose 28, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose198:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose199:
+ax_pose 18, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose200:
+ax_pose 9, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose201:
+ax_pose 6, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sArbokPose202:
+ax_pose 3, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+.align 2
+sArbokAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 1, 0, 2, 0, 2,
+ax_anim 6, 0, 0, 0, 2, 0, 2,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, -1,
+ax_anim_terminator
+sArbokAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 4, 2, 2, 2, 2,
+ax_anim 6, 0, 3, 2, 2, 2, 2,
+ax_anim 6, 0, 5, 1, 1, 1, 1,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 7, 2, 0, 2, 0,
+ax_anim 6, 0, 6, 3, 0, 3, 0,
+ax_anim 6, 0, 8, 2, 0, 2, 0,
+ax_anim 6, 0, 8, 1, 0, 1, 0,
+ax_anim_terminator
+sArbokAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 10, 2, -2, 2, -2,
+ax_anim 6, 0, 9, 3, -3, 3, -3,
+ax_anim 6, 0, 11, 2, -2, 2, -2,
+ax_anim 6, 0, 11, 1, -1, 1, -1,
+ax_anim_terminator
+sArbokAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, -1,
+ax_anim 8, 0, 13, 0, -3, 0, -3,
+ax_anim 6, 0, 12, 0, -2, 0, -2,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 1,
+ax_anim_terminator
+sArbokAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 16, -2, -2, -2, -2,
+ax_anim 6, 0, 15, -3, -3, -3, -3,
+ax_anim 6, 0, 17, -2, -2, -2, -2,
+ax_anim 6, 0, 17, -1, -1, -1, -1,
+ax_anim_terminator
+sArbokAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, 0, -1, 0,
+ax_anim 8, 0, 19, -2, 0, -2, 0,
+ax_anim 6, 0, 18, -3, 0, -3, 0,
+ax_anim 6, 0, 20, -2, 0, -2, 0,
+ax_anim 6, 0, 20, -1, 0, -1, 0,
+ax_anim_terminator
+sArbokAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 22, -2, 2, -2, 2,
+ax_anim 6, 0, 21, -3, 2, -3, 2,
+ax_anim 6, 0, 23, -3, 2, -3, 2,
+ax_anim 6, 0, 23, 0, -1, 0, -1,
+ax_anim_terminator
+.align 2
+sArbokAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 6, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sArbokAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 6, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 2, 28, 2, 3, 2, 3,
+ax_anim 1, 0, 29, 10, 13, 10, 13,
+ax_anim 2, 0, 29, 17, 21, 17, 21,
+ax_anim 2, 1, 29, 18, 20, 18, 20,
+ax_anim 2, 0, 29, 17, 21, 17, 21,
+ax_anim 2, 0, 29, 18, 20, 18, 20,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sArbokAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 6, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 2, 31, 2, 0, 2, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 17, 0, 17, 0,
+ax_anim 2, 1, 32, 17, -1, 17, -1,
+ax_anim 2, 0, 32, 17, 0, 17, 0,
+ax_anim 2, 0, 32, 17, -1, 17, -1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sArbokAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 6, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 2, -2, 2, -2,
+ax_anim 1, 0, 35, 9, -11, 9, -11,
+ax_anim 2, 0, 35, 13, -15, 13, -15,
+ax_anim 2, 1, 35, 12, -16, 12, -16,
+ax_anim 2, 0, 35, 13, -15, 13, -15,
+ax_anim 2, 0, 35, 12, -16, 12, -16,
+ax_anim 2, 0, 33, 6, 0, 6, 0,
+ax_anim_terminator
+sArbokAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 2, 2, 37, 0, -2, 0, -2,
+ax_anim 1, 0, 38, 0, -9, 0, -9,
+ax_anim 2, 0, 38, 0, -12, 0, -12,
+ax_anim 2, 1, 38, 1, -12, 1, -12,
+ax_anim 2, 0, 38, 0, -12, 0, -12,
+ax_anim 2, 0, 38, 1, -12, 1, -12,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 6, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 2, 40, -2, -2, -2, -2,
+ax_anim 1, 0, 41, -9, -11, -9, -11,
+ax_anim 2, 0, 41, -12, -14, -12, -14,
+ax_anim 2, 1, 41, -11, -15, -11, -15,
+ax_anim 2, 0, 41, -12, -14, -12, -14,
+ax_anim 2, 0, 41, -11, -15, -11, -15,
+ax_anim 2, 0, 39, -6, 0, -6, 0,
+ax_anim_terminator
+sArbokAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 6, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 2, 43, -2, 0, -2, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 1, 44, -17, -1, -17, -1,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 44, -17, -1, -17, -1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sArbokAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 6, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 2, 46, -2, 2, -2, 2,
+ax_anim 1, 0, 47, -10, 11, -10, 11,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 2, 1, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 2, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sArbokAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 49, 0, 2, 0, 2,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sArbokAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 6, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 2, 52, 2, 3, 2, 3,
+ax_anim 1, 0, 53, 10, 13, 10, 13,
+ax_anim 2, 0, 53, 17, 21, 17, 21,
+ax_anim 2, 1, 53, 18, 20, 18, 20,
+ax_anim 2, 0, 53, 17, 21, 17, 21,
+ax_anim 2, 0, 53, 18, 20, 18, 20,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sArbokAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 6, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 2, 55, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 17, 0, 17, 0,
+ax_anim 2, 1, 56, 17, -1, 17, -1,
+ax_anim 2, 0, 56, 17, 0, 17, 0,
+ax_anim 2, 0, 56, 17, -1, 17, -1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sArbokAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 6, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 2, 58, 2, -2, 2, -2,
+ax_anim 1, 0, 59, 9, -11, 9, -11,
+ax_anim 2, 0, 59, 13, -15, 13, -15,
+ax_anim 2, 1, 59, 12, -16, 12, -16,
+ax_anim 2, 0, 59, 13, -15, 13, -15,
+ax_anim 2, 0, 59, 12, -16, 12, -16,
+ax_anim 2, 0, 57, 6, 0, 6, 0,
+ax_anim_terminator
+sArbokAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 6, 0, 61, 0, 2, 0, 2,
+ax_anim 2, 2, 61, 0, -2, 0, -2,
+ax_anim 1, 0, 62, 0, -9, 0, -9,
+ax_anim 2, 0, 62, 0, -12, 0, -12,
+ax_anim 2, 1, 62, 1, -12, 1, -12,
+ax_anim 2, 0, 62, 0, -12, 0, -12,
+ax_anim 2, 0, 62, 1, -12, 1, -12,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 6, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 2, 64, -2, -2, -2, -2,
+ax_anim 1, 0, 65, -9, -11, -9, -11,
+ax_anim 2, 0, 65, -12, -14, -12, -14,
+ax_anim 2, 1, 65, -11, -15, -11, -15,
+ax_anim 2, 0, 65, -12, -14, -12, -14,
+ax_anim 2, 0, 65, -11, -15, -11, -15,
+ax_anim 2, 0, 63, -6, 0, -6, 0,
+ax_anim_terminator
+sArbokAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 6, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 2, 67, -2, 0, -2, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 68, -17, 0, -17, 0,
+ax_anim 2, 1, 68, -17, -1, -17, -1,
+ax_anim 2, 0, 68, -17, 0, -17, 0,
+ax_anim 2, 0, 68, -17, -1, -17, -1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sArbokAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 6, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 2, 70, -2, 2, -2, 2,
+ax_anim 1, 0, 71, -10, 11, -10, 11,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 2, 1, 71, -18, 18, -18, 18,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 2, 0, 71, -18, 18, -18, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sArbokAnims_4_1:
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 6, 0, 73, 0, -3, 0, -3,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, -1, 4, -1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, -1, 4, -1, 4,
+ax_anim 2, 1, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, -1, 4, -1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, -1, 4, -1, 4,
+ax_anim 4, 0, 74, 0, 2, 0, 4,
+ax_anim_terminator
+sArbokAnims_4_2:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 6, 0, 77, -3, -3, -3, -3,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 5, 3, 5, 3,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 5, 3, 5, 3,
+ax_anim 2, 1, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 5, 3, 5, 3,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 5, 3, 5, 3,
+ax_anim 4, 0, 78, 2, 2, 2, 2,
+ax_anim_terminator
+sArbokAnims_4_3:
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 6, 0, 81, -3, 0, -3, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 1, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 4, 0, 82, 2, 0, 2, 0,
+ax_anim_terminator
+sArbokAnims_4_4:
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 6, 0, 85, -3, 3, -3, 3,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 2, 1, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 4, 0, 86, 2, -2, 2, -2,
+ax_anim_terminator
+sArbokAnims_4_5:
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim 6, 0, 89, 0, 3, 0, 3,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 1, -4, 1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 1, -4, 1, -4,
+ax_anim 2, 1, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 1, -4, 1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 1, -4, 1, -4,
+ax_anim 4, 0, 90, 0, -2, 0, -2,
+ax_anim_terminator
+sArbokAnims_4_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 6, 0, 93, 3, 3, 3, 3,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 2, 1, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 4, 0, 94, -2, -2, -2, -2,
+ax_anim_terminator
+sArbokAnims_4_7:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 6, 0, 97, 3, 0, 3, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 1, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 4, 0, 98, -2, 0, -2, 0,
+ax_anim_terminator
+sArbokAnims_4_8:
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 6, 0, 101, 3, -3, 3, -3,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 1, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 4, 0, 102, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sArbokAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArbokAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArbokAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sArbokAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sArbokAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sArbokAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sArbokAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sArbokAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sArbokAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sArbokAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sArbokAnims_8_1:
+ax_anim 32, 0, 122, 0, 0, 0, 0,
+ax_anim 14, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_8_2:
+ax_anim 32, 0, 125, 0, 0, 0, 0,
+ax_anim 14, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_8_3:
+ax_anim 32, 0, 128, 0, 0, 0, 0,
+ax_anim 14, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_8_4:
+ax_anim 32, 0, 131, 0, 0, 0, 0,
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_8_5:
+ax_anim 32, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_8_6:
+ax_anim 32, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_8_7:
+ax_anim 32, 0, 140, 0, 0, 0, 0,
+ax_anim 14, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_8_8:
+ax_anim 32, 0, 143, 0, 0, 0, 0,
+ax_anim 14, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArbokAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 16, 7, 16,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 16, -7, 16,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 24, 9, 24, 9,
+ax_anim 3, 0, 149, 20, 17, 20, 17,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 2, 12, 2, 12,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -8, 11, -8,
+ax_anim 2, 0, 147, 16, -4, 16, -4,
+ax_anim 3, 0, 148, 16, 1, 16, 1,
+ax_anim 2, 3, 149, 17, 4, 17, 4,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 3, 7, 3, 7,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -20, 11, -20,
+ax_anim 3, 0, 147, 17, -22, 17, -22,
+ax_anim 2, 3, 148, 18, -12, 18, -12,
+ax_anim 2, 0, 149, 16, -6, 16, -6,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -10, -8, -10,
+ax_anim 2, 0, 153, -7, -18, -7, -18,
+ax_anim 3, 0, 146, 0, -22, 0, -22,
+ax_anim 2, 3, 147, 7, -18, 7, -18,
+ax_anim 2, 0, 148, 8, -8, 8, -8,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -11, -20, -11, -20,
+ax_anim 3, 0, 153, -16, -20, -16, -20,
+ax_anim 2, 3, 152, -18, -12, -18, -12,
+ax_anim 2, 0, 151, -16, -6, -16, -6,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -8, -11, -8,
+ax_anim 2, 0, 153, -16, -4, -16, -4,
+ax_anim 3, 0, 152, -16, 1, -16, 1,
+ax_anim 2, 3, 151, -17, 5, -17, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -9, 0, -9, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -24, 9, -24, 9,
+ax_anim 3, 0, 151, -20, 19, -20, 19,
+ax_anim 2, 3, 150, -11, 21, -11, 21,
+ax_anim 2, 0, 149, -2, 12, -2, 12,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArbokAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArbokAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -27, 0, 0,
+ax_anim 3, 0, 163, 0, -25, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, -1, -24, 0, 0,
+ax_anim 3, 0, 166, 0, -23, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -23, 0, 0,
+ax_anim 3, 0, 169, 0, -22, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 172, 0, -21, 0, 0,
+ax_anim 2, 0, 172, 0, -17, 0, 0,
+ax_anim 1, 0, 172, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 2, 0, 175, 0, -17, 0, 0,
+ax_anim 1, 0, 175, 0, -11, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -21, 0, 0,
+ax_anim 2, 0, 178, 0, -17, 0, 0,
+ax_anim 1, 0, 178, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 1, -24, 0, 0,
+ax_anim 3, 0, 184, 0, -23, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArbokAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArbokAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sArbokGfx1:
+.incbin "baserom.gba", 0x60CF54, 0x200
+sArbokSprites1:
+ax_sprite sArbokGfx1, 0x200
+ax_sprite_terminator
+sArbokGfx2:
+.incbin "baserom.gba", 0x60D164, 0x200
+sArbokSprites2:
+ax_sprite sArbokGfx2, 0x200
+ax_sprite_terminator
+sArbokGfx3:
+.incbin "baserom.gba", 0x60D374, 0x200
+sArbokSprites3:
+ax_sprite sArbokGfx3, 0x200
+ax_sprite_terminator
+sArbokGfx4:
+.incbin "baserom.gba", 0x60D584, 0x200
+sArbokSprites4:
+ax_sprite sArbokGfx4, 0x200
+ax_sprite_terminator
+sArbokGfx5:
+.incbin "baserom.gba", 0x60D794, 0x200
+sArbokSprites5:
+ax_sprite sArbokGfx5, 0x200
+ax_sprite_terminator
+sArbokGfx6:
+.incbin "baserom.gba", 0x60D9A4, 0x200
+sArbokSprites6:
+ax_sprite sArbokGfx6, 0x200
+ax_sprite_terminator
+sArbokGfx7:
+.incbin "baserom.gba", 0x60DBB4, 0x200
+sArbokSprites7:
+ax_sprite sArbokGfx7, 0x200
+ax_sprite_terminator
+sArbokGfx8:
+.incbin "baserom.gba", 0x60DDC4, 0x200
+sArbokSprites8:
+ax_sprite sArbokGfx8, 0x200
+ax_sprite_terminator
+sArbokGfx9:
+.incbin "baserom.gba", 0x60DFD4, 0x200
+sArbokSprites9:
+ax_sprite sArbokGfx9, 0x200
+ax_sprite_terminator
+sArbokGfx10:
+.incbin "baserom.gba", 0x60E1E4, 0x200
+sArbokSprites10:
+ax_sprite sArbokGfx10, 0x200
+ax_sprite_terminator
+sArbokGfx11:
+.incbin "baserom.gba", 0x60E3F4, 0x100
+sArbokSprites11:
+ax_sprite sArbokGfx11, 0x100
+ax_sprite_terminator
+sArbokGfx12:
+.incbin "baserom.gba", 0x60E504, 0x40
+sArbokSprites12:
+ax_sprite sArbokGfx12, 0x40
+ax_sprite_terminator
+sArbokGfx13:
+.incbin "baserom.gba", 0x60E554, 0x40
+sArbokSprites13:
+ax_sprite sArbokGfx13, 0x40
+ax_sprite_terminator
+sArbokGfx14:
+.incbin "baserom.gba", 0x60E5A4, 0x20
+sArbokSprites14:
+ax_sprite sArbokGfx14, 0x20
+ax_sprite_terminator
+sArbokGfx15:
+.incbin "baserom.gba", 0x60E5D4, 0x20
+sArbokSprites15:
+ax_sprite sArbokGfx15, 0x20
+ax_sprite_terminator
+sArbokGfx16:
+.incbin "baserom.gba", 0x60E604, 0x20
+sArbokSprites16:
+ax_sprite sArbokGfx16, 0x20
+ax_sprite_terminator
+sArbokGfx17:
+.incbin "baserom.gba", 0x60E634, 0x20
+sArbokSprites17:
+ax_sprite sArbokGfx17, 0x20
+ax_sprite_terminator
+sArbokGfx18:
+.incbin "baserom.gba", 0x60E664, 0x200
+sArbokSprites18:
+ax_sprite sArbokGfx18, 0x200
+ax_sprite_terminator
+sArbokGfx19:
+.incbin "baserom.gba", 0x60E874, 0x200
+sArbokSprites19:
+ax_sprite sArbokGfx19, 0x200
+ax_sprite_terminator
+sArbokGfx20:
+.incbin "baserom.gba", 0x60EA84, 0x200
+sArbokSprites20:
+ax_sprite sArbokGfx20, 0x200
+ax_sprite_terminator
+sArbokGfx21:
+.incbin "baserom.gba", 0x60EC94, 0x200
+sArbokSprites21:
+ax_sprite sArbokGfx21, 0x200
+ax_sprite_terminator
+sArbokGfx22:
+.incbin "baserom.gba", 0x60EEA4, 0x200
+sArbokSprites22:
+ax_sprite sArbokGfx22, 0x200
+ax_sprite_terminator
+sArbokGfx23:
+.incbin "baserom.gba", 0x60F0B4, 0x100
+sArbokSprites23:
+ax_sprite sArbokGfx23, 0x100
+ax_sprite_terminator
+sArbokGfx24:
+.incbin "baserom.gba", 0x60F1C4, 0x80
+sArbokSprites24:
+ax_sprite sArbokGfx24, 0x80
+ax_sprite_terminator
+sArbokGfx25:
+.incbin "baserom.gba", 0x60F254, 0x40
+sArbokSprites25:
+ax_sprite sArbokGfx25, 0x40
+ax_sprite_terminator
+sArbokGfx26:
+.incbin "baserom.gba", 0x60F2A4, 0x20
+sArbokSprites26:
+ax_sprite sArbokGfx26, 0x20
+ax_sprite_terminator
+sArbokGfx27:
+.incbin "baserom.gba", 0x60F2D4, 0x20
+sArbokSprites27:
+ax_sprite sArbokGfx27, 0x20
+ax_sprite_terminator
+sArbokGfx28:
+.incbin "baserom.gba", 0x60F304, 0x200
+sArbokSprites28:
+ax_sprite sArbokGfx28, 0x200
+ax_sprite_terminator
+sArbokGfx29:
+.incbin "baserom.gba", 0x60F514, 0x200
+sArbokSprites29:
+ax_sprite sArbokGfx29, 0x200
+ax_sprite_terminator
+sArbokGfx30:
+.incbin "baserom.gba", 0x60F724, 0x200
+sArbokSprites30:
+ax_sprite sArbokGfx30, 0x200
+ax_sprite_terminator
+sArbokGfx31:
+.incbin "baserom.gba", 0x60F934, 0x200
+sArbokSprites31:
+ax_sprite sArbokGfx31, 0x200
+ax_sprite_terminator
+sArbokGfx32:
+.incbin "baserom.gba", 0x60FB44, 0x200
+sArbokSprites32:
+ax_sprite sArbokGfx32, 0x200
+ax_sprite_terminator
+sArbokGfx33:
+.incbin "baserom.gba", 0x60FD54, 0x200
+sArbokSprites33:
+ax_sprite sArbokGfx33, 0x200
+ax_sprite_terminator
+sArbokGfx34:
+.incbin "baserom.gba", 0x60FF64, 0x100
+sArbokSprites34:
+ax_sprite sArbokGfx34, 0x100
+ax_sprite_terminator
+sArbokGfx35:
+.incbin "baserom.gba", 0x610074, 0x80
+sArbokSprites35:
+ax_sprite sArbokGfx35, 0x80
+ax_sprite_terminator
+sArbokGfx36:
+.incbin "baserom.gba", 0x610104, 0x40
+sArbokSprites36:
+ax_sprite sArbokGfx36, 0x40
+ax_sprite_terminator
+sArbokGfx37:
+.incbin "baserom.gba", 0x610154, 0x20
+sArbokSprites37:
+ax_sprite sArbokGfx37, 0x20
+ax_sprite_terminator
+sArbokGfx38:
+.incbin "baserom.gba", 0x610184, 0x200
+sArbokSprites38:
+ax_sprite sArbokGfx38, 0x200
+ax_sprite_terminator
+sArbokGfx39:
+.incbin "baserom.gba", 0x610394, 0x60
+sArbokSprites39:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx39, 0x60
+ax_sprite_terminator
+sArbokGfx40:
+.incbin "baserom.gba", 0x61040C, 0x100
+sArbokSprites40:
+ax_sprite sArbokGfx40, 0x100
+ax_sprite_terminator
+sArbokGfx41:
+.incbin "baserom.gba", 0x61051C, 0x80
+sArbokSprites41:
+ax_sprite sArbokGfx41, 0x80
+ax_sprite_terminator
+sArbokGfx42:
+.incbin "baserom.gba", 0x6105AC, 0x100
+sArbokSprites42:
+ax_sprite sArbokGfx42, 0x100
+ax_sprite_terminator
+sArbokGfx43:
+.incbin "baserom.gba", 0x6106BC, 0x80
+sArbokSprites43:
+ax_sprite sArbokGfx43, 0x80
+ax_sprite_terminator
+sArbokGfx44:
+.incbin "baserom.gba", 0x61074C, 0x40
+sArbokSprites44:
+ax_sprite sArbokGfx44, 0x40
+ax_sprite_terminator
+sArbokGfx45:
+.incbin "baserom.gba", 0x61079C, 0x20
+sArbokSprites45:
+ax_sprite sArbokGfx45, 0x20
+ax_sprite_terminator
+sArbokGfx46:
+.incbin "baserom.gba", 0x6107CC, 0x20
+sArbokSprites46:
+ax_sprite sArbokGfx46, 0x20
+ax_sprite_terminator
+sArbokGfx47:
+.incbin "baserom.gba", 0x6107FC, 0x60
+sArbokGfx47_1:
+.incbin "baserom.gba", 0x61085C, 0x140
+sArbokSprites47:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx47_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArbokGfx48:
+.incbin "baserom.gba", 0x6109CC, 0x100
+sArbokSprites48:
+ax_sprite sArbokGfx48, 0x100
+ax_sprite_terminator
+sArbokGfx49:
+.incbin "baserom.gba", 0x610ADC, 0x80
+sArbokSprites49:
+ax_sprite sArbokGfx49, 0x80
+ax_sprite_terminator
+sArbokGfx50:
+.incbin "baserom.gba", 0x610B6C, 0x20
+sArbokSprites50:
+ax_sprite sArbokGfx50, 0x20
+ax_sprite_terminator
+sArbokGfx51:
+.incbin "baserom.gba", 0x610B9C, 0x20
+sArbokSprites51:
+ax_sprite sArbokGfx51, 0x20
+ax_sprite_terminator
+sArbokGfx52:
+.incbin "baserom.gba", 0x610BCC, 0x100
+sArbokSprites52:
+ax_sprite sArbokGfx52, 0x100
+ax_sprite_terminator
+sArbokGfx53:
+.incbin "baserom.gba", 0x610CDC, 0x80
+sArbokSprites53:
+ax_sprite sArbokGfx53, 0x80
+ax_sprite_terminator
+sArbokGfx54:
+.incbin "baserom.gba", 0x610D6C, 0x40
+sArbokSprites54:
+ax_sprite sArbokGfx54, 0x40
+ax_sprite_terminator
+sArbokGfx55:
+.incbin "baserom.gba", 0x610DBC, 0x20
+sArbokSprites55:
+ax_sprite sArbokGfx55, 0x20
+ax_sprite_terminator
+sArbokGfx56:
+.incbin "baserom.gba", 0x610DEC, 0x60
+sArbokGfx56_1:
+.incbin "baserom.gba", 0x610E4C, 0x180
+sArbokSprites56:
+ax_sprite sArbokGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx56_1, 0x180
+ax_sprite_terminator
+sArbokGfx57:
+.incbin "baserom.gba", 0x610FEC, 0x1E0
+sArbokSprites57:
+ax_sprite sArbokGfx57, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArbokGfx58:
+.incbin "baserom.gba", 0x6111E4, 0x40
+sArbokSprites58:
+ax_sprite sArbokGfx58, 0x40
+ax_sprite_terminator
+sArbokGfx59:
+.incbin "baserom.gba", 0x611234, 0x1E0
+sArbokSprites59:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx59, 0x1e0
+ax_sprite_terminator
+sArbokGfx60:
+.incbin "baserom.gba", 0x61142C, 0x200
+sArbokSprites60:
+ax_sprite sArbokGfx60, 0x200
+ax_sprite_terminator
+sArbokGfx61:
+.incbin "baserom.gba", 0x61163C, 0x60
+sArbokSprites61:
+ax_sprite sArbokGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArbokGfx62:
+.incbin "baserom.gba", 0x6116B4, 0xE0
+sArbokSprites62:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx62, 0xe0
+ax_sprite_terminator
+sArbokGfx63:
+.incbin "baserom.gba", 0x6117AC, 0x80
+sArbokSprites63:
+ax_sprite sArbokGfx63, 0x80
+ax_sprite_terminator
+sArbokGfx64:
+.incbin "baserom.gba", 0x61183C, 0x40
+sArbokSprites64:
+ax_sprite sArbokGfx64, 0x40
+ax_sprite_terminator
+sArbokGfx65:
+.incbin "baserom.gba", 0x61188C, 0x20
+sArbokSprites65:
+ax_sprite sArbokGfx65, 0x20
+ax_sprite_terminator
+sArbokGfx66:
+.incbin "baserom.gba", 0x6118BC, 0x20
+sArbokSprites66:
+ax_sprite sArbokGfx66, 0x20
+ax_sprite_terminator
+sArbokGfx67:
+.incbin "baserom.gba", 0x6118EC, 0x60
+sArbokGfx67_1:
+.incbin "baserom.gba", 0x61194C, 0x160
+sArbokSprites67:
+ax_sprite sArbokGfx67, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx67_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArbokGfx68:
+.incbin "baserom.gba", 0x611AD4, 0x80
+sArbokSprites68:
+ax_sprite sArbokGfx68, 0x80
+ax_sprite_terminator
+sArbokGfx69:
+.incbin "baserom.gba", 0x611B64, 0x40
+sArbokSprites69:
+ax_sprite sArbokGfx69, 0x40
+ax_sprite_terminator
+sArbokGfx70:
+.incbin "baserom.gba", 0x611BB4, 0x100
+sArbokSprites70:
+ax_sprite sArbokGfx70, 0x100
+ax_sprite_terminator
+sArbokGfx71:
+.incbin "baserom.gba", 0x611CC4, 0x80
+sArbokSprites71:
+ax_sprite sArbokGfx71, 0x80
+ax_sprite_terminator
+sArbokGfx72:
+.incbin "baserom.gba", 0x611D54, 0x20
+sArbokSprites72:
+ax_sprite sArbokGfx72, 0x20
+ax_sprite_terminator
+sArbokGfx73:
+.incbin "baserom.gba", 0x611D84, 0x20
+sArbokSprites73:
+ax_sprite sArbokGfx73, 0x20
+ax_sprite_terminator
+sArbokGfx74:
+.incbin "baserom.gba", 0x611DB4, 0x100
+sArbokSprites74:
+ax_sprite sArbokGfx74, 0x100
+ax_sprite_terminator
+sArbokGfx75:
+.incbin "baserom.gba", 0x611EC4, 0x60
+sArbokSprites75:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx75, 0x60
+ax_sprite_terminator
+sArbokGfx76:
+.incbin "baserom.gba", 0x611F3C, 0x40
+sArbokSprites76:
+ax_sprite sArbokGfx76, 0x40
+ax_sprite_terminator
+sArbokGfx77:
+.incbin "baserom.gba", 0x611F8C, 0x40
+sArbokSprites77:
+ax_sprite sArbokGfx77, 0x40
+ax_sprite_terminator
+sArbokGfx78:
+.incbin "baserom.gba", 0x611FDC, 0x160
+sArbokGfx78_1:
+.incbin "baserom.gba", 0x61213C, 0x60
+sArbokSprites78:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx78, 0x160
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx78_1, 0x60
+ax_sprite_terminator
+sArbokGfx79:
+.incbin "baserom.gba", 0x6121C4, 0x60
+sArbokSprites79:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx79, 0x60
+ax_sprite_terminator
+sArbokGfx80:
+.incbin "baserom.gba", 0x61223C, 0x100
+sArbokSprites80:
+ax_sprite sArbokGfx80, 0x100
+ax_sprite_terminator
+sArbokGfx81:
+.incbin "baserom.gba", 0x61234C, 0x60
+sArbokSprites81:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx81, 0x60
+ax_sprite_terminator
+sArbokGfx82:
+.incbin "baserom.gba", 0x6123C4, 0x40
+sArbokSprites82:
+ax_sprite sArbokGfx82, 0x40
+ax_sprite_terminator
+sArbokGfx83:
+.incbin "baserom.gba", 0x612414, 0x40
+sArbokSprites83:
+ax_sprite sArbokGfx83, 0x40
+ax_sprite_terminator
+sArbokGfx84:
+.incbin "baserom.gba", 0x612464, 0x80
+sArbokSprites84:
+ax_sprite sArbokGfx84, 0x80
+ax_sprite_terminator
+sArbokGfx85:
+.incbin "baserom.gba", 0x6124F4, 0x100
+sArbokSprites85:
+ax_sprite sArbokGfx85, 0x100
+ax_sprite_terminator
+sArbokGfx86:
+.incbin "baserom.gba", 0x612604, 0xE0
+sArbokSprites86:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx86, 0xe0
+ax_sprite_terminator
+sArbokGfx87:
+.incbin "baserom.gba", 0x6126FC, 0x80
+sArbokSprites87:
+ax_sprite sArbokGfx87, 0x80
+ax_sprite_terminator
+sArbokGfx88:
+.incbin "baserom.gba", 0x61278C, 0x80
+sArbokSprites88:
+ax_sprite sArbokGfx88, 0x80
+ax_sprite_terminator
+sArbokGfx89:
+.incbin "baserom.gba", 0x61281C, 0xE0
+sArbokSprites89:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx89, 0xe0
+ax_sprite_terminator
+sArbokGfx90:
+.incbin "baserom.gba", 0x612914, 0x80
+sArbokSprites90:
+ax_sprite sArbokGfx90, 0x80
+ax_sprite_terminator
+sArbokGfx91:
+.incbin "baserom.gba", 0x6129A4, 0x80
+sArbokSprites91:
+ax_sprite sArbokGfx91, 0x80
+ax_sprite_terminator
+sArbokGfx92:
+.incbin "baserom.gba", 0x612A34, 0x60
+sArbokGfx92_1:
+.incbin "baserom.gba", 0x612A94, 0xC0
+sArbokGfx92_2:
+.incbin "baserom.gba", 0x612B54, 0x40
+sArbokSprites92:
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx92, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx92_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArbokGfx92_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sArbokGfx93:
+.incbin "baserom.gba", 0x612BD4, 0x80
+sArbokSprites93:
+ax_sprite sArbokGfx93, 0x80
+ax_sprite_terminator
+sArbokGfx94:
+.incbin "baserom.gba", 0x612C64, 0x40
+sArbokSprites94:
+ax_sprite sArbokGfx94, 0x40
+ax_sprite_terminator
+sArbokGfx95:
+.incbin "baserom.gba", 0x612CB4, 0x200
+sArbokSprites95:
+ax_sprite sArbokGfx95, 0x200
+ax_sprite_terminator
+sArbokGfx96:
+.incbin "baserom.gba", 0x612EC4, 0x80
+sArbokSprites96:
+ax_sprite sArbokGfx96, 0x80
+ax_sprite_terminator
+sArbokGfx97:
+.incbin "baserom.gba", 0x612F54, 0x100
+sArbokSprites97:
+ax_sprite sArbokGfx97, 0x100
+ax_sprite_terminator
+sArbokGfx98:
+.incbin "baserom.gba", 0x613064, 0x80
+sArbokSprites98:
+ax_sprite sArbokGfx98, 0x80
+ax_sprite_terminator
+sArbokGfx99:
+.incbin "baserom.gba", 0x6130F4, 0x80
+sArbokSprites99:
+ax_sprite sArbokGfx99, 0x80
+ax_sprite_terminator
+sArbokGfx100:
+.incbin "baserom.gba", 0x613184, 0x80
+sArbokSprites100:
+ax_sprite sArbokGfx100, 0x80
+ax_sprite_terminator
+sArbokGfx101:
+.incbin "baserom.gba", 0x613214, 0x80
+sArbokSprites101:
+ax_sprite sArbokGfx101, 0x80
+ax_sprite_terminator
+sArbokGfx102:
+.incbin "baserom.gba", 0x6132A4, 0x40
+sArbokSprites102:
+ax_sprite sArbokGfx102, 0x40
+ax_sprite_terminator
+sArbokGfx103:
+.incbin "baserom.gba", 0x6132F4, 0x80
+sArbokSprites103:
+ax_sprite sArbokGfx103, 0x80
+ax_sprite_terminator
+sArbokGfx104:
+.incbin "baserom.gba", 0x613384, 0x40
+sArbokSprites104:
+ax_sprite sArbokGfx104, 0x40
+ax_sprite_terminator
+sArbokGfx105:
+.incbin "baserom.gba", 0x6133D4, 0x40
+sArbokSprites105:
+ax_sprite sArbokGfx105, 0x40
+ax_sprite_terminator
+sArbokGfx106:
+.incbin "baserom.gba", 0x613424, 0x20
+sArbokSprites106:
+ax_sprite sArbokGfx106, 0x20
+ax_sprite_terminator
+sArbokGfx107:
+.incbin "baserom.gba", 0x613454, 0x20
+sArbokSprites107:
+ax_sprite sArbokGfx107, 0x20
+ax_sprite_terminator
+sArbokGfx108:
+.incbin "baserom.gba", 0x613484, 0x40
+sArbokSprites108:
+ax_sprite sArbokGfx108, 0x40
+ax_sprite_terminator
+sArbokGfx109:
+.incbin "baserom.gba", 0x6134D4, 0x40
+sArbokSprites109:
+ax_sprite sArbokGfx109, 0x40
+ax_sprite_terminator
+sArbokGfx110:
+.incbin "baserom.gba", 0x613524, 0xC0
+sArbokSprites110:
+ax_sprite 0, 0x40
+ax_sprite sArbokGfx110, 0xc0
+ax_sprite_terminator
+sArbokGfx111:
+.incbin "baserom.gba", 0x6135FC, 0x20
+sArbokSprites111:
+ax_sprite sArbokGfx111, 0x20
+ax_sprite_terminator
+sArbokGfx112:
+.incbin "baserom.gba", 0x61362C, 0x40
+sArbokSprites112:
+ax_sprite sArbokGfx112, 0x40
+ax_sprite_terminator
+sArbokGfx113:
+.incbin "baserom.gba", 0x61367C, 0x20
+sArbokSprites113:
+ax_sprite sArbokGfx113, 0x20
+ax_sprite_terminator
+sArbokGfx114:
+.incbin "baserom.gba", 0x6136AC, 0x200
+sArbokSprites114:
+ax_sprite sArbokGfx114, 0x200
+ax_sprite_terminator
+sArbokGfx115:
+.incbin "baserom.gba", 0x6138BC, 0x200
+sArbokSprites115:
+ax_sprite sArbokGfx115, 0x200
+ax_sprite_terminator
+sArbokGfx116:
+.incbin "baserom.gba", 0x613ACC, 0x200
+sArbokSprites116:
+ax_sprite sArbokGfx116, 0x200
+ax_sprite_terminator
+sArbokGfx117:
+.incbin "baserom.gba", 0x613CDC, 0x200
+sArbokSprites117:
+ax_sprite sArbokGfx117, 0x200
+ax_sprite_terminator
+sArbokGfx118:
+.incbin "baserom.gba", 0x613EEC, 0x200
+sArbokSprites118:
+ax_sprite sArbokGfx118, 0x200
+ax_sprite_terminator
+sArbokGfx119:
+.incbin "baserom.gba", 0x6140FC, 0x200
+sArbokSprites119:
+ax_sprite sArbokGfx119, 0x200
+ax_sprite_terminator
+sArbokGfx120:
+.incbin "baserom.gba", 0x61430C, 0x200
+sArbokSprites120:
+ax_sprite sArbokGfx120, 0x200
+ax_sprite_terminator
+sAxPosesArbok:
+.4byte sArbokPose1
+.4byte sArbokPose2
+.4byte sArbokPose3
+.4byte sArbokPose4
+.4byte sArbokPose5
+.4byte sArbokPose6
+.4byte sArbokPose7
+.4byte sArbokPose8
+.4byte sArbokPose9
+.4byte sArbokPose10
+.4byte sArbokPose11
+.4byte sArbokPose12
+.4byte sArbokPose13
+.4byte sArbokPose14
+.4byte sArbokPose15
+.4byte sArbokPose16
+.4byte sArbokPose17
+.4byte sArbokPose18
+.4byte sArbokPose19
+.4byte sArbokPose20
+.4byte sArbokPose21
+.4byte sArbokPose22
+.4byte sArbokPose23
+.4byte sArbokPose24
+.4byte sArbokPose25
+.4byte sArbokPose26
+.4byte sArbokPose27
+.4byte sArbokPose28
+.4byte sArbokPose29
+.4byte sArbokPose30
+.4byte sArbokPose31
+.4byte sArbokPose32
+.4byte sArbokPose33
+.4byte sArbokPose34
+.4byte sArbokPose35
+.4byte sArbokPose36
+.4byte sArbokPose37
+.4byte sArbokPose38
+.4byte sArbokPose39
+.4byte sArbokPose40
+.4byte sArbokPose41
+.4byte sArbokPose42
+.4byte sArbokPose43
+.4byte sArbokPose44
+.4byte sArbokPose45
+.4byte sArbokPose46
+.4byte sArbokPose47
+.4byte sArbokPose48
+.4byte sArbokPose49
+.4byte sArbokPose50
+.4byte sArbokPose51
+.4byte sArbokPose52
+.4byte sArbokPose53
+.4byte sArbokPose54
+.4byte sArbokPose55
+.4byte sArbokPose56
+.4byte sArbokPose57
+.4byte sArbokPose58
+.4byte sArbokPose59
+.4byte sArbokPose60
+.4byte sArbokPose61
+.4byte sArbokPose62
+.4byte sArbokPose63
+.4byte sArbokPose64
+.4byte sArbokPose65
+.4byte sArbokPose66
+.4byte sArbokPose67
+.4byte sArbokPose68
+.4byte sArbokPose69
+.4byte sArbokPose70
+.4byte sArbokPose71
+.4byte sArbokPose72
+.4byte sArbokPose73
+.4byte sArbokPose74
+.4byte sArbokPose75
+.4byte sArbokPose76
+.4byte sArbokPose77
+.4byte sArbokPose78
+.4byte sArbokPose79
+.4byte sArbokPose80
+.4byte sArbokPose81
+.4byte sArbokPose82
+.4byte sArbokPose83
+.4byte sArbokPose84
+.4byte sArbokPose85
+.4byte sArbokPose86
+.4byte sArbokPose87
+.4byte sArbokPose88
+.4byte sArbokPose89
+.4byte sArbokPose90
+.4byte sArbokPose91
+.4byte sArbokPose92
+.4byte sArbokPose93
+.4byte sArbokPose94
+.4byte sArbokPose95
+.4byte sArbokPose96
+.4byte sArbokPose97
+.4byte sArbokPose98
+.4byte sArbokPose99
+.4byte sArbokPose100
+.4byte sArbokPose101
+.4byte sArbokPose102
+.4byte sArbokPose103
+.4byte sArbokPose104
+.4byte sArbokPose105
+.4byte sArbokPose106
+.4byte sArbokPose107
+.4byte sArbokPose108
+.4byte sArbokPose109
+.4byte sArbokPose110
+.4byte sArbokPose111
+.4byte sArbokPose112
+.4byte sArbokPose113
+.4byte sArbokPose114
+.4byte sArbokPose115
+.4byte sArbokPose116
+.4byte sArbokPose117
+.4byte sArbokPose118
+.4byte sArbokPose119
+.4byte sArbokPose120
+.4byte sArbokPose121
+.4byte sArbokPose122
+.4byte sArbokPose123
+.4byte sArbokPose124
+.4byte sArbokPose125
+.4byte sArbokPose126
+.4byte sArbokPose127
+.4byte sArbokPose128
+.4byte sArbokPose129
+.4byte sArbokPose130
+.4byte sArbokPose131
+.4byte sArbokPose132
+.4byte sArbokPose133
+.4byte sArbokPose134
+.4byte sArbokPose135
+.4byte sArbokPose136
+.4byte sArbokPose137
+.4byte sArbokPose138
+.4byte sArbokPose139
+.4byte sArbokPose140
+.4byte sArbokPose141
+.4byte sArbokPose142
+.4byte sArbokPose143
+.4byte sArbokPose144
+.4byte sArbokPose145
+.4byte sArbokPose146
+.4byte sArbokPose147
+.4byte sArbokPose148
+.4byte sArbokPose149
+.4byte sArbokPose150
+.4byte sArbokPose151
+.4byte sArbokPose152
+.4byte sArbokPose153
+.4byte sArbokPose154
+.4byte sArbokPose155
+.4byte sArbokPose156
+.4byte sArbokPose157
+.4byte sArbokPose158
+.4byte sArbokPose159
+.4byte sArbokPose160
+.4byte sArbokPose161
+.4byte sArbokPose162
+.4byte sArbokPose163
+.4byte sArbokPose164
+.4byte sArbokPose165
+.4byte sArbokPose166
+.4byte sArbokPose167
+.4byte sArbokPose168
+.4byte sArbokPose169
+.4byte sArbokPose170
+.4byte sArbokPose171
+.4byte sArbokPose172
+.4byte sArbokPose173
+.4byte sArbokPose174
+.4byte sArbokPose175
+.4byte sArbokPose176
+.4byte sArbokPose177
+.4byte sArbokPose178
+.4byte sArbokPose179
+.4byte sArbokPose180
+.4byte sArbokPose181
+.4byte sArbokPose182
+.4byte sArbokPose183
+.4byte sArbokPose184
+.4byte sArbokPose185
+.4byte sArbokPose186
+.4byte sArbokPose187
+.4byte sArbokPose188
+.4byte sArbokPose189
+.4byte sArbokPose190
+.4byte sArbokPose191
+.4byte sArbokPose192
+.4byte sArbokPose193
+.4byte sArbokPose194
+.4byte sArbokPose195
+.4byte sArbokPose196
+.4byte sArbokPose197
+.4byte sArbokPose198
+.4byte sArbokPose199
+.4byte sArbokPose200
+.4byte sArbokPose201
+.4byte sArbokPose202
+sAxPositionsArbok:
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -1,  -10, 	 -13,  -13, 	  11,  -13, 	  -1,   -8
+.2byte   -1,  -17, 	 -13,  -18, 	  11,  -18, 	  -1,  -10
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+.2byte    7,  -12, 	  -9,  -14, 	  11,  -17, 	   2,  -11
+.2byte    3,  -16, 	 -13,  -17, 	   7,  -21, 	  -1,  -10
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte   10,  -17, 	  -2,  -15, 	  -1,  -20, 	  -2,  -13
+.2byte    5,  -18, 	  -4,  -16, 	  -4,  -20, 	  -3,  -13
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    9,  -25, 	  13,  -18, 	  -8,  -22, 	   1,  -14
+.2byte    4,  -20, 	   8,  -13, 	 -13,  -17, 	  -2,  -12
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte   -1,  -24, 	  11,  -19, 	 -13,  -19, 	  -1,  -13
+.2byte   -1,  -21, 	  11,  -16, 	 -13,  -16, 	  -1,  -11
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte  -12,  -24, 	   5,  -21, 	 -14,  -17, 	  -1,  -10
+.2byte   -7,  -20, 	  11,  -17, 	  -9,  -13, 	   2,  -12
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte  -14,  -17, 	  -4,  -19, 	  -2,  -14, 	   0,  -11
+.2byte   -7,  -18, 	   2,  -19, 	   3,  -15, 	   1,  -11
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte  -10,  -12, 	 -14,  -17, 	   6,  -13, 	   0,   -9
+.2byte   -5,  -17, 	  -9,  -22, 	  11,  -17, 	   0,  -11
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -1,  -21, 	 -13,  -21, 	  11,  -21, 	  -1,  -12
+.2byte   -1,   -8, 	 -13,  -10, 	  11,  -10, 	  -1,   -7
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+.2byte    1,  -19, 	 -15,  -20, 	   5,  -24, 	  -1,  -12
+.2byte   12,  -12, 	  -4,  -13, 	  16,  -16, 	   2,  -10
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte    4,  -21, 	  -5,  -18, 	  -5,  -25, 	  -3,  -13
+.2byte   14,  -19, 	   6,  -17, 	   6,  -22, 	   2,  -11
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    2,  -23, 	   5,  -16, 	 -14,  -20, 	  -4,  -13
+.2byte   14,  -25, 	  16,  -18, 	  -3,  -23, 	   4,  -13
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte   -1,  -18, 	  11,  -14, 	 -13,  -14, 	  -1,  -11
+.2byte   -1,  -27, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte   -4,  -23, 	  14,  -19, 	  -6,  -16, 	   4,  -11
+.2byte  -16,  -26, 	   2,  -22, 	 -18,  -19, 	  -6,  -13
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte   -3,  -21, 	   5,  -22, 	   6,  -16, 	   3,  -12
+.2byte  -18,  -18, 	 -10,  -19, 	  -9,  -15, 	  -6,   -9
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte   -3,  -20, 	  -7,  -23, 	  13,  -19, 	   1,  -11
+.2byte  -14,   -9, 	 -18,  -13, 	   2,   -9, 	  -4,   -6
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -1,  -21, 	 -13,  -21, 	  11,  -21, 	  -1,  -12
+.2byte   -1,   -8, 	 -13,  -10, 	  11,  -10, 	  -1,   -7
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+.2byte    1,  -19, 	 -15,  -20, 	   5,  -24, 	  -1,  -12
+.2byte   12,  -12, 	  -4,  -13, 	  16,  -16, 	   2,  -10
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte    4,  -21, 	  -5,  -18, 	  -5,  -25, 	  -3,  -13
+.2byte   14,  -19, 	   6,  -17, 	   6,  -22, 	   2,  -11
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    2,  -23, 	   5,  -16, 	 -14,  -20, 	  -4,  -13
+.2byte   14,  -25, 	  16,  -18, 	  -3,  -23, 	   4,  -13
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte   -1,  -18, 	  11,  -14, 	 -13,  -14, 	  -1,  -11
+.2byte   -1,  -27, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte   -4,  -23, 	  14,  -19, 	  -6,  -16, 	   4,  -11
+.2byte  -16,  -26, 	   2,  -22, 	 -18,  -19, 	  -6,  -13
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte   -3,  -21, 	   5,  -22, 	   6,  -16, 	   3,  -12
+.2byte  -18,  -18, 	 -10,  -19, 	  -9,  -15, 	  -6,   -9
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte   -3,  -20, 	  -7,  -23, 	  13,  -19, 	   1,  -11
+.2byte  -14,   -9, 	 -18,  -13, 	   2,   -9, 	  -4,   -6
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -1,  -21, 	 -13,  -21, 	  11,  -21, 	  -1,  -12
+.2byte   -1,   -8, 	 -13,  -10, 	  11,  -10, 	  -1,   -7
+.2byte   -1,   -2, 	 -13,   -7, 	  11,   -7, 	  -1,   -5
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+.2byte    1,  -19, 	 -15,  -20, 	   5,  -24, 	  -1,  -12
+.2byte   12,  -12, 	  -4,  -13, 	  16,  -16, 	   2,  -10
+.2byte   19,   -8, 	   0,  -11, 	  23,  -12, 	   5,   -8
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte    4,  -21, 	  -5,  -18, 	  -5,  -25, 	  -3,  -13
+.2byte   14,  -19, 	   6,  -17, 	   6,  -22, 	   2,  -11
+.2byte   24,  -14, 	  14,  -13, 	  12,  -21, 	   8,  -11
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    2,  -23, 	   5,  -16, 	 -14,  -20, 	  -4,  -13
+.2byte   14,  -25, 	  16,  -18, 	  -3,  -23, 	   4,  -13
+.2byte   20,  -28, 	  23,  -21, 	  -1,  -26, 	   8,  -14
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte   -1,  -18, 	  11,  -14, 	 -13,  -14, 	  -1,  -11
+.2byte   -1,  -27, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -1,  -31, 	  11,  -26, 	 -13,  -26, 	  -1,  -16
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte   -4,  -23, 	  14,  -19, 	  -6,  -16, 	   4,  -11
+.2byte  -16,  -26, 	   2,  -22, 	 -18,  -19, 	  -6,  -13
+.2byte  -24,  -28, 	  -4,  -25, 	 -25,  -23, 	 -11,  -13
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte   -3,  -21, 	   5,  -22, 	   6,  -16, 	   3,  -12
+.2byte  -18,  -18, 	 -10,  -19, 	  -9,  -15, 	  -6,   -9
+.2byte  -27,  -13, 	 -17,  -22, 	 -16,  -11, 	  -8,   -6
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte   -3,  -20, 	  -7,  -23, 	  13,  -19, 	   1,  -11
+.2byte  -14,   -9, 	 -18,  -13, 	   2,   -9, 	  -4,   -6
+.2byte  -20,   -5, 	 -23,  -10, 	  -2,   -7, 	  -7,   -5
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+.2byte   12,   -2, 	  -4,   -2, 	   8,  -17, 	   0,   -9
+.2byte   12,   -1, 	  -4,   -1, 	   9,  -15, 	   0,   -8
+.2byte   -1,  -10, 	 -13,  -15, 	  11,  -15, 	  -1,   -9
+.2byte    1,  -11, 	   6,  -17, 	 -13,  -14, 	  -3,  -10
+.2byte    6,  -12, 	  -2,  -17, 	  -3,  -13, 	  -2,  -10
+.2byte    5,  -18, 	 -12,  -17, 	   7,  -14, 	  -3,  -13
+.2byte    0,  -19, 	  12,  -15, 	 -12,  -15, 	   0,  -11
+.2byte   -6,  -18, 	  11,  -17, 	  -8,  -14, 	   2,  -13
+.2byte   -7,  -12, 	   1,  -17, 	   2,  -13, 	   1,  -10
+.2byte   -2,  -11, 	  -7,  -17, 	  12,  -14, 	   2,  -10
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -1,  -10, 	 -13,  -13, 	  11,  -13, 	  -1,   -8
+.2byte   -1,  -17, 	 -13,  -18, 	  11,  -18, 	  -1,  -10
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+.2byte    7,  -12, 	  -9,  -14, 	  11,  -17, 	   2,  -11
+.2byte    3,  -16, 	 -13,  -17, 	   7,  -21, 	  -1,  -10
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte   10,  -17, 	  -2,  -15, 	  -1,  -20, 	  -2,  -13
+.2byte    5,  -18, 	  -4,  -16, 	  -4,  -20, 	  -3,  -13
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    9,  -25, 	  13,  -18, 	  -8,  -22, 	   1,  -14
+.2byte    4,  -20, 	   8,  -13, 	 -13,  -17, 	  -2,  -12
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte   -1,  -24, 	  11,  -19, 	 -13,  -19, 	  -1,  -13
+.2byte   -1,  -21, 	  11,  -16, 	 -13,  -16, 	  -1,  -11
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte  -12,  -24, 	   5,  -21, 	 -14,  -17, 	  -1,  -10
+.2byte   -7,  -20, 	  11,  -17, 	  -9,  -13, 	   2,  -12
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte  -14,  -17, 	  -4,  -19, 	  -2,  -14, 	   0,  -11
+.2byte   -7,  -18, 	   2,  -19, 	   3,  -15, 	   1,  -11
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte  -10,  -12, 	 -14,  -17, 	   6,  -13, 	   0,   -9
+.2byte   -5,  -17, 	  -9,  -22, 	  11,  -17, 	   0,  -11
+.2byte   -1,  -10, 	 -13,  -13, 	  11,  -13, 	  -1,   -8
+.2byte  -10,  -12, 	 -14,  -17, 	   6,  -13, 	   0,   -9
+.2byte  -14,  -17, 	  -4,  -19, 	  -2,  -14, 	   0,  -11
+.2byte  -12,  -24, 	   5,  -21, 	 -14,  -17, 	  -1,  -10
+.2byte   -1,  -24, 	  11,  -19, 	 -13,  -19, 	  -1,  -13
+.2byte    9,  -25, 	  13,  -18, 	  -8,  -22, 	   1,  -14
+.2byte   10,  -17, 	  -2,  -15, 	  -1,  -20, 	  -2,  -13
+.2byte    7,  -12, 	  -9,  -14, 	  11,  -17, 	   2,  -11
+.2byte   -1,  -17, 	 -13,  -18, 	  11,  -18, 	  -1,  -10
+.2byte    3,  -16, 	 -13,  -17, 	   7,  -21, 	  -1,  -10
+.2byte    5,  -18, 	  -4,  -16, 	  -4,  -20, 	  -3,  -13
+.2byte    5,  -20, 	   9,  -13, 	 -12,  -17, 	  -1,  -12
+.2byte   -1,  -21, 	  11,  -16, 	 -13,  -16, 	  -1,  -11
+.2byte   -7,  -20, 	  11,  -17, 	  -9,  -13, 	   2,  -12
+.2byte   -7,  -18, 	   2,  -19, 	   3,  -15, 	   1,  -11
+.2byte   -5,  -17, 	  -9,  -22, 	  11,  -17, 	   0,  -11
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -1,  -10, 	 -13,  -13, 	  11,  -13, 	  -1,   -8
+.2byte   -1,  -17, 	 -13,  -18, 	  11,  -18, 	  -1,  -10
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+.2byte    7,  -12, 	  -9,  -14, 	  11,  -17, 	   2,  -11
+.2byte    3,  -16, 	 -13,  -17, 	   7,  -21, 	  -1,  -10
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte   10,  -17, 	  -2,  -15, 	  -1,  -20, 	  -2,  -13
+.2byte    5,  -18, 	  -4,  -16, 	  -4,  -20, 	  -3,  -13
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    9,  -25, 	  13,  -18, 	  -8,  -22, 	   1,  -14
+.2byte    4,  -20, 	   8,  -13, 	 -13,  -17, 	  -2,  -12
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte   -1,  -24, 	  11,  -19, 	 -13,  -19, 	  -1,  -13
+.2byte   -1,  -21, 	  11,  -16, 	 -13,  -16, 	  -1,  -11
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte  -12,  -24, 	   5,  -21, 	 -14,  -17, 	  -1,  -10
+.2byte   -7,  -20, 	  11,  -17, 	  -9,  -13, 	   2,  -12
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte  -14,  -17, 	  -4,  -19, 	  -2,  -14, 	   0,  -11
+.2byte   -7,  -18, 	   2,  -19, 	   3,  -15, 	   1,  -11
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte  -10,  -12, 	 -14,  -17, 	   6,  -13, 	   0,   -9
+.2byte   -5,  -17, 	  -9,  -22, 	  11,  -17, 	   0,  -11
+.2byte   -1,  -10, 	 -13,  -13, 	  11,  -13, 	  -1,   -8
+.2byte  -10,  -12, 	 -14,  -17, 	   6,  -13, 	   0,   -9
+.2byte  -14,  -17, 	  -4,  -19, 	  -2,  -14, 	   0,  -11
+.2byte  -12,  -24, 	   5,  -21, 	 -14,  -17, 	  -1,  -10
+.2byte   -1,  -24, 	  11,  -19, 	 -13,  -19, 	  -1,  -13
+.2byte    9,  -25, 	  13,  -18, 	  -8,  -22, 	   1,  -14
+.2byte   10,  -17, 	  -2,  -15, 	  -1,  -20, 	  -2,  -13
+.2byte    7,  -12, 	  -9,  -14, 	  11,  -17, 	   2,  -11
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -16, 	  -1,   -9
+.2byte   -7,  -15, 	 -11,  -20, 	   9,  -15, 	   0,  -10
+.2byte  -10,  -18, 	  -2,  -18, 	   0,  -14, 	   0,  -11
+.2byte   -9,  -22, 	   9,  -19, 	 -11,  -15, 	   0,  -12
+.2byte   -1,  -24, 	  11,  -18, 	 -13,  -18, 	  -1,  -13
+.2byte    6,  -22, 	  10,  -15, 	 -11,  -19, 	  -1,  -14
+.2byte    8,  -18, 	  -2,  -15, 	  -2,  -20, 	  -2,  -13
+.2byte    5,  -15, 	 -11,  -16, 	   9,  -19, 	   0,  -11
+sArbokAnimTable1:
+.4byte sArbokAnims_1_1
+.4byte sArbokAnims_1_2
+.4byte sArbokAnims_1_3
+.4byte sArbokAnims_1_4
+.4byte sArbokAnims_1_5
+.4byte sArbokAnims_1_6
+.4byte sArbokAnims_1_7
+.4byte sArbokAnims_1_8
+sArbokAnimTable2:
+.4byte sArbokAnims_2_1
+.4byte sArbokAnims_2_2
+.4byte sArbokAnims_2_3
+.4byte sArbokAnims_2_4
+.4byte sArbokAnims_2_5
+.4byte sArbokAnims_2_6
+.4byte sArbokAnims_2_7
+.4byte sArbokAnims_2_8
+sArbokAnimTable3:
+.4byte sArbokAnims_3_1
+.4byte sArbokAnims_3_2
+.4byte sArbokAnims_3_3
+.4byte sArbokAnims_3_4
+.4byte sArbokAnims_3_5
+.4byte sArbokAnims_3_6
+.4byte sArbokAnims_3_7
+.4byte sArbokAnims_3_8
+sArbokAnimTable4:
+.4byte sArbokAnims_4_1
+.4byte sArbokAnims_4_2
+.4byte sArbokAnims_4_3
+.4byte sArbokAnims_4_4
+.4byte sArbokAnims_4_5
+.4byte sArbokAnims_4_6
+.4byte sArbokAnims_4_7
+.4byte sArbokAnims_4_8
+sArbokAnimTable5:
+.4byte sArbokAnims_5_1
+.4byte sArbokAnims_5_2
+.4byte sArbokAnims_5_3
+.4byte sArbokAnims_5_4
+.4byte sArbokAnims_5_5
+.4byte sArbokAnims_5_6
+.4byte sArbokAnims_5_7
+.4byte sArbokAnims_5_8
+sArbokAnimTable6:
+.4byte sArbokAnims_6_1
+.4byte sArbokAnims_6_1
+.4byte sArbokAnims_6_1
+.4byte sArbokAnims_6_1
+.4byte sArbokAnims_6_1
+.4byte sArbokAnims_6_1
+.4byte sArbokAnims_6_1
+.4byte sArbokAnims_6_1
+sArbokAnimTable7:
+.4byte sArbokAnims_7_1
+.4byte sArbokAnims_7_2
+.4byte sArbokAnims_7_3
+.4byte sArbokAnims_7_4
+.4byte sArbokAnims_7_5
+.4byte sArbokAnims_7_6
+.4byte sArbokAnims_7_7
+.4byte sArbokAnims_7_8
+sArbokAnimTable8:
+.4byte sArbokAnims_8_1
+.4byte sArbokAnims_8_2
+.4byte sArbokAnims_8_3
+.4byte sArbokAnims_8_4
+.4byte sArbokAnims_8_5
+.4byte sArbokAnims_8_6
+.4byte sArbokAnims_8_7
+.4byte sArbokAnims_8_8
+sArbokAnimTable9:
+.4byte sArbokAnims_9_1
+.4byte sArbokAnims_9_2
+.4byte sArbokAnims_9_3
+.4byte sArbokAnims_9_4
+.4byte sArbokAnims_9_5
+.4byte sArbokAnims_9_6
+.4byte sArbokAnims_9_7
+.4byte sArbokAnims_9_8
+sArbokAnimTable10:
+.4byte sArbokAnims_10_1
+.4byte sArbokAnims_10_2
+.4byte sArbokAnims_10_3
+.4byte sArbokAnims_10_4
+.4byte sArbokAnims_10_5
+.4byte sArbokAnims_10_6
+.4byte sArbokAnims_10_7
+.4byte sArbokAnims_10_8
+sArbokAnimTable11:
+.4byte sArbokAnims_11_1
+.4byte sArbokAnims_11_2
+.4byte sArbokAnims_11_3
+.4byte sArbokAnims_11_4
+.4byte sArbokAnims_11_5
+.4byte sArbokAnims_11_6
+.4byte sArbokAnims_11_7
+.4byte sArbokAnims_11_8
+sArbokAnimTable12:
+.4byte sArbokAnims_12_1
+.4byte sArbokAnims_12_2
+.4byte sArbokAnims_12_3
+.4byte sArbokAnims_12_4
+.4byte sArbokAnims_12_5
+.4byte sArbokAnims_12_6
+.4byte sArbokAnims_12_7
+.4byte sArbokAnims_12_8
+sArbokAnimTable13:
+.4byte sArbokAnims_13_1
+.4byte sArbokAnims_13_2
+.4byte sArbokAnims_13_3
+.4byte sArbokAnims_13_4
+.4byte sArbokAnims_13_5
+.4byte sArbokAnims_13_6
+.4byte sArbokAnims_13_7
+.4byte sArbokAnims_13_8
+sAxAnimationsArbok:
+.4byte sArbokAnimTable1
+.4byte sArbokAnimTable2
+.4byte sArbokAnimTable3
+.4byte sArbokAnimTable4
+.4byte sArbokAnimTable5
+.4byte sArbokAnimTable6
+.4byte sArbokAnimTable7
+.4byte sArbokAnimTable8
+.4byte sArbokAnimTable9
+.4byte sArbokAnimTable10
+.4byte sArbokAnimTable11
+.4byte sArbokAnimTable12
+.4byte sArbokAnimTable13
+sAxSpritesArbok:
+.4byte sArbokSprites1
+.4byte sArbokSprites2
+.4byte sArbokSprites3
+.4byte sArbokSprites4
+.4byte sArbokSprites5
+.4byte sArbokSprites6
+.4byte sArbokSprites7
+.4byte sArbokSprites8
+.4byte sArbokSprites9
+.4byte sArbokSprites10
+.4byte sArbokSprites11
+.4byte sArbokSprites12
+.4byte sArbokSprites13
+.4byte sArbokSprites14
+.4byte sArbokSprites15
+.4byte sArbokSprites16
+.4byte sArbokSprites17
+.4byte sArbokSprites18
+.4byte sArbokSprites19
+.4byte sArbokSprites20
+.4byte sArbokSprites21
+.4byte sArbokSprites22
+.4byte sArbokSprites23
+.4byte sArbokSprites24
+.4byte sArbokSprites25
+.4byte sArbokSprites26
+.4byte sArbokSprites27
+.4byte sArbokSprites28
+.4byte sArbokSprites29
+.4byte sArbokSprites30
+.4byte sArbokSprites31
+.4byte sArbokSprites32
+.4byte sArbokSprites33
+.4byte sArbokSprites34
+.4byte sArbokSprites35
+.4byte sArbokSprites36
+.4byte sArbokSprites37
+.4byte sArbokSprites38
+.4byte sArbokSprites39
+.4byte sArbokSprites40
+.4byte sArbokSprites41
+.4byte sArbokSprites42
+.4byte sArbokSprites43
+.4byte sArbokSprites44
+.4byte sArbokSprites45
+.4byte sArbokSprites46
+.4byte sArbokSprites47
+.4byte sArbokSprites48
+.4byte sArbokSprites49
+.4byte sArbokSprites50
+.4byte sArbokSprites51
+.4byte sArbokSprites52
+.4byte sArbokSprites53
+.4byte sArbokSprites54
+.4byte sArbokSprites55
+.4byte sArbokSprites56
+.4byte sArbokSprites57
+.4byte sArbokSprites58
+.4byte sArbokSprites59
+.4byte sArbokSprites60
+.4byte sArbokSprites61
+.4byte sArbokSprites62
+.4byte sArbokSprites63
+.4byte sArbokSprites64
+.4byte sArbokSprites65
+.4byte sArbokSprites66
+.4byte sArbokSprites67
+.4byte sArbokSprites68
+.4byte sArbokSprites69
+.4byte sArbokSprites70
+.4byte sArbokSprites71
+.4byte sArbokSprites72
+.4byte sArbokSprites73
+.4byte sArbokSprites74
+.4byte sArbokSprites75
+.4byte sArbokSprites76
+.4byte sArbokSprites77
+.4byte sArbokSprites78
+.4byte sArbokSprites79
+.4byte sArbokSprites80
+.4byte sArbokSprites81
+.4byte sArbokSprites82
+.4byte sArbokSprites83
+.4byte sArbokSprites84
+.4byte sArbokSprites85
+.4byte sArbokSprites86
+.4byte sArbokSprites87
+.4byte sArbokSprites88
+.4byte sArbokSprites89
+.4byte sArbokSprites90
+.4byte sArbokSprites91
+.4byte sArbokSprites92
+.4byte sArbokSprites93
+.4byte sArbokSprites94
+.4byte sArbokSprites95
+.4byte sArbokSprites96
+.4byte sArbokSprites97
+.4byte sArbokSprites98
+.4byte sArbokSprites99
+.4byte sArbokSprites100
+.4byte sArbokSprites101
+.4byte sArbokSprites102
+.4byte sArbokSprites103
+.4byte sArbokSprites104
+.4byte sArbokSprites105
+.4byte sArbokSprites106
+.4byte sArbokSprites107
+.4byte sArbokSprites108
+.4byte sArbokSprites109
+.4byte sArbokSprites110
+.4byte sArbokSprites111
+.4byte sArbokSprites112
+.4byte sArbokSprites113
+.4byte sArbokSprites114
+.4byte sArbokSprites115
+.4byte sArbokSprites116
+.4byte sArbokSprites117
+.4byte sArbokSprites118
+.4byte sArbokSprites119
+.4byte sArbokSprites120
+sAxMainArbok:
+ax_main sAxPosesArbok, sAxAnimationsArbok, 13, sAxSpritesArbok, sAxPositionsArbok

--- a/data/ax/arcanine.inc
+++ b/data/ax/arcanine.inc
@@ -1,0 +1,2857 @@
+.global gAxArcanine
+gAxArcanine:
+ax_siro sAxMainArcanine
+sArcaninePose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose4:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose5:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose6:
+ax_pose 5, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose8:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose10:
+ax_pose 9, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose11:
+ax_pose 10, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose12:
+ax_pose 11, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose13:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose18:
+ax_pose 11, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose24:
+ax_pose 5, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose26:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose27:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose28:
+ax_pose 15, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose29:
+ax_pose 16, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose30:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose31:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose32:
+ax_pose 5, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose33:
+ax_pose 17, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose34:
+ax_pose 18, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose35:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose36:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose37:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose38:
+ax_pose 19, 0x41e5, 0x90f0, 0x0c00
+ax_pose 20, 0x41f5, 0x50f0, 0x0c08
+ax_pose 21, 0x01fd, 0x10f0, 0x0c0c
+ax_pose 22, 0x01eb, 0x10e8, 0x0c0d
+ax_pose 23, 0x01f3, 0x10e8, 0x0c0e
+ax_pose_terminator
+sArcaninePose39:
+ax_pose 24, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sArcaninePose40:
+ax_pose 9, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose41:
+ax_pose 10, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose42:
+ax_pose 11, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose43:
+ax_pose 25, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose44:
+ax_pose 26, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose45:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose46:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose47:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose48:
+ax_pose 27, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose49:
+ax_pose 28, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose50:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose51:
+ax_pose 10, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose52:
+ax_pose 11, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose53:
+ax_pose 25, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose54:
+ax_pose 26, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose55:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose56:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose57:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose58:
+ax_pose 19, 0x41e5, 0x80f0, 0x0c00
+ax_pose 20, 0x41f5, 0x40f0, 0x0c08
+ax_pose 21, 0x01fd, 0x0108, 0x0c0c
+ax_pose 22, 0x01eb, 0x0110, 0x0c0d
+ax_pose 23, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sArcaninePose59:
+ax_pose 24, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sArcaninePose60:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose61:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose62:
+ax_pose 5, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose63:
+ax_pose 17, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose64:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose65:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose66:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose67:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose68:
+ax_pose 15, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose69:
+ax_pose 16, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose70:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose71:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose72:
+ax_pose 5, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose73:
+ax_pose 17, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose74:
+ax_pose 18, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose75:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose76:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose77:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose78:
+ax_pose 19, 0x41e5, 0x90f0, 0x0c00
+ax_pose 20, 0x41f5, 0x50f0, 0x0c08
+ax_pose 21, 0x01fd, 0x10f0, 0x0c0c
+ax_pose 22, 0x01eb, 0x10e8, 0x0c0d
+ax_pose 23, 0x01f3, 0x10e8, 0x0c0e
+ax_pose_terminator
+sArcaninePose79:
+ax_pose 24, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sArcaninePose80:
+ax_pose 9, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose81:
+ax_pose 10, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose82:
+ax_pose 11, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose83:
+ax_pose 25, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose84:
+ax_pose 26, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose85:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose86:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose87:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose88:
+ax_pose 27, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose89:
+ax_pose 28, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose90:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose91:
+ax_pose 10, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose92:
+ax_pose 11, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose93:
+ax_pose 25, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose94:
+ax_pose 26, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose95:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose96:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose97:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose98:
+ax_pose 19, 0x41e5, 0x80f0, 0x0c00
+ax_pose 20, 0x41f5, 0x40f0, 0x0c08
+ax_pose 21, 0x01fd, 0x0108, 0x0c0c
+ax_pose 22, 0x01eb, 0x0110, 0x0c0d
+ax_pose 23, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sArcaninePose99:
+ax_pose 24, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sArcaninePose100:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose101:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose102:
+ax_pose 5, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose103:
+ax_pose 17, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose104:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose105:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose106:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose107:
+ax_pose 29, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose108:
+ax_pose 30, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose109:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose110:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose111:
+ax_pose 31, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose112:
+ax_pose 32, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose113:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose114:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose115:
+ax_pose 33, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sArcaninePose116:
+ax_pose 34, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sArcaninePose117:
+ax_pose 9, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose118:
+ax_pose 10, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose119:
+ax_pose 35, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose120:
+ax_pose 36, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sArcaninePose121:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose122:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose123:
+ax_pose 37, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose124:
+ax_pose 38, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose125:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose126:
+ax_pose 10, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose127:
+ax_pose 35, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sArcaninePose128:
+ax_pose 36, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sArcaninePose129:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose130:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose131:
+ax_pose 33, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sArcaninePose132:
+ax_pose 34, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sArcaninePose133:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose134:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose135:
+ax_pose 31, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose136:
+ax_pose 32, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose137:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose138:
+ax_pose 15, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose139:
+ax_pose 29, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose140:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose141:
+ax_pose 17, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sArcaninePose142:
+ax_pose 31, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose143:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose144:
+ax_pose 19, 0x41e5, 0x90f1, 0x0c00
+ax_pose 20, 0x41f5, 0x50f1, 0x0c08
+ax_pose 21, 0x01fd, 0x10f1, 0x0c0c
+ax_pose 22, 0x01eb, 0x10e9, 0x0c0d
+ax_pose 23, 0x01f3, 0x10e9, 0x0c0e
+ax_pose_terminator
+sArcaninePose145:
+ax_pose 33, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose146:
+ax_pose 9, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose147:
+ax_pose 25, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sArcaninePose148:
+ax_pose 35, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose149:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose150:
+ax_pose 27, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose151:
+ax_pose 37, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose152:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose153:
+ax_pose 25, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sArcaninePose154:
+ax_pose 35, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose155:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose156:
+ax_pose 19, 0x41e5, 0x80f0, 0x0c00
+ax_pose 20, 0x41f5, 0x40f0, 0x0c08
+ax_pose 21, 0x01fd, 0x0108, 0x0c0c
+ax_pose 22, 0x01eb, 0x0110, 0x0c0d
+ax_pose 23, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sArcaninePose157:
+ax_pose 33, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose158:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose159:
+ax_pose 17, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sArcaninePose160:
+ax_pose 31, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose161:
+ax_pose 39, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose162:
+ax_pose 40, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose163:
+ax_pose 41, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose164:
+ax_pose 42, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose165:
+ax_pose 43, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose166:
+ax_pose 44, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose167:
+ax_pose 45, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose168:
+ax_pose 44, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose169:
+ax_pose 43, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose170:
+ax_pose 42, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose171:
+ax_pose 29, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose172:
+ax_pose 31, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose173:
+ax_pose 33, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sArcaninePose174:
+ax_pose 35, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sArcaninePose175:
+ax_pose 37, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose176:
+ax_pose 35, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose177:
+ax_pose 33, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sArcaninePose178:
+ax_pose 31, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose179:
+ax_pose 30, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose180:
+ax_pose 32, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose181:
+ax_pose 34, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sArcaninePose182:
+ax_pose 36, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose183:
+ax_pose 38, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose184:
+ax_pose 36, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose185:
+ax_pose 34, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sArcaninePose186:
+ax_pose 32, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose187:
+ax_pose 30, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose188:
+ax_pose 32, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose189:
+ax_pose 34, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sArcaninePose190:
+ax_pose 36, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose191:
+ax_pose 38, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose192:
+ax_pose 36, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose193:
+ax_pose 34, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sArcaninePose194:
+ax_pose 32, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose195:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose196:
+ax_pose 15, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose197:
+ax_pose 30, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose198:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose199:
+ax_pose 17, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sArcaninePose200:
+ax_pose 32, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose201:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose202:
+ax_pose 19, 0x41e5, 0x90f0, 0x0c00
+ax_pose 20, 0x41f5, 0x50f0, 0x0c08
+ax_pose 21, 0x01fd, 0x10f0, 0x0c0c
+ax_pose 22, 0x01eb, 0x10e8, 0x0c0d
+ax_pose 23, 0x01f3, 0x10e8, 0x0c0e
+ax_pose_terminator
+sArcaninePose203:
+ax_pose 34, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sArcaninePose204:
+ax_pose 9, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose205:
+ax_pose 25, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose206:
+ax_pose 36, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sArcaninePose207:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose208:
+ax_pose 27, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose209:
+ax_pose 38, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose210:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose211:
+ax_pose 25, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose212:
+ax_pose 36, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sArcaninePose213:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose214:
+ax_pose 19, 0x41e5, 0x80f0, 0x0c00
+ax_pose 20, 0x41f5, 0x40f0, 0x0c08
+ax_pose 21, 0x01fd, 0x0108, 0x0c0c
+ax_pose 22, 0x01eb, 0x0110, 0x0c0d
+ax_pose 23, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sArcaninePose215:
+ax_pose 34, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sArcaninePose216:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose217:
+ax_pose 17, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sArcaninePose218:
+ax_pose 32, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose219:
+ax_pose 29, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose220:
+ax_pose 31, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose221:
+ax_pose 33, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sArcaninePose222:
+ax_pose 35, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sArcaninePose223:
+ax_pose 37, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose224:
+ax_pose 35, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose225:
+ax_pose 33, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sArcaninePose226:
+ax_pose 31, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose227:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose228:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose229:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose230:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sArcaninePose231:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sArcaninePose232:
+ax_pose 9, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose233:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sArcaninePose234:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+.align 2
+sArcanineAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_2_1:
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, -6, 0, -6,
+ax_anim 6, 0, 24, 0, -8, 0, -8,
+ax_anim 1, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 28, 0, 7, 0, 7,
+ax_anim 2, 2, 27, 0, 9, 0, 9,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, -1, 20, -1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, -1, 20, -1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 0, 11, 0, 11,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sArcanineAnims_2_2:
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim 6, 0, 29, -8, -8, -8, -8,
+ax_anim 1, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 33, 7, 7, 7, 7,
+ax_anim 2, 2, 32, 11, 11, 11, 11,
+ax_anim 2, 0, 33, 20, 18, 20, 18,
+ax_anim 2, 1, 33, 19, 19, 19, 19,
+ax_anim 2, 0, 33, 20, 18, 20, 18,
+ax_anim 2, 0, 33, 19, 19, 19, 19,
+ax_anim 2, 0, 33, 20, 18, 20, 18,
+ax_anim 2, 0, 30, 11, 11, 11, 11,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sArcanineAnims_2_3:
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 2, 0, 36, -6, 0, -6, 0,
+ax_anim 6, 0, 34, -8, 0, -8, 0,
+ax_anim 1, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 38, 5, 0, 5, 0,
+ax_anim 2, 2, 37, 11, 0, 11, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sArcanineAnims_2_4:
+ax_anim 2, 0, 40, -3, 3, -3, 3,
+ax_anim 2, 0, 41, -6, 6, -6, 6,
+ax_anim 6, 0, 39, -8, 8, -8, 8,
+ax_anim 1, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 43, 6, -9, 6, -9,
+ax_anim 2, 2, 42, 9, -12, 9, -12,
+ax_anim 2, 0, 43, 15, -21, 15, -21,
+ax_anim 2, 1, 43, 14, -22, 14, -22,
+ax_anim 2, 0, 43, 15, -21, 15, -21,
+ax_anim 2, 0, 43, 14, -22, 14, -22,
+ax_anim 2, 0, 43, 15, -21, 15, -21,
+ax_anim 2, 0, 40, 9, -13, 9, -13,
+ax_anim 2, 0, 39, 3, -5, 3, -5,
+ax_anim_terminator
+sArcanineAnims_2_5:
+ax_anim 2, 0, 45, 0, 3, 0, 3,
+ax_anim 2, 0, 46, 0, 6, 0, 6,
+ax_anim 6, 0, 44, 0, 8, 0, 8,
+ax_anim 1, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 48, 0, -7, 0, -7,
+ax_anim 2, 2, 47, 0, -9, 0, -9,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 1, 48, -1, -20, -1, -20,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 48, -1, -20, -1, -20,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 45, 0, -11, 0, -11,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sArcanineAnims_2_6:
+ax_anim 2, 0, 50, 3, 3, 3, 3,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim 6, 0, 49, 8, 8, 8, 8,
+ax_anim 1, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 53, -6, -9, -6, -9,
+ax_anim 2, 2, 52, -9, -12, -9, -12,
+ax_anim 2, 0, 53, -15, -21, -15, -21,
+ax_anim 2, 1, 53, -14, -22, -14, -22,
+ax_anim 2, 0, 53, -15, -21, -15, -21,
+ax_anim 2, 0, 53, -14, -22, -14, -22,
+ax_anim 2, 0, 53, -15, -21, -15, -21,
+ax_anim 2, 0, 50, -9, -13, -9, -13,
+ax_anim 2, 0, 49, -3, -5, -3, -5,
+ax_anim_terminator
+sArcanineAnims_2_7:
+ax_anim 2, 0, 55, 3, 0, 3, 0,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim 6, 0, 54, 8, 0, 8, 0,
+ax_anim 1, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 58, -5, 0, -5, 0,
+ax_anim 2, 2, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 55, -11, 0, -11, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sArcanineAnims_2_8:
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim 2, 0, 61, 6, -6, 6, -6,
+ax_anim 6, 0, 59, 8, -8, 8, -8,
+ax_anim 1, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 63, -7, 7, -7, 7,
+ax_anim 2, 2, 62, -9, 9, -9, 9,
+ax_anim 2, 0, 63, -20, 18, -20, 18,
+ax_anim 2, 1, 63, -19, 19, -19, 19,
+ax_anim 2, 0, 63, -20, 18, -20, 18,
+ax_anim 2, 0, 63, -19, 19, -19, 19,
+ax_anim 2, 0, 63, -20, 18, -20, 18,
+ax_anim 2, 0, 60, -11, 11, -11, 11,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sArcanineAnims_3_1:
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 66, 0, -6, 0, -6,
+ax_anim 6, 0, 64, 0, -8, 0, -8,
+ax_anim 1, 0, 67, 0, 6, 0, 6,
+ax_anim 1, 0, 68, 0, 23, 0, 23,
+ax_anim 2, 2, 67, 0, 33, 0, 33,
+ax_anim 2, 0, 68, 0, 44, 0, 44,
+ax_anim 2, 1, 68, -1, 44, -1, 44,
+ax_anim 2, 0, 68, 0, 44, 0, 44,
+ax_anim 2, 0, 68, -1, 44, -1, 44,
+ax_anim 2, 0, 68, 0, 44, 0, 44,
+ax_anim 2, 0, 65, 0, 11, 0, 11,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sArcanineAnims_3_2:
+ax_anim 2, 0, 70, -3, -3, -3, -3,
+ax_anim 2, 0, 71, -6, -6, -6, -6,
+ax_anim 6, 0, 69, -8, -8, -8, -8,
+ax_anim 1, 0, 72, -2, -2, -2, -2,
+ax_anim 1, 0, 73, 15, 15, 15, 15,
+ax_anim 2, 2, 72, 27, 27, 27, 27,
+ax_anim 2, 0, 73, 44, 42, 44, 42,
+ax_anim 2, 1, 73, 43, 43, 43, 43,
+ax_anim 2, 0, 73, 44, 42, 44, 42,
+ax_anim 2, 0, 73, 43, 43, 43, 43,
+ax_anim 2, 0, 73, 44, 42, 44, 42,
+ax_anim 2, 0, 70, 11, 11, 11, 11,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sArcanineAnims_3_3:
+ax_anim 2, 0, 75, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -6, 0, -6, 0,
+ax_anim 6, 0, 74, -8, 0, -8, 0,
+ax_anim 1, 0, 77, 6, 0, 6, 0,
+ax_anim 1, 0, 78, 21, 0, 21, 0,
+ax_anim 2, 2, 77, 35, 0, 35, 0,
+ax_anim 2, 0, 78, 42, 0, 42, 0,
+ax_anim 2, 1, 78, 42, 1, 42, 1,
+ax_anim 2, 0, 78, 42, 0, 42, 0,
+ax_anim 2, 0, 78, 42, 1, 42, 1,
+ax_anim 2, 0, 78, 42, 0, 42, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sArcanineAnims_3_4:
+ax_anim 2, 0, 80, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -6, 6, -6, 6,
+ax_anim 6, 0, 79, -8, 8, -8, 8,
+ax_anim 1, 0, 82, 6, -6, 6, -6,
+ax_anim 1, 0, 83, 22, -25, 22, -25,
+ax_anim 2, 2, 82, 33, -36, 33, -36,
+ax_anim 2, 0, 83, 39, -45, 39, -45,
+ax_anim 2, 1, 83, 38, -46, 38, -46,
+ax_anim 2, 0, 83, 39, -45, 39, -45,
+ax_anim 2, 0, 83, 38, -46, 38, -46,
+ax_anim 2, 0, 83, 39, -45, 39, -45,
+ax_anim 2, 0, 80, 9, -13, 9, -13,
+ax_anim 2, 0, 79, 3, -5, 3, -5,
+ax_anim_terminator
+sArcanineAnims_3_5:
+ax_anim 2, 0, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 86, 0, 6, 0, 6,
+ax_anim 6, 0, 84, 0, 8, 0, 8,
+ax_anim 1, 0, 87, 0, -6, 0, -6,
+ax_anim 1, 0, 88, 0, -23, 0, -23,
+ax_anim 2, 2, 87, 0, -33, 0, -33,
+ax_anim 2, 0, 88, 0, -44, 0, -44,
+ax_anim 2, 1, 88, -1, -44, -1, -44,
+ax_anim 2, 0, 88, 0, -44, 0, -44,
+ax_anim 2, 0, 88, -1, -44, -1, -44,
+ax_anim 2, 0, 88, 0, -44, 0, -44,
+ax_anim 2, 0, 85, 0, -11, 0, -11,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sArcanineAnims_3_6:
+ax_anim 2, 0, 90, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 6, 6, 6, 6,
+ax_anim 6, 0, 89, 8, 8, 8, 8,
+ax_anim 1, 0, 92, -6, -6, -6, -6,
+ax_anim 1, 0, 93, -22, -25, -22, -25,
+ax_anim 2, 2, 92, -33, -36, -33, -36,
+ax_anim 2, 0, 93, -39, -45, -39, -45,
+ax_anim 2, 1, 93, -38, -46, -38, -46,
+ax_anim 2, 0, 93, -39, -45, -39, -45,
+ax_anim 2, 0, 93, -38, -46, -38, -46,
+ax_anim 2, 0, 93, -39, -45, -39, -45,
+ax_anim 2, 0, 90, -9, -13, -9, -13,
+ax_anim 2, 0, 89, -3, -5, -3, -5,
+ax_anim_terminator
+sArcanineAnims_3_7:
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 6, 0, 94, 8, 0, 8, 0,
+ax_anim 1, 0, 97, -6, 0, -6, 0,
+ax_anim 1, 0, 98, -21, 0, -21, 0,
+ax_anim 2, 2, 97, -35, 0, -35, 0,
+ax_anim 2, 0, 98, -42, 0, -42, 0,
+ax_anim 2, 1, 98, -42, 1, -42, 1,
+ax_anim 2, 0, 98, -42, 0, -42, 0,
+ax_anim 2, 0, 98, -42, 1, -42, 1,
+ax_anim 2, 0, 98, -42, 0, -42, 0,
+ax_anim 2, 0, 95, -11, 0, -11, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sArcanineAnims_3_8:
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 6, -6, 6, -6,
+ax_anim 6, 0, 99, 8, -8, 8, -8,
+ax_anim 1, 0, 102, -6, 6, -6, 6,
+ax_anim 1, 0, 103, -23, 23, -23, 23,
+ax_anim 2, 2, 102, -33, 33, -33, 33,
+ax_anim 2, 0, 103, -44, 42, -44, 42,
+ax_anim 2, 1, 103, -43, 43, -43, 43,
+ax_anim 2, 0, 103, -44, 42, -44, 42,
+ax_anim 2, 0, 103, -43, 43, -43, 43,
+ax_anim 2, 0, 103, -44, 42, -44, 42,
+ax_anim 2, 0, 100, -11, 11, -11, 11,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sArcanineAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim 6, 2, 106, 0, -4, 0, -4,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 1, 107, 1, 3, 1, 3,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 107, 1, 3, 1, 3,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 107, 1, 3, 1, 3,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sArcanineAnims_4_2:
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 109, -4, -4, -4, -4,
+ax_anim 6, 2, 110, -5, -5, -5, -5,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 1, 111, 4, 2, 4, 2,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 4, 2, 4, 2,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 4, 2, 4, 2,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim_terminator
+sArcanineAnims_4_3:
+ax_anim 2, 0, 113, -2, 0, -2, 0,
+ax_anim 2, 0, 113, -4, 0, -4, 0,
+ax_anim 6, 2, 114, -5, 0, -5, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 1, 115, 3, 1, 3, 1,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 115, 3, 1, 3, 1,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 115, 3, 1, 3, 1,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim_terminator
+sArcanineAnims_4_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 6, 2, 118, -5, 5, -5, 5,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 1, 119, 4, -2, 4, -2,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 0, 119, 4, -2, 4, -2,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 0, 119, 4, -2, 4, -2,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim_terminator
+sArcanineAnims_4_5:
+ax_anim 2, 0, 121, 0, 2, 0, 2,
+ax_anim 2, 0, 121, 0, 3, 0, 3,
+ax_anim 6, 2, 122, 0, 5, 0, 5,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 1, 123, 1, -3, 1, -3,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 0, 123, 1, -3, 1, -3,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 0, 123, 1, -3, 1, -3,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim_terminator
+sArcanineAnims_4_6:
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 125, 4, 4, 4, 4,
+ax_anim 6, 2, 126, 5, 5, 5, 5,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 1, 127, -4, -2, -4, -2,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 0, 127, -4, -2, -4, -2,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 0, 127, -4, -2, -4, -2,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 0, 124, -1, -1, -1, -1,
+ax_anim_terminator
+sArcanineAnims_4_7:
+ax_anim 2, 0, 129, 2, 0, 2, 0,
+ax_anim 2, 0, 129, 4, 0, 4, 0,
+ax_anim 6, 2, 130, 5, 0, 5, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 1, 131, -3, 1, -3, 1,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 131, -3, 1, -3, 1,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 131, -3, 1, -3, 1,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 128, -1, 0, -1, 0,
+ax_anim_terminator
+sArcanineAnims_4_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 133, 4, -4, 4, -4,
+ax_anim 6, 2, 134, 5, -5, 5, -5,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 1, 135, -4, 2, -4, 2,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 135, -4, 2, -4, 2,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 135, -4, 2, -4, 2,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 132, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sArcanineAnims_5_1:
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 3, 0, 137, 0, -8, 0, 0,
+ax_anim 3, 0, 137, 0, -9, 0, 0,
+ax_anim 3, 2, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 138, -1, 0, -1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 1, 138, -1, 0, -1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, -1, 0, -1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_5_2:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 3, 0, 140, 0, -8, 0, 0,
+ax_anim 3, 0, 140, 0, -9, 0, 0,
+ax_anim 3, 2, 140, 0, -8, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 1, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_5_3:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 3, 0, 143, 0, -8, 0, 0,
+ax_anim 3, 0, 143, 0, -9, 0, 0,
+ax_anim 3, 2, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 1, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_5_4:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -3, 0, 0,
+ax_anim 3, 0, 146, 0, -8, 0, 0,
+ax_anim 3, 0, 146, 0, -9, 0, 0,
+ax_anim 3, 2, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 1, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_5_5:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 3, 0, 149, 0, -8, 0, 0,
+ax_anim 3, 0, 149, 0, -9, 0, 0,
+ax_anim 3, 2, 149, 0, -8, 0, 0,
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 1, 150, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_5_6:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -3, 0, 0,
+ax_anim 3, 0, 152, 0, -8, 0, 0,
+ax_anim 3, 0, 152, 0, -9, 0, 0,
+ax_anim 3, 2, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 1, -1, 1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 1, 153, -1, 1, -1, 1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 1, -1, 1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_5_7:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 3, 0, 155, 0, -8, 0, 0,
+ax_anim 3, 0, 155, 0, -9, 0, 0,
+ax_anim 3, 2, 155, 0, -8, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 1, 0, 1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 1, 156, 0, 1, 0, 1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 1, 0, 1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_5_8:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -3, 0, 0,
+ax_anim 3, 0, 158, 0, -8, 0, 0,
+ax_anim 3, 0, 158, 0, -9, 0, 0,
+ax_anim 3, 2, 158, 0, -8, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 1, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sArcanineAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sArcanineAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sArcanineAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sArcanineAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sArcanineAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sArcanineAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sArcanineAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sArcanineAnims_8_1:
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_8_2:
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_8_3:
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_8_4:
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_8_5:
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_8_6:
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_8_7:
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_8_8:
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 16, 7, 16,
+ax_anim 3, 0, 182, 0, 18, 0, 18,
+ax_anim 2, 3, 183, -7, 16, -7, 16,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 19, 3, 19, 3,
+ax_anim 2, 0, 180, 21, 10, 21, 10,
+ax_anim 3, 0, 181, 18, 19, 18, 19,
+ax_anim 2, 3, 182, 11, 19, 11, 19,
+ax_anim 2, 0, 183, 5, 14, 5, 14,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 16, -5, 16, -5,
+ax_anim 3, 0, 180, 18, -2, 18, -2,
+ax_anim 2, 3, 181, 16, 4, 16, 4,
+ax_anim 2, 0, 182, 12, 5, 12, 5,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 19, -21, 19, -21,
+ax_anim 2, 3, 180, 22, -15, 22, -15,
+ax_anim 2, 0, 181, 17, -4, 17, -4,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -12, -9, -12,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -21, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -19, -21, -19, -21,
+ax_anim 2, 3, 184, -22, -15, -22, -15,
+ax_anim 2, 0, 183, -17, -4, -17, -4,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -16, -5, -16, -5,
+ax_anim 3, 0, 184, -18, -2, -18, -2,
+ax_anim 2, 3, 183, -18, 4, -18, 4,
+ax_anim 2, 0, 182, -12, 5, -12, 5,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -19, 3, -19, 3,
+ax_anim 2, 0, 184, -21, 10, -21, 10,
+ax_anim 3, 0, 183, -18, 19, -18, 19,
+ax_anim 2, 3, 182, -11, 19, -11, 19,
+ax_anim 2, 0, 181, -5, 14, -5, 14,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArcanineAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sArcanineGfx1:
+.incbin "baserom.gba", 0x792594, 0x200
+sArcanineSprites1:
+ax_sprite sArcanineGfx1, 0x200
+ax_sprite_terminator
+sArcanineGfx2:
+.incbin "baserom.gba", 0x7927A4, 0x200
+sArcanineSprites2:
+ax_sprite sArcanineGfx2, 0x200
+ax_sprite_terminator
+sArcanineGfx3:
+.incbin "baserom.gba", 0x7929B4, 0x200
+sArcanineSprites3:
+ax_sprite sArcanineGfx3, 0x200
+ax_sprite_terminator
+sArcanineGfx4:
+.incbin "baserom.gba", 0x792BC4, 0x200
+sArcanineSprites4:
+ax_sprite sArcanineGfx4, 0x200
+ax_sprite_terminator
+sArcanineGfx5:
+.incbin "baserom.gba", 0x792DD4, 0x200
+sArcanineSprites5:
+ax_sprite sArcanineGfx5, 0x200
+ax_sprite_terminator
+sArcanineGfx6:
+.incbin "baserom.gba", 0x792FE4, 0x200
+sArcanineSprites6:
+ax_sprite sArcanineGfx6, 0x200
+ax_sprite_terminator
+sArcanineGfx7:
+.incbin "baserom.gba", 0x7931F4, 0x200
+sArcanineSprites7:
+ax_sprite sArcanineGfx7, 0x200
+ax_sprite_terminator
+sArcanineGfx8:
+.incbin "baserom.gba", 0x793404, 0x200
+sArcanineSprites8:
+ax_sprite sArcanineGfx8, 0x200
+ax_sprite_terminator
+sArcanineGfx9:
+.incbin "baserom.gba", 0x793614, 0x200
+sArcanineSprites9:
+ax_sprite sArcanineGfx9, 0x200
+ax_sprite_terminator
+sArcanineGfx10:
+.incbin "baserom.gba", 0x793824, 0x200
+sArcanineSprites10:
+ax_sprite sArcanineGfx10, 0x200
+ax_sprite_terminator
+sArcanineGfx11:
+.incbin "baserom.gba", 0x793A34, 0x200
+sArcanineSprites11:
+ax_sprite sArcanineGfx11, 0x200
+ax_sprite_terminator
+sArcanineGfx12:
+.incbin "baserom.gba", 0x793C44, 0x200
+sArcanineSprites12:
+ax_sprite sArcanineGfx12, 0x200
+ax_sprite_terminator
+sArcanineGfx13:
+.incbin "baserom.gba", 0x793E54, 0x200
+sArcanineSprites13:
+ax_sprite sArcanineGfx13, 0x200
+ax_sprite_terminator
+sArcanineGfx14:
+.incbin "baserom.gba", 0x794064, 0x200
+sArcanineSprites14:
+ax_sprite sArcanineGfx14, 0x200
+ax_sprite_terminator
+sArcanineGfx15:
+.incbin "baserom.gba", 0x794274, 0x200
+sArcanineSprites15:
+ax_sprite sArcanineGfx15, 0x200
+ax_sprite_terminator
+sArcanineGfx16:
+.incbin "baserom.gba", 0x794484, 0x60
+sArcanineGfx16_1:
+.incbin "baserom.gba", 0x7944E4, 0x60
+sArcanineGfx16_2:
+.incbin "baserom.gba", 0x794544, 0x60
+sArcanineGfx16_3:
+.incbin "baserom.gba", 0x7945A4, 0x60
+sArcanineSprites16:
+ax_sprite sArcanineGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx17:
+.incbin "baserom.gba", 0x79464C, 0x60
+sArcanineGfx17_1:
+.incbin "baserom.gba", 0x7946AC, 0x60
+sArcanineGfx17_2:
+.incbin "baserom.gba", 0x79470C, 0x60
+sArcanineGfx17_3:
+.incbin "baserom.gba", 0x79476C, 0x60
+sArcanineSprites17:
+ax_sprite sArcanineGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx18:
+.incbin "baserom.gba", 0x794814, 0x200
+sArcanineSprites18:
+ax_sprite sArcanineGfx18, 0x200
+ax_sprite_terminator
+sArcanineGfx19:
+.incbin "baserom.gba", 0x794A24, 0x1C0
+sArcanineSprites19:
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx19, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx20:
+.incbin "baserom.gba", 0x794C04, 0x100
+sArcanineSprites20:
+ax_sprite sArcanineGfx20, 0x100
+ax_sprite_terminator
+sArcanineGfx21:
+.incbin "baserom.gba", 0x794D14, 0x80
+sArcanineSprites21:
+ax_sprite sArcanineGfx21, 0x80
+ax_sprite_terminator
+sArcanineGfx22:
+.incbin "baserom.gba", 0x794DA4, 0x20
+sArcanineSprites22:
+ax_sprite sArcanineGfx22, 0x20
+ax_sprite_terminator
+sArcanineGfx23:
+.incbin "baserom.gba", 0x794DD4, 0x20
+sArcanineSprites23:
+ax_sprite sArcanineGfx23, 0x20
+ax_sprite_terminator
+sArcanineGfx24:
+.incbin "baserom.gba", 0x794E04, 0x20
+sArcanineSprites24:
+ax_sprite sArcanineGfx24, 0x20
+ax_sprite_terminator
+sArcanineGfx25:
+.incbin "baserom.gba", 0x794E34, 0x180
+sArcanineGfx25_1:
+.incbin "baserom.gba", 0x794FB4, 0x60
+sArcanineSprites25:
+ax_sprite sArcanineGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx25_1, 0x60
+ax_sprite_terminator
+sArcanineGfx26:
+.incbin "baserom.gba", 0x795034, 0x60
+sArcanineGfx26_1:
+.incbin "baserom.gba", 0x795094, 0x100
+sArcanineGfx26_2:
+.incbin "baserom.gba", 0x795194, 0x60
+sArcanineSprites26:
+ax_sprite sArcanineGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx26_2, 0x60
+ax_sprite_terminator
+sArcanineGfx27:
+.incbin "baserom.gba", 0x795224, 0x1E0
+sArcanineSprites27:
+ax_sprite sArcanineGfx27, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx28:
+.incbin "baserom.gba", 0x79541C, 0x60
+sArcanineGfx28_1:
+.incbin "baserom.gba", 0x79547C, 0x60
+sArcanineGfx28_2:
+.incbin "baserom.gba", 0x7954DC, 0x60
+sArcanineGfx28_3:
+.incbin "baserom.gba", 0x79553C, 0x60
+sArcanineSprites28:
+ax_sprite sArcanineGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx29:
+.incbin "baserom.gba", 0x7955E4, 0x60
+sArcanineGfx29_1:
+.incbin "baserom.gba", 0x795644, 0x60
+sArcanineGfx29_2:
+.incbin "baserom.gba", 0x7956A4, 0x60
+sArcanineGfx29_3:
+.incbin "baserom.gba", 0x795704, 0x60
+sArcanineSprites29:
+ax_sprite sArcanineGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx30:
+.incbin "baserom.gba", 0x7957AC, 0x60
+sArcanineGfx30_1:
+.incbin "baserom.gba", 0x79580C, 0x60
+sArcanineGfx30_2:
+.incbin "baserom.gba", 0x79586C, 0x60
+sArcanineGfx30_3:
+.incbin "baserom.gba", 0x7958CC, 0x60
+sArcanineSprites30:
+ax_sprite sArcanineGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx31:
+.incbin "baserom.gba", 0x795974, 0x60
+sArcanineGfx31_1:
+.incbin "baserom.gba", 0x7959D4, 0x60
+sArcanineGfx31_2:
+.incbin "baserom.gba", 0x795A34, 0x60
+sArcanineGfx31_3:
+.incbin "baserom.gba", 0x795A94, 0x60
+sArcanineSprites31:
+ax_sprite sArcanineGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx32:
+.incbin "baserom.gba", 0x795B3C, 0x60
+sArcanineGfx32_1:
+.incbin "baserom.gba", 0x795B9C, 0x180
+sArcanineSprites32:
+ax_sprite sArcanineGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx32_1, 0x180
+ax_sprite_terminator
+sArcanineGfx33:
+.incbin "baserom.gba", 0x795D3C, 0x200
+sArcanineSprites33:
+ax_sprite sArcanineGfx33, 0x200
+ax_sprite_terminator
+sArcanineGfx34:
+.incbin "baserom.gba", 0x795F4C, 0x60
+sArcanineGfx34_1:
+.incbin "baserom.gba", 0x795FAC, 0x180
+sArcanineSprites34:
+ax_sprite sArcanineGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx34_1, 0x180
+ax_sprite_terminator
+sArcanineGfx35:
+.incbin "baserom.gba", 0x79614C, 0x200
+sArcanineSprites35:
+ax_sprite sArcanineGfx35, 0x200
+ax_sprite_terminator
+sArcanineGfx36:
+.incbin "baserom.gba", 0x79635C, 0x60
+sArcanineGfx36_1:
+.incbin "baserom.gba", 0x7963BC, 0x100
+sArcanineGfx36_2:
+.incbin "baserom.gba", 0x7964BC, 0x60
+sArcanineSprites36:
+ax_sprite sArcanineGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx36_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx36_2, 0x60
+ax_sprite_terminator
+sArcanineGfx37:
+.incbin "baserom.gba", 0x79654C, 0x200
+sArcanineSprites37:
+ax_sprite sArcanineGfx37, 0x200
+ax_sprite_terminator
+sArcanineGfx38:
+.incbin "baserom.gba", 0x79675C, 0x60
+sArcanineGfx38_1:
+.incbin "baserom.gba", 0x7967BC, 0x60
+sArcanineGfx38_2:
+.incbin "baserom.gba", 0x79681C, 0x60
+sArcanineGfx38_3:
+.incbin "baserom.gba", 0x79687C, 0x60
+sArcanineSprites38:
+ax_sprite sArcanineGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx39:
+.incbin "baserom.gba", 0x796924, 0x60
+sArcanineGfx39_1:
+.incbin "baserom.gba", 0x796984, 0x60
+sArcanineGfx39_2:
+.incbin "baserom.gba", 0x7969E4, 0x60
+sArcanineGfx39_3:
+.incbin "baserom.gba", 0x796A44, 0x60
+sArcanineSprites39:
+ax_sprite sArcanineGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArcanineGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArcanineGfx40:
+.incbin "baserom.gba", 0x796AEC, 0x200
+sArcanineSprites40:
+ax_sprite sArcanineGfx40, 0x200
+ax_sprite_terminator
+sArcanineGfx41:
+.incbin "baserom.gba", 0x796CFC, 0x200
+sArcanineSprites41:
+ax_sprite sArcanineGfx41, 0x200
+ax_sprite_terminator
+sArcanineGfx42:
+.incbin "baserom.gba", 0x796F0C, 0x200
+sArcanineSprites42:
+ax_sprite sArcanineGfx42, 0x200
+ax_sprite_terminator
+sArcanineGfx43:
+.incbin "baserom.gba", 0x79711C, 0x200
+sArcanineSprites43:
+ax_sprite sArcanineGfx43, 0x200
+ax_sprite_terminator
+sArcanineGfx44:
+.incbin "baserom.gba", 0x79732C, 0x200
+sArcanineSprites44:
+ax_sprite sArcanineGfx44, 0x200
+ax_sprite_terminator
+sArcanineGfx45:
+.incbin "baserom.gba", 0x79753C, 0x200
+sArcanineSprites45:
+ax_sprite sArcanineGfx45, 0x200
+ax_sprite_terminator
+sArcanineGfx46:
+.incbin "baserom.gba", 0x79774C, 0x200
+sArcanineSprites46:
+ax_sprite sArcanineGfx46, 0x200
+ax_sprite_terminator
+sAxPosesArcanine:
+.4byte sArcaninePose1
+.4byte sArcaninePose2
+.4byte sArcaninePose3
+.4byte sArcaninePose4
+.4byte sArcaninePose5
+.4byte sArcaninePose6
+.4byte sArcaninePose7
+.4byte sArcaninePose8
+.4byte sArcaninePose9
+.4byte sArcaninePose10
+.4byte sArcaninePose11
+.4byte sArcaninePose12
+.4byte sArcaninePose13
+.4byte sArcaninePose14
+.4byte sArcaninePose15
+.4byte sArcaninePose16
+.4byte sArcaninePose17
+.4byte sArcaninePose18
+.4byte sArcaninePose19
+.4byte sArcaninePose20
+.4byte sArcaninePose21
+.4byte sArcaninePose22
+.4byte sArcaninePose23
+.4byte sArcaninePose24
+.4byte sArcaninePose25
+.4byte sArcaninePose26
+.4byte sArcaninePose27
+.4byte sArcaninePose28
+.4byte sArcaninePose29
+.4byte sArcaninePose30
+.4byte sArcaninePose31
+.4byte sArcaninePose32
+.4byte sArcaninePose33
+.4byte sArcaninePose34
+.4byte sArcaninePose35
+.4byte sArcaninePose36
+.4byte sArcaninePose37
+.4byte sArcaninePose38
+.4byte sArcaninePose39
+.4byte sArcaninePose40
+.4byte sArcaninePose41
+.4byte sArcaninePose42
+.4byte sArcaninePose43
+.4byte sArcaninePose44
+.4byte sArcaninePose45
+.4byte sArcaninePose46
+.4byte sArcaninePose47
+.4byte sArcaninePose48
+.4byte sArcaninePose49
+.4byte sArcaninePose50
+.4byte sArcaninePose51
+.4byte sArcaninePose52
+.4byte sArcaninePose53
+.4byte sArcaninePose54
+.4byte sArcaninePose55
+.4byte sArcaninePose56
+.4byte sArcaninePose57
+.4byte sArcaninePose58
+.4byte sArcaninePose59
+.4byte sArcaninePose60
+.4byte sArcaninePose61
+.4byte sArcaninePose62
+.4byte sArcaninePose63
+.4byte sArcaninePose64
+.4byte sArcaninePose65
+.4byte sArcaninePose66
+.4byte sArcaninePose67
+.4byte sArcaninePose68
+.4byte sArcaninePose69
+.4byte sArcaninePose70
+.4byte sArcaninePose71
+.4byte sArcaninePose72
+.4byte sArcaninePose73
+.4byte sArcaninePose74
+.4byte sArcaninePose75
+.4byte sArcaninePose76
+.4byte sArcaninePose77
+.4byte sArcaninePose78
+.4byte sArcaninePose79
+.4byte sArcaninePose80
+.4byte sArcaninePose81
+.4byte sArcaninePose82
+.4byte sArcaninePose83
+.4byte sArcaninePose84
+.4byte sArcaninePose85
+.4byte sArcaninePose86
+.4byte sArcaninePose87
+.4byte sArcaninePose88
+.4byte sArcaninePose89
+.4byte sArcaninePose90
+.4byte sArcaninePose91
+.4byte sArcaninePose92
+.4byte sArcaninePose93
+.4byte sArcaninePose94
+.4byte sArcaninePose95
+.4byte sArcaninePose96
+.4byte sArcaninePose97
+.4byte sArcaninePose98
+.4byte sArcaninePose99
+.4byte sArcaninePose100
+.4byte sArcaninePose101
+.4byte sArcaninePose102
+.4byte sArcaninePose103
+.4byte sArcaninePose104
+.4byte sArcaninePose105
+.4byte sArcaninePose106
+.4byte sArcaninePose107
+.4byte sArcaninePose108
+.4byte sArcaninePose109
+.4byte sArcaninePose110
+.4byte sArcaninePose111
+.4byte sArcaninePose112
+.4byte sArcaninePose113
+.4byte sArcaninePose114
+.4byte sArcaninePose115
+.4byte sArcaninePose116
+.4byte sArcaninePose117
+.4byte sArcaninePose118
+.4byte sArcaninePose119
+.4byte sArcaninePose120
+.4byte sArcaninePose121
+.4byte sArcaninePose122
+.4byte sArcaninePose123
+.4byte sArcaninePose124
+.4byte sArcaninePose125
+.4byte sArcaninePose126
+.4byte sArcaninePose127
+.4byte sArcaninePose128
+.4byte sArcaninePose129
+.4byte sArcaninePose130
+.4byte sArcaninePose131
+.4byte sArcaninePose132
+.4byte sArcaninePose133
+.4byte sArcaninePose134
+.4byte sArcaninePose135
+.4byte sArcaninePose136
+.4byte sArcaninePose137
+.4byte sArcaninePose138
+.4byte sArcaninePose139
+.4byte sArcaninePose140
+.4byte sArcaninePose141
+.4byte sArcaninePose142
+.4byte sArcaninePose143
+.4byte sArcaninePose144
+.4byte sArcaninePose145
+.4byte sArcaninePose146
+.4byte sArcaninePose147
+.4byte sArcaninePose148
+.4byte sArcaninePose149
+.4byte sArcaninePose150
+.4byte sArcaninePose151
+.4byte sArcaninePose152
+.4byte sArcaninePose153
+.4byte sArcaninePose154
+.4byte sArcaninePose155
+.4byte sArcaninePose156
+.4byte sArcaninePose157
+.4byte sArcaninePose158
+.4byte sArcaninePose159
+.4byte sArcaninePose160
+.4byte sArcaninePose161
+.4byte sArcaninePose162
+.4byte sArcaninePose163
+.4byte sArcaninePose164
+.4byte sArcaninePose165
+.4byte sArcaninePose166
+.4byte sArcaninePose167
+.4byte sArcaninePose168
+.4byte sArcaninePose169
+.4byte sArcaninePose170
+.4byte sArcaninePose171
+.4byte sArcaninePose172
+.4byte sArcaninePose173
+.4byte sArcaninePose174
+.4byte sArcaninePose175
+.4byte sArcaninePose176
+.4byte sArcaninePose177
+.4byte sArcaninePose178
+.4byte sArcaninePose179
+.4byte sArcaninePose180
+.4byte sArcaninePose181
+.4byte sArcaninePose182
+.4byte sArcaninePose183
+.4byte sArcaninePose184
+.4byte sArcaninePose185
+.4byte sArcaninePose186
+.4byte sArcaninePose187
+.4byte sArcaninePose188
+.4byte sArcaninePose189
+.4byte sArcaninePose190
+.4byte sArcaninePose191
+.4byte sArcaninePose192
+.4byte sArcaninePose193
+.4byte sArcaninePose194
+.4byte sArcaninePose195
+.4byte sArcaninePose196
+.4byte sArcaninePose197
+.4byte sArcaninePose198
+.4byte sArcaninePose199
+.4byte sArcaninePose200
+.4byte sArcaninePose201
+.4byte sArcaninePose202
+.4byte sArcaninePose203
+.4byte sArcaninePose204
+.4byte sArcaninePose205
+.4byte sArcaninePose206
+.4byte sArcaninePose207
+.4byte sArcaninePose208
+.4byte sArcaninePose209
+.4byte sArcaninePose210
+.4byte sArcaninePose211
+.4byte sArcaninePose212
+.4byte sArcaninePose213
+.4byte sArcaninePose214
+.4byte sArcaninePose215
+.4byte sArcaninePose216
+.4byte sArcaninePose217
+.4byte sArcaninePose218
+.4byte sArcaninePose219
+.4byte sArcaninePose220
+.4byte sArcaninePose221
+.4byte sArcaninePose222
+.4byte sArcaninePose223
+.4byte sArcaninePose224
+.4byte sArcaninePose225
+.4byte sArcaninePose226
+.4byte sArcaninePose227
+.4byte sArcaninePose228
+.4byte sArcaninePose229
+.4byte sArcaninePose230
+.4byte sArcaninePose231
+.4byte sArcaninePose232
+.4byte sArcaninePose233
+.4byte sArcaninePose234
+sAxPositionsArcanine:
+.2byte    0,   -6, 	  -5,    2, 	   4,    2, 	   0,   -9
+.2byte    0,   -5, 	  -4,    5, 	   3,    1, 	   0,   -8
+.2byte    0,   -5, 	  -4,    1, 	   3,    5, 	   0,   -8
+.2byte    8,   -7, 	   7,    0, 	   1,    2, 	  -1,   -9
+.2byte    8,   -6, 	  10,    2, 	  -2,    2, 	  -1,   -8
+.2byte    8,   -6, 	  -1,   -2, 	   4,    5, 	  -2,   -8
+.2byte   10,   -9, 	   9,   -1, 	   8,    0, 	  -1,   -9
+.2byte   10,   -8, 	  11,   -1, 	   4,    1, 	  -2,   -8
+.2byte   10,   -8, 	   3,   -1, 	   9,    1, 	  -1,   -7
+.2byte   10,  -12, 	   2,   -4, 	   7,   -2, 	   0,   -8
+.2byte   10,  -11, 	   5,   -6, 	   5,    0, 	   0,   -8
+.2byte   10,  -11, 	  -1,   -3, 	   9,   -2, 	  -1,   -8
+.2byte    0,  -15, 	   5,   -7, 	  -6,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -6,   -4, 	   0,  -10
+.2byte    1,  -14, 	   5,   -4, 	  -7,   -7, 	   0,  -10
+.2byte  -11,  -12, 	  -3,   -4, 	  -8,   -2, 	  -1,   -8
+.2byte  -11,  -11, 	  -6,   -6, 	  -6,    0, 	  -1,   -8
+.2byte  -11,  -11, 	   0,   -3, 	 -10,   -2, 	   0,   -8
+.2byte  -11,   -9, 	 -10,   -1, 	  -9,    0, 	   0,   -9
+.2byte  -11,   -8, 	 -12,   -1, 	  -5,    1, 	   1,   -8
+.2byte  -11,   -8, 	  -4,   -1, 	 -10,    1, 	   0,   -7
+.2byte   -9,   -7, 	  -8,    0, 	  -2,    2, 	   0,   -9
+.2byte   -9,   -6, 	 -11,    2, 	   1,    2, 	   0,   -8
+.2byte   -9,   -6, 	   0,   -2, 	  -5,    5, 	   1,   -8
+.2byte    0,   -6, 	  -5,    2, 	   4,    2, 	   0,   -9
+.2byte    0,   -5, 	  -4,    5, 	   3,    1, 	   0,   -8
+.2byte    0,   -5, 	  -4,    1, 	   3,    5, 	   0,   -8
+.2byte    0,   -9, 	  -9,   -6, 	   8,   -6, 	   0,  -10
+.2byte    0,   -5, 	  -3,    1, 	   2,    1, 	   0,  -11
+.2byte    8,   -7, 	   7,    0, 	   1,    2, 	  -1,   -9
+.2byte    8,   -6, 	  10,    2, 	  -2,    2, 	  -1,   -8
+.2byte    8,   -6, 	  -1,   -2, 	   4,    5, 	  -2,   -8
+.2byte    9,   -9, 	  13,   -7, 	   5,   -4, 	  -1,  -10
+.2byte    8,   -4, 	   3,    1, 	  -3,    3, 	  -1,   -9
+.2byte   10,   -9, 	   9,   -1, 	   8,    0, 	  -1,   -9
+.2byte   10,   -8, 	  11,   -1, 	   4,    1, 	  -2,   -8
+.2byte   10,   -8, 	   3,   -1, 	   9,    1, 	  -1,   -7
+.2byte   12,  -14, 	  13,  -12, 	  12,   -9, 	  -1,  -13
+.2byte   13,   -8, 	   1,   -2, 	  -1,    0, 	   0,  -10
+.2byte   10,  -12, 	   2,   -4, 	   7,   -2, 	   0,   -8
+.2byte   10,  -11, 	   5,   -6, 	   5,    0, 	   0,   -8
+.2byte   10,  -11, 	  -1,   -3, 	   9,   -2, 	  -1,   -8
+.2byte   11,  -15, 	   2,  -14, 	  11,  -11, 	   0,  -10
+.2byte   13,   -8, 	  -4,   -2, 	   1,    1, 	   1,  -10
+.2byte    0,  -15, 	   5,   -7, 	  -6,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -6,   -4, 	   0,  -10
+.2byte    1,  -14, 	   5,   -4, 	  -7,   -7, 	   0,  -10
+.2byte    0,  -20, 	   6,  -16, 	  -7,  -16, 	   0,  -13
+.2byte    0,  -15, 	   2,   -1, 	  -3,   -1, 	   0,  -13
+.2byte  -11,  -12, 	  -3,   -4, 	  -8,   -2, 	  -1,   -8
+.2byte  -11,  -11, 	  -6,   -6, 	  -6,    0, 	  -1,   -8
+.2byte  -11,  -11, 	   0,   -3, 	 -10,   -2, 	   0,   -8
+.2byte  -12,  -15, 	  -3,  -14, 	 -12,  -11, 	  -1,  -10
+.2byte  -14,   -8, 	   3,   -2, 	  -2,    1, 	  -2,  -10
+.2byte  -11,   -9, 	 -10,   -1, 	  -9,    0, 	   0,   -9
+.2byte  -11,   -8, 	 -12,   -1, 	  -5,    1, 	   1,   -8
+.2byte  -11,   -8, 	  -4,   -1, 	 -10,    1, 	   0,   -7
+.2byte  -13,  -14, 	 -14,  -12, 	 -13,   -9, 	   0,  -13
+.2byte  -14,   -8, 	  -2,   -2, 	   0,    0, 	  -1,  -10
+.2byte   -9,   -7, 	  -8,    0, 	  -2,    2, 	   0,   -9
+.2byte   -9,   -6, 	 -11,    2, 	   1,    2, 	   0,   -8
+.2byte   -9,   -6, 	   0,   -2, 	  -5,    5, 	   1,   -8
+.2byte  -10,   -9, 	 -14,   -7, 	  -6,   -4, 	   0,  -10
+.2byte   -9,   -4, 	  -4,    1, 	   2,    3, 	   0,   -9
+.2byte    0,   -6, 	  -5,    2, 	   4,    2, 	   0,   -9
+.2byte    0,   -5, 	  -4,    5, 	   3,    1, 	   0,   -8
+.2byte    0,   -5, 	  -4,    1, 	   3,    5, 	   0,   -8
+.2byte    0,   -9, 	  -9,   -6, 	   8,   -6, 	   0,  -10
+.2byte    0,   -5, 	  -3,    1, 	   2,    1, 	   0,  -11
+.2byte    8,   -7, 	   7,    0, 	   1,    2, 	  -1,   -9
+.2byte    8,   -6, 	  10,    2, 	  -2,    2, 	  -1,   -8
+.2byte    8,   -6, 	  -1,   -2, 	   4,    5, 	  -2,   -8
+.2byte    9,   -9, 	  13,   -7, 	   5,   -4, 	  -1,  -10
+.2byte    8,   -4, 	   3,    1, 	  -3,    3, 	  -1,   -9
+.2byte   10,   -9, 	   9,   -1, 	   8,    0, 	  -1,   -9
+.2byte   10,   -8, 	  11,   -1, 	   4,    1, 	  -2,   -8
+.2byte   10,   -8, 	   3,   -1, 	   9,    1, 	  -1,   -7
+.2byte   12,  -14, 	  13,  -12, 	  12,   -9, 	  -1,  -13
+.2byte   13,   -8, 	   1,   -2, 	  -1,    0, 	   0,  -10
+.2byte   10,  -12, 	   2,   -4, 	   7,   -2, 	   0,   -8
+.2byte   10,  -11, 	   5,   -6, 	   5,    0, 	   0,   -8
+.2byte   10,  -11, 	  -1,   -3, 	   9,   -2, 	  -1,   -8
+.2byte   11,  -15, 	   2,  -14, 	  11,  -11, 	   0,  -10
+.2byte   13,   -8, 	  -4,   -2, 	   1,    1, 	   1,  -10
+.2byte    0,  -15, 	   5,   -7, 	  -6,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -6,   -4, 	   0,  -10
+.2byte    1,  -14, 	   5,   -4, 	  -7,   -7, 	   0,  -10
+.2byte    0,  -20, 	   6,  -16, 	  -7,  -16, 	   0,  -13
+.2byte    0,  -15, 	   2,   -1, 	  -3,   -1, 	   0,  -13
+.2byte  -11,  -12, 	  -3,   -4, 	  -8,   -2, 	  -1,   -8
+.2byte  -11,  -11, 	  -6,   -6, 	  -6,    0, 	  -1,   -8
+.2byte  -11,  -11, 	   0,   -3, 	 -10,   -2, 	   0,   -8
+.2byte  -12,  -15, 	  -3,  -14, 	 -12,  -11, 	  -1,  -10
+.2byte  -14,   -8, 	   3,   -2, 	  -2,    1, 	  -2,  -10
+.2byte  -11,   -9, 	 -10,   -1, 	  -9,    0, 	   0,   -9
+.2byte  -11,   -8, 	 -12,   -1, 	  -5,    1, 	   1,   -8
+.2byte  -11,   -8, 	  -4,   -1, 	 -10,    1, 	   0,   -7
+.2byte  -13,  -14, 	 -14,  -12, 	 -13,   -9, 	   0,  -13
+.2byte  -14,   -8, 	  -2,   -2, 	   0,    0, 	  -1,  -10
+.2byte   -9,   -7, 	  -8,    0, 	  -2,    2, 	   0,   -9
+.2byte   -9,   -6, 	 -11,    2, 	   1,    2, 	   0,   -8
+.2byte   -9,   -6, 	   0,   -2, 	  -5,    5, 	   1,   -8
+.2byte  -10,   -9, 	 -14,   -7, 	  -6,   -4, 	   0,  -10
+.2byte   -9,   -4, 	  -4,    1, 	   2,    3, 	   0,   -9
+.2byte    0,   -6, 	  -5,    2, 	   4,    2, 	   0,   -9
+.2byte    0,   -5, 	  -4,    5, 	   3,    1, 	   0,   -8
+.2byte    0,  -10, 	  -5,    1, 	   4,    1, 	   0,  -11
+.2byte    0,   -3, 	  -6,    2, 	   5,    2, 	   0,  -11
+.2byte    8,   -7, 	   7,    0, 	   1,    2, 	  -1,   -9
+.2byte    8,   -6, 	  10,    2, 	  -2,    2, 	  -1,   -8
+.2byte    6,  -11, 	   7,   -2, 	   1,    2, 	  -2,  -10
+.2byte   10,   -6, 	   9,   -1, 	   0,    2, 	   1,   -8
+.2byte   10,   -9, 	   9,   -1, 	   8,    0, 	  -1,   -9
+.2byte   10,   -8, 	  11,   -1, 	   4,    1, 	  -2,   -8
+.2byte   10,  -13, 	   4,   -1, 	   4,    1, 	  -1,   -8
+.2byte   13,   -8, 	   8,   -1, 	   7,    1, 	   0,   -8
+.2byte   10,  -12, 	   2,   -4, 	   7,   -2, 	   0,   -8
+.2byte   10,  -11, 	   5,   -6, 	   5,    0, 	   0,   -8
+.2byte    7,  -15, 	   0,   -3, 	   5,   -1, 	  -2,  -11
+.2byte   14,  -11, 	   1,   -5, 	   7,   -2, 	   1,  -11
+.2byte    0,  -15, 	   5,   -7, 	  -6,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -6,   -4, 	   0,  -10
+.2byte    0,  -20, 	   6,   -5, 	  -7,   -5, 	   0,  -11
+.2byte    0,  -15, 	   4,   -7, 	  -5,   -7, 	   0,  -11
+.2byte  -11,  -12, 	  -3,   -4, 	  -8,   -2, 	  -1,   -8
+.2byte  -11,  -11, 	  -6,   -6, 	  -6,    0, 	  -1,   -8
+.2byte   -9,  -15, 	  -2,   -3, 	  -7,   -1, 	   0,  -11
+.2byte  -15,  -11, 	  -2,   -5, 	  -8,   -2, 	  -2,  -11
+.2byte  -11,   -9, 	 -10,   -1, 	  -9,    0, 	   0,   -9
+.2byte  -11,   -8, 	 -12,   -1, 	  -5,    1, 	   1,   -8
+.2byte  -11,  -13, 	  -5,   -1, 	  -5,    1, 	   0,   -8
+.2byte  -14,   -8, 	  -9,   -1, 	  -8,    1, 	  -1,   -8
+.2byte   -9,   -7, 	  -8,    0, 	  -2,    2, 	   0,   -9
+.2byte   -9,   -6, 	 -11,    2, 	   1,    2, 	   0,   -8
+.2byte   -7,  -10, 	  -8,   -1, 	  -2,    3, 	   1,   -9
+.2byte  -11,   -6, 	 -10,   -1, 	  -1,    2, 	  -2,   -8
+.2byte    0,   -6, 	  -5,    2, 	   4,    2, 	   0,   -9
+.2byte    0,   -9, 	  -9,   -6, 	   8,   -6, 	   0,  -10
+.2byte    0,  -10, 	  -5,    1, 	   4,    1, 	   0,  -11
+.2byte    8,   -7, 	   7,    0, 	   1,    2, 	  -1,   -9
+.2byte    8,   -9, 	  12,   -7, 	   4,   -4, 	  -2,  -10
+.2byte    6,  -11, 	   7,   -2, 	   1,    2, 	  -2,  -10
+.2byte   10,   -9, 	   9,   -1, 	   8,    0, 	  -1,   -9
+.2byte   13,  -14, 	  14,  -12, 	  13,   -9, 	   0,  -13
+.2byte   12,  -13, 	   6,   -1, 	   6,    1, 	   1,   -8
+.2byte   10,  -12, 	   2,   -4, 	   7,   -2, 	   0,   -8
+.2byte    9,  -15, 	   0,  -14, 	   9,  -11, 	  -2,  -10
+.2byte    7,  -14, 	   0,   -2, 	   5,    0, 	  -2,  -10
+.2byte    0,  -15, 	   5,   -7, 	  -6,   -7, 	   0,  -11
+.2byte    0,  -20, 	   6,  -16, 	  -7,  -16, 	   0,  -13
+.2byte    0,  -16, 	   6,   -1, 	  -7,   -1, 	   0,   -7
+.2byte  -11,  -12, 	  -3,   -4, 	  -8,   -2, 	  -1,   -8
+.2byte  -10,  -15, 	  -1,  -14, 	 -10,  -11, 	   1,  -10
+.2byte   -8,  -14, 	  -1,   -2, 	  -6,    0, 	   1,  -10
+.2byte  -11,   -9, 	 -10,   -1, 	  -9,    0, 	   0,   -9
+.2byte  -13,  -14, 	 -14,  -12, 	 -13,   -9, 	   0,  -13
+.2byte  -13,  -13, 	  -7,   -1, 	  -7,    1, 	  -2,   -8
+.2byte   -9,   -7, 	  -8,    0, 	  -2,    2, 	   0,   -9
+.2byte   -9,   -9, 	 -13,   -7, 	  -5,   -4, 	   1,  -10
+.2byte   -7,  -11, 	  -8,   -2, 	  -2,    2, 	   1,  -10
+.2byte   -8,   -2, 	 -13,   -1, 	  -6,    3, 	   1,   -8
+.2byte   -8,   -1, 	 -13,   -1, 	  -6,    3, 	   1,   -7
+.2byte    0,   -5, 	  -9,    0, 	   8,    0, 	   0,  -11
+.2byte    4,   -7, 	  11,   -3, 	  -6,    1, 	  -2,   -9
+.2byte    8,   -9, 	  14,   -4, 	  10,    0, 	  -1,   -9
+.2byte   10,  -11, 	   1,   -9, 	  11,   -2, 	   0,   -8
+.2byte    0,  -12, 	   9,   -4, 	 -10,   -4, 	   0,   -9
+.2byte  -11,  -11, 	  -2,   -9, 	 -12,   -2, 	  -1,   -8
+.2byte   -9,   -9, 	 -15,   -4, 	 -11,    0, 	   0,   -9
+.2byte   -5,   -7, 	 -12,   -3, 	   5,    1, 	   1,   -9
+.2byte    0,  -10, 	  -5,    1, 	   4,    1, 	   0,  -11
+.2byte   -7,  -10, 	  -8,   -1, 	  -2,    3, 	   1,   -9
+.2byte  -11,  -13, 	  -5,   -1, 	  -5,    1, 	   0,   -8
+.2byte   -9,  -15, 	  -2,   -3, 	  -7,   -1, 	   0,  -11
+.2byte    0,  -21, 	   6,   -6, 	  -7,   -6, 	   0,  -12
+.2byte    7,  -15, 	   0,   -3, 	   5,   -1, 	  -2,  -11
+.2byte   10,  -13, 	   4,   -1, 	   4,    1, 	  -1,   -8
+.2byte    6,  -11, 	   7,   -2, 	   1,    2, 	  -2,  -10
+.2byte    0,   -3, 	  -6,    2, 	   5,    2, 	   0,  -11
+.2byte  -11,   -5, 	 -10,    0, 	  -1,    3, 	  -2,   -7
+.2byte  -14,   -8, 	  -9,   -1, 	  -8,    1, 	  -1,   -8
+.2byte  -14,  -11, 	  -1,   -5, 	  -7,   -2, 	  -1,  -11
+.2byte    0,  -15, 	   4,   -7, 	  -5,   -7, 	   0,  -11
+.2byte   13,  -11, 	   0,   -5, 	   6,   -2, 	   0,  -11
+.2byte   13,   -8, 	   8,   -1, 	   7,    1, 	   0,   -8
+.2byte   10,   -5, 	   9,    0, 	   0,    3, 	   1,   -7
+.2byte    0,   -3, 	  -6,    2, 	   5,    2, 	   0,  -11
+.2byte   10,   -5, 	   9,    0, 	   0,    3, 	   1,   -7
+.2byte   13,   -8, 	   8,   -1, 	   7,    1, 	   0,   -8
+.2byte   13,  -11, 	   0,   -5, 	   6,   -2, 	   0,  -11
+.2byte    0,  -15, 	   4,   -7, 	  -5,   -7, 	   0,  -11
+.2byte  -14,  -11, 	  -1,   -5, 	  -7,   -2, 	  -1,  -11
+.2byte  -14,   -8, 	  -9,   -1, 	  -8,    1, 	  -1,   -8
+.2byte  -11,   -5, 	 -10,    0, 	  -1,    3, 	  -2,   -7
+.2byte    0,   -6, 	  -5,    2, 	   4,    2, 	   0,   -9
+.2byte    0,   -9, 	  -9,   -6, 	   8,   -6, 	   0,  -10
+.2byte    0,   -3, 	  -6,    2, 	   5,    2, 	   0,  -11
+.2byte    8,   -7, 	   7,    0, 	   1,    2, 	  -1,   -9
+.2byte    8,   -9, 	  12,   -7, 	   4,   -4, 	  -2,  -10
+.2byte   10,   -6, 	   9,   -1, 	   0,    2, 	   1,   -8
+.2byte   10,   -9, 	   9,   -1, 	   8,    0, 	  -1,   -9
+.2byte   12,  -14, 	  13,  -12, 	  12,   -9, 	  -1,  -13
+.2byte   12,   -8, 	   7,   -1, 	   6,    1, 	  -1,   -8
+.2byte   10,  -12, 	   2,   -4, 	   7,   -2, 	   0,   -8
+.2byte   11,  -15, 	   2,  -14, 	  11,  -11, 	   0,  -10
+.2byte   12,  -11, 	  -1,   -5, 	   5,   -2, 	  -1,  -11
+.2byte    0,  -15, 	   5,   -7, 	  -6,   -7, 	   0,  -11
+.2byte    0,  -20, 	   6,  -16, 	  -7,  -16, 	   0,  -13
+.2byte    0,  -15, 	   4,   -7, 	  -5,   -7, 	   0,  -11
+.2byte  -11,  -12, 	  -3,   -4, 	  -8,   -2, 	  -1,   -8
+.2byte  -12,  -15, 	  -3,  -14, 	 -12,  -11, 	  -1,  -10
+.2byte  -12,  -11, 	   1,   -5, 	  -5,   -2, 	   1,  -11
+.2byte  -11,   -9, 	 -10,   -1, 	  -9,    0, 	   0,   -9
+.2byte  -13,  -14, 	 -14,  -12, 	 -13,   -9, 	   0,  -13
+.2byte  -13,   -8, 	  -8,   -1, 	  -7,    1, 	   0,   -8
+.2byte   -9,   -7, 	  -8,    0, 	  -2,    2, 	   0,   -9
+.2byte   -9,   -9, 	 -13,   -7, 	  -5,   -4, 	   1,  -10
+.2byte  -11,   -6, 	 -10,   -1, 	  -1,    2, 	  -2,   -8
+.2byte    0,  -10, 	  -5,    1, 	   4,    1, 	   0,  -11
+.2byte   -7,  -10, 	  -8,   -1, 	  -2,    3, 	   1,   -9
+.2byte  -11,  -13, 	  -5,   -1, 	  -5,    1, 	   0,   -8
+.2byte   -9,  -15, 	  -2,   -3, 	  -7,   -1, 	   0,  -11
+.2byte    0,  -21, 	   6,   -6, 	  -7,   -6, 	   0,  -12
+.2byte    7,  -15, 	   0,   -3, 	   5,   -1, 	  -2,  -11
+.2byte   10,  -13, 	   4,   -1, 	   4,    1, 	  -1,   -8
+.2byte    6,  -11, 	   7,   -2, 	   1,    2, 	  -2,  -10
+.2byte    0,   -6, 	  -5,    2, 	   4,    2, 	   0,   -9
+.2byte   -9,   -7, 	  -8,    0, 	  -2,    2, 	   0,   -9
+.2byte  -11,   -9, 	 -10,   -1, 	  -9,    0, 	   0,   -9
+.2byte  -11,  -12, 	  -3,   -4, 	  -8,   -2, 	  -1,   -8
+.2byte    0,  -15, 	   5,   -7, 	  -6,   -7, 	   0,  -11
+.2byte   10,  -12, 	   2,   -4, 	   7,   -2, 	   0,   -8
+.2byte   10,   -9, 	   9,   -1, 	   8,    0, 	  -1,   -9
+.2byte    8,   -7, 	   7,    0, 	   1,    2, 	  -1,   -9
+sArcanineAnimTable1:
+.4byte sArcanineAnims_1_1
+.4byte sArcanineAnims_1_2
+.4byte sArcanineAnims_1_3
+.4byte sArcanineAnims_1_4
+.4byte sArcanineAnims_1_5
+.4byte sArcanineAnims_1_6
+.4byte sArcanineAnims_1_7
+.4byte sArcanineAnims_1_8
+sArcanineAnimTable2:
+.4byte sArcanineAnims_2_1
+.4byte sArcanineAnims_2_2
+.4byte sArcanineAnims_2_3
+.4byte sArcanineAnims_2_4
+.4byte sArcanineAnims_2_5
+.4byte sArcanineAnims_2_6
+.4byte sArcanineAnims_2_7
+.4byte sArcanineAnims_2_8
+sArcanineAnimTable3:
+.4byte sArcanineAnims_3_1
+.4byte sArcanineAnims_3_2
+.4byte sArcanineAnims_3_3
+.4byte sArcanineAnims_3_4
+.4byte sArcanineAnims_3_5
+.4byte sArcanineAnims_3_6
+.4byte sArcanineAnims_3_7
+.4byte sArcanineAnims_3_8
+sArcanineAnimTable4:
+.4byte sArcanineAnims_4_1
+.4byte sArcanineAnims_4_2
+.4byte sArcanineAnims_4_3
+.4byte sArcanineAnims_4_4
+.4byte sArcanineAnims_4_5
+.4byte sArcanineAnims_4_6
+.4byte sArcanineAnims_4_7
+.4byte sArcanineAnims_4_8
+sArcanineAnimTable5:
+.4byte sArcanineAnims_5_1
+.4byte sArcanineAnims_5_2
+.4byte sArcanineAnims_5_3
+.4byte sArcanineAnims_5_4
+.4byte sArcanineAnims_5_5
+.4byte sArcanineAnims_5_6
+.4byte sArcanineAnims_5_7
+.4byte sArcanineAnims_5_8
+sArcanineAnimTable6:
+.4byte sArcanineAnims_6_1
+.4byte sArcanineAnims_6_1
+.4byte sArcanineAnims_6_1
+.4byte sArcanineAnims_6_1
+.4byte sArcanineAnims_6_1
+.4byte sArcanineAnims_6_1
+.4byte sArcanineAnims_6_1
+.4byte sArcanineAnims_6_1
+sArcanineAnimTable7:
+.4byte sArcanineAnims_7_1
+.4byte sArcanineAnims_7_2
+.4byte sArcanineAnims_7_3
+.4byte sArcanineAnims_7_4
+.4byte sArcanineAnims_7_5
+.4byte sArcanineAnims_7_6
+.4byte sArcanineAnims_7_7
+.4byte sArcanineAnims_7_8
+sArcanineAnimTable8:
+.4byte sArcanineAnims_8_1
+.4byte sArcanineAnims_8_2
+.4byte sArcanineAnims_8_3
+.4byte sArcanineAnims_8_4
+.4byte sArcanineAnims_8_5
+.4byte sArcanineAnims_8_6
+.4byte sArcanineAnims_8_7
+.4byte sArcanineAnims_8_8
+sArcanineAnimTable9:
+.4byte sArcanineAnims_9_1
+.4byte sArcanineAnims_9_2
+.4byte sArcanineAnims_9_3
+.4byte sArcanineAnims_9_4
+.4byte sArcanineAnims_9_5
+.4byte sArcanineAnims_9_6
+.4byte sArcanineAnims_9_7
+.4byte sArcanineAnims_9_8
+sArcanineAnimTable10:
+.4byte sArcanineAnims_10_1
+.4byte sArcanineAnims_10_2
+.4byte sArcanineAnims_10_3
+.4byte sArcanineAnims_10_4
+.4byte sArcanineAnims_10_5
+.4byte sArcanineAnims_10_6
+.4byte sArcanineAnims_10_7
+.4byte sArcanineAnims_10_8
+sArcanineAnimTable11:
+.4byte sArcanineAnims_11_1
+.4byte sArcanineAnims_11_2
+.4byte sArcanineAnims_11_3
+.4byte sArcanineAnims_11_4
+.4byte sArcanineAnims_11_5
+.4byte sArcanineAnims_11_6
+.4byte sArcanineAnims_11_7
+.4byte sArcanineAnims_11_8
+sArcanineAnimTable12:
+.4byte sArcanineAnims_12_1
+.4byte sArcanineAnims_12_2
+.4byte sArcanineAnims_12_3
+.4byte sArcanineAnims_12_4
+.4byte sArcanineAnims_12_5
+.4byte sArcanineAnims_12_6
+.4byte sArcanineAnims_12_7
+.4byte sArcanineAnims_12_8
+sArcanineAnimTable13:
+.4byte sArcanineAnims_13_1
+.4byte sArcanineAnims_13_2
+.4byte sArcanineAnims_13_3
+.4byte sArcanineAnims_13_4
+.4byte sArcanineAnims_13_5
+.4byte sArcanineAnims_13_6
+.4byte sArcanineAnims_13_7
+.4byte sArcanineAnims_13_8
+sAxAnimationsArcanine:
+.4byte sArcanineAnimTable1
+.4byte sArcanineAnimTable2
+.4byte sArcanineAnimTable3
+.4byte sArcanineAnimTable4
+.4byte sArcanineAnimTable5
+.4byte sArcanineAnimTable6
+.4byte sArcanineAnimTable7
+.4byte sArcanineAnimTable8
+.4byte sArcanineAnimTable9
+.4byte sArcanineAnimTable10
+.4byte sArcanineAnimTable11
+.4byte sArcanineAnimTable12
+.4byte sArcanineAnimTable13
+sAxSpritesArcanine:
+.4byte sArcanineSprites1
+.4byte sArcanineSprites2
+.4byte sArcanineSprites3
+.4byte sArcanineSprites4
+.4byte sArcanineSprites5
+.4byte sArcanineSprites6
+.4byte sArcanineSprites7
+.4byte sArcanineSprites8
+.4byte sArcanineSprites9
+.4byte sArcanineSprites10
+.4byte sArcanineSprites11
+.4byte sArcanineSprites12
+.4byte sArcanineSprites13
+.4byte sArcanineSprites14
+.4byte sArcanineSprites15
+.4byte sArcanineSprites16
+.4byte sArcanineSprites17
+.4byte sArcanineSprites18
+.4byte sArcanineSprites19
+.4byte sArcanineSprites20
+.4byte sArcanineSprites21
+.4byte sArcanineSprites22
+.4byte sArcanineSprites23
+.4byte sArcanineSprites24
+.4byte sArcanineSprites25
+.4byte sArcanineSprites26
+.4byte sArcanineSprites27
+.4byte sArcanineSprites28
+.4byte sArcanineSprites29
+.4byte sArcanineSprites30
+.4byte sArcanineSprites31
+.4byte sArcanineSprites32
+.4byte sArcanineSprites33
+.4byte sArcanineSprites34
+.4byte sArcanineSprites35
+.4byte sArcanineSprites36
+.4byte sArcanineSprites37
+.4byte sArcanineSprites38
+.4byte sArcanineSprites39
+.4byte sArcanineSprites40
+.4byte sArcanineSprites41
+.4byte sArcanineSprites42
+.4byte sArcanineSprites43
+.4byte sArcanineSprites44
+.4byte sArcanineSprites45
+.4byte sArcanineSprites46
+sAxMainArcanine:
+ax_main sAxPosesArcanine, sAxAnimationsArcanine, 13, sAxSpritesArcanine, sAxPositionsArcanine

--- a/data/ax/ariados.inc
+++ b/data/ax/ariados.inc
@@ -1,0 +1,2678 @@
+.global gAxAriados
+gAxAriados:
+ax_siro sAxMainAriados
+sAriadosPose1:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose3:
+ax_pose 2, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose4:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose5:
+ax_pose 4, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose6:
+ax_pose 5, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose7:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose8:
+ax_pose 7, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose9:
+ax_pose 8, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose10:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose11:
+ax_pose 10, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose12:
+ax_pose 11, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose14:
+ax_pose 13, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose15:
+ax_pose 14, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose16:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose17:
+ax_pose 10, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose18:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose19:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose20:
+ax_pose 7, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose21:
+ax_pose 8, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose22:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose23:
+ax_pose 4, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose24:
+ax_pose 5, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose25:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose26:
+ax_pose 1, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose27:
+ax_pose 2, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose28:
+ax_pose 15, 0x01ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sAriadosPose29:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose30:
+ax_pose 4, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose31:
+ax_pose 5, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose32:
+ax_pose 16, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose33:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose34:
+ax_pose 7, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose35:
+ax_pose 8, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose36:
+ax_pose 17, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose37:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose38:
+ax_pose 10, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose39:
+ax_pose 11, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose40:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose41:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose42:
+ax_pose 13, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose43:
+ax_pose 14, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose44:
+ax_pose 19, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose45:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose46:
+ax_pose 10, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose47:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose48:
+ax_pose 18, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose49:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose50:
+ax_pose 7, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose51:
+ax_pose 8, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose52:
+ax_pose 17, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose53:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose54:
+ax_pose 4, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose55:
+ax_pose 5, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose56:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose57:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose58:
+ax_pose 1, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose59:
+ax_pose 2, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose60:
+ax_pose 15, 0x01ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sAriadosPose61:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose62:
+ax_pose 4, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose63:
+ax_pose 5, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose64:
+ax_pose 16, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose65:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose66:
+ax_pose 7, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose67:
+ax_pose 8, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose68:
+ax_pose 17, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose69:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose70:
+ax_pose 10, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose71:
+ax_pose 11, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose72:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose73:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose74:
+ax_pose 13, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose75:
+ax_pose 14, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose76:
+ax_pose 19, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose77:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose78:
+ax_pose 10, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose79:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose80:
+ax_pose 18, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose81:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose82:
+ax_pose 7, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose83:
+ax_pose 8, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose84:
+ax_pose 17, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose85:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose86:
+ax_pose 4, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose87:
+ax_pose 5, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose88:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose89:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose90:
+ax_pose 20, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose91:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose92:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose93:
+ax_pose 22, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose94:
+ax_pose 23, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose95:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose96:
+ax_pose 24, 0x01ed, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose97:
+ax_pose 25, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose98:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose99:
+ax_pose 26, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose100:
+ax_pose 27, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose101:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose102:
+ax_pose 28, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose103:
+ax_pose 29, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose104:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose105:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose106:
+ax_pose 27, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose107:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose108:
+ax_pose 24, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose109:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose110:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose111:
+ax_pose 22, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose112:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose113:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose114:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose115:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose116:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose117:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose118:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose119:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose120:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose121:
+ax_pose 30, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose122:
+ax_pose 31, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose123:
+ax_pose 32, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sAriadosPose124:
+ax_pose 33, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose125:
+ax_pose 34, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sAriadosPose126:
+ax_pose 35, 0x01e4, 0x90ee, 0x2c00
+ax_pose_terminator
+sAriadosPose127:
+ax_pose 36, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sAriadosPose128:
+ax_pose 35, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sAriadosPose129:
+ax_pose 34, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sAriadosPose130:
+ax_pose 33, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sAriadosPose131:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose132:
+ax_pose 20, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose133:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose134:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose135:
+ax_pose 22, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose136:
+ax_pose 23, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose137:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose138:
+ax_pose 24, 0x01ed, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose139:
+ax_pose 25, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose140:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose141:
+ax_pose 26, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose142:
+ax_pose 27, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose143:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose144:
+ax_pose 28, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose145:
+ax_pose 29, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose146:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose147:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose148:
+ax_pose 27, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose149:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose150:
+ax_pose 24, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose151:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose152:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose153:
+ax_pose 22, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose154:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose155:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose156:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose157:
+ax_pose 6, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sAriadosPose158:
+ax_pose 9, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sAriadosPose159:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose160:
+ax_pose 9, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sAriadosPose161:
+ax_pose 6, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sAriadosPose162:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose163:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose164:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose165:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sAriadosPose166:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sAriadosPose167:
+ax_pose 29, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose168:
+ax_pose 27, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sAriadosPose169:
+ax_pose 25, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sAriadosPose170:
+ax_pose 23, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose171:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose172:
+ax_pose 23, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose173:
+ax_pose 25, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sAriadosPose174:
+ax_pose 27, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sAriadosPose175:
+ax_pose 29, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose176:
+ax_pose 27, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sAriadosPose177:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sAriadosPose178:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose179:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose180:
+ax_pose 20, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose181:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose182:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose183:
+ax_pose 22, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose184:
+ax_pose 23, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose185:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose186:
+ax_pose 24, 0x01ed, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose187:
+ax_pose 25, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose188:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose189:
+ax_pose 26, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose190:
+ax_pose 27, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose191:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose192:
+ax_pose 28, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose193:
+ax_pose 29, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose194:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose195:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose196:
+ax_pose 27, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose197:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose198:
+ax_pose 24, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose199:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose200:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose201:
+ax_pose 22, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose202:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose203:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose204:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose205:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sAriadosPose206:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sAriadosPose207:
+ax_pose 29, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose208:
+ax_pose 27, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sAriadosPose209:
+ax_pose 25, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sAriadosPose210:
+ax_pose 23, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose211:
+ax_pose 0, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose212:
+ax_pose 3, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose213:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose214:
+ax_pose 9, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose215:
+ax_pose 12, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sAriadosPose216:
+ax_pose 9, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose217:
+ax_pose 6, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sAriadosPose218:
+ax_pose 3, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+.align 2
+sAriadosAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_2_1:
+ax_anim 1, 0, 25, 0, -3, 0, -3,
+ax_anim 6, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 1, 27, 1, 15, 1, 15,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 0, 27, 1, 15, 1, 15,
+ax_anim 2, 0, 24, 0, 6, 0, 9,
+ax_anim 3, 0, 24, 0, -3, 0, 4,
+ax_anim 4, 0, 24, 0, -2, 0, 1,
+ax_anim_terminator
+sAriadosAnims_2_2:
+ax_anim 1, 0, 29, -3, -3, -3, -3,
+ax_anim 6, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 15, 15, 15, 15,
+ax_anim 2, 1, 31, 16, 14, 16, 14,
+ax_anim 2, 0, 31, 15, 15, 15, 15,
+ax_anim 2, 0, 31, 16, 14, 16, 14,
+ax_anim 2, 0, 28, 10, -3, 10, 10,
+ax_anim 3, 0, 28, 8, -4, 8, 8,
+ax_anim 4, 0, 28, 4, -1, 4, 4,
+ax_anim_terminator
+sAriadosAnims_2_3:
+ax_anim 1, 0, 33, -3, 0, -3, 0,
+ax_anim 6, 0, 33, -4, 0, -4, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 1, 35, 16, 0, 15, 1,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 0, 35, 16, 0, 15, 1,
+ax_anim 2, 0, 32, 10, -6, 10, 0,
+ax_anim 3, 0, 32, 6, -5, 8, 0,
+ax_anim 4, 0, 32, 4, -3, 4, 0,
+ax_anim_terminator
+sAriadosAnims_2_4:
+ax_anim 1, 0, 37, -3, 3, -3, 3,
+ax_anim 6, 0, 37, -4, 4, -4, 4,
+ax_anim 1, 2, 39, 4, -4, 4, -4,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 1, 39, 16, -14, 16, -14,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 0, 39, 16, -14, 16, -14,
+ax_anim 2, 0, 36, 10, -13, 10, -10,
+ax_anim 3, 0, 36, 8, -10, 8, -8,
+ax_anim 4, 0, 36, 4, -5, 4, -4,
+ax_anim_terminator
+sAriadosAnims_2_5:
+ax_anim 1, 0, 41, 0, 3, 0, 3,
+ax_anim 6, 0, 41, 0, 4, 0, 4,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -10, 0, -10,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 40, 0, -11, 0, -9,
+ax_anim 3, 0, 40, 0, -9, 0, -4,
+ax_anim 4, 0, 40, 0, -3, 0, -1,
+ax_anim_terminator
+sAriadosAnims_2_6:
+ax_anim 1, 0, 45, 3, 3, 3, 3,
+ax_anim 6, 0, 45, 4, 4, 4, 4,
+ax_anim 1, 2, 47, -4, -4, -4, -4,
+ax_anim 1, 0, 47, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 1, 47, -16, -14, -16, -14,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 0, 47, -16, -14, -16, -14,
+ax_anim 2, 0, 44, -10, -13, -10, -10,
+ax_anim 3, 0, 44, -8, -10, -8, -8,
+ax_anim 4, 0, 44, -4, -5, -4, -4,
+ax_anim_terminator
+sAriadosAnims_2_7:
+ax_anim 1, 0, 49, 3, 0, 3, 0,
+ax_anim 6, 0, 49, 4, 0, 4, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 1, 51, -16, 0, -15, 1,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -16, 0, -15, 1,
+ax_anim 2, 0, 48, -10, -6, -10, 0,
+ax_anim 3, 0, 48, -6, -5, -8, 0,
+ax_anim 4, 0, 48, -4, -3, -4, 0,
+ax_anim_terminator
+sAriadosAnims_2_8:
+ax_anim 1, 0, 53, 3, -3, 3, -3,
+ax_anim 6, 0, 53, 4, -4, 4, -4,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -15, 15, -15, 15,
+ax_anim 2, 1, 55, -16, 14, -16, 14,
+ax_anim 2, 0, 55, -15, 15, -15, 15,
+ax_anim 2, 0, 55, -16, 14, -16, 14,
+ax_anim 2, 0, 52, -10, -3, -10, 10,
+ax_anim 3, 0, 52, -8, -4, -8, 8,
+ax_anim 4, 0, 52, -4, -1, -4, 4,
+ax_anim_terminator
+.align 2
+sAriadosAnims_3_1:
+ax_anim 1, 0, 57, 0, -3, 0, -3,
+ax_anim 6, 0, 57, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 1, 59, 1, 15, 1, 15,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 0, 59, 1, 15, 1, 15,
+ax_anim 2, 0, 56, 0, 6, 0, 9,
+ax_anim 3, 0, 56, 0, -3, 0, 4,
+ax_anim 4, 0, 56, 0, -2, 0, 1,
+ax_anim_terminator
+sAriadosAnims_3_2:
+ax_anim 1, 0, 61, -3, -3, -3, -3,
+ax_anim 6, 0, 61, -4, -4, -4, -4,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 15, 15, 15, 15,
+ax_anim 2, 1, 63, 16, 14, 16, 14,
+ax_anim 2, 0, 63, 15, 15, 15, 15,
+ax_anim 2, 0, 63, 16, 14, 16, 14,
+ax_anim 2, 0, 60, 10, -3, 10, 10,
+ax_anim 3, 0, 60, 8, -4, 8, 8,
+ax_anim 4, 0, 60, 4, -1, 4, 4,
+ax_anim_terminator
+sAriadosAnims_3_3:
+ax_anim 1, 0, 65, -3, 0, -3, 0,
+ax_anim 6, 0, 65, -4, 0, -4, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 1, 67, 16, 0, 15, 1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 67, 16, 0, 15, 1,
+ax_anim 2, 0, 64, 10, -6, 10, 0,
+ax_anim 3, 0, 64, 6, -5, 8, 0,
+ax_anim 4, 0, 64, 4, -3, 4, 0,
+ax_anim_terminator
+sAriadosAnims_3_4:
+ax_anim 1, 0, 69, -3, 3, -3, 3,
+ax_anim 6, 0, 69, -4, 4, -4, 4,
+ax_anim 1, 2, 71, 4, -4, 4, -4,
+ax_anim 1, 0, 71, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 15, -15, 15, -15,
+ax_anim 2, 1, 71, 16, -14, 16, -14,
+ax_anim 2, 0, 71, 15, -15, 15, -15,
+ax_anim 2, 0, 71, 16, -14, 16, -14,
+ax_anim 2, 0, 68, 10, -13, 10, -10,
+ax_anim 3, 0, 68, 8, -10, 8, -8,
+ax_anim 4, 0, 68, 4, -5, 4, -4,
+ax_anim_terminator
+sAriadosAnims_3_5:
+ax_anim 1, 0, 73, 0, 3, 0, 3,
+ax_anim 6, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -10, 0, -10,
+ax_anim 2, 0, 75, 0, -15, 0, -15,
+ax_anim 2, 1, 75, 1, -15, 1, -15,
+ax_anim 2, 0, 75, 0, -15, 0, -15,
+ax_anim 2, 0, 75, 1, -15, 1, -15,
+ax_anim 2, 0, 72, 0, -11, 0, -9,
+ax_anim 3, 0, 72, 0, -9, 0, -4,
+ax_anim 4, 0, 72, 0, -3, 0, -1,
+ax_anim_terminator
+sAriadosAnims_3_6:
+ax_anim 1, 0, 77, 3, 3, 3, 3,
+ax_anim 6, 0, 77, 4, 4, 4, 4,
+ax_anim 1, 2, 79, -4, -4, -4, -4,
+ax_anim 1, 0, 79, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -15, -15, -15, -15,
+ax_anim 2, 1, 79, -16, -14, -16, -14,
+ax_anim 2, 0, 79, -15, -15, -15, -15,
+ax_anim 2, 0, 79, -16, -14, -16, -14,
+ax_anim 2, 0, 76, -10, -13, -10, -10,
+ax_anim 3, 0, 76, -8, -10, -8, -8,
+ax_anim 4, 0, 76, -4, -5, -4, -4,
+ax_anim_terminator
+sAriadosAnims_3_7:
+ax_anim 1, 0, 81, 3, 0, 3, 0,
+ax_anim 6, 0, 81, 4, 0, 4, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 1, 83, -16, 0, -15, 1,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 83, -16, 0, -15, 1,
+ax_anim 2, 0, 80, -10, -6, -10, 0,
+ax_anim 3, 0, 80, -6, -5, -8, 0,
+ax_anim 4, 0, 80, -4, -3, -4, 0,
+ax_anim_terminator
+sAriadosAnims_3_8:
+ax_anim 1, 0, 85, 3, -3, 3, -3,
+ax_anim 6, 0, 85, 4, -4, 4, -4,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -15, 15, -15, 15,
+ax_anim 2, 1, 87, -16, 14, -16, 14,
+ax_anim 2, 0, 87, -15, 15, -15, 15,
+ax_anim 2, 0, 87, -16, 14, -16, 14,
+ax_anim 2, 0, 84, -10, -3, -10, 10,
+ax_anim 3, 0, 84, -8, -4, -8, 8,
+ax_anim 4, 0, 84, -4, -1, -4, 4,
+ax_anim_terminator
+.align 2
+sAriadosAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 0, 89, 0, -4, 0, -4,
+ax_anim 2, 0, 88, 0, -4, 0, -4,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 2, 90, -1, 4, -1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, -1, 4, -1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 1, 90, -1, 4, -1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, -1, 4, -1, 4,
+ax_anim 4, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sAriadosAnims_4_2:
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 6, 0, 92, -4, -4, -4, -4,
+ax_anim 2, 0, 91, -4, -4, -4, -4,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 2, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 1, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 4, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sAriadosAnims_4_3:
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 6, 0, 95, -4, 0, -4, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 2, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 1, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 4, 1, 4, 1,
+ax_anim 4, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sAriadosAnims_4_4:
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 6, 0, 98, -4, 4, -4, 4,
+ax_anim 2, 0, 97, -4, 4, -4, 4,
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 2, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 1, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 4, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sAriadosAnims_4_5:
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 6, 0, 101, 0, 4, 0, 4,
+ax_anim 2, 0, 100, 0, 4, 0, 4,
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 2, 102, -1, -4, -1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, -1, -4, -1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 1, 102, -1, -4, -1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, -1, -4, -1, -4,
+ax_anim 4, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sAriadosAnims_4_6:
+ax_anim 2, 0, 104, 1, 1, 1, 1,
+ax_anim 6, 0, 104, 4, 4, 4, 4,
+ax_anim 2, 0, 103, 4, 4, 4, 4,
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 2, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 1, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 4, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sAriadosAnims_4_7:
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 6, 0, 107, 4, 0, 4, 0,
+ax_anim 2, 0, 106, 4, 0, 4, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 2, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 1, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -4, 1, -4, 1,
+ax_anim 4, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sAriadosAnims_4_8:
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 6, 0, 110, 4, -4, 4, -4,
+ax_anim 2, 0, 109, 4, -4, 4, -4,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 2, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 1, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 4, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sAriadosAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sAriadosAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sAriadosAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sAriadosAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sAriadosAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sAriadosAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sAriadosAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sAriadosAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sAriadosAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 0, 1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 0, 1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 0, 1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 1, 0, 1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 1, 0, 1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 1, 0, 1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 1, 1, 1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 1, 1, 1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 1, 1, 1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 1, -1, 1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 1, -1, 1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 1, -1, 1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 1, 0, 1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 1, 0, 1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 1, 0, 1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, -1, -1, -1,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, -1, -1, -1,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, -1, -1, -1,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 17, 7, 17,
+ax_anim 3, 0, 158, 0, 21, 0, 21,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 22, 9, 22, 9,
+ax_anim 3, 0, 157, 21, 17, 21, 17,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 0, 12, 0, 12,
+ax_anim 1, 0, 168, -2, 7, -2, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -4, 17, -4,
+ax_anim 3, 0, 156, 22, 0, 22, 0,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 4, -18, 4, -18,
+ax_anim 2, 0, 154, 12, -22, 12, -22,
+ax_anim 3, 0, 155, 21, -19, 21, -19,
+ax_anim 2, 3, 164, 23, -12, 23, -12,
+ax_anim 2, 0, 165, 18, -5, 18, -5,
+ax_anim 1, 0, 166, 8, 1, 8, 1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -10, -10, -10, -10,
+ax_anim 2, 0, 161, -9, -18, -9, -18,
+ax_anim 3, 0, 154, -1, -21, -1, -25,
+ax_anim 2, 3, 163, 8, -18, 8, -18,
+ax_anim 2, 0, 164, 10, -10, 10, -10,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -18, -4, -18,
+ax_anim 2, 0, 154, -12, -22, -12, -22,
+ax_anim 3, 0, 161, -21, -19, -21, -19,
+ax_anim 2, 3, 168, -23, -12, -23, -12,
+ax_anim 2, 0, 167, -18, -5, -18, -5,
+ax_anim 1, 0, 166, -8, 1, -8, 1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -4, -17, -4,
+ax_anim 3, 0, 160, -22, 0, -22, 0,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -22, 9, -22, 9,
+ax_anim 3, 0, 159, -21, 17, -21, 17,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, 0, 12, 0, 12,
+ax_anim 1, 0, 164, 2, 7, 2, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAriadosAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sAriadosGfx1:
+.incbin "baserom.gba", 0xC5D9F8, 0x200
+sAriadosSprites1:
+ax_sprite sAriadosGfx1, 0x200
+ax_sprite_terminator
+sAriadosGfx2:
+.incbin "baserom.gba", 0xC5DC08, 0x200
+sAriadosSprites2:
+ax_sprite sAriadosGfx2, 0x200
+ax_sprite_terminator
+sAriadosGfx3:
+.incbin "baserom.gba", 0xC5DE18, 0x200
+sAriadosSprites3:
+ax_sprite sAriadosGfx3, 0x200
+ax_sprite_terminator
+sAriadosGfx4:
+.incbin "baserom.gba", 0xC5E028, 0x200
+sAriadosSprites4:
+ax_sprite sAriadosGfx4, 0x200
+ax_sprite_terminator
+sAriadosGfx5:
+.incbin "baserom.gba", 0xC5E238, 0x200
+sAriadosSprites5:
+ax_sprite sAriadosGfx5, 0x200
+ax_sprite_terminator
+sAriadosGfx6:
+.incbin "baserom.gba", 0xC5E448, 0x200
+sAriadosSprites6:
+ax_sprite sAriadosGfx6, 0x200
+ax_sprite_terminator
+sAriadosGfx7:
+.incbin "baserom.gba", 0xC5E658, 0x200
+sAriadosSprites7:
+ax_sprite sAriadosGfx7, 0x200
+ax_sprite_terminator
+sAriadosGfx8:
+.incbin "baserom.gba", 0xC5E868, 0x200
+sAriadosSprites8:
+ax_sprite sAriadosGfx8, 0x200
+ax_sprite_terminator
+sAriadosGfx9:
+.incbin "baserom.gba", 0xC5EA78, 0x200
+sAriadosSprites9:
+ax_sprite sAriadosGfx9, 0x200
+ax_sprite_terminator
+sAriadosGfx10:
+.incbin "baserom.gba", 0xC5EC88, 0x200
+sAriadosSprites10:
+ax_sprite sAriadosGfx10, 0x200
+ax_sprite_terminator
+sAriadosGfx11:
+.incbin "baserom.gba", 0xC5EE98, 0x200
+sAriadosSprites11:
+ax_sprite sAriadosGfx11, 0x200
+ax_sprite_terminator
+sAriadosGfx12:
+.incbin "baserom.gba", 0xC5F0A8, 0x200
+sAriadosSprites12:
+ax_sprite sAriadosGfx12, 0x200
+ax_sprite_terminator
+sAriadosGfx13:
+.incbin "baserom.gba", 0xC5F2B8, 0x200
+sAriadosSprites13:
+ax_sprite sAriadosGfx13, 0x200
+ax_sprite_terminator
+sAriadosGfx14:
+.incbin "baserom.gba", 0xC5F4C8, 0x200
+sAriadosSprites14:
+ax_sprite sAriadosGfx14, 0x200
+ax_sprite_terminator
+sAriadosGfx15:
+.incbin "baserom.gba", 0xC5F6D8, 0x200
+sAriadosSprites15:
+ax_sprite sAriadosGfx15, 0x200
+ax_sprite_terminator
+sAriadosGfx16:
+.incbin "baserom.gba", 0xC5F8E8, 0x60
+sAriadosGfx16_1:
+.incbin "baserom.gba", 0xC5F948, 0x60
+sAriadosGfx16_2:
+.incbin "baserom.gba", 0xC5F9A8, 0x60
+sAriadosSprites16:
+ax_sprite sAriadosGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAriadosGfx17:
+.incbin "baserom.gba", 0xC5FA40, 0x40
+sAriadosGfx17_1:
+.incbin "baserom.gba", 0xC5FA80, 0x140
+sAriadosSprites17:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAriadosGfx17_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAriadosGfx18:
+.incbin "baserom.gba", 0xC5FBF0, 0x40
+sAriadosGfx18_1:
+.incbin "baserom.gba", 0xC5FC30, 0x140
+sAriadosSprites18:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx18_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAriadosGfx19:
+.incbin "baserom.gba", 0xC5FDA0, 0x180
+sAriadosSprites19:
+ax_sprite sAriadosGfx19, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAriadosGfx20:
+.incbin "baserom.gba", 0xC5FF38, 0x40
+sAriadosGfx20_1:
+.incbin "baserom.gba", 0xC5FF78, 0x100
+sAriadosSprites20:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAriadosGfx21:
+.incbin "baserom.gba", 0xC600A8, 0x40
+sAriadosGfx21_1:
+.incbin "baserom.gba", 0xC600E8, 0x100
+sAriadosSprites21:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAriadosGfx22:
+.incbin "baserom.gba", 0xC60218, 0x40
+sAriadosGfx22_1:
+.incbin "baserom.gba", 0xC60258, 0x180
+sAriadosSprites22:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx22_1, 0x180
+ax_sprite_terminator
+sAriadosGfx23:
+.incbin "baserom.gba", 0xC60400, 0x100
+sAriadosGfx23_1:
+.incbin "baserom.gba", 0xC60500, 0x60
+sAriadosSprites23:
+ax_sprite sAriadosGfx23, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx23_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAriadosGfx24:
+.incbin "baserom.gba", 0xC60588, 0x40
+sAriadosGfx24_1:
+.incbin "baserom.gba", 0xC605C8, 0x60
+sAriadosGfx24_2:
+.incbin "baserom.gba", 0xC60628, 0x100
+sAriadosSprites24:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx24_2, 0x100
+ax_sprite_terminator
+sAriadosGfx25:
+.incbin "baserom.gba", 0xC60760, 0x180
+sAriadosSprites25:
+ax_sprite sAriadosGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sAriadosGfx26:
+.incbin "baserom.gba", 0xC608F8, 0x60
+sAriadosGfx26_1:
+.incbin "baserom.gba", 0xC60958, 0x60
+sAriadosGfx26_2:
+.incbin "baserom.gba", 0xC609B8, 0x60
+sAriadosGfx26_3:
+.incbin "baserom.gba", 0xC60A18, 0x60
+sAriadosSprites26:
+ax_sprite sAriadosGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAriadosGfx27:
+.incbin "baserom.gba", 0xC60AC0, 0x40
+sAriadosGfx27_1:
+.incbin "baserom.gba", 0xC60B00, 0x100
+sAriadosGfx27_2:
+.incbin "baserom.gba", 0xC60C00, 0x60
+sAriadosSprites27:
+ax_sprite sAriadosGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAriadosGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx27_2, 0x60
+ax_sprite_terminator
+sAriadosGfx28:
+.incbin "baserom.gba", 0xC60C90, 0x60
+sAriadosGfx28_1:
+.incbin "baserom.gba", 0xC60CF0, 0x60
+sAriadosGfx28_2:
+.incbin "baserom.gba", 0xC60D50, 0x60
+sAriadosGfx28_3:
+.incbin "baserom.gba", 0xC60DB0, 0x60
+sAriadosSprites28:
+ax_sprite sAriadosGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAriadosGfx29:
+.incbin "baserom.gba", 0xC60E58, 0x40
+sAriadosGfx29_1:
+.incbin "baserom.gba", 0xC60E98, 0x60
+sAriadosGfx29_2:
+.incbin "baserom.gba", 0xC60EF8, 0x100
+sAriadosSprites29:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx29_2, 0x100
+ax_sprite_terminator
+sAriadosGfx30:
+.incbin "baserom.gba", 0xC61030, 0x40
+sAriadosGfx30_1:
+.incbin "baserom.gba", 0xC61070, 0x120
+sAriadosGfx30_2:
+.incbin "baserom.gba", 0xC61190, 0x20
+sAriadosSprites30:
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAriadosGfx30_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite sAriadosGfx30_2, 0x20
+ax_sprite_terminator
+sAriadosGfx31:
+.incbin "baserom.gba", 0xC611E8, 0x200
+sAriadosSprites31:
+ax_sprite sAriadosGfx31, 0x200
+ax_sprite_terminator
+sAriadosGfx32:
+.incbin "baserom.gba", 0xC613F8, 0x200
+sAriadosSprites32:
+ax_sprite sAriadosGfx32, 0x200
+ax_sprite_terminator
+sAriadosGfx33:
+.incbin "baserom.gba", 0xC61608, 0x200
+sAriadosSprites33:
+ax_sprite sAriadosGfx33, 0x200
+ax_sprite_terminator
+sAriadosGfx34:
+.incbin "baserom.gba", 0xC61818, 0x200
+sAriadosSprites34:
+ax_sprite sAriadosGfx34, 0x200
+ax_sprite_terminator
+sAriadosGfx35:
+.incbin "baserom.gba", 0xC61A28, 0x200
+sAriadosSprites35:
+ax_sprite sAriadosGfx35, 0x200
+ax_sprite_terminator
+sAriadosGfx36:
+.incbin "baserom.gba", 0xC61C38, 0x200
+sAriadosSprites36:
+ax_sprite sAriadosGfx36, 0x200
+ax_sprite_terminator
+sAriadosGfx37:
+.incbin "baserom.gba", 0xC61E48, 0x200
+sAriadosSprites37:
+ax_sprite sAriadosGfx37, 0x200
+ax_sprite_terminator
+sAxPosesAriados:
+.4byte sAriadosPose1
+.4byte sAriadosPose2
+.4byte sAriadosPose3
+.4byte sAriadosPose4
+.4byte sAriadosPose5
+.4byte sAriadosPose6
+.4byte sAriadosPose7
+.4byte sAriadosPose8
+.4byte sAriadosPose9
+.4byte sAriadosPose10
+.4byte sAriadosPose11
+.4byte sAriadosPose12
+.4byte sAriadosPose13
+.4byte sAriadosPose14
+.4byte sAriadosPose15
+.4byte sAriadosPose16
+.4byte sAriadosPose17
+.4byte sAriadosPose18
+.4byte sAriadosPose19
+.4byte sAriadosPose20
+.4byte sAriadosPose21
+.4byte sAriadosPose22
+.4byte sAriadosPose23
+.4byte sAriadosPose24
+.4byte sAriadosPose25
+.4byte sAriadosPose26
+.4byte sAriadosPose27
+.4byte sAriadosPose28
+.4byte sAriadosPose29
+.4byte sAriadosPose30
+.4byte sAriadosPose31
+.4byte sAriadosPose32
+.4byte sAriadosPose33
+.4byte sAriadosPose34
+.4byte sAriadosPose35
+.4byte sAriadosPose36
+.4byte sAriadosPose37
+.4byte sAriadosPose38
+.4byte sAriadosPose39
+.4byte sAriadosPose40
+.4byte sAriadosPose41
+.4byte sAriadosPose42
+.4byte sAriadosPose43
+.4byte sAriadosPose44
+.4byte sAriadosPose45
+.4byte sAriadosPose46
+.4byte sAriadosPose47
+.4byte sAriadosPose48
+.4byte sAriadosPose49
+.4byte sAriadosPose50
+.4byte sAriadosPose51
+.4byte sAriadosPose52
+.4byte sAriadosPose53
+.4byte sAriadosPose54
+.4byte sAriadosPose55
+.4byte sAriadosPose56
+.4byte sAriadosPose57
+.4byte sAriadosPose58
+.4byte sAriadosPose59
+.4byte sAriadosPose60
+.4byte sAriadosPose61
+.4byte sAriadosPose62
+.4byte sAriadosPose63
+.4byte sAriadosPose64
+.4byte sAriadosPose65
+.4byte sAriadosPose66
+.4byte sAriadosPose67
+.4byte sAriadosPose68
+.4byte sAriadosPose69
+.4byte sAriadosPose70
+.4byte sAriadosPose71
+.4byte sAriadosPose72
+.4byte sAriadosPose73
+.4byte sAriadosPose74
+.4byte sAriadosPose75
+.4byte sAriadosPose76
+.4byte sAriadosPose77
+.4byte sAriadosPose78
+.4byte sAriadosPose79
+.4byte sAriadosPose80
+.4byte sAriadosPose81
+.4byte sAriadosPose82
+.4byte sAriadosPose83
+.4byte sAriadosPose84
+.4byte sAriadosPose85
+.4byte sAriadosPose86
+.4byte sAriadosPose87
+.4byte sAriadosPose88
+.4byte sAriadosPose89
+.4byte sAriadosPose90
+.4byte sAriadosPose91
+.4byte sAriadosPose92
+.4byte sAriadosPose93
+.4byte sAriadosPose94
+.4byte sAriadosPose95
+.4byte sAriadosPose96
+.4byte sAriadosPose97
+.4byte sAriadosPose98
+.4byte sAriadosPose99
+.4byte sAriadosPose100
+.4byte sAriadosPose101
+.4byte sAriadosPose102
+.4byte sAriadosPose103
+.4byte sAriadosPose104
+.4byte sAriadosPose105
+.4byte sAriadosPose106
+.4byte sAriadosPose107
+.4byte sAriadosPose108
+.4byte sAriadosPose109
+.4byte sAriadosPose110
+.4byte sAriadosPose111
+.4byte sAriadosPose112
+.4byte sAriadosPose113
+.4byte sAriadosPose114
+.4byte sAriadosPose115
+.4byte sAriadosPose116
+.4byte sAriadosPose117
+.4byte sAriadosPose118
+.4byte sAriadosPose119
+.4byte sAriadosPose120
+.4byte sAriadosPose121
+.4byte sAriadosPose122
+.4byte sAriadosPose123
+.4byte sAriadosPose124
+.4byte sAriadosPose125
+.4byte sAriadosPose126
+.4byte sAriadosPose127
+.4byte sAriadosPose128
+.4byte sAriadosPose129
+.4byte sAriadosPose130
+.4byte sAriadosPose131
+.4byte sAriadosPose132
+.4byte sAriadosPose133
+.4byte sAriadosPose134
+.4byte sAriadosPose135
+.4byte sAriadosPose136
+.4byte sAriadosPose137
+.4byte sAriadosPose138
+.4byte sAriadosPose139
+.4byte sAriadosPose140
+.4byte sAriadosPose141
+.4byte sAriadosPose142
+.4byte sAriadosPose143
+.4byte sAriadosPose144
+.4byte sAriadosPose145
+.4byte sAriadosPose146
+.4byte sAriadosPose147
+.4byte sAriadosPose148
+.4byte sAriadosPose149
+.4byte sAriadosPose150
+.4byte sAriadosPose151
+.4byte sAriadosPose152
+.4byte sAriadosPose153
+.4byte sAriadosPose154
+.4byte sAriadosPose155
+.4byte sAriadosPose156
+.4byte sAriadosPose157
+.4byte sAriadosPose158
+.4byte sAriadosPose159
+.4byte sAriadosPose160
+.4byte sAriadosPose161
+.4byte sAriadosPose162
+.4byte sAriadosPose163
+.4byte sAriadosPose164
+.4byte sAriadosPose165
+.4byte sAriadosPose166
+.4byte sAriadosPose167
+.4byte sAriadosPose168
+.4byte sAriadosPose169
+.4byte sAriadosPose170
+.4byte sAriadosPose171
+.4byte sAriadosPose172
+.4byte sAriadosPose173
+.4byte sAriadosPose174
+.4byte sAriadosPose175
+.4byte sAriadosPose176
+.4byte sAriadosPose177
+.4byte sAriadosPose178
+.4byte sAriadosPose179
+.4byte sAriadosPose180
+.4byte sAriadosPose181
+.4byte sAriadosPose182
+.4byte sAriadosPose183
+.4byte sAriadosPose184
+.4byte sAriadosPose185
+.4byte sAriadosPose186
+.4byte sAriadosPose187
+.4byte sAriadosPose188
+.4byte sAriadosPose189
+.4byte sAriadosPose190
+.4byte sAriadosPose191
+.4byte sAriadosPose192
+.4byte sAriadosPose193
+.4byte sAriadosPose194
+.4byte sAriadosPose195
+.4byte sAriadosPose196
+.4byte sAriadosPose197
+.4byte sAriadosPose198
+.4byte sAriadosPose199
+.4byte sAriadosPose200
+.4byte sAriadosPose201
+.4byte sAriadosPose202
+.4byte sAriadosPose203
+.4byte sAriadosPose204
+.4byte sAriadosPose205
+.4byte sAriadosPose206
+.4byte sAriadosPose207
+.4byte sAriadosPose208
+.4byte sAriadosPose209
+.4byte sAriadosPose210
+.4byte sAriadosPose211
+.4byte sAriadosPose212
+.4byte sAriadosPose213
+.4byte sAriadosPose214
+.4byte sAriadosPose215
+.4byte sAriadosPose216
+.4byte sAriadosPose217
+.4byte sAriadosPose218
+sAxPositionsAriados:
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -1,    2, 	  -8,    5, 	   8,   -1, 	  -1,   -7
+.2byte   -1,    0, 	 -10,   -1, 	   6,    5, 	  -1,   -8
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte    7,    1, 	  13,   -1, 	  -6,    2, 	  -3,   -9
+.2byte    7,   -1, 	   7,   -6, 	   1,    5, 	   0,   -9
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte   11,   -3, 	   8,   -5, 	   1,    2, 	  -2,   -8
+.2byte   11,   -4, 	   0,   -7, 	   9,    2, 	  -2,   -9
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte    6,  -10, 	   3,  -12, 	   7,   -1, 	  -2,   -8
+.2byte    7,  -12, 	  -2,  -11, 	  10,   -4, 	  -4,   -8
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -11, 	  -9,   -8, 	  -2,   -7
+.2byte   -1,  -14, 	   7,   -8, 	  -7,  -10, 	   0,   -8
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -8,  -10, 	  -5,  -12, 	  -9,   -1, 	   0,   -8
+.2byte   -9,  -12, 	   0,  -11, 	 -12,   -4, 	   2,   -8
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte  -13,   -3, 	 -10,   -5, 	  -3,    2, 	   0,   -8
+.2byte  -13,   -4, 	  -2,   -7, 	 -11,    2, 	   0,   -9
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte   -9,    1, 	 -15,   -1, 	   4,    2, 	   1,   -9
+.2byte   -9,   -1, 	  -9,   -6, 	  -3,    5, 	  -2,   -9
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -1,    2, 	  -8,    5, 	   8,   -1, 	  -1,   -7
+.2byte   -1,    0, 	 -10,   -1, 	   6,    5, 	  -1,   -8
+.2byte   -1,    3, 	 -11,    4, 	   9,    4, 	  -1,   -7
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte    7,    1, 	  13,   -1, 	  -6,    2, 	  -3,   -9
+.2byte    7,   -1, 	   7,   -6, 	   1,    5, 	   0,   -9
+.2byte    7,    1, 	  12,    0, 	   0,    5, 	   2,   -5
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte   11,   -3, 	   8,   -5, 	   1,    2, 	  -2,   -8
+.2byte   11,   -4, 	   0,   -7, 	   9,    2, 	  -2,   -9
+.2byte   11,   -2, 	   8,   -5, 	   8,    3, 	   4,   -7
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte    6,  -10, 	   3,  -12, 	   7,   -1, 	  -2,   -8
+.2byte    7,  -12, 	  -2,  -11, 	  10,   -4, 	  -4,   -8
+.2byte    6,  -10, 	   2,  -11, 	  12,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -11, 	  -9,   -8, 	  -2,   -7
+.2byte   -1,  -14, 	   7,   -8, 	  -7,  -10, 	   0,   -8
+.2byte   -1,  -12, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -8,  -10, 	  -5,  -12, 	  -9,   -1, 	   0,   -8
+.2byte   -9,  -12, 	   0,  -11, 	 -12,   -4, 	   2,   -8
+.2byte   -8,  -10, 	  -4,  -11, 	 -14,   -4, 	  -1,   -9
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte  -13,   -3, 	 -10,   -5, 	  -3,    2, 	   0,   -8
+.2byte  -13,   -4, 	  -2,   -7, 	 -11,    2, 	   0,   -9
+.2byte  -13,   -2, 	 -10,   -5, 	 -10,    3, 	  -6,   -7
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte   -9,    1, 	 -15,   -1, 	   4,    2, 	   1,   -9
+.2byte   -9,   -1, 	  -9,   -6, 	  -3,    5, 	  -2,   -9
+.2byte   -9,    1, 	 -14,    0, 	  -2,    5, 	  -4,   -5
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -1,    2, 	  -8,    5, 	   8,   -1, 	  -1,   -7
+.2byte   -1,    0, 	 -10,   -1, 	   6,    5, 	  -1,   -8
+.2byte   -1,    3, 	 -11,    4, 	   9,    4, 	  -1,   -7
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte    7,    1, 	  13,   -1, 	  -6,    2, 	  -3,   -9
+.2byte    7,   -1, 	   7,   -6, 	   1,    5, 	   0,   -9
+.2byte    7,    1, 	  12,    0, 	   0,    5, 	   2,   -5
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte   11,   -3, 	   8,   -5, 	   1,    2, 	  -2,   -8
+.2byte   11,   -4, 	   0,   -7, 	   9,    2, 	  -2,   -9
+.2byte   11,   -2, 	   8,   -5, 	   8,    3, 	   4,   -7
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte    6,  -10, 	   3,  -12, 	   7,   -1, 	  -2,   -8
+.2byte    7,  -12, 	  -2,  -11, 	  10,   -4, 	  -4,   -8
+.2byte    6,  -10, 	   2,  -11, 	  12,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -11, 	  -9,   -8, 	  -2,   -7
+.2byte   -1,  -14, 	   7,   -8, 	  -7,  -10, 	   0,   -8
+.2byte   -1,  -12, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -8,  -10, 	  -5,  -12, 	  -9,   -1, 	   0,   -8
+.2byte   -9,  -12, 	   0,  -11, 	 -12,   -4, 	   2,   -8
+.2byte   -8,  -10, 	  -4,  -11, 	 -14,   -4, 	  -1,   -9
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte  -13,   -3, 	 -10,   -5, 	  -3,    2, 	   0,   -8
+.2byte  -13,   -4, 	  -2,   -7, 	 -11,    2, 	   0,   -9
+.2byte  -13,   -2, 	 -10,   -5, 	 -10,    3, 	  -6,   -7
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte   -9,    1, 	 -15,   -1, 	   4,    2, 	   1,   -9
+.2byte   -9,   -1, 	  -9,   -6, 	  -3,    5, 	  -2,   -9
+.2byte   -9,    1, 	 -14,    0, 	  -2,    5, 	  -4,   -5
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -1,   -7, 	 -10,   -3, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -20, 	 -10,    3, 	   8,    3, 	  -1,  -10
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte    7,   -8, 	  11,   -7, 	   1,   -1, 	  -2,  -10
+.2byte   -1,  -21, 	  13,   -2, 	  -1,    4, 	   1,   -8
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte   10,  -15, 	   8,   -6, 	   6,  -11, 	  -2,   -8
+.2byte    0,  -22, 	   7,   -1, 	   6,    2, 	   2,  -12
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte    6,  -18, 	  -1,  -15, 	  10,   -9, 	  -2,   -8
+.2byte   -2,  -22, 	  -2,   -7, 	  11,   -2, 	  -2,  -11
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte   -1,  -16, 	   6,  -12, 	  -8,  -12, 	  -1,   -6
+.2byte   -1,  -22, 	   5,   -4, 	  -7,   -4, 	  -1,  -11
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -8,  -18, 	  -1,  -15, 	 -12,   -9, 	   0,   -8
+.2byte    0,  -22, 	   0,   -7, 	 -13,   -2, 	   0,  -11
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte  -12,  -15, 	 -10,   -6, 	  -8,  -11, 	   0,   -8
+.2byte   -2,  -22, 	  -9,   -1, 	  -8,    2, 	  -4,  -12
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte   -9,   -8, 	 -13,   -7, 	  -3,   -1, 	   0,  -10
+.2byte   -1,  -21, 	 -15,   -2, 	  -1,    4, 	  -3,   -8
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte   -1,    2, 	  -9,    2, 	   7,    2, 	  -1,   -7
+.2byte   -1,    3, 	  -9,    2, 	   7,    2, 	  -1,   -7
+.2byte    0,  -22, 	 -10,  -20, 	  10,  -20, 	   0,  -11
+.2byte   -7,  -21, 	   4,  -21, 	 -12,  -16, 	  -2,  -11
+.2byte   -4,  -20, 	  -6,  -23, 	   3,  -20, 	  -2,   -8
+.2byte   -3,  -18, 	  -8,  -23, 	   5,  -18, 	  -2,   -9
+.2byte    0,  -18, 	   8,  -18, 	  -8,  -18, 	   0,   -8
+.2byte    2,  -18, 	   7,  -23, 	  -6,  -18, 	   1,   -9
+.2byte    3,  -20, 	   5,  -23, 	  -4,  -20, 	   1,   -8
+.2byte    6,  -21, 	  -5,  -21, 	  11,  -16, 	   1,  -11
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -1,   -7, 	 -10,   -3, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -20, 	 -10,    3, 	   8,    3, 	  -1,  -10
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte    7,   -8, 	  11,   -7, 	   1,   -1, 	  -2,  -10
+.2byte   -1,  -21, 	  13,   -2, 	  -1,    4, 	   1,   -8
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte   10,  -15, 	   8,   -6, 	   6,  -11, 	  -2,   -8
+.2byte    0,  -22, 	   7,   -1, 	   6,    2, 	   2,  -12
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte    6,  -18, 	  -1,  -15, 	  10,   -9, 	  -2,   -8
+.2byte   -2,  -22, 	  -2,   -7, 	  11,   -2, 	  -2,  -11
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte   -1,  -16, 	   6,  -12, 	  -8,  -12, 	  -1,   -6
+.2byte   -1,  -22, 	   5,   -4, 	  -7,   -4, 	  -1,  -11
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -8,  -18, 	  -1,  -15, 	 -12,   -9, 	   0,   -8
+.2byte    0,  -22, 	   0,   -7, 	 -13,   -2, 	   0,  -11
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte  -12,  -15, 	 -10,   -6, 	  -8,  -11, 	   0,   -8
+.2byte   -2,  -22, 	  -9,   -1, 	  -8,    2, 	  -4,  -12
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte   -9,   -8, 	 -13,   -7, 	  -3,   -1, 	   0,  -10
+.2byte   -1,  -21, 	 -15,   -2, 	  -1,    4, 	  -3,   -8
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte  -12,   -4, 	  -8,   -7, 	  -6,    2, 	   1,   -9
+.2byte   -9,  -11, 	  -4,  -11, 	 -13,   -2, 	   0,   -8
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte    7,  -11, 	   2,  -11, 	  11,   -2, 	  -2,   -8
+.2byte   10,   -4, 	   6,   -7, 	   4,    2, 	  -3,   -9
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte   -1,  -20, 	 -10,    3, 	   8,    3, 	  -1,  -10
+.2byte   -1,  -21, 	 -15,   -2, 	  -1,    4, 	  -3,   -8
+.2byte   -1,  -22, 	  -8,   -1, 	  -7,    2, 	  -3,  -12
+.2byte   -1,  -22, 	  -1,   -7, 	 -14,   -2, 	  -1,  -11
+.2byte   -1,  -22, 	   5,   -4, 	  -7,   -4, 	  -1,  -11
+.2byte   -1,  -22, 	  -1,   -7, 	  12,   -2, 	  -1,  -11
+.2byte   -1,  -22, 	   6,   -1, 	   5,    2, 	   1,  -12
+.2byte   -1,  -21, 	  13,   -2, 	  -1,    4, 	   1,   -8
+.2byte   -1,  -20, 	 -10,    3, 	   8,    3, 	  -1,  -10
+.2byte   -1,  -21, 	  13,   -2, 	  -1,    4, 	   1,   -8
+.2byte   -1,  -22, 	   6,   -1, 	   5,    2, 	   1,  -12
+.2byte   -4,  -22, 	  -4,   -7, 	   9,   -2, 	  -4,  -11
+.2byte   -1,  -22, 	   5,   -4, 	  -7,   -4, 	  -1,  -11
+.2byte    2,  -22, 	   2,   -7, 	 -11,   -2, 	   2,  -11
+.2byte   -1,  -22, 	  -8,   -1, 	  -7,    2, 	  -3,  -12
+.2byte   -1,  -21, 	 -15,   -2, 	  -1,    4, 	  -3,   -8
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -1,   -7, 	 -10,   -3, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -20, 	 -10,    3, 	   8,    3, 	  -1,  -10
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+.2byte    7,   -8, 	  11,   -7, 	   1,   -1, 	  -2,  -10
+.2byte   -1,  -21, 	  13,   -2, 	  -1,    4, 	   1,   -8
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte   10,  -15, 	   8,   -6, 	   6,  -11, 	  -2,   -8
+.2byte    0,  -22, 	   7,   -1, 	   6,    2, 	   2,  -12
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte    6,  -18, 	  -1,  -15, 	  10,   -9, 	  -2,   -8
+.2byte   -2,  -22, 	  -2,   -7, 	  11,   -2, 	  -2,  -11
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte   -1,  -16, 	   6,  -12, 	  -8,  -12, 	  -1,   -6
+.2byte   -1,  -22, 	   5,   -4, 	  -7,   -4, 	  -1,  -11
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -8,  -18, 	  -1,  -15, 	 -12,   -9, 	   0,   -8
+.2byte    0,  -22, 	   0,   -7, 	 -13,   -2, 	   0,  -11
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte  -12,  -15, 	 -10,   -6, 	  -8,  -11, 	   0,   -8
+.2byte   -2,  -22, 	  -9,   -1, 	  -8,    2, 	  -4,  -12
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte   -9,   -8, 	 -13,   -7, 	  -3,   -1, 	   0,  -10
+.2byte   -1,  -21, 	 -15,   -2, 	  -1,    4, 	  -3,   -8
+.2byte   -1,  -20, 	 -10,    3, 	   8,    3, 	  -1,  -10
+.2byte   -1,  -21, 	 -15,   -2, 	  -1,    4, 	  -3,   -8
+.2byte   -1,  -22, 	  -8,   -1, 	  -7,    2, 	  -3,  -12
+.2byte   -1,  -22, 	  -1,   -7, 	 -14,   -2, 	  -1,  -11
+.2byte   -1,  -22, 	   5,   -4, 	  -7,   -4, 	  -1,  -11
+.2byte   -1,  -22, 	  -1,   -7, 	  12,   -2, 	  -1,  -11
+.2byte   -1,  -22, 	   6,   -1, 	   5,    2, 	   1,  -12
+.2byte   -1,  -21, 	  13,   -2, 	  -1,    4, 	   1,   -8
+.2byte   -1,    1, 	 -10,    2, 	   8,    2, 	  -1,   -8
+.2byte   -9,    0, 	 -13,   -4, 	   0,    3, 	  -1,   -9
+.2byte  -13,   -4, 	  -9,   -7, 	  -7,    2, 	   0,   -9
+.2byte   -8,  -11, 	  -3,  -11, 	 -12,   -2, 	   1,   -8
+.2byte   -1,  -13, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte    6,  -11, 	   1,  -11, 	  10,   -2, 	  -3,   -8
+.2byte   11,   -4, 	   7,   -7, 	   5,    2, 	  -2,   -9
+.2byte    7,    0, 	  11,   -4, 	  -2,    3, 	  -1,   -9
+sAriadosAnimTable1:
+.4byte sAriadosAnims_1_1
+.4byte sAriadosAnims_1_2
+.4byte sAriadosAnims_1_3
+.4byte sAriadosAnims_1_4
+.4byte sAriadosAnims_1_5
+.4byte sAriadosAnims_1_6
+.4byte sAriadosAnims_1_7
+.4byte sAriadosAnims_1_8
+sAriadosAnimTable2:
+.4byte sAriadosAnims_2_1
+.4byte sAriadosAnims_2_2
+.4byte sAriadosAnims_2_3
+.4byte sAriadosAnims_2_4
+.4byte sAriadosAnims_2_5
+.4byte sAriadosAnims_2_6
+.4byte sAriadosAnims_2_7
+.4byte sAriadosAnims_2_8
+sAriadosAnimTable3:
+.4byte sAriadosAnims_3_1
+.4byte sAriadosAnims_3_2
+.4byte sAriadosAnims_3_3
+.4byte sAriadosAnims_3_4
+.4byte sAriadosAnims_3_5
+.4byte sAriadosAnims_3_6
+.4byte sAriadosAnims_3_7
+.4byte sAriadosAnims_3_8
+sAriadosAnimTable4:
+.4byte sAriadosAnims_4_1
+.4byte sAriadosAnims_4_2
+.4byte sAriadosAnims_4_3
+.4byte sAriadosAnims_4_4
+.4byte sAriadosAnims_4_5
+.4byte sAriadosAnims_4_6
+.4byte sAriadosAnims_4_7
+.4byte sAriadosAnims_4_8
+sAriadosAnimTable5:
+.4byte sAriadosAnims_5_1
+.4byte sAriadosAnims_5_2
+.4byte sAriadosAnims_5_3
+.4byte sAriadosAnims_5_4
+.4byte sAriadosAnims_5_5
+.4byte sAriadosAnims_5_6
+.4byte sAriadosAnims_5_7
+.4byte sAriadosAnims_5_8
+sAriadosAnimTable6:
+.4byte sAriadosAnims_6_1
+.4byte sAriadosAnims_6_1
+.4byte sAriadosAnims_6_1
+.4byte sAriadosAnims_6_1
+.4byte sAriadosAnims_6_1
+.4byte sAriadosAnims_6_1
+.4byte sAriadosAnims_6_1
+.4byte sAriadosAnims_6_1
+sAriadosAnimTable7:
+.4byte sAriadosAnims_7_1
+.4byte sAriadosAnims_7_2
+.4byte sAriadosAnims_7_3
+.4byte sAriadosAnims_7_4
+.4byte sAriadosAnims_7_5
+.4byte sAriadosAnims_7_6
+.4byte sAriadosAnims_7_7
+.4byte sAriadosAnims_7_8
+sAriadosAnimTable8:
+.4byte sAriadosAnims_8_1
+.4byte sAriadosAnims_8_2
+.4byte sAriadosAnims_8_3
+.4byte sAriadosAnims_8_4
+.4byte sAriadosAnims_8_5
+.4byte sAriadosAnims_8_6
+.4byte sAriadosAnims_8_7
+.4byte sAriadosAnims_8_8
+sAriadosAnimTable9:
+.4byte sAriadosAnims_9_1
+.4byte sAriadosAnims_9_2
+.4byte sAriadosAnims_9_3
+.4byte sAriadosAnims_9_4
+.4byte sAriadosAnims_9_5
+.4byte sAriadosAnims_9_6
+.4byte sAriadosAnims_9_7
+.4byte sAriadosAnims_9_8
+sAriadosAnimTable10:
+.4byte sAriadosAnims_10_1
+.4byte sAriadosAnims_10_2
+.4byte sAriadosAnims_10_3
+.4byte sAriadosAnims_10_4
+.4byte sAriadosAnims_10_5
+.4byte sAriadosAnims_10_6
+.4byte sAriadosAnims_10_7
+.4byte sAriadosAnims_10_8
+sAriadosAnimTable11:
+.4byte sAriadosAnims_11_1
+.4byte sAriadosAnims_11_2
+.4byte sAriadosAnims_11_3
+.4byte sAriadosAnims_11_4
+.4byte sAriadosAnims_11_5
+.4byte sAriadosAnims_11_6
+.4byte sAriadosAnims_11_7
+.4byte sAriadosAnims_11_8
+sAriadosAnimTable12:
+.4byte sAriadosAnims_12_1
+.4byte sAriadosAnims_12_2
+.4byte sAriadosAnims_12_3
+.4byte sAriadosAnims_12_4
+.4byte sAriadosAnims_12_5
+.4byte sAriadosAnims_12_6
+.4byte sAriadosAnims_12_7
+.4byte sAriadosAnims_12_8
+sAriadosAnimTable13:
+.4byte sAriadosAnims_13_1
+.4byte sAriadosAnims_13_2
+.4byte sAriadosAnims_13_3
+.4byte sAriadosAnims_13_4
+.4byte sAriadosAnims_13_5
+.4byte sAriadosAnims_13_6
+.4byte sAriadosAnims_13_7
+.4byte sAriadosAnims_13_8
+sAxAnimationsAriados:
+.4byte sAriadosAnimTable1
+.4byte sAriadosAnimTable2
+.4byte sAriadosAnimTable3
+.4byte sAriadosAnimTable4
+.4byte sAriadosAnimTable5
+.4byte sAriadosAnimTable6
+.4byte sAriadosAnimTable7
+.4byte sAriadosAnimTable8
+.4byte sAriadosAnimTable9
+.4byte sAriadosAnimTable10
+.4byte sAriadosAnimTable11
+.4byte sAriadosAnimTable12
+.4byte sAriadosAnimTable13
+sAxSpritesAriados:
+.4byte sAriadosSprites1
+.4byte sAriadosSprites2
+.4byte sAriadosSprites3
+.4byte sAriadosSprites4
+.4byte sAriadosSprites5
+.4byte sAriadosSprites6
+.4byte sAriadosSprites7
+.4byte sAriadosSprites8
+.4byte sAriadosSprites9
+.4byte sAriadosSprites10
+.4byte sAriadosSprites11
+.4byte sAriadosSprites12
+.4byte sAriadosSprites13
+.4byte sAriadosSprites14
+.4byte sAriadosSprites15
+.4byte sAriadosSprites16
+.4byte sAriadosSprites17
+.4byte sAriadosSprites18
+.4byte sAriadosSprites19
+.4byte sAriadosSprites20
+.4byte sAriadosSprites21
+.4byte sAriadosSprites22
+.4byte sAriadosSprites23
+.4byte sAriadosSprites24
+.4byte sAriadosSprites25
+.4byte sAriadosSprites26
+.4byte sAriadosSprites27
+.4byte sAriadosSprites28
+.4byte sAriadosSprites29
+.4byte sAriadosSprites30
+.4byte sAriadosSprites31
+.4byte sAriadosSprites32
+.4byte sAriadosSprites33
+.4byte sAriadosSprites34
+.4byte sAriadosSprites35
+.4byte sAriadosSprites36
+.4byte sAriadosSprites37
+sAxMainAriados:
+ax_main sAxPosesAriados, sAxAnimationsAriados, 13, sAxSpritesAriados, sAxPositionsAriados

--- a/data/ax/armaldo.inc
+++ b/data/ax/armaldo.inc
@@ -1,0 +1,3281 @@
+.global gAxArmaldo
+gAxArmaldo:
+ax_siro sAxMainArmaldo
+sArmaldoPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose4:
+ax_pose 3, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose5:
+ax_pose 4, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sArmaldoPose6:
+ax_pose 5, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose7:
+ax_pose 6, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sArmaldoPose8:
+ax_pose 7, 0x81e4, 0x90fe, 0x5c00
+ax_pose 8, 0x81e4, 0x50f6, 0x5c08
+ax_pose 9, 0x81f4, 0x10ee, 0x5c0c
+ax_pose 10, 0x81f4, 0x10e6, 0x5c0e
+ax_pose_terminator
+sArmaldoPose9:
+ax_pose 11, 0x81e4, 0x90fe, 0x5c00
+ax_pose 12, 0x81e4, 0x50f6, 0x5c08
+ax_pose 13, 0x81f4, 0x10ee, 0x5c0c
+ax_pose 14, 0x01f4, 0x10e6, 0x5c0e
+ax_pose_terminator
+sArmaldoPose10:
+ax_pose 15, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose11:
+ax_pose 16, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose12:
+ax_pose 17, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose13:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose14:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose15:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose16:
+ax_pose 15, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose17:
+ax_pose 16, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose18:
+ax_pose 17, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose20:
+ax_pose 7, 0x81e5, 0x80f1, 0x5c00
+ax_pose 8, 0x81e5, 0x4101, 0x5c08
+ax_pose 9, 0x81f5, 0x0109, 0x5c0c
+ax_pose 10, 0x81f5, 0x0111, 0x5c0e
+ax_pose_terminator
+sArmaldoPose21:
+ax_pose 11, 0x81e5, 0x80f1, 0x5c00
+ax_pose 12, 0x81e5, 0x4101, 0x5c08
+ax_pose 13, 0x81f5, 0x0109, 0x5c0c
+ax_pose 14, 0x01f5, 0x0111, 0x5c0e
+ax_pose_terminator
+sArmaldoPose22:
+ax_pose 3, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose23:
+ax_pose 4, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sArmaldoPose24:
+ax_pose 5, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose26:
+ax_pose 1, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose27:
+ax_pose 2, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose28:
+ax_pose 21, 0x41e5, 0x80ef, 0x5c00
+ax_pose 22, 0x41f5, 0x40ef, 0x5c08
+ax_pose 23, 0x01fd, 0x0107, 0x5c0c
+ax_pose 24, 0x41fd, 0x00f7, 0x5c0d
+ax_pose 25, 0x01e8, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose29:
+ax_pose 26, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose30:
+ax_pose 3, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose31:
+ax_pose 4, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sArmaldoPose32:
+ax_pose 5, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose33:
+ax_pose 27, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose34:
+ax_pose 28, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose35:
+ax_pose 6, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sArmaldoPose36:
+ax_pose 7, 0x81e4, 0x90fe, 0x5c00
+ax_pose 8, 0x81e4, 0x50f6, 0x5c08
+ax_pose 9, 0x81f4, 0x10ee, 0x5c0c
+ax_pose 10, 0x81f4, 0x10e6, 0x5c0e
+ax_pose_terminator
+sArmaldoPose37:
+ax_pose 11, 0x81e4, 0x90fe, 0x5c00
+ax_pose 12, 0x81e4, 0x50f6, 0x5c08
+ax_pose 13, 0x81f4, 0x10ee, 0x5c0c
+ax_pose 14, 0x01f4, 0x10e6, 0x5c0e
+ax_pose_terminator
+sArmaldoPose38:
+ax_pose 29, 0x41fb, 0x10f0, 0x5c00
+ax_pose 30, 0x01fb, 0x1100, 0x5c02
+ax_pose 31, 0x41f3, 0x50f0, 0x5c03
+ax_pose 32, 0x41e3, 0x90f0, 0x5c07
+ax_pose 33, 0x01f3, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose39:
+ax_pose 34, 0x41fd, 0x10f8, 0x5c00
+ax_pose 35, 0x41f5, 0x10f8, 0x5c02
+ax_pose 36, 0x01f5, 0x10f0, 0x5c04
+ax_pose 37, 0x41e5, 0x90f0, 0x5c05
+ax_pose 38, 0x81ed, 0x10e8, 0x5c0d
+ax_pose_terminator
+sArmaldoPose40:
+ax_pose 15, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose41:
+ax_pose 16, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose42:
+ax_pose 17, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose43:
+ax_pose 39, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose44:
+ax_pose 40, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose45:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose46:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose47:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose48:
+ax_pose 41, 0x41e6, 0x80ee, 0x5c00
+ax_pose 42, 0x41f6, 0x40ee, 0x5c08
+ax_pose 43, 0x41fe, 0x00fc, 0x5c0c
+ax_pose 44, 0x01fe, 0x00f4, 0x5c0e
+ax_pose 45, 0x01e6, 0x010e, 0x5c0f
+ax_pose_terminator
+sArmaldoPose49:
+ax_pose 46, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose50:
+ax_pose 15, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose51:
+ax_pose 16, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose52:
+ax_pose 17, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose53:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose54:
+ax_pose 40, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose55:
+ax_pose 6, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose56:
+ax_pose 7, 0x81e5, 0x80f1, 0x5c00
+ax_pose 8, 0x81e5, 0x4101, 0x5c08
+ax_pose 9, 0x81f5, 0x0109, 0x5c0c
+ax_pose 10, 0x81f5, 0x0111, 0x5c0e
+ax_pose_terminator
+sArmaldoPose57:
+ax_pose 11, 0x81e5, 0x80f1, 0x5c00
+ax_pose 12, 0x81e5, 0x4101, 0x5c08
+ax_pose 13, 0x81f5, 0x0109, 0x5c0c
+ax_pose 14, 0x01f5, 0x0111, 0x5c0e
+ax_pose_terminator
+sArmaldoPose58:
+ax_pose 29, 0x41fc, 0x00ff, 0x5c00
+ax_pose 30, 0x01fc, 0x00f7, 0x5c02
+ax_pose 31, 0x41f4, 0x40ef, 0x5c03
+ax_pose 32, 0x41e4, 0x80ef, 0x5c07
+ax_pose 33, 0x01f4, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose59:
+ax_pose 34, 0x41fe, 0x00f7, 0x5c00
+ax_pose 35, 0x41f6, 0x00f7, 0x5c02
+ax_pose 36, 0x01f6, 0x0107, 0x5c04
+ax_pose 37, 0x41e6, 0x80ef, 0x5c05
+ax_pose 38, 0x81ee, 0x010f, 0x5c0d
+ax_pose_terminator
+sArmaldoPose60:
+ax_pose 3, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose61:
+ax_pose 4, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sArmaldoPose62:
+ax_pose 5, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose63:
+ax_pose 27, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose64:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose65:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose66:
+ax_pose 21, 0x41e5, 0x80ef, 0x5c00
+ax_pose 22, 0x41f5, 0x40ef, 0x5c08
+ax_pose 23, 0x01fd, 0x0107, 0x5c0c
+ax_pose 24, 0x41fd, 0x00f7, 0x5c0d
+ax_pose 25, 0x01e8, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose67:
+ax_pose 47, 0x01e5, 0x80ef, 0x5c00
+ax_pose 48, 0x01e5, 0x80ef, 0x5c10
+ax_pose_terminator
+sArmaldoPose68:
+ax_pose 48, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose69:
+ax_pose 3, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose70:
+ax_pose 27, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose71:
+ax_pose 49, 0x01e4, 0x90f8, 0x5c00
+ax_pose 50, 0x01e4, 0x90ef, 0x5c10
+ax_pose_terminator
+sArmaldoPose72:
+ax_pose 50, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose73:
+ax_pose 6, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sArmaldoPose74:
+ax_pose 29, 0x41fb, 0x10f0, 0x5c00
+ax_pose 30, 0x01fb, 0x1100, 0x5c02
+ax_pose 31, 0x41f3, 0x50f0, 0x5c03
+ax_pose 32, 0x41e3, 0x90f0, 0x5c07
+ax_pose 33, 0x01f3, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose75:
+ax_pose 51, 0x81e2, 0x9105, 0x5c00
+ax_pose 52, 0x41f3, 0x90f0, 0x5c08
+ax_pose 53, 0x41eb, 0x50f0, 0x5c10
+ax_pose 54, 0x41e3, 0x1100, 0x5c14
+ax_pose 55, 0x01eb, 0x10e8, 0x5c16
+ax_pose 56, 0x01f3, 0x10e8, 0x5c17
+ax_pose_terminator
+sArmaldoPose76:
+ax_pose 52, 0x41f3, 0x90f0, 0x5c00
+ax_pose 53, 0x41eb, 0x50f0, 0x5c08
+ax_pose 54, 0x41e3, 0x1100, 0x5c0c
+ax_pose 55, 0x01eb, 0x10e8, 0x5c0e
+ax_pose 56, 0x01f3, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose77:
+ax_pose 15, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose78:
+ax_pose 39, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose79:
+ax_pose 57, 0x01df, 0x90f5, 0x5c00
+ax_pose 58, 0x01e6, 0x90f1, 0x5c10
+ax_pose_terminator
+sArmaldoPose80:
+ax_pose 58, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose81:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose82:
+ax_pose 41, 0x41e6, 0x80ee, 0x5c00
+ax_pose 42, 0x41f6, 0x40ee, 0x5c08
+ax_pose 43, 0x41fe, 0x00fc, 0x5c0c
+ax_pose 44, 0x01fe, 0x00f4, 0x5c0e
+ax_pose 45, 0x01e6, 0x010e, 0x5c0f
+ax_pose_terminator
+sArmaldoPose83:
+ax_pose 59, 0x41e0, 0x80f0, 0x5c00
+ax_pose 60, 0x41f0, 0x40f0, 0x5c08
+ax_pose 61, 0x01e8, 0x0110, 0x5c0c
+ax_pose 62, 0x01e0, 0x0110, 0x5c0d
+ax_pose 63, 0x01e6, 0x80ef, 0x5c0e
+ax_pose_terminator
+sArmaldoPose84:
+ax_pose 63, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose85:
+ax_pose 15, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose86:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose87:
+ax_pose 57, 0x01df, 0x80eb, 0x5c00
+ax_pose 58, 0x01e6, 0x80ef, 0x5c10
+ax_pose_terminator
+sArmaldoPose88:
+ax_pose 58, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose89:
+ax_pose 6, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose90:
+ax_pose 29, 0x41fc, 0x00ff, 0x5c00
+ax_pose 30, 0x01fc, 0x00f7, 0x5c02
+ax_pose 31, 0x41f4, 0x40ef, 0x5c03
+ax_pose 32, 0x41e4, 0x80ef, 0x5c07
+ax_pose 33, 0x01f4, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose91:
+ax_pose 51, 0x81e3, 0x80ea, 0x5c00
+ax_pose 52, 0x41f4, 0x80ef, 0x5c08
+ax_pose 53, 0x41ec, 0x40ef, 0x5c10
+ax_pose 54, 0x41e4, 0x00ef, 0x5c14
+ax_pose 55, 0x01ec, 0x010f, 0x5c16
+ax_pose 56, 0x01f4, 0x010f, 0x5c17
+ax_pose_terminator
+sArmaldoPose92:
+ax_pose 52, 0x41f4, 0x80ef, 0x5c00
+ax_pose 53, 0x41ec, 0x40ef, 0x5c08
+ax_pose 54, 0x41e4, 0x00ef, 0x5c0c
+ax_pose 55, 0x01ec, 0x010f, 0x5c0e
+ax_pose 56, 0x01f4, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose93:
+ax_pose 3, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose94:
+ax_pose 27, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose95:
+ax_pose 49, 0x01e4, 0x80e7, 0x5c00
+ax_pose 50, 0x01e4, 0x80f0, 0x5c10
+ax_pose_terminator
+sArmaldoPose96:
+ax_pose 50, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose97:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose98:
+ax_pose 21, 0x41e5, 0x80ef, 0x5c00
+ax_pose 22, 0x41f5, 0x40ef, 0x5c08
+ax_pose 23, 0x01fd, 0x0107, 0x5c0c
+ax_pose 24, 0x41fd, 0x00f7, 0x5c0d
+ax_pose 25, 0x01e8, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose99:
+ax_pose 26, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose100:
+ax_pose 3, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose101:
+ax_pose 27, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose102:
+ax_pose 28, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose103:
+ax_pose 6, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sArmaldoPose104:
+ax_pose 29, 0x41fb, 0x10f0, 0x5c00
+ax_pose 30, 0x01fb, 0x1100, 0x5c02
+ax_pose 31, 0x41f3, 0x50f0, 0x5c03
+ax_pose 32, 0x41e3, 0x90f0, 0x5c07
+ax_pose 33, 0x01f3, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose105:
+ax_pose 34, 0x41fd, 0x10f8, 0x5c00
+ax_pose 35, 0x41f5, 0x10f8, 0x5c02
+ax_pose 36, 0x01f5, 0x10f0, 0x5c04
+ax_pose 37, 0x41e5, 0x90f0, 0x5c05
+ax_pose 38, 0x81ed, 0x10e8, 0x5c0d
+ax_pose_terminator
+sArmaldoPose106:
+ax_pose 15, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose107:
+ax_pose 39, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose108:
+ax_pose 40, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose109:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose110:
+ax_pose 41, 0x41e6, 0x80ee, 0x5c00
+ax_pose 42, 0x41f6, 0x40ee, 0x5c08
+ax_pose 43, 0x41fe, 0x00fc, 0x5c0c
+ax_pose 44, 0x01fe, 0x00f4, 0x5c0e
+ax_pose 45, 0x01e6, 0x010e, 0x5c0f
+ax_pose_terminator
+sArmaldoPose111:
+ax_pose 46, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose112:
+ax_pose 15, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose113:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose114:
+ax_pose 40, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose115:
+ax_pose 6, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose116:
+ax_pose 29, 0x41fc, 0x00ff, 0x5c00
+ax_pose 30, 0x01fc, 0x00f7, 0x5c02
+ax_pose 31, 0x41f4, 0x40ef, 0x5c03
+ax_pose 32, 0x41e4, 0x80ef, 0x5c07
+ax_pose 33, 0x01f4, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose117:
+ax_pose 34, 0x41fe, 0x00f7, 0x5c00
+ax_pose 35, 0x41f6, 0x00f7, 0x5c02
+ax_pose 36, 0x01f6, 0x0107, 0x5c04
+ax_pose 37, 0x41e6, 0x80ef, 0x5c05
+ax_pose 38, 0x81ee, 0x010f, 0x5c0d
+ax_pose_terminator
+sArmaldoPose118:
+ax_pose 3, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose119:
+ax_pose 27, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose120:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose121:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose122:
+ax_pose 3, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose123:
+ax_pose 6, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sArmaldoPose124:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose125:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose126:
+ax_pose 15, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose127:
+ax_pose 6, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sArmaldoPose128:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose129:
+ax_pose 64, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sArmaldoPose130:
+ax_pose 65, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sArmaldoPose131:
+ax_pose 66, 0x01e2, 0x80f2, 0x5c00
+ax_pose_terminator
+sArmaldoPose132:
+ax_pose 67, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose133:
+ax_pose 68, 0x01e3, 0x90e9, 0x5c00
+ax_pose_terminator
+sArmaldoPose134:
+ax_pose 69, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose135:
+ax_pose 70, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose136:
+ax_pose 69, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose137:
+ax_pose 68, 0x01e3, 0x80f7, 0x5c00
+ax_pose_terminator
+sArmaldoPose138:
+ax_pose 67, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose139:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose140:
+ax_pose 21, 0x41e5, 0x80ef, 0x5c00
+ax_pose 22, 0x41f5, 0x40ef, 0x5c08
+ax_pose 23, 0x01fd, 0x0107, 0x5c0c
+ax_pose 24, 0x41fd, 0x00f7, 0x5c0d
+ax_pose 25, 0x01e8, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose141:
+ax_pose 26, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose142:
+ax_pose 3, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose143:
+ax_pose 27, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose144:
+ax_pose 28, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose145:
+ax_pose 6, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sArmaldoPose146:
+ax_pose 29, 0x41fb, 0x10f0, 0x5c00
+ax_pose 30, 0x01fb, 0x1100, 0x5c02
+ax_pose 31, 0x41f3, 0x50f0, 0x5c03
+ax_pose 32, 0x41e3, 0x90f0, 0x5c07
+ax_pose 33, 0x01f3, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose147:
+ax_pose 34, 0x41fd, 0x10f8, 0x5c00
+ax_pose 35, 0x41f5, 0x10f8, 0x5c02
+ax_pose 36, 0x01f5, 0x10f0, 0x5c04
+ax_pose 37, 0x41e5, 0x90f0, 0x5c05
+ax_pose 38, 0x81ed, 0x10e8, 0x5c0d
+ax_pose_terminator
+sArmaldoPose148:
+ax_pose 15, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose149:
+ax_pose 39, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose150:
+ax_pose 40, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose151:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose152:
+ax_pose 41, 0x41e6, 0x80ee, 0x5c00
+ax_pose 42, 0x41f6, 0x40ee, 0x5c08
+ax_pose 43, 0x41fe, 0x00fc, 0x5c0c
+ax_pose 44, 0x01fe, 0x00f4, 0x5c0e
+ax_pose 45, 0x01e6, 0x010e, 0x5c0f
+ax_pose_terminator
+sArmaldoPose153:
+ax_pose 46, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose154:
+ax_pose 15, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose155:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose156:
+ax_pose 40, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose157:
+ax_pose 6, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose158:
+ax_pose 29, 0x41fc, 0x00ff, 0x5c00
+ax_pose 30, 0x01fc, 0x00f7, 0x5c02
+ax_pose 31, 0x41f4, 0x40ef, 0x5c03
+ax_pose 32, 0x41e4, 0x80ef, 0x5c07
+ax_pose 33, 0x01f4, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose159:
+ax_pose 34, 0x41fe, 0x00f7, 0x5c00
+ax_pose 35, 0x41f6, 0x00f7, 0x5c02
+ax_pose 36, 0x01f6, 0x0107, 0x5c04
+ax_pose 37, 0x41e6, 0x80ef, 0x5c05
+ax_pose 38, 0x81ee, 0x010f, 0x5c0d
+ax_pose_terminator
+sArmaldoPose160:
+ax_pose 3, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose161:
+ax_pose 27, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose162:
+ax_pose 28, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose163:
+ax_pose 26, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose164:
+ax_pose 28, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose165:
+ax_pose 34, 0x41fe, 0x00f7, 0x5c00
+ax_pose 35, 0x41f6, 0x00f7, 0x5c02
+ax_pose 36, 0x01f6, 0x0107, 0x5c04
+ax_pose 37, 0x41e6, 0x80ef, 0x5c05
+ax_pose 38, 0x81ee, 0x010f, 0x5c0d
+ax_pose_terminator
+sArmaldoPose166:
+ax_pose 40, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose167:
+ax_pose 46, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose168:
+ax_pose 40, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose169:
+ax_pose 34, 0x41fe, 0x10f8, 0x5c00
+ax_pose 35, 0x41f6, 0x10f8, 0x5c02
+ax_pose 36, 0x01f6, 0x10f0, 0x5c04
+ax_pose 37, 0x41e6, 0x90f0, 0x5c05
+ax_pose 38, 0x81ee, 0x10e8, 0x5c0d
+ax_pose_terminator
+sArmaldoPose170:
+ax_pose 28, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose171:
+ax_pose 3, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose172:
+ax_pose 4, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sArmaldoPose173:
+ax_pose 5, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose174:
+ax_pose 27, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose175:
+ax_pose 6, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sArmaldoPose176:
+ax_pose 7, 0x81e4, 0x90fe, 0x5c00
+ax_pose 8, 0x81e4, 0x50f6, 0x5c08
+ax_pose 9, 0x81f4, 0x10ee, 0x5c0c
+ax_pose 10, 0x81f4, 0x10e6, 0x5c0e
+ax_pose_terminator
+sArmaldoPose177:
+ax_pose 11, 0x81e4, 0x90fe, 0x5c00
+ax_pose 12, 0x81e4, 0x50f6, 0x5c08
+ax_pose 13, 0x81f4, 0x10ee, 0x5c0c
+ax_pose 14, 0x01f4, 0x10e6, 0x5c0e
+ax_pose_terminator
+sArmaldoPose178:
+ax_pose 29, 0x41fb, 0x10f0, 0x5c00
+ax_pose 30, 0x01fb, 0x1100, 0x5c02
+ax_pose 31, 0x41f3, 0x50f0, 0x5c03
+ax_pose 32, 0x41e3, 0x90f0, 0x5c07
+ax_pose 33, 0x01f3, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose179:
+ax_pose 15, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose180:
+ax_pose 16, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose181:
+ax_pose 17, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose182:
+ax_pose 39, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose183:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose184:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose185:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose186:
+ax_pose 41, 0x41e6, 0x80ee, 0x5c00
+ax_pose 42, 0x41f6, 0x40ee, 0x5c08
+ax_pose 43, 0x41fe, 0x00fc, 0x5c0c
+ax_pose 44, 0x01fe, 0x00f4, 0x5c0e
+ax_pose 45, 0x01e6, 0x010e, 0x5c0f
+ax_pose_terminator
+sArmaldoPose187:
+ax_pose 15, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose188:
+ax_pose 16, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose189:
+ax_pose 17, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose190:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose191:
+ax_pose 6, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose192:
+ax_pose 7, 0x81e5, 0x80f1, 0x5c00
+ax_pose 8, 0x81e5, 0x4101, 0x5c08
+ax_pose 9, 0x81f5, 0x0109, 0x5c0c
+ax_pose 10, 0x81f5, 0x0111, 0x5c0e
+ax_pose_terminator
+sArmaldoPose193:
+ax_pose 11, 0x81e5, 0x80f1, 0x5c00
+ax_pose 12, 0x81e5, 0x4101, 0x5c08
+ax_pose 13, 0x81f5, 0x0109, 0x5c0c
+ax_pose 14, 0x01f5, 0x0111, 0x5c0e
+ax_pose_terminator
+sArmaldoPose194:
+ax_pose 29, 0x41fc, 0x00ff, 0x5c00
+ax_pose 30, 0x01fc, 0x00f7, 0x5c02
+ax_pose 31, 0x41f4, 0x40ef, 0x5c03
+ax_pose 32, 0x41e4, 0x80ef, 0x5c07
+ax_pose 33, 0x01f4, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose195:
+ax_pose 3, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose196:
+ax_pose 4, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sArmaldoPose197:
+ax_pose 5, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose198:
+ax_pose 27, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose199:
+ax_pose 21, 0x41e6, 0x80ef, 0x5c00
+ax_pose 22, 0x41f6, 0x40ef, 0x5c08
+ax_pose 23, 0x01fe, 0x0107, 0x5c0c
+ax_pose 24, 0x41fe, 0x00f7, 0x5c0d
+ax_pose 25, 0x01e9, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose200:
+ax_pose 27, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose201:
+ax_pose 29, 0x41fc, 0x10f0, 0x5c00
+ax_pose 30, 0x01fc, 0x1100, 0x5c02
+ax_pose 31, 0x41f4, 0x50f0, 0x5c03
+ax_pose 32, 0x41e4, 0x90f0, 0x5c07
+ax_pose 33, 0x01f4, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose202:
+ax_pose 39, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose203:
+ax_pose 41, 0x41e7, 0x80ee, 0x5c00
+ax_pose 42, 0x41f7, 0x40ee, 0x5c08
+ax_pose 43, 0x41ff, 0x00fc, 0x5c0c
+ax_pose 44, 0x01ff, 0x00f4, 0x5c0e
+ax_pose 45, 0x01e7, 0x010e, 0x5c0f
+ax_pose_terminator
+sArmaldoPose204:
+ax_pose 39, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose205:
+ax_pose 29, 0x41fc, 0x0100, 0x5c00
+ax_pose 30, 0x01fc, 0x00f8, 0x5c02
+ax_pose 31, 0x41f4, 0x40f0, 0x5c03
+ax_pose 32, 0x41e4, 0x80f0, 0x5c07
+ax_pose 33, 0x01f4, 0x0110, 0x5c0f
+ax_pose_terminator
+sArmaldoPose206:
+ax_pose 27, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose207:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose208:
+ax_pose 21, 0x41e6, 0x80ef, 0x5c00
+ax_pose 22, 0x41f6, 0x40ef, 0x5c08
+ax_pose 23, 0x01fe, 0x0107, 0x5c0c
+ax_pose 24, 0x41fe, 0x00f7, 0x5c0d
+ax_pose 25, 0x01e9, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose209:
+ax_pose 26, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose210:
+ax_pose 3, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose211:
+ax_pose 27, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose212:
+ax_pose 28, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sArmaldoPose213:
+ax_pose 6, 0x01e5, 0x90eb, 0x5c00
+ax_pose_terminator
+sArmaldoPose214:
+ax_pose 29, 0x41fc, 0x10f0, 0x5c00
+ax_pose 30, 0x01fc, 0x1100, 0x5c02
+ax_pose 31, 0x41f4, 0x50f0, 0x5c03
+ax_pose 32, 0x41e4, 0x90f0, 0x5c07
+ax_pose 33, 0x01f4, 0x10e8, 0x5c0f
+ax_pose_terminator
+sArmaldoPose215:
+ax_pose 34, 0x41fe, 0x10f7, 0x5c00
+ax_pose 35, 0x41f6, 0x10f7, 0x5c02
+ax_pose 36, 0x01f6, 0x10ef, 0x5c04
+ax_pose 37, 0x41e6, 0x90ef, 0x5c05
+ax_pose 38, 0x81ee, 0x10e7, 0x5c0d
+ax_pose_terminator
+sArmaldoPose216:
+ax_pose 15, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose217:
+ax_pose 39, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose218:
+ax_pose 40, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose219:
+ax_pose 18, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose220:
+ax_pose 41, 0x41e7, 0x80ee, 0x5c00
+ax_pose 42, 0x41f7, 0x40ee, 0x5c08
+ax_pose 43, 0x41ff, 0x00fc, 0x5c0c
+ax_pose 44, 0x01ff, 0x00f4, 0x5c0e
+ax_pose 45, 0x01e7, 0x010e, 0x5c0f
+ax_pose_terminator
+sArmaldoPose221:
+ax_pose 46, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose222:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose223:
+ax_pose 39, 0x01e3, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose224:
+ax_pose 40, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sArmaldoPose225:
+ax_pose 6, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sArmaldoPose226:
+ax_pose 29, 0x41fc, 0x0100, 0x5c00
+ax_pose 30, 0x01fc, 0x00f8, 0x5c02
+ax_pose 31, 0x41f4, 0x40f0, 0x5c03
+ax_pose 32, 0x41e4, 0x80f0, 0x5c07
+ax_pose 33, 0x01f4, 0x0110, 0x5c0f
+ax_pose_terminator
+sArmaldoPose227:
+ax_pose 34, 0x41fe, 0x00f9, 0x5c00
+ax_pose 35, 0x41f6, 0x00f9, 0x5c02
+ax_pose 36, 0x01f6, 0x0109, 0x5c04
+ax_pose 37, 0x41e6, 0x80f1, 0x5c05
+ax_pose 38, 0x81ee, 0x0111, 0x5c0d
+ax_pose_terminator
+sArmaldoPose228:
+ax_pose 3, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose229:
+ax_pose 27, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose230:
+ax_pose 28, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sArmaldoPose231:
+ax_pose 48, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose232:
+ax_pose 50, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose233:
+ax_pose 52, 0x41f4, 0x80ef, 0x5c00
+ax_pose 53, 0x41ec, 0x40ef, 0x5c08
+ax_pose 54, 0x41e4, 0x00ef, 0x5c0c
+ax_pose 55, 0x01ec, 0x010f, 0x5c0e
+ax_pose 56, 0x01f4, 0x010f, 0x5c0f
+ax_pose_terminator
+sArmaldoPose234:
+ax_pose 58, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose235:
+ax_pose 63, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose236:
+ax_pose 58, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose237:
+ax_pose 52, 0x41f4, 0x90f1, 0x5c00
+ax_pose 53, 0x41ec, 0x50f1, 0x5c08
+ax_pose 54, 0x41e4, 0x1101, 0x5c0c
+ax_pose 55, 0x01ec, 0x10e9, 0x5c0e
+ax_pose 56, 0x01f4, 0x10e9, 0x5c0f
+ax_pose_terminator
+sArmaldoPose238:
+ax_pose 50, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose239:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose240:
+ax_pose 3, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose241:
+ax_pose 6, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sArmaldoPose242:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sArmaldoPose243:
+ax_pose 18, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sArmaldoPose244:
+ax_pose 15, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sArmaldoPose245:
+ax_pose 6, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sArmaldoPose246:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sArmaldoAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 1, 28, 1, 21, 1, 21,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 0, 28, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sArmaldoAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 6, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 11, 10, 11,
+ax_anim 2, 0, 33, 18, 22, 18, 22,
+ax_anim 2, 1, 33, 19, 21, 19, 21,
+ax_anim 2, 0, 33, 18, 22, 18, 22,
+ax_anim 2, 0, 33, 19, 21, 19, 21,
+ax_anim 2, 0, 29, 6, 7, 6, 7,
+ax_anim_terminator
+sArmaldoAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 6, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 17, 0, 17, 0,
+ax_anim 2, 1, 38, 17, 1, 17, 1,
+ax_anim 2, 0, 38, 17, 0, 17, 0,
+ax_anim 2, 0, 38, 17, 1, 17, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sArmaldoAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 6, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, 6, -5, 6, -5,
+ax_anim 1, 0, 41, 12, -11, 12, -11,
+ax_anim 2, 0, 43, 16, -15, 16, -15,
+ax_anim 2, 1, 43, 17, -14, 17, -14,
+ax_anim 2, 0, 43, 16, -15, 16, -15,
+ax_anim 2, 0, 43, 17, -14, 17, -14,
+ax_anim 2, 0, 39, 7, -6, 7, -6,
+ax_anim_terminator
+sArmaldoAnims_2_5:
+ax_anim 2, 0, 47, 0, 1, 0, 1,
+ax_anim 6, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -2, 0, -2,
+ax_anim 1, 0, 46, 0, -9, 0, -9,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 1, 48, 1, -16, 1, -16,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 0, 48, 1, -16, 1, -16,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sArmaldoAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 6, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 50, -6, -5, -6, -5,
+ax_anim 1, 0, 51, -12, -11, -12, -11,
+ax_anim 2, 0, 53, -16, -15, -16, -15,
+ax_anim 2, 1, 53, -17, -14, -17, -14,
+ax_anim 2, 0, 53, -16, -15, -16, -15,
+ax_anim 2, 0, 53, -17, -14, -17, -14,
+ax_anim 2, 0, 49, -7, -6, -7, -6,
+ax_anim_terminator
+sArmaldoAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 6, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 56, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -17, 0, -17, 0,
+ax_anim 2, 1, 58, -17, 1, -17, 1,
+ax_anim 2, 0, 58, -17, 0, -17, 0,
+ax_anim 2, 0, 58, -17, 1, -17, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sArmaldoAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 6, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 61, -10, 11, -10, 11,
+ax_anim 2, 0, 63, -18, 22, -18, 22,
+ax_anim 2, 1, 63, -19, 21, -19, 21,
+ax_anim 2, 0, 63, -18, 22, -18, 22,
+ax_anim 2, 0, 63, -19, 21, -19, 21,
+ax_anim 2, 0, 59, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_3_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 65, 0, -4, 0, -4,
+ax_anim 6, 0, 65, 0, -5, 0, -5,
+ax_anim 1, 2, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 65, 0, 8, 0, 8,
+ax_anim 2, 0, 66, 0, 17, 0, 17,
+ax_anim 2, 1, 67, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 67, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 67, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 1, 0, 64, 0, 8, 0, 8,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sArmaldoAnims_3_2:
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -4, -4, -4, -4,
+ax_anim 6, 0, 69, -5, -5, -5, -5,
+ax_anim 1, 2, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 8, 10, 8, 10,
+ax_anim 2, 0, 70, 15, 19, 15, 19,
+ax_anim 2, 1, 71, 16, 18, 16, 18,
+ax_anim 2, 0, 71, 15, 19, 15, 19,
+ax_anim 2, 0, 71, 16, 18, 16, 18,
+ax_anim 2, 0, 71, 15, 19, 15, 19,
+ax_anim 2, 0, 71, 16, 18, 16, 18,
+ax_anim 2, 0, 71, 15, 19, 15, 19,
+ax_anim 1, 0, 68, 8, 10, 8, 10,
+ax_anim 2, 0, 68, 4, 4, 4, 4,
+ax_anim_terminator
+sArmaldoAnims_3_3:
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim 2, 0, 73, -4, 0, -4, 0,
+ax_anim 6, 0, 73, -5, 0, -5, 0,
+ax_anim 1, 2, 73, -2, 0, -2, 0,
+ax_anim 1, 0, 73, 5, 0, 5, 0,
+ax_anim 2, 0, 74, 11, 0, 11, 0,
+ax_anim 2, 1, 75, 11, 1, 11, 1,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 75, 11, 1, 11, 1,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 75, 11, 1, 11, 1,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 1, 0, 72, 6, 0, 6, 0,
+ax_anim 2, 0, 72, 2, 0, 2, 0,
+ax_anim_terminator
+sArmaldoAnims_3_4:
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 2, 0, 77, -4, 4, -4, 4,
+ax_anim 6, 0, 77, -5, 5, -5, 5,
+ax_anim 1, 2, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 9, -7, 9, -7,
+ax_anim 2, 0, 78, 15, -12, 15, -12,
+ax_anim 2, 1, 79, 16, -11, 16, -11,
+ax_anim 2, 0, 79, 15, -12, 15, -12,
+ax_anim 2, 0, 79, 16, -11, 16, -11,
+ax_anim 2, 0, 79, 15, -12, 15, -12,
+ax_anim 2, 0, 79, 16, -11, 16, -11,
+ax_anim 2, 0, 79, 15, -12, 15, -12,
+ax_anim 1, 0, 76, 10, -7, 10, -7,
+ax_anim 2, 0, 76, 3, -3, 3, -3,
+ax_anim_terminator
+sArmaldoAnims_3_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 2, 0, 81, 0, 4, 0, 4,
+ax_anim 6, 0, 81, 0, 5, 0, 5,
+ax_anim 1, 2, 81, 0, 2, 0, 2,
+ax_anim 1, 0, 81, 0, -4, 0, -4,
+ax_anim 2, 0, 82, 0, -13, 0, -13,
+ax_anim 2, 1, 83, 1, -13, 1, -13,
+ax_anim 2, 0, 83, 0, -13, 0, -13,
+ax_anim 2, 0, 83, 1, -13, 1, -13,
+ax_anim 2, 0, 83, 0, -13, 0, -13,
+ax_anim 2, 0, 83, 1, -13, 1, -13,
+ax_anim 2, 0, 83, 0, -13, 0, -13,
+ax_anim 1, 0, 80, 0, -6, 0, -6,
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim_terminator
+sArmaldoAnims_3_6:
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 6, 0, 85, 5, 5, 5, 5,
+ax_anim 1, 2, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 85, -9, -7, -9, -7,
+ax_anim 2, 0, 86, -15, -12, -15, -12,
+ax_anim 2, 1, 87, -16, -11, -16, -11,
+ax_anim 2, 0, 87, -15, -12, -15, -12,
+ax_anim 2, 0, 87, -16, -11, -16, -11,
+ax_anim 2, 0, 87, -15, -12, -15, -12,
+ax_anim 2, 0, 87, -16, -11, -16, -11,
+ax_anim 2, 0, 87, -15, -12, -15, -12,
+ax_anim 1, 0, 84, -10, -7, -10, -7,
+ax_anim 2, 0, 84, -3, -3, -3, -3,
+ax_anim_terminator
+sArmaldoAnims_3_7:
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 89, 4, 0, 4, 0,
+ax_anim 6, 0, 89, 5, 0, 5, 0,
+ax_anim 1, 2, 89, 2, 0, 2, 0,
+ax_anim 1, 0, 89, -5, 0, -5, 0,
+ax_anim 2, 0, 90, -11, 0, -11, 0,
+ax_anim 2, 1, 91, -11, 1, -11, 1,
+ax_anim 2, 0, 91, -11, 0, -11, 0,
+ax_anim 2, 0, 91, -11, 1, -11, 1,
+ax_anim 2, 0, 91, -11, 0, -11, 0,
+ax_anim 2, 0, 91, -11, 1, -11, 1,
+ax_anim 2, 0, 91, -11, 0, -11, 0,
+ax_anim 1, 0, 88, -6, 0, -6, 0,
+ax_anim 2, 0, 88, -2, 0, -2, 0,
+ax_anim_terminator
+sArmaldoAnims_3_8:
+ax_anim 2, 0, 92, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 4, -4, 4, -4,
+ax_anim 6, 0, 93, 5, -5, 5, -5,
+ax_anim 1, 2, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 93, -8, 10, -8, 10,
+ax_anim 2, 0, 94, -15, 19, -15, 19,
+ax_anim 2, 1, 95, -16, 18, -16, 18,
+ax_anim 2, 0, 95, -15, 19, -15, 19,
+ax_anim 2, 0, 95, -16, 18, -16, 18,
+ax_anim 2, 0, 95, -15, 19, -15, 19,
+ax_anim 2, 0, 95, -16, 18, -16, 18,
+ax_anim 2, 0, 95, -15, 19, -15, 19,
+ax_anim 1, 0, 92, -8, 10, -8, 10,
+ax_anim 2, 0, 92, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_4_1:
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 6, 2, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim_terminator
+sArmaldoAnims_4_2:
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim 6, 2, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sArmaldoAnims_4_3:
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim 6, 2, 103, -3, 0, -3, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 1, 104, 3, 0, 3, 0,
+ax_anim 2, 0, 104, 3, 1, 3, 1,
+ax_anim 2, 0, 104, 3, 0, 3, 0,
+ax_anim 2, 0, 104, 3, 1, 3, 1,
+ax_anim 2, 0, 104, 3, 0, 3, 0,
+ax_anim 2, 0, 104, 3, 1, 3, 1,
+ax_anim 2, 0, 104, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim_terminator
+sArmaldoAnims_4_4:
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 6, 2, 106, -3, 3, -3, 3,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 1, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim_terminator
+sArmaldoAnims_4_5:
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim 6, 2, 109, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 1, 0, 1,
+ax_anim 2, 1, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sArmaldoAnims_4_6:
+ax_anim 2, 0, 112, 2, 2, 2, 2,
+ax_anim 6, 2, 112, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 1, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+sArmaldoAnims_4_7:
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 6, 2, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 116, -3, 0, -3, 0,
+ax_anim 2, 0, 116, -3, 1, -3, 1,
+ax_anim 2, 0, 116, -3, 0, -3, 0,
+ax_anim 2, 0, 116, -3, 1, -3, 1,
+ax_anim 2, 0, 116, -3, 0, -3, 0,
+ax_anim 2, 0, 116, -3, 1, -3, 1,
+ax_anim 2, 0, 116, -3, 0, -3, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim_terminator
+sArmaldoAnims_4_8:
+ax_anim 2, 0, 118, 2, -2, 2, -2,
+ax_anim 6, 2, 118, 3, -3, 3, -3,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_7_1:
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 8, 0, 130, 0, -4, 0, -4,
+ax_anim_terminator
+sArmaldoAnims_7_2:
+ax_anim 2, 0, 131, -3, -3, -3, -3,
+ax_anim 8, 0, 131, -4, -4, -4, -4,
+ax_anim_terminator
+sArmaldoAnims_7_3:
+ax_anim 2, 0, 132, -3, 0, -3, 0,
+ax_anim 8, 0, 132, -4, 0, -4, 0,
+ax_anim_terminator
+sArmaldoAnims_7_4:
+ax_anim 2, 0, 133, -3, 3, -3, 3,
+ax_anim 8, 0, 133, -4, 4, -4, 4,
+ax_anim_terminator
+sArmaldoAnims_7_5:
+ax_anim 2, 0, 134, 0, 3, 0, 3,
+ax_anim 8, 0, 134, 0, 4, 0, 4,
+ax_anim_terminator
+sArmaldoAnims_7_6:
+ax_anim 2, 0, 135, 3, 3, 3, 3,
+ax_anim 8, 0, 135, 4, 4, 4, 4,
+ax_anim_terminator
+sArmaldoAnims_7_7:
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 8, 0, 136, 4, 0, 4, 0,
+ax_anim_terminator
+sArmaldoAnims_7_8:
+ax_anim 2, 0, 137, 3, -3, 3, -3,
+ax_anim 8, 0, 137, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_8_1:
+ax_anim 60, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_8_2:
+ax_anim 60, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_8_3:
+ax_anim 60, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_8_4:
+ax_anim 60, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_8_5:
+ax_anim 60, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_8_6:
+ax_anim 60, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_8_7:
+ax_anim 60, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_8_8:
+ax_anim 60, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 9, 4, 9, 4,
+ax_anim 2, 0, 164, 13, 11, 13, 11,
+ax_anim 2, 0, 165, 11, 17, 11, 17,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -10, 17, -10, 17,
+ax_anim 2, 0, 168, -13, 11, -13, 11,
+ax_anim 1, 0, 169, -9, 4, -9, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, 2, 9, 2,
+ax_anim 2, 0, 163, 15, 6, 15, 6,
+ax_anim 2, 0, 164, 20, 13, 20, 13,
+ax_anim 3, 0, 165, 19, 19, 19, 19,
+ax_anim 2, 3, 166, 9, 20, 9, 20,
+ax_anim 2, 0, 167, 1, 15, 1, 15,
+ax_anim 1, 0, 168, -1, 9, -1, 9,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 10, -6, 10, -6,
+ax_anim 2, 0, 163, 15, -5, 15, -5,
+ax_anim 3, 0, 164, 18, 0, 18, 0,
+ax_anim 2, 3, 165, 16, 4, 16, 4,
+ax_anim 2, 0, 166, 10, 7, 10, 7,
+ax_anim 1, 0, 167, 3, 5, 3, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 11, -20, 11, -20,
+ax_anim 3, 0, 163, 19, -21, 19, -21,
+ax_anim 2, 3, 164, 22, -14, 22, -14,
+ax_anim 2, 0, 165, 19, -8, 19, -8,
+ax_anim 1, 0, 166, 12, -2, 12, -2,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -11, -5, -11, -5,
+ax_anim 2, 0, 168, -12, -12, -12, -12,
+ax_anim 2, 0, 169, -7, -20, -7, -20,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -20, 7, -20,
+ax_anim 2, 0, 164, 12, -12, 12, -12,
+ax_anim 1, 0, 165, 11, -5, 11, -5,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -11, -20, -11, -20,
+ax_anim 3, 0, 169, -19, -21, -19, -21,
+ax_anim 2, 3, 168, -22, -14, -22, -14,
+ax_anim 2, 0, 167, -19, -8, -19, -8,
+ax_anim 1, 0, 166, -12, -2, -12, -2,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -10, -6, -10, -6,
+ax_anim 2, 0, 169, -15, -5, -15, -5,
+ax_anim 3, 0, 168, -18, 0, -18, 0,
+ax_anim 2, 3, 167, -16, 4, -16, 4,
+ax_anim 2, 0, 166, -10, 7, -10, 7,
+ax_anim 1, 0, 165, -3, 5, -3, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, 2, -9, 2,
+ax_anim 2, 0, 169, -15, 6, -15, 6,
+ax_anim 2, 0, 168, -20, 13, -20, 13,
+ax_anim 3, 0, 167, -19, 19, -19, 19,
+ax_anim 2, 3, 166, -9, 20, -9, 20,
+ax_anim 2, 0, 165, -1, 15, -1, 15,
+ax_anim 1, 0, 164, 1, 9, 1, 9,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_10_1:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_10_2:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_10_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_10_4:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_10_5:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_10_6:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_10_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_10_8:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_11_1:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -22, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_11_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -24, 0, 0,
+ax_anim 2, 0, 211, 0, -19, 0, 0,
+ax_anim 1, 0, 211, 0, -12, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_11_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -22, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_11_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -22, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 2, 0, 217, 0, -17, 0, 0,
+ax_anim 1, 0, 217, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_11_5:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -21, 0, 0,
+ax_anim 2, 0, 220, 0, -17, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_11_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 2, 0, 223, 0, -17, 0, 0,
+ax_anim 1, 0, 223, 0, -11, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_11_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -22, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_11_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -24, 0, 0,
+ax_anim 2, 0, 229, 0, -19, 0, 0,
+ax_anim 1, 0, 229, 0, -12, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_12_1:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_12_2:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_12_3:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_12_4:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_12_5:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_12_6:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_12_7:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_12_8:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArmaldoAnims_13_1:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_13_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_13_3:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_13_4:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_13_5:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_13_6:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_13_7:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoAnims_13_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sArmaldoGfx1:
+.incbin "baserom.gba", 0x14333C0, 0x200
+sArmaldoSprites1:
+ax_sprite sArmaldoGfx1, 0x200
+ax_sprite_terminator
+sArmaldoGfx2:
+.incbin "baserom.gba", 0x14335D0, 0x200
+sArmaldoSprites2:
+ax_sprite sArmaldoGfx2, 0x200
+ax_sprite_terminator
+sArmaldoGfx3:
+.incbin "baserom.gba", 0x14337E0, 0x200
+sArmaldoSprites3:
+ax_sprite sArmaldoGfx3, 0x200
+ax_sprite_terminator
+sArmaldoGfx4:
+.incbin "baserom.gba", 0x14339F0, 0x200
+sArmaldoSprites4:
+ax_sprite sArmaldoGfx4, 0x200
+ax_sprite_terminator
+sArmaldoGfx5:
+.incbin "baserom.gba", 0x1433C00, 0x200
+sArmaldoSprites5:
+ax_sprite sArmaldoGfx5, 0x200
+ax_sprite_terminator
+sArmaldoGfx6:
+.incbin "baserom.gba", 0x1433E10, 0x200
+sArmaldoSprites6:
+ax_sprite sArmaldoGfx6, 0x200
+ax_sprite_terminator
+sArmaldoGfx7:
+.incbin "baserom.gba", 0x1434020, 0x200
+sArmaldoSprites7:
+ax_sprite sArmaldoGfx7, 0x200
+ax_sprite_terminator
+sArmaldoGfx8:
+.incbin "baserom.gba", 0x1434230, 0x100
+sArmaldoSprites8:
+ax_sprite sArmaldoGfx8, 0x100
+ax_sprite_terminator
+sArmaldoGfx9:
+.incbin "baserom.gba", 0x1434340, 0x80
+sArmaldoSprites9:
+ax_sprite sArmaldoGfx9, 0x80
+ax_sprite_terminator
+sArmaldoGfx10:
+.incbin "baserom.gba", 0x14343D0, 0x40
+sArmaldoSprites10:
+ax_sprite sArmaldoGfx10, 0x40
+ax_sprite_terminator
+sArmaldoGfx11:
+.incbin "baserom.gba", 0x1434420, 0x40
+sArmaldoSprites11:
+ax_sprite sArmaldoGfx11, 0x40
+ax_sprite_terminator
+sArmaldoGfx12:
+.incbin "baserom.gba", 0x1434470, 0x100
+sArmaldoSprites12:
+ax_sprite sArmaldoGfx12, 0x100
+ax_sprite_terminator
+sArmaldoGfx13:
+.incbin "baserom.gba", 0x1434580, 0x80
+sArmaldoSprites13:
+ax_sprite sArmaldoGfx13, 0x80
+ax_sprite_terminator
+sArmaldoGfx14:
+.incbin "baserom.gba", 0x1434610, 0x40
+sArmaldoSprites14:
+ax_sprite sArmaldoGfx14, 0x40
+ax_sprite_terminator
+sArmaldoGfx15:
+.incbin "baserom.gba", 0x1434660, 0x20
+sArmaldoSprites15:
+ax_sprite sArmaldoGfx15, 0x20
+ax_sprite_terminator
+sArmaldoGfx16:
+.incbin "baserom.gba", 0x1434690, 0x200
+sArmaldoSprites16:
+ax_sprite sArmaldoGfx16, 0x200
+ax_sprite_terminator
+sArmaldoGfx17:
+.incbin "baserom.gba", 0x14348A0, 0x200
+sArmaldoSprites17:
+ax_sprite sArmaldoGfx17, 0x200
+ax_sprite_terminator
+sArmaldoGfx18:
+.incbin "baserom.gba", 0x1434AB0, 0x200
+sArmaldoSprites18:
+ax_sprite sArmaldoGfx18, 0x200
+ax_sprite_terminator
+sArmaldoGfx19:
+.incbin "baserom.gba", 0x1434CC0, 0x200
+sArmaldoSprites19:
+ax_sprite sArmaldoGfx19, 0x200
+ax_sprite_terminator
+sArmaldoGfx20:
+.incbin "baserom.gba", 0x1434ED0, 0x200
+sArmaldoSprites20:
+ax_sprite sArmaldoGfx20, 0x200
+ax_sprite_terminator
+sArmaldoGfx21:
+.incbin "baserom.gba", 0x14350E0, 0x200
+sArmaldoSprites21:
+ax_sprite sArmaldoGfx21, 0x200
+ax_sprite_terminator
+sArmaldoGfx22:
+.incbin "baserom.gba", 0x14352F0, 0x100
+sArmaldoSprites22:
+ax_sprite sArmaldoGfx22, 0x100
+ax_sprite_terminator
+sArmaldoGfx23:
+.incbin "baserom.gba", 0x1435400, 0x80
+sArmaldoSprites23:
+ax_sprite sArmaldoGfx23, 0x80
+ax_sprite_terminator
+sArmaldoGfx24:
+.incbin "baserom.gba", 0x1435490, 0x20
+sArmaldoSprites24:
+ax_sprite sArmaldoGfx24, 0x20
+ax_sprite_terminator
+sArmaldoGfx25:
+.incbin "baserom.gba", 0x14354C0, 0x40
+sArmaldoSprites25:
+ax_sprite sArmaldoGfx25, 0x40
+ax_sprite_terminator
+sArmaldoGfx26:
+.incbin "baserom.gba", 0x1435510, 0x20
+sArmaldoSprites26:
+ax_sprite sArmaldoGfx26, 0x20
+ax_sprite_terminator
+sArmaldoGfx27:
+.incbin "baserom.gba", 0x1435540, 0x40
+sArmaldoGfx27_1:
+.incbin "baserom.gba", 0x1435580, 0x100
+sArmaldoGfx27_2:
+.incbin "baserom.gba", 0x1435680, 0x60
+sArmaldoSprites27:
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx27_2, 0x60
+ax_sprite_terminator
+sArmaldoGfx28:
+.incbin "baserom.gba", 0x1435718, 0x60
+sArmaldoGfx28_1:
+.incbin "baserom.gba", 0x1435778, 0x80
+sArmaldoGfx28_2:
+.incbin "baserom.gba", 0x14357F8, 0x60
+sArmaldoGfx28_3:
+.incbin "baserom.gba", 0x1435858, 0x40
+sArmaldoSprites28:
+ax_sprite sArmaldoGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx28_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArmaldoGfx29:
+.incbin "baserom.gba", 0x14358E0, 0x20
+sArmaldoGfx29_1:
+.incbin "baserom.gba", 0x1435900, 0x140
+sArmaldoGfx29_2:
+.incbin "baserom.gba", 0x1435A40, 0x60
+sArmaldoSprites29:
+ax_sprite sArmaldoGfx29, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx29_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx29_2, 0x60
+ax_sprite_terminator
+sArmaldoGfx30:
+.incbin "baserom.gba", 0x1435AD0, 0x40
+sArmaldoSprites30:
+ax_sprite sArmaldoGfx30, 0x40
+ax_sprite_terminator
+sArmaldoGfx31:
+.incbin "baserom.gba", 0x1435B20, 0x20
+sArmaldoSprites31:
+ax_sprite sArmaldoGfx31, 0x20
+ax_sprite_terminator
+sArmaldoGfx32:
+.incbin "baserom.gba", 0x1435B50, 0x60
+sArmaldoSprites32:
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx32, 0x60
+ax_sprite_terminator
+sArmaldoGfx33:
+.incbin "baserom.gba", 0x1435BC8, 0x60
+sArmaldoGfx33_1:
+.incbin "baserom.gba", 0x1435C28, 0x60
+sArmaldoSprites33:
+ax_sprite sArmaldoGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArmaldoGfx34:
+.incbin "baserom.gba", 0x1435CB0, 0x20
+sArmaldoSprites34:
+ax_sprite sArmaldoGfx34, 0x20
+ax_sprite_terminator
+sArmaldoGfx35:
+.incbin "baserom.gba", 0x1435CE0, 0x40
+sArmaldoSprites35:
+ax_sprite sArmaldoGfx35, 0x40
+ax_sprite_terminator
+sArmaldoGfx36:
+.incbin "baserom.gba", 0x1435D30, 0x40
+sArmaldoSprites36:
+ax_sprite sArmaldoGfx36, 0x40
+ax_sprite_terminator
+sArmaldoGfx37:
+.incbin "baserom.gba", 0x1435D80, 0x20
+sArmaldoSprites37:
+ax_sprite sArmaldoGfx37, 0x20
+ax_sprite_terminator
+sArmaldoGfx38:
+.incbin "baserom.gba", 0x1435DB0, 0x60
+sArmaldoGfx38_1:
+.incbin "baserom.gba", 0x1435E10, 0x80
+sArmaldoSprites38:
+ax_sprite sArmaldoGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx38_1, 0x80
+ax_sprite_terminator
+sArmaldoGfx39:
+.incbin "baserom.gba", 0x1435EB0, 0x40
+sArmaldoSprites39:
+ax_sprite sArmaldoGfx39, 0x40
+ax_sprite_terminator
+sArmaldoGfx40:
+.incbin "baserom.gba", 0x1435F00, 0x160
+sArmaldoGfx40_1:
+.incbin "baserom.gba", 0x1436060, 0x60
+sArmaldoSprites40:
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx40, 0x160
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx40_1, 0x60
+ax_sprite_terminator
+sArmaldoGfx41:
+.incbin "baserom.gba", 0x14360E8, 0x60
+sArmaldoGfx41_1:
+.incbin "baserom.gba", 0x1436148, 0x100
+sArmaldoGfx41_2:
+.incbin "baserom.gba", 0x1436248, 0x60
+sArmaldoSprites41:
+ax_sprite sArmaldoGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx41_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx41_2, 0x60
+ax_sprite_terminator
+sArmaldoGfx42:
+.incbin "baserom.gba", 0x14362D8, 0x100
+sArmaldoSprites42:
+ax_sprite sArmaldoGfx42, 0x100
+ax_sprite_terminator
+sArmaldoGfx43:
+.incbin "baserom.gba", 0x14363E8, 0x80
+sArmaldoSprites43:
+ax_sprite sArmaldoGfx43, 0x80
+ax_sprite_terminator
+sArmaldoGfx44:
+.incbin "baserom.gba", 0x1436478, 0x40
+sArmaldoSprites44:
+ax_sprite sArmaldoGfx44, 0x40
+ax_sprite_terminator
+sArmaldoGfx45:
+.incbin "baserom.gba", 0x14364C8, 0x20
+sArmaldoSprites45:
+ax_sprite sArmaldoGfx45, 0x20
+ax_sprite_terminator
+sArmaldoGfx46:
+.incbin "baserom.gba", 0x14364F8, 0x20
+sArmaldoSprites46:
+ax_sprite sArmaldoGfx46, 0x20
+ax_sprite_terminator
+sArmaldoGfx47:
+.incbin "baserom.gba", 0x1436528, 0x200
+sArmaldoSprites47:
+ax_sprite sArmaldoGfx47, 0x200
+ax_sprite_terminator
+sArmaldoGfx48:
+.incbin "baserom.gba", 0x1436738, 0x20
+sArmaldoGfx48_1:
+.incbin "baserom.gba", 0x1436758, 0x40
+sArmaldoGfx48_2:
+.incbin "baserom.gba", 0x1436798, 0x120
+sArmaldoSprites48:
+ax_sprite sArmaldoGfx48, 0x20
+ax_sprite 0, 0x40
+ax_sprite sArmaldoGfx48_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArmaldoGfx48_2, 0x120
+ax_sprite_terminator
+sArmaldoGfx49:
+.incbin "baserom.gba", 0x14368E8, 0x40
+sArmaldoGfx49_1:
+.incbin "baserom.gba", 0x1436928, 0x180
+sArmaldoSprites49:
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx49_1, 0x180
+ax_sprite_terminator
+sArmaldoGfx50:
+.incbin "baserom.gba", 0x1436AD0, 0x40
+sArmaldoGfx50_1:
+.incbin "baserom.gba", 0x1436B10, 0x60
+sArmaldoGfx50_2:
+.incbin "baserom.gba", 0x1436B70, 0xA0
+sArmaldoGfx50_3:
+.incbin "baserom.gba", 0x1436C10, 0x40
+sArmaldoSprites50:
+ax_sprite sArmaldoGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx50_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx50_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArmaldoGfx51:
+.incbin "baserom.gba", 0x1436C98, 0x20
+sArmaldoGfx51_1:
+.incbin "baserom.gba", 0x1436CB8, 0x1A0
+sArmaldoSprites51:
+ax_sprite sArmaldoGfx51, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx51_1, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArmaldoGfx52:
+.incbin "baserom.gba", 0x1436E80, 0x100
+sArmaldoSprites52:
+ax_sprite sArmaldoGfx52, 0x100
+ax_sprite_terminator
+sArmaldoGfx53:
+.incbin "baserom.gba", 0x1436F90, 0x100
+sArmaldoSprites53:
+ax_sprite sArmaldoGfx53, 0x100
+ax_sprite_terminator
+sArmaldoGfx54:
+.incbin "baserom.gba", 0x14370A0, 0x80
+sArmaldoSprites54:
+ax_sprite sArmaldoGfx54, 0x80
+ax_sprite_terminator
+sArmaldoGfx55:
+.incbin "baserom.gba", 0x1437130, 0x40
+sArmaldoSprites55:
+ax_sprite sArmaldoGfx55, 0x40
+ax_sprite_terminator
+sArmaldoGfx56:
+.incbin "baserom.gba", 0x1437180, 0x20
+sArmaldoSprites56:
+ax_sprite sArmaldoGfx56, 0x20
+ax_sprite_terminator
+sArmaldoGfx57:
+.incbin "baserom.gba", 0x14371B0, 0x20
+sArmaldoSprites57:
+ax_sprite sArmaldoGfx57, 0x20
+ax_sprite_terminator
+sArmaldoGfx58:
+.incbin "baserom.gba", 0x14371E0, 0x60
+sArmaldoGfx58_1:
+.incbin "baserom.gba", 0x1437240, 0x60
+sArmaldoGfx58_2:
+.incbin "baserom.gba", 0x14372A0, 0x40
+sArmaldoSprites58:
+ax_sprite 0, 0x40
+ax_sprite sArmaldoGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx58_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sArmaldoGfx58_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sArmaldoGfx59:
+.incbin "baserom.gba", 0x1437320, 0x60
+sArmaldoGfx59_1:
+.incbin "baserom.gba", 0x1437380, 0x100
+sArmaldoGfx59_2:
+.incbin "baserom.gba", 0x1437480, 0x60
+sArmaldoSprites59:
+ax_sprite sArmaldoGfx59, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx59_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sArmaldoGfx59_2, 0x60
+ax_sprite_terminator
+sArmaldoGfx60:
+.incbin "baserom.gba", 0x1437510, 0x20
+sArmaldoGfx60_1:
+.incbin "baserom.gba", 0x1437530, 0x40
+sArmaldoGfx60_2:
+.incbin "baserom.gba", 0x1437570, 0x20
+sArmaldoSprites60:
+ax_sprite sArmaldoGfx60, 0x20
+ax_sprite 0, 0x40
+ax_sprite sArmaldoGfx60_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArmaldoGfx60_2, 0x20
+ax_sprite_terminator
+sArmaldoGfx61:
+.incbin "baserom.gba", 0x14375C0, 0x20
+sArmaldoGfx61_1:
+.incbin "baserom.gba", 0x14375E0, 0x20
+sArmaldoSprites61:
+ax_sprite sArmaldoGfx61, 0x20
+ax_sprite 0, 0x40
+ax_sprite sArmaldoGfx61_1, 0x20
+ax_sprite_terminator
+sArmaldoGfx62:
+.incbin "baserom.gba", 0x1437620, 0x20
+sArmaldoSprites62:
+ax_sprite sArmaldoGfx62, 0x20
+ax_sprite_terminator
+sArmaldoGfx63:
+.incbin "baserom.gba", 0x1437650, 0x20
+sArmaldoSprites63:
+ax_sprite sArmaldoGfx63, 0x20
+ax_sprite_terminator
+sArmaldoGfx64:
+.incbin "baserom.gba", 0x1437680, 0x200
+sArmaldoSprites64:
+ax_sprite sArmaldoGfx64, 0x200
+ax_sprite_terminator
+sArmaldoGfx65:
+.incbin "baserom.gba", 0x1437890, 0x200
+sArmaldoSprites65:
+ax_sprite sArmaldoGfx65, 0x200
+ax_sprite_terminator
+sArmaldoGfx66:
+.incbin "baserom.gba", 0x1437AA0, 0x200
+sArmaldoSprites66:
+ax_sprite sArmaldoGfx66, 0x200
+ax_sprite_terminator
+sArmaldoGfx67:
+.incbin "baserom.gba", 0x1437CB0, 0x200
+sArmaldoSprites67:
+ax_sprite sArmaldoGfx67, 0x200
+ax_sprite_terminator
+sArmaldoGfx68:
+.incbin "baserom.gba", 0x1437EC0, 0x200
+sArmaldoSprites68:
+ax_sprite sArmaldoGfx68, 0x200
+ax_sprite_terminator
+sArmaldoGfx69:
+.incbin "baserom.gba", 0x14380D0, 0x200
+sArmaldoSprites69:
+ax_sprite sArmaldoGfx69, 0x200
+ax_sprite_terminator
+sArmaldoGfx70:
+.incbin "baserom.gba", 0x14382E0, 0x200
+sArmaldoSprites70:
+ax_sprite sArmaldoGfx70, 0x200
+ax_sprite_terminator
+sArmaldoGfx71:
+.incbin "baserom.gba", 0x14384F0, 0x200
+sArmaldoSprites71:
+ax_sprite sArmaldoGfx71, 0x200
+ax_sprite_terminator
+sAxPosesArmaldo:
+.4byte sArmaldoPose1
+.4byte sArmaldoPose2
+.4byte sArmaldoPose3
+.4byte sArmaldoPose4
+.4byte sArmaldoPose5
+.4byte sArmaldoPose6
+.4byte sArmaldoPose7
+.4byte sArmaldoPose8
+.4byte sArmaldoPose9
+.4byte sArmaldoPose10
+.4byte sArmaldoPose11
+.4byte sArmaldoPose12
+.4byte sArmaldoPose13
+.4byte sArmaldoPose14
+.4byte sArmaldoPose15
+.4byte sArmaldoPose16
+.4byte sArmaldoPose17
+.4byte sArmaldoPose18
+.4byte sArmaldoPose19
+.4byte sArmaldoPose20
+.4byte sArmaldoPose21
+.4byte sArmaldoPose22
+.4byte sArmaldoPose23
+.4byte sArmaldoPose24
+.4byte sArmaldoPose25
+.4byte sArmaldoPose26
+.4byte sArmaldoPose27
+.4byte sArmaldoPose28
+.4byte sArmaldoPose29
+.4byte sArmaldoPose30
+.4byte sArmaldoPose31
+.4byte sArmaldoPose32
+.4byte sArmaldoPose33
+.4byte sArmaldoPose34
+.4byte sArmaldoPose35
+.4byte sArmaldoPose36
+.4byte sArmaldoPose37
+.4byte sArmaldoPose38
+.4byte sArmaldoPose39
+.4byte sArmaldoPose40
+.4byte sArmaldoPose41
+.4byte sArmaldoPose42
+.4byte sArmaldoPose43
+.4byte sArmaldoPose44
+.4byte sArmaldoPose45
+.4byte sArmaldoPose46
+.4byte sArmaldoPose47
+.4byte sArmaldoPose48
+.4byte sArmaldoPose49
+.4byte sArmaldoPose50
+.4byte sArmaldoPose51
+.4byte sArmaldoPose52
+.4byte sArmaldoPose53
+.4byte sArmaldoPose54
+.4byte sArmaldoPose55
+.4byte sArmaldoPose56
+.4byte sArmaldoPose57
+.4byte sArmaldoPose58
+.4byte sArmaldoPose59
+.4byte sArmaldoPose60
+.4byte sArmaldoPose61
+.4byte sArmaldoPose62
+.4byte sArmaldoPose63
+.4byte sArmaldoPose64
+.4byte sArmaldoPose65
+.4byte sArmaldoPose66
+.4byte sArmaldoPose67
+.4byte sArmaldoPose68
+.4byte sArmaldoPose69
+.4byte sArmaldoPose70
+.4byte sArmaldoPose71
+.4byte sArmaldoPose72
+.4byte sArmaldoPose73
+.4byte sArmaldoPose74
+.4byte sArmaldoPose75
+.4byte sArmaldoPose76
+.4byte sArmaldoPose77
+.4byte sArmaldoPose78
+.4byte sArmaldoPose79
+.4byte sArmaldoPose80
+.4byte sArmaldoPose81
+.4byte sArmaldoPose82
+.4byte sArmaldoPose83
+.4byte sArmaldoPose84
+.4byte sArmaldoPose85
+.4byte sArmaldoPose86
+.4byte sArmaldoPose87
+.4byte sArmaldoPose88
+.4byte sArmaldoPose89
+.4byte sArmaldoPose90
+.4byte sArmaldoPose91
+.4byte sArmaldoPose92
+.4byte sArmaldoPose93
+.4byte sArmaldoPose94
+.4byte sArmaldoPose95
+.4byte sArmaldoPose96
+.4byte sArmaldoPose97
+.4byte sArmaldoPose98
+.4byte sArmaldoPose99
+.4byte sArmaldoPose100
+.4byte sArmaldoPose101
+.4byte sArmaldoPose102
+.4byte sArmaldoPose103
+.4byte sArmaldoPose104
+.4byte sArmaldoPose105
+.4byte sArmaldoPose106
+.4byte sArmaldoPose107
+.4byte sArmaldoPose108
+.4byte sArmaldoPose109
+.4byte sArmaldoPose110
+.4byte sArmaldoPose111
+.4byte sArmaldoPose112
+.4byte sArmaldoPose113
+.4byte sArmaldoPose114
+.4byte sArmaldoPose115
+.4byte sArmaldoPose116
+.4byte sArmaldoPose117
+.4byte sArmaldoPose118
+.4byte sArmaldoPose119
+.4byte sArmaldoPose120
+.4byte sArmaldoPose121
+.4byte sArmaldoPose122
+.4byte sArmaldoPose123
+.4byte sArmaldoPose124
+.4byte sArmaldoPose125
+.4byte sArmaldoPose126
+.4byte sArmaldoPose127
+.4byte sArmaldoPose128
+.4byte sArmaldoPose129
+.4byte sArmaldoPose130
+.4byte sArmaldoPose131
+.4byte sArmaldoPose132
+.4byte sArmaldoPose133
+.4byte sArmaldoPose134
+.4byte sArmaldoPose135
+.4byte sArmaldoPose136
+.4byte sArmaldoPose137
+.4byte sArmaldoPose138
+.4byte sArmaldoPose139
+.4byte sArmaldoPose140
+.4byte sArmaldoPose141
+.4byte sArmaldoPose142
+.4byte sArmaldoPose143
+.4byte sArmaldoPose144
+.4byte sArmaldoPose145
+.4byte sArmaldoPose146
+.4byte sArmaldoPose147
+.4byte sArmaldoPose148
+.4byte sArmaldoPose149
+.4byte sArmaldoPose150
+.4byte sArmaldoPose151
+.4byte sArmaldoPose152
+.4byte sArmaldoPose153
+.4byte sArmaldoPose154
+.4byte sArmaldoPose155
+.4byte sArmaldoPose156
+.4byte sArmaldoPose157
+.4byte sArmaldoPose158
+.4byte sArmaldoPose159
+.4byte sArmaldoPose160
+.4byte sArmaldoPose161
+.4byte sArmaldoPose162
+.4byte sArmaldoPose163
+.4byte sArmaldoPose164
+.4byte sArmaldoPose165
+.4byte sArmaldoPose166
+.4byte sArmaldoPose167
+.4byte sArmaldoPose168
+.4byte sArmaldoPose169
+.4byte sArmaldoPose170
+.4byte sArmaldoPose171
+.4byte sArmaldoPose172
+.4byte sArmaldoPose173
+.4byte sArmaldoPose174
+.4byte sArmaldoPose175
+.4byte sArmaldoPose176
+.4byte sArmaldoPose177
+.4byte sArmaldoPose178
+.4byte sArmaldoPose179
+.4byte sArmaldoPose180
+.4byte sArmaldoPose181
+.4byte sArmaldoPose182
+.4byte sArmaldoPose183
+.4byte sArmaldoPose184
+.4byte sArmaldoPose185
+.4byte sArmaldoPose186
+.4byte sArmaldoPose187
+.4byte sArmaldoPose188
+.4byte sArmaldoPose189
+.4byte sArmaldoPose190
+.4byte sArmaldoPose191
+.4byte sArmaldoPose192
+.4byte sArmaldoPose193
+.4byte sArmaldoPose194
+.4byte sArmaldoPose195
+.4byte sArmaldoPose196
+.4byte sArmaldoPose197
+.4byte sArmaldoPose198
+.4byte sArmaldoPose199
+.4byte sArmaldoPose200
+.4byte sArmaldoPose201
+.4byte sArmaldoPose202
+.4byte sArmaldoPose203
+.4byte sArmaldoPose204
+.4byte sArmaldoPose205
+.4byte sArmaldoPose206
+.4byte sArmaldoPose207
+.4byte sArmaldoPose208
+.4byte sArmaldoPose209
+.4byte sArmaldoPose210
+.4byte sArmaldoPose211
+.4byte sArmaldoPose212
+.4byte sArmaldoPose213
+.4byte sArmaldoPose214
+.4byte sArmaldoPose215
+.4byte sArmaldoPose216
+.4byte sArmaldoPose217
+.4byte sArmaldoPose218
+.4byte sArmaldoPose219
+.4byte sArmaldoPose220
+.4byte sArmaldoPose221
+.4byte sArmaldoPose222
+.4byte sArmaldoPose223
+.4byte sArmaldoPose224
+.4byte sArmaldoPose225
+.4byte sArmaldoPose226
+.4byte sArmaldoPose227
+.4byte sArmaldoPose228
+.4byte sArmaldoPose229
+.4byte sArmaldoPose230
+.4byte sArmaldoPose231
+.4byte sArmaldoPose232
+.4byte sArmaldoPose233
+.4byte sArmaldoPose234
+.4byte sArmaldoPose235
+.4byte sArmaldoPose236
+.4byte sArmaldoPose237
+.4byte sArmaldoPose238
+.4byte sArmaldoPose239
+.4byte sArmaldoPose240
+.4byte sArmaldoPose241
+.4byte sArmaldoPose242
+.4byte sArmaldoPose243
+.4byte sArmaldoPose244
+.4byte sArmaldoPose245
+.4byte sArmaldoPose246
+sAxPositionsArmaldo:
+.2byte   -1,  -13, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -11, 	  -8,   -2, 	   7,    1, 	   0,   -7
+.2byte   -1,  -11, 	  -9,    1, 	   7,   -1, 	  -1,   -7
+.2byte    4,  -14, 	  10,   -5, 	  -2,    1, 	  -1,  -10
+.2byte    5,  -12, 	   8,   -4, 	   0,    3, 	   0,   -8
+.2byte    5,  -12, 	  11,   -3, 	  -2,    0, 	   1,   -9
+.2byte    9,  -18, 	   8,  -10, 	   8,   -3, 	  -2,  -10
+.2byte   10,  -17, 	   9,   -8, 	  10,   -2, 	  -1,   -9
+.2byte   10,  -17, 	  10,   -8, 	   6,   -1, 	  -1,   -9
+.2byte    5,  -20, 	  -4,  -13, 	  10,   -6, 	  -2,  -11
+.2byte    6,  -19, 	  -3,  -13, 	  11,   -6, 	  -2,  -10
+.2byte    6,  -19, 	  -2,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte   -1,  -19, 	   6,   -8, 	  -6,   -9, 	  -1,  -10
+.2byte    0,  -19, 	   8,   -8, 	  -5,   -7, 	   0,  -10
+.2byte   -6,  -20, 	   3,  -13, 	 -11,   -6, 	   1,  -11
+.2byte   -7,  -19, 	   2,  -13, 	 -12,   -6, 	   1,  -10
+.2byte   -7,  -19, 	   1,  -12, 	  -9,   -5, 	  -1,  -11
+.2byte  -11,  -17, 	 -10,   -9, 	 -10,   -2, 	   0,   -9
+.2byte  -12,  -16, 	 -11,   -7, 	 -12,   -1, 	  -1,   -8
+.2byte  -12,  -16, 	 -12,   -7, 	  -8,    0, 	  -1,   -8
+.2byte   -6,  -14, 	 -12,   -5, 	   0,    1, 	  -1,  -10
+.2byte   -7,  -12, 	 -10,   -4, 	  -2,    3, 	  -2,   -8
+.2byte   -7,  -12, 	 -13,   -3, 	   0,    0, 	  -3,   -9
+.2byte   -1,  -13, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -11, 	  -8,   -2, 	   7,    1, 	   0,   -7
+.2byte   -1,  -11, 	  -9,    1, 	   7,   -1, 	  -1,   -7
+.2byte   -1,  -15, 	 -14,  -20, 	  13,  -20, 	   0,  -10
+.2byte   -1,   -9, 	 -12,   -5, 	  12,   -5, 	   0,   -7
+.2byte    4,  -14, 	  10,   -5, 	  -2,    1, 	  -1,  -10
+.2byte    5,  -12, 	   8,   -4, 	   0,    3, 	   0,   -8
+.2byte    5,  -12, 	  11,   -3, 	  -2,    0, 	   1,   -9
+.2byte    3,  -16, 	  11,  -22, 	  -6,  -19, 	  -1,  -11
+.2byte    7,  -11, 	   0,  -11, 	 -11,   -5, 	  -1,   -8
+.2byte    9,  -18, 	   8,  -10, 	   8,   -3, 	  -2,  -10
+.2byte   10,  -17, 	   9,   -8, 	  10,   -2, 	  -1,   -9
+.2byte   10,  -17, 	  10,   -8, 	   6,   -1, 	  -1,   -9
+.2byte    6,  -20, 	   9,  -26, 	   8,  -15, 	  -1,  -11
+.2byte   12,  -16, 	  -1,  -11, 	  -3,   -3, 	   0,  -13
+.2byte    5,  -20, 	  -4,  -13, 	  10,   -6, 	  -2,  -11
+.2byte    6,  -19, 	  -3,  -13, 	  11,   -6, 	  -2,  -10
+.2byte    6,  -19, 	  -2,  -12, 	   8,   -5, 	   0,  -11
+.2byte    2,  -22, 	  -5,  -27, 	  14,  -20, 	  -2,  -12
+.2byte    8,  -20, 	  -6,  -12, 	   7,   -3, 	  -1,  -13
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte   -1,  -19, 	   6,   -8, 	  -6,   -9, 	  -1,  -10
+.2byte    0,  -19, 	   8,   -8, 	  -5,   -7, 	   0,  -10
+.2byte   -1,  -22, 	  13,  -23, 	 -14,  -22, 	  -1,  -12
+.2byte    0,  -20, 	  13,   -7, 	 -14,   -7, 	  -1,  -13
+.2byte   -6,  -20, 	   3,  -13, 	 -11,   -6, 	   1,  -11
+.2byte   -7,  -19, 	   2,  -13, 	 -12,   -6, 	   1,  -10
+.2byte   -7,  -19, 	   1,  -12, 	  -9,   -5, 	  -1,  -11
+.2byte   -3,  -22, 	   4,  -27, 	 -15,  -20, 	   1,  -12
+.2byte   -9,  -20, 	   5,  -12, 	  -8,   -3, 	   0,  -13
+.2byte  -11,  -17, 	 -10,   -9, 	 -10,   -2, 	   0,   -9
+.2byte  -12,  -16, 	 -11,   -7, 	 -12,   -1, 	  -1,   -8
+.2byte  -12,  -16, 	 -12,   -7, 	  -8,    0, 	  -1,   -8
+.2byte   -8,  -19, 	 -11,  -25, 	 -10,  -14, 	  -1,  -10
+.2byte  -14,  -15, 	  -1,  -10, 	   1,   -2, 	  -2,  -12
+.2byte   -6,  -14, 	 -12,   -5, 	   0,    1, 	  -1,  -10
+.2byte   -7,  -12, 	 -10,   -4, 	  -2,    3, 	  -2,   -8
+.2byte   -7,  -12, 	 -13,   -3, 	   0,    0, 	  -3,   -9
+.2byte   -5,  -16, 	 -13,  -22, 	   4,  -19, 	  -1,  -11
+.2byte   -9,  -11, 	  -2,  -11, 	   9,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -15, 	 -14,  -20, 	  13,  -20, 	   0,  -10
+.2byte   -1,   -9, 	   7,    2, 	  -7,    3, 	   0,   -6
+.2byte   -1,   -9, 	   7,    2, 	  -7,    3, 	   0,   -6
+.2byte    4,  -14, 	  10,   -5, 	  -2,    1, 	  -1,  -10
+.2byte    3,  -16, 	  11,  -22, 	  -6,  -19, 	  -1,  -11
+.2byte    7,  -11, 	   5,    2, 	  11,   -1, 	  -1,   -9
+.2byte    7,  -11, 	   5,    2, 	  11,   -1, 	  -1,   -9
+.2byte    9,  -18, 	   8,  -10, 	   8,   -3, 	  -2,  -10
+.2byte    6,  -20, 	   9,  -26, 	   8,  -15, 	  -1,  -11
+.2byte   12,  -16, 	  10,   -1, 	  14,  -11, 	   0,  -11
+.2byte   12,  -16, 	  10,   -1, 	  14,  -11, 	   0,  -11
+.2byte    5,  -20, 	  -4,  -13, 	  10,   -6, 	  -2,  -11
+.2byte    2,  -22, 	  -5,  -27, 	  14,  -20, 	  -2,  -12
+.2byte    7,  -19, 	  10,   -6, 	  -1,  -13, 	  -2,  -11
+.2byte    7,  -19, 	  10,   -6, 	  -1,  -13, 	  -2,  -11
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte   -1,  -22, 	  13,  -23, 	 -14,  -22, 	  -1,  -12
+.2byte    0,  -20, 	   8,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte    0,  -20, 	   8,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte   -6,  -20, 	   3,  -13, 	 -11,   -6, 	   1,  -11
+.2byte   -3,  -22, 	   4,  -27, 	 -15,  -20, 	   1,  -12
+.2byte   -8,  -19, 	 -11,   -6, 	   0,  -13, 	   1,  -11
+.2byte   -8,  -19, 	 -11,   -6, 	   0,  -13, 	   1,  -11
+.2byte  -11,  -17, 	 -10,   -9, 	 -10,   -2, 	   0,   -9
+.2byte   -8,  -19, 	 -11,  -25, 	 -10,  -14, 	  -1,  -10
+.2byte  -14,  -15, 	 -12,    0, 	 -16,  -10, 	  -2,  -10
+.2byte  -14,  -15, 	 -12,    0, 	 -16,  -10, 	  -2,  -10
+.2byte   -6,  -14, 	 -12,   -5, 	   0,    1, 	  -1,  -10
+.2byte   -5,  -16, 	 -13,  -22, 	   4,  -19, 	  -1,  -11
+.2byte   -9,  -11, 	  -7,    2, 	 -13,   -1, 	  -1,   -9
+.2byte   -9,  -11, 	  -7,    2, 	 -13,   -1, 	  -1,   -9
+.2byte   -1,  -13, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -15, 	 -14,  -20, 	  13,  -20, 	   0,  -10
+.2byte   -1,   -9, 	 -12,   -5, 	  12,   -5, 	   0,   -7
+.2byte    4,  -14, 	  10,   -5, 	  -2,    1, 	  -1,  -10
+.2byte    3,  -16, 	  11,  -22, 	  -6,  -19, 	  -1,  -11
+.2byte    7,  -11, 	   0,  -11, 	 -11,   -5, 	  -1,   -8
+.2byte    9,  -18, 	   8,  -10, 	   8,   -3, 	  -2,  -10
+.2byte    6,  -20, 	   9,  -26, 	   8,  -15, 	  -1,  -11
+.2byte   12,  -16, 	  -1,  -11, 	  -3,   -3, 	   0,  -13
+.2byte    5,  -20, 	  -4,  -13, 	  10,   -6, 	  -2,  -11
+.2byte    2,  -22, 	  -5,  -27, 	  14,  -20, 	  -2,  -12
+.2byte    8,  -20, 	  -6,  -12, 	   7,   -3, 	  -1,  -13
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte   -1,  -22, 	  13,  -23, 	 -14,  -22, 	  -1,  -12
+.2byte    0,  -20, 	  13,   -7, 	 -14,   -7, 	  -1,  -13
+.2byte   -6,  -20, 	   3,  -13, 	 -11,   -6, 	   1,  -11
+.2byte   -3,  -22, 	   4,  -27, 	 -15,  -20, 	   1,  -12
+.2byte   -9,  -20, 	   5,  -12, 	  -8,   -3, 	   0,  -13
+.2byte  -11,  -17, 	 -10,   -9, 	 -10,   -2, 	   0,   -9
+.2byte   -8,  -19, 	 -11,  -25, 	 -10,  -14, 	  -1,  -10
+.2byte  -14,  -15, 	  -1,  -10, 	   1,   -2, 	  -2,  -12
+.2byte   -6,  -14, 	 -12,   -5, 	   0,    1, 	  -1,  -10
+.2byte   -5,  -16, 	 -13,  -22, 	   4,  -19, 	  -1,  -11
+.2byte   -9,  -11, 	  -2,  -11, 	   9,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -5,  -13, 	 -11,   -4, 	   1,    2, 	   0,   -9
+.2byte  -10,  -17, 	  -9,   -9, 	  -9,   -2, 	   1,   -9
+.2byte   -5,  -20, 	   4,  -13, 	 -10,   -6, 	   2,  -11
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte    4,  -20, 	  -5,  -13, 	   9,   -6, 	  -3,  -11
+.2byte   10,  -18, 	   9,  -10, 	   9,   -3, 	  -1,  -10
+.2byte    5,  -13, 	  11,   -4, 	  -1,    2, 	   0,   -9
+.2byte   -5,  -11, 	 -11,   -3, 	   1,    2, 	  -1,   -6
+.2byte   -6,  -10, 	 -12,   -2, 	   1,    3, 	  -1,   -5
+.2byte   -1,  -18, 	 -12,   -9, 	  12,   -9, 	   0,   -9
+.2byte    0,  -17, 	  11,  -10, 	 -10,   -3, 	  -1,   -9
+.2byte    2,  -23, 	  -9,  -10, 	  -6,   -4, 	  -2,  -10
+.2byte    2,  -22, 	  -8,  -11, 	   9,   -5, 	  -3,  -12
+.2byte    0,  -19, 	  10,  -10, 	 -11,   -9, 	   0,   -9
+.2byte   -3,  -22, 	   7,  -11, 	 -10,   -5, 	   2,  -12
+.2byte   -3,  -23, 	   8,  -10, 	   5,   -4, 	   1,  -10
+.2byte   -1,  -17, 	 -12,  -10, 	   9,   -3, 	   0,   -9
+.2byte   -1,  -13, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -15, 	 -14,  -20, 	  13,  -20, 	   0,  -10
+.2byte   -1,   -9, 	 -12,   -5, 	  12,   -5, 	   0,   -7
+.2byte    4,  -14, 	  10,   -5, 	  -2,    1, 	  -1,  -10
+.2byte    3,  -16, 	  11,  -22, 	  -6,  -19, 	  -1,  -11
+.2byte    7,  -11, 	   0,  -11, 	 -11,   -5, 	  -1,   -8
+.2byte    9,  -18, 	   8,  -10, 	   8,   -3, 	  -2,  -10
+.2byte    6,  -20, 	   9,  -26, 	   8,  -15, 	  -1,  -11
+.2byte   12,  -16, 	  -1,  -11, 	  -3,   -3, 	   0,  -13
+.2byte    5,  -20, 	  -4,  -13, 	  10,   -6, 	  -2,  -11
+.2byte    2,  -22, 	  -5,  -27, 	  14,  -20, 	  -2,  -12
+.2byte    8,  -20, 	  -6,  -12, 	   7,   -3, 	  -1,  -13
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte   -1,  -22, 	  13,  -23, 	 -14,  -22, 	  -1,  -12
+.2byte    0,  -20, 	  13,   -7, 	 -14,   -7, 	  -1,  -13
+.2byte   -6,  -20, 	   3,  -13, 	 -11,   -6, 	   1,  -11
+.2byte   -3,  -22, 	   4,  -27, 	 -15,  -20, 	   1,  -12
+.2byte   -9,  -20, 	   5,  -12, 	  -8,   -3, 	   0,  -13
+.2byte  -11,  -17, 	 -10,   -9, 	 -10,   -2, 	   0,   -9
+.2byte   -8,  -19, 	 -11,  -25, 	 -10,  -14, 	  -1,  -10
+.2byte  -14,  -15, 	  -1,  -10, 	   1,   -2, 	  -2,  -12
+.2byte   -6,  -14, 	 -12,   -5, 	   0,    1, 	  -1,  -10
+.2byte   -5,  -16, 	 -13,  -22, 	   4,  -19, 	  -1,  -11
+.2byte   -9,  -11, 	  -2,  -11, 	   9,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -4, 	  12,   -4, 	   0,   -6
+.2byte   -9,   -9, 	  -2,   -9, 	   9,   -3, 	  -1,   -6
+.2byte  -14,  -15, 	  -1,  -10, 	   1,   -2, 	  -2,  -12
+.2byte   -9,  -19, 	   5,  -11, 	  -8,   -2, 	   0,  -12
+.2byte    0,  -19, 	  13,   -6, 	 -14,   -6, 	  -1,  -12
+.2byte    8,  -19, 	  -6,  -11, 	   7,   -2, 	  -1,  -12
+.2byte   12,  -15, 	  -1,  -10, 	  -3,   -2, 	   0,  -12
+.2byte    8,   -9, 	   1,   -9, 	 -10,   -3, 	   0,   -6
+.2byte    4,  -14, 	  10,   -5, 	  -2,    1, 	  -1,  -10
+.2byte    5,  -12, 	   8,   -4, 	   0,    3, 	   0,   -8
+.2byte    5,  -12, 	  11,   -3, 	  -2,    0, 	   1,   -9
+.2byte    3,  -16, 	  11,  -22, 	  -6,  -19, 	  -1,  -11
+.2byte    9,  -18, 	   8,  -10, 	   8,   -3, 	  -2,  -10
+.2byte   10,  -17, 	   9,   -8, 	  10,   -2, 	  -1,   -9
+.2byte   10,  -17, 	  10,   -8, 	   6,   -1, 	  -1,   -9
+.2byte    6,  -20, 	   9,  -26, 	   8,  -15, 	  -1,  -11
+.2byte    5,  -20, 	  -4,  -13, 	  10,   -6, 	  -2,  -11
+.2byte    6,  -19, 	  -3,  -13, 	  11,   -6, 	  -2,  -10
+.2byte    6,  -19, 	  -2,  -12, 	   8,   -5, 	   0,  -11
+.2byte    2,  -22, 	  -5,  -27, 	  14,  -20, 	  -2,  -12
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte   -1,  -19, 	   6,   -8, 	  -6,   -9, 	  -1,  -10
+.2byte    0,  -19, 	   8,   -8, 	  -5,   -7, 	   0,  -10
+.2byte   -1,  -22, 	  13,  -23, 	 -14,  -22, 	  -1,  -12
+.2byte   -6,  -20, 	   3,  -13, 	 -11,   -6, 	   1,  -11
+.2byte   -7,  -19, 	   2,  -13, 	 -12,   -6, 	   1,  -10
+.2byte   -7,  -19, 	   1,  -12, 	  -9,   -5, 	  -1,  -11
+.2byte   -3,  -22, 	   4,  -27, 	 -15,  -20, 	   1,  -12
+.2byte  -11,  -17, 	 -10,   -9, 	 -10,   -2, 	   0,   -9
+.2byte  -12,  -16, 	 -11,   -7, 	 -12,   -1, 	  -1,   -8
+.2byte  -12,  -16, 	 -12,   -7, 	  -8,    0, 	  -1,   -8
+.2byte   -8,  -19, 	 -11,  -25, 	 -10,  -14, 	  -1,  -10
+.2byte   -6,  -14, 	 -12,   -5, 	   0,    1, 	  -1,  -10
+.2byte   -7,  -12, 	 -10,   -4, 	  -2,    3, 	  -2,   -8
+.2byte   -7,  -12, 	 -13,   -3, 	   0,    0, 	  -3,   -9
+.2byte   -5,  -16, 	 -13,  -22, 	   4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	 -14,  -19, 	  13,  -19, 	   0,   -9
+.2byte    4,  -14, 	  12,  -20, 	  -5,  -17, 	   0,   -9
+.2byte    6,  -19, 	   9,  -25, 	   8,  -14, 	  -1,  -10
+.2byte    2,  -20, 	  -5,  -25, 	  14,  -18, 	  -2,  -10
+.2byte   -1,  -21, 	  13,  -22, 	 -14,  -21, 	  -1,  -11
+.2byte   -3,  -20, 	   4,  -25, 	 -15,  -18, 	   1,  -10
+.2byte   -7,  -19, 	 -10,  -25, 	  -9,  -14, 	   0,  -10
+.2byte   -5,  -14, 	 -13,  -20, 	   4,  -17, 	  -1,   -9
+.2byte   -1,  -12, 	  -9,   -1, 	   7,   -1, 	  -1,   -8
+.2byte   -1,  -14, 	 -14,  -19, 	  13,  -19, 	   0,   -9
+.2byte   -1,   -8, 	 -12,   -4, 	  12,   -4, 	   0,   -6
+.2byte    4,  -12, 	  10,   -3, 	  -2,    3, 	  -1,   -8
+.2byte    3,  -14, 	  11,  -20, 	  -6,  -17, 	  -1,   -9
+.2byte    6,   -9, 	  -1,   -9, 	 -12,   -3, 	  -2,   -6
+.2byte    9,  -17, 	   8,   -9, 	   8,   -2, 	  -2,   -9
+.2byte    6,  -19, 	   9,  -25, 	   8,  -14, 	  -1,  -10
+.2byte   11,  -15, 	  -2,  -10, 	  -4,   -2, 	  -1,  -12
+.2byte    5,  -19, 	  -4,  -12, 	  10,   -5, 	  -2,  -10
+.2byte    2,  -21, 	  -5,  -26, 	  14,  -19, 	  -2,  -11
+.2byte    7,  -19, 	  -7,  -11, 	   6,   -2, 	  -2,  -12
+.2byte   -1,  -20, 	   6,   -8, 	  -6,   -8, 	   0,  -10
+.2byte   -1,  -21, 	  13,  -22, 	 -14,  -21, 	  -1,  -11
+.2byte    0,  -19, 	  13,   -6, 	 -14,   -6, 	  -1,  -12
+.2byte   -6,  -19, 	   3,  -12, 	 -11,   -5, 	   1,  -10
+.2byte   -3,  -21, 	   4,  -26, 	 -15,  -19, 	   1,  -11
+.2byte   -8,  -19, 	   6,  -11, 	  -7,   -2, 	   1,  -12
+.2byte  -10,  -17, 	  -9,   -9, 	  -9,   -2, 	   1,   -9
+.2byte   -7,  -19, 	 -10,  -25, 	  -9,  -14, 	   0,  -10
+.2byte  -12,  -15, 	   1,  -10, 	   3,   -2, 	   0,  -12
+.2byte   -5,  -12, 	 -11,   -3, 	   1,    3, 	   0,   -8
+.2byte   -4,  -14, 	 -12,  -20, 	   5,  -17, 	   0,   -9
+.2byte   -7,   -9, 	   0,   -9, 	  11,   -3, 	   1,   -6
+.2byte   -1,  -10, 	   7,    1, 	  -7,    2, 	   0,   -7
+.2byte   -8,  -11, 	  -6,    2, 	 -12,   -1, 	   0,   -9
+.2byte  -14,  -15, 	 -12,    0, 	 -16,  -10, 	  -2,  -10
+.2byte   -8,  -19, 	 -11,   -6, 	   0,  -13, 	   1,  -11
+.2byte    0,  -20, 	   8,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte    7,  -19, 	  10,   -6, 	  -1,  -13, 	  -2,  -11
+.2byte   13,  -15, 	  11,    0, 	  15,  -10, 	   1,  -10
+.2byte    7,  -11, 	   5,    2, 	  11,   -1, 	  -1,   -9
+.2byte   -1,  -13, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -5,  -13, 	 -11,   -4, 	   1,    2, 	   0,   -9
+.2byte  -10,  -17, 	  -9,   -9, 	  -9,   -2, 	   1,   -9
+.2byte   -5,  -20, 	   4,  -13, 	 -10,   -6, 	   2,  -11
+.2byte   -1,  -21, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte    4,  -20, 	  -5,  -13, 	   9,   -6, 	  -3,  -11
+.2byte   10,  -18, 	   9,  -10, 	   9,   -3, 	  -1,  -10
+.2byte    5,  -13, 	  11,   -4, 	  -1,    2, 	   0,   -9
+sArmaldoAnimTable1:
+.4byte sArmaldoAnims_1_1
+.4byte sArmaldoAnims_1_2
+.4byte sArmaldoAnims_1_3
+.4byte sArmaldoAnims_1_4
+.4byte sArmaldoAnims_1_5
+.4byte sArmaldoAnims_1_6
+.4byte sArmaldoAnims_1_7
+.4byte sArmaldoAnims_1_8
+sArmaldoAnimTable2:
+.4byte sArmaldoAnims_2_1
+.4byte sArmaldoAnims_2_2
+.4byte sArmaldoAnims_2_3
+.4byte sArmaldoAnims_2_4
+.4byte sArmaldoAnims_2_5
+.4byte sArmaldoAnims_2_6
+.4byte sArmaldoAnims_2_7
+.4byte sArmaldoAnims_2_8
+sArmaldoAnimTable3:
+.4byte sArmaldoAnims_3_1
+.4byte sArmaldoAnims_3_2
+.4byte sArmaldoAnims_3_3
+.4byte sArmaldoAnims_3_4
+.4byte sArmaldoAnims_3_5
+.4byte sArmaldoAnims_3_6
+.4byte sArmaldoAnims_3_7
+.4byte sArmaldoAnims_3_8
+sArmaldoAnimTable4:
+.4byte sArmaldoAnims_4_1
+.4byte sArmaldoAnims_4_2
+.4byte sArmaldoAnims_4_3
+.4byte sArmaldoAnims_4_4
+.4byte sArmaldoAnims_4_5
+.4byte sArmaldoAnims_4_6
+.4byte sArmaldoAnims_4_7
+.4byte sArmaldoAnims_4_8
+sArmaldoAnimTable5:
+.4byte sArmaldoAnims_5_1
+.4byte sArmaldoAnims_5_2
+.4byte sArmaldoAnims_5_3
+.4byte sArmaldoAnims_5_4
+.4byte sArmaldoAnims_5_5
+.4byte sArmaldoAnims_5_6
+.4byte sArmaldoAnims_5_7
+.4byte sArmaldoAnims_5_8
+sArmaldoAnimTable6:
+.4byte sArmaldoAnims_6_1
+.4byte sArmaldoAnims_6_1
+.4byte sArmaldoAnims_6_1
+.4byte sArmaldoAnims_6_1
+.4byte sArmaldoAnims_6_1
+.4byte sArmaldoAnims_6_1
+.4byte sArmaldoAnims_6_1
+.4byte sArmaldoAnims_6_1
+sArmaldoAnimTable7:
+.4byte sArmaldoAnims_7_1
+.4byte sArmaldoAnims_7_2
+.4byte sArmaldoAnims_7_3
+.4byte sArmaldoAnims_7_4
+.4byte sArmaldoAnims_7_5
+.4byte sArmaldoAnims_7_6
+.4byte sArmaldoAnims_7_7
+.4byte sArmaldoAnims_7_8
+sArmaldoAnimTable8:
+.4byte sArmaldoAnims_8_1
+.4byte sArmaldoAnims_8_2
+.4byte sArmaldoAnims_8_3
+.4byte sArmaldoAnims_8_4
+.4byte sArmaldoAnims_8_5
+.4byte sArmaldoAnims_8_6
+.4byte sArmaldoAnims_8_7
+.4byte sArmaldoAnims_8_8
+sArmaldoAnimTable9:
+.4byte sArmaldoAnims_9_1
+.4byte sArmaldoAnims_9_2
+.4byte sArmaldoAnims_9_3
+.4byte sArmaldoAnims_9_4
+.4byte sArmaldoAnims_9_5
+.4byte sArmaldoAnims_9_6
+.4byte sArmaldoAnims_9_7
+.4byte sArmaldoAnims_9_8
+sArmaldoAnimTable10:
+.4byte sArmaldoAnims_10_1
+.4byte sArmaldoAnims_10_2
+.4byte sArmaldoAnims_10_3
+.4byte sArmaldoAnims_10_4
+.4byte sArmaldoAnims_10_5
+.4byte sArmaldoAnims_10_6
+.4byte sArmaldoAnims_10_7
+.4byte sArmaldoAnims_10_8
+sArmaldoAnimTable11:
+.4byte sArmaldoAnims_11_1
+.4byte sArmaldoAnims_11_2
+.4byte sArmaldoAnims_11_3
+.4byte sArmaldoAnims_11_4
+.4byte sArmaldoAnims_11_5
+.4byte sArmaldoAnims_11_6
+.4byte sArmaldoAnims_11_7
+.4byte sArmaldoAnims_11_8
+sArmaldoAnimTable12:
+.4byte sArmaldoAnims_12_1
+.4byte sArmaldoAnims_12_2
+.4byte sArmaldoAnims_12_3
+.4byte sArmaldoAnims_12_4
+.4byte sArmaldoAnims_12_5
+.4byte sArmaldoAnims_12_6
+.4byte sArmaldoAnims_12_7
+.4byte sArmaldoAnims_12_8
+sArmaldoAnimTable13:
+.4byte sArmaldoAnims_13_1
+.4byte sArmaldoAnims_13_2
+.4byte sArmaldoAnims_13_3
+.4byte sArmaldoAnims_13_4
+.4byte sArmaldoAnims_13_5
+.4byte sArmaldoAnims_13_6
+.4byte sArmaldoAnims_13_7
+.4byte sArmaldoAnims_13_8
+sAxAnimationsArmaldo:
+.4byte sArmaldoAnimTable1
+.4byte sArmaldoAnimTable2
+.4byte sArmaldoAnimTable3
+.4byte sArmaldoAnimTable4
+.4byte sArmaldoAnimTable5
+.4byte sArmaldoAnimTable6
+.4byte sArmaldoAnimTable7
+.4byte sArmaldoAnimTable8
+.4byte sArmaldoAnimTable9
+.4byte sArmaldoAnimTable10
+.4byte sArmaldoAnimTable11
+.4byte sArmaldoAnimTable12
+.4byte sArmaldoAnimTable13
+sAxSpritesArmaldo:
+.4byte sArmaldoSprites1
+.4byte sArmaldoSprites2
+.4byte sArmaldoSprites3
+.4byte sArmaldoSprites4
+.4byte sArmaldoSprites5
+.4byte sArmaldoSprites6
+.4byte sArmaldoSprites7
+.4byte sArmaldoSprites8
+.4byte sArmaldoSprites9
+.4byte sArmaldoSprites10
+.4byte sArmaldoSprites11
+.4byte sArmaldoSprites12
+.4byte sArmaldoSprites13
+.4byte sArmaldoSprites14
+.4byte sArmaldoSprites15
+.4byte sArmaldoSprites16
+.4byte sArmaldoSprites17
+.4byte sArmaldoSprites18
+.4byte sArmaldoSprites19
+.4byte sArmaldoSprites20
+.4byte sArmaldoSprites21
+.4byte sArmaldoSprites22
+.4byte sArmaldoSprites23
+.4byte sArmaldoSprites24
+.4byte sArmaldoSprites25
+.4byte sArmaldoSprites26
+.4byte sArmaldoSprites27
+.4byte sArmaldoSprites28
+.4byte sArmaldoSprites29
+.4byte sArmaldoSprites30
+.4byte sArmaldoSprites31
+.4byte sArmaldoSprites32
+.4byte sArmaldoSprites33
+.4byte sArmaldoSprites34
+.4byte sArmaldoSprites35
+.4byte sArmaldoSprites36
+.4byte sArmaldoSprites37
+.4byte sArmaldoSprites38
+.4byte sArmaldoSprites39
+.4byte sArmaldoSprites40
+.4byte sArmaldoSprites41
+.4byte sArmaldoSprites42
+.4byte sArmaldoSprites43
+.4byte sArmaldoSprites44
+.4byte sArmaldoSprites45
+.4byte sArmaldoSprites46
+.4byte sArmaldoSprites47
+.4byte sArmaldoSprites48
+.4byte sArmaldoSprites49
+.4byte sArmaldoSprites50
+.4byte sArmaldoSprites51
+.4byte sArmaldoSprites52
+.4byte sArmaldoSprites53
+.4byte sArmaldoSprites54
+.4byte sArmaldoSprites55
+.4byte sArmaldoSprites56
+.4byte sArmaldoSprites57
+.4byte sArmaldoSprites58
+.4byte sArmaldoSprites59
+.4byte sArmaldoSprites60
+.4byte sArmaldoSprites61
+.4byte sArmaldoSprites62
+.4byte sArmaldoSprites63
+.4byte sArmaldoSprites64
+.4byte sArmaldoSprites65
+.4byte sArmaldoSprites66
+.4byte sArmaldoSprites67
+.4byte sArmaldoSprites68
+.4byte sArmaldoSprites69
+.4byte sArmaldoSprites70
+.4byte sArmaldoSprites71
+sAxMainArmaldo:
+ax_main sAxPosesArmaldo, sAxAnimationsArmaldo, 13, sAxSpritesArmaldo, sAxPositionsArmaldo

--- a/data/ax/aron.inc
+++ b/data/ax/aron.inc
@@ -1,0 +1,2829 @@
+.global gAxAron
+gAxAron:
+ax_siro sAxMainAron
+sAronPose1:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose2:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose3:
+ax_pose 2, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose4:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose5:
+ax_pose 4, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose6:
+ax_pose 5, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose7:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose8:
+ax_pose 7, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose9:
+ax_pose 8, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose10:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose11:
+ax_pose 10, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose12:
+ax_pose 11, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose13:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose14:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose15:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose16:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose17:
+ax_pose 10, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose18:
+ax_pose 11, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose19:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose20:
+ax_pose 7, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose21:
+ax_pose 8, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose22:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose23:
+ax_pose 4, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose24:
+ax_pose 5, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose25:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose26:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose27:
+ax_pose 2, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose28:
+ax_pose 15, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose29:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose30:
+ax_pose 4, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose31:
+ax_pose 5, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose32:
+ax_pose 16, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose33:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose34:
+ax_pose 7, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose35:
+ax_pose 8, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose36:
+ax_pose 17, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose37:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose38:
+ax_pose 10, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose39:
+ax_pose 11, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose40:
+ax_pose 18, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose41:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose42:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose43:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose44:
+ax_pose 19, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose45:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose46:
+ax_pose 10, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose47:
+ax_pose 11, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose48:
+ax_pose 18, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose49:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose50:
+ax_pose 7, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose51:
+ax_pose 8, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose52:
+ax_pose 17, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose53:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose54:
+ax_pose 4, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose55:
+ax_pose 5, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose56:
+ax_pose 16, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose57:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose58:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose59:
+ax_pose 2, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose60:
+ax_pose 15, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose61:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose62:
+ax_pose 4, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose63:
+ax_pose 5, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose64:
+ax_pose 16, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose65:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose66:
+ax_pose 7, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose67:
+ax_pose 8, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose68:
+ax_pose 17, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose69:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose70:
+ax_pose 10, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose71:
+ax_pose 11, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose72:
+ax_pose 18, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose73:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose74:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose75:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose76:
+ax_pose 19, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose77:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose78:
+ax_pose 10, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose79:
+ax_pose 11, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose80:
+ax_pose 18, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose81:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose82:
+ax_pose 7, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose83:
+ax_pose 8, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose84:
+ax_pose 17, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose85:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose86:
+ax_pose 4, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose87:
+ax_pose 5, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose88:
+ax_pose 16, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose89:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose90:
+ax_pose 15, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose91:
+ax_pose 20, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose92:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose93:
+ax_pose 16, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose94:
+ax_pose 21, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose95:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose96:
+ax_pose 17, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose97:
+ax_pose 22, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose98:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose99:
+ax_pose 18, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose100:
+ax_pose 23, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose101:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose102:
+ax_pose 19, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose103:
+ax_pose 24, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose104:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose105:
+ax_pose 18, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose106:
+ax_pose 23, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose107:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose108:
+ax_pose 17, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose109:
+ax_pose 22, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose110:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose111:
+ax_pose 16, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose112:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose113:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose114:
+ax_pose 25, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose115:
+ax_pose 26, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose116:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose117:
+ax_pose 27, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose118:
+ax_pose 28, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose119:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose120:
+ax_pose 29, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose121:
+ax_pose 30, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose122:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose123:
+ax_pose 31, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose124:
+ax_pose 32, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose125:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose126:
+ax_pose 33, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose127:
+ax_pose 34, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose128:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose129:
+ax_pose 31, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose130:
+ax_pose 32, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose131:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose132:
+ax_pose 29, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose133:
+ax_pose 30, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose134:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose135:
+ax_pose 27, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose136:
+ax_pose 28, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose137:
+ax_pose 35, 0x01f0, 0x80f4, 0x5c00
+ax_pose_terminator
+sAronPose138:
+ax_pose 36, 0x01f0, 0x80f4, 0x5c00
+ax_pose_terminator
+sAronPose139:
+ax_pose 37, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAronPose140:
+ax_pose 38, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose141:
+ax_pose 39, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sAronPose142:
+ax_pose 40, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sAronPose143:
+ax_pose 41, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose144:
+ax_pose 40, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sAronPose145:
+ax_pose 39, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sAronPose146:
+ax_pose 38, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose147:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose148:
+ax_pose 15, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose149:
+ax_pose 20, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose150:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose151:
+ax_pose 16, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose152:
+ax_pose 21, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose153:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose154:
+ax_pose 17, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose155:
+ax_pose 22, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose156:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose157:
+ax_pose 18, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose158:
+ax_pose 23, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose159:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose160:
+ax_pose 19, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose161:
+ax_pose 24, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose162:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose163:
+ax_pose 18, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose164:
+ax_pose 23, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose165:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose166:
+ax_pose 17, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose167:
+ax_pose 22, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose168:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose169:
+ax_pose 16, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose170:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose171:
+ax_pose 20, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose172:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose173:
+ax_pose 22, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose174:
+ax_pose 23, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose175:
+ax_pose 24, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose176:
+ax_pose 23, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose177:
+ax_pose 22, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose178:
+ax_pose 21, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose179:
+ax_pose 20, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose180:
+ax_pose 21, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sAronPose181:
+ax_pose 22, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sAronPose182:
+ax_pose 23, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sAronPose183:
+ax_pose 24, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose184:
+ax_pose 23, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sAronPose185:
+ax_pose 22, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sAronPose186:
+ax_pose 21, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sAronPose187:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose188:
+ax_pose 20, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose189:
+ax_pose 15, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose190:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose191:
+ax_pose 21, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sAronPose192:
+ax_pose 16, 0x01ef, 0x90f1, 0x5c00
+ax_pose_terminator
+sAronPose193:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose194:
+ax_pose 22, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sAronPose195:
+ax_pose 17, 0x01ee, 0x90f1, 0x5c00
+ax_pose_terminator
+sAronPose196:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose197:
+ax_pose 23, 0x01ef, 0x90ef, 0x5c00
+ax_pose_terminator
+sAronPose198:
+ax_pose 18, 0x01ee, 0x90f1, 0x5c00
+ax_pose_terminator
+sAronPose199:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose200:
+ax_pose 24, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose201:
+ax_pose 19, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose202:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose203:
+ax_pose 23, 0x01ef, 0x80f1, 0x5c00
+ax_pose_terminator
+sAronPose204:
+ax_pose 18, 0x01ee, 0x80ef, 0x5c00
+ax_pose_terminator
+sAronPose205:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose206:
+ax_pose 22, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sAronPose207:
+ax_pose 17, 0x01ee, 0x80ef, 0x5c00
+ax_pose_terminator
+sAronPose208:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose209:
+ax_pose 21, 0x01ed, 0x80f1, 0x5c00
+ax_pose_terminator
+sAronPose210:
+ax_pose 16, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sAronPose211:
+ax_pose 15, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose212:
+ax_pose 16, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose213:
+ax_pose 17, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose214:
+ax_pose 18, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose215:
+ax_pose 19, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose216:
+ax_pose 18, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose217:
+ax_pose 17, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose218:
+ax_pose 16, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose219:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose220:
+ax_pose 4, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose221:
+ax_pose 5, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose222:
+ax_pose 16, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose223:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose224:
+ax_pose 7, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose225:
+ax_pose 8, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose226:
+ax_pose 17, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose227:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose228:
+ax_pose 10, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose229:
+ax_pose 11, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose230:
+ax_pose 18, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose231:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose232:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose233:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose234:
+ax_pose 19, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose235:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose236:
+ax_pose 10, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose237:
+ax_pose 11, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose238:
+ax_pose 18, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose239:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose240:
+ax_pose 7, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose241:
+ax_pose 8, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose242:
+ax_pose 17, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose243:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose244:
+ax_pose 4, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose245:
+ax_pose 5, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose246:
+ax_pose 16, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose247:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose248:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose249:
+ax_pose 6, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose250:
+ax_pose 9, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sAronPose251:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAronPose252:
+ax_pose 9, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose253:
+ax_pose 6, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sAronPose254:
+ax_pose 3, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sAronAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sAronAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 12, 10, 12, 10,
+ax_anim 2, 0, 31, 21, 18, 21, 18,
+ax_anim 2, 1, 31, 22, 17, 22, 17,
+ax_anim 2, 0, 31, 21, 18, 21, 18,
+ax_anim 2, 0, 31, 22, 17, 22, 17,
+ax_anim 2, 0, 28, 7, 6, 7, 6,
+ax_anim_terminator
+sAronAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sAronAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 20, -23, 20, -23,
+ax_anim 2, 1, 39, 21, -22, 21, -22,
+ax_anim 2, 0, 39, 20, -23, 20, -23,
+ax_anim 2, 0, 39, 21, -22, 21, -22,
+ax_anim 2, 0, 36, 5, -6, 5, -6,
+ax_anim_terminator
+sAronAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 1, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sAronAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -20, -23, -20, -23,
+ax_anim 2, 1, 47, -21, -22, -21, -22,
+ax_anim 2, 0, 47, -20, -23, -20, -23,
+ax_anim 2, 0, 47, -21, -22, -21, -22,
+ax_anim 2, 0, 44, -5, -6, -5, -6,
+ax_anim_terminator
+sAronAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sAronAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -12, 10, -12, 10,
+ax_anim 2, 0, 55, -21, 18, -21, 18,
+ax_anim 2, 1, 55, -22, 17, -22, 17,
+ax_anim 2, 0, 55, -21, 18, -21, 18,
+ax_anim 2, 0, 55, -22, 17, -22, 17,
+ax_anim 2, 0, 52, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sAronAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sAronAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 12, 10, 12, 10,
+ax_anim 2, 0, 63, 21, 18, 21, 18,
+ax_anim 2, 1, 63, 22, 17, 22, 17,
+ax_anim 2, 0, 63, 21, 18, 21, 18,
+ax_anim 2, 0, 63, 22, 17, 22, 17,
+ax_anim 2, 0, 60, 7, 6, 7, 6,
+ax_anim_terminator
+sAronAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 20, 0, 20, 0,
+ax_anim 2, 1, 67, 20, 1, 20, 1,
+ax_anim 2, 0, 67, 20, 0, 20, 0,
+ax_anim 2, 0, 67, 20, 1, 20, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sAronAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 20, -23, 20, -23,
+ax_anim 2, 1, 71, 21, -22, 21, -22,
+ax_anim 2, 0, 71, 20, -23, 20, -23,
+ax_anim 2, 0, 71, 21, -22, 21, -22,
+ax_anim 2, 0, 68, 5, -6, 5, -6,
+ax_anim_terminator
+sAronAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -24, 0, -24,
+ax_anim 2, 1, 75, 1, -24, 1, -24,
+ax_anim 2, 0, 75, 0, -24, 0, -24,
+ax_anim 2, 0, 75, 1, -24, 1, -24,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sAronAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -20, -23, -20, -23,
+ax_anim 2, 1, 79, -21, -22, -21, -22,
+ax_anim 2, 0, 79, -20, -23, -20, -23,
+ax_anim 2, 0, 79, -21, -22, -21, -22,
+ax_anim 2, 0, 76, -5, -6, -5, -6,
+ax_anim_terminator
+sAronAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 1, 83, -20, 1, -20, 1,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 0, 83, -20, 1, -20, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sAronAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -12, 10, -12, 10,
+ax_anim 2, 0, 87, -21, 18, -21, 18,
+ax_anim 2, 1, 87, -22, 17, -22, 17,
+ax_anim 2, 0, 87, -21, 18, -21, 18,
+ax_anim 2, 0, 87, -22, 17, -22, 17,
+ax_anim 2, 0, 84, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sAronAnims_4_1:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 6, 2, 90, 0, -2, 0, -2,
+ax_anim 1, 0, 90, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, 1, 0, 1,
+ax_anim 2, 1, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, -1, 3, -1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, -1, 3, -1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, -1, 3, -1, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sAronAnims_4_2:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 6, 2, 93, -2, -2, -2, -2,
+ax_anim 1, 0, 93, -3, -3, -3, -3,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 4, 2, 4, 2,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 4, 2, 4, 2,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 4, 2, 4, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sAronAnims_4_3:
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 6, 2, 96, -2, 0, -2, 0,
+ax_anim 1, 0, 96, -3, 0, -3, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 1, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 94, 1, -1, 1, 0,
+ax_anim_terminator
+sAronAnims_4_4:
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 6, 2, 99, -2, 2, -2, 2,
+ax_anim 1, 0, 99, -3, 3, -3, 3,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 1, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, 4, -2, 4, -2,
+ax_anim 2, 0, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, 4, -2, 4, -2,
+ax_anim 2, 0, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, 4, -2, 4, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sAronAnims_4_5:
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim 6, 2, 102, 0, 2, 0, 2,
+ax_anim 1, 0, 102, 0, 3, 0, 3,
+ax_anim 1, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 1, 101, 0, -4, 0, -4,
+ax_anim 2, 0, 101, -1, -4, -1, -4,
+ax_anim 2, 0, 101, 0, -4, 0, -4,
+ax_anim 2, 0, 101, -1, -4, -1, -4,
+ax_anim 2, 0, 101, 0, -4, 0, -4,
+ax_anim 2, 0, 101, -1, -4, -1, -4,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sAronAnims_4_6:
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 6, 2, 105, 2, 2, 2, 2,
+ax_anim 1, 0, 105, 3, 3, 3, 3,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 1, 104, -3, -3, -3, -3,
+ax_anim 2, 0, 104, -4, -2, -4, -2,
+ax_anim 2, 0, 104, -3, -3, -3, -3,
+ax_anim 2, 0, 104, -4, -2, -4, -2,
+ax_anim 2, 0, 104, -3, -3, -3, -3,
+ax_anim 2, 0, 104, -4, -2, -4, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sAronAnims_4_7:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 6, 2, 108, 2, 0, 2, 0,
+ax_anim 1, 0, 108, 3, 0, 3, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 106, -1, -1, -1, 0,
+ax_anim_terminator
+sAronAnims_4_8:
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 6, 2, 111, 2, -2, 2, -2,
+ax_anim 1, 0, 111, 3, -3, 3, -3,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 110, -4, 2, -4, 2,
+ax_anim 2, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 110, -4, 2, -4, 2,
+ax_anim 2, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 110, -4, 2, -4, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sAronAnims_5_1:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 1, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_5_2:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 1, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_5_3:
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 1, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_5_4:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 1, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_5_5:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 1, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_5_6:
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 1, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_5_7:
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 1, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_5_8:
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 1, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sAronAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sAronAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sAronAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sAronAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sAronAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sAronAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sAronAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sAronAnims_8_1:
+ax_anim 34, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_8_2:
+ax_anim 34, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_8_3:
+ax_anim 34, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_8_4:
+ax_anim 34, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_8_5:
+ax_anim 34, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_8_6:
+ax_anim 34, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_8_7:
+ax_anim 34, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_8_8:
+ax_anim 34, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 10, 8, 10,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 10, -8, 10,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 24, 12, 24, 12,
+ax_anim 3, 0, 173, 23, 18, 23, 18,
+ax_anim 2, 3, 174, 11, 18, 11, 18,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 4, -5, 4, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 20, -5, 20, -5,
+ax_anim 3, 0, 172, 23, -1, 23, -1,
+ax_anim 2, 3, 173, 20, 4, 20, 4,
+ax_anim 2, 0, 174, 10, 6, 10, 6,
+ax_anim 1, 0, 175, 3, 4, 3, 4,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 1, -7, 1, -7,
+ax_anim 2, 0, 177, 6, -16, 6, -16,
+ax_anim 2, 0, 170, 15, -22, 15, -22,
+ax_anim 3, 0, 171, 23, -24, 23, -24,
+ax_anim 2, 3, 172, 24, -14, 24, -14,
+ax_anim 2, 0, 173, 20, -3, 20, -3,
+ax_anim 1, 0, 174, 10, 1, 10, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -20, -7, -20,
+ax_anim 3, 0, 170, 0, -23, 0, -23,
+ax_anim 2, 3, 171, 7, -20, 7, -20,
+ax_anim 2, 0, 172, 9, -12, 9, -12,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -7, 1, -7,
+ax_anim 2, 0, 171, -6, -16, -6, -16,
+ax_anim 2, 0, 170, -15, -22, -15, -22,
+ax_anim 3, 0, 177, -23, -24, -23, -24,
+ax_anim 2, 3, 176, -24, -14, -24, -14,
+ax_anim 2, 0, 175, -20, -3, -20, -3,
+ax_anim 1, 0, 174, -10, -1, -10, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -4, -5, -4, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -20, -5, -20, -5,
+ax_anim 3, 0, 176, -23, -1, -23, -1,
+ax_anim 2, 3, 175, -20, 4, -20, 4,
+ax_anim 2, 0, 174, -10, 6, -10, 6,
+ax_anim 1, 0, 173, -3, 4, -3, 4,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -24, 12, -24, 12,
+ax_anim 3, 0, 175, -23, 18, -23, 18,
+ax_anim 2, 3, 174, -11, 18, -11, 18,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAronAnims_13_1:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_13_2:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_13_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_13_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_13_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_13_6:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_13_7:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sAronAnims_13_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sAronGfx1:
+.incbin "baserom.gba", 0x126000C, 0x100
+sAronSprites1:
+ax_sprite sAronGfx1, 0x100
+ax_sprite_terminator
+sAronGfx2:
+.incbin "baserom.gba", 0x126011C, 0x100
+sAronSprites2:
+ax_sprite sAronGfx2, 0x100
+ax_sprite_terminator
+sAronGfx3:
+.incbin "baserom.gba", 0x126022C, 0x100
+sAronSprites3:
+ax_sprite sAronGfx3, 0x100
+ax_sprite_terminator
+sAronGfx4:
+.incbin "baserom.gba", 0x126033C, 0x200
+sAronSprites4:
+ax_sprite sAronGfx4, 0x200
+ax_sprite_terminator
+sAronGfx5:
+.incbin "baserom.gba", 0x126054C, 0x200
+sAronSprites5:
+ax_sprite sAronGfx5, 0x200
+ax_sprite_terminator
+sAronGfx6:
+.incbin "baserom.gba", 0x126075C, 0x200
+sAronSprites6:
+ax_sprite sAronGfx6, 0x200
+ax_sprite_terminator
+sAronGfx7:
+.incbin "baserom.gba", 0x126096C, 0x200
+sAronSprites7:
+ax_sprite sAronGfx7, 0x200
+ax_sprite_terminator
+sAronGfx8:
+.incbin "baserom.gba", 0x1260B7C, 0x200
+sAronSprites8:
+ax_sprite sAronGfx8, 0x200
+ax_sprite_terminator
+sAronGfx9:
+.incbin "baserom.gba", 0x1260D8C, 0x200
+sAronSprites9:
+ax_sprite sAronGfx9, 0x200
+ax_sprite_terminator
+sAronGfx10:
+.incbin "baserom.gba", 0x1260F9C, 0x200
+sAronSprites10:
+ax_sprite sAronGfx10, 0x200
+ax_sprite_terminator
+sAronGfx11:
+.incbin "baserom.gba", 0x12611AC, 0x200
+sAronSprites11:
+ax_sprite sAronGfx11, 0x200
+ax_sprite_terminator
+sAronGfx12:
+.incbin "baserom.gba", 0x12613BC, 0x200
+sAronSprites12:
+ax_sprite sAronGfx12, 0x200
+ax_sprite_terminator
+sAronGfx13:
+.incbin "baserom.gba", 0x12615CC, 0x100
+sAronSprites13:
+ax_sprite sAronGfx13, 0x100
+ax_sprite_terminator
+sAronGfx14:
+.incbin "baserom.gba", 0x12616DC, 0x100
+sAronSprites14:
+ax_sprite sAronGfx14, 0x100
+ax_sprite_terminator
+sAronGfx15:
+.incbin "baserom.gba", 0x12617EC, 0x100
+sAronSprites15:
+ax_sprite sAronGfx15, 0x100
+ax_sprite_terminator
+sAronGfx16:
+.incbin "baserom.gba", 0x12618FC, 0xC0
+sAronSprites16:
+ax_sprite sAronGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx17:
+.incbin "baserom.gba", 0x12619D4, 0x40
+sAronGfx17_1:
+.incbin "baserom.gba", 0x1261A14, 0x40
+sAronGfx17_2:
+.incbin "baserom.gba", 0x1261A54, 0x40
+sAronSprites17:
+ax_sprite 0, 0x20
+ax_sprite sAronGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAronGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAronGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx18:
+.incbin "baserom.gba", 0x1261AD4, 0x60
+sAronGfx18_1:
+.incbin "baserom.gba", 0x1261B34, 0x60
+sAronGfx18_2:
+.incbin "baserom.gba", 0x1261B94, 0x60
+sAronSprites18:
+ax_sprite sAronGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx19:
+.incbin "baserom.gba", 0x1261C2C, 0x40
+sAronGfx19_1:
+.incbin "baserom.gba", 0x1261C6C, 0x60
+sAronGfx19_2:
+.incbin "baserom.gba", 0x1261CCC, 0x40
+sAronSprites19:
+ax_sprite 0, 0x20
+ax_sprite sAronGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAronGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAronGfx19_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx20:
+.incbin "baserom.gba", 0x1261D4C, 0xC0
+sAronSprites20:
+ax_sprite sAronGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx21:
+.incbin "baserom.gba", 0x1261E24, 0xC0
+sAronSprites21:
+ax_sprite sAronGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx22:
+.incbin "baserom.gba", 0x1261EFC, 0x60
+sAronGfx22_1:
+.incbin "baserom.gba", 0x1261F5C, 0x60
+sAronGfx22_2:
+.incbin "baserom.gba", 0x1261FBC, 0x40
+sAronSprites22:
+ax_sprite sAronGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAronGfx22_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx23:
+.incbin "baserom.gba", 0x1262034, 0x60
+sAronGfx23_1:
+.incbin "baserom.gba", 0x1262094, 0x60
+sAronGfx23_2:
+.incbin "baserom.gba", 0x12620F4, 0x40
+sAronSprites23:
+ax_sprite sAronGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAronGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx24:
+.incbin "baserom.gba", 0x126216C, 0x60
+sAronGfx24_1:
+.incbin "baserom.gba", 0x12621CC, 0x60
+sAronGfx24_2:
+.incbin "baserom.gba", 0x126222C, 0x40
+sAronSprites24:
+ax_sprite sAronGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAronGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx25:
+.incbin "baserom.gba", 0x12622A4, 0xC0
+sAronSprites25:
+ax_sprite sAronGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx26:
+.incbin "baserom.gba", 0x126237C, 0xC0
+sAronSprites26:
+ax_sprite sAronGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx27:
+.incbin "baserom.gba", 0x1262454, 0xC0
+sAronSprites27:
+ax_sprite sAronGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx28:
+.incbin "baserom.gba", 0x126252C, 0x60
+sAronGfx28_1:
+.incbin "baserom.gba", 0x126258C, 0x60
+sAronGfx28_2:
+.incbin "baserom.gba", 0x12625EC, 0x60
+sAronSprites28:
+ax_sprite sAronGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx29:
+.incbin "baserom.gba", 0x1262684, 0x40
+sAronGfx29_1:
+.incbin "baserom.gba", 0x12626C4, 0x40
+sAronGfx29_2:
+.incbin "baserom.gba", 0x1262704, 0x40
+sAronSprites29:
+ax_sprite 0, 0x20
+ax_sprite sAronGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAronGfx29_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAronGfx29_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx30:
+.incbin "baserom.gba", 0x1262784, 0x60
+sAronGfx30_1:
+.incbin "baserom.gba", 0x12627E4, 0x60
+sAronGfx30_2:
+.incbin "baserom.gba", 0x1262844, 0x60
+sAronSprites30:
+ax_sprite sAronGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx31:
+.incbin "baserom.gba", 0x12628DC, 0x60
+sAronGfx31_1:
+.incbin "baserom.gba", 0x126293C, 0x60
+sAronGfx31_2:
+.incbin "baserom.gba", 0x126299C, 0x60
+sAronSprites31:
+ax_sprite sAronGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx32:
+.incbin "baserom.gba", 0x1262A34, 0x60
+sAronGfx32_1:
+.incbin "baserom.gba", 0x1262A94, 0x60
+sAronGfx32_2:
+.incbin "baserom.gba", 0x1262AF4, 0x40
+sAronSprites32:
+ax_sprite sAronGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx32_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAronGfx32_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx33:
+.incbin "baserom.gba", 0x1262B6C, 0x60
+sAronGfx33_1:
+.incbin "baserom.gba", 0x1262BCC, 0x60
+sAronGfx33_2:
+.incbin "baserom.gba", 0x1262C2C, 0x60
+sAronSprites33:
+ax_sprite sAronGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAronGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAronGfx34:
+.incbin "baserom.gba", 0x1262CC4, 0xC0
+sAronSprites34:
+ax_sprite sAronGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx35:
+.incbin "baserom.gba", 0x1262D9C, 0xC0
+sAronSprites35:
+ax_sprite sAronGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAronGfx36:
+.incbin "baserom.gba", 0x1262E74, 0x200
+sAronSprites36:
+ax_sprite sAronGfx36, 0x200
+ax_sprite_terminator
+sAronGfx37:
+.incbin "baserom.gba", 0x1263084, 0x200
+sAronSprites37:
+ax_sprite sAronGfx37, 0x200
+ax_sprite_terminator
+sAronGfx38:
+.incbin "baserom.gba", 0x1263294, 0x200
+sAronSprites38:
+ax_sprite sAronGfx38, 0x200
+ax_sprite_terminator
+sAronGfx39:
+.incbin "baserom.gba", 0x12634A4, 0x200
+sAronSprites39:
+ax_sprite sAronGfx39, 0x200
+ax_sprite_terminator
+sAronGfx40:
+.incbin "baserom.gba", 0x12636B4, 0x200
+sAronSprites40:
+ax_sprite sAronGfx40, 0x200
+ax_sprite_terminator
+sAronGfx41:
+.incbin "baserom.gba", 0x12638C4, 0x200
+sAronSprites41:
+ax_sprite sAronGfx41, 0x200
+ax_sprite_terminator
+sAronGfx42:
+.incbin "baserom.gba", 0x1263AD4, 0x200
+sAronSprites42:
+ax_sprite sAronGfx42, 0x200
+ax_sprite_terminator
+sAxPosesAron:
+.4byte sAronPose1
+.4byte sAronPose2
+.4byte sAronPose3
+.4byte sAronPose4
+.4byte sAronPose5
+.4byte sAronPose6
+.4byte sAronPose7
+.4byte sAronPose8
+.4byte sAronPose9
+.4byte sAronPose10
+.4byte sAronPose11
+.4byte sAronPose12
+.4byte sAronPose13
+.4byte sAronPose14
+.4byte sAronPose15
+.4byte sAronPose16
+.4byte sAronPose17
+.4byte sAronPose18
+.4byte sAronPose19
+.4byte sAronPose20
+.4byte sAronPose21
+.4byte sAronPose22
+.4byte sAronPose23
+.4byte sAronPose24
+.4byte sAronPose25
+.4byte sAronPose26
+.4byte sAronPose27
+.4byte sAronPose28
+.4byte sAronPose29
+.4byte sAronPose30
+.4byte sAronPose31
+.4byte sAronPose32
+.4byte sAronPose33
+.4byte sAronPose34
+.4byte sAronPose35
+.4byte sAronPose36
+.4byte sAronPose37
+.4byte sAronPose38
+.4byte sAronPose39
+.4byte sAronPose40
+.4byte sAronPose41
+.4byte sAronPose42
+.4byte sAronPose43
+.4byte sAronPose44
+.4byte sAronPose45
+.4byte sAronPose46
+.4byte sAronPose47
+.4byte sAronPose48
+.4byte sAronPose49
+.4byte sAronPose50
+.4byte sAronPose51
+.4byte sAronPose52
+.4byte sAronPose53
+.4byte sAronPose54
+.4byte sAronPose55
+.4byte sAronPose56
+.4byte sAronPose57
+.4byte sAronPose58
+.4byte sAronPose59
+.4byte sAronPose60
+.4byte sAronPose61
+.4byte sAronPose62
+.4byte sAronPose63
+.4byte sAronPose64
+.4byte sAronPose65
+.4byte sAronPose66
+.4byte sAronPose67
+.4byte sAronPose68
+.4byte sAronPose69
+.4byte sAronPose70
+.4byte sAronPose71
+.4byte sAronPose72
+.4byte sAronPose73
+.4byte sAronPose74
+.4byte sAronPose75
+.4byte sAronPose76
+.4byte sAronPose77
+.4byte sAronPose78
+.4byte sAronPose79
+.4byte sAronPose80
+.4byte sAronPose81
+.4byte sAronPose82
+.4byte sAronPose83
+.4byte sAronPose84
+.4byte sAronPose85
+.4byte sAronPose86
+.4byte sAronPose87
+.4byte sAronPose88
+.4byte sAronPose89
+.4byte sAronPose90
+.4byte sAronPose91
+.4byte sAronPose92
+.4byte sAronPose93
+.4byte sAronPose94
+.4byte sAronPose95
+.4byte sAronPose96
+.4byte sAronPose97
+.4byte sAronPose98
+.4byte sAronPose99
+.4byte sAronPose100
+.4byte sAronPose101
+.4byte sAronPose102
+.4byte sAronPose103
+.4byte sAronPose104
+.4byte sAronPose105
+.4byte sAronPose106
+.4byte sAronPose107
+.4byte sAronPose108
+.4byte sAronPose109
+.4byte sAronPose110
+.4byte sAronPose111
+.4byte sAronPose112
+.4byte sAronPose113
+.4byte sAronPose114
+.4byte sAronPose115
+.4byte sAronPose116
+.4byte sAronPose117
+.4byte sAronPose118
+.4byte sAronPose119
+.4byte sAronPose120
+.4byte sAronPose121
+.4byte sAronPose122
+.4byte sAronPose123
+.4byte sAronPose124
+.4byte sAronPose125
+.4byte sAronPose126
+.4byte sAronPose127
+.4byte sAronPose128
+.4byte sAronPose129
+.4byte sAronPose130
+.4byte sAronPose131
+.4byte sAronPose132
+.4byte sAronPose133
+.4byte sAronPose134
+.4byte sAronPose135
+.4byte sAronPose136
+.4byte sAronPose137
+.4byte sAronPose138
+.4byte sAronPose139
+.4byte sAronPose140
+.4byte sAronPose141
+.4byte sAronPose142
+.4byte sAronPose143
+.4byte sAronPose144
+.4byte sAronPose145
+.4byte sAronPose146
+.4byte sAronPose147
+.4byte sAronPose148
+.4byte sAronPose149
+.4byte sAronPose150
+.4byte sAronPose151
+.4byte sAronPose152
+.4byte sAronPose153
+.4byte sAronPose154
+.4byte sAronPose155
+.4byte sAronPose156
+.4byte sAronPose157
+.4byte sAronPose158
+.4byte sAronPose159
+.4byte sAronPose160
+.4byte sAronPose161
+.4byte sAronPose162
+.4byte sAronPose163
+.4byte sAronPose164
+.4byte sAronPose165
+.4byte sAronPose166
+.4byte sAronPose167
+.4byte sAronPose168
+.4byte sAronPose169
+.4byte sAronPose170
+.4byte sAronPose171
+.4byte sAronPose172
+.4byte sAronPose173
+.4byte sAronPose174
+.4byte sAronPose175
+.4byte sAronPose176
+.4byte sAronPose177
+.4byte sAronPose178
+.4byte sAronPose179
+.4byte sAronPose180
+.4byte sAronPose181
+.4byte sAronPose182
+.4byte sAronPose183
+.4byte sAronPose184
+.4byte sAronPose185
+.4byte sAronPose186
+.4byte sAronPose187
+.4byte sAronPose188
+.4byte sAronPose189
+.4byte sAronPose190
+.4byte sAronPose191
+.4byte sAronPose192
+.4byte sAronPose193
+.4byte sAronPose194
+.4byte sAronPose195
+.4byte sAronPose196
+.4byte sAronPose197
+.4byte sAronPose198
+.4byte sAronPose199
+.4byte sAronPose200
+.4byte sAronPose201
+.4byte sAronPose202
+.4byte sAronPose203
+.4byte sAronPose204
+.4byte sAronPose205
+.4byte sAronPose206
+.4byte sAronPose207
+.4byte sAronPose208
+.4byte sAronPose209
+.4byte sAronPose210
+.4byte sAronPose211
+.4byte sAronPose212
+.4byte sAronPose213
+.4byte sAronPose214
+.4byte sAronPose215
+.4byte sAronPose216
+.4byte sAronPose217
+.4byte sAronPose218
+.4byte sAronPose219
+.4byte sAronPose220
+.4byte sAronPose221
+.4byte sAronPose222
+.4byte sAronPose223
+.4byte sAronPose224
+.4byte sAronPose225
+.4byte sAronPose226
+.4byte sAronPose227
+.4byte sAronPose228
+.4byte sAronPose229
+.4byte sAronPose230
+.4byte sAronPose231
+.4byte sAronPose232
+.4byte sAronPose233
+.4byte sAronPose234
+.4byte sAronPose235
+.4byte sAronPose236
+.4byte sAronPose237
+.4byte sAronPose238
+.4byte sAronPose239
+.4byte sAronPose240
+.4byte sAronPose241
+.4byte sAronPose242
+.4byte sAronPose243
+.4byte sAronPose244
+.4byte sAronPose245
+.4byte sAronPose246
+.4byte sAronPose247
+.4byte sAronPose248
+.4byte sAronPose249
+.4byte sAronPose250
+.4byte sAronPose251
+.4byte sAronPose252
+.4byte sAronPose253
+.4byte sAronPose254
+sAxPositionsAron:
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte    0,   -1, 	  -5,    0, 	   4,    2, 	  -1,   -5
+.2byte   -1,   -1, 	  -4,    2, 	   4,    0, 	   0,   -6
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    4,    0, 	   5,    0, 	   0,    3, 	   0,   -5
+.2byte    6,   -1, 	   7,    2, 	  -2,    1, 	   1,   -5
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    9,   -4, 	   0,   -3, 	   4,    1, 	  -1,   -5
+.2byte    9,   -6, 	   5,   -3, 	   2,    1, 	  -1,   -5
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    5,   -4, 	  -2,   -3, 	   5,    0, 	   1,   -5
+.2byte    3,   -4, 	   0,   -5, 	   3,    1, 	   1,   -5
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -2,   -4, 	   3,   -1, 	  -5,   -3, 	  -1,   -5
+.2byte    0,   -4, 	   4,   -3, 	  -4,   -1, 	  -1,   -5
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -6,   -4, 	   1,   -3, 	  -6,    0, 	  -2,   -5
+.2byte   -4,   -4, 	  -1,   -5, 	  -4,    1, 	  -2,   -5
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -1,   -3, 	  -5,    1, 	   0,   -5
+.2byte  -10,   -6, 	  -6,   -3, 	  -3,    1, 	   0,   -5
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -5,    0, 	  -6,    0, 	  -1,    3, 	  -1,   -5
+.2byte   -7,   -1, 	  -8,    2, 	   1,    1, 	  -2,   -5
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte    0,   -1, 	  -5,    0, 	   4,    2, 	  -1,   -5
+.2byte   -1,   -1, 	  -4,    2, 	   4,    0, 	   0,   -6
+.2byte   -1,    0, 	  -5,    1, 	   4,    1, 	  -1,   -4
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    4,    0, 	   5,    0, 	   0,    3, 	   0,   -5
+.2byte    6,   -1, 	   7,    2, 	  -2,    1, 	   1,   -5
+.2byte    4,    0, 	   6,    0, 	  -2,    2, 	  -1,   -5
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    9,   -4, 	   0,   -3, 	   4,    1, 	  -1,   -5
+.2byte    9,   -6, 	   5,   -3, 	   2,    1, 	  -1,   -5
+.2byte    7,   -2, 	   3,   -5, 	   3,    0, 	  -2,   -5
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    5,   -4, 	  -2,   -3, 	   5,    0, 	   1,   -5
+.2byte    3,   -4, 	   0,   -5, 	   3,    1, 	   1,   -5
+.2byte    3,   -3, 	  -2,   -4, 	   4,   -1, 	   0,   -6
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -2,   -4, 	   3,   -1, 	  -5,   -3, 	  -1,   -5
+.2byte    0,   -4, 	   4,   -3, 	  -4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -6,   -4, 	   1,   -3, 	  -6,    0, 	  -2,   -5
+.2byte   -4,   -4, 	  -1,   -5, 	  -4,    1, 	  -2,   -5
+.2byte   -4,   -3, 	   1,   -4, 	  -5,   -1, 	  -1,   -6
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -1,   -3, 	  -5,    1, 	   0,   -5
+.2byte  -10,   -6, 	  -6,   -3, 	  -3,    1, 	   0,   -5
+.2byte   -8,   -2, 	  -4,   -5, 	  -4,    0, 	   1,   -5
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -5,    0, 	  -6,    0, 	  -1,    3, 	  -1,   -5
+.2byte   -7,   -1, 	  -8,    2, 	   1,    1, 	  -2,   -5
+.2byte   -5,    0, 	  -7,    0, 	   1,    2, 	   0,   -5
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte    0,   -1, 	  -5,    0, 	   4,    2, 	  -1,   -5
+.2byte   -1,   -1, 	  -4,    2, 	   4,    0, 	   0,   -6
+.2byte   -1,    0, 	  -5,    1, 	   4,    1, 	  -1,   -4
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    4,    0, 	   5,    0, 	   0,    3, 	   0,   -5
+.2byte    6,   -1, 	   7,    2, 	  -2,    1, 	   1,   -5
+.2byte    4,    0, 	   6,    0, 	  -2,    2, 	  -1,   -5
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    9,   -4, 	   0,   -3, 	   4,    1, 	  -1,   -5
+.2byte    9,   -6, 	   5,   -3, 	   2,    1, 	  -1,   -5
+.2byte    7,   -2, 	   3,   -5, 	   3,    0, 	  -2,   -5
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    5,   -4, 	  -2,   -3, 	   5,    0, 	   1,   -5
+.2byte    3,   -4, 	   0,   -5, 	   3,    1, 	   1,   -5
+.2byte    3,   -3, 	  -2,   -4, 	   4,   -1, 	   0,   -6
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -2,   -4, 	   3,   -1, 	  -5,   -3, 	  -1,   -5
+.2byte    0,   -4, 	   4,   -3, 	  -4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -6,   -4, 	   1,   -3, 	  -6,    0, 	  -2,   -5
+.2byte   -4,   -4, 	  -1,   -5, 	  -4,    1, 	  -2,   -5
+.2byte   -4,   -3, 	   1,   -4, 	  -5,   -1, 	  -1,   -6
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -1,   -3, 	  -5,    1, 	   0,   -5
+.2byte  -10,   -6, 	  -6,   -3, 	  -3,    1, 	   0,   -5
+.2byte   -8,   -2, 	  -4,   -5, 	  -4,    0, 	   1,   -5
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -5,    0, 	  -6,    0, 	  -1,    3, 	  -1,   -5
+.2byte   -7,   -1, 	  -8,    2, 	   1,    1, 	  -2,   -5
+.2byte   -5,    0, 	  -7,    0, 	   1,    2, 	   0,   -5
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,    0, 	  -5,    1, 	   4,    1, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    4,    0, 	   6,    0, 	  -2,    2, 	  -1,   -5
+.2byte    3,   -3, 	   6,    0, 	  -2,    2, 	   0,   -5
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    7,   -2, 	   3,   -5, 	   3,    0, 	  -2,   -5
+.2byte   10,   -6, 	   2,   -3, 	   2,    0, 	   1,   -6
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    3,   -3, 	  -2,   -4, 	   4,   -1, 	   0,   -6
+.2byte    7,  -12, 	  -2,   -3, 	   3,   -1, 	   2,   -7
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -1,  -12, 	   3,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -4,   -3, 	   1,   -4, 	  -5,   -1, 	  -1,   -6
+.2byte   -8,  -12, 	   1,   -3, 	  -4,   -1, 	  -3,   -7
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -8,   -2, 	  -4,   -5, 	  -4,    0, 	   1,   -5
+.2byte  -11,   -6, 	  -3,   -3, 	  -3,    0, 	  -2,   -6
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -5,    0, 	  -7,    0, 	   1,    2, 	   0,   -5
+.2byte   -4,   -3, 	  -7,    0, 	   1,    2, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -2,   -2, 	  -5,    1, 	   4,    1, 	  -2,   -7
+.2byte    1,   -2, 	  -5,    1, 	   3,    1, 	   0,   -7
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    6,   -1, 	   6,    0, 	  -2,    2, 	  -1,   -6
+.2byte    4,    0, 	   6,    0, 	  -1,    2, 	   1,   -5
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    9,   -3, 	   3,   -3, 	   3,    0, 	   1,   -5
+.2byte    8,   -2, 	   3,   -3, 	   3,    0, 	   0,   -4
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    4,   -4, 	  -2,   -5, 	   4,   -1, 	   2,   -6
+.2byte    5,   -3, 	  -3,   -6, 	   4,   -1, 	   1,   -7
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte    1,   -5, 	   4,   -1, 	  -5,   -1, 	   0,   -6
+.2byte   -2,   -5, 	   4,   -1, 	  -5,   -2, 	  -1,   -6
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -5,   -4, 	   1,   -5, 	  -5,   -1, 	  -3,   -6
+.2byte   -6,   -3, 	   2,   -6, 	  -5,   -1, 	  -2,   -7
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte  -10,   -3, 	  -4,   -3, 	  -4,    0, 	  -2,   -5
+.2byte   -9,   -2, 	  -4,   -3, 	  -4,    0, 	  -1,   -4
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -7,   -1, 	  -7,    0, 	   1,    2, 	   0,   -6
+.2byte   -5,    0, 	  -7,    0, 	   0,    2, 	  -2,   -5
+.2byte   -5,    0, 	  -8,    1, 	  -1,    2, 	   3,   -3
+.2byte   -5,    1, 	  -8,    1, 	  -1,    2, 	   3,   -3
+.2byte    0,   -1, 	  -6,    1, 	   7,    1, 	   0,   -6
+.2byte    7,   -1, 	  10,   -1, 	   2,    1, 	   2,   -6
+.2byte    9,   -3, 	   5,   -5, 	   5,    0, 	   0,   -5
+.2byte    5,   -7, 	  -6,   -9, 	   6,   -2, 	   0,   -7
+.2byte   -1,   -7, 	   6,   -6, 	  -7,   -6, 	  -1,   -6
+.2byte   -6,   -7, 	   5,   -9, 	  -7,   -2, 	  -1,   -7
+.2byte  -10,   -3, 	  -6,   -5, 	  -6,    0, 	  -1,   -5
+.2byte   -8,   -1, 	 -11,   -1, 	  -3,    1, 	  -3,   -6
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,    0, 	  -5,    1, 	   4,    1, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    4,    0, 	   6,    0, 	  -2,    2, 	  -1,   -5
+.2byte    3,   -3, 	   6,    0, 	  -2,    2, 	   0,   -5
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    7,   -2, 	   3,   -5, 	   3,    0, 	  -2,   -5
+.2byte   10,   -6, 	   2,   -3, 	   2,    0, 	   1,   -6
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    3,   -3, 	  -2,   -4, 	   4,   -1, 	   0,   -6
+.2byte    7,  -12, 	  -2,   -3, 	   3,   -1, 	   2,   -7
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -1,  -12, 	   3,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -4,   -3, 	   1,   -4, 	  -5,   -1, 	  -1,   -6
+.2byte   -8,  -12, 	   1,   -3, 	  -4,   -1, 	  -3,   -7
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -8,   -2, 	  -4,   -5, 	  -4,    0, 	   1,   -5
+.2byte  -11,   -6, 	  -3,   -3, 	  -3,    0, 	  -2,   -6
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -5,    0, 	  -7,    0, 	   1,    2, 	   0,   -5
+.2byte   -4,   -3, 	  -7,    0, 	   1,    2, 	  -1,   -5
+.2byte   -1,   -5, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte   -4,   -3, 	  -7,    0, 	   1,    2, 	  -1,   -5
+.2byte  -11,   -6, 	  -3,   -3, 	  -3,    0, 	  -2,   -6
+.2byte   -8,  -12, 	   1,   -3, 	  -4,   -1, 	  -3,   -7
+.2byte   -1,  -12, 	   3,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte    7,  -12, 	  -2,   -3, 	   3,   -1, 	   2,   -7
+.2byte   10,   -6, 	   2,   -3, 	   2,    0, 	   1,   -6
+.2byte    3,   -3, 	   6,    0, 	  -2,    2, 	   0,   -5
+.2byte   -1,   -5, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte    2,   -3, 	   5,    0, 	  -3,    2, 	  -1,   -5
+.2byte    9,   -6, 	   1,   -3, 	   1,    0, 	   0,   -6
+.2byte    6,  -12, 	  -3,   -3, 	   2,   -1, 	   1,   -7
+.2byte   -1,  -12, 	   3,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -7,  -12, 	   2,   -3, 	  -3,   -1, 	  -2,   -7
+.2byte  -10,   -6, 	  -2,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -3,   -3, 	  -6,    0, 	   2,    2, 	   0,   -5
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -5, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte   -1,    0, 	  -5,    1, 	   4,    1, 	  -1,   -4
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    2,   -4, 	   5,   -1, 	  -3,    1, 	  -1,   -6
+.2byte    5,    1, 	   7,    1, 	  -1,    3, 	   0,   -4
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    8,   -6, 	   0,   -3, 	   0,    0, 	  -1,   -6
+.2byte    8,   -2, 	   4,   -5, 	   4,    0, 	  -1,   -5
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    6,  -11, 	  -3,   -2, 	   2,    0, 	   1,   -6
+.2byte    4,   -3, 	  -1,   -4, 	   5,   -1, 	   1,   -6
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -11, 	   3,   -3, 	  -4,   -3, 	  -1,   -7
+.2byte   -1,   -4, 	   4,   -3, 	  -5,   -3, 	  -1,   -6
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -7,  -11, 	   2,   -2, 	  -3,    0, 	  -2,   -6
+.2byte   -5,   -3, 	   0,   -4, 	  -6,   -1, 	  -2,   -6
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -9,   -6, 	  -1,   -3, 	  -1,    0, 	   0,   -6
+.2byte   -9,   -2, 	  -5,   -5, 	  -5,    0, 	   0,   -5
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -3,   -4, 	  -6,   -1, 	   2,    1, 	   0,   -6
+.2byte   -6,    1, 	  -8,    1, 	   0,    3, 	  -1,   -4
+.2byte   -1,    0, 	  -5,    1, 	   4,    1, 	  -1,   -4
+.2byte   -5,    0, 	  -7,    0, 	   1,    2, 	   0,   -5
+.2byte   -8,   -2, 	  -4,   -5, 	  -4,    0, 	   1,   -5
+.2byte   -4,   -4, 	   1,   -5, 	  -5,   -2, 	  -1,   -7
+.2byte   -1,   -4, 	   4,   -3, 	  -5,   -3, 	  -1,   -6
+.2byte    3,   -4, 	  -2,   -5, 	   4,   -2, 	   0,   -7
+.2byte    7,   -2, 	   3,   -5, 	   3,    0, 	  -2,   -5
+.2byte    4,    0, 	   6,    0, 	  -2,    2, 	  -1,   -5
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+.2byte    4,    0, 	   5,    0, 	   0,    3, 	   0,   -5
+.2byte    6,   -1, 	   7,    2, 	  -2,    1, 	   1,   -5
+.2byte    4,    0, 	   6,    0, 	  -2,    2, 	  -1,   -5
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    9,   -4, 	   0,   -3, 	   4,    1, 	  -1,   -5
+.2byte    9,   -6, 	   5,   -3, 	   2,    1, 	  -1,   -5
+.2byte    7,   -2, 	   3,   -5, 	   3,    0, 	  -2,   -5
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    5,   -4, 	  -2,   -3, 	   5,    0, 	   1,   -5
+.2byte    3,   -4, 	   0,   -5, 	   3,    1, 	   1,   -5
+.2byte    3,   -3, 	  -2,   -4, 	   4,   -1, 	   0,   -6
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -2,   -4, 	   3,   -1, 	  -5,   -3, 	  -1,   -5
+.2byte    0,   -4, 	   4,   -3, 	  -4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -6,   -4, 	   1,   -3, 	  -6,    0, 	  -2,   -5
+.2byte   -4,   -4, 	  -1,   -5, 	  -4,    1, 	  -2,   -5
+.2byte   -4,   -3, 	   1,   -4, 	  -5,   -1, 	  -1,   -6
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -1,   -3, 	  -5,    1, 	   0,   -5
+.2byte  -10,   -6, 	  -6,   -3, 	  -3,    1, 	   0,   -5
+.2byte   -8,   -2, 	  -4,   -5, 	  -4,    0, 	   1,   -5
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -5,    0, 	  -6,    0, 	  -1,    3, 	  -1,   -5
+.2byte   -7,   -1, 	  -8,    2, 	   1,    1, 	  -2,   -5
+.2byte   -5,    0, 	  -7,    0, 	   1,    2, 	   0,   -5
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -6,   -1, 	  -7,    0, 	   0,    2, 	  -1,   -6
+.2byte   -9,   -3, 	  -4,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -6,   -4, 	   1,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -1,   -5, 	   3,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte    5,   -4, 	  -2,   -4, 	   4,   -1, 	   1,   -6
+.2byte    8,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -6
+.2byte    5,   -1, 	   6,    0, 	  -1,    2, 	   0,   -6
+sAronAnimTable1:
+.4byte sAronAnims_1_1
+.4byte sAronAnims_1_2
+.4byte sAronAnims_1_3
+.4byte sAronAnims_1_4
+.4byte sAronAnims_1_5
+.4byte sAronAnims_1_6
+.4byte sAronAnims_1_7
+.4byte sAronAnims_1_8
+sAronAnimTable2:
+.4byte sAronAnims_2_1
+.4byte sAronAnims_2_2
+.4byte sAronAnims_2_3
+.4byte sAronAnims_2_4
+.4byte sAronAnims_2_5
+.4byte sAronAnims_2_6
+.4byte sAronAnims_2_7
+.4byte sAronAnims_2_8
+sAronAnimTable3:
+.4byte sAronAnims_3_1
+.4byte sAronAnims_3_2
+.4byte sAronAnims_3_3
+.4byte sAronAnims_3_4
+.4byte sAronAnims_3_5
+.4byte sAronAnims_3_6
+.4byte sAronAnims_3_7
+.4byte sAronAnims_3_8
+sAronAnimTable4:
+.4byte sAronAnims_4_1
+.4byte sAronAnims_4_2
+.4byte sAronAnims_4_3
+.4byte sAronAnims_4_4
+.4byte sAronAnims_4_5
+.4byte sAronAnims_4_6
+.4byte sAronAnims_4_7
+.4byte sAronAnims_4_8
+sAronAnimTable5:
+.4byte sAronAnims_5_1
+.4byte sAronAnims_5_2
+.4byte sAronAnims_5_3
+.4byte sAronAnims_5_4
+.4byte sAronAnims_5_5
+.4byte sAronAnims_5_6
+.4byte sAronAnims_5_7
+.4byte sAronAnims_5_8
+sAronAnimTable6:
+.4byte sAronAnims_6_1
+.4byte sAronAnims_6_1
+.4byte sAronAnims_6_1
+.4byte sAronAnims_6_1
+.4byte sAronAnims_6_1
+.4byte sAronAnims_6_1
+.4byte sAronAnims_6_1
+.4byte sAronAnims_6_1
+sAronAnimTable7:
+.4byte sAronAnims_7_1
+.4byte sAronAnims_7_2
+.4byte sAronAnims_7_3
+.4byte sAronAnims_7_4
+.4byte sAronAnims_7_5
+.4byte sAronAnims_7_6
+.4byte sAronAnims_7_7
+.4byte sAronAnims_7_8
+sAronAnimTable8:
+.4byte sAronAnims_8_1
+.4byte sAronAnims_8_2
+.4byte sAronAnims_8_3
+.4byte sAronAnims_8_4
+.4byte sAronAnims_8_5
+.4byte sAronAnims_8_6
+.4byte sAronAnims_8_7
+.4byte sAronAnims_8_8
+sAronAnimTable9:
+.4byte sAronAnims_9_1
+.4byte sAronAnims_9_2
+.4byte sAronAnims_9_3
+.4byte sAronAnims_9_4
+.4byte sAronAnims_9_5
+.4byte sAronAnims_9_6
+.4byte sAronAnims_9_7
+.4byte sAronAnims_9_8
+sAronAnimTable10:
+.4byte sAronAnims_10_1
+.4byte sAronAnims_10_2
+.4byte sAronAnims_10_3
+.4byte sAronAnims_10_4
+.4byte sAronAnims_10_5
+.4byte sAronAnims_10_6
+.4byte sAronAnims_10_7
+.4byte sAronAnims_10_8
+sAronAnimTable11:
+.4byte sAronAnims_11_1
+.4byte sAronAnims_11_2
+.4byte sAronAnims_11_3
+.4byte sAronAnims_11_4
+.4byte sAronAnims_11_5
+.4byte sAronAnims_11_6
+.4byte sAronAnims_11_7
+.4byte sAronAnims_11_8
+sAronAnimTable12:
+.4byte sAronAnims_12_1
+.4byte sAronAnims_12_2
+.4byte sAronAnims_12_3
+.4byte sAronAnims_12_4
+.4byte sAronAnims_12_5
+.4byte sAronAnims_12_6
+.4byte sAronAnims_12_7
+.4byte sAronAnims_12_8
+sAronAnimTable13:
+.4byte sAronAnims_13_1
+.4byte sAronAnims_13_2
+.4byte sAronAnims_13_3
+.4byte sAronAnims_13_4
+.4byte sAronAnims_13_5
+.4byte sAronAnims_13_6
+.4byte sAronAnims_13_7
+.4byte sAronAnims_13_8
+sAxAnimationsAron:
+.4byte sAronAnimTable1
+.4byte sAronAnimTable2
+.4byte sAronAnimTable3
+.4byte sAronAnimTable4
+.4byte sAronAnimTable5
+.4byte sAronAnimTable6
+.4byte sAronAnimTable7
+.4byte sAronAnimTable8
+.4byte sAronAnimTable9
+.4byte sAronAnimTable10
+.4byte sAronAnimTable11
+.4byte sAronAnimTable12
+.4byte sAronAnimTable13
+sAxSpritesAron:
+.4byte sAronSprites1
+.4byte sAronSprites2
+.4byte sAronSprites3
+.4byte sAronSprites4
+.4byte sAronSprites5
+.4byte sAronSprites6
+.4byte sAronSprites7
+.4byte sAronSprites8
+.4byte sAronSprites9
+.4byte sAronSprites10
+.4byte sAronSprites11
+.4byte sAronSprites12
+.4byte sAronSprites13
+.4byte sAronSprites14
+.4byte sAronSprites15
+.4byte sAronSprites16
+.4byte sAronSprites17
+.4byte sAronSprites18
+.4byte sAronSprites19
+.4byte sAronSprites20
+.4byte sAronSprites21
+.4byte sAronSprites22
+.4byte sAronSprites23
+.4byte sAronSprites24
+.4byte sAronSprites25
+.4byte sAronSprites26
+.4byte sAronSprites27
+.4byte sAronSprites28
+.4byte sAronSprites29
+.4byte sAronSprites30
+.4byte sAronSprites31
+.4byte sAronSprites32
+.4byte sAronSprites33
+.4byte sAronSprites34
+.4byte sAronSprites35
+.4byte sAronSprites36
+.4byte sAronSprites37
+.4byte sAronSprites38
+.4byte sAronSprites39
+.4byte sAronSprites40
+.4byte sAronSprites41
+.4byte sAronSprites42
+sAxMainAron:
+ax_main sAxPosesAron, sAxAnimationsAron, 13, sAxSpritesAron, sAxPositionsAron

--- a/data/ax/articuno.inc
+++ b/data/ax/articuno.inc
@@ -1,0 +1,4853 @@
+.global gAxArticuno
+gAxArticuno:
+ax_siro sAxMainArticuno
+sArticunoPose1:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose2:
+ax_pose 1, 0x01d4, 0x80ec, 0x5c00
+ax_pose 2, 0x81d4, 0x410c, 0x5c10
+ax_pose 3, 0x01f4, 0x40f8, 0x5c14
+ax_pose_terminator
+sArticunoPose3:
+ax_pose 4, 0x81ec, 0x80e8, 0x5c00
+ax_pose 5, 0x81dc, 0x80f8, 0x5c08
+ax_pose 6, 0x81ec, 0x8108, 0x5c10
+ax_pose_terminator
+sArticunoPose4:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose5:
+ax_pose 13, 0x01f4, 0x50f7, 0x5c00
+ax_pose 14, 0x01d4, 0x90f1, 0x5c04
+ax_pose 15, 0x81dc, 0x10e9, 0x5c14
+ax_pose 16, 0x01dc, 0x10e1, 0x5c16
+ax_pose 17, 0x01f4, 0x1107, 0x5c17
+ax_pose_terminator
+sArticunoPose6:
+ax_pose 18, 0x01e2, 0x90f0, 0x5c00
+ax_pose 19, 0x81ea, 0x5110, 0x5c10
+ax_pose 20, 0x4202, 0x1100, 0x5c14
+ax_pose 21, 0x01e2, 0x50e0, 0x5c16
+ax_pose_terminator
+sArticunoPose7:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose8:
+ax_pose 25, 0x01e3, 0x90f5, 0x5c00
+ax_pose 26, 0x41eb, 0x90d5, 0x5c10
+ax_pose 27, 0x01d3, 0x50f5, 0x5c18
+ax_pose 28, 0x01cb, 0x10fd, 0x5c1c
+ax_pose_terminator
+sArticunoPose9:
+ax_pose 29, 0x01e8, 0x90f9, 0x5c00
+ax_pose 30, 0x41e8, 0x90d9, 0x5c10
+ax_pose 31, 0x01f8, 0x10f1, 0x5c18
+ax_pose 32, 0x41e0, 0x1101, 0x5c19
+ax_pose 33, 0x01f0, 0x10d1, 0x5c1b
+ax_pose_terminator
+sArticunoPose10:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose11:
+ax_pose 39, 0x01da, 0x90f4, 0x5c00
+ax_pose 40, 0x01d2, 0x10f4, 0x5c10
+ax_pose 41, 0x81da, 0x1114, 0x5c11
+ax_pose 42, 0x01f2, 0x10ec, 0x5c13
+ax_pose 43, 0x41fa, 0x90e6, 0x5c14
+ax_pose_terminator
+sArticunoPose12:
+ax_pose 44, 0x01e0, 0x90f0, 0x5c00
+ax_pose 45, 0x81f0, 0x10e8, 0x5c10
+ax_pose 46, 0x8200, 0x10e8, 0x5c12
+ax_pose 47, 0x81f8, 0x1110, 0x5c14
+ax_pose 48, 0x0200, 0x10f8, 0x5c16
+ax_pose 49, 0x0200, 0x1108, 0x5c17
+ax_pose 50, 0x0200, 0x10f0, 0x5c18
+ax_pose_terminator
+sArticunoPose13:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose14:
+ax_pose 55, 0x81d5, 0x80e8, 0x5c00
+ax_pose 56, 0x81e5, 0x80f8, 0x5c08
+ax_pose 57, 0x81d5, 0x8108, 0x5c10
+ax_pose 58, 0x0205, 0x00fc, 0x5c18
+ax_pose_terminator
+sArticunoPose15:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose 60, 0x01dc, 0x00fd, 0x5c10
+ax_pose 61, 0x0204, 0x00fc, 0x5c11
+ax_pose_terminator
+sArticunoPose16:
+ax_pose 34, 0x41e3, 0x80e4, 0x5c00
+ax_pose 35, 0x41f3, 0x40e4, 0x5c08
+ax_pose 36, 0x81db, 0x8104, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fc, 0x5c14
+ax_pose 38, 0x4203, 0x010c, 0x5c18
+ax_pose_terminator
+sArticunoPose17:
+ax_pose 39, 0x01da, 0x80ed, 0x5c00
+ax_pose 40, 0x01d2, 0x0105, 0x5c10
+ax_pose 41, 0x81da, 0x00e5, 0x5c11
+ax_pose 42, 0x01f2, 0x010d, 0x5c13
+ax_pose 43, 0x41fa, 0x80fb, 0x5c14
+ax_pose_terminator
+sArticunoPose18:
+ax_pose 44, 0x01e0, 0x80f1, 0x5c00
+ax_pose 45, 0x81f0, 0x0111, 0x5c10
+ax_pose 46, 0x8200, 0x0111, 0x5c12
+ax_pose 47, 0x81f8, 0x00e9, 0x5c14
+ax_pose 48, 0x0200, 0x0101, 0x5c16
+ax_pose 49, 0x0200, 0x00f1, 0x5c17
+ax_pose 50, 0x0200, 0x0109, 0x5c18
+ax_pose_terminator
+sArticunoPose19:
+ax_pose 22, 0x01e4, 0x80f0, 0x5c00
+ax_pose 23, 0x41e9, 0x8110, 0x5c10
+ax_pose 24, 0x01d4, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose20:
+ax_pose 25, 0x01e3, 0x80ec, 0x5c00
+ax_pose 26, 0x41eb, 0x810c, 0x5c10
+ax_pose 27, 0x01d3, 0x40fc, 0x5c18
+ax_pose 28, 0x01cb, 0x00fc, 0x5c1c
+ax_pose_terminator
+sArticunoPose21:
+ax_pose 29, 0x01e8, 0x80e8, 0x5c00
+ax_pose 30, 0x41e8, 0x8108, 0x5c10
+ax_pose 31, 0x01f8, 0x0108, 0x5c18
+ax_pose 32, 0x41e0, 0x00f0, 0x5c19
+ax_pose 33, 0x01f0, 0x0128, 0x5c1b
+ax_pose_terminator
+sArticunoPose22:
+ax_pose 7, 0x81dd, 0x80ed, 0x5c00
+ax_pose 8, 0x01ed, 0x40fd, 0x5c08
+ax_pose 9, 0x41e5, 0x00fd, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ed, 0x5c0e
+ax_pose 11, 0x01dd, 0x0112, 0x5c0f
+ax_pose 12, 0x01e5, 0x410d, 0x5c10
+ax_pose_terminator
+sArticunoPose23:
+ax_pose 13, 0x01f4, 0x40fa, 0x5c00
+ax_pose 14, 0x01d4, 0x80f0, 0x5c04
+ax_pose 15, 0x81dc, 0x0110, 0x5c14
+ax_pose 16, 0x01dc, 0x0118, 0x5c16
+ax_pose 17, 0x01f4, 0x00f2, 0x5c17
+ax_pose_terminator
+sArticunoPose24:
+ax_pose 18, 0x01e2, 0x80f1, 0x5c00
+ax_pose 19, 0x81ea, 0x40e9, 0x5c10
+ax_pose 20, 0x4202, 0x00f1, 0x5c14
+ax_pose 21, 0x01e2, 0x4111, 0x5c16
+ax_pose_terminator
+sArticunoPose25:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose26:
+ax_pose 1, 0x01d2, 0x80ec, 0x5c00
+ax_pose 2, 0x81d2, 0x410c, 0x5c10
+ax_pose 3, 0x01f2, 0x40f8, 0x5c14
+ax_pose_terminator
+sArticunoPose27:
+ax_pose 4, 0x81ee, 0x80e8, 0x5c00
+ax_pose 5, 0x81de, 0x80f8, 0x5c08
+ax_pose 6, 0x81ee, 0x8108, 0x5c10
+ax_pose_terminator
+sArticunoPose28:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose29:
+ax_pose 13, 0x01f2, 0x50f7, 0x5c00
+ax_pose 14, 0x01d2, 0x90f1, 0x5c04
+ax_pose 15, 0x81da, 0x10e9, 0x5c14
+ax_pose 16, 0x01da, 0x10e1, 0x5c16
+ax_pose 17, 0x01f2, 0x1107, 0x5c17
+ax_pose_terminator
+sArticunoPose30:
+ax_pose 18, 0x01e2, 0x90f0, 0x5c00
+ax_pose 19, 0x81ea, 0x5110, 0x5c10
+ax_pose 20, 0x4202, 0x1100, 0x5c14
+ax_pose 21, 0x01e2, 0x50e0, 0x5c16
+ax_pose_terminator
+sArticunoPose31:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose32:
+ax_pose 25, 0x01e1, 0x90f4, 0x5c00
+ax_pose 26, 0x41e9, 0x90d4, 0x5c10
+ax_pose 27, 0x01d1, 0x50f4, 0x5c18
+ax_pose 28, 0x01c9, 0x10fc, 0x5c1c
+ax_pose_terminator
+sArticunoPose33:
+ax_pose 29, 0x01e8, 0x90f9, 0x5c00
+ax_pose 30, 0x41e8, 0x90d9, 0x5c10
+ax_pose 31, 0x01f8, 0x10f1, 0x5c18
+ax_pose 32, 0x41e0, 0x1101, 0x5c19
+ax_pose 33, 0x01f0, 0x10d1, 0x5c1b
+ax_pose_terminator
+sArticunoPose34:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose35:
+ax_pose 39, 0x01d7, 0x90f4, 0x5c00
+ax_pose 40, 0x01cf, 0x10f4, 0x5c10
+ax_pose 41, 0x81d7, 0x1114, 0x5c11
+ax_pose 42, 0x01ef, 0x10ec, 0x5c13
+ax_pose 43, 0x41f7, 0x90e6, 0x5c14
+ax_pose_terminator
+sArticunoPose36:
+ax_pose 44, 0x01e0, 0x90f0, 0x5c00
+ax_pose 45, 0x81f0, 0x10e8, 0x5c10
+ax_pose 46, 0x8200, 0x10e8, 0x5c12
+ax_pose 47, 0x81f8, 0x1110, 0x5c14
+ax_pose 48, 0x0200, 0x10f8, 0x5c16
+ax_pose 49, 0x0200, 0x1108, 0x5c17
+ax_pose 50, 0x0200, 0x10f0, 0x5c18
+ax_pose_terminator
+sArticunoPose37:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose38:
+ax_pose 55, 0x81d3, 0x80e8, 0x5c00
+ax_pose 56, 0x81e3, 0x80f8, 0x5c08
+ax_pose 57, 0x81d3, 0x8108, 0x5c10
+ax_pose 58, 0x0203, 0x00fc, 0x5c18
+ax_pose_terminator
+sArticunoPose39:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose 60, 0x01dc, 0x00fd, 0x5c10
+ax_pose 61, 0x0204, 0x00fc, 0x5c11
+ax_pose_terminator
+sArticunoPose40:
+ax_pose 34, 0x41e3, 0x80e3, 0x5c00
+ax_pose 35, 0x41f3, 0x40e3, 0x5c08
+ax_pose 36, 0x81db, 0x8103, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fb, 0x5c14
+ax_pose 38, 0x4203, 0x010b, 0x5c18
+ax_pose_terminator
+sArticunoPose41:
+ax_pose 39, 0x01d7, 0x80ec, 0x5c00
+ax_pose 40, 0x01cf, 0x0104, 0x5c10
+ax_pose 41, 0x81d7, 0x00e4, 0x5c11
+ax_pose 42, 0x01ef, 0x010c, 0x5c13
+ax_pose 43, 0x41f7, 0x80fa, 0x5c14
+ax_pose_terminator
+sArticunoPose42:
+ax_pose 44, 0x01e0, 0x80f0, 0x5c00
+ax_pose 45, 0x81f0, 0x0110, 0x5c10
+ax_pose 46, 0x8200, 0x0110, 0x5c12
+ax_pose 47, 0x81f8, 0x00e8, 0x5c14
+ax_pose 48, 0x0200, 0x0100, 0x5c16
+ax_pose 49, 0x0200, 0x00f0, 0x5c17
+ax_pose 50, 0x0200, 0x0108, 0x5c18
+ax_pose_terminator
+sArticunoPose43:
+ax_pose 22, 0x01e4, 0x80ef, 0x5c00
+ax_pose 23, 0x41e9, 0x810f, 0x5c10
+ax_pose 24, 0x01d4, 0x40f7, 0x5c18
+ax_pose_terminator
+sArticunoPose44:
+ax_pose 25, 0x01e1, 0x80ec, 0x5c00
+ax_pose 26, 0x41e9, 0x810c, 0x5c10
+ax_pose 27, 0x01d1, 0x40fc, 0x5c18
+ax_pose 28, 0x01c9, 0x00fc, 0x5c1c
+ax_pose_terminator
+sArticunoPose45:
+ax_pose 29, 0x01e8, 0x80e7, 0x5c00
+ax_pose 30, 0x41e8, 0x8107, 0x5c10
+ax_pose 31, 0x01f8, 0x0107, 0x5c18
+ax_pose 32, 0x41e0, 0x00ef, 0x5c19
+ax_pose 33, 0x01f0, 0x0127, 0x5c1b
+ax_pose_terminator
+sArticunoPose46:
+ax_pose 7, 0x81dd, 0x80ec, 0x5c00
+ax_pose 8, 0x01ed, 0x40fc, 0x5c08
+ax_pose 9, 0x41e5, 0x00fc, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ec, 0x5c0e
+ax_pose 11, 0x01dd, 0x0111, 0x5c0f
+ax_pose 12, 0x01e5, 0x410c, 0x5c10
+ax_pose_terminator
+sArticunoPose47:
+ax_pose 13, 0x01f2, 0x40f9, 0x5c00
+ax_pose 14, 0x01d2, 0x80ef, 0x5c04
+ax_pose 15, 0x81da, 0x010f, 0x5c14
+ax_pose 16, 0x01da, 0x0117, 0x5c16
+ax_pose 17, 0x01f2, 0x00f1, 0x5c17
+ax_pose_terminator
+sArticunoPose48:
+ax_pose 18, 0x01e2, 0x80f0, 0x5c00
+ax_pose 19, 0x81ea, 0x40e8, 0x5c10
+ax_pose 20, 0x4202, 0x00f0, 0x5c14
+ax_pose 21, 0x01e2, 0x4110, 0x5c16
+ax_pose_terminator
+sArticunoPose49:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose50:
+ax_pose 1, 0x01d2, 0x80ec, 0x5c00
+ax_pose 2, 0x81d2, 0x410c, 0x5c10
+ax_pose 3, 0x01f2, 0x40f8, 0x5c14
+ax_pose_terminator
+sArticunoPose51:
+ax_pose 4, 0x81ee, 0x80e8, 0x5c00
+ax_pose 5, 0x81de, 0x80f8, 0x5c08
+ax_pose 6, 0x81ee, 0x8108, 0x5c10
+ax_pose_terminator
+sArticunoPose52:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose53:
+ax_pose 13, 0x01f2, 0x50f7, 0x5c00
+ax_pose 14, 0x01d2, 0x90f1, 0x5c04
+ax_pose 15, 0x81da, 0x10e9, 0x5c14
+ax_pose 16, 0x01da, 0x10e1, 0x5c16
+ax_pose 17, 0x01f2, 0x1107, 0x5c17
+ax_pose_terminator
+sArticunoPose54:
+ax_pose 18, 0x01e2, 0x90f0, 0x5c00
+ax_pose 19, 0x81ea, 0x5110, 0x5c10
+ax_pose 20, 0x4202, 0x1100, 0x5c14
+ax_pose 21, 0x01e2, 0x50e0, 0x5c16
+ax_pose_terminator
+sArticunoPose55:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose56:
+ax_pose 25, 0x01e1, 0x90f4, 0x5c00
+ax_pose 26, 0x41e9, 0x90d4, 0x5c10
+ax_pose 27, 0x01d1, 0x50f4, 0x5c18
+ax_pose 28, 0x01c9, 0x10fc, 0x5c1c
+ax_pose_terminator
+sArticunoPose57:
+ax_pose 29, 0x01e8, 0x90f9, 0x5c00
+ax_pose 30, 0x41e8, 0x90d9, 0x5c10
+ax_pose 31, 0x01f8, 0x10f1, 0x5c18
+ax_pose 32, 0x41e0, 0x1101, 0x5c19
+ax_pose 33, 0x01f0, 0x10d1, 0x5c1b
+ax_pose_terminator
+sArticunoPose58:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose59:
+ax_pose 39, 0x01d7, 0x90f4, 0x5c00
+ax_pose 40, 0x01cf, 0x10f4, 0x5c10
+ax_pose 41, 0x81d7, 0x1114, 0x5c11
+ax_pose 42, 0x01ef, 0x10ec, 0x5c13
+ax_pose 43, 0x41f7, 0x90e6, 0x5c14
+ax_pose_terminator
+sArticunoPose60:
+ax_pose 44, 0x01e0, 0x90f0, 0x5c00
+ax_pose 45, 0x81f0, 0x10e8, 0x5c10
+ax_pose 46, 0x8200, 0x10e8, 0x5c12
+ax_pose 47, 0x81f8, 0x1110, 0x5c14
+ax_pose 48, 0x0200, 0x10f8, 0x5c16
+ax_pose 49, 0x0200, 0x1108, 0x5c17
+ax_pose 50, 0x0200, 0x10f0, 0x5c18
+ax_pose_terminator
+sArticunoPose61:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose62:
+ax_pose 55, 0x81d3, 0x80e8, 0x5c00
+ax_pose 56, 0x81e3, 0x80f8, 0x5c08
+ax_pose 57, 0x81d3, 0x8108, 0x5c10
+ax_pose 58, 0x0203, 0x00fc, 0x5c18
+ax_pose_terminator
+sArticunoPose63:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose 60, 0x01dc, 0x00fd, 0x5c10
+ax_pose 61, 0x0204, 0x00fc, 0x5c11
+ax_pose_terminator
+sArticunoPose64:
+ax_pose 34, 0x41e3, 0x80e3, 0x5c00
+ax_pose 35, 0x41f3, 0x40e3, 0x5c08
+ax_pose 36, 0x81db, 0x8103, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fb, 0x5c14
+ax_pose 38, 0x4203, 0x010b, 0x5c18
+ax_pose_terminator
+sArticunoPose65:
+ax_pose 39, 0x01d7, 0x80ec, 0x5c00
+ax_pose 40, 0x01cf, 0x0104, 0x5c10
+ax_pose 41, 0x81d7, 0x00e4, 0x5c11
+ax_pose 42, 0x01ef, 0x010c, 0x5c13
+ax_pose 43, 0x41f7, 0x80fa, 0x5c14
+ax_pose_terminator
+sArticunoPose66:
+ax_pose 44, 0x01e0, 0x80f0, 0x5c00
+ax_pose 45, 0x81f0, 0x0110, 0x5c10
+ax_pose 46, 0x8200, 0x0110, 0x5c12
+ax_pose 47, 0x81f8, 0x00e8, 0x5c14
+ax_pose 48, 0x0200, 0x0100, 0x5c16
+ax_pose 49, 0x0200, 0x00f0, 0x5c17
+ax_pose 50, 0x0200, 0x0108, 0x5c18
+ax_pose_terminator
+sArticunoPose67:
+ax_pose 22, 0x01e4, 0x80ef, 0x5c00
+ax_pose 23, 0x41e9, 0x810f, 0x5c10
+ax_pose 24, 0x01d4, 0x40f7, 0x5c18
+ax_pose_terminator
+sArticunoPose68:
+ax_pose 25, 0x01e1, 0x80ec, 0x5c00
+ax_pose 26, 0x41e9, 0x810c, 0x5c10
+ax_pose 27, 0x01d1, 0x40fc, 0x5c18
+ax_pose 28, 0x01c9, 0x00fc, 0x5c1c
+ax_pose_terminator
+sArticunoPose69:
+ax_pose 29, 0x01e8, 0x80e7, 0x5c00
+ax_pose 30, 0x41e8, 0x8107, 0x5c10
+ax_pose 31, 0x01f8, 0x0107, 0x5c18
+ax_pose 32, 0x41e0, 0x00ef, 0x5c19
+ax_pose 33, 0x01f0, 0x0127, 0x5c1b
+ax_pose_terminator
+sArticunoPose70:
+ax_pose 7, 0x81dd, 0x80ec, 0x5c00
+ax_pose 8, 0x01ed, 0x40fc, 0x5c08
+ax_pose 9, 0x41e5, 0x00fc, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ec, 0x5c0e
+ax_pose 11, 0x01dd, 0x0111, 0x5c0f
+ax_pose 12, 0x01e5, 0x410c, 0x5c10
+ax_pose_terminator
+sArticunoPose71:
+ax_pose 13, 0x01f2, 0x40f9, 0x5c00
+ax_pose 14, 0x01d2, 0x80ef, 0x5c04
+ax_pose 15, 0x81da, 0x010f, 0x5c14
+ax_pose 16, 0x01da, 0x0117, 0x5c16
+ax_pose 17, 0x01f2, 0x00f1, 0x5c17
+ax_pose_terminator
+sArticunoPose72:
+ax_pose 18, 0x01e2, 0x80f0, 0x5c00
+ax_pose 19, 0x81ea, 0x40e8, 0x5c10
+ax_pose 20, 0x4202, 0x00f0, 0x5c14
+ax_pose 21, 0x01e2, 0x4110, 0x5c16
+ax_pose_terminator
+sArticunoPose73:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose74:
+ax_pose 1, 0x01d4, 0x80ec, 0x5c00
+ax_pose 2, 0x81d4, 0x410c, 0x5c10
+ax_pose 3, 0x01f4, 0x40f8, 0x5c14
+ax_pose_terminator
+sArticunoPose75:
+ax_pose 4, 0x81ec, 0x80e8, 0x5c00
+ax_pose 5, 0x81dc, 0x80f8, 0x5c08
+ax_pose 6, 0x81ec, 0x8108, 0x5c10
+ax_pose_terminator
+sArticunoPose76:
+ax_pose 62, 0x01dc, 0x80e0, 0x5c00
+ax_pose 63, 0x81dc, 0x8100, 0x5c10
+ax_pose 64, 0x01dc, 0x4110, 0x5c18
+ax_pose 65, 0x41ec, 0x0110, 0x5c1c
+ax_pose 66, 0x01dc, 0x0120, 0x5c1e
+ax_pose_terminator
+sArticunoPose77:
+ax_pose 67, 0x81dc, 0x80f9, 0x5c00
+ax_pose 68, 0x01dc, 0x80d9, 0x5c08
+ax_pose -1, 0x01dc, 0x9108, 0x5c08
+ax_pose_terminator
+sArticunoPose78:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose79:
+ax_pose 13, 0x01f4, 0x50f7, 0x5c00
+ax_pose 14, 0x01d4, 0x90f1, 0x5c04
+ax_pose 15, 0x81dc, 0x10e9, 0x5c14
+ax_pose 16, 0x01dc, 0x10e1, 0x5c16
+ax_pose 17, 0x01f4, 0x1107, 0x5c17
+ax_pose_terminator
+sArticunoPose80:
+ax_pose 18, 0x01e2, 0x90f0, 0x5c00
+ax_pose 19, 0x81ea, 0x5110, 0x5c10
+ax_pose 20, 0x4202, 0x1100, 0x5c14
+ax_pose 21, 0x01e2, 0x50e0, 0x5c16
+ax_pose_terminator
+sArticunoPose81:
+ax_pose 69, 0x01d4, 0x90ef, 0x5c00
+ax_pose 70, 0x41f4, 0x90ef, 0x5c10
+ax_pose 71, 0x81dc, 0x10e7, 0x5c18
+ax_pose 72, 0x81ec, 0x10e7, 0x5c1a
+ax_pose_terminator
+sArticunoPose82:
+ax_pose 73, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose83:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose84:
+ax_pose 25, 0x01e3, 0x90f5, 0x5c00
+ax_pose 26, 0x41eb, 0x90d5, 0x5c10
+ax_pose 27, 0x01d3, 0x50f5, 0x5c18
+ax_pose 28, 0x01cb, 0x10fd, 0x5c1c
+ax_pose_terminator
+sArticunoPose85:
+ax_pose 29, 0x01e8, 0x90f9, 0x5c00
+ax_pose 30, 0x41e8, 0x90d9, 0x5c10
+ax_pose 31, 0x01f8, 0x10f1, 0x5c18
+ax_pose 32, 0x41e0, 0x1101, 0x5c19
+ax_pose 33, 0x01f0, 0x10d1, 0x5c1b
+ax_pose_terminator
+sArticunoPose86:
+ax_pose 74, 0x01d4, 0x90f1, 0x5c00
+ax_pose 75, 0x01f4, 0x5101, 0x5c10
+ax_pose 76, 0x01f0, 0x50e1, 0x5c14
+ax_pose 77, 0x41f4, 0x10f1, 0x5c18
+ax_pose 78, 0x01f8, 0x10d9, 0x5c1a
+ax_pose_terminator
+sArticunoPose87:
+ax_pose 79, 0x01e4, 0x90f1, 0x5c00
+ax_pose 80, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f7, 0x5c18
+ax_pose_terminator
+sArticunoPose88:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose89:
+ax_pose 39, 0x01da, 0x90f4, 0x5c00
+ax_pose 40, 0x01d2, 0x10f4, 0x5c10
+ax_pose 41, 0x81da, 0x1114, 0x5c11
+ax_pose 42, 0x01f2, 0x10ec, 0x5c13
+ax_pose 43, 0x41fa, 0x90e6, 0x5c14
+ax_pose_terminator
+sArticunoPose90:
+ax_pose 44, 0x01e0, 0x90f0, 0x5c00
+ax_pose 45, 0x81f0, 0x10e8, 0x5c10
+ax_pose 46, 0x8200, 0x10e8, 0x5c12
+ax_pose 47, 0x81f8, 0x1110, 0x5c14
+ax_pose 48, 0x0200, 0x10f8, 0x5c16
+ax_pose 50, 0x0200, 0x10f0, 0x5c17
+ax_pose 49, 0x0200, 0x1108, 0x5c18
+ax_pose_terminator
+sArticunoPose91:
+ax_pose 81, 0x01d4, 0x90f9, 0x5c00
+ax_pose 82, 0x01f4, 0x5101, 0x5c10
+ax_pose 83, 0x01f4, 0x50f1, 0x5c14
+ax_pose 84, 0x81d4, 0x10f1, 0x5c18
+ax_pose 85, 0x01e4, 0x10f1, 0x5c1a
+ax_pose 86, 0x4204, 0x10e9, 0x5c1b
+ax_pose_terminator
+sArticunoPose92:
+ax_pose 87, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose93:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose94:
+ax_pose 55, 0x81d5, 0x80e8, 0x5c00
+ax_pose 56, 0x81e5, 0x80f8, 0x5c08
+ax_pose 57, 0x81d5, 0x8108, 0x5c10
+ax_pose 58, 0x0205, 0x00fc, 0x5c18
+ax_pose_terminator
+sArticunoPose95:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose 60, 0x01dc, 0x00fd, 0x5c10
+ax_pose 61, 0x0204, 0x00fc, 0x5c11
+ax_pose_terminator
+sArticunoPose96:
+ax_pose 88, 0x41da, 0x80e0, 0x5c00
+ax_pose 89, 0x41da, 0x8100, 0x5c08
+ax_pose 90, 0x41ea, 0x40e8, 0x5c10
+ax_pose 91, 0x41ea, 0x0108, 0x5c14
+ax_pose 92, 0x41f2, 0x40f4, 0x5c16
+ax_pose 93, 0x41fa, 0x40f4, 0x5c1a
+ax_pose 94, 0x0202, 0x00fc, 0x5c1e
+ax_pose 95, 0x020a, 0x00fc, 0x5c1f
+ax_pose_terminator
+sArticunoPose97:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose98:
+ax_pose 34, 0x41e3, 0x80e3, 0x5c00
+ax_pose 35, 0x41f3, 0x40e3, 0x5c08
+ax_pose 36, 0x81db, 0x8103, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fb, 0x5c14
+ax_pose 38, 0x4203, 0x010b, 0x5c18
+ax_pose_terminator
+sArticunoPose99:
+ax_pose 39, 0x01da, 0x80ec, 0x5c00
+ax_pose 40, 0x01d2, 0x0104, 0x5c10
+ax_pose 41, 0x81da, 0x00e4, 0x5c11
+ax_pose 42, 0x01f2, 0x010c, 0x5c13
+ax_pose 43, 0x41fa, 0x80fa, 0x5c14
+ax_pose_terminator
+sArticunoPose100:
+ax_pose 44, 0x01e0, 0x80f0, 0x5c00
+ax_pose 45, 0x81f0, 0x0110, 0x5c10
+ax_pose 46, 0x8200, 0x0110, 0x5c12
+ax_pose 47, 0x81f8, 0x00e8, 0x5c14
+ax_pose 48, 0x0200, 0x0100, 0x5c16
+ax_pose 50, 0x0200, 0x0108, 0x5c17
+ax_pose 49, 0x0200, 0x00f0, 0x5c18
+ax_pose_terminator
+sArticunoPose101:
+ax_pose 81, 0x01d4, 0x80e7, 0x5c00
+ax_pose 82, 0x01f4, 0x40ef, 0x5c10
+ax_pose 83, 0x01f4, 0x40ff, 0x5c14
+ax_pose 84, 0x81d4, 0x0107, 0x5c18
+ax_pose 85, 0x01e4, 0x0107, 0x5c1a
+ax_pose 86, 0x4204, 0x0107, 0x5c1b
+ax_pose_terminator
+sArticunoPose102:
+ax_pose 87, 0x41e3, 0x80e3, 0x5c00
+ax_pose 35, 0x41f3, 0x40e3, 0x5c08
+ax_pose 36, 0x81db, 0x8103, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fb, 0x5c14
+ax_pose 38, 0x4203, 0x010b, 0x5c18
+ax_pose_terminator
+sArticunoPose103:
+ax_pose 22, 0x01e4, 0x80ef, 0x5c00
+ax_pose 23, 0x41e9, 0x810f, 0x5c10
+ax_pose 24, 0x01d4, 0x40f7, 0x5c18
+ax_pose_terminator
+sArticunoPose104:
+ax_pose 25, 0x01e3, 0x80eb, 0x5c00
+ax_pose 26, 0x41eb, 0x810b, 0x5c10
+ax_pose 27, 0x01d3, 0x40fb, 0x5c18
+ax_pose 28, 0x01cb, 0x00fb, 0x5c1c
+ax_pose_terminator
+sArticunoPose105:
+ax_pose 29, 0x01e8, 0x80e7, 0x5c00
+ax_pose 30, 0x41e8, 0x8107, 0x5c10
+ax_pose 31, 0x01f8, 0x0107, 0x5c18
+ax_pose 32, 0x41e0, 0x00ef, 0x5c19
+ax_pose 33, 0x01f0, 0x0127, 0x5c1b
+ax_pose_terminator
+sArticunoPose106:
+ax_pose 74, 0x01d4, 0x80ef, 0x5c00
+ax_pose 75, 0x01f4, 0x40ef, 0x5c10
+ax_pose 76, 0x01f0, 0x410f, 0x5c14
+ax_pose 77, 0x41f4, 0x00ff, 0x5c18
+ax_pose 78, 0x01f8, 0x011f, 0x5c1a
+ax_pose_terminator
+sArticunoPose107:
+ax_pose 79, 0x01e4, 0x80ef, 0x5c00
+ax_pose 80, 0x41e9, 0x810f, 0x5c10
+ax_pose 24, 0x01d4, 0x40f9, 0x5c18
+ax_pose_terminator
+sArticunoPose108:
+ax_pose 7, 0x81dd, 0x80ec, 0x5c00
+ax_pose 8, 0x01ed, 0x40fc, 0x5c08
+ax_pose 9, 0x41e5, 0x00fc, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ec, 0x5c0e
+ax_pose 11, 0x01dd, 0x0111, 0x5c0f
+ax_pose 12, 0x01e5, 0x410c, 0x5c10
+ax_pose_terminator
+sArticunoPose109:
+ax_pose 13, 0x01f4, 0x40f9, 0x5c00
+ax_pose 14, 0x01d4, 0x80ef, 0x5c04
+ax_pose 15, 0x81dc, 0x010f, 0x5c14
+ax_pose 16, 0x01dc, 0x0117, 0x5c16
+ax_pose 17, 0x01f4, 0x00f1, 0x5c17
+ax_pose_terminator
+sArticunoPose110:
+ax_pose 18, 0x01e2, 0x80f0, 0x5c00
+ax_pose 19, 0x81ea, 0x40e8, 0x5c10
+ax_pose 20, 0x4202, 0x00f0, 0x5c14
+ax_pose 21, 0x01e2, 0x4110, 0x5c16
+ax_pose_terminator
+sArticunoPose111:
+ax_pose 69, 0x01d4, 0x80f1, 0x5c00
+ax_pose 70, 0x41f4, 0x80f1, 0x5c10
+ax_pose 71, 0x81dc, 0x0111, 0x5c18
+ax_pose 72, 0x81ec, 0x0111, 0x5c1a
+ax_pose_terminator
+sArticunoPose112:
+ax_pose 73, 0x81dd, 0x80ec, 0x5c00
+ax_pose 8, 0x01ed, 0x40fc, 0x5c08
+ax_pose 9, 0x41e5, 0x00fc, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ec, 0x5c0e
+ax_pose 11, 0x01dd, 0x0111, 0x5c0f
+ax_pose 12, 0x01e5, 0x410c, 0x5c10
+ax_pose_terminator
+sArticunoPose113:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose114:
+ax_pose 1, 0x01d4, 0x80ec, 0x5c00
+ax_pose 2, 0x81d4, 0x410c, 0x5c10
+ax_pose 3, 0x01f4, 0x40f8, 0x5c14
+ax_pose_terminator
+sArticunoPose115:
+ax_pose 4, 0x81ec, 0x80e8, 0x5c00
+ax_pose 5, 0x81dc, 0x80f8, 0x5c08
+ax_pose 6, 0x81ec, 0x8108, 0x5c10
+ax_pose_terminator
+sArticunoPose116:
+ax_pose 62, 0x01dc, 0x80e0, 0x5c00
+ax_pose 63, 0x81dc, 0x8100, 0x5c10
+ax_pose 64, 0x01dc, 0x4110, 0x5c18
+ax_pose 65, 0x41ec, 0x0110, 0x5c1c
+ax_pose 66, 0x01dc, 0x0120, 0x5c1e
+ax_pose_terminator
+sArticunoPose117:
+ax_pose 67, 0x81dc, 0x80f9, 0x5c00
+ax_pose 68, 0x01dc, 0x80d9, 0x5c08
+ax_pose -1, 0x01dc, 0x9108, 0x5c08
+ax_pose_terminator
+sArticunoPose118:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose119:
+ax_pose 13, 0x01f4, 0x50f7, 0x5c00
+ax_pose 14, 0x01d4, 0x90f1, 0x5c04
+ax_pose 15, 0x81dc, 0x10e9, 0x5c14
+ax_pose 16, 0x01dc, 0x10e1, 0x5c16
+ax_pose 17, 0x01f4, 0x1107, 0x5c17
+ax_pose_terminator
+sArticunoPose120:
+ax_pose 18, 0x01e2, 0x90f0, 0x5c00
+ax_pose 19, 0x81ea, 0x5110, 0x5c10
+ax_pose 20, 0x4202, 0x1100, 0x5c14
+ax_pose 21, 0x01e2, 0x50e0, 0x5c16
+ax_pose_terminator
+sArticunoPose121:
+ax_pose 69, 0x01d4, 0x90ef, 0x5c00
+ax_pose 70, 0x41f4, 0x90ef, 0x5c10
+ax_pose 71, 0x81dc, 0x10e7, 0x5c18
+ax_pose 72, 0x81ec, 0x10e7, 0x5c1a
+ax_pose_terminator
+sArticunoPose122:
+ax_pose 73, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose123:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose124:
+ax_pose 25, 0x01e3, 0x90f5, 0x5c00
+ax_pose 26, 0x41eb, 0x90d5, 0x5c10
+ax_pose 27, 0x01d3, 0x50f5, 0x5c18
+ax_pose 28, 0x01cb, 0x10fd, 0x5c1c
+ax_pose_terminator
+sArticunoPose125:
+ax_pose 29, 0x01e8, 0x90f9, 0x5c00
+ax_pose 30, 0x41e8, 0x90d9, 0x5c10
+ax_pose 31, 0x01f8, 0x10f1, 0x5c18
+ax_pose 32, 0x41e0, 0x1101, 0x5c19
+ax_pose 33, 0x01f0, 0x10d1, 0x5c1b
+ax_pose_terminator
+sArticunoPose126:
+ax_pose 74, 0x01d4, 0x90f1, 0x5c00
+ax_pose 75, 0x01f4, 0x5101, 0x5c10
+ax_pose 76, 0x01f0, 0x50e1, 0x5c14
+ax_pose 77, 0x41f4, 0x10f1, 0x5c18
+ax_pose 78, 0x01f8, 0x10d9, 0x5c1a
+ax_pose_terminator
+sArticunoPose127:
+ax_pose 79, 0x01e4, 0x90f1, 0x5c00
+ax_pose 80, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f7, 0x5c18
+ax_pose_terminator
+sArticunoPose128:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose129:
+ax_pose 39, 0x01da, 0x90f4, 0x5c00
+ax_pose 40, 0x01d2, 0x10f4, 0x5c10
+ax_pose 41, 0x81da, 0x1114, 0x5c11
+ax_pose 42, 0x01f2, 0x10ec, 0x5c13
+ax_pose 43, 0x41fa, 0x90e6, 0x5c14
+ax_pose_terminator
+sArticunoPose130:
+ax_pose 44, 0x01e0, 0x90f0, 0x5c00
+ax_pose 45, 0x81f0, 0x10e8, 0x5c10
+ax_pose 46, 0x8200, 0x10e8, 0x5c12
+ax_pose 47, 0x81f8, 0x1110, 0x5c14
+ax_pose 48, 0x0200, 0x10f8, 0x5c16
+ax_pose 50, 0x0200, 0x10f0, 0x5c17
+ax_pose 49, 0x0200, 0x1108, 0x5c18
+ax_pose_terminator
+sArticunoPose131:
+ax_pose 81, 0x01d4, 0x90f9, 0x5c00
+ax_pose 82, 0x01f4, 0x5101, 0x5c10
+ax_pose 83, 0x01f4, 0x50f1, 0x5c14
+ax_pose 84, 0x81d4, 0x10f1, 0x5c18
+ax_pose 85, 0x01e4, 0x10f1, 0x5c1a
+ax_pose 86, 0x4204, 0x10e9, 0x5c1b
+ax_pose_terminator
+sArticunoPose132:
+ax_pose 87, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose133:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose134:
+ax_pose 55, 0x81d5, 0x80e8, 0x5c00
+ax_pose 56, 0x81e5, 0x80f8, 0x5c08
+ax_pose 57, 0x81d5, 0x8108, 0x5c10
+ax_pose 58, 0x0205, 0x00fc, 0x5c18
+ax_pose_terminator
+sArticunoPose135:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose 60, 0x01dc, 0x00fd, 0x5c10
+ax_pose 61, 0x0204, 0x00fc, 0x5c11
+ax_pose_terminator
+sArticunoPose136:
+ax_pose 88, 0x41da, 0x80e0, 0x5c00
+ax_pose 89, 0x41da, 0x8100, 0x5c08
+ax_pose 90, 0x41ea, 0x40e8, 0x5c10
+ax_pose 91, 0x41ea, 0x0108, 0x5c14
+ax_pose 92, 0x41f2, 0x40f4, 0x5c16
+ax_pose 93, 0x41fa, 0x40f4, 0x5c1a
+ax_pose 94, 0x0202, 0x00fc, 0x5c1e
+ax_pose 95, 0x020a, 0x00fc, 0x5c1f
+ax_pose_terminator
+sArticunoPose137:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose138:
+ax_pose 34, 0x41e3, 0x80e3, 0x5c00
+ax_pose 35, 0x41f3, 0x40e3, 0x5c08
+ax_pose 36, 0x81db, 0x8103, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fb, 0x5c14
+ax_pose 38, 0x4203, 0x010b, 0x5c18
+ax_pose_terminator
+sArticunoPose139:
+ax_pose 39, 0x01da, 0x80ec, 0x5c00
+ax_pose 40, 0x01d2, 0x0104, 0x5c10
+ax_pose 41, 0x81da, 0x00e4, 0x5c11
+ax_pose 42, 0x01f2, 0x010c, 0x5c13
+ax_pose 43, 0x41fa, 0x80fa, 0x5c14
+ax_pose_terminator
+sArticunoPose140:
+ax_pose 44, 0x01e0, 0x80f0, 0x5c00
+ax_pose 45, 0x81f0, 0x0110, 0x5c10
+ax_pose 46, 0x8200, 0x0110, 0x5c12
+ax_pose 47, 0x81f8, 0x00e8, 0x5c14
+ax_pose 48, 0x0200, 0x0100, 0x5c16
+ax_pose 50, 0x0200, 0x0108, 0x5c17
+ax_pose 49, 0x0200, 0x00f0, 0x5c18
+ax_pose_terminator
+sArticunoPose141:
+ax_pose 81, 0x01d4, 0x80e7, 0x5c00
+ax_pose 82, 0x01f4, 0x40ef, 0x5c10
+ax_pose 83, 0x01f4, 0x40ff, 0x5c14
+ax_pose 84, 0x81d4, 0x0107, 0x5c18
+ax_pose 85, 0x01e4, 0x0107, 0x5c1a
+ax_pose 86, 0x4204, 0x0107, 0x5c1b
+ax_pose_terminator
+sArticunoPose142:
+ax_pose 87, 0x41e3, 0x80e3, 0x5c00
+ax_pose 35, 0x41f3, 0x40e3, 0x5c08
+ax_pose 36, 0x81db, 0x8103, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fb, 0x5c14
+ax_pose 38, 0x4203, 0x010b, 0x5c18
+ax_pose_terminator
+sArticunoPose143:
+ax_pose 22, 0x01e4, 0x80ef, 0x5c00
+ax_pose 23, 0x41e9, 0x810f, 0x5c10
+ax_pose 24, 0x01d4, 0x40f7, 0x5c18
+ax_pose_terminator
+sArticunoPose144:
+ax_pose 25, 0x01e3, 0x80eb, 0x5c00
+ax_pose 26, 0x41eb, 0x810b, 0x5c10
+ax_pose 27, 0x01d3, 0x40fb, 0x5c18
+ax_pose 28, 0x01cb, 0x00fb, 0x5c1c
+ax_pose_terminator
+sArticunoPose145:
+ax_pose 29, 0x01e8, 0x80e7, 0x5c00
+ax_pose 30, 0x41e8, 0x8107, 0x5c10
+ax_pose 31, 0x01f8, 0x0107, 0x5c18
+ax_pose 32, 0x41e0, 0x00ef, 0x5c19
+ax_pose 33, 0x01f0, 0x0127, 0x5c1b
+ax_pose_terminator
+sArticunoPose146:
+ax_pose 74, 0x01d4, 0x80ef, 0x5c00
+ax_pose 75, 0x01f4, 0x40ef, 0x5c10
+ax_pose 76, 0x01f0, 0x410f, 0x5c14
+ax_pose 77, 0x41f4, 0x00ff, 0x5c18
+ax_pose 78, 0x01f8, 0x011f, 0x5c1a
+ax_pose_terminator
+sArticunoPose147:
+ax_pose 79, 0x01e4, 0x80ef, 0x5c00
+ax_pose 80, 0x41e9, 0x810f, 0x5c10
+ax_pose 24, 0x01d4, 0x40f9, 0x5c18
+ax_pose_terminator
+sArticunoPose148:
+ax_pose 7, 0x81dd, 0x80ec, 0x5c00
+ax_pose 8, 0x01ed, 0x40fc, 0x5c08
+ax_pose 9, 0x41e5, 0x00fc, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ec, 0x5c0e
+ax_pose 11, 0x01dd, 0x0111, 0x5c0f
+ax_pose 12, 0x01e5, 0x410c, 0x5c10
+ax_pose_terminator
+sArticunoPose149:
+ax_pose 13, 0x01f4, 0x40f9, 0x5c00
+ax_pose 14, 0x01d4, 0x80ef, 0x5c04
+ax_pose 15, 0x81dc, 0x010f, 0x5c14
+ax_pose 16, 0x01dc, 0x0117, 0x5c16
+ax_pose 17, 0x01f4, 0x00f1, 0x5c17
+ax_pose_terminator
+sArticunoPose150:
+ax_pose 18, 0x01e2, 0x80f0, 0x5c00
+ax_pose 19, 0x81ea, 0x40e8, 0x5c10
+ax_pose 20, 0x4202, 0x00f0, 0x5c14
+ax_pose 21, 0x01e2, 0x4110, 0x5c16
+ax_pose_terminator
+sArticunoPose151:
+ax_pose 69, 0x01d4, 0x80f1, 0x5c00
+ax_pose 70, 0x41f4, 0x80f1, 0x5c10
+ax_pose 71, 0x81dc, 0x0111, 0x5c18
+ax_pose 72, 0x81ec, 0x0111, 0x5c1a
+ax_pose_terminator
+sArticunoPose152:
+ax_pose 73, 0x81dd, 0x80ec, 0x5c00
+ax_pose 8, 0x01ed, 0x40fc, 0x5c08
+ax_pose 9, 0x41e5, 0x00fc, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ec, 0x5c0e
+ax_pose 11, 0x01dd, 0x0111, 0x5c0f
+ax_pose 12, 0x01e5, 0x410c, 0x5c10
+ax_pose_terminator
+sArticunoPose153:
+ax_pose 96, 0x81e7, 0x80f4, 0x5c00
+ax_pose 97, 0x01ef, 0x4104, 0x5c08
+ax_pose 98, 0x01f2, 0x0114, 0x5c0c
+ax_pose_terminator
+sArticunoPose154:
+ax_pose 99, 0x81e7, 0x80f4, 0x5c00
+ax_pose 100, 0x01ef, 0x4104, 0x5c08
+ax_pose 101, 0x01f2, 0x0114, 0x5c0c
+ax_pose_terminator
+sArticunoPose155:
+ax_pose 102, 0x01d0, 0x80f0, 0x5c00
+ax_pose 103, 0x81c8, 0x40e8, 0x5c10
+ax_pose 104, 0x81ca, 0x4110, 0x5c14
+ax_pose 105, 0x01c6, 0x00f0, 0x5c18
+ax_pose 106, 0x01cf, 0x0118, 0x5c19
+ax_pose 107, 0x01f0, 0x40f8, 0x5c1a
+ax_pose 108, 0x01f8, 0x0108, 0x5c1e
+ax_pose_terminator
+sArticunoPose156:
+ax_pose 109, 0x81c2, 0xd0ea, 0x5c00
+ax_pose_terminator
+sArticunoPose157:
+ax_pose 110, 0x41ed, 0x90ea, 0x5c00
+ax_pose 111, 0x81d5, 0x10e2, 0x5c08
+ax_pose 112, 0x41fd, 0x10fa, 0x5c0a
+ax_pose 113, 0x01cd, 0x90ea, 0x5c0c
+ax_pose_terminator
+sArticunoPose158:
+ax_pose 114, 0x41ee, 0x90f1, 0x5c00
+ax_pose 115, 0x81de, 0x10e9, 0x5c08
+ax_pose 116, 0x81ce, 0x10e9, 0x5c0a
+ax_pose 117, 0x01fe, 0x1102, 0x5c0c
+ax_pose 118, 0x01ce, 0x90f1, 0x5c0d
+ax_pose_terminator
+sArticunoPose159:
+ax_pose 119, 0x01e0, 0x80f1, 0x5c00
+ax_pose 120, 0x81d0, 0x40e9, 0x5c10
+ax_pose 121, 0x81cb, 0x4111, 0x5c14
+ax_pose 122, 0x01d0, 0x40f1, 0x5c18
+ax_pose 123, 0x01c8, 0x00f1, 0x5c1c
+ax_pose 124, 0x01d0, 0x0119, 0x5c1d
+ax_pose 125, 0x01d8, 0x0109, 0x5c1e
+ax_pose_terminator
+sArticunoPose160:
+ax_pose 114, 0x41ee, 0x80ef, 0x5c00
+ax_pose 115, 0x81de, 0x010f, 0x5c08
+ax_pose 116, 0x81ce, 0x010f, 0x5c0a
+ax_pose 117, 0x01fe, 0x00f6, 0x5c0c
+ax_pose 118, 0x01ce, 0x80ef, 0x5c0d
+ax_pose_terminator
+sArticunoPose161:
+ax_pose 110, 0x41ed, 0x80f6, 0x5c00
+ax_pose 111, 0x81d5, 0x0116, 0x5c08
+ax_pose 112, 0x41fd, 0x00f6, 0x5c0a
+ax_pose 113, 0x01cd, 0x80f6, 0x5c0c
+ax_pose_terminator
+sArticunoPose162:
+ax_pose 109, 0x81c2, 0xc0f6, 0x5c00
+ax_pose_terminator
+sArticunoPose163:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose164:
+ax_pose 1, 0x01d4, 0x80ec, 0x5c00
+ax_pose 2, 0x81d4, 0x410c, 0x5c10
+ax_pose 3, 0x01f4, 0x40f8, 0x5c14
+ax_pose_terminator
+sArticunoPose165:
+ax_pose 4, 0x81ec, 0x80e8, 0x5c00
+ax_pose 5, 0x81dc, 0x80f8, 0x5c08
+ax_pose 6, 0x81ec, 0x8108, 0x5c10
+ax_pose_terminator
+sArticunoPose166:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose167:
+ax_pose 13, 0x01f4, 0x50f7, 0x5c00
+ax_pose 14, 0x01d4, 0x90f1, 0x5c04
+ax_pose 15, 0x81dc, 0x10e9, 0x5c14
+ax_pose 16, 0x01dc, 0x10e1, 0x5c16
+ax_pose 17, 0x01f4, 0x1107, 0x5c17
+ax_pose_terminator
+sArticunoPose168:
+ax_pose 18, 0x01e2, 0x90f0, 0x5c00
+ax_pose 19, 0x81ea, 0x5110, 0x5c10
+ax_pose 20, 0x4202, 0x1100, 0x5c14
+ax_pose 21, 0x01e2, 0x50e0, 0x5c16
+ax_pose_terminator
+sArticunoPose169:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose170:
+ax_pose 25, 0x01e3, 0x90f5, 0x5c00
+ax_pose 26, 0x41eb, 0x90d5, 0x5c10
+ax_pose 27, 0x01d3, 0x50f5, 0x5c18
+ax_pose 28, 0x01cb, 0x10fd, 0x5c1c
+ax_pose_terminator
+sArticunoPose171:
+ax_pose 29, 0x01e8, 0x90f9, 0x5c00
+ax_pose 30, 0x41e8, 0x90d9, 0x5c10
+ax_pose 31, 0x01f8, 0x10f1, 0x5c18
+ax_pose 32, 0x41e0, 0x1101, 0x5c19
+ax_pose 33, 0x01f0, 0x10d1, 0x5c1b
+ax_pose_terminator
+sArticunoPose172:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose173:
+ax_pose 39, 0x01da, 0x90f4, 0x5c00
+ax_pose 40, 0x01d2, 0x10f4, 0x5c10
+ax_pose 41, 0x81da, 0x1114, 0x5c11
+ax_pose 42, 0x01f2, 0x10ec, 0x5c13
+ax_pose 43, 0x41fa, 0x90e6, 0x5c14
+ax_pose_terminator
+sArticunoPose174:
+ax_pose 44, 0x01e0, 0x90f0, 0x5c00
+ax_pose 45, 0x81f0, 0x10e8, 0x5c10
+ax_pose 46, 0x8200, 0x10e8, 0x5c12
+ax_pose 47, 0x81f8, 0x1110, 0x5c14
+ax_pose 48, 0x0200, 0x10f8, 0x5c16
+ax_pose 49, 0x0200, 0x1108, 0x5c17
+ax_pose_terminator
+sArticunoPose175:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose176:
+ax_pose 55, 0x81d5, 0x80e8, 0x5c00
+ax_pose 56, 0x81e5, 0x80f8, 0x5c08
+ax_pose 57, 0x81d5, 0x8108, 0x5c10
+ax_pose 58, 0x0205, 0x00fc, 0x5c18
+ax_pose_terminator
+sArticunoPose177:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose 60, 0x01dc, 0x00fd, 0x5c10
+ax_pose 61, 0x0204, 0x00fc, 0x5c11
+ax_pose_terminator
+sArticunoPose178:
+ax_pose 34, 0x41e3, 0x80e4, 0x5c00
+ax_pose 35, 0x41f3, 0x40e4, 0x5c08
+ax_pose 36, 0x81db, 0x8104, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fc, 0x5c14
+ax_pose 38, 0x4203, 0x010c, 0x5c18
+ax_pose_terminator
+sArticunoPose179:
+ax_pose 39, 0x01da, 0x80ed, 0x5c00
+ax_pose 40, 0x01d2, 0x0105, 0x5c10
+ax_pose 41, 0x81da, 0x00e5, 0x5c11
+ax_pose 42, 0x01f2, 0x010d, 0x5c13
+ax_pose 43, 0x41fa, 0x80fb, 0x5c14
+ax_pose_terminator
+sArticunoPose180:
+ax_pose 44, 0x01e0, 0x80f1, 0x5c00
+ax_pose 45, 0x81f0, 0x0111, 0x5c10
+ax_pose 46, 0x8200, 0x0111, 0x5c12
+ax_pose 47, 0x81f8, 0x00e9, 0x5c14
+ax_pose 48, 0x0200, 0x0101, 0x5c16
+ax_pose 49, 0x0200, 0x00f1, 0x5c17
+ax_pose_terminator
+sArticunoPose181:
+ax_pose 22, 0x01e4, 0x80f0, 0x5c00
+ax_pose 23, 0x41e9, 0x8110, 0x5c10
+ax_pose 24, 0x01d4, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose182:
+ax_pose 25, 0x01e3, 0x80ec, 0x5c00
+ax_pose 26, 0x41eb, 0x810c, 0x5c10
+ax_pose 27, 0x01d3, 0x40fc, 0x5c18
+ax_pose 28, 0x01cb, 0x00fc, 0x5c1c
+ax_pose_terminator
+sArticunoPose183:
+ax_pose 29, 0x01e8, 0x80e8, 0x5c00
+ax_pose 30, 0x41e8, 0x8108, 0x5c10
+ax_pose 31, 0x01f8, 0x0108, 0x5c18
+ax_pose 32, 0x41e0, 0x00f0, 0x5c19
+ax_pose 33, 0x01f0, 0x0128, 0x5c1b
+ax_pose_terminator
+sArticunoPose184:
+ax_pose 7, 0x81dd, 0x80ed, 0x5c00
+ax_pose 8, 0x01ed, 0x40fd, 0x5c08
+ax_pose 9, 0x41e5, 0x00fd, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ed, 0x5c0e
+ax_pose 11, 0x01dd, 0x0112, 0x5c0f
+ax_pose 12, 0x01e5, 0x410d, 0x5c10
+ax_pose_terminator
+sArticunoPose185:
+ax_pose 13, 0x01f4, 0x40fa, 0x5c00
+ax_pose 14, 0x01d4, 0x80f0, 0x5c04
+ax_pose 15, 0x81dc, 0x0110, 0x5c14
+ax_pose 16, 0x01dc, 0x0118, 0x5c16
+ax_pose 17, 0x01f4, 0x00f2, 0x5c17
+ax_pose_terminator
+sArticunoPose186:
+ax_pose 18, 0x01e2, 0x80f1, 0x5c00
+ax_pose 19, 0x81ea, 0x40e9, 0x5c10
+ax_pose 20, 0x4202, 0x00f1, 0x5c14
+ax_pose 21, 0x01e2, 0x4111, 0x5c16
+ax_pose_terminator
+sArticunoPose187:
+ax_pose 62, 0x01de, 0x80e0, 0x5c00
+ax_pose 63, 0x81de, 0x8100, 0x5c10
+ax_pose 64, 0x01de, 0x4110, 0x5c18
+ax_pose 65, 0x41ee, 0x0110, 0x5c1c
+ax_pose 66, 0x01de, 0x0120, 0x5c1e
+ax_pose_terminator
+sArticunoPose188:
+ax_pose 69, 0x01d0, 0x80f0, 0x5c00
+ax_pose 70, 0x41f0, 0x80f0, 0x5c10
+ax_pose 71, 0x81d8, 0x0110, 0x5c18
+ax_pose 72, 0x81e8, 0x0110, 0x5c1a
+ax_pose_terminator
+sArticunoPose189:
+ax_pose 74, 0x01d4, 0x80ee, 0x5c00
+ax_pose 75, 0x01f4, 0x40ee, 0x5c10
+ax_pose 76, 0x01f0, 0x410e, 0x5c14
+ax_pose 77, 0x41f4, 0x00fe, 0x5c18
+ax_pose 78, 0x01f8, 0x011e, 0x5c1a
+ax_pose_terminator
+sArticunoPose190:
+ax_pose 81, 0x01d1, 0x80ea, 0x5c00
+ax_pose 82, 0x01f1, 0x40f2, 0x5c10
+ax_pose 83, 0x01f1, 0x4102, 0x5c14
+ax_pose 84, 0x81d1, 0x010a, 0x5c18
+ax_pose 85, 0x01e1, 0x010a, 0x5c1a
+ax_pose 86, 0x4201, 0x010a, 0x5c1b
+ax_pose_terminator
+sArticunoPose191:
+ax_pose 88, 0x41d7, 0x80e0, 0x5c00
+ax_pose 89, 0x41d7, 0x8100, 0x5c08
+ax_pose 90, 0x41e7, 0x40e8, 0x5c10
+ax_pose 91, 0x41e7, 0x0108, 0x5c14
+ax_pose 92, 0x41ef, 0x40f4, 0x5c16
+ax_pose 93, 0x41f7, 0x40f4, 0x5c1a
+ax_pose 94, 0x01ff, 0x00fc, 0x5c1e
+ax_pose 95, 0x0207, 0x00fc, 0x5c1f
+ax_pose_terminator
+sArticunoPose192:
+ax_pose 81, 0x01d1, 0x90f7, 0x5c00
+ax_pose 82, 0x01f1, 0x50ff, 0x5c10
+ax_pose 83, 0x01f1, 0x50ef, 0x5c14
+ax_pose 84, 0x81d1, 0x10ef, 0x5c18
+ax_pose 85, 0x01e1, 0x10ef, 0x5c1a
+ax_pose 86, 0x4201, 0x10e7, 0x5c1b
+ax_pose_terminator
+sArticunoPose193:
+ax_pose 74, 0x01d4, 0x90f3, 0x5c00
+ax_pose 75, 0x01f4, 0x5103, 0x5c10
+ax_pose 76, 0x01f0, 0x50e3, 0x5c14
+ax_pose 77, 0x41f4, 0x10f3, 0x5c18
+ax_pose 78, 0x01f8, 0x10db, 0x5c1a
+ax_pose_terminator
+sArticunoPose194:
+ax_pose 69, 0x01d0, 0x90f0, 0x5c00
+ax_pose 70, 0x41f0, 0x90f0, 0x5c10
+ax_pose 71, 0x81d8, 0x10e8, 0x5c18
+ax_pose 72, 0x81e8, 0x10e8, 0x5c1a
+ax_pose_terminator
+sArticunoPose195:
+ax_pose 62, 0x01de, 0x80e0, 0x5c00
+ax_pose 63, 0x81de, 0x8100, 0x5c10
+ax_pose 64, 0x01de, 0x4110, 0x5c18
+ax_pose 65, 0x41ee, 0x0110, 0x5c1c
+ax_pose 66, 0x01de, 0x0120, 0x5c1e
+ax_pose_terminator
+sArticunoPose196:
+ax_pose 69, 0x01d0, 0x90f0, 0x5c00
+ax_pose 70, 0x41f0, 0x90f0, 0x5c10
+ax_pose 71, 0x81d8, 0x10e8, 0x5c18
+ax_pose 72, 0x81e8, 0x10e8, 0x5c1a
+ax_pose_terminator
+sArticunoPose197:
+ax_pose 74, 0x01d4, 0x90f3, 0x5c00
+ax_pose 75, 0x01f4, 0x5103, 0x5c10
+ax_pose 76, 0x01f0, 0x50e3, 0x5c14
+ax_pose 77, 0x41f4, 0x10f3, 0x5c18
+ax_pose 78, 0x01f8, 0x10db, 0x5c1a
+ax_pose_terminator
+sArticunoPose198:
+ax_pose 81, 0x01d1, 0x90f7, 0x5c00
+ax_pose 82, 0x01f1, 0x50ff, 0x5c10
+ax_pose 83, 0x01f1, 0x50ef, 0x5c14
+ax_pose 84, 0x81d1, 0x10ef, 0x5c18
+ax_pose 85, 0x01e1, 0x10ef, 0x5c1a
+ax_pose 86, 0x4201, 0x10e7, 0x5c1b
+ax_pose_terminator
+sArticunoPose199:
+ax_pose 88, 0x41d7, 0x80e0, 0x5c00
+ax_pose 89, 0x41d7, 0x8100, 0x5c08
+ax_pose 90, 0x41e7, 0x40e8, 0x5c10
+ax_pose 91, 0x41e7, 0x0108, 0x5c14
+ax_pose 92, 0x41ef, 0x40f4, 0x5c16
+ax_pose 93, 0x41f7, 0x40f4, 0x5c1a
+ax_pose 94, 0x01ff, 0x00fc, 0x5c1e
+ax_pose 95, 0x0207, 0x00fc, 0x5c1f
+ax_pose_terminator
+sArticunoPose200:
+ax_pose 81, 0x01d1, 0x80ea, 0x5c00
+ax_pose 82, 0x01f1, 0x40f2, 0x5c10
+ax_pose 83, 0x01f1, 0x4102, 0x5c14
+ax_pose 84, 0x81d1, 0x010a, 0x5c18
+ax_pose 85, 0x01e1, 0x010a, 0x5c1a
+ax_pose 86, 0x4201, 0x010a, 0x5c1b
+ax_pose_terminator
+sArticunoPose201:
+ax_pose 74, 0x01d4, 0x80ee, 0x5c00
+ax_pose 75, 0x01f4, 0x40ee, 0x5c10
+ax_pose 76, 0x01f0, 0x410e, 0x5c14
+ax_pose 77, 0x41f4, 0x00fe, 0x5c18
+ax_pose 78, 0x01f8, 0x011e, 0x5c1a
+ax_pose_terminator
+sArticunoPose202:
+ax_pose 69, 0x01d0, 0x80f0, 0x5c00
+ax_pose 70, 0x41f0, 0x80f0, 0x5c10
+ax_pose 71, 0x81d8, 0x0110, 0x5c18
+ax_pose 72, 0x81e8, 0x0110, 0x5c1a
+ax_pose_terminator
+sArticunoPose203:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose204:
+ax_pose 1, 0x01d4, 0x80ec, 0x5c00
+ax_pose 2, 0x81d4, 0x410c, 0x5c10
+ax_pose 3, 0x01f4, 0x40f8, 0x5c14
+ax_pose_terminator
+sArticunoPose205:
+ax_pose 4, 0x81ec, 0x80e8, 0x5c00
+ax_pose 5, 0x81dc, 0x80f8, 0x5c08
+ax_pose 6, 0x81ec, 0x8108, 0x5c10
+ax_pose_terminator
+sArticunoPose206:
+ax_pose 62, 0x01dc, 0x80e0, 0x5c00
+ax_pose 63, 0x81dc, 0x8100, 0x5c10
+ax_pose 64, 0x01dc, 0x4110, 0x5c18
+ax_pose 65, 0x41ec, 0x0110, 0x5c1c
+ax_pose 66, 0x01dc, 0x0120, 0x5c1e
+ax_pose_terminator
+sArticunoPose207:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose208:
+ax_pose 13, 0x01f4, 0x50f7, 0x5c00
+ax_pose 14, 0x01d4, 0x90f1, 0x5c04
+ax_pose 15, 0x81dc, 0x10e9, 0x5c14
+ax_pose 16, 0x01dc, 0x10e1, 0x5c16
+ax_pose 17, 0x01f4, 0x1107, 0x5c17
+ax_pose_terminator
+sArticunoPose209:
+ax_pose 18, 0x01e2, 0x90f0, 0x5c00
+ax_pose 19, 0x81ea, 0x5110, 0x5c10
+ax_pose 20, 0x4202, 0x1100, 0x5c14
+ax_pose 21, 0x01e2, 0x50e0, 0x5c16
+ax_pose_terminator
+sArticunoPose210:
+ax_pose 69, 0x01d4, 0x90ef, 0x5c00
+ax_pose 70, 0x41f4, 0x90ef, 0x5c10
+ax_pose 71, 0x81dc, 0x10e7, 0x5c18
+ax_pose 72, 0x81ec, 0x10e7, 0x5c1a
+ax_pose_terminator
+sArticunoPose211:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose212:
+ax_pose 25, 0x01e3, 0x90f5, 0x5c00
+ax_pose 26, 0x41eb, 0x90d5, 0x5c10
+ax_pose 27, 0x01d3, 0x50f5, 0x5c18
+ax_pose 28, 0x01cb, 0x10fd, 0x5c1c
+ax_pose_terminator
+sArticunoPose213:
+ax_pose 29, 0x01e8, 0x90f9, 0x5c00
+ax_pose 30, 0x41e8, 0x90d9, 0x5c10
+ax_pose 31, 0x01f8, 0x10f1, 0x5c18
+ax_pose 32, 0x41e0, 0x1101, 0x5c19
+ax_pose 33, 0x01f0, 0x10d1, 0x5c1b
+ax_pose_terminator
+sArticunoPose214:
+ax_pose 74, 0x01d4, 0x90f1, 0x5c00
+ax_pose 75, 0x01f4, 0x5101, 0x5c10
+ax_pose 76, 0x01f0, 0x50e1, 0x5c14
+ax_pose 77, 0x41f4, 0x10f1, 0x5c18
+ax_pose 78, 0x01f8, 0x10d9, 0x5c1a
+ax_pose_terminator
+sArticunoPose215:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose216:
+ax_pose 39, 0x01da, 0x90f4, 0x5c00
+ax_pose 40, 0x01d2, 0x10f4, 0x5c10
+ax_pose 41, 0x81da, 0x1114, 0x5c11
+ax_pose 42, 0x01f2, 0x10ec, 0x5c13
+ax_pose 43, 0x41fa, 0x90e6, 0x5c14
+ax_pose_terminator
+sArticunoPose217:
+ax_pose 44, 0x01e0, 0x90f0, 0x5c00
+ax_pose 45, 0x81f0, 0x10e8, 0x5c10
+ax_pose 46, 0x8200, 0x10e8, 0x5c12
+ax_pose 47, 0x81f8, 0x1110, 0x5c14
+ax_pose 48, 0x0200, 0x10f8, 0x5c16
+ax_pose 50, 0x0200, 0x10f0, 0x5c17
+ax_pose 49, 0x0200, 0x1108, 0x5c18
+ax_pose_terminator
+sArticunoPose218:
+ax_pose 81, 0x01d4, 0x90f9, 0x5c00
+ax_pose 82, 0x01f4, 0x5101, 0x5c10
+ax_pose 83, 0x01f4, 0x50f1, 0x5c14
+ax_pose 84, 0x81d4, 0x10f1, 0x5c18
+ax_pose 85, 0x01e4, 0x10f1, 0x5c1a
+ax_pose 86, 0x4204, 0x10e9, 0x5c1b
+ax_pose_terminator
+sArticunoPose219:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose220:
+ax_pose 55, 0x81d5, 0x80e8, 0x5c00
+ax_pose 56, 0x81e5, 0x80f8, 0x5c08
+ax_pose 57, 0x81d5, 0x8108, 0x5c10
+ax_pose 58, 0x0205, 0x00fc, 0x5c18
+ax_pose_terminator
+sArticunoPose221:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose 60, 0x01dc, 0x00fd, 0x5c10
+ax_pose 61, 0x0204, 0x00fc, 0x5c11
+ax_pose_terminator
+sArticunoPose222:
+ax_pose 88, 0x41da, 0x80e0, 0x5c00
+ax_pose 89, 0x41da, 0x8100, 0x5c08
+ax_pose 90, 0x41ea, 0x40e8, 0x5c10
+ax_pose 91, 0x41ea, 0x0108, 0x5c14
+ax_pose 92, 0x41f2, 0x40f4, 0x5c16
+ax_pose 93, 0x41fa, 0x40f4, 0x5c1a
+ax_pose 94, 0x0202, 0x00fc, 0x5c1e
+ax_pose 95, 0x020a, 0x00fc, 0x5c1f
+ax_pose_terminator
+sArticunoPose223:
+ax_pose 34, 0x41e3, 0x80e4, 0x5c00
+ax_pose 35, 0x41f3, 0x40e4, 0x5c08
+ax_pose 36, 0x81db, 0x8104, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fc, 0x5c14
+ax_pose 38, 0x4203, 0x010c, 0x5c18
+ax_pose_terminator
+sArticunoPose224:
+ax_pose 39, 0x01da, 0x80ed, 0x5c00
+ax_pose 40, 0x01d2, 0x0105, 0x5c10
+ax_pose 41, 0x81da, 0x00e5, 0x5c11
+ax_pose 42, 0x01f2, 0x010d, 0x5c13
+ax_pose 43, 0x41fa, 0x80fb, 0x5c14
+ax_pose_terminator
+sArticunoPose225:
+ax_pose 44, 0x01e0, 0x80f1, 0x5c00
+ax_pose 45, 0x81f0, 0x0111, 0x5c10
+ax_pose 46, 0x8200, 0x0111, 0x5c12
+ax_pose 47, 0x81f8, 0x00e9, 0x5c14
+ax_pose 48, 0x0200, 0x0101, 0x5c16
+ax_pose 50, 0x0200, 0x0109, 0x5c17
+ax_pose 49, 0x0200, 0x00f1, 0x5c18
+ax_pose_terminator
+sArticunoPose226:
+ax_pose 81, 0x01d4, 0x80e8, 0x5c00
+ax_pose 82, 0x01f4, 0x40f0, 0x5c10
+ax_pose 83, 0x01f4, 0x4100, 0x5c14
+ax_pose 84, 0x81d4, 0x0108, 0x5c18
+ax_pose 85, 0x01e4, 0x0108, 0x5c1a
+ax_pose 86, 0x4204, 0x0108, 0x5c1b
+ax_pose_terminator
+sArticunoPose227:
+ax_pose 22, 0x01e4, 0x80f0, 0x5c00
+ax_pose 23, 0x41e9, 0x8110, 0x5c10
+ax_pose 24, 0x01d4, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose228:
+ax_pose 25, 0x01e3, 0x80ec, 0x5c00
+ax_pose 26, 0x41eb, 0x810c, 0x5c10
+ax_pose 27, 0x01d3, 0x40fc, 0x5c18
+ax_pose 28, 0x01cb, 0x00fc, 0x5c1c
+ax_pose_terminator
+sArticunoPose229:
+ax_pose 29, 0x01e8, 0x80e8, 0x5c00
+ax_pose 30, 0x41e8, 0x8108, 0x5c10
+ax_pose 31, 0x01f8, 0x0108, 0x5c18
+ax_pose 32, 0x41e0, 0x00f0, 0x5c19
+ax_pose 33, 0x01f0, 0x0128, 0x5c1b
+ax_pose_terminator
+sArticunoPose230:
+ax_pose 74, 0x01d4, 0x80f0, 0x5c00
+ax_pose 75, 0x01f4, 0x40f0, 0x5c10
+ax_pose 76, 0x01f0, 0x4110, 0x5c14
+ax_pose 77, 0x41f4, 0x0100, 0x5c18
+ax_pose 78, 0x01f8, 0x0120, 0x5c1a
+ax_pose_terminator
+sArticunoPose231:
+ax_pose 7, 0x81dd, 0x80ed, 0x5c00
+ax_pose 8, 0x01ed, 0x40fd, 0x5c08
+ax_pose 9, 0x41e5, 0x00fd, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ed, 0x5c0e
+ax_pose 11, 0x01dd, 0x0112, 0x5c0f
+ax_pose 12, 0x01e5, 0x410d, 0x5c10
+ax_pose_terminator
+sArticunoPose232:
+ax_pose 13, 0x01f4, 0x40fa, 0x5c00
+ax_pose 14, 0x01d4, 0x80f0, 0x5c04
+ax_pose 15, 0x81dc, 0x0110, 0x5c14
+ax_pose 16, 0x01dc, 0x0118, 0x5c16
+ax_pose 17, 0x01f4, 0x00f2, 0x5c17
+ax_pose_terminator
+sArticunoPose233:
+ax_pose 18, 0x01e2, 0x80f1, 0x5c00
+ax_pose 19, 0x81ea, 0x40e9, 0x5c10
+ax_pose 20, 0x4202, 0x00f1, 0x5c14
+ax_pose 21, 0x01e2, 0x4111, 0x5c16
+ax_pose_terminator
+sArticunoPose234:
+ax_pose 69, 0x01d4, 0x80f0, 0x5c00
+ax_pose 70, 0x41f4, 0x80f0, 0x5c10
+ax_pose 71, 0x81dc, 0x0110, 0x5c18
+ax_pose 72, 0x81ec, 0x0110, 0x5c1a
+ax_pose_terminator
+sArticunoPose235:
+ax_pose 62, 0x01de, 0x80e0, 0x5c00
+ax_pose 63, 0x81de, 0x8100, 0x5c10
+ax_pose 64, 0x01de, 0x4110, 0x5c18
+ax_pose 65, 0x41ee, 0x0110, 0x5c1c
+ax_pose 66, 0x01de, 0x0120, 0x5c1e
+ax_pose_terminator
+sArticunoPose236:
+ax_pose 69, 0x01d0, 0x80f0, 0x5c00
+ax_pose 70, 0x41f0, 0x80f0, 0x5c10
+ax_pose 71, 0x81d8, 0x0110, 0x5c18
+ax_pose 72, 0x81e8, 0x0110, 0x5c1a
+ax_pose_terminator
+sArticunoPose237:
+ax_pose 74, 0x01d4, 0x80ee, 0x5c00
+ax_pose 75, 0x01f4, 0x40ee, 0x5c10
+ax_pose 76, 0x01f0, 0x410e, 0x5c14
+ax_pose 77, 0x41f4, 0x00fe, 0x5c18
+ax_pose 78, 0x01f8, 0x011e, 0x5c1a
+ax_pose_terminator
+sArticunoPose238:
+ax_pose 81, 0x01d1, 0x80ea, 0x5c00
+ax_pose 82, 0x01f1, 0x40f2, 0x5c10
+ax_pose 83, 0x01f1, 0x4102, 0x5c14
+ax_pose 84, 0x81d1, 0x010a, 0x5c18
+ax_pose 85, 0x01e1, 0x010a, 0x5c1a
+ax_pose 86, 0x4201, 0x010a, 0x5c1b
+ax_pose_terminator
+sArticunoPose239:
+ax_pose 88, 0x41d7, 0x80e0, 0x5c00
+ax_pose 89, 0x41d7, 0x8100, 0x5c08
+ax_pose 90, 0x41e7, 0x40e8, 0x5c10
+ax_pose 91, 0x41e7, 0x0108, 0x5c14
+ax_pose 92, 0x41ef, 0x40f4, 0x5c16
+ax_pose 93, 0x41f7, 0x40f4, 0x5c1a
+ax_pose 94, 0x01ff, 0x00fc, 0x5c1e
+ax_pose 95, 0x0207, 0x00fc, 0x5c1f
+ax_pose_terminator
+sArticunoPose240:
+ax_pose 81, 0x01d1, 0x90f7, 0x5c00
+ax_pose 82, 0x01f1, 0x50ff, 0x5c10
+ax_pose 83, 0x01f1, 0x50ef, 0x5c14
+ax_pose 84, 0x81d1, 0x10ef, 0x5c18
+ax_pose 85, 0x01e1, 0x10ef, 0x5c1a
+ax_pose 86, 0x4201, 0x10e7, 0x5c1b
+ax_pose_terminator
+sArticunoPose241:
+ax_pose 74, 0x01d4, 0x90f3, 0x5c00
+ax_pose 75, 0x01f4, 0x5103, 0x5c10
+ax_pose 76, 0x01f0, 0x50e3, 0x5c14
+ax_pose 77, 0x41f4, 0x10f3, 0x5c18
+ax_pose 78, 0x01f8, 0x10db, 0x5c1a
+ax_pose_terminator
+sArticunoPose242:
+ax_pose 69, 0x01d0, 0x90f0, 0x5c00
+ax_pose 70, 0x41f0, 0x90f0, 0x5c10
+ax_pose 71, 0x81d8, 0x10e8, 0x5c18
+ax_pose 72, 0x81e8, 0x10e8, 0x5c1a
+ax_pose_terminator
+sArticunoPose243:
+ax_pose 0, 0x41dc, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose244:
+ax_pose 7, 0x81dd, 0x80ed, 0x5c00
+ax_pose 8, 0x01ed, 0x40fd, 0x5c08
+ax_pose 9, 0x41e5, 0x00fd, 0x5c0c
+ax_pose 10, 0x01d5, 0x00ed, 0x5c0e
+ax_pose 11, 0x01dd, 0x0112, 0x5c0f
+ax_pose 12, 0x01e5, 0x410d, 0x5c10
+ax_pose_terminator
+sArticunoPose245:
+ax_pose 22, 0x01e4, 0x80f0, 0x5c00
+ax_pose 23, 0x41e9, 0x8110, 0x5c10
+ax_pose 24, 0x01d4, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose246:
+ax_pose 34, 0x41e3, 0x80e4, 0x5c00
+ax_pose 35, 0x41f3, 0x40e4, 0x5c08
+ax_pose 36, 0x81db, 0x8104, 0x5c0c
+ax_pose 37, 0x41fb, 0x40fc, 0x5c14
+ax_pose 38, 0x4203, 0x010c, 0x5c18
+ax_pose_terminator
+sArticunoPose247:
+ax_pose 51, 0x01e0, 0x40e0, 0x5c00
+ax_pose 52, 0x01e0, 0x4110, 0x5c04
+ax_pose 53, 0x01e0, 0x80f0, 0x5c08
+ax_pose 54, 0x0200, 0x40f8, 0x5c18
+ax_pose_terminator
+sArticunoPose248:
+ax_pose 34, 0x41e3, 0x90fd, 0x5c00
+ax_pose 35, 0x41f3, 0x50fd, 0x5c08
+ax_pose 36, 0x81db, 0x90ed, 0x5c0c
+ax_pose 37, 0x41fb, 0x50e5, 0x5c14
+ax_pose 38, 0x4203, 0x10e5, 0x5c18
+ax_pose_terminator
+sArticunoPose249:
+ax_pose 22, 0x01e4, 0x90f1, 0x5c00
+ax_pose 23, 0x41e9, 0x90d1, 0x5c10
+ax_pose 24, 0x01d4, 0x50f9, 0x5c18
+ax_pose_terminator
+sArticunoPose250:
+ax_pose 7, 0x81dd, 0x9104, 0x5c00
+ax_pose 8, 0x01ed, 0x50f4, 0x5c08
+ax_pose 9, 0x41e5, 0x10f4, 0x5c0c
+ax_pose 10, 0x01d5, 0x110c, 0x5c0e
+ax_pose 11, 0x01dd, 0x10e7, 0x5c0f
+ax_pose 12, 0x01e5, 0x50e4, 0x5c10
+ax_pose_terminator
+sArticunoPose251:
+ax_pose 126, 0x41ec, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose252:
+ax_pose 127, 0x41ec, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose253:
+ax_pose 126, 0x41ec, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose254:
+ax_pose 127, 0x41ec, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose255:
+ax_pose 128, 0x41e7, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose256:
+ax_pose 129, 0x41e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose257:
+ax_pose 130, 0x81da, 0x0118, 0x5c00
+ax_pose 131, 0x81da, 0x8108, 0x5c02
+ax_pose 132, 0x01da, 0x80e8, 0x5c0a
+ax_pose 133, 0x41fa, 0x00f8, 0x5c1a
+ax_pose_terminator
+sArticunoPose258:
+ax_pose 130, 0x81da, 0x0118, 0x5c00
+ax_pose 131, 0x81da, 0x8108, 0x5c02
+ax_pose 132, 0x01da, 0x80e8, 0x5c0a
+ax_pose 133, 0x41fa, 0x00f8, 0x5c1a
+ax_pose_terminator
+sArticunoPose259:
+ax_pose 134, 0x41e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose260:
+ax_pose 135, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sArticunoPose261:
+ax_pose 136, 0x81e2, 0x80f5, 0x5c00
+ax_pose 137, 0x81e2, 0x4105, 0x5c08
+ax_pose_terminator
+sArticunoPose262:
+ax_pose 130, 0x81da, 0x0118, 0x5c00
+ax_pose 131, 0x81da, 0x8108, 0x5c02
+ax_pose 132, 0x01da, 0x80e8, 0x5c0a
+ax_pose 133, 0x41fa, 0x00f8, 0x5c1a
+ax_pose_terminator
+sArticunoPose263:
+ax_pose 134, 0x41e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sArticunoPose264:
+ax_pose 135, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sArticunoPose265:
+ax_pose 136, 0x81e2, 0x80f5, 0x5c00
+ax_pose 137, 0x81e2, 0x4105, 0x5c08
+ax_pose_terminator
+.align 2
+sArticunoAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 6, 0, 6,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 1, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 0, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 17, 0, 17,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim_terminator
+sArticunoAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 6, 6, 6, 6,
+ax_anim 1, 0, 28, 9, 10, 9, 10,
+ax_anim 2, 0, 28, 19, 23, 19, 23,
+ax_anim 2, 1, 28, 20, 23, 20, 23,
+ax_anim 2, 0, 28, 19, 23, 19, 23,
+ax_anim 2, 0, 28, 20, 23, 20, 23,
+ax_anim 2, 0, 27, 9, 10, 9, 10,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sArticunoAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 3, 1, 3, 0,
+ax_anim 1, 0, 31, 6, 1, 6, 0,
+ax_anim 2, 0, 31, 12, 2, 12, 0,
+ax_anim 2, 1, 31, 13, 2, 13, 0,
+ax_anim 2, 0, 31, 12, 2, 12, 0,
+ax_anim 2, 0, 31, 13, 2, 13, 0,
+ax_anim 2, 0, 30, 6, 1, 6, 0,
+ax_anim 2, 0, 30, 3, 1, 3, 0,
+ax_anim_terminator
+sArticunoAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 34, 8, -8, 8, -8,
+ax_anim 2, 0, 34, 14, -14, 14, -14,
+ax_anim 2, 1, 34, 15, -13, 15, -13,
+ax_anim 2, 0, 34, 14, -14, 14, -14,
+ax_anim 2, 0, 34, 15, -13, 15, -13,
+ax_anim 2, 0, 33, 8, -8, 8, -8,
+ax_anim 2, 0, 33, 4, -4, 4, -4,
+ax_anim_terminator
+sArticunoAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -8, 0, -8,
+ax_anim 2, 0, 37, 0, -14, 0, -14,
+ax_anim 2, 1, 37, 0, -13, 0, -13,
+ax_anim 2, 0, 37, 0, -14, 0, -14,
+ax_anim 2, 0, 37, 0, -13, 0, -13,
+ax_anim 2, 0, 36, 0, -8, 0, -8,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sArticunoAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 40, -8, -8, -8, -8,
+ax_anim 2, 0, 40, -14, -14, -14, -14,
+ax_anim 2, 1, 40, -15, -13, -15, -13,
+ax_anim 2, 0, 40, -14, -14, -14, -14,
+ax_anim 2, 0, 40, -15, -13, -15, -13,
+ax_anim 2, 0, 39, -8, -8, -8, -8,
+ax_anim 2, 0, 39, -4, -4, -4, -4,
+ax_anim_terminator
+sArticunoAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -3, 1, -3, 0,
+ax_anim 1, 0, 43, -6, 1, -6, 0,
+ax_anim 2, 0, 43, -12, 2, -12, 0,
+ax_anim 2, 1, 43, -13, 2, -13, 0,
+ax_anim 2, 0, 43, -12, 2, -12, 0,
+ax_anim 2, 0, 43, -13, 2, -13, 0,
+ax_anim 2, 0, 42, -6, 1, -6, 0,
+ax_anim 2, 0, 42, -3, 1, -3, 0,
+ax_anim_terminator
+sArticunoAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -6, 6, -6, 6,
+ax_anim 1, 0, 46, -9, 10, -9, 10,
+ax_anim 2, 0, 46, -19, 23, -19, 23,
+ax_anim 2, 1, 46, -20, 23, -20, 23,
+ax_anim 2, 0, 46, -19, 23, -19, 23,
+ax_anim 2, 0, 46, -20, 23, -20, 23,
+ax_anim 2, 0, 45, -9, 10, -9, 10,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sArticunoAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 6, 0, 6,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 23, 0, 23,
+ax_anim 2, 1, 49, 1, 23, 1, 23,
+ax_anim 2, 0, 49, 0, 23, 0, 23,
+ax_anim 2, 0, 49, 1, 23, 1, 23,
+ax_anim 2, 0, 48, 0, 17, 0, 17,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim_terminator
+sArticunoAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 6, 6, 6, 6,
+ax_anim 1, 0, 52, 9, 10, 9, 10,
+ax_anim 2, 0, 52, 19, 23, 19, 23,
+ax_anim 2, 1, 52, 20, 23, 20, 23,
+ax_anim 2, 0, 52, 19, 23, 19, 23,
+ax_anim 2, 0, 52, 20, 23, 20, 23,
+ax_anim 2, 0, 51, 9, 10, 9, 10,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sArticunoAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 3, 1, 3, 0,
+ax_anim 1, 0, 55, 6, 1, 6, 0,
+ax_anim 2, 0, 55, 12, 2, 12, 0,
+ax_anim 2, 1, 55, 13, 2, 13, 0,
+ax_anim 2, 0, 55, 12, 2, 12, 0,
+ax_anim 2, 0, 55, 13, 2, 13, 0,
+ax_anim 2, 0, 54, 6, 1, 6, 0,
+ax_anim 2, 0, 54, 3, 1, 3, 0,
+ax_anim_terminator
+sArticunoAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 4, -4, 4, -4,
+ax_anim 1, 0, 58, 8, -8, 8, -8,
+ax_anim 2, 0, 58, 14, -14, 14, -14,
+ax_anim 2, 1, 58, 15, -13, 15, -13,
+ax_anim 2, 0, 58, 14, -14, 14, -14,
+ax_anim 2, 0, 58, 15, -13, 15, -13,
+ax_anim 2, 0, 57, 8, -8, 8, -8,
+ax_anim 2, 0, 57, 4, -4, 4, -4,
+ax_anim_terminator
+sArticunoAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -8, 0, -8,
+ax_anim 2, 0, 61, 0, -14, 0, -14,
+ax_anim 2, 1, 61, 0, -13, 0, -13,
+ax_anim 2, 0, 61, 0, -14, 0, -14,
+ax_anim 2, 0, 61, 0, -13, 0, -13,
+ax_anim 2, 0, 60, 0, -8, 0, -8,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sArticunoAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 64, -4, -4, -4, -4,
+ax_anim 1, 0, 64, -8, -8, -8, -8,
+ax_anim 2, 0, 64, -14, -14, -14, -14,
+ax_anim 2, 1, 64, -15, -13, -15, -13,
+ax_anim 2, 0, 64, -14, -14, -14, -14,
+ax_anim 2, 0, 64, -15, -13, -15, -13,
+ax_anim 2, 0, 63, -8, -8, -8, -8,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim_terminator
+sArticunoAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -3, 1, -3, 0,
+ax_anim 1, 0, 67, -6, 1, -6, 0,
+ax_anim 2, 0, 67, -12, 2, -12, 0,
+ax_anim 2, 1, 67, -13, 2, -13, 0,
+ax_anim 2, 0, 67, -12, 2, -12, 0,
+ax_anim 2, 0, 67, -13, 2, -13, 0,
+ax_anim 2, 0, 66, -6, 1, -6, 0,
+ax_anim 2, 0, 66, -3, 1, -3, 0,
+ax_anim_terminator
+sArticunoAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -6, 6, -6, 6,
+ax_anim 1, 0, 70, -9, 10, -9, 10,
+ax_anim 2, 0, 70, -19, 23, -19, 23,
+ax_anim 2, 1, 70, -20, 23, -20, 23,
+ax_anim 2, 0, 70, -19, 23, -19, 23,
+ax_anim 2, 0, 70, -20, 23, -20, 23,
+ax_anim 2, 0, 69, -9, 10, -9, 10,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sArticunoAnims_4_1:
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 1, 0, 72, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, -1,
+ax_anim 1, 0, 72, 0, -2, 0, -1,
+ax_anim 2, 0, 73, 0, -4, 0, -1,
+ax_anim 1, 0, 72, 0, -3, 0, -2,
+ax_anim 2, 0, 74, 0, -2, 0, -2,
+ax_anim 1, 0, 74, 0, -4, 0, -3,
+ax_anim 2, 0, 74, 0, -6, 0, -3,
+ax_anim 1, 0, 72, 0, -9, 0, -4,
+ax_anim 2, 0, 75, 0, -5, 0, -4,
+ax_anim 6, 2, 75, 0, -6, 0, -5,
+ax_anim 2, 0, 76, 0, -2, 0, -2,
+ax_anim 2, 1, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 76, -1, 2, -1, 2,
+ax_anim 2, 0, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 76, -1, 2, -1, 2,
+ax_anim 2, 0, 76, 0, 2, 0, 2,
+ax_anim_terminator
+sArticunoAnims_4_2:
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 1, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 79, -4, -1, -1, -1,
+ax_anim 1, 0, 77, -4, -4, -2, -2,
+ax_anim 2, 0, 78, -6, -8, -2, -2,
+ax_anim 1, 0, 77, -5, -5, -2, -2,
+ax_anim 2, 0, 79, -6, -5, -3, -3,
+ax_anim 1, 0, 79, -7, -6, -3, -3,
+ax_anim 2, 0, 79, -8, -7, -4, -4,
+ax_anim 1, 0, 77, -8, -9, -4, -4,
+ax_anim 2, 0, 80, -7, -10, -4, -4,
+ax_anim 6, 2, 80, -8, -11, -5, -5,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 1, 81, 4, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 3, 1, 2,
+ax_anim 2, 0, 81, 4, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 3, 1, 2,
+ax_anim 2, 0, 81, 4, 2, 2, 2,
+ax_anim_terminator
+sArticunoAnims_4_3:
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -2, -1, 0,
+ax_anim 1, 0, 82, -1, -1, -1, 0,
+ax_anim 2, 0, 84, -3, -1, -3, 0,
+ax_anim 1, 0, 82, -4, -4, -4, 0,
+ax_anim 2, 0, 83, -6, -8, -6, 0,
+ax_anim 1, 0, 82, -5, -5, -5, 0,
+ax_anim 2, 0, 84, -7, -5, -7, 0,
+ax_anim 1, 0, 84, -8, -6, -8, 0,
+ax_anim 2, 0, 84, -9, -7, -9, 0,
+ax_anim 1, 0, 82, -10, -10, -10, 0,
+ax_anim 2, 0, 85, -7, -7, -7, 0,
+ax_anim 6, 2, 85, -8, -8, -8, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 2, 1, 86, 4, -2, 4, 0,
+ax_anim 2, 0, 86, 4, -1, 4, 0,
+ax_anim 2, 0, 86, 4, -2, 4, -1,
+ax_anim 2, 0, 86, 4, -1, 4, 0,
+ax_anim 2, 0, 86, 4, -2, 4, -1,
+ax_anim_terminator
+sArticunoAnims_4_4:
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -3, -1, 1,
+ax_anim 1, 0, 87, -1, -1, -1, 1,
+ax_anim 2, 0, 89, -4, -1, -1, 1,
+ax_anim 1, 0, 87, -5, -4, -2, 2,
+ax_anim 2, 0, 88, -7, -8, -2, 2,
+ax_anim 1, 0, 87, -7, -5, -2, 2,
+ax_anim 2, 0, 89, -8, -4, -3, 3,
+ax_anim 1, 0, 89, -9, -5, -3, 3,
+ax_anim 2, 0, 89, -10, -6, -4, 4,
+ax_anim 1, 0, 87, -11, -9, -4, 4,
+ax_anim 2, 0, 90, -12, -8, -4, 4,
+ax_anim 6, 2, 90, -13, -9, -5, 5,
+ax_anim 2, 0, 91, -2, -4, 0, 0,
+ax_anim 2, 1, 91, 4, -2, 4, -4,
+ax_anim 2, 0, 91, 3, -3, 3, -4,
+ax_anim 2, 0, 91, 4, -2, 4, -4,
+ax_anim 2, 0, 91, 3, -3, 3, -4,
+ax_anim 2, 0, 91, 4, -2, 4, -4,
+ax_anim_terminator
+sArticunoAnims_4_5:
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 1,
+ax_anim 1, 0, 92, 0, -1, 0, 1,
+ax_anim 2, 0, 94, 0, 0, 0, 2,
+ax_anim 1, 0, 92, 0, -3, 0, 2,
+ax_anim 2, 0, 93, 0, -5, 0, 2,
+ax_anim 1, 0, 92, 0, -3, 0, 2,
+ax_anim 2, 0, 94, 0, -2, 0, 3,
+ax_anim 1, 0, 94, 0, -1, 0, 3,
+ax_anim 2, 0, 94, 0, 0, 0, 4,
+ax_anim 1, 0, 92, 0, -3, 0, 4,
+ax_anim 2, 0, 95, 0, -2, 0, 4,
+ax_anim 6, 2, 95, 0, -1, 0, 5,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 1, 92, 0, -8, 0, -6,
+ax_anim 2, 0, 92, -1, -8, 0, -6,
+ax_anim 2, 0, 92, 0, -8, 0, -6,
+ax_anim 2, 0, 92, -1, -8, 0, -6,
+ax_anim 2, 0, 92, 0, -8, 0, -6,
+ax_anim_terminator
+sArticunoAnims_4_6:
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, -3, 1, 1,
+ax_anim 1, 0, 97, 1, -1, 1, 1,
+ax_anim 2, 0, 99, 4, -1, 1, 1,
+ax_anim 1, 0, 97, 5, -4, 2, 2,
+ax_anim 2, 0, 98, 7, -8, 2, 2,
+ax_anim 1, 0, 97, 7, -5, 2, 2,
+ax_anim 2, 0, 99, 8, -4, 3, 3,
+ax_anim 1, 0, 99, 9, -5, 3, 3,
+ax_anim 2, 0, 99, 10, -6, 4, 4,
+ax_anim 1, 0, 97, 11, -9, 4, 4,
+ax_anim 2, 0, 100, 12, -8, 4, 4,
+ax_anim 6, 2, 100, 13, -9, 5, 5,
+ax_anim 2, 0, 101, 2, -4, 0, 0,
+ax_anim 2, 1, 101, -4, -2, -4, -4,
+ax_anim 2, 0, 101, -3, -3, -3, -4,
+ax_anim 2, 0, 101, -4, -2, -4, -4,
+ax_anim 2, 0, 101, -3, -3, -3, -4,
+ax_anim 2, 0, 101, -4, -2, -4, -4,
+ax_anim_terminator
+sArticunoAnims_4_7:
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -2, 1, 0,
+ax_anim 1, 0, 102, 1, -1, 1, 0,
+ax_anim 2, 0, 104, 3, -1, 3, 0,
+ax_anim 1, 0, 102, 4, -4, 4, 0,
+ax_anim 2, 0, 103, 6, -8, 6, 0,
+ax_anim 1, 0, 102, 5, -5, 5, 0,
+ax_anim 2, 0, 104, 7, -5, 7, 0,
+ax_anim 1, 0, 104, 8, -6, 8, 0,
+ax_anim 2, 0, 104, 9, -7, 9, 0,
+ax_anim 1, 0, 102, 10, -10, 10, 0,
+ax_anim 2, 0, 105, 7, -7, 7, 0,
+ax_anim 6, 2, 105, 8, -8, 8, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 1, 106, -4, -2, -4, 0,
+ax_anim 2, 0, 106, -4, -1, -4, 0,
+ax_anim 2, 0, 106, -4, -2, -4, -1,
+ax_anim 2, 0, 106, -4, -1, -4, 0,
+ax_anim 2, 0, 106, -4, -2, -4, -1,
+ax_anim_terminator
+sArticunoAnims_4_8:
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 4, -1, 1, -1,
+ax_anim 1, 0, 107, 4, -4, 2, -2,
+ax_anim 2, 0, 108, 6, -8, 2, -2,
+ax_anim 1, 0, 107, 5, -5, 2, -2,
+ax_anim 2, 0, 109, 6, -5, 3, -3,
+ax_anim 1, 0, 109, 7, -6, 3, -3,
+ax_anim 2, 0, 109, 8, -7, 4, -4,
+ax_anim 1, 0, 107, 8, -9, 4, -4,
+ax_anim 2, 0, 110, 7, -10, 4, -4,
+ax_anim 6, 2, 110, 8, -11, 5, -5,
+ax_anim 2, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 1, 111, -4, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 3, -1, 2,
+ax_anim 2, 0, 111, -4, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 3, -1, 2,
+ax_anim 2, 0, 111, -4, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sArticunoAnims_5_1:
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -5, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -8, 0, 0,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 2, 115, -1, -6, -1, 0,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, -1, -6, -1, 0,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, -1, -6, -1, 0,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, -1, -6, -1, 0,
+ax_anim_terminator
+sArticunoAnims_5_2:
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -8, 0, 0,
+ax_anim 2, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 2, 120, -1, -5, -1, 1,
+ax_anim 2, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 0, 120, -1, -5, -1, 1,
+ax_anim 2, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 0, 120, -1, -5, -1, 1,
+ax_anim 2, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 0, 120, -1, -5, -1, 1,
+ax_anim_terminator
+sArticunoAnims_5_3:
+ax_anim 2, 0, 123, 0, -1, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 1, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -8, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 2, 125, 0, -7, 0, -1,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -7, 0, -1,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -7, 0, -1,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -7, 0, -1,
+ax_anim_terminator
+sArticunoAnims_5_4:
+ax_anim 2, 0, 128, 0, -1, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -8, 0, 0,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 2, 2, 130, -1, -7, -1, -1,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 2, 0, 130, -1, -7, -1, -1,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 2, 0, 130, -1, -7, -1, -1,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 2, 0, 130, -1, -7, -1, -1,
+ax_anim_terminator
+sArticunoAnims_5_5:
+ax_anim 2, 0, 133, 0, -1, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 2, 135, -1, -6, -1, 0,
+ax_anim 2, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, -1, -6, -1, 0,
+ax_anim 2, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, -1, -6, -1, 0,
+ax_anim 2, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, -1, -6, -1, 0,
+ax_anim_terminator
+sArticunoAnims_5_6:
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, 0,
+ax_anim 2, 2, 140, 1, -7, 1, -1,
+ax_anim 2, 0, 140, 0, -6, 0, 0,
+ax_anim 2, 0, 140, 1, -7, 1, -1,
+ax_anim 2, 0, 140, 0, -6, 0, 0,
+ax_anim 2, 0, 140, 1, -7, 1, -1,
+ax_anim 2, 0, 140, 0, -6, 0, 0,
+ax_anim 2, 0, 140, 1, -7, 1, -1,
+ax_anim_terminator
+sArticunoAnims_5_7:
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 145, 0, -6, 0, 0,
+ax_anim 2, 2, 145, 0, -7, 0, -1,
+ax_anim 2, 0, 145, 0, -6, 0, 0,
+ax_anim 2, 0, 145, 0, -7, 0, -1,
+ax_anim 2, 0, 145, 0, -6, 0, 0,
+ax_anim 2, 0, 145, 0, -7, 0, -1,
+ax_anim 2, 0, 145, 0, -6, 0, 0,
+ax_anim 2, 0, 145, 0, -7, 0, -1,
+ax_anim_terminator
+sArticunoAnims_5_8:
+ax_anim 2, 0, 148, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 148, 0, -5, 0, 0,
+ax_anim 1, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 150, 0, -6, 0, 0,
+ax_anim 2, 2, 150, -1, -7, -1, -1,
+ax_anim 2, 0, 150, 0, -6, 0, 0,
+ax_anim 2, 0, 150, -1, -7, -1, -1,
+ax_anim 2, 0, 150, 0, -6, 0, 0,
+ax_anim 2, 0, 150, -1, -7, -1, -1,
+ax_anim 2, 0, 150, 0, -6, 0, 0,
+ax_anim 2, 0, 150, -1, -7, -1, -1,
+ax_anim_terminator
+.align 2
+sArticunoAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sArticunoAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sArticunoAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sArticunoAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sArticunoAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sArticunoAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sArticunoAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sArticunoAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sArticunoAnims_8_1:
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_8_2:
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 16, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_8_3:
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_8_4:
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 16, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_8_5:
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 16, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_8_6:
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 16, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_8_7:
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim 16, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_8_8:
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 16, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 4, 6, 4,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 19, 7, 19,
+ax_anim 3, 0, 190, 0, 24, 0, 24,
+ax_anim 2, 3, 191, -7, 19, -7, 19,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 4, -6, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 24, 9, 24, 9,
+ax_anim 3, 0, 189, 20, 25, 20, 25,
+ax_anim 2, 3, 190, 11, 21, 11, 21,
+ax_anim 2, 0, 191, 2, 12, 2, 12,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -4, 3, -4,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 17, -4, 17, -4,
+ax_anim 3, 0, 188, 20, 1, 20, 1,
+ax_anim 2, 3, 189, 17, 5, 17, 5,
+ax_anim 2, 0, 190, 12, 7, 12, 7,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -6, -1, -6,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 11, -20, 11, -20,
+ax_anim 3, 0, 187, 16, -16, 16, -16,
+ax_anim 2, 3, 188, 18, -12, 18, -12,
+ax_anim 2, 0, 189, 16, -6, 16, -6,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -6, -4, -6, -4,
+ax_anim 2, 0, 192, -8, -10, -8, -10,
+ax_anim 2, 0, 193, -7, -14, -7, -14,
+ax_anim 3, 0, 186, 0, -17, 0, -17,
+ax_anim 2, 3, 187, 7, -14, 7, -14,
+ax_anim 2, 0, 188, 8, -8, 8, -8,
+ax_anim 1, 0, 189, 6, -4, 6, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -6, 1, -6,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -11, -20, -11, -20,
+ax_anim 3, 0, 193, -16, -16, -16, -16,
+ax_anim 2, 3, 192, -18, -12, -18, -12,
+ax_anim 2, 0, 191, -16, -6, -16, -6,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -4, -3, -4,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -17, -4, -17, -4,
+ax_anim 3, 0, 192, -20, 1, -20, 1,
+ax_anim 2, 3, 191, -17, 5, -17, 5,
+ax_anim 2, 0, 190, -12, 7, -12, 7,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -24, 9, -24, 9,
+ax_anim 3, 0, 191, -20, 25, -20, 25,
+ax_anim 2, 3, 190, -11, 21, -11, 21,
+ax_anim 2, 0, 189, -2, 12, -2, 12,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -26, 0, 0,
+ax_anim 3, 0, 203, 0, -24, 0, 0,
+ax_anim 2, 0, 203, 0, -18, 0, 0,
+ax_anim 1, 0, 203, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 5, 0, 0,
+ax_anim_terminator
+sArticunoAnims_11_2:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, -1, -26, 0, 0,
+ax_anim 3, 0, 207, -1, -24, 0, 0,
+ax_anim 2, 0, 207, -1, -18, 0, 0,
+ax_anim 1, 0, 207, -1, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 2, 0, 0,
+ax_anim_terminator
+sArticunoAnims_11_3:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, -1, -26, 0, 0,
+ax_anim 3, 0, 211, -1, -24, 0, 0,
+ax_anim 2, 0, 211, -1, -18, 0, 0,
+ax_anim 1, 0, 211, -1, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 2, 0, 0,
+ax_anim_terminator
+sArticunoAnims_11_4:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, -1, -26, 0, 0,
+ax_anim 3, 0, 215, -1, -24, 0, 0,
+ax_anim 2, 0, 215, -1, -17, 0, 0,
+ax_anim 1, 0, 215, -1, -11, 0, 0,
+ax_anim 2, 2, 217, -1, 4, 0, 0,
+ax_anim_terminator
+sArticunoAnims_11_5:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -26, 0, 0,
+ax_anim 3, 0, 219, 0, -24, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 4, 0, 0,
+ax_anim_terminator
+sArticunoAnims_11_6:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 1, -26, 0, 0,
+ax_anim 3, 0, 223, 1, -24, 0, 0,
+ax_anim 2, 0, 223, 1, -17, 0, 0,
+ax_anim 1, 0, 223, 1, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 4, 0, 0,
+ax_anim_terminator
+sArticunoAnims_11_7:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 1, -26, 0, 0,
+ax_anim 3, 0, 227, 1, -24, 0, 0,
+ax_anim 2, 0, 227, 1, -18, 0, 0,
+ax_anim 1, 0, 227, 1, -12, 0, 0,
+ax_anim 2, 2, 229, 0, 5, 0, 0,
+ax_anim_terminator
+sArticunoAnims_11_8:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 1, -26, 0, 0,
+ax_anim 3, 0, 231, 1, -24, 0, 0,
+ax_anim 2, 0, 231, 1, -18, 0, 0,
+ax_anim 1, 0, 231, 1, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_14_1:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_14_2:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_14_3:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_14_4:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_14_5:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_14_6:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_14_7:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_14_8:
+ax_anim 24, 0, 250, 0, 0, 0, 0,
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_15_1:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_15_2:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_15_3:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_15_4:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_15_5:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_15_6:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_15_7:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_15_8:
+ax_anim 14, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 20, 0, 252, 0, 0, 0, 0,
+ax_anim 3, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, -1, 0, -1, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_16_1:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_16_2:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_16_3:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_16_4:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_16_5:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_16_6:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_16_7:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoAnims_16_8:
+ax_anim 16, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 6, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sArticunoAnims_17_1:
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 16, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sArticunoGfx1:
+.incbin "baserom.gba", 0xB371F4, 0x20
+sArticunoGfx1_1:
+.incbin "baserom.gba", 0xB37214, 0x40
+sArticunoGfx1_2:
+.incbin "baserom.gba", 0xB37254, 0x220
+sArticunoGfx1_3:
+.incbin "baserom.gba", 0xB37474, 0x60
+sArticunoSprites1:
+ax_sprite sArticunoGfx1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx1_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx1_2, 0x220
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx1_3, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sArticunoGfx2:
+.incbin "baserom.gba", 0xB3751C, 0x60
+sArticunoGfx2_1:
+.incbin "baserom.gba", 0xB3757C, 0x100
+sArticunoGfx2_2:
+.incbin "baserom.gba", 0xB3767C, 0x60
+sArticunoSprites2:
+ax_sprite sArticunoGfx2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx2_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx2_2, 0x60
+ax_sprite_terminator
+sArticunoGfx3:
+.incbin "baserom.gba", 0xB3770C, 0x80
+sArticunoSprites3:
+ax_sprite sArticunoGfx3, 0x80
+ax_sprite_terminator
+sArticunoGfx4:
+.incbin "baserom.gba", 0xB3779C, 0x80
+sArticunoSprites4:
+ax_sprite sArticunoGfx4, 0x80
+ax_sprite_terminator
+sArticunoGfx5:
+.incbin "baserom.gba", 0xB3782C, 0xE0
+sArticunoSprites5:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx5, 0xe0
+ax_sprite_terminator
+sArticunoGfx6:
+.incbin "baserom.gba", 0xB37924, 0x100
+sArticunoSprites6:
+ax_sprite sArticunoGfx6, 0x100
+ax_sprite_terminator
+sArticunoGfx7:
+.incbin "baserom.gba", 0xB37A34, 0x20
+sArticunoGfx7_1:
+.incbin "baserom.gba", 0xB37A54, 0xC0
+sArticunoSprites7:
+ax_sprite sArticunoGfx7, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx7_1, 0xc0
+ax_sprite_terminator
+sArticunoGfx8:
+.incbin "baserom.gba", 0xB37B34, 0xC0
+sArticunoGfx8_1:
+.incbin "baserom.gba", 0xB37BF4, 0x20
+sArticunoSprites8:
+ax_sprite sArticunoGfx8, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx8_1, 0x20
+ax_sprite_terminator
+sArticunoGfx9:
+.incbin "baserom.gba", 0xB37C34, 0x80
+sArticunoSprites9:
+ax_sprite sArticunoGfx9, 0x80
+ax_sprite_terminator
+sArticunoGfx10:
+.incbin "baserom.gba", 0xB37CC4, 0x40
+sArticunoSprites10:
+ax_sprite sArticunoGfx10, 0x40
+ax_sprite_terminator
+sArticunoGfx11:
+.incbin "baserom.gba", 0xB37D14, 0x20
+sArticunoSprites11:
+ax_sprite sArticunoGfx11, 0x20
+ax_sprite_terminator
+sArticunoGfx12:
+.incbin "baserom.gba", 0xB37D44, 0x20
+sArticunoSprites12:
+ax_sprite sArticunoGfx12, 0x20
+ax_sprite_terminator
+sArticunoGfx13:
+.incbin "baserom.gba", 0xB37D74, 0x80
+sArticunoSprites13:
+ax_sprite sArticunoGfx13, 0x80
+ax_sprite_terminator
+sArticunoGfx14:
+.incbin "baserom.gba", 0xB37E04, 0x80
+sArticunoSprites14:
+ax_sprite sArticunoGfx14, 0x80
+ax_sprite_terminator
+sArticunoGfx15:
+.incbin "baserom.gba", 0xB37E94, 0x20
+sArticunoGfx15_1:
+.incbin "baserom.gba", 0xB37EB4, 0x20
+sArticunoGfx15_2:
+.incbin "baserom.gba", 0xB37ED4, 0x160
+sArticunoSprites15:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx15, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx15_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx15_2, 0x160
+ax_sprite_terminator
+sArticunoGfx16:
+.incbin "baserom.gba", 0xB3806C, 0x40
+sArticunoSprites16:
+ax_sprite sArticunoGfx16, 0x40
+ax_sprite_terminator
+sArticunoGfx17:
+.incbin "baserom.gba", 0xB380BC, 0x20
+sArticunoSprites17:
+ax_sprite sArticunoGfx17, 0x20
+ax_sprite_terminator
+sArticunoGfx18:
+.incbin "baserom.gba", 0xB380EC, 0x20
+sArticunoSprites18:
+ax_sprite sArticunoGfx18, 0x20
+ax_sprite_terminator
+sArticunoGfx19:
+.incbin "baserom.gba", 0xB3811C, 0x1E0
+sArticunoSprites19:
+ax_sprite sArticunoGfx19, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx20:
+.incbin "baserom.gba", 0xB38314, 0x60
+sArticunoSprites20:
+ax_sprite sArticunoGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx21:
+.incbin "baserom.gba", 0xB3838C, 0x40
+sArticunoSprites21:
+ax_sprite sArticunoGfx21, 0x40
+ax_sprite_terminator
+sArticunoGfx22:
+.incbin "baserom.gba", 0xB383DC, 0x60
+sArticunoSprites22:
+ax_sprite sArticunoGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx23:
+.incbin "baserom.gba", 0xB38454, 0x180
+sArticunoGfx23_1:
+.incbin "baserom.gba", 0xB385D4, 0x40
+sArticunoSprites23:
+ax_sprite sArticunoGfx23, 0x180
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx23_1, 0x40
+ax_sprite_terminator
+sArticunoGfx24:
+.incbin "baserom.gba", 0xB38634, 0x40
+sArticunoGfx24_1:
+.incbin "baserom.gba", 0xB38674, 0x80
+sArticunoSprites24:
+ax_sprite sArticunoGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx24_1, 0x80
+ax_sprite_terminator
+sArticunoGfx25:
+.incbin "baserom.gba", 0xB38714, 0x80
+sArticunoSprites25:
+ax_sprite sArticunoGfx25, 0x80
+ax_sprite_terminator
+sArticunoGfx26:
+.incbin "baserom.gba", 0xB387A4, 0x180
+sArticunoGfx26_1:
+.incbin "baserom.gba", 0xB38924, 0x40
+sArticunoSprites26:
+ax_sprite sArticunoGfx26, 0x180
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx26_1, 0x40
+ax_sprite_terminator
+sArticunoGfx27:
+.incbin "baserom.gba", 0xB38984, 0x100
+sArticunoSprites27:
+ax_sprite sArticunoGfx27, 0x100
+ax_sprite_terminator
+sArticunoGfx28:
+.incbin "baserom.gba", 0xB38A94, 0x80
+sArticunoSprites28:
+ax_sprite sArticunoGfx28, 0x80
+ax_sprite_terminator
+sArticunoGfx29:
+.incbin "baserom.gba", 0xB38B24, 0x20
+sArticunoSprites29:
+ax_sprite sArticunoGfx29, 0x20
+ax_sprite_terminator
+sArticunoGfx30:
+.incbin "baserom.gba", 0xB38B54, 0x1C0
+sArticunoSprites30:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx30, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx31:
+.incbin "baserom.gba", 0xB38D34, 0x60
+sArticunoGfx31_1:
+.incbin "baserom.gba", 0xB38D94, 0x80
+sArticunoSprites31:
+ax_sprite sArticunoGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx31_1, 0x80
+ax_sprite_terminator
+sArticunoGfx32:
+.incbin "baserom.gba", 0xB38E34, 0x20
+sArticunoSprites32:
+ax_sprite sArticunoGfx32, 0x20
+ax_sprite_terminator
+sArticunoGfx33:
+.incbin "baserom.gba", 0xB38E64, 0x40
+sArticunoSprites33:
+ax_sprite sArticunoGfx33, 0x40
+ax_sprite_terminator
+sArticunoGfx34:
+.incbin "baserom.gba", 0xB38EB4, 0x20
+sArticunoSprites34:
+ax_sprite sArticunoGfx34, 0x20
+ax_sprite_terminator
+sArticunoGfx35:
+.incbin "baserom.gba", 0xB38EE4, 0xE0
+sArticunoSprites35:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx35, 0xe0
+ax_sprite_terminator
+sArticunoGfx36:
+.incbin "baserom.gba", 0xB38FDC, 0x80
+sArticunoSprites36:
+ax_sprite sArticunoGfx36, 0x80
+ax_sprite_terminator
+sArticunoGfx37:
+.incbin "baserom.gba", 0xB3906C, 0x100
+sArticunoSprites37:
+ax_sprite sArticunoGfx37, 0x100
+ax_sprite_terminator
+sArticunoGfx38:
+.incbin "baserom.gba", 0xB3917C, 0x60
+sArticunoSprites38:
+ax_sprite sArticunoGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx39:
+.incbin "baserom.gba", 0xB391F4, 0x40
+sArticunoSprites39:
+ax_sprite sArticunoGfx39, 0x40
+ax_sprite_terminator
+sArticunoGfx40:
+.incbin "baserom.gba", 0xB39244, 0x20
+sArticunoGfx40_1:
+.incbin "baserom.gba", 0xB39264, 0x140
+sArticunoGfx40_2:
+.incbin "baserom.gba", 0xB393A4, 0x60
+sArticunoSprites40:
+ax_sprite sArticunoGfx40, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx40_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx40_2, 0x60
+ax_sprite_terminator
+sArticunoGfx41:
+.incbin "baserom.gba", 0xB39434, 0x20
+sArticunoSprites41:
+ax_sprite sArticunoGfx41, 0x20
+ax_sprite_terminator
+sArticunoGfx42:
+.incbin "baserom.gba", 0xB39464, 0x40
+sArticunoSprites42:
+ax_sprite sArticunoGfx42, 0x40
+ax_sprite_terminator
+sArticunoGfx43:
+.incbin "baserom.gba", 0xB394B4, 0x20
+sArticunoSprites43:
+ax_sprite sArticunoGfx43, 0x20
+ax_sprite_terminator
+sArticunoGfx44:
+.incbin "baserom.gba", 0xB394E4, 0x100
+sArticunoSprites44:
+ax_sprite sArticunoGfx44, 0x100
+ax_sprite_terminator
+sArticunoGfx45:
+.incbin "baserom.gba", 0xB395F4, 0x40
+sArticunoGfx45_1:
+.incbin "baserom.gba", 0xB39634, 0x180
+sArticunoSprites45:
+ax_sprite sArticunoGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx45_1, 0x180
+ax_sprite_terminator
+sArticunoGfx46:
+.incbin "baserom.gba", 0xB397D4, 0x40
+sArticunoSprites46:
+ax_sprite sArticunoGfx46, 0x40
+ax_sprite_terminator
+sArticunoGfx47:
+.incbin "baserom.gba", 0xB39824, 0x40
+sArticunoSprites47:
+ax_sprite sArticunoGfx47, 0x40
+ax_sprite_terminator
+sArticunoGfx48:
+.incbin "baserom.gba", 0xB39874, 0x40
+sArticunoSprites48:
+ax_sprite sArticunoGfx48, 0x40
+ax_sprite_terminator
+sArticunoGfx49:
+.incbin "baserom.gba", 0xB398C4, 0x20
+sArticunoSprites49:
+ax_sprite sArticunoGfx49, 0x20
+ax_sprite_terminator
+sArticunoGfx50:
+.incbin "baserom.gba", 0xB398F4, 0x20
+sArticunoSprites50:
+ax_sprite sArticunoGfx50, 0x20
+ax_sprite_terminator
+sArticunoGfx51:
+.incbin "baserom.gba", 0xB39924, 0x20
+sArticunoSprites51:
+ax_sprite sArticunoGfx51, 0x20
+ax_sprite_terminator
+sArticunoGfx52:
+.incbin "baserom.gba", 0xB39954, 0x80
+sArticunoSprites52:
+ax_sprite sArticunoGfx52, 0x80
+ax_sprite_terminator
+sArticunoGfx53:
+.incbin "baserom.gba", 0xB399E4, 0x80
+sArticunoSprites53:
+ax_sprite sArticunoGfx53, 0x80
+ax_sprite_terminator
+sArticunoGfx54:
+.incbin "baserom.gba", 0xB39A74, 0x60
+sArticunoGfx54_1:
+.incbin "baserom.gba", 0xB39AD4, 0x100
+sArticunoGfx54_2:
+.incbin "baserom.gba", 0xB39BD4, 0x40
+sArticunoSprites54:
+ax_sprite sArticunoGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx54_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx54_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx55:
+.incbin "baserom.gba", 0xB39C4C, 0x80
+sArticunoSprites55:
+ax_sprite sArticunoGfx55, 0x80
+ax_sprite_terminator
+sArticunoGfx56:
+.incbin "baserom.gba", 0xB39CDC, 0xC0
+sArticunoGfx56_1:
+.incbin "baserom.gba", 0xB39D9C, 0x20
+sArticunoSprites56:
+ax_sprite sArticunoGfx56, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx56_1, 0x20
+ax_sprite_terminator
+sArticunoGfx57:
+.incbin "baserom.gba", 0xB39DDC, 0x100
+sArticunoSprites57:
+ax_sprite sArticunoGfx57, 0x100
+ax_sprite_terminator
+sArticunoGfx58:
+.incbin "baserom.gba", 0xB39EEC, 0xE0
+sArticunoSprites58:
+ax_sprite sArticunoGfx58, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx59:
+.incbin "baserom.gba", 0xB39FE4, 0x20
+sArticunoSprites59:
+ax_sprite sArticunoGfx59, 0x20
+ax_sprite_terminator
+sArticunoGfx60:
+.incbin "baserom.gba", 0xB3A014, 0x40
+sArticunoGfx60_1:
+.incbin "baserom.gba", 0xB3A054, 0x180
+sArticunoSprites60:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx60, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx60_1, 0x180
+ax_sprite_terminator
+sArticunoGfx61:
+.incbin "baserom.gba", 0xB3A1FC, 0x20
+sArticunoSprites61:
+ax_sprite sArticunoGfx61, 0x20
+ax_sprite_terminator
+sArticunoGfx62:
+.incbin "baserom.gba", 0xB3A22C, 0x20
+sArticunoSprites62:
+ax_sprite sArticunoGfx62, 0x20
+ax_sprite_terminator
+sArticunoGfx63:
+.incbin "baserom.gba", 0xB3A25C, 0x40
+sArticunoGfx63_1:
+.incbin "baserom.gba", 0xB3A29C, 0xA0
+sArticunoGfx63_2:
+.incbin "baserom.gba", 0xB3A33C, 0x60
+sArticunoGfx63_3:
+.incbin "baserom.gba", 0xB3A39C, 0x20
+sArticunoSprites63:
+ax_sprite sArticunoGfx63, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx63_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx63_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx63_3, 0x20
+ax_sprite_terminator
+sArticunoGfx64:
+.incbin "baserom.gba", 0xB3A3FC, 0x20
+sArticunoGfx64_1:
+.incbin "baserom.gba", 0xB3A41C, 0xA0
+sArticunoSprites64:
+ax_sprite sArticunoGfx64, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx64_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx65:
+.incbin "baserom.gba", 0xB3A4E4, 0x80
+sArticunoSprites65:
+ax_sprite sArticunoGfx65, 0x80
+ax_sprite_terminator
+sArticunoGfx66:
+.incbin "baserom.gba", 0xB3A574, 0x20
+sArticunoSprites66:
+ax_sprite sArticunoGfx66, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx67:
+.incbin "baserom.gba", 0xB3A5AC, 0x20
+sArticunoSprites67:
+ax_sprite sArticunoGfx67, 0x20
+ax_sprite_terminator
+sArticunoGfx68:
+.incbin "baserom.gba", 0xB3A5DC, 0x100
+sArticunoSprites68:
+ax_sprite sArticunoGfx68, 0x100
+ax_sprite_terminator
+sArticunoGfx69:
+.incbin "baserom.gba", 0xB3A6EC, 0x20
+sArticunoGfx69_1:
+.incbin "baserom.gba", 0xB3A70C, 0x60
+sArticunoGfx69_2:
+.incbin "baserom.gba", 0xB3A76C, 0x60
+sArticunoGfx69_3:
+.incbin "baserom.gba", 0xB3A7CC, 0x20
+sArticunoSprites69:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx69, 0x20
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx69_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx69_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx69_3, 0x20
+ax_sprite_terminator
+sArticunoGfx70:
+.incbin "baserom.gba", 0xB3A834, 0x40
+sArticunoGfx70_1:
+.incbin "baserom.gba", 0xB3A874, 0x40
+sArticunoGfx70_2:
+.incbin "baserom.gba", 0xB3A8B4, 0x120
+sArticunoSprites70:
+ax_sprite sArticunoGfx70, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx70_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx70_2, 0x120
+ax_sprite_terminator
+sArticunoGfx71:
+.incbin "baserom.gba", 0xB3AA04, 0xE0
+sArticunoSprites71:
+ax_sprite sArticunoGfx71, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx72:
+.incbin "baserom.gba", 0xB3AAFC, 0x40
+sArticunoSprites72:
+ax_sprite sArticunoGfx72, 0x40
+ax_sprite_terminator
+sArticunoGfx73:
+.incbin "baserom.gba", 0xB3AB4C, 0x40
+sArticunoSprites73:
+ax_sprite sArticunoGfx73, 0x40
+ax_sprite_terminator
+sArticunoGfx74:
+.incbin "baserom.gba", 0xB3AB9C, 0xC0
+sArticunoGfx74_1:
+.incbin "baserom.gba", 0xB3AC5C, 0x20
+sArticunoSprites74:
+ax_sprite sArticunoGfx74, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx74_1, 0x20
+ax_sprite_terminator
+sArticunoGfx75:
+.incbin "baserom.gba", 0xB3AC9C, 0x160
+sArticunoGfx75_1:
+.incbin "baserom.gba", 0xB3ADFC, 0x60
+sArticunoSprites75:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx75, 0x160
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx75_1, 0x60
+ax_sprite_terminator
+sArticunoGfx76:
+.incbin "baserom.gba", 0xB3AE84, 0x20
+sArticunoGfx76_1:
+.incbin "baserom.gba", 0xB3AEA4, 0x20
+sArticunoSprites76:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx76, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx76_1, 0x20
+ax_sprite_terminator
+sArticunoGfx77:
+.incbin "baserom.gba", 0xB3AEEC, 0x80
+sArticunoSprites77:
+ax_sprite sArticunoGfx77, 0x80
+ax_sprite_terminator
+sArticunoGfx78:
+.incbin "baserom.gba", 0xB3AF7C, 0x40
+sArticunoSprites78:
+ax_sprite sArticunoGfx78, 0x40
+ax_sprite_terminator
+sArticunoGfx79:
+.incbin "baserom.gba", 0xB3AFCC, 0x20
+sArticunoSprites79:
+ax_sprite sArticunoGfx79, 0x20
+ax_sprite_terminator
+sArticunoGfx80:
+.incbin "baserom.gba", 0xB3AFFC, 0x180
+sArticunoGfx80_1:
+.incbin "baserom.gba", 0xB3B17C, 0x40
+sArticunoSprites80:
+ax_sprite sArticunoGfx80, 0x180
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx80_1, 0x40
+ax_sprite_terminator
+sArticunoGfx81:
+.incbin "baserom.gba", 0xB3B1DC, 0x60
+sArticunoGfx81_1:
+.incbin "baserom.gba", 0xB3B23C, 0x80
+sArticunoSprites81:
+ax_sprite sArticunoGfx81, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx81_1, 0x80
+ax_sprite_terminator
+sArticunoGfx82:
+.incbin "baserom.gba", 0xB3B2DC, 0x1A0
+sArticunoSprites82:
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx82, 0x1a0
+ax_sprite_terminator
+sArticunoGfx83:
+.incbin "baserom.gba", 0xB3B494, 0x80
+sArticunoSprites83:
+ax_sprite sArticunoGfx83, 0x80
+ax_sprite_terminator
+sArticunoGfx84:
+.incbin "baserom.gba", 0xB3B524, 0x80
+sArticunoSprites84:
+ax_sprite sArticunoGfx84, 0x80
+ax_sprite_terminator
+sArticunoGfx85:
+.incbin "baserom.gba", 0xB3B5B4, 0x40
+sArticunoSprites85:
+ax_sprite sArticunoGfx85, 0x40
+ax_sprite_terminator
+sArticunoGfx86:
+.incbin "baserom.gba", 0xB3B604, 0x20
+sArticunoSprites86:
+ax_sprite sArticunoGfx86, 0x20
+ax_sprite_terminator
+sArticunoGfx87:
+.incbin "baserom.gba", 0xB3B634, 0x40
+sArticunoSprites87:
+ax_sprite sArticunoGfx87, 0x40
+ax_sprite_terminator
+sArticunoGfx88:
+.incbin "baserom.gba", 0xB3B684, 0xE0
+sArticunoSprites88:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx88, 0xe0
+ax_sprite_terminator
+sArticunoGfx89:
+.incbin "baserom.gba", 0xB3B77C, 0x40
+sArticunoGfx89_1:
+.incbin "baserom.gba", 0xB3B7BC, 0xA0
+sArticunoSprites89:
+ax_sprite sArticunoGfx89, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx89_1, 0xa0
+ax_sprite_terminator
+sArticunoGfx90:
+.incbin "baserom.gba", 0xB3B87C, 0x20
+sArticunoGfx90_1:
+.incbin "baserom.gba", 0xB3B89C, 0xC0
+sArticunoSprites90:
+ax_sprite sArticunoGfx90, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx90_1, 0xc0
+ax_sprite_terminator
+sArticunoGfx91:
+.incbin "baserom.gba", 0xB3B97C, 0x80
+sArticunoSprites91:
+ax_sprite sArticunoGfx91, 0x80
+ax_sprite_terminator
+sArticunoGfx92:
+.incbin "baserom.gba", 0xB3BA0C, 0x40
+sArticunoSprites92:
+ax_sprite sArticunoGfx92, 0x40
+ax_sprite_terminator
+sArticunoGfx93:
+.incbin "baserom.gba", 0xB3BA5C, 0x60
+sArticunoSprites93:
+ax_sprite sArticunoGfx93, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx94:
+.incbin "baserom.gba", 0xB3BAD4, 0x60
+sArticunoSprites94:
+ax_sprite sArticunoGfx94, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx95:
+.incbin "baserom.gba", 0xB3BB4C, 0x20
+sArticunoSprites95:
+ax_sprite sArticunoGfx95, 0x20
+ax_sprite_terminator
+sArticunoGfx96:
+.incbin "baserom.gba", 0xB3BB7C, 0x20
+sArticunoSprites96:
+ax_sprite sArticunoGfx96, 0x20
+ax_sprite_terminator
+sArticunoGfx97:
+.incbin "baserom.gba", 0xB3BBAC, 0x100
+sArticunoSprites97:
+ax_sprite sArticunoGfx97, 0x100
+ax_sprite_terminator
+sArticunoGfx98:
+.incbin "baserom.gba", 0xB3BCBC, 0x80
+sArticunoSprites98:
+ax_sprite sArticunoGfx98, 0x80
+ax_sprite_terminator
+sArticunoGfx99:
+.incbin "baserom.gba", 0xB3BD4C, 0x20
+sArticunoSprites99:
+ax_sprite sArticunoGfx99, 0x20
+ax_sprite_terminator
+sArticunoGfx100:
+.incbin "baserom.gba", 0xB3BD7C, 0x100
+sArticunoSprites100:
+ax_sprite sArticunoGfx100, 0x100
+ax_sprite_terminator
+sArticunoGfx101:
+.incbin "baserom.gba", 0xB3BE8C, 0x80
+sArticunoSprites101:
+ax_sprite sArticunoGfx101, 0x80
+ax_sprite_terminator
+sArticunoGfx102:
+.incbin "baserom.gba", 0xB3BF1C, 0x20
+sArticunoSprites102:
+ax_sprite sArticunoGfx102, 0x20
+ax_sprite_terminator
+sArticunoGfx103:
+.incbin "baserom.gba", 0xB3BF4C, 0x60
+sArticunoGfx103_1:
+.incbin "baserom.gba", 0xB3BFAC, 0x180
+sArticunoSprites103:
+ax_sprite sArticunoGfx103, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx103_1, 0x180
+ax_sprite_terminator
+sArticunoGfx104:
+.incbin "baserom.gba", 0xB3C14C, 0x80
+sArticunoSprites104:
+ax_sprite sArticunoGfx104, 0x80
+ax_sprite_terminator
+sArticunoGfx105:
+.incbin "baserom.gba", 0xB3C1DC, 0x80
+sArticunoSprites105:
+ax_sprite sArticunoGfx105, 0x80
+ax_sprite_terminator
+sArticunoGfx106:
+.incbin "baserom.gba", 0xB3C26C, 0x20
+sArticunoSprites106:
+ax_sprite sArticunoGfx106, 0x20
+ax_sprite_terminator
+sArticunoGfx107:
+.incbin "baserom.gba", 0xB3C29C, 0x20
+sArticunoSprites107:
+ax_sprite sArticunoGfx107, 0x20
+ax_sprite_terminator
+sArticunoGfx108:
+.incbin "baserom.gba", 0xB3C2CC, 0x80
+sArticunoSprites108:
+ax_sprite sArticunoGfx108, 0x80
+ax_sprite_terminator
+sArticunoGfx109:
+.incbin "baserom.gba", 0xB3C35C, 0x20
+sArticunoSprites109:
+ax_sprite sArticunoGfx109, 0x20
+ax_sprite_terminator
+sArticunoGfx110:
+.incbin "baserom.gba", 0xB3C38C, 0x20
+sArticunoGfx110_1:
+.incbin "baserom.gba", 0xB3C3AC, 0x20
+sArticunoGfx110_2:
+.incbin "baserom.gba", 0xB3C3CC, 0x220
+sArticunoGfx110_3:
+.incbin "baserom.gba", 0xB3C5EC, 0x40
+sArticunoGfx110_4:
+.incbin "baserom.gba", 0xB3C62C, 0x40
+sArticunoSprites110:
+ax_sprite sArticunoGfx110, 0x20
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx110_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx110_2, 0x220
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx110_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx110_4, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sArticunoGfx111:
+.incbin "baserom.gba", 0xB3C6C4, 0xE0
+sArticunoSprites111:
+ax_sprite sArticunoGfx111, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx112:
+.incbin "baserom.gba", 0xB3C7BC, 0x40
+sArticunoSprites112:
+ax_sprite sArticunoGfx112, 0x40
+ax_sprite_terminator
+sArticunoGfx113:
+.incbin "baserom.gba", 0xB3C80C, 0x40
+sArticunoSprites113:
+ax_sprite sArticunoGfx113, 0x40
+ax_sprite_terminator
+sArticunoGfx114:
+.incbin "baserom.gba", 0xB3C85C, 0x60
+sArticunoGfx114_1:
+.incbin "baserom.gba", 0xB3C8BC, 0x160
+sArticunoSprites114:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx114, 0x60
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx114_1, 0x160
+ax_sprite_terminator
+sArticunoGfx115:
+.incbin "baserom.gba", 0xB3CA44, 0x100
+sArticunoSprites115:
+ax_sprite sArticunoGfx115, 0x100
+ax_sprite_terminator
+sArticunoGfx116:
+.incbin "baserom.gba", 0xB3CB54, 0x40
+sArticunoSprites116:
+ax_sprite sArticunoGfx116, 0x40
+ax_sprite_terminator
+sArticunoGfx117:
+.incbin "baserom.gba", 0xB3CBA4, 0x40
+sArticunoSprites117:
+ax_sprite sArticunoGfx117, 0x40
+ax_sprite_terminator
+sArticunoGfx118:
+.incbin "baserom.gba", 0xB3CBF4, 0x20
+sArticunoSprites118:
+ax_sprite sArticunoGfx118, 0x20
+ax_sprite_terminator
+sArticunoGfx119:
+.incbin "baserom.gba", 0xB3CC24, 0x1C0
+sArticunoSprites119:
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx119, 0x1c0
+ax_sprite_terminator
+sArticunoGfx120:
+.incbin "baserom.gba", 0xB3CDFC, 0x1E0
+sArticunoSprites120:
+ax_sprite sArticunoGfx120, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sArticunoGfx121:
+.incbin "baserom.gba", 0xB3CFF4, 0x80
+sArticunoSprites121:
+ax_sprite sArticunoGfx121, 0x80
+ax_sprite_terminator
+sArticunoGfx122:
+.incbin "baserom.gba", 0xB3D084, 0x80
+sArticunoSprites122:
+ax_sprite sArticunoGfx122, 0x80
+ax_sprite_terminator
+sArticunoGfx123:
+.incbin "baserom.gba", 0xB3D114, 0x80
+sArticunoSprites123:
+ax_sprite sArticunoGfx123, 0x80
+ax_sprite_terminator
+sArticunoGfx124:
+.incbin "baserom.gba", 0xB3D1A4, 0x20
+sArticunoSprites124:
+ax_sprite sArticunoGfx124, 0x20
+ax_sprite_terminator
+sArticunoGfx125:
+.incbin "baserom.gba", 0xB3D1D4, 0x20
+sArticunoSprites125:
+ax_sprite sArticunoGfx125, 0x20
+ax_sprite_terminator
+sArticunoGfx126:
+.incbin "baserom.gba", 0xB3D204, 0x20
+sArticunoSprites126:
+ax_sprite sArticunoGfx126, 0x20
+ax_sprite_terminator
+sArticunoGfx127:
+.incbin "baserom.gba", 0xB3D234, 0x40
+sArticunoGfx127_1:
+.incbin "baserom.gba", 0xB3D274, 0xC0
+sArticunoGfx127_2:
+.incbin "baserom.gba", 0xB3D334, 0x100
+sArticunoSprites127:
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx127, 0x40
+ax_sprite 0, 0x80
+ax_sprite sArticunoGfx127_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx127_2, 0x100
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sArticunoGfx128:
+.incbin "baserom.gba", 0xB3D474, 0x40
+sArticunoGfx128_1:
+.incbin "baserom.gba", 0xB3D4B4, 0xC0
+sArticunoGfx128_2:
+.incbin "baserom.gba", 0xB3D574, 0x100
+sArticunoSprites128:
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx128, 0x40
+ax_sprite 0, 0x80
+ax_sprite sArticunoGfx128_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx128_2, 0x100
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sArticunoGfx129:
+.incbin "baserom.gba", 0xB3D6B4, 0x40
+sArticunoGfx129_1:
+.incbin "baserom.gba", 0xB3D6F4, 0xC0
+sArticunoGfx129_2:
+.incbin "baserom.gba", 0xB3D7B4, 0x200
+sArticunoSprites129:
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx129, 0x40
+ax_sprite 0, 0x80
+ax_sprite sArticunoGfx129_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx129_2, 0x200
+ax_sprite_terminator
+sArticunoGfx130:
+.incbin "baserom.gba", 0xB3D9EC, 0x40
+sArticunoGfx130_1:
+.incbin "baserom.gba", 0xB3DA2C, 0x40
+sArticunoGfx130_2:
+.incbin "baserom.gba", 0xB3DA6C, 0x240
+sArticunoGfx130_3:
+.incbin "baserom.gba", 0xB3DCAC, 0x40
+sArticunoSprites130:
+ax_sprite sArticunoGfx130, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx130_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx130_2, 0x240
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx130_3, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sArticunoGfx131:
+.incbin "baserom.gba", 0xB3DD34, 0x40
+sArticunoSprites131:
+ax_sprite sArticunoGfx131, 0x40
+ax_sprite_terminator
+sArticunoGfx132:
+.incbin "baserom.gba", 0xB3DD84, 0x100
+sArticunoSprites132:
+ax_sprite sArticunoGfx132, 0x100
+ax_sprite_terminator
+sArticunoGfx133:
+.incbin "baserom.gba", 0xB3DE94, 0x40
+sArticunoGfx133_1:
+.incbin "baserom.gba", 0xB3DED4, 0x180
+sArticunoSprites133:
+ax_sprite sArticunoGfx133, 0x40
+ax_sprite 0, 0x40
+ax_sprite sArticunoGfx133_1, 0x180
+ax_sprite_terminator
+sArticunoGfx134:
+.incbin "baserom.gba", 0xB3E074, 0x40
+sArticunoSprites134:
+ax_sprite sArticunoGfx134, 0x40
+ax_sprite_terminator
+sArticunoGfx135:
+.incbin "baserom.gba", 0xB3E0C4, 0x40
+sArticunoGfx135_1:
+.incbin "baserom.gba", 0xB3E104, 0xC0
+sArticunoGfx135_2:
+.incbin "baserom.gba", 0xB3E1C4, 0x140
+sArticunoGfx135_3:
+.incbin "baserom.gba", 0xB3E304, 0x40
+sArticunoGfx135_4:
+.incbin "baserom.gba", 0xB3E344, 0x40
+sArticunoSprites135:
+ax_sprite 0, 0x60
+ax_sprite sArticunoGfx135, 0x40
+ax_sprite 0, 0x80
+ax_sprite sArticunoGfx135_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx135_2, 0x140
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx135_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx135_4, 0x40
+ax_sprite_terminator
+sArticunoGfx136:
+.incbin "baserom.gba", 0xB3E3DC, 0x40
+sArticunoGfx136_1:
+.incbin "baserom.gba", 0xB3E41C, 0x180
+sArticunoSprites136:
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx136, 0x40
+ax_sprite 0, 0x20
+ax_sprite sArticunoGfx136_1, 0x180
+ax_sprite_terminator
+sArticunoGfx137:
+.incbin "baserom.gba", 0xB3E5C4, 0x100
+sArticunoSprites137:
+ax_sprite sArticunoGfx137, 0x100
+ax_sprite_terminator
+sArticunoGfx138:
+.incbin "baserom.gba", 0xB3E6D4, 0x80
+sArticunoSprites138:
+ax_sprite sArticunoGfx138, 0x80
+ax_sprite_terminator
+sAxPosesArticuno:
+.4byte sArticunoPose1
+.4byte sArticunoPose2
+.4byte sArticunoPose3
+.4byte sArticunoPose4
+.4byte sArticunoPose5
+.4byte sArticunoPose6
+.4byte sArticunoPose7
+.4byte sArticunoPose8
+.4byte sArticunoPose9
+.4byte sArticunoPose10
+.4byte sArticunoPose11
+.4byte sArticunoPose12
+.4byte sArticunoPose13
+.4byte sArticunoPose14
+.4byte sArticunoPose15
+.4byte sArticunoPose16
+.4byte sArticunoPose17
+.4byte sArticunoPose18
+.4byte sArticunoPose19
+.4byte sArticunoPose20
+.4byte sArticunoPose21
+.4byte sArticunoPose22
+.4byte sArticunoPose23
+.4byte sArticunoPose24
+.4byte sArticunoPose25
+.4byte sArticunoPose26
+.4byte sArticunoPose27
+.4byte sArticunoPose28
+.4byte sArticunoPose29
+.4byte sArticunoPose30
+.4byte sArticunoPose31
+.4byte sArticunoPose32
+.4byte sArticunoPose33
+.4byte sArticunoPose34
+.4byte sArticunoPose35
+.4byte sArticunoPose36
+.4byte sArticunoPose37
+.4byte sArticunoPose38
+.4byte sArticunoPose39
+.4byte sArticunoPose40
+.4byte sArticunoPose41
+.4byte sArticunoPose42
+.4byte sArticunoPose43
+.4byte sArticunoPose44
+.4byte sArticunoPose45
+.4byte sArticunoPose46
+.4byte sArticunoPose47
+.4byte sArticunoPose48
+.4byte sArticunoPose49
+.4byte sArticunoPose50
+.4byte sArticunoPose51
+.4byte sArticunoPose52
+.4byte sArticunoPose53
+.4byte sArticunoPose54
+.4byte sArticunoPose55
+.4byte sArticunoPose56
+.4byte sArticunoPose57
+.4byte sArticunoPose58
+.4byte sArticunoPose59
+.4byte sArticunoPose60
+.4byte sArticunoPose61
+.4byte sArticunoPose62
+.4byte sArticunoPose63
+.4byte sArticunoPose64
+.4byte sArticunoPose65
+.4byte sArticunoPose66
+.4byte sArticunoPose67
+.4byte sArticunoPose68
+.4byte sArticunoPose69
+.4byte sArticunoPose70
+.4byte sArticunoPose71
+.4byte sArticunoPose72
+.4byte sArticunoPose73
+.4byte sArticunoPose74
+.4byte sArticunoPose75
+.4byte sArticunoPose76
+.4byte sArticunoPose77
+.4byte sArticunoPose78
+.4byte sArticunoPose79
+.4byte sArticunoPose80
+.4byte sArticunoPose81
+.4byte sArticunoPose82
+.4byte sArticunoPose83
+.4byte sArticunoPose84
+.4byte sArticunoPose85
+.4byte sArticunoPose86
+.4byte sArticunoPose87
+.4byte sArticunoPose88
+.4byte sArticunoPose89
+.4byte sArticunoPose90
+.4byte sArticunoPose91
+.4byte sArticunoPose92
+.4byte sArticunoPose93
+.4byte sArticunoPose94
+.4byte sArticunoPose95
+.4byte sArticunoPose96
+.4byte sArticunoPose97
+.4byte sArticunoPose98
+.4byte sArticunoPose99
+.4byte sArticunoPose100
+.4byte sArticunoPose101
+.4byte sArticunoPose102
+.4byte sArticunoPose103
+.4byte sArticunoPose104
+.4byte sArticunoPose105
+.4byte sArticunoPose106
+.4byte sArticunoPose107
+.4byte sArticunoPose108
+.4byte sArticunoPose109
+.4byte sArticunoPose110
+.4byte sArticunoPose111
+.4byte sArticunoPose112
+.4byte sArticunoPose113
+.4byte sArticunoPose114
+.4byte sArticunoPose115
+.4byte sArticunoPose116
+.4byte sArticunoPose117
+.4byte sArticunoPose118
+.4byte sArticunoPose119
+.4byte sArticunoPose120
+.4byte sArticunoPose121
+.4byte sArticunoPose122
+.4byte sArticunoPose123
+.4byte sArticunoPose124
+.4byte sArticunoPose125
+.4byte sArticunoPose126
+.4byte sArticunoPose127
+.4byte sArticunoPose128
+.4byte sArticunoPose129
+.4byte sArticunoPose130
+.4byte sArticunoPose131
+.4byte sArticunoPose132
+.4byte sArticunoPose133
+.4byte sArticunoPose134
+.4byte sArticunoPose135
+.4byte sArticunoPose136
+.4byte sArticunoPose137
+.4byte sArticunoPose138
+.4byte sArticunoPose139
+.4byte sArticunoPose140
+.4byte sArticunoPose141
+.4byte sArticunoPose142
+.4byte sArticunoPose143
+.4byte sArticunoPose144
+.4byte sArticunoPose145
+.4byte sArticunoPose146
+.4byte sArticunoPose147
+.4byte sArticunoPose148
+.4byte sArticunoPose149
+.4byte sArticunoPose150
+.4byte sArticunoPose151
+.4byte sArticunoPose152
+.4byte sArticunoPose153
+.4byte sArticunoPose154
+.4byte sArticunoPose155
+.4byte sArticunoPose156
+.4byte sArticunoPose157
+.4byte sArticunoPose158
+.4byte sArticunoPose159
+.4byte sArticunoPose160
+.4byte sArticunoPose161
+.4byte sArticunoPose162
+.4byte sArticunoPose163
+.4byte sArticunoPose164
+.4byte sArticunoPose165
+.4byte sArticunoPose166
+.4byte sArticunoPose167
+.4byte sArticunoPose168
+.4byte sArticunoPose169
+.4byte sArticunoPose170
+.4byte sArticunoPose171
+.4byte sArticunoPose172
+.4byte sArticunoPose173
+.4byte sArticunoPose174
+.4byte sArticunoPose175
+.4byte sArticunoPose176
+.4byte sArticunoPose177
+.4byte sArticunoPose178
+.4byte sArticunoPose179
+.4byte sArticunoPose180
+.4byte sArticunoPose181
+.4byte sArticunoPose182
+.4byte sArticunoPose183
+.4byte sArticunoPose184
+.4byte sArticunoPose185
+.4byte sArticunoPose186
+.4byte sArticunoPose187
+.4byte sArticunoPose188
+.4byte sArticunoPose189
+.4byte sArticunoPose190
+.4byte sArticunoPose191
+.4byte sArticunoPose192
+.4byte sArticunoPose193
+.4byte sArticunoPose194
+.4byte sArticunoPose195
+.4byte sArticunoPose196
+.4byte sArticunoPose197
+.4byte sArticunoPose198
+.4byte sArticunoPose199
+.4byte sArticunoPose200
+.4byte sArticunoPose201
+.4byte sArticunoPose202
+.4byte sArticunoPose203
+.4byte sArticunoPose204
+.4byte sArticunoPose205
+.4byte sArticunoPose206
+.4byte sArticunoPose207
+.4byte sArticunoPose208
+.4byte sArticunoPose209
+.4byte sArticunoPose210
+.4byte sArticunoPose211
+.4byte sArticunoPose212
+.4byte sArticunoPose213
+.4byte sArticunoPose214
+.4byte sArticunoPose215
+.4byte sArticunoPose216
+.4byte sArticunoPose217
+.4byte sArticunoPose218
+.4byte sArticunoPose219
+.4byte sArticunoPose220
+.4byte sArticunoPose221
+.4byte sArticunoPose222
+.4byte sArticunoPose223
+.4byte sArticunoPose224
+.4byte sArticunoPose225
+.4byte sArticunoPose226
+.4byte sArticunoPose227
+.4byte sArticunoPose228
+.4byte sArticunoPose229
+.4byte sArticunoPose230
+.4byte sArticunoPose231
+.4byte sArticunoPose232
+.4byte sArticunoPose233
+.4byte sArticunoPose234
+.4byte sArticunoPose235
+.4byte sArticunoPose236
+.4byte sArticunoPose237
+.4byte sArticunoPose238
+.4byte sArticunoPose239
+.4byte sArticunoPose240
+.4byte sArticunoPose241
+.4byte sArticunoPose242
+.4byte sArticunoPose243
+.4byte sArticunoPose244
+.4byte sArticunoPose245
+.4byte sArticunoPose246
+.4byte sArticunoPose247
+.4byte sArticunoPose248
+.4byte sArticunoPose249
+.4byte sArticunoPose250
+.4byte sArticunoPose251
+.4byte sArticunoPose252
+.4byte sArticunoPose253
+.4byte sArticunoPose254
+.4byte sArticunoPose255
+.4byte sArticunoPose256
+.4byte sArticunoPose257
+.4byte sArticunoPose258
+.4byte sArticunoPose259
+.4byte sArticunoPose260
+.4byte sArticunoPose261
+.4byte sArticunoPose262
+.4byte sArticunoPose263
+.4byte sArticunoPose264
+.4byte sArticunoPose265
+sAxPositionsArticuno:
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte    0,   -9, 	 -15,  -35, 	  15,  -35, 	   0,  -15
+.2byte    0,  -15, 	 -15,    3, 	  15,    3, 	   0,  -18
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte   12,  -10, 	  -8,  -31, 	   6,  -39, 	   1,  -13
+.2byte   10,  -17, 	   5,    1, 	  21,   -6, 	   5,  -16
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   17,  -13, 	  -3,  -30, 	   0,  -41, 	   7,  -12
+.2byte   14,  -21, 	  14,    2, 	  21,   -4, 	   9,  -16
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   10,  -17, 	  18,  -33, 	  -7,  -39, 	   4,  -15
+.2byte   10,  -21, 	  19,   -1, 	   3,   -9, 	   3,  -17
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte    0,  -19, 	  17,  -35, 	 -17,  -35, 	   0,  -12
+.2byte    0,  -23, 	  13,   -6, 	 -13,   -6, 	   0,  -12
+.2byte  -11,  -18, 	  14,  -33, 	 -21,  -18, 	  -3,  -15
+.2byte  -10,  -17, 	   7,  -39, 	 -18,  -33, 	  -4,  -15
+.2byte  -10,  -21, 	  -3,   -9, 	 -19,   -1, 	  -3,  -17
+.2byte  -15,  -17, 	   2,  -33, 	   3,  -19, 	  -4,  -14
+.2byte  -17,  -13, 	   0,  -41, 	   3,  -30, 	  -7,  -12
+.2byte  -14,  -21, 	 -21,   -4, 	 -14,    2, 	  -9,  -16
+.2byte  -11,  -13, 	 -18,  -35, 	  19,  -20, 	  -4,  -14
+.2byte  -12,  -10, 	  -6,  -39, 	   8,  -31, 	  -1,  -13
+.2byte  -10,  -17, 	 -21,   -6, 	  -5,    1, 	  -5,  -16
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte    0,  -11, 	 -15,  -37, 	  15,  -37, 	   0,  -17
+.2byte    0,  -13, 	 -15,    5, 	  15,    5, 	   0,  -16
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte   12,  -12, 	  -8,  -33, 	   6,  -41, 	   1,  -15
+.2byte   10,  -17, 	   5,    1, 	  21,   -6, 	   5,  -16
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   16,  -15, 	  -4,  -32, 	  -1,  -43, 	   6,  -14
+.2byte   14,  -21, 	  14,    2, 	  21,   -4, 	   9,  -16
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   10,  -20, 	  18,  -36, 	  -7,  -42, 	   4,  -18
+.2byte   10,  -21, 	  19,   -1, 	   3,   -9, 	   3,  -17
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte    0,  -21, 	  17,  -37, 	 -17,  -37, 	   0,  -14
+.2byte    0,  -23, 	  13,   -6, 	 -13,   -6, 	   0,  -12
+.2byte  -12,  -18, 	  13,  -33, 	 -22,  -18, 	  -4,  -15
+.2byte  -11,  -20, 	   6,  -42, 	 -19,  -36, 	  -5,  -18
+.2byte  -11,  -21, 	  -4,   -9, 	 -20,   -1, 	  -4,  -17
+.2byte  -16,  -17, 	   1,  -33, 	   2,  -19, 	  -5,  -14
+.2byte  -17,  -15, 	   0,  -43, 	   3,  -32, 	  -7,  -14
+.2byte  -15,  -21, 	 -22,   -4, 	 -15,    2, 	 -10,  -16
+.2byte  -12,  -13, 	 -19,  -35, 	  18,  -20, 	  -5,  -14
+.2byte  -13,  -12, 	  -7,  -41, 	   7,  -33, 	  -2,  -15
+.2byte  -11,  -17, 	 -22,   -6, 	  -6,    1, 	  -6,  -16
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte    0,  -11, 	 -15,  -37, 	  15,  -37, 	   0,  -17
+.2byte    0,  -13, 	 -15,    5, 	  15,    5, 	   0,  -16
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte   12,  -12, 	  -8,  -33, 	   6,  -41, 	   1,  -15
+.2byte   10,  -17, 	   5,    1, 	  21,   -6, 	   5,  -16
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   16,  -15, 	  -4,  -32, 	  -1,  -43, 	   6,  -14
+.2byte   14,  -21, 	  14,    2, 	  21,   -4, 	   9,  -16
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   10,  -20, 	  18,  -36, 	  -7,  -42, 	   4,  -18
+.2byte   10,  -21, 	  19,   -1, 	   3,   -9, 	   3,  -17
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte    0,  -21, 	  17,  -37, 	 -17,  -37, 	   0,  -14
+.2byte    0,  -23, 	  13,   -6, 	 -13,   -6, 	   0,  -12
+.2byte  -12,  -18, 	  13,  -33, 	 -22,  -18, 	  -4,  -15
+.2byte  -11,  -20, 	   6,  -42, 	 -19,  -36, 	  -5,  -18
+.2byte  -11,  -21, 	  -4,   -9, 	 -20,   -1, 	  -4,  -17
+.2byte  -16,  -17, 	   1,  -33, 	   2,  -19, 	  -5,  -14
+.2byte  -17,  -15, 	   0,  -43, 	   3,  -32, 	  -7,  -14
+.2byte  -15,  -21, 	 -22,   -4, 	 -15,    2, 	 -10,  -16
+.2byte  -12,  -13, 	 -19,  -35, 	  18,  -20, 	  -5,  -14
+.2byte  -13,  -12, 	  -7,  -41, 	   7,  -33, 	  -2,  -15
+.2byte  -11,  -17, 	 -22,   -6, 	  -6,    1, 	  -6,  -16
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte    0,   -9, 	 -15,  -35, 	  15,  -35, 	   0,  -15
+.2byte    0,  -15, 	 -15,    3, 	  15,    3, 	   0,  -18
+.2byte    0,  -22, 	 -27,  -29, 	  27,  -29, 	   0,  -18
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -16
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte   12,  -10, 	  -8,  -31, 	   6,  -39, 	   1,  -13
+.2byte   10,  -17, 	   5,    1, 	  21,   -6, 	   5,  -16
+.2byte    8,  -16, 	 -18,  -28, 	   7,  -39, 	   1,  -13
+.2byte   10,  -13, 	 -19,  -20, 	  16,  -34, 	   4,  -14
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   17,  -13, 	  -3,  -30, 	   0,  -41, 	   7,  -12
+.2byte   14,  -21, 	  14,    2, 	  21,   -4, 	   9,  -16
+.2byte   10,  -23, 	 -11,  -32, 	  -4,  -39, 	   3,  -17
+.2byte   13,  -17, 	  -5,  -19, 	  -4,  -33, 	   3,  -13
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   10,  -17, 	  18,  -33, 	  -7,  -39, 	   4,  -15
+.2byte   10,  -21, 	  19,   -1, 	   3,   -9, 	   3,  -17
+.2byte   10,  -23, 	  20,  -28, 	  -9,  -37, 	   4,  -18
+.2byte   12,  -19, 	  21,  -18, 	 -14,  -33, 	   2,  -15
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte    0,  -19, 	  17,  -35, 	 -17,  -35, 	   0,  -12
+.2byte    0,  -23, 	  13,   -6, 	 -13,   -6, 	   0,  -12
+.2byte    0,  -25, 	  25,  -33, 	 -25,  -33, 	   0,  -19
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte  -12,  -18, 	  13,  -33, 	 -22,  -18, 	  -4,  -15
+.2byte  -11,  -17, 	   6,  -39, 	 -19,  -33, 	  -5,  -15
+.2byte  -11,  -21, 	  -4,   -9, 	 -20,   -1, 	  -4,  -17
+.2byte  -11,  -23, 	   8,  -37, 	 -21,  -28, 	  -5,  -18
+.2byte  -13,  -19, 	  13,  -33, 	 -22,  -18, 	  -3,  -15
+.2byte  -16,  -17, 	   1,  -33, 	   2,  -19, 	  -5,  -14
+.2byte  -18,  -13, 	  -1,  -41, 	   2,  -30, 	  -8,  -12
+.2byte  -15,  -21, 	 -22,   -4, 	 -15,    2, 	 -10,  -16
+.2byte  -11,  -23, 	   3,  -39, 	  10,  -32, 	  -4,  -17
+.2byte  -14,  -17, 	   3,  -33, 	   4,  -19, 	  -4,  -13
+.2byte  -12,  -13, 	 -19,  -35, 	  18,  -20, 	  -5,  -14
+.2byte  -13,  -10, 	  -7,  -39, 	   7,  -31, 	  -2,  -13
+.2byte  -11,  -17, 	 -22,   -6, 	  -6,    1, 	  -6,  -16
+.2byte   -9,  -16, 	  -8,  -39, 	  17,  -28, 	  -2,  -13
+.2byte  -11,  -13, 	 -17,  -34, 	  18,  -20, 	  -5,  -14
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte    0,   -9, 	 -15,  -35, 	  15,  -35, 	   0,  -15
+.2byte    0,  -15, 	 -15,    3, 	  15,    3, 	   0,  -18
+.2byte    0,  -22, 	 -27,  -29, 	  27,  -29, 	   0,  -18
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -16
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte   12,  -10, 	  -8,  -31, 	   6,  -39, 	   1,  -13
+.2byte   10,  -17, 	   5,    1, 	  21,   -6, 	   5,  -16
+.2byte    8,  -16, 	 -18,  -28, 	   7,  -39, 	   1,  -13
+.2byte   10,  -13, 	 -19,  -20, 	  16,  -34, 	   4,  -14
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   17,  -13, 	  -3,  -30, 	   0,  -41, 	   7,  -12
+.2byte   14,  -21, 	  14,    2, 	  21,   -4, 	   9,  -16
+.2byte   10,  -23, 	 -11,  -32, 	  -4,  -39, 	   3,  -17
+.2byte   13,  -17, 	  -5,  -19, 	  -4,  -33, 	   3,  -13
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   10,  -17, 	  18,  -33, 	  -7,  -39, 	   4,  -15
+.2byte   10,  -21, 	  19,   -1, 	   3,   -9, 	   3,  -17
+.2byte   10,  -23, 	  20,  -28, 	  -9,  -37, 	   4,  -18
+.2byte   12,  -19, 	  21,  -18, 	 -14,  -33, 	   2,  -15
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte    0,  -19, 	  17,  -35, 	 -17,  -35, 	   0,  -12
+.2byte    0,  -23, 	  13,   -6, 	 -13,   -6, 	   0,  -12
+.2byte    0,  -25, 	  25,  -33, 	 -25,  -33, 	   0,  -19
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte  -12,  -18, 	  13,  -33, 	 -22,  -18, 	  -4,  -15
+.2byte  -11,  -17, 	   6,  -39, 	 -19,  -33, 	  -5,  -15
+.2byte  -11,  -21, 	  -4,   -9, 	 -20,   -1, 	  -4,  -17
+.2byte  -11,  -23, 	   8,  -37, 	 -21,  -28, 	  -5,  -18
+.2byte  -13,  -19, 	  13,  -33, 	 -22,  -18, 	  -3,  -15
+.2byte  -16,  -17, 	   1,  -33, 	   2,  -19, 	  -5,  -14
+.2byte  -18,  -13, 	  -1,  -41, 	   2,  -30, 	  -8,  -12
+.2byte  -15,  -21, 	 -22,   -4, 	 -15,    2, 	 -10,  -16
+.2byte  -11,  -23, 	   3,  -39, 	  10,  -32, 	  -4,  -17
+.2byte  -14,  -17, 	   3,  -33, 	   4,  -19, 	  -4,  -13
+.2byte  -12,  -13, 	 -19,  -35, 	  18,  -20, 	  -5,  -14
+.2byte  -13,  -10, 	  -7,  -39, 	   7,  -31, 	  -2,  -13
+.2byte  -11,  -17, 	 -22,   -6, 	  -6,    1, 	  -6,  -16
+.2byte   -9,  -16, 	  -8,  -39, 	  17,  -28, 	  -2,  -13
+.2byte  -11,  -13, 	 -17,  -34, 	  18,  -20, 	  -5,  -14
+.2byte   -7,  -13, 	  -1,  -11, 	   7,   -8, 	   2,   -8
+.2byte   -8,  -12, 	   0,  -10, 	   6,   -8, 	   2,   -7
+.2byte    0,  -21, 	 -19,  -37, 	  19,  -37, 	   0,  -17
+.2byte    3,  -19, 	 -14,  -35, 	   6,  -41, 	   0,  -16
+.2byte    5,  -21, 	  -9,  -32, 	  -6,  -41, 	  -1,  -16
+.2byte    2,  -20, 	  11,  -31, 	 -13,  -36, 	  -3,  -17
+.2byte    0,  -20, 	  20,  -37, 	 -20,  -37, 	   0,  -15
+.2byte   -3,  -20, 	  12,  -36, 	 -12,  -31, 	   2,  -17
+.2byte   -6,  -21, 	   5,  -41, 	   8,  -32, 	   0,  -16
+.2byte   -4,  -19, 	  -7,  -41, 	  13,  -35, 	  -1,  -16
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte    0,   -9, 	 -15,  -35, 	  15,  -35, 	   0,  -15
+.2byte    0,  -15, 	 -15,    3, 	  15,    3, 	   0,  -18
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte   12,  -10, 	  -8,  -31, 	   6,  -39, 	   1,  -13
+.2byte   10,  -17, 	   5,    1, 	  21,   -6, 	   5,  -16
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   17,  -13, 	  -3,  -30, 	   0,  -41, 	   7,  -12
+.2byte   14,  -21, 	  14,    2, 	  21,   -4, 	   9,  -16
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   10,  -17, 	  18,  -33, 	  -7,  -39, 	   4,  -15
+.2byte   10,  -21, 	  19,   -1, 	   3,   -9, 	   3,  -17
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte    0,  -19, 	  17,  -35, 	 -17,  -35, 	   0,  -12
+.2byte    0,  -23, 	  13,   -6, 	 -13,   -6, 	   0,  -12
+.2byte  -11,  -18, 	  14,  -33, 	 -21,  -18, 	  -3,  -15
+.2byte  -10,  -17, 	   7,  -39, 	 -18,  -33, 	  -4,  -15
+.2byte  -10,  -21, 	  -3,   -9, 	 -19,   -1, 	  -3,  -17
+.2byte  -15,  -17, 	   2,  -33, 	   3,  -19, 	  -4,  -14
+.2byte  -17,  -13, 	   0,  -41, 	   3,  -30, 	  -7,  -12
+.2byte  -14,  -21, 	 -21,   -4, 	 -14,    2, 	  -9,  -16
+.2byte  -11,  -13, 	 -18,  -35, 	  19,  -20, 	  -4,  -14
+.2byte  -12,  -10, 	  -6,  -39, 	   8,  -31, 	  -1,  -13
+.2byte  -10,  -17, 	 -21,   -6, 	  -5,    1, 	  -5,  -16
+.2byte    0,  -20, 	 -27,  -27, 	  27,  -27, 	   0,  -16
+.2byte  -10,  -20, 	  -9,  -43, 	  16,  -32, 	  -3,  -17
+.2byte  -12,  -23, 	   2,  -39, 	   9,  -32, 	  -5,  -17
+.2byte   -8,  -26, 	  11,  -40, 	 -18,  -31, 	  -2,  -21
+.2byte    0,  -28, 	  25,  -36, 	 -25,  -36, 	   0,  -22
+.2byte    8,  -26, 	  18,  -31, 	 -11,  -40, 	   2,  -21
+.2byte   12,  -23, 	  -9,  -32, 	  -2,  -39, 	   5,  -17
+.2byte    9,  -20, 	 -17,  -32, 	   8,  -43, 	   2,  -17
+.2byte    0,  -20, 	 -27,  -27, 	  27,  -27, 	   0,  -16
+.2byte    9,  -20, 	 -17,  -32, 	   8,  -43, 	   2,  -17
+.2byte   12,  -23, 	  -9,  -32, 	  -2,  -39, 	   5,  -17
+.2byte    8,  -26, 	  18,  -31, 	 -11,  -40, 	   2,  -21
+.2byte    0,  -28, 	  25,  -36, 	 -25,  -36, 	   0,  -22
+.2byte   -8,  -26, 	  11,  -40, 	 -18,  -31, 	  -2,  -21
+.2byte  -12,  -23, 	   2,  -39, 	   9,  -32, 	  -5,  -17
+.2byte  -10,  -20, 	  -9,  -43, 	  16,  -32, 	  -3,  -17
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte    0,   -9, 	 -15,  -35, 	  15,  -35, 	   0,  -15
+.2byte    0,  -15, 	 -15,    3, 	  15,    3, 	   0,  -18
+.2byte    0,  -22, 	 -27,  -29, 	  27,  -29, 	   0,  -18
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte   12,  -10, 	  -8,  -31, 	   6,  -39, 	   1,  -13
+.2byte   10,  -17, 	   5,    1, 	  21,   -6, 	   5,  -16
+.2byte    8,  -16, 	 -18,  -28, 	   7,  -39, 	   1,  -13
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   17,  -13, 	  -3,  -30, 	   0,  -41, 	   7,  -12
+.2byte   14,  -21, 	  14,    2, 	  21,   -4, 	   9,  -16
+.2byte   10,  -23, 	 -11,  -32, 	  -4,  -39, 	   3,  -17
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   10,  -17, 	  18,  -33, 	  -7,  -39, 	   4,  -15
+.2byte   10,  -21, 	  19,   -1, 	   3,   -9, 	   3,  -17
+.2byte   10,  -23, 	  20,  -28, 	  -9,  -37, 	   4,  -18
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte    0,  -19, 	  17,  -35, 	 -17,  -35, 	   0,  -12
+.2byte    0,  -23, 	  13,   -6, 	 -13,   -6, 	   0,  -12
+.2byte    0,  -25, 	  25,  -33, 	 -25,  -33, 	   0,  -19
+.2byte  -11,  -18, 	  14,  -33, 	 -21,  -18, 	  -3,  -15
+.2byte  -10,  -17, 	   7,  -39, 	 -18,  -33, 	  -4,  -15
+.2byte  -10,  -21, 	  -3,   -9, 	 -19,   -1, 	  -3,  -17
+.2byte  -10,  -23, 	   9,  -37, 	 -20,  -28, 	  -4,  -18
+.2byte  -15,  -17, 	   2,  -33, 	   3,  -19, 	  -4,  -14
+.2byte  -17,  -13, 	   0,  -41, 	   3,  -30, 	  -7,  -12
+.2byte  -14,  -21, 	 -21,   -4, 	 -14,    2, 	  -9,  -16
+.2byte  -10,  -23, 	   4,  -39, 	  11,  -32, 	  -3,  -17
+.2byte  -11,  -13, 	 -18,  -35, 	  19,  -20, 	  -4,  -14
+.2byte  -12,  -10, 	  -6,  -39, 	   8,  -31, 	  -1,  -13
+.2byte  -10,  -17, 	 -21,   -6, 	  -5,    1, 	  -5,  -16
+.2byte  -10,  -16, 	  -9,  -39, 	  16,  -28, 	  -3,  -13
+.2byte    0,  -20, 	 -27,  -27, 	  27,  -27, 	   0,  -16
+.2byte  -10,  -20, 	  -9,  -43, 	  16,  -32, 	  -3,  -17
+.2byte  -12,  -23, 	   2,  -39, 	   9,  -32, 	  -5,  -17
+.2byte   -8,  -26, 	  11,  -40, 	 -18,  -31, 	  -2,  -21
+.2byte    0,  -28, 	  25,  -36, 	 -25,  -36, 	   0,  -22
+.2byte    8,  -26, 	  18,  -31, 	 -11,  -40, 	   2,  -21
+.2byte   12,  -23, 	  -9,  -32, 	  -2,  -39, 	   5,  -17
+.2byte    9,  -20, 	 -17,  -32, 	   8,  -43, 	   2,  -17
+.2byte    0,  -12, 	 -27,  -26, 	  27,  -26, 	   0,  -18
+.2byte  -11,  -13, 	 -18,  -35, 	  19,  -20, 	  -4,  -14
+.2byte  -15,  -17, 	   2,  -33, 	   3,  -19, 	  -4,  -14
+.2byte  -11,  -18, 	  14,  -33, 	 -21,  -18, 	  -3,  -15
+.2byte    0,  -21, 	  27,  -28, 	 -27,  -28, 	   0,  -17
+.2byte   11,  -18, 	  21,  -18, 	 -14,  -33, 	   3,  -15
+.2byte   15,  -17, 	  -3,  -19, 	  -2,  -33, 	   4,  -14
+.2byte   11,  -13, 	 -19,  -20, 	  18,  -35, 	   4,  -14
+.2byte    0,   -7, 	 -26,    1, 	  26,    1, 	   0,   -6
+.2byte    0,   -9, 	 -25,    1, 	  25,    1, 	   0,   -7
+.2byte    0,   -7, 	 -26,    1, 	  26,    1, 	   0,   -6
+.2byte    0,   -9, 	 -25,    1, 	  25,    1, 	   0,   -7
+.2byte    0,  -11, 	 -26,   -1, 	  26,   -1, 	   0,   -9
+.2byte    0,  -13, 	 -26,  -22, 	  27,  -23, 	   0,  -11
+.2byte    0,  -17, 	 -18,  -34, 	  19,  -34, 	   0,  -13
+.2byte    0,  -17, 	 -18,  -34, 	  19,  -34, 	   0,  -13
+.2byte    0,  -15, 	 -24,   -7, 	  25,   -7, 	   0,  -12
+.2byte    0,  -14, 	 -12,   -3, 	  12,   -3, 	   0,  -11
+.2byte    0,  -13, 	  -7,   -5, 	   7,   -5, 	   0,  -11
+.2byte    0,  -17, 	 -18,  -34, 	  19,  -34, 	   0,  -13
+.2byte    0,  -15, 	 -24,   -7, 	  25,   -7, 	   0,  -12
+.2byte    0,  -14, 	 -12,   -3, 	  12,   -3, 	   0,  -11
+.2byte    0,  -13, 	  -7,   -5, 	   7,   -5, 	   0,  -11
+sArticunoAnimTable1:
+.4byte sArticunoAnims_1_1
+.4byte sArticunoAnims_1_2
+.4byte sArticunoAnims_1_3
+.4byte sArticunoAnims_1_4
+.4byte sArticunoAnims_1_5
+.4byte sArticunoAnims_1_6
+.4byte sArticunoAnims_1_7
+.4byte sArticunoAnims_1_8
+sArticunoAnimTable2:
+.4byte sArticunoAnims_2_1
+.4byte sArticunoAnims_2_2
+.4byte sArticunoAnims_2_3
+.4byte sArticunoAnims_2_4
+.4byte sArticunoAnims_2_5
+.4byte sArticunoAnims_2_6
+.4byte sArticunoAnims_2_7
+.4byte sArticunoAnims_2_8
+sArticunoAnimTable3:
+.4byte sArticunoAnims_3_1
+.4byte sArticunoAnims_3_2
+.4byte sArticunoAnims_3_3
+.4byte sArticunoAnims_3_4
+.4byte sArticunoAnims_3_5
+.4byte sArticunoAnims_3_6
+.4byte sArticunoAnims_3_7
+.4byte sArticunoAnims_3_8
+sArticunoAnimTable4:
+.4byte sArticunoAnims_4_1
+.4byte sArticunoAnims_4_2
+.4byte sArticunoAnims_4_3
+.4byte sArticunoAnims_4_4
+.4byte sArticunoAnims_4_5
+.4byte sArticunoAnims_4_6
+.4byte sArticunoAnims_4_7
+.4byte sArticunoAnims_4_8
+sArticunoAnimTable5:
+.4byte sArticunoAnims_5_1
+.4byte sArticunoAnims_5_2
+.4byte sArticunoAnims_5_3
+.4byte sArticunoAnims_5_4
+.4byte sArticunoAnims_5_5
+.4byte sArticunoAnims_5_6
+.4byte sArticunoAnims_5_7
+.4byte sArticunoAnims_5_8
+sArticunoAnimTable6:
+.4byte sArticunoAnims_6_1
+.4byte sArticunoAnims_6_1
+.4byte sArticunoAnims_6_1
+.4byte sArticunoAnims_6_1
+.4byte sArticunoAnims_6_1
+.4byte sArticunoAnims_6_1
+.4byte sArticunoAnims_6_1
+.4byte sArticunoAnims_6_1
+sArticunoAnimTable7:
+.4byte sArticunoAnims_7_1
+.4byte sArticunoAnims_7_2
+.4byte sArticunoAnims_7_3
+.4byte sArticunoAnims_7_4
+.4byte sArticunoAnims_7_5
+.4byte sArticunoAnims_7_6
+.4byte sArticunoAnims_7_7
+.4byte sArticunoAnims_7_8
+sArticunoAnimTable8:
+.4byte sArticunoAnims_8_1
+.4byte sArticunoAnims_8_2
+.4byte sArticunoAnims_8_3
+.4byte sArticunoAnims_8_4
+.4byte sArticunoAnims_8_5
+.4byte sArticunoAnims_8_6
+.4byte sArticunoAnims_8_7
+.4byte sArticunoAnims_8_8
+sArticunoAnimTable9:
+.4byte sArticunoAnims_9_1
+.4byte sArticunoAnims_9_2
+.4byte sArticunoAnims_9_3
+.4byte sArticunoAnims_9_4
+.4byte sArticunoAnims_9_5
+.4byte sArticunoAnims_9_6
+.4byte sArticunoAnims_9_7
+.4byte sArticunoAnims_9_8
+sArticunoAnimTable10:
+.4byte sArticunoAnims_10_1
+.4byte sArticunoAnims_10_2
+.4byte sArticunoAnims_10_3
+.4byte sArticunoAnims_10_4
+.4byte sArticunoAnims_10_5
+.4byte sArticunoAnims_10_6
+.4byte sArticunoAnims_10_7
+.4byte sArticunoAnims_10_8
+sArticunoAnimTable11:
+.4byte sArticunoAnims_11_1
+.4byte sArticunoAnims_11_2
+.4byte sArticunoAnims_11_3
+.4byte sArticunoAnims_11_4
+.4byte sArticunoAnims_11_5
+.4byte sArticunoAnims_11_6
+.4byte sArticunoAnims_11_7
+.4byte sArticunoAnims_11_8
+sArticunoAnimTable12:
+.4byte sArticunoAnims_12_1
+.4byte sArticunoAnims_12_2
+.4byte sArticunoAnims_12_3
+.4byte sArticunoAnims_12_4
+.4byte sArticunoAnims_12_5
+.4byte sArticunoAnims_12_6
+.4byte sArticunoAnims_12_7
+.4byte sArticunoAnims_12_8
+sArticunoAnimTable13:
+.4byte sArticunoAnims_13_1
+.4byte sArticunoAnims_13_2
+.4byte sArticunoAnims_13_3
+.4byte sArticunoAnims_13_4
+.4byte sArticunoAnims_13_5
+.4byte sArticunoAnims_13_6
+.4byte sArticunoAnims_13_7
+.4byte sArticunoAnims_13_8
+sArticunoAnimTable14:
+.4byte sArticunoAnims_14_1
+.4byte sArticunoAnims_14_2
+.4byte sArticunoAnims_14_3
+.4byte sArticunoAnims_14_4
+.4byte sArticunoAnims_14_5
+.4byte sArticunoAnims_14_6
+.4byte sArticunoAnims_14_7
+.4byte sArticunoAnims_14_8
+sArticunoAnimTable15:
+.4byte sArticunoAnims_15_1
+.4byte sArticunoAnims_15_2
+.4byte sArticunoAnims_15_3
+.4byte sArticunoAnims_15_4
+.4byte sArticunoAnims_15_5
+.4byte sArticunoAnims_15_6
+.4byte sArticunoAnims_15_7
+.4byte sArticunoAnims_15_8
+sArticunoAnimTable16:
+.4byte sArticunoAnims_16_1
+.4byte sArticunoAnims_16_2
+.4byte sArticunoAnims_16_3
+.4byte sArticunoAnims_16_4
+.4byte sArticunoAnims_16_5
+.4byte sArticunoAnims_16_6
+.4byte sArticunoAnims_16_7
+.4byte sArticunoAnims_16_8
+sArticunoAnimTable17:
+.4byte sArticunoAnims_17_1
+.4byte sArticunoAnims_17_1
+.4byte sArticunoAnims_17_1
+.4byte sArticunoAnims_17_1
+.4byte sArticunoAnims_17_1
+.4byte sArticunoAnims_17_1
+.4byte sArticunoAnims_17_1
+.4byte sArticunoAnims_17_1
+sAxAnimationsArticuno:
+.4byte sArticunoAnimTable1
+.4byte sArticunoAnimTable2
+.4byte sArticunoAnimTable3
+.4byte sArticunoAnimTable4
+.4byte sArticunoAnimTable5
+.4byte sArticunoAnimTable6
+.4byte sArticunoAnimTable7
+.4byte sArticunoAnimTable8
+.4byte sArticunoAnimTable9
+.4byte sArticunoAnimTable10
+.4byte sArticunoAnimTable11
+.4byte sArticunoAnimTable12
+.4byte sArticunoAnimTable13
+.4byte sArticunoAnimTable14
+.4byte sArticunoAnimTable15
+.4byte sArticunoAnimTable16
+.4byte sArticunoAnimTable17
+sAxSpritesArticuno:
+.4byte sArticunoSprites1
+.4byte sArticunoSprites2
+.4byte sArticunoSprites3
+.4byte sArticunoSprites4
+.4byte sArticunoSprites5
+.4byte sArticunoSprites6
+.4byte sArticunoSprites7
+.4byte sArticunoSprites8
+.4byte sArticunoSprites9
+.4byte sArticunoSprites10
+.4byte sArticunoSprites11
+.4byte sArticunoSprites12
+.4byte sArticunoSprites13
+.4byte sArticunoSprites14
+.4byte sArticunoSprites15
+.4byte sArticunoSprites16
+.4byte sArticunoSprites17
+.4byte sArticunoSprites18
+.4byte sArticunoSprites19
+.4byte sArticunoSprites20
+.4byte sArticunoSprites21
+.4byte sArticunoSprites22
+.4byte sArticunoSprites23
+.4byte sArticunoSprites24
+.4byte sArticunoSprites25
+.4byte sArticunoSprites26
+.4byte sArticunoSprites27
+.4byte sArticunoSprites28
+.4byte sArticunoSprites29
+.4byte sArticunoSprites30
+.4byte sArticunoSprites31
+.4byte sArticunoSprites32
+.4byte sArticunoSprites33
+.4byte sArticunoSprites34
+.4byte sArticunoSprites35
+.4byte sArticunoSprites36
+.4byte sArticunoSprites37
+.4byte sArticunoSprites38
+.4byte sArticunoSprites39
+.4byte sArticunoSprites40
+.4byte sArticunoSprites41
+.4byte sArticunoSprites42
+.4byte sArticunoSprites43
+.4byte sArticunoSprites44
+.4byte sArticunoSprites45
+.4byte sArticunoSprites46
+.4byte sArticunoSprites47
+.4byte sArticunoSprites48
+.4byte sArticunoSprites49
+.4byte sArticunoSprites50
+.4byte sArticunoSprites51
+.4byte sArticunoSprites52
+.4byte sArticunoSprites53
+.4byte sArticunoSprites54
+.4byte sArticunoSprites55
+.4byte sArticunoSprites56
+.4byte sArticunoSprites57
+.4byte sArticunoSprites58
+.4byte sArticunoSprites59
+.4byte sArticunoSprites60
+.4byte sArticunoSprites61
+.4byte sArticunoSprites62
+.4byte sArticunoSprites63
+.4byte sArticunoSprites64
+.4byte sArticunoSprites65
+.4byte sArticunoSprites66
+.4byte sArticunoSprites67
+.4byte sArticunoSprites68
+.4byte sArticunoSprites69
+.4byte sArticunoSprites70
+.4byte sArticunoSprites71
+.4byte sArticunoSprites72
+.4byte sArticunoSprites73
+.4byte sArticunoSprites74
+.4byte sArticunoSprites75
+.4byte sArticunoSprites76
+.4byte sArticunoSprites77
+.4byte sArticunoSprites78
+.4byte sArticunoSprites79
+.4byte sArticunoSprites80
+.4byte sArticunoSprites81
+.4byte sArticunoSprites82
+.4byte sArticunoSprites83
+.4byte sArticunoSprites84
+.4byte sArticunoSprites85
+.4byte sArticunoSprites86
+.4byte sArticunoSprites87
+.4byte sArticunoSprites88
+.4byte sArticunoSprites89
+.4byte sArticunoSprites90
+.4byte sArticunoSprites91
+.4byte sArticunoSprites92
+.4byte sArticunoSprites93
+.4byte sArticunoSprites94
+.4byte sArticunoSprites95
+.4byte sArticunoSprites96
+.4byte sArticunoSprites97
+.4byte sArticunoSprites98
+.4byte sArticunoSprites99
+.4byte sArticunoSprites100
+.4byte sArticunoSprites101
+.4byte sArticunoSprites102
+.4byte sArticunoSprites103
+.4byte sArticunoSprites104
+.4byte sArticunoSprites105
+.4byte sArticunoSprites106
+.4byte sArticunoSprites107
+.4byte sArticunoSprites108
+.4byte sArticunoSprites109
+.4byte sArticunoSprites110
+.4byte sArticunoSprites111
+.4byte sArticunoSprites112
+.4byte sArticunoSprites113
+.4byte sArticunoSprites114
+.4byte sArticunoSprites115
+.4byte sArticunoSprites116
+.4byte sArticunoSprites117
+.4byte sArticunoSprites118
+.4byte sArticunoSprites119
+.4byte sArticunoSprites120
+.4byte sArticunoSprites121
+.4byte sArticunoSprites122
+.4byte sArticunoSprites123
+.4byte sArticunoSprites124
+.4byte sArticunoSprites125
+.4byte sArticunoSprites126
+.4byte sArticunoSprites127
+.4byte sArticunoSprites128
+.4byte sArticunoSprites129
+.4byte sArticunoSprites130
+.4byte sArticunoSprites131
+.4byte sArticunoSprites132
+.4byte sArticunoSprites133
+.4byte sArticunoSprites134
+.4byte sArticunoSprites135
+.4byte sArticunoSprites136
+.4byte sArticunoSprites137
+.4byte sArticunoSprites138
+sAxMainArticuno:
+ax_main sAxPosesArticuno, sAxAnimationsArticuno, 17, sAxSpritesArticuno, sAxPositionsArticuno

--- a/data/ax/azumarill.inc
+++ b/data/ax/azumarill.inc
@@ -1,0 +1,2871 @@
+.global gAxAzumarill
+gAxAzumarill:
+ax_siro sAxMainAzumarill
+sAzumarillPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose4:
+ax_pose 3, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose5:
+ax_pose 4, 0x01e6, 0x90e9, 0x5c00
+ax_pose_terminator
+sAzumarillPose6:
+ax_pose 5, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose7:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose8:
+ax_pose 7, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose9:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose10:
+ax_pose 9, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose11:
+ax_pose 10, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose12:
+ax_pose 11, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose16:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose17:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose18:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose20:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose22:
+ax_pose 3, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose23:
+ax_pose 4, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sAzumarillPose24:
+ax_pose 5, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose26:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose28:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose29:
+ax_pose 3, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose30:
+ax_pose 4, 0x01e6, 0x90e9, 0x5c00
+ax_pose_terminator
+sAzumarillPose31:
+ax_pose 5, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose32:
+ax_pose 16, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose33:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose34:
+ax_pose 7, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose35:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose36:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose37:
+ax_pose 9, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose38:
+ax_pose 10, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose39:
+ax_pose 11, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose40:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose41:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose42:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose43:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose44:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose45:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose46:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose47:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose48:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose49:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose50:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose51:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose52:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose53:
+ax_pose 3, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose54:
+ax_pose 4, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sAzumarillPose55:
+ax_pose 5, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose56:
+ax_pose 16, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose57:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose58:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose59:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose60:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose61:
+ax_pose 3, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose62:
+ax_pose 4, 0x01e6, 0x90e9, 0x5c00
+ax_pose_terminator
+sAzumarillPose63:
+ax_pose 5, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose64:
+ax_pose 16, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose65:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose66:
+ax_pose 7, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose67:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose68:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose69:
+ax_pose 9, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose70:
+ax_pose 10, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose71:
+ax_pose 11, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose72:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose73:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose74:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose75:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose76:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose77:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose78:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose79:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose80:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose81:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose82:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose83:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose84:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose85:
+ax_pose 3, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose86:
+ax_pose 4, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sAzumarillPose87:
+ax_pose 5, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose88:
+ax_pose 16, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose89:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose90:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose91:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose92:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose93:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose94:
+ax_pose 3, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose95:
+ax_pose 4, 0x01e6, 0x90e9, 0x5c00
+ax_pose_terminator
+sAzumarillPose96:
+ax_pose 5, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose97:
+ax_pose 21, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose98:
+ax_pose 16, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose99:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose100:
+ax_pose 7, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose101:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose102:
+ax_pose 22, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose103:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose104:
+ax_pose 9, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose105:
+ax_pose 10, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose106:
+ax_pose 11, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose107:
+ax_pose 23, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose108:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose109:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose110:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose111:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose112:
+ax_pose 24, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose113:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose114:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose115:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose116:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose117:
+ax_pose 23, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose118:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose119:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose120:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose121:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose122:
+ax_pose 22, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose123:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose124:
+ax_pose 3, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose125:
+ax_pose 4, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sAzumarillPose126:
+ax_pose 5, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose127:
+ax_pose 21, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose128:
+ax_pose 16, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose129:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose130:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose131:
+ax_pose 25, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose132:
+ax_pose 26, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose133:
+ax_pose 27, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose134:
+ax_pose 28, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose135:
+ax_pose 29, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose136:
+ax_pose 30, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose137:
+ax_pose 31, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose138:
+ax_pose 32, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose139:
+ax_pose 21, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose140:
+ax_pose 16, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose141:
+ax_pose 22, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose142:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose143:
+ax_pose 23, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose144:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose145:
+ax_pose 24, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose146:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose147:
+ax_pose 23, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose148:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose149:
+ax_pose 22, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose150:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose151:
+ax_pose 21, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose152:
+ax_pose 16, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose153:
+ax_pose 33, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose154:
+ax_pose 34, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose155:
+ax_pose 35, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose156:
+ax_pose 36, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzumarillPose157:
+ax_pose 37, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose158:
+ax_pose 38, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose159:
+ax_pose 39, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose160:
+ax_pose 38, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose161:
+ax_pose 37, 0x01e2, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose162:
+ax_pose 36, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sAzumarillPose163:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose164:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose165:
+ax_pose 3, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose166:
+ax_pose 4, 0x01e6, 0x90e9, 0x5c00
+ax_pose_terminator
+sAzumarillPose167:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose168:
+ax_pose 7, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose169:
+ax_pose 9, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose170:
+ax_pose 10, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose171:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose172:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose173:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose174:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose175:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose176:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose177:
+ax_pose 3, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose178:
+ax_pose 4, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sAzumarillPose179:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose180:
+ax_pose 16, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose181:
+ax_pose 17, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose182:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose183:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose184:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose185:
+ax_pose 17, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose186:
+ax_pose 16, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose187:
+ax_pose 25, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose188:
+ax_pose 26, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose189:
+ax_pose 27, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose190:
+ax_pose 28, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzumarillPose191:
+ax_pose 29, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sAzumarillPose192:
+ax_pose 28, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzumarillPose193:
+ax_pose 27, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzumarillPose194:
+ax_pose 26, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sAzumarillPose195:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose196:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose197:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose198:
+ax_pose 3, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzumarillPose199:
+ax_pose 21, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose200:
+ax_pose 16, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose201:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose202:
+ax_pose 22, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose203:
+ax_pose 17, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose204:
+ax_pose 9, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose205:
+ax_pose 23, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose206:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose207:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose208:
+ax_pose 24, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose209:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose210:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose211:
+ax_pose 23, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose212:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose213:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose214:
+ax_pose 22, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose215:
+ax_pose 17, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose216:
+ax_pose 3, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose217:
+ax_pose 21, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose218:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose219:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose220:
+ax_pose 21, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose221:
+ax_pose 22, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose222:
+ax_pose 23, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose223:
+ax_pose 24, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose224:
+ax_pose 23, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose225:
+ax_pose 22, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose226:
+ax_pose 21, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzumarillPose227:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose228:
+ax_pose 3, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzumarillPose229:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose230:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose231:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzumarillPose232:
+ax_pose 9, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose233:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzumarillPose234:
+ax_pose 3, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+.align 2
+sAzumarillAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 5, 0, 9,
+ax_anim 2, 0, 24, 0, 4, 0, 7,
+ax_anim_terminator
+sAzumarillAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 8, 2, 8, 8,
+ax_anim 2, 0, 28, 4, 2, 4, 4,
+ax_anim_terminator
+sAzumarillAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 8, -5, 8, 0,
+ax_anim 2, 0, 32, 4, -3, 6, 0,
+ax_anim_terminator
+sAzumarillAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -14, 11, -14,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 1, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 36, 8, -11, 8, -8,
+ax_anim 2, 0, 36, 4, -6, 4, -4,
+ax_anim_terminator
+sAzumarillAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -12, 0, -8,
+ax_anim 2, 0, 40, 0, -6, 0, -4,
+ax_anim_terminator
+sAzumarillAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -14, -11, -14,
+ax_anim 2, 0, 47, -19, -23, -19, -23,
+ax_anim 2, 1, 47, -20, -22, -20, -22,
+ax_anim 2, 0, 47, -19, -23, -19, -23,
+ax_anim 2, 0, 47, -20, -22, -20, -22,
+ax_anim 2, 0, 44, -8, -11, -8, -8,
+ax_anim 2, 0, 44, -4, -6, -4, -4,
+ax_anim_terminator
+sAzumarillAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -8, -5, -8, 0,
+ax_anim 2, 0, 48, -4, -3, -6, 0,
+ax_anim_terminator
+sAzumarillAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -12, 12, -12, 12,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 1, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 52, -8, 2, -8, 8,
+ax_anim 2, 0, 52, -4, 2, -4, 4,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 5, 0, 9,
+ax_anim 2, 0, 56, 0, 4, 0, 7,
+ax_anim_terminator
+sAzumarillAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 12, 12, 12, 12,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 1, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 60, 8, 2, 8, 8,
+ax_anim 2, 0, 60, 4, 2, 4, 4,
+ax_anim_terminator
+sAzumarillAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 1, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 0, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 8, -5, 8, 0,
+ax_anim 2, 0, 64, 4, -3, 6, 0,
+ax_anim_terminator
+sAzumarillAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 11, -14, 11, -14,
+ax_anim 2, 0, 71, 19, -23, 19, -23,
+ax_anim 2, 1, 71, 20, -22, 20, -22,
+ax_anim 2, 0, 71, 19, -23, 19, -23,
+ax_anim 2, 0, 71, 20, -22, 20, -22,
+ax_anim 2, 0, 68, 8, -11, 8, -8,
+ax_anim 2, 0, 68, 4, -6, 4, -4,
+ax_anim_terminator
+sAzumarillAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 1, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 72, 0, -12, 0, -8,
+ax_anim 2, 0, 72, 0, -6, 0, -4,
+ax_anim_terminator
+sAzumarillAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -11, -14, -11, -14,
+ax_anim 2, 0, 79, -19, -23, -19, -23,
+ax_anim 2, 1, 79, -20, -22, -20, -22,
+ax_anim 2, 0, 79, -19, -23, -19, -23,
+ax_anim 2, 0, 79, -20, -22, -20, -22,
+ax_anim 2, 0, 76, -8, -11, -8, -8,
+ax_anim 2, 0, 76, -4, -6, -4, -4,
+ax_anim_terminator
+sAzumarillAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 1, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 0, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -8, -5, -8, 0,
+ax_anim 2, 0, 80, -4, -3, -6, 0,
+ax_anim_terminator
+sAzumarillAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -12, 12, -12, 12,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 1, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 84, -8, 2, -8, 8,
+ax_anim 2, 0, 84, -4, 2, -4, 4,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_4_1:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, -2,
+ax_anim 6, 2, 91, 0, -3, 0, -3,
+ax_anim 1, 0, 92, 0, -1, 0, -1,
+ax_anim 1, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 1, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sAzumarillAnims_4_2:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -2, -2, -2, -2,
+ax_anim 6, 2, 96, -3, -3, -3, -3,
+ax_anim 1, 0, 97, -1, -1, -1, -1,
+ax_anim 1, 0, 97, 3, 3, 3, 3,
+ax_anim 2, 1, 97, 4, 2, 4, 2,
+ax_anim 2, 0, 97, 3, 3, 3, 3,
+ax_anim 2, 0, 97, 4, 2, 4, 2,
+ax_anim 2, 0, 97, 3, 3, 3, 3,
+ax_anim 2, 0, 97, 4, 2, 4, 2,
+ax_anim 2, 0, 97, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim_terminator
+sAzumarillAnims_4_3:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 6, 2, 101, -3, 0, -3, 0,
+ax_anim 1, 0, 102, -1, 0, -1, 0,
+ax_anim 1, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 1, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim_terminator
+sAzumarillAnims_4_4:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 6, 2, 106, -3, 3, -3, 3,
+ax_anim 1, 0, 107, -1, 1, -1, 1,
+ax_anim 1, 0, 107, 3, -3, 3, -3,
+ax_anim 2, 1, 107, 4, -2, 4, -2,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 4, -2, 4, -2,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 4, -2, 4, -2,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim_terminator
+sAzumarillAnims_4_5:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 6, 2, 111, 0, 3, 0, 3,
+ax_anim 1, 0, 112, 0, 1, 0, 1,
+ax_anim 1, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 1, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sAzumarillAnims_4_6:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 2, 2, 2, 2,
+ax_anim 6, 2, 116, 3, 3, 3, 3,
+ax_anim 1, 0, 117, 1, 1, 1, 1,
+ax_anim 1, 0, 117, -3, -3, -3, -3,
+ax_anim 2, 1, 117, -4, -2, -4, -2,
+ax_anim 2, 0, 117, -3, -3, -3, -3,
+ax_anim 2, 0, 117, -4, -2, -4, -2,
+ax_anim 2, 0, 117, -3, -3, -3, -3,
+ax_anim 2, 0, 117, -4, -2, -4, -2,
+ax_anim 2, 0, 117, -3, -3, -3, -3,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim_terminator
+sAzumarillAnims_4_7:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 2, 0, 2, 0,
+ax_anim 6, 2, 121, 3, 0, 3, 0,
+ax_anim 1, 0, 122, 1, 0, 1, 0,
+ax_anim 1, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 1, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim_terminator
+sAzumarillAnims_4_8:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 1, 0, 127, 1, -1, 1, -1,
+ax_anim 1, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 1, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_5_1:
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 4, 0, 128, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim_terminator
+sAzumarillAnims_5_2:
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim_terminator
+sAzumarillAnims_5_3:
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, -1, 0, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, -1,
+ax_anim_terminator
+sAzumarillAnims_5_4:
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 0, 0,
+ax_anim 2, 0, 133, 1, 0, 0, 0,
+ax_anim 2, 0, 134, 1, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim_terminator
+sAzumarillAnims_5_5:
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 4, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 3, -1, 0, 0,
+ax_anim 2, 0, 135, 3, 0, 0, 0,
+ax_anim 2, 0, 136, 3, 0, 0, 0,
+ax_anim 2, 0, 137, 3, 0, 0, 0,
+ax_anim 2, 0, 130, 3, 0, 0, 0,
+ax_anim 2, 0, 131, 3, 0, 0, 0,
+ax_anim 2, 0, 132, 3, 0, 0, 0,
+ax_anim 2, 0, 133, 3, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 1, 0, 1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, 0, 1, 0,
+ax_anim_terminator
+sAzumarillAnims_5_6:
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 2, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 1, -1, 0, 0,
+ax_anim 2, 0, 134, 1, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 1, -1, 1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim_terminator
+sAzumarillAnims_5_7:
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, -1, 0, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -1, 0, -1,
+ax_anim_terminator
+sAzumarillAnims_5_8:
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 4, 0, 150, 0, -4, 0, 0,
+ax_anim 2, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sAzumarillAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sAzumarillAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sAzumarillAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sAzumarillAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sAzumarillAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sAzumarillAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sAzumarillAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_8_1:
+ax_anim 30, 0, 162, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, -3, 0, 0,
+ax_anim 6, 0, 163, 0, -4, 0, 0,
+ax_anim 6, 0, 163, 0, -3, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_8_2:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, -3, 0, 0,
+ax_anim 6, 0, 165, 0, -4, 0, 0,
+ax_anim 6, 0, 165, 0, -3, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_8_3:
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim 6, 0, 167, 0, -3, 0, 0,
+ax_anim 6, 0, 167, 0, -4, 0, 0,
+ax_anim 6, 0, 167, 0, -3, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_8_4:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 6, 0, 169, 0, -3, 0, 0,
+ax_anim 6, 0, 169, 0, -4, 0, 0,
+ax_anim 6, 0, 169, 0, -3, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_8_5:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 6, 0, 171, 0, -3, 0, 0,
+ax_anim 6, 0, 171, 0, -4, 0, 0,
+ax_anim 6, 0, 171, 0, -3, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_8_6:
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim 6, 0, 173, 0, -3, 0, 0,
+ax_anim 6, 0, 173, 0, -4, 0, 0,
+ax_anim 6, 0, 173, 0, -3, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_8_7:
+ax_anim 30, 0, 174, 0, 0, 0, 0,
+ax_anim 6, 0, 175, 0, -3, 0, 0,
+ax_anim 6, 0, 175, 0, -4, 0, 0,
+ax_anim 6, 0, 175, 0, -3, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_8_8:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 0, 177, 0, -3, 0, 0,
+ax_anim 6, 0, 177, 0, -4, 0, 0,
+ax_anim 6, 0, 177, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 7, 3, 7, 3,
+ax_anim 2, 0, 180, 11, 9, 11, 9,
+ax_anim 2, 0, 181, 9, 19, 9, 19,
+ax_anim 3, 0, 182, 0, 22, 0, 22,
+ax_anim 2, 3, 183, -9, 19, -9, 19,
+ax_anim 2, 0, 184, -11, 9, -11, 9,
+ax_anim 1, 0, 185, -7, 3, -7, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 18, 4, 18, 4,
+ax_anim 2, 0, 180, 22, 12, 22, 12,
+ax_anim 3, 0, 181, 20, 21, 20, 21,
+ax_anim 2, 3, 182, 10, 21, 10, 21,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 16, -5, 16, -5,
+ax_anim 3, 0, 180, 21, 0, 21, 0,
+ax_anim 2, 3, 181, 18, 5, 18, 5,
+ax_anim 2, 0, 182, 12, 6, 12, 6,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -8, -1, -8,
+ax_anim 2, 0, 185, 2, -16, 2, -16,
+ax_anim 2, 0, 178, 12, -21, 12, -21,
+ax_anim 3, 0, 179, 21, -20, 21, -20,
+ax_anim 2, 3, 180, 22, -14, 22, -14,
+ax_anim 2, 0, 181, 18, -4, 18, -4,
+ax_anim 1, 0, 182, 10, 0, 10, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -10, -12, -10, -12,
+ax_anim 2, 0, 185, -8, -18, -8, -18,
+ax_anim 3, 0, 178, 0, -20, 0, -20,
+ax_anim 2, 3, 179, 8, -18, 8, -18,
+ax_anim 2, 0, 180, 10, -10, 10, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -8, 1, -6,
+ax_anim 2, 0, 179, -2, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -21, -12, -22,
+ax_anim 3, 0, 185, -21, -20, -18, -22,
+ax_anim 2, 3, 184, -22, -14, -20, -15,
+ax_anim 2, 0, 183, -18, -4, -17, -4,
+ax_anim 1, 0, 182, -10, 0, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -16, -5, -16, -5,
+ax_anim 3, 0, 184, -21, 0, -18, -2,
+ax_anim 2, 3, 183, -18, 5, -16, 4,
+ax_anim 2, 0, 182, -12, 6, -12, 5,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -18, 4, -17, 3,
+ax_anim 2, 0, 184, -22, 12, -19, 10,
+ax_anim 3, 0, 183, -20, 21, -17, 19,
+ax_anim 2, 3, 182, -10, 21, -11, 19,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -23, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -9, 0, 0,
+ax_anim 2, 0, 207, 0, -15, 0, 0,
+ax_anim 3, 0, 207, 0, -19, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzumarillAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sAzumarillGfx1:
+.incbin "baserom.gba", 0xCF2E48, 0x200
+sAzumarillSprites1:
+ax_sprite sAzumarillGfx1, 0x200
+ax_sprite_terminator
+sAzumarillGfx2:
+.incbin "baserom.gba", 0xCF3058, 0x200
+sAzumarillSprites2:
+ax_sprite sAzumarillGfx2, 0x200
+ax_sprite_terminator
+sAzumarillGfx3:
+.incbin "baserom.gba", 0xCF3268, 0x200
+sAzumarillSprites3:
+ax_sprite sAzumarillGfx3, 0x200
+ax_sprite_terminator
+sAzumarillGfx4:
+.incbin "baserom.gba", 0xCF3478, 0x200
+sAzumarillSprites4:
+ax_sprite sAzumarillGfx4, 0x200
+ax_sprite_terminator
+sAzumarillGfx5:
+.incbin "baserom.gba", 0xCF3688, 0x200
+sAzumarillSprites5:
+ax_sprite sAzumarillGfx5, 0x200
+ax_sprite_terminator
+sAzumarillGfx6:
+.incbin "baserom.gba", 0xCF3898, 0x200
+sAzumarillSprites6:
+ax_sprite sAzumarillGfx6, 0x200
+ax_sprite_terminator
+sAzumarillGfx7:
+.incbin "baserom.gba", 0xCF3AA8, 0x200
+sAzumarillSprites7:
+ax_sprite sAzumarillGfx7, 0x200
+ax_sprite_terminator
+sAzumarillGfx8:
+.incbin "baserom.gba", 0xCF3CB8, 0x200
+sAzumarillSprites8:
+ax_sprite sAzumarillGfx8, 0x200
+ax_sprite_terminator
+sAzumarillGfx9:
+.incbin "baserom.gba", 0xCF3EC8, 0x200
+sAzumarillSprites9:
+ax_sprite sAzumarillGfx9, 0x200
+ax_sprite_terminator
+sAzumarillGfx10:
+.incbin "baserom.gba", 0xCF40D8, 0x200
+sAzumarillSprites10:
+ax_sprite sAzumarillGfx10, 0x200
+ax_sprite_terminator
+sAzumarillGfx11:
+.incbin "baserom.gba", 0xCF42E8, 0x200
+sAzumarillSprites11:
+ax_sprite sAzumarillGfx11, 0x200
+ax_sprite_terminator
+sAzumarillGfx12:
+.incbin "baserom.gba", 0xCF44F8, 0x200
+sAzumarillSprites12:
+ax_sprite sAzumarillGfx12, 0x200
+ax_sprite_terminator
+sAzumarillGfx13:
+.incbin "baserom.gba", 0xCF4708, 0x200
+sAzumarillSprites13:
+ax_sprite sAzumarillGfx13, 0x200
+ax_sprite_terminator
+sAzumarillGfx14:
+.incbin "baserom.gba", 0xCF4918, 0x200
+sAzumarillSprites14:
+ax_sprite sAzumarillGfx14, 0x200
+ax_sprite_terminator
+sAzumarillGfx15:
+.incbin "baserom.gba", 0xCF4B28, 0x200
+sAzumarillSprites15:
+ax_sprite sAzumarillGfx15, 0x200
+ax_sprite_terminator
+sAzumarillGfx16:
+.incbin "baserom.gba", 0xCF4D38, 0x180
+sAzumarillGfx16_1:
+.incbin "baserom.gba", 0xCF4EB8, 0x40
+sAzumarillSprites16:
+ax_sprite sAzumarillGfx16, 0x180
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx17:
+.incbin "baserom.gba", 0xCF4F20, 0x40
+sAzumarillGfx17_1:
+.incbin "baserom.gba", 0xCF4F60, 0x80
+sAzumarillGfx17_2:
+.incbin "baserom.gba", 0xCF4FE0, 0x60
+sAzumarillGfx17_3:
+.incbin "baserom.gba", 0xCF5040, 0x40
+sAzumarillSprites17:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx17_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx18:
+.incbin "baserom.gba", 0xCF50D0, 0x40
+sAzumarillGfx18_1:
+.incbin "baserom.gba", 0xCF5110, 0x60
+sAzumarillGfx18_2:
+.incbin "baserom.gba", 0xCF5170, 0x60
+sAzumarillGfx18_3:
+.incbin "baserom.gba", 0xCF51D0, 0x40
+sAzumarillSprites18:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx19:
+.incbin "baserom.gba", 0xCF5260, 0x60
+sAzumarillGfx19_1:
+.incbin "baserom.gba", 0xCF52C0, 0x60
+sAzumarillGfx19_2:
+.incbin "baserom.gba", 0xCF5320, 0x40
+sAzumarillGfx19_3:
+.incbin "baserom.gba", 0xCF5360, 0x40
+sAzumarillSprites19:
+ax_sprite sAzumarillGfx19, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx19_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx20:
+.incbin "baserom.gba", 0xCF53E8, 0x40
+sAzumarillGfx20_1:
+.incbin "baserom.gba", 0xCF5428, 0x100
+sAzumarillGfx20_2:
+.incbin "baserom.gba", 0xCF5528, 0x40
+sAzumarillSprites20:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx21:
+.incbin "baserom.gba", 0xCF55A8, 0x40
+sAzumarillGfx21_1:
+.incbin "baserom.gba", 0xCF55E8, 0x40
+sAzumarillGfx21_2:
+.incbin "baserom.gba", 0xCF5628, 0x60
+sAzumarillGfx21_3:
+.incbin "baserom.gba", 0xCF5688, 0x40
+sAzumarillSprites21:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx22:
+.incbin "baserom.gba", 0xCF5718, 0x60
+sAzumarillGfx22_1:
+.incbin "baserom.gba", 0xCF5778, 0x60
+sAzumarillGfx22_2:
+.incbin "baserom.gba", 0xCF57D8, 0x60
+sAzumarillGfx22_3:
+.incbin "baserom.gba", 0xCF5838, 0x40
+sAzumarillSprites22:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx23:
+.incbin "baserom.gba", 0xCF58C8, 0x20
+sAzumarillGfx23_1:
+.incbin "baserom.gba", 0xCF58E8, 0x40
+sAzumarillGfx23_2:
+.incbin "baserom.gba", 0xCF5928, 0x60
+sAzumarillGfx23_3:
+.incbin "baserom.gba", 0xCF5988, 0x60
+sAzumarillSprites23:
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx23_3, 0x60
+ax_sprite_terminator
+sAzumarillGfx24:
+.incbin "baserom.gba", 0xCF5A30, 0x40
+sAzumarillGfx24_1:
+.incbin "baserom.gba", 0xCF5A70, 0x40
+sAzumarillGfx24_2:
+.incbin "baserom.gba", 0xCF5AB0, 0x60
+sAzumarillGfx24_3:
+.incbin "baserom.gba", 0xCF5B10, 0x40
+sAzumarillSprites24:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx25:
+.incbin "baserom.gba", 0xCF5BA0, 0x60
+sAzumarillGfx25_1:
+.incbin "baserom.gba", 0xCF5C00, 0x80
+sAzumarillGfx25_2:
+.incbin "baserom.gba", 0xCF5C80, 0x60
+sAzumarillGfx25_3:
+.incbin "baserom.gba", 0xCF5CE0, 0x40
+sAzumarillSprites25:
+ax_sprite sAzumarillGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx25_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx26:
+.incbin "baserom.gba", 0xCF5D68, 0x60
+sAzumarillGfx26_1:
+.incbin "baserom.gba", 0xCF5DC8, 0x160
+sAzumarillSprites26:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx26_1, 0x160
+ax_sprite_terminator
+sAzumarillGfx27:
+.incbin "baserom.gba", 0xCF5F50, 0x60
+sAzumarillGfx27_1:
+.incbin "baserom.gba", 0xCF5FB0, 0xC0
+sAzumarillGfx27_2:
+.incbin "baserom.gba", 0xCF6070, 0x40
+sAzumarillSprites27:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx27_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx28:
+.incbin "baserom.gba", 0xCF60F0, 0x40
+sAzumarillGfx28_1:
+.incbin "baserom.gba", 0xCF6130, 0x60
+sAzumarillGfx28_2:
+.incbin "baserom.gba", 0xCF6190, 0x60
+sAzumarillGfx28_3:
+.incbin "baserom.gba", 0xCF61F0, 0x40
+sAzumarillSprites28:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx29:
+.incbin "baserom.gba", 0xCF6280, 0x60
+sAzumarillGfx29_1:
+.incbin "baserom.gba", 0xCF62E0, 0x60
+sAzumarillGfx29_2:
+.incbin "baserom.gba", 0xCF6340, 0x60
+sAzumarillGfx29_3:
+.incbin "baserom.gba", 0xCF63A0, 0x40
+sAzumarillSprites29:
+ax_sprite sAzumarillGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx30:
+.incbin "baserom.gba", 0xCF6428, 0x60
+sAzumarillGfx30_1:
+.incbin "baserom.gba", 0xCF6488, 0x60
+sAzumarillGfx30_2:
+.incbin "baserom.gba", 0xCF64E8, 0xE0
+sAzumarillSprites30:
+ax_sprite sAzumarillGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx30_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx31:
+.incbin "baserom.gba", 0xCF6600, 0x40
+sAzumarillGfx31_1:
+.incbin "baserom.gba", 0xCF6640, 0x60
+sAzumarillGfx31_2:
+.incbin "baserom.gba", 0xCF66A0, 0x60
+sAzumarillGfx31_3:
+.incbin "baserom.gba", 0xCF6700, 0x60
+sAzumarillSprites31:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx32:
+.incbin "baserom.gba", 0xCF67B0, 0x40
+sAzumarillGfx32_1:
+.incbin "baserom.gba", 0xCF67F0, 0x40
+sAzumarillGfx32_2:
+.incbin "baserom.gba", 0xCF6830, 0x40
+sAzumarillGfx32_3:
+.incbin "baserom.gba", 0xCF6870, 0x40
+sAzumarillSprites32:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx32_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx33:
+.incbin "baserom.gba", 0xCF6900, 0x40
+sAzumarillGfx33_1:
+.incbin "baserom.gba", 0xCF6940, 0x140
+sAzumarillSprites33:
+ax_sprite 0, 0x20
+ax_sprite sAzumarillGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzumarillGfx33_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzumarillGfx34:
+.incbin "baserom.gba", 0xCF6AB0, 0x200
+sAzumarillSprites34:
+ax_sprite sAzumarillGfx34, 0x200
+ax_sprite_terminator
+sAzumarillGfx35:
+.incbin "baserom.gba", 0xCF6CC0, 0x200
+sAzumarillSprites35:
+ax_sprite sAzumarillGfx35, 0x200
+ax_sprite_terminator
+sAzumarillGfx36:
+.incbin "baserom.gba", 0xCF6ED0, 0x200
+sAzumarillSprites36:
+ax_sprite sAzumarillGfx36, 0x200
+ax_sprite_terminator
+sAzumarillGfx37:
+.incbin "baserom.gba", 0xCF70E0, 0x200
+sAzumarillSprites37:
+ax_sprite sAzumarillGfx37, 0x200
+ax_sprite_terminator
+sAzumarillGfx38:
+.incbin "baserom.gba", 0xCF72F0, 0x200
+sAzumarillSprites38:
+ax_sprite sAzumarillGfx38, 0x200
+ax_sprite_terminator
+sAzumarillGfx39:
+.incbin "baserom.gba", 0xCF7500, 0x200
+sAzumarillSprites39:
+ax_sprite sAzumarillGfx39, 0x200
+ax_sprite_terminator
+sAzumarillGfx40:
+.incbin "baserom.gba", 0xCF7710, 0x200
+sAzumarillSprites40:
+ax_sprite sAzumarillGfx40, 0x200
+ax_sprite_terminator
+sAxPosesAzumarill:
+.4byte sAzumarillPose1
+.4byte sAzumarillPose2
+.4byte sAzumarillPose3
+.4byte sAzumarillPose4
+.4byte sAzumarillPose5
+.4byte sAzumarillPose6
+.4byte sAzumarillPose7
+.4byte sAzumarillPose8
+.4byte sAzumarillPose9
+.4byte sAzumarillPose10
+.4byte sAzumarillPose11
+.4byte sAzumarillPose12
+.4byte sAzumarillPose13
+.4byte sAzumarillPose14
+.4byte sAzumarillPose15
+.4byte sAzumarillPose16
+.4byte sAzumarillPose17
+.4byte sAzumarillPose18
+.4byte sAzumarillPose19
+.4byte sAzumarillPose20
+.4byte sAzumarillPose21
+.4byte sAzumarillPose22
+.4byte sAzumarillPose23
+.4byte sAzumarillPose24
+.4byte sAzumarillPose25
+.4byte sAzumarillPose26
+.4byte sAzumarillPose27
+.4byte sAzumarillPose28
+.4byte sAzumarillPose29
+.4byte sAzumarillPose30
+.4byte sAzumarillPose31
+.4byte sAzumarillPose32
+.4byte sAzumarillPose33
+.4byte sAzumarillPose34
+.4byte sAzumarillPose35
+.4byte sAzumarillPose36
+.4byte sAzumarillPose37
+.4byte sAzumarillPose38
+.4byte sAzumarillPose39
+.4byte sAzumarillPose40
+.4byte sAzumarillPose41
+.4byte sAzumarillPose42
+.4byte sAzumarillPose43
+.4byte sAzumarillPose44
+.4byte sAzumarillPose45
+.4byte sAzumarillPose46
+.4byte sAzumarillPose47
+.4byte sAzumarillPose48
+.4byte sAzumarillPose49
+.4byte sAzumarillPose50
+.4byte sAzumarillPose51
+.4byte sAzumarillPose52
+.4byte sAzumarillPose53
+.4byte sAzumarillPose54
+.4byte sAzumarillPose55
+.4byte sAzumarillPose56
+.4byte sAzumarillPose57
+.4byte sAzumarillPose58
+.4byte sAzumarillPose59
+.4byte sAzumarillPose60
+.4byte sAzumarillPose61
+.4byte sAzumarillPose62
+.4byte sAzumarillPose63
+.4byte sAzumarillPose64
+.4byte sAzumarillPose65
+.4byte sAzumarillPose66
+.4byte sAzumarillPose67
+.4byte sAzumarillPose68
+.4byte sAzumarillPose69
+.4byte sAzumarillPose70
+.4byte sAzumarillPose71
+.4byte sAzumarillPose72
+.4byte sAzumarillPose73
+.4byte sAzumarillPose74
+.4byte sAzumarillPose75
+.4byte sAzumarillPose76
+.4byte sAzumarillPose77
+.4byte sAzumarillPose78
+.4byte sAzumarillPose79
+.4byte sAzumarillPose80
+.4byte sAzumarillPose81
+.4byte sAzumarillPose82
+.4byte sAzumarillPose83
+.4byte sAzumarillPose84
+.4byte sAzumarillPose85
+.4byte sAzumarillPose86
+.4byte sAzumarillPose87
+.4byte sAzumarillPose88
+.4byte sAzumarillPose89
+.4byte sAzumarillPose90
+.4byte sAzumarillPose91
+.4byte sAzumarillPose92
+.4byte sAzumarillPose93
+.4byte sAzumarillPose94
+.4byte sAzumarillPose95
+.4byte sAzumarillPose96
+.4byte sAzumarillPose97
+.4byte sAzumarillPose98
+.4byte sAzumarillPose99
+.4byte sAzumarillPose100
+.4byte sAzumarillPose101
+.4byte sAzumarillPose102
+.4byte sAzumarillPose103
+.4byte sAzumarillPose104
+.4byte sAzumarillPose105
+.4byte sAzumarillPose106
+.4byte sAzumarillPose107
+.4byte sAzumarillPose108
+.4byte sAzumarillPose109
+.4byte sAzumarillPose110
+.4byte sAzumarillPose111
+.4byte sAzumarillPose112
+.4byte sAzumarillPose113
+.4byte sAzumarillPose114
+.4byte sAzumarillPose115
+.4byte sAzumarillPose116
+.4byte sAzumarillPose117
+.4byte sAzumarillPose118
+.4byte sAzumarillPose119
+.4byte sAzumarillPose120
+.4byte sAzumarillPose121
+.4byte sAzumarillPose122
+.4byte sAzumarillPose123
+.4byte sAzumarillPose124
+.4byte sAzumarillPose125
+.4byte sAzumarillPose126
+.4byte sAzumarillPose127
+.4byte sAzumarillPose128
+.4byte sAzumarillPose129
+.4byte sAzumarillPose130
+.4byte sAzumarillPose131
+.4byte sAzumarillPose132
+.4byte sAzumarillPose133
+.4byte sAzumarillPose134
+.4byte sAzumarillPose135
+.4byte sAzumarillPose136
+.4byte sAzumarillPose137
+.4byte sAzumarillPose138
+.4byte sAzumarillPose139
+.4byte sAzumarillPose140
+.4byte sAzumarillPose141
+.4byte sAzumarillPose142
+.4byte sAzumarillPose143
+.4byte sAzumarillPose144
+.4byte sAzumarillPose145
+.4byte sAzumarillPose146
+.4byte sAzumarillPose147
+.4byte sAzumarillPose148
+.4byte sAzumarillPose149
+.4byte sAzumarillPose150
+.4byte sAzumarillPose151
+.4byte sAzumarillPose152
+.4byte sAzumarillPose153
+.4byte sAzumarillPose154
+.4byte sAzumarillPose155
+.4byte sAzumarillPose156
+.4byte sAzumarillPose157
+.4byte sAzumarillPose158
+.4byte sAzumarillPose159
+.4byte sAzumarillPose160
+.4byte sAzumarillPose161
+.4byte sAzumarillPose162
+.4byte sAzumarillPose163
+.4byte sAzumarillPose164
+.4byte sAzumarillPose165
+.4byte sAzumarillPose166
+.4byte sAzumarillPose167
+.4byte sAzumarillPose168
+.4byte sAzumarillPose169
+.4byte sAzumarillPose170
+.4byte sAzumarillPose171
+.4byte sAzumarillPose172
+.4byte sAzumarillPose173
+.4byte sAzumarillPose174
+.4byte sAzumarillPose175
+.4byte sAzumarillPose176
+.4byte sAzumarillPose177
+.4byte sAzumarillPose178
+.4byte sAzumarillPose179
+.4byte sAzumarillPose180
+.4byte sAzumarillPose181
+.4byte sAzumarillPose182
+.4byte sAzumarillPose183
+.4byte sAzumarillPose184
+.4byte sAzumarillPose185
+.4byte sAzumarillPose186
+.4byte sAzumarillPose187
+.4byte sAzumarillPose188
+.4byte sAzumarillPose189
+.4byte sAzumarillPose190
+.4byte sAzumarillPose191
+.4byte sAzumarillPose192
+.4byte sAzumarillPose193
+.4byte sAzumarillPose194
+.4byte sAzumarillPose195
+.4byte sAzumarillPose196
+.4byte sAzumarillPose197
+.4byte sAzumarillPose198
+.4byte sAzumarillPose199
+.4byte sAzumarillPose200
+.4byte sAzumarillPose201
+.4byte sAzumarillPose202
+.4byte sAzumarillPose203
+.4byte sAzumarillPose204
+.4byte sAzumarillPose205
+.4byte sAzumarillPose206
+.4byte sAzumarillPose207
+.4byte sAzumarillPose208
+.4byte sAzumarillPose209
+.4byte sAzumarillPose210
+.4byte sAzumarillPose211
+.4byte sAzumarillPose212
+.4byte sAzumarillPose213
+.4byte sAzumarillPose214
+.4byte sAzumarillPose215
+.4byte sAzumarillPose216
+.4byte sAzumarillPose217
+.4byte sAzumarillPose218
+.4byte sAzumarillPose219
+.4byte sAzumarillPose220
+.4byte sAzumarillPose221
+.4byte sAzumarillPose222
+.4byte sAzumarillPose223
+.4byte sAzumarillPose224
+.4byte sAzumarillPose225
+.4byte sAzumarillPose226
+.4byte sAzumarillPose227
+.4byte sAzumarillPose228
+.4byte sAzumarillPose229
+.4byte sAzumarillPose230
+.4byte sAzumarillPose231
+.4byte sAzumarillPose232
+.4byte sAzumarillPose233
+.4byte sAzumarillPose234
+sAxPositionsAzumarill:
+.2byte   -1,   -7, 	 -10,   -6, 	   9,   -6, 	   0,   -8
+.2byte    0,   -6, 	  -9,   -5, 	   7,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    3,   -7, 	   8,   -9, 	  -7,   -4, 	  -1,   -8
+.2byte    3,   -6, 	   7,  -10, 	  -3,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte    5,   -8, 	   2,   -6, 	   0,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -3,   -7, 	   2,   -3, 	  -1,   -7
+.2byte    5,   -7, 	   4,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte    2,  -10, 	  -8,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -9,   -7, 	   7,   -7, 	  -1,   -7
+.2byte    2,   -9, 	   0,   -9, 	   4,   -4, 	  -1,   -7
+.2byte   -1,  -10, 	  10,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,   -9, 	   8,   -5, 	  -9,   -9, 	   0,   -7
+.2byte    0,   -8, 	   9,   -9, 	  -9,   -6, 	   0,   -7
+.2byte   -3,  -10, 	   7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   8,   -7, 	  -8,   -7, 	   0,   -7
+.2byte   -3,   -9, 	  -1,   -9, 	  -5,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -3,   -6, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -7, 	   2,   -7, 	  -3,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -5,   -7, 	   2,   -3, 	   0,   -6
+.2byte   -4,   -7, 	  -9,   -9, 	   6,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -8,  -10, 	   2,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -9,   -7, 	   7,   -4, 	   0,   -8
+.2byte   -1,   -7, 	 -10,   -6, 	   9,   -6, 	   0,   -8
+.2byte    0,   -6, 	  -9,   -5, 	   7,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -5, 	 -10,  -10, 	   9,  -10, 	  -1,   -7
+.2byte    3,   -7, 	   8,   -9, 	  -7,   -4, 	  -1,   -8
+.2byte    3,   -6, 	   7,  -10, 	  -3,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte    4,   -4, 	   8,  -12, 	  -8,   -7, 	   0,   -7
+.2byte    5,   -8, 	   2,   -6, 	   0,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -3,   -7, 	   2,   -3, 	  -1,   -7
+.2byte    5,   -7, 	   4,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte    7,   -7, 	   1,   -9, 	  -4,   -5, 	   1,   -7
+.2byte    2,  -10, 	  -8,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -9,   -7, 	   7,   -7, 	  -1,   -7
+.2byte    2,   -9, 	   0,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    1,  -11, 	  -8,  -12, 	   4,   -5, 	  -2,   -8
+.2byte   -1,  -10, 	  10,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,   -9, 	   8,   -5, 	  -9,   -9, 	   0,   -7
+.2byte    0,   -8, 	   9,   -9, 	  -9,   -6, 	   0,   -7
+.2byte    0,  -11, 	   9,  -12, 	 -10,  -12, 	   0,   -9
+.2byte   -3,  -10, 	   7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   8,   -7, 	  -8,   -7, 	   0,   -7
+.2byte   -3,   -9, 	  -1,   -9, 	  -5,   -4, 	   0,   -7
+.2byte   -2,  -11, 	   7,  -12, 	  -5,   -5, 	   1,   -8
+.2byte   -6,   -8, 	  -3,   -6, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -7, 	   2,   -7, 	  -3,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -5,   -7, 	   2,   -3, 	   0,   -6
+.2byte   -8,   -7, 	  -2,   -9, 	   3,   -5, 	  -2,   -7
+.2byte   -4,   -7, 	  -9,   -9, 	   6,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -8,  -10, 	   2,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -9,   -7, 	   7,   -4, 	   0,   -8
+.2byte   -5,   -4, 	  -9,  -12, 	   7,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	 -10,   -6, 	   9,   -6, 	   0,   -8
+.2byte    0,   -6, 	  -9,   -5, 	   7,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -5, 	 -10,  -10, 	   9,  -10, 	  -1,   -7
+.2byte    3,   -7, 	   8,   -9, 	  -7,   -4, 	  -1,   -8
+.2byte    3,   -6, 	   7,  -10, 	  -3,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte    4,   -4, 	   8,  -12, 	  -8,   -7, 	   0,   -7
+.2byte    5,   -8, 	   2,   -6, 	   0,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -3,   -7, 	   2,   -3, 	  -1,   -7
+.2byte    5,   -7, 	   4,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte    7,   -7, 	   1,   -9, 	  -4,   -5, 	   1,   -7
+.2byte    2,  -10, 	  -8,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -9,   -7, 	   7,   -7, 	  -1,   -7
+.2byte    2,   -9, 	   0,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    1,  -11, 	  -8,  -12, 	   4,   -5, 	  -2,   -8
+.2byte   -1,  -10, 	  10,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,   -9, 	   8,   -5, 	  -9,   -9, 	   0,   -7
+.2byte    0,   -8, 	   9,   -9, 	  -9,   -6, 	   0,   -7
+.2byte    0,  -11, 	   9,  -12, 	 -10,  -12, 	   0,   -9
+.2byte   -3,  -10, 	   7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   8,   -7, 	  -8,   -7, 	   0,   -7
+.2byte   -3,   -9, 	  -1,   -9, 	  -5,   -4, 	   0,   -7
+.2byte   -2,  -11, 	   7,  -12, 	  -5,   -5, 	   1,   -8
+.2byte   -6,   -8, 	  -3,   -6, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -7, 	   2,   -7, 	  -3,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -5,   -7, 	   2,   -3, 	   0,   -6
+.2byte   -8,   -7, 	  -2,   -9, 	   3,   -5, 	  -2,   -7
+.2byte   -4,   -7, 	  -9,   -9, 	   6,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -8,  -10, 	   2,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -9,   -7, 	   7,   -4, 	   0,   -8
+.2byte   -5,   -4, 	  -9,  -12, 	   7,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	 -10,   -6, 	   9,   -6, 	   0,   -8
+.2byte    0,   -6, 	  -9,   -5, 	   7,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte   -1,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte    0,   -5, 	 -10,  -10, 	   9,  -10, 	  -1,   -7
+.2byte    3,   -7, 	   8,   -9, 	  -7,   -4, 	  -1,   -8
+.2byte    3,   -6, 	   7,  -10, 	  -3,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte    2,  -10, 	   6,  -11, 	  -1,   -8, 	   0,   -9
+.2byte    4,   -4, 	   8,  -12, 	  -8,   -7, 	   0,   -7
+.2byte    5,   -8, 	   2,   -6, 	   0,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -3,   -7, 	   2,   -3, 	  -1,   -7
+.2byte    5,   -7, 	   4,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte    4,  -12, 	   3,  -13, 	   3,   -9, 	  -1,   -9
+.2byte    7,   -7, 	   1,   -9, 	  -4,   -5, 	   1,   -7
+.2byte    2,  -10, 	  -8,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -9,   -7, 	   7,   -7, 	  -1,   -7
+.2byte    2,   -9, 	   0,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    2,  -12, 	  -2,  -13, 	   6,  -10, 	  -2,   -9
+.2byte    1,  -11, 	  -8,  -12, 	   4,   -5, 	  -2,   -8
+.2byte   -1,  -10, 	  10,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,   -9, 	   8,   -5, 	  -9,   -9, 	   0,   -7
+.2byte    0,   -8, 	   9,   -9, 	  -9,   -6, 	   0,   -7
+.2byte    0,  -11, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte    0,  -10, 	   9,  -11, 	 -10,  -11, 	   0,   -8
+.2byte   -3,  -10, 	   7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   8,   -7, 	  -8,   -7, 	   0,   -7
+.2byte   -3,   -9, 	  -1,   -9, 	  -5,   -4, 	   0,   -7
+.2byte   -3,  -12, 	   1,  -13, 	  -7,  -10, 	   1,   -9
+.2byte   -2,  -11, 	   7,  -12, 	  -5,   -5, 	   1,   -8
+.2byte   -6,   -8, 	  -3,   -6, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -7, 	   2,   -7, 	  -3,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -5,   -7, 	   2,   -3, 	   0,   -6
+.2byte   -5,  -12, 	  -4,  -13, 	  -4,   -9, 	   0,   -9
+.2byte   -8,   -7, 	  -2,   -9, 	   3,   -5, 	  -2,   -7
+.2byte   -4,   -7, 	  -9,   -9, 	   6,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -8,  -10, 	   2,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -9,   -7, 	   7,   -4, 	   0,   -8
+.2byte   -3,  -10, 	  -7,  -11, 	   0,   -8, 	  -1,   -9
+.2byte   -5,   -4, 	  -9,  -12, 	   7,   -7, 	  -1,   -7
+.2byte   -1,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte    0,   -5, 	 -10,  -10, 	   9,  -10, 	  -1,   -7
+.2byte    0,  -10, 	  -3,   -9, 	   4,   -9, 	   1,   -9
+.2byte   -3,  -10, 	  -6,  -11, 	   0,   -8, 	   0,   -9
+.2byte   -6,  -12, 	  -8,  -12, 	  -4,   -8, 	  -1,   -9
+.2byte   -6,  -11, 	  -1,  -13, 	  -9,  -11, 	  -2,   -9
+.2byte   -4,  -11, 	   2,  -12, 	  -9,  -12, 	  -3,   -9
+.2byte   -2,  -11, 	   4,  -11, 	  -3,  -12, 	  -2,   -9
+.2byte    4,  -12, 	   3,   -8, 	   3,  -12, 	   0,   -9
+.2byte    5,  -10, 	   1,   -8, 	   7,  -11, 	   2,   -8
+.2byte    2,  -10, 	   6,  -11, 	  -1,   -8, 	   0,   -9
+.2byte    4,   -4, 	   8,  -12, 	  -8,   -7, 	   0,   -7
+.2byte    4,  -12, 	   3,  -13, 	   3,   -9, 	  -1,   -9
+.2byte    7,   -7, 	   1,   -9, 	  -4,   -5, 	   1,   -7
+.2byte    2,  -12, 	  -2,  -13, 	   6,  -10, 	  -2,   -9
+.2byte    1,  -11, 	  -8,  -12, 	   4,   -5, 	  -2,   -8
+.2byte    0,  -11, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte    0,  -10, 	   9,  -11, 	 -10,  -11, 	   0,   -8
+.2byte   -3,  -12, 	   1,  -13, 	  -7,  -10, 	   1,   -9
+.2byte   -2,  -11, 	   7,  -12, 	  -5,   -5, 	   1,   -8
+.2byte   -5,  -12, 	  -4,  -13, 	  -4,   -9, 	   0,   -9
+.2byte   -8,   -7, 	  -2,   -9, 	   3,   -5, 	  -2,   -7
+.2byte   -3,  -10, 	  -7,  -11, 	   0,   -8, 	  -1,   -9
+.2byte   -5,   -4, 	  -9,  -12, 	   7,   -7, 	  -1,   -7
+.2byte   -1,   -5, 	  -4,   -3, 	   2,   -3, 	  -1,   -7
+.2byte   -1,   -4, 	  -4,   -3, 	   2,   -3, 	  -1,   -6
+.2byte   -1,   -6, 	  -8,   -6, 	   7,   -6, 	   0,   -6
+.2byte    3,   -6, 	   6,  -11, 	  -2,   -7, 	   0,   -7
+.2byte    5,   -7, 	   5,  -11, 	   1,   -7, 	  -1,   -6
+.2byte    1,   -9, 	   0,  -12, 	   7,   -7, 	  -1,   -6
+.2byte    0,   -7, 	   7,   -9, 	  -7,   -9, 	   0,   -6
+.2byte   -2,   -9, 	  -1,  -12, 	  -8,   -7, 	   0,   -6
+.2byte   -6,   -7, 	  -6,  -11, 	  -2,   -7, 	   0,   -6
+.2byte   -4,   -6, 	  -7,  -11, 	   1,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	 -10,   -6, 	   9,   -6, 	   0,   -8
+.2byte    0,   -6, 	  -9,   -5, 	   7,   -5, 	   0,   -7
+.2byte    3,   -7, 	   8,   -9, 	  -7,   -4, 	  -1,   -8
+.2byte    3,   -6, 	   7,  -10, 	  -3,   -4, 	  -1,   -7
+.2byte    5,   -8, 	   2,   -6, 	   0,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -3,   -7, 	   2,   -3, 	  -1,   -7
+.2byte    2,  -10, 	  -8,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -9,   -7, 	   7,   -7, 	  -1,   -7
+.2byte   -1,  -10, 	  10,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,   -9, 	   8,   -5, 	  -9,   -9, 	   0,   -7
+.2byte   -3,  -10, 	   7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   8,   -7, 	  -8,   -7, 	   0,   -7
+.2byte   -6,   -8, 	  -3,   -6, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -7, 	   2,   -7, 	  -3,   -3, 	   0,   -7
+.2byte   -4,   -7, 	  -9,   -9, 	   6,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -8,  -10, 	   2,   -4, 	   0,   -7
+.2byte    0,   -5, 	 -10,  -10, 	   9,  -10, 	  -1,   -7
+.2byte   -4,   -5, 	  -8,  -13, 	   8,   -8, 	   0,   -8
+.2byte   -6,   -7, 	   0,   -9, 	   5,   -5, 	   0,   -7
+.2byte   -2,  -11, 	   7,  -12, 	  -5,   -5, 	   1,   -8
+.2byte    0,  -10, 	   9,  -11, 	 -10,  -11, 	   0,   -8
+.2byte    1,  -11, 	  -8,  -12, 	   4,   -5, 	  -2,   -8
+.2byte    5,   -7, 	  -1,   -9, 	  -6,   -5, 	  -1,   -7
+.2byte    3,   -5, 	   7,  -13, 	  -9,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte    3,  -10, 	   6,  -11, 	   0,   -8, 	   0,   -9
+.2byte    4,  -12, 	   6,  -12, 	   2,   -8, 	  -1,   -9
+.2byte    2,  -11, 	  -3,  -13, 	   5,  -11, 	  -2,   -9
+.2byte   -1,  -11, 	   5,  -12, 	  -6,  -12, 	   0,   -9
+.2byte   -4,  -11, 	   1,  -13, 	  -7,  -11, 	   0,   -9
+.2byte   -5,  -12, 	  -7,  -12, 	  -3,   -8, 	   0,   -9
+.2byte   -4,  -10, 	  -7,  -11, 	  -1,   -8, 	  -1,   -9
+.2byte   -1,   -7, 	 -10,   -6, 	   9,   -6, 	   0,   -8
+.2byte   -1,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte    0,   -5, 	 -10,  -10, 	   9,  -10, 	  -1,   -7
+.2byte    3,   -7, 	   8,   -9, 	  -7,   -4, 	  -1,   -8
+.2byte    2,  -10, 	   6,  -11, 	  -1,   -8, 	   0,   -9
+.2byte    3,   -4, 	   7,  -12, 	  -9,   -7, 	  -1,   -7
+.2byte    5,   -8, 	   2,   -6, 	   0,   -2, 	  -1,   -7
+.2byte    4,  -12, 	   3,  -13, 	   3,   -9, 	  -1,   -9
+.2byte    6,   -7, 	   0,   -9, 	  -5,   -5, 	   0,   -7
+.2byte    2,  -10, 	  -8,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    2,  -12, 	  -2,  -13, 	   6,  -10, 	  -2,   -9
+.2byte    1,  -11, 	  -8,  -12, 	   4,   -5, 	  -2,   -8
+.2byte   -1,  -10, 	  10,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,  -11, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte    0,  -10, 	   9,  -11, 	 -10,  -11, 	   0,   -8
+.2byte   -3,  -10, 	   7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -3,  -12, 	   1,  -13, 	  -7,  -10, 	   1,   -9
+.2byte   -2,  -11, 	   7,  -12, 	  -5,   -5, 	   1,   -8
+.2byte   -6,   -8, 	  -3,   -6, 	  -1,   -2, 	   0,   -7
+.2byte   -5,  -12, 	  -4,  -13, 	  -4,   -9, 	   0,   -9
+.2byte   -7,   -7, 	  -1,   -9, 	   4,   -5, 	  -1,   -7
+.2byte   -4,   -7, 	  -9,   -9, 	   6,   -4, 	   0,   -8
+.2byte   -3,  -10, 	  -7,  -11, 	   0,   -8, 	  -1,   -9
+.2byte   -4,   -4, 	  -8,  -12, 	   8,   -7, 	   0,   -7
+.2byte   -1,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -3,  -10, 	  -7,  -11, 	   0,   -8, 	  -1,   -9
+.2byte   -5,  -12, 	  -4,  -13, 	  -4,   -9, 	   0,   -9
+.2byte   -3,  -12, 	   1,  -13, 	  -7,  -10, 	   1,   -9
+.2byte    0,  -11, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte    2,  -12, 	  -2,  -13, 	   6,  -10, 	  -2,   -9
+.2byte    4,  -12, 	   3,  -13, 	   3,   -9, 	  -1,   -9
+.2byte    2,  -10, 	   6,  -11, 	  -1,   -8, 	   0,   -9
+.2byte   -1,   -7, 	 -10,   -6, 	   9,   -6, 	   0,   -8
+.2byte   -4,   -7, 	  -9,   -9, 	   6,   -4, 	   0,   -8
+.2byte   -6,   -8, 	  -3,   -6, 	  -1,   -2, 	   0,   -7
+.2byte   -3,  -10, 	   7,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -1,  -10, 	  10,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    2,  -10, 	  -8,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    5,   -8, 	   2,   -6, 	   0,   -2, 	  -1,   -7
+.2byte    3,   -7, 	   8,   -9, 	  -7,   -4, 	  -1,   -8
+sAzumarillAnimTable1:
+.4byte sAzumarillAnims_1_1
+.4byte sAzumarillAnims_1_2
+.4byte sAzumarillAnims_1_3
+.4byte sAzumarillAnims_1_4
+.4byte sAzumarillAnims_1_5
+.4byte sAzumarillAnims_1_6
+.4byte sAzumarillAnims_1_7
+.4byte sAzumarillAnims_1_8
+sAzumarillAnimTable2:
+.4byte sAzumarillAnims_2_1
+.4byte sAzumarillAnims_2_2
+.4byte sAzumarillAnims_2_3
+.4byte sAzumarillAnims_2_4
+.4byte sAzumarillAnims_2_5
+.4byte sAzumarillAnims_2_6
+.4byte sAzumarillAnims_2_7
+.4byte sAzumarillAnims_2_8
+sAzumarillAnimTable3:
+.4byte sAzumarillAnims_3_1
+.4byte sAzumarillAnims_3_2
+.4byte sAzumarillAnims_3_3
+.4byte sAzumarillAnims_3_4
+.4byte sAzumarillAnims_3_5
+.4byte sAzumarillAnims_3_6
+.4byte sAzumarillAnims_3_7
+.4byte sAzumarillAnims_3_8
+sAzumarillAnimTable4:
+.4byte sAzumarillAnims_4_1
+.4byte sAzumarillAnims_4_2
+.4byte sAzumarillAnims_4_3
+.4byte sAzumarillAnims_4_4
+.4byte sAzumarillAnims_4_5
+.4byte sAzumarillAnims_4_6
+.4byte sAzumarillAnims_4_7
+.4byte sAzumarillAnims_4_8
+sAzumarillAnimTable5:
+.4byte sAzumarillAnims_5_1
+.4byte sAzumarillAnims_5_2
+.4byte sAzumarillAnims_5_3
+.4byte sAzumarillAnims_5_4
+.4byte sAzumarillAnims_5_5
+.4byte sAzumarillAnims_5_6
+.4byte sAzumarillAnims_5_7
+.4byte sAzumarillAnims_5_8
+sAzumarillAnimTable6:
+.4byte sAzumarillAnims_6_1
+.4byte sAzumarillAnims_6_1
+.4byte sAzumarillAnims_6_1
+.4byte sAzumarillAnims_6_1
+.4byte sAzumarillAnims_6_1
+.4byte sAzumarillAnims_6_1
+.4byte sAzumarillAnims_6_1
+.4byte sAzumarillAnims_6_1
+sAzumarillAnimTable7:
+.4byte sAzumarillAnims_7_1
+.4byte sAzumarillAnims_7_2
+.4byte sAzumarillAnims_7_3
+.4byte sAzumarillAnims_7_4
+.4byte sAzumarillAnims_7_5
+.4byte sAzumarillAnims_7_6
+.4byte sAzumarillAnims_7_7
+.4byte sAzumarillAnims_7_8
+sAzumarillAnimTable8:
+.4byte sAzumarillAnims_8_1
+.4byte sAzumarillAnims_8_2
+.4byte sAzumarillAnims_8_3
+.4byte sAzumarillAnims_8_4
+.4byte sAzumarillAnims_8_5
+.4byte sAzumarillAnims_8_6
+.4byte sAzumarillAnims_8_7
+.4byte sAzumarillAnims_8_8
+sAzumarillAnimTable9:
+.4byte sAzumarillAnims_9_1
+.4byte sAzumarillAnims_9_2
+.4byte sAzumarillAnims_9_3
+.4byte sAzumarillAnims_9_4
+.4byte sAzumarillAnims_9_5
+.4byte sAzumarillAnims_9_6
+.4byte sAzumarillAnims_9_7
+.4byte sAzumarillAnims_9_8
+sAzumarillAnimTable10:
+.4byte sAzumarillAnims_10_1
+.4byte sAzumarillAnims_10_2
+.4byte sAzumarillAnims_10_3
+.4byte sAzumarillAnims_10_4
+.4byte sAzumarillAnims_10_5
+.4byte sAzumarillAnims_10_6
+.4byte sAzumarillAnims_10_7
+.4byte sAzumarillAnims_10_8
+sAzumarillAnimTable11:
+.4byte sAzumarillAnims_11_1
+.4byte sAzumarillAnims_11_2
+.4byte sAzumarillAnims_11_3
+.4byte sAzumarillAnims_11_4
+.4byte sAzumarillAnims_11_5
+.4byte sAzumarillAnims_11_6
+.4byte sAzumarillAnims_11_7
+.4byte sAzumarillAnims_11_8
+sAzumarillAnimTable12:
+.4byte sAzumarillAnims_12_1
+.4byte sAzumarillAnims_12_2
+.4byte sAzumarillAnims_12_3
+.4byte sAzumarillAnims_12_4
+.4byte sAzumarillAnims_12_5
+.4byte sAzumarillAnims_12_6
+.4byte sAzumarillAnims_12_7
+.4byte sAzumarillAnims_12_8
+sAzumarillAnimTable13:
+.4byte sAzumarillAnims_13_1
+.4byte sAzumarillAnims_13_2
+.4byte sAzumarillAnims_13_3
+.4byte sAzumarillAnims_13_4
+.4byte sAzumarillAnims_13_5
+.4byte sAzumarillAnims_13_6
+.4byte sAzumarillAnims_13_7
+.4byte sAzumarillAnims_13_8
+sAxAnimationsAzumarill:
+.4byte sAzumarillAnimTable1
+.4byte sAzumarillAnimTable2
+.4byte sAzumarillAnimTable3
+.4byte sAzumarillAnimTable4
+.4byte sAzumarillAnimTable5
+.4byte sAzumarillAnimTable6
+.4byte sAzumarillAnimTable7
+.4byte sAzumarillAnimTable8
+.4byte sAzumarillAnimTable9
+.4byte sAzumarillAnimTable10
+.4byte sAzumarillAnimTable11
+.4byte sAzumarillAnimTable12
+.4byte sAzumarillAnimTable13
+sAxSpritesAzumarill:
+.4byte sAzumarillSprites1
+.4byte sAzumarillSprites2
+.4byte sAzumarillSprites3
+.4byte sAzumarillSprites4
+.4byte sAzumarillSprites5
+.4byte sAzumarillSprites6
+.4byte sAzumarillSprites7
+.4byte sAzumarillSprites8
+.4byte sAzumarillSprites9
+.4byte sAzumarillSprites10
+.4byte sAzumarillSprites11
+.4byte sAzumarillSprites12
+.4byte sAzumarillSprites13
+.4byte sAzumarillSprites14
+.4byte sAzumarillSprites15
+.4byte sAzumarillSprites16
+.4byte sAzumarillSprites17
+.4byte sAzumarillSprites18
+.4byte sAzumarillSprites19
+.4byte sAzumarillSprites20
+.4byte sAzumarillSprites21
+.4byte sAzumarillSprites22
+.4byte sAzumarillSprites23
+.4byte sAzumarillSprites24
+.4byte sAzumarillSprites25
+.4byte sAzumarillSprites26
+.4byte sAzumarillSprites27
+.4byte sAzumarillSprites28
+.4byte sAzumarillSprites29
+.4byte sAzumarillSprites30
+.4byte sAzumarillSprites31
+.4byte sAzumarillSprites32
+.4byte sAzumarillSprites33
+.4byte sAzumarillSprites34
+.4byte sAzumarillSprites35
+.4byte sAzumarillSprites36
+.4byte sAzumarillSprites37
+.4byte sAzumarillSprites38
+.4byte sAzumarillSprites39
+.4byte sAzumarillSprites40
+sAxMainAzumarill:
+ax_main sAxPosesAzumarill, sAxAnimationsAzumarill, 13, sAxSpritesAzumarill, sAxPositionsAzumarill

--- a/data/ax/azurill.inc
+++ b/data/ax/azurill.inc
@@ -1,0 +1,2789 @@
+.global gAxAzurill
+gAxAzurill:
+ax_siro sAxMainAzurill
+sAzurillPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose4:
+ax_pose 3, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose5:
+ax_pose 4, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose6:
+ax_pose 5, 0x01ed, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose7:
+ax_pose 6, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose8:
+ax_pose 7, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose9:
+ax_pose 8, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose10:
+ax_pose 9, 0x01f2, 0x90e8, 0x5c00
+ax_pose_terminator
+sAzurillPose11:
+ax_pose 10, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzurillPose12:
+ax_pose 11, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sAzurillPose13:
+ax_pose 12, 0x81f3, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose14:
+ax_pose 13, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose15:
+ax_pose 14, 0x01f3, 0x40f8, 0x5c00
+ax_pose_terminator
+sAzurillPose16:
+ax_pose 9, 0x01f2, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose17:
+ax_pose 10, 0x01ea, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzurillPose18:
+ax_pose 11, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose19:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose21:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose22:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose23:
+ax_pose 4, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose24:
+ax_pose 5, 0x01ed, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose28:
+ax_pose 3, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose29:
+ax_pose 4, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose30:
+ax_pose 5, 0x01ed, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose31:
+ax_pose 6, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose32:
+ax_pose 7, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose33:
+ax_pose 8, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose34:
+ax_pose 9, 0x01f2, 0x90e8, 0x5c00
+ax_pose_terminator
+sAzurillPose35:
+ax_pose 10, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sAzurillPose36:
+ax_pose 11, 0x41f2, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose37:
+ax_pose 12, 0x81f3, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose38:
+ax_pose 13, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose39:
+ax_pose 14, 0x01f3, 0x40f8, 0x5c00
+ax_pose_terminator
+sAzurillPose40:
+ax_pose 9, 0x01f2, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose41:
+ax_pose 10, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose42:
+ax_pose 11, 0x41f2, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose43:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose44:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose45:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose46:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose47:
+ax_pose 4, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose48:
+ax_pose 5, 0x01ed, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose49:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose50:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose51:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose52:
+ax_pose 3, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose53:
+ax_pose 4, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose54:
+ax_pose 5, 0x01ed, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose55:
+ax_pose 6, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose56:
+ax_pose 7, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose57:
+ax_pose 8, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose58:
+ax_pose 9, 0x01f2, 0x90e8, 0x5c00
+ax_pose_terminator
+sAzurillPose59:
+ax_pose 10, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sAzurillPose60:
+ax_pose 11, 0x41f2, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose61:
+ax_pose 12, 0x81f3, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose62:
+ax_pose 13, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose63:
+ax_pose 14, 0x01f3, 0x40f8, 0x5c00
+ax_pose_terminator
+sAzurillPose64:
+ax_pose 9, 0x01f2, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose65:
+ax_pose 10, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose66:
+ax_pose 11, 0x41f2, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose67:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose68:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose69:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose70:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose71:
+ax_pose 4, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose72:
+ax_pose 5, 0x01ed, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose73:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose74:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose75:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose76:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose77:
+ax_pose 19, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose78:
+ax_pose 20, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose79:
+ax_pose 21, 0x01e3, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose80:
+ax_pose 22, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose81:
+ax_pose 23, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose82:
+ax_pose 24, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose83:
+ax_pose 25, 0x01e3, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose84:
+ax_pose 26, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose85:
+ax_pose 27, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose86:
+ax_pose 28, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose87:
+ax_pose 29, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose88:
+ax_pose 30, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose89:
+ax_pose 31, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose90:
+ax_pose 32, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose91:
+ax_pose 33, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose92:
+ax_pose 34, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose93:
+ax_pose 27, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose94:
+ax_pose 28, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose95:
+ax_pose 29, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose96:
+ax_pose 30, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose97:
+ax_pose 23, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose98:
+ax_pose 24, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose99:
+ax_pose 25, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose100:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose101:
+ax_pose 19, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose102:
+ax_pose 20, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose103:
+ax_pose 21, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose104:
+ax_pose 22, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose105:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose106:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose107:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose108:
+ax_pose 19, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose109:
+ax_pose 20, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose110:
+ax_pose 22, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose111:
+ax_pose 23, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose112:
+ax_pose 24, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose113:
+ax_pose 26, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose114:
+ax_pose 27, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose115:
+ax_pose 28, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose116:
+ax_pose 30, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose117:
+ax_pose 31, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose118:
+ax_pose 32, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose119:
+ax_pose 34, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose120:
+ax_pose 27, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose121:
+ax_pose 28, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose122:
+ax_pose 30, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose123:
+ax_pose 23, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose124:
+ax_pose 24, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose125:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose126:
+ax_pose 19, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose127:
+ax_pose 20, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose128:
+ax_pose 22, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose129:
+ax_pose 35, 0x01f2, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzurillPose130:
+ax_pose 36, 0x01f3, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzurillPose131:
+ax_pose 37, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose132:
+ax_pose 38, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sAzurillPose133:
+ax_pose 39, 0x41f3, 0x50f0, 0x5c00
+ax_pose 40, 0x01f3, 0x10e8, 0x5c04
+ax_pose 41, 0x01eb, 0x10e8, 0x5c05
+ax_pose 42, 0x41e3, 0x90f0, 0x5c06
+ax_pose_terminator
+sAzurillPose134:
+ax_pose 43, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose135:
+ax_pose 44, 0x01df, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose136:
+ax_pose 43, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose137:
+ax_pose 39, 0x41f3, 0x40f0, 0x5c00
+ax_pose 40, 0x01f3, 0x0110, 0x5c04
+ax_pose 41, 0x01eb, 0x0110, 0x5c05
+ax_pose 42, 0x41e3, 0x80f0, 0x5c06
+ax_pose_terminator
+sAzurillPose138:
+ax_pose 38, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose139:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose140:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose141:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose142:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose143:
+ax_pose 19, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose144:
+ax_pose 20, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose145:
+ax_pose 21, 0x01e3, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose146:
+ax_pose 22, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose147:
+ax_pose 23, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose148:
+ax_pose 24, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose149:
+ax_pose 25, 0x01e3, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose150:
+ax_pose 26, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose151:
+ax_pose 27, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose152:
+ax_pose 28, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose153:
+ax_pose 29, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose154:
+ax_pose 30, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose155:
+ax_pose 31, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose156:
+ax_pose 32, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose157:
+ax_pose 33, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose158:
+ax_pose 34, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose159:
+ax_pose 27, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose160:
+ax_pose 28, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose161:
+ax_pose 29, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose162:
+ax_pose 30, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose163:
+ax_pose 23, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose164:
+ax_pose 24, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose165:
+ax_pose 25, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose166:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose167:
+ax_pose 19, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose168:
+ax_pose 20, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose169:
+ax_pose 21, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose170:
+ax_pose 22, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose171:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose172:
+ax_pose 20, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose173:
+ax_pose 24, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose174:
+ax_pose 28, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose175:
+ax_pose 32, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose176:
+ax_pose 28, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose177:
+ax_pose 24, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose178:
+ax_pose 20, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose179:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sAzurillPose180:
+ax_pose 21, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose181:
+ax_pose 25, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sAzurillPose182:
+ax_pose 29, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose183:
+ax_pose 33, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sAzurillPose184:
+ax_pose 29, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose185:
+ax_pose 25, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sAzurillPose186:
+ax_pose 21, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose187:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose188:
+ax_pose 1, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose189:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose190:
+ax_pose 3, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sAzurillPose191:
+ax_pose 4, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose192:
+ax_pose 5, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose193:
+ax_pose 6, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose194:
+ax_pose 7, 0x01ef, 0x90ea, 0x5c00
+ax_pose_terminator
+sAzurillPose195:
+ax_pose 8, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sAzurillPose196:
+ax_pose 9, 0x01f2, 0x90e8, 0x5c00
+ax_pose_terminator
+sAzurillPose197:
+ax_pose 10, 0x01ed, 0x90e7, 0x5c00
+ax_pose_terminator
+sAzurillPose198:
+ax_pose 11, 0x41f3, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose199:
+ax_pose 12, 0x81f3, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose200:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose201:
+ax_pose 14, 0x01f6, 0x40f8, 0x5c00
+ax_pose_terminator
+sAzurillPose202:
+ax_pose 9, 0x01f2, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose203:
+ax_pose 10, 0x01ed, 0x80f9, 0x5c00
+ax_pose_terminator
+sAzurillPose204:
+ax_pose 11, 0x41f3, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose205:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose206:
+ax_pose 7, 0x01ef, 0x80f6, 0x5c00
+ax_pose_terminator
+sAzurillPose207:
+ax_pose 8, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sAzurillPose208:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose209:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose210:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose211:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose212:
+ax_pose 22, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose213:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose214:
+ax_pose 30, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose215:
+ax_pose 34, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose216:
+ax_pose 30, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose217:
+ax_pose 26, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose218:
+ax_pose 22, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sAzurillPose219:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose220:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sAzurillPose221:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sAzurillPose222:
+ax_pose 9, 0x01f2, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose223:
+ax_pose 12, 0x81f3, 0x80f8, 0x5c00
+ax_pose_terminator
+sAzurillPose224:
+ax_pose 9, 0x01f2, 0x90e8, 0x5c00
+ax_pose_terminator
+sAzurillPose225:
+ax_pose 6, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sAzurillPose226:
+ax_pose 3, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+.align 2
+sAzurillAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 1,
+ax_anim 6, 0, 1, 0, 2, 0, 1,
+ax_anim 6, 0, 1, 0, 4, 0, 2,
+ax_anim 6, 0, 2, 0, 0, 0, 2,
+ax_anim 6, 0, 2, 0, -1, 0, 1,
+ax_anim_terminator
+sAzurillAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -1, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 1, 0,
+ax_anim 6, 0, 4, 1, 1, 1, 0,
+ax_anim 6, 0, 4, 2, 3, 2, 1,
+ax_anim 6, 0, 5, 2, 0, 2, 1,
+ax_anim 6, 0, 5, 1, -1, 1, 0,
+ax_anim_terminator
+sAzurillAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -2, 2, 0, 0,
+ax_anim 6, 0, 7, -1, 1, 1, 0,
+ax_anim 6, 0, 7, 0, 0, 2, 0,
+ax_anim 6, 0, 7, 2, 1, 3, 1,
+ax_anim 6, 0, 8, 2, -1, 3, 1,
+ax_anim 6, 0, 8, 0, -1, 2, 0,
+ax_anim_terminator
+sAzurillAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, 3, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 1, 0,
+ax_anim 6, 0, 10, 1, -1, 2, -1,
+ax_anim 6, 0, 10, 2, 0, 3, -2,
+ax_anim 6, 0, 11, 2, -1, 3, -2,
+ax_anim 6, 0, 11, 1, 0, 2, -1,
+ax_anim_terminator
+sAzurillAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 2, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, -1,
+ax_anim 6, 0, 14, 0, -4, 0, -1,
+ax_anim 6, 0, 14, 0, -3, 0, -2,
+ax_anim 6, 0, 14, 0, -1, 0, -2,
+ax_anim 6, 0, 14, 0, 0, 0, -1,
+ax_anim_terminator
+sAzurillAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 1, 3, 0, 0,
+ax_anim 6, 0, 16, 0, 0, -1, 0,
+ax_anim 6, 0, 16, -1, -1, -2, -1,
+ax_anim 6, 0, 16, -2, 0, -3, -2,
+ax_anim 6, 0, 17, -2, -1, -3, -2,
+ax_anim 6, 0, 17, -1, 0, -2, -1,
+ax_anim_terminator
+sAzurillAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 2, 2, 0, 0,
+ax_anim 6, 0, 19, 1, 1, -1, 0,
+ax_anim 6, 0, 19, 0, 0, -2, 0,
+ax_anim 6, 0, 19, -2, 1, -3, 0,
+ax_anim 6, 0, 20, -2, -1, -3, 0,
+ax_anim 6, 0, 20, 0, -1, -2, 0,
+ax_anim_terminator
+sAzurillAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 1, 1, 0, 0,
+ax_anim 6, 0, 22, 0, 0, -1, 0,
+ax_anim 6, 0, 22, -1, 1, -1, 0,
+ax_anim 6, 0, 22, -2, 3, -2, 1,
+ax_anim 6, 0, 23, -2, 0, -2, 1,
+ax_anim 6, 0, 23, -1, -1, -1, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 3, 0, 6,
+ax_anim_terminator
+sAzurillAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 6, 2, 6, 6,
+ax_anim 2, 2, 28, 14, 11, 14, 14,
+ax_anim 2, 0, 29, 19, 17, 19, 19,
+ax_anim 2, 1, 29, 20, 16, 20, 18,
+ax_anim 2, 0, 29, 19, 17, 19, 19,
+ax_anim 2, 0, 29, 20, 16, 20, 18,
+ax_anim 2, 0, 27, 8, 5, 8, 8,
+ax_anim_terminator
+sAzurillAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, -1, 4, 0,
+ax_anim 2, 2, 31, 10, -1, 10, 0,
+ax_anim 2, 0, 32, 18, -1, 18, 0,
+ax_anim 2, 1, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, -1, 18, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 6, -3, 6, 0,
+ax_anim_terminator
+sAzurillAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 2, -4, 3, -3,
+ax_anim 2, 0, 34, 6, -11, 6, -6,
+ax_anim 2, 2, 34, 10, -15, 10, -10,
+ax_anim 2, 0, 35, 19, -22, 21, -21,
+ax_anim 2, 1, 35, 20, -21, 22, -20,
+ax_anim 2, 0, 35, 19, -22, 21, -21,
+ax_anim 2, 0, 35, 20, -21, 22, -20,
+ax_anim 2, 0, 33, 6, -9, 6, -6,
+ax_anim_terminator
+sAzurillAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 37, 0, -10, 0, -10,
+ax_anim 2, 0, 38, 0, -20, 0, -20,
+ax_anim 2, 1, 38, 1, -20, 1, -20,
+ax_anim 2, 0, 38, 0, -20, 0, -20,
+ax_anim 2, 0, 38, 1, -20, 1, -20,
+ax_anim 2, 0, 36, 0, -9, 0, -6,
+ax_anim_terminator
+sAzurillAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, -2, -4, -2, -2,
+ax_anim 2, 0, 40, -6, -11, -6, -6,
+ax_anim 2, 2, 40, -10, -15, -10, -10,
+ax_anim 2, 0, 41, -19, -22, -21, -22,
+ax_anim 2, 1, 41, -20, -21, -22, -21,
+ax_anim 2, 0, 41, -19, -22, -21, -22,
+ax_anim 2, 0, 41, -20, -21, -22, -21,
+ax_anim 2, 0, 39, -6, -9, -6, -6,
+ax_anim_terminator
+sAzurillAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, -1, -4, 0,
+ax_anim 2, 2, 43, -10, -1, -10, 0,
+ax_anim 2, 0, 44, -18, -1, -18, 0,
+ax_anim 2, 1, 44, -18, 0, -18, 1,
+ax_anim 2, 0, 44, -18, -1, -18, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 1,
+ax_anim 2, 0, 42, -6, -3, -6, 0,
+ax_anim_terminator
+sAzurillAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 46, -6, 2, -6, 6,
+ax_anim 2, 2, 46, -14, 11, -14, 14,
+ax_anim 2, 0, 47, -19, 17, -19, 19,
+ax_anim 2, 1, 47, -20, 16, -20, 18,
+ax_anim 2, 0, 47, -19, 17, -19, 19,
+ax_anim 2, 0, 47, -20, 16, -20, 18,
+ax_anim 2, 0, 45, -8, 5, -8, 8,
+ax_anim_terminator
+.align 2
+sAzurillAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 3, 0, 6,
+ax_anim_terminator
+sAzurillAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 6, 2, 6, 6,
+ax_anim 2, 2, 52, 14, 11, 14, 14,
+ax_anim 2, 0, 53, 19, 17, 19, 19,
+ax_anim 2, 1, 53, 20, 16, 20, 18,
+ax_anim 2, 0, 53, 19, 17, 19, 19,
+ax_anim 2, 0, 53, 20, 16, 20, 18,
+ax_anim 2, 0, 51, 8, 5, 8, 8,
+ax_anim_terminator
+sAzurillAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 4, -1, 4, 0,
+ax_anim 2, 2, 55, 10, -1, 10, 0,
+ax_anim 2, 0, 56, 18, -1, 18, 0,
+ax_anim 2, 1, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, -1, 18, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 54, 6, -3, 6, 0,
+ax_anim_terminator
+sAzurillAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 2, -4, 3, -3,
+ax_anim 2, 0, 58, 6, -11, 6, -6,
+ax_anim 2, 2, 58, 10, -15, 10, -10,
+ax_anim 2, 0, 59, 19, -22, 21, -21,
+ax_anim 2, 1, 59, 20, -21, 22, -20,
+ax_anim 2, 0, 59, 19, -22, 21, -21,
+ax_anim 2, 0, 59, 20, -21, 22, -20,
+ax_anim 2, 0, 57, 6, -9, 6, -6,
+ax_anim_terminator
+sAzurillAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, -4,
+ax_anim 2, 2, 61, 0, -10, 0, -10,
+ax_anim 2, 0, 62, 0, -20, 0, -20,
+ax_anim 2, 1, 62, 1, -20, 1, -20,
+ax_anim 2, 0, 62, 0, -20, 0, -20,
+ax_anim 2, 0, 62, 1, -20, 1, -20,
+ax_anim 2, 0, 60, 0, -9, 0, -6,
+ax_anim_terminator
+sAzurillAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, -2, -4, -2, -2,
+ax_anim 2, 0, 64, -6, -11, -6, -6,
+ax_anim 2, 2, 64, -10, -15, -10, -10,
+ax_anim 2, 0, 65, -19, -22, -21, -22,
+ax_anim 2, 1, 65, -20, -21, -22, -21,
+ax_anim 2, 0, 65, -19, -22, -21, -22,
+ax_anim 2, 0, 65, -20, -21, -22, -21,
+ax_anim 2, 0, 63, -6, -9, -6, -6,
+ax_anim_terminator
+sAzurillAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -4, -1, -4, 0,
+ax_anim 2, 2, 67, -10, -1, -10, 0,
+ax_anim 2, 0, 68, -18, -1, -18, 0,
+ax_anim 2, 1, 68, -18, 0, -18, 1,
+ax_anim 2, 0, 68, -18, -1, -18, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 1,
+ax_anim 2, 0, 66, -6, -3, -6, 0,
+ax_anim_terminator
+sAzurillAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 70, -6, 2, -6, 6,
+ax_anim 2, 2, 70, -14, 11, -14, 14,
+ax_anim 2, 0, 71, -19, 17, -19, 19,
+ax_anim 2, 1, 71, -20, 16, -20, 18,
+ax_anim 2, 0, 71, -19, 17, -19, 19,
+ax_anim 2, 0, 71, -20, 16, -20, 18,
+ax_anim 2, 0, 69, -8, 5, -8, 8,
+ax_anim_terminator
+.align 2
+sAzurillAnims_4_1:
+ax_anim 6, 2, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 1, 0, 1,
+ax_anim 1, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 1, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim_terminator
+sAzurillAnims_4_2:
+ax_anim 6, 2, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 1, 1, 1, 1,
+ax_anim 1, 0, 78, 3, 3, 3, 3,
+ax_anim 2, 1, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 4, 6, 4, 6,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 4, 6, 4, 6,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 4, 6, 4, 6,
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim_terminator
+sAzurillAnims_4_3:
+ax_anim 6, 2, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 1, 0, 1, 0,
+ax_anim 1, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 1, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 1, 5, 1,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 1, 5, 1,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim_terminator
+sAzurillAnims_4_4:
+ax_anim 6, 2, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 1, -1, 1, -1,
+ax_anim 1, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 1, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 4, -6, 4, -6,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 4, -6, 4, -6,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 4, -6, 4, -6,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim_terminator
+sAzurillAnims_4_5:
+ax_anim 6, 2, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 90, 0, -3, 0, -3,
+ax_anim 2, 1, 90, 0, -5, 0, -5,
+ax_anim 2, 0, 90, 1, -5, 1, -5,
+ax_anim 2, 0, 90, 0, -5, 0, -5,
+ax_anim 2, 0, 90, 1, -5, 1, -5,
+ax_anim 2, 0, 90, 0, -5, 0, -5,
+ax_anim 2, 0, 90, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -2, 0, -2,
+ax_anim_terminator
+sAzurillAnims_4_6:
+ax_anim 6, 2, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 94, -1, -1, -1, -1,
+ax_anim 1, 0, 94, -3, -3, -3, -3,
+ax_anim 2, 1, 94, -5, -5, -5, -5,
+ax_anim 2, 0, 94, -4, -6, -4, -6,
+ax_anim 2, 0, 94, -5, -5, -5, -5,
+ax_anim 2, 0, 94, -4, -6, -4, -6,
+ax_anim 2, 0, 94, -5, -5, -5, -5,
+ax_anim 2, 0, 94, -4, -6, -4, -6,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim_terminator
+sAzurillAnims_4_7:
+ax_anim 6, 2, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 98, -1, 0, -1, 0,
+ax_anim 1, 0, 98, -3, 0, -3, 0,
+ax_anim 2, 1, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 1, -5, 1,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 1, -5, 1,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim_terminator
+sAzurillAnims_4_8:
+ax_anim 6, 2, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 102, -1, 1, -1, 1,
+ax_anim 1, 0, 102, -3, 3, -3, 3,
+ax_anim 2, 1, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -4, 6, -4, 6,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -4, 6, -4, 6,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -4, 6, -4, 6,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sAzurillAnims_5_1:
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_5_2:
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_5_3:
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_5_4:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_5_5:
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_5_6:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_5_7:
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_5_8:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sAzurillAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sAzurillAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sAzurillAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sAzurillAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sAzurillAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sAzurillAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sAzurillAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sAzurillAnims_8_1:
+ax_anim 16, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_8_2:
+ax_anim 16, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 16, 0, 143, 0, 0, 0, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_8_3:
+ax_anim 16, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_8_4:
+ax_anim 16, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_8_5:
+ax_anim 16, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim 16, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_8_6:
+ax_anim 16, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_8_7:
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_8_8:
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim 16, 0, 167, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 18, 7, 18,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -7, 18, -7, 18,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 23, 13, 23, 13,
+ax_anim 3, 0, 173, 24, 20, 24, 20,
+ax_anim 2, 3, 174, 13, 22, 13, 22,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 12, -6, 12, -6,
+ax_anim 2, 0, 171, 20, -4, 20, -4,
+ax_anim 3, 0, 172, 25, 0, 25, 0,
+ax_anim 2, 3, 173, 22, 5, 22, 5,
+ax_anim 2, 0, 174, 12, 8, 12, 8,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -17, 4, -17,
+ax_anim 2, 0, 170, 13, -23, 13, -23,
+ax_anim 3, 0, 171, 24, -23, 24, -23,
+ax_anim 2, 3, 172, 25, -14, 25, -14,
+ax_anim 2, 0, 173, 20, -5, 20, -5,
+ax_anim 1, 0, 174, 11, 1, 11, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -5, -8, -5,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -6, -20, -6, -20,
+ax_anim 3, 0, 170, 0, -23, 0, -23,
+ax_anim 2, 3, 171, 6, -20, 6, -20,
+ax_anim 2, 0, 172, 9, -12, 9, -12,
+ax_anim 1, 0, 173, 8, -5, 8, -5,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -17, -4, -17,
+ax_anim 2, 0, 170, -13, -23, -13, -23,
+ax_anim 3, 0, 177, -24, -23, -24, -23,
+ax_anim 2, 3, 176, -25, -14, -25, -14,
+ax_anim 2, 0, 175, -20, -5, -20, -5,
+ax_anim 1, 0, 174, -11, 1, -11, 1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -12, -6, -12, -6,
+ax_anim 2, 0, 177, -20, -4, -20, -4,
+ax_anim 3, 0, 176, -25, 0, -25, 0,
+ax_anim 2, 3, 175, -22, 5, -22, 5,
+ax_anim 2, 0, 174, -12, 8, -12, 8,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -23, 13, -23, 13,
+ax_anim 3, 0, 175, -24, 20, -24, 20,
+ax_anim 2, 3, 174, -13, 22, -13, 22,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -24, 0, 0,
+ax_anim 2, 0, 188, 0, -20, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -24, 0, 0,
+ax_anim 3, 0, 191, 0, -25, 0, 0,
+ax_anim 2, 0, 191, 0, -20, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -24, 0, 0,
+ax_anim 3, 0, 194, 0, -24, 0, 0,
+ax_anim 2, 0, 194, 0, -19, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -24, 0, 0,
+ax_anim 3, 0, 197, 0, -24, 0, 0,
+ax_anim 2, 0, 197, 0, -19, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -24, 0, 0,
+ax_anim 3, 0, 200, 0, -25, 0, 0,
+ax_anim 2, 0, 200, 0, -20, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -24, 0, 0,
+ax_anim 3, 0, 203, 0, -24, 0, 0,
+ax_anim 2, 0, 203, 0, -19, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -24, 0, 0,
+ax_anim 3, 0, 206, 0, -24, 0, 0,
+ax_anim 2, 0, 206, 0, -19, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -24, 0, 0,
+ax_anim 3, 0, 209, 0, -25, 0, 0,
+ax_anim 2, 0, 209, 0, -20, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sAzurillAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sAzurillGfx1:
+.incbin "baserom.gba", 0x121B678, 0x200
+sAzurillSprites1:
+ax_sprite sAzurillGfx1, 0x200
+ax_sprite_terminator
+sAzurillGfx2:
+.incbin "baserom.gba", 0x121B888, 0x200
+sAzurillSprites2:
+ax_sprite sAzurillGfx2, 0x200
+ax_sprite_terminator
+sAzurillGfx3:
+.incbin "baserom.gba", 0x121BA98, 0x200
+sAzurillSprites3:
+ax_sprite sAzurillGfx3, 0x200
+ax_sprite_terminator
+sAzurillGfx4:
+.incbin "baserom.gba", 0x121BCA8, 0x200
+sAzurillSprites4:
+ax_sprite sAzurillGfx4, 0x200
+ax_sprite_terminator
+sAzurillGfx5:
+.incbin "baserom.gba", 0x121BEB8, 0x200
+sAzurillSprites5:
+ax_sprite sAzurillGfx5, 0x200
+ax_sprite_terminator
+sAzurillGfx6:
+.incbin "baserom.gba", 0x121C0C8, 0x200
+sAzurillSprites6:
+ax_sprite sAzurillGfx6, 0x200
+ax_sprite_terminator
+sAzurillGfx7:
+.incbin "baserom.gba", 0x121C2D8, 0x200
+sAzurillSprites7:
+ax_sprite sAzurillGfx7, 0x200
+ax_sprite_terminator
+sAzurillGfx8:
+.incbin "baserom.gba", 0x121C4E8, 0x200
+sAzurillSprites8:
+ax_sprite sAzurillGfx8, 0x200
+ax_sprite_terminator
+sAzurillGfx9:
+.incbin "baserom.gba", 0x121C6F8, 0x200
+sAzurillSprites9:
+ax_sprite sAzurillGfx9, 0x200
+ax_sprite_terminator
+sAzurillGfx10:
+.incbin "baserom.gba", 0x121C908, 0x200
+sAzurillSprites10:
+ax_sprite sAzurillGfx10, 0x200
+ax_sprite_terminator
+sAzurillGfx11:
+.incbin "baserom.gba", 0x121CB18, 0x200
+sAzurillSprites11:
+ax_sprite sAzurillGfx11, 0x200
+ax_sprite_terminator
+sAzurillGfx12:
+.incbin "baserom.gba", 0x121CD28, 0x100
+sAzurillSprites12:
+ax_sprite sAzurillGfx12, 0x100
+ax_sprite_terminator
+sAzurillGfx13:
+.incbin "baserom.gba", 0x121CE38, 0x100
+sAzurillSprites13:
+ax_sprite sAzurillGfx13, 0x100
+ax_sprite_terminator
+sAzurillGfx14:
+.incbin "baserom.gba", 0x121CF48, 0x100
+sAzurillSprites14:
+ax_sprite sAzurillGfx14, 0x100
+ax_sprite_terminator
+sAzurillGfx15:
+.incbin "baserom.gba", 0x121D058, 0x80
+sAzurillSprites15:
+ax_sprite sAzurillGfx15, 0x80
+ax_sprite_terminator
+sAzurillGfx16:
+.incbin "baserom.gba", 0x121D0E8, 0x60
+sAzurillGfx16_1:
+.incbin "baserom.gba", 0x121D148, 0x60
+sAzurillGfx16_2:
+.incbin "baserom.gba", 0x121D1A8, 0x40
+sAzurillSprites16:
+ax_sprite sAzurillGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx16_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx17:
+.incbin "baserom.gba", 0x121D220, 0x60
+sAzurillGfx17_1:
+.incbin "baserom.gba", 0x121D280, 0x40
+sAzurillGfx17_2:
+.incbin "baserom.gba", 0x121D2C0, 0x40
+sAzurillSprites17:
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx18:
+.incbin "baserom.gba", 0x121D340, 0x40
+sAzurillGfx18_1:
+.incbin "baserom.gba", 0x121D380, 0x40
+sAzurillGfx18_2:
+.incbin "baserom.gba", 0x121D3C0, 0x40
+sAzurillGfx18_3:
+.incbin "baserom.gba", 0x121D400, 0x40
+sAzurillSprites18:
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx18_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx18_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzurillGfx19:
+.incbin "baserom.gba", 0x121D490, 0xC0
+sAzurillSprites19:
+ax_sprite sAzurillGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAzurillGfx20:
+.incbin "baserom.gba", 0x121D568, 0x60
+sAzurillGfx20_1:
+.incbin "baserom.gba", 0x121D5C8, 0x60
+sAzurillGfx20_2:
+.incbin "baserom.gba", 0x121D628, 0x40
+sAzurillSprites20:
+ax_sprite sAzurillGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx20_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx21:
+.incbin "baserom.gba", 0x121D6A0, 0x60
+sAzurillGfx21_1:
+.incbin "baserom.gba", 0x121D700, 0x60
+sAzurillGfx21_2:
+.incbin "baserom.gba", 0x121D760, 0x40
+sAzurillSprites21:
+ax_sprite sAzurillGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx21_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx22:
+.incbin "baserom.gba", 0x121D7D8, 0x60
+sAzurillGfx22_1:
+.incbin "baserom.gba", 0x121D838, 0x60
+sAzurillGfx22_2:
+.incbin "baserom.gba", 0x121D898, 0x60
+sAzurillGfx22_3:
+.incbin "baserom.gba", 0x121D8F8, 0x40
+sAzurillSprites22:
+ax_sprite sAzurillGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzurillGfx23:
+.incbin "baserom.gba", 0x121D980, 0x60
+sAzurillGfx23_1:
+.incbin "baserom.gba", 0x121D9E0, 0x60
+sAzurillGfx23_2:
+.incbin "baserom.gba", 0x121DA40, 0x40
+sAzurillSprites23:
+ax_sprite sAzurillGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx24:
+.incbin "baserom.gba", 0x121DAB8, 0x60
+sAzurillGfx24_1:
+.incbin "baserom.gba", 0x121DB18, 0x60
+sAzurillGfx24_2:
+.incbin "baserom.gba", 0x121DB78, 0x40
+sAzurillSprites24:
+ax_sprite sAzurillGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx25:
+.incbin "baserom.gba", 0x121DBF0, 0x60
+sAzurillGfx25_1:
+.incbin "baserom.gba", 0x121DC50, 0x60
+sAzurillGfx25_2:
+.incbin "baserom.gba", 0x121DCB0, 0x40
+sAzurillSprites25:
+ax_sprite sAzurillGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx26:
+.incbin "baserom.gba", 0x121DD28, 0x40
+sAzurillGfx26_1:
+.incbin "baserom.gba", 0x121DD68, 0x60
+sAzurillGfx26_2:
+.incbin "baserom.gba", 0x121DDC8, 0x60
+sAzurillGfx26_3:
+.incbin "baserom.gba", 0x121DE28, 0x40
+sAzurillSprites26:
+ax_sprite sAzurillGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzurillGfx27:
+.incbin "baserom.gba", 0x121DEB0, 0x60
+sAzurillGfx27_1:
+.incbin "baserom.gba", 0x121DF10, 0x60
+sAzurillGfx27_2:
+.incbin "baserom.gba", 0x121DF70, 0x40
+sAzurillSprites27:
+ax_sprite sAzurillGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx28:
+.incbin "baserom.gba", 0x121DFE8, 0x60
+sAzurillGfx28_1:
+.incbin "baserom.gba", 0x121E048, 0x60
+sAzurillGfx28_2:
+.incbin "baserom.gba", 0x121E0A8, 0x40
+sAzurillSprites28:
+ax_sprite sAzurillGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx28_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx29:
+.incbin "baserom.gba", 0x121E120, 0x60
+sAzurillGfx29_1:
+.incbin "baserom.gba", 0x121E180, 0x60
+sAzurillGfx29_2:
+.incbin "baserom.gba", 0x121E1E0, 0x40
+sAzurillSprites29:
+ax_sprite sAzurillGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx29_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx30:
+.incbin "baserom.gba", 0x121E258, 0x40
+sAzurillGfx30_1:
+.incbin "baserom.gba", 0x121E298, 0x60
+sAzurillGfx30_2:
+.incbin "baserom.gba", 0x121E2F8, 0x60
+sAzurillGfx30_3:
+.incbin "baserom.gba", 0x121E358, 0x40
+sAzurillSprites30:
+ax_sprite sAzurillGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzurillGfx31:
+.incbin "baserom.gba", 0x121E3E0, 0x60
+sAzurillGfx31_1:
+.incbin "baserom.gba", 0x121E440, 0x60
+sAzurillGfx31_2:
+.incbin "baserom.gba", 0x121E4A0, 0x40
+sAzurillSprites31:
+ax_sprite sAzurillGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx31_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx32:
+.incbin "baserom.gba", 0x121E518, 0x40
+sAzurillGfx32_1:
+.incbin "baserom.gba", 0x121E558, 0x60
+sAzurillGfx32_2:
+.incbin "baserom.gba", 0x121E5B8, 0x40
+sAzurillSprites32:
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx32_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx32_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx33:
+.incbin "baserom.gba", 0x121E638, 0x60
+sAzurillGfx33_1:
+.incbin "baserom.gba", 0x121E698, 0x60
+sAzurillGfx33_2:
+.incbin "baserom.gba", 0x121E6F8, 0x40
+sAzurillSprites33:
+ax_sprite sAzurillGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sAzurillGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx33_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sAzurillGfx34:
+.incbin "baserom.gba", 0x121E770, 0x60
+sAzurillGfx34_1:
+.incbin "baserom.gba", 0x121E7D0, 0x40
+sAzurillGfx34_2:
+.incbin "baserom.gba", 0x121E810, 0x40
+sAzurillGfx34_3:
+.incbin "baserom.gba", 0x121E850, 0x40
+sAzurillSprites34:
+ax_sprite sAzurillGfx34, 0x60
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sAzurillGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAzurillGfx35:
+.incbin "baserom.gba", 0x121E8D8, 0xC0
+sAzurillSprites35:
+ax_sprite sAzurillGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAzurillGfx36:
+.incbin "baserom.gba", 0x121E9B0, 0x200
+sAzurillSprites36:
+ax_sprite sAzurillGfx36, 0x200
+ax_sprite_terminator
+sAzurillGfx37:
+.incbin "baserom.gba", 0x121EBC0, 0x200
+sAzurillSprites37:
+ax_sprite sAzurillGfx37, 0x200
+ax_sprite_terminator
+sAzurillGfx38:
+.incbin "baserom.gba", 0x121EDD0, 0x200
+sAzurillSprites38:
+ax_sprite sAzurillGfx38, 0x200
+ax_sprite_terminator
+sAzurillGfx39:
+.incbin "baserom.gba", 0x121EFE0, 0x200
+sAzurillSprites39:
+ax_sprite sAzurillGfx39, 0x200
+ax_sprite_terminator
+sAzurillGfx40:
+.incbin "baserom.gba", 0x121F1F0, 0x80
+sAzurillSprites40:
+ax_sprite sAzurillGfx40, 0x80
+ax_sprite_terminator
+sAzurillGfx41:
+.incbin "baserom.gba", 0x121F280, 0x20
+sAzurillSprites41:
+ax_sprite sAzurillGfx41, 0x20
+ax_sprite_terminator
+sAzurillGfx42:
+.incbin "baserom.gba", 0x121F2B0, 0x20
+sAzurillSprites42:
+ax_sprite sAzurillGfx42, 0x20
+ax_sprite_terminator
+sAzurillGfx43:
+.incbin "baserom.gba", 0x121F2E0, 0x100
+sAzurillSprites43:
+ax_sprite sAzurillGfx43, 0x100
+ax_sprite_terminator
+sAzurillGfx44:
+.incbin "baserom.gba", 0x121F3F0, 0x200
+sAzurillSprites44:
+ax_sprite sAzurillGfx44, 0x200
+ax_sprite_terminator
+sAzurillGfx45:
+.incbin "baserom.gba", 0x121F600, 0x200
+sAzurillSprites45:
+ax_sprite sAzurillGfx45, 0x200
+ax_sprite_terminator
+sAxPosesAzurill:
+.4byte sAzurillPose1
+.4byte sAzurillPose2
+.4byte sAzurillPose3
+.4byte sAzurillPose4
+.4byte sAzurillPose5
+.4byte sAzurillPose6
+.4byte sAzurillPose7
+.4byte sAzurillPose8
+.4byte sAzurillPose9
+.4byte sAzurillPose10
+.4byte sAzurillPose11
+.4byte sAzurillPose12
+.4byte sAzurillPose13
+.4byte sAzurillPose14
+.4byte sAzurillPose15
+.4byte sAzurillPose16
+.4byte sAzurillPose17
+.4byte sAzurillPose18
+.4byte sAzurillPose19
+.4byte sAzurillPose20
+.4byte sAzurillPose21
+.4byte sAzurillPose22
+.4byte sAzurillPose23
+.4byte sAzurillPose24
+.4byte sAzurillPose25
+.4byte sAzurillPose26
+.4byte sAzurillPose27
+.4byte sAzurillPose28
+.4byte sAzurillPose29
+.4byte sAzurillPose30
+.4byte sAzurillPose31
+.4byte sAzurillPose32
+.4byte sAzurillPose33
+.4byte sAzurillPose34
+.4byte sAzurillPose35
+.4byte sAzurillPose36
+.4byte sAzurillPose37
+.4byte sAzurillPose38
+.4byte sAzurillPose39
+.4byte sAzurillPose40
+.4byte sAzurillPose41
+.4byte sAzurillPose42
+.4byte sAzurillPose43
+.4byte sAzurillPose44
+.4byte sAzurillPose45
+.4byte sAzurillPose46
+.4byte sAzurillPose47
+.4byte sAzurillPose48
+.4byte sAzurillPose49
+.4byte sAzurillPose50
+.4byte sAzurillPose51
+.4byte sAzurillPose52
+.4byte sAzurillPose53
+.4byte sAzurillPose54
+.4byte sAzurillPose55
+.4byte sAzurillPose56
+.4byte sAzurillPose57
+.4byte sAzurillPose58
+.4byte sAzurillPose59
+.4byte sAzurillPose60
+.4byte sAzurillPose61
+.4byte sAzurillPose62
+.4byte sAzurillPose63
+.4byte sAzurillPose64
+.4byte sAzurillPose65
+.4byte sAzurillPose66
+.4byte sAzurillPose67
+.4byte sAzurillPose68
+.4byte sAzurillPose69
+.4byte sAzurillPose70
+.4byte sAzurillPose71
+.4byte sAzurillPose72
+.4byte sAzurillPose73
+.4byte sAzurillPose74
+.4byte sAzurillPose75
+.4byte sAzurillPose76
+.4byte sAzurillPose77
+.4byte sAzurillPose78
+.4byte sAzurillPose79
+.4byte sAzurillPose80
+.4byte sAzurillPose81
+.4byte sAzurillPose82
+.4byte sAzurillPose83
+.4byte sAzurillPose84
+.4byte sAzurillPose85
+.4byte sAzurillPose86
+.4byte sAzurillPose87
+.4byte sAzurillPose88
+.4byte sAzurillPose89
+.4byte sAzurillPose90
+.4byte sAzurillPose91
+.4byte sAzurillPose92
+.4byte sAzurillPose93
+.4byte sAzurillPose94
+.4byte sAzurillPose95
+.4byte sAzurillPose96
+.4byte sAzurillPose97
+.4byte sAzurillPose98
+.4byte sAzurillPose99
+.4byte sAzurillPose100
+.4byte sAzurillPose101
+.4byte sAzurillPose102
+.4byte sAzurillPose103
+.4byte sAzurillPose104
+.4byte sAzurillPose105
+.4byte sAzurillPose106
+.4byte sAzurillPose107
+.4byte sAzurillPose108
+.4byte sAzurillPose109
+.4byte sAzurillPose110
+.4byte sAzurillPose111
+.4byte sAzurillPose112
+.4byte sAzurillPose113
+.4byte sAzurillPose114
+.4byte sAzurillPose115
+.4byte sAzurillPose116
+.4byte sAzurillPose117
+.4byte sAzurillPose118
+.4byte sAzurillPose119
+.4byte sAzurillPose120
+.4byte sAzurillPose121
+.4byte sAzurillPose122
+.4byte sAzurillPose123
+.4byte sAzurillPose124
+.4byte sAzurillPose125
+.4byte sAzurillPose126
+.4byte sAzurillPose127
+.4byte sAzurillPose128
+.4byte sAzurillPose129
+.4byte sAzurillPose130
+.4byte sAzurillPose131
+.4byte sAzurillPose132
+.4byte sAzurillPose133
+.4byte sAzurillPose134
+.4byte sAzurillPose135
+.4byte sAzurillPose136
+.4byte sAzurillPose137
+.4byte sAzurillPose138
+.4byte sAzurillPose139
+.4byte sAzurillPose140
+.4byte sAzurillPose141
+.4byte sAzurillPose142
+.4byte sAzurillPose143
+.4byte sAzurillPose144
+.4byte sAzurillPose145
+.4byte sAzurillPose146
+.4byte sAzurillPose147
+.4byte sAzurillPose148
+.4byte sAzurillPose149
+.4byte sAzurillPose150
+.4byte sAzurillPose151
+.4byte sAzurillPose152
+.4byte sAzurillPose153
+.4byte sAzurillPose154
+.4byte sAzurillPose155
+.4byte sAzurillPose156
+.4byte sAzurillPose157
+.4byte sAzurillPose158
+.4byte sAzurillPose159
+.4byte sAzurillPose160
+.4byte sAzurillPose161
+.4byte sAzurillPose162
+.4byte sAzurillPose163
+.4byte sAzurillPose164
+.4byte sAzurillPose165
+.4byte sAzurillPose166
+.4byte sAzurillPose167
+.4byte sAzurillPose168
+.4byte sAzurillPose169
+.4byte sAzurillPose170
+.4byte sAzurillPose171
+.4byte sAzurillPose172
+.4byte sAzurillPose173
+.4byte sAzurillPose174
+.4byte sAzurillPose175
+.4byte sAzurillPose176
+.4byte sAzurillPose177
+.4byte sAzurillPose178
+.4byte sAzurillPose179
+.4byte sAzurillPose180
+.4byte sAzurillPose181
+.4byte sAzurillPose182
+.4byte sAzurillPose183
+.4byte sAzurillPose184
+.4byte sAzurillPose185
+.4byte sAzurillPose186
+.4byte sAzurillPose187
+.4byte sAzurillPose188
+.4byte sAzurillPose189
+.4byte sAzurillPose190
+.4byte sAzurillPose191
+.4byte sAzurillPose192
+.4byte sAzurillPose193
+.4byte sAzurillPose194
+.4byte sAzurillPose195
+.4byte sAzurillPose196
+.4byte sAzurillPose197
+.4byte sAzurillPose198
+.4byte sAzurillPose199
+.4byte sAzurillPose200
+.4byte sAzurillPose201
+.4byte sAzurillPose202
+.4byte sAzurillPose203
+.4byte sAzurillPose204
+.4byte sAzurillPose205
+.4byte sAzurillPose206
+.4byte sAzurillPose207
+.4byte sAzurillPose208
+.4byte sAzurillPose209
+.4byte sAzurillPose210
+.4byte sAzurillPose211
+.4byte sAzurillPose212
+.4byte sAzurillPose213
+.4byte sAzurillPose214
+.4byte sAzurillPose215
+.4byte sAzurillPose216
+.4byte sAzurillPose217
+.4byte sAzurillPose218
+.4byte sAzurillPose219
+.4byte sAzurillPose220
+.4byte sAzurillPose221
+.4byte sAzurillPose222
+.4byte sAzurillPose223
+.4byte sAzurillPose224
+.4byte sAzurillPose225
+.4byte sAzurillPose226
+sAxPositionsAzurill:
+.2byte   -1,   -2, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -8, 	   4,   -8, 	  -1,  -10
+.2byte   -1,    2, 	  -6,    0, 	   4,    0, 	  -1,   -2
+.2byte    3,   -3, 	   5,   -5, 	  -4,   -3, 	   0,   -5
+.2byte    5,   -8, 	   7,   -8, 	  -2,   -5, 	   2,   -8
+.2byte    5,    1, 	   7,   -1, 	  -1,    1, 	   2,   -2
+.2byte    4,   -4, 	   1,   -7, 	   1,   -2, 	   0,   -5
+.2byte    7,  -10, 	   2,  -11, 	   2,   -7, 	   2,  -10
+.2byte    7,   -1, 	   4,   -5, 	   4,   -1, 	   3,   -4
+.2byte    2,   -5, 	  -5,   -7, 	   4,   -4, 	   0,   -6
+.2byte    5,  -10, 	  -2,  -12, 	   7,   -9, 	   2,  -11
+.2byte    6,   -4, 	   2,   -8, 	   7,   -4, 	   4,   -6
+.2byte    0,   -7, 	   5,   -6, 	  -5,   -6, 	   0,   -6
+.2byte    0,  -13, 	   5,  -11, 	  -5,  -11, 	   0,  -12
+.2byte    0,   -5, 	   5,   -7, 	  -5,   -7, 	   0,   -7
+.2byte   -3,   -5, 	   4,   -7, 	  -5,   -4, 	  -1,   -6
+.2byte   -6,  -10, 	   1,  -12, 	  -8,   -9, 	  -3,  -11
+.2byte   -7,   -4, 	  -3,   -8, 	  -8,   -4, 	  -5,   -6
+.2byte   -5,   -4, 	  -2,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte   -8,  -10, 	  -3,  -11, 	  -3,   -7, 	  -3,  -10
+.2byte   -8,   -1, 	  -5,   -5, 	  -5,   -1, 	  -4,   -4
+.2byte   -4,   -3, 	  -6,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -6,   -8, 	  -8,   -8, 	   1,   -5, 	  -3,   -8
+.2byte   -6,    1, 	  -8,   -1, 	   0,    1, 	  -3,   -2
+.2byte   -1,   -2, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -8, 	   4,   -8, 	  -1,  -10
+.2byte   -1,    2, 	  -6,    0, 	   4,    0, 	  -1,   -2
+.2byte    3,   -3, 	   5,   -5, 	  -4,   -3, 	   0,   -5
+.2byte    5,   -8, 	   7,   -8, 	  -2,   -5, 	   2,   -8
+.2byte    5,    1, 	   7,   -1, 	  -1,    1, 	   2,   -2
+.2byte    4,   -4, 	   1,   -7, 	   1,   -2, 	   0,   -5
+.2byte    7,  -10, 	   2,  -11, 	   2,   -7, 	   2,  -10
+.2byte    7,   -1, 	   4,   -5, 	   4,   -1, 	   3,   -4
+.2byte    2,   -5, 	  -5,   -7, 	   4,   -4, 	   0,   -6
+.2byte    3,  -10, 	  -4,  -12, 	   5,   -9, 	   0,  -11
+.2byte    4,   -4, 	   0,   -8, 	   5,   -4, 	   2,   -6
+.2byte    0,   -7, 	   5,   -6, 	  -5,   -6, 	   0,   -6
+.2byte    0,  -13, 	   5,  -11, 	  -5,  -11, 	   0,  -12
+.2byte    0,   -5, 	   5,   -7, 	  -5,   -7, 	   0,   -7
+.2byte   -3,   -5, 	   4,   -7, 	  -5,   -4, 	  -1,   -6
+.2byte   -4,  -10, 	   3,  -12, 	  -6,   -9, 	  -1,  -11
+.2byte   -5,   -4, 	  -1,   -8, 	  -6,   -4, 	  -3,   -6
+.2byte   -5,   -4, 	  -2,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte   -8,  -10, 	  -3,  -11, 	  -3,   -7, 	  -3,  -10
+.2byte   -8,   -1, 	  -5,   -5, 	  -5,   -1, 	  -4,   -4
+.2byte   -4,   -3, 	  -6,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -6,   -8, 	  -8,   -8, 	   1,   -5, 	  -3,   -8
+.2byte   -6,    1, 	  -8,   -1, 	   0,    1, 	  -3,   -2
+.2byte   -1,   -2, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -8, 	   4,   -8, 	  -1,  -10
+.2byte   -1,    2, 	  -6,    0, 	   4,    0, 	  -1,   -2
+.2byte    3,   -3, 	   5,   -5, 	  -4,   -3, 	   0,   -5
+.2byte    5,   -8, 	   7,   -8, 	  -2,   -5, 	   2,   -8
+.2byte    5,    1, 	   7,   -1, 	  -1,    1, 	   2,   -2
+.2byte    4,   -4, 	   1,   -7, 	   1,   -2, 	   0,   -5
+.2byte    7,  -10, 	   2,  -11, 	   2,   -7, 	   2,  -10
+.2byte    7,   -1, 	   4,   -5, 	   4,   -1, 	   3,   -4
+.2byte    2,   -5, 	  -5,   -7, 	   4,   -4, 	   0,   -6
+.2byte    3,  -10, 	  -4,  -12, 	   5,   -9, 	   0,  -11
+.2byte    4,   -4, 	   0,   -8, 	   5,   -4, 	   2,   -6
+.2byte    0,   -7, 	   5,   -6, 	  -5,   -6, 	   0,   -6
+.2byte    0,  -13, 	   5,  -11, 	  -5,  -11, 	   0,  -12
+.2byte    0,   -5, 	   5,   -7, 	  -5,   -7, 	   0,   -7
+.2byte   -3,   -5, 	   4,   -7, 	  -5,   -4, 	  -1,   -6
+.2byte   -4,  -10, 	   3,  -12, 	  -6,   -9, 	  -1,  -11
+.2byte   -5,   -4, 	  -1,   -8, 	  -6,   -4, 	  -3,   -6
+.2byte   -5,   -4, 	  -2,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte   -8,  -10, 	  -3,  -11, 	  -3,   -7, 	  -3,  -10
+.2byte   -8,   -1, 	  -5,   -5, 	  -5,   -1, 	  -4,   -4
+.2byte   -4,   -3, 	  -6,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -6,   -8, 	  -8,   -8, 	   1,   -5, 	  -3,   -8
+.2byte   -6,    1, 	  -8,   -1, 	   0,    1, 	  -3,   -2
+.2byte   -3,  -10, 	  -7,   -9, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -10, 	  -5,  -12, 	   5,   -9, 	   0,  -11
+.2byte   -1,  -19, 	  -6,  -20, 	   4,  -20, 	  -1,  -20
+.2byte   -1,   -7, 	  -6,   -9, 	   4,   -9, 	  -1,  -10
+.2byte    2,  -10, 	   4,   -9, 	  -4,  -11, 	   0,  -11
+.2byte    3,   -9, 	   4,  -11, 	  -4,   -8, 	   1,  -10
+.2byte    6,  -18, 	   7,  -20, 	  -1,  -18, 	   3,  -19
+.2byte    3,   -8, 	   5,  -11, 	  -4,   -8, 	  -1,  -10
+.2byte    5,  -10, 	   1,  -12, 	   1,   -8, 	   0,  -10
+.2byte    5,   -9, 	   2,  -13, 	   1,   -7, 	   1,  -10
+.2byte   11,  -18, 	   7,  -22, 	   7,  -17, 	   7,  -19
+.2byte    5,   -9, 	   1,  -13, 	   1,   -8, 	   1,  -10
+.2byte    1,  -11, 	  -5,  -10, 	   4,  -11, 	   0,  -11
+.2byte    1,  -10, 	  -4,  -12, 	   4,   -8, 	  -1,  -11
+.2byte    3,  -18, 	   0,  -20, 	   7,  -17, 	   1,  -19
+.2byte    2,   -9, 	  -3,  -11, 	   4,   -9, 	  -1,  -10
+.2byte   -1,  -10, 	   5,   -9, 	  -5,  -11, 	   0,  -10
+.2byte   -1,  -10, 	   4,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   4,  -18, 	  -6,  -18, 	  -1,  -18
+.2byte   -1,  -10, 	   4,  -10, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -11, 	   3,  -10, 	  -6,  -11, 	  -2,  -11
+.2byte   -3,  -10, 	   2,  -12, 	  -6,   -8, 	  -1,  -11
+.2byte   -5,  -18, 	  -2,  -20, 	  -9,  -17, 	  -3,  -19
+.2byte   -4,   -9, 	   1,  -11, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -10, 	  -3,  -12, 	  -3,   -8, 	  -2,  -10
+.2byte   -7,   -9, 	  -4,  -13, 	  -3,   -7, 	  -3,  -10
+.2byte  -13,  -18, 	  -9,  -22, 	  -9,  -17, 	  -9,  -19
+.2byte   -7,   -9, 	  -3,  -13, 	  -3,   -8, 	  -3,  -10
+.2byte   -4,  -10, 	  -6,   -9, 	   2,  -11, 	  -2,  -11
+.2byte   -5,   -9, 	  -6,  -11, 	   2,   -8, 	  -3,  -10
+.2byte   -8,  -18, 	  -9,  -20, 	  -1,  -18, 	  -5,  -19
+.2byte   -5,   -8, 	  -7,  -11, 	   2,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	  -7,   -9, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -10, 	  -5,  -12, 	   5,   -9, 	   0,  -11
+.2byte   -1,   -7, 	  -6,   -9, 	   4,   -9, 	  -1,  -10
+.2byte    2,  -10, 	   4,   -9, 	  -4,  -11, 	   0,  -11
+.2byte    3,   -9, 	   4,  -11, 	  -4,   -8, 	   1,  -10
+.2byte    3,   -8, 	   5,  -11, 	  -4,   -8, 	  -1,  -10
+.2byte    5,  -10, 	   1,  -12, 	   1,   -8, 	   0,  -10
+.2byte    5,   -9, 	   2,  -13, 	   1,   -7, 	   1,  -10
+.2byte    5,   -9, 	   1,  -13, 	   1,   -8, 	   1,  -10
+.2byte    1,  -11, 	  -5,  -10, 	   4,  -11, 	   0,  -11
+.2byte    1,  -10, 	  -4,  -12, 	   4,   -8, 	  -1,  -11
+.2byte    2,   -9, 	  -3,  -11, 	   4,   -9, 	  -1,  -10
+.2byte   -1,  -10, 	   5,   -9, 	  -5,  -11, 	   0,  -10
+.2byte   -1,  -10, 	   4,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte   -1,  -10, 	   4,  -10, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -11, 	   3,  -10, 	  -6,  -11, 	  -2,  -11
+.2byte   -3,  -10, 	   2,  -12, 	  -6,   -8, 	  -1,  -11
+.2byte   -4,   -9, 	   1,  -11, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -10, 	  -3,  -12, 	  -3,   -8, 	  -2,  -10
+.2byte   -7,   -9, 	  -4,  -13, 	  -3,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -3,  -13, 	  -3,   -8, 	  -3,  -10
+.2byte   -4,  -10, 	  -6,   -9, 	   2,  -11, 	  -2,  -11
+.2byte   -5,   -9, 	  -6,  -11, 	   2,   -8, 	  -3,  -10
+.2byte   -5,   -8, 	  -7,  -11, 	   2,   -8, 	  -1,  -10
+.2byte   -4,   -3, 	  -4,   -6, 	   2,   -3, 	  -1,   -5
+.2byte   -5,   -1, 	  -4,   -4, 	   2,   -2, 	  -1,   -3
+.2byte    0,  -17, 	  -5,  -14, 	   5,  -14, 	   0,  -15
+.2byte   -2,  -16, 	   2,  -18, 	  -6,  -13, 	  -3,  -15
+.2byte   -1,  -15, 	  -2,  -17, 	  -4,  -11, 	  -4,  -13
+.2byte   -1,  -15, 	  -5,  -16, 	   1,  -11, 	  -4,  -11
+.2byte    0,  -15, 	   5,   -9, 	  -5,   -9, 	   0,  -11
+.2byte    0,  -15, 	   4,  -16, 	  -2,  -11, 	   3,  -11
+.2byte    0,  -15, 	   1,  -17, 	   3,  -11, 	   3,  -13
+.2byte    1,  -16, 	  -3,  -18, 	   5,  -13, 	   2,  -15
+.2byte   -3,  -10, 	  -7,   -9, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -10, 	  -5,  -12, 	   5,   -9, 	   0,  -11
+.2byte   -1,  -19, 	  -6,  -20, 	   4,  -20, 	  -1,  -20
+.2byte   -1,   -7, 	  -6,   -9, 	   4,   -9, 	  -1,  -10
+.2byte    2,  -10, 	   4,   -9, 	  -4,  -11, 	   0,  -11
+.2byte    3,   -9, 	   4,  -11, 	  -4,   -8, 	   1,  -10
+.2byte    6,  -18, 	   7,  -20, 	  -1,  -18, 	   3,  -19
+.2byte    3,   -8, 	   5,  -11, 	  -4,   -8, 	  -1,  -10
+.2byte    5,  -10, 	   1,  -12, 	   1,   -8, 	   0,  -10
+.2byte    5,   -9, 	   2,  -13, 	   1,   -7, 	   1,  -10
+.2byte   11,  -18, 	   7,  -22, 	   7,  -17, 	   7,  -19
+.2byte    5,   -9, 	   1,  -13, 	   1,   -8, 	   1,  -10
+.2byte    1,  -11, 	  -5,  -10, 	   4,  -11, 	   0,  -11
+.2byte    1,  -10, 	  -4,  -12, 	   4,   -8, 	  -1,  -11
+.2byte    3,  -18, 	   0,  -20, 	   7,  -17, 	   1,  -19
+.2byte    2,   -9, 	  -3,  -11, 	   4,   -9, 	  -1,  -10
+.2byte   -1,  -10, 	   5,   -9, 	  -5,  -11, 	   0,  -10
+.2byte   -1,  -10, 	   4,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   4,  -18, 	  -6,  -18, 	  -1,  -18
+.2byte   -1,  -10, 	   4,  -10, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -11, 	   3,  -10, 	  -6,  -11, 	  -2,  -11
+.2byte   -3,  -10, 	   2,  -12, 	  -6,   -8, 	  -1,  -11
+.2byte   -5,  -18, 	  -2,  -20, 	  -9,  -17, 	  -3,  -19
+.2byte   -4,   -9, 	   1,  -11, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -10, 	  -3,  -12, 	  -3,   -8, 	  -2,  -10
+.2byte   -7,   -9, 	  -4,  -13, 	  -3,   -7, 	  -3,  -10
+.2byte  -13,  -18, 	  -9,  -22, 	  -9,  -17, 	  -9,  -19
+.2byte   -7,   -9, 	  -3,  -13, 	  -3,   -8, 	  -3,  -10
+.2byte   -4,  -10, 	  -6,   -9, 	   2,  -11, 	  -2,  -11
+.2byte   -5,   -9, 	  -6,  -11, 	   2,   -8, 	  -3,  -10
+.2byte   -8,  -18, 	  -9,  -20, 	  -1,  -18, 	  -5,  -19
+.2byte   -5,   -8, 	  -7,  -11, 	   2,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -5,  -12, 	   5,   -9, 	   0,  -11
+.2byte   -5,   -9, 	  -6,  -11, 	   2,   -8, 	  -3,  -10
+.2byte   -7,   -9, 	  -4,  -13, 	  -3,   -7, 	  -3,  -10
+.2byte   -3,  -10, 	   2,  -12, 	  -6,   -8, 	  -1,  -11
+.2byte   -1,  -10, 	   4,  -12, 	  -6,  -11, 	  -1,  -11
+.2byte    1,  -10, 	  -4,  -12, 	   4,   -8, 	  -1,  -11
+.2byte    5,   -9, 	   2,  -13, 	   1,   -7, 	   1,  -10
+.2byte    3,   -9, 	   4,  -11, 	  -4,   -8, 	   1,  -10
+.2byte   -1,  -19, 	  -6,  -20, 	   4,  -20, 	  -1,  -20
+.2byte    5,  -18, 	   6,  -20, 	  -2,  -18, 	   2,  -19
+.2byte    9,  -18, 	   5,  -22, 	   5,  -17, 	   5,  -19
+.2byte    2,  -18, 	  -1,  -20, 	   6,  -17, 	   0,  -19
+.2byte   -1,  -19, 	   4,  -18, 	  -6,  -18, 	  -1,  -18
+.2byte   -3,  -18, 	   0,  -20, 	  -7,  -17, 	  -1,  -19
+.2byte  -10,  -18, 	  -6,  -22, 	  -6,  -17, 	  -6,  -19
+.2byte   -6,  -18, 	  -7,  -20, 	   1,  -18, 	  -3,  -19
+.2byte   -1,   -2, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,    0, 	  -6,   -2, 	   4,   -2, 	  -1,   -4
+.2byte    3,   -3, 	   5,   -5, 	  -4,   -3, 	   0,   -5
+.2byte    3,   -7, 	   5,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    3,   -1, 	   5,   -3, 	  -3,   -1, 	   0,   -4
+.2byte    4,   -4, 	   1,   -7, 	   1,   -2, 	   0,   -5
+.2byte    5,   -7, 	   0,   -8, 	   0,   -4, 	   0,   -7
+.2byte    4,   -2, 	   1,   -6, 	   1,   -2, 	   0,   -5
+.2byte    2,   -5, 	  -5,   -7, 	   4,   -4, 	   0,   -6
+.2byte    2,   -7, 	  -5,   -9, 	   4,   -6, 	  -1,   -8
+.2byte    2,   -3, 	  -2,   -7, 	   3,   -3, 	   0,   -5
+.2byte    0,   -7, 	   5,   -6, 	  -5,   -6, 	   0,   -6
+.2byte    0,  -10, 	   5,   -8, 	  -5,   -8, 	   0,   -9
+.2byte    0,   -2, 	   5,   -4, 	  -5,   -4, 	   0,   -4
+.2byte   -3,   -5, 	   4,   -7, 	  -5,   -4, 	  -1,   -6
+.2byte   -3,   -7, 	   4,   -9, 	  -5,   -6, 	   0,   -8
+.2byte   -3,   -3, 	   1,   -7, 	  -4,   -3, 	  -1,   -5
+.2byte   -5,   -4, 	  -2,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte   -6,   -7, 	  -1,   -8, 	  -1,   -4, 	  -1,   -7
+.2byte   -5,   -2, 	  -2,   -6, 	  -2,   -2, 	  -1,   -5
+.2byte   -4,   -3, 	  -6,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -4,   -7, 	  -6,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -4,   -1, 	  -6,   -3, 	   2,   -1, 	  -1,   -4
+.2byte   -1,   -7, 	  -6,   -9, 	   4,   -9, 	  -1,  -10
+.2byte   -5,   -8, 	  -7,  -11, 	   2,   -8, 	  -1,  -10
+.2byte   -7,   -9, 	  -3,  -13, 	  -3,   -8, 	  -3,  -10
+.2byte   -4,   -9, 	   1,  -11, 	  -6,   -9, 	  -1,  -10
+.2byte   -1,  -10, 	   4,  -10, 	  -6,  -10, 	  -1,  -11
+.2byte    2,   -9, 	  -3,  -11, 	   4,   -9, 	  -1,  -10
+.2byte    5,   -9, 	   1,  -13, 	   1,   -8, 	   1,  -10
+.2byte    3,   -8, 	   5,  -11, 	  -4,   -8, 	  -1,  -10
+.2byte   -1,   -2, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -4,   -3, 	  -6,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -5,   -4, 	  -2,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte   -3,   -5, 	   4,   -7, 	  -5,   -4, 	  -1,   -6
+.2byte    0,   -7, 	   5,   -6, 	  -5,   -6, 	   0,   -6
+.2byte    2,   -5, 	  -5,   -7, 	   4,   -4, 	   0,   -6
+.2byte    4,   -4, 	   1,   -7, 	   1,   -2, 	   0,   -5
+.2byte    3,   -3, 	   5,   -5, 	  -4,   -3, 	   0,   -5
+sAzurillAnimTable1:
+.4byte sAzurillAnims_1_1
+.4byte sAzurillAnims_1_2
+.4byte sAzurillAnims_1_3
+.4byte sAzurillAnims_1_4
+.4byte sAzurillAnims_1_5
+.4byte sAzurillAnims_1_6
+.4byte sAzurillAnims_1_7
+.4byte sAzurillAnims_1_8
+sAzurillAnimTable2:
+.4byte sAzurillAnims_2_1
+.4byte sAzurillAnims_2_2
+.4byte sAzurillAnims_2_3
+.4byte sAzurillAnims_2_4
+.4byte sAzurillAnims_2_5
+.4byte sAzurillAnims_2_6
+.4byte sAzurillAnims_2_7
+.4byte sAzurillAnims_2_8
+sAzurillAnimTable3:
+.4byte sAzurillAnims_3_1
+.4byte sAzurillAnims_3_2
+.4byte sAzurillAnims_3_3
+.4byte sAzurillAnims_3_4
+.4byte sAzurillAnims_3_5
+.4byte sAzurillAnims_3_6
+.4byte sAzurillAnims_3_7
+.4byte sAzurillAnims_3_8
+sAzurillAnimTable4:
+.4byte sAzurillAnims_4_1
+.4byte sAzurillAnims_4_2
+.4byte sAzurillAnims_4_3
+.4byte sAzurillAnims_4_4
+.4byte sAzurillAnims_4_5
+.4byte sAzurillAnims_4_6
+.4byte sAzurillAnims_4_7
+.4byte sAzurillAnims_4_8
+sAzurillAnimTable5:
+.4byte sAzurillAnims_5_1
+.4byte sAzurillAnims_5_2
+.4byte sAzurillAnims_5_3
+.4byte sAzurillAnims_5_4
+.4byte sAzurillAnims_5_5
+.4byte sAzurillAnims_5_6
+.4byte sAzurillAnims_5_7
+.4byte sAzurillAnims_5_8
+sAzurillAnimTable6:
+.4byte sAzurillAnims_6_1
+.4byte sAzurillAnims_6_1
+.4byte sAzurillAnims_6_1
+.4byte sAzurillAnims_6_1
+.4byte sAzurillAnims_6_1
+.4byte sAzurillAnims_6_1
+.4byte sAzurillAnims_6_1
+.4byte sAzurillAnims_6_1
+sAzurillAnimTable7:
+.4byte sAzurillAnims_7_1
+.4byte sAzurillAnims_7_2
+.4byte sAzurillAnims_7_3
+.4byte sAzurillAnims_7_4
+.4byte sAzurillAnims_7_5
+.4byte sAzurillAnims_7_6
+.4byte sAzurillAnims_7_7
+.4byte sAzurillAnims_7_8
+sAzurillAnimTable8:
+.4byte sAzurillAnims_8_1
+.4byte sAzurillAnims_8_2
+.4byte sAzurillAnims_8_3
+.4byte sAzurillAnims_8_4
+.4byte sAzurillAnims_8_5
+.4byte sAzurillAnims_8_6
+.4byte sAzurillAnims_8_7
+.4byte sAzurillAnims_8_8
+sAzurillAnimTable9:
+.4byte sAzurillAnims_9_1
+.4byte sAzurillAnims_9_2
+.4byte sAzurillAnims_9_3
+.4byte sAzurillAnims_9_4
+.4byte sAzurillAnims_9_5
+.4byte sAzurillAnims_9_6
+.4byte sAzurillAnims_9_7
+.4byte sAzurillAnims_9_8
+sAzurillAnimTable10:
+.4byte sAzurillAnims_10_1
+.4byte sAzurillAnims_10_2
+.4byte sAzurillAnims_10_3
+.4byte sAzurillAnims_10_4
+.4byte sAzurillAnims_10_5
+.4byte sAzurillAnims_10_6
+.4byte sAzurillAnims_10_7
+.4byte sAzurillAnims_10_8
+sAzurillAnimTable11:
+.4byte sAzurillAnims_11_1
+.4byte sAzurillAnims_11_2
+.4byte sAzurillAnims_11_3
+.4byte sAzurillAnims_11_4
+.4byte sAzurillAnims_11_5
+.4byte sAzurillAnims_11_6
+.4byte sAzurillAnims_11_7
+.4byte sAzurillAnims_11_8
+sAzurillAnimTable12:
+.4byte sAzurillAnims_12_1
+.4byte sAzurillAnims_12_2
+.4byte sAzurillAnims_12_3
+.4byte sAzurillAnims_12_4
+.4byte sAzurillAnims_12_5
+.4byte sAzurillAnims_12_6
+.4byte sAzurillAnims_12_7
+.4byte sAzurillAnims_12_8
+sAzurillAnimTable13:
+.4byte sAzurillAnims_13_1
+.4byte sAzurillAnims_13_2
+.4byte sAzurillAnims_13_3
+.4byte sAzurillAnims_13_4
+.4byte sAzurillAnims_13_5
+.4byte sAzurillAnims_13_6
+.4byte sAzurillAnims_13_7
+.4byte sAzurillAnims_13_8
+sAxAnimationsAzurill:
+.4byte sAzurillAnimTable1
+.4byte sAzurillAnimTable2
+.4byte sAzurillAnimTable3
+.4byte sAzurillAnimTable4
+.4byte sAzurillAnimTable5
+.4byte sAzurillAnimTable6
+.4byte sAzurillAnimTable7
+.4byte sAzurillAnimTable8
+.4byte sAzurillAnimTable9
+.4byte sAzurillAnimTable10
+.4byte sAzurillAnimTable11
+.4byte sAzurillAnimTable12
+.4byte sAzurillAnimTable13
+sAxSpritesAzurill:
+.4byte sAzurillSprites1
+.4byte sAzurillSprites2
+.4byte sAzurillSprites3
+.4byte sAzurillSprites4
+.4byte sAzurillSprites5
+.4byte sAzurillSprites6
+.4byte sAzurillSprites7
+.4byte sAzurillSprites8
+.4byte sAzurillSprites9
+.4byte sAzurillSprites10
+.4byte sAzurillSprites11
+.4byte sAzurillSprites12
+.4byte sAzurillSprites13
+.4byte sAzurillSprites14
+.4byte sAzurillSprites15
+.4byte sAzurillSprites16
+.4byte sAzurillSprites17
+.4byte sAzurillSprites18
+.4byte sAzurillSprites19
+.4byte sAzurillSprites20
+.4byte sAzurillSprites21
+.4byte sAzurillSprites22
+.4byte sAzurillSprites23
+.4byte sAzurillSprites24
+.4byte sAzurillSprites25
+.4byte sAzurillSprites26
+.4byte sAzurillSprites27
+.4byte sAzurillSprites28
+.4byte sAzurillSprites29
+.4byte sAzurillSprites30
+.4byte sAzurillSprites31
+.4byte sAzurillSprites32
+.4byte sAzurillSprites33
+.4byte sAzurillSprites34
+.4byte sAzurillSprites35
+.4byte sAzurillSprites36
+.4byte sAzurillSprites37
+.4byte sAzurillSprites38
+.4byte sAzurillSprites39
+.4byte sAzurillSprites40
+.4byte sAzurillSprites41
+.4byte sAzurillSprites42
+.4byte sAzurillSprites43
+.4byte sAzurillSprites44
+.4byte sAzurillSprites45
+sAxMainAzurill:
+ax_main sAxPosesAzurill, sAxAnimationsAzurill, 13, sAxSpritesAzurill, sAxPositionsAzurill

--- a/data/ax/bagon.inc
+++ b/data/ax/bagon.inc
@@ -1,0 +1,2910 @@
+.global gAxBagon
+gAxBagon:
+ax_siro sAxMainBagon
+sBagonPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose4:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose5:
+ax_pose 4, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose6:
+ax_pose 5, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose7:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose8:
+ax_pose 7, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose9:
+ax_pose 8, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose10:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose11:
+ax_pose 10, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose12:
+ax_pose 11, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose16:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose17:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose18:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose19:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose22:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose23:
+ax_pose 4, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose24:
+ax_pose 5, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose28:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose29:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose30:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose31:
+ax_pose 4, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose32:
+ax_pose 5, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose33:
+ax_pose 17, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose34:
+ax_pose 18, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose35:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose36:
+ax_pose 7, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose37:
+ax_pose 8, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose38:
+ax_pose 19, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose39:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose40:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose41:
+ax_pose 10, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose42:
+ax_pose 11, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose43:
+ax_pose 21, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sBagonPose44:
+ax_pose 22, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose45:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose46:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose47:
+ax_pose 14, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose48:
+ax_pose 23, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose49:
+ax_pose 24, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose50:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose51:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose52:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose53:
+ax_pose 21, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sBagonPose54:
+ax_pose 22, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose55:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose56:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose57:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose58:
+ax_pose 19, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose59:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose60:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose61:
+ax_pose 4, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose62:
+ax_pose 5, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose63:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose64:
+ax_pose 18, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose65:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose66:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose67:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose68:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose69:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose70:
+ax_pose 25, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose71:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose72:
+ax_pose 4, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose73:
+ax_pose 5, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose74:
+ax_pose 17, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose75:
+ax_pose 18, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose76:
+ax_pose 26, 0x01e9, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose77:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose78:
+ax_pose 7, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose79:
+ax_pose 8, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose80:
+ax_pose 19, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose81:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose82:
+ax_pose 27, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose83:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose84:
+ax_pose 10, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose85:
+ax_pose 11, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose86:
+ax_pose 21, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sBagonPose87:
+ax_pose 22, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose88:
+ax_pose 28, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose89:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose90:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose91:
+ax_pose 14, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose92:
+ax_pose 23, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose93:
+ax_pose 24, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose94:
+ax_pose 29, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose95:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose96:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose97:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose98:
+ax_pose 21, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sBagonPose99:
+ax_pose 22, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose100:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose101:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose102:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose103:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose104:
+ax_pose 19, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose105:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose106:
+ax_pose 27, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose107:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose108:
+ax_pose 4, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose109:
+ax_pose 5, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose110:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose111:
+ax_pose 18, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose112:
+ax_pose 26, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose113:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose114:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose115:
+ax_pose 30, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose116:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose117:
+ax_pose 18, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose118:
+ax_pose 31, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sBagonPose119:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose120:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose121:
+ax_pose 32, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose122:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose123:
+ax_pose 22, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose124:
+ax_pose 33, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose125:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose126:
+ax_pose 24, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose127:
+ax_pose 34, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose128:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose129:
+ax_pose 22, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose130:
+ax_pose 33, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose131:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose132:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose133:
+ax_pose 32, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose134:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose135:
+ax_pose 18, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose136:
+ax_pose 31, 0x01ea, 0x80f5, 0x5c00
+ax_pose_terminator
+sBagonPose137:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose138:
+ax_pose 25, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose139:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose140:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose141:
+ax_pose 26, 0x01e9, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose142:
+ax_pose 18, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose143:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose144:
+ax_pose 27, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose145:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose146:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose147:
+ax_pose 28, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose148:
+ax_pose 22, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose149:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose150:
+ax_pose 29, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose151:
+ax_pose 24, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose152:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose153:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose154:
+ax_pose 22, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose155:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose156:
+ax_pose 27, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose157:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose158:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose159:
+ax_pose 26, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose160:
+ax_pose 18, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose161:
+ax_pose 35, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sBagonPose162:
+ax_pose 36, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sBagonPose163:
+ax_pose 37, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose164:
+ax_pose 38, 0x01e2, 0x90ea, 0x5c00
+ax_pose_terminator
+sBagonPose165:
+ax_pose 39, 0x01e5, 0x90eb, 0x5c00
+ax_pose_terminator
+sBagonPose166:
+ax_pose 40, 0x01e6, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose167:
+ax_pose 41, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sBagonPose168:
+ax_pose 40, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sBagonPose169:
+ax_pose 39, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sBagonPose170:
+ax_pose 38, 0x01e2, 0x80f6, 0x5c00
+ax_pose_terminator
+sBagonPose171:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose172:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose173:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose174:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose175:
+ax_pose 4, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose176:
+ax_pose 5, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose177:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose178:
+ax_pose 7, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose179:
+ax_pose 8, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose180:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose181:
+ax_pose 10, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose182:
+ax_pose 11, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose183:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose184:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose185:
+ax_pose 14, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose186:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose187:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose188:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose189:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose190:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose191:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose192:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose193:
+ax_pose 4, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose194:
+ax_pose 5, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose195:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sBagonPose196:
+ax_pose 3, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sBagonPose197:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose198:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose199:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose200:
+ax_pose 9, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose201:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose202:
+ax_pose 3, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sBagonPose203:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose204:
+ax_pose 18, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose205:
+ax_pose 20, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose206:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose207:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose208:
+ax_pose 22, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose209:
+ax_pose 20, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose210:
+ax_pose 18, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose211:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose212:
+ax_pose 25, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose213:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose214:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sBagonPose215:
+ax_pose 26, 0x01e9, 0x90e9, 0x5c00
+ax_pose_terminator
+sBagonPose216:
+ax_pose 17, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose217:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose218:
+ax_pose 27, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose219:
+ax_pose 19, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sBagonPose220:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose221:
+ax_pose 28, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose222:
+ax_pose 21, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose223:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose224:
+ax_pose 29, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose225:
+ax_pose 23, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose226:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose227:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose228:
+ax_pose 21, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose229:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose230:
+ax_pose 27, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose231:
+ax_pose 19, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sBagonPose232:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose233:
+ax_pose 26, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose234:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose235:
+ax_pose 30, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose236:
+ax_pose 31, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sBagonPose237:
+ax_pose 32, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose238:
+ax_pose 33, 0x01ea, 0x80f5, 0x5c00
+ax_pose_terminator
+sBagonPose239:
+ax_pose 34, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose240:
+ax_pose 33, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sBagonPose241:
+ax_pose 32, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose242:
+ax_pose 31, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sBagonPose243:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose244:
+ax_pose 3, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sBagonPose245:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBagonPose246:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose247:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sBagonPose248:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sBagonPose249:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sBagonPose250:
+ax_pose 3, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+.align 2
+sBagonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_2_1:
+ax_anim 2, 0, 28, 0, -1, 0, -1,
+ax_anim 6, 0, 28, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBagonAnims_2_2:
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 6, 0, 33, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 6, 7, 6, 7,
+ax_anim 1, 0, 31, 13, 15, 13, 15,
+ax_anim 2, 0, 32, 17, 20, 17, 20,
+ax_anim 2, 1, 32, 18, 20, 18, 20,
+ax_anim 2, 0, 32, 17, 20, 17, 20,
+ax_anim 2, 0, 32, 18, 20, 18, 20,
+ax_anim 2, 0, 29, 8, 9, 8, 9,
+ax_anim_terminator
+sBagonAnims_2_3:
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 6, 0, 38, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, -1, 0, 0,
+ax_anim 1, 2, 35, 6, 0, 6, 0,
+ax_anim 1, 0, 36, 13, 0, 13, 0,
+ax_anim 2, 0, 37, 17, 1, 17, 1,
+ax_anim 2, 1, 37, 17, 0, 17, 0,
+ax_anim 2, 0, 37, 17, 1, 17, 1,
+ax_anim 2, 0, 37, 17, 0, 17, 0,
+ax_anim 2, 0, 34, 8, 0, 8, 0,
+ax_anim_terminator
+sBagonAnims_2_4:
+ax_anim 2, 0, 43, -1, 2, -1, 2,
+ax_anim 6, 0, 43, -1, 2, -1, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 6, -7, 6, -7,
+ax_anim 1, 0, 41, 10, -15, 11, -15,
+ax_anim 2, 0, 42, 14, -20, 15, -20,
+ax_anim 2, 1, 42, 16, -20, 16, -20,
+ax_anim 2, 0, 42, 15, -20, 15, -20,
+ax_anim 2, 0, 42, 16, -20, 16, -20,
+ax_anim 2, 0, 39, 8, -9, 8, -9,
+ax_anim_terminator
+sBagonAnims_2_5:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 6, 0, 48, 0, 2, 0, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, -4,
+ax_anim 1, 0, 46, 0, -10, 0, -10,
+ax_anim 2, 0, 47, 0, -21, 0, -21,
+ax_anim 2, 1, 47, 1, -21, 1, -21,
+ax_anim 2, 0, 47, 0, -21, 0, -21,
+ax_anim 2, 0, 47, 1, -21, 1, -21,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sBagonAnims_2_6:
+ax_anim 2, 0, 53, 1, 2, 1, 2,
+ax_anim 6, 0, 53, 1, 2, 1, 2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -6, -7, -6, -7,
+ax_anim 1, 0, 51, -10, -15, -11, -15,
+ax_anim 2, 0, 52, -14, -20, -15, -20,
+ax_anim 2, 1, 52, -16, -20, -16, -20,
+ax_anim 2, 0, 52, -15, -20, -15, -20,
+ax_anim 2, 0, 52, -16, -20, -16, -20,
+ax_anim 2, 0, 49, -8, -9, -8, -9,
+ax_anim_terminator
+sBagonAnims_2_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 6, 0, 58, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, -1, 0, 0,
+ax_anim 1, 2, 55, -6, 0, -6, 0,
+ax_anim 1, 0, 56, -13, 0, -13, 0,
+ax_anim 2, 0, 57, -17, 1, -17, 1,
+ax_anim 2, 1, 57, -17, 0, -17, 0,
+ax_anim 2, 0, 57, -17, 1, -17, 1,
+ax_anim 2, 0, 57, -17, 0, -17, 0,
+ax_anim 2, 0, 54, -8, 0, -8, 0,
+ax_anim_terminator
+sBagonAnims_2_8:
+ax_anim 2, 0, 63, 1, -1, 1, -1,
+ax_anim 6, 0, 63, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -6, 7, -6, 7,
+ax_anim 1, 0, 61, -13, 15, -13, 15,
+ax_anim 2, 0, 62, -18, 20, -18, 20,
+ax_anim 2, 1, 62, -19, 20, -19, 20,
+ax_anim 2, 0, 62, -18, 20, -18, 20,
+ax_anim 2, 0, 62, -19, 20, -19, 20,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim_terminator
+.align 2
+sBagonAnims_3_1:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 6, 0, 69, 0, -1, 0, -1,
+ax_anim 1, 0, 69, 0, 3, 0, 1,
+ax_anim 1, 2, 69, 0, 7, 0, 0,
+ax_anim 1, 0, 64, 0, 14, 0, 4,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 1, 67, 1, 18, 1, 18,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 0, 67, 1, 18, 1, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sBagonAnims_3_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 6, 0, 75, -1, -1, -1, -1,
+ax_anim 1, 0, 75, 3, 3, 3, 3,
+ax_anim 1, 2, 75, 8, 8, 8, 8,
+ax_anim 1, 0, 70, 14, 14, 14, 14,
+ax_anim 2, 0, 73, 19, 20, 19, 20,
+ax_anim 2, 1, 73, 20, 20, 20, 20,
+ax_anim 2, 0, 73, 19, 20, 19, 20,
+ax_anim 2, 0, 73, 20, 20, 20, 20,
+ax_anim 2, 0, 70, 7, 8, 7, 8,
+ax_anim_terminator
+sBagonAnims_3_3:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 6, 0, 81, -1, 0, -1, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 2, 81, 8, 0, 8, 0,
+ax_anim 1, 0, 76, 14, 0, 14, 0,
+ax_anim 2, 0, 79, 17, 0, 17, 0,
+ax_anim 2, 1, 79, 17, 1, 17, 1,
+ax_anim 2, 0, 79, 17, 0, 17, 0,
+ax_anim 2, 0, 79, 17, 1, 17, 1,
+ax_anim 2, 0, 76, 5, 0, 5, 0,
+ax_anim_terminator
+sBagonAnims_3_4:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 6, 0, 87, -1, 1, -1, 1,
+ax_anim 1, 0, 87, 1, -3, 1, -3,
+ax_anim 1, 2, 87, 6, -8, 6, -8,
+ax_anim 1, 0, 82, 11, -14, 11, -14,
+ax_anim 2, 0, 85, 16, -20, 16, -20,
+ax_anim 2, 1, 85, 17, -19, 17, -19,
+ax_anim 2, 0, 85, 16, -20, 16, -20,
+ax_anim 2, 0, 85, 17, -19, 17, -19,
+ax_anim 2, 0, 82, 6, -7, 6, -7,
+ax_anim_terminator
+sBagonAnims_3_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 1, 0, 1,
+ax_anim 1, 0, 93, 0, -3, 0, -3,
+ax_anim 1, 2, 93, 0, -7, 0, -7,
+ax_anim 1, 0, 88, 0, -14, 0, -14,
+ax_anim 2, 0, 91, 0, -19, 0, -19,
+ax_anim 2, 1, 91, -1, -19, -1, -19,
+ax_anim 2, 0, 91, 0, -19, 0, -19,
+ax_anim 2, 0, 91, -1, -19, -1, -19,
+ax_anim 2, 0, 88, 0, -5, 0, -5,
+ax_anim_terminator
+sBagonAnims_3_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 1, 1, 1, 1,
+ax_anim 1, 0, 99, -1, -3, -1, -3,
+ax_anim 1, 2, 99, -6, -8, -6, -8,
+ax_anim 1, 0, 94, -11, -14, -11, -14,
+ax_anim 2, 0, 97, -16, -20, -16, -20,
+ax_anim 2, 1, 97, -17, -19, -17, -19,
+ax_anim 2, 0, 97, -16, -20, -16, -20,
+ax_anim 2, 0, 97, -17, -19, -17, -19,
+ax_anim 2, 0, 94, -6, -7, -6, -7,
+ax_anim_terminator
+sBagonAnims_3_7:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 1, 0, 1, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 2, 105, -8, 0, -8, 0,
+ax_anim 1, 0, 100, -14, 0, -14, 0,
+ax_anim 2, 0, 103, -17, 0, -17, 0,
+ax_anim 2, 1, 103, -17, 1, -17, 1,
+ax_anim 2, 0, 103, -17, 0, -17, 0,
+ax_anim 2, 0, 103, -17, 1, -17, 1,
+ax_anim 2, 0, 100, -5, 0, -5, 0,
+ax_anim_terminator
+sBagonAnims_3_8:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 1, -1, 1, -1,
+ax_anim 1, 0, 111, -3, 3, -3, 3,
+ax_anim 1, 2, 111, -8, 8, -8, 8,
+ax_anim 1, 0, 106, -14, 14, -14, 14,
+ax_anim 2, 0, 109, -19, 20, -19, 20,
+ax_anim 2, 1, 109, -20, 20, -20, 20,
+ax_anim 2, 0, 109, -19, 20, -19, 20,
+ax_anim 2, 0, 109, -20, 20, -20, 20,
+ax_anim 2, 0, 106, -7, 8, -7, 8,
+ax_anim_terminator
+.align 2
+sBagonAnims_4_1:
+ax_anim 2, 0, 113, 0, -1, 0, -2,
+ax_anim 6, 2, 113, 0, -2, 0, -3,
+ax_anim 2, 0, 113, 0, 0, 0, -1,
+ax_anim 2, 0, 114, 0, 4, 0, 4,
+ax_anim 2, 1, 114, 1, 4, 1, 4,
+ax_anim 2, 0, 114, 0, 4, 0, 4,
+ax_anim 2, 0, 114, 1, 4, 1, 4,
+ax_anim 2, 0, 114, 0, 4, 0, 4,
+ax_anim 2, 0, 114, 1, 4, 1, 4,
+ax_anim 2, 0, 114, 0, 4, 0, 4,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim_terminator
+sBagonAnims_4_2:
+ax_anim 2, 0, 116, -1, -1, -1, -1,
+ax_anim 6, 2, 116, -2, -2, -2, -2,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 1, 117, 3, 1, 3, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 3, 1, 3, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 3, 1, 3, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim_terminator
+sBagonAnims_4_3:
+ax_anim 2, 0, 119, -2, 0, -2, 0,
+ax_anim 6, 2, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 1, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim_terminator
+sBagonAnims_4_4:
+ax_anim 2, 0, 122, -2, 2, -2, 2,
+ax_anim 6, 2, 122, -3, 3, -3, 3,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 1, 123, 3, -1, 3, -1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -1, 3, -1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -1, 3, -1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim_terminator
+sBagonAnims_4_5:
+ax_anim 2, 0, 125, 0, 2, 0, 2,
+ax_anim 6, 2, 125, 0, 3, 0, 3,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 1, 126, 1, -3, 1, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 126, 1, -3, 1, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 126, 1, -3, 1, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sBagonAnims_4_6:
+ax_anim 2, 0, 128, 2, 2, 2, 2,
+ax_anim 6, 2, 128, 3, 3, 3, 3,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 2, 1, 129, -3, -1, -3, -1,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 2, 0, 129, -3, -1, -3, -1,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 2, 0, 129, -3, -1, -3, -1,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+sBagonAnims_4_7:
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 6, 2, 131, 3, 0, 3, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 1, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim_terminator
+sBagonAnims_4_8:
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim 6, 2, 134, 2, -2, 2, -2,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 1, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 133, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sBagonAnims_5_1:
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim 6, 2, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_5_2:
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 6, 2, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_5_3:
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 6, 2, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_5_4:
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim 6, 2, 146, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, 1, 1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, 1, 1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, 1, 1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_5_5:
+ax_anim 2, 0, 149, 0, -1, 0, 0,
+ax_anim 6, 2, 149, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_5_6:
+ax_anim 2, 0, 152, 0, -1, 0, 0,
+ax_anim 6, 2, 152, 0, -2, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 1, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 1, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 1, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_5_7:
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim 6, 2, 155, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -1, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -1, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -1, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_5_8:
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 6, 2, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sBagonAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sBagonAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sBagonAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sBagonAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sBagonAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sBagonAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sBagonAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBagonAnims_8_1:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim 14, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_8_2:
+ax_anim 40, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 14, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_8_3:
+ax_anim 40, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 14, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_8_4:
+ax_anim 40, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 14, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_8_5:
+ax_anim 40, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 14, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_8_6:
+ax_anim 40, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim 14, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_8_7:
+ax_anim 40, 0, 188, 0, 0, 0, 0,
+ax_anim 10, 0, 190, 0, 0, 0, 0,
+ax_anim 14, 0, 188, 0, 0, 0, 0,
+ax_anim 10, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_8_8:
+ax_anim 40, 0, 191, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim 14, 0, 191, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 9, 11, 9, 11,
+ax_anim 2, 0, 197, 7, 17, 7, 17,
+ax_anim 3, 0, 198, 0, 20, 0, 20,
+ax_anim 2, 3, 199, -7, 17, -7, 17,
+ax_anim 2, 0, 200, -9, 11, -9, 11,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 21, 12, 21, 12,
+ax_anim 3, 0, 197, 20, 19, 20, 19,
+ax_anim 2, 3, 198, 11, 20, 11, 20,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 17, -4, 17, -4,
+ax_anim 3, 0, 196, 21, -2, 21, -2,
+ax_anim 2, 3, 197, 18, 4, 18, 4,
+ax_anim 2, 0, 198, 12, 5, 12, 5,
+ax_anim 1, 0, 199, 4, 4, 4, 4,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 14, -21, 14, -21,
+ax_anim 3, 0, 195, 21, -19, 21, -19,
+ax_anim 2, 3, 196, 22, -13, 22, -13,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 1, 0, 198, 9, 0, 9, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -17, -7, -17,
+ax_anim 3, 0, 194, 0, -19, 0, -19,
+ax_anim 2, 3, 195, 7, -17, 7, -17,
+ax_anim 2, 0, 196, 9, -10, 9, -10,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -14, -21, -14, -21,
+ax_anim 3, 0, 201, -21, -19, -21, -19,
+ax_anim 2, 3, 200, -22, -13, -22, -13,
+ax_anim 2, 0, 199, -17, -4, -17, -4,
+ax_anim 1, 0, 198, -9, 0, -9, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -17, -4, -17, -4,
+ax_anim 3, 0, 200, -21, -2, -21, -2,
+ax_anim 2, 3, 199, -18, 4, -18, 4,
+ax_anim 2, 0, 198, -12, 5, -12, 5,
+ax_anim 1, 0, 197, -4, 4, -4, 4,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -21, 12, -21, 12,
+ax_anim 3, 0, 199, -20, 19, -20, 19,
+ax_anim 2, 3, 198, -11, 20, -11, 20,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 1, 0, 0,
+ax_anim_terminator
+sBagonAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 1, 0, 0,
+ax_anim_terminator
+sBagonAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 1, 0, 0,
+ax_anim_terminator
+sBagonAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBagonAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sBagonGfx1:
+.incbin "baserom.gba", 0x1547F34, 0x200
+sBagonSprites1:
+ax_sprite sBagonGfx1, 0x200
+ax_sprite_terminator
+sBagonGfx2:
+.incbin "baserom.gba", 0x1548144, 0x200
+sBagonSprites2:
+ax_sprite sBagonGfx2, 0x200
+ax_sprite_terminator
+sBagonGfx3:
+.incbin "baserom.gba", 0x1548354, 0x200
+sBagonSprites3:
+ax_sprite sBagonGfx3, 0x200
+ax_sprite_terminator
+sBagonGfx4:
+.incbin "baserom.gba", 0x1548564, 0x100
+sBagonSprites4:
+ax_sprite sBagonGfx4, 0x100
+ax_sprite_terminator
+sBagonGfx5:
+.incbin "baserom.gba", 0x1548674, 0x100
+sBagonSprites5:
+ax_sprite sBagonGfx5, 0x100
+ax_sprite_terminator
+sBagonGfx6:
+.incbin "baserom.gba", 0x1548784, 0x100
+sBagonSprites6:
+ax_sprite sBagonGfx6, 0x100
+ax_sprite_terminator
+sBagonGfx7:
+.incbin "baserom.gba", 0x1548894, 0x200
+sBagonSprites7:
+ax_sprite sBagonGfx7, 0x200
+ax_sprite_terminator
+sBagonGfx8:
+.incbin "baserom.gba", 0x1548AA4, 0x200
+sBagonSprites8:
+ax_sprite sBagonGfx8, 0x200
+ax_sprite_terminator
+sBagonGfx9:
+.incbin "baserom.gba", 0x1548CB4, 0x200
+sBagonSprites9:
+ax_sprite sBagonGfx9, 0x200
+ax_sprite_terminator
+sBagonGfx10:
+.incbin "baserom.gba", 0x1548EC4, 0x200
+sBagonSprites10:
+ax_sprite sBagonGfx10, 0x200
+ax_sprite_terminator
+sBagonGfx11:
+.incbin "baserom.gba", 0x15490D4, 0x200
+sBagonSprites11:
+ax_sprite sBagonGfx11, 0x200
+ax_sprite_terminator
+sBagonGfx12:
+.incbin "baserom.gba", 0x15492E4, 0x200
+sBagonSprites12:
+ax_sprite sBagonGfx12, 0x200
+ax_sprite_terminator
+sBagonGfx13:
+.incbin "baserom.gba", 0x15494F4, 0x200
+sBagonSprites13:
+ax_sprite sBagonGfx13, 0x200
+ax_sprite_terminator
+sBagonGfx14:
+.incbin "baserom.gba", 0x1549704, 0x200
+sBagonSprites14:
+ax_sprite sBagonGfx14, 0x200
+ax_sprite_terminator
+sBagonGfx15:
+.incbin "baserom.gba", 0x1549914, 0x200
+sBagonSprites15:
+ax_sprite sBagonGfx15, 0x200
+ax_sprite_terminator
+sBagonGfx16:
+.incbin "baserom.gba", 0x1549B24, 0x20
+sBagonGfx16_1:
+.incbin "baserom.gba", 0x1549B44, 0x60
+sBagonGfx16_2:
+.incbin "baserom.gba", 0x1549BA4, 0x60
+sBagonGfx16_3:
+.incbin "baserom.gba", 0x1549C04, 0x40
+sBagonSprites16:
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx16_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBagonGfx17:
+.incbin "baserom.gba", 0x1549C94, 0x60
+sBagonGfx17_1:
+.incbin "baserom.gba", 0x1549CF4, 0x60
+sBagonGfx17_2:
+.incbin "baserom.gba", 0x1549D54, 0x60
+sBagonSprites17:
+ax_sprite sBagonGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx18:
+.incbin "baserom.gba", 0x1549DEC, 0x20
+sBagonGfx18_1:
+.incbin "baserom.gba", 0x1549E0C, 0x60
+sBagonGfx18_2:
+.incbin "baserom.gba", 0x1549E6C, 0x60
+sBagonSprites18:
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx19:
+.incbin "baserom.gba", 0x1549F0C, 0x60
+sBagonGfx19_1:
+.incbin "baserom.gba", 0x1549F6C, 0x60
+sBagonGfx19_2:
+.incbin "baserom.gba", 0x1549FCC, 0x40
+sBagonSprites19:
+ax_sprite sBagonGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx19_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sBagonGfx20:
+.incbin "baserom.gba", 0x154A044, 0x60
+sBagonGfx20_1:
+.incbin "baserom.gba", 0x154A0A4, 0x60
+sBagonGfx20_2:
+.incbin "baserom.gba", 0x154A104, 0x60
+sBagonSprites20:
+ax_sprite sBagonGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx21:
+.incbin "baserom.gba", 0x154A19C, 0x60
+sBagonGfx21_1:
+.incbin "baserom.gba", 0x154A1FC, 0x60
+sBagonGfx21_2:
+.incbin "baserom.gba", 0x154A25C, 0x40
+sBagonGfx21_3:
+.incbin "baserom.gba", 0x154A29C, 0x40
+sBagonSprites21:
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx21_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBagonGfx22:
+.incbin "baserom.gba", 0x154A32C, 0x40
+sBagonGfx22_1:
+.incbin "baserom.gba", 0x154A36C, 0x60
+sBagonGfx22_2:
+.incbin "baserom.gba", 0x154A3CC, 0x60
+sBagonSprites22:
+ax_sprite sBagonGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx23:
+.incbin "baserom.gba", 0x154A464, 0x60
+sBagonGfx23_1:
+.incbin "baserom.gba", 0x154A4C4, 0x60
+sBagonGfx23_2:
+.incbin "baserom.gba", 0x154A524, 0x40
+sBagonGfx23_3:
+.incbin "baserom.gba", 0x154A564, 0x20
+sBagonSprites23:
+ax_sprite sBagonGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx23_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBagonGfx24:
+.incbin "baserom.gba", 0x154A5CC, 0x60
+sBagonGfx24_1:
+.incbin "baserom.gba", 0x154A62C, 0x60
+sBagonGfx24_2:
+.incbin "baserom.gba", 0x154A68C, 0x60
+sBagonGfx24_3:
+.incbin "baserom.gba", 0x154A6EC, 0x20
+sBagonSprites24:
+ax_sprite sBagonGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx24_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sBagonGfx25:
+.incbin "baserom.gba", 0x154A754, 0x60
+sBagonGfx25_1:
+.incbin "baserom.gba", 0x154A7B4, 0x60
+sBagonGfx25_2:
+.incbin "baserom.gba", 0x154A814, 0x60
+sBagonGfx25_3:
+.incbin "baserom.gba", 0x154A874, 0x60
+sBagonSprites25:
+ax_sprite sBagonGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBagonGfx26:
+.incbin "baserom.gba", 0x154A91C, 0x60
+sBagonGfx26_1:
+.incbin "baserom.gba", 0x154A97C, 0x60
+sBagonGfx26_2:
+.incbin "baserom.gba", 0x154A9DC, 0x60
+sBagonSprites26:
+ax_sprite sBagonGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx27:
+.incbin "baserom.gba", 0x154AA74, 0x60
+sBagonGfx27_1:
+.incbin "baserom.gba", 0x154AAD4, 0x60
+sBagonGfx27_2:
+.incbin "baserom.gba", 0x154AB34, 0x40
+sBagonGfx27_3:
+.incbin "baserom.gba", 0x154AB74, 0x20
+sBagonSprites27:
+ax_sprite sBagonGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx27_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sBagonGfx27_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBagonGfx28:
+.incbin "baserom.gba", 0x154ABDC, 0x60
+sBagonGfx28_1:
+.incbin "baserom.gba", 0x154AC3C, 0x60
+sBagonGfx28_2:
+.incbin "baserom.gba", 0x154AC9C, 0x40
+sBagonSprites28:
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx28_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx29:
+.incbin "baserom.gba", 0x154AD1C, 0x60
+sBagonGfx29_1:
+.incbin "baserom.gba", 0x154AD7C, 0x60
+sBagonGfx29_2:
+.incbin "baserom.gba", 0x154ADDC, 0x40
+sBagonGfx29_3:
+.incbin "baserom.gba", 0x154AE1C, 0x20
+sBagonSprites29:
+ax_sprite sBagonGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBagonGfx30:
+.incbin "baserom.gba", 0x154AE84, 0x60
+sBagonGfx30_1:
+.incbin "baserom.gba", 0x154AEE4, 0x60
+sBagonGfx30_2:
+.incbin "baserom.gba", 0x154AF44, 0x60
+sBagonSprites30:
+ax_sprite sBagonGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx31:
+.incbin "baserom.gba", 0x154AFDC, 0x60
+sBagonGfx31_1:
+.incbin "baserom.gba", 0x154B03C, 0x60
+sBagonGfx31_2:
+.incbin "baserom.gba", 0x154B09C, 0x60
+sBagonSprites31:
+ax_sprite sBagonGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx32:
+.incbin "baserom.gba", 0x154B134, 0x40
+sBagonGfx32_1:
+.incbin "baserom.gba", 0x154B174, 0x60
+sBagonGfx32_2:
+.incbin "baserom.gba", 0x154B1D4, 0x60
+sBagonSprites32:
+ax_sprite sBagonGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBagonGfx33:
+.incbin "baserom.gba", 0x154B26C, 0x60
+sBagonGfx33_1:
+.incbin "baserom.gba", 0x154B2CC, 0x100
+sBagonSprites33:
+ax_sprite sBagonGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx33_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBagonGfx34:
+.incbin "baserom.gba", 0x154B3F4, 0x60
+sBagonGfx34_1:
+.incbin "baserom.gba", 0x154B454, 0x60
+sBagonGfx34_2:
+.incbin "baserom.gba", 0x154B4B4, 0x60
+sBagonGfx34_3:
+.incbin "baserom.gba", 0x154B514, 0x20
+sBagonSprites34:
+ax_sprite sBagonGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBagonGfx34_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBagonGfx35:
+.incbin "baserom.gba", 0x154B57C, 0x60
+sBagonGfx35_1:
+.incbin "baserom.gba", 0x154B5DC, 0x60
+sBagonGfx35_2:
+.incbin "baserom.gba", 0x154B63C, 0x60
+sBagonGfx35_3:
+.incbin "baserom.gba", 0x154B69C, 0x20
+sBagonGfx35_4:
+.incbin "baserom.gba", 0x154B6BC, 0x20
+sBagonSprites35:
+ax_sprite sBagonGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx35_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBagonGfx35_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBagonGfx36:
+.incbin "baserom.gba", 0x154B734, 0x200
+sBagonSprites36:
+ax_sprite sBagonGfx36, 0x200
+ax_sprite_terminator
+sBagonGfx37:
+.incbin "baserom.gba", 0x154B944, 0x200
+sBagonSprites37:
+ax_sprite sBagonGfx37, 0x200
+ax_sprite_terminator
+sBagonGfx38:
+.incbin "baserom.gba", 0x154BB54, 0x200
+sBagonSprites38:
+ax_sprite sBagonGfx38, 0x200
+ax_sprite_terminator
+sBagonGfx39:
+.incbin "baserom.gba", 0x154BD64, 0x200
+sBagonSprites39:
+ax_sprite sBagonGfx39, 0x200
+ax_sprite_terminator
+sBagonGfx40:
+.incbin "baserom.gba", 0x154BF74, 0x200
+sBagonSprites40:
+ax_sprite sBagonGfx40, 0x200
+ax_sprite_terminator
+sBagonGfx41:
+.incbin "baserom.gba", 0x154C184, 0x200
+sBagonSprites41:
+ax_sprite sBagonGfx41, 0x200
+ax_sprite_terminator
+sBagonGfx42:
+.incbin "baserom.gba", 0x154C394, 0x200
+sBagonSprites42:
+ax_sprite sBagonGfx42, 0x200
+ax_sprite_terminator
+sAxPosesBagon:
+.4byte sBagonPose1
+.4byte sBagonPose2
+.4byte sBagonPose3
+.4byte sBagonPose4
+.4byte sBagonPose5
+.4byte sBagonPose6
+.4byte sBagonPose7
+.4byte sBagonPose8
+.4byte sBagonPose9
+.4byte sBagonPose10
+.4byte sBagonPose11
+.4byte sBagonPose12
+.4byte sBagonPose13
+.4byte sBagonPose14
+.4byte sBagonPose15
+.4byte sBagonPose16
+.4byte sBagonPose17
+.4byte sBagonPose18
+.4byte sBagonPose19
+.4byte sBagonPose20
+.4byte sBagonPose21
+.4byte sBagonPose22
+.4byte sBagonPose23
+.4byte sBagonPose24
+.4byte sBagonPose25
+.4byte sBagonPose26
+.4byte sBagonPose27
+.4byte sBagonPose28
+.4byte sBagonPose29
+.4byte sBagonPose30
+.4byte sBagonPose31
+.4byte sBagonPose32
+.4byte sBagonPose33
+.4byte sBagonPose34
+.4byte sBagonPose35
+.4byte sBagonPose36
+.4byte sBagonPose37
+.4byte sBagonPose38
+.4byte sBagonPose39
+.4byte sBagonPose40
+.4byte sBagonPose41
+.4byte sBagonPose42
+.4byte sBagonPose43
+.4byte sBagonPose44
+.4byte sBagonPose45
+.4byte sBagonPose46
+.4byte sBagonPose47
+.4byte sBagonPose48
+.4byte sBagonPose49
+.4byte sBagonPose50
+.4byte sBagonPose51
+.4byte sBagonPose52
+.4byte sBagonPose53
+.4byte sBagonPose54
+.4byte sBagonPose55
+.4byte sBagonPose56
+.4byte sBagonPose57
+.4byte sBagonPose58
+.4byte sBagonPose59
+.4byte sBagonPose60
+.4byte sBagonPose61
+.4byte sBagonPose62
+.4byte sBagonPose63
+.4byte sBagonPose64
+.4byte sBagonPose65
+.4byte sBagonPose66
+.4byte sBagonPose67
+.4byte sBagonPose68
+.4byte sBagonPose69
+.4byte sBagonPose70
+.4byte sBagonPose71
+.4byte sBagonPose72
+.4byte sBagonPose73
+.4byte sBagonPose74
+.4byte sBagonPose75
+.4byte sBagonPose76
+.4byte sBagonPose77
+.4byte sBagonPose78
+.4byte sBagonPose79
+.4byte sBagonPose80
+.4byte sBagonPose81
+.4byte sBagonPose82
+.4byte sBagonPose83
+.4byte sBagonPose84
+.4byte sBagonPose85
+.4byte sBagonPose86
+.4byte sBagonPose87
+.4byte sBagonPose88
+.4byte sBagonPose89
+.4byte sBagonPose90
+.4byte sBagonPose91
+.4byte sBagonPose92
+.4byte sBagonPose93
+.4byte sBagonPose94
+.4byte sBagonPose95
+.4byte sBagonPose96
+.4byte sBagonPose97
+.4byte sBagonPose98
+.4byte sBagonPose99
+.4byte sBagonPose100
+.4byte sBagonPose101
+.4byte sBagonPose102
+.4byte sBagonPose103
+.4byte sBagonPose104
+.4byte sBagonPose105
+.4byte sBagonPose106
+.4byte sBagonPose107
+.4byte sBagonPose108
+.4byte sBagonPose109
+.4byte sBagonPose110
+.4byte sBagonPose111
+.4byte sBagonPose112
+.4byte sBagonPose113
+.4byte sBagonPose114
+.4byte sBagonPose115
+.4byte sBagonPose116
+.4byte sBagonPose117
+.4byte sBagonPose118
+.4byte sBagonPose119
+.4byte sBagonPose120
+.4byte sBagonPose121
+.4byte sBagonPose122
+.4byte sBagonPose123
+.4byte sBagonPose124
+.4byte sBagonPose125
+.4byte sBagonPose126
+.4byte sBagonPose127
+.4byte sBagonPose128
+.4byte sBagonPose129
+.4byte sBagonPose130
+.4byte sBagonPose131
+.4byte sBagonPose132
+.4byte sBagonPose133
+.4byte sBagonPose134
+.4byte sBagonPose135
+.4byte sBagonPose136
+.4byte sBagonPose137
+.4byte sBagonPose138
+.4byte sBagonPose139
+.4byte sBagonPose140
+.4byte sBagonPose141
+.4byte sBagonPose142
+.4byte sBagonPose143
+.4byte sBagonPose144
+.4byte sBagonPose145
+.4byte sBagonPose146
+.4byte sBagonPose147
+.4byte sBagonPose148
+.4byte sBagonPose149
+.4byte sBagonPose150
+.4byte sBagonPose151
+.4byte sBagonPose152
+.4byte sBagonPose153
+.4byte sBagonPose154
+.4byte sBagonPose155
+.4byte sBagonPose156
+.4byte sBagonPose157
+.4byte sBagonPose158
+.4byte sBagonPose159
+.4byte sBagonPose160
+.4byte sBagonPose161
+.4byte sBagonPose162
+.4byte sBagonPose163
+.4byte sBagonPose164
+.4byte sBagonPose165
+.4byte sBagonPose166
+.4byte sBagonPose167
+.4byte sBagonPose168
+.4byte sBagonPose169
+.4byte sBagonPose170
+.4byte sBagonPose171
+.4byte sBagonPose172
+.4byte sBagonPose173
+.4byte sBagonPose174
+.4byte sBagonPose175
+.4byte sBagonPose176
+.4byte sBagonPose177
+.4byte sBagonPose178
+.4byte sBagonPose179
+.4byte sBagonPose180
+.4byte sBagonPose181
+.4byte sBagonPose182
+.4byte sBagonPose183
+.4byte sBagonPose184
+.4byte sBagonPose185
+.4byte sBagonPose186
+.4byte sBagonPose187
+.4byte sBagonPose188
+.4byte sBagonPose189
+.4byte sBagonPose190
+.4byte sBagonPose191
+.4byte sBagonPose192
+.4byte sBagonPose193
+.4byte sBagonPose194
+.4byte sBagonPose195
+.4byte sBagonPose196
+.4byte sBagonPose197
+.4byte sBagonPose198
+.4byte sBagonPose199
+.4byte sBagonPose200
+.4byte sBagonPose201
+.4byte sBagonPose202
+.4byte sBagonPose203
+.4byte sBagonPose204
+.4byte sBagonPose205
+.4byte sBagonPose206
+.4byte sBagonPose207
+.4byte sBagonPose208
+.4byte sBagonPose209
+.4byte sBagonPose210
+.4byte sBagonPose211
+.4byte sBagonPose212
+.4byte sBagonPose213
+.4byte sBagonPose214
+.4byte sBagonPose215
+.4byte sBagonPose216
+.4byte sBagonPose217
+.4byte sBagonPose218
+.4byte sBagonPose219
+.4byte sBagonPose220
+.4byte sBagonPose221
+.4byte sBagonPose222
+.4byte sBagonPose223
+.4byte sBagonPose224
+.4byte sBagonPose225
+.4byte sBagonPose226
+.4byte sBagonPose227
+.4byte sBagonPose228
+.4byte sBagonPose229
+.4byte sBagonPose230
+.4byte sBagonPose231
+.4byte sBagonPose232
+.4byte sBagonPose233
+.4byte sBagonPose234
+.4byte sBagonPose235
+.4byte sBagonPose236
+.4byte sBagonPose237
+.4byte sBagonPose238
+.4byte sBagonPose239
+.4byte sBagonPose240
+.4byte sBagonPose241
+.4byte sBagonPose242
+.4byte sBagonPose243
+.4byte sBagonPose244
+.4byte sBagonPose245
+.4byte sBagonPose246
+.4byte sBagonPose247
+.4byte sBagonPose248
+.4byte sBagonPose249
+.4byte sBagonPose250
+sAxPositionsBagon:
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -1,   -5, 	  -3,   -4, 	   7,   -6, 	   0,   -9
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+.2byte    3,   -6, 	   3,   -5, 	  -1,   -5, 	   0,   -6
+.2byte    3,   -6, 	   4,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte    6,   -7, 	  -1,   -6, 	   3,   -5, 	   0,   -6
+.2byte    8,   -9, 	   6,   -5, 	   1,   -4, 	  -1,   -6
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    6,   -9, 	  -5,   -9, 	   5,   -6, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	   2,   -5, 	  -1,   -6
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -1,  -12, 	   6,   -7, 	  -4,   -9, 	   0,   -7
+.2byte    1,  -12, 	   4,   -9, 	  -6,   -7, 	   0,   -7
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte   -6,   -9, 	   5,   -9, 	  -5,   -6, 	   1,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -2,   -5, 	   1,   -6
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte   -6,   -7, 	   1,   -6, 	  -3,   -5, 	   0,   -6
+.2byte   -8,   -9, 	  -6,   -5, 	  -1,   -4, 	   1,   -6
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte   -3,   -6, 	  -3,   -5, 	   1,   -5, 	   0,   -6
+.2byte   -3,   -6, 	  -4,   -5, 	   5,   -5, 	   0,   -6
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -1,   -5, 	  -3,   -4, 	   7,   -6, 	   0,   -9
+.2byte    0,    2, 	  -7,   -1, 	   5,   -1, 	   0,   -5
+.2byte    0,  -13, 	  -6,   -9, 	   6,   -9, 	   0,   -7
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+.2byte    3,   -6, 	   3,   -5, 	  -1,   -5, 	   0,   -6
+.2byte    3,   -6, 	   4,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    1,   -1, 	   5,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    4,  -13, 	   5,  -10, 	  -4,   -9, 	   0,   -6
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte    6,   -7, 	  -1,   -6, 	   3,   -5, 	   0,   -6
+.2byte    8,   -9, 	   6,   -5, 	   1,   -4, 	  -1,   -6
+.2byte    5,   -2, 	   4,   -6, 	   2,   -3, 	   0,   -6
+.2byte    4,  -14, 	   4,  -11, 	   2,  -10, 	  -2,   -7
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    6,   -9, 	  -5,   -9, 	   5,   -6, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	   2,   -5, 	  -1,   -6
+.2byte    6,   -5, 	  -1,   -8, 	   5,   -3, 	   2,   -8
+.2byte    5,  -15, 	  -4,  -13, 	   4,  -11, 	  -2,   -8
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -1,  -12, 	   6,   -7, 	  -4,   -9, 	   0,   -7
+.2byte    1,  -12, 	   4,   -9, 	  -6,   -7, 	   0,   -7
+.2byte    0,   -8, 	   5,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -18, 	   6,  -11, 	  -6,  -11, 	   0,   -8
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte   -6,   -9, 	   5,   -9, 	  -5,   -6, 	   1,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -2,   -5, 	   1,   -6
+.2byte   -6,   -5, 	   1,   -8, 	  -5,   -3, 	  -2,   -8
+.2byte   -5,  -15, 	   4,  -13, 	  -4,  -11, 	   2,   -8
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte   -6,   -7, 	   1,   -6, 	  -3,   -5, 	   0,   -6
+.2byte   -8,   -9, 	  -6,   -5, 	  -1,   -4, 	   1,   -6
+.2byte   -5,   -2, 	  -4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -4,  -14, 	  -4,  -11, 	  -2,  -10, 	   2,   -7
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte   -3,   -6, 	  -3,   -5, 	   1,   -5, 	   0,   -6
+.2byte   -3,   -6, 	  -4,   -5, 	   5,   -5, 	   0,   -6
+.2byte   -1,   -1, 	  -5,   -5, 	   2,   -2, 	   1,   -7
+.2byte   -4,  -13, 	  -5,  -10, 	   4,   -9, 	   0,   -6
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -1,   -5, 	  -3,   -4, 	   7,   -6, 	   0,   -9
+.2byte    0,    2, 	  -7,   -1, 	   5,   -1, 	   0,   -5
+.2byte    0,  -13, 	  -6,   -9, 	   6,   -9, 	   0,   -7
+.2byte    0,  -15, 	  -5,  -12, 	   5,  -12, 	   0,   -7
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+.2byte    3,   -6, 	   3,   -5, 	  -1,   -5, 	   0,   -6
+.2byte    3,   -6, 	   4,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    1,   -1, 	   5,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    4,  -13, 	   5,  -10, 	  -4,   -9, 	   0,   -6
+.2byte   -1,  -15, 	   4,  -13, 	  -4,  -12, 	   0,   -8
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte    6,   -7, 	  -1,   -6, 	   3,   -5, 	   0,   -6
+.2byte    8,   -9, 	   6,   -5, 	   1,   -4, 	  -1,   -6
+.2byte    5,   -2, 	   4,   -6, 	   2,   -3, 	   0,   -6
+.2byte    4,  -14, 	   4,  -11, 	   2,  -10, 	  -2,   -7
+.2byte   -2,  -16, 	  -1,  -14, 	   0,  -12, 	  -3,   -8
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    6,   -9, 	  -5,   -9, 	   5,   -6, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	   2,   -5, 	  -1,   -6
+.2byte    6,   -5, 	  -1,   -8, 	   5,   -3, 	   2,   -8
+.2byte    5,  -15, 	  -4,  -13, 	   4,  -11, 	  -2,   -8
+.2byte    3,  -16, 	  -6,  -15, 	   3,  -13, 	  -2,   -9
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -1,  -12, 	   6,   -7, 	  -4,   -9, 	   0,   -7
+.2byte    1,  -12, 	   4,   -9, 	  -6,   -7, 	   0,   -7
+.2byte    0,   -8, 	   5,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -18, 	   6,  -11, 	  -6,  -11, 	   0,   -8
+.2byte    0,  -18, 	   6,  -12, 	  -6,  -12, 	   0,   -7
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte   -6,   -9, 	   5,   -9, 	  -5,   -6, 	   1,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -2,   -5, 	   1,   -6
+.2byte   -6,   -5, 	   1,   -8, 	  -5,   -3, 	  -2,   -8
+.2byte   -5,  -15, 	   4,  -13, 	  -4,  -11, 	   2,   -8
+.2byte   -3,  -16, 	   6,  -15, 	  -3,  -13, 	   2,   -9
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte   -6,   -7, 	   1,   -6, 	  -3,   -5, 	   0,   -6
+.2byte   -8,   -9, 	  -6,   -5, 	  -1,   -4, 	   1,   -6
+.2byte   -5,   -2, 	  -4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -4,  -14, 	  -4,  -11, 	  -2,  -10, 	   2,   -7
+.2byte    2,  -16, 	   1,  -14, 	   0,  -12, 	   3,   -8
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte   -3,   -6, 	  -3,   -5, 	   1,   -5, 	   0,   -6
+.2byte   -3,   -6, 	  -4,   -5, 	   5,   -5, 	   0,   -6
+.2byte   -1,   -1, 	  -5,   -5, 	   2,   -2, 	   1,   -7
+.2byte   -4,  -13, 	  -5,  -10, 	   4,   -9, 	   0,   -6
+.2byte    1,  -15, 	  -4,  -13, 	   4,  -12, 	   0,   -8
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte    0,  -13, 	  -6,   -9, 	   6,   -9, 	   0,   -7
+.2byte    0,   -6, 	  -5,   -3, 	   5,   -3, 	   0,   -5
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+.2byte    4,  -13, 	   5,  -10, 	  -4,   -9, 	   0,   -6
+.2byte    6,   -7, 	   8,   -8, 	  -1,   -6, 	   0,   -8
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte    4,  -14, 	   4,  -11, 	   2,  -10, 	  -2,   -7
+.2byte    8,   -8, 	   4,   -9, 	   4,   -5, 	   1,   -9
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    5,  -15, 	  -4,  -13, 	   4,  -11, 	  -2,   -8
+.2byte    7,  -11, 	  -3,  -10, 	   6,   -6, 	   0,   -8
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte    0,  -18, 	   6,  -11, 	  -6,  -11, 	   0,   -8
+.2byte    0,  -11, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte   -5,  -15, 	   4,  -13, 	  -4,  -11, 	   2,   -8
+.2byte   -7,  -11, 	   3,  -10, 	  -6,   -6, 	   0,   -8
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte   -4,  -14, 	  -4,  -11, 	  -2,  -10, 	   2,   -7
+.2byte   -8,   -8, 	  -4,   -9, 	  -4,   -5, 	  -1,   -9
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte   -4,  -13, 	  -5,  -10, 	   4,   -9, 	   0,   -6
+.2byte   -6,   -7, 	  -8,   -8, 	   1,   -6, 	   0,   -8
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte    0,  -15, 	  -5,  -12, 	   5,  -12, 	   0,   -7
+.2byte    0,  -13, 	  -6,   -9, 	   6,   -9, 	   0,   -7
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+.2byte   -1,  -15, 	   4,  -13, 	  -4,  -12, 	   0,   -8
+.2byte    4,  -13, 	   5,  -10, 	  -4,   -9, 	   0,   -6
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte   -2,  -16, 	  -1,  -14, 	   0,  -12, 	  -3,   -8
+.2byte    4,  -14, 	   4,  -11, 	   2,  -10, 	  -2,   -7
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    3,  -16, 	  -6,  -15, 	   3,  -13, 	  -2,   -9
+.2byte    5,  -15, 	  -4,  -13, 	   4,  -11, 	  -2,   -8
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte    0,  -18, 	   6,  -12, 	  -6,  -12, 	   0,   -7
+.2byte    0,  -18, 	   6,  -11, 	  -6,  -11, 	   0,   -8
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte   -3,  -16, 	   6,  -15, 	  -3,  -13, 	   2,   -9
+.2byte   -5,  -15, 	   4,  -13, 	  -4,  -11, 	   2,   -8
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    2,  -16, 	   1,  -14, 	   0,  -12, 	   3,   -8
+.2byte   -4,  -14, 	  -4,  -11, 	  -2,  -10, 	   2,   -7
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte    1,  -15, 	  -4,  -13, 	   4,  -12, 	   0,   -8
+.2byte   -4,  -13, 	  -5,  -10, 	   4,   -9, 	   0,   -6
+.2byte   -1,   -9, 	  -4,   -5, 	   7,   -3, 	   0,   -4
+.2byte   -3,   -9, 	  -4,   -5, 	   7,   -3, 	   0,   -4
+.2byte   -1,  -12, 	  -9,   -8, 	   7,   -8, 	  -1,  -10
+.2byte    0,  -14, 	   3,  -13, 	  -9,   -7, 	  -3,   -8
+.2byte    1,  -13, 	  -5,   -8, 	  -5,   -6, 	  -2,   -7
+.2byte    0,  -10, 	  -7,   -6, 	  -1,   -4, 	  -3,   -5
+.2byte    0,  -10, 	   7,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -1,  -10, 	   6,   -6, 	   0,   -4, 	   2,   -5
+.2byte   -2,  -13, 	   4,   -8, 	   4,   -6, 	   1,   -7
+.2byte   -1,  -14, 	  -4,  -13, 	   8,   -7, 	   2,   -8
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -1,   -5, 	  -3,   -4, 	   7,   -6, 	   0,   -9
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+.2byte    3,   -6, 	   3,   -5, 	  -1,   -5, 	   0,   -6
+.2byte    3,   -6, 	   4,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte    6,   -7, 	  -1,   -6, 	   3,   -5, 	   0,   -6
+.2byte    8,   -9, 	   6,   -5, 	   1,   -4, 	  -1,   -6
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    6,   -9, 	  -5,   -9, 	   5,   -6, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	   2,   -5, 	  -1,   -6
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -1,  -12, 	   6,   -7, 	  -4,   -9, 	   0,   -7
+.2byte    1,  -12, 	   4,   -9, 	  -6,   -7, 	   0,   -7
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte   -6,   -9, 	   5,   -9, 	  -5,   -6, 	   1,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -2,   -5, 	   1,   -6
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte   -6,   -7, 	   1,   -6, 	  -3,   -5, 	   0,   -6
+.2byte   -8,   -9, 	  -6,   -5, 	  -1,   -4, 	   1,   -6
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte   -3,   -6, 	  -3,   -5, 	   1,   -5, 	   0,   -6
+.2byte   -3,   -6, 	  -4,   -5, 	   5,   -5, 	   0,   -6
+.2byte   -1,   -7, 	  -6,   -6, 	   4,   -6, 	  -1,  -10
+.2byte   -3,   -7, 	  -5,   -5, 	   3,   -5, 	   1,   -7
+.2byte   -8,   -8, 	  -3,   -6, 	  -2,   -5, 	  -1,   -6
+.2byte   -5,   -9, 	   4,   -9, 	  -4,   -5, 	   1,   -6
+.2byte    0,  -12, 	   5,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    5,   -9, 	  -4,   -9, 	   4,   -5, 	  -1,   -6
+.2byte    8,   -8, 	   3,   -6, 	   2,   -5, 	   1,   -6
+.2byte    3,   -8, 	   5,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte    0,  -13, 	  -6,   -9, 	   6,   -9, 	   0,   -7
+.2byte    4,  -13, 	   5,  -10, 	  -4,   -9, 	   0,   -6
+.2byte    4,  -13, 	   4,  -10, 	   2,   -9, 	  -2,   -6
+.2byte    5,  -14, 	  -4,  -12, 	   4,  -10, 	  -2,   -7
+.2byte    0,  -17, 	   6,  -10, 	  -6,  -10, 	   0,   -7
+.2byte   -5,  -14, 	   4,  -12, 	  -4,  -10, 	   2,   -7
+.2byte   -4,  -13, 	  -4,  -10, 	  -2,   -9, 	   2,   -6
+.2byte   -4,  -13, 	  -5,  -10, 	   4,   -9, 	   0,   -6
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte    0,  -15, 	  -5,  -12, 	   5,  -12, 	   0,   -7
+.2byte    0,    0, 	  -7,   -3, 	   5,   -3, 	   0,   -7
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+.2byte   -1,  -15, 	   4,  -13, 	  -4,  -12, 	   0,   -8
+.2byte    1,   -1, 	   5,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte   -2,  -16, 	  -1,  -14, 	   0,  -12, 	  -3,   -8
+.2byte    4,   -2, 	   3,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    3,  -16, 	  -6,  -15, 	   3,  -13, 	  -2,   -9
+.2byte    5,   -5, 	  -2,   -8, 	   4,   -3, 	   1,   -8
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte    0,  -18, 	   6,  -12, 	  -6,  -12, 	   0,   -7
+.2byte    0,   -7, 	   5,   -7, 	  -5,   -7, 	   0,   -6
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte   -3,  -16, 	   6,  -15, 	  -3,  -13, 	   2,   -9
+.2byte   -5,   -5, 	   2,   -8, 	  -4,   -3, 	  -1,   -8
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    2,  -16, 	   1,  -14, 	   0,  -12, 	   3,   -8
+.2byte   -4,   -2, 	  -3,   -6, 	  -1,   -3, 	   1,   -6
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte    1,  -15, 	  -4,  -13, 	   4,  -12, 	   0,   -8
+.2byte   -1,   -1, 	  -5,   -5, 	   2,   -2, 	   1,   -7
+.2byte    0,   -6, 	  -5,   -3, 	   5,   -3, 	   0,   -5
+.2byte   -6,   -6, 	  -8,   -7, 	   1,   -5, 	   0,   -7
+.2byte   -8,   -6, 	  -4,   -7, 	  -4,   -3, 	  -1,   -7
+.2byte   -6,  -10, 	   4,   -9, 	  -5,   -5, 	   1,   -7
+.2byte    0,  -10, 	   6,   -7, 	  -6,   -7, 	   0,   -7
+.2byte    6,  -10, 	  -4,   -9, 	   5,   -5, 	  -1,   -7
+.2byte    8,   -6, 	   4,   -7, 	   4,   -3, 	   1,   -7
+.2byte    6,   -6, 	   8,   -7, 	  -1,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -5,   -5, 	   5,   -5, 	   0,   -9
+.2byte   -4,   -7, 	  -6,   -5, 	   2,   -5, 	   0,   -7
+.2byte   -8,   -9, 	  -3,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte   -5,  -10, 	   4,  -10, 	  -4,   -6, 	   1,   -7
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte    5,  -10, 	  -4,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    8,   -9, 	   3,   -7, 	   2,   -6, 	   1,   -7
+.2byte    4,   -7, 	   6,   -5, 	  -2,   -5, 	   0,   -7
+sBagonAnimTable1:
+.4byte sBagonAnims_1_1
+.4byte sBagonAnims_1_2
+.4byte sBagonAnims_1_3
+.4byte sBagonAnims_1_4
+.4byte sBagonAnims_1_5
+.4byte sBagonAnims_1_6
+.4byte sBagonAnims_1_7
+.4byte sBagonAnims_1_8
+sBagonAnimTable2:
+.4byte sBagonAnims_2_1
+.4byte sBagonAnims_2_2
+.4byte sBagonAnims_2_3
+.4byte sBagonAnims_2_4
+.4byte sBagonAnims_2_5
+.4byte sBagonAnims_2_6
+.4byte sBagonAnims_2_7
+.4byte sBagonAnims_2_8
+sBagonAnimTable3:
+.4byte sBagonAnims_3_1
+.4byte sBagonAnims_3_2
+.4byte sBagonAnims_3_3
+.4byte sBagonAnims_3_4
+.4byte sBagonAnims_3_5
+.4byte sBagonAnims_3_6
+.4byte sBagonAnims_3_7
+.4byte sBagonAnims_3_8
+sBagonAnimTable4:
+.4byte sBagonAnims_4_1
+.4byte sBagonAnims_4_2
+.4byte sBagonAnims_4_3
+.4byte sBagonAnims_4_4
+.4byte sBagonAnims_4_5
+.4byte sBagonAnims_4_6
+.4byte sBagonAnims_4_7
+.4byte sBagonAnims_4_8
+sBagonAnimTable5:
+.4byte sBagonAnims_5_1
+.4byte sBagonAnims_5_2
+.4byte sBagonAnims_5_3
+.4byte sBagonAnims_5_4
+.4byte sBagonAnims_5_5
+.4byte sBagonAnims_5_6
+.4byte sBagonAnims_5_7
+.4byte sBagonAnims_5_8
+sBagonAnimTable6:
+.4byte sBagonAnims_6_1
+.4byte sBagonAnims_6_1
+.4byte sBagonAnims_6_1
+.4byte sBagonAnims_6_1
+.4byte sBagonAnims_6_1
+.4byte sBagonAnims_6_1
+.4byte sBagonAnims_6_1
+.4byte sBagonAnims_6_1
+sBagonAnimTable7:
+.4byte sBagonAnims_7_1
+.4byte sBagonAnims_7_2
+.4byte sBagonAnims_7_3
+.4byte sBagonAnims_7_4
+.4byte sBagonAnims_7_5
+.4byte sBagonAnims_7_6
+.4byte sBagonAnims_7_7
+.4byte sBagonAnims_7_8
+sBagonAnimTable8:
+.4byte sBagonAnims_8_1
+.4byte sBagonAnims_8_2
+.4byte sBagonAnims_8_3
+.4byte sBagonAnims_8_4
+.4byte sBagonAnims_8_5
+.4byte sBagonAnims_8_6
+.4byte sBagonAnims_8_7
+.4byte sBagonAnims_8_8
+sBagonAnimTable9:
+.4byte sBagonAnims_9_1
+.4byte sBagonAnims_9_2
+.4byte sBagonAnims_9_3
+.4byte sBagonAnims_9_4
+.4byte sBagonAnims_9_5
+.4byte sBagonAnims_9_6
+.4byte sBagonAnims_9_7
+.4byte sBagonAnims_9_8
+sBagonAnimTable10:
+.4byte sBagonAnims_10_1
+.4byte sBagonAnims_10_2
+.4byte sBagonAnims_10_3
+.4byte sBagonAnims_10_4
+.4byte sBagonAnims_10_5
+.4byte sBagonAnims_10_6
+.4byte sBagonAnims_10_7
+.4byte sBagonAnims_10_8
+sBagonAnimTable11:
+.4byte sBagonAnims_11_1
+.4byte sBagonAnims_11_2
+.4byte sBagonAnims_11_3
+.4byte sBagonAnims_11_4
+.4byte sBagonAnims_11_5
+.4byte sBagonAnims_11_6
+.4byte sBagonAnims_11_7
+.4byte sBagonAnims_11_8
+sBagonAnimTable12:
+.4byte sBagonAnims_12_1
+.4byte sBagonAnims_12_2
+.4byte sBagonAnims_12_3
+.4byte sBagonAnims_12_4
+.4byte sBagonAnims_12_5
+.4byte sBagonAnims_12_6
+.4byte sBagonAnims_12_7
+.4byte sBagonAnims_12_8
+sBagonAnimTable13:
+.4byte sBagonAnims_13_1
+.4byte sBagonAnims_13_2
+.4byte sBagonAnims_13_3
+.4byte sBagonAnims_13_4
+.4byte sBagonAnims_13_5
+.4byte sBagonAnims_13_6
+.4byte sBagonAnims_13_7
+.4byte sBagonAnims_13_8
+sAxAnimationsBagon:
+.4byte sBagonAnimTable1
+.4byte sBagonAnimTable2
+.4byte sBagonAnimTable3
+.4byte sBagonAnimTable4
+.4byte sBagonAnimTable5
+.4byte sBagonAnimTable6
+.4byte sBagonAnimTable7
+.4byte sBagonAnimTable8
+.4byte sBagonAnimTable9
+.4byte sBagonAnimTable10
+.4byte sBagonAnimTable11
+.4byte sBagonAnimTable12
+.4byte sBagonAnimTable13
+sAxSpritesBagon:
+.4byte sBagonSprites1
+.4byte sBagonSprites2
+.4byte sBagonSprites3
+.4byte sBagonSprites4
+.4byte sBagonSprites5
+.4byte sBagonSprites6
+.4byte sBagonSprites7
+.4byte sBagonSprites8
+.4byte sBagonSprites9
+.4byte sBagonSprites10
+.4byte sBagonSprites11
+.4byte sBagonSprites12
+.4byte sBagonSprites13
+.4byte sBagonSprites14
+.4byte sBagonSprites15
+.4byte sBagonSprites16
+.4byte sBagonSprites17
+.4byte sBagonSprites18
+.4byte sBagonSprites19
+.4byte sBagonSprites20
+.4byte sBagonSprites21
+.4byte sBagonSprites22
+.4byte sBagonSprites23
+.4byte sBagonSprites24
+.4byte sBagonSprites25
+.4byte sBagonSprites26
+.4byte sBagonSprites27
+.4byte sBagonSprites28
+.4byte sBagonSprites29
+.4byte sBagonSprites30
+.4byte sBagonSprites31
+.4byte sBagonSprites32
+.4byte sBagonSprites33
+.4byte sBagonSprites34
+.4byte sBagonSprites35
+.4byte sBagonSprites36
+.4byte sBagonSprites37
+.4byte sBagonSprites38
+.4byte sBagonSprites39
+.4byte sBagonSprites40
+.4byte sBagonSprites41
+.4byte sBagonSprites42
+sAxMainBagon:
+ax_main sAxPosesBagon, sAxAnimationsBagon, 13, sAxSpritesBagon, sAxPositionsBagon

--- a/data/ax/baltoy.inc
+++ b/data/ax/baltoy.inc
@@ -1,0 +1,2261 @@
+.global gAxBaltoy
+gAxBaltoy:
+ax_siro sAxMainBaltoy
+sBaltoyPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose3:
+ax_pose 2, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose4:
+ax_pose 3, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose5:
+ax_pose 4, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose6:
+ax_pose 3, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose7:
+ax_pose 2, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sBaltoyPose8:
+ax_pose 1, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sBaltoyPose9:
+ax_pose 0, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose10:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose11:
+ax_pose 2, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose12:
+ax_pose 3, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose13:
+ax_pose 4, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose14:
+ax_pose 3, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose15:
+ax_pose 2, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sBaltoyPose16:
+ax_pose 1, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sBaltoyPose17:
+ax_pose 0, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose18:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose19:
+ax_pose 2, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose20:
+ax_pose 3, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose21:
+ax_pose 4, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose22:
+ax_pose 3, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose23:
+ax_pose 2, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sBaltoyPose24:
+ax_pose 1, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sBaltoyPose25:
+ax_pose 0, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose26:
+ax_pose 5, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose27:
+ax_pose 1, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sBaltoyPose28:
+ax_pose 6, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose29:
+ax_pose 2, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sBaltoyPose30:
+ax_pose 7, 0x81ea, 0x90f7, 0x0c00
+ax_pose 8, 0x81ea, 0x10ef, 0x0c08
+ax_pose_terminator
+sBaltoyPose31:
+ax_pose 3, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose32:
+ax_pose 9, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose33:
+ax_pose 4, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose34:
+ax_pose 10, 0x41f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose35:
+ax_pose 3, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose36:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose37:
+ax_pose 2, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose38:
+ax_pose 7, 0x81ea, 0x80f8, 0x0c00
+ax_pose 8, 0x81ea, 0x0108, 0x0c08
+ax_pose_terminator
+sBaltoyPose39:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose40:
+ax_pose 6, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose41:
+ax_pose 0, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose42:
+ax_pose 11, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose43:
+ax_pose 1, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sBaltoyPose44:
+ax_pose 12, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sBaltoyPose45:
+ax_pose 2, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sBaltoyPose46:
+ax_pose 13, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sBaltoyPose47:
+ax_pose 3, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose48:
+ax_pose 14, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sBaltoyPose49:
+ax_pose 4, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose50:
+ax_pose 15, 0x41ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose51:
+ax_pose 3, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose52:
+ax_pose 14, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose53:
+ax_pose 2, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose54:
+ax_pose 13, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sBaltoyPose55:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose56:
+ax_pose 12, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sBaltoyPose57:
+ax_pose 16, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sBaltoyPose58:
+ax_pose 17, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sBaltoyPose59:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose60:
+ax_pose 18, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose61:
+ax_pose 19, 0x01e4, 0x90ec, 0x0c00
+ax_pose_terminator
+sBaltoyPose62:
+ax_pose 20, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sBaltoyPose63:
+ax_pose 21, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose64:
+ax_pose 22, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose65:
+ax_pose 21, 0x01e4, 0x80f3, 0x0c00
+ax_pose_terminator
+sBaltoyPose66:
+ax_pose 20, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sBaltoyPose67:
+ax_pose 19, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose68:
+ax_pose 0, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose69:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose70:
+ax_pose 2, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose71:
+ax_pose 3, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose72:
+ax_pose 4, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose73:
+ax_pose 3, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose74:
+ax_pose 2, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sBaltoyPose75:
+ax_pose 1, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sBaltoyPose76:
+ax_pose 5, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose77:
+ax_pose 6, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sBaltoyPose78:
+ax_pose 7, 0x81ea, 0x80f7, 0x0c00
+ax_pose 8, 0x81ea, 0x0107, 0x0c08
+ax_pose_terminator
+sBaltoyPose79:
+ax_pose 9, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose80:
+ax_pose 10, 0x41ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose81:
+ax_pose 9, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sBaltoyPose82:
+ax_pose 7, 0x81ea, 0x90f9, 0x0c00
+ax_pose 8, 0x81ea, 0x10f1, 0x0c08
+ax_pose_terminator
+sBaltoyPose83:
+ax_pose 6, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose84:
+ax_pose 11, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose85:
+ax_pose 12, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose86:
+ax_pose 13, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose87:
+ax_pose 14, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sBaltoyPose88:
+ax_pose 15, 0x41ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose89:
+ax_pose 14, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose90:
+ax_pose 13, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose91:
+ax_pose 12, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sBaltoyPose92:
+ax_pose 0, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose93:
+ax_pose 11, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose94:
+ax_pose 1, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sBaltoyPose95:
+ax_pose 12, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sBaltoyPose96:
+ax_pose 2, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose97:
+ax_pose 13, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose98:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sBaltoyPose99:
+ax_pose 14, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sBaltoyPose100:
+ax_pose 4, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose101:
+ax_pose 15, 0x41f0, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose102:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose103:
+ax_pose 14, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose104:
+ax_pose 2, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose105:
+ax_pose 13, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose106:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose107:
+ax_pose 12, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose108:
+ax_pose 5, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose109:
+ax_pose 6, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sBaltoyPose110:
+ax_pose 7, 0x81ea, 0x80f7, 0x0c00
+ax_pose 8, 0x81ea, 0x0107, 0x0c08
+ax_pose_terminator
+sBaltoyPose111:
+ax_pose 9, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose112:
+ax_pose 10, 0x41ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sBaltoyPose113:
+ax_pose 9, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sBaltoyPose114:
+ax_pose 7, 0x81ea, 0x90f9, 0x0c00
+ax_pose 8, 0x81ea, 0x10f1, 0x0c08
+ax_pose_terminator
+sBaltoyPose115:
+ax_pose 6, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose116:
+ax_pose 0, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose117:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sBaltoyPose118:
+ax_pose 2, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sBaltoyPose119:
+ax_pose 3, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sBaltoyPose120:
+ax_pose 4, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sBaltoyPose121:
+ax_pose 3, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sBaltoyPose122:
+ax_pose 2, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sBaltoyPose123:
+ax_pose 1, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+.align 2
+sBaltoyAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -4, 0, 0,
+ax_anim 6, 0, 4, 0, -4, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_1_2:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -4, 0, 0,
+ax_anim 4, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 6, 0, 2, 0, -4, 0, 0,
+ax_anim 6, 0, 3, 0, -4, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -4, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -4, 0, 0,
+ax_anim 6, 0, 2, 0, -4, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_1_4:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -4, 0, 0,
+ax_anim 6, 0, 1, 0, -4, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -4, 0, 0,
+ax_anim 6, 0, 0, 0, -4, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_1_6:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -4, 0, 0,
+ax_anim 6, 0, 7, 0, -4, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_1_7:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -4, 0, 0,
+ax_anim 4, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -4, 0, 0,
+ax_anim 6, 0, 6, 0, -4, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_1_8:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -4, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -4, 0, 0,
+ax_anim 6, 0, 5, 0, -4, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_2_1:
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim 2, 2, 12, 0, 4, 0, 4,
+ax_anim 2, 0, 13, 0, 11, 0, 11,
+ax_anim 2, 0, 14, 0, 21, 0, 21,
+ax_anim 1, 1, 15, 0, 22, 0, 22,
+ax_anim 1, 0, 8, 0, 22, 0, 22,
+ax_anim 1, 0, 9, 0, 22, 0, 22,
+ax_anim 1, 0, 10, 0, 22, 0, 22,
+ax_anim 1, 0, 11, 0, 22, 0, 22,
+ax_anim 1, 0, 12, 0, 22, 0, 22,
+ax_anim 2, 0, 13, 0, 14, 0, 14,
+ax_anim 2, 0, 14, 0, 6, 0, 6,
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_2_2:
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 2, 11, 4, 4, 4, 4,
+ax_anim 2, 0, 12, 11, 11, 11, 11,
+ax_anim 2, 0, 13, 21, 21, 21, 21,
+ax_anim 1, 1, 14, 22, 22, 22, 22,
+ax_anim 1, 0, 15, 22, 22, 22, 22,
+ax_anim 1, 0, 8, 22, 22, 22, 22,
+ax_anim 1, 0, 9, 22, 22, 22, 22,
+ax_anim 1, 0, 10, 22, 22, 22, 22,
+ax_anim 1, 0, 11, 22, 22, 22, 22,
+ax_anim 2, 0, 12, 14, 14, 14, 14,
+ax_anim 2, 0, 13, 6, 6, 6, 6,
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_2_3:
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 2, 10, 4, 0, 4, 0,
+ax_anim 2, 0, 11, 11, 0, 11, 0,
+ax_anim 2, 0, 12, 21, 0, 21, 0,
+ax_anim 1, 1, 13, 22, 0, 22, 0,
+ax_anim 1, 0, 14, 22, 0, 22, 0,
+ax_anim 1, 0, 15, 22, 0, 22, 0,
+ax_anim 1, 0, 8, 22, 0, 22, 0,
+ax_anim 1, 0, 9, 22, 0, 22, 0,
+ax_anim 1, 0, 10, 22, 0, 22, 0,
+ax_anim 2, 0, 11, 14, 0, 14, 0,
+ax_anim 2, 0, 12, 6, 0, 6, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_2_4:
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim 2, 2, 9, 4, -4, 4, -4,
+ax_anim 2, 0, 10, 11, -9, 11, -9,
+ax_anim 2, 0, 11, 21, -17, 21, -17,
+ax_anim 1, 1, 12, 22, -18, 22, -18,
+ax_anim 1, 0, 13, 22, -18, 22, -18,
+ax_anim 1, 0, 14, 22, -18, 22, -18,
+ax_anim 1, 0, 15, 22, -18, 22, -18,
+ax_anim 1, 0, 8, 22, -18, 22, -18,
+ax_anim 1, 0, 9, 22, -18, 22, -18,
+ax_anim 2, 0, 10, 14, -12, 14, -12,
+ax_anim 2, 0, 11, 6, -5, 6, -5,
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_2_5:
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 2, 8, 0, -4, 0, -4,
+ax_anim 2, 0, 9, 0, -9, 0, -9,
+ax_anim 2, 0, 10, 0, -17, 0, -17,
+ax_anim 1, 1, 11, 0, -18, 0, -18,
+ax_anim 1, 0, 12, 0, -18, 0, -18,
+ax_anim 1, 0, 13, 0, -18, 0, -18,
+ax_anim 1, 0, 14, 0, -18, 0, -18,
+ax_anim 1, 0, 15, 0, -18, 0, -18,
+ax_anim 1, 0, 8, 0, -18, 0, -18,
+ax_anim 2, 0, 9, 0, -12, 0, -12,
+ax_anim 2, 0, 10, 0, -5, 0, -5,
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_2_6:
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim 2, 2, 15, -4, -4, -4, -4,
+ax_anim 2, 0, 8, -11, -9, -11, -9,
+ax_anim 2, 0, 9, -21, -17, -21, -17,
+ax_anim 1, 1, 10, -22, -18, -22, -18,
+ax_anim 1, 0, 11, -22, -18, -22, -18,
+ax_anim 1, 0, 12, -22, -18, -22, -18,
+ax_anim 1, 0, 13, -22, -18, -22, -18,
+ax_anim 1, 0, 14, -22, -18, -22, -18,
+ax_anim 1, 0, 15, -22, -18, -22, -18,
+ax_anim 2, 0, 8, -14, -12, -14, -12,
+ax_anim 2, 0, 9, -6, -5, -6, -5,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_2_7:
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 2, 14, -4, 0, -4, 0,
+ax_anim 2, 0, 15, -11, 0, -11, 0,
+ax_anim 2, 0, 8, -21, 0, -21, 0,
+ax_anim 1, 1, 9, -22, 0, -22, 0,
+ax_anim 1, 0, 10, -22, 0, -22, 0,
+ax_anim 1, 0, 11, -22, 0, -22, 0,
+ax_anim 1, 0, 12, -22, 0, -22, 0,
+ax_anim 1, 0, 13, -22, 0, -22, 0,
+ax_anim 1, 0, 14, -22, 0, -22, 0,
+ax_anim 2, 0, 15, -14, 0, -14, 0,
+ax_anim 2, 0, 8, -6, 0, -6, 0,
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_2_8:
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 2, 13, -4, 4, -4, 4,
+ax_anim 2, 0, 14, -11, 11, -11, 11,
+ax_anim 2, 0, 15, -21, 21, -21, 21,
+ax_anim 1, 1, 8, -22, 22, -22, 22,
+ax_anim 1, 0, 9, -22, 22, -22, 22,
+ax_anim 1, 0, 10, -22, 22, -22, 22,
+ax_anim 1, 0, 11, -22, 22, -22, 22,
+ax_anim 1, 0, 12, -22, 22, -22, 22,
+ax_anim 1, 0, 13, -22, 22, -22, 22,
+ax_anim 2, 0, 14, -14, 14, -14, 14,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_3_1:
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, 8, 0, 8,
+ax_anim 1, 0, 21, 0, 22, 0, 22,
+ax_anim 1, 0, 22, 0, 44, 0, 44,
+ax_anim 1, 1, 23, 0, 46, 0, 46,
+ax_anim 1, 0, 16, 0, 46, 0, 46,
+ax_anim 1, 0, 17, 0, 46, 0, 46,
+ax_anim 1, 0, 18, 0, 46, 0, 46,
+ax_anim 1, 0, 19, 0, 46, 0, 46,
+ax_anim 1, 0, 20, 0, 46, 0, 46,
+ax_anim 2, 0, 21, 0, 28, 0, 28,
+ax_anim 2, 0, 22, 0, 12, 0, 12,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_3_2:
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 8, 8, 8, 8,
+ax_anim 1, 0, 20, 22, 22, 22, 22,
+ax_anim 1, 0, 21, 42, 42, 42, 42,
+ax_anim 1, 1, 22, 46, 46, 46, 46,
+ax_anim 1, 0, 23, 46, 46, 46, 46,
+ax_anim 1, 0, 16, 46, 46, 46, 46,
+ax_anim 1, 0, 17, 46, 46, 46, 46,
+ax_anim 1, 0, 18, 46, 46, 46, 46,
+ax_anim 1, 0, 19, 46, 46, 46, 46,
+ax_anim 2, 0, 20, 28, 28, 28, 28,
+ax_anim 2, 0, 21, 12, 12, 12, 12,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_3_3:
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 8, 0, 8, 0,
+ax_anim 1, 0, 19, 22, 0, 22, 0,
+ax_anim 1, 0, 20, 44, 0, 44, 0,
+ax_anim 1, 1, 21, 46, 0, 46, 0,
+ax_anim 1, 0, 22, 46, 0, 46, 0,
+ax_anim 1, 0, 23, 46, 0, 46, 0,
+ax_anim 1, 0, 16, 46, 0, 46, 0,
+ax_anim 1, 0, 17, 46, 0, 46, 0,
+ax_anim 1, 0, 18, 46, 0, 46, 0,
+ax_anim 2, 0, 19, 28, 0, 28, 0,
+ax_anim 2, 0, 20, 12, 0, 12, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_3_4:
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 8, -8, 8, -8,
+ax_anim 1, 0, 18, 22, -21, 22, -21,
+ax_anim 1, 0, 19, 44, -40, 44, -40,
+ax_anim 1, 1, 20, 46, -42, 46, -42,
+ax_anim 1, 0, 21, 46, -42, 46, -42,
+ax_anim 1, 0, 22, 46, -42, 46, -42,
+ax_anim 1, 0, 23, 46, -42, 46, -42,
+ax_anim 1, 0, 16, 46, -42, 46, -42,
+ax_anim 1, 0, 17, 46, -42, 46, -42,
+ax_anim 2, 0, 18, 28, -26, 28, -26,
+ax_anim 2, 0, 19, 12, -11, 12, -11,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_3_5:
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, -8, 0, -8,
+ax_anim 1, 0, 17, 0, -18, 0, -18,
+ax_anim 1, 0, 18, 0, -34, 0, -34,
+ax_anim 1, 1, 20, 0, -40, 0, -40,
+ax_anim 1, 0, 21, 0, -42, 0, -42,
+ax_anim 1, 0, 21, 0, -42, 0, -42,
+ax_anim 1, 0, 22, 0, -42, 0, -42,
+ax_anim 1, 0, 23, 0, -42, 0, -42,
+ax_anim 1, 0, 16, 0, -42, 0, -42,
+ax_anim 2, 0, 17, 0, -24, 0, -24,
+ax_anim 2, 0, 18, 0, -10, 0, -10,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_3_6:
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -8, -8, -8, -8,
+ax_anim 1, 0, 16, -22, -21, -22, -21,
+ax_anim 1, 0, 17, -44, -40, -44, -40,
+ax_anim 1, 1, 18, -46, -42, -46, -42,
+ax_anim 1, 0, 19, -46, -42, -46, -42,
+ax_anim 1, 0, 20, -46, -42, -46, -42,
+ax_anim 1, 0, 21, -46, -42, -46, -42,
+ax_anim 1, 0, 22, -46, -42, -46, -42,
+ax_anim 1, 0, 23, -46, -42, -46, -42,
+ax_anim 2, 0, 16, -28, -26, -28, -26,
+ax_anim 2, 0, 17, -12, -11, -12, -11,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_3_7:
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 16, -8, 0, -8, 0,
+ax_anim 1, 0, 17, -22, 0, -22, 0,
+ax_anim 1, 0, 18, -44, 0, -44, 0,
+ax_anim 1, 1, 19, -46, 0, -46, 0,
+ax_anim 1, 0, 20, -46, 0, -46, 0,
+ax_anim 1, 0, 21, -46, 0, -46, 0,
+ax_anim 1, 0, 22, -46, 0, -46, 0,
+ax_anim 1, 0, 23, -46, 0, -46, 0,
+ax_anim 1, 0, 16, -46, 0, -46, 0,
+ax_anim 2, 0, 17, -28, 0, -28, 0,
+ax_anim 2, 0, 18, -12, 0, -12, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_3_8:
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -8, 8, -8, 8,
+ax_anim 1, 0, 22, -22, 22, -22, 22,
+ax_anim 1, 0, 23, -42, 42, -42, 42,
+ax_anim 1, 1, 16, -46, 46, -46, 46,
+ax_anim 1, 0, 17, -46, 46, -46, 46,
+ax_anim 1, 0, 18, -46, 46, -46, 46,
+ax_anim 1, 0, 19, -46, 46, -46, 46,
+ax_anim 1, 0, 20, -46, 46, -46, 46,
+ax_anim 1, 0, 21, -46, 46, -46, 46,
+ax_anim 2, 0, 22, -28, 28, -28, 28,
+ax_anim 2, 0, 23, -12, 12, -12, 12,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_4_1:
+ax_anim 2, 0, 24, 0, 1, 0, 1,
+ax_anim 2, 2, 24, 0, 3, 0, 3,
+ax_anim 6, 0, 24, 0, 4, 0, 4,
+ax_anim 1, 1, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, -5, 0, -5,
+ax_anim 1, 0, 25, 0, -8, 0, -8,
+ax_anim 4, 0, 25, 0, -9, 0, -9,
+ax_anim 2, 0, 24, 0, -7, 0, -7,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim_terminator
+sBaltoyAnims_4_2:
+ax_anim 2, 0, 26, 1, 1, 1, 1,
+ax_anim 2, 2, 26, 3, 3, 3, 3,
+ax_anim 6, 0, 26, 4, 4, 4, 4,
+ax_anim 1, 1, 26, 4, 4, 4, 4,
+ax_anim 1, 0, 27, -5, -5, -5, -5,
+ax_anim 1, 0, 27, -8, -8, -8, -8,
+ax_anim 4, 0, 27, -9, -9, -9, -9,
+ax_anim 2, 0, 26, -7, -7, -7, -7,
+ax_anim 2, 0, 26, -4, -4, -4, -4,
+ax_anim 2, 0, 26, -2, -2, -2, -2,
+ax_anim_terminator
+sBaltoyAnims_4_3:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 3, 0, 3, 0,
+ax_anim 6, 0, 28, 4, 0, 4, 0,
+ax_anim 1, 1, 28, 4, 0, 4, 0,
+ax_anim 1, 0, 29, -5, 0, -5, 0,
+ax_anim 1, 0, 29, -8, 0, -8, 0,
+ax_anim 4, 0, 29, -9, 0, -9, 0,
+ax_anim 2, 0, 28, -7, 0, -7, 0,
+ax_anim 2, 0, 28, -4, 0, -4, 0,
+ax_anim 2, 0, 28, -2, 0, -2, 0,
+ax_anim_terminator
+sBaltoyAnims_4_4:
+ax_anim 2, 0, 30, 1, -1, 1, -1,
+ax_anim 2, 2, 30, 3, -3, 3, -3,
+ax_anim 6, 0, 30, 4, -4, 4, -4,
+ax_anim 1, 1, 30, 4, -4, 4, -4,
+ax_anim 1, 0, 31, -5, 5, -5, 5,
+ax_anim 1, 0, 31, -8, 8, -8, 8,
+ax_anim 4, 0, 31, -9, 9, -9, 9,
+ax_anim 2, 0, 30, -7, 7, -7, 7,
+ax_anim 2, 0, 30, -4, 4, -4, 4,
+ax_anim 2, 0, 30, -2, 2, -2, 2,
+ax_anim_terminator
+sBaltoyAnims_4_5:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 2, 2, 32, 0, -3, 0, -3,
+ax_anim 6, 0, 32, 0, -4, 0, -4,
+ax_anim 1, 1, 32, 0, -4, 0, -4,
+ax_anim 1, 0, 33, 0, 5, 0, 5,
+ax_anim 1, 0, 33, 0, 8, 0, 8,
+ax_anim 4, 0, 33, 0, 9, 0, 9,
+ax_anim 2, 0, 32, 0, 7, 0, 7,
+ax_anim 2, 0, 32, 0, 4, 0, 4,
+ax_anim 2, 0, 32, 0, 2, 0, 2,
+ax_anim_terminator
+sBaltoyAnims_4_6:
+ax_anim 2, 0, 34, -1, -1, -1, -1,
+ax_anim 2, 2, 34, -3, -3, -3, -3,
+ax_anim 6, 0, 34, -4, -4, -4, -4,
+ax_anim 1, 1, 34, -4, -4, -4, -4,
+ax_anim 1, 0, 35, 5, 5, 5, 5,
+ax_anim 1, 0, 35, 8, 8, 8, 8,
+ax_anim 4, 0, 35, 9, 9, 9, 9,
+ax_anim 2, 0, 34, 7, 7, 7, 7,
+ax_anim 2, 0, 34, 4, 4, 4, 4,
+ax_anim 2, 0, 34, 2, 2, 2, 2,
+ax_anim_terminator
+sBaltoyAnims_4_7:
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 2, 2, 36, -3, 0, -3, 0,
+ax_anim 6, 0, 36, -4, 0, -4, 0,
+ax_anim 1, 1, 36, -4, 0, -4, 0,
+ax_anim 1, 0, 37, 5, 0, 5, 0,
+ax_anim 1, 0, 37, 8, 0, 8, 0,
+ax_anim 4, 0, 37, 9, 0, 9, 0,
+ax_anim 2, 0, 36, 7, 0, 7, 0,
+ax_anim 2, 0, 36, 4, 0, 4, 0,
+ax_anim 2, 0, 36, 2, 0, 2, 0,
+ax_anim_terminator
+sBaltoyAnims_4_8:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 2, 2, 38, -3, 3, -3, 3,
+ax_anim 6, 0, 38, -4, 4, -4, 4,
+ax_anim 1, 1, 38, -4, 4, -4, 4,
+ax_anim 1, 0, 39, 5, -5, 5, -5,
+ax_anim 1, 0, 39, 8, -8, 8, -8,
+ax_anim 4, 0, 39, 9, -9, 9, -9,
+ax_anim 2, 0, 38, 7, -7, 7, -7,
+ax_anim 2, 0, 38, 4, -4, 4, -4,
+ax_anim 2, 0, 38, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_5_1:
+ax_anim 3, 0, 40, 0, -2, 0, 0,
+ax_anim 3, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 41, 0, -5, 0, 0,
+ax_anim 2, 0, 41, 1, -5, 1, 0,
+ax_anim 2, 2, 41, 0, -5, 0, 0,
+ax_anim 2, 0, 41, 1, -5, 1, 0,
+ax_anim 2, 0, 41, 0, -5, 0, 0,
+ax_anim 2, 0, 41, 1, -5, 1, 0,
+ax_anim 2, 0, 41, 0, -5, 0, 0,
+ax_anim 4, 0, 41, 1, -5, 1, 0,
+ax_anim 2, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 41, 0, -2, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_5_2:
+ax_anim 3, 0, 42, 0, -2, 0, 0,
+ax_anim 3, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 43, 0, -5, 0, 0,
+ax_anim 2, 0, 43, 1, -6, 1, -1,
+ax_anim 2, 2, 43, 0, -5, 0, 0,
+ax_anim 2, 0, 43, 1, -6, 1, -1,
+ax_anim 2, 0, 43, 0, -5, 0, 0,
+ax_anim 2, 0, 43, 1, -6, 1, -1,
+ax_anim 2, 0, 43, 0, -5, 0, 0,
+ax_anim 4, 0, 43, 1, -6, 1, -1,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 43, 0, -2, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_5_3:
+ax_anim 3, 0, 44, 0, -2, 0, 0,
+ax_anim 3, 0, 45, 0, -4, 0, 0,
+ax_anim 2, 0, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 45, 0, -6, 0, -1,
+ax_anim 2, 2, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 45, 0, -6, 0, -1,
+ax_anim 2, 0, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 45, 0, -6, 0, -1,
+ax_anim 2, 0, 45, 0, -5, 0, 0,
+ax_anim 4, 0, 45, 0, -6, 0, -1,
+ax_anim 2, 0, 45, 0, -4, 0, 0,
+ax_anim 2, 0, 45, 0, -2, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_5_4:
+ax_anim 3, 0, 46, 0, -2, 0, 0,
+ax_anim 3, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 47, 0, -5, 0, 0,
+ax_anim 2, 0, 47, -1, -6, -1, -1,
+ax_anim 2, 2, 47, 0, -5, 0, 0,
+ax_anim 2, 0, 47, -1, -6, -1, -1,
+ax_anim 2, 0, 47, 0, -5, 0, 0,
+ax_anim 2, 0, 47, -1, -6, -1, -1,
+ax_anim 2, 0, 47, 0, -5, 0, 0,
+ax_anim 4, 0, 47, -1, -6, -1, -1,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 47, 0, -2, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_5_5:
+ax_anim 3, 0, 48, 0, -2, 0, 0,
+ax_anim 3, 0, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 2, 0, 49, 1, -5, 1, 0,
+ax_anim 2, 2, 49, 0, -5, 0, 0,
+ax_anim 2, 0, 49, 1, -5, 1, 0,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 2, 0, 49, 1, -5, 1, 0,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 4, 0, 49, 1, -5, 1, 0,
+ax_anim 2, 0, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_5_6:
+ax_anim 3, 0, 50, 0, -2, 0, 0,
+ax_anim 3, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 51, 1, -6, 1, -1,
+ax_anim 2, 2, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 51, 1, -6, 1, -1,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 51, 1, -6, 1, -1,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 1, -6, 1, -1,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -2, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_5_7:
+ax_anim 3, 0, 52, 0, -2, 0, 0,
+ax_anim 3, 0, 53, 0, -4, 0, 0,
+ax_anim 2, 0, 53, 0, -5, 0, 0,
+ax_anim 2, 0, 53, 0, -6, 0, -1,
+ax_anim 2, 2, 53, 0, -5, 0, 0,
+ax_anim 2, 0, 53, 0, -6, 0, -1,
+ax_anim 2, 0, 53, 0, -5, 0, 0,
+ax_anim 2, 0, 53, 0, -6, 0, -1,
+ax_anim 2, 0, 53, 0, -5, 0, 0,
+ax_anim 4, 0, 53, 0, -6, 0, -1,
+ax_anim 2, 0, 53, 0, -4, 0, 0,
+ax_anim 2, 0, 53, 0, -2, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_5_8:
+ax_anim 3, 0, 54, 0, -2, 0, 0,
+ax_anim 3, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 55, 0, -5, 0, 0,
+ax_anim 2, 0, 55, -1, -6, -1, -1,
+ax_anim 2, 2, 55, 0, -5, 0, 0,
+ax_anim 2, 0, 55, -1, -6, -1, -1,
+ax_anim 2, 0, 55, 0, -5, 0, 0,
+ax_anim 2, 0, 55, -1, -6, -1, -1,
+ax_anim 2, 0, 55, 0, -5, 0, 0,
+ax_anim 4, 0, 55, -1, -6, -1, -1,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 55, 0, -2, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_6_1:
+ax_anim 8, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 1, 1, 0, 0,
+ax_anim 16, 0, 56, 2, 2, 0, 0,
+ax_anim 8, 0, 58, 2, 2, 0, 0,
+ax_anim 8, 0, 57, 1, 1, 0, 0,
+ax_anim 8, 0, 57, 0, 0, 0, 0,
+ax_anim 8, 0, 57, -1, -1, 0, 0,
+ax_anim 16, 0, 57, -2, -2, 0, 0,
+ax_anim 8, 0, 58, -2, -2, 0, 0,
+ax_anim 8, 0, 56, -1, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_7_1:
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 8, 0, 59, 0, -3, 0, -3,
+ax_anim_terminator
+sBaltoyAnims_7_2:
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 8, 0, 60, -3, -3, -3, -3,
+ax_anim_terminator
+sBaltoyAnims_7_3:
+ax_anim 2, 0, 61, -2, 0, -2, 0,
+ax_anim 8, 0, 61, -3, 0, -3, 0,
+ax_anim_terminator
+sBaltoyAnims_7_4:
+ax_anim 2, 0, 62, -2, 2, -2, 2,
+ax_anim 8, 0, 62, -3, 3, -3, 3,
+ax_anim_terminator
+sBaltoyAnims_7_5:
+ax_anim 2, 0, 63, 0, 2, 0, 2,
+ax_anim 8, 0, 63, 0, 3, 0, 3,
+ax_anim_terminator
+sBaltoyAnims_7_6:
+ax_anim 2, 0, 64, 2, 2, 2, 2,
+ax_anim 8, 0, 64, 3, 3, 3, 3,
+ax_anim_terminator
+sBaltoyAnims_7_7:
+ax_anim 2, 0, 65, 2, 0, 2, 0,
+ax_anim 8, 0, 65, 3, 0, 3, 0,
+ax_anim_terminator
+sBaltoyAnims_7_8:
+ax_anim 2, 0, 66, 2, -2, 2, -2,
+ax_anim 8, 0, 66, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_8_1:
+ax_anim 8, 0, 67, 0, 0, 0, 0,
+ax_anim 8, 0, 67, 0, -1, 0, 0,
+ax_anim 8, 0, 67, 0, -2, 0, 0,
+ax_anim 8, 0, 67, 0, -3, 0, 0,
+ax_anim 8, 0, 67, 0, -2, 0, 0,
+ax_anim 8, 0, 67, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_8_2:
+ax_anim 8, 0, 74, 0, 0, 0, 0,
+ax_anim 8, 0, 74, 0, -1, 0, 0,
+ax_anim 8, 0, 74, 0, -2, 0, 0,
+ax_anim 8, 0, 74, 0, -3, 0, 0,
+ax_anim 8, 0, 74, 0, -2, 0, 0,
+ax_anim 8, 0, 74, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_8_3:
+ax_anim 8, 0, 73, 0, 0, 0, 0,
+ax_anim 8, 0, 73, 0, -1, 0, 0,
+ax_anim 8, 0, 73, 0, -2, 0, 0,
+ax_anim 8, 0, 73, 0, -3, 0, 0,
+ax_anim 8, 0, 73, 0, -2, 0, 0,
+ax_anim 8, 0, 73, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_8_4:
+ax_anim 8, 0, 72, 0, 0, 0, 0,
+ax_anim 8, 0, 72, 0, -1, 0, 0,
+ax_anim 8, 0, 72, 0, -2, 0, 0,
+ax_anim 8, 0, 72, 0, -3, 0, 0,
+ax_anim 8, 0, 72, 0, -2, 0, 0,
+ax_anim 8, 0, 72, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_8_5:
+ax_anim 8, 0, 71, 0, 0, 0, 0,
+ax_anim 8, 0, 71, 0, -1, 0, 0,
+ax_anim 8, 0, 71, 0, -2, 0, 0,
+ax_anim 8, 0, 71, 0, -3, 0, 0,
+ax_anim 8, 0, 71, 0, -2, 0, 0,
+ax_anim 8, 0, 71, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_8_6:
+ax_anim 8, 0, 70, 0, 0, 0, 0,
+ax_anim 8, 0, 70, 0, -1, 0, 0,
+ax_anim 8, 0, 70, 0, -2, 0, 0,
+ax_anim 8, 0, 70, 0, -3, 0, 0,
+ax_anim 8, 0, 70, 0, -2, 0, 0,
+ax_anim 8, 0, 70, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_8_7:
+ax_anim 8, 0, 69, 0, 0, 0, 0,
+ax_anim 8, 0, 69, 0, -1, 0, 0,
+ax_anim 8, 0, 69, 0, -2, 0, 0,
+ax_anim 8, 0, 69, 0, -3, 0, 0,
+ax_anim 8, 0, 69, 0, -2, 0, 0,
+ax_anim 8, 0, 69, 0, -1, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_8_8:
+ax_anim 8, 0, 68, 0, 0, 0, 0,
+ax_anim 8, 0, 68, 0, -1, 0, 0,
+ax_anim 8, 0, 68, 0, -2, 0, 0,
+ax_anim 8, 0, 68, 0, -3, 0, 0,
+ax_anim 8, 0, 68, 0, -2, 0, 0,
+ax_anim 8, 0, 68, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_9_1:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 8, 5, 8, 5,
+ax_anim 2, 0, 77, 11, 13, 11, 13,
+ax_anim 2, 0, 78, 9, 20, 9, 19,
+ax_anim 3, 0, 79, 0, 25, 0, 23,
+ax_anim 2, 3, 80, -9, 20, -9, 19,
+ax_anim 2, 0, 81, -11, 13, -11, 13,
+ax_anim 1, 0, 82, -8, 5, -8, 5,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_9_2:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 11, 2, 11, 2,
+ax_anim 2, 0, 76, 19, 8, 19, 8,
+ax_anim 2, 0, 77, 25, 17, 25, 17,
+ax_anim 3, 0, 78, 24, 24, 24, 22,
+ax_anim 2, 3, 79, 12, 25, 12, 24,
+ax_anim 2, 0, 80, 3, 19, 3, 19,
+ax_anim 1, 0, 81, -1, 11, -1, 11,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_9_3:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 4, -4, 4, -4,
+ax_anim 2, 0, 75, 11, -5, 11, -5,
+ax_anim 2, 0, 76, 16, -5, 16, -5,
+ax_anim 3, 0, 77, 23, 2, 23, 2,
+ax_anim 2, 3, 78, 19, 6, 19, 6,
+ax_anim 2, 0, 79, 11, 7, 11, 7,
+ax_anim 1, 0, 80, 6, 5, 6, 5,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_9_4:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 81, -1, -6, -1, -6,
+ax_anim 2, 0, 82, 5, -16, 5, -16,
+ax_anim 2, 0, 75, 13, -19, 13, -19,
+ax_anim 3, 0, 76, 23, -19, 23, -19,
+ax_anim 2, 3, 77, 25, -11, 25, -11,
+ax_anim 2, 0, 78, 20, -5, 20, -5,
+ax_anim 1, 0, 79, 13, -1, 13, -1,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_9_5:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 80, -10, -3, -10, -3,
+ax_anim 2, 0, 81, -11, -10, -11, -10,
+ax_anim 2, 0, 82, -8, -17, -8, -17,
+ax_anim 3, 0, 75, 0, -19, 0, -19,
+ax_anim 2, 3, 76, 8, -17, 8, -17,
+ax_anim 2, 0, 77, 11, -10, 11, -10,
+ax_anim 1, 0, 78, 10, -3, 10, -3,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_9_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 1, -6, 1, -6,
+ax_anim 2, 0, 76, -5, -16, -5, -16,
+ax_anim 2, 0, 75, -13, -19, -13, -19,
+ax_anim 3, 0, 82, -23, -19, -23, -19,
+ax_anim 2, 3, 81, -25, -11, -25, -11,
+ax_anim 2, 0, 80, -20, -5, -20, -5,
+ax_anim 1, 0, 79, -13, -1, -13, -1,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_9_7:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 76, -4, -4, -4, -4,
+ax_anim 2, 0, 75, -11, -5, -11, -5,
+ax_anim 2, 0, 82, -16, -5, -16, -5,
+ax_anim 3, 0, 81, -23, 2, -23, 2,
+ax_anim 2, 3, 80, -19, 6, -19, 6,
+ax_anim 2, 0, 79, -11, 7, -11, 7,
+ax_anim 1, 0, 78, -6, 5, -6, 5,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_9_8:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 75, -11, 2, -11, 2,
+ax_anim 2, 0, 82, -19, 8, -19, 8,
+ax_anim 2, 0, 81, -25, 17, -25, 17,
+ax_anim 3, 0, 80, -24, 24, -24, 22,
+ax_anim 2, 3, 79, -12, 25, -12, 24,
+ax_anim 2, 0, 78, -3, 19, -3, 19,
+ax_anim 1, 0, 77, 1, 11, 1, 11,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_10_1:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 6, 0, 6, 0,
+ax_anim 2, 0, 83, -6, 0, -6, 0,
+ax_anim 2, 0, 83, 10, 0, 10, 0,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, 12, 0, 12, 0,
+ax_anim 3, 0, 83, -12, 0, -12, 0,
+ax_anim 3, 0, 83, 13, 0, 13, 0,
+ax_anim 3, 0, 83, -13, 0, -13, 0,
+ax_anim 2, 0, 83, 12, 0, 12, 0,
+ax_anim 3, 0, 83, -12, 0, -12, 0,
+ax_anim 2, 0, 83, 10, 0, 10, 0,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, 6, 0, 6, 0,
+ax_anim 2, 0, 83, -6, 0, -6, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_10_2:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 6, -6, 6, -6,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim 2, 0, 84, 10, -10, 10, -10,
+ax_anim 2, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 84, 12, -12, 12, -12,
+ax_anim 3, 0, 84, -12, 12, -12, 12,
+ax_anim 3, 0, 84, 13, -13, 13, -13,
+ax_anim 3, 0, 84, -13, 13, -13, 13,
+ax_anim 2, 0, 84, 12, -12, 12, -12,
+ax_anim 3, 0, 84, -12, 12, -12, 12,
+ax_anim 2, 0, 84, 10, -10, 10, -10,
+ax_anim 2, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 84, 6, -6, 6, -6,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_10_3:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, -6,
+ax_anim 2, 0, 85, 0, 6, 0, 6,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 85, 0, 10, 0, 10,
+ax_anim 2, 0, 85, 0, -12, 0, -12,
+ax_anim 3, 0, 85, 0, 12, 0, 12,
+ax_anim 3, 0, 85, 0, -13, 0, -13,
+ax_anim 3, 0, 85, 0, 13, 0, 13,
+ax_anim 2, 0, 85, 0, -12, 0, -12,
+ax_anim 3, 0, 85, 0, 12, 0, 12,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 85, 0, 10, 0, 10,
+ax_anim 2, 0, 85, 0, -6, 0, -6,
+ax_anim 2, 0, 85, 0, 6, 0, 6,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_10_4:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -6, -6, -6, -6,
+ax_anim 2, 0, 86, 6, 6, 6, 6,
+ax_anim 2, 0, 86, -10, -10, -10, -10,
+ax_anim 2, 0, 86, 10, 10, 10, 10,
+ax_anim 2, 0, 86, -12, -12, -12, -12,
+ax_anim 3, 0, 86, 12, 12, 12, 12,
+ax_anim 3, 0, 86, -13, -13, -13, -13,
+ax_anim 3, 0, 86, 13, 13, 13, 13,
+ax_anim 2, 0, 86, -12, -12, -12, -12,
+ax_anim 3, 0, 86, 12, 12, 12, 12,
+ax_anim 2, 0, 86, -10, -10, -10, -10,
+ax_anim 2, 0, 86, 10, 10, 10, 10,
+ax_anim 2, 0, 86, -6, -6, -6, -6,
+ax_anim 2, 0, 86, 6, 6, 6, 6,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_10_5:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 6, 0, 6, 0,
+ax_anim 2, 0, 87, -6, 0, -6, 0,
+ax_anim 2, 0, 87, 10, 0, 10, 0,
+ax_anim 2, 0, 87, -10, 0, -10, 0,
+ax_anim 2, 0, 87, 12, 0, 12, 0,
+ax_anim 3, 0, 87, -12, 0, -12, 0,
+ax_anim 3, 0, 87, 13, 0, 13, 0,
+ax_anim 3, 0, 87, -13, 0, -13, 0,
+ax_anim 2, 0, 87, 12, 0, 12, 0,
+ax_anim 3, 0, 87, -12, 0, -12, 0,
+ax_anim 2, 0, 87, 10, 0, 10, 0,
+ax_anim 2, 0, 87, -10, 0, -10, 0,
+ax_anim 2, 0, 87, 6, 0, 6, 0,
+ax_anim 2, 0, 87, -6, 0, -6, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_10_6:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 6, -6, 6, -6,
+ax_anim 2, 0, 88, -6, 6, -6, 6,
+ax_anim 2, 0, 88, 10, -10, 10, -10,
+ax_anim 2, 0, 88, -10, 10, -10, 10,
+ax_anim 2, 0, 88, 12, -12, 12, -12,
+ax_anim 3, 0, 88, -12, 12, -12, 12,
+ax_anim 3, 0, 88, 13, -13, 13, -13,
+ax_anim 3, 0, 88, -13, 13, -13, 13,
+ax_anim 2, 0, 88, 12, -12, 12, -12,
+ax_anim 3, 0, 88, -12, 12, -12, 12,
+ax_anim 2, 0, 88, 10, -10, 10, -10,
+ax_anim 2, 0, 88, -10, 10, -10, 10,
+ax_anim 2, 0, 88, 6, -6, 6, -6,
+ax_anim 2, 0, 88, -6, 6, -6, 6,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_10_7:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -6, 0, -6,
+ax_anim 2, 0, 89, 0, 6, 0, 6,
+ax_anim 2, 0, 89, 0, -10, 0, -10,
+ax_anim 2, 0, 89, 0, 10, 0, 10,
+ax_anim 2, 0, 89, 0, -12, 0, -12,
+ax_anim 3, 0, 89, 0, 12, 0, 12,
+ax_anim 3, 0, 89, 0, -13, 0, -13,
+ax_anim 3, 0, 89, 0, 13, 0, 13,
+ax_anim 2, 0, 89, 0, -12, 0, -12,
+ax_anim 3, 0, 89, 0, 12, 0, 12,
+ax_anim 2, 0, 89, 0, -10, 0, -10,
+ax_anim 2, 0, 89, 0, 10, 0, 10,
+ax_anim 2, 0, 89, 0, -6, 0, -6,
+ax_anim 2, 0, 89, 0, 6, 0, 6,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_10_8:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -6, -6, -6, -6,
+ax_anim 2, 0, 90, 6, 6, 6, 6,
+ax_anim 2, 0, 90, -10, -10, -10, -10,
+ax_anim 2, 0, 90, 10, 10, 10, 10,
+ax_anim 2, 0, 90, -12, -12, -12, -12,
+ax_anim 3, 0, 90, 12, 12, 12, 12,
+ax_anim 3, 0, 90, -13, -13, -13, -13,
+ax_anim 3, 0, 90, 13, 13, 13, 13,
+ax_anim 2, 0, 90, -12, -12, -12, -12,
+ax_anim 3, 0, 90, 12, 12, 12, 12,
+ax_anim 2, 0, 90, -10, -10, -10, -10,
+ax_anim 2, 0, 90, 10, 10, 10, 10,
+ax_anim 2, 0, 90, -6, -6, -6, -6,
+ax_anim 2, 0, 90, 6, 6, 6, 6,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_11_1:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -10, 0, 0,
+ax_anim 2, 0, 92, 0, -16, 0, 0,
+ax_anim 3, 0, 92, 0, -20, 0, 0,
+ax_anim 4, 0, 92, 0, -21, 0, 0,
+ax_anim 4, 0, 91, 0, -22, 0, 0,
+ax_anim 3, 0, 91, 0, -21, 0, 0,
+ax_anim 2, 0, 91, 0, -18, 0, 0,
+ax_anim 1, 0, 91, 0, -12, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_11_2:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -10, 0, 0,
+ax_anim 2, 0, 94, 0, -16, 0, 0,
+ax_anim 3, 0, 94, 0, -20, 0, 0,
+ax_anim 4, 0, 94, 0, -21, 0, 0,
+ax_anim 4, 0, 93, 0, -22, 0, 0,
+ax_anim 3, 0, 93, 0, -21, 0, 0,
+ax_anim 2, 0, 93, 0, -18, 0, 0,
+ax_anim 1, 0, 93, 0, -12, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_11_3:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -10, 0, 0,
+ax_anim 2, 0, 96, 0, -16, 0, 0,
+ax_anim 3, 0, 96, 0, -20, 0, 0,
+ax_anim 4, 0, 96, 0, -21, 0, 0,
+ax_anim 4, 0, 95, 0, -22, 0, 0,
+ax_anim 3, 0, 95, 0, -21, 0, 0,
+ax_anim 2, 0, 95, 0, -18, 0, 0,
+ax_anim 1, 0, 95, 0, -12, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_11_4:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -10, 0, 0,
+ax_anim 2, 0, 98, 0, -16, 0, 0,
+ax_anim 3, 0, 98, 0, -20, 0, 0,
+ax_anim 4, 0, 98, 0, -21, 0, 0,
+ax_anim 4, 0, 97, 0, -21, 0, 0,
+ax_anim 3, 0, 97, 0, -20, 0, 0,
+ax_anim 2, 0, 97, 0, -17, 0, 0,
+ax_anim 1, 0, 97, 0, -11, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_11_5:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, -10, 0, 0,
+ax_anim 2, 0, 100, 0, -16, 0, 0,
+ax_anim 3, 0, 100, 0, -20, 0, 0,
+ax_anim 4, 0, 100, 0, -21, 0, 0,
+ax_anim 4, 0, 99, 0, -19, 0, 0,
+ax_anim 3, 0, 99, 0, -18, 0, 0,
+ax_anim 2, 0, 99, 0, -16, 0, 0,
+ax_anim 1, 0, 99, 0, -11, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_11_6:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -10, 0, 0,
+ax_anim 2, 0, 102, 0, -16, 0, 0,
+ax_anim 3, 0, 102, 0, -20, 0, 0,
+ax_anim 4, 0, 102, 0, -21, 0, 0,
+ax_anim 4, 0, 101, 0, -21, 0, 0,
+ax_anim 3, 0, 101, 0, -20, 0, 0,
+ax_anim 2, 0, 101, 0, -17, 0, 0,
+ax_anim 1, 0, 101, 0, -11, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_11_7:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -10, 0, 0,
+ax_anim 2, 0, 104, 0, -16, 0, 0,
+ax_anim 3, 0, 104, 0, -20, 0, 0,
+ax_anim 4, 0, 104, 0, -21, 0, 0,
+ax_anim 4, 0, 103, 0, -22, 0, 0,
+ax_anim 3, 0, 103, 0, -21, 0, 0,
+ax_anim 2, 0, 103, 0, -18, 0, 0,
+ax_anim 1, 0, 103, 0, -12, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_11_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, -10, 0, 0,
+ax_anim 2, 0, 106, 0, -16, 0, 0,
+ax_anim 3, 0, 106, 0, -20, 0, 0,
+ax_anim 4, 0, 106, 0, -21, 0, 0,
+ax_anim 4, 0, 105, 0, -22, 0, 0,
+ax_anim 3, 0, 105, 0, -21, 0, 0,
+ax_anim 2, 0, 105, 0, -18, 0, 0,
+ax_anim 1, 0, 105, 0, -12, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_12_1:
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_12_2:
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_12_3:
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_12_4:
+ax_anim 2, 0, 112, -1, -1, -1, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, -1, -1, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, -1, -1, -1,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, -1, -1, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, -1, -1, -1,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_12_5:
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_12_6:
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_12_7:
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_12_8:
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBaltoyAnims_13_1:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_13_2:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_13_3:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_13_4:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_13_5:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_13_6:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_13_7:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyAnims_13_8:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sBaltoyGfx1:
+.incbin "baserom.gba", 0x1400230, 0x200
+sBaltoySprites1:
+ax_sprite sBaltoyGfx1, 0x200
+ax_sprite_terminator
+sBaltoyGfx2:
+.incbin "baserom.gba", 0x1400440, 0x200
+sBaltoySprites2:
+ax_sprite sBaltoyGfx2, 0x200
+ax_sprite_terminator
+sBaltoyGfx3:
+.incbin "baserom.gba", 0x1400650, 0x100
+sBaltoySprites3:
+ax_sprite sBaltoyGfx3, 0x100
+ax_sprite_terminator
+sBaltoyGfx4:
+.incbin "baserom.gba", 0x1400760, 0x200
+sBaltoySprites4:
+ax_sprite sBaltoyGfx4, 0x200
+ax_sprite_terminator
+sBaltoyGfx5:
+.incbin "baserom.gba", 0x1400970, 0x200
+sBaltoySprites5:
+ax_sprite sBaltoyGfx5, 0x200
+ax_sprite_terminator
+sBaltoyGfx6:
+.incbin "baserom.gba", 0x1400B80, 0x40
+sBaltoyGfx6_1:
+.incbin "baserom.gba", 0x1400BC0, 0x60
+sBaltoyGfx6_2:
+.incbin "baserom.gba", 0x1400C20, 0x60
+sBaltoySprites6:
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx6, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx6_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx6_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBaltoyGfx7:
+.incbin "baserom.gba", 0x1400CC0, 0x40
+sBaltoyGfx7_1:
+.incbin "baserom.gba", 0x1400D00, 0x60
+sBaltoyGfx7_2:
+.incbin "baserom.gba", 0x1400D60, 0x60
+sBaltoySprites7:
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx7, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx7_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx7_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBaltoyGfx8:
+.incbin "baserom.gba", 0x1400E00, 0xC0
+sBaltoySprites8:
+ax_sprite sBaltoyGfx8, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBaltoyGfx9:
+.incbin "baserom.gba", 0x1400ED8, 0x40
+sBaltoySprites9:
+ax_sprite sBaltoyGfx9, 0x40
+ax_sprite_terminator
+sBaltoyGfx10:
+.incbin "baserom.gba", 0x1400F28, 0x40
+sBaltoyGfx10_1:
+.incbin "baserom.gba", 0x1400F68, 0x60
+sBaltoyGfx10_2:
+.incbin "baserom.gba", 0x1400FC8, 0x40
+sBaltoySprites10:
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx10, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx10_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBaltoyGfx10_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBaltoyGfx11:
+.incbin "baserom.gba", 0x1401048, 0x80
+sBaltoyGfx11_1:
+.incbin "baserom.gba", 0x14010C8, 0x40
+sBaltoySprites11:
+ax_sprite sBaltoyGfx11, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx11_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBaltoyGfx12:
+.incbin "baserom.gba", 0x1401130, 0x40
+sBaltoyGfx12_1:
+.incbin "baserom.gba", 0x1401170, 0x100
+sBaltoySprites12:
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx12, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx12_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBaltoyGfx13:
+.incbin "baserom.gba", 0x14012A0, 0x40
+sBaltoyGfx13_1:
+.incbin "baserom.gba", 0x14012E0, 0x60
+sBaltoyGfx13_2:
+.incbin "baserom.gba", 0x1401340, 0x60
+sBaltoySprites13:
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx13, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx13_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx13_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBaltoyGfx14:
+.incbin "baserom.gba", 0x14013E0, 0xC0
+sBaltoyGfx14_1:
+.incbin "baserom.gba", 0x14014A0, 0x20
+sBaltoySprites14:
+ax_sprite sBaltoyGfx14, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx14_1, 0x20
+ax_sprite_terminator
+sBaltoyGfx15:
+.incbin "baserom.gba", 0x14014E0, 0x40
+sBaltoyGfx15_1:
+.incbin "baserom.gba", 0x1401520, 0x40
+sBaltoyGfx15_2:
+.incbin "baserom.gba", 0x1401560, 0x60
+sBaltoySprites15:
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx15, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBaltoyGfx15_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBaltoyGfx15_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBaltoyGfx16:
+.incbin "baserom.gba", 0x1401600, 0x100
+sBaltoySprites16:
+ax_sprite sBaltoyGfx16, 0x100
+ax_sprite_terminator
+sBaltoyGfx17:
+.incbin "baserom.gba", 0x1401710, 0x200
+sBaltoySprites17:
+ax_sprite sBaltoyGfx17, 0x200
+ax_sprite_terminator
+sBaltoyGfx18:
+.incbin "baserom.gba", 0x1401920, 0x200
+sBaltoySprites18:
+ax_sprite sBaltoyGfx18, 0x200
+ax_sprite_terminator
+sBaltoyGfx19:
+.incbin "baserom.gba", 0x1401B30, 0x200
+sBaltoySprites19:
+ax_sprite sBaltoyGfx19, 0x200
+ax_sprite_terminator
+sBaltoyGfx20:
+.incbin "baserom.gba", 0x1401D40, 0x200
+sBaltoySprites20:
+ax_sprite sBaltoyGfx20, 0x200
+ax_sprite_terminator
+sBaltoyGfx21:
+.incbin "baserom.gba", 0x1401F50, 0x200
+sBaltoySprites21:
+ax_sprite sBaltoyGfx21, 0x200
+ax_sprite_terminator
+sBaltoyGfx22:
+.incbin "baserom.gba", 0x1402160, 0x200
+sBaltoySprites22:
+ax_sprite sBaltoyGfx22, 0x200
+ax_sprite_terminator
+sBaltoyGfx23:
+.incbin "baserom.gba", 0x1402370, 0x200
+sBaltoySprites23:
+ax_sprite sBaltoyGfx23, 0x200
+ax_sprite_terminator
+sAxPosesBaltoy:
+.4byte sBaltoyPose1
+.4byte sBaltoyPose2
+.4byte sBaltoyPose3
+.4byte sBaltoyPose4
+.4byte sBaltoyPose5
+.4byte sBaltoyPose6
+.4byte sBaltoyPose7
+.4byte sBaltoyPose8
+.4byte sBaltoyPose9
+.4byte sBaltoyPose10
+.4byte sBaltoyPose11
+.4byte sBaltoyPose12
+.4byte sBaltoyPose13
+.4byte sBaltoyPose14
+.4byte sBaltoyPose15
+.4byte sBaltoyPose16
+.4byte sBaltoyPose17
+.4byte sBaltoyPose18
+.4byte sBaltoyPose19
+.4byte sBaltoyPose20
+.4byte sBaltoyPose21
+.4byte sBaltoyPose22
+.4byte sBaltoyPose23
+.4byte sBaltoyPose24
+.4byte sBaltoyPose25
+.4byte sBaltoyPose26
+.4byte sBaltoyPose27
+.4byte sBaltoyPose28
+.4byte sBaltoyPose29
+.4byte sBaltoyPose30
+.4byte sBaltoyPose31
+.4byte sBaltoyPose32
+.4byte sBaltoyPose33
+.4byte sBaltoyPose34
+.4byte sBaltoyPose35
+.4byte sBaltoyPose36
+.4byte sBaltoyPose37
+.4byte sBaltoyPose38
+.4byte sBaltoyPose39
+.4byte sBaltoyPose40
+.4byte sBaltoyPose41
+.4byte sBaltoyPose42
+.4byte sBaltoyPose43
+.4byte sBaltoyPose44
+.4byte sBaltoyPose45
+.4byte sBaltoyPose46
+.4byte sBaltoyPose47
+.4byte sBaltoyPose48
+.4byte sBaltoyPose49
+.4byte sBaltoyPose50
+.4byte sBaltoyPose51
+.4byte sBaltoyPose52
+.4byte sBaltoyPose53
+.4byte sBaltoyPose54
+.4byte sBaltoyPose55
+.4byte sBaltoyPose56
+.4byte sBaltoyPose57
+.4byte sBaltoyPose58
+.4byte sBaltoyPose59
+.4byte sBaltoyPose60
+.4byte sBaltoyPose61
+.4byte sBaltoyPose62
+.4byte sBaltoyPose63
+.4byte sBaltoyPose64
+.4byte sBaltoyPose65
+.4byte sBaltoyPose66
+.4byte sBaltoyPose67
+.4byte sBaltoyPose68
+.4byte sBaltoyPose69
+.4byte sBaltoyPose70
+.4byte sBaltoyPose71
+.4byte sBaltoyPose72
+.4byte sBaltoyPose73
+.4byte sBaltoyPose74
+.4byte sBaltoyPose75
+.4byte sBaltoyPose76
+.4byte sBaltoyPose77
+.4byte sBaltoyPose78
+.4byte sBaltoyPose79
+.4byte sBaltoyPose80
+.4byte sBaltoyPose81
+.4byte sBaltoyPose82
+.4byte sBaltoyPose83
+.4byte sBaltoyPose84
+.4byte sBaltoyPose85
+.4byte sBaltoyPose86
+.4byte sBaltoyPose87
+.4byte sBaltoyPose88
+.4byte sBaltoyPose89
+.4byte sBaltoyPose90
+.4byte sBaltoyPose91
+.4byte sBaltoyPose92
+.4byte sBaltoyPose93
+.4byte sBaltoyPose94
+.4byte sBaltoyPose95
+.4byte sBaltoyPose96
+.4byte sBaltoyPose97
+.4byte sBaltoyPose98
+.4byte sBaltoyPose99
+.4byte sBaltoyPose100
+.4byte sBaltoyPose101
+.4byte sBaltoyPose102
+.4byte sBaltoyPose103
+.4byte sBaltoyPose104
+.4byte sBaltoyPose105
+.4byte sBaltoyPose106
+.4byte sBaltoyPose107
+.4byte sBaltoyPose108
+.4byte sBaltoyPose109
+.4byte sBaltoyPose110
+.4byte sBaltoyPose111
+.4byte sBaltoyPose112
+.4byte sBaltoyPose113
+.4byte sBaltoyPose114
+.4byte sBaltoyPose115
+.4byte sBaltoyPose116
+.4byte sBaltoyPose117
+.4byte sBaltoyPose118
+.4byte sBaltoyPose119
+.4byte sBaltoyPose120
+.4byte sBaltoyPose121
+.4byte sBaltoyPose122
+.4byte sBaltoyPose123
+sAxPositionsBaltoy:
+.2byte   -1,   -9, 	 -11,   -6, 	   9,   -6, 	  -1,   -7
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -5,  -10, 	  -2,   -5, 	   0,   -2, 	  -1,   -7
+.2byte   -2,  -11, 	   7,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -9
+.2byte    0,  -11, 	  -9,   -8, 	   7,   -3, 	  -1,   -7
+.2byte    3,  -10, 	   0,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    1,   -9, 	   6,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,   -9, 	 -11,   -6, 	   9,   -6, 	  -1,   -7
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -5,  -10, 	  -2,   -5, 	   0,   -2, 	  -1,   -7
+.2byte   -2,  -11, 	   7,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -9
+.2byte    0,  -11, 	  -9,   -8, 	   7,   -3, 	  -1,   -7
+.2byte    3,  -10, 	   0,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    1,   -9, 	   6,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,   -9, 	 -11,   -6, 	   9,   -6, 	  -1,   -7
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -5,  -10, 	  -2,   -5, 	   0,   -2, 	  -1,   -7
+.2byte   -2,  -11, 	   7,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -9
+.2byte    0,  -11, 	  -9,   -8, 	   7,   -3, 	  -1,   -7
+.2byte    3,  -10, 	   0,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    1,   -9, 	   6,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,   -9, 	 -11,   -6, 	   9,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte    1,   -9, 	   6,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte    1,  -12, 	   7,   -8, 	  -6,   -3, 	  -1,   -8
+.2byte    3,  -10, 	   0,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte   -1,  -11, 	   4,  -15, 	   3,   -9, 	  -3,   -8
+.2byte    0,  -11, 	  -9,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	  -4,  -17, 	   7,  -11, 	  -4,   -6
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   9,  -13, 	 -10,  -13, 	  -1,   -8
+.2byte   -2,  -11, 	   7,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   2,  -17, 	  -9,  -11, 	   2,   -6
+.2byte   -5,  -10, 	  -2,   -5, 	   0,   -2, 	  -1,   -7
+.2byte   -1,  -11, 	  -6,  -15, 	  -5,   -9, 	   1,   -8
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -3,  -12, 	  -9,   -8, 	   4,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -11,   -6, 	   9,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	 -11,   -6, 	   9,   -6, 	  -1,   -8
+.2byte    1,   -9, 	   6,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte    0,  -12, 	   5,   -8, 	  -9,   -2, 	  -2,   -7
+.2byte    3,  -10, 	   0,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    0,  -12, 	  -1,   -7, 	  -3,    0, 	  -3,   -7
+.2byte    0,  -11, 	  -9,   -8, 	   7,   -3, 	  -1,   -7
+.2byte    0,  -12, 	  -9,   -6, 	   6,   -1, 	  -2,   -6
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	  10,   -6, 	 -11,   -7, 	  -1,   -8
+.2byte   -2,  -11, 	   7,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -2,  -12, 	   7,   -6, 	  -8,   -1, 	   0,   -6
+.2byte   -5,  -10, 	  -2,   -5, 	   0,   -2, 	  -1,   -7
+.2byte   -2,  -12, 	  -1,   -7, 	   1,    0, 	   1,   -7
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -2,  -12, 	  -7,   -8, 	   7,   -2, 	   0,   -7
+.2byte   -2,  -10, 	  -7,   -9, 	   8,   -2, 	   0,   -8
+.2byte   -6,  -11, 	  -9,   -7, 	   5,  -10, 	  -3,   -9
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -1,   -9, 	  -8,  -11, 	   6,  -11, 	  -1,   -7
+.2byte    1,  -10, 	   4,  -15, 	  -7,  -10, 	  -1,   -7
+.2byte    3,  -10, 	  -4,  -12, 	  -2,   -9, 	  -2,   -7
+.2byte    0,  -11, 	  -4,  -14, 	   3,  -12, 	  -2,   -7
+.2byte   -1,  -14, 	   5,  -13, 	  -7,  -13, 	  -1,   -8
+.2byte   -1,  -11, 	   3,  -14, 	  -4,  -12, 	   1,   -7
+.2byte   -4,  -10, 	   3,  -12, 	   1,   -9, 	   1,   -7
+.2byte   -2,  -10, 	  -5,  -15, 	   6,  -10, 	   0,   -7
+.2byte   -1,   -9, 	 -11,   -6, 	   9,   -6, 	  -1,   -7
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -5,  -10, 	  -2,   -5, 	   0,   -2, 	  -1,   -7
+.2byte   -2,  -11, 	   7,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -9
+.2byte    0,  -11, 	  -9,   -8, 	   7,   -3, 	  -1,   -7
+.2byte    3,  -10, 	   0,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    1,   -9, 	   6,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -2,  -12, 	  -8,   -8, 	   5,   -3, 	   0,   -8
+.2byte   -2,  -11, 	  -7,  -15, 	  -6,   -9, 	   0,   -8
+.2byte   -2,  -14, 	   1,  -19, 	 -10,  -13, 	   1,   -8
+.2byte    0,  -17, 	  10,  -16, 	  -9,  -16, 	   0,  -11
+.2byte    1,  -14, 	  -2,  -19, 	   9,  -13, 	  -2,   -8
+.2byte    1,  -11, 	   6,  -15, 	   5,   -9, 	  -1,   -8
+.2byte    1,  -12, 	   7,   -8, 	  -6,   -3, 	  -1,   -8
+.2byte   -1,  -12, 	 -11,   -6, 	   9,   -6, 	  -1,   -8
+.2byte    1,  -13, 	   6,   -9, 	  -8,   -3, 	  -1,   -8
+.2byte    2,  -13, 	   1,   -8, 	  -1,   -1, 	  -1,   -8
+.2byte    1,  -14, 	  -8,   -8, 	   7,   -3, 	  -1,   -8
+.2byte    0,  -17, 	  11,   -9, 	 -10,  -10, 	   0,  -11
+.2byte   -2,  -14, 	   7,   -8, 	  -8,   -3, 	   0,   -8
+.2byte   -3,  -13, 	  -2,   -8, 	   0,   -1, 	   0,   -8
+.2byte   -2,  -13, 	  -7,   -9, 	   7,   -3, 	   0,   -8
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -6
+.2byte    0,  -10, 	 -10,   -4, 	  10,   -4, 	   0,   -6
+.2byte    2,   -9, 	   7,   -8, 	  -8,   -3, 	   0,   -7
+.2byte    2,  -11, 	   7,   -7, 	  -7,   -1, 	   0,   -6
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -1, 	   0,   -6
+.2byte    2,  -11, 	   1,   -6, 	  -1,    1, 	  -1,   -6
+.2byte    1,  -10, 	  -8,   -7, 	   8,   -2, 	   0,   -6
+.2byte    1,  -13, 	  -8,   -7, 	   7,   -2, 	  -1,   -7
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte    0,  -13, 	  11,   -5, 	 -10,   -6, 	   0,   -7
+.2byte   -2,  -10, 	   7,   -7, 	  -9,   -2, 	  -1,   -6
+.2byte   -2,  -13, 	   7,   -7, 	  -8,   -2, 	   0,   -7
+.2byte   -5,   -9, 	  -2,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,  -11, 	  -2,   -6, 	   0,    1, 	   0,   -6
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -3,  -11, 	  -8,   -7, 	   6,   -1, 	  -1,   -6
+.2byte   -1,  -12, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -2,  -12, 	  -8,   -8, 	   5,   -3, 	   0,   -8
+.2byte   -2,  -11, 	  -7,  -15, 	  -6,   -9, 	   0,   -8
+.2byte   -2,  -14, 	   1,  -19, 	 -10,  -13, 	   1,   -8
+.2byte    0,  -16, 	  10,  -15, 	  -9,  -15, 	   0,  -10
+.2byte    1,  -14, 	  -2,  -19, 	   9,  -13, 	  -2,   -8
+.2byte    1,  -11, 	   6,  -15, 	   5,   -9, 	  -1,   -8
+.2byte    1,  -12, 	   7,   -8, 	  -6,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -11,   -6, 	   9,   -6, 	  -1,   -7
+.2byte   -3,   -9, 	  -8,   -8, 	   7,   -3, 	  -1,   -7
+.2byte   -5,  -10, 	  -2,   -5, 	   0,   -2, 	  -1,   -7
+.2byte   -2,  -11, 	   7,   -8, 	  -9,   -3, 	  -1,   -7
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -9
+.2byte    0,  -11, 	  -9,   -8, 	   7,   -3, 	  -1,   -7
+.2byte    3,  -10, 	   0,   -5, 	  -2,   -2, 	  -1,   -7
+.2byte    1,   -9, 	   6,   -8, 	  -9,   -3, 	  -1,   -7
+sBaltoyAnimTable1:
+.4byte sBaltoyAnims_1_1
+.4byte sBaltoyAnims_1_2
+.4byte sBaltoyAnims_1_3
+.4byte sBaltoyAnims_1_4
+.4byte sBaltoyAnims_1_5
+.4byte sBaltoyAnims_1_6
+.4byte sBaltoyAnims_1_7
+.4byte sBaltoyAnims_1_8
+sBaltoyAnimTable2:
+.4byte sBaltoyAnims_2_1
+.4byte sBaltoyAnims_2_2
+.4byte sBaltoyAnims_2_3
+.4byte sBaltoyAnims_2_4
+.4byte sBaltoyAnims_2_5
+.4byte sBaltoyAnims_2_6
+.4byte sBaltoyAnims_2_7
+.4byte sBaltoyAnims_2_8
+sBaltoyAnimTable3:
+.4byte sBaltoyAnims_3_1
+.4byte sBaltoyAnims_3_2
+.4byte sBaltoyAnims_3_3
+.4byte sBaltoyAnims_3_4
+.4byte sBaltoyAnims_3_5
+.4byte sBaltoyAnims_3_6
+.4byte sBaltoyAnims_3_7
+.4byte sBaltoyAnims_3_8
+sBaltoyAnimTable4:
+.4byte sBaltoyAnims_4_1
+.4byte sBaltoyAnims_4_2
+.4byte sBaltoyAnims_4_3
+.4byte sBaltoyAnims_4_4
+.4byte sBaltoyAnims_4_5
+.4byte sBaltoyAnims_4_6
+.4byte sBaltoyAnims_4_7
+.4byte sBaltoyAnims_4_8
+sBaltoyAnimTable5:
+.4byte sBaltoyAnims_5_1
+.4byte sBaltoyAnims_5_2
+.4byte sBaltoyAnims_5_3
+.4byte sBaltoyAnims_5_4
+.4byte sBaltoyAnims_5_5
+.4byte sBaltoyAnims_5_6
+.4byte sBaltoyAnims_5_7
+.4byte sBaltoyAnims_5_8
+sBaltoyAnimTable6:
+.4byte sBaltoyAnims_6_1
+.4byte sBaltoyAnims_6_1
+.4byte sBaltoyAnims_6_1
+.4byte sBaltoyAnims_6_1
+.4byte sBaltoyAnims_6_1
+.4byte sBaltoyAnims_6_1
+.4byte sBaltoyAnims_6_1
+.4byte sBaltoyAnims_6_1
+sBaltoyAnimTable7:
+.4byte sBaltoyAnims_7_1
+.4byte sBaltoyAnims_7_2
+.4byte sBaltoyAnims_7_3
+.4byte sBaltoyAnims_7_4
+.4byte sBaltoyAnims_7_5
+.4byte sBaltoyAnims_7_6
+.4byte sBaltoyAnims_7_7
+.4byte sBaltoyAnims_7_8
+sBaltoyAnimTable8:
+.4byte sBaltoyAnims_8_1
+.4byte sBaltoyAnims_8_2
+.4byte sBaltoyAnims_8_3
+.4byte sBaltoyAnims_8_4
+.4byte sBaltoyAnims_8_5
+.4byte sBaltoyAnims_8_6
+.4byte sBaltoyAnims_8_7
+.4byte sBaltoyAnims_8_8
+sBaltoyAnimTable9:
+.4byte sBaltoyAnims_9_1
+.4byte sBaltoyAnims_9_2
+.4byte sBaltoyAnims_9_3
+.4byte sBaltoyAnims_9_4
+.4byte sBaltoyAnims_9_5
+.4byte sBaltoyAnims_9_6
+.4byte sBaltoyAnims_9_7
+.4byte sBaltoyAnims_9_8
+sBaltoyAnimTable10:
+.4byte sBaltoyAnims_10_1
+.4byte sBaltoyAnims_10_2
+.4byte sBaltoyAnims_10_3
+.4byte sBaltoyAnims_10_4
+.4byte sBaltoyAnims_10_5
+.4byte sBaltoyAnims_10_6
+.4byte sBaltoyAnims_10_7
+.4byte sBaltoyAnims_10_8
+sBaltoyAnimTable11:
+.4byte sBaltoyAnims_11_1
+.4byte sBaltoyAnims_11_2
+.4byte sBaltoyAnims_11_3
+.4byte sBaltoyAnims_11_4
+.4byte sBaltoyAnims_11_5
+.4byte sBaltoyAnims_11_6
+.4byte sBaltoyAnims_11_7
+.4byte sBaltoyAnims_11_8
+sBaltoyAnimTable12:
+.4byte sBaltoyAnims_12_1
+.4byte sBaltoyAnims_12_2
+.4byte sBaltoyAnims_12_3
+.4byte sBaltoyAnims_12_4
+.4byte sBaltoyAnims_12_5
+.4byte sBaltoyAnims_12_6
+.4byte sBaltoyAnims_12_7
+.4byte sBaltoyAnims_12_8
+sBaltoyAnimTable13:
+.4byte sBaltoyAnims_13_1
+.4byte sBaltoyAnims_13_2
+.4byte sBaltoyAnims_13_3
+.4byte sBaltoyAnims_13_4
+.4byte sBaltoyAnims_13_5
+.4byte sBaltoyAnims_13_6
+.4byte sBaltoyAnims_13_7
+.4byte sBaltoyAnims_13_8
+sAxAnimationsBaltoy:
+.4byte sBaltoyAnimTable1
+.4byte sBaltoyAnimTable2
+.4byte sBaltoyAnimTable3
+.4byte sBaltoyAnimTable4
+.4byte sBaltoyAnimTable5
+.4byte sBaltoyAnimTable6
+.4byte sBaltoyAnimTable7
+.4byte sBaltoyAnimTable8
+.4byte sBaltoyAnimTable9
+.4byte sBaltoyAnimTable10
+.4byte sBaltoyAnimTable11
+.4byte sBaltoyAnimTable12
+.4byte sBaltoyAnimTable13
+sAxSpritesBaltoy:
+.4byte sBaltoySprites1
+.4byte sBaltoySprites2
+.4byte sBaltoySprites3
+.4byte sBaltoySprites4
+.4byte sBaltoySprites5
+.4byte sBaltoySprites6
+.4byte sBaltoySprites7
+.4byte sBaltoySprites8
+.4byte sBaltoySprites9
+.4byte sBaltoySprites10
+.4byte sBaltoySprites11
+.4byte sBaltoySprites12
+.4byte sBaltoySprites13
+.4byte sBaltoySprites14
+.4byte sBaltoySprites15
+.4byte sBaltoySprites16
+.4byte sBaltoySprites17
+.4byte sBaltoySprites18
+.4byte sBaltoySprites19
+.4byte sBaltoySprites20
+.4byte sBaltoySprites21
+.4byte sBaltoySprites22
+.4byte sBaltoySprites23
+sAxMainBaltoy:
+ax_main sAxPosesBaltoy, sAxAnimationsBaltoy, 13, sAxSpritesBaltoy, sAxPositionsBaltoy

--- a/data/ax/banette.inc
+++ b/data/ax/banette.inc
@@ -1,0 +1,3173 @@
+.global gAxBanette
+gAxBanette:
+ax_siro sAxMainBanette
+sBanettePose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose4:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose5:
+ax_pose 4, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose6:
+ax_pose 5, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose7:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose8:
+ax_pose 7, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose9:
+ax_pose 8, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose10:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose11:
+ax_pose 10, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose12:
+ax_pose 11, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose13:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose14:
+ax_pose 13, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose15:
+ax_pose 14, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose16:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose17:
+ax_pose 16, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose18:
+ax_pose 17, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose19:
+ax_pose 18, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose20:
+ax_pose 19, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose21:
+ax_pose 20, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose22:
+ax_pose 21, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose23:
+ax_pose 22, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose24:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose26:
+ax_pose 24, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose27:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose28:
+ax_pose 25, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose29:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose30:
+ax_pose 26, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sBanettePose31:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose32:
+ax_pose 27, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose33:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose34:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose35:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose36:
+ax_pose 29, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose37:
+ax_pose 18, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose38:
+ax_pose 30, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sBanettePose39:
+ax_pose 21, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose40:
+ax_pose 31, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose41:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose42:
+ax_pose 32, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose43:
+ax_pose 33, 0x01e9, 0x80ef, 0x5c00
+ax_pose 34, 0x01e8, 0x80f1, 0x5c10
+ax_pose_terminator
+sBanettePose44:
+ax_pose 34, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose45:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose46:
+ax_pose 35, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose47:
+ax_pose 36, 0x01e6, 0x90f1, 0x5c00
+ax_pose 37, 0x01e8, 0x80ef, 0x5c10
+ax_pose_terminator
+sBanettePose48:
+ax_pose 37, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose49:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose50:
+ax_pose 38, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose51:
+ax_pose 39, 0x81e7, 0x9100, 0x5c00
+ax_pose 40, 0x01e8, 0x80ef, 0x5c08
+ax_pose_terminator
+sBanettePose52:
+ax_pose 40, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose53:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose54:
+ax_pose 41, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sBanettePose55:
+ax_pose 42, 0x81e7, 0x9103, 0x5c00
+ax_pose 43, 0x01e8, 0x80ef, 0x5c08
+ax_pose_terminator
+sBanettePose56:
+ax_pose 43, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose57:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose58:
+ax_pose 44, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose59:
+ax_pose 45, 0x01e8, 0x80f4, 0x5c00
+ax_pose 46, 0x01e8, 0x80ee, 0x5c10
+ax_pose_terminator
+sBanettePose60:
+ax_pose 45, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose61:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose62:
+ax_pose 41, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose63:
+ax_pose 42, 0x81e7, 0x80ed, 0x5c00
+ax_pose 47, 0x01e8, 0x80f1, 0x5c08
+ax_pose_terminator
+sBanettePose64:
+ax_pose 47, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose65:
+ax_pose 18, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose66:
+ax_pose 48, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose67:
+ax_pose 39, 0x81e7, 0x80f0, 0x5c00
+ax_pose 49, 0x01e8, 0x80f1, 0x5c08
+ax_pose_terminator
+sBanettePose68:
+ax_pose 49, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose69:
+ax_pose 21, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose70:
+ax_pose 50, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose71:
+ax_pose 36, 0x01e6, 0x80ef, 0x5c00
+ax_pose 51, 0x01e8, 0x80f1, 0x5c10
+ax_pose_terminator
+sBanettePose72:
+ax_pose 51, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose73:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose74:
+ax_pose 22, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sBanettePose75:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sBanettePose76:
+ax_pose 16, 0x01e8, 0x80f6, 0x5c00
+ax_pose_terminator
+sBanettePose77:
+ax_pose 13, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose78:
+ax_pose 10, 0x01e8, 0x80eb, 0x5c00
+ax_pose_terminator
+sBanettePose79:
+ax_pose 7, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose80:
+ax_pose 4, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose81:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose82:
+ax_pose 52, 0x01f0, 0x00f8, 0x5c00
+ax_pose -1, 0x01f0, 0x00ff, 0x5c00
+ax_pose 53, 0x01e8, 0x80f4, 0x5c01
+ax_pose_terminator
+sBanettePose83:
+ax_pose 54, 0x01f0, 0x00f8, 0x5c00
+ax_pose -1, 0x01f0, 0x00ff, 0x5c00
+ax_pose 53, 0x01e8, 0x80f4, 0x5c01
+ax_pose_terminator
+sBanettePose84:
+ax_pose 55, 0x01f0, 0x00f8, 0x5c00
+ax_pose -1, 0x01f0, 0x00ff, 0x5c00
+ax_pose 53, 0x01e8, 0x80f4, 0x5c01
+ax_pose_terminator
+sBanettePose85:
+ax_pose 56, 0x01ec, 0x40f4, 0x5c00
+ax_pose -1, 0x01ec, 0x40fb, 0x5c00
+ax_pose 53, 0x01e8, 0x80f4, 0x5c04
+ax_pose_terminator
+sBanettePose86:
+ax_pose 57, 0x01ec, 0x40f4, 0x5c00
+ax_pose -1, 0x01ec, 0x40fb, 0x5c00
+ax_pose 53, 0x01e8, 0x80f4, 0x5c04
+ax_pose_terminator
+sBanettePose87:
+ax_pose 58, 0x01ec, 0x40f4, 0x5c00
+ax_pose -1, 0x01ec, 0x40fb, 0x5c00
+ax_pose 53, 0x01e8, 0x80f4, 0x5c04
+ax_pose_terminator
+sBanettePose88:
+ax_pose 53, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose89:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose90:
+ax_pose 52, 0x01ed, 0x0103, 0x5c00
+ax_pose -1, 0x01f0, 0x00fd, 0x5c00
+ax_pose 3, 0x01e8, 0x80ec, 0x5c01
+ax_pose_terminator
+sBanettePose91:
+ax_pose 54, 0x01ed, 0x0103, 0x5c00
+ax_pose -1, 0x01f0, 0x00fd, 0x5c00
+ax_pose 3, 0x01e8, 0x80ec, 0x5c01
+ax_pose_terminator
+sBanettePose92:
+ax_pose 55, 0x01ed, 0x0103, 0x5c00
+ax_pose -1, 0x01f0, 0x00fd, 0x5c00
+ax_pose 3, 0x01e8, 0x80ec, 0x5c01
+ax_pose_terminator
+sBanettePose93:
+ax_pose 56, 0x01e9, 0x40ff, 0x5c00
+ax_pose -1, 0x01ec, 0x40f9, 0x5c00
+ax_pose 3, 0x01e8, 0x80ec, 0x5c04
+ax_pose_terminator
+sBanettePose94:
+ax_pose 57, 0x01e9, 0x40ff, 0x5c00
+ax_pose -1, 0x01ec, 0x40f9, 0x5c00
+ax_pose 3, 0x01e8, 0x80ec, 0x5c04
+ax_pose_terminator
+sBanettePose95:
+ax_pose 58, 0x01e9, 0x40ff, 0x5c00
+ax_pose -1, 0x01ec, 0x40f9, 0x5c00
+ax_pose 3, 0x01e8, 0x80ec, 0x5c04
+ax_pose_terminator
+sBanettePose96:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose97:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose98:
+ax_pose 52, 0x01ee, 0x0101, 0x5c00
+ax_pose 6, 0x01e8, 0x80ec, 0x5c01
+ax_pose -1, 0x01ec, 0x0104, 0x5c00
+ax_pose_terminator
+sBanettePose99:
+ax_pose 54, 0x01ee, 0x0101, 0x5c00
+ax_pose 6, 0x01e8, 0x80ec, 0x5c01
+ax_pose -1, 0x01ec, 0x0104, 0x5c00
+ax_pose_terminator
+sBanettePose100:
+ax_pose 55, 0x01ee, 0x0101, 0x5c00
+ax_pose 6, 0x01e8, 0x80ec, 0x5c01
+ax_pose -1, 0x01ec, 0x0104, 0x5c00
+ax_pose_terminator
+sBanettePose101:
+ax_pose 56, 0x01ea, 0x40fd, 0x5c00
+ax_pose 6, 0x01e8, 0x80ec, 0x5c04
+ax_pose -1, 0x01e8, 0x4100, 0x5c00
+ax_pose_terminator
+sBanettePose102:
+ax_pose 57, 0x01ea, 0x40fd, 0x5c00
+ax_pose 6, 0x01e8, 0x80ec, 0x5c04
+ax_pose -1, 0x01e8, 0x4100, 0x5c00
+ax_pose_terminator
+sBanettePose103:
+ax_pose 58, 0x01ea, 0x40fd, 0x5c00
+ax_pose 6, 0x01e8, 0x80ec, 0x5c04
+ax_pose -1, 0x01e8, 0x4100, 0x5c00
+ax_pose_terminator
+sBanettePose104:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose105:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose106:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose 52, 0x01e9, 0x00ff, 0x5c10
+ax_pose -1, 0x01ec, 0x0105, 0x5c10
+ax_pose_terminator
+sBanettePose107:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose 54, 0x01e9, 0x00ff, 0x5c10
+ax_pose -1, 0x01ec, 0x0105, 0x5c10
+ax_pose_terminator
+sBanettePose108:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose 55, 0x01e9, 0x00ff, 0x5c10
+ax_pose -1, 0x01ec, 0x0105, 0x5c10
+ax_pose_terminator
+sBanettePose109:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose 56, 0x01e5, 0x40fb, 0x5c10
+ax_pose -1, 0x01e8, 0x4101, 0x5c10
+ax_pose_terminator
+sBanettePose110:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose 57, 0x01e5, 0x40fb, 0x5c10
+ax_pose -1, 0x01e8, 0x4101, 0x5c10
+ax_pose_terminator
+sBanettePose111:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose 58, 0x01e5, 0x40fb, 0x5c10
+ax_pose -1, 0x01e8, 0x4101, 0x5c10
+ax_pose_terminator
+sBanettePose112:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose113:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose 52, 0x01e8, 0x00f7, 0x5c10
+ax_pose -1, 0x01e8, 0x0100, 0x5c10
+ax_pose_terminator
+sBanettePose114:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose 54, 0x01e8, 0x00f7, 0x5c10
+ax_pose -1, 0x01e8, 0x0100, 0x5c10
+ax_pose_terminator
+sBanettePose115:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose 55, 0x01e8, 0x00f7, 0x5c10
+ax_pose -1, 0x01e8, 0x0100, 0x5c10
+ax_pose_terminator
+sBanettePose116:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose 56, 0x01e4, 0x40f3, 0x5c10
+ax_pose -1, 0x01e4, 0x40fc, 0x5c10
+ax_pose_terminator
+sBanettePose117:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose 57, 0x01e4, 0x40f3, 0x5c10
+ax_pose -1, 0x01e4, 0x40fc, 0x5c10
+ax_pose_terminator
+sBanettePose118:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose 58, 0x01e4, 0x40f3, 0x5c10
+ax_pose -1, 0x01e4, 0x40fc, 0x5c10
+ax_pose_terminator
+sBanettePose119:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose120:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose 52, 0x01e9, 0x00f7, 0x5c10
+ax_pose -1, 0x01ec, 0x00f2, 0x5c10
+ax_pose_terminator
+sBanettePose121:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose 54, 0x01e9, 0x00f7, 0x5c10
+ax_pose -1, 0x01ec, 0x00f2, 0x5c10
+ax_pose_terminator
+sBanettePose122:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose 55, 0x01e9, 0x00f7, 0x5c10
+ax_pose -1, 0x01ec, 0x00f2, 0x5c10
+ax_pose_terminator
+sBanettePose123:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose 56, 0x01e5, 0x40f3, 0x5c10
+ax_pose -1, 0x01e8, 0x40ee, 0x5c10
+ax_pose_terminator
+sBanettePose124:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose 57, 0x01e5, 0x40f3, 0x5c10
+ax_pose -1, 0x01e8, 0x40ee, 0x5c10
+ax_pose_terminator
+sBanettePose125:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose 58, 0x01e5, 0x40f3, 0x5c10
+ax_pose -1, 0x01e8, 0x40ee, 0x5c10
+ax_pose_terminator
+sBanettePose126:
+ax_pose 18, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose127:
+ax_pose 52, 0x01ee, 0x00f6, 0x5c00
+ax_pose 59, 0x01e8, 0x80f4, 0x5c01
+ax_pose -1, 0x01ec, 0x00f3, 0x5c00
+ax_pose_terminator
+sBanettePose128:
+ax_pose 54, 0x01ee, 0x00f6, 0x5c00
+ax_pose 59, 0x01e8, 0x80f4, 0x5c01
+ax_pose -1, 0x01ec, 0x00f3, 0x5c00
+ax_pose_terminator
+sBanettePose129:
+ax_pose 55, 0x01ee, 0x00f6, 0x5c00
+ax_pose 59, 0x01e8, 0x80f4, 0x5c01
+ax_pose -1, 0x01ec, 0x00f3, 0x5c00
+ax_pose_terminator
+sBanettePose130:
+ax_pose 56, 0x01ea, 0x40f2, 0x5c00
+ax_pose 59, 0x01e8, 0x80f4, 0x5c04
+ax_pose -1, 0x01e8, 0x40ef, 0x5c00
+ax_pose_terminator
+sBanettePose131:
+ax_pose 57, 0x01ea, 0x40f2, 0x5c00
+ax_pose 59, 0x01e8, 0x80f4, 0x5c04
+ax_pose -1, 0x01e8, 0x40ef, 0x5c00
+ax_pose_terminator
+sBanettePose132:
+ax_pose 58, 0x01ea, 0x40f2, 0x5c00
+ax_pose 59, 0x01e8, 0x80f4, 0x5c04
+ax_pose -1, 0x01e8, 0x40ef, 0x5c00
+ax_pose_terminator
+sBanettePose133:
+ax_pose 59, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose134:
+ax_pose 21, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose135:
+ax_pose 52, 0x01ed, 0x00f5, 0x5c00
+ax_pose -1, 0x01f0, 0x00fa, 0x5c00
+ax_pose 60, 0x01e8, 0x80f4, 0x5c01
+ax_pose_terminator
+sBanettePose136:
+ax_pose 54, 0x01ed, 0x00f5, 0x5c00
+ax_pose -1, 0x01f0, 0x00fa, 0x5c00
+ax_pose 60, 0x01e8, 0x80f4, 0x5c01
+ax_pose_terminator
+sBanettePose137:
+ax_pose 55, 0x01ed, 0x00f5, 0x5c00
+ax_pose -1, 0x01f0, 0x00fa, 0x5c00
+ax_pose 60, 0x01e8, 0x80f4, 0x5c01
+ax_pose_terminator
+sBanettePose138:
+ax_pose 56, 0x01e9, 0x40f1, 0x5c00
+ax_pose -1, 0x01ec, 0x40f6, 0x5c00
+ax_pose 60, 0x01e8, 0x80f4, 0x5c04
+ax_pose_terminator
+sBanettePose139:
+ax_pose 57, 0x01e9, 0x40f1, 0x5c00
+ax_pose -1, 0x01ec, 0x40f6, 0x5c00
+ax_pose 60, 0x01e8, 0x80f4, 0x5c04
+ax_pose_terminator
+sBanettePose140:
+ax_pose 58, 0x01e9, 0x40f1, 0x5c00
+ax_pose -1, 0x01ec, 0x40f6, 0x5c00
+ax_pose 60, 0x01e8, 0x80f4, 0x5c04
+ax_pose_terminator
+sBanettePose141:
+ax_pose 60, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose142:
+ax_pose 61, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sBanettePose143:
+ax_pose 62, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sBanettePose144:
+ax_pose 63, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose145:
+ax_pose 64, 0x01e1, 0x80eb, 0x5c00
+ax_pose_terminator
+sBanettePose146:
+ax_pose 65, 0x01e3, 0x80e8, 0x5c00
+ax_pose_terminator
+sBanettePose147:
+ax_pose 66, 0x01e4, 0x90e8, 0x5c00
+ax_pose_terminator
+sBanettePose148:
+ax_pose 67, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose149:
+ax_pose 66, 0x01e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sBanettePose150:
+ax_pose 68, 0x01e3, 0x80f8, 0x5c00
+ax_pose_terminator
+sBanettePose151:
+ax_pose 69, 0x01e1, 0x80f5, 0x5c00
+ax_pose_terminator
+sBanettePose152:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose153:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose154:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose155:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose156:
+ax_pose 4, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose157:
+ax_pose 5, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose158:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose159:
+ax_pose 7, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose160:
+ax_pose 8, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose161:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose162:
+ax_pose 10, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose163:
+ax_pose 11, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose164:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose165:
+ax_pose 13, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose166:
+ax_pose 14, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose167:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose168:
+ax_pose 16, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose169:
+ax_pose 17, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose170:
+ax_pose 18, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose171:
+ax_pose 19, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose172:
+ax_pose 20, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose173:
+ax_pose 21, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose174:
+ax_pose 22, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose175:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose176:
+ax_pose 24, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose177:
+ax_pose 31, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose178:
+ax_pose 30, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sBanettePose179:
+ax_pose 29, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose180:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose181:
+ax_pose 27, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose182:
+ax_pose 26, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sBanettePose183:
+ax_pose 25, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sBanettePose184:
+ax_pose 24, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose185:
+ax_pose 25, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose186:
+ax_pose 26, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sBanettePose187:
+ax_pose 27, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose188:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose189:
+ax_pose 29, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose190:
+ax_pose 30, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sBanettePose191:
+ax_pose 31, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose192:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose193:
+ax_pose 24, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose194:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose195:
+ax_pose 25, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose196:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose197:
+ax_pose 26, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sBanettePose198:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose199:
+ax_pose 27, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sBanettePose200:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose201:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose202:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose203:
+ax_pose 29, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose204:
+ax_pose 18, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose205:
+ax_pose 30, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sBanettePose206:
+ax_pose 21, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose207:
+ax_pose 31, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sBanettePose208:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose209:
+ax_pose 21, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose210:
+ax_pose 18, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose211:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose212:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose213:
+ax_pose 9, 0x01eb, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose214:
+ax_pose 6, 0x01eb, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose215:
+ax_pose 3, 0x01eb, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose216:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose217:
+ax_pose 21, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose218:
+ax_pose 18, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose219:
+ax_pose 15, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose220:
+ax_pose 12, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sBanettePose221:
+ax_pose 9, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose222:
+ax_pose 6, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+sBanettePose223:
+ax_pose 3, 0x01e8, 0x80ec, 0x5c00
+ax_pose_terminator
+.align 2
+sBanetteAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 6, 0, 5,
+ax_anim 1, 0, 25, 0, 12, 0, 10,
+ax_anim 2, 0, 25, 0, 26, 0, 22,
+ax_anim 2, 1, 25, 1, 26, 1, 22,
+ax_anim 2, 0, 25, 0, 26, 0, 22,
+ax_anim 2, 0, 25, 1, 26, 1, 22,
+ax_anim 2, 0, 24, 0, 9, 0, 9,
+ax_anim_terminator
+sBanetteAnims_2_2:
+ax_anim 2, 0, 26, -1, -1, -1, -1,
+ax_anim 4, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 3, 6, 3, 3,
+ax_anim 1, 0, 27, 9, 14, 9, 9,
+ax_anim 2, 0, 27, 18, 26, 18, 18,
+ax_anim 2, 1, 27, 19, 25, 19, 17,
+ax_anim 2, 0, 27, 18, 26, 18, 18,
+ax_anim 2, 0, 27, 19, 25, 19, 17,
+ax_anim 2, 0, 26, 5, 5, 5, 5,
+ax_anim_terminator
+sBanetteAnims_2_3:
+ax_anim 2, 0, 28, -1, 0, -1, 0,
+ax_anim 4, 0, 28, -2, 0, -2, 0,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 1, 4, 0,
+ax_anim 1, 0, 29, 10, 3, 10, 0,
+ax_anim 2, 0, 29, 18, 5, 18, 0,
+ax_anim 2, 1, 29, 18, 6, 18, 1,
+ax_anim 2, 0, 29, 18, 5, 18, 0,
+ax_anim 2, 0, 29, 18, 6, 18, 1,
+ax_anim 2, 0, 28, 6, 2, 6, 0,
+ax_anim_terminator
+sBanetteAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 4, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 31, 0, -1, 0, -1,
+ax_anim 1, 2, 31, 5, -5, 5, -5,
+ax_anim 1, 0, 31, 11, -10, 11, -11,
+ax_anim 2, 0, 31, 17, -14, 17, -17,
+ax_anim 2, 1, 31, 18, -13, 18, -16,
+ax_anim 2, 0, 31, 17, -14, 17, -17,
+ax_anim 2, 0, 31, 18, -13, 18, -16,
+ax_anim 2, 0, 30, 6, -6, 6, -6,
+ax_anim_terminator
+sBanetteAnims_2_5:
+ax_anim 2, 0, 32, 0, 1, 0, 1,
+ax_anim 4, 0, 32, 0, 2, 0, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, -4, 0, -4,
+ax_anim 1, 0, 33, 0, -11, 0, -14,
+ax_anim 2, 0, 33, 0, -16, 0, -22,
+ax_anim 2, 1, 33, 1, -16, 1, -22,
+ax_anim 2, 0, 33, 0, -16, 0, -22,
+ax_anim 2, 0, 33, 1, -16, 1, -22,
+ax_anim 2, 0, 32, 0, -6, 0, -8,
+ax_anim_terminator
+sBanetteAnims_2_6:
+ax_anim 2, 0, 34, 1, 1, 1, 1,
+ax_anim 4, 0, 34, 2, 2, 2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 35, -5, -5, -5, -5,
+ax_anim 1, 0, 35, -11, -10, -11, -11,
+ax_anim 2, 0, 35, -17, -14, -17, -17,
+ax_anim 2, 1, 35, -18, -13, -18, -16,
+ax_anim 2, 0, 35, -17, -14, -17, -17,
+ax_anim 2, 0, 35, -18, -13, -18, -16,
+ax_anim 2, 0, 34, -6, -6, -6, -6,
+ax_anim_terminator
+sBanetteAnims_2_7:
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 4, 0, 36, 2, 0, 2, 0,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, -4, 1, -4, 0,
+ax_anim 1, 0, 37, -10, 3, -10, 0,
+ax_anim 2, 0, 37, -18, 5, -18, 0,
+ax_anim 2, 1, 37, -18, 6, -18, 1,
+ax_anim 2, 0, 37, -18, 5, -18, 0,
+ax_anim 2, 0, 37, -18, 6, -18, 1,
+ax_anim 2, 0, 36, -6, 2, -6, 0,
+ax_anim_terminator
+sBanetteAnims_2_8:
+ax_anim 2, 0, 38, 1, -1, 1, -1,
+ax_anim 4, 0, 38, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, -3, 6, -3, 3,
+ax_anim 1, 0, 39, -9, 14, -9, 9,
+ax_anim 2, 0, 39, -18, 26, -18, 18,
+ax_anim 2, 1, 39, -19, 25, -19, 17,
+ax_anim 2, 0, 39, -18, 26, -18, 18,
+ax_anim 2, 0, 39, -19, 25, -19, 17,
+ax_anim 2, 0, 38, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sBanetteAnims_3_1:
+ax_anim 2, 0, 40, 0, -2, 0, -2,
+ax_anim 2, 0, 41, 0, -3, 0, -3,
+ax_anim 6, 0, 41, 0, -4, 0, -4,
+ax_anim 1, 2, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 12, 0, 12,
+ax_anim 2, 0, 42, 0, 23, 0, 23,
+ax_anim 1, 1, 43, 2, 24, 2, 24,
+ax_anim 1, 0, 48, 4, 24, 4, 24,
+ax_anim 1, 0, 52, 6, 18, 6, 18,
+ax_anim 2, 0, 56, 7, 13, 7, 13,
+ax_anim 2, 0, 60, 4, 6, 4, 6,
+ax_anim 2, 0, 64, 2, 4, 2, 4,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_3_2:
+ax_anim 2, 0, 44, -2, -2, -2, -2,
+ax_anim 2, 0, 45, -3, -3, -3, -3,
+ax_anim 6, 0, 45, -4, -4, -4, -4,
+ax_anim 1, 2, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 11, 13, 11, 13,
+ax_anim 2, 0, 46, 20, 23, 20, 23,
+ax_anim 1, 1, 47, 18, 24, 18, 24,
+ax_anim 1, 0, 68, 16, 26, 16, 26,
+ax_anim 1, 0, 64, 9, 20, 9, 20,
+ax_anim 2, 0, 60, 4, 16, 4, 16,
+ax_anim 2, 0, 56, 0, 9, 0, 9,
+ax_anim 2, 0, 52, -1, 4, -1, 4,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_3_3:
+ax_anim 2, 0, 48, -2, 0, -2, 0,
+ax_anim 2, 0, 49, -3, 0, -3, 0,
+ax_anim 6, 0, 49, -4, 0, -4, 0,
+ax_anim 1, 2, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 11, 0, 11, 0,
+ax_anim 2, 0, 50, 20, 0, 20, 0,
+ax_anim 1, 1, 51, 21, 3, 21, 3,
+ax_anim 1, 0, 40, 19, 8, 19, 8,
+ax_anim 1, 0, 68, 15, 11, 15, 11,
+ax_anim 2, 0, 64, 9, 10, 9, 10,
+ax_anim 2, 0, 60, 4, 5, 4, 5,
+ax_anim 2, 0, 56, 1, 3, 1, 3,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_3_4:
+ax_anim 2, 0, 52, -2, 2, -2, 2,
+ax_anim 2, 0, 53, -3, 3, -3, 3,
+ax_anim 6, 0, 53, -4, 4, -4, 4,
+ax_anim 1, 2, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 12, -10, 12, -10,
+ax_anim 2, 0, 54, 18, -14, 18, -14,
+ax_anim 1, 1, 55, 20, -12, 20, -12,
+ax_anim 1, 0, 44, 21, -7, 21, -7,
+ax_anim 1, 0, 40, 20, -4, 20, -4,
+ax_anim 2, 0, 68, 17, -2, 17, -2,
+ax_anim 2, 0, 64, 9, -1, 9, -1,
+ax_anim 2, 0, 60, 4, 0, 4, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_3_5:
+ax_anim 2, 0, 56, 0, 2, 0, 2,
+ax_anim 2, 0, 57, 0, 3, 0, 3,
+ax_anim 6, 0, 57, 0, 4, 0, 4,
+ax_anim 1, 2, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, -12, 0, -12,
+ax_anim 2, 0, 58, 0, -15, 0, -15,
+ax_anim 1, 1, 59, -2, -16, -2, -16,
+ax_anim 1, 0, 64, -5, -16, -5, -16,
+ax_anim 1, 0, 68, -6, -13, -6, -13,
+ax_anim 2, 0, 40, -8, -9, -8, -9,
+ax_anim 2, 0, 44, -6, -4, -6, -4,
+ax_anim 2, 0, 48, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_3_6:
+ax_anim 2, 0, 60, 2, 2, 2, 2,
+ax_anim 2, 0, 61, 3, 3, 3, 3,
+ax_anim 6, 0, 61, 4, 4, 4, 4,
+ax_anim 1, 2, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 61, -12, -10, -12, -10,
+ax_anim 2, 0, 62, -18, -14, -18, -14,
+ax_anim 1, 1, 63, -20, -12, -20, -12,
+ax_anim 1, 0, 68, -21, -7, -21, -7,
+ax_anim 1, 0, 40, -20, -4, -20, -4,
+ax_anim 2, 0, 44, -17, -2, -17, -2,
+ax_anim 2, 0, 48, -9, -1, -9, -1,
+ax_anim 2, 0, 52, -4, 0, -4, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_3_7:
+ax_anim 2, 0, 64, 2, 0, 2, 0,
+ax_anim 2, 0, 65, 3, 0, 3, 0,
+ax_anim 6, 0, 65, 4, 0, 4, 0,
+ax_anim 1, 2, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 65, -11, 0, -11, 0,
+ax_anim 2, 0, 66, -20, 0, -20, 0,
+ax_anim 1, 1, 67, -21, 3, -21, 3,
+ax_anim 1, 0, 40, -19, 8, -19, 8,
+ax_anim 1, 0, 44, -15, 11, -15, 11,
+ax_anim 2, 0, 48, -9, 10, -9, 10,
+ax_anim 2, 0, 52, -4, 5, -4, 5,
+ax_anim 2, 0, 56, -1, 3, -1, 3,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_3_8:
+ax_anim 2, 0, 68, 2, -2, 2, -2,
+ax_anim 2, 0, 69, 3, -3, 3, -3,
+ax_anim 6, 0, 69, 4, -4, 4, -4,
+ax_anim 1, 2, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 69, -11, 13, -11, 13,
+ax_anim 2, 0, 70, -20, 23, -20, 23,
+ax_anim 1, 1, 71, -18, 24, -18, 24,
+ax_anim 1, 0, 44, -16, 26, -16, 26,
+ax_anim 1, 0, 48, -9, 20, -9, 20,
+ax_anim 2, 0, 52, -4, 16, -4, 16,
+ax_anim 2, 0, 56, 0, 9, 0, 9,
+ax_anim 2, 0, 60, 1, 4, 1, 4,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_5_1:
+ax_anim 3, 0, 88, 0, 0, 0, 0,
+ax_anim 3, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 80, 0, 0, 0, 0,
+ax_anim 3, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 1, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_5_2:
+ax_anim 3, 0, 96, 0, 0, 0, 0,
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 3, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 2, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 1, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_5_3:
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 3, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 1, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_5_4:
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 2, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 1, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_5_5:
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 2, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 1, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_5_6:
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 2, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 1, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_5_7:
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 1, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_5_8:
+ax_anim 3, 0, 80, 0, 0, 0, 0,
+ax_anim 3, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 2, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 1, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_6_1:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 35, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_7_1:
+ax_anim 2, 0, 143, 0, -2, 0, -2,
+ax_anim 8, 0, 143, 0, -3, 0, -3,
+ax_anim_terminator
+sBanetteAnims_7_2:
+ax_anim 2, 0, 144, -2, -2, -2, -2,
+ax_anim 8, 0, 144, -3, -3, -3, -3,
+ax_anim_terminator
+sBanetteAnims_7_3:
+ax_anim 2, 0, 145, -2, 0, -2, 0,
+ax_anim 8, 0, 145, -3, 0, -3, 0,
+ax_anim_terminator
+sBanetteAnims_7_4:
+ax_anim 2, 0, 146, -2, 2, -2, 2,
+ax_anim 8, 0, 146, -3, 3, -3, 3,
+ax_anim_terminator
+sBanetteAnims_7_5:
+ax_anim 2, 0, 147, 0, 2, 0, 2,
+ax_anim 8, 0, 147, 0, 3, 0, 3,
+ax_anim_terminator
+sBanetteAnims_7_6:
+ax_anim 2, 0, 148, 2, 2, 2, 2,
+ax_anim 8, 0, 148, 3, 3, 3, 3,
+ax_anim_terminator
+sBanetteAnims_7_7:
+ax_anim 2, 0, 149, 2, 0, 2, 0,
+ax_anim 8, 0, 149, 3, 0, 3, 0,
+ax_anim_terminator
+sBanetteAnims_7_8:
+ax_anim 2, 0, 150, 2, -2, 2, -2,
+ax_anim 8, 0, 150, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBanetteAnims_8_1:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 151, 0, -3, 0, 0,
+ax_anim 4, 0, 152, 0, -5, 0, 0,
+ax_anim 4, 0, 153, 0, -6, 0, 0,
+ax_anim 4, 0, 152, 0, -6, 0, 0,
+ax_anim 4, 0, 153, 0, -5, 0, 0,
+ax_anim 2, 0, 151, 0, -3, 0, 0,
+ax_anim 1, 0, 151, 0, -2, 0, 0,
+ax_anim_terminator
+sBanetteAnims_8_2:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, -5, 0, 0,
+ax_anim 4, 0, 156, 0, -6, 0, 0,
+ax_anim 4, 0, 155, 0, -6, 0, 0,
+ax_anim 4, 0, 156, 0, -5, 0, 0,
+ax_anim 2, 0, 154, 0, -3, 0, 0,
+ax_anim 1, 0, 154, 0, -2, 0, 0,
+ax_anim_terminator
+sBanetteAnims_8_3:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 158, 0, -5, 0, 0,
+ax_anim 4, 0, 159, 0, -6, 0, 0,
+ax_anim 4, 0, 158, 0, -6, 0, 0,
+ax_anim 4, 0, 159, 0, -5, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 1, 0, 157, 0, -2, 0, 0,
+ax_anim_terminator
+sBanetteAnims_8_4:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, -3, 0, 0,
+ax_anim 4, 0, 161, 0, -5, 0, 0,
+ax_anim 4, 0, 162, 0, -6, 0, 0,
+ax_anim 4, 0, 161, 0, -6, 0, 0,
+ax_anim 4, 0, 162, 0, -5, 0, 0,
+ax_anim 2, 0, 160, 0, -3, 0, 0,
+ax_anim 1, 0, 160, 0, -2, 0, 0,
+ax_anim_terminator
+sBanetteAnims_8_5:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim 2, 0, 163, 0, -3, 0, 0,
+ax_anim 4, 0, 164, 0, -5, 0, 0,
+ax_anim 4, 0, 165, 0, -6, 0, 0,
+ax_anim 4, 0, 164, 0, -6, 0, 0,
+ax_anim 4, 0, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 163, 0, -3, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim_terminator
+sBanetteAnims_8_6:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -2, 0, 0,
+ax_anim 2, 0, 166, 0, -3, 0, 0,
+ax_anim 4, 0, 167, 0, -5, 0, 0,
+ax_anim 4, 0, 168, 0, -6, 0, 0,
+ax_anim 4, 0, 167, 0, -6, 0, 0,
+ax_anim 4, 0, 168, 0, -5, 0, 0,
+ax_anim 2, 0, 166, 0, -3, 0, 0,
+ax_anim 1, 0, 166, 0, -2, 0, 0,
+ax_anim_terminator
+sBanetteAnims_8_7:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim 2, 0, 169, 0, -3, 0, 0,
+ax_anim 4, 0, 170, 0, -5, 0, 0,
+ax_anim 4, 0, 171, 0, -6, 0, 0,
+ax_anim 4, 0, 170, 0, -6, 0, 0,
+ax_anim 4, 0, 171, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -3, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim_terminator
+sBanetteAnims_8_8:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -2, 0, 0,
+ax_anim 2, 0, 172, 0, -3, 0, 0,
+ax_anim 4, 0, 173, 0, -5, 0, 0,
+ax_anim 4, 0, 174, 0, -6, 0, 0,
+ax_anim 4, 0, 173, 0, -6, 0, 0,
+ax_anim 4, 0, 174, 0, -5, 0, 0,
+ax_anim 2, 0, 172, 0, -3, 0, 0,
+ax_anim 1, 0, 172, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_9_1:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 6, 4, 6, 4,
+ax_anim 2, 0, 177, 10, 12, 10, 12,
+ax_anim 2, 0, 178, 7, 20, 7, 20,
+ax_anim 3, 0, 179, 0, 23, 0, 23,
+ax_anim 2, 3, 180, -7, 20, -7, 20,
+ax_anim 2, 0, 181, -10, 12, -10, 12,
+ax_anim 1, 0, 182, -6, 4, -6, 4,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_9_2:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 11, -2, 11, -2,
+ax_anim 2, 0, 176, 21, 6, 21, 6,
+ax_anim 2, 0, 177, 24, 16, 24, 16,
+ax_anim 3, 0, 178, 20, 24, 20, 24,
+ax_anim 2, 3, 179, 11, 24, 11, 24,
+ax_anim 2, 0, 180, 4, 20, 4, 20,
+ax_anim 1, 0, 181, -1, 10, -1, 10,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_9_3:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 4, -3, 4, -3,
+ax_anim 2, 0, 175, 11, -5, 11, -5,
+ax_anim 2, 0, 176, 17, -2, 17, -2,
+ax_anim 3, 0, 177, 20, 3, 20, 3,
+ax_anim 2, 3, 178, 17, 8, 17, 8,
+ax_anim 2, 0, 179, 12, 9, 12, 9,
+ax_anim 1, 0, 180, 3, 6, 3, 6,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_9_4:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 1, -5, 1, -5,
+ax_anim 2, 0, 182, 5, -11, 5, -11,
+ax_anim 2, 0, 175, 12, -16, 12, -16,
+ax_anim 3, 0, 176, 21, -16, 21, -16,
+ax_anim 2, 3, 177, 24, -10, 24, -10,
+ax_anim 2, 0, 178, 19, -3, 19, -3,
+ax_anim 1, 0, 179, 8, 1, 8, 1,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_9_5:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -7, -3, -7, -3,
+ax_anim 2, 0, 181, -11, -8, -11, -8,
+ax_anim 2, 0, 182, -8, -14, -8, -14,
+ax_anim 3, 0, 175, 0, -16, 0, -16,
+ax_anim 2, 3, 176, 8, -14, 8, -14,
+ax_anim 2, 0, 177, 11, -6, 11, -6,
+ax_anim 1, 0, 178, 8, -2, 8, -2,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_9_6:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 177, -1, -5, -1, -5,
+ax_anim 2, 0, 176, -5, -11, -5, -11,
+ax_anim 2, 0, 175, -12, -16, -12, -16,
+ax_anim 3, 0, 182, -21, -16, -21, -16,
+ax_anim 2, 3, 181, -24, -10, -24, -10,
+ax_anim 2, 0, 180, -19, -3, -19, -3,
+ax_anim 1, 0, 179, -8, 1, -8, 1,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_9_7:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -4, -3, -4, -3,
+ax_anim 2, 0, 175, -11, -5, -11, -5,
+ax_anim 2, 0, 182, -17, -2, -17, -2,
+ax_anim 3, 0, 181, -20, 3, -20, 3,
+ax_anim 2, 3, 180, -17, 8, -17, 8,
+ax_anim 2, 0, 179, -12, 9, -12, 9,
+ax_anim 1, 0, 178, -3, 6, -3, 6,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_9_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -11, -2, -11, -2,
+ax_anim 2, 0, 182, -21, 6, -21, 6,
+ax_anim 2, 0, 181, -24, 16, -24, 16,
+ax_anim 3, 0, 180, -20, 24, -20, 24,
+ax_anim 2, 3, 179, -11, 24, -11, 24,
+ax_anim 2, 0, 178, -4, 20, -4, 20,
+ax_anim 1, 0, 177, 1, 10, 1, 10,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_10_1:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, 0, 6, 0,
+ax_anim 2, 0, 183, -6, 0, -6, 0,
+ax_anim 2, 0, 183, 10, 0, 10, 0,
+ax_anim 2, 0, 183, -10, 0, -10, 0,
+ax_anim 2, 0, 183, 12, 0, 12, 0,
+ax_anim 3, 0, 183, -12, 0, -12, 0,
+ax_anim 3, 0, 183, 13, 0, 13, 0,
+ax_anim 3, 0, 183, -13, 0, -13, 0,
+ax_anim 2, 0, 183, 12, 0, 12, 0,
+ax_anim 3, 0, 183, -12, 0, -12, 0,
+ax_anim 2, 0, 183, 10, 0, 10, 0,
+ax_anim 2, 0, 183, -10, 0, -10, 0,
+ax_anim 2, 0, 183, 6, 0, 6, 0,
+ax_anim 2, 0, 183, -6, 0, -6, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_10_2:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 6, -6, 6, -6,
+ax_anim 2, 0, 184, -6, 6, -6, 6,
+ax_anim 2, 0, 184, 10, -10, 10, -10,
+ax_anim 2, 0, 184, -10, 10, -10, 10,
+ax_anim 2, 0, 184, 12, -12, 12, -12,
+ax_anim 3, 0, 184, -12, 12, -12, 12,
+ax_anim 3, 0, 184, 13, -13, 13, -13,
+ax_anim 3, 0, 184, -13, 13, -13, 13,
+ax_anim 2, 0, 184, 12, -12, 12, -12,
+ax_anim 3, 0, 184, -12, 12, -12, 12,
+ax_anim 2, 0, 184, 10, -10, 10, -10,
+ax_anim 2, 0, 184, -10, 10, -10, 10,
+ax_anim 2, 0, 184, 6, -6, 6, -6,
+ax_anim 2, 0, 184, -6, 6, -6, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_10_3:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -6, 0, -6,
+ax_anim 2, 0, 185, 0, 6, 0, 6,
+ax_anim 2, 0, 185, 0, -10, 0, -10,
+ax_anim 2, 0, 185, 0, 10, 0, 10,
+ax_anim 2, 0, 185, 0, -12, 0, -12,
+ax_anim 3, 0, 185, 0, 12, 0, 12,
+ax_anim 3, 0, 185, 0, -13, 0, -13,
+ax_anim 3, 0, 185, 0, 13, 0, 13,
+ax_anim 2, 0, 185, 0, -12, 0, -12,
+ax_anim 3, 0, 185, 0, 12, 0, 12,
+ax_anim 2, 0, 185, 0, -10, 0, -10,
+ax_anim 2, 0, 185, 0, 10, 0, 10,
+ax_anim 2, 0, 185, 0, -6, 0, -6,
+ax_anim 2, 0, 185, 0, 6, 0, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_10_4:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -6, -6, -6, -6,
+ax_anim 2, 0, 186, 6, 6, 6, 6,
+ax_anim 2, 0, 186, -10, -10, -10, -10,
+ax_anim 2, 0, 186, 10, 10, 10, 10,
+ax_anim 2, 0, 186, -12, -12, -12, -12,
+ax_anim 3, 0, 186, 12, 12, 12, 12,
+ax_anim 3, 0, 186, -13, -13, -13, -13,
+ax_anim 3, 0, 186, 13, 13, 13, 13,
+ax_anim 2, 0, 186, -12, -12, -12, -12,
+ax_anim 3, 0, 186, 12, 12, 12, 12,
+ax_anim 2, 0, 186, -10, -10, -10, -10,
+ax_anim 2, 0, 186, 10, 10, 10, 10,
+ax_anim 2, 0, 186, -6, -6, -6, -6,
+ax_anim 2, 0, 186, 6, 6, 6, 6,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_10_5:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, 0, 6, 0,
+ax_anim 2, 0, 187, -6, 0, -6, 0,
+ax_anim 2, 0, 187, 10, 0, 10, 0,
+ax_anim 2, 0, 187, -10, 0, -10, 0,
+ax_anim 2, 0, 187, 12, 0, 12, 0,
+ax_anim 3, 0, 187, -12, 0, -12, 0,
+ax_anim 3, 0, 187, 13, 0, 13, 0,
+ax_anim 3, 0, 187, -13, 0, -13, 0,
+ax_anim 2, 0, 187, 12, 0, 12, 0,
+ax_anim 3, 0, 187, -12, 0, -12, 0,
+ax_anim 2, 0, 187, 10, 0, 10, 0,
+ax_anim 2, 0, 187, -10, 0, -10, 0,
+ax_anim 2, 0, 187, 6, 0, 6, 0,
+ax_anim 2, 0, 187, -6, 0, -6, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_10_6:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 6, -6, 6, -6,
+ax_anim 2, 0, 188, -6, 6, -6, 6,
+ax_anim 2, 0, 188, 10, -10, 10, -10,
+ax_anim 2, 0, 188, -10, 10, -10, 10,
+ax_anim 2, 0, 188, 12, -12, 12, -12,
+ax_anim 3, 0, 188, -12, 12, -12, 12,
+ax_anim 3, 0, 188, 13, -13, 13, -13,
+ax_anim 3, 0, 188, -13, 13, -13, 13,
+ax_anim 2, 0, 188, 12, -12, 12, -12,
+ax_anim 3, 0, 188, -12, 12, -12, 12,
+ax_anim 2, 0, 188, 10, -10, 10, -10,
+ax_anim 2, 0, 188, -10, 10, -10, 10,
+ax_anim 2, 0, 188, 6, -6, 6, -6,
+ax_anim 2, 0, 188, -6, 6, -6, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_10_7:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -6, 0, -6,
+ax_anim 2, 0, 189, 0, 6, 0, 6,
+ax_anim 2, 0, 189, 0, -10, 0, -10,
+ax_anim 2, 0, 189, 0, 10, 0, 10,
+ax_anim 2, 0, 189, 0, -12, 0, -12,
+ax_anim 3, 0, 189, 0, 12, 0, 12,
+ax_anim 3, 0, 189, 0, -13, 0, -13,
+ax_anim 3, 0, 189, 0, 13, 0, 13,
+ax_anim 2, 0, 189, 0, -12, 0, -12,
+ax_anim 3, 0, 189, 0, 12, 0, 12,
+ax_anim 2, 0, 189, 0, -10, 0, -10,
+ax_anim 2, 0, 189, 0, 10, 0, 10,
+ax_anim 2, 0, 189, 0, -6, 0, -6,
+ax_anim 2, 0, 189, 0, 6, 0, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_10_8:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, -6, -6, -6, -6,
+ax_anim 2, 0, 190, 6, 6, 6, 6,
+ax_anim 2, 0, 190, -10, -10, -10, -10,
+ax_anim 2, 0, 190, 10, 10, 10, 10,
+ax_anim 2, 0, 190, -12, -12, -12, -12,
+ax_anim 3, 0, 190, 12, 12, 12, 12,
+ax_anim 3, 0, 190, -13, -13, -13, -13,
+ax_anim 3, 0, 190, 13, 13, 13, 13,
+ax_anim 2, 0, 190, -12, -12, -12, -12,
+ax_anim 3, 0, 190, 12, 12, 12, 12,
+ax_anim 2, 0, 190, -10, -10, -10, -10,
+ax_anim 2, 0, 190, 10, 10, 10, 10,
+ax_anim 2, 0, 190, -6, -6, -6, -6,
+ax_anim 2, 0, 190, 6, 6, 6, 6,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_11_1:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -19, 0, 0,
+ax_anim 4, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -14, 0, 0,
+ax_anim 1, 0, 192, 0, -3, 0, 0,
+ax_anim 2, 2, 191, 0, 3, 0, 0,
+ax_anim_terminator
+sBanetteAnims_11_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -18, 0, 0,
+ax_anim 4, 0, 193, 0, -19, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -14, 0, 0,
+ax_anim 1, 0, 194, 0, -3, 0, 0,
+ax_anim 2, 2, 193, 0, 3, 0, 0,
+ax_anim_terminator
+sBanetteAnims_11_3:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -14, 0, 0,
+ax_anim 1, 0, 196, 0, -3, 0, 0,
+ax_anim 2, 2, 195, 0, 3, 0, 0,
+ax_anim_terminator
+sBanetteAnims_11_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -19, 0, 0,
+ax_anim 4, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -14, 0, 0,
+ax_anim 1, 0, 198, 0, -3, 0, 0,
+ax_anim 2, 2, 197, 0, 3, 0, 0,
+ax_anim_terminator
+sBanetteAnims_11_5:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -14, 0, 0,
+ax_anim 1, 0, 200, 0, -3, 0, 0,
+ax_anim 2, 2, 199, 0, 3, 0, 0,
+ax_anim_terminator
+sBanetteAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -19, 0, 0,
+ax_anim 4, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -14, 0, 0,
+ax_anim 1, 0, 202, 0, -3, 0, 0,
+ax_anim 2, 2, 201, 0, 3, 0, 0,
+ax_anim_terminator
+sBanetteAnims_11_7:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -14, 0, 0,
+ax_anim 1, 0, 204, 0, -3, 0, 0,
+ax_anim 2, 2, 203, 0, 3, 0, 0,
+ax_anim_terminator
+sBanetteAnims_11_8:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -18, 0, 0,
+ax_anim 4, 0, 205, 0, -19, 0, 0,
+ax_anim 4, 0, 206, 0, -22, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -14, 0, 0,
+ax_anim 1, 0, 206, 0, -3, 0, 0,
+ax_anim 2, 2, 205, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_12_1:
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_12_2:
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_12_3:
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_12_4:
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_12_5:
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_12_6:
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_12_7:
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_12_8:
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBanetteAnims_13_1:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_13_2:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_13_3:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_13_4:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_13_5:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_13_6:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_13_7:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteAnims_13_8:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sBanetteGfx1:
+.incbin "baserom.gba", 0x149BED4, 0x200
+sBanetteSprites1:
+ax_sprite sBanetteGfx1, 0x200
+ax_sprite_terminator
+sBanetteGfx2:
+.incbin "baserom.gba", 0x149C0E4, 0x200
+sBanetteSprites2:
+ax_sprite sBanetteGfx2, 0x200
+ax_sprite_terminator
+sBanetteGfx3:
+.incbin "baserom.gba", 0x149C2F4, 0x200
+sBanetteSprites3:
+ax_sprite sBanetteGfx3, 0x200
+ax_sprite_terminator
+sBanetteGfx4:
+.incbin "baserom.gba", 0x149C504, 0x200
+sBanetteSprites4:
+ax_sprite sBanetteGfx4, 0x200
+ax_sprite_terminator
+sBanetteGfx5:
+.incbin "baserom.gba", 0x149C714, 0x200
+sBanetteSprites5:
+ax_sprite sBanetteGfx5, 0x200
+ax_sprite_terminator
+sBanetteGfx6:
+.incbin "baserom.gba", 0x149C924, 0x200
+sBanetteSprites6:
+ax_sprite sBanetteGfx6, 0x200
+ax_sprite_terminator
+sBanetteGfx7:
+.incbin "baserom.gba", 0x149CB34, 0x200
+sBanetteSprites7:
+ax_sprite sBanetteGfx7, 0x200
+ax_sprite_terminator
+sBanetteGfx8:
+.incbin "baserom.gba", 0x149CD44, 0x200
+sBanetteSprites8:
+ax_sprite sBanetteGfx8, 0x200
+ax_sprite_terminator
+sBanetteGfx9:
+.incbin "baserom.gba", 0x149CF54, 0x200
+sBanetteSprites9:
+ax_sprite sBanetteGfx9, 0x200
+ax_sprite_terminator
+sBanetteGfx10:
+.incbin "baserom.gba", 0x149D164, 0x200
+sBanetteSprites10:
+ax_sprite sBanetteGfx10, 0x200
+ax_sprite_terminator
+sBanetteGfx11:
+.incbin "baserom.gba", 0x149D374, 0x200
+sBanetteSprites11:
+ax_sprite sBanetteGfx11, 0x200
+ax_sprite_terminator
+sBanetteGfx12:
+.incbin "baserom.gba", 0x149D584, 0x200
+sBanetteSprites12:
+ax_sprite sBanetteGfx12, 0x200
+ax_sprite_terminator
+sBanetteGfx13:
+.incbin "baserom.gba", 0x149D794, 0x200
+sBanetteSprites13:
+ax_sprite sBanetteGfx13, 0x200
+ax_sprite_terminator
+sBanetteGfx14:
+.incbin "baserom.gba", 0x149D9A4, 0x200
+sBanetteSprites14:
+ax_sprite sBanetteGfx14, 0x200
+ax_sprite_terminator
+sBanetteGfx15:
+.incbin "baserom.gba", 0x149DBB4, 0x200
+sBanetteSprites15:
+ax_sprite sBanetteGfx15, 0x200
+ax_sprite_terminator
+sBanetteGfx16:
+.incbin "baserom.gba", 0x149DDC4, 0x200
+sBanetteSprites16:
+ax_sprite sBanetteGfx16, 0x200
+ax_sprite_terminator
+sBanetteGfx17:
+.incbin "baserom.gba", 0x149DFD4, 0x200
+sBanetteSprites17:
+ax_sprite sBanetteGfx17, 0x200
+ax_sprite_terminator
+sBanetteGfx18:
+.incbin "baserom.gba", 0x149E1E4, 0x200
+sBanetteSprites18:
+ax_sprite sBanetteGfx18, 0x200
+ax_sprite_terminator
+sBanetteGfx19:
+.incbin "baserom.gba", 0x149E3F4, 0x200
+sBanetteSprites19:
+ax_sprite sBanetteGfx19, 0x200
+ax_sprite_terminator
+sBanetteGfx20:
+.incbin "baserom.gba", 0x149E604, 0x200
+sBanetteSprites20:
+ax_sprite sBanetteGfx20, 0x200
+ax_sprite_terminator
+sBanetteGfx21:
+.incbin "baserom.gba", 0x149E814, 0x200
+sBanetteSprites21:
+ax_sprite sBanetteGfx21, 0x200
+ax_sprite_terminator
+sBanetteGfx22:
+.incbin "baserom.gba", 0x149EA24, 0x200
+sBanetteSprites22:
+ax_sprite sBanetteGfx22, 0x200
+ax_sprite_terminator
+sBanetteGfx23:
+.incbin "baserom.gba", 0x149EC34, 0x200
+sBanetteSprites23:
+ax_sprite sBanetteGfx23, 0x200
+ax_sprite_terminator
+sBanetteGfx24:
+.incbin "baserom.gba", 0x149EE44, 0x200
+sBanetteSprites24:
+ax_sprite sBanetteGfx24, 0x200
+ax_sprite_terminator
+sBanetteGfx25:
+.incbin "baserom.gba", 0x149F054, 0x40
+sBanetteGfx25_1:
+.incbin "baserom.gba", 0x149F094, 0x100
+sBanetteSprites25:
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx25_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx26:
+.incbin "baserom.gba", 0x149F1C4, 0x100
+sBanetteGfx26_1:
+.incbin "baserom.gba", 0x149F2C4, 0x60
+sBanetteSprites26:
+ax_sprite sBanetteGfx26, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx26_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx27:
+.incbin "baserom.gba", 0x149F34C, 0xE0
+sBanetteGfx27_1:
+.incbin "baserom.gba", 0x149F42C, 0x60
+sBanetteSprites27:
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx27_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx28:
+.incbin "baserom.gba", 0x149F4BC, 0x140
+sBanetteSprites28:
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx28, 0x140
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx29:
+.incbin "baserom.gba", 0x149F61C, 0x60
+sBanetteGfx29_1:
+.incbin "baserom.gba", 0x149F67C, 0x60
+sBanetteGfx29_2:
+.incbin "baserom.gba", 0x149F6DC, 0x60
+sBanetteGfx29_3:
+.incbin "baserom.gba", 0x149F73C, 0x20
+sBanetteSprites29:
+ax_sprite sBanetteGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBanetteGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBanetteGfx30:
+.incbin "baserom.gba", 0x149F7A4, 0x60
+sBanetteGfx30_1:
+.incbin "baserom.gba", 0x149F804, 0x80
+sBanetteGfx30_2:
+.incbin "baserom.gba", 0x149F884, 0x60
+sBanetteSprites30:
+ax_sprite sBanetteGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx30_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx30_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx31:
+.incbin "baserom.gba", 0x149F91C, 0x60
+sBanetteGfx31_1:
+.incbin "baserom.gba", 0x149F97C, 0xE0
+sBanetteSprites31:
+ax_sprite sBanetteGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx31_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx32:
+.incbin "baserom.gba", 0x149FA84, 0x160
+sBanetteSprites32:
+ax_sprite sBanetteGfx32, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx33:
+.incbin "baserom.gba", 0x149FBFC, 0x60
+sBanetteGfx33_1:
+.incbin "baserom.gba", 0x149FC5C, 0x60
+sBanetteGfx33_2:
+.incbin "baserom.gba", 0x149FCBC, 0x40
+sBanetteSprites33:
+ax_sprite sBanetteGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBanetteGfx33_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx34:
+.incbin "baserom.gba", 0x149FD34, 0x20
+sBanetteGfx34_1:
+.incbin "baserom.gba", 0x149FD54, 0x40
+sBanetteGfx34_2:
+.incbin "baserom.gba", 0x149FD94, 0x80
+sBanetteSprites34:
+ax_sprite sBanetteGfx34, 0x20
+ax_sprite 0, 0x60
+ax_sprite sBanetteGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBanetteGfx34_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx35:
+.incbin "baserom.gba", 0x149FE4C, 0x60
+sBanetteGfx35_1:
+.incbin "baserom.gba", 0x149FEAC, 0x60
+sBanetteGfx35_2:
+.incbin "baserom.gba", 0x149FF0C, 0x60
+sBanetteSprites35:
+ax_sprite sBanetteGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx35_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBanetteGfx35_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx36:
+.incbin "baserom.gba", 0x149FFA4, 0x60
+sBanetteGfx36_1:
+.incbin "baserom.gba", 0x14A0004, 0x60
+sBanetteGfx36_2:
+.incbin "baserom.gba", 0x14A0064, 0x60
+sBanetteSprites36:
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx36_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx37:
+.incbin "baserom.gba", 0x14A0104, 0x40
+sBanetteGfx37_1:
+.incbin "baserom.gba", 0x14A0144, 0x20
+sBanetteGfx37_2:
+.incbin "baserom.gba", 0x14A0164, 0x60
+sBanetteSprites37:
+ax_sprite sBanetteGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBanetteGfx37_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sBanetteGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx38:
+.incbin "baserom.gba", 0x14A01FC, 0x60
+sBanetteGfx38_1:
+.incbin "baserom.gba", 0x14A025C, 0x60
+sBanetteGfx38_2:
+.incbin "baserom.gba", 0x14A02BC, 0x40
+sBanetteGfx38_3:
+.incbin "baserom.gba", 0x14A02FC, 0x20
+sBanetteSprites38:
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx38_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sBanetteGfx38_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBanetteGfx39:
+.incbin "baserom.gba", 0x14A036C, 0x160
+sBanetteSprites39:
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx39, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx40:
+.incbin "baserom.gba", 0x14A04EC, 0x60
+sBanetteGfx40_1:
+.incbin "baserom.gba", 0x14A054C, 0x40
+sBanetteSprites40:
+ax_sprite sBanetteGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx40_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBanetteGfx41:
+.incbin "baserom.gba", 0x14A05B4, 0x60
+sBanetteGfx41_1:
+.incbin "baserom.gba", 0x14A0614, 0x60
+sBanetteGfx41_2:
+.incbin "baserom.gba", 0x14A0674, 0x60
+sBanetteSprites41:
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx41_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx42:
+.incbin "baserom.gba", 0x14A0714, 0x100
+sBanetteGfx42_1:
+.incbin "baserom.gba", 0x14A0814, 0x40
+sBanetteSprites42:
+ax_sprite sBanetteGfx42, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx42_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx43:
+.incbin "baserom.gba", 0x14A087C, 0x60
+sBanetteGfx43_1:
+.incbin "baserom.gba", 0x14A08DC, 0x40
+sBanetteSprites43:
+ax_sprite sBanetteGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx43_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBanetteGfx44:
+.incbin "baserom.gba", 0x14A0944, 0x180
+sBanetteSprites44:
+ax_sprite sBanetteGfx44, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx45:
+.incbin "baserom.gba", 0x14A0ADC, 0x60
+sBanetteGfx45_1:
+.incbin "baserom.gba", 0x14A0B3C, 0x60
+sBanetteGfx45_2:
+.incbin "baserom.gba", 0x14A0B9C, 0x60
+sBanetteSprites45:
+ax_sprite sBanetteGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx45_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx46:
+.incbin "baserom.gba", 0x14A0C34, 0x60
+sBanetteGfx46_1:
+.incbin "baserom.gba", 0x14A0C94, 0x60
+sBanetteGfx46_2:
+.incbin "baserom.gba", 0x14A0CF4, 0x60
+sBanetteSprites46:
+ax_sprite sBanetteGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx46_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx47:
+.incbin "baserom.gba", 0x14A0D8C, 0xA0
+sBanetteSprites47:
+ax_sprite sBanetteGfx47, 0xa0
+ax_sprite 0, 0x160
+ax_sprite_terminator
+sBanetteGfx48:
+.incbin "baserom.gba", 0x14A0E44, 0x180
+sBanetteSprites48:
+ax_sprite sBanetteGfx48, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx49:
+.incbin "baserom.gba", 0x14A0FDC, 0x60
+sBanetteGfx49_1:
+.incbin "baserom.gba", 0x14A103C, 0x100
+sBanetteSprites49:
+ax_sprite sBanetteGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx49_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBanetteGfx50:
+.incbin "baserom.gba", 0x14A1164, 0x60
+sBanetteGfx50_1:
+.incbin "baserom.gba", 0x14A11C4, 0x60
+sBanetteGfx50_2:
+.incbin "baserom.gba", 0x14A1224, 0x60
+sBanetteSprites50:
+ax_sprite sBanetteGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx50_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx51:
+.incbin "baserom.gba", 0x14A12BC, 0x60
+sBanetteGfx51_1:
+.incbin "baserom.gba", 0x14A131C, 0x60
+sBanetteGfx51_2:
+.incbin "baserom.gba", 0x14A137C, 0x60
+sBanetteSprites51:
+ax_sprite sBanetteGfx51, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx51_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx51_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx52:
+.incbin "baserom.gba", 0x14A1414, 0x60
+sBanetteGfx52_1:
+.incbin "baserom.gba", 0x14A1474, 0x60
+sBanetteGfx52_2:
+.incbin "baserom.gba", 0x14A14D4, 0x60
+sBanetteGfx52_3:
+.incbin "baserom.gba", 0x14A1534, 0x20
+sBanetteSprites52:
+ax_sprite sBanetteGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx52_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBanetteGfx52_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBanetteGfx53:
+.incbin "baserom.gba", 0x14A159C, 0x20
+sBanetteSprites53:
+ax_sprite sBanetteGfx53, 0x20
+ax_sprite_terminator
+sBanetteGfx54:
+.incbin "baserom.gba", 0x14A15CC, 0x60
+sBanetteGfx54_1:
+.incbin "baserom.gba", 0x14A162C, 0x60
+sBanetteGfx54_2:
+.incbin "baserom.gba", 0x14A168C, 0x60
+sBanetteSprites54:
+ax_sprite sBanetteGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx54_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx55:
+.incbin "baserom.gba", 0x14A1724, 0x20
+sBanetteSprites55:
+ax_sprite sBanetteGfx55, 0x20
+ax_sprite_terminator
+sBanetteGfx56:
+.incbin "baserom.gba", 0x14A1754, 0x20
+sBanetteSprites56:
+ax_sprite sBanetteGfx56, 0x20
+ax_sprite_terminator
+sBanetteGfx57:
+.incbin "baserom.gba", 0x14A1784, 0x80
+sBanetteSprites57:
+ax_sprite sBanetteGfx57, 0x80
+ax_sprite_terminator
+sBanetteGfx58:
+.incbin "baserom.gba", 0x14A1814, 0x80
+sBanetteSprites58:
+ax_sprite sBanetteGfx58, 0x80
+ax_sprite_terminator
+sBanetteGfx59:
+.incbin "baserom.gba", 0x14A18A4, 0x80
+sBanetteSprites59:
+ax_sprite sBanetteGfx59, 0x80
+ax_sprite_terminator
+sBanetteGfx60:
+.incbin "baserom.gba", 0x14A1934, 0x60
+sBanetteGfx60_1:
+.incbin "baserom.gba", 0x14A1994, 0x60
+sBanetteGfx60_2:
+.incbin "baserom.gba", 0x14A19F4, 0x60
+sBanetteSprites60:
+ax_sprite sBanetteGfx60, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx60_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx61:
+.incbin "baserom.gba", 0x14A1A8C, 0x60
+sBanetteGfx61_1:
+.incbin "baserom.gba", 0x14A1AEC, 0x60
+sBanetteGfx61_2:
+.incbin "baserom.gba", 0x14A1B4C, 0x60
+sBanetteSprites61:
+ax_sprite sBanetteGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx61_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBanetteGfx61_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBanetteGfx62:
+.incbin "baserom.gba", 0x14A1BE4, 0x200
+sBanetteSprites62:
+ax_sprite sBanetteGfx62, 0x200
+ax_sprite_terminator
+sBanetteGfx63:
+.incbin "baserom.gba", 0x14A1DF4, 0x200
+sBanetteSprites63:
+ax_sprite sBanetteGfx63, 0x200
+ax_sprite_terminator
+sBanetteGfx64:
+.incbin "baserom.gba", 0x14A2004, 0x200
+sBanetteSprites64:
+ax_sprite sBanetteGfx64, 0x200
+ax_sprite_terminator
+sBanetteGfx65:
+.incbin "baserom.gba", 0x14A2214, 0x200
+sBanetteSprites65:
+ax_sprite sBanetteGfx65, 0x200
+ax_sprite_terminator
+sBanetteGfx66:
+.incbin "baserom.gba", 0x14A2424, 0x200
+sBanetteSprites66:
+ax_sprite sBanetteGfx66, 0x200
+ax_sprite_terminator
+sBanetteGfx67:
+.incbin "baserom.gba", 0x14A2634, 0x200
+sBanetteSprites67:
+ax_sprite sBanetteGfx67, 0x200
+ax_sprite_terminator
+sBanetteGfx68:
+.incbin "baserom.gba", 0x14A2844, 0x200
+sBanetteSprites68:
+ax_sprite sBanetteGfx68, 0x200
+ax_sprite_terminator
+sBanetteGfx69:
+.incbin "baserom.gba", 0x14A2A54, 0x200
+sBanetteSprites69:
+ax_sprite sBanetteGfx69, 0x200
+ax_sprite_terminator
+sBanetteGfx70:
+.incbin "baserom.gba", 0x14A2C64, 0x200
+sBanetteSprites70:
+ax_sprite sBanetteGfx70, 0x200
+ax_sprite_terminator
+sAxPosesBanette:
+.4byte sBanettePose1
+.4byte sBanettePose2
+.4byte sBanettePose3
+.4byte sBanettePose4
+.4byte sBanettePose5
+.4byte sBanettePose6
+.4byte sBanettePose7
+.4byte sBanettePose8
+.4byte sBanettePose9
+.4byte sBanettePose10
+.4byte sBanettePose11
+.4byte sBanettePose12
+.4byte sBanettePose13
+.4byte sBanettePose14
+.4byte sBanettePose15
+.4byte sBanettePose16
+.4byte sBanettePose17
+.4byte sBanettePose18
+.4byte sBanettePose19
+.4byte sBanettePose20
+.4byte sBanettePose21
+.4byte sBanettePose22
+.4byte sBanettePose23
+.4byte sBanettePose24
+.4byte sBanettePose25
+.4byte sBanettePose26
+.4byte sBanettePose27
+.4byte sBanettePose28
+.4byte sBanettePose29
+.4byte sBanettePose30
+.4byte sBanettePose31
+.4byte sBanettePose32
+.4byte sBanettePose33
+.4byte sBanettePose34
+.4byte sBanettePose35
+.4byte sBanettePose36
+.4byte sBanettePose37
+.4byte sBanettePose38
+.4byte sBanettePose39
+.4byte sBanettePose40
+.4byte sBanettePose41
+.4byte sBanettePose42
+.4byte sBanettePose43
+.4byte sBanettePose44
+.4byte sBanettePose45
+.4byte sBanettePose46
+.4byte sBanettePose47
+.4byte sBanettePose48
+.4byte sBanettePose49
+.4byte sBanettePose50
+.4byte sBanettePose51
+.4byte sBanettePose52
+.4byte sBanettePose53
+.4byte sBanettePose54
+.4byte sBanettePose55
+.4byte sBanettePose56
+.4byte sBanettePose57
+.4byte sBanettePose58
+.4byte sBanettePose59
+.4byte sBanettePose60
+.4byte sBanettePose61
+.4byte sBanettePose62
+.4byte sBanettePose63
+.4byte sBanettePose64
+.4byte sBanettePose65
+.4byte sBanettePose66
+.4byte sBanettePose67
+.4byte sBanettePose68
+.4byte sBanettePose69
+.4byte sBanettePose70
+.4byte sBanettePose71
+.4byte sBanettePose72
+.4byte sBanettePose73
+.4byte sBanettePose74
+.4byte sBanettePose75
+.4byte sBanettePose76
+.4byte sBanettePose77
+.4byte sBanettePose78
+.4byte sBanettePose79
+.4byte sBanettePose80
+.4byte sBanettePose81
+.4byte sBanettePose82
+.4byte sBanettePose83
+.4byte sBanettePose84
+.4byte sBanettePose85
+.4byte sBanettePose86
+.4byte sBanettePose87
+.4byte sBanettePose88
+.4byte sBanettePose89
+.4byte sBanettePose90
+.4byte sBanettePose91
+.4byte sBanettePose92
+.4byte sBanettePose93
+.4byte sBanettePose94
+.4byte sBanettePose95
+.4byte sBanettePose96
+.4byte sBanettePose97
+.4byte sBanettePose98
+.4byte sBanettePose99
+.4byte sBanettePose100
+.4byte sBanettePose101
+.4byte sBanettePose102
+.4byte sBanettePose103
+.4byte sBanettePose104
+.4byte sBanettePose105
+.4byte sBanettePose106
+.4byte sBanettePose107
+.4byte sBanettePose108
+.4byte sBanettePose109
+.4byte sBanettePose110
+.4byte sBanettePose111
+.4byte sBanettePose112
+.4byte sBanettePose113
+.4byte sBanettePose114
+.4byte sBanettePose115
+.4byte sBanettePose116
+.4byte sBanettePose117
+.4byte sBanettePose118
+.4byte sBanettePose119
+.4byte sBanettePose120
+.4byte sBanettePose121
+.4byte sBanettePose122
+.4byte sBanettePose123
+.4byte sBanettePose124
+.4byte sBanettePose125
+.4byte sBanettePose126
+.4byte sBanettePose127
+.4byte sBanettePose128
+.4byte sBanettePose129
+.4byte sBanettePose130
+.4byte sBanettePose131
+.4byte sBanettePose132
+.4byte sBanettePose133
+.4byte sBanettePose134
+.4byte sBanettePose135
+.4byte sBanettePose136
+.4byte sBanettePose137
+.4byte sBanettePose138
+.4byte sBanettePose139
+.4byte sBanettePose140
+.4byte sBanettePose141
+.4byte sBanettePose142
+.4byte sBanettePose143
+.4byte sBanettePose144
+.4byte sBanettePose145
+.4byte sBanettePose146
+.4byte sBanettePose147
+.4byte sBanettePose148
+.4byte sBanettePose149
+.4byte sBanettePose150
+.4byte sBanettePose151
+.4byte sBanettePose152
+.4byte sBanettePose153
+.4byte sBanettePose154
+.4byte sBanettePose155
+.4byte sBanettePose156
+.4byte sBanettePose157
+.4byte sBanettePose158
+.4byte sBanettePose159
+.4byte sBanettePose160
+.4byte sBanettePose161
+.4byte sBanettePose162
+.4byte sBanettePose163
+.4byte sBanettePose164
+.4byte sBanettePose165
+.4byte sBanettePose166
+.4byte sBanettePose167
+.4byte sBanettePose168
+.4byte sBanettePose169
+.4byte sBanettePose170
+.4byte sBanettePose171
+.4byte sBanettePose172
+.4byte sBanettePose173
+.4byte sBanettePose174
+.4byte sBanettePose175
+.4byte sBanettePose176
+.4byte sBanettePose177
+.4byte sBanettePose178
+.4byte sBanettePose179
+.4byte sBanettePose180
+.4byte sBanettePose181
+.4byte sBanettePose182
+.4byte sBanettePose183
+.4byte sBanettePose184
+.4byte sBanettePose185
+.4byte sBanettePose186
+.4byte sBanettePose187
+.4byte sBanettePose188
+.4byte sBanettePose189
+.4byte sBanettePose190
+.4byte sBanettePose191
+.4byte sBanettePose192
+.4byte sBanettePose193
+.4byte sBanettePose194
+.4byte sBanettePose195
+.4byte sBanettePose196
+.4byte sBanettePose197
+.4byte sBanettePose198
+.4byte sBanettePose199
+.4byte sBanettePose200
+.4byte sBanettePose201
+.4byte sBanettePose202
+.4byte sBanettePose203
+.4byte sBanettePose204
+.4byte sBanettePose205
+.4byte sBanettePose206
+.4byte sBanettePose207
+.4byte sBanettePose208
+.4byte sBanettePose209
+.4byte sBanettePose210
+.4byte sBanettePose211
+.4byte sBanettePose212
+.4byte sBanettePose213
+.4byte sBanettePose214
+.4byte sBanettePose215
+.4byte sBanettePose216
+.4byte sBanettePose217
+.4byte sBanettePose218
+.4byte sBanettePose219
+.4byte sBanettePose220
+.4byte sBanettePose221
+.4byte sBanettePose222
+.4byte sBanettePose223
+sAxPositionsBanette:
+.2byte    0,  -10, 	  -8,   -6, 	   7,   -6, 	   0,  -11
+.2byte    0,   -9, 	  -7,   -5, 	   6,   -3, 	   0,  -10
+.2byte    0,   -9, 	  -7,   -3, 	   7,   -6, 	   0,  -10
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    4,  -10, 	   1,   -4, 	   5,   -7, 	   2,   -8
+.2byte    4,  -10, 	  -3,   -4, 	   7,   -6, 	   2,   -8
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -11, 	   7,   -5, 	   1,   -8, 	   0,   -8
+.2byte    6,  -11, 	   4,   -4, 	   6,   -8, 	   1,   -8
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -13, 	   7,   -8, 	  -1,   -8, 	   2,   -9
+.2byte    5,  -13, 	   6,   -6, 	   2,  -10, 	   1,   -9
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,   -8, 	  -6,  -10, 	   0,  -10
+.2byte    0,  -14, 	   4,  -10, 	  -7,   -8, 	   0,  -10
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -13, 	   0,   -9, 	  -7,   -7, 	  -2,  -10
+.2byte   -6,  -13, 	  -3,  -10, 	  -7,   -5, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -11
+.2byte   -7,  -11, 	  -2,   -9, 	  -8,   -5, 	  -2,  -10
+.2byte   -7,  -11, 	  -7,   -8, 	  -6,   -4, 	  -2,   -9
+.2byte   -5,  -11, 	  -8,   -8, 	  -1,   -5, 	  -2,  -12
+.2byte   -5,  -10, 	  -7,   -6, 	  -2,   -3, 	  -2,  -11
+.2byte   -5,  -10, 	  -8,   -6, 	   2,   -4, 	  -2,  -11
+.2byte    0,  -10, 	  -8,   -6, 	   7,   -6, 	   0,  -11
+.2byte    0,   -8, 	 -11,  -10, 	  10,  -10, 	   0,  -11
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,   -9, 	  -3,   -8, 	  12,  -12, 	   1,  -13
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -11, 	   8,   -9, 	  11,  -14, 	   2,  -11
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    6,  -14, 	  11,  -11, 	   4,  -14, 	   1,  -10
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -17, 	   7,  -14, 	  -8,  -14, 	   0,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -7,  -13, 	  -3,  -15, 	 -12,  -11, 	  -1,  -11
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -11
+.2byte   -8,  -11, 	 -12,  -14, 	  -9,   -9, 	  -1,  -10
+.2byte   -5,  -11, 	  -8,   -8, 	  -1,   -5, 	  -2,  -12
+.2byte   -7,  -10, 	 -13,  -12, 	   2,   -8, 	   0,  -12
+.2byte    0,  -10, 	  -8,   -6, 	   7,   -6, 	   0,  -11
+.2byte   -1,  -10, 	 -10,  -16, 	  -3,   -5, 	  -1,  -12
+.2byte    4,  -10, 	   6,   -5, 	   6,  -11, 	   1,  -10
+.2byte    4,  -10, 	   6,   -5, 	   6,  -11, 	   1,  -10
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	   5,   -5, 	   5,  -20, 	   0,  -10
+.2byte    1,  -10, 	  -5,   -8, 	  -1,   -3, 	   1,  -11
+.2byte    1,  -10, 	  -5,   -8, 	  -1,   -3, 	   1,  -11
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    5,  -11, 	   8,   -7, 	  -4,  -13, 	   1,  -10
+.2byte    5,  -11, 	  -2,   -6, 	   4,   -4, 	   1,  -10
+.2byte    5,  -11, 	  -2,   -6, 	   4,   -4, 	   1,  -10
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	  -7,  -17, 	   9,  -11, 	   0,  -10
+.2byte    5,  -11, 	   2,   -6, 	   7,   -5, 	   1,  -10
+.2byte    5,  -11, 	   2,   -6, 	   7,   -5, 	   1,  -10
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    1,  -18, 	   9,  -16, 	  -3,  -14, 	   0,  -12
+.2byte   -6,  -16, 	  -9,   -7, 	  -2,  -15, 	  -2,  -11
+.2byte   -6,  -16, 	  -9,   -7, 	  -2,  -15, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -14, 	   6,  -17, 	 -10,  -11, 	  -1,  -10
+.2byte   -6,  -11, 	  -7,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -6,  -11, 	  -7,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -11
+.2byte   -6,  -11, 	   3,  -14, 	  -9,   -7, 	  -1,  -10
+.2byte   -6,  -12, 	  -5,   -4, 	   1,   -7, 	  -2,   -9
+.2byte   -6,  -12, 	  -5,   -4, 	   1,   -7, 	  -2,   -9
+.2byte   -5,  -11, 	  -8,   -8, 	  -1,   -5, 	  -2,  -12
+.2byte   -6,  -12, 	  -6,  -20, 	  -6,   -5, 	  -1,  -10
+.2byte   -2,  -10, 	  -1,   -3, 	   4,   -8, 	  -2,   -8
+.2byte   -2,  -10, 	  -1,   -3, 	   4,   -8, 	  -2,   -8
+.2byte    0,   -9, 	  -7,   -5, 	   6,   -3, 	   0,  -10
+.2byte   -4,  -10, 	  -6,   -6, 	  -1,   -3, 	  -1,  -11
+.2byte   -6,  -11, 	  -1,   -9, 	  -7,   -5, 	  -1,  -10
+.2byte   -4,  -13, 	   2,   -9, 	  -5,   -7, 	   0,  -10
+.2byte    0,  -15, 	   6,   -8, 	  -6,  -10, 	   0,  -10
+.2byte    4,  -13, 	   6,   -8, 	  -2,   -8, 	   1,   -9
+.2byte    6,  -11, 	   7,   -5, 	   1,   -8, 	   0,   -8
+.2byte    4,  -10, 	   1,   -4, 	   5,   -7, 	   2,   -8
+.2byte    0,  -10, 	  -8,   -6, 	   7,   -6, 	   0,  -11
+.2byte    0,  -10, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -10, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -10, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -10, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -10, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -10, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -10, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -11
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -8,   -8, 	  -1,   -5, 	  -2,  -12
+.2byte   -5,  -11, 	  -7,   -8, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -7,   -8, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -7,   -8, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -7,   -8, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -7,   -8, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -7,   -8, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -7,   -8, 	  -1,   -6, 	  -2,  -10
+.2byte   -4,   -5, 	  -7,   -4, 	   6,    0, 	   0,   -3
+.2byte   -4,   -6, 	  -6,   -4, 	   6,    0, 	  -1,   -4
+.2byte    0,  -14, 	 -11,  -18, 	  10,  -18, 	   0,  -10
+.2byte   -1,  -12, 	   3,  -15, 	 -11,  -13, 	  -3,  -10
+.2byte    0,  -13, 	  -7,  -16, 	  -9,  -12, 	  -5,  -10
+.2byte   -2,  -15, 	  -8,  -13, 	   2,  -13, 	  -5,   -8
+.2byte    0,  -14, 	   8,  -12, 	  -9,  -12, 	   0,   -9
+.2byte    1,  -15, 	   7,  -13, 	  -3,  -13, 	   4,   -8
+.2byte   -1,  -13, 	   6,  -13, 	   9,  -12, 	   4,  -10
+.2byte    0,  -13, 	  -4,  -15, 	  10,  -13, 	   2,  -10
+.2byte    0,  -10, 	  -8,   -6, 	   7,   -6, 	   0,  -11
+.2byte    0,   -9, 	  -7,   -5, 	   6,   -3, 	   0,  -10
+.2byte    0,   -9, 	  -7,   -3, 	   7,   -6, 	   0,  -10
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    4,  -10, 	   1,   -4, 	   5,   -7, 	   2,   -8
+.2byte    4,  -10, 	  -3,   -4, 	   7,   -6, 	   2,   -8
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    6,  -11, 	   7,   -5, 	   1,   -8, 	   0,   -8
+.2byte    6,  -11, 	   4,   -4, 	   6,   -8, 	   1,   -8
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -13, 	   7,   -8, 	  -1,   -8, 	   2,   -9
+.2byte    5,  -13, 	   6,   -6, 	   2,  -10, 	   1,   -9
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -15, 	   6,   -8, 	  -6,  -10, 	   0,  -10
+.2byte    0,  -14, 	   4,  -10, 	  -7,   -8, 	   0,  -10
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -13, 	   0,   -9, 	  -7,   -7, 	  -2,  -10
+.2byte   -6,  -13, 	  -3,  -10, 	  -7,   -5, 	  -2,  -10
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -11
+.2byte   -7,  -11, 	  -2,   -9, 	  -8,   -5, 	  -2,  -10
+.2byte   -7,  -11, 	  -7,   -8, 	  -6,   -4, 	  -2,   -9
+.2byte   -5,  -11, 	  -8,   -8, 	  -1,   -5, 	  -2,  -12
+.2byte   -5,  -10, 	  -7,   -6, 	  -2,   -3, 	  -2,  -11
+.2byte   -5,  -10, 	  -8,   -6, 	   2,   -4, 	  -2,  -11
+.2byte    0,   -7, 	 -11,   -9, 	  10,   -9, 	   0,  -10
+.2byte   -7,   -9, 	 -13,  -11, 	   2,   -7, 	   0,  -11
+.2byte   -8,  -10, 	 -12,  -13, 	  -9,   -8, 	  -1,   -9
+.2byte   -6,  -13, 	  -2,  -15, 	 -11,  -11, 	   0,  -11
+.2byte    0,  -17, 	   7,  -14, 	  -8,  -14, 	   0,  -11
+.2byte    5,  -14, 	  10,  -11, 	   3,  -14, 	   0,  -10
+.2byte    6,  -10, 	   8,   -8, 	  11,  -13, 	   2,  -10
+.2byte    5,   -8, 	  -3,   -7, 	  12,  -11, 	   1,  -12
+.2byte    0,   -8, 	 -11,  -10, 	  10,  -10, 	   0,  -11
+.2byte    4,   -9, 	  -4,   -8, 	  11,  -12, 	   0,  -13
+.2byte    5,  -11, 	   7,   -9, 	  10,  -14, 	   1,  -11
+.2byte    5,  -14, 	  10,  -11, 	   3,  -14, 	   0,  -10
+.2byte    0,  -17, 	   7,  -14, 	  -8,  -14, 	   0,  -11
+.2byte   -6,  -13, 	  -2,  -15, 	 -11,  -11, 	   0,  -11
+.2byte   -7,  -11, 	 -11,  -14, 	  -8,   -9, 	   0,  -10
+.2byte   -6,  -10, 	 -12,  -12, 	   3,   -8, 	   1,  -12
+.2byte    0,  -10, 	  -8,   -6, 	   7,   -6, 	   0,  -11
+.2byte    0,   -8, 	 -11,  -10, 	  10,  -10, 	   0,  -11
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+.2byte    4,   -9, 	  -4,   -8, 	  11,  -12, 	   0,  -13
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    5,  -11, 	   7,   -9, 	  10,  -14, 	   1,  -11
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    5,  -14, 	  10,  -11, 	   3,  -14, 	   0,  -10
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    0,  -17, 	   7,  -14, 	  -8,  -14, 	   0,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -6,  -13, 	  -2,  -15, 	 -11,  -11, 	   0,  -11
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -14, 	  -8,   -9, 	   0,  -10
+.2byte   -5,  -11, 	  -8,   -8, 	  -1,   -5, 	  -2,  -12
+.2byte   -6,  -10, 	 -12,  -12, 	   3,   -8, 	   1,  -12
+.2byte    0,   -7, 	  -8,   -3, 	   7,   -3, 	   0,   -8
+.2byte   -5,   -8, 	  -8,   -5, 	  -1,   -2, 	  -2,   -9
+.2byte   -7,   -9, 	  -7,   -7, 	  -7,   -3, 	  -2,   -8
+.2byte   -6,  -11, 	  -1,   -7, 	  -8,   -4, 	  -2,   -8
+.2byte    0,  -12, 	   6,   -7, 	  -7,   -7, 	   0,   -9
+.2byte    5,  -11, 	   7,   -5, 	  -1,   -7, 	   2,   -7
+.2byte    6,   -9, 	   5,   -3, 	   6,   -7, 	   1,   -6
+.2byte    5,   -8, 	  -1,   -2, 	   7,   -5, 	   2,   -6
+.2byte    0,  -10, 	  -8,   -6, 	   7,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -8,   -8, 	  -1,   -5, 	  -2,  -12
+.2byte   -7,  -12, 	  -7,  -10, 	  -7,   -6, 	  -2,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -12
+.2byte    5,  -14, 	   7,   -8, 	  -1,  -10, 	   2,  -10
+.2byte    6,  -12, 	   5,   -6, 	   6,  -10, 	   1,   -9
+.2byte    5,  -11, 	  -1,   -5, 	   7,   -8, 	   2,   -9
+sBanetteAnimTable1:
+.4byte sBanetteAnims_1_1
+.4byte sBanetteAnims_1_2
+.4byte sBanetteAnims_1_3
+.4byte sBanetteAnims_1_4
+.4byte sBanetteAnims_1_5
+.4byte sBanetteAnims_1_6
+.4byte sBanetteAnims_1_7
+.4byte sBanetteAnims_1_8
+sBanetteAnimTable2:
+.4byte sBanetteAnims_2_1
+.4byte sBanetteAnims_2_2
+.4byte sBanetteAnims_2_3
+.4byte sBanetteAnims_2_4
+.4byte sBanetteAnims_2_5
+.4byte sBanetteAnims_2_6
+.4byte sBanetteAnims_2_7
+.4byte sBanetteAnims_2_8
+sBanetteAnimTable3:
+.4byte sBanetteAnims_3_1
+.4byte sBanetteAnims_3_2
+.4byte sBanetteAnims_3_3
+.4byte sBanetteAnims_3_4
+.4byte sBanetteAnims_3_5
+.4byte sBanetteAnims_3_6
+.4byte sBanetteAnims_3_7
+.4byte sBanetteAnims_3_8
+sBanetteAnimTable4:
+.4byte sBanetteAnims_4_1
+.4byte sBanetteAnims_4_2
+.4byte sBanetteAnims_4_3
+.4byte sBanetteAnims_4_4
+.4byte sBanetteAnims_4_5
+.4byte sBanetteAnims_4_6
+.4byte sBanetteAnims_4_7
+.4byte sBanetteAnims_4_8
+sBanetteAnimTable5:
+.4byte sBanetteAnims_5_1
+.4byte sBanetteAnims_5_2
+.4byte sBanetteAnims_5_3
+.4byte sBanetteAnims_5_4
+.4byte sBanetteAnims_5_5
+.4byte sBanetteAnims_5_6
+.4byte sBanetteAnims_5_7
+.4byte sBanetteAnims_5_8
+sBanetteAnimTable6:
+.4byte sBanetteAnims_6_1
+.4byte sBanetteAnims_6_1
+.4byte sBanetteAnims_6_1
+.4byte sBanetteAnims_6_1
+.4byte sBanetteAnims_6_1
+.4byte sBanetteAnims_6_1
+.4byte sBanetteAnims_6_1
+.4byte sBanetteAnims_6_1
+sBanetteAnimTable7:
+.4byte sBanetteAnims_7_1
+.4byte sBanetteAnims_7_2
+.4byte sBanetteAnims_7_3
+.4byte sBanetteAnims_7_4
+.4byte sBanetteAnims_7_5
+.4byte sBanetteAnims_7_6
+.4byte sBanetteAnims_7_7
+.4byte sBanetteAnims_7_8
+sBanetteAnimTable8:
+.4byte sBanetteAnims_8_1
+.4byte sBanetteAnims_8_2
+.4byte sBanetteAnims_8_3
+.4byte sBanetteAnims_8_4
+.4byte sBanetteAnims_8_5
+.4byte sBanetteAnims_8_6
+.4byte sBanetteAnims_8_7
+.4byte sBanetteAnims_8_8
+sBanetteAnimTable9:
+.4byte sBanetteAnims_9_1
+.4byte sBanetteAnims_9_2
+.4byte sBanetteAnims_9_3
+.4byte sBanetteAnims_9_4
+.4byte sBanetteAnims_9_5
+.4byte sBanetteAnims_9_6
+.4byte sBanetteAnims_9_7
+.4byte sBanetteAnims_9_8
+sBanetteAnimTable10:
+.4byte sBanetteAnims_10_1
+.4byte sBanetteAnims_10_2
+.4byte sBanetteAnims_10_3
+.4byte sBanetteAnims_10_4
+.4byte sBanetteAnims_10_5
+.4byte sBanetteAnims_10_6
+.4byte sBanetteAnims_10_7
+.4byte sBanetteAnims_10_8
+sBanetteAnimTable11:
+.4byte sBanetteAnims_11_1
+.4byte sBanetteAnims_11_2
+.4byte sBanetteAnims_11_3
+.4byte sBanetteAnims_11_4
+.4byte sBanetteAnims_11_5
+.4byte sBanetteAnims_11_6
+.4byte sBanetteAnims_11_7
+.4byte sBanetteAnims_11_8
+sBanetteAnimTable12:
+.4byte sBanetteAnims_12_1
+.4byte sBanetteAnims_12_2
+.4byte sBanetteAnims_12_3
+.4byte sBanetteAnims_12_4
+.4byte sBanetteAnims_12_5
+.4byte sBanetteAnims_12_6
+.4byte sBanetteAnims_12_7
+.4byte sBanetteAnims_12_8
+sBanetteAnimTable13:
+.4byte sBanetteAnims_13_1
+.4byte sBanetteAnims_13_2
+.4byte sBanetteAnims_13_3
+.4byte sBanetteAnims_13_4
+.4byte sBanetteAnims_13_5
+.4byte sBanetteAnims_13_6
+.4byte sBanetteAnims_13_7
+.4byte sBanetteAnims_13_8
+sAxAnimationsBanette:
+.4byte sBanetteAnimTable1
+.4byte sBanetteAnimTable2
+.4byte sBanetteAnimTable3
+.4byte sBanetteAnimTable4
+.4byte sBanetteAnimTable5
+.4byte sBanetteAnimTable6
+.4byte sBanetteAnimTable7
+.4byte sBanetteAnimTable8
+.4byte sBanetteAnimTable9
+.4byte sBanetteAnimTable10
+.4byte sBanetteAnimTable11
+.4byte sBanetteAnimTable12
+.4byte sBanetteAnimTable13
+sAxSpritesBanette:
+.4byte sBanetteSprites1
+.4byte sBanetteSprites2
+.4byte sBanetteSprites3
+.4byte sBanetteSprites4
+.4byte sBanetteSprites5
+.4byte sBanetteSprites6
+.4byte sBanetteSprites7
+.4byte sBanetteSprites8
+.4byte sBanetteSprites9
+.4byte sBanetteSprites10
+.4byte sBanetteSprites11
+.4byte sBanetteSprites12
+.4byte sBanetteSprites13
+.4byte sBanetteSprites14
+.4byte sBanetteSprites15
+.4byte sBanetteSprites16
+.4byte sBanetteSprites17
+.4byte sBanetteSprites18
+.4byte sBanetteSprites19
+.4byte sBanetteSprites20
+.4byte sBanetteSprites21
+.4byte sBanetteSprites22
+.4byte sBanetteSprites23
+.4byte sBanetteSprites24
+.4byte sBanetteSprites25
+.4byte sBanetteSprites26
+.4byte sBanetteSprites27
+.4byte sBanetteSprites28
+.4byte sBanetteSprites29
+.4byte sBanetteSprites30
+.4byte sBanetteSprites31
+.4byte sBanetteSprites32
+.4byte sBanetteSprites33
+.4byte sBanetteSprites34
+.4byte sBanetteSprites35
+.4byte sBanetteSprites36
+.4byte sBanetteSprites37
+.4byte sBanetteSprites38
+.4byte sBanetteSprites39
+.4byte sBanetteSprites40
+.4byte sBanetteSprites41
+.4byte sBanetteSprites42
+.4byte sBanetteSprites43
+.4byte sBanetteSprites44
+.4byte sBanetteSprites45
+.4byte sBanetteSprites46
+.4byte sBanetteSprites47
+.4byte sBanetteSprites48
+.4byte sBanetteSprites49
+.4byte sBanetteSprites50
+.4byte sBanetteSprites51
+.4byte sBanetteSprites52
+.4byte sBanetteSprites53
+.4byte sBanetteSprites54
+.4byte sBanetteSprites55
+.4byte sBanetteSprites56
+.4byte sBanetteSprites57
+.4byte sBanetteSprites58
+.4byte sBanetteSprites59
+.4byte sBanetteSprites60
+.4byte sBanetteSprites61
+.4byte sBanetteSprites62
+.4byte sBanetteSprites63
+.4byte sBanetteSprites64
+.4byte sBanetteSprites65
+.4byte sBanetteSprites66
+.4byte sBanetteSprites67
+.4byte sBanetteSprites68
+.4byte sBanetteSprites69
+.4byte sBanetteSprites70
+sAxMainBanette:
+ax_main sAxPosesBanette, sAxAnimationsBanette, 13, sAxSpritesBanette, sAxPositionsBanette

--- a/data/ax/barboach.inc
+++ b/data/ax/barboach.inc
@@ -1,0 +1,2704 @@
+.global gAxBarboach
+gAxBarboach:
+ax_siro sAxMainBarboach
+sBarboachPose1:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose2:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose3:
+ax_pose 2, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose4:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose5:
+ax_pose 4, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose6:
+ax_pose 5, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose7:
+ax_pose 6, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose8:
+ax_pose 7, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose9:
+ax_pose 8, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose10:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose11:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose12:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose13:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose14:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose15:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose16:
+ax_pose 15, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose17:
+ax_pose 16, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose18:
+ax_pose 17, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose19:
+ax_pose 18, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose20:
+ax_pose 19, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose21:
+ax_pose 20, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose22:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose23:
+ax_pose 22, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose24:
+ax_pose 23, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose25:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose26:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose27:
+ax_pose 2, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose28:
+ax_pose 24, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose29:
+ax_pose 25, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose30:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose31:
+ax_pose 4, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose32:
+ax_pose 5, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose33:
+ax_pose 26, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose34:
+ax_pose 27, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose35:
+ax_pose 6, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose36:
+ax_pose 7, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose37:
+ax_pose 8, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose38:
+ax_pose 28, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose39:
+ax_pose 29, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose41:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose43:
+ax_pose 30, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose44:
+ax_pose 31, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose45:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose46:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose47:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose48:
+ax_pose 32, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose49:
+ax_pose 33, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose50:
+ax_pose 15, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose51:
+ax_pose 16, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose52:
+ax_pose 17, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose53:
+ax_pose 30, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose54:
+ax_pose 31, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose55:
+ax_pose 18, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose56:
+ax_pose 19, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose57:
+ax_pose 20, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose58:
+ax_pose 28, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose59:
+ax_pose 29, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose60:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose61:
+ax_pose 22, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose62:
+ax_pose 23, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose63:
+ax_pose 26, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose64:
+ax_pose 27, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose65:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose66:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose67:
+ax_pose 2, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose68:
+ax_pose 24, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose69:
+ax_pose 25, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose70:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose71:
+ax_pose 4, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose72:
+ax_pose 5, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose73:
+ax_pose 26, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose74:
+ax_pose 27, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose75:
+ax_pose 6, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose76:
+ax_pose 7, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose77:
+ax_pose 8, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose78:
+ax_pose 28, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose79:
+ax_pose 29, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose80:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose81:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose82:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose83:
+ax_pose 30, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose84:
+ax_pose 31, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose85:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose86:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose87:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose88:
+ax_pose 32, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose89:
+ax_pose 33, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose90:
+ax_pose 15, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose91:
+ax_pose 16, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose92:
+ax_pose 17, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose93:
+ax_pose 30, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose94:
+ax_pose 31, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose95:
+ax_pose 18, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose96:
+ax_pose 19, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose97:
+ax_pose 20, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose98:
+ax_pose 28, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose99:
+ax_pose 29, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose100:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose101:
+ax_pose 22, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose102:
+ax_pose 23, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose103:
+ax_pose 26, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose104:
+ax_pose 27, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose105:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose106:
+ax_pose 24, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose107:
+ax_pose 25, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose108:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose109:
+ax_pose 26, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose110:
+ax_pose 27, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose111:
+ax_pose 6, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose112:
+ax_pose 28, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose113:
+ax_pose 29, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose114:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose115:
+ax_pose 30, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose116:
+ax_pose 31, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose117:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose118:
+ax_pose 32, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose119:
+ax_pose 33, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose120:
+ax_pose 15, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose121:
+ax_pose 30, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose122:
+ax_pose 31, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose123:
+ax_pose 18, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose124:
+ax_pose 28, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose125:
+ax_pose 29, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose126:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose127:
+ax_pose 26, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose128:
+ax_pose 27, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose129:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose130:
+ax_pose 24, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose131:
+ax_pose 25, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose132:
+ax_pose 4, 0x01ed, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose133:
+ax_pose 26, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose134:
+ax_pose 27, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose135:
+ax_pose 7, 0x41f2, 0x80ef, 0x5c00
+ax_pose_terminator
+sBarboachPose136:
+ax_pose 28, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose137:
+ax_pose 29, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose138:
+ax_pose 10, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose139:
+ax_pose 30, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sBarboachPose140:
+ax_pose 31, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sBarboachPose141:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose142:
+ax_pose 32, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose143:
+ax_pose 33, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose144:
+ax_pose 17, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose145:
+ax_pose 30, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose146:
+ax_pose 31, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose147:
+ax_pose 20, 0x41f2, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose148:
+ax_pose 28, 0x41f2, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose149:
+ax_pose 29, 0x41f2, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose150:
+ax_pose 22, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose151:
+ax_pose 26, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose152:
+ax_pose 27, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose153:
+ax_pose 34, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sBarboachPose154:
+ax_pose 35, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sBarboachPose155:
+ax_pose 36, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sBarboachPose156:
+ax_pose 37, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sBarboachPose157:
+ax_pose 38, 0x01e4, 0x90e9, 0x5c00
+ax_pose_terminator
+sBarboachPose158:
+ax_pose 39, 0x01e3, 0x90ed, 0x5c00
+ax_pose_terminator
+sBarboachPose159:
+ax_pose 40, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sBarboachPose160:
+ax_pose 39, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose161:
+ax_pose 38, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose162:
+ax_pose 37, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sBarboachPose163:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose164:
+ax_pose 1, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose165:
+ax_pose 2, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose166:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose167:
+ax_pose 4, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose168:
+ax_pose 5, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose169:
+ax_pose 6, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose170:
+ax_pose 7, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose171:
+ax_pose 8, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose172:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose173:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose174:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose175:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose176:
+ax_pose 13, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose177:
+ax_pose 14, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose178:
+ax_pose 15, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose179:
+ax_pose 16, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose180:
+ax_pose 17, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose181:
+ax_pose 18, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose182:
+ax_pose 19, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose183:
+ax_pose 20, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose184:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose185:
+ax_pose 22, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose186:
+ax_pose 23, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose187:
+ax_pose 25, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose188:
+ax_pose 27, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sBarboachPose189:
+ax_pose 29, 0x41f3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose190:
+ax_pose 31, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose191:
+ax_pose 33, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose192:
+ax_pose 31, 0x01ed, 0x90ed, 0x5c00
+ax_pose_terminator
+sBarboachPose193:
+ax_pose 29, 0x41f3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBarboachPose194:
+ax_pose 27, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose195:
+ax_pose 25, 0x81ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose196:
+ax_pose 27, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose197:
+ax_pose 29, 0x41f3, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose198:
+ax_pose 31, 0x01ed, 0x90ee, 0x5c00
+ax_pose_terminator
+sBarboachPose199:
+ax_pose 33, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose200:
+ax_pose 31, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose201:
+ax_pose 29, 0x41f3, 0x80f1, 0x5c00
+ax_pose_terminator
+sBarboachPose202:
+ax_pose 27, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose203:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose204:
+ax_pose 24, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose205:
+ax_pose 25, 0x81ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose206:
+ax_pose 3, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose207:
+ax_pose 26, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose208:
+ax_pose 27, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose209:
+ax_pose 6, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose210:
+ax_pose 28, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose211:
+ax_pose 29, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose212:
+ax_pose 9, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose213:
+ax_pose 30, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sBarboachPose214:
+ax_pose 31, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sBarboachPose215:
+ax_pose 12, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose216:
+ax_pose 32, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose217:
+ax_pose 33, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose218:
+ax_pose 15, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose219:
+ax_pose 30, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose220:
+ax_pose 31, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose221:
+ax_pose 18, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose222:
+ax_pose 28, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose223:
+ax_pose 29, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose224:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose225:
+ax_pose 26, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose226:
+ax_pose 27, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose227:
+ax_pose 24, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sBarboachPose228:
+ax_pose 26, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose229:
+ax_pose 28, 0x41f0, 0x80f1, 0x5c00
+ax_pose_terminator
+sBarboachPose230:
+ax_pose 30, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sBarboachPose231:
+ax_pose 32, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose232:
+ax_pose 30, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose233:
+ax_pose 28, 0x41f0, 0x90ef, 0x5c00
+ax_pose_terminator
+sBarboachPose234:
+ax_pose 26, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sBarboachPose235:
+ax_pose 0, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose236:
+ax_pose 21, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose237:
+ax_pose 18, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose238:
+ax_pose 15, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sBarboachPose239:
+ax_pose 12, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sBarboachPose240:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sBarboachPose241:
+ax_pose 6, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBarboachPose242:
+ax_pose 3, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+.align 2
+sBarboachAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 1, 28, 1, 14, 1, 14,
+ax_anim 2, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 0, 28, 1, 14, 1, 14,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBarboachAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 32, 21, 18, 21, 18,
+ax_anim 2, 1, 33, 22, 17, 22, 17,
+ax_anim 2, 0, 32, 21, 18, 21, 18,
+ax_anim 2, 0, 33, 22, 17, 22, 17,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sBarboachAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sBarboachAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, 2, -1,
+ax_anim 4, 0, 39, -2, 2, 1, 0,
+ax_anim 1, 0, 41, 0, -1, 3, -3,
+ax_anim 1, 2, 40, 4, -6, 7, -8,
+ax_anim 1, 0, 41, 10, -13, 13, -15,
+ax_anim 2, 0, 42, 18, -21, 21, -23,
+ax_anim 2, 1, 43, 19, -20, 22, -22,
+ax_anim 2, 0, 42, 18, -21, 21, -23,
+ax_anim 2, 0, 43, 19, -20, 22, -22,
+ax_anim 2, 0, 39, 6, -7, 9, -9,
+ax_anim_terminator
+sBarboachAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, -2,
+ax_anim 4, 0, 44, 0, 2, 0, -1,
+ax_anim 1, 0, 46, 0, 0, 0, -3,
+ax_anim 1, 2, 45, 0, -4, 0, -7,
+ax_anim 1, 0, 46, 0, -11, 0, -14,
+ax_anim 2, 0, 47, 0, -21, 0, -24,
+ax_anim 2, 1, 48, 1, -21, 1, -24,
+ax_anim 2, 0, 47, 0, -21, 0, -24,
+ax_anim 2, 0, 48, 1, -21, 1, -24,
+ax_anim 2, 0, 44, 0, -6, 0, -9,
+ax_anim_terminator
+sBarboachAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, -2, -1,
+ax_anim 4, 0, 49, 2, 2, -1, 0,
+ax_anim 1, 0, 51, 0, -1, -3, -3,
+ax_anim 1, 2, 50, -4, -6, -7, -8,
+ax_anim 1, 0, 51, -10, -13, -13, -15,
+ax_anim 2, 0, 52, -18, -21, -21, -23,
+ax_anim 2, 1, 53, -19, -20, -22, -22,
+ax_anim 2, 0, 52, -18, -21, -21, -23,
+ax_anim 2, 0, 53, -19, -20, -22, -22,
+ax_anim 2, 0, 49, -6, -7, -9, -9,
+ax_anim_terminator
+sBarboachAnims_2_7:
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 4, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 56, -10, 0, -10, 0,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sBarboachAnims_2_8:
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 4, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 61, -11, 9, -11, 9,
+ax_anim 2, 0, 62, -20, 16, -20, 16,
+ax_anim 2, 1, 63, -21, 15, -21, 15,
+ax_anim 2, 0, 62, -20, 16, -20, 16,
+ax_anim 2, 0, 63, -21, 15, -21, 15,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBarboachAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 64, 0, -2, 0, -2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 14, 0, 14,
+ax_anim 2, 1, 68, 1, 14, 1, 14,
+ax_anim 2, 0, 67, 0, 14, 0, 14,
+ax_anim 2, 0, 68, 1, 14, 1, 14,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sBarboachAnims_3_2:
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 4, 0, 69, -2, -2, -2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, 4, 4, 4,
+ax_anim 1, 0, 71, 10, 10, 10, 10,
+ax_anim 2, 0, 72, 21, 18, 21, 18,
+ax_anim 2, 1, 73, 22, 17, 22, 17,
+ax_anim 2, 0, 72, 21, 18, 21, 18,
+ax_anim 2, 0, 73, 22, 17, 22, 17,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sBarboachAnims_3_3:
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 4, 0, 74, -2, 0, -2, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 4, 0, 4, 0,
+ax_anim 1, 0, 76, 10, 0, 10, 0,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 1, 78, 18, 1, 18, 1,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 0, 78, 18, 1, 18, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sBarboachAnims_3_4:
+ax_anim 2, 0, 79, -1, 1, 2, -1,
+ax_anim 4, 0, 79, -2, 2, 1, 0,
+ax_anim 1, 0, 81, 0, -1, 3, -3,
+ax_anim 1, 2, 80, 4, -6, 7, -8,
+ax_anim 1, 0, 81, 10, -13, 13, -15,
+ax_anim 2, 0, 82, 18, -21, 21, -23,
+ax_anim 2, 1, 83, 19, -20, 22, -22,
+ax_anim 2, 0, 82, 18, -21, 21, -23,
+ax_anim 2, 0, 83, 19, -20, 22, -22,
+ax_anim 2, 0, 79, 6, -7, 9, -9,
+ax_anim_terminator
+sBarboachAnims_3_5:
+ax_anim 2, 0, 84, 0, 1, 0, -2,
+ax_anim 4, 0, 84, 0, 2, 0, -1,
+ax_anim 1, 0, 86, 0, 0, 0, -3,
+ax_anim 1, 2, 85, 0, -4, 0, -7,
+ax_anim 1, 0, 86, 0, -11, 0, -14,
+ax_anim 2, 0, 87, 0, -21, 0, -24,
+ax_anim 2, 1, 88, 1, -21, 1, -24,
+ax_anim 2, 0, 87, 0, -21, 0, -24,
+ax_anim 2, 0, 88, 1, -21, 1, -24,
+ax_anim 2, 0, 84, 0, -6, 0, -9,
+ax_anim_terminator
+sBarboachAnims_3_6:
+ax_anim 2, 0, 89, 1, 1, -2, -1,
+ax_anim 4, 0, 89, 2, 2, -1, 0,
+ax_anim 1, 0, 91, 0, -1, -3, -3,
+ax_anim 1, 2, 90, -4, -6, -7, -8,
+ax_anim 1, 0, 91, -10, -13, -13, -15,
+ax_anim 2, 0, 92, -18, -21, -21, -23,
+ax_anim 2, 1, 93, -19, -20, -22, -22,
+ax_anim 2, 0, 92, -18, -21, -21, -23,
+ax_anim 2, 0, 93, -19, -20, -22, -22,
+ax_anim 2, 0, 89, -6, -7, -9, -9,
+ax_anim_terminator
+sBarboachAnims_3_7:
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 4, 0, 94, 2, 0, 2, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 95, -4, 0, -4, 0,
+ax_anim 1, 0, 96, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 1, 98, -18, 1, -18, 1,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 0, 98, -18, 1, -18, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sBarboachAnims_3_8:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 100, -4, 4, -4, 4,
+ax_anim 1, 0, 101, -11, 9, -11, 9,
+ax_anim 2, 0, 102, -20, 16, -20, 16,
+ax_anim 2, 1, 103, -21, 15, -21, 15,
+ax_anim 2, 0, 102, -20, 16, -20, 16,
+ax_anim 2, 0, 103, -21, 15, -21, 15,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBarboachAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sBarboachAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sBarboachAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -1, 0,
+ax_anim 6, 2, 111, -3, 0, -2, 0,
+ax_anim 2, 0, 110, -1, 0, 0, 0,
+ax_anim 2, 1, 112, 2, 0, 3, 0,
+ax_anim 2, 0, 112, 2, 1, 3, 1,
+ax_anim 2, 0, 112, 2, 0, 3, 0,
+ax_anim 2, 0, 112, 2, 1, 3, 1,
+ax_anim 2, 0, 112, 2, 0, 3, 0,
+ax_anim 2, 0, 112, 2, 1, 3, 1,
+ax_anim 2, 0, 112, 2, 0, 3, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sBarboachAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, 1, 0,
+ax_anim 6, 2, 114, -3, 3, 0, 1,
+ax_anim 2, 0, 113, -1, 1, 2, 0,
+ax_anim 2, 1, 115, 2, -2, 6, -2,
+ax_anim 2, 0, 115, 3, -1, 7, -1,
+ax_anim 2, 0, 115, 2, -2, 6, -2,
+ax_anim 2, 0, 115, 3, -1, 7, -1,
+ax_anim 2, 0, 115, 2, -2, 6, -2,
+ax_anim 2, 0, 115, 3, -1, 7, -1,
+ax_anim 2, 0, 115, 2, -2, 6, -2,
+ax_anim 2, 0, 113, 1, -1, 2, -1,
+ax_anim_terminator
+sBarboachAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, -1,
+ax_anim 6, 2, 117, 0, 3, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, -3,
+ax_anim 2, 1, 118, 0, -3, 0, -6,
+ax_anim 2, 0, 118, 1, -3, 1, -6,
+ax_anim 2, 0, 118, 0, -3, 0, -6,
+ax_anim 2, 0, 118, 1, -3, 1, -6,
+ax_anim 2, 0, 118, 0, -3, 0, -6,
+ax_anim 2, 0, 118, 1, -3, 1, -6,
+ax_anim 2, 0, 118, 0, -3, 0, -6,
+ax_anim 2, 0, 116, 0, -1, 0, -6,
+ax_anim_terminator
+sBarboachAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, -1, 0,
+ax_anim 6, 2, 120, 3, 3, 0, 1,
+ax_anim 2, 0, 119, 1, 1, -2, 0,
+ax_anim 2, 1, 121, -2, -2, -6, -2,
+ax_anim 2, 0, 121, -3, -1, -7, -2,
+ax_anim 2, 0, 121, -2, -2, -6, -2,
+ax_anim 2, 0, 121, -3, -1, -7, -1,
+ax_anim 2, 0, 121, -2, -2, -6, -2,
+ax_anim 2, 0, 121, -3, -1, -7, -1,
+ax_anim 2, 0, 121, -2, -2, -5, -2,
+ax_anim 2, 0, 119, -1, -1, -2, -1,
+ax_anim_terminator
+sBarboachAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 1, 0,
+ax_anim 6, 2, 123, 3, 0, 2, 0,
+ax_anim 2, 0, 122, 1, 0, 0, 0,
+ax_anim 2, 1, 124, -2, 0, -3, 0,
+ax_anim 2, 0, 124, -2, 1, -3, 1,
+ax_anim 2, 0, 124, -2, 0, -3, 0,
+ax_anim 2, 0, 124, -2, 1, -3, 1,
+ax_anim 2, 0, 124, -2, 0, -3, 0,
+ax_anim 2, 0, 124, -2, 1, -3, 1,
+ax_anim 2, 0, 124, -2, 0, -3, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sBarboachAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sBarboachAnims_5_1:
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 4, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 2, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_5_2:
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 2, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_5_3:
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, 1, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 4, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 2, 135, 0, 1, 0, 0,
+ax_anim 4, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_5_4:
+ax_anim 2, 0, 139, -1, -4, 0, 0,
+ax_anim 2, 0, 139, -1, -2, 0, 0,
+ax_anim 2, 0, 138, -1, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, 0, 0,
+ax_anim 2, 0, 138, -1, -4, 0, 0,
+ax_anim 4, 0, 139, -1, -2, 0, 0,
+ax_anim 4, 2, 138, -1, 0, 0, 0,
+ax_anim 4, 0, 139, -1, -2, 0, 0,
+ax_anim 2, 0, 138, -1, -2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_5_5:
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 2, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_5_6:
+ax_anim 2, 0, 145, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 2, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_5_7:
+ax_anim 2, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, 2, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 2, 147, 0, 1, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_5_8:
+ax_anim 2, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 2, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_6_1:
+ax_anim 16, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, -1, 0, 0,
+ax_anim 16, 0, 152, 0, -2, 0, 0,
+ax_anim 16, 0, 153, 0, -2, 0, 0,
+ax_anim 12, 0, 153, 0, -1, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sBarboachAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sBarboachAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sBarboachAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sBarboachAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sBarboachAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sBarboachAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sBarboachAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sBarboachAnims_8_1:
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 163, 0, -1, 0, 0,
+ax_anim 10, 0, 163, 0, -2, 0, 0,
+ax_anim 12, 0, 162, 0, -2, 0, 0,
+ax_anim 10, 0, 164, 0, -1, 0, 0,
+ax_anim 10, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_8_2:
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, -1, 0, 0,
+ax_anim 10, 0, 166, 0, -2, 0, 0,
+ax_anim 12, 0, 165, 0, -2, 0, 0,
+ax_anim 10, 0, 167, 0, -1, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_8_3:
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, -1, 0, 0,
+ax_anim 10, 0, 169, 0, -2, 0, 0,
+ax_anim 12, 0, 168, 0, -2, 0, 0,
+ax_anim 10, 0, 170, 0, -1, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_8_4:
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, -1, 0, 0,
+ax_anim 10, 0, 172, 0, -2, 0, 0,
+ax_anim 12, 0, 171, 0, -2, 0, 0,
+ax_anim 10, 0, 173, 0, -1, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_8_5:
+ax_anim 12, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, -1, 0, 0,
+ax_anim 10, 0, 175, 0, -2, 0, 0,
+ax_anim 12, 0, 174, 0, -2, 0, 0,
+ax_anim 10, 0, 176, 0, -1, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_8_6:
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, -1, 0, 0,
+ax_anim 10, 0, 178, 0, -2, 0, 0,
+ax_anim 12, 0, 177, 0, -2, 0, 0,
+ax_anim 10, 0, 179, 0, -1, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_8_7:
+ax_anim 12, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, -1, 0, 0,
+ax_anim 10, 0, 181, 0, -2, 0, 0,
+ax_anim 12, 0, 180, 0, -2, 0, 0,
+ax_anim 10, 0, 182, 0, -1, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_8_8:
+ax_anim 12, 0, 183, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, -1, 0, 0,
+ax_anim 10, 0, 184, 0, -2, 0, 0,
+ax_anim 12, 0, 183, 0, -2, 0, 0,
+ax_anim 10, 0, 185, 0, -1, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 9, 10, 9, 10,
+ax_anim 2, 0, 189, 7, 14, 7, 14,
+ax_anim 3, 0, 190, 0, 17, 0, 17,
+ax_anim 2, 3, 191, -7, 14, -7, 14,
+ax_anim 2, 0, 192, -9, 10, -9, 10,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 12, -1, 12, -1,
+ax_anim 2, 0, 187, 19, 4, 19, 4,
+ax_anim 2, 0, 188, 24, 12, 24, 12,
+ax_anim 3, 0, 189, 21, 20, 21, 20,
+ax_anim 2, 3, 190, 10, 21, 10, 21,
+ax_anim 2, 0, 191, 2, 17, 2, 17,
+ax_anim 1, 0, 192, -1, 10, -1, 10,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 4, -5, 4, -5,
+ax_anim 2, 0, 186, 12, -8, 12, -8,
+ax_anim 2, 0, 187, 19, -5, 19, -5,
+ax_anim 3, 0, 188, 22, 0, 22, 0,
+ax_anim 2, 3, 189, 19, 8, 19, 8,
+ax_anim 2, 0, 190, 9, 12, 9, 12,
+ax_anim 1, 0, 191, 4, 7, 4, 7,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 19, -22, 19, -22,
+ax_anim 2, 3, 188, 21, -11, 21, -11,
+ax_anim 2, 0, 189, 17, -4, 17, -4,
+ax_anim 1, 0, 190, 8, 2, 8, 2,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -3, -8, -3,
+ax_anim 2, 0, 192, -10, -9, -10, -9,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -23, 0, -23,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 10, -9, 10, -9,
+ax_anim 1, 0, 189, 8, -3, 8, -3,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -19, -22, -19, -22,
+ax_anim 2, 3, 192, -21, -11, -21, -11,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -8, 2, -8, 2,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -4, -5, -4, -5,
+ax_anim 2, 0, 186, -12, -8, -12, -8,
+ax_anim 2, 0, 193, -19, -5, -19, -5,
+ax_anim 3, 0, 192, -22, 0, -22, 0,
+ax_anim 2, 3, 191, -19, 8, -19, 8,
+ax_anim 2, 0, 190, -9, 12, -9, 12,
+ax_anim 1, 0, 189, -4, 7, -4, 7,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -12, -1, -12, -1,
+ax_anim 2, 0, 193, -19, 4, -19, 4,
+ax_anim 2, 0, 192, -24, 12, -24, 12,
+ax_anim 3, 0, 191, -21, 20, -21, 20,
+ax_anim 2, 3, 190, -10, 21, -10, 21,
+ax_anim 2, 0, 189, -2, 17, -2, 17,
+ax_anim 1, 0, 188, 1, 10, 1, 10,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -24, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 2, 0, 0,
+ax_anim_terminator
+sBarboachAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 4, 0, 0,
+ax_anim_terminator
+sBarboachAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 3, 0, 0,
+ax_anim_terminator
+sBarboachAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBarboachAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sBarboachGfx1:
+.incbin "baserom.gba", 0x13D767C, 0x100
+sBarboachSprites1:
+ax_sprite sBarboachGfx1, 0x100
+ax_sprite_terminator
+sBarboachGfx2:
+.incbin "baserom.gba", 0x13D778C, 0x100
+sBarboachSprites2:
+ax_sprite sBarboachGfx2, 0x100
+ax_sprite_terminator
+sBarboachGfx3:
+.incbin "baserom.gba", 0x13D789C, 0x100
+sBarboachSprites3:
+ax_sprite sBarboachGfx3, 0x100
+ax_sprite_terminator
+sBarboachGfx4:
+.incbin "baserom.gba", 0x13D79AC, 0x200
+sBarboachSprites4:
+ax_sprite sBarboachGfx4, 0x200
+ax_sprite_terminator
+sBarboachGfx5:
+.incbin "baserom.gba", 0x13D7BBC, 0x200
+sBarboachSprites5:
+ax_sprite sBarboachGfx5, 0x200
+ax_sprite_terminator
+sBarboachGfx6:
+.incbin "baserom.gba", 0x13D7DCC, 0x200
+sBarboachSprites6:
+ax_sprite sBarboachGfx6, 0x200
+ax_sprite_terminator
+sBarboachGfx7:
+.incbin "baserom.gba", 0x13D7FDC, 0x100
+sBarboachSprites7:
+ax_sprite sBarboachGfx7, 0x100
+ax_sprite_terminator
+sBarboachGfx8:
+.incbin "baserom.gba", 0x13D80EC, 0x100
+sBarboachSprites8:
+ax_sprite sBarboachGfx8, 0x100
+ax_sprite_terminator
+sBarboachGfx9:
+.incbin "baserom.gba", 0x13D81FC, 0x100
+sBarboachSprites9:
+ax_sprite sBarboachGfx9, 0x100
+ax_sprite_terminator
+sBarboachGfx10:
+.incbin "baserom.gba", 0x13D830C, 0x200
+sBarboachSprites10:
+ax_sprite sBarboachGfx10, 0x200
+ax_sprite_terminator
+sBarboachGfx11:
+.incbin "baserom.gba", 0x13D851C, 0x200
+sBarboachSprites11:
+ax_sprite sBarboachGfx11, 0x200
+ax_sprite_terminator
+sBarboachGfx12:
+.incbin "baserom.gba", 0x13D872C, 0x200
+sBarboachSprites12:
+ax_sprite sBarboachGfx12, 0x200
+ax_sprite_terminator
+sBarboachGfx13:
+.incbin "baserom.gba", 0x13D893C, 0x100
+sBarboachSprites13:
+ax_sprite sBarboachGfx13, 0x100
+ax_sprite_terminator
+sBarboachGfx14:
+.incbin "baserom.gba", 0x13D8A4C, 0x100
+sBarboachSprites14:
+ax_sprite sBarboachGfx14, 0x100
+ax_sprite_terminator
+sBarboachGfx15:
+.incbin "baserom.gba", 0x13D8B5C, 0x100
+sBarboachSprites15:
+ax_sprite sBarboachGfx15, 0x100
+ax_sprite_terminator
+sBarboachGfx16:
+.incbin "baserom.gba", 0x13D8C6C, 0x200
+sBarboachSprites16:
+ax_sprite sBarboachGfx16, 0x200
+ax_sprite_terminator
+sBarboachGfx17:
+.incbin "baserom.gba", 0x13D8E7C, 0x200
+sBarboachSprites17:
+ax_sprite sBarboachGfx17, 0x200
+ax_sprite_terminator
+sBarboachGfx18:
+.incbin "baserom.gba", 0x13D908C, 0x200
+sBarboachSprites18:
+ax_sprite sBarboachGfx18, 0x200
+ax_sprite_terminator
+sBarboachGfx19:
+.incbin "baserom.gba", 0x13D929C, 0x100
+sBarboachSprites19:
+ax_sprite sBarboachGfx19, 0x100
+ax_sprite_terminator
+sBarboachGfx20:
+.incbin "baserom.gba", 0x13D93AC, 0x100
+sBarboachSprites20:
+ax_sprite sBarboachGfx20, 0x100
+ax_sprite_terminator
+sBarboachGfx21:
+.incbin "baserom.gba", 0x13D94BC, 0x100
+sBarboachSprites21:
+ax_sprite sBarboachGfx21, 0x100
+ax_sprite_terminator
+sBarboachGfx22:
+.incbin "baserom.gba", 0x13D95CC, 0x200
+sBarboachSprites22:
+ax_sprite sBarboachGfx22, 0x200
+ax_sprite_terminator
+sBarboachGfx23:
+.incbin "baserom.gba", 0x13D97DC, 0x200
+sBarboachSprites23:
+ax_sprite sBarboachGfx23, 0x200
+ax_sprite_terminator
+sBarboachGfx24:
+.incbin "baserom.gba", 0x13D99EC, 0x200
+sBarboachSprites24:
+ax_sprite sBarboachGfx24, 0x200
+ax_sprite_terminator
+sBarboachGfx25:
+.incbin "baserom.gba", 0x13D9BFC, 0xE0
+sBarboachSprites25:
+ax_sprite 0, 0x20
+ax_sprite sBarboachGfx25, 0xe0
+ax_sprite_terminator
+sBarboachGfx26:
+.incbin "baserom.gba", 0x13D9CF4, 0x100
+sBarboachSprites26:
+ax_sprite sBarboachGfx26, 0x100
+ax_sprite_terminator
+sBarboachGfx27:
+.incbin "baserom.gba", 0x13D9E04, 0x20
+sBarboachGfx27_1:
+.incbin "baserom.gba", 0x13D9E24, 0xE0
+sBarboachSprites27:
+ax_sprite 0, 0x40
+ax_sprite sBarboachGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBarboachGfx27_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBarboachGfx28:
+.incbin "baserom.gba", 0x13D9F34, 0x120
+sBarboachSprites28:
+ax_sprite 0, 0x40
+ax_sprite sBarboachGfx28, 0x120
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBarboachGfx29:
+.incbin "baserom.gba", 0x13DA074, 0x60
+sBarboachGfx29_1:
+.incbin "baserom.gba", 0x13DA0D4, 0x80
+sBarboachSprites29:
+ax_sprite sBarboachGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBarboachGfx29_1, 0x80
+ax_sprite_terminator
+sBarboachGfx30:
+.incbin "baserom.gba", 0x13DA174, 0x100
+sBarboachSprites30:
+ax_sprite sBarboachGfx30, 0x100
+ax_sprite_terminator
+sBarboachGfx31:
+.incbin "baserom.gba", 0x13DA284, 0x40
+sBarboachGfx31_1:
+.incbin "baserom.gba", 0x13DA2C4, 0x60
+sBarboachGfx31_2:
+.incbin "baserom.gba", 0x13DA324, 0x40
+sBarboachSprites31:
+ax_sprite sBarboachGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBarboachGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBarboachGfx31_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBarboachGfx32:
+.incbin "baserom.gba", 0x13DA39C, 0x40
+sBarboachGfx32_1:
+.incbin "baserom.gba", 0x13DA3DC, 0x100
+sBarboachSprites32:
+ax_sprite sBarboachGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBarboachGfx32_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBarboachGfx33:
+.incbin "baserom.gba", 0x13DA504, 0xC0
+sBarboachSprites33:
+ax_sprite sBarboachGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBarboachGfx34:
+.incbin "baserom.gba", 0x13DA5DC, 0xC0
+sBarboachGfx34_1:
+.incbin "baserom.gba", 0x13DA69C, 0x20
+sBarboachSprites34:
+ax_sprite sBarboachGfx34, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBarboachGfx34_1, 0x20
+ax_sprite_terminator
+sBarboachGfx35:
+.incbin "baserom.gba", 0x13DA6DC, 0x200
+sBarboachSprites35:
+ax_sprite sBarboachGfx35, 0x200
+ax_sprite_terminator
+sBarboachGfx36:
+.incbin "baserom.gba", 0x13DA8EC, 0x200
+sBarboachSprites36:
+ax_sprite sBarboachGfx36, 0x200
+ax_sprite_terminator
+sBarboachGfx37:
+.incbin "baserom.gba", 0x13DAAFC, 0x200
+sBarboachSprites37:
+ax_sprite sBarboachGfx37, 0x200
+ax_sprite_terminator
+sBarboachGfx38:
+.incbin "baserom.gba", 0x13DAD0C, 0x200
+sBarboachSprites38:
+ax_sprite sBarboachGfx38, 0x200
+ax_sprite_terminator
+sBarboachGfx39:
+.incbin "baserom.gba", 0x13DAF1C, 0x200
+sBarboachSprites39:
+ax_sprite sBarboachGfx39, 0x200
+ax_sprite_terminator
+sBarboachGfx40:
+.incbin "baserom.gba", 0x13DB12C, 0x200
+sBarboachSprites40:
+ax_sprite sBarboachGfx40, 0x200
+ax_sprite_terminator
+sBarboachGfx41:
+.incbin "baserom.gba", 0x13DB33C, 0x200
+sBarboachSprites41:
+ax_sprite sBarboachGfx41, 0x200
+ax_sprite_terminator
+sAxPosesBarboach:
+.4byte sBarboachPose1
+.4byte sBarboachPose2
+.4byte sBarboachPose3
+.4byte sBarboachPose4
+.4byte sBarboachPose5
+.4byte sBarboachPose6
+.4byte sBarboachPose7
+.4byte sBarboachPose8
+.4byte sBarboachPose9
+.4byte sBarboachPose10
+.4byte sBarboachPose11
+.4byte sBarboachPose12
+.4byte sBarboachPose13
+.4byte sBarboachPose14
+.4byte sBarboachPose15
+.4byte sBarboachPose16
+.4byte sBarboachPose17
+.4byte sBarboachPose18
+.4byte sBarboachPose19
+.4byte sBarboachPose20
+.4byte sBarboachPose21
+.4byte sBarboachPose22
+.4byte sBarboachPose23
+.4byte sBarboachPose24
+.4byte sBarboachPose25
+.4byte sBarboachPose26
+.4byte sBarboachPose27
+.4byte sBarboachPose28
+.4byte sBarboachPose29
+.4byte sBarboachPose30
+.4byte sBarboachPose31
+.4byte sBarboachPose32
+.4byte sBarboachPose33
+.4byte sBarboachPose34
+.4byte sBarboachPose35
+.4byte sBarboachPose36
+.4byte sBarboachPose37
+.4byte sBarboachPose38
+.4byte sBarboachPose39
+.4byte sBarboachPose40
+.4byte sBarboachPose41
+.4byte sBarboachPose42
+.4byte sBarboachPose43
+.4byte sBarboachPose44
+.4byte sBarboachPose45
+.4byte sBarboachPose46
+.4byte sBarboachPose47
+.4byte sBarboachPose48
+.4byte sBarboachPose49
+.4byte sBarboachPose50
+.4byte sBarboachPose51
+.4byte sBarboachPose52
+.4byte sBarboachPose53
+.4byte sBarboachPose54
+.4byte sBarboachPose55
+.4byte sBarboachPose56
+.4byte sBarboachPose57
+.4byte sBarboachPose58
+.4byte sBarboachPose59
+.4byte sBarboachPose60
+.4byte sBarboachPose61
+.4byte sBarboachPose62
+.4byte sBarboachPose63
+.4byte sBarboachPose64
+.4byte sBarboachPose65
+.4byte sBarboachPose66
+.4byte sBarboachPose67
+.4byte sBarboachPose68
+.4byte sBarboachPose69
+.4byte sBarboachPose70
+.4byte sBarboachPose71
+.4byte sBarboachPose72
+.4byte sBarboachPose73
+.4byte sBarboachPose74
+.4byte sBarboachPose75
+.4byte sBarboachPose76
+.4byte sBarboachPose77
+.4byte sBarboachPose78
+.4byte sBarboachPose79
+.4byte sBarboachPose80
+.4byte sBarboachPose81
+.4byte sBarboachPose82
+.4byte sBarboachPose83
+.4byte sBarboachPose84
+.4byte sBarboachPose85
+.4byte sBarboachPose86
+.4byte sBarboachPose87
+.4byte sBarboachPose88
+.4byte sBarboachPose89
+.4byte sBarboachPose90
+.4byte sBarboachPose91
+.4byte sBarboachPose92
+.4byte sBarboachPose93
+.4byte sBarboachPose94
+.4byte sBarboachPose95
+.4byte sBarboachPose96
+.4byte sBarboachPose97
+.4byte sBarboachPose98
+.4byte sBarboachPose99
+.4byte sBarboachPose100
+.4byte sBarboachPose101
+.4byte sBarboachPose102
+.4byte sBarboachPose103
+.4byte sBarboachPose104
+.4byte sBarboachPose105
+.4byte sBarboachPose106
+.4byte sBarboachPose107
+.4byte sBarboachPose108
+.4byte sBarboachPose109
+.4byte sBarboachPose110
+.4byte sBarboachPose111
+.4byte sBarboachPose112
+.4byte sBarboachPose113
+.4byte sBarboachPose114
+.4byte sBarboachPose115
+.4byte sBarboachPose116
+.4byte sBarboachPose117
+.4byte sBarboachPose118
+.4byte sBarboachPose119
+.4byte sBarboachPose120
+.4byte sBarboachPose121
+.4byte sBarboachPose122
+.4byte sBarboachPose123
+.4byte sBarboachPose124
+.4byte sBarboachPose125
+.4byte sBarboachPose126
+.4byte sBarboachPose127
+.4byte sBarboachPose128
+.4byte sBarboachPose129
+.4byte sBarboachPose130
+.4byte sBarboachPose131
+.4byte sBarboachPose132
+.4byte sBarboachPose133
+.4byte sBarboachPose134
+.4byte sBarboachPose135
+.4byte sBarboachPose136
+.4byte sBarboachPose137
+.4byte sBarboachPose138
+.4byte sBarboachPose139
+.4byte sBarboachPose140
+.4byte sBarboachPose141
+.4byte sBarboachPose142
+.4byte sBarboachPose143
+.4byte sBarboachPose144
+.4byte sBarboachPose145
+.4byte sBarboachPose146
+.4byte sBarboachPose147
+.4byte sBarboachPose148
+.4byte sBarboachPose149
+.4byte sBarboachPose150
+.4byte sBarboachPose151
+.4byte sBarboachPose152
+.4byte sBarboachPose153
+.4byte sBarboachPose154
+.4byte sBarboachPose155
+.4byte sBarboachPose156
+.4byte sBarboachPose157
+.4byte sBarboachPose158
+.4byte sBarboachPose159
+.4byte sBarboachPose160
+.4byte sBarboachPose161
+.4byte sBarboachPose162
+.4byte sBarboachPose163
+.4byte sBarboachPose164
+.4byte sBarboachPose165
+.4byte sBarboachPose166
+.4byte sBarboachPose167
+.4byte sBarboachPose168
+.4byte sBarboachPose169
+.4byte sBarboachPose170
+.4byte sBarboachPose171
+.4byte sBarboachPose172
+.4byte sBarboachPose173
+.4byte sBarboachPose174
+.4byte sBarboachPose175
+.4byte sBarboachPose176
+.4byte sBarboachPose177
+.4byte sBarboachPose178
+.4byte sBarboachPose179
+.4byte sBarboachPose180
+.4byte sBarboachPose181
+.4byte sBarboachPose182
+.4byte sBarboachPose183
+.4byte sBarboachPose184
+.4byte sBarboachPose185
+.4byte sBarboachPose186
+.4byte sBarboachPose187
+.4byte sBarboachPose188
+.4byte sBarboachPose189
+.4byte sBarboachPose190
+.4byte sBarboachPose191
+.4byte sBarboachPose192
+.4byte sBarboachPose193
+.4byte sBarboachPose194
+.4byte sBarboachPose195
+.4byte sBarboachPose196
+.4byte sBarboachPose197
+.4byte sBarboachPose198
+.4byte sBarboachPose199
+.4byte sBarboachPose200
+.4byte sBarboachPose201
+.4byte sBarboachPose202
+.4byte sBarboachPose203
+.4byte sBarboachPose204
+.4byte sBarboachPose205
+.4byte sBarboachPose206
+.4byte sBarboachPose207
+.4byte sBarboachPose208
+.4byte sBarboachPose209
+.4byte sBarboachPose210
+.4byte sBarboachPose211
+.4byte sBarboachPose212
+.4byte sBarboachPose213
+.4byte sBarboachPose214
+.4byte sBarboachPose215
+.4byte sBarboachPose216
+.4byte sBarboachPose217
+.4byte sBarboachPose218
+.4byte sBarboachPose219
+.4byte sBarboachPose220
+.4byte sBarboachPose221
+.4byte sBarboachPose222
+.4byte sBarboachPose223
+.4byte sBarboachPose224
+.4byte sBarboachPose225
+.4byte sBarboachPose226
+.4byte sBarboachPose227
+.4byte sBarboachPose228
+.4byte sBarboachPose229
+.4byte sBarboachPose230
+.4byte sBarboachPose231
+.4byte sBarboachPose232
+.4byte sBarboachPose233
+.4byte sBarboachPose234
+.4byte sBarboachPose235
+.4byte sBarboachPose236
+.4byte sBarboachPose237
+.4byte sBarboachPose238
+.4byte sBarboachPose239
+.4byte sBarboachPose240
+.4byte sBarboachPose241
+.4byte sBarboachPose242
+sAxPositionsBarboach:
+.2byte   -2,    3, 	  -4,   -1, 	   1,   -1, 	  -1,   -4
+.2byte    0,    3, 	  -3,   -2, 	   2,   -2, 	  -1,   -5
+.2byte   -4,    3, 	  -4,   -3, 	   0,   -1, 	  -2,   -5
+.2byte    6,    1, 	  -1,    0, 	   3,   -3, 	  -1,   -5
+.2byte    7,    1, 	   1,    0, 	   4,   -3, 	  -1,   -4
+.2byte    4,    1, 	  -2,    0, 	   2,   -3, 	  -2,   -6
+.2byte   11,   -4, 	   5,   -3, 	   5,   -7, 	   1,   -7
+.2byte   11,   -5, 	   5,   -4, 	   5,   -8, 	   1,   -8
+.2byte   10,   -2, 	   5,   -2, 	   7,   -6, 	   1,   -6
+.2byte    8,  -13, 	   6,   -9, 	   2,  -11, 	   1,   -8
+.2byte    7,  -13, 	   5,   -8, 	   1,  -10, 	   0,   -8
+.2byte    9,  -12, 	   6,   -8, 	   2,   -9, 	   0,   -8
+.2byte    0,  -14, 	   3,  -10, 	  -2,  -10, 	   0,   -8
+.2byte   -1,  -14, 	   2,  -10, 	  -2,   -9, 	   0,   -8
+.2byte    2,  -14, 	   4,  -10, 	  -1,  -10, 	   0,   -8
+.2byte   -9,  -12, 	  -1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,  -12, 	  -5,   -8, 	  -2,   -9
+.2byte   -8,  -13, 	   0,  -10, 	  -4,   -8, 	  -1,   -8
+.2byte  -12,   -4, 	  -5,   -7, 	  -5,   -5, 	  -2,   -6
+.2byte  -12,   -3, 	  -6,   -7, 	  -6,   -4, 	  -3,   -6
+.2byte  -12,   -5, 	  -7,   -7, 	  -7,   -5, 	  -2,   -6
+.2byte   -7,    3, 	  -8,   -2, 	  -2,   -1, 	  -3,   -5
+.2byte   -5,    3, 	  -5,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -9,    3, 	  -9,   -1, 	  -4,    1, 	  -4,   -4
+.2byte   -2,    3, 	  -4,   -1, 	   1,   -1, 	  -1,   -4
+.2byte    0,    3, 	  -3,   -2, 	   2,   -2, 	  -1,   -5
+.2byte   -4,    3, 	  -4,   -3, 	   0,   -1, 	  -2,   -5
+.2byte   -1,    6, 	  -4,    1, 	   1,    1, 	  -1,   -2
+.2byte   -1,    4, 	  -4,   -1, 	   1,    0, 	  -1,   -2
+.2byte    6,    1, 	  -1,    0, 	   3,   -3, 	  -1,   -5
+.2byte    7,    1, 	   1,    0, 	   4,   -3, 	  -1,   -4
+.2byte    4,    1, 	  -2,    0, 	   2,   -3, 	  -2,   -6
+.2byte    3,    1, 	   5,   -5, 	   0,   -3, 	   0,   -6
+.2byte    5,    0, 	   3,   -5, 	   0,   -2, 	  -1,   -5
+.2byte   11,   -4, 	   5,   -3, 	   5,   -7, 	   1,   -7
+.2byte   11,   -5, 	   5,   -4, 	   5,   -8, 	   1,   -8
+.2byte   10,   -2, 	   5,   -2, 	   7,   -6, 	   1,   -6
+.2byte    8,   -2, 	   4,   -8, 	   3,   -5, 	   1,   -6
+.2byte   12,   -5, 	   5,   -6, 	   4,   -3, 	   1,   -4
+.2byte    8,  -13, 	   6,   -9, 	   2,  -11, 	   1,   -8
+.2byte    7,  -13, 	   5,   -8, 	   1,  -10, 	   0,   -8
+.2byte    9,  -12, 	   6,   -8, 	   2,   -9, 	   0,   -8
+.2byte    9,  -11, 	   0,  -11, 	   3,   -8, 	   1,   -8
+.2byte   10,  -11, 	   3,  -10, 	   6,   -6, 	   3,   -6
+.2byte    0,  -14, 	   3,  -10, 	  -2,  -10, 	   0,   -8
+.2byte   -1,  -14, 	   2,  -10, 	  -2,   -9, 	   0,   -8
+.2byte    2,  -14, 	   4,  -10, 	  -1,  -10, 	   0,   -8
+.2byte    0,  -11, 	   3,  -10, 	  -1,   -8, 	   1,   -8
+.2byte    0,  -16, 	   2,  -11, 	  -2,  -11, 	   1,   -9
+.2byte   -9,  -12, 	  -1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,  -12, 	  -5,   -8, 	  -2,   -9
+.2byte   -8,  -13, 	   0,  -10, 	  -4,   -8, 	  -1,   -8
+.2byte   -8,  -11, 	   1,  -11, 	  -2,   -8, 	   0,   -8
+.2byte   -9,  -11, 	  -2,  -10, 	  -5,   -6, 	  -2,   -6
+.2byte  -12,   -4, 	  -5,   -7, 	  -5,   -5, 	  -2,   -6
+.2byte  -12,   -3, 	  -6,   -7, 	  -6,   -4, 	  -3,   -6
+.2byte  -12,   -5, 	  -7,   -7, 	  -7,   -5, 	  -2,   -6
+.2byte   -9,   -2, 	  -5,   -8, 	  -4,   -5, 	  -2,   -6
+.2byte  -13,   -5, 	  -6,   -6, 	  -5,   -3, 	  -2,   -4
+.2byte   -7,    3, 	  -8,   -2, 	  -2,   -1, 	  -3,   -5
+.2byte   -5,    3, 	  -5,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -9,    3, 	  -9,   -1, 	  -4,    1, 	  -4,   -4
+.2byte   -5,    3, 	  -7,   -3, 	  -2,   -1, 	  -2,   -4
+.2byte   -7,    2, 	  -5,   -3, 	  -2,    0, 	  -1,   -3
+.2byte   -2,    3, 	  -4,   -1, 	   1,   -1, 	  -1,   -4
+.2byte    0,    3, 	  -3,   -2, 	   2,   -2, 	  -1,   -5
+.2byte   -4,    3, 	  -4,   -3, 	   0,   -1, 	  -2,   -5
+.2byte   -1,    6, 	  -4,    1, 	   1,    1, 	  -1,   -2
+.2byte   -1,    4, 	  -4,   -1, 	   1,    0, 	  -1,   -2
+.2byte    6,    1, 	  -1,    0, 	   3,   -3, 	  -1,   -5
+.2byte    7,    1, 	   1,    0, 	   4,   -3, 	  -1,   -4
+.2byte    4,    1, 	  -2,    0, 	   2,   -3, 	  -2,   -6
+.2byte    3,    1, 	   5,   -5, 	   0,   -3, 	   0,   -6
+.2byte    5,    0, 	   3,   -5, 	   0,   -2, 	  -1,   -5
+.2byte   11,   -4, 	   5,   -3, 	   5,   -7, 	   1,   -7
+.2byte   11,   -5, 	   5,   -4, 	   5,   -8, 	   1,   -8
+.2byte   10,   -2, 	   5,   -2, 	   7,   -6, 	   1,   -6
+.2byte    8,   -2, 	   4,   -8, 	   3,   -5, 	   1,   -6
+.2byte   12,   -5, 	   5,   -6, 	   4,   -3, 	   1,   -4
+.2byte    8,  -13, 	   6,   -9, 	   2,  -11, 	   1,   -8
+.2byte    7,  -13, 	   5,   -8, 	   1,  -10, 	   0,   -8
+.2byte    9,  -12, 	   6,   -8, 	   2,   -9, 	   0,   -8
+.2byte    9,  -11, 	   0,  -11, 	   3,   -8, 	   1,   -8
+.2byte   10,  -11, 	   3,  -10, 	   6,   -6, 	   3,   -6
+.2byte    0,  -14, 	   3,  -10, 	  -2,  -10, 	   0,   -8
+.2byte   -1,  -14, 	   2,  -10, 	  -2,   -9, 	   0,   -8
+.2byte    2,  -14, 	   4,  -10, 	  -1,  -10, 	   0,   -8
+.2byte    0,  -11, 	   3,  -10, 	  -1,   -8, 	   1,   -8
+.2byte    0,  -16, 	   2,  -11, 	  -2,  -11, 	   1,   -9
+.2byte   -9,  -12, 	  -1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,  -12, 	  -5,   -8, 	  -2,   -9
+.2byte   -8,  -13, 	   0,  -10, 	  -4,   -8, 	  -1,   -8
+.2byte   -8,  -11, 	   1,  -11, 	  -2,   -8, 	   0,   -8
+.2byte   -9,  -11, 	  -2,  -10, 	  -5,   -6, 	  -2,   -6
+.2byte  -12,   -4, 	  -5,   -7, 	  -5,   -5, 	  -2,   -6
+.2byte  -12,   -3, 	  -6,   -7, 	  -6,   -4, 	  -3,   -6
+.2byte  -12,   -5, 	  -7,   -7, 	  -7,   -5, 	  -2,   -6
+.2byte   -9,   -2, 	  -5,   -8, 	  -4,   -5, 	  -2,   -6
+.2byte  -13,   -5, 	  -6,   -6, 	  -5,   -3, 	  -2,   -4
+.2byte   -7,    3, 	  -8,   -2, 	  -2,   -1, 	  -3,   -5
+.2byte   -5,    3, 	  -5,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -9,    3, 	  -9,   -1, 	  -4,    1, 	  -4,   -4
+.2byte   -5,    3, 	  -7,   -3, 	  -2,   -1, 	  -2,   -4
+.2byte   -7,    2, 	  -5,   -3, 	  -2,    0, 	  -1,   -3
+.2byte   -2,    3, 	  -4,   -1, 	   1,   -1, 	  -1,   -4
+.2byte   -1,    6, 	  -4,    1, 	   1,    1, 	  -1,   -2
+.2byte   -1,    4, 	  -4,   -1, 	   1,    0, 	  -1,   -2
+.2byte    6,    1, 	  -1,    0, 	   3,   -3, 	  -1,   -5
+.2byte    3,    1, 	   5,   -5, 	   0,   -3, 	   0,   -6
+.2byte    5,    0, 	   3,   -5, 	   0,   -2, 	  -1,   -5
+.2byte   11,   -4, 	   5,   -3, 	   5,   -7, 	   1,   -7
+.2byte    8,   -2, 	   4,   -8, 	   3,   -5, 	   1,   -6
+.2byte   12,   -5, 	   5,   -6, 	   4,   -3, 	   1,   -4
+.2byte    8,  -13, 	   6,   -9, 	   2,  -11, 	   1,   -8
+.2byte    9,  -11, 	   0,  -11, 	   3,   -8, 	   1,   -8
+.2byte   10,  -11, 	   3,  -10, 	   6,   -6, 	   3,   -6
+.2byte    0,  -14, 	   3,  -10, 	  -2,  -10, 	   0,   -8
+.2byte    0,  -11, 	   3,  -10, 	  -1,   -8, 	   1,   -8
+.2byte    0,  -16, 	   2,  -11, 	  -2,  -11, 	   1,   -9
+.2byte   -9,  -12, 	  -1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte   -8,  -11, 	   1,  -11, 	  -2,   -8, 	   0,   -8
+.2byte   -9,  -11, 	  -2,  -10, 	  -5,   -6, 	  -2,   -6
+.2byte  -12,   -4, 	  -5,   -7, 	  -5,   -5, 	  -2,   -6
+.2byte   -9,   -2, 	  -5,   -8, 	  -4,   -5, 	  -2,   -6
+.2byte  -13,   -5, 	  -6,   -6, 	  -5,   -3, 	  -2,   -4
+.2byte   -7,    3, 	  -8,   -2, 	  -2,   -1, 	  -3,   -5
+.2byte   -5,    3, 	  -7,   -3, 	  -2,   -1, 	  -2,   -4
+.2byte   -7,    2, 	  -5,   -3, 	  -2,    0, 	  -1,   -3
+.2byte    0,    3, 	  -3,   -2, 	   2,   -2, 	  -1,   -5
+.2byte   -1,    6, 	  -4,    1, 	   1,    1, 	  -1,   -2
+.2byte   -1,    4, 	  -4,   -1, 	   1,    0, 	  -1,   -2
+.2byte    7,    0, 	   1,   -1, 	   4,   -4, 	  -1,   -5
+.2byte    3,    0, 	   5,   -6, 	   0,   -4, 	   0,   -7
+.2byte    5,   -1, 	   3,   -6, 	   0,   -3, 	  -1,   -6
+.2byte   10,   -5, 	   4,   -4, 	   4,   -8, 	   0,   -8
+.2byte    7,   -2, 	   3,   -8, 	   2,   -5, 	   0,   -6
+.2byte   11,   -5, 	   4,   -6, 	   3,   -3, 	   0,   -4
+.2byte    5,  -13, 	   3,   -8, 	  -1,  -10, 	  -2,   -8
+.2byte    7,  -11, 	  -2,  -11, 	   1,   -8, 	  -1,   -8
+.2byte    8,  -11, 	   1,  -10, 	   4,   -6, 	   1,   -6
+.2byte   -1,  -14, 	   2,  -10, 	  -2,   -9, 	   0,   -8
+.2byte    0,  -11, 	   3,  -10, 	  -1,   -8, 	   1,   -8
+.2byte    0,  -16, 	   2,  -11, 	  -2,  -11, 	   1,   -9
+.2byte   -7,  -13, 	   1,  -10, 	  -3,   -8, 	   0,   -8
+.2byte   -7,  -11, 	   2,  -11, 	  -1,   -8, 	   1,   -8
+.2byte   -8,  -11, 	  -1,  -10, 	  -4,   -6, 	  -1,   -6
+.2byte  -10,   -5, 	  -5,   -7, 	  -5,   -5, 	   0,   -6
+.2byte   -7,   -2, 	  -3,   -8, 	  -2,   -5, 	   0,   -6
+.2byte  -11,   -5, 	  -4,   -6, 	  -3,   -3, 	   0,   -4
+.2byte   -5,    2, 	  -5,   -2, 	  -1,   -1, 	  -1,   -6
+.2byte   -5,    2, 	  -7,   -4, 	  -2,   -2, 	  -2,   -5
+.2byte   -7,    1, 	  -5,   -4, 	  -2,   -1, 	  -1,   -4
+.2byte   -6,    1, 	  -6,   -4, 	  -2,   -3, 	  -1,   -6
+.2byte   -6,    2, 	  -6,   -4, 	  -2,   -2, 	  -1,   -5
+.2byte    2,  -17, 	  -3,  -14, 	   2,  -13, 	  -1,  -11
+.2byte   -4,  -17, 	   1,  -14, 	  -3,  -12, 	   0,   -9
+.2byte   -1,  -16, 	   4,  -11, 	   0,  -10, 	   1,   -8
+.2byte    0,  -17, 	  -1,  -13, 	   4,  -13, 	   0,   -9
+.2byte   -2,  -15, 	   2,  -13, 	  -2,  -12, 	   0,  -10
+.2byte   -1,  -17, 	   0,  -13, 	  -5,  -13, 	  -1,   -9
+.2byte    0,  -16, 	  -5,  -11, 	  -1,  -10, 	  -2,   -8
+.2byte    3,  -17, 	  -2,  -14, 	   2,  -12, 	  -1,   -9
+.2byte   -2,    3, 	  -4,   -1, 	   1,   -1, 	  -1,   -4
+.2byte    0,    3, 	  -3,   -2, 	   2,   -2, 	  -1,   -5
+.2byte   -4,    3, 	  -4,   -3, 	   0,   -1, 	  -2,   -5
+.2byte    6,    1, 	  -1,    0, 	   3,   -3, 	  -1,   -5
+.2byte    7,    1, 	   1,    0, 	   4,   -3, 	  -1,   -4
+.2byte    4,    1, 	  -2,    0, 	   2,   -3, 	  -2,   -6
+.2byte   11,   -4, 	   5,   -3, 	   5,   -7, 	   1,   -7
+.2byte   11,   -5, 	   5,   -4, 	   5,   -8, 	   1,   -8
+.2byte   10,   -2, 	   5,   -2, 	   7,   -6, 	   1,   -6
+.2byte    8,  -13, 	   6,   -9, 	   2,  -11, 	   1,   -8
+.2byte    7,  -13, 	   5,   -8, 	   1,  -10, 	   0,   -8
+.2byte    9,  -12, 	   6,   -8, 	   2,   -9, 	   0,   -8
+.2byte    0,  -14, 	   3,  -10, 	  -2,  -10, 	   0,   -8
+.2byte   -1,  -14, 	   2,  -10, 	  -2,   -9, 	   0,   -8
+.2byte    2,  -14, 	   4,  -10, 	  -1,  -10, 	   0,   -8
+.2byte   -9,  -12, 	  -1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,  -12, 	  -5,   -8, 	  -2,   -9
+.2byte   -8,  -13, 	   0,  -10, 	  -4,   -8, 	  -1,   -8
+.2byte  -12,   -4, 	  -5,   -7, 	  -5,   -5, 	  -2,   -6
+.2byte  -12,   -3, 	  -6,   -7, 	  -6,   -4, 	  -3,   -6
+.2byte  -12,   -5, 	  -7,   -7, 	  -7,   -5, 	  -2,   -6
+.2byte   -7,    3, 	  -8,   -2, 	  -2,   -1, 	  -3,   -5
+.2byte   -5,    3, 	  -5,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -9,    3, 	  -9,   -1, 	  -4,    1, 	  -4,   -4
+.2byte   -1,    4, 	  -4,   -1, 	   1,    0, 	  -1,   -2
+.2byte   -6,    2, 	  -4,   -3, 	  -1,    0, 	   0,   -3
+.2byte  -11,   -4, 	  -4,   -5, 	  -3,   -2, 	   0,   -3
+.2byte   -8,  -10, 	  -1,   -9, 	  -4,   -5, 	  -1,   -5
+.2byte    0,  -16, 	   2,  -11, 	  -2,  -11, 	   1,   -9
+.2byte    7,  -10, 	   0,   -9, 	   3,   -5, 	   0,   -5
+.2byte   10,   -4, 	   3,   -5, 	   2,   -2, 	  -1,   -3
+.2byte    6,    2, 	   4,   -3, 	   1,    0, 	   0,   -3
+.2byte   -1,    3, 	  -4,   -2, 	   1,   -1, 	  -1,   -3
+.2byte    5,    1, 	   3,   -4, 	   0,   -1, 	  -1,   -4
+.2byte   11,   -4, 	   4,   -5, 	   3,   -2, 	   0,   -3
+.2byte    8,  -10, 	   1,   -9, 	   4,   -5, 	   1,   -5
+.2byte    0,  -16, 	   2,  -11, 	  -2,  -11, 	   1,   -9
+.2byte   -8,  -11, 	  -1,  -10, 	  -4,   -6, 	  -1,   -6
+.2byte  -12,   -4, 	  -5,   -5, 	  -4,   -2, 	  -1,   -3
+.2byte   -7,    1, 	  -5,   -4, 	  -2,   -1, 	  -1,   -4
+.2byte   -2,    3, 	  -4,   -1, 	   1,   -1, 	  -1,   -4
+.2byte   -1,    6, 	  -4,    1, 	   1,    1, 	  -1,   -2
+.2byte   -1,    4, 	  -4,   -1, 	   1,    0, 	  -1,   -2
+.2byte    8,    0, 	   1,   -1, 	   5,   -4, 	   1,   -6
+.2byte    4,    1, 	   6,   -5, 	   1,   -3, 	   1,   -6
+.2byte    6,    0, 	   4,   -5, 	   1,   -2, 	   0,   -5
+.2byte   11,   -4, 	   5,   -3, 	   5,   -7, 	   1,   -7
+.2byte    8,   -2, 	   4,   -8, 	   3,   -5, 	   1,   -6
+.2byte   11,   -5, 	   4,   -6, 	   3,   -3, 	   0,   -4
+.2byte    7,  -12, 	   5,   -8, 	   1,  -10, 	   0,   -7
+.2byte    7,   -9, 	  -2,   -9, 	   1,   -6, 	  -1,   -6
+.2byte    8,   -9, 	   1,   -8, 	   4,   -4, 	   1,   -4
+.2byte    0,  -13, 	   3,   -9, 	  -2,   -9, 	   0,   -7
+.2byte    0,  -10, 	   3,   -9, 	  -1,   -7, 	   1,   -7
+.2byte    0,  -15, 	   2,  -10, 	  -2,  -10, 	   1,   -8
+.2byte   -7,  -11, 	   1,  -11, 	  -3,   -8, 	   1,   -8
+.2byte   -6,   -9, 	   3,   -9, 	   0,   -6, 	   2,   -6
+.2byte   -7,   -9, 	   0,   -8, 	  -3,   -4, 	   0,   -4
+.2byte  -12,   -4, 	  -5,   -7, 	  -5,   -5, 	  -2,   -6
+.2byte   -9,   -2, 	  -5,   -8, 	  -4,   -5, 	  -2,   -6
+.2byte  -13,   -5, 	  -6,   -6, 	  -5,   -3, 	  -2,   -4
+.2byte   -7,    3, 	  -8,   -2, 	  -2,   -1, 	  -3,   -5
+.2byte   -5,    3, 	  -7,   -3, 	  -2,   -1, 	  -2,   -4
+.2byte   -7,    2, 	  -5,   -3, 	  -2,    0, 	  -1,   -3
+.2byte   -1,    2, 	  -4,   -3, 	   1,   -3, 	  -1,   -6
+.2byte   -5,   -1, 	  -7,   -7, 	  -2,   -5, 	  -2,   -8
+.2byte   -8,   -4, 	  -4,  -10, 	  -3,   -7, 	  -1,   -8
+.2byte   -7,  -11, 	   2,  -11, 	  -1,   -8, 	   1,   -8
+.2byte    0,  -13, 	   3,  -12, 	  -1,  -10, 	   1,  -10
+.2byte    8,  -11, 	  -1,  -11, 	   2,   -8, 	   0,   -8
+.2byte    7,   -4, 	   3,  -10, 	   2,   -7, 	   0,   -8
+.2byte    4,    0, 	   6,   -6, 	   1,   -4, 	   1,   -7
+.2byte   -2,    3, 	  -4,   -1, 	   1,   -1, 	  -1,   -4
+.2byte   -7,    3, 	  -8,   -2, 	  -2,   -1, 	  -3,   -5
+.2byte  -12,   -4, 	  -5,   -7, 	  -5,   -5, 	  -2,   -6
+.2byte   -9,  -12, 	  -1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte    0,  -14, 	   3,  -10, 	  -2,  -10, 	   0,   -8
+.2byte    8,  -13, 	   6,   -9, 	   2,  -11, 	   1,   -8
+.2byte   11,   -4, 	   5,   -3, 	   5,   -7, 	   1,   -7
+.2byte    6,    1, 	  -1,    0, 	   3,   -3, 	  -1,   -5
+sBarboachAnimTable1:
+.4byte sBarboachAnims_1_1
+.4byte sBarboachAnims_1_2
+.4byte sBarboachAnims_1_3
+.4byte sBarboachAnims_1_4
+.4byte sBarboachAnims_1_5
+.4byte sBarboachAnims_1_6
+.4byte sBarboachAnims_1_7
+.4byte sBarboachAnims_1_8
+sBarboachAnimTable2:
+.4byte sBarboachAnims_2_1
+.4byte sBarboachAnims_2_2
+.4byte sBarboachAnims_2_3
+.4byte sBarboachAnims_2_4
+.4byte sBarboachAnims_2_5
+.4byte sBarboachAnims_2_6
+.4byte sBarboachAnims_2_7
+.4byte sBarboachAnims_2_8
+sBarboachAnimTable3:
+.4byte sBarboachAnims_3_1
+.4byte sBarboachAnims_3_2
+.4byte sBarboachAnims_3_3
+.4byte sBarboachAnims_3_4
+.4byte sBarboachAnims_3_5
+.4byte sBarboachAnims_3_6
+.4byte sBarboachAnims_3_7
+.4byte sBarboachAnims_3_8
+sBarboachAnimTable4:
+.4byte sBarboachAnims_4_1
+.4byte sBarboachAnims_4_2
+.4byte sBarboachAnims_4_3
+.4byte sBarboachAnims_4_4
+.4byte sBarboachAnims_4_5
+.4byte sBarboachAnims_4_6
+.4byte sBarboachAnims_4_7
+.4byte sBarboachAnims_4_8
+sBarboachAnimTable5:
+.4byte sBarboachAnims_5_1
+.4byte sBarboachAnims_5_2
+.4byte sBarboachAnims_5_3
+.4byte sBarboachAnims_5_4
+.4byte sBarboachAnims_5_5
+.4byte sBarboachAnims_5_6
+.4byte sBarboachAnims_5_7
+.4byte sBarboachAnims_5_8
+sBarboachAnimTable6:
+.4byte sBarboachAnims_6_1
+.4byte sBarboachAnims_6_1
+.4byte sBarboachAnims_6_1
+.4byte sBarboachAnims_6_1
+.4byte sBarboachAnims_6_1
+.4byte sBarboachAnims_6_1
+.4byte sBarboachAnims_6_1
+.4byte sBarboachAnims_6_1
+sBarboachAnimTable7:
+.4byte sBarboachAnims_7_1
+.4byte sBarboachAnims_7_2
+.4byte sBarboachAnims_7_3
+.4byte sBarboachAnims_7_4
+.4byte sBarboachAnims_7_5
+.4byte sBarboachAnims_7_6
+.4byte sBarboachAnims_7_7
+.4byte sBarboachAnims_7_8
+sBarboachAnimTable8:
+.4byte sBarboachAnims_8_1
+.4byte sBarboachAnims_8_2
+.4byte sBarboachAnims_8_3
+.4byte sBarboachAnims_8_4
+.4byte sBarboachAnims_8_5
+.4byte sBarboachAnims_8_6
+.4byte sBarboachAnims_8_7
+.4byte sBarboachAnims_8_8
+sBarboachAnimTable9:
+.4byte sBarboachAnims_9_1
+.4byte sBarboachAnims_9_2
+.4byte sBarboachAnims_9_3
+.4byte sBarboachAnims_9_4
+.4byte sBarboachAnims_9_5
+.4byte sBarboachAnims_9_6
+.4byte sBarboachAnims_9_7
+.4byte sBarboachAnims_9_8
+sBarboachAnimTable10:
+.4byte sBarboachAnims_10_1
+.4byte sBarboachAnims_10_2
+.4byte sBarboachAnims_10_3
+.4byte sBarboachAnims_10_4
+.4byte sBarboachAnims_10_5
+.4byte sBarboachAnims_10_6
+.4byte sBarboachAnims_10_7
+.4byte sBarboachAnims_10_8
+sBarboachAnimTable11:
+.4byte sBarboachAnims_11_1
+.4byte sBarboachAnims_11_2
+.4byte sBarboachAnims_11_3
+.4byte sBarboachAnims_11_4
+.4byte sBarboachAnims_11_5
+.4byte sBarboachAnims_11_6
+.4byte sBarboachAnims_11_7
+.4byte sBarboachAnims_11_8
+sBarboachAnimTable12:
+.4byte sBarboachAnims_12_1
+.4byte sBarboachAnims_12_2
+.4byte sBarboachAnims_12_3
+.4byte sBarboachAnims_12_4
+.4byte sBarboachAnims_12_5
+.4byte sBarboachAnims_12_6
+.4byte sBarboachAnims_12_7
+.4byte sBarboachAnims_12_8
+sBarboachAnimTable13:
+.4byte sBarboachAnims_13_1
+.4byte sBarboachAnims_13_2
+.4byte sBarboachAnims_13_3
+.4byte sBarboachAnims_13_4
+.4byte sBarboachAnims_13_5
+.4byte sBarboachAnims_13_6
+.4byte sBarboachAnims_13_7
+.4byte sBarboachAnims_13_8
+sAxAnimationsBarboach:
+.4byte sBarboachAnimTable1
+.4byte sBarboachAnimTable2
+.4byte sBarboachAnimTable3
+.4byte sBarboachAnimTable4
+.4byte sBarboachAnimTable5
+.4byte sBarboachAnimTable6
+.4byte sBarboachAnimTable7
+.4byte sBarboachAnimTable8
+.4byte sBarboachAnimTable9
+.4byte sBarboachAnimTable10
+.4byte sBarboachAnimTable11
+.4byte sBarboachAnimTable12
+.4byte sBarboachAnimTable13
+sAxSpritesBarboach:
+.4byte sBarboachSprites1
+.4byte sBarboachSprites2
+.4byte sBarboachSprites3
+.4byte sBarboachSprites4
+.4byte sBarboachSprites5
+.4byte sBarboachSprites6
+.4byte sBarboachSprites7
+.4byte sBarboachSprites8
+.4byte sBarboachSprites9
+.4byte sBarboachSprites10
+.4byte sBarboachSprites11
+.4byte sBarboachSprites12
+.4byte sBarboachSprites13
+.4byte sBarboachSprites14
+.4byte sBarboachSprites15
+.4byte sBarboachSprites16
+.4byte sBarboachSprites17
+.4byte sBarboachSprites18
+.4byte sBarboachSprites19
+.4byte sBarboachSprites20
+.4byte sBarboachSprites21
+.4byte sBarboachSprites22
+.4byte sBarboachSprites23
+.4byte sBarboachSprites24
+.4byte sBarboachSprites25
+.4byte sBarboachSprites26
+.4byte sBarboachSprites27
+.4byte sBarboachSprites28
+.4byte sBarboachSprites29
+.4byte sBarboachSprites30
+.4byte sBarboachSprites31
+.4byte sBarboachSprites32
+.4byte sBarboachSprites33
+.4byte sBarboachSprites34
+.4byte sBarboachSprites35
+.4byte sBarboachSprites36
+.4byte sBarboachSprites37
+.4byte sBarboachSprites38
+.4byte sBarboachSprites39
+.4byte sBarboachSprites40
+.4byte sBarboachSprites41
+sAxMainBarboach:
+ax_main sAxPosesBarboach, sAxAnimationsBarboach, 13, sAxSpritesBarboach, sAxPositionsBarboach

--- a/data/ax/bayleef.inc
+++ b/data/ax/bayleef.inc
@@ -1,0 +1,2585 @@
+.global gAxBayleef
+gAxBayleef:
+ax_siro sAxMainBayleef
+sBayleefPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose4:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose5:
+ax_pose 4, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose6:
+ax_pose 5, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose7:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose8:
+ax_pose 7, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose9:
+ax_pose 8, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose10:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose11:
+ax_pose 10, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose12:
+ax_pose 11, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose13:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose14:
+ax_pose 13, 0x81e3, 0x80f4, 0x3c00
+ax_pose 14, 0x01f3, 0x4104, 0x3c08
+ax_pose 15, 0x81e3, 0x0104, 0x3c0c
+ax_pose 16, 0x0203, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose15:
+ax_pose 17, 0x81e3, 0x80f4, 0x3c00
+ax_pose 18, 0x01f3, 0x4104, 0x3c08
+ax_pose 19, 0x0203, 0x00f8, 0x3c0c
+ax_pose 20, 0x81e3, 0x0104, 0x3c0d
+ax_pose_terminator
+sBayleefPose16:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose17:
+ax_pose 10, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose22:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose23:
+ax_pose 4, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose24:
+ax_pose 5, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose26:
+ax_pose 1, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose27:
+ax_pose 2, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose28:
+ax_pose 21, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose29:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose30:
+ax_pose 4, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose31:
+ax_pose 5, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose32:
+ax_pose 22, 0x01e2, 0x90ef, 0x3c00
+ax_pose_terminator
+sBayleefPose33:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose34:
+ax_pose 7, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose35:
+ax_pose 8, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose36:
+ax_pose 23, 0x01e1, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose37:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose38:
+ax_pose 10, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose39:
+ax_pose 11, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose40:
+ax_pose 24, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sBayleefPose41:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose42:
+ax_pose 13, 0x81e3, 0x80f4, 0x3c00
+ax_pose 14, 0x01f3, 0x4104, 0x3c08
+ax_pose 15, 0x81e3, 0x0104, 0x3c0c
+ax_pose 16, 0x0203, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose43:
+ax_pose 17, 0x81e3, 0x80f4, 0x3c00
+ax_pose 18, 0x01f3, 0x4104, 0x3c08
+ax_pose 19, 0x0203, 0x00f8, 0x3c0c
+ax_pose 20, 0x81e3, 0x0104, 0x3c0d
+ax_pose_terminator
+sBayleefPose44:
+ax_pose 25, 0x81e3, 0x80f0, 0x3c00
+ax_pose 26, 0x81e3, 0x4100, 0x3c08
+ax_pose 27, 0x81e3, 0x0108, 0x3c0c
+ax_pose 28, 0x01db, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose45:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose46:
+ax_pose 10, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose47:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose48:
+ax_pose 24, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose49:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose50:
+ax_pose 7, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose51:
+ax_pose 8, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose52:
+ax_pose 23, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose53:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose54:
+ax_pose 4, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose55:
+ax_pose 5, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose56:
+ax_pose 22, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sBayleefPose57:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose58:
+ax_pose 1, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose59:
+ax_pose 2, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose60:
+ax_pose 21, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose61:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose62:
+ax_pose 4, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose63:
+ax_pose 5, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose64:
+ax_pose 22, 0x01e2, 0x90ef, 0x3c00
+ax_pose_terminator
+sBayleefPose65:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose66:
+ax_pose 7, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose67:
+ax_pose 8, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose68:
+ax_pose 23, 0x01e1, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose69:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose70:
+ax_pose 10, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose71:
+ax_pose 11, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose72:
+ax_pose 24, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sBayleefPose73:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose74:
+ax_pose 13, 0x81e3, 0x80f4, 0x3c00
+ax_pose 14, 0x01f3, 0x4104, 0x3c08
+ax_pose 15, 0x81e3, 0x0104, 0x3c0c
+ax_pose 16, 0x0203, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose75:
+ax_pose 17, 0x81e3, 0x80f4, 0x3c00
+ax_pose 18, 0x01f3, 0x4104, 0x3c08
+ax_pose 19, 0x0203, 0x00f8, 0x3c0c
+ax_pose 20, 0x81e3, 0x0104, 0x3c0d
+ax_pose_terminator
+sBayleefPose76:
+ax_pose 25, 0x81e3, 0x80f0, 0x3c00
+ax_pose 26, 0x81e3, 0x4100, 0x3c08
+ax_pose 27, 0x81e3, 0x0108, 0x3c0c
+ax_pose 28, 0x01db, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose77:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose78:
+ax_pose 10, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose79:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose80:
+ax_pose 24, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose81:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose82:
+ax_pose 7, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose83:
+ax_pose 8, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose84:
+ax_pose 23, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose85:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose86:
+ax_pose 4, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose87:
+ax_pose 5, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose88:
+ax_pose 22, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sBayleefPose89:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose90:
+ax_pose 21, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose91:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose92:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose93:
+ax_pose 22, 0x01e2, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose94:
+ax_pose 30, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose95:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose96:
+ax_pose 23, 0x01e1, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose97:
+ax_pose 31, 0x01e1, 0x90f4, 0x3c00
+ax_pose_terminator
+sBayleefPose98:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose99:
+ax_pose 24, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sBayleefPose100:
+ax_pose 32, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose101:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose102:
+ax_pose 25, 0x81e3, 0x80f0, 0x3c00
+ax_pose 26, 0x81e3, 0x4100, 0x3c08
+ax_pose 27, 0x81e3, 0x0108, 0x3c0c
+ax_pose 28, 0x01db, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose103:
+ax_pose 33, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose104:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose105:
+ax_pose 24, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose106:
+ax_pose 32, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sBayleefPose107:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose108:
+ax_pose 23, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose109:
+ax_pose 31, 0x01e1, 0x80ec, 0x3c00
+ax_pose_terminator
+sBayleefPose110:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose111:
+ax_pose 22, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose112:
+ax_pose 30, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose113:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose114:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose115:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose116:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose117:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose118:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose119:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose120:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose121:
+ax_pose 34, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose122:
+ax_pose 35, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose123:
+ax_pose 36, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sBayleefPose124:
+ax_pose 37, 0x01e3, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose125:
+ax_pose 38, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose126:
+ax_pose 39, 0x01e4, 0x90ee, 0x3c00
+ax_pose_terminator
+sBayleefPose127:
+ax_pose 40, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sBayleefPose128:
+ax_pose 39, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose129:
+ax_pose 38, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sBayleefPose130:
+ax_pose 37, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose131:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose132:
+ax_pose 1, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose133:
+ax_pose 2, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose134:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose135:
+ax_pose 4, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose136:
+ax_pose 5, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose137:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose138:
+ax_pose 7, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose139:
+ax_pose 8, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose140:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose141:
+ax_pose 10, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose142:
+ax_pose 11, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose143:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose144:
+ax_pose 13, 0x81e3, 0x80f4, 0x3c00
+ax_pose 14, 0x01f3, 0x4104, 0x3c08
+ax_pose 15, 0x81e3, 0x0104, 0x3c0c
+ax_pose 16, 0x0203, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose145:
+ax_pose 17, 0x81e3, 0x80f4, 0x3c00
+ax_pose 18, 0x01f3, 0x4104, 0x3c08
+ax_pose 19, 0x0203, 0x00f8, 0x3c0c
+ax_pose 20, 0x81e3, 0x0104, 0x3c0d
+ax_pose_terminator
+sBayleefPose146:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose147:
+ax_pose 10, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose148:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose149:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose150:
+ax_pose 7, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose151:
+ax_pose 8, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose152:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose153:
+ax_pose 4, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose154:
+ax_pose 5, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose155:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose156:
+ax_pose 30, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose157:
+ax_pose 31, 0x01e3, 0x80eb, 0x3c00
+ax_pose_terminator
+sBayleefPose158:
+ax_pose 32, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sBayleefPose159:
+ax_pose 33, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose160:
+ax_pose 32, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose161:
+ax_pose 31, 0x01e3, 0x90f5, 0x3c00
+ax_pose_terminator
+sBayleefPose162:
+ax_pose 30, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose163:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose164:
+ax_pose 30, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose165:
+ax_pose 31, 0x01e3, 0x90f4, 0x3c00
+ax_pose_terminator
+sBayleefPose166:
+ax_pose 32, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose167:
+ax_pose 33, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose168:
+ax_pose 32, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose169:
+ax_pose 31, 0x01e3, 0x80ec, 0x3c00
+ax_pose_terminator
+sBayleefPose170:
+ax_pose 30, 0x01e4, 0x80f1, 0x3c00
+ax_pose_terminator
+sBayleefPose171:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose172:
+ax_pose 21, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose173:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose174:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sBayleefPose175:
+ax_pose 22, 0x01e2, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose176:
+ax_pose 30, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose177:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose178:
+ax_pose 23, 0x01e1, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose179:
+ax_pose 31, 0x01e1, 0x90f4, 0x3c00
+ax_pose_terminator
+sBayleefPose180:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose181:
+ax_pose 24, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sBayleefPose182:
+ax_pose 32, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose183:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose184:
+ax_pose 25, 0x81e3, 0x80f0, 0x3c00
+ax_pose 26, 0x81e3, 0x4100, 0x3c08
+ax_pose 27, 0x81e3, 0x0108, 0x3c0c
+ax_pose 28, 0x01db, 0x0100, 0x3c0e
+ax_pose_terminator
+sBayleefPose185:
+ax_pose 33, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose186:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose187:
+ax_pose 24, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose188:
+ax_pose 32, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sBayleefPose189:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose190:
+ax_pose 23, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose191:
+ax_pose 31, 0x01e1, 0x80ec, 0x3c00
+ax_pose_terminator
+sBayleefPose192:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose193:
+ax_pose 22, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose194:
+ax_pose 30, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose195:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose196:
+ax_pose 30, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose197:
+ax_pose 31, 0x01e3, 0x80eb, 0x3c00
+ax_pose_terminator
+sBayleefPose198:
+ax_pose 32, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sBayleefPose199:
+ax_pose 33, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sBayleefPose200:
+ax_pose 32, 0x01e4, 0x90f1, 0x3c00
+ax_pose_terminator
+sBayleefPose201:
+ax_pose 31, 0x01e3, 0x90f5, 0x3c00
+ax_pose_terminator
+sBayleefPose202:
+ax_pose 30, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose203:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose204:
+ax_pose 3, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sBayleefPose205:
+ax_pose 6, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBayleefPose206:
+ax_pose 9, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose207:
+ax_pose 12, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sBayleefPose208:
+ax_pose 9, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sBayleefPose209:
+ax_pose 6, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sBayleefPose210:
+ax_pose 3, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+.align 2
+sBayleefAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 1, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 0, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBayleefAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 6, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 2, 29, 3, 4, 3, 4,
+ax_anim 1, 0, 30, 9, 11, 9, 11,
+ax_anim 2, 0, 34, 17, 21, 17, 21,
+ax_anim 2, 1, 34, 18, 20, 18, 20,
+ax_anim 2, 0, 34, 17, 21, 17, 21,
+ax_anim 2, 0, 34, 18, 20, 18, 20,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sBayleefAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 6, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 2, 33, 3, 0, 3, 0,
+ax_anim 1, 0, 34, 9, 0, 9, 0,
+ax_anim 2, 0, 37, 19, 0, 19, 0,
+ax_anim 2, 1, 37, 19, -1, 19, -1,
+ax_anim 2, 0, 37, 19, 0, 19, 0,
+ax_anim 2, 0, 37, 19, -1, 19, -1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sBayleefAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 2, 37, 4, -4, 4, -4,
+ax_anim 1, 0, 38, 12, -10, 12, -10,
+ax_anim 2, 0, 42, 22, -18, 22, -18,
+ax_anim 2, 1, 42, 23, -17, 23, -17,
+ax_anim 2, 0, 42, 22, -18, 22, -18,
+ax_anim 2, 0, 42, 23, -17, 23, -17,
+ax_anim 2, 0, 36, 7, -6, 7, -6,
+ax_anim_terminator
+sBayleefAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 6, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 1, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 0, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sBayleefAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 6, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 2, 45, -4, -4, -4, -4,
+ax_anim 1, 0, 46, -12, -10, -12, -10,
+ax_anim 2, 0, 42, -22, -18, -22, -18,
+ax_anim 2, 1, 42, -23, -17, -23, -17,
+ax_anim 2, 0, 42, -22, -18, -22, -18,
+ax_anim 2, 0, 42, -23, -17, -23, -17,
+ax_anim 2, 0, 44, -7, -6, -7, -6,
+ax_anim_terminator
+sBayleefAnims_2_7:
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 6, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 2, 49, -3, 0, -3, 0,
+ax_anim 1, 0, 50, -9, 0, -9, 0,
+ax_anim 2, 0, 45, -19, 0, -19, 0,
+ax_anim 2, 1, 45, -19, -1, -19, -1,
+ax_anim 2, 0, 45, -19, 0, -19, 0,
+ax_anim 2, 0, 45, -19, -1, -19, -1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sBayleefAnims_2_8:
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 6, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 2, 53, -3, 4, -3, 4,
+ax_anim 1, 0, 54, -9, 11, -9, 11,
+ax_anim 2, 0, 50, -17, 21, -17, 21,
+ax_anim 2, 1, 50, -18, 20, -18, 20,
+ax_anim 2, 0, 50, -17, 21, -17, 21,
+ax_anim 2, 0, 50, -18, 20, -18, 20,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBayleefAnims_3_1:
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 6, 0, 59, 0, -2, 0, -2,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 85, 0, 19, 0, 19,
+ax_anim 2, 1, 85, 1, 19, 1, 19,
+ax_anim 2, 0, 85, 0, 19, 0, 19,
+ax_anim 2, 0, 85, 1, 19, 1, 19,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sBayleefAnims_3_2:
+ax_anim 2, 0, 63, -1, -1, -1, -1,
+ax_anim 6, 0, 63, -2, -2, -2, -2,
+ax_anim 1, 2, 61, 3, 4, 3, 4,
+ax_anim 1, 0, 62, 9, 11, 9, 11,
+ax_anim 2, 0, 66, 17, 21, 17, 21,
+ax_anim 2, 1, 66, 18, 20, 18, 20,
+ax_anim 2, 0, 66, 17, 21, 17, 21,
+ax_anim 2, 0, 66, 18, 20, 18, 20,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sBayleefAnims_3_3:
+ax_anim 2, 0, 67, -1, 0, -1, 0,
+ax_anim 6, 0, 67, -2, 0, -2, 0,
+ax_anim 1, 2, 65, 3, 0, 3, 0,
+ax_anim 1, 0, 66, 9, 0, 9, 0,
+ax_anim 2, 0, 69, 19, 0, 19, 0,
+ax_anim 2, 1, 69, 19, -1, 19, -1,
+ax_anim 2, 0, 69, 19, 0, 19, 0,
+ax_anim 2, 0, 69, 19, -1, 19, -1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sBayleefAnims_3_4:
+ax_anim 2, 0, 71, -1, 1, -1, 1,
+ax_anim 6, 0, 71, -2, 2, -2, 2,
+ax_anim 1, 2, 69, 4, -4, 4, -4,
+ax_anim 1, 0, 70, 12, -10, 12, -10,
+ax_anim 2, 0, 74, 22, -18, 22, -18,
+ax_anim 2, 1, 74, 23, -17, 23, -17,
+ax_anim 2, 0, 74, 22, -18, 22, -18,
+ax_anim 2, 0, 74, 23, -17, 23, -17,
+ax_anim 2, 0, 68, 7, -6, 7, -6,
+ax_anim_terminator
+sBayleefAnims_3_5:
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 6, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -10, 0, -10,
+ax_anim 2, 0, 69, 0, -19, 0, -19,
+ax_anim 2, 1, 69, 1, -19, 1, -19,
+ax_anim 2, 0, 69, 0, -19, 0, -19,
+ax_anim 2, 0, 69, 1, -19, 1, -19,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sBayleefAnims_3_6:
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 6, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 2, 77, -4, -4, -4, -4,
+ax_anim 1, 0, 78, -12, -10, -12, -10,
+ax_anim 2, 0, 74, -22, -18, -22, -18,
+ax_anim 2, 1, 74, -23, -17, -23, -17,
+ax_anim 2, 0, 74, -22, -18, -22, -18,
+ax_anim 2, 0, 74, -23, -17, -23, -17,
+ax_anim 2, 0, 76, -7, -6, -7, -6,
+ax_anim_terminator
+sBayleefAnims_3_7:
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 6, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 2, 81, -3, 0, -3, 0,
+ax_anim 1, 0, 82, -9, 0, -9, 0,
+ax_anim 2, 0, 77, -19, 0, -19, 0,
+ax_anim 2, 1, 77, -19, -1, -19, -1,
+ax_anim 2, 0, 77, -19, 0, -19, 0,
+ax_anim 2, 0, 77, -19, -1, -19, -1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sBayleefAnims_3_8:
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 6, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 2, 85, -3, 4, -3, 4,
+ax_anim 1, 0, 86, -9, 11, -9, 11,
+ax_anim 2, 0, 82, -17, 21, -17, 21,
+ax_anim 2, 1, 82, -18, 20, -18, 20,
+ax_anim 2, 0, 82, -17, 21, -17, 21,
+ax_anim 2, 0, 82, -18, 20, -18, 20,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBayleefAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, -1, -3, -1, -3,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 1, 90, 1, 2, 1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 1, 2, 1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 1, 2, 1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sBayleefAnims_4_2:
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -2, -3, -2, -3,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 1, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sBayleefAnims_4_3:
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, -1, -3, -1,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 1, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sBayleefAnims_4_4:
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 2, -3, 2,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 1, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sBayleefAnims_4_5:
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 1, 3, 1, 3,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 1, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sBayleefAnims_4_6:
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 2, 3, 2,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 1, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sBayleefAnims_4_7:
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, -1, 3, -1,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 1, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sBayleefAnims_4_8:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 2, -3, 2, -3,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 1, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sBayleefAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sBayleefAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sBayleefAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sBayleefAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sBayleefAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sBayleefAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sBayleefAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sBayleefAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBayleefAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 14, 0, 131, 0, 0, 0, 0,
+ax_anim 20, 0, 130, 0, 0, 0, 0,
+ax_anim 14, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 14, 0, 134, 0, 0, 0, 0,
+ax_anim 20, 0, 133, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 14, 0, 137, 0, 0, 0, 0,
+ax_anim 20, 0, 136, 0, 0, 0, 0,
+ax_anim 14, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 14, 0, 140, 0, 0, 0, 0,
+ax_anim 20, 0, 139, 0, 0, 0, 0,
+ax_anim 14, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 14, 0, 143, 0, 0, 0, 0,
+ax_anim 20, 0, 142, 0, 0, 0, 0,
+ax_anim 14, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 14, 0, 146, 0, 0, 0, 0,
+ax_anim 20, 0, 145, 0, 0, 0, 0,
+ax_anim 14, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 14, 0, 149, 0, 0, 0, 0,
+ax_anim 20, 0, 148, 0, 0, 0, 0,
+ax_anim 14, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 14, 0, 152, 0, 0, 0, 0,
+ax_anim 20, 0, 151, 0, 0, 0, 0,
+ax_anim 14, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 11, 8, 11,
+ax_anim 2, 0, 157, 7, 18, 7, 18,
+ax_anim 3, 0, 158, 0, 20, 0, 20,
+ax_anim 2, 3, 159, -7, 18, -7, 18,
+ax_anim 2, 0, 160, -8, 11, -8, 11,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 18, 4, 18, 4,
+ax_anim 2, 0, 156, 23, 12, 23, 12,
+ax_anim 3, 0, 157, 22, 19, 22, 19,
+ax_anim 2, 3, 158, 13, 20, 13, 20,
+ax_anim 2, 0, 159, 4, 15, 4, 15,
+ax_anim 1, 0, 160, 1, 9, 1, 9,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 4, -5, 4, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -5, 16, -5,
+ax_anim 3, 0, 156, 20, 0, 20, 0,
+ax_anim 2, 3, 157, 18, 4, 18, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 3, 4, 3,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 3, -18, 3, -18,
+ax_anim 2, 0, 154, 11, -21, 11, -21,
+ax_anim 3, 0, 155, 21, -22, 21, -22,
+ax_anim 2, 3, 156, 21, -13, 21, -13,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 9, -1, 9, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -7, -4, -7, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -6, -18, -6, -18,
+ax_anim 3, 0, 154, 0, -20, 0, -20,
+ax_anim 2, 3, 155, 6, -18, 6, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 7, -4, 7, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -3, -18, -3, -18,
+ax_anim 2, 0, 154, -11, -21, -11, -21,
+ax_anim 3, 0, 161, -21, -22, -21, -22,
+ax_anim 2, 3, 160, -21, -13, -21, -13,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -9, -1, -9, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -4, -5, -4, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -5, -16, -5,
+ax_anim 3, 0, 160, -20, 0, -20, 0,
+ax_anim 2, 3, 159, -18, 4, -18, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 3, -4, 3,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -18, 4, -18, 4,
+ax_anim 2, 0, 160, -23, 12, -23, 12,
+ax_anim 3, 0, 159, -22, 19, -22, 19,
+ax_anim 2, 3, 158, -13, 20, -13, 20,
+ax_anim 2, 0, 157, -4, 15, -4, 15,
+ax_anim 1, 0, 156, 1, 9, 1, 9,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -7, 0, 0,
+ax_anim 2, 0, 171, 0, -13, 0, 0,
+ax_anim 3, 0, 171, 0, -17, 0, 0,
+ax_anim 4, 0, 171, 0, -18, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -7, 0, 0,
+ax_anim 2, 0, 174, 0, -13, 0, 0,
+ax_anim 3, 0, 174, 0, -17, 0, 0,
+ax_anim 4, 0, 174, 0, -18, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -6, 0, 0,
+ax_anim 2, 0, 177, 0, -12, 0, 0,
+ax_anim 3, 0, 177, 0, -16, 0, 0,
+ax_anim 4, 0, 177, 0, -17, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -6, 0, 0,
+ax_anim 2, 0, 180, 0, -12, 0, 0,
+ax_anim 3, 0, 180, 0, -16, 0, 0,
+ax_anim 4, 0, 180, 0, -17, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -9, 0, 0,
+ax_anim 2, 0, 183, 0, -15, 0, 0,
+ax_anim 3, 0, 183, 0, -19, 0, 0,
+ax_anim 4, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -6, 0, 0,
+ax_anim 2, 0, 186, 0, -12, 0, 0,
+ax_anim 3, 0, 186, 0, -16, 0, 0,
+ax_anim 4, 0, 186, 0, -17, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -6, 0, 0,
+ax_anim 2, 0, 189, 0, -12, 0, 0,
+ax_anim 3, 0, 189, 0, -16, 0, 0,
+ax_anim 4, 0, 189, 0, -17, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -7, 0, 0,
+ax_anim 2, 0, 192, 0, -13, 0, 0,
+ax_anim 3, 0, 192, 0, -17, 0, 0,
+ax_anim 4, 0, 192, 0, -18, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBayleefAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sBayleefGfx1:
+.incbin "baserom.gba", 0xBB2928, 0x200
+sBayleefSprites1:
+ax_sprite sBayleefGfx1, 0x200
+ax_sprite_terminator
+sBayleefGfx2:
+.incbin "baserom.gba", 0xBB2B38, 0x200
+sBayleefSprites2:
+ax_sprite sBayleefGfx2, 0x200
+ax_sprite_terminator
+sBayleefGfx3:
+.incbin "baserom.gba", 0xBB2D48, 0x200
+sBayleefSprites3:
+ax_sprite sBayleefGfx3, 0x200
+ax_sprite_terminator
+sBayleefGfx4:
+.incbin "baserom.gba", 0xBB2F58, 0x200
+sBayleefSprites4:
+ax_sprite sBayleefGfx4, 0x200
+ax_sprite_terminator
+sBayleefGfx5:
+.incbin "baserom.gba", 0xBB3168, 0x200
+sBayleefSprites5:
+ax_sprite sBayleefGfx5, 0x200
+ax_sprite_terminator
+sBayleefGfx6:
+.incbin "baserom.gba", 0xBB3378, 0x200
+sBayleefSprites6:
+ax_sprite sBayleefGfx6, 0x200
+ax_sprite_terminator
+sBayleefGfx7:
+.incbin "baserom.gba", 0xBB3588, 0x200
+sBayleefSprites7:
+ax_sprite sBayleefGfx7, 0x200
+ax_sprite_terminator
+sBayleefGfx8:
+.incbin "baserom.gba", 0xBB3798, 0x200
+sBayleefSprites8:
+ax_sprite sBayleefGfx8, 0x200
+ax_sprite_terminator
+sBayleefGfx9:
+.incbin "baserom.gba", 0xBB39A8, 0x200
+sBayleefSprites9:
+ax_sprite sBayleefGfx9, 0x200
+ax_sprite_terminator
+sBayleefGfx10:
+.incbin "baserom.gba", 0xBB3BB8, 0x200
+sBayleefSprites10:
+ax_sprite sBayleefGfx10, 0x200
+ax_sprite_terminator
+sBayleefGfx11:
+.incbin "baserom.gba", 0xBB3DC8, 0x200
+sBayleefSprites11:
+ax_sprite sBayleefGfx11, 0x200
+ax_sprite_terminator
+sBayleefGfx12:
+.incbin "baserom.gba", 0xBB3FD8, 0x200
+sBayleefSprites12:
+ax_sprite sBayleefGfx12, 0x200
+ax_sprite_terminator
+sBayleefGfx13:
+.incbin "baserom.gba", 0xBB41E8, 0x200
+sBayleefSprites13:
+ax_sprite sBayleefGfx13, 0x200
+ax_sprite_terminator
+sBayleefGfx14:
+.incbin "baserom.gba", 0xBB43F8, 0x100
+sBayleefSprites14:
+ax_sprite sBayleefGfx14, 0x100
+ax_sprite_terminator
+sBayleefGfx15:
+.incbin "baserom.gba", 0xBB4508, 0x80
+sBayleefSprites15:
+ax_sprite sBayleefGfx15, 0x80
+ax_sprite_terminator
+sBayleefGfx16:
+.incbin "baserom.gba", 0xBB4598, 0x40
+sBayleefSprites16:
+ax_sprite sBayleefGfx16, 0x40
+ax_sprite_terminator
+sBayleefGfx17:
+.incbin "baserom.gba", 0xBB45E8, 0x20
+sBayleefSprites17:
+ax_sprite sBayleefGfx17, 0x20
+ax_sprite_terminator
+sBayleefGfx18:
+.incbin "baserom.gba", 0xBB4618, 0x100
+sBayleefSprites18:
+ax_sprite sBayleefGfx18, 0x100
+ax_sprite_terminator
+sBayleefGfx19:
+.incbin "baserom.gba", 0xBB4728, 0x80
+sBayleefSprites19:
+ax_sprite sBayleefGfx19, 0x80
+ax_sprite_terminator
+sBayleefGfx20:
+.incbin "baserom.gba", 0xBB47B8, 0x20
+sBayleefSprites20:
+ax_sprite sBayleefGfx20, 0x20
+ax_sprite_terminator
+sBayleefGfx21:
+.incbin "baserom.gba", 0xBB47E8, 0x40
+sBayleefSprites21:
+ax_sprite sBayleefGfx21, 0x40
+ax_sprite_terminator
+sBayleefGfx22:
+.incbin "baserom.gba", 0xBB4838, 0x60
+sBayleefGfx22_1:
+.incbin "baserom.gba", 0xBB4898, 0x160
+sBayleefSprites22:
+ax_sprite sBayleefGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBayleefGfx23:
+.incbin "baserom.gba", 0xBB4A20, 0x40
+sBayleefGfx23_1:
+.incbin "baserom.gba", 0xBB4A60, 0x100
+sBayleefGfx23_2:
+.incbin "baserom.gba", 0xBB4B60, 0x40
+sBayleefSprites23:
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBayleefGfx24:
+.incbin "baserom.gba", 0xBB4BE0, 0x160
+sBayleefGfx24_1:
+.incbin "baserom.gba", 0xBB4D40, 0x60
+sBayleefSprites24:
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx24_1, 0x60
+ax_sprite_terminator
+sBayleefGfx25:
+.incbin "baserom.gba", 0xBB4DC8, 0x160
+sBayleefGfx25_1:
+.incbin "baserom.gba", 0xBB4F28, 0x40
+sBayleefSprites25:
+ax_sprite sBayleefGfx25, 0x160
+ax_sprite 0, 0x40
+ax_sprite sBayleefGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBayleefGfx26:
+.incbin "baserom.gba", 0xBB4F90, 0xC0
+sBayleefGfx26_1:
+.incbin "baserom.gba", 0xBB5050, 0x20
+sBayleefSprites26:
+ax_sprite sBayleefGfx26, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx26_1, 0x20
+ax_sprite_terminator
+sBayleefGfx27:
+.incbin "baserom.gba", 0xBB5090, 0x80
+sBayleefSprites27:
+ax_sprite sBayleefGfx27, 0x80
+ax_sprite_terminator
+sBayleefGfx28:
+.incbin "baserom.gba", 0xBB5120, 0x40
+sBayleefSprites28:
+ax_sprite sBayleefGfx28, 0x40
+ax_sprite_terminator
+sBayleefGfx29:
+.incbin "baserom.gba", 0xBB5170, 0x20
+sBayleefSprites29:
+ax_sprite sBayleefGfx29, 0x20
+ax_sprite_terminator
+sBayleefGfx30:
+.incbin "baserom.gba", 0xBB51A0, 0x40
+sBayleefGfx30_1:
+.incbin "baserom.gba", 0xBB51E0, 0x100
+sBayleefGfx30_2:
+.incbin "baserom.gba", 0xBB52E0, 0x40
+sBayleefSprites30:
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBayleefGfx31:
+.incbin "baserom.gba", 0xBB5360, 0x40
+sBayleefGfx31_1:
+.incbin "baserom.gba", 0xBB53A0, 0x60
+sBayleefGfx31_2:
+.incbin "baserom.gba", 0xBB5400, 0x100
+sBayleefSprites31:
+ax_sprite sBayleefGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBayleefGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx31_2, 0x100
+ax_sprite_terminator
+sBayleefGfx32:
+.incbin "baserom.gba", 0xBB5530, 0x60
+sBayleefGfx32_1:
+.incbin "baserom.gba", 0xBB5590, 0x60
+sBayleefGfx32_2:
+.incbin "baserom.gba", 0xBB55F0, 0x80
+sBayleefGfx32_3:
+.incbin "baserom.gba", 0xBB5670, 0x60
+sBayleefSprites32:
+ax_sprite sBayleefGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx32_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx32_3, 0x60
+ax_sprite_terminator
+sBayleefGfx33:
+.incbin "baserom.gba", 0xBB5710, 0x40
+sBayleefGfx33_1:
+.incbin "baserom.gba", 0xBB5750, 0x60
+sBayleefGfx33_2:
+.incbin "baserom.gba", 0xBB57B0, 0x100
+sBayleefSprites33:
+ax_sprite sBayleefGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBayleefGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx33_2, 0x100
+ax_sprite_terminator
+sBayleefGfx34:
+.incbin "baserom.gba", 0xBB58E0, 0x40
+sBayleefGfx34_1:
+.incbin "baserom.gba", 0xBB5920, 0x60
+sBayleefGfx34_2:
+.incbin "baserom.gba", 0xBB5980, 0x60
+sBayleefGfx34_3:
+.incbin "baserom.gba", 0xBB59E0, 0x60
+sBayleefSprites34:
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBayleefGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBayleefGfx35:
+.incbin "baserom.gba", 0xBB5A90, 0x200
+sBayleefSprites35:
+ax_sprite sBayleefGfx35, 0x200
+ax_sprite_terminator
+sBayleefGfx36:
+.incbin "baserom.gba", 0xBB5CA0, 0x200
+sBayleefSprites36:
+ax_sprite sBayleefGfx36, 0x200
+ax_sprite_terminator
+sBayleefGfx37:
+.incbin "baserom.gba", 0xBB5EB0, 0x200
+sBayleefSprites37:
+ax_sprite sBayleefGfx37, 0x200
+ax_sprite_terminator
+sBayleefGfx38:
+.incbin "baserom.gba", 0xBB60C0, 0x200
+sBayleefSprites38:
+ax_sprite sBayleefGfx38, 0x200
+ax_sprite_terminator
+sBayleefGfx39:
+.incbin "baserom.gba", 0xBB62D0, 0x200
+sBayleefSprites39:
+ax_sprite sBayleefGfx39, 0x200
+ax_sprite_terminator
+sBayleefGfx40:
+.incbin "baserom.gba", 0xBB64E0, 0x200
+sBayleefSprites40:
+ax_sprite sBayleefGfx40, 0x200
+ax_sprite_terminator
+sBayleefGfx41:
+.incbin "baserom.gba", 0xBB66F0, 0x200
+sBayleefSprites41:
+ax_sprite sBayleefGfx41, 0x200
+ax_sprite_terminator
+sAxPosesBayleef:
+.4byte sBayleefPose1
+.4byte sBayleefPose2
+.4byte sBayleefPose3
+.4byte sBayleefPose4
+.4byte sBayleefPose5
+.4byte sBayleefPose6
+.4byte sBayleefPose7
+.4byte sBayleefPose8
+.4byte sBayleefPose9
+.4byte sBayleefPose10
+.4byte sBayleefPose11
+.4byte sBayleefPose12
+.4byte sBayleefPose13
+.4byte sBayleefPose14
+.4byte sBayleefPose15
+.4byte sBayleefPose16
+.4byte sBayleefPose17
+.4byte sBayleefPose18
+.4byte sBayleefPose19
+.4byte sBayleefPose20
+.4byte sBayleefPose21
+.4byte sBayleefPose22
+.4byte sBayleefPose23
+.4byte sBayleefPose24
+.4byte sBayleefPose25
+.4byte sBayleefPose26
+.4byte sBayleefPose27
+.4byte sBayleefPose28
+.4byte sBayleefPose29
+.4byte sBayleefPose30
+.4byte sBayleefPose31
+.4byte sBayleefPose32
+.4byte sBayleefPose33
+.4byte sBayleefPose34
+.4byte sBayleefPose35
+.4byte sBayleefPose36
+.4byte sBayleefPose37
+.4byte sBayleefPose38
+.4byte sBayleefPose39
+.4byte sBayleefPose40
+.4byte sBayleefPose41
+.4byte sBayleefPose42
+.4byte sBayleefPose43
+.4byte sBayleefPose44
+.4byte sBayleefPose45
+.4byte sBayleefPose46
+.4byte sBayleefPose47
+.4byte sBayleefPose48
+.4byte sBayleefPose49
+.4byte sBayleefPose50
+.4byte sBayleefPose51
+.4byte sBayleefPose52
+.4byte sBayleefPose53
+.4byte sBayleefPose54
+.4byte sBayleefPose55
+.4byte sBayleefPose56
+.4byte sBayleefPose57
+.4byte sBayleefPose58
+.4byte sBayleefPose59
+.4byte sBayleefPose60
+.4byte sBayleefPose61
+.4byte sBayleefPose62
+.4byte sBayleefPose63
+.4byte sBayleefPose64
+.4byte sBayleefPose65
+.4byte sBayleefPose66
+.4byte sBayleefPose67
+.4byte sBayleefPose68
+.4byte sBayleefPose69
+.4byte sBayleefPose70
+.4byte sBayleefPose71
+.4byte sBayleefPose72
+.4byte sBayleefPose73
+.4byte sBayleefPose74
+.4byte sBayleefPose75
+.4byte sBayleefPose76
+.4byte sBayleefPose77
+.4byte sBayleefPose78
+.4byte sBayleefPose79
+.4byte sBayleefPose80
+.4byte sBayleefPose81
+.4byte sBayleefPose82
+.4byte sBayleefPose83
+.4byte sBayleefPose84
+.4byte sBayleefPose85
+.4byte sBayleefPose86
+.4byte sBayleefPose87
+.4byte sBayleefPose88
+.4byte sBayleefPose89
+.4byte sBayleefPose90
+.4byte sBayleefPose91
+.4byte sBayleefPose92
+.4byte sBayleefPose93
+.4byte sBayleefPose94
+.4byte sBayleefPose95
+.4byte sBayleefPose96
+.4byte sBayleefPose97
+.4byte sBayleefPose98
+.4byte sBayleefPose99
+.4byte sBayleefPose100
+.4byte sBayleefPose101
+.4byte sBayleefPose102
+.4byte sBayleefPose103
+.4byte sBayleefPose104
+.4byte sBayleefPose105
+.4byte sBayleefPose106
+.4byte sBayleefPose107
+.4byte sBayleefPose108
+.4byte sBayleefPose109
+.4byte sBayleefPose110
+.4byte sBayleefPose111
+.4byte sBayleefPose112
+.4byte sBayleefPose113
+.4byte sBayleefPose114
+.4byte sBayleefPose115
+.4byte sBayleefPose116
+.4byte sBayleefPose117
+.4byte sBayleefPose118
+.4byte sBayleefPose119
+.4byte sBayleefPose120
+.4byte sBayleefPose121
+.4byte sBayleefPose122
+.4byte sBayleefPose123
+.4byte sBayleefPose124
+.4byte sBayleefPose125
+.4byte sBayleefPose126
+.4byte sBayleefPose127
+.4byte sBayleefPose128
+.4byte sBayleefPose129
+.4byte sBayleefPose130
+.4byte sBayleefPose131
+.4byte sBayleefPose132
+.4byte sBayleefPose133
+.4byte sBayleefPose134
+.4byte sBayleefPose135
+.4byte sBayleefPose136
+.4byte sBayleefPose137
+.4byte sBayleefPose138
+.4byte sBayleefPose139
+.4byte sBayleefPose140
+.4byte sBayleefPose141
+.4byte sBayleefPose142
+.4byte sBayleefPose143
+.4byte sBayleefPose144
+.4byte sBayleefPose145
+.4byte sBayleefPose146
+.4byte sBayleefPose147
+.4byte sBayleefPose148
+.4byte sBayleefPose149
+.4byte sBayleefPose150
+.4byte sBayleefPose151
+.4byte sBayleefPose152
+.4byte sBayleefPose153
+.4byte sBayleefPose154
+.4byte sBayleefPose155
+.4byte sBayleefPose156
+.4byte sBayleefPose157
+.4byte sBayleefPose158
+.4byte sBayleefPose159
+.4byte sBayleefPose160
+.4byte sBayleefPose161
+.4byte sBayleefPose162
+.4byte sBayleefPose163
+.4byte sBayleefPose164
+.4byte sBayleefPose165
+.4byte sBayleefPose166
+.4byte sBayleefPose167
+.4byte sBayleefPose168
+.4byte sBayleefPose169
+.4byte sBayleefPose170
+.4byte sBayleefPose171
+.4byte sBayleefPose172
+.4byte sBayleefPose173
+.4byte sBayleefPose174
+.4byte sBayleefPose175
+.4byte sBayleefPose176
+.4byte sBayleefPose177
+.4byte sBayleefPose178
+.4byte sBayleefPose179
+.4byte sBayleefPose180
+.4byte sBayleefPose181
+.4byte sBayleefPose182
+.4byte sBayleefPose183
+.4byte sBayleefPose184
+.4byte sBayleefPose185
+.4byte sBayleefPose186
+.4byte sBayleefPose187
+.4byte sBayleefPose188
+.4byte sBayleefPose189
+.4byte sBayleefPose190
+.4byte sBayleefPose191
+.4byte sBayleefPose192
+.4byte sBayleefPose193
+.4byte sBayleefPose194
+.4byte sBayleefPose195
+.4byte sBayleefPose196
+.4byte sBayleefPose197
+.4byte sBayleefPose198
+.4byte sBayleefPose199
+.4byte sBayleefPose200
+.4byte sBayleefPose201
+.4byte sBayleefPose202
+.4byte sBayleefPose203
+.4byte sBayleefPose204
+.4byte sBayleefPose205
+.4byte sBayleefPose206
+.4byte sBayleefPose207
+.4byte sBayleefPose208
+.4byte sBayleefPose209
+.4byte sBayleefPose210
+sAxPositionsBayleef:
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    0,  -11, 	  -6,    2, 	   4,    1, 	   0,   -8
+.2byte    0,  -11, 	  -5,    1, 	   5,    2, 	  -1,   -8
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    6,  -13, 	   9,   -1, 	  -3,    1, 	   0,   -7
+.2byte    6,  -13, 	   5,   -1, 	   2,    1, 	  -1,   -6
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte   10,  -14, 	  10,   -3, 	   3,   -1, 	   0,   -8
+.2byte   10,  -14, 	   2,   -2, 	   9,   -2, 	  -2,   -7
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte    7,  -16, 	   1,   -8, 	   6,   -2, 	  -1,   -6
+.2byte    7,  -16, 	  -2,   -7, 	   8,   -4, 	  -2,   -6
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte   -1,  -18, 	   4,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -1,  -18, 	   4,   -5, 	  -5,   -7, 	   0,   -6
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte   -8,  -16, 	  -2,   -8, 	  -7,   -2, 	   0,   -6
+.2byte   -8,  -16, 	   1,   -7, 	  -9,   -4, 	   1,   -6
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte  -10,  -14, 	 -10,   -3, 	  -3,   -1, 	   0,   -8
+.2byte  -10,  -14, 	  -2,   -2, 	  -9,   -2, 	   2,   -7
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -7,  -13, 	 -10,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -7,  -13, 	  -6,   -1, 	  -3,    1, 	   0,   -6
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    0,  -11, 	  -6,    2, 	   4,    1, 	   0,   -8
+.2byte    0,  -11, 	  -5,    1, 	   5,    2, 	  -1,   -8
+.2byte    1,  -23, 	   3,   -6, 	   8,   -8, 	  -2,   -8
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    6,  -13, 	   9,   -1, 	  -3,    1, 	   0,   -7
+.2byte    6,  -13, 	   5,   -1, 	   2,    1, 	  -1,   -6
+.2byte   -3,  -25, 	   3,   -6, 	  -6,   -6, 	  -2,   -9
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte   10,  -14, 	  10,   -3, 	   3,   -1, 	   0,   -8
+.2byte   10,  -14, 	   2,   -2, 	   9,   -2, 	  -2,   -7
+.2byte   -8,  -26, 	   9,  -10, 	   2,   -8, 	  -2,  -10
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte    7,  -16, 	   1,   -8, 	   6,   -2, 	  -1,   -6
+.2byte    7,  -16, 	  -2,   -7, 	   8,   -4, 	  -2,   -6
+.2byte   -3,  -20, 	   8,  -12, 	   9,   -7, 	  -1,   -6
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte   -1,  -18, 	   4,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -1,  -18, 	   4,   -5, 	  -5,   -7, 	   0,   -6
+.2byte   -2,  -23, 	  -4,  -15, 	 -12,  -11, 	  -2,   -9
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte   -8,  -16, 	  -2,   -8, 	  -7,   -2, 	   0,   -6
+.2byte   -8,  -16, 	   1,   -7, 	  -9,   -4, 	   1,   -6
+.2byte    2,  -20, 	  -9,  -12, 	 -10,   -7, 	   0,   -6
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte  -10,  -14, 	 -10,   -3, 	  -3,   -1, 	   0,   -8
+.2byte  -10,  -14, 	  -2,   -2, 	  -9,   -2, 	   2,   -7
+.2byte    7,  -26, 	 -10,  -10, 	  -3,   -8, 	   1,  -10
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -7,  -13, 	 -10,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -7,  -13, 	  -6,   -1, 	  -3,    1, 	   0,   -6
+.2byte    2,  -25, 	  -4,   -6, 	   5,   -6, 	   1,   -9
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    0,  -11, 	  -6,    2, 	   4,    1, 	   0,   -8
+.2byte    0,  -11, 	  -5,    1, 	   5,    2, 	  -1,   -8
+.2byte    1,  -23, 	   3,   -6, 	   8,   -8, 	  -2,   -8
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    6,  -13, 	   9,   -1, 	  -3,    1, 	   0,   -7
+.2byte    6,  -13, 	   5,   -1, 	   2,    1, 	  -1,   -6
+.2byte   -3,  -25, 	   3,   -6, 	  -6,   -6, 	  -2,   -9
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte   10,  -14, 	  10,   -3, 	   3,   -1, 	   0,   -8
+.2byte   10,  -14, 	   2,   -2, 	   9,   -2, 	  -2,   -7
+.2byte   -8,  -26, 	   9,  -10, 	   2,   -8, 	  -2,  -10
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte    7,  -16, 	   1,   -8, 	   6,   -2, 	  -1,   -6
+.2byte    7,  -16, 	  -2,   -7, 	   8,   -4, 	  -2,   -6
+.2byte   -3,  -20, 	   8,  -12, 	   9,   -7, 	  -1,   -6
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte   -1,  -18, 	   4,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -1,  -18, 	   4,   -5, 	  -5,   -7, 	   0,   -6
+.2byte   -2,  -23, 	  -4,  -15, 	 -12,  -11, 	  -2,   -9
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte   -8,  -16, 	  -2,   -8, 	  -7,   -2, 	   0,   -6
+.2byte   -8,  -16, 	   1,   -7, 	  -9,   -4, 	   1,   -6
+.2byte    2,  -20, 	  -9,  -12, 	 -10,   -7, 	   0,   -6
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte  -10,  -14, 	 -10,   -3, 	  -3,   -1, 	   0,   -8
+.2byte  -10,  -14, 	  -2,   -2, 	  -9,   -2, 	   2,   -7
+.2byte    7,  -26, 	 -10,  -10, 	  -3,   -8, 	   1,  -10
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -7,  -13, 	 -10,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -7,  -13, 	  -6,   -1, 	  -3,    1, 	   0,   -6
+.2byte    2,  -25, 	  -4,   -6, 	   5,   -6, 	   1,   -9
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    1,  -23, 	   3,   -6, 	   8,   -8, 	  -2,   -8
+.2byte   -1,   -6, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte   -2,  -25, 	   4,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte   10,   -6, 	   8,   -1, 	  -1,    3, 	   1,   -6
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte   -8,  -26, 	   9,  -10, 	   2,   -8, 	  -2,  -10
+.2byte   15,  -11, 	   6,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte   -3,  -20, 	   8,  -12, 	   9,   -7, 	  -1,   -6
+.2byte   13,  -14, 	   1,   -7, 	   8,   -4, 	   0,   -8
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte   -2,  -23, 	  -4,  -15, 	 -12,  -11, 	  -2,   -9
+.2byte    0,  -13, 	   5,   -5, 	  -6,   -5, 	   0,   -8
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte    2,  -20, 	  -9,  -12, 	 -10,   -7, 	   0,   -6
+.2byte  -14,  -14, 	  -2,   -7, 	  -9,   -4, 	  -1,   -8
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte    7,  -26, 	 -10,  -10, 	  -3,   -8, 	   1,  -10
+.2byte  -16,  -11, 	  -7,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte    1,  -25, 	  -5,   -6, 	   4,   -6, 	   0,   -9
+.2byte  -11,   -6, 	  -9,   -1, 	   0,    3, 	  -2,   -6
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte   -5,   -9, 	  -8,    0, 	  -5,    1, 	   0,   -6
+.2byte   -5,   -7, 	  -8,    0, 	  -5,    1, 	   0,   -6
+.2byte    1,  -10, 	  -6,   -3, 	   6,    0, 	   1,   -9
+.2byte    8,   -9, 	   9,   -3, 	   0,    1, 	   0,   -7
+.2byte   11,  -10, 	  10,   -4, 	   5,    1, 	  -1,   -5
+.2byte    9,  -14, 	   1,   -9, 	   7,   -4, 	  -1,   -8
+.2byte    1,  -13, 	   7,   -5, 	  -4,   -4, 	   0,   -7
+.2byte  -10,  -14, 	  -2,   -9, 	  -8,   -4, 	   0,   -8
+.2byte  -10,  -10, 	  -9,   -4, 	  -4,    1, 	   2,   -5
+.2byte   -9,   -9, 	 -10,   -3, 	  -1,    1, 	  -1,   -7
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    0,  -11, 	  -6,    2, 	   4,    1, 	   0,   -8
+.2byte    0,  -11, 	  -5,    1, 	   5,    2, 	  -1,   -8
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    6,  -13, 	   9,   -1, 	  -3,    1, 	   0,   -7
+.2byte    6,  -13, 	   5,   -1, 	   2,    1, 	  -1,   -6
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte   10,  -14, 	  10,   -3, 	   3,   -1, 	   0,   -8
+.2byte   10,  -14, 	   2,   -2, 	   9,   -2, 	  -2,   -7
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte    7,  -16, 	   1,   -8, 	   6,   -2, 	  -1,   -6
+.2byte    7,  -16, 	  -2,   -7, 	   8,   -4, 	  -2,   -6
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte   -1,  -18, 	   4,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -1,  -18, 	   4,   -5, 	  -5,   -7, 	   0,   -6
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte   -8,  -16, 	  -2,   -8, 	  -7,   -2, 	   0,   -6
+.2byte   -8,  -16, 	   1,   -7, 	  -9,   -4, 	   1,   -6
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte  -10,  -14, 	 -10,   -3, 	  -3,   -1, 	   0,   -8
+.2byte  -10,  -14, 	  -2,   -2, 	  -9,   -2, 	   2,   -7
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -7,  -13, 	 -10,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -7,  -13, 	  -6,   -1, 	  -3,    1, 	   0,   -6
+.2byte   -1,   -6, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte  -11,   -6, 	  -9,   -1, 	   0,    3, 	  -2,   -6
+.2byte  -17,   -9, 	  -8,   -2, 	  -5,    1, 	  -1,   -7
+.2byte  -14,  -14, 	  -2,   -7, 	  -9,   -4, 	  -1,   -8
+.2byte    0,  -13, 	   5,   -5, 	  -6,   -5, 	   0,   -8
+.2byte   13,  -14, 	   1,   -7, 	   8,   -4, 	   0,   -8
+.2byte   16,   -9, 	   7,   -2, 	   4,    1, 	   0,   -7
+.2byte   10,   -6, 	   8,   -1, 	  -1,    3, 	   1,   -6
+.2byte   -1,   -6, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte   10,   -7, 	   8,   -2, 	  -1,    2, 	   1,   -7
+.2byte   15,   -9, 	   6,   -2, 	   3,    1, 	  -1,   -7
+.2byte   12,  -14, 	   0,   -7, 	   7,   -4, 	  -1,   -8
+.2byte    0,  -13, 	   5,   -5, 	  -6,   -5, 	   0,   -8
+.2byte  -13,  -14, 	  -1,   -7, 	  -8,   -4, 	   0,   -8
+.2byte  -16,   -9, 	  -7,   -2, 	  -4,    1, 	   0,   -7
+.2byte  -10,   -7, 	  -8,   -2, 	   1,    2, 	  -1,   -7
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    1,  -23, 	   3,   -6, 	   8,   -8, 	  -2,   -8
+.2byte   -1,   -6, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte   -2,  -25, 	   4,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte   10,   -6, 	   8,   -1, 	  -1,    3, 	   1,   -6
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte   -8,  -26, 	   9,  -10, 	   2,   -8, 	  -2,  -10
+.2byte   15,  -11, 	   6,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte   -3,  -20, 	   8,  -12, 	   9,   -7, 	  -1,   -6
+.2byte   13,  -14, 	   1,   -7, 	   8,   -4, 	   0,   -8
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte   -2,  -23, 	  -4,  -15, 	 -12,  -11, 	  -2,   -9
+.2byte    0,  -13, 	   5,   -5, 	  -6,   -5, 	   0,   -8
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte    2,  -20, 	  -9,  -12, 	 -10,   -7, 	   0,   -6
+.2byte  -14,  -14, 	  -2,   -7, 	  -9,   -4, 	  -1,   -8
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte    7,  -26, 	 -10,  -10, 	  -3,   -8, 	   1,  -10
+.2byte  -16,  -11, 	  -7,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte    1,  -25, 	  -5,   -6, 	   4,   -6, 	   0,   -9
+.2byte  -11,   -6, 	  -9,   -1, 	   0,    3, 	  -2,   -6
+.2byte   -1,   -6, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte  -11,   -6, 	  -9,   -1, 	   0,    3, 	  -2,   -6
+.2byte  -17,   -9, 	  -8,   -2, 	  -5,    1, 	  -1,   -7
+.2byte  -14,  -14, 	  -2,   -7, 	  -9,   -4, 	  -1,   -8
+.2byte    0,  -13, 	   5,   -5, 	  -6,   -5, 	   0,   -8
+.2byte   13,  -14, 	   1,   -7, 	   8,   -4, 	   0,   -8
+.2byte   16,   -9, 	   7,   -2, 	   4,    1, 	   0,   -7
+.2byte   10,   -6, 	   8,   -1, 	  -1,    3, 	   1,   -6
+.2byte    0,  -12, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte   -6,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte  -10,  -15, 	  -9,   -3, 	  -7,   -1, 	   1,   -8
+.2byte   -8,  -17, 	  -1,   -7, 	  -8,   -4, 	   0,   -7
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	   0,   -8
+.2byte    7,  -17, 	   0,   -7, 	   7,   -4, 	  -1,   -7
+.2byte    9,  -15, 	   8,   -3, 	   6,   -1, 	  -2,   -8
+.2byte    5,  -14, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+sBayleefAnimTable1:
+.4byte sBayleefAnims_1_1
+.4byte sBayleefAnims_1_2
+.4byte sBayleefAnims_1_3
+.4byte sBayleefAnims_1_4
+.4byte sBayleefAnims_1_5
+.4byte sBayleefAnims_1_6
+.4byte sBayleefAnims_1_7
+.4byte sBayleefAnims_1_8
+sBayleefAnimTable2:
+.4byte sBayleefAnims_2_1
+.4byte sBayleefAnims_2_2
+.4byte sBayleefAnims_2_3
+.4byte sBayleefAnims_2_4
+.4byte sBayleefAnims_2_5
+.4byte sBayleefAnims_2_6
+.4byte sBayleefAnims_2_7
+.4byte sBayleefAnims_2_8
+sBayleefAnimTable3:
+.4byte sBayleefAnims_3_1
+.4byte sBayleefAnims_3_2
+.4byte sBayleefAnims_3_3
+.4byte sBayleefAnims_3_4
+.4byte sBayleefAnims_3_5
+.4byte sBayleefAnims_3_6
+.4byte sBayleefAnims_3_7
+.4byte sBayleefAnims_3_8
+sBayleefAnimTable4:
+.4byte sBayleefAnims_4_1
+.4byte sBayleefAnims_4_2
+.4byte sBayleefAnims_4_3
+.4byte sBayleefAnims_4_4
+.4byte sBayleefAnims_4_5
+.4byte sBayleefAnims_4_6
+.4byte sBayleefAnims_4_7
+.4byte sBayleefAnims_4_8
+sBayleefAnimTable5:
+.4byte sBayleefAnims_5_1
+.4byte sBayleefAnims_5_2
+.4byte sBayleefAnims_5_3
+.4byte sBayleefAnims_5_4
+.4byte sBayleefAnims_5_5
+.4byte sBayleefAnims_5_6
+.4byte sBayleefAnims_5_7
+.4byte sBayleefAnims_5_8
+sBayleefAnimTable6:
+.4byte sBayleefAnims_6_1
+.4byte sBayleefAnims_6_1
+.4byte sBayleefAnims_6_1
+.4byte sBayleefAnims_6_1
+.4byte sBayleefAnims_6_1
+.4byte sBayleefAnims_6_1
+.4byte sBayleefAnims_6_1
+.4byte sBayleefAnims_6_1
+sBayleefAnimTable7:
+.4byte sBayleefAnims_7_1
+.4byte sBayleefAnims_7_2
+.4byte sBayleefAnims_7_3
+.4byte sBayleefAnims_7_4
+.4byte sBayleefAnims_7_5
+.4byte sBayleefAnims_7_6
+.4byte sBayleefAnims_7_7
+.4byte sBayleefAnims_7_8
+sBayleefAnimTable8:
+.4byte sBayleefAnims_8_1
+.4byte sBayleefAnims_8_2
+.4byte sBayleefAnims_8_3
+.4byte sBayleefAnims_8_4
+.4byte sBayleefAnims_8_5
+.4byte sBayleefAnims_8_6
+.4byte sBayleefAnims_8_7
+.4byte sBayleefAnims_8_8
+sBayleefAnimTable9:
+.4byte sBayleefAnims_9_1
+.4byte sBayleefAnims_9_2
+.4byte sBayleefAnims_9_3
+.4byte sBayleefAnims_9_4
+.4byte sBayleefAnims_9_5
+.4byte sBayleefAnims_9_6
+.4byte sBayleefAnims_9_7
+.4byte sBayleefAnims_9_8
+sBayleefAnimTable10:
+.4byte sBayleefAnims_10_1
+.4byte sBayleefAnims_10_2
+.4byte sBayleefAnims_10_3
+.4byte sBayleefAnims_10_4
+.4byte sBayleefAnims_10_5
+.4byte sBayleefAnims_10_6
+.4byte sBayleefAnims_10_7
+.4byte sBayleefAnims_10_8
+sBayleefAnimTable11:
+.4byte sBayleefAnims_11_1
+.4byte sBayleefAnims_11_2
+.4byte sBayleefAnims_11_3
+.4byte sBayleefAnims_11_4
+.4byte sBayleefAnims_11_5
+.4byte sBayleefAnims_11_6
+.4byte sBayleefAnims_11_7
+.4byte sBayleefAnims_11_8
+sBayleefAnimTable12:
+.4byte sBayleefAnims_12_1
+.4byte sBayleefAnims_12_2
+.4byte sBayleefAnims_12_3
+.4byte sBayleefAnims_12_4
+.4byte sBayleefAnims_12_5
+.4byte sBayleefAnims_12_6
+.4byte sBayleefAnims_12_7
+.4byte sBayleefAnims_12_8
+sBayleefAnimTable13:
+.4byte sBayleefAnims_13_1
+.4byte sBayleefAnims_13_2
+.4byte sBayleefAnims_13_3
+.4byte sBayleefAnims_13_4
+.4byte sBayleefAnims_13_5
+.4byte sBayleefAnims_13_6
+.4byte sBayleefAnims_13_7
+.4byte sBayleefAnims_13_8
+sAxAnimationsBayleef:
+.4byte sBayleefAnimTable1
+.4byte sBayleefAnimTable2
+.4byte sBayleefAnimTable3
+.4byte sBayleefAnimTable4
+.4byte sBayleefAnimTable5
+.4byte sBayleefAnimTable6
+.4byte sBayleefAnimTable7
+.4byte sBayleefAnimTable8
+.4byte sBayleefAnimTable9
+.4byte sBayleefAnimTable10
+.4byte sBayleefAnimTable11
+.4byte sBayleefAnimTable12
+.4byte sBayleefAnimTable13
+sAxSpritesBayleef:
+.4byte sBayleefSprites1
+.4byte sBayleefSprites2
+.4byte sBayleefSprites3
+.4byte sBayleefSprites4
+.4byte sBayleefSprites5
+.4byte sBayleefSprites6
+.4byte sBayleefSprites7
+.4byte sBayleefSprites8
+.4byte sBayleefSprites9
+.4byte sBayleefSprites10
+.4byte sBayleefSprites11
+.4byte sBayleefSprites12
+.4byte sBayleefSprites13
+.4byte sBayleefSprites14
+.4byte sBayleefSprites15
+.4byte sBayleefSprites16
+.4byte sBayleefSprites17
+.4byte sBayleefSprites18
+.4byte sBayleefSprites19
+.4byte sBayleefSprites20
+.4byte sBayleefSprites21
+.4byte sBayleefSprites22
+.4byte sBayleefSprites23
+.4byte sBayleefSprites24
+.4byte sBayleefSprites25
+.4byte sBayleefSprites26
+.4byte sBayleefSprites27
+.4byte sBayleefSprites28
+.4byte sBayleefSprites29
+.4byte sBayleefSprites30
+.4byte sBayleefSprites31
+.4byte sBayleefSprites32
+.4byte sBayleefSprites33
+.4byte sBayleefSprites34
+.4byte sBayleefSprites35
+.4byte sBayleefSprites36
+.4byte sBayleefSprites37
+.4byte sBayleefSprites38
+.4byte sBayleefSprites39
+.4byte sBayleefSprites40
+.4byte sBayleefSprites41
+sAxMainBayleef:
+ax_main sAxPosesBayleef, sAxAnimationsBayleef, 13, sAxSpritesBayleef, sAxPositionsBayleef

--- a/data/ax/beautifly.inc
+++ b/data/ax/beautifly.inc
@@ -1,0 +1,3009 @@
+.global gAxBeautifly
+gAxBeautifly:
+ax_siro sAxMainBeautifly
+sBeautiflyPose1:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose2:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose3:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose4:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose5:
+ax_pose 10, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBeautiflyPose6:
+ax_pose 11, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose7:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose8:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose9:
+ax_pose 16, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose10:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose11:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose12:
+ax_pose 22, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBeautiflyPose13:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose14:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose15:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose16:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose17:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose18:
+ax_pose 22, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBeautiflyPose19:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose20:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose21:
+ax_pose 16, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose22:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose23:
+ax_pose 10, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose24:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose25:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose26:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose27:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose28:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose29:
+ax_pose 10, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBeautiflyPose30:
+ax_pose 11, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose31:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose32:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose33:
+ax_pose 16, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose34:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose35:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose36:
+ax_pose 22, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBeautiflyPose37:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose38:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose39:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose40:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose41:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose42:
+ax_pose 22, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBeautiflyPose43:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose44:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose45:
+ax_pose 16, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose46:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose47:
+ax_pose 10, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose48:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose49:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose50:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose51:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose52:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose53:
+ax_pose 10, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBeautiflyPose54:
+ax_pose 11, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose55:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose56:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose57:
+ax_pose 16, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose58:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose59:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose60:
+ax_pose 22, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBeautiflyPose61:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose62:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose63:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose64:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose65:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose66:
+ax_pose 22, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBeautiflyPose67:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose68:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose69:
+ax_pose 16, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose70:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose71:
+ax_pose 10, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose72:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose73:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose74:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose75:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose76:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose77:
+ax_pose 10, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBeautiflyPose78:
+ax_pose 11, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose79:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose80:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose81:
+ax_pose 16, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose82:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose83:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose84:
+ax_pose 22, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBeautiflyPose85:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose86:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose87:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose88:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose89:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose90:
+ax_pose 22, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBeautiflyPose91:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose92:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose93:
+ax_pose 16, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose94:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose95:
+ax_pose 10, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose96:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose97:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose98:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose99:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose100:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose101:
+ax_pose 10, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBeautiflyPose102:
+ax_pose 11, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose103:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose104:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose105:
+ax_pose 16, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose106:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose107:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose108:
+ax_pose 22, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBeautiflyPose109:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose110:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose111:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose112:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose113:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose114:
+ax_pose 22, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBeautiflyPose115:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose116:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose117:
+ax_pose 16, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose118:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose119:
+ax_pose 10, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose120:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose121:
+ax_pose 31, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sBeautiflyPose122:
+ax_pose 32, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sBeautiflyPose123:
+ax_pose 33, 0x01de, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose124:
+ax_pose 34, 0x01e0, 0x90ed, 0x5c00
+ax_pose_terminator
+sBeautiflyPose125:
+ax_pose 35, 0x81e4, 0x50ff, 0x5c00
+ax_pose 36, 0x01dc, 0x10f7, 0x5c04
+ax_pose 37, 0x81ec, 0x1107, 0x5c05
+ax_pose 38, 0x01dc, 0x10ff, 0x5c07
+ax_pose 39, 0x81e4, 0x90ef, 0x5c08
+ax_pose_terminator
+sBeautiflyPose126:
+ax_pose 40, 0x01e6, 0x50eb, 0x5c00
+ax_pose 41, 0x01de, 0x10fb, 0x5c04
+ax_pose 42, 0x01fe, 0x10eb, 0x5c05
+ax_pose 43, 0x41f6, 0x10eb, 0x5c06
+ax_pose 44, 0x81e6, 0x90fb, 0x5c08
+ax_pose_terminator
+sBeautiflyPose127:
+ax_pose 45, 0x81e0, 0x40f0, 0x5c00
+ax_pose 46, 0x81e0, 0x90f8, 0x5c04
+ax_pose 47, 0x01fb, 0x0106, 0x5c0c
+ax_pose -1, 0x81e0, 0x5108, 0x5c00
+ax_pose -1, 0x01fb, 0x10f1, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose128:
+ax_pose 40, 0x01e6, 0x4105, 0x5c00
+ax_pose 41, 0x01de, 0x00fd, 0x5c04
+ax_pose 42, 0x01fe, 0x010d, 0x5c05
+ax_pose 43, 0x41f6, 0x0105, 0x5c06
+ax_pose 44, 0x81e6, 0x80f5, 0x5c08
+ax_pose_terminator
+sBeautiflyPose129:
+ax_pose 35, 0x81e4, 0x40f9, 0x5c00
+ax_pose 36, 0x01dc, 0x0101, 0x5c04
+ax_pose 37, 0x81ec, 0x00f1, 0x5c05
+ax_pose 38, 0x01dc, 0x00f9, 0x5c07
+ax_pose 39, 0x81e4, 0x8101, 0x5c08
+ax_pose_terminator
+sBeautiflyPose130:
+ax_pose 34, 0x01e0, 0x80f3, 0x5c00
+ax_pose_terminator
+sBeautiflyPose131:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose132:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose133:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose134:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose135:
+ax_pose 10, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBeautiflyPose136:
+ax_pose 11, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose137:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose138:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose139:
+ax_pose 16, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose140:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose141:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose142:
+ax_pose 22, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBeautiflyPose143:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose144:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose145:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose146:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose147:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose148:
+ax_pose 22, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBeautiflyPose149:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose150:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose151:
+ax_pose 16, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose152:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose153:
+ax_pose 10, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose154:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose155:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose156:
+ax_pose 10, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose157:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose158:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose159:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose160:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose161:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose162:
+ax_pose 10, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose163:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose164:
+ax_pose 10, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose165:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose166:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose167:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose168:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose169:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose170:
+ax_pose 10, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose171:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose172:
+ax_pose 1, 0x41e5, 0x80ed, 0x5c00
+ax_pose 2, 0x01f5, 0x00ed, 0x5c08
+ax_pose 3, 0x01fd, 0x00ed, 0x5c09
+ax_pose 4, 0x41f5, 0x00f5, 0x5c0a
+ax_pose 5, 0x01f5, 0x0105, 0x5c0c
+ax_pose -1, 0x01fd, 0x110a, 0x5c09
+ax_pose 6, 0x01e5, 0x010d, 0x5c0d
+ax_pose 7, 0x01ed, 0x010d, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose173:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose174:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose175:
+ax_pose 10, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sBeautiflyPose176:
+ax_pose 11, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose177:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose178:
+ax_pose 13, 0x81e3, 0x9100, 0x5c00
+ax_pose 14, 0x81e3, 0x50f8, 0x5c08
+ax_pose 15, 0x01db, 0x10f8, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose179:
+ax_pose 16, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose180:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose181:
+ax_pose 18, 0x81e3, 0x90fe, 0x5c00
+ax_pose 19, 0x81e3, 0x50f6, 0x5c08
+ax_pose 20, 0x81f3, 0x10ee, 0x5c0c
+ax_pose 21, 0x01db, 0x10f6, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose182:
+ax_pose 22, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sBeautiflyPose183:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose184:
+ax_pose 24, 0x41e4, 0x80ed, 0x5c00
+ax_pose 25, 0x01f4, 0x00ed, 0x5c08
+ax_pose 26, 0x41f4, 0x00f5, 0x5c09
+ax_pose 27, 0x01f4, 0x0105, 0x5c0b
+ax_pose 28, 0x01e4, 0x010d, 0x5c0c
+ax_pose 29, 0x01ec, 0x010d, 0x5c0d
+ax_pose -1, 0x01f4, 0x110a, 0x5c08
+ax_pose_terminator
+sBeautiflyPose185:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose186:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose187:
+ax_pose 18, 0x81e3, 0x80f2, 0x5c00
+ax_pose 19, 0x81e3, 0x4102, 0x5c08
+ax_pose 20, 0x81f3, 0x010a, 0x5c0c
+ax_pose 21, 0x01db, 0x0102, 0x5c0e
+ax_pose_terminator
+sBeautiflyPose188:
+ax_pose 22, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sBeautiflyPose189:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose190:
+ax_pose 13, 0x81e3, 0x80f0, 0x5c00
+ax_pose 14, 0x81e3, 0x4100, 0x5c08
+ax_pose 15, 0x01db, 0x0100, 0x5c0c
+ax_pose_terminator
+sBeautiflyPose191:
+ax_pose 16, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose192:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose193:
+ax_pose 10, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sBeautiflyPose194:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose195:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose196:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose197:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose198:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose199:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose200:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose201:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose202:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose203:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose204:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose205:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose206:
+ax_pose 17, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose207:
+ax_pose 23, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose208:
+ax_pose 17, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose209:
+ax_pose 12, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sBeautiflyPose210:
+ax_pose 9, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sBeautiflyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 1, 1, 1, 0,
+ax_anim 8, 0, 0, 1, 2, 1, 0,
+ax_anim 8, 0, 2, 0, 2, 0, 0,
+ax_anim 8, 0, 0, 0, 1, 0, 0,
+ax_anim 8, 0, 1, -1, 0, -1, 0,
+ax_anim 8, 0, 0, -1, -1, -1, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 0, -1, 1, -1, 0,
+ax_anim 8, 0, 2, -1, 0, -1, 0,
+ax_anim_terminator
+sBeautiflyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 3, 1, 2, 1, 2,
+ax_anim 8, 0, 5, 0, 2, 0, 2,
+ax_anim 8, 0, 3, 0, 1, 0, 1,
+ax_anim 8, 0, 4, 1, 0, 1, 0,
+ax_anim 8, 0, 3, 1, -1, 1, -1,
+ax_anim 8, 0, 5, 1, -1, 1, -1,
+ax_anim 8, 0, 3, 1, 0, 1, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 1,
+ax_anim 8, 0, 3, -1, 1, -1, 1,
+ax_anim 8, 0, 5, -1, 0, -1, 0,
+ax_anim_terminator
+sBeautiflyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 1, 1, 1, 0,
+ax_anim 8, 0, 6, 1, 2, 1, 0,
+ax_anim 8, 0, 8, 0, 2, 0, 0,
+ax_anim 8, 0, 6, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 6, 1, -1, 1, 0,
+ax_anim 8, 0, 8, 1, -1, 1, 0,
+ax_anim 8, 0, 6, 1, 0, 1, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 6, -1, 1, -1, 0,
+ax_anim 8, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sBeautiflyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 9, 1, -2, 1, -2,
+ax_anim 8, 0, 11, 0, -2, 0, -2,
+ax_anim 8, 0, 9, 0, -1, 0, -1,
+ax_anim 8, 0, 10, 1, 0, 1, 0,
+ax_anim 8, 0, 9, 1, 1, 1, 1,
+ax_anim 8, 0, 11, 1, 1, 1, 1,
+ax_anim 8, 0, 9, 1, 0, 1, 0,
+ax_anim 8, 0, 10, 0, -1, 0, -1,
+ax_anim 8, 0, 9, -1, -1, -1, -1,
+ax_anim 8, 0, 11, -1, 0, -1, 0,
+ax_anim_terminator
+sBeautiflyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 1, 1, 1, 0,
+ax_anim 8, 0, 12, 1, 2, 1, 0,
+ax_anim 8, 0, 14, 0, 2, 0, 0,
+ax_anim 8, 0, 12, 0, 1, 0, 0,
+ax_anim 8, 0, 13, -1, 0, -1, 0,
+ax_anim 8, 0, 12, -1, -1, -1, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 12, -1, 1, -1, 0,
+ax_anim 8, 0, 14, -1, 0, -1, 0,
+ax_anim_terminator
+sBeautiflyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 15, -1, -2, -1, -2,
+ax_anim 8, 0, 17, 0, -2, 0, -2,
+ax_anim 8, 0, 15, 0, -1, 0, -1,
+ax_anim 8, 0, 16, -1, 0, -1, 0,
+ax_anim 8, 0, 15, -1, 1, -1, 1,
+ax_anim 8, 0, 17, -1, 1, -1, 1,
+ax_anim 8, 0, 15, -1, 0, -1, 0,
+ax_anim 8, 0, 16, 0, -1, 0, -1,
+ax_anim 8, 0, 15, 1, -1, 1, -1,
+ax_anim 8, 0, 17, 1, 0, 1, 0,
+ax_anim_terminator
+sBeautiflyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, -1, 1, -1, 0,
+ax_anim 8, 0, 18, -1, 2, -1, 0,
+ax_anim 8, 0, 20, 0, 2, 0, 0,
+ax_anim 8, 0, 18, 0, 1, 0, 0,
+ax_anim 8, 0, 19, -1, 0, -1, 0,
+ax_anim 8, 0, 18, -1, -1, -1, 0,
+ax_anim 8, 0, 20, -1, -1, -1, 0,
+ax_anim 8, 0, 18, -1, 0, -1, 0,
+ax_anim 8, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 18, 1, 1, 1, 0,
+ax_anim 8, 0, 20, 1, 0, 1, 0,
+ax_anim_terminator
+sBeautiflyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 21, -1, 2, -1, 2,
+ax_anim 8, 0, 23, 0, 2, 0, 2,
+ax_anim 8, 0, 21, 0, 1, 0, 1,
+ax_anim 8, 0, 22, -1, 0, -1, 0,
+ax_anim 8, 0, 21, -1, -1, -1, -1,
+ax_anim 8, 0, 23, -1, -1, -1, -1,
+ax_anim 8, 0, 21, -1, 0, -1, 0,
+ax_anim 8, 0, 22, 0, 1, 0, 1,
+ax_anim 8, 0, 21, 1, 1, 1, 1,
+ax_anim 8, 0, 23, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_2_1:
+ax_anim 1, 0, 24, 0, -2, 0, 0,
+ax_anim 1, 0, 25, 0, -4, 0, 0,
+ax_anim 2, 0, 24, 0, -5, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 2, 0, 24, 0, -5, 0, 0,
+ax_anim 2, 0, 25, 0, -5, 0, 0,
+ax_anim 4, 0, 24, 0, -5, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 15, 0, 13,
+ax_anim 2, 0, 26, 0, 25, 0, 22,
+ax_anim 2, 1, 26, 1, 25, 1, 22,
+ax_anim 2, 0, 26, 0, 25, 0, 22,
+ax_anim 2, 0, 26, 1, 25, 1, 22,
+ax_anim 2, 0, 26, 0, 25, 0, 22,
+ax_anim 2, 0, 24, 0, 16, 0, 14,
+ax_anim 2, 0, 24, 0, 5, 0, 5,
+ax_anim_terminator
+sBeautiflyAnims_2_2:
+ax_anim 1, 0, 27, 0, -2, 0, 0,
+ax_anim 1, 0, 28, 0, -4, 0, 0,
+ax_anim 2, 0, 27, 0, -5, 0, 0,
+ax_anim 2, 0, 29, 0, -5, 0, 0,
+ax_anim 2, 0, 27, 0, -5, 0, 0,
+ax_anim 2, 0, 28, 0, -5, 0, 0,
+ax_anim 4, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 14, 18, 14, 15,
+ax_anim 2, 0, 29, 20, 25, 20, 21,
+ax_anim 2, 1, 29, 21, 24, 21, 20,
+ax_anim 2, 0, 29, 20, 25, 20, 21,
+ax_anim 2, 0, 29, 21, 24, 21, 20,
+ax_anim 2, 0, 29, 20, 25, 20, 21,
+ax_anim 2, 0, 27, 15, 19, 15, 17,
+ax_anim 2, 0, 27, 5, 5, 5, 5,
+ax_anim_terminator
+sBeautiflyAnims_2_3:
+ax_anim 1, 0, 30, 0, -2, 0, 0,
+ax_anim 1, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 2, 0, 32, 0, -5, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 2, 0, 31, 0, -5, 0, 0,
+ax_anim 4, 0, 30, 0, -5, 0, 0,
+ax_anim 1, 2, 32, 4, -3, 4, 0,
+ax_anim 1, 0, 32, 14, 1, 14, 0,
+ax_anim 2, 0, 32, 20, 3, 20, 0,
+ax_anim 2, 1, 32, 20, 4, 20, 1,
+ax_anim 2, 0, 32, 20, 3, 20, 0,
+ax_anim 2, 0, 32, 20, 4, 20, 1,
+ax_anim 2, 0, 32, 20, 3, 20, 0,
+ax_anim 2, 0, 30, 13, 3, 13, 0,
+ax_anim 2, 0, 30, 5, 0, 5, 0,
+ax_anim_terminator
+sBeautiflyAnims_2_4:
+ax_anim 1, 0, 33, 0, -2, 0, 0,
+ax_anim 1, 0, 34, 0, -4, 0, 0,
+ax_anim 2, 0, 33, 0, -5, 0, 0,
+ax_anim 2, 0, 35, 0, -5, 0, 0,
+ax_anim 2, 0, 33, 0, -5, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 4, 0, 33, 0, -5, 0, 0,
+ax_anim 1, 2, 35, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 12, -10, 12, -11,
+ax_anim 2, 0, 35, 19, -15, 19, -19,
+ax_anim 2, 1, 35, 20, -14, 20, -18,
+ax_anim 2, 0, 35, 19, -15, 19, -19,
+ax_anim 2, 0, 35, 20, -14, 20, -18,
+ax_anim 2, 0, 35, 19, -15, 19, -19,
+ax_anim 2, 0, 33, 11, -6, 11, -10,
+ax_anim 2, 0, 33, 6, -3, 6, -5,
+ax_anim_terminator
+sBeautiflyAnims_2_5:
+ax_anim 1, 0, 36, 0, -2, 0, 0,
+ax_anim 1, 0, 37, 0, -4, 0, 0,
+ax_anim 2, 0, 36, 0, -5, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 2, 0, 36, 0, -5, 0, 0,
+ax_anim 2, 0, 37, 0, -5, 0, 0,
+ax_anim 4, 0, 36, 0, -5, 0, 0,
+ax_anim 1, 2, 38, 0, -3, 0, -3,
+ax_anim 1, 0, 38, 0, -8, 0, -8,
+ax_anim 2, 0, 38, 0, -15, 0, -15,
+ax_anim 2, 1, 38, 1, -15, 1, -15,
+ax_anim 2, 0, 38, 0, -15, 0, -15,
+ax_anim 2, 0, 38, 1, -15, 1, -15,
+ax_anim 2, 0, 38, 0, -15, 0, -15,
+ax_anim 2, 0, 36, 0, -9, 0, -9,
+ax_anim 2, 0, 36, 0, -1, 0, -1,
+ax_anim_terminator
+sBeautiflyAnims_2_6:
+ax_anim 1, 0, 39, 0, -2, 0, 0,
+ax_anim 1, 0, 40, 0, -4, 0, 0,
+ax_anim 2, 0, 39, 0, -5, 0, 0,
+ax_anim 2, 0, 41, 0, -5, 0, 0,
+ax_anim 2, 0, 39, 0, -5, 0, 0,
+ax_anim 2, 0, 40, 0, -5, 0, 0,
+ax_anim 4, 0, 39, 0, -5, 0, 0,
+ax_anim 1, 2, 41, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -12, -10, -12, -11,
+ax_anim 2, 0, 41, -19, -15, -19, -19,
+ax_anim 2, 1, 41, -20, -14, -20, -18,
+ax_anim 2, 0, 41, -19, -15, -19, -19,
+ax_anim 2, 0, 41, -20, -14, -20, -18,
+ax_anim 2, 0, 41, -19, -15, -19, -19,
+ax_anim 2, 0, 39, -11, -6, -11, -10,
+ax_anim 2, 0, 39, -6, -3, -6, -5,
+ax_anim_terminator
+sBeautiflyAnims_2_7:
+ax_anim 1, 0, 42, 0, -2, 0, 0,
+ax_anim 1, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 2, 0, 44, 0, -5, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 2, 0, 43, 0, -5, 0, 0,
+ax_anim 4, 0, 42, 0, -5, 0, 0,
+ax_anim 1, 2, 44, -4, -3, -4, 0,
+ax_anim 1, 0, 44, -14, 1, -14, 0,
+ax_anim 2, 0, 44, -20, 3, -20, 0,
+ax_anim 2, 1, 44, -20, 4, -20, 1,
+ax_anim 2, 0, 44, -20, 3, -20, 0,
+ax_anim 2, 0, 44, -20, 4, -20, 1,
+ax_anim 2, 0, 44, -20, 3, -20, 0,
+ax_anim 2, 0, 42, -13, 3, -13, 0,
+ax_anim 2, 0, 42, -5, 0, -5, 0,
+ax_anim_terminator
+sBeautiflyAnims_2_8:
+ax_anim 1, 0, 45, 0, -2, 0, 0,
+ax_anim 1, 0, 46, 0, -4, 0, 0,
+ax_anim 2, 0, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 47, 0, -5, 0, 0,
+ax_anim 2, 0, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 4, 0, 45, 0, -5, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -14, 18, -14, 15,
+ax_anim 2, 0, 47, -20, 25, -20, 21,
+ax_anim 2, 1, 47, -21, 24, -21, 20,
+ax_anim 2, 0, 47, -20, 25, -20, 21,
+ax_anim 2, 0, 47, -21, 24, -21, 20,
+ax_anim 2, 0, 47, -20, 25, -20, 21,
+ax_anim 2, 0, 45, -15, 18, -15, 16,
+ax_anim 2, 0, 45, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_3_1:
+ax_anim 1, 0, 48, 0, -2, 0, 0,
+ax_anim 1, 0, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 4, 0, 48, 0, -5, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 15, 0, 13,
+ax_anim 2, 0, 50, 0, 25, 0, 22,
+ax_anim 2, 1, 50, 1, 25, 1, 22,
+ax_anim 2, 0, 50, 0, 25, 0, 22,
+ax_anim 2, 0, 50, 1, 25, 1, 22,
+ax_anim 2, 0, 50, 0, 25, 0, 22,
+ax_anim 2, 0, 48, 0, 16, 0, 14,
+ax_anim 2, 0, 48, 0, 5, 0, 5,
+ax_anim_terminator
+sBeautiflyAnims_3_2:
+ax_anim 1, 0, 51, 0, -2, 0, 0,
+ax_anim 1, 0, 52, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 53, 0, -5, 0, 0,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 52, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 14, 18, 14, 15,
+ax_anim 2, 0, 53, 20, 25, 20, 21,
+ax_anim 2, 1, 53, 21, 24, 21, 20,
+ax_anim 2, 0, 53, 20, 25, 20, 21,
+ax_anim 2, 0, 53, 21, 24, 21, 20,
+ax_anim 2, 0, 53, 20, 25, 20, 21,
+ax_anim 2, 0, 51, 15, 19, 15, 17,
+ax_anim 2, 0, 51, 5, 5, 5, 5,
+ax_anim_terminator
+sBeautiflyAnims_3_3:
+ax_anim 1, 0, 54, 0, -2, 0, 0,
+ax_anim 1, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 2, 0, 56, 0, -5, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 2, 0, 55, 0, -5, 0, 0,
+ax_anim 4, 0, 54, 0, -5, 0, 0,
+ax_anim 1, 2, 56, 4, -3, 4, 0,
+ax_anim 1, 0, 56, 14, 1, 14, 0,
+ax_anim 2, 0, 56, 20, 3, 20, 0,
+ax_anim 2, 1, 56, 20, 4, 20, 1,
+ax_anim 2, 0, 56, 20, 3, 20, 0,
+ax_anim 2, 0, 56, 20, 4, 20, 1,
+ax_anim 2, 0, 56, 20, 3, 20, 0,
+ax_anim 2, 0, 54, 13, 3, 13, 0,
+ax_anim 2, 0, 54, 5, 0, 5, 0,
+ax_anim_terminator
+sBeautiflyAnims_3_4:
+ax_anim 1, 0, 57, 0, -2, 0, 0,
+ax_anim 1, 0, 58, 0, -4, 0, 0,
+ax_anim 2, 0, 57, 0, -5, 0, 0,
+ax_anim 2, 0, 59, 0, -5, 0, 0,
+ax_anim 2, 0, 57, 0, -5, 0, 0,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 4, 0, 57, 0, -5, 0, 0,
+ax_anim 1, 2, 59, 4, -4, 4, -4,
+ax_anim 1, 0, 59, 12, -10, 12, -11,
+ax_anim 2, 0, 59, 19, -15, 19, -19,
+ax_anim 2, 1, 59, 20, -14, 20, -18,
+ax_anim 2, 0, 59, 19, -15, 19, -19,
+ax_anim 2, 0, 59, 20, -14, 20, -18,
+ax_anim 2, 0, 59, 19, -15, 19, -19,
+ax_anim 2, 0, 57, 11, -6, 11, -10,
+ax_anim 2, 0, 57, 6, -3, 6, -5,
+ax_anim_terminator
+sBeautiflyAnims_3_5:
+ax_anim 1, 0, 60, 0, -2, 0, 0,
+ax_anim 1, 0, 61, 0, -4, 0, 0,
+ax_anim 2, 0, 60, 0, -5, 0, 0,
+ax_anim 2, 0, 62, 0, -5, 0, 0,
+ax_anim 2, 0, 60, 0, -5, 0, 0,
+ax_anim 2, 0, 61, 0, -5, 0, 0,
+ax_anim 4, 0, 60, 0, -5, 0, 0,
+ax_anim 1, 2, 62, 0, -3, 0, -3,
+ax_anim 1, 0, 62, 0, -8, 0, -8,
+ax_anim 2, 0, 62, 0, -15, 0, -15,
+ax_anim 2, 1, 62, 1, -15, 1, -15,
+ax_anim 2, 0, 62, 0, -15, 0, -15,
+ax_anim 2, 0, 62, 1, -15, 1, -15,
+ax_anim 2, 0, 62, 0, -15, 0, -15,
+ax_anim 2, 0, 60, 0, -9, 0, -9,
+ax_anim 2, 0, 60, 0, -1, 0, -1,
+ax_anim_terminator
+sBeautiflyAnims_3_6:
+ax_anim 1, 0, 63, 0, -2, 0, 0,
+ax_anim 1, 0, 64, 0, -4, 0, 0,
+ax_anim 2, 0, 63, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 63, 0, -5, 0, 0,
+ax_anim 2, 0, 64, 0, -5, 0, 0,
+ax_anim 4, 0, 63, 0, -5, 0, 0,
+ax_anim 1, 2, 65, -4, -4, -4, -4,
+ax_anim 1, 0, 65, -12, -10, -12, -11,
+ax_anim 2, 0, 65, -19, -15, -19, -19,
+ax_anim 2, 1, 65, -20, -14, -20, -18,
+ax_anim 2, 0, 65, -19, -15, -19, -19,
+ax_anim 2, 0, 65, -20, -14, -20, -18,
+ax_anim 2, 0, 65, -19, -15, -19, -19,
+ax_anim 2, 0, 63, -11, -6, -11, -10,
+ax_anim 2, 0, 63, -6, -3, -6, -5,
+ax_anim_terminator
+sBeautiflyAnims_3_7:
+ax_anim 1, 0, 66, 0, -2, 0, 0,
+ax_anim 1, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 2, 0, 68, 0, -5, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 4, 0, 66, 0, -5, 0, 0,
+ax_anim 1, 2, 68, -4, -3, -4, 0,
+ax_anim 1, 0, 68, -14, 1, -14, 0,
+ax_anim 2, 0, 68, -20, 3, -20, 0,
+ax_anim 2, 1, 68, -20, 4, -20, 1,
+ax_anim 2, 0, 68, -20, 3, -20, 0,
+ax_anim 2, 0, 68, -20, 4, -20, 1,
+ax_anim 2, 0, 68, -20, 3, -20, 0,
+ax_anim 2, 0, 66, -13, 3, -13, 0,
+ax_anim 2, 0, 66, -5, 0, -5, 0,
+ax_anim_terminator
+sBeautiflyAnims_3_8:
+ax_anim 1, 0, 69, 0, -2, 0, 0,
+ax_anim 1, 0, 70, 0, -4, 0, 0,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 4, 0, 69, 0, -5, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -14, 18, -14, 15,
+ax_anim 2, 0, 71, -20, 25, -20, 21,
+ax_anim 2, 1, 71, -21, 24, -21, 20,
+ax_anim 2, 0, 71, -20, 25, -20, 21,
+ax_anim 2, 0, 71, -21, 24, -21, 20,
+ax_anim 2, 0, 71, -20, 25, -20, 21,
+ax_anim 2, 0, 69, -15, 18, -15, 16,
+ax_anim 2, 0, 69, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 1, 1, 1, 0,
+ax_anim 2, 0, 72, 1, 2, 1, 0,
+ax_anim 2, 0, 74, 0, 2, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 0,
+ax_anim 2, 0, 73, -1, 0, -1, 0,
+ax_anim 2, 2, 72, -1, -1, -1, 0,
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 1, 0, 0,
+ax_anim 2, 0, 72, -1, 1, -1, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 1, 1, 1, 0,
+ax_anim 2, 0, 72, 1, 2, 1, 0,
+ax_anim_terminator
+sBeautiflyAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 75, 1, 2, 1, 2,
+ax_anim 2, 0, 77, 0, 2, 0, 2,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 1, 0, 1,
+ax_anim 2, 0, 75, -1, 1, -1, 1,
+ax_anim 2, 0, 77, -1, 0, -1, 0,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 75, 1, 2, 1, 2,
+ax_anim_terminator
+sBeautiflyAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 0,
+ax_anim 2, 0, 78, 1, 2, 1, 0,
+ax_anim 2, 0, 80, 0, 2, 0, 0,
+ax_anim 2, 0, 78, 0, 1, 0, 0,
+ax_anim 2, 0, 79, 1, 0, 1, 0,
+ax_anim 2, 2, 78, 1, -1, 1, 0,
+ax_anim 2, 0, 80, 1, -1, 1, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim 2, 0, 79, 0, 1, 0, 0,
+ax_anim 2, 0, 78, -1, 1, -1, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 0,
+ax_anim 2, 0, 78, 1, 2, 1, 0,
+ax_anim_terminator
+sBeautiflyAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 81, 1, -2, 1, -2,
+ax_anim 2, 0, 83, 0, -2, 0, -2,
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 1, 1, 1, 1,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 83, -1, 0, -1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 81, 1, -2, 1, -2,
+ax_anim_terminator
+sBeautiflyAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 1, 1, 0,
+ax_anim 2, 0, 84, 1, 2, 1, 0,
+ax_anim 2, 0, 86, 0, 2, 0, 0,
+ax_anim 2, 0, 84, 0, 1, 0, 0,
+ax_anim 2, 0, 85, -1, 0, -1, 0,
+ax_anim 2, 2, 84, -1, -1, -1, 0,
+ax_anim 2, 0, 86, 0, -1, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 1, 0, 0,
+ax_anim 2, 0, 84, -1, 1, -1, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 1, 1, 0,
+ax_anim 2, 0, 84, 1, 2, 1, 0,
+ax_anim_terminator
+sBeautiflyAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 87, -1, -2, -1, -2,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 88, -1, 0, -1, 0,
+ax_anim 2, 2, 87, -1, 1, -1, 1,
+ax_anim 2, 0, 89, -1, 1, -1, 1,
+ax_anim 2, 0, 87, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 87, -1, -2, -1, -2,
+ax_anim_terminator
+sBeautiflyAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 1, -1, 0,
+ax_anim 2, 0, 90, -1, 2, -1, 0,
+ax_anim 2, 0, 92, 0, 2, 0, 0,
+ax_anim 2, 0, 90, 0, 1, 0, 0,
+ax_anim 2, 0, 91, -1, 0, -1, 0,
+ax_anim 2, 2, 90, -1, -1, -1, 0,
+ax_anim 2, 0, 92, -1, -1, -1, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim 2, 0, 91, 0, 1, 0, 0,
+ax_anim 2, 0, 90, 1, 1, 1, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 1, -1, 0,
+ax_anim 2, 0, 90, -1, 2, -1, 0,
+ax_anim_terminator
+sBeautiflyAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 0, 93, -1, 2, -1, 2,
+ax_anim 2, 0, 95, 0, 2, 0, 2,
+ax_anim 2, 0, 93, 0, 1, 0, 1,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 2, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 93, -1, 0, -1, 0,
+ax_anim 2, 0, 94, 0, 1, 0, 1,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 0, 93, -1, 2, -1, 2,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_5_1:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 1, 98, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_5_2:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 1, 101, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_5_3:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 1, 104, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_5_4:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 107, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_5_5:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 110, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_5_6:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 113, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_5_7:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 116, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_5_8:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sBeautiflyAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sBeautiflyAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sBeautiflyAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sBeautiflyAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sBeautiflyAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sBeautiflyAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sBeautiflyAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_8_1:
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, -1, 0, 0,
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 132, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_8_2:
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, -1, 0, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 135, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_8_3:
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, -1, 0, 0,
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 138, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_8_4:
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, -1, 0, 0,
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_8_5:
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, -1, 0, 0,
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_8_6:
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, -1, 0, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_8_7:
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, -1, 0, 0,
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 150, 0, 1, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_8_8:
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, -1, 0, 0,
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 153, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_9_1:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 19, 7, 17,
+ax_anim 3, 0, 158, 0, 25, 0, 22,
+ax_anim 2, 3, 159, -7, 19, -7, 17,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_9_2:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 21, 10, 21, 10,
+ax_anim 3, 0, 157, 22, 21, 22, 21,
+ax_anim 2, 3, 158, 13, 27, 13, 24,
+ax_anim 2, 0, 159, -1, 19, -1, 19,
+ax_anim 1, 0, 160, -6, 7, -6, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_9_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -5, 16, -5,
+ax_anim 3, 0, 156, 23, 0, 23, 0,
+ax_anim 2, 3, 157, 21, 6, 21, 6,
+ax_anim 2, 0, 158, 12, 11, 12, 8,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_9_4:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -22, 12, -22,
+ax_anim 3, 0, 155, 20, -15, 20, -15,
+ax_anim 2, 3, 156, 24, -8, 24, -8,
+ax_anim 2, 0, 157, 19, -3, 19, -3,
+ax_anim 1, 0, 158, 7, 1, 7, 1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_9_5:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -11, -9, -11, -9,
+ax_anim 2, 0, 161, -7, -15, -7, -15,
+ax_anim 3, 0, 154, 0, -18, 0, -18,
+ax_anim 2, 3, 155, 7, -15, 7, -15,
+ax_anim 2, 0, 156, 11, -9, 11, -9,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_9_6:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -22, -12, -22,
+ax_anim 3, 0, 161, -20, -15, -20, -15,
+ax_anim 2, 3, 160, -24, -8, -24, -8,
+ax_anim 2, 0, 159, -19, -3, -19, -3,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -5, -16, -5,
+ax_anim 3, 0, 160, -23, 0, -23, 0,
+ax_anim 2, 3, 159, -21, 6, -21, 6,
+ax_anim 2, 0, 158, -12, 11, -12, 8,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_9_8:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -21, 10, -21, 10,
+ax_anim 3, 0, 159, -22, 21, -22, 21,
+ax_anim 2, 3, 158, -13, 27, -13, 24,
+ax_anim 2, 0, 157, -1, 17, -1, 17,
+ax_anim 1, 0, 156, 2, 7, 2, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 4, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 4, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 4, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 4, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 4, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 4, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 4, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeautiflyAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sBeautiflyGfx1:
+.incbin "baserom.gba", 0x10F1D80, 0x200
+sBeautiflySprites1:
+ax_sprite sBeautiflyGfx1, 0x200
+ax_sprite_terminator
+sBeautiflyGfx2:
+.incbin "baserom.gba", 0x10F1F90, 0x100
+sBeautiflySprites2:
+ax_sprite sBeautiflyGfx2, 0x100
+ax_sprite_terminator
+sBeautiflyGfx3:
+.incbin "baserom.gba", 0x10F20A0, 0x20
+sBeautiflySprites3:
+ax_sprite sBeautiflyGfx3, 0x20
+ax_sprite_terminator
+sBeautiflyGfx4:
+.incbin "baserom.gba", 0x10F20D0, 0x20
+sBeautiflySprites4:
+ax_sprite sBeautiflyGfx4, 0x20
+ax_sprite_terminator
+sBeautiflyGfx5:
+.incbin "baserom.gba", 0x10F2100, 0x40
+sBeautiflySprites5:
+ax_sprite sBeautiflyGfx5, 0x40
+ax_sprite_terminator
+sBeautiflyGfx6:
+.incbin "baserom.gba", 0x10F2150, 0x20
+sBeautiflySprites6:
+ax_sprite sBeautiflyGfx6, 0x20
+ax_sprite_terminator
+sBeautiflyGfx7:
+.incbin "baserom.gba", 0x10F2180, 0x20
+sBeautiflySprites7:
+ax_sprite sBeautiflyGfx7, 0x20
+ax_sprite_terminator
+sBeautiflyGfx8:
+.incbin "baserom.gba", 0x10F21B0, 0x20
+sBeautiflySprites8:
+ax_sprite sBeautiflyGfx8, 0x20
+ax_sprite_terminator
+sBeautiflyGfx9:
+.incbin "baserom.gba", 0x10F21E0, 0x200
+sBeautiflySprites9:
+ax_sprite sBeautiflyGfx9, 0x200
+ax_sprite_terminator
+sBeautiflyGfx10:
+.incbin "baserom.gba", 0x10F23F0, 0x200
+sBeautiflySprites10:
+ax_sprite sBeautiflyGfx10, 0x200
+ax_sprite_terminator
+sBeautiflyGfx11:
+.incbin "baserom.gba", 0x10F2600, 0x200
+sBeautiflySprites11:
+ax_sprite sBeautiflyGfx11, 0x200
+ax_sprite_terminator
+sBeautiflyGfx12:
+.incbin "baserom.gba", 0x10F2810, 0x200
+sBeautiflySprites12:
+ax_sprite sBeautiflyGfx12, 0x200
+ax_sprite_terminator
+sBeautiflyGfx13:
+.incbin "baserom.gba", 0x10F2A20, 0x200
+sBeautiflySprites13:
+ax_sprite sBeautiflyGfx13, 0x200
+ax_sprite_terminator
+sBeautiflyGfx14:
+.incbin "baserom.gba", 0x10F2C30, 0x100
+sBeautiflySprites14:
+ax_sprite sBeautiflyGfx14, 0x100
+ax_sprite_terminator
+sBeautiflyGfx15:
+.incbin "baserom.gba", 0x10F2D40, 0x80
+sBeautiflySprites15:
+ax_sprite sBeautiflyGfx15, 0x80
+ax_sprite_terminator
+sBeautiflyGfx16:
+.incbin "baserom.gba", 0x10F2DD0, 0x20
+sBeautiflySprites16:
+ax_sprite sBeautiflyGfx16, 0x20
+ax_sprite_terminator
+sBeautiflyGfx17:
+.incbin "baserom.gba", 0x10F2E00, 0x200
+sBeautiflySprites17:
+ax_sprite sBeautiflyGfx17, 0x200
+ax_sprite_terminator
+sBeautiflyGfx18:
+.incbin "baserom.gba", 0x10F3010, 0x200
+sBeautiflySprites18:
+ax_sprite sBeautiflyGfx18, 0x200
+ax_sprite_terminator
+sBeautiflyGfx19:
+.incbin "baserom.gba", 0x10F3220, 0x100
+sBeautiflySprites19:
+ax_sprite sBeautiflyGfx19, 0x100
+ax_sprite_terminator
+sBeautiflyGfx20:
+.incbin "baserom.gba", 0x10F3330, 0x80
+sBeautiflySprites20:
+ax_sprite sBeautiflyGfx20, 0x80
+ax_sprite_terminator
+sBeautiflyGfx21:
+.incbin "baserom.gba", 0x10F33C0, 0x40
+sBeautiflySprites21:
+ax_sprite sBeautiflyGfx21, 0x40
+ax_sprite_terminator
+sBeautiflyGfx22:
+.incbin "baserom.gba", 0x10F3410, 0x20
+sBeautiflySprites22:
+ax_sprite sBeautiflyGfx22, 0x20
+ax_sprite_terminator
+sBeautiflyGfx23:
+.incbin "baserom.gba", 0x10F3440, 0x200
+sBeautiflySprites23:
+ax_sprite sBeautiflyGfx23, 0x200
+ax_sprite_terminator
+sBeautiflyGfx24:
+.incbin "baserom.gba", 0x10F3650, 0x200
+sBeautiflySprites24:
+ax_sprite sBeautiflyGfx24, 0x200
+ax_sprite_terminator
+sBeautiflyGfx25:
+.incbin "baserom.gba", 0x10F3860, 0x100
+sBeautiflySprites25:
+ax_sprite sBeautiflyGfx25, 0x100
+ax_sprite_terminator
+sBeautiflyGfx26:
+.incbin "baserom.gba", 0x10F3970, 0x20
+sBeautiflySprites26:
+ax_sprite sBeautiflyGfx26, 0x20
+ax_sprite_terminator
+sBeautiflyGfx27:
+.incbin "baserom.gba", 0x10F39A0, 0x40
+sBeautiflySprites27:
+ax_sprite sBeautiflyGfx27, 0x40
+ax_sprite_terminator
+sBeautiflyGfx28:
+.incbin "baserom.gba", 0x10F39F0, 0x20
+sBeautiflySprites28:
+ax_sprite sBeautiflyGfx28, 0x20
+ax_sprite_terminator
+sBeautiflyGfx29:
+.incbin "baserom.gba", 0x10F3A20, 0x20
+sBeautiflySprites29:
+ax_sprite sBeautiflyGfx29, 0x20
+ax_sprite_terminator
+sBeautiflyGfx30:
+.incbin "baserom.gba", 0x10F3A50, 0x20
+sBeautiflySprites30:
+ax_sprite sBeautiflyGfx30, 0x20
+ax_sprite_terminator
+sBeautiflyGfx31:
+.incbin "baserom.gba", 0x10F3A80, 0x200
+sBeautiflySprites31:
+ax_sprite sBeautiflyGfx31, 0x200
+ax_sprite_terminator
+sBeautiflyGfx32:
+.incbin "baserom.gba", 0x10F3C90, 0x200
+sBeautiflySprites32:
+ax_sprite sBeautiflyGfx32, 0x200
+ax_sprite_terminator
+sBeautiflyGfx33:
+.incbin "baserom.gba", 0x10F3EA0, 0x200
+sBeautiflySprites33:
+ax_sprite sBeautiflyGfx33, 0x200
+ax_sprite_terminator
+sBeautiflyGfx34:
+.incbin "baserom.gba", 0x10F40B0, 0x200
+sBeautiflySprites34:
+ax_sprite sBeautiflyGfx34, 0x200
+ax_sprite_terminator
+sBeautiflyGfx35:
+.incbin "baserom.gba", 0x10F42C0, 0x200
+sBeautiflySprites35:
+ax_sprite sBeautiflyGfx35, 0x200
+ax_sprite_terminator
+sBeautiflyGfx36:
+.incbin "baserom.gba", 0x10F44D0, 0x80
+sBeautiflySprites36:
+ax_sprite sBeautiflyGfx36, 0x80
+ax_sprite_terminator
+sBeautiflyGfx37:
+.incbin "baserom.gba", 0x10F4560, 0x20
+sBeautiflySprites37:
+ax_sprite sBeautiflyGfx37, 0x20
+ax_sprite_terminator
+sBeautiflyGfx38:
+.incbin "baserom.gba", 0x10F4590, 0x40
+sBeautiflySprites38:
+ax_sprite sBeautiflyGfx38, 0x40
+ax_sprite_terminator
+sBeautiflyGfx39:
+.incbin "baserom.gba", 0x10F45E0, 0x20
+sBeautiflySprites39:
+ax_sprite sBeautiflyGfx39, 0x20
+ax_sprite_terminator
+sBeautiflyGfx40:
+.incbin "baserom.gba", 0x10F4610, 0x100
+sBeautiflySprites40:
+ax_sprite sBeautiflyGfx40, 0x100
+ax_sprite_terminator
+sBeautiflyGfx41:
+.incbin "baserom.gba", 0x10F4720, 0x80
+sBeautiflySprites41:
+ax_sprite sBeautiflyGfx41, 0x80
+ax_sprite_terminator
+sBeautiflyGfx42:
+.incbin "baserom.gba", 0x10F47B0, 0x20
+sBeautiflySprites42:
+ax_sprite sBeautiflyGfx42, 0x20
+ax_sprite_terminator
+sBeautiflyGfx43:
+.incbin "baserom.gba", 0x10F47E0, 0x20
+sBeautiflySprites43:
+ax_sprite sBeautiflyGfx43, 0x20
+ax_sprite_terminator
+sBeautiflyGfx44:
+.incbin "baserom.gba", 0x10F4810, 0x40
+sBeautiflySprites44:
+ax_sprite sBeautiflyGfx44, 0x40
+ax_sprite_terminator
+sBeautiflyGfx45:
+.incbin "baserom.gba", 0x10F4860, 0x100
+sBeautiflySprites45:
+ax_sprite sBeautiflyGfx45, 0x100
+ax_sprite_terminator
+sBeautiflyGfx46:
+.incbin "baserom.gba", 0x10F4970, 0x80
+sBeautiflySprites46:
+ax_sprite sBeautiflyGfx46, 0x80
+ax_sprite_terminator
+sBeautiflyGfx47:
+.incbin "baserom.gba", 0x10F4A00, 0x100
+sBeautiflySprites47:
+ax_sprite sBeautiflyGfx47, 0x100
+ax_sprite_terminator
+sBeautiflyGfx48:
+.incbin "baserom.gba", 0x10F4B10, 0x20
+sBeautiflySprites48:
+ax_sprite sBeautiflyGfx48, 0x20
+ax_sprite_terminator
+sAxPosesBeautifly:
+.4byte sBeautiflyPose1
+.4byte sBeautiflyPose2
+.4byte sBeautiflyPose3
+.4byte sBeautiflyPose4
+.4byte sBeautiflyPose5
+.4byte sBeautiflyPose6
+.4byte sBeautiflyPose7
+.4byte sBeautiflyPose8
+.4byte sBeautiflyPose9
+.4byte sBeautiflyPose10
+.4byte sBeautiflyPose11
+.4byte sBeautiflyPose12
+.4byte sBeautiflyPose13
+.4byte sBeautiflyPose14
+.4byte sBeautiflyPose15
+.4byte sBeautiflyPose16
+.4byte sBeautiflyPose17
+.4byte sBeautiflyPose18
+.4byte sBeautiflyPose19
+.4byte sBeautiflyPose20
+.4byte sBeautiflyPose21
+.4byte sBeautiflyPose22
+.4byte sBeautiflyPose23
+.4byte sBeautiflyPose24
+.4byte sBeautiflyPose25
+.4byte sBeautiflyPose26
+.4byte sBeautiflyPose27
+.4byte sBeautiflyPose28
+.4byte sBeautiflyPose29
+.4byte sBeautiflyPose30
+.4byte sBeautiflyPose31
+.4byte sBeautiflyPose32
+.4byte sBeautiflyPose33
+.4byte sBeautiflyPose34
+.4byte sBeautiflyPose35
+.4byte sBeautiflyPose36
+.4byte sBeautiflyPose37
+.4byte sBeautiflyPose38
+.4byte sBeautiflyPose39
+.4byte sBeautiflyPose40
+.4byte sBeautiflyPose41
+.4byte sBeautiflyPose42
+.4byte sBeautiflyPose43
+.4byte sBeautiflyPose44
+.4byte sBeautiflyPose45
+.4byte sBeautiflyPose46
+.4byte sBeautiflyPose47
+.4byte sBeautiflyPose48
+.4byte sBeautiflyPose49
+.4byte sBeautiflyPose50
+.4byte sBeautiflyPose51
+.4byte sBeautiflyPose52
+.4byte sBeautiflyPose53
+.4byte sBeautiflyPose54
+.4byte sBeautiflyPose55
+.4byte sBeautiflyPose56
+.4byte sBeautiflyPose57
+.4byte sBeautiflyPose58
+.4byte sBeautiflyPose59
+.4byte sBeautiflyPose60
+.4byte sBeautiflyPose61
+.4byte sBeautiflyPose62
+.4byte sBeautiflyPose63
+.4byte sBeautiflyPose64
+.4byte sBeautiflyPose65
+.4byte sBeautiflyPose66
+.4byte sBeautiflyPose67
+.4byte sBeautiflyPose68
+.4byte sBeautiflyPose69
+.4byte sBeautiflyPose70
+.4byte sBeautiflyPose71
+.4byte sBeautiflyPose72
+.4byte sBeautiflyPose73
+.4byte sBeautiflyPose74
+.4byte sBeautiflyPose75
+.4byte sBeautiflyPose76
+.4byte sBeautiflyPose77
+.4byte sBeautiflyPose78
+.4byte sBeautiflyPose79
+.4byte sBeautiflyPose80
+.4byte sBeautiflyPose81
+.4byte sBeautiflyPose82
+.4byte sBeautiflyPose83
+.4byte sBeautiflyPose84
+.4byte sBeautiflyPose85
+.4byte sBeautiflyPose86
+.4byte sBeautiflyPose87
+.4byte sBeautiflyPose88
+.4byte sBeautiflyPose89
+.4byte sBeautiflyPose90
+.4byte sBeautiflyPose91
+.4byte sBeautiflyPose92
+.4byte sBeautiflyPose93
+.4byte sBeautiflyPose94
+.4byte sBeautiflyPose95
+.4byte sBeautiflyPose96
+.4byte sBeautiflyPose97
+.4byte sBeautiflyPose98
+.4byte sBeautiflyPose99
+.4byte sBeautiflyPose100
+.4byte sBeautiflyPose101
+.4byte sBeautiflyPose102
+.4byte sBeautiflyPose103
+.4byte sBeautiflyPose104
+.4byte sBeautiflyPose105
+.4byte sBeautiflyPose106
+.4byte sBeautiflyPose107
+.4byte sBeautiflyPose108
+.4byte sBeautiflyPose109
+.4byte sBeautiflyPose110
+.4byte sBeautiflyPose111
+.4byte sBeautiflyPose112
+.4byte sBeautiflyPose113
+.4byte sBeautiflyPose114
+.4byte sBeautiflyPose115
+.4byte sBeautiflyPose116
+.4byte sBeautiflyPose117
+.4byte sBeautiflyPose118
+.4byte sBeautiflyPose119
+.4byte sBeautiflyPose120
+.4byte sBeautiflyPose121
+.4byte sBeautiflyPose122
+.4byte sBeautiflyPose123
+.4byte sBeautiflyPose124
+.4byte sBeautiflyPose125
+.4byte sBeautiflyPose126
+.4byte sBeautiflyPose127
+.4byte sBeautiflyPose128
+.4byte sBeautiflyPose129
+.4byte sBeautiflyPose130
+.4byte sBeautiflyPose131
+.4byte sBeautiflyPose132
+.4byte sBeautiflyPose133
+.4byte sBeautiflyPose134
+.4byte sBeautiflyPose135
+.4byte sBeautiflyPose136
+.4byte sBeautiflyPose137
+.4byte sBeautiflyPose138
+.4byte sBeautiflyPose139
+.4byte sBeautiflyPose140
+.4byte sBeautiflyPose141
+.4byte sBeautiflyPose142
+.4byte sBeautiflyPose143
+.4byte sBeautiflyPose144
+.4byte sBeautiflyPose145
+.4byte sBeautiflyPose146
+.4byte sBeautiflyPose147
+.4byte sBeautiflyPose148
+.4byte sBeautiflyPose149
+.4byte sBeautiflyPose150
+.4byte sBeautiflyPose151
+.4byte sBeautiflyPose152
+.4byte sBeautiflyPose153
+.4byte sBeautiflyPose154
+.4byte sBeautiflyPose155
+.4byte sBeautiflyPose156
+.4byte sBeautiflyPose157
+.4byte sBeautiflyPose158
+.4byte sBeautiflyPose159
+.4byte sBeautiflyPose160
+.4byte sBeautiflyPose161
+.4byte sBeautiflyPose162
+.4byte sBeautiflyPose163
+.4byte sBeautiflyPose164
+.4byte sBeautiflyPose165
+.4byte sBeautiflyPose166
+.4byte sBeautiflyPose167
+.4byte sBeautiflyPose168
+.4byte sBeautiflyPose169
+.4byte sBeautiflyPose170
+.4byte sBeautiflyPose171
+.4byte sBeautiflyPose172
+.4byte sBeautiflyPose173
+.4byte sBeautiflyPose174
+.4byte sBeautiflyPose175
+.4byte sBeautiflyPose176
+.4byte sBeautiflyPose177
+.4byte sBeautiflyPose178
+.4byte sBeautiflyPose179
+.4byte sBeautiflyPose180
+.4byte sBeautiflyPose181
+.4byte sBeautiflyPose182
+.4byte sBeautiflyPose183
+.4byte sBeautiflyPose184
+.4byte sBeautiflyPose185
+.4byte sBeautiflyPose186
+.4byte sBeautiflyPose187
+.4byte sBeautiflyPose188
+.4byte sBeautiflyPose189
+.4byte sBeautiflyPose190
+.4byte sBeautiflyPose191
+.4byte sBeautiflyPose192
+.4byte sBeautiflyPose193
+.4byte sBeautiflyPose194
+.4byte sBeautiflyPose195
+.4byte sBeautiflyPose196
+.4byte sBeautiflyPose197
+.4byte sBeautiflyPose198
+.4byte sBeautiflyPose199
+.4byte sBeautiflyPose200
+.4byte sBeautiflyPose201
+.4byte sBeautiflyPose202
+.4byte sBeautiflyPose203
+.4byte sBeautiflyPose204
+.4byte sBeautiflyPose205
+.4byte sBeautiflyPose206
+.4byte sBeautiflyPose207
+.4byte sBeautiflyPose208
+.4byte sBeautiflyPose209
+.4byte sBeautiflyPose210
+sAxPositionsBeautifly:
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -12, 	   5,  -11, 	   2,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    7,  -16, 	   6,  -13, 	   2,  -15, 	   1,  -13
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -8,  -16, 	  -3,  -15, 	  -7,  -13, 	  -2,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -12, 	  -3,  -13
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -12, 	   5,  -11, 	   2,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    7,  -16, 	   6,  -13, 	   2,  -15, 	   1,  -13
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -8,  -16, 	  -3,  -15, 	  -7,  -13, 	  -2,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -12, 	  -3,  -13
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -12, 	   5,  -11, 	   2,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    7,  -16, 	   6,  -13, 	   2,  -15, 	   1,  -13
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -8,  -16, 	  -3,  -15, 	  -7,  -13, 	  -2,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -12, 	  -3,  -13
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -12, 	   5,  -11, 	   2,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    7,  -16, 	   6,  -13, 	   2,  -15, 	   1,  -13
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -8,  -16, 	  -3,  -15, 	  -7,  -13, 	  -2,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -12, 	  -3,  -13
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -12, 	   5,  -11, 	   2,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    7,  -16, 	   6,  -13, 	   2,  -15, 	   1,  -13
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -8,  -16, 	  -3,  -15, 	  -7,  -13, 	  -2,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -12, 	  -3,  -13
+.2byte   -5,   -4, 	  -5,   -3, 	  -3,   -2, 	  -3,   -6
+.2byte   -6,   -3, 	  -6,   -2, 	  -3,   -2, 	  -4,   -5
+.2byte    0,  -13, 	  -4,  -12, 	   4,  -12, 	   0,  -12
+.2byte    6,  -12, 	   4,  -11, 	   7,  -13, 	   3,  -12
+.2byte    7,  -14, 	   6,  -12, 	   6,  -14, 	   3,  -12
+.2byte    4,  -15, 	   6,  -13, 	   0,  -15, 	  -2,  -12
+.2byte    0,  -16, 	  -4,  -14, 	   3,  -14, 	   0,  -13
+.2byte   -5,  -15, 	  -1,  -15, 	  -7,  -13, 	   1,  -12
+.2byte   -8,  -14, 	  -7,  -14, 	  -7,  -12, 	  -4,  -12
+.2byte   -7,  -12, 	  -8,  -13, 	  -5,  -11, 	  -4,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -12, 	   5,  -11, 	   2,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    7,  -16, 	   6,  -13, 	   2,  -15, 	   1,  -13
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -8,  -16, 	  -3,  -15, 	  -7,  -13, 	  -2,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -12, 	  -3,  -13
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -7,  -13, 	  -7,  -11, 	  -5,  -11, 	  -5,  -12
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    6,  -13, 	   4,  -11, 	   6,  -11, 	   4,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    6,  -13, 	   4,  -11, 	   6,  -11, 	   4,  -12
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -7,  -13, 	  -7,  -11, 	  -5,  -11, 	  -5,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte    5,  -13, 	   3,  -12, 	   5,  -11, 	   2,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    7,  -16, 	   6,  -13, 	   2,  -15, 	   1,  -13
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -9,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -8,  -16, 	  -3,  -15, 	  -7,  -13, 	  -2,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -12, 	  -3,  -13
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -1,  -17, 	   2,  -15, 	  -4,  -15, 	  -1,  -14
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   2,  -12, 	  -1,  -12
+.2byte   -6,  -13, 	  -6,  -11, 	  -4,  -11, 	  -4,  -12
+.2byte   -9,  -14, 	  -5,  -12, 	  -5,  -11, 	  -4,  -13
+.2byte   -8,  -15, 	  -3,  -16, 	  -7,  -13, 	  -2,  -14
+.2byte   -1,  -18, 	   2,  -16, 	  -4,  -16, 	  -1,  -15
+.2byte    7,  -15, 	   6,  -13, 	   2,  -16, 	   1,  -14
+.2byte    8,  -14, 	   4,  -11, 	   4,  -12, 	   3,  -13
+.2byte    5,  -13, 	   3,  -11, 	   5,  -11, 	   3,  -12
+sBeautiflyAnimTable1:
+.4byte sBeautiflyAnims_1_1
+.4byte sBeautiflyAnims_1_2
+.4byte sBeautiflyAnims_1_3
+.4byte sBeautiflyAnims_1_4
+.4byte sBeautiflyAnims_1_5
+.4byte sBeautiflyAnims_1_6
+.4byte sBeautiflyAnims_1_7
+.4byte sBeautiflyAnims_1_8
+sBeautiflyAnimTable2:
+.4byte sBeautiflyAnims_2_1
+.4byte sBeautiflyAnims_2_2
+.4byte sBeautiflyAnims_2_3
+.4byte sBeautiflyAnims_2_4
+.4byte sBeautiflyAnims_2_5
+.4byte sBeautiflyAnims_2_6
+.4byte sBeautiflyAnims_2_7
+.4byte sBeautiflyAnims_2_8
+sBeautiflyAnimTable3:
+.4byte sBeautiflyAnims_3_1
+.4byte sBeautiflyAnims_3_2
+.4byte sBeautiflyAnims_3_3
+.4byte sBeautiflyAnims_3_4
+.4byte sBeautiflyAnims_3_5
+.4byte sBeautiflyAnims_3_6
+.4byte sBeautiflyAnims_3_7
+.4byte sBeautiflyAnims_3_8
+sBeautiflyAnimTable4:
+.4byte sBeautiflyAnims_4_1
+.4byte sBeautiflyAnims_4_2
+.4byte sBeautiflyAnims_4_3
+.4byte sBeautiflyAnims_4_4
+.4byte sBeautiflyAnims_4_5
+.4byte sBeautiflyAnims_4_6
+.4byte sBeautiflyAnims_4_7
+.4byte sBeautiflyAnims_4_8
+sBeautiflyAnimTable5:
+.4byte sBeautiflyAnims_5_1
+.4byte sBeautiflyAnims_5_2
+.4byte sBeautiflyAnims_5_3
+.4byte sBeautiflyAnims_5_4
+.4byte sBeautiflyAnims_5_5
+.4byte sBeautiflyAnims_5_6
+.4byte sBeautiflyAnims_5_7
+.4byte sBeautiflyAnims_5_8
+sBeautiflyAnimTable6:
+.4byte sBeautiflyAnims_6_1
+.4byte sBeautiflyAnims_6_1
+.4byte sBeautiflyAnims_6_1
+.4byte sBeautiflyAnims_6_1
+.4byte sBeautiflyAnims_6_1
+.4byte sBeautiflyAnims_6_1
+.4byte sBeautiflyAnims_6_1
+.4byte sBeautiflyAnims_6_1
+sBeautiflyAnimTable7:
+.4byte sBeautiflyAnims_7_1
+.4byte sBeautiflyAnims_7_2
+.4byte sBeautiflyAnims_7_3
+.4byte sBeautiflyAnims_7_4
+.4byte sBeautiflyAnims_7_5
+.4byte sBeautiflyAnims_7_6
+.4byte sBeautiflyAnims_7_7
+.4byte sBeautiflyAnims_7_8
+sBeautiflyAnimTable8:
+.4byte sBeautiflyAnims_8_1
+.4byte sBeautiflyAnims_8_2
+.4byte sBeautiflyAnims_8_3
+.4byte sBeautiflyAnims_8_4
+.4byte sBeautiflyAnims_8_5
+.4byte sBeautiflyAnims_8_6
+.4byte sBeautiflyAnims_8_7
+.4byte sBeautiflyAnims_8_8
+sBeautiflyAnimTable9:
+.4byte sBeautiflyAnims_9_1
+.4byte sBeautiflyAnims_9_2
+.4byte sBeautiflyAnims_9_3
+.4byte sBeautiflyAnims_9_4
+.4byte sBeautiflyAnims_9_5
+.4byte sBeautiflyAnims_9_6
+.4byte sBeautiflyAnims_9_7
+.4byte sBeautiflyAnims_9_8
+sBeautiflyAnimTable10:
+.4byte sBeautiflyAnims_10_1
+.4byte sBeautiflyAnims_10_2
+.4byte sBeautiflyAnims_10_3
+.4byte sBeautiflyAnims_10_4
+.4byte sBeautiflyAnims_10_5
+.4byte sBeautiflyAnims_10_6
+.4byte sBeautiflyAnims_10_7
+.4byte sBeautiflyAnims_10_8
+sBeautiflyAnimTable11:
+.4byte sBeautiflyAnims_11_1
+.4byte sBeautiflyAnims_11_2
+.4byte sBeautiflyAnims_11_3
+.4byte sBeautiflyAnims_11_4
+.4byte sBeautiflyAnims_11_5
+.4byte sBeautiflyAnims_11_6
+.4byte sBeautiflyAnims_11_7
+.4byte sBeautiflyAnims_11_8
+sBeautiflyAnimTable12:
+.4byte sBeautiflyAnims_12_1
+.4byte sBeautiflyAnims_12_2
+.4byte sBeautiflyAnims_12_3
+.4byte sBeautiflyAnims_12_4
+.4byte sBeautiflyAnims_12_5
+.4byte sBeautiflyAnims_12_6
+.4byte sBeautiflyAnims_12_7
+.4byte sBeautiflyAnims_12_8
+sBeautiflyAnimTable13:
+.4byte sBeautiflyAnims_13_1
+.4byte sBeautiflyAnims_13_2
+.4byte sBeautiflyAnims_13_3
+.4byte sBeautiflyAnims_13_4
+.4byte sBeautiflyAnims_13_5
+.4byte sBeautiflyAnims_13_6
+.4byte sBeautiflyAnims_13_7
+.4byte sBeautiflyAnims_13_8
+sAxAnimationsBeautifly:
+.4byte sBeautiflyAnimTable1
+.4byte sBeautiflyAnimTable2
+.4byte sBeautiflyAnimTable3
+.4byte sBeautiflyAnimTable4
+.4byte sBeautiflyAnimTable5
+.4byte sBeautiflyAnimTable6
+.4byte sBeautiflyAnimTable7
+.4byte sBeautiflyAnimTable8
+.4byte sBeautiflyAnimTable9
+.4byte sBeautiflyAnimTable10
+.4byte sBeautiflyAnimTable11
+.4byte sBeautiflyAnimTable12
+.4byte sBeautiflyAnimTable13
+sAxSpritesBeautifly:
+.4byte sBeautiflySprites1
+.4byte sBeautiflySprites2
+.4byte sBeautiflySprites3
+.4byte sBeautiflySprites4
+.4byte sBeautiflySprites5
+.4byte sBeautiflySprites6
+.4byte sBeautiflySprites7
+.4byte sBeautiflySprites8
+.4byte sBeautiflySprites9
+.4byte sBeautiflySprites10
+.4byte sBeautiflySprites11
+.4byte sBeautiflySprites12
+.4byte sBeautiflySprites13
+.4byte sBeautiflySprites14
+.4byte sBeautiflySprites15
+.4byte sBeautiflySprites16
+.4byte sBeautiflySprites17
+.4byte sBeautiflySprites18
+.4byte sBeautiflySprites19
+.4byte sBeautiflySprites20
+.4byte sBeautiflySprites21
+.4byte sBeautiflySprites22
+.4byte sBeautiflySprites23
+.4byte sBeautiflySprites24
+.4byte sBeautiflySprites25
+.4byte sBeautiflySprites26
+.4byte sBeautiflySprites27
+.4byte sBeautiflySprites28
+.4byte sBeautiflySprites29
+.4byte sBeautiflySprites30
+.4byte sBeautiflySprites31
+.4byte sBeautiflySprites32
+.4byte sBeautiflySprites33
+.4byte sBeautiflySprites34
+.4byte sBeautiflySprites35
+.4byte sBeautiflySprites36
+.4byte sBeautiflySprites37
+.4byte sBeautiflySprites38
+.4byte sBeautiflySprites39
+.4byte sBeautiflySprites40
+.4byte sBeautiflySprites41
+.4byte sBeautiflySprites42
+.4byte sBeautiflySprites43
+.4byte sBeautiflySprites44
+.4byte sBeautiflySprites45
+.4byte sBeautiflySprites46
+.4byte sBeautiflySprites47
+.4byte sBeautiflySprites48
+sAxMainBeautifly:
+ax_main sAxPosesBeautifly, sAxAnimationsBeautifly, 13, sAxSpritesBeautifly, sAxPositionsBeautifly

--- a/data/ax/beedrill.inc
+++ b/data/ax/beedrill.inc
@@ -1,0 +1,3088 @@
+.global gAxBeedrill
+gAxBeedrill:
+ax_siro sAxMainBeedrill
+sBeedrillPose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose3:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose4:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose5:
+ax_pose 4, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose6:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose7:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose8:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose9:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose10:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose11:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose12:
+ax_pose 11, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose16:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose17:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose18:
+ax_pose 11, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose19:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose20:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose21:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose22:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose23:
+ax_pose 4, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose24:
+ax_pose 5, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose25:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose26:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose27:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose28:
+ax_pose 15, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose29:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose30:
+ax_pose 4, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose31:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose32:
+ax_pose 16, 0x01df, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose33:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose34:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose35:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose36:
+ax_pose 17, 0x01e1, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose37:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose38:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose39:
+ax_pose 11, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose40:
+ax_pose 18, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose41:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose42:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose43:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose44:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose45:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose46:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose47:
+ax_pose 11, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose48:
+ax_pose 18, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose49:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose50:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose51:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose52:
+ax_pose 17, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose53:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose54:
+ax_pose 4, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose55:
+ax_pose 5, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose56:
+ax_pose 16, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose57:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose58:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose59:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose60:
+ax_pose 15, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose61:
+ax_pose 20, 0x01e3, 0x80f0, 0x2c00
+ax_pose 21, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose62:
+ax_pose 21, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose63:
+ax_pose 20, 0x01e3, 0x90f0, 0x2c00
+ax_pose 22, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose64:
+ax_pose 22, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose65:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose66:
+ax_pose 4, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose67:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose68:
+ax_pose 16, 0x01e0, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose69:
+ax_pose 23, 0x01e3, 0x90ef, 0x2c00
+ax_pose 24, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sBeedrillPose70:
+ax_pose 24, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose71:
+ax_pose 25, 0x01e3, 0x90ef, 0x2c00
+ax_pose 26, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sBeedrillPose72:
+ax_pose 26, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose73:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose74:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose75:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose76:
+ax_pose 17, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose77:
+ax_pose 27, 0x01e3, 0x90ef, 0x2c00
+ax_pose 28, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sBeedrillPose78:
+ax_pose 28, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose79:
+ax_pose 29, 0x41f2, 0x90ef, 0x2c00
+ax_pose 30, 0x01e3, 0x90ef, 0x2c08
+ax_pose_terminator
+sBeedrillPose80:
+ax_pose 30, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose81:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose82:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose83:
+ax_pose 11, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose84:
+ax_pose 18, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose85:
+ax_pose 31, 0x01e3, 0x90ef, 0x2c00
+ax_pose 32, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sBeedrillPose86:
+ax_pose 32, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose87:
+ax_pose 33, 0x81e3, 0x90ff, 0x2c00
+ax_pose 34, 0x01e3, 0x90ef, 0x2c08
+ax_pose_terminator
+sBeedrillPose88:
+ax_pose 34, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose89:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose90:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose91:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose92:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose93:
+ax_pose 35, 0x01e4, 0x80f0, 0x2c00
+ax_pose 36, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose94:
+ax_pose 36, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose95:
+ax_pose 35, 0x01e4, 0x90f0, 0x2c00
+ax_pose 37, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose96:
+ax_pose 37, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose97:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose98:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose99:
+ax_pose 11, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose100:
+ax_pose 18, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose101:
+ax_pose 31, 0x01e3, 0x80f0, 0x2c00
+ax_pose 32, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose102:
+ax_pose 32, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose103:
+ax_pose 33, 0x81e3, 0x80f0, 0x2c00
+ax_pose 34, 0x01e3, 0x80f0, 0x2c08
+ax_pose_terminator
+sBeedrillPose104:
+ax_pose 34, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose105:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose106:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose107:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose108:
+ax_pose 17, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose109:
+ax_pose 27, 0x01e3, 0x80f0, 0x2c00
+ax_pose 28, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose110:
+ax_pose 28, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose111:
+ax_pose 29, 0x41f2, 0x80f0, 0x2c00
+ax_pose 30, 0x01e3, 0x80f0, 0x2c08
+ax_pose_terminator
+sBeedrillPose112:
+ax_pose 30, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose113:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose114:
+ax_pose 4, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose115:
+ax_pose 5, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose116:
+ax_pose 16, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose117:
+ax_pose 23, 0x01e3, 0x80f0, 0x2c00
+ax_pose 24, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose118:
+ax_pose 24, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose119:
+ax_pose 25, 0x01e3, 0x80f0, 0x2c00
+ax_pose 26, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sBeedrillPose120:
+ax_pose 26, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose121:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose122:
+ax_pose 1, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose123:
+ax_pose 2, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose124:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose125:
+ax_pose 4, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose126:
+ax_pose 5, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose127:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose128:
+ax_pose 7, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose129:
+ax_pose 8, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose130:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose131:
+ax_pose 10, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose132:
+ax_pose 11, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose133:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose134:
+ax_pose 13, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose135:
+ax_pose 14, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose136:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose137:
+ax_pose 10, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose138:
+ax_pose 11, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose139:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose140:
+ax_pose 7, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose141:
+ax_pose 8, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose142:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose143:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose144:
+ax_pose 5, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose145:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose146:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose147:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose148:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose149:
+ax_pose 4, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose150:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose151:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose152:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose153:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose154:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose155:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose156:
+ax_pose 11, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose157:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose158:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose159:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose160:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose161:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose162:
+ax_pose 11, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose163:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose164:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose165:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose166:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose167:
+ax_pose 4, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose168:
+ax_pose 5, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose169:
+ax_pose 38, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sBeedrillPose170:
+ax_pose 39, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sBeedrillPose171:
+ax_pose 40, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sBeedrillPose172:
+ax_pose 41, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sBeedrillPose173:
+ax_pose 42, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sBeedrillPose174:
+ax_pose 43, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sBeedrillPose175:
+ax_pose 44, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose176:
+ax_pose 43, 0x01e4, 0x80f6, 0x2c00
+ax_pose_terminator
+sBeedrillPose177:
+ax_pose 42, 0x01e3, 0x80f5, 0x2c00
+ax_pose_terminator
+sBeedrillPose178:
+ax_pose 41, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sBeedrillPose179:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose180:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose181:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose182:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose183:
+ax_pose 4, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose184:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose185:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose186:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose187:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose188:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose189:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose190:
+ax_pose 11, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose191:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose192:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose193:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose194:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose195:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose196:
+ax_pose 11, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose197:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose198:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose199:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose200:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose201:
+ax_pose 4, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose202:
+ax_pose 5, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose203:
+ax_pose 15, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose204:
+ax_pose 16, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose205:
+ax_pose 17, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose206:
+ax_pose 18, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose207:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose208:
+ax_pose 18, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose209:
+ax_pose 17, 0x01e1, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose210:
+ax_pose 16, 0x01df, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose211:
+ax_pose 15, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose212:
+ax_pose 16, 0x01df, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose213:
+ax_pose 17, 0x01e1, 0x90ed, 0x2c00
+ax_pose_terminator
+sBeedrillPose214:
+ax_pose 18, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sBeedrillPose215:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose216:
+ax_pose 18, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sBeedrillPose217:
+ax_pose 17, 0x01e1, 0x80f2, 0x2c00
+ax_pose_terminator
+sBeedrillPose218:
+ax_pose 16, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose219:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose220:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose221:
+ax_pose 15, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose222:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose223:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose224:
+ax_pose 16, 0x01df, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose225:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose226:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose227:
+ax_pose 17, 0x01e1, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose228:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose229:
+ax_pose 11, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose230:
+ax_pose 18, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose231:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose232:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose233:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose234:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose235:
+ax_pose 11, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose236:
+ax_pose 18, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose237:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose238:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose239:
+ax_pose 17, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose240:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose241:
+ax_pose 5, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose242:
+ax_pose 16, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose243:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose244:
+ax_pose 4, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose245:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose246:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose247:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose248:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose249:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose250:
+ax_pose 4, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose251:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose252:
+ax_pose 3, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose253:
+ax_pose 6, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose254:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose255:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sBeedrillPose256:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose257:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sBeedrillPose258:
+ax_pose 3, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+.align 2
+sBeedrillAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -3, 0, -3,
+ax_anim 4, 0, 26, 0, -4, 0, -4,
+ax_anim 1, 0, 24, 0, -4, 0, -4,
+ax_anim 1, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 24, 0, -4, 0, -4,
+ax_anim 1, 0, 26, 0, -4, 0, -4,
+ax_anim 1, 0, 24, 0, -4, 0, -4,
+ax_anim 1, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 2, 27, 0, 5, 0, 5,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 0, 11, 0, 11,
+ax_anim 1, 0, 26, 0, 5, 0, 5,
+ax_anim_terminator
+sBeedrillAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 4, 0, 30, -4, -4, -4, -4,
+ax_anim 1, 0, 28, -4, -4, -4, -4,
+ax_anim 1, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 0, 28, -4, -4, -4, -4,
+ax_anim 1, 0, 30, -4, -4, -4, -4,
+ax_anim 1, 0, 28, -4, -4, -4, -4,
+ax_anim 1, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 2, 31, 5, 5, 5, 5,
+ax_anim 2, 0, 31, 15, 19, 15, 19,
+ax_anim 2, 1, 31, 16, 18, 16, 18,
+ax_anim 2, 0, 31, 15, 19, 15, 19,
+ax_anim 2, 0, 31, 16, 18, 16, 18,
+ax_anim 2, 0, 31, 15, 19, 15, 19,
+ax_anim 2, 0, 30, 10, 12, 10, 12,
+ax_anim 1, 0, 30, 4, 5, 4, 5,
+ax_anim_terminator
+sBeedrillAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 4, 0, 34, -4, 0, -4, 0,
+ax_anim 1, 0, 32, -4, 0, -4, 0,
+ax_anim 1, 0, 33, -4, 0, -4, 0,
+ax_anim 1, 0, 32, -4, 0, -4, 0,
+ax_anim 1, 0, 34, -4, 0, -4, 0,
+ax_anim 1, 0, 32, -4, 0, -4, 0,
+ax_anim 1, 0, 33, -4, 0, -4, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 5, 0, 5, 0,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 1, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 0, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 0, 34, 10, 0, 10, 0,
+ax_anim 1, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sBeedrillAnims_2_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 2, 0, 38, -3, 3, -3, 3,
+ax_anim 4, 0, 38, -4, 4, -4, 4,
+ax_anim 1, 0, 36, -4, 4, -4, 4,
+ax_anim 1, 0, 37, -4, 4, -4, 4,
+ax_anim 1, 0, 36, -4, 4, -4, 4,
+ax_anim 1, 0, 38, -4, 4, -4, 4,
+ax_anim 1, 0, 36, -4, 4, -4, 4,
+ax_anim 1, 0, 37, -4, 4, -4, 4,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 5, -5, 5, -5,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 1, 39, 16, -14, 16, -14,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 0, 39, 16, -14, 16, -14,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 0, 38, 10, -10, 10, -10,
+ax_anim 1, 0, 38, 4, -4, 4, -4,
+ax_anim_terminator
+sBeedrillAnims_2_5:
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 2, 0, 42, 0, 3, 0, 3,
+ax_anim 4, 0, 42, 0, 4, 0, 4,
+ax_anim 1, 0, 40, 0, 4, 0, 4,
+ax_anim 1, 0, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 40, 0, 4, 0, 4,
+ax_anim 1, 0, 42, 0, 4, 0, 4,
+ax_anim 1, 0, 40, 0, 4, 0, 4,
+ax_anim 1, 0, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 2, 43, 0, -5, 0, -5,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 42, 0, -10, 0, -10,
+ax_anim 1, 0, 42, 0, -4, 0, -4,
+ax_anim_terminator
+sBeedrillAnims_2_6:
+ax_anim 2, 0, 46, 1, 1, 1, 1,
+ax_anim 2, 0, 46, 3, 3, 3, 3,
+ax_anim 4, 0, 46, 4, 4, 4, 4,
+ax_anim 1, 0, 44, 4, 4, 4, 4,
+ax_anim 1, 0, 45, 4, 4, 4, 4,
+ax_anim 1, 0, 44, 4, 4, 4, 4,
+ax_anim 1, 0, 46, 4, 4, 4, 4,
+ax_anim 1, 0, 44, 4, 4, 4, 4,
+ax_anim 1, 0, 45, 4, 4, 4, 4,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 2, 47, -5, -5, -5, -5,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 1, 47, -16, -14, -16, -14,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 0, 47, -16, -14, -16, -14,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 0, 46, -10, -10, -10, -10,
+ax_anim 1, 0, 46, -4, -4, -4, -4,
+ax_anim_terminator
+sBeedrillAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 2, 0, 50, 3, 0, 3, 0,
+ax_anim 4, 0, 50, 4, 0, 4, 0,
+ax_anim 1, 0, 48, 4, 0, 4, 0,
+ax_anim 1, 0, 49, 4, 0, 4, 0,
+ax_anim 1, 0, 48, 4, 0, 4, 0,
+ax_anim 1, 0, 50, 4, 0, 4, 0,
+ax_anim 1, 0, 48, 4, 0, 4, 0,
+ax_anim 1, 0, 49, 4, 0, 4, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 2, 51, -5, 0, -5, 0,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 1, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 50, -10, 0, -10, 0,
+ax_anim 1, 0, 50, -4, 0, -4, 0,
+ax_anim_terminator
+sBeedrillAnims_2_8:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 2, 0, 54, 3, -3, 3, -3,
+ax_anim 4, 0, 54, 4, -4, 4, -4,
+ax_anim 1, 0, 52, 4, -4, 4, -4,
+ax_anim 1, 0, 53, 4, -4, 4, -4,
+ax_anim 1, 0, 52, 4, -4, 4, -4,
+ax_anim 1, 0, 54, 4, -4, 4, -4,
+ax_anim 1, 0, 52, 4, -4, 4, -4,
+ax_anim 1, 0, 53, 4, -4, 4, -4,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 2, 55, -5, 5, -5, 5,
+ax_anim 2, 0, 55, -15, 19, -15, 19,
+ax_anim 2, 1, 55, -16, 18, -16, 18,
+ax_anim 2, 0, 55, -15, 19, -15, 19,
+ax_anim 2, 0, 55, -16, 18, -16, 18,
+ax_anim 2, 0, 55, -15, 19, -15, 19,
+ax_anim 2, 0, 54, -10, 12, -10, 12,
+ax_anim 1, 0, 54, -4, 5, -4, 5,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 2, 0, 56, 0, -4, 0, -4,
+ax_anim 4, 0, 57, 0, -6, 0, -6,
+ax_anim 1, 2, 59, 0, -3, 0, -3,
+ax_anim 1, 0, 115, 0, 3, 0, 3,
+ax_anim 2, 0, 60, 0, 19, 0, 19,
+ax_anim 2, 1, 61, 1, 20, 1, 20,
+ax_anim 2, 0, 64, 1, 16, 1, 16,
+ax_anim 2, 0, 67, 0, 14, 0, 14,
+ax_anim 2, 0, 62, 0, 19, 0, 19,
+ax_anim 2, 0, 63, -1, 20, -1, 20,
+ax_anim 2, 0, 56, -1, 16, -1, 16,
+ax_anim 2, 0, 56, 0, 11, 0, 11,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sBeedrillAnims_3_2:
+ax_anim 2, 0, 66, -2, -2, -2, -2,
+ax_anim 2, 0, 64, -4, -4, -4, -4,
+ax_anim 4, 0, 65, -6, -6, -6, -6,
+ax_anim 1, 2, 64, -3, -3, -3, -3,
+ax_anim 1, 0, 75, 3, 3, 3, 3,
+ax_anim 2, 0, 68, 17, 19, 17, 19,
+ax_anim 2, 1, 69, 16, 21, 16, 21,
+ax_anim 2, 0, 56, 14, 17, 14, 17,
+ax_anim 2, 0, 59, 14, 14, 14, 14,
+ax_anim 2, 0, 70, 17, 19, 17, 19,
+ax_anim 2, 0, 71, 19, 18, 19, 18,
+ax_anim 2, 0, 64, 18, 15, 18, 15,
+ax_anim 2, 0, 64, 11, 11, 11, 11,
+ax_anim 2, 0, 64, 3, 3, 3, 3,
+ax_anim_terminator
+sBeedrillAnims_3_3:
+ax_anim 2, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 0, 72, -4, 0, -4, 0,
+ax_anim 4, 0, 73, -6, 0, -6, 0,
+ax_anim 1, 2, 75, -3, 0, -3, 0,
+ax_anim 1, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 76, 15, 0, 15, 0,
+ax_anim 2, 1, 77, 16, 2, 16, 2,
+ax_anim 2, 0, 64, 10, 2, 10, 2,
+ax_anim 2, 0, 67, 7, 0, 7, 0,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 0, 79, 16, -2, 16, -2,
+ax_anim 2, 0, 72, 10, -2, 10, -2,
+ax_anim 2, 0, 72, 6, -1, 6, -1,
+ax_anim 2, 0, 72, 3, 0, 3, 0,
+ax_anim_terminator
+sBeedrillAnims_3_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 2, 0, 80, -4, 4, -4, 4,
+ax_anim 4, 0, 81, -6, 6, -6, 6,
+ax_anim 1, 2, 83, -3, 3, -3, 3,
+ax_anim 1, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 84, 17, -15, 17, -15,
+ax_anim 2, 1, 85, 19, -15, 19, -15,
+ax_anim 2, 0, 72, 15, -11, 15, -11,
+ax_anim 2, 0, 75, 9, -8, 9, -8,
+ax_anim 2, 0, 86, 21, -15, 21, -15,
+ax_anim 2, 0, 87, 21, -17, 21, -17,
+ax_anim 2, 0, 80, 8, -10, 8, -10,
+ax_anim 2, 0, 80, 7, -7, 7, -7,
+ax_anim 2, 0, 80, 3, -3, 3, -3,
+ax_anim_terminator
+sBeedrillAnims_3_5:
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim 4, 0, 89, 0, 6, 0, 6,
+ax_anim 1, 2, 91, 0, 3, 0, 3,
+ax_anim 1, 0, 83, 0, -3, 0, -3,
+ax_anim 2, 0, 92, 0, -11, 0, -11,
+ax_anim 2, 1, 93, -1, -12, -1, -12,
+ax_anim 2, 0, 96, -1, -8, -1, -8,
+ax_anim 2, 0, 99, 0, -6, 0, -6,
+ax_anim 2, 0, 94, 0, -11, 0, -11,
+ax_anim 2, 0, 95, 1, -12, 1, -12,
+ax_anim 2, 0, 88, 1, -8, 1, -8,
+ax_anim 2, 0, 88, 0, -5, 0, -5,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim_terminator
+sBeedrillAnims_3_6:
+ax_anim 2, 0, 98, 2, 2, 2, 2,
+ax_anim 2, 0, 96, 4, 4, 4, 4,
+ax_anim 4, 0, 97, 6, 6, 6, 6,
+ax_anim 1, 2, 99, 3, 3, 3, 3,
+ax_anim 1, 0, 91, -3, -3, -3, -3,
+ax_anim 2, 0, 100, -17, -15, -17, -15,
+ax_anim 2, 1, 101, -19, -15, -19, -15,
+ax_anim 2, 0, 104, -15, -11, -15, -11,
+ax_anim 2, 0, 107, -9, -8, -9, -8,
+ax_anim 2, 0, 102, -21, -15, -21, -15,
+ax_anim 2, 0, 103, -21, -17, -21, -17,
+ax_anim 2, 0, 96, -8, -10, -8, -10,
+ax_anim 2, 0, 96, -7, -7, -7, -7,
+ax_anim 2, 0, 96, -3, -3, -3, -3,
+ax_anim_terminator
+sBeedrillAnims_3_7:
+ax_anim 2, 0, 106, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 4, 0, 4, 0,
+ax_anim 4, 0, 105, 6, 0, 6, 0,
+ax_anim 1, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -15, 0, -15, 0,
+ax_anim 2, 1, 109, -16, 2, -16, 2,
+ax_anim 2, 0, 112, -10, 2, -10, 2,
+ax_anim 2, 0, 115, -7, 0, -7, 0,
+ax_anim 2, 0, 110, -15, 0, -15, 0,
+ax_anim 2, 0, 111, -16, -2, -16, -2,
+ax_anim 2, 0, 104, -10, -2, -10, -2,
+ax_anim 2, 0, 104, -6, -1, -6, -1,
+ax_anim 2, 0, 104, -3, 0, -3, 0,
+ax_anim_terminator
+sBeedrillAnims_3_8:
+ax_anim 2, 0, 114, 2, -2, 2, -2,
+ax_anim 2, 0, 112, 4, -4, 4, -4,
+ax_anim 4, 0, 113, 6, -6, 6, -6,
+ax_anim 1, 2, 115, 3, -3, 3, -3,
+ax_anim 1, 0, 107, -3, 3, -3, 3,
+ax_anim 2, 0, 116, -17, 19, -17, 19,
+ax_anim 2, 1, 117, -16, 21, -16, 21,
+ax_anim 2, 0, 56, -14, 17, -14, 17,
+ax_anim 2, 0, 59, -14, 14, -14, 14,
+ax_anim 2, 0, 118, -17, 19, -17, 19,
+ax_anim 2, 0, 119, -19, 18, -19, 18,
+ax_anim 2, 0, 112, -18, 15, -18, 15,
+ax_anim 2, 0, 112, -11, 11, -11, 11,
+ax_anim 2, 0, 112, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_4_1:
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim 2, 0, 121, 0, -3, 0, -3,
+ax_anim 2, 0, 120, 0, -4, 0, -4,
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 4, 2, 120, 0, -4, 0, -4,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 5, 0, 5,
+ax_anim 2, 0, 121, 1, 5, 1, 5,
+ax_anim 2, 1, 121, 0, 5, 0, 5,
+ax_anim 2, 0, 121, 1, 5, 1, 5,
+ax_anim 2, 0, 121, 0, 5, 0, 5,
+ax_anim 2, 0, 121, 1, 5, 1, 5,
+ax_anim 2, 0, 121, 0, 5, 0, 5,
+ax_anim 2, 0, 122, 0, 2, 0, 2,
+ax_anim_terminator
+sBeedrillAnims_4_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 2, 0, 125, -4, -4, -4, -4,
+ax_anim 4, 2, 123, -4, -4, -4, -4,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 5, 5, 5, 5,
+ax_anim 2, 0, 124, 6, 4, 6, 4,
+ax_anim 2, 1, 124, 5, 5, 5, 5,
+ax_anim 2, 0, 124, 6, 4, 6, 4,
+ax_anim 2, 0, 124, 5, 5, 5, 5,
+ax_anim 2, 0, 124, 6, 4, 6, 4,
+ax_anim 2, 0, 124, 5, 5, 5, 5,
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim_terminator
+sBeedrillAnims_4_3:
+ax_anim 2, 0, 126, -2, 0, -2, 0,
+ax_anim 2, 0, 127, -3, 0, -3, 0,
+ax_anim 2, 0, 126, -4, 0, -4, 0,
+ax_anim 2, 0, 128, -4, 0, -4, 0,
+ax_anim 4, 2, 126, -4, 0, -4, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 5, 0, 5, 0,
+ax_anim 2, 0, 127, 5, -1, 5, -1,
+ax_anim 2, 1, 127, 5, 0, 5, 0,
+ax_anim 2, 0, 127, 5, -1, 5, -1,
+ax_anim 2, 0, 127, 5, 0, 5, 0,
+ax_anim 2, 0, 127, 5, -1, 5, -1,
+ax_anim 2, 0, 127, 5, 0, 5, 0,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim_terminator
+sBeedrillAnims_4_4:
+ax_anim 2, 0, 129, -2, 2, -2, 2,
+ax_anim 2, 0, 130, -3, 3, -3, 3,
+ax_anim 2, 0, 129, -4, 4, -4, 4,
+ax_anim 2, 0, 131, -4, 4, -4, 4,
+ax_anim 4, 2, 129, -4, 4, -4, 4,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 5, -5, 5, -5,
+ax_anim 2, 0, 130, 6, -4, 6, -4,
+ax_anim 2, 1, 130, 5, -5, 5, -5,
+ax_anim 2, 0, 130, 6, -4, 6, -4,
+ax_anim 2, 0, 130, 5, -5, 5, -5,
+ax_anim 2, 0, 130, 6, -4, 6, -4,
+ax_anim 2, 0, 130, 5, -5, 5, -5,
+ax_anim 2, 0, 131, 2, -2, 2, -2,
+ax_anim_terminator
+sBeedrillAnims_4_5:
+ax_anim 2, 0, 132, 0, 2, 0, 2,
+ax_anim 2, 0, 133, 0, 3, 0, 3,
+ax_anim 2, 0, 132, 0, 4, 0, 4,
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 4, 2, 132, 0, 4, 0, 4,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, -5,
+ax_anim 2, 0, 133, 1, -5, 1, -5,
+ax_anim 2, 1, 133, 0, -5, 0, -5,
+ax_anim 2, 0, 133, 1, -5, 1, -5,
+ax_anim 2, 0, 133, 0, -5, 0, -5,
+ax_anim 2, 0, 133, 1, -5, 1, -5,
+ax_anim 2, 0, 133, 0, -5, 0, -5,
+ax_anim 2, 0, 134, 0, -2, 0, -2,
+ax_anim_terminator
+sBeedrillAnims_4_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 2, 0, 136, 3, 3, 3, 3,
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 2, 0, 137, 4, 4, 4, 4,
+ax_anim 4, 2, 135, 4, 4, 4, 4,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -5, -5, -5, -5,
+ax_anim 2, 0, 136, -6, -4, -6, -4,
+ax_anim 2, 1, 136, -5, -5, -5, -5,
+ax_anim 2, 0, 136, -6, -4, -6, -4,
+ax_anim 2, 0, 136, -5, -5, -5, -5,
+ax_anim 2, 0, 136, -6, -4, -6, -4,
+ax_anim 2, 0, 136, -5, -5, -5, -5,
+ax_anim 2, 0, 137, -2, -2, -2, -2,
+ax_anim_terminator
+sBeedrillAnims_4_7:
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 0, 139, 3, 0, 3, 0,
+ax_anim 2, 0, 138, 4, 0, 4, 0,
+ax_anim 2, 0, 140, 4, 0, 4, 0,
+ax_anim 4, 2, 138, 4, 0, 4, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -5, 0, -5, 0,
+ax_anim 2, 0, 139, -5, -1, -5, -1,
+ax_anim 2, 1, 139, -5, 0, -5, 0,
+ax_anim 2, 0, 139, -5, -1, -5, -1,
+ax_anim 2, 0, 139, -5, 0, -5, 0,
+ax_anim 2, 0, 139, -5, -1, -5, -1,
+ax_anim 2, 0, 139, -5, 0, -5, 0,
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim_terminator
+sBeedrillAnims_4_8:
+ax_anim 2, 0, 141, 2, -2, 2, -2,
+ax_anim 2, 0, 142, 3, -3, 3, -3,
+ax_anim 2, 0, 141, 4, -4, 4, -4,
+ax_anim 2, 0, 143, 4, -4, 4, -4,
+ax_anim 4, 2, 141, 4, -4, 4, -4,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -6, 4, -6, 4,
+ax_anim 2, 1, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -6, 4, -6, 4,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -6, 4, -6, 4,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_5_1:
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 2, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 1, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_5_2:
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 2, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 1, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_5_3:
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 2, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 1, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_5_4:
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 1, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_5_5:
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 3, 2, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 1, 156, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_5_6:
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 2, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 1, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_5_7:
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 2, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 1, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_5_8:
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 3, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 3, 2, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 3, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 3, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 1, 165, 0, 0, 0, 0,
+ax_anim 3, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 3, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_6_1:
+ax_anim 16, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, -1, 0, 0,
+ax_anim 16, 0, 169, 0, -2, 0, 0,
+ax_anim 16, 0, 168, 0, -2, 0, 0,
+ax_anim 8, 0, 168, 0, -1, 0, 0,
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_7_1:
+ax_anim 2, 0, 170, 0, -2, 0, -2,
+ax_anim 8, 0, 170, 0, -3, 0, -3,
+ax_anim_terminator
+sBeedrillAnims_7_2:
+ax_anim 2, 0, 171, -2, -2, -2, -2,
+ax_anim 8, 0, 171, -3, -3, -3, -3,
+ax_anim_terminator
+sBeedrillAnims_7_3:
+ax_anim 2, 0, 172, -2, 0, -2, 0,
+ax_anim 8, 0, 172, -3, 0, -3, 0,
+ax_anim_terminator
+sBeedrillAnims_7_4:
+ax_anim 2, 0, 173, -2, 2, -2, 2,
+ax_anim 8, 0, 173, -3, 3, -3, 3,
+ax_anim_terminator
+sBeedrillAnims_7_5:
+ax_anim 2, 0, 174, 0, 2, 0, 2,
+ax_anim 8, 0, 174, 0, 3, 0, 3,
+ax_anim_terminator
+sBeedrillAnims_7_6:
+ax_anim 2, 0, 175, 2, 2, 2, 2,
+ax_anim 8, 0, 175, 3, 3, 3, 3,
+ax_anim_terminator
+sBeedrillAnims_7_7:
+ax_anim 2, 0, 176, 2, 0, 2, 0,
+ax_anim 8, 0, 176, 3, 0, 3, 0,
+ax_anim_terminator
+sBeedrillAnims_7_8:
+ax_anim 2, 0, 177, 2, -2, 2, -2,
+ax_anim 8, 0, 177, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_8_1:
+ax_anim 4, 0, 178, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, 0, 0, 0,
+ax_anim 4, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_8_2:
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_8_3:
+ax_anim 4, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_8_4:
+ax_anim 4, 0, 187, 0, 0, 0, 0,
+ax_anim 4, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 187, 0, 0, 0, 0,
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_8_5:
+ax_anim 4, 0, 190, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 190, 0, 0, 0, 0,
+ax_anim 4, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_8_6:
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 4, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_8_7:
+ax_anim 4, 0, 196, 0, 0, 0, 0,
+ax_anim 4, 0, 197, 0, 0, 0, 0,
+ax_anim 4, 0, 196, 0, 0, 0, 0,
+ax_anim 4, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_8_8:
+ax_anim 4, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 4, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 4, 6, 4,
+ax_anim 2, 0, 204, 8, 9, 8, 9,
+ax_anim 2, 0, 205, 7, 19, 7, 19,
+ax_anim 3, 0, 206, 0, 24, 0, 24,
+ax_anim 2, 3, 207, -7, 19, -7, 19,
+ax_anim 2, 0, 208, -8, 9, -8, 9,
+ax_anim 1, 0, 209, -6, 4, -6, 4,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, -2, 8, -2,
+ax_anim 2, 0, 203, 17, 3, 17, 3,
+ax_anim 2, 0, 204, 24, 9, 24, 9,
+ax_anim 3, 0, 205, 23, 24, 23, 24,
+ax_anim 2, 3, 206, 11, 23, 11, 23,
+ax_anim 2, 0, 207, 1, 14, 1, 14,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -4, 3, -4,
+ax_anim 2, 0, 202, 11, -8, 11, -8,
+ax_anim 2, 0, 203, 17, -4, 17, -4,
+ax_anim 3, 0, 204, 23, 1, 23, 1,
+ax_anim 2, 3, 205, 17, 5, 17, 5,
+ax_anim 2, 0, 206, 12, 4, 12, 4,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -6, -1, -6,
+ax_anim 2, 0, 209, 4, -13, 4, -13,
+ax_anim 2, 0, 202, 11, -20, 11, -20,
+ax_anim 3, 0, 203, 21, -17, 21, -17,
+ax_anim 2, 3, 204, 21, -9, 21, -9,
+ax_anim 2, 0, 205, 17, -3, 17, -3,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -6, -2, -6, -2,
+ax_anim 2, 0, 208, -8, -10, -8, -10,
+ax_anim 2, 0, 209, -7, -13, -7, -13,
+ax_anim 3, 0, 202, 0, -19, 0, -19,
+ax_anim 2, 3, 203, 7, -13, 7, -13,
+ax_anim 2, 0, 204, 8, -8, 8, -8,
+ax_anim 1, 0, 205, 6, -2, 6, -2,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -6, 1, -6,
+ax_anim 2, 0, 203, -4, -13, -4, -13,
+ax_anim 2, 0, 202, -11, -20, -11, -20,
+ax_anim 3, 0, 209, -20, -17, -20, -17,
+ax_anim 2, 3, 208, -21, -9, -21, -9,
+ax_anim 2, 0, 207, -17, -3, -17, -3,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -4, -3, -4,
+ax_anim 2, 0, 202, -11, -8, -11, -8,
+ax_anim 2, 0, 209, -17, -4, -17, -4,
+ax_anim 3, 0, 208, -23, 1, -23, 1,
+ax_anim 2, 3, 207, -17, 5, -17, 5,
+ax_anim 2, 0, 206, -12, 4, -12, 4,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, -2, -6, 0,
+ax_anim 2, 0, 209, -17, 3, -17, 3,
+ax_anim 2, 0, 208, -24, 9, -24, 9,
+ax_anim 3, 0, 207, -23, 24, -23, 16,
+ax_anim 2, 3, 206, -11, 23, -11, 16,
+ax_anim 2, 0, 205, -1, 14, -4, 12,
+ax_anim 1, 0, 204, 0, 7, -3, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 4, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 2, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 3, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 229, 0, 4, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 232, 0, 4, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 235, 0, 4, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 238, 0, 3, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 241, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeedrillAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sBeedrillGfx1:
+.incbin "baserom.gba", 0x5B37CC, 0x200
+sBeedrillSprites1:
+ax_sprite sBeedrillGfx1, 0x200
+ax_sprite_terminator
+sBeedrillGfx2:
+.incbin "baserom.gba", 0x5B39DC, 0x200
+sBeedrillSprites2:
+ax_sprite sBeedrillGfx2, 0x200
+ax_sprite_terminator
+sBeedrillGfx3:
+.incbin "baserom.gba", 0x5B3BEC, 0x200
+sBeedrillSprites3:
+ax_sprite sBeedrillGfx3, 0x200
+ax_sprite_terminator
+sBeedrillGfx4:
+.incbin "baserom.gba", 0x5B3DFC, 0x200
+sBeedrillSprites4:
+ax_sprite sBeedrillGfx4, 0x200
+ax_sprite_terminator
+sBeedrillGfx5:
+.incbin "baserom.gba", 0x5B400C, 0x200
+sBeedrillSprites5:
+ax_sprite sBeedrillGfx5, 0x200
+ax_sprite_terminator
+sBeedrillGfx6:
+.incbin "baserom.gba", 0x5B421C, 0x200
+sBeedrillSprites6:
+ax_sprite sBeedrillGfx6, 0x200
+ax_sprite_terminator
+sBeedrillGfx7:
+.incbin "baserom.gba", 0x5B442C, 0x200
+sBeedrillSprites7:
+ax_sprite sBeedrillGfx7, 0x200
+ax_sprite_terminator
+sBeedrillGfx8:
+.incbin "baserom.gba", 0x5B463C, 0x200
+sBeedrillSprites8:
+ax_sprite sBeedrillGfx8, 0x200
+ax_sprite_terminator
+sBeedrillGfx9:
+.incbin "baserom.gba", 0x5B484C, 0x200
+sBeedrillSprites9:
+ax_sprite sBeedrillGfx9, 0x200
+ax_sprite_terminator
+sBeedrillGfx10:
+.incbin "baserom.gba", 0x5B4A5C, 0x200
+sBeedrillSprites10:
+ax_sprite sBeedrillGfx10, 0x200
+ax_sprite_terminator
+sBeedrillGfx11:
+.incbin "baserom.gba", 0x5B4C6C, 0x200
+sBeedrillSprites11:
+ax_sprite sBeedrillGfx11, 0x200
+ax_sprite_terminator
+sBeedrillGfx12:
+.incbin "baserom.gba", 0x5B4E7C, 0x200
+sBeedrillSprites12:
+ax_sprite sBeedrillGfx12, 0x200
+ax_sprite_terminator
+sBeedrillGfx13:
+.incbin "baserom.gba", 0x5B508C, 0x200
+sBeedrillSprites13:
+ax_sprite sBeedrillGfx13, 0x200
+ax_sprite_terminator
+sBeedrillGfx14:
+.incbin "baserom.gba", 0x5B529C, 0x200
+sBeedrillSprites14:
+ax_sprite sBeedrillGfx14, 0x200
+ax_sprite_terminator
+sBeedrillGfx15:
+.incbin "baserom.gba", 0x5B54AC, 0x200
+sBeedrillSprites15:
+ax_sprite sBeedrillGfx15, 0x200
+ax_sprite_terminator
+sBeedrillGfx16:
+.incbin "baserom.gba", 0x5B56BC, 0x200
+sBeedrillSprites16:
+ax_sprite sBeedrillGfx16, 0x200
+ax_sprite_terminator
+sBeedrillGfx17:
+.incbin "baserom.gba", 0x5B58CC, 0x40
+sBeedrillGfx17_1:
+.incbin "baserom.gba", 0x5B590C, 0xE0
+sBeedrillGfx17_2:
+.incbin "baserom.gba", 0x5B59EC, 0x80
+sBeedrillSprites17:
+ax_sprite sBeedrillGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx17_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx17_2, 0x80
+ax_sprite_terminator
+sBeedrillGfx18:
+.incbin "baserom.gba", 0x5B5A9C, 0x20
+sBeedrillGfx18_1:
+.incbin "baserom.gba", 0x5B5ABC, 0x60
+sBeedrillGfx18_2:
+.incbin "baserom.gba", 0x5B5B1C, 0x60
+sBeedrillGfx18_3:
+.incbin "baserom.gba", 0x5B5B7C, 0x60
+sBeedrillSprites18:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx19:
+.incbin "baserom.gba", 0x5B5C2C, 0x60
+sBeedrillGfx19_1:
+.incbin "baserom.gba", 0x5B5C8C, 0x60
+sBeedrillGfx19_2:
+.incbin "baserom.gba", 0x5B5CEC, 0x60
+sBeedrillGfx19_3:
+.incbin "baserom.gba", 0x5B5D4C, 0x40
+sBeedrillSprites19:
+ax_sprite sBeedrillGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx20:
+.incbin "baserom.gba", 0x5B5DD4, 0x100
+sBeedrillGfx20_1:
+.incbin "baserom.gba", 0x5B5ED4, 0x40
+sBeedrillGfx20_2:
+.incbin "baserom.gba", 0x5B5F14, 0x40
+sBeedrillSprites20:
+ax_sprite sBeedrillGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx21:
+.incbin "baserom.gba", 0x5B5F8C, 0x20
+sBeedrillGfx21_1:
+.incbin "baserom.gba", 0x5B5FAC, 0x20
+sBeedrillGfx21_2:
+.incbin "baserom.gba", 0x5B5FCC, 0x60
+sBeedrillGfx21_3:
+.incbin "baserom.gba", 0x5B602C, 0x60
+sBeedrillSprites21:
+ax_sprite sBeedrillGfx21, 0x20
+ax_sprite 0, 0x60
+ax_sprite sBeedrillGfx21_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sBeedrillGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx22:
+.incbin "baserom.gba", 0x5B60D4, 0x40
+sBeedrillGfx22_1:
+.incbin "baserom.gba", 0x5B6114, 0xE0
+sBeedrillGfx22_2:
+.incbin "baserom.gba", 0x5B61F4, 0x80
+sBeedrillSprites22:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx22_2, 0x80
+ax_sprite_terminator
+sBeedrillGfx23:
+.incbin "baserom.gba", 0x5B62AC, 0x40
+sBeedrillGfx23_1:
+.incbin "baserom.gba", 0x5B62EC, 0x80
+sBeedrillGfx23_2:
+.incbin "baserom.gba", 0x5B636C, 0xE0
+sBeedrillSprites23:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx23_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx23_2, 0xe0
+ax_sprite_terminator
+sBeedrillGfx24:
+.incbin "baserom.gba", 0x5B6484, 0x20
+sBeedrillGfx24_1:
+.incbin "baserom.gba", 0x5B64A4, 0x40
+sBeedrillGfx24_2:
+.incbin "baserom.gba", 0x5B64E4, 0x40
+sBeedrillGfx24_3:
+.incbin "baserom.gba", 0x5B6524, 0x40
+sBeedrillSprites24:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx24, 0x20
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx24_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBeedrillGfx25:
+.incbin "baserom.gba", 0x5B65B4, 0x40
+sBeedrillGfx25_1:
+.incbin "baserom.gba", 0x5B65F4, 0xE0
+sBeedrillGfx25_2:
+.incbin "baserom.gba", 0x5B66D4, 0x60
+sBeedrillSprites25:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx25_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx25_2, 0x60
+ax_sprite_terminator
+sBeedrillGfx26:
+.incbin "baserom.gba", 0x5B676C, 0x100
+sBeedrillSprites26:
+ax_sprite 0, 0xe0
+ax_sprite sBeedrillGfx26, 0x100
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx27:
+.incbin "baserom.gba", 0x5B688C, 0x60
+sBeedrillGfx27_1:
+.incbin "baserom.gba", 0x5B68EC, 0x160
+sBeedrillSprites27:
+ax_sprite sBeedrillGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx28:
+.incbin "baserom.gba", 0x5B6A74, 0xA0
+sBeedrillGfx28_1:
+.incbin "baserom.gba", 0x5B6B14, 0x40
+sBeedrillGfx28_2:
+.incbin "baserom.gba", 0x5B6B54, 0x40
+sBeedrillSprites28:
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx28, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx28_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBeedrillGfx29:
+.incbin "baserom.gba", 0x5B6BD4, 0x1E0
+sBeedrillSprites29:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx29, 0x1e0
+ax_sprite_terminator
+sBeedrillGfx30:
+.incbin "baserom.gba", 0x5B6DCC, 0xE0
+sBeedrillSprites30:
+ax_sprite sBeedrillGfx30, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx31:
+.incbin "baserom.gba", 0x5B6EC4, 0x40
+sBeedrillGfx31_1:
+.incbin "baserom.gba", 0x5B6F04, 0x160
+sBeedrillSprites31:
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx31_1, 0x160
+ax_sprite_terminator
+sBeedrillGfx32:
+.incbin "baserom.gba", 0x5B708C, 0xC0
+sBeedrillGfx32_1:
+.incbin "baserom.gba", 0x5B714C, 0x60
+sBeedrillSprites32:
+ax_sprite sBeedrillGfx32, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx32_1, 0x60
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sBeedrillGfx33:
+.incbin "baserom.gba", 0x5B71D4, 0x40
+sBeedrillGfx33_1:
+.incbin "baserom.gba", 0x5B7214, 0xE0
+sBeedrillGfx33_2:
+.incbin "baserom.gba", 0x5B72F4, 0x60
+sBeedrillSprites33:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx33_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx33_2, 0x60
+ax_sprite_terminator
+sBeedrillGfx34:
+.incbin "baserom.gba", 0x5B738C, 0xA0
+sBeedrillGfx34_1:
+.incbin "baserom.gba", 0x5B742C, 0x20
+sBeedrillSprites34:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx34, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx34_1, 0x20
+ax_sprite_terminator
+sBeedrillGfx35:
+.incbin "baserom.gba", 0x5B7474, 0x40
+sBeedrillGfx35_1:
+.incbin "baserom.gba", 0x5B74B4, 0x80
+sBeedrillGfx35_2:
+.incbin "baserom.gba", 0x5B7534, 0x60
+sBeedrillGfx35_3:
+.incbin "baserom.gba", 0x5B7594, 0x40
+sBeedrillSprites35:
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx35_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBeedrillGfx35_3, 0x40
+ax_sprite_terminator
+sBeedrillGfx36:
+.incbin "baserom.gba", 0x5B761C, 0xC0
+sBeedrillGfx36_1:
+.incbin "baserom.gba", 0x5B76DC, 0x60
+sBeedrillGfx36_2:
+.incbin "baserom.gba", 0x5B773C, 0x20
+sBeedrillSprites36:
+ax_sprite sBeedrillGfx36, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx36_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBeedrillGfx37:
+.incbin "baserom.gba", 0x5B7794, 0x160
+sBeedrillGfx37_1:
+.incbin "baserom.gba", 0x5B78F4, 0x20
+sBeedrillGfx37_2:
+.incbin "baserom.gba", 0x5B7914, 0x20
+sBeedrillSprites37:
+ax_sprite sBeedrillGfx37, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx37_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBeedrillGfx38:
+.incbin "baserom.gba", 0x5B796C, 0x100
+sBeedrillGfx38_1:
+.incbin "baserom.gba", 0x5B7A6C, 0x60
+sBeedrillGfx38_2:
+.incbin "baserom.gba", 0x5B7ACC, 0x20
+sBeedrillGfx38_3:
+.incbin "baserom.gba", 0x5B7AEC, 0x20
+sBeedrillSprites38:
+ax_sprite sBeedrillGfx38, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx38_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBeedrillGfx38_3, 0x20
+ax_sprite_terminator
+sBeedrillGfx39:
+.incbin "baserom.gba", 0x5B7B4C, 0x200
+sBeedrillSprites39:
+ax_sprite sBeedrillGfx39, 0x200
+ax_sprite_terminator
+sBeedrillGfx40:
+.incbin "baserom.gba", 0x5B7D5C, 0x200
+sBeedrillSprites40:
+ax_sprite sBeedrillGfx40, 0x200
+ax_sprite_terminator
+sBeedrillGfx41:
+.incbin "baserom.gba", 0x5B7F6C, 0x200
+sBeedrillSprites41:
+ax_sprite sBeedrillGfx41, 0x200
+ax_sprite_terminator
+sBeedrillGfx42:
+.incbin "baserom.gba", 0x5B817C, 0x200
+sBeedrillSprites42:
+ax_sprite sBeedrillGfx42, 0x200
+ax_sprite_terminator
+sBeedrillGfx43:
+.incbin "baserom.gba", 0x5B838C, 0x200
+sBeedrillSprites43:
+ax_sprite sBeedrillGfx43, 0x200
+ax_sprite_terminator
+sBeedrillGfx44:
+.incbin "baserom.gba", 0x5B859C, 0x200
+sBeedrillSprites44:
+ax_sprite sBeedrillGfx44, 0x200
+ax_sprite_terminator
+sBeedrillGfx45:
+.incbin "baserom.gba", 0x5B87AC, 0x200
+sBeedrillSprites45:
+ax_sprite sBeedrillGfx45, 0x200
+ax_sprite_terminator
+sAxPosesBeedrill:
+.4byte sBeedrillPose1
+.4byte sBeedrillPose2
+.4byte sBeedrillPose3
+.4byte sBeedrillPose4
+.4byte sBeedrillPose5
+.4byte sBeedrillPose6
+.4byte sBeedrillPose7
+.4byte sBeedrillPose8
+.4byte sBeedrillPose9
+.4byte sBeedrillPose10
+.4byte sBeedrillPose11
+.4byte sBeedrillPose12
+.4byte sBeedrillPose13
+.4byte sBeedrillPose14
+.4byte sBeedrillPose15
+.4byte sBeedrillPose16
+.4byte sBeedrillPose17
+.4byte sBeedrillPose18
+.4byte sBeedrillPose19
+.4byte sBeedrillPose20
+.4byte sBeedrillPose21
+.4byte sBeedrillPose22
+.4byte sBeedrillPose23
+.4byte sBeedrillPose24
+.4byte sBeedrillPose25
+.4byte sBeedrillPose26
+.4byte sBeedrillPose27
+.4byte sBeedrillPose28
+.4byte sBeedrillPose29
+.4byte sBeedrillPose30
+.4byte sBeedrillPose31
+.4byte sBeedrillPose32
+.4byte sBeedrillPose33
+.4byte sBeedrillPose34
+.4byte sBeedrillPose35
+.4byte sBeedrillPose36
+.4byte sBeedrillPose37
+.4byte sBeedrillPose38
+.4byte sBeedrillPose39
+.4byte sBeedrillPose40
+.4byte sBeedrillPose41
+.4byte sBeedrillPose42
+.4byte sBeedrillPose43
+.4byte sBeedrillPose44
+.4byte sBeedrillPose45
+.4byte sBeedrillPose46
+.4byte sBeedrillPose47
+.4byte sBeedrillPose48
+.4byte sBeedrillPose49
+.4byte sBeedrillPose50
+.4byte sBeedrillPose51
+.4byte sBeedrillPose52
+.4byte sBeedrillPose53
+.4byte sBeedrillPose54
+.4byte sBeedrillPose55
+.4byte sBeedrillPose56
+.4byte sBeedrillPose57
+.4byte sBeedrillPose58
+.4byte sBeedrillPose59
+.4byte sBeedrillPose60
+.4byte sBeedrillPose61
+.4byte sBeedrillPose62
+.4byte sBeedrillPose63
+.4byte sBeedrillPose64
+.4byte sBeedrillPose65
+.4byte sBeedrillPose66
+.4byte sBeedrillPose67
+.4byte sBeedrillPose68
+.4byte sBeedrillPose69
+.4byte sBeedrillPose70
+.4byte sBeedrillPose71
+.4byte sBeedrillPose72
+.4byte sBeedrillPose73
+.4byte sBeedrillPose74
+.4byte sBeedrillPose75
+.4byte sBeedrillPose76
+.4byte sBeedrillPose77
+.4byte sBeedrillPose78
+.4byte sBeedrillPose79
+.4byte sBeedrillPose80
+.4byte sBeedrillPose81
+.4byte sBeedrillPose82
+.4byte sBeedrillPose83
+.4byte sBeedrillPose84
+.4byte sBeedrillPose85
+.4byte sBeedrillPose86
+.4byte sBeedrillPose87
+.4byte sBeedrillPose88
+.4byte sBeedrillPose89
+.4byte sBeedrillPose90
+.4byte sBeedrillPose91
+.4byte sBeedrillPose92
+.4byte sBeedrillPose93
+.4byte sBeedrillPose94
+.4byte sBeedrillPose95
+.4byte sBeedrillPose96
+.4byte sBeedrillPose97
+.4byte sBeedrillPose98
+.4byte sBeedrillPose99
+.4byte sBeedrillPose100
+.4byte sBeedrillPose101
+.4byte sBeedrillPose102
+.4byte sBeedrillPose103
+.4byte sBeedrillPose104
+.4byte sBeedrillPose105
+.4byte sBeedrillPose106
+.4byte sBeedrillPose107
+.4byte sBeedrillPose108
+.4byte sBeedrillPose109
+.4byte sBeedrillPose110
+.4byte sBeedrillPose111
+.4byte sBeedrillPose112
+.4byte sBeedrillPose113
+.4byte sBeedrillPose114
+.4byte sBeedrillPose115
+.4byte sBeedrillPose116
+.4byte sBeedrillPose117
+.4byte sBeedrillPose118
+.4byte sBeedrillPose119
+.4byte sBeedrillPose120
+.4byte sBeedrillPose121
+.4byte sBeedrillPose122
+.4byte sBeedrillPose123
+.4byte sBeedrillPose124
+.4byte sBeedrillPose125
+.4byte sBeedrillPose126
+.4byte sBeedrillPose127
+.4byte sBeedrillPose128
+.4byte sBeedrillPose129
+.4byte sBeedrillPose130
+.4byte sBeedrillPose131
+.4byte sBeedrillPose132
+.4byte sBeedrillPose133
+.4byte sBeedrillPose134
+.4byte sBeedrillPose135
+.4byte sBeedrillPose136
+.4byte sBeedrillPose137
+.4byte sBeedrillPose138
+.4byte sBeedrillPose139
+.4byte sBeedrillPose140
+.4byte sBeedrillPose141
+.4byte sBeedrillPose142
+.4byte sBeedrillPose143
+.4byte sBeedrillPose144
+.4byte sBeedrillPose145
+.4byte sBeedrillPose146
+.4byte sBeedrillPose147
+.4byte sBeedrillPose148
+.4byte sBeedrillPose149
+.4byte sBeedrillPose150
+.4byte sBeedrillPose151
+.4byte sBeedrillPose152
+.4byte sBeedrillPose153
+.4byte sBeedrillPose154
+.4byte sBeedrillPose155
+.4byte sBeedrillPose156
+.4byte sBeedrillPose157
+.4byte sBeedrillPose158
+.4byte sBeedrillPose159
+.4byte sBeedrillPose160
+.4byte sBeedrillPose161
+.4byte sBeedrillPose162
+.4byte sBeedrillPose163
+.4byte sBeedrillPose164
+.4byte sBeedrillPose165
+.4byte sBeedrillPose166
+.4byte sBeedrillPose167
+.4byte sBeedrillPose168
+.4byte sBeedrillPose169
+.4byte sBeedrillPose170
+.4byte sBeedrillPose171
+.4byte sBeedrillPose172
+.4byte sBeedrillPose173
+.4byte sBeedrillPose174
+.4byte sBeedrillPose175
+.4byte sBeedrillPose176
+.4byte sBeedrillPose177
+.4byte sBeedrillPose178
+.4byte sBeedrillPose179
+.4byte sBeedrillPose180
+.4byte sBeedrillPose181
+.4byte sBeedrillPose182
+.4byte sBeedrillPose183
+.4byte sBeedrillPose184
+.4byte sBeedrillPose185
+.4byte sBeedrillPose186
+.4byte sBeedrillPose187
+.4byte sBeedrillPose188
+.4byte sBeedrillPose189
+.4byte sBeedrillPose190
+.4byte sBeedrillPose191
+.4byte sBeedrillPose192
+.4byte sBeedrillPose193
+.4byte sBeedrillPose194
+.4byte sBeedrillPose195
+.4byte sBeedrillPose196
+.4byte sBeedrillPose197
+.4byte sBeedrillPose198
+.4byte sBeedrillPose199
+.4byte sBeedrillPose200
+.4byte sBeedrillPose201
+.4byte sBeedrillPose202
+.4byte sBeedrillPose203
+.4byte sBeedrillPose204
+.4byte sBeedrillPose205
+.4byte sBeedrillPose206
+.4byte sBeedrillPose207
+.4byte sBeedrillPose208
+.4byte sBeedrillPose209
+.4byte sBeedrillPose210
+.4byte sBeedrillPose211
+.4byte sBeedrillPose212
+.4byte sBeedrillPose213
+.4byte sBeedrillPose214
+.4byte sBeedrillPose215
+.4byte sBeedrillPose216
+.4byte sBeedrillPose217
+.4byte sBeedrillPose218
+.4byte sBeedrillPose219
+.4byte sBeedrillPose220
+.4byte sBeedrillPose221
+.4byte sBeedrillPose222
+.4byte sBeedrillPose223
+.4byte sBeedrillPose224
+.4byte sBeedrillPose225
+.4byte sBeedrillPose226
+.4byte sBeedrillPose227
+.4byte sBeedrillPose228
+.4byte sBeedrillPose229
+.4byte sBeedrillPose230
+.4byte sBeedrillPose231
+.4byte sBeedrillPose232
+.4byte sBeedrillPose233
+.4byte sBeedrillPose234
+.4byte sBeedrillPose235
+.4byte sBeedrillPose236
+.4byte sBeedrillPose237
+.4byte sBeedrillPose238
+.4byte sBeedrillPose239
+.4byte sBeedrillPose240
+.4byte sBeedrillPose241
+.4byte sBeedrillPose242
+.4byte sBeedrillPose243
+.4byte sBeedrillPose244
+.4byte sBeedrillPose245
+.4byte sBeedrillPose246
+.4byte sBeedrillPose247
+.4byte sBeedrillPose248
+.4byte sBeedrillPose249
+.4byte sBeedrillPose250
+.4byte sBeedrillPose251
+.4byte sBeedrillPose252
+.4byte sBeedrillPose253
+.4byte sBeedrillPose254
+.4byte sBeedrillPose255
+.4byte sBeedrillPose256
+.4byte sBeedrillPose257
+.4byte sBeedrillPose258
+sAxPositionsBeedrill:
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,   -2, 	 -11,   -7, 	   9,   -7, 	  -1,  -11
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,  -13
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+.2byte    4,   -3, 	  12,  -11, 	  -1,   -4, 	   0,  -11
+.2byte    4,   -5, 	  12,  -13, 	  -1,   -6, 	   0,  -13
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    7,   -7, 	  10,  -16, 	   9,  -10, 	  -2,  -11
+.2byte    7,   -9, 	  10,  -18, 	   9,  -12, 	  -2,  -13
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    6,   -9, 	  -1,  -19, 	  10,  -15, 	  -2,  -12
+.2byte    6,  -11, 	  -1,  -21, 	  10,  -17, 	  -1,  -13
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte   -1,  -13, 	   8,  -19, 	 -10,  -19, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -20, 	 -10,  -20, 	  -1,  -13
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -8,   -9, 	  -1,  -19, 	 -12,  -15, 	   0,  -12
+.2byte   -8,  -11, 	  -1,  -21, 	 -12,  -17, 	  -1,  -13
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -9,   -7, 	 -12,  -16, 	 -11,  -10, 	   0,  -11
+.2byte   -9,   -9, 	 -12,  -18, 	 -11,  -12, 	   0,  -13
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -6,   -3, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -6,   -5, 	 -14,  -13, 	  -1,   -6, 	  -2,  -13
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,   -2, 	 -11,   -7, 	   9,   -7, 	  -1,  -11
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,  -13
+.2byte   -1,   -8, 	 -10,    1, 	   8,    1, 	  -1,  -11
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+.2byte    4,   -3, 	  12,  -11, 	  -1,   -4, 	   0,  -11
+.2byte    4,   -5, 	  12,  -13, 	  -1,   -6, 	   0,  -13
+.2byte    3,  -11, 	  13,   -8, 	   1,   -3, 	  -1,  -13
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    7,   -7, 	  10,  -16, 	   9,  -10, 	  -2,  -11
+.2byte    7,   -9, 	  10,  -18, 	   9,  -12, 	  -2,  -13
+.2byte    3,  -12, 	  13,  -14, 	  12,   -8, 	   0,  -13
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    6,   -9, 	  -1,  -19, 	  10,  -15, 	  -2,  -12
+.2byte    6,  -11, 	  -1,  -21, 	  10,  -17, 	  -1,  -13
+.2byte    5,  -16, 	   1,  -20, 	  13,  -17, 	   0,  -16
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte   -1,  -13, 	   8,  -19, 	 -10,  -19, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -20, 	 -10,  -20, 	  -1,  -13
+.2byte   -1,  -17, 	   6,  -23, 	  -8,  -23, 	  -1,  -13
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -8,   -9, 	  -1,  -19, 	 -12,  -15, 	   0,  -12
+.2byte   -8,  -11, 	  -1,  -21, 	 -12,  -17, 	  -1,  -13
+.2byte   -7,  -16, 	  -3,  -20, 	 -15,  -17, 	  -2,  -16
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -9,   -7, 	 -12,  -16, 	 -11,  -10, 	   0,  -11
+.2byte   -9,   -9, 	 -12,  -18, 	 -11,  -12, 	   0,  -13
+.2byte   -5,  -12, 	 -15,  -14, 	 -14,   -8, 	  -2,  -13
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -6,   -3, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -6,   -5, 	 -14,  -13, 	  -1,   -6, 	  -2,  -13
+.2byte   -5,  -11, 	 -15,   -8, 	  -3,   -3, 	  -1,  -13
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,   -2, 	 -11,   -7, 	   9,   -7, 	  -1,  -11
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,  -13
+.2byte   -1,   -8, 	 -10,    1, 	   8,    1, 	  -1,  -11
+.2byte    4,  -12, 	   5,    0, 	  13,  -20, 	  -1,  -13
+.2byte    4,  -12, 	   5,    0, 	  13,  -20, 	  -1,  -13
+.2byte   -5,  -12, 	 -14,  -20, 	  -6,    0, 	   0,  -13
+.2byte   -5,  -12, 	 -14,  -20, 	  -6,    0, 	   0,  -13
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+.2byte    4,   -3, 	  12,  -11, 	  -1,   -4, 	   0,  -11
+.2byte    4,   -5, 	  12,  -13, 	  -1,   -6, 	   0,  -13
+.2byte    3,  -10, 	  13,   -7, 	   1,   -2, 	  -1,  -12
+.2byte   -3,  -13, 	   1,    1, 	 -15,  -15, 	  -2,  -12
+.2byte   -3,  -13, 	   1,    1, 	 -15,  -15, 	  -2,  -12
+.2byte    3,  -12, 	   9,  -21, 	  10,   -4, 	  -1,  -12
+.2byte    3,  -12, 	   9,  -21, 	  10,   -4, 	  -1,  -12
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    7,   -7, 	  10,  -16, 	   9,  -10, 	  -2,  -11
+.2byte    7,   -9, 	  10,  -18, 	   9,  -12, 	  -2,  -13
+.2byte    3,  -10, 	  13,  -12, 	  12,   -6, 	   0,  -11
+.2byte    0,  -11, 	   9,   -3, 	  -7,   -7, 	  -4,  -12
+.2byte    0,  -11, 	   9,   -3, 	  -7,   -7, 	  -4,  -12
+.2byte    1,  -11, 	  -2,  -13, 	  10,   -3, 	  -4,  -11
+.2byte    1,  -11, 	  -2,  -13, 	  10,   -3, 	  -4,  -11
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    6,   -9, 	  -1,  -19, 	  10,  -15, 	  -2,  -12
+.2byte    6,  -11, 	  -1,  -21, 	  10,  -17, 	  -1,  -13
+.2byte    5,  -16, 	   1,  -20, 	  13,  -17, 	   0,  -16
+.2byte    2,  -14, 	   9,   -9, 	   8,  -12, 	  -4,  -15
+.2byte    2,  -14, 	   9,   -9, 	   8,  -12, 	  -4,  -15
+.2byte   -6,  -16, 	 -15,  -17, 	  -5,  -17, 	  -5,  -14
+.2byte   -6,  -16, 	 -15,  -17, 	  -5,  -17, 	  -5,  -14
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte   -1,  -13, 	   8,  -19, 	 -10,  -19, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -20, 	 -10,  -20, 	  -1,  -13
+.2byte   -1,  -17, 	   6,  -23, 	  -8,  -23, 	  -1,  -13
+.2byte   -5,  -16, 	 -10,  -11, 	 -15,  -16, 	  -1,  -14
+.2byte   -5,  -16, 	 -10,  -11, 	 -15,  -16, 	  -1,  -14
+.2byte    4,  -16, 	  14,  -16, 	   9,  -11, 	   0,  -14
+.2byte    4,  -16, 	  14,  -16, 	   9,  -11, 	   0,  -14
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -8,   -9, 	  -1,  -19, 	 -12,  -15, 	   0,  -12
+.2byte   -8,  -11, 	  -1,  -21, 	 -12,  -17, 	  -1,  -13
+.2byte   -7,  -16, 	  -3,  -20, 	 -15,  -17, 	  -2,  -16
+.2byte   -4,  -14, 	 -11,   -9, 	 -10,  -12, 	   2,  -15
+.2byte   -4,  -14, 	 -11,   -9, 	 -10,  -12, 	   2,  -15
+.2byte    4,  -16, 	  13,  -17, 	   3,  -17, 	   3,  -14
+.2byte    4,  -16, 	  13,  -17, 	   3,  -17, 	   3,  -14
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -9,   -7, 	 -12,  -16, 	 -11,  -10, 	   0,  -11
+.2byte   -9,   -9, 	 -12,  -18, 	 -11,  -12, 	   0,  -13
+.2byte   -5,  -10, 	 -15,  -12, 	 -14,   -6, 	  -2,  -11
+.2byte   -2,  -11, 	 -11,   -3, 	   5,   -7, 	   2,  -12
+.2byte   -2,  -11, 	 -11,   -3, 	   5,   -7, 	   2,  -12
+.2byte   -3,  -11, 	   0,  -13, 	 -12,   -3, 	   2,  -11
+.2byte   -3,  -11, 	   0,  -13, 	 -12,   -3, 	   2,  -11
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -6,   -3, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -6,   -5, 	 -14,  -13, 	  -1,   -6, 	  -2,  -13
+.2byte   -5,  -10, 	 -15,   -7, 	  -3,   -2, 	  -1,  -12
+.2byte    1,  -13, 	  -3,    1, 	  13,  -15, 	   0,  -12
+.2byte    1,  -13, 	  -3,    1, 	  13,  -15, 	   0,  -12
+.2byte   -5,  -12, 	 -11,  -21, 	 -12,   -4, 	  -1,  -12
+.2byte   -5,  -12, 	 -11,  -21, 	 -12,   -4, 	  -1,  -12
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,   -3, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -1,   -3, 	 -11,   -7, 	   9,   -7, 	  -1,  -12
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+.2byte    4,   -4, 	  12,  -12, 	  -1,   -5, 	   0,  -12
+.2byte    4,   -4, 	  12,  -12, 	  -1,   -5, 	   0,  -12
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    7,   -8, 	  10,  -17, 	   9,  -11, 	  -2,  -12
+.2byte    7,   -8, 	  10,  -17, 	   9,  -11, 	  -2,  -12
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    6,  -10, 	  -1,  -20, 	  10,  -16, 	  -2,  -13
+.2byte    6,  -10, 	  -1,  -20, 	  10,  -16, 	  -1,  -12
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte   -1,  -14, 	   8,  -20, 	 -10,  -20, 	  -1,  -12
+.2byte   -1,  -14, 	   8,  -19, 	 -10,  -19, 	  -1,  -12
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -8,  -10, 	  -1,  -20, 	 -12,  -16, 	   0,  -13
+.2byte   -8,  -10, 	  -1,  -20, 	 -12,  -16, 	  -1,  -12
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -9,   -8, 	 -12,  -17, 	 -11,  -11, 	   0,  -12
+.2byte   -9,   -8, 	 -12,  -17, 	 -11,  -11, 	   0,  -12
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -6,   -4, 	 -14,  -12, 	  -1,   -5, 	  -2,  -12
+.2byte   -6,   -4, 	 -14,  -12, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,   -2, 	 -11,   -7, 	   9,   -7, 	  -1,  -11
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,  -13
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+.2byte    4,   -3, 	  12,  -11, 	  -1,   -4, 	   0,  -11
+.2byte    4,   -5, 	  12,  -13, 	  -1,   -6, 	   0,  -13
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    7,   -7, 	  10,  -16, 	   9,  -10, 	  -2,  -11
+.2byte    7,   -9, 	  10,  -18, 	   9,  -12, 	  -2,  -13
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    6,   -9, 	  -1,  -19, 	  10,  -15, 	  -2,  -12
+.2byte    6,  -11, 	  -1,  -21, 	  10,  -17, 	  -1,  -13
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte   -1,  -13, 	   8,  -19, 	 -10,  -19, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -20, 	 -10,  -20, 	  -1,  -13
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -8,   -9, 	  -1,  -19, 	 -12,  -15, 	   0,  -12
+.2byte   -8,  -11, 	  -1,  -21, 	 -12,  -17, 	  -1,  -13
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -9,   -7, 	 -12,  -16, 	 -11,  -10, 	   0,  -11
+.2byte   -9,   -9, 	 -12,  -18, 	 -11,  -12, 	   0,  -13
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -6,   -3, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -6,   -5, 	 -14,  -13, 	  -1,   -6, 	  -2,  -13
+.2byte   -2,  -16, 	  -5,   -6, 	   5,   -1, 	   1,  -14
+.2byte   -1,  -17, 	  -5,   -7, 	   5,   -2, 	   1,  -14
+.2byte    0,   -9, 	   2,  -20, 	  -1,  -19, 	   0,   -8
+.2byte    0,   -9, 	  -1,  -18, 	   0,  -19, 	  -2,   -9
+.2byte   -1,   -9, 	   1,  -19, 	   3,  -16, 	  -3,   -8
+.2byte    0,  -11, 	  -1,  -15, 	   0,  -16, 	  -4,   -6
+.2byte   -1,  -11, 	  -2,  -19, 	  -1,  -20, 	  -1,   -7
+.2byte   -1,  -11, 	   0,  -15, 	  -1,  -16, 	   3,   -6
+.2byte    0,   -9, 	  -2,  -19, 	  -4,  -16, 	   2,   -8
+.2byte   -1,   -8, 	   0,  -17, 	  -1,  -18, 	   1,   -8
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,   -2, 	 -11,   -7, 	   9,   -7, 	  -1,  -11
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,  -13
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+.2byte    4,   -3, 	  12,  -11, 	  -1,   -4, 	   0,  -11
+.2byte    4,   -5, 	  12,  -13, 	  -1,   -6, 	   0,  -13
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    7,   -7, 	  10,  -16, 	   9,  -10, 	  -2,  -11
+.2byte    7,   -9, 	  10,  -18, 	   9,  -12, 	  -2,  -13
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    6,   -9, 	  -1,  -19, 	  10,  -15, 	  -2,  -12
+.2byte    6,  -11, 	  -1,  -21, 	  10,  -17, 	  -1,  -13
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte   -1,  -13, 	   8,  -19, 	 -10,  -19, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -20, 	 -10,  -20, 	  -1,  -13
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -8,   -9, 	  -1,  -19, 	 -12,  -15, 	   0,  -12
+.2byte   -8,  -11, 	  -1,  -21, 	 -12,  -17, 	  -1,  -13
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -9,   -7, 	 -12,  -16, 	 -11,  -10, 	   0,  -11
+.2byte   -9,   -9, 	 -12,  -18, 	 -11,  -12, 	   0,  -13
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -6,   -3, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -6,   -5, 	 -14,  -13, 	  -1,   -6, 	  -2,  -13
+.2byte   -1,   -8, 	 -10,    1, 	   8,    1, 	  -1,  -11
+.2byte   -5,  -11, 	 -15,   -8, 	  -3,   -3, 	  -1,  -13
+.2byte   -5,  -12, 	 -15,  -14, 	 -14,   -8, 	  -2,  -13
+.2byte   -7,  -16, 	  -3,  -20, 	 -15,  -17, 	  -2,  -16
+.2byte   -1,  -17, 	   6,  -23, 	  -8,  -23, 	  -1,  -13
+.2byte    5,  -16, 	   1,  -20, 	  13,  -17, 	   0,  -16
+.2byte    3,  -12, 	  13,  -14, 	  12,   -8, 	   0,  -13
+.2byte    3,  -11, 	  13,   -8, 	   1,   -3, 	  -1,  -13
+.2byte   -1,  -10, 	 -10,   -1, 	   8,   -1, 	  -1,  -13
+.2byte    3,  -11, 	  13,   -8, 	   1,   -3, 	  -1,  -13
+.2byte    1,  -12, 	  11,  -14, 	  10,   -8, 	  -2,  -13
+.2byte    4,  -14, 	   0,  -18, 	  12,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   6,  -23, 	  -8,  -23, 	  -1,  -13
+.2byte   -6,  -14, 	  -2,  -18, 	 -14,  -15, 	  -1,  -14
+.2byte   -3,  -12, 	 -13,  -14, 	 -12,   -8, 	   0,  -13
+.2byte   -5,  -11, 	 -15,   -8, 	  -3,   -3, 	  -1,  -13
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,  -13
+.2byte   -1,   -8, 	 -10,    1, 	   8,    1, 	  -1,  -11
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+.2byte    4,   -5, 	  12,  -13, 	  -1,   -6, 	   0,  -13
+.2byte    3,  -11, 	  13,   -8, 	   1,   -3, 	  -1,  -13
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    7,   -9, 	  10,  -18, 	   9,  -12, 	  -2,  -13
+.2byte    3,  -12, 	  13,  -14, 	  12,   -8, 	   0,  -13
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    6,  -11, 	  -1,  -21, 	  10,  -17, 	  -1,  -13
+.2byte    5,  -16, 	   1,  -20, 	  13,  -17, 	   0,  -16
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte   -1,  -15, 	   8,  -20, 	 -10,  -20, 	  -1,  -13
+.2byte   -1,  -17, 	   6,  -23, 	  -8,  -23, 	  -1,  -13
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -8,  -11, 	  -1,  -21, 	 -12,  -17, 	  -1,  -13
+.2byte   -7,  -16, 	  -3,  -20, 	 -15,  -17, 	  -2,  -16
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -9,   -9, 	 -12,  -18, 	 -11,  -12, 	   0,  -13
+.2byte   -5,  -12, 	 -15,  -14, 	 -14,   -8, 	  -2,  -13
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -6,   -5, 	 -14,  -13, 	  -1,   -6, 	  -2,  -13
+.2byte   -5,  -11, 	 -15,   -8, 	  -3,   -3, 	  -1,  -13
+.2byte   -1,   -2, 	 -11,   -7, 	   9,   -7, 	  -1,  -11
+.2byte   -6,   -3, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -9,   -7, 	 -12,  -16, 	 -11,  -10, 	   0,  -11
+.2byte   -8,   -9, 	  -1,  -19, 	 -12,  -15, 	   0,  -12
+.2byte   -1,  -13, 	   8,  -19, 	 -10,  -19, 	  -1,  -11
+.2byte    6,   -9, 	  -1,  -19, 	  10,  -15, 	  -2,  -12
+.2byte    7,   -7, 	  10,  -16, 	   9,  -10, 	  -2,  -11
+.2byte    4,   -3, 	  12,  -11, 	  -1,   -4, 	   0,  -11
+.2byte   -1,   -3, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -6,   -4, 	 -15,  -11, 	  -2,   -4, 	  -2,  -12
+.2byte   -9,   -8, 	 -13,  -17, 	 -12,  -11, 	   0,  -12
+.2byte   -8,  -10, 	  -1,  -20, 	 -13,  -17, 	  -1,  -12
+.2byte   -1,  -14, 	   8,  -21, 	 -10,  -21, 	  -1,  -12
+.2byte    6,  -10, 	  -1,  -20, 	  11,  -17, 	  -1,  -12
+.2byte    7,   -8, 	  11,  -17, 	  10,  -11, 	  -2,  -12
+.2byte    4,   -4, 	  13,  -11, 	   0,   -4, 	   0,  -12
+sBeedrillAnimTable1:
+.4byte sBeedrillAnims_1_1
+.4byte sBeedrillAnims_1_2
+.4byte sBeedrillAnims_1_3
+.4byte sBeedrillAnims_1_4
+.4byte sBeedrillAnims_1_5
+.4byte sBeedrillAnims_1_6
+.4byte sBeedrillAnims_1_7
+.4byte sBeedrillAnims_1_8
+sBeedrillAnimTable2:
+.4byte sBeedrillAnims_2_1
+.4byte sBeedrillAnims_2_2
+.4byte sBeedrillAnims_2_3
+.4byte sBeedrillAnims_2_4
+.4byte sBeedrillAnims_2_5
+.4byte sBeedrillAnims_2_6
+.4byte sBeedrillAnims_2_7
+.4byte sBeedrillAnims_2_8
+sBeedrillAnimTable3:
+.4byte sBeedrillAnims_3_1
+.4byte sBeedrillAnims_3_2
+.4byte sBeedrillAnims_3_3
+.4byte sBeedrillAnims_3_4
+.4byte sBeedrillAnims_3_5
+.4byte sBeedrillAnims_3_6
+.4byte sBeedrillAnims_3_7
+.4byte sBeedrillAnims_3_8
+sBeedrillAnimTable4:
+.4byte sBeedrillAnims_4_1
+.4byte sBeedrillAnims_4_2
+.4byte sBeedrillAnims_4_3
+.4byte sBeedrillAnims_4_4
+.4byte sBeedrillAnims_4_5
+.4byte sBeedrillAnims_4_6
+.4byte sBeedrillAnims_4_7
+.4byte sBeedrillAnims_4_8
+sBeedrillAnimTable5:
+.4byte sBeedrillAnims_5_1
+.4byte sBeedrillAnims_5_2
+.4byte sBeedrillAnims_5_3
+.4byte sBeedrillAnims_5_4
+.4byte sBeedrillAnims_5_5
+.4byte sBeedrillAnims_5_6
+.4byte sBeedrillAnims_5_7
+.4byte sBeedrillAnims_5_8
+sBeedrillAnimTable6:
+.4byte sBeedrillAnims_6_1
+.4byte sBeedrillAnims_6_1
+.4byte sBeedrillAnims_6_1
+.4byte sBeedrillAnims_6_1
+.4byte sBeedrillAnims_6_1
+.4byte sBeedrillAnims_6_1
+.4byte sBeedrillAnims_6_1
+.4byte sBeedrillAnims_6_1
+sBeedrillAnimTable7:
+.4byte sBeedrillAnims_7_1
+.4byte sBeedrillAnims_7_2
+.4byte sBeedrillAnims_7_3
+.4byte sBeedrillAnims_7_4
+.4byte sBeedrillAnims_7_5
+.4byte sBeedrillAnims_7_6
+.4byte sBeedrillAnims_7_7
+.4byte sBeedrillAnims_7_8
+sBeedrillAnimTable8:
+.4byte sBeedrillAnims_8_1
+.4byte sBeedrillAnims_8_2
+.4byte sBeedrillAnims_8_3
+.4byte sBeedrillAnims_8_4
+.4byte sBeedrillAnims_8_5
+.4byte sBeedrillAnims_8_6
+.4byte sBeedrillAnims_8_7
+.4byte sBeedrillAnims_8_8
+sBeedrillAnimTable9:
+.4byte sBeedrillAnims_9_1
+.4byte sBeedrillAnims_9_2
+.4byte sBeedrillAnims_9_3
+.4byte sBeedrillAnims_9_4
+.4byte sBeedrillAnims_9_5
+.4byte sBeedrillAnims_9_6
+.4byte sBeedrillAnims_9_7
+.4byte sBeedrillAnims_9_8
+sBeedrillAnimTable10:
+.4byte sBeedrillAnims_10_1
+.4byte sBeedrillAnims_10_2
+.4byte sBeedrillAnims_10_3
+.4byte sBeedrillAnims_10_4
+.4byte sBeedrillAnims_10_5
+.4byte sBeedrillAnims_10_6
+.4byte sBeedrillAnims_10_7
+.4byte sBeedrillAnims_10_8
+sBeedrillAnimTable11:
+.4byte sBeedrillAnims_11_1
+.4byte sBeedrillAnims_11_2
+.4byte sBeedrillAnims_11_3
+.4byte sBeedrillAnims_11_4
+.4byte sBeedrillAnims_11_5
+.4byte sBeedrillAnims_11_6
+.4byte sBeedrillAnims_11_7
+.4byte sBeedrillAnims_11_8
+sBeedrillAnimTable12:
+.4byte sBeedrillAnims_12_1
+.4byte sBeedrillAnims_12_2
+.4byte sBeedrillAnims_12_3
+.4byte sBeedrillAnims_12_4
+.4byte sBeedrillAnims_12_5
+.4byte sBeedrillAnims_12_6
+.4byte sBeedrillAnims_12_7
+.4byte sBeedrillAnims_12_8
+sBeedrillAnimTable13:
+.4byte sBeedrillAnims_13_1
+.4byte sBeedrillAnims_13_2
+.4byte sBeedrillAnims_13_3
+.4byte sBeedrillAnims_13_4
+.4byte sBeedrillAnims_13_5
+.4byte sBeedrillAnims_13_6
+.4byte sBeedrillAnims_13_7
+.4byte sBeedrillAnims_13_8
+sAxAnimationsBeedrill:
+.4byte sBeedrillAnimTable1
+.4byte sBeedrillAnimTable2
+.4byte sBeedrillAnimTable3
+.4byte sBeedrillAnimTable4
+.4byte sBeedrillAnimTable5
+.4byte sBeedrillAnimTable6
+.4byte sBeedrillAnimTable7
+.4byte sBeedrillAnimTable8
+.4byte sBeedrillAnimTable9
+.4byte sBeedrillAnimTable10
+.4byte sBeedrillAnimTable11
+.4byte sBeedrillAnimTable12
+.4byte sBeedrillAnimTable13
+sAxSpritesBeedrill:
+.4byte sBeedrillSprites1
+.4byte sBeedrillSprites2
+.4byte sBeedrillSprites3
+.4byte sBeedrillSprites4
+.4byte sBeedrillSprites5
+.4byte sBeedrillSprites6
+.4byte sBeedrillSprites7
+.4byte sBeedrillSprites8
+.4byte sBeedrillSprites9
+.4byte sBeedrillSprites10
+.4byte sBeedrillSprites11
+.4byte sBeedrillSprites12
+.4byte sBeedrillSprites13
+.4byte sBeedrillSprites14
+.4byte sBeedrillSprites15
+.4byte sBeedrillSprites16
+.4byte sBeedrillSprites17
+.4byte sBeedrillSprites18
+.4byte sBeedrillSprites19
+.4byte sBeedrillSprites20
+.4byte sBeedrillSprites21
+.4byte sBeedrillSprites22
+.4byte sBeedrillSprites23
+.4byte sBeedrillSprites24
+.4byte sBeedrillSprites25
+.4byte sBeedrillSprites26
+.4byte sBeedrillSprites27
+.4byte sBeedrillSprites28
+.4byte sBeedrillSprites29
+.4byte sBeedrillSprites30
+.4byte sBeedrillSprites31
+.4byte sBeedrillSprites32
+.4byte sBeedrillSprites33
+.4byte sBeedrillSprites34
+.4byte sBeedrillSprites35
+.4byte sBeedrillSprites36
+.4byte sBeedrillSprites37
+.4byte sBeedrillSprites38
+.4byte sBeedrillSprites39
+.4byte sBeedrillSprites40
+.4byte sBeedrillSprites41
+.4byte sBeedrillSprites42
+.4byte sBeedrillSprites43
+.4byte sBeedrillSprites44
+.4byte sBeedrillSprites45
+sAxMainBeedrill:
+ax_main sAxPosesBeedrill, sAxAnimationsBeedrill, 13, sAxSpritesBeedrill, sAxPositionsBeedrill

--- a/data/ax/beldum.inc
+++ b/data/ax/beldum.inc
@@ -1,0 +1,2422 @@
+.global gAxBeldum
+gAxBeldum:
+ax_siro sAxMainBeldum
+sBeldumPose1:
+ax_pose 0, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose2:
+ax_pose 1, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose3:
+ax_pose 2, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose4:
+ax_pose 3, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose5:
+ax_pose 4, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose6:
+ax_pose 5, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose7:
+ax_pose 6, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose8:
+ax_pose 7, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose9:
+ax_pose 8, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose10:
+ax_pose 9, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose11:
+ax_pose 10, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose12:
+ax_pose 11, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose13:
+ax_pose 12, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose14:
+ax_pose 13, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose15:
+ax_pose 14, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose16:
+ax_pose 9, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose17:
+ax_pose 10, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose18:
+ax_pose 11, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose19:
+ax_pose 6, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose20:
+ax_pose 7, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose21:
+ax_pose 8, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose22:
+ax_pose 3, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose23:
+ax_pose 4, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose24:
+ax_pose 5, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose25:
+ax_pose 0, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose26:
+ax_pose 1, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose27:
+ax_pose 2, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose28:
+ax_pose 3, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose29:
+ax_pose 4, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose30:
+ax_pose 5, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose31:
+ax_pose 6, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose32:
+ax_pose 7, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose33:
+ax_pose 8, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose34:
+ax_pose 9, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose35:
+ax_pose 10, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose36:
+ax_pose 11, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose37:
+ax_pose 12, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose38:
+ax_pose 13, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose39:
+ax_pose 14, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose40:
+ax_pose 9, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose41:
+ax_pose 10, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose42:
+ax_pose 11, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose43:
+ax_pose 6, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose44:
+ax_pose 7, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose45:
+ax_pose 8, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose46:
+ax_pose 3, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose47:
+ax_pose 4, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose48:
+ax_pose 5, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose49:
+ax_pose 0, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose50:
+ax_pose 1, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose51:
+ax_pose 2, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose52:
+ax_pose 3, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose53:
+ax_pose 4, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose54:
+ax_pose 5, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose55:
+ax_pose 6, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose56:
+ax_pose 7, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose57:
+ax_pose 8, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose58:
+ax_pose 9, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose59:
+ax_pose 10, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose60:
+ax_pose 11, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose61:
+ax_pose 12, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose62:
+ax_pose 13, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose63:
+ax_pose 14, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose64:
+ax_pose 9, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose65:
+ax_pose 10, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose66:
+ax_pose 11, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose67:
+ax_pose 6, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose68:
+ax_pose 7, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose69:
+ax_pose 8, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose70:
+ax_pose 3, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose71:
+ax_pose 4, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose72:
+ax_pose 5, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose73:
+ax_pose 0, 0x81ed, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose74:
+ax_pose 3, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose75:
+ax_pose 6, 0x41f1, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose76:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose77:
+ax_pose 12, 0x81ee, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose78:
+ax_pose 9, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose79:
+ax_pose 6, 0x41f1, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose80:
+ax_pose 3, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose81:
+ax_pose 0, 0x81ed, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose82:
+ax_pose 3, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose83:
+ax_pose 6, 0x41f1, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose84:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose85:
+ax_pose 12, 0x81ee, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose86:
+ax_pose 9, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose87:
+ax_pose 6, 0x41f1, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose88:
+ax_pose 3, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose89:
+ax_pose 15, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose90:
+ax_pose 16, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose91:
+ax_pose 17, 0x01dd, 0x80f2, 0xbc00
+ax_pose_terminator
+sBeldumPose92:
+ax_pose 18, 0x01de, 0x90e8, 0xbc00
+ax_pose_terminator
+sBeldumPose93:
+ax_pose 19, 0x41e2, 0x90ea, 0xbc00
+ax_pose 20, 0x01f2, 0x50fa, 0xbc08
+ax_pose 21, 0x81f2, 0x10f2, 0xbc0c
+ax_pose 22, 0x01da, 0x10ea, 0xbc0e
+ax_pose_terminator
+sBeldumPose94:
+ax_pose 23, 0x41e1, 0x90eb, 0xbc00
+ax_pose 24, 0x01f1, 0x50fb, 0xbc08
+ax_pose 25, 0x81f1, 0x10f3, 0xbc0c
+ax_pose 26, 0x01d9, 0x10eb, 0xbc0e
+ax_pose_terminator
+sBeldumPose95:
+ax_pose 27, 0x01df, 0x80f5, 0xbc00
+ax_pose_terminator
+sBeldumPose96:
+ax_pose 23, 0x41e1, 0x80f5, 0xbc00
+ax_pose 24, 0x01f1, 0x40f5, 0xbc08
+ax_pose 25, 0x81f1, 0x0105, 0xbc0c
+ax_pose 26, 0x01d9, 0x010d, 0xbc0e
+ax_pose_terminator
+sBeldumPose97:
+ax_pose 19, 0x41e2, 0x80f6, 0xbc00
+ax_pose 20, 0x01f2, 0x40f6, 0xbc08
+ax_pose 21, 0x81f2, 0x0106, 0xbc0c
+ax_pose 22, 0x01da, 0x010e, 0xbc0e
+ax_pose_terminator
+sBeldumPose98:
+ax_pose 18, 0x01de, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose99:
+ax_pose 0, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose100:
+ax_pose 1, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose101:
+ax_pose 2, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose102:
+ax_pose 3, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose103:
+ax_pose 4, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose104:
+ax_pose 5, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose105:
+ax_pose 6, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose106:
+ax_pose 7, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose107:
+ax_pose 8, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose108:
+ax_pose 9, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose109:
+ax_pose 10, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose110:
+ax_pose 11, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose111:
+ax_pose 12, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose112:
+ax_pose 13, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose113:
+ax_pose 14, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose114:
+ax_pose 9, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose115:
+ax_pose 10, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose116:
+ax_pose 11, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose117:
+ax_pose 6, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose118:
+ax_pose 7, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose119:
+ax_pose 8, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose120:
+ax_pose 3, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose121:
+ax_pose 4, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose122:
+ax_pose 5, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose123:
+ax_pose 0, 0x81ed, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose124:
+ax_pose 3, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose125:
+ax_pose 6, 0x41f1, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose126:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose127:
+ax_pose 12, 0x81ee, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose128:
+ax_pose 9, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose129:
+ax_pose 6, 0x41f1, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose130:
+ax_pose 3, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose131:
+ax_pose 0, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose132:
+ax_pose 3, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose133:
+ax_pose 6, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose134:
+ax_pose 9, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose135:
+ax_pose 12, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose136:
+ax_pose 9, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose137:
+ax_pose 6, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose138:
+ax_pose 3, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose139:
+ax_pose 0, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose140:
+ax_pose 1, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose141:
+ax_pose 2, 0x81e9, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose142:
+ax_pose 3, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose143:
+ax_pose 4, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose144:
+ax_pose 5, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose145:
+ax_pose 6, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose146:
+ax_pose 7, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose147:
+ax_pose 8, 0x41ed, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose148:
+ax_pose 9, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose149:
+ax_pose 10, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose150:
+ax_pose 11, 0x01e9, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose151:
+ax_pose 12, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose152:
+ax_pose 13, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose153:
+ax_pose 14, 0x81ea, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose154:
+ax_pose 9, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose155:
+ax_pose 10, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose156:
+ax_pose 11, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose157:
+ax_pose 6, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose158:
+ax_pose 7, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose159:
+ax_pose 8, 0x41ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose160:
+ax_pose 3, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose161:
+ax_pose 4, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose162:
+ax_pose 5, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose163:
+ax_pose 0, 0x81ed, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose164:
+ax_pose 3, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose165:
+ax_pose 6, 0x41f1, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose166:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose167:
+ax_pose 12, 0x81ee, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose168:
+ax_pose 9, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose169:
+ax_pose 6, 0x41f1, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose170:
+ax_pose 3, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose171:
+ax_pose 0, 0x81ed, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose172:
+ax_pose 3, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose173:
+ax_pose 6, 0x41f1, 0x80f0, 0xbc00
+ax_pose_terminator
+sBeldumPose174:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sBeldumPose175:
+ax_pose 12, 0x81ee, 0x80f8, 0xbc00
+ax_pose_terminator
+sBeldumPose176:
+ax_pose 9, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+sBeldumPose177:
+ax_pose 6, 0x41f1, 0x90f0, 0xbc00
+ax_pose_terminator
+sBeldumPose178:
+ax_pose 3, 0x01ed, 0x90ec, 0xbc00
+ax_pose_terminator
+.align 2
+sBeldumAnims_1_1:
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -4, 0, 0,
+ax_anim 8, 0, 2, 0, -5, 0, 0,
+ax_anim 8, 0, 0, 0, -5, 0, 0,
+ax_anim 8, 0, 1, 0, -4, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sBeldumAnims_1_2:
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -4, 0, 0,
+ax_anim 8, 0, 5, 0, -5, 0, 0,
+ax_anim 8, 0, 3, 0, -5, 0, 0,
+ax_anim 8, 0, 4, 0, -4, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sBeldumAnims_1_3:
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -4, 0, 0,
+ax_anim 8, 0, 8, 0, -5, 0, 0,
+ax_anim 8, 0, 6, 0, -5, 0, 0,
+ax_anim 8, 0, 7, 0, -4, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sBeldumAnims_1_4:
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -4, 0, 0,
+ax_anim 8, 0, 11, 0, -5, 0, 0,
+ax_anim 8, 0, 9, 0, -5, 0, 0,
+ax_anim 8, 0, 10, 0, -4, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sBeldumAnims_1_5:
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -4, 0, 0,
+ax_anim 8, 0, 14, 0, -5, 0, 0,
+ax_anim 8, 0, 12, 0, -5, 0, 0,
+ax_anim 8, 0, 13, 0, -4, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sBeldumAnims_1_6:
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -4, 0, 0,
+ax_anim 8, 0, 17, 0, -5, 0, 0,
+ax_anim 8, 0, 15, 0, -5, 0, 0,
+ax_anim 8, 0, 16, 0, -4, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sBeldumAnims_1_7:
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 18, 0, -4, 0, 0,
+ax_anim 8, 0, 20, 0, -5, 0, 0,
+ax_anim 8, 0, 18, 0, -5, 0, 0,
+ax_anim 8, 0, 19, 0, -4, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sBeldumAnims_1_8:
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 21, 0, -4, 0, 0,
+ax_anim 8, 0, 23, 0, -5, 0, 0,
+ax_anim 8, 0, 21, 0, -5, 0, 0,
+ax_anim 8, 0, 22, 0, -4, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 1, 25, 0, 21, 0, 18,
+ax_anim 2, 0, 25, 1, 21, 1, 18,
+ax_anim 2, 0, 25, 0, 21, 0, 18,
+ax_anim 2, 0, 25, 1, 21, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBeldumAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 10, 11, 10, 11,
+ax_anim 1, 0, 29, 16, 20, 16, 17,
+ax_anim 2, 1, 28, 20, 23, 20, 20,
+ax_anim 2, 0, 28, 21, 22, 21, 19,
+ax_anim 2, 0, 28, 20, 23, 20, 20,
+ax_anim 2, 0, 28, 21, 22, 21, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sBeldumAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 1, 31, 21, 2, 21, 0,
+ax_anim 2, 0, 31, 21, 3, 21, 1,
+ax_anim 2, 0, 31, 21, 2, 21, 0,
+ax_anim 2, 0, 31, 21, 3, 21, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sBeldumAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 4, -5, 4, -5,
+ax_anim 1, 0, 35, 10, -11, 10, -11,
+ax_anim 2, 1, 34, 20, -18, 21, -20,
+ax_anim 2, 0, 34, 21, -17, 22, -19,
+ax_anim 2, 0, 34, 20, -18, 21, -20,
+ax_anim 2, 0, 34, 21, -17, 22, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sBeldumAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 1, 37, 0, -18, 0, -22,
+ax_anim 2, 0, 37, 1, -18, 1, -22,
+ax_anim 2, 0, 37, 0, -18, 0, -22,
+ax_anim 2, 0, 37, 1, -18, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sBeldumAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 40, -4, -5, -4, -5,
+ax_anim 1, 0, 41, -10, -11, -10, -11,
+ax_anim 2, 1, 40, -20, -18, -21, -20,
+ax_anim 2, 0, 40, -21, -17, -22, -19,
+ax_anim 2, 0, 40, -20, -18, -21, -20,
+ax_anim 2, 0, 40, -21, -17, -22, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sBeldumAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 2, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 1, 43, -21, 2, -21, 0,
+ax_anim 2, 0, 43, -21, 3, -21, 1,
+ax_anim 2, 0, 43, -21, 2, -21, 0,
+ax_anim 2, 0, 43, -21, 3, -21, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sBeldumAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 2, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -10, 11, -10, 11,
+ax_anim 1, 0, 47, -16, 20, -16, 17,
+ax_anim 2, 1, 46, -20, 23, -20, 20,
+ax_anim 2, 0, 46, -21, 22, -21, 19,
+ax_anim 2, 0, 46, -20, 23, -20, 20,
+ax_anim 2, 0, 46, -21, 22, -21, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBeldumAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 2, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 1, 49, 0, 21, 0, 18,
+ax_anim 2, 0, 49, 1, 21, 1, 18,
+ax_anim 2, 0, 49, 0, 21, 0, 18,
+ax_anim 2, 0, 49, 1, 21, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sBeldumAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 2, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 10, 11, 10, 11,
+ax_anim 1, 0, 53, 16, 20, 16, 17,
+ax_anim 2, 1, 52, 20, 23, 20, 20,
+ax_anim 2, 0, 52, 21, 22, 21, 19,
+ax_anim 2, 0, 52, 20, 23, 20, 20,
+ax_anim 2, 0, 52, 21, 22, 21, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sBeldumAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 2, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 1, 55, 21, 2, 21, 0,
+ax_anim 2, 0, 55, 21, 3, 21, 1,
+ax_anim 2, 0, 55, 21, 2, 21, 0,
+ax_anim 2, 0, 55, 21, 3, 21, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sBeldumAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 2, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 4, -5, 4, -5,
+ax_anim 1, 0, 59, 10, -11, 10, -11,
+ax_anim 2, 1, 58, 20, -18, 21, -20,
+ax_anim 2, 0, 58, 21, -17, 22, -19,
+ax_anim 2, 0, 58, 20, -18, 21, -20,
+ax_anim 2, 0, 58, 21, -17, 22, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sBeldumAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 2, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 1, 61, 0, -18, 0, -22,
+ax_anim 2, 0, 61, 1, -18, 1, -22,
+ax_anim 2, 0, 61, 0, -18, 0, -22,
+ax_anim 2, 0, 61, 1, -18, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sBeldumAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 2, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -4, -5, -4, -5,
+ax_anim 1, 0, 65, -10, -11, -10, -11,
+ax_anim 2, 1, 64, -20, -18, -21, -20,
+ax_anim 2, 0, 64, -21, -17, -22, -19,
+ax_anim 2, 0, 64, -20, -18, -21, -20,
+ax_anim 2, 0, 64, -21, -17, -22, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sBeldumAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 2, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 1, 67, -21, 2, -21, 0,
+ax_anim 2, 0, 67, -21, 3, -21, 1,
+ax_anim 2, 0, 67, -21, 2, -21, 0,
+ax_anim 2, 0, 67, -21, 3, -21, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sBeldumAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 2, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 70, -10, 11, -10, 11,
+ax_anim 1, 0, 71, -16, 20, -16, 17,
+ax_anim 2, 1, 70, -20, 23, -20, 20,
+ax_anim 2, 0, 70, -21, 22, -21, 19,
+ax_anim 2, 0, 70, -20, 23, -20, 20,
+ax_anim 2, 0, 70, -21, 22, -21, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBeldumAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_5_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_5_2:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_5_3:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_5_4:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_5_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_5_6:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_5_7:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_5_8:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_6_1:
+ax_anim 16, 0, 88, 0, 0, 0, 0,
+ax_anim 12, 0, 88, 0, -1, 0, 0,
+ax_anim 16, 0, 88, 0, -2, 0, 0,
+ax_anim 16, 0, 89, 0, -2, 0, 0,
+ax_anim 12, 0, 89, 0, -1, 0, 0,
+ax_anim 16, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_7_1:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 8, 0, 90, 0, -3, 0, -3,
+ax_anim_terminator
+sBeldumAnims_7_2:
+ax_anim 2, 0, 91, -2, -2, -2, -2,
+ax_anim 8, 0, 91, -3, -3, -3, -3,
+ax_anim_terminator
+sBeldumAnims_7_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 8, 0, 92, -3, 0, -3, 0,
+ax_anim_terminator
+sBeldumAnims_7_4:
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim 8, 0, 93, -3, 3, -3, 3,
+ax_anim_terminator
+sBeldumAnims_7_5:
+ax_anim 2, 0, 94, 0, 2, 0, 2,
+ax_anim 8, 0, 94, 0, 3, 0, 3,
+ax_anim_terminator
+sBeldumAnims_7_6:
+ax_anim 2, 0, 95, 2, 2, 2, 2,
+ax_anim 8, 0, 95, 3, 3, 3, 3,
+ax_anim_terminator
+sBeldumAnims_7_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 8, 0, 96, 3, 0, 3, 0,
+ax_anim_terminator
+sBeldumAnims_7_8:
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim 8, 0, 97, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBeldumAnims_8_1:
+ax_anim 10, 0, 98, 0, -2, 0, 0,
+ax_anim 10, 0, 99, 0, -2, 0, 0,
+ax_anim 10, 0, 98, 0, -2, 0, 0,
+ax_anim 10, 0, 100, 0, -2, 0, 0,
+ax_anim 10, 0, 98, 0, -3, 0, 0,
+ax_anim 10, 0, 99, 0, -3, 0, 0,
+ax_anim 10, 0, 98, 0, -3, 0, 0,
+ax_anim 10, 0, 100, 0, -3, 0, 0,
+ax_anim_terminator
+sBeldumAnims_8_2:
+ax_anim 10, 0, 101, 0, -2, 0, 0,
+ax_anim 10, 0, 102, 0, -2, 0, 0,
+ax_anim 10, 0, 101, 0, -2, 0, 0,
+ax_anim 10, 0, 103, 0, -2, 0, 0,
+ax_anim 10, 0, 101, 0, -3, 0, 0,
+ax_anim 10, 0, 102, 0, -3, 0, 0,
+ax_anim 10, 0, 101, 0, -3, 0, 0,
+ax_anim 10, 0, 103, 0, -3, 0, 0,
+ax_anim_terminator
+sBeldumAnims_8_3:
+ax_anim 10, 0, 104, 0, -2, 0, 0,
+ax_anim 10, 0, 105, 0, -2, 0, 0,
+ax_anim 10, 0, 104, 0, -2, 0, 0,
+ax_anim 10, 0, 106, 0, -2, 0, 0,
+ax_anim 10, 0, 104, 0, -3, 0, 0,
+ax_anim 10, 0, 105, 0, -3, 0, 0,
+ax_anim 10, 0, 104, 0, -3, 0, 0,
+ax_anim 10, 0, 106, 0, -3, 0, 0,
+ax_anim_terminator
+sBeldumAnims_8_4:
+ax_anim 10, 0, 107, 0, -2, 0, 0,
+ax_anim 10, 0, 108, 0, -2, 0, 0,
+ax_anim 10, 0, 107, 0, -2, 0, 0,
+ax_anim 10, 0, 109, 0, -2, 0, 0,
+ax_anim 10, 0, 107, 0, -3, 0, 0,
+ax_anim 10, 0, 108, 0, -3, 0, 0,
+ax_anim 10, 0, 107, 0, -3, 0, 0,
+ax_anim 10, 0, 109, 0, -3, 0, 0,
+ax_anim_terminator
+sBeldumAnims_8_5:
+ax_anim 10, 0, 110, 0, -2, 0, 0,
+ax_anim 10, 0, 111, 0, -2, 0, 0,
+ax_anim 10, 0, 110, 0, -2, 0, 0,
+ax_anim 10, 0, 112, 0, -2, 0, 0,
+ax_anim 10, 0, 110, 0, -3, 0, 0,
+ax_anim 10, 0, 111, 0, -3, 0, 0,
+ax_anim 10, 0, 110, 0, -3, 0, 0,
+ax_anim 10, 0, 112, 0, -3, 0, 0,
+ax_anim_terminator
+sBeldumAnims_8_6:
+ax_anim 10, 0, 113, 0, -2, 0, 0,
+ax_anim 10, 0, 114, 0, -2, 0, 0,
+ax_anim 10, 0, 113, 0, -2, 0, 0,
+ax_anim 10, 0, 115, 0, -2, 0, 0,
+ax_anim 10, 0, 113, 0, -3, 0, 0,
+ax_anim 10, 0, 114, 0, -3, 0, 0,
+ax_anim 10, 0, 113, 0, -3, 0, 0,
+ax_anim 10, 0, 115, 0, -3, 0, 0,
+ax_anim_terminator
+sBeldumAnims_8_7:
+ax_anim 10, 0, 116, 0, -2, 0, 0,
+ax_anim 10, 0, 117, 0, -2, 0, 0,
+ax_anim 10, 0, 116, 0, -2, 0, 0,
+ax_anim 10, 0, 118, 0, -2, 0, 0,
+ax_anim 10, 0, 116, 0, -3, 0, 0,
+ax_anim 10, 0, 117, 0, -3, 0, 0,
+ax_anim 10, 0, 116, 0, -3, 0, 0,
+ax_anim 10, 0, 118, 0, -3, 0, 0,
+ax_anim_terminator
+sBeldumAnims_8_8:
+ax_anim 10, 0, 119, 0, -2, 0, 0,
+ax_anim 10, 0, 120, 0, -2, 0, 0,
+ax_anim 10, 0, 119, 0, -2, 0, 0,
+ax_anim 10, 0, 121, 0, -2, 0, 0,
+ax_anim 10, 0, 119, 0, -3, 0, 0,
+ax_anim 10, 0, 120, 0, -3, 0, 0,
+ax_anim 10, 0, 119, 0, -3, 0, 0,
+ax_anim 10, 0, 121, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 6, 3, 6, 3,
+ax_anim 2, 0, 124, 8, 9, 8, 9,
+ax_anim 2, 0, 125, 7, 15, 7, 15,
+ax_anim 3, 0, 126, 0, 18, 0, 18,
+ax_anim 2, 3, 127, -7, 15, -7, 15,
+ax_anim 2, 0, 128, -8, 9, -8, 9,
+ax_anim 1, 0, 129, -6, 3, -6, 3,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 123, 19, 4, 19, 4,
+ax_anim 2, 0, 124, 21, 10, 21, 10,
+ax_anim 3, 0, 125, 20, 17, 20, 17,
+ax_anim 2, 3, 126, 11, 19, 11, 19,
+ax_anim 2, 0, 127, 3, 15, 3, 15,
+ax_anim 1, 0, 128, 0, 7, 0, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 3, -5, 3, -5,
+ax_anim 2, 0, 122, 11, -7, 11, -7,
+ax_anim 2, 0, 123, 16, -5, 16, -5,
+ax_anim 3, 0, 124, 18, -2, 18, -1,
+ax_anim 2, 3, 125, 16, 4, 16, 4,
+ax_anim 2, 0, 126, 10, 6, 10, 6,
+ax_anim 1, 0, 127, 3, 5, 3, 5,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, -1, -8, -1, -8,
+ax_anim 2, 0, 129, 3, -15, 3, -15,
+ax_anim 2, 0, 122, 11, -20, 11, -20,
+ax_anim 3, 0, 123, 19, -21, 19, -22,
+ax_anim 2, 3, 124, 22, -14, 22, -14,
+ax_anim 2, 0, 125, 18, -6, 18, -6,
+ax_anim 1, 0, 126, 9, -1, 9, -1,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -8, -4, -8, -4,
+ax_anim 2, 0, 128, -9, -12, -9, -12,
+ax_anim 2, 0, 129, -7, -18, -7, -18,
+ax_anim 3, 0, 122, 0, -22, 0, -22,
+ax_anim 2, 3, 123, 7, -18, 7, -18,
+ax_anim 2, 0, 124, 9, -12, 9, -12,
+ax_anim 1, 0, 125, 8, -4, 8, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 1, -8, 1, -8,
+ax_anim 2, 0, 123, -3, -15, -3, -15,
+ax_anim 2, 0, 122, -11, -20, -11, -20,
+ax_anim 3, 0, 129, -19, -21, -19, -22,
+ax_anim 2, 3, 128, -22, -14, -22, -14,
+ax_anim 2, 0, 127, -18, -6, -18, -6,
+ax_anim 1, 0, 126, -9, -1, -9, -1,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -3, -5, -3, -5,
+ax_anim 2, 0, 122, -11, -7, -11, -7,
+ax_anim 2, 0, 129, -16, -5, -16, -5,
+ax_anim 3, 0, 128, -18, -2, -18, -1,
+ax_anim 2, 3, 127, -16, 4, -16, 4,
+ax_anim 2, 0, 126, -10, 6, -10, 6,
+ax_anim 1, 0, 125, -3, 5, -3, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 129, -19, 4, -19, 4,
+ax_anim 2, 0, 128, -21, 10, -21, 10,
+ax_anim 3, 0, 127, -20, 17, -20, 17,
+ax_anim 2, 3, 126, -11, 19, -11, 19,
+ax_anim 2, 0, 125, -3, 15, -3, 15,
+ax_anim 1, 0, 124, 0, 7, 0, 7,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -22, 0, 0,
+ax_anim 3, 0, 140, 0, -21, 0, 0,
+ax_anim 2, 0, 140, 0, -18, 0, 0,
+ax_anim 1, 0, 140, 0, -12, 0, 0,
+ax_anim 2, 2, 138, 0, 5, 0, 0,
+ax_anim_terminator
+sBeldumAnims_11_2:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -10, 0, 0,
+ax_anim 2, 0, 142, 0, -16, 0, 0,
+ax_anim 3, 0, 142, 0, -20, 0, 0,
+ax_anim 4, 0, 142, 0, -21, 0, 0,
+ax_anim 4, 0, 141, 0, -22, 0, 0,
+ax_anim 3, 0, 143, 0, -21, 0, 0,
+ax_anim 2, 0, 143, 0, -18, 0, 0,
+ax_anim 1, 0, 143, 0, -12, 0, 0,
+ax_anim 2, 2, 141, 0, 5, 0, 0,
+ax_anim_terminator
+sBeldumAnims_11_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -22, 0, 0,
+ax_anim 3, 0, 146, 0, -21, 0, 0,
+ax_anim 2, 0, 146, 0, -18, 0, 0,
+ax_anim 1, 0, 146, 0, -12, 0, 0,
+ax_anim 2, 2, 144, 0, 5, 0, 0,
+ax_anim_terminator
+sBeldumAnims_11_4:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -22, 0, 0,
+ax_anim 3, 0, 149, 0, -21, 0, 0,
+ax_anim 2, 0, 149, 0, -17, 0, 0,
+ax_anim 1, 0, 149, 0, -11, 0, 0,
+ax_anim 2, 2, 147, 0, 5, 0, 0,
+ax_anim_terminator
+sBeldumAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -22, 0, 0,
+ax_anim 3, 0, 152, 0, -21, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -12, 0, 0,
+ax_anim 2, 2, 150, 0, 5, 0, 0,
+ax_anim_terminator
+sBeldumAnims_11_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -22, 0, 0,
+ax_anim 3, 0, 155, 0, -21, 0, 0,
+ax_anim 2, 0, 155, 0, -17, 0, 0,
+ax_anim 1, 0, 155, 0, -11, 0, 0,
+ax_anim 2, 2, 153, 0, 5, 0, 0,
+ax_anim_terminator
+sBeldumAnims_11_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -22, 0, 0,
+ax_anim 3, 0, 158, 0, -21, 0, 0,
+ax_anim 2, 0, 158, 0, -18, 0, 0,
+ax_anim 1, 0, 158, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 5, 0, 0,
+ax_anim_terminator
+sBeldumAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -22, 0, 0,
+ax_anim 3, 0, 161, 0, -21, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBeldumAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sBeldumGfx1:
+.incbin "baserom.gba", 0x156B520, 0x100
+sBeldumSprites1:
+ax_sprite sBeldumGfx1, 0x100
+ax_sprite_terminator
+sBeldumGfx2:
+.incbin "baserom.gba", 0x156B630, 0x100
+sBeldumSprites2:
+ax_sprite sBeldumGfx2, 0x100
+ax_sprite_terminator
+sBeldumGfx3:
+.incbin "baserom.gba", 0x156B740, 0x100
+sBeldumSprites3:
+ax_sprite sBeldumGfx3, 0x100
+ax_sprite_terminator
+sBeldumGfx4:
+.incbin "baserom.gba", 0x156B850, 0x200
+sBeldumSprites4:
+ax_sprite sBeldumGfx4, 0x200
+ax_sprite_terminator
+sBeldumGfx5:
+.incbin "baserom.gba", 0x156BA60, 0x200
+sBeldumSprites5:
+ax_sprite sBeldumGfx5, 0x200
+ax_sprite_terminator
+sBeldumGfx6:
+.incbin "baserom.gba", 0x156BC70, 0x200
+sBeldumSprites6:
+ax_sprite sBeldumGfx6, 0x200
+ax_sprite_terminator
+sBeldumGfx7:
+.incbin "baserom.gba", 0x156BE80, 0x100
+sBeldumSprites7:
+ax_sprite sBeldumGfx7, 0x100
+ax_sprite_terminator
+sBeldumGfx8:
+.incbin "baserom.gba", 0x156BF90, 0x100
+sBeldumSprites8:
+ax_sprite sBeldumGfx8, 0x100
+ax_sprite_terminator
+sBeldumGfx9:
+.incbin "baserom.gba", 0x156C0A0, 0x100
+sBeldumSprites9:
+ax_sprite sBeldumGfx9, 0x100
+ax_sprite_terminator
+sBeldumGfx10:
+.incbin "baserom.gba", 0x156C1B0, 0x200
+sBeldumSprites10:
+ax_sprite sBeldumGfx10, 0x200
+ax_sprite_terminator
+sBeldumGfx11:
+.incbin "baserom.gba", 0x156C3C0, 0x200
+sBeldumSprites11:
+ax_sprite sBeldumGfx11, 0x200
+ax_sprite_terminator
+sBeldumGfx12:
+.incbin "baserom.gba", 0x156C5D0, 0x200
+sBeldumSprites12:
+ax_sprite sBeldumGfx12, 0x200
+ax_sprite_terminator
+sBeldumGfx13:
+.incbin "baserom.gba", 0x156C7E0, 0x100
+sBeldumSprites13:
+ax_sprite sBeldumGfx13, 0x100
+ax_sprite_terminator
+sBeldumGfx14:
+.incbin "baserom.gba", 0x156C8F0, 0x100
+sBeldumSprites14:
+ax_sprite sBeldumGfx14, 0x100
+ax_sprite_terminator
+sBeldumGfx15:
+.incbin "baserom.gba", 0x156CA00, 0x100
+sBeldumSprites15:
+ax_sprite sBeldumGfx15, 0x100
+ax_sprite_terminator
+sBeldumGfx16:
+.incbin "baserom.gba", 0x156CB10, 0x200
+sBeldumSprites16:
+ax_sprite sBeldumGfx16, 0x200
+ax_sprite_terminator
+sBeldumGfx17:
+.incbin "baserom.gba", 0x156CD20, 0x200
+sBeldumSprites17:
+ax_sprite sBeldumGfx17, 0x200
+ax_sprite_terminator
+sBeldumGfx18:
+.incbin "baserom.gba", 0x156CF30, 0x200
+sBeldumSprites18:
+ax_sprite sBeldumGfx18, 0x200
+ax_sprite_terminator
+sBeldumGfx19:
+.incbin "baserom.gba", 0x156D140, 0x200
+sBeldumSprites19:
+ax_sprite sBeldumGfx19, 0x200
+ax_sprite_terminator
+sBeldumGfx20:
+.incbin "baserom.gba", 0x156D350, 0x100
+sBeldumSprites20:
+ax_sprite sBeldumGfx20, 0x100
+ax_sprite_terminator
+sBeldumGfx21:
+.incbin "baserom.gba", 0x156D460, 0x80
+sBeldumSprites21:
+ax_sprite sBeldumGfx21, 0x80
+ax_sprite_terminator
+sBeldumGfx22:
+.incbin "baserom.gba", 0x156D4F0, 0x40
+sBeldumSprites22:
+ax_sprite sBeldumGfx22, 0x40
+ax_sprite_terminator
+sBeldumGfx23:
+.incbin "baserom.gba", 0x156D540, 0x20
+sBeldumSprites23:
+ax_sprite sBeldumGfx23, 0x20
+ax_sprite_terminator
+sBeldumGfx24:
+.incbin "baserom.gba", 0x156D570, 0x100
+sBeldumSprites24:
+ax_sprite sBeldumGfx24, 0x100
+ax_sprite_terminator
+sBeldumGfx25:
+.incbin "baserom.gba", 0x156D680, 0x80
+sBeldumSprites25:
+ax_sprite sBeldumGfx25, 0x80
+ax_sprite_terminator
+sBeldumGfx26:
+.incbin "baserom.gba", 0x156D710, 0x40
+sBeldumSprites26:
+ax_sprite sBeldumGfx26, 0x40
+ax_sprite_terminator
+sBeldumGfx27:
+.incbin "baserom.gba", 0x156D760, 0x20
+sBeldumSprites27:
+ax_sprite sBeldumGfx27, 0x20
+ax_sprite_terminator
+sBeldumGfx28:
+.incbin "baserom.gba", 0x156D790, 0x200
+sBeldumSprites28:
+ax_sprite sBeldumGfx28, 0x200
+ax_sprite_terminator
+sAxPosesBeldum:
+.4byte sBeldumPose1
+.4byte sBeldumPose2
+.4byte sBeldumPose3
+.4byte sBeldumPose4
+.4byte sBeldumPose5
+.4byte sBeldumPose6
+.4byte sBeldumPose7
+.4byte sBeldumPose8
+.4byte sBeldumPose9
+.4byte sBeldumPose10
+.4byte sBeldumPose11
+.4byte sBeldumPose12
+.4byte sBeldumPose13
+.4byte sBeldumPose14
+.4byte sBeldumPose15
+.4byte sBeldumPose16
+.4byte sBeldumPose17
+.4byte sBeldumPose18
+.4byte sBeldumPose19
+.4byte sBeldumPose20
+.4byte sBeldumPose21
+.4byte sBeldumPose22
+.4byte sBeldumPose23
+.4byte sBeldumPose24
+.4byte sBeldumPose25
+.4byte sBeldumPose26
+.4byte sBeldumPose27
+.4byte sBeldumPose28
+.4byte sBeldumPose29
+.4byte sBeldumPose30
+.4byte sBeldumPose31
+.4byte sBeldumPose32
+.4byte sBeldumPose33
+.4byte sBeldumPose34
+.4byte sBeldumPose35
+.4byte sBeldumPose36
+.4byte sBeldumPose37
+.4byte sBeldumPose38
+.4byte sBeldumPose39
+.4byte sBeldumPose40
+.4byte sBeldumPose41
+.4byte sBeldumPose42
+.4byte sBeldumPose43
+.4byte sBeldumPose44
+.4byte sBeldumPose45
+.4byte sBeldumPose46
+.4byte sBeldumPose47
+.4byte sBeldumPose48
+.4byte sBeldumPose49
+.4byte sBeldumPose50
+.4byte sBeldumPose51
+.4byte sBeldumPose52
+.4byte sBeldumPose53
+.4byte sBeldumPose54
+.4byte sBeldumPose55
+.4byte sBeldumPose56
+.4byte sBeldumPose57
+.4byte sBeldumPose58
+.4byte sBeldumPose59
+.4byte sBeldumPose60
+.4byte sBeldumPose61
+.4byte sBeldumPose62
+.4byte sBeldumPose63
+.4byte sBeldumPose64
+.4byte sBeldumPose65
+.4byte sBeldumPose66
+.4byte sBeldumPose67
+.4byte sBeldumPose68
+.4byte sBeldumPose69
+.4byte sBeldumPose70
+.4byte sBeldumPose71
+.4byte sBeldumPose72
+.4byte sBeldumPose73
+.4byte sBeldumPose74
+.4byte sBeldumPose75
+.4byte sBeldumPose76
+.4byte sBeldumPose77
+.4byte sBeldumPose78
+.4byte sBeldumPose79
+.4byte sBeldumPose80
+.4byte sBeldumPose81
+.4byte sBeldumPose82
+.4byte sBeldumPose83
+.4byte sBeldumPose84
+.4byte sBeldumPose85
+.4byte sBeldumPose86
+.4byte sBeldumPose87
+.4byte sBeldumPose88
+.4byte sBeldumPose89
+.4byte sBeldumPose90
+.4byte sBeldumPose91
+.4byte sBeldumPose92
+.4byte sBeldumPose93
+.4byte sBeldumPose94
+.4byte sBeldumPose95
+.4byte sBeldumPose96
+.4byte sBeldumPose97
+.4byte sBeldumPose98
+.4byte sBeldumPose99
+.4byte sBeldumPose100
+.4byte sBeldumPose101
+.4byte sBeldumPose102
+.4byte sBeldumPose103
+.4byte sBeldumPose104
+.4byte sBeldumPose105
+.4byte sBeldumPose106
+.4byte sBeldumPose107
+.4byte sBeldumPose108
+.4byte sBeldumPose109
+.4byte sBeldumPose110
+.4byte sBeldumPose111
+.4byte sBeldumPose112
+.4byte sBeldumPose113
+.4byte sBeldumPose114
+.4byte sBeldumPose115
+.4byte sBeldumPose116
+.4byte sBeldumPose117
+.4byte sBeldumPose118
+.4byte sBeldumPose119
+.4byte sBeldumPose120
+.4byte sBeldumPose121
+.4byte sBeldumPose122
+.4byte sBeldumPose123
+.4byte sBeldumPose124
+.4byte sBeldumPose125
+.4byte sBeldumPose126
+.4byte sBeldumPose127
+.4byte sBeldumPose128
+.4byte sBeldumPose129
+.4byte sBeldumPose130
+.4byte sBeldumPose131
+.4byte sBeldumPose132
+.4byte sBeldumPose133
+.4byte sBeldumPose134
+.4byte sBeldumPose135
+.4byte sBeldumPose136
+.4byte sBeldumPose137
+.4byte sBeldumPose138
+.4byte sBeldumPose139
+.4byte sBeldumPose140
+.4byte sBeldumPose141
+.4byte sBeldumPose142
+.4byte sBeldumPose143
+.4byte sBeldumPose144
+.4byte sBeldumPose145
+.4byte sBeldumPose146
+.4byte sBeldumPose147
+.4byte sBeldumPose148
+.4byte sBeldumPose149
+.4byte sBeldumPose150
+.4byte sBeldumPose151
+.4byte sBeldumPose152
+.4byte sBeldumPose153
+.4byte sBeldumPose154
+.4byte sBeldumPose155
+.4byte sBeldumPose156
+.4byte sBeldumPose157
+.4byte sBeldumPose158
+.4byte sBeldumPose159
+.4byte sBeldumPose160
+.4byte sBeldumPose161
+.4byte sBeldumPose162
+.4byte sBeldumPose163
+.4byte sBeldumPose164
+.4byte sBeldumPose165
+.4byte sBeldumPose166
+.4byte sBeldumPose167
+.4byte sBeldumPose168
+.4byte sBeldumPose169
+.4byte sBeldumPose170
+.4byte sBeldumPose171
+.4byte sBeldumPose172
+.4byte sBeldumPose173
+.4byte sBeldumPose174
+.4byte sBeldumPose175
+.4byte sBeldumPose176
+.4byte sBeldumPose177
+.4byte sBeldumPose178
+sAxPositionsBeldum:
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -14
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -14
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -14
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -14
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -14
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -14
+.2byte   -1,    1, 	  -6,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -7,    0, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte  -10,   -5, 	  -4,  -11, 	  -3,   -5, 	   0,   -7
+.2byte   -6,   -8, 	   2,  -10, 	  -5,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -9, 	  -5,   -9, 	  -1,   -9
+.2byte    5,   -8, 	  -3,  -10, 	   4,   -6, 	   0,   -8
+.2byte    9,   -5, 	   3,  -11, 	   2,   -5, 	  -1,   -7
+.2byte    6,    0, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -1,    1, 	  -6,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -7,    0, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte  -10,   -5, 	  -4,  -11, 	  -3,   -5, 	   0,   -7
+.2byte   -6,   -8, 	   2,  -10, 	  -5,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -9, 	  -5,   -9, 	  -1,   -9
+.2byte    5,   -8, 	  -3,  -10, 	   4,   -6, 	   0,   -8
+.2byte    9,   -5, 	   3,  -11, 	   2,   -5, 	  -1,   -7
+.2byte    6,    0, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -7,    0, 	  -5,   -7, 	   0,   -5, 	   0,   -9
+.2byte   -7,   -1, 	  -5,   -8, 	   0,   -6, 	   0,  -10
+.2byte   -1,  -26, 	  -6,  -18, 	   4,  -18, 	  -1,  -16
+.2byte   -7,  -23, 	  -2,  -18, 	  -8,  -15, 	  -3,  -14
+.2byte   -4,  -25, 	  -6,  -19, 	  -5,  -17, 	  -4,  -13
+.2byte   -3,  -24, 	  -7,  -15, 	  -1,  -17, 	  -3,  -13
+.2byte    0,  -26, 	   5,  -16, 	  -5,  -16, 	   0,  -16
+.2byte    2,  -24, 	   6,  -15, 	   0,  -17, 	   2,  -13
+.2byte    3,  -25, 	   5,  -19, 	   4,  -17, 	   3,  -13
+.2byte    6,  -23, 	   1,  -18, 	   7,  -15, 	   2,  -14
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -14
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -14
+.2byte   -1,    1, 	  -6,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -7,    0, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte  -10,   -5, 	  -4,  -11, 	  -3,   -5, 	   0,   -7
+.2byte   -6,   -8, 	   2,  -10, 	  -5,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -9, 	  -5,   -9, 	  -1,   -9
+.2byte    5,   -8, 	  -3,  -10, 	   4,   -6, 	   0,   -8
+.2byte    9,   -5, 	   3,  -11, 	   2,   -5, 	  -1,   -7
+.2byte    6,    0, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   4,  -10, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   4,  -10, 	  -1,   -9, 	  -1,  -14
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    9,   -9, 	   3,  -15, 	   2,   -9, 	  -1,  -11
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte    5,  -12, 	  -3,  -14, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -1,  -18, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte   -6,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -12
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte  -10,   -9, 	  -4,  -15, 	  -3,   -9, 	   0,  -11
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -13
+.2byte   -7,   -4, 	  -5,  -10, 	   0,   -9, 	   0,  -14
+.2byte   -1,    1, 	  -6,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -7,    0, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte  -10,   -5, 	  -4,  -11, 	  -3,   -5, 	   0,   -7
+.2byte   -6,   -8, 	   2,  -10, 	  -5,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -9, 	  -5,   -9, 	  -1,   -9
+.2byte    5,   -8, 	  -3,  -10, 	   4,   -6, 	   0,   -8
+.2byte    9,   -5, 	   3,  -11, 	   2,   -5, 	  -1,   -7
+.2byte    6,    0, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -1,    1, 	  -6,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -7,    0, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte  -10,   -5, 	  -4,  -11, 	  -3,   -5, 	   0,   -7
+.2byte   -6,   -8, 	   2,  -10, 	  -5,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -9, 	  -5,   -9, 	  -1,   -9
+.2byte    5,   -8, 	  -3,  -10, 	   4,   -6, 	   0,   -8
+.2byte    9,   -5, 	   3,  -11, 	   2,   -5, 	  -1,   -7
+.2byte    6,    0, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+sBeldumAnimTable1:
+.4byte sBeldumAnims_1_1
+.4byte sBeldumAnims_1_2
+.4byte sBeldumAnims_1_3
+.4byte sBeldumAnims_1_4
+.4byte sBeldumAnims_1_5
+.4byte sBeldumAnims_1_6
+.4byte sBeldumAnims_1_7
+.4byte sBeldumAnims_1_8
+sBeldumAnimTable2:
+.4byte sBeldumAnims_2_1
+.4byte sBeldumAnims_2_2
+.4byte sBeldumAnims_2_3
+.4byte sBeldumAnims_2_4
+.4byte sBeldumAnims_2_5
+.4byte sBeldumAnims_2_6
+.4byte sBeldumAnims_2_7
+.4byte sBeldumAnims_2_8
+sBeldumAnimTable3:
+.4byte sBeldumAnims_3_1
+.4byte sBeldumAnims_3_2
+.4byte sBeldumAnims_3_3
+.4byte sBeldumAnims_3_4
+.4byte sBeldumAnims_3_5
+.4byte sBeldumAnims_3_6
+.4byte sBeldumAnims_3_7
+.4byte sBeldumAnims_3_8
+sBeldumAnimTable4:
+.4byte sBeldumAnims_4_1
+.4byte sBeldumAnims_4_2
+.4byte sBeldumAnims_4_3
+.4byte sBeldumAnims_4_4
+.4byte sBeldumAnims_4_5
+.4byte sBeldumAnims_4_6
+.4byte sBeldumAnims_4_7
+.4byte sBeldumAnims_4_8
+sBeldumAnimTable5:
+.4byte sBeldumAnims_5_1
+.4byte sBeldumAnims_5_2
+.4byte sBeldumAnims_5_3
+.4byte sBeldumAnims_5_4
+.4byte sBeldumAnims_5_5
+.4byte sBeldumAnims_5_6
+.4byte sBeldumAnims_5_7
+.4byte sBeldumAnims_5_8
+sBeldumAnimTable6:
+.4byte sBeldumAnims_6_1
+.4byte sBeldumAnims_6_1
+.4byte sBeldumAnims_6_1
+.4byte sBeldumAnims_6_1
+.4byte sBeldumAnims_6_1
+.4byte sBeldumAnims_6_1
+.4byte sBeldumAnims_6_1
+.4byte sBeldumAnims_6_1
+sBeldumAnimTable7:
+.4byte sBeldumAnims_7_1
+.4byte sBeldumAnims_7_2
+.4byte sBeldumAnims_7_3
+.4byte sBeldumAnims_7_4
+.4byte sBeldumAnims_7_5
+.4byte sBeldumAnims_7_6
+.4byte sBeldumAnims_7_7
+.4byte sBeldumAnims_7_8
+sBeldumAnimTable8:
+.4byte sBeldumAnims_8_1
+.4byte sBeldumAnims_8_2
+.4byte sBeldumAnims_8_3
+.4byte sBeldumAnims_8_4
+.4byte sBeldumAnims_8_5
+.4byte sBeldumAnims_8_6
+.4byte sBeldumAnims_8_7
+.4byte sBeldumAnims_8_8
+sBeldumAnimTable9:
+.4byte sBeldumAnims_9_1
+.4byte sBeldumAnims_9_2
+.4byte sBeldumAnims_9_3
+.4byte sBeldumAnims_9_4
+.4byte sBeldumAnims_9_5
+.4byte sBeldumAnims_9_6
+.4byte sBeldumAnims_9_7
+.4byte sBeldumAnims_9_8
+sBeldumAnimTable10:
+.4byte sBeldumAnims_10_1
+.4byte sBeldumAnims_10_2
+.4byte sBeldumAnims_10_3
+.4byte sBeldumAnims_10_4
+.4byte sBeldumAnims_10_5
+.4byte sBeldumAnims_10_6
+.4byte sBeldumAnims_10_7
+.4byte sBeldumAnims_10_8
+sBeldumAnimTable11:
+.4byte sBeldumAnims_11_1
+.4byte sBeldumAnims_11_2
+.4byte sBeldumAnims_11_3
+.4byte sBeldumAnims_11_4
+.4byte sBeldumAnims_11_5
+.4byte sBeldumAnims_11_6
+.4byte sBeldumAnims_11_7
+.4byte sBeldumAnims_11_8
+sBeldumAnimTable12:
+.4byte sBeldumAnims_12_1
+.4byte sBeldumAnims_12_2
+.4byte sBeldumAnims_12_3
+.4byte sBeldumAnims_12_4
+.4byte sBeldumAnims_12_5
+.4byte sBeldumAnims_12_6
+.4byte sBeldumAnims_12_7
+.4byte sBeldumAnims_12_8
+sBeldumAnimTable13:
+.4byte sBeldumAnims_13_1
+.4byte sBeldumAnims_13_2
+.4byte sBeldumAnims_13_3
+.4byte sBeldumAnims_13_4
+.4byte sBeldumAnims_13_5
+.4byte sBeldumAnims_13_6
+.4byte sBeldumAnims_13_7
+.4byte sBeldumAnims_13_8
+sAxAnimationsBeldum:
+.4byte sBeldumAnimTable1
+.4byte sBeldumAnimTable2
+.4byte sBeldumAnimTable3
+.4byte sBeldumAnimTable4
+.4byte sBeldumAnimTable5
+.4byte sBeldumAnimTable6
+.4byte sBeldumAnimTable7
+.4byte sBeldumAnimTable8
+.4byte sBeldumAnimTable9
+.4byte sBeldumAnimTable10
+.4byte sBeldumAnimTable11
+.4byte sBeldumAnimTable12
+.4byte sBeldumAnimTable13
+sAxSpritesBeldum:
+.4byte sBeldumSprites1
+.4byte sBeldumSprites2
+.4byte sBeldumSprites3
+.4byte sBeldumSprites4
+.4byte sBeldumSprites5
+.4byte sBeldumSprites6
+.4byte sBeldumSprites7
+.4byte sBeldumSprites8
+.4byte sBeldumSprites9
+.4byte sBeldumSprites10
+.4byte sBeldumSprites11
+.4byte sBeldumSprites12
+.4byte sBeldumSprites13
+.4byte sBeldumSprites14
+.4byte sBeldumSprites15
+.4byte sBeldumSprites16
+.4byte sBeldumSprites17
+.4byte sBeldumSprites18
+.4byte sBeldumSprites19
+.4byte sBeldumSprites20
+.4byte sBeldumSprites21
+.4byte sBeldumSprites22
+.4byte sBeldumSprites23
+.4byte sBeldumSprites24
+.4byte sBeldumSprites25
+.4byte sBeldumSprites26
+.4byte sBeldumSprites27
+.4byte sBeldumSprites28
+sAxMainBeldum:
+ax_main sAxPosesBeldum, sAxAnimationsBeldum, 13, sAxSpritesBeldum, sAxPositionsBeldum

--- a/data/ax/bellossom.inc
+++ b/data/ax/bellossom.inc
@@ -1,0 +1,2742 @@
+.global gAxBellossom
+gAxBellossom:
+ax_siro sAxMainBellossom
+sBellossomPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose4:
+ax_pose 3, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose5:
+ax_pose 4, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose7:
+ax_pose 6, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose8:
+ax_pose 7, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose9:
+ax_pose 8, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose10:
+ax_pose 9, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose11:
+ax_pose 10, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose14:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose15:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose19:
+ax_pose 6, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose20:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose21:
+ax_pose 8, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose23:
+ax_pose 4, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose28:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose29:
+ax_pose 3, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose30:
+ax_pose 4, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose31:
+ax_pose 5, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose32:
+ax_pose 16, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose33:
+ax_pose 6, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose34:
+ax_pose 7, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose35:
+ax_pose 8, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose36:
+ax_pose 17, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose37:
+ax_pose 9, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose38:
+ax_pose 10, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose39:
+ax_pose 11, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose40:
+ax_pose 18, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose41:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose42:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose43:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose44:
+ax_pose 19, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose45:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose46:
+ax_pose 10, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose47:
+ax_pose 11, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose48:
+ax_pose 18, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose49:
+ax_pose 6, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose50:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose51:
+ax_pose 8, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose52:
+ax_pose 17, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose53:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose54:
+ax_pose 4, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose55:
+ax_pose 5, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose56:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose57:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose58:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose59:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose60:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose61:
+ax_pose 3, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose62:
+ax_pose 4, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose63:
+ax_pose 5, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose64:
+ax_pose 16, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose65:
+ax_pose 6, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose66:
+ax_pose 7, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose67:
+ax_pose 8, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose68:
+ax_pose 17, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose69:
+ax_pose 9, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose70:
+ax_pose 10, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose71:
+ax_pose 11, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose72:
+ax_pose 18, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose73:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose74:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose75:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose76:
+ax_pose 19, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose77:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose78:
+ax_pose 10, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose79:
+ax_pose 11, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose80:
+ax_pose 18, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose81:
+ax_pose 6, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose82:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose83:
+ax_pose 8, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose84:
+ax_pose 17, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose85:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose86:
+ax_pose 4, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose87:
+ax_pose 5, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose88:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose89:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose90:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose91:
+ax_pose 17, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose92:
+ax_pose 18, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose93:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose94:
+ax_pose 18, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose95:
+ax_pose 17, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose96:
+ax_pose 16, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose97:
+ax_pose 20, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose98:
+ax_pose 21, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose99:
+ax_pose 22, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose100:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose101:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose102:
+ax_pose 6, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose103:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose104:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose105:
+ax_pose 9, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose106:
+ax_pose 6, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose107:
+ax_pose 3, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose108:
+ax_pose 23, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose109:
+ax_pose 24, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose110:
+ax_pose 25, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose111:
+ax_pose 26, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose112:
+ax_pose 27, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose113:
+ax_pose 28, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose114:
+ax_pose 29, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose115:
+ax_pose 30, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose116:
+ax_pose 31, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose117:
+ax_pose 32, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose118:
+ax_pose 33, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose119:
+ax_pose 34, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose120:
+ax_pose 30, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose121:
+ax_pose 29, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose122:
+ax_pose 31, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose123:
+ax_pose 27, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose124:
+ax_pose 26, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose125:
+ax_pose 28, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose126:
+ax_pose 24, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose127:
+ax_pose 23, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose128:
+ax_pose 25, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose129:
+ax_pose 35, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose130:
+ax_pose 36, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose131:
+ax_pose 37, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sBellossomPose132:
+ax_pose 38, 0x01e3, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellossomPose133:
+ax_pose 39, 0x01e4, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellossomPose134:
+ax_pose 40, 0x01e4, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose135:
+ax_pose 41, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sBellossomPose136:
+ax_pose 40, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sBellossomPose137:
+ax_pose 39, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellossomPose138:
+ax_pose 38, 0x01e3, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellossomPose139:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose140:
+ax_pose 20, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose141:
+ax_pose 21, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose142:
+ax_pose 3, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose143:
+ax_pose 23, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose144:
+ax_pose 24, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose145:
+ax_pose 6, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose146:
+ax_pose 26, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose147:
+ax_pose 27, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose148:
+ax_pose 9, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose149:
+ax_pose 29, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose150:
+ax_pose 30, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose151:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose152:
+ax_pose 32, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose153:
+ax_pose 33, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose154:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose155:
+ax_pose 30, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose156:
+ax_pose 29, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose157:
+ax_pose 6, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose158:
+ax_pose 27, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose159:
+ax_pose 26, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose160:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose161:
+ax_pose 24, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose162:
+ax_pose 23, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose163:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose164:
+ax_pose 16, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose165:
+ax_pose 17, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose166:
+ax_pose 18, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellossomPose167:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose168:
+ax_pose 18, 0x01ec, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellossomPose169:
+ax_pose 17, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose170:
+ax_pose 16, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose171:
+ax_pose 22, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose172:
+ax_pose 25, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose173:
+ax_pose 28, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose174:
+ax_pose 31, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose175:
+ax_pose 34, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose176:
+ax_pose 31, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose177:
+ax_pose 28, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose178:
+ax_pose 25, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose179:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose180:
+ax_pose 22, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose181:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose182:
+ax_pose 3, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose183:
+ax_pose 25, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose184:
+ax_pose 16, 0x01ed, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellossomPose185:
+ax_pose 6, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose186:
+ax_pose 28, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose187:
+ax_pose 17, 0x01ed, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellossomPose188:
+ax_pose 9, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose189:
+ax_pose 31, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose190:
+ax_pose 18, 0x01ed, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellossomPose191:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose192:
+ax_pose 34, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellossomPose193:
+ax_pose 19, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose194:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose195:
+ax_pose 31, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose196:
+ax_pose 18, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sBellossomPose197:
+ax_pose 6, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose198:
+ax_pose 28, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose199:
+ax_pose 17, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sBellossomPose200:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose201:
+ax_pose 25, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose202:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose203:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose204:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose205:
+ax_pose 17, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose206:
+ax_pose 18, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose207:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose208:
+ax_pose 18, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose209:
+ax_pose 17, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose210:
+ax_pose 16, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose211:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose212:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose213:
+ax_pose 6, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose214:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose215:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellossomPose216:
+ax_pose 9, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose217:
+ax_pose 6, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellossomPose218:
+ax_pose 3, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+.align 2
+sBellossomAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBellossomAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 1, 31, 21, 17, 21, 17,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 21, 17, 21, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sBellossomAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 1, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sBellossomAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 20, -23, 20, -23,
+ax_anim 2, 1, 39, 21, -22, 21, -22,
+ax_anim 2, 0, 39, 20, -23, 20, -23,
+ax_anim 2, 0, 39, 21, -22, 21, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sBellossomAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -23, 0, -23,
+ax_anim 2, 1, 43, 1, -23, 1, -23,
+ax_anim 2, 0, 43, 0, -23, 0, -23,
+ax_anim 2, 0, 43, 1, -23, 1, -23,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sBellossomAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -20, -23, -20, -23,
+ax_anim 2, 1, 47, -21, -22, -21, -22,
+ax_anim 2, 0, 47, -20, -23, -20, -23,
+ax_anim 2, 0, 47, -21, -22, -21, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sBellossomAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 1, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sBellossomAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 1, 55, -21, 17, -21, 17,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -21, 17, -21, 17,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBellossomAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sBellossomAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 1, 63, 21, 17, 21, 17,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 21, 17, 21, 17,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sBellossomAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 1, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 0, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sBellossomAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 71, 4, -6, 4, -6,
+ax_anim 1, 0, 71, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 20, -23, 20, -23,
+ax_anim 2, 1, 71, 21, -22, 21, -22,
+ax_anim 2, 0, 71, 20, -23, 20, -23,
+ax_anim 2, 0, 71, 21, -22, 21, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sBellossomAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -23, 0, -23,
+ax_anim 2, 1, 75, 1, -23, 1, -23,
+ax_anim 2, 0, 75, 0, -23, 0, -23,
+ax_anim 2, 0, 75, 1, -23, 1, -23,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sBellossomAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 79, -4, -6, -4, -6,
+ax_anim 1, 0, 79, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -20, -23, -20, -23,
+ax_anim 2, 1, 79, -21, -22, -21, -22,
+ax_anim 2, 0, 79, -20, -23, -20, -23,
+ax_anim 2, 0, 79, -21, -22, -21, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sBellossomAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 1, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 0, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sBellossomAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 1, 87, -21, 17, -21, 17,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -21, 17, -21, 17,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBellossomAnims_4_1:
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_4_2:
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_4_3:
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_4_4:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_4_5:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_4_6:
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_4_7:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_4_8:
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_5_1:
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 103, 0, -7, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 2, 2, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_5_2:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 2, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_5_3:
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -7, 0, 0,
+ax_anim 2, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 0, 102, 0, -6, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 2, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_5_4:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 100, 0, -7, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 2, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_5_5:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 106, 0, -7, 0, 0,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 2, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_5_6:
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 106, 0, -7, 0, 0,
+ax_anim 2, 0, 99, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 2, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_5_7:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 2, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_5_8:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -6, 0, 0,
+ax_anim 2, 0, 103, 0, -7, 0, 0,
+ax_anim 2, 0, 104, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 2, 127, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sBellossomAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sBellossomAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sBellossomAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sBellossomAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sBellossomAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sBellossomAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sBellossomAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBellossomAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 7, 3, 7, 3,
+ax_anim 2, 0, 164, 10, 9, 10, 9,
+ax_anim 2, 0, 165, 10, 16, 10, 16,
+ax_anim 3, 0, 166, 0, 19, 0, 19,
+ax_anim 2, 3, 167, -10, 16, -10, 16,
+ax_anim 2, 0, 168, -10, 9, -10, 9,
+ax_anim 1, 0, 169, -7, 3, -7, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 18, 4, 18, 4,
+ax_anim 2, 0, 164, 21, 10, 21, 10,
+ax_anim 3, 0, 165, 20, 19, 21, 19,
+ax_anim 2, 3, 166, 11, 19, 11, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 10, -6, 10, -6,
+ax_anim 2, 0, 163, 19, -3, 19, -3,
+ax_anim 3, 0, 164, 22, 0, 22, 0,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 10, 7, 10, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -17, 4, -17,
+ax_anim 2, 0, 162, 12, -23, 12, -23,
+ax_anim 3, 0, 163, 22, -23, 22, -24,
+ax_anim 2, 3, 164, 24, -15, 24, -15,
+ax_anim 2, 0, 165, 19, -5, 19, -5,
+ax_anim 1, 0, 166, 11, -1, 11, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -8, -20, -8, -20,
+ax_anim 3, 0, 162, 0, -25, 0, -25,
+ax_anim 2, 3, 163, 9, -20, 9, -20,
+ax_anim 2, 0, 164, 11, -11, 11, -11,
+ax_anim 1, 0, 165, 9, -5, 9, -5,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -17, -4, -17,
+ax_anim 2, 0, 162, -12, -23, -12, -23,
+ax_anim 3, 0, 169, -22, -23, -22, -23,
+ax_anim 2, 3, 168, -24, -15, -24, -15,
+ax_anim 2, 0, 167, -19, -5, -19, -5,
+ax_anim 1, 0, 166, -11, -1, -11, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -10, -6, -10, -6,
+ax_anim 2, 0, 169, -19, -3, -19, -3,
+ax_anim 3, 0, 168, -22, 0, -22, 0,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -10, 7, -10, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -18, 4, -18, 4,
+ax_anim 2, 0, 168, -21, 10, -21, 10,
+ax_anim 3, 0, 167, -20, 19, -20, 19,
+ax_anim 2, 3, 166, -11, 19, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellossomAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBellossomGfx1:
+.incbin "baserom.gba", 0xCE0260, 0x200
+sBellossomSprites1:
+ax_sprite sBellossomGfx1, 0x200
+ax_sprite_terminator
+sBellossomGfx2:
+.incbin "baserom.gba", 0xCE0470, 0x200
+sBellossomSprites2:
+ax_sprite sBellossomGfx2, 0x200
+ax_sprite_terminator
+sBellossomGfx3:
+.incbin "baserom.gba", 0xCE0680, 0x200
+sBellossomSprites3:
+ax_sprite sBellossomGfx3, 0x200
+ax_sprite_terminator
+sBellossomGfx4:
+.incbin "baserom.gba", 0xCE0890, 0x200
+sBellossomSprites4:
+ax_sprite sBellossomGfx4, 0x200
+ax_sprite_terminator
+sBellossomGfx5:
+.incbin "baserom.gba", 0xCE0AA0, 0x200
+sBellossomSprites5:
+ax_sprite sBellossomGfx5, 0x200
+ax_sprite_terminator
+sBellossomGfx6:
+.incbin "baserom.gba", 0xCE0CB0, 0x200
+sBellossomSprites6:
+ax_sprite sBellossomGfx6, 0x200
+ax_sprite_terminator
+sBellossomGfx7:
+.incbin "baserom.gba", 0xCE0EC0, 0x200
+sBellossomSprites7:
+ax_sprite sBellossomGfx7, 0x200
+ax_sprite_terminator
+sBellossomGfx8:
+.incbin "baserom.gba", 0xCE10D0, 0x200
+sBellossomSprites8:
+ax_sprite sBellossomGfx8, 0x200
+ax_sprite_terminator
+sBellossomGfx9:
+.incbin "baserom.gba", 0xCE12E0, 0x200
+sBellossomSprites9:
+ax_sprite sBellossomGfx9, 0x200
+ax_sprite_terminator
+sBellossomGfx10:
+.incbin "baserom.gba", 0xCE14F0, 0x200
+sBellossomSprites10:
+ax_sprite sBellossomGfx10, 0x200
+ax_sprite_terminator
+sBellossomGfx11:
+.incbin "baserom.gba", 0xCE1700, 0x200
+sBellossomSprites11:
+ax_sprite sBellossomGfx11, 0x200
+ax_sprite_terminator
+sBellossomGfx12:
+.incbin "baserom.gba", 0xCE1910, 0x200
+sBellossomSprites12:
+ax_sprite sBellossomGfx12, 0x200
+ax_sprite_terminator
+sBellossomGfx13:
+.incbin "baserom.gba", 0xCE1B20, 0x200
+sBellossomSprites13:
+ax_sprite sBellossomGfx13, 0x200
+ax_sprite_terminator
+sBellossomGfx14:
+.incbin "baserom.gba", 0xCE1D30, 0x200
+sBellossomSprites14:
+ax_sprite sBellossomGfx14, 0x200
+ax_sprite_terminator
+sBellossomGfx15:
+.incbin "baserom.gba", 0xCE1F40, 0x200
+sBellossomSprites15:
+ax_sprite sBellossomGfx15, 0x200
+ax_sprite_terminator
+sBellossomGfx16:
+.incbin "baserom.gba", 0xCE2150, 0x60
+sBellossomGfx16_1:
+.incbin "baserom.gba", 0xCE21B0, 0x60
+sBellossomGfx16_2:
+.incbin "baserom.gba", 0xCE2210, 0x60
+sBellossomSprites16:
+ax_sprite sBellossomGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx17:
+.incbin "baserom.gba", 0xCE22A8, 0x40
+sBellossomGfx17_1:
+.incbin "baserom.gba", 0xCE22E8, 0x60
+sBellossomGfx17_2:
+.incbin "baserom.gba", 0xCE2348, 0x60
+sBellossomGfx17_3:
+.incbin "baserom.gba", 0xCE23A8, 0x20
+sBellossomSprites17:
+ax_sprite sBellossomGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx17_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBellossomGfx18:
+.incbin "baserom.gba", 0xCE2410, 0x40
+sBellossomGfx18_1:
+.incbin "baserom.gba", 0xCE2450, 0x60
+sBellossomGfx18_2:
+.incbin "baserom.gba", 0xCE24B0, 0x60
+sBellossomSprites18:
+ax_sprite sBellossomGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx19:
+.incbin "baserom.gba", 0xCE2548, 0x40
+sBellossomGfx19_1:
+.incbin "baserom.gba", 0xCE2588, 0x60
+sBellossomGfx19_2:
+.incbin "baserom.gba", 0xCE25E8, 0x60
+sBellossomSprites19:
+ax_sprite sBellossomGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx20:
+.incbin "baserom.gba", 0xCE2680, 0x60
+sBellossomGfx20_1:
+.incbin "baserom.gba", 0xCE26E0, 0x60
+sBellossomGfx20_2:
+.incbin "baserom.gba", 0xCE2740, 0x60
+sBellossomSprites20:
+ax_sprite sBellossomGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx21:
+.incbin "baserom.gba", 0xCE27D8, 0x60
+sBellossomGfx21_1:
+.incbin "baserom.gba", 0xCE2838, 0x60
+sBellossomGfx21_2:
+.incbin "baserom.gba", 0xCE2898, 0x60
+sBellossomSprites21:
+ax_sprite sBellossomGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx22:
+.incbin "baserom.gba", 0xCE2930, 0x60
+sBellossomGfx22_1:
+.incbin "baserom.gba", 0xCE2990, 0x60
+sBellossomGfx22_2:
+.incbin "baserom.gba", 0xCE29F0, 0x60
+sBellossomSprites22:
+ax_sprite sBellossomGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx23:
+.incbin "baserom.gba", 0xCE2A88, 0x60
+sBellossomGfx23_1:
+.incbin "baserom.gba", 0xCE2AE8, 0x60
+sBellossomGfx23_2:
+.incbin "baserom.gba", 0xCE2B48, 0x80
+sBellossomSprites23:
+ax_sprite sBellossomGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx23_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBellossomGfx24:
+.incbin "baserom.gba", 0xCE2C00, 0x60
+sBellossomGfx24_1:
+.incbin "baserom.gba", 0xCE2C60, 0x60
+sBellossomGfx24_2:
+.incbin "baserom.gba", 0xCE2CC0, 0x60
+sBellossomSprites24:
+ax_sprite sBellossomGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx25:
+.incbin "baserom.gba", 0xCE2D58, 0x60
+sBellossomGfx25_1:
+.incbin "baserom.gba", 0xCE2DB8, 0x60
+sBellossomGfx25_2:
+.incbin "baserom.gba", 0xCE2E18, 0x60
+sBellossomSprites25:
+ax_sprite sBellossomGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx26:
+.incbin "baserom.gba", 0xCE2EB0, 0x60
+sBellossomGfx26_1:
+.incbin "baserom.gba", 0xCE2F10, 0x60
+sBellossomGfx26_2:
+.incbin "baserom.gba", 0xCE2F70, 0x60
+sBellossomGfx26_3:
+.incbin "baserom.gba", 0xCE2FD0, 0x20
+sBellossomSprites26:
+ax_sprite sBellossomGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBellossomGfx27:
+.incbin "baserom.gba", 0xCE3038, 0x60
+sBellossomGfx27_1:
+.incbin "baserom.gba", 0xCE3098, 0x60
+sBellossomGfx27_2:
+.incbin "baserom.gba", 0xCE30F8, 0x60
+sBellossomSprites27:
+ax_sprite sBellossomGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx28:
+.incbin "baserom.gba", 0xCE3190, 0x60
+sBellossomGfx28_1:
+.incbin "baserom.gba", 0xCE31F0, 0x60
+sBellossomGfx28_2:
+.incbin "baserom.gba", 0xCE3250, 0x60
+sBellossomSprites28:
+ax_sprite sBellossomGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx29:
+.incbin "baserom.gba", 0xCE32E8, 0x60
+sBellossomGfx29_1:
+.incbin "baserom.gba", 0xCE3348, 0x60
+sBellossomGfx29_2:
+.incbin "baserom.gba", 0xCE33A8, 0x60
+sBellossomGfx29_3:
+.incbin "baserom.gba", 0xCE3408, 0x20
+sBellossomSprites29:
+ax_sprite sBellossomGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBellossomGfx30:
+.incbin "baserom.gba", 0xCE3470, 0x40
+sBellossomGfx30_1:
+.incbin "baserom.gba", 0xCE34B0, 0x60
+sBellossomGfx30_2:
+.incbin "baserom.gba", 0xCE3510, 0x60
+sBellossomSprites30:
+ax_sprite sBellossomGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx31:
+.incbin "baserom.gba", 0xCE35A8, 0x60
+sBellossomGfx31_1:
+.incbin "baserom.gba", 0xCE3608, 0x60
+sBellossomGfx31_2:
+.incbin "baserom.gba", 0xCE3668, 0x60
+sBellossomSprites31:
+ax_sprite sBellossomGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx32:
+.incbin "baserom.gba", 0xCE3700, 0x60
+sBellossomGfx32_1:
+.incbin "baserom.gba", 0xCE3760, 0x60
+sBellossomGfx32_2:
+.incbin "baserom.gba", 0xCE37C0, 0x60
+sBellossomGfx32_3:
+.incbin "baserom.gba", 0xCE3820, 0x20
+sBellossomSprites32:
+ax_sprite sBellossomGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellossomGfx32_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBellossomGfx33:
+.incbin "baserom.gba", 0xCE3888, 0x60
+sBellossomGfx33_1:
+.incbin "baserom.gba", 0xCE38E8, 0x60
+sBellossomGfx33_2:
+.incbin "baserom.gba", 0xCE3948, 0x60
+sBellossomSprites33:
+ax_sprite sBellossomGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx34:
+.incbin "baserom.gba", 0xCE39E0, 0x60
+sBellossomGfx34_1:
+.incbin "baserom.gba", 0xCE3A40, 0x60
+sBellossomGfx34_2:
+.incbin "baserom.gba", 0xCE3AA0, 0x60
+sBellossomSprites34:
+ax_sprite sBellossomGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellossomGfx35:
+.incbin "baserom.gba", 0xCE3B38, 0x60
+sBellossomGfx35_1:
+.incbin "baserom.gba", 0xCE3B98, 0x60
+sBellossomGfx35_2:
+.incbin "baserom.gba", 0xCE3BF8, 0x80
+sBellossomSprites35:
+ax_sprite sBellossomGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellossomGfx35_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBellossomGfx36:
+.incbin "baserom.gba", 0xCE3CB0, 0x200
+sBellossomSprites36:
+ax_sprite sBellossomGfx36, 0x200
+ax_sprite_terminator
+sBellossomGfx37:
+.incbin "baserom.gba", 0xCE3EC0, 0x200
+sBellossomSprites37:
+ax_sprite sBellossomGfx37, 0x200
+ax_sprite_terminator
+sBellossomGfx38:
+.incbin "baserom.gba", 0xCE40D0, 0x200
+sBellossomSprites38:
+ax_sprite sBellossomGfx38, 0x200
+ax_sprite_terminator
+sBellossomGfx39:
+.incbin "baserom.gba", 0xCE42E0, 0x200
+sBellossomSprites39:
+ax_sprite sBellossomGfx39, 0x200
+ax_sprite_terminator
+sBellossomGfx40:
+.incbin "baserom.gba", 0xCE44F0, 0x200
+sBellossomSprites40:
+ax_sprite sBellossomGfx40, 0x200
+ax_sprite_terminator
+sBellossomGfx41:
+.incbin "baserom.gba", 0xCE4700, 0x200
+sBellossomSprites41:
+ax_sprite sBellossomGfx41, 0x200
+ax_sprite_terminator
+sBellossomGfx42:
+.incbin "baserom.gba", 0xCE4910, 0x200
+sBellossomSprites42:
+ax_sprite sBellossomGfx42, 0x200
+ax_sprite_terminator
+sAxPosesBellossom:
+.4byte sBellossomPose1
+.4byte sBellossomPose2
+.4byte sBellossomPose3
+.4byte sBellossomPose4
+.4byte sBellossomPose5
+.4byte sBellossomPose6
+.4byte sBellossomPose7
+.4byte sBellossomPose8
+.4byte sBellossomPose9
+.4byte sBellossomPose10
+.4byte sBellossomPose11
+.4byte sBellossomPose12
+.4byte sBellossomPose13
+.4byte sBellossomPose14
+.4byte sBellossomPose15
+.4byte sBellossomPose16
+.4byte sBellossomPose17
+.4byte sBellossomPose18
+.4byte sBellossomPose19
+.4byte sBellossomPose20
+.4byte sBellossomPose21
+.4byte sBellossomPose22
+.4byte sBellossomPose23
+.4byte sBellossomPose24
+.4byte sBellossomPose25
+.4byte sBellossomPose26
+.4byte sBellossomPose27
+.4byte sBellossomPose28
+.4byte sBellossomPose29
+.4byte sBellossomPose30
+.4byte sBellossomPose31
+.4byte sBellossomPose32
+.4byte sBellossomPose33
+.4byte sBellossomPose34
+.4byte sBellossomPose35
+.4byte sBellossomPose36
+.4byte sBellossomPose37
+.4byte sBellossomPose38
+.4byte sBellossomPose39
+.4byte sBellossomPose40
+.4byte sBellossomPose41
+.4byte sBellossomPose42
+.4byte sBellossomPose43
+.4byte sBellossomPose44
+.4byte sBellossomPose45
+.4byte sBellossomPose46
+.4byte sBellossomPose47
+.4byte sBellossomPose48
+.4byte sBellossomPose49
+.4byte sBellossomPose50
+.4byte sBellossomPose51
+.4byte sBellossomPose52
+.4byte sBellossomPose53
+.4byte sBellossomPose54
+.4byte sBellossomPose55
+.4byte sBellossomPose56
+.4byte sBellossomPose57
+.4byte sBellossomPose58
+.4byte sBellossomPose59
+.4byte sBellossomPose60
+.4byte sBellossomPose61
+.4byte sBellossomPose62
+.4byte sBellossomPose63
+.4byte sBellossomPose64
+.4byte sBellossomPose65
+.4byte sBellossomPose66
+.4byte sBellossomPose67
+.4byte sBellossomPose68
+.4byte sBellossomPose69
+.4byte sBellossomPose70
+.4byte sBellossomPose71
+.4byte sBellossomPose72
+.4byte sBellossomPose73
+.4byte sBellossomPose74
+.4byte sBellossomPose75
+.4byte sBellossomPose76
+.4byte sBellossomPose77
+.4byte sBellossomPose78
+.4byte sBellossomPose79
+.4byte sBellossomPose80
+.4byte sBellossomPose81
+.4byte sBellossomPose82
+.4byte sBellossomPose83
+.4byte sBellossomPose84
+.4byte sBellossomPose85
+.4byte sBellossomPose86
+.4byte sBellossomPose87
+.4byte sBellossomPose88
+.4byte sBellossomPose89
+.4byte sBellossomPose90
+.4byte sBellossomPose91
+.4byte sBellossomPose92
+.4byte sBellossomPose93
+.4byte sBellossomPose94
+.4byte sBellossomPose95
+.4byte sBellossomPose96
+.4byte sBellossomPose97
+.4byte sBellossomPose98
+.4byte sBellossomPose99
+.4byte sBellossomPose100
+.4byte sBellossomPose101
+.4byte sBellossomPose102
+.4byte sBellossomPose103
+.4byte sBellossomPose104
+.4byte sBellossomPose105
+.4byte sBellossomPose106
+.4byte sBellossomPose107
+.4byte sBellossomPose108
+.4byte sBellossomPose109
+.4byte sBellossomPose110
+.4byte sBellossomPose111
+.4byte sBellossomPose112
+.4byte sBellossomPose113
+.4byte sBellossomPose114
+.4byte sBellossomPose115
+.4byte sBellossomPose116
+.4byte sBellossomPose117
+.4byte sBellossomPose118
+.4byte sBellossomPose119
+.4byte sBellossomPose120
+.4byte sBellossomPose121
+.4byte sBellossomPose122
+.4byte sBellossomPose123
+.4byte sBellossomPose124
+.4byte sBellossomPose125
+.4byte sBellossomPose126
+.4byte sBellossomPose127
+.4byte sBellossomPose128
+.4byte sBellossomPose129
+.4byte sBellossomPose130
+.4byte sBellossomPose131
+.4byte sBellossomPose132
+.4byte sBellossomPose133
+.4byte sBellossomPose134
+.4byte sBellossomPose135
+.4byte sBellossomPose136
+.4byte sBellossomPose137
+.4byte sBellossomPose138
+.4byte sBellossomPose139
+.4byte sBellossomPose140
+.4byte sBellossomPose141
+.4byte sBellossomPose142
+.4byte sBellossomPose143
+.4byte sBellossomPose144
+.4byte sBellossomPose145
+.4byte sBellossomPose146
+.4byte sBellossomPose147
+.4byte sBellossomPose148
+.4byte sBellossomPose149
+.4byte sBellossomPose150
+.4byte sBellossomPose151
+.4byte sBellossomPose152
+.4byte sBellossomPose153
+.4byte sBellossomPose154
+.4byte sBellossomPose155
+.4byte sBellossomPose156
+.4byte sBellossomPose157
+.4byte sBellossomPose158
+.4byte sBellossomPose159
+.4byte sBellossomPose160
+.4byte sBellossomPose161
+.4byte sBellossomPose162
+.4byte sBellossomPose163
+.4byte sBellossomPose164
+.4byte sBellossomPose165
+.4byte sBellossomPose166
+.4byte sBellossomPose167
+.4byte sBellossomPose168
+.4byte sBellossomPose169
+.4byte sBellossomPose170
+.4byte sBellossomPose171
+.4byte sBellossomPose172
+.4byte sBellossomPose173
+.4byte sBellossomPose174
+.4byte sBellossomPose175
+.4byte sBellossomPose176
+.4byte sBellossomPose177
+.4byte sBellossomPose178
+.4byte sBellossomPose179
+.4byte sBellossomPose180
+.4byte sBellossomPose181
+.4byte sBellossomPose182
+.4byte sBellossomPose183
+.4byte sBellossomPose184
+.4byte sBellossomPose185
+.4byte sBellossomPose186
+.4byte sBellossomPose187
+.4byte sBellossomPose188
+.4byte sBellossomPose189
+.4byte sBellossomPose190
+.4byte sBellossomPose191
+.4byte sBellossomPose192
+.4byte sBellossomPose193
+.4byte sBellossomPose194
+.4byte sBellossomPose195
+.4byte sBellossomPose196
+.4byte sBellossomPose197
+.4byte sBellossomPose198
+.4byte sBellossomPose199
+.4byte sBellossomPose200
+.4byte sBellossomPose201
+.4byte sBellossomPose202
+.4byte sBellossomPose203
+.4byte sBellossomPose204
+.4byte sBellossomPose205
+.4byte sBellossomPose206
+.4byte sBellossomPose207
+.4byte sBellossomPose208
+.4byte sBellossomPose209
+.4byte sBellossomPose210
+.4byte sBellossomPose211
+.4byte sBellossomPose212
+.4byte sBellossomPose213
+.4byte sBellossomPose214
+.4byte sBellossomPose215
+.4byte sBellossomPose216
+.4byte sBellossomPose217
+.4byte sBellossomPose218
+sAxPositionsBellossom:
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   1,   -3, 	  -1,   -4
+.2byte   -1,   -7, 	  -4,   -3, 	   4,   -4, 	   0,   -4
+.2byte    1,   -8, 	   5,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	   6,   -6, 	   3,   -3, 	  -1,   -5
+.2byte    1,   -7, 	   4,   -5, 	  -2,   -2, 	  -1,   -5
+.2byte    2,   -9, 	   4,   -8, 	   3,   -5, 	  -1,   -7
+.2byte    2,   -9, 	   4,   -7, 	   3,   -6, 	  -1,   -6
+.2byte    2,   -8, 	   3,   -6, 	   1,   -4, 	  -2,   -6
+.2byte    0,  -10, 	  -2,  -10, 	   5,   -8, 	  -2,   -7
+.2byte    0,   -9, 	  -5,   -8, 	   1,   -7, 	  -2,   -5
+.2byte    0,   -9, 	   0,   -8, 	   5,   -6, 	  -2,   -6
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -5, 	  -3,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   1,   -4, 	  -5,   -5, 	  -1,   -4
+.2byte   -2,  -10, 	   0,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -3,   -7, 	   0,   -5
+.2byte   -2,   -9, 	  -2,   -8, 	  -7,   -6, 	   0,   -6
+.2byte   -4,   -9, 	  -6,   -8, 	  -5,   -5, 	  -1,   -7
+.2byte   -4,   -9, 	  -6,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,   -8, 	  -5,   -6, 	  -3,   -4, 	   0,   -6
+.2byte   -3,   -8, 	  -7,   -6, 	  -3,   -3, 	  -1,   -6
+.2byte   -3,   -7, 	  -8,   -6, 	  -5,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	  -6,   -5, 	   0,   -2, 	  -1,   -5
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   1,   -3, 	  -1,   -4
+.2byte   -1,   -7, 	  -4,   -3, 	   4,   -4, 	   0,   -4
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte    1,   -8, 	   5,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	   6,   -6, 	   3,   -3, 	  -1,   -5
+.2byte    1,   -7, 	   4,   -5, 	  -2,   -2, 	  -1,   -5
+.2byte    4,   -5, 	   5,   -4, 	   2,    0, 	   0,   -5
+.2byte    2,   -9, 	   4,   -8, 	   3,   -5, 	  -1,   -7
+.2byte    2,   -9, 	   4,   -7, 	   3,   -6, 	  -1,   -6
+.2byte    2,   -8, 	   3,   -6, 	   1,   -4, 	  -2,   -6
+.2byte    4,   -6, 	   4,   -4, 	   4,   -3, 	  -1,   -6
+.2byte    0,  -10, 	  -2,  -10, 	   5,   -8, 	  -2,   -7
+.2byte    0,   -9, 	  -5,   -8, 	   1,   -7, 	  -2,   -5
+.2byte    0,   -9, 	   0,   -8, 	   5,   -6, 	  -2,   -6
+.2byte    2,   -8, 	  -1,   -6, 	   3,   -3, 	   0,   -6
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -5, 	  -3,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   1,   -4, 	  -5,   -5, 	  -1,   -4
+.2byte   -1,   -7, 	   3,   -2, 	  -5,   -2, 	  -1,   -4
+.2byte   -2,  -10, 	   0,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -3,   -7, 	   0,   -5
+.2byte   -2,   -9, 	  -2,   -8, 	  -7,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -1,   -6, 	  -5,   -3, 	  -2,   -6
+.2byte   -4,   -9, 	  -6,   -8, 	  -5,   -5, 	  -1,   -7
+.2byte   -4,   -9, 	  -6,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,   -8, 	  -5,   -6, 	  -3,   -4, 	   0,   -6
+.2byte   -6,   -6, 	  -6,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte   -3,   -8, 	  -7,   -6, 	  -3,   -3, 	  -1,   -6
+.2byte   -3,   -7, 	  -8,   -6, 	  -5,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	  -6,   -5, 	   0,   -2, 	  -1,   -5
+.2byte   -6,   -5, 	  -7,   -4, 	  -4,    0, 	  -2,   -5
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   1,   -3, 	  -1,   -4
+.2byte   -1,   -7, 	  -4,   -3, 	   4,   -4, 	   0,   -4
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte    1,   -8, 	   5,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	   6,   -6, 	   3,   -3, 	  -1,   -5
+.2byte    1,   -7, 	   4,   -5, 	  -2,   -2, 	  -1,   -5
+.2byte    4,   -5, 	   5,   -4, 	   2,    0, 	   0,   -5
+.2byte    2,   -9, 	   4,   -8, 	   3,   -5, 	  -1,   -7
+.2byte    2,   -9, 	   4,   -7, 	   3,   -6, 	  -1,   -6
+.2byte    2,   -8, 	   3,   -6, 	   1,   -4, 	  -2,   -6
+.2byte    4,   -6, 	   4,   -4, 	   4,   -3, 	  -1,   -6
+.2byte    0,  -10, 	  -2,  -10, 	   5,   -8, 	  -2,   -7
+.2byte    0,   -9, 	  -5,   -8, 	   1,   -7, 	  -2,   -5
+.2byte    0,   -9, 	   0,   -8, 	   5,   -6, 	  -2,   -6
+.2byte    2,   -8, 	  -1,   -6, 	   3,   -3, 	   0,   -6
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -5, 	  -3,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   1,   -4, 	  -5,   -5, 	  -1,   -4
+.2byte   -1,   -7, 	   3,   -2, 	  -5,   -2, 	  -1,   -4
+.2byte   -2,  -10, 	   0,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -3,   -7, 	   0,   -5
+.2byte   -2,   -9, 	  -2,   -8, 	  -7,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -1,   -6, 	  -5,   -3, 	  -2,   -6
+.2byte   -4,   -9, 	  -6,   -8, 	  -5,   -5, 	  -1,   -7
+.2byte   -4,   -9, 	  -6,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,   -8, 	  -5,   -6, 	  -3,   -4, 	   0,   -6
+.2byte   -6,   -6, 	  -6,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte   -3,   -8, 	  -7,   -6, 	  -3,   -3, 	  -1,   -6
+.2byte   -3,   -7, 	  -8,   -6, 	  -5,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	  -6,   -5, 	   0,   -2, 	  -1,   -5
+.2byte   -6,   -5, 	  -7,   -4, 	  -4,    0, 	  -2,   -5
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte   -6,   -5, 	  -7,   -4, 	  -4,    0, 	  -2,   -5
+.2byte   -6,   -6, 	  -6,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -1,   -7, 	  -5,   -4, 	  -2,   -7
+.2byte   -1,   -9, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte    2,   -9, 	  -1,   -7, 	   3,   -4, 	   0,   -7
+.2byte    4,   -6, 	   4,   -4, 	   4,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   5,   -4, 	   2,    0, 	   0,   -5
+.2byte   -3,   -8, 	  -6,   -5, 	  -2,   -4, 	  -2,   -6
+.2byte    1,   -8, 	   0,   -4, 	   4,   -5, 	   0,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -4
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -7,   -6, 	  -3,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -6,   -8, 	  -5,   -5, 	  -1,   -7
+.2byte   -2,  -10, 	   0,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte    0,  -10, 	  -2,  -10, 	   5,   -8, 	  -2,   -7
+.2byte    2,   -9, 	   4,   -8, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   5,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	   2,   -4, 	  -3,   -2, 	   0,   -5
+.2byte    3,   -8, 	   5,   -8, 	   3,   -5, 	  -2,   -6
+.2byte    1,   -7, 	   5,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte    1,   -8, 	   4,   -6, 	  -1,   -3, 	   0,   -5
+.2byte    0,   -9, 	  -3,   -8, 	   4,   -8, 	  -2,   -6
+.2byte    2,   -7, 	   4,   -9, 	   1,   -3, 	  -2,   -5
+.2byte    1,   -9, 	   2,   -8, 	   5,   -5, 	  -1,   -5
+.2byte   -1,   -9, 	  -6,   -5, 	   0,   -6, 	  -2,   -6
+.2byte    0,   -8, 	   1,   -6, 	   5,   -5, 	  -2,   -5
+.2byte    1,  -10, 	   3,   -5, 	  -2,   -5, 	  -1,   -6
+.2byte   -3,  -10, 	   0,   -5, 	  -5,   -5, 	   0,   -6
+.2byte   -1,   -8, 	   5,   -8, 	  -7,   -8, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -5, 	  -2,   -6, 	   0,   -6
+.2byte   -3,   -9, 	  -4,   -8, 	  -7,   -5, 	  -1,   -5
+.2byte   -2,   -8, 	  -3,   -6, 	  -7,   -5, 	   0,   -5
+.2byte   -2,   -9, 	   1,   -8, 	  -6,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -6,   -6, 	  -1,   -3, 	  -2,   -5
+.2byte   -4,   -7, 	  -6,   -9, 	  -3,   -3, 	   0,   -5
+.2byte   -5,   -8, 	  -7,   -8, 	  -5,   -5, 	   0,   -6
+.2byte   -3,   -7, 	  -4,   -4, 	   1,   -2, 	  -2,   -5
+.2byte   -3,   -7, 	  -7,   -7, 	   0,   -2, 	  -1,   -5
+.2byte   -1,   -9, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -5,   -8, 	   3,   -8, 	  -1,   -7
+.2byte    0,  -11, 	   4,  -14, 	   1,   -9, 	  -1,   -8
+.2byte    0,  -12, 	   2,  -14, 	   1,  -11, 	  -3,   -9
+.2byte    0,  -12, 	  -1,  -13, 	   4,  -12, 	  -2,   -7
+.2byte   -1,   -9, 	   3,   -9, 	  -5,   -9, 	  -1,   -7
+.2byte   -1,  -12, 	   0,  -13, 	  -5,  -12, 	   1,   -7
+.2byte   -1,  -12, 	  -3,  -14, 	  -2,  -11, 	   2,   -9
+.2byte   -1,  -11, 	  -5,  -14, 	  -2,   -9, 	   0,   -8
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -6,   -5, 	  -2,   -4, 	  -2,   -6
+.2byte    1,   -8, 	   0,   -4, 	   4,   -5, 	   0,   -6
+.2byte    1,   -8, 	   5,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	   2,   -4, 	  -3,   -2, 	   0,   -5
+.2byte    3,   -8, 	   5,   -8, 	   3,   -5, 	  -2,   -6
+.2byte    2,   -9, 	   4,   -8, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   4,   -6, 	  -1,   -3, 	   0,   -5
+.2byte    0,   -9, 	  -3,   -8, 	   4,   -8, 	  -2,   -6
+.2byte    0,  -10, 	  -2,  -10, 	   5,   -8, 	  -2,   -7
+.2byte    1,   -9, 	   2,   -8, 	   5,   -5, 	  -1,   -5
+.2byte   -1,   -9, 	  -6,   -5, 	   0,   -6, 	  -2,   -6
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte    1,  -10, 	   3,   -5, 	  -2,   -5, 	  -1,   -6
+.2byte   -3,  -10, 	   0,   -5, 	  -5,   -5, 	   0,   -6
+.2byte   -2,  -10, 	   0,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -1,   -9, 	   4,   -5, 	  -2,   -6, 	   0,   -6
+.2byte   -3,   -9, 	  -4,   -8, 	  -7,   -5, 	  -1,   -5
+.2byte   -4,   -9, 	  -6,   -8, 	  -5,   -5, 	  -1,   -7
+.2byte   -2,   -9, 	   1,   -8, 	  -6,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -6,   -6, 	  -1,   -3, 	  -2,   -5
+.2byte   -3,   -8, 	  -7,   -6, 	  -3,   -3, 	  -1,   -6
+.2byte   -5,   -8, 	  -7,   -8, 	  -5,   -5, 	   0,   -6
+.2byte   -3,   -7, 	  -4,   -4, 	   1,   -2, 	  -2,   -5
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte   -6,   -6, 	  -7,   -5, 	  -4,   -1, 	  -2,   -6
+.2byte   -6,   -6, 	  -6,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte   -2,   -9, 	   1,   -7, 	  -3,   -4, 	   0,   -7
+.2byte   -1,   -9, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte    1,   -9, 	  -2,   -7, 	   2,   -4, 	  -1,   -7
+.2byte    4,   -6, 	   4,   -4, 	   4,   -3, 	  -1,   -6
+.2byte    4,   -6, 	   5,   -5, 	   2,   -1, 	   0,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -4
+.2byte    1,   -7, 	   5,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte    2,   -7, 	   4,   -9, 	   1,   -3, 	  -2,   -5
+.2byte    0,   -8, 	   1,   -6, 	   5,   -5, 	  -2,   -5
+.2byte   -1,   -8, 	   5,   -8, 	  -7,   -8, 	  -1,   -5
+.2byte   -2,   -8, 	  -3,   -6, 	  -7,   -5, 	   0,   -5
+.2byte   -4,   -7, 	  -6,   -9, 	  -3,   -3, 	   0,   -5
+.2byte   -3,   -7, 	  -7,   -7, 	   0,   -2, 	  -1,   -5
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -4
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte    1,   -8, 	   5,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	   5,   -7, 	  -2,   -2, 	  -1,   -5
+.2byte    3,   -5, 	   4,   -4, 	   1,    0, 	  -1,   -5
+.2byte    2,   -9, 	   4,   -8, 	   3,   -5, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -9, 	   1,   -3, 	  -2,   -5
+.2byte    3,   -6, 	   3,   -4, 	   3,   -3, 	  -2,   -6
+.2byte    0,  -10, 	  -2,  -10, 	   5,   -8, 	  -2,   -7
+.2byte    0,   -8, 	   1,   -6, 	   5,   -5, 	  -2,   -5
+.2byte    1,   -8, 	  -2,   -6, 	   2,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,   -8, 	   5,   -8, 	  -7,   -8, 	  -1,   -5
+.2byte   -1,   -7, 	   3,   -2, 	  -5,   -2, 	  -1,   -4
+.2byte   -2,  -10, 	   0,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -2,   -8, 	  -3,   -6, 	  -7,   -5, 	   0,   -5
+.2byte   -3,   -8, 	   0,   -6, 	  -4,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -6,   -8, 	  -5,   -5, 	  -1,   -7
+.2byte   -4,   -7, 	  -6,   -9, 	  -3,   -3, 	   0,   -5
+.2byte   -5,   -6, 	  -5,   -4, 	  -5,   -3, 	   0,   -6
+.2byte   -3,   -8, 	  -7,   -6, 	  -3,   -3, 	  -1,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   0,   -2, 	  -1,   -5
+.2byte   -6,   -5, 	  -7,   -4, 	  -4,    0, 	  -2,   -5
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte   -6,   -5, 	  -7,   -4, 	  -4,    0, 	  -2,   -5
+.2byte   -6,   -6, 	  -6,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -1,   -7, 	  -5,   -4, 	  -2,   -7
+.2byte   -1,   -9, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte    2,   -9, 	  -1,   -7, 	   3,   -4, 	   0,   -7
+.2byte    4,   -6, 	   4,   -4, 	   4,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   5,   -4, 	   2,    0, 	   0,   -5
+.2byte   -1,   -8, 	  -5,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -7,   -6, 	  -3,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -6,   -8, 	  -5,   -5, 	  -1,   -7
+.2byte   -2,  -10, 	   0,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte    0,  -10, 	  -2,  -10, 	   5,   -8, 	  -2,   -7
+.2byte    2,   -9, 	   4,   -8, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   5,   -6, 	   1,   -3, 	  -1,   -6
+sBellossomAnimTable1:
+.4byte sBellossomAnims_1_1
+.4byte sBellossomAnims_1_2
+.4byte sBellossomAnims_1_3
+.4byte sBellossomAnims_1_4
+.4byte sBellossomAnims_1_5
+.4byte sBellossomAnims_1_6
+.4byte sBellossomAnims_1_7
+.4byte sBellossomAnims_1_8
+sBellossomAnimTable2:
+.4byte sBellossomAnims_2_1
+.4byte sBellossomAnims_2_2
+.4byte sBellossomAnims_2_3
+.4byte sBellossomAnims_2_4
+.4byte sBellossomAnims_2_5
+.4byte sBellossomAnims_2_6
+.4byte sBellossomAnims_2_7
+.4byte sBellossomAnims_2_8
+sBellossomAnimTable3:
+.4byte sBellossomAnims_3_1
+.4byte sBellossomAnims_3_2
+.4byte sBellossomAnims_3_3
+.4byte sBellossomAnims_3_4
+.4byte sBellossomAnims_3_5
+.4byte sBellossomAnims_3_6
+.4byte sBellossomAnims_3_7
+.4byte sBellossomAnims_3_8
+sBellossomAnimTable4:
+.4byte sBellossomAnims_4_1
+.4byte sBellossomAnims_4_2
+.4byte sBellossomAnims_4_3
+.4byte sBellossomAnims_4_4
+.4byte sBellossomAnims_4_5
+.4byte sBellossomAnims_4_6
+.4byte sBellossomAnims_4_7
+.4byte sBellossomAnims_4_8
+sBellossomAnimTable5:
+.4byte sBellossomAnims_5_1
+.4byte sBellossomAnims_5_2
+.4byte sBellossomAnims_5_3
+.4byte sBellossomAnims_5_4
+.4byte sBellossomAnims_5_5
+.4byte sBellossomAnims_5_6
+.4byte sBellossomAnims_5_7
+.4byte sBellossomAnims_5_8
+sBellossomAnimTable6:
+.4byte sBellossomAnims_6_1
+.4byte sBellossomAnims_6_1
+.4byte sBellossomAnims_6_1
+.4byte sBellossomAnims_6_1
+.4byte sBellossomAnims_6_1
+.4byte sBellossomAnims_6_1
+.4byte sBellossomAnims_6_1
+.4byte sBellossomAnims_6_1
+sBellossomAnimTable7:
+.4byte sBellossomAnims_7_1
+.4byte sBellossomAnims_7_2
+.4byte sBellossomAnims_7_3
+.4byte sBellossomAnims_7_4
+.4byte sBellossomAnims_7_5
+.4byte sBellossomAnims_7_6
+.4byte sBellossomAnims_7_7
+.4byte sBellossomAnims_7_8
+sBellossomAnimTable8:
+.4byte sBellossomAnims_8_1
+.4byte sBellossomAnims_8_2
+.4byte sBellossomAnims_8_3
+.4byte sBellossomAnims_8_4
+.4byte sBellossomAnims_8_5
+.4byte sBellossomAnims_8_6
+.4byte sBellossomAnims_8_7
+.4byte sBellossomAnims_8_8
+sBellossomAnimTable9:
+.4byte sBellossomAnims_9_1
+.4byte sBellossomAnims_9_2
+.4byte sBellossomAnims_9_3
+.4byte sBellossomAnims_9_4
+.4byte sBellossomAnims_9_5
+.4byte sBellossomAnims_9_6
+.4byte sBellossomAnims_9_7
+.4byte sBellossomAnims_9_8
+sBellossomAnimTable10:
+.4byte sBellossomAnims_10_1
+.4byte sBellossomAnims_10_2
+.4byte sBellossomAnims_10_3
+.4byte sBellossomAnims_10_4
+.4byte sBellossomAnims_10_5
+.4byte sBellossomAnims_10_6
+.4byte sBellossomAnims_10_7
+.4byte sBellossomAnims_10_8
+sBellossomAnimTable11:
+.4byte sBellossomAnims_11_1
+.4byte sBellossomAnims_11_2
+.4byte sBellossomAnims_11_3
+.4byte sBellossomAnims_11_4
+.4byte sBellossomAnims_11_5
+.4byte sBellossomAnims_11_6
+.4byte sBellossomAnims_11_7
+.4byte sBellossomAnims_11_8
+sBellossomAnimTable12:
+.4byte sBellossomAnims_12_1
+.4byte sBellossomAnims_12_2
+.4byte sBellossomAnims_12_3
+.4byte sBellossomAnims_12_4
+.4byte sBellossomAnims_12_5
+.4byte sBellossomAnims_12_6
+.4byte sBellossomAnims_12_7
+.4byte sBellossomAnims_12_8
+sBellossomAnimTable13:
+.4byte sBellossomAnims_13_1
+.4byte sBellossomAnims_13_2
+.4byte sBellossomAnims_13_3
+.4byte sBellossomAnims_13_4
+.4byte sBellossomAnims_13_5
+.4byte sBellossomAnims_13_6
+.4byte sBellossomAnims_13_7
+.4byte sBellossomAnims_13_8
+sAxAnimationsBellossom:
+.4byte sBellossomAnimTable1
+.4byte sBellossomAnimTable2
+.4byte sBellossomAnimTable3
+.4byte sBellossomAnimTable4
+.4byte sBellossomAnimTable5
+.4byte sBellossomAnimTable6
+.4byte sBellossomAnimTable7
+.4byte sBellossomAnimTable8
+.4byte sBellossomAnimTable9
+.4byte sBellossomAnimTable10
+.4byte sBellossomAnimTable11
+.4byte sBellossomAnimTable12
+.4byte sBellossomAnimTable13
+sAxSpritesBellossom:
+.4byte sBellossomSprites1
+.4byte sBellossomSprites2
+.4byte sBellossomSprites3
+.4byte sBellossomSprites4
+.4byte sBellossomSprites5
+.4byte sBellossomSprites6
+.4byte sBellossomSprites7
+.4byte sBellossomSprites8
+.4byte sBellossomSprites9
+.4byte sBellossomSprites10
+.4byte sBellossomSprites11
+.4byte sBellossomSprites12
+.4byte sBellossomSprites13
+.4byte sBellossomSprites14
+.4byte sBellossomSprites15
+.4byte sBellossomSprites16
+.4byte sBellossomSprites17
+.4byte sBellossomSprites18
+.4byte sBellossomSprites19
+.4byte sBellossomSprites20
+.4byte sBellossomSprites21
+.4byte sBellossomSprites22
+.4byte sBellossomSprites23
+.4byte sBellossomSprites24
+.4byte sBellossomSprites25
+.4byte sBellossomSprites26
+.4byte sBellossomSprites27
+.4byte sBellossomSprites28
+.4byte sBellossomSprites29
+.4byte sBellossomSprites30
+.4byte sBellossomSprites31
+.4byte sBellossomSprites32
+.4byte sBellossomSprites33
+.4byte sBellossomSprites34
+.4byte sBellossomSprites35
+.4byte sBellossomSprites36
+.4byte sBellossomSprites37
+.4byte sBellossomSprites38
+.4byte sBellossomSprites39
+.4byte sBellossomSprites40
+.4byte sBellossomSprites41
+.4byte sBellossomSprites42
+sAxMainBellossom:
+ax_main sAxPosesBellossom, sAxAnimationsBellossom, 13, sAxSpritesBellossom, sAxPositionsBellossom

--- a/data/ax/bellsprout.inc
+++ b/data/ax/bellsprout.inc
@@ -1,0 +1,2758 @@
+.global gAxBellsprout
+gAxBellsprout:
+ax_siro sAxMainBellsprout
+sBellsproutPose1:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose2:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose3:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose4:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose5:
+ax_pose 4, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose6:
+ax_pose 5, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose7:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose8:
+ax_pose 7, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose9:
+ax_pose 8, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose10:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose11:
+ax_pose 10, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose12:
+ax_pose 11, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose13:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose14:
+ax_pose 13, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose15:
+ax_pose 14, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose16:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose17:
+ax_pose 10, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose18:
+ax_pose 11, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose19:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose20:
+ax_pose 7, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose21:
+ax_pose 8, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose22:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose23:
+ax_pose 4, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose24:
+ax_pose 5, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose25:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose26:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose27:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose28:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose29:
+ax_pose 4, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose30:
+ax_pose 5, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose31:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose32:
+ax_pose 7, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose33:
+ax_pose 8, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose34:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose35:
+ax_pose 10, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose36:
+ax_pose 11, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose37:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose38:
+ax_pose 13, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose39:
+ax_pose 14, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose40:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose41:
+ax_pose 10, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose42:
+ax_pose 11, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose43:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose44:
+ax_pose 7, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose45:
+ax_pose 8, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose46:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose47:
+ax_pose 4, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose48:
+ax_pose 5, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose49:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose50:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose51:
+ax_pose 16, 0x81eb, 0x80f4, 0x3c00
+ax_pose 17, 0x01eb, 0x80f4, 0x3c08
+ax_pose_terminator
+sBellsproutPose52:
+ax_pose 17, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose53:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose54:
+ax_pose 18, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose55:
+ax_pose 19, 0x01ea, 0x90ed, 0x3c00
+ax_pose 20, 0x81e8, 0x90fe, 0x3c10
+ax_pose_terminator
+sBellsproutPose56:
+ax_pose 19, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose57:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose58:
+ax_pose 21, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sBellsproutPose59:
+ax_pose 22, 0x01e8, 0x90ee, 0x3c00
+ax_pose 23, 0x01e6, 0x90ee, 0x3c10
+ax_pose_terminator
+sBellsproutPose60:
+ax_pose 22, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sBellsproutPose61:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose62:
+ax_pose 24, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose63:
+ax_pose 25, 0x01ec, 0x90ed, 0x3c00
+ax_pose 26, 0x01eb, 0x90ed, 0x3c10
+ax_pose_terminator
+sBellsproutPose64:
+ax_pose 25, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose65:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose66:
+ax_pose 27, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose67:
+ax_pose 28, 0x01ec, 0x80f8, 0x3c00
+ax_pose 29, 0x81e3, 0x80fb, 0x3c10
+ax_pose_terminator
+sBellsproutPose68:
+ax_pose 28, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose69:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose70:
+ax_pose 24, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose71:
+ax_pose 25, 0x01ec, 0x80f3, 0x3c00
+ax_pose 26, 0x01eb, 0x80f3, 0x3c10
+ax_pose_terminator
+sBellsproutPose72:
+ax_pose 25, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose73:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose74:
+ax_pose 21, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sBellsproutPose75:
+ax_pose 22, 0x01e8, 0x80f2, 0x3c00
+ax_pose 23, 0x01e6, 0x80f2, 0x3c10
+ax_pose_terminator
+sBellsproutPose76:
+ax_pose 22, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sBellsproutPose77:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose78:
+ax_pose 18, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose79:
+ax_pose 19, 0x01ea, 0x80f3, 0x3c00
+ax_pose 20, 0x81e8, 0x80f2, 0x3c10
+ax_pose_terminator
+sBellsproutPose80:
+ax_pose 19, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose81:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose82:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose83:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose84:
+ax_pose 30, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose85:
+ax_pose 31, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose86:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose87:
+ax_pose 4, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose88:
+ax_pose 5, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose89:
+ax_pose 32, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellsproutPose90:
+ax_pose 33, 0x01ea, 0x90eb, 0x3c00
+ax_pose_terminator
+sBellsproutPose91:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose92:
+ax_pose 7, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose93:
+ax_pose 8, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose94:
+ax_pose 34, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose95:
+ax_pose 35, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose96:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose97:
+ax_pose 10, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose98:
+ax_pose 11, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose99:
+ax_pose 36, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sBellsproutPose100:
+ax_pose 37, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sBellsproutPose101:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose102:
+ax_pose 13, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose103:
+ax_pose 14, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose104:
+ax_pose 38, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sBellsproutPose105:
+ax_pose 39, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sBellsproutPose106:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose107:
+ax_pose 10, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose108:
+ax_pose 11, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose109:
+ax_pose 36, 0x01eb, 0x80f1, 0x3c00
+ax_pose_terminator
+sBellsproutPose110:
+ax_pose 37, 0x01eb, 0x80f1, 0x3c00
+ax_pose_terminator
+sBellsproutPose111:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose112:
+ax_pose 7, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose113:
+ax_pose 8, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose114:
+ax_pose 34, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose115:
+ax_pose 35, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose116:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose117:
+ax_pose 4, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose118:
+ax_pose 5, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose119:
+ax_pose 32, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellsproutPose120:
+ax_pose 33, 0x01ea, 0x80f5, 0x3c00
+ax_pose_terminator
+sBellsproutPose121:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose122:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose123:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose124:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose125:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose126:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose127:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose128:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose129:
+ax_pose 40, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose130:
+ax_pose 41, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose131:
+ax_pose 42, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sBellsproutPose132:
+ax_pose 43, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sBellsproutPose133:
+ax_pose 44, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sBellsproutPose134:
+ax_pose 45, 0x01e9, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose135:
+ax_pose 46, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose136:
+ax_pose 45, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose137:
+ax_pose 44, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose138:
+ax_pose 43, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sBellsproutPose139:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose140:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose141:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose142:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose143:
+ax_pose 4, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose144:
+ax_pose 5, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose145:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose146:
+ax_pose 7, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose147:
+ax_pose 8, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose148:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose149:
+ax_pose 10, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose150:
+ax_pose 11, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose151:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose152:
+ax_pose 13, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose153:
+ax_pose 14, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sBellsproutPose154:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose155:
+ax_pose 10, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose156:
+ax_pose 11, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose157:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose158:
+ax_pose 7, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose159:
+ax_pose 8, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose160:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose161:
+ax_pose 4, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose162:
+ax_pose 5, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose163:
+ax_pose 30, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose164:
+ax_pose 32, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellsproutPose165:
+ax_pose 34, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose166:
+ax_pose 36, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose167:
+ax_pose 38, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sBellsproutPose168:
+ax_pose 36, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose169:
+ax_pose 34, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose170:
+ax_pose 32, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellsproutPose171:
+ax_pose 30, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose172:
+ax_pose 32, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellsproutPose173:
+ax_pose 34, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose174:
+ax_pose 36, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose175:
+ax_pose 38, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sBellsproutPose176:
+ax_pose 36, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose177:
+ax_pose 34, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose178:
+ax_pose 32, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellsproutPose179:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose180:
+ax_pose 30, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose181:
+ax_pose 31, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose182:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose183:
+ax_pose 32, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellsproutPose184:
+ax_pose 33, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellsproutPose185:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose186:
+ax_pose 34, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose187:
+ax_pose 35, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose188:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose189:
+ax_pose 36, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose190:
+ax_pose 37, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose191:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose192:
+ax_pose 38, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sBellsproutPose193:
+ax_pose 39, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sBellsproutPose194:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose195:
+ax_pose 36, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose196:
+ax_pose 37, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose197:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose198:
+ax_pose 34, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose199:
+ax_pose 35, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose200:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose201:
+ax_pose 32, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellsproutPose202:
+ax_pose 33, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellsproutPose203:
+ax_pose 30, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose204:
+ax_pose 32, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sBellsproutPose205:
+ax_pose 34, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose206:
+ax_pose 36, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sBellsproutPose207:
+ax_pose 38, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sBellsproutPose208:
+ax_pose 36, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose209:
+ax_pose 34, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sBellsproutPose210:
+ax_pose 32, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sBellsproutPose211:
+ax_pose 0, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBellsproutPose212:
+ax_pose 3, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose213:
+ax_pose 6, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose214:
+ax_pose 9, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose215:
+ax_pose 12, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose216:
+ax_pose 9, 0x81ec, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose217:
+ax_pose 6, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+sBellsproutPose218:
+ax_pose 3, 0x81ee, 0x90f8, 0x3c00
+ax_pose_terminator
+.align 2
+sBellsproutAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBellsproutAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, -1,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 1, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 0, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sBellsproutAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 13, 0, 13, 0,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 1, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 0, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sBellsproutAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 21, -23, 21, -23,
+ax_anim 2, 1, 34, 22, -22, 22, -22,
+ax_anim 2, 0, 34, 21, -23, 21, -23,
+ax_anim 2, 0, 34, 22, -22, 22, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sBellsproutAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sBellsproutAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -21, -23, -21, -23,
+ax_anim 2, 1, 40, -22, -22, -22, -22,
+ax_anim 2, 0, 40, -21, -23, -21, -23,
+ax_anim 2, 0, 40, -22, -22, -22, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sBellsproutAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -13, 0, -13, 0,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 1, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 0, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sBellsproutAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -19, 21, -19, 21,
+ax_anim 2, 1, 46, -20, 20, -20, 20,
+ax_anim 2, 0, 46, -19, 21, -19, 21,
+ax_anim 2, 0, 46, -19, 21, -19, 21,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 1, 2, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, 9, 0, 9,
+ax_anim 2, 0, 50, 0, 20, 0, 20,
+ax_anim 2, 1, 51, 1, 20, 1, 20,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 0, 51, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sBellsproutAnims_3_2:
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 1, 2, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 53, 9, 9, 9, 9,
+ax_anim 2, 0, 54, 19, 20, 19, 20,
+ax_anim 2, 1, 55, 20, 19, 20, 19,
+ax_anim 2, 0, 55, 19, 20, 19, 20,
+ax_anim 2, 0, 55, 20, 19, 20, 19,
+ax_anim 2, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 3, 3, 3, 3,
+ax_anim_terminator
+sBellsproutAnims_3_3:
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 6, 0, 57, -3, 0, -3, 0,
+ax_anim 1, 2, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 9, 0, 9, 0,
+ax_anim 2, 0, 58, 17, 0, 17, 0,
+ax_anim 2, 1, 59, 17, 1, 17, 1,
+ax_anim 2, 0, 59, 17, 0, 17, 0,
+ax_anim 2, 0, 59, 17, 1, 17, 1,
+ax_anim 2, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim_terminator
+sBellsproutAnims_3_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 1, 2, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 9, -11, 9, -11,
+ax_anim 2, 0, 62, 19, -23, 19, -23,
+ax_anim 2, 1, 63, 19, -22, 19, -22,
+ax_anim 2, 0, 63, 19, -23, 19, -23,
+ax_anim 2, 0, 63, 19, -22, 19, -22,
+ax_anim 2, 0, 60, 10, -10, 10, -10,
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim_terminator
+sBellsproutAnims_3_5:
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 1, 2, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 65, 0, -11, 0, -11,
+ax_anim 2, 0, 66, 0, -23, 0, -23,
+ax_anim 2, 1, 67, -1, -23, -1, -23,
+ax_anim 2, 0, 67, 0, -23, 0, -23,
+ax_anim 2, 0, 67, -1, -23, -1, -23,
+ax_anim 2, 0, 64, 0, -10, 0, -10,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sBellsproutAnims_3_6:
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 1, 2, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 69, -9, -11, -9, -11,
+ax_anim 2, 0, 70, -19, -23, -19, -23,
+ax_anim 2, 1, 71, -19, -22, -19, -22,
+ax_anim 2, 0, 71, -19, -23, -19, -23,
+ax_anim 2, 0, 71, -19, -22, -19, -22,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, -3, -3, -3, -3,
+ax_anim_terminator
+sBellsproutAnims_3_7:
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 6, 0, 73, 3, 0, 3, 0,
+ax_anim 1, 2, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, -9, 0, -9, 0,
+ax_anim 2, 0, 74, -17, 0, -17, 0,
+ax_anim 2, 1, 75, -17, 1, -17, 1,
+ax_anim 2, 0, 75, -17, 0, -17, 0,
+ax_anim 2, 0, 75, -17, 1, -17, 1,
+ax_anim 2, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sBellsproutAnims_3_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 1, 2, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, -9, 9, -9, 9,
+ax_anim 2, 0, 78, -19, 20, -19, 20,
+ax_anim 2, 1, 79, -20, 19, -20, 19,
+ax_anim 2, 0, 79, -19, 20, -19, 20,
+ax_anim 2, 0, 79, -20, 19, -20, 19,
+ax_anim 2, 0, 76, -10, 10, -10, 10,
+ax_anim 2, 0, 76, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_4_1:
+ax_anim 2, 0, 82, 0, -2, 0, -2,
+ax_anim 2, 0, 82, 0, -3, 0, -3,
+ax_anim 4, 2, 83, 0, -2, 0, -2,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 84, 0, 4, 0, 4,
+ax_anim 2, 1, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 84, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 84, 0, 4, 0, 4,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sBellsproutAnims_4_2:
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -3, -3, -3, -3,
+ax_anim 4, 2, 88, -2, -2, -2, -2,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 4, 4, 4, 4,
+ax_anim 2, 0, 89, 4, 4, 4, 4,
+ax_anim 2, 1, 88, 4, 4, 4, 4,
+ax_anim 2, 0, 89, 4, 4, 4, 4,
+ax_anim 2, 0, 88, 4, 4, 4, 4,
+ax_anim 2, 0, 89, 4, 4, 4, 4,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim_terminator
+sBellsproutAnims_4_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 4, 2, 93, -3, 0, -3, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 4, 0, 4, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim 2, 1, 93, 4, 0, 4, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim 2, 0, 93, 4, 0, 4, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim_terminator
+sBellsproutAnims_4_4:
+ax_anim 2, 0, 97, -2, 2, -2, 2,
+ax_anim 2, 0, 97, -3, 3, -3, 3,
+ax_anim 4, 2, 98, -2, 2, -2, 2,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 1, 98, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 98, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim_terminator
+sBellsproutAnims_4_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 2, 0, 102, 0, 3, 0, 3,
+ax_anim 4, 2, 103, 0, 2, 0, 2,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, -4,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim 2, 1, 103, 0, -4, 0, -4,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim 2, 0, 103, 0, -4, 0, -4,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sBellsproutAnims_4_6:
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 3, 3, 3, 3,
+ax_anim 4, 2, 108, 2, 2, 2, 2,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -4, -4, -4, -4,
+ax_anim 2, 0, 109, -4, -4, -4, -4,
+ax_anim 2, 1, 108, -4, -4, -4, -4,
+ax_anim 2, 0, 109, -4, -4, -4, -4,
+ax_anim 2, 0, 108, -4, -4, -4, -4,
+ax_anim 2, 0, 109, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim_terminator
+sBellsproutAnims_4_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 4, 2, 113, 3, 0, 3, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -4, 0, -4, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 1, 113, -4, 0, -4, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 0, 113, -4, 0, -4, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim_terminator
+sBellsproutAnims_4_8:
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 2, 0, 117, 3, -3, 3, -3,
+ax_anim 4, 2, 118, 2, -2, 2, -2,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 1, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sBellsproutAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sBellsproutAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sBellsproutAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sBellsproutAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sBellsproutAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sBellsproutAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sBellsproutAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_8_1:
+ax_anim 20, 0, 140, 0, 0, 0, 0,
+ax_anim 22, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_8_2:
+ax_anim 20, 0, 143, 0, 0, 0, 0,
+ax_anim 22, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_8_3:
+ax_anim 20, 0, 146, 0, 0, 0, 0,
+ax_anim 22, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_8_4:
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim 22, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_8_5:
+ax_anim 20, 0, 152, 0, 0, 0, 0,
+ax_anim 22, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_8_6:
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim 22, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_8_7:
+ax_anim 20, 0, 158, 0, 0, 0, 0,
+ax_anim 22, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_8_8:
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim 22, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 19, 7, 19,
+ax_anim 3, 0, 166, 0, 21, 0, 24,
+ax_anim 2, 3, 167, -7, 19, -7, 19,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 24, 9, 24, 9,
+ax_anim 3, 0, 165, 20, 21, 20, 21,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 12, 2, 12,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 19, -4, 19, -4,
+ax_anim 3, 0, 164, 22, 1, 22, 1,
+ax_anim 2, 3, 165, 18, 6, 18, 6,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 2, -18, 2, -18,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 21, -19, 21, -19,
+ax_anim 2, 3, 164, 21, -15, 21, -15,
+ax_anim 2, 0, 165, 16, -6, 16, -6,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -7, -16, -7, -16,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -16, 7, -16,
+ax_anim 2, 0, 164, 8, -8, 8, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -2, -18, -2, -18,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -21, -19, -21, -19,
+ax_anim 2, 3, 168, -21, -15, -21, -15,
+ax_anim 2, 0, 167, -16, -6, -16, -6,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -19, -4, -19, -4,
+ax_anim 3, 0, 168, -22, 1, -22, 1,
+ax_anim 2, 3, 167, -18, 6, -18, 6,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -24, 9, -24, 9,
+ax_anim 3, 0, 167, -20, 21, -20, 21,
+ax_anim 2, 3, 166, -11, 21, -11, 16,
+ax_anim 2, 0, 165, -2, 12, -4, 12,
+ax_anim 1, 0, 164, 0, 7, -3, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -17, 0, 0,
+ax_anim 1, 0, 188, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -17, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 197, 0, -22, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBellsproutAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBellsproutGfx1:
+.incbin "baserom.gba", 0x802490, 0x200
+sBellsproutSprites1:
+ax_sprite sBellsproutGfx1, 0x200
+ax_sprite_terminator
+sBellsproutGfx2:
+.incbin "baserom.gba", 0x8026A0, 0x200
+sBellsproutSprites2:
+ax_sprite sBellsproutGfx2, 0x200
+ax_sprite_terminator
+sBellsproutGfx3:
+.incbin "baserom.gba", 0x8028B0, 0x200
+sBellsproutSprites3:
+ax_sprite sBellsproutGfx3, 0x200
+ax_sprite_terminator
+sBellsproutGfx4:
+.incbin "baserom.gba", 0x802AC0, 0x100
+sBellsproutSprites4:
+ax_sprite sBellsproutGfx4, 0x100
+ax_sprite_terminator
+sBellsproutGfx5:
+.incbin "baserom.gba", 0x802BD0, 0x100
+sBellsproutSprites5:
+ax_sprite sBellsproutGfx5, 0x100
+ax_sprite_terminator
+sBellsproutGfx6:
+.incbin "baserom.gba", 0x802CE0, 0x100
+sBellsproutSprites6:
+ax_sprite sBellsproutGfx6, 0x100
+ax_sprite_terminator
+sBellsproutGfx7:
+.incbin "baserom.gba", 0x802DF0, 0x100
+sBellsproutSprites7:
+ax_sprite sBellsproutGfx7, 0x100
+ax_sprite_terminator
+sBellsproutGfx8:
+.incbin "baserom.gba", 0x802F00, 0x100
+sBellsproutSprites8:
+ax_sprite sBellsproutGfx8, 0x100
+ax_sprite_terminator
+sBellsproutGfx9:
+.incbin "baserom.gba", 0x803010, 0x100
+sBellsproutSprites9:
+ax_sprite sBellsproutGfx9, 0x100
+ax_sprite_terminator
+sBellsproutGfx10:
+.incbin "baserom.gba", 0x803120, 0x100
+sBellsproutSprites10:
+ax_sprite sBellsproutGfx10, 0x100
+ax_sprite_terminator
+sBellsproutGfx11:
+.incbin "baserom.gba", 0x803230, 0x100
+sBellsproutSprites11:
+ax_sprite sBellsproutGfx11, 0x100
+ax_sprite_terminator
+sBellsproutGfx12:
+.incbin "baserom.gba", 0x803340, 0x100
+sBellsproutSprites12:
+ax_sprite sBellsproutGfx12, 0x100
+ax_sprite_terminator
+sBellsproutGfx13:
+.incbin "baserom.gba", 0x803450, 0x200
+sBellsproutSprites13:
+ax_sprite sBellsproutGfx13, 0x200
+ax_sprite_terminator
+sBellsproutGfx14:
+.incbin "baserom.gba", 0x803660, 0x100
+sBellsproutSprites14:
+ax_sprite sBellsproutGfx14, 0x100
+ax_sprite_terminator
+sBellsproutGfx15:
+.incbin "baserom.gba", 0x803770, 0x100
+sBellsproutSprites15:
+ax_sprite sBellsproutGfx15, 0x100
+ax_sprite_terminator
+sBellsproutGfx16:
+.incbin "baserom.gba", 0x803880, 0x40
+sBellsproutGfx16_1:
+.incbin "baserom.gba", 0x8038C0, 0x60
+sBellsproutGfx16_2:
+.incbin "baserom.gba", 0x803920, 0x60
+sBellsproutSprites16:
+ax_sprite sBellsproutGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx17:
+.incbin "baserom.gba", 0x8039B8, 0x20
+sBellsproutGfx17_1:
+.incbin "baserom.gba", 0x8039D8, 0x20
+sBellsproutGfx17_2:
+.incbin "baserom.gba", 0x8039F8, 0x40
+sBellsproutSprites17:
+ax_sprite sBellsproutGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx17_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx17_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBellsproutGfx18:
+.incbin "baserom.gba", 0x803A70, 0x40
+sBellsproutGfx18_1:
+.incbin "baserom.gba", 0x803AB0, 0x60
+sBellsproutGfx18_2:
+.incbin "baserom.gba", 0x803B10, 0x60
+sBellsproutSprites18:
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx19:
+.incbin "baserom.gba", 0x803BB0, 0x60
+sBellsproutGfx19_1:
+.incbin "baserom.gba", 0x803C10, 0x60
+sBellsproutGfx19_2:
+.incbin "baserom.gba", 0x803C70, 0x60
+sBellsproutSprites19:
+ax_sprite sBellsproutGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx20:
+.incbin "baserom.gba", 0x803D08, 0x60
+sBellsproutGfx20_1:
+.incbin "baserom.gba", 0x803D68, 0x60
+sBellsproutSprites20:
+ax_sprite 0, 0x80
+ax_sprite sBellsproutGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx20_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx21:
+.incbin "baserom.gba", 0x803DF8, 0x60
+sBellsproutGfx21_1:
+.incbin "baserom.gba", 0x803E58, 0x20
+sBellsproutSprites21:
+ax_sprite sBellsproutGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx21_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sBellsproutGfx22:
+.incbin "baserom.gba", 0x803EA0, 0x40
+sBellsproutGfx22_1:
+.incbin "baserom.gba", 0x803EE0, 0x60
+sBellsproutGfx22_2:
+.incbin "baserom.gba", 0x803F40, 0x40
+sBellsproutGfx22_3:
+.incbin "baserom.gba", 0x803F80, 0x40
+sBellsproutSprites22:
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx22_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBellsproutGfx23:
+.incbin "baserom.gba", 0x804010, 0x40
+sBellsproutGfx23_1:
+.incbin "baserom.gba", 0x804050, 0x60
+sBellsproutGfx23_2:
+.incbin "baserom.gba", 0x8040B0, 0x40
+sBellsproutSprites23:
+ax_sprite 0, 0x80
+ax_sprite sBellsproutGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBellsproutGfx24:
+.incbin "baserom.gba", 0x804130, 0x60
+sBellsproutGfx24_1:
+.incbin "baserom.gba", 0x804190, 0x40
+sBellsproutGfx24_2:
+.incbin "baserom.gba", 0x8041D0, 0x20
+sBellsproutSprites24:
+ax_sprite sBellsproutGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx24_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sBellsproutGfx25:
+.incbin "baserom.gba", 0x804228, 0x40
+sBellsproutGfx25_1:
+.incbin "baserom.gba", 0x804268, 0x60
+sBellsproutGfx25_2:
+.incbin "baserom.gba", 0x8042C8, 0x40
+sBellsproutSprites25:
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx26:
+.incbin "baserom.gba", 0x804348, 0x40
+sBellsproutGfx26_1:
+.incbin "baserom.gba", 0x804388, 0x60
+sBellsproutGfx26_2:
+.incbin "baserom.gba", 0x8043E8, 0x60
+sBellsproutSprites26:
+ax_sprite sBellsproutGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx27:
+.incbin "baserom.gba", 0x804480, 0x60
+sBellsproutGfx27_1:
+.incbin "baserom.gba", 0x8044E0, 0xC0
+sBellsproutSprites27:
+ax_sprite sBellsproutGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx27_1, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sBellsproutGfx28:
+.incbin "baserom.gba", 0x8045C8, 0x40
+sBellsproutGfx28_1:
+.incbin "baserom.gba", 0x804608, 0x40
+sBellsproutGfx28_2:
+.incbin "baserom.gba", 0x804648, 0x40
+sBellsproutSprites28:
+ax_sprite sBellsproutGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx28_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sBellsproutGfx29:
+.incbin "baserom.gba", 0x8046C0, 0x40
+sBellsproutGfx29_1:
+.incbin "baserom.gba", 0x804700, 0x40
+sBellsproutGfx29_2:
+.incbin "baserom.gba", 0x804740, 0x60
+sBellsproutSprites29:
+ax_sprite sBellsproutGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx29_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx30:
+.incbin "baserom.gba", 0x8047D8, 0xC0
+sBellsproutSprites30:
+ax_sprite sBellsproutGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBellsproutGfx31:
+.incbin "baserom.gba", 0x8048B0, 0x40
+sBellsproutGfx31_1:
+.incbin "baserom.gba", 0x8048F0, 0x60
+sBellsproutGfx31_2:
+.incbin "baserom.gba", 0x804950, 0x60
+sBellsproutSprites31:
+ax_sprite sBellsproutGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx32:
+.incbin "baserom.gba", 0x8049E8, 0x40
+sBellsproutGfx32_1:
+.incbin "baserom.gba", 0x804A28, 0x60
+sBellsproutGfx32_2:
+.incbin "baserom.gba", 0x804A88, 0x60
+sBellsproutSprites32:
+ax_sprite sBellsproutGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx33:
+.incbin "baserom.gba", 0x804B20, 0x40
+sBellsproutGfx33_1:
+.incbin "baserom.gba", 0x804B60, 0x60
+sBellsproutGfx33_2:
+.incbin "baserom.gba", 0x804BC0, 0x60
+sBellsproutSprites33:
+ax_sprite sBellsproutGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx34:
+.incbin "baserom.gba", 0x804C58, 0x40
+sBellsproutGfx34_1:
+.incbin "baserom.gba", 0x804C98, 0x60
+sBellsproutGfx34_2:
+.incbin "baserom.gba", 0x804CF8, 0x60
+sBellsproutSprites34:
+ax_sprite sBellsproutGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx35:
+.incbin "baserom.gba", 0x804D90, 0x40
+sBellsproutGfx35_1:
+.incbin "baserom.gba", 0x804DD0, 0x60
+sBellsproutGfx35_2:
+.incbin "baserom.gba", 0x804E30, 0x40
+sBellsproutSprites35:
+ax_sprite sBellsproutGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx35_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx35_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx36:
+.incbin "baserom.gba", 0x804EA8, 0x40
+sBellsproutGfx36_1:
+.incbin "baserom.gba", 0x804EE8, 0x60
+sBellsproutGfx36_2:
+.incbin "baserom.gba", 0x804F48, 0x40
+sBellsproutSprites36:
+ax_sprite sBellsproutGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx36_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx36_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx37:
+.incbin "baserom.gba", 0x804FC0, 0x40
+sBellsproutGfx37_1:
+.incbin "baserom.gba", 0x805000, 0x60
+sBellsproutGfx37_2:
+.incbin "baserom.gba", 0x805060, 0x40
+sBellsproutSprites37:
+ax_sprite sBellsproutGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx37_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx37_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx38:
+.incbin "baserom.gba", 0x8050D8, 0x40
+sBellsproutGfx38_1:
+.incbin "baserom.gba", 0x805118, 0x60
+sBellsproutGfx38_2:
+.incbin "baserom.gba", 0x805178, 0x40
+sBellsproutSprites38:
+ax_sprite sBellsproutGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx38_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx38_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx39:
+.incbin "baserom.gba", 0x8051F0, 0x40
+sBellsproutGfx39_1:
+.incbin "baserom.gba", 0x805230, 0x60
+sBellsproutGfx39_2:
+.incbin "baserom.gba", 0x805290, 0x60
+sBellsproutSprites39:
+ax_sprite sBellsproutGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBellsproutGfx39_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx40:
+.incbin "baserom.gba", 0x805328, 0x40
+sBellsproutGfx40_1:
+.incbin "baserom.gba", 0x805368, 0x40
+sBellsproutGfx40_2:
+.incbin "baserom.gba", 0x8053A8, 0x60
+sBellsproutSprites40:
+ax_sprite sBellsproutGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx40_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBellsproutGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBellsproutGfx41:
+.incbin "baserom.gba", 0x805440, 0x200
+sBellsproutSprites41:
+ax_sprite sBellsproutGfx41, 0x200
+ax_sprite_terminator
+sBellsproutGfx42:
+.incbin "baserom.gba", 0x805650, 0x200
+sBellsproutSprites42:
+ax_sprite sBellsproutGfx42, 0x200
+ax_sprite_terminator
+sBellsproutGfx43:
+.incbin "baserom.gba", 0x805860, 0x200
+sBellsproutSprites43:
+ax_sprite sBellsproutGfx43, 0x200
+ax_sprite_terminator
+sBellsproutGfx44:
+.incbin "baserom.gba", 0x805A70, 0x200
+sBellsproutSprites44:
+ax_sprite sBellsproutGfx44, 0x200
+ax_sprite_terminator
+sBellsproutGfx45:
+.incbin "baserom.gba", 0x805C80, 0x200
+sBellsproutSprites45:
+ax_sprite sBellsproutGfx45, 0x200
+ax_sprite_terminator
+sBellsproutGfx46:
+.incbin "baserom.gba", 0x805E90, 0x200
+sBellsproutSprites46:
+ax_sprite sBellsproutGfx46, 0x200
+ax_sprite_terminator
+sBellsproutGfx47:
+.incbin "baserom.gba", 0x8060A0, 0x200
+sBellsproutSprites47:
+ax_sprite sBellsproutGfx47, 0x200
+ax_sprite_terminator
+sAxPosesBellsprout:
+.4byte sBellsproutPose1
+.4byte sBellsproutPose2
+.4byte sBellsproutPose3
+.4byte sBellsproutPose4
+.4byte sBellsproutPose5
+.4byte sBellsproutPose6
+.4byte sBellsproutPose7
+.4byte sBellsproutPose8
+.4byte sBellsproutPose9
+.4byte sBellsproutPose10
+.4byte sBellsproutPose11
+.4byte sBellsproutPose12
+.4byte sBellsproutPose13
+.4byte sBellsproutPose14
+.4byte sBellsproutPose15
+.4byte sBellsproutPose16
+.4byte sBellsproutPose17
+.4byte sBellsproutPose18
+.4byte sBellsproutPose19
+.4byte sBellsproutPose20
+.4byte sBellsproutPose21
+.4byte sBellsproutPose22
+.4byte sBellsproutPose23
+.4byte sBellsproutPose24
+.4byte sBellsproutPose25
+.4byte sBellsproutPose26
+.4byte sBellsproutPose27
+.4byte sBellsproutPose28
+.4byte sBellsproutPose29
+.4byte sBellsproutPose30
+.4byte sBellsproutPose31
+.4byte sBellsproutPose32
+.4byte sBellsproutPose33
+.4byte sBellsproutPose34
+.4byte sBellsproutPose35
+.4byte sBellsproutPose36
+.4byte sBellsproutPose37
+.4byte sBellsproutPose38
+.4byte sBellsproutPose39
+.4byte sBellsproutPose40
+.4byte sBellsproutPose41
+.4byte sBellsproutPose42
+.4byte sBellsproutPose43
+.4byte sBellsproutPose44
+.4byte sBellsproutPose45
+.4byte sBellsproutPose46
+.4byte sBellsproutPose47
+.4byte sBellsproutPose48
+.4byte sBellsproutPose49
+.4byte sBellsproutPose50
+.4byte sBellsproutPose51
+.4byte sBellsproutPose52
+.4byte sBellsproutPose53
+.4byte sBellsproutPose54
+.4byte sBellsproutPose55
+.4byte sBellsproutPose56
+.4byte sBellsproutPose57
+.4byte sBellsproutPose58
+.4byte sBellsproutPose59
+.4byte sBellsproutPose60
+.4byte sBellsproutPose61
+.4byte sBellsproutPose62
+.4byte sBellsproutPose63
+.4byte sBellsproutPose64
+.4byte sBellsproutPose65
+.4byte sBellsproutPose66
+.4byte sBellsproutPose67
+.4byte sBellsproutPose68
+.4byte sBellsproutPose69
+.4byte sBellsproutPose70
+.4byte sBellsproutPose71
+.4byte sBellsproutPose72
+.4byte sBellsproutPose73
+.4byte sBellsproutPose74
+.4byte sBellsproutPose75
+.4byte sBellsproutPose76
+.4byte sBellsproutPose77
+.4byte sBellsproutPose78
+.4byte sBellsproutPose79
+.4byte sBellsproutPose80
+.4byte sBellsproutPose81
+.4byte sBellsproutPose82
+.4byte sBellsproutPose83
+.4byte sBellsproutPose84
+.4byte sBellsproutPose85
+.4byte sBellsproutPose86
+.4byte sBellsproutPose87
+.4byte sBellsproutPose88
+.4byte sBellsproutPose89
+.4byte sBellsproutPose90
+.4byte sBellsproutPose91
+.4byte sBellsproutPose92
+.4byte sBellsproutPose93
+.4byte sBellsproutPose94
+.4byte sBellsproutPose95
+.4byte sBellsproutPose96
+.4byte sBellsproutPose97
+.4byte sBellsproutPose98
+.4byte sBellsproutPose99
+.4byte sBellsproutPose100
+.4byte sBellsproutPose101
+.4byte sBellsproutPose102
+.4byte sBellsproutPose103
+.4byte sBellsproutPose104
+.4byte sBellsproutPose105
+.4byte sBellsproutPose106
+.4byte sBellsproutPose107
+.4byte sBellsproutPose108
+.4byte sBellsproutPose109
+.4byte sBellsproutPose110
+.4byte sBellsproutPose111
+.4byte sBellsproutPose112
+.4byte sBellsproutPose113
+.4byte sBellsproutPose114
+.4byte sBellsproutPose115
+.4byte sBellsproutPose116
+.4byte sBellsproutPose117
+.4byte sBellsproutPose118
+.4byte sBellsproutPose119
+.4byte sBellsproutPose120
+.4byte sBellsproutPose121
+.4byte sBellsproutPose122
+.4byte sBellsproutPose123
+.4byte sBellsproutPose124
+.4byte sBellsproutPose125
+.4byte sBellsproutPose126
+.4byte sBellsproutPose127
+.4byte sBellsproutPose128
+.4byte sBellsproutPose129
+.4byte sBellsproutPose130
+.4byte sBellsproutPose131
+.4byte sBellsproutPose132
+.4byte sBellsproutPose133
+.4byte sBellsproutPose134
+.4byte sBellsproutPose135
+.4byte sBellsproutPose136
+.4byte sBellsproutPose137
+.4byte sBellsproutPose138
+.4byte sBellsproutPose139
+.4byte sBellsproutPose140
+.4byte sBellsproutPose141
+.4byte sBellsproutPose142
+.4byte sBellsproutPose143
+.4byte sBellsproutPose144
+.4byte sBellsproutPose145
+.4byte sBellsproutPose146
+.4byte sBellsproutPose147
+.4byte sBellsproutPose148
+.4byte sBellsproutPose149
+.4byte sBellsproutPose150
+.4byte sBellsproutPose151
+.4byte sBellsproutPose152
+.4byte sBellsproutPose153
+.4byte sBellsproutPose154
+.4byte sBellsproutPose155
+.4byte sBellsproutPose156
+.4byte sBellsproutPose157
+.4byte sBellsproutPose158
+.4byte sBellsproutPose159
+.4byte sBellsproutPose160
+.4byte sBellsproutPose161
+.4byte sBellsproutPose162
+.4byte sBellsproutPose163
+.4byte sBellsproutPose164
+.4byte sBellsproutPose165
+.4byte sBellsproutPose166
+.4byte sBellsproutPose167
+.4byte sBellsproutPose168
+.4byte sBellsproutPose169
+.4byte sBellsproutPose170
+.4byte sBellsproutPose171
+.4byte sBellsproutPose172
+.4byte sBellsproutPose173
+.4byte sBellsproutPose174
+.4byte sBellsproutPose175
+.4byte sBellsproutPose176
+.4byte sBellsproutPose177
+.4byte sBellsproutPose178
+.4byte sBellsproutPose179
+.4byte sBellsproutPose180
+.4byte sBellsproutPose181
+.4byte sBellsproutPose182
+.4byte sBellsproutPose183
+.4byte sBellsproutPose184
+.4byte sBellsproutPose185
+.4byte sBellsproutPose186
+.4byte sBellsproutPose187
+.4byte sBellsproutPose188
+.4byte sBellsproutPose189
+.4byte sBellsproutPose190
+.4byte sBellsproutPose191
+.4byte sBellsproutPose192
+.4byte sBellsproutPose193
+.4byte sBellsproutPose194
+.4byte sBellsproutPose195
+.4byte sBellsproutPose196
+.4byte sBellsproutPose197
+.4byte sBellsproutPose198
+.4byte sBellsproutPose199
+.4byte sBellsproutPose200
+.4byte sBellsproutPose201
+.4byte sBellsproutPose202
+.4byte sBellsproutPose203
+.4byte sBellsproutPose204
+.4byte sBellsproutPose205
+.4byte sBellsproutPose206
+.4byte sBellsproutPose207
+.4byte sBellsproutPose208
+.4byte sBellsproutPose209
+.4byte sBellsproutPose210
+.4byte sBellsproutPose211
+.4byte sBellsproutPose212
+.4byte sBellsproutPose213
+.4byte sBellsproutPose214
+.4byte sBellsproutPose215
+.4byte sBellsproutPose216
+.4byte sBellsproutPose217
+.4byte sBellsproutPose218
+sAxPositionsBellsprout:
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   6,   -8, 	   0,   -5
+.2byte   -2,   -6, 	  -7,   -4, 	   5,   -4, 	  -1,   -4
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   2,   -6, 	  -6,   -7, 	  -1,   -6
+.2byte    4,   -5, 	   5,   -5, 	  -5,   -1, 	   0,   -5
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -6, 	   2,   -8, 	  -2,   -5, 	   0,   -7
+.2byte    4,   -7, 	   2,   -5, 	  -1,   -1, 	   0,   -5
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    4,   -8, 	  -5,  -10, 	   3,   -6, 	  -2,   -8
+.2byte    3,   -9, 	  -5,   -6, 	   2,   -2, 	  -2,   -8
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    2,   -8, 	   6,   -4, 	  -5,   -4, 	   1,   -7
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte   -5,   -8, 	   4,  -10, 	  -4,   -6, 	   1,   -8
+.2byte   -4,   -9, 	   4,   -6, 	  -3,   -2, 	   1,   -8
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte   -6,   -6, 	  -3,   -8, 	   1,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -5, 	   0,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -3,   -6, 	   5,   -7, 	   0,   -6
+.2byte   -5,   -5, 	  -6,   -5, 	   4,   -1, 	  -1,   -5
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   6,   -8, 	   0,   -5
+.2byte   -2,   -6, 	  -7,   -4, 	   5,   -4, 	  -1,   -4
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   2,   -6, 	  -6,   -7, 	  -1,   -6
+.2byte    4,   -5, 	   5,   -5, 	  -5,   -1, 	   0,   -5
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -6, 	   2,   -8, 	  -2,   -5, 	   0,   -7
+.2byte    4,   -7, 	   2,   -5, 	  -1,   -1, 	   0,   -5
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    4,   -8, 	  -5,  -10, 	   3,   -6, 	  -2,   -8
+.2byte    3,   -9, 	  -5,   -6, 	   2,   -2, 	  -2,   -8
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    2,   -8, 	   6,   -4, 	  -5,   -4, 	   1,   -7
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte   -5,   -8, 	   4,  -10, 	  -4,   -6, 	   1,   -8
+.2byte   -4,   -9, 	   4,   -6, 	  -3,   -2, 	   1,   -8
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte   -6,   -6, 	  -3,   -8, 	   1,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -5, 	   0,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -3,   -6, 	   5,   -7, 	   0,   -6
+.2byte   -5,   -5, 	  -6,   -5, 	   4,   -1, 	  -1,   -5
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -5,  -10, 	  -4,  -18, 	   3,   -5, 	   0,   -8
+.2byte   -1,   -4, 	  -5,   -1, 	   4,  -12, 	  -2,   -6
+.2byte   -1,   -4, 	  -5,   -1, 	   4,  -12, 	  -2,   -6
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte    6,  -12, 	  -1,  -19, 	   2,   -5, 	  -1,   -9
+.2byte    6,   -4, 	   6,   -2, 	  -6,  -10, 	  -1,   -6
+.2byte    6,   -4, 	   6,   -2, 	  -6,  -10, 	  -1,   -6
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte    6,  -13, 	  -2,  -18, 	   4,   -6, 	  -1,  -10
+.2byte    7,   -6, 	   4,   -5, 	  -5,   -6, 	   1,   -7
+.2byte    7,   -6, 	   4,   -5, 	  -5,   -6, 	   1,   -7
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    2,  -13, 	  -7,  -15, 	   3,   -6, 	  -3,   -9
+.2byte    5,   -7, 	   1,   -6, 	  -7,   -6, 	  -2,  -10
+.2byte    5,   -7, 	   1,   -6, 	  -7,   -6, 	  -2,  -10
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte   -1,  -11, 	   5,  -16, 	  -5,   -6, 	   0,   -9
+.2byte    0,   -8, 	   1,   -5, 	  -5,   -6, 	   0,   -6
+.2byte    0,   -8, 	   1,   -5, 	  -5,   -6, 	   0,   -6
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte   -3,  -13, 	   6,  -15, 	  -4,   -6, 	   2,   -9
+.2byte   -6,   -7, 	  -2,   -6, 	   6,   -6, 	   1,  -10
+.2byte   -6,   -7, 	  -2,   -6, 	   6,   -6, 	   1,  -10
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte   -7,  -13, 	   1,  -18, 	  -5,   -6, 	   0,  -10
+.2byte   -8,   -6, 	  -5,   -5, 	   4,   -6, 	  -2,   -7
+.2byte   -8,   -6, 	  -5,   -5, 	   4,   -6, 	  -2,   -7
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -7,  -12, 	   0,  -19, 	  -3,   -5, 	   0,   -9
+.2byte   -7,   -4, 	  -7,   -2, 	   5,  -10, 	   0,   -6
+.2byte   -7,   -4, 	  -7,   -2, 	   5,  -10, 	   0,   -6
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   6,   -8, 	   0,   -5
+.2byte   -2,   -6, 	  -7,   -4, 	   5,   -4, 	  -1,   -4
+.2byte   -2,  -12, 	  -8,   -9, 	   6,   -9, 	  -1,  -10
+.2byte   -1,  -12, 	  -7,   -5, 	   5,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   2,   -6, 	  -6,   -7, 	  -1,   -6
+.2byte    4,   -5, 	   5,   -5, 	  -5,   -1, 	   0,   -5
+.2byte    6,  -13, 	   3,   -9, 	  -6,   -9, 	   0,   -9
+.2byte    6,  -14, 	   3,   -8, 	  -6,   -5, 	   0,  -10
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -6, 	   2,   -8, 	  -2,   -5, 	   0,   -7
+.2byte    4,   -7, 	   2,   -5, 	  -1,   -1, 	   0,   -5
+.2byte   11,  -17, 	   4,  -10, 	  -8,   -7, 	  -1,  -11
+.2byte   11,  -18, 	   0,   -8, 	  -7,   -3, 	  -2,  -11
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    4,   -8, 	  -5,  -10, 	   3,   -6, 	  -2,   -8
+.2byte    3,   -9, 	  -5,   -6, 	   2,   -2, 	  -2,   -8
+.2byte   10,  -17, 	  -4,   -8, 	   5,   -6, 	  -1,   -9
+.2byte   11,  -17, 	  -4,   -6, 	   5,   -1, 	  -1,   -9
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    2,   -8, 	   6,   -4, 	  -5,   -4, 	   1,   -7
+.2byte    1,  -14, 	   7,   -8, 	  -7,   -8, 	   0,   -9
+.2byte    1,  -16, 	   6,   -4, 	  -6,   -4, 	   0,   -9
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte   -5,   -8, 	   4,  -10, 	  -4,   -6, 	   1,   -8
+.2byte   -4,   -9, 	   4,   -6, 	  -3,   -2, 	   1,   -8
+.2byte  -11,  -17, 	   3,   -8, 	  -6,   -6, 	   0,   -9
+.2byte  -12,  -17, 	   3,   -6, 	  -6,   -1, 	   0,   -9
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte   -6,   -6, 	  -3,   -8, 	   1,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -5, 	   0,   -1, 	  -1,   -5
+.2byte  -12,  -17, 	  -5,  -10, 	   7,   -7, 	   0,  -11
+.2byte  -12,  -18, 	  -1,   -8, 	   6,   -3, 	   1,  -11
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -3,   -6, 	   5,   -7, 	   0,   -6
+.2byte   -5,   -5, 	  -6,   -5, 	   4,   -1, 	  -1,   -5
+.2byte   -7,  -13, 	  -4,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -7,  -14, 	  -4,   -8, 	   5,   -5, 	  -1,  -10
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -5,   -5, 	  -4,   -4, 	   4,   -3, 	  -1,   -6
+.2byte   -5,   -6, 	  -4,   -5, 	   4,   -4, 	  -1,   -6
+.2byte    0,   -7, 	  -8,   -7, 	   6,   -8, 	   0,   -4
+.2byte   -1,   -8, 	  -3,  -11, 	 -10,   -8, 	  -4,   -7
+.2byte    0,   -9, 	  -5,  -10, 	  -7,   -8, 	  -3,   -6
+.2byte    2,  -10, 	  -7,  -10, 	  -7,   -7, 	  -3,   -7
+.2byte    0,   -9, 	   7,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte   -3,  -10, 	   6,  -10, 	   6,   -7, 	   2,   -7
+.2byte   -1,   -9, 	   4,  -10, 	   6,   -8, 	   2,   -6
+.2byte    0,   -8, 	   2,  -11, 	   9,   -8, 	   3,   -7
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   6,   -8, 	   0,   -5
+.2byte   -2,   -6, 	  -7,   -4, 	   5,   -4, 	  -1,   -4
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   2,   -6, 	  -6,   -7, 	  -1,   -6
+.2byte    4,   -5, 	   5,   -5, 	  -5,   -1, 	   0,   -5
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -6, 	   2,   -8, 	  -2,   -5, 	   0,   -7
+.2byte    4,   -7, 	   2,   -5, 	  -1,   -1, 	   0,   -5
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    4,   -8, 	  -5,  -10, 	   3,   -6, 	  -2,   -8
+.2byte    3,   -9, 	  -5,   -6, 	   2,   -2, 	  -2,   -8
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    2,   -8, 	   6,   -4, 	  -5,   -4, 	   1,   -7
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte   -5,   -8, 	   4,  -10, 	  -4,   -6, 	   1,   -8
+.2byte   -4,   -9, 	   4,   -6, 	  -3,   -2, 	   1,   -8
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte   -6,   -6, 	  -3,   -8, 	   1,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -5, 	   0,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -3,   -6, 	   5,   -7, 	   0,   -6
+.2byte   -5,   -5, 	  -6,   -5, 	   4,   -1, 	  -1,   -5
+.2byte   -2,  -12, 	  -8,   -9, 	   6,   -9, 	  -1,  -10
+.2byte   -7,  -13, 	  -4,   -9, 	   5,   -9, 	  -1,   -9
+.2byte  -12,  -17, 	  -5,  -10, 	   7,   -7, 	   0,  -11
+.2byte   -9,  -18, 	   5,   -9, 	  -4,   -7, 	   2,  -10
+.2byte    1,  -14, 	   7,   -8, 	  -7,   -8, 	   0,   -9
+.2byte    8,  -18, 	  -6,   -9, 	   3,   -7, 	  -3,  -10
+.2byte   11,  -17, 	   4,  -10, 	  -8,   -7, 	  -1,  -11
+.2byte    6,  -13, 	   3,   -9, 	  -6,   -9, 	   0,   -9
+.2byte   -2,  -12, 	  -8,   -9, 	   6,   -9, 	  -1,  -10
+.2byte    6,  -13, 	   3,   -9, 	  -6,   -9, 	   0,   -9
+.2byte   11,  -17, 	   4,  -10, 	  -8,   -7, 	  -1,  -11
+.2byte    8,  -18, 	  -6,   -9, 	   3,   -7, 	  -3,  -10
+.2byte    1,  -14, 	   7,   -8, 	  -7,   -8, 	   0,   -9
+.2byte   -9,  -18, 	   5,   -9, 	  -4,   -7, 	   2,  -10
+.2byte  -12,  -17, 	  -5,  -10, 	   7,   -7, 	   0,  -11
+.2byte   -7,  -13, 	  -4,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -2,  -12, 	  -8,   -9, 	   6,   -9, 	  -1,  -10
+.2byte   -1,  -12, 	  -7,   -5, 	   5,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte    6,  -13, 	   3,   -9, 	  -6,   -9, 	   0,   -9
+.2byte    5,  -14, 	   2,   -8, 	  -7,   -5, 	  -1,  -10
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte   11,  -17, 	   4,  -10, 	  -8,   -7, 	  -1,  -11
+.2byte   11,  -17, 	   0,   -7, 	  -7,   -2, 	  -2,  -10
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    8,  -18, 	  -6,   -9, 	   3,   -7, 	  -3,  -10
+.2byte    9,  -18, 	  -6,   -7, 	   3,   -2, 	  -3,  -10
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    1,  -14, 	   7,   -8, 	  -7,   -8, 	   0,   -9
+.2byte    1,  -16, 	   6,   -4, 	  -6,   -4, 	   0,   -9
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte   -9,  -18, 	   5,   -9, 	  -4,   -7, 	   2,  -10
+.2byte  -10,  -18, 	   5,   -7, 	  -4,   -2, 	   2,  -10
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte  -12,  -17, 	  -5,  -10, 	   7,   -7, 	   0,  -11
+.2byte  -12,  -17, 	  -1,   -7, 	   6,   -2, 	   1,  -10
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -7,  -13, 	  -4,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -6,  -14, 	  -3,   -8, 	   6,   -5, 	   0,  -10
+.2byte   -2,  -12, 	  -8,   -9, 	   6,   -9, 	  -1,  -10
+.2byte   -7,  -13, 	  -4,   -9, 	   5,   -9, 	  -1,   -9
+.2byte  -12,  -17, 	  -5,  -10, 	   7,   -7, 	   0,  -11
+.2byte   -9,  -18, 	   5,   -9, 	  -4,   -7, 	   2,  -10
+.2byte    1,  -14, 	   7,   -8, 	  -7,   -8, 	   0,   -9
+.2byte    8,  -18, 	  -6,   -9, 	   3,   -7, 	  -3,  -10
+.2byte   11,  -17, 	   4,  -10, 	  -8,   -7, 	  -1,  -11
+.2byte    6,  -13, 	   3,   -9, 	  -6,   -9, 	   0,   -9
+.2byte   -2,   -8, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -5,   -7, 	  -3,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -2,   -7, 	   0,   -3, 	  -1,   -8
+.2byte   -5,  -10, 	   5,   -8, 	  -4,   -3, 	   1,  -10
+.2byte    0,   -9, 	   6,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    4,  -10, 	  -6,   -8, 	   3,   -3, 	  -2,  -10
+.2byte    5,   -8, 	   1,   -7, 	  -1,   -3, 	   0,   -8
+.2byte    4,   -7, 	   2,   -7, 	  -5,   -4, 	  -1,   -7
+sBellsproutAnimTable1:
+.4byte sBellsproutAnims_1_1
+.4byte sBellsproutAnims_1_2
+.4byte sBellsproutAnims_1_3
+.4byte sBellsproutAnims_1_4
+.4byte sBellsproutAnims_1_5
+.4byte sBellsproutAnims_1_6
+.4byte sBellsproutAnims_1_7
+.4byte sBellsproutAnims_1_8
+sBellsproutAnimTable2:
+.4byte sBellsproutAnims_2_1
+.4byte sBellsproutAnims_2_2
+.4byte sBellsproutAnims_2_3
+.4byte sBellsproutAnims_2_4
+.4byte sBellsproutAnims_2_5
+.4byte sBellsproutAnims_2_6
+.4byte sBellsproutAnims_2_7
+.4byte sBellsproutAnims_2_8
+sBellsproutAnimTable3:
+.4byte sBellsproutAnims_3_1
+.4byte sBellsproutAnims_3_2
+.4byte sBellsproutAnims_3_3
+.4byte sBellsproutAnims_3_4
+.4byte sBellsproutAnims_3_5
+.4byte sBellsproutAnims_3_6
+.4byte sBellsproutAnims_3_7
+.4byte sBellsproutAnims_3_8
+sBellsproutAnimTable4:
+.4byte sBellsproutAnims_4_1
+.4byte sBellsproutAnims_4_2
+.4byte sBellsproutAnims_4_3
+.4byte sBellsproutAnims_4_4
+.4byte sBellsproutAnims_4_5
+.4byte sBellsproutAnims_4_6
+.4byte sBellsproutAnims_4_7
+.4byte sBellsproutAnims_4_8
+sBellsproutAnimTable5:
+.4byte sBellsproutAnims_5_1
+.4byte sBellsproutAnims_5_2
+.4byte sBellsproutAnims_5_3
+.4byte sBellsproutAnims_5_4
+.4byte sBellsproutAnims_5_5
+.4byte sBellsproutAnims_5_6
+.4byte sBellsproutAnims_5_7
+.4byte sBellsproutAnims_5_8
+sBellsproutAnimTable6:
+.4byte sBellsproutAnims_6_1
+.4byte sBellsproutAnims_6_1
+.4byte sBellsproutAnims_6_1
+.4byte sBellsproutAnims_6_1
+.4byte sBellsproutAnims_6_1
+.4byte sBellsproutAnims_6_1
+.4byte sBellsproutAnims_6_1
+.4byte sBellsproutAnims_6_1
+sBellsproutAnimTable7:
+.4byte sBellsproutAnims_7_1
+.4byte sBellsproutAnims_7_2
+.4byte sBellsproutAnims_7_3
+.4byte sBellsproutAnims_7_4
+.4byte sBellsproutAnims_7_5
+.4byte sBellsproutAnims_7_6
+.4byte sBellsproutAnims_7_7
+.4byte sBellsproutAnims_7_8
+sBellsproutAnimTable8:
+.4byte sBellsproutAnims_8_1
+.4byte sBellsproutAnims_8_2
+.4byte sBellsproutAnims_8_3
+.4byte sBellsproutAnims_8_4
+.4byte sBellsproutAnims_8_5
+.4byte sBellsproutAnims_8_6
+.4byte sBellsproutAnims_8_7
+.4byte sBellsproutAnims_8_8
+sBellsproutAnimTable9:
+.4byte sBellsproutAnims_9_1
+.4byte sBellsproutAnims_9_2
+.4byte sBellsproutAnims_9_3
+.4byte sBellsproutAnims_9_4
+.4byte sBellsproutAnims_9_5
+.4byte sBellsproutAnims_9_6
+.4byte sBellsproutAnims_9_7
+.4byte sBellsproutAnims_9_8
+sBellsproutAnimTable10:
+.4byte sBellsproutAnims_10_1
+.4byte sBellsproutAnims_10_2
+.4byte sBellsproutAnims_10_3
+.4byte sBellsproutAnims_10_4
+.4byte sBellsproutAnims_10_5
+.4byte sBellsproutAnims_10_6
+.4byte sBellsproutAnims_10_7
+.4byte sBellsproutAnims_10_8
+sBellsproutAnimTable11:
+.4byte sBellsproutAnims_11_1
+.4byte sBellsproutAnims_11_2
+.4byte sBellsproutAnims_11_3
+.4byte sBellsproutAnims_11_4
+.4byte sBellsproutAnims_11_5
+.4byte sBellsproutAnims_11_6
+.4byte sBellsproutAnims_11_7
+.4byte sBellsproutAnims_11_8
+sBellsproutAnimTable12:
+.4byte sBellsproutAnims_12_1
+.4byte sBellsproutAnims_12_2
+.4byte sBellsproutAnims_12_3
+.4byte sBellsproutAnims_12_4
+.4byte sBellsproutAnims_12_5
+.4byte sBellsproutAnims_12_6
+.4byte sBellsproutAnims_12_7
+.4byte sBellsproutAnims_12_8
+sBellsproutAnimTable13:
+.4byte sBellsproutAnims_13_1
+.4byte sBellsproutAnims_13_2
+.4byte sBellsproutAnims_13_3
+.4byte sBellsproutAnims_13_4
+.4byte sBellsproutAnims_13_5
+.4byte sBellsproutAnims_13_6
+.4byte sBellsproutAnims_13_7
+.4byte sBellsproutAnims_13_8
+sAxAnimationsBellsprout:
+.4byte sBellsproutAnimTable1
+.4byte sBellsproutAnimTable2
+.4byte sBellsproutAnimTable3
+.4byte sBellsproutAnimTable4
+.4byte sBellsproutAnimTable5
+.4byte sBellsproutAnimTable6
+.4byte sBellsproutAnimTable7
+.4byte sBellsproutAnimTable8
+.4byte sBellsproutAnimTable9
+.4byte sBellsproutAnimTable10
+.4byte sBellsproutAnimTable11
+.4byte sBellsproutAnimTable12
+.4byte sBellsproutAnimTable13
+sAxSpritesBellsprout:
+.4byte sBellsproutSprites1
+.4byte sBellsproutSprites2
+.4byte sBellsproutSprites3
+.4byte sBellsproutSprites4
+.4byte sBellsproutSprites5
+.4byte sBellsproutSprites6
+.4byte sBellsproutSprites7
+.4byte sBellsproutSprites8
+.4byte sBellsproutSprites9
+.4byte sBellsproutSprites10
+.4byte sBellsproutSprites11
+.4byte sBellsproutSprites12
+.4byte sBellsproutSprites13
+.4byte sBellsproutSprites14
+.4byte sBellsproutSprites15
+.4byte sBellsproutSprites16
+.4byte sBellsproutSprites17
+.4byte sBellsproutSprites18
+.4byte sBellsproutSprites19
+.4byte sBellsproutSprites20
+.4byte sBellsproutSprites21
+.4byte sBellsproutSprites22
+.4byte sBellsproutSprites23
+.4byte sBellsproutSprites24
+.4byte sBellsproutSprites25
+.4byte sBellsproutSprites26
+.4byte sBellsproutSprites27
+.4byte sBellsproutSprites28
+.4byte sBellsproutSprites29
+.4byte sBellsproutSprites30
+.4byte sBellsproutSprites31
+.4byte sBellsproutSprites32
+.4byte sBellsproutSprites33
+.4byte sBellsproutSprites34
+.4byte sBellsproutSprites35
+.4byte sBellsproutSprites36
+.4byte sBellsproutSprites37
+.4byte sBellsproutSprites38
+.4byte sBellsproutSprites39
+.4byte sBellsproutSprites40
+.4byte sBellsproutSprites41
+.4byte sBellsproutSprites42
+.4byte sBellsproutSprites43
+.4byte sBellsproutSprites44
+.4byte sBellsproutSprites45
+.4byte sBellsproutSprites46
+.4byte sBellsproutSprites47
+sAxMainBellsprout:
+ax_main sAxPosesBellsprout, sAxAnimationsBellsprout, 13, sAxSpritesBellsprout, sAxPositionsBellsprout

--- a/data/ax/blastoise.inc
+++ b/data/ax/blastoise.inc
@@ -1,0 +1,3266 @@
+.global gAxBlastoise
+gAxBlastoise:
+ax_siro sAxMainBlastoise
+sBlastoisePose1:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose2:
+ax_pose 1, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose3:
+ax_pose 2, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose4:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose5:
+ax_pose 4, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose6:
+ax_pose 5, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose7:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose8:
+ax_pose 7, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose9:
+ax_pose 8, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose10:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose11:
+ax_pose 10, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose12:
+ax_pose 11, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose13:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose14:
+ax_pose 13, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose15:
+ax_pose 14, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose16:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose17:
+ax_pose 10, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose18:
+ax_pose 11, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose19:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose20:
+ax_pose 7, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose21:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose22:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose23:
+ax_pose 4, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose24:
+ax_pose 5, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose25:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose26:
+ax_pose 1, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose27:
+ax_pose 2, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose28:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose29:
+ax_pose 4, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose30:
+ax_pose 5, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose31:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose32:
+ax_pose 7, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose33:
+ax_pose 8, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose34:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose35:
+ax_pose 10, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose36:
+ax_pose 11, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose37:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose38:
+ax_pose 13, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose39:
+ax_pose 14, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose40:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose41:
+ax_pose 10, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose42:
+ax_pose 11, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose43:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose44:
+ax_pose 7, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose45:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose46:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose47:
+ax_pose 4, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose48:
+ax_pose 5, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose49:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose50:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose51:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose52:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose53:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose54:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose55:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose56:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose57:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose58:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose59:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose60:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose61:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose62:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose63:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose64:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose65:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose66:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose67:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose68:
+ax_pose 21, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose69:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose70:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose71:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose72:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose73:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose74:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose75:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose76:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose77:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose78:
+ax_pose 22, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose79:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose80:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose81:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose82:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose83:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose84:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose85:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose86:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose87:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose88:
+ax_pose 23, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose89:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose90:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose91:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose92:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose93:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose94:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose95:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose96:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose97:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose98:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose99:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose100:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose101:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose102:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose103:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose104:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose105:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose106:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose107:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose108:
+ax_pose 23, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose109:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose110:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose111:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose112:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose113:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose114:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose115:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose116:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose117:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose118:
+ax_pose 22, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose119:
+ax_pose 16, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose120:
+ax_pose 17, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose121:
+ax_pose 18, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose122:
+ax_pose 19, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose123:
+ax_pose 18, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose124:
+ax_pose 17, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose125:
+ax_pose 16, 0x01ed, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose126:
+ax_pose 15, 0x01ed, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose127:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose128:
+ax_pose 21, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose129:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose130:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose131:
+ax_pose 25, 0x41f0, 0x80f0, 0x9c00
+ax_pose 20, 0x01e9, 0x80f0, 0x9c08
+ax_pose_terminator
+sBlastoisePose132:
+ax_pose 26, 0x41ef, 0x80f0, 0x9c00
+ax_pose 0, 0x01e9, 0x80f0, 0x9c08
+ax_pose_terminator
+sBlastoisePose133:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose134:
+ax_pose 21, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose135:
+ax_pose 27, 0x01e8, 0x90f0, 0x9c00
+ax_pose 21, 0x01ec, 0x90f0, 0x9c10
+ax_pose_terminator
+sBlastoisePose136:
+ax_pose 28, 0x01e8, 0x90f0, 0x9c00
+ax_pose 3, 0x01e8, 0x90ef, 0x9c10
+ax_pose_terminator
+sBlastoisePose137:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose138:
+ax_pose 22, 0x01ec, 0x90f1, 0x9c00
+ax_pose_terminator
+sBlastoisePose139:
+ax_pose 29, 0x81e8, 0x9101, 0x9c00
+ax_pose 22, 0x01ec, 0x90f1, 0x9c08
+ax_pose_terminator
+sBlastoisePose140:
+ax_pose 30, 0x81e8, 0x90fe, 0x9c00
+ax_pose 6, 0x01e8, 0x90f0, 0x9c08
+ax_pose_terminator
+sBlastoisePose141:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose142:
+ax_pose 23, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose143:
+ax_pose 31, 0x01e7, 0x90f1, 0x9c00
+ax_pose 23, 0x01ec, 0x90f0, 0x9c10
+ax_pose_terminator
+sBlastoisePose144:
+ax_pose 32, 0x01e7, 0x90f1, 0x9c00
+ax_pose 9, 0x01e8, 0x90f0, 0x9c10
+ax_pose_terminator
+sBlastoisePose145:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose146:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose147:
+ax_pose 33, 0x41e5, 0x80f0, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c08
+ax_pose_terminator
+sBlastoisePose148:
+ax_pose 34, 0x41e5, 0x80f0, 0x9c00
+ax_pose 12, 0x01e8, 0x80f0, 0x9c08
+ax_pose_terminator
+sBlastoisePose149:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose150:
+ax_pose 23, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose151:
+ax_pose 31, 0x01e7, 0x80ef, 0x9c00
+ax_pose 23, 0x01ec, 0x80f0, 0x9c10
+ax_pose_terminator
+sBlastoisePose152:
+ax_pose 32, 0x01e7, 0x80ef, 0x9c00
+ax_pose 9, 0x01e8, 0x80f0, 0x9c10
+ax_pose_terminator
+sBlastoisePose153:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose154:
+ax_pose 22, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose155:
+ax_pose 29, 0x81e8, 0x80ef, 0x9c00
+ax_pose 22, 0x01ec, 0x80ef, 0x9c08
+ax_pose_terminator
+sBlastoisePose156:
+ax_pose 30, 0x81e8, 0x80f2, 0x9c00
+ax_pose 6, 0x01e8, 0x80f0, 0x9c08
+ax_pose_terminator
+sBlastoisePose157:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose158:
+ax_pose 21, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose159:
+ax_pose 27, 0x01e8, 0x80ef, 0x9c00
+ax_pose 21, 0x01ec, 0x80ef, 0x9c10
+ax_pose_terminator
+sBlastoisePose160:
+ax_pose 28, 0x01e8, 0x80f0, 0x9c00
+ax_pose 3, 0x01e8, 0x80f0, 0x9c10
+ax_pose_terminator
+sBlastoisePose161:
+ax_pose 15, 0x01ee, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose162:
+ax_pose 16, 0x01ee, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose163:
+ax_pose 17, 0x01ee, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose164:
+ax_pose 18, 0x01ee, 0x90ed, 0x9c00
+ax_pose_terminator
+sBlastoisePose165:
+ax_pose 19, 0x01ee, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose166:
+ax_pose 18, 0x01ee, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose167:
+ax_pose 17, 0x01ee, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose168:
+ax_pose 16, 0x01ee, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose169:
+ax_pose 35, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose170:
+ax_pose 36, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose171:
+ax_pose 15, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose172:
+ax_pose 16, 0x01eb, 0x90ec, 0x9c00
+ax_pose_terminator
+sBlastoisePose173:
+ax_pose 17, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sBlastoisePose174:
+ax_pose 18, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sBlastoisePose175:
+ax_pose 19, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose176:
+ax_pose 18, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose177:
+ax_pose 17, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose178:
+ax_pose 16, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sBlastoisePose179:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose180:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose181:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose182:
+ax_pose 21, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose183:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose184:
+ax_pose 22, 0x01ec, 0x90f1, 0x9c00
+ax_pose_terminator
+sBlastoisePose185:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose186:
+ax_pose 23, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose187:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose188:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose189:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose190:
+ax_pose 23, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose191:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose192:
+ax_pose 22, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose193:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose194:
+ax_pose 21, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose195:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose196:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose197:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose198:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose199:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose200:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose201:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose202:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose203:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose204:
+ax_pose 21, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose205:
+ax_pose 22, 0x01ec, 0x90f1, 0x9c00
+ax_pose_terminator
+sBlastoisePose206:
+ax_pose 23, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose207:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose208:
+ax_pose 23, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose209:
+ax_pose 22, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose210:
+ax_pose 21, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose211:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose212:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose213:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose214:
+ax_pose 21, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose215:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose216:
+ax_pose 22, 0x01ec, 0x90f1, 0x9c00
+ax_pose_terminator
+sBlastoisePose217:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose218:
+ax_pose 23, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose219:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose220:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose221:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose222:
+ax_pose 23, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose223:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose224:
+ax_pose 22, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose225:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose226:
+ax_pose 21, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose227:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose228:
+ax_pose 21, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose229:
+ax_pose 22, 0x01ec, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose230:
+ax_pose 23, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose231:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose232:
+ax_pose 23, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose233:
+ax_pose 22, 0x01ec, 0x90f1, 0x9c00
+ax_pose_terminator
+sBlastoisePose234:
+ax_pose 21, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose235:
+ax_pose 0, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose236:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose237:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose238:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose239:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose240:
+ax_pose 9, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose241:
+ax_pose 6, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose242:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose243:
+ax_pose 12, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose244:
+ax_pose 37, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose245:
+ax_pose 38, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose246:
+ax_pose 39, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose247:
+ax_pose 40, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose248:
+ax_pose 41, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose249:
+ax_pose 42, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose250:
+ax_pose 43, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose251:
+ax_pose 9, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose252:
+ax_pose 44, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose253:
+ax_pose 45, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose254:
+ax_pose 46, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose255:
+ax_pose 47, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose256:
+ax_pose 48, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose257:
+ax_pose 46, 0x01e7, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose258:
+ax_pose 47, 0x01e7, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose259:
+ax_pose 48, 0x01e7, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose260:
+ax_pose 46, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose261:
+ax_pose 47, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose262:
+ax_pose 48, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose263:
+ax_pose 49, 0x01e6, 0x80ef, 0x9c00
+ax_pose_terminator
+sBlastoisePose264:
+ax_pose 46, 0x01e7, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose265:
+ax_pose 47, 0x01e7, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose266:
+ax_pose 48, 0x01e7, 0x90f0, 0x9c00
+ax_pose_terminator
+sBlastoisePose267:
+ax_pose 49, 0x01e6, 0x90f1, 0x9c00
+ax_pose_terminator
+.align 2
+sBlastoiseAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 24, -1, -2, -1, -2,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 24, -1, -2, -1, -2,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 24, -1, -2, -1, -2,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 1, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 4, 0, 25, 0, 2, 0, 2,
+ax_anim_terminator
+sBlastoiseAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 27, -3, -1, -3, -1,
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 27, -3, -1, -3, -1,
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 27, -3, -1, -3, -1,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 1, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 19, 18, 19, 18,
+ax_anim 2, 0, 27, 10, 10, 10, 10,
+ax_anim 4, 0, 28, 2, 2, 2, 2,
+ax_anim_terminator
+sBlastoiseAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 1, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 30, 10, 0, 10, 0,
+ax_anim 4, 0, 31, 2, 0, 2, 0,
+ax_anim_terminator
+sBlastoiseAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 33, -3, 1, -3, 1,
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 33, -3, 1, -3, 1,
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 33, -3, 1, -3, 1,
+ax_anim 1, 2, 35, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 1, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 1, 35, 19, -18, 19, -18,
+ax_anim 2, 0, 33, 10, -10, 10, -10,
+ax_anim 4, 0, 34, 2, -2, 2, -2,
+ax_anim_terminator
+sBlastoiseAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 36, -1, 2, -1, 2,
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 36, -1, 2, -1, 2,
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 36, -1, 2, -1, 2,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -10, 0, -10,
+ax_anim 1, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -10, 0, -10,
+ax_anim 4, 0, 37, 0, -2, 0, -2,
+ax_anim_terminator
+sBlastoiseAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 39, 3, 1, 3, 1,
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 39, 3, 1, 3, 1,
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 39, 3, 1, 3, 1,
+ax_anim 1, 2, 41, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -10, -10, -10, -10,
+ax_anim 1, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 1, 41, -19, -18, -19, -18,
+ax_anim 2, 0, 39, -10, -10, -10, -10,
+ax_anim 4, 0, 40, -2, -2, -2, -2,
+ax_anim_terminator
+sBlastoiseAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 1, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -19, 0, -19, 0,
+ax_anim 2, 0, 42, -10, 0, -10, 0,
+ax_anim 4, 0, 43, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 45, 3, -1, 3, -1,
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 45, 3, -1, 3, -1,
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 45, 3, -1, 3, -1,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 1, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 1, 47, -19, 18, -19, 18,
+ax_anim 2, 0, 45, -10, 10, -10, 10,
+ax_anim 4, 0, 46, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_3_1:
+ax_anim 6, 0, 57, 0, -2, 0, 0,
+ax_anim 2, 0, 56, 0, -7, 0, 0,
+ax_anim 2, 0, 56, 0, -8, 0, 0,
+ax_anim 4, 0, 48, 0, -10, 0, 0,
+ax_anim 3, 0, 49, 0, -11, 0, 0,
+ax_anim 2, 0, 50, 0, -11, 0, 0,
+ax_anim 1, 2, 51, 0, -10, 0, 1,
+ax_anim 1, 0, 52, 0, -8, 0, 2,
+ax_anim 1, 0, 53, 0, 2, 0, 8,
+ax_anim 1, 0, 54, 0, 18, 0, 21,
+ax_anim 2, 1, 55, 1, 18, 1, 21,
+ax_anim 2, 0, 48, 0, 18, 0, 21,
+ax_anim 2, 0, 49, 1, 18, 1, 21,
+ax_anim 2, 0, 50, 0, 11, 0, 15,
+ax_anim 2, 0, 57, 0, -4, 0, 2,
+ax_anim 2, 0, 57, 0, -5, 0, 1,
+ax_anim 2, 0, 57, 0, -4, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_3_2:
+ax_anim 6, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 66, 0, -7, 0, 0,
+ax_anim 2, 0, 66, 0, -8, 0, 0,
+ax_anim 4, 0, 58, 0, -10, 0, 0,
+ax_anim 3, 0, 59, 1, -11, 0, 0,
+ax_anim 2, 0, 60, 2, -11, 0, 0,
+ax_anim 1, 2, 61, 3, -10, 1, 1,
+ax_anim 1, 0, 62, 6, -8, 2, 2,
+ax_anim 1, 0, 63, 10, 0, 8, 8,
+ax_anim 1, 0, 64, 18, 13, 18, 18,
+ax_anim 2, 1, 65, 19, 13, 19, 18,
+ax_anim 2, 0, 58, 18, 13, 18, 18,
+ax_anim 2, 0, 59, 19, 13, 19, 18,
+ax_anim 2, 0, 60, 8, -3, 8, 8,
+ax_anim 2, 0, 67, 2, -4, 2, 2,
+ax_anim 2, 0, 67, 1, -5, 1, 1,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_3_3:
+ax_anim 6, 0, 77, -2, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -7, 0, 0,
+ax_anim 2, 0, 76, 0, -8, 0, 0,
+ax_anim 4, 0, 68, 0, -10, 0, 0,
+ax_anim 3, 0, 69, 0, -11, 0, 0,
+ax_anim 2, 0, 70, 1, -11, 1, 0,
+ax_anim 1, 2, 71, 2, -11, 2, 0,
+ax_anim 1, 0, 72, 6, -10, 6, 0,
+ax_anim 1, 0, 73, 10, -7, 10, 0,
+ax_anim 1, 0, 74, 18, -3, 18, 0,
+ax_anim 2, 1, 75, 18, -4, 18, -1,
+ax_anim 2, 0, 68, 18, -3, 18, 0,
+ax_anim 2, 0, 69, 18, -4, 18, -1,
+ax_anim 2, 0, 70, 10, -6, 10, 0,
+ax_anim 2, 0, 77, 2, -6, 2, 0,
+ax_anim 2, 0, 77, 1, -6, 1, 0,
+ax_anim 2, 0, 77, 0, -4, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_3_4:
+ax_anim 6, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -6, 0, 0,
+ax_anim 2, 0, 86, 0, -7, 0, 0,
+ax_anim 4, 0, 78, 0, -10, 0, 0,
+ax_anim 3, 0, 79, 1, -11, 1, -1,
+ax_anim 2, 0, 80, 2, -12, 2, -2,
+ax_anim 1, 2, 81, 3, -13, 3, -3,
+ax_anim 1, 0, 82, 6, -15, 6, -6,
+ax_anim 1, 0, 83, 10, -17, 10, -10,
+ax_anim 1, 0, 84, 18, -20, 18, -18,
+ax_anim 2, 1, 85, 18, -21, 18, -19,
+ax_anim 2, 0, 78, 18, -20, 18, -18,
+ax_anim 2, 0, 79, 18, -21, 18, -19,
+ax_anim 2, 0, 80, 10, -19, 10, -10,
+ax_anim 2, 0, 87, 2, -11, 2, -2,
+ax_anim 2, 0, 87, 1, -10, 1, -1,
+ax_anim 2, 0, 87, 0, -6, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_3_5:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -6, 0, 0,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 4, 0, 88, 0, -11, 0, 0,
+ax_anim 3, 0, 89, 0, -12, 0, -1,
+ax_anim 2, 0, 90, 0, -13, 0, -2,
+ax_anim 1, 2, 91, 0, -14, 0, -3,
+ax_anim 1, 0, 92, 0, -16, 0, -6,
+ax_anim 1, 0, 93, 0, -17, 0, -10,
+ax_anim 1, 0, 94, 0, -20, 0, -18,
+ax_anim 2, 1, 95, -1, -20, -1, -18,
+ax_anim 2, 0, 88, 0, -20, 0, -18,
+ax_anim 2, 0, 89, -1, -20, -1, -18,
+ax_anim 2, 0, 90, 0, -17, 0, -10,
+ax_anim 2, 0, 97, 0, -9, 0, -2,
+ax_anim 2, 0, 97, 0, -8, 0, -1,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_3_6:
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 106, 0, -7, 0, 0,
+ax_anim 4, 0, 98, 0, -10, 0, 0,
+ax_anim 3, 0, 99, -1, -11, -1, -1,
+ax_anim 2, 0, 100, -2, -12, -2, -2,
+ax_anim 1, 2, 101, -3, -13, -3, -3,
+ax_anim 1, 0, 102, -6, -15, -6, -6,
+ax_anim 1, 0, 103, -10, -17, -10, -10,
+ax_anim 1, 0, 104, -18, -20, -18, -18,
+ax_anim 2, 1, 105, -18, -21, -18, -19,
+ax_anim 2, 0, 98, -18, -20, -18, -18,
+ax_anim 2, 0, 99, -18, -21, -18, -19,
+ax_anim 2, 0, 100, -10, -19, -10, -10,
+ax_anim 2, 0, 107, -2, -11, -2, -2,
+ax_anim 2, 0, 107, -1, -10, -1, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_3_7:
+ax_anim 6, 0, 117, 2, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -7, 0, 0,
+ax_anim 2, 0, 116, 0, -8, 0, 0,
+ax_anim 4, 0, 108, 0, -10, 0, 0,
+ax_anim 3, 0, 109, 0, -11, 0, 0,
+ax_anim 2, 0, 110, -1, -11, -1, 0,
+ax_anim 1, 2, 111, -2, -11, -2, 0,
+ax_anim 1, 0, 112, -6, -10, -6, 0,
+ax_anim 1, 0, 113, -10, -7, -10, 0,
+ax_anim 1, 0, 114, -18, -3, -18, 0,
+ax_anim 2, 1, 115, -18, -4, -18, -1,
+ax_anim 2, 0, 108, -18, -3, -18, 0,
+ax_anim 2, 0, 109, -18, -4, -18, -1,
+ax_anim 2, 0, 110, -10, -6, -10, 0,
+ax_anim 2, 0, 117, -2, -6, -2, 0,
+ax_anim 2, 0, 117, -1, -6, -1, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_3_8:
+ax_anim 6, 0, 127, 0, -2, 0, 0,
+ax_anim 2, 0, 126, 0, -7, 0, 0,
+ax_anim 2, 0, 126, 0, -8, 0, 0,
+ax_anim 4, 0, 118, 0, -10, 0, 0,
+ax_anim 3, 0, 119, -1, -11, 0, 0,
+ax_anim 2, 0, 120, -2, -11, 0, 0,
+ax_anim 1, 2, 121, -3, -10, -1, 1,
+ax_anim 1, 0, 122, -6, -8, -2, 2,
+ax_anim 1, 0, 123, -10, 0, -8, 8,
+ax_anim 1, 0, 124, -18, 13, -18, 18,
+ax_anim 2, 1, 125, -19, 13, -19, 18,
+ax_anim 2, 0, 118, -18, 13, -18, 18,
+ax_anim 2, 0, 119, -19, 13, -19, 18,
+ax_anim 2, 0, 120, -8, -3, -8, 8,
+ax_anim 2, 0, 127, -2, -4, -2, 2,
+ax_anim 2, 0, 127, -1, -5, -1, 1,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_4_1:
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 1, 0, 2,
+ax_anim 6, 0, 130, 0, 2, 0, 2,
+ax_anim 2, 1, 131, 0, 1, 0, 1,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim 4, 0, 128, 0, -5, 0, -5,
+ax_anim_terminator
+sBlastoiseAnims_4_2:
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 1, 1, 2, 2,
+ax_anim 6, 0, 134, 2, 2, 2, 2,
+ax_anim 2, 1, 135, 2, 2, 2, 2,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 4, 0, 132, -5, -5, -5, -5,
+ax_anim_terminator
+sBlastoiseAnims_4_3:
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 1, 0, 2, 0,
+ax_anim 6, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 1, 139, 2, 0, -6, 0,
+ax_anim 2, 0, 136, -4, 0, -6, 0,
+ax_anim 4, 0, 136, -5, 0, -4, 0,
+ax_anim_terminator
+sBlastoiseAnims_4_4:
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 1, -1, 1, -1,
+ax_anim 6, 0, 142, 2, -2, 2, -2,
+ax_anim 2, 1, 143, 2, -1, 2, -1,
+ax_anim 2, 0, 140, -4, 4, -4, 4,
+ax_anim 4, 0, 140, -5, 5, -5, 5,
+ax_anim_terminator
+sBlastoiseAnims_4_5:
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, -1, 0, -1,
+ax_anim 6, 0, 146, 0, -2, 0, -2,
+ax_anim 2, 1, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 4, 0, 4,
+ax_anim 4, 0, 144, 0, 5, 0, 5,
+ax_anim_terminator
+sBlastoiseAnims_4_6:
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 149, -1, -1, -1, -1,
+ax_anim 6, 0, 150, -2, -2, -2, -2,
+ax_anim 2, 1, 151, -2, -1, -2, -1,
+ax_anim 2, 0, 148, 4, 4, 4, 4,
+ax_anim 4, 0, 148, 5, 5, 5, 5,
+ax_anim_terminator
+sBlastoiseAnims_4_7:
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 2, 153, -1, 0, -2, 0,
+ax_anim 6, 0, 154, -2, 0, -2, 0,
+ax_anim 2, 1, 155, -2, 0, 6, 0,
+ax_anim 2, 0, 152, 4, 0, 6, 0,
+ax_anim 4, 0, 152, 5, 0, 4, 0,
+ax_anim_terminator
+sBlastoiseAnims_4_8:
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 2, 157, -1, 1, -2, 2,
+ax_anim 6, 0, 158, -2, 2, -2, 2,
+ax_anim 2, 1, 159, -2, 2, -2, 2,
+ax_anim 2, 0, 156, 4, -4, 4, -4,
+ax_anim 4, 0, 156, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_5_1:
+ax_anim 20, 0, 160, 0, 0, 1, 0,
+ax_anim 2, 2, 160, 1, 0, 2, 0,
+ax_anim 2, 0, 160, 0, 0, 1, 0,
+ax_anim 1, 0, 160, 1, 0, 2, 0,
+ax_anim 1, 0, 160, 0, 0, 1, 0,
+ax_anim 2, 0, 160, 1, 0, 2, 0,
+ax_anim 2, 0, 160, 0, 0, 1, 0,
+ax_anim_terminator
+sBlastoiseAnims_5_2:
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 2, 167, 1, 0, 1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 1, 0, 1, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, 0, 1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_5_3:
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 2, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 1, 0, 1, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_5_4:
+ax_anim 20, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 2, 165, 1, 0, 1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 1, 0, 1, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, 0, 1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_5_5:
+ax_anim 20, 0, 164, 0, 0, 1, 0,
+ax_anim 2, 2, 164, 1, 0, 2, 0,
+ax_anim 2, 0, 164, 0, 0, 1, 0,
+ax_anim 1, 0, 164, 1, 0, 2, 0,
+ax_anim 1, 0, 164, 0, 0, 1, 0,
+ax_anim 2, 0, 164, 1, 0, 2, 0,
+ax_anim 2, 0, 164, 0, 0, 1, 0,
+ax_anim_terminator
+sBlastoiseAnims_5_6:
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 2, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 1, 0, 1, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_5_7:
+ax_anim 20, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 2, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 1, 0, 1, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_5_8:
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 2, 161, 1, 0, 1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 1, 0, 1, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, 0, 1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_7_1:
+ax_anim 2, 0, 170, 0, -3, 0, -3,
+ax_anim 8, 0, 170, 0, -4, 0, -4,
+ax_anim_terminator
+sBlastoiseAnims_7_2:
+ax_anim 2, 0, 171, -3, -3, -3, -3,
+ax_anim 8, 0, 171, -4, -4, -4, -4,
+ax_anim_terminator
+sBlastoiseAnims_7_3:
+ax_anim 2, 0, 172, -3, 0, -3, 0,
+ax_anim 8, 0, 172, -4, 0, -4, 0,
+ax_anim_terminator
+sBlastoiseAnims_7_4:
+ax_anim 2, 0, 173, -3, 3, -3, 3,
+ax_anim 8, 0, 173, -4, 4, -4, 4,
+ax_anim_terminator
+sBlastoiseAnims_7_5:
+ax_anim 2, 0, 174, 0, 3, 0, 3,
+ax_anim 8, 0, 174, 0, 4, 0, 4,
+ax_anim_terminator
+sBlastoiseAnims_7_6:
+ax_anim 2, 0, 175, 3, 3, 3, 3,
+ax_anim 8, 0, 175, 4, 4, 4, 4,
+ax_anim_terminator
+sBlastoiseAnims_7_7:
+ax_anim 2, 0, 176, 3, 0, 3, 0,
+ax_anim 8, 0, 176, 4, 0, 4, 0,
+ax_anim_terminator
+sBlastoiseAnims_7_8:
+ax_anim 2, 0, 177, 3, -3, 3, -3,
+ax_anim 8, 0, 177, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_8_1:
+ax_anim 32, 0, 178, 0, 0, 0, 0,
+ax_anim 12, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 1, 0, 1, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 1, 0, 1, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 1, 0, 1, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_8_2:
+ax_anim 32, 0, 180, 0, 0, 0, 0,
+ax_anim 12, 0, 181, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 1, -1, 1, -1,
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 1, -1, 1, -1,
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 1, -1, 1, -1,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_8_3:
+ax_anim 32, 0, 182, 0, 0, 0, 0,
+ax_anim 12, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, 1, 0, 1,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, 1, 0, 1,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, 1, 0, 1,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_8_4:
+ax_anim 32, 0, 184, 0, 0, 0, 0,
+ax_anim 12, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 1, 1, 1, 1,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 1, 1, 1, 1,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 1, 1, 1, 1,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_8_5:
+ax_anim 32, 0, 186, 0, 0, 0, 0,
+ax_anim 12, 0, 187, 0, 0, 0, 0,
+ax_anim 4, 0, 187, -1, 0, -1, 0,
+ax_anim 4, 0, 187, 0, 0, 0, 0,
+ax_anim 4, 0, 187, -1, 0, -1, 0,
+ax_anim 4, 0, 187, 0, 0, 0, 0,
+ax_anim 4, 0, 187, -1, 0, -1, 0,
+ax_anim 8, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_8_6:
+ax_anim 32, 0, 188, 0, 0, 0, 0,
+ax_anim 12, 0, 189, 0, 0, 0, 0,
+ax_anim 4, 0, 189, -1, 1, -1, 1,
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim 4, 0, 189, -1, 1, -1, 1,
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim 4, 0, 189, -1, 1, -1, 1,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_8_7:
+ax_anim 32, 0, 190, 0, 0, 0, 0,
+ax_anim 12, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, 1, 0, 1,
+ax_anim 4, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, 1, 0, 1,
+ax_anim 4, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, 1, 0, 1,
+ax_anim 8, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_8_8:
+ax_anim 32, 0, 192, 0, 0, 0, 0,
+ax_anim 12, 0, 193, 0, 0, 0, 0,
+ax_anim 4, 0, 193, -1, -1, -1, -1,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 4, 0, 193, -1, -1, -1, -1,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 4, 0, 193, -1, -1, -1, -1,
+ax_anim 8, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 4, 6, 4,
+ax_anim 2, 0, 196, 8, 9, 11, 9,
+ax_anim 2, 0, 197, 8, 15, 8, 15,
+ax_anim 3, 0, 198, 0, 20, 0, 20,
+ax_anim 2, 3, 199, -8, 15, -8, 15,
+ax_anim 2, 0, 200, -8, 9, -11, 9,
+ax_anim 1, 0, 201, -6, 4, -6, 4,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 24, 9, 24, 9,
+ax_anim 3, 0, 197, 23, 16, 23, 16,
+ax_anim 2, 3, 198, 11, 16, 11, 16,
+ax_anim 2, 0, 199, 4, 12, 4, 12,
+ax_anim 1, 0, 200, 3, 7, 3, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -4, 3, -4,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 17, -4, 17, -4,
+ax_anim 3, 0, 196, 20, 1, 20, 1,
+ax_anim 2, 3, 197, 17, 5, 17, 5,
+ax_anim 2, 0, 198, 12, 7, 12, 7,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 1, -6, 1, -6,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 11, -20, 11, -20,
+ax_anim 3, 0, 195, 16, -20, 16, -20,
+ax_anim 2, 3, 196, 16, -15, 16, -15,
+ax_anim 2, 0, 197, 14, -6, 14, -6,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -6, -4, -6, -4,
+ax_anim 2, 0, 200, -8, -11, -8, -11,
+ax_anim 2, 0, 201, -7, -17, -7, -17,
+ax_anim 3, 0, 194, -1, -20, -1, -20,
+ax_anim 2, 3, 195, 4, -18, 4, -18,
+ax_anim 2, 0, 196, 5, -10, 5, -10,
+ax_anim 1, 0, 197, 4, -4, 4, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, -1, -6, -1, -6,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -11, -20, -11, -20,
+ax_anim 3, 0, 201, -16, -20, -16, -20,
+ax_anim 2, 3, 200, -16, -15, -16, -15,
+ax_anim 2, 0, 199, -14, -6, -14, -6,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -4, -3, -4,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -17, -4, -17, -4,
+ax_anim 3, 0, 200, -20, 1, -20, 1,
+ax_anim 2, 3, 199, -17, 5, -17, 5,
+ax_anim 2, 0, 198, -12, 7, -12, 7,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -24, 9, -24, 9,
+ax_anim 3, 0, 199, -23, 16, -23, 16,
+ax_anim 2, 3, 198, -11, 16, -11, 16,
+ax_anim 2, 0, 197, -4, 12, -4, 12,
+ax_anim 1, 0, 196, -3, 7, -3, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_11_1:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -22, 0, 0,
+ax_anim 2, 0, 211, 0, -18, 0, 0,
+ax_anim 1, 0, 211, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_11_3:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_11_4:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -17, 0, 0,
+ax_anim 1, 0, 217, 0, -11, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_11_5:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_11_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_11_7:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_11_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_14_1:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 6, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, 0, -1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, 0, -1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 14, 0, 243, -1, 0, -1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, -1,
+ax_anim 2, 0, 244, 0, -4, 0, -2,
+ax_anim 4, 0, 244, 0, -6, 0, -2,
+ax_anim 2, 0, 245, 0, -7, 0, -2,
+ax_anim 2, 0, 245, 0, -3, 0, -2,
+ax_anim 2, 0, 245, 0, -5, 0, -2,
+ax_anim 6, 0, 245, 0, -7, 0, -2,
+ax_anim 2, 0, 245, 0, -5, 0, -2,
+ax_anim 10, 0, 245, 0, -3, 0, -2,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_15_1:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_15_2:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_15_3:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_15_4:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_15_5:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_15_6:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_15_7:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_15_8:
+ax_anim 20, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 20, 0, 248, 0, 0, 0, 0,
+ax_anim 7, 0, 249, 0, 0, 0, 0,
+ax_anim 15, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_16_1:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_16_2:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_16_3:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_16_4:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_16_5:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_16_6:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_16_7:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_16_8:
+ax_anim 20, 0, 251, 0, 0, 0, 0,
+ax_anim 30, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_17_1:
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 257, 0, 0, 0, 0,
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_17_2:
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 257, 0, 0, 0, 0,
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_17_3:
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 257, 0, 0, 0, 0,
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_17_4:
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 257, 0, 0, 0, 0,
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_17_5:
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 257, 0, 0, 0, 0,
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_17_6:
+ax_anim 18, 0, 253, 0, 0, 0, 0,
+ax_anim 28, 0, 254, 0, 0, 0, 0,
+ax_anim 18, 0, 253, 0, 0, 0, 0,
+ax_anim 28, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_17_7:
+ax_anim 18, 0, 253, 0, 0, 0, 0,
+ax_anim 28, 0, 254, 0, 0, 0, 0,
+ax_anim 18, 0, 253, 0, 0, 0, 0,
+ax_anim 28, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sBlastoiseAnims_17_8:
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 257, 0, 0, 0, 0,
+ax_anim 18, 0, 256, 0, 0, 0, 0,
+ax_anim 28, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlastoiseAnims_18_1:
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim 6, 0, 261, 0, 0, -1, 0,
+ax_anim 4, 0, 262, -2, 0, -2, 0,
+ax_anim 2, 0, 262, -2, -1, -2, -1,
+ax_anim 6, 0, 262, -2, -2, -2, -2,
+ax_anim 1, 0, 262, -2, -1, -2, -1,
+ax_anim 10, 0, 262, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseAnims_18_2:
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim 6, 0, 261, 0, 0, -1, 0,
+ax_anim 4, 0, 262, -2, 0, -2, 0,
+ax_anim 2, 0, 262, -2, -1, -2, -1,
+ax_anim 6, 0, 262, -2, -2, -2, -2,
+ax_anim 1, 0, 262, -2, -1, -2, -1,
+ax_anim 10, 0, 262, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseAnims_18_3:
+ax_anim 20, 0, 263, 0, 0, 0, 0,
+ax_anim 6, 0, 265, 0, 0, 1, 0,
+ax_anim 4, 0, 266, 2, 0, 2, 0,
+ax_anim 2, 0, 266, 2, -1, 2, -1,
+ax_anim 6, 0, 266, 2, -2, 2, -2,
+ax_anim 1, 0, 266, 2, -1, 2, -1,
+ax_anim 10, 0, 266, 2, 0, 2, 0,
+ax_anim_terminator
+sBlastoiseAnims_18_4:
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim 6, 0, 261, 0, 0, -1, 0,
+ax_anim 4, 0, 262, -2, 0, -2, 0,
+ax_anim 2, 0, 262, -2, -1, -2, -1,
+ax_anim 6, 0, 262, -2, -2, -2, -2,
+ax_anim 1, 0, 262, -2, -1, -2, -1,
+ax_anim 10, 0, 262, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseAnims_18_5:
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim 6, 0, 261, 0, 0, -1, 0,
+ax_anim 4, 0, 262, -2, 0, -2, 0,
+ax_anim 2, 0, 262, -2, -1, -2, -1,
+ax_anim 6, 0, 262, -2, -2, -2, -2,
+ax_anim 1, 0, 262, -2, -1, -2, -1,
+ax_anim 10, 0, 262, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseAnims_18_6:
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim 6, 0, 261, 0, 0, -1, 0,
+ax_anim 4, 0, 262, -2, 0, -2, 0,
+ax_anim 2, 0, 262, -2, -1, -2, -1,
+ax_anim 6, 0, 262, -2, -2, -2, -2,
+ax_anim 1, 0, 262, -2, -1, -2, -1,
+ax_anim 10, 0, 262, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseAnims_18_7:
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim 6, 0, 261, 0, 0, -1, 0,
+ax_anim 4, 0, 262, -2, 0, -2, 0,
+ax_anim 2, 0, 262, -2, -1, -2, -1,
+ax_anim 6, 0, 262, -2, -2, -2, -2,
+ax_anim 1, 0, 262, -2, -1, -2, -1,
+ax_anim 10, 0, 262, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseAnims_18_8:
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim 6, 0, 261, 0, 0, -1, 0,
+ax_anim 4, 0, 262, -2, 0, -2, 0,
+ax_anim 2, 0, 262, -2, -1, -2, -1,
+ax_anim 6, 0, 262, -2, -2, -2, -2,
+ax_anim 1, 0, 262, -2, -1, -2, -1,
+ax_anim 10, 0, 262, -2, 0, -2, 0,
+ax_anim_terminator
+sBlastoiseGfx1:
+.incbin "baserom.gba", 0x57A780, 0x200
+sBlastoiseSprites1:
+ax_sprite sBlastoiseGfx1, 0x200
+ax_sprite_terminator
+sBlastoiseGfx2:
+.incbin "baserom.gba", 0x57A990, 0x200
+sBlastoiseSprites2:
+ax_sprite sBlastoiseGfx2, 0x200
+ax_sprite_terminator
+sBlastoiseGfx3:
+.incbin "baserom.gba", 0x57ABA0, 0x200
+sBlastoiseSprites3:
+ax_sprite sBlastoiseGfx3, 0x200
+ax_sprite_terminator
+sBlastoiseGfx4:
+.incbin "baserom.gba", 0x57ADB0, 0x200
+sBlastoiseSprites4:
+ax_sprite sBlastoiseGfx4, 0x200
+ax_sprite_terminator
+sBlastoiseGfx5:
+.incbin "baserom.gba", 0x57AFC0, 0x200
+sBlastoiseSprites5:
+ax_sprite sBlastoiseGfx5, 0x200
+ax_sprite_terminator
+sBlastoiseGfx6:
+.incbin "baserom.gba", 0x57B1D0, 0x200
+sBlastoiseSprites6:
+ax_sprite sBlastoiseGfx6, 0x200
+ax_sprite_terminator
+sBlastoiseGfx7:
+.incbin "baserom.gba", 0x57B3E0, 0x200
+sBlastoiseSprites7:
+ax_sprite sBlastoiseGfx7, 0x200
+ax_sprite_terminator
+sBlastoiseGfx8:
+.incbin "baserom.gba", 0x57B5F0, 0x200
+sBlastoiseSprites8:
+ax_sprite sBlastoiseGfx8, 0x200
+ax_sprite_terminator
+sBlastoiseGfx9:
+.incbin "baserom.gba", 0x57B800, 0x200
+sBlastoiseSprites9:
+ax_sprite sBlastoiseGfx9, 0x200
+ax_sprite_terminator
+sBlastoiseGfx10:
+.incbin "baserom.gba", 0x57BA10, 0x200
+sBlastoiseSprites10:
+ax_sprite sBlastoiseGfx10, 0x200
+ax_sprite_terminator
+sBlastoiseGfx11:
+.incbin "baserom.gba", 0x57BC20, 0x200
+sBlastoiseSprites11:
+ax_sprite sBlastoiseGfx11, 0x200
+ax_sprite_terminator
+sBlastoiseGfx12:
+.incbin "baserom.gba", 0x57BE30, 0x200
+sBlastoiseSprites12:
+ax_sprite sBlastoiseGfx12, 0x200
+ax_sprite_terminator
+sBlastoiseGfx13:
+.incbin "baserom.gba", 0x57C040, 0x200
+sBlastoiseSprites13:
+ax_sprite sBlastoiseGfx13, 0x200
+ax_sprite_terminator
+sBlastoiseGfx14:
+.incbin "baserom.gba", 0x57C250, 0x200
+sBlastoiseSprites14:
+ax_sprite sBlastoiseGfx14, 0x200
+ax_sprite_terminator
+sBlastoiseGfx15:
+.incbin "baserom.gba", 0x57C460, 0x200
+sBlastoiseSprites15:
+ax_sprite sBlastoiseGfx15, 0x200
+ax_sprite_terminator
+sBlastoiseGfx16:
+.incbin "baserom.gba", 0x57C670, 0x60
+sBlastoiseGfx16_1:
+.incbin "baserom.gba", 0x57C6D0, 0x60
+sBlastoiseGfx16_2:
+.incbin "baserom.gba", 0x57C730, 0x60
+sBlastoiseSprites16:
+ax_sprite sBlastoiseGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBlastoiseGfx17:
+.incbin "baserom.gba", 0x57C7C8, 0x60
+sBlastoiseGfx17_1:
+.incbin "baserom.gba", 0x57C828, 0x60
+sBlastoiseGfx17_2:
+.incbin "baserom.gba", 0x57C888, 0x60
+sBlastoiseSprites17:
+ax_sprite sBlastoiseGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBlastoiseGfx18:
+.incbin "baserom.gba", 0x57C920, 0x60
+sBlastoiseGfx18_1:
+.incbin "baserom.gba", 0x57C980, 0xE0
+sBlastoiseSprites18:
+ax_sprite sBlastoiseGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx18_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBlastoiseGfx19:
+.incbin "baserom.gba", 0x57CA88, 0x60
+sBlastoiseGfx19_1:
+.incbin "baserom.gba", 0x57CAE8, 0x60
+sBlastoiseGfx19_2:
+.incbin "baserom.gba", 0x57CB48, 0x60
+sBlastoiseSprites19:
+ax_sprite sBlastoiseGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBlastoiseGfx20:
+.incbin "baserom.gba", 0x57CBE0, 0x60
+sBlastoiseGfx20_1:
+.incbin "baserom.gba", 0x57CC40, 0x60
+sBlastoiseGfx20_2:
+.incbin "baserom.gba", 0x57CCA0, 0x60
+sBlastoiseSprites20:
+ax_sprite sBlastoiseGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBlastoiseGfx21:
+.incbin "baserom.gba", 0x57CD38, 0x180
+sBlastoiseSprites21:
+ax_sprite sBlastoiseGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlastoiseGfx22:
+.incbin "baserom.gba", 0x57CED0, 0x180
+sBlastoiseSprites22:
+ax_sprite sBlastoiseGfx22, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlastoiseGfx23:
+.incbin "baserom.gba", 0x57D068, 0x100
+sBlastoiseGfx23_1:
+.incbin "baserom.gba", 0x57D168, 0x60
+sBlastoiseSprites23:
+ax_sprite sBlastoiseGfx23, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx23_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlastoiseGfx24:
+.incbin "baserom.gba", 0x57D1F0, 0x180
+sBlastoiseSprites24:
+ax_sprite sBlastoiseGfx24, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlastoiseGfx25:
+.incbin "baserom.gba", 0x57D388, 0x180
+sBlastoiseGfx25_1:
+.incbin "baserom.gba", 0x57D508, 0x40
+sBlastoiseSprites25:
+ax_sprite sBlastoiseGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlastoiseGfx26:
+.incbin "baserom.gba", 0x57D570, 0x100
+sBlastoiseSprites26:
+ax_sprite sBlastoiseGfx26, 0x100
+ax_sprite_terminator
+sBlastoiseGfx27:
+.incbin "baserom.gba", 0x57D680, 0x100
+sBlastoiseSprites27:
+ax_sprite sBlastoiseGfx27, 0x100
+ax_sprite_terminator
+sBlastoiseGfx28:
+.incbin "baserom.gba", 0x57D790, 0x20
+sBlastoiseGfx28_1:
+.incbin "baserom.gba", 0x57D7B0, 0x20
+sBlastoiseGfx28_2:
+.incbin "baserom.gba", 0x57D7D0, 0x20
+sBlastoiseGfx28_3:
+.incbin "baserom.gba", 0x57D7F0, 0x80
+sBlastoiseSprites28:
+ax_sprite sBlastoiseGfx28, 0x20
+ax_sprite 0, 0x60
+ax_sprite sBlastoiseGfx28_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx28_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx28_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlastoiseGfx29:
+.incbin "baserom.gba", 0x57D8B8, 0x40
+sBlastoiseGfx29_1:
+.incbin "baserom.gba", 0x57D8F8, 0x20
+sBlastoiseGfx29_2:
+.incbin "baserom.gba", 0x57D918, 0xC0
+sBlastoiseGfx29_3:
+.incbin "baserom.gba", 0x57D9D8, 0x40
+sBlastoiseSprites29:
+ax_sprite sBlastoiseGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBlastoiseGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx29_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sBlastoiseGfx29_3, 0x40
+ax_sprite_terminator
+sBlastoiseGfx30:
+.incbin "baserom.gba", 0x57DA58, 0xC0
+sBlastoiseSprites30:
+ax_sprite sBlastoiseGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBlastoiseGfx31:
+.incbin "baserom.gba", 0x57DB30, 0x100
+sBlastoiseSprites31:
+ax_sprite sBlastoiseGfx31, 0x100
+ax_sprite_terminator
+sBlastoiseGfx32:
+.incbin "baserom.gba", 0x57DC40, 0x60
+sBlastoiseGfx32_1:
+.incbin "baserom.gba", 0x57DCA0, 0x40
+sBlastoiseGfx32_2:
+.incbin "baserom.gba", 0x57DCE0, 0x20
+sBlastoiseSprites32:
+ax_sprite sBlastoiseGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlastoiseGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBlastoiseGfx32_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sBlastoiseGfx33:
+.incbin "baserom.gba", 0x57DD38, 0xC0
+sBlastoiseGfx33_1:
+.incbin "baserom.gba", 0x57DDF8, 0x20
+sBlastoiseSprites33:
+ax_sprite sBlastoiseGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sBlastoiseGfx33_1, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sBlastoiseGfx34:
+.incbin "baserom.gba", 0x57DE40, 0x100
+sBlastoiseSprites34:
+ax_sprite sBlastoiseGfx34, 0x100
+ax_sprite_terminator
+sBlastoiseGfx35:
+.incbin "baserom.gba", 0x57DF50, 0xA0
+sBlastoiseGfx35_1:
+.incbin "baserom.gba", 0x57DFF0, 0x20
+sBlastoiseSprites35:
+ax_sprite sBlastoiseGfx35, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sBlastoiseGfx35_1, 0x20
+ax_sprite_terminator
+sBlastoiseGfx36:
+.incbin "baserom.gba", 0x57E030, 0x200
+sBlastoiseSprites36:
+ax_sprite sBlastoiseGfx36, 0x200
+ax_sprite_terminator
+sBlastoiseGfx37:
+.incbin "baserom.gba", 0x57E240, 0x200
+sBlastoiseSprites37:
+ax_sprite sBlastoiseGfx37, 0x200
+ax_sprite_terminator
+sBlastoiseGfx38:
+.incbin "baserom.gba", 0x57E450, 0x200
+sBlastoiseSprites38:
+ax_sprite sBlastoiseGfx38, 0x200
+ax_sprite_terminator
+sBlastoiseGfx39:
+.incbin "baserom.gba", 0x57E660, 0x200
+sBlastoiseSprites39:
+ax_sprite sBlastoiseGfx39, 0x200
+ax_sprite_terminator
+sBlastoiseGfx40:
+.incbin "baserom.gba", 0x57E870, 0x200
+sBlastoiseSprites40:
+ax_sprite sBlastoiseGfx40, 0x200
+ax_sprite_terminator
+sBlastoiseGfx41:
+.incbin "baserom.gba", 0x57EA80, 0x200
+sBlastoiseSprites41:
+ax_sprite sBlastoiseGfx41, 0x200
+ax_sprite_terminator
+sBlastoiseGfx42:
+.incbin "baserom.gba", 0x57EC90, 0x200
+sBlastoiseSprites42:
+ax_sprite sBlastoiseGfx42, 0x200
+ax_sprite_terminator
+sBlastoiseGfx43:
+.incbin "baserom.gba", 0x57EEA0, 0x200
+sBlastoiseSprites43:
+ax_sprite sBlastoiseGfx43, 0x200
+ax_sprite_terminator
+sBlastoiseGfx44:
+.incbin "baserom.gba", 0x57F0B0, 0x200
+sBlastoiseSprites44:
+ax_sprite sBlastoiseGfx44, 0x200
+ax_sprite_terminator
+sBlastoiseGfx45:
+.incbin "baserom.gba", 0x57F2C0, 0x200
+sBlastoiseSprites45:
+ax_sprite sBlastoiseGfx45, 0x200
+ax_sprite_terminator
+sBlastoiseGfx46:
+.incbin "baserom.gba", 0x57F4D0, 0x200
+sBlastoiseSprites46:
+ax_sprite sBlastoiseGfx46, 0x200
+ax_sprite_terminator
+sBlastoiseGfx47:
+.incbin "baserom.gba", 0x57F6E0, 0x200
+sBlastoiseSprites47:
+ax_sprite sBlastoiseGfx47, 0x200
+ax_sprite_terminator
+sBlastoiseGfx48:
+.incbin "baserom.gba", 0x57F8F0, 0x200
+sBlastoiseSprites48:
+ax_sprite sBlastoiseGfx48, 0x200
+ax_sprite_terminator
+sBlastoiseGfx49:
+.incbin "baserom.gba", 0x57FB00, 0x200
+sBlastoiseSprites49:
+ax_sprite sBlastoiseGfx49, 0x200
+ax_sprite_terminator
+sBlastoiseGfx50:
+.incbin "baserom.gba", 0x57FD10, 0x200
+sBlastoiseSprites50:
+ax_sprite sBlastoiseGfx50, 0x200
+ax_sprite_terminator
+sAxPosesBlastoise:
+.4byte sBlastoisePose1
+.4byte sBlastoisePose2
+.4byte sBlastoisePose3
+.4byte sBlastoisePose4
+.4byte sBlastoisePose5
+.4byte sBlastoisePose6
+.4byte sBlastoisePose7
+.4byte sBlastoisePose8
+.4byte sBlastoisePose9
+.4byte sBlastoisePose10
+.4byte sBlastoisePose11
+.4byte sBlastoisePose12
+.4byte sBlastoisePose13
+.4byte sBlastoisePose14
+.4byte sBlastoisePose15
+.4byte sBlastoisePose16
+.4byte sBlastoisePose17
+.4byte sBlastoisePose18
+.4byte sBlastoisePose19
+.4byte sBlastoisePose20
+.4byte sBlastoisePose21
+.4byte sBlastoisePose22
+.4byte sBlastoisePose23
+.4byte sBlastoisePose24
+.4byte sBlastoisePose25
+.4byte sBlastoisePose26
+.4byte sBlastoisePose27
+.4byte sBlastoisePose28
+.4byte sBlastoisePose29
+.4byte sBlastoisePose30
+.4byte sBlastoisePose31
+.4byte sBlastoisePose32
+.4byte sBlastoisePose33
+.4byte sBlastoisePose34
+.4byte sBlastoisePose35
+.4byte sBlastoisePose36
+.4byte sBlastoisePose37
+.4byte sBlastoisePose38
+.4byte sBlastoisePose39
+.4byte sBlastoisePose40
+.4byte sBlastoisePose41
+.4byte sBlastoisePose42
+.4byte sBlastoisePose43
+.4byte sBlastoisePose44
+.4byte sBlastoisePose45
+.4byte sBlastoisePose46
+.4byte sBlastoisePose47
+.4byte sBlastoisePose48
+.4byte sBlastoisePose49
+.4byte sBlastoisePose50
+.4byte sBlastoisePose51
+.4byte sBlastoisePose52
+.4byte sBlastoisePose53
+.4byte sBlastoisePose54
+.4byte sBlastoisePose55
+.4byte sBlastoisePose56
+.4byte sBlastoisePose57
+.4byte sBlastoisePose58
+.4byte sBlastoisePose59
+.4byte sBlastoisePose60
+.4byte sBlastoisePose61
+.4byte sBlastoisePose62
+.4byte sBlastoisePose63
+.4byte sBlastoisePose64
+.4byte sBlastoisePose65
+.4byte sBlastoisePose66
+.4byte sBlastoisePose67
+.4byte sBlastoisePose68
+.4byte sBlastoisePose69
+.4byte sBlastoisePose70
+.4byte sBlastoisePose71
+.4byte sBlastoisePose72
+.4byte sBlastoisePose73
+.4byte sBlastoisePose74
+.4byte sBlastoisePose75
+.4byte sBlastoisePose76
+.4byte sBlastoisePose77
+.4byte sBlastoisePose78
+.4byte sBlastoisePose79
+.4byte sBlastoisePose80
+.4byte sBlastoisePose81
+.4byte sBlastoisePose82
+.4byte sBlastoisePose83
+.4byte sBlastoisePose84
+.4byte sBlastoisePose85
+.4byte sBlastoisePose86
+.4byte sBlastoisePose87
+.4byte sBlastoisePose88
+.4byte sBlastoisePose89
+.4byte sBlastoisePose90
+.4byte sBlastoisePose91
+.4byte sBlastoisePose92
+.4byte sBlastoisePose93
+.4byte sBlastoisePose94
+.4byte sBlastoisePose95
+.4byte sBlastoisePose96
+.4byte sBlastoisePose97
+.4byte sBlastoisePose98
+.4byte sBlastoisePose99
+.4byte sBlastoisePose100
+.4byte sBlastoisePose101
+.4byte sBlastoisePose102
+.4byte sBlastoisePose103
+.4byte sBlastoisePose104
+.4byte sBlastoisePose105
+.4byte sBlastoisePose106
+.4byte sBlastoisePose107
+.4byte sBlastoisePose108
+.4byte sBlastoisePose109
+.4byte sBlastoisePose110
+.4byte sBlastoisePose111
+.4byte sBlastoisePose112
+.4byte sBlastoisePose113
+.4byte sBlastoisePose114
+.4byte sBlastoisePose115
+.4byte sBlastoisePose116
+.4byte sBlastoisePose117
+.4byte sBlastoisePose118
+.4byte sBlastoisePose119
+.4byte sBlastoisePose120
+.4byte sBlastoisePose121
+.4byte sBlastoisePose122
+.4byte sBlastoisePose123
+.4byte sBlastoisePose124
+.4byte sBlastoisePose125
+.4byte sBlastoisePose126
+.4byte sBlastoisePose127
+.4byte sBlastoisePose128
+.4byte sBlastoisePose129
+.4byte sBlastoisePose130
+.4byte sBlastoisePose131
+.4byte sBlastoisePose132
+.4byte sBlastoisePose133
+.4byte sBlastoisePose134
+.4byte sBlastoisePose135
+.4byte sBlastoisePose136
+.4byte sBlastoisePose137
+.4byte sBlastoisePose138
+.4byte sBlastoisePose139
+.4byte sBlastoisePose140
+.4byte sBlastoisePose141
+.4byte sBlastoisePose142
+.4byte sBlastoisePose143
+.4byte sBlastoisePose144
+.4byte sBlastoisePose145
+.4byte sBlastoisePose146
+.4byte sBlastoisePose147
+.4byte sBlastoisePose148
+.4byte sBlastoisePose149
+.4byte sBlastoisePose150
+.4byte sBlastoisePose151
+.4byte sBlastoisePose152
+.4byte sBlastoisePose153
+.4byte sBlastoisePose154
+.4byte sBlastoisePose155
+.4byte sBlastoisePose156
+.4byte sBlastoisePose157
+.4byte sBlastoisePose158
+.4byte sBlastoisePose159
+.4byte sBlastoisePose160
+.4byte sBlastoisePose161
+.4byte sBlastoisePose162
+.4byte sBlastoisePose163
+.4byte sBlastoisePose164
+.4byte sBlastoisePose165
+.4byte sBlastoisePose166
+.4byte sBlastoisePose167
+.4byte sBlastoisePose168
+.4byte sBlastoisePose169
+.4byte sBlastoisePose170
+.4byte sBlastoisePose171
+.4byte sBlastoisePose172
+.4byte sBlastoisePose173
+.4byte sBlastoisePose174
+.4byte sBlastoisePose175
+.4byte sBlastoisePose176
+.4byte sBlastoisePose177
+.4byte sBlastoisePose178
+.4byte sBlastoisePose179
+.4byte sBlastoisePose180
+.4byte sBlastoisePose181
+.4byte sBlastoisePose182
+.4byte sBlastoisePose183
+.4byte sBlastoisePose184
+.4byte sBlastoisePose185
+.4byte sBlastoisePose186
+.4byte sBlastoisePose187
+.4byte sBlastoisePose188
+.4byte sBlastoisePose189
+.4byte sBlastoisePose190
+.4byte sBlastoisePose191
+.4byte sBlastoisePose192
+.4byte sBlastoisePose193
+.4byte sBlastoisePose194
+.4byte sBlastoisePose195
+.4byte sBlastoisePose196
+.4byte sBlastoisePose197
+.4byte sBlastoisePose198
+.4byte sBlastoisePose199
+.4byte sBlastoisePose200
+.4byte sBlastoisePose201
+.4byte sBlastoisePose202
+.4byte sBlastoisePose203
+.4byte sBlastoisePose204
+.4byte sBlastoisePose205
+.4byte sBlastoisePose206
+.4byte sBlastoisePose207
+.4byte sBlastoisePose208
+.4byte sBlastoisePose209
+.4byte sBlastoisePose210
+.4byte sBlastoisePose211
+.4byte sBlastoisePose212
+.4byte sBlastoisePose213
+.4byte sBlastoisePose214
+.4byte sBlastoisePose215
+.4byte sBlastoisePose216
+.4byte sBlastoisePose217
+.4byte sBlastoisePose218
+.4byte sBlastoisePose219
+.4byte sBlastoisePose220
+.4byte sBlastoisePose221
+.4byte sBlastoisePose222
+.4byte sBlastoisePose223
+.4byte sBlastoisePose224
+.4byte sBlastoisePose225
+.4byte sBlastoisePose226
+.4byte sBlastoisePose227
+.4byte sBlastoisePose228
+.4byte sBlastoisePose229
+.4byte sBlastoisePose230
+.4byte sBlastoisePose231
+.4byte sBlastoisePose232
+.4byte sBlastoisePose233
+.4byte sBlastoisePose234
+.4byte sBlastoisePose235
+.4byte sBlastoisePose236
+.4byte sBlastoisePose237
+.4byte sBlastoisePose238
+.4byte sBlastoisePose239
+.4byte sBlastoisePose240
+.4byte sBlastoisePose241
+.4byte sBlastoisePose242
+.4byte sBlastoisePose243
+.4byte sBlastoisePose244
+.4byte sBlastoisePose245
+.4byte sBlastoisePose246
+.4byte sBlastoisePose247
+.4byte sBlastoisePose248
+.4byte sBlastoisePose249
+.4byte sBlastoisePose250
+.4byte sBlastoisePose251
+.4byte sBlastoisePose252
+.4byte sBlastoisePose253
+.4byte sBlastoisePose254
+.4byte sBlastoisePose255
+.4byte sBlastoisePose256
+.4byte sBlastoisePose257
+.4byte sBlastoisePose258
+.4byte sBlastoisePose259
+.4byte sBlastoisePose260
+.4byte sBlastoisePose261
+.4byte sBlastoisePose262
+.4byte sBlastoisePose263
+.4byte sBlastoisePose264
+.4byte sBlastoisePose265
+.4byte sBlastoisePose266
+.4byte sBlastoisePose267
+sAxPositionsBlastoise:
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte    2,   -8, 	  -6,   -4, 	   8,   -6, 	  -1,   -8
+.2byte   -3,   -8, 	  -9,   -6, 	   5,   -4, 	   0,   -8
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    3,   -8, 	  10,   -6, 	  -5,   -5, 	  -2,   -9
+.2byte    5,   -8, 	   8,   -9, 	  -1,   -4, 	  -3,   -9
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte    7,   -9, 	   5,  -12, 	   4,   -3, 	  -4,   -7
+.2byte    7,  -12, 	   1,  -12, 	   8,   -6, 	  -4,   -9
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    7,  -12, 	  -4,  -13, 	   9,   -7, 	  -2,   -7
+.2byte    6,  -14, 	  -5,  -14, 	  10,  -10, 	  -2,   -8
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -2,  -17, 	   8,  -13, 	  -9,   -8, 	   0,   -7
+.2byte    1,  -17, 	   8,   -9, 	  -8,  -13, 	   0,   -6
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte   -8,  -12, 	   3,  -13, 	 -10,   -7, 	   1,   -7
+.2byte   -7,  -14, 	   4,  -14, 	 -11,  -10, 	   1,   -8
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte   -8,   -9, 	  -6,  -12, 	  -5,   -3, 	   3,   -7
+.2byte   -8,  -12, 	  -2,  -12, 	  -9,   -6, 	   3,   -9
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -5,   -8, 	 -12,   -6, 	   3,   -5, 	   0,   -9
+.2byte   -7,   -8, 	 -10,   -9, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte    2,   -8, 	  -6,   -4, 	   8,   -6, 	  -1,   -8
+.2byte   -3,   -8, 	  -9,   -6, 	   5,   -4, 	   0,   -8
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    3,   -8, 	  10,   -6, 	  -5,   -5, 	  -2,   -9
+.2byte    5,   -8, 	   8,   -9, 	  -1,   -4, 	  -3,   -9
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte    7,   -9, 	   5,  -12, 	   4,   -3, 	  -4,   -7
+.2byte    7,  -12, 	   1,  -12, 	   8,   -6, 	  -4,   -9
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    7,  -12, 	  -4,  -13, 	   9,   -7, 	  -2,   -7
+.2byte    6,  -14, 	  -5,  -14, 	  10,  -10, 	  -2,   -8
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -2,  -17, 	   8,  -13, 	  -9,   -8, 	   0,   -7
+.2byte    1,  -17, 	   8,   -9, 	  -8,  -13, 	   0,   -6
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte   -8,  -12, 	   3,  -13, 	 -10,   -7, 	   1,   -7
+.2byte   -7,  -14, 	   4,  -14, 	 -11,  -10, 	   1,   -8
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte   -8,   -9, 	  -6,  -12, 	  -5,   -3, 	   3,   -7
+.2byte   -8,  -12, 	  -2,  -12, 	  -9,   -6, 	   3,   -9
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -5,   -8, 	 -12,   -6, 	   3,   -5, 	   0,   -9
+.2byte   -7,   -8, 	 -10,   -9, 	  -1,   -4, 	   1,   -9
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte   -1,   -7, 	 -11,   -8, 	  10,   -7, 	   0,  -10
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    5,   -7, 	  10,  -10, 	  -6,   -4, 	  -2,   -7
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte   10,   -9, 	   5,  -16, 	   5,   -7, 	  -1,   -5
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    9,  -14, 	  -2,  -17, 	  11,  -12, 	  -1,   -6
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    0,  -20, 	   9,  -20, 	 -10,  -20, 	  -1,   -8
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte  -10,  -14, 	   1,  -17, 	 -12,  -12, 	   0,   -6
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte  -11,   -9, 	  -6,  -16, 	  -6,   -7, 	   0,   -5
+.2byte   -6,   -4, 	 -10,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,  -12, 	  -4,   -3, 	   0,   -9
+.2byte   -6,  -13, 	   1,  -13, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -11, 	  -9,  -10, 	  -1,   -8
+.2byte    6,  -13, 	  -1,  -13, 	   8,   -8, 	   0,   -9
+.2byte    8,   -8, 	   5,  -12, 	   4,   -3, 	   0,   -9
+.2byte    6,   -4, 	  10,   -9, 	  -2,   -2, 	   1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -7,   -7, 	 -12,  -10, 	   4,   -4, 	   0,   -7
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte   -1,   -7, 	 -11,   -8, 	  10,   -7, 	   0,  -10
+.2byte   -1,   -7, 	 -11,   -8, 	  10,   -7, 	   0,  -10
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -9
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    6,   -7, 	  11,  -10, 	  -5,   -4, 	  -1,   -7
+.2byte    6,   -7, 	  11,  -10, 	  -5,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte   11,   -9, 	   6,  -16, 	   6,   -7, 	   0,   -5
+.2byte   11,   -9, 	   6,  -16, 	   6,   -7, 	   0,   -5
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    9,  -14, 	  -2,  -17, 	  11,  -12, 	  -1,   -6
+.2byte    9,  -14, 	  -2,  -17, 	  11,  -12, 	  -1,   -6
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    0,  -20, 	   9,  -20, 	 -10,  -20, 	  -1,   -8
+.2byte    0,  -20, 	   9,  -20, 	 -10,  -20, 	  -1,   -8
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte  -10,  -14, 	   1,  -17, 	 -12,  -12, 	   0,   -6
+.2byte  -10,  -14, 	   1,  -17, 	 -12,  -12, 	   0,   -6
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte  -12,   -9, 	  -7,  -16, 	  -7,   -7, 	  -1,   -5
+.2byte  -12,   -9, 	  -7,  -16, 	  -7,   -7, 	  -1,   -5
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -8,   -7, 	 -13,  -10, 	   3,   -4, 	  -1,   -7
+.2byte   -8,   -7, 	 -13,  -10, 	   3,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -1,   -6, 	  -9,   -3, 	   8,   -3, 	   0,   -6
+.2byte    6,   -3, 	  10,   -8, 	  -2,   -1, 	   1,   -7
+.2byte    8,   -7, 	   5,  -11, 	   4,   -2, 	   0,   -8
+.2byte    6,  -12, 	  -1,  -12, 	   8,   -7, 	   0,   -8
+.2byte   -1,  -13, 	   8,  -10, 	  -9,   -9, 	  -1,   -7
+.2byte   -6,  -12, 	   1,  -12, 	  -8,   -7, 	   0,   -8
+.2byte   -8,   -7, 	  -5,  -11, 	  -4,   -2, 	   0,   -8
+.2byte   -6,   -3, 	 -10,   -8, 	   2,   -1, 	  -1,   -7
+.2byte   -6,   -7, 	 -10,   -8, 	   4,   -2, 	  -1,   -6
+.2byte   -7,   -6, 	 -11,   -8, 	   4,   -1, 	   0,   -6
+.2byte   -1,  -10, 	  -9,   -7, 	   8,   -7, 	   0,  -10
+.2byte    5,   -6, 	   9,  -11, 	  -3,   -4, 	   0,  -10
+.2byte    7,   -9, 	   4,  -13, 	   3,   -4, 	  -1,  -10
+.2byte    5,  -14, 	  -2,  -14, 	   7,   -9, 	  -1,  -10
+.2byte   -1,  -15, 	   8,  -12, 	  -9,  -11, 	  -1,   -9
+.2byte   -6,  -14, 	   1,  -14, 	  -8,   -9, 	   0,  -10
+.2byte   -8,   -9, 	  -5,  -13, 	  -4,   -4, 	   0,  -10
+.2byte   -6,   -6, 	 -10,  -11, 	   2,   -4, 	  -1,  -10
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte   -1,   -7, 	 -11,   -8, 	  10,   -7, 	   0,  -10
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    6,   -7, 	  11,  -10, 	  -5,   -4, 	  -1,   -7
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte   11,   -9, 	   6,  -16, 	   6,   -7, 	   0,   -5
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    9,  -14, 	  -2,  -17, 	  11,  -12, 	  -1,   -6
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    0,  -20, 	   9,  -20, 	 -10,  -20, 	  -1,   -8
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte  -10,  -14, 	   1,  -17, 	 -12,  -12, 	   0,   -6
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte  -12,   -9, 	  -7,  -16, 	  -7,   -7, 	  -1,   -5
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -8,   -7, 	 -13,  -10, 	   3,   -4, 	  -1,   -7
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte   -1,   -7, 	 -11,   -8, 	  10,   -7, 	   0,  -10
+.2byte    6,   -7, 	  11,  -10, 	  -5,   -4, 	  -1,   -7
+.2byte   11,   -9, 	   6,  -16, 	   6,   -7, 	   0,   -5
+.2byte    9,  -14, 	  -2,  -17, 	  11,  -12, 	  -1,   -6
+.2byte    0,  -20, 	   9,  -20, 	 -10,  -20, 	  -1,   -8
+.2byte  -10,  -14, 	   1,  -17, 	 -12,  -12, 	   0,   -6
+.2byte  -12,   -9, 	  -7,  -16, 	  -7,   -7, 	  -1,   -5
+.2byte   -8,   -7, 	 -13,  -10, 	   3,   -4, 	  -1,   -7
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte   -1,   -7, 	 -11,   -8, 	  10,   -7, 	   0,  -10
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    6,   -7, 	  11,  -10, 	  -5,   -4, 	  -1,   -7
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte   11,   -9, 	   6,  -16, 	   6,   -7, 	   0,   -5
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    9,  -14, 	  -2,  -17, 	  11,  -12, 	  -1,   -6
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    0,  -20, 	   9,  -20, 	 -10,  -20, 	  -1,   -8
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte  -10,  -14, 	   1,  -17, 	 -12,  -12, 	   0,   -6
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte  -12,   -9, 	  -7,  -16, 	  -7,   -7, 	  -1,   -5
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -8,   -7, 	 -13,  -10, 	   3,   -4, 	  -1,   -7
+.2byte   -1,   -7, 	 -11,   -8, 	  10,   -7, 	   0,  -10
+.2byte   -8,   -7, 	 -13,  -10, 	   3,   -4, 	  -1,   -7
+.2byte  -12,   -9, 	  -7,  -16, 	  -7,   -7, 	  -1,   -5
+.2byte  -10,  -14, 	   1,  -17, 	 -12,  -12, 	   0,   -6
+.2byte    0,  -20, 	   9,  -20, 	 -10,  -20, 	  -1,   -8
+.2byte    9,  -14, 	  -2,  -17, 	  11,  -12, 	  -1,   -6
+.2byte   11,   -9, 	   6,  -16, 	   6,   -7, 	   0,   -5
+.2byte    6,   -7, 	  11,  -10, 	  -5,   -4, 	  -1,   -7
+.2byte    0,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -8,  -11, 	  -3,  -12, 	  -7,   -5, 	   3,   -7
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    7,  -14, 	  -4,  -14, 	   9,  -10, 	  -2,   -8
+.2byte    7,  -11, 	   2,  -12, 	   6,   -5, 	  -4,   -7
+.2byte    4,   -9, 	   9,   -9, 	  -2,   -5, 	  -3,  -11
+.2byte    0,  -18, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    6,  -19, 	  12,   -9, 	  -4,  -14, 	   1,   -9
+.2byte    0,  -19, 	  12,  -13, 	 -12,  -11, 	   0,   -9
+.2byte    0,  -10, 	  12,   -6, 	 -13,   -6, 	   0,   -9
+.2byte  -11,   -8, 	  -1,  -10, 	 -15,   -2, 	  -3,   -8
+.2byte   -8,  -10, 	   0,  -10, 	 -14,   -3, 	  -2,   -9
+.2byte   -9,  -13, 	   2,  -12, 	 -14,   -5, 	  -1,  -10
+.2byte  -10,  -15, 	   2,  -15, 	 -13,  -10, 	   0,   -9
+.2byte   -8,  -14, 	   3,  -14, 	 -10,  -10, 	   1,   -8
+.2byte    0,   -7, 	 -11,   -4, 	  10,   -4, 	   0,  -12
+.2byte    0,   -6, 	 -10,   -3, 	   9,   -3, 	   0,  -11
+.2byte  -10,   -6, 	  -5,   -2, 	  -5,    0, 	   0,  -10
+.2byte   -8,   -5, 	  -4,   -1, 	  -3,    1, 	   1,   -9
+.2byte  -10,   -7, 	  -6,   -1, 	  -6,    1, 	   0,   -9
+.2byte    9,   -6, 	   4,   -2, 	   4,    0, 	  -1,  -10
+.2byte    7,   -5, 	   3,   -1, 	   2,    1, 	  -2,   -9
+.2byte    9,   -7, 	   5,   -1, 	   5,    1, 	  -1,   -9
+.2byte  -10,   -6, 	  -5,   -2, 	  -5,    0, 	   0,  -10
+.2byte   -8,   -5, 	  -4,   -1, 	  -3,    1, 	   1,   -9
+.2byte  -10,   -7, 	  -6,   -1, 	  -6,    1, 	   0,   -9
+.2byte  -11,   -3, 	 -12,   -1, 	  -9,    2, 	  -1,   -8
+.2byte    9,   -6, 	   4,   -2, 	   4,    0, 	  -1,  -10
+.2byte    7,   -5, 	   3,   -1, 	   2,    1, 	  -2,   -9
+.2byte    9,   -7, 	   5,   -1, 	   5,    1, 	  -1,   -9
+.2byte   10,   -3, 	  11,   -1, 	   8,    2, 	   0,   -8
+sBlastoiseAnimTable1:
+.4byte sBlastoiseAnims_1_1
+.4byte sBlastoiseAnims_1_2
+.4byte sBlastoiseAnims_1_3
+.4byte sBlastoiseAnims_1_4
+.4byte sBlastoiseAnims_1_5
+.4byte sBlastoiseAnims_1_6
+.4byte sBlastoiseAnims_1_7
+.4byte sBlastoiseAnims_1_8
+sBlastoiseAnimTable2:
+.4byte sBlastoiseAnims_2_1
+.4byte sBlastoiseAnims_2_2
+.4byte sBlastoiseAnims_2_3
+.4byte sBlastoiseAnims_2_4
+.4byte sBlastoiseAnims_2_5
+.4byte sBlastoiseAnims_2_6
+.4byte sBlastoiseAnims_2_7
+.4byte sBlastoiseAnims_2_8
+sBlastoiseAnimTable3:
+.4byte sBlastoiseAnims_3_1
+.4byte sBlastoiseAnims_3_2
+.4byte sBlastoiseAnims_3_3
+.4byte sBlastoiseAnims_3_4
+.4byte sBlastoiseAnims_3_5
+.4byte sBlastoiseAnims_3_6
+.4byte sBlastoiseAnims_3_7
+.4byte sBlastoiseAnims_3_8
+sBlastoiseAnimTable4:
+.4byte sBlastoiseAnims_4_1
+.4byte sBlastoiseAnims_4_2
+.4byte sBlastoiseAnims_4_3
+.4byte sBlastoiseAnims_4_4
+.4byte sBlastoiseAnims_4_5
+.4byte sBlastoiseAnims_4_6
+.4byte sBlastoiseAnims_4_7
+.4byte sBlastoiseAnims_4_8
+sBlastoiseAnimTable5:
+.4byte sBlastoiseAnims_5_1
+.4byte sBlastoiseAnims_5_2
+.4byte sBlastoiseAnims_5_3
+.4byte sBlastoiseAnims_5_4
+.4byte sBlastoiseAnims_5_5
+.4byte sBlastoiseAnims_5_6
+.4byte sBlastoiseAnims_5_7
+.4byte sBlastoiseAnims_5_8
+sBlastoiseAnimTable6:
+.4byte sBlastoiseAnims_6_1
+.4byte sBlastoiseAnims_6_1
+.4byte sBlastoiseAnims_6_1
+.4byte sBlastoiseAnims_6_1
+.4byte sBlastoiseAnims_6_1
+.4byte sBlastoiseAnims_6_1
+.4byte sBlastoiseAnims_6_1
+.4byte sBlastoiseAnims_6_1
+sBlastoiseAnimTable7:
+.4byte sBlastoiseAnims_7_1
+.4byte sBlastoiseAnims_7_2
+.4byte sBlastoiseAnims_7_3
+.4byte sBlastoiseAnims_7_4
+.4byte sBlastoiseAnims_7_5
+.4byte sBlastoiseAnims_7_6
+.4byte sBlastoiseAnims_7_7
+.4byte sBlastoiseAnims_7_8
+sBlastoiseAnimTable8:
+.4byte sBlastoiseAnims_8_1
+.4byte sBlastoiseAnims_8_2
+.4byte sBlastoiseAnims_8_3
+.4byte sBlastoiseAnims_8_4
+.4byte sBlastoiseAnims_8_5
+.4byte sBlastoiseAnims_8_6
+.4byte sBlastoiseAnims_8_7
+.4byte sBlastoiseAnims_8_8
+sBlastoiseAnimTable9:
+.4byte sBlastoiseAnims_9_1
+.4byte sBlastoiseAnims_9_2
+.4byte sBlastoiseAnims_9_3
+.4byte sBlastoiseAnims_9_4
+.4byte sBlastoiseAnims_9_5
+.4byte sBlastoiseAnims_9_6
+.4byte sBlastoiseAnims_9_7
+.4byte sBlastoiseAnims_9_8
+sBlastoiseAnimTable10:
+.4byte sBlastoiseAnims_10_1
+.4byte sBlastoiseAnims_10_2
+.4byte sBlastoiseAnims_10_3
+.4byte sBlastoiseAnims_10_4
+.4byte sBlastoiseAnims_10_5
+.4byte sBlastoiseAnims_10_6
+.4byte sBlastoiseAnims_10_7
+.4byte sBlastoiseAnims_10_8
+sBlastoiseAnimTable11:
+.4byte sBlastoiseAnims_11_1
+.4byte sBlastoiseAnims_11_2
+.4byte sBlastoiseAnims_11_3
+.4byte sBlastoiseAnims_11_4
+.4byte sBlastoiseAnims_11_5
+.4byte sBlastoiseAnims_11_6
+.4byte sBlastoiseAnims_11_7
+.4byte sBlastoiseAnims_11_8
+sBlastoiseAnimTable12:
+.4byte sBlastoiseAnims_12_1
+.4byte sBlastoiseAnims_12_2
+.4byte sBlastoiseAnims_12_3
+.4byte sBlastoiseAnims_12_4
+.4byte sBlastoiseAnims_12_5
+.4byte sBlastoiseAnims_12_6
+.4byte sBlastoiseAnims_12_7
+.4byte sBlastoiseAnims_12_8
+sBlastoiseAnimTable13:
+.4byte sBlastoiseAnims_13_1
+.4byte sBlastoiseAnims_13_2
+.4byte sBlastoiseAnims_13_3
+.4byte sBlastoiseAnims_13_4
+.4byte sBlastoiseAnims_13_5
+.4byte sBlastoiseAnims_13_6
+.4byte sBlastoiseAnims_13_7
+.4byte sBlastoiseAnims_13_8
+sBlastoiseAnimTable14:
+.4byte sBlastoiseAnims_14_1
+.4byte sBlastoiseAnims_14_1
+.4byte sBlastoiseAnims_14_1
+.4byte sBlastoiseAnims_14_1
+.4byte sBlastoiseAnims_14_1
+.4byte sBlastoiseAnims_14_1
+.4byte sBlastoiseAnims_14_1
+.4byte sBlastoiseAnims_14_1
+sBlastoiseAnimTable15:
+.4byte sBlastoiseAnims_15_1
+.4byte sBlastoiseAnims_15_2
+.4byte sBlastoiseAnims_15_3
+.4byte sBlastoiseAnims_15_4
+.4byte sBlastoiseAnims_15_5
+.4byte sBlastoiseAnims_15_6
+.4byte sBlastoiseAnims_15_7
+.4byte sBlastoiseAnims_15_8
+sBlastoiseAnimTable16:
+.4byte sBlastoiseAnims_16_1
+.4byte sBlastoiseAnims_16_2
+.4byte sBlastoiseAnims_16_3
+.4byte sBlastoiseAnims_16_4
+.4byte sBlastoiseAnims_16_5
+.4byte sBlastoiseAnims_16_6
+.4byte sBlastoiseAnims_16_7
+.4byte sBlastoiseAnims_16_8
+sBlastoiseAnimTable17:
+.4byte sBlastoiseAnims_17_1
+.4byte sBlastoiseAnims_17_2
+.4byte sBlastoiseAnims_17_3
+.4byte sBlastoiseAnims_17_4
+.4byte sBlastoiseAnims_17_5
+.4byte sBlastoiseAnims_17_6
+.4byte sBlastoiseAnims_17_7
+.4byte sBlastoiseAnims_17_8
+sBlastoiseAnimTable18:
+.4byte sBlastoiseAnims_18_1
+.4byte sBlastoiseAnims_18_2
+.4byte sBlastoiseAnims_18_3
+.4byte sBlastoiseAnims_18_4
+.4byte sBlastoiseAnims_18_5
+.4byte sBlastoiseAnims_18_6
+.4byte sBlastoiseAnims_18_7
+.4byte sBlastoiseAnims_18_8
+sAxAnimationsBlastoise:
+.4byte sBlastoiseAnimTable1
+.4byte sBlastoiseAnimTable2
+.4byte sBlastoiseAnimTable3
+.4byte sBlastoiseAnimTable4
+.4byte sBlastoiseAnimTable5
+.4byte sBlastoiseAnimTable6
+.4byte sBlastoiseAnimTable7
+.4byte sBlastoiseAnimTable8
+.4byte sBlastoiseAnimTable9
+.4byte sBlastoiseAnimTable10
+.4byte sBlastoiseAnimTable11
+.4byte sBlastoiseAnimTable12
+.4byte sBlastoiseAnimTable13
+.4byte sBlastoiseAnimTable14
+.4byte sBlastoiseAnimTable15
+.4byte sBlastoiseAnimTable16
+.4byte sBlastoiseAnimTable17
+.4byte sBlastoiseAnimTable18
+sAxSpritesBlastoise:
+.4byte sBlastoiseSprites1
+.4byte sBlastoiseSprites2
+.4byte sBlastoiseSprites3
+.4byte sBlastoiseSprites4
+.4byte sBlastoiseSprites5
+.4byte sBlastoiseSprites6
+.4byte sBlastoiseSprites7
+.4byte sBlastoiseSprites8
+.4byte sBlastoiseSprites9
+.4byte sBlastoiseSprites10
+.4byte sBlastoiseSprites11
+.4byte sBlastoiseSprites12
+.4byte sBlastoiseSprites13
+.4byte sBlastoiseSprites14
+.4byte sBlastoiseSprites15
+.4byte sBlastoiseSprites16
+.4byte sBlastoiseSprites17
+.4byte sBlastoiseSprites18
+.4byte sBlastoiseSprites19
+.4byte sBlastoiseSprites20
+.4byte sBlastoiseSprites21
+.4byte sBlastoiseSprites22
+.4byte sBlastoiseSprites23
+.4byte sBlastoiseSprites24
+.4byte sBlastoiseSprites25
+.4byte sBlastoiseSprites26
+.4byte sBlastoiseSprites27
+.4byte sBlastoiseSprites28
+.4byte sBlastoiseSprites29
+.4byte sBlastoiseSprites30
+.4byte sBlastoiseSprites31
+.4byte sBlastoiseSprites32
+.4byte sBlastoiseSprites33
+.4byte sBlastoiseSprites34
+.4byte sBlastoiseSprites35
+.4byte sBlastoiseSprites36
+.4byte sBlastoiseSprites37
+.4byte sBlastoiseSprites38
+.4byte sBlastoiseSprites39
+.4byte sBlastoiseSprites40
+.4byte sBlastoiseSprites41
+.4byte sBlastoiseSprites42
+.4byte sBlastoiseSprites43
+.4byte sBlastoiseSprites44
+.4byte sBlastoiseSprites45
+.4byte sBlastoiseSprites46
+.4byte sBlastoiseSprites47
+.4byte sBlastoiseSprites48
+.4byte sBlastoiseSprites49
+.4byte sBlastoiseSprites50
+sAxMainBlastoise:
+ax_main sAxPosesBlastoise, sAxAnimationsBlastoise, 18, sAxSpritesBlastoise, sAxPositionsBlastoise

--- a/data/ax/blaziken.inc
+++ b/data/ax/blaziken.inc
@@ -1,0 +1,3403 @@
+.global gAxBlaziken
+gAxBlaziken:
+ax_siro sAxMainBlaziken
+sBlazikenPose1:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose2:
+ax_pose 1, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose3:
+ax_pose 2, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose4:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose5:
+ax_pose 4, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose6:
+ax_pose 5, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose7:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose8:
+ax_pose 7, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose9:
+ax_pose 8, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose10:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose11:
+ax_pose 10, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose12:
+ax_pose 11, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose13:
+ax_pose 12, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose16:
+ax_pose 9, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose17:
+ax_pose 10, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose19:
+ax_pose 6, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose20:
+ax_pose 7, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose21:
+ax_pose 8, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose22:
+ax_pose 3, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose24:
+ax_pose 5, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose25:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose26:
+ax_pose 1, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose27:
+ax_pose 2, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose28:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose29:
+ax_pose 4, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose30:
+ax_pose 5, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose31:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose32:
+ax_pose 7, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose33:
+ax_pose 8, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose34:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose35:
+ax_pose 10, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose36:
+ax_pose 11, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose37:
+ax_pose 12, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose38:
+ax_pose 13, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose39:
+ax_pose 14, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose40:
+ax_pose 9, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose41:
+ax_pose 10, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose42:
+ax_pose 11, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose43:
+ax_pose 6, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose44:
+ax_pose 7, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose45:
+ax_pose 8, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose46:
+ax_pose 3, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose47:
+ax_pose 4, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose48:
+ax_pose 5, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose49:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose50:
+ax_pose 1, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose51:
+ax_pose 2, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose52:
+ax_pose 15, 0x41e4, 0x80f0, 0xcc00
+ax_pose 16, 0x41e3, 0x80ef, 0xcc08
+ax_pose 17, 0x01f3, 0x40f7, 0xcc10
+ax_pose 18, 0x01eb, 0x010f, 0xcc14
+ax_pose_terminator
+sBlazikenPose53:
+ax_pose 16, 0x41e3, 0x80ef, 0xcc00
+ax_pose 17, 0x01f3, 0x40f7, 0xcc08
+ax_pose 18, 0x01eb, 0x010f, 0xcc0c
+ax_pose_terminator
+sBlazikenPose54:
+ax_pose 19, 0x01e3, 0x80ef, 0xcc00
+ax_pose 20, 0x01e7, 0x80ef, 0xcc10
+ax_pose_terminator
+sBlazikenPose55:
+ax_pose 21, 0x01e3, 0x80ef, 0xcc00
+ax_pose 20, 0x01e7, 0x80ef, 0xcc10
+ax_pose_terminator
+sBlazikenPose56:
+ax_pose 20, 0x01e7, 0x80ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose57:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose58:
+ax_pose 4, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose59:
+ax_pose 5, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose60:
+ax_pose 22, 0x41e6, 0x90ed, 0xcc00
+ax_pose 23, 0x01e3, 0x90ed, 0xcc08
+ax_pose_terminator
+sBlazikenPose61:
+ax_pose 23, 0x01e3, 0x90ed, 0xcc00
+ax_pose_terminator
+sBlazikenPose62:
+ax_pose 24, 0x01e1, 0x90f3, 0xcc00
+ax_pose 25, 0x01e3, 0x90ef, 0xcc10
+ax_pose_terminator
+sBlazikenPose63:
+ax_pose 26, 0x01e1, 0x90f3, 0xcc00
+ax_pose 25, 0x01e3, 0x90ef, 0xcc10
+ax_pose_terminator
+sBlazikenPose64:
+ax_pose 25, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose65:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose66:
+ax_pose 7, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose67:
+ax_pose 8, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose68:
+ax_pose 27, 0x01e3, 0x50ed, 0xcc00
+ax_pose 28, 0x01e3, 0x90ef, 0xcc04
+ax_pose_terminator
+sBlazikenPose69:
+ax_pose 28, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose70:
+ax_pose 29, 0x01e3, 0x90ec, 0xcc00
+ax_pose 30, 0x01e3, 0x90ec, 0xcc10
+ax_pose_terminator
+sBlazikenPose71:
+ax_pose 31, 0x01e3, 0x90ec, 0xcc00
+ax_pose 30, 0x01e3, 0x90ec, 0xcc10
+ax_pose_terminator
+sBlazikenPose72:
+ax_pose 30, 0x01e3, 0x90ec, 0xcc00
+ax_pose_terminator
+sBlazikenPose73:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose74:
+ax_pose 10, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose75:
+ax_pose 11, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose76:
+ax_pose 32, 0x01e6, 0x50f4, 0xcc00
+ax_pose 33, 0x01e3, 0x90ef, 0xcc04
+ax_pose_terminator
+sBlazikenPose77:
+ax_pose 33, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose78:
+ax_pose 34, 0x01df, 0x90f3, 0xcc00
+ax_pose 35, 0x01e3, 0x90ed, 0xcc10
+ax_pose_terminator
+sBlazikenPose79:
+ax_pose 36, 0x01df, 0x90f3, 0xcc00
+ax_pose 35, 0x01e3, 0x90ed, 0xcc10
+ax_pose_terminator
+sBlazikenPose80:
+ax_pose 35, 0x01e3, 0x90ed, 0xcc00
+ax_pose_terminator
+sBlazikenPose81:
+ax_pose 12, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose82:
+ax_pose 13, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose83:
+ax_pose 14, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose84:
+ax_pose 37, 0x41e6, 0x80f1, 0xcc00
+ax_pose 38, 0x01e2, 0x80f0, 0xcc08
+ax_pose_terminator
+sBlazikenPose85:
+ax_pose 38, 0x01e2, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose86:
+ax_pose 39, 0x01e1, 0x80f0, 0xcc00
+ax_pose 40, 0x01e2, 0x80f2, 0xcc10
+ax_pose_terminator
+sBlazikenPose87:
+ax_pose 41, 0x01e1, 0x80f0, 0xcc00
+ax_pose 40, 0x01e2, 0x80f2, 0xcc10
+ax_pose_terminator
+sBlazikenPose88:
+ax_pose 40, 0x01e2, 0x80f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose89:
+ax_pose 9, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose90:
+ax_pose 10, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose91:
+ax_pose 11, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose92:
+ax_pose 32, 0x01e6, 0x40fb, 0xcc00
+ax_pose 33, 0x01e3, 0x80f0, 0xcc04
+ax_pose_terminator
+sBlazikenPose93:
+ax_pose 33, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose94:
+ax_pose 34, 0x01df, 0x80ec, 0xcc00
+ax_pose 35, 0x01e3, 0x80f2, 0xcc10
+ax_pose_terminator
+sBlazikenPose95:
+ax_pose 36, 0x01df, 0x80ec, 0xcc00
+ax_pose 35, 0x01e3, 0x80f2, 0xcc10
+ax_pose_terminator
+sBlazikenPose96:
+ax_pose 35, 0x01e3, 0x80f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose97:
+ax_pose 6, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose98:
+ax_pose 7, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose99:
+ax_pose 8, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose100:
+ax_pose 27, 0x01e3, 0x4102, 0xcc00
+ax_pose 28, 0x01e3, 0x80f0, 0xcc04
+ax_pose_terminator
+sBlazikenPose101:
+ax_pose 28, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose102:
+ax_pose 29, 0x01e3, 0x80f3, 0xcc00
+ax_pose 30, 0x01e3, 0x80f3, 0xcc10
+ax_pose_terminator
+sBlazikenPose103:
+ax_pose 31, 0x01e3, 0x80f3, 0xcc00
+ax_pose 30, 0x01e3, 0x80f3, 0xcc10
+ax_pose_terminator
+sBlazikenPose104:
+ax_pose 30, 0x01e3, 0x80f3, 0xcc00
+ax_pose_terminator
+sBlazikenPose105:
+ax_pose 3, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose106:
+ax_pose 4, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose107:
+ax_pose 5, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose108:
+ax_pose 22, 0x41e6, 0x80f2, 0xcc00
+ax_pose 23, 0x01e3, 0x80f2, 0xcc08
+ax_pose_terminator
+sBlazikenPose109:
+ax_pose 23, 0x01e3, 0x80f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose110:
+ax_pose 24, 0x01e1, 0x80ec, 0xcc00
+ax_pose 25, 0x01e3, 0x80f0, 0xcc10
+ax_pose_terminator
+sBlazikenPose111:
+ax_pose 26, 0x01e1, 0x80ec, 0xcc00
+ax_pose 25, 0x01e3, 0x80f0, 0xcc10
+ax_pose_terminator
+sBlazikenPose112:
+ax_pose 25, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose113:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose114:
+ax_pose 1, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose115:
+ax_pose 2, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose116:
+ax_pose 15, 0x41e4, 0x80f0, 0xcc00
+ax_pose 16, 0x41e3, 0x80ef, 0xcc08
+ax_pose 17, 0x01f3, 0x40f7, 0xcc10
+ax_pose 18, 0x01eb, 0x010f, 0xcc14
+ax_pose 42, 0x81f3, 0x0107, 0xcc15
+ax_pose 43, 0x01f3, 0x00ef, 0xcc17
+ax_pose_terminator
+sBlazikenPose117:
+ax_pose 16, 0x41e3, 0x80ef, 0xcc00
+ax_pose 17, 0x01f3, 0x40f7, 0xcc08
+ax_pose 18, 0x01eb, 0x010f, 0xcc0c
+ax_pose 42, 0x81f3, 0x0107, 0xcc0d
+ax_pose 43, 0x01f3, 0x00ef, 0xcc0f
+ax_pose_terminator
+sBlazikenPose118:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose119:
+ax_pose 4, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose120:
+ax_pose 5, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose121:
+ax_pose 22, 0x41e6, 0x90ef, 0xcc00
+ax_pose 23, 0x01e3, 0x90ef, 0xcc08
+ax_pose_terminator
+sBlazikenPose122:
+ax_pose 23, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose123:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose124:
+ax_pose 7, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose125:
+ax_pose 8, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose126:
+ax_pose 27, 0x01e3, 0x50f1, 0xcc00
+ax_pose 28, 0x01e3, 0x90f3, 0xcc04
+ax_pose_terminator
+sBlazikenPose127:
+ax_pose 28, 0x01e3, 0x90f3, 0xcc00
+ax_pose_terminator
+sBlazikenPose128:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose129:
+ax_pose 10, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose130:
+ax_pose 11, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose131:
+ax_pose 32, 0x01e6, 0x50f4, 0xcc00
+ax_pose 33, 0x01e3, 0x90ef, 0xcc04
+ax_pose_terminator
+sBlazikenPose132:
+ax_pose 33, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose133:
+ax_pose 12, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose134:
+ax_pose 13, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose135:
+ax_pose 14, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose136:
+ax_pose 37, 0x41e6, 0x80f1, 0xcc00
+ax_pose 38, 0x01e2, 0x80f0, 0xcc08
+ax_pose_terminator
+sBlazikenPose137:
+ax_pose 38, 0x01e2, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose138:
+ax_pose 9, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose139:
+ax_pose 10, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose140:
+ax_pose 11, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose141:
+ax_pose 32, 0x01e6, 0x40fb, 0xcc00
+ax_pose 33, 0x01e3, 0x80f0, 0xcc04
+ax_pose_terminator
+sBlazikenPose142:
+ax_pose 33, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose143:
+ax_pose 6, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose144:
+ax_pose 7, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose145:
+ax_pose 8, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose146:
+ax_pose 27, 0x01e3, 0x40fe, 0xcc00
+ax_pose 28, 0x01e3, 0x80ec, 0xcc04
+ax_pose_terminator
+sBlazikenPose147:
+ax_pose 28, 0x01e3, 0x80ec, 0xcc00
+ax_pose_terminator
+sBlazikenPose148:
+ax_pose 3, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose149:
+ax_pose 4, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose150:
+ax_pose 5, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose151:
+ax_pose 22, 0x41e6, 0x80f0, 0xcc00
+ax_pose 23, 0x01e3, 0x80f0, 0xcc08
+ax_pose_terminator
+sBlazikenPose152:
+ax_pose 23, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose153:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose154:
+ax_pose 1, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose155:
+ax_pose 2, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose156:
+ax_pose 44, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose157:
+ax_pose 45, 0x81e2, 0x8100, 0xcc00
+ax_pose 46, 0x01e2, 0x80f0, 0xcc08
+ax_pose_terminator
+sBlazikenPose158:
+ax_pose 46, 0x01e2, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose159:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose160:
+ax_pose 4, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose161:
+ax_pose 5, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose162:
+ax_pose 47, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose163:
+ax_pose 48, 0x81e3, 0x90ff, 0xcc00
+ax_pose 49, 0x01e3, 0x90ef, 0xcc08
+ax_pose_terminator
+sBlazikenPose164:
+ax_pose 49, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose165:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose166:
+ax_pose 7, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose167:
+ax_pose 8, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose168:
+ax_pose 50, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose169:
+ax_pose 51, 0x81e3, 0x90ff, 0xcc00
+ax_pose 52, 0x01e3, 0x90ef, 0xcc08
+ax_pose_terminator
+sBlazikenPose170:
+ax_pose 52, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose171:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose172:
+ax_pose 10, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose173:
+ax_pose 11, 0x01e5, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose174:
+ax_pose 53, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose175:
+ax_pose 54, 0x81e1, 0x90ff, 0xcc00
+ax_pose 55, 0x01e3, 0x90ef, 0xcc08
+ax_pose_terminator
+sBlazikenPose176:
+ax_pose 55, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose177:
+ax_pose 12, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose178:
+ax_pose 13, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose179:
+ax_pose 14, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose180:
+ax_pose 56, 0x01e2, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose181:
+ax_pose 57, 0x81df, 0x80f0, 0xcc00
+ax_pose 58, 0x81e2, 0x80f8, 0xcc08
+ax_pose 59, 0x81ea, 0x0108, 0xcc10
+ax_pose 60, 0x01da, 0x00f8, 0xcc12
+ax_pose -1, 0x01da, 0x0102, 0xcc12
+ax_pose 61, 0x01ea, 0x0110, 0xcc13
+ax_pose 62, 0x81ea, 0x00f0, 0xcc14
+ax_pose_terminator
+sBlazikenPose182:
+ax_pose 58, 0x81e2, 0x80f8, 0xcc00
+ax_pose 59, 0x81ea, 0x0108, 0xcc08
+ax_pose 60, 0x01da, 0x00f8, 0xcc0a
+ax_pose -1, 0x01da, 0x0102, 0xcc0a
+ax_pose 61, 0x01ea, 0x0110, 0xcc0b
+ax_pose 62, 0x81ea, 0x00f0, 0xcc0c
+ax_pose_terminator
+sBlazikenPose183:
+ax_pose 9, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose184:
+ax_pose 10, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose185:
+ax_pose 11, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose186:
+ax_pose 53, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose187:
+ax_pose 54, 0x81e1, 0x80f0, 0xcc00
+ax_pose 55, 0x01e3, 0x80f0, 0xcc08
+ax_pose_terminator
+sBlazikenPose188:
+ax_pose 55, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose189:
+ax_pose 6, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose190:
+ax_pose 7, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose191:
+ax_pose 8, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose192:
+ax_pose 50, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose193:
+ax_pose 51, 0x81e3, 0x80f0, 0xcc00
+ax_pose 52, 0x01e3, 0x80f0, 0xcc08
+ax_pose_terminator
+sBlazikenPose194:
+ax_pose 52, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose195:
+ax_pose 3, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose196:
+ax_pose 4, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose197:
+ax_pose 5, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose198:
+ax_pose 47, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose199:
+ax_pose 48, 0x81e3, 0x80f0, 0xcc00
+ax_pose 49, 0x01e3, 0x80f0, 0xcc08
+ax_pose_terminator
+sBlazikenPose200:
+ax_pose 49, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose201:
+ax_pose 63, 0x01ed, 0x80f1, 0xcc00
+ax_pose_terminator
+sBlazikenPose202:
+ax_pose 64, 0x01ed, 0x80f1, 0xcc00
+ax_pose_terminator
+sBlazikenPose203:
+ax_pose 65, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose204:
+ax_pose 66, 0x01e4, 0x90ec, 0xcc00
+ax_pose_terminator
+sBlazikenPose205:
+ax_pose 67, 0x01e4, 0x90ec, 0xcc00
+ax_pose_terminator
+sBlazikenPose206:
+ax_pose 68, 0x01e4, 0x90ec, 0xcc00
+ax_pose_terminator
+sBlazikenPose207:
+ax_pose 69, 0x01e2, 0x80f1, 0xcc00
+ax_pose_terminator
+sBlazikenPose208:
+ax_pose 68, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose209:
+ax_pose 67, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose210:
+ax_pose 66, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose211:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose212:
+ax_pose 70, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose213:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose214:
+ax_pose 71, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose215:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose216:
+ax_pose 72, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose217:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose218:
+ax_pose 73, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose219:
+ax_pose 12, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose220:
+ax_pose 74, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose221:
+ax_pose 9, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose222:
+ax_pose 73, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose223:
+ax_pose 6, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose224:
+ax_pose 72, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose225:
+ax_pose 3, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose226:
+ax_pose 71, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose227:
+ax_pose 46, 0x01e2, 0x80f1, 0xcc00
+ax_pose_terminator
+sBlazikenPose228:
+ax_pose 49, 0x01e2, 0x80f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose229:
+ax_pose 52, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose230:
+ax_pose 55, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose231:
+ax_pose 58, 0x81e3, 0x80f7, 0xcc00
+ax_pose 59, 0x81eb, 0x0107, 0xcc08
+ax_pose 60, 0x01db, 0x00f7, 0xcc0a
+ax_pose -1, 0x01db, 0x0101, 0xcc0a
+ax_pose 61, 0x01eb, 0x010f, 0xcc0b
+ax_pose 62, 0x81eb, 0x00ef, 0xcc0c
+ax_pose_terminator
+sBlazikenPose232:
+ax_pose 55, 0x01e3, 0x90f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose233:
+ax_pose 52, 0x01e3, 0x90f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose234:
+ax_pose 49, 0x01e2, 0x90ee, 0xcc00
+ax_pose_terminator
+sBlazikenPose235:
+ax_pose 16, 0x41e3, 0x80ef, 0xcc00
+ax_pose 17, 0x01f3, 0x40f7, 0xcc08
+ax_pose 18, 0x01eb, 0x010f, 0xcc0c
+ax_pose_terminator
+sBlazikenPose236:
+ax_pose 23, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose237:
+ax_pose 28, 0x01e3, 0x90f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose238:
+ax_pose 33, 0x01e3, 0x90f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose239:
+ax_pose 38, 0x01e3, 0x80f1, 0xcc00
+ax_pose_terminator
+sBlazikenPose240:
+ax_pose 33, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose241:
+ax_pose 28, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose242:
+ax_pose 23, 0x01e3, 0x80f1, 0xcc00
+ax_pose_terminator
+sBlazikenPose243:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose244:
+ax_pose 16, 0x41e3, 0x80ef, 0xcc00
+ax_pose 17, 0x01f3, 0x40f7, 0xcc08
+ax_pose 18, 0x01eb, 0x010f, 0xcc0c
+ax_pose_terminator
+sBlazikenPose245:
+ax_pose 20, 0x01e5, 0x80ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose246:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose247:
+ax_pose 23, 0x01e3, 0x90ee, 0xcc00
+ax_pose_terminator
+sBlazikenPose248:
+ax_pose 25, 0x01e1, 0x90ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose249:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose250:
+ax_pose 28, 0x01e3, 0x90f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose251:
+ax_pose 30, 0x01e2, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose252:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose253:
+ax_pose 33, 0x01e3, 0x90f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose254:
+ax_pose 35, 0x01e1, 0x90ed, 0xcc00
+ax_pose_terminator
+sBlazikenPose255:
+ax_pose 12, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose256:
+ax_pose 38, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose257:
+ax_pose 40, 0x01e1, 0x80f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose258:
+ax_pose 9, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose259:
+ax_pose 33, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose260:
+ax_pose 35, 0x01e1, 0x80f3, 0xcc00
+ax_pose_terminator
+sBlazikenPose261:
+ax_pose 6, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose262:
+ax_pose 28, 0x01e3, 0x80ee, 0xcc00
+ax_pose_terminator
+sBlazikenPose263:
+ax_pose 30, 0x01e2, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose264:
+ax_pose 3, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sBlazikenPose265:
+ax_pose 23, 0x01e3, 0x80f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose266:
+ax_pose 25, 0x01e1, 0x80f1, 0xcc00
+ax_pose_terminator
+sBlazikenPose267:
+ax_pose 20, 0x01e7, 0x80ef, 0xcc00
+ax_pose_terminator
+sBlazikenPose268:
+ax_pose 25, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose269:
+ax_pose 30, 0x01e3, 0x80f3, 0xcc00
+ax_pose_terminator
+sBlazikenPose270:
+ax_pose 35, 0x01e4, 0x80f3, 0xcc00
+ax_pose_terminator
+sBlazikenPose271:
+ax_pose 40, 0x01e3, 0x80f2, 0xcc00
+ax_pose_terminator
+sBlazikenPose272:
+ax_pose 35, 0x01e4, 0x90ed, 0xcc00
+ax_pose_terminator
+sBlazikenPose273:
+ax_pose 30, 0x01e3, 0x90ed, 0xcc00
+ax_pose_terminator
+sBlazikenPose274:
+ax_pose 25, 0x01e3, 0x90f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose275:
+ax_pose 0, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sBlazikenPose276:
+ax_pose 3, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose277:
+ax_pose 6, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose278:
+ax_pose 9, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose279:
+ax_pose 12, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sBlazikenPose280:
+ax_pose 9, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose281:
+ax_pose 6, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sBlazikenPose282:
+ax_pose 3, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+.align 2
+sBlazikenAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_2_1:
+ax_anim 2, 0, 46, 1, -1, 0, -1,
+ax_anim 6, 0, 46, 1, -2, 0, -2,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sBlazikenAnims_2_2:
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 6, 0, 25, -2, -2, -2, -2,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 1, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sBlazikenAnims_2_3:
+ax_anim 2, 0, 29, -1, 0, -1, 0,
+ax_anim 6, 0, 29, -2, 0, -2, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 1, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 0, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sBlazikenAnims_2_4:
+ax_anim 2, 0, 31, -1, 1, -1, 1,
+ax_anim 6, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 34, 11, -13, 11, -13,
+ax_anim 2, 0, 34, 21, -17, 21, -17,
+ax_anim 2, 1, 34, 22, -16, 22, -16,
+ax_anim 2, 0, 34, 21, -17, 21, -17,
+ax_anim 2, 0, 34, 22, -16, 22, -16,
+ax_anim 2, 0, 35, 7, -6, 7, -6,
+ax_anim_terminator
+sBlazikenAnims_2_5:
+ax_anim 2, 0, 34, 0, 1, 0, 1,
+ax_anim 6, 0, 34, 0, 2, 0, 2,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -16, 0, -16,
+ax_anim 2, 1, 37, 1, -16, 1, -16,
+ax_anim 2, 0, 37, 0, -16, 0, -16,
+ax_anim 2, 0, 37, 1, -16, 1, -16,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim_terminator
+sBlazikenAnims_2_6:
+ax_anim 2, 0, 37, 1, 1, 1, 1,
+ax_anim 6, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 2, 41, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -13, -11, -13,
+ax_anim 2, 0, 41, -21, -17, -21, -17,
+ax_anim 2, 1, 41, -22, -16, -22, -16,
+ax_anim 2, 0, 41, -21, -17, -21, -17,
+ax_anim 2, 0, 41, -22, -16, -22, -16,
+ax_anim 2, 0, 40, -7, -6, -7, -6,
+ax_anim_terminator
+sBlazikenAnims_2_7:
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 6, 0, 40, 2, 0, 2, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 1, 44, -21, 1, -21, 1,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 0, 44, -21, 1, -21, 1,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim_terminator
+sBlazikenAnims_2_8:
+ax_anim 2, 0, 44, 1, -1, 1, -1,
+ax_anim 6, 0, 44, 2, -2, 2, -2,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 1, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 47, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_3_1:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, -2, 0, -2,
+ax_anim 4, 0, 52, 0, -3, 0, -3,
+ax_anim 2, 0, 51, 0, -3, 0, -3,
+ax_anim 1, 0, 51, 0, -2, 0, -2,
+ax_anim 2, 0, 54, 0, -1, 0, -1,
+ax_anim 2, 2, 55, 0, 7, 0, 7,
+ax_anim 1, 0, 53, 0, 17, 0, 17,
+ax_anim 1, 0, 55, 0, 17, 0, 17,
+ax_anim 1, 1, 53, 1, 17, 1, 17,
+ax_anim 1, 0, 54, 0, 17, 0, 17,
+ax_anim 1, 0, 55, 1, 17, 1, 17,
+ax_anim 1, 0, 53, 0, 17, 0, 17,
+ax_anim 1, 0, 54, 1, 17, 1, 17,
+ax_anim 1, 0, 55, 0, 17, 0, 17,
+ax_anim 1, 0, 53, 1, 17, 1, 17,
+ax_anim 1, 0, 54, 0, 17, 0, 17,
+ax_anim 1, 0, 52, 0, 11, 0, 11,
+ax_anim 2, 0, 48, 0, 5, 0, 5,
+ax_anim_terminator
+sBlazikenAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 4, 0, 60, -3, -3, -3, -3,
+ax_anim 2, 0, 59, -3, -3, -3, -3,
+ax_anim 1, 0, 59, -2, -2, -2, -2,
+ax_anim 2, 0, 62, 1, 1, 1, 1,
+ax_anim 2, 2, 63, 7, 8, 7, 8,
+ax_anim 1, 0, 61, 17, 20, 17, 20,
+ax_anim 1, 0, 63, 17, 20, 17, 20,
+ax_anim 1, 1, 61, 18, 19, 18, 19,
+ax_anim 1, 0, 62, 17, 20, 17, 20,
+ax_anim 1, 0, 63, 18, 19, 18, 19,
+ax_anim 1, 0, 61, 17, 20, 17, 20,
+ax_anim 1, 0, 62, 18, 19, 18, 19,
+ax_anim 1, 0, 63, 17, 20, 17, 20,
+ax_anim 1, 0, 61, 18, 19, 18, 19,
+ax_anim 1, 0, 62, 17, 20, 17, 20,
+ax_anim 1, 0, 60, 10, 12, 10, 12,
+ax_anim 2, 0, 56, 4, 6, 4, 6,
+ax_anim_terminator
+sBlazikenAnims_3_3:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -2, 0, -2, 0,
+ax_anim 4, 0, 68, -3, 0, -3, 0,
+ax_anim 2, 0, 67, -3, 0, -3, 0,
+ax_anim 1, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 70, 1, 0, 1, 0,
+ax_anim 2, 2, 71, 7, 0, 7, 0,
+ax_anim 1, 0, 69, 17, 0, 17, 0,
+ax_anim 1, 0, 71, 17, 0, 17, 0,
+ax_anim 1, 1, 69, 17, -1, 17, -1,
+ax_anim 1, 0, 70, 17, 0, 17, 0,
+ax_anim 1, 0, 71, 17, -1, 17, -1,
+ax_anim 1, 0, 69, 17, 0, 17, 0,
+ax_anim 1, 0, 70, 17, -1, 17, -1,
+ax_anim 1, 0, 71, 17, 0, 17, 0,
+ax_anim 1, 0, 69, 17, -1, 17, -1,
+ax_anim 1, 0, 70, 17, 0, 17, 0,
+ax_anim 1, 0, 68, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sBlazikenAnims_3_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 4, 0, 76, -3, 3, -3, 3,
+ax_anim 2, 0, 75, -3, 3, -3, 3,
+ax_anim 1, 0, 75, -2, 2, -2, 2,
+ax_anim 2, 0, 78, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 9, -7, 9, -7,
+ax_anim 1, 0, 77, 17, -12, 17, -12,
+ax_anim 1, 0, 79, 17, -12, 17, -12,
+ax_anim 1, 1, 77, 16, -13, 16, -13,
+ax_anim 1, 0, 78, 17, -12, 17, -12,
+ax_anim 1, 0, 79, 16, -13, 16, -13,
+ax_anim 1, 0, 77, 17, -12, 17, -12,
+ax_anim 1, 0, 78, 16, -13, 16, -13,
+ax_anim 1, 0, 79, 17, -12, 17, -12,
+ax_anim 1, 0, 77, 16, -13, 16, -13,
+ax_anim 1, 0, 78, 17, -12, 17, -12,
+ax_anim 1, 0, 76, 12, -10, 12, -10,
+ax_anim 2, 0, 72, 4, -4, 4, -4,
+ax_anim_terminator
+sBlazikenAnims_3_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 4, 0, 84, 0, 3, 0, 3,
+ax_anim 2, 0, 83, 0, 3, 0, 3,
+ax_anim 1, 0, 83, 0, 2, 0, 2,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, -7, 0, -7,
+ax_anim 1, 0, 85, 0, -12, 0, -12,
+ax_anim 1, 0, 87, 0, -12, 0, -12,
+ax_anim 1, 1, 85, -1, -12, -1, -12,
+ax_anim 1, 0, 86, 0, -12, 0, -12,
+ax_anim 1, 0, 87, -1, -12, -1, -12,
+ax_anim 1, 0, 85, 0, -12, 0, -12,
+ax_anim 1, 0, 86, -1, -12, -1, -12,
+ax_anim 1, 0, 87, 0, -12, 0, -12,
+ax_anim 1, 0, 85, -1, -12, -1, -12,
+ax_anim 1, 0, 86, 0, -12, 0, -12,
+ax_anim 1, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sBlazikenAnims_3_6:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 4, 0, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 1, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 2, 95, -9, -7, -9, -7,
+ax_anim 1, 0, 93, -17, -12, -17, -12,
+ax_anim 1, 0, 95, -17, -12, -17, -12,
+ax_anim 1, 1, 93, -16, -13, -16, -13,
+ax_anim 1, 0, 94, -17, -12, -17, -12,
+ax_anim 1, 0, 95, -16, -13, -16, -13,
+ax_anim 1, 0, 93, -17, -12, -17, -12,
+ax_anim 1, 0, 94, -16, -13, -16, -13,
+ax_anim 1, 0, 95, -17, -12, -17, -12,
+ax_anim 1, 0, 93, -16, -13, -16, -13,
+ax_anim 1, 0, 94, -17, -12, -17, -12,
+ax_anim 1, 0, 92, -12, -10, -12, -10,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim_terminator
+sBlazikenAnims_3_7:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 4, 0, 100, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 1, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 2, 103, -7, 0, -7, 0,
+ax_anim 1, 0, 101, -17, 0, -17, 0,
+ax_anim 1, 0, 103, -17, 0, -17, 0,
+ax_anim 1, 1, 101, -17, -1, -17, -1,
+ax_anim 1, 0, 102, -17, 0, -17, 0,
+ax_anim 1, 0, 103, -17, -1, -17, -1,
+ax_anim 1, 0, 101, -17, 0, -17, 0,
+ax_anim 1, 0, 102, -17, -1, -17, -1,
+ax_anim 1, 0, 103, -17, 0, -17, 0,
+ax_anim 1, 0, 101, -17, -1, -17, -1,
+ax_anim 1, 0, 102, -17, 0, -17, 0,
+ax_anim 1, 0, 100, -10, 0, -10, 0,
+ax_anim 2, 0, 96, -4, 0, -4, 0,
+ax_anim_terminator
+sBlazikenAnims_3_8:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim 4, 0, 108, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim 1, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 110, -1, 1, -1, 1,
+ax_anim 2, 2, 111, -7, 8, -7, 8,
+ax_anim 1, 0, 109, -17, 20, -17, 20,
+ax_anim 1, 0, 111, -17, 20, -17, 20,
+ax_anim 1, 1, 109, -18, 19, -18, 19,
+ax_anim 1, 0, 110, -17, 20, -17, 20,
+ax_anim 1, 0, 111, -18, 19, -18, 19,
+ax_anim 1, 0, 109, -17, 20, -17, 20,
+ax_anim 1, 0, 110, -18, 19, -18, 19,
+ax_anim 1, 0, 111, -17, 20, -17, 20,
+ax_anim 1, 0, 109, -18, 19, -18, 19,
+ax_anim 1, 0, 110, -17, 20, -17, 20,
+ax_anim 1, 0, 108, -10, 12, -10, 12,
+ax_anim 2, 0, 104, -4, 6, -4, 6,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_4_1:
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -6, 0, 0,
+ax_anim 2, 0, 113, 0, -9, 0, 0,
+ax_anim 4, 2, 115, 0, -7, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim_terminator
+sBlazikenAnims_4_2:
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 118, 0, -9, 0, 0,
+ax_anim 4, 2, 120, 0, -7, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 121, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim_terminator
+sBlazikenAnims_4_3:
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -6, 0, 0,
+ax_anim 2, 0, 123, 0, -9, 0, 0,
+ax_anim 4, 2, 125, 0, -7, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 1,
+ax_anim_terminator
+sBlazikenAnims_4_4:
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 128, 0, -9, 0, 0,
+ax_anim 4, 2, 130, 0, -7, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 1, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim_terminator
+sBlazikenAnims_4_5:
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -9, 0, 0,
+ax_anim 4, 2, 135, 0, -7, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim_terminator
+sBlazikenAnims_4_6:
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 138, 0, -9, 0, 0,
+ax_anim 4, 2, 140, 0, -7, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 1, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim_terminator
+sBlazikenAnims_4_7:
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -9, 0, 0,
+ax_anim 4, 2, 145, 0, -7, 0, 0,
+ax_anim 2, 0, 146, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 1, 146, 0, 1, 0, 1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 1, 0, 1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 1, 0, 1,
+ax_anim_terminator
+sBlazikenAnims_4_8:
+ax_anim 2, 0, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, 0,
+ax_anim 2, 0, 148, 0, -9, 0, 0,
+ax_anim 4, 2, 150, 0, -7, 0, 0,
+ax_anim 2, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 1, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_5_1:
+ax_anim 2, 0, 157, 0, 2, 0, 2,
+ax_anim 2, 0, 155, -1, 6, -1, 6,
+ax_anim 4, 0, 155, -2, 17, -2, 17,
+ax_anim 2, 2, 155, -2, 17, -2, 17,
+ax_anim 2, 0, 156, -2, 19, -2, 19,
+ax_anim 1, 1, 153, -1, 20, -1, 20,
+ax_anim 2, 0, 154, 0, 17, 0, 17,
+ax_anim 4, 0, 154, 0, 16, 0, 16,
+ax_anim 2, 0, 153, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, 4, 0, 4,
+ax_anim_terminator
+sBlazikenAnims_5_2:
+ax_anim 2, 0, 163, 2, 2, 2, 2,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 4, 0, 161, 18, 18, 18, 18,
+ax_anim 2, 2, 161, 18, 18, 18, 18,
+ax_anim 2, 0, 162, 20, 20, 20, 20,
+ax_anim 1, 1, 159, 21, 22, 21, 22,
+ax_anim 2, 0, 160, 17, 19, 17, 19,
+ax_anim 4, 0, 160, 16, 18, 16, 18,
+ax_anim 2, 0, 159, 12, 12, 12, 12,
+ax_anim 2, 0, 158, 4, 4, 4, 4,
+ax_anim_terminator
+sBlazikenAnims_5_3:
+ax_anim 2, 0, 169, 4, 0, 4, 0,
+ax_anim 2, 0, 167, 8, 0, 8, 0,
+ax_anim 4, 0, 167, 12, 0, 12, 0,
+ax_anim 2, 2, 167, 12, 0, 12, 0,
+ax_anim 2, 0, 168, 16, 0, 16, 0,
+ax_anim 1, 1, 165, 17, 0, 17, 0,
+ax_anim 2, 0, 166, 14, 0, 14, 0,
+ax_anim 4, 0, 166, 13, 0, 13, 0,
+ax_anim 2, 0, 165, 5, 0, 5, 0,
+ax_anim 2, 0, 164, 4, 0, 4, 0,
+ax_anim_terminator
+sBlazikenAnims_5_4:
+ax_anim 2, 0, 175, 4, -4, 4, -4,
+ax_anim 2, 0, 173, 8, -8, 4, -4,
+ax_anim 4, 0, 173, 13, -14, 14, -15,
+ax_anim 2, 2, 173, 13, -14, 14, -15,
+ax_anim 2, 0, 174, 14, -15, 15, -14,
+ax_anim 1, 1, 171, 17, -16, 14, -15,
+ax_anim 2, 0, 172, 13, -13, 15, -14,
+ax_anim 4, 0, 172, 12, -12, 15, -14,
+ax_anim 2, 0, 171, 7, -9, 7, -8,
+ax_anim 2, 0, 170, 4, -4, 4, -4,
+ax_anim_terminator
+sBlazikenAnims_5_5:
+ax_anim 2, 0, 181, 2, -2, 2, -2,
+ax_anim 2, 0, 179, 2, -6, 2, -6,
+ax_anim 4, 0, 179, 2, -13, 2, -13,
+ax_anim 2, 2, 179, 2, -13, 2, -13,
+ax_anim 2, 0, 180, 2, -14, 2, -14,
+ax_anim 1, 1, 177, 0, -17, 0, -17,
+ax_anim 2, 0, 178, 0, -12, 0, -12,
+ax_anim 4, 0, 178, 0, -11, 0, -11,
+ax_anim 2, 0, 177, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, -2, 0, -2,
+ax_anim_terminator
+sBlazikenAnims_5_6:
+ax_anim 2, 0, 187, -4, -4, -4, -4,
+ax_anim 2, 0, 185, -8, -8, -8, -8,
+ax_anim 4, 0, 185, -13, -14, -13, -14,
+ax_anim 2, 2, 185, -13, -14, -13, -14,
+ax_anim 2, 0, 186, -14, -15, -14, -15,
+ax_anim 1, 1, 183, -17, -16, -17, -16,
+ax_anim 2, 0, 184, -13, -13, -13, -13,
+ax_anim 4, 0, 184, -12, -12, -12, -12,
+ax_anim 2, 0, 183, -7, -9, -7, -9,
+ax_anim 2, 0, 182, -4, -4, -4, -4,
+ax_anim_terminator
+sBlazikenAnims_5_7:
+ax_anim 2, 0, 193, -4, 0, -4, 0,
+ax_anim 2, 0, 191, -8, 0, -8, 0,
+ax_anim 4, 0, 191, -12, 0, -12, 0,
+ax_anim 2, 2, 191, -12, 0, -12, 0,
+ax_anim 2, 0, 192, -16, 0, -16, 0,
+ax_anim 1, 1, 189, -17, 0, -17, 0,
+ax_anim 2, 0, 190, -14, 0, -14, 0,
+ax_anim 4, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 189, -5, 0, -5, 0,
+ax_anim 2, 0, 188, -4, 0, -4, 0,
+ax_anim_terminator
+sBlazikenAnims_5_8:
+ax_anim 2, 0, 199, -2, 2, -2, 2,
+ax_anim 2, 0, 197, -10, 10, -10, 10,
+ax_anim 4, 0, 197, -18, 18, -18, 18,
+ax_anim 2, 2, 197, -18, 18, -18, 18,
+ax_anim 2, 0, 198, -20, 20, -20, 20,
+ax_anim 1, 1, 195, -21, 22, -21, 22,
+ax_anim 2, 0, 196, -17, 19, -17, 19,
+ax_anim 4, 0, 196, -16, 18, -16, 18,
+ax_anim 2, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 194, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_6_1:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 35, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_7_1:
+ax_anim 2, 0, 202, 0, -2, 0, -2,
+ax_anim 8, 0, 202, 0, -3, 0, -3,
+ax_anim_terminator
+sBlazikenAnims_7_2:
+ax_anim 2, 0, 203, -2, -2, -2, -2,
+ax_anim 8, 0, 203, -3, -3, -3, -3,
+ax_anim_terminator
+sBlazikenAnims_7_3:
+ax_anim 2, 0, 204, -2, 0, -2, 0,
+ax_anim 8, 0, 204, -3, 0, -3, 0,
+ax_anim_terminator
+sBlazikenAnims_7_4:
+ax_anim 2, 0, 205, -2, 2, -2, 2,
+ax_anim 8, 0, 205, -3, 3, -3, 3,
+ax_anim_terminator
+sBlazikenAnims_7_5:
+ax_anim 2, 0, 206, 0, 2, 0, 2,
+ax_anim 8, 0, 206, 0, 3, 0, 3,
+ax_anim_terminator
+sBlazikenAnims_7_6:
+ax_anim 2, 0, 207, 2, 2, 2, 2,
+ax_anim 8, 0, 207, 3, 3, 3, 3,
+ax_anim_terminator
+sBlazikenAnims_7_7:
+ax_anim 2, 0, 208, 2, 0, 2, 0,
+ax_anim 8, 0, 208, 3, 0, 3, 0,
+ax_anim_terminator
+sBlazikenAnims_7_8:
+ax_anim 2, 0, 209, 2, -2, 2, -2,
+ax_anim 8, 0, 209, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_8_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 30, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_8_2:
+ax_anim 30, 0, 212, 0, 0, 0, 0,
+ax_anim 30, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_8_3:
+ax_anim 30, 0, 214, 0, 0, 0, 0,
+ax_anim 30, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_8_4:
+ax_anim 30, 0, 216, 0, 0, 0, 0,
+ax_anim 30, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_8_5:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_8_6:
+ax_anim 30, 0, 220, 0, 0, 0, 0,
+ax_anim 30, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_8_7:
+ax_anim 30, 0, 222, 0, 0, 0, 0,
+ax_anim 30, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_8_8:
+ax_anim 30, 0, 224, 0, 0, 0, 0,
+ax_anim 30, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_9_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 6, 3, 6, 3,
+ax_anim 2, 0, 228, 8, 9, 8, 9,
+ax_anim 2, 0, 229, 7, 15, 7, 15,
+ax_anim 3, 0, 230, 0, 20, 0, 20,
+ax_anim 2, 3, 231, -7, 15, -7, 15,
+ax_anim 2, 0, 232, -8, 9, -8, 9,
+ax_anim 1, 0, 233, -6, 3, -6, 3,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_9_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 12, 2, 12, 2,
+ax_anim 2, 0, 227, 18, 7, 18, 7,
+ax_anim 2, 0, 228, 23, 12, 23, 12,
+ax_anim 3, 0, 229, 23, 21, 23, 21,
+ax_anim 2, 3, 230, 15, 20, 15, 20,
+ax_anim 2, 0, 231, 8, 17, 8, 17,
+ax_anim 1, 0, 232, 2, 9, 2, 9,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_9_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 4, -3, 4, -3,
+ax_anim 2, 0, 226, 9, -6, 9, -6,
+ax_anim 2, 0, 227, 17, -3, 17, -3,
+ax_anim 3, 0, 228, 21, 1, 21, 1,
+ax_anim 2, 3, 229, 15, 4, 15, 4,
+ax_anim 2, 0, 230, 10, 4, 10, 4,
+ax_anim 1, 0, 231, 7, 4, 7, 4,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_9_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, -1, -8, -1, -8,
+ax_anim 2, 0, 233, 3, -14, 3, -14,
+ax_anim 2, 0, 226, 11, -17, 11, -17,
+ax_anim 3, 0, 227, 21, -17, 21, -17,
+ax_anim 2, 3, 228, 24, -12, 24, -12,
+ax_anim 2, 0, 229, 17, -4, 17, -4,
+ax_anim 1, 0, 230, 7, -1, 7, -1,
+ax_anim 1, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_9_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, -8, -2, -8, -2,
+ax_anim 2, 0, 232, -12, -8, -12, -8,
+ax_anim 2, 0, 233, -8, -15, -8, -15,
+ax_anim 3, 0, 226, 0, -17, 0, -17,
+ax_anim 2, 3, 227, 8, -15, 8, -15,
+ax_anim 2, 0, 228, 12, -8, 12, -8,
+ax_anim 1, 0, 229, 8, -2, 8, -2,
+ax_anim 1, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_9_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 1, -8, 1, -8,
+ax_anim 2, 0, 227, -3, -14, -3, -14,
+ax_anim 2, 0, 226, -11, -17, -11, -17,
+ax_anim 3, 0, 233, -21, -17, -21, -17,
+ax_anim 2, 3, 232, -24, -12, -24, -12,
+ax_anim 2, 0, 231, -17, -4, -17, -4,
+ax_anim 1, 0, 230, -7, -1, -7, -1,
+ax_anim 1, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_9_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 227, -4, -3, -4, -3,
+ax_anim 2, 0, 226, -9, -6, -9, -6,
+ax_anim 2, 0, 233, -17, -3, -17, -3,
+ax_anim 3, 0, 232, -21, 1, -21, 1,
+ax_anim 2, 3, 231, -15, 4, -15, 4,
+ax_anim 2, 0, 230, -10, 4, -10, 4,
+ax_anim 1, 0, 229, -7, 4, -7, 4,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_9_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 226, -12, 2, -12, 2,
+ax_anim 2, 0, 233, -18, 7, -18, 7,
+ax_anim 2, 0, 232, -23, 12, -23, 12,
+ax_anim 3, 0, 231, -23, 21, -23, 21,
+ax_anim 2, 3, 230, -15, 20, -15, 20,
+ax_anim 2, 0, 229, -8, 17, -8, 17,
+ax_anim 1, 0, 228, -2, 9, -2, 9,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_10_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 3, 0, 234, 13, 0, 13, 0,
+ax_anim 3, 0, 234, -13, 0, -13, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_10_2:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 3, 0, 235, 13, -13, 13, -13,
+ax_anim 3, 0, 235, -13, 13, -13, 13,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_10_3:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 3, 0, 236, 0, -13, 0, -13,
+ax_anim 3, 0, 236, 0, 13, 0, 13,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_10_4:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 3, 0, 237, -13, -13, -13, -13,
+ax_anim 3, 0, 237, 13, 13, 13, 13,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_10_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 3, 0, 238, 13, 0, 13, 0,
+ax_anim 3, 0, 238, -13, 0, -13, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_10_6:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 3, 0, 239, 13, -13, 13, -13,
+ax_anim 3, 0, 239, -13, 13, -13, 13,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_10_7:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 3, 0, 240, 0, -13, 0, -13,
+ax_anim 3, 0, 240, 0, 13, 0, 13,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_10_8:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 3, 0, 241, -13, -13, -13, -13,
+ax_anim 3, 0, 241, 13, 13, 13, 13,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_11_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -9, 0, 0,
+ax_anim 2, 0, 243, 0, -14, 0, 0,
+ax_anim 3, 0, 243, 0, -17, 0, 0,
+ax_anim 4, 0, 243, 0, -18, 0, 0,
+ax_anim 4, 0, 242, 0, -21, 0, 0,
+ax_anim 3, 0, 244, 0, -21, 0, 0,
+ax_anim 2, 0, 244, 0, -17, 0, 0,
+ax_anim 1, 0, 244, 0, -12, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_11_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -15, 0, 0,
+ax_anim 3, 0, 246, 0, -19, 0, 0,
+ax_anim 4, 0, 246, 0, -20, 0, 0,
+ax_anim 4, 0, 245, 0, -22, 0, 0,
+ax_anim 3, 0, 247, 0, -21, 0, 0,
+ax_anim 2, 0, 247, 0, -17, 0, 0,
+ax_anim 1, 0, 247, 0, -12, 0, 0,
+ax_anim 2, 2, 247, 0, 1, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_11_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 0, -9, 0, 0,
+ax_anim 2, 0, 249, 0, -14, 0, 0,
+ax_anim 3, 0, 249, 0, -18, 0, 0,
+ax_anim 4, 0, 249, 0, -19, 0, 0,
+ax_anim 4, 0, 248, 0, -20, 0, 0,
+ax_anim 3, 0, 250, 0, -20, 0, 0,
+ax_anim 2, 0, 250, 0, -16, 0, 0,
+ax_anim 1, 0, 250, 0, -12, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_11_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -10, 0, 0,
+ax_anim 2, 0, 252, 0, -14, 0, 0,
+ax_anim 3, 0, 252, 0, -18, 0, 0,
+ax_anim 4, 0, 252, 0, -19, 0, 0,
+ax_anim 4, 0, 251, 0, -20, 0, 0,
+ax_anim 3, 0, 253, 0, -18, 0, 0,
+ax_anim 2, 0, 253, 0, -15, 0, 0,
+ax_anim 1, 0, 253, 0, -11, 0, 0,
+ax_anim 2, 2, 253, 0, 3, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_11_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, -9, 0, 0,
+ax_anim 2, 0, 255, 0, -14, 0, 0,
+ax_anim 3, 0, 255, 0, -18, 0, 0,
+ax_anim 4, 0, 255, 0, -19, 0, 0,
+ax_anim 4, 0, 254, 0, -20, 0, 0,
+ax_anim 3, 0, 256, 0, -19, 0, 0,
+ax_anim 2, 0, 256, 0, -16, 0, 0,
+ax_anim 1, 0, 256, 0, -12, 0, 0,
+ax_anim 2, 2, 256, 0, 3, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_11_6:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -14, 0, 0,
+ax_anim 3, 0, 258, 0, -18, 0, 0,
+ax_anim 4, 0, 258, 0, -19, 0, 0,
+ax_anim 4, 0, 257, 0, -20, 0, 0,
+ax_anim 3, 0, 259, 0, -18, 0, 0,
+ax_anim 2, 0, 259, 0, -15, 0, 0,
+ax_anim 1, 0, 259, 0, -11, 0, 0,
+ax_anim 2, 2, 259, 0, 3, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_11_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 261, 0, -9, 0, 0,
+ax_anim 2, 0, 261, 0, -14, 0, 0,
+ax_anim 3, 0, 261, 0, -18, 0, 0,
+ax_anim 4, 0, 261, 0, -19, 0, 0,
+ax_anim 4, 0, 260, 0, -20, 0, 0,
+ax_anim 3, 0, 262, 0, -20, 0, 0,
+ax_anim 2, 0, 262, 0, -16, 0, 0,
+ax_anim 1, 0, 262, 0, -12, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_11_8:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 264, 0, -10, 0, 0,
+ax_anim 2, 0, 264, 0, -15, 0, 0,
+ax_anim 3, 0, 264, 0, -19, 0, 0,
+ax_anim 4, 0, 264, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -22, 0, 0,
+ax_anim 3, 0, 265, 0, -21, 0, 0,
+ax_anim 2, 0, 265, 0, -17, 0, 0,
+ax_anim 1, 0, 265, 0, -12, 0, 0,
+ax_anim 2, 2, 265, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_12_1:
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 1, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_12_2:
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 1, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_12_3:
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 1, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_12_4:
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 1, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_12_5:
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 1, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_12_6:
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 1, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_12_7:
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 1, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_12_8:
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 1, 267, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlazikenAnims_13_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_13_2:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_13_3:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_13_4:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_13_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_13_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_13_7:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenAnims_13_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sBlazikenGfx1:
+.incbin "baserom.gba", 0x108CE48, 0x200
+sBlazikenSprites1:
+ax_sprite sBlazikenGfx1, 0x200
+ax_sprite_terminator
+sBlazikenGfx2:
+.incbin "baserom.gba", 0x108D058, 0x200
+sBlazikenSprites2:
+ax_sprite sBlazikenGfx2, 0x200
+ax_sprite_terminator
+sBlazikenGfx3:
+.incbin "baserom.gba", 0x108D268, 0x200
+sBlazikenSprites3:
+ax_sprite sBlazikenGfx3, 0x200
+ax_sprite_terminator
+sBlazikenGfx4:
+.incbin "baserom.gba", 0x108D478, 0x200
+sBlazikenSprites4:
+ax_sprite sBlazikenGfx4, 0x200
+ax_sprite_terminator
+sBlazikenGfx5:
+.incbin "baserom.gba", 0x108D688, 0x200
+sBlazikenSprites5:
+ax_sprite sBlazikenGfx5, 0x200
+ax_sprite_terminator
+sBlazikenGfx6:
+.incbin "baserom.gba", 0x108D898, 0x200
+sBlazikenSprites6:
+ax_sprite sBlazikenGfx6, 0x200
+ax_sprite_terminator
+sBlazikenGfx7:
+.incbin "baserom.gba", 0x108DAA8, 0x200
+sBlazikenSprites7:
+ax_sprite sBlazikenGfx7, 0x200
+ax_sprite_terminator
+sBlazikenGfx8:
+.incbin "baserom.gba", 0x108DCB8, 0x200
+sBlazikenSprites8:
+ax_sprite sBlazikenGfx8, 0x200
+ax_sprite_terminator
+sBlazikenGfx9:
+.incbin "baserom.gba", 0x108DEC8, 0x200
+sBlazikenSprites9:
+ax_sprite sBlazikenGfx9, 0x200
+ax_sprite_terminator
+sBlazikenGfx10:
+.incbin "baserom.gba", 0x108E0D8, 0x200
+sBlazikenSprites10:
+ax_sprite sBlazikenGfx10, 0x200
+ax_sprite_terminator
+sBlazikenGfx11:
+.incbin "baserom.gba", 0x108E2E8, 0x200
+sBlazikenSprites11:
+ax_sprite sBlazikenGfx11, 0x200
+ax_sprite_terminator
+sBlazikenGfx12:
+.incbin "baserom.gba", 0x108E4F8, 0x200
+sBlazikenSprites12:
+ax_sprite sBlazikenGfx12, 0x200
+ax_sprite_terminator
+sBlazikenGfx13:
+.incbin "baserom.gba", 0x108E708, 0x200
+sBlazikenSprites13:
+ax_sprite sBlazikenGfx13, 0x200
+ax_sprite_terminator
+sBlazikenGfx14:
+.incbin "baserom.gba", 0x108E918, 0x200
+sBlazikenSprites14:
+ax_sprite sBlazikenGfx14, 0x200
+ax_sprite_terminator
+sBlazikenGfx15:
+.incbin "baserom.gba", 0x108EB28, 0x200
+sBlazikenSprites15:
+ax_sprite sBlazikenGfx15, 0x200
+ax_sprite_terminator
+sBlazikenGfx16:
+.incbin "baserom.gba", 0x108ED38, 0x100
+sBlazikenSprites16:
+ax_sprite sBlazikenGfx16, 0x100
+ax_sprite_terminator
+sBlazikenGfx17:
+.incbin "baserom.gba", 0x108EE48, 0x40
+sBlazikenGfx17_1:
+.incbin "baserom.gba", 0x108EE88, 0x80
+sBlazikenSprites17:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx17_1, 0x80
+ax_sprite_terminator
+sBlazikenGfx18:
+.incbin "baserom.gba", 0x108EF30, 0x80
+sBlazikenSprites18:
+ax_sprite sBlazikenGfx18, 0x80
+ax_sprite_terminator
+sBlazikenGfx19:
+.incbin "baserom.gba", 0x108EFC0, 0x20
+sBlazikenSprites19:
+ax_sprite sBlazikenGfx19, 0x20
+ax_sprite_terminator
+sBlazikenGfx20:
+.incbin "baserom.gba", 0x108EFF0, 0x200
+sBlazikenSprites20:
+ax_sprite sBlazikenGfx20, 0x200
+ax_sprite_terminator
+sBlazikenGfx21:
+.incbin "baserom.gba", 0x108F200, 0x80
+sBlazikenGfx21_1:
+.incbin "baserom.gba", 0x108F280, 0x40
+sBlazikenGfx21_2:
+.incbin "baserom.gba", 0x108F2C0, 0x100
+sBlazikenSprites21:
+ax_sprite sBlazikenGfx21, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx21_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx21_2, 0x100
+ax_sprite_terminator
+sBlazikenGfx22:
+.incbin "baserom.gba", 0x108F3F0, 0x1E0
+sBlazikenSprites22:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx22, 0x1e0
+ax_sprite_terminator
+sBlazikenGfx23:
+.incbin "baserom.gba", 0x108F5E8, 0x100
+sBlazikenSprites23:
+ax_sprite sBlazikenGfx23, 0x100
+ax_sprite_terminator
+sBlazikenGfx24:
+.incbin "baserom.gba", 0x108F6F8, 0x60
+sBlazikenGfx24_1:
+.incbin "baserom.gba", 0x108F758, 0x160
+sBlazikenSprites24:
+ax_sprite sBlazikenGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx24_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx25:
+.incbin "baserom.gba", 0x108F8E0, 0x20
+sBlazikenGfx25_1:
+.incbin "baserom.gba", 0x108F900, 0x100
+sBlazikenGfx25_2:
+.incbin "baserom.gba", 0x108FA00, 0x20
+sBlazikenSprites25:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sBlazikenGfx25_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sBlazikenGfx25_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx26:
+.incbin "baserom.gba", 0x108FA60, 0x160
+sBlazikenGfx26_1:
+.incbin "baserom.gba", 0x108FBC0, 0x80
+sBlazikenSprites26:
+ax_sprite sBlazikenGfx26, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx26_1, 0x80
+ax_sprite_terminator
+sBlazikenGfx27:
+.incbin "baserom.gba", 0x108FC60, 0x20
+sBlazikenGfx27_1:
+.incbin "baserom.gba", 0x108FC80, 0x100
+sBlazikenGfx27_2:
+.incbin "baserom.gba", 0x108FD80, 0x20
+sBlazikenSprites27:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sBlazikenGfx27_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sBlazikenGfx27_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx28:
+.incbin "baserom.gba", 0x108FDE0, 0x80
+sBlazikenSprites28:
+ax_sprite sBlazikenGfx28, 0x80
+ax_sprite_terminator
+sBlazikenGfx29:
+.incbin "baserom.gba", 0x108FE70, 0x40
+sBlazikenGfx29_1:
+.incbin "baserom.gba", 0x108FEB0, 0x140
+sBlazikenSprites29:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBlazikenGfx29_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx30:
+.incbin "baserom.gba", 0x1090020, 0x40
+sBlazikenGfx30_1:
+.incbin "baserom.gba", 0x1090060, 0x60
+sBlazikenGfx30_2:
+.incbin "baserom.gba", 0x10900C0, 0x60
+sBlazikenSprites30:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBlazikenGfx31:
+.incbin "baserom.gba", 0x1090160, 0x160
+sBlazikenGfx31_1:
+.incbin "baserom.gba", 0x10902C0, 0x60
+sBlazikenSprites31:
+ax_sprite sBlazikenGfx31, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx32:
+.incbin "baserom.gba", 0x1090348, 0x40
+sBlazikenGfx32_1:
+.incbin "baserom.gba", 0x1090388, 0x60
+sBlazikenGfx32_2:
+.incbin "baserom.gba", 0x10903E8, 0x60
+sBlazikenSprites32:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBlazikenGfx33:
+.incbin "baserom.gba", 0x1090488, 0x80
+sBlazikenSprites33:
+ax_sprite sBlazikenGfx33, 0x80
+ax_sprite_terminator
+sBlazikenGfx34:
+.incbin "baserom.gba", 0x1090518, 0x160
+sBlazikenGfx34_1:
+.incbin "baserom.gba", 0x1090678, 0x40
+sBlazikenSprites34:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx34, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx35:
+.incbin "baserom.gba", 0x10906E8, 0x140
+sBlazikenGfx35_1:
+.incbin "baserom.gba", 0x1090828, 0x20
+sBlazikenSprites35:
+ax_sprite sBlazikenGfx35, 0x140
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx35_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlazikenGfx36:
+.incbin "baserom.gba", 0x1090870, 0x160
+sBlazikenGfx36_1:
+.incbin "baserom.gba", 0x10909D0, 0x60
+sBlazikenSprites36:
+ax_sprite sBlazikenGfx36, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx37:
+.incbin "baserom.gba", 0x1090A58, 0x120
+sBlazikenGfx37_1:
+.incbin "baserom.gba", 0x1090B78, 0x20
+sBlazikenGfx37_2:
+.incbin "baserom.gba", 0x1090B98, 0x20
+sBlazikenSprites37:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx37, 0x120
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx37_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBlazikenGfx38:
+.incbin "baserom.gba", 0x1090BF8, 0x100
+sBlazikenSprites38:
+ax_sprite sBlazikenGfx38, 0x100
+ax_sprite_terminator
+sBlazikenGfx39:
+.incbin "baserom.gba", 0x1090D08, 0x40
+sBlazikenGfx39_1:
+.incbin "baserom.gba", 0x1090D48, 0x160
+sBlazikenSprites39:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx39_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx40:
+.incbin "baserom.gba", 0x1090ED8, 0xC0
+sBlazikenGfx40_1:
+.incbin "baserom.gba", 0x1090F98, 0xA0
+sBlazikenSprites40:
+ax_sprite sBlazikenGfx40, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx40_1, 0xa0
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlazikenGfx41:
+.incbin "baserom.gba", 0x1091060, 0x60
+sBlazikenGfx41_1:
+.incbin "baserom.gba", 0x10910C0, 0xE0
+sBlazikenGfx41_2:
+.incbin "baserom.gba", 0x10911A0, 0x60
+sBlazikenSprites41:
+ax_sprite sBlazikenGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx41_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx42:
+.incbin "baserom.gba", 0x1091238, 0xC0
+sBlazikenGfx42_1:
+.incbin "baserom.gba", 0x10912F8, 0xA0
+sBlazikenSprites42:
+ax_sprite sBlazikenGfx42, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx42_1, 0xa0
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sBlazikenGfx43:
+.incbin "baserom.gba", 0x10913C0, 0x40
+sBlazikenSprites43:
+ax_sprite sBlazikenGfx43, 0x40
+ax_sprite_terminator
+sBlazikenGfx44:
+.incbin "baserom.gba", 0x1091410, 0x20
+sBlazikenSprites44:
+ax_sprite sBlazikenGfx44, 0x20
+ax_sprite_terminator
+sBlazikenGfx45:
+.incbin "baserom.gba", 0x1091440, 0x100
+sBlazikenGfx45_1:
+.incbin "baserom.gba", 0x1091540, 0x40
+sBlazikenGfx45_2:
+.incbin "baserom.gba", 0x1091580, 0x40
+sBlazikenSprites45:
+ax_sprite sBlazikenGfx45, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx45_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBlazikenGfx45_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx46:
+.incbin "baserom.gba", 0x10915F8, 0x20
+sBlazikenGfx46_1:
+.incbin "baserom.gba", 0x1091618, 0x20
+sBlazikenGfx46_2:
+.incbin "baserom.gba", 0x1091638, 0x20
+sBlazikenGfx46_3:
+.incbin "baserom.gba", 0x1091658, 0x20
+sBlazikenSprites46:
+ax_sprite sBlazikenGfx46, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx46_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx46_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx46_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx47:
+.incbin "baserom.gba", 0x10916C0, 0x60
+sBlazikenGfx47_1:
+.incbin "baserom.gba", 0x1091720, 0x100
+sBlazikenGfx47_2:
+.incbin "baserom.gba", 0x1091820, 0x40
+sBlazikenSprites47:
+ax_sprite sBlazikenGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx47_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx47_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx48:
+.incbin "baserom.gba", 0x1091898, 0x60
+sBlazikenGfx48_1:
+.incbin "baserom.gba", 0x10918F8, 0x80
+sBlazikenGfx48_2:
+.incbin "baserom.gba", 0x1091978, 0x60
+sBlazikenGfx48_3:
+.incbin "baserom.gba", 0x10919D8, 0x40
+sBlazikenSprites48:
+ax_sprite sBlazikenGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx48_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx48_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx49:
+.incbin "baserom.gba", 0x1091A60, 0x100
+sBlazikenSprites49:
+ax_sprite sBlazikenGfx49, 0x100
+ax_sprite_terminator
+sBlazikenGfx50:
+.incbin "baserom.gba", 0x1091B70, 0x40
+sBlazikenGfx50_1:
+.incbin "baserom.gba", 0x1091BB0, 0x160
+sBlazikenSprites50:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx50_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx51:
+.incbin "baserom.gba", 0x1091D40, 0x100
+sBlazikenGfx51_1:
+.incbin "baserom.gba", 0x1091E40, 0x60
+sBlazikenGfx51_2:
+.incbin "baserom.gba", 0x1091EA0, 0x40
+sBlazikenSprites51:
+ax_sprite sBlazikenGfx51, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx51_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx51_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx52:
+.incbin "baserom.gba", 0x1091F18, 0x60
+sBlazikenGfx52_1:
+.incbin "baserom.gba", 0x1091F78, 0x20
+sBlazikenSprites52:
+ax_sprite sBlazikenGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx52_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sBlazikenGfx53:
+.incbin "baserom.gba", 0x1091FC0, 0x160
+sBlazikenGfx53_1:
+.incbin "baserom.gba", 0x1092120, 0x40
+sBlazikenSprites53:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx53, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx53_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx54:
+.incbin "baserom.gba", 0x1092190, 0x60
+sBlazikenGfx54_1:
+.incbin "baserom.gba", 0x10921F0, 0x80
+sBlazikenGfx54_2:
+.incbin "baserom.gba", 0x1092270, 0x60
+sBlazikenGfx54_3:
+.incbin "baserom.gba", 0x10922D0, 0x40
+sBlazikenSprites54:
+ax_sprite sBlazikenGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx54_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx54_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx54_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx55:
+.incbin "baserom.gba", 0x1092358, 0x60
+sBlazikenGfx55_1:
+.incbin "baserom.gba", 0x10923B8, 0x20
+sBlazikenSprites55:
+ax_sprite sBlazikenGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx55_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sBlazikenGfx56:
+.incbin "baserom.gba", 0x1092400, 0x40
+sBlazikenGfx56_1:
+.incbin "baserom.gba", 0x1092440, 0x100
+sBlazikenGfx56_2:
+.incbin "baserom.gba", 0x1092540, 0x40
+sBlazikenSprites56:
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx56_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx56_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx57:
+.incbin "baserom.gba", 0x10925C0, 0x60
+sBlazikenGfx57_1:
+.incbin "baserom.gba", 0x1092620, 0x100
+sBlazikenGfx57_2:
+.incbin "baserom.gba", 0x1092720, 0x40
+sBlazikenSprites57:
+ax_sprite sBlazikenGfx57, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx57_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx57_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlazikenGfx58:
+.incbin "baserom.gba", 0x1092798, 0xA0
+sBlazikenGfx58_1:
+.incbin "baserom.gba", 0x1092838, 0x40
+sBlazikenSprites58:
+ax_sprite sBlazikenGfx58, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sBlazikenGfx58_1, 0x40
+ax_sprite_terminator
+sBlazikenGfx59:
+.incbin "baserom.gba", 0x1092898, 0x100
+sBlazikenSprites59:
+ax_sprite sBlazikenGfx59, 0x100
+ax_sprite_terminator
+sBlazikenGfx60:
+.incbin "baserom.gba", 0x10929A8, 0x40
+sBlazikenSprites60:
+ax_sprite sBlazikenGfx60, 0x40
+ax_sprite_terminator
+sBlazikenGfx61:
+.incbin "baserom.gba", 0x10929F8, 0x20
+sBlazikenSprites61:
+ax_sprite sBlazikenGfx61, 0x20
+ax_sprite_terminator
+sBlazikenGfx62:
+.incbin "baserom.gba", 0x1092A28, 0x20
+sBlazikenSprites62:
+ax_sprite sBlazikenGfx62, 0x20
+ax_sprite_terminator
+sBlazikenGfx63:
+.incbin "baserom.gba", 0x1092A58, 0x40
+sBlazikenSprites63:
+ax_sprite sBlazikenGfx63, 0x40
+ax_sprite_terminator
+sBlazikenGfx64:
+.incbin "baserom.gba", 0x1092AA8, 0x200
+sBlazikenSprites64:
+ax_sprite sBlazikenGfx64, 0x200
+ax_sprite_terminator
+sBlazikenGfx65:
+.incbin "baserom.gba", 0x1092CB8, 0x200
+sBlazikenSprites65:
+ax_sprite sBlazikenGfx65, 0x200
+ax_sprite_terminator
+sBlazikenGfx66:
+.incbin "baserom.gba", 0x1092EC8, 0x200
+sBlazikenSprites66:
+ax_sprite sBlazikenGfx66, 0x200
+ax_sprite_terminator
+sBlazikenGfx67:
+.incbin "baserom.gba", 0x10930D8, 0x200
+sBlazikenSprites67:
+ax_sprite sBlazikenGfx67, 0x200
+ax_sprite_terminator
+sBlazikenGfx68:
+.incbin "baserom.gba", 0x10932E8, 0x200
+sBlazikenSprites68:
+ax_sprite sBlazikenGfx68, 0x200
+ax_sprite_terminator
+sBlazikenGfx69:
+.incbin "baserom.gba", 0x10934F8, 0x200
+sBlazikenSprites69:
+ax_sprite sBlazikenGfx69, 0x200
+ax_sprite_terminator
+sBlazikenGfx70:
+.incbin "baserom.gba", 0x1093708, 0x200
+sBlazikenSprites70:
+ax_sprite sBlazikenGfx70, 0x200
+ax_sprite_terminator
+sBlazikenGfx71:
+.incbin "baserom.gba", 0x1093918, 0x200
+sBlazikenSprites71:
+ax_sprite sBlazikenGfx71, 0x200
+ax_sprite_terminator
+sBlazikenGfx72:
+.incbin "baserom.gba", 0x1093B28, 0x200
+sBlazikenSprites72:
+ax_sprite sBlazikenGfx72, 0x200
+ax_sprite_terminator
+sBlazikenGfx73:
+.incbin "baserom.gba", 0x1093D38, 0x200
+sBlazikenSprites73:
+ax_sprite sBlazikenGfx73, 0x200
+ax_sprite_terminator
+sBlazikenGfx74:
+.incbin "baserom.gba", 0x1093F48, 0x200
+sBlazikenSprites74:
+ax_sprite sBlazikenGfx74, 0x200
+ax_sprite_terminator
+sBlazikenGfx75:
+.incbin "baserom.gba", 0x1094158, 0x200
+sBlazikenSprites75:
+ax_sprite sBlazikenGfx75, 0x200
+ax_sprite_terminator
+sAxPosesBlaziken:
+.4byte sBlazikenPose1
+.4byte sBlazikenPose2
+.4byte sBlazikenPose3
+.4byte sBlazikenPose4
+.4byte sBlazikenPose5
+.4byte sBlazikenPose6
+.4byte sBlazikenPose7
+.4byte sBlazikenPose8
+.4byte sBlazikenPose9
+.4byte sBlazikenPose10
+.4byte sBlazikenPose11
+.4byte sBlazikenPose12
+.4byte sBlazikenPose13
+.4byte sBlazikenPose14
+.4byte sBlazikenPose15
+.4byte sBlazikenPose16
+.4byte sBlazikenPose17
+.4byte sBlazikenPose18
+.4byte sBlazikenPose19
+.4byte sBlazikenPose20
+.4byte sBlazikenPose21
+.4byte sBlazikenPose22
+.4byte sBlazikenPose23
+.4byte sBlazikenPose24
+.4byte sBlazikenPose25
+.4byte sBlazikenPose26
+.4byte sBlazikenPose27
+.4byte sBlazikenPose28
+.4byte sBlazikenPose29
+.4byte sBlazikenPose30
+.4byte sBlazikenPose31
+.4byte sBlazikenPose32
+.4byte sBlazikenPose33
+.4byte sBlazikenPose34
+.4byte sBlazikenPose35
+.4byte sBlazikenPose36
+.4byte sBlazikenPose37
+.4byte sBlazikenPose38
+.4byte sBlazikenPose39
+.4byte sBlazikenPose40
+.4byte sBlazikenPose41
+.4byte sBlazikenPose42
+.4byte sBlazikenPose43
+.4byte sBlazikenPose44
+.4byte sBlazikenPose45
+.4byte sBlazikenPose46
+.4byte sBlazikenPose47
+.4byte sBlazikenPose48
+.4byte sBlazikenPose49
+.4byte sBlazikenPose50
+.4byte sBlazikenPose51
+.4byte sBlazikenPose52
+.4byte sBlazikenPose53
+.4byte sBlazikenPose54
+.4byte sBlazikenPose55
+.4byte sBlazikenPose56
+.4byte sBlazikenPose57
+.4byte sBlazikenPose58
+.4byte sBlazikenPose59
+.4byte sBlazikenPose60
+.4byte sBlazikenPose61
+.4byte sBlazikenPose62
+.4byte sBlazikenPose63
+.4byte sBlazikenPose64
+.4byte sBlazikenPose65
+.4byte sBlazikenPose66
+.4byte sBlazikenPose67
+.4byte sBlazikenPose68
+.4byte sBlazikenPose69
+.4byte sBlazikenPose70
+.4byte sBlazikenPose71
+.4byte sBlazikenPose72
+.4byte sBlazikenPose73
+.4byte sBlazikenPose74
+.4byte sBlazikenPose75
+.4byte sBlazikenPose76
+.4byte sBlazikenPose77
+.4byte sBlazikenPose78
+.4byte sBlazikenPose79
+.4byte sBlazikenPose80
+.4byte sBlazikenPose81
+.4byte sBlazikenPose82
+.4byte sBlazikenPose83
+.4byte sBlazikenPose84
+.4byte sBlazikenPose85
+.4byte sBlazikenPose86
+.4byte sBlazikenPose87
+.4byte sBlazikenPose88
+.4byte sBlazikenPose89
+.4byte sBlazikenPose90
+.4byte sBlazikenPose91
+.4byte sBlazikenPose92
+.4byte sBlazikenPose93
+.4byte sBlazikenPose94
+.4byte sBlazikenPose95
+.4byte sBlazikenPose96
+.4byte sBlazikenPose97
+.4byte sBlazikenPose98
+.4byte sBlazikenPose99
+.4byte sBlazikenPose100
+.4byte sBlazikenPose101
+.4byte sBlazikenPose102
+.4byte sBlazikenPose103
+.4byte sBlazikenPose104
+.4byte sBlazikenPose105
+.4byte sBlazikenPose106
+.4byte sBlazikenPose107
+.4byte sBlazikenPose108
+.4byte sBlazikenPose109
+.4byte sBlazikenPose110
+.4byte sBlazikenPose111
+.4byte sBlazikenPose112
+.4byte sBlazikenPose113
+.4byte sBlazikenPose114
+.4byte sBlazikenPose115
+.4byte sBlazikenPose116
+.4byte sBlazikenPose117
+.4byte sBlazikenPose118
+.4byte sBlazikenPose119
+.4byte sBlazikenPose120
+.4byte sBlazikenPose121
+.4byte sBlazikenPose122
+.4byte sBlazikenPose123
+.4byte sBlazikenPose124
+.4byte sBlazikenPose125
+.4byte sBlazikenPose126
+.4byte sBlazikenPose127
+.4byte sBlazikenPose128
+.4byte sBlazikenPose129
+.4byte sBlazikenPose130
+.4byte sBlazikenPose131
+.4byte sBlazikenPose132
+.4byte sBlazikenPose133
+.4byte sBlazikenPose134
+.4byte sBlazikenPose135
+.4byte sBlazikenPose136
+.4byte sBlazikenPose137
+.4byte sBlazikenPose138
+.4byte sBlazikenPose139
+.4byte sBlazikenPose140
+.4byte sBlazikenPose141
+.4byte sBlazikenPose142
+.4byte sBlazikenPose143
+.4byte sBlazikenPose144
+.4byte sBlazikenPose145
+.4byte sBlazikenPose146
+.4byte sBlazikenPose147
+.4byte sBlazikenPose148
+.4byte sBlazikenPose149
+.4byte sBlazikenPose150
+.4byte sBlazikenPose151
+.4byte sBlazikenPose152
+.4byte sBlazikenPose153
+.4byte sBlazikenPose154
+.4byte sBlazikenPose155
+.4byte sBlazikenPose156
+.4byte sBlazikenPose157
+.4byte sBlazikenPose158
+.4byte sBlazikenPose159
+.4byte sBlazikenPose160
+.4byte sBlazikenPose161
+.4byte sBlazikenPose162
+.4byte sBlazikenPose163
+.4byte sBlazikenPose164
+.4byte sBlazikenPose165
+.4byte sBlazikenPose166
+.4byte sBlazikenPose167
+.4byte sBlazikenPose168
+.4byte sBlazikenPose169
+.4byte sBlazikenPose170
+.4byte sBlazikenPose171
+.4byte sBlazikenPose172
+.4byte sBlazikenPose173
+.4byte sBlazikenPose174
+.4byte sBlazikenPose175
+.4byte sBlazikenPose176
+.4byte sBlazikenPose177
+.4byte sBlazikenPose178
+.4byte sBlazikenPose179
+.4byte sBlazikenPose180
+.4byte sBlazikenPose181
+.4byte sBlazikenPose182
+.4byte sBlazikenPose183
+.4byte sBlazikenPose184
+.4byte sBlazikenPose185
+.4byte sBlazikenPose186
+.4byte sBlazikenPose187
+.4byte sBlazikenPose188
+.4byte sBlazikenPose189
+.4byte sBlazikenPose190
+.4byte sBlazikenPose191
+.4byte sBlazikenPose192
+.4byte sBlazikenPose193
+.4byte sBlazikenPose194
+.4byte sBlazikenPose195
+.4byte sBlazikenPose196
+.4byte sBlazikenPose197
+.4byte sBlazikenPose198
+.4byte sBlazikenPose199
+.4byte sBlazikenPose200
+.4byte sBlazikenPose201
+.4byte sBlazikenPose202
+.4byte sBlazikenPose203
+.4byte sBlazikenPose204
+.4byte sBlazikenPose205
+.4byte sBlazikenPose206
+.4byte sBlazikenPose207
+.4byte sBlazikenPose208
+.4byte sBlazikenPose209
+.4byte sBlazikenPose210
+.4byte sBlazikenPose211
+.4byte sBlazikenPose212
+.4byte sBlazikenPose213
+.4byte sBlazikenPose214
+.4byte sBlazikenPose215
+.4byte sBlazikenPose216
+.4byte sBlazikenPose217
+.4byte sBlazikenPose218
+.4byte sBlazikenPose219
+.4byte sBlazikenPose220
+.4byte sBlazikenPose221
+.4byte sBlazikenPose222
+.4byte sBlazikenPose223
+.4byte sBlazikenPose224
+.4byte sBlazikenPose225
+.4byte sBlazikenPose226
+.4byte sBlazikenPose227
+.4byte sBlazikenPose228
+.4byte sBlazikenPose229
+.4byte sBlazikenPose230
+.4byte sBlazikenPose231
+.4byte sBlazikenPose232
+.4byte sBlazikenPose233
+.4byte sBlazikenPose234
+.4byte sBlazikenPose235
+.4byte sBlazikenPose236
+.4byte sBlazikenPose237
+.4byte sBlazikenPose238
+.4byte sBlazikenPose239
+.4byte sBlazikenPose240
+.4byte sBlazikenPose241
+.4byte sBlazikenPose242
+.4byte sBlazikenPose243
+.4byte sBlazikenPose244
+.4byte sBlazikenPose245
+.4byte sBlazikenPose246
+.4byte sBlazikenPose247
+.4byte sBlazikenPose248
+.4byte sBlazikenPose249
+.4byte sBlazikenPose250
+.4byte sBlazikenPose251
+.4byte sBlazikenPose252
+.4byte sBlazikenPose253
+.4byte sBlazikenPose254
+.4byte sBlazikenPose255
+.4byte sBlazikenPose256
+.4byte sBlazikenPose257
+.4byte sBlazikenPose258
+.4byte sBlazikenPose259
+.4byte sBlazikenPose260
+.4byte sBlazikenPose261
+.4byte sBlazikenPose262
+.4byte sBlazikenPose263
+.4byte sBlazikenPose264
+.4byte sBlazikenPose265
+.4byte sBlazikenPose266
+.4byte sBlazikenPose267
+.4byte sBlazikenPose268
+.4byte sBlazikenPose269
+.4byte sBlazikenPose270
+.4byte sBlazikenPose271
+.4byte sBlazikenPose272
+.4byte sBlazikenPose273
+.4byte sBlazikenPose274
+.4byte sBlazikenPose275
+.4byte sBlazikenPose276
+.4byte sBlazikenPose277
+.4byte sBlazikenPose278
+.4byte sBlazikenPose279
+.4byte sBlazikenPose280
+.4byte sBlazikenPose281
+.4byte sBlazikenPose282
+sAxPositionsBlaziken:
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -7,   -7, 	   8,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	 -10,   -9, 	   5,   -8, 	  -1,  -12
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+.2byte    5,  -15, 	   8,   -7, 	  -9,   -8, 	   0,  -11
+.2byte    5,  -15, 	   7,  -11, 	  -1,   -7, 	   0,  -11
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    8,  -17, 	   7,  -11, 	  -4,   -7, 	   0,  -12
+.2byte    8,  -17, 	  -7,  -11, 	   4,   -9, 	  -2,  -11
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    5,  -17, 	   0,  -14, 	   3,   -6, 	  -2,  -13
+.2byte    5,  -17, 	  -6,  -12, 	   6,  -11, 	  -2,  -12
+.2byte   -1,  -20, 	   8,  -12, 	 -10,  -12, 	  -1,  -14
+.2byte   -1,  -18, 	   7,  -14, 	 -10,   -9, 	  -1,  -13
+.2byte   -1,  -18, 	   8,   -9, 	  -9,  -14, 	  -1,  -13
+.2byte   -6,  -19, 	   3,  -15, 	  -9,  -10, 	   0,  -13
+.2byte   -7,  -17, 	  -2,  -14, 	  -5,   -6, 	   0,  -13
+.2byte   -7,  -17, 	   4,  -12, 	  -8,  -11, 	   0,  -12
+.2byte   -9,  -19, 	  -6,  -14, 	  -3,   -8, 	   0,  -12
+.2byte  -10,  -17, 	  -9,  -11, 	   2,   -7, 	  -2,  -12
+.2byte  -10,  -17, 	   5,  -11, 	  -6,   -9, 	   0,  -11
+.2byte   -6,  -17, 	  -9,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -7,  -15, 	 -10,   -7, 	   7,   -8, 	  -2,  -11
+.2byte   -7,  -15, 	  -9,  -11, 	  -1,   -7, 	  -2,  -11
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -7,   -7, 	   8,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	 -10,   -9, 	   5,   -8, 	  -1,  -12
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+.2byte    5,  -15, 	   8,   -7, 	  -9,   -8, 	   0,  -11
+.2byte    5,  -15, 	   7,  -11, 	  -1,   -7, 	   0,  -11
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    8,  -17, 	   7,  -11, 	  -4,   -7, 	   0,  -12
+.2byte    8,  -17, 	  -7,  -11, 	   4,   -9, 	  -2,  -11
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    5,  -17, 	   0,  -14, 	   3,   -6, 	  -2,  -13
+.2byte    5,  -17, 	  -6,  -12, 	   6,  -11, 	  -2,  -12
+.2byte   -1,  -20, 	   8,  -12, 	 -10,  -12, 	  -1,  -14
+.2byte   -1,  -18, 	   7,  -14, 	 -10,   -9, 	  -1,  -13
+.2byte   -1,  -18, 	   8,   -9, 	  -9,  -14, 	  -1,  -13
+.2byte   -6,  -19, 	   3,  -15, 	  -9,  -10, 	   0,  -13
+.2byte   -7,  -17, 	  -2,  -14, 	  -5,   -6, 	   0,  -13
+.2byte   -7,  -17, 	   4,  -12, 	  -8,  -11, 	   0,  -12
+.2byte   -9,  -19, 	  -6,  -14, 	  -3,   -8, 	   0,  -12
+.2byte  -10,  -17, 	  -9,  -11, 	   2,   -7, 	  -2,  -12
+.2byte  -10,  -17, 	   5,  -11, 	  -6,   -9, 	   0,  -11
+.2byte   -6,  -17, 	  -9,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -7,  -15, 	 -10,   -7, 	   7,   -8, 	  -2,  -11
+.2byte   -7,  -15, 	  -9,  -11, 	  -1,   -7, 	  -2,  -11
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -7,   -7, 	   8,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	 -10,   -9, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -18, 	 -15,  -17, 	  13,  -17, 	  -1,  -14
+.2byte   -1,  -18, 	 -15,  -17, 	  13,  -17, 	  -1,  -14
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+.2byte    5,  -15, 	   8,   -7, 	  -9,   -8, 	   0,  -11
+.2byte    5,  -15, 	   7,  -11, 	  -1,   -7, 	   0,  -11
+.2byte   -1,  -17, 	   7,  -22, 	 -15,  -14, 	  -2,  -14
+.2byte   -1,  -17, 	   7,  -22, 	 -15,  -14, 	  -2,  -14
+.2byte    3,  -13, 	   8,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    3,  -13, 	   8,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    3,  -13, 	   8,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    8,  -17, 	   7,  -11, 	  -4,   -7, 	   0,  -12
+.2byte    8,  -17, 	  -7,  -11, 	   4,   -9, 	  -2,  -11
+.2byte    2,  -19, 	  -2,  -23, 	  -7,  -19, 	  -3,  -15
+.2byte    2,  -19, 	  -2,  -23, 	  -7,  -19, 	  -3,  -15
+.2byte    3,  -12, 	   9,  -18, 	   8,  -15, 	  -1,  -12
+.2byte    3,  -12, 	   9,  -18, 	   8,  -15, 	  -1,  -12
+.2byte    3,  -12, 	   9,  -18, 	   8,  -15, 	  -1,  -12
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    5,  -17, 	   0,  -14, 	   3,   -6, 	  -2,  -13
+.2byte    5,  -17, 	  -6,  -12, 	   6,  -11, 	  -2,  -12
+.2byte    3,  -18, 	  -8,  -21, 	   4,  -14, 	   0,  -13
+.2byte    3,  -18, 	  -8,  -21, 	   4,  -14, 	   0,  -13
+.2byte    3,  -18, 	   0,  -22, 	   8,  -19, 	  -2,  -14
+.2byte    3,  -18, 	   0,  -22, 	   8,  -19, 	  -2,  -14
+.2byte    3,  -18, 	   0,  -22, 	   8,  -19, 	  -2,  -14
+.2byte   -1,  -20, 	   8,  -12, 	 -10,  -12, 	  -1,  -14
+.2byte   -1,  -18, 	   7,  -14, 	 -10,   -9, 	  -1,  -13
+.2byte   -1,  -18, 	   8,   -9, 	  -9,  -14, 	  -1,  -13
+.2byte   -1,  -21, 	  12,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -21, 	  12,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte    0,  -21, 	   6,  -22, 	  -6,  -22, 	   0,  -16
+.2byte    0,  -21, 	   6,  -22, 	  -6,  -22, 	   0,  -16
+.2byte    0,  -21, 	   6,  -22, 	  -6,  -22, 	   0,  -16
+.2byte   -6,  -19, 	   3,  -15, 	  -9,  -10, 	   0,  -13
+.2byte   -7,  -17, 	  -2,  -14, 	  -5,   -6, 	   0,  -13
+.2byte   -7,  -17, 	   4,  -12, 	  -8,  -11, 	   0,  -12
+.2byte   -5,  -18, 	   6,  -21, 	  -6,  -14, 	  -2,  -13
+.2byte   -5,  -18, 	   6,  -21, 	  -6,  -14, 	  -2,  -13
+.2byte   -5,  -18, 	  -2,  -22, 	 -10,  -19, 	   0,  -14
+.2byte   -5,  -18, 	  -2,  -22, 	 -10,  -19, 	   0,  -14
+.2byte   -5,  -18, 	  -2,  -22, 	 -10,  -19, 	   0,  -14
+.2byte   -9,  -19, 	  -6,  -14, 	  -3,   -8, 	   0,  -12
+.2byte  -10,  -17, 	  -9,  -11, 	   2,   -7, 	  -2,  -12
+.2byte  -10,  -17, 	   5,  -11, 	  -6,   -9, 	   0,  -11
+.2byte   -4,  -19, 	   0,  -23, 	   5,  -19, 	   1,  -15
+.2byte   -4,  -19, 	   0,  -23, 	   5,  -19, 	   1,  -15
+.2byte   -5,  -12, 	 -11,  -18, 	 -10,  -15, 	  -1,  -12
+.2byte   -5,  -12, 	 -11,  -18, 	 -10,  -15, 	  -1,  -12
+.2byte   -5,  -12, 	 -11,  -18, 	 -10,  -15, 	  -1,  -12
+.2byte   -6,  -17, 	  -9,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -7,  -15, 	 -10,   -7, 	   7,   -8, 	  -2,  -11
+.2byte   -7,  -15, 	  -9,  -11, 	  -1,   -7, 	  -2,  -11
+.2byte   -1,  -17, 	  -9,  -22, 	  13,  -14, 	   0,  -14
+.2byte   -1,  -17, 	  -9,  -22, 	  13,  -14, 	   0,  -14
+.2byte   -5,  -13, 	 -10,  -14, 	  -6,  -10, 	  -1,  -11
+.2byte   -5,  -13, 	 -10,  -14, 	  -6,  -10, 	  -1,  -11
+.2byte   -5,  -13, 	 -10,  -14, 	  -6,  -10, 	  -1,  -11
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -7,   -7, 	   8,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	 -10,   -9, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -18, 	 -15,  -17, 	  13,  -17, 	  -1,  -14
+.2byte   -1,  -18, 	 -15,  -17, 	  13,  -17, 	  -1,  -14
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+.2byte    5,  -15, 	   8,   -7, 	  -9,   -8, 	   0,  -11
+.2byte    5,  -15, 	   7,  -11, 	  -1,   -7, 	   0,  -11
+.2byte    1,  -17, 	   9,  -22, 	 -13,  -14, 	   0,  -14
+.2byte    1,  -17, 	   9,  -22, 	 -13,  -14, 	   0,  -14
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    8,  -17, 	   7,  -11, 	  -4,   -7, 	   0,  -12
+.2byte    8,  -17, 	  -7,  -11, 	   4,   -9, 	  -2,  -11
+.2byte    6,  -19, 	   2,  -23, 	  -3,  -19, 	   1,  -15
+.2byte    6,  -19, 	   2,  -23, 	  -3,  -19, 	   1,  -15
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    5,  -17, 	   0,  -14, 	   3,   -6, 	  -2,  -13
+.2byte    5,  -17, 	  -6,  -12, 	   6,  -11, 	  -2,  -12
+.2byte    3,  -18, 	  -8,  -21, 	   4,  -14, 	   0,  -13
+.2byte    3,  -18, 	  -8,  -21, 	   4,  -14, 	   0,  -13
+.2byte   -1,  -20, 	   8,  -12, 	 -10,  -12, 	  -1,  -14
+.2byte   -1,  -18, 	   7,  -14, 	 -10,   -9, 	  -1,  -13
+.2byte   -1,  -18, 	   8,   -9, 	  -9,  -14, 	  -1,  -13
+.2byte   -1,  -21, 	  12,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -1,  -21, 	  12,  -18, 	 -14,  -18, 	  -1,  -14
+.2byte   -6,  -19, 	   3,  -15, 	  -9,  -10, 	   0,  -13
+.2byte   -7,  -17, 	  -2,  -14, 	  -5,   -6, 	   0,  -13
+.2byte   -7,  -17, 	   4,  -12, 	  -8,  -11, 	   0,  -12
+.2byte   -5,  -18, 	   6,  -21, 	  -6,  -14, 	  -2,  -13
+.2byte   -5,  -18, 	   6,  -21, 	  -6,  -14, 	  -2,  -13
+.2byte   -9,  -19, 	  -6,  -14, 	  -3,   -8, 	   0,  -12
+.2byte  -10,  -17, 	  -9,  -11, 	   2,   -7, 	  -2,  -12
+.2byte  -10,  -17, 	   5,  -11, 	  -6,   -9, 	   0,  -11
+.2byte   -8,  -19, 	  -4,  -23, 	   1,  -19, 	  -3,  -15
+.2byte   -8,  -19, 	  -4,  -23, 	   1,  -19, 	  -3,  -15
+.2byte   -6,  -17, 	  -9,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -7,  -15, 	 -10,   -7, 	   7,   -8, 	  -2,  -11
+.2byte   -7,  -15, 	  -9,  -11, 	  -1,   -7, 	  -2,  -11
+.2byte   -3,  -17, 	 -11,  -22, 	  11,  -14, 	  -2,  -14
+.2byte   -3,  -17, 	 -11,  -22, 	  11,  -14, 	  -2,  -14
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -7,   -7, 	   8,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	 -10,   -9, 	   5,   -8, 	  -1,  -12
+.2byte   -2,  -18, 	 -13,  -18, 	   9,  -18, 	  -2,  -15
+.2byte   -2,  -19, 	 -14,  -14, 	  10,  -14, 	  -2,  -16
+.2byte   -2,  -19, 	 -14,  -14, 	  10,  -14, 	  -2,  -16
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+.2byte    5,  -15, 	   8,   -7, 	  -9,   -8, 	   0,  -11
+.2byte    5,  -15, 	   7,  -11, 	  -1,   -7, 	   0,  -11
+.2byte    2,  -18, 	   6,  -18, 	  -7,  -16, 	   0,  -15
+.2byte    3,  -18, 	   8,  -16, 	  -9,  -11, 	   1,  -14
+.2byte    3,  -18, 	   8,  -16, 	  -9,  -11, 	   1,  -14
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    8,  -17, 	   7,  -11, 	  -4,   -7, 	   0,  -12
+.2byte    8,  -17, 	  -7,  -11, 	   4,   -9, 	  -2,  -11
+.2byte    3,  -18, 	  -1,  -18, 	  -5,  -14, 	  -4,  -14
+.2byte    2,  -18, 	  -1,  -13, 	  -7,  -11, 	  -2,  -14
+.2byte    2,  -18, 	  -1,  -13, 	  -7,  -11, 	  -2,  -14
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    5,  -17, 	   0,  -14, 	   3,   -6, 	  -2,  -13
+.2byte    5,  -17, 	  -6,  -12, 	   6,  -11, 	  -2,  -12
+.2byte    2,  -19, 	  -7,  -21, 	   4,  -14, 	  -2,  -15
+.2byte    4,  -19, 	  -8,  -18, 	   3,  -10, 	  -1,  -15
+.2byte    4,  -19, 	  -8,  -18, 	   3,  -10, 	  -1,  -15
+.2byte   -1,  -20, 	   8,  -12, 	 -10,  -12, 	  -1,  -14
+.2byte   -1,  -18, 	   7,  -14, 	 -10,   -9, 	  -1,  -13
+.2byte   -1,  -18, 	   8,   -9, 	  -9,  -14, 	  -1,  -13
+.2byte    0,  -22, 	  10,  -19, 	 -10,  -19, 	   0,  -16
+.2byte    0,  -24, 	  14,  -15, 	 -14,  -15, 	   0,  -17
+.2byte    0,  -24, 	  14,  -15, 	 -14,  -15, 	   0,  -17
+.2byte   -6,  -19, 	   3,  -15, 	  -9,  -10, 	   0,  -13
+.2byte   -7,  -17, 	  -2,  -14, 	  -5,   -6, 	   0,  -13
+.2byte   -7,  -17, 	   4,  -12, 	  -8,  -11, 	   0,  -12
+.2byte   -4,  -19, 	   5,  -21, 	  -6,  -14, 	   0,  -15
+.2byte   -6,  -19, 	   6,  -18, 	  -5,  -10, 	  -1,  -15
+.2byte   -6,  -19, 	   6,  -18, 	  -5,  -10, 	  -1,  -15
+.2byte   -9,  -19, 	  -6,  -14, 	  -3,   -8, 	   0,  -12
+.2byte  -10,  -17, 	  -9,  -11, 	   2,   -7, 	  -2,  -12
+.2byte  -10,  -17, 	   5,  -11, 	  -6,   -9, 	   0,  -11
+.2byte   -5,  -18, 	  -1,  -18, 	   3,  -14, 	   2,  -14
+.2byte   -4,  -18, 	  -1,  -13, 	   5,  -11, 	   0,  -14
+.2byte   -4,  -18, 	  -1,  -13, 	   5,  -11, 	   0,  -14
+.2byte   -6,  -17, 	  -9,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -7,  -15, 	 -10,   -7, 	   7,   -8, 	  -2,  -11
+.2byte   -7,  -15, 	  -9,  -11, 	  -1,   -7, 	  -2,  -11
+.2byte   -4,  -18, 	  -8,  -18, 	   5,  -16, 	  -2,  -15
+.2byte   -5,  -18, 	 -10,  -16, 	   7,  -11, 	  -3,  -14
+.2byte   -5,  -18, 	 -10,  -16, 	   7,  -11, 	  -3,  -14
+.2byte    4,   -6, 	  -3,   -8, 	  11,   -6, 	   0,   -4
+.2byte    5,   -7, 	  -3,   -9, 	  13,   -6, 	   1,   -4
+.2byte   -1,  -14, 	   2,  -14, 	  -4,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -3,  -16, 	   2,  -17, 	  -1,  -12
+.2byte    2,  -15, 	   3,  -15, 	   5,  -18, 	  -1,   -9
+.2byte    4,  -17, 	   7,  -17, 	   2,  -19, 	  -1,  -13
+.2byte    0,  -18, 	  -3,  -16, 	   3,  -16, 	   0,  -13
+.2byte   -5,  -17, 	  -8,  -17, 	  -3,  -19, 	   0,  -13
+.2byte   -3,  -16, 	  -4,  -16, 	  -6,  -19, 	   0,  -10
+.2byte    0,  -17, 	   2,  -17, 	  -3,  -18, 	   0,  -13
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+.2byte    5,  -15, 	   7,  -11, 	  -4,   -7, 	   1,  -12
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    8,  -16, 	   4,  -14, 	   2,   -7, 	   0,  -12
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    3,  -18, 	  -2,  -14, 	   6,   -9, 	  -2,  -13
+.2byte   -1,  -20, 	   8,  -12, 	 -10,  -12, 	  -1,  -14
+.2byte   -1,  -20, 	   7,  -12, 	  -8,  -12, 	  -1,  -13
+.2byte   -5,  -19, 	   4,  -15, 	  -8,  -10, 	   1,  -13
+.2byte   -4,  -18, 	   1,  -14, 	  -7,   -9, 	   1,  -13
+.2byte   -8,  -19, 	  -5,  -14, 	  -2,   -8, 	   1,  -12
+.2byte   -9,  -16, 	  -5,  -14, 	  -3,   -7, 	  -1,  -12
+.2byte   -5,  -17, 	  -8,  -10, 	   4,   -8, 	  -1,  -12
+.2byte   -6,  -15, 	  -8,  -11, 	   3,   -7, 	  -2,  -12
+.2byte   -1,  -19, 	 -13,  -14, 	  11,  -14, 	  -1,  -16
+.2byte   -3,  -19, 	  -8,  -17, 	   9,  -12, 	  -1,  -15
+.2byte   -4,  -18, 	  -1,  -13, 	   5,  -11, 	   0,  -14
+.2byte   -6,  -19, 	   6,  -18, 	  -5,  -10, 	  -1,  -15
+.2byte   -1,  -23, 	  13,  -14, 	 -15,  -14, 	  -1,  -16
+.2byte    5,  -19, 	  -7,  -18, 	   4,  -10, 	   0,  -15
+.2byte    3,  -18, 	   0,  -13, 	  -6,  -11, 	  -1,  -14
+.2byte    2,  -19, 	   7,  -17, 	 -10,  -12, 	   0,  -15
+.2byte   -1,  -18, 	 -15,  -17, 	  13,  -17, 	  -1,  -14
+.2byte    1,  -17, 	   9,  -22, 	 -13,  -14, 	   0,  -14
+.2byte    3,  -19, 	  -1,  -23, 	  -6,  -19, 	  -2,  -15
+.2byte    4,  -18, 	  -7,  -21, 	   5,  -14, 	   1,  -13
+.2byte    0,  -20, 	  13,  -17, 	 -13,  -17, 	   0,  -13
+.2byte   -5,  -18, 	   6,  -21, 	  -6,  -14, 	  -2,  -13
+.2byte   -4,  -19, 	   0,  -23, 	   5,  -19, 	   1,  -15
+.2byte   -2,  -17, 	 -10,  -22, 	  12,  -14, 	  -1,  -14
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -1,  -18, 	 -15,  -17, 	  13,  -17, 	  -1,  -14
+.2byte   -1,  -11, 	  -5,   -8, 	   3,   -8, 	  -1,  -13
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+.2byte    0,  -17, 	   8,  -22, 	 -14,  -14, 	  -1,  -14
+.2byte    3,  -15, 	   8,  -16, 	   4,  -12, 	  -1,  -13
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    5,  -19, 	   1,  -23, 	  -4,  -19, 	   0,  -15
+.2byte    2,  -13, 	   8,  -19, 	   7,  -16, 	  -2,  -13
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    4,  -18, 	  -7,  -21, 	   5,  -14, 	   1,  -13
+.2byte    3,  -20, 	   0,  -24, 	   8,  -21, 	  -2,  -16
+.2byte   -1,  -20, 	   8,  -12, 	 -10,  -12, 	  -1,  -14
+.2byte   -1,  -20, 	  12,  -17, 	 -14,  -17, 	  -1,  -13
+.2byte    0,  -22, 	   6,  -23, 	  -6,  -23, 	   0,  -17
+.2byte   -5,  -19, 	   4,  -15, 	  -8,  -10, 	   1,  -13
+.2byte   -5,  -18, 	   6,  -21, 	  -6,  -14, 	  -2,  -13
+.2byte   -4,  -20, 	  -1,  -24, 	  -9,  -21, 	   1,  -16
+.2byte   -8,  -19, 	  -5,  -14, 	  -2,   -8, 	   1,  -12
+.2byte   -6,  -19, 	  -2,  -23, 	   3,  -19, 	  -1,  -15
+.2byte   -3,  -13, 	  -9,  -19, 	  -8,  -16, 	   1,  -13
+.2byte   -5,  -17, 	  -8,  -10, 	   4,   -8, 	  -1,  -12
+.2byte   -1,  -17, 	  -9,  -22, 	  13,  -14, 	   0,  -14
+.2byte   -4,  -15, 	  -9,  -16, 	  -5,  -12, 	   0,  -13
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte   -5,  -13, 	 -10,  -14, 	  -6,  -10, 	  -1,  -11
+.2byte   -5,  -12, 	 -11,  -18, 	 -10,  -15, 	  -1,  -12
+.2byte   -4,  -17, 	  -1,  -21, 	  -9,  -18, 	   1,  -13
+.2byte    0,  -20, 	   6,  -21, 	  -6,  -21, 	   0,  -15
+.2byte    3,  -17, 	   0,  -21, 	   8,  -18, 	  -2,  -13
+.2byte    4,  -12, 	  10,  -18, 	   9,  -15, 	   0,  -12
+.2byte    4,  -13, 	   9,  -14, 	   5,  -10, 	   0,  -11
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -13
+.2byte   -6,  -17, 	  -9,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -9,  -19, 	  -6,  -14, 	  -3,   -8, 	   0,  -12
+.2byte   -6,  -19, 	   3,  -15, 	  -9,  -10, 	   0,  -13
+.2byte   -1,  -19, 	   8,  -11, 	 -10,  -11, 	  -1,  -13
+.2byte    4,  -19, 	  -5,  -15, 	   7,  -10, 	  -2,  -13
+.2byte    7,  -19, 	   4,  -14, 	   1,   -8, 	  -2,  -12
+.2byte    4,  -17, 	   7,  -10, 	  -5,   -8, 	   0,  -12
+sBlazikenAnimTable1:
+.4byte sBlazikenAnims_1_1
+.4byte sBlazikenAnims_1_2
+.4byte sBlazikenAnims_1_3
+.4byte sBlazikenAnims_1_4
+.4byte sBlazikenAnims_1_5
+.4byte sBlazikenAnims_1_6
+.4byte sBlazikenAnims_1_7
+.4byte sBlazikenAnims_1_8
+sBlazikenAnimTable2:
+.4byte sBlazikenAnims_2_1
+.4byte sBlazikenAnims_2_2
+.4byte sBlazikenAnims_2_3
+.4byte sBlazikenAnims_2_4
+.4byte sBlazikenAnims_2_5
+.4byte sBlazikenAnims_2_6
+.4byte sBlazikenAnims_2_7
+.4byte sBlazikenAnims_2_8
+sBlazikenAnimTable3:
+.4byte sBlazikenAnims_3_1
+.4byte sBlazikenAnims_3_2
+.4byte sBlazikenAnims_3_3
+.4byte sBlazikenAnims_3_4
+.4byte sBlazikenAnims_3_5
+.4byte sBlazikenAnims_3_6
+.4byte sBlazikenAnims_3_7
+.4byte sBlazikenAnims_3_8
+sBlazikenAnimTable4:
+.4byte sBlazikenAnims_4_1
+.4byte sBlazikenAnims_4_2
+.4byte sBlazikenAnims_4_3
+.4byte sBlazikenAnims_4_4
+.4byte sBlazikenAnims_4_5
+.4byte sBlazikenAnims_4_6
+.4byte sBlazikenAnims_4_7
+.4byte sBlazikenAnims_4_8
+sBlazikenAnimTable5:
+.4byte sBlazikenAnims_5_1
+.4byte sBlazikenAnims_5_2
+.4byte sBlazikenAnims_5_3
+.4byte sBlazikenAnims_5_4
+.4byte sBlazikenAnims_5_5
+.4byte sBlazikenAnims_5_6
+.4byte sBlazikenAnims_5_7
+.4byte sBlazikenAnims_5_8
+sBlazikenAnimTable6:
+.4byte sBlazikenAnims_6_1
+.4byte sBlazikenAnims_6_1
+.4byte sBlazikenAnims_6_1
+.4byte sBlazikenAnims_6_1
+.4byte sBlazikenAnims_6_1
+.4byte sBlazikenAnims_6_1
+.4byte sBlazikenAnims_6_1
+.4byte sBlazikenAnims_6_1
+sBlazikenAnimTable7:
+.4byte sBlazikenAnims_7_1
+.4byte sBlazikenAnims_7_2
+.4byte sBlazikenAnims_7_3
+.4byte sBlazikenAnims_7_4
+.4byte sBlazikenAnims_7_5
+.4byte sBlazikenAnims_7_6
+.4byte sBlazikenAnims_7_7
+.4byte sBlazikenAnims_7_8
+sBlazikenAnimTable8:
+.4byte sBlazikenAnims_8_1
+.4byte sBlazikenAnims_8_2
+.4byte sBlazikenAnims_8_3
+.4byte sBlazikenAnims_8_4
+.4byte sBlazikenAnims_8_5
+.4byte sBlazikenAnims_8_6
+.4byte sBlazikenAnims_8_7
+.4byte sBlazikenAnims_8_8
+sBlazikenAnimTable9:
+.4byte sBlazikenAnims_9_1
+.4byte sBlazikenAnims_9_2
+.4byte sBlazikenAnims_9_3
+.4byte sBlazikenAnims_9_4
+.4byte sBlazikenAnims_9_5
+.4byte sBlazikenAnims_9_6
+.4byte sBlazikenAnims_9_7
+.4byte sBlazikenAnims_9_8
+sBlazikenAnimTable10:
+.4byte sBlazikenAnims_10_1
+.4byte sBlazikenAnims_10_2
+.4byte sBlazikenAnims_10_3
+.4byte sBlazikenAnims_10_4
+.4byte sBlazikenAnims_10_5
+.4byte sBlazikenAnims_10_6
+.4byte sBlazikenAnims_10_7
+.4byte sBlazikenAnims_10_8
+sBlazikenAnimTable11:
+.4byte sBlazikenAnims_11_1
+.4byte sBlazikenAnims_11_2
+.4byte sBlazikenAnims_11_3
+.4byte sBlazikenAnims_11_4
+.4byte sBlazikenAnims_11_5
+.4byte sBlazikenAnims_11_6
+.4byte sBlazikenAnims_11_7
+.4byte sBlazikenAnims_11_8
+sBlazikenAnimTable12:
+.4byte sBlazikenAnims_12_1
+.4byte sBlazikenAnims_12_2
+.4byte sBlazikenAnims_12_3
+.4byte sBlazikenAnims_12_4
+.4byte sBlazikenAnims_12_5
+.4byte sBlazikenAnims_12_6
+.4byte sBlazikenAnims_12_7
+.4byte sBlazikenAnims_12_8
+sBlazikenAnimTable13:
+.4byte sBlazikenAnims_13_1
+.4byte sBlazikenAnims_13_2
+.4byte sBlazikenAnims_13_3
+.4byte sBlazikenAnims_13_4
+.4byte sBlazikenAnims_13_5
+.4byte sBlazikenAnims_13_6
+.4byte sBlazikenAnims_13_7
+.4byte sBlazikenAnims_13_8
+sAxAnimationsBlaziken:
+.4byte sBlazikenAnimTable1
+.4byte sBlazikenAnimTable2
+.4byte sBlazikenAnimTable3
+.4byte sBlazikenAnimTable4
+.4byte sBlazikenAnimTable5
+.4byte sBlazikenAnimTable6
+.4byte sBlazikenAnimTable7
+.4byte sBlazikenAnimTable8
+.4byte sBlazikenAnimTable9
+.4byte sBlazikenAnimTable10
+.4byte sBlazikenAnimTable11
+.4byte sBlazikenAnimTable12
+.4byte sBlazikenAnimTable13
+sAxSpritesBlaziken:
+.4byte sBlazikenSprites1
+.4byte sBlazikenSprites2
+.4byte sBlazikenSprites3
+.4byte sBlazikenSprites4
+.4byte sBlazikenSprites5
+.4byte sBlazikenSprites6
+.4byte sBlazikenSprites7
+.4byte sBlazikenSprites8
+.4byte sBlazikenSprites9
+.4byte sBlazikenSprites10
+.4byte sBlazikenSprites11
+.4byte sBlazikenSprites12
+.4byte sBlazikenSprites13
+.4byte sBlazikenSprites14
+.4byte sBlazikenSprites15
+.4byte sBlazikenSprites16
+.4byte sBlazikenSprites17
+.4byte sBlazikenSprites18
+.4byte sBlazikenSprites19
+.4byte sBlazikenSprites20
+.4byte sBlazikenSprites21
+.4byte sBlazikenSprites22
+.4byte sBlazikenSprites23
+.4byte sBlazikenSprites24
+.4byte sBlazikenSprites25
+.4byte sBlazikenSprites26
+.4byte sBlazikenSprites27
+.4byte sBlazikenSprites28
+.4byte sBlazikenSprites29
+.4byte sBlazikenSprites30
+.4byte sBlazikenSprites31
+.4byte sBlazikenSprites32
+.4byte sBlazikenSprites33
+.4byte sBlazikenSprites34
+.4byte sBlazikenSprites35
+.4byte sBlazikenSprites36
+.4byte sBlazikenSprites37
+.4byte sBlazikenSprites38
+.4byte sBlazikenSprites39
+.4byte sBlazikenSprites40
+.4byte sBlazikenSprites41
+.4byte sBlazikenSprites42
+.4byte sBlazikenSprites43
+.4byte sBlazikenSprites44
+.4byte sBlazikenSprites45
+.4byte sBlazikenSprites46
+.4byte sBlazikenSprites47
+.4byte sBlazikenSprites48
+.4byte sBlazikenSprites49
+.4byte sBlazikenSprites50
+.4byte sBlazikenSprites51
+.4byte sBlazikenSprites52
+.4byte sBlazikenSprites53
+.4byte sBlazikenSprites54
+.4byte sBlazikenSprites55
+.4byte sBlazikenSprites56
+.4byte sBlazikenSprites57
+.4byte sBlazikenSprites58
+.4byte sBlazikenSprites59
+.4byte sBlazikenSprites60
+.4byte sBlazikenSprites61
+.4byte sBlazikenSprites62
+.4byte sBlazikenSprites63
+.4byte sBlazikenSprites64
+.4byte sBlazikenSprites65
+.4byte sBlazikenSprites66
+.4byte sBlazikenSprites67
+.4byte sBlazikenSprites68
+.4byte sBlazikenSprites69
+.4byte sBlazikenSprites70
+.4byte sBlazikenSprites71
+.4byte sBlazikenSprites72
+.4byte sBlazikenSprites73
+.4byte sBlazikenSprites74
+.4byte sBlazikenSprites75
+sAxMainBlaziken:
+ax_main sAxPosesBlaziken, sAxAnimationsBlaziken, 13, sAxSpritesBlaziken, sAxPositionsBlaziken

--- a/data/ax/blissey.inc
+++ b/data/ax/blissey.inc
@@ -1,0 +1,2944 @@
+.global gAxBlissey
+gAxBlissey:
+ax_siro sAxMainBlissey
+sBlisseyPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose3:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose4:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose5:
+ax_pose 4, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose7:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose8:
+ax_pose 7, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose9:
+ax_pose 8, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose10:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose11:
+ax_pose 10, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose12:
+ax_pose 11, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose16:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose17:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose18:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose22:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose23:
+ax_pose 4, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose25:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose27:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose28:
+ax_pose 15, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose29:
+ax_pose 16, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose30:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose31:
+ax_pose 4, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose32:
+ax_pose 5, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose33:
+ax_pose 17, 0x01e5, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose34:
+ax_pose 18, 0x01e7, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose35:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose36:
+ax_pose 7, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose37:
+ax_pose 8, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose38:
+ax_pose 19, 0x01e6, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose39:
+ax_pose 20, 0x01e6, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose40:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose41:
+ax_pose 10, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose42:
+ax_pose 11, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose43:
+ax_pose 21, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose44:
+ax_pose 22, 0x01e8, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose45:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose46:
+ax_pose 13, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose47:
+ax_pose 14, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose48:
+ax_pose 23, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose49:
+ax_pose 24, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose50:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose51:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose52:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose53:
+ax_pose 21, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose54:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose55:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose56:
+ax_pose 7, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose57:
+ax_pose 8, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose58:
+ax_pose 19, 0x01e6, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose59:
+ax_pose 20, 0x01e6, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose60:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose61:
+ax_pose 4, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose62:
+ax_pose 5, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose63:
+ax_pose 17, 0x01e5, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose64:
+ax_pose 18, 0x01e7, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose65:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose66:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose67:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose68:
+ax_pose 15, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose69:
+ax_pose 16, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose70:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose71:
+ax_pose 4, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose72:
+ax_pose 5, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose73:
+ax_pose 17, 0x01e5, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose74:
+ax_pose 18, 0x01e7, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose75:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose76:
+ax_pose 7, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose77:
+ax_pose 8, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose78:
+ax_pose 19, 0x01e6, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose79:
+ax_pose 20, 0x01e6, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose80:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose81:
+ax_pose 10, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose82:
+ax_pose 11, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose83:
+ax_pose 21, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose84:
+ax_pose 22, 0x01e8, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose85:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose86:
+ax_pose 13, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose87:
+ax_pose 14, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose88:
+ax_pose 23, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose89:
+ax_pose 24, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose90:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose91:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose92:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose93:
+ax_pose 21, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose94:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose95:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose96:
+ax_pose 7, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose97:
+ax_pose 8, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose98:
+ax_pose 19, 0x01e6, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose99:
+ax_pose 20, 0x01e6, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose100:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose101:
+ax_pose 4, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose102:
+ax_pose 5, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose103:
+ax_pose 17, 0x01e5, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose104:
+ax_pose 18, 0x01e7, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose105:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose106:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose107:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose108:
+ax_pose 15, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose109:
+ax_pose 16, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose110:
+ax_pose 25, 0x01e2, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose111:
+ax_pose 26, 0x01e2, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose112:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose113:
+ax_pose 4, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose114:
+ax_pose 5, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose115:
+ax_pose 17, 0x01e6, 0x90f1, 0xac00
+ax_pose_terminator
+sBlisseyPose116:
+ax_pose 18, 0x01e7, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose117:
+ax_pose 27, 0x01e0, 0x90ed, 0xac00
+ax_pose 28, 0x0200, 0x10f9, 0xac10
+ax_pose_terminator
+sBlisseyPose118:
+ax_pose 29, 0x01e3, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose119:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose120:
+ax_pose 7, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose121:
+ax_pose 8, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose122:
+ax_pose 19, 0x01e6, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose123:
+ax_pose 20, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose124:
+ax_pose 30, 0x81e2, 0x90f0, 0xac00
+ax_pose 31, 0x81e2, 0x5100, 0xac08
+ax_pose 32, 0x81f2, 0x1108, 0xac0c
+ax_pose 33, 0x01ea, 0x1108, 0xac0e
+ax_pose 34, 0x0202, 0x10fc, 0xac0f
+ax_pose_terminator
+sBlisseyPose125:
+ax_pose 35, 0x01e3, 0x90f0, 0xac00
+ax_pose 36, 0x01ed, 0x10e8, 0xac10
+ax_pose_terminator
+sBlisseyPose126:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose127:
+ax_pose 10, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose128:
+ax_pose 11, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose129:
+ax_pose 21, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose130:
+ax_pose 22, 0x01e8, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose131:
+ax_pose 37, 0x01e2, 0x90ed, 0xac00
+ax_pose_terminator
+sBlisseyPose132:
+ax_pose 38, 0x81e1, 0x90ff, 0xac00
+ax_pose 39, 0x81e1, 0x50f7, 0xac08
+ax_pose 40, 0x01e9, 0x10ef, 0xac0c
+ax_pose 41, 0x81f1, 0x10ef, 0xac0d
+ax_pose 42, 0x0201, 0x10ff, 0xac0f
+ax_pose_terminator
+sBlisseyPose133:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose134:
+ax_pose 13, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose135:
+ax_pose 14, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose136:
+ax_pose 23, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose137:
+ax_pose 24, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose138:
+ax_pose 43, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose139:
+ax_pose 44, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose140:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose141:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose142:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose143:
+ax_pose 21, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose144:
+ax_pose 22, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose145:
+ax_pose 37, 0x01e2, 0x80f3, 0xac00
+ax_pose_terminator
+sBlisseyPose146:
+ax_pose 38, 0x81e1, 0x80f1, 0xac00
+ax_pose 39, 0x81e1, 0x4101, 0xac08
+ax_pose 40, 0x01e9, 0x0109, 0xac0c
+ax_pose 41, 0x81f1, 0x0109, 0xac0d
+ax_pose 42, 0x0201, 0x00f9, 0xac0f
+ax_pose_terminator
+sBlisseyPose147:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose148:
+ax_pose 7, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose149:
+ax_pose 8, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose150:
+ax_pose 19, 0x01e6, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose151:
+ax_pose 20, 0x01e8, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose152:
+ax_pose 30, 0x81e2, 0x8100, 0xac00
+ax_pose 31, 0x81e2, 0x40f8, 0xac08
+ax_pose 32, 0x81f2, 0x00f0, 0xac0c
+ax_pose 33, 0x01ea, 0x00f0, 0xac0e
+ax_pose 34, 0x0202, 0x00fc, 0xac0f
+ax_pose_terminator
+sBlisseyPose153:
+ax_pose 35, 0x01e3, 0x80f0, 0xac00
+ax_pose 36, 0x01ed, 0x0110, 0xac10
+ax_pose_terminator
+sBlisseyPose154:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose155:
+ax_pose 4, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose156:
+ax_pose 5, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose157:
+ax_pose 17, 0x01e6, 0x80ef, 0xac00
+ax_pose_terminator
+sBlisseyPose158:
+ax_pose 18, 0x01e7, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose159:
+ax_pose 27, 0x01e0, 0x80f3, 0xac00
+ax_pose 28, 0x0200, 0x00ff, 0xac10
+ax_pose_terminator
+sBlisseyPose160:
+ax_pose 29, 0x01e3, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose161:
+ax_pose 15, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose162:
+ax_pose 16, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose163:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose164:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose165:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose166:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose167:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose168:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose169:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose170:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose171:
+ax_pose 17, 0x01e6, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose172:
+ax_pose 18, 0x01e8, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose173:
+ax_pose 19, 0x01e6, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose174:
+ax_pose 20, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose175:
+ax_pose 21, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose176:
+ax_pose 22, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose177:
+ax_pose 23, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose178:
+ax_pose 24, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose179:
+ax_pose 21, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose180:
+ax_pose 22, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose181:
+ax_pose 19, 0x01e6, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose182:
+ax_pose 20, 0x01e8, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose183:
+ax_pose 17, 0x01e6, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose184:
+ax_pose 18, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose185:
+ax_pose 45, 0x01eb, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose186:
+ax_pose 46, 0x01eb, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose187:
+ax_pose 47, 0x01e0, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose188:
+ax_pose 48, 0x01e0, 0x90ed, 0xac00
+ax_pose_terminator
+sBlisseyPose189:
+ax_pose 49, 0x01e0, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose190:
+ax_pose 50, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose191:
+ax_pose 51, 0x01e0, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose192:
+ax_pose 50, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose193:
+ax_pose 49, 0x01e0, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose194:
+ax_pose 48, 0x01e0, 0x80f3, 0xac00
+ax_pose_terminator
+sBlisseyPose195:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose196:
+ax_pose 15, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose197:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose198:
+ax_pose 17, 0x01e6, 0x90f2, 0xac00
+ax_pose_terminator
+sBlisseyPose199:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose200:
+ax_pose 19, 0x01e6, 0x90f2, 0xac00
+ax_pose_terminator
+sBlisseyPose201:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose202:
+ax_pose 21, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sBlisseyPose203:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose204:
+ax_pose 23, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose205:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose206:
+ax_pose 21, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sBlisseyPose207:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose208:
+ax_pose 19, 0x01e6, 0x80ee, 0xac00
+ax_pose_terminator
+sBlisseyPose209:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose210:
+ax_pose 17, 0x01e6, 0x80ee, 0xac00
+ax_pose_terminator
+sBlisseyPose211:
+ax_pose 16, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose212:
+ax_pose 18, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose213:
+ax_pose 20, 0x01e8, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose214:
+ax_pose 22, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose215:
+ax_pose 24, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose216:
+ax_pose 22, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose217:
+ax_pose 20, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose218:
+ax_pose 18, 0x01e8, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose219:
+ax_pose 16, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose220:
+ax_pose 18, 0x01e8, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose221:
+ax_pose 20, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose222:
+ax_pose 22, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose223:
+ax_pose 24, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose224:
+ax_pose 22, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose225:
+ax_pose 20, 0x01e8, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose226:
+ax_pose 18, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose227:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose228:
+ax_pose 15, 0x01e3, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose229:
+ax_pose 16, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose230:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose231:
+ax_pose 17, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose232:
+ax_pose 18, 0x01e7, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose233:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose234:
+ax_pose 19, 0x01e5, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose235:
+ax_pose 20, 0x01e6, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose236:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose237:
+ax_pose 21, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sBlisseyPose238:
+ax_pose 22, 0x01e8, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose239:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose240:
+ax_pose 23, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose241:
+ax_pose 24, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose242:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose243:
+ax_pose 21, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sBlisseyPose244:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose245:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose246:
+ax_pose 19, 0x01e5, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose247:
+ax_pose 20, 0x01e6, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose248:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose249:
+ax_pose 17, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose250:
+ax_pose 18, 0x01e7, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose251:
+ax_pose 15, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose252:
+ax_pose 17, 0x01e5, 0x80f1, 0xac00
+ax_pose_terminator
+sBlisseyPose253:
+ax_pose 19, 0x01e5, 0x80f2, 0xac00
+ax_pose_terminator
+sBlisseyPose254:
+ax_pose 21, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose255:
+ax_pose 23, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose256:
+ax_pose 21, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose257:
+ax_pose 19, 0x01e5, 0x90ee, 0xac00
+ax_pose_terminator
+sBlisseyPose258:
+ax_pose 17, 0x01e5, 0x90ef, 0xac00
+ax_pose_terminator
+sBlisseyPose259:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose260:
+ax_pose 3, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose261:
+ax_pose 6, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose262:
+ax_pose 9, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sBlisseyPose263:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sBlisseyPose264:
+ax_pose 9, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose265:
+ax_pose 6, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sBlisseyPose266:
+ax_pose 3, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+.align 2
+sBlisseyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_2_1:
+ax_anim 8, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 0, 3, 0, 3,
+ax_anim 1, 2, 28, 0, 9, 0, 9,
+ax_anim 1, 0, 28, 0, 15, 0, 15,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 1, 28, 1, 21, 1, 21,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 0, 28, 1, 21, 1, 21,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 0, 24, 0, 8, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sBlisseyAnims_2_2:
+ax_anim 8, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 3, 3, 3, 3,
+ax_anim 1, 2, 33, 9, 9, 9, 9,
+ax_anim 1, 0, 33, 15, 15, 15, 15,
+ax_anim 2, 0, 33, 21, 21, 21, 21,
+ax_anim 2, 1, 33, 20, 21, 20, 21,
+ax_anim 2, 0, 33, 19, 21, 19, 21,
+ax_anim 2, 0, 33, 20, 21, 20, 21,
+ax_anim 2, 0, 33, 19, 21, 19, 21,
+ax_anim 2, 0, 29, 8, 6, 8, 8,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sBlisseyAnims_2_3:
+ax_anim 8, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 0, 38, 3, 0, 3, 0,
+ax_anim 1, 2, 38, 9, 0, 9, 0,
+ax_anim 1, 0, 38, 14, 0, 14, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, -1, 18, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, -1, 18, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 8, -3, 8, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sBlisseyAnims_2_4:
+ax_anim 8, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 3, -3, 3, -3,
+ax_anim 1, 2, 43, 9, -9, 9, -9,
+ax_anim 1, 0, 43, 15, -15, 15, -15,
+ax_anim 2, 0, 43, 21, -21, 21, -21,
+ax_anim 2, 1, 43, 20, -21, 20, -21,
+ax_anim 2, 0, 43, 19, -21, 19, -21,
+ax_anim 2, 0, 43, 20, -21, 20, -21,
+ax_anim 2, 0, 43, 19, -21, 19, -21,
+ax_anim 2, 0, 39, 8, -10, 8, -8,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sBlisseyAnims_2_5:
+ax_anim 8, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, -3, 0, -3,
+ax_anim 1, 2, 48, 0, -9, 0, -9,
+ax_anim 1, 0, 48, 0, -15, 0, -15,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 1, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 0, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 0, 44, 0, -12, 0, -10,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sBlisseyAnims_2_6:
+ax_anim 8, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 53, -3, -3, -3, -3,
+ax_anim 1, 2, 53, -9, -9, -9, -9,
+ax_anim 1, 0, 53, -15, -15, -15, -15,
+ax_anim 2, 0, 53, -21, -21, -21, -21,
+ax_anim 2, 1, 53, -20, -21, -20, -21,
+ax_anim 2, 0, 53, -19, -21, -19, -21,
+ax_anim 2, 0, 53, -20, -21, -20, -21,
+ax_anim 2, 0, 53, -19, -21, -19, -21,
+ax_anim 2, 0, 49, -8, -10, -8, -8,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sBlisseyAnims_2_7:
+ax_anim 8, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 58, -3, 0, -3, 0,
+ax_anim 1, 2, 58, -9, 0, -9, 0,
+ax_anim 1, 0, 58, -14, 0, -14, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, -1, -18, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, -1, -18, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 54, -8, -3, -8, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sBlisseyAnims_2_8:
+ax_anim 8, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, -3, 3, -3, 3,
+ax_anim 1, 2, 63, -9, 9, -9, 9,
+ax_anim 1, 0, 63, -15, 15, -15, 15,
+ax_anim 2, 0, 63, -21, 21, -21, 21,
+ax_anim 2, 1, 63, -20, 21, -20, 21,
+ax_anim 2, 0, 63, -19, 21, -19, 21,
+ax_anim 2, 0, 63, -20, 21, -20, 21,
+ax_anim 2, 0, 63, -19, 21, -19, 21,
+ax_anim 2, 0, 59, -8, 6, -8, 8,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_3_1:
+ax_anim 8, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 0, 3, 0, 3,
+ax_anim 1, 0, 68, 0, 9, 0, 9,
+ax_anim 1, 2, 68, 0, 15, 0, 15,
+ax_anim 1, 0, 64, 0, 21, 0, 21,
+ax_anim 1, 0, 69, 1, 21, 1, 21,
+ax_anim 3, 1, 74, 2, 21, 2, 21,
+ax_anim 1, 0, 69, 1, 21, 1, 21,
+ax_anim 1, 0, 64, 0, 21, 0, 21,
+ax_anim 1, 0, 99, -1, 21, -1, 21,
+ax_anim 3, 0, 94, -2, 21, -2, 21,
+ax_anim 1, 0, 99, -1, 21, -1, 21,
+ax_anim 1, 0, 64, 0, 21, 0, 21,
+ax_anim 2, 0, 64, 0, 8, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sBlisseyAnims_3_2:
+ax_anim 8, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 3, 3, 3, 3,
+ax_anim 1, 0, 73, 9, 9, 9, 9,
+ax_anim 1, 2, 73, 15, 15, 15, 15,
+ax_anim 1, 0, 69, 21, 21, 21, 21,
+ax_anim 1, 0, 74, 22, 21, 22, 21,
+ax_anim 3, 1, 79, 23, 20, 23, 20,
+ax_anim 1, 0, 74, 22, 21, 22, 21,
+ax_anim 1, 0, 69, 21, 21, 21, 21,
+ax_anim 1, 0, 64, 20, 21, 20, 21,
+ax_anim 3, 0, 99, 19, 20, 19, 20,
+ax_anim 1, 0, 64, 20, 21, 20, 21,
+ax_anim 1, 0, 69, 20, 21, 20, 21,
+ax_anim 2, 0, 69, 8, 6, 8, 8,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sBlisseyAnims_3_3:
+ax_anim 8, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 3, 0, 3, 0,
+ax_anim 1, 0, 78, 9, 0, 9, 0,
+ax_anim 1, 2, 78, 15, 0, 15, 0,
+ax_anim 1, 0, 74, 21, 0, 21, 0,
+ax_anim 1, 0, 79, 21, -1, 21, -1,
+ax_anim 3, 1, 84, 20, -2, 20, -2,
+ax_anim 1, 0, 79, 21, -1, 21, -1,
+ax_anim 1, 0, 74, 21, 0, 21, 0,
+ax_anim 1, 0, 69, 20, 1, 20, 1,
+ax_anim 3, 0, 64, 19, 2, 19, 2,
+ax_anim 1, 0, 69, 20, 1, 20, 1,
+ax_anim 1, 0, 74, 20, 0, 20, 0,
+ax_anim 2, 0, 74, 8, -2, 8, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sBlisseyAnims_3_4:
+ax_anim 8, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 3, -3, 3, -3,
+ax_anim 1, 0, 83, 9, -9, 9, -9,
+ax_anim 1, 2, 83, 15, -15, 15, -15,
+ax_anim 1, 0, 79, 21, -21, 21, -21,
+ax_anim 1, 0, 84, 20, -22, 20, -22,
+ax_anim 3, 1, 89, 19, -22, 19, -22,
+ax_anim 1, 0, 84, 20, -22, 20, -22,
+ax_anim 1, 0, 79, 21, -21, 21, -21,
+ax_anim 1, 0, 74, 21, -20, 21, -20,
+ax_anim 3, 0, 69, 19, -19, 19, -19,
+ax_anim 1, 0, 74, 20, -21, 20, -21,
+ax_anim 1, 0, 79, 20, -21, 20, -21,
+ax_anim 2, 0, 79, 8, -10, 8, -8,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sBlisseyAnims_3_5:
+ax_anim 8, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, -9, 0, -9,
+ax_anim 1, 2, 88, 0, -15, 0, -15,
+ax_anim 1, 0, 84, 0, -21, 0, -21,
+ax_anim 1, 0, 89, -2, -21, -2, -21,
+ax_anim 3, 1, 94, -3, -21, -3, -21,
+ax_anim 1, 0, 89, -2, -21, -2, -21,
+ax_anim 1, 0, 84, 0, -21, 0, -21,
+ax_anim 1, 0, 79, 2, -21, 2, -21,
+ax_anim 3, 0, 74, 3, -21, 3, -21,
+ax_anim 1, 0, 79, 2, -21, 2, -21,
+ax_anim 1, 0, 84, 0, -21, 0, -21,
+ax_anim 2, 0, 84, 0, -10, 0, -8,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sBlisseyAnims_3_6:
+ax_anim 8, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, -3, -3, -3, -3,
+ax_anim 1, 0, 93, -9, -9, -9, -9,
+ax_anim 1, 2, 93, -15, -15, -15, -15,
+ax_anim 1, 0, 89, -21, -21, -21, -21,
+ax_anim 1, 0, 94, -22, -20, -22, -20,
+ax_anim 3, 1, 99, -22, -19, -22, -19,
+ax_anim 1, 0, 94, -22, -20, -22, -20,
+ax_anim 1, 0, 89, -21, -21, -21, -21,
+ax_anim 1, 0, 84, -19, -21, -19, -21,
+ax_anim 3, 0, 79, -17, -21, -17, -21,
+ax_anim 1, 0, 84, -20, -21, -20, -21,
+ax_anim 1, 0, 89, -20, -21, -20, -21,
+ax_anim 2, 0, 89, -8, -10, -8, -8,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sBlisseyAnims_3_7:
+ax_anim 8, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, -3, 0, -3, 0,
+ax_anim 1, 0, 98, -9, 0, -9, 0,
+ax_anim 1, 2, 98, -15, 0, -15, 0,
+ax_anim 1, 0, 94, -21, 0, -21, 0,
+ax_anim 1, 0, 99, -21, 1, -21, 1,
+ax_anim 3, 1, 64, -20, 2, -20, 2,
+ax_anim 1, 0, 99, -21, 1, -21, 1,
+ax_anim 1, 0, 94, -21, 0, -21, 0,
+ax_anim 1, 0, 89, -20, -1, -20, -1,
+ax_anim 3, 0, 84, -19, -2, -19, -2,
+ax_anim 1, 0, 89, -20, -1, -20, -1,
+ax_anim 1, 0, 94, -20, 0, -20, 0,
+ax_anim 2, 0, 94, -8, -2, -8, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sBlisseyAnims_3_8:
+ax_anim 8, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, -3, 3, -3, 3,
+ax_anim 1, 0, 103, -9, 9, -9, 9,
+ax_anim 1, 2, 103, -15, 15, -15, 15,
+ax_anim 1, 0, 99, -21, 21, -21, 21,
+ax_anim 1, 0, 64, -20, 21, -20, 21,
+ax_anim 3, 1, 69, -19, 21, -19, 21,
+ax_anim 1, 0, 64, -20, 21, -20, 21,
+ax_anim 1, 0, 99, -21, 21, -21, 21,
+ax_anim 1, 0, 94, -22, 20, -22, 20,
+ax_anim 3, 0, 89, -21, 19, -21, 19,
+ax_anim 1, 0, 94, -20, 21, -20, 21,
+ax_anim 1, 0, 99, -20, 21, -20, 21,
+ax_anim 2, 0, 99, -8, 6, -8, 8,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_4_1:
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 2, 109, 0, -1, 0, -1,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 2, 0, 2,
+ax_anim 2, 1, 110, 0, 3, 0, 3,
+ax_anim 2, 0, 110, 1, 3, 1, 3,
+ax_anim 2, 0, 110, 0, 3, 0, 3,
+ax_anim 2, 0, 110, 1, 3, 1, 3,
+ax_anim 2, 0, 110, 0, 3, 0, 3,
+ax_anim 2, 0, 110, 1, 3, 1, 3,
+ax_anim 2, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sBlisseyAnims_4_2:
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 2, 116, -1, -1, 0, -1,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 1, 117, 3, 3, 3, 3,
+ax_anim 2, 0, 117, 4, 2, 4, 2,
+ax_anim 2, 0, 117, 3, 3, 3, 3,
+ax_anim 2, 0, 117, 4, 2, 4, 2,
+ax_anim 2, 0, 117, 3, 3, 3, 3,
+ax_anim 2, 0, 117, 4, 2, 4, 2,
+ax_anim 2, 0, 117, 3, 3, 3, 3,
+ax_anim_terminator
+sBlisseyAnims_4_3:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 2, 123, -1, -1, -1, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 2, 0, 2, 0,
+ax_anim 2, 1, 124, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 3, -1, 3, -1,
+ax_anim 2, 0, 124, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 3, -1, 3, -1,
+ax_anim 2, 0, 124, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 3, -1, 3, -1,
+ax_anim 2, 0, 124, 3, 0, 3, 0,
+ax_anim_terminator
+sBlisseyAnims_4_4:
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 2, 130, -1, 1, -1, 1,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 2, -2, 2, -2,
+ax_anim 2, 1, 131, 3, -3, 3, -3,
+ax_anim 2, 0, 131, 4, -2, 4, -2,
+ax_anim 2, 0, 131, 3, -3, 3, -3,
+ax_anim 2, 0, 131, 4, -2, 4, -2,
+ax_anim 2, 0, 131, 3, -3, 3, -3,
+ax_anim 2, 0, 131, 4, -2, 4, -2,
+ax_anim 2, 0, 131, 3, -3, 3, -3,
+ax_anim_terminator
+sBlisseyAnims_4_5:
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 6, 2, 137, 0, 1, 0, 1,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, -2, 0, -2,
+ax_anim 2, 1, 138, 0, -3, 0, -3,
+ax_anim 2, 0, 138, 1, -3, 1, -3,
+ax_anim 2, 0, 138, 0, -3, 0, -3,
+ax_anim 2, 0, 138, 1, -3, 1, -3,
+ax_anim 2, 0, 138, 0, -3, 0, -3,
+ax_anim 2, 0, 138, 1, -3, 1, -3,
+ax_anim 2, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sBlisseyAnims_4_6:
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 2, 144, 1, 1, 1, 1,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 145, -2, -2, -2, -2,
+ax_anim 2, 1, 145, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -4, -2, -4, -2,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -4, -2, -4, -2,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -4, -2, -4, -2,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim_terminator
+sBlisseyAnims_4_7:
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 2, 151, 1, -1, 1, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -2, 0, -2, 0,
+ax_anim 2, 1, 152, -3, 0, -3, 0,
+ax_anim 2, 0, 152, -3, -1, -3, -1,
+ax_anim 2, 0, 152, -3, 0, -3, 0,
+ax_anim 2, 0, 152, -3, -1, -3, -1,
+ax_anim 2, 0, 152, -3, 0, -3, 0,
+ax_anim 2, 0, 152, -3, -1, -3, -1,
+ax_anim 2, 0, 152, -3, 0, -3, 0,
+ax_anim_terminator
+sBlisseyAnims_4_8:
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 2, 158, 1, -1, 0, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -2, 2, -2, 2,
+ax_anim 2, 1, 159, -3, 3, -3, 3,
+ax_anim 2, 0, 159, -4, 2, -4, 2,
+ax_anim 2, 0, 159, -3, 3, -3, 3,
+ax_anim 2, 0, 159, -4, 2, -4, 2,
+ax_anim 2, 0, 159, -3, 3, -3, 3,
+ax_anim 2, 0, 159, -4, 2, -4, 2,
+ax_anim 2, 0, 159, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_5_1:
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -2, 0, 0,
+ax_anim 2, 2, 165, 0, -4, 0, 0,
+ax_anim 2, 0, 166, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -5, 0, 0,
+ax_anim 2, 0, 168, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -4, 0, 0,
+ax_anim 2, 0, 162, 0, -2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_5_2:
+ax_anim 6, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -2, 0, 0,
+ax_anim 2, 2, 164, 0, -4, 0, 0,
+ax_anim 2, 0, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 166, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -5, 0, 0,
+ax_anim 2, 0, 168, 0, -4, 0, 0,
+ax_anim 2, 0, 169, 0, -2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_5_3:
+ax_anim 6, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -2, 0, 0,
+ax_anim 2, 2, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 164, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 166, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 2, 0, 168, 0, -2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_5_4:
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, -2, 0, 0,
+ax_anim 2, 2, 162, 0, -4, 0, 0,
+ax_anim 2, 0, 163, 0, -5, 0, 0,
+ax_anim 2, 0, 164, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_5_5:
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -2, 0, 0,
+ax_anim 2, 2, 169, 0, -4, 0, 0,
+ax_anim 2, 0, 162, 0, -5, 0, 0,
+ax_anim 2, 0, 163, 0, -5, 0, 0,
+ax_anim 2, 0, 164, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim 2, 0, 166, 0, -2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_5_6:
+ax_anim 6, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 2, 2, 168, 0, -4, 0, 0,
+ax_anim 2, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 162, 0, -5, 0, 0,
+ax_anim 2, 0, 163, 0, -5, 0, 0,
+ax_anim 2, 0, 164, 0, -4, 0, 0,
+ax_anim 2, 0, 165, 0, -2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_5_7:
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -2, 0, 0,
+ax_anim 2, 2, 167, 0, -4, 0, 0,
+ax_anim 2, 0, 168, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 162, 0, -5, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 164, 0, -2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_5_8:
+ax_anim 6, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, -2, 0, 0,
+ax_anim 2, 2, 166, 0, -4, 0, 0,
+ax_anim 2, 0, 167, 0, -5, 0, 0,
+ax_anim 2, 0, 168, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 2, 0, 163, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_6_1:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 35, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_7_1:
+ax_anim 2, 0, 186, 0, -4, 0, -4,
+ax_anim 8, 0, 186, 0, -5, 0, -5,
+ax_anim_terminator
+sBlisseyAnims_7_2:
+ax_anim 2, 0, 187, -4, -4, -4, -4,
+ax_anim 8, 0, 187, -5, -5, -5, -5,
+ax_anim_terminator
+sBlisseyAnims_7_3:
+ax_anim 2, 0, 188, -4, 0, -4, 0,
+ax_anim 8, 0, 188, -5, 0, -5, 0,
+ax_anim_terminator
+sBlisseyAnims_7_4:
+ax_anim 2, 0, 189, -4, 4, -4, 4,
+ax_anim 8, 0, 189, -5, 5, -5, 5,
+ax_anim_terminator
+sBlisseyAnims_7_5:
+ax_anim 2, 0, 190, 0, 4, 0, 4,
+ax_anim 8, 0, 190, 0, 5, 0, 5,
+ax_anim_terminator
+sBlisseyAnims_7_6:
+ax_anim 2, 0, 191, 4, 4, 4, 4,
+ax_anim 8, 0, 191, 5, 5, 5, 5,
+ax_anim_terminator
+sBlisseyAnims_7_7:
+ax_anim 2, 0, 192, 4, 0, 4, 0,
+ax_anim 8, 0, 192, 5, 0, 5, 0,
+ax_anim_terminator
+sBlisseyAnims_7_8:
+ax_anim 2, 0, 193, 4, -4, 4, -4,
+ax_anim 8, 0, 193, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_8_1:
+ax_anim 30, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 195, 0, 0, 0, 2,
+ax_anim_terminator
+sBlisseyAnims_8_2:
+ax_anim 30, 0, 196, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 2, 1,
+ax_anim_terminator
+sBlisseyAnims_8_3:
+ax_anim 30, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 199, 0, 0, 4, 0,
+ax_anim_terminator
+sBlisseyAnims_8_4:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 2, -2,
+ax_anim_terminator
+sBlisseyAnims_8_5:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 10, 0, 203, 0, 0, 0, -2,
+ax_anim_terminator
+sBlisseyAnims_8_6:
+ax_anim 30, 0, 204, 0, 0, 0, 0,
+ax_anim 10, 0, 205, 0, 0, -2, -2,
+ax_anim_terminator
+sBlisseyAnims_8_7:
+ax_anim 30, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 207, 0, 0, -4, 0,
+ax_anim_terminator
+sBlisseyAnims_8_8:
+ax_anim 30, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, -2, 1,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 9, 5, 9, 5,
+ax_anim 2, 0, 212, 13, 12, 13, 12,
+ax_anim 2, 0, 213, 10, 18, 10, 18,
+ax_anim 3, 0, 214, 0, 21, 0, 21,
+ax_anim 2, 3, 215, -10, 18, -10, 18,
+ax_anim 2, 0, 216, -13, 12, -13, 12,
+ax_anim 1, 0, 217, -9, 5, -9, 5,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 8, 0, 8, 0,
+ax_anim 2, 0, 211, 17, 3, 17, 3,
+ax_anim 2, 0, 212, 23, 10, 23, 10,
+ax_anim 3, 0, 213, 21, 20, 21, 20,
+ax_anim 2, 3, 214, 10, 20, 10, 20,
+ax_anim 2, 0, 215, 1, 16, 1, 16,
+ax_anim 1, 0, 216, -2, 7, -2, 7,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 5, -3, 5, -3,
+ax_anim 2, 0, 210, 11, -4, 11, -4,
+ax_anim 2, 0, 211, 18, -3, 18, -3,
+ax_anim 3, 0, 212, 22, 2, 22, 2,
+ax_anim 2, 3, 213, 17, 5, 17, 5,
+ax_anim 2, 0, 214, 12, 6, 12, 6,
+ax_anim 1, 0, 215, 5, 5, 5, 5,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, -1, -9, -1, -9,
+ax_anim 2, 0, 217, 5, -16, 5, -16,
+ax_anim 2, 0, 210, 12, -19, 12, -19,
+ax_anim 3, 0, 211, 20, -18, 20, -18,
+ax_anim 2, 3, 212, 24, -13, 24, -13,
+ax_anim 2, 0, 213, 20, -5, 20, -5,
+ax_anim 1, 0, 214, 9, -1, 9, -1,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -10, -4, -10, -4,
+ax_anim 2, 0, 216, -12, -12, -12, -12,
+ax_anim 2, 0, 217, -8, -17, -8, -17,
+ax_anim 3, 0, 210, 0, -20, 0, -20,
+ax_anim 2, 3, 211, 8, -17, 8, -17,
+ax_anim 2, 0, 212, 12, -12, 12, -12,
+ax_anim 1, 0, 213, 10, -4, 10, -4,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 1, -8, 1, -8,
+ax_anim 2, 0, 211, -5, -16, -5, -16,
+ax_anim 2, 0, 210, -12, -19, -12, -19,
+ax_anim 3, 0, 217, -20, -18, -20, -18,
+ax_anim 2, 3, 216, -24, -13, -24, -13,
+ax_anim 2, 0, 215, -20, -5, -20, -5,
+ax_anim 1, 0, 214, -9, -1, -9, -1,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, -5, -3, -5, -3,
+ax_anim 2, 0, 210, -11, -4, -11, -4,
+ax_anim 2, 0, 217, -18, -3, -18, -3,
+ax_anim 3, 0, 216, -22, 2, -22, 2,
+ax_anim 2, 3, 215, -17, 5, -17, 5,
+ax_anim 2, 0, 214, -12, 6, -12, 6,
+ax_anim 1, 0, 213, -5, 5, -5, 5,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -8, 0, -8, 0,
+ax_anim 2, 0, 217, -17, 3, -17, 3,
+ax_anim 2, 0, 216, -23, 10, -23, 10,
+ax_anim 3, 0, 215, -21, 20, -21, 20,
+ax_anim 2, 3, 214, -10, 20, -10, 20,
+ax_anim 2, 0, 213, -1, 16, -1, 16,
+ax_anim 1, 0, 212, 2, 7, 2, 7,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -18, 0, 0,
+ax_anim 1, 0, 227, 0, -12, 0, 0,
+ax_anim 2, 2, 227, 0, 2, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_11_2:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -19, 0, 0,
+ax_anim 4, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_11_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -18, 0, 0,
+ax_anim 4, 0, 234, 0, -19, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_11_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -19, 0, 0,
+ax_anim 4, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -23, 0, 0,
+ax_anim 3, 0, 236, 0, -21, 0, 0,
+ax_anim 2, 0, 236, 0, -18, 0, 0,
+ax_anim 1, 0, 236, 0, -11, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_11_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 2, 0, 239, 0, -18, 0, 0,
+ax_anim 1, 0, 239, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_11_6:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 243, 0, -19, 0, 0,
+ax_anim 4, 0, 243, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -23, 0, 0,
+ax_anim 3, 0, 242, 0, -21, 0, 0,
+ax_anim 2, 0, 242, 0, -18, 0, 0,
+ax_anim 1, 0, 242, 0, -11, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_11_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 246, 0, -18, 0, 0,
+ax_anim 4, 0, 246, 0, -19, 0, 0,
+ax_anim 4, 0, 244, 0, -23, 0, 0,
+ax_anim 3, 0, 245, 0, -22, 0, 0,
+ax_anim 2, 0, 245, 0, -18, 0, 0,
+ax_anim 1, 0, 245, 0, -12, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_11_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 0, -10, 0, 0,
+ax_anim 2, 0, 249, 0, -16, 0, 0,
+ax_anim 3, 0, 249, 0, -19, 0, 0,
+ax_anim 4, 0, 249, 0, -20, 0, 0,
+ax_anim 4, 0, 247, 0, -23, 0, 0,
+ax_anim 3, 0, 248, 0, -21, 0, 0,
+ax_anim 2, 0, 248, 0, -18, 0, 0,
+ax_anim 1, 0, 248, 0, -12, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_12_1:
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_12_2:
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 1, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_12_3:
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 1, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_12_4:
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 1, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_12_5:
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 1, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_12_6:
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 1, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_12_7:
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 1, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_12_8:
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 1, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBlisseyAnims_13_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_13_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_13_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_13_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_13_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_13_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_13_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyAnims_13_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sBlisseyGfx1:
+.incbin "baserom.gba", 0xFCF2F0, 0x200
+sBlisseySprites1:
+ax_sprite sBlisseyGfx1, 0x200
+ax_sprite_terminator
+sBlisseyGfx2:
+.incbin "baserom.gba", 0xFCF500, 0x200
+sBlisseySprites2:
+ax_sprite sBlisseyGfx2, 0x200
+ax_sprite_terminator
+sBlisseyGfx3:
+.incbin "baserom.gba", 0xFCF710, 0x200
+sBlisseySprites3:
+ax_sprite sBlisseyGfx3, 0x200
+ax_sprite_terminator
+sBlisseyGfx4:
+.incbin "baserom.gba", 0xFCF920, 0x200
+sBlisseySprites4:
+ax_sprite sBlisseyGfx4, 0x200
+ax_sprite_terminator
+sBlisseyGfx5:
+.incbin "baserom.gba", 0xFCFB30, 0x200
+sBlisseySprites5:
+ax_sprite sBlisseyGfx5, 0x200
+ax_sprite_terminator
+sBlisseyGfx6:
+.incbin "baserom.gba", 0xFCFD40, 0x200
+sBlisseySprites6:
+ax_sprite sBlisseyGfx6, 0x200
+ax_sprite_terminator
+sBlisseyGfx7:
+.incbin "baserom.gba", 0xFCFF50, 0x200
+sBlisseySprites7:
+ax_sprite sBlisseyGfx7, 0x200
+ax_sprite_terminator
+sBlisseyGfx8:
+.incbin "baserom.gba", 0xFD0160, 0x200
+sBlisseySprites8:
+ax_sprite sBlisseyGfx8, 0x200
+ax_sprite_terminator
+sBlisseyGfx9:
+.incbin "baserom.gba", 0xFD0370, 0x200
+sBlisseySprites9:
+ax_sprite sBlisseyGfx9, 0x200
+ax_sprite_terminator
+sBlisseyGfx10:
+.incbin "baserom.gba", 0xFD0580, 0x200
+sBlisseySprites10:
+ax_sprite sBlisseyGfx10, 0x200
+ax_sprite_terminator
+sBlisseyGfx11:
+.incbin "baserom.gba", 0xFD0790, 0x200
+sBlisseySprites11:
+ax_sprite sBlisseyGfx11, 0x200
+ax_sprite_terminator
+sBlisseyGfx12:
+.incbin "baserom.gba", 0xFD09A0, 0x200
+sBlisseySprites12:
+ax_sprite sBlisseyGfx12, 0x200
+ax_sprite_terminator
+sBlisseyGfx13:
+.incbin "baserom.gba", 0xFD0BB0, 0x200
+sBlisseySprites13:
+ax_sprite sBlisseyGfx13, 0x200
+ax_sprite_terminator
+sBlisseyGfx14:
+.incbin "baserom.gba", 0xFD0DC0, 0x200
+sBlisseySprites14:
+ax_sprite sBlisseyGfx14, 0x200
+ax_sprite_terminator
+sBlisseyGfx15:
+.incbin "baserom.gba", 0xFD0FD0, 0x200
+sBlisseySprites15:
+ax_sprite sBlisseyGfx15, 0x200
+ax_sprite_terminator
+sBlisseyGfx16:
+.incbin "baserom.gba", 0xFD11E0, 0x40
+sBlisseyGfx16_1:
+.incbin "baserom.gba", 0xFD1220, 0x180
+sBlisseySprites16:
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx16_1, 0x180
+ax_sprite_terminator
+sBlisseyGfx17:
+.incbin "baserom.gba", 0xFD13C8, 0x180
+sBlisseyGfx17_1:
+.incbin "baserom.gba", 0xFD1548, 0x40
+sBlisseySprites17:
+ax_sprite sBlisseyGfx17, 0x180
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx18:
+.incbin "baserom.gba", 0xFD15B0, 0x40
+sBlisseyGfx18_1:
+.incbin "baserom.gba", 0xFD15F0, 0x160
+sBlisseySprites18:
+ax_sprite sBlisseyGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBlisseyGfx18_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx19:
+.incbin "baserom.gba", 0xFD1778, 0x180
+sBlisseyGfx19_1:
+.incbin "baserom.gba", 0xFD18F8, 0x40
+sBlisseySprites19:
+ax_sprite sBlisseyGfx19, 0x180
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx20:
+.incbin "baserom.gba", 0xFD1960, 0x40
+sBlisseyGfx20_1:
+.incbin "baserom.gba", 0xFD19A0, 0x160
+sBlisseySprites20:
+ax_sprite sBlisseyGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBlisseyGfx20_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx21:
+.incbin "baserom.gba", 0xFD1B28, 0x60
+sBlisseyGfx21_1:
+.incbin "baserom.gba", 0xFD1B88, 0x100
+sBlisseyGfx21_2:
+.incbin "baserom.gba", 0xFD1C88, 0x40
+sBlisseySprites21:
+ax_sprite sBlisseyGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx22:
+.incbin "baserom.gba", 0xFD1D00, 0x60
+sBlisseyGfx22_1:
+.incbin "baserom.gba", 0xFD1D60, 0x60
+sBlisseyGfx22_2:
+.incbin "baserom.gba", 0xFD1DC0, 0x60
+sBlisseyGfx22_3:
+.incbin "baserom.gba", 0xFD1E20, 0x60
+sBlisseySprites22:
+ax_sprite sBlisseyGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx23:
+.incbin "baserom.gba", 0xFD1EC8, 0x60
+sBlisseyGfx23_1:
+.incbin "baserom.gba", 0xFD1F28, 0xE0
+sBlisseyGfx23_2:
+.incbin "baserom.gba", 0xFD2008, 0x20
+sBlisseySprites23:
+ax_sprite sBlisseyGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx23_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sBlisseyGfx23_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBlisseyGfx24:
+.incbin "baserom.gba", 0xFD2060, 0x200
+sBlisseySprites24:
+ax_sprite sBlisseyGfx24, 0x200
+ax_sprite_terminator
+sBlisseyGfx25:
+.incbin "baserom.gba", 0xFD2270, 0x180
+sBlisseyGfx25_1:
+.incbin "baserom.gba", 0xFD23F0, 0x40
+sBlisseySprites25:
+ax_sprite sBlisseyGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sBlisseyGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx26:
+.incbin "baserom.gba", 0xFD2458, 0x200
+sBlisseySprites26:
+ax_sprite sBlisseyGfx26, 0x200
+ax_sprite_terminator
+sBlisseyGfx27:
+.incbin "baserom.gba", 0xFD2668, 0x200
+sBlisseySprites27:
+ax_sprite sBlisseyGfx27, 0x200
+ax_sprite_terminator
+sBlisseyGfx28:
+.incbin "baserom.gba", 0xFD2878, 0x200
+sBlisseySprites28:
+ax_sprite sBlisseyGfx28, 0x200
+ax_sprite_terminator
+sBlisseyGfx29:
+.incbin "baserom.gba", 0xFD2A88, 0x20
+sBlisseySprites29:
+ax_sprite sBlisseyGfx29, 0x20
+ax_sprite_terminator
+sBlisseyGfx30:
+.incbin "baserom.gba", 0xFD2AB8, 0x200
+sBlisseySprites30:
+ax_sprite sBlisseyGfx30, 0x200
+ax_sprite_terminator
+sBlisseyGfx31:
+.incbin "baserom.gba", 0xFD2CC8, 0x100
+sBlisseySprites31:
+ax_sprite sBlisseyGfx31, 0x100
+ax_sprite_terminator
+sBlisseyGfx32:
+.incbin "baserom.gba", 0xFD2DD8, 0x80
+sBlisseySprites32:
+ax_sprite sBlisseyGfx32, 0x80
+ax_sprite_terminator
+sBlisseyGfx33:
+.incbin "baserom.gba", 0xFD2E68, 0x40
+sBlisseySprites33:
+ax_sprite sBlisseyGfx33, 0x40
+ax_sprite_terminator
+sBlisseyGfx34:
+.incbin "baserom.gba", 0xFD2EB8, 0x20
+sBlisseySprites34:
+ax_sprite sBlisseyGfx34, 0x20
+ax_sprite_terminator
+sBlisseyGfx35:
+.incbin "baserom.gba", 0xFD2EE8, 0x20
+sBlisseySprites35:
+ax_sprite sBlisseyGfx35, 0x20
+ax_sprite_terminator
+sBlisseyGfx36:
+.incbin "baserom.gba", 0xFD2F18, 0x200
+sBlisseySprites36:
+ax_sprite sBlisseyGfx36, 0x200
+ax_sprite_terminator
+sBlisseyGfx37:
+.incbin "baserom.gba", 0xFD3128, 0x20
+sBlisseySprites37:
+ax_sprite sBlisseyGfx37, 0x20
+ax_sprite_terminator
+sBlisseyGfx38:
+.incbin "baserom.gba", 0xFD3158, 0x1E0
+sBlisseySprites38:
+ax_sprite sBlisseyGfx38, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBlisseyGfx39:
+.incbin "baserom.gba", 0xFD3350, 0x100
+sBlisseySprites39:
+ax_sprite sBlisseyGfx39, 0x100
+ax_sprite_terminator
+sBlisseyGfx40:
+.incbin "baserom.gba", 0xFD3460, 0x80
+sBlisseySprites40:
+ax_sprite sBlisseyGfx40, 0x80
+ax_sprite_terminator
+sBlisseyGfx41:
+.incbin "baserom.gba", 0xFD34F0, 0x20
+sBlisseySprites41:
+ax_sprite sBlisseyGfx41, 0x20
+ax_sprite_terminator
+sBlisseyGfx42:
+.incbin "baserom.gba", 0xFD3520, 0x40
+sBlisseySprites42:
+ax_sprite sBlisseyGfx42, 0x40
+ax_sprite_terminator
+sBlisseyGfx43:
+.incbin "baserom.gba", 0xFD3570, 0x20
+sBlisseySprites43:
+ax_sprite sBlisseyGfx43, 0x20
+ax_sprite_terminator
+sBlisseyGfx44:
+.incbin "baserom.gba", 0xFD35A0, 0x200
+sBlisseySprites44:
+ax_sprite sBlisseyGfx44, 0x200
+ax_sprite_terminator
+sBlisseyGfx45:
+.incbin "baserom.gba", 0xFD37B0, 0x200
+sBlisseySprites45:
+ax_sprite sBlisseyGfx45, 0x200
+ax_sprite_terminator
+sBlisseyGfx46:
+.incbin "baserom.gba", 0xFD39C0, 0x200
+sBlisseySprites46:
+ax_sprite sBlisseyGfx46, 0x200
+ax_sprite_terminator
+sBlisseyGfx47:
+.incbin "baserom.gba", 0xFD3BD0, 0x200
+sBlisseySprites47:
+ax_sprite sBlisseyGfx47, 0x200
+ax_sprite_terminator
+sBlisseyGfx48:
+.incbin "baserom.gba", 0xFD3DE0, 0x200
+sBlisseySprites48:
+ax_sprite sBlisseyGfx48, 0x200
+ax_sprite_terminator
+sBlisseyGfx49:
+.incbin "baserom.gba", 0xFD3FF0, 0x200
+sBlisseySprites49:
+ax_sprite sBlisseyGfx49, 0x200
+ax_sprite_terminator
+sBlisseyGfx50:
+.incbin "baserom.gba", 0xFD4200, 0x200
+sBlisseySprites50:
+ax_sprite sBlisseyGfx50, 0x200
+ax_sprite_terminator
+sBlisseyGfx51:
+.incbin "baserom.gba", 0xFD4410, 0x200
+sBlisseySprites51:
+ax_sprite sBlisseyGfx51, 0x200
+ax_sprite_terminator
+sBlisseyGfx52:
+.incbin "baserom.gba", 0xFD4620, 0x200
+sBlisseySprites52:
+ax_sprite sBlisseyGfx52, 0x200
+ax_sprite_terminator
+sAxPosesBlissey:
+.4byte sBlisseyPose1
+.4byte sBlisseyPose2
+.4byte sBlisseyPose3
+.4byte sBlisseyPose4
+.4byte sBlisseyPose5
+.4byte sBlisseyPose6
+.4byte sBlisseyPose7
+.4byte sBlisseyPose8
+.4byte sBlisseyPose9
+.4byte sBlisseyPose10
+.4byte sBlisseyPose11
+.4byte sBlisseyPose12
+.4byte sBlisseyPose13
+.4byte sBlisseyPose14
+.4byte sBlisseyPose15
+.4byte sBlisseyPose16
+.4byte sBlisseyPose17
+.4byte sBlisseyPose18
+.4byte sBlisseyPose19
+.4byte sBlisseyPose20
+.4byte sBlisseyPose21
+.4byte sBlisseyPose22
+.4byte sBlisseyPose23
+.4byte sBlisseyPose24
+.4byte sBlisseyPose25
+.4byte sBlisseyPose26
+.4byte sBlisseyPose27
+.4byte sBlisseyPose28
+.4byte sBlisseyPose29
+.4byte sBlisseyPose30
+.4byte sBlisseyPose31
+.4byte sBlisseyPose32
+.4byte sBlisseyPose33
+.4byte sBlisseyPose34
+.4byte sBlisseyPose35
+.4byte sBlisseyPose36
+.4byte sBlisseyPose37
+.4byte sBlisseyPose38
+.4byte sBlisseyPose39
+.4byte sBlisseyPose40
+.4byte sBlisseyPose41
+.4byte sBlisseyPose42
+.4byte sBlisseyPose43
+.4byte sBlisseyPose44
+.4byte sBlisseyPose45
+.4byte sBlisseyPose46
+.4byte sBlisseyPose47
+.4byte sBlisseyPose48
+.4byte sBlisseyPose49
+.4byte sBlisseyPose50
+.4byte sBlisseyPose51
+.4byte sBlisseyPose52
+.4byte sBlisseyPose53
+.4byte sBlisseyPose54
+.4byte sBlisseyPose55
+.4byte sBlisseyPose56
+.4byte sBlisseyPose57
+.4byte sBlisseyPose58
+.4byte sBlisseyPose59
+.4byte sBlisseyPose60
+.4byte sBlisseyPose61
+.4byte sBlisseyPose62
+.4byte sBlisseyPose63
+.4byte sBlisseyPose64
+.4byte sBlisseyPose65
+.4byte sBlisseyPose66
+.4byte sBlisseyPose67
+.4byte sBlisseyPose68
+.4byte sBlisseyPose69
+.4byte sBlisseyPose70
+.4byte sBlisseyPose71
+.4byte sBlisseyPose72
+.4byte sBlisseyPose73
+.4byte sBlisseyPose74
+.4byte sBlisseyPose75
+.4byte sBlisseyPose76
+.4byte sBlisseyPose77
+.4byte sBlisseyPose78
+.4byte sBlisseyPose79
+.4byte sBlisseyPose80
+.4byte sBlisseyPose81
+.4byte sBlisseyPose82
+.4byte sBlisseyPose83
+.4byte sBlisseyPose84
+.4byte sBlisseyPose85
+.4byte sBlisseyPose86
+.4byte sBlisseyPose87
+.4byte sBlisseyPose88
+.4byte sBlisseyPose89
+.4byte sBlisseyPose90
+.4byte sBlisseyPose91
+.4byte sBlisseyPose92
+.4byte sBlisseyPose93
+.4byte sBlisseyPose94
+.4byte sBlisseyPose95
+.4byte sBlisseyPose96
+.4byte sBlisseyPose97
+.4byte sBlisseyPose98
+.4byte sBlisseyPose99
+.4byte sBlisseyPose100
+.4byte sBlisseyPose101
+.4byte sBlisseyPose102
+.4byte sBlisseyPose103
+.4byte sBlisseyPose104
+.4byte sBlisseyPose105
+.4byte sBlisseyPose106
+.4byte sBlisseyPose107
+.4byte sBlisseyPose108
+.4byte sBlisseyPose109
+.4byte sBlisseyPose110
+.4byte sBlisseyPose111
+.4byte sBlisseyPose112
+.4byte sBlisseyPose113
+.4byte sBlisseyPose114
+.4byte sBlisseyPose115
+.4byte sBlisseyPose116
+.4byte sBlisseyPose117
+.4byte sBlisseyPose118
+.4byte sBlisseyPose119
+.4byte sBlisseyPose120
+.4byte sBlisseyPose121
+.4byte sBlisseyPose122
+.4byte sBlisseyPose123
+.4byte sBlisseyPose124
+.4byte sBlisseyPose125
+.4byte sBlisseyPose126
+.4byte sBlisseyPose127
+.4byte sBlisseyPose128
+.4byte sBlisseyPose129
+.4byte sBlisseyPose130
+.4byte sBlisseyPose131
+.4byte sBlisseyPose132
+.4byte sBlisseyPose133
+.4byte sBlisseyPose134
+.4byte sBlisseyPose135
+.4byte sBlisseyPose136
+.4byte sBlisseyPose137
+.4byte sBlisseyPose138
+.4byte sBlisseyPose139
+.4byte sBlisseyPose140
+.4byte sBlisseyPose141
+.4byte sBlisseyPose142
+.4byte sBlisseyPose143
+.4byte sBlisseyPose144
+.4byte sBlisseyPose145
+.4byte sBlisseyPose146
+.4byte sBlisseyPose147
+.4byte sBlisseyPose148
+.4byte sBlisseyPose149
+.4byte sBlisseyPose150
+.4byte sBlisseyPose151
+.4byte sBlisseyPose152
+.4byte sBlisseyPose153
+.4byte sBlisseyPose154
+.4byte sBlisseyPose155
+.4byte sBlisseyPose156
+.4byte sBlisseyPose157
+.4byte sBlisseyPose158
+.4byte sBlisseyPose159
+.4byte sBlisseyPose160
+.4byte sBlisseyPose161
+.4byte sBlisseyPose162
+.4byte sBlisseyPose163
+.4byte sBlisseyPose164
+.4byte sBlisseyPose165
+.4byte sBlisseyPose166
+.4byte sBlisseyPose167
+.4byte sBlisseyPose168
+.4byte sBlisseyPose169
+.4byte sBlisseyPose170
+.4byte sBlisseyPose171
+.4byte sBlisseyPose172
+.4byte sBlisseyPose173
+.4byte sBlisseyPose174
+.4byte sBlisseyPose175
+.4byte sBlisseyPose176
+.4byte sBlisseyPose177
+.4byte sBlisseyPose178
+.4byte sBlisseyPose179
+.4byte sBlisseyPose180
+.4byte sBlisseyPose181
+.4byte sBlisseyPose182
+.4byte sBlisseyPose183
+.4byte sBlisseyPose184
+.4byte sBlisseyPose185
+.4byte sBlisseyPose186
+.4byte sBlisseyPose187
+.4byte sBlisseyPose188
+.4byte sBlisseyPose189
+.4byte sBlisseyPose190
+.4byte sBlisseyPose191
+.4byte sBlisseyPose192
+.4byte sBlisseyPose193
+.4byte sBlisseyPose194
+.4byte sBlisseyPose195
+.4byte sBlisseyPose196
+.4byte sBlisseyPose197
+.4byte sBlisseyPose198
+.4byte sBlisseyPose199
+.4byte sBlisseyPose200
+.4byte sBlisseyPose201
+.4byte sBlisseyPose202
+.4byte sBlisseyPose203
+.4byte sBlisseyPose204
+.4byte sBlisseyPose205
+.4byte sBlisseyPose206
+.4byte sBlisseyPose207
+.4byte sBlisseyPose208
+.4byte sBlisseyPose209
+.4byte sBlisseyPose210
+.4byte sBlisseyPose211
+.4byte sBlisseyPose212
+.4byte sBlisseyPose213
+.4byte sBlisseyPose214
+.4byte sBlisseyPose215
+.4byte sBlisseyPose216
+.4byte sBlisseyPose217
+.4byte sBlisseyPose218
+.4byte sBlisseyPose219
+.4byte sBlisseyPose220
+.4byte sBlisseyPose221
+.4byte sBlisseyPose222
+.4byte sBlisseyPose223
+.4byte sBlisseyPose224
+.4byte sBlisseyPose225
+.4byte sBlisseyPose226
+.4byte sBlisseyPose227
+.4byte sBlisseyPose228
+.4byte sBlisseyPose229
+.4byte sBlisseyPose230
+.4byte sBlisseyPose231
+.4byte sBlisseyPose232
+.4byte sBlisseyPose233
+.4byte sBlisseyPose234
+.4byte sBlisseyPose235
+.4byte sBlisseyPose236
+.4byte sBlisseyPose237
+.4byte sBlisseyPose238
+.4byte sBlisseyPose239
+.4byte sBlisseyPose240
+.4byte sBlisseyPose241
+.4byte sBlisseyPose242
+.4byte sBlisseyPose243
+.4byte sBlisseyPose244
+.4byte sBlisseyPose245
+.4byte sBlisseyPose246
+.4byte sBlisseyPose247
+.4byte sBlisseyPose248
+.4byte sBlisseyPose249
+.4byte sBlisseyPose250
+.4byte sBlisseyPose251
+.4byte sBlisseyPose252
+.4byte sBlisseyPose253
+.4byte sBlisseyPose254
+.4byte sBlisseyPose255
+.4byte sBlisseyPose256
+.4byte sBlisseyPose257
+.4byte sBlisseyPose258
+.4byte sBlisseyPose259
+.4byte sBlisseyPose260
+.4byte sBlisseyPose261
+.4byte sBlisseyPose262
+.4byte sBlisseyPose263
+.4byte sBlisseyPose264
+.4byte sBlisseyPose265
+.4byte sBlisseyPose266
+sAxPositionsBlissey:
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -1,  -13, 	  -7,  -11, 	   9,   -8, 	   0,  -11
+.2byte    0,  -13, 	 -10,   -8, 	   6,  -11, 	  -1,  -11
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    5,  -13, 	  10,  -12, 	  -2,   -6, 	   0,  -10
+.2byte    3,  -13, 	  10,  -10, 	  -1,  -10, 	   0,  -11
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte    6,  -14, 	   5,  -11, 	   2,   -7, 	  -1,  -10
+.2byte    7,  -15, 	  -4,  -10, 	   0,  -11, 	  -2,  -10
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   8,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -8,  -11, 	   9,  -12, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte   -2,  -15, 	   7,  -16, 	 -11,  -12, 	  -1,  -11
+.2byte    1,  -14, 	  10,  -11, 	  -8,  -16, 	   0,  -11
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -9,   -9, 	   0,  -12
+.2byte   -3,  -13, 	   7,  -11, 	 -10,  -12, 	   0,  -11
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte   -7,  -14, 	  -6,  -11, 	  -3,   -7, 	   0,  -10
+.2byte   -8,  -15, 	   3,  -10, 	  -1,  -11, 	   1,  -10
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte   -6,  -13, 	 -11,  -12, 	   1,   -6, 	  -1,  -10
+.2byte   -4,  -13, 	 -11,  -10, 	   0,  -10, 	  -1,  -11
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -1,  -13, 	  -7,  -11, 	   9,   -8, 	   0,  -11
+.2byte    0,  -13, 	 -10,   -8, 	   6,  -11, 	  -1,  -11
+.2byte   -1,   -8, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	 -11,  -12, 	  10,  -12, 	  -1,  -13
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    5,  -13, 	  10,  -12, 	  -2,   -6, 	   0,  -10
+.2byte    3,  -13, 	  10,  -10, 	  -1,  -10, 	   0,  -11
+.2byte    6,  -10, 	   8,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    3,  -19, 	  11,  -14, 	  -1,  -10, 	  -2,  -12
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte    6,  -14, 	   5,  -11, 	   2,   -7, 	  -1,  -10
+.2byte    7,  -15, 	  -4,  -10, 	   0,  -11, 	  -2,  -10
+.2byte    9,   -9, 	   6,   -4, 	   4,   -3, 	  -2,   -8
+.2byte    6,  -20, 	   7,  -17, 	   3,  -13, 	  -1,  -13
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   8,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -8,  -11, 	   9,  -12, 	  -1,  -11
+.2byte    5,  -11, 	  -2,  -15, 	   8,   -8, 	  -1,  -12
+.2byte    4,  -17, 	  -5,  -18, 	  10,  -14, 	  -2,  -12
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte   -2,  -15, 	   7,  -16, 	 -11,  -12, 	  -1,  -11
+.2byte    1,  -14, 	  10,  -11, 	  -8,  -16, 	   0,  -11
+.2byte   -1,  -15, 	   9,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   5,  -16, 	  -6,  -16, 	   0,  -12
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -9,   -9, 	   0,  -12
+.2byte   -3,  -13, 	   7,  -11, 	 -10,  -12, 	   0,  -11
+.2byte   -6,  -11, 	   1,  -15, 	  -9,   -8, 	   0,  -12
+.2byte   -5,  -17, 	   4,  -18, 	 -11,  -14, 	   1,  -12
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte   -7,  -14, 	  -6,  -11, 	  -3,   -7, 	   0,  -10
+.2byte   -8,  -15, 	   3,  -10, 	  -1,  -11, 	   1,  -10
+.2byte  -10,   -9, 	  -7,   -4, 	  -5,   -3, 	   1,   -8
+.2byte   -7,  -20, 	  -8,  -17, 	  -4,  -13, 	   0,  -13
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte   -6,  -13, 	 -11,  -12, 	   1,   -6, 	  -1,  -10
+.2byte   -4,  -13, 	 -11,  -10, 	   0,  -10, 	  -1,  -11
+.2byte   -7,  -10, 	  -9,   -5, 	  -2,   -4, 	   0,   -9
+.2byte   -4,  -19, 	 -12,  -14, 	   0,  -10, 	   1,  -12
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -1,  -13, 	  -7,  -11, 	   9,   -8, 	   0,  -11
+.2byte    0,  -13, 	 -10,   -8, 	   6,  -11, 	  -1,  -11
+.2byte   -1,   -8, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	 -11,  -12, 	  10,  -12, 	  -1,  -13
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    5,  -13, 	  10,  -12, 	  -2,   -6, 	   0,  -10
+.2byte    3,  -13, 	  10,  -10, 	  -1,  -10, 	   0,  -11
+.2byte    6,  -10, 	   8,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    3,  -19, 	  11,  -14, 	  -1,  -10, 	  -2,  -12
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte    6,  -14, 	   5,  -11, 	   2,   -7, 	  -1,  -10
+.2byte    7,  -15, 	  -4,  -10, 	   0,  -11, 	  -2,  -10
+.2byte    9,   -9, 	   6,   -4, 	   4,   -3, 	  -2,   -8
+.2byte    6,  -20, 	   7,  -17, 	   3,  -13, 	  -1,  -13
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   8,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -8,  -11, 	   9,  -12, 	  -1,  -11
+.2byte    5,  -11, 	  -2,  -15, 	   8,   -8, 	  -1,  -12
+.2byte    4,  -17, 	  -5,  -18, 	  10,  -14, 	  -2,  -12
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte   -2,  -15, 	   7,  -16, 	 -11,  -12, 	  -1,  -11
+.2byte    1,  -14, 	  10,  -11, 	  -8,  -16, 	   0,  -11
+.2byte   -1,  -15, 	   9,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   5,  -16, 	  -6,  -16, 	   0,  -12
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -9,   -9, 	   0,  -12
+.2byte   -3,  -13, 	   7,  -11, 	 -10,  -12, 	   0,  -11
+.2byte   -6,  -11, 	   1,  -15, 	  -9,   -8, 	   0,  -12
+.2byte   -5,  -17, 	   4,  -18, 	 -11,  -14, 	   1,  -12
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte   -7,  -14, 	  -6,  -11, 	  -3,   -7, 	   0,  -10
+.2byte   -8,  -15, 	   3,  -10, 	  -1,  -11, 	   1,  -10
+.2byte  -10,   -9, 	  -7,   -4, 	  -5,   -3, 	   1,   -8
+.2byte   -7,  -20, 	  -8,  -17, 	  -4,  -13, 	   0,  -13
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte   -6,  -13, 	 -11,  -12, 	   1,   -6, 	  -1,  -10
+.2byte   -4,  -13, 	 -11,  -10, 	   0,  -10, 	  -1,  -11
+.2byte   -7,  -10, 	  -9,   -5, 	  -2,   -4, 	   0,   -9
+.2byte   -4,  -19, 	 -12,  -14, 	   0,  -10, 	   1,  -12
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -1,  -13, 	  -7,  -11, 	   9,   -8, 	   0,  -11
+.2byte    0,  -13, 	 -10,   -8, 	   6,  -11, 	  -1,  -11
+.2byte   -1,   -8, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte   -1,  -15, 	 -11,  -11, 	  10,  -11, 	  -1,  -12
+.2byte   -1,  -21, 	 -10,  -15, 	  10,  -15, 	  -1,  -15
+.2byte   -1,  -11, 	 -14,  -11, 	  13,  -11, 	   0,  -11
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    5,  -13, 	  10,  -12, 	  -2,   -6, 	   0,  -10
+.2byte    3,  -13, 	  10,  -10, 	  -1,  -10, 	   0,  -11
+.2byte    8,   -9, 	  10,   -4, 	   3,   -3, 	   1,   -8
+.2byte    3,  -19, 	  11,  -14, 	  -1,  -10, 	  -2,  -12
+.2byte   -3,  -26, 	  10,  -21, 	  -2,  -14, 	  -5,  -15
+.2byte    9,  -10, 	   5,  -18, 	  -5,  -11, 	  -2,  -13
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte    6,  -14, 	   5,  -11, 	   2,   -7, 	  -1,  -10
+.2byte    7,  -15, 	  -4,  -10, 	   0,  -11, 	  -2,  -10
+.2byte    9,   -9, 	   6,   -4, 	   4,   -3, 	  -2,   -8
+.2byte    6,  -18, 	   7,  -15, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -26, 	   0,  -23, 	   5,  -14, 	  -2,  -16
+.2byte   13,  -15, 	   7,  -12, 	   1,  -10, 	   1,  -12
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   8,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -8,  -11, 	   9,  -12, 	  -1,  -11
+.2byte    5,  -11, 	  -2,  -15, 	   8,   -8, 	  -1,  -12
+.2byte    4,  -17, 	  -5,  -18, 	  10,  -14, 	  -2,  -12
+.2byte   -2,  -28, 	  -4,  -22, 	   8,  -17, 	  -3,  -16
+.2byte    7,  -17, 	   0,  -18, 	  12,   -9, 	   1,  -16
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte   -2,  -15, 	   7,  -16, 	 -11,  -12, 	  -1,  -11
+.2byte    1,  -14, 	  10,  -11, 	  -8,  -16, 	   0,  -11
+.2byte   -1,  -15, 	   9,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   5,  -16, 	  -6,  -16, 	   0,  -12
+.2byte    0,  -25, 	  10,  -15, 	 -11,  -15, 	  -1,  -11
+.2byte   -1,  -20, 	  14,  -15, 	 -15,  -15, 	  -1,  -14
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -9,   -9, 	   0,  -12
+.2byte   -3,  -13, 	   7,  -11, 	 -10,  -12, 	   0,  -11
+.2byte   -6,  -11, 	   1,  -15, 	  -9,   -8, 	   0,  -12
+.2byte   -5,  -18, 	   4,  -19, 	 -11,  -15, 	   1,  -13
+.2byte    1,  -28, 	   3,  -22, 	  -9,  -17, 	   2,  -16
+.2byte   -8,  -17, 	  -1,  -18, 	 -13,   -9, 	  -2,  -16
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte   -7,  -14, 	  -6,  -11, 	  -3,   -7, 	   0,  -10
+.2byte   -8,  -15, 	   3,  -10, 	  -1,  -11, 	   1,  -10
+.2byte  -10,   -9, 	  -7,   -4, 	  -5,   -3, 	   1,   -8
+.2byte   -7,  -18, 	  -8,  -15, 	  -4,  -11, 	   0,  -11
+.2byte    0,  -26, 	  -1,  -23, 	  -6,  -14, 	   1,  -16
+.2byte  -14,  -15, 	  -8,  -12, 	  -2,  -10, 	  -2,  -12
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte   -6,  -13, 	 -11,  -12, 	   1,   -6, 	  -1,  -10
+.2byte   -4,  -13, 	 -11,  -10, 	   0,  -10, 	  -1,  -11
+.2byte   -9,   -9, 	 -11,   -4, 	  -4,   -3, 	  -2,   -8
+.2byte   -4,  -19, 	 -12,  -14, 	   0,  -10, 	   1,  -12
+.2byte    2,  -26, 	 -11,  -21, 	   1,  -14, 	   4,  -15
+.2byte  -10,  -10, 	  -6,  -18, 	   4,  -11, 	   1,  -13
+.2byte   -1,   -8, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte   -1,  -15, 	 -11,  -11, 	  10,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    6,   -9, 	   8,   -4, 	   1,   -3, 	  -1,   -8
+.2byte    3,  -18, 	  11,  -13, 	  -1,   -9, 	  -2,  -11
+.2byte    9,   -9, 	   6,   -4, 	   4,   -3, 	  -2,   -8
+.2byte    6,  -18, 	   7,  -15, 	   3,  -11, 	  -1,  -11
+.2byte    5,  -11, 	  -2,  -15, 	   8,   -8, 	  -1,  -12
+.2byte    4,  -16, 	  -5,  -17, 	  10,  -13, 	  -2,  -11
+.2byte   -1,  -15, 	   9,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   5,  -16, 	  -6,  -16, 	   0,  -12
+.2byte   -6,  -11, 	   1,  -15, 	  -9,   -8, 	   0,  -12
+.2byte   -5,  -16, 	   4,  -17, 	 -11,  -13, 	   1,  -11
+.2byte  -10,   -9, 	  -7,   -4, 	  -5,   -3, 	   1,   -8
+.2byte   -7,  -18, 	  -8,  -15, 	  -4,  -11, 	   0,  -11
+.2byte   -7,   -9, 	  -9,   -4, 	  -2,   -3, 	   0,   -8
+.2byte   -4,  -18, 	 -12,  -13, 	   0,   -9, 	   1,  -11
+.2byte   -1,   -9, 	 -12,   -4, 	  11,   -4, 	  -1,   -7
+.2byte   -1,   -8, 	 -13,   -4, 	  12,   -4, 	  -1,   -7
+.2byte   -1,  -18, 	  -4,  -18, 	   3,  -18, 	   0,  -13
+.2byte   -3,  -18, 	  -1,  -22, 	  -6,  -19, 	   0,  -12
+.2byte    2,  -18, 	   2,  -21, 	   3,  -17, 	   1,  -12
+.2byte    4,  -19, 	  -4,  -20, 	   8,  -16, 	  -1,  -11
+.2byte   -1,  -21, 	   4,  -20, 	  -5,  -20, 	  -1,  -11
+.2byte   -5,  -19, 	   3,  -20, 	  -9,  -16, 	   0,  -11
+.2byte   -3,  -18, 	  -3,  -21, 	  -4,  -17, 	  -2,  -12
+.2byte    2,  -18, 	   0,  -22, 	   5,  -19, 	  -1,  -12
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    9,   -9, 	  11,   -4, 	   4,   -3, 	   2,   -8
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte   13,   -9, 	  10,   -4, 	   8,   -3, 	   2,   -8
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    6,  -11, 	  -1,  -15, 	   9,   -8, 	   0,  -12
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte   -1,  -15, 	   9,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -7,  -11, 	   0,  -15, 	 -10,   -8, 	  -1,  -12
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte  -14,   -9, 	 -11,   -4, 	  -9,   -3, 	  -3,   -8
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte  -10,   -9, 	 -12,   -4, 	  -5,   -3, 	  -3,   -8
+.2byte   -1,  -16, 	 -11,  -12, 	  10,  -12, 	  -1,  -13
+.2byte   -4,  -18, 	 -12,  -13, 	   0,   -9, 	   1,  -11
+.2byte   -7,  -18, 	  -8,  -15, 	  -4,  -11, 	   0,  -11
+.2byte   -5,  -16, 	   4,  -17, 	 -11,  -13, 	   1,  -11
+.2byte   -1,  -14, 	   5,  -15, 	  -6,  -15, 	   0,  -11
+.2byte    4,  -16, 	  -5,  -17, 	  10,  -13, 	  -2,  -11
+.2byte    6,  -18, 	   7,  -15, 	   3,  -11, 	  -1,  -11
+.2byte    3,  -18, 	  11,  -13, 	  -1,   -9, 	  -2,  -11
+.2byte   -1,  -16, 	 -11,  -12, 	  10,  -12, 	  -1,  -13
+.2byte    3,  -18, 	  11,  -13, 	  -1,   -9, 	  -2,  -11
+.2byte    6,  -18, 	   7,  -15, 	   3,  -11, 	  -1,  -11
+.2byte    4,  -16, 	  -5,  -17, 	  10,  -13, 	  -2,  -11
+.2byte   -1,  -14, 	   5,  -15, 	  -6,  -15, 	   0,  -11
+.2byte   -5,  -16, 	   4,  -17, 	 -11,  -13, 	   1,  -11
+.2byte   -7,  -18, 	  -8,  -15, 	  -4,  -11, 	   0,  -11
+.2byte   -4,  -18, 	 -12,  -13, 	   0,   -9, 	   1,  -11
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	  -6,   -6, 	   5,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	 -11,  -10, 	  10,  -10, 	  -1,  -11
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    6,  -11, 	   8,   -6, 	   1,   -5, 	  -1,  -10
+.2byte    3,  -19, 	  11,  -14, 	  -1,  -10, 	  -2,  -12
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte    9,  -10, 	   6,   -5, 	   4,   -4, 	  -2,   -9
+.2byte    5,  -20, 	   6,  -17, 	   2,  -13, 	  -2,  -13
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    4,  -11, 	  -3,  -15, 	   7,   -8, 	  -2,  -12
+.2byte    4,  -17, 	  -5,  -18, 	  10,  -14, 	  -2,  -12
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte   -1,  -14, 	   9,  -12, 	 -10,  -12, 	  -1,  -11
+.2byte   -1,  -14, 	   5,  -15, 	  -6,  -15, 	   0,  -11
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -5,  -11, 	   2,  -15, 	  -8,   -8, 	   1,  -12
+.2byte   -5,  -17, 	   4,  -18, 	 -11,  -14, 	   1,  -12
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte  -10,  -10, 	  -7,   -5, 	  -5,   -4, 	   1,   -9
+.2byte   -6,  -20, 	  -7,  -17, 	  -3,  -13, 	   1,  -13
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte   -7,  -11, 	  -9,   -6, 	  -2,   -5, 	   0,  -10
+.2byte   -4,  -19, 	 -12,  -14, 	   0,  -10, 	   1,  -12
+.2byte   -1,   -8, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte   -7,  -10, 	  -9,   -5, 	  -2,   -4, 	   0,   -9
+.2byte  -10,  -10, 	  -7,   -5, 	  -5,   -4, 	   1,   -9
+.2byte   -6,  -10, 	   1,  -14, 	  -9,   -7, 	   0,  -11
+.2byte   -1,  -13, 	   9,  -11, 	 -10,  -11, 	  -1,  -10
+.2byte    5,  -10, 	  -2,  -14, 	   8,   -7, 	  -1,  -11
+.2byte    9,  -10, 	   6,   -5, 	   4,   -4, 	  -2,   -9
+.2byte    6,  -10, 	   8,   -5, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	  -7,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -5,  -12, 	  -8,   -9, 	   0,   -7, 	   0,  -10
+.2byte   -8,  -13, 	  -6,  -10, 	  -4,   -8, 	   0,   -9
+.2byte   -7,  -13, 	   3,  -14, 	  -9,  -10, 	   0,  -11
+.2byte   -1,  -15, 	   8,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte    6,  -13, 	  -4,  -14, 	   8,  -10, 	  -1,  -11
+.2byte    7,  -13, 	   5,  -10, 	   3,   -8, 	  -1,   -9
+.2byte    4,  -12, 	   7,   -9, 	  -1,   -7, 	  -1,  -10
+sBlisseyAnimTable1:
+.4byte sBlisseyAnims_1_1
+.4byte sBlisseyAnims_1_2
+.4byte sBlisseyAnims_1_3
+.4byte sBlisseyAnims_1_4
+.4byte sBlisseyAnims_1_5
+.4byte sBlisseyAnims_1_6
+.4byte sBlisseyAnims_1_7
+.4byte sBlisseyAnims_1_8
+sBlisseyAnimTable2:
+.4byte sBlisseyAnims_2_1
+.4byte sBlisseyAnims_2_2
+.4byte sBlisseyAnims_2_3
+.4byte sBlisseyAnims_2_4
+.4byte sBlisseyAnims_2_5
+.4byte sBlisseyAnims_2_6
+.4byte sBlisseyAnims_2_7
+.4byte sBlisseyAnims_2_8
+sBlisseyAnimTable3:
+.4byte sBlisseyAnims_3_1
+.4byte sBlisseyAnims_3_2
+.4byte sBlisseyAnims_3_3
+.4byte sBlisseyAnims_3_4
+.4byte sBlisseyAnims_3_5
+.4byte sBlisseyAnims_3_6
+.4byte sBlisseyAnims_3_7
+.4byte sBlisseyAnims_3_8
+sBlisseyAnimTable4:
+.4byte sBlisseyAnims_4_1
+.4byte sBlisseyAnims_4_2
+.4byte sBlisseyAnims_4_3
+.4byte sBlisseyAnims_4_4
+.4byte sBlisseyAnims_4_5
+.4byte sBlisseyAnims_4_6
+.4byte sBlisseyAnims_4_7
+.4byte sBlisseyAnims_4_8
+sBlisseyAnimTable5:
+.4byte sBlisseyAnims_5_1
+.4byte sBlisseyAnims_5_2
+.4byte sBlisseyAnims_5_3
+.4byte sBlisseyAnims_5_4
+.4byte sBlisseyAnims_5_5
+.4byte sBlisseyAnims_5_6
+.4byte sBlisseyAnims_5_7
+.4byte sBlisseyAnims_5_8
+sBlisseyAnimTable6:
+.4byte sBlisseyAnims_6_1
+.4byte sBlisseyAnims_6_1
+.4byte sBlisseyAnims_6_1
+.4byte sBlisseyAnims_6_1
+.4byte sBlisseyAnims_6_1
+.4byte sBlisseyAnims_6_1
+.4byte sBlisseyAnims_6_1
+.4byte sBlisseyAnims_6_1
+sBlisseyAnimTable7:
+.4byte sBlisseyAnims_7_1
+.4byte sBlisseyAnims_7_2
+.4byte sBlisseyAnims_7_3
+.4byte sBlisseyAnims_7_4
+.4byte sBlisseyAnims_7_5
+.4byte sBlisseyAnims_7_6
+.4byte sBlisseyAnims_7_7
+.4byte sBlisseyAnims_7_8
+sBlisseyAnimTable8:
+.4byte sBlisseyAnims_8_1
+.4byte sBlisseyAnims_8_2
+.4byte sBlisseyAnims_8_3
+.4byte sBlisseyAnims_8_4
+.4byte sBlisseyAnims_8_5
+.4byte sBlisseyAnims_8_6
+.4byte sBlisseyAnims_8_7
+.4byte sBlisseyAnims_8_8
+sBlisseyAnimTable9:
+.4byte sBlisseyAnims_9_1
+.4byte sBlisseyAnims_9_2
+.4byte sBlisseyAnims_9_3
+.4byte sBlisseyAnims_9_4
+.4byte sBlisseyAnims_9_5
+.4byte sBlisseyAnims_9_6
+.4byte sBlisseyAnims_9_7
+.4byte sBlisseyAnims_9_8
+sBlisseyAnimTable10:
+.4byte sBlisseyAnims_10_1
+.4byte sBlisseyAnims_10_2
+.4byte sBlisseyAnims_10_3
+.4byte sBlisseyAnims_10_4
+.4byte sBlisseyAnims_10_5
+.4byte sBlisseyAnims_10_6
+.4byte sBlisseyAnims_10_7
+.4byte sBlisseyAnims_10_8
+sBlisseyAnimTable11:
+.4byte sBlisseyAnims_11_1
+.4byte sBlisseyAnims_11_2
+.4byte sBlisseyAnims_11_3
+.4byte sBlisseyAnims_11_4
+.4byte sBlisseyAnims_11_5
+.4byte sBlisseyAnims_11_6
+.4byte sBlisseyAnims_11_7
+.4byte sBlisseyAnims_11_8
+sBlisseyAnimTable12:
+.4byte sBlisseyAnims_12_1
+.4byte sBlisseyAnims_12_2
+.4byte sBlisseyAnims_12_3
+.4byte sBlisseyAnims_12_4
+.4byte sBlisseyAnims_12_5
+.4byte sBlisseyAnims_12_6
+.4byte sBlisseyAnims_12_7
+.4byte sBlisseyAnims_12_8
+sBlisseyAnimTable13:
+.4byte sBlisseyAnims_13_1
+.4byte sBlisseyAnims_13_2
+.4byte sBlisseyAnims_13_3
+.4byte sBlisseyAnims_13_4
+.4byte sBlisseyAnims_13_5
+.4byte sBlisseyAnims_13_6
+.4byte sBlisseyAnims_13_7
+.4byte sBlisseyAnims_13_8
+sAxAnimationsBlissey:
+.4byte sBlisseyAnimTable1
+.4byte sBlisseyAnimTable2
+.4byte sBlisseyAnimTable3
+.4byte sBlisseyAnimTable4
+.4byte sBlisseyAnimTable5
+.4byte sBlisseyAnimTable6
+.4byte sBlisseyAnimTable7
+.4byte sBlisseyAnimTable8
+.4byte sBlisseyAnimTable9
+.4byte sBlisseyAnimTable10
+.4byte sBlisseyAnimTable11
+.4byte sBlisseyAnimTable12
+.4byte sBlisseyAnimTable13
+sAxSpritesBlissey:
+.4byte sBlisseySprites1
+.4byte sBlisseySprites2
+.4byte sBlisseySprites3
+.4byte sBlisseySprites4
+.4byte sBlisseySprites5
+.4byte sBlisseySprites6
+.4byte sBlisseySprites7
+.4byte sBlisseySprites8
+.4byte sBlisseySprites9
+.4byte sBlisseySprites10
+.4byte sBlisseySprites11
+.4byte sBlisseySprites12
+.4byte sBlisseySprites13
+.4byte sBlisseySprites14
+.4byte sBlisseySprites15
+.4byte sBlisseySprites16
+.4byte sBlisseySprites17
+.4byte sBlisseySprites18
+.4byte sBlisseySprites19
+.4byte sBlisseySprites20
+.4byte sBlisseySprites21
+.4byte sBlisseySprites22
+.4byte sBlisseySprites23
+.4byte sBlisseySprites24
+.4byte sBlisseySprites25
+.4byte sBlisseySprites26
+.4byte sBlisseySprites27
+.4byte sBlisseySprites28
+.4byte sBlisseySprites29
+.4byte sBlisseySprites30
+.4byte sBlisseySprites31
+.4byte sBlisseySprites32
+.4byte sBlisseySprites33
+.4byte sBlisseySprites34
+.4byte sBlisseySprites35
+.4byte sBlisseySprites36
+.4byte sBlisseySprites37
+.4byte sBlisseySprites38
+.4byte sBlisseySprites39
+.4byte sBlisseySprites40
+.4byte sBlisseySprites41
+.4byte sBlisseySprites42
+.4byte sBlisseySprites43
+.4byte sBlisseySprites44
+.4byte sBlisseySprites45
+.4byte sBlisseySprites46
+.4byte sBlisseySprites47
+.4byte sBlisseySprites48
+.4byte sBlisseySprites49
+.4byte sBlisseySprites50
+.4byte sBlisseySprites51
+.4byte sBlisseySprites52
+sAxMainBlissey:
+ax_main sAxPosesBlissey, sAxAnimationsBlissey, 13, sAxSpritesBlissey, sAxPositionsBlissey

--- a/data/ax/breloom.inc
+++ b/data/ax/breloom.inc
@@ -1,0 +1,2843 @@
+.global gAxBreloom
+gAxBreloom:
+ax_siro sAxMainBreloom
+sBreloomPose1:
+ax_pose 0, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose2:
+ax_pose 1, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose3:
+ax_pose 2, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose4:
+ax_pose 3, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose5:
+ax_pose 4, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose6:
+ax_pose 5, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose7:
+ax_pose 6, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose8:
+ax_pose 7, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose9:
+ax_pose 8, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose10:
+ax_pose 9, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose11:
+ax_pose 10, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose12:
+ax_pose 11, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose14:
+ax_pose 13, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose15:
+ax_pose 14, 0x01e7, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose16:
+ax_pose 9, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose17:
+ax_pose 10, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose18:
+ax_pose 11, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose19:
+ax_pose 6, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose20:
+ax_pose 7, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose21:
+ax_pose 8, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose22:
+ax_pose 3, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose23:
+ax_pose 4, 0x01ea, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose24:
+ax_pose 5, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose25:
+ax_pose 0, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose26:
+ax_pose 1, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose27:
+ax_pose 2, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose28:
+ax_pose 3, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose29:
+ax_pose 4, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose30:
+ax_pose 5, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose31:
+ax_pose 6, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose32:
+ax_pose 7, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose33:
+ax_pose 8, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose34:
+ax_pose 9, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose35:
+ax_pose 10, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose36:
+ax_pose 11, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose37:
+ax_pose 12, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose38:
+ax_pose 13, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose39:
+ax_pose 14, 0x01e7, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose40:
+ax_pose 9, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose41:
+ax_pose 10, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose42:
+ax_pose 11, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose43:
+ax_pose 6, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose44:
+ax_pose 7, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose45:
+ax_pose 8, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose46:
+ax_pose 3, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose47:
+ax_pose 4, 0x01ea, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose48:
+ax_pose 5, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose49:
+ax_pose 0, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose50:
+ax_pose 1, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose51:
+ax_pose 2, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose52:
+ax_pose 15, 0x01f3, 0x40f0, 0x8c00
+ax_pose 16, 0x01e3, 0x80f0, 0x8c04
+ax_pose_terminator
+sBreloomPose53:
+ax_pose 16, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose54:
+ax_pose 17, 0x01f3, 0x4100, 0x8c00
+ax_pose 18, 0x01e3, 0x80f0, 0x8c04
+ax_pose_terminator
+sBreloomPose55:
+ax_pose 18, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose56:
+ax_pose 3, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose57:
+ax_pose 4, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose58:
+ax_pose 5, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose59:
+ax_pose 19, 0x81e5, 0x5108, 0x8c00
+ax_pose 20, 0x01e5, 0x90f0, 0x8c04
+ax_pose_terminator
+sBreloomPose60:
+ax_pose 20, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sBreloomPose61:
+ax_pose 21, 0x81f5, 0x1108, 0x8c00
+ax_pose 22, 0x01f5, 0x50f8, 0x8c02
+ax_pose 23, 0x01e5, 0x90f0, 0x8c06
+ax_pose_terminator
+sBreloomPose62:
+ax_pose 23, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sBreloomPose63:
+ax_pose 6, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose64:
+ax_pose 7, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose65:
+ax_pose 8, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose66:
+ax_pose 24, 0x01ec, 0x5101, 0x8c00
+ax_pose 25, 0x81e4, 0x90f9, 0x8c04
+ax_pose 26, 0x81e4, 0x50f1, 0x8c0c
+ax_pose 27, 0x81e8, 0x10e9, 0x8c10
+ax_pose 28, 0x01f0, 0x1109, 0x8c12
+ax_pose_terminator
+sBreloomPose67:
+ax_pose 25, 0x81e4, 0x90f9, 0x8c00
+ax_pose 26, 0x81e4, 0x50f1, 0x8c08
+ax_pose 27, 0x81e8, 0x10e9, 0x8c0c
+ax_pose 28, 0x01f0, 0x1109, 0x8c0e
+ax_pose_terminator
+sBreloomPose68:
+ax_pose 29, 0x41f4, 0x90f1, 0x8c00
+ax_pose 30, 0x01e4, 0x90f1, 0x8c08
+ax_pose_terminator
+sBreloomPose69:
+ax_pose 30, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sBreloomPose70:
+ax_pose 9, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose71:
+ax_pose 10, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose72:
+ax_pose 11, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose73:
+ax_pose 31, 0x41e6, 0x90ee, 0x8c00
+ax_pose 32, 0x01e6, 0x90ee, 0x8c08
+ax_pose_terminator
+sBreloomPose74:
+ax_pose 32, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sBreloomPose75:
+ax_pose 33, 0x01ee, 0x50fe, 0x8c00
+ax_pose 34, 0x01e6, 0x90ee, 0x8c04
+ax_pose_terminator
+sBreloomPose76:
+ax_pose 34, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sBreloomPose77:
+ax_pose 12, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose78:
+ax_pose 13, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose79:
+ax_pose 14, 0x01e7, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose80:
+ax_pose 35, 0x81e6, 0x8100, 0x8c00
+ax_pose 36, 0x01e6, 0x80f0, 0x8c08
+ax_pose_terminator
+sBreloomPose81:
+ax_pose 36, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose82:
+ax_pose 37, 0x81e6, 0x80f0, 0x8c00
+ax_pose 38, 0x01e6, 0x80f0, 0x8c08
+ax_pose_terminator
+sBreloomPose83:
+ax_pose 38, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose84:
+ax_pose 9, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose85:
+ax_pose 10, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose86:
+ax_pose 11, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose87:
+ax_pose 31, 0x41e6, 0x80f1, 0x8c00
+ax_pose 32, 0x01e6, 0x80f1, 0x8c08
+ax_pose_terminator
+sBreloomPose88:
+ax_pose 32, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose89:
+ax_pose 33, 0x01ee, 0x40f1, 0x8c00
+ax_pose 34, 0x01e6, 0x80f1, 0x8c04
+ax_pose_terminator
+sBreloomPose90:
+ax_pose 34, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose91:
+ax_pose 6, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose92:
+ax_pose 7, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose93:
+ax_pose 8, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose94:
+ax_pose 24, 0x01ec, 0x40ef, 0x8c00
+ax_pose 25, 0x81e4, 0x80f7, 0x8c04
+ax_pose 26, 0x81e4, 0x4107, 0x8c0c
+ax_pose 27, 0x81e8, 0x010f, 0x8c10
+ax_pose 28, 0x01f0, 0x00ef, 0x8c12
+ax_pose_terminator
+sBreloomPose95:
+ax_pose 25, 0x81e4, 0x80f7, 0x8c00
+ax_pose 26, 0x81e4, 0x4107, 0x8c08
+ax_pose 27, 0x81e8, 0x010f, 0x8c0c
+ax_pose 28, 0x01f0, 0x00ef, 0x8c0e
+ax_pose_terminator
+sBreloomPose96:
+ax_pose 29, 0x41f4, 0x80ef, 0x8c00
+ax_pose 30, 0x01e4, 0x80ef, 0x8c08
+ax_pose_terminator
+sBreloomPose97:
+ax_pose 30, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sBreloomPose98:
+ax_pose 3, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose99:
+ax_pose 4, 0x01ea, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose100:
+ax_pose 5, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose101:
+ax_pose 19, 0x81e5, 0x40f0, 0x8c00
+ax_pose 20, 0x01e5, 0x80f0, 0x8c04
+ax_pose_terminator
+sBreloomPose102:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose103:
+ax_pose 21, 0x81f5, 0x00f0, 0x8c00
+ax_pose 22, 0x01f5, 0x40f8, 0x8c02
+ax_pose 23, 0x01e5, 0x80f0, 0x8c06
+ax_pose_terminator
+sBreloomPose104:
+ax_pose 23, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose105:
+ax_pose 0, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose106:
+ax_pose 39, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose107:
+ax_pose 3, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose108:
+ax_pose 40, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sBreloomPose109:
+ax_pose 6, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose110:
+ax_pose 41, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose111:
+ax_pose 9, 0x01e7, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose112:
+ax_pose 42, 0x01e7, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose113:
+ax_pose 12, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose114:
+ax_pose 43, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose115:
+ax_pose 9, 0x01e7, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose116:
+ax_pose 42, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose117:
+ax_pose 6, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose118:
+ax_pose 41, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose119:
+ax_pose 3, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose120:
+ax_pose 40, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose121:
+ax_pose 0, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose122:
+ax_pose 3, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose123:
+ax_pose 6, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose124:
+ax_pose 9, 0x01e7, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose125:
+ax_pose 12, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose126:
+ax_pose 9, 0x01e7, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose127:
+ax_pose 6, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose128:
+ax_pose 3, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose129:
+ax_pose 44, 0x01e8, 0x80f4, 0x8c00
+ax_pose_terminator
+sBreloomPose130:
+ax_pose 45, 0x01e8, 0x80f4, 0x8c00
+ax_pose_terminator
+sBreloomPose131:
+ax_pose 46, 0x01e0, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose132:
+ax_pose 47, 0x01e2, 0x90eb, 0x8c00
+ax_pose_terminator
+sBreloomPose133:
+ax_pose 48, 0x01e0, 0x90eb, 0x8c00
+ax_pose_terminator
+sBreloomPose134:
+ax_pose 49, 0x01e4, 0x90eb, 0x8c00
+ax_pose_terminator
+sBreloomPose135:
+ax_pose 50, 0x81e2, 0x4106, 0x8c00
+ax_pose 51, 0x0202, 0x00fa, 0x8c04
+ax_pose 52, 0x81e2, 0x80f6, 0x8c05
+ax_pose_terminator
+sBreloomPose136:
+ax_pose 49, 0x01e4, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose137:
+ax_pose 48, 0x01e0, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose138:
+ax_pose 47, 0x01e2, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose139:
+ax_pose 0, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose140:
+ax_pose 1, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose141:
+ax_pose 2, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose142:
+ax_pose 3, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose143:
+ax_pose 4, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose144:
+ax_pose 5, 0x01e5, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose145:
+ax_pose 6, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose146:
+ax_pose 7, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose147:
+ax_pose 8, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose148:
+ax_pose 9, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose149:
+ax_pose 10, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose150:
+ax_pose 11, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose151:
+ax_pose 12, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose152:
+ax_pose 13, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose153:
+ax_pose 14, 0x01e7, 0x80f5, 0x8c00
+ax_pose_terminator
+sBreloomPose154:
+ax_pose 9, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose155:
+ax_pose 10, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose156:
+ax_pose 11, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose157:
+ax_pose 6, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose158:
+ax_pose 7, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose159:
+ax_pose 8, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose160:
+ax_pose 3, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose161:
+ax_pose 4, 0x01ea, 0x80f1, 0x8c00
+ax_pose_terminator
+sBreloomPose162:
+ax_pose 5, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sBreloomPose163:
+ax_pose 39, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose164:
+ax_pose 40, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose165:
+ax_pose 41, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sBreloomPose166:
+ax_pose 42, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose167:
+ax_pose 43, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose168:
+ax_pose 42, 0x01e7, 0x90f0, 0x8c00
+ax_pose_terminator
+sBreloomPose169:
+ax_pose 41, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sBreloomPose170:
+ax_pose 40, 0x01e7, 0x90ee, 0x8c00
+ax_pose_terminator
+sBreloomPose171:
+ax_pose 39, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose172:
+ax_pose 40, 0x01e7, 0x90ee, 0x8c00
+ax_pose_terminator
+sBreloomPose173:
+ax_pose 41, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sBreloomPose174:
+ax_pose 42, 0x01e7, 0x90f0, 0x8c00
+ax_pose_terminator
+sBreloomPose175:
+ax_pose 43, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose176:
+ax_pose 42, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose177:
+ax_pose 41, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sBreloomPose178:
+ax_pose 40, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose179:
+ax_pose 0, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose180:
+ax_pose 39, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose181:
+ax_pose 3, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose182:
+ax_pose 40, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose183:
+ax_pose 6, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose184:
+ax_pose 41, 0x01e4, 0x90ec, 0x8c00
+ax_pose_terminator
+sBreloomPose185:
+ax_pose 9, 0x01e7, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose186:
+ax_pose 42, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sBreloomPose187:
+ax_pose 12, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose188:
+ax_pose 43, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose189:
+ax_pose 9, 0x01e7, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose190:
+ax_pose 42, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose191:
+ax_pose 6, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose192:
+ax_pose 41, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose193:
+ax_pose 3, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose194:
+ax_pose 40, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose195:
+ax_pose 39, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose196:
+ax_pose 40, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose197:
+ax_pose 41, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sBreloomPose198:
+ax_pose 42, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose199:
+ax_pose 43, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose200:
+ax_pose 42, 0x01e7, 0x90f0, 0x8c00
+ax_pose_terminator
+sBreloomPose201:
+ax_pose 41, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sBreloomPose202:
+ax_pose 40, 0x01e7, 0x90ee, 0x8c00
+ax_pose_terminator
+sBreloomPose203:
+ax_pose 0, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sBreloomPose204:
+ax_pose 3, 0x01e6, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose205:
+ax_pose 6, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sBreloomPose206:
+ax_pose 9, 0x01e7, 0x80f6, 0x8c00
+ax_pose_terminator
+sBreloomPose207:
+ax_pose 12, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sBreloomPose208:
+ax_pose 9, 0x01e7, 0x90e9, 0x8c00
+ax_pose_terminator
+sBreloomPose209:
+ax_pose 6, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sBreloomPose210:
+ax_pose 3, 0x01e6, 0x90e9, 0x8c00
+ax_pose_terminator
+.align 2
+sBreloomAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBreloomAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 21, 20, 21,
+ax_anim 2, 1, 28, 21, 20, 21, 20,
+ax_anim 2, 0, 28, 20, 21, 20, 21,
+ax_anim 2, 0, 28, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sBreloomAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sBreloomAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 11, -11, 11, -11,
+ax_anim 2, 0, 34, 20, -19, 20, -19,
+ax_anim 2, 1, 34, 21, -18, 21, -18,
+ax_anim 2, 0, 34, 20, -19, 20, -19,
+ax_anim 2, 0, 34, 21, -18, 21, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sBreloomAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -9, 0, -9,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 1, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 0, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sBreloomAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -11, -11, -11, -11,
+ax_anim 2, 0, 40, -20, -19, -20, -19,
+ax_anim 2, 1, 40, -21, -18, -21, -18,
+ax_anim 2, 0, 40, -20, -19, -20, -19,
+ax_anim 2, 0, 40, -21, -18, -21, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sBreloomAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sBreloomAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -20, 21, -20, 21,
+ax_anim 2, 1, 46, -21, 20, -21, 20,
+ax_anim 2, 0, 46, -20, 21, -20, 21,
+ax_anim 2, 0, 46, -21, 20, -21, 20,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBreloomAnims_3_1:
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 4, 0, 50, 0, -3, 0, -3,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, 2, 0, 2,
+ax_anim 2, 2, 52, 0, 11, 0, 11,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 1, 52, 1, 20, 1, 20,
+ax_anim 2, 0, 53, 0, 20, 0, 20,
+ax_anim 2, 0, 54, -1, 21, -1, 21,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 0, 52, 1, 21, 1, 21,
+ax_anim 2, 0, 53, 0, 20, 0, 20,
+ax_anim 2, 0, 54, -1, 21, -1, 21,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sBreloomAnims_3_2:
+ax_anim 2, 0, 57, -2, -2, -2, -2,
+ax_anim 4, 0, 57, -3, -3, -3, -3,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 56, 2, 2, 2, 2,
+ax_anim 2, 2, 59, 9, 14, 9, 14,
+ax_anim 2, 0, 58, 14, 22, 14, 22,
+ax_anim 2, 1, 59, 14, 24, 14, 24,
+ax_anim 2, 0, 60, 14, 22, 14, 22,
+ax_anim 2, 0, 61, 16, 22, 16, 22,
+ax_anim 2, 0, 58, 14, 22, 14, 22,
+ax_anim 2, 0, 59, 14, 24, 14, 24,
+ax_anim 2, 0, 60, 14, 22, 14, 22,
+ax_anim 2, 0, 61, 16, 22, 16, 22,
+ax_anim 2, 0, 55, 8, 12, 8, 12,
+ax_anim 2, 0, 55, 2, 4, 2, 4,
+ax_anim_terminator
+sBreloomAnims_3_3:
+ax_anim 2, 0, 64, -2, 0, -2, 0,
+ax_anim 4, 0, 64, -3, 0, -3, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 2, 0, 2, 0,
+ax_anim 2, 2, 66, 9, 0, 9, 0,
+ax_anim 2, 0, 65, 14, 0, 14, 0,
+ax_anim 2, 1, 66, 15, 1, 15, 1,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 0, 68, 16, -1, 16, -1,
+ax_anim 2, 0, 65, 14, 0, 14, 0,
+ax_anim 2, 0, 66, 15, 1, 15, 1,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 0, 68, 15, -1, 15, -1,
+ax_anim 2, 0, 62, 8, -2, 8, 0,
+ax_anim 2, 0, 62, 2, -1, 2, 0,
+ax_anim_terminator
+sBreloomAnims_3_4:
+ax_anim 2, 0, 71, -2, 2, -2, 2,
+ax_anim 4, 0, 71, -3, 3, -3, 3,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 0, 70, 2, -2, 2, -2,
+ax_anim 2, 2, 73, 9, -9, 9, -9,
+ax_anim 2, 0, 72, 15, -15, 15, -15,
+ax_anim 2, 1, 73, 17, -15, 17, -15,
+ax_anim 2, 0, 74, 15, -15, 15, -15,
+ax_anim 2, 0, 75, 15, -17, 15, -17,
+ax_anim 2, 0, 72, 15, -15, 15, -15,
+ax_anim 2, 0, 73, 17, -15, 17, -15,
+ax_anim 2, 0, 74, 15, -15, 15, -15,
+ax_anim 2, 0, 75, 15, -17, 15, -17,
+ax_anim 2, 0, 69, 8, -8, 8, -8,
+ax_anim 2, 0, 69, 2, -2, 2, -2,
+ax_anim_terminator
+sBreloomAnims_3_5:
+ax_anim 2, 0, 78, 0, 2, 0, 2,
+ax_anim 4, 0, 78, 0, 3, 0, 3,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -2, 0, -2,
+ax_anim 2, 2, 80, 0, -9, 0, -9,
+ax_anim 2, 0, 79, 0, -13, 0, -13,
+ax_anim 2, 1, 80, -1, -14, -1, -14,
+ax_anim 2, 0, 81, 0, -13, 0, -13,
+ax_anim 2, 0, 82, 1, -14, 1, -14,
+ax_anim 2, 0, 79, 0, -13, 0, -13,
+ax_anim 2, 0, 80, -1, -14, -1, -14,
+ax_anim 2, 0, 81, 0, -13, 0, -13,
+ax_anim 2, 0, 82, 1, -14, 1, -14,
+ax_anim 2, 0, 76, 0, -8, 0, -8,
+ax_anim 2, 0, 76, 0, -2, 0, -2,
+ax_anim_terminator
+sBreloomAnims_3_6:
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 4, 0, 85, 3, 3, 3, 3,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 84, -2, -2, -2, -2,
+ax_anim 2, 2, 87, -9, -9, -9, -9,
+ax_anim 2, 0, 86, -15, -15, -15, -15,
+ax_anim 2, 1, 87, -17, -15, -17, -15,
+ax_anim 2, 0, 88, -15, -15, -15, -15,
+ax_anim 2, 0, 89, -15, -17, -15, -17,
+ax_anim 2, 0, 86, -15, -15, -15, -15,
+ax_anim 2, 0, 87, -17, -15, -17, -15,
+ax_anim 2, 0, 88, -15, -15, -15, -15,
+ax_anim 2, 0, 89, -15, -17, -15, -17,
+ax_anim 2, 0, 83, -8, -8, -8, -8,
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim_terminator
+sBreloomAnims_3_7:
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 4, 0, 92, 3, 0, 3, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 2, 94, -9, 0, -9, 0,
+ax_anim 2, 0, 93, -14, 0, -14, 0,
+ax_anim 2, 1, 94, -15, 1, -15, 1,
+ax_anim 2, 0, 95, -14, 0, -14, 0,
+ax_anim 2, 0, 96, -16, -1, -16, -1,
+ax_anim 2, 0, 93, -14, 0, -14, 0,
+ax_anim 2, 0, 94, -15, 1, -15, 1,
+ax_anim 2, 0, 95, -14, 0, -14, 0,
+ax_anim 2, 0, 96, -15, -1, -15, -1,
+ax_anim 2, 0, 90, -8, -2, -8, 0,
+ax_anim 2, 0, 90, -2, -1, -2, 0,
+ax_anim_terminator
+sBreloomAnims_3_8:
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 4, 0, 99, 3, -3, 3, -3,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 98, -2, 2, -2, 2,
+ax_anim 2, 2, 101, -9, 14, -9, 14,
+ax_anim 2, 0, 100, -14, 22, -14, 22,
+ax_anim 2, 1, 101, -14, 24, -14, 24,
+ax_anim 2, 0, 102, -14, 22, -14, 22,
+ax_anim 2, 0, 103, -16, 22, -16, 22,
+ax_anim 2, 0, 100, -14, 22, -14, 22,
+ax_anim 2, 0, 101, -14, 24, -14, 24,
+ax_anim 2, 0, 102, -14, 22, -14, 22,
+ax_anim 2, 0, 103, -16, 22, -16, 22,
+ax_anim 2, 0, 97, -8, 12, -8, 12,
+ax_anim 2, 0, 97, -2, 4, -2, 4,
+ax_anim_terminator
+.align 2
+sBreloomAnims_4_1:
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim 6, 2, 104, 0, -5, 0, -5,
+ax_anim 1, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 105, 0, 5, 0, 5,
+ax_anim 2, 1, 105, 1, 5, 1, 5,
+ax_anim 2, 0, 105, 0, 5, 0, 5,
+ax_anim 2, 0, 105, 1, 5, 1, 5,
+ax_anim 2, 0, 105, 0, 5, 0, 5,
+ax_anim 2, 0, 105, 1, 5, 1, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sBreloomAnims_4_2:
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -4, -4, -4, -4,
+ax_anim 6, 2, 106, -5, -5, -5, -5,
+ax_anim 1, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 107, 5, 5, 5, 5,
+ax_anim 2, 1, 107, 6, 4, 6, 4,
+ax_anim 2, 0, 107, 5, 5, 5, 5,
+ax_anim 2, 0, 107, 6, 4, 6, 4,
+ax_anim 2, 0, 107, 5, 5, 5, 5,
+ax_anim 2, 0, 107, 6, 4, 6, 4,
+ax_anim 2, 0, 106, 2, 2, 2, 2,
+ax_anim_terminator
+sBreloomAnims_4_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 6, 2, 108, -5, 0, -5, 0,
+ax_anim 1, 0, 109, -2, 0, -2, 0,
+ax_anim 2, 0, 109, 5, 0, 5, 0,
+ax_anim 2, 1, 109, 5, -1, 5, -1,
+ax_anim 2, 0, 109, 5, 0, 5, 0,
+ax_anim 2, 0, 109, 5, -1, 5, -1,
+ax_anim 2, 0, 109, 5, 0, 5, 0,
+ax_anim 2, 0, 109, 5, -1, 5, -1,
+ax_anim 2, 0, 108, 2, 0, 2, 0,
+ax_anim_terminator
+sBreloomAnims_4_4:
+ax_anim 2, 0, 110, -2, 2, -2, 2,
+ax_anim 2, 0, 110, -4, 4, -4, 4,
+ax_anim 6, 2, 110, -5, 5, -5, 5,
+ax_anim 1, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim 2, 1, 111, 6, -4, 6, -4,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim 2, 0, 111, 6, -4, 6, -4,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim 2, 0, 111, 6, -4, 6, -4,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim_terminator
+sBreloomAnims_4_5:
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim 2, 0, 112, 0, 4, 0, 4,
+ax_anim 6, 2, 112, 0, 5, 0, 5,
+ax_anim 1, 0, 113, 0, 2, 0, 2,
+ax_anim 2, 0, 113, 0, -5, 0, -5,
+ax_anim 2, 1, 113, 1, -5, 1, -5,
+ax_anim 2, 0, 113, 0, -5, 0, -5,
+ax_anim 2, 0, 113, 1, -5, 1, -5,
+ax_anim 2, 0, 113, 0, -5, 0, -5,
+ax_anim 2, 0, 113, 1, -5, 1, -5,
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim_terminator
+sBreloomAnims_4_6:
+ax_anim 2, 0, 114, 2, 2, 2, 2,
+ax_anim 2, 0, 114, 4, 4, 4, 4,
+ax_anim 6, 2, 114, 5, 5, 5, 5,
+ax_anim 1, 0, 115, 2, 2, 2, 2,
+ax_anim 2, 0, 115, -5, -5, -5, -5,
+ax_anim 2, 1, 115, -6, -4, -6, -4,
+ax_anim 2, 0, 115, -5, -5, -5, -5,
+ax_anim 2, 0, 115, -6, -4, -6, -4,
+ax_anim 2, 0, 115, -5, -5, -5, -5,
+ax_anim 2, 0, 115, -6, -4, -6, -4,
+ax_anim 2, 0, 114, -2, -2, -2, -2,
+ax_anim_terminator
+sBreloomAnims_4_7:
+ax_anim 2, 0, 116, 2, 0, 2, 0,
+ax_anim 2, 0, 116, 4, 0, 4, 0,
+ax_anim 6, 2, 116, 5, 0, 5, 0,
+ax_anim 1, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 117, -5, 0, -5, 0,
+ax_anim 2, 1, 117, -5, -1, -5, -1,
+ax_anim 2, 0, 117, -5, 0, -5, 0,
+ax_anim 2, 0, 117, -5, -1, -5, -1,
+ax_anim 2, 0, 117, -5, 0, -5, 0,
+ax_anim 2, 0, 117, -5, -1, -5, -1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim_terminator
+sBreloomAnims_4_8:
+ax_anim 2, 0, 118, 2, -2, 2, -2,
+ax_anim 2, 0, 118, 4, -4, 4, -4,
+ax_anim 6, 2, 118, 5, -5, 5, -5,
+ax_anim 1, 0, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 1, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sBreloomAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sBreloomAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sBreloomAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sBreloomAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sBreloomAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sBreloomAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sBreloomAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sBreloomAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sBreloomAnims_8_1:
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 139, 0, -4, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sBreloomAnims_8_2:
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim_terminator
+sBreloomAnims_8_3:
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 4, 0, 145, 0, -4, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim_terminator
+sBreloomAnims_8_4:
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -3, 0, 0,
+ax_anim 4, 0, 148, 0, -4, 0, 0,
+ax_anim 4, 0, 148, 0, -3, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim_terminator
+sBreloomAnims_8_5:
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -3, 0, 0,
+ax_anim 4, 0, 151, 0, -4, 0, 0,
+ax_anim 4, 0, 151, 0, -3, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim_terminator
+sBreloomAnims_8_6:
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 4, 0, 154, 0, -4, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim_terminator
+sBreloomAnims_8_7:
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 157, 0, -4, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 4, 0, 158, 0, -4, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim_terminator
+sBreloomAnims_8_8:
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 4, 0, 160, 0, -4, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 4, 0, 161, 0, -4, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 5, 3, 5, 3,
+ax_anim 2, 0, 164, 7, 12, 7, 12,
+ax_anim 2, 0, 165, 5, 19, 5, 19,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -5, 19, -5, 19,
+ax_anim 2, 0, 168, -7, 12, -7, 12,
+ax_anim 1, 0, 169, -5, 3, -5, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 10, 22, 10,
+ax_anim 3, 0, 165, 22, 18, 22, 18,
+ax_anim 2, 3, 166, 12, 19, 12, 19,
+ax_anim 2, 0, 167, 5, 15, 5, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 4, -5, 4, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 21, 1, 21, 1,
+ax_anim 2, 3, 165, 18, 5, 18, 5,
+ax_anim 2, 0, 166, 10, 7, 10, 7,
+ax_anim 1, 0, 167, 5, 5, 5, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 3, -16, 3, -16,
+ax_anim 2, 0, 162, 9, -19, 9, -19,
+ax_anim 3, 0, 163, 19, -20, 19, -20,
+ax_anim 2, 3, 164, 21, -10, 21, -10,
+ax_anim 2, 0, 165, 15, -3, 15, -3,
+ax_anim 1, 0, 166, 8, 0, 8, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -7, -3, -7, -3,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -6, -18, -6, -16,
+ax_anim 3, 0, 162, 0, -20, 0, -18,
+ax_anim 2, 3, 163, 6, -18, 6, -16,
+ax_anim 2, 0, 164, 8, -10, 8, -10,
+ax_anim 1, 0, 165, 7, -3, 7, -3,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -3, -16, -3, -16,
+ax_anim 2, 0, 162, -9, -19, -9, -19,
+ax_anim 3, 0, 169, -19, -20, -19, -20,
+ax_anim 2, 3, 168, -21, -10, -21, -10,
+ax_anim 2, 0, 167, -15, -3, -15, -3,
+ax_anim 1, 0, 166, -8, 0, -8, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -4, -5, -4, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -21, -1, -21, -1,
+ax_anim 2, 3, 167, -18, 5, -18, 5,
+ax_anim 2, 0, 166, -10, 7, -10, 7,
+ax_anim 1, 0, 165, -5, 5, -5, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 10, -22, 10,
+ax_anim 3, 0, 167, -22, 18, -22, 18,
+ax_anim 2, 3, 166, -12, 19, -12, 19,
+ax_anim 2, 0, 165, -5, 15, -5, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_11_2:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -23, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_11_3:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_11_4:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_11_5:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -23, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_11_6:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_11_7:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_11_8:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -23, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBreloomAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sBreloomGfx1:
+.incbin "baserom.gba", 0x11A6574, 0x200
+sBreloomSprites1:
+ax_sprite sBreloomGfx1, 0x200
+ax_sprite_terminator
+sBreloomGfx2:
+.incbin "baserom.gba", 0x11A6784, 0x200
+sBreloomSprites2:
+ax_sprite sBreloomGfx2, 0x200
+ax_sprite_terminator
+sBreloomGfx3:
+.incbin "baserom.gba", 0x11A6994, 0x200
+sBreloomSprites3:
+ax_sprite sBreloomGfx3, 0x200
+ax_sprite_terminator
+sBreloomGfx4:
+.incbin "baserom.gba", 0x11A6BA4, 0x200
+sBreloomSprites4:
+ax_sprite sBreloomGfx4, 0x200
+ax_sprite_terminator
+sBreloomGfx5:
+.incbin "baserom.gba", 0x11A6DB4, 0x200
+sBreloomSprites5:
+ax_sprite sBreloomGfx5, 0x200
+ax_sprite_terminator
+sBreloomGfx6:
+.incbin "baserom.gba", 0x11A6FC4, 0x200
+sBreloomSprites6:
+ax_sprite sBreloomGfx6, 0x200
+ax_sprite_terminator
+sBreloomGfx7:
+.incbin "baserom.gba", 0x11A71D4, 0x200
+sBreloomSprites7:
+ax_sprite sBreloomGfx7, 0x200
+ax_sprite_terminator
+sBreloomGfx8:
+.incbin "baserom.gba", 0x11A73E4, 0x200
+sBreloomSprites8:
+ax_sprite sBreloomGfx8, 0x200
+ax_sprite_terminator
+sBreloomGfx9:
+.incbin "baserom.gba", 0x11A75F4, 0x200
+sBreloomSprites9:
+ax_sprite sBreloomGfx9, 0x200
+ax_sprite_terminator
+sBreloomGfx10:
+.incbin "baserom.gba", 0x11A7804, 0x200
+sBreloomSprites10:
+ax_sprite sBreloomGfx10, 0x200
+ax_sprite_terminator
+sBreloomGfx11:
+.incbin "baserom.gba", 0x11A7A14, 0x200
+sBreloomSprites11:
+ax_sprite sBreloomGfx11, 0x200
+ax_sprite_terminator
+sBreloomGfx12:
+.incbin "baserom.gba", 0x11A7C24, 0x200
+sBreloomSprites12:
+ax_sprite sBreloomGfx12, 0x200
+ax_sprite_terminator
+sBreloomGfx13:
+.incbin "baserom.gba", 0x11A7E34, 0x200
+sBreloomSprites13:
+ax_sprite sBreloomGfx13, 0x200
+ax_sprite_terminator
+sBreloomGfx14:
+.incbin "baserom.gba", 0x11A8044, 0x200
+sBreloomSprites14:
+ax_sprite sBreloomGfx14, 0x200
+ax_sprite_terminator
+sBreloomGfx15:
+.incbin "baserom.gba", 0x11A8254, 0x200
+sBreloomSprites15:
+ax_sprite sBreloomGfx15, 0x200
+ax_sprite_terminator
+sBreloomGfx16:
+.incbin "baserom.gba", 0x11A8464, 0x80
+sBreloomSprites16:
+ax_sprite sBreloomGfx16, 0x80
+ax_sprite_terminator
+sBreloomGfx17:
+.incbin "baserom.gba", 0x11A84F4, 0x40
+sBreloomGfx17_1:
+.incbin "baserom.gba", 0x11A8534, 0x60
+sBreloomGfx17_2:
+.incbin "baserom.gba", 0x11A8594, 0x40
+sBreloomGfx17_3:
+.incbin "baserom.gba", 0x11A85D4, 0x40
+sBreloomSprites17:
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBreloomGfx17_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBreloomGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx18:
+.incbin "baserom.gba", 0x11A8664, 0x80
+sBreloomSprites18:
+ax_sprite sBreloomGfx18, 0x80
+ax_sprite_terminator
+sBreloomGfx19:
+.incbin "baserom.gba", 0x11A86F4, 0x40
+sBreloomGfx19_1:
+.incbin "baserom.gba", 0x11A8734, 0x60
+sBreloomGfx19_2:
+.incbin "baserom.gba", 0x11A8794, 0x40
+sBreloomGfx19_3:
+.incbin "baserom.gba", 0x11A87D4, 0x40
+sBreloomSprites19:
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBreloomGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx19_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBreloomGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx20:
+.incbin "baserom.gba", 0x11A8864, 0x60
+sBreloomSprites20:
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx20, 0x60
+ax_sprite_terminator
+sBreloomGfx21:
+.incbin "baserom.gba", 0x11A88DC, 0x1E0
+sBreloomSprites21:
+ax_sprite sBreloomGfx21, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx22:
+.incbin "baserom.gba", 0x11A8AD4, 0x40
+sBreloomSprites22:
+ax_sprite sBreloomGfx22, 0x40
+ax_sprite_terminator
+sBreloomGfx23:
+.incbin "baserom.gba", 0x11A8B24, 0x60
+sBreloomSprites23:
+ax_sprite sBreloomGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx24:
+.incbin "baserom.gba", 0x11A8B9C, 0x160
+sBreloomGfx24_1:
+.incbin "baserom.gba", 0x11A8CFC, 0x60
+sBreloomSprites24:
+ax_sprite sBreloomGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx25:
+.incbin "baserom.gba", 0x11A8D84, 0x60
+sBreloomSprites25:
+ax_sprite sBreloomGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx26:
+.incbin "baserom.gba", 0x11A8DFC, 0xC0
+sBreloomGfx26_1:
+.incbin "baserom.gba", 0x11A8EBC, 0x20
+sBreloomSprites26:
+ax_sprite sBreloomGfx26, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx26_1, 0x20
+ax_sprite_terminator
+sBreloomGfx27:
+.incbin "baserom.gba", 0x11A8EFC, 0x80
+sBreloomSprites27:
+ax_sprite sBreloomGfx27, 0x80
+ax_sprite_terminator
+sBreloomGfx28:
+.incbin "baserom.gba", 0x11A8F8C, 0x40
+sBreloomSprites28:
+ax_sprite sBreloomGfx28, 0x40
+ax_sprite_terminator
+sBreloomGfx29:
+.incbin "baserom.gba", 0x11A8FDC, 0x20
+sBreloomSprites29:
+ax_sprite sBreloomGfx29, 0x20
+ax_sprite_terminator
+sBreloomGfx30:
+.incbin "baserom.gba", 0x11A900C, 0x60
+sBreloomGfx30_1:
+.incbin "baserom.gba", 0x11A906C, 0x20
+sBreloomSprites30:
+ax_sprite sBreloomGfx30, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBreloomGfx30_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBreloomGfx31:
+.incbin "baserom.gba", 0x11A90B4, 0x60
+sBreloomGfx31_1:
+.incbin "baserom.gba", 0x11A9114, 0xE0
+sBreloomGfx31_2:
+.incbin "baserom.gba", 0x11A91F4, 0x40
+sBreloomSprites31:
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx31_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx32:
+.incbin "baserom.gba", 0x11A9274, 0x20
+sBreloomGfx32_1:
+.incbin "baserom.gba", 0x11A9294, 0x80
+sBreloomSprites32:
+ax_sprite sBreloomGfx32, 0x20
+ax_sprite 0, 0x60
+ax_sprite sBreloomGfx32_1, 0x80
+ax_sprite_terminator
+sBreloomGfx33:
+.incbin "baserom.gba", 0x11A9334, 0x60
+sBreloomGfx33_1:
+.incbin "baserom.gba", 0x11A9394, 0x80
+sBreloomGfx33_2:
+.incbin "baserom.gba", 0x11A9414, 0x60
+sBreloomGfx33_3:
+.incbin "baserom.gba", 0x11A9474, 0x40
+sBreloomSprites33:
+ax_sprite sBreloomGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx33_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx34:
+.incbin "baserom.gba", 0x11A94FC, 0x20
+sBreloomGfx34_1:
+.incbin "baserom.gba", 0x11A951C, 0x40
+sBreloomSprites34:
+ax_sprite sBreloomGfx34, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx34_1, 0x40
+ax_sprite_terminator
+sBreloomGfx35:
+.incbin "baserom.gba", 0x11A957C, 0x60
+sBreloomGfx35_1:
+.incbin "baserom.gba", 0x11A95DC, 0x80
+sBreloomGfx35_2:
+.incbin "baserom.gba", 0x11A965C, 0x60
+sBreloomGfx35_3:
+.incbin "baserom.gba", 0x11A96BC, 0x40
+sBreloomSprites35:
+ax_sprite sBreloomGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx35_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx36:
+.incbin "baserom.gba", 0x11A9744, 0xC0
+sBreloomSprites36:
+ax_sprite sBreloomGfx36, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sBreloomGfx37:
+.incbin "baserom.gba", 0x11A981C, 0xC0
+sBreloomGfx37_1:
+.incbin "baserom.gba", 0x11A98DC, 0x60
+sBreloomGfx37_2:
+.incbin "baserom.gba", 0x11A993C, 0x60
+sBreloomSprites37:
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx37, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx38:
+.incbin "baserom.gba", 0x11A99DC, 0x20
+sBreloomGfx38_1:
+.incbin "baserom.gba", 0x11A99FC, 0x20
+sBreloomGfx38_2:
+.incbin "baserom.gba", 0x11A9A1C, 0x20
+sBreloomSprites38:
+ax_sprite sBreloomGfx38, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx38_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx38_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sBreloomGfx39:
+.incbin "baserom.gba", 0x11A9A74, 0x60
+sBreloomGfx39_1:
+.incbin "baserom.gba", 0x11A9AD4, 0x60
+sBreloomGfx39_2:
+.incbin "baserom.gba", 0x11A9B34, 0x60
+sBreloomGfx39_3:
+.incbin "baserom.gba", 0x11A9B94, 0x40
+sBreloomSprites39:
+ax_sprite sBreloomGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx39_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBreloomGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx40:
+.incbin "baserom.gba", 0x11A9C1C, 0x40
+sBreloomGfx40_1:
+.incbin "baserom.gba", 0x11A9C5C, 0x180
+sBreloomSprites40:
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx40_1, 0x180
+ax_sprite_terminator
+sBreloomGfx41:
+.incbin "baserom.gba", 0x11A9E04, 0x1E0
+sBreloomSprites41:
+ax_sprite sBreloomGfx41, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx42:
+.incbin "baserom.gba", 0x11A9FFC, 0x40
+sBreloomGfx42_1:
+.incbin "baserom.gba", 0x11AA03C, 0x120
+sBreloomGfx42_2:
+.incbin "baserom.gba", 0x11AA15C, 0x40
+sBreloomSprites42:
+ax_sprite sBreloomGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx42_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx42_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx43:
+.incbin "baserom.gba", 0x11AA1D4, 0x60
+sBreloomGfx43_1:
+.incbin "baserom.gba", 0x11AA234, 0x100
+sBreloomGfx43_2:
+.incbin "baserom.gba", 0x11AA334, 0x60
+sBreloomSprites43:
+ax_sprite sBreloomGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx43_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx43_2, 0x60
+ax_sprite_terminator
+sBreloomGfx44:
+.incbin "baserom.gba", 0x11AA3C4, 0x60
+sBreloomGfx44_1:
+.incbin "baserom.gba", 0x11AA424, 0x60
+sBreloomGfx44_2:
+.incbin "baserom.gba", 0x11AA484, 0x80
+sBreloomGfx44_3:
+.incbin "baserom.gba", 0x11AA504, 0x40
+sBreloomSprites44:
+ax_sprite sBreloomGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx44_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sBreloomGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sBreloomGfx45:
+.incbin "baserom.gba", 0x11AA58C, 0x200
+sBreloomSprites45:
+ax_sprite sBreloomGfx45, 0x200
+ax_sprite_terminator
+sBreloomGfx46:
+.incbin "baserom.gba", 0x11AA79C, 0x200
+sBreloomSprites46:
+ax_sprite sBreloomGfx46, 0x200
+ax_sprite_terminator
+sBreloomGfx47:
+.incbin "baserom.gba", 0x11AA9AC, 0x200
+sBreloomSprites47:
+ax_sprite sBreloomGfx47, 0x200
+ax_sprite_terminator
+sBreloomGfx48:
+.incbin "baserom.gba", 0x11AABBC, 0x200
+sBreloomSprites48:
+ax_sprite sBreloomGfx48, 0x200
+ax_sprite_terminator
+sBreloomGfx49:
+.incbin "baserom.gba", 0x11AADCC, 0x200
+sBreloomSprites49:
+ax_sprite sBreloomGfx49, 0x200
+ax_sprite_terminator
+sBreloomGfx50:
+.incbin "baserom.gba", 0x11AAFDC, 0x200
+sBreloomSprites50:
+ax_sprite sBreloomGfx50, 0x200
+ax_sprite_terminator
+sBreloomGfx51:
+.incbin "baserom.gba", 0x11AB1EC, 0x80
+sBreloomSprites51:
+ax_sprite sBreloomGfx51, 0x80
+ax_sprite_terminator
+sBreloomGfx52:
+.incbin "baserom.gba", 0x11AB27C, 0x20
+sBreloomSprites52:
+ax_sprite sBreloomGfx52, 0x20
+ax_sprite_terminator
+sBreloomGfx53:
+.incbin "baserom.gba", 0x11AB2AC, 0x100
+sBreloomSprites53:
+ax_sprite sBreloomGfx53, 0x100
+ax_sprite_terminator
+sAxPosesBreloom:
+.4byte sBreloomPose1
+.4byte sBreloomPose2
+.4byte sBreloomPose3
+.4byte sBreloomPose4
+.4byte sBreloomPose5
+.4byte sBreloomPose6
+.4byte sBreloomPose7
+.4byte sBreloomPose8
+.4byte sBreloomPose9
+.4byte sBreloomPose10
+.4byte sBreloomPose11
+.4byte sBreloomPose12
+.4byte sBreloomPose13
+.4byte sBreloomPose14
+.4byte sBreloomPose15
+.4byte sBreloomPose16
+.4byte sBreloomPose17
+.4byte sBreloomPose18
+.4byte sBreloomPose19
+.4byte sBreloomPose20
+.4byte sBreloomPose21
+.4byte sBreloomPose22
+.4byte sBreloomPose23
+.4byte sBreloomPose24
+.4byte sBreloomPose25
+.4byte sBreloomPose26
+.4byte sBreloomPose27
+.4byte sBreloomPose28
+.4byte sBreloomPose29
+.4byte sBreloomPose30
+.4byte sBreloomPose31
+.4byte sBreloomPose32
+.4byte sBreloomPose33
+.4byte sBreloomPose34
+.4byte sBreloomPose35
+.4byte sBreloomPose36
+.4byte sBreloomPose37
+.4byte sBreloomPose38
+.4byte sBreloomPose39
+.4byte sBreloomPose40
+.4byte sBreloomPose41
+.4byte sBreloomPose42
+.4byte sBreloomPose43
+.4byte sBreloomPose44
+.4byte sBreloomPose45
+.4byte sBreloomPose46
+.4byte sBreloomPose47
+.4byte sBreloomPose48
+.4byte sBreloomPose49
+.4byte sBreloomPose50
+.4byte sBreloomPose51
+.4byte sBreloomPose52
+.4byte sBreloomPose53
+.4byte sBreloomPose54
+.4byte sBreloomPose55
+.4byte sBreloomPose56
+.4byte sBreloomPose57
+.4byte sBreloomPose58
+.4byte sBreloomPose59
+.4byte sBreloomPose60
+.4byte sBreloomPose61
+.4byte sBreloomPose62
+.4byte sBreloomPose63
+.4byte sBreloomPose64
+.4byte sBreloomPose65
+.4byte sBreloomPose66
+.4byte sBreloomPose67
+.4byte sBreloomPose68
+.4byte sBreloomPose69
+.4byte sBreloomPose70
+.4byte sBreloomPose71
+.4byte sBreloomPose72
+.4byte sBreloomPose73
+.4byte sBreloomPose74
+.4byte sBreloomPose75
+.4byte sBreloomPose76
+.4byte sBreloomPose77
+.4byte sBreloomPose78
+.4byte sBreloomPose79
+.4byte sBreloomPose80
+.4byte sBreloomPose81
+.4byte sBreloomPose82
+.4byte sBreloomPose83
+.4byte sBreloomPose84
+.4byte sBreloomPose85
+.4byte sBreloomPose86
+.4byte sBreloomPose87
+.4byte sBreloomPose88
+.4byte sBreloomPose89
+.4byte sBreloomPose90
+.4byte sBreloomPose91
+.4byte sBreloomPose92
+.4byte sBreloomPose93
+.4byte sBreloomPose94
+.4byte sBreloomPose95
+.4byte sBreloomPose96
+.4byte sBreloomPose97
+.4byte sBreloomPose98
+.4byte sBreloomPose99
+.4byte sBreloomPose100
+.4byte sBreloomPose101
+.4byte sBreloomPose102
+.4byte sBreloomPose103
+.4byte sBreloomPose104
+.4byte sBreloomPose105
+.4byte sBreloomPose106
+.4byte sBreloomPose107
+.4byte sBreloomPose108
+.4byte sBreloomPose109
+.4byte sBreloomPose110
+.4byte sBreloomPose111
+.4byte sBreloomPose112
+.4byte sBreloomPose113
+.4byte sBreloomPose114
+.4byte sBreloomPose115
+.4byte sBreloomPose116
+.4byte sBreloomPose117
+.4byte sBreloomPose118
+.4byte sBreloomPose119
+.4byte sBreloomPose120
+.4byte sBreloomPose121
+.4byte sBreloomPose122
+.4byte sBreloomPose123
+.4byte sBreloomPose124
+.4byte sBreloomPose125
+.4byte sBreloomPose126
+.4byte sBreloomPose127
+.4byte sBreloomPose128
+.4byte sBreloomPose129
+.4byte sBreloomPose130
+.4byte sBreloomPose131
+.4byte sBreloomPose132
+.4byte sBreloomPose133
+.4byte sBreloomPose134
+.4byte sBreloomPose135
+.4byte sBreloomPose136
+.4byte sBreloomPose137
+.4byte sBreloomPose138
+.4byte sBreloomPose139
+.4byte sBreloomPose140
+.4byte sBreloomPose141
+.4byte sBreloomPose142
+.4byte sBreloomPose143
+.4byte sBreloomPose144
+.4byte sBreloomPose145
+.4byte sBreloomPose146
+.4byte sBreloomPose147
+.4byte sBreloomPose148
+.4byte sBreloomPose149
+.4byte sBreloomPose150
+.4byte sBreloomPose151
+.4byte sBreloomPose152
+.4byte sBreloomPose153
+.4byte sBreloomPose154
+.4byte sBreloomPose155
+.4byte sBreloomPose156
+.4byte sBreloomPose157
+.4byte sBreloomPose158
+.4byte sBreloomPose159
+.4byte sBreloomPose160
+.4byte sBreloomPose161
+.4byte sBreloomPose162
+.4byte sBreloomPose163
+.4byte sBreloomPose164
+.4byte sBreloomPose165
+.4byte sBreloomPose166
+.4byte sBreloomPose167
+.4byte sBreloomPose168
+.4byte sBreloomPose169
+.4byte sBreloomPose170
+.4byte sBreloomPose171
+.4byte sBreloomPose172
+.4byte sBreloomPose173
+.4byte sBreloomPose174
+.4byte sBreloomPose175
+.4byte sBreloomPose176
+.4byte sBreloomPose177
+.4byte sBreloomPose178
+.4byte sBreloomPose179
+.4byte sBreloomPose180
+.4byte sBreloomPose181
+.4byte sBreloomPose182
+.4byte sBreloomPose183
+.4byte sBreloomPose184
+.4byte sBreloomPose185
+.4byte sBreloomPose186
+.4byte sBreloomPose187
+.4byte sBreloomPose188
+.4byte sBreloomPose189
+.4byte sBreloomPose190
+.4byte sBreloomPose191
+.4byte sBreloomPose192
+.4byte sBreloomPose193
+.4byte sBreloomPose194
+.4byte sBreloomPose195
+.4byte sBreloomPose196
+.4byte sBreloomPose197
+.4byte sBreloomPose198
+.4byte sBreloomPose199
+.4byte sBreloomPose200
+.4byte sBreloomPose201
+.4byte sBreloomPose202
+.4byte sBreloomPose203
+.4byte sBreloomPose204
+.4byte sBreloomPose205
+.4byte sBreloomPose206
+.4byte sBreloomPose207
+.4byte sBreloomPose208
+.4byte sBreloomPose209
+.4byte sBreloomPose210
+sAxPositionsBreloom:
+.2byte   -1,  -12, 	  -7,   -7, 	   5,   -7, 	  -1,  -10
+.2byte   -2,  -11, 	  -9,   -7, 	   2,   -6, 	  -2,   -9
+.2byte    0,  -11, 	  -4,   -6, 	   7,   -7, 	   0,   -9
+.2byte    2,  -12, 	   5,   -8, 	  -2,   -5, 	   0,  -11
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   1,  -10
+.2byte    1,  -11, 	   4,   -6, 	  -6,   -6, 	  -1,  -10
+.2byte    3,  -13, 	   3,   -9, 	   4,   -6, 	  -1,  -11
+.2byte    4,  -12, 	  -4,   -7, 	   5,   -6, 	   0,  -10
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   0,  -10
+.2byte    2,  -14, 	  -3,   -9, 	   5,   -8, 	  -2,  -11
+.2byte    3,  -13, 	  -7,   -9, 	   4,   -7, 	  -2,  -10
+.2byte    1,  -13, 	  -3,  -10, 	   5,   -7, 	  -2,  -10
+.2byte   -1,  -14, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   6,   -7, 	  -5,   -9, 	   0,  -10
+.2byte   -2,  -13, 	   3,   -9, 	  -8,   -7, 	  -2,  -10
+.2byte   -4,  -14, 	   1,   -9, 	  -7,   -8, 	   0,  -11
+.2byte   -5,  -13, 	   5,   -9, 	  -6,   -7, 	   0,  -10
+.2byte   -3,  -13, 	   1,  -10, 	  -7,   -7, 	   0,  -10
+.2byte   -4,  -13, 	  -4,   -9, 	  -5,   -6, 	   0,  -11
+.2byte   -5,  -12, 	   3,   -7, 	  -6,   -6, 	  -1,  -10
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -1,  -10
+.2byte   -3,  -12, 	  -6,   -8, 	   1,   -5, 	  -1,  -11
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -2,  -10
+.2byte   -2,  -11, 	  -5,   -6, 	   5,   -6, 	   0,  -10
+.2byte   -1,  -12, 	  -7,   -7, 	   5,   -7, 	  -1,  -10
+.2byte   -2,  -11, 	  -9,   -7, 	   2,   -6, 	  -2,   -9
+.2byte    0,  -11, 	  -4,   -6, 	   7,   -7, 	   0,   -9
+.2byte    2,  -12, 	   5,   -8, 	  -2,   -5, 	   0,  -11
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   1,  -10
+.2byte    1,  -11, 	   4,   -6, 	  -6,   -6, 	  -1,  -10
+.2byte    3,  -13, 	   3,   -9, 	   4,   -6, 	  -1,  -11
+.2byte    4,  -12, 	  -4,   -7, 	   5,   -6, 	   0,  -10
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   0,  -10
+.2byte    2,  -14, 	  -3,   -9, 	   5,   -8, 	  -2,  -11
+.2byte    3,  -13, 	  -7,   -9, 	   4,   -7, 	  -2,  -10
+.2byte    1,  -13, 	  -3,  -10, 	   5,   -7, 	  -2,  -10
+.2byte   -1,  -14, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   6,   -7, 	  -5,   -9, 	   0,  -10
+.2byte   -2,  -13, 	   3,   -9, 	  -8,   -7, 	  -2,  -10
+.2byte   -4,  -14, 	   1,   -9, 	  -7,   -8, 	   0,  -11
+.2byte   -5,  -13, 	   5,   -9, 	  -6,   -7, 	   0,  -10
+.2byte   -3,  -13, 	   1,  -10, 	  -7,   -7, 	   0,  -10
+.2byte   -4,  -13, 	  -4,   -9, 	  -5,   -6, 	   0,  -11
+.2byte   -5,  -12, 	   3,   -7, 	  -6,   -6, 	  -1,  -10
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -1,  -10
+.2byte   -3,  -12, 	  -6,   -8, 	   1,   -5, 	  -1,  -11
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -2,  -10
+.2byte   -2,  -11, 	  -5,   -6, 	   5,   -6, 	   0,  -10
+.2byte   -1,  -12, 	  -7,   -7, 	   5,   -7, 	  -1,  -10
+.2byte   -2,  -11, 	  -9,   -7, 	   2,   -6, 	  -2,   -9
+.2byte    0,  -11, 	  -4,   -6, 	   7,   -7, 	   0,   -9
+.2byte    0,  -13, 	  -5,   -4, 	   5,  -12, 	   0,  -11
+.2byte    0,  -13, 	  -5,   -4, 	   5,  -12, 	   0,  -11
+.2byte   -1,  -13, 	  -7,  -12, 	   4,   -4, 	  -1,  -11
+.2byte   -1,  -13, 	  -7,  -12, 	   4,   -4, 	  -1,  -11
+.2byte    2,  -12, 	   5,   -8, 	  -2,   -5, 	   0,  -11
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   1,  -10
+.2byte    1,  -11, 	   4,   -6, 	  -6,   -6, 	  -1,  -10
+.2byte    5,  -12, 	  12,   -5, 	  -4,  -10, 	   3,  -12
+.2byte    5,  -12, 	  12,   -5, 	  -4,  -10, 	   3,  -12
+.2byte    6,  -13, 	   5,  -14, 	   8,   -3, 	   2,  -11
+.2byte    6,  -13, 	   5,  -14, 	   8,   -3, 	   2,  -11
+.2byte    3,  -13, 	   3,   -9, 	   4,   -6, 	  -1,  -11
+.2byte    4,  -12, 	  -4,   -7, 	   5,   -6, 	   0,  -10
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   0,  -10
+.2byte    5,  -15, 	   9,  -12, 	  -5,  -11, 	   1,  -13
+.2byte    5,  -15, 	   9,  -12, 	  -5,  -11, 	   1,  -13
+.2byte    5,  -14, 	   0,  -13, 	  10,   -8, 	   1,  -12
+.2byte    5,  -14, 	   0,  -13, 	  10,   -8, 	   1,  -12
+.2byte    2,  -14, 	  -3,   -9, 	   5,   -8, 	  -2,  -11
+.2byte    3,  -13, 	  -7,   -9, 	   4,   -7, 	  -2,  -10
+.2byte    1,  -13, 	  -3,  -10, 	   5,   -7, 	  -2,  -10
+.2byte    3,  -16, 	   6,  -18, 	   2,  -10, 	  -2,  -13
+.2byte    3,  -16, 	   6,  -18, 	   2,  -10, 	  -2,  -13
+.2byte    4,  -17, 	  -3,  -16, 	  10,  -15, 	   0,  -13
+.2byte    4,  -17, 	  -3,  -16, 	  10,  -15, 	   0,  -13
+.2byte   -1,  -14, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   6,   -7, 	  -5,   -9, 	   0,  -10
+.2byte   -2,  -13, 	   3,   -9, 	  -8,   -7, 	  -2,  -10
+.2byte   -1,  -18, 	   6,  -19, 	  -8,  -11, 	  -2,  -15
+.2byte   -1,  -18, 	   6,  -19, 	  -8,  -11, 	  -2,  -15
+.2byte   -2,  -18, 	   5,  -11, 	  -9,  -19, 	  -1,  -15
+.2byte   -2,  -18, 	   5,  -11, 	  -9,  -19, 	  -1,  -15
+.2byte   -4,  -14, 	   1,   -9, 	  -7,   -8, 	   0,  -11
+.2byte   -5,  -13, 	   5,   -9, 	  -6,   -7, 	   0,  -10
+.2byte   -3,  -13, 	   1,  -10, 	  -7,   -7, 	   0,  -10
+.2byte   -5,  -16, 	  -8,  -18, 	  -4,  -10, 	   0,  -13
+.2byte   -5,  -16, 	  -8,  -18, 	  -4,  -10, 	   0,  -13
+.2byte   -6,  -17, 	   1,  -16, 	 -12,  -15, 	  -2,  -13
+.2byte   -6,  -17, 	   1,  -16, 	 -12,  -15, 	  -2,  -13
+.2byte   -4,  -13, 	  -4,   -9, 	  -5,   -6, 	   0,  -11
+.2byte   -5,  -12, 	   3,   -7, 	  -6,   -6, 	  -1,  -10
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -1,  -10
+.2byte   -6,  -15, 	 -10,  -12, 	   4,  -11, 	  -2,  -13
+.2byte   -6,  -15, 	 -10,  -12, 	   4,  -11, 	  -2,  -13
+.2byte   -6,  -14, 	  -1,  -13, 	 -11,   -8, 	  -2,  -12
+.2byte   -6,  -14, 	  -1,  -13, 	 -11,   -8, 	  -2,  -12
+.2byte   -3,  -12, 	  -6,   -8, 	   1,   -5, 	  -1,  -11
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -2,  -10
+.2byte   -2,  -11, 	  -5,   -6, 	   5,   -6, 	   0,  -10
+.2byte   -6,  -12, 	 -13,   -5, 	   3,  -10, 	  -4,  -12
+.2byte   -6,  -12, 	 -13,   -5, 	   3,  -10, 	  -4,  -12
+.2byte   -7,  -13, 	  -6,  -14, 	  -9,   -3, 	  -3,  -11
+.2byte   -7,  -13, 	  -6,  -14, 	  -9,   -3, 	  -3,  -11
+.2byte   -1,  -11, 	  -7,   -6, 	   5,   -6, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,   -7
+.2byte    2,  -11, 	   5,   -7, 	  -2,   -4, 	   0,  -10
+.2byte    3,   -9, 	   8,   -8, 	  -6,   -4, 	   0,   -9
+.2byte    3,  -12, 	   3,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    6,  -11, 	   2,   -9, 	   2,   -3, 	   1,   -9
+.2byte    2,  -13, 	  -3,   -8, 	   5,   -7, 	  -2,  -10
+.2byte    3,  -12, 	  -8,   -8, 	   5,   -4, 	  -2,   -9
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	   1,   -8, 	  -7,   -7, 	   0,  -10
+.2byte   -5,  -12, 	   6,   -8, 	  -7,   -4, 	   0,   -9
+.2byte   -5,  -12, 	  -5,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -8,  -11, 	  -4,   -9, 	  -4,   -3, 	  -3,   -9
+.2byte   -4,  -11, 	  -7,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -5,   -9, 	 -10,   -8, 	   4,   -4, 	  -2,   -9
+.2byte   -1,  -11, 	  -7,   -6, 	   5,   -6, 	  -1,   -9
+.2byte   -4,  -11, 	  -7,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -5,  -12, 	  -5,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -4,  -13, 	   1,   -8, 	  -7,   -7, 	   0,  -10
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -10
+.2byte    2,  -13, 	  -3,   -8, 	   5,   -7, 	  -2,  -10
+.2byte    3,  -12, 	   3,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    2,  -11, 	   5,   -7, 	  -2,   -4, 	   0,  -10
+.2byte   -3,   -9, 	  -6,   -5, 	   4,   -3, 	  -1,   -8
+.2byte   -4,   -8, 	  -6,   -5, 	   4,   -3, 	  -1,   -8
+.2byte    0,  -16, 	  -6,  -13, 	   6,  -13, 	   0,  -14
+.2byte    2,  -16, 	   5,  -16, 	  -5,  -12, 	   0,  -13
+.2byte    3,  -16, 	   3,  -17, 	  -1,  -13, 	   1,  -13
+.2byte    1,  -18, 	  -3,  -19, 	   5,  -15, 	   0,  -12
+.2byte    0,  -14, 	   7,  -14, 	  -7,  -14, 	   0,  -11
+.2byte   -2,  -18, 	   2,  -19, 	  -6,  -15, 	  -1,  -12
+.2byte   -4,  -16, 	  -4,  -17, 	   0,  -13, 	  -2,  -13
+.2byte   -3,  -16, 	  -6,  -16, 	   4,  -12, 	  -1,  -13
+.2byte   -1,  -12, 	  -7,   -7, 	   5,   -7, 	  -1,  -10
+.2byte   -2,  -11, 	  -9,   -7, 	   2,   -6, 	  -2,   -9
+.2byte    0,  -11, 	  -4,   -6, 	   7,   -7, 	   0,   -9
+.2byte    2,  -12, 	   5,   -8, 	  -2,   -5, 	   0,  -11
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   1,  -10
+.2byte    1,  -11, 	   4,   -6, 	  -6,   -6, 	  -1,  -10
+.2byte    3,  -13, 	   3,   -9, 	   4,   -6, 	  -1,  -11
+.2byte    4,  -12, 	  -4,   -7, 	   5,   -6, 	   0,  -10
+.2byte    3,  -11, 	   4,   -7, 	   0,   -5, 	   0,  -10
+.2byte    2,  -14, 	  -3,   -9, 	   5,   -8, 	  -2,  -11
+.2byte    3,  -13, 	  -7,   -9, 	   4,   -7, 	  -2,  -10
+.2byte    1,  -13, 	  -3,  -10, 	   5,   -7, 	  -2,  -10
+.2byte   -1,  -14, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   6,   -7, 	  -5,   -9, 	   0,  -10
+.2byte   -2,  -13, 	   3,   -9, 	  -8,   -7, 	  -2,  -10
+.2byte   -4,  -14, 	   1,   -9, 	  -7,   -8, 	   0,  -11
+.2byte   -5,  -13, 	   5,   -9, 	  -6,   -7, 	   0,  -10
+.2byte   -3,  -13, 	   1,  -10, 	  -7,   -7, 	   0,  -10
+.2byte   -4,  -13, 	  -4,   -9, 	  -5,   -6, 	   0,  -11
+.2byte   -5,  -12, 	   3,   -7, 	  -6,   -6, 	  -1,  -10
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -1,  -10
+.2byte   -3,  -12, 	  -6,   -8, 	   1,   -5, 	  -1,  -11
+.2byte   -4,  -11, 	  -5,   -7, 	  -1,   -5, 	  -2,  -10
+.2byte   -2,  -11, 	  -5,   -6, 	   5,   -6, 	   0,  -10
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -9,   -7, 	   5,   -3, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,   -9, 	  -2,   -3, 	  -1,   -9
+.2byte   -5,  -12, 	   6,   -8, 	  -7,   -4, 	   0,   -9
+.2byte   -1,  -12, 	   7,   -6, 	  -9,   -6, 	  -1,  -10
+.2byte    4,  -12, 	  -7,   -8, 	   6,   -4, 	  -1,   -9
+.2byte    5,  -11, 	   1,   -9, 	   1,   -3, 	   0,   -9
+.2byte    3,   -8, 	   8,   -7, 	  -6,   -3, 	   0,   -8
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,   -7
+.2byte    3,   -8, 	   8,   -7, 	  -6,   -3, 	   0,   -8
+.2byte    5,  -11, 	   1,   -9, 	   1,   -3, 	   0,   -9
+.2byte    4,  -12, 	  -7,   -8, 	   6,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   7,   -6, 	  -9,   -6, 	  -1,  -10
+.2byte   -5,  -12, 	   6,   -8, 	  -7,   -4, 	   0,   -9
+.2byte   -6,  -11, 	  -2,   -9, 	  -2,   -3, 	  -1,   -9
+.2byte   -4,   -8, 	  -9,   -7, 	   5,   -3, 	  -1,   -8
+.2byte   -1,  -11, 	  -7,   -6, 	   5,   -6, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,   -7
+.2byte    2,  -11, 	   5,   -7, 	  -2,   -4, 	   0,  -10
+.2byte    2,   -9, 	   7,   -8, 	  -7,   -4, 	  -1,   -9
+.2byte    3,  -12, 	   3,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    5,  -12, 	   1,  -10, 	   1,   -4, 	   0,  -10
+.2byte    2,  -13, 	  -3,   -8, 	   5,   -7, 	  -2,  -10
+.2byte    3,  -13, 	  -8,   -9, 	   5,   -5, 	  -2,  -10
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	   1,   -8, 	  -7,   -7, 	   0,  -10
+.2byte   -5,  -13, 	   6,   -9, 	  -7,   -5, 	   0,  -10
+.2byte   -5,  -12, 	  -5,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -12, 	  -3,  -10, 	  -3,   -4, 	  -2,  -10
+.2byte   -4,  -11, 	  -7,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -4,   -8, 	  -9,   -7, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -9,   -7, 	   5,   -3, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,   -9, 	  -2,   -3, 	  -1,   -9
+.2byte   -5,  -12, 	   6,   -8, 	  -7,   -4, 	   0,   -9
+.2byte   -1,  -12, 	   7,   -6, 	  -9,   -6, 	  -1,  -10
+.2byte    4,  -12, 	  -7,   -8, 	   6,   -4, 	  -1,   -9
+.2byte    5,  -11, 	   1,   -9, 	   1,   -3, 	   0,   -9
+.2byte    3,   -8, 	   8,   -7, 	  -6,   -3, 	   0,   -8
+.2byte   -1,  -11, 	  -7,   -6, 	   5,   -6, 	  -1,   -9
+.2byte   -4,  -11, 	  -7,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -5,  -12, 	  -5,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -4,  -13, 	   1,   -8, 	  -7,   -7, 	   0,  -10
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -10
+.2byte    2,  -13, 	  -3,   -8, 	   5,   -7, 	  -2,  -10
+.2byte    3,  -12, 	   3,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    2,  -11, 	   5,   -7, 	  -2,   -4, 	   0,  -10
+sBreloomAnimTable1:
+.4byte sBreloomAnims_1_1
+.4byte sBreloomAnims_1_2
+.4byte sBreloomAnims_1_3
+.4byte sBreloomAnims_1_4
+.4byte sBreloomAnims_1_5
+.4byte sBreloomAnims_1_6
+.4byte sBreloomAnims_1_7
+.4byte sBreloomAnims_1_8
+sBreloomAnimTable2:
+.4byte sBreloomAnims_2_1
+.4byte sBreloomAnims_2_2
+.4byte sBreloomAnims_2_3
+.4byte sBreloomAnims_2_4
+.4byte sBreloomAnims_2_5
+.4byte sBreloomAnims_2_6
+.4byte sBreloomAnims_2_7
+.4byte sBreloomAnims_2_8
+sBreloomAnimTable3:
+.4byte sBreloomAnims_3_1
+.4byte sBreloomAnims_3_2
+.4byte sBreloomAnims_3_3
+.4byte sBreloomAnims_3_4
+.4byte sBreloomAnims_3_5
+.4byte sBreloomAnims_3_6
+.4byte sBreloomAnims_3_7
+.4byte sBreloomAnims_3_8
+sBreloomAnimTable4:
+.4byte sBreloomAnims_4_1
+.4byte sBreloomAnims_4_2
+.4byte sBreloomAnims_4_3
+.4byte sBreloomAnims_4_4
+.4byte sBreloomAnims_4_5
+.4byte sBreloomAnims_4_6
+.4byte sBreloomAnims_4_7
+.4byte sBreloomAnims_4_8
+sBreloomAnimTable5:
+.4byte sBreloomAnims_5_1
+.4byte sBreloomAnims_5_2
+.4byte sBreloomAnims_5_3
+.4byte sBreloomAnims_5_4
+.4byte sBreloomAnims_5_5
+.4byte sBreloomAnims_5_6
+.4byte sBreloomAnims_5_7
+.4byte sBreloomAnims_5_8
+sBreloomAnimTable6:
+.4byte sBreloomAnims_6_1
+.4byte sBreloomAnims_6_1
+.4byte sBreloomAnims_6_1
+.4byte sBreloomAnims_6_1
+.4byte sBreloomAnims_6_1
+.4byte sBreloomAnims_6_1
+.4byte sBreloomAnims_6_1
+.4byte sBreloomAnims_6_1
+sBreloomAnimTable7:
+.4byte sBreloomAnims_7_1
+.4byte sBreloomAnims_7_2
+.4byte sBreloomAnims_7_3
+.4byte sBreloomAnims_7_4
+.4byte sBreloomAnims_7_5
+.4byte sBreloomAnims_7_6
+.4byte sBreloomAnims_7_7
+.4byte sBreloomAnims_7_8
+sBreloomAnimTable8:
+.4byte sBreloomAnims_8_1
+.4byte sBreloomAnims_8_2
+.4byte sBreloomAnims_8_3
+.4byte sBreloomAnims_8_4
+.4byte sBreloomAnims_8_5
+.4byte sBreloomAnims_8_6
+.4byte sBreloomAnims_8_7
+.4byte sBreloomAnims_8_8
+sBreloomAnimTable9:
+.4byte sBreloomAnims_9_1
+.4byte sBreloomAnims_9_2
+.4byte sBreloomAnims_9_3
+.4byte sBreloomAnims_9_4
+.4byte sBreloomAnims_9_5
+.4byte sBreloomAnims_9_6
+.4byte sBreloomAnims_9_7
+.4byte sBreloomAnims_9_8
+sBreloomAnimTable10:
+.4byte sBreloomAnims_10_1
+.4byte sBreloomAnims_10_2
+.4byte sBreloomAnims_10_3
+.4byte sBreloomAnims_10_4
+.4byte sBreloomAnims_10_5
+.4byte sBreloomAnims_10_6
+.4byte sBreloomAnims_10_7
+.4byte sBreloomAnims_10_8
+sBreloomAnimTable11:
+.4byte sBreloomAnims_11_1
+.4byte sBreloomAnims_11_2
+.4byte sBreloomAnims_11_3
+.4byte sBreloomAnims_11_4
+.4byte sBreloomAnims_11_5
+.4byte sBreloomAnims_11_6
+.4byte sBreloomAnims_11_7
+.4byte sBreloomAnims_11_8
+sBreloomAnimTable12:
+.4byte sBreloomAnims_12_1
+.4byte sBreloomAnims_12_2
+.4byte sBreloomAnims_12_3
+.4byte sBreloomAnims_12_4
+.4byte sBreloomAnims_12_5
+.4byte sBreloomAnims_12_6
+.4byte sBreloomAnims_12_7
+.4byte sBreloomAnims_12_8
+sBreloomAnimTable13:
+.4byte sBreloomAnims_13_1
+.4byte sBreloomAnims_13_2
+.4byte sBreloomAnims_13_3
+.4byte sBreloomAnims_13_4
+.4byte sBreloomAnims_13_5
+.4byte sBreloomAnims_13_6
+.4byte sBreloomAnims_13_7
+.4byte sBreloomAnims_13_8
+sAxAnimationsBreloom:
+.4byte sBreloomAnimTable1
+.4byte sBreloomAnimTable2
+.4byte sBreloomAnimTable3
+.4byte sBreloomAnimTable4
+.4byte sBreloomAnimTable5
+.4byte sBreloomAnimTable6
+.4byte sBreloomAnimTable7
+.4byte sBreloomAnimTable8
+.4byte sBreloomAnimTable9
+.4byte sBreloomAnimTable10
+.4byte sBreloomAnimTable11
+.4byte sBreloomAnimTable12
+.4byte sBreloomAnimTable13
+sAxSpritesBreloom:
+.4byte sBreloomSprites1
+.4byte sBreloomSprites2
+.4byte sBreloomSprites3
+.4byte sBreloomSprites4
+.4byte sBreloomSprites5
+.4byte sBreloomSprites6
+.4byte sBreloomSprites7
+.4byte sBreloomSprites8
+.4byte sBreloomSprites9
+.4byte sBreloomSprites10
+.4byte sBreloomSprites11
+.4byte sBreloomSprites12
+.4byte sBreloomSprites13
+.4byte sBreloomSprites14
+.4byte sBreloomSprites15
+.4byte sBreloomSprites16
+.4byte sBreloomSprites17
+.4byte sBreloomSprites18
+.4byte sBreloomSprites19
+.4byte sBreloomSprites20
+.4byte sBreloomSprites21
+.4byte sBreloomSprites22
+.4byte sBreloomSprites23
+.4byte sBreloomSprites24
+.4byte sBreloomSprites25
+.4byte sBreloomSprites26
+.4byte sBreloomSprites27
+.4byte sBreloomSprites28
+.4byte sBreloomSprites29
+.4byte sBreloomSprites30
+.4byte sBreloomSprites31
+.4byte sBreloomSprites32
+.4byte sBreloomSprites33
+.4byte sBreloomSprites34
+.4byte sBreloomSprites35
+.4byte sBreloomSprites36
+.4byte sBreloomSprites37
+.4byte sBreloomSprites38
+.4byte sBreloomSprites39
+.4byte sBreloomSprites40
+.4byte sBreloomSprites41
+.4byte sBreloomSprites42
+.4byte sBreloomSprites43
+.4byte sBreloomSprites44
+.4byte sBreloomSprites45
+.4byte sBreloomSprites46
+.4byte sBreloomSprites47
+.4byte sBreloomSprites48
+.4byte sBreloomSprites49
+.4byte sBreloomSprites50
+.4byte sBreloomSprites51
+.4byte sBreloomSprites52
+.4byte sBreloomSprites53
+sAxMainBreloom:
+ax_main sAxPosesBreloom, sAxAnimationsBreloom, 13, sAxSpritesBreloom, sAxPositionsBreloom

--- a/data/ax/bulbasaur.inc
+++ b/data/ax/bulbasaur.inc
@@ -1,0 +1,4004 @@
+.global gAxBulbasaur
+gAxBulbasaur:
+ax_siro sAxMainBulbasaur
+sBulbasaurPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose3:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose4:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose5:
+ax_pose 4, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose6:
+ax_pose 5, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose7:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose8:
+ax_pose 7, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose9:
+ax_pose 8, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose10:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose12:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose16:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose17:
+ax_pose 10, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose18:
+ax_pose 11, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose19:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose20:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose21:
+ax_pose 8, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose22:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose23:
+ax_pose 4, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose24:
+ax_pose 5, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose27:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose28:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose29:
+ax_pose 4, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose30:
+ax_pose 5, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose31:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose32:
+ax_pose 7, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose33:
+ax_pose 8, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose34:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose35:
+ax_pose 10, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose36:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose40:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose41:
+ax_pose 10, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose42:
+ax_pose 11, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose43:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose44:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose45:
+ax_pose 8, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose46:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose47:
+ax_pose 4, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose48:
+ax_pose 5, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose50:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose51:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose52:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose53:
+ax_pose 4, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose54:
+ax_pose 5, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose55:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose56:
+ax_pose 7, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose57:
+ax_pose 8, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose58:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose59:
+ax_pose 10, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose60:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose61:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose62:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose63:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose64:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose65:
+ax_pose 10, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose66:
+ax_pose 11, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose67:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose68:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose69:
+ax_pose 8, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose70:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose71:
+ax_pose 4, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose72:
+ax_pose 5, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose73:
+ax_pose 15, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose74:
+ax_pose 16, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose75:
+ax_pose 17, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose76:
+ax_pose 18, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose77:
+ax_pose 19, 0x01ec, 0x90f1, 0x3c00
+ax_pose_terminator
+sBulbasaurPose78:
+ax_pose 20, 0x01ec, 0x90f1, 0x3c00
+ax_pose_terminator
+sBulbasaurPose79:
+ax_pose 21, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose80:
+ax_pose 22, 0x01e9, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose81:
+ax_pose 23, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose82:
+ax_pose 24, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose83:
+ax_pose 21, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose84:
+ax_pose 22, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose85:
+ax_pose 19, 0x01ec, 0x80ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose86:
+ax_pose 20, 0x01ec, 0x80ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose87:
+ax_pose 17, 0x01ed, 0x80ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose88:
+ax_pose 18, 0x01ed, 0x80ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose89:
+ax_pose 25, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose90:
+ax_pose 26, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose91:
+ax_pose 27, 0x01ec, 0x90ec, 0x3c00
+ax_pose_terminator
+sBulbasaurPose92:
+ax_pose 28, 0x01ec, 0x90ec, 0x3c00
+ax_pose_terminator
+sBulbasaurPose93:
+ax_pose 29, 0x01ec, 0x90ec, 0x3c00
+ax_pose_terminator
+sBulbasaurPose94:
+ax_pose 30, 0x01ec, 0x90ec, 0x3c00
+ax_pose_terminator
+sBulbasaurPose95:
+ax_pose 31, 0x01ec, 0x90ec, 0x3c00
+ax_pose_terminator
+sBulbasaurPose96:
+ax_pose 32, 0x01ec, 0x90ec, 0x3c00
+ax_pose_terminator
+sBulbasaurPose97:
+ax_pose 33, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose98:
+ax_pose 34, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose99:
+ax_pose 31, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBulbasaurPose100:
+ax_pose 32, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBulbasaurPose101:
+ax_pose 29, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBulbasaurPose102:
+ax_pose 30, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBulbasaurPose103:
+ax_pose 27, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBulbasaurPose104:
+ax_pose 28, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sBulbasaurPose105:
+ax_pose 35, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose106:
+ax_pose 36, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose107:
+ax_pose 37, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose108:
+ax_pose 38, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sBulbasaurPose109:
+ax_pose 39, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose110:
+ax_pose 40, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sBulbasaurPose111:
+ax_pose 41, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose112:
+ax_pose 40, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose113:
+ax_pose 39, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose114:
+ax_pose 38, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose115:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose116:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose117:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose118:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose119:
+ax_pose 4, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose120:
+ax_pose 5, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose121:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose122:
+ax_pose 7, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose123:
+ax_pose 8, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose124:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose125:
+ax_pose 10, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose126:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose127:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose128:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose129:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose130:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose131:
+ax_pose 10, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose132:
+ax_pose 11, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose133:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose134:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose135:
+ax_pose 8, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose136:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose137:
+ax_pose 4, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose138:
+ax_pose 5, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose139:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose140:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose141:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose142:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose143:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose144:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose145:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose146:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose147:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose148:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose149:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose150:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose151:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose152:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose153:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose154:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sBulbasaurPose155:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose156:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose157:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose158:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose159:
+ax_pose 4, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose160:
+ax_pose 5, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose161:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose162:
+ax_pose 7, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose163:
+ax_pose 8, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose164:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose165:
+ax_pose 10, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose166:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose167:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose168:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose169:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose170:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose171:
+ax_pose 10, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose172:
+ax_pose 11, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose173:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose174:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose175:
+ax_pose 8, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose176:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose177:
+ax_pose 4, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose178:
+ax_pose 5, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose179:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose180:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose181:
+ax_pose 2, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose182:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose183:
+ax_pose 4, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose184:
+ax_pose 5, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose185:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose186:
+ax_pose 7, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose187:
+ax_pose 8, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose188:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose189:
+ax_pose 10, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose190:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose191:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose192:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose193:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose194:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose195:
+ax_pose 10, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose196:
+ax_pose 11, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose197:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose198:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose199:
+ax_pose 8, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose200:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose201:
+ax_pose 4, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose202:
+ax_pose 5, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose203:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose204:
+ax_pose 3, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose205:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose206:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose207:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose208:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose209:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose210:
+ax_pose 3, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose211:
+ax_pose 42, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose212:
+ax_pose 43, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose213:
+ax_pose 42, 0x01ef, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose214:
+ax_pose 43, 0x01ef, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose215:
+ax_pose 42, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose216:
+ax_pose 44, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose217:
+ax_pose 45, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose218:
+ax_pose 46, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose219:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose220:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose221:
+ax_pose 47, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose222:
+ax_pose 48, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose223:
+ax_pose 49, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose224:
+ax_pose 50, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose225:
+ax_pose 51, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose226:
+ax_pose 50, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose227:
+ax_pose 52, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose228:
+ax_pose 53, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose229:
+ax_pose 54, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose230:
+ax_pose 55, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose231:
+ax_pose 56, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose232:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose233:
+ax_pose 57, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose234:
+ax_pose 58, 0x01e8, 0x80ee, 0x3c00
+ax_pose_terminator
+sBulbasaurPose235:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose236:
+ax_pose 59, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose237:
+ax_pose 60, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose238:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sBulbasaurPose239:
+ax_pose 61, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose240:
+ax_pose 62, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose241:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose242:
+ax_pose 63, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose243:
+ax_pose 6, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose244:
+ax_pose 63, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose245:
+ax_pose 64, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose246:
+ax_pose 65, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose247:
+ax_pose 66, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose248:
+ax_pose 67, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose249:
+ax_pose 68, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose250:
+ax_pose 69, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose251:
+ax_pose 65, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose252:
+ax_pose 66, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose253:
+ax_pose 67, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose254:
+ax_pose 68, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose255:
+ax_pose 69, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sBulbasaurPose256:
+ax_pose 9, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose257:
+ax_pose 70, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sBulbasaurPose258:
+ax_pose 9, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose259:
+ax_pose 70, 0x01e8, 0x90ed, 0x3c00
+ax_pose_terminator
+sBulbasaurPose260:
+ax_pose 42, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose261:
+ax_pose 43, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose262:
+ax_pose 42, 0x01ef, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose263:
+ax_pose 43, 0x01ef, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose264:
+ax_pose 42, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose265:
+ax_pose 43, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose266:
+ax_pose 42, 0x01ef, 0x90f0, 0x3c00
+ax_pose_terminator
+sBulbasaurPose267:
+ax_pose 43, 0x01ef, 0x90f0, 0x3c00
+ax_pose_terminator
+.align 2
+sBulbasaurAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, -1,
+ax_anim 4, 0, 1, 0, -2, 0, 2,
+ax_anim 4, 0, 2, 0, -3, 0, 3,
+ax_anim 4, 0, 2, 0, -1, 0, 4,
+ax_anim 4, 0, 0, 0, 2, 0, 2,
+ax_anim_terminator
+sBulbasaurAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 2, -1, 1, 1,
+ax_anim 4, 0, 4, 3, -2, 2, 2,
+ax_anim 4, 0, 5, 4, -3, 3, 3,
+ax_anim 4, 0, 5, 5, 1, 4, 4,
+ax_anim 4, 0, 3, 5, 2, 5, 2,
+ax_anim_terminator
+sBulbasaurAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 1, -2, 1, 0,
+ax_anim 4, 0, 8, 2, -4, 2, 0,
+ax_anim 4, 0, 8, 3, -1, 3, 0,
+ax_anim 4, 0, 6, 4, 0, 4, 0,
+ax_anim_terminator
+sBulbasaurAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 2, -2, 2, -2,
+ax_anim 4, 0, 10, 3, -4, 3, -3,
+ax_anim 4, 0, 11, 3, -3, 4, -4,
+ax_anim 4, 0, 11, 4, -2, 5, -5,
+ax_anim 4, 0, 9, 5, -3, 5, -5,
+ax_anim_terminator
+sBulbasaurAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, -1,
+ax_anim 4, 0, 13, 0, -3, 0, -2,
+ax_anim 4, 0, 14, 0, -4, 0, -3,
+ax_anim 4, 0, 14, 0, -2, 0, -4,
+ax_anim 4, 0, 12, 0, -2, 0, -3,
+ax_anim_terminator
+sBulbasaurAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -2, -2, -2, -2,
+ax_anim 4, 0, 16, -3, -4, -3, -3,
+ax_anim 4, 0, 17, -3, -3, -4, -4,
+ax_anim 4, 0, 17, -4, -2, -5, -5,
+ax_anim 4, 0, 15, -5, -3, -5, -5,
+ax_anim_terminator
+sBulbasaurAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -1, -2, -1, 0,
+ax_anim 4, 0, 20, -2, -4, -2, 0,
+ax_anim 4, 0, 20, -3, -1, -3, 0,
+ax_anim 4, 0, 18, -4, 0, -4, 0,
+ax_anim_terminator
+sBulbasaurAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -2, -1, -1, 1,
+ax_anim 4, 0, 22, -3, -2, -2, 2,
+ax_anim 4, 0, 23, -4, -3, -3, 3,
+ax_anim 4, 0, 23, -5, 1, -4, 4,
+ax_anim 4, 0, 21, -5, 2, -5, 2,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sBulbasaurAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 2, 4, 4,
+ax_anim 2, 2, 28, 10, 9, 10, 10,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 0, 29, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sBulbasaurAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, -1, 4, 0,
+ax_anim 2, 2, 31, 10, -1, 10, 0,
+ax_anim 2, 0, 32, 18, -1, 18, 0,
+ax_anim 2, 1, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, -1, 18, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sBulbasaurAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -6, 4, -4,
+ax_anim 2, 2, 34, 10, -11, 10, -10,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 1, 35, 19, -17, 19, -17,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 0, 35, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sBulbasaurAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 37, 0, -10, 0, -10,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 1, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 0, 38, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sBulbasaurAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 2, 0, 40, -4, -6, -4, -4,
+ax_anim 2, 2, 40, -10, -11, -10, -10,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 1, 41, -19, -17, -19, -17,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 0, 41, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sBulbasaurAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, -1, -4, 0,
+ax_anim 2, 2, 43, -10, -1, -10, 0,
+ax_anim 2, 0, 44, -18, -1, -18, 0,
+ax_anim 2, 1, 44, -18, 0, -18, 1,
+ax_anim 2, 0, 44, -18, -1, -18, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sBulbasaurAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 46, -4, 2, -4, 4,
+ax_anim 2, 2, 46, -10, 9, -10, 10,
+ax_anim 2, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 1, 47, -17, 19, -17, 19,
+ax_anim 2, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sBulbasaurAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 4, 2, 4, 4,
+ax_anim 2, 2, 52, 10, 9, 10, 10,
+ax_anim 2, 0, 53, 18, 18, 18, 18,
+ax_anim 2, 1, 53, 19, 17, 19, 17,
+ax_anim 2, 0, 53, 18, 18, 18, 18,
+ax_anim 2, 0, 53, 19, 17, 19, 17,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sBulbasaurAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 4, -1, 4, 0,
+ax_anim 2, 2, 55, 10, -1, 10, 0,
+ax_anim 2, 0, 56, 18, -1, 18, 0,
+ax_anim 2, 1, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, -1, 18, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sBulbasaurAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 4, -6, 4, -4,
+ax_anim 2, 2, 58, 10, -11, 10, -10,
+ax_anim 2, 0, 59, 18, -18, 18, -18,
+ax_anim 2, 1, 59, 19, -17, 19, -17,
+ax_anim 2, 0, 59, 18, -18, 18, -18,
+ax_anim 2, 0, 59, 19, -17, 19, -17,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sBulbasaurAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, -4,
+ax_anim 2, 2, 61, 0, -10, 0, -10,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 1, 62, 1, -18, 1, -18,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 0, 62, 1, -18, 1, -18,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sBulbasaurAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 2, 0, 64, -4, -6, -4, -4,
+ax_anim 2, 2, 64, -10, -11, -10, -10,
+ax_anim 2, 0, 65, -18, -18, -18, -18,
+ax_anim 2, 1, 65, -19, -17, -19, -17,
+ax_anim 2, 0, 65, -18, -18, -18, -18,
+ax_anim 2, 0, 65, -19, -17, -19, -17,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sBulbasaurAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -4, -1, -4, 0,
+ax_anim 2, 2, 67, -10, -1, -10, 0,
+ax_anim 2, 0, 68, -18, -1, -18, 0,
+ax_anim 2, 1, 68, -18, 0, -18, 1,
+ax_anim 2, 0, 68, -18, -1, -18, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sBulbasaurAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 70, -4, 2, -4, 4,
+ax_anim 2, 2, 70, -10, 9, -10, 10,
+ax_anim 2, 0, 71, -18, 18, -18, 18,
+ax_anim 2, 1, 71, -17, 19, -17, 19,
+ax_anim 2, 0, 71, -18, 18, -18, 18,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_4_1:
+ax_anim 12, 0, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 2, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_4_2:
+ax_anim 12, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 4, 2, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_4_3:
+ax_anim 12, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 2, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_4_4:
+ax_anim 12, 0, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 2, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_4_5:
+ax_anim 12, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 2, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_4_6:
+ax_anim 12, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 2, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_4_7:
+ax_anim 12, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 2, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_4_8:
+ax_anim 12, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 2, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_5_1:
+ax_anim 6, 2, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 1, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_5_2:
+ax_anim 6, 2, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 0, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 1, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_5_3:
+ax_anim 6, 2, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 1, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_5_4:
+ax_anim 6, 2, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 1, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_5_5:
+ax_anim 6, 2, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 1, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_5_6:
+ax_anim 6, 2, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 1, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_5_7:
+ax_anim 6, 2, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 1, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_5_8:
+ax_anim 6, 2, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 1, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sBulbasaurAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sBulbasaurAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sBulbasaurAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sBulbasaurAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sBulbasaurAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sBulbasaurAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sBulbasaurAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_8_1:
+ax_anim 40, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, -2, 0, 0,
+ax_anim 6, 0, 116, 0, -4, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_8_2:
+ax_anim 40, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 1, -4, 0, 0,
+ax_anim 6, 0, 119, 0, -3, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_8_3:
+ax_anim 40, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 1, -3, 0, 0,
+ax_anim 6, 0, 122, 1, -3, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_8_4:
+ax_anim 40, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 1, -2, 0, 0,
+ax_anim 6, 0, 125, 1, -2, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_8_5:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, -2, 0, 0,
+ax_anim 6, 0, 128, 0, -3, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_8_6:
+ax_anim 40, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 130, -1, -2, 0, 0,
+ax_anim 6, 0, 131, -1, -2, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_8_7:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 133, -1, -3, 0, 0,
+ax_anim 6, 0, 134, -1, -3, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_8_8:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 136, -1, -4, 0, 0,
+ax_anim 6, 0, 137, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 4, 6, 4,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 13, 7, 13,
+ax_anim 3, 0, 142, 1, 16, 1, 16,
+ax_anim 2, 3, 143, -4, 14, -4, 14,
+ax_anim 2, 0, 144, -5, 8, -5, 8,
+ax_anim 1, 0, 145, -4, 4, -4, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 24, 9, 24, 9,
+ax_anim 3, 0, 141, 23, 16, 23, 16,
+ax_anim 2, 3, 142, 11, 16, 11, 16,
+ax_anim 2, 0, 143, 4, 12, 4, 12,
+ax_anim 1, 0, 144, 3, 7, 3, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 17, -4, 17, -4,
+ax_anim 3, 0, 140, 20, 1, 20, 1,
+ax_anim 2, 3, 141, 17, 5, 17, 5,
+ax_anim 2, 0, 142, 12, 7, 12, 7,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 1, -6, 1, -6,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 11, -20, 11, -20,
+ax_anim 3, 0, 139, 16, -20, 16, -20,
+ax_anim 2, 3, 140, 16, -15, 16, -15,
+ax_anim 2, 0, 141, 14, -6, 14, -6,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -6, -4, -6, -4,
+ax_anim 2, 0, 144, -8, -9, -8, -9,
+ax_anim 2, 0, 145, -7, -13, -7, -13,
+ax_anim 3, 0, 138, -1, -16, -1, -16,
+ax_anim 2, 3, 139, 4, -14, 4, -14,
+ax_anim 2, 0, 140, 5, -8, 5, -8,
+ax_anim 1, 0, 141, 4, -4, 4, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -1, -6, -1, -6,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -11, -20, -11, -20,
+ax_anim 3, 0, 145, -16, -20, -16, -20,
+ax_anim 2, 3, 144, -16, -15, -16, -15,
+ax_anim 2, 0, 143, -14, -6, -14, -6,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -17, -4, -17, -4,
+ax_anim 3, 0, 144, -20, 1, -20, 1,
+ax_anim 2, 3, 143, -17, 5, -17, 5,
+ax_anim 2, 0, 142, -12, 7, -12, 7,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -24, 9, -24, 9,
+ax_anim 3, 0, 143, -23, 16, -23, 16,
+ax_anim 2, 3, 142, -11, 16, -11, 16,
+ax_anim 2, 0, 141, -4, 12, -4, 12,
+ax_anim 1, 0, 140, -3, 7, -3, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_12_1:
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_12_2:
+ax_anim 2, 0, 182, 1, -1, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_12_3:
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_12_4:
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_12_5:
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_12_6:
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_12_7:
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_12_8:
+ax_anim 2, 0, 200, -1, -1, -1, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, -1, -1, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, -1, -1, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, -1, -1, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, -1, -1, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_14_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_14_2:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_14_3:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_14_4:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_14_5:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_14_6:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_14_7:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_14_8:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_15_1:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_15_2:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_15_3:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_15_4:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_15_5:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_15_6:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_15_7:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_15_8:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_16_1:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_16_2:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_16_3:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_16_4:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_16_5:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_16_6:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_16_7:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_16_8:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_17_1:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sBulbasaurAnims_17_2:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sBulbasaurAnims_17_3:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sBulbasaurAnims_17_4:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sBulbasaurAnims_17_5:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sBulbasaurAnims_17_6:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sBulbasaurAnims_17_7:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sBulbasaurAnims_17_8:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_18_1:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -1, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_18_2:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -1, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_18_3:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -1, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_18_4:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -1, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_18_5:
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -2, 0, 0,
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_18_6:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -1, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_18_7:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -1, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_18_8:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -1, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_19_1:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_19_2:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_19_3:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_19_4:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_19_5:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_19_6:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_19_7:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_19_8:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_20_1:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 1, 0, 0,
+ax_anim 2, 0, 233, 1, 1, 1, 0,
+ax_anim 2, 0, 233, 0, 1, 0, 0,
+ax_anim 2, 0, 233, 1, 1, 1, 0,
+ax_anim 2, 0, 233, 0, 1, 0, 0,
+ax_anim 2, 0, 233, 1, 1, 1, 0,
+ax_anim_terminator
+sBulbasaurAnims_20_2:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sBulbasaurAnims_20_3:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sBulbasaurAnims_20_4:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sBulbasaurAnims_20_5:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sBulbasaurAnims_20_6:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sBulbasaurAnims_20_7:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sBulbasaurAnims_20_8:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_21_1:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_21_2:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_21_3:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_21_4:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_21_5:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_21_6:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_21_7:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_21_8:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_22_1:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_22_2:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_22_3:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_22_4:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_22_5:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_22_6:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_22_7:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_22_8:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_23_1:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_23_2:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_23_3:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_23_4:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_23_5:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_23_6:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_23_7:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_23_8:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_24_1:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_24_2:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_24_3:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_24_4:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_24_5:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_24_6:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_24_7:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_24_8:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_25_1:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_25_2:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_25_3:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_25_4:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_25_5:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_25_6:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_25_7:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_25_8:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_26_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sBulbasaurAnims_26_2:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sBulbasaurAnims_26_3:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sBulbasaurAnims_26_4:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sBulbasaurAnims_26_5:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sBulbasaurAnims_26_6:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sBulbasaurAnims_26_7:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sBulbasaurAnims_26_8:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_27_1:
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 16, 0, 259, -1, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 1, 0, 0, 0,
+ax_anim 16, 0, 259, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sBulbasaurAnims_28_1:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_28_2:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_28_3:
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_28_4:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_28_5:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_28_6:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_28_7:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurAnims_28_8:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sBulbasaurGfx1:
+.incbin "baserom.gba", 0x517B74, 0x200
+sBulbasaurSprites1:
+ax_sprite sBulbasaurGfx1, 0x200
+ax_sprite_terminator
+sBulbasaurGfx2:
+.incbin "baserom.gba", 0x517D84, 0x200
+sBulbasaurSprites2:
+ax_sprite sBulbasaurGfx2, 0x200
+ax_sprite_terminator
+sBulbasaurGfx3:
+.incbin "baserom.gba", 0x517F94, 0x200
+sBulbasaurSprites3:
+ax_sprite sBulbasaurGfx3, 0x200
+ax_sprite_terminator
+sBulbasaurGfx4:
+.incbin "baserom.gba", 0x5181A4, 0x200
+sBulbasaurSprites4:
+ax_sprite sBulbasaurGfx4, 0x200
+ax_sprite_terminator
+sBulbasaurGfx5:
+.incbin "baserom.gba", 0x5183B4, 0x200
+sBulbasaurSprites5:
+ax_sprite sBulbasaurGfx5, 0x200
+ax_sprite_terminator
+sBulbasaurGfx6:
+.incbin "baserom.gba", 0x5185C4, 0x200
+sBulbasaurSprites6:
+ax_sprite sBulbasaurGfx6, 0x200
+ax_sprite_terminator
+sBulbasaurGfx7:
+.incbin "baserom.gba", 0x5187D4, 0x200
+sBulbasaurSprites7:
+ax_sprite sBulbasaurGfx7, 0x200
+ax_sprite_terminator
+sBulbasaurGfx8:
+.incbin "baserom.gba", 0x5189E4, 0x200
+sBulbasaurSprites8:
+ax_sprite sBulbasaurGfx8, 0x200
+ax_sprite_terminator
+sBulbasaurGfx9:
+.incbin "baserom.gba", 0x518BF4, 0x200
+sBulbasaurSprites9:
+ax_sprite sBulbasaurGfx9, 0x200
+ax_sprite_terminator
+sBulbasaurGfx10:
+.incbin "baserom.gba", 0x518E04, 0x200
+sBulbasaurSprites10:
+ax_sprite sBulbasaurGfx10, 0x200
+ax_sprite_terminator
+sBulbasaurGfx11:
+.incbin "baserom.gba", 0x519014, 0x200
+sBulbasaurSprites11:
+ax_sprite sBulbasaurGfx11, 0x200
+ax_sprite_terminator
+sBulbasaurGfx12:
+.incbin "baserom.gba", 0x519224, 0x200
+sBulbasaurSprites12:
+ax_sprite sBulbasaurGfx12, 0x200
+ax_sprite_terminator
+sBulbasaurGfx13:
+.incbin "baserom.gba", 0x519434, 0x200
+sBulbasaurSprites13:
+ax_sprite sBulbasaurGfx13, 0x200
+ax_sprite_terminator
+sBulbasaurGfx14:
+.incbin "baserom.gba", 0x519644, 0x200
+sBulbasaurSprites14:
+ax_sprite sBulbasaurGfx14, 0x200
+ax_sprite_terminator
+sBulbasaurGfx15:
+.incbin "baserom.gba", 0x519854, 0x200
+sBulbasaurSprites15:
+ax_sprite sBulbasaurGfx15, 0x200
+ax_sprite_terminator
+sBulbasaurGfx16:
+.incbin "baserom.gba", 0x519A64, 0x40
+sBulbasaurGfx16_1:
+.incbin "baserom.gba", 0x519AA4, 0x60
+sBulbasaurGfx16_2:
+.incbin "baserom.gba", 0x519B04, 0x40
+sBulbasaurSprites16:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBulbasaurGfx16_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx17:
+.incbin "baserom.gba", 0x519B84, 0x40
+sBulbasaurGfx17_1:
+.incbin "baserom.gba", 0x519BC4, 0x60
+sBulbasaurGfx17_2:
+.incbin "baserom.gba", 0x519C24, 0x40
+sBulbasaurSprites17:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sBulbasaurGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx18:
+.incbin "baserom.gba", 0x519CA4, 0x40
+sBulbasaurGfx18_1:
+.incbin "baserom.gba", 0x519CE4, 0x60
+sBulbasaurGfx18_2:
+.incbin "baserom.gba", 0x519D44, 0x60
+sBulbasaurSprites18:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx19:
+.incbin "baserom.gba", 0x519DE4, 0x40
+sBulbasaurGfx19_1:
+.incbin "baserom.gba", 0x519E24, 0x60
+sBulbasaurGfx19_2:
+.incbin "baserom.gba", 0x519E84, 0x60
+sBulbasaurSprites19:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx20:
+.incbin "baserom.gba", 0x519F24, 0x40
+sBulbasaurGfx20_1:
+.incbin "baserom.gba", 0x519F64, 0x60
+sBulbasaurGfx20_2:
+.incbin "baserom.gba", 0x519FC4, 0x60
+sBulbasaurSprites20:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx21:
+.incbin "baserom.gba", 0x51A064, 0x40
+sBulbasaurGfx21_1:
+.incbin "baserom.gba", 0x51A0A4, 0x60
+sBulbasaurGfx21_2:
+.incbin "baserom.gba", 0x51A104, 0x60
+sBulbasaurSprites21:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx22:
+.incbin "baserom.gba", 0x51A1A4, 0x40
+sBulbasaurGfx22_1:
+.incbin "baserom.gba", 0x51A1E4, 0x60
+sBulbasaurGfx22_2:
+.incbin "baserom.gba", 0x51A244, 0x60
+sBulbasaurSprites22:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx23:
+.incbin "baserom.gba", 0x51A2E4, 0x40
+sBulbasaurGfx23_1:
+.incbin "baserom.gba", 0x51A324, 0x60
+sBulbasaurGfx23_2:
+.incbin "baserom.gba", 0x51A384, 0x60
+sBulbasaurSprites23:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx24:
+.incbin "baserom.gba", 0x51A424, 0x40
+sBulbasaurGfx24_1:
+.incbin "baserom.gba", 0x51A464, 0x60
+sBulbasaurGfx24_2:
+.incbin "baserom.gba", 0x51A4C4, 0x60
+sBulbasaurSprites24:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx25:
+.incbin "baserom.gba", 0x51A564, 0x40
+sBulbasaurGfx25_1:
+.incbin "baserom.gba", 0x51A5A4, 0x60
+sBulbasaurGfx25_2:
+.incbin "baserom.gba", 0x51A604, 0x60
+sBulbasaurSprites25:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx26:
+.incbin "baserom.gba", 0x51A6A4, 0x40
+sBulbasaurGfx26_1:
+.incbin "baserom.gba", 0x51A6E4, 0x60
+sBulbasaurGfx26_2:
+.incbin "baserom.gba", 0x51A744, 0x60
+sBulbasaurSprites26:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx27:
+.incbin "baserom.gba", 0x51A7E4, 0x40
+sBulbasaurGfx27_1:
+.incbin "baserom.gba", 0x51A824, 0x40
+sBulbasaurGfx27_2:
+.incbin "baserom.gba", 0x51A864, 0x40
+sBulbasaurSprites27:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBulbasaurGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sBulbasaurGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx28:
+.incbin "baserom.gba", 0x51A8E4, 0x60
+sBulbasaurGfx28_1:
+.incbin "baserom.gba", 0x51A944, 0x60
+sBulbasaurGfx28_2:
+.incbin "baserom.gba", 0x51A9A4, 0x60
+sBulbasaurSprites28:
+ax_sprite sBulbasaurGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx29:
+.incbin "baserom.gba", 0x51AA3C, 0x60
+sBulbasaurGfx29_1:
+.incbin "baserom.gba", 0x51AA9C, 0x60
+sBulbasaurGfx29_2:
+.incbin "baserom.gba", 0x51AAFC, 0x60
+sBulbasaurSprites29:
+ax_sprite sBulbasaurGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx30:
+.incbin "baserom.gba", 0x51AB94, 0x60
+sBulbasaurGfx30_1:
+.incbin "baserom.gba", 0x51ABF4, 0x60
+sBulbasaurGfx30_2:
+.incbin "baserom.gba", 0x51AC54, 0x60
+sBulbasaurSprites30:
+ax_sprite sBulbasaurGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx31:
+.incbin "baserom.gba", 0x51ACEC, 0x60
+sBulbasaurGfx31_1:
+.incbin "baserom.gba", 0x51AD4C, 0x60
+sBulbasaurGfx31_2:
+.incbin "baserom.gba", 0x51ADAC, 0x60
+sBulbasaurSprites31:
+ax_sprite sBulbasaurGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx32:
+.incbin "baserom.gba", 0x51AE44, 0x60
+sBulbasaurGfx32_1:
+.incbin "baserom.gba", 0x51AEA4, 0x60
+sBulbasaurGfx32_2:
+.incbin "baserom.gba", 0x51AF04, 0x60
+sBulbasaurSprites32:
+ax_sprite sBulbasaurGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx33:
+.incbin "baserom.gba", 0x51AF9C, 0x60
+sBulbasaurGfx33_1:
+.incbin "baserom.gba", 0x51AFFC, 0x60
+sBulbasaurGfx33_2:
+.incbin "baserom.gba", 0x51B05C, 0x60
+sBulbasaurSprites33:
+ax_sprite sBulbasaurGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx34:
+.incbin "baserom.gba", 0x51B0F4, 0x40
+sBulbasaurGfx34_1:
+.incbin "baserom.gba", 0x51B134, 0x60
+sBulbasaurGfx34_2:
+.incbin "baserom.gba", 0x51B194, 0x60
+sBulbasaurSprites34:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx35:
+.incbin "baserom.gba", 0x51B234, 0x40
+sBulbasaurGfx35_1:
+.incbin "baserom.gba", 0x51B274, 0x60
+sBulbasaurGfx35_2:
+.incbin "baserom.gba", 0x51B2D4, 0x60
+sBulbasaurSprites35:
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sBulbasaurGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sBulbasaurGfx36:
+.incbin "baserom.gba", 0x51B374, 0x200
+sBulbasaurSprites36:
+ax_sprite sBulbasaurGfx36, 0x200
+ax_sprite_terminator
+sBulbasaurGfx37:
+.incbin "baserom.gba", 0x51B584, 0x200
+sBulbasaurSprites37:
+ax_sprite sBulbasaurGfx37, 0x200
+ax_sprite_terminator
+sBulbasaurGfx38:
+.incbin "baserom.gba", 0x51B794, 0x200
+sBulbasaurSprites38:
+ax_sprite sBulbasaurGfx38, 0x200
+ax_sprite_terminator
+sBulbasaurGfx39:
+.incbin "baserom.gba", 0x51B9A4, 0x200
+sBulbasaurSprites39:
+ax_sprite sBulbasaurGfx39, 0x200
+ax_sprite_terminator
+sBulbasaurGfx40:
+.incbin "baserom.gba", 0x51BBB4, 0x200
+sBulbasaurSprites40:
+ax_sprite sBulbasaurGfx40, 0x200
+ax_sprite_terminator
+sBulbasaurGfx41:
+.incbin "baserom.gba", 0x51BDC4, 0x200
+sBulbasaurSprites41:
+ax_sprite sBulbasaurGfx41, 0x200
+ax_sprite_terminator
+sBulbasaurGfx42:
+.incbin "baserom.gba", 0x51BFD4, 0x200
+sBulbasaurSprites42:
+ax_sprite sBulbasaurGfx42, 0x200
+ax_sprite_terminator
+sBulbasaurGfx43:
+.incbin "baserom.gba", 0x51C1E4, 0x200
+sBulbasaurSprites43:
+ax_sprite sBulbasaurGfx43, 0x200
+ax_sprite_terminator
+sBulbasaurGfx44:
+.incbin "baserom.gba", 0x51C3F4, 0x200
+sBulbasaurSprites44:
+ax_sprite sBulbasaurGfx44, 0x200
+ax_sprite_terminator
+sBulbasaurGfx45:
+.incbin "baserom.gba", 0x51C604, 0x200
+sBulbasaurSprites45:
+ax_sprite sBulbasaurGfx45, 0x200
+ax_sprite_terminator
+sBulbasaurGfx46:
+.incbin "baserom.gba", 0x51C814, 0x200
+sBulbasaurSprites46:
+ax_sprite sBulbasaurGfx46, 0x200
+ax_sprite_terminator
+sBulbasaurGfx47:
+.incbin "baserom.gba", 0x51CA24, 0x200
+sBulbasaurSprites47:
+ax_sprite sBulbasaurGfx47, 0x200
+ax_sprite_terminator
+sBulbasaurGfx48:
+.incbin "baserom.gba", 0x51CC34, 0x200
+sBulbasaurSprites48:
+ax_sprite sBulbasaurGfx48, 0x200
+ax_sprite_terminator
+sBulbasaurGfx49:
+.incbin "baserom.gba", 0x51CE44, 0x200
+sBulbasaurSprites49:
+ax_sprite sBulbasaurGfx49, 0x200
+ax_sprite_terminator
+sBulbasaurGfx50:
+.incbin "baserom.gba", 0x51D054, 0x200
+sBulbasaurSprites50:
+ax_sprite sBulbasaurGfx50, 0x200
+ax_sprite_terminator
+sBulbasaurGfx51:
+.incbin "baserom.gba", 0x51D264, 0x200
+sBulbasaurSprites51:
+ax_sprite sBulbasaurGfx51, 0x200
+ax_sprite_terminator
+sBulbasaurGfx52:
+.incbin "baserom.gba", 0x51D474, 0x200
+sBulbasaurSprites52:
+ax_sprite sBulbasaurGfx52, 0x200
+ax_sprite_terminator
+sBulbasaurGfx53:
+.incbin "baserom.gba", 0x51D684, 0x200
+sBulbasaurSprites53:
+ax_sprite sBulbasaurGfx53, 0x200
+ax_sprite_terminator
+sBulbasaurGfx54:
+.incbin "baserom.gba", 0x51D894, 0x200
+sBulbasaurSprites54:
+ax_sprite sBulbasaurGfx54, 0x200
+ax_sprite_terminator
+sBulbasaurGfx55:
+.incbin "baserom.gba", 0x51DAA4, 0x200
+sBulbasaurSprites55:
+ax_sprite sBulbasaurGfx55, 0x200
+ax_sprite_terminator
+sBulbasaurGfx56:
+.incbin "baserom.gba", 0x51DCB4, 0x200
+sBulbasaurSprites56:
+ax_sprite sBulbasaurGfx56, 0x200
+ax_sprite_terminator
+sBulbasaurGfx57:
+.incbin "baserom.gba", 0x51DEC4, 0x200
+sBulbasaurSprites57:
+ax_sprite sBulbasaurGfx57, 0x200
+ax_sprite_terminator
+sBulbasaurGfx58:
+.incbin "baserom.gba", 0x51E0D4, 0x200
+sBulbasaurSprites58:
+ax_sprite sBulbasaurGfx58, 0x200
+ax_sprite_terminator
+sBulbasaurGfx59:
+.incbin "baserom.gba", 0x51E2E4, 0x200
+sBulbasaurSprites59:
+ax_sprite sBulbasaurGfx59, 0x200
+ax_sprite_terminator
+sBulbasaurGfx60:
+.incbin "baserom.gba", 0x51E4F4, 0x200
+sBulbasaurSprites60:
+ax_sprite sBulbasaurGfx60, 0x200
+ax_sprite_terminator
+sBulbasaurGfx61:
+.incbin "baserom.gba", 0x51E704, 0x200
+sBulbasaurSprites61:
+ax_sprite sBulbasaurGfx61, 0x200
+ax_sprite_terminator
+sBulbasaurGfx62:
+.incbin "baserom.gba", 0x51E914, 0x200
+sBulbasaurSprites62:
+ax_sprite sBulbasaurGfx62, 0x200
+ax_sprite_terminator
+sBulbasaurGfx63:
+.incbin "baserom.gba", 0x51EB24, 0x200
+sBulbasaurSprites63:
+ax_sprite sBulbasaurGfx63, 0x200
+ax_sprite_terminator
+sBulbasaurGfx64:
+.incbin "baserom.gba", 0x51ED34, 0x200
+sBulbasaurSprites64:
+ax_sprite sBulbasaurGfx64, 0x200
+ax_sprite_terminator
+sBulbasaurGfx65:
+.incbin "baserom.gba", 0x51EF44, 0x200
+sBulbasaurSprites65:
+ax_sprite sBulbasaurGfx65, 0x200
+ax_sprite_terminator
+sBulbasaurGfx66:
+.incbin "baserom.gba", 0x51F154, 0x200
+sBulbasaurSprites66:
+ax_sprite sBulbasaurGfx66, 0x200
+ax_sprite_terminator
+sBulbasaurGfx67:
+.incbin "baserom.gba", 0x51F364, 0x200
+sBulbasaurSprites67:
+ax_sprite sBulbasaurGfx67, 0x200
+ax_sprite_terminator
+sBulbasaurGfx68:
+.incbin "baserom.gba", 0x51F574, 0x200
+sBulbasaurSprites68:
+ax_sprite sBulbasaurGfx68, 0x200
+ax_sprite_terminator
+sBulbasaurGfx69:
+.incbin "baserom.gba", 0x51F784, 0x200
+sBulbasaurSprites69:
+ax_sprite sBulbasaurGfx69, 0x200
+ax_sprite_terminator
+sBulbasaurGfx70:
+.incbin "baserom.gba", 0x51F994, 0x200
+sBulbasaurSprites70:
+ax_sprite sBulbasaurGfx70, 0x200
+ax_sprite_terminator
+sBulbasaurGfx71:
+.incbin "baserom.gba", 0x51FBA4, 0x200
+sBulbasaurSprites71:
+ax_sprite sBulbasaurGfx71, 0x200
+ax_sprite_terminator
+sAxPosesBulbasaur:
+.4byte sBulbasaurPose1
+.4byte sBulbasaurPose2
+.4byte sBulbasaurPose3
+.4byte sBulbasaurPose4
+.4byte sBulbasaurPose5
+.4byte sBulbasaurPose6
+.4byte sBulbasaurPose7
+.4byte sBulbasaurPose8
+.4byte sBulbasaurPose9
+.4byte sBulbasaurPose10
+.4byte sBulbasaurPose11
+.4byte sBulbasaurPose12
+.4byte sBulbasaurPose13
+.4byte sBulbasaurPose14
+.4byte sBulbasaurPose15
+.4byte sBulbasaurPose16
+.4byte sBulbasaurPose17
+.4byte sBulbasaurPose18
+.4byte sBulbasaurPose19
+.4byte sBulbasaurPose20
+.4byte sBulbasaurPose21
+.4byte sBulbasaurPose22
+.4byte sBulbasaurPose23
+.4byte sBulbasaurPose24
+.4byte sBulbasaurPose25
+.4byte sBulbasaurPose26
+.4byte sBulbasaurPose27
+.4byte sBulbasaurPose28
+.4byte sBulbasaurPose29
+.4byte sBulbasaurPose30
+.4byte sBulbasaurPose31
+.4byte sBulbasaurPose32
+.4byte sBulbasaurPose33
+.4byte sBulbasaurPose34
+.4byte sBulbasaurPose35
+.4byte sBulbasaurPose36
+.4byte sBulbasaurPose37
+.4byte sBulbasaurPose38
+.4byte sBulbasaurPose39
+.4byte sBulbasaurPose40
+.4byte sBulbasaurPose41
+.4byte sBulbasaurPose42
+.4byte sBulbasaurPose43
+.4byte sBulbasaurPose44
+.4byte sBulbasaurPose45
+.4byte sBulbasaurPose46
+.4byte sBulbasaurPose47
+.4byte sBulbasaurPose48
+.4byte sBulbasaurPose49
+.4byte sBulbasaurPose50
+.4byte sBulbasaurPose51
+.4byte sBulbasaurPose52
+.4byte sBulbasaurPose53
+.4byte sBulbasaurPose54
+.4byte sBulbasaurPose55
+.4byte sBulbasaurPose56
+.4byte sBulbasaurPose57
+.4byte sBulbasaurPose58
+.4byte sBulbasaurPose59
+.4byte sBulbasaurPose60
+.4byte sBulbasaurPose61
+.4byte sBulbasaurPose62
+.4byte sBulbasaurPose63
+.4byte sBulbasaurPose64
+.4byte sBulbasaurPose65
+.4byte sBulbasaurPose66
+.4byte sBulbasaurPose67
+.4byte sBulbasaurPose68
+.4byte sBulbasaurPose69
+.4byte sBulbasaurPose70
+.4byte sBulbasaurPose71
+.4byte sBulbasaurPose72
+.4byte sBulbasaurPose73
+.4byte sBulbasaurPose74
+.4byte sBulbasaurPose75
+.4byte sBulbasaurPose76
+.4byte sBulbasaurPose77
+.4byte sBulbasaurPose78
+.4byte sBulbasaurPose79
+.4byte sBulbasaurPose80
+.4byte sBulbasaurPose81
+.4byte sBulbasaurPose82
+.4byte sBulbasaurPose83
+.4byte sBulbasaurPose84
+.4byte sBulbasaurPose85
+.4byte sBulbasaurPose86
+.4byte sBulbasaurPose87
+.4byte sBulbasaurPose88
+.4byte sBulbasaurPose89
+.4byte sBulbasaurPose90
+.4byte sBulbasaurPose91
+.4byte sBulbasaurPose92
+.4byte sBulbasaurPose93
+.4byte sBulbasaurPose94
+.4byte sBulbasaurPose95
+.4byte sBulbasaurPose96
+.4byte sBulbasaurPose97
+.4byte sBulbasaurPose98
+.4byte sBulbasaurPose99
+.4byte sBulbasaurPose100
+.4byte sBulbasaurPose101
+.4byte sBulbasaurPose102
+.4byte sBulbasaurPose103
+.4byte sBulbasaurPose104
+.4byte sBulbasaurPose105
+.4byte sBulbasaurPose106
+.4byte sBulbasaurPose107
+.4byte sBulbasaurPose108
+.4byte sBulbasaurPose109
+.4byte sBulbasaurPose110
+.4byte sBulbasaurPose111
+.4byte sBulbasaurPose112
+.4byte sBulbasaurPose113
+.4byte sBulbasaurPose114
+.4byte sBulbasaurPose115
+.4byte sBulbasaurPose116
+.4byte sBulbasaurPose117
+.4byte sBulbasaurPose118
+.4byte sBulbasaurPose119
+.4byte sBulbasaurPose120
+.4byte sBulbasaurPose121
+.4byte sBulbasaurPose122
+.4byte sBulbasaurPose123
+.4byte sBulbasaurPose124
+.4byte sBulbasaurPose125
+.4byte sBulbasaurPose126
+.4byte sBulbasaurPose127
+.4byte sBulbasaurPose128
+.4byte sBulbasaurPose129
+.4byte sBulbasaurPose130
+.4byte sBulbasaurPose131
+.4byte sBulbasaurPose132
+.4byte sBulbasaurPose133
+.4byte sBulbasaurPose134
+.4byte sBulbasaurPose135
+.4byte sBulbasaurPose136
+.4byte sBulbasaurPose137
+.4byte sBulbasaurPose138
+.4byte sBulbasaurPose139
+.4byte sBulbasaurPose140
+.4byte sBulbasaurPose141
+.4byte sBulbasaurPose142
+.4byte sBulbasaurPose143
+.4byte sBulbasaurPose144
+.4byte sBulbasaurPose145
+.4byte sBulbasaurPose146
+.4byte sBulbasaurPose147
+.4byte sBulbasaurPose148
+.4byte sBulbasaurPose149
+.4byte sBulbasaurPose150
+.4byte sBulbasaurPose151
+.4byte sBulbasaurPose152
+.4byte sBulbasaurPose153
+.4byte sBulbasaurPose154
+.4byte sBulbasaurPose155
+.4byte sBulbasaurPose156
+.4byte sBulbasaurPose157
+.4byte sBulbasaurPose158
+.4byte sBulbasaurPose159
+.4byte sBulbasaurPose160
+.4byte sBulbasaurPose161
+.4byte sBulbasaurPose162
+.4byte sBulbasaurPose163
+.4byte sBulbasaurPose164
+.4byte sBulbasaurPose165
+.4byte sBulbasaurPose166
+.4byte sBulbasaurPose167
+.4byte sBulbasaurPose168
+.4byte sBulbasaurPose169
+.4byte sBulbasaurPose170
+.4byte sBulbasaurPose171
+.4byte sBulbasaurPose172
+.4byte sBulbasaurPose173
+.4byte sBulbasaurPose174
+.4byte sBulbasaurPose175
+.4byte sBulbasaurPose176
+.4byte sBulbasaurPose177
+.4byte sBulbasaurPose178
+.4byte sBulbasaurPose179
+.4byte sBulbasaurPose180
+.4byte sBulbasaurPose181
+.4byte sBulbasaurPose182
+.4byte sBulbasaurPose183
+.4byte sBulbasaurPose184
+.4byte sBulbasaurPose185
+.4byte sBulbasaurPose186
+.4byte sBulbasaurPose187
+.4byte sBulbasaurPose188
+.4byte sBulbasaurPose189
+.4byte sBulbasaurPose190
+.4byte sBulbasaurPose191
+.4byte sBulbasaurPose192
+.4byte sBulbasaurPose193
+.4byte sBulbasaurPose194
+.4byte sBulbasaurPose195
+.4byte sBulbasaurPose196
+.4byte sBulbasaurPose197
+.4byte sBulbasaurPose198
+.4byte sBulbasaurPose199
+.4byte sBulbasaurPose200
+.4byte sBulbasaurPose201
+.4byte sBulbasaurPose202
+.4byte sBulbasaurPose203
+.4byte sBulbasaurPose204
+.4byte sBulbasaurPose205
+.4byte sBulbasaurPose206
+.4byte sBulbasaurPose207
+.4byte sBulbasaurPose208
+.4byte sBulbasaurPose209
+.4byte sBulbasaurPose210
+.4byte sBulbasaurPose211
+.4byte sBulbasaurPose212
+.4byte sBulbasaurPose213
+.4byte sBulbasaurPose214
+.4byte sBulbasaurPose215
+.4byte sBulbasaurPose216
+.4byte sBulbasaurPose217
+.4byte sBulbasaurPose218
+.4byte sBulbasaurPose219
+.4byte sBulbasaurPose220
+.4byte sBulbasaurPose221
+.4byte sBulbasaurPose222
+.4byte sBulbasaurPose223
+.4byte sBulbasaurPose224
+.4byte sBulbasaurPose225
+.4byte sBulbasaurPose226
+.4byte sBulbasaurPose227
+.4byte sBulbasaurPose228
+.4byte sBulbasaurPose229
+.4byte sBulbasaurPose230
+.4byte sBulbasaurPose231
+.4byte sBulbasaurPose232
+.4byte sBulbasaurPose233
+.4byte sBulbasaurPose234
+.4byte sBulbasaurPose235
+.4byte sBulbasaurPose236
+.4byte sBulbasaurPose237
+.4byte sBulbasaurPose238
+.4byte sBulbasaurPose239
+.4byte sBulbasaurPose240
+.4byte sBulbasaurPose241
+.4byte sBulbasaurPose242
+.4byte sBulbasaurPose243
+.4byte sBulbasaurPose244
+.4byte sBulbasaurPose245
+.4byte sBulbasaurPose246
+.4byte sBulbasaurPose247
+.4byte sBulbasaurPose248
+.4byte sBulbasaurPose249
+.4byte sBulbasaurPose250
+.4byte sBulbasaurPose251
+.4byte sBulbasaurPose252
+.4byte sBulbasaurPose253
+.4byte sBulbasaurPose254
+.4byte sBulbasaurPose255
+.4byte sBulbasaurPose256
+.4byte sBulbasaurPose257
+.4byte sBulbasaurPose258
+.4byte sBulbasaurPose259
+.4byte sBulbasaurPose260
+.4byte sBulbasaurPose261
+.4byte sBulbasaurPose262
+.4byte sBulbasaurPose263
+.4byte sBulbasaurPose264
+.4byte sBulbasaurPose265
+.4byte sBulbasaurPose266
+.4byte sBulbasaurPose267
+sAxPositionsBulbasaur:
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,   -4
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte    6,   -6, 	  10,   -7, 	   1,   -2, 	  -1,   -8
+.2byte    7,   -1, 	   7,   -4, 	  -2,    3, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    8,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte    9,   -4, 	   3,   -2, 	   1,    2, 	  -2,   -6
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    6,  -16, 	  -1,  -13, 	   8,   -9, 	  -2,   -9
+.2byte    8,  -15, 	   1,  -11, 	   7,   -5, 	   0,  -10
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,  -18, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,   -9
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,  -16, 	  -1,  -13, 	 -10,   -9, 	   0,   -9
+.2byte  -10,  -15, 	  -3,  -11, 	  -9,   -5, 	  -2,  -10
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte  -10,   -9, 	  -7,   -7, 	  -8,   -4, 	   0,   -7
+.2byte  -11,   -4, 	  -5,   -2, 	  -3,    2, 	   0,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte   -8,   -6, 	 -12,   -7, 	  -3,   -2, 	  -1,   -8
+.2byte   -9,   -1, 	  -9,   -4, 	   0,    3, 	   0,   -6
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,   -4
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte    6,   -6, 	  10,   -7, 	   1,   -2, 	  -1,   -8
+.2byte    7,   -1, 	   7,   -4, 	  -2,    3, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    8,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte    9,   -4, 	   3,   -2, 	   1,    2, 	  -2,   -6
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    6,  -16, 	  -1,  -13, 	   8,   -9, 	  -2,   -9
+.2byte    8,  -15, 	   1,  -11, 	   7,   -5, 	   0,  -10
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,  -18, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,   -9
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,  -16, 	  -1,  -13, 	 -10,   -9, 	   0,   -9
+.2byte  -10,  -15, 	  -3,  -11, 	  -9,   -5, 	  -2,  -10
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte  -10,   -9, 	  -7,   -7, 	  -8,   -4, 	   0,   -7
+.2byte  -11,   -4, 	  -5,   -2, 	  -3,    2, 	   0,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte   -8,   -6, 	 -12,   -7, 	  -3,   -2, 	  -1,   -8
+.2byte   -9,   -1, 	  -9,   -4, 	   0,    3, 	   0,   -6
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,   -4
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte    6,   -6, 	  10,   -7, 	   1,   -2, 	  -1,   -8
+.2byte    7,   -1, 	   7,   -4, 	  -2,    3, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    8,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte    9,   -4, 	   3,   -2, 	   1,    2, 	  -2,   -6
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    6,  -16, 	  -1,  -13, 	   8,   -9, 	  -2,   -9
+.2byte    8,  -15, 	   1,  -11, 	   7,   -5, 	   0,  -10
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,  -18, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,   -9
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,  -16, 	  -1,  -13, 	 -10,   -9, 	   0,   -9
+.2byte  -10,  -15, 	  -3,  -11, 	  -9,   -5, 	  -2,  -10
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte  -10,   -9, 	  -7,   -7, 	  -8,   -4, 	   0,   -7
+.2byte  -11,   -4, 	  -5,   -2, 	  -3,    2, 	   0,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte   -8,   -6, 	 -12,   -7, 	  -3,   -2, 	  -1,   -8
+.2byte   -9,   -1, 	  -9,   -4, 	   0,    3, 	   0,   -6
+.2byte   -1,  -11, 	  -7,    0, 	   5,    0, 	  -1,   -6
+.2byte   -1,  -14, 	  -7,    0, 	   5,    0, 	  -1,   -7
+.2byte    2,  -13, 	   7,   -3, 	  -2,    1, 	   2,   -7
+.2byte    1,  -15, 	   6,   -2, 	  -2,    1, 	   0,   -7
+.2byte    5,  -16, 	   6,   -8, 	   1,    0, 	   3,   -7
+.2byte    4,  -16, 	   4,   -7, 	   1,    0, 	   2,   -7
+.2byte    3,  -16, 	  -4,  -11, 	   7,   -3, 	   2,  -11
+.2byte    2,  -16, 	  -4,  -10, 	   7,   -2, 	   1,  -10
+.2byte   -1,  -17, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -16, 	   4,   -8, 	  -6,   -7, 	  -1,   -9
+.2byte   -5,  -16, 	   2,  -11, 	  -9,   -3, 	  -4,  -11
+.2byte   -3,  -16, 	   3,  -10, 	  -8,   -2, 	  -2,  -10
+.2byte   -6,  -16, 	  -7,   -8, 	  -2,    0, 	  -4,   -7
+.2byte   -5,  -16, 	  -5,   -7, 	  -2,    0, 	  -3,   -7
+.2byte   -4,  -13, 	  -9,   -3, 	   0,    1, 	  -4,   -7
+.2byte   -3,  -15, 	  -8,   -2, 	   0,    1, 	  -2,   -7
+.2byte   -3,  -12, 	  -7,    0, 	   5,    0, 	  -2,   -6
+.2byte    1,  -12, 	  -7,    0, 	   5,    0, 	   0,   -7
+.2byte   -3,  -12, 	   6,   -5, 	  -3,    0, 	  -2,   -9
+.2byte   -5,  -11, 	   4,   -5, 	  -3,    0, 	  -3,   -9
+.2byte   -4,  -10, 	   0,   -8, 	  -1,    0, 	  -2,   -7
+.2byte   -4,   -8, 	   0,   -7, 	  -1,    0, 	  -1,   -6
+.2byte   -4,  -11, 	  -8,   -7, 	   6,   -3, 	  -1,   -8
+.2byte    0,  -10, 	  -8,   -7, 	   6,   -3, 	   0,   -7
+.2byte    1,  -10, 	   5,   -7, 	  -7,   -7, 	   0,   -6
+.2byte   -2,  -10, 	   5,   -7, 	  -7,   -8, 	  -2,   -6
+.2byte    2,  -11, 	   6,   -7, 	  -8,   -3, 	  -1,   -8
+.2byte   -2,  -10, 	   6,   -7, 	  -8,   -3, 	  -2,   -7
+.2byte    2,  -10, 	  -2,   -8, 	  -1,    0, 	   0,   -7
+.2byte    2,   -8, 	  -2,   -7, 	  -1,    0, 	  -1,   -6
+.2byte    1,  -12, 	  -8,   -5, 	   1,    0, 	   0,   -9
+.2byte    3,  -11, 	  -6,   -5, 	   1,    0, 	   1,   -9
+.2byte   -8,   -2, 	  -8,   -5, 	  -2,    2, 	   0,   -6
+.2byte   -8,   -1, 	  -8,   -4, 	  -2,    2, 	   0,   -6
+.2byte   -1,    0, 	  -8,    1, 	   6,    1, 	  -1,   -8
+.2byte    8,   -2, 	   7,   -7, 	   2,    1, 	  -1,   -8
+.2byte   10,   -4, 	   7,   -8, 	   5,    1, 	   1,   -7
+.2byte    9,  -11, 	   0,  -13, 	   8,   -3, 	  -1,   -8
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -8, 	  -1,   -9
+.2byte  -10,  -11, 	  -1,  -13, 	  -9,   -3, 	   0,   -8
+.2byte  -11,   -4, 	  -8,   -8, 	  -6,    1, 	  -2,   -7
+.2byte   -9,   -2, 	  -8,   -7, 	  -3,    1, 	   0,   -8
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,   -4
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte    6,   -6, 	  10,   -7, 	   1,   -2, 	  -1,   -8
+.2byte    7,   -1, 	   7,   -4, 	  -2,    3, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    8,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte    9,   -4, 	   3,   -2, 	   1,    2, 	  -2,   -6
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    6,  -16, 	  -1,  -13, 	   8,   -9, 	  -2,   -9
+.2byte    8,  -15, 	   1,  -11, 	   7,   -5, 	   0,  -10
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,  -18, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,   -9
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,  -16, 	  -1,  -13, 	 -10,   -9, 	   0,   -9
+.2byte  -10,  -15, 	  -3,  -11, 	  -9,   -5, 	  -2,  -10
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte  -10,   -9, 	  -7,   -7, 	  -8,   -4, 	   0,   -7
+.2byte  -11,   -4, 	  -5,   -2, 	  -3,    2, 	   0,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte   -8,   -6, 	 -12,   -7, 	  -3,   -2, 	  -1,   -8
+.2byte   -9,   -1, 	  -9,   -4, 	   0,    3, 	   0,   -6
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte   -7,   -4, 	  -5,   -5, 	   2,    0, 	   1,   -6
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,   -4
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte    6,   -6, 	  10,   -7, 	   1,   -2, 	  -1,   -8
+.2byte    7,   -1, 	   7,   -4, 	  -2,    3, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    8,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte    9,   -4, 	   3,   -2, 	   1,    2, 	  -2,   -6
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    6,  -16, 	  -1,  -13, 	   8,   -9, 	  -2,   -9
+.2byte    8,  -15, 	   1,  -11, 	   7,   -5, 	   0,  -10
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,  -18, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,   -9
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,  -16, 	  -1,  -13, 	 -10,   -9, 	   0,   -9
+.2byte  -10,  -15, 	  -3,  -11, 	  -9,   -5, 	  -2,  -10
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte  -10,   -9, 	  -7,   -7, 	  -8,   -4, 	   0,   -7
+.2byte  -11,   -4, 	  -5,   -2, 	  -3,    2, 	   0,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte   -8,   -6, 	 -12,   -7, 	  -3,   -2, 	  -1,   -8
+.2byte   -9,   -1, 	  -9,   -4, 	   0,    3, 	   0,   -6
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,   -4
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte    6,   -6, 	  10,   -7, 	   1,   -2, 	  -1,   -8
+.2byte    7,   -1, 	   7,   -4, 	  -2,    3, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    8,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte    9,   -4, 	   3,   -2, 	   1,    2, 	  -2,   -6
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    6,  -16, 	  -1,  -13, 	   8,   -9, 	  -2,   -9
+.2byte    8,  -15, 	   1,  -11, 	   7,   -5, 	   0,  -10
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,  -18, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,   -9
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,  -16, 	  -1,  -13, 	 -10,   -9, 	   0,   -9
+.2byte  -10,  -15, 	  -3,  -11, 	  -9,   -5, 	  -2,  -10
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte  -10,   -9, 	  -7,   -7, 	  -8,   -4, 	   0,   -7
+.2byte  -11,   -4, 	  -5,   -2, 	  -3,    2, 	   0,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte   -8,   -6, 	 -12,   -7, 	  -3,   -2, 	  -1,   -8
+.2byte   -9,   -1, 	  -9,   -4, 	   0,    3, 	   0,   -6
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -8,   -4, 	  -6,   -5, 	   1,    0, 	   0,   -6
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    6,   -4, 	   4,   -5, 	  -3,    0, 	  -2,   -6
+.2byte   -9,   -2, 	  -8,   -3, 	  -6,    0, 	  -1,   -6
+.2byte   -9,   -1, 	  -8,   -2, 	  -6,    0, 	  -1,   -6
+.2byte    8,   -2, 	   7,   -3, 	   5,    0, 	   0,   -6
+.2byte    8,   -1, 	   7,   -2, 	   5,    0, 	   0,   -6
+.2byte   -9,   -2, 	  -8,   -3, 	  -6,    0, 	  -1,   -6
+.2byte   -6,   -4, 	  -6,   -2, 	  -5,    0, 	   0,   -6
+.2byte   -6,   -5, 	  -6,   -2, 	  -5,    0, 	   0,   -6
+.2byte   -9,   -2, 	  -7,   -2, 	  -6,    0, 	   0,   -6
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -8
+.2byte   -1,   -8, 	   5,   -8, 	  -7,   -8, 	  -1,   -9
+.2byte   -1,    3, 	  -8,    2, 	   6,    2, 	  -1,   -6
+.2byte   -1,   -2, 	  -8,    2, 	   6,    2, 	  -1,   -6
+.2byte   -1,    3, 	  -8,    2, 	   6,    2, 	  -1,   -5
+.2byte   -1,   -2, 	  -8,    2, 	   6,    2, 	  -1,   -6
+.2byte   -1,   -6, 	   7,   -6, 	  -9,   -6, 	  -1,   -3
+.2byte   -1,   -8, 	   7,   -6, 	  -9,   -6, 	  -1,   -3
+.2byte   -1,   -4, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -3, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -3, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte   -8,   -6, 	  -9,   -5, 	   0,   -6, 	  -2,   -7
+.2byte   -5,   -7, 	  -8,   -4, 	  -1,  -11, 	  -1,   -7
+.2byte   -1,  -15, 	   5,  -12, 	  -7,  -12, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -7, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,   -6, 	   7,   -5, 	  -9,   -5, 	  -1,   -5
+.2byte   -1,   -1, 	  -6,    0, 	   4,    0, 	  -1,   -6
+.2byte   -1,   -5, 	  -7,    0, 	   5,    0, 	  -1,   -7
+.2byte   -1,    4, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte  -10,   -6, 	  -4,   -5, 	  -1,    0, 	   0,   -5
+.2byte   -8,   -1, 	  -4,   -3, 	  -1,   -1, 	  -2,   -6
+.2byte    8,   -6, 	   2,   -5, 	  -1,    0, 	  -2,   -5
+.2byte    6,   -1, 	   2,   -3, 	  -1,   -1, 	   0,   -6
+.2byte   -1,  -11, 	   7,   -9, 	  -9,   -9, 	  -1,   -7
+.2byte   -7,   -1, 	  -6,   -3, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -2, 	 -12,   -7, 	  -1,   -1, 	  -2,   -7
+.2byte   -7,    0, 	 -13,   -3, 	   0,    1, 	  -2,   -6
+.2byte   -8,   -2, 	  -8,   -4, 	  -5,   -2, 	  -1,   -7
+.2byte   -9,    0, 	  -8,   -2, 	  -6,    1, 	  -1,   -5
+.2byte    5,   -1, 	   4,   -3, 	   0,   -1, 	  -1,   -7
+.2byte    4,   -2, 	  10,   -7, 	  -1,   -1, 	   0,   -7
+.2byte    5,    0, 	  11,   -3, 	  -2,    1, 	   0,   -6
+.2byte    6,   -2, 	   6,   -4, 	   3,   -2, 	  -1,   -7
+.2byte    7,    0, 	   6,   -2, 	   4,    1, 	  -1,   -5
+.2byte   -8,  -13, 	  -2,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	   1,  -10, 	  -8,   -7, 	   1,   -7
+.2byte    6,  -13, 	   0,   -8, 	   6,   -3, 	  -1,   -6
+.2byte    2,   -9, 	  -3,  -10, 	   6,   -7, 	  -3,   -7
+.2byte   -9,   -2, 	  -8,   -3, 	  -6,    0, 	  -1,   -6
+.2byte   -9,   -1, 	  -8,   -2, 	  -6,    0, 	  -1,   -6
+.2byte    8,   -2, 	   7,   -3, 	   5,    0, 	   0,   -6
+.2byte    8,   -1, 	   7,   -2, 	   5,    0, 	   0,   -6
+.2byte   -9,   -2, 	  -8,   -3, 	  -6,    0, 	  -1,   -6
+.2byte   -9,   -1, 	  -8,   -2, 	  -6,    0, 	  -1,   -6
+.2byte    8,   -2, 	   7,   -3, 	   5,    0, 	   0,   -6
+.2byte    8,   -1, 	   7,   -2, 	   5,    0, 	   0,   -6
+sBulbasaurAnimTable1:
+.4byte sBulbasaurAnims_1_1
+.4byte sBulbasaurAnims_1_2
+.4byte sBulbasaurAnims_1_3
+.4byte sBulbasaurAnims_1_4
+.4byte sBulbasaurAnims_1_5
+.4byte sBulbasaurAnims_1_6
+.4byte sBulbasaurAnims_1_7
+.4byte sBulbasaurAnims_1_8
+sBulbasaurAnimTable2:
+.4byte sBulbasaurAnims_2_1
+.4byte sBulbasaurAnims_2_2
+.4byte sBulbasaurAnims_2_3
+.4byte sBulbasaurAnims_2_4
+.4byte sBulbasaurAnims_2_5
+.4byte sBulbasaurAnims_2_6
+.4byte sBulbasaurAnims_2_7
+.4byte sBulbasaurAnims_2_8
+sBulbasaurAnimTable3:
+.4byte sBulbasaurAnims_3_1
+.4byte sBulbasaurAnims_3_2
+.4byte sBulbasaurAnims_3_3
+.4byte sBulbasaurAnims_3_4
+.4byte sBulbasaurAnims_3_5
+.4byte sBulbasaurAnims_3_6
+.4byte sBulbasaurAnims_3_7
+.4byte sBulbasaurAnims_3_8
+sBulbasaurAnimTable4:
+.4byte sBulbasaurAnims_4_1
+.4byte sBulbasaurAnims_4_2
+.4byte sBulbasaurAnims_4_3
+.4byte sBulbasaurAnims_4_4
+.4byte sBulbasaurAnims_4_5
+.4byte sBulbasaurAnims_4_6
+.4byte sBulbasaurAnims_4_7
+.4byte sBulbasaurAnims_4_8
+sBulbasaurAnimTable5:
+.4byte sBulbasaurAnims_5_1
+.4byte sBulbasaurAnims_5_2
+.4byte sBulbasaurAnims_5_3
+.4byte sBulbasaurAnims_5_4
+.4byte sBulbasaurAnims_5_5
+.4byte sBulbasaurAnims_5_6
+.4byte sBulbasaurAnims_5_7
+.4byte sBulbasaurAnims_5_8
+sBulbasaurAnimTable6:
+.4byte sBulbasaurAnims_6_1
+.4byte sBulbasaurAnims_6_1
+.4byte sBulbasaurAnims_6_1
+.4byte sBulbasaurAnims_6_1
+.4byte sBulbasaurAnims_6_1
+.4byte sBulbasaurAnims_6_1
+.4byte sBulbasaurAnims_6_1
+.4byte sBulbasaurAnims_6_1
+sBulbasaurAnimTable7:
+.4byte sBulbasaurAnims_7_1
+.4byte sBulbasaurAnims_7_2
+.4byte sBulbasaurAnims_7_3
+.4byte sBulbasaurAnims_7_4
+.4byte sBulbasaurAnims_7_5
+.4byte sBulbasaurAnims_7_6
+.4byte sBulbasaurAnims_7_7
+.4byte sBulbasaurAnims_7_8
+sBulbasaurAnimTable8:
+.4byte sBulbasaurAnims_8_1
+.4byte sBulbasaurAnims_8_2
+.4byte sBulbasaurAnims_8_3
+.4byte sBulbasaurAnims_8_4
+.4byte sBulbasaurAnims_8_5
+.4byte sBulbasaurAnims_8_6
+.4byte sBulbasaurAnims_8_7
+.4byte sBulbasaurAnims_8_8
+sBulbasaurAnimTable9:
+.4byte sBulbasaurAnims_9_1
+.4byte sBulbasaurAnims_9_2
+.4byte sBulbasaurAnims_9_3
+.4byte sBulbasaurAnims_9_4
+.4byte sBulbasaurAnims_9_5
+.4byte sBulbasaurAnims_9_6
+.4byte sBulbasaurAnims_9_7
+.4byte sBulbasaurAnims_9_8
+sBulbasaurAnimTable10:
+.4byte sBulbasaurAnims_10_1
+.4byte sBulbasaurAnims_10_2
+.4byte sBulbasaurAnims_10_3
+.4byte sBulbasaurAnims_10_4
+.4byte sBulbasaurAnims_10_5
+.4byte sBulbasaurAnims_10_6
+.4byte sBulbasaurAnims_10_7
+.4byte sBulbasaurAnims_10_8
+sBulbasaurAnimTable11:
+.4byte sBulbasaurAnims_11_1
+.4byte sBulbasaurAnims_11_2
+.4byte sBulbasaurAnims_11_3
+.4byte sBulbasaurAnims_11_4
+.4byte sBulbasaurAnims_11_5
+.4byte sBulbasaurAnims_11_6
+.4byte sBulbasaurAnims_11_7
+.4byte sBulbasaurAnims_11_8
+sBulbasaurAnimTable12:
+.4byte sBulbasaurAnims_12_1
+.4byte sBulbasaurAnims_12_2
+.4byte sBulbasaurAnims_12_3
+.4byte sBulbasaurAnims_12_4
+.4byte sBulbasaurAnims_12_5
+.4byte sBulbasaurAnims_12_6
+.4byte sBulbasaurAnims_12_7
+.4byte sBulbasaurAnims_12_8
+sBulbasaurAnimTable13:
+.4byte sBulbasaurAnims_13_1
+.4byte sBulbasaurAnims_13_2
+.4byte sBulbasaurAnims_13_3
+.4byte sBulbasaurAnims_13_4
+.4byte sBulbasaurAnims_13_5
+.4byte sBulbasaurAnims_13_6
+.4byte sBulbasaurAnims_13_7
+.4byte sBulbasaurAnims_13_8
+sBulbasaurAnimTable14:
+.4byte sBulbasaurAnims_14_1
+.4byte sBulbasaurAnims_14_2
+.4byte sBulbasaurAnims_14_3
+.4byte sBulbasaurAnims_14_4
+.4byte sBulbasaurAnims_14_5
+.4byte sBulbasaurAnims_14_6
+.4byte sBulbasaurAnims_14_7
+.4byte sBulbasaurAnims_14_8
+sBulbasaurAnimTable15:
+.4byte sBulbasaurAnims_15_1
+.4byte sBulbasaurAnims_15_2
+.4byte sBulbasaurAnims_15_3
+.4byte sBulbasaurAnims_15_4
+.4byte sBulbasaurAnims_15_5
+.4byte sBulbasaurAnims_15_6
+.4byte sBulbasaurAnims_15_7
+.4byte sBulbasaurAnims_15_8
+sBulbasaurAnimTable16:
+.4byte sBulbasaurAnims_16_1
+.4byte sBulbasaurAnims_16_2
+.4byte sBulbasaurAnims_16_3
+.4byte sBulbasaurAnims_16_4
+.4byte sBulbasaurAnims_16_5
+.4byte sBulbasaurAnims_16_6
+.4byte sBulbasaurAnims_16_7
+.4byte sBulbasaurAnims_16_8
+sBulbasaurAnimTable17:
+.4byte sBulbasaurAnims_17_1
+.4byte sBulbasaurAnims_17_2
+.4byte sBulbasaurAnims_17_3
+.4byte sBulbasaurAnims_17_4
+.4byte sBulbasaurAnims_17_5
+.4byte sBulbasaurAnims_17_6
+.4byte sBulbasaurAnims_17_7
+.4byte sBulbasaurAnims_17_8
+sBulbasaurAnimTable18:
+.4byte sBulbasaurAnims_18_1
+.4byte sBulbasaurAnims_18_2
+.4byte sBulbasaurAnims_18_3
+.4byte sBulbasaurAnims_18_4
+.4byte sBulbasaurAnims_18_5
+.4byte sBulbasaurAnims_18_6
+.4byte sBulbasaurAnims_18_7
+.4byte sBulbasaurAnims_18_8
+sBulbasaurAnimTable19:
+.4byte sBulbasaurAnims_19_1
+.4byte sBulbasaurAnims_19_2
+.4byte sBulbasaurAnims_19_3
+.4byte sBulbasaurAnims_19_4
+.4byte sBulbasaurAnims_19_5
+.4byte sBulbasaurAnims_19_6
+.4byte sBulbasaurAnims_19_7
+.4byte sBulbasaurAnims_19_8
+sBulbasaurAnimTable20:
+.4byte sBulbasaurAnims_20_1
+.4byte sBulbasaurAnims_20_2
+.4byte sBulbasaurAnims_20_3
+.4byte sBulbasaurAnims_20_4
+.4byte sBulbasaurAnims_20_5
+.4byte sBulbasaurAnims_20_6
+.4byte sBulbasaurAnims_20_7
+.4byte sBulbasaurAnims_20_8
+sBulbasaurAnimTable21:
+.4byte sBulbasaurAnims_21_1
+.4byte sBulbasaurAnims_21_2
+.4byte sBulbasaurAnims_21_3
+.4byte sBulbasaurAnims_21_4
+.4byte sBulbasaurAnims_21_5
+.4byte sBulbasaurAnims_21_6
+.4byte sBulbasaurAnims_21_7
+.4byte sBulbasaurAnims_21_8
+sBulbasaurAnimTable22:
+.4byte sBulbasaurAnims_22_1
+.4byte sBulbasaurAnims_22_2
+.4byte sBulbasaurAnims_22_3
+.4byte sBulbasaurAnims_22_4
+.4byte sBulbasaurAnims_22_5
+.4byte sBulbasaurAnims_22_6
+.4byte sBulbasaurAnims_22_7
+.4byte sBulbasaurAnims_22_8
+sBulbasaurAnimTable23:
+.4byte sBulbasaurAnims_23_1
+.4byte sBulbasaurAnims_23_2
+.4byte sBulbasaurAnims_23_3
+.4byte sBulbasaurAnims_23_4
+.4byte sBulbasaurAnims_23_5
+.4byte sBulbasaurAnims_23_6
+.4byte sBulbasaurAnims_23_7
+.4byte sBulbasaurAnims_23_8
+sBulbasaurAnimTable24:
+.4byte sBulbasaurAnims_24_1
+.4byte sBulbasaurAnims_24_2
+.4byte sBulbasaurAnims_24_3
+.4byte sBulbasaurAnims_24_4
+.4byte sBulbasaurAnims_24_5
+.4byte sBulbasaurAnims_24_6
+.4byte sBulbasaurAnims_24_7
+.4byte sBulbasaurAnims_24_8
+sBulbasaurAnimTable25:
+.4byte sBulbasaurAnims_25_1
+.4byte sBulbasaurAnims_25_2
+.4byte sBulbasaurAnims_25_3
+.4byte sBulbasaurAnims_25_4
+.4byte sBulbasaurAnims_25_5
+.4byte sBulbasaurAnims_25_6
+.4byte sBulbasaurAnims_25_7
+.4byte sBulbasaurAnims_25_8
+sBulbasaurAnimTable26:
+.4byte sBulbasaurAnims_26_1
+.4byte sBulbasaurAnims_26_2
+.4byte sBulbasaurAnims_26_3
+.4byte sBulbasaurAnims_26_4
+.4byte sBulbasaurAnims_26_5
+.4byte sBulbasaurAnims_26_6
+.4byte sBulbasaurAnims_26_7
+.4byte sBulbasaurAnims_26_8
+sBulbasaurAnimTable27:
+.4byte sBulbasaurAnims_27_1
+.4byte sBulbasaurAnims_27_1
+.4byte sBulbasaurAnims_27_1
+.4byte sBulbasaurAnims_27_1
+.4byte sBulbasaurAnims_27_1
+.4byte sBulbasaurAnims_27_1
+.4byte sBulbasaurAnims_27_1
+.4byte sBulbasaurAnims_27_1
+sBulbasaurAnimTable28:
+.4byte sBulbasaurAnims_28_1
+.4byte sBulbasaurAnims_28_2
+.4byte sBulbasaurAnims_28_3
+.4byte sBulbasaurAnims_28_4
+.4byte sBulbasaurAnims_28_5
+.4byte sBulbasaurAnims_28_6
+.4byte sBulbasaurAnims_28_7
+.4byte sBulbasaurAnims_28_8
+sAxAnimationsBulbasaur:
+.4byte sBulbasaurAnimTable1
+.4byte sBulbasaurAnimTable2
+.4byte sBulbasaurAnimTable3
+.4byte sBulbasaurAnimTable4
+.4byte sBulbasaurAnimTable5
+.4byte sBulbasaurAnimTable6
+.4byte sBulbasaurAnimTable7
+.4byte sBulbasaurAnimTable8
+.4byte sBulbasaurAnimTable9
+.4byte sBulbasaurAnimTable10
+.4byte sBulbasaurAnimTable11
+.4byte sBulbasaurAnimTable12
+.4byte sBulbasaurAnimTable13
+.4byte sBulbasaurAnimTable14
+.4byte sBulbasaurAnimTable15
+.4byte sBulbasaurAnimTable16
+.4byte sBulbasaurAnimTable17
+.4byte sBulbasaurAnimTable18
+.4byte sBulbasaurAnimTable19
+.4byte sBulbasaurAnimTable20
+.4byte sBulbasaurAnimTable21
+.4byte sBulbasaurAnimTable22
+.4byte sBulbasaurAnimTable23
+.4byte sBulbasaurAnimTable24
+.4byte sBulbasaurAnimTable25
+.4byte sBulbasaurAnimTable26
+.4byte sBulbasaurAnimTable27
+.4byte sBulbasaurAnimTable28
+sAxSpritesBulbasaur:
+.4byte sBulbasaurSprites1
+.4byte sBulbasaurSprites2
+.4byte sBulbasaurSprites3
+.4byte sBulbasaurSprites4
+.4byte sBulbasaurSprites5
+.4byte sBulbasaurSprites6
+.4byte sBulbasaurSprites7
+.4byte sBulbasaurSprites8
+.4byte sBulbasaurSprites9
+.4byte sBulbasaurSprites10
+.4byte sBulbasaurSprites11
+.4byte sBulbasaurSprites12
+.4byte sBulbasaurSprites13
+.4byte sBulbasaurSprites14
+.4byte sBulbasaurSprites15
+.4byte sBulbasaurSprites16
+.4byte sBulbasaurSprites17
+.4byte sBulbasaurSprites18
+.4byte sBulbasaurSprites19
+.4byte sBulbasaurSprites20
+.4byte sBulbasaurSprites21
+.4byte sBulbasaurSprites22
+.4byte sBulbasaurSprites23
+.4byte sBulbasaurSprites24
+.4byte sBulbasaurSprites25
+.4byte sBulbasaurSprites26
+.4byte sBulbasaurSprites27
+.4byte sBulbasaurSprites28
+.4byte sBulbasaurSprites29
+.4byte sBulbasaurSprites30
+.4byte sBulbasaurSprites31
+.4byte sBulbasaurSprites32
+.4byte sBulbasaurSprites33
+.4byte sBulbasaurSprites34
+.4byte sBulbasaurSprites35
+.4byte sBulbasaurSprites36
+.4byte sBulbasaurSprites37
+.4byte sBulbasaurSprites38
+.4byte sBulbasaurSprites39
+.4byte sBulbasaurSprites40
+.4byte sBulbasaurSprites41
+.4byte sBulbasaurSprites42
+.4byte sBulbasaurSprites43
+.4byte sBulbasaurSprites44
+.4byte sBulbasaurSprites45
+.4byte sBulbasaurSprites46
+.4byte sBulbasaurSprites47
+.4byte sBulbasaurSprites48
+.4byte sBulbasaurSprites49
+.4byte sBulbasaurSprites50
+.4byte sBulbasaurSprites51
+.4byte sBulbasaurSprites52
+.4byte sBulbasaurSprites53
+.4byte sBulbasaurSprites54
+.4byte sBulbasaurSprites55
+.4byte sBulbasaurSprites56
+.4byte sBulbasaurSprites57
+.4byte sBulbasaurSprites58
+.4byte sBulbasaurSprites59
+.4byte sBulbasaurSprites60
+.4byte sBulbasaurSprites61
+.4byte sBulbasaurSprites62
+.4byte sBulbasaurSprites63
+.4byte sBulbasaurSprites64
+.4byte sBulbasaurSprites65
+.4byte sBulbasaurSprites66
+.4byte sBulbasaurSprites67
+.4byte sBulbasaurSprites68
+.4byte sBulbasaurSprites69
+.4byte sBulbasaurSprites70
+.4byte sBulbasaurSprites71
+sAxMainBulbasaur:
+ax_main sAxPosesBulbasaur, sAxAnimationsBulbasaur, 28, sAxSpritesBulbasaur, sAxPositionsBulbasaur

--- a/data/ax/butterfree.inc
+++ b/data/ax/butterfree.inc
@@ -1,0 +1,3052 @@
+.global gAxButterfree
+gAxButterfree:
+ax_siro sAxMainButterfree
+sButterfreePose1:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose3:
+ax_pose 2, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose4:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose5:
+ax_pose 4, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose6:
+ax_pose 5, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose7:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose8:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose9:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose10:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose11:
+ax_pose 10, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose12:
+ax_pose 11, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose13:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose14:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose15:
+ax_pose 14, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose16:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose17:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose18:
+ax_pose 11, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose19:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose20:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose21:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose22:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose23:
+ax_pose 4, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose24:
+ax_pose 5, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose25:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose26:
+ax_pose 1, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose27:
+ax_pose 2, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose28:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose29:
+ax_pose 4, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose30:
+ax_pose 5, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose31:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose32:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose33:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose34:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sButterfreePose35:
+ax_pose 10, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sButterfreePose36:
+ax_pose 11, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sButterfreePose37:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose38:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose39:
+ax_pose 14, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose40:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose41:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose42:
+ax_pose 11, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose43:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose44:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose45:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose46:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose47:
+ax_pose 4, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose48:
+ax_pose 5, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose49:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose50:
+ax_pose 1, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose51:
+ax_pose 2, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose52:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose53:
+ax_pose 4, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose54:
+ax_pose 5, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose55:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose56:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose57:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose58:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sButterfreePose59:
+ax_pose 10, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sButterfreePose60:
+ax_pose 11, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sButterfreePose61:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose62:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose63:
+ax_pose 14, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose64:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose65:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose66:
+ax_pose 11, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose67:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose68:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose69:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose70:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose71:
+ax_pose 4, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose72:
+ax_pose 5, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose73:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose74:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose75:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose76:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose77:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose78:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose79:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose80:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose81:
+ax_pose 15, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose82:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose83:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose84:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose85:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose86:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose87:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose88:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose89:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose90:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose91:
+ax_pose 17, 0x01e3, 0x90e8, 0x5c00
+ax_pose_terminator
+sButterfreePose92:
+ax_pose 18, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sButterfreePose93:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose94:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose95:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose96:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose97:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose98:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose99:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose100:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose101:
+ax_pose 19, 0x81e4, 0x90f7, 0x5c00
+ax_pose_terminator
+sButterfreePose102:
+ax_pose 20, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sButterfreePose103:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose104:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose105:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose106:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose107:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose108:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose109:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose110:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose111:
+ax_pose 21, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sButterfreePose112:
+ax_pose 22, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sButterfreePose113:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose114:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose115:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose116:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose117:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose118:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose119:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose120:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose121:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose122:
+ax_pose 24, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose123:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose124:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose125:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose126:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose127:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose128:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose129:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose130:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose131:
+ax_pose 21, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose132:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose133:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose134:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose135:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose136:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose137:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose138:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose139:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose140:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose141:
+ax_pose 19, 0x81e4, 0x80f9, 0x5c00
+ax_pose_terminator
+sButterfreePose142:
+ax_pose 20, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose143:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose144:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose145:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose146:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose147:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose148:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose149:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose150:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose151:
+ax_pose 17, 0x01e3, 0x80f8, 0x5c00
+ax_pose_terminator
+sButterfreePose152:
+ax_pose 18, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose153:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose154:
+ax_pose 1, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose155:
+ax_pose 2, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose156:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose157:
+ax_pose 4, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose158:
+ax_pose 5, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose159:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose160:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose161:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose162:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose163:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose164:
+ax_pose 11, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose165:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose166:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose167:
+ax_pose 14, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose168:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose169:
+ax_pose 10, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose170:
+ax_pose 11, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose171:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose172:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose173:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose174:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose175:
+ax_pose 4, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose176:
+ax_pose 5, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose177:
+ax_pose 25, 0x01ed, 0x80ef, 0x5c00
+ax_pose_terminator
+sButterfreePose178:
+ax_pose 26, 0x01ed, 0x80ef, 0x5c00
+ax_pose_terminator
+sButterfreePose179:
+ax_pose 27, 0x01de, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose180:
+ax_pose 28, 0x01e1, 0x90ea, 0x5c00
+ax_pose_terminator
+sButterfreePose181:
+ax_pose 29, 0x01e1, 0x90ea, 0x5c00
+ax_pose_terminator
+sButterfreePose182:
+ax_pose 30, 0x01e2, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose183:
+ax_pose 31, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose184:
+ax_pose 30, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sButterfreePose185:
+ax_pose 29, 0x01e1, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose186:
+ax_pose 28, 0x01e1, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose187:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose188:
+ax_pose 1, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose189:
+ax_pose 2, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose190:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose191:
+ax_pose 4, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose192:
+ax_pose 5, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose193:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose194:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose195:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose196:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose197:
+ax_pose 10, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose198:
+ax_pose 11, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose199:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose200:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose201:
+ax_pose 14, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose202:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose203:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose204:
+ax_pose 11, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose205:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose206:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose207:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose208:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose209:
+ax_pose 4, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose210:
+ax_pose 5, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose211:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose212:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose213:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose214:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose215:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose216:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose217:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose218:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose219:
+ax_pose 1, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose220:
+ax_pose 4, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose221:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose222:
+ax_pose 10, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sButterfreePose223:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose224:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose225:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose226:
+ax_pose 4, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose227:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose228:
+ax_pose 15, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose229:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose230:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sButterfreePose231:
+ax_pose 17, 0x01e3, 0x90e8, 0x5c00
+ax_pose_terminator
+sButterfreePose232:
+ax_pose 18, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sButterfreePose233:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose234:
+ax_pose 19, 0x81e4, 0x90f7, 0x5c00
+ax_pose_terminator
+sButterfreePose235:
+ax_pose 20, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sButterfreePose236:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose237:
+ax_pose 21, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sButterfreePose238:
+ax_pose 22, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sButterfreePose239:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose240:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose241:
+ax_pose 24, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose242:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose243:
+ax_pose 21, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose244:
+ax_pose 22, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose245:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose246:
+ax_pose 19, 0x81e4, 0x80f9, 0x5c00
+ax_pose_terminator
+sButterfreePose247:
+ax_pose 20, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose248:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose249:
+ax_pose 17, 0x01e3, 0x80f8, 0x5c00
+ax_pose_terminator
+sButterfreePose250:
+ax_pose 18, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose251:
+ax_pose 15, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose252:
+ax_pose 17, 0x01e3, 0x80f8, 0x5c00
+ax_pose_terminator
+sButterfreePose253:
+ax_pose 19, 0x81e4, 0x80f9, 0x5c00
+ax_pose_terminator
+sButterfreePose254:
+ax_pose 21, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose255:
+ax_pose 23, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sButterfreePose256:
+ax_pose 21, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sButterfreePose257:
+ax_pose 19, 0x81e4, 0x90f7, 0x5c00
+ax_pose_terminator
+sButterfreePose258:
+ax_pose 17, 0x01e3, 0x90e8, 0x5c00
+ax_pose_terminator
+sButterfreePose259:
+ax_pose 0, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose260:
+ax_pose 3, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sButterfreePose261:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sButterfreePose262:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose263:
+ax_pose 12, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sButterfreePose264:
+ax_pose 9, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sButterfreePose265:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sButterfreePose266:
+ax_pose 3, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+.align 2
+sButterfreeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 1, 1, 1, 0,
+ax_anim 8, 0, 0, 1, 2, 1, 0,
+ax_anim 8, 0, 2, 0, 2, 0, 0,
+ax_anim 8, 0, 0, 0, 1, 0, 0,
+ax_anim 8, 0, 1, -1, 0, -1, 0,
+ax_anim 8, 0, 0, -1, -1, -1, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 0, -1, 1, -1, 0,
+ax_anim 8, 0, 2, -1, 0, -1, 0,
+ax_anim_terminator
+sButterfreeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 3, 1, 2, 1, 2,
+ax_anim 8, 0, 5, 0, 2, 0, 2,
+ax_anim 8, 0, 3, 0, 1, 0, 1,
+ax_anim 8, 0, 4, 1, 0, 1, 0,
+ax_anim 8, 0, 3, 1, -1, 1, -1,
+ax_anim 8, 0, 5, 1, -1, 1, -1,
+ax_anim 8, 0, 3, 1, 0, 1, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 1,
+ax_anim 8, 0, 3, -1, 1, -1, 1,
+ax_anim 8, 0, 5, -1, 0, -1, 0,
+ax_anim_terminator
+sButterfreeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 1, 1, 1, 0,
+ax_anim 8, 0, 6, 1, 2, 1, 0,
+ax_anim 8, 0, 8, 0, 2, 0, 0,
+ax_anim 8, 0, 6, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 6, 1, -1, 1, 0,
+ax_anim 8, 0, 8, 1, -1, 1, 0,
+ax_anim 8, 0, 6, 1, 0, 1, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 6, -1, 1, -1, 0,
+ax_anim 8, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sButterfreeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 9, 1, -2, 1, -2,
+ax_anim 8, 0, 11, 0, -2, 0, -2,
+ax_anim 8, 0, 9, 0, -1, 0, -1,
+ax_anim 8, 0, 10, 1, 0, 1, 0,
+ax_anim 8, 0, 9, 1, 1, 1, 1,
+ax_anim 8, 0, 11, 1, 1, 1, 1,
+ax_anim 8, 0, 9, 1, 0, 1, 0,
+ax_anim 8, 0, 10, 0, -1, 0, -1,
+ax_anim 8, 0, 9, -1, -1, -1, -1,
+ax_anim 8, 0, 11, -1, 0, -1, 0,
+ax_anim_terminator
+sButterfreeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 1, 1, 1, 0,
+ax_anim 8, 0, 12, 1, 2, 1, 0,
+ax_anim 8, 0, 14, 0, 2, 0, 0,
+ax_anim 8, 0, 12, 0, 1, 0, 0,
+ax_anim 8, 0, 13, -1, 0, -1, 0,
+ax_anim 8, 0, 12, -1, -1, -1, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 12, -1, 1, -1, 0,
+ax_anim 8, 0, 14, -1, 0, -1, 0,
+ax_anim_terminator
+sButterfreeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 15, -1, -2, -1, -2,
+ax_anim 8, 0, 17, 0, -2, 0, -2,
+ax_anim 8, 0, 15, 0, -1, 0, -1,
+ax_anim 8, 0, 16, -1, 0, -1, 0,
+ax_anim 8, 0, 15, -1, 1, -1, 1,
+ax_anim 8, 0, 17, -1, 1, -1, 1,
+ax_anim 8, 0, 15, -1, 0, -1, 0,
+ax_anim 8, 0, 16, 0, -1, 0, -1,
+ax_anim 8, 0, 15, 1, -1, 1, -1,
+ax_anim 8, 0, 17, 1, 0, 1, 0,
+ax_anim_terminator
+sButterfreeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, -1, 1, -1, 0,
+ax_anim 8, 0, 18, -1, 2, -1, 0,
+ax_anim 8, 0, 20, 0, 2, 0, 0,
+ax_anim 8, 0, 18, 0, 1, 0, 0,
+ax_anim 8, 0, 19, -1, 0, -1, 0,
+ax_anim 8, 0, 18, -1, -1, -1, 0,
+ax_anim 8, 0, 20, -1, -1, -1, 0,
+ax_anim 8, 0, 18, -1, 0, -1, 0,
+ax_anim 8, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 18, 1, 1, 1, 0,
+ax_anim 8, 0, 20, 1, 0, 1, 0,
+ax_anim_terminator
+sButterfreeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 21, -1, 2, -1, 2,
+ax_anim 8, 0, 23, 0, 2, 0, 2,
+ax_anim 8, 0, 21, 0, 1, 0, 1,
+ax_anim 8, 0, 22, -1, 0, -1, 0,
+ax_anim 8, 0, 21, -1, -1, -1, -1,
+ax_anim 8, 0, 23, -1, -1, -1, -1,
+ax_anim 8, 0, 21, -1, 0, -1, 0,
+ax_anim 8, 0, 22, 0, 1, 0, 1,
+ax_anim 8, 0, 21, 1, 1, 1, 1,
+ax_anim 8, 0, 23, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -5, 0, -2,
+ax_anim 2, 0, 26, 0, -6, 0, -3,
+ax_anim 2, 0, 25, 0, -6, 0, -3,
+ax_anim 2, 0, 26, 0, -6, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 25, 0, 22,
+ax_anim 2, 1, 25, 1, 25, 1, 22,
+ax_anim 2, 0, 25, 0, 25, 0, 22,
+ax_anim 2, 0, 26, 1, 25, 1, 22,
+ax_anim 2, 0, 25, 0, 14, 0, 14,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sButterfreeAnims_2_2:
+ax_anim 2, 0, 28, -1, -2, -1, -1,
+ax_anim 2, 0, 27, -5, -6, -5, -5,
+ax_anim 2, 0, 29, -6, -8, -6, -6,
+ax_anim 2, 0, 28, -6, -8, -6, -6,
+ax_anim 2, 0, 29, -6, -8, -6, -6,
+ax_anim 1, 0, 29, 0, -2, 0, 0,
+ax_anim 1, 2, 29, 4, 3, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 1, 28, 21, 20, 21, 20,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 0, 29, 21, 20, 21, 20,
+ax_anim 2, 0, 28, 14, 14, 14, 14,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sButterfreeAnims_2_3:
+ax_anim 2, 0, 31, -1, -1, -1, 0,
+ax_anim 2, 0, 30, -5, -2, -5, 0,
+ax_anim 2, 0, 32, -6, -3, -6, 0,
+ax_anim 2, 0, 31, -6, -3, -6, 0,
+ax_anim 2, 0, 32, -6, -3, -6, 0,
+ax_anim 1, 0, 32, 0, -2, 0, 0,
+ax_anim 1, 2, 32, 4, -1, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 21, 0, 21, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 21, 0, 21, 0,
+ax_anim 2, 0, 31, 14, 0, 14, 0,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sButterfreeAnims_2_4:
+ax_anim 2, 0, 34, -1, 0, -1, 1,
+ax_anim 2, 0, 33, -5, -1, -2, 2,
+ax_anim 2, 0, 35, -6, -2, -3, 3,
+ax_anim 2, 0, 34, -6, -2, -3, 3,
+ax_anim 2, 0, 35, -6, -2, -3, 3,
+ax_anim 1, 0, 35, 0, -5, 0, 0,
+ax_anim 1, 2, 35, 4, -8, 4, -4,
+ax_anim 1, 0, 35, 10, -11, 10, -10,
+ax_anim 2, 0, 34, 16, -13, 16, -17,
+ax_anim 2, 1, 34, 17, -13, 17, -17,
+ax_anim 2, 0, 34, 16, -13, 16, -17,
+ax_anim 2, 0, 35, 17, -13, 17, -17,
+ax_anim 2, 0, 34, 11, -11, 11, -11,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sButterfreeAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -2, 0, -2,
+ax_anim 1, 0, 38, 0, -6, 0, -6,
+ax_anim 2, 0, 37, 0, -13, 0, -13,
+ax_anim 2, 1, 37, 1, -13, 1, -13,
+ax_anim 2, 0, 37, 0, -13, 0, -13,
+ax_anim 2, 0, 38, 1, -13, 1, -13,
+ax_anim 2, 0, 37, 0, -8, 0, -8,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sButterfreeAnims_2_6:
+ax_anim 2, 0, 40, 1, 0, 1, 1,
+ax_anim 2, 0, 39, 5, -1, 2, 2,
+ax_anim 2, 0, 41, 6, -2, 3, 3,
+ax_anim 2, 0, 40, 6, -2, 3, 3,
+ax_anim 2, 0, 41, 6, -2, 3, 3,
+ax_anim 1, 0, 41, 0, -5, 0, 0,
+ax_anim 1, 2, 41, -4, -8, -4, -4,
+ax_anim 1, 0, 41, -10, -11, -10, -10,
+ax_anim 2, 0, 40, -16, -13, -16, -17,
+ax_anim 2, 1, 40, -17, -13, -17, -17,
+ax_anim 2, 0, 40, -16, -13, -16, -17,
+ax_anim 2, 0, 41, -17, -13, -17, -17,
+ax_anim 2, 0, 40, -11, -11, -11, -11,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sButterfreeAnims_2_7:
+ax_anim 2, 0, 43, 1, -1, 1, 0,
+ax_anim 2, 0, 42, 5, -2, 5, 0,
+ax_anim 2, 0, 44, 6, -3, 6, 0,
+ax_anim 2, 0, 43, 6, -3, 6, 0,
+ax_anim 2, 0, 44, 6, -3, 6, 0,
+ax_anim 1, 0, 44, 0, -2, 0, 0,
+ax_anim 1, 2, 44, -4, -1, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -21, 0, -21, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 0, 43, -14, 0, -14, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sButterfreeAnims_2_8:
+ax_anim 2, 0, 46, 1, -2, 1, -1,
+ax_anim 2, 0, 45, 5, -6, 5, -5,
+ax_anim 2, 0, 47, 6, -8, 6, -6,
+ax_anim 2, 0, 46, 6, -8, 6, -6,
+ax_anim 2, 0, 47, 6, -8, 6, -6,
+ax_anim 1, 0, 47, 0, -2, 0, 0,
+ax_anim 1, 2, 47, -4, 3, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -20, 20, -20, 20,
+ax_anim 2, 1, 46, -21, 20, -21, 20,
+ax_anim 2, 0, 46, -20, 20, -20, 20,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 0, 46, -14, 14, -14, 14,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 48, 0, -5, 0, -2,
+ax_anim 2, 0, 50, 0, -6, 0, -3,
+ax_anim 2, 0, 49, 0, -6, 0, -3,
+ax_anim 2, 0, 50, 0, -6, 0, -3,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 25, 0, 22,
+ax_anim 2, 1, 49, 1, 25, 1, 22,
+ax_anim 2, 0, 49, 0, 25, 0, 22,
+ax_anim 2, 0, 50, 1, 25, 1, 22,
+ax_anim 2, 0, 49, 0, 14, 0, 14,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sButterfreeAnims_3_2:
+ax_anim 2, 0, 52, -1, -2, -1, -1,
+ax_anim 2, 0, 51, -5, -6, -5, -5,
+ax_anim 2, 0, 53, -6, -8, -6, -6,
+ax_anim 2, 0, 52, -6, -8, -6, -6,
+ax_anim 2, 0, 53, -6, -8, -6, -6,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 2, 53, 4, 3, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 20, 20, 20, 20,
+ax_anim 2, 1, 52, 21, 20, 21, 20,
+ax_anim 2, 0, 52, 20, 20, 20, 20,
+ax_anim 2, 0, 53, 21, 20, 21, 20,
+ax_anim 2, 0, 52, 14, 14, 14, 14,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sButterfreeAnims_3_3:
+ax_anim 2, 0, 55, -1, -1, -1, 0,
+ax_anim 2, 0, 54, -5, -2, -5, 0,
+ax_anim 2, 0, 56, -6, -3, -6, 0,
+ax_anim 2, 0, 55, -6, -3, -6, 0,
+ax_anim 2, 0, 56, -6, -3, -6, 0,
+ax_anim 1, 0, 56, 0, -2, 0, 0,
+ax_anim 1, 2, 56, 4, -1, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 1, 55, 21, 0, 21, 0,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 56, 21, 0, 21, 0,
+ax_anim 2, 0, 55, 14, 0, 14, 0,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sButterfreeAnims_3_4:
+ax_anim 2, 0, 58, -1, 0, -1, 1,
+ax_anim 2, 0, 57, -5, -1, -2, 2,
+ax_anim 2, 0, 59, -6, -2, -3, 3,
+ax_anim 2, 0, 58, -6, -2, -3, 3,
+ax_anim 2, 0, 59, -6, -2, -3, 3,
+ax_anim 1, 0, 59, 0, -5, 0, 0,
+ax_anim 1, 2, 59, 4, -8, 4, -4,
+ax_anim 1, 0, 59, 10, -11, 10, -10,
+ax_anim 2, 0, 58, 16, -13, 16, -17,
+ax_anim 2, 1, 58, 17, -13, 17, -17,
+ax_anim 2, 0, 58, 16, -13, 16, -17,
+ax_anim 2, 0, 59, 17, -13, 17, -17,
+ax_anim 2, 0, 58, 11, -11, 11, -11,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sButterfreeAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 2, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 2, 0, 2,
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -2, 0, -2,
+ax_anim 1, 0, 62, 0, -6, 0, -6,
+ax_anim 2, 0, 61, 0, -13, 0, -13,
+ax_anim 2, 1, 61, 1, -13, 1, -13,
+ax_anim 2, 0, 61, 0, -13, 0, -13,
+ax_anim 2, 0, 62, 1, -13, 1, -13,
+ax_anim 2, 0, 61, 0, -8, 0, -8,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sButterfreeAnims_3_6:
+ax_anim 2, 0, 64, 1, 0, 1, 1,
+ax_anim 2, 0, 63, 5, -1, 2, 2,
+ax_anim 2, 0, 65, 6, -2, 3, 3,
+ax_anim 2, 0, 64, 6, -2, 3, 3,
+ax_anim 2, 0, 65, 6, -2, 3, 3,
+ax_anim 1, 0, 65, 0, -5, 0, 0,
+ax_anim 1, 2, 65, -4, -8, -4, -4,
+ax_anim 1, 0, 65, -10, -11, -10, -10,
+ax_anim 2, 0, 64, -16, -13, -16, -17,
+ax_anim 2, 1, 64, -17, -13, -17, -17,
+ax_anim 2, 0, 64, -16, -13, -16, -17,
+ax_anim 2, 0, 65, -17, -13, -17, -17,
+ax_anim 2, 0, 64, -11, -11, -11, -11,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sButterfreeAnims_3_7:
+ax_anim 2, 0, 67, 1, -1, 1, 0,
+ax_anim 2, 0, 66, 5, -2, 5, 0,
+ax_anim 2, 0, 68, 6, -3, 6, 0,
+ax_anim 2, 0, 67, 6, -3, 6, 0,
+ax_anim 2, 0, 68, 6, -3, 6, 0,
+ax_anim 1, 0, 68, 0, -2, 0, 0,
+ax_anim 1, 2, 68, -4, -1, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 1, 67, -21, 0, -21, 0,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 68, -21, 0, -21, 0,
+ax_anim 2, 0, 67, -14, 0, -14, 0,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sButterfreeAnims_3_8:
+ax_anim 2, 0, 70, 1, -2, 1, -1,
+ax_anim 2, 0, 69, 5, -6, 5, -5,
+ax_anim 2, 0, 71, 6, -8, 6, -6,
+ax_anim 2, 0, 70, 6, -8, 6, -6,
+ax_anim 2, 0, 71, 6, -8, 6, -6,
+ax_anim 1, 0, 71, 0, -2, 0, 0,
+ax_anim 1, 2, 71, -4, 3, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -20, 20, -20, 20,
+ax_anim 2, 1, 70, -21, 20, -21, 20,
+ax_anim 2, 0, 70, -20, 20, -20, 20,
+ax_anim 2, 0, 71, -21, 20, -21, 20,
+ax_anim 2, 0, 70, -14, 14, -14, 14,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 3, 0, 80, 0, -1, 0, -1,
+ax_anim 6, 2, 80, 0, -2, 0, -2,
+ax_anim 2, 0, 81, 0, 1, 0, 1,
+ax_anim 2, 1, 81, 0, 5, 0, 5,
+ax_anim 2, 0, 81, 1, 5, 1, 5,
+ax_anim 2, 0, 81, 0, 5, 0, 5,
+ax_anim 2, 0, 81, 1, 5, 1, 5,
+ax_anim_terminator
+sButterfreeAnims_4_2:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 3, 0, 90, -1, -1, -2, -2,
+ax_anim 6, 2, 90, -2, -2, -3, -3,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 4, 4, 4, 4,
+ax_anim 2, 0, 91, 3, 5, 3, 5,
+ax_anim 2, 0, 91, 4, 4, 4, 4,
+ax_anim 2, 0, 91, 3, 5, 3, 5,
+ax_anim_terminator
+sButterfreeAnims_4_3:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 3, 0, 100, -1, 0, -2, 0,
+ax_anim 6, 2, 100, -2, -1, -3, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 1, 101, 4, 0, 4, 0,
+ax_anim 2, 0, 101, 4, 1, 4, 1,
+ax_anim 2, 0, 101, 4, 0, 4, 0,
+ax_anim 2, 0, 101, 4, 1, 4, 1,
+ax_anim_terminator
+sButterfreeAnims_4_4:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 1, -1, 1,
+ax_anim 3, 0, 110, -1, 1, -2, 2,
+ax_anim 6, 2, 110, -2, 2, -3, 3,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 111, 4, -4, 4, -4,
+ax_anim 2, 0, 111, 3, -5, 3, -5,
+ax_anim 2, 0, 111, 4, -4, 4, -4,
+ax_anim 2, 0, 111, 3, -5, 3, -5,
+ax_anim_terminator
+sButterfreeAnims_4_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 3, 0, 120, 0, 1, 0, 2,
+ax_anim 6, 2, 120, 0, 2, 0, 2,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 121, 0, -4, 0, -4,
+ax_anim 2, 0, 121, 0, -5, 0, -5,
+ax_anim 2, 0, 121, 0, -4, 0, -4,
+ax_anim 2, 0, 121, 0, -5, 0, -5,
+ax_anim_terminator
+sButterfreeAnims_4_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, 1, 1, 1,
+ax_anim 3, 0, 130, 1, 1, 2, 2,
+ax_anim 6, 2, 130, 2, 2, 3, 3,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 1, 131, -4, -4, -4, -4,
+ax_anim 2, 0, 131, -3, -5, -3, -5,
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 2, 0, 131, -3, -5, -3, -5,
+ax_anim_terminator
+sButterfreeAnims_4_7:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 3, 0, 140, 1, 0, 2, 0,
+ax_anim 6, 2, 140, 2, -1, 3, 0,
+ax_anim 2, 0, 141, 0, -1, 0, -1,
+ax_anim 2, 1, 141, -4, 0, -4, 0,
+ax_anim 2, 0, 141, -4, 1, -4, 1,
+ax_anim 2, 0, 141, -4, 0, -4, 0,
+ax_anim 2, 0, 141, -4, 1, -4, 1,
+ax_anim_terminator
+sButterfreeAnims_4_8:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 3, 0, 150, 1, -1, 2, -2,
+ax_anim 6, 2, 150, 2, -2, 3, -3,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 1, 151, -4, 4, -4, 4,
+ax_anim 2, 0, 151, -3, 5, -3, 5,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 0, 151, -3, 5, -3, 5,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_5_1:
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_5_2:
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 2, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_5_3:
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 2, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_5_4:
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 2, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_5_5:
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 2, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_5_6:
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 2, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_5_7:
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 2, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_5_8:
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 2, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_6_1:
+ax_anim 35, 0, 176, 0, -1, 0, 0,
+ax_anim 30, 0, 177, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sButterfreeAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sButterfreeAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sButterfreeAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sButterfreeAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sButterfreeAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sButterfreeAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sButterfreeAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_8_1:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 8, 0, 187, 0, -1, 0, 1,
+ax_anim 8, 0, 186, 0, -2, 0, 1,
+ax_anim 8, 0, 188, 0, -1, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_8_2:
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim 8, 0, 190, 1, -1, 1, 0,
+ax_anim 8, 0, 189, 1, -2, 1, 0,
+ax_anim 8, 0, 191, 0, -1, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_8_3:
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim 8, 0, 193, 1, -1, 1, 0,
+ax_anim 8, 0, 192, 1, -2, 1, 0,
+ax_anim 8, 0, 194, 0, -1, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_8_4:
+ax_anim 8, 0, 195, 0, 0, 0, 0,
+ax_anim 8, 0, 196, 0, -1, 1, -1,
+ax_anim 8, 0, 195, 0, -2, 1, -1,
+ax_anim 8, 0, 197, 0, -1, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_8_5:
+ax_anim 8, 0, 198, 0, 0, 0, 0,
+ax_anim 8, 0, 199, 0, -1, 0, -1,
+ax_anim 8, 0, 198, 0, -2, 0, -1,
+ax_anim 8, 0, 200, 0, -1, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_8_6:
+ax_anim 8, 0, 201, 0, 0, 0, 0,
+ax_anim 8, 0, 202, 0, -1, -1, -1,
+ax_anim 8, 0, 201, 0, -2, -1, -1,
+ax_anim 8, 0, 203, 0, -1, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_8_7:
+ax_anim 8, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, -1, -1, -1, 0,
+ax_anim 8, 0, 204, -1, -2, -1, 0,
+ax_anim 8, 0, 206, 0, -1, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_8_8:
+ax_anim 8, 0, 207, 0, 0, 0, 0,
+ax_anim 8, 0, 208, -1, -1, -1, 0,
+ax_anim 8, 0, 207, -1, -2, -1, 0,
+ax_anim 8, 0, 209, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 6, 4, 6, 4,
+ax_anim 2, 0, 212, 11, 12, 11, 12,
+ax_anim 2, 0, 213, 9, 22, 9, 19,
+ax_anim 3, 0, 214, 1, 28, 1, 23,
+ax_anim 2, 3, 215, -9, 22, -9, 19,
+ax_anim 2, 0, 216, -11, 12, -11, 12,
+ax_anim 1, 0, 217, -6, 4, -6, 4,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 211, 17, 3, 17, 3,
+ax_anim 2, 0, 212, 24, 11, 24, 9,
+ax_anim 3, 0, 213, 23, 26, 23, 21,
+ax_anim 2, 3, 214, 11, 29, 11, 25,
+ax_anim 2, 0, 215, 2, 18, 2, 18,
+ax_anim 1, 0, 216, -2, 10, -2, 10,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 3, -4, 3, -4,
+ax_anim 2, 0, 210, 8, -6, 8, -6,
+ax_anim 2, 0, 211, 17, -3, 17, -5,
+ax_anim 3, 0, 212, 23, 4, 23, 0,
+ax_anim 2, 3, 213, 17, 8, 17, 5,
+ax_anim 2, 0, 214, 12, 10, 12, 7,
+ax_anim 1, 0, 215, 4, 5, 4, 5,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 1, -6, 1, -6,
+ax_anim 2, 0, 217, 4, -14, 4, -14,
+ax_anim 2, 0, 210, 9, -18, 9, -18,
+ax_anim 3, 0, 211, 17, -18, 17, -18,
+ax_anim 2, 3, 212, 19, -11, 19, -11,
+ax_anim 2, 0, 213, 13, -1, 13, -1,
+ax_anim 1, 0, 214, 7, 1, 7, 1,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -6, -4, -6, -4,
+ax_anim 2, 0, 216, -8, -9, -8, -9,
+ax_anim 2, 0, 217, -7, -13, -7, -13,
+ax_anim 3, 0, 210, -1, -16, -1, -16,
+ax_anim 2, 3, 211, 4, -14, 4, -14,
+ax_anim 2, 0, 212, 5, -8, 5, -8,
+ax_anim 1, 0, 213, 4, -4, 4, -4,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, -1, -6, -1, -6,
+ax_anim 2, 0, 211, -4, -14, -4, -14,
+ax_anim 2, 0, 210, -9, -18, -9, -18,
+ax_anim 3, 0, 217, -17, -18, -17, -18,
+ax_anim 2, 3, 216, -19, -11, -19, -11,
+ax_anim 2, 0, 215, -13, -1, -13, -1,
+ax_anim 1, 0, 214, -7, 1, -7, 1,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, -3, -4, -3, -4,
+ax_anim 2, 0, 210, -8, -6, -8, -6,
+ax_anim 2, 0, 217, -17, -3, -17, -5,
+ax_anim 3, 0, 216, -23, 4, -23, 0,
+ax_anim 2, 3, 215, -17, 9, -17, 5,
+ax_anim 2, 0, 214, -12, 10, -12, 7,
+ax_anim 1, 0, 213, -4, 5, -4, 4,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 217, -17, 3, -17, 3,
+ax_anim 2, 0, 216, -24, 11, -24, 9,
+ax_anim 3, 0, 215, -23, 26, -23, 21,
+ax_anim 2, 3, 214, -11, 29, -11, 25,
+ax_anim 2, 0, 213, -2, 18, -2, 18,
+ax_anim 1, 0, 212, 2, 10, 2, 10,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 228, 0, -22, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 1, 0, 228, 0, -9, 0, 0,
+ax_anim 2, 2, 226, 0, 4, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_11_2:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 230, 0, -16, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 231, 0, -22, 0, 0,
+ax_anim 2, 0, 231, 0, -17, 0, 0,
+ax_anim 1, 0, 231, 0, -9, 0, 0,
+ax_anim 2, 2, 229, 0, 4, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_11_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -23, 0, 0,
+ax_anim 3, 0, 234, 0, -22, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 1, 0, 234, 0, -9, 0, 0,
+ax_anim 2, 2, 232, 0, 4, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_11_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 236, 0, -16, 0, 0,
+ax_anim 3, 0, 236, 0, -20, 0, 0,
+ax_anim 4, 0, 236, 0, -21, 0, 0,
+ax_anim 4, 0, 237, 0, -22, 0, 0,
+ax_anim 3, 0, 237, 0, -21, 0, 0,
+ax_anim 2, 0, 237, 0, -15, 0, 0,
+ax_anim 1, 0, 237, 0, -8, 0, 0,
+ax_anim 2, 2, 235, 0, 6, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_11_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 239, 0, -16, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -23, 0, 0,
+ax_anim 3, 0, 240, 0, -22, 0, 0,
+ax_anim 2, 0, 240, 0, -14, 0, 0,
+ax_anim 1, 0, 240, 0, -5, 0, 0,
+ax_anim 2, 2, 238, 0, 7, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_11_6:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -10, 0, 0,
+ax_anim 2, 0, 242, 0, -16, 0, 0,
+ax_anim 3, 0, 242, 0, -20, 0, 0,
+ax_anim 4, 0, 242, 0, -21, 0, 0,
+ax_anim 4, 0, 243, 0, -22, 0, 0,
+ax_anim 3, 0, 243, 0, -21, 0, 0,
+ax_anim 2, 0, 243, 0, -15, 0, 0,
+ax_anim 1, 0, 243, 0, -7, 0, 0,
+ax_anim 2, 2, 241, 0, 6, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_11_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 245, 0, -10, 0, 0,
+ax_anim 2, 0, 245, 0, -16, 0, 0,
+ax_anim 3, 0, 245, 0, -20, 0, 0,
+ax_anim 4, 0, 245, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -23, 0, 0,
+ax_anim 3, 0, 246, 0, -22, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 1, 0, 246, 0, -9, 0, 0,
+ax_anim 2, 2, 244, 0, 4, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_11_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -10, 0, 0,
+ax_anim 2, 0, 248, 0, -16, 0, 0,
+ax_anim 3, 0, 248, 0, -20, 0, 0,
+ax_anim 4, 0, 248, 0, -21, 0, 0,
+ax_anim 4, 0, 249, 0, -23, 0, 0,
+ax_anim 3, 0, 249, 0, -22, 0, 0,
+ax_anim 2, 0, 249, 0, -17, 0, 0,
+ax_anim 1, 0, 249, 0, -9, 0, 0,
+ax_anim 2, 2, 247, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_12_1:
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_12_2:
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 1, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_12_3:
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 1, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_12_4:
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 1, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_12_5:
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 1, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_12_6:
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 1, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_12_7:
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 1, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_12_8:
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 1, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sButterfreeAnims_13_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_13_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_13_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_13_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_13_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_13_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_13_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeAnims_13_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sButterfreeGfx1:
+.incbin "baserom.gba", 0x598284, 0x200
+sButterfreeSprites1:
+ax_sprite sButterfreeGfx1, 0x200
+ax_sprite_terminator
+sButterfreeGfx2:
+.incbin "baserom.gba", 0x598494, 0x200
+sButterfreeSprites2:
+ax_sprite sButterfreeGfx2, 0x200
+ax_sprite_terminator
+sButterfreeGfx3:
+.incbin "baserom.gba", 0x5986A4, 0x200
+sButterfreeSprites3:
+ax_sprite sButterfreeGfx3, 0x200
+ax_sprite_terminator
+sButterfreeGfx4:
+.incbin "baserom.gba", 0x5988B4, 0x200
+sButterfreeSprites4:
+ax_sprite sButterfreeGfx4, 0x200
+ax_sprite_terminator
+sButterfreeGfx5:
+.incbin "baserom.gba", 0x598AC4, 0x200
+sButterfreeSprites5:
+ax_sprite sButterfreeGfx5, 0x200
+ax_sprite_terminator
+sButterfreeGfx6:
+.incbin "baserom.gba", 0x598CD4, 0x200
+sButterfreeSprites6:
+ax_sprite sButterfreeGfx6, 0x200
+ax_sprite_terminator
+sButterfreeGfx7:
+.incbin "baserom.gba", 0x598EE4, 0x200
+sButterfreeSprites7:
+ax_sprite sButterfreeGfx7, 0x200
+ax_sprite_terminator
+sButterfreeGfx8:
+.incbin "baserom.gba", 0x5990F4, 0x200
+sButterfreeSprites8:
+ax_sprite sButterfreeGfx8, 0x200
+ax_sprite_terminator
+sButterfreeGfx9:
+.incbin "baserom.gba", 0x599304, 0x200
+sButterfreeSprites9:
+ax_sprite sButterfreeGfx9, 0x200
+ax_sprite_terminator
+sButterfreeGfx10:
+.incbin "baserom.gba", 0x599514, 0x200
+sButterfreeSprites10:
+ax_sprite sButterfreeGfx10, 0x200
+ax_sprite_terminator
+sButterfreeGfx11:
+.incbin "baserom.gba", 0x599724, 0x200
+sButterfreeSprites11:
+ax_sprite sButterfreeGfx11, 0x200
+ax_sprite_terminator
+sButterfreeGfx12:
+.incbin "baserom.gba", 0x599934, 0x200
+sButterfreeSprites12:
+ax_sprite sButterfreeGfx12, 0x200
+ax_sprite_terminator
+sButterfreeGfx13:
+.incbin "baserom.gba", 0x599B44, 0x200
+sButterfreeSprites13:
+ax_sprite sButterfreeGfx13, 0x200
+ax_sprite_terminator
+sButterfreeGfx14:
+.incbin "baserom.gba", 0x599D54, 0x200
+sButterfreeSprites14:
+ax_sprite sButterfreeGfx14, 0x200
+ax_sprite_terminator
+sButterfreeGfx15:
+.incbin "baserom.gba", 0x599F64, 0x200
+sButterfreeSprites15:
+ax_sprite sButterfreeGfx15, 0x200
+ax_sprite_terminator
+sButterfreeGfx16:
+.incbin "baserom.gba", 0x59A174, 0x180
+sButterfreeSprites16:
+ax_sprite sButterfreeGfx16, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sButterfreeGfx17:
+.incbin "baserom.gba", 0x59A30C, 0x180
+sButterfreeSprites17:
+ax_sprite sButterfreeGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sButterfreeGfx18:
+.incbin "baserom.gba", 0x59A4A4, 0x60
+sButterfreeGfx18_1:
+.incbin "baserom.gba", 0x59A504, 0x60
+sButterfreeGfx18_2:
+.incbin "baserom.gba", 0x59A564, 0x60
+sButterfreeGfx18_3:
+.incbin "baserom.gba", 0x59A5C4, 0x40
+sButterfreeSprites18:
+ax_sprite sButterfreeGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sButterfreeGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sButterfreeGfx19:
+.incbin "baserom.gba", 0x59A64C, 0x40
+sButterfreeGfx19_1:
+.incbin "baserom.gba", 0x59A68C, 0x60
+sButterfreeGfx19_2:
+.incbin "baserom.gba", 0x59A6EC, 0x60
+sButterfreeSprites19:
+ax_sprite sButterfreeGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sButterfreeGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sButterfreeGfx20:
+.incbin "baserom.gba", 0x59A784, 0xC0
+sButterfreeGfx20_1:
+.incbin "baserom.gba", 0x59A844, 0x20
+sButterfreeSprites20:
+ax_sprite sButterfreeGfx20, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx20_1, 0x20
+ax_sprite_terminator
+sButterfreeGfx21:
+.incbin "baserom.gba", 0x59A884, 0x40
+sButterfreeGfx21_1:
+.incbin "baserom.gba", 0x59A8C4, 0x60
+sButterfreeGfx21_2:
+.incbin "baserom.gba", 0x59A924, 0x60
+sButterfreeGfx21_3:
+.incbin "baserom.gba", 0x59A984, 0x20
+sButterfreeSprites21:
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sButterfreeGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sButterfreeGfx22:
+.incbin "baserom.gba", 0x59A9F4, 0x60
+sButterfreeGfx22_1:
+.incbin "baserom.gba", 0x59AA54, 0x60
+sButterfreeGfx22_2:
+.incbin "baserom.gba", 0x59AAB4, 0x60
+sButterfreeSprites22:
+ax_sprite sButterfreeGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sButterfreeGfx23:
+.incbin "baserom.gba", 0x59AB4C, 0x60
+sButterfreeGfx23_1:
+.incbin "baserom.gba", 0x59ABAC, 0x60
+sButterfreeGfx23_2:
+.incbin "baserom.gba", 0x59AC0C, 0x60
+sButterfreeSprites23:
+ax_sprite sButterfreeGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sButterfreeGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sButterfreeGfx24:
+.incbin "baserom.gba", 0x59ACA4, 0x180
+sButterfreeSprites24:
+ax_sprite sButterfreeGfx24, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sButterfreeGfx25:
+.incbin "baserom.gba", 0x59AE3C, 0x180
+sButterfreeSprites25:
+ax_sprite sButterfreeGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sButterfreeGfx26:
+.incbin "baserom.gba", 0x59AFD4, 0x200
+sButterfreeSprites26:
+ax_sprite sButterfreeGfx26, 0x200
+ax_sprite_terminator
+sButterfreeGfx27:
+.incbin "baserom.gba", 0x59B1E4, 0x200
+sButterfreeSprites27:
+ax_sprite sButterfreeGfx27, 0x200
+ax_sprite_terminator
+sButterfreeGfx28:
+.incbin "baserom.gba", 0x59B3F4, 0x200
+sButterfreeSprites28:
+ax_sprite sButterfreeGfx28, 0x200
+ax_sprite_terminator
+sButterfreeGfx29:
+.incbin "baserom.gba", 0x59B604, 0x200
+sButterfreeSprites29:
+ax_sprite sButterfreeGfx29, 0x200
+ax_sprite_terminator
+sButterfreeGfx30:
+.incbin "baserom.gba", 0x59B814, 0x200
+sButterfreeSprites30:
+ax_sprite sButterfreeGfx30, 0x200
+ax_sprite_terminator
+sButterfreeGfx31:
+.incbin "baserom.gba", 0x59BA24, 0x200
+sButterfreeSprites31:
+ax_sprite sButterfreeGfx31, 0x200
+ax_sprite_terminator
+sButterfreeGfx32:
+.incbin "baserom.gba", 0x59BC34, 0x200
+sButterfreeSprites32:
+ax_sprite sButterfreeGfx32, 0x200
+ax_sprite_terminator
+sAxPosesButterfree:
+.4byte sButterfreePose1
+.4byte sButterfreePose2
+.4byte sButterfreePose3
+.4byte sButterfreePose4
+.4byte sButterfreePose5
+.4byte sButterfreePose6
+.4byte sButterfreePose7
+.4byte sButterfreePose8
+.4byte sButterfreePose9
+.4byte sButterfreePose10
+.4byte sButterfreePose11
+.4byte sButterfreePose12
+.4byte sButterfreePose13
+.4byte sButterfreePose14
+.4byte sButterfreePose15
+.4byte sButterfreePose16
+.4byte sButterfreePose17
+.4byte sButterfreePose18
+.4byte sButterfreePose19
+.4byte sButterfreePose20
+.4byte sButterfreePose21
+.4byte sButterfreePose22
+.4byte sButterfreePose23
+.4byte sButterfreePose24
+.4byte sButterfreePose25
+.4byte sButterfreePose26
+.4byte sButterfreePose27
+.4byte sButterfreePose28
+.4byte sButterfreePose29
+.4byte sButterfreePose30
+.4byte sButterfreePose31
+.4byte sButterfreePose32
+.4byte sButterfreePose33
+.4byte sButterfreePose34
+.4byte sButterfreePose35
+.4byte sButterfreePose36
+.4byte sButterfreePose37
+.4byte sButterfreePose38
+.4byte sButterfreePose39
+.4byte sButterfreePose40
+.4byte sButterfreePose41
+.4byte sButterfreePose42
+.4byte sButterfreePose43
+.4byte sButterfreePose44
+.4byte sButterfreePose45
+.4byte sButterfreePose46
+.4byte sButterfreePose47
+.4byte sButterfreePose48
+.4byte sButterfreePose49
+.4byte sButterfreePose50
+.4byte sButterfreePose51
+.4byte sButterfreePose52
+.4byte sButterfreePose53
+.4byte sButterfreePose54
+.4byte sButterfreePose55
+.4byte sButterfreePose56
+.4byte sButterfreePose57
+.4byte sButterfreePose58
+.4byte sButterfreePose59
+.4byte sButterfreePose60
+.4byte sButterfreePose61
+.4byte sButterfreePose62
+.4byte sButterfreePose63
+.4byte sButterfreePose64
+.4byte sButterfreePose65
+.4byte sButterfreePose66
+.4byte sButterfreePose67
+.4byte sButterfreePose68
+.4byte sButterfreePose69
+.4byte sButterfreePose70
+.4byte sButterfreePose71
+.4byte sButterfreePose72
+.4byte sButterfreePose73
+.4byte sButterfreePose74
+.4byte sButterfreePose75
+.4byte sButterfreePose76
+.4byte sButterfreePose77
+.4byte sButterfreePose78
+.4byte sButterfreePose79
+.4byte sButterfreePose80
+.4byte sButterfreePose81
+.4byte sButterfreePose82
+.4byte sButterfreePose83
+.4byte sButterfreePose84
+.4byte sButterfreePose85
+.4byte sButterfreePose86
+.4byte sButterfreePose87
+.4byte sButterfreePose88
+.4byte sButterfreePose89
+.4byte sButterfreePose90
+.4byte sButterfreePose91
+.4byte sButterfreePose92
+.4byte sButterfreePose93
+.4byte sButterfreePose94
+.4byte sButterfreePose95
+.4byte sButterfreePose96
+.4byte sButterfreePose97
+.4byte sButterfreePose98
+.4byte sButterfreePose99
+.4byte sButterfreePose100
+.4byte sButterfreePose101
+.4byte sButterfreePose102
+.4byte sButterfreePose103
+.4byte sButterfreePose104
+.4byte sButterfreePose105
+.4byte sButterfreePose106
+.4byte sButterfreePose107
+.4byte sButterfreePose108
+.4byte sButterfreePose109
+.4byte sButterfreePose110
+.4byte sButterfreePose111
+.4byte sButterfreePose112
+.4byte sButterfreePose113
+.4byte sButterfreePose114
+.4byte sButterfreePose115
+.4byte sButterfreePose116
+.4byte sButterfreePose117
+.4byte sButterfreePose118
+.4byte sButterfreePose119
+.4byte sButterfreePose120
+.4byte sButterfreePose121
+.4byte sButterfreePose122
+.4byte sButterfreePose123
+.4byte sButterfreePose124
+.4byte sButterfreePose125
+.4byte sButterfreePose126
+.4byte sButterfreePose127
+.4byte sButterfreePose128
+.4byte sButterfreePose129
+.4byte sButterfreePose130
+.4byte sButterfreePose131
+.4byte sButterfreePose132
+.4byte sButterfreePose133
+.4byte sButterfreePose134
+.4byte sButterfreePose135
+.4byte sButterfreePose136
+.4byte sButterfreePose137
+.4byte sButterfreePose138
+.4byte sButterfreePose139
+.4byte sButterfreePose140
+.4byte sButterfreePose141
+.4byte sButterfreePose142
+.4byte sButterfreePose143
+.4byte sButterfreePose144
+.4byte sButterfreePose145
+.4byte sButterfreePose146
+.4byte sButterfreePose147
+.4byte sButterfreePose148
+.4byte sButterfreePose149
+.4byte sButterfreePose150
+.4byte sButterfreePose151
+.4byte sButterfreePose152
+.4byte sButterfreePose153
+.4byte sButterfreePose154
+.4byte sButterfreePose155
+.4byte sButterfreePose156
+.4byte sButterfreePose157
+.4byte sButterfreePose158
+.4byte sButterfreePose159
+.4byte sButterfreePose160
+.4byte sButterfreePose161
+.4byte sButterfreePose162
+.4byte sButterfreePose163
+.4byte sButterfreePose164
+.4byte sButterfreePose165
+.4byte sButterfreePose166
+.4byte sButterfreePose167
+.4byte sButterfreePose168
+.4byte sButterfreePose169
+.4byte sButterfreePose170
+.4byte sButterfreePose171
+.4byte sButterfreePose172
+.4byte sButterfreePose173
+.4byte sButterfreePose174
+.4byte sButterfreePose175
+.4byte sButterfreePose176
+.4byte sButterfreePose177
+.4byte sButterfreePose178
+.4byte sButterfreePose179
+.4byte sButterfreePose180
+.4byte sButterfreePose181
+.4byte sButterfreePose182
+.4byte sButterfreePose183
+.4byte sButterfreePose184
+.4byte sButterfreePose185
+.4byte sButterfreePose186
+.4byte sButterfreePose187
+.4byte sButterfreePose188
+.4byte sButterfreePose189
+.4byte sButterfreePose190
+.4byte sButterfreePose191
+.4byte sButterfreePose192
+.4byte sButterfreePose193
+.4byte sButterfreePose194
+.4byte sButterfreePose195
+.4byte sButterfreePose196
+.4byte sButterfreePose197
+.4byte sButterfreePose198
+.4byte sButterfreePose199
+.4byte sButterfreePose200
+.4byte sButterfreePose201
+.4byte sButterfreePose202
+.4byte sButterfreePose203
+.4byte sButterfreePose204
+.4byte sButterfreePose205
+.4byte sButterfreePose206
+.4byte sButterfreePose207
+.4byte sButterfreePose208
+.4byte sButterfreePose209
+.4byte sButterfreePose210
+.4byte sButterfreePose211
+.4byte sButterfreePose212
+.4byte sButterfreePose213
+.4byte sButterfreePose214
+.4byte sButterfreePose215
+.4byte sButterfreePose216
+.4byte sButterfreePose217
+.4byte sButterfreePose218
+.4byte sButterfreePose219
+.4byte sButterfreePose220
+.4byte sButterfreePose221
+.4byte sButterfreePose222
+.4byte sButterfreePose223
+.4byte sButterfreePose224
+.4byte sButterfreePose225
+.4byte sButterfreePose226
+.4byte sButterfreePose227
+.4byte sButterfreePose228
+.4byte sButterfreePose229
+.4byte sButterfreePose230
+.4byte sButterfreePose231
+.4byte sButterfreePose232
+.4byte sButterfreePose233
+.4byte sButterfreePose234
+.4byte sButterfreePose235
+.4byte sButterfreePose236
+.4byte sButterfreePose237
+.4byte sButterfreePose238
+.4byte sButterfreePose239
+.4byte sButterfreePose240
+.4byte sButterfreePose241
+.4byte sButterfreePose242
+.4byte sButterfreePose243
+.4byte sButterfreePose244
+.4byte sButterfreePose245
+.4byte sButterfreePose246
+.4byte sButterfreePose247
+.4byte sButterfreePose248
+.4byte sButterfreePose249
+.4byte sButterfreePose250
+.4byte sButterfreePose251
+.4byte sButterfreePose252
+.4byte sButterfreePose253
+.4byte sButterfreePose254
+.4byte sButterfreePose255
+.4byte sButterfreePose256
+.4byte sButterfreePose257
+.4byte sButterfreePose258
+.4byte sButterfreePose259
+.4byte sButterfreePose260
+.4byte sButterfreePose261
+.4byte sButterfreePose262
+.4byte sButterfreePose263
+.4byte sButterfreePose264
+.4byte sButterfreePose265
+.4byte sButterfreePose266
+sAxPositionsButterfree:
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,  -11, 	 -13,  -14, 	  12,  -14, 	  -1,  -12
+.2byte   -1,  -11, 	  -9,  -18, 	   8,  -18, 	  -1,  -13
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    5,  -11, 	   6,  -20, 	 -11,  -12, 	   0,  -13
+.2byte    5,  -11, 	   2,  -24, 	 -10,  -20, 	  -1,  -15
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    7,  -13, 	  -3,  -22, 	  -5,  -13, 	   1,  -13
+.2byte    7,  -12, 	  -8,  -21, 	 -10,  -16, 	   0,  -14
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -18, 	  -6,  -21, 	  10,  -14, 	   2,  -16
+.2byte    6,  -17, 	 -10,  -21, 	   4,  -15, 	  -1,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte   -1,  -16, 	  12,  -17, 	 -13,  -17, 	   0,  -15
+.2byte   -1,  -17, 	   8,  -17, 	  -9,  -17, 	   0,  -15
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -7,  -18, 	   6,  -21, 	 -10,  -14, 	  -2,  -16
+.2byte   -6,  -17, 	  10,  -21, 	  -4,  -15, 	   1,  -16
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -7,  -13, 	   3,  -22, 	   5,  -13, 	  -1,  -13
+.2byte   -7,  -12, 	   8,  -21, 	  10,  -16, 	   0,  -14
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -5,  -11, 	  -6,  -20, 	  11,  -12, 	   0,  -13
+.2byte   -5,  -11, 	  -2,  -24, 	  10,  -20, 	   1,  -15
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,  -11, 	 -13,  -14, 	  12,  -14, 	  -1,  -12
+.2byte   -1,  -11, 	  -9,  -18, 	   8,  -18, 	  -1,  -13
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    5,  -11, 	   6,  -20, 	 -11,  -12, 	   0,  -13
+.2byte    5,  -11, 	   2,  -24, 	 -10,  -20, 	  -1,  -15
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    7,  -13, 	  -3,  -22, 	  -5,  -13, 	   1,  -13
+.2byte    7,  -12, 	  -8,  -21, 	 -10,  -16, 	   0,  -14
+.2byte    5,  -18, 	 -10,  -20, 	   7,  -15, 	  -1,  -16
+.2byte    6,  -18, 	  -7,  -21, 	   9,  -14, 	   1,  -16
+.2byte    5,  -17, 	 -11,  -21, 	   3,  -15, 	  -2,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte   -1,  -16, 	  12,  -17, 	 -13,  -17, 	   0,  -15
+.2byte   -1,  -17, 	   8,  -17, 	  -9,  -17, 	   0,  -15
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -7,  -18, 	   6,  -21, 	 -10,  -14, 	  -2,  -16
+.2byte   -6,  -17, 	  10,  -21, 	  -4,  -15, 	   1,  -16
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -7,  -13, 	   3,  -22, 	   5,  -13, 	  -1,  -13
+.2byte   -7,  -12, 	   8,  -21, 	  10,  -16, 	   0,  -14
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -5,  -11, 	  -6,  -20, 	  11,  -12, 	   0,  -13
+.2byte   -5,  -11, 	  -2,  -24, 	  10,  -20, 	   1,  -15
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,  -11, 	 -13,  -14, 	  12,  -14, 	  -1,  -12
+.2byte   -1,  -11, 	  -9,  -18, 	   8,  -18, 	  -1,  -13
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    5,  -11, 	   6,  -20, 	 -11,  -12, 	   0,  -13
+.2byte    5,  -11, 	   2,  -24, 	 -10,  -20, 	  -1,  -15
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    7,  -13, 	  -3,  -22, 	  -5,  -13, 	   1,  -13
+.2byte    7,  -12, 	  -8,  -21, 	 -10,  -16, 	   0,  -14
+.2byte    5,  -18, 	 -10,  -20, 	   7,  -15, 	  -1,  -16
+.2byte    6,  -18, 	  -7,  -21, 	   9,  -14, 	   1,  -16
+.2byte    5,  -17, 	 -11,  -21, 	   3,  -15, 	  -2,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte   -1,  -16, 	  12,  -17, 	 -13,  -17, 	   0,  -15
+.2byte   -1,  -17, 	   8,  -17, 	  -9,  -17, 	   0,  -15
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -7,  -18, 	   6,  -21, 	 -10,  -14, 	  -2,  -16
+.2byte   -6,  -17, 	  10,  -21, 	  -4,  -15, 	   1,  -16
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -7,  -13, 	   3,  -22, 	   5,  -13, 	  -1,  -13
+.2byte   -7,  -12, 	   8,  -21, 	  10,  -16, 	   0,  -14
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -5,  -11, 	  -6,  -20, 	  11,  -12, 	   0,  -13
+.2byte   -5,  -11, 	  -2,  -24, 	  10,  -20, 	   1,  -15
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte   -1,  -14, 	 -12,  -16, 	  11,  -16, 	   0,  -14
+.2byte    0,   -7, 	 -12,  -13, 	  11,  -13, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    3,  -13, 	   4,  -21, 	 -12,  -12, 	  -2,  -13
+.2byte    4,   -7, 	   9,  -17, 	  -9,  -11, 	   1,  -10
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -1,  -22, 	  -6,  -14, 	   0,  -13
+.2byte    5,   -9, 	  -2,  -24, 	   3,  -11, 	   0,  -13
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    4,  -17, 	  -8,  -22, 	   9,  -14, 	  -1,  -15
+.2byte    6,  -15, 	  -6,  -23, 	  10,  -12, 	   0,  -15
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte   -1,  -19, 	  11,  -20, 	 -12,  -20, 	   0,  -16
+.2byte   -1,  -17, 	  11,  -19, 	 -12,  -19, 	   0,  -16
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte   -5,  -17, 	   7,  -22, 	 -10,  -14, 	   0,  -15
+.2byte   -7,  -15, 	   5,  -23, 	 -11,  -12, 	  -1,  -15
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte   -5,  -15, 	   0,  -22, 	   5,  -14, 	  -1,  -13
+.2byte   -6,   -9, 	   1,  -24, 	  -4,  -11, 	  -1,  -13
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte   -4,  -13, 	  -5,  -21, 	  11,  -12, 	   1,  -13
+.2byte   -5,   -7, 	 -10,  -17, 	   8,  -11, 	  -2,  -10
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,  -11, 	 -13,  -14, 	  12,  -14, 	  -1,  -12
+.2byte   -1,  -11, 	  -9,  -18, 	   8,  -18, 	  -1,  -13
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -5,  -11, 	  -6,  -20, 	  11,  -12, 	   0,  -13
+.2byte   -5,  -11, 	  -2,  -24, 	  10,  -20, 	   1,  -15
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -7,  -13, 	   3,  -22, 	   5,  -13, 	  -1,  -13
+.2byte   -7,  -12, 	   8,  -21, 	  10,  -16, 	   0,  -14
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -7,  -18, 	   6,  -21, 	 -10,  -14, 	  -2,  -16
+.2byte   -6,  -17, 	  10,  -21, 	  -4,  -15, 	   1,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte   -1,  -16, 	  12,  -17, 	 -13,  -17, 	   0,  -15
+.2byte   -1,  -17, 	   8,  -17, 	  -9,  -17, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -18, 	  -6,  -21, 	  10,  -14, 	   2,  -16
+.2byte    6,  -17, 	 -10,  -21, 	   4,  -15, 	  -1,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    7,  -13, 	  -3,  -22, 	  -5,  -13, 	   1,  -13
+.2byte    7,  -12, 	  -8,  -21, 	 -10,  -16, 	   0,  -14
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    5,  -11, 	   6,  -20, 	 -11,  -12, 	   0,  -13
+.2byte    5,  -11, 	   2,  -24, 	 -10,  -20, 	  -1,  -15
+.2byte   -6,   -1, 	   4,  -12, 	   6,  -12, 	   0,   -4
+.2byte   -6,    0, 	   3,  -11, 	   6,  -12, 	   0,   -4
+.2byte   -1,  -12, 	  14,  -15, 	 -15,  -15, 	  -1,  -11
+.2byte    0,  -14, 	   3,  -22, 	 -12,   -6, 	  -1,  -11
+.2byte    3,  -14, 	  -8,  -18, 	 -10,   -7, 	  -1,  -10
+.2byte    0,  -15, 	 -14,  -16, 	  10,  -11, 	  -1,  -10
+.2byte   -1,  -11, 	  13,  -10, 	 -14,  -10, 	   0,   -8
+.2byte   -1,  -15, 	  13,  -16, 	 -11,  -11, 	   0,  -10
+.2byte   -4,  -14, 	   7,  -18, 	   9,   -7, 	   0,  -10
+.2byte   -1,  -14, 	  -4,  -22, 	  11,   -6, 	   0,  -11
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,  -11, 	 -13,  -14, 	  12,  -14, 	  -1,  -12
+.2byte   -1,  -11, 	  -9,  -18, 	   8,  -18, 	  -1,  -13
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    5,  -11, 	   6,  -20, 	 -11,  -12, 	   0,  -13
+.2byte    5,  -11, 	   2,  -24, 	 -10,  -20, 	  -1,  -15
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    7,  -13, 	  -3,  -22, 	  -5,  -13, 	   1,  -13
+.2byte    7,  -12, 	  -8,  -21, 	 -10,  -16, 	   0,  -14
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -18, 	  -6,  -21, 	  10,  -14, 	   2,  -16
+.2byte    6,  -17, 	 -10,  -21, 	   4,  -15, 	  -1,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte   -1,  -16, 	  12,  -17, 	 -13,  -17, 	   0,  -15
+.2byte   -1,  -17, 	   8,  -17, 	  -9,  -17, 	   0,  -15
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -7,  -18, 	   6,  -21, 	 -10,  -14, 	  -2,  -16
+.2byte   -6,  -17, 	  10,  -21, 	  -4,  -15, 	   1,  -16
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -7,  -13, 	   3,  -22, 	   5,  -13, 	  -1,  -13
+.2byte   -7,  -12, 	   8,  -21, 	  10,  -16, 	   0,  -14
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -5,  -11, 	  -6,  -20, 	  11,  -12, 	   0,  -13
+.2byte   -5,  -11, 	  -2,  -24, 	  10,  -20, 	   1,  -15
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte   -1,  -11, 	 -13,  -14, 	  12,  -14, 	  -1,  -12
+.2byte    5,  -11, 	   6,  -20, 	 -11,  -12, 	   0,  -13
+.2byte    7,  -13, 	  -3,  -22, 	  -5,  -13, 	   1,  -13
+.2byte    7,  -18, 	  -6,  -21, 	  10,  -14, 	   2,  -16
+.2byte   -1,  -16, 	  12,  -17, 	 -13,  -17, 	   0,  -15
+.2byte   -7,  -18, 	   6,  -21, 	 -10,  -14, 	  -2,  -16
+.2byte   -7,  -13, 	   3,  -22, 	   5,  -13, 	  -1,  -13
+.2byte   -5,  -11, 	  -6,  -20, 	  11,  -12, 	   0,  -13
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,  -14, 	 -12,  -16, 	  11,  -16, 	   0,  -14
+.2byte    0,   -7, 	 -12,  -13, 	  11,  -13, 	  -1,  -10
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+.2byte    3,  -13, 	   4,  -21, 	 -12,  -12, 	  -2,  -13
+.2byte    4,   -7, 	   9,  -17, 	  -9,  -11, 	   1,  -10
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    4,  -15, 	  -1,  -22, 	  -6,  -14, 	   0,  -13
+.2byte    5,   -9, 	  -2,  -24, 	   3,  -11, 	   0,  -13
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    4,  -17, 	  -8,  -22, 	   9,  -14, 	  -1,  -15
+.2byte    6,  -15, 	  -6,  -23, 	  10,  -12, 	   0,  -15
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte   -1,  -19, 	  11,  -20, 	 -12,  -20, 	   0,  -16
+.2byte   -1,  -17, 	  11,  -19, 	 -12,  -19, 	   0,  -16
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -5,  -17, 	   7,  -22, 	 -10,  -14, 	   0,  -15
+.2byte   -7,  -15, 	   5,  -23, 	 -11,  -12, 	  -1,  -15
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -5,  -15, 	   0,  -22, 	   5,  -14, 	  -1,  -13
+.2byte   -6,   -9, 	   1,  -24, 	  -4,  -11, 	  -1,  -13
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -4,  -13, 	  -5,  -21, 	  11,  -12, 	   1,  -13
+.2byte   -5,   -7, 	 -10,  -17, 	   8,  -11, 	  -2,  -10
+.2byte   -1,  -14, 	 -12,  -16, 	  11,  -16, 	   0,  -14
+.2byte   -4,  -13, 	  -5,  -21, 	  11,  -12, 	   1,  -13
+.2byte   -5,  -15, 	   0,  -22, 	   5,  -14, 	  -1,  -13
+.2byte   -5,  -17, 	   7,  -22, 	 -10,  -14, 	   0,  -15
+.2byte   -1,  -19, 	  11,  -20, 	 -12,  -20, 	   0,  -16
+.2byte    4,  -17, 	  -8,  -22, 	   9,  -14, 	  -1,  -15
+.2byte    4,  -15, 	  -1,  -22, 	  -6,  -14, 	   0,  -13
+.2byte    3,  -13, 	   4,  -21, 	 -12,  -12, 	  -2,  -13
+.2byte   -1,  -11, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -5,  -11, 	  -3,  -24, 	  10,  -16, 	   0,  -13
+.2byte   -7,  -13, 	   5,  -21, 	   7,  -14, 	  -1,  -12
+.2byte   -6,  -18, 	   9,  -20, 	  -8,  -15, 	   0,  -16
+.2byte   -1,  -17, 	  10,  -18, 	 -11,  -18, 	   0,  -15
+.2byte    6,  -18, 	  -9,  -20, 	   8,  -15, 	   0,  -16
+.2byte    7,  -13, 	  -5,  -21, 	  -7,  -14, 	   1,  -12
+.2byte    5,  -11, 	   3,  -24, 	 -10,  -16, 	   0,  -13
+sButterfreeAnimTable1:
+.4byte sButterfreeAnims_1_1
+.4byte sButterfreeAnims_1_2
+.4byte sButterfreeAnims_1_3
+.4byte sButterfreeAnims_1_4
+.4byte sButterfreeAnims_1_5
+.4byte sButterfreeAnims_1_6
+.4byte sButterfreeAnims_1_7
+.4byte sButterfreeAnims_1_8
+sButterfreeAnimTable2:
+.4byte sButterfreeAnims_2_1
+.4byte sButterfreeAnims_2_2
+.4byte sButterfreeAnims_2_3
+.4byte sButterfreeAnims_2_4
+.4byte sButterfreeAnims_2_5
+.4byte sButterfreeAnims_2_6
+.4byte sButterfreeAnims_2_7
+.4byte sButterfreeAnims_2_8
+sButterfreeAnimTable3:
+.4byte sButterfreeAnims_3_1
+.4byte sButterfreeAnims_3_2
+.4byte sButterfreeAnims_3_3
+.4byte sButterfreeAnims_3_4
+.4byte sButterfreeAnims_3_5
+.4byte sButterfreeAnims_3_6
+.4byte sButterfreeAnims_3_7
+.4byte sButterfreeAnims_3_8
+sButterfreeAnimTable4:
+.4byte sButterfreeAnims_4_1
+.4byte sButterfreeAnims_4_2
+.4byte sButterfreeAnims_4_3
+.4byte sButterfreeAnims_4_4
+.4byte sButterfreeAnims_4_5
+.4byte sButterfreeAnims_4_6
+.4byte sButterfreeAnims_4_7
+.4byte sButterfreeAnims_4_8
+sButterfreeAnimTable5:
+.4byte sButterfreeAnims_5_1
+.4byte sButterfreeAnims_5_2
+.4byte sButterfreeAnims_5_3
+.4byte sButterfreeAnims_5_4
+.4byte sButterfreeAnims_5_5
+.4byte sButterfreeAnims_5_6
+.4byte sButterfreeAnims_5_7
+.4byte sButterfreeAnims_5_8
+sButterfreeAnimTable6:
+.4byte sButterfreeAnims_6_1
+.4byte sButterfreeAnims_6_1
+.4byte sButterfreeAnims_6_1
+.4byte sButterfreeAnims_6_1
+.4byte sButterfreeAnims_6_1
+.4byte sButterfreeAnims_6_1
+.4byte sButterfreeAnims_6_1
+.4byte sButterfreeAnims_6_1
+sButterfreeAnimTable7:
+.4byte sButterfreeAnims_7_1
+.4byte sButterfreeAnims_7_2
+.4byte sButterfreeAnims_7_3
+.4byte sButterfreeAnims_7_4
+.4byte sButterfreeAnims_7_5
+.4byte sButterfreeAnims_7_6
+.4byte sButterfreeAnims_7_7
+.4byte sButterfreeAnims_7_8
+sButterfreeAnimTable8:
+.4byte sButterfreeAnims_8_1
+.4byte sButterfreeAnims_8_2
+.4byte sButterfreeAnims_8_3
+.4byte sButterfreeAnims_8_4
+.4byte sButterfreeAnims_8_5
+.4byte sButterfreeAnims_8_6
+.4byte sButterfreeAnims_8_7
+.4byte sButterfreeAnims_8_8
+sButterfreeAnimTable9:
+.4byte sButterfreeAnims_9_1
+.4byte sButterfreeAnims_9_2
+.4byte sButterfreeAnims_9_3
+.4byte sButterfreeAnims_9_4
+.4byte sButterfreeAnims_9_5
+.4byte sButterfreeAnims_9_6
+.4byte sButterfreeAnims_9_7
+.4byte sButterfreeAnims_9_8
+sButterfreeAnimTable10:
+.4byte sButterfreeAnims_10_1
+.4byte sButterfreeAnims_10_2
+.4byte sButterfreeAnims_10_3
+.4byte sButterfreeAnims_10_4
+.4byte sButterfreeAnims_10_5
+.4byte sButterfreeAnims_10_6
+.4byte sButterfreeAnims_10_7
+.4byte sButterfreeAnims_10_8
+sButterfreeAnimTable11:
+.4byte sButterfreeAnims_11_1
+.4byte sButterfreeAnims_11_2
+.4byte sButterfreeAnims_11_3
+.4byte sButterfreeAnims_11_4
+.4byte sButterfreeAnims_11_5
+.4byte sButterfreeAnims_11_6
+.4byte sButterfreeAnims_11_7
+.4byte sButterfreeAnims_11_8
+sButterfreeAnimTable12:
+.4byte sButterfreeAnims_12_1
+.4byte sButterfreeAnims_12_2
+.4byte sButterfreeAnims_12_3
+.4byte sButterfreeAnims_12_4
+.4byte sButterfreeAnims_12_5
+.4byte sButterfreeAnims_12_6
+.4byte sButterfreeAnims_12_7
+.4byte sButterfreeAnims_12_8
+sButterfreeAnimTable13:
+.4byte sButterfreeAnims_13_1
+.4byte sButterfreeAnims_13_2
+.4byte sButterfreeAnims_13_3
+.4byte sButterfreeAnims_13_4
+.4byte sButterfreeAnims_13_5
+.4byte sButterfreeAnims_13_6
+.4byte sButterfreeAnims_13_7
+.4byte sButterfreeAnims_13_8
+sAxAnimationsButterfree:
+.4byte sButterfreeAnimTable1
+.4byte sButterfreeAnimTable2
+.4byte sButterfreeAnimTable3
+.4byte sButterfreeAnimTable4
+.4byte sButterfreeAnimTable5
+.4byte sButterfreeAnimTable6
+.4byte sButterfreeAnimTable7
+.4byte sButterfreeAnimTable8
+.4byte sButterfreeAnimTable9
+.4byte sButterfreeAnimTable10
+.4byte sButterfreeAnimTable11
+.4byte sButterfreeAnimTable12
+.4byte sButterfreeAnimTable13
+sAxSpritesButterfree:
+.4byte sButterfreeSprites1
+.4byte sButterfreeSprites2
+.4byte sButterfreeSprites3
+.4byte sButterfreeSprites4
+.4byte sButterfreeSprites5
+.4byte sButterfreeSprites6
+.4byte sButterfreeSprites7
+.4byte sButterfreeSprites8
+.4byte sButterfreeSprites9
+.4byte sButterfreeSprites10
+.4byte sButterfreeSprites11
+.4byte sButterfreeSprites12
+.4byte sButterfreeSprites13
+.4byte sButterfreeSprites14
+.4byte sButterfreeSprites15
+.4byte sButterfreeSprites16
+.4byte sButterfreeSprites17
+.4byte sButterfreeSprites18
+.4byte sButterfreeSprites19
+.4byte sButterfreeSprites20
+.4byte sButterfreeSprites21
+.4byte sButterfreeSprites22
+.4byte sButterfreeSprites23
+.4byte sButterfreeSprites24
+.4byte sButterfreeSprites25
+.4byte sButterfreeSprites26
+.4byte sButterfreeSprites27
+.4byte sButterfreeSprites28
+.4byte sButterfreeSprites29
+.4byte sButterfreeSprites30
+.4byte sButterfreeSprites31
+.4byte sButterfreeSprites32
+sAxMainButterfree:
+ax_main sAxPosesButterfree, sAxAnimationsButterfree, 13, sAxSpritesButterfree, sAxPositionsButterfree

--- a/data/ax/cacnea.inc
+++ b/data/ax/cacnea.inc
@@ -1,0 +1,3190 @@
+.global gAxCacnea
+gAxCacnea:
+ax_siro sAxMainCacnea
+sCacneaPose1:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose2:
+ax_pose 1, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose4:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose5:
+ax_pose 4, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose6:
+ax_pose 5, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose7:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose8:
+ax_pose 7, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose9:
+ax_pose 8, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose10:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose11:
+ax_pose 10, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose12:
+ax_pose 11, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose13:
+ax_pose 12, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose14:
+ax_pose 13, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose15:
+ax_pose 14, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose16:
+ax_pose 9, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose17:
+ax_pose 10, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose18:
+ax_pose 11, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose19:
+ax_pose 6, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose20:
+ax_pose 7, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose21:
+ax_pose 8, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose22:
+ax_pose 3, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose23:
+ax_pose 4, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose24:
+ax_pose 5, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose25:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose26:
+ax_pose 1, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose27:
+ax_pose 2, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose28:
+ax_pose 15, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose29:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose30:
+ax_pose 4, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose31:
+ax_pose 5, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose32:
+ax_pose 16, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose33:
+ax_pose 17, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose34:
+ax_pose 18, 0x01ee, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacneaPose35:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose36:
+ax_pose 7, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose37:
+ax_pose 8, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose38:
+ax_pose 19, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose39:
+ax_pose 20, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose40:
+ax_pose 21, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose41:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose42:
+ax_pose 10, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose43:
+ax_pose 11, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose44:
+ax_pose 22, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose45:
+ax_pose 23, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose46:
+ax_pose 24, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose47:
+ax_pose 12, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose48:
+ax_pose 13, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose49:
+ax_pose 14, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose50:
+ax_pose 25, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose51:
+ax_pose 26, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose52:
+ax_pose 27, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose53:
+ax_pose 9, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose54:
+ax_pose 10, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose55:
+ax_pose 11, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose56:
+ax_pose 22, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose57:
+ax_pose 23, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose58:
+ax_pose 24, 0x01ed, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacneaPose59:
+ax_pose 6, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose60:
+ax_pose 7, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose61:
+ax_pose 8, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose62:
+ax_pose 19, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose63:
+ax_pose 20, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose64:
+ax_pose 21, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose65:
+ax_pose 3, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose66:
+ax_pose 4, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose67:
+ax_pose 5, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose68:
+ax_pose 16, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose69:
+ax_pose 17, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose70:
+ax_pose 18, 0x01ee, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacneaPose71:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose72:
+ax_pose 1, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose73:
+ax_pose 2, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose74:
+ax_pose 15, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose75:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose76:
+ax_pose 4, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose77:
+ax_pose 5, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose78:
+ax_pose 16, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose79:
+ax_pose 17, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose80:
+ax_pose 18, 0x01ee, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacneaPose81:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose82:
+ax_pose 7, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose83:
+ax_pose 8, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose84:
+ax_pose 19, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose85:
+ax_pose 20, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose86:
+ax_pose 21, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose87:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose88:
+ax_pose 10, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose89:
+ax_pose 11, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose90:
+ax_pose 22, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose91:
+ax_pose 23, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose92:
+ax_pose 24, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose93:
+ax_pose 12, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose94:
+ax_pose 13, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose95:
+ax_pose 14, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose96:
+ax_pose 25, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose97:
+ax_pose 26, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose98:
+ax_pose 27, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose99:
+ax_pose 9, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose100:
+ax_pose 10, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose101:
+ax_pose 11, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose102:
+ax_pose 22, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose103:
+ax_pose 23, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose104:
+ax_pose 24, 0x01ed, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacneaPose105:
+ax_pose 6, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose106:
+ax_pose 7, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose107:
+ax_pose 8, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose108:
+ax_pose 19, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose109:
+ax_pose 20, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose110:
+ax_pose 21, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose111:
+ax_pose 3, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose112:
+ax_pose 4, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose113:
+ax_pose 5, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose114:
+ax_pose 16, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose115:
+ax_pose 17, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose116:
+ax_pose 18, 0x01ee, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacneaPose117:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose118:
+ax_pose 15, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose119:
+ax_pose 28, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose120:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose121:
+ax_pose 16, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose122:
+ax_pose 17, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose123:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose124:
+ax_pose 19, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose125:
+ax_pose 20, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose126:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose127:
+ax_pose 22, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose128:
+ax_pose 23, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose129:
+ax_pose 12, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose130:
+ax_pose 25, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose131:
+ax_pose 26, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose132:
+ax_pose 9, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose133:
+ax_pose 22, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose134:
+ax_pose 23, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose135:
+ax_pose 6, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose136:
+ax_pose 19, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose137:
+ax_pose 20, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose138:
+ax_pose 3, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose139:
+ax_pose 16, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose140:
+ax_pose 17, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose141:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose142:
+ax_pose 15, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose143:
+ax_pose 28, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose144:
+ax_pose 29, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose145:
+ax_pose 30, 0x01f4, 0x40f4, 0x3c00
+ax_pose -1, 0x01f4, 0x40fc, 0x3c00
+ax_pose 29, 0x01eb, 0x80f0, 0x3c04
+ax_pose_terminator
+sCacneaPose146:
+ax_pose 31, 0x01f4, 0x40f4, 0x3c00
+ax_pose -1, 0x01f4, 0x40fc, 0x3c00
+ax_pose 29, 0x01eb, 0x80f0, 0x3c04
+ax_pose_terminator
+sCacneaPose147:
+ax_pose 32, 0x01f4, 0x40f4, 0x3c00
+ax_pose -1, 0x01f4, 0x40fc, 0x3c00
+ax_pose 29, 0x01eb, 0x80f0, 0x3c04
+ax_pose_terminator
+sCacneaPose148:
+ax_pose 33, 0x01f4, 0x40f4, 0x3c00
+ax_pose -1, 0x01f4, 0x40fc, 0x3c00
+ax_pose 29, 0x01eb, 0x80f0, 0x3c04
+ax_pose_terminator
+sCacneaPose149:
+ax_pose 34, 0x01f4, 0x40f4, 0x3c00
+ax_pose -1, 0x01f4, 0x40fc, 0x3c00
+ax_pose 29, 0x01eb, 0x80f0, 0x3c04
+ax_pose_terminator
+sCacneaPose150:
+ax_pose 35, 0x01f4, 0x40f4, 0x3c00
+ax_pose -1, 0x01f4, 0x40fc, 0x3c00
+ax_pose 29, 0x01eb, 0x80f0, 0x3c04
+ax_pose_terminator
+sCacneaPose151:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose152:
+ax_pose 16, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose153:
+ax_pose 17, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose154:
+ax_pose 18, 0x01ed, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacneaPose155:
+ax_pose 30, 0x01f1, 0x4101, 0x3c00
+ax_pose -1, 0x01f5, 0x40fb, 0x3c00
+ax_pose 18, 0x01ed, 0x90f1, 0x3c04
+ax_pose_terminator
+sCacneaPose156:
+ax_pose 31, 0x01f1, 0x4101, 0x3c00
+ax_pose -1, 0x01f5, 0x40fb, 0x3c00
+ax_pose 18, 0x01ed, 0x90f1, 0x3c04
+ax_pose_terminator
+sCacneaPose157:
+ax_pose 32, 0x01f1, 0x4101, 0x3c00
+ax_pose -1, 0x01f5, 0x40fb, 0x3c00
+ax_pose 18, 0x01ed, 0x90f1, 0x3c04
+ax_pose_terminator
+sCacneaPose158:
+ax_pose 33, 0x01f1, 0x4101, 0x3c00
+ax_pose -1, 0x01f5, 0x40fb, 0x3c00
+ax_pose 18, 0x01ed, 0x90f1, 0x3c04
+ax_pose_terminator
+sCacneaPose159:
+ax_pose 34, 0x01f1, 0x4101, 0x3c00
+ax_pose -1, 0x01f5, 0x40fb, 0x3c00
+ax_pose 18, 0x01ed, 0x90f1, 0x3c04
+ax_pose_terminator
+sCacneaPose160:
+ax_pose 35, 0x01f1, 0x4101, 0x3c00
+ax_pose -1, 0x01f5, 0x40fb, 0x3c00
+ax_pose 18, 0x01ed, 0x90f1, 0x3c04
+ax_pose_terminator
+sCacneaPose161:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose162:
+ax_pose 19, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose163:
+ax_pose 20, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose164:
+ax_pose 21, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose165:
+ax_pose 36, 0x01f4, 0x50ff, 0x3c00
+ax_pose 30, 0x01ee, 0x4101, 0x3c04
+ax_pose -1, 0x01eb, 0x4103, 0x3c04
+ax_pose 21, 0x01ec, 0x90ef, 0x3c08
+ax_pose_terminator
+sCacneaPose166:
+ax_pose 36, 0x01f4, 0x50ff, 0x3c00
+ax_pose 31, 0x01ee, 0x4101, 0x3c04
+ax_pose -1, 0x01eb, 0x4103, 0x3c04
+ax_pose 21, 0x01ec, 0x90ef, 0x3c08
+ax_pose_terminator
+sCacneaPose167:
+ax_pose 36, 0x01f4, 0x50ff, 0x3c00
+ax_pose 32, 0x01ee, 0x4101, 0x3c04
+ax_pose -1, 0x01eb, 0x4103, 0x3c04
+ax_pose 21, 0x01ec, 0x90ef, 0x3c08
+ax_pose_terminator
+sCacneaPose168:
+ax_pose 36, 0x01f4, 0x50ff, 0x3c00
+ax_pose 33, 0x01ee, 0x4101, 0x3c04
+ax_pose -1, 0x01eb, 0x4103, 0x3c04
+ax_pose 21, 0x01ec, 0x90ef, 0x3c08
+ax_pose_terminator
+sCacneaPose169:
+ax_pose 36, 0x01f4, 0x50ff, 0x3c00
+ax_pose 34, 0x01ee, 0x4101, 0x3c04
+ax_pose -1, 0x01eb, 0x4103, 0x3c04
+ax_pose 21, 0x01ec, 0x90ef, 0x3c08
+ax_pose_terminator
+sCacneaPose170:
+ax_pose 36, 0x01f4, 0x50ff, 0x3c00
+ax_pose 35, 0x01ee, 0x4101, 0x3c04
+ax_pose -1, 0x01eb, 0x4103, 0x3c04
+ax_pose 21, 0x01ec, 0x90ef, 0x3c08
+ax_pose_terminator
+sCacneaPose171:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose172:
+ax_pose 22, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose173:
+ax_pose 23, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose174:
+ax_pose 24, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose175:
+ax_pose 24, 0x01eb, 0x90f0, 0x3c00
+ax_pose 30, 0x01ea, 0x4102, 0x3c10
+ax_pose -1, 0x01e6, 0x40fc, 0x3c10
+ax_pose_terminator
+sCacneaPose176:
+ax_pose 24, 0x01eb, 0x90f0, 0x3c00
+ax_pose 31, 0x01ea, 0x4102, 0x3c10
+ax_pose -1, 0x01e6, 0x40fc, 0x3c10
+ax_pose_terminator
+sCacneaPose177:
+ax_pose 24, 0x01eb, 0x90f0, 0x3c00
+ax_pose 32, 0x01ea, 0x4102, 0x3c10
+ax_pose -1, 0x01e6, 0x40fc, 0x3c10
+ax_pose_terminator
+sCacneaPose178:
+ax_pose 24, 0x01eb, 0x90f0, 0x3c00
+ax_pose 33, 0x01ea, 0x4102, 0x3c10
+ax_pose -1, 0x01e6, 0x40fc, 0x3c10
+ax_pose_terminator
+sCacneaPose179:
+ax_pose 24, 0x01eb, 0x90f0, 0x3c00
+ax_pose 34, 0x01ea, 0x4102, 0x3c10
+ax_pose -1, 0x01e6, 0x40fc, 0x3c10
+ax_pose_terminator
+sCacneaPose180:
+ax_pose 24, 0x01eb, 0x90f0, 0x3c00
+ax_pose 35, 0x01ea, 0x4102, 0x3c10
+ax_pose -1, 0x01e6, 0x40fc, 0x3c10
+ax_pose_terminator
+sCacneaPose181:
+ax_pose 12, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose182:
+ax_pose 25, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose183:
+ax_pose 26, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose184:
+ax_pose 27, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose185:
+ax_pose 27, 0x01eb, 0x80f0, 0x3c00
+ax_pose 30, 0x01e6, 0x40fd, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose186:
+ax_pose 27, 0x01eb, 0x80f0, 0x3c00
+ax_pose 31, 0x01e6, 0x40fd, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose187:
+ax_pose 27, 0x01eb, 0x80f0, 0x3c00
+ax_pose 32, 0x01e6, 0x40fd, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose188:
+ax_pose 27, 0x01eb, 0x80f0, 0x3c00
+ax_pose 33, 0x01e6, 0x40fd, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose189:
+ax_pose 27, 0x01eb, 0x80f0, 0x3c00
+ax_pose 34, 0x01e6, 0x40fd, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose190:
+ax_pose 27, 0x01eb, 0x80f0, 0x3c00
+ax_pose 35, 0x01e6, 0x40fd, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose191:
+ax_pose 9, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose192:
+ax_pose 22, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose193:
+ax_pose 23, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose194:
+ax_pose 24, 0x01eb, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacneaPose195:
+ax_pose 24, 0x01eb, 0x80ef, 0x3c00
+ax_pose 30, 0x01ea, 0x40ed, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose196:
+ax_pose 24, 0x01eb, 0x80ef, 0x3c00
+ax_pose 31, 0x01ea, 0x40ed, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose197:
+ax_pose 24, 0x01eb, 0x80ef, 0x3c00
+ax_pose 32, 0x01ea, 0x40ed, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose198:
+ax_pose 24, 0x01eb, 0x80ef, 0x3c00
+ax_pose 33, 0x01ea, 0x40ed, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose199:
+ax_pose 24, 0x01eb, 0x80ef, 0x3c00
+ax_pose 34, 0x01ea, 0x40ed, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose200:
+ax_pose 24, 0x01eb, 0x80ef, 0x3c00
+ax_pose 35, 0x01ea, 0x40ed, 0x3c10
+ax_pose -1, 0x01e6, 0x40f3, 0x3c10
+ax_pose_terminator
+sCacneaPose201:
+ax_pose 6, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose202:
+ax_pose 19, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose203:
+ax_pose 20, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose204:
+ax_pose 21, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose205:
+ax_pose 36, 0x01f4, 0x40f0, 0x3c00
+ax_pose 30, 0x01ee, 0x40ee, 0x3c04
+ax_pose -1, 0x01eb, 0x40ec, 0x3c04
+ax_pose 21, 0x01ec, 0x80f0, 0x3c08
+ax_pose_terminator
+sCacneaPose206:
+ax_pose 36, 0x01f4, 0x40f0, 0x3c00
+ax_pose 31, 0x01ee, 0x40ee, 0x3c04
+ax_pose -1, 0x01eb, 0x40ec, 0x3c04
+ax_pose 21, 0x01ec, 0x80f0, 0x3c08
+ax_pose_terminator
+sCacneaPose207:
+ax_pose 36, 0x01f4, 0x40f0, 0x3c00
+ax_pose 32, 0x01ee, 0x40ee, 0x3c04
+ax_pose -1, 0x01eb, 0x40ec, 0x3c04
+ax_pose 21, 0x01ec, 0x80f0, 0x3c08
+ax_pose_terminator
+sCacneaPose208:
+ax_pose 36, 0x01f4, 0x40f0, 0x3c00
+ax_pose 33, 0x01ee, 0x40ee, 0x3c04
+ax_pose -1, 0x01eb, 0x40ec, 0x3c04
+ax_pose 21, 0x01ec, 0x80f0, 0x3c08
+ax_pose_terminator
+sCacneaPose209:
+ax_pose 36, 0x01f4, 0x40f0, 0x3c00
+ax_pose 34, 0x01ee, 0x40ee, 0x3c04
+ax_pose -1, 0x01eb, 0x40ec, 0x3c04
+ax_pose 21, 0x01ec, 0x80f0, 0x3c08
+ax_pose_terminator
+sCacneaPose210:
+ax_pose 36, 0x01f4, 0x40f0, 0x3c00
+ax_pose 35, 0x01ee, 0x40ee, 0x3c04
+ax_pose -1, 0x01eb, 0x40ec, 0x3c04
+ax_pose 21, 0x01ec, 0x80f0, 0x3c08
+ax_pose_terminator
+sCacneaPose211:
+ax_pose 3, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose212:
+ax_pose 16, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose213:
+ax_pose 17, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose214:
+ax_pose 18, 0x01ed, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacneaPose215:
+ax_pose 30, 0x01f1, 0x40ee, 0x3c00
+ax_pose -1, 0x01f5, 0x40f4, 0x3c00
+ax_pose 18, 0x01ed, 0x80ee, 0x3c04
+ax_pose_terminator
+sCacneaPose216:
+ax_pose 31, 0x01f1, 0x40ee, 0x3c00
+ax_pose -1, 0x01f5, 0x40f4, 0x3c00
+ax_pose 18, 0x01ed, 0x80ee, 0x3c04
+ax_pose_terminator
+sCacneaPose217:
+ax_pose 32, 0x01f1, 0x40ee, 0x3c00
+ax_pose -1, 0x01f5, 0x40f4, 0x3c00
+ax_pose 18, 0x01ed, 0x80ee, 0x3c04
+ax_pose_terminator
+sCacneaPose218:
+ax_pose 33, 0x01f1, 0x40ee, 0x3c00
+ax_pose -1, 0x01f5, 0x40f4, 0x3c00
+ax_pose 18, 0x01ed, 0x80ee, 0x3c04
+ax_pose_terminator
+sCacneaPose219:
+ax_pose 34, 0x01f1, 0x40ee, 0x3c00
+ax_pose -1, 0x01f5, 0x40f4, 0x3c00
+ax_pose 18, 0x01ed, 0x80ee, 0x3c04
+ax_pose_terminator
+sCacneaPose220:
+ax_pose 35, 0x01f1, 0x40ee, 0x3c00
+ax_pose -1, 0x01f5, 0x40f4, 0x3c00
+ax_pose 18, 0x01ed, 0x80ee, 0x3c04
+ax_pose_terminator
+sCacneaPose221:
+ax_pose 37, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sCacneaPose222:
+ax_pose 38, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sCacneaPose223:
+ax_pose 39, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose224:
+ax_pose 40, 0x01e6, 0x90ed, 0x3c00
+ax_pose_terminator
+sCacneaPose225:
+ax_pose 41, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sCacneaPose226:
+ax_pose 42, 0x01e9, 0x90ed, 0x3c00
+ax_pose_terminator
+sCacneaPose227:
+ax_pose 43, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose228:
+ax_pose 42, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sCacneaPose229:
+ax_pose 41, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacneaPose230:
+ax_pose 40, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sCacneaPose231:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose232:
+ax_pose 15, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose233:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose234:
+ax_pose 16, 0x01ee, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose235:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose236:
+ax_pose 19, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose237:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose238:
+ax_pose 22, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose239:
+ax_pose 12, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose240:
+ax_pose 25, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose241:
+ax_pose 9, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose242:
+ax_pose 22, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose243:
+ax_pose 6, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose244:
+ax_pose 19, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose245:
+ax_pose 3, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose246:
+ax_pose 16, 0x01ee, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacneaPose247:
+ax_pose 28, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose248:
+ax_pose 17, 0x01ef, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacneaPose249:
+ax_pose 20, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sCacneaPose250:
+ax_pose 23, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacneaPose251:
+ax_pose 26, 0x01ee, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose252:
+ax_pose 23, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose253:
+ax_pose 20, 0x01ee, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacneaPose254:
+ax_pose 17, 0x01ef, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacneaPose255:
+ax_pose 15, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose256:
+ax_pose 16, 0x01ef, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose257:
+ax_pose 19, 0x01ee, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose258:
+ax_pose 22, 0x01ec, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose259:
+ax_pose 25, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose260:
+ax_pose 22, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose261:
+ax_pose 19, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose262:
+ax_pose 16, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose263:
+ax_pose 0, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose264:
+ax_pose 15, 0x01ee, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose265:
+ax_pose 28, 0x01ec, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose266:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose267:
+ax_pose 16, 0x01ee, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacneaPose268:
+ax_pose 17, 0x01ef, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacneaPose269:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose270:
+ax_pose 19, 0x01ee, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose271:
+ax_pose 20, 0x01ee, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacneaPose272:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose273:
+ax_pose 22, 0x01ec, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacneaPose274:
+ax_pose 23, 0x01ed, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacneaPose275:
+ax_pose 12, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose276:
+ax_pose 25, 0x01ec, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose277:
+ax_pose 26, 0x01ee, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose278:
+ax_pose 9, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose279:
+ax_pose 22, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose280:
+ax_pose 23, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacneaPose281:
+ax_pose 6, 0x01ee, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose282:
+ax_pose 19, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose283:
+ax_pose 20, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacneaPose284:
+ax_pose 3, 0x01ef, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose285:
+ax_pose 16, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose286:
+ax_pose 17, 0x01ef, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacneaPose287:
+ax_pose 28, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose288:
+ax_pose 17, 0x01ef, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacneaPose289:
+ax_pose 20, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sCacneaPose290:
+ax_pose 23, 0x01ee, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacneaPose291:
+ax_pose 26, 0x01ee, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacneaPose292:
+ax_pose 23, 0x01ee, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacneaPose293:
+ax_pose 20, 0x01ee, 0x90ed, 0x3c00
+ax_pose_terminator
+sCacneaPose294:
+ax_pose 17, 0x01ef, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacneaPose295:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose296:
+ax_pose 3, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose297:
+ax_pose 6, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose298:
+ax_pose 9, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose299:
+ax_pose 12, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacneaPose300:
+ax_pose 9, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose301:
+ax_pose 6, 0x01ee, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacneaPose302:
+ax_pose 3, 0x01ef, 0x90ef, 0x3c00
+ax_pose_terminator
+.align 2
+sCacneaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCacneaAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 9, 10, 9,
+ax_anim 2, 0, 31, 22, 20, 22, 20,
+ax_anim 2, 1, 31, 23, 19, 23, 19,
+ax_anim 2, 0, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 31, 23, 19, 23, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sCacneaAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 22, 0, 22, 0,
+ax_anim 2, 1, 37, 22, 1, 22, 1,
+ax_anim 2, 0, 37, 22, 0, 22, 0,
+ax_anim 2, 0, 37, 22, 1, 22, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sCacneaAnims_2_4:
+ax_anim 2, 0, 40, -1, 1, -1, 1,
+ax_anim 4, 0, 40, -2, 2, -2, 2,
+ax_anim 1, 0, 42, 0, -1, 0, -1,
+ax_anim 1, 2, 41, 5, -6, 5, -6,
+ax_anim 1, 0, 42, 11, -12, 11, -12,
+ax_anim 2, 0, 43, 22, -23, 22, -23,
+ax_anim 2, 1, 43, 23, -22, 23, -22,
+ax_anim 2, 0, 43, 22, -23, 22, -23,
+ax_anim 2, 0, 43, 23, -22, 23, -22,
+ax_anim 2, 0, 40, 6, -6, 6, -6,
+ax_anim_terminator
+sCacneaAnims_2_5:
+ax_anim 2, 0, 46, 0, 1, 0, 1,
+ax_anim 4, 0, 46, 0, 2, 0, 2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 47, 0, -4, 0, -4,
+ax_anim 1, 0, 48, 0, -11, 0, -11,
+ax_anim 2, 0, 49, 0, -24, 0, -24,
+ax_anim 2, 1, 49, 1, -24, 1, -24,
+ax_anim 2, 0, 49, 0, -24, 0, -24,
+ax_anim 2, 0, 49, 1, -24, 1, -24,
+ax_anim 2, 0, 46, 0, -6, 0, -6,
+ax_anim_terminator
+sCacneaAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 4, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 54, 0, -1, 0, -1,
+ax_anim 1, 2, 53, -5, -6, -5, -6,
+ax_anim 1, 0, 54, -11, -12, -11, -12,
+ax_anim 2, 0, 55, -22, -23, -22, -23,
+ax_anim 2, 1, 55, -23, -22, -23, -22,
+ax_anim 2, 0, 55, -22, -23, -22, -23,
+ax_anim 2, 0, 55, -23, -22, -23, -22,
+ax_anim 2, 0, 52, -6, -6, -6, -6,
+ax_anim_terminator
+sCacneaAnims_2_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 4, 0, 58, 2, 0, 2, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 59, -4, 0, -4, 0,
+ax_anim 1, 0, 60, -10, 0, -10, 0,
+ax_anim 2, 0, 61, -22, 0, -22, 0,
+ax_anim 2, 1, 61, -22, 1, -22, 1,
+ax_anim 2, 0, 61, -22, 0, -22, 0,
+ax_anim 2, 0, 61, -22, 1, -22, 1,
+ax_anim 2, 0, 58, -6, 0, -6, 0,
+ax_anim_terminator
+sCacneaAnims_2_8:
+ax_anim 2, 0, 64, 1, -1, 1, -1,
+ax_anim 4, 0, 64, 2, -2, 2, -2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, -4, 4, -4, 4,
+ax_anim 1, 0, 66, -10, 9, -10, 9,
+ax_anim 2, 0, 67, -22, 20, -22, 20,
+ax_anim 2, 1, 67, -23, 19, -23, 19,
+ax_anim 2, 0, 67, -22, 20, -22, 20,
+ax_anim 2, 0, 67, -23, 19, -23, 19,
+ax_anim 2, 0, 64, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCacneaAnims_3_1:
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 4, 0, 70, 0, -2, 0, -2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 0, 4, 0, 4,
+ax_anim 1, 0, 72, 0, 10, 0, 10,
+ax_anim 2, 0, 73, 0, 21, 0, 21,
+ax_anim 2, 1, 73, 1, 21, 1, 21,
+ax_anim 2, 0, 73, 0, 21, 0, 21,
+ax_anim 2, 0, 73, 1, 21, 1, 21,
+ax_anim 2, 0, 70, 0, 6, 0, 6,
+ax_anim_terminator
+sCacneaAnims_3_2:
+ax_anim 2, 0, 74, -1, -1, -1, -1,
+ax_anim 4, 0, 74, -2, -2, -2, -2,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 4, 4, 4, 4,
+ax_anim 1, 0, 76, 10, 9, 10, 9,
+ax_anim 2, 0, 77, 22, 20, 22, 20,
+ax_anim 2, 1, 77, 23, 19, 23, 19,
+ax_anim 2, 0, 77, 22, 20, 22, 20,
+ax_anim 2, 0, 77, 23, 19, 23, 19,
+ax_anim 2, 0, 74, 6, 6, 6, 6,
+ax_anim_terminator
+sCacneaAnims_3_3:
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 4, 0, 80, -2, 0, -2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, 4, 0, 4, 0,
+ax_anim 1, 0, 82, 10, 0, 10, 0,
+ax_anim 2, 0, 83, 22, 0, 22, 0,
+ax_anim 2, 1, 83, 22, 1, 22, 1,
+ax_anim 2, 0, 83, 22, 0, 22, 0,
+ax_anim 2, 0, 83, 22, 1, 22, 1,
+ax_anim 2, 0, 80, 6, 0, 6, 0,
+ax_anim_terminator
+sCacneaAnims_3_4:
+ax_anim 2, 0, 86, -1, 1, -1, 1,
+ax_anim 4, 0, 86, -2, 2, -2, 2,
+ax_anim 1, 0, 88, 0, -1, 0, -1,
+ax_anim 1, 2, 87, 5, -6, 5, -6,
+ax_anim 1, 0, 88, 11, -12, 11, -12,
+ax_anim 2, 0, 89, 22, -23, 22, -23,
+ax_anim 2, 1, 89, 23, -22, 23, -22,
+ax_anim 2, 0, 89, 22, -23, 22, -23,
+ax_anim 2, 0, 89, 23, -22, 23, -22,
+ax_anim 2, 0, 86, 6, -6, 6, -6,
+ax_anim_terminator
+sCacneaAnims_3_5:
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 4, 0, 92, 0, 2, 0, 2,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 2, 93, 0, -4, 0, -4,
+ax_anim 1, 0, 94, 0, -11, 0, -11,
+ax_anim 2, 0, 95, 0, -24, 0, -24,
+ax_anim 2, 1, 95, 1, -24, 1, -24,
+ax_anim 2, 0, 95, 0, -24, 0, -24,
+ax_anim 2, 0, 95, 1, -24, 1, -24,
+ax_anim 2, 0, 92, 0, -6, 0, -6,
+ax_anim_terminator
+sCacneaAnims_3_6:
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 4, 0, 98, 2, 2, 2, 2,
+ax_anim 1, 0, 100, 0, -1, 0, -1,
+ax_anim 1, 2, 99, -5, -6, -5, -6,
+ax_anim 1, 0, 100, -11, -12, -11, -12,
+ax_anim 2, 0, 101, -22, -23, -22, -23,
+ax_anim 2, 1, 101, -23, -22, -23, -22,
+ax_anim 2, 0, 101, -22, -23, -22, -23,
+ax_anim 2, 0, 101, -23, -22, -23, -22,
+ax_anim 2, 0, 98, -6, -6, -6, -6,
+ax_anim_terminator
+sCacneaAnims_3_7:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 4, 0, 104, 2, 0, 2, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 2, 105, -4, 0, -4, 0,
+ax_anim 1, 0, 106, -10, 0, -10, 0,
+ax_anim 2, 0, 107, -22, 0, -22, 0,
+ax_anim 2, 1, 107, -22, 1, -22, 1,
+ax_anim 2, 0, 107, -22, 0, -22, 0,
+ax_anim 2, 0, 107, -22, 1, -22, 1,
+ax_anim 2, 0, 104, -6, 0, -6, 0,
+ax_anim_terminator
+sCacneaAnims_3_8:
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 4, 0, 110, 2, -2, 2, -2,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 2, 111, -4, 4, -4, 4,
+ax_anim 1, 0, 112, -10, 9, -10, 9,
+ax_anim 2, 0, 113, -22, 20, -22, 20,
+ax_anim 2, 1, 113, -23, 19, -23, 19,
+ax_anim 2, 0, 113, -22, 20, -22, 20,
+ax_anim 2, 0, 113, -23, 19, -23, 19,
+ax_anim 2, 0, 110, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCacneaAnims_4_1:
+ax_anim 2, 0, 117, 0, -2, 0, -2,
+ax_anim 6, 2, 117, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 1, 118, 0, 3, 0, 3,
+ax_anim 2, 0, 118, 1, 3, 1, 3,
+ax_anim 2, 0, 118, 0, 3, 0, 3,
+ax_anim 2, 0, 118, 1, 3, 1, 3,
+ax_anim 2, 0, 118, 0, 3, 0, 3,
+ax_anim 2, 0, 118, 1, 3, 1, 3,
+ax_anim 2, 0, 118, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim_terminator
+sCacneaAnims_4_2:
+ax_anim 2, 0, 120, -2, -2, -2, -2,
+ax_anim 6, 2, 120, -3, -3, -3, -3,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 1, 121, 2, 2, 2, 2,
+ax_anim 2, 0, 121, 3, 1, 3, 1,
+ax_anim 2, 0, 121, 2, 2, 2, 2,
+ax_anim 2, 0, 121, 3, 1, 3, 1,
+ax_anim 2, 0, 121, 2, 2, 2, 2,
+ax_anim 2, 0, 121, 3, 1, 3, 1,
+ax_anim 2, 0, 121, 2, 2, 2, 2,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim_terminator
+sCacneaAnims_4_3:
+ax_anim 2, 0, 123, -2, 0, -2, 0,
+ax_anim 6, 2, 123, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim 2, 1, 124, 2, 0, 2, 0,
+ax_anim 2, 0, 124, 2, 1, 2, 1,
+ax_anim 2, 0, 124, 2, 0, 2, 0,
+ax_anim 2, 0, 124, 2, 1, 2, 1,
+ax_anim 2, 0, 124, 2, 0, 2, 0,
+ax_anim 2, 0, 124, 2, 1, 2, 1,
+ax_anim 2, 0, 124, 2, 0, 2, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim_terminator
+sCacneaAnims_4_4:
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim 6, 2, 126, -3, 3, -3, 3,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim 2, 1, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 127, 3, -1, 3, -1,
+ax_anim 2, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 127, 3, -1, 3, -1,
+ax_anim 2, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 127, 3, -1, 3, -1,
+ax_anim 2, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim_terminator
+sCacneaAnims_4_5:
+ax_anim 2, 0, 129, 0, 2, 0, 2,
+ax_anim 6, 2, 129, 0, 3, 0, 3,
+ax_anim 2, 0, 128, 0, 1, 0, 1,
+ax_anim 2, 1, 130, 0, -3, 0, -3,
+ax_anim 2, 0, 130, 1, -3, 1, -3,
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 2, 0, 130, 1, -3, 1, -3,
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 2, 0, 130, 1, -3, 1, -3,
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 0, -1, 0, -1,
+ax_anim_terminator
+sCacneaAnims_4_6:
+ax_anim 2, 0, 132, 2, 2, 2, 2,
+ax_anim 6, 2, 132, 3, 3, 3, 3,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 1, 133, -2, -2, -2, -2,
+ax_anim 2, 0, 133, -3, -1, -3, -1,
+ax_anim 2, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 0, 133, -3, -1, -3, -1,
+ax_anim 2, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 0, 133, -3, -1, -3, -1,
+ax_anim 2, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim_terminator
+sCacneaAnims_4_7:
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim 6, 2, 135, 3, 0, 3, 0,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 1, 136, -2, 0, -2, 0,
+ax_anim 2, 0, 136, -2, 1, -2, 1,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim 2, 0, 136, -2, 1, -2, 1,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim 2, 0, 136, -2, 1, -2, 1,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim_terminator
+sCacneaAnims_4_8:
+ax_anim 2, 0, 138, 2, -2, 2, -2,
+ax_anim 6, 2, 138, 3, -3, 3, -3,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 1, 139, -2, 2, -2, 2,
+ax_anim 2, 0, 139, -3, 1, -3, 1,
+ax_anim 2, 0, 139, -2, 2, -2, 2,
+ax_anim 2, 0, 139, -3, 1, -3, 1,
+ax_anim 2, 0, 139, -2, 2, -2, 2,
+ax_anim 2, 0, 139, -3, 1, -3, 1,
+ax_anim 2, 0, 139, -2, 2, -2, 2,
+ax_anim 2, 0, 137, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCacneaAnims_5_1:
+ax_anim 2, 0, 141, 0, -2, 0, -2,
+ax_anim 4, 0, 141, 0, -3, 0, -3,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 2, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_5_2:
+ax_anim 2, 0, 151, -2, -2, -2, -2,
+ax_anim 4, 0, 151, -3, -3, -3, -3,
+ax_anim 2, 0, 150, -1, -1, -1, -1,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 2, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_5_3:
+ax_anim 2, 0, 161, -2, 0, -2, 0,
+ax_anim 4, 0, 161, -3, 0, -3, 0,
+ax_anim 2, 0, 160, -1, 0, -1, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 2, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_5_4:
+ax_anim 2, 0, 171, -2, 2, -2, 2,
+ax_anim 4, 0, 171, -3, 3, -3, 3,
+ax_anim 2, 0, 170, -1, 1, -1, 1,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 6, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 2, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_5_5:
+ax_anim 2, 0, 181, 0, 2, 0, 2,
+ax_anim 4, 0, 181, 0, 3, 0, 3,
+ax_anim 2, 0, 180, 0, 1, 0, 1,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 6, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim 4, 2, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_5_6:
+ax_anim 2, 0, 191, 2, 2, 2, 2,
+ax_anim 4, 0, 191, 3, 3, 3, 3,
+ax_anim 2, 0, 190, 1, 1, 1, 1,
+ax_anim 4, 0, 192, 0, 0, 0, 0,
+ax_anim 6, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 2, 193, 0, 0, 0, 0,
+ax_anim 4, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_5_7:
+ax_anim 2, 0, 201, 2, 0, 2, 0,
+ax_anim 4, 0, 201, 3, 0, 3, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 4, 0, 202, 0, 0, 0, 0,
+ax_anim 6, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim 4, 2, 203, 0, 0, 0, 0,
+ax_anim 4, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_5_8:
+ax_anim 2, 0, 211, 2, -2, 2, -2,
+ax_anim 4, 0, 211, 3, -3, 3, -3,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 4, 0, 212, 0, 0, 0, 0,
+ax_anim 6, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 2, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_6_1:
+ax_anim 30, 0, 220, 0, 0, 0, 0,
+ax_anim 35, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_7_1:
+ax_anim 2, 0, 222, 0, -4, 0, -4,
+ax_anim 8, 0, 222, 0, -5, 0, -5,
+ax_anim_terminator
+sCacneaAnims_7_2:
+ax_anim 2, 0, 223, -4, -4, -4, -4,
+ax_anim 8, 0, 223, -5, -5, -5, -5,
+ax_anim_terminator
+sCacneaAnims_7_3:
+ax_anim 2, 0, 224, -4, 0, -4, 0,
+ax_anim 8, 0, 224, -5, 0, -5, 0,
+ax_anim_terminator
+sCacneaAnims_7_4:
+ax_anim 2, 0, 225, -4, 4, -4, 4,
+ax_anim 8, 0, 225, -5, 5, -5, 5,
+ax_anim_terminator
+sCacneaAnims_7_5:
+ax_anim 2, 0, 226, 0, 4, 0, 4,
+ax_anim 8, 0, 226, 0, 5, 0, 5,
+ax_anim_terminator
+sCacneaAnims_7_6:
+ax_anim 2, 0, 227, 4, 4, 4, 4,
+ax_anim 8, 0, 227, 5, 5, 5, 5,
+ax_anim_terminator
+sCacneaAnims_7_7:
+ax_anim 2, 0, 228, 4, 0, 4, 0,
+ax_anim 8, 0, 228, 5, 0, 5, 0,
+ax_anim_terminator
+sCacneaAnims_7_8:
+ax_anim 2, 0, 229, 4, -4, 4, -4,
+ax_anim 8, 0, 229, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sCacneaAnims_8_1:
+ax_anim 40, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 16, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_8_2:
+ax_anim 40, 0, 232, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 16, 0, 232, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_8_3:
+ax_anim 40, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim 16, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_8_4:
+ax_anim 40, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 16, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_8_5:
+ax_anim 40, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 16, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_8_6:
+ax_anim 40, 0, 240, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 16, 0, 240, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_8_7:
+ax_anim 40, 0, 242, 0, 0, 0, 0,
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 16, 0, 242, 0, 0, 0, 0,
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_8_8:
+ax_anim 40, 0, 244, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 16, 0, 244, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_9_1:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 247, 9, 6, 9, 6,
+ax_anim 2, 0, 248, 11, 13, 11, 13,
+ax_anim 2, 0, 249, 9, 18, 9, 18,
+ax_anim 3, 0, 250, 0, 21, 0, 21,
+ax_anim 2, 3, 251, -9, 18, -9, 18,
+ax_anim 2, 0, 252, -11, 13, -11, 13,
+ax_anim 1, 0, 253, -9, 6, -9, 6,
+ax_anim 1, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_9_2:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 10, -1, 10, -1,
+ax_anim 2, 0, 247, 18, 4, 18, 4,
+ax_anim 2, 0, 248, 23, 12, 23, 12,
+ax_anim 3, 0, 249, 22, 20, 22, 20,
+ax_anim 2, 3, 250, 11, 20, 11, 20,
+ax_anim 2, 0, 251, 3, 16, 3, 16,
+ax_anim 1, 0, 252, 0, 7, 0, 7,
+ax_anim 1, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_9_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 253, 5, -4, 5, -4,
+ax_anim 2, 0, 246, 13, -6, 13, -6,
+ax_anim 2, 0, 247, 20, -3, 20, -3,
+ax_anim 3, 0, 248, 23, -1, 23, -1,
+ax_anim 2, 3, 249, 21, 4, 21, 4,
+ax_anim 2, 0, 250, 12, 5, 12, 5,
+ax_anim 1, 0, 251, 6, 4, 6, 4,
+ax_anim 1, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_9_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -9, 0, -9,
+ax_anim 2, 0, 253, 6, -17, 6, -17,
+ax_anim 2, 0, 246, 13, -24, 13, -24,
+ax_anim 3, 0, 247, 23, -23, 23, -23,
+ax_anim 2, 3, 248, 27, -15, 27, -15,
+ax_anim 2, 0, 249, 21, -7, 21, -7,
+ax_anim 1, 0, 250, 12, -1, 12, -1,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_9_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, -10, -4, -10, -4,
+ax_anim 2, 0, 252, -12, -11, -12, -11,
+ax_anim 2, 0, 253, -9, -19, -9, -19,
+ax_anim 3, 0, 246, 0, -25, 0, -25,
+ax_anim 2, 3, 247, 9, -19, 9, -19,
+ax_anim 2, 0, 248, 12, -11, 12, -11,
+ax_anim 1, 0, 249, 10, -4, 10, -4,
+ax_anim 1, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_9_6:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -9, 0, -9,
+ax_anim 2, 0, 247, -6, -17, -6, -17,
+ax_anim 2, 0, 246, -13, -24, -13, -24,
+ax_anim 3, 0, 253, -23, -23, -23, -23,
+ax_anim 2, 3, 252, -27, -15, -27, -15,
+ax_anim 2, 0, 251, -21, -7, -21, -7,
+ax_anim 1, 0, 250, -12, -1, -12, -1,
+ax_anim 1, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_9_7:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 247, -5, -4, -5, -4,
+ax_anim 2, 0, 246, -13, -6, -13, -6,
+ax_anim 2, 0, 253, -20, -4, -20, -4,
+ax_anim 3, 0, 252, -23, -1, -23, -1,
+ax_anim 2, 3, 251, -21, 4, -21, 4,
+ax_anim 2, 0, 250, -12, 5, -12, 5,
+ax_anim 1, 0, 249, -6, 4, -6, 4,
+ax_anim 1, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_9_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 246, -10, -1, -10, -1,
+ax_anim 2, 0, 253, -18, 4, -18, 4,
+ax_anim 2, 0, 252, -23, 12, -23, 12,
+ax_anim 3, 0, 251, -22, 20, -22, 20,
+ax_anim 2, 3, 250, -11, 20, -11, 20,
+ax_anim 2, 0, 249, -3, 16, -3, 16,
+ax_anim 1, 0, 248, 0, 7, 0, 7,
+ax_anim 1, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_10_1:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 6, 0, 6, 0,
+ax_anim 2, 0, 254, -6, 0, -6, 0,
+ax_anim 2, 0, 254, 10, 0, 10, 0,
+ax_anim 2, 0, 254, -10, 0, -10, 0,
+ax_anim 2, 0, 254, 12, 0, 12, 0,
+ax_anim 3, 0, 254, -12, 0, -12, 0,
+ax_anim 3, 0, 254, 13, 0, 13, 0,
+ax_anim 3, 0, 254, -13, 0, -13, 0,
+ax_anim 2, 0, 254, 12, 0, 12, 0,
+ax_anim 3, 0, 254, -12, 0, -12, 0,
+ax_anim 2, 0, 254, 10, 0, 10, 0,
+ax_anim 2, 0, 254, -10, 0, -10, 0,
+ax_anim 2, 0, 254, 6, 0, 6, 0,
+ax_anim 2, 0, 254, -6, 0, -6, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_10_2:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 6, -6, 6, -6,
+ax_anim 2, 0, 255, -6, 6, -6, 6,
+ax_anim 2, 0, 255, 10, -10, 10, -10,
+ax_anim 2, 0, 255, -10, 10, -10, 10,
+ax_anim 2, 0, 255, 12, -12, 12, -12,
+ax_anim 3, 0, 255, -12, 12, -12, 12,
+ax_anim 3, 0, 255, 13, -13, 13, -13,
+ax_anim 3, 0, 255, -13, 13, -13, 13,
+ax_anim 2, 0, 255, 12, -12, 12, -12,
+ax_anim 3, 0, 255, -12, 12, -12, 12,
+ax_anim 2, 0, 255, 10, -10, 10, -10,
+ax_anim 2, 0, 255, -10, 10, -10, 10,
+ax_anim 2, 0, 255, 6, -6, 6, -6,
+ax_anim 2, 0, 255, -6, 6, -6, 6,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_10_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -6, 0, -6,
+ax_anim 2, 0, 256, 0, 6, 0, 6,
+ax_anim 2, 0, 256, 0, -10, 0, -10,
+ax_anim 2, 0, 256, 0, 10, 0, 10,
+ax_anim 2, 0, 256, 0, -12, 0, -12,
+ax_anim 3, 0, 256, 0, 12, 0, 12,
+ax_anim 3, 0, 256, 0, -13, 0, -13,
+ax_anim 3, 0, 256, 0, 13, 0, 13,
+ax_anim 2, 0, 256, 0, -12, 0, -12,
+ax_anim 3, 0, 256, 0, 12, 0, 12,
+ax_anim 2, 0, 256, 0, -10, 0, -10,
+ax_anim 2, 0, 256, 0, 10, 0, 10,
+ax_anim 2, 0, 256, 0, -6, 0, -6,
+ax_anim 2, 0, 256, 0, 6, 0, 6,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_10_4:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, -6, -6, -6, -6,
+ax_anim 2, 0, 257, 6, 6, 6, 6,
+ax_anim 2, 0, 257, -10, -10, -10, -10,
+ax_anim 2, 0, 257, 10, 10, 10, 10,
+ax_anim 2, 0, 257, -12, -12, -12, -12,
+ax_anim 3, 0, 257, 12, 12, 12, 12,
+ax_anim 3, 0, 257, -13, -13, -13, -13,
+ax_anim 3, 0, 257, 13, 13, 13, 13,
+ax_anim 2, 0, 257, -12, -12, -12, -12,
+ax_anim 3, 0, 257, 12, 12, 12, 12,
+ax_anim 2, 0, 257, -10, -10, -10, -10,
+ax_anim 2, 0, 257, 10, 10, 10, 10,
+ax_anim 2, 0, 257, -6, -6, -6, -6,
+ax_anim 2, 0, 257, 6, 6, 6, 6,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_10_5:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 6, 0, 6, 0,
+ax_anim 2, 0, 258, -6, 0, -6, 0,
+ax_anim 2, 0, 258, 10, 0, 10, 0,
+ax_anim 2, 0, 258, -10, 0, -10, 0,
+ax_anim 2, 0, 258, 12, 0, 12, 0,
+ax_anim 3, 0, 258, -12, 0, -12, 0,
+ax_anim 3, 0, 258, 13, 0, 13, 0,
+ax_anim 3, 0, 258, -13, 0, -13, 0,
+ax_anim 2, 0, 258, 12, 0, 12, 0,
+ax_anim 3, 0, 258, -12, 0, -12, 0,
+ax_anim 2, 0, 258, 10, 0, 10, 0,
+ax_anim 2, 0, 258, -10, 0, -10, 0,
+ax_anim 2, 0, 258, 6, 0, 6, 0,
+ax_anim 2, 0, 258, -6, 0, -6, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_10_6:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 6, -6, 6, -6,
+ax_anim 2, 0, 259, -6, 6, -6, 6,
+ax_anim 2, 0, 259, 10, -10, 10, -10,
+ax_anim 2, 0, 259, -10, 10, -10, 10,
+ax_anim 2, 0, 259, 12, -12, 12, -12,
+ax_anim 3, 0, 259, -12, 12, -12, 12,
+ax_anim 3, 0, 259, 13, -13, 13, -13,
+ax_anim 3, 0, 259, -13, 13, -13, 13,
+ax_anim 2, 0, 259, 12, -12, 12, -12,
+ax_anim 3, 0, 259, -12, 12, -12, 12,
+ax_anim 2, 0, 259, 10, -10, 10, -10,
+ax_anim 2, 0, 259, -10, 10, -10, 10,
+ax_anim 2, 0, 259, 6, -6, 6, -6,
+ax_anim 2, 0, 259, -6, 6, -6, 6,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_10_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -6, 0, -6,
+ax_anim 2, 0, 260, 0, 6, 0, 6,
+ax_anim 2, 0, 260, 0, -10, 0, -10,
+ax_anim 2, 0, 260, 0, 10, 0, 10,
+ax_anim 2, 0, 260, 0, -12, 0, -12,
+ax_anim 3, 0, 260, 0, 12, 0, 12,
+ax_anim 3, 0, 260, 0, -13, 0, -13,
+ax_anim 3, 0, 260, 0, 13, 0, 13,
+ax_anim 2, 0, 260, 0, -12, 0, -12,
+ax_anim 3, 0, 260, 0, 12, 0, 12,
+ax_anim 2, 0, 260, 0, -10, 0, -10,
+ax_anim 2, 0, 260, 0, 10, 0, 10,
+ax_anim 2, 0, 260, 0, -6, 0, -6,
+ax_anim 2, 0, 260, 0, 6, 0, 6,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_10_8:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, -6, -6, -6, -6,
+ax_anim 2, 0, 261, 6, 6, 6, 6,
+ax_anim 2, 0, 261, -10, -10, -10, -10,
+ax_anim 2, 0, 261, 10, 10, 10, 10,
+ax_anim 2, 0, 261, -12, -12, -12, -12,
+ax_anim 3, 0, 261, 12, 12, 12, 12,
+ax_anim 3, 0, 261, -13, -13, -13, -13,
+ax_anim 3, 0, 261, 13, 13, 13, 13,
+ax_anim 2, 0, 261, -12, -12, -12, -12,
+ax_anim 3, 0, 261, 12, 12, 12, 12,
+ax_anim 2, 0, 261, -10, -10, -10, -10,
+ax_anim 2, 0, 261, 10, 10, 10, 10,
+ax_anim 2, 0, 261, -6, -6, -6, -6,
+ax_anim 2, 0, 261, 6, 6, 6, 6,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_11_1:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -23, 0, 0,
+ax_anim 3, 0, 264, 0, -23, 0, 0,
+ax_anim 2, 0, 264, 0, -18, 0, 0,
+ax_anim 1, 0, 264, 0, -12, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_11_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -23, 0, 0,
+ax_anim 3, 0, 267, 0, -22, 0, 0,
+ax_anim 2, 0, 267, 0, -18, 0, 0,
+ax_anim 1, 0, 267, 0, -12, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_11_3:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 268, 0, -22, 0, 0,
+ax_anim 3, 0, 270, 0, -21, 0, 0,
+ax_anim 2, 0, 270, 0, -18, 0, 0,
+ax_anim 1, 0, 270, 0, -12, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_11_4:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 271, 0, -22, 0, 0,
+ax_anim 3, 0, 273, 0, -21, 0, 0,
+ax_anim 2, 0, 273, 0, -17, 0, 0,
+ax_anim 1, 0, 273, 0, -11, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_11_5:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 275, 0, -10, 0, 0,
+ax_anim 2, 0, 275, 0, -16, 0, 0,
+ax_anim 3, 0, 275, 0, -20, 0, 0,
+ax_anim 4, 0, 275, 0, -21, 0, 0,
+ax_anim 4, 0, 274, 0, -22, 0, 0,
+ax_anim 3, 0, 276, 0, -21, 0, 0,
+ax_anim 2, 0, 276, 0, -18, 0, 0,
+ax_anim 1, 0, 276, 0, -12, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_11_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 1, 0, 278, 0, -10, 0, 0,
+ax_anim 2, 0, 278, 0, -16, 0, 0,
+ax_anim 3, 0, 278, 0, -20, 0, 0,
+ax_anim 4, 0, 278, 0, -21, 0, 0,
+ax_anim 4, 0, 277, 0, -22, 0, 0,
+ax_anim 3, 0, 279, 0, -21, 0, 0,
+ax_anim 2, 0, 279, 0, -17, 0, 0,
+ax_anim 1, 0, 279, 0, -11, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_11_7:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 1, 0, 281, 0, -10, 0, 0,
+ax_anim 2, 0, 281, 0, -16, 0, 0,
+ax_anim 3, 0, 281, 0, -20, 0, 0,
+ax_anim 4, 0, 281, 0, -21, 0, 0,
+ax_anim 4, 0, 280, 0, -22, 0, 0,
+ax_anim 3, 0, 282, 0, -21, 0, 0,
+ax_anim 2, 0, 282, 0, -18, 0, 0,
+ax_anim 1, 0, 282, 0, -12, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_11_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 1, 0, 284, 0, -10, 0, 0,
+ax_anim 2, 0, 284, 0, -16, 0, 0,
+ax_anim 3, 0, 284, 0, -20, 0, 0,
+ax_anim 4, 0, 284, 0, -21, 0, 0,
+ax_anim 4, 0, 283, 0, -23, 0, 0,
+ax_anim 3, 0, 285, 0, -22, 0, 0,
+ax_anim 2, 0, 285, 0, -18, 0, 0,
+ax_anim 1, 0, 285, 0, -12, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_12_1:
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 1, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_12_2:
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 2, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 1, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_12_3:
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 2, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 1, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_12_4:
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 2, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 1, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_12_5:
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 2, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 1, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_12_6:
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 1, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_12_7:
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 1, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_12_8:
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 1, 287, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacneaAnims_13_1:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 2, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_13_2:
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 2, 301, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_13_3:
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 2, 300, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_13_4:
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 2, 299, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_13_5:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 2, 298, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_13_6:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 2, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_13_7:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 2, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaAnims_13_8:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 2, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sCacneaGfx1:
+.incbin "baserom.gba", 0x138283C, 0x200
+sCacneaSprites1:
+ax_sprite sCacneaGfx1, 0x200
+ax_sprite_terminator
+sCacneaGfx2:
+.incbin "baserom.gba", 0x1382A4C, 0x200
+sCacneaSprites2:
+ax_sprite sCacneaGfx2, 0x200
+ax_sprite_terminator
+sCacneaGfx3:
+.incbin "baserom.gba", 0x1382C5C, 0x200
+sCacneaSprites3:
+ax_sprite sCacneaGfx3, 0x200
+ax_sprite_terminator
+sCacneaGfx4:
+.incbin "baserom.gba", 0x1382E6C, 0x200
+sCacneaSprites4:
+ax_sprite sCacneaGfx4, 0x200
+ax_sprite_terminator
+sCacneaGfx5:
+.incbin "baserom.gba", 0x138307C, 0x200
+sCacneaSprites5:
+ax_sprite sCacneaGfx5, 0x200
+ax_sprite_terminator
+sCacneaGfx6:
+.incbin "baserom.gba", 0x138328C, 0x200
+sCacneaSprites6:
+ax_sprite sCacneaGfx6, 0x200
+ax_sprite_terminator
+sCacneaGfx7:
+.incbin "baserom.gba", 0x138349C, 0x200
+sCacneaSprites7:
+ax_sprite sCacneaGfx7, 0x200
+ax_sprite_terminator
+sCacneaGfx8:
+.incbin "baserom.gba", 0x13836AC, 0x200
+sCacneaSprites8:
+ax_sprite sCacneaGfx8, 0x200
+ax_sprite_terminator
+sCacneaGfx9:
+.incbin "baserom.gba", 0x13838BC, 0x200
+sCacneaSprites9:
+ax_sprite sCacneaGfx9, 0x200
+ax_sprite_terminator
+sCacneaGfx10:
+.incbin "baserom.gba", 0x1383ACC, 0x200
+sCacneaSprites10:
+ax_sprite sCacneaGfx10, 0x200
+ax_sprite_terminator
+sCacneaGfx11:
+.incbin "baserom.gba", 0x1383CDC, 0x200
+sCacneaSprites11:
+ax_sprite sCacneaGfx11, 0x200
+ax_sprite_terminator
+sCacneaGfx12:
+.incbin "baserom.gba", 0x1383EEC, 0x200
+sCacneaSprites12:
+ax_sprite sCacneaGfx12, 0x200
+ax_sprite_terminator
+sCacneaGfx13:
+.incbin "baserom.gba", 0x13840FC, 0x200
+sCacneaSprites13:
+ax_sprite sCacneaGfx13, 0x200
+ax_sprite_terminator
+sCacneaGfx14:
+.incbin "baserom.gba", 0x138430C, 0x200
+sCacneaSprites14:
+ax_sprite sCacneaGfx14, 0x200
+ax_sprite_terminator
+sCacneaGfx15:
+.incbin "baserom.gba", 0x138451C, 0x200
+sCacneaSprites15:
+ax_sprite sCacneaGfx15, 0x200
+ax_sprite_terminator
+sCacneaGfx16:
+.incbin "baserom.gba", 0x138472C, 0x60
+sCacneaGfx16_1:
+.incbin "baserom.gba", 0x138478C, 0x80
+sCacneaGfx16_2:
+.incbin "baserom.gba", 0x138480C, 0x40
+sCacneaSprites16:
+ax_sprite sCacneaGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx16_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCacneaGfx17:
+.incbin "baserom.gba", 0x1384884, 0x60
+sCacneaGfx17_1:
+.incbin "baserom.gba", 0x13848E4, 0x60
+sCacneaGfx17_2:
+.incbin "baserom.gba", 0x1384944, 0x60
+sCacneaSprites17:
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx17_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCacneaGfx18:
+.incbin "baserom.gba", 0x13849E4, 0x60
+sCacneaGfx18_1:
+.incbin "baserom.gba", 0x1384A44, 0x60
+sCacneaGfx18_2:
+.incbin "baserom.gba", 0x1384AA4, 0x40
+sCacneaSprites18:
+ax_sprite sCacneaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCacneaGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCacneaGfx19:
+.incbin "baserom.gba", 0x1384B1C, 0x100
+sCacneaGfx19_1:
+.incbin "baserom.gba", 0x1384C1C, 0x60
+sCacneaSprites19:
+ax_sprite sCacneaGfx19, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx19_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCacneaGfx20:
+.incbin "baserom.gba", 0x1384CA4, 0x40
+sCacneaGfx20_1:
+.incbin "baserom.gba", 0x1384CE4, 0x60
+sCacneaGfx20_2:
+.incbin "baserom.gba", 0x1384D44, 0x60
+sCacneaSprites20:
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCacneaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx20_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCacneaGfx21:
+.incbin "baserom.gba", 0x1384DE4, 0x60
+sCacneaGfx21_1:
+.incbin "baserom.gba", 0x1384E44, 0x60
+sCacneaGfx21_2:
+.incbin "baserom.gba", 0x1384EA4, 0x60
+sCacneaSprites21:
+ax_sprite sCacneaGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCacneaGfx22:
+.incbin "baserom.gba", 0x1384F3C, 0x60
+sCacneaGfx22_1:
+.incbin "baserom.gba", 0x1384F9C, 0x60
+sCacneaGfx22_2:
+.incbin "baserom.gba", 0x1384FFC, 0x60
+sCacneaSprites22:
+ax_sprite sCacneaGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCacneaGfx23:
+.incbin "baserom.gba", 0x1385094, 0x40
+sCacneaGfx23_1:
+.incbin "baserom.gba", 0x13850D4, 0xE0
+sCacneaGfx23_2:
+.incbin "baserom.gba", 0x13851B4, 0x20
+sCacneaSprites23:
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCacneaGfx23_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx23_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCacneaGfx24:
+.incbin "baserom.gba", 0x1385214, 0x60
+sCacneaGfx24_1:
+.incbin "baserom.gba", 0x1385274, 0x60
+sCacneaGfx24_2:
+.incbin "baserom.gba", 0x13852D4, 0x60
+sCacneaSprites24:
+ax_sprite sCacneaGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCacneaGfx25:
+.incbin "baserom.gba", 0x138536C, 0x60
+sCacneaGfx25_1:
+.incbin "baserom.gba", 0x13853CC, 0x100
+sCacneaSprites25:
+ax_sprite sCacneaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx25_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCacneaGfx26:
+.incbin "baserom.gba", 0x13854F4, 0x40
+sCacneaGfx26_1:
+.incbin "baserom.gba", 0x1385534, 0x100
+sCacneaSprites26:
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx26_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCacneaGfx27:
+.incbin "baserom.gba", 0x1385664, 0x100
+sCacneaGfx27_1:
+.incbin "baserom.gba", 0x1385764, 0x40
+sCacneaSprites27:
+ax_sprite sCacneaGfx27, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx27_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCacneaGfx28:
+.incbin "baserom.gba", 0x13857CC, 0x160
+sCacneaSprites28:
+ax_sprite sCacneaGfx28, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCacneaGfx29:
+.incbin "baserom.gba", 0x1385944, 0x40
+sCacneaGfx29_1:
+.incbin "baserom.gba", 0x1385984, 0x100
+sCacneaSprites29:
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx29_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCacneaGfx30:
+.incbin "baserom.gba", 0x1385AB4, 0x40
+sCacneaGfx30_1:
+.incbin "baserom.gba", 0x1385AF4, 0x120
+sCacneaGfx30_2:
+.incbin "baserom.gba", 0x1385C14, 0x20
+sCacneaSprites30:
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCacneaGfx30_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite sCacneaGfx30_2, 0x20
+ax_sprite_terminator
+sCacneaGfx31:
+.incbin "baserom.gba", 0x1385C6C, 0x80
+sCacneaSprites31:
+ax_sprite sCacneaGfx31, 0x80
+ax_sprite_terminator
+sCacneaGfx32:
+.incbin "baserom.gba", 0x1385CFC, 0x80
+sCacneaSprites32:
+ax_sprite sCacneaGfx32, 0x80
+ax_sprite_terminator
+sCacneaGfx33:
+.incbin "baserom.gba", 0x1385D8C, 0x80
+sCacneaSprites33:
+ax_sprite sCacneaGfx33, 0x80
+ax_sprite_terminator
+sCacneaGfx34:
+.incbin "baserom.gba", 0x1385E1C, 0x80
+sCacneaSprites34:
+ax_sprite sCacneaGfx34, 0x80
+ax_sprite_terminator
+sCacneaGfx35:
+.incbin "baserom.gba", 0x1385EAC, 0x80
+sCacneaSprites35:
+ax_sprite sCacneaGfx35, 0x80
+ax_sprite_terminator
+sCacneaGfx36:
+.incbin "baserom.gba", 0x1385F3C, 0x80
+sCacneaSprites36:
+ax_sprite sCacneaGfx36, 0x80
+ax_sprite_terminator
+sCacneaGfx37:
+.incbin "baserom.gba", 0x1385FCC, 0x80
+sCacneaSprites37:
+ax_sprite sCacneaGfx37, 0x80
+ax_sprite_terminator
+sCacneaGfx38:
+.incbin "baserom.gba", 0x138605C, 0x200
+sCacneaSprites38:
+ax_sprite sCacneaGfx38, 0x200
+ax_sprite_terminator
+sCacneaGfx39:
+.incbin "baserom.gba", 0x138626C, 0x200
+sCacneaSprites39:
+ax_sprite sCacneaGfx39, 0x200
+ax_sprite_terminator
+sCacneaGfx40:
+.incbin "baserom.gba", 0x138647C, 0x200
+sCacneaSprites40:
+ax_sprite sCacneaGfx40, 0x200
+ax_sprite_terminator
+sCacneaGfx41:
+.incbin "baserom.gba", 0x138668C, 0x200
+sCacneaSprites41:
+ax_sprite sCacneaGfx41, 0x200
+ax_sprite_terminator
+sCacneaGfx42:
+.incbin "baserom.gba", 0x138689C, 0x200
+sCacneaSprites42:
+ax_sprite sCacneaGfx42, 0x200
+ax_sprite_terminator
+sCacneaGfx43:
+.incbin "baserom.gba", 0x1386AAC, 0x200
+sCacneaSprites43:
+ax_sprite sCacneaGfx43, 0x200
+ax_sprite_terminator
+sCacneaGfx44:
+.incbin "baserom.gba", 0x1386CBC, 0x200
+sCacneaSprites44:
+ax_sprite sCacneaGfx44, 0x200
+ax_sprite_terminator
+sAxPosesCacnea:
+.4byte sCacneaPose1
+.4byte sCacneaPose2
+.4byte sCacneaPose3
+.4byte sCacneaPose4
+.4byte sCacneaPose5
+.4byte sCacneaPose6
+.4byte sCacneaPose7
+.4byte sCacneaPose8
+.4byte sCacneaPose9
+.4byte sCacneaPose10
+.4byte sCacneaPose11
+.4byte sCacneaPose12
+.4byte sCacneaPose13
+.4byte sCacneaPose14
+.4byte sCacneaPose15
+.4byte sCacneaPose16
+.4byte sCacneaPose17
+.4byte sCacneaPose18
+.4byte sCacneaPose19
+.4byte sCacneaPose20
+.4byte sCacneaPose21
+.4byte sCacneaPose22
+.4byte sCacneaPose23
+.4byte sCacneaPose24
+.4byte sCacneaPose25
+.4byte sCacneaPose26
+.4byte sCacneaPose27
+.4byte sCacneaPose28
+.4byte sCacneaPose29
+.4byte sCacneaPose30
+.4byte sCacneaPose31
+.4byte sCacneaPose32
+.4byte sCacneaPose33
+.4byte sCacneaPose34
+.4byte sCacneaPose35
+.4byte sCacneaPose36
+.4byte sCacneaPose37
+.4byte sCacneaPose38
+.4byte sCacneaPose39
+.4byte sCacneaPose40
+.4byte sCacneaPose41
+.4byte sCacneaPose42
+.4byte sCacneaPose43
+.4byte sCacneaPose44
+.4byte sCacneaPose45
+.4byte sCacneaPose46
+.4byte sCacneaPose47
+.4byte sCacneaPose48
+.4byte sCacneaPose49
+.4byte sCacneaPose50
+.4byte sCacneaPose51
+.4byte sCacneaPose52
+.4byte sCacneaPose53
+.4byte sCacneaPose54
+.4byte sCacneaPose55
+.4byte sCacneaPose56
+.4byte sCacneaPose57
+.4byte sCacneaPose58
+.4byte sCacneaPose59
+.4byte sCacneaPose60
+.4byte sCacneaPose61
+.4byte sCacneaPose62
+.4byte sCacneaPose63
+.4byte sCacneaPose64
+.4byte sCacneaPose65
+.4byte sCacneaPose66
+.4byte sCacneaPose67
+.4byte sCacneaPose68
+.4byte sCacneaPose69
+.4byte sCacneaPose70
+.4byte sCacneaPose71
+.4byte sCacneaPose72
+.4byte sCacneaPose73
+.4byte sCacneaPose74
+.4byte sCacneaPose75
+.4byte sCacneaPose76
+.4byte sCacneaPose77
+.4byte sCacneaPose78
+.4byte sCacneaPose79
+.4byte sCacneaPose80
+.4byte sCacneaPose81
+.4byte sCacneaPose82
+.4byte sCacneaPose83
+.4byte sCacneaPose84
+.4byte sCacneaPose85
+.4byte sCacneaPose86
+.4byte sCacneaPose87
+.4byte sCacneaPose88
+.4byte sCacneaPose89
+.4byte sCacneaPose90
+.4byte sCacneaPose91
+.4byte sCacneaPose92
+.4byte sCacneaPose93
+.4byte sCacneaPose94
+.4byte sCacneaPose95
+.4byte sCacneaPose96
+.4byte sCacneaPose97
+.4byte sCacneaPose98
+.4byte sCacneaPose99
+.4byte sCacneaPose100
+.4byte sCacneaPose101
+.4byte sCacneaPose102
+.4byte sCacneaPose103
+.4byte sCacneaPose104
+.4byte sCacneaPose105
+.4byte sCacneaPose106
+.4byte sCacneaPose107
+.4byte sCacneaPose108
+.4byte sCacneaPose109
+.4byte sCacneaPose110
+.4byte sCacneaPose111
+.4byte sCacneaPose112
+.4byte sCacneaPose113
+.4byte sCacneaPose114
+.4byte sCacneaPose115
+.4byte sCacneaPose116
+.4byte sCacneaPose117
+.4byte sCacneaPose118
+.4byte sCacneaPose119
+.4byte sCacneaPose120
+.4byte sCacneaPose121
+.4byte sCacneaPose122
+.4byte sCacneaPose123
+.4byte sCacneaPose124
+.4byte sCacneaPose125
+.4byte sCacneaPose126
+.4byte sCacneaPose127
+.4byte sCacneaPose128
+.4byte sCacneaPose129
+.4byte sCacneaPose130
+.4byte sCacneaPose131
+.4byte sCacneaPose132
+.4byte sCacneaPose133
+.4byte sCacneaPose134
+.4byte sCacneaPose135
+.4byte sCacneaPose136
+.4byte sCacneaPose137
+.4byte sCacneaPose138
+.4byte sCacneaPose139
+.4byte sCacneaPose140
+.4byte sCacneaPose141
+.4byte sCacneaPose142
+.4byte sCacneaPose143
+.4byte sCacneaPose144
+.4byte sCacneaPose145
+.4byte sCacneaPose146
+.4byte sCacneaPose147
+.4byte sCacneaPose148
+.4byte sCacneaPose149
+.4byte sCacneaPose150
+.4byte sCacneaPose151
+.4byte sCacneaPose152
+.4byte sCacneaPose153
+.4byte sCacneaPose154
+.4byte sCacneaPose155
+.4byte sCacneaPose156
+.4byte sCacneaPose157
+.4byte sCacneaPose158
+.4byte sCacneaPose159
+.4byte sCacneaPose160
+.4byte sCacneaPose161
+.4byte sCacneaPose162
+.4byte sCacneaPose163
+.4byte sCacneaPose164
+.4byte sCacneaPose165
+.4byte sCacneaPose166
+.4byte sCacneaPose167
+.4byte sCacneaPose168
+.4byte sCacneaPose169
+.4byte sCacneaPose170
+.4byte sCacneaPose171
+.4byte sCacneaPose172
+.4byte sCacneaPose173
+.4byte sCacneaPose174
+.4byte sCacneaPose175
+.4byte sCacneaPose176
+.4byte sCacneaPose177
+.4byte sCacneaPose178
+.4byte sCacneaPose179
+.4byte sCacneaPose180
+.4byte sCacneaPose181
+.4byte sCacneaPose182
+.4byte sCacneaPose183
+.4byte sCacneaPose184
+.4byte sCacneaPose185
+.4byte sCacneaPose186
+.4byte sCacneaPose187
+.4byte sCacneaPose188
+.4byte sCacneaPose189
+.4byte sCacneaPose190
+.4byte sCacneaPose191
+.4byte sCacneaPose192
+.4byte sCacneaPose193
+.4byte sCacneaPose194
+.4byte sCacneaPose195
+.4byte sCacneaPose196
+.4byte sCacneaPose197
+.4byte sCacneaPose198
+.4byte sCacneaPose199
+.4byte sCacneaPose200
+.4byte sCacneaPose201
+.4byte sCacneaPose202
+.4byte sCacneaPose203
+.4byte sCacneaPose204
+.4byte sCacneaPose205
+.4byte sCacneaPose206
+.4byte sCacneaPose207
+.4byte sCacneaPose208
+.4byte sCacneaPose209
+.4byte sCacneaPose210
+.4byte sCacneaPose211
+.4byte sCacneaPose212
+.4byte sCacneaPose213
+.4byte sCacneaPose214
+.4byte sCacneaPose215
+.4byte sCacneaPose216
+.4byte sCacneaPose217
+.4byte sCacneaPose218
+.4byte sCacneaPose219
+.4byte sCacneaPose220
+.4byte sCacneaPose221
+.4byte sCacneaPose222
+.4byte sCacneaPose223
+.4byte sCacneaPose224
+.4byte sCacneaPose225
+.4byte sCacneaPose226
+.4byte sCacneaPose227
+.4byte sCacneaPose228
+.4byte sCacneaPose229
+.4byte sCacneaPose230
+.4byte sCacneaPose231
+.4byte sCacneaPose232
+.4byte sCacneaPose233
+.4byte sCacneaPose234
+.4byte sCacneaPose235
+.4byte sCacneaPose236
+.4byte sCacneaPose237
+.4byte sCacneaPose238
+.4byte sCacneaPose239
+.4byte sCacneaPose240
+.4byte sCacneaPose241
+.4byte sCacneaPose242
+.4byte sCacneaPose243
+.4byte sCacneaPose244
+.4byte sCacneaPose245
+.4byte sCacneaPose246
+.4byte sCacneaPose247
+.4byte sCacneaPose248
+.4byte sCacneaPose249
+.4byte sCacneaPose250
+.4byte sCacneaPose251
+.4byte sCacneaPose252
+.4byte sCacneaPose253
+.4byte sCacneaPose254
+.4byte sCacneaPose255
+.4byte sCacneaPose256
+.4byte sCacneaPose257
+.4byte sCacneaPose258
+.4byte sCacneaPose259
+.4byte sCacneaPose260
+.4byte sCacneaPose261
+.4byte sCacneaPose262
+.4byte sCacneaPose263
+.4byte sCacneaPose264
+.4byte sCacneaPose265
+.4byte sCacneaPose266
+.4byte sCacneaPose267
+.4byte sCacneaPose268
+.4byte sCacneaPose269
+.4byte sCacneaPose270
+.4byte sCacneaPose271
+.4byte sCacneaPose272
+.4byte sCacneaPose273
+.4byte sCacneaPose274
+.4byte sCacneaPose275
+.4byte sCacneaPose276
+.4byte sCacneaPose277
+.4byte sCacneaPose278
+.4byte sCacneaPose279
+.4byte sCacneaPose280
+.4byte sCacneaPose281
+.4byte sCacneaPose282
+.4byte sCacneaPose283
+.4byte sCacneaPose284
+.4byte sCacneaPose285
+.4byte sCacneaPose286
+.4byte sCacneaPose287
+.4byte sCacneaPose288
+.4byte sCacneaPose289
+.4byte sCacneaPose290
+.4byte sCacneaPose291
+.4byte sCacneaPose292
+.4byte sCacneaPose293
+.4byte sCacneaPose294
+.4byte sCacneaPose295
+.4byte sCacneaPose296
+.4byte sCacneaPose297
+.4byte sCacneaPose298
+.4byte sCacneaPose299
+.4byte sCacneaPose300
+.4byte sCacneaPose301
+.4byte sCacneaPose302
+sAxPositionsCacnea:
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,   -6
+.2byte    0,   -2, 	 -10,    0, 	  11,   -4, 	   0,   -5
+.2byte   -2,   -2, 	 -12,   -5, 	   8,    1, 	  -2,   -5
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+.2byte    3,   -3, 	  10,   -5, 	 -11,    1, 	   0,   -5
+.2byte    5,   -3, 	   8,   -8, 	  -3,    3, 	   0,   -5
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    5,   -3, 	   7,   -6, 	  -4,    1, 	  -2,   -6
+.2byte    4,   -5, 	  -4,   -8, 	   5,    0, 	  -2,   -6
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    2,   -5, 	   0,  -10, 	   7,    1, 	  -3,   -5
+.2byte   -1,   -5, 	 -11,   -7, 	  11,   -5, 	  -3,   -5
+.2byte   -1,   -6, 	  11,   -5, 	 -12,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	  10,   -8, 	 -11,   -2, 	   0,   -4
+.2byte    0,   -5, 	   9,   -3, 	 -12,   -8, 	  -2,   -4
+.2byte   -3,   -7, 	   8,   -9, 	 -11,   -2, 	   1,   -7
+.2byte   -4,   -5, 	  -2,  -10, 	  -9,    1, 	   1,   -5
+.2byte   -1,   -5, 	   9,   -7, 	 -13,   -5, 	   1,   -5
+.2byte   -7,   -4, 	  -2,   -8, 	  -3,    1, 	   0,   -6
+.2byte   -7,   -3, 	  -9,   -6, 	   2,    1, 	   0,   -6
+.2byte   -6,   -5, 	   2,   -8, 	  -7,    0, 	   0,   -6
+.2byte   -6,   -4, 	 -11,   -7, 	   5,    0, 	  -2,   -6
+.2byte   -5,   -3, 	 -12,   -5, 	   9,    1, 	  -2,   -5
+.2byte   -7,   -3, 	 -10,   -8, 	   1,    3, 	  -2,   -5
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,   -6
+.2byte    0,   -2, 	 -10,    0, 	  11,   -4, 	   0,   -5
+.2byte   -2,   -2, 	 -12,   -5, 	   8,    1, 	  -2,   -5
+.2byte   -1,   -5, 	 -12,   -8, 	  11,   -7, 	  -1,   -7
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+.2byte    3,   -3, 	  10,   -5, 	 -11,    1, 	   0,   -5
+.2byte    5,   -3, 	   8,   -8, 	  -3,    3, 	   0,   -5
+.2byte    2,   -5, 	   2,  -10, 	 -12,   -4, 	  -1,   -7
+.2byte    4,   -2, 	  12,   -9, 	  -2,    0, 	   0,   -7
+.2byte    5,   -1, 	  13,  -10, 	  -2,    1, 	   0,   -6
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    5,   -3, 	   7,   -6, 	  -4,    1, 	  -2,   -6
+.2byte    4,   -5, 	  -4,   -8, 	   5,    0, 	  -2,   -6
+.2byte    5,   -6, 	  -5,  -10, 	  -8,    1, 	  -3,   -5
+.2byte    4,   -4, 	   9,  -12, 	   8,   -5, 	   0,   -6
+.2byte    5,   -4, 	  11,  -13, 	   9,   -4, 	  -1,   -6
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    2,   -5, 	   0,  -10, 	   7,    1, 	  -3,   -5
+.2byte   -1,   -5, 	 -11,   -7, 	  11,   -5, 	  -3,   -5
+.2byte    0,   -4, 	 -11,   -4, 	   3,    3, 	  -3,   -5
+.2byte    4,   -7, 	  -4,  -15, 	  11,   -9, 	  -2,   -7
+.2byte    2,   -6, 	  -5,  -16, 	  12,   -9, 	  -3,   -7
+.2byte   -1,   -6, 	  11,   -5, 	 -12,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	  10,   -8, 	 -11,   -2, 	   0,   -4
+.2byte    0,   -5, 	   9,   -3, 	 -12,   -8, 	  -2,   -4
+.2byte   -1,   -6, 	   9,   -1, 	 -10,   -1, 	  -1,   -4
+.2byte   -1,   -8, 	   7,  -14, 	 -10,  -14, 	  -1,   -6
+.2byte   -1,   -8, 	   9,  -14, 	 -12,  -15, 	  -1,   -5
+.2byte   -3,   -7, 	   8,   -9, 	 -11,   -2, 	   1,   -7
+.2byte   -4,   -5, 	  -2,  -10, 	  -9,    1, 	   1,   -5
+.2byte   -1,   -5, 	   9,   -7, 	 -13,   -5, 	   1,   -5
+.2byte   -2,   -4, 	   9,   -4, 	  -5,    3, 	   1,   -5
+.2byte   -6,   -7, 	   2,  -15, 	 -13,   -9, 	   0,   -7
+.2byte   -4,   -6, 	   3,  -16, 	 -14,   -9, 	   1,   -7
+.2byte   -7,   -4, 	  -2,   -8, 	  -3,    1, 	   0,   -6
+.2byte   -7,   -3, 	  -9,   -6, 	   2,    1, 	   0,   -6
+.2byte   -6,   -5, 	   2,   -8, 	  -7,    0, 	   0,   -6
+.2byte   -7,   -6, 	   3,  -10, 	   6,    1, 	   1,   -5
+.2byte   -6,   -4, 	 -11,  -12, 	 -10,   -5, 	  -2,   -6
+.2byte   -7,   -4, 	 -13,  -13, 	 -11,   -4, 	  -1,   -6
+.2byte   -6,   -4, 	 -11,   -7, 	   5,    0, 	  -2,   -6
+.2byte   -5,   -3, 	 -12,   -5, 	   9,    1, 	  -2,   -5
+.2byte   -7,   -3, 	 -10,   -8, 	   1,    3, 	  -2,   -5
+.2byte   -4,   -5, 	  -4,  -10, 	  10,   -4, 	  -1,   -7
+.2byte   -6,   -2, 	 -14,   -9, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -1, 	 -15,  -10, 	   0,    1, 	  -2,   -6
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,   -6
+.2byte    0,   -2, 	 -10,    0, 	  11,   -4, 	   0,   -5
+.2byte   -2,   -2, 	 -12,   -5, 	   8,    1, 	  -2,   -5
+.2byte   -1,   -5, 	 -12,   -8, 	  11,   -7, 	  -1,   -7
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+.2byte    3,   -3, 	  10,   -5, 	 -11,    1, 	   0,   -5
+.2byte    5,   -3, 	   8,   -8, 	  -3,    3, 	   0,   -5
+.2byte    2,   -5, 	   2,  -10, 	 -12,   -4, 	  -1,   -7
+.2byte    4,   -2, 	  12,   -9, 	  -2,    0, 	   0,   -7
+.2byte    5,   -1, 	  13,  -10, 	  -2,    1, 	   0,   -6
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    5,   -3, 	   7,   -6, 	  -4,    1, 	  -2,   -6
+.2byte    4,   -5, 	  -4,   -8, 	   5,    0, 	  -2,   -6
+.2byte    5,   -6, 	  -5,  -10, 	  -8,    1, 	  -3,   -5
+.2byte    4,   -4, 	   9,  -12, 	   8,   -5, 	   0,   -6
+.2byte    5,   -4, 	  11,  -13, 	   9,   -4, 	  -1,   -6
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    2,   -5, 	   0,  -10, 	   7,    1, 	  -3,   -5
+.2byte   -1,   -5, 	 -11,   -7, 	  11,   -5, 	  -3,   -5
+.2byte    0,   -4, 	 -11,   -4, 	   3,    3, 	  -3,   -5
+.2byte    4,   -7, 	  -4,  -15, 	  11,   -9, 	  -2,   -7
+.2byte    2,   -6, 	  -5,  -16, 	  12,   -9, 	  -3,   -7
+.2byte   -1,   -6, 	  11,   -5, 	 -12,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	  10,   -8, 	 -11,   -2, 	   0,   -4
+.2byte    0,   -5, 	   9,   -3, 	 -12,   -8, 	  -2,   -4
+.2byte   -1,   -6, 	   9,   -1, 	 -10,   -1, 	  -1,   -4
+.2byte   -1,   -8, 	   7,  -14, 	 -10,  -14, 	  -1,   -6
+.2byte   -1,   -8, 	   9,  -14, 	 -12,  -15, 	  -1,   -5
+.2byte   -3,   -7, 	   8,   -9, 	 -11,   -2, 	   1,   -7
+.2byte   -4,   -5, 	  -2,  -10, 	  -9,    1, 	   1,   -5
+.2byte   -1,   -5, 	   9,   -7, 	 -13,   -5, 	   1,   -5
+.2byte   -2,   -4, 	   9,   -4, 	  -5,    3, 	   1,   -5
+.2byte   -6,   -7, 	   2,  -15, 	 -13,   -9, 	   0,   -7
+.2byte   -4,   -6, 	   3,  -16, 	 -14,   -9, 	   1,   -7
+.2byte   -7,   -4, 	  -2,   -8, 	  -3,    1, 	   0,   -6
+.2byte   -7,   -3, 	  -9,   -6, 	   2,    1, 	   0,   -6
+.2byte   -6,   -5, 	   2,   -8, 	  -7,    0, 	   0,   -6
+.2byte   -7,   -6, 	   3,  -10, 	   6,    1, 	   1,   -5
+.2byte   -6,   -4, 	 -11,  -12, 	 -10,   -5, 	  -2,   -6
+.2byte   -7,   -4, 	 -13,  -13, 	 -11,   -4, 	  -1,   -6
+.2byte   -6,   -4, 	 -11,   -7, 	   5,    0, 	  -2,   -6
+.2byte   -5,   -3, 	 -12,   -5, 	   9,    1, 	  -2,   -5
+.2byte   -7,   -3, 	 -10,   -8, 	   1,    3, 	  -2,   -5
+.2byte   -4,   -5, 	  -4,  -10, 	  10,   -4, 	  -1,   -7
+.2byte   -6,   -2, 	 -14,   -9, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -1, 	 -15,  -10, 	   0,    1, 	  -2,   -6
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	 -12,   -8, 	  11,   -7, 	  -1,   -7
+.2byte   -1,   -1, 	 -10,    0, 	   9,    0, 	  -1,   -4
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+.2byte    2,   -5, 	   2,  -10, 	 -12,   -4, 	  -1,   -7
+.2byte    4,   -2, 	  12,   -9, 	  -2,    0, 	   0,   -7
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    5,   -6, 	  -5,  -10, 	  -8,    1, 	  -3,   -5
+.2byte    4,   -4, 	   9,  -12, 	   8,   -5, 	   0,   -6
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    0,   -4, 	 -11,   -4, 	   3,    3, 	  -3,   -5
+.2byte    4,   -7, 	  -4,  -15, 	  11,   -9, 	  -2,   -7
+.2byte   -1,   -6, 	  11,   -5, 	 -12,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	   9,   -1, 	 -10,   -1, 	  -1,   -4
+.2byte   -1,   -8, 	   7,  -14, 	 -10,  -14, 	  -1,   -6
+.2byte   -3,   -7, 	   8,   -9, 	 -11,   -2, 	   1,   -7
+.2byte   -2,   -4, 	   9,   -4, 	  -5,    3, 	   1,   -5
+.2byte   -6,   -7, 	   2,  -15, 	 -13,   -9, 	   0,   -7
+.2byte   -7,   -4, 	  -2,   -8, 	  -3,    1, 	   0,   -6
+.2byte   -7,   -6, 	   3,  -10, 	   6,    1, 	   1,   -5
+.2byte   -6,   -4, 	 -11,  -12, 	 -10,   -5, 	  -2,   -6
+.2byte   -6,   -4, 	 -11,   -7, 	   5,    0, 	  -2,   -6
+.2byte   -4,   -5, 	  -4,  -10, 	  10,   -4, 	  -1,   -7
+.2byte   -6,   -2, 	 -14,   -9, 	   0,    0, 	  -2,   -7
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	 -12,   -8, 	  11,   -7, 	  -1,   -7
+.2byte   -1,   -1, 	 -10,    0, 	   9,    0, 	  -1,   -4
+.2byte   -1,   -1, 	 -11,    0, 	  10,    1, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,    0, 	  10,    1, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,    0, 	  10,    1, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,    0, 	  10,    1, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,    0, 	  10,    1, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,    0, 	  10,    1, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,    0, 	  10,    1, 	  -1,   -5
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+.2byte    2,   -5, 	   2,  -10, 	 -12,   -4, 	  -1,   -7
+.2byte    4,   -2, 	  12,   -9, 	  -2,    0, 	   0,   -7
+.2byte    5,   -2, 	  13,  -11, 	  -2,    0, 	   0,   -7
+.2byte    5,   -2, 	  13,  -11, 	  -2,    0, 	   0,   -7
+.2byte    5,   -2, 	  13,  -11, 	  -2,    0, 	   0,   -7
+.2byte    5,   -2, 	  13,  -11, 	  -2,    0, 	   0,   -7
+.2byte    5,   -2, 	  13,  -11, 	  -2,    0, 	   0,   -7
+.2byte    5,   -2, 	  13,  -11, 	  -2,    0, 	   0,   -7
+.2byte    5,   -2, 	  13,  -11, 	  -2,    0, 	   0,   -7
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    5,   -6, 	  -5,  -10, 	  -8,    1, 	  -3,   -5
+.2byte    4,   -4, 	   9,  -12, 	   8,   -5, 	   0,   -6
+.2byte    5,   -6, 	  11,  -15, 	   9,   -6, 	  -1,   -8
+.2byte    5,   -6, 	  11,  -15, 	   9,   -6, 	  -1,   -8
+.2byte    5,   -6, 	  11,  -15, 	   9,   -6, 	  -1,   -8
+.2byte    5,   -6, 	  11,  -15, 	   9,   -6, 	  -1,   -8
+.2byte    5,   -6, 	  11,  -15, 	   9,   -6, 	  -1,   -8
+.2byte    5,   -6, 	  11,  -15, 	   9,   -6, 	  -1,   -8
+.2byte    5,   -6, 	  11,  -15, 	   9,   -6, 	  -1,   -8
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    0,   -4, 	 -11,   -4, 	   3,    3, 	  -3,   -5
+.2byte    4,   -7, 	  -4,  -15, 	  11,   -9, 	  -2,   -7
+.2byte    2,   -8, 	  -5,  -18, 	  12,  -11, 	  -3,   -9
+.2byte    2,   -8, 	  -5,  -18, 	  12,  -11, 	  -3,   -9
+.2byte    2,   -8, 	  -5,  -18, 	  12,  -11, 	  -3,   -9
+.2byte    2,   -8, 	  -5,  -18, 	  12,  -11, 	  -3,   -9
+.2byte    2,   -8, 	  -5,  -18, 	  12,  -11, 	  -3,   -9
+.2byte    2,   -8, 	  -5,  -18, 	  12,  -11, 	  -3,   -9
+.2byte    2,   -8, 	  -5,  -18, 	  12,  -11, 	  -3,   -9
+.2byte   -1,   -6, 	  11,   -5, 	 -12,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	   9,   -1, 	 -10,   -1, 	  -1,   -4
+.2byte   -1,   -8, 	   7,  -14, 	 -10,  -14, 	  -1,   -6
+.2byte   -1,  -10, 	   9,  -16, 	 -12,  -17, 	  -1,   -7
+.2byte   -1,  -10, 	   9,  -16, 	 -12,  -17, 	  -1,   -7
+.2byte   -1,  -10, 	   9,  -16, 	 -12,  -17, 	  -1,   -7
+.2byte   -1,  -10, 	   9,  -16, 	 -12,  -17, 	  -1,   -7
+.2byte   -1,  -10, 	   9,  -16, 	 -12,  -17, 	  -1,   -7
+.2byte   -1,  -10, 	   9,  -16, 	 -12,  -17, 	  -1,   -7
+.2byte   -1,  -10, 	   9,  -16, 	 -12,  -17, 	  -1,   -7
+.2byte   -3,   -7, 	   8,   -9, 	 -11,   -2, 	   1,   -7
+.2byte   -2,   -4, 	   9,   -4, 	  -5,    3, 	   1,   -5
+.2byte   -6,   -7, 	   2,  -15, 	 -13,   -9, 	   0,   -7
+.2byte   -4,   -8, 	   3,  -18, 	 -14,  -11, 	   1,   -9
+.2byte   -4,   -8, 	   3,  -18, 	 -14,  -11, 	   1,   -9
+.2byte   -4,   -8, 	   3,  -18, 	 -14,  -11, 	   1,   -9
+.2byte   -4,   -8, 	   3,  -18, 	 -14,  -11, 	   1,   -9
+.2byte   -4,   -8, 	   3,  -18, 	 -14,  -11, 	   1,   -9
+.2byte   -4,   -8, 	   3,  -18, 	 -14,  -11, 	   1,   -9
+.2byte   -4,   -8, 	   3,  -18, 	 -14,  -11, 	   1,   -9
+.2byte   -7,   -4, 	  -2,   -8, 	  -3,    1, 	   0,   -6
+.2byte   -7,   -6, 	   3,  -10, 	   6,    1, 	   1,   -5
+.2byte   -6,   -4, 	 -11,  -12, 	 -10,   -5, 	  -2,   -6
+.2byte   -7,   -6, 	 -13,  -15, 	 -11,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	 -13,  -15, 	 -11,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	 -13,  -15, 	 -11,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	 -13,  -15, 	 -11,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	 -13,  -15, 	 -11,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	 -13,  -15, 	 -11,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	 -13,  -15, 	 -11,   -6, 	  -1,   -8
+.2byte   -6,   -4, 	 -11,   -7, 	   5,    0, 	  -2,   -6
+.2byte   -4,   -5, 	  -4,  -10, 	  10,   -4, 	  -1,   -7
+.2byte   -6,   -2, 	 -14,   -9, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -2, 	 -15,  -11, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -2, 	 -15,  -11, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -2, 	 -15,  -11, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -2, 	 -15,  -11, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -2, 	 -15,  -11, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -2, 	 -15,  -11, 	   0,    0, 	  -2,   -7
+.2byte   -7,   -2, 	 -15,  -11, 	   0,    0, 	  -2,   -7
+.2byte   -3,   -4, 	  -9,   -9, 	  11,    1, 	   1,   -5
+.2byte   -4,   -2, 	  -9,   -6, 	   8,    2, 	   0,   -4
+.2byte    0,   -1, 	 -12,   -4, 	  13,   -5, 	   0,   -4
+.2byte    1,   -3, 	   9,  -10, 	 -13,    1, 	  -1,   -5
+.2byte    0,   -2, 	  -1,  -12, 	  -3,    5, 	  -2,   -6
+.2byte    0,   -3, 	  -6,  -11, 	   9,    1, 	  -3,   -6
+.2byte    0,   -3, 	  13,   -2, 	 -12,   -2, 	   0,   -5
+.2byte   -1,   -3, 	   5,  -11, 	 -10,    1, 	   2,   -6
+.2byte   -1,   -2, 	   0,  -12, 	   2,    5, 	   1,   -6
+.2byte   -2,   -3, 	 -10,  -10, 	  12,    1, 	   0,   -5
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	 -12,   -8, 	  11,   -7, 	  -1,   -7
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+.2byte    3,   -5, 	   3,  -10, 	 -11,   -4, 	   0,   -7
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    5,   -6, 	  -5,  -10, 	  -8,    1, 	  -3,   -5
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    0,   -4, 	 -11,   -4, 	   3,    3, 	  -3,   -5
+.2byte   -1,   -6, 	  11,   -5, 	 -12,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	   9,   -1, 	 -10,   -1, 	  -1,   -4
+.2byte   -3,   -7, 	   8,   -9, 	 -11,   -2, 	   1,   -7
+.2byte   -2,   -4, 	   9,   -4, 	  -5,    3, 	   1,   -5
+.2byte   -7,   -4, 	  -2,   -8, 	  -3,    1, 	   0,   -6
+.2byte   -7,   -6, 	   3,  -10, 	   6,    1, 	   1,   -5
+.2byte   -6,   -4, 	 -11,   -7, 	   5,    0, 	  -2,   -6
+.2byte   -5,   -5, 	  -5,  -10, 	   9,   -4, 	  -2,   -7
+.2byte    0,   -1, 	  -9,    0, 	  10,    0, 	   0,   -4
+.2byte   -4,   -2, 	 -12,   -9, 	   2,    0, 	   0,   -7
+.2byte   -3,   -4, 	  -8,  -12, 	  -7,   -5, 	   1,   -6
+.2byte   -4,   -6, 	   4,  -14, 	 -11,   -8, 	   2,   -6
+.2byte    0,   -7, 	   8,  -13, 	  -9,  -13, 	   0,   -5
+.2byte    4,   -6, 	  -4,  -14, 	  11,   -8, 	  -2,   -6
+.2byte    3,   -4, 	   8,  -12, 	   7,   -5, 	  -1,   -6
+.2byte    3,   -2, 	  11,   -9, 	  -3,    0, 	  -1,   -7
+.2byte   -1,   -4, 	 -12,   -7, 	  11,   -6, 	  -1,   -6
+.2byte    3,   -4, 	   3,   -9, 	 -11,   -3, 	   0,   -6
+.2byte    6,   -6, 	  -4,  -10, 	  -7,    1, 	  -2,   -5
+.2byte    1,   -5, 	 -10,   -5, 	   4,    2, 	  -2,   -6
+.2byte   -1,   -7, 	   9,   -2, 	 -10,   -2, 	  -1,   -5
+.2byte   -2,   -5, 	   9,   -5, 	  -5,    2, 	   1,   -6
+.2byte   -7,   -6, 	   3,  -10, 	   6,    1, 	   1,   -5
+.2byte   -4,   -4, 	  -4,   -9, 	  10,   -3, 	  -1,   -6
+.2byte    0,   -3, 	 -11,   -3, 	  12,   -3, 	   0,   -6
+.2byte    0,   -4, 	 -11,   -7, 	  12,   -6, 	   0,   -6
+.2byte    0,   -2, 	  -9,   -1, 	  10,   -1, 	   0,   -5
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+.2byte    4,   -5, 	   4,  -10, 	 -10,   -4, 	   1,   -7
+.2byte    3,   -2, 	  11,   -9, 	  -3,    0, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    6,   -6, 	  -4,  -10, 	  -7,    1, 	  -2,   -5
+.2byte    3,   -4, 	   8,  -12, 	   7,   -5, 	  -1,   -6
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    1,   -5, 	 -10,   -5, 	   4,    2, 	  -2,   -6
+.2byte    3,   -7, 	  -5,  -15, 	  10,   -9, 	  -3,   -7
+.2byte    0,   -6, 	  12,   -5, 	 -11,   -4, 	   0,   -4
+.2byte    0,   -7, 	  10,   -2, 	  -9,   -2, 	   0,   -5
+.2byte    0,   -7, 	   8,  -13, 	  -9,  -13, 	   0,   -5
+.2byte   -2,   -7, 	   9,   -9, 	 -10,   -2, 	   2,   -7
+.2byte   -2,   -5, 	   9,   -5, 	  -5,    2, 	   1,   -6
+.2byte   -4,   -7, 	   4,  -15, 	 -11,   -9, 	   2,   -7
+.2byte   -6,   -4, 	  -1,   -8, 	  -2,    1, 	   1,   -6
+.2byte   -7,   -6, 	   3,  -10, 	   6,    1, 	   1,   -5
+.2byte   -4,   -4, 	  -9,  -12, 	  -8,   -5, 	   0,   -6
+.2byte   -5,   -4, 	 -10,   -7, 	   6,    0, 	  -1,   -6
+.2byte   -4,   -5, 	  -4,  -10, 	  10,   -4, 	  -1,   -7
+.2byte   -4,   -2, 	 -12,   -9, 	   2,    0, 	   0,   -7
+.2byte    0,   -1, 	  -9,    0, 	  10,    0, 	   0,   -4
+.2byte   -4,   -2, 	 -12,   -9, 	   2,    0, 	   0,   -7
+.2byte   -3,   -4, 	  -8,  -12, 	  -7,   -5, 	   1,   -6
+.2byte   -4,   -6, 	   4,  -14, 	 -11,   -8, 	   2,   -6
+.2byte    0,   -7, 	   8,  -13, 	  -9,  -13, 	   0,   -5
+.2byte    3,   -6, 	  -5,  -14, 	  10,   -8, 	  -3,   -6
+.2byte    2,   -4, 	   7,  -12, 	   6,   -5, 	  -2,   -6
+.2byte    3,   -2, 	  11,   -9, 	  -3,    0, 	  -1,   -7
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,   -6
+.2byte   -6,   -4, 	 -11,   -7, 	   5,    0, 	  -2,   -6
+.2byte   -7,   -4, 	  -2,   -8, 	  -3,    1, 	   0,   -6
+.2byte   -3,   -7, 	   8,   -9, 	 -11,   -2, 	   1,   -7
+.2byte   -1,   -6, 	  11,   -5, 	 -12,   -4, 	  -1,   -4
+.2byte    1,   -7, 	 -10,   -9, 	   9,   -2, 	  -3,   -7
+.2byte    5,   -4, 	   0,   -8, 	   1,    1, 	  -2,   -6
+.2byte    4,   -4, 	   9,   -7, 	  -7,    0, 	   0,   -6
+sCacneaAnimTable1:
+.4byte sCacneaAnims_1_1
+.4byte sCacneaAnims_1_2
+.4byte sCacneaAnims_1_3
+.4byte sCacneaAnims_1_4
+.4byte sCacneaAnims_1_5
+.4byte sCacneaAnims_1_6
+.4byte sCacneaAnims_1_7
+.4byte sCacneaAnims_1_8
+sCacneaAnimTable2:
+.4byte sCacneaAnims_2_1
+.4byte sCacneaAnims_2_2
+.4byte sCacneaAnims_2_3
+.4byte sCacneaAnims_2_4
+.4byte sCacneaAnims_2_5
+.4byte sCacneaAnims_2_6
+.4byte sCacneaAnims_2_7
+.4byte sCacneaAnims_2_8
+sCacneaAnimTable3:
+.4byte sCacneaAnims_3_1
+.4byte sCacneaAnims_3_2
+.4byte sCacneaAnims_3_3
+.4byte sCacneaAnims_3_4
+.4byte sCacneaAnims_3_5
+.4byte sCacneaAnims_3_6
+.4byte sCacneaAnims_3_7
+.4byte sCacneaAnims_3_8
+sCacneaAnimTable4:
+.4byte sCacneaAnims_4_1
+.4byte sCacneaAnims_4_2
+.4byte sCacneaAnims_4_3
+.4byte sCacneaAnims_4_4
+.4byte sCacneaAnims_4_5
+.4byte sCacneaAnims_4_6
+.4byte sCacneaAnims_4_7
+.4byte sCacneaAnims_4_8
+sCacneaAnimTable5:
+.4byte sCacneaAnims_5_1
+.4byte sCacneaAnims_5_2
+.4byte sCacneaAnims_5_3
+.4byte sCacneaAnims_5_4
+.4byte sCacneaAnims_5_5
+.4byte sCacneaAnims_5_6
+.4byte sCacneaAnims_5_7
+.4byte sCacneaAnims_5_8
+sCacneaAnimTable6:
+.4byte sCacneaAnims_6_1
+.4byte sCacneaAnims_6_1
+.4byte sCacneaAnims_6_1
+.4byte sCacneaAnims_6_1
+.4byte sCacneaAnims_6_1
+.4byte sCacneaAnims_6_1
+.4byte sCacneaAnims_6_1
+.4byte sCacneaAnims_6_1
+sCacneaAnimTable7:
+.4byte sCacneaAnims_7_1
+.4byte sCacneaAnims_7_2
+.4byte sCacneaAnims_7_3
+.4byte sCacneaAnims_7_4
+.4byte sCacneaAnims_7_5
+.4byte sCacneaAnims_7_6
+.4byte sCacneaAnims_7_7
+.4byte sCacneaAnims_7_8
+sCacneaAnimTable8:
+.4byte sCacneaAnims_8_1
+.4byte sCacneaAnims_8_2
+.4byte sCacneaAnims_8_3
+.4byte sCacneaAnims_8_4
+.4byte sCacneaAnims_8_5
+.4byte sCacneaAnims_8_6
+.4byte sCacneaAnims_8_7
+.4byte sCacneaAnims_8_8
+sCacneaAnimTable9:
+.4byte sCacneaAnims_9_1
+.4byte sCacneaAnims_9_2
+.4byte sCacneaAnims_9_3
+.4byte sCacneaAnims_9_4
+.4byte sCacneaAnims_9_5
+.4byte sCacneaAnims_9_6
+.4byte sCacneaAnims_9_7
+.4byte sCacneaAnims_9_8
+sCacneaAnimTable10:
+.4byte sCacneaAnims_10_1
+.4byte sCacneaAnims_10_2
+.4byte sCacneaAnims_10_3
+.4byte sCacneaAnims_10_4
+.4byte sCacneaAnims_10_5
+.4byte sCacneaAnims_10_6
+.4byte sCacneaAnims_10_7
+.4byte sCacneaAnims_10_8
+sCacneaAnimTable11:
+.4byte sCacneaAnims_11_1
+.4byte sCacneaAnims_11_2
+.4byte sCacneaAnims_11_3
+.4byte sCacneaAnims_11_4
+.4byte sCacneaAnims_11_5
+.4byte sCacneaAnims_11_6
+.4byte sCacneaAnims_11_7
+.4byte sCacneaAnims_11_8
+sCacneaAnimTable12:
+.4byte sCacneaAnims_12_1
+.4byte sCacneaAnims_12_2
+.4byte sCacneaAnims_12_3
+.4byte sCacneaAnims_12_4
+.4byte sCacneaAnims_12_5
+.4byte sCacneaAnims_12_6
+.4byte sCacneaAnims_12_7
+.4byte sCacneaAnims_12_8
+sCacneaAnimTable13:
+.4byte sCacneaAnims_13_1
+.4byte sCacneaAnims_13_2
+.4byte sCacneaAnims_13_3
+.4byte sCacneaAnims_13_4
+.4byte sCacneaAnims_13_5
+.4byte sCacneaAnims_13_6
+.4byte sCacneaAnims_13_7
+.4byte sCacneaAnims_13_8
+sAxAnimationsCacnea:
+.4byte sCacneaAnimTable1
+.4byte sCacneaAnimTable2
+.4byte sCacneaAnimTable3
+.4byte sCacneaAnimTable4
+.4byte sCacneaAnimTable5
+.4byte sCacneaAnimTable6
+.4byte sCacneaAnimTable7
+.4byte sCacneaAnimTable8
+.4byte sCacneaAnimTable9
+.4byte sCacneaAnimTable10
+.4byte sCacneaAnimTable11
+.4byte sCacneaAnimTable12
+.4byte sCacneaAnimTable13
+sAxSpritesCacnea:
+.4byte sCacneaSprites1
+.4byte sCacneaSprites2
+.4byte sCacneaSprites3
+.4byte sCacneaSprites4
+.4byte sCacneaSprites5
+.4byte sCacneaSprites6
+.4byte sCacneaSprites7
+.4byte sCacneaSprites8
+.4byte sCacneaSprites9
+.4byte sCacneaSprites10
+.4byte sCacneaSprites11
+.4byte sCacneaSprites12
+.4byte sCacneaSprites13
+.4byte sCacneaSprites14
+.4byte sCacneaSprites15
+.4byte sCacneaSprites16
+.4byte sCacneaSprites17
+.4byte sCacneaSprites18
+.4byte sCacneaSprites19
+.4byte sCacneaSprites20
+.4byte sCacneaSprites21
+.4byte sCacneaSprites22
+.4byte sCacneaSprites23
+.4byte sCacneaSprites24
+.4byte sCacneaSprites25
+.4byte sCacneaSprites26
+.4byte sCacneaSprites27
+.4byte sCacneaSprites28
+.4byte sCacneaSprites29
+.4byte sCacneaSprites30
+.4byte sCacneaSprites31
+.4byte sCacneaSprites32
+.4byte sCacneaSprites33
+.4byte sCacneaSprites34
+.4byte sCacneaSprites35
+.4byte sCacneaSprites36
+.4byte sCacneaSprites37
+.4byte sCacneaSprites38
+.4byte sCacneaSprites39
+.4byte sCacneaSprites40
+.4byte sCacneaSprites41
+.4byte sCacneaSprites42
+.4byte sCacneaSprites43
+.4byte sCacneaSprites44
+sAxMainCacnea:
+ax_main sAxPosesCacnea, sAxAnimationsCacnea, 13, sAxSpritesCacnea, sAxPositionsCacnea

--- a/data/ax/cacturne.inc
+++ b/data/ax/cacturne.inc
@@ -1,0 +1,3350 @@
+.global gAxCacturne
+gAxCacturne:
+ax_siro sAxMainCacturne
+sCacturnePose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose3:
+ax_pose 2, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose4:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose5:
+ax_pose 4, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose6:
+ax_pose 5, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose7:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose8:
+ax_pose 7, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose9:
+ax_pose 8, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose10:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose11:
+ax_pose 10, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose12:
+ax_pose 11, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose13:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose14:
+ax_pose 13, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose15:
+ax_pose 14, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose16:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose17:
+ax_pose 10, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose18:
+ax_pose 11, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose19:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose20:
+ax_pose 7, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose21:
+ax_pose 8, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose22:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose23:
+ax_pose 4, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose24:
+ax_pose 5, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose25:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose26:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose27:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose28:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose29:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose30:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose31:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose32:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose33:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose34:
+ax_pose 1, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose35:
+ax_pose 2, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose36:
+ax_pose 15, 0x81e4, 0x80f6, 0x3c00
+ax_pose 16, 0x81e4, 0x4106, 0x3c08
+ax_pose 17, 0x81e8, 0x00ee, 0x3c0c
+ax_pose 18, 0x01ee, 0x010e, 0x3c0e
+ax_pose_terminator
+sCacturnePose37:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose38:
+ax_pose 4, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose39:
+ax_pose 5, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose40:
+ax_pose 19, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose41:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose42:
+ax_pose 7, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose43:
+ax_pose 8, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose44:
+ax_pose 20, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose45:
+ax_pose 21, 0x41eb, 0x90f6, 0x3c00
+ax_pose 22, 0x41e3, 0x50f6, 0x3c08
+ax_pose 23, 0x41fb, 0x10f6, 0x3c0c
+ax_pose 24, 0x41db, 0x10f6, 0x3c0e
+ax_pose_terminator
+sCacturnePose46:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose47:
+ax_pose 10, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose48:
+ax_pose 11, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose49:
+ax_pose 25, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose50:
+ax_pose 26, 0x01e0, 0x90f2, 0x3c00
+ax_pose 27, 0x4200, 0x10fa, 0x3c10
+ax_pose_terminator
+sCacturnePose51:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose52:
+ax_pose 13, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose53:
+ax_pose 14, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose54:
+ax_pose 28, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose55:
+ax_pose 29, 0x01e4, 0x80ee, 0x3c00
+ax_pose 30, 0x01dc, 0x00fc, 0x3c10
+ax_pose 31, 0x01e9, 0x010e, 0x3c11
+ax_pose_terminator
+sCacturnePose56:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose57:
+ax_pose 10, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose58:
+ax_pose 11, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose59:
+ax_pose 25, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose60:
+ax_pose 26, 0x01e0, 0x80ed, 0x3c00
+ax_pose 27, 0x4200, 0x00f5, 0x3c10
+ax_pose_terminator
+sCacturnePose61:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose62:
+ax_pose 7, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose63:
+ax_pose 8, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose64:
+ax_pose 20, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose65:
+ax_pose 21, 0x41eb, 0x80e9, 0x3c00
+ax_pose 22, 0x41e3, 0x40e9, 0x3c08
+ax_pose 23, 0x41fb, 0x00f9, 0x3c0c
+ax_pose 24, 0x41db, 0x00f9, 0x3c0e
+ax_pose_terminator
+sCacturnePose66:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose67:
+ax_pose 4, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose68:
+ax_pose 5, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose69:
+ax_pose 19, 0x01e2, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose70:
+ax_pose 32, 0x81e2, 0x80fd, 0x3c00
+ax_pose 33, 0x81e2, 0x40f5, 0x3c08
+ax_pose 34, 0x81e2, 0x00ed, 0x3c0c
+ax_pose 35, 0x01da, 0x00f5, 0x3c0e
+ax_pose_terminator
+sCacturnePose71:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose72:
+ax_pose 1, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose73:
+ax_pose 2, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose74:
+ax_pose 15, 0x81e4, 0x80f6, 0x3c00
+ax_pose 16, 0x81e4, 0x4106, 0x3c08
+ax_pose 17, 0x81e8, 0x00ee, 0x3c0c
+ax_pose 18, 0x01ee, 0x010e, 0x3c0e
+ax_pose_terminator
+sCacturnePose75:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose76:
+ax_pose 4, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose77:
+ax_pose 5, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose78:
+ax_pose 19, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose79:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose80:
+ax_pose 7, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose81:
+ax_pose 8, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose82:
+ax_pose 20, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose83:
+ax_pose 21, 0x41eb, 0x90f6, 0x3c00
+ax_pose 22, 0x41e3, 0x50f6, 0x3c08
+ax_pose 23, 0x41fb, 0x10f6, 0x3c0c
+ax_pose 24, 0x41db, 0x10f6, 0x3c0e
+ax_pose_terminator
+sCacturnePose84:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose85:
+ax_pose 10, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose86:
+ax_pose 11, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose87:
+ax_pose 25, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose88:
+ax_pose 26, 0x01e0, 0x90f2, 0x3c00
+ax_pose 27, 0x4200, 0x10fa, 0x3c10
+ax_pose_terminator
+sCacturnePose89:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose90:
+ax_pose 13, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose91:
+ax_pose 14, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose92:
+ax_pose 28, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose93:
+ax_pose 29, 0x01e4, 0x80ee, 0x3c00
+ax_pose 30, 0x01dc, 0x00fc, 0x3c10
+ax_pose 31, 0x01e9, 0x010e, 0x3c11
+ax_pose_terminator
+sCacturnePose94:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose95:
+ax_pose 10, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose96:
+ax_pose 11, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose97:
+ax_pose 25, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose98:
+ax_pose 26, 0x01e0, 0x80ed, 0x3c00
+ax_pose 27, 0x4200, 0x00f5, 0x3c10
+ax_pose_terminator
+sCacturnePose99:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose100:
+ax_pose 7, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose101:
+ax_pose 8, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose102:
+ax_pose 20, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose103:
+ax_pose 21, 0x41eb, 0x80e9, 0x3c00
+ax_pose 22, 0x41e3, 0x40e9, 0x3c08
+ax_pose 23, 0x41fb, 0x00f9, 0x3c0c
+ax_pose 24, 0x41db, 0x00f9, 0x3c0e
+ax_pose_terminator
+sCacturnePose104:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose105:
+ax_pose 4, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose106:
+ax_pose 5, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose107:
+ax_pose 19, 0x01e2, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose108:
+ax_pose 32, 0x81e2, 0x80fd, 0x3c00
+ax_pose 33, 0x81e2, 0x40f5, 0x3c08
+ax_pose 34, 0x81e2, 0x00ed, 0x3c0c
+ax_pose 35, 0x01da, 0x00f5, 0x3c0e
+ax_pose_terminator
+sCacturnePose109:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose110:
+ax_pose 36, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose111:
+ax_pose 15, 0x81e4, 0x80f6, 0x3c00
+ax_pose 16, 0x81e4, 0x4106, 0x3c08
+ax_pose 17, 0x81e8, 0x00ee, 0x3c0c
+ax_pose 18, 0x01ee, 0x010e, 0x3c0e
+ax_pose_terminator
+sCacturnePose112:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose113:
+ax_pose 37, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacturnePose114:
+ax_pose 19, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose115:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose116:
+ax_pose 38, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacturnePose117:
+ax_pose 20, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose118:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose119:
+ax_pose 39, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose120:
+ax_pose 25, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose121:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose122:
+ax_pose 40, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose123:
+ax_pose 28, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose124:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose125:
+ax_pose 39, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose126:
+ax_pose 25, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose127:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose128:
+ax_pose 38, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose129:
+ax_pose 20, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose130:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose131:
+ax_pose 37, 0x01e3, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose132:
+ax_pose 19, 0x01e2, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose133:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose134:
+ax_pose 36, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose135:
+ax_pose 15, 0x81e4, 0x80f6, 0x3c00
+ax_pose 16, 0x81e4, 0x4106, 0x3c08
+ax_pose 17, 0x81e8, 0x00ee, 0x3c0c
+ax_pose 18, 0x01ee, 0x010e, 0x3c0e
+ax_pose_terminator
+sCacturnePose136:
+ax_pose 41, 0x01e4, 0x80ea, 0x3c00
+ax_pose 42, 0x81e4, 0x010a, 0x3c10
+ax_pose 43, 0x01dc, 0x00fa, 0x3c12
+ax_pose 44, 0x01ec, 0x0112, 0x3c13
+ax_pose_terminator
+sCacturnePose137:
+ax_pose 45, 0x01e8, 0x44fa, 0x4c00
+ax_pose -1, 0x01e8, 0x44f4, 0x4c00
+ax_pose 41, 0x01e4, 0x80ea, 0x3c04
+ax_pose 42, 0x81e4, 0x010a, 0x3c14
+ax_pose 43, 0x01dc, 0x00fa, 0x3c16
+ax_pose 44, 0x01ec, 0x0112, 0x3c17
+ax_pose_terminator
+sCacturnePose138:
+ax_pose 46, 0x01e8, 0x44fa, 0x4c00
+ax_pose -1, 0x01e8, 0x44f4, 0x4c00
+ax_pose 41, 0x01e4, 0x80ea, 0x3c04
+ax_pose 42, 0x81e4, 0x010a, 0x3c14
+ax_pose 43, 0x01dc, 0x00fa, 0x3c16
+ax_pose 44, 0x01ec, 0x0112, 0x3c17
+ax_pose_terminator
+sCacturnePose139:
+ax_pose 47, 0x01e8, 0x44fa, 0x4c00
+ax_pose -1, 0x01e8, 0x44f4, 0x4c00
+ax_pose 41, 0x01e4, 0x80ea, 0x3c04
+ax_pose 42, 0x81e4, 0x010a, 0x3c14
+ax_pose 43, 0x01dc, 0x00fa, 0x3c16
+ax_pose 44, 0x01ec, 0x0112, 0x3c17
+ax_pose_terminator
+sCacturnePose140:
+ax_pose 48, 0x01e8, 0x44fa, 0x4c00
+ax_pose -1, 0x01e8, 0x44f4, 0x4c00
+ax_pose 41, 0x01e4, 0x80ea, 0x3c04
+ax_pose 42, 0x81e4, 0x010a, 0x3c14
+ax_pose 43, 0x01dc, 0x00fa, 0x3c16
+ax_pose 44, 0x01ec, 0x0112, 0x3c17
+ax_pose_terminator
+sCacturnePose141:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose142:
+ax_pose 37, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacturnePose143:
+ax_pose 19, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose144:
+ax_pose 32, 0x81e2, 0x90f2, 0x3c00
+ax_pose 33, 0x81e2, 0x5102, 0x3c08
+ax_pose 34, 0x81e2, 0x110a, 0x3c0c
+ax_pose 35, 0x01da, 0x1102, 0x3c0e
+ax_pose_terminator
+sCacturnePose145:
+ax_pose 45, 0x01e6, 0x44fd, 0x4c00
+ax_pose -1, 0x01e5, 0x4503, 0x4c00
+ax_pose 32, 0x81e2, 0x90f2, 0x3c04
+ax_pose 33, 0x81e2, 0x5102, 0x3c0c
+ax_pose 34, 0x81e2, 0x110a, 0x3c10
+ax_pose 35, 0x01da, 0x1102, 0x3c12
+ax_pose_terminator
+sCacturnePose146:
+ax_pose 46, 0x01e5, 0x4503, 0x4c00
+ax_pose -1, 0x01e6, 0x44fd, 0x4c00
+ax_pose 32, 0x81e2, 0x90f2, 0x3c04
+ax_pose 33, 0x81e2, 0x5102, 0x3c0c
+ax_pose 34, 0x81e2, 0x110a, 0x3c10
+ax_pose 35, 0x01da, 0x1102, 0x3c12
+ax_pose_terminator
+sCacturnePose147:
+ax_pose 47, 0x01e6, 0x44fd, 0x4c00
+ax_pose -1, 0x01e5, 0x4503, 0x4c00
+ax_pose 32, 0x81e2, 0x90f2, 0x3c04
+ax_pose 33, 0x81e2, 0x5102, 0x3c0c
+ax_pose 34, 0x81e2, 0x110a, 0x3c10
+ax_pose 35, 0x01da, 0x1102, 0x3c12
+ax_pose_terminator
+sCacturnePose148:
+ax_pose 48, 0x01e6, 0x44fd, 0x4c00
+ax_pose -1, 0x01e5, 0x4503, 0x4c00
+ax_pose 32, 0x81e2, 0x90f2, 0x3c04
+ax_pose 33, 0x81e2, 0x5102, 0x3c0c
+ax_pose 34, 0x81e2, 0x110a, 0x3c10
+ax_pose 35, 0x01da, 0x1102, 0x3c12
+ax_pose_terminator
+sCacturnePose149:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose150:
+ax_pose 38, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose151:
+ax_pose 20, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose152:
+ax_pose 21, 0x41eb, 0x90f6, 0x3c00
+ax_pose 22, 0x41e3, 0x50f6, 0x3c08
+ax_pose 23, 0x41fb, 0x10f6, 0x3c0c
+ax_pose 24, 0x41db, 0x10f6, 0x3c0e
+ax_pose_terminator
+sCacturnePose153:
+ax_pose 45, 0x01e4, 0x44ff, 0x4c00
+ax_pose 21, 0x41eb, 0x90f6, 0x3c04
+ax_pose 22, 0x41e3, 0x50f6, 0x3c0c
+ax_pose 23, 0x41fb, 0x10f6, 0x3c10
+ax_pose 24, 0x41db, 0x10f6, 0x3c12
+ax_pose -1, 0x01de, 0x44ff, 0x4c00
+ax_pose_terminator
+sCacturnePose154:
+ax_pose 46, 0x01e4, 0x44ff, 0x4c00
+ax_pose 21, 0x41eb, 0x90f6, 0x3c04
+ax_pose 22, 0x41e3, 0x50f6, 0x3c0c
+ax_pose 23, 0x41fb, 0x10f6, 0x3c10
+ax_pose 24, 0x41db, 0x10f6, 0x3c12
+ax_pose -1, 0x01de, 0x44ff, 0x4c00
+ax_pose_terminator
+sCacturnePose155:
+ax_pose 47, 0x01e4, 0x44ff, 0x4c00
+ax_pose 21, 0x41eb, 0x90f6, 0x3c04
+ax_pose 22, 0x41e3, 0x50f6, 0x3c0c
+ax_pose 23, 0x41fb, 0x10f6, 0x3c10
+ax_pose 24, 0x41db, 0x10f6, 0x3c12
+ax_pose -1, 0x01de, 0x44ff, 0x4c00
+ax_pose_terminator
+sCacturnePose156:
+ax_pose 48, 0x01e4, 0x44ff, 0x4c00
+ax_pose 21, 0x41eb, 0x90f6, 0x3c04
+ax_pose 22, 0x41e3, 0x50f6, 0x3c0c
+ax_pose 23, 0x41fb, 0x10f6, 0x3c10
+ax_pose 24, 0x41db, 0x10f6, 0x3c12
+ax_pose -1, 0x01de, 0x44ff, 0x4c00
+ax_pose_terminator
+sCacturnePose157:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose158:
+ax_pose 39, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose159:
+ax_pose 25, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose160:
+ax_pose 26, 0x01e0, 0x90f2, 0x3c00
+ax_pose 27, 0x4200, 0x10fa, 0x3c10
+ax_pose_terminator
+sCacturnePose161:
+ax_pose 26, 0x01e0, 0x90f2, 0x3c00
+ax_pose 27, 0x4200, 0x10fa, 0x3c10
+ax_pose 45, 0x01e1, 0x4503, 0x4c12
+ax_pose -1, 0x01dd, 0x44fa, 0x4c12
+ax_pose_terminator
+sCacturnePose162:
+ax_pose 26, 0x01e0, 0x90f2, 0x3c00
+ax_pose 27, 0x4200, 0x10fa, 0x3c10
+ax_pose 46, 0x01e1, 0x4503, 0x4c12
+ax_pose -1, 0x01dd, 0x44fa, 0x4c12
+ax_pose_terminator
+sCacturnePose163:
+ax_pose 26, 0x01e0, 0x90f2, 0x3c00
+ax_pose 27, 0x4200, 0x10fa, 0x3c10
+ax_pose 47, 0x01e1, 0x4503, 0x4c12
+ax_pose -1, 0x01dd, 0x44fa, 0x4c12
+ax_pose_terminator
+sCacturnePose164:
+ax_pose 26, 0x01e0, 0x90f2, 0x3c00
+ax_pose 27, 0x4200, 0x10fa, 0x3c10
+ax_pose 48, 0x01e1, 0x4503, 0x4c12
+ax_pose -1, 0x01dd, 0x44fa, 0x4c12
+ax_pose_terminator
+sCacturnePose165:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose166:
+ax_pose 40, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose167:
+ax_pose 28, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose168:
+ax_pose 29, 0x01e4, 0x80ee, 0x3c00
+ax_pose 30, 0x01dc, 0x00fc, 0x3c10
+ax_pose 31, 0x01e9, 0x010e, 0x3c11
+ax_pose_terminator
+sCacturnePose169:
+ax_pose 29, 0x01e4, 0x80ee, 0x3c00
+ax_pose 30, 0x01dc, 0x00fc, 0x3c10
+ax_pose 31, 0x01e9, 0x010e, 0x3c11
+ax_pose 45, 0x01dc, 0x44fb, 0x4c12
+ax_pose -1, 0x01dc, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose170:
+ax_pose 29, 0x01e4, 0x80ee, 0x3c00
+ax_pose 30, 0x01dc, 0x00fc, 0x3c10
+ax_pose 31, 0x01e9, 0x010e, 0x3c11
+ax_pose 46, 0x01dc, 0x44fb, 0x4c12
+ax_pose -1, 0x01dc, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose171:
+ax_pose 29, 0x01e4, 0x80ee, 0x3c00
+ax_pose 30, 0x01dc, 0x00fc, 0x3c10
+ax_pose 31, 0x01e9, 0x010e, 0x3c11
+ax_pose 47, 0x01dc, 0x44fb, 0x4c12
+ax_pose -1, 0x01dc, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose172:
+ax_pose 29, 0x01e4, 0x80ee, 0x3c00
+ax_pose 30, 0x01dc, 0x00fc, 0x3c10
+ax_pose 31, 0x01e9, 0x010e, 0x3c11
+ax_pose 48, 0x01dc, 0x44fb, 0x4c12
+ax_pose -1, 0x01dc, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose173:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose174:
+ax_pose 39, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose175:
+ax_pose 25, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose176:
+ax_pose 26, 0x01e0, 0x80ed, 0x3c00
+ax_pose 27, 0x4200, 0x00f5, 0x3c10
+ax_pose_terminator
+sCacturnePose177:
+ax_pose 26, 0x01e0, 0x80ed, 0x3c00
+ax_pose 27, 0x4200, 0x00f5, 0x3c10
+ax_pose 45, 0x01e1, 0x44eb, 0x4c12
+ax_pose -1, 0x01dd, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose178:
+ax_pose 26, 0x01e0, 0x80ed, 0x3c00
+ax_pose 27, 0x4200, 0x00f5, 0x3c10
+ax_pose 46, 0x01e1, 0x44eb, 0x4c12
+ax_pose -1, 0x01dd, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose179:
+ax_pose 26, 0x01e0, 0x80ed, 0x3c00
+ax_pose 27, 0x4200, 0x00f5, 0x3c10
+ax_pose 47, 0x01e1, 0x44eb, 0x4c12
+ax_pose -1, 0x01dd, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose180:
+ax_pose 26, 0x01e0, 0x80ed, 0x3c00
+ax_pose 27, 0x4200, 0x00f5, 0x3c10
+ax_pose 48, 0x01e1, 0x44eb, 0x4c12
+ax_pose -1, 0x01dd, 0x44f3, 0x4c12
+ax_pose_terminator
+sCacturnePose181:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose182:
+ax_pose 38, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose183:
+ax_pose 20, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose184:
+ax_pose 21, 0x41eb, 0x80e9, 0x3c00
+ax_pose 22, 0x41e3, 0x40e9, 0x3c08
+ax_pose 23, 0x41fb, 0x00f9, 0x3c0c
+ax_pose 24, 0x41db, 0x00f9, 0x3c0e
+ax_pose_terminator
+sCacturnePose185:
+ax_pose 45, 0x01e4, 0x44ef, 0x4c00
+ax_pose 21, 0x41eb, 0x80e9, 0x3c04
+ax_pose 22, 0x41e3, 0x40e9, 0x3c0c
+ax_pose 23, 0x41fb, 0x00f9, 0x3c10
+ax_pose 24, 0x41db, 0x00f9, 0x3c12
+ax_pose -1, 0x01de, 0x44ef, 0x4c00
+ax_pose_terminator
+sCacturnePose186:
+ax_pose 46, 0x01e4, 0x44ef, 0x4c00
+ax_pose 21, 0x41eb, 0x80e9, 0x3c04
+ax_pose 22, 0x41e3, 0x40e9, 0x3c0c
+ax_pose 23, 0x41fb, 0x00f9, 0x3c10
+ax_pose 24, 0x41db, 0x00f9, 0x3c12
+ax_pose -1, 0x01de, 0x44ef, 0x4c00
+ax_pose_terminator
+sCacturnePose187:
+ax_pose 47, 0x01e4, 0x44ef, 0x4c00
+ax_pose 21, 0x41eb, 0x80e9, 0x3c04
+ax_pose 22, 0x41e3, 0x40e9, 0x3c0c
+ax_pose 23, 0x41fb, 0x00f9, 0x3c10
+ax_pose 24, 0x41db, 0x00f9, 0x3c12
+ax_pose -1, 0x01de, 0x44ef, 0x4c00
+ax_pose_terminator
+sCacturnePose188:
+ax_pose 48, 0x01e4, 0x44ef, 0x4c00
+ax_pose 21, 0x41eb, 0x80e9, 0x3c04
+ax_pose 22, 0x41e3, 0x40e9, 0x3c0c
+ax_pose 23, 0x41fb, 0x00f9, 0x3c10
+ax_pose 24, 0x41db, 0x00f9, 0x3c12
+ax_pose -1, 0x01de, 0x44ef, 0x4c00
+ax_pose_terminator
+sCacturnePose189:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose190:
+ax_pose 37, 0x01e3, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose191:
+ax_pose 19, 0x01e2, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose192:
+ax_pose 32, 0x81e2, 0x80fd, 0x3c00
+ax_pose 33, 0x81e2, 0x40f5, 0x3c08
+ax_pose 34, 0x81e2, 0x00ed, 0x3c0c
+ax_pose 35, 0x01da, 0x00f5, 0x3c0e
+ax_pose_terminator
+sCacturnePose193:
+ax_pose 45, 0x01e6, 0x44f1, 0x4c00
+ax_pose -1, 0x01e5, 0x44eb, 0x4c00
+ax_pose 32, 0x81e2, 0x80fd, 0x3c04
+ax_pose 33, 0x81e2, 0x40f5, 0x3c0c
+ax_pose 34, 0x81e2, 0x00ed, 0x3c10
+ax_pose 35, 0x01da, 0x00f5, 0x3c12
+ax_pose_terminator
+sCacturnePose194:
+ax_pose 46, 0x01e6, 0x44f1, 0x4c00
+ax_pose -1, 0x01e5, 0x44eb, 0x4c00
+ax_pose 32, 0x81e2, 0x80fd, 0x3c04
+ax_pose 33, 0x81e2, 0x40f5, 0x3c0c
+ax_pose 34, 0x81e2, 0x00ed, 0x3c10
+ax_pose 35, 0x01da, 0x00f5, 0x3c12
+ax_pose_terminator
+sCacturnePose195:
+ax_pose 47, 0x01e6, 0x44f1, 0x4c00
+ax_pose -1, 0x01e5, 0x44eb, 0x4c00
+ax_pose 32, 0x81e2, 0x80fd, 0x3c04
+ax_pose 33, 0x81e2, 0x40f5, 0x3c0c
+ax_pose 34, 0x81e2, 0x00ed, 0x3c10
+ax_pose 35, 0x01da, 0x00f5, 0x3c12
+ax_pose_terminator
+sCacturnePose196:
+ax_pose 48, 0x01e6, 0x44f1, 0x4c00
+ax_pose -1, 0x01e5, 0x44eb, 0x4c00
+ax_pose 32, 0x81e2, 0x80fd, 0x3c04
+ax_pose 33, 0x81e2, 0x40f5, 0x3c0c
+ax_pose 34, 0x81e2, 0x00ed, 0x3c10
+ax_pose 35, 0x01da, 0x00f5, 0x3c12
+ax_pose_terminator
+sCacturnePose197:
+ax_pose 49, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose198:
+ax_pose 50, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose199:
+ax_pose 51, 0x01e1, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacturnePose200:
+ax_pose 52, 0x01e3, 0x90ea, 0x3c00
+ax_pose_terminator
+sCacturnePose201:
+ax_pose 53, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sCacturnePose202:
+ax_pose 54, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose203:
+ax_pose 55, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sCacturnePose204:
+ax_pose 54, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose205:
+ax_pose 53, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCacturnePose206:
+ax_pose 52, 0x01e3, 0x80f6, 0x3c00
+ax_pose_terminator
+sCacturnePose207:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose208:
+ax_pose 1, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose209:
+ax_pose 2, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose210:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose211:
+ax_pose 4, 0x01e3, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose212:
+ax_pose 5, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose213:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose214:
+ax_pose 7, 0x01e3, 0x90ea, 0x3c00
+ax_pose_terminator
+sCacturnePose215:
+ax_pose 8, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose216:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose217:
+ax_pose 10, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose218:
+ax_pose 11, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose219:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose220:
+ax_pose 13, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose221:
+ax_pose 14, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose222:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose223:
+ax_pose 10, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose224:
+ax_pose 11, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose225:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose226:
+ax_pose 7, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sCacturnePose227:
+ax_pose 8, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose228:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose229:
+ax_pose 4, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose230:
+ax_pose 5, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose231:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose232:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose233:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose234:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose235:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose236:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose237:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose238:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose239:
+ax_pose 15, 0x81e4, 0x80f7, 0x3c00
+ax_pose 16, 0x81e4, 0x4107, 0x3c08
+ax_pose 17, 0x81e8, 0x00ef, 0x3c0c
+ax_pose 18, 0x01ee, 0x010f, 0x3c0e
+ax_pose_terminator
+sCacturnePose240:
+ax_pose 19, 0x01e2, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose241:
+ax_pose 20, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose242:
+ax_pose 25, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose243:
+ax_pose 28, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose244:
+ax_pose 25, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose245:
+ax_pose 20, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose246:
+ax_pose 19, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose247:
+ax_pose 15, 0x81e4, 0x80f7, 0x3c00
+ax_pose 16, 0x81e4, 0x4107, 0x3c08
+ax_pose 17, 0x81e8, 0x00ef, 0x3c0c
+ax_pose 18, 0x01ee, 0x010f, 0x3c0e
+ax_pose_terminator
+sCacturnePose248:
+ax_pose 19, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose249:
+ax_pose 20, 0x01e3, 0x90f3, 0x3c00
+ax_pose_terminator
+sCacturnePose250:
+ax_pose 25, 0x01e4, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose251:
+ax_pose 28, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose252:
+ax_pose 25, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose253:
+ax_pose 20, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose254:
+ax_pose 19, 0x01e2, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose255:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose256:
+ax_pose 15, 0x81e3, 0x80f6, 0x3c00
+ax_pose 16, 0x81e3, 0x4106, 0x3c08
+ax_pose 17, 0x81e7, 0x00ee, 0x3c0c
+ax_pose 18, 0x01ed, 0x010e, 0x3c0e
+ax_pose_terminator
+sCacturnePose257:
+ax_pose 36, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose258:
+ax_pose 3, 0x01e2, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose259:
+ax_pose 19, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose260:
+ax_pose 37, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacturnePose261:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose262:
+ax_pose 20, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose263:
+ax_pose 38, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose264:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose265:
+ax_pose 25, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose266:
+ax_pose 39, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose267:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose268:
+ax_pose 28, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose269:
+ax_pose 40, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose270:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose271:
+ax_pose 25, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose272:
+ax_pose 39, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose273:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose274:
+ax_pose 20, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose275:
+ax_pose 38, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose276:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose277:
+ax_pose 19, 0x01e2, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose278:
+ax_pose 37, 0x01e3, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose279:
+ax_pose 36, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose280:
+ax_pose 37, 0x01e3, 0x80ee, 0x3c00
+ax_pose_terminator
+sCacturnePose281:
+ax_pose 38, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sCacturnePose282:
+ax_pose 39, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose283:
+ax_pose 40, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sCacturnePose284:
+ax_pose 39, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sCacturnePose285:
+ax_pose 38, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sCacturnePose286:
+ax_pose 37, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sCacturnePose287:
+ax_pose 0, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose288:
+ax_pose 3, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose289:
+ax_pose 6, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCacturnePose290:
+ax_pose 9, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose291:
+ax_pose 12, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sCacturnePose292:
+ax_pose 9, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sCacturnePose293:
+ax_pose 6, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sCacturnePose294:
+ax_pose 3, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+.align 2
+sCacturneAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacturneAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 4, 0, 32, 0, -2, 0, -2,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, 4, 0, 4,
+ax_anim 1, 0, 34, 0, 12, 0, 12,
+ax_anim 2, 0, 35, 0, 19, 0, 19,
+ax_anim 2, 1, 35, 1, 19, 1, 19,
+ax_anim 2, 0, 35, 0, 19, 0, 19,
+ax_anim 2, 0, 35, 1, 19, 1, 19,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sCacturneAnims_2_2:
+ax_anim 2, 0, 36, -1, -1, -1, -1,
+ax_anim 4, 0, 36, -2, -2, -2, -2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 4, 5, 4, 5,
+ax_anim 1, 0, 38, 12, 15, 12, 15,
+ax_anim 2, 0, 39, 17, 21, 17, 21,
+ax_anim 2, 1, 39, 18, 20, 18, 20,
+ax_anim 2, 0, 39, 17, 21, 17, 21,
+ax_anim 2, 0, 39, 18, 20, 18, 20,
+ax_anim 2, 0, 36, 6, 8, 6, 8,
+ax_anim_terminator
+sCacturneAnims_2_3:
+ax_anim 2, 0, 40, -1, 0, -1, 0,
+ax_anim 4, 0, 40, -2, 0, -2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 4, 0, 4, 0,
+ax_anim 1, 0, 42, 10, 0, 10, 0,
+ax_anim 2, 0, 43, 20, 0, 20, 0,
+ax_anim 2, 1, 43, 20, 1, 20, 1,
+ax_anim 2, 0, 43, 20, 0, 20, 0,
+ax_anim 2, 0, 43, 20, 1, 20, 1,
+ax_anim 2, 0, 40, 6, 0, 6, 0,
+ax_anim_terminator
+sCacturneAnims_2_4:
+ax_anim 2, 0, 45, -1, 1, -1, 1,
+ax_anim 4, 0, 45, -2, 2, -2, 2,
+ax_anim 1, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 2, 46, 6, -6, 6, -6,
+ax_anim 1, 0, 47, 11, -12, 11, -12,
+ax_anim 2, 0, 48, 15, -16, 15, -16,
+ax_anim 2, 1, 48, 16, -15, 16, -15,
+ax_anim 2, 0, 48, 15, -16, 15, -16,
+ax_anim 2, 0, 48, 16, -15, 16, -15,
+ax_anim 2, 0, 45, 6, -6, 6, -6,
+ax_anim_terminator
+sCacturneAnims_2_5:
+ax_anim 2, 0, 50, 0, 1, 0, 1,
+ax_anim 4, 0, 50, 0, 2, 0, 2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 0, -4, 0, -4,
+ax_anim 1, 0, 52, 0, -11, 0, -11,
+ax_anim 2, 0, 53, 0, -14, 0, -14,
+ax_anim 2, 1, 53, 1, -14, 1, -14,
+ax_anim 2, 0, 53, 0, -14, 0, -14,
+ax_anim 2, 0, 53, 1, -14, 1, -14,
+ax_anim 2, 0, 50, 0, -6, 0, -6,
+ax_anim_terminator
+sCacturneAnims_2_6:
+ax_anim 2, 0, 55, 1, 1, 1, 1,
+ax_anim 4, 0, 55, 2, 2, 2, 2,
+ax_anim 1, 0, 57, -2, -2, -2, -2,
+ax_anim 1, 2, 56, -6, -6, -6, -6,
+ax_anim 1, 0, 57, -11, -12, -11, -12,
+ax_anim 2, 0, 58, -15, -16, -15, -16,
+ax_anim 2, 1, 58, -16, -15, -16, -15,
+ax_anim 2, 0, 58, -15, -16, -15, -16,
+ax_anim 2, 0, 58, -16, -15, -16, -15,
+ax_anim 2, 0, 55, -6, -6, -6, -6,
+ax_anim_terminator
+sCacturneAnims_2_7:
+ax_anim 2, 0, 60, 1, 0, 1, 0,
+ax_anim 4, 0, 60, 2, 0, 2, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, -4, 0, -4, 0,
+ax_anim 1, 0, 62, -10, 0, -10, 0,
+ax_anim 2, 0, 63, -20, 0, -20, 0,
+ax_anim 2, 1, 63, -20, 1, -20, 1,
+ax_anim 2, 0, 63, -20, 0, -20, 0,
+ax_anim 2, 0, 63, -20, 1, -20, 1,
+ax_anim 2, 0, 60, -6, 0, -6, 0,
+ax_anim_terminator
+sCacturneAnims_2_8:
+ax_anim 2, 0, 65, 1, -1, 1, -1,
+ax_anim 4, 0, 65, 2, -2, 2, -2,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 5, -4, 5,
+ax_anim 1, 0, 67, -12, 15, -12, 15,
+ax_anim 2, 0, 68, -17, 21, -17, 21,
+ax_anim 2, 1, 68, -18, 20, -18, 20,
+ax_anim 2, 0, 68, -17, 21, -17, 21,
+ax_anim 2, 0, 68, -18, 20, -18, 20,
+ax_anim 2, 0, 65, -6, 8, -6, 8,
+ax_anim_terminator
+.align 2
+sCacturneAnims_3_1:
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 4, 0, 70, 0, -2, 0, -2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 0, 4, 0, 4,
+ax_anim 1, 0, 72, 0, 12, 0, 12,
+ax_anim 2, 0, 73, 0, 19, 0, 19,
+ax_anim 2, 1, 73, 1, 19, 1, 19,
+ax_anim 2, 0, 73, 0, 19, 0, 19,
+ax_anim 2, 0, 73, 1, 19, 1, 19,
+ax_anim 2, 0, 70, 0, 6, 0, 6,
+ax_anim_terminator
+sCacturneAnims_3_2:
+ax_anim 2, 0, 74, -1, -1, -1, -1,
+ax_anim 4, 0, 74, -2, -2, -2, -2,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 4, 5, 4, 5,
+ax_anim 1, 0, 76, 12, 15, 12, 15,
+ax_anim 2, 0, 77, 17, 21, 17, 21,
+ax_anim 2, 1, 77, 18, 20, 18, 20,
+ax_anim 2, 0, 77, 17, 21, 17, 21,
+ax_anim 2, 0, 77, 18, 20, 18, 20,
+ax_anim 2, 0, 74, 6, 8, 6, 8,
+ax_anim_terminator
+sCacturneAnims_3_3:
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 4, 0, 78, -2, 0, -2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 79, 4, 0, 4, 0,
+ax_anim 1, 0, 80, 10, 0, 10, 0,
+ax_anim 2, 0, 81, 20, 0, 20, 0,
+ax_anim 2, 1, 81, 20, 1, 20, 1,
+ax_anim 2, 0, 81, 20, 0, 20, 0,
+ax_anim 2, 0, 81, 20, 1, 20, 1,
+ax_anim 2, 0, 78, 6, 0, 6, 0,
+ax_anim_terminator
+sCacturneAnims_3_4:
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 4, 0, 83, -2, 2, -2, 2,
+ax_anim 1, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 2, 84, 6, -6, 6, -6,
+ax_anim 1, 0, 85, 11, -12, 11, -12,
+ax_anim 2, 0, 86, 15, -16, 15, -16,
+ax_anim 2, 1, 86, 16, -15, 16, -15,
+ax_anim 2, 0, 86, 15, -16, 15, -16,
+ax_anim 2, 0, 86, 16, -15, 16, -15,
+ax_anim 2, 0, 83, 6, -6, 6, -6,
+ax_anim_terminator
+sCacturneAnims_3_5:
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 4, 0, 88, 0, 2, 0, 2,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 2, 89, 0, -4, 0, -4,
+ax_anim 1, 0, 90, 0, -11, 0, -11,
+ax_anim 2, 0, 91, 0, -14, 0, -14,
+ax_anim 2, 1, 91, 1, -14, 1, -14,
+ax_anim 2, 0, 91, 0, -14, 0, -14,
+ax_anim 2, 0, 91, 1, -14, 1, -14,
+ax_anim 2, 0, 88, 0, -6, 0, -6,
+ax_anim_terminator
+sCacturneAnims_3_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 4, 0, 93, 2, 2, 2, 2,
+ax_anim 1, 0, 95, -2, -2, -2, -2,
+ax_anim 1, 2, 94, -6, -6, -6, -6,
+ax_anim 1, 0, 95, -11, -12, -11, -12,
+ax_anim 2, 0, 96, -15, -16, -15, -16,
+ax_anim 2, 1, 96, -16, -15, -16, -15,
+ax_anim 2, 0, 96, -15, -16, -15, -16,
+ax_anim 2, 0, 96, -16, -15, -16, -15,
+ax_anim 2, 0, 93, -6, -6, -6, -6,
+ax_anim_terminator
+sCacturneAnims_3_7:
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 4, 0, 98, 2, 0, 2, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 2, 99, -4, 0, -4, 0,
+ax_anim 1, 0, 100, -10, 0, -10, 0,
+ax_anim 2, 0, 101, -20, 0, -20, 0,
+ax_anim 2, 1, 101, -20, 1, -20, 1,
+ax_anim 2, 0, 101, -20, 0, -20, 0,
+ax_anim 2, 0, 101, -20, 1, -20, 1,
+ax_anim 2, 0, 98, -6, 0, -6, 0,
+ax_anim_terminator
+sCacturneAnims_3_8:
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 4, 0, 103, 2, -2, 2, -2,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 2, 104, -4, 5, -4, 5,
+ax_anim 1, 0, 105, -12, 15, -12, 15,
+ax_anim 2, 0, 106, -17, 21, -17, 21,
+ax_anim 2, 1, 106, -18, 20, -18, 20,
+ax_anim 2, 0, 106, -17, 21, -17, 21,
+ax_anim 2, 0, 106, -18, 20, -18, 20,
+ax_anim 2, 0, 103, -6, 8, -6, 8,
+ax_anim_terminator
+.align 2
+sCacturneAnims_4_1:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 3, 0, 3,
+ax_anim 2, 1, 110, 0, 5, 0, 5,
+ax_anim 2, 0, 110, 1, 5, 1, 5,
+ax_anim 2, 0, 110, 0, 5, 0, 5,
+ax_anim 2, 0, 110, 1, 5, 1, 5,
+ax_anim 2, 0, 110, 0, 5, 0, 5,
+ax_anim 2, 0, 110, 1, 5, 1, 5,
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim_terminator
+sCacturneAnims_4_2:
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 115, 1, 0, 1, -1,
+ax_anim 2, 0, 115, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, -1,
+ax_anim 2, 2, 115, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, -1,
+ax_anim 2, 0, 112, 0, 1, 0, 0,
+ax_anim 2, 0, 113, 2, 3, 2, 3,
+ax_anim 2, 1, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 3, 5, 3,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 3, 5, 3,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 3, 5, 3,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim_terminator
+sCacturneAnims_4_3:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 2, -1, 2, -1,
+ax_anim 2, 1, 116, 5, -1, 5, -1,
+ax_anim 2, 0, 116, 5, 0, 5, 0,
+ax_anim 2, 0, 116, 5, -1, 5, -1,
+ax_anim 2, 0, 116, 5, 0, 5, 0,
+ax_anim 2, 0, 116, 5, -1, 5, -1,
+ax_anim 2, 0, 116, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sCacturneAnims_4_4:
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 115, 1, 0, 1, 1,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, 1,
+ax_anim 2, 2, 115, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, 1,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim 2, 0, 119, 2, -3, 2, -3,
+ax_anim 2, 1, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 3, -5, 5, -3,
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 3, -5, 5, -3,
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 3, -5, 5, -3,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim_terminator
+sCacturneAnims_4_5:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 2, 1, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 1, -5, 1, -5,
+ax_anim 2, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 1, -5, 1, -5,
+ax_anim 2, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 1, -5, 1, -5,
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim_terminator
+sCacturneAnims_4_6:
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 121, -1, 0, -1, 1,
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 1,
+ax_anim 2, 2, 121, 0, -1, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 1,
+ax_anim 2, 0, 124, 0, -1, 0, 0,
+ax_anim 2, 0, 125, -2, -3, -2, -3,
+ax_anim 2, 1, 125, -4, -4, -4, -4,
+ax_anim 2, 0, 125, -3, -5, -5, -3,
+ax_anim 2, 0, 125, -4, -4, -4, -4,
+ax_anim 2, 0, 125, -3, -5, -5, -3,
+ax_anim 2, 0, 125, -4, -4, -4, -4,
+ax_anim 2, 0, 125, -3, -5, -5, -3,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim_terminator
+sCacturneAnims_4_7:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 0, -1,
+ax_anim 2, 0, 128, -2, -1, -2, -1,
+ax_anim 2, 1, 128, -5, -1, -5, -1,
+ax_anim 2, 0, 128, -5, 0, -5, 0,
+ax_anim 2, 0, 128, -5, -1, -5, -1,
+ax_anim 2, 0, 128, -5, 0, -5, 0,
+ax_anim 2, 0, 128, -5, -1, -5, -1,
+ax_anim 2, 0, 128, -5, 0, -5, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim_terminator
+sCacturneAnims_4_8:
+ax_anim 2, 0, 130, 0, 1, 0, 1,
+ax_anim 2, 0, 127, -1, 0, -1, -1,
+ax_anim 2, 0, 127, 0, 1, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, -1,
+ax_anim 2, 2, 127, 0, 1, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, -1,
+ax_anim 2, 0, 130, 0, 1, 0, 0,
+ax_anim 2, 0, 131, -2, 3, -2, 3,
+ax_anim 2, 1, 131, -4, 4, -4, 4,
+ax_anim 2, 0, 131, -5, 3, -5, 3,
+ax_anim 2, 0, 131, -4, 4, -4, 4,
+ax_anim 2, 0, 131, -5, 3, -5, 3,
+ax_anim 2, 0, 131, -4, 4, -4, 4,
+ax_anim 2, 0, 131, -5, 3, -5, 3,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCacturneAnims_5_1:
+ax_anim 2, 0, 133, 0, -1, 0, -1,
+ax_anim 2, 0, 133, 0, -2, 0, -2,
+ax_anim 6, 0, 133, 0, -3, 0, -3,
+ax_anim 1, 0, 134, 0, 2, 0, 2,
+ax_anim 6, 0, 135, 0, 2, 0, 2,
+ax_anim 1, 0, 136, 0, 2, 0, 2,
+ax_anim 1, 0, 137, 0, 2, 0, 2,
+ax_anim 1, 0, 138, 0, 2, 0, 2,
+ax_anim 1, 2, 139, 0, 2, 0, 2,
+ax_anim 4, 0, 135, 0, 2, 0, 2,
+ax_anim 2, 0, 134, 0, 1, 0, 1,
+ax_anim_terminator
+sCacturneAnims_5_2:
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, -2, -2, -2, -2,
+ax_anim 6, 0, 141, -3, -3, -3, -3,
+ax_anim 1, 0, 142, 2, 2, 2, 2,
+ax_anim 6, 0, 143, 3, 3, 3, 3,
+ax_anim 1, 0, 144, 3, 3, 3, 3,
+ax_anim 1, 0, 145, 3, 3, 3, 3,
+ax_anim 1, 0, 146, 3, 3, 3, 3,
+ax_anim 1, 2, 147, 3, 3, 3, 3,
+ax_anim 4, 0, 143, 3, 3, 3, 3,
+ax_anim 2, 0, 142, 1, 1, 1, 1,
+ax_anim_terminator
+sCacturneAnims_5_3:
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, -2, 0, -2, 0,
+ax_anim 6, 0, 149, -3, 0, -3, 0,
+ax_anim 1, 0, 150, 5, 0, 5, 0,
+ax_anim 6, 0, 151, 6, 0, 6, 0,
+ax_anim 1, 0, 152, 6, 0, 6, 0,
+ax_anim 1, 0, 153, 6, 0, 6, 0,
+ax_anim 1, 0, 154, 6, 0, 6, 0,
+ax_anim 1, 2, 155, 6, 0, 6, 0,
+ax_anim 4, 0, 151, 6, 0, 6, 0,
+ax_anim 2, 0, 150, 3, 0, 3, 0,
+ax_anim_terminator
+sCacturneAnims_5_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 1, -1, 1,
+ax_anim 6, 0, 157, -2, 2, -2, 2,
+ax_anim 1, 0, 158, 2, -2, 2, -2,
+ax_anim 6, 0, 159, 3, -3, 3, -3,
+ax_anim 1, 0, 160, 3, -3, 3, -3,
+ax_anim 1, 0, 161, 3, -3, 3, -3,
+ax_anim 1, 0, 162, 3, -3, 3, -3,
+ax_anim 1, 2, 163, 3, -3, 3, -3,
+ax_anim 4, 0, 159, 3, -3, 3, -3,
+ax_anim 2, 0, 158, 1, -1, 1, -1,
+ax_anim_terminator
+sCacturneAnims_5_5:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 1, 0, 1,
+ax_anim 6, 0, 165, 0, 2, 0, 2,
+ax_anim 1, 0, 166, 0, -3, 0, -3,
+ax_anim 6, 0, 167, 0, -3, 0, -3,
+ax_anim 1, 0, 168, 0, -3, 0, -3,
+ax_anim 1, 0, 169, 0, -3, 0, -3,
+ax_anim 1, 0, 170, 0, -3, 0, -3,
+ax_anim 1, 2, 171, 0, -3, 0, -3,
+ax_anim 4, 0, 167, 0, -3, 0, -3,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim_terminator
+sCacturneAnims_5_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, 1, 1, 1,
+ax_anim 6, 0, 173, 2, 2, 2, 2,
+ax_anim 1, 0, 174, -2, -2, -2, -2,
+ax_anim 6, 0, 175, -3, -3, -3, -3,
+ax_anim 1, 0, 176, -3, -3, -3, -3,
+ax_anim 1, 0, 177, -3, -3, -3, -3,
+ax_anim 1, 0, 178, -3, -3, -3, -3,
+ax_anim 1, 2, 179, -3, -3, -3, -3,
+ax_anim 4, 0, 175, -3, -3, -3, -3,
+ax_anim 2, 0, 174, -1, -1, -1, -1,
+ax_anim_terminator
+sCacturneAnims_5_7:
+ax_anim 2, 0, 181, 1, 0, 1, 0,
+ax_anim 2, 0, 181, 2, 0, 2, 0,
+ax_anim 6, 0, 181, 3, 0, 3, 0,
+ax_anim 1, 0, 182, -5, 0, -5, 0,
+ax_anim 6, 0, 183, -6, 0, -6, 0,
+ax_anim 1, 0, 184, -6, 0, -6, 0,
+ax_anim 1, 0, 185, -6, 0, -6, 0,
+ax_anim 1, 0, 186, -6, 0, -6, 0,
+ax_anim 1, 2, 187, -6, 0, -6, 0,
+ax_anim 4, 0, 183, -6, 0, -6, 0,
+ax_anim 2, 0, 182, -2, 0, -2, 0,
+ax_anim_terminator
+sCacturneAnims_5_8:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 2, -2, 2, -2,
+ax_anim 6, 0, 189, 3, -3, 3, -3,
+ax_anim 1, 0, 190, -2, 2, -2, 2,
+ax_anim 6, 0, 191, -3, 3, -3, 3,
+ax_anim 1, 0, 192, -3, 3, -3, 3,
+ax_anim 1, 0, 193, -3, 3, -3, 3,
+ax_anim 1, 0, 194, -3, 3, -3, 3,
+ax_anim 1, 2, 195, -3, 3, -3, 3,
+ax_anim 4, 0, 191, -3, 3, -3, 3,
+ax_anim 2, 0, 190, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCacturneAnims_6_1:
+ax_anim 30, 0, 196, 0, 0, 0, 0,
+ax_anim 35, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacturneAnims_7_1:
+ax_anim 2, 0, 198, 0, -3, 0, -3,
+ax_anim 8, 0, 198, 0, -4, 0, -4,
+ax_anim_terminator
+sCacturneAnims_7_2:
+ax_anim 2, 0, 199, -3, -3, -3, -3,
+ax_anim 8, 0, 199, -4, -4, -4, -4,
+ax_anim_terminator
+sCacturneAnims_7_3:
+ax_anim 2, 0, 200, -3, 0, -3, 0,
+ax_anim 8, 0, 200, -4, 0, -4, 0,
+ax_anim_terminator
+sCacturneAnims_7_4:
+ax_anim 2, 0, 201, -3, 3, -3, 3,
+ax_anim 8, 0, 201, -4, 4, -4, 4,
+ax_anim_terminator
+sCacturneAnims_7_5:
+ax_anim 2, 0, 202, 0, 3, 0, 3,
+ax_anim 8, 0, 202, 0, 4, 0, 4,
+ax_anim_terminator
+sCacturneAnims_7_6:
+ax_anim 2, 0, 203, 3, 3, 3, 3,
+ax_anim 8, 0, 203, 4, 4, 4, 4,
+ax_anim_terminator
+sCacturneAnims_7_7:
+ax_anim 2, 0, 204, 3, 0, 3, 0,
+ax_anim 8, 0, 204, 4, 0, 4, 0,
+ax_anim_terminator
+sCacturneAnims_7_8:
+ax_anim 2, 0, 205, 3, -3, 3, -3,
+ax_anim 8, 0, 205, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sCacturneAnims_8_1:
+ax_anim 40, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, -2, 0, 0,
+ax_anim 4, 0, 207, 0, -4, 0, 0,
+ax_anim 4, 0, 206, 0, -5, 0, 0,
+ax_anim 4, 0, 208, 0, -4, 0, 0,
+ax_anim 2, 0, 208, 0, -2, 0, 0,
+ax_anim_terminator
+sCacturneAnims_8_2:
+ax_anim 40, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, -2, 0, 0,
+ax_anim 4, 0, 210, 0, -4, 0, 0,
+ax_anim 4, 0, 209, 0, -5, 0, 0,
+ax_anim 4, 0, 211, 0, -4, 0, 0,
+ax_anim 2, 0, 211, 0, -2, 0, 0,
+ax_anim_terminator
+sCacturneAnims_8_3:
+ax_anim 40, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -2, 0, 0,
+ax_anim 4, 0, 213, 0, -4, 0, 0,
+ax_anim 4, 0, 212, 0, -5, 0, 0,
+ax_anim 4, 0, 214, 0, -4, 0, 0,
+ax_anim 2, 0, 214, 0, -2, 0, 0,
+ax_anim_terminator
+sCacturneAnims_8_4:
+ax_anim 40, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -2, 0, 0,
+ax_anim 4, 0, 216, 0, -4, 0, 0,
+ax_anim 4, 0, 215, 0, -5, 0, 0,
+ax_anim 4, 0, 217, 0, -4, 0, 0,
+ax_anim 2, 0, 217, 0, -2, 0, 0,
+ax_anim_terminator
+sCacturneAnims_8_5:
+ax_anim 40, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, -2, 0, 0,
+ax_anim 4, 0, 219, 0, -4, 0, 0,
+ax_anim 4, 0, 218, 0, -5, 0, 0,
+ax_anim 4, 0, 220, 0, -4, 0, 0,
+ax_anim 2, 0, 220, 0, -2, 0, 0,
+ax_anim_terminator
+sCacturneAnims_8_6:
+ax_anim 40, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, -2, 0, 0,
+ax_anim 4, 0, 222, 0, -4, 0, 0,
+ax_anim 4, 0, 221, 0, -5, 0, 0,
+ax_anim 4, 0, 223, 0, -4, 0, 0,
+ax_anim 2, 0, 223, 0, -2, 0, 0,
+ax_anim_terminator
+sCacturneAnims_8_7:
+ax_anim 40, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 4, 0, 225, 0, -4, 0, 0,
+ax_anim 4, 0, 224, 0, -5, 0, 0,
+ax_anim 4, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 226, 0, -2, 0, 0,
+ax_anim_terminator
+sCacturneAnims_8_8:
+ax_anim 40, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -2, 0, 0,
+ax_anim 4, 0, 228, 0, -4, 0, 0,
+ax_anim 4, 0, 227, 0, -5, 0, 0,
+ax_anim 4, 0, 229, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sCacturneAnims_9_1:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 6, 3, 6, 3,
+ax_anim 2, 0, 240, 10, 9, 10, 9,
+ax_anim 2, 0, 241, 7, 17, 7, 17,
+ax_anim 3, 0, 242, 0, 20, 0, 20,
+ax_anim 2, 3, 243, -7, 17, -7, 17,
+ax_anim 2, 0, 244, -9, 9, -9, 9,
+ax_anim 1, 0, 245, -6, 3, -6, 3,
+ax_anim 1, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_9_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 10, -1, 10, -1,
+ax_anim 2, 0, 239, 19, 5, 19, 5,
+ax_anim 2, 0, 240, 25, 10, 25, 10,
+ax_anim 3, 0, 241, 24, 19, 24, 19,
+ax_anim 2, 3, 242, 13, 20, 13, 20,
+ax_anim 2, 0, 243, 3, 15, 3, 15,
+ax_anim 1, 0, 244, 0, 7, 0, 7,
+ax_anim 1, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_9_3:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 245, 4, -5, 4, -5,
+ax_anim 2, 0, 238, 10, -8, 10, -8,
+ax_anim 2, 0, 239, 16, -5, 16, -5,
+ax_anim 3, 0, 240, 23, -2, 23, -2,
+ax_anim 2, 3, 241, 20, 4, 20, 4,
+ax_anim 2, 0, 242, 12, 6, 12, 6,
+ax_anim 1, 0, 243, 4, 5, 4, 5,
+ax_anim 1, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_9_4:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 244, 2, -10, 2, -10,
+ax_anim 2, 0, 245, 6, -16, 6, -16,
+ax_anim 2, 0, 238, 12, -20, 12, -20,
+ax_anim 3, 0, 239, 18, -18, 18, -18,
+ax_anim 2, 3, 240, 21, -13, 21, -13,
+ax_anim 2, 0, 241, 18, -6, 18, -6,
+ax_anim 1, 0, 242, 7, -1, 7, -1,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_9_5:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, -8, -4, -8, -4,
+ax_anim 2, 0, 244, -12, -13, -10, -13,
+ax_anim 2, 0, 245, -8, -17, -8, -20,
+ax_anim 3, 0, 238, 0, -20, 0, -24,
+ax_anim 2, 3, 239, 8, -17, 8, -20,
+ax_anim 2, 0, 240, 12, -11, 10, -11,
+ax_anim 1, 0, 241, 8, -4, 8, -4,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_9_6:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 240, -2, -10, -2, -10,
+ax_anim 2, 0, 239, -6, -16, -6, -16,
+ax_anim 2, 0, 238, -12, -20, -12, -20,
+ax_anim 3, 0, 245, -18, -18, -18, -18,
+ax_anim 2, 3, 244, -21, -13, -21, -13,
+ax_anim 2, 0, 243, -18, -6, -18, -6,
+ax_anim 1, 0, 242, -7, -1, -7, -1,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_9_7:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 239, -4, -5, -4, -5,
+ax_anim 2, 0, 238, -10, -8, -10, -8,
+ax_anim 2, 0, 245, -16, -5, -16, -5,
+ax_anim 3, 0, 244, -23, -2, -23, -2,
+ax_anim 2, 3, 243, -20, 4, -20, 4,
+ax_anim 2, 0, 242, -12, 6, -12, 6,
+ax_anim 1, 0, 241, -4, 5, -4, 5,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_9_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 245, -19, 5, -19, 5,
+ax_anim 2, 0, 244, -25, 10, -25, 10,
+ax_anim 3, 0, 243, -24, 19, -24, 19,
+ax_anim 2, 3, 242, -13, 20, -13, 20,
+ax_anim 2, 0, 241, -3, 15, -3, 15,
+ax_anim 1, 0, 240, 0, 7, 0, 7,
+ax_anim 1, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacturneAnims_10_1:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 3, 0, 246, 13, 0, 13, 0,
+ax_anim 3, 0, 246, -13, 0, -13, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_10_2:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 3, 0, 247, 13, -13, 13, -13,
+ax_anim 3, 0, 247, -13, 13, -13, 13,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_10_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 3, 0, 248, 0, -13, 0, -13,
+ax_anim 3, 0, 248, 0, 13, 0, 13,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_10_4:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 3, 0, 249, -13, -13, -13, -13,
+ax_anim 3, 0, 249, 13, 13, 13, 13,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_10_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 3, 0, 250, 13, 0, 13, 0,
+ax_anim 3, 0, 250, -13, 0, -13, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_10_6:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 3, 0, 251, 13, -13, 13, -13,
+ax_anim 3, 0, 251, -13, 13, -13, 13,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_10_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 3, 0, 252, 0, -13, 0, -13,
+ax_anim 3, 0, 252, 0, 13, 0, 13,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_10_8:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 3, 0, 253, -13, -13, -13, -13,
+ax_anim 3, 0, 253, 13, 13, 13, 13,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacturneAnims_11_1:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, -10, 0, 0,
+ax_anim 2, 0, 255, 0, -16, 0, 0,
+ax_anim 3, 0, 255, 0, -20, 0, 0,
+ax_anim 4, 0, 255, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 256, 0, -22, 0, 0,
+ax_anim 2, 0, 256, 0, -18, 0, 0,
+ax_anim 1, 0, 256, 0, -12, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_11_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -16, 0, 0,
+ax_anim 3, 0, 258, 0, -20, 0, 0,
+ax_anim 4, 0, 258, 0, -21, 0, 0,
+ax_anim 4, 0, 259, 0, -23, 0, 0,
+ax_anim 3, 0, 259, 0, -22, 0, 0,
+ax_anim 2, 0, 259, 0, -18, 0, 0,
+ax_anim 1, 0, 259, 0, -12, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_11_3:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 261, 0, -10, 0, 0,
+ax_anim 2, 0, 261, 0, -16, 0, 0,
+ax_anim 3, 0, 261, 0, -20, 0, 0,
+ax_anim 4, 0, 261, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -23, 0, 0,
+ax_anim 3, 0, 262, 0, -22, 0, 0,
+ax_anim 2, 0, 262, 0, -18, 0, 0,
+ax_anim 1, 0, 262, 0, -12, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_11_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 264, 0, -10, 0, 0,
+ax_anim 2, 0, 264, 0, -16, 0, 0,
+ax_anim 3, 0, 264, 0, -20, 0, 0,
+ax_anim 4, 0, 264, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -22, 0, 0,
+ax_anim 3, 0, 265, 0, -21, 0, 0,
+ax_anim 2, 0, 265, 0, -17, 0, 0,
+ax_anim 1, 0, 265, 0, -11, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_11_5:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 267, 0, -10, 0, 0,
+ax_anim 2, 0, 267, 0, -16, 0, 0,
+ax_anim 3, 0, 267, 0, -20, 0, 0,
+ax_anim 4, 0, 267, 0, -21, 0, 0,
+ax_anim 4, 0, 268, 0, -23, 0, 0,
+ax_anim 3, 0, 268, 0, -22, 0, 0,
+ax_anim 2, 0, 268, 0, -18, 0, 0,
+ax_anim 1, 0, 268, 0, -12, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_11_6:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 1, 0, 270, 0, -10, 0, 0,
+ax_anim 2, 0, 270, 0, -16, 0, 0,
+ax_anim 3, 0, 270, 0, -20, 0, 0,
+ax_anim 4, 0, 270, 0, -21, 0, 0,
+ax_anim 4, 0, 271, 0, -22, 0, 0,
+ax_anim 3, 0, 271, 0, -21, 0, 0,
+ax_anim 2, 0, 271, 0, -17, 0, 0,
+ax_anim 1, 0, 271, 0, -11, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_11_7:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 1, 0, 273, 0, -10, 0, 0,
+ax_anim 2, 0, 273, 0, -16, 0, 0,
+ax_anim 3, 0, 273, 0, -20, 0, 0,
+ax_anim 4, 0, 273, 0, -21, 0, 0,
+ax_anim 4, 0, 274, 0, -23, 0, 0,
+ax_anim 3, 0, 274, 0, -22, 0, 0,
+ax_anim 2, 0, 274, 0, -18, 0, 0,
+ax_anim 1, 0, 274, 0, -12, 0, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_11_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 1, 0, 276, 0, -10, 0, 0,
+ax_anim 2, 0, 276, 0, -16, 0, 0,
+ax_anim 3, 0, 276, 0, -20, 0, 0,
+ax_anim 4, 0, 276, 0, -21, 0, 0,
+ax_anim 4, 0, 277, 0, -23, 0, 0,
+ax_anim 3, 0, 277, 0, -22, 0, 0,
+ax_anim 2, 0, 277, 0, -18, 0, 0,
+ax_anim 1, 0, 277, 0, -12, 0, 0,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacturneAnims_12_1:
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 1, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_12_2:
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 1, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_12_3:
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 1, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_12_4:
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 1, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_12_5:
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 1, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_12_6:
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 1, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_12_7:
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 1, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_12_8:
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 1, 279, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCacturneAnims_13_1:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_13_2:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 2, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_13_3:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 2, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_13_4:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 2, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_13_5:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 2, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_13_6:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_13_7:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneAnims_13_8:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sCacturneGfx1:
+.incbin "baserom.gba", 0x138D6B4, 0x200
+sCacturneSprites1:
+ax_sprite sCacturneGfx1, 0x200
+ax_sprite_terminator
+sCacturneGfx2:
+.incbin "baserom.gba", 0x138D8C4, 0x200
+sCacturneSprites2:
+ax_sprite sCacturneGfx2, 0x200
+ax_sprite_terminator
+sCacturneGfx3:
+.incbin "baserom.gba", 0x138DAD4, 0x200
+sCacturneSprites3:
+ax_sprite sCacturneGfx3, 0x200
+ax_sprite_terminator
+sCacturneGfx4:
+.incbin "baserom.gba", 0x138DCE4, 0x200
+sCacturneSprites4:
+ax_sprite sCacturneGfx4, 0x200
+ax_sprite_terminator
+sCacturneGfx5:
+.incbin "baserom.gba", 0x138DEF4, 0x200
+sCacturneSprites5:
+ax_sprite sCacturneGfx5, 0x200
+ax_sprite_terminator
+sCacturneGfx6:
+.incbin "baserom.gba", 0x138E104, 0x200
+sCacturneSprites6:
+ax_sprite sCacturneGfx6, 0x200
+ax_sprite_terminator
+sCacturneGfx7:
+.incbin "baserom.gba", 0x138E314, 0x200
+sCacturneSprites7:
+ax_sprite sCacturneGfx7, 0x200
+ax_sprite_terminator
+sCacturneGfx8:
+.incbin "baserom.gba", 0x138E524, 0x200
+sCacturneSprites8:
+ax_sprite sCacturneGfx8, 0x200
+ax_sprite_terminator
+sCacturneGfx9:
+.incbin "baserom.gba", 0x138E734, 0x200
+sCacturneSprites9:
+ax_sprite sCacturneGfx9, 0x200
+ax_sprite_terminator
+sCacturneGfx10:
+.incbin "baserom.gba", 0x138E944, 0x200
+sCacturneSprites10:
+ax_sprite sCacturneGfx10, 0x200
+ax_sprite_terminator
+sCacturneGfx11:
+.incbin "baserom.gba", 0x138EB54, 0x200
+sCacturneSprites11:
+ax_sprite sCacturneGfx11, 0x200
+ax_sprite_terminator
+sCacturneGfx12:
+.incbin "baserom.gba", 0x138ED64, 0x200
+sCacturneSprites12:
+ax_sprite sCacturneGfx12, 0x200
+ax_sprite_terminator
+sCacturneGfx13:
+.incbin "baserom.gba", 0x138EF74, 0x200
+sCacturneSprites13:
+ax_sprite sCacturneGfx13, 0x200
+ax_sprite_terminator
+sCacturneGfx14:
+.incbin "baserom.gba", 0x138F184, 0x200
+sCacturneSprites14:
+ax_sprite sCacturneGfx14, 0x200
+ax_sprite_terminator
+sCacturneGfx15:
+.incbin "baserom.gba", 0x138F394, 0x200
+sCacturneSprites15:
+ax_sprite sCacturneGfx15, 0x200
+ax_sprite_terminator
+sCacturneGfx16:
+.incbin "baserom.gba", 0x138F5A4, 0x100
+sCacturneSprites16:
+ax_sprite sCacturneGfx16, 0x100
+ax_sprite_terminator
+sCacturneGfx17:
+.incbin "baserom.gba", 0x138F6B4, 0x80
+sCacturneSprites17:
+ax_sprite sCacturneGfx17, 0x80
+ax_sprite_terminator
+sCacturneGfx18:
+.incbin "baserom.gba", 0x138F744, 0x40
+sCacturneSprites18:
+ax_sprite sCacturneGfx18, 0x40
+ax_sprite_terminator
+sCacturneGfx19:
+.incbin "baserom.gba", 0x138F794, 0x20
+sCacturneSprites19:
+ax_sprite sCacturneGfx19, 0x20
+ax_sprite_terminator
+sCacturneGfx20:
+.incbin "baserom.gba", 0x138F7C4, 0x60
+sCacturneGfx20_1:
+.incbin "baserom.gba", 0x138F824, 0x80
+sCacturneGfx20_2:
+.incbin "baserom.gba", 0x138F8A4, 0x60
+sCacturneGfx20_3:
+.incbin "baserom.gba", 0x138F904, 0x60
+sCacturneSprites20:
+ax_sprite sCacturneGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx20_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx20_3, 0x60
+ax_sprite_terminator
+sCacturneGfx21:
+.incbin "baserom.gba", 0x138F9A4, 0x100
+sCacturneGfx21_1:
+.incbin "baserom.gba", 0x138FAA4, 0x40
+sCacturneGfx21_2:
+.incbin "baserom.gba", 0x138FAE4, 0x60
+sCacturneSprites21:
+ax_sprite sCacturneGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCacturneGfx21_2, 0x60
+ax_sprite_terminator
+sCacturneGfx22:
+.incbin "baserom.gba", 0x138FB74, 0x60
+sCacturneGfx22_1:
+.incbin "baserom.gba", 0x138FBD4, 0x60
+sCacturneSprites22:
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx22_1, 0x60
+ax_sprite_terminator
+sCacturneGfx23:
+.incbin "baserom.gba", 0x138FC5C, 0x80
+sCacturneSprites23:
+ax_sprite sCacturneGfx23, 0x80
+ax_sprite_terminator
+sCacturneGfx24:
+.incbin "baserom.gba", 0x138FCEC, 0x40
+sCacturneSprites24:
+ax_sprite sCacturneGfx24, 0x40
+ax_sprite_terminator
+sCacturneGfx25:
+.incbin "baserom.gba", 0x138FD3C, 0x40
+sCacturneSprites25:
+ax_sprite sCacturneGfx25, 0x40
+ax_sprite_terminator
+sCacturneGfx26:
+.incbin "baserom.gba", 0x138FD8C, 0x160
+sCacturneGfx26_1:
+.incbin "baserom.gba", 0x138FEEC, 0x40
+sCacturneSprites26:
+ax_sprite sCacturneGfx26, 0x160
+ax_sprite 0, 0x40
+ax_sprite sCacturneGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCacturneGfx27:
+.incbin "baserom.gba", 0x138FF54, 0x180
+sCacturneGfx27_1:
+.incbin "baserom.gba", 0x13900D4, 0x60
+sCacturneSprites27:
+ax_sprite sCacturneGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx27_1, 0x60
+ax_sprite_terminator
+sCacturneGfx28:
+.incbin "baserom.gba", 0x1390154, 0x40
+sCacturneSprites28:
+ax_sprite sCacturneGfx28, 0x40
+ax_sprite_terminator
+sCacturneGfx29:
+.incbin "baserom.gba", 0x13901A4, 0x180
+sCacturneGfx29_1:
+.incbin "baserom.gba", 0x1390324, 0x60
+sCacturneSprites29:
+ax_sprite sCacturneGfx29, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx29_1, 0x60
+ax_sprite_terminator
+sCacturneGfx30:
+.incbin "baserom.gba", 0x13903A4, 0x100
+sCacturneGfx30_1:
+.incbin "baserom.gba", 0x13904A4, 0x60
+sCacturneGfx30_2:
+.incbin "baserom.gba", 0x1390504, 0x60
+sCacturneSprites30:
+ax_sprite sCacturneGfx30, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx30_2, 0x60
+ax_sprite_terminator
+sCacturneGfx31:
+.incbin "baserom.gba", 0x1390594, 0x20
+sCacturneSprites31:
+ax_sprite sCacturneGfx31, 0x20
+ax_sprite_terminator
+sCacturneGfx32:
+.incbin "baserom.gba", 0x13905C4, 0x20
+sCacturneSprites32:
+ax_sprite sCacturneGfx32, 0x20
+ax_sprite_terminator
+sCacturneGfx33:
+.incbin "baserom.gba", 0x13905F4, 0x100
+sCacturneSprites33:
+ax_sprite sCacturneGfx33, 0x100
+ax_sprite_terminator
+sCacturneGfx34:
+.incbin "baserom.gba", 0x1390704, 0x80
+sCacturneSprites34:
+ax_sprite sCacturneGfx34, 0x80
+ax_sprite_terminator
+sCacturneGfx35:
+.incbin "baserom.gba", 0x1390794, 0x40
+sCacturneSprites35:
+ax_sprite sCacturneGfx35, 0x40
+ax_sprite_terminator
+sCacturneGfx36:
+.incbin "baserom.gba", 0x13907E4, 0x20
+sCacturneSprites36:
+ax_sprite sCacturneGfx36, 0x20
+ax_sprite_terminator
+sCacturneGfx37:
+.incbin "baserom.gba", 0x1390814, 0x60
+sCacturneGfx37_1:
+.incbin "baserom.gba", 0x1390874, 0x100
+sCacturneGfx37_2:
+.incbin "baserom.gba", 0x1390974, 0x60
+sCacturneSprites37:
+ax_sprite sCacturneGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx37_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx37_2, 0x60
+ax_sprite_terminator
+sCacturneGfx38:
+.incbin "baserom.gba", 0x1390A04, 0x40
+sCacturneGfx38_1:
+.incbin "baserom.gba", 0x1390A44, 0x100
+sCacturneGfx38_2:
+.incbin "baserom.gba", 0x1390B44, 0x60
+sCacturneSprites38:
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx38_2, 0x60
+ax_sprite_terminator
+sCacturneGfx39:
+.incbin "baserom.gba", 0x1390BDC, 0x60
+sCacturneGfx39_1:
+.incbin "baserom.gba", 0x1390C3C, 0x100
+sCacturneGfx39_2:
+.incbin "baserom.gba", 0x1390D3C, 0x60
+sCacturneSprites39:
+ax_sprite sCacturneGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx39_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx39_2, 0x60
+ax_sprite_terminator
+sCacturneGfx40:
+.incbin "baserom.gba", 0x1390DCC, 0x60
+sCacturneGfx40_1:
+.incbin "baserom.gba", 0x1390E2C, 0x100
+sCacturneGfx40_2:
+.incbin "baserom.gba", 0x1390F2C, 0x40
+sCacturneSprites40:
+ax_sprite sCacturneGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx40_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx40_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCacturneGfx41:
+.incbin "baserom.gba", 0x1390FA4, 0x160
+sCacturneGfx41_1:
+.incbin "baserom.gba", 0x1391104, 0x60
+sCacturneSprites41:
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx41, 0x160
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx41_1, 0x60
+ax_sprite_terminator
+sCacturneGfx42:
+.incbin "baserom.gba", 0x139118C, 0xE0
+sCacturneGfx42_1:
+.incbin "baserom.gba", 0x139126C, 0x60
+sCacturneGfx42_2:
+.incbin "baserom.gba", 0x13912CC, 0x60
+sCacturneSprites42:
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx42, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCacturneGfx42_2, 0x60
+ax_sprite_terminator
+sCacturneGfx43:
+.incbin "baserom.gba", 0x1391364, 0x40
+sCacturneSprites43:
+ax_sprite sCacturneGfx43, 0x40
+ax_sprite_terminator
+sCacturneGfx44:
+.incbin "baserom.gba", 0x13913B4, 0x20
+sCacturneSprites44:
+ax_sprite sCacturneGfx44, 0x20
+ax_sprite_terminator
+sCacturneGfx45:
+.incbin "baserom.gba", 0x13913E4, 0x20
+sCacturneSprites45:
+ax_sprite sCacturneGfx45, 0x20
+ax_sprite_terminator
+sCacturneGfx46:
+.incbin "baserom.gba", 0x1391414, 0x80
+sCacturneSprites46:
+ax_sprite sCacturneGfx46, 0x80
+ax_sprite_terminator
+sCacturneGfx47:
+.incbin "baserom.gba", 0x13914A4, 0x80
+sCacturneSprites47:
+ax_sprite sCacturneGfx47, 0x80
+ax_sprite_terminator
+sCacturneGfx48:
+.incbin "baserom.gba", 0x1391534, 0x80
+sCacturneSprites48:
+ax_sprite sCacturneGfx48, 0x80
+ax_sprite_terminator
+sCacturneGfx49:
+.incbin "baserom.gba", 0x13915C4, 0x80
+sCacturneSprites49:
+ax_sprite sCacturneGfx49, 0x80
+ax_sprite_terminator
+sCacturneGfx50:
+.incbin "baserom.gba", 0x1391654, 0x200
+sCacturneSprites50:
+ax_sprite sCacturneGfx50, 0x200
+ax_sprite_terminator
+sCacturneGfx51:
+.incbin "baserom.gba", 0x1391864, 0x200
+sCacturneSprites51:
+ax_sprite sCacturneGfx51, 0x200
+ax_sprite_terminator
+sCacturneGfx52:
+.incbin "baserom.gba", 0x1391A74, 0x200
+sCacturneSprites52:
+ax_sprite sCacturneGfx52, 0x200
+ax_sprite_terminator
+sCacturneGfx53:
+.incbin "baserom.gba", 0x1391C84, 0x200
+sCacturneSprites53:
+ax_sprite sCacturneGfx53, 0x200
+ax_sprite_terminator
+sCacturneGfx54:
+.incbin "baserom.gba", 0x1391E94, 0x200
+sCacturneSprites54:
+ax_sprite sCacturneGfx54, 0x200
+ax_sprite_terminator
+sCacturneGfx55:
+.incbin "baserom.gba", 0x13920A4, 0x200
+sCacturneSprites55:
+ax_sprite sCacturneGfx55, 0x200
+ax_sprite_terminator
+sCacturneGfx56:
+.incbin "baserom.gba", 0x13922B4, 0x200
+sCacturneSprites56:
+ax_sprite sCacturneGfx56, 0x200
+ax_sprite_terminator
+sAxPosesCacturne:
+.4byte sCacturnePose1
+.4byte sCacturnePose2
+.4byte sCacturnePose3
+.4byte sCacturnePose4
+.4byte sCacturnePose5
+.4byte sCacturnePose6
+.4byte sCacturnePose7
+.4byte sCacturnePose8
+.4byte sCacturnePose9
+.4byte sCacturnePose10
+.4byte sCacturnePose11
+.4byte sCacturnePose12
+.4byte sCacturnePose13
+.4byte sCacturnePose14
+.4byte sCacturnePose15
+.4byte sCacturnePose16
+.4byte sCacturnePose17
+.4byte sCacturnePose18
+.4byte sCacturnePose19
+.4byte sCacturnePose20
+.4byte sCacturnePose21
+.4byte sCacturnePose22
+.4byte sCacturnePose23
+.4byte sCacturnePose24
+.4byte sCacturnePose25
+.4byte sCacturnePose26
+.4byte sCacturnePose27
+.4byte sCacturnePose28
+.4byte sCacturnePose29
+.4byte sCacturnePose30
+.4byte sCacturnePose31
+.4byte sCacturnePose32
+.4byte sCacturnePose33
+.4byte sCacturnePose34
+.4byte sCacturnePose35
+.4byte sCacturnePose36
+.4byte sCacturnePose37
+.4byte sCacturnePose38
+.4byte sCacturnePose39
+.4byte sCacturnePose40
+.4byte sCacturnePose41
+.4byte sCacturnePose42
+.4byte sCacturnePose43
+.4byte sCacturnePose44
+.4byte sCacturnePose45
+.4byte sCacturnePose46
+.4byte sCacturnePose47
+.4byte sCacturnePose48
+.4byte sCacturnePose49
+.4byte sCacturnePose50
+.4byte sCacturnePose51
+.4byte sCacturnePose52
+.4byte sCacturnePose53
+.4byte sCacturnePose54
+.4byte sCacturnePose55
+.4byte sCacturnePose56
+.4byte sCacturnePose57
+.4byte sCacturnePose58
+.4byte sCacturnePose59
+.4byte sCacturnePose60
+.4byte sCacturnePose61
+.4byte sCacturnePose62
+.4byte sCacturnePose63
+.4byte sCacturnePose64
+.4byte sCacturnePose65
+.4byte sCacturnePose66
+.4byte sCacturnePose67
+.4byte sCacturnePose68
+.4byte sCacturnePose69
+.4byte sCacturnePose70
+.4byte sCacturnePose71
+.4byte sCacturnePose72
+.4byte sCacturnePose73
+.4byte sCacturnePose74
+.4byte sCacturnePose75
+.4byte sCacturnePose76
+.4byte sCacturnePose77
+.4byte sCacturnePose78
+.4byte sCacturnePose79
+.4byte sCacturnePose80
+.4byte sCacturnePose81
+.4byte sCacturnePose82
+.4byte sCacturnePose83
+.4byte sCacturnePose84
+.4byte sCacturnePose85
+.4byte sCacturnePose86
+.4byte sCacturnePose87
+.4byte sCacturnePose88
+.4byte sCacturnePose89
+.4byte sCacturnePose90
+.4byte sCacturnePose91
+.4byte sCacturnePose92
+.4byte sCacturnePose93
+.4byte sCacturnePose94
+.4byte sCacturnePose95
+.4byte sCacturnePose96
+.4byte sCacturnePose97
+.4byte sCacturnePose98
+.4byte sCacturnePose99
+.4byte sCacturnePose100
+.4byte sCacturnePose101
+.4byte sCacturnePose102
+.4byte sCacturnePose103
+.4byte sCacturnePose104
+.4byte sCacturnePose105
+.4byte sCacturnePose106
+.4byte sCacturnePose107
+.4byte sCacturnePose108
+.4byte sCacturnePose109
+.4byte sCacturnePose110
+.4byte sCacturnePose111
+.4byte sCacturnePose112
+.4byte sCacturnePose113
+.4byte sCacturnePose114
+.4byte sCacturnePose115
+.4byte sCacturnePose116
+.4byte sCacturnePose117
+.4byte sCacturnePose118
+.4byte sCacturnePose119
+.4byte sCacturnePose120
+.4byte sCacturnePose121
+.4byte sCacturnePose122
+.4byte sCacturnePose123
+.4byte sCacturnePose124
+.4byte sCacturnePose125
+.4byte sCacturnePose126
+.4byte sCacturnePose127
+.4byte sCacturnePose128
+.4byte sCacturnePose129
+.4byte sCacturnePose130
+.4byte sCacturnePose131
+.4byte sCacturnePose132
+.4byte sCacturnePose133
+.4byte sCacturnePose134
+.4byte sCacturnePose135
+.4byte sCacturnePose136
+.4byte sCacturnePose137
+.4byte sCacturnePose138
+.4byte sCacturnePose139
+.4byte sCacturnePose140
+.4byte sCacturnePose141
+.4byte sCacturnePose142
+.4byte sCacturnePose143
+.4byte sCacturnePose144
+.4byte sCacturnePose145
+.4byte sCacturnePose146
+.4byte sCacturnePose147
+.4byte sCacturnePose148
+.4byte sCacturnePose149
+.4byte sCacturnePose150
+.4byte sCacturnePose151
+.4byte sCacturnePose152
+.4byte sCacturnePose153
+.4byte sCacturnePose154
+.4byte sCacturnePose155
+.4byte sCacturnePose156
+.4byte sCacturnePose157
+.4byte sCacturnePose158
+.4byte sCacturnePose159
+.4byte sCacturnePose160
+.4byte sCacturnePose161
+.4byte sCacturnePose162
+.4byte sCacturnePose163
+.4byte sCacturnePose164
+.4byte sCacturnePose165
+.4byte sCacturnePose166
+.4byte sCacturnePose167
+.4byte sCacturnePose168
+.4byte sCacturnePose169
+.4byte sCacturnePose170
+.4byte sCacturnePose171
+.4byte sCacturnePose172
+.4byte sCacturnePose173
+.4byte sCacturnePose174
+.4byte sCacturnePose175
+.4byte sCacturnePose176
+.4byte sCacturnePose177
+.4byte sCacturnePose178
+.4byte sCacturnePose179
+.4byte sCacturnePose180
+.4byte sCacturnePose181
+.4byte sCacturnePose182
+.4byte sCacturnePose183
+.4byte sCacturnePose184
+.4byte sCacturnePose185
+.4byte sCacturnePose186
+.4byte sCacturnePose187
+.4byte sCacturnePose188
+.4byte sCacturnePose189
+.4byte sCacturnePose190
+.4byte sCacturnePose191
+.4byte sCacturnePose192
+.4byte sCacturnePose193
+.4byte sCacturnePose194
+.4byte sCacturnePose195
+.4byte sCacturnePose196
+.4byte sCacturnePose197
+.4byte sCacturnePose198
+.4byte sCacturnePose199
+.4byte sCacturnePose200
+.4byte sCacturnePose201
+.4byte sCacturnePose202
+.4byte sCacturnePose203
+.4byte sCacturnePose204
+.4byte sCacturnePose205
+.4byte sCacturnePose206
+.4byte sCacturnePose207
+.4byte sCacturnePose208
+.4byte sCacturnePose209
+.4byte sCacturnePose210
+.4byte sCacturnePose211
+.4byte sCacturnePose212
+.4byte sCacturnePose213
+.4byte sCacturnePose214
+.4byte sCacturnePose215
+.4byte sCacturnePose216
+.4byte sCacturnePose217
+.4byte sCacturnePose218
+.4byte sCacturnePose219
+.4byte sCacturnePose220
+.4byte sCacturnePose221
+.4byte sCacturnePose222
+.4byte sCacturnePose223
+.4byte sCacturnePose224
+.4byte sCacturnePose225
+.4byte sCacturnePose226
+.4byte sCacturnePose227
+.4byte sCacturnePose228
+.4byte sCacturnePose229
+.4byte sCacturnePose230
+.4byte sCacturnePose231
+.4byte sCacturnePose232
+.4byte sCacturnePose233
+.4byte sCacturnePose234
+.4byte sCacturnePose235
+.4byte sCacturnePose236
+.4byte sCacturnePose237
+.4byte sCacturnePose238
+.4byte sCacturnePose239
+.4byte sCacturnePose240
+.4byte sCacturnePose241
+.4byte sCacturnePose242
+.4byte sCacturnePose243
+.4byte sCacturnePose244
+.4byte sCacturnePose245
+.4byte sCacturnePose246
+.4byte sCacturnePose247
+.4byte sCacturnePose248
+.4byte sCacturnePose249
+.4byte sCacturnePose250
+.4byte sCacturnePose251
+.4byte sCacturnePose252
+.4byte sCacturnePose253
+.4byte sCacturnePose254
+.4byte sCacturnePose255
+.4byte sCacturnePose256
+.4byte sCacturnePose257
+.4byte sCacturnePose258
+.4byte sCacturnePose259
+.4byte sCacturnePose260
+.4byte sCacturnePose261
+.4byte sCacturnePose262
+.4byte sCacturnePose263
+.4byte sCacturnePose264
+.4byte sCacturnePose265
+.4byte sCacturnePose266
+.4byte sCacturnePose267
+.4byte sCacturnePose268
+.4byte sCacturnePose269
+.4byte sCacturnePose270
+.4byte sCacturnePose271
+.4byte sCacturnePose272
+.4byte sCacturnePose273
+.4byte sCacturnePose274
+.4byte sCacturnePose275
+.4byte sCacturnePose276
+.4byte sCacturnePose277
+.4byte sCacturnePose278
+.4byte sCacturnePose279
+.4byte sCacturnePose280
+.4byte sCacturnePose281
+.4byte sCacturnePose282
+.4byte sCacturnePose283
+.4byte sCacturnePose284
+.4byte sCacturnePose285
+.4byte sCacturnePose286
+.4byte sCacturnePose287
+.4byte sCacturnePose288
+.4byte sCacturnePose289
+.4byte sCacturnePose290
+.4byte sCacturnePose291
+.4byte sCacturnePose292
+.4byte sCacturnePose293
+.4byte sCacturnePose294
+sAxPositionsCacturne:
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -2,  -14, 	 -11,   -7, 	  11,  -10, 	  -1,   -9
+.2byte    0,  -14, 	 -12,  -11, 	  10,   -6, 	  -1,   -9
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte    1,  -15, 	   9,   -9, 	 -12,   -9, 	  -2,   -8
+.2byte    3,  -15, 	   5,  -13, 	  -8,   -5, 	  -1,   -8
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    4,  -16, 	   7,  -12, 	  -5,   -5, 	   0,   -8
+.2byte    2,  -16, 	  -5,   -8, 	   0,   -5, 	  -3,   -7
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    3,  -17, 	  -6,  -14, 	   7,   -5, 	  -2,   -8
+.2byte    1,  -17, 	 -10,  -11, 	   9,   -9, 	  -2,   -9
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte   -2,  -15, 	  10,   -7, 	 -12,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  10,  -11, 	 -12,   -7, 	  -1,   -9
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -5,  -17, 	   4,  -14, 	  -9,   -5, 	   0,   -8
+.2byte   -3,  -17, 	   8,  -11, 	 -11,   -9, 	   0,   -9
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -6,  -16, 	  -9,  -12, 	   3,   -5, 	  -2,   -8
+.2byte   -4,  -16, 	   3,   -8, 	  -2,   -5, 	   1,   -7
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -3,  -15, 	 -11,   -9, 	  10,   -9, 	   0,   -8
+.2byte   -5,  -15, 	  -7,  -13, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -2,  -14, 	 -11,   -7, 	  11,  -10, 	  -1,   -9
+.2byte    0,  -14, 	 -12,  -11, 	  10,   -6, 	  -1,   -9
+.2byte   -1,  -12, 	 -15,  -15, 	  13,  -15, 	  -1,   -8
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte    1,  -15, 	   9,   -9, 	 -12,   -9, 	  -2,   -8
+.2byte    3,  -15, 	   5,  -13, 	  -8,   -5, 	  -1,   -8
+.2byte    6,  -15, 	  12,  -21, 	 -10,  -10, 	   2,   -9
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    4,  -16, 	   7,  -12, 	  -5,   -5, 	   0,   -8
+.2byte    2,  -16, 	  -5,   -8, 	   0,   -5, 	  -3,   -7
+.2byte    6,  -16, 	   2,  -26, 	   5,  -10, 	   0,   -8
+.2byte    7,  -18, 	   1,  -30, 	   6,  -11, 	  -2,  -10
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    3,  -17, 	  -6,  -14, 	   7,   -5, 	  -2,   -8
+.2byte    1,  -17, 	 -10,  -11, 	   9,   -9, 	  -2,   -9
+.2byte    5,  -16, 	  -8,  -21, 	  13,  -12, 	  -1,   -9
+.2byte    4,  -18, 	 -10,  -23, 	  14,  -14, 	  -2,  -10
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte   -2,  -15, 	  10,   -7, 	 -12,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  10,  -11, 	 -12,   -7, 	  -1,   -9
+.2byte   -1,  -17, 	  11,  -17, 	 -13,  -18, 	  -1,  -10
+.2byte   -1,  -22, 	  12,  -20, 	 -15,  -19, 	  -1,  -10
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -5,  -17, 	   4,  -14, 	  -9,   -5, 	   0,   -8
+.2byte   -3,  -17, 	   8,  -11, 	 -11,   -9, 	   0,   -9
+.2byte   -7,  -16, 	   6,  -21, 	 -15,  -12, 	  -1,   -9
+.2byte   -6,  -18, 	   8,  -23, 	 -16,  -14, 	   0,  -10
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -6,  -16, 	  -9,  -12, 	   3,   -5, 	  -2,   -8
+.2byte   -4,  -16, 	   3,   -8, 	  -2,   -5, 	   1,   -7
+.2byte   -8,  -16, 	  -4,  -26, 	  -7,  -10, 	  -2,   -8
+.2byte   -9,  -18, 	  -3,  -30, 	  -8,  -11, 	   0,  -10
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -3,  -15, 	 -11,   -9, 	  10,   -9, 	   0,   -8
+.2byte   -5,  -15, 	  -7,  -13, 	   6,   -5, 	  -1,   -8
+.2byte   -8,  -15, 	 -14,  -21, 	   8,  -10, 	  -4,   -9
+.2byte   -8,  -16, 	 -16,  -24, 	   9,  -11, 	  -4,  -10
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -2,  -14, 	 -11,   -7, 	  11,  -10, 	  -1,   -9
+.2byte    0,  -14, 	 -12,  -11, 	  10,   -6, 	  -1,   -9
+.2byte   -1,  -12, 	 -15,  -15, 	  13,  -15, 	  -1,   -8
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte    1,  -15, 	   9,   -9, 	 -12,   -9, 	  -2,   -8
+.2byte    3,  -15, 	   5,  -13, 	  -8,   -5, 	  -1,   -8
+.2byte    6,  -15, 	  12,  -21, 	 -10,  -10, 	   2,   -9
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    4,  -16, 	   7,  -12, 	  -5,   -5, 	   0,   -8
+.2byte    2,  -16, 	  -5,   -8, 	   0,   -5, 	  -3,   -7
+.2byte    6,  -16, 	   2,  -26, 	   5,  -10, 	   0,   -8
+.2byte    7,  -18, 	   1,  -30, 	   6,  -11, 	  -2,  -10
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    3,  -17, 	  -6,  -14, 	   7,   -5, 	  -2,   -8
+.2byte    1,  -17, 	 -10,  -11, 	   9,   -9, 	  -2,   -9
+.2byte    5,  -16, 	  -8,  -21, 	  13,  -12, 	  -1,   -9
+.2byte    4,  -18, 	 -10,  -23, 	  14,  -14, 	  -2,  -10
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte   -2,  -15, 	  10,   -7, 	 -12,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  10,  -11, 	 -12,   -7, 	  -1,   -9
+.2byte   -1,  -17, 	  11,  -17, 	 -13,  -18, 	  -1,  -10
+.2byte   -1,  -22, 	  12,  -20, 	 -15,  -19, 	  -1,  -10
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -5,  -17, 	   4,  -14, 	  -9,   -5, 	   0,   -8
+.2byte   -3,  -17, 	   8,  -11, 	 -11,   -9, 	   0,   -9
+.2byte   -7,  -16, 	   6,  -21, 	 -15,  -12, 	  -1,   -9
+.2byte   -6,  -18, 	   8,  -23, 	 -16,  -14, 	   0,  -10
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -6,  -16, 	  -9,  -12, 	   3,   -5, 	  -2,   -8
+.2byte   -4,  -16, 	   3,   -8, 	  -2,   -5, 	   1,   -7
+.2byte   -8,  -16, 	  -4,  -26, 	  -7,  -10, 	  -2,   -8
+.2byte   -9,  -18, 	  -3,  -30, 	  -8,  -11, 	   0,  -10
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -3,  -15, 	 -11,   -9, 	  10,   -9, 	   0,   -8
+.2byte   -5,  -15, 	  -7,  -13, 	   6,   -5, 	  -1,   -8
+.2byte   -8,  -15, 	 -14,  -21, 	   8,  -10, 	  -4,   -9
+.2byte   -8,  -16, 	 -16,  -24, 	   9,  -11, 	  -4,  -10
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -3,  -10, 	  -9,   -8, 	   7,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	 -15,  -15, 	  13,  -15, 	  -1,   -8
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte    4,  -12, 	   8,  -10, 	  -4,   -5, 	  -1,   -8
+.2byte    6,  -15, 	  12,  -21, 	 -10,  -10, 	   2,   -9
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    3,  -14, 	  -5,  -13, 	   3,   -5, 	  -4,   -8
+.2byte    6,  -16, 	   2,  -26, 	   5,  -10, 	   0,   -8
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    2,  -16, 	  -4,  -13, 	   8,   -8, 	  -2,   -8
+.2byte    5,  -16, 	  -8,  -21, 	  13,  -12, 	  -1,   -9
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte    2,  -15, 	  10,  -12, 	  -9,  -12, 	   0,   -9
+.2byte   -1,  -17, 	  11,  -17, 	 -13,  -18, 	  -1,  -10
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -4,  -16, 	   2,  -13, 	 -10,   -8, 	   0,   -8
+.2byte   -7,  -16, 	   6,  -21, 	 -15,  -12, 	  -1,   -9
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -4,  -14, 	   4,  -13, 	  -4,   -5, 	   3,   -8
+.2byte   -8,  -16, 	  -4,  -26, 	  -7,  -10, 	  -2,   -8
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -6,  -12, 	 -10,  -10, 	   2,   -5, 	  -1,   -8
+.2byte   -8,  -15, 	 -14,  -21, 	   8,  -10, 	  -4,   -9
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -3,  -10, 	  -9,   -8, 	   7,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	 -15,  -15, 	  13,  -15, 	  -1,   -8
+.2byte   -1,  -13, 	 -18,  -17, 	  16,  -17, 	  -1,   -9
+.2byte   -1,  -13, 	 -18,  -17, 	  16,  -17, 	  -1,   -9
+.2byte   -1,  -13, 	 -18,  -17, 	  16,  -17, 	  -1,   -9
+.2byte   -1,  -13, 	 -18,  -17, 	  16,  -17, 	  -1,   -9
+.2byte   -1,  -13, 	 -18,  -17, 	  16,  -17, 	  -1,   -9
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte    4,  -12, 	   8,  -10, 	  -4,   -5, 	  -1,   -8
+.2byte    6,  -15, 	  12,  -21, 	 -10,  -10, 	   2,   -9
+.2byte    6,  -16, 	  14,  -24, 	 -11,  -11, 	   2,  -10
+.2byte    6,  -16, 	  14,  -24, 	 -11,  -11, 	   2,  -10
+.2byte    6,  -16, 	  14,  -24, 	 -11,  -11, 	   2,  -10
+.2byte    6,  -16, 	  14,  -24, 	 -11,  -11, 	   2,  -10
+.2byte    6,  -16, 	  14,  -24, 	 -11,  -11, 	   2,  -10
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    4,  -14, 	  -4,  -13, 	   4,   -5, 	  -3,   -8
+.2byte    6,  -16, 	   2,  -26, 	   5,  -10, 	   0,   -8
+.2byte    7,  -18, 	   1,  -30, 	   6,  -11, 	  -2,  -10
+.2byte    7,  -18, 	   1,  -30, 	   6,  -11, 	  -2,  -10
+.2byte    7,  -18, 	   1,  -30, 	   6,  -11, 	  -2,  -10
+.2byte    7,  -18, 	   1,  -30, 	   6,  -11, 	  -2,  -10
+.2byte    7,  -18, 	   1,  -30, 	   6,  -11, 	  -2,  -10
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    2,  -16, 	  -4,  -13, 	   8,   -8, 	  -2,   -8
+.2byte    5,  -16, 	  -8,  -21, 	  13,  -12, 	  -1,   -9
+.2byte    4,  -18, 	 -10,  -23, 	  14,  -14, 	  -2,  -10
+.2byte    4,  -18, 	 -10,  -23, 	  14,  -14, 	  -2,  -10
+.2byte    4,  -18, 	 -10,  -23, 	  14,  -14, 	  -2,  -10
+.2byte    4,  -18, 	 -10,  -23, 	  14,  -14, 	  -2,  -10
+.2byte    4,  -18, 	 -10,  -23, 	  14,  -14, 	  -2,  -10
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte    2,  -15, 	  10,  -12, 	  -9,  -12, 	   0,   -9
+.2byte   -1,  -17, 	  11,  -17, 	 -13,  -18, 	  -1,  -10
+.2byte   -1,  -22, 	  12,  -20, 	 -15,  -19, 	  -1,  -10
+.2byte   -1,  -22, 	  12,  -20, 	 -15,  -19, 	  -1,  -10
+.2byte   -1,  -22, 	  12,  -20, 	 -15,  -19, 	  -1,  -10
+.2byte   -1,  -22, 	  12,  -20, 	 -15,  -19, 	  -1,  -10
+.2byte   -1,  -22, 	  12,  -20, 	 -15,  -19, 	  -1,  -10
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -4,  -16, 	   2,  -13, 	 -10,   -8, 	   0,   -8
+.2byte   -7,  -16, 	   6,  -21, 	 -15,  -12, 	  -1,   -9
+.2byte   -6,  -18, 	   8,  -23, 	 -16,  -14, 	   0,  -10
+.2byte   -6,  -18, 	   8,  -23, 	 -16,  -14, 	   0,  -10
+.2byte   -6,  -18, 	   8,  -23, 	 -16,  -14, 	   0,  -10
+.2byte   -6,  -18, 	   8,  -23, 	 -16,  -14, 	   0,  -10
+.2byte   -6,  -18, 	   8,  -23, 	 -16,  -14, 	   0,  -10
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -6,  -14, 	   2,  -13, 	  -6,   -5, 	   1,   -8
+.2byte   -8,  -16, 	  -4,  -26, 	  -7,  -10, 	  -2,   -8
+.2byte   -9,  -18, 	  -3,  -30, 	  -8,  -11, 	   0,  -10
+.2byte   -9,  -18, 	  -3,  -30, 	  -8,  -11, 	   0,  -10
+.2byte   -9,  -18, 	  -3,  -30, 	  -8,  -11, 	   0,  -10
+.2byte   -9,  -18, 	  -3,  -30, 	  -8,  -11, 	   0,  -10
+.2byte   -9,  -18, 	  -3,  -30, 	  -8,  -11, 	   0,  -10
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -6,  -12, 	 -10,  -10, 	   2,   -5, 	  -1,   -8
+.2byte   -8,  -15, 	 -14,  -21, 	   8,  -10, 	  -4,   -9
+.2byte   -8,  -16, 	 -16,  -24, 	   9,  -11, 	  -4,  -10
+.2byte   -8,  -16, 	 -16,  -24, 	   9,  -11, 	  -4,  -10
+.2byte   -8,  -16, 	 -16,  -24, 	   9,  -11, 	  -4,  -10
+.2byte   -8,  -16, 	 -16,  -24, 	   9,  -11, 	  -4,  -10
+.2byte   -8,  -16, 	 -16,  -24, 	   9,  -11, 	  -4,  -10
+.2byte    6,   -8, 	  -3,   -9, 	   7,    3, 	   1,   -4
+.2byte    6,   -7, 	  -3,   -8, 	   7,    3, 	   1,   -3
+.2byte    0,  -16, 	  -3,  -21, 	  12,  -23, 	   0,  -12
+.2byte   -4,  -14, 	  -1,  -21, 	 -17,  -15, 	  -3,  -10
+.2byte   -1,  -15, 	   4,  -19, 	 -13,  -21, 	  -2,   -9
+.2byte   -1,  -14, 	  -2,  -19, 	   7,  -15, 	  -5,   -9
+.2byte    0,  -16, 	   3,  -20, 	 -10,  -17, 	   0,   -9
+.2byte    0,  -14, 	   1,  -19, 	  -8,  -15, 	   4,   -9
+.2byte    0,  -14, 	  -5,  -18, 	  12,  -20, 	   1,   -8
+.2byte    3,  -14, 	   0,  -21, 	  16,  -15, 	   2,  -10
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -2,  -14, 	 -11,   -7, 	  11,  -10, 	  -1,   -9
+.2byte    0,  -14, 	 -12,  -11, 	  10,   -6, 	  -1,   -9
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte    2,  -15, 	  10,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte    3,  -15, 	   5,  -13, 	  -8,   -5, 	  -1,   -8
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    3,  -16, 	   6,  -12, 	  -6,   -5, 	  -1,   -8
+.2byte    2,  -16, 	  -5,   -8, 	   0,   -5, 	  -3,   -7
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    3,  -17, 	  -6,  -14, 	   7,   -5, 	  -2,   -8
+.2byte    1,  -17, 	 -10,  -11, 	   9,   -9, 	  -2,   -9
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte   -2,  -15, 	  10,   -7, 	 -12,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  10,  -11, 	 -12,   -7, 	  -1,   -9
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -5,  -17, 	   4,  -14, 	  -9,   -5, 	   0,   -8
+.2byte   -3,  -17, 	   8,  -11, 	 -11,   -9, 	   0,   -9
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -5,  -16, 	  -8,  -12, 	   4,   -5, 	  -1,   -8
+.2byte   -4,  -16, 	   3,   -8, 	  -2,   -5, 	   1,   -7
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -4,  -15, 	 -12,   -9, 	   9,   -9, 	  -1,   -8
+.2byte   -5,  -15, 	  -7,  -13, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+.2byte    0,  -12, 	 -14,  -15, 	  14,  -15, 	   0,   -8
+.2byte   -6,  -15, 	 -12,  -21, 	  10,  -10, 	  -2,   -9
+.2byte   -8,  -16, 	  -4,  -26, 	  -7,  -10, 	  -2,   -8
+.2byte   -7,  -16, 	   6,  -21, 	 -15,  -12, 	  -1,   -9
+.2byte   -1,  -17, 	  11,  -17, 	 -13,  -18, 	  -1,  -10
+.2byte    5,  -16, 	  -8,  -21, 	  13,  -12, 	  -1,   -9
+.2byte    6,  -16, 	   2,  -26, 	   5,  -10, 	   0,   -8
+.2byte    6,  -15, 	  12,  -21, 	 -10,  -10, 	   2,   -9
+.2byte    0,  -12, 	 -14,  -15, 	  14,  -15, 	   0,   -8
+.2byte    6,  -15, 	  12,  -21, 	 -10,  -10, 	   2,   -9
+.2byte    7,  -16, 	   3,  -26, 	   6,  -10, 	   1,   -8
+.2byte    4,  -16, 	  -9,  -21, 	  12,  -12, 	  -2,   -9
+.2byte   -1,  -17, 	  11,  -17, 	 -13,  -18, 	  -1,  -10
+.2byte   -6,  -16, 	   7,  -21, 	 -14,  -12, 	   0,   -9
+.2byte   -8,  -16, 	  -4,  -26, 	  -7,  -10, 	  -2,   -8
+.2byte   -6,  -15, 	 -12,  -21, 	  10,  -10, 	  -2,   -9
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	 -15,  -16, 	  13,  -16, 	  -1,   -9
+.2byte   -3,  -10, 	  -9,   -8, 	   7,   -8, 	  -2,   -7
+.2byte    2,  -17, 	   8,  -12, 	 -10,   -9, 	  -1,  -10
+.2byte    6,  -15, 	  12,  -21, 	 -10,  -10, 	   2,   -9
+.2byte    4,  -12, 	   8,  -10, 	  -4,   -5, 	  -1,   -8
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    6,  -16, 	   2,  -26, 	   5,  -10, 	   0,   -8
+.2byte    4,  -14, 	  -4,  -13, 	   4,   -5, 	  -3,   -8
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    5,  -16, 	  -8,  -21, 	  13,  -12, 	  -1,   -9
+.2byte    2,  -16, 	  -4,  -13, 	   8,   -8, 	  -2,   -8
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte   -1,  -17, 	  11,  -17, 	 -13,  -18, 	  -1,  -10
+.2byte    1,  -15, 	   9,  -12, 	 -10,  -12, 	  -1,   -9
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -7,  -16, 	   6,  -21, 	 -15,  -12, 	  -1,   -9
+.2byte   -4,  -16, 	   2,  -13, 	 -10,   -8, 	   0,   -8
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -8,  -16, 	  -4,  -26, 	  -7,  -10, 	  -2,   -8
+.2byte   -6,  -14, 	   2,  -13, 	  -6,   -5, 	   1,   -8
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -8,  -15, 	 -14,  -21, 	   8,  -10, 	  -4,   -9
+.2byte   -6,  -12, 	 -10,  -10, 	   2,   -5, 	  -1,   -8
+.2byte   -3,  -10, 	  -9,   -8, 	   7,   -8, 	  -2,   -7
+.2byte   -6,  -12, 	 -10,  -10, 	   2,   -5, 	  -1,   -8
+.2byte   -6,  -14, 	   2,  -13, 	  -6,   -5, 	   1,   -8
+.2byte   -4,  -16, 	   2,  -13, 	 -10,   -8, 	   0,   -8
+.2byte    2,  -15, 	  10,  -12, 	  -9,  -12, 	   0,   -9
+.2byte    2,  -16, 	  -4,  -13, 	   8,   -8, 	  -2,   -8
+.2byte    4,  -14, 	  -4,  -13, 	   4,   -5, 	  -3,   -8
+.2byte    4,  -12, 	   8,  -10, 	  -4,   -5, 	  -1,   -8
+.2byte   -1,  -15, 	 -13,  -10, 	  12,  -10, 	  -1,  -10
+.2byte   -4,  -16, 	 -10,  -11, 	   8,   -8, 	  -1,   -9
+.2byte   -5,  -17, 	  -6,  -12, 	   1,   -6, 	  -1,   -8
+.2byte   -4,  -18, 	   6,  -12, 	 -11,   -8, 	  -1,   -9
+.2byte   -1,  -16, 	  12,   -9, 	 -13,  -10, 	  -1,  -10
+.2byte    2,  -18, 	  -8,  -12, 	   9,   -8, 	  -1,   -9
+.2byte    3,  -17, 	   4,  -12, 	  -3,   -6, 	  -1,   -8
+.2byte    2,  -16, 	   8,  -11, 	 -10,   -8, 	  -1,   -9
+sCacturneAnimTable1:
+.4byte sCacturneAnims_1_1
+.4byte sCacturneAnims_1_2
+.4byte sCacturneAnims_1_3
+.4byte sCacturneAnims_1_4
+.4byte sCacturneAnims_1_5
+.4byte sCacturneAnims_1_6
+.4byte sCacturneAnims_1_7
+.4byte sCacturneAnims_1_8
+sCacturneAnimTable2:
+.4byte sCacturneAnims_2_1
+.4byte sCacturneAnims_2_2
+.4byte sCacturneAnims_2_3
+.4byte sCacturneAnims_2_4
+.4byte sCacturneAnims_2_5
+.4byte sCacturneAnims_2_6
+.4byte sCacturneAnims_2_7
+.4byte sCacturneAnims_2_8
+sCacturneAnimTable3:
+.4byte sCacturneAnims_3_1
+.4byte sCacturneAnims_3_2
+.4byte sCacturneAnims_3_3
+.4byte sCacturneAnims_3_4
+.4byte sCacturneAnims_3_5
+.4byte sCacturneAnims_3_6
+.4byte sCacturneAnims_3_7
+.4byte sCacturneAnims_3_8
+sCacturneAnimTable4:
+.4byte sCacturneAnims_4_1
+.4byte sCacturneAnims_4_2
+.4byte sCacturneAnims_4_3
+.4byte sCacturneAnims_4_4
+.4byte sCacturneAnims_4_5
+.4byte sCacturneAnims_4_6
+.4byte sCacturneAnims_4_7
+.4byte sCacturneAnims_4_8
+sCacturneAnimTable5:
+.4byte sCacturneAnims_5_1
+.4byte sCacturneAnims_5_2
+.4byte sCacturneAnims_5_3
+.4byte sCacturneAnims_5_4
+.4byte sCacturneAnims_5_5
+.4byte sCacturneAnims_5_6
+.4byte sCacturneAnims_5_7
+.4byte sCacturneAnims_5_8
+sCacturneAnimTable6:
+.4byte sCacturneAnims_6_1
+.4byte sCacturneAnims_6_1
+.4byte sCacturneAnims_6_1
+.4byte sCacturneAnims_6_1
+.4byte sCacturneAnims_6_1
+.4byte sCacturneAnims_6_1
+.4byte sCacturneAnims_6_1
+.4byte sCacturneAnims_6_1
+sCacturneAnimTable7:
+.4byte sCacturneAnims_7_1
+.4byte sCacturneAnims_7_2
+.4byte sCacturneAnims_7_3
+.4byte sCacturneAnims_7_4
+.4byte sCacturneAnims_7_5
+.4byte sCacturneAnims_7_6
+.4byte sCacturneAnims_7_7
+.4byte sCacturneAnims_7_8
+sCacturneAnimTable8:
+.4byte sCacturneAnims_8_1
+.4byte sCacturneAnims_8_2
+.4byte sCacturneAnims_8_3
+.4byte sCacturneAnims_8_4
+.4byte sCacturneAnims_8_5
+.4byte sCacturneAnims_8_6
+.4byte sCacturneAnims_8_7
+.4byte sCacturneAnims_8_8
+sCacturneAnimTable9:
+.4byte sCacturneAnims_9_1
+.4byte sCacturneAnims_9_2
+.4byte sCacturneAnims_9_3
+.4byte sCacturneAnims_9_4
+.4byte sCacturneAnims_9_5
+.4byte sCacturneAnims_9_6
+.4byte sCacturneAnims_9_7
+.4byte sCacturneAnims_9_8
+sCacturneAnimTable10:
+.4byte sCacturneAnims_10_1
+.4byte sCacturneAnims_10_2
+.4byte sCacturneAnims_10_3
+.4byte sCacturneAnims_10_4
+.4byte sCacturneAnims_10_5
+.4byte sCacturneAnims_10_6
+.4byte sCacturneAnims_10_7
+.4byte sCacturneAnims_10_8
+sCacturneAnimTable11:
+.4byte sCacturneAnims_11_1
+.4byte sCacturneAnims_11_2
+.4byte sCacturneAnims_11_3
+.4byte sCacturneAnims_11_4
+.4byte sCacturneAnims_11_5
+.4byte sCacturneAnims_11_6
+.4byte sCacturneAnims_11_7
+.4byte sCacturneAnims_11_8
+sCacturneAnimTable12:
+.4byte sCacturneAnims_12_1
+.4byte sCacturneAnims_12_2
+.4byte sCacturneAnims_12_3
+.4byte sCacturneAnims_12_4
+.4byte sCacturneAnims_12_5
+.4byte sCacturneAnims_12_6
+.4byte sCacturneAnims_12_7
+.4byte sCacturneAnims_12_8
+sCacturneAnimTable13:
+.4byte sCacturneAnims_13_1
+.4byte sCacturneAnims_13_2
+.4byte sCacturneAnims_13_3
+.4byte sCacturneAnims_13_4
+.4byte sCacturneAnims_13_5
+.4byte sCacturneAnims_13_6
+.4byte sCacturneAnims_13_7
+.4byte sCacturneAnims_13_8
+sAxAnimationsCacturne:
+.4byte sCacturneAnimTable1
+.4byte sCacturneAnimTable2
+.4byte sCacturneAnimTable3
+.4byte sCacturneAnimTable4
+.4byte sCacturneAnimTable5
+.4byte sCacturneAnimTable6
+.4byte sCacturneAnimTable7
+.4byte sCacturneAnimTable8
+.4byte sCacturneAnimTable9
+.4byte sCacturneAnimTable10
+.4byte sCacturneAnimTable11
+.4byte sCacturneAnimTable12
+.4byte sCacturneAnimTable13
+sAxSpritesCacturne:
+.4byte sCacturneSprites1
+.4byte sCacturneSprites2
+.4byte sCacturneSprites3
+.4byte sCacturneSprites4
+.4byte sCacturneSprites5
+.4byte sCacturneSprites6
+.4byte sCacturneSprites7
+.4byte sCacturneSprites8
+.4byte sCacturneSprites9
+.4byte sCacturneSprites10
+.4byte sCacturneSprites11
+.4byte sCacturneSprites12
+.4byte sCacturneSprites13
+.4byte sCacturneSprites14
+.4byte sCacturneSprites15
+.4byte sCacturneSprites16
+.4byte sCacturneSprites17
+.4byte sCacturneSprites18
+.4byte sCacturneSprites19
+.4byte sCacturneSprites20
+.4byte sCacturneSprites21
+.4byte sCacturneSprites22
+.4byte sCacturneSprites23
+.4byte sCacturneSprites24
+.4byte sCacturneSprites25
+.4byte sCacturneSprites26
+.4byte sCacturneSprites27
+.4byte sCacturneSprites28
+.4byte sCacturneSprites29
+.4byte sCacturneSprites30
+.4byte sCacturneSprites31
+.4byte sCacturneSprites32
+.4byte sCacturneSprites33
+.4byte sCacturneSprites34
+.4byte sCacturneSprites35
+.4byte sCacturneSprites36
+.4byte sCacturneSprites37
+.4byte sCacturneSprites38
+.4byte sCacturneSprites39
+.4byte sCacturneSprites40
+.4byte sCacturneSprites41
+.4byte sCacturneSprites42
+.4byte sCacturneSprites43
+.4byte sCacturneSprites44
+.4byte sCacturneSprites45
+.4byte sCacturneSprites46
+.4byte sCacturneSprites47
+.4byte sCacturneSprites48
+.4byte sCacturneSprites49
+.4byte sCacturneSprites50
+.4byte sCacturneSprites51
+.4byte sCacturneSprites52
+.4byte sCacturneSprites53
+.4byte sCacturneSprites54
+.4byte sCacturneSprites55
+.4byte sCacturneSprites56
+sAxMainCacturne:
+ax_main sAxPosesCacturne, sAxAnimationsCacturne, 13, sAxSpritesCacturne, sAxPositionsCacturne

--- a/data/ax/camerupt.inc
+++ b/data/ax/camerupt.inc
@@ -1,0 +1,2704 @@
+.global gAxCamerupt
+gAxCamerupt:
+ax_siro sAxMainCamerupt
+sCameruptPose1:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose4:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose5:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose6:
+ax_pose 5, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose7:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose8:
+ax_pose 7, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose9:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose10:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose11:
+ax_pose 10, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sCameruptPose12:
+ax_pose 11, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sCameruptPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose16:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose17:
+ax_pose 10, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose18:
+ax_pose 11, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose19:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose20:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose21:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose22:
+ax_pose 3, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose23:
+ax_pose 4, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose24:
+ax_pose 5, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose25:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose26:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose27:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose28:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose29:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose30:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose31:
+ax_pose 5, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose32:
+ax_pose 16, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose33:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose34:
+ax_pose 7, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose35:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose36:
+ax_pose 17, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose37:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose38:
+ax_pose 10, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sCameruptPose39:
+ax_pose 11, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sCameruptPose40:
+ax_pose 18, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sCameruptPose41:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose42:
+ax_pose 13, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose43:
+ax_pose 14, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose44:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose45:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose46:
+ax_pose 10, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose47:
+ax_pose 11, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose48:
+ax_pose 18, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose49:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose50:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose51:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose52:
+ax_pose 17, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose53:
+ax_pose 3, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose54:
+ax_pose 4, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose55:
+ax_pose 5, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose56:
+ax_pose 16, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose57:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose58:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose59:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose60:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose61:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose62:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose63:
+ax_pose 5, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose64:
+ax_pose 16, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose65:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose66:
+ax_pose 7, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose67:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose68:
+ax_pose 17, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose69:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose70:
+ax_pose 10, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sCameruptPose71:
+ax_pose 11, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sCameruptPose72:
+ax_pose 18, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sCameruptPose73:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose74:
+ax_pose 13, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose75:
+ax_pose 14, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose76:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose77:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose78:
+ax_pose 10, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose79:
+ax_pose 11, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose80:
+ax_pose 18, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose81:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose82:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose83:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose84:
+ax_pose 17, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose85:
+ax_pose 3, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose86:
+ax_pose 4, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose87:
+ax_pose 5, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose88:
+ax_pose 16, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose89:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose90:
+ax_pose 20, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose91:
+ax_pose 21, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose92:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose93:
+ax_pose 22, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose94:
+ax_pose 23, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose95:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose96:
+ax_pose 24, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sCameruptPose97:
+ax_pose 25, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose98:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose99:
+ax_pose 26, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose100:
+ax_pose 27, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose101:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose102:
+ax_pose 28, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose103:
+ax_pose 29, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose104:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose105:
+ax_pose 26, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose106:
+ax_pose 27, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose107:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose108:
+ax_pose 24, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose109:
+ax_pose 25, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose110:
+ax_pose 3, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose111:
+ax_pose 22, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose112:
+ax_pose 23, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose113:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose114:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose115:
+ax_pose 30, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose116:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose117:
+ax_pose 22, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose118:
+ax_pose 31, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose119:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose120:
+ax_pose 24, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sCameruptPose121:
+ax_pose 32, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose122:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose123:
+ax_pose 26, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose124:
+ax_pose 33, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose125:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose126:
+ax_pose 28, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose127:
+ax_pose 34, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose128:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose129:
+ax_pose 26, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose130:
+ax_pose 33, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose131:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose132:
+ax_pose 24, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose133:
+ax_pose 32, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose134:
+ax_pose 3, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose135:
+ax_pose 22, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose136:
+ax_pose 31, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose137:
+ax_pose 35, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sCameruptPose138:
+ax_pose 36, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sCameruptPose139:
+ax_pose 37, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose140:
+ax_pose 38, 0x01e2, 0x90eb, 0x5c00
+ax_pose_terminator
+sCameruptPose141:
+ax_pose 39, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sCameruptPose142:
+ax_pose 40, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sCameruptPose143:
+ax_pose 41, 0x81e5, 0x4105, 0x5c00
+ax_pose 42, 0x01dd, 0x0105, 0x5c04
+ax_pose 43, 0x01dd, 0x00f5, 0x5c05
+ax_pose 44, 0x81e5, 0x80f5, 0x5c06
+ax_pose_terminator
+sCameruptPose144:
+ax_pose 40, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose145:
+ax_pose 39, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sCameruptPose146:
+ax_pose 38, 0x01e2, 0x80f5, 0x5c00
+ax_pose_terminator
+sCameruptPose147:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose148:
+ax_pose 20, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose149:
+ax_pose 21, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose150:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose151:
+ax_pose 22, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose152:
+ax_pose 23, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose153:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose154:
+ax_pose 24, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sCameruptPose155:
+ax_pose 25, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose156:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose157:
+ax_pose 26, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose158:
+ax_pose 27, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose159:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose160:
+ax_pose 28, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose161:
+ax_pose 29, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose162:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose163:
+ax_pose 26, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose164:
+ax_pose 27, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose165:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose166:
+ax_pose 24, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose167:
+ax_pose 25, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose168:
+ax_pose 3, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose169:
+ax_pose 22, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose170:
+ax_pose 23, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose171:
+ax_pose 15, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose172:
+ax_pose 16, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose173:
+ax_pose 17, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose174:
+ax_pose 18, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose175:
+ax_pose 19, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose176:
+ax_pose 18, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose177:
+ax_pose 17, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose178:
+ax_pose 16, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose179:
+ax_pose 20, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose180:
+ax_pose 22, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose181:
+ax_pose 24, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose182:
+ax_pose 26, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose183:
+ax_pose 28, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose184:
+ax_pose 26, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose185:
+ax_pose 24, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose186:
+ax_pose 22, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose187:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose188:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose189:
+ax_pose 21, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose190:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sCameruptPose191:
+ax_pose 22, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose192:
+ax_pose 23, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose193:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose194:
+ax_pose 24, 0x01e8, 0x90f0, 0x5c00
+ax_pose_terminator
+sCameruptPose195:
+ax_pose 25, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose196:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose197:
+ax_pose 26, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose198:
+ax_pose 27, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose199:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose200:
+ax_pose 28, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose201:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose202:
+ax_pose 9, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose203:
+ax_pose 26, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose204:
+ax_pose 27, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose205:
+ax_pose 6, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sCameruptPose206:
+ax_pose 24, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose207:
+ax_pose 25, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose208:
+ax_pose 3, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sCameruptPose209:
+ax_pose 22, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose210:
+ax_pose 23, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose211:
+ax_pose 21, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose212:
+ax_pose 23, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sCameruptPose213:
+ax_pose 25, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sCameruptPose214:
+ax_pose 27, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sCameruptPose215:
+ax_pose 29, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose216:
+ax_pose 27, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sCameruptPose217:
+ax_pose 25, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sCameruptPose218:
+ax_pose 23, 0x01e7, 0x90f3, 0x5c00
+ax_pose_terminator
+sCameruptPose219:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose220:
+ax_pose 3, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCameruptPose221:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose222:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sCameruptPose223:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sCameruptPose224:
+ax_pose 9, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose225:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCameruptPose226:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+.align 2
+sCameruptAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 1, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCameruptAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 9, 10, 9, 10,
+ax_anim 2, 0, 31, 16, 17, 16, 17,
+ax_anim 2, 1, 31, 17, 16, 17, 16,
+ax_anim 2, 0, 31, 16, 17, 16, 17,
+ax_anim 2, 0, 31, 17, 16, 17, 16,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sCameruptAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sCameruptAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 1, 39, 19, -17, 19, -17,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 39, 19, -17, 19, -17,
+ax_anim 2, 0, 36, 6, -7, 6, -7,
+ax_anim_terminator
+sCameruptAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 1, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 0, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sCameruptAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 1, 47, -19, -17, -19, -17,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 47, -19, -17, -19, -17,
+ax_anim 2, 0, 44, -6, -7, -6, -7,
+ax_anim_terminator
+sCameruptAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sCameruptAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -9, 10, -9, 10,
+ax_anim 2, 0, 55, -16, 17, -16, 17,
+ax_anim 2, 1, 55, -17, 16, -17, 16,
+ax_anim 2, 0, 55, -16, 17, -16, 17,
+ax_anim 2, 0, 55, -17, 16, -17, 16,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCameruptAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 6, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 1, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sCameruptAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 6, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 9, 10, 9, 10,
+ax_anim 2, 0, 63, 16, 17, 16, 17,
+ax_anim 2, 1, 63, 17, 16, 17, 16,
+ax_anim 2, 0, 63, 16, 17, 16, 17,
+ax_anim 2, 0, 63, 17, 16, 17, 16,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sCameruptAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 6, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 1, 67, 16, 1, 16, 1,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 0, 67, 16, 1, 16, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sCameruptAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 6, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 5, -6, 5, -6,
+ax_anim 1, 0, 70, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 2, 1, 71, 19, -17, 19, -17,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 2, 0, 71, 19, -17, 19, -17,
+ax_anim 2, 0, 68, 6, -7, 6, -7,
+ax_anim_terminator
+sCameruptAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -19, 0, -19,
+ax_anim 2, 1, 75, 1, -19, 1, -19,
+ax_anim 2, 0, 75, 0, -19, 0, -19,
+ax_anim 2, 0, 75, 1, -19, 1, -19,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sCameruptAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 6, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -5, -6, -5, -6,
+ax_anim 1, 0, 78, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 1, 79, -19, -17, -19, -17,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 0, 79, -19, -17, -19, -17,
+ax_anim 2, 0, 76, -6, -7, -6, -7,
+ax_anim_terminator
+sCameruptAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 6, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -16, 0, -16, 0,
+ax_anim 2, 1, 83, -16, 1, -16, 1,
+ax_anim 2, 0, 83, -16, 0, -16, 0,
+ax_anim 2, 0, 83, -16, 1, -16, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sCameruptAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 6, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -9, 10, -9, 10,
+ax_anim 2, 0, 87, -16, 17, -16, 17,
+ax_anim 2, 1, 87, -17, 16, -17, 16,
+ax_anim 2, 0, 87, -16, 17, -16, 17,
+ax_anim 2, 0, 87, -17, 16, -17, 16,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCameruptAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sCameruptAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sCameruptAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sCameruptAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sCameruptAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sCameruptAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sCameruptAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sCameruptAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCameruptAnims_5_1:
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 4, 0, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 6, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_5_2:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 4, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 6, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_5_3:
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 6, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_5_4:
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 6, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_5_5:
+ax_anim 1, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 6, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_5_6:
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 6, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_5_7:
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 6, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_5_8:
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 6, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sCameruptAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sCameruptAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sCameruptAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sCameruptAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sCameruptAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sCameruptAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sCameruptAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCameruptAnims_8_1:
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 20, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 20, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_8_2:
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 20, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 20, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_8_3:
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 20, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 20, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_8_4:
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 20, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 20, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_8_5:
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 20, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 20, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_8_6:
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 20, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_8_7:
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 20, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_8_8:
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 20, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 8, 4, 8, 4,
+ax_anim 2, 0, 172, 10, 9, 10, 9,
+ax_anim 2, 0, 173, 8, 16, 8, 16,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -8, 16, -8, 16,
+ax_anim 2, 0, 176, -10, 9, -10, 9,
+ax_anim 1, 0, 177, -8, 4, -8, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 4, 17, 4,
+ax_anim 2, 0, 172, 21, 12, 21, 12,
+ax_anim 3, 0, 173, 20, 17, 20, 17,
+ax_anim 2, 3, 174, 10, 18, 10, 18,
+ax_anim 2, 0, 175, 4, 13, 4, 13,
+ax_anim 1, 0, 176, 0, 8, 0, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -8, 11, -8,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 19, 0, 19, 0,
+ax_anim 2, 3, 173, 15, 6, 15, 6,
+ax_anim 2, 0, 174, 10, 8, 10, 8,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 3, -16, 3, -16,
+ax_anim 2, 0, 170, 12, -21, 12, -21,
+ax_anim 3, 0, 171, 18, -21, 18, -21,
+ax_anim 2, 3, 172, 21, -14, 21, -14,
+ax_anim 2, 0, 173, 18, -6, 18, -6,
+ax_anim 1, 0, 174, 8, -1, 8, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -3, -8, -3,
+ax_anim 2, 0, 176, -12, -10, -12, -10,
+ax_anim 2, 0, 177, -9, -17, -9, -17,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 9, -17, 9, -17,
+ax_anim 2, 0, 172, 12, -10, 12, -10,
+ax_anim 1, 0, 173, 8, -3, 8, -3,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -3, -16, -3, -16,
+ax_anim 2, 0, 170, -12, -21, -12, -21,
+ax_anim 3, 0, 177, -18, -21, -18, -21,
+ax_anim 2, 3, 176, -21, -14, -21, -14,
+ax_anim 2, 0, 175, -18, -6, -18, -6,
+ax_anim 1, 0, 174, -8, -1, -8, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -8, -11, -8,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -19, 0, -19, 0,
+ax_anim 2, 3, 175, -15, 6, -15, 6,
+ax_anim 2, 0, 174, -10, 8, -10, 8,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 4, -17, 4,
+ax_anim 2, 0, 176, -21, 12, -21, 12,
+ax_anim 3, 0, 175, -20, 17, -20, 17,
+ax_anim 2, 3, 174, -10, 18, -10, 18,
+ax_anim 2, 0, 173, -4, 13, -4, 13,
+ax_anim 1, 0, 172, 0, 8, 0, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -24, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -24, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 197, 0, -19, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 2, 0, 200, 0, -17, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -19, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -24, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCameruptAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sCameruptGfx1:
+.incbin "baserom.gba", 0x132EB9C, 0x200
+sCameruptSprites1:
+ax_sprite sCameruptGfx1, 0x200
+ax_sprite_terminator
+sCameruptGfx2:
+.incbin "baserom.gba", 0x132EDAC, 0x200
+sCameruptSprites2:
+ax_sprite sCameruptGfx2, 0x200
+ax_sprite_terminator
+sCameruptGfx3:
+.incbin "baserom.gba", 0x132EFBC, 0x200
+sCameruptSprites3:
+ax_sprite sCameruptGfx3, 0x200
+ax_sprite_terminator
+sCameruptGfx4:
+.incbin "baserom.gba", 0x132F1CC, 0x200
+sCameruptSprites4:
+ax_sprite sCameruptGfx4, 0x200
+ax_sprite_terminator
+sCameruptGfx5:
+.incbin "baserom.gba", 0x132F3DC, 0x200
+sCameruptSprites5:
+ax_sprite sCameruptGfx5, 0x200
+ax_sprite_terminator
+sCameruptGfx6:
+.incbin "baserom.gba", 0x132F5EC, 0x200
+sCameruptSprites6:
+ax_sprite sCameruptGfx6, 0x200
+ax_sprite_terminator
+sCameruptGfx7:
+.incbin "baserom.gba", 0x132F7FC, 0x200
+sCameruptSprites7:
+ax_sprite sCameruptGfx7, 0x200
+ax_sprite_terminator
+sCameruptGfx8:
+.incbin "baserom.gba", 0x132FA0C, 0x200
+sCameruptSprites8:
+ax_sprite sCameruptGfx8, 0x200
+ax_sprite_terminator
+sCameruptGfx9:
+.incbin "baserom.gba", 0x132FC1C, 0x200
+sCameruptSprites9:
+ax_sprite sCameruptGfx9, 0x200
+ax_sprite_terminator
+sCameruptGfx10:
+.incbin "baserom.gba", 0x132FE2C, 0x200
+sCameruptSprites10:
+ax_sprite sCameruptGfx10, 0x200
+ax_sprite_terminator
+sCameruptGfx11:
+.incbin "baserom.gba", 0x133003C, 0x200
+sCameruptSprites11:
+ax_sprite sCameruptGfx11, 0x200
+ax_sprite_terminator
+sCameruptGfx12:
+.incbin "baserom.gba", 0x133024C, 0x200
+sCameruptSprites12:
+ax_sprite sCameruptGfx12, 0x200
+ax_sprite_terminator
+sCameruptGfx13:
+.incbin "baserom.gba", 0x133045C, 0x200
+sCameruptSprites13:
+ax_sprite sCameruptGfx13, 0x200
+ax_sprite_terminator
+sCameruptGfx14:
+.incbin "baserom.gba", 0x133066C, 0x200
+sCameruptSprites14:
+ax_sprite sCameruptGfx14, 0x200
+ax_sprite_terminator
+sCameruptGfx15:
+.incbin "baserom.gba", 0x133087C, 0x200
+sCameruptSprites15:
+ax_sprite sCameruptGfx15, 0x200
+ax_sprite_terminator
+sCameruptGfx16:
+.incbin "baserom.gba", 0x1330A8C, 0x40
+sCameruptGfx16_1:
+.incbin "baserom.gba", 0x1330ACC, 0x160
+sCameruptSprites16:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx16_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx17:
+.incbin "baserom.gba", 0x1330C5C, 0x1C0
+sCameruptSprites17:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx17, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx18:
+.incbin "baserom.gba", 0x1330E3C, 0x1E0
+sCameruptSprites18:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx18, 0x1e0
+ax_sprite_terminator
+sCameruptGfx19:
+.incbin "baserom.gba", 0x1331034, 0x180
+sCameruptGfx19_1:
+.incbin "baserom.gba", 0x13311B4, 0x60
+sCameruptSprites19:
+ax_sprite sCameruptGfx19, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx19_1, 0x60
+ax_sprite_terminator
+sCameruptGfx20:
+.incbin "baserom.gba", 0x1331234, 0x40
+sCameruptGfx20_1:
+.incbin "baserom.gba", 0x1331274, 0x160
+sCameruptSprites20:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx20_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx21:
+.incbin "baserom.gba", 0x1331404, 0x40
+sCameruptGfx21_1:
+.incbin "baserom.gba", 0x1331444, 0x160
+sCameruptSprites21:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx22:
+.incbin "baserom.gba", 0x13315D4, 0x40
+sCameruptGfx22_1:
+.incbin "baserom.gba", 0x1331614, 0x180
+sCameruptSprites22:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx22_1, 0x180
+ax_sprite_terminator
+sCameruptGfx23:
+.incbin "baserom.gba", 0x13317BC, 0x180
+sCameruptGfx23_1:
+.incbin "baserom.gba", 0x133193C, 0x60
+sCameruptSprites23:
+ax_sprite sCameruptGfx23, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx23_1, 0x60
+ax_sprite_terminator
+sCameruptGfx24:
+.incbin "baserom.gba", 0x13319BC, 0x40
+sCameruptGfx24_1:
+.incbin "baserom.gba", 0x13319FC, 0x180
+sCameruptSprites24:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx24_1, 0x180
+ax_sprite_terminator
+sCameruptGfx25:
+.incbin "baserom.gba", 0x1331BA4, 0x100
+sCameruptGfx25_1:
+.incbin "baserom.gba", 0x1331CA4, 0x60
+sCameruptGfx25_2:
+.incbin "baserom.gba", 0x1331D04, 0x60
+sCameruptSprites25:
+ax_sprite sCameruptGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx25_2, 0x60
+ax_sprite_terminator
+sCameruptGfx26:
+.incbin "baserom.gba", 0x1331D94, 0x1E0
+sCameruptSprites26:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx26, 0x1e0
+ax_sprite_terminator
+sCameruptGfx27:
+.incbin "baserom.gba", 0x1331F8C, 0x100
+sCameruptGfx27_1:
+.incbin "baserom.gba", 0x133208C, 0x60
+sCameruptGfx27_2:
+.incbin "baserom.gba", 0x13320EC, 0x60
+sCameruptSprites27:
+ax_sprite sCameruptGfx27, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx27_2, 0x60
+ax_sprite_terminator
+sCameruptGfx28:
+.incbin "baserom.gba", 0x133217C, 0x60
+sCameruptGfx28_1:
+.incbin "baserom.gba", 0x13321DC, 0x180
+sCameruptSprites28:
+ax_sprite sCameruptGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx28_1, 0x180
+ax_sprite_terminator
+sCameruptGfx29:
+.incbin "baserom.gba", 0x133237C, 0xE0
+sCameruptGfx29_1:
+.incbin "baserom.gba", 0x133245C, 0xE0
+sCameruptSprites29:
+ax_sprite sCameruptGfx29, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx29_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx30:
+.incbin "baserom.gba", 0x1332564, 0x40
+sCameruptGfx30_1:
+.incbin "baserom.gba", 0x13325A4, 0x160
+sCameruptSprites30:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx30_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx31:
+.incbin "baserom.gba", 0x1332734, 0x40
+sCameruptGfx31_1:
+.incbin "baserom.gba", 0x1332774, 0x160
+sCameruptSprites31:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx31_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx32:
+.incbin "baserom.gba", 0x1332904, 0x1C0
+sCameruptSprites32:
+ax_sprite 0, 0x40
+ax_sprite sCameruptGfx32, 0x1c0
+ax_sprite_terminator
+sCameruptGfx33:
+.incbin "baserom.gba", 0x1332ADC, 0x160
+sCameruptGfx33_1:
+.incbin "baserom.gba", 0x1332C3C, 0x60
+sCameruptSprites33:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx33, 0x160
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx33_1, 0x60
+ax_sprite_terminator
+sCameruptGfx34:
+.incbin "baserom.gba", 0x1332CC4, 0x60
+sCameruptGfx34_1:
+.incbin "baserom.gba", 0x1332D24, 0x100
+sCameruptGfx34_2:
+.incbin "baserom.gba", 0x1332E24, 0x60
+sCameruptSprites34:
+ax_sprite sCameruptGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx34_2, 0x60
+ax_sprite_terminator
+sCameruptGfx35:
+.incbin "baserom.gba", 0x1332EB4, 0x40
+sCameruptGfx35_1:
+.incbin "baserom.gba", 0x1332EF4, 0x160
+sCameruptSprites35:
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCameruptGfx35_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCameruptGfx36:
+.incbin "baserom.gba", 0x1333084, 0x200
+sCameruptSprites36:
+ax_sprite sCameruptGfx36, 0x200
+ax_sprite_terminator
+sCameruptGfx37:
+.incbin "baserom.gba", 0x1333294, 0x200
+sCameruptSprites37:
+ax_sprite sCameruptGfx37, 0x200
+ax_sprite_terminator
+sCameruptGfx38:
+.incbin "baserom.gba", 0x13334A4, 0x200
+sCameruptSprites38:
+ax_sprite sCameruptGfx38, 0x200
+ax_sprite_terminator
+sCameruptGfx39:
+.incbin "baserom.gba", 0x13336B4, 0x200
+sCameruptSprites39:
+ax_sprite sCameruptGfx39, 0x200
+ax_sprite_terminator
+sCameruptGfx40:
+.incbin "baserom.gba", 0x13338C4, 0x200
+sCameruptSprites40:
+ax_sprite sCameruptGfx40, 0x200
+ax_sprite_terminator
+sCameruptGfx41:
+.incbin "baserom.gba", 0x1333AD4, 0x200
+sCameruptSprites41:
+ax_sprite sCameruptGfx41, 0x200
+ax_sprite_terminator
+sCameruptGfx42:
+.incbin "baserom.gba", 0x1333CE4, 0x80
+sCameruptSprites42:
+ax_sprite sCameruptGfx42, 0x80
+ax_sprite_terminator
+sCameruptGfx43:
+.incbin "baserom.gba", 0x1333D74, 0x20
+sCameruptSprites43:
+ax_sprite sCameruptGfx43, 0x20
+ax_sprite_terminator
+sCameruptGfx44:
+.incbin "baserom.gba", 0x1333DA4, 0x20
+sCameruptSprites44:
+ax_sprite sCameruptGfx44, 0x20
+ax_sprite_terminator
+sCameruptGfx45:
+.incbin "baserom.gba", 0x1333DD4, 0x100
+sCameruptSprites45:
+ax_sprite sCameruptGfx45, 0x100
+ax_sprite_terminator
+sAxPosesCamerupt:
+.4byte sCameruptPose1
+.4byte sCameruptPose2
+.4byte sCameruptPose3
+.4byte sCameruptPose4
+.4byte sCameruptPose5
+.4byte sCameruptPose6
+.4byte sCameruptPose7
+.4byte sCameruptPose8
+.4byte sCameruptPose9
+.4byte sCameruptPose10
+.4byte sCameruptPose11
+.4byte sCameruptPose12
+.4byte sCameruptPose13
+.4byte sCameruptPose14
+.4byte sCameruptPose15
+.4byte sCameruptPose16
+.4byte sCameruptPose17
+.4byte sCameruptPose18
+.4byte sCameruptPose19
+.4byte sCameruptPose20
+.4byte sCameruptPose21
+.4byte sCameruptPose22
+.4byte sCameruptPose23
+.4byte sCameruptPose24
+.4byte sCameruptPose25
+.4byte sCameruptPose26
+.4byte sCameruptPose27
+.4byte sCameruptPose28
+.4byte sCameruptPose29
+.4byte sCameruptPose30
+.4byte sCameruptPose31
+.4byte sCameruptPose32
+.4byte sCameruptPose33
+.4byte sCameruptPose34
+.4byte sCameruptPose35
+.4byte sCameruptPose36
+.4byte sCameruptPose37
+.4byte sCameruptPose38
+.4byte sCameruptPose39
+.4byte sCameruptPose40
+.4byte sCameruptPose41
+.4byte sCameruptPose42
+.4byte sCameruptPose43
+.4byte sCameruptPose44
+.4byte sCameruptPose45
+.4byte sCameruptPose46
+.4byte sCameruptPose47
+.4byte sCameruptPose48
+.4byte sCameruptPose49
+.4byte sCameruptPose50
+.4byte sCameruptPose51
+.4byte sCameruptPose52
+.4byte sCameruptPose53
+.4byte sCameruptPose54
+.4byte sCameruptPose55
+.4byte sCameruptPose56
+.4byte sCameruptPose57
+.4byte sCameruptPose58
+.4byte sCameruptPose59
+.4byte sCameruptPose60
+.4byte sCameruptPose61
+.4byte sCameruptPose62
+.4byte sCameruptPose63
+.4byte sCameruptPose64
+.4byte sCameruptPose65
+.4byte sCameruptPose66
+.4byte sCameruptPose67
+.4byte sCameruptPose68
+.4byte sCameruptPose69
+.4byte sCameruptPose70
+.4byte sCameruptPose71
+.4byte sCameruptPose72
+.4byte sCameruptPose73
+.4byte sCameruptPose74
+.4byte sCameruptPose75
+.4byte sCameruptPose76
+.4byte sCameruptPose77
+.4byte sCameruptPose78
+.4byte sCameruptPose79
+.4byte sCameruptPose80
+.4byte sCameruptPose81
+.4byte sCameruptPose82
+.4byte sCameruptPose83
+.4byte sCameruptPose84
+.4byte sCameruptPose85
+.4byte sCameruptPose86
+.4byte sCameruptPose87
+.4byte sCameruptPose88
+.4byte sCameruptPose89
+.4byte sCameruptPose90
+.4byte sCameruptPose91
+.4byte sCameruptPose92
+.4byte sCameruptPose93
+.4byte sCameruptPose94
+.4byte sCameruptPose95
+.4byte sCameruptPose96
+.4byte sCameruptPose97
+.4byte sCameruptPose98
+.4byte sCameruptPose99
+.4byte sCameruptPose100
+.4byte sCameruptPose101
+.4byte sCameruptPose102
+.4byte sCameruptPose103
+.4byte sCameruptPose104
+.4byte sCameruptPose105
+.4byte sCameruptPose106
+.4byte sCameruptPose107
+.4byte sCameruptPose108
+.4byte sCameruptPose109
+.4byte sCameruptPose110
+.4byte sCameruptPose111
+.4byte sCameruptPose112
+.4byte sCameruptPose113
+.4byte sCameruptPose114
+.4byte sCameruptPose115
+.4byte sCameruptPose116
+.4byte sCameruptPose117
+.4byte sCameruptPose118
+.4byte sCameruptPose119
+.4byte sCameruptPose120
+.4byte sCameruptPose121
+.4byte sCameruptPose122
+.4byte sCameruptPose123
+.4byte sCameruptPose124
+.4byte sCameruptPose125
+.4byte sCameruptPose126
+.4byte sCameruptPose127
+.4byte sCameruptPose128
+.4byte sCameruptPose129
+.4byte sCameruptPose130
+.4byte sCameruptPose131
+.4byte sCameruptPose132
+.4byte sCameruptPose133
+.4byte sCameruptPose134
+.4byte sCameruptPose135
+.4byte sCameruptPose136
+.4byte sCameruptPose137
+.4byte sCameruptPose138
+.4byte sCameruptPose139
+.4byte sCameruptPose140
+.4byte sCameruptPose141
+.4byte sCameruptPose142
+.4byte sCameruptPose143
+.4byte sCameruptPose144
+.4byte sCameruptPose145
+.4byte sCameruptPose146
+.4byte sCameruptPose147
+.4byte sCameruptPose148
+.4byte sCameruptPose149
+.4byte sCameruptPose150
+.4byte sCameruptPose151
+.4byte sCameruptPose152
+.4byte sCameruptPose153
+.4byte sCameruptPose154
+.4byte sCameruptPose155
+.4byte sCameruptPose156
+.4byte sCameruptPose157
+.4byte sCameruptPose158
+.4byte sCameruptPose159
+.4byte sCameruptPose160
+.4byte sCameruptPose161
+.4byte sCameruptPose162
+.4byte sCameruptPose163
+.4byte sCameruptPose164
+.4byte sCameruptPose165
+.4byte sCameruptPose166
+.4byte sCameruptPose167
+.4byte sCameruptPose168
+.4byte sCameruptPose169
+.4byte sCameruptPose170
+.4byte sCameruptPose171
+.4byte sCameruptPose172
+.4byte sCameruptPose173
+.4byte sCameruptPose174
+.4byte sCameruptPose175
+.4byte sCameruptPose176
+.4byte sCameruptPose177
+.4byte sCameruptPose178
+.4byte sCameruptPose179
+.4byte sCameruptPose180
+.4byte sCameruptPose181
+.4byte sCameruptPose182
+.4byte sCameruptPose183
+.4byte sCameruptPose184
+.4byte sCameruptPose185
+.4byte sCameruptPose186
+.4byte sCameruptPose187
+.4byte sCameruptPose188
+.4byte sCameruptPose189
+.4byte sCameruptPose190
+.4byte sCameruptPose191
+.4byte sCameruptPose192
+.4byte sCameruptPose193
+.4byte sCameruptPose194
+.4byte sCameruptPose195
+.4byte sCameruptPose196
+.4byte sCameruptPose197
+.4byte sCameruptPose198
+.4byte sCameruptPose199
+.4byte sCameruptPose200
+.4byte sCameruptPose201
+.4byte sCameruptPose202
+.4byte sCameruptPose203
+.4byte sCameruptPose204
+.4byte sCameruptPose205
+.4byte sCameruptPose206
+.4byte sCameruptPose207
+.4byte sCameruptPose208
+.4byte sCameruptPose209
+.4byte sCameruptPose210
+.4byte sCameruptPose211
+.4byte sCameruptPose212
+.4byte sCameruptPose213
+.4byte sCameruptPose214
+.4byte sCameruptPose215
+.4byte sCameruptPose216
+.4byte sCameruptPose217
+.4byte sCameruptPose218
+.4byte sCameruptPose219
+.4byte sCameruptPose220
+.4byte sCameruptPose221
+.4byte sCameruptPose222
+.4byte sCameruptPose223
+.4byte sCameruptPose224
+.4byte sCameruptPose225
+.4byte sCameruptPose226
+sAxPositionsCamerupt:
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -2,    1, 	  -6,    1, 	   4,    4, 	  -1,   -8
+.2byte    0,    1, 	  -6,    3, 	   5,    1, 	  -1,   -7
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+.2byte    9,   -1, 	   3,   -3, 	   2,    3, 	  -3,   -6
+.2byte    8,    0, 	   8,    2, 	  -3,    2, 	  -4,   -7
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte   12,   -2, 	   5,   -3, 	   6,    1, 	  -2,   -5
+.2byte   11,   -3, 	   2,   -2, 	   1,    2, 	  -3,   -6
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte    7,   -7, 	  -2,   -6, 	   7,   -3, 	  -3,   -7
+.2byte    8,   -7, 	   0,   -9, 	   3,    0, 	  -4,   -8
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -13, 	   4,   -9, 	  -7,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   5,   -6, 	  -7,  -11, 	   0,   -8
+.2byte  -10,   -8, 	   0,   -8, 	  -7,   -2, 	   1,   -7
+.2byte   -9,   -7, 	   0,   -6, 	  -9,   -3, 	   1,   -7
+.2byte  -10,   -7, 	  -2,   -9, 	  -5,    0, 	   2,   -8
+.2byte  -14,   -4, 	  -4,   -4, 	  -6,    1, 	   1,   -7
+.2byte  -14,   -2, 	  -7,   -3, 	  -8,    1, 	   0,   -5
+.2byte  -13,   -3, 	  -4,   -2, 	  -3,    2, 	   1,   -6
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    2, 	   1,   -8
+.2byte  -11,   -1, 	  -5,   -3, 	  -4,    3, 	   1,   -6
+.2byte  -10,    0, 	 -10,    2, 	   1,    2, 	   2,   -7
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -2,    1, 	  -6,    1, 	   4,    4, 	  -1,   -8
+.2byte    0,    1, 	  -6,    3, 	   5,    1, 	  -1,   -7
+.2byte   -1,    5, 	  -6,    3, 	   5,    3, 	  -1,   -7
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+.2byte    9,   -1, 	   3,   -3, 	   2,    3, 	  -3,   -6
+.2byte    8,    0, 	   8,    2, 	  -3,    2, 	  -4,   -7
+.2byte   10,    3, 	   4,   -2, 	   0,    3, 	  -2,   -6
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte   12,   -2, 	   5,   -3, 	   6,    1, 	  -2,   -5
+.2byte   11,   -3, 	   2,   -2, 	   1,    2, 	  -3,   -6
+.2byte   11,   -1, 	   2,   -2, 	   1,    0, 	  -3,   -7
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte    7,   -7, 	  -2,   -6, 	   7,   -3, 	  -3,   -7
+.2byte    8,   -7, 	   0,   -9, 	   3,    0, 	  -4,   -8
+.2byte    9,   -7, 	   1,   -8, 	   4,   -2, 	  -3,   -8
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -13, 	   4,   -9, 	  -7,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   5,   -6, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -13, 	   5,  -11, 	  -7,  -11, 	  -1,  -10
+.2byte  -10,   -8, 	   0,   -8, 	  -7,   -2, 	   1,   -7
+.2byte   -9,   -7, 	   0,   -6, 	  -9,   -3, 	   1,   -7
+.2byte  -10,   -7, 	  -2,   -9, 	  -5,    0, 	   2,   -8
+.2byte  -11,   -7, 	  -3,   -8, 	  -6,   -2, 	   1,   -8
+.2byte  -14,   -4, 	  -4,   -4, 	  -6,    1, 	   1,   -7
+.2byte  -14,   -2, 	  -7,   -3, 	  -8,    1, 	   0,   -5
+.2byte  -13,   -3, 	  -4,   -2, 	  -3,    2, 	   1,   -6
+.2byte  -13,   -1, 	  -4,   -2, 	  -3,    0, 	   1,   -7
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    2, 	   1,   -8
+.2byte  -11,   -1, 	  -5,   -3, 	  -4,    3, 	   1,   -6
+.2byte  -10,    0, 	 -10,    2, 	   1,    2, 	   2,   -7
+.2byte  -12,    3, 	  -6,   -2, 	  -2,    3, 	   0,   -6
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -2,    1, 	  -6,    1, 	   4,    4, 	  -1,   -8
+.2byte    0,    1, 	  -6,    3, 	   5,    1, 	  -1,   -7
+.2byte   -1,    5, 	  -6,    3, 	   5,    3, 	  -1,   -7
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+.2byte    9,   -1, 	   3,   -3, 	   2,    3, 	  -3,   -6
+.2byte    8,    0, 	   8,    2, 	  -3,    2, 	  -4,   -7
+.2byte   10,    3, 	   4,   -2, 	   0,    3, 	  -2,   -6
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte   12,   -2, 	   5,   -3, 	   6,    1, 	  -2,   -5
+.2byte   11,   -3, 	   2,   -2, 	   1,    2, 	  -3,   -6
+.2byte   11,   -1, 	   2,   -2, 	   1,    0, 	  -3,   -7
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte    7,   -7, 	  -2,   -6, 	   7,   -3, 	  -3,   -7
+.2byte    8,   -7, 	   0,   -9, 	   3,    0, 	  -4,   -8
+.2byte    9,   -7, 	   1,   -8, 	   4,   -2, 	  -3,   -8
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -13, 	   4,   -9, 	  -7,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   5,   -6, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -13, 	   5,  -11, 	  -7,  -11, 	  -1,  -10
+.2byte  -10,   -8, 	   0,   -8, 	  -7,   -2, 	   1,   -7
+.2byte   -9,   -7, 	   0,   -6, 	  -9,   -3, 	   1,   -7
+.2byte  -10,   -7, 	  -2,   -9, 	  -5,    0, 	   2,   -8
+.2byte  -11,   -7, 	  -3,   -8, 	  -6,   -2, 	   1,   -8
+.2byte  -14,   -4, 	  -4,   -4, 	  -6,    1, 	   1,   -7
+.2byte  -14,   -2, 	  -7,   -3, 	  -8,    1, 	   0,   -5
+.2byte  -13,   -3, 	  -4,   -2, 	  -3,    2, 	   1,   -6
+.2byte  -13,   -1, 	  -4,   -2, 	  -3,    0, 	   1,   -7
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    2, 	   1,   -8
+.2byte  -11,   -1, 	  -5,   -3, 	  -4,    3, 	   1,   -6
+.2byte  -10,    0, 	 -10,    2, 	   1,    2, 	   2,   -7
+.2byte  -12,    3, 	  -6,   -2, 	  -2,    3, 	   0,   -6
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -1,   -9, 	  -6,    1, 	   4,    1, 	  -1,  -10
+.2byte   -1,    7, 	  -8,    4, 	   7,    4, 	  -1,   -6
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+.2byte   10,  -12, 	   6,   -4, 	   2,   -1, 	  -4,   -8
+.2byte   11,    2, 	   3,   -2, 	  -2,    3, 	  -2,   -7
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte   10,  -14, 	   3,   -5, 	   5,   -3, 	  -4,   -8
+.2byte   12,   -4, 	   3,   -1, 	   4,    3, 	  -3,   -6
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte    8,  -20, 	   0,   -9, 	   6,   -5, 	  -4,   -9
+.2byte   11,  -11, 	   2,   -6, 	   8,    0, 	  -2,   -8
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -24, 	   5,   -7, 	  -6,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -9, 	  -7,  -10, 	  -1,   -8
+.2byte  -10,   -8, 	   0,   -8, 	  -7,   -2, 	   1,   -7
+.2byte  -10,  -20, 	  -2,   -9, 	  -8,   -5, 	   2,   -9
+.2byte  -13,  -11, 	  -4,   -6, 	 -10,    0, 	   0,   -8
+.2byte  -14,   -4, 	  -4,   -4, 	  -6,    1, 	   1,   -7
+.2byte  -12,  -14, 	  -5,   -5, 	  -7,   -3, 	   2,   -8
+.2byte  -14,   -4, 	  -5,   -1, 	  -6,    3, 	   1,   -6
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    2, 	   1,   -8
+.2byte  -12,  -12, 	  -8,   -4, 	  -4,   -1, 	   2,   -8
+.2byte  -13,    2, 	  -5,   -2, 	   0,    3, 	   0,   -7
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -1,   -8, 	  -6,    2, 	   4,    2, 	  -1,   -9
+.2byte   -1,    5, 	  -7,    2, 	   5,    2, 	  -1,   -8
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+.2byte   10,  -12, 	   6,   -4, 	   2,   -1, 	  -4,   -8
+.2byte    3,    0, 	   5,   -2, 	   0,    2, 	  -3,   -8
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte   10,  -14, 	   3,   -5, 	   5,   -3, 	  -4,   -8
+.2byte    6,   -3, 	   3,   -2, 	   5,    1, 	  -3,   -7
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte    8,  -20, 	   0,   -9, 	   6,   -5, 	  -4,   -9
+.2byte    5,   -8, 	  -1,   -6, 	   5,   -1, 	  -4,   -7
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -24, 	   5,   -7, 	  -6,   -7, 	  -1,  -10
+.2byte   -1,  -10, 	   5,   -8, 	  -6,   -8, 	  -1,   -7
+.2byte  -10,   -8, 	   0,   -8, 	  -7,   -2, 	   1,   -7
+.2byte  -10,  -20, 	  -2,   -9, 	  -8,   -5, 	   2,   -9
+.2byte   -7,   -8, 	  -1,   -6, 	  -7,   -1, 	   2,   -7
+.2byte  -14,   -4, 	  -4,   -4, 	  -6,    1, 	   1,   -7
+.2byte  -12,  -14, 	  -5,   -5, 	  -7,   -3, 	   2,   -8
+.2byte   -8,   -3, 	  -5,   -2, 	  -7,    1, 	   1,   -7
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    2, 	   1,   -8
+.2byte  -12,  -12, 	  -8,   -4, 	  -4,   -1, 	   2,   -8
+.2byte   -5,    0, 	  -7,   -2, 	  -2,    2, 	   1,   -8
+.2byte   -8,    2, 	  -6,   -1, 	  -2,    3, 	   2,   -6
+.2byte   -8,    2, 	  -5,   -1, 	  -2,    3, 	   2,   -6
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,  -10
+.2byte    6,  -12, 	   7,  -10, 	   1,   -9, 	  -5,  -11
+.2byte    7,  -13, 	   7,  -11, 	   3,   -9, 	  -5,   -9
+.2byte    6,  -15, 	   0,  -12, 	   7,  -10, 	  -3,   -8
+.2byte    0,  -15, 	   9,  -15, 	  -9,  -15, 	   0,  -10
+.2byte   -7,  -15, 	  -1,  -12, 	  -8,  -10, 	   2,   -8
+.2byte   -8,  -13, 	  -8,  -11, 	  -4,   -9, 	   4,   -9
+.2byte   -7,  -12, 	  -8,  -10, 	  -2,   -9, 	   4,  -11
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -1,   -9, 	  -6,    1, 	   4,    1, 	  -1,  -10
+.2byte   -1,    7, 	  -8,    4, 	   7,    4, 	  -1,   -6
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+.2byte   10,  -12, 	   6,   -4, 	   2,   -1, 	  -4,   -8
+.2byte   11,    2, 	   3,   -2, 	  -2,    3, 	  -2,   -7
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte   10,  -14, 	   3,   -5, 	   5,   -3, 	  -4,   -8
+.2byte   12,   -4, 	   3,   -1, 	   4,    3, 	  -3,   -6
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte    8,  -20, 	   0,   -9, 	   6,   -5, 	  -4,   -9
+.2byte   11,  -11, 	   2,   -6, 	   8,    0, 	  -2,   -8
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -24, 	   5,   -7, 	  -6,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -9, 	  -7,  -10, 	  -1,   -8
+.2byte  -10,   -8, 	   0,   -8, 	  -7,   -2, 	   1,   -7
+.2byte  -10,  -20, 	  -2,   -9, 	  -8,   -5, 	   2,   -9
+.2byte  -13,  -11, 	  -4,   -6, 	 -10,    0, 	   0,   -8
+.2byte  -14,   -4, 	  -4,   -4, 	  -6,    1, 	   1,   -7
+.2byte  -12,  -14, 	  -5,   -5, 	  -7,   -3, 	   2,   -8
+.2byte  -14,   -4, 	  -5,   -1, 	  -6,    3, 	   1,   -6
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    2, 	   1,   -8
+.2byte  -12,  -12, 	  -8,   -4, 	  -4,   -1, 	   2,   -8
+.2byte  -13,    2, 	  -5,   -2, 	   0,    3, 	   0,   -7
+.2byte    0,    5, 	  -5,    3, 	   6,    3, 	   0,   -7
+.2byte  -11,    2, 	  -5,   -3, 	  -1,    2, 	   1,   -7
+.2byte  -13,   -1, 	  -4,   -2, 	  -3,    0, 	   1,   -7
+.2byte  -11,   -7, 	  -3,   -8, 	  -6,   -2, 	   1,   -8
+.2byte    0,  -13, 	   6,  -11, 	  -6,  -11, 	   0,  -10
+.2byte   10,   -7, 	   2,   -8, 	   5,   -2, 	  -2,   -8
+.2byte   12,   -1, 	   3,   -2, 	   2,    0, 	  -2,   -7
+.2byte   10,    2, 	   4,   -3, 	   0,    2, 	  -2,   -7
+.2byte    0,   -9, 	  -5,    1, 	   5,    1, 	   0,  -10
+.2byte   10,  -12, 	   6,   -4, 	   2,   -1, 	  -4,   -8
+.2byte   11,  -14, 	   4,   -5, 	   6,   -3, 	  -3,   -8
+.2byte    8,  -19, 	   0,   -8, 	   6,   -4, 	  -4,   -8
+.2byte    0,  -24, 	   6,   -7, 	  -5,   -7, 	   0,  -10
+.2byte  -10,  -19, 	  -2,   -8, 	  -8,   -4, 	   2,   -8
+.2byte  -12,  -14, 	  -5,   -5, 	  -7,   -3, 	   2,   -8
+.2byte  -11,  -12, 	  -7,   -4, 	  -3,   -1, 	   3,   -8
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte   -1,   -8, 	  -6,    2, 	   4,    2, 	  -1,   -9
+.2byte   -1,    4, 	  -8,    1, 	   7,    1, 	  -1,   -9
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+.2byte    9,  -11, 	   5,   -3, 	   1,    0, 	  -5,   -7
+.2byte   10,    2, 	   2,   -2, 	  -3,    3, 	  -3,   -7
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte   10,  -13, 	   3,   -4, 	   5,   -2, 	  -4,   -7
+.2byte   13,   -5, 	   4,   -2, 	   5,    2, 	  -2,   -7
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte    9,  -20, 	   1,   -9, 	   7,   -5, 	  -3,   -9
+.2byte   11,  -11, 	   2,   -6, 	   8,    0, 	  -2,   -8
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -24, 	   5,   -7, 	  -6,   -7, 	  -1,  -10
+.2byte   -1,  -12, 	   5,  -10, 	  -7,  -11, 	  -1,   -9
+.2byte   -9,   -8, 	   1,   -8, 	  -6,   -2, 	   2,   -7
+.2byte  -10,  -20, 	  -2,   -9, 	  -8,   -5, 	   2,   -9
+.2byte  -12,  -12, 	  -3,   -7, 	  -9,   -1, 	   1,   -9
+.2byte  -13,   -4, 	  -3,   -4, 	  -5,    1, 	   2,   -7
+.2byte  -11,  -13, 	  -4,   -4, 	  -6,   -2, 	   3,   -7
+.2byte  -14,   -5, 	  -5,   -2, 	  -6,    2, 	   1,   -7
+.2byte   -9,   -2, 	  -6,    0, 	  -1,    2, 	   2,   -8
+.2byte  -11,  -11, 	  -7,   -3, 	  -3,    0, 	   3,   -7
+.2byte  -11,    2, 	  -3,   -2, 	   2,    3, 	   2,   -7
+.2byte   -1,    5, 	  -8,    2, 	   7,    2, 	  -1,   -8
+.2byte  -13,    2, 	  -5,   -2, 	   0,    3, 	   0,   -7
+.2byte  -14,   -4, 	  -5,   -1, 	  -6,    3, 	   1,   -6
+.2byte  -12,  -10, 	  -3,   -5, 	  -9,    1, 	   1,   -7
+.2byte   -1,  -12, 	   5,  -10, 	  -7,  -11, 	  -1,   -9
+.2byte   11,  -10, 	   2,   -5, 	   8,    1, 	  -2,   -7
+.2byte   13,   -4, 	   4,   -1, 	   5,    3, 	  -2,   -6
+.2byte   12,    2, 	   4,   -2, 	  -1,    3, 	  -1,   -7
+.2byte   -1,    0, 	  -6,    2, 	   4,    2, 	  -1,   -8
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    2, 	   1,   -8
+.2byte  -14,   -4, 	  -4,   -4, 	  -6,    1, 	   1,   -7
+.2byte  -10,   -8, 	   0,   -8, 	  -7,   -2, 	   1,   -7
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -9, 	  -1,  -10
+.2byte    8,   -8, 	  -2,   -8, 	   5,   -2, 	  -3,   -7
+.2byte   12,   -4, 	   2,   -4, 	   4,    1, 	  -3,   -7
+.2byte    8,   -2, 	   5,    0, 	   0,    2, 	  -3,   -8
+sCameruptAnimTable1:
+.4byte sCameruptAnims_1_1
+.4byte sCameruptAnims_1_2
+.4byte sCameruptAnims_1_3
+.4byte sCameruptAnims_1_4
+.4byte sCameruptAnims_1_5
+.4byte sCameruptAnims_1_6
+.4byte sCameruptAnims_1_7
+.4byte sCameruptAnims_1_8
+sCameruptAnimTable2:
+.4byte sCameruptAnims_2_1
+.4byte sCameruptAnims_2_2
+.4byte sCameruptAnims_2_3
+.4byte sCameruptAnims_2_4
+.4byte sCameruptAnims_2_5
+.4byte sCameruptAnims_2_6
+.4byte sCameruptAnims_2_7
+.4byte sCameruptAnims_2_8
+sCameruptAnimTable3:
+.4byte sCameruptAnims_3_1
+.4byte sCameruptAnims_3_2
+.4byte sCameruptAnims_3_3
+.4byte sCameruptAnims_3_4
+.4byte sCameruptAnims_3_5
+.4byte sCameruptAnims_3_6
+.4byte sCameruptAnims_3_7
+.4byte sCameruptAnims_3_8
+sCameruptAnimTable4:
+.4byte sCameruptAnims_4_1
+.4byte sCameruptAnims_4_2
+.4byte sCameruptAnims_4_3
+.4byte sCameruptAnims_4_4
+.4byte sCameruptAnims_4_5
+.4byte sCameruptAnims_4_6
+.4byte sCameruptAnims_4_7
+.4byte sCameruptAnims_4_8
+sCameruptAnimTable5:
+.4byte sCameruptAnims_5_1
+.4byte sCameruptAnims_5_2
+.4byte sCameruptAnims_5_3
+.4byte sCameruptAnims_5_4
+.4byte sCameruptAnims_5_5
+.4byte sCameruptAnims_5_6
+.4byte sCameruptAnims_5_7
+.4byte sCameruptAnims_5_8
+sCameruptAnimTable6:
+.4byte sCameruptAnims_6_1
+.4byte sCameruptAnims_6_1
+.4byte sCameruptAnims_6_1
+.4byte sCameruptAnims_6_1
+.4byte sCameruptAnims_6_1
+.4byte sCameruptAnims_6_1
+.4byte sCameruptAnims_6_1
+.4byte sCameruptAnims_6_1
+sCameruptAnimTable7:
+.4byte sCameruptAnims_7_1
+.4byte sCameruptAnims_7_2
+.4byte sCameruptAnims_7_3
+.4byte sCameruptAnims_7_4
+.4byte sCameruptAnims_7_5
+.4byte sCameruptAnims_7_6
+.4byte sCameruptAnims_7_7
+.4byte sCameruptAnims_7_8
+sCameruptAnimTable8:
+.4byte sCameruptAnims_8_1
+.4byte sCameruptAnims_8_2
+.4byte sCameruptAnims_8_3
+.4byte sCameruptAnims_8_4
+.4byte sCameruptAnims_8_5
+.4byte sCameruptAnims_8_6
+.4byte sCameruptAnims_8_7
+.4byte sCameruptAnims_8_8
+sCameruptAnimTable9:
+.4byte sCameruptAnims_9_1
+.4byte sCameruptAnims_9_2
+.4byte sCameruptAnims_9_3
+.4byte sCameruptAnims_9_4
+.4byte sCameruptAnims_9_5
+.4byte sCameruptAnims_9_6
+.4byte sCameruptAnims_9_7
+.4byte sCameruptAnims_9_8
+sCameruptAnimTable10:
+.4byte sCameruptAnims_10_1
+.4byte sCameruptAnims_10_2
+.4byte sCameruptAnims_10_3
+.4byte sCameruptAnims_10_4
+.4byte sCameruptAnims_10_5
+.4byte sCameruptAnims_10_6
+.4byte sCameruptAnims_10_7
+.4byte sCameruptAnims_10_8
+sCameruptAnimTable11:
+.4byte sCameruptAnims_11_1
+.4byte sCameruptAnims_11_2
+.4byte sCameruptAnims_11_3
+.4byte sCameruptAnims_11_4
+.4byte sCameruptAnims_11_5
+.4byte sCameruptAnims_11_6
+.4byte sCameruptAnims_11_7
+.4byte sCameruptAnims_11_8
+sCameruptAnimTable12:
+.4byte sCameruptAnims_12_1
+.4byte sCameruptAnims_12_2
+.4byte sCameruptAnims_12_3
+.4byte sCameruptAnims_12_4
+.4byte sCameruptAnims_12_5
+.4byte sCameruptAnims_12_6
+.4byte sCameruptAnims_12_7
+.4byte sCameruptAnims_12_8
+sCameruptAnimTable13:
+.4byte sCameruptAnims_13_1
+.4byte sCameruptAnims_13_2
+.4byte sCameruptAnims_13_3
+.4byte sCameruptAnims_13_4
+.4byte sCameruptAnims_13_5
+.4byte sCameruptAnims_13_6
+.4byte sCameruptAnims_13_7
+.4byte sCameruptAnims_13_8
+sAxAnimationsCamerupt:
+.4byte sCameruptAnimTable1
+.4byte sCameruptAnimTable2
+.4byte sCameruptAnimTable3
+.4byte sCameruptAnimTable4
+.4byte sCameruptAnimTable5
+.4byte sCameruptAnimTable6
+.4byte sCameruptAnimTable7
+.4byte sCameruptAnimTable8
+.4byte sCameruptAnimTable9
+.4byte sCameruptAnimTable10
+.4byte sCameruptAnimTable11
+.4byte sCameruptAnimTable12
+.4byte sCameruptAnimTable13
+sAxSpritesCamerupt:
+.4byte sCameruptSprites1
+.4byte sCameruptSprites2
+.4byte sCameruptSprites3
+.4byte sCameruptSprites4
+.4byte sCameruptSprites5
+.4byte sCameruptSprites6
+.4byte sCameruptSprites7
+.4byte sCameruptSprites8
+.4byte sCameruptSprites9
+.4byte sCameruptSprites10
+.4byte sCameruptSprites11
+.4byte sCameruptSprites12
+.4byte sCameruptSprites13
+.4byte sCameruptSprites14
+.4byte sCameruptSprites15
+.4byte sCameruptSprites16
+.4byte sCameruptSprites17
+.4byte sCameruptSprites18
+.4byte sCameruptSprites19
+.4byte sCameruptSprites20
+.4byte sCameruptSprites21
+.4byte sCameruptSprites22
+.4byte sCameruptSprites23
+.4byte sCameruptSprites24
+.4byte sCameruptSprites25
+.4byte sCameruptSprites26
+.4byte sCameruptSprites27
+.4byte sCameruptSprites28
+.4byte sCameruptSprites29
+.4byte sCameruptSprites30
+.4byte sCameruptSprites31
+.4byte sCameruptSprites32
+.4byte sCameruptSprites33
+.4byte sCameruptSprites34
+.4byte sCameruptSprites35
+.4byte sCameruptSprites36
+.4byte sCameruptSprites37
+.4byte sCameruptSprites38
+.4byte sCameruptSprites39
+.4byte sCameruptSprites40
+.4byte sCameruptSprites41
+.4byte sCameruptSprites42
+.4byte sCameruptSprites43
+.4byte sCameruptSprites44
+.4byte sCameruptSprites45
+sAxMainCamerupt:
+ax_main sAxPosesCamerupt, sAxAnimationsCamerupt, 13, sAxSpritesCamerupt, sAxPositionsCamerupt

--- a/data/ax/carvanha.inc
+++ b/data/ax/carvanha.inc
@@ -1,0 +1,2627 @@
+.global gAxCarvanha
+gAxCarvanha:
+ax_siro sAxMainCarvanha
+sCarvanhaPose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose3:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose4:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose5:
+ax_pose 4, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose6:
+ax_pose 5, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose7:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose8:
+ax_pose 7, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose9:
+ax_pose 8, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose10:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose11:
+ax_pose 10, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose12:
+ax_pose 11, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose13:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose14:
+ax_pose 13, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose15:
+ax_pose 14, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose16:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose17:
+ax_pose 10, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose18:
+ax_pose 11, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose19:
+ax_pose 6, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose20:
+ax_pose 7, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose21:
+ax_pose 8, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose22:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose23:
+ax_pose 4, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose24:
+ax_pose 5, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose25:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose26:
+ax_pose 15, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose27:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose28:
+ax_pose 16, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose29:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose30:
+ax_pose 17, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose31:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose32:
+ax_pose 18, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose33:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose34:
+ax_pose 19, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose35:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose36:
+ax_pose 18, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose37:
+ax_pose 6, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose38:
+ax_pose 17, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose39:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose40:
+ax_pose 16, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose41:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose42:
+ax_pose 15, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose43:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose44:
+ax_pose 16, 0x01e2, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose45:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose46:
+ax_pose 17, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose47:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose48:
+ax_pose 18, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose49:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose50:
+ax_pose 19, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose51:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose52:
+ax_pose 18, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose53:
+ax_pose 6, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose54:
+ax_pose 17, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose55:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose56:
+ax_pose 16, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose57:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose58:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose59:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose60:
+ax_pose 20, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose61:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose62:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose63:
+ax_pose 4, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose64:
+ax_pose 5, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose65:
+ax_pose 21, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose66:
+ax_pose 16, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose67:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose68:
+ax_pose 7, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose69:
+ax_pose 8, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose70:
+ax_pose 22, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose71:
+ax_pose 17, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose72:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose73:
+ax_pose 10, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose74:
+ax_pose 11, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose75:
+ax_pose 23, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose76:
+ax_pose 18, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose77:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose78:
+ax_pose 13, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose79:
+ax_pose 14, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose80:
+ax_pose 24, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose81:
+ax_pose 19, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose82:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose83:
+ax_pose 10, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose84:
+ax_pose 11, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose85:
+ax_pose 23, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose86:
+ax_pose 18, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose87:
+ax_pose 6, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose88:
+ax_pose 7, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose89:
+ax_pose 8, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose90:
+ax_pose 22, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose91:
+ax_pose 17, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose92:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose93:
+ax_pose 4, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose94:
+ax_pose 5, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose95:
+ax_pose 21, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose96:
+ax_pose 16, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose97:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose98:
+ax_pose 25, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose99:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose100:
+ax_pose 26, 0x01e1, 0x90ee, 0x2c00
+ax_pose_terminator
+sCarvanhaPose101:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose102:
+ax_pose 27, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sCarvanhaPose103:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose104:
+ax_pose 28, 0x01e1, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose105:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose106:
+ax_pose 29, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose107:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose108:
+ax_pose 28, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose109:
+ax_pose 6, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose110:
+ax_pose 27, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose111:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose112:
+ax_pose 26, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose113:
+ax_pose 30, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose114:
+ax_pose 31, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose115:
+ax_pose 32, 0x01db, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose116:
+ax_pose 33, 0x01e1, 0x90ef, 0x2c00
+ax_pose_terminator
+sCarvanhaPose117:
+ax_pose 34, 0x01df, 0x90ea, 0x2c00
+ax_pose_terminator
+sCarvanhaPose118:
+ax_pose 35, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose119:
+ax_pose 36, 0x41e1, 0x80f0, 0x2c00
+ax_pose 37, 0x41d9, 0x00f8, 0x2c08
+ax_pose 38, 0x01f9, 0x00fc, 0x2c0a
+ax_pose 39, 0x41f1, 0x40f0, 0x2c0b
+ax_pose_terminator
+sCarvanhaPose120:
+ax_pose 35, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose121:
+ax_pose 34, 0x01df, 0x80f6, 0x2c00
+ax_pose_terminator
+sCarvanhaPose122:
+ax_pose 33, 0x01e1, 0x80f1, 0x2c00
+ax_pose_terminator
+sCarvanhaPose123:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose124:
+ax_pose 1, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose125:
+ax_pose 2, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose126:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose127:
+ax_pose 4, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose128:
+ax_pose 5, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose129:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose130:
+ax_pose 7, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose131:
+ax_pose 8, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose132:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose133:
+ax_pose 10, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose134:
+ax_pose 11, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose135:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose136:
+ax_pose 13, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose137:
+ax_pose 14, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose138:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose139:
+ax_pose 10, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose140:
+ax_pose 11, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose141:
+ax_pose 6, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose142:
+ax_pose 7, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose143:
+ax_pose 8, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose144:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose145:
+ax_pose 4, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose146:
+ax_pose 5, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose147:
+ax_pose 15, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose148:
+ax_pose 16, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose149:
+ax_pose 17, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose150:
+ax_pose 18, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose151:
+ax_pose 19, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose152:
+ax_pose 18, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose153:
+ax_pose 17, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose154:
+ax_pose 16, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose155:
+ax_pose 20, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose156:
+ax_pose 21, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose157:
+ax_pose 22, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose158:
+ax_pose 23, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose159:
+ax_pose 24, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose160:
+ax_pose 23, 0x01e3, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose161:
+ax_pose 22, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose162:
+ax_pose 21, 0x01e3, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose163:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose164:
+ax_pose 15, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose165:
+ax_pose 20, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose166:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose167:
+ax_pose 16, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose168:
+ax_pose 21, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose169:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose170:
+ax_pose 17, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose171:
+ax_pose 22, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sCarvanhaPose172:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose173:
+ax_pose 18, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose174:
+ax_pose 23, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose175:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose176:
+ax_pose 19, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose177:
+ax_pose 24, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose178:
+ax_pose 9, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose179:
+ax_pose 18, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose180:
+ax_pose 23, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose181:
+ax_pose 6, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose182:
+ax_pose 17, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose183:
+ax_pose 22, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sCarvanhaPose184:
+ax_pose 3, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose185:
+ax_pose 16, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose186:
+ax_pose 21, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sCarvanhaPose187:
+ax_pose 15, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose188:
+ax_pose 16, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose189:
+ax_pose 17, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sCarvanhaPose190:
+ax_pose 18, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose191:
+ax_pose 19, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose192:
+ax_pose 18, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose193:
+ax_pose 17, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sCarvanhaPose194:
+ax_pose 16, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose195:
+ax_pose 0, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose196:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose197:
+ax_pose 6, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose198:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCarvanhaPose199:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCarvanhaPose200:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose201:
+ax_pose 6, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sCarvanhaPose202:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sCarvanhaAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -1, 0, -1, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, 0, 1, 0,
+ax_anim_terminator
+sCarvanhaAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 0, 1, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, -1, 0, -1, 0,
+ax_anim_terminator
+sCarvanhaAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 1,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, -1,
+ax_anim_terminator
+sCarvanhaAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, 0, -1, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 1, 0, 1, 0,
+ax_anim_terminator
+sCarvanhaAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 1, 0, 1, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, -1, 0, -1, 0,
+ax_anim_terminator
+sCarvanhaAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 1, -1, 1, -1,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, -1, 1, -1, 1,
+ax_anim_terminator
+sCarvanhaAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, -1,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 1,
+ax_anim_terminator
+sCarvanhaAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, -1, -1, -1,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 22, 0, 22,
+ax_anim 2, 1, 24, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 22, 0, 22,
+ax_anim 2, 0, 24, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCarvanhaAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 10, 11, 10, 11,
+ax_anim 2, 0, 26, 18, 22, 18, 20,
+ax_anim 2, 1, 26, 19, 21, 19, 19,
+ax_anim 2, 0, 26, 18, 22, 18, 20,
+ax_anim 2, 0, 26, 19, 21, 19, 19,
+ax_anim 2, 0, 26, 6, 6, 6, 6,
+ax_anim_terminator
+sCarvanhaAnims_2_3:
+ax_anim 2, 0, 29, -1, 0, -1, 0,
+ax_anim 4, 0, 29, -2, 0, -2, 0,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 1, 4, 0,
+ax_anim 1, 0, 29, 10, 2, 10, 0,
+ax_anim 2, 0, 28, 17, 3, 17, 0,
+ax_anim 2, 1, 28, 17, 4, 17, 1,
+ax_anim 2, 0, 28, 17, 3, 17, 0,
+ax_anim 2, 0, 28, 17, 4, 17, 1,
+ax_anim 2, 0, 28, 6, 1, 6, 0,
+ax_anim_terminator
+sCarvanhaAnims_2_4:
+ax_anim 2, 0, 31, -1, 1, -1, 1,
+ax_anim 4, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 0, 31, 0, -1, 0, -1,
+ax_anim 1, 2, 31, 5, -6, 5, -6,
+ax_anim 1, 0, 31, 11, -12, 11, -13,
+ax_anim 2, 0, 30, 17, -18, 17, -21,
+ax_anim 2, 1, 30, 18, -17, 18, -20,
+ax_anim 2, 0, 30, 17, -18, 17, -21,
+ax_anim 2, 0, 30, 18, -17, 18, -20,
+ax_anim 2, 0, 30, 5, -7, 5, -7,
+ax_anim_terminator
+sCarvanhaAnims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 4, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, -4, 0, -4,
+ax_anim 1, 0, 33, 0, -11, 0, -12,
+ax_anim 2, 0, 32, 0, -18, 0, -21,
+ax_anim 2, 1, 32, 1, -18, 1, -21,
+ax_anim 2, 0, 32, 0, -18, 0, -21,
+ax_anim 2, 0, 32, 1, -18, 1, -21,
+ax_anim 2, 0, 32, 0, -6, 0, -6,
+ax_anim_terminator
+sCarvanhaAnims_2_6:
+ax_anim 2, 0, 35, 1, 1, 1, 1,
+ax_anim 4, 0, 35, 2, 2, 2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 35, -5, -6, -5, -6,
+ax_anim 1, 0, 35, -11, -12, -11, -13,
+ax_anim 2, 0, 34, -17, -18, -17, -21,
+ax_anim 2, 1, 34, -18, -17, -18, -20,
+ax_anim 2, 0, 34, -17, -18, -17, -21,
+ax_anim 2, 0, 34, -18, -17, -18, -20,
+ax_anim 2, 0, 34, -5, -7, -5, -7,
+ax_anim_terminator
+sCarvanhaAnims_2_7:
+ax_anim 2, 0, 37, 1, 0, 1, 0,
+ax_anim 4, 0, 37, 2, 0, 2, 0,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, -4, 1, -4, 0,
+ax_anim 1, 0, 37, -10, 2, -10, 0,
+ax_anim 2, 0, 36, -17, 3, -17, 0,
+ax_anim 2, 1, 36, -17, 4, -17, 1,
+ax_anim 2, 0, 36, -17, 3, -17, 0,
+ax_anim 2, 0, 36, -17, 4, -17, 1,
+ax_anim 2, 0, 36, -6, 1, -6, 0,
+ax_anim_terminator
+sCarvanhaAnims_2_8:
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 4, 0, 39, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, -4, 4, -4, 4,
+ax_anim 1, 0, 39, -10, 11, -10, 11,
+ax_anim 2, 0, 38, -18, 22, -18, 20,
+ax_anim 2, 1, 38, -19, 21, -19, 19,
+ax_anim 2, 0, 38, -18, 22, -18, 20,
+ax_anim 2, 0, 38, -19, 21, -19, 19,
+ax_anim 2, 0, 38, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_3_1:
+ax_anim 2, 0, 40, 0, -2, 0, -2,
+ax_anim 6, 0, 40, 0, -3, 0, -3,
+ax_anim 1, 0, 41, 0, 1, 0, 1,
+ax_anim 2, 0, 41, 0, 11, 0, 11,
+ax_anim 4, 2, 41, 0, 21, 0, 19,
+ax_anim 2, 1, 40, 0, 21, 0, 19,
+ax_anim 2, 0, 41, 0, 21, 0, 19,
+ax_anim 2, 0, 40, 0, 21, 0, 19,
+ax_anim 2, 0, 41, 0, 21, 0, 19,
+ax_anim 2, 0, 40, 0, 21, 0, 19,
+ax_anim 2, 0, 40, 0, 13, 0, 13,
+ax_anim 2, 0, 40, 0, 4, 0, 4,
+ax_anim_terminator
+sCarvanhaAnims_3_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 6, 0, 42, -3, -3, -3, -3,
+ax_anim 1, 0, 43, 1, 1, 1, 1,
+ax_anim 2, 0, 43, 10, 12, 10, 12,
+ax_anim 4, 2, 43, 19, 21, 19, 20,
+ax_anim 2, 1, 42, 19, 21, 20, 20,
+ax_anim 2, 0, 43, 19, 21, 19, 20,
+ax_anim 2, 0, 42, 19, 21, 20, 20,
+ax_anim 2, 0, 43, 19, 21, 19, 20,
+ax_anim 2, 0, 42, 19, 21, 20, 20,
+ax_anim 2, 0, 42, 13, 13, 13, 13,
+ax_anim 2, 0, 42, 4, 4, 4, 4,
+ax_anim_terminator
+sCarvanhaAnims_3_3:
+ax_anim 2, 0, 44, -2, 0, -2, 0,
+ax_anim 6, 0, 44, -3, 0, -3, 0,
+ax_anim 1, 0, 45, 1, 1, 1, 0,
+ax_anim 2, 0, 45, 10, 2, 10, 0,
+ax_anim 4, 2, 45, 18, 3, 18, 0,
+ax_anim 2, 1, 44, 18, 3, 18, 0,
+ax_anim 2, 0, 45, 18, 3, 18, 0,
+ax_anim 2, 0, 44, 18, 3, 18, 0,
+ax_anim 2, 0, 45, 18, 3, 18, 0,
+ax_anim 2, 0, 44, 18, 3, 18, 0,
+ax_anim 2, 0, 44, 13, 0, 13, 0,
+ax_anim 2, 0, 44, 4, 1, 4, 0,
+ax_anim_terminator
+sCarvanhaAnims_3_4:
+ax_anim 2, 0, 46, -2, 2, -2, 2,
+ax_anim 6, 0, 46, -3, 3, -3, 3,
+ax_anim 1, 0, 47, 1, -1, 1, -1,
+ax_anim 2, 0, 47, 12, -12, 12, -13,
+ax_anim 4, 2, 47, 18, -16, 19, -19,
+ax_anim 2, 1, 46, 18, -16, 19, -19,
+ax_anim 2, 0, 47, 18, -16, 19, -19,
+ax_anim 2, 0, 46, 18, -16, 19, -19,
+ax_anim 2, 0, 47, 18, -16, 19, -19,
+ax_anim 2, 0, 46, 18, -16, 19, -19,
+ax_anim 2, 0, 46, 12, -11, 12, -11,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim_terminator
+sCarvanhaAnims_3_5:
+ax_anim 2, 0, 48, 0, 2, 0, 2,
+ax_anim 6, 0, 48, 0, 3, 0, 3,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -12, 0, -12,
+ax_anim 4, 2, 49, 0, -19, 0, -21,
+ax_anim 2, 1, 48, 0, -19, 0, -21,
+ax_anim 2, 0, 49, 0, -19, 0, -21,
+ax_anim 2, 0, 48, 0, -19, 0, -21,
+ax_anim 2, 0, 49, 0, -19, 0, -21,
+ax_anim 2, 0, 48, 0, -19, 0, -21,
+ax_anim 2, 0, 48, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -4, 0, -4,
+ax_anim_terminator
+sCarvanhaAnims_3_6:
+ax_anim 2, 0, 50, 2, 2, 2, 2,
+ax_anim 6, 0, 50, 3, 3, 3, 3,
+ax_anim 1, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 51, -12, -12, -12, -13,
+ax_anim 4, 2, 51, -18, -16, -19, -19,
+ax_anim 2, 1, 50, -18, -16, -19, -19,
+ax_anim 2, 0, 51, -18, -16, -19, -19,
+ax_anim 2, 0, 50, -18, -16, -19, -19,
+ax_anim 2, 0, 51, -18, -16, -19, -19,
+ax_anim 2, 0, 50, -18, -16, -19, -19,
+ax_anim 2, 0, 50, -12, -11, -12, -11,
+ax_anim 2, 0, 50, -4, -4, -4, -4,
+ax_anim_terminator
+sCarvanhaAnims_3_7:
+ax_anim 2, 0, 52, 2, 0, 2, 0,
+ax_anim 6, 0, 52, 3, 0, 3, 0,
+ax_anim 1, 0, 53, -1, 1, -1, 0,
+ax_anim 2, 0, 53, -10, 2, -10, 0,
+ax_anim 4, 2, 53, -18, 3, -18, 0,
+ax_anim 2, 1, 52, -18, 3, -18, 0,
+ax_anim 2, 0, 53, -18, 3, -18, 0,
+ax_anim 2, 0, 52, -18, 3, -18, 0,
+ax_anim 2, 0, 53, -18, 3, -18, 0,
+ax_anim 2, 0, 52, -18, 3, -18, 0,
+ax_anim 2, 0, 52, -13, 0, -13, 0,
+ax_anim 2, 0, 52, -4, 1, -4, 0,
+ax_anim_terminator
+sCarvanhaAnims_3_8:
+ax_anim 2, 0, 54, 2, -2, 2, -2,
+ax_anim 6, 0, 54, 3, -3, 3, -3,
+ax_anim 1, 0, 55, -1, 1, -1, 1,
+ax_anim 2, 0, 55, -10, 12, -10, 12,
+ax_anim 4, 2, 55, -19, 21, -19, 20,
+ax_anim 2, 1, 54, -19, 21, -20, 20,
+ax_anim 2, 0, 55, -19, 21, -19, 20,
+ax_anim 2, 0, 54, -19, 21, -20, 20,
+ax_anim 2, 0, 55, -19, 21, -19, 20,
+ax_anim 2, 0, 54, -19, 21, -20, 20,
+ax_anim 2, 0, 54, -13, 13, -13, 13,
+ax_anim 2, 0, 54, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_4_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, -4, 0, -4,
+ax_anim 6, 2, 56, 0, -5, 0, -5,
+ax_anim 1, 0, 59, 0, 1, 0, 1,
+ax_anim 2, 0, 59, 0, 3, 0, 3,
+ax_anim 2, 0, 60, 0, 5, 0, 5,
+ax_anim 2, 1, 60, -1, 5, -1, 5,
+ax_anim 2, 0, 60, 0, 5, 0, 5,
+ax_anim 2, 0, 60, -1, 5, -1, 5,
+ax_anim 2, 0, 60, 0, 5, 0, 5,
+ax_anim 2, 0, 60, -1, 5, -1, 5,
+ax_anim 2, 0, 56, 0, 2, 0, 2,
+ax_anim_terminator
+sCarvanhaAnims_4_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim 6, 2, 61, -5, -5, -5, -5,
+ax_anim 1, 0, 64, 1, 1, 1, 1,
+ax_anim 2, 0, 64, 3, 3, 3, 3,
+ax_anim 2, 0, 65, 5, 5, 5, 5,
+ax_anim 2, 1, 65, 4, 6, 4, 6,
+ax_anim 2, 0, 65, 5, 5, 5, 5,
+ax_anim 2, 0, 65, 4, 6, 4, 6,
+ax_anim 2, 0, 65, 5, 5, 5, 5,
+ax_anim 2, 0, 65, 4, 6, 4, 6,
+ax_anim 2, 0, 61, 2, 2, 2, 2,
+ax_anim_terminator
+sCarvanhaAnims_4_3:
+ax_anim 2, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 68, -4, 0, -4, 0,
+ax_anim 6, 2, 66, -5, 0, -5, 0,
+ax_anim 1, 0, 69, 1, 0, 1, 0,
+ax_anim 2, 0, 69, 3, 0, 3, 0,
+ax_anim 2, 0, 70, 5, 0, 5, 0,
+ax_anim 2, 1, 70, 5, -1, 5, -1,
+ax_anim 2, 0, 70, 5, 0, 5, 0,
+ax_anim 2, 0, 70, 5, -1, 5, -1,
+ax_anim 2, 0, 70, 5, 0, 5, 0,
+ax_anim 2, 0, 70, 5, -1, 5, -1,
+ax_anim 2, 0, 66, 2, 0, 2, 0,
+ax_anim_terminator
+sCarvanhaAnims_4_4:
+ax_anim 2, 0, 72, -2, 2, -2, 2,
+ax_anim 2, 0, 73, -4, 4, -4, 4,
+ax_anim 6, 2, 71, -5, 5, -5, 5,
+ax_anim 1, 0, 74, 1, -1, 1, -1,
+ax_anim 2, 0, 74, 3, -3, 3, -3,
+ax_anim 2, 0, 75, 5, -5, 5, -5,
+ax_anim 2, 1, 75, 4, -6, 4, -6,
+ax_anim 2, 0, 75, 5, -5, 5, -5,
+ax_anim 2, 0, 75, 4, -6, 4, -6,
+ax_anim 2, 0, 75, 5, -5, 5, -5,
+ax_anim 2, 0, 75, 4, -6, 4, -6,
+ax_anim 2, 0, 71, 2, -2, 2, -2,
+ax_anim_terminator
+sCarvanhaAnims_4_5:
+ax_anim 2, 0, 77, 0, 2, 0, 2,
+ax_anim 2, 0, 78, 0, 4, 0, 4,
+ax_anim 6, 2, 76, 0, 6, 0, 5,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 2, 0, 79, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 0, -5, 0, -5,
+ax_anim 2, 1, 80, -1, -5, -1, -5,
+ax_anim 2, 0, 80, 0, -5, 0, -5,
+ax_anim 2, 0, 80, -1, -5, -1, -5,
+ax_anim 2, 0, 80, 0, -5, 0, -5,
+ax_anim 2, 0, 80, -1, -5, -1, -5,
+ax_anim 2, 0, 76, 0, -2, 0, -2,
+ax_anim_terminator
+sCarvanhaAnims_4_6:
+ax_anim 2, 0, 82, 2, 2, 2, 2,
+ax_anim 2, 0, 83, 4, 4, 4, 4,
+ax_anim 6, 2, 81, 5, 5, 5, 5,
+ax_anim 1, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, -3, -3, -3, -3,
+ax_anim 2, 0, 85, -5, -5, -5, -5,
+ax_anim 2, 1, 85, -4, -6, -4, -6,
+ax_anim 2, 0, 85, -5, -5, -5, -5,
+ax_anim 2, 0, 85, -4, -6, -4, -6,
+ax_anim 2, 0, 85, -5, -5, -5, -5,
+ax_anim 2, 0, 85, -4, -6, -4, -6,
+ax_anim 2, 0, 81, -2, -2, -2, -2,
+ax_anim_terminator
+sCarvanhaAnims_4_7:
+ax_anim 2, 0, 87, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim 6, 2, 86, 5, 0, 5, 0,
+ax_anim 1, 0, 89, -1, 0, -1, 0,
+ax_anim 2, 0, 89, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -5, 0, -5, 0,
+ax_anim 2, 1, 90, -5, -1, -5, -1,
+ax_anim 2, 0, 90, -5, 0, -5, 0,
+ax_anim 2, 0, 90, -5, -1, -5, -1,
+ax_anim 2, 0, 90, -5, 0, -5, 0,
+ax_anim 2, 0, 90, -5, -1, -5, -1,
+ax_anim 2, 0, 86, -2, 0, -2, 0,
+ax_anim_terminator
+sCarvanhaAnims_4_8:
+ax_anim 2, 0, 92, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 4, -4, 4, -4,
+ax_anim 6, 2, 91, 5, -5, 5, -5,
+ax_anim 1, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 0, 94, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -5, 5, -5, 5,
+ax_anim 2, 1, 95, -4, 6, -4, 6,
+ax_anim 2, 0, 95, -5, 5, -5, 5,
+ax_anim 2, 0, 95, -4, 6, -4, 6,
+ax_anim 2, 0, 95, -5, 5, -5, 5,
+ax_anim 2, 0, 95, -4, 6, -4, 6,
+ax_anim 2, 0, 91, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_5_1:
+ax_anim 3, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 3, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 3, 2, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_5_2:
+ax_anim 3, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 3, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 3, 2, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_5_3:
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 3, 2, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_5_4:
+ax_anim 3, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 3, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 3, 2, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_5_5:
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 2, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_5_6:
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 2, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_5_7:
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 2, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_5_8:
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 2, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_6_1:
+ax_anim 8, 0, 112, 0, 0, 0, 0,
+ax_anim 8, 0, 112, 0, -1, 0, 0,
+ax_anim 26, 0, 112, 0, -2, 0, 0,
+ax_anim 8, 0, 113, 0, -2, 0, 0,
+ax_anim 8, 0, 113, 0, -1, 0, 0,
+ax_anim 26, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sCarvanhaAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sCarvanhaAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sCarvanhaAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sCarvanhaAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sCarvanhaAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sCarvanhaAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sCarvanhaAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_8_1:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 26, 0, 123, 0, 1, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 36, 0, 124, 0, -1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_8_2:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 26, 0, 126, 0, 1, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 36, 0, 127, 0, -1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_8_3:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 26, 0, 129, 0, 1, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 36, 0, 130, 0, -1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_8_4:
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 26, 0, 132, 0, 1, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 36, 0, 133, 0, -1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_8_5:
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 26, 0, 135, 0, 1, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 36, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_8_6:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 26, 0, 138, 0, 1, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 36, 0, 139, 0, -1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_8_7:
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 26, 0, 141, 0, 1, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 36, 0, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_8_8:
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 26, 0, 144, 0, 1, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 36, 0, 145, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 8, 3, 8, 3,
+ax_anim 2, 0, 148, 12, 9, 12, 9,
+ax_anim 2, 0, 149, 9, 17, 9, 17,
+ax_anim 3, 0, 150, 0, 19, 0, 19,
+ax_anim 2, 3, 151, -9, 17, -9, 17,
+ax_anim 2, 0, 152, -12, 9, -12, 9,
+ax_anim 1, 0, 153, -8, 3, -8, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 11, 1, 11, 1,
+ax_anim 2, 0, 147, 18, 5, 18, 5,
+ax_anim 2, 0, 148, 23, 13, 23, 13,
+ax_anim 3, 0, 149, 21, 20, 21, 20,
+ax_anim 2, 3, 150, 11, 19, 11, 19,
+ax_anim 2, 0, 151, 4, 16, 4, 16,
+ax_anim 1, 0, 152, 1, 7, 1, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -7, 11, -7,
+ax_anim 2, 0, 147, 17, -5, 17, -5,
+ax_anim 3, 0, 148, 21, 3, 21, 3,
+ax_anim 2, 3, 149, 16, 7, 16, 7,
+ax_anim 2, 0, 150, 10, 7, 10, 7,
+ax_anim 1, 0, 151, 4, 6, 4, 6,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 12, -20, 12, -20,
+ax_anim 3, 0, 147, 22, -18, 22, -18,
+ax_anim 2, 3, 148, 24, -12, 24, -12,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 8, 0, 8, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -9, -4, -9, -4,
+ax_anim 2, 0, 152, -11, -12, -11, -12,
+ax_anim 2, 0, 153, -8, -16, -8, -16,
+ax_anim 3, 0, 146, 0, -19, 0, -19,
+ax_anim 2, 3, 147, 8, -16, 8, -16,
+ax_anim 2, 0, 148, 11, -12, 11, -12,
+ax_anim 1, 0, 149, 9, -4, 9, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -20, -12, -20,
+ax_anim 3, 0, 153, -22, -18, -22, -18,
+ax_anim 2, 3, 152, -24, -12, -24, -12,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -8, 0, -8, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -7, -11, -7,
+ax_anim 2, 0, 153, -17, -5, -17, -5,
+ax_anim 3, 0, 152, -21, 3, -21, 3,
+ax_anim 2, 3, 151, -16, 7, -16, 7,
+ax_anim 2, 0, 150, -10, 7, -10, 7,
+ax_anim 1, 0, 149, -4, 6, -4, 6,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -11, 1, -11, 1,
+ax_anim 2, 0, 153, -18, 5, -18, 5,
+ax_anim 2, 0, 152, -23, 13, -23, 13,
+ax_anim 3, 0, 151, -21, 20, -21, 20,
+ax_anim 2, 3, 150, -11, 19, -11, 19,
+ax_anim 2, 0, 149, -4, 16, -4, 16,
+ax_anim 1, 0, 148, -1, 7, -1, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -17, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 2, 164, 0, 1, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -21, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 2, 167, 0, 2, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -17, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 2, 170, 0, 2, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -20, 0, 0,
+ax_anim 3, 0, 173, 0, -19, 0, 0,
+ax_anim 2, 0, 173, 0, -15, 0, 0,
+ax_anim 1, 0, 173, 0, -9, 0, 0,
+ax_anim 2, 2, 173, 0, 3, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 2, 176, 0, 3, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -20, 0, 0,
+ax_anim 3, 0, 179, 0, -19, 0, 0,
+ax_anim 2, 0, 179, 0, -15, 0, 0,
+ax_anim 1, 0, 179, 0, -9, 0, 0,
+ax_anim 2, 2, 179, 0, 3, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -17, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 2, 182, 0, 2, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 2, 185, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCarvanhaAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sCarvanhaGfx1:
+.incbin "baserom.gba", 0x12F53B0, 0x200
+sCarvanhaSprites1:
+ax_sprite sCarvanhaGfx1, 0x200
+ax_sprite_terminator
+sCarvanhaGfx2:
+.incbin "baserom.gba", 0x12F55C0, 0x200
+sCarvanhaSprites2:
+ax_sprite sCarvanhaGfx2, 0x200
+ax_sprite_terminator
+sCarvanhaGfx3:
+.incbin "baserom.gba", 0x12F57D0, 0x200
+sCarvanhaSprites3:
+ax_sprite sCarvanhaGfx3, 0x200
+ax_sprite_terminator
+sCarvanhaGfx4:
+.incbin "baserom.gba", 0x12F59E0, 0x200
+sCarvanhaSprites4:
+ax_sprite sCarvanhaGfx4, 0x200
+ax_sprite_terminator
+sCarvanhaGfx5:
+.incbin "baserom.gba", 0x12F5BF0, 0x200
+sCarvanhaSprites5:
+ax_sprite sCarvanhaGfx5, 0x200
+ax_sprite_terminator
+sCarvanhaGfx6:
+.incbin "baserom.gba", 0x12F5E00, 0x200
+sCarvanhaSprites6:
+ax_sprite sCarvanhaGfx6, 0x200
+ax_sprite_terminator
+sCarvanhaGfx7:
+.incbin "baserom.gba", 0x12F6010, 0x200
+sCarvanhaSprites7:
+ax_sprite sCarvanhaGfx7, 0x200
+ax_sprite_terminator
+sCarvanhaGfx8:
+.incbin "baserom.gba", 0x12F6220, 0x200
+sCarvanhaSprites8:
+ax_sprite sCarvanhaGfx8, 0x200
+ax_sprite_terminator
+sCarvanhaGfx9:
+.incbin "baserom.gba", 0x12F6430, 0x200
+sCarvanhaSprites9:
+ax_sprite sCarvanhaGfx9, 0x200
+ax_sprite_terminator
+sCarvanhaGfx10:
+.incbin "baserom.gba", 0x12F6640, 0x200
+sCarvanhaSprites10:
+ax_sprite sCarvanhaGfx10, 0x200
+ax_sprite_terminator
+sCarvanhaGfx11:
+.incbin "baserom.gba", 0x12F6850, 0x200
+sCarvanhaSprites11:
+ax_sprite sCarvanhaGfx11, 0x200
+ax_sprite_terminator
+sCarvanhaGfx12:
+.incbin "baserom.gba", 0x12F6A60, 0x200
+sCarvanhaSprites12:
+ax_sprite sCarvanhaGfx12, 0x200
+ax_sprite_terminator
+sCarvanhaGfx13:
+.incbin "baserom.gba", 0x12F6C70, 0x200
+sCarvanhaSprites13:
+ax_sprite sCarvanhaGfx13, 0x200
+ax_sprite_terminator
+sCarvanhaGfx14:
+.incbin "baserom.gba", 0x12F6E80, 0x200
+sCarvanhaSprites14:
+ax_sprite sCarvanhaGfx14, 0x200
+ax_sprite_terminator
+sCarvanhaGfx15:
+.incbin "baserom.gba", 0x12F7090, 0x200
+sCarvanhaSprites15:
+ax_sprite sCarvanhaGfx15, 0x200
+ax_sprite_terminator
+sCarvanhaGfx16:
+.incbin "baserom.gba", 0x12F72A0, 0x20
+sCarvanhaGfx16_1:
+.incbin "baserom.gba", 0x12F72C0, 0x40
+sCarvanhaGfx16_2:
+.incbin "baserom.gba", 0x12F7300, 0x80
+sCarvanhaGfx16_3:
+.incbin "baserom.gba", 0x12F7380, 0x40
+sCarvanhaSprites16:
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx16_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx17:
+.incbin "baserom.gba", 0x12F7410, 0x60
+sCarvanhaGfx17_1:
+.incbin "baserom.gba", 0x12F7470, 0x60
+sCarvanhaGfx17_2:
+.incbin "baserom.gba", 0x12F74D0, 0x60
+sCarvanhaGfx17_3:
+.incbin "baserom.gba", 0x12F7530, 0x60
+sCarvanhaSprites17:
+ax_sprite sCarvanhaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx18:
+.incbin "baserom.gba", 0x12F75D8, 0x60
+sCarvanhaGfx18_1:
+.incbin "baserom.gba", 0x12F7638, 0x60
+sCarvanhaGfx18_2:
+.incbin "baserom.gba", 0x12F7698, 0x60
+sCarvanhaGfx18_3:
+.incbin "baserom.gba", 0x12F76F8, 0x20
+sCarvanhaSprites18:
+ax_sprite sCarvanhaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCarvanhaGfx19:
+.incbin "baserom.gba", 0x12F7760, 0x40
+sCarvanhaGfx19_1:
+.incbin "baserom.gba", 0x12F77A0, 0x40
+sCarvanhaGfx19_2:
+.incbin "baserom.gba", 0x12F77E0, 0x60
+sCarvanhaGfx19_3:
+.incbin "baserom.gba", 0x12F7840, 0x60
+sCarvanhaSprites19:
+ax_sprite sCarvanhaGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx19_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx20:
+.incbin "baserom.gba", 0x12F78E8, 0x40
+sCarvanhaGfx20_1:
+.incbin "baserom.gba", 0x12F7928, 0x100
+sCarvanhaGfx20_2:
+.incbin "baserom.gba", 0x12F7A28, 0x40
+sCarvanhaSprites20:
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx21:
+.incbin "baserom.gba", 0x12F7AA8, 0x40
+sCarvanhaGfx21_1:
+.incbin "baserom.gba", 0x12F7AE8, 0x40
+sCarvanhaGfx21_2:
+.incbin "baserom.gba", 0x12F7B28, 0x80
+sCarvanhaGfx21_3:
+.incbin "baserom.gba", 0x12F7BA8, 0x40
+sCarvanhaSprites21:
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx21_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx21_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx22:
+.incbin "baserom.gba", 0x12F7C38, 0x40
+sCarvanhaGfx22_1:
+.incbin "baserom.gba", 0x12F7C78, 0x60
+sCarvanhaGfx22_2:
+.incbin "baserom.gba", 0x12F7CD8, 0x60
+sCarvanhaGfx22_3:
+.incbin "baserom.gba", 0x12F7D38, 0x60
+sCarvanhaSprites22:
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx23:
+.incbin "baserom.gba", 0x12F7DE8, 0x60
+sCarvanhaGfx23_1:
+.incbin "baserom.gba", 0x12F7E48, 0x60
+sCarvanhaGfx23_2:
+.incbin "baserom.gba", 0x12F7EA8, 0x60
+sCarvanhaGfx23_3:
+.incbin "baserom.gba", 0x12F7F08, 0x20
+sCarvanhaSprites23:
+ax_sprite sCarvanhaGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCarvanhaGfx24:
+.incbin "baserom.gba", 0x12F7F70, 0x40
+sCarvanhaGfx24_1:
+.incbin "baserom.gba", 0x12F7FB0, 0x60
+sCarvanhaGfx24_2:
+.incbin "baserom.gba", 0x12F8010, 0x60
+sCarvanhaGfx24_3:
+.incbin "baserom.gba", 0x12F8070, 0x60
+sCarvanhaSprites24:
+ax_sprite sCarvanhaGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx25:
+.incbin "baserom.gba", 0x12F8118, 0x40
+sCarvanhaGfx25_1:
+.incbin "baserom.gba", 0x12F8158, 0x40
+sCarvanhaGfx25_2:
+.incbin "baserom.gba", 0x12F8198, 0x80
+sCarvanhaGfx25_3:
+.incbin "baserom.gba", 0x12F8218, 0x40
+sCarvanhaSprites25:
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx26:
+.incbin "baserom.gba", 0x12F82A8, 0x40
+sCarvanhaGfx26_1:
+.incbin "baserom.gba", 0x12F82E8, 0x40
+sCarvanhaGfx26_2:
+.incbin "baserom.gba", 0x12F8328, 0x80
+sCarvanhaGfx26_3:
+.incbin "baserom.gba", 0x12F83A8, 0x40
+sCarvanhaSprites26:
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx26_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx27:
+.incbin "baserom.gba", 0x12F8438, 0x20
+sCarvanhaGfx27_1:
+.incbin "baserom.gba", 0x12F8458, 0x20
+sCarvanhaGfx27_2:
+.incbin "baserom.gba", 0x12F8478, 0x60
+sCarvanhaGfx27_3:
+.incbin "baserom.gba", 0x12F84D8, 0x60
+sCarvanhaGfx27_4:
+.incbin "baserom.gba", 0x12F8538, 0x60
+sCarvanhaSprites27:
+ax_sprite sCarvanhaGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx27_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx27_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx28:
+.incbin "baserom.gba", 0x12F85F0, 0x180
+sCarvanhaGfx28_1:
+.incbin "baserom.gba", 0x12F8770, 0x20
+sCarvanhaSprites28:
+ax_sprite sCarvanhaGfx28, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx28_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCarvanhaGfx29:
+.incbin "baserom.gba", 0x12F87B8, 0x40
+sCarvanhaGfx29_1:
+.incbin "baserom.gba", 0x12F87F8, 0x60
+sCarvanhaGfx29_2:
+.incbin "baserom.gba", 0x12F8858, 0x60
+sCarvanhaGfx29_3:
+.incbin "baserom.gba", 0x12F88B8, 0x60
+sCarvanhaSprites29:
+ax_sprite sCarvanhaGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCarvanhaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx30:
+.incbin "baserom.gba", 0x12F8960, 0x40
+sCarvanhaGfx30_1:
+.incbin "baserom.gba", 0x12F89A0, 0x100
+sCarvanhaGfx30_2:
+.incbin "baserom.gba", 0x12F8AA0, 0x40
+sCarvanhaSprites30:
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCarvanhaGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCarvanhaGfx31:
+.incbin "baserom.gba", 0x12F8B20, 0x200
+sCarvanhaSprites31:
+ax_sprite sCarvanhaGfx31, 0x200
+ax_sprite_terminator
+sCarvanhaGfx32:
+.incbin "baserom.gba", 0x12F8D30, 0x200
+sCarvanhaSprites32:
+ax_sprite sCarvanhaGfx32, 0x200
+ax_sprite_terminator
+sCarvanhaGfx33:
+.incbin "baserom.gba", 0x12F8F40, 0x200
+sCarvanhaSprites33:
+ax_sprite sCarvanhaGfx33, 0x200
+ax_sprite_terminator
+sCarvanhaGfx34:
+.incbin "baserom.gba", 0x12F9150, 0x200
+sCarvanhaSprites34:
+ax_sprite sCarvanhaGfx34, 0x200
+ax_sprite_terminator
+sCarvanhaGfx35:
+.incbin "baserom.gba", 0x12F9360, 0x200
+sCarvanhaSprites35:
+ax_sprite sCarvanhaGfx35, 0x200
+ax_sprite_terminator
+sCarvanhaGfx36:
+.incbin "baserom.gba", 0x12F9570, 0x200
+sCarvanhaSprites36:
+ax_sprite sCarvanhaGfx36, 0x200
+ax_sprite_terminator
+sCarvanhaGfx37:
+.incbin "baserom.gba", 0x12F9780, 0x100
+sCarvanhaSprites37:
+ax_sprite sCarvanhaGfx37, 0x100
+ax_sprite_terminator
+sCarvanhaGfx38:
+.incbin "baserom.gba", 0x12F9890, 0x40
+sCarvanhaSprites38:
+ax_sprite sCarvanhaGfx38, 0x40
+ax_sprite_terminator
+sCarvanhaGfx39:
+.incbin "baserom.gba", 0x12F98E0, 0x20
+sCarvanhaSprites39:
+ax_sprite sCarvanhaGfx39, 0x20
+ax_sprite_terminator
+sCarvanhaGfx40:
+.incbin "baserom.gba", 0x12F9910, 0x80
+sCarvanhaSprites40:
+ax_sprite sCarvanhaGfx40, 0x80
+ax_sprite_terminator
+sAxPosesCarvanha:
+.4byte sCarvanhaPose1
+.4byte sCarvanhaPose2
+.4byte sCarvanhaPose3
+.4byte sCarvanhaPose4
+.4byte sCarvanhaPose5
+.4byte sCarvanhaPose6
+.4byte sCarvanhaPose7
+.4byte sCarvanhaPose8
+.4byte sCarvanhaPose9
+.4byte sCarvanhaPose10
+.4byte sCarvanhaPose11
+.4byte sCarvanhaPose12
+.4byte sCarvanhaPose13
+.4byte sCarvanhaPose14
+.4byte sCarvanhaPose15
+.4byte sCarvanhaPose16
+.4byte sCarvanhaPose17
+.4byte sCarvanhaPose18
+.4byte sCarvanhaPose19
+.4byte sCarvanhaPose20
+.4byte sCarvanhaPose21
+.4byte sCarvanhaPose22
+.4byte sCarvanhaPose23
+.4byte sCarvanhaPose24
+.4byte sCarvanhaPose25
+.4byte sCarvanhaPose26
+.4byte sCarvanhaPose27
+.4byte sCarvanhaPose28
+.4byte sCarvanhaPose29
+.4byte sCarvanhaPose30
+.4byte sCarvanhaPose31
+.4byte sCarvanhaPose32
+.4byte sCarvanhaPose33
+.4byte sCarvanhaPose34
+.4byte sCarvanhaPose35
+.4byte sCarvanhaPose36
+.4byte sCarvanhaPose37
+.4byte sCarvanhaPose38
+.4byte sCarvanhaPose39
+.4byte sCarvanhaPose40
+.4byte sCarvanhaPose41
+.4byte sCarvanhaPose42
+.4byte sCarvanhaPose43
+.4byte sCarvanhaPose44
+.4byte sCarvanhaPose45
+.4byte sCarvanhaPose46
+.4byte sCarvanhaPose47
+.4byte sCarvanhaPose48
+.4byte sCarvanhaPose49
+.4byte sCarvanhaPose50
+.4byte sCarvanhaPose51
+.4byte sCarvanhaPose52
+.4byte sCarvanhaPose53
+.4byte sCarvanhaPose54
+.4byte sCarvanhaPose55
+.4byte sCarvanhaPose56
+.4byte sCarvanhaPose57
+.4byte sCarvanhaPose58
+.4byte sCarvanhaPose59
+.4byte sCarvanhaPose60
+.4byte sCarvanhaPose61
+.4byte sCarvanhaPose62
+.4byte sCarvanhaPose63
+.4byte sCarvanhaPose64
+.4byte sCarvanhaPose65
+.4byte sCarvanhaPose66
+.4byte sCarvanhaPose67
+.4byte sCarvanhaPose68
+.4byte sCarvanhaPose69
+.4byte sCarvanhaPose70
+.4byte sCarvanhaPose71
+.4byte sCarvanhaPose72
+.4byte sCarvanhaPose73
+.4byte sCarvanhaPose74
+.4byte sCarvanhaPose75
+.4byte sCarvanhaPose76
+.4byte sCarvanhaPose77
+.4byte sCarvanhaPose78
+.4byte sCarvanhaPose79
+.4byte sCarvanhaPose80
+.4byte sCarvanhaPose81
+.4byte sCarvanhaPose82
+.4byte sCarvanhaPose83
+.4byte sCarvanhaPose84
+.4byte sCarvanhaPose85
+.4byte sCarvanhaPose86
+.4byte sCarvanhaPose87
+.4byte sCarvanhaPose88
+.4byte sCarvanhaPose89
+.4byte sCarvanhaPose90
+.4byte sCarvanhaPose91
+.4byte sCarvanhaPose92
+.4byte sCarvanhaPose93
+.4byte sCarvanhaPose94
+.4byte sCarvanhaPose95
+.4byte sCarvanhaPose96
+.4byte sCarvanhaPose97
+.4byte sCarvanhaPose98
+.4byte sCarvanhaPose99
+.4byte sCarvanhaPose100
+.4byte sCarvanhaPose101
+.4byte sCarvanhaPose102
+.4byte sCarvanhaPose103
+.4byte sCarvanhaPose104
+.4byte sCarvanhaPose105
+.4byte sCarvanhaPose106
+.4byte sCarvanhaPose107
+.4byte sCarvanhaPose108
+.4byte sCarvanhaPose109
+.4byte sCarvanhaPose110
+.4byte sCarvanhaPose111
+.4byte sCarvanhaPose112
+.4byte sCarvanhaPose113
+.4byte sCarvanhaPose114
+.4byte sCarvanhaPose115
+.4byte sCarvanhaPose116
+.4byte sCarvanhaPose117
+.4byte sCarvanhaPose118
+.4byte sCarvanhaPose119
+.4byte sCarvanhaPose120
+.4byte sCarvanhaPose121
+.4byte sCarvanhaPose122
+.4byte sCarvanhaPose123
+.4byte sCarvanhaPose124
+.4byte sCarvanhaPose125
+.4byte sCarvanhaPose126
+.4byte sCarvanhaPose127
+.4byte sCarvanhaPose128
+.4byte sCarvanhaPose129
+.4byte sCarvanhaPose130
+.4byte sCarvanhaPose131
+.4byte sCarvanhaPose132
+.4byte sCarvanhaPose133
+.4byte sCarvanhaPose134
+.4byte sCarvanhaPose135
+.4byte sCarvanhaPose136
+.4byte sCarvanhaPose137
+.4byte sCarvanhaPose138
+.4byte sCarvanhaPose139
+.4byte sCarvanhaPose140
+.4byte sCarvanhaPose141
+.4byte sCarvanhaPose142
+.4byte sCarvanhaPose143
+.4byte sCarvanhaPose144
+.4byte sCarvanhaPose145
+.4byte sCarvanhaPose146
+.4byte sCarvanhaPose147
+.4byte sCarvanhaPose148
+.4byte sCarvanhaPose149
+.4byte sCarvanhaPose150
+.4byte sCarvanhaPose151
+.4byte sCarvanhaPose152
+.4byte sCarvanhaPose153
+.4byte sCarvanhaPose154
+.4byte sCarvanhaPose155
+.4byte sCarvanhaPose156
+.4byte sCarvanhaPose157
+.4byte sCarvanhaPose158
+.4byte sCarvanhaPose159
+.4byte sCarvanhaPose160
+.4byte sCarvanhaPose161
+.4byte sCarvanhaPose162
+.4byte sCarvanhaPose163
+.4byte sCarvanhaPose164
+.4byte sCarvanhaPose165
+.4byte sCarvanhaPose166
+.4byte sCarvanhaPose167
+.4byte sCarvanhaPose168
+.4byte sCarvanhaPose169
+.4byte sCarvanhaPose170
+.4byte sCarvanhaPose171
+.4byte sCarvanhaPose172
+.4byte sCarvanhaPose173
+.4byte sCarvanhaPose174
+.4byte sCarvanhaPose175
+.4byte sCarvanhaPose176
+.4byte sCarvanhaPose177
+.4byte sCarvanhaPose178
+.4byte sCarvanhaPose179
+.4byte sCarvanhaPose180
+.4byte sCarvanhaPose181
+.4byte sCarvanhaPose182
+.4byte sCarvanhaPose183
+.4byte sCarvanhaPose184
+.4byte sCarvanhaPose185
+.4byte sCarvanhaPose186
+.4byte sCarvanhaPose187
+.4byte sCarvanhaPose188
+.4byte sCarvanhaPose189
+.4byte sCarvanhaPose190
+.4byte sCarvanhaPose191
+.4byte sCarvanhaPose192
+.4byte sCarvanhaPose193
+.4byte sCarvanhaPose194
+.4byte sCarvanhaPose195
+.4byte sCarvanhaPose196
+.4byte sCarvanhaPose197
+.4byte sCarvanhaPose198
+.4byte sCarvanhaPose199
+.4byte sCarvanhaPose200
+.4byte sCarvanhaPose201
+.4byte sCarvanhaPose202
+sAxPositionsCarvanha:
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte    0,   -5, 	  -8,  -11, 	   9,  -11, 	   0,  -10
+.2byte    0,   -5, 	  -8,   -9, 	   9,   -9, 	   0,  -10
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+.2byte    7,   -6, 	   6,  -11, 	  -5,   -7, 	   2,  -11
+.2byte    7,   -6, 	  10,  -11, 	  -4,   -4, 	   3,  -11
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte   10,   -8, 	   2,  -10, 	  -1,   -6, 	   1,  -12
+.2byte   10,   -9, 	   2,   -7, 	   1,   -4, 	   2,  -11
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte    9,  -13, 	  -5,  -15, 	   8,   -8, 	   2,  -13
+.2byte    8,  -13, 	  -3,  -14, 	   7,   -6, 	   1,  -13
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -15, 	  10,  -13, 	  -9,  -12, 	   0,  -12
+.2byte    0,  -15, 	  10,  -10, 	  -9,  -10, 	   0,  -12
+.2byte   -8,  -13, 	   4,  -14, 	  -8,   -7, 	  -1,  -13
+.2byte   -9,  -13, 	   5,  -15, 	  -8,   -8, 	  -2,  -13
+.2byte   -8,  -13, 	   3,  -14, 	  -7,   -6, 	  -1,  -13
+.2byte  -10,   -9, 	  -4,   -9, 	   0,   -4, 	  -2,  -12
+.2byte  -10,   -8, 	  -2,  -10, 	   1,   -6, 	  -1,  -12
+.2byte  -10,   -9, 	  -2,   -7, 	  -1,   -4, 	  -2,  -11
+.2byte   -6,   -6, 	  -6,  -11, 	   5,   -5, 	  -2,  -11
+.2byte   -7,   -6, 	  -6,  -11, 	   5,   -7, 	  -2,  -11
+.2byte   -7,   -6, 	 -10,  -11, 	   4,   -4, 	  -3,  -11
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte    0,   -7, 	  -9,  -11, 	  10,  -11, 	   0,  -12
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+.2byte    6,   -7, 	   4,   -9, 	  -5,   -5, 	   2,  -12
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte    7,  -10, 	  -1,   -8, 	  -3,   -7, 	   2,  -11
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte    6,  -11, 	  -2,  -12, 	   6,   -6, 	   2,  -13
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -16, 	  10,  -10, 	  -9,  -10, 	   0,  -10
+.2byte   -8,  -13, 	   4,  -14, 	  -8,   -7, 	  -1,  -13
+.2byte   -6,  -11, 	   2,  -12, 	  -6,   -6, 	  -2,  -13
+.2byte  -10,   -9, 	  -4,   -9, 	   0,   -4, 	  -2,  -12
+.2byte   -7,  -10, 	   1,   -8, 	   3,   -7, 	  -2,  -11
+.2byte   -6,   -6, 	  -6,  -11, 	   5,   -5, 	  -2,  -11
+.2byte   -6,   -7, 	  -4,   -9, 	   5,   -5, 	  -2,  -12
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte    0,   -8, 	  -9,  -12, 	  10,  -12, 	   0,  -13
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+.2byte    5,   -7, 	   3,   -9, 	  -6,   -5, 	   1,  -12
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte    7,  -10, 	  -1,   -8, 	  -3,   -7, 	   2,  -11
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte    6,  -11, 	  -2,  -12, 	   6,   -6, 	   2,  -13
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -17, 	  10,  -11, 	  -9,  -11, 	   0,  -11
+.2byte   -8,  -13, 	   4,  -14, 	  -8,   -7, 	  -1,  -13
+.2byte   -6,  -11, 	   2,  -12, 	  -6,   -6, 	  -2,  -13
+.2byte  -10,   -9, 	  -4,   -9, 	   0,   -4, 	  -2,  -12
+.2byte   -7,  -10, 	   1,   -8, 	   3,   -7, 	  -2,  -11
+.2byte   -6,   -6, 	  -6,  -11, 	   5,   -5, 	  -2,  -11
+.2byte   -5,   -7, 	  -3,   -9, 	   6,   -5, 	  -1,  -12
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte    0,   -5, 	  -8,  -11, 	   9,  -11, 	   0,  -10
+.2byte    0,   -5, 	  -8,   -9, 	   9,   -9, 	   0,  -10
+.2byte    0,   -4, 	  -9,  -10, 	   9,   -9, 	   0,  -10
+.2byte    0,   -6, 	  -9,  -10, 	  10,  -10, 	   0,  -11
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+.2byte    7,   -6, 	   6,  -11, 	  -5,   -7, 	   2,  -11
+.2byte    7,   -6, 	  10,  -11, 	  -4,   -4, 	   3,  -11
+.2byte    7,   -5, 	  10,  -12, 	  -6,   -6, 	   4,  -12
+.2byte    6,   -6, 	   4,   -8, 	  -5,   -4, 	   2,  -11
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte   10,   -8, 	   2,  -10, 	  -1,   -6, 	   1,  -12
+.2byte   10,   -9, 	   2,   -7, 	   1,   -4, 	   2,  -11
+.2byte    9,   -8, 	   0,   -6, 	  -2,   -4, 	   3,  -11
+.2byte    7,   -9, 	  -1,   -7, 	  -3,   -6, 	   2,  -10
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte    9,  -13, 	  -5,  -15, 	   8,   -8, 	   2,  -13
+.2byte    8,  -13, 	  -3,  -14, 	   7,   -6, 	   1,  -13
+.2byte    8,  -11, 	  -3,  -13, 	   7,   -5, 	   2,  -11
+.2byte    6,  -11, 	  -2,  -12, 	   6,   -6, 	   2,  -13
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -15, 	  10,  -13, 	  -9,  -12, 	   0,  -12
+.2byte    0,  -15, 	  10,  -10, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -15, 	  10,   -9, 	  -9,   -9, 	   1,  -13
+.2byte    0,  -18, 	  10,  -12, 	  -9,  -12, 	   0,  -12
+.2byte   -8,  -13, 	   4,  -14, 	  -8,   -7, 	  -1,  -13
+.2byte   -9,  -13, 	   5,  -15, 	  -8,   -8, 	  -2,  -13
+.2byte   -8,  -13, 	   3,  -14, 	  -7,   -6, 	  -1,  -13
+.2byte   -8,  -11, 	   3,  -13, 	  -7,   -5, 	  -2,  -11
+.2byte   -6,  -11, 	   2,  -12, 	  -6,   -6, 	  -2,  -13
+.2byte  -10,   -9, 	  -4,   -9, 	   0,   -4, 	  -2,  -12
+.2byte  -10,   -8, 	  -2,  -10, 	   1,   -6, 	  -1,  -12
+.2byte  -10,   -9, 	  -2,   -7, 	  -1,   -4, 	  -2,  -11
+.2byte   -9,   -8, 	   0,   -6, 	   2,   -4, 	  -3,  -11
+.2byte   -7,   -9, 	   1,   -7, 	   3,   -6, 	  -2,  -10
+.2byte   -6,   -6, 	  -6,  -11, 	   5,   -5, 	  -2,  -11
+.2byte   -7,   -6, 	  -6,  -11, 	   5,   -7, 	  -2,  -11
+.2byte   -7,   -6, 	 -10,  -11, 	   4,   -4, 	  -3,  -11
+.2byte   -7,   -5, 	 -10,  -12, 	   6,   -6, 	  -4,  -12
+.2byte   -6,   -6, 	  -4,   -8, 	   5,   -4, 	  -2,  -11
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte    0,   -6, 	 -11,  -13, 	  11,  -13, 	   0,  -12
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+.2byte    9,   -7, 	  12,  -15, 	  -5,   -6, 	   4,  -13
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte   11,  -10, 	   0,   -7, 	  -1,   -5, 	   3,  -13
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte    9,  -15, 	  -5,  -17, 	   9,   -8, 	   2,  -15
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -18, 	  11,  -13, 	 -11,  -12, 	   0,  -15
+.2byte   -8,  -13, 	   4,  -14, 	  -8,   -7, 	  -1,  -13
+.2byte   -9,  -15, 	   5,  -17, 	  -9,   -8, 	  -2,  -15
+.2byte  -10,   -9, 	  -4,   -9, 	   0,   -4, 	  -2,  -12
+.2byte  -11,  -10, 	   0,   -7, 	   1,   -5, 	  -3,  -13
+.2byte   -6,   -6, 	  -6,  -11, 	   5,   -5, 	  -2,  -11
+.2byte   -9,   -8, 	 -12,  -16, 	   5,   -7, 	  -4,  -14
+.2byte    0,   -3, 	 -10,   -8, 	  10,   -7, 	   0,   -8
+.2byte    0,   -3, 	  -8,   -9, 	   9,   -9, 	   0,   -8
+.2byte    0,  -17, 	 -10,  -14, 	  10,  -14, 	   0,  -15
+.2byte    5,  -19, 	   3,  -17, 	  -4,  -13, 	   0,  -16
+.2byte    5,  -20, 	   4,  -14, 	   2,   -9, 	  -2,  -15
+.2byte    5,  -23, 	  -6,  -24, 	   8,  -11, 	  -1,  -17
+.2byte    0,  -23, 	  10,  -17, 	 -10,  -17, 	   0,  -16
+.2byte   -6,  -23, 	   5,  -24, 	  -9,  -11, 	   0,  -17
+.2byte   -6,  -20, 	  -5,  -14, 	  -3,   -9, 	   1,  -15
+.2byte   -6,  -19, 	  -4,  -17, 	   3,  -13, 	  -1,  -16
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte    0,   -5, 	  -8,  -11, 	   9,  -11, 	   0,  -10
+.2byte    0,   -5, 	  -8,   -9, 	   9,   -9, 	   0,  -10
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+.2byte    7,   -6, 	   6,  -11, 	  -5,   -7, 	   2,  -11
+.2byte    7,   -6, 	  10,  -11, 	  -4,   -4, 	   3,  -11
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte   10,   -8, 	   2,  -10, 	  -1,   -6, 	   1,  -12
+.2byte   10,   -9, 	   2,   -7, 	   1,   -4, 	   2,  -11
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte    9,  -13, 	  -5,  -15, 	   8,   -8, 	   2,  -13
+.2byte    8,  -13, 	  -3,  -14, 	   7,   -6, 	   1,  -13
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -15, 	  10,  -13, 	  -9,  -12, 	   0,  -12
+.2byte    0,  -15, 	  10,  -10, 	  -9,  -10, 	   0,  -12
+.2byte   -8,  -13, 	   4,  -14, 	  -8,   -7, 	  -1,  -13
+.2byte   -9,  -13, 	   5,  -15, 	  -8,   -8, 	  -2,  -13
+.2byte   -8,  -13, 	   3,  -14, 	  -7,   -6, 	  -1,  -13
+.2byte  -10,   -9, 	  -4,   -9, 	   0,   -4, 	  -2,  -12
+.2byte  -10,   -8, 	  -2,  -10, 	   1,   -6, 	  -1,  -12
+.2byte  -10,   -9, 	  -2,   -7, 	  -1,   -4, 	  -2,  -11
+.2byte   -6,   -6, 	  -6,  -11, 	   5,   -5, 	  -2,  -11
+.2byte   -7,   -6, 	  -6,  -11, 	   5,   -7, 	  -2,  -11
+.2byte   -7,   -6, 	 -10,  -11, 	   4,   -4, 	  -3,  -11
+.2byte    0,   -7, 	  -9,  -11, 	  10,  -11, 	   0,  -12
+.2byte   -6,   -7, 	  -4,   -9, 	   5,   -5, 	  -2,  -12
+.2byte   -7,  -10, 	   1,   -8, 	   3,   -7, 	  -2,  -11
+.2byte   -6,  -11, 	   2,  -12, 	  -6,   -6, 	  -2,  -13
+.2byte    0,  -17, 	  10,  -11, 	  -9,  -11, 	   0,  -11
+.2byte    6,  -11, 	  -2,  -12, 	   6,   -6, 	   2,  -13
+.2byte    7,  -10, 	  -1,   -8, 	  -3,   -7, 	   2,  -11
+.2byte    6,   -7, 	   4,   -9, 	  -5,   -5, 	   2,  -12
+.2byte    0,   -4, 	  -9,  -10, 	   9,   -9, 	   0,  -10
+.2byte    6,   -5, 	   9,  -12, 	  -7,   -6, 	   3,  -12
+.2byte    8,   -8, 	  -1,   -6, 	  -3,   -4, 	   2,  -11
+.2byte    7,  -11, 	  -4,  -13, 	   6,   -5, 	   1,  -11
+.2byte    0,  -15, 	  10,   -9, 	  -9,   -9, 	   1,  -13
+.2byte   -7,  -11, 	   4,  -13, 	  -6,   -5, 	  -1,  -11
+.2byte   -8,   -8, 	   1,   -6, 	   3,   -4, 	  -2,  -11
+.2byte   -6,   -5, 	  -9,  -12, 	   7,   -6, 	  -3,  -12
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte    0,   -7, 	  -9,  -11, 	  10,  -11, 	   0,  -12
+.2byte    0,   -4, 	  -9,  -10, 	   9,   -9, 	   0,  -10
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+.2byte    6,   -7, 	   4,   -9, 	  -5,   -5, 	   2,  -12
+.2byte    7,   -5, 	  10,  -12, 	  -6,   -6, 	   4,  -12
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte    7,  -10, 	  -1,   -8, 	  -3,   -7, 	   2,  -11
+.2byte   10,   -8, 	   1,   -6, 	  -1,   -4, 	   4,  -11
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte    6,  -11, 	  -2,  -12, 	   6,   -6, 	   2,  -13
+.2byte    8,  -11, 	  -3,  -13, 	   7,   -5, 	   2,  -11
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    0,  -17, 	  10,  -11, 	  -9,  -11, 	   0,  -11
+.2byte    0,  -15, 	  10,   -9, 	  -9,   -9, 	   1,  -13
+.2byte   -9,  -13, 	   3,  -14, 	  -9,   -7, 	  -2,  -13
+.2byte   -7,  -11, 	   1,  -12, 	  -7,   -6, 	  -3,  -13
+.2byte   -9,  -11, 	   2,  -13, 	  -8,   -5, 	  -3,  -11
+.2byte  -11,   -9, 	  -5,   -9, 	  -1,   -4, 	  -3,  -12
+.2byte   -8,  -10, 	   0,   -8, 	   2,   -7, 	  -3,  -11
+.2byte  -11,   -8, 	  -2,   -6, 	   0,   -4, 	  -5,  -11
+.2byte   -7,   -6, 	  -7,  -11, 	   4,   -5, 	  -3,  -11
+.2byte   -7,   -7, 	  -5,   -9, 	   4,   -5, 	  -3,  -12
+.2byte   -8,   -5, 	 -11,  -12, 	   5,   -6, 	  -5,  -12
+.2byte    0,   -7, 	  -9,  -11, 	  10,  -11, 	   0,  -12
+.2byte   -6,   -7, 	  -4,   -9, 	   5,   -5, 	  -2,  -12
+.2byte   -7,  -10, 	   1,   -8, 	   3,   -7, 	  -2,  -11
+.2byte   -6,  -11, 	   2,  -12, 	  -6,   -6, 	  -2,  -13
+.2byte    0,  -17, 	  10,  -11, 	  -9,  -11, 	   0,  -11
+.2byte    6,  -11, 	  -2,  -12, 	   6,   -6, 	   2,  -13
+.2byte    7,  -10, 	  -1,   -8, 	  -3,   -7, 	   2,  -11
+.2byte    6,   -7, 	   4,   -9, 	  -5,   -5, 	   2,  -12
+.2byte    0,   -5, 	  -9,  -10, 	  10,  -10, 	   0,  -10
+.2byte   -6,   -6, 	  -6,  -11, 	   5,   -5, 	  -2,  -11
+.2byte  -10,   -9, 	  -4,   -9, 	   0,   -4, 	  -2,  -12
+.2byte   -8,  -13, 	   4,  -14, 	  -8,   -7, 	  -1,  -13
+.2byte    0,  -15, 	  10,  -11, 	  -9,  -10, 	   0,  -12
+.2byte    8,  -13, 	  -4,  -14, 	   8,   -7, 	   1,  -13
+.2byte   10,   -9, 	   4,   -9, 	   0,   -4, 	   2,  -12
+.2byte    6,   -6, 	   6,  -11, 	  -5,   -5, 	   2,  -11
+sCarvanhaAnimTable1:
+.4byte sCarvanhaAnims_1_1
+.4byte sCarvanhaAnims_1_2
+.4byte sCarvanhaAnims_1_3
+.4byte sCarvanhaAnims_1_4
+.4byte sCarvanhaAnims_1_5
+.4byte sCarvanhaAnims_1_6
+.4byte sCarvanhaAnims_1_7
+.4byte sCarvanhaAnims_1_8
+sCarvanhaAnimTable2:
+.4byte sCarvanhaAnims_2_1
+.4byte sCarvanhaAnims_2_2
+.4byte sCarvanhaAnims_2_3
+.4byte sCarvanhaAnims_2_4
+.4byte sCarvanhaAnims_2_5
+.4byte sCarvanhaAnims_2_6
+.4byte sCarvanhaAnims_2_7
+.4byte sCarvanhaAnims_2_8
+sCarvanhaAnimTable3:
+.4byte sCarvanhaAnims_3_1
+.4byte sCarvanhaAnims_3_2
+.4byte sCarvanhaAnims_3_3
+.4byte sCarvanhaAnims_3_4
+.4byte sCarvanhaAnims_3_5
+.4byte sCarvanhaAnims_3_6
+.4byte sCarvanhaAnims_3_7
+.4byte sCarvanhaAnims_3_8
+sCarvanhaAnimTable4:
+.4byte sCarvanhaAnims_4_1
+.4byte sCarvanhaAnims_4_2
+.4byte sCarvanhaAnims_4_3
+.4byte sCarvanhaAnims_4_4
+.4byte sCarvanhaAnims_4_5
+.4byte sCarvanhaAnims_4_6
+.4byte sCarvanhaAnims_4_7
+.4byte sCarvanhaAnims_4_8
+sCarvanhaAnimTable5:
+.4byte sCarvanhaAnims_5_1
+.4byte sCarvanhaAnims_5_2
+.4byte sCarvanhaAnims_5_3
+.4byte sCarvanhaAnims_5_4
+.4byte sCarvanhaAnims_5_5
+.4byte sCarvanhaAnims_5_6
+.4byte sCarvanhaAnims_5_7
+.4byte sCarvanhaAnims_5_8
+sCarvanhaAnimTable6:
+.4byte sCarvanhaAnims_6_1
+.4byte sCarvanhaAnims_6_1
+.4byte sCarvanhaAnims_6_1
+.4byte sCarvanhaAnims_6_1
+.4byte sCarvanhaAnims_6_1
+.4byte sCarvanhaAnims_6_1
+.4byte sCarvanhaAnims_6_1
+.4byte sCarvanhaAnims_6_1
+sCarvanhaAnimTable7:
+.4byte sCarvanhaAnims_7_1
+.4byte sCarvanhaAnims_7_2
+.4byte sCarvanhaAnims_7_3
+.4byte sCarvanhaAnims_7_4
+.4byte sCarvanhaAnims_7_5
+.4byte sCarvanhaAnims_7_6
+.4byte sCarvanhaAnims_7_7
+.4byte sCarvanhaAnims_7_8
+sCarvanhaAnimTable8:
+.4byte sCarvanhaAnims_8_1
+.4byte sCarvanhaAnims_8_2
+.4byte sCarvanhaAnims_8_3
+.4byte sCarvanhaAnims_8_4
+.4byte sCarvanhaAnims_8_5
+.4byte sCarvanhaAnims_8_6
+.4byte sCarvanhaAnims_8_7
+.4byte sCarvanhaAnims_8_8
+sCarvanhaAnimTable9:
+.4byte sCarvanhaAnims_9_1
+.4byte sCarvanhaAnims_9_2
+.4byte sCarvanhaAnims_9_3
+.4byte sCarvanhaAnims_9_4
+.4byte sCarvanhaAnims_9_5
+.4byte sCarvanhaAnims_9_6
+.4byte sCarvanhaAnims_9_7
+.4byte sCarvanhaAnims_9_8
+sCarvanhaAnimTable10:
+.4byte sCarvanhaAnims_10_1
+.4byte sCarvanhaAnims_10_2
+.4byte sCarvanhaAnims_10_3
+.4byte sCarvanhaAnims_10_4
+.4byte sCarvanhaAnims_10_5
+.4byte sCarvanhaAnims_10_6
+.4byte sCarvanhaAnims_10_7
+.4byte sCarvanhaAnims_10_8
+sCarvanhaAnimTable11:
+.4byte sCarvanhaAnims_11_1
+.4byte sCarvanhaAnims_11_2
+.4byte sCarvanhaAnims_11_3
+.4byte sCarvanhaAnims_11_4
+.4byte sCarvanhaAnims_11_5
+.4byte sCarvanhaAnims_11_6
+.4byte sCarvanhaAnims_11_7
+.4byte sCarvanhaAnims_11_8
+sCarvanhaAnimTable12:
+.4byte sCarvanhaAnims_12_1
+.4byte sCarvanhaAnims_12_2
+.4byte sCarvanhaAnims_12_3
+.4byte sCarvanhaAnims_12_4
+.4byte sCarvanhaAnims_12_5
+.4byte sCarvanhaAnims_12_6
+.4byte sCarvanhaAnims_12_7
+.4byte sCarvanhaAnims_12_8
+sCarvanhaAnimTable13:
+.4byte sCarvanhaAnims_13_1
+.4byte sCarvanhaAnims_13_2
+.4byte sCarvanhaAnims_13_3
+.4byte sCarvanhaAnims_13_4
+.4byte sCarvanhaAnims_13_5
+.4byte sCarvanhaAnims_13_6
+.4byte sCarvanhaAnims_13_7
+.4byte sCarvanhaAnims_13_8
+sAxAnimationsCarvanha:
+.4byte sCarvanhaAnimTable1
+.4byte sCarvanhaAnimTable2
+.4byte sCarvanhaAnimTable3
+.4byte sCarvanhaAnimTable4
+.4byte sCarvanhaAnimTable5
+.4byte sCarvanhaAnimTable6
+.4byte sCarvanhaAnimTable7
+.4byte sCarvanhaAnimTable8
+.4byte sCarvanhaAnimTable9
+.4byte sCarvanhaAnimTable10
+.4byte sCarvanhaAnimTable11
+.4byte sCarvanhaAnimTable12
+.4byte sCarvanhaAnimTable13
+sAxSpritesCarvanha:
+.4byte sCarvanhaSprites1
+.4byte sCarvanhaSprites2
+.4byte sCarvanhaSprites3
+.4byte sCarvanhaSprites4
+.4byte sCarvanhaSprites5
+.4byte sCarvanhaSprites6
+.4byte sCarvanhaSprites7
+.4byte sCarvanhaSprites8
+.4byte sCarvanhaSprites9
+.4byte sCarvanhaSprites10
+.4byte sCarvanhaSprites11
+.4byte sCarvanhaSprites12
+.4byte sCarvanhaSprites13
+.4byte sCarvanhaSprites14
+.4byte sCarvanhaSprites15
+.4byte sCarvanhaSprites16
+.4byte sCarvanhaSprites17
+.4byte sCarvanhaSprites18
+.4byte sCarvanhaSprites19
+.4byte sCarvanhaSprites20
+.4byte sCarvanhaSprites21
+.4byte sCarvanhaSprites22
+.4byte sCarvanhaSprites23
+.4byte sCarvanhaSprites24
+.4byte sCarvanhaSprites25
+.4byte sCarvanhaSprites26
+.4byte sCarvanhaSprites27
+.4byte sCarvanhaSprites28
+.4byte sCarvanhaSprites29
+.4byte sCarvanhaSprites30
+.4byte sCarvanhaSprites31
+.4byte sCarvanhaSprites32
+.4byte sCarvanhaSprites33
+.4byte sCarvanhaSprites34
+.4byte sCarvanhaSprites35
+.4byte sCarvanhaSprites36
+.4byte sCarvanhaSprites37
+.4byte sCarvanhaSprites38
+.4byte sCarvanhaSprites39
+.4byte sCarvanhaSprites40
+sAxMainCarvanha:
+ax_main sAxPosesCarvanha, sAxAnimationsCarvanha, 13, sAxSpritesCarvanha, sAxPositionsCarvanha

--- a/data/ax/cascoon.inc
+++ b/data/ax/cascoon.inc
@@ -1,0 +1,2082 @@
+.global gAxCascoon
+gAxCascoon:
+ax_siro sAxMainCascoon
+sCascoonPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose4:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose5:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose6:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose7:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose8:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose9:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose10:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose11:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose12:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose13:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose14:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose15:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose16:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose17:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose18:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose19:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose20:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose21:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose22:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose23:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose24:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose28:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose29:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose30:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose31:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose32:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose33:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose34:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose35:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose36:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose37:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose38:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose39:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose40:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose41:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose42:
+ax_pose 8, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCascoonPose43:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose44:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose45:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose46:
+ax_pose 10, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose47:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose48:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose49:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose50:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose51:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose52:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose53:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose54:
+ax_pose 14, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose55:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose56:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose57:
+ax_pose 16, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose58:
+ax_pose 17, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose59:
+ax_pose 18, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sCascoonPose60:
+ax_pose 19, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sCascoonPose61:
+ax_pose 20, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sCascoonPose62:
+ax_pose 21, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sCascoonPose63:
+ax_pose 22, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sCascoonPose64:
+ax_pose 21, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sCascoonPose65:
+ax_pose 20, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sCascoonPose66:
+ax_pose 19, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose67:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose68:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose69:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose70:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose71:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose72:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose73:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose74:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose75:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose76:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose77:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose78:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose79:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose80:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose81:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose82:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose83:
+ax_pose 8, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCascoonPose84:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose85:
+ax_pose 14, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose86:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose87:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose88:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose89:
+ax_pose 10, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose90:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose91:
+ax_pose 8, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCascoonPose92:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose93:
+ax_pose 10, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose94:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose95:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose96:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose97:
+ax_pose 14, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose98:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose99:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose100:
+ax_pose 8, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCascoonPose101:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose102:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose103:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose104:
+ax_pose 10, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose105:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose106:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose107:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose108:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose109:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose110:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose111:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose112:
+ax_pose 14, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose113:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose114:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose115:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose116:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose117:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose118:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose119:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose120:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose121:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose122:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose123:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose124:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose125:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose126:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose127:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose128:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose129:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCascoonPose130:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+.align 2
+sCascoonAnims_1_1:
+ax_anim 2, 0, 0, 1, 0, 1, 0,
+ax_anim 2, 0, 0, -1, 0, -1, 0,
+ax_anim 120, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_1_2:
+ax_anim 2, 0, 1, -1, 1, -1, 1,
+ax_anim 2, 0, 1, 1, -1, 0, 0,
+ax_anim 120, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_1_3:
+ax_anim 2, 0, 2, 0, 1, 0, 1,
+ax_anim 2, 0, 2, 0, -1, 0, -1,
+ax_anim 120, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_1_4:
+ax_anim 2, 0, 3, 1, 1, 1, 1,
+ax_anim 2, 0, 3, -1, -1, 0, 0,
+ax_anim 120, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_1_5:
+ax_anim 2, 0, 4, -1, 0, -1, 0,
+ax_anim 2, 0, 4, 1, 0, 1, 0,
+ax_anim 120, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_1_6:
+ax_anim 2, 0, 5, -1, 1, -1, 1,
+ax_anim 2, 0, 5, 1, -1, 0, 0,
+ax_anim 120, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_1_7:
+ax_anim 2, 0, 6, 0, 1, 0, 1,
+ax_anim 2, 0, 6, 0, -1, 0, -1,
+ax_anim 120, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_1_8:
+ax_anim 2, 0, 7, 1, 1, 1, 1,
+ax_anim 2, 0, 7, -1, -1, 0, 0,
+ax_anim 120, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 10,
+ax_anim 2, 0, 16, 0, 18, 0, 18,
+ax_anim 2, 1, 17, 0, 18, 1, 18,
+ax_anim 2, 0, 16, 0, 18, 0, 18,
+ax_anim 2, 0, 23, 0, 18, 1, 18,
+ax_anim 2, 0, 16, 0, 18, 0, 18,
+ax_anim 2, 0, 17, 0, 18, 1, 18,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sCascoonAnims_2_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 10,
+ax_anim 2, 0, 17, 19, 18, 19, 18,
+ax_anim 2, 1, 18, 19, 18, 19, 18,
+ax_anim 2, 0, 17, 19, 18, 19, 18,
+ax_anim 2, 0, 16, 19, 18, 19, 18,
+ax_anim 2, 0, 17, 19, 18, 19, 18,
+ax_anim 2, 0, 18, 19, 18, 19, 18,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sCascoonAnims_2_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 0, 10, 0,
+ax_anim 2, 0, 18, 19, 0, 19, 0,
+ax_anim 2, 1, 19, 19, 0, 19, 0,
+ax_anim 2, 0, 18, 19, 0, 19, 0,
+ax_anim 2, 0, 17, 19, 0, 19, 0,
+ax_anim 2, 0, 18, 19, 0, 19, 0,
+ax_anim 2, 0, 19, 19, 0, 19, 0,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sCascoonAnims_2_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 4, -4, 4, -4,
+ax_anim 1, 0, 19, 10, -10, 10, -10,
+ax_anim 2, 0, 19, 19, -21, 19, -21,
+ax_anim 2, 1, 20, 19, -21, 19, -21,
+ax_anim 2, 0, 19, 19, -21, 19, -21,
+ax_anim 2, 0, 18, 19, -21, 19, -21,
+ax_anim 2, 0, 19, 19, -21, 19, -21,
+ax_anim 2, 0, 20, 19, -21, 19, -21,
+ax_anim 2, 0, 19, 6, -6, 6, -6,
+ax_anim_terminator
+sCascoonAnims_2_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -10, 0, -10,
+ax_anim 2, 0, 20, 0, -21, 0, -21,
+ax_anim 2, 1, 21, 0, -21, 0, -21,
+ax_anim 2, 0, 20, 0, -21, 0, -21,
+ax_anim 2, 0, 19, 0, -21, 0, -21,
+ax_anim 2, 0, 20, 0, -21, 0, -21,
+ax_anim 2, 0, 21, 0, -21, 0, -21,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sCascoonAnims_2_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -4, -4, -4, -4,
+ax_anim 1, 0, 21, -10, -10, -10, -10,
+ax_anim 2, 0, 21, -19, -21, -19, -21,
+ax_anim 2, 1, 22, -19, -21, -19, -21,
+ax_anim 2, 0, 21, -19, -21, -19, -21,
+ax_anim 2, 0, 20, -19, -21, -19, -21,
+ax_anim 2, 0, 21, -19, -21, -19, -21,
+ax_anim 2, 0, 22, -19, -21, -19, -21,
+ax_anim 2, 0, 21, -6, -6, -6, -6,
+ax_anim_terminator
+sCascoonAnims_2_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 0, -10, 0,
+ax_anim 2, 0, 22, -19, 0, -19, 0,
+ax_anim 2, 1, 21, -19, 0, -19, 0,
+ax_anim 2, 0, 22, -19, 0, -19, 0,
+ax_anim 2, 0, 23, -19, 0, -19, 0,
+ax_anim 2, 0, 22, -19, 0, -19, 0,
+ax_anim 2, 0, 21, -19, 0, -19, 0,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sCascoonAnims_2_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 10,
+ax_anim 2, 0, 23, -19, 18, -19, 18,
+ax_anim 2, 1, 22, -19, 18, -19, 18,
+ax_anim 2, 0, 23, -19, 18, -19, 18,
+ax_anim 2, 0, 16, -19, 18, -19, 18,
+ax_anim 2, 0, 23, -19, 18, -19, 18,
+ax_anim 2, 0, 22, -19, 18, -19, 18,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCascoonAnims_3_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 0, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 31, 0, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 0, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCascoonAnims_3_2:
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 4, 0, 25, -2, -2, -2, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 4, 4, 4, 4,
+ax_anim 1, 0, 25, 10, 10, 10, 10,
+ax_anim 2, 0, 25, 19, 18, 19, 18,
+ax_anim 2, 1, 26, 19, 18, 19, 18,
+ax_anim 2, 0, 25, 19, 18, 19, 18,
+ax_anim 2, 0, 24, 19, 18, 19, 18,
+ax_anim 2, 0, 25, 19, 18, 19, 18,
+ax_anim 2, 0, 26, 19, 18, 19, 18,
+ax_anim 2, 0, 25, 6, 6, 6, 6,
+ax_anim_terminator
+sCascoonAnims_3_3:
+ax_anim 2, 0, 26, -1, 0, -1, 0,
+ax_anim 4, 0, 26, -2, 0, -2, 0,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 4, 0, 4, 0,
+ax_anim 1, 0, 26, 10, 0, 10, 0,
+ax_anim 2, 0, 26, 19, 0, 19, 0,
+ax_anim 2, 1, 27, 19, 0, 19, 0,
+ax_anim 2, 0, 26, 19, 0, 19, 0,
+ax_anim 2, 0, 25, 19, 0, 19, 0,
+ax_anim 2, 0, 26, 19, 0, 19, 0,
+ax_anim 2, 0, 27, 19, 0, 19, 0,
+ax_anim 2, 0, 26, 6, 0, 6, 0,
+ax_anim_terminator
+sCascoonAnims_3_4:
+ax_anim 2, 0, 27, -1, 1, -1, 1,
+ax_anim 4, 0, 27, -2, 2, -2, 2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, -4, 4, -4,
+ax_anim 1, 0, 27, 10, -10, 10, -10,
+ax_anim 2, 0, 27, 19, -21, 19, -21,
+ax_anim 2, 1, 28, 19, -21, 19, -21,
+ax_anim 2, 0, 27, 19, -21, 19, -21,
+ax_anim 2, 0, 26, 19, -21, 19, -21,
+ax_anim 2, 0, 27, 19, -21, 19, -21,
+ax_anim 2, 0, 28, 19, -21, 19, -21,
+ax_anim 2, 0, 27, 6, -6, 6, -6,
+ax_anim_terminator
+sCascoonAnims_3_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 4, 0, 28, 0, 2, 0, 2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 0, -4, 0, -4,
+ax_anim 1, 0, 28, 0, -10, 0, -10,
+ax_anim 2, 0, 28, 0, -21, 0, -21,
+ax_anim 2, 1, 29, 0, -21, 0, -21,
+ax_anim 2, 0, 28, 0, -21, 0, -21,
+ax_anim 2, 0, 27, 0, -21, 0, -21,
+ax_anim 2, 0, 28, 0, -21, 0, -21,
+ax_anim 2, 0, 29, 0, -21, 0, -21,
+ax_anim 2, 0, 28, 0, -6, 0, -6,
+ax_anim_terminator
+sCascoonAnims_3_6:
+ax_anim 2, 0, 29, 1, 1, 1, 1,
+ax_anim 4, 0, 29, 2, 2, 2, 2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, -4, -4, -4, -4,
+ax_anim 1, 0, 29, -10, -10, -10, -10,
+ax_anim 2, 0, 29, -19, -21, -19, -21,
+ax_anim 2, 1, 30, -19, -21, -19, -21,
+ax_anim 2, 0, 29, -19, -21, -19, -21,
+ax_anim 2, 0, 28, -19, -21, -19, -21,
+ax_anim 2, 0, 29, -19, -21, -19, -21,
+ax_anim 2, 0, 30, -19, -21, -19, -21,
+ax_anim 2, 0, 29, -6, -6, -6, -6,
+ax_anim_terminator
+sCascoonAnims_3_7:
+ax_anim 2, 0, 30, 1, 0, 1, 0,
+ax_anim 4, 0, 30, 2, 0, 2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, -4, 0, -4, 0,
+ax_anim 1, 0, 30, -10, 0, -10, 0,
+ax_anim 2, 0, 30, -19, 0, -19, 0,
+ax_anim 2, 1, 29, -19, 0, -19, 0,
+ax_anim 2, 0, 30, -19, 0, -19, 0,
+ax_anim 2, 0, 31, -19, 0, -19, 0,
+ax_anim 2, 0, 30, -19, 0, -19, 0,
+ax_anim 2, 0, 29, -19, 0, -19, 0,
+ax_anim 2, 0, 30, -6, 0, -6, 0,
+ax_anim_terminator
+sCascoonAnims_3_8:
+ax_anim 2, 0, 31, 1, -1, 1, -1,
+ax_anim 4, 0, 31, 2, -2, 2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, -4, 4, -4, 4,
+ax_anim 1, 0, 31, -10, 10, -10, 10,
+ax_anim 2, 0, 31, -19, 18, -19, 18,
+ax_anim 2, 1, 30, -19, 18, -19, 18,
+ax_anim 2, 0, 31, -19, 18, -19, 18,
+ax_anim 2, 0, 24, -19, 18, -19, 18,
+ax_anim 2, 0, 31, -19, 18, -19, 18,
+ax_anim 2, 0, 30, -19, 18, -19, 18,
+ax_anim 2, 0, 31, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCascoonAnims_4_1:
+ax_anim 2, 0, 32, 1, 0, 1, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 1, 0, 1, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 1, 0, 1, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 1, 0, 1, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 1, 0, 1, 0,
+ax_anim 2, 1, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_4_2:
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 2, 1, 39, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_4_3:
+ax_anim 2, 0, 38, 0, -1, 0, -1,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, -1, 0, -1,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, -1, 0, -1,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, -1, 0, -1,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, -1, 0, -1,
+ax_anim 2, 1, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_4_4:
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 2, 1, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_4_5:
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 2, 1, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_4_6:
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 1, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_4_7:
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 1, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_4_8:
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 2, 1, 33, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_5_1:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim 2, 2, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim_terminator
+sCascoonAnims_5_2:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 4, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 2, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim_terminator
+sCascoonAnims_5_3:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 2, 2, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim_terminator
+sCascoonAnims_5_4:
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 4, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 2, 2, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim_terminator
+sCascoonAnims_5_5:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 4, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 2, 2, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim_terminator
+sCascoonAnims_5_6:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, 1, -1, 1,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, 1, -1, 1,
+ax_anim 2, 2, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, 1, -1, 1,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, 1, -1, 1,
+ax_anim_terminator
+sCascoonAnims_5_7:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 4, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, -1, 0, -1,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, -1, 0, -1,
+ax_anim 2, 2, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, -1, 0, -1,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, -1, 0, -1,
+ax_anim_terminator
+sCascoonAnims_5_8:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 4, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 2, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sCascoonAnims_6_1:
+ax_anim 30, 0, 56, 0, 0, 0, 0,
+ax_anim 35, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_7_1:
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 8, 0, 58, 0, -3, 0, -3,
+ax_anim_terminator
+sCascoonAnims_7_2:
+ax_anim 2, 0, 59, -2, -2, -2, -2,
+ax_anim 8, 0, 59, -3, -3, -3, -3,
+ax_anim_terminator
+sCascoonAnims_7_3:
+ax_anim 2, 0, 60, -2, 0, -2, 0,
+ax_anim 8, 0, 60, -3, 0, -3, 0,
+ax_anim_terminator
+sCascoonAnims_7_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 8, 0, 61, -3, 3, -3, 3,
+ax_anim_terminator
+sCascoonAnims_7_5:
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 8, 0, 62, 0, 3, 0, 3,
+ax_anim_terminator
+sCascoonAnims_7_6:
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 8, 0, 63, 3, 3, 3, 3,
+ax_anim_terminator
+sCascoonAnims_7_7:
+ax_anim 2, 0, 64, 2, 0, 2, 0,
+ax_anim 8, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sCascoonAnims_7_8:
+ax_anim 2, 0, 65, 2, -2, 2, -2,
+ax_anim 8, 0, 65, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCascoonAnims_8_1:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 2, 0, 66, -1, 0, -1, 0,
+ax_anim 120, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_8_2:
+ax_anim 2, 0, 67, -1, 1, -1, 1,
+ax_anim 2, 0, 67, 1, -1, 0, 0,
+ax_anim 120, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_8_3:
+ax_anim 2, 0, 68, 0, 1, 0, 1,
+ax_anim 2, 0, 68, 0, -1, 0, -1,
+ax_anim 120, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_8_4:
+ax_anim 2, 0, 69, 1, 1, 1, 1,
+ax_anim 2, 0, 69, -1, -1, 0, 0,
+ax_anim 120, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_8_5:
+ax_anim 2, 0, 70, -1, 0, -1, 0,
+ax_anim 2, 0, 70, 1, 0, 1, 0,
+ax_anim 120, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_8_6:
+ax_anim 2, 0, 71, -1, 1, -1, 1,
+ax_anim 2, 0, 71, 1, -1, 0, 0,
+ax_anim 120, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_8_7:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 120, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_8_8:
+ax_anim 2, 0, 73, 1, 1, 1, 1,
+ax_anim 2, 0, 73, -1, -1, 0, 0,
+ax_anim 120, 0, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_9_1:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 6, 4, 6, 4,
+ax_anim 2, 0, 84, 8, 11, 8, 11,
+ax_anim 2, 0, 85, 7, 17, 7, 17,
+ax_anim 3, 0, 86, 0, 21, 0, 21,
+ax_anim 2, 3, 87, -7, 17, -7, 17,
+ax_anim 2, 0, 88, -8, 11, -8, 11,
+ax_anim 1, 0, 89, -6, 4, -6, 4,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_9_2:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 8, 0, 8, 0,
+ax_anim 2, 0, 83, 17, 5, 17, 5,
+ax_anim 2, 0, 84, 21, 13, 21, 13,
+ax_anim 3, 0, 85, 19, 21, 19, 21,
+ax_anim 2, 3, 86, 13, 22, 13, 22,
+ax_anim 2, 0, 87, 4, 17, 4, 17,
+ax_anim 1, 0, 88, 0, 10, 0, 10,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_9_3:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 3, -5, 3, -5,
+ax_anim 2, 0, 82, 11, -6, 11, -6,
+ax_anim 2, 0, 83, 16, -5, 16, -5,
+ax_anim 3, 0, 84, 20, 0, 20, 0,
+ax_anim 2, 3, 85, 19, 6, 19, 6,
+ax_anim 2, 0, 86, 12, 7, 12, 7,
+ax_anim 1, 0, 87, 4, 5, 4, 5,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_9_4:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 88, -1, -8, -1, -8,
+ax_anim 2, 0, 89, 4, -16, 4, -16,
+ax_anim 2, 0, 82, 12, -22, 12, -22,
+ax_anim 3, 0, 83, 19, -22, 19, -22,
+ax_anim 2, 3, 84, 21, -15, 21, -15,
+ax_anim 2, 0, 85, 17, -4, 17, -4,
+ax_anim 1, 0, 86, 7, -1, 7, -1,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_9_5:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, -8, -4, -8, -4,
+ax_anim 2, 0, 88, -9, -13, -9, -13,
+ax_anim 2, 0, 89, -7, -20, -7, -20,
+ax_anim 3, 0, 82, 0, -23, 0, -23,
+ax_anim 2, 3, 83, 7, -20, 7, -20,
+ax_anim 2, 0, 84, 9, -13, 9, -13,
+ax_anim 1, 0, 85, 8, -4, 8, -4,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_9_6:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 1, -8, 1, -8,
+ax_anim 2, 0, 83, -4, -16, -4, -16,
+ax_anim 2, 0, 82, -12, -22, -12, -22,
+ax_anim 3, 0, 89, -19, -22, -19, -22,
+ax_anim 2, 3, 88, -21, -15, -21, -15,
+ax_anim 2, 0, 87, -17, -4, -17, -4,
+ax_anim 1, 0, 86, -7, -1, -7, -1,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_9_7:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 83, -3, -5, -3, -5,
+ax_anim 2, 0, 82, -11, -6, -11, -6,
+ax_anim 2, 0, 89, -16, -5, -16, -5,
+ax_anim 3, 0, 88, -20, 0, -20, 0,
+ax_anim 2, 3, 87, -19, 6, -19, 6,
+ax_anim 2, 0, 86, -12, 7, -12, 7,
+ax_anim 1, 0, 85, -4, 5, -4, 5,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_9_8:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 82, -8, 0, -8, 0,
+ax_anim 2, 0, 89, -17, 5, -17, 5,
+ax_anim 2, 0, 88, -21, 13, -21, 13,
+ax_anim 3, 0, 87, -19, 21, -19, 21,
+ax_anim 2, 3, 86, -13, 22, -13, 22,
+ax_anim 2, 0, 85, -4, 17, -4, 17,
+ax_anim 1, 0, 84, 0, 10, 0, 10,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_10_1:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 6, 0, 6, 0,
+ax_anim 2, 0, 90, -6, 0, -6, 0,
+ax_anim 2, 0, 90, 10, 0, 10, 0,
+ax_anim 2, 0, 90, -10, 0, -10, 0,
+ax_anim 2, 0, 90, 12, 0, 12, 0,
+ax_anim 3, 0, 90, -12, 0, -12, 0,
+ax_anim 3, 0, 90, 13, 0, 13, 0,
+ax_anim 3, 0, 90, -13, 0, -13, 0,
+ax_anim 2, 0, 90, 12, 0, 12, 0,
+ax_anim 3, 0, 90, -12, 0, -12, 0,
+ax_anim 2, 0, 90, 10, 0, 10, 0,
+ax_anim 2, 0, 90, -10, 0, -10, 0,
+ax_anim 2, 0, 90, 6, 0, 6, 0,
+ax_anim 2, 0, 90, -6, 0, -6, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_10_2:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 6, -6, 6, -6,
+ax_anim 2, 0, 91, -6, 6, -6, 6,
+ax_anim 2, 0, 91, 10, -10, 10, -10,
+ax_anim 2, 0, 91, -10, 10, -10, 10,
+ax_anim 2, 0, 91, 12, -12, 12, -12,
+ax_anim 3, 0, 91, -12, 12, -12, 12,
+ax_anim 3, 0, 91, 13, -13, 13, -13,
+ax_anim 3, 0, 91, -13, 13, -13, 13,
+ax_anim 2, 0, 91, 12, -12, 12, -12,
+ax_anim 3, 0, 91, -12, 12, -12, 12,
+ax_anim 2, 0, 91, 10, -10, 10, -10,
+ax_anim 2, 0, 91, -10, 10, -10, 10,
+ax_anim 2, 0, 91, 6, -6, 6, -6,
+ax_anim 2, 0, 91, -6, 6, -6, 6,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_10_3:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -6, 0, -6,
+ax_anim 2, 0, 92, 0, 6, 0, 6,
+ax_anim 2, 0, 92, 0, -10, 0, -10,
+ax_anim 2, 0, 92, 0, 10, 0, 10,
+ax_anim 2, 0, 92, 0, -12, 0, -12,
+ax_anim 3, 0, 92, 0, 12, 0, 12,
+ax_anim 3, 0, 92, 0, -13, 0, -13,
+ax_anim 3, 0, 92, 0, 13, 0, 13,
+ax_anim 2, 0, 92, 0, -12, 0, -12,
+ax_anim 3, 0, 92, 0, 12, 0, 12,
+ax_anim 2, 0, 92, 0, -10, 0, -10,
+ax_anim 2, 0, 92, 0, 10, 0, 10,
+ax_anim 2, 0, 92, 0, -6, 0, -6,
+ax_anim 2, 0, 92, 0, 6, 0, 6,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_10_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -6, -6, -6, -6,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, -10, -10, -10, -10,
+ax_anim 2, 0, 93, 10, 10, 10, 10,
+ax_anim 2, 0, 93, -12, -12, -12, -12,
+ax_anim 3, 0, 93, 12, 12, 12, 12,
+ax_anim 3, 0, 93, -13, -13, -13, -13,
+ax_anim 3, 0, 93, 13, 13, 13, 13,
+ax_anim 2, 0, 93, -12, -12, -12, -12,
+ax_anim 3, 0, 93, 12, 12, 12, 12,
+ax_anim 2, 0, 93, -10, -10, -10, -10,
+ax_anim 2, 0, 93, 10, 10, 10, 10,
+ax_anim 2, 0, 93, -6, -6, -6, -6,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_10_5:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 6, 0, 6, 0,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim 2, 0, 94, 10, 0, 10, 0,
+ax_anim 2, 0, 94, -10, 0, -10, 0,
+ax_anim 2, 0, 94, 12, 0, 12, 0,
+ax_anim 3, 0, 94, -12, 0, -12, 0,
+ax_anim 3, 0, 94, 13, 0, 13, 0,
+ax_anim 3, 0, 94, -13, 0, -13, 0,
+ax_anim 2, 0, 94, 12, 0, 12, 0,
+ax_anim 3, 0, 94, -12, 0, -12, 0,
+ax_anim 2, 0, 94, 10, 0, 10, 0,
+ax_anim 2, 0, 94, -10, 0, -10, 0,
+ax_anim 2, 0, 94, 6, 0, 6, 0,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_10_6:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 6, -6, 6, -6,
+ax_anim 2, 0, 95, -6, 6, -6, 6,
+ax_anim 2, 0, 95, 10, -10, 10, -10,
+ax_anim 2, 0, 95, -10, 10, -10, 10,
+ax_anim 2, 0, 95, 12, -12, 12, -12,
+ax_anim 3, 0, 95, -12, 12, -12, 12,
+ax_anim 3, 0, 95, 13, -13, 13, -13,
+ax_anim 3, 0, 95, -13, 13, -13, 13,
+ax_anim 2, 0, 95, 12, -12, 12, -12,
+ax_anim 3, 0, 95, -12, 12, -12, 12,
+ax_anim 2, 0, 95, 10, -10, 10, -10,
+ax_anim 2, 0, 95, -10, 10, -10, 10,
+ax_anim 2, 0, 95, 6, -6, 6, -6,
+ax_anim 2, 0, 95, -6, 6, -6, 6,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_10_7:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -6, 0, -6,
+ax_anim 2, 0, 96, 0, 6, 0, 6,
+ax_anim 2, 0, 96, 0, -10, 0, -10,
+ax_anim 2, 0, 96, 0, 10, 0, 10,
+ax_anim 2, 0, 96, 0, -12, 0, -12,
+ax_anim 3, 0, 96, 0, 12, 0, 12,
+ax_anim 3, 0, 96, 0, -13, 0, -13,
+ax_anim 3, 0, 96, 0, 13, 0, 13,
+ax_anim 2, 0, 96, 0, -12, 0, -12,
+ax_anim 3, 0, 96, 0, 12, 0, 12,
+ax_anim 2, 0, 96, 0, -10, 0, -10,
+ax_anim 2, 0, 96, 0, 10, 0, 10,
+ax_anim 2, 0, 96, 0, -6, 0, -6,
+ax_anim 2, 0, 96, 0, 6, 0, 6,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_10_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -6, -6, -6, -6,
+ax_anim 2, 0, 97, 6, 6, 6, 6,
+ax_anim 2, 0, 97, -10, -10, -10, -10,
+ax_anim 2, 0, 97, 10, 10, 10, 10,
+ax_anim 2, 0, 97, -12, -12, -12, -12,
+ax_anim 3, 0, 97, 12, 12, 12, 12,
+ax_anim 3, 0, 97, -13, -13, -13, -13,
+ax_anim 3, 0, 97, 13, 13, 13, 13,
+ax_anim 2, 0, 97, -12, -12, -12, -12,
+ax_anim 3, 0, 97, 12, 12, 12, 12,
+ax_anim 2, 0, 97, -10, -10, -10, -10,
+ax_anim 2, 0, 97, 10, 10, 10, 10,
+ax_anim 2, 0, 97, -6, -6, -6, -6,
+ax_anim 2, 0, 97, 6, 6, 6, 6,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_11_1:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -10, 0, 0,
+ax_anim 2, 0, 99, 0, -16, 0, 0,
+ax_anim 3, 0, 99, 0, -20, 0, 0,
+ax_anim 4, 0, 99, 0, -21, 0, 0,
+ax_anim 4, 0, 98, 0, -22, 0, 0,
+ax_anim 3, 0, 98, 0, -21, 0, 0,
+ax_anim 2, 0, 98, 0, -18, 0, 0,
+ax_anim 1, 0, 98, 0, -12, 0, 0,
+ax_anim 2, 2, 98, 0, 1, 0, 0,
+ax_anim_terminator
+sCascoonAnims_11_2:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -10, 0, 0,
+ax_anim 2, 0, 101, 0, -16, 0, 0,
+ax_anim 3, 0, 101, 0, -20, 0, 0,
+ax_anim 4, 0, 101, 0, -21, 0, 0,
+ax_anim 4, 0, 100, 0, -22, 0, 0,
+ax_anim 3, 0, 100, 0, -21, 0, 0,
+ax_anim 2, 0, 100, 0, -18, 0, 0,
+ax_anim 1, 0, 100, 0, -12, 0, 0,
+ax_anim 2, 2, 100, 0, 1, 0, 0,
+ax_anim_terminator
+sCascoonAnims_11_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -10, 0, 0,
+ax_anim 2, 0, 103, 0, -16, 0, 0,
+ax_anim 3, 0, 103, 0, -20, 0, 0,
+ax_anim 4, 0, 103, 0, -21, 0, 0,
+ax_anim 4, 0, 102, 0, -22, 0, 0,
+ax_anim 3, 0, 102, 0, -21, 0, 0,
+ax_anim 2, 0, 102, 0, -18, 0, 0,
+ax_anim 1, 0, 102, 0, -12, 0, 0,
+ax_anim 2, 2, 102, 0, 1, 0, 0,
+ax_anim_terminator
+sCascoonAnims_11_4:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -10, 0, 0,
+ax_anim 2, 0, 105, 0, -16, 0, 0,
+ax_anim 3, 0, 105, 0, -20, 0, 0,
+ax_anim 4, 0, 105, 0, -21, 0, 0,
+ax_anim 4, 0, 104, 0, -22, 0, 0,
+ax_anim 3, 0, 104, 0, -21, 0, 0,
+ax_anim 2, 0, 104, 0, -17, 0, 0,
+ax_anim 1, 0, 104, 0, -11, 0, 0,
+ax_anim 2, 2, 104, 0, 1, 0, 0,
+ax_anim_terminator
+sCascoonAnims_11_5:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -10, 0, 0,
+ax_anim 2, 0, 107, 0, -16, 0, 0,
+ax_anim 3, 0, 107, 0, -20, 0, 0,
+ax_anim 4, 0, 107, 0, -21, 0, 0,
+ax_anim 4, 0, 106, 0, -22, 0, 0,
+ax_anim 3, 0, 106, 0, -21, 0, 0,
+ax_anim 2, 0, 106, 0, -18, 0, 0,
+ax_anim 1, 0, 106, 0, -12, 0, 0,
+ax_anim 2, 2, 106, 0, 1, 0, 0,
+ax_anim_terminator
+sCascoonAnims_11_6:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, -10, 0, 0,
+ax_anim 2, 0, 109, 0, -16, 0, 0,
+ax_anim 3, 0, 109, 0, -20, 0, 0,
+ax_anim 4, 0, 109, 0, -21, 0, 0,
+ax_anim 4, 0, 108, 0, -22, 0, 0,
+ax_anim 3, 0, 108, 0, -21, 0, 0,
+ax_anim 2, 0, 108, 0, -17, 0, 0,
+ax_anim 1, 0, 108, 0, -11, 0, 0,
+ax_anim 2, 2, 108, 0, 1, 0, 0,
+ax_anim_terminator
+sCascoonAnims_11_7:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -10, 0, 0,
+ax_anim 2, 0, 111, 0, -16, 0, 0,
+ax_anim 3, 0, 111, 0, -20, 0, 0,
+ax_anim 4, 0, 111, 0, -21, 0, 0,
+ax_anim 4, 0, 110, 0, -22, 0, 0,
+ax_anim 3, 0, 110, 0, -21, 0, 0,
+ax_anim 2, 0, 110, 0, -18, 0, 0,
+ax_anim 1, 0, 110, 0, -12, 0, 0,
+ax_anim 2, 2, 110, 0, 1, 0, 0,
+ax_anim_terminator
+sCascoonAnims_11_8:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, -10, 0, 0,
+ax_anim 2, 0, 113, 0, -16, 0, 0,
+ax_anim 3, 0, 113, 0, -20, 0, 0,
+ax_anim 4, 0, 113, 0, -21, 0, 0,
+ax_anim 4, 0, 112, 0, -22, 0, 0,
+ax_anim 3, 0, 112, 0, -21, 0, 0,
+ax_anim 2, 0, 112, 0, -18, 0, 0,
+ax_anim 1, 0, 112, 0, -12, 0, 0,
+ax_anim 2, 2, 112, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_12_1:
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_12_2:
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 1, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_12_3:
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_12_4:
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_12_5:
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_12_6:
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_12_7:
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_12_8:
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCascoonAnims_13_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_13_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_13_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_13_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_13_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_13_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_13_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonAnims_13_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sCascoonGfx1:
+.incbin "baserom.gba", 0x10F954C, 0x200
+sCascoonSprites1:
+ax_sprite sCascoonGfx1, 0x200
+ax_sprite_terminator
+sCascoonGfx2:
+.incbin "baserom.gba", 0x10F975C, 0x200
+sCascoonSprites2:
+ax_sprite sCascoonGfx2, 0x200
+ax_sprite_terminator
+sCascoonGfx3:
+.incbin "baserom.gba", 0x10F996C, 0x200
+sCascoonSprites3:
+ax_sprite sCascoonGfx3, 0x200
+ax_sprite_terminator
+sCascoonGfx4:
+.incbin "baserom.gba", 0x10F9B7C, 0x200
+sCascoonSprites4:
+ax_sprite sCascoonGfx4, 0x200
+ax_sprite_terminator
+sCascoonGfx5:
+.incbin "baserom.gba", 0x10F9D8C, 0x200
+sCascoonSprites5:
+ax_sprite sCascoonGfx5, 0x200
+ax_sprite_terminator
+sCascoonGfx6:
+.incbin "baserom.gba", 0x10F9F9C, 0x200
+sCascoonSprites6:
+ax_sprite sCascoonGfx6, 0x200
+ax_sprite_terminator
+sCascoonGfx7:
+.incbin "baserom.gba", 0x10FA1AC, 0x200
+sCascoonSprites7:
+ax_sprite sCascoonGfx7, 0x200
+ax_sprite_terminator
+sCascoonGfx8:
+.incbin "baserom.gba", 0x10FA3BC, 0x200
+sCascoonSprites8:
+ax_sprite sCascoonGfx8, 0x200
+ax_sprite_terminator
+sCascoonGfx9:
+.incbin "baserom.gba", 0x10FA5CC, 0xE0
+sCascoonGfx9_1:
+.incbin "baserom.gba", 0x10FA6AC, 0x80
+sCascoonGfx9_2:
+.incbin "baserom.gba", 0x10FA72C, 0x20
+sCascoonSprites9:
+ax_sprite sCascoonGfx9, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx9_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx9_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCascoonGfx10:
+.incbin "baserom.gba", 0x10FA784, 0x60
+sCascoonGfx10_1:
+.incbin "baserom.gba", 0x10FA7E4, 0x60
+sCascoonGfx10_2:
+.incbin "baserom.gba", 0x10FA844, 0x60
+sCascoonGfx10_3:
+.incbin "baserom.gba", 0x10FA8A4, 0x40
+sCascoonSprites10:
+ax_sprite sCascoonGfx10, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx10_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx10_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx10_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCascoonGfx11:
+.incbin "baserom.gba", 0x10FA92C, 0x40
+sCascoonGfx11_1:
+.incbin "baserom.gba", 0x10FA96C, 0x60
+sCascoonGfx11_2:
+.incbin "baserom.gba", 0x10FA9CC, 0x60
+sCascoonGfx11_3:
+.incbin "baserom.gba", 0x10FAA2C, 0x60
+sCascoonSprites11:
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx11, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx11_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx11_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx11_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCascoonGfx12:
+.incbin "baserom.gba", 0x10FAADC, 0x60
+sCascoonGfx12_1:
+.incbin "baserom.gba", 0x10FAB3C, 0x60
+sCascoonGfx12_2:
+.incbin "baserom.gba", 0x10FAB9C, 0x60
+sCascoonGfx12_3:
+.incbin "baserom.gba", 0x10FABFC, 0x20
+sCascoonSprites12:
+ax_sprite sCascoonGfx12, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx12_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx12_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx12_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sCascoonGfx13:
+.incbin "baserom.gba", 0x10FAC64, 0xE0
+sCascoonGfx13_1:
+.incbin "baserom.gba", 0x10FAD44, 0x80
+sCascoonGfx13_2:
+.incbin "baserom.gba", 0x10FADC4, 0x20
+sCascoonSprites13:
+ax_sprite sCascoonGfx13, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx13_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx13_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCascoonGfx14:
+.incbin "baserom.gba", 0x10FAE1C, 0x40
+sCascoonGfx14_1:
+.incbin "baserom.gba", 0x10FAE5C, 0x60
+sCascoonGfx14_2:
+.incbin "baserom.gba", 0x10FAEBC, 0xE0
+sCascoonSprites14:
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx14, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx14_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx14_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCascoonGfx15:
+.incbin "baserom.gba", 0x10FAFDC, 0x60
+sCascoonGfx15_1:
+.incbin "baserom.gba", 0x10FB03C, 0x60
+sCascoonGfx15_2:
+.incbin "baserom.gba", 0x10FB09C, 0x60
+sCascoonGfx15_3:
+.incbin "baserom.gba", 0x10FB0FC, 0x60
+sCascoonSprites15:
+ax_sprite sCascoonGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx15_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx15_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx15_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCascoonGfx16:
+.incbin "baserom.gba", 0x10FB1A4, 0xE0
+sCascoonGfx16_1:
+.incbin "baserom.gba", 0x10FB284, 0x60
+sCascoonGfx16_2:
+.incbin "baserom.gba", 0x10FB2E4, 0x20
+sCascoonSprites16:
+ax_sprite sCascoonGfx16, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCascoonGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCascoonGfx16_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCascoonGfx17:
+.incbin "baserom.gba", 0x10FB33C, 0x200
+sCascoonSprites17:
+ax_sprite sCascoonGfx17, 0x200
+ax_sprite_terminator
+sCascoonGfx18:
+.incbin "baserom.gba", 0x10FB54C, 0x200
+sCascoonSprites18:
+ax_sprite sCascoonGfx18, 0x200
+ax_sprite_terminator
+sCascoonGfx19:
+.incbin "baserom.gba", 0x10FB75C, 0x200
+sCascoonSprites19:
+ax_sprite sCascoonGfx19, 0x200
+ax_sprite_terminator
+sCascoonGfx20:
+.incbin "baserom.gba", 0x10FB96C, 0x200
+sCascoonSprites20:
+ax_sprite sCascoonGfx20, 0x200
+ax_sprite_terminator
+sCascoonGfx21:
+.incbin "baserom.gba", 0x10FBB7C, 0x200
+sCascoonSprites21:
+ax_sprite sCascoonGfx21, 0x200
+ax_sprite_terminator
+sCascoonGfx22:
+.incbin "baserom.gba", 0x10FBD8C, 0x200
+sCascoonSprites22:
+ax_sprite sCascoonGfx22, 0x200
+ax_sprite_terminator
+sCascoonGfx23:
+.incbin "baserom.gba", 0x10FBF9C, 0x200
+sCascoonSprites23:
+ax_sprite sCascoonGfx23, 0x200
+ax_sprite_terminator
+sAxPosesCascoon:
+.4byte sCascoonPose1
+.4byte sCascoonPose2
+.4byte sCascoonPose3
+.4byte sCascoonPose4
+.4byte sCascoonPose5
+.4byte sCascoonPose6
+.4byte sCascoonPose7
+.4byte sCascoonPose8
+.4byte sCascoonPose9
+.4byte sCascoonPose10
+.4byte sCascoonPose11
+.4byte sCascoonPose12
+.4byte sCascoonPose13
+.4byte sCascoonPose14
+.4byte sCascoonPose15
+.4byte sCascoonPose16
+.4byte sCascoonPose17
+.4byte sCascoonPose18
+.4byte sCascoonPose19
+.4byte sCascoonPose20
+.4byte sCascoonPose21
+.4byte sCascoonPose22
+.4byte sCascoonPose23
+.4byte sCascoonPose24
+.4byte sCascoonPose25
+.4byte sCascoonPose26
+.4byte sCascoonPose27
+.4byte sCascoonPose28
+.4byte sCascoonPose29
+.4byte sCascoonPose30
+.4byte sCascoonPose31
+.4byte sCascoonPose32
+.4byte sCascoonPose33
+.4byte sCascoonPose34
+.4byte sCascoonPose35
+.4byte sCascoonPose36
+.4byte sCascoonPose37
+.4byte sCascoonPose38
+.4byte sCascoonPose39
+.4byte sCascoonPose40
+.4byte sCascoonPose41
+.4byte sCascoonPose42
+.4byte sCascoonPose43
+.4byte sCascoonPose44
+.4byte sCascoonPose45
+.4byte sCascoonPose46
+.4byte sCascoonPose47
+.4byte sCascoonPose48
+.4byte sCascoonPose49
+.4byte sCascoonPose50
+.4byte sCascoonPose51
+.4byte sCascoonPose52
+.4byte sCascoonPose53
+.4byte sCascoonPose54
+.4byte sCascoonPose55
+.4byte sCascoonPose56
+.4byte sCascoonPose57
+.4byte sCascoonPose58
+.4byte sCascoonPose59
+.4byte sCascoonPose60
+.4byte sCascoonPose61
+.4byte sCascoonPose62
+.4byte sCascoonPose63
+.4byte sCascoonPose64
+.4byte sCascoonPose65
+.4byte sCascoonPose66
+.4byte sCascoonPose67
+.4byte sCascoonPose68
+.4byte sCascoonPose69
+.4byte sCascoonPose70
+.4byte sCascoonPose71
+.4byte sCascoonPose72
+.4byte sCascoonPose73
+.4byte sCascoonPose74
+.4byte sCascoonPose75
+.4byte sCascoonPose76
+.4byte sCascoonPose77
+.4byte sCascoonPose78
+.4byte sCascoonPose79
+.4byte sCascoonPose80
+.4byte sCascoonPose81
+.4byte sCascoonPose82
+.4byte sCascoonPose83
+.4byte sCascoonPose84
+.4byte sCascoonPose85
+.4byte sCascoonPose86
+.4byte sCascoonPose87
+.4byte sCascoonPose88
+.4byte sCascoonPose89
+.4byte sCascoonPose90
+.4byte sCascoonPose91
+.4byte sCascoonPose92
+.4byte sCascoonPose93
+.4byte sCascoonPose94
+.4byte sCascoonPose95
+.4byte sCascoonPose96
+.4byte sCascoonPose97
+.4byte sCascoonPose98
+.4byte sCascoonPose99
+.4byte sCascoonPose100
+.4byte sCascoonPose101
+.4byte sCascoonPose102
+.4byte sCascoonPose103
+.4byte sCascoonPose104
+.4byte sCascoonPose105
+.4byte sCascoonPose106
+.4byte sCascoonPose107
+.4byte sCascoonPose108
+.4byte sCascoonPose109
+.4byte sCascoonPose110
+.4byte sCascoonPose111
+.4byte sCascoonPose112
+.4byte sCascoonPose113
+.4byte sCascoonPose114
+.4byte sCascoonPose115
+.4byte sCascoonPose116
+.4byte sCascoonPose117
+.4byte sCascoonPose118
+.4byte sCascoonPose119
+.4byte sCascoonPose120
+.4byte sCascoonPose121
+.4byte sCascoonPose122
+.4byte sCascoonPose123
+.4byte sCascoonPose124
+.4byte sCascoonPose125
+.4byte sCascoonPose126
+.4byte sCascoonPose127
+.4byte sCascoonPose128
+.4byte sCascoonPose129
+.4byte sCascoonPose130
+sAxPositionsCascoon:
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -6,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -2, 	  -1,   -4, 	  -1,  -10, 	   0,   -6
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    5,   -5, 	   4,   -5, 	  -5,   -9, 	  -1,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -5, 	   4,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -2, 	   0,  -10, 	   2,   -3, 	   0,   -6
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -9, 	   7,   -7, 	   0,   -7
+.2byte    3,   -4, 	   7,   -5, 	  -5,   -7, 	   0,   -5
+.2byte    3,   -4, 	   7,   -4, 	  -5,   -7, 	   0,   -5
+.2byte    0,   -6, 	  -8,   -9, 	   8,   -9, 	   0,   -9
+.2byte    3,   -8, 	   3,  -11, 	  -8,   -6, 	  -1,   -7
+.2byte    7,   -9, 	  -1,  -10, 	  -6,   -7, 	  -1,   -8
+.2byte    6,  -14, 	  -4,  -12, 	   3,   -7, 	   0,  -10
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte   -7,  -13, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte   -8,   -9, 	   0,  -10, 	   5,   -7, 	   0,   -8
+.2byte   -4,   -8, 	  -4,  -11, 	   7,   -6, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -9, 	   7,   -7, 	   0,   -7
+.2byte   -5,   -2, 	   0,  -10, 	   2,   -3, 	   0,   -6
+.2byte   -5,   -5, 	   4,   -9, 	  -4,   -6, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    5,   -5, 	   4,   -5, 	  -5,   -9, 	  -1,   -7
+.2byte    4,   -2, 	  -1,   -4, 	  -1,  -10, 	   0,   -6
+.2byte    4,   -2, 	  -6,   -6, 	   4,  -10, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    4,   -2, 	  -6,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -1,   -4, 	  -1,  -10, 	   0,   -6
+.2byte    5,   -5, 	   4,   -5, 	  -5,   -9, 	  -1,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -5,   -5, 	   4,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -2, 	   0,  -10, 	   2,   -3, 	   0,   -6
+.2byte   -4,   -2, 	  -4,   -9, 	   7,   -7, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -6,   -6, 	   4,  -10, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -2, 	  -1,   -4, 	  -1,  -10, 	   0,   -6
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    5,   -5, 	   4,   -5, 	  -5,   -9, 	  -1,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -5, 	   4,   -9, 	  -4,   -6, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -2, 	   0,  -10, 	   2,   -3, 	   0,   -6
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -9, 	   7,   -7, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+.2byte    0,   -2, 	  -7,   -7, 	   7,   -7, 	   0,   -7
+.2byte   -4,   -2, 	  -4,   -8, 	   7,   -5, 	   0,   -7
+.2byte   -5,   -2, 	   0,   -9, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -5, 	   3,   -9, 	  -4,   -6, 	   0,   -7
+.2byte    0,   -6, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    4,   -5, 	   3,   -5, 	  -5,   -9, 	   0,   -7
+.2byte    4,   -2, 	  -2,   -5, 	  -2,  -11, 	   0,   -6
+.2byte    4,   -2, 	  -5,   -6, 	   4,  -10, 	   0,   -7
+sCascoonAnimTable1:
+.4byte sCascoonAnims_1_1
+.4byte sCascoonAnims_1_2
+.4byte sCascoonAnims_1_3
+.4byte sCascoonAnims_1_4
+.4byte sCascoonAnims_1_5
+.4byte sCascoonAnims_1_6
+.4byte sCascoonAnims_1_7
+.4byte sCascoonAnims_1_8
+sCascoonAnimTable2:
+.4byte sCascoonAnims_2_1
+.4byte sCascoonAnims_2_2
+.4byte sCascoonAnims_2_3
+.4byte sCascoonAnims_2_4
+.4byte sCascoonAnims_2_5
+.4byte sCascoonAnims_2_6
+.4byte sCascoonAnims_2_7
+.4byte sCascoonAnims_2_8
+sCascoonAnimTable3:
+.4byte sCascoonAnims_3_1
+.4byte sCascoonAnims_3_2
+.4byte sCascoonAnims_3_3
+.4byte sCascoonAnims_3_4
+.4byte sCascoonAnims_3_5
+.4byte sCascoonAnims_3_6
+.4byte sCascoonAnims_3_7
+.4byte sCascoonAnims_3_8
+sCascoonAnimTable4:
+.4byte sCascoonAnims_4_1
+.4byte sCascoonAnims_4_2
+.4byte sCascoonAnims_4_3
+.4byte sCascoonAnims_4_4
+.4byte sCascoonAnims_4_5
+.4byte sCascoonAnims_4_6
+.4byte sCascoonAnims_4_7
+.4byte sCascoonAnims_4_8
+sCascoonAnimTable5:
+.4byte sCascoonAnims_5_1
+.4byte sCascoonAnims_5_2
+.4byte sCascoonAnims_5_3
+.4byte sCascoonAnims_5_4
+.4byte sCascoonAnims_5_5
+.4byte sCascoonAnims_5_6
+.4byte sCascoonAnims_5_7
+.4byte sCascoonAnims_5_8
+sCascoonAnimTable6:
+.4byte sCascoonAnims_6_1
+.4byte sCascoonAnims_6_1
+.4byte sCascoonAnims_6_1
+.4byte sCascoonAnims_6_1
+.4byte sCascoonAnims_6_1
+.4byte sCascoonAnims_6_1
+.4byte sCascoonAnims_6_1
+.4byte sCascoonAnims_6_1
+sCascoonAnimTable7:
+.4byte sCascoonAnims_7_1
+.4byte sCascoonAnims_7_2
+.4byte sCascoonAnims_7_3
+.4byte sCascoonAnims_7_4
+.4byte sCascoonAnims_7_5
+.4byte sCascoonAnims_7_6
+.4byte sCascoonAnims_7_7
+.4byte sCascoonAnims_7_8
+sCascoonAnimTable8:
+.4byte sCascoonAnims_8_1
+.4byte sCascoonAnims_8_2
+.4byte sCascoonAnims_8_3
+.4byte sCascoonAnims_8_4
+.4byte sCascoonAnims_8_5
+.4byte sCascoonAnims_8_6
+.4byte sCascoonAnims_8_7
+.4byte sCascoonAnims_8_8
+sCascoonAnimTable9:
+.4byte sCascoonAnims_9_1
+.4byte sCascoonAnims_9_2
+.4byte sCascoonAnims_9_3
+.4byte sCascoonAnims_9_4
+.4byte sCascoonAnims_9_5
+.4byte sCascoonAnims_9_6
+.4byte sCascoonAnims_9_7
+.4byte sCascoonAnims_9_8
+sCascoonAnimTable10:
+.4byte sCascoonAnims_10_1
+.4byte sCascoonAnims_10_2
+.4byte sCascoonAnims_10_3
+.4byte sCascoonAnims_10_4
+.4byte sCascoonAnims_10_5
+.4byte sCascoonAnims_10_6
+.4byte sCascoonAnims_10_7
+.4byte sCascoonAnims_10_8
+sCascoonAnimTable11:
+.4byte sCascoonAnims_11_1
+.4byte sCascoonAnims_11_2
+.4byte sCascoonAnims_11_3
+.4byte sCascoonAnims_11_4
+.4byte sCascoonAnims_11_5
+.4byte sCascoonAnims_11_6
+.4byte sCascoonAnims_11_7
+.4byte sCascoonAnims_11_8
+sCascoonAnimTable12:
+.4byte sCascoonAnims_12_1
+.4byte sCascoonAnims_12_2
+.4byte sCascoonAnims_12_3
+.4byte sCascoonAnims_12_4
+.4byte sCascoonAnims_12_5
+.4byte sCascoonAnims_12_6
+.4byte sCascoonAnims_12_7
+.4byte sCascoonAnims_12_8
+sCascoonAnimTable13:
+.4byte sCascoonAnims_13_1
+.4byte sCascoonAnims_13_2
+.4byte sCascoonAnims_13_3
+.4byte sCascoonAnims_13_4
+.4byte sCascoonAnims_13_5
+.4byte sCascoonAnims_13_6
+.4byte sCascoonAnims_13_7
+.4byte sCascoonAnims_13_8
+sAxAnimationsCascoon:
+.4byte sCascoonAnimTable1
+.4byte sCascoonAnimTable2
+.4byte sCascoonAnimTable3
+.4byte sCascoonAnimTable4
+.4byte sCascoonAnimTable5
+.4byte sCascoonAnimTable6
+.4byte sCascoonAnimTable7
+.4byte sCascoonAnimTable8
+.4byte sCascoonAnimTable9
+.4byte sCascoonAnimTable10
+.4byte sCascoonAnimTable11
+.4byte sCascoonAnimTable12
+.4byte sCascoonAnimTable13
+sAxSpritesCascoon:
+.4byte sCascoonSprites1
+.4byte sCascoonSprites2
+.4byte sCascoonSprites3
+.4byte sCascoonSprites4
+.4byte sCascoonSprites5
+.4byte sCascoonSprites6
+.4byte sCascoonSprites7
+.4byte sCascoonSprites8
+.4byte sCascoonSprites9
+.4byte sCascoonSprites10
+.4byte sCascoonSprites11
+.4byte sCascoonSprites12
+.4byte sCascoonSprites13
+.4byte sCascoonSprites14
+.4byte sCascoonSprites15
+.4byte sCascoonSprites16
+.4byte sCascoonSprites17
+.4byte sCascoonSprites18
+.4byte sCascoonSprites19
+.4byte sCascoonSprites20
+.4byte sCascoonSprites21
+.4byte sCascoonSprites22
+.4byte sCascoonSprites23
+sAxMainCascoon:
+ax_main sAxPosesCascoon, sAxAnimationsCascoon, 13, sAxSpritesCascoon, sAxPositionsCascoon

--- a/data/ax/castform.inc
+++ b/data/ax/castform.inc
@@ -1,0 +1,2994 @@
+.global gAxCastform
+gAxCastform:
+ax_siro sAxMainCastform
+sCastformPose1:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose2:
+ax_pose 1, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose3:
+ax_pose 2, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose4:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose5:
+ax_pose 4, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose6:
+ax_pose 5, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose7:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose8:
+ax_pose 7, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose9:
+ax_pose 8, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose10:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose11:
+ax_pose 10, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose12:
+ax_pose 11, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose13:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose14:
+ax_pose 13, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose15:
+ax_pose 14, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose16:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose17:
+ax_pose 10, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose18:
+ax_pose 11, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose19:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose20:
+ax_pose 7, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose21:
+ax_pose 8, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose22:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose23:
+ax_pose 4, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose24:
+ax_pose 5, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose25:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose26:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose27:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose28:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose29:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose30:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose31:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose32:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose33:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose34:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose35:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose36:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose37:
+ax_pose 17, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose38:
+ax_pose 18, 0x01f0, 0x50f7, 0x5c00
+ax_pose_terminator
+sCastformPose39:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose40:
+ax_pose 19, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose41:
+ax_pose 20, 0x01ef, 0x50f8, 0x5c00
+ax_pose_terminator
+sCastformPose42:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose43:
+ax_pose 21, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose44:
+ax_pose 22, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose45:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose46:
+ax_pose 23, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose47:
+ax_pose 24, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose48:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose49:
+ax_pose 21, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose50:
+ax_pose 22, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose51:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose52:
+ax_pose 19, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose53:
+ax_pose 20, 0x01ef, 0x40f7, 0x5c00
+ax_pose_terminator
+sCastformPose54:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose55:
+ax_pose 17, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose56:
+ax_pose 18, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose57:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose58:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose59:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose60:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose61:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose62:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose63:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose64:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose65:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose66:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose67:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose68:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose69:
+ax_pose 17, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose70:
+ax_pose 18, 0x01f0, 0x50f7, 0x5c00
+ax_pose_terminator
+sCastformPose71:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose72:
+ax_pose 19, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose73:
+ax_pose 20, 0x01ef, 0x50f8, 0x5c00
+ax_pose_terminator
+sCastformPose74:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose75:
+ax_pose 21, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose76:
+ax_pose 22, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose77:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose78:
+ax_pose 23, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose79:
+ax_pose 24, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose80:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose81:
+ax_pose 21, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose82:
+ax_pose 22, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose83:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose84:
+ax_pose 19, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose85:
+ax_pose 20, 0x01ef, 0x40f7, 0x5c00
+ax_pose_terminator
+sCastformPose86:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose87:
+ax_pose 17, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose88:
+ax_pose 18, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose89:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose90:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose91:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose92:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose93:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose94:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose95:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose96:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose97:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose98:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose99:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose100:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose101:
+ax_pose 17, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose102:
+ax_pose 18, 0x01f0, 0x50f7, 0x5c00
+ax_pose_terminator
+sCastformPose103:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose104:
+ax_pose 19, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose105:
+ax_pose 20, 0x01ef, 0x50f8, 0x5c00
+ax_pose_terminator
+sCastformPose106:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose107:
+ax_pose 21, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose108:
+ax_pose 22, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose109:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose110:
+ax_pose 23, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose111:
+ax_pose 24, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose112:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose113:
+ax_pose 21, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose114:
+ax_pose 22, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose115:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose116:
+ax_pose 19, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose117:
+ax_pose 20, 0x01ef, 0x40f7, 0x5c00
+ax_pose_terminator
+sCastformPose118:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose119:
+ax_pose 17, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose120:
+ax_pose 18, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose121:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose122:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose123:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose124:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose125:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose126:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose127:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose128:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose129:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose130:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose131:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose132:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose133:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose134:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose135:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose136:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose137:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose138:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose139:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose140:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose141:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose142:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose143:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose144:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose145:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose146:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose147:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose148:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose149:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose150:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose151:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose152:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose153:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose154:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose155:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose156:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose157:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose158:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose159:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose160:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose161:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose162:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose163:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose164:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose165:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose166:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose167:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose168:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose169:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose170:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose171:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose172:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose173:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose174:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose175:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose176:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose177:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose178:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose179:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose180:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose181:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose182:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose183:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose184:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose185:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose186:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose187:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose188:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose189:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose190:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose191:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose192:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose193:
+ax_pose 25, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose194:
+ax_pose 26, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose195:
+ax_pose 27, 0x01e1, 0x80f2, 0x5c00
+ax_pose_terminator
+sCastformPose196:
+ax_pose 28, 0x01e2, 0x90e7, 0x5c00
+ax_pose_terminator
+sCastformPose197:
+ax_pose 29, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sCastformPose198:
+ax_pose 30, 0x01e6, 0x90e7, 0x5c00
+ax_pose_terminator
+sCastformPose199:
+ax_pose 31, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sCastformPose200:
+ax_pose 30, 0x01e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sCastformPose201:
+ax_pose 29, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sCastformPose202:
+ax_pose 28, 0x01e2, 0x80fa, 0x5c00
+ax_pose_terminator
+sCastformPose203:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose204:
+ax_pose 1, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose205:
+ax_pose 2, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose206:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose207:
+ax_pose 4, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose208:
+ax_pose 5, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose209:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose210:
+ax_pose 7, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose211:
+ax_pose 8, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose212:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose213:
+ax_pose 10, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose214:
+ax_pose 11, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose215:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose216:
+ax_pose 13, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose217:
+ax_pose 14, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose218:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose219:
+ax_pose 10, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose220:
+ax_pose 11, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose221:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose222:
+ax_pose 7, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose223:
+ax_pose 8, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose224:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose225:
+ax_pose 4, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose226:
+ax_pose 5, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose227:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose228:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose229:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose230:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose231:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose232:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose233:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose234:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose235:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose236:
+ax_pose 18, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose237:
+ax_pose 20, 0x01ef, 0x40f7, 0x5c00
+ax_pose_terminator
+sCastformPose238:
+ax_pose 22, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose239:
+ax_pose 24, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose240:
+ax_pose 22, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose241:
+ax_pose 20, 0x01ef, 0x50f8, 0x5c00
+ax_pose_terminator
+sCastformPose242:
+ax_pose 18, 0x01f0, 0x50f7, 0x5c00
+ax_pose_terminator
+sCastformPose243:
+ax_pose 15, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose244:
+ax_pose 17, 0x81e9, 0x90f9, 0x5c00
+ax_pose_terminator
+sCastformPose245:
+ax_pose 19, 0x81e8, 0x90fa, 0x5c00
+ax_pose_terminator
+sCastformPose246:
+ax_pose 21, 0x81e7, 0x90f9, 0x5c00
+ax_pose_terminator
+sCastformPose247:
+ax_pose 23, 0x01ed, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose248:
+ax_pose 21, 0x81e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sCastformPose249:
+ax_pose 19, 0x81e8, 0x80f6, 0x5c00
+ax_pose_terminator
+sCastformPose250:
+ax_pose 17, 0x81e9, 0x80f7, 0x5c00
+ax_pose_terminator
+sCastformPose251:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose252:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose253:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose254:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose255:
+ax_pose 17, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose256:
+ax_pose 18, 0x01f0, 0x50f7, 0x5c00
+ax_pose_terminator
+sCastformPose257:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose258:
+ax_pose 19, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose259:
+ax_pose 20, 0x01ef, 0x50f8, 0x5c00
+ax_pose_terminator
+sCastformPose260:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose261:
+ax_pose 21, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose262:
+ax_pose 22, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose263:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose264:
+ax_pose 23, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose265:
+ax_pose 24, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose266:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose267:
+ax_pose 21, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose268:
+ax_pose 22, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose269:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose270:
+ax_pose 19, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose271:
+ax_pose 20, 0x01ef, 0x40f7, 0x5c00
+ax_pose_terminator
+sCastformPose272:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose273:
+ax_pose 17, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose274:
+ax_pose 18, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose275:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose276:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose277:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose278:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose279:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose280:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose281:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose282:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose283:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose284:
+ax_pose 18, 0x01f0, 0x40f9, 0x5c00
+ax_pose_terminator
+sCastformPose285:
+ax_pose 20, 0x01ef, 0x40f8, 0x5c00
+ax_pose_terminator
+sCastformPose286:
+ax_pose 22, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sCastformPose287:
+ax_pose 24, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose288:
+ax_pose 22, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose289:
+ax_pose 20, 0x01ef, 0x50f8, 0x5c00
+ax_pose_terminator
+sCastformPose290:
+ax_pose 18, 0x01f0, 0x50f7, 0x5c00
+ax_pose_terminator
+sCastformPose291:
+ax_pose 0, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose292:
+ax_pose 3, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose293:
+ax_pose 6, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose294:
+ax_pose 9, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose295:
+ax_pose 12, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sCastformPose296:
+ax_pose 9, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose297:
+ax_pose 6, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sCastformPose298:
+ax_pose 3, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+.align 2
+sCastformAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 4, 0, 33, 0, -2, 0, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 0, 4, 0, 4,
+ax_anim 1, 0, 32, 0, 13, 0, 13,
+ax_anim 2, 0, 34, 0, 23, 0, 23,
+ax_anim 2, 1, 34, 1, 23, 1, 23,
+ax_anim 2, 0, 34, 0, 23, 0, 23,
+ax_anim 2, 0, 34, 1, 23, 1, 23,
+ax_anim 2, 0, 32, 0, 13, 0, 13,
+ax_anim_terminator
+sCastformAnims_2_2:
+ax_anim 2, 0, 35, -1, -1, -1, -1,
+ax_anim 4, 0, 36, -2, -2, -2, -2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 4, 4, 4,
+ax_anim 1, 0, 35, 13, 12, 13, 13,
+ax_anim 2, 0, 37, 22, 22, 22, 21,
+ax_anim 2, 1, 37, 23, 21, 23, 20,
+ax_anim 2, 0, 37, 22, 22, 22, 21,
+ax_anim 2, 0, 37, 23, 21, 23, 20,
+ax_anim 2, 0, 35, 6, 6, 6, 6,
+ax_anim_terminator
+sCastformAnims_2_3:
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 4, 0, 39, -2, 0, -2, 0,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, 0, 4, 0,
+ax_anim 1, 0, 38, 14, 0, 13, 0,
+ax_anim 2, 0, 40, 23, 1, 23, -1,
+ax_anim 2, 1, 40, 23, 2, 23, 0,
+ax_anim 2, 0, 40, 23, 1, 23, -1,
+ax_anim 2, 0, 40, 23, 2, 23, 0,
+ax_anim 2, 0, 38, 6, 0, 6, 0,
+ax_anim_terminator
+sCastformAnims_2_4:
+ax_anim 2, 0, 41, -1, 1, -1, 1,
+ax_anim 4, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 41, 4, -4, 4, -4,
+ax_anim 1, 0, 41, 10, -11, 10, -11,
+ax_anim 2, 0, 43, 20, -20, 19, -22,
+ax_anim 2, 1, 43, 21, -19, 20, -21,
+ax_anim 2, 0, 43, 20, -20, 19, -22,
+ax_anim 2, 0, 43, 21, -19, 20, -21,
+ax_anim 2, 0, 41, 6, -6, 6, -6,
+ax_anim_terminator
+sCastformAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 45, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 0, -4, 0, -4,
+ax_anim 1, 0, 44, 0, -11, 0, -11,
+ax_anim 2, 0, 46, 0, -18, 0, -21,
+ax_anim 2, 1, 46, 1, -18, 1, -21,
+ax_anim 2, 0, 46, 0, -18, 0, -21,
+ax_anim 2, 0, 46, 1, -18, 1, -21,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 4, 0, 48, 2, 2, 2, 2,
+ax_anim 1, 0, 47, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -4, -4, -4,
+ax_anim 1, 0, 47, -10, -11, -10, -11,
+ax_anim 2, 0, 49, -20, -20, -19, -22,
+ax_anim 2, 1, 49, -21, -19, -20, -21,
+ax_anim 2, 0, 49, -20, -20, -19, -22,
+ax_anim 2, 0, 49, -21, -19, -20, -21,
+ax_anim 2, 0, 47, -6, -6, -6, -6,
+ax_anim_terminator
+sCastformAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 4, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -14, 0, -13, 0,
+ax_anim 2, 0, 52, -23, 1, -23, -1,
+ax_anim 2, 1, 52, -23, 2, -23, 0,
+ax_anim 2, 0, 52, -23, 1, -23, -1,
+ax_anim 2, 0, 52, -23, 2, -23, 0,
+ax_anim 2, 0, 50, -6, 0, -6, 0,
+ax_anim_terminator
+sCastformAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 53, -13, 12, -13, 13,
+ax_anim 2, 0, 55, -22, 22, -22, 21,
+ax_anim 2, 1, 55, -23, 21, -23, 20,
+ax_anim 2, 0, 55, -22, 22, -22, 21,
+ax_anim 2, 0, 55, -23, 21, -23, 20,
+ax_anim 2, 0, 53, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCastformAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 65, 0, -2, 0, -2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 0, 4, 0, 4,
+ax_anim 1, 0, 64, 0, 13, 0, 13,
+ax_anim 2, 0, 66, 0, 23, 0, 23,
+ax_anim 2, 1, 66, 1, 23, 1, 23,
+ax_anim 2, 0, 66, 0, 23, 0, 23,
+ax_anim 2, 0, 66, 1, 23, 1, 23,
+ax_anim 2, 0, 64, 0, 13, 0, 13,
+ax_anim_terminator
+sCastformAnims_3_2:
+ax_anim 2, 0, 67, -1, -1, -1, -1,
+ax_anim 4, 0, 68, -2, -2, -2, -2,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 4, 4, 4,
+ax_anim 1, 0, 67, 13, 12, 13, 13,
+ax_anim 2, 0, 69, 22, 22, 22, 21,
+ax_anim 2, 1, 69, 23, 21, 23, 20,
+ax_anim 2, 0, 69, 22, 22, 22, 21,
+ax_anim 2, 0, 69, 23, 21, 23, 20,
+ax_anim 2, 0, 67, 6, 6, 6, 6,
+ax_anim_terminator
+sCastformAnims_3_3:
+ax_anim 2, 0, 70, -1, 0, -1, 0,
+ax_anim 4, 0, 71, -2, 0, -2, 0,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, 0, 4, 0,
+ax_anim 1, 0, 70, 14, 0, 13, 0,
+ax_anim 2, 0, 72, 23, 1, 23, -1,
+ax_anim 2, 1, 72, 23, 2, 23, 0,
+ax_anim 2, 0, 72, 23, 1, 23, -1,
+ax_anim 2, 0, 72, 23, 2, 23, 0,
+ax_anim 2, 0, 70, 6, 0, 6, 0,
+ax_anim_terminator
+sCastformAnims_3_4:
+ax_anim 2, 0, 73, -1, 1, -1, 1,
+ax_anim 4, 0, 74, -2, 2, -2, 2,
+ax_anim 1, 0, 73, 0, -1, 0, -1,
+ax_anim 1, 2, 73, 4, -4, 4, -4,
+ax_anim 1, 0, 73, 10, -11, 10, -11,
+ax_anim 2, 0, 75, 20, -20, 19, -22,
+ax_anim 2, 1, 75, 21, -19, 20, -21,
+ax_anim 2, 0, 75, 20, -20, 19, -22,
+ax_anim 2, 0, 75, 21, -19, 20, -21,
+ax_anim 2, 0, 73, 6, -6, 6, -6,
+ax_anim_terminator
+sCastformAnims_3_5:
+ax_anim 2, 0, 76, 0, 1, 0, 1,
+ax_anim 4, 0, 77, 0, 2, 0, 2,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 76, 0, -4, 0, -4,
+ax_anim 1, 0, 76, 0, -11, 0, -11,
+ax_anim 2, 0, 78, 0, -18, 0, -21,
+ax_anim 2, 1, 78, 1, -18, 1, -21,
+ax_anim 2, 0, 78, 0, -18, 0, -21,
+ax_anim 2, 0, 78, 1, -18, 1, -21,
+ax_anim 2, 0, 76, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformAnims_3_6:
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 4, 0, 80, 2, 2, 2, 2,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 1, 2, 79, -4, -4, -4, -4,
+ax_anim 1, 0, 79, -10, -11, -10, -11,
+ax_anim 2, 0, 81, -20, -20, -19, -22,
+ax_anim 2, 1, 81, -21, -19, -20, -21,
+ax_anim 2, 0, 81, -20, -20, -19, -22,
+ax_anim 2, 0, 81, -21, -19, -20, -21,
+ax_anim 2, 0, 79, -6, -6, -6, -6,
+ax_anim_terminator
+sCastformAnims_3_7:
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 4, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -14, 0, -13, 0,
+ax_anim 2, 0, 84, -23, 1, -23, -1,
+ax_anim 2, 1, 84, -23, 2, -23, 0,
+ax_anim 2, 0, 84, -23, 1, -23, -1,
+ax_anim 2, 0, 84, -23, 2, -23, 0,
+ax_anim 2, 0, 82, -6, 0, -6, 0,
+ax_anim_terminator
+sCastformAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 4, 0, 86, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 85, -13, 12, -13, 13,
+ax_anim 2, 0, 87, -22, 22, -22, 21,
+ax_anim 2, 1, 87, -23, 21, -23, 20,
+ax_anim 2, 0, 87, -22, 22, -22, 21,
+ax_anim 2, 0, 87, -23, 21, -23, 20,
+ax_anim 2, 0, 85, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCastformAnims_4_1:
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 6, 2, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim_terminator
+sCastformAnims_4_2:
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim 6, 2, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sCastformAnims_4_3:
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim 6, 2, 103, -3, 0, -3, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 1, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim_terminator
+sCastformAnims_4_4:
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 6, 2, 106, -3, 3, -3, 3,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 1, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim_terminator
+sCastformAnims_4_5:
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim 6, 2, 109, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 1, 0, 1,
+ax_anim 2, 1, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sCastformAnims_4_6:
+ax_anim 2, 0, 112, 2, 2, 2, 2,
+ax_anim 6, 2, 112, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 1, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+sCastformAnims_4_7:
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 6, 2, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim_terminator
+sCastformAnims_4_8:
+ax_anim 2, 0, 118, 2, -2, 2, -2,
+ax_anim 6, 2, 118, 3, -3, 3, -3,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCastformAnims_5_1:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 2, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 1, 0, 130, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 0, 135, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -8, 0, 0,
+ax_anim 1, 0, 133, 0, -7, 0, 0,
+ax_anim 1, 0, 132, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 1, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_5_2:
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 1, 0, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 2, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -8, 0, 0,
+ax_anim 1, 0, 138, 0, -9, 0, 0,
+ax_anim 1, 0, 137, 0, -9, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, 0,
+ax_anim 1, 0, 143, 0, -9, 0, 0,
+ax_anim 1, 0, 142, 0, -8, 0, 0,
+ax_anim 1, 0, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 1, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_5_3:
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 1, 0, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 149, 0, -6, 0, 0,
+ax_anim 1, 2, 148, 0, -7, 0, 0,
+ax_anim 1, 0, 147, 0, -8, 0, 0,
+ax_anim 1, 0, 146, 0, -9, 0, 0,
+ax_anim 1, 0, 145, 0, -9, 0, 0,
+ax_anim 1, 0, 144, 0, -9, 0, 0,
+ax_anim 1, 0, 151, 0, -9, 0, 0,
+ax_anim 1, 0, 150, 0, -8, 0, 0,
+ax_anim 1, 0, 149, 0, -7, 0, 0,
+ax_anim 1, 0, 148, 0, -6, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 1, 146, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_5_4:
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 1, 0, 159, 0, -4, 0, 0,
+ax_anim 1, 0, 158, 0, -5, 0, 0,
+ax_anim 1, 0, 157, 0, -6, 0, 0,
+ax_anim 1, 2, 156, 0, -7, 0, 0,
+ax_anim 1, 0, 155, 0, -8, 0, 0,
+ax_anim 1, 0, 154, 0, -9, 0, 0,
+ax_anim 1, 0, 153, 0, -9, 0, 0,
+ax_anim 1, 0, 152, 0, -9, 0, 0,
+ax_anim 1, 0, 159, 0, -9, 0, 0,
+ax_anim 1, 0, 158, 0, -8, 0, 0,
+ax_anim 1, 0, 157, 0, -7, 0, 0,
+ax_anim 1, 0, 156, 0, -6, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 1, 1, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_5_5:
+ax_anim 6, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -2, 0, 0,
+ax_anim 1, 0, 167, 0, -4, 0, 0,
+ax_anim 1, 0, 166, 0, -5, 0, 0,
+ax_anim 1, 0, 165, 0, -6, 0, 0,
+ax_anim 1, 2, 164, 0, -7, 0, 0,
+ax_anim 1, 0, 163, 0, -8, 0, 0,
+ax_anim 1, 0, 162, 0, -9, 0, 0,
+ax_anim 1, 0, 161, 0, -9, 0, 0,
+ax_anim 1, 0, 160, 0, -9, 0, 0,
+ax_anim 1, 0, 167, 0, -9, 0, 0,
+ax_anim 1, 0, 166, 0, -8, 0, 0,
+ax_anim 1, 0, 165, 0, -7, 0, 0,
+ax_anim 1, 0, 164, 0, -6, 0, 0,
+ax_anim 1, 0, 163, 0, -5, 0, 0,
+ax_anim 1, 1, 162, 0, -4, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_5_6:
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -2, 0, 0,
+ax_anim 1, 0, 175, 0, -4, 0, 0,
+ax_anim 1, 0, 174, 0, -5, 0, 0,
+ax_anim 1, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 2, 172, 0, -7, 0, 0,
+ax_anim 1, 0, 171, 0, -8, 0, 0,
+ax_anim 1, 0, 170, 0, -9, 0, 0,
+ax_anim 1, 0, 169, 0, -9, 0, 0,
+ax_anim 1, 0, 168, 0, -9, 0, 0,
+ax_anim 1, 0, 175, 0, -9, 0, 0,
+ax_anim 1, 0, 174, 0, -8, 0, 0,
+ax_anim 1, 0, 173, 0, -7, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 171, 0, -5, 0, 0,
+ax_anim 1, 1, 170, 0, -4, 0, 0,
+ax_anim 2, 0, 169, 0, -2, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_5_7:
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -2, 0, 0,
+ax_anim 1, 0, 183, 0, -4, 0, 0,
+ax_anim 1, 0, 182, 0, -5, 0, 0,
+ax_anim 1, 0, 181, 0, -6, 0, 0,
+ax_anim 1, 2, 180, 0, -7, 0, 0,
+ax_anim 1, 0, 179, 0, -8, 0, 0,
+ax_anim 1, 0, 178, 0, -9, 0, 0,
+ax_anim 1, 0, 177, 0, -9, 0, 0,
+ax_anim 1, 0, 176, 0, -9, 0, 0,
+ax_anim 1, 0, 183, 0, -9, 0, 0,
+ax_anim 1, 0, 182, 0, -8, 0, 0,
+ax_anim 1, 0, 181, 0, -7, 0, 0,
+ax_anim 1, 0, 180, 0, -6, 0, 0,
+ax_anim 1, 0, 179, 0, -5, 0, 0,
+ax_anim 1, 1, 178, 0, -4, 0, 0,
+ax_anim 2, 0, 177, 0, -2, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_5_8:
+ax_anim 6, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -2, 0, 0,
+ax_anim 1, 0, 191, 0, -4, 0, 0,
+ax_anim 1, 0, 190, 0, -5, 0, 0,
+ax_anim 1, 0, 189, 0, -6, 0, 0,
+ax_anim 1, 2, 188, 0, -7, 0, 0,
+ax_anim 1, 0, 187, 0, -8, 0, 0,
+ax_anim 1, 0, 186, 0, -9, 0, 0,
+ax_anim 1, 0, 185, 0, -9, 0, 0,
+ax_anim 1, 0, 184, 0, -9, 0, 0,
+ax_anim 1, 0, 191, 0, -9, 0, 0,
+ax_anim 1, 0, 190, 0, -8, 0, 0,
+ax_anim 1, 0, 189, 0, -7, 0, 0,
+ax_anim 1, 0, 188, 0, -6, 0, 0,
+ax_anim 1, 0, 187, 0, -5, 0, 0,
+ax_anim 1, 1, 186, 0, -4, 0, 0,
+ax_anim 2, 0, 185, 0, -2, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_6_1:
+ax_anim 35, 0, 192, 0, 0, 0, 0,
+ax_anim 30, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_7_1:
+ax_anim 2, 0, 194, 0, -2, 0, -2,
+ax_anim 8, 0, 194, 0, -3, 0, -3,
+ax_anim_terminator
+sCastformAnims_7_2:
+ax_anim 2, 0, 195, -2, -2, -2, -2,
+ax_anim 8, 0, 195, -3, -3, -3, -3,
+ax_anim_terminator
+sCastformAnims_7_3:
+ax_anim 2, 0, 196, -2, 0, -2, 0,
+ax_anim 8, 0, 196, -3, 0, -3, 0,
+ax_anim_terminator
+sCastformAnims_7_4:
+ax_anim 2, 0, 197, -2, 2, -2, 2,
+ax_anim 8, 0, 197, -3, 3, -3, 3,
+ax_anim_terminator
+sCastformAnims_7_5:
+ax_anim 2, 0, 198, 0, 2, 0, 2,
+ax_anim 8, 0, 198, 0, 3, 0, 3,
+ax_anim_terminator
+sCastformAnims_7_6:
+ax_anim 2, 0, 199, 2, 2, 2, 2,
+ax_anim 8, 0, 199, 3, 3, 3, 3,
+ax_anim_terminator
+sCastformAnims_7_7:
+ax_anim 2, 0, 200, 2, 0, 2, 0,
+ax_anim 8, 0, 200, 3, 0, 3, 0,
+ax_anim_terminator
+sCastformAnims_7_8:
+ax_anim 2, 0, 201, 2, -2, 2, -2,
+ax_anim 8, 0, 201, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCastformAnims_8_1:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim 6, 0, 203, 0, -1, 0, 0,
+ax_anim 6, 0, 204, 0, -2, 0, 0,
+ax_anim 6, 0, 203, 0, -2, 0, 0,
+ax_anim 6, 0, 202, 0, -1, 0, 0,
+ax_anim 8, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_8_2:
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim 6, 0, 206, 0, -1, 0, 0,
+ax_anim 6, 0, 207, 0, -2, 0, 0,
+ax_anim 6, 0, 206, 0, -2, 0, 0,
+ax_anim 6, 0, 205, 0, -1, 0, 0,
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_8_3:
+ax_anim 8, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, -1, 0, 0,
+ax_anim 6, 0, 210, 0, -2, 0, 0,
+ax_anim 6, 0, 209, 0, -2, 0, 0,
+ax_anim 6, 0, 208, 0, -1, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_8_4:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 212, 0, -1, 0, 0,
+ax_anim 6, 0, 213, 0, -2, 0, 0,
+ax_anim 6, 0, 212, 0, -2, 0, 0,
+ax_anim 6, 0, 211, 0, -1, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_8_5:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, -1, 0, 0,
+ax_anim 6, 0, 216, 0, -2, 0, 0,
+ax_anim 6, 0, 215, 0, -2, 0, 0,
+ax_anim 6, 0, 214, 0, -1, 0, 0,
+ax_anim 8, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_8_6:
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 6, 0, 218, 0, -1, 0, 0,
+ax_anim 6, 0, 219, 0, -2, 0, 0,
+ax_anim 6, 0, 218, 0, -2, 0, 0,
+ax_anim 6, 0, 217, 0, -1, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_8_7:
+ax_anim 8, 0, 220, 0, 0, 0, 0,
+ax_anim 6, 0, 221, 0, -1, 0, 0,
+ax_anim 6, 0, 222, 0, -2, 0, 0,
+ax_anim 6, 0, 221, 0, -2, 0, 0,
+ax_anim 6, 0, 220, 0, -1, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_8_8:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, -1, 0, 0,
+ax_anim 6, 0, 225, 0, -2, 0, 0,
+ax_anim 6, 0, 224, 0, -2, 0, 0,
+ax_anim 6, 0, 223, 0, -1, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_9_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 6, 4, 6, 3,
+ax_anim 2, 0, 236, 9, 13, 9, 13,
+ax_anim 2, 0, 237, 7, 21, 7, 20,
+ax_anim 3, 0, 238, 0, 23, 0, 22,
+ax_anim 2, 3, 239, -7, 21, -7, 20,
+ax_anim 2, 0, 240, -9, 13, -9, 13,
+ax_anim 1, 0, 241, -6, 4, -6, 3,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_9_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 10, 2, 10, 2,
+ax_anim 2, 0, 235, 22, 9, 22, 9,
+ax_anim 2, 0, 236, 26, 16, 26, 15,
+ax_anim 3, 0, 237, 24, 22, 24, 21,
+ax_anim 2, 3, 238, 13, 21, 13, 20,
+ax_anim 2, 0, 239, 3, 15, 3, 15,
+ax_anim 1, 0, 240, 0, 7, 0, 7,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_9_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 4, -3, 4, -3,
+ax_anim 2, 0, 234, 11, -5, 11, -5,
+ax_anim 2, 0, 235, 20, -3, 20, -3,
+ax_anim 3, 0, 236, 25, 2, 25, 0,
+ax_anim 2, 3, 237, 21, 5, 21, 4,
+ax_anim 2, 0, 238, 13, 6, 13, 6,
+ax_anim 1, 0, 239, 5, 4, 5, 4,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_9_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 1, -8, 1, -8,
+ax_anim 2, 0, 241, 4, -15, 4, -15,
+ax_anim 2, 0, 234, 13, -21, 13, -21,
+ax_anim 3, 0, 235, 24, -22, 24, -22,
+ax_anim 2, 3, 236, 24, -13, 24, -13,
+ax_anim 2, 0, 237, 21, -6, 21, -6,
+ax_anim 1, 0, 238, 13, -2, 13, -2,
+ax_anim 1, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_9_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, -5, -2, -5, -2,
+ax_anim 2, 0, 240, -10, -11, -10, -11,
+ax_anim 2, 0, 241, -7, -20, -7, -21,
+ax_anim 3, 0, 234, 0, -23, 0, -24,
+ax_anim 2, 3, 235, 7, -20, 7, -21,
+ax_anim 2, 0, 236, 10, -9, 10, -9,
+ax_anim 1, 0, 237, 5, -2, 5, -2,
+ax_anim 1, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_9_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 1, -8, 1, -8,
+ax_anim 2, 0, 235, -4, -15, -4, -15,
+ax_anim 2, 0, 234, -13, -21, -13, -21,
+ax_anim 3, 0, 241, -24, -22, -24, -22,
+ax_anim 2, 3, 240, -24, -13, -24, -13,
+ax_anim 2, 0, 239, -21, -6, -21, -6,
+ax_anim 1, 0, 238, -13, -2, -13, -2,
+ax_anim 1, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_9_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -4, -3, -4, -3,
+ax_anim 2, 0, 234, -11, -5, -11, -5,
+ax_anim 2, 0, 241, -20, -3, -20, -3,
+ax_anim 3, 0, 240, -25, 2, -25, 0,
+ax_anim 2, 3, 239, -21, 5, -21, 4,
+ax_anim 2, 0, 238, -13, 6, -13, 6,
+ax_anim 1, 0, 237, -5, 4, -5, 4,
+ax_anim 1, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_9_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 234, -10, 2, -10, 2,
+ax_anim 2, 0, 241, -22, 9, -22, 9,
+ax_anim 2, 0, 240, -26, 16, -26, 16,
+ax_anim 3, 0, 239, -24, 22, -24, 21,
+ax_anim 2, 3, 238, -13, 21, -13, 20,
+ax_anim 2, 0, 237, -3, 15, -3, 15,
+ax_anim 1, 0, 236, 0, 7, 0, 7,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_10_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 3, 0, 242, 13, 0, 13, 0,
+ax_anim 3, 0, 242, -13, 0, -13, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_10_2:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 3, 0, 243, 13, -13, 13, -13,
+ax_anim 3, 0, 243, -13, 13, -13, 13,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_10_3:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 3, 0, 244, 0, -13, 0, -13,
+ax_anim 3, 0, 244, 0, 13, 0, 13,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_10_4:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 3, 0, 245, -13, -13, -13, -13,
+ax_anim 3, 0, 245, 13, 13, 13, 13,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_10_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 3, 0, 246, 13, 0, 13, 0,
+ax_anim 3, 0, 246, -13, 0, -13, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_10_6:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 3, 0, 247, 13, -13, 13, -13,
+ax_anim 3, 0, 247, -13, 13, -13, 13,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_10_7:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 3, 0, 248, 0, -13, 0, -13,
+ax_anim 3, 0, 248, 0, 13, 0, 13,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_10_8:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 3, 0, 249, -13, -13, -13, -13,
+ax_anim 3, 0, 249, 13, 13, 13, 13,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_11_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -10, 0, 0,
+ax_anim 2, 0, 251, 0, -16, 0, 0,
+ax_anim 3, 0, 251, 0, -20, 0, 0,
+ax_anim 4, 0, 251, 0, -21, 0, 0,
+ax_anim 4, 0, 250, 0, -23, 0, 0,
+ax_anim 3, 0, 252, 0, -22, 0, 0,
+ax_anim 2, 0, 252, 0, -15, 0, 0,
+ax_anim 1, 0, 252, 0, -6, 0, 0,
+ax_anim 2, 2, 250, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformAnims_11_2:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 254, 0, -10, 0, 0,
+ax_anim 2, 0, 254, 0, -16, 0, 0,
+ax_anim 3, 0, 254, 0, -20, 0, 0,
+ax_anim 4, 0, 254, 0, -21, 0, 0,
+ax_anim 4, 0, 253, 0, -23, 0, 0,
+ax_anim 3, 0, 255, 0, -23, 0, 0,
+ax_anim 2, 0, 255, 0, -15, 0, 0,
+ax_anim 1, 0, 255, 0, -6, 0, 0,
+ax_anim 2, 2, 253, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformAnims_11_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 0, -10, 0, 0,
+ax_anim 2, 0, 257, 0, -16, 0, 0,
+ax_anim 3, 0, 257, 0, -20, 0, 0,
+ax_anim 4, 0, 257, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 258, 0, -22, 0, 0,
+ax_anim 2, 0, 258, 0, -15, 0, 0,
+ax_anim 1, 0, 258, 0, -6, 0, 0,
+ax_anim 2, 2, 256, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformAnims_11_4:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -10, 0, 0,
+ax_anim 2, 0, 260, 0, -16, 0, 0,
+ax_anim 3, 0, 260, 0, -20, 0, 0,
+ax_anim 4, 0, 260, 0, -21, 0, 0,
+ax_anim 4, 0, 259, 0, -22, 0, 0,
+ax_anim 3, 0, 261, 0, -21, 0, 0,
+ax_anim 2, 0, 261, 0, -15, 0, 0,
+ax_anim 1, 0, 261, 0, -6, 0, 0,
+ax_anim 2, 2, 259, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformAnims_11_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -21, 0, 0,
+ax_anim 3, 0, 264, 0, -18, 0, 0,
+ax_anim 2, 0, 264, 0, -15, 0, 0,
+ax_anim 1, 0, 264, 0, -6, 0, 0,
+ax_anim 2, 2, 262, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformAnims_11_6:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -22, 0, 0,
+ax_anim 3, 0, 267, 0, -22, 0, 0,
+ax_anim 2, 0, 267, 0, -15, 0, 0,
+ax_anim 1, 0, 267, 0, -6, 0, 0,
+ax_anim 2, 2, 265, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformAnims_11_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 268, 0, -23, 0, 0,
+ax_anim 3, 0, 270, 0, -22, 0, 0,
+ax_anim 2, 0, 270, 0, -15, 0, 0,
+ax_anim 1, 0, 270, 0, -6, 0, 0,
+ax_anim 2, 2, 268, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformAnims_11_8:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 271, 0, -23, 0, 0,
+ax_anim 3, 0, 273, 0, -23, 0, 0,
+ax_anim 2, 0, 273, 0, -15, 0, 0,
+ax_anim 1, 0, 273, 0, -6, 0, 0,
+ax_anim 2, 2, 271, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_12_1:
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 1, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_12_2:
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 1, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_12_3:
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 1, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_12_4:
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 1, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_12_5:
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 1, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_12_6:
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 1, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_12_7:
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 1, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_12_8:
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 1, 283, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformAnims_13_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 2, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_13_2:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 2, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_13_3:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 2, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_13_4:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 2, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_13_5:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 2, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_13_6:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 2, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_13_7:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 2, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformAnims_13_8:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 2, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformGfx1:
+.incbin "baserom.gba", 0x1462030, 0x100
+sCastformSprites1:
+ax_sprite sCastformGfx1, 0x100
+ax_sprite_terminator
+sCastformGfx2:
+.incbin "baserom.gba", 0x1462140, 0x100
+sCastformSprites2:
+ax_sprite sCastformGfx2, 0x100
+ax_sprite_terminator
+sCastformGfx3:
+.incbin "baserom.gba", 0x1462250, 0x100
+sCastformSprites3:
+ax_sprite sCastformGfx3, 0x100
+ax_sprite_terminator
+sCastformGfx4:
+.incbin "baserom.gba", 0x1462360, 0x100
+sCastformSprites4:
+ax_sprite sCastformGfx4, 0x100
+ax_sprite_terminator
+sCastformGfx5:
+.incbin "baserom.gba", 0x1462470, 0x100
+sCastformSprites5:
+ax_sprite sCastformGfx5, 0x100
+ax_sprite_terminator
+sCastformGfx6:
+.incbin "baserom.gba", 0x1462580, 0x100
+sCastformSprites6:
+ax_sprite sCastformGfx6, 0x100
+ax_sprite_terminator
+sCastformGfx7:
+.incbin "baserom.gba", 0x1462690, 0x100
+sCastformSprites7:
+ax_sprite sCastformGfx7, 0x100
+ax_sprite_terminator
+sCastformGfx8:
+.incbin "baserom.gba", 0x14627A0, 0x100
+sCastformSprites8:
+ax_sprite sCastformGfx8, 0x100
+ax_sprite_terminator
+sCastformGfx9:
+.incbin "baserom.gba", 0x14628B0, 0x100
+sCastformSprites9:
+ax_sprite sCastformGfx9, 0x100
+ax_sprite_terminator
+sCastformGfx10:
+.incbin "baserom.gba", 0x14629C0, 0x100
+sCastformSprites10:
+ax_sprite sCastformGfx10, 0x100
+ax_sprite_terminator
+sCastformGfx11:
+.incbin "baserom.gba", 0x1462AD0, 0x100
+sCastformSprites11:
+ax_sprite sCastformGfx11, 0x100
+ax_sprite_terminator
+sCastformGfx12:
+.incbin "baserom.gba", 0x1462BE0, 0x100
+sCastformSprites12:
+ax_sprite sCastformGfx12, 0x100
+ax_sprite_terminator
+sCastformGfx13:
+.incbin "baserom.gba", 0x1462CF0, 0x100
+sCastformSprites13:
+ax_sprite sCastformGfx13, 0x100
+ax_sprite_terminator
+sCastformGfx14:
+.incbin "baserom.gba", 0x1462E00, 0x100
+sCastformSprites14:
+ax_sprite sCastformGfx14, 0x100
+ax_sprite_terminator
+sCastformGfx15:
+.incbin "baserom.gba", 0x1462F10, 0x100
+sCastformSprites15:
+ax_sprite sCastformGfx15, 0x100
+ax_sprite_terminator
+sCastformGfx16:
+.incbin "baserom.gba", 0x1463020, 0xC0
+sCastformSprites16:
+ax_sprite sCastformGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformGfx17:
+.incbin "baserom.gba", 0x14630F8, 0x80
+sCastformSprites17:
+ax_sprite sCastformGfx17, 0x80
+ax_sprite_terminator
+sCastformGfx18:
+.incbin "baserom.gba", 0x1463188, 0xC0
+sCastformSprites18:
+ax_sprite sCastformGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformGfx19:
+.incbin "baserom.gba", 0x1463260, 0x80
+sCastformSprites19:
+ax_sprite sCastformGfx19, 0x80
+ax_sprite_terminator
+sCastformGfx20:
+.incbin "baserom.gba", 0x14632F0, 0xA0
+sCastformSprites20:
+ax_sprite 0, 0x20
+ax_sprite sCastformGfx20, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformGfx21:
+.incbin "baserom.gba", 0x14633B0, 0x80
+sCastformSprites21:
+ax_sprite sCastformGfx21, 0x80
+ax_sprite_terminator
+sCastformGfx22:
+.incbin "baserom.gba", 0x1463440, 0xA0
+sCastformSprites22:
+ax_sprite 0, 0x20
+ax_sprite sCastformGfx22, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformGfx23:
+.incbin "baserom.gba", 0x1463500, 0x20
+sCastformGfx23_1:
+.incbin "baserom.gba", 0x1463520, 0x80
+sCastformSprites23:
+ax_sprite sCastformGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCastformGfx23_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformGfx24:
+.incbin "baserom.gba", 0x14635C8, 0x80
+sCastformSprites24:
+ax_sprite sCastformGfx24, 0x80
+ax_sprite_terminator
+sCastformGfx25:
+.incbin "baserom.gba", 0x1463658, 0xC0
+sCastformSprites25:
+ax_sprite sCastformGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformGfx26:
+.incbin "baserom.gba", 0x1463730, 0x100
+sCastformSprites26:
+ax_sprite sCastformGfx26, 0x100
+ax_sprite_terminator
+sCastformGfx27:
+.incbin "baserom.gba", 0x1463840, 0x100
+sCastformSprites27:
+ax_sprite sCastformGfx27, 0x100
+ax_sprite_terminator
+sCastformGfx28:
+.incbin "baserom.gba", 0x1463950, 0x200
+sCastformSprites28:
+ax_sprite sCastformGfx28, 0x200
+ax_sprite_terminator
+sCastformGfx29:
+.incbin "baserom.gba", 0x1463B60, 0x200
+sCastformSprites29:
+ax_sprite sCastformGfx29, 0x200
+ax_sprite_terminator
+sCastformGfx30:
+.incbin "baserom.gba", 0x1463D70, 0x200
+sCastformSprites30:
+ax_sprite sCastformGfx30, 0x200
+ax_sprite_terminator
+sCastformGfx31:
+.incbin "baserom.gba", 0x1463F80, 0x200
+sCastformSprites31:
+ax_sprite sCastformGfx31, 0x200
+ax_sprite_terminator
+sCastformGfx32:
+.incbin "baserom.gba", 0x1464190, 0x200
+sCastformSprites32:
+ax_sprite sCastformGfx32, 0x200
+ax_sprite_terminator
+sAxPosesCastform:
+.4byte sCastformPose1
+.4byte sCastformPose2
+.4byte sCastformPose3
+.4byte sCastformPose4
+.4byte sCastformPose5
+.4byte sCastformPose6
+.4byte sCastformPose7
+.4byte sCastformPose8
+.4byte sCastformPose9
+.4byte sCastformPose10
+.4byte sCastformPose11
+.4byte sCastformPose12
+.4byte sCastformPose13
+.4byte sCastformPose14
+.4byte sCastformPose15
+.4byte sCastformPose16
+.4byte sCastformPose17
+.4byte sCastformPose18
+.4byte sCastformPose19
+.4byte sCastformPose20
+.4byte sCastformPose21
+.4byte sCastformPose22
+.4byte sCastformPose23
+.4byte sCastformPose24
+.4byte sCastformPose25
+.4byte sCastformPose26
+.4byte sCastformPose27
+.4byte sCastformPose28
+.4byte sCastformPose29
+.4byte sCastformPose30
+.4byte sCastformPose31
+.4byte sCastformPose32
+.4byte sCastformPose33
+.4byte sCastformPose34
+.4byte sCastformPose35
+.4byte sCastformPose36
+.4byte sCastformPose37
+.4byte sCastformPose38
+.4byte sCastformPose39
+.4byte sCastformPose40
+.4byte sCastformPose41
+.4byte sCastformPose42
+.4byte sCastformPose43
+.4byte sCastformPose44
+.4byte sCastformPose45
+.4byte sCastformPose46
+.4byte sCastformPose47
+.4byte sCastformPose48
+.4byte sCastformPose49
+.4byte sCastformPose50
+.4byte sCastformPose51
+.4byte sCastformPose52
+.4byte sCastformPose53
+.4byte sCastformPose54
+.4byte sCastformPose55
+.4byte sCastformPose56
+.4byte sCastformPose57
+.4byte sCastformPose58
+.4byte sCastformPose59
+.4byte sCastformPose60
+.4byte sCastformPose61
+.4byte sCastformPose62
+.4byte sCastformPose63
+.4byte sCastformPose64
+.4byte sCastformPose65
+.4byte sCastformPose66
+.4byte sCastformPose67
+.4byte sCastformPose68
+.4byte sCastformPose69
+.4byte sCastformPose70
+.4byte sCastformPose71
+.4byte sCastformPose72
+.4byte sCastformPose73
+.4byte sCastformPose74
+.4byte sCastformPose75
+.4byte sCastformPose76
+.4byte sCastformPose77
+.4byte sCastformPose78
+.4byte sCastformPose79
+.4byte sCastformPose80
+.4byte sCastformPose81
+.4byte sCastformPose82
+.4byte sCastformPose83
+.4byte sCastformPose84
+.4byte sCastformPose85
+.4byte sCastformPose86
+.4byte sCastformPose87
+.4byte sCastformPose88
+.4byte sCastformPose89
+.4byte sCastformPose90
+.4byte sCastformPose91
+.4byte sCastformPose92
+.4byte sCastformPose93
+.4byte sCastformPose94
+.4byte sCastformPose95
+.4byte sCastformPose96
+.4byte sCastformPose97
+.4byte sCastformPose98
+.4byte sCastformPose99
+.4byte sCastformPose100
+.4byte sCastformPose101
+.4byte sCastformPose102
+.4byte sCastformPose103
+.4byte sCastformPose104
+.4byte sCastformPose105
+.4byte sCastformPose106
+.4byte sCastformPose107
+.4byte sCastformPose108
+.4byte sCastformPose109
+.4byte sCastformPose110
+.4byte sCastformPose111
+.4byte sCastformPose112
+.4byte sCastformPose113
+.4byte sCastformPose114
+.4byte sCastformPose115
+.4byte sCastformPose116
+.4byte sCastformPose117
+.4byte sCastformPose118
+.4byte sCastformPose119
+.4byte sCastformPose120
+.4byte sCastformPose121
+.4byte sCastformPose122
+.4byte sCastformPose123
+.4byte sCastformPose124
+.4byte sCastformPose125
+.4byte sCastformPose126
+.4byte sCastformPose127
+.4byte sCastformPose128
+.4byte sCastformPose129
+.4byte sCastformPose130
+.4byte sCastformPose131
+.4byte sCastformPose132
+.4byte sCastformPose133
+.4byte sCastformPose134
+.4byte sCastformPose135
+.4byte sCastformPose136
+.4byte sCastformPose137
+.4byte sCastformPose138
+.4byte sCastformPose139
+.4byte sCastformPose140
+.4byte sCastformPose141
+.4byte sCastformPose142
+.4byte sCastformPose143
+.4byte sCastformPose144
+.4byte sCastformPose145
+.4byte sCastformPose146
+.4byte sCastformPose147
+.4byte sCastformPose148
+.4byte sCastformPose149
+.4byte sCastformPose150
+.4byte sCastformPose151
+.4byte sCastformPose152
+.4byte sCastformPose153
+.4byte sCastformPose154
+.4byte sCastformPose155
+.4byte sCastformPose156
+.4byte sCastformPose157
+.4byte sCastformPose158
+.4byte sCastformPose159
+.4byte sCastformPose160
+.4byte sCastformPose161
+.4byte sCastformPose162
+.4byte sCastformPose163
+.4byte sCastformPose164
+.4byte sCastformPose165
+.4byte sCastformPose166
+.4byte sCastformPose167
+.4byte sCastformPose168
+.4byte sCastformPose169
+.4byte sCastformPose170
+.4byte sCastformPose171
+.4byte sCastformPose172
+.4byte sCastformPose173
+.4byte sCastformPose174
+.4byte sCastformPose175
+.4byte sCastformPose176
+.4byte sCastformPose177
+.4byte sCastformPose178
+.4byte sCastformPose179
+.4byte sCastformPose180
+.4byte sCastformPose181
+.4byte sCastformPose182
+.4byte sCastformPose183
+.4byte sCastformPose184
+.4byte sCastformPose185
+.4byte sCastformPose186
+.4byte sCastformPose187
+.4byte sCastformPose188
+.4byte sCastformPose189
+.4byte sCastformPose190
+.4byte sCastformPose191
+.4byte sCastformPose192
+.4byte sCastformPose193
+.4byte sCastformPose194
+.4byte sCastformPose195
+.4byte sCastformPose196
+.4byte sCastformPose197
+.4byte sCastformPose198
+.4byte sCastformPose199
+.4byte sCastformPose200
+.4byte sCastformPose201
+.4byte sCastformPose202
+.4byte sCastformPose203
+.4byte sCastformPose204
+.4byte sCastformPose205
+.4byte sCastformPose206
+.4byte sCastformPose207
+.4byte sCastformPose208
+.4byte sCastformPose209
+.4byte sCastformPose210
+.4byte sCastformPose211
+.4byte sCastformPose212
+.4byte sCastformPose213
+.4byte sCastformPose214
+.4byte sCastformPose215
+.4byte sCastformPose216
+.4byte sCastformPose217
+.4byte sCastformPose218
+.4byte sCastformPose219
+.4byte sCastformPose220
+.4byte sCastformPose221
+.4byte sCastformPose222
+.4byte sCastformPose223
+.4byte sCastformPose224
+.4byte sCastformPose225
+.4byte sCastformPose226
+.4byte sCastformPose227
+.4byte sCastformPose228
+.4byte sCastformPose229
+.4byte sCastformPose230
+.4byte sCastformPose231
+.4byte sCastformPose232
+.4byte sCastformPose233
+.4byte sCastformPose234
+.4byte sCastformPose235
+.4byte sCastformPose236
+.4byte sCastformPose237
+.4byte sCastformPose238
+.4byte sCastformPose239
+.4byte sCastformPose240
+.4byte sCastformPose241
+.4byte sCastformPose242
+.4byte sCastformPose243
+.4byte sCastformPose244
+.4byte sCastformPose245
+.4byte sCastformPose246
+.4byte sCastformPose247
+.4byte sCastformPose248
+.4byte sCastformPose249
+.4byte sCastformPose250
+.4byte sCastformPose251
+.4byte sCastformPose252
+.4byte sCastformPose253
+.4byte sCastformPose254
+.4byte sCastformPose255
+.4byte sCastformPose256
+.4byte sCastformPose257
+.4byte sCastformPose258
+.4byte sCastformPose259
+.4byte sCastformPose260
+.4byte sCastformPose261
+.4byte sCastformPose262
+.4byte sCastformPose263
+.4byte sCastformPose264
+.4byte sCastformPose265
+.4byte sCastformPose266
+.4byte sCastformPose267
+.4byte sCastformPose268
+.4byte sCastformPose269
+.4byte sCastformPose270
+.4byte sCastformPose271
+.4byte sCastformPose272
+.4byte sCastformPose273
+.4byte sCastformPose274
+.4byte sCastformPose275
+.4byte sCastformPose276
+.4byte sCastformPose277
+.4byte sCastformPose278
+.4byte sCastformPose279
+.4byte sCastformPose280
+.4byte sCastformPose281
+.4byte sCastformPose282
+.4byte sCastformPose283
+.4byte sCastformPose284
+.4byte sCastformPose285
+.4byte sCastformPose286
+.4byte sCastformPose287
+.4byte sCastformPose288
+.4byte sCastformPose289
+.4byte sCastformPose290
+.4byte sCastformPose291
+.4byte sCastformPose292
+.4byte sCastformPose293
+.4byte sCastformPose294
+.4byte sCastformPose295
+.4byte sCastformPose296
+.4byte sCastformPose297
+.4byte sCastformPose298
+sAxPositionsCastform:
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	  -3,   -6, 	   1,   -6, 	  -1,  -11
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -7, 	  -2,   -6, 	  -3,  -11
+.2byte    0,   -6, 	   1,   -3, 	  -2,   -3, 	   0,   -8
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    0,   -9, 	   1,   -6, 	  -1,   -4, 	  -3,  -10
+.2byte    2,   -6, 	   0,   -4, 	  -1,   -3, 	   0,   -9
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    0,   -9, 	  -1,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -4, 	   0,   -3, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   1,   -6, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -2,   -9, 	  -1,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -2,   -9, 	  -3,   -6, 	  -1,   -4, 	   1,  -10
+.2byte   -4,   -6, 	  -2,   -4, 	  -1,   -3, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,  -10, 	  -3,   -7, 	   0,   -6, 	   1,  -11
+.2byte   -2,   -6, 	  -3,   -3, 	   0,   -3, 	  -2,   -8
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	  -3,   -6, 	   1,   -6, 	  -1,  -11
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -7, 	  -2,   -6, 	  -3,  -11
+.2byte    0,   -6, 	   1,   -3, 	  -2,   -3, 	   0,   -8
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    0,   -9, 	   1,   -6, 	  -1,   -4, 	  -3,  -10
+.2byte    2,   -6, 	   0,   -4, 	  -1,   -3, 	   0,   -9
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    0,   -9, 	  -1,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -4, 	   0,   -3, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   1,   -6, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -2,   -9, 	  -1,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -2,   -9, 	  -3,   -6, 	  -1,   -4, 	   1,  -10
+.2byte   -4,   -6, 	  -2,   -4, 	  -1,   -3, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,  -10, 	  -3,   -7, 	   0,   -6, 	   1,  -11
+.2byte   -2,   -6, 	  -3,   -3, 	   0,   -3, 	  -2,   -8
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	  -3,   -6, 	   1,   -6, 	  -1,  -11
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -7, 	  -2,   -6, 	  -3,  -11
+.2byte    0,   -6, 	   1,   -3, 	  -2,   -3, 	   0,   -8
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    0,   -9, 	   1,   -6, 	  -1,   -4, 	  -3,  -10
+.2byte    2,   -6, 	   0,   -4, 	  -1,   -3, 	   0,   -9
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    0,   -9, 	  -1,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -4, 	   0,   -3, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   1,   -6, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -2,   -9, 	  -1,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -2,   -9, 	  -3,   -6, 	  -1,   -4, 	   1,  -10
+.2byte   -4,   -6, 	  -2,   -4, 	  -1,   -3, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,  -10, 	  -3,   -7, 	   0,   -6, 	   1,  -11
+.2byte   -2,   -6, 	  -3,   -3, 	   0,   -3, 	  -2,   -8
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -2,   -5, 	  -2,   -2, 	   0,   -1, 	   0,   -7
+.2byte   -2,   -4, 	  -2,   -2, 	   0,   -1, 	   0,   -6
+.2byte    0,  -10, 	  -2,   -6, 	   2,   -6, 	   0,  -12
+.2byte    1,   -8, 	   3,   -5, 	   1,   -4, 	  -1,  -10
+.2byte    2,   -9, 	   3,   -7, 	   3,   -6, 	  -2,   -9
+.2byte    1,  -10, 	   0,   -7, 	   2,   -6, 	  -2,  -10
+.2byte    0,  -12, 	   2,   -6, 	  -2,   -6, 	   0,  -10
+.2byte   -1,  -10, 	   0,   -7, 	  -2,   -6, 	   2,  -10
+.2byte   -2,   -9, 	  -3,   -7, 	  -3,   -6, 	   2,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	  -1,   -4, 	   1,  -10
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte   -2,   -6, 	  -3,   -3, 	   0,   -3, 	  -2,   -8
+.2byte   -4,   -6, 	  -2,   -4, 	  -1,   -3, 	  -2,   -9
+.2byte   -4,   -7, 	  -1,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte   -1,  -10, 	   1,   -4, 	  -3,   -4, 	  -1,   -9
+.2byte    2,   -7, 	  -1,   -4, 	   0,   -3, 	   0,   -9
+.2byte    2,   -6, 	   0,   -4, 	  -1,   -3, 	   0,   -9
+.2byte    0,   -6, 	   1,   -3, 	  -2,   -3, 	   0,   -8
+.2byte   -1,   -9, 	  -3,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    1,  -10, 	   3,   -7, 	   0,   -6, 	  -1,  -11
+.2byte    3,  -10, 	   4,   -7, 	   2,   -5, 	   0,  -11
+.2byte    2,  -11, 	   1,   -8, 	   3,   -7, 	  -1,  -11
+.2byte   -1,  -12, 	   1,   -7, 	  -3,   -7, 	  -1,  -11
+.2byte   -3,  -11, 	  -2,   -8, 	  -4,   -7, 	   0,  -11
+.2byte   -4,  -10, 	  -5,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -10, 	  -4,   -7, 	  -1,   -6, 	   0,  -11
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	  -3,   -6, 	   1,   -6, 	  -1,  -11
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -7, 	  -2,   -6, 	  -3,  -11
+.2byte    0,   -6, 	   1,   -3, 	  -2,   -3, 	   0,   -8
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    0,   -9, 	   1,   -6, 	  -1,   -4, 	  -3,  -10
+.2byte    2,   -6, 	   0,   -4, 	  -1,   -3, 	   0,   -9
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    0,   -9, 	  -1,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -4, 	   0,   -3, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   1,   -6, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -2,   -9, 	  -1,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -2,   -9, 	  -3,   -6, 	  -1,   -4, 	   1,  -10
+.2byte   -4,   -6, 	  -2,   -4, 	  -1,   -3, 	  -2,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,  -10, 	  -3,   -7, 	   0,   -6, 	   1,  -11
+.2byte   -2,   -6, 	  -3,   -3, 	   0,   -3, 	  -2,   -8
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	  -2,   -3, 	   1,   -3, 	  -1,   -8
+.2byte   -3,   -6, 	  -1,   -4, 	   0,   -3, 	  -1,   -9
+.2byte   -3,   -7, 	   0,   -4, 	  -1,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	   1,   -4, 	  -3,   -4, 	  -1,   -9
+.2byte    2,   -7, 	  -1,   -4, 	   0,   -3, 	   0,   -9
+.2byte    2,   -6, 	   0,   -4, 	  -1,   -3, 	   0,   -9
+.2byte    0,   -6, 	   1,   -3, 	  -2,   -3, 	   0,   -8
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	  -2,   -9
+.2byte   -4,   -8, 	  -3,   -5, 	  -3,   -4, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte    1,  -10, 	  -1,   -5, 	   1,   -5, 	  -1,  -10
+.2byte    2,   -8, 	   1,   -5, 	   1,   -4, 	  -1,   -9
+.2byte    1,   -7, 	   1,   -5, 	  -1,   -4, 	   0,   -9
+sCastformAnimTable1:
+.4byte sCastformAnims_1_1
+.4byte sCastformAnims_1_2
+.4byte sCastformAnims_1_3
+.4byte sCastformAnims_1_4
+.4byte sCastformAnims_1_5
+.4byte sCastformAnims_1_6
+.4byte sCastformAnims_1_7
+.4byte sCastformAnims_1_8
+sCastformAnimTable2:
+.4byte sCastformAnims_2_1
+.4byte sCastformAnims_2_2
+.4byte sCastformAnims_2_3
+.4byte sCastformAnims_2_4
+.4byte sCastformAnims_2_5
+.4byte sCastformAnims_2_6
+.4byte sCastformAnims_2_7
+.4byte sCastformAnims_2_8
+sCastformAnimTable3:
+.4byte sCastformAnims_3_1
+.4byte sCastformAnims_3_2
+.4byte sCastformAnims_3_3
+.4byte sCastformAnims_3_4
+.4byte sCastformAnims_3_5
+.4byte sCastformAnims_3_6
+.4byte sCastformAnims_3_7
+.4byte sCastformAnims_3_8
+sCastformAnimTable4:
+.4byte sCastformAnims_4_1
+.4byte sCastformAnims_4_2
+.4byte sCastformAnims_4_3
+.4byte sCastformAnims_4_4
+.4byte sCastformAnims_4_5
+.4byte sCastformAnims_4_6
+.4byte sCastformAnims_4_7
+.4byte sCastformAnims_4_8
+sCastformAnimTable5:
+.4byte sCastformAnims_5_1
+.4byte sCastformAnims_5_2
+.4byte sCastformAnims_5_3
+.4byte sCastformAnims_5_4
+.4byte sCastformAnims_5_5
+.4byte sCastformAnims_5_6
+.4byte sCastformAnims_5_7
+.4byte sCastformAnims_5_8
+sCastformAnimTable6:
+.4byte sCastformAnims_6_1
+.4byte sCastformAnims_6_1
+.4byte sCastformAnims_6_1
+.4byte sCastformAnims_6_1
+.4byte sCastformAnims_6_1
+.4byte sCastformAnims_6_1
+.4byte sCastformAnims_6_1
+.4byte sCastformAnims_6_1
+sCastformAnimTable7:
+.4byte sCastformAnims_7_1
+.4byte sCastformAnims_7_2
+.4byte sCastformAnims_7_3
+.4byte sCastformAnims_7_4
+.4byte sCastformAnims_7_5
+.4byte sCastformAnims_7_6
+.4byte sCastformAnims_7_7
+.4byte sCastformAnims_7_8
+sCastformAnimTable8:
+.4byte sCastformAnims_8_1
+.4byte sCastformAnims_8_2
+.4byte sCastformAnims_8_3
+.4byte sCastformAnims_8_4
+.4byte sCastformAnims_8_5
+.4byte sCastformAnims_8_6
+.4byte sCastformAnims_8_7
+.4byte sCastformAnims_8_8
+sCastformAnimTable9:
+.4byte sCastformAnims_9_1
+.4byte sCastformAnims_9_2
+.4byte sCastformAnims_9_3
+.4byte sCastformAnims_9_4
+.4byte sCastformAnims_9_5
+.4byte sCastformAnims_9_6
+.4byte sCastformAnims_9_7
+.4byte sCastformAnims_9_8
+sCastformAnimTable10:
+.4byte sCastformAnims_10_1
+.4byte sCastformAnims_10_2
+.4byte sCastformAnims_10_3
+.4byte sCastformAnims_10_4
+.4byte sCastformAnims_10_5
+.4byte sCastformAnims_10_6
+.4byte sCastformAnims_10_7
+.4byte sCastformAnims_10_8
+sCastformAnimTable11:
+.4byte sCastformAnims_11_1
+.4byte sCastformAnims_11_2
+.4byte sCastformAnims_11_3
+.4byte sCastformAnims_11_4
+.4byte sCastformAnims_11_5
+.4byte sCastformAnims_11_6
+.4byte sCastformAnims_11_7
+.4byte sCastformAnims_11_8
+sCastformAnimTable12:
+.4byte sCastformAnims_12_1
+.4byte sCastformAnims_12_2
+.4byte sCastformAnims_12_3
+.4byte sCastformAnims_12_4
+.4byte sCastformAnims_12_5
+.4byte sCastformAnims_12_6
+.4byte sCastformAnims_12_7
+.4byte sCastformAnims_12_8
+sCastformAnimTable13:
+.4byte sCastformAnims_13_1
+.4byte sCastformAnims_13_2
+.4byte sCastformAnims_13_3
+.4byte sCastformAnims_13_4
+.4byte sCastformAnims_13_5
+.4byte sCastformAnims_13_6
+.4byte sCastformAnims_13_7
+.4byte sCastformAnims_13_8
+sAxAnimationsCastform:
+.4byte sCastformAnimTable1
+.4byte sCastformAnimTable2
+.4byte sCastformAnimTable3
+.4byte sCastformAnimTable4
+.4byte sCastformAnimTable5
+.4byte sCastformAnimTable6
+.4byte sCastformAnimTable7
+.4byte sCastformAnimTable8
+.4byte sCastformAnimTable9
+.4byte sCastformAnimTable10
+.4byte sCastformAnimTable11
+.4byte sCastformAnimTable12
+.4byte sCastformAnimTable13
+sAxSpritesCastform:
+.4byte sCastformSprites1
+.4byte sCastformSprites2
+.4byte sCastformSprites3
+.4byte sCastformSprites4
+.4byte sCastformSprites5
+.4byte sCastformSprites6
+.4byte sCastformSprites7
+.4byte sCastformSprites8
+.4byte sCastformSprites9
+.4byte sCastformSprites10
+.4byte sCastformSprites11
+.4byte sCastformSprites12
+.4byte sCastformSprites13
+.4byte sCastformSprites14
+.4byte sCastformSprites15
+.4byte sCastformSprites16
+.4byte sCastformSprites17
+.4byte sCastformSprites18
+.4byte sCastformSprites19
+.4byte sCastformSprites20
+.4byte sCastformSprites21
+.4byte sCastformSprites22
+.4byte sCastformSprites23
+.4byte sCastformSprites24
+.4byte sCastformSprites25
+.4byte sCastformSprites26
+.4byte sCastformSprites27
+.4byte sCastformSprites28
+.4byte sCastformSprites29
+.4byte sCastformSprites30
+.4byte sCastformSprites31
+.4byte sCastformSprites32
+sAxMainCastform:
+ax_main sAxPosesCastform, sAxAnimationsCastform, 13, sAxSpritesCastform, sAxPositionsCastform

--- a/data/ax/castformrainy.inc
+++ b/data/ax/castformrainy.inc
@@ -1,0 +1,2778 @@
+.global gAxCastformRainy
+gAxCastformRainy:
+ax_siro sAxMainCastformRainy
+sCastformRainyPose1:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose2:
+ax_pose 1, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose3:
+ax_pose 2, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose4:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose5:
+ax_pose 4, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose6:
+ax_pose 5, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose7:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose8:
+ax_pose 7, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose9:
+ax_pose 8, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose10:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose11:
+ax_pose 10, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose12:
+ax_pose 11, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose13:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose14:
+ax_pose 13, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose15:
+ax_pose 14, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose16:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose17:
+ax_pose 10, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose18:
+ax_pose 11, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose19:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose20:
+ax_pose 7, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose21:
+ax_pose 8, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose22:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose23:
+ax_pose 4, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose24:
+ax_pose 5, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose25:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose26:
+ax_pose 15, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose27:
+ax_pose 16, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose28:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose29:
+ax_pose 17, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose30:
+ax_pose 18, 0x81e7, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose31:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose32:
+ax_pose 19, 0x01e7, 0x90e7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose33:
+ax_pose 20, 0x81e7, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose34:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose35:
+ax_pose 21, 0x81e7, 0x90f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose36:
+ax_pose 22, 0x81e7, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose37:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose38:
+ax_pose 23, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose39:
+ax_pose 24, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose40:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose41:
+ax_pose 21, 0x81e7, 0x80f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose42:
+ax_pose 22, 0x81e7, 0x80f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose43:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose44:
+ax_pose 19, 0x01e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose45:
+ax_pose 20, 0x81e7, 0x80f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose46:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose47:
+ax_pose 17, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose48:
+ax_pose 18, 0x81e7, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose49:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose50:
+ax_pose 15, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose51:
+ax_pose 16, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose52:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose53:
+ax_pose 17, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose54:
+ax_pose 18, 0x81e7, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose55:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose56:
+ax_pose 19, 0x01e7, 0x90e7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose57:
+ax_pose 20, 0x81e7, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose58:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose59:
+ax_pose 21, 0x81e7, 0x90f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose60:
+ax_pose 22, 0x81e7, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose61:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose62:
+ax_pose 23, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose63:
+ax_pose 24, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose64:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose65:
+ax_pose 21, 0x81e7, 0x80f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose66:
+ax_pose 22, 0x81e7, 0x80f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose67:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose68:
+ax_pose 19, 0x01e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose69:
+ax_pose 20, 0x81e7, 0x80f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose70:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose71:
+ax_pose 17, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose72:
+ax_pose 18, 0x81e7, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose73:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose74:
+ax_pose 15, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose75:
+ax_pose 16, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose76:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose77:
+ax_pose 17, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose78:
+ax_pose 18, 0x81e8, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose79:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose80:
+ax_pose 19, 0x01e7, 0x90e7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose81:
+ax_pose 20, 0x81e7, 0x90fa, 0x7c00
+ax_pose_terminator
+sCastformRainyPose82:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose83:
+ax_pose 21, 0x81e7, 0x90f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose84:
+ax_pose 22, 0x81e6, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose85:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose86:
+ax_pose 23, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose87:
+ax_pose 24, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose88:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose89:
+ax_pose 21, 0x81e7, 0x80f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose90:
+ax_pose 22, 0x81e6, 0x80f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose91:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose92:
+ax_pose 19, 0x01e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose93:
+ax_pose 20, 0x81e7, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformRainyPose94:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose95:
+ax_pose 17, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose96:
+ax_pose 18, 0x81e8, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose97:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose98:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose99:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose100:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose101:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose102:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose103:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose104:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose105:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose106:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose107:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose108:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose109:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose110:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose111:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose112:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose113:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose114:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose115:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose116:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose117:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose118:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose119:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose120:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose121:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose122:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose123:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose124:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose125:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose126:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose127:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose128:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose129:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose130:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose131:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose132:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose133:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose134:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose135:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose136:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose137:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose138:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose139:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose140:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose141:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose142:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose143:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose144:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose145:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose146:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose147:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose148:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose149:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose150:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose151:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose152:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose153:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose154:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose155:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose156:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose157:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose158:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose159:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose160:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose161:
+ax_pose 25, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformRainyPose162:
+ax_pose 26, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformRainyPose163:
+ax_pose 27, 0x01e0, 0x80f1, 0x7c00
+ax_pose_terminator
+sCastformRainyPose164:
+ax_pose 28, 0x01e0, 0x90e8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose165:
+ax_pose 29, 0x01e2, 0x90e8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose166:
+ax_pose 30, 0x01e5, 0x90e7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose167:
+ax_pose 31, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sCastformRainyPose168:
+ax_pose 30, 0x01e5, 0x80f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose169:
+ax_pose 29, 0x01e2, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose170:
+ax_pose 28, 0x01e0, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose171:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose172:
+ax_pose 1, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose173:
+ax_pose 2, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose174:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose175:
+ax_pose 4, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose176:
+ax_pose 5, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose177:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose178:
+ax_pose 7, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose179:
+ax_pose 8, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose180:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose181:
+ax_pose 10, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose182:
+ax_pose 11, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose183:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose184:
+ax_pose 13, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose185:
+ax_pose 14, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose186:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose187:
+ax_pose 10, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose188:
+ax_pose 11, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose189:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose190:
+ax_pose 7, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose191:
+ax_pose 8, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose192:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose193:
+ax_pose 4, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose194:
+ax_pose 5, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose195:
+ax_pose 16, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose196:
+ax_pose 18, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose197:
+ax_pose 20, 0x81e7, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose198:
+ax_pose 22, 0x81e7, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose199:
+ax_pose 24, 0x81e9, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose200:
+ax_pose 22, 0x81e7, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose201:
+ax_pose 20, 0x81e7, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose202:
+ax_pose 18, 0x81e7, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose203:
+ax_pose 15, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose204:
+ax_pose 17, 0x81e8, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose205:
+ax_pose 19, 0x01e7, 0x90e9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose206:
+ax_pose 21, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose207:
+ax_pose 23, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose208:
+ax_pose 21, 0x81e6, 0x80f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose209:
+ax_pose 19, 0x01e7, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose210:
+ax_pose 17, 0x81e9, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose211:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose212:
+ax_pose 15, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose213:
+ax_pose 16, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose214:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose215:
+ax_pose 17, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose216:
+ax_pose 18, 0x81e8, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose217:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose218:
+ax_pose 19, 0x01e7, 0x90e8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose219:
+ax_pose 20, 0x81e7, 0x90f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose220:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose221:
+ax_pose 21, 0x81e7, 0x90f6, 0x7c00
+ax_pose_terminator
+sCastformRainyPose222:
+ax_pose 22, 0x81e6, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose223:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose224:
+ax_pose 23, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose225:
+ax_pose 24, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose226:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose227:
+ax_pose 21, 0x81e7, 0x80f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose228:
+ax_pose 22, 0x81e6, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose229:
+ax_pose 6, 0x81e7, 0x80f9, 0x7c00
+ax_pose_terminator
+sCastformRainyPose230:
+ax_pose 19, 0x01e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose231:
+ax_pose 20, 0x81e7, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose232:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose233:
+ax_pose 17, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose234:
+ax_pose 18, 0x81e8, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose235:
+ax_pose 16, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose236:
+ax_pose 18, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose237:
+ax_pose 20, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose238:
+ax_pose 22, 0x81e5, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose239:
+ax_pose 24, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose240:
+ax_pose 22, 0x81e5, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose241:
+ax_pose 20, 0x81e6, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose242:
+ax_pose 18, 0x81e6, 0x90f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose243:
+ax_pose 0, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose244:
+ax_pose 3, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose245:
+ax_pose 6, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose246:
+ax_pose 9, 0x81e7, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose247:
+ax_pose 12, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sCastformRainyPose248:
+ax_pose 9, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose249:
+ax_pose 6, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+sCastformRainyPose250:
+ax_pose 3, 0x81e7, 0x90f7, 0x7c00
+ax_pose_terminator
+.align 2
+sCastformRainyAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 13, 0, 13,
+ax_anim 2, 0, 26, 0, 21, 0, 22,
+ax_anim 2, 1, 26, 1, 21, 1, 22,
+ax_anim 2, 0, 26, 0, 21, 0, 22,
+ax_anim 2, 0, 26, 1, 21, 1, 22,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim_terminator
+sCastformRainyAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 13, 14, 13, 13,
+ax_anim 2, 0, 29, 22, 21, 22, 21,
+ax_anim 2, 1, 29, 23, 20, 23, 20,
+ax_anim 2, 0, 29, 22, 21, 22, 21,
+ax_anim 2, 0, 29, 23, 20, 23, 20,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sCastformRainyAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 14, 0, 13, 0,
+ax_anim 2, 0, 32, 21, 0, 21, -1,
+ax_anim 2, 1, 32, 21, 1, 21, 0,
+ax_anim 2, 0, 32, 21, 0, 21, -1,
+ax_anim 2, 0, 32, 21, 1, 21, 0,
+ax_anim 2, 0, 30, 8, 0, 8, 0,
+ax_anim_terminator
+sCastformRainyAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 4, -4, 4, -4,
+ax_anim 1, 0, 33, 12, -11, 12, -11,
+ax_anim 2, 0, 35, 21, -19, 21, -20,
+ax_anim 2, 1, 35, 22, -18, 22, -19,
+ax_anim 2, 0, 35, 21, -19, 21, -20,
+ax_anim 2, 0, 35, 22, -18, 22, -19,
+ax_anim 2, 0, 33, 8, -8, 8, -8,
+ax_anim_terminator
+sCastformRainyAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -9, 0, -10,
+ax_anim 2, 0, 38, 0, -16, 0, -19,
+ax_anim 2, 1, 38, 1, -16, 1, -19,
+ax_anim 2, 0, 38, 0, -16, 0, -19,
+ax_anim 2, 0, 38, 1, -16, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformRainyAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -4, -4, -4, -4,
+ax_anim 1, 0, 39, -12, -11, -12, -11,
+ax_anim 2, 0, 41, -21, -19, -21, -20,
+ax_anim 2, 1, 41, -22, -18, -22, -19,
+ax_anim 2, 0, 41, -21, -19, -21, -20,
+ax_anim 2, 0, 41, -22, -18, -22, -19,
+ax_anim 2, 0, 39, -8, -8, -8, -8,
+ax_anim_terminator
+sCastformRainyAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -14, 0, -13, 0,
+ax_anim 2, 0, 44, -21, 0, -21, -1,
+ax_anim 2, 1, 44, -21, 1, -21, 0,
+ax_anim 2, 0, 44, -21, 0, -21, -1,
+ax_anim 2, 0, 44, -21, 1, -21, 0,
+ax_anim 2, 0, 42, -8, 0, -8, 0,
+ax_anim_terminator
+sCastformRainyAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -13, 14, -13, 13,
+ax_anim 2, 0, 47, -22, 21, -22, 21,
+ax_anim 2, 1, 47, -23, 20, -23, 20,
+ax_anim 2, 0, 47, -22, 21, -22, 21,
+ax_anim 2, 0, 47, -23, 20, -23, 20,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 48, 0, 13, 0, 13,
+ax_anim 2, 0, 50, 0, 21, 0, 22,
+ax_anim 2, 1, 50, 1, 21, 1, 22,
+ax_anim 2, 0, 50, 0, 21, 0, 22,
+ax_anim 2, 0, 50, 1, 21, 1, 22,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim_terminator
+sCastformRainyAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 13, 14, 13, 13,
+ax_anim 2, 0, 53, 22, 21, 22, 21,
+ax_anim 2, 1, 53, 23, 20, 23, 20,
+ax_anim 2, 0, 53, 22, 21, 22, 21,
+ax_anim 2, 0, 53, 23, 20, 23, 20,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sCastformRainyAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 14, 0, 13, 0,
+ax_anim 2, 0, 56, 21, 0, 21, -1,
+ax_anim 2, 1, 56, 21, 1, 21, 0,
+ax_anim 2, 0, 56, 21, 0, 21, -1,
+ax_anim 2, 0, 56, 21, 1, 21, 0,
+ax_anim 2, 0, 54, 8, 0, 8, 0,
+ax_anim_terminator
+sCastformRainyAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 4, -4, 4, -4,
+ax_anim 1, 0, 57, 12, -11, 12, -11,
+ax_anim 2, 0, 59, 21, -19, 21, -20,
+ax_anim 2, 1, 59, 22, -18, 22, -19,
+ax_anim 2, 0, 59, 21, -19, 21, -20,
+ax_anim 2, 0, 59, 22, -18, 22, -19,
+ax_anim 2, 0, 57, 8, -8, 8, -8,
+ax_anim_terminator
+sCastformRainyAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -9, 0, -10,
+ax_anim 2, 0, 62, 0, -16, 0, -19,
+ax_anim 2, 1, 62, 1, -16, 1, -19,
+ax_anim 2, 0, 62, 0, -16, 0, -19,
+ax_anim 2, 0, 62, 1, -16, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformRainyAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -4, -4, -4, -4,
+ax_anim 1, 0, 63, -12, -11, -12, -11,
+ax_anim 2, 0, 65, -21, -19, -21, -20,
+ax_anim 2, 1, 65, -22, -18, -22, -19,
+ax_anim 2, 0, 65, -21, -19, -21, -20,
+ax_anim 2, 0, 65, -22, -18, -22, -19,
+ax_anim 2, 0, 63, -8, -8, -8, -8,
+ax_anim_terminator
+sCastformRainyAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -14, 0, -13, 0,
+ax_anim 2, 0, 68, -21, 0, -21, -1,
+ax_anim 2, 1, 68, -21, 1, -21, 0,
+ax_anim 2, 0, 68, -21, 0, -21, -1,
+ax_anim 2, 0, 68, -21, 1, -21, 0,
+ax_anim 2, 0, 66, -8, 0, -8, 0,
+ax_anim_terminator
+sCastformRainyAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -13, 14, -13, 13,
+ax_anim 2, 0, 71, -22, 21, -22, 21,
+ax_anim 2, 1, 71, -23, 20, -23, 20,
+ax_anim 2, 0, 71, -22, 21, -22, 21,
+ax_anim 2, 0, 71, -23, 20, -23, 20,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sCastformRainyAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sCastformRainyAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sCastformRainyAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sCastformRainyAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sCastformRainyAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sCastformRainyAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sCastformRainyAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_5_1:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 2, 100, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -6, 0, 0,
+ax_anim 1, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 1, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_5_2:
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 1, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 109, 0, -6, 0, 0,
+ax_anim 1, 2, 108, 0, -7, 0, 0,
+ax_anim 1, 0, 107, 0, -8, 0, 0,
+ax_anim 1, 0, 106, 0, -9, 0, 0,
+ax_anim 1, 0, 105, 0, -9, 0, 0,
+ax_anim 1, 0, 104, 0, -9, 0, 0,
+ax_anim 1, 0, 111, 0, -9, 0, 0,
+ax_anim 1, 0, 110, 0, -8, 0, 0,
+ax_anim 1, 0, 109, 0, -7, 0, 0,
+ax_anim 1, 0, 108, 0, -6, 0, 0,
+ax_anim 1, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 1, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_5_3:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 1, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 117, 0, -6, 0, 0,
+ax_anim 1, 2, 116, 0, -7, 0, 0,
+ax_anim 1, 0, 115, 0, -8, 0, 0,
+ax_anim 1, 0, 114, 0, -9, 0, 0,
+ax_anim 1, 0, 113, 0, -9, 0, 0,
+ax_anim 1, 0, 112, 0, -9, 0, 0,
+ax_anim 1, 0, 119, 0, -9, 0, 0,
+ax_anim 1, 0, 118, 0, -8, 0, 0,
+ax_anim 1, 0, 117, 0, -7, 0, 0,
+ax_anim 1, 0, 116, 0, -6, 0, 0,
+ax_anim 1, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 1, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_5_4:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -5, 0, 0,
+ax_anim 1, 0, 125, 0, -6, 0, 0,
+ax_anim 1, 2, 124, 0, -7, 0, 0,
+ax_anim 1, 0, 123, 0, -8, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 126, 0, -8, 0, 0,
+ax_anim 1, 0, 125, 0, -7, 0, 0,
+ax_anim 1, 0, 124, 0, -6, 0, 0,
+ax_anim 1, 0, 123, 0, -5, 0, 0,
+ax_anim 1, 1, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_5_5:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 2, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 1, 0, 130, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 0, 135, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -8, 0, 0,
+ax_anim 1, 0, 133, 0, -7, 0, 0,
+ax_anim 1, 0, 132, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 1, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_5_6:
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 1, 0, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 2, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -8, 0, 0,
+ax_anim 1, 0, 138, 0, -9, 0, 0,
+ax_anim 1, 0, 137, 0, -9, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, 0,
+ax_anim 1, 0, 143, 0, -9, 0, 0,
+ax_anim 1, 0, 142, 0, -8, 0, 0,
+ax_anim 1, 0, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 1, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_5_7:
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 1, 0, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 149, 0, -6, 0, 0,
+ax_anim 1, 2, 148, 0, -7, 0, 0,
+ax_anim 1, 0, 147, 0, -8, 0, 0,
+ax_anim 1, 0, 146, 0, -9, 0, 0,
+ax_anim 1, 0, 145, 0, -9, 0, 0,
+ax_anim 1, 0, 144, 0, -9, 0, 0,
+ax_anim 1, 0, 151, 0, -9, 0, 0,
+ax_anim 1, 0, 150, 0, -8, 0, 0,
+ax_anim 1, 0, 149, 0, -7, 0, 0,
+ax_anim 1, 0, 148, 0, -6, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 1, 146, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_5_8:
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 1, 0, 159, 0, -4, 0, 0,
+ax_anim 1, 0, 158, 0, -5, 0, 0,
+ax_anim 1, 0, 157, 0, -6, 0, 0,
+ax_anim 1, 2, 156, 0, -7, 0, 0,
+ax_anim 1, 0, 155, 0, -8, 0, 0,
+ax_anim 1, 0, 154, 0, -9, 0, 0,
+ax_anim 1, 0, 153, 0, -9, 0, 0,
+ax_anim 1, 0, 152, 0, -9, 0, 0,
+ax_anim 1, 0, 159, 0, -9, 0, 0,
+ax_anim 1, 0, 158, 0, -8, 0, 0,
+ax_anim 1, 0, 157, 0, -7, 0, 0,
+ax_anim 1, 0, 156, 0, -6, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 1, 1, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_6_1:
+ax_anim 10, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 160, 0, -1, 0, 0,
+ax_anim 16, 0, 160, 0, -2, 0, 0,
+ax_anim 10, 0, 161, 0, -2, 0, 0,
+ax_anim 10, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sCastformRainyAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sCastformRainyAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sCastformRainyAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sCastformRainyAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sCastformRainyAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sCastformRainyAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sCastformRainyAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_8_1:
+ax_anim 6, 0, 170, 0, 0, 0, 0,
+ax_anim 6, 0, 171, 0, -1, 0, 0,
+ax_anim 6, 0, 172, 0, -2, 0, 0,
+ax_anim 6, 0, 171, 0, -2, 0, 0,
+ax_anim 6, 0, 170, 0, -1, 0, 0,
+ax_anim 6, 0, 171, 0, 0, 0, 0,
+ax_anim 6, 0, 172, 0, 1, 0, 0,
+ax_anim 6, 0, 171, 0, 1, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_8_2:
+ax_anim 6, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 174, 0, -1, 0, 0,
+ax_anim 6, 0, 175, 0, -2, 0, 0,
+ax_anim 6, 0, 174, 0, -2, 0, 0,
+ax_anim 6, 0, 173, 0, -1, 0, 0,
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim 6, 0, 175, 0, 1, 0, 0,
+ax_anim 6, 0, 174, 0, 1, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_8_3:
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 0, 177, 0, -1, 0, 0,
+ax_anim 6, 0, 178, 0, -2, 0, 0,
+ax_anim 6, 0, 177, 0, -2, 0, 0,
+ax_anim 6, 0, 176, 0, -1, 0, 0,
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 6, 0, 178, 0, 1, 0, 0,
+ax_anim 6, 0, 177, 0, 1, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_8_4:
+ax_anim 6, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 180, 0, -1, 0, 0,
+ax_anim 6, 0, 181, 0, -2, 0, 0,
+ax_anim 6, 0, 180, 0, -2, 0, 0,
+ax_anim 6, 0, 179, 0, -1, 0, 0,
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim 6, 0, 181, 0, 1, 0, 0,
+ax_anim 6, 0, 180, 0, 1, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_8_5:
+ax_anim 6, 0, 182, 0, 0, 0, 0,
+ax_anim 6, 0, 183, 0, -1, 0, 0,
+ax_anim 6, 0, 184, 0, -2, 0, 0,
+ax_anim 6, 0, 183, 0, -2, 0, 0,
+ax_anim 6, 0, 182, 0, -1, 0, 0,
+ax_anim 6, 0, 183, 0, 0, 0, 0,
+ax_anim 6, 0, 184, 0, 1, 0, 0,
+ax_anim 6, 0, 183, 0, 1, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_8_6:
+ax_anim 6, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 186, 0, -1, 0, 0,
+ax_anim 6, 0, 187, 0, -2, 0, 0,
+ax_anim 6, 0, 186, 0, -2, 0, 0,
+ax_anim 6, 0, 185, 0, -1, 0, 0,
+ax_anim 6, 0, 186, 0, 0, 0, 0,
+ax_anim 6, 0, 187, 0, 1, 0, 0,
+ax_anim 6, 0, 186, 0, 1, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_8_7:
+ax_anim 6, 0, 188, 0, 0, 0, 0,
+ax_anim 6, 0, 189, 0, -1, 0, 0,
+ax_anim 6, 0, 190, 0, -2, 0, 0,
+ax_anim 6, 0, 189, 0, -2, 0, 0,
+ax_anim 6, 0, 188, 0, -1, 0, 0,
+ax_anim 6, 0, 189, 0, 0, 0, 0,
+ax_anim 6, 0, 190, 0, 1, 0, 0,
+ax_anim 6, 0, 189, 0, 1, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_8_8:
+ax_anim 6, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, -1, 0, 0,
+ax_anim 6, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 192, 0, -2, 0, 0,
+ax_anim 6, 0, 191, 0, -1, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 6, 0, 193, 0, 1, 0, 0,
+ax_anim 6, 0, 192, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 10, 11, 10, 11,
+ax_anim 2, 0, 197, 7, 19, 7, 19,
+ax_anim 3, 0, 198, 0, 22, 0, 22,
+ax_anim 2, 3, 199, -7, 19, -7, 19,
+ax_anim 2, 0, 200, -10, 11, -10, 11,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 10, 2, 10, 2,
+ax_anim 2, 0, 195, 18, 6, 18, 6,
+ax_anim 2, 0, 196, 25, 15, 25, 15,
+ax_anim 3, 0, 197, 24, 22, 24, 22,
+ax_anim 2, 3, 198, 14, 22, 14, 22,
+ax_anim 2, 0, 199, 5, 18, 5, 18,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 4, -3, 4, -3,
+ax_anim 2, 0, 194, 11, -4, 11, -4,
+ax_anim 2, 0, 195, 18, -3, 18, -3,
+ax_anim 3, 0, 196, 24, 0, 24, 0,
+ax_anim 2, 3, 197, 20, 4, 20, 4,
+ax_anim 2, 0, 198, 12, 6, 12, 6,
+ax_anim 1, 0, 199, 5, 5, 5, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -8, 0, -8,
+ax_anim 2, 0, 201, 6, -16, 6, -16,
+ax_anim 2, 0, 194, 15, -20, 15, -20,
+ax_anim 3, 0, 195, 23, -20, 23, -20,
+ax_anim 2, 3, 196, 25, -12, 25, -12,
+ax_anim 2, 0, 197, 19, -4, 19, -4,
+ax_anim 1, 0, 198, 9, 0, 9, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -5, -2, -5, -2,
+ax_anim 2, 0, 200, -9, -11, -9, -11,
+ax_anim 2, 0, 201, -6, -18, -6, -18,
+ax_anim 3, 0, 194, 0, -20, 0, -20,
+ax_anim 2, 3, 195, 6, -18, 6, -18,
+ax_anim 2, 0, 196, 9, -11, 9, -11,
+ax_anim 1, 0, 197, 5, -2, 5, -2,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -8, 0, -8,
+ax_anim 2, 0, 195, -6, -16, -6, -16,
+ax_anim 2, 0, 194, -15, -20, -15, -20,
+ax_anim 3, 0, 201, -23, -20, -23, -20,
+ax_anim 2, 3, 200, -25, -12, -25, -12,
+ax_anim 2, 0, 199, -19, -4, -19, -4,
+ax_anim 1, 0, 198, -9, 0, -9, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -4, -3, -4, -3,
+ax_anim 2, 0, 194, -11, -4, -11, -4,
+ax_anim 2, 0, 201, -18, -3, -18, -3,
+ax_anim 3, 0, 200, -24, 0, -24, 0,
+ax_anim 2, 3, 199, -20, 4, -20, 4,
+ax_anim 2, 0, 198, -12, 6, -12, 6,
+ax_anim 1, 0, 197, -5, 5, -5, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -10, 2, -10, 2,
+ax_anim 2, 0, 201, -18, 6, -18, 6,
+ax_anim 2, 0, 200, -25, 15, -25, 15,
+ax_anim 3, 0, 199, -24, 22, -24, 22,
+ax_anim 2, 3, 198, -14, 22, -14, 22,
+ax_anim 2, 0, 197, -5, 18, -5, 18,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_11_1:
+ax_anim 2, 0, 210, 0, 3, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -8, 0, 0,
+ax_anim 2, 2, 210, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -8, 0, 0,
+ax_anim 2, 2, 213, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -21, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -8, 0, 0,
+ax_anim 2, 2, 216, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -8, 0, 0,
+ax_anim 2, 2, 219, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 3, 0, 224, 0, -19, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -8, 0, 0,
+ax_anim 2, 2, 222, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -8, 0, 0,
+ax_anim 2, 2, 225, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -8, 0, 0,
+ax_anim 2, 2, 228, 0, 3, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -8, 0, 0,
+ax_anim 2, 2, 231, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformRainyAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformRainyGfx1:
+.incbin "baserom.gba", 0x147E914, 0x100
+sCastformRainySprites1:
+ax_sprite sCastformRainyGfx1, 0x100
+ax_sprite_terminator
+sCastformRainyGfx2:
+.incbin "baserom.gba", 0x147EA24, 0x100
+sCastformRainySprites2:
+ax_sprite sCastformRainyGfx2, 0x100
+ax_sprite_terminator
+sCastformRainyGfx3:
+.incbin "baserom.gba", 0x147EB34, 0x100
+sCastformRainySprites3:
+ax_sprite sCastformRainyGfx3, 0x100
+ax_sprite_terminator
+sCastformRainyGfx4:
+.incbin "baserom.gba", 0x147EC44, 0x100
+sCastformRainySprites4:
+ax_sprite sCastformRainyGfx4, 0x100
+ax_sprite_terminator
+sCastformRainyGfx5:
+.incbin "baserom.gba", 0x147ED54, 0x100
+sCastformRainySprites5:
+ax_sprite sCastformRainyGfx5, 0x100
+ax_sprite_terminator
+sCastformRainyGfx6:
+.incbin "baserom.gba", 0x147EE64, 0x100
+sCastformRainySprites6:
+ax_sprite sCastformRainyGfx6, 0x100
+ax_sprite_terminator
+sCastformRainyGfx7:
+.incbin "baserom.gba", 0x147EF74, 0x100
+sCastformRainySprites7:
+ax_sprite sCastformRainyGfx7, 0x100
+ax_sprite_terminator
+sCastformRainyGfx8:
+.incbin "baserom.gba", 0x147F084, 0x100
+sCastformRainySprites8:
+ax_sprite sCastformRainyGfx8, 0x100
+ax_sprite_terminator
+sCastformRainyGfx9:
+.incbin "baserom.gba", 0x147F194, 0x100
+sCastformRainySprites9:
+ax_sprite sCastformRainyGfx9, 0x100
+ax_sprite_terminator
+sCastformRainyGfx10:
+.incbin "baserom.gba", 0x147F2A4, 0x100
+sCastformRainySprites10:
+ax_sprite sCastformRainyGfx10, 0x100
+ax_sprite_terminator
+sCastformRainyGfx11:
+.incbin "baserom.gba", 0x147F3B4, 0x100
+sCastformRainySprites11:
+ax_sprite sCastformRainyGfx11, 0x100
+ax_sprite_terminator
+sCastformRainyGfx12:
+.incbin "baserom.gba", 0x147F4C4, 0x100
+sCastformRainySprites12:
+ax_sprite sCastformRainyGfx12, 0x100
+ax_sprite_terminator
+sCastformRainyGfx13:
+.incbin "baserom.gba", 0x147F5D4, 0x100
+sCastformRainySprites13:
+ax_sprite sCastformRainyGfx13, 0x100
+ax_sprite_terminator
+sCastformRainyGfx14:
+.incbin "baserom.gba", 0x147F6E4, 0x100
+sCastformRainySprites14:
+ax_sprite sCastformRainyGfx14, 0x100
+ax_sprite_terminator
+sCastformRainyGfx15:
+.incbin "baserom.gba", 0x147F7F4, 0x100
+sCastformRainySprites15:
+ax_sprite sCastformRainyGfx15, 0x100
+ax_sprite_terminator
+sCastformRainyGfx16:
+.incbin "baserom.gba", 0x147F904, 0xC0
+sCastformRainySprites16:
+ax_sprite sCastformRainyGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformRainyGfx17:
+.incbin "baserom.gba", 0x147F9DC, 0x100
+sCastformRainySprites17:
+ax_sprite sCastformRainyGfx17, 0x100
+ax_sprite_terminator
+sCastformRainyGfx18:
+.incbin "baserom.gba", 0x147FAEC, 0xC0
+sCastformRainySprites18:
+ax_sprite sCastformRainyGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformRainyGfx19:
+.incbin "baserom.gba", 0x147FBC4, 0x100
+sCastformRainySprites19:
+ax_sprite sCastformRainyGfx19, 0x100
+ax_sprite_terminator
+sCastformRainyGfx20:
+.incbin "baserom.gba", 0x147FCD4, 0x60
+sCastformRainyGfx20_1:
+.incbin "baserom.gba", 0x147FD34, 0x60
+sCastformRainyGfx20_2:
+.incbin "baserom.gba", 0x147FD94, 0x60
+sCastformRainyGfx20_3:
+.incbin "baserom.gba", 0x147FDF4, 0x20
+sCastformRainySprites20:
+ax_sprite sCastformRainyGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformRainyGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformRainyGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformRainyGfx20_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformRainyGfx21:
+.incbin "baserom.gba", 0x147FE5C, 0x100
+sCastformRainySprites21:
+ax_sprite sCastformRainyGfx21, 0x100
+ax_sprite_terminator
+sCastformRainyGfx22:
+.incbin "baserom.gba", 0x147FF6C, 0x100
+sCastformRainySprites22:
+ax_sprite sCastformRainyGfx22, 0x100
+ax_sprite_terminator
+sCastformRainyGfx23:
+.incbin "baserom.gba", 0x148007C, 0x100
+sCastformRainySprites23:
+ax_sprite sCastformRainyGfx23, 0x100
+ax_sprite_terminator
+sCastformRainyGfx24:
+.incbin "baserom.gba", 0x148018C, 0x100
+sCastformRainySprites24:
+ax_sprite sCastformRainyGfx24, 0x100
+ax_sprite_terminator
+sCastformRainyGfx25:
+.incbin "baserom.gba", 0x148029C, 0xC0
+sCastformRainySprites25:
+ax_sprite sCastformRainyGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformRainyGfx26:
+.incbin "baserom.gba", 0x1480374, 0x200
+sCastformRainySprites26:
+ax_sprite sCastformRainyGfx26, 0x200
+ax_sprite_terminator
+sCastformRainyGfx27:
+.incbin "baserom.gba", 0x1480584, 0x200
+sCastformRainySprites27:
+ax_sprite sCastformRainyGfx27, 0x200
+ax_sprite_terminator
+sCastformRainyGfx28:
+.incbin "baserom.gba", 0x1480794, 0x200
+sCastformRainySprites28:
+ax_sprite sCastformRainyGfx28, 0x200
+ax_sprite_terminator
+sCastformRainyGfx29:
+.incbin "baserom.gba", 0x14809A4, 0x200
+sCastformRainySprites29:
+ax_sprite sCastformRainyGfx29, 0x200
+ax_sprite_terminator
+sCastformRainyGfx30:
+.incbin "baserom.gba", 0x1480BB4, 0x200
+sCastformRainySprites30:
+ax_sprite sCastformRainyGfx30, 0x200
+ax_sprite_terminator
+sCastformRainyGfx31:
+.incbin "baserom.gba", 0x1480DC4, 0x200
+sCastformRainySprites31:
+ax_sprite sCastformRainyGfx31, 0x200
+ax_sprite_terminator
+sCastformRainyGfx32:
+.incbin "baserom.gba", 0x1480FD4, 0x200
+sCastformRainySprites32:
+ax_sprite sCastformRainyGfx32, 0x200
+ax_sprite_terminator
+sAxPosesCastformRainy:
+.4byte sCastformRainyPose1
+.4byte sCastformRainyPose2
+.4byte sCastformRainyPose3
+.4byte sCastformRainyPose4
+.4byte sCastformRainyPose5
+.4byte sCastformRainyPose6
+.4byte sCastformRainyPose7
+.4byte sCastformRainyPose8
+.4byte sCastformRainyPose9
+.4byte sCastformRainyPose10
+.4byte sCastformRainyPose11
+.4byte sCastformRainyPose12
+.4byte sCastformRainyPose13
+.4byte sCastformRainyPose14
+.4byte sCastformRainyPose15
+.4byte sCastformRainyPose16
+.4byte sCastformRainyPose17
+.4byte sCastformRainyPose18
+.4byte sCastformRainyPose19
+.4byte sCastformRainyPose20
+.4byte sCastformRainyPose21
+.4byte sCastformRainyPose22
+.4byte sCastformRainyPose23
+.4byte sCastformRainyPose24
+.4byte sCastformRainyPose25
+.4byte sCastformRainyPose26
+.4byte sCastformRainyPose27
+.4byte sCastformRainyPose28
+.4byte sCastformRainyPose29
+.4byte sCastformRainyPose30
+.4byte sCastformRainyPose31
+.4byte sCastformRainyPose32
+.4byte sCastformRainyPose33
+.4byte sCastformRainyPose34
+.4byte sCastformRainyPose35
+.4byte sCastformRainyPose36
+.4byte sCastformRainyPose37
+.4byte sCastformRainyPose38
+.4byte sCastformRainyPose39
+.4byte sCastformRainyPose40
+.4byte sCastformRainyPose41
+.4byte sCastformRainyPose42
+.4byte sCastformRainyPose43
+.4byte sCastformRainyPose44
+.4byte sCastformRainyPose45
+.4byte sCastformRainyPose46
+.4byte sCastformRainyPose47
+.4byte sCastformRainyPose48
+.4byte sCastformRainyPose49
+.4byte sCastformRainyPose50
+.4byte sCastformRainyPose51
+.4byte sCastformRainyPose52
+.4byte sCastformRainyPose53
+.4byte sCastformRainyPose54
+.4byte sCastformRainyPose55
+.4byte sCastformRainyPose56
+.4byte sCastformRainyPose57
+.4byte sCastformRainyPose58
+.4byte sCastformRainyPose59
+.4byte sCastformRainyPose60
+.4byte sCastformRainyPose61
+.4byte sCastformRainyPose62
+.4byte sCastformRainyPose63
+.4byte sCastformRainyPose64
+.4byte sCastformRainyPose65
+.4byte sCastformRainyPose66
+.4byte sCastformRainyPose67
+.4byte sCastformRainyPose68
+.4byte sCastformRainyPose69
+.4byte sCastformRainyPose70
+.4byte sCastformRainyPose71
+.4byte sCastformRainyPose72
+.4byte sCastformRainyPose73
+.4byte sCastformRainyPose74
+.4byte sCastformRainyPose75
+.4byte sCastformRainyPose76
+.4byte sCastformRainyPose77
+.4byte sCastformRainyPose78
+.4byte sCastformRainyPose79
+.4byte sCastformRainyPose80
+.4byte sCastformRainyPose81
+.4byte sCastformRainyPose82
+.4byte sCastformRainyPose83
+.4byte sCastformRainyPose84
+.4byte sCastformRainyPose85
+.4byte sCastformRainyPose86
+.4byte sCastformRainyPose87
+.4byte sCastformRainyPose88
+.4byte sCastformRainyPose89
+.4byte sCastformRainyPose90
+.4byte sCastformRainyPose91
+.4byte sCastformRainyPose92
+.4byte sCastformRainyPose93
+.4byte sCastformRainyPose94
+.4byte sCastformRainyPose95
+.4byte sCastformRainyPose96
+.4byte sCastformRainyPose97
+.4byte sCastformRainyPose98
+.4byte sCastformRainyPose99
+.4byte sCastformRainyPose100
+.4byte sCastformRainyPose101
+.4byte sCastformRainyPose102
+.4byte sCastformRainyPose103
+.4byte sCastformRainyPose104
+.4byte sCastformRainyPose105
+.4byte sCastformRainyPose106
+.4byte sCastformRainyPose107
+.4byte sCastformRainyPose108
+.4byte sCastformRainyPose109
+.4byte sCastformRainyPose110
+.4byte sCastformRainyPose111
+.4byte sCastformRainyPose112
+.4byte sCastformRainyPose113
+.4byte sCastformRainyPose114
+.4byte sCastformRainyPose115
+.4byte sCastformRainyPose116
+.4byte sCastformRainyPose117
+.4byte sCastformRainyPose118
+.4byte sCastformRainyPose119
+.4byte sCastformRainyPose120
+.4byte sCastformRainyPose121
+.4byte sCastformRainyPose122
+.4byte sCastformRainyPose123
+.4byte sCastformRainyPose124
+.4byte sCastformRainyPose125
+.4byte sCastformRainyPose126
+.4byte sCastformRainyPose127
+.4byte sCastformRainyPose128
+.4byte sCastformRainyPose129
+.4byte sCastformRainyPose130
+.4byte sCastformRainyPose131
+.4byte sCastformRainyPose132
+.4byte sCastformRainyPose133
+.4byte sCastformRainyPose134
+.4byte sCastformRainyPose135
+.4byte sCastformRainyPose136
+.4byte sCastformRainyPose137
+.4byte sCastformRainyPose138
+.4byte sCastformRainyPose139
+.4byte sCastformRainyPose140
+.4byte sCastformRainyPose141
+.4byte sCastformRainyPose142
+.4byte sCastformRainyPose143
+.4byte sCastformRainyPose144
+.4byte sCastformRainyPose145
+.4byte sCastformRainyPose146
+.4byte sCastformRainyPose147
+.4byte sCastformRainyPose148
+.4byte sCastformRainyPose149
+.4byte sCastformRainyPose150
+.4byte sCastformRainyPose151
+.4byte sCastformRainyPose152
+.4byte sCastformRainyPose153
+.4byte sCastformRainyPose154
+.4byte sCastformRainyPose155
+.4byte sCastformRainyPose156
+.4byte sCastformRainyPose157
+.4byte sCastformRainyPose158
+.4byte sCastformRainyPose159
+.4byte sCastformRainyPose160
+.4byte sCastformRainyPose161
+.4byte sCastformRainyPose162
+.4byte sCastformRainyPose163
+.4byte sCastformRainyPose164
+.4byte sCastformRainyPose165
+.4byte sCastformRainyPose166
+.4byte sCastformRainyPose167
+.4byte sCastformRainyPose168
+.4byte sCastformRainyPose169
+.4byte sCastformRainyPose170
+.4byte sCastformRainyPose171
+.4byte sCastformRainyPose172
+.4byte sCastformRainyPose173
+.4byte sCastformRainyPose174
+.4byte sCastformRainyPose175
+.4byte sCastformRainyPose176
+.4byte sCastformRainyPose177
+.4byte sCastformRainyPose178
+.4byte sCastformRainyPose179
+.4byte sCastformRainyPose180
+.4byte sCastformRainyPose181
+.4byte sCastformRainyPose182
+.4byte sCastformRainyPose183
+.4byte sCastformRainyPose184
+.4byte sCastformRainyPose185
+.4byte sCastformRainyPose186
+.4byte sCastformRainyPose187
+.4byte sCastformRainyPose188
+.4byte sCastformRainyPose189
+.4byte sCastformRainyPose190
+.4byte sCastformRainyPose191
+.4byte sCastformRainyPose192
+.4byte sCastformRainyPose193
+.4byte sCastformRainyPose194
+.4byte sCastformRainyPose195
+.4byte sCastformRainyPose196
+.4byte sCastformRainyPose197
+.4byte sCastformRainyPose198
+.4byte sCastformRainyPose199
+.4byte sCastformRainyPose200
+.4byte sCastformRainyPose201
+.4byte sCastformRainyPose202
+.4byte sCastformRainyPose203
+.4byte sCastformRainyPose204
+.4byte sCastformRainyPose205
+.4byte sCastformRainyPose206
+.4byte sCastformRainyPose207
+.4byte sCastformRainyPose208
+.4byte sCastformRainyPose209
+.4byte sCastformRainyPose210
+.4byte sCastformRainyPose211
+.4byte sCastformRainyPose212
+.4byte sCastformRainyPose213
+.4byte sCastformRainyPose214
+.4byte sCastformRainyPose215
+.4byte sCastformRainyPose216
+.4byte sCastformRainyPose217
+.4byte sCastformRainyPose218
+.4byte sCastformRainyPose219
+.4byte sCastformRainyPose220
+.4byte sCastformRainyPose221
+.4byte sCastformRainyPose222
+.4byte sCastformRainyPose223
+.4byte sCastformRainyPose224
+.4byte sCastformRainyPose225
+.4byte sCastformRainyPose226
+.4byte sCastformRainyPose227
+.4byte sCastformRainyPose228
+.4byte sCastformRainyPose229
+.4byte sCastformRainyPose230
+.4byte sCastformRainyPose231
+.4byte sCastformRainyPose232
+.4byte sCastformRainyPose233
+.4byte sCastformRainyPose234
+.4byte sCastformRainyPose235
+.4byte sCastformRainyPose236
+.4byte sCastformRainyPose237
+.4byte sCastformRainyPose238
+.4byte sCastformRainyPose239
+.4byte sCastformRainyPose240
+.4byte sCastformRainyPose241
+.4byte sCastformRainyPose242
+.4byte sCastformRainyPose243
+.4byte sCastformRainyPose244
+.4byte sCastformRainyPose245
+.4byte sCastformRainyPose246
+.4byte sCastformRainyPose247
+.4byte sCastformRainyPose248
+.4byte sCastformRainyPose249
+.4byte sCastformRainyPose250
+sAxPositionsCastformRainy:
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -6, 	   2,   -3, 	  -2,  -10
+.2byte    1,   -8, 	  -1,   -6, 	   2,   -3, 	  -2,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -2,   -8, 	  -1,   -6, 	  -4,   -3, 	   0,  -10
+.2byte   -3,   -8, 	  -1,   -6, 	  -4,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -11, 	  -5,   -6, 	   3,   -6, 	  -1,  -13
+.2byte   -1,   -4, 	  -5,   -3, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,  -11, 	   3,   -7, 	  -2,   -5, 	  -2,  -13
+.2byte    1,   -4, 	   3,   -2, 	  -3,   -1, 	   0,   -8
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    1,  -10, 	   1,   -6, 	   2,   -4, 	  -3,  -10
+.2byte    4,   -5, 	   1,   -3, 	   1,   -1, 	   0,   -8
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    0,  -10, 	  -1,   -5, 	   3,   -3, 	  -2,   -8
+.2byte    3,   -6, 	   0,   -4, 	   3,   -2, 	   0,   -8
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   3,   -6, 	  -4,   -6, 	  -1,  -13
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -2,  -10, 	  -1,   -5, 	  -5,   -3, 	   0,   -8
+.2byte   -5,   -6, 	  -2,   -4, 	  -5,   -2, 	  -2,   -8
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -3,  -10, 	  -3,   -6, 	  -4,   -4, 	   1,  -10
+.2byte   -6,   -5, 	  -3,   -3, 	  -3,   -1, 	  -2,   -8
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,  -11, 	  -5,   -7, 	   0,   -5, 	   0,  -13
+.2byte   -3,   -4, 	  -5,   -2, 	   1,   -1, 	  -2,   -8
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -11, 	  -5,   -6, 	   3,   -6, 	  -1,  -13
+.2byte   -1,   -4, 	  -5,   -3, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,  -11, 	   3,   -7, 	  -2,   -5, 	  -2,  -13
+.2byte    1,   -4, 	   3,   -2, 	  -3,   -1, 	   0,   -8
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    1,  -10, 	   1,   -6, 	   2,   -4, 	  -3,  -10
+.2byte    4,   -5, 	   1,   -3, 	   1,   -1, 	   0,   -8
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    0,  -10, 	  -1,   -5, 	   3,   -3, 	  -2,   -8
+.2byte    3,   -6, 	   0,   -4, 	   3,   -2, 	   0,   -8
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   3,   -6, 	  -4,   -6, 	  -1,  -13
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -2,  -10, 	  -1,   -5, 	  -5,   -3, 	   0,   -8
+.2byte   -5,   -6, 	  -2,   -4, 	  -5,   -2, 	  -2,   -8
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -3,  -10, 	  -3,   -6, 	  -4,   -4, 	   1,  -10
+.2byte   -6,   -5, 	  -3,   -3, 	  -3,   -1, 	  -2,   -8
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,  -11, 	  -5,   -7, 	   0,   -5, 	   0,  -13
+.2byte   -3,   -4, 	  -5,   -2, 	   1,   -1, 	  -2,   -8
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -11, 	  -5,   -6, 	   3,   -6, 	  -1,  -13
+.2byte   -1,   -4, 	  -5,   -3, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,  -11, 	   3,   -7, 	  -2,   -5, 	  -2,  -13
+.2byte    1,   -3, 	   3,   -1, 	  -3,    0, 	   0,   -7
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    1,  -10, 	   1,   -6, 	   2,   -4, 	  -3,  -10
+.2byte    5,   -5, 	   2,   -3, 	   2,   -1, 	   1,   -8
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    0,  -10, 	  -1,   -5, 	   3,   -3, 	  -2,   -8
+.2byte    3,   -7, 	   0,   -5, 	   3,   -3, 	   0,   -9
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   3,   -6, 	  -4,   -6, 	  -1,  -13
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -2,  -10, 	  -1,   -5, 	  -5,   -3, 	   0,   -8
+.2byte   -5,   -7, 	  -2,   -5, 	  -5,   -3, 	  -2,   -9
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -3,  -10, 	  -3,   -6, 	  -4,   -4, 	   1,  -10
+.2byte   -7,   -5, 	  -4,   -3, 	  -4,   -1, 	  -3,   -8
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,  -11, 	  -5,   -7, 	   0,   -5, 	   0,  -13
+.2byte   -3,   -3, 	  -5,   -1, 	   1,    0, 	  -2,   -7
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,   -6, 	  -5,   -4, 	   1,   -3, 	  -1,   -9
+.2byte    0,   -8, 	  -4,   -5, 	   4,   -5, 	   0,  -11
+.2byte   -1,   -8, 	   2,   -5, 	  -3,   -3, 	  -2,  -11
+.2byte    1,   -8, 	   2,   -6, 	   3,   -4, 	  -3,  -10
+.2byte    1,   -9, 	  -1,   -6, 	   3,   -4, 	  -3,  -10
+.2byte    0,   -9, 	   5,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -2,   -9, 	   0,   -6, 	  -4,   -4, 	   2,  -10
+.2byte   -2,   -8, 	  -3,   -6, 	  -4,   -4, 	   2,  -10
+.2byte    0,   -8, 	  -3,   -5, 	   2,   -3, 	   1,  -11
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -6, 	   2,   -3, 	  -2,  -10
+.2byte    1,   -8, 	  -1,   -6, 	   2,   -3, 	  -2,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -2,   -8, 	  -1,   -6, 	  -4,   -3, 	   0,  -10
+.2byte   -3,   -8, 	  -1,   -6, 	  -4,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -1,   -4, 	  -5,   -3, 	   3,   -3, 	  -1,   -8
+.2byte   -2,   -4, 	  -4,   -2, 	   2,   -1, 	  -1,   -8
+.2byte   -5,   -5, 	  -2,   -3, 	  -2,   -1, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,   -4, 	  -4,   -2, 	  -1,   -8
+.2byte   -1,  -10, 	   3,   -4, 	  -4,   -4, 	  -1,  -11
+.2byte    3,   -6, 	   0,   -4, 	   3,   -2, 	   0,   -8
+.2byte    4,   -5, 	   1,   -3, 	   1,   -1, 	   0,   -8
+.2byte    1,   -4, 	   3,   -2, 	  -3,   -1, 	   0,   -8
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,  -12
+.2byte    1,  -10, 	   4,   -6, 	  -1,   -4, 	  -1,  -12
+.2byte    3,  -10, 	   3,   -6, 	   4,   -4, 	  -1,  -10
+.2byte    1,  -11, 	   0,   -6, 	   4,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -5, 	  -6,   -5, 	  -1,   -9
+.2byte   -2,  -11, 	  -1,   -6, 	  -5,   -4, 	   0,   -9
+.2byte   -4,  -10, 	  -4,   -6, 	  -5,   -4, 	   0,  -10
+.2byte   -2,   -9, 	  -5,   -5, 	   0,   -3, 	   0,  -11
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -11, 	  -5,   -6, 	   3,   -6, 	  -1,  -13
+.2byte   -1,   -4, 	  -5,   -3, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+.2byte    0,  -11, 	   3,   -7, 	  -2,   -5, 	  -2,  -13
+.2byte    1,   -3, 	   3,   -1, 	  -3,    0, 	   0,   -7
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    2,  -10, 	   2,   -6, 	   3,   -4, 	  -2,  -10
+.2byte    4,   -5, 	   1,   -3, 	   1,   -1, 	   0,   -8
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    0,  -10, 	  -1,   -5, 	   3,   -3, 	  -2,   -8
+.2byte    2,   -7, 	  -1,   -5, 	   2,   -3, 	  -1,   -9
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   3,   -6, 	  -4,   -6, 	  -1,  -13
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -2,  -10, 	  -1,   -5, 	  -5,   -3, 	   0,   -8
+.2byte   -4,   -7, 	  -1,   -5, 	  -4,   -3, 	  -1,   -9
+.2byte   -3,   -7, 	  -2,   -5, 	  -2,   -3, 	   1,  -11
+.2byte   -3,  -10, 	  -3,   -6, 	  -4,   -4, 	   1,  -10
+.2byte   -5,   -5, 	  -2,   -3, 	  -2,   -1, 	  -1,   -8
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -2,  -11, 	  -5,   -7, 	   0,   -5, 	   0,  -13
+.2byte   -3,   -3, 	  -5,   -1, 	   1,    0, 	  -2,   -7
+.2byte   -1,   -5, 	  -5,   -4, 	   3,   -4, 	  -1,   -9
+.2byte   -2,   -5, 	  -4,   -3, 	   2,   -2, 	  -1,   -9
+.2byte   -4,   -6, 	  -1,   -4, 	  -1,   -2, 	   0,   -9
+.2byte   -3,   -8, 	   0,   -6, 	  -3,   -4, 	   0,  -10
+.2byte   -1,  -12, 	   3,   -6, 	  -4,   -6, 	  -1,  -13
+.2byte    2,   -8, 	  -1,   -6, 	   2,   -4, 	  -1,  -10
+.2byte    3,   -6, 	   0,   -4, 	   0,   -2, 	  -1,   -9
+.2byte    1,   -5, 	   3,   -3, 	  -3,   -2, 	   0,   -9
+.2byte   -1,   -7, 	  -5,   -4, 	   3,   -4, 	  -1,  -10
+.2byte   -2,   -7, 	  -5,   -4, 	   1,   -3, 	  -1,  -10
+.2byte   -4,   -7, 	  -3,   -5, 	  -3,   -3, 	   0,  -11
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte    0,   -8, 	  -1,   -5, 	   2,   -3, 	  -1,  -10
+.2byte    2,   -7, 	   1,   -5, 	   1,   -3, 	  -2,  -11
+.2byte    0,   -7, 	   3,   -4, 	  -3,   -3, 	  -1,  -10
+sCastformRainyAnimTable1:
+.4byte sCastformRainyAnims_1_1
+.4byte sCastformRainyAnims_1_2
+.4byte sCastformRainyAnims_1_3
+.4byte sCastformRainyAnims_1_4
+.4byte sCastformRainyAnims_1_5
+.4byte sCastformRainyAnims_1_6
+.4byte sCastformRainyAnims_1_7
+.4byte sCastformRainyAnims_1_8
+sCastformRainyAnimTable2:
+.4byte sCastformRainyAnims_2_1
+.4byte sCastformRainyAnims_2_2
+.4byte sCastformRainyAnims_2_3
+.4byte sCastformRainyAnims_2_4
+.4byte sCastformRainyAnims_2_5
+.4byte sCastformRainyAnims_2_6
+.4byte sCastformRainyAnims_2_7
+.4byte sCastformRainyAnims_2_8
+sCastformRainyAnimTable3:
+.4byte sCastformRainyAnims_3_1
+.4byte sCastformRainyAnims_3_2
+.4byte sCastformRainyAnims_3_3
+.4byte sCastformRainyAnims_3_4
+.4byte sCastformRainyAnims_3_5
+.4byte sCastformRainyAnims_3_6
+.4byte sCastformRainyAnims_3_7
+.4byte sCastformRainyAnims_3_8
+sCastformRainyAnimTable4:
+.4byte sCastformRainyAnims_4_1
+.4byte sCastformRainyAnims_4_2
+.4byte sCastformRainyAnims_4_3
+.4byte sCastformRainyAnims_4_4
+.4byte sCastformRainyAnims_4_5
+.4byte sCastformRainyAnims_4_6
+.4byte sCastformRainyAnims_4_7
+.4byte sCastformRainyAnims_4_8
+sCastformRainyAnimTable5:
+.4byte sCastformRainyAnims_5_1
+.4byte sCastformRainyAnims_5_2
+.4byte sCastformRainyAnims_5_3
+.4byte sCastformRainyAnims_5_4
+.4byte sCastformRainyAnims_5_5
+.4byte sCastformRainyAnims_5_6
+.4byte sCastformRainyAnims_5_7
+.4byte sCastformRainyAnims_5_8
+sCastformRainyAnimTable6:
+.4byte sCastformRainyAnims_6_1
+.4byte sCastformRainyAnims_6_1
+.4byte sCastformRainyAnims_6_1
+.4byte sCastformRainyAnims_6_1
+.4byte sCastformRainyAnims_6_1
+.4byte sCastformRainyAnims_6_1
+.4byte sCastformRainyAnims_6_1
+.4byte sCastformRainyAnims_6_1
+sCastformRainyAnimTable7:
+.4byte sCastformRainyAnims_7_1
+.4byte sCastformRainyAnims_7_2
+.4byte sCastformRainyAnims_7_3
+.4byte sCastformRainyAnims_7_4
+.4byte sCastformRainyAnims_7_5
+.4byte sCastformRainyAnims_7_6
+.4byte sCastformRainyAnims_7_7
+.4byte sCastformRainyAnims_7_8
+sCastformRainyAnimTable8:
+.4byte sCastformRainyAnims_8_1
+.4byte sCastformRainyAnims_8_2
+.4byte sCastformRainyAnims_8_3
+.4byte sCastformRainyAnims_8_4
+.4byte sCastformRainyAnims_8_5
+.4byte sCastformRainyAnims_8_6
+.4byte sCastformRainyAnims_8_7
+.4byte sCastformRainyAnims_8_8
+sCastformRainyAnimTable9:
+.4byte sCastformRainyAnims_9_1
+.4byte sCastformRainyAnims_9_2
+.4byte sCastformRainyAnims_9_3
+.4byte sCastformRainyAnims_9_4
+.4byte sCastformRainyAnims_9_5
+.4byte sCastformRainyAnims_9_6
+.4byte sCastformRainyAnims_9_7
+.4byte sCastformRainyAnims_9_8
+sCastformRainyAnimTable10:
+.4byte sCastformRainyAnims_10_1
+.4byte sCastformRainyAnims_10_2
+.4byte sCastformRainyAnims_10_3
+.4byte sCastformRainyAnims_10_4
+.4byte sCastformRainyAnims_10_5
+.4byte sCastformRainyAnims_10_6
+.4byte sCastformRainyAnims_10_7
+.4byte sCastformRainyAnims_10_8
+sCastformRainyAnimTable11:
+.4byte sCastformRainyAnims_11_1
+.4byte sCastformRainyAnims_11_2
+.4byte sCastformRainyAnims_11_3
+.4byte sCastformRainyAnims_11_4
+.4byte sCastformRainyAnims_11_5
+.4byte sCastformRainyAnims_11_6
+.4byte sCastformRainyAnims_11_7
+.4byte sCastformRainyAnims_11_8
+sCastformRainyAnimTable12:
+.4byte sCastformRainyAnims_12_1
+.4byte sCastformRainyAnims_12_2
+.4byte sCastformRainyAnims_12_3
+.4byte sCastformRainyAnims_12_4
+.4byte sCastformRainyAnims_12_5
+.4byte sCastformRainyAnims_12_6
+.4byte sCastformRainyAnims_12_7
+.4byte sCastformRainyAnims_12_8
+sCastformRainyAnimTable13:
+.4byte sCastformRainyAnims_13_1
+.4byte sCastformRainyAnims_13_2
+.4byte sCastformRainyAnims_13_3
+.4byte sCastformRainyAnims_13_4
+.4byte sCastformRainyAnims_13_5
+.4byte sCastformRainyAnims_13_6
+.4byte sCastformRainyAnims_13_7
+.4byte sCastformRainyAnims_13_8
+sAxAnimationsCastformRainy:
+.4byte sCastformRainyAnimTable1
+.4byte sCastformRainyAnimTable2
+.4byte sCastformRainyAnimTable3
+.4byte sCastformRainyAnimTable4
+.4byte sCastformRainyAnimTable5
+.4byte sCastformRainyAnimTable6
+.4byte sCastformRainyAnimTable7
+.4byte sCastformRainyAnimTable8
+.4byte sCastformRainyAnimTable9
+.4byte sCastformRainyAnimTable10
+.4byte sCastformRainyAnimTable11
+.4byte sCastformRainyAnimTable12
+.4byte sCastformRainyAnimTable13
+sAxSpritesCastformRainy:
+.4byte sCastformRainySprites1
+.4byte sCastformRainySprites2
+.4byte sCastformRainySprites3
+.4byte sCastformRainySprites4
+.4byte sCastformRainySprites5
+.4byte sCastformRainySprites6
+.4byte sCastformRainySprites7
+.4byte sCastformRainySprites8
+.4byte sCastformRainySprites9
+.4byte sCastformRainySprites10
+.4byte sCastformRainySprites11
+.4byte sCastformRainySprites12
+.4byte sCastformRainySprites13
+.4byte sCastformRainySprites14
+.4byte sCastformRainySprites15
+.4byte sCastformRainySprites16
+.4byte sCastformRainySprites17
+.4byte sCastformRainySprites18
+.4byte sCastformRainySprites19
+.4byte sCastformRainySprites20
+.4byte sCastformRainySprites21
+.4byte sCastformRainySprites22
+.4byte sCastformRainySprites23
+.4byte sCastformRainySprites24
+.4byte sCastformRainySprites25
+.4byte sCastformRainySprites26
+.4byte sCastformRainySprites27
+.4byte sCastformRainySprites28
+.4byte sCastformRainySprites29
+.4byte sCastformRainySprites30
+.4byte sCastformRainySprites31
+.4byte sCastformRainySprites32
+sAxMainCastformRainy:
+ax_main sAxPosesCastformRainy, sAxAnimationsCastformRainy, 13, sAxSpritesCastformRainy, sAxPositionsCastformRainy

--- a/data/ax/castformsnowy.inc
+++ b/data/ax/castformsnowy.inc
@@ -1,0 +1,2722 @@
+.global gAxCastformSnowy
+gAxCastformSnowy:
+ax_siro sAxMainCastformSnowy
+sCastformSnowyPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose4:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose5:
+ax_pose 4, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose6:
+ax_pose 5, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose7:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose8:
+ax_pose 7, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose9:
+ax_pose 8, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose10:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose11:
+ax_pose 10, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose12:
+ax_pose 11, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose13:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose14:
+ax_pose 13, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose15:
+ax_pose 14, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose16:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose17:
+ax_pose 16, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose18:
+ax_pose 17, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose19:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose20:
+ax_pose 19, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose21:
+ax_pose 20, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose22:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose23:
+ax_pose 22, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose24:
+ax_pose 23, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose26:
+ax_pose 24, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose27:
+ax_pose 25, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose28:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose29:
+ax_pose 26, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose30:
+ax_pose 27, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose31:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose32:
+ax_pose 28, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose33:
+ax_pose 29, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose34:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose35:
+ax_pose 30, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose36:
+ax_pose 31, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose37:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose38:
+ax_pose 32, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose39:
+ax_pose 33, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose40:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose41:
+ax_pose 34, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose42:
+ax_pose 35, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose43:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose44:
+ax_pose 36, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose45:
+ax_pose 37, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose46:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose47:
+ax_pose 38, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose48:
+ax_pose 39, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose49:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose50:
+ax_pose 24, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose51:
+ax_pose 25, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose52:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose53:
+ax_pose 26, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose54:
+ax_pose 27, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose55:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose56:
+ax_pose 28, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose57:
+ax_pose 29, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose58:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose59:
+ax_pose 30, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose60:
+ax_pose 31, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose61:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose62:
+ax_pose 32, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose63:
+ax_pose 33, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose64:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose65:
+ax_pose 34, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose66:
+ax_pose 35, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose67:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose68:
+ax_pose 36, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose69:
+ax_pose 37, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose70:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose71:
+ax_pose 38, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose72:
+ax_pose 39, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose73:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose74:
+ax_pose 24, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose75:
+ax_pose 25, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose76:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose77:
+ax_pose 26, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose78:
+ax_pose 27, 0x01e7, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose79:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose80:
+ax_pose 28, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose81:
+ax_pose 29, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose82:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose83:
+ax_pose 30, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose84:
+ax_pose 31, 0x01e5, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose85:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose86:
+ax_pose 32, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose87:
+ax_pose 33, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose88:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose89:
+ax_pose 34, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose90:
+ax_pose 35, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose91:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose92:
+ax_pose 36, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose93:
+ax_pose 37, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose94:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose95:
+ax_pose 38, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose96:
+ax_pose 39, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose97:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose98:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose99:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose100:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose101:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose102:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose103:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose104:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose105:
+ax_pose 40, 0x01e3, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose106:
+ax_pose 41, 0x01e3, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose107:
+ax_pose 42, 0x01de, 0x80f2, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose108:
+ax_pose 43, 0x01e1, 0x80ed, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose109:
+ax_pose 44, 0x01e1, 0x80ec, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose110:
+ax_pose 45, 0x01e4, 0x80ed, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose111:
+ax_pose 46, 0x01de, 0x80f1, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose112:
+ax_pose 47, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose113:
+ax_pose 48, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose114:
+ax_pose 49, 0x01df, 0x80f7, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose115:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose116:
+ax_pose 1, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose117:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose118:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose119:
+ax_pose 4, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose120:
+ax_pose 5, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose121:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose122:
+ax_pose 7, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose123:
+ax_pose 8, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose124:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose125:
+ax_pose 10, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose126:
+ax_pose 11, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose127:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose128:
+ax_pose 13, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose129:
+ax_pose 14, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose130:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose131:
+ax_pose 16, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose132:
+ax_pose 17, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose133:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose134:
+ax_pose 19, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose135:
+ax_pose 20, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose136:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose137:
+ax_pose 22, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose138:
+ax_pose 23, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose139:
+ax_pose 25, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose140:
+ax_pose 39, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose141:
+ax_pose 37, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose142:
+ax_pose 35, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose143:
+ax_pose 33, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose144:
+ax_pose 31, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose145:
+ax_pose 29, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose146:
+ax_pose 27, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose147:
+ax_pose 24, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose148:
+ax_pose 26, 0x01e6, 0x80f6, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose149:
+ax_pose 28, 0x01e6, 0x80f6, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose150:
+ax_pose 30, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose151:
+ax_pose 32, 0x01e5, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose152:
+ax_pose 34, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose153:
+ax_pose 36, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose154:
+ax_pose 38, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose155:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose156:
+ax_pose 24, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose157:
+ax_pose 25, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose158:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose159:
+ax_pose 26, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose160:
+ax_pose 27, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose161:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose162:
+ax_pose 28, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose163:
+ax_pose 29, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose164:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose165:
+ax_pose 30, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose166:
+ax_pose 31, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose167:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose168:
+ax_pose 32, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose169:
+ax_pose 33, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose170:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose171:
+ax_pose 34, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose172:
+ax_pose 35, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose173:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose174:
+ax_pose 36, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose175:
+ax_pose 37, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose176:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose177:
+ax_pose 38, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose178:
+ax_pose 39, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose179:
+ax_pose 25, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose180:
+ax_pose 39, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose181:
+ax_pose 37, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose182:
+ax_pose 35, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose183:
+ax_pose 33, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose184:
+ax_pose 31, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose185:
+ax_pose 29, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose186:
+ax_pose 27, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose187:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose188:
+ax_pose 21, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose189:
+ax_pose 18, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose190:
+ax_pose 15, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose191:
+ax_pose 12, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose192:
+ax_pose 9, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose193:
+ax_pose 6, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCastformSnowyPose194:
+ax_pose 3, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+.align 2
+sCastformSnowyAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 17, 0, 1, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 13, 0, 13,
+ax_anim 2, 0, 26, 0, 22, 0, 22,
+ax_anim 2, 1, 26, 1, 22, 1, 22,
+ax_anim 2, 0, 26, 0, 22, 0, 22,
+ax_anim 2, 0, 26, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 13, 0, 13,
+ax_anim_terminator
+sCastformSnowyAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 13, 14, 13, 13,
+ax_anim 2, 0, 29, 21, 23, 21, 20,
+ax_anim 2, 1, 29, 22, 22, 22, 19,
+ax_anim 2, 0, 29, 21, 23, 21, 20,
+ax_anim 2, 0, 29, 22, 22, 22, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sCastformSnowyAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 14, 1, 13, 0,
+ax_anim 2, 0, 32, 21, 3, 21, -1,
+ax_anim 2, 1, 32, 21, 4, 21, 0,
+ax_anim 2, 0, 32, 21, 3, 21, -1,
+ax_anim 2, 0, 32, 21, 4, 21, 0,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sCastformSnowyAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 4, -4, 4, -4,
+ax_anim 1, 0, 33, 10, -9, 10, -10,
+ax_anim 2, 0, 35, 20, -16, 20, -19,
+ax_anim 2, 1, 35, 21, -15, 21, -18,
+ax_anim 2, 0, 35, 20, -16, 20, -19,
+ax_anim 2, 0, 35, 21, -15, 21, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sCastformSnowyAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -10, 0, -11,
+ax_anim 2, 0, 38, 0, -15, 0, -20,
+ax_anim 2, 1, 38, 1, -15, 1, -20,
+ax_anim 2, 0, 38, 0, -15, 0, -20,
+ax_anim 2, 0, 38, 1, -15, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformSnowyAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -4, -4, -4, -4,
+ax_anim 1, 0, 39, -10, -9, -10, -10,
+ax_anim 2, 0, 41, -20, -16, -20, -19,
+ax_anim 2, 1, 41, -21, -15, -21, -18,
+ax_anim 2, 0, 41, -20, -16, -20, -19,
+ax_anim 2, 0, 41, -21, -15, -21, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sCastformSnowyAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -14, 1, -13, 0,
+ax_anim 2, 0, 44, -21, 3, -21, -1,
+ax_anim 2, 1, 44, -21, 4, -21, 0,
+ax_anim 2, 0, 44, -21, 3, -21, -1,
+ax_anim 2, 0, 44, -21, 4, -21, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sCastformSnowyAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -13, 14, -13, 13,
+ax_anim 2, 0, 47, -21, 23, -21, 20,
+ax_anim 2, 1, 47, -22, 22, -22, 19,
+ax_anim 2, 0, 47, -21, 23, -21, 20,
+ax_anim 2, 0, 47, -22, 22, -22, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 48, 0, 13, 0, 13,
+ax_anim 2, 0, 50, 0, 22, 0, 22,
+ax_anim 2, 1, 50, 1, 22, 1, 22,
+ax_anim 2, 0, 50, 0, 22, 0, 22,
+ax_anim 2, 0, 50, 1, 22, 1, 22,
+ax_anim 2, 0, 48, 0, 13, 0, 13,
+ax_anim_terminator
+sCastformSnowyAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 13, 14, 13, 13,
+ax_anim 2, 0, 53, 21, 23, 21, 20,
+ax_anim 2, 1, 53, 22, 22, 22, 19,
+ax_anim 2, 0, 53, 21, 23, 21, 20,
+ax_anim 2, 0, 53, 22, 22, 22, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sCastformSnowyAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 14, 1, 13, 0,
+ax_anim 2, 0, 56, 21, 3, 21, -1,
+ax_anim 2, 1, 56, 21, 4, 21, 0,
+ax_anim 2, 0, 56, 21, 3, 21, -1,
+ax_anim 2, 0, 56, 21, 4, 21, 0,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sCastformSnowyAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 4, -4, 4, -4,
+ax_anim 1, 0, 57, 10, -9, 10, -10,
+ax_anim 2, 0, 59, 20, -16, 20, -19,
+ax_anim 2, 1, 59, 21, -15, 21, -18,
+ax_anim 2, 0, 59, 20, -16, 20, -19,
+ax_anim 2, 0, 59, 21, -15, 21, -18,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sCastformSnowyAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -10, 0, -11,
+ax_anim 2, 0, 62, 0, -15, 0, -20,
+ax_anim 2, 1, 62, 1, -15, 1, -20,
+ax_anim 2, 0, 62, 0, -15, 0, -20,
+ax_anim 2, 0, 62, 1, -15, 1, -20,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformSnowyAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -4, -4, -4, -4,
+ax_anim 1, 0, 63, -10, -9, -10, -10,
+ax_anim 2, 0, 65, -20, -16, -20, -19,
+ax_anim 2, 1, 65, -21, -15, -21, -18,
+ax_anim 2, 0, 65, -20, -16, -20, -19,
+ax_anim 2, 0, 65, -21, -15, -21, -18,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sCastformSnowyAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -14, 1, -13, 0,
+ax_anim 2, 0, 68, -21, 3, -21, -1,
+ax_anim 2, 1, 68, -21, 4, -21, 0,
+ax_anim 2, 0, 68, -21, 3, -21, -1,
+ax_anim 2, 0, 68, -21, 4, -21, 0,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sCastformSnowyAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -13, 14, -13, 13,
+ax_anim 2, 0, 71, -21, 23, -21, 20,
+ax_anim 2, 1, 71, -22, 22, -22, 19,
+ax_anim 2, 0, 71, -21, 23, -21, 20,
+ax_anim 2, 0, 71, -22, 22, -22, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sCastformSnowyAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sCastformSnowyAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 1, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sCastformSnowyAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sCastformSnowyAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sCastformSnowyAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sCastformSnowyAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 92, -5, 1, -5, 1,
+ax_anim 2, 0, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 92, -5, 1, -5, 1,
+ax_anim 2, 0, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 92, -5, 1, -5, 1,
+ax_anim 2, 0, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sCastformSnowyAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_5_1:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 2, 100, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -6, 0, 0,
+ax_anim 1, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 1, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_5_2:
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 1, 0, 102, 0, -4, 0, 0,
+ax_anim 1, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 100, 0, -6, 0, 0,
+ax_anim 1, 2, 99, 0, -7, 0, 0,
+ax_anim 1, 0, 98, 0, -8, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -9, 0, 0,
+ax_anim 1, 0, 101, 0, -8, 0, 0,
+ax_anim 1, 0, 100, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -6, 0, 0,
+ax_anim 1, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 1, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_5_3:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 1, 0, 101, 0, -4, 0, 0,
+ax_anim 1, 0, 100, 0, -5, 0, 0,
+ax_anim 1, 0, 99, 0, -6, 0, 0,
+ax_anim 1, 2, 98, 0, -7, 0, 0,
+ax_anim 1, 0, 97, 0, -8, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -9, 0, 0,
+ax_anim 1, 0, 101, 0, -9, 0, 0,
+ax_anim 1, 0, 100, 0, -8, 0, 0,
+ax_anim 1, 0, 99, 0, -7, 0, 0,
+ax_anim 1, 0, 98, 0, -6, 0, 0,
+ax_anim 1, 0, 97, 0, -5, 0, 0,
+ax_anim 1, 1, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_5_4:
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 1, 0, 100, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -6, 0, 0,
+ax_anim 1, 2, 97, 0, -7, 0, 0,
+ax_anim 1, 0, 96, 0, -8, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -9, 0, 0,
+ax_anim 1, 0, 101, 0, -9, 0, 0,
+ax_anim 1, 0, 100, 0, -9, 0, 0,
+ax_anim 1, 0, 99, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -7, 0, 0,
+ax_anim 1, 0, 97, 0, -6, 0, 0,
+ax_anim 1, 0, 96, 0, -5, 0, 0,
+ax_anim 1, 1, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_5_5:
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 1, 0, 99, 0, -4, 0, 0,
+ax_anim 1, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 97, 0, -6, 0, 0,
+ax_anim 1, 2, 96, 0, -7, 0, 0,
+ax_anim 1, 0, 103, 0, -8, 0, 0,
+ax_anim 1, 0, 102, 0, -9, 0, 0,
+ax_anim 1, 0, 101, 0, -9, 0, 0,
+ax_anim 1, 0, 100, 0, -9, 0, 0,
+ax_anim 1, 0, 99, 0, -9, 0, 0,
+ax_anim 1, 0, 98, 0, -8, 0, 0,
+ax_anim 1, 0, 97, 0, -7, 0, 0,
+ax_anim 1, 0, 96, 0, -6, 0, 0,
+ax_anim 1, 0, 103, 0, -5, 0, 0,
+ax_anim 1, 1, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_5_6:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 1, 0, 98, 0, -4, 0, 0,
+ax_anim 1, 0, 97, 0, -5, 0, 0,
+ax_anim 1, 0, 96, 0, -6, 0, 0,
+ax_anim 1, 2, 103, 0, -7, 0, 0,
+ax_anim 1, 0, 102, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -9, 0, 0,
+ax_anim 1, 0, 100, 0, -9, 0, 0,
+ax_anim 1, 0, 99, 0, -9, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -8, 0, 0,
+ax_anim 1, 0, 96, 0, -7, 0, 0,
+ax_anim 1, 0, 103, 0, -6, 0, 0,
+ax_anim 1, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 1, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_5_7:
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 1, 0, 97, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -5, 0, 0,
+ax_anim 1, 0, 103, 0, -6, 0, 0,
+ax_anim 1, 2, 102, 0, -7, 0, 0,
+ax_anim 1, 0, 101, 0, -8, 0, 0,
+ax_anim 1, 0, 100, 0, -9, 0, 0,
+ax_anim 1, 0, 99, 0, -9, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -8, 0, 0,
+ax_anim 1, 0, 103, 0, -7, 0, 0,
+ax_anim 1, 0, 102, 0, -6, 0, 0,
+ax_anim 1, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 1, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_5_8:
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 1, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 103, 0, -5, 0, 0,
+ax_anim 1, 0, 102, 0, -6, 0, 0,
+ax_anim 1, 2, 101, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -8, 0, 0,
+ax_anim 1, 0, 99, 0, -9, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 103, 0, -8, 0, 0,
+ax_anim 1, 0, 102, 0, -7, 0, 0,
+ax_anim 1, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 0, 100, 0, -5, 0, 0,
+ax_anim 1, 1, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_6_1:
+ax_anim 10, 0, 104, 0, 0, 0, 0,
+ax_anim 10, 0, 104, 0, -1, 0, 0,
+ax_anim 16, 0, 104, 0, -2, 0, 0,
+ax_anim 10, 0, 105, 0, -2, 0, 0,
+ax_anim 10, 0, 105, 0, -1, 0, 0,
+ax_anim 16, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sCastformSnowyAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sCastformSnowyAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sCastformSnowyAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sCastformSnowyAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sCastformSnowyAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sCastformSnowyAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sCastformSnowyAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_8_1:
+ax_anim 8, 0, 114, 0, 0, 0, 0,
+ax_anim 12, 0, 115, 1, 0, 1, 0,
+ax_anim 8, 0, 116, 0, 0, 0, 0,
+ax_anim 12, 0, 115, -1, 0, -1, 0,
+ax_anim_terminator
+sCastformSnowyAnims_8_2:
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 12, 0, 118, 1, -1, 1, -1,
+ax_anim 8, 0, 119, 0, 0, 0, 0,
+ax_anim 12, 0, 118, -1, 1, -1, 1,
+ax_anim_terminator
+sCastformSnowyAnims_8_3:
+ax_anim 8, 0, 120, 0, 0, 0, 0,
+ax_anim 12, 0, 121, 0, -1, 0, -1,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 12, 0, 121, 0, 1, 0, 1,
+ax_anim_terminator
+sCastformSnowyAnims_8_4:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 12, 0, 124, -1, -1, -1, -1,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 12, 0, 124, 1, 1, 1, 1,
+ax_anim_terminator
+sCastformSnowyAnims_8_5:
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 12, 0, 127, -1, 0, -1, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 127, 1, 0, 1, 0,
+ax_anim_terminator
+sCastformSnowyAnims_8_6:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 1, -1, 1, -1,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 130, -1, 1, -1, 1,
+ax_anim_terminator
+sCastformSnowyAnims_8_7:
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 133, 0, -1, 0, -1,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 12, 0, 133, 0, 1, 0, 1,
+ax_anim_terminator
+sCastformSnowyAnims_8_8:
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 136, -1, -1, -1, -1,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 9, 10, 9, 10,
+ax_anim 2, 0, 141, 7, 22, 7, 22,
+ax_anim 3, 0, 142, 0, 26, 0, 24,
+ax_anim 2, 3, 143, -7, 22, -7, 22,
+ax_anim 2, 0, 144, -9, 10, -9, 10,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 19, 3, 19, 3,
+ax_anim 2, 0, 140, 24, 16, 24, 15,
+ax_anim 3, 0, 141, 22, 25, 22, 23,
+ax_anim 2, 3, 142, 12, 26, 12, 24,
+ax_anim 2, 0, 143, 3, 19, 3, 19,
+ax_anim 1, 0, 144, 0, 8, 0, 8,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 22, -2, 22, -2,
+ax_anim 3, 0, 140, 23, 3, 23, 1,
+ax_anim 2, 3, 141, 20, 9, 20, 7,
+ax_anim 2, 0, 142, 12, 11, 12, 10,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 3, -13, 3, -13,
+ax_anim 2, 0, 138, 14, -18, 14, -18,
+ax_anim 3, 0, 139, 23, -17, 23, -19,
+ax_anim 2, 3, 140, 23, -11, 23, -12,
+ax_anim 2, 0, 141, 17, -3, 17, -3,
+ax_anim 1, 0, 142, 8, 1, 8, 1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -11, -9, -11,
+ax_anim 2, 0, 145, -7, -16, -7, -17,
+ax_anim 3, 0, 138, 0, -18, 0, -20,
+ax_anim 2, 3, 139, 7, -16, 7, -17,
+ax_anim 2, 0, 140, 9, -11, 9, -11,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -3, -13, -3, -13,
+ax_anim 2, 0, 138, -14, -18, -14, -18,
+ax_anim 3, 0, 145, -23, -17, -23, -19,
+ax_anim 2, 3, 144, -24, -12, -23, -12,
+ax_anim 2, 0, 143, -17, -4, -17, -3,
+ax_anim 1, 0, 142, -8, -1, -8, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -22, -2, -22, -2,
+ax_anim 3, 0, 144, -23, 3, -23, 1,
+ax_anim 2, 3, 143, -20, 9, -20, 7,
+ax_anim 2, 0, 142, -12, 11, -12, 10,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -19, 3, -19, 3,
+ax_anim 2, 0, 144, -24, 16, -24, 15,
+ax_anim 3, 0, 143, -22, 25, -22, 23,
+ax_anim 2, 3, 142, -12, 26, -12, 24,
+ax_anim 2, 0, 141, -3, 19, -3, 19,
+ax_anim 1, 0, 140, 0, 8, 0, 8,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 156, 0, -23, 0, 0,
+ax_anim 2, 0, 156, 0, -19, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 4, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -22, 0, 0,
+ax_anim 3, 0, 159, 0, -21, 0, 0,
+ax_anim 2, 0, 159, 0, -19, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 4, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 4, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 4, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 2, 168, 0, 5, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 4, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -19, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 4, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSnowyAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSnowyGfx1:
+.incbin "baserom.gba", 0x1469D3C, 0x200
+sCastformSnowySprites1:
+ax_sprite sCastformSnowyGfx1, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx2:
+.incbin "baserom.gba", 0x1469F4C, 0x200
+sCastformSnowySprites2:
+ax_sprite sCastformSnowyGfx2, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx3:
+.incbin "baserom.gba", 0x146A15C, 0x200
+sCastformSnowySprites3:
+ax_sprite sCastformSnowyGfx3, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx4:
+.incbin "baserom.gba", 0x146A36C, 0x200
+sCastformSnowySprites4:
+ax_sprite sCastformSnowyGfx4, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx5:
+.incbin "baserom.gba", 0x146A57C, 0x200
+sCastformSnowySprites5:
+ax_sprite sCastformSnowyGfx5, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx6:
+.incbin "baserom.gba", 0x146A78C, 0x200
+sCastformSnowySprites6:
+ax_sprite sCastformSnowyGfx6, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx7:
+.incbin "baserom.gba", 0x146A99C, 0x200
+sCastformSnowySprites7:
+ax_sprite sCastformSnowyGfx7, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx8:
+.incbin "baserom.gba", 0x146ABAC, 0x200
+sCastformSnowySprites8:
+ax_sprite sCastformSnowyGfx8, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx9:
+.incbin "baserom.gba", 0x146ADBC, 0x200
+sCastformSnowySprites9:
+ax_sprite sCastformSnowyGfx9, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx10:
+.incbin "baserom.gba", 0x146AFCC, 0x200
+sCastformSnowySprites10:
+ax_sprite sCastformSnowyGfx10, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx11:
+.incbin "baserom.gba", 0x146B1DC, 0x200
+sCastformSnowySprites11:
+ax_sprite sCastformSnowyGfx11, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx12:
+.incbin "baserom.gba", 0x146B3EC, 0x200
+sCastformSnowySprites12:
+ax_sprite sCastformSnowyGfx12, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx13:
+.incbin "baserom.gba", 0x146B5FC, 0x200
+sCastformSnowySprites13:
+ax_sprite sCastformSnowyGfx13, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx14:
+.incbin "baserom.gba", 0x146B80C, 0x200
+sCastformSnowySprites14:
+ax_sprite sCastformSnowyGfx14, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx15:
+.incbin "baserom.gba", 0x146BA1C, 0x200
+sCastformSnowySprites15:
+ax_sprite sCastformSnowyGfx15, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx16:
+.incbin "baserom.gba", 0x146BC2C, 0x200
+sCastformSnowySprites16:
+ax_sprite sCastformSnowyGfx16, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx17:
+.incbin "baserom.gba", 0x146BE3C, 0x200
+sCastformSnowySprites17:
+ax_sprite sCastformSnowyGfx17, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx18:
+.incbin "baserom.gba", 0x146C04C, 0x200
+sCastformSnowySprites18:
+ax_sprite sCastformSnowyGfx18, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx19:
+.incbin "baserom.gba", 0x146C25C, 0x200
+sCastformSnowySprites19:
+ax_sprite sCastformSnowyGfx19, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx20:
+.incbin "baserom.gba", 0x146C46C, 0x200
+sCastformSnowySprites20:
+ax_sprite sCastformSnowyGfx20, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx21:
+.incbin "baserom.gba", 0x146C67C, 0x200
+sCastformSnowySprites21:
+ax_sprite sCastformSnowyGfx21, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx22:
+.incbin "baserom.gba", 0x146C88C, 0x200
+sCastformSnowySprites22:
+ax_sprite sCastformSnowyGfx22, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx23:
+.incbin "baserom.gba", 0x146CA9C, 0x200
+sCastformSnowySprites23:
+ax_sprite sCastformSnowyGfx23, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx24:
+.incbin "baserom.gba", 0x146CCAC, 0x200
+sCastformSnowySprites24:
+ax_sprite sCastformSnowyGfx24, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx25:
+.incbin "baserom.gba", 0x146CEBC, 0x60
+sCastformSnowyGfx25_1:
+.incbin "baserom.gba", 0x146CF1C, 0x60
+sCastformSnowyGfx25_2:
+.incbin "baserom.gba", 0x146CF7C, 0x60
+sCastformSnowySprites25:
+ax_sprite sCastformSnowyGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx26:
+.incbin "baserom.gba", 0x146D014, 0x60
+sCastformSnowyGfx26_1:
+.incbin "baserom.gba", 0x146D074, 0x60
+sCastformSnowyGfx26_2:
+.incbin "baserom.gba", 0x146D0D4, 0x60
+sCastformSnowyGfx26_3:
+.incbin "baserom.gba", 0x146D134, 0x20
+sCastformSnowySprites26:
+ax_sprite sCastformSnowyGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSnowyGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSnowyGfx27:
+.incbin "baserom.gba", 0x146D19C, 0x40
+sCastformSnowyGfx27_1:
+.incbin "baserom.gba", 0x146D1DC, 0x60
+sCastformSnowyGfx27_2:
+.incbin "baserom.gba", 0x146D23C, 0x60
+sCastformSnowySprites27:
+ax_sprite sCastformSnowyGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCastformSnowyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx28:
+.incbin "baserom.gba", 0x146D2D4, 0x60
+sCastformSnowyGfx28_1:
+.incbin "baserom.gba", 0x146D334, 0x60
+sCastformSnowyGfx28_2:
+.incbin "baserom.gba", 0x146D394, 0x60
+sCastformSnowyGfx28_3:
+.incbin "baserom.gba", 0x146D3F4, 0x40
+sCastformSnowySprites28:
+ax_sprite sCastformSnowyGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSnowyGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCastformSnowyGfx29:
+.incbin "baserom.gba", 0x146D47C, 0x40
+sCastformSnowyGfx29_1:
+.incbin "baserom.gba", 0x146D4BC, 0x60
+sCastformSnowyGfx29_2:
+.incbin "baserom.gba", 0x146D51C, 0x60
+sCastformSnowySprites29:
+ax_sprite sCastformSnowyGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCastformSnowyGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx30:
+.incbin "baserom.gba", 0x146D5B4, 0x60
+sCastformSnowyGfx30_1:
+.incbin "baserom.gba", 0x146D614, 0x60
+sCastformSnowyGfx30_2:
+.incbin "baserom.gba", 0x146D674, 0x60
+sCastformSnowySprites30:
+ax_sprite sCastformSnowyGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx31:
+.incbin "baserom.gba", 0x146D70C, 0x60
+sCastformSnowyGfx31_1:
+.incbin "baserom.gba", 0x146D76C, 0x60
+sCastformSnowyGfx31_2:
+.incbin "baserom.gba", 0x146D7CC, 0x60
+sCastformSnowyGfx31_3:
+.incbin "baserom.gba", 0x146D82C, 0x20
+sCastformSnowySprites31:
+ax_sprite sCastformSnowyGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx31_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSnowyGfx31_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSnowyGfx32:
+.incbin "baserom.gba", 0x146D894, 0x60
+sCastformSnowyGfx32_1:
+.incbin "baserom.gba", 0x146D8F4, 0x60
+sCastformSnowyGfx32_2:
+.incbin "baserom.gba", 0x146D954, 0x60
+sCastformSnowySprites32:
+ax_sprite sCastformSnowyGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx33:
+.incbin "baserom.gba", 0x146D9EC, 0x60
+sCastformSnowyGfx33_1:
+.incbin "baserom.gba", 0x146DA4C, 0x60
+sCastformSnowyGfx33_2:
+.incbin "baserom.gba", 0x146DAAC, 0x60
+sCastformSnowySprites33:
+ax_sprite sCastformSnowyGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx34:
+.incbin "baserom.gba", 0x146DB44, 0x60
+sCastformSnowyGfx34_1:
+.incbin "baserom.gba", 0x146DBA4, 0x60
+sCastformSnowyGfx34_2:
+.incbin "baserom.gba", 0x146DC04, 0x60
+sCastformSnowySprites34:
+ax_sprite sCastformSnowyGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx35:
+.incbin "baserom.gba", 0x146DC9C, 0x60
+sCastformSnowyGfx35_1:
+.incbin "baserom.gba", 0x146DCFC, 0x60
+sCastformSnowyGfx35_2:
+.incbin "baserom.gba", 0x146DD5C, 0x60
+sCastformSnowyGfx35_3:
+.incbin "baserom.gba", 0x146DDBC, 0x20
+sCastformSnowySprites35:
+ax_sprite sCastformSnowyGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSnowyGfx35_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSnowyGfx36:
+.incbin "baserom.gba", 0x146DE24, 0x60
+sCastformSnowyGfx36_1:
+.incbin "baserom.gba", 0x146DE84, 0x60
+sCastformSnowyGfx36_2:
+.incbin "baserom.gba", 0x146DEE4, 0x60
+sCastformSnowySprites36:
+ax_sprite sCastformSnowyGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx37:
+.incbin "baserom.gba", 0x146DF7C, 0x60
+sCastformSnowyGfx37_1:
+.incbin "baserom.gba", 0x146DFDC, 0x60
+sCastformSnowyGfx37_2:
+.incbin "baserom.gba", 0x146E03C, 0x60
+sCastformSnowySprites37:
+ax_sprite sCastformSnowyGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx38:
+.incbin "baserom.gba", 0x146E0D4, 0x60
+sCastformSnowyGfx38_1:
+.incbin "baserom.gba", 0x146E134, 0x60
+sCastformSnowyGfx38_2:
+.incbin "baserom.gba", 0x146E194, 0x60
+sCastformSnowySprites38:
+ax_sprite sCastformSnowyGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx39:
+.incbin "baserom.gba", 0x146E22C, 0x60
+sCastformSnowyGfx39_1:
+.incbin "baserom.gba", 0x146E28C, 0x60
+sCastformSnowyGfx39_2:
+.incbin "baserom.gba", 0x146E2EC, 0x60
+sCastformSnowySprites39:
+ax_sprite sCastformSnowyGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx39_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSnowyGfx40:
+.incbin "baserom.gba", 0x146E384, 0x60
+sCastformSnowyGfx40_1:
+.incbin "baserom.gba", 0x146E3E4, 0x60
+sCastformSnowyGfx40_2:
+.incbin "baserom.gba", 0x146E444, 0x60
+sCastformSnowyGfx40_3:
+.incbin "baserom.gba", 0x146E4A4, 0x40
+sCastformSnowySprites40:
+ax_sprite sCastformSnowyGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSnowyGfx40_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSnowyGfx41:
+.incbin "baserom.gba", 0x146E52C, 0x200
+sCastformSnowySprites41:
+ax_sprite sCastformSnowyGfx41, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx42:
+.incbin "baserom.gba", 0x146E73C, 0x200
+sCastformSnowySprites42:
+ax_sprite sCastformSnowyGfx42, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx43:
+.incbin "baserom.gba", 0x146E94C, 0x200
+sCastformSnowySprites43:
+ax_sprite sCastformSnowyGfx43, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx44:
+.incbin "baserom.gba", 0x146EB5C, 0x200
+sCastformSnowySprites44:
+ax_sprite sCastformSnowyGfx44, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx45:
+.incbin "baserom.gba", 0x146ED6C, 0x200
+sCastformSnowySprites45:
+ax_sprite sCastformSnowyGfx45, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx46:
+.incbin "baserom.gba", 0x146EF7C, 0x200
+sCastformSnowySprites46:
+ax_sprite sCastformSnowyGfx46, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx47:
+.incbin "baserom.gba", 0x146F18C, 0x200
+sCastformSnowySprites47:
+ax_sprite sCastformSnowyGfx47, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx48:
+.incbin "baserom.gba", 0x146F39C, 0x200
+sCastformSnowySprites48:
+ax_sprite sCastformSnowyGfx48, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx49:
+.incbin "baserom.gba", 0x146F5AC, 0x200
+sCastformSnowySprites49:
+ax_sprite sCastformSnowyGfx49, 0x200
+ax_sprite_terminator
+sCastformSnowyGfx50:
+.incbin "baserom.gba", 0x146F7BC, 0x200
+sCastformSnowySprites50:
+ax_sprite sCastformSnowyGfx50, 0x200
+ax_sprite_terminator
+sAxPosesCastformSnowy:
+.4byte sCastformSnowyPose1
+.4byte sCastformSnowyPose2
+.4byte sCastformSnowyPose3
+.4byte sCastformSnowyPose4
+.4byte sCastformSnowyPose5
+.4byte sCastformSnowyPose6
+.4byte sCastformSnowyPose7
+.4byte sCastformSnowyPose8
+.4byte sCastformSnowyPose9
+.4byte sCastformSnowyPose10
+.4byte sCastformSnowyPose11
+.4byte sCastformSnowyPose12
+.4byte sCastformSnowyPose13
+.4byte sCastformSnowyPose14
+.4byte sCastformSnowyPose15
+.4byte sCastformSnowyPose16
+.4byte sCastformSnowyPose17
+.4byte sCastformSnowyPose18
+.4byte sCastformSnowyPose19
+.4byte sCastformSnowyPose20
+.4byte sCastformSnowyPose21
+.4byte sCastformSnowyPose22
+.4byte sCastformSnowyPose23
+.4byte sCastformSnowyPose24
+.4byte sCastformSnowyPose25
+.4byte sCastformSnowyPose26
+.4byte sCastformSnowyPose27
+.4byte sCastformSnowyPose28
+.4byte sCastformSnowyPose29
+.4byte sCastformSnowyPose30
+.4byte sCastformSnowyPose31
+.4byte sCastformSnowyPose32
+.4byte sCastformSnowyPose33
+.4byte sCastformSnowyPose34
+.4byte sCastformSnowyPose35
+.4byte sCastformSnowyPose36
+.4byte sCastformSnowyPose37
+.4byte sCastformSnowyPose38
+.4byte sCastformSnowyPose39
+.4byte sCastformSnowyPose40
+.4byte sCastformSnowyPose41
+.4byte sCastformSnowyPose42
+.4byte sCastformSnowyPose43
+.4byte sCastformSnowyPose44
+.4byte sCastformSnowyPose45
+.4byte sCastformSnowyPose46
+.4byte sCastformSnowyPose47
+.4byte sCastformSnowyPose48
+.4byte sCastformSnowyPose49
+.4byte sCastformSnowyPose50
+.4byte sCastformSnowyPose51
+.4byte sCastformSnowyPose52
+.4byte sCastformSnowyPose53
+.4byte sCastformSnowyPose54
+.4byte sCastformSnowyPose55
+.4byte sCastformSnowyPose56
+.4byte sCastformSnowyPose57
+.4byte sCastformSnowyPose58
+.4byte sCastformSnowyPose59
+.4byte sCastformSnowyPose60
+.4byte sCastformSnowyPose61
+.4byte sCastformSnowyPose62
+.4byte sCastformSnowyPose63
+.4byte sCastformSnowyPose64
+.4byte sCastformSnowyPose65
+.4byte sCastformSnowyPose66
+.4byte sCastformSnowyPose67
+.4byte sCastformSnowyPose68
+.4byte sCastformSnowyPose69
+.4byte sCastformSnowyPose70
+.4byte sCastformSnowyPose71
+.4byte sCastformSnowyPose72
+.4byte sCastformSnowyPose73
+.4byte sCastformSnowyPose74
+.4byte sCastformSnowyPose75
+.4byte sCastformSnowyPose76
+.4byte sCastformSnowyPose77
+.4byte sCastformSnowyPose78
+.4byte sCastformSnowyPose79
+.4byte sCastformSnowyPose80
+.4byte sCastformSnowyPose81
+.4byte sCastformSnowyPose82
+.4byte sCastformSnowyPose83
+.4byte sCastformSnowyPose84
+.4byte sCastformSnowyPose85
+.4byte sCastformSnowyPose86
+.4byte sCastformSnowyPose87
+.4byte sCastformSnowyPose88
+.4byte sCastformSnowyPose89
+.4byte sCastformSnowyPose90
+.4byte sCastformSnowyPose91
+.4byte sCastformSnowyPose92
+.4byte sCastformSnowyPose93
+.4byte sCastformSnowyPose94
+.4byte sCastformSnowyPose95
+.4byte sCastformSnowyPose96
+.4byte sCastformSnowyPose97
+.4byte sCastformSnowyPose98
+.4byte sCastformSnowyPose99
+.4byte sCastformSnowyPose100
+.4byte sCastformSnowyPose101
+.4byte sCastformSnowyPose102
+.4byte sCastformSnowyPose103
+.4byte sCastformSnowyPose104
+.4byte sCastformSnowyPose105
+.4byte sCastformSnowyPose106
+.4byte sCastformSnowyPose107
+.4byte sCastformSnowyPose108
+.4byte sCastformSnowyPose109
+.4byte sCastformSnowyPose110
+.4byte sCastformSnowyPose111
+.4byte sCastformSnowyPose112
+.4byte sCastformSnowyPose113
+.4byte sCastformSnowyPose114
+.4byte sCastformSnowyPose115
+.4byte sCastformSnowyPose116
+.4byte sCastformSnowyPose117
+.4byte sCastformSnowyPose118
+.4byte sCastformSnowyPose119
+.4byte sCastformSnowyPose120
+.4byte sCastformSnowyPose121
+.4byte sCastformSnowyPose122
+.4byte sCastformSnowyPose123
+.4byte sCastformSnowyPose124
+.4byte sCastformSnowyPose125
+.4byte sCastformSnowyPose126
+.4byte sCastformSnowyPose127
+.4byte sCastformSnowyPose128
+.4byte sCastformSnowyPose129
+.4byte sCastformSnowyPose130
+.4byte sCastformSnowyPose131
+.4byte sCastformSnowyPose132
+.4byte sCastformSnowyPose133
+.4byte sCastformSnowyPose134
+.4byte sCastformSnowyPose135
+.4byte sCastformSnowyPose136
+.4byte sCastformSnowyPose137
+.4byte sCastformSnowyPose138
+.4byte sCastformSnowyPose139
+.4byte sCastformSnowyPose140
+.4byte sCastformSnowyPose141
+.4byte sCastformSnowyPose142
+.4byte sCastformSnowyPose143
+.4byte sCastformSnowyPose144
+.4byte sCastformSnowyPose145
+.4byte sCastformSnowyPose146
+.4byte sCastformSnowyPose147
+.4byte sCastformSnowyPose148
+.4byte sCastformSnowyPose149
+.4byte sCastformSnowyPose150
+.4byte sCastformSnowyPose151
+.4byte sCastformSnowyPose152
+.4byte sCastformSnowyPose153
+.4byte sCastformSnowyPose154
+.4byte sCastformSnowyPose155
+.4byte sCastformSnowyPose156
+.4byte sCastformSnowyPose157
+.4byte sCastformSnowyPose158
+.4byte sCastformSnowyPose159
+.4byte sCastformSnowyPose160
+.4byte sCastformSnowyPose161
+.4byte sCastformSnowyPose162
+.4byte sCastformSnowyPose163
+.4byte sCastformSnowyPose164
+.4byte sCastformSnowyPose165
+.4byte sCastformSnowyPose166
+.4byte sCastformSnowyPose167
+.4byte sCastformSnowyPose168
+.4byte sCastformSnowyPose169
+.4byte sCastformSnowyPose170
+.4byte sCastformSnowyPose171
+.4byte sCastformSnowyPose172
+.4byte sCastformSnowyPose173
+.4byte sCastformSnowyPose174
+.4byte sCastformSnowyPose175
+.4byte sCastformSnowyPose176
+.4byte sCastformSnowyPose177
+.4byte sCastformSnowyPose178
+.4byte sCastformSnowyPose179
+.4byte sCastformSnowyPose180
+.4byte sCastformSnowyPose181
+.4byte sCastformSnowyPose182
+.4byte sCastformSnowyPose183
+.4byte sCastformSnowyPose184
+.4byte sCastformSnowyPose185
+.4byte sCastformSnowyPose186
+.4byte sCastformSnowyPose187
+.4byte sCastformSnowyPose188
+.4byte sCastformSnowyPose189
+.4byte sCastformSnowyPose190
+.4byte sCastformSnowyPose191
+.4byte sCastformSnowyPose192
+.4byte sCastformSnowyPose193
+.4byte sCastformSnowyPose194
+sAxPositionsCastformSnowy:
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -11, 	  -8,   -8, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -11, 	  -8,   -8, 	   6,   -9, 	  -1,  -13
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	  -1,  -12
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	  -1,  -12
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	   0,  -13
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -13, 	   0,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -12, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -3,  -11, 	  -8,  -11, 	   4,   -7, 	  -1,  -12
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -8,  -12, 	   6,  -12, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -7, 	   6,   -7, 	  -1,  -10
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+.2byte   -1,  -14, 	  -5,   -9, 	   5,  -14, 	  -1,  -15
+.2byte    1,   -8, 	  -5,   -5, 	   6,   -8, 	   0,  -11
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -15, 	   5,  -12, 	   0,  -14, 	  -2,  -14
+.2byte    4,  -10, 	   4,   -5, 	   0,  -11, 	   1,  -11
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    0,  -15, 	   6,  -12, 	  -5,  -13, 	  -3,  -12
+.2byte    1,  -12, 	   5,   -6, 	  -3,  -11, 	   0,  -14
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -15, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   6,  -10, 	  -8,  -10, 	  -1,  -16
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -14, 	   3,  -14, 	  -8,  -12, 	   1,  -13
+.2byte   -5,  -11, 	  -1,  -13, 	  -7,   -6, 	  -2,  -13
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -3,  -14, 	  -3,  -12, 	  -2,   -7, 	   0,  -14
+.2byte   -5,   -8, 	  -4,  -10, 	   3,   -6, 	  -2,  -11
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	  -7,  -14, 	   3,  -10, 	   0,  -14
+.2byte   -4,   -9, 	  -8,   -8, 	   3,   -5, 	  -2,  -11
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -8,  -12, 	   6,  -12, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -7, 	   6,   -7, 	  -1,  -10
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+.2byte   -1,  -14, 	  -5,   -9, 	   5,  -14, 	  -1,  -15
+.2byte    1,   -8, 	  -5,   -5, 	   6,   -8, 	   0,  -11
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -15, 	   5,  -12, 	   0,  -14, 	  -2,  -14
+.2byte    4,  -10, 	   4,   -5, 	   0,  -11, 	   1,  -11
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    0,  -15, 	   6,  -12, 	  -5,  -13, 	  -3,  -12
+.2byte    1,  -12, 	   5,   -6, 	  -3,  -11, 	   0,  -14
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -15, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   6,  -10, 	  -8,  -10, 	  -1,  -16
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -14, 	   3,  -14, 	  -8,  -12, 	   1,  -13
+.2byte   -5,  -11, 	  -1,  -13, 	  -7,   -6, 	  -2,  -13
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -3,  -14, 	  -3,  -12, 	  -2,   -7, 	   0,  -14
+.2byte   -5,   -8, 	  -4,  -10, 	   3,   -6, 	  -2,  -11
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	  -7,  -14, 	   3,  -10, 	   0,  -14
+.2byte   -4,   -9, 	  -8,   -8, 	   3,   -5, 	  -2,  -11
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -8,  -12, 	   6,  -12, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -7, 	   6,   -7, 	  -1,  -10
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+.2byte   -1,  -14, 	  -5,   -9, 	   5,  -14, 	  -1,  -15
+.2byte    2,   -7, 	  -4,   -4, 	   7,   -7, 	   1,  -10
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -15, 	   5,  -12, 	   0,  -14, 	  -2,  -14
+.2byte    5,  -10, 	   5,   -5, 	   1,  -11, 	   2,  -11
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    0,  -15, 	   6,  -12, 	  -5,  -13, 	  -3,  -12
+.2byte    2,  -13, 	   6,   -7, 	  -2,  -12, 	   1,  -15
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -15, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   6,  -10, 	  -8,  -10, 	  -1,  -16
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -14, 	   3,  -14, 	  -8,  -12, 	   1,  -13
+.2byte   -6,  -12, 	  -2,  -14, 	  -8,   -7, 	  -3,  -14
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -3,  -14, 	  -3,  -12, 	  -2,   -7, 	   0,  -14
+.2byte   -6,   -8, 	  -5,  -10, 	   2,   -6, 	  -3,  -11
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	  -7,  -14, 	   3,  -10, 	   0,  -14
+.2byte   -5,   -8, 	  -9,   -7, 	   2,   -4, 	  -3,  -10
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+.2byte   -3,  -11, 	  -8,  -10, 	   3,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -8,  -10, 	   3,   -7, 	  -1,  -12
+.2byte    0,  -13, 	  -7,  -12, 	   7,  -12, 	   0,  -14
+.2byte    1,  -12, 	  -4,   -8, 	   7,  -13, 	  -1,  -13
+.2byte    2,  -14, 	   6,  -13, 	   0,  -15, 	  -2,  -14
+.2byte    2,  -15, 	   7,  -14, 	  -4,  -17, 	  -1,  -14
+.2byte    0,  -15, 	   7,  -13, 	  -7,  -13, 	   0,  -12
+.2byte   -2,  -17, 	   2,  -17, 	  -8,  -15, 	   1,  -15
+.2byte   -2,  -14, 	  -1,  -13, 	   1,   -8, 	   2,  -14
+.2byte    0,  -13, 	  -5,  -13, 	   6,   -6, 	   2,  -13
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -11, 	  -8,   -8, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -11, 	  -8,   -8, 	   6,   -9, 	  -1,  -13
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	  -1,  -12
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	  -1,  -12
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	   0,  -13
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -13, 	   0,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -12, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -3,  -11, 	  -8,  -11, 	   4,   -7, 	  -1,  -12
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -1,   -8, 	  -8,   -7, 	   6,   -7, 	  -1,  -10
+.2byte   -4,   -9, 	  -8,   -8, 	   3,   -5, 	  -2,  -11
+.2byte   -4,   -8, 	  -3,  -10, 	   4,   -6, 	  -1,  -11
+.2byte   -4,  -11, 	   0,  -13, 	  -6,   -6, 	  -1,  -13
+.2byte   -1,  -13, 	   6,   -9, 	  -8,   -9, 	  -1,  -15
+.2byte    2,  -12, 	   6,   -6, 	  -2,  -11, 	   1,  -14
+.2byte    5,  -10, 	   5,   -5, 	   1,  -11, 	   2,  -11
+.2byte    1,   -8, 	  -5,   -5, 	   6,   -8, 	   0,  -11
+.2byte   -1,  -14, 	  -8,  -12, 	   6,  -12, 	  -1,  -15
+.2byte    1,  -14, 	  -3,   -9, 	   7,  -14, 	   1,  -15
+.2byte    4,  -15, 	   7,  -12, 	   2,  -14, 	   0,  -14
+.2byte    1,  -17, 	   7,  -14, 	  -4,  -15, 	  -2,  -14
+.2byte   -1,  -16, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -3,  -15, 	   2,  -15, 	  -9,  -13, 	   0,  -14
+.2byte   -4,  -14, 	  -4,  -12, 	  -3,   -7, 	  -1,  -14
+.2byte   -2,  -14, 	  -8,  -14, 	   2,  -10, 	  -1,  -14
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -1,  -14, 	  -8,  -12, 	   6,  -12, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -7, 	   6,   -7, 	  -1,  -10
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+.2byte   -1,  -14, 	  -5,   -9, 	   5,  -14, 	  -1,  -15
+.2byte    1,   -8, 	  -5,   -5, 	   6,   -8, 	   0,  -11
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -15, 	   5,  -12, 	   0,  -14, 	  -2,  -14
+.2byte    4,  -10, 	   4,   -5, 	   0,  -11, 	   1,  -11
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    0,  -15, 	   6,  -12, 	  -5,  -13, 	  -3,  -12
+.2byte    1,  -12, 	   5,   -6, 	  -3,  -11, 	   0,  -14
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -15, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   6,  -10, 	  -8,  -10, 	  -1,  -16
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -2,  -14, 	   3,  -14, 	  -8,  -12, 	   1,  -13
+.2byte   -5,  -11, 	  -1,  -13, 	  -7,   -6, 	  -2,  -13
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -3,  -14, 	  -3,  -12, 	  -2,   -7, 	   0,  -14
+.2byte   -5,   -8, 	  -4,  -10, 	   3,   -6, 	  -2,  -11
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	  -7,  -14, 	   3,  -10, 	   0,  -14
+.2byte   -4,   -9, 	  -8,   -8, 	   3,   -5, 	  -2,  -11
+.2byte   -1,   -8, 	  -8,   -7, 	   6,   -7, 	  -1,  -10
+.2byte   -4,   -9, 	  -8,   -8, 	   3,   -5, 	  -2,  -11
+.2byte   -4,   -8, 	  -3,  -10, 	   4,   -6, 	  -1,  -11
+.2byte   -4,  -11, 	   0,  -13, 	  -6,   -6, 	  -1,  -13
+.2byte   -1,  -13, 	   6,   -9, 	  -8,   -9, 	  -1,  -15
+.2byte    1,  -12, 	   5,   -6, 	  -3,  -11, 	   0,  -14
+.2byte    5,  -10, 	   5,   -5, 	   1,  -11, 	   2,  -11
+.2byte    1,   -8, 	  -5,   -5, 	   6,   -8, 	   0,  -11
+.2byte   -1,  -11, 	  -8,   -9, 	   6,   -9, 	  -1,  -13
+.2byte   -3,  -11, 	  -8,  -10, 	   4,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   1,   -7, 	  -1,  -12
+.2byte   -2,  -13, 	   1,  -13, 	  -8,  -10, 	  -1,  -14
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte    4,  -14, 	   6,  -10, 	  -5,  -13, 	  -1,  -13
+.2byte    2,  -11, 	  -3,   -7, 	  -1,  -12, 	  -1,  -13
+.2byte    2,  -11, 	  -6,   -7, 	   6,  -11, 	   0,  -12
+sCastformSnowyAnimTable1:
+.4byte sCastformSnowyAnims_1_1
+.4byte sCastformSnowyAnims_1_2
+.4byte sCastformSnowyAnims_1_3
+.4byte sCastformSnowyAnims_1_4
+.4byte sCastformSnowyAnims_1_5
+.4byte sCastformSnowyAnims_1_6
+.4byte sCastformSnowyAnims_1_7
+.4byte sCastformSnowyAnims_1_8
+sCastformSnowyAnimTable2:
+.4byte sCastformSnowyAnims_2_1
+.4byte sCastformSnowyAnims_2_2
+.4byte sCastformSnowyAnims_2_3
+.4byte sCastformSnowyAnims_2_4
+.4byte sCastformSnowyAnims_2_5
+.4byte sCastformSnowyAnims_2_6
+.4byte sCastformSnowyAnims_2_7
+.4byte sCastformSnowyAnims_2_8
+sCastformSnowyAnimTable3:
+.4byte sCastformSnowyAnims_3_1
+.4byte sCastformSnowyAnims_3_2
+.4byte sCastformSnowyAnims_3_3
+.4byte sCastformSnowyAnims_3_4
+.4byte sCastformSnowyAnims_3_5
+.4byte sCastformSnowyAnims_3_6
+.4byte sCastformSnowyAnims_3_7
+.4byte sCastformSnowyAnims_3_8
+sCastformSnowyAnimTable4:
+.4byte sCastformSnowyAnims_4_1
+.4byte sCastformSnowyAnims_4_2
+.4byte sCastformSnowyAnims_4_3
+.4byte sCastformSnowyAnims_4_4
+.4byte sCastformSnowyAnims_4_5
+.4byte sCastformSnowyAnims_4_6
+.4byte sCastformSnowyAnims_4_7
+.4byte sCastformSnowyAnims_4_8
+sCastformSnowyAnimTable5:
+.4byte sCastformSnowyAnims_5_1
+.4byte sCastformSnowyAnims_5_2
+.4byte sCastformSnowyAnims_5_3
+.4byte sCastformSnowyAnims_5_4
+.4byte sCastformSnowyAnims_5_5
+.4byte sCastformSnowyAnims_5_6
+.4byte sCastformSnowyAnims_5_7
+.4byte sCastformSnowyAnims_5_8
+sCastformSnowyAnimTable6:
+.4byte sCastformSnowyAnims_6_1
+.4byte sCastformSnowyAnims_6_1
+.4byte sCastformSnowyAnims_6_1
+.4byte sCastformSnowyAnims_6_1
+.4byte sCastformSnowyAnims_6_1
+.4byte sCastformSnowyAnims_6_1
+.4byte sCastformSnowyAnims_6_1
+.4byte sCastformSnowyAnims_6_1
+sCastformSnowyAnimTable7:
+.4byte sCastformSnowyAnims_7_1
+.4byte sCastformSnowyAnims_7_2
+.4byte sCastformSnowyAnims_7_3
+.4byte sCastformSnowyAnims_7_4
+.4byte sCastformSnowyAnims_7_5
+.4byte sCastformSnowyAnims_7_6
+.4byte sCastformSnowyAnims_7_7
+.4byte sCastformSnowyAnims_7_8
+sCastformSnowyAnimTable8:
+.4byte sCastformSnowyAnims_8_1
+.4byte sCastformSnowyAnims_8_2
+.4byte sCastformSnowyAnims_8_3
+.4byte sCastformSnowyAnims_8_4
+.4byte sCastformSnowyAnims_8_5
+.4byte sCastformSnowyAnims_8_6
+.4byte sCastformSnowyAnims_8_7
+.4byte sCastformSnowyAnims_8_8
+sCastformSnowyAnimTable9:
+.4byte sCastformSnowyAnims_9_1
+.4byte sCastformSnowyAnims_9_2
+.4byte sCastformSnowyAnims_9_3
+.4byte sCastformSnowyAnims_9_4
+.4byte sCastformSnowyAnims_9_5
+.4byte sCastformSnowyAnims_9_6
+.4byte sCastformSnowyAnims_9_7
+.4byte sCastformSnowyAnims_9_8
+sCastformSnowyAnimTable10:
+.4byte sCastformSnowyAnims_10_1
+.4byte sCastformSnowyAnims_10_2
+.4byte sCastformSnowyAnims_10_3
+.4byte sCastformSnowyAnims_10_4
+.4byte sCastformSnowyAnims_10_5
+.4byte sCastformSnowyAnims_10_6
+.4byte sCastformSnowyAnims_10_7
+.4byte sCastformSnowyAnims_10_8
+sCastformSnowyAnimTable11:
+.4byte sCastformSnowyAnims_11_1
+.4byte sCastformSnowyAnims_11_2
+.4byte sCastformSnowyAnims_11_3
+.4byte sCastformSnowyAnims_11_4
+.4byte sCastformSnowyAnims_11_5
+.4byte sCastformSnowyAnims_11_6
+.4byte sCastformSnowyAnims_11_7
+.4byte sCastformSnowyAnims_11_8
+sCastformSnowyAnimTable12:
+.4byte sCastformSnowyAnims_12_1
+.4byte sCastformSnowyAnims_12_2
+.4byte sCastformSnowyAnims_12_3
+.4byte sCastformSnowyAnims_12_4
+.4byte sCastformSnowyAnims_12_5
+.4byte sCastformSnowyAnims_12_6
+.4byte sCastformSnowyAnims_12_7
+.4byte sCastformSnowyAnims_12_8
+sCastformSnowyAnimTable13:
+.4byte sCastformSnowyAnims_13_1
+.4byte sCastformSnowyAnims_13_2
+.4byte sCastformSnowyAnims_13_3
+.4byte sCastformSnowyAnims_13_4
+.4byte sCastformSnowyAnims_13_5
+.4byte sCastformSnowyAnims_13_6
+.4byte sCastformSnowyAnims_13_7
+.4byte sCastformSnowyAnims_13_8
+sAxAnimationsCastformSnowy:
+.4byte sCastformSnowyAnimTable1
+.4byte sCastformSnowyAnimTable2
+.4byte sCastformSnowyAnimTable3
+.4byte sCastformSnowyAnimTable4
+.4byte sCastformSnowyAnimTable5
+.4byte sCastformSnowyAnimTable6
+.4byte sCastformSnowyAnimTable7
+.4byte sCastformSnowyAnimTable8
+.4byte sCastformSnowyAnimTable9
+.4byte sCastformSnowyAnimTable10
+.4byte sCastformSnowyAnimTable11
+.4byte sCastformSnowyAnimTable12
+.4byte sCastformSnowyAnimTable13
+sAxSpritesCastformSnowy:
+.4byte sCastformSnowySprites1
+.4byte sCastformSnowySprites2
+.4byte sCastformSnowySprites3
+.4byte sCastformSnowySprites4
+.4byte sCastformSnowySprites5
+.4byte sCastformSnowySprites6
+.4byte sCastformSnowySprites7
+.4byte sCastformSnowySprites8
+.4byte sCastformSnowySprites9
+.4byte sCastformSnowySprites10
+.4byte sCastformSnowySprites11
+.4byte sCastformSnowySprites12
+.4byte sCastformSnowySprites13
+.4byte sCastformSnowySprites14
+.4byte sCastformSnowySprites15
+.4byte sCastformSnowySprites16
+.4byte sCastformSnowySprites17
+.4byte sCastformSnowySprites18
+.4byte sCastformSnowySprites19
+.4byte sCastformSnowySprites20
+.4byte sCastformSnowySprites21
+.4byte sCastformSnowySprites22
+.4byte sCastformSnowySprites23
+.4byte sCastformSnowySprites24
+.4byte sCastformSnowySprites25
+.4byte sCastformSnowySprites26
+.4byte sCastformSnowySprites27
+.4byte sCastformSnowySprites28
+.4byte sCastformSnowySprites29
+.4byte sCastformSnowySprites30
+.4byte sCastformSnowySprites31
+.4byte sCastformSnowySprites32
+.4byte sCastformSnowySprites33
+.4byte sCastformSnowySprites34
+.4byte sCastformSnowySprites35
+.4byte sCastformSnowySprites36
+.4byte sCastformSnowySprites37
+.4byte sCastformSnowySprites38
+.4byte sCastformSnowySprites39
+.4byte sCastformSnowySprites40
+.4byte sCastformSnowySprites41
+.4byte sCastformSnowySprites42
+.4byte sCastformSnowySprites43
+.4byte sCastformSnowySprites44
+.4byte sCastformSnowySprites45
+.4byte sCastformSnowySprites46
+.4byte sCastformSnowySprites47
+.4byte sCastformSnowySprites48
+.4byte sCastformSnowySprites49
+.4byte sCastformSnowySprites50
+sAxMainCastformSnowy:
+ax_main sAxPosesCastformSnowy, sAxAnimationsCastformSnowy, 13, sAxSpritesCastformSnowy, sAxPositionsCastformSnowy

--- a/data/ax/castformsunny.inc
+++ b/data/ax/castformsunny.inc
@@ -1,0 +1,2897 @@
+.global gAxCastformSunny
+gAxCastformSunny:
+ax_siro sAxMainCastformSunny
+sCastformSunnyPose1:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose4:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose5:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose6:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose7:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose8:
+ax_pose 7, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose9:
+ax_pose 8, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose10:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose11:
+ax_pose 10, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose12:
+ax_pose 11, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose13:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose16:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose17:
+ax_pose 10, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose18:
+ax_pose 11, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose19:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose20:
+ax_pose 7, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose21:
+ax_pose 8, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose22:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose23:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose24:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose25:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose26:
+ax_pose 15, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose27:
+ax_pose 16, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose28:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose29:
+ax_pose 17, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose30:
+ax_pose 18, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose31:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose32:
+ax_pose 19, 0x81e7, 0x90f5, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose33:
+ax_pose 20, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose34:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose35:
+ax_pose 21, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose36:
+ax_pose 22, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose37:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose38:
+ax_pose 23, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose39:
+ax_pose 24, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose40:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose41:
+ax_pose 21, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose42:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose43:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose44:
+ax_pose 19, 0x81e7, 0x80fc, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose45:
+ax_pose 20, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose46:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose47:
+ax_pose 17, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose48:
+ax_pose 18, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose49:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose50:
+ax_pose 15, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose51:
+ax_pose 16, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose52:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose53:
+ax_pose 17, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose54:
+ax_pose 18, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose55:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose56:
+ax_pose 19, 0x81e7, 0x90f5, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose57:
+ax_pose 20, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose58:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose59:
+ax_pose 21, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose60:
+ax_pose 22, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose61:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose62:
+ax_pose 23, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose63:
+ax_pose 24, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose64:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose65:
+ax_pose 21, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose66:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose67:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose68:
+ax_pose 19, 0x81e7, 0x80fc, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose69:
+ax_pose 20, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose70:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose71:
+ax_pose 17, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose72:
+ax_pose 18, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose73:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose74:
+ax_pose 15, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose75:
+ax_pose 16, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose76:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose77:
+ax_pose 17, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose78:
+ax_pose 18, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose79:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose80:
+ax_pose 19, 0x81e7, 0x90f5, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose81:
+ax_pose 20, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose82:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose83:
+ax_pose 21, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose84:
+ax_pose 22, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose85:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose86:
+ax_pose 23, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose87:
+ax_pose 24, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose88:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose89:
+ax_pose 21, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose90:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose91:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose92:
+ax_pose 19, 0x81e7, 0x80fc, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose93:
+ax_pose 20, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose94:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose95:
+ax_pose 17, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose96:
+ax_pose 18, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose97:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose98:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose99:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose100:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose101:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose102:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose103:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose104:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose105:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose106:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose107:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose108:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose109:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose110:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose111:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose112:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose113:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose114:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose115:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose116:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose117:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose118:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose119:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose120:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose121:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose122:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose123:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose124:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose125:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose126:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose127:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose128:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose129:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose130:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose131:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose132:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose133:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose134:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose135:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose136:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose137:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose138:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose139:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose140:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose141:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose142:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose143:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose144:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose145:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose146:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose147:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose148:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose149:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose150:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose151:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose152:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose153:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose154:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose155:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose156:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose157:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose158:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose159:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose160:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose161:
+ax_pose 25, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose162:
+ax_pose 26, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose163:
+ax_pose 27, 0x01e1, 0x80f2, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose164:
+ax_pose 28, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose165:
+ax_pose 29, 0x01e4, 0x90e9, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose166:
+ax_pose 30, 0x01e5, 0x90e9, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose167:
+ax_pose 31, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose168:
+ax_pose 30, 0x01e5, 0x80f7, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose169:
+ax_pose 29, 0x01e4, 0x80f7, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose170:
+ax_pose 28, 0x01e2, 0x80f6, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose171:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose172:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose173:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose174:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose175:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose176:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose177:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose178:
+ax_pose 7, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose179:
+ax_pose 8, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose180:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose181:
+ax_pose 10, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose182:
+ax_pose 11, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose183:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose184:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose185:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose186:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose187:
+ax_pose 10, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose188:
+ax_pose 11, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose189:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose190:
+ax_pose 7, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose191:
+ax_pose 8, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose192:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose193:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose194:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose195:
+ax_pose 16, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose196:
+ax_pose 18, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose197:
+ax_pose 20, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose198:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose199:
+ax_pose 24, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose200:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose201:
+ax_pose 20, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose202:
+ax_pose 18, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose203:
+ax_pose 15, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose204:
+ax_pose 17, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose205:
+ax_pose 19, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose206:
+ax_pose 21, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose207:
+ax_pose 23, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose208:
+ax_pose 21, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose209:
+ax_pose 19, 0x81e7, 0x80f9, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose210:
+ax_pose 17, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose211:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose212:
+ax_pose 15, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose213:
+ax_pose 16, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose214:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose215:
+ax_pose 17, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose216:
+ax_pose 18, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose217:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose218:
+ax_pose 19, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose219:
+ax_pose 20, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose220:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose221:
+ax_pose 21, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose222:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose223:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose224:
+ax_pose 23, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose225:
+ax_pose 24, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose226:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose227:
+ax_pose 21, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose228:
+ax_pose 22, 0x01e9, 0x80f5, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose229:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose230:
+ax_pose 19, 0x81e7, 0x80fa, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose231:
+ax_pose 20, 0x01e6, 0x80f6, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose232:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose233:
+ax_pose 17, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose234:
+ax_pose 18, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose235:
+ax_pose 16, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose236:
+ax_pose 18, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose237:
+ax_pose 20, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose238:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose239:
+ax_pose 24, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose240:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose241:
+ax_pose 20, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose242:
+ax_pose 18, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose243:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose244:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose245:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose246:
+ax_pose 9, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose247:
+ax_pose 12, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose248:
+ax_pose 9, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose249:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose250:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose251:
+ax_pose 0, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose252:
+ax_pose 1, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sCastformSunnyPose253:
+ax_pose 2, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+.align 2
+sCastformSunnyAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 1,
+ax_anim 4, 0, 2, 0, 2, 0, 2,
+ax_anim 4, 0, 0, 0, 3, 0, 3,
+ax_anim 4, 0, 1, 0, 2, 0, 2,
+ax_anim 6, 0, 2, 0, 0, 0, 1,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, -1,
+ax_anim 6, 0, 2, 0, -1, 0, -1,
+ax_anim_terminator
+sCastformSunnyAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 1, 1, 1, 1,
+ax_anim 4, 0, 5, 2, 1, 2, 2,
+ax_anim 4, 0, 3, 3, 0, 3, 3,
+ax_anim 4, 0, 4, 3, -1, 3, 3,
+ax_anim 6, 0, 5, 2, -2, 2, 2,
+ax_anim 6, 0, 3, 1, -2, 1, 1,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 1, 0, 1, 0,
+ax_anim 4, 0, 8, 2, -1, 2, 0,
+ax_anim 4, 0, 6, 3, -2, 3, 0,
+ax_anim 4, 0, 7, 3, -3, 3, 0,
+ax_anim 6, 0, 8, 2, -3, 2, 0,
+ax_anim 6, 0, 6, 1, -2, 1, 0,
+ax_anim 6, 0, 7, 1, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 1, 0, 1, -1,
+ax_anim 4, 0, 11, 2, -1, 2, -2,
+ax_anim 4, 0, 9, 3, -3, 3, -3,
+ax_anim 4, 0, 10, 3, -4, 3, -3,
+ax_anim 6, 0, 11, 2, -4, 2, -2,
+ax_anim 6, 0, 9, 1, -3, 1, -1,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, -1,
+ax_anim 4, 0, 14, 0, -2, 0, -2,
+ax_anim 4, 0, 12, 0, -3, 0, -3,
+ax_anim 4, 0, 13, 0, -4, 0, -4,
+ax_anim 6, 0, 14, 0, -3, 0, -3,
+ax_anim 6, 0, 12, 0, -2, 0, -1,
+ax_anim 6, 0, 13, 0, -1, 0, 1,
+ax_anim 6, 0, 14, 0, 0, 0, 1,
+ax_anim_terminator
+sCastformSunnyAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -1, 0, -1, -1,
+ax_anim 4, 0, 17, -2, -1, -2, -2,
+ax_anim 4, 0, 15, -3, -3, -3, -3,
+ax_anim 4, 0, 16, -3, -4, -3, -3,
+ax_anim 6, 0, 17, -2, -4, -2, -2,
+ax_anim 6, 0, 15, -1, -3, -1, -1,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -1, 0, -1, 0,
+ax_anim 4, 0, 20, -2, -1, -2, 0,
+ax_anim 4, 0, 18, -3, -2, -3, 0,
+ax_anim 4, 0, 19, -3, -3, -3, 0,
+ax_anim 6, 0, 20, -2, -3, -2, 0,
+ax_anim 6, 0, 18, -1, -2, -1, 0,
+ax_anim 6, 0, 19, -1, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -1, 1, -1, 1,
+ax_anim 4, 0, 23, -2, 1, -2, 2,
+ax_anim 4, 0, 21, -3, 0, -3, 3,
+ax_anim 4, 0, 22, -3, -1, -3, 3,
+ax_anim 6, 0, 23, -2, -2, -2, 2,
+ax_anim 6, 0, 21, -1, -2, -1, 1,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 13, 0, 13,
+ax_anim 2, 0, 26, 0, 22, 0, 22,
+ax_anim 2, 1, 26, 1, 22, 1, 22,
+ax_anim 2, 0, 26, 0, 22, 0, 22,
+ax_anim 2, 0, 26, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim_terminator
+sCastformSunnyAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 13, 12, 13, 13,
+ax_anim 2, 0, 29, 21, 21, 22, 21,
+ax_anim 2, 1, 29, 22, 20, 23, 20,
+ax_anim 2, 0, 29, 21, 21, 22, 21,
+ax_anim 2, 0, 29, 22, 20, 23, 20,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sCastformSunnyAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 14, 0, 13, 0,
+ax_anim 2, 0, 32, 21, 0, 21, -1,
+ax_anim 2, 1, 32, 21, 1, 21, 0,
+ax_anim 2, 0, 32, 21, 0, 21, -1,
+ax_anim 2, 0, 32, 21, 1, 21, 0,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sCastformSunnyAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 4, -4, 4, -4,
+ax_anim 1, 0, 33, 10, -11, 10, -11,
+ax_anim 2, 0, 35, 18, -19, 18, -21,
+ax_anim 2, 1, 35, 19, -18, 19, -20,
+ax_anim 2, 0, 35, 18, -19, 18, -21,
+ax_anim 2, 0, 35, 19, -18, 19, -20,
+ax_anim 2, 0, 33, 8, -8, 8, -8,
+ax_anim_terminator
+sCastformSunnyAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 0, -17, 0, -19,
+ax_anim 2, 1, 38, 1, -17, 1, -19,
+ax_anim 2, 0, 38, 0, -17, 0, -19,
+ax_anim 2, 0, 38, 1, -17, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformSunnyAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -4, -4, -4, -4,
+ax_anim 1, 0, 39, -10, -11, -10, -11,
+ax_anim 2, 0, 41, -18, -19, -18, -21,
+ax_anim 2, 1, 41, -19, -18, -19, -20,
+ax_anim 2, 0, 41, -18, -19, -18, -21,
+ax_anim 2, 0, 41, -19, -18, -19, -20,
+ax_anim 2, 0, 39, -8, -8, -8, -8,
+ax_anim_terminator
+sCastformSunnyAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -14, 0, -14, 0,
+ax_anim 2, 0, 44, -21, 0, -21, -1,
+ax_anim 2, 1, 44, -21, 1, -21, 0,
+ax_anim 2, 0, 44, -21, 0, -21, -1,
+ax_anim 2, 0, 44, -21, 1, -21, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sCastformSunnyAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -13, 12, -13, 13,
+ax_anim 2, 0, 47, -21, 21, -22, 21,
+ax_anim 2, 1, 47, -22, 20, -23, 20,
+ax_anim 2, 0, 47, -21, 21, -22, 21,
+ax_anim 2, 0, 47, -22, 20, -23, 20,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 48, 0, 13, 0, 13,
+ax_anim 2, 0, 50, 0, 22, 0, 22,
+ax_anim 2, 1, 50, 1, 22, 1, 22,
+ax_anim 2, 0, 50, 0, 22, 0, 22,
+ax_anim 2, 0, 50, 1, 22, 1, 22,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim_terminator
+sCastformSunnyAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 13, 12, 13, 13,
+ax_anim 2, 0, 53, 21, 21, 22, 21,
+ax_anim 2, 1, 53, 22, 20, 23, 20,
+ax_anim 2, 0, 53, 21, 21, 22, 21,
+ax_anim 2, 0, 53, 22, 20, 23, 20,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sCastformSunnyAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 14, 0, 13, 0,
+ax_anim 2, 0, 56, 21, 0, 21, -1,
+ax_anim 2, 1, 56, 21, 1, 21, 0,
+ax_anim 2, 0, 56, 21, 0, 21, -1,
+ax_anim 2, 0, 56, 21, 1, 21, 0,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sCastformSunnyAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 4, -4, 4, -4,
+ax_anim 1, 0, 57, 10, -11, 10, -11,
+ax_anim 2, 0, 59, 18, -19, 18, -21,
+ax_anim 2, 1, 59, 19, -18, 19, -20,
+ax_anim 2, 0, 59, 18, -19, 18, -21,
+ax_anim 2, 0, 59, 19, -18, 19, -20,
+ax_anim 2, 0, 57, 8, -8, 8, -8,
+ax_anim_terminator
+sCastformSunnyAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -11, 0, -11,
+ax_anim 2, 0, 62, 0, -17, 0, -19,
+ax_anim 2, 1, 62, 1, -17, 1, -19,
+ax_anim 2, 0, 62, 0, -17, 0, -19,
+ax_anim 2, 0, 62, 1, -17, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sCastformSunnyAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -4, -4, -4, -4,
+ax_anim 1, 0, 63, -10, -11, -10, -11,
+ax_anim 2, 0, 65, -18, -19, -18, -21,
+ax_anim 2, 1, 65, -19, -18, -19, -20,
+ax_anim 2, 0, 65, -18, -19, -18, -21,
+ax_anim 2, 0, 65, -19, -18, -19, -20,
+ax_anim 2, 0, 63, -8, -8, -8, -8,
+ax_anim_terminator
+sCastformSunnyAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -14, 0, -14, 0,
+ax_anim 2, 0, 68, -21, 0, -21, -1,
+ax_anim 2, 1, 68, -21, 1, -21, 0,
+ax_anim 2, 0, 68, -21, 0, -21, -1,
+ax_anim 2, 0, 68, -21, 1, -21, 0,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sCastformSunnyAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -13, 12, -13, 13,
+ax_anim 2, 0, 71, -21, 21, -22, 21,
+ax_anim 2, 1, 71, -22, 20, -23, 20,
+ax_anim 2, 0, 71, -21, 21, -22, 21,
+ax_anim 2, 0, 71, -22, 20, -23, 20,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sCastformSunnyAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sCastformSunnyAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sCastformSunnyAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sCastformSunnyAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sCastformSunnyAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sCastformSunnyAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sCastformSunnyAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_5_1:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 2, 100, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -6, 0, 0,
+ax_anim 1, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 1, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_5_2:
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 1, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 109, 0, -6, 0, 0,
+ax_anim 1, 2, 108, 0, -7, 0, 0,
+ax_anim 1, 0, 107, 0, -8, 0, 0,
+ax_anim 1, 0, 106, 0, -9, 0, 0,
+ax_anim 1, 0, 105, 0, -9, 0, 0,
+ax_anim 1, 0, 104, 0, -9, 0, 0,
+ax_anim 1, 0, 111, 0, -9, 0, 0,
+ax_anim 1, 0, 110, 0, -8, 0, 0,
+ax_anim 1, 0, 109, 0, -7, 0, 0,
+ax_anim 1, 0, 108, 0, -6, 0, 0,
+ax_anim 1, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 1, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_5_3:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 1, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 117, 0, -6, 0, 0,
+ax_anim 1, 2, 116, 0, -7, 0, 0,
+ax_anim 1, 0, 115, 0, -8, 0, 0,
+ax_anim 1, 0, 114, 0, -9, 0, 0,
+ax_anim 1, 0, 113, 0, -9, 0, 0,
+ax_anim 1, 0, 112, 0, -9, 0, 0,
+ax_anim 1, 0, 119, 0, -9, 0, 0,
+ax_anim 1, 0, 118, 0, -8, 0, 0,
+ax_anim 1, 0, 117, 0, -7, 0, 0,
+ax_anim 1, 0, 116, 0, -6, 0, 0,
+ax_anim 1, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 1, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_5_4:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -5, 0, 0,
+ax_anim 1, 0, 125, 0, -6, 0, 0,
+ax_anim 1, 2, 124, 0, -7, 0, 0,
+ax_anim 1, 0, 123, 0, -8, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 126, 0, -8, 0, 0,
+ax_anim 1, 0, 125, 0, -7, 0, 0,
+ax_anim 1, 0, 124, 0, -6, 0, 0,
+ax_anim 1, 0, 123, 0, -5, 0, 0,
+ax_anim 1, 1, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_5_5:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 2, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 1, 0, 130, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 0, 135, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -8, 0, 0,
+ax_anim 1, 0, 133, 0, -7, 0, 0,
+ax_anim 1, 0, 132, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 1, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_5_6:
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 1, 0, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 2, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -8, 0, 0,
+ax_anim 1, 0, 138, 0, -9, 0, 0,
+ax_anim 1, 0, 137, 0, -9, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, 0,
+ax_anim 1, 0, 143, 0, -9, 0, 0,
+ax_anim 1, 0, 142, 0, -8, 0, 0,
+ax_anim 1, 0, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 1, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_5_7:
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 1, 0, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 149, 0, -6, 0, 0,
+ax_anim 1, 2, 148, 0, -7, 0, 0,
+ax_anim 1, 0, 147, 0, -8, 0, 0,
+ax_anim 1, 0, 146, 0, -9, 0, 0,
+ax_anim 1, 0, 145, 0, -9, 0, 0,
+ax_anim 1, 0, 144, 0, -9, 0, 0,
+ax_anim 1, 0, 151, 0, -9, 0, 0,
+ax_anim 1, 0, 150, 0, -8, 0, 0,
+ax_anim 1, 0, 149, 0, -7, 0, 0,
+ax_anim 1, 0, 148, 0, -6, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 1, 146, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_5_8:
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 1, 0, 159, 0, -4, 0, 0,
+ax_anim 1, 0, 158, 0, -5, 0, 0,
+ax_anim 1, 0, 157, 0, -6, 0, 0,
+ax_anim 1, 2, 156, 0, -7, 0, 0,
+ax_anim 1, 0, 155, 0, -8, 0, 0,
+ax_anim 1, 0, 154, 0, -9, 0, 0,
+ax_anim 1, 0, 153, 0, -9, 0, 0,
+ax_anim 1, 0, 152, 0, -9, 0, 0,
+ax_anim 1, 0, 159, 0, -9, 0, 0,
+ax_anim 1, 0, 158, 0, -8, 0, 0,
+ax_anim 1, 0, 157, 0, -7, 0, 0,
+ax_anim 1, 0, 156, 0, -6, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 1, 1, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_6_1:
+ax_anim 10, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 160, 0, -1, 0, 0,
+ax_anim 16, 0, 160, 0, -2, 0, 0,
+ax_anim 10, 0, 161, 0, -2, 0, 0,
+ax_anim 10, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sCastformSunnyAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sCastformSunnyAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sCastformSunnyAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sCastformSunnyAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sCastformSunnyAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sCastformSunnyAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sCastformSunnyAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_8_1:
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, -1, 0, 0,
+ax_anim 8, 0, 172, 0, -1, 0, 0,
+ax_anim 8, 0, 170, 0, -2, 0, 0,
+ax_anim 8, 0, 171, 0, -2, 0, 0,
+ax_anim 8, 0, 172, 0, -2, 0, 0,
+ax_anim 8, 0, 170, 0, -1, 0, 0,
+ax_anim 8, 0, 171, 0, -1, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_8_2:
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, -1, 0, 0,
+ax_anim 8, 0, 175, 0, -1, 0, 0,
+ax_anim 8, 0, 173, 0, -2, 0, 0,
+ax_anim 8, 0, 174, 0, -2, 0, 0,
+ax_anim 8, 0, 175, 0, -2, 0, 0,
+ax_anim 8, 0, 173, 0, -1, 0, 0,
+ax_anim 8, 0, 174, 0, -1, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_8_3:
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, -1, 0, 0,
+ax_anim 8, 0, 178, 0, -1, 0, 0,
+ax_anim 8, 0, 176, 0, -2, 0, 0,
+ax_anim 8, 0, 177, 0, -2, 0, 0,
+ax_anim 8, 0, 178, 0, -2, 0, 0,
+ax_anim 8, 0, 176, 0, -1, 0, 0,
+ax_anim 8, 0, 177, 0, -1, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_8_4:
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim 8, 0, 180, 0, -1, 0, 0,
+ax_anim 8, 0, 181, 0, -1, 0, 0,
+ax_anim 8, 0, 179, 0, -2, 0, 0,
+ax_anim 8, 0, 180, 0, -2, 0, 0,
+ax_anim 8, 0, 181, 0, -2, 0, 0,
+ax_anim 8, 0, 179, 0, -1, 0, 0,
+ax_anim 8, 0, 180, 0, -1, 0, 0,
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_8_5:
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, -1, 0, 0,
+ax_anim 8, 0, 184, 0, -1, 0, 0,
+ax_anim 8, 0, 182, 0, -2, 0, 0,
+ax_anim 8, 0, 183, 0, -2, 0, 0,
+ax_anim 8, 0, 184, 0, -2, 0, 0,
+ax_anim 8, 0, 182, 0, -1, 0, 0,
+ax_anim 8, 0, 183, 0, -1, 0, 0,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_8_6:
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim 8, 0, 186, 0, -1, 0, 0,
+ax_anim 8, 0, 187, 0, -1, 0, 0,
+ax_anim 8, 0, 185, 0, -2, 0, 0,
+ax_anim 8, 0, 186, 0, -2, 0, 0,
+ax_anim 8, 0, 187, 0, -2, 0, 0,
+ax_anim 8, 0, 185, 0, -1, 0, 0,
+ax_anim 8, 0, 186, 0, -1, 0, 0,
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_8_7:
+ax_anim 8, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, -1, 0, 0,
+ax_anim 8, 0, 190, 0, -1, 0, 0,
+ax_anim 8, 0, 188, 0, -2, 0, 0,
+ax_anim 8, 0, 189, 0, -2, 0, 0,
+ax_anim 8, 0, 190, 0, -2, 0, 0,
+ax_anim 8, 0, 188, 0, -1, 0, 0,
+ax_anim 8, 0, 189, 0, -1, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_8_8:
+ax_anim 8, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, -1, 0, 0,
+ax_anim 8, 0, 193, 0, -1, 0, 0,
+ax_anim 8, 0, 191, 0, -2, 0, 0,
+ax_anim 8, 0, 192, 0, -2, 0, 0,
+ax_anim 8, 0, 193, 0, -2, 0, 0,
+ax_anim 8, 0, 191, 0, -1, 0, 0,
+ax_anim 8, 0, 192, 0, -1, 0, 0,
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 9, 9, 9, 9,
+ax_anim 2, 0, 197, 8, 19, 8, 19,
+ax_anim 3, 0, 198, 0, 22, 0, 22,
+ax_anim 2, 3, 199, -8, 19, -8, 19,
+ax_anim 2, 0, 200, -9, 9, -9, 9,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 22, 12, 22, 12,
+ax_anim 3, 0, 197, 22, 22, 22, 22,
+ax_anim 2, 3, 198, 12, 23, 12, 23,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 12, -7, 12, -7,
+ax_anim 2, 0, 195, 19, -5, 19, -5,
+ax_anim 3, 0, 196, 23, 0, 23, 0,
+ax_anim 2, 3, 197, 19, 5, 19, 5,
+ax_anim 2, 0, 198, 11, 6, 11, 6,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 3, -16, 3, -16,
+ax_anim 2, 0, 194, 11, -22, 11, -22,
+ax_anim 3, 0, 195, 22, -22, 22, -22,
+ax_anim 2, 3, 196, 24, -15, 24, -15,
+ax_anim 2, 0, 197, 19, -4, 19, -4,
+ax_anim 1, 0, 198, 9, 0, 9, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -7, -3, -7, -3,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -20, -7, -20,
+ax_anim 3, 0, 194, 0, -23, 0, -23,
+ax_anim 2, 3, 195, 7, -20, 7, -20,
+ax_anim 2, 0, 196, 9, -12, 9, -12,
+ax_anim 1, 0, 197, 7, -3, 7, -3,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -3, -16, -3, -16,
+ax_anim 2, 0, 194, -11, -22, -11, -22,
+ax_anim 3, 0, 201, -22, -22, -22, -22,
+ax_anim 2, 3, 200, -24, -15, -24, -15,
+ax_anim 2, 0, 199, -19, -4, -19, -4,
+ax_anim 1, 0, 198, -9, 0, -9, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -12, -7, -12, -7,
+ax_anim 2, 0, 201, -19, -5, -19, -5,
+ax_anim 3, 0, 200, -23, 0, -23, 0,
+ax_anim 2, 3, 199, -19, 5, -19, 5,
+ax_anim 2, 0, 198, -11, 6, -11, 6,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -22, 12, -22, 12,
+ax_anim 3, 0, 199, -22, 22, -22, 22,
+ax_anim 2, 3, 198, -12, 23, -12, 23,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 2, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -23, 0, 0,
+ax_anim 2, 0, 215, 0, -19, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 2, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 2, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 2, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, -10,
+ax_anim 2, 0, 223, 0, -16, 0, -16,
+ax_anim 3, 0, 223, 0, -22, 0, -22,
+ax_anim 4, 0, 223, 0, -23, 0, -23,
+ax_anim 4, 0, 222, 0, -21, 0, -21,
+ax_anim 3, 0, 224, 0, -20, 0, -20,
+ax_anim 2, 0, 224, 0, -17, 0, -17,
+ax_anim 1, 0, 224, 0, -12, 0, -12,
+ax_anim 2, 2, 224, 0, 2, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 2, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 2, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -23, 0, 0,
+ax_anim 2, 0, 233, 0, -19, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCastformSunnyAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sCastformSunnyGfx1:
+.incbin "baserom.gba", 0x147526C, 0x200
+sCastformSunnySprites1:
+ax_sprite sCastformSunnyGfx1, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx2:
+.incbin "baserom.gba", 0x147547C, 0x200
+sCastformSunnySprites2:
+ax_sprite sCastformSunnyGfx2, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx3:
+.incbin "baserom.gba", 0x147568C, 0x200
+sCastformSunnySprites3:
+ax_sprite sCastformSunnyGfx3, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx4:
+.incbin "baserom.gba", 0x147589C, 0x200
+sCastformSunnySprites4:
+ax_sprite sCastformSunnyGfx4, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx5:
+.incbin "baserom.gba", 0x1475AAC, 0x200
+sCastformSunnySprites5:
+ax_sprite sCastformSunnyGfx5, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx6:
+.incbin "baserom.gba", 0x1475CBC, 0x200
+sCastformSunnySprites6:
+ax_sprite sCastformSunnyGfx6, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx7:
+.incbin "baserom.gba", 0x1475ECC, 0x200
+sCastformSunnySprites7:
+ax_sprite sCastformSunnyGfx7, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx8:
+.incbin "baserom.gba", 0x14760DC, 0x200
+sCastformSunnySprites8:
+ax_sprite sCastformSunnyGfx8, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx9:
+.incbin "baserom.gba", 0x14762EC, 0x200
+sCastformSunnySprites9:
+ax_sprite sCastformSunnyGfx9, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx10:
+.incbin "baserom.gba", 0x14764FC, 0x200
+sCastformSunnySprites10:
+ax_sprite sCastformSunnyGfx10, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx11:
+.incbin "baserom.gba", 0x147670C, 0x200
+sCastformSunnySprites11:
+ax_sprite sCastformSunnyGfx11, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx12:
+.incbin "baserom.gba", 0x147691C, 0x200
+sCastformSunnySprites12:
+ax_sprite sCastformSunnyGfx12, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx13:
+.incbin "baserom.gba", 0x1476B2C, 0x200
+sCastformSunnySprites13:
+ax_sprite sCastformSunnyGfx13, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx14:
+.incbin "baserom.gba", 0x1476D3C, 0x200
+sCastformSunnySprites14:
+ax_sprite sCastformSunnyGfx14, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx15:
+.incbin "baserom.gba", 0x1476F4C, 0x200
+sCastformSunnySprites15:
+ax_sprite sCastformSunnyGfx15, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx16:
+.incbin "baserom.gba", 0x147715C, 0x60
+sCastformSunnyGfx16_1:
+.incbin "baserom.gba", 0x14771BC, 0x60
+sCastformSunnyGfx16_2:
+.incbin "baserom.gba", 0x147721C, 0x60
+sCastformSunnySprites16:
+ax_sprite sCastformSunnyGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSunnyGfx17:
+.incbin "baserom.gba", 0x14772B4, 0x20
+sCastformSunnyGfx17_1:
+.incbin "baserom.gba", 0x14772D4, 0x60
+sCastformSunnyGfx17_2:
+.incbin "baserom.gba", 0x1477334, 0x60
+sCastformSunnyGfx17_3:
+.incbin "baserom.gba", 0x1477394, 0x20
+sCastformSunnySprites17:
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx17_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSunnyGfx18:
+.incbin "baserom.gba", 0x1477404, 0x60
+sCastformSunnyGfx18_1:
+.incbin "baserom.gba", 0x1477464, 0x60
+sCastformSunnyGfx18_2:
+.incbin "baserom.gba", 0x14774C4, 0x60
+sCastformSunnySprites18:
+ax_sprite sCastformSunnyGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSunnyGfx19:
+.incbin "baserom.gba", 0x147755C, 0x40
+sCastformSunnyGfx19_1:
+.incbin "baserom.gba", 0x147759C, 0x60
+sCastformSunnyGfx19_2:
+.incbin "baserom.gba", 0x14775FC, 0x60
+sCastformSunnyGfx19_3:
+.incbin "baserom.gba", 0x147765C, 0x20
+sCastformSunnySprites19:
+ax_sprite sCastformSunnyGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSunnyGfx20:
+.incbin "baserom.gba", 0x14776C4, 0xC0
+sCastformSunnySprites20:
+ax_sprite sCastformSunnyGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSunnyGfx21:
+.incbin "baserom.gba", 0x147779C, 0x40
+sCastformSunnyGfx21_1:
+.incbin "baserom.gba", 0x14777DC, 0x60
+sCastformSunnyGfx21_2:
+.incbin "baserom.gba", 0x147783C, 0x60
+sCastformSunnyGfx21_3:
+.incbin "baserom.gba", 0x147789C, 0x20
+sCastformSunnySprites21:
+ax_sprite sCastformSunnyGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSunnyGfx22:
+.incbin "baserom.gba", 0x1477904, 0x40
+sCastformSunnyGfx22_1:
+.incbin "baserom.gba", 0x1477944, 0x60
+sCastformSunnyGfx22_2:
+.incbin "baserom.gba", 0x14779A4, 0x60
+sCastformSunnyGfx22_3:
+.incbin "baserom.gba", 0x1477A04, 0x20
+sCastformSunnySprites22:
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx22_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSunnyGfx23:
+.incbin "baserom.gba", 0x1477A74, 0x60
+sCastformSunnyGfx23_1:
+.incbin "baserom.gba", 0x1477AD4, 0x60
+sCastformSunnyGfx23_2:
+.incbin "baserom.gba", 0x1477B34, 0x60
+sCastformSunnySprites23:
+ax_sprite sCastformSunnyGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSunnyGfx24:
+.incbin "baserom.gba", 0x1477BCC, 0x60
+sCastformSunnyGfx24_1:
+.incbin "baserom.gba", 0x1477C2C, 0x60
+sCastformSunnyGfx24_2:
+.incbin "baserom.gba", 0x1477C8C, 0x60
+sCastformSunnyGfx24_3:
+.incbin "baserom.gba", 0x1477CEC, 0x20
+sCastformSunnySprites24:
+ax_sprite sCastformSunnyGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCastformSunnyGfx24_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCastformSunnyGfx25:
+.incbin "baserom.gba", 0x1477D54, 0x60
+sCastformSunnyGfx25_1:
+.incbin "baserom.gba", 0x1477DB4, 0x60
+sCastformSunnyGfx25_2:
+.incbin "baserom.gba", 0x1477E14, 0x60
+sCastformSunnySprites25:
+ax_sprite sCastformSunnyGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCastformSunnyGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCastformSunnyGfx26:
+.incbin "baserom.gba", 0x1477EAC, 0x200
+sCastformSunnySprites26:
+ax_sprite sCastformSunnyGfx26, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx27:
+.incbin "baserom.gba", 0x14780BC, 0x200
+sCastformSunnySprites27:
+ax_sprite sCastformSunnyGfx27, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx28:
+.incbin "baserom.gba", 0x14782CC, 0x200
+sCastformSunnySprites28:
+ax_sprite sCastformSunnyGfx28, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx29:
+.incbin "baserom.gba", 0x14784DC, 0x200
+sCastformSunnySprites29:
+ax_sprite sCastformSunnyGfx29, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx30:
+.incbin "baserom.gba", 0x14786EC, 0x200
+sCastformSunnySprites30:
+ax_sprite sCastformSunnyGfx30, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx31:
+.incbin "baserom.gba", 0x14788FC, 0x200
+sCastformSunnySprites31:
+ax_sprite sCastformSunnyGfx31, 0x200
+ax_sprite_terminator
+sCastformSunnyGfx32:
+.incbin "baserom.gba", 0x1478B0C, 0x200
+sCastformSunnySprites32:
+ax_sprite sCastformSunnyGfx32, 0x200
+ax_sprite_terminator
+sAxPosesCastformSunny:
+.4byte sCastformSunnyPose1
+.4byte sCastformSunnyPose2
+.4byte sCastformSunnyPose3
+.4byte sCastformSunnyPose4
+.4byte sCastformSunnyPose5
+.4byte sCastformSunnyPose6
+.4byte sCastformSunnyPose7
+.4byte sCastformSunnyPose8
+.4byte sCastformSunnyPose9
+.4byte sCastformSunnyPose10
+.4byte sCastformSunnyPose11
+.4byte sCastformSunnyPose12
+.4byte sCastformSunnyPose13
+.4byte sCastformSunnyPose14
+.4byte sCastformSunnyPose15
+.4byte sCastformSunnyPose16
+.4byte sCastformSunnyPose17
+.4byte sCastformSunnyPose18
+.4byte sCastformSunnyPose19
+.4byte sCastformSunnyPose20
+.4byte sCastformSunnyPose21
+.4byte sCastformSunnyPose22
+.4byte sCastformSunnyPose23
+.4byte sCastformSunnyPose24
+.4byte sCastformSunnyPose25
+.4byte sCastformSunnyPose26
+.4byte sCastformSunnyPose27
+.4byte sCastformSunnyPose28
+.4byte sCastformSunnyPose29
+.4byte sCastformSunnyPose30
+.4byte sCastformSunnyPose31
+.4byte sCastformSunnyPose32
+.4byte sCastformSunnyPose33
+.4byte sCastformSunnyPose34
+.4byte sCastformSunnyPose35
+.4byte sCastformSunnyPose36
+.4byte sCastformSunnyPose37
+.4byte sCastformSunnyPose38
+.4byte sCastformSunnyPose39
+.4byte sCastformSunnyPose40
+.4byte sCastformSunnyPose41
+.4byte sCastformSunnyPose42
+.4byte sCastformSunnyPose43
+.4byte sCastformSunnyPose44
+.4byte sCastformSunnyPose45
+.4byte sCastformSunnyPose46
+.4byte sCastformSunnyPose47
+.4byte sCastformSunnyPose48
+.4byte sCastformSunnyPose49
+.4byte sCastformSunnyPose50
+.4byte sCastformSunnyPose51
+.4byte sCastformSunnyPose52
+.4byte sCastformSunnyPose53
+.4byte sCastformSunnyPose54
+.4byte sCastformSunnyPose55
+.4byte sCastformSunnyPose56
+.4byte sCastformSunnyPose57
+.4byte sCastformSunnyPose58
+.4byte sCastformSunnyPose59
+.4byte sCastformSunnyPose60
+.4byte sCastformSunnyPose61
+.4byte sCastformSunnyPose62
+.4byte sCastformSunnyPose63
+.4byte sCastformSunnyPose64
+.4byte sCastformSunnyPose65
+.4byte sCastformSunnyPose66
+.4byte sCastformSunnyPose67
+.4byte sCastformSunnyPose68
+.4byte sCastformSunnyPose69
+.4byte sCastformSunnyPose70
+.4byte sCastformSunnyPose71
+.4byte sCastformSunnyPose72
+.4byte sCastformSunnyPose73
+.4byte sCastformSunnyPose74
+.4byte sCastformSunnyPose75
+.4byte sCastformSunnyPose76
+.4byte sCastformSunnyPose77
+.4byte sCastformSunnyPose78
+.4byte sCastformSunnyPose79
+.4byte sCastformSunnyPose80
+.4byte sCastformSunnyPose81
+.4byte sCastformSunnyPose82
+.4byte sCastformSunnyPose83
+.4byte sCastformSunnyPose84
+.4byte sCastformSunnyPose85
+.4byte sCastformSunnyPose86
+.4byte sCastformSunnyPose87
+.4byte sCastformSunnyPose88
+.4byte sCastformSunnyPose89
+.4byte sCastformSunnyPose90
+.4byte sCastformSunnyPose91
+.4byte sCastformSunnyPose92
+.4byte sCastformSunnyPose93
+.4byte sCastformSunnyPose94
+.4byte sCastformSunnyPose95
+.4byte sCastformSunnyPose96
+.4byte sCastformSunnyPose97
+.4byte sCastformSunnyPose98
+.4byte sCastformSunnyPose99
+.4byte sCastformSunnyPose100
+.4byte sCastformSunnyPose101
+.4byte sCastformSunnyPose102
+.4byte sCastformSunnyPose103
+.4byte sCastformSunnyPose104
+.4byte sCastformSunnyPose105
+.4byte sCastformSunnyPose106
+.4byte sCastformSunnyPose107
+.4byte sCastformSunnyPose108
+.4byte sCastformSunnyPose109
+.4byte sCastformSunnyPose110
+.4byte sCastformSunnyPose111
+.4byte sCastformSunnyPose112
+.4byte sCastformSunnyPose113
+.4byte sCastformSunnyPose114
+.4byte sCastformSunnyPose115
+.4byte sCastformSunnyPose116
+.4byte sCastformSunnyPose117
+.4byte sCastformSunnyPose118
+.4byte sCastformSunnyPose119
+.4byte sCastformSunnyPose120
+.4byte sCastformSunnyPose121
+.4byte sCastformSunnyPose122
+.4byte sCastformSunnyPose123
+.4byte sCastformSunnyPose124
+.4byte sCastformSunnyPose125
+.4byte sCastformSunnyPose126
+.4byte sCastformSunnyPose127
+.4byte sCastformSunnyPose128
+.4byte sCastformSunnyPose129
+.4byte sCastformSunnyPose130
+.4byte sCastformSunnyPose131
+.4byte sCastformSunnyPose132
+.4byte sCastformSunnyPose133
+.4byte sCastformSunnyPose134
+.4byte sCastformSunnyPose135
+.4byte sCastformSunnyPose136
+.4byte sCastformSunnyPose137
+.4byte sCastformSunnyPose138
+.4byte sCastformSunnyPose139
+.4byte sCastformSunnyPose140
+.4byte sCastformSunnyPose141
+.4byte sCastformSunnyPose142
+.4byte sCastformSunnyPose143
+.4byte sCastformSunnyPose144
+.4byte sCastformSunnyPose145
+.4byte sCastformSunnyPose146
+.4byte sCastformSunnyPose147
+.4byte sCastformSunnyPose148
+.4byte sCastformSunnyPose149
+.4byte sCastformSunnyPose150
+.4byte sCastformSunnyPose151
+.4byte sCastformSunnyPose152
+.4byte sCastformSunnyPose153
+.4byte sCastformSunnyPose154
+.4byte sCastformSunnyPose155
+.4byte sCastformSunnyPose156
+.4byte sCastformSunnyPose157
+.4byte sCastformSunnyPose158
+.4byte sCastformSunnyPose159
+.4byte sCastformSunnyPose160
+.4byte sCastformSunnyPose161
+.4byte sCastformSunnyPose162
+.4byte sCastformSunnyPose163
+.4byte sCastformSunnyPose164
+.4byte sCastformSunnyPose165
+.4byte sCastformSunnyPose166
+.4byte sCastformSunnyPose167
+.4byte sCastformSunnyPose168
+.4byte sCastformSunnyPose169
+.4byte sCastformSunnyPose170
+.4byte sCastformSunnyPose171
+.4byte sCastformSunnyPose172
+.4byte sCastformSunnyPose173
+.4byte sCastformSunnyPose174
+.4byte sCastformSunnyPose175
+.4byte sCastformSunnyPose176
+.4byte sCastformSunnyPose177
+.4byte sCastformSunnyPose178
+.4byte sCastformSunnyPose179
+.4byte sCastformSunnyPose180
+.4byte sCastformSunnyPose181
+.4byte sCastformSunnyPose182
+.4byte sCastformSunnyPose183
+.4byte sCastformSunnyPose184
+.4byte sCastformSunnyPose185
+.4byte sCastformSunnyPose186
+.4byte sCastformSunnyPose187
+.4byte sCastformSunnyPose188
+.4byte sCastformSunnyPose189
+.4byte sCastformSunnyPose190
+.4byte sCastformSunnyPose191
+.4byte sCastformSunnyPose192
+.4byte sCastformSunnyPose193
+.4byte sCastformSunnyPose194
+.4byte sCastformSunnyPose195
+.4byte sCastformSunnyPose196
+.4byte sCastformSunnyPose197
+.4byte sCastformSunnyPose198
+.4byte sCastformSunnyPose199
+.4byte sCastformSunnyPose200
+.4byte sCastformSunnyPose201
+.4byte sCastformSunnyPose202
+.4byte sCastformSunnyPose203
+.4byte sCastformSunnyPose204
+.4byte sCastformSunnyPose205
+.4byte sCastformSunnyPose206
+.4byte sCastformSunnyPose207
+.4byte sCastformSunnyPose208
+.4byte sCastformSunnyPose209
+.4byte sCastformSunnyPose210
+.4byte sCastformSunnyPose211
+.4byte sCastformSunnyPose212
+.4byte sCastformSunnyPose213
+.4byte sCastformSunnyPose214
+.4byte sCastformSunnyPose215
+.4byte sCastformSunnyPose216
+.4byte sCastformSunnyPose217
+.4byte sCastformSunnyPose218
+.4byte sCastformSunnyPose219
+.4byte sCastformSunnyPose220
+.4byte sCastformSunnyPose221
+.4byte sCastformSunnyPose222
+.4byte sCastformSunnyPose223
+.4byte sCastformSunnyPose224
+.4byte sCastformSunnyPose225
+.4byte sCastformSunnyPose226
+.4byte sCastformSunnyPose227
+.4byte sCastformSunnyPose228
+.4byte sCastformSunnyPose229
+.4byte sCastformSunnyPose230
+.4byte sCastformSunnyPose231
+.4byte sCastformSunnyPose232
+.4byte sCastformSunnyPose233
+.4byte sCastformSunnyPose234
+.4byte sCastformSunnyPose235
+.4byte sCastformSunnyPose236
+.4byte sCastformSunnyPose237
+.4byte sCastformSunnyPose238
+.4byte sCastformSunnyPose239
+.4byte sCastformSunnyPose240
+.4byte sCastformSunnyPose241
+.4byte sCastformSunnyPose242
+.4byte sCastformSunnyPose243
+.4byte sCastformSunnyPose244
+.4byte sCastformSunnyPose245
+.4byte sCastformSunnyPose246
+.4byte sCastformSunnyPose247
+.4byte sCastformSunnyPose248
+.4byte sCastformSunnyPose249
+.4byte sCastformSunnyPose250
+.4byte sCastformSunnyPose251
+.4byte sCastformSunnyPose252
+.4byte sCastformSunnyPose253
+sAxPositionsCastformSunny:
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -5, 	   0,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    2,   -7, 	   3,   -6, 	  -2,   -4, 	   1,   -9
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    4,   -7, 	   1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte    4,   -7, 	   2,   -6, 	   2,   -3, 	   0,  -10
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -2,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    1,   -9, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte   -1,  -10, 	   2,   -7, 	  -3,   -5, 	   1,  -10
+.2byte   -1,   -9, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -2,   -6, 	  -2,   -3, 	   0,  -10
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   2,   -4, 	  -1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,   -6, 	  -3,   -3, 	   3,   -3, 	   0,   -8
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,  -10, 	   3,   -7, 	   0,   -6, 	  -2,  -12
+.2byte    3,   -5, 	   3,   -3, 	   0,   -1, 	   1,   -7
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    1,  -11, 	   0,   -7, 	   0,   -5, 	  -4,  -12
+.2byte    5,   -6, 	   1,   -3, 	   0,   -1, 	   2,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	  -3,   -5, 	   3,   -4, 	  -4,  -10
+.2byte    2,   -8, 	   0,   -6, 	   2,   -3, 	   1,  -11
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -10, 	   4,   -4, 	  -4,   -4, 	   0,   -8
+.2byte    0,  -13, 	   4,   -6, 	  -4,   -6, 	   0,  -12
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    1,  -10, 	   3,   -5, 	  -3,   -4, 	   4,  -10
+.2byte   -2,   -8, 	   0,   -6, 	  -2,   -3, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -11, 	   0,   -7, 	   0,   -5, 	   4,  -12
+.2byte   -5,   -6, 	  -1,   -3, 	   0,   -1, 	  -2,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte    0,  -10, 	  -3,   -7, 	   0,   -6, 	   2,  -12
+.2byte   -3,   -5, 	  -3,   -3, 	   0,   -1, 	  -1,   -7
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,   -6, 	  -3,   -3, 	   3,   -3, 	   0,   -8
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,  -10, 	   3,   -7, 	   0,   -6, 	  -2,  -12
+.2byte    3,   -5, 	   3,   -3, 	   0,   -1, 	   1,   -7
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    1,  -11, 	   0,   -7, 	   0,   -5, 	  -4,  -12
+.2byte    5,   -6, 	   1,   -3, 	   0,   -1, 	   2,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	  -3,   -5, 	   3,   -4, 	  -4,  -10
+.2byte    2,   -8, 	   0,   -6, 	   2,   -3, 	   1,  -11
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -10, 	   4,   -4, 	  -4,   -4, 	   0,   -8
+.2byte    0,  -13, 	   4,   -6, 	  -4,   -6, 	   0,  -12
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    1,  -10, 	   3,   -5, 	  -3,   -4, 	   4,  -10
+.2byte   -2,   -8, 	   0,   -6, 	  -2,   -3, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -11, 	   0,   -7, 	   0,   -5, 	   4,  -12
+.2byte   -5,   -6, 	  -1,   -3, 	   0,   -1, 	  -2,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte    0,  -10, 	  -3,   -7, 	   0,   -6, 	   2,  -12
+.2byte   -3,   -5, 	  -3,   -3, 	   0,   -1, 	  -1,   -7
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,   -6, 	  -3,   -3, 	   3,   -3, 	   0,   -8
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,  -10, 	   3,   -7, 	   0,   -6, 	  -2,  -12
+.2byte    3,   -6, 	   3,   -4, 	   0,   -2, 	   1,   -8
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    1,  -11, 	   0,   -7, 	   0,   -5, 	  -4,  -12
+.2byte    5,   -7, 	   1,   -4, 	   0,   -2, 	   2,  -10
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	  -3,   -5, 	   3,   -4, 	  -4,  -10
+.2byte    2,   -8, 	   0,   -6, 	   2,   -3, 	   1,  -11
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -10, 	   4,   -4, 	  -4,   -4, 	   0,   -8
+.2byte    0,  -13, 	   4,   -6, 	  -4,   -6, 	   0,  -12
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    1,  -10, 	   3,   -5, 	  -3,   -4, 	   4,  -10
+.2byte   -2,   -8, 	   0,   -6, 	  -2,   -3, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -11, 	   0,   -7, 	   0,   -5, 	   4,  -12
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	  -2,  -10
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte    0,  -10, 	  -3,   -7, 	   0,   -6, 	   2,  -12
+.2byte   -3,   -6, 	  -3,   -4, 	   0,   -2, 	  -1,   -8
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -5,  -14, 	  -4,  -16, 	  -8,   -9, 	  -2,  -12
+.2byte   -5,  -14, 	  -4,  -16, 	  -7,   -8, 	  -1,  -12
+.2byte    0,   -8, 	  -3,   -5, 	   3,   -5, 	   0,  -10
+.2byte    1,   -8, 	   4,   -6, 	   0,   -4, 	   0,  -10
+.2byte    1,   -9, 	   0,   -5, 	   2,   -4, 	  -3,  -10
+.2byte   -2,  -13, 	  -3,   -7, 	   2,   -5, 	  -3,  -10
+.2byte    0,  -13, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    1,  -13, 	   2,   -7, 	  -3,   -5, 	   2,  -10
+.2byte   -2,   -9, 	  -1,   -5, 	  -3,   -4, 	   2,  -10
+.2byte   -2,   -8, 	  -5,   -6, 	  -1,   -4, 	  -1,  -10
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -5, 	   0,   -9
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    2,   -7, 	   3,   -6, 	  -2,   -4, 	   1,   -9
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    4,   -7, 	   1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte    4,   -7, 	   2,   -6, 	   2,   -3, 	   0,  -10
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -2,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    1,   -9, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte   -1,  -10, 	   2,   -7, 	  -3,   -5, 	   1,  -10
+.2byte   -1,   -9, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -2,   -6, 	  -2,   -3, 	   0,  -10
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   2,   -4, 	  -1,   -9
+.2byte    0,   -6, 	  -3,   -3, 	   3,   -3, 	   0,   -8
+.2byte   -3,   -6, 	  -3,   -4, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	  -2,  -10
+.2byte   -2,   -8, 	   0,   -6, 	  -2,   -3, 	  -1,  -11
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,  -10
+.2byte    1,   -8, 	  -1,   -6, 	   1,   -3, 	   0,  -11
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	   1,  -10
+.2byte    3,   -6, 	   3,   -4, 	   0,   -2, 	   1,   -8
+.2byte    0,  -10, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,  -10, 	   3,   -7, 	   0,   -6, 	  -2,  -12
+.2byte    3,  -11, 	   2,   -7, 	   2,   -5, 	  -2,  -12
+.2byte    1,  -11, 	  -1,   -6, 	   5,   -5, 	  -2,  -11
+.2byte    0,  -12, 	   4,   -6, 	  -4,   -6, 	   0,  -10
+.2byte   -1,  -11, 	   1,   -6, 	  -5,   -5, 	   2,  -11
+.2byte   -4,  -11, 	  -3,   -7, 	  -3,   -5, 	   1,  -12
+.2byte   -1,  -10, 	  -4,   -7, 	  -1,   -6, 	   1,  -12
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,   -6, 	  -3,   -3, 	   3,   -3, 	   0,   -8
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte    1,  -10, 	   4,   -7, 	   1,   -6, 	  -1,  -12
+.2byte    3,   -6, 	   3,   -4, 	   0,   -2, 	   1,   -8
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    3,  -11, 	   2,   -7, 	   2,   -5, 	  -2,  -12
+.2byte    3,   -7, 	  -1,   -4, 	  -2,   -2, 	   0,  -10
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    0,  -10, 	  -2,   -5, 	   4,   -4, 	  -3,  -10
+.2byte    1,   -8, 	  -1,   -6, 	   1,   -3, 	   0,  -11
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    0,  -10, 	   4,   -4, 	  -4,   -4, 	   0,   -8
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -10, 	   2,   -5, 	  -4,   -4, 	   3,  -10
+.2byte   -1,   -8, 	   1,   -6, 	  -1,   -3, 	   0,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -3,  -11, 	  -2,   -7, 	  -2,   -5, 	   2,  -12
+.2byte   -3,   -7, 	   1,   -4, 	   2,   -2, 	   0,  -10
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	  -4,   -7, 	  -1,   -6, 	   1,  -12
+.2byte   -3,   -6, 	  -3,   -4, 	   0,   -2, 	  -1,   -8
+.2byte    0,   -6, 	  -3,   -3, 	   3,   -3, 	   0,   -8
+.2byte   -3,   -6, 	  -3,   -4, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	  -2,  -10
+.2byte   -2,   -8, 	   0,   -6, 	  -2,   -3, 	  -1,  -11
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,  -10
+.2byte    1,   -8, 	  -1,   -6, 	   1,   -3, 	   0,  -11
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	   1,  -10
+.2byte    3,   -6, 	   3,   -4, 	   0,   -2, 	   1,   -8
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -9
+.2byte   -2,   -7, 	  -3,   -6, 	   1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -1,   -6, 	  -1,   -3, 	   0,  -10
+.2byte   -1,  -10, 	   3,   -7, 	  -3,   -5, 	   1,  -10
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   3,   -5, 	  -1,  -10
+.2byte    4,   -7, 	   1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    2,   -7, 	   3,   -6, 	  -1,   -4, 	   1,   -9
+.2byte   -4,    2, 	  -7,    5, 	  -1,    5, 	  -4,    0
+.2byte   -4,    2, 	  -7,    4, 	  -1,    4, 	  -4,    0
+.2byte   -4,    2, 	  -7,    5, 	  -1,    5, 	  -4,    0
+sCastformSunnyAnimTable1:
+.4byte sCastformSunnyAnims_1_1
+.4byte sCastformSunnyAnims_1_2
+.4byte sCastformSunnyAnims_1_3
+.4byte sCastformSunnyAnims_1_4
+.4byte sCastformSunnyAnims_1_5
+.4byte sCastformSunnyAnims_1_6
+.4byte sCastformSunnyAnims_1_7
+.4byte sCastformSunnyAnims_1_8
+sCastformSunnyAnimTable2:
+.4byte sCastformSunnyAnims_2_1
+.4byte sCastformSunnyAnims_2_2
+.4byte sCastformSunnyAnims_2_3
+.4byte sCastformSunnyAnims_2_4
+.4byte sCastformSunnyAnims_2_5
+.4byte sCastformSunnyAnims_2_6
+.4byte sCastformSunnyAnims_2_7
+.4byte sCastformSunnyAnims_2_8
+sCastformSunnyAnimTable3:
+.4byte sCastformSunnyAnims_3_1
+.4byte sCastformSunnyAnims_3_2
+.4byte sCastformSunnyAnims_3_3
+.4byte sCastformSunnyAnims_3_4
+.4byte sCastformSunnyAnims_3_5
+.4byte sCastformSunnyAnims_3_6
+.4byte sCastformSunnyAnims_3_7
+.4byte sCastformSunnyAnims_3_8
+sCastformSunnyAnimTable4:
+.4byte sCastformSunnyAnims_4_1
+.4byte sCastformSunnyAnims_4_2
+.4byte sCastformSunnyAnims_4_3
+.4byte sCastformSunnyAnims_4_4
+.4byte sCastformSunnyAnims_4_5
+.4byte sCastformSunnyAnims_4_6
+.4byte sCastformSunnyAnims_4_7
+.4byte sCastformSunnyAnims_4_8
+sCastformSunnyAnimTable5:
+.4byte sCastformSunnyAnims_5_1
+.4byte sCastformSunnyAnims_5_2
+.4byte sCastformSunnyAnims_5_3
+.4byte sCastformSunnyAnims_5_4
+.4byte sCastformSunnyAnims_5_5
+.4byte sCastformSunnyAnims_5_6
+.4byte sCastformSunnyAnims_5_7
+.4byte sCastformSunnyAnims_5_8
+sCastformSunnyAnimTable6:
+.4byte sCastformSunnyAnims_6_1
+.4byte sCastformSunnyAnims_6_1
+.4byte sCastformSunnyAnims_6_1
+.4byte sCastformSunnyAnims_6_1
+.4byte sCastformSunnyAnims_6_1
+.4byte sCastformSunnyAnims_6_1
+.4byte sCastformSunnyAnims_6_1
+.4byte sCastformSunnyAnims_6_1
+sCastformSunnyAnimTable7:
+.4byte sCastformSunnyAnims_7_1
+.4byte sCastformSunnyAnims_7_2
+.4byte sCastformSunnyAnims_7_3
+.4byte sCastformSunnyAnims_7_4
+.4byte sCastformSunnyAnims_7_5
+.4byte sCastformSunnyAnims_7_6
+.4byte sCastformSunnyAnims_7_7
+.4byte sCastformSunnyAnims_7_8
+sCastformSunnyAnimTable8:
+.4byte sCastformSunnyAnims_8_1
+.4byte sCastformSunnyAnims_8_2
+.4byte sCastformSunnyAnims_8_3
+.4byte sCastformSunnyAnims_8_4
+.4byte sCastformSunnyAnims_8_5
+.4byte sCastformSunnyAnims_8_6
+.4byte sCastformSunnyAnims_8_7
+.4byte sCastformSunnyAnims_8_8
+sCastformSunnyAnimTable9:
+.4byte sCastformSunnyAnims_9_1
+.4byte sCastformSunnyAnims_9_2
+.4byte sCastformSunnyAnims_9_3
+.4byte sCastformSunnyAnims_9_4
+.4byte sCastformSunnyAnims_9_5
+.4byte sCastformSunnyAnims_9_6
+.4byte sCastformSunnyAnims_9_7
+.4byte sCastformSunnyAnims_9_8
+sCastformSunnyAnimTable10:
+.4byte sCastformSunnyAnims_10_1
+.4byte sCastformSunnyAnims_10_2
+.4byte sCastformSunnyAnims_10_3
+.4byte sCastformSunnyAnims_10_4
+.4byte sCastformSunnyAnims_10_5
+.4byte sCastformSunnyAnims_10_6
+.4byte sCastformSunnyAnims_10_7
+.4byte sCastformSunnyAnims_10_8
+sCastformSunnyAnimTable11:
+.4byte sCastformSunnyAnims_11_1
+.4byte sCastformSunnyAnims_11_2
+.4byte sCastformSunnyAnims_11_3
+.4byte sCastformSunnyAnims_11_4
+.4byte sCastformSunnyAnims_11_5
+.4byte sCastformSunnyAnims_11_6
+.4byte sCastformSunnyAnims_11_7
+.4byte sCastformSunnyAnims_11_8
+sCastformSunnyAnimTable12:
+.4byte sCastformSunnyAnims_12_1
+.4byte sCastformSunnyAnims_12_2
+.4byte sCastformSunnyAnims_12_3
+.4byte sCastformSunnyAnims_12_4
+.4byte sCastformSunnyAnims_12_5
+.4byte sCastformSunnyAnims_12_6
+.4byte sCastformSunnyAnims_12_7
+.4byte sCastformSunnyAnims_12_8
+sCastformSunnyAnimTable13:
+.4byte sCastformSunnyAnims_13_1
+.4byte sCastformSunnyAnims_13_2
+.4byte sCastformSunnyAnims_13_3
+.4byte sCastformSunnyAnims_13_4
+.4byte sCastformSunnyAnims_13_5
+.4byte sCastformSunnyAnims_13_6
+.4byte sCastformSunnyAnims_13_7
+.4byte sCastformSunnyAnims_13_8
+sAxAnimationsCastformSunny:
+.4byte sCastformSunnyAnimTable1
+.4byte sCastformSunnyAnimTable2
+.4byte sCastformSunnyAnimTable3
+.4byte sCastformSunnyAnimTable4
+.4byte sCastformSunnyAnimTable5
+.4byte sCastformSunnyAnimTable6
+.4byte sCastformSunnyAnimTable7
+.4byte sCastformSunnyAnimTable8
+.4byte sCastformSunnyAnimTable9
+.4byte sCastformSunnyAnimTable10
+.4byte sCastformSunnyAnimTable11
+.4byte sCastformSunnyAnimTable12
+.4byte sCastformSunnyAnimTable13
+sAxSpritesCastformSunny:
+.4byte sCastformSunnySprites1
+.4byte sCastformSunnySprites2
+.4byte sCastformSunnySprites3
+.4byte sCastformSunnySprites4
+.4byte sCastformSunnySprites5
+.4byte sCastformSunnySprites6
+.4byte sCastformSunnySprites7
+.4byte sCastformSunnySprites8
+.4byte sCastformSunnySprites9
+.4byte sCastformSunnySprites10
+.4byte sCastformSunnySprites11
+.4byte sCastformSunnySprites12
+.4byte sCastformSunnySprites13
+.4byte sCastformSunnySprites14
+.4byte sCastformSunnySprites15
+.4byte sCastformSunnySprites16
+.4byte sCastformSunnySprites17
+.4byte sCastformSunnySprites18
+.4byte sCastformSunnySprites19
+.4byte sCastformSunnySprites20
+.4byte sCastformSunnySprites21
+.4byte sCastformSunnySprites22
+.4byte sCastformSunnySprites23
+.4byte sCastformSunnySprites24
+.4byte sCastformSunnySprites25
+.4byte sCastformSunnySprites26
+.4byte sCastformSunnySprites27
+.4byte sCastformSunnySprites28
+.4byte sCastformSunnySprites29
+.4byte sCastformSunnySprites30
+.4byte sCastformSunnySprites31
+.4byte sCastformSunnySprites32
+sAxMainCastformSunny:
+ax_main sAxPosesCastformSunny, sAxAnimationsCastformSunny, 13, sAxSpritesCastformSunny, sAxPositionsCastformSunny

--- a/data/ax/caterpie.inc
+++ b/data/ax/caterpie.inc
@@ -1,0 +1,2638 @@
+.global gAxCaterpie
+gAxCaterpie:
+ax_siro sAxMainCaterpie
+sCaterpiePose1:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose2:
+ax_pose 1, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose3:
+ax_pose 2, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose4:
+ax_pose 3, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose5:
+ax_pose 4, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose6:
+ax_pose 5, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose7:
+ax_pose 6, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose8:
+ax_pose 7, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose9:
+ax_pose 8, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose10:
+ax_pose 9, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose11:
+ax_pose 10, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose12:
+ax_pose 11, 0x01ee, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose13:
+ax_pose 12, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose14:
+ax_pose 13, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose15:
+ax_pose 14, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose17:
+ax_pose 10, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose18:
+ax_pose 11, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose19:
+ax_pose 6, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose20:
+ax_pose 7, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose21:
+ax_pose 8, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose22:
+ax_pose 3, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose23:
+ax_pose 4, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose24:
+ax_pose 5, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose25:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose26:
+ax_pose 1, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose27:
+ax_pose 2, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose28:
+ax_pose 15, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose29:
+ax_pose 16, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose30:
+ax_pose 3, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose31:
+ax_pose 4, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose32:
+ax_pose 5, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose33:
+ax_pose 17, 0x81ed, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose34:
+ax_pose 18, 0x81e9, 0x90f5, 0x3c00
+ax_pose_terminator
+sCaterpiePose35:
+ax_pose 6, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose36:
+ax_pose 7, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose37:
+ax_pose 8, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose38:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose39:
+ax_pose 20, 0x81e9, 0x90f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose40:
+ax_pose 9, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose41:
+ax_pose 10, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose42:
+ax_pose 11, 0x01ee, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose43:
+ax_pose 21, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose44:
+ax_pose 22, 0x81ed, 0x90f5, 0x3c00
+ax_pose_terminator
+sCaterpiePose45:
+ax_pose 12, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose46:
+ax_pose 13, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose47:
+ax_pose 14, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose48:
+ax_pose 23, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose49:
+ax_pose 24, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose50:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose51:
+ax_pose 10, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose52:
+ax_pose 11, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose53:
+ax_pose 21, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose54:
+ax_pose 22, 0x81ed, 0x80fb, 0x3c00
+ax_pose_terminator
+sCaterpiePose55:
+ax_pose 6, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose56:
+ax_pose 7, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose57:
+ax_pose 8, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose58:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose59:
+ax_pose 20, 0x81e9, 0x80fd, 0x3c00
+ax_pose_terminator
+sCaterpiePose60:
+ax_pose 3, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose61:
+ax_pose 4, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose62:
+ax_pose 5, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose63:
+ax_pose 17, 0x81ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose64:
+ax_pose 18, 0x81e9, 0x80fb, 0x3c00
+ax_pose_terminator
+sCaterpiePose65:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose66:
+ax_pose 1, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose67:
+ax_pose 2, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose68:
+ax_pose 15, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose69:
+ax_pose 16, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose70:
+ax_pose 3, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose71:
+ax_pose 4, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose72:
+ax_pose 5, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose73:
+ax_pose 17, 0x81ed, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose74:
+ax_pose 18, 0x81e9, 0x90f5, 0x3c00
+ax_pose_terminator
+sCaterpiePose75:
+ax_pose 6, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose76:
+ax_pose 7, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose77:
+ax_pose 8, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose78:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose79:
+ax_pose 20, 0x81e9, 0x90f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose80:
+ax_pose 9, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose81:
+ax_pose 10, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose82:
+ax_pose 11, 0x01ee, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose83:
+ax_pose 21, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose84:
+ax_pose 22, 0x81ed, 0x90f5, 0x3c00
+ax_pose_terminator
+sCaterpiePose85:
+ax_pose 12, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose86:
+ax_pose 13, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose87:
+ax_pose 14, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose88:
+ax_pose 23, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose89:
+ax_pose 24, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose90:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose91:
+ax_pose 10, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose92:
+ax_pose 11, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose93:
+ax_pose 21, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose94:
+ax_pose 22, 0x81ed, 0x80fb, 0x3c00
+ax_pose_terminator
+sCaterpiePose95:
+ax_pose 6, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose96:
+ax_pose 7, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose97:
+ax_pose 8, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose98:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose99:
+ax_pose 20, 0x81e9, 0x80fd, 0x3c00
+ax_pose_terminator
+sCaterpiePose100:
+ax_pose 3, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose101:
+ax_pose 4, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose102:
+ax_pose 5, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose103:
+ax_pose 17, 0x81ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose104:
+ax_pose 18, 0x81e9, 0x80fb, 0x3c00
+ax_pose_terminator
+sCaterpiePose105:
+ax_pose 15, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose106:
+ax_pose 16, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose107:
+ax_pose 25, 0x01f1, 0x40f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose108:
+ax_pose 17, 0x81ed, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose109:
+ax_pose 18, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose110:
+ax_pose 26, 0x41f3, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose111:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose112:
+ax_pose 20, 0x81e9, 0x90f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose113:
+ax_pose 27, 0x41f3, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose114:
+ax_pose 21, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose115:
+ax_pose 22, 0x81ec, 0x90f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose116:
+ax_pose 28, 0x41f3, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose117:
+ax_pose 23, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose118:
+ax_pose 24, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose119:
+ax_pose 29, 0x81f3, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose120:
+ax_pose 21, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose121:
+ax_pose 22, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose122:
+ax_pose 28, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose123:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose124:
+ax_pose 20, 0x81e9, 0x80f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose125:
+ax_pose 27, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose126:
+ax_pose 17, 0x81ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose127:
+ax_pose 18, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose128:
+ax_pose 26, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose129:
+ax_pose 15, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose130:
+ax_pose 17, 0x81ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose131:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose132:
+ax_pose 21, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose133:
+ax_pose 23, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose134:
+ax_pose 21, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose135:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose136:
+ax_pose 17, 0x81ed, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose137:
+ax_pose 30, 0x41f2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose138:
+ax_pose 31, 0x41f2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose139:
+ax_pose 32, 0x81e2, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose140:
+ax_pose 33, 0x01e4, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose141:
+ax_pose 34, 0x01e4, 0x90eb, 0x3c00
+ax_pose_terminator
+sCaterpiePose142:
+ax_pose 35, 0x01e6, 0x90e7, 0x3c00
+ax_pose_terminator
+sCaterpiePose143:
+ax_pose 36, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose144:
+ax_pose 35, 0x01e6, 0x80fa, 0x3c00
+ax_pose_terminator
+sCaterpiePose145:
+ax_pose 34, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sCaterpiePose146:
+ax_pose 33, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose147:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose148:
+ax_pose 1, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose149:
+ax_pose 2, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose150:
+ax_pose 15, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose151:
+ax_pose 3, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose152:
+ax_pose 4, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose153:
+ax_pose 5, 0x41f4, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose154:
+ax_pose 17, 0x81ec, 0x90fa, 0x3c00
+ax_pose_terminator
+sCaterpiePose155:
+ax_pose 6, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose156:
+ax_pose 7, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose157:
+ax_pose 8, 0x41f1, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose158:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose159:
+ax_pose 9, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose160:
+ax_pose 10, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose161:
+ax_pose 11, 0x01ee, 0x90f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose162:
+ax_pose 21, 0x81e9, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose163:
+ax_pose 12, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose164:
+ax_pose 13, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose165:
+ax_pose 14, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose166:
+ax_pose 23, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose167:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose168:
+ax_pose 10, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose169:
+ax_pose 11, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sCaterpiePose170:
+ax_pose 21, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose171:
+ax_pose 6, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose172:
+ax_pose 7, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose173:
+ax_pose 8, 0x41f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose174:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose175:
+ax_pose 3, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose176:
+ax_pose 4, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose177:
+ax_pose 5, 0x41f4, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose178:
+ax_pose 17, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose179:
+ax_pose 2, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose180:
+ax_pose 5, 0x41f5, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose181:
+ax_pose 8, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sCaterpiePose182:
+ax_pose 11, 0x01f0, 0x80f2, 0x3c00
+ax_pose_terminator
+sCaterpiePose183:
+ax_pose 14, 0x81f2, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose184:
+ax_pose 11, 0x01f0, 0x90ee, 0x3c00
+ax_pose_terminator
+sCaterpiePose185:
+ax_pose 8, 0x41f3, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose186:
+ax_pose 5, 0x41f5, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose187:
+ax_pose 15, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose188:
+ax_pose 17, 0x81ed, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose189:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose190:
+ax_pose 21, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose191:
+ax_pose 23, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose192:
+ax_pose 21, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose193:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose194:
+ax_pose 17, 0x81ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose195:
+ax_pose 15, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose196:
+ax_pose 16, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose197:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose198:
+ax_pose 17, 0x81ed, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose199:
+ax_pose 18, 0x81e9, 0x90f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose200:
+ax_pose 3, 0x41f4, 0x90ed, 0x3c00
+ax_pose_terminator
+sCaterpiePose201:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose202:
+ax_pose 20, 0x81e9, 0x90f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose203:
+ax_pose 6, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose204:
+ax_pose 21, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose205:
+ax_pose 22, 0x81ed, 0x90f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose206:
+ax_pose 9, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sCaterpiePose207:
+ax_pose 23, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose208:
+ax_pose 24, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose209:
+ax_pose 12, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose210:
+ax_pose 21, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose211:
+ax_pose 22, 0x81ed, 0x80f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose212:
+ax_pose 9, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose213:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose214:
+ax_pose 20, 0x81e9, 0x80fa, 0x3c00
+ax_pose_terminator
+sCaterpiePose215:
+ax_pose 6, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sCaterpiePose216:
+ax_pose 17, 0x81ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose217:
+ax_pose 18, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose218:
+ax_pose 3, 0x41f4, 0x80f3, 0x3c00
+ax_pose_terminator
+sCaterpiePose219:
+ax_pose 16, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose220:
+ax_pose 18, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose221:
+ax_pose 20, 0x81e9, 0x80fa, 0x3c00
+ax_pose_terminator
+sCaterpiePose222:
+ax_pose 22, 0x81ed, 0x80f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose223:
+ax_pose 24, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose224:
+ax_pose 22, 0x81ed, 0x90f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose225:
+ax_pose 20, 0x81e9, 0x90f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose226:
+ax_pose 18, 0x81e9, 0x90f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose227:
+ax_pose 15, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose228:
+ax_pose 17, 0x81ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose229:
+ax_pose 19, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sCaterpiePose230:
+ax_pose 21, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sCaterpiePose231:
+ax_pose 23, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sCaterpiePose232:
+ax_pose 21, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sCaterpiePose233:
+ax_pose 19, 0x01e9, 0x90ea, 0x3c00
+ax_pose_terminator
+sCaterpiePose234:
+ax_pose 17, 0x81ed, 0x90f9, 0x3c00
+ax_pose_terminator
+.align 2
+sCaterpieAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 2, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 4, 0, 4,
+ax_anim 2, 2, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 15, 0, 15,
+ax_anim 2, 1, 28, 1, 15, 1, 15,
+ax_anim 2, 0, 28, 0, 15, 0, 15,
+ax_anim 2, 0, 28, 1, 15, 1, 15,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCaterpieAnims_2_2:
+ax_anim 4, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 4, 0, 30, -2, -2, -2, -2,
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 2, 0, 31, 4, 4, 4, 4,
+ax_anim 2, 2, 32, 8, 8, 12, 12,
+ax_anim 2, 0, 33, 18, 18, 16, 17,
+ax_anim 2, 1, 33, 19, 17, 17, 16,
+ax_anim 2, 0, 33, 18, 18, 16, 17,
+ax_anim 2, 0, 33, 19, 17, 17, 16,
+ax_anim 4, 0, 29, 8, 8, 6, 6,
+ax_anim_terminator
+sCaterpieAnims_2_3:
+ax_anim 4, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 4, 0, 35, -2, 0, -2, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 4, 0, 4, 0,
+ax_anim 2, 2, 37, 13, 0, 13, 0,
+ax_anim 2, 0, 38, 21, 0, 18, 0,
+ax_anim 2, 1, 38, 21, 1, 18, 1,
+ax_anim 2, 0, 38, 21, 0, 18, 0,
+ax_anim 2, 0, 38, 21, 1, 18, 1,
+ax_anim 4, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sCaterpieAnims_2_4:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, -1, 1, -1, 1,
+ax_anim 4, 0, 40, -2, 2, -2, 2,
+ax_anim 2, 0, 41, 0, -1, 0, -1,
+ax_anim 2, 0, 41, 4, -4, 4, -4,
+ax_anim 2, 2, 42, 10, -10, 10, -10,
+ax_anim 2, 0, 43, 18, -18, 17, -17,
+ax_anim 2, 1, 43, 19, -17, 18, -16,
+ax_anim 2, 0, 43, 18, -18, 17, -17,
+ax_anim 2, 0, 43, 19, -17, 18, -16,
+ax_anim 4, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sCaterpieAnims_2_5:
+ax_anim 4, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 1, 0, 1,
+ax_anim 4, 0, 45, 0, 2, 0, 2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, -4, 0, -4,
+ax_anim 2, 2, 47, 0, -10, 0, -10,
+ax_anim 2, 0, 48, 0, -18, 0, -18,
+ax_anim 2, 1, 48, 1, -18, 1, -18,
+ax_anim 2, 0, 48, 0, -18, 0, -18,
+ax_anim 2, 0, 48, 1, -18, 1, -18,
+ax_anim 4, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sCaterpieAnims_2_6:
+ax_anim 4, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 1, 1, 1, 1,
+ax_anim 4, 0, 50, 2, 2, 2, 2,
+ax_anim 2, 0, 51, 0, -1, 0, -1,
+ax_anim 2, 0, 51, -4, -4, -4, -4,
+ax_anim 2, 2, 52, -10, -10, -10, -10,
+ax_anim 2, 0, 53, -18, -18, -18, -18,
+ax_anim 2, 1, 53, -19, -17, -19, -17,
+ax_anim 2, 0, 53, -18, -18, -18, -18,
+ax_anim 2, 0, 53, -19, -17, -19, -17,
+ax_anim 4, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sCaterpieAnims_2_7:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 1, 0, 1, 0,
+ax_anim 4, 0, 55, 2, 0, 2, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, -4, 0, -4, 0,
+ax_anim 2, 2, 57, -13, 0, -13, 0,
+ax_anim 2, 0, 58, -21, 0, -21, 0,
+ax_anim 2, 1, 58, -21, 1, -21, 1,
+ax_anim 2, 0, 58, -21, 0, -21, 0,
+ax_anim 2, 0, 58, -21, 1, -21, 1,
+ax_anim 4, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sCaterpieAnims_2_8:
+ax_anim 4, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 1, -1, 1, -1,
+ax_anim 4, 0, 60, 2, -2, 2, -2,
+ax_anim 2, 0, 61, 0, -1, 0, -1,
+ax_anim 2, 0, 61, -4, 4, -4, 4,
+ax_anim 2, 2, 62, -8, 8, -8, 8,
+ax_anim 2, 0, 63, -18, 18, -18, 18,
+ax_anim 2, 1, 63, -19, 17, -19, 17,
+ax_anim 2, 0, 63, -18, 18, -18, 18,
+ax_anim 2, 0, 63, -19, 17, -19, 17,
+ax_anim 4, 0, 59, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_3_1:
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, -1, 0, -1,
+ax_anim 4, 0, 65, 0, -2, 0, -2,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 4, 0, 4,
+ax_anim 2, 2, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 15, 0, 15,
+ax_anim 2, 1, 68, 1, 15, 1, 15,
+ax_anim 2, 0, 68, 0, 15, 0, 15,
+ax_anim 2, 0, 68, 1, 15, 1, 15,
+ax_anim 4, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sCaterpieAnims_3_2:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, -1, -1, -1, -1,
+ax_anim 4, 0, 70, -2, -2, -2, -2,
+ax_anim 2, 0, 71, 0, -1, 0, 0,
+ax_anim 2, 0, 71, 4, 4, 4, 4,
+ax_anim 2, 2, 72, 8, 8, 12, 12,
+ax_anim 2, 0, 73, 18, 18, 16, 17,
+ax_anim 2, 1, 73, 19, 17, 17, 16,
+ax_anim 2, 0, 73, 18, 18, 16, 17,
+ax_anim 2, 0, 73, 19, 17, 17, 16,
+ax_anim 4, 0, 69, 8, 8, 6, 6,
+ax_anim_terminator
+sCaterpieAnims_3_3:
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 4, 0, 75, -2, 0, -2, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 4, 0, 4, 0,
+ax_anim 2, 2, 77, 13, 0, 13, 0,
+ax_anim 2, 0, 78, 21, 0, 18, 0,
+ax_anim 2, 1, 78, 21, 1, 18, 1,
+ax_anim 2, 0, 78, 21, 0, 18, 0,
+ax_anim 2, 0, 78, 21, 1, 18, 1,
+ax_anim 4, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sCaterpieAnims_3_4:
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 1, -1, 1,
+ax_anim 4, 0, 80, -2, 2, -2, 2,
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 0, 81, 4, -4, 4, -4,
+ax_anim 2, 2, 82, 10, -10, 10, -10,
+ax_anim 2, 0, 83, 18, -18, 17, -17,
+ax_anim 2, 1, 83, 19, -17, 18, -16,
+ax_anim 2, 0, 83, 18, -18, 17, -17,
+ax_anim 2, 0, 83, 19, -17, 18, -16,
+ax_anim 4, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sCaterpieAnims_3_5:
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim 4, 0, 85, 0, 2, 0, 2,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 2, 87, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 0, -18, 0, -18,
+ax_anim 2, 1, 88, 1, -18, 1, -18,
+ax_anim 2, 0, 88, 0, -18, 0, -18,
+ax_anim 2, 0, 88, 1, -18, 1, -18,
+ax_anim 4, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sCaterpieAnims_3_6:
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim 4, 0, 90, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, -4, -4, -4, -4,
+ax_anim 2, 2, 92, -10, -10, -10, -10,
+ax_anim 2, 0, 93, -18, -18, -18, -18,
+ax_anim 2, 1, 93, -19, -17, -19, -17,
+ax_anim 2, 0, 93, -18, -18, -18, -18,
+ax_anim 2, 0, 93, -19, -17, -19, -17,
+ax_anim 4, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sCaterpieAnims_3_7:
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 4, 0, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -4, 0, -4, 0,
+ax_anim 2, 2, 97, -13, 0, -13, 0,
+ax_anim 2, 0, 98, -21, 0, -21, 0,
+ax_anim 2, 1, 98, -21, 1, -21, 1,
+ax_anim 2, 0, 98, -21, 0, -21, 0,
+ax_anim 2, 0, 98, -21, 1, -21, 1,
+ax_anim 4, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sCaterpieAnims_3_8:
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 4, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, -4, 4, -4, 4,
+ax_anim 2, 2, 102, -8, 8, -8, 8,
+ax_anim 2, 0, 103, -18, 18, -18, 18,
+ax_anim 2, 1, 103, -19, 17, -19, 17,
+ax_anim 2, 0, 103, -18, 18, -18, 18,
+ax_anim 2, 0, 103, -19, 17, -19, 17,
+ax_anim 4, 0, 99, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_4_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 1, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -1, 0, -1,
+ax_anim 6, 0, 105, 0, -2, 0, -2,
+ax_anim_terminator
+sCaterpieAnims_4_2:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 1, 107, 1, 1, 1, 1,
+ax_anim 1, 0, 108, -1, -1, -1, -1,
+ax_anim 6, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sCaterpieAnims_4_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 1, 110, 1, 0, 1, 0,
+ax_anim 1, 0, 111, -1, 0, -1, 0,
+ax_anim 6, 0, 111, -2, 0, -2, 0,
+ax_anim_terminator
+sCaterpieAnims_4_4:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 1, 113, 0, 0, 1, -1,
+ax_anim 1, 0, 114, -1, 1, -1, 1,
+ax_anim 6, 0, 114, -2, 2, -2, 2,
+ax_anim_terminator
+sCaterpieAnims_4_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 118, -1, 0, -1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 1, 116, 0, 0, 1, -1,
+ax_anim 1, 0, 117, 0, 1, 0, 1,
+ax_anim 6, 0, 117, 0, 2, 0, 2,
+ax_anim_terminator
+sCaterpieAnims_4_6:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 1, 119, 0, 0, -1, -1,
+ax_anim 1, 0, 120, 1, 1, 1, 1,
+ax_anim 6, 0, 120, 2, 2, 2, 2,
+ax_anim_terminator
+sCaterpieAnims_4_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 1, 122, -1, 0, -1, 0,
+ax_anim 1, 0, 123, 1, 0, 1, 0,
+ax_anim 6, 0, 123, 2, 0, 2, 0,
+ax_anim_terminator
+sCaterpieAnims_4_8:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 1, 125, -1, 1, -1, 1,
+ax_anim 1, 0, 126, 1, -1, 1, -1,
+ax_anim 6, 0, 126, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sCaterpieAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sCaterpieAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sCaterpieAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sCaterpieAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sCaterpieAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sCaterpieAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sCaterpieAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_8_1:
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, -1, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_8_2:
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 153, 0, -1, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_8_3:
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 10, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_8_4:
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_8_5:
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim 4, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_8_6:
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, -1, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_8_7:
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, -1, 0, 0,
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_8_8:
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 13, 7, 13,
+ax_anim 3, 0, 182, 1, 16, 1, 16,
+ax_anim 2, 3, 183, -4, 14, -4, 14,
+ax_anim 2, 0, 184, -5, 8, -5, 8,
+ax_anim 1, 0, 185, -4, 4, -4, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 24, 9, 24, 9,
+ax_anim 3, 0, 181, 23, 16, 23, 16,
+ax_anim 2, 3, 182, 11, 16, 11, 16,
+ax_anim 2, 0, 183, 4, 12, 4, 12,
+ax_anim 1, 0, 184, 1, 7, 1, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 20, 1, 20, 1,
+ax_anim 2, 3, 181, 17, 5, 17, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 1, -6, 1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 11, -20, 11, -20,
+ax_anim 3, 0, 179, 16, -20, 16, -20,
+ax_anim 2, 3, 180, 16, -15, 16, -15,
+ax_anim 2, 0, 181, 14, -6, 14, -6,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -8, -9, -8, -9,
+ax_anim 2, 0, 185, -7, -13, -7, -13,
+ax_anim 3, 0, 178, -1, -16, -1, -16,
+ax_anim 2, 3, 179, 4, -14, 4, -14,
+ax_anim 2, 0, 180, 5, -8, 5, -8,
+ax_anim 1, 0, 181, 4, -4, 4, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -1, -6, -1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -11, -20, -11, -20,
+ax_anim 3, 0, 185, -16, -20, -16, -20,
+ax_anim 2, 3, 184, -16, -15, -16, -15,
+ax_anim 2, 0, 183, -14, -6, -14, -6,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -4, -17, -4,
+ax_anim 3, 0, 184, -20, 1, -20, 1,
+ax_anim 2, 3, 183, -17, 5, -17, 5,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -24, 9, -24, 9,
+ax_anim 3, 0, 183, -23, 16, -23, 16,
+ax_anim 2, 3, 182, -11, 16, -11, 16,
+ax_anim 2, 0, 181, -4, 12, -4, 12,
+ax_anim 1, 0, 180, -1, 7, -1, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCaterpieAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sCaterpieGfx1:
+.incbin "baserom.gba", 0x5856DC, 0x100
+sCaterpieSprites1:
+ax_sprite sCaterpieGfx1, 0x100
+ax_sprite_terminator
+sCaterpieGfx2:
+.incbin "baserom.gba", 0x5857EC, 0x100
+sCaterpieSprites2:
+ax_sprite sCaterpieGfx2, 0x100
+ax_sprite_terminator
+sCaterpieGfx3:
+.incbin "baserom.gba", 0x5858FC, 0x100
+sCaterpieSprites3:
+ax_sprite sCaterpieGfx3, 0x100
+ax_sprite_terminator
+sCaterpieGfx4:
+.incbin "baserom.gba", 0x585A0C, 0x100
+sCaterpieSprites4:
+ax_sprite sCaterpieGfx4, 0x100
+ax_sprite_terminator
+sCaterpieGfx5:
+.incbin "baserom.gba", 0x585B1C, 0x100
+sCaterpieSprites5:
+ax_sprite sCaterpieGfx5, 0x100
+ax_sprite_terminator
+sCaterpieGfx6:
+.incbin "baserom.gba", 0x585C2C, 0x100
+sCaterpieSprites6:
+ax_sprite sCaterpieGfx6, 0x100
+ax_sprite_terminator
+sCaterpieGfx7:
+.incbin "baserom.gba", 0x585D3C, 0x200
+sCaterpieSprites7:
+ax_sprite sCaterpieGfx7, 0x200
+ax_sprite_terminator
+sCaterpieGfx8:
+.incbin "baserom.gba", 0x585F4C, 0x100
+sCaterpieSprites8:
+ax_sprite sCaterpieGfx8, 0x100
+ax_sprite_terminator
+sCaterpieGfx9:
+.incbin "baserom.gba", 0x58605C, 0x100
+sCaterpieSprites9:
+ax_sprite sCaterpieGfx9, 0x100
+ax_sprite_terminator
+sCaterpieGfx10:
+.incbin "baserom.gba", 0x58616C, 0x200
+sCaterpieSprites10:
+ax_sprite sCaterpieGfx10, 0x200
+ax_sprite_terminator
+sCaterpieGfx11:
+.incbin "baserom.gba", 0x58637C, 0x200
+sCaterpieSprites11:
+ax_sprite sCaterpieGfx11, 0x200
+ax_sprite_terminator
+sCaterpieGfx12:
+.incbin "baserom.gba", 0x58658C, 0x200
+sCaterpieSprites12:
+ax_sprite sCaterpieGfx12, 0x200
+ax_sprite_terminator
+sCaterpieGfx13:
+.incbin "baserom.gba", 0x58679C, 0x100
+sCaterpieSprites13:
+ax_sprite sCaterpieGfx13, 0x100
+ax_sprite_terminator
+sCaterpieGfx14:
+.incbin "baserom.gba", 0x5868AC, 0x100
+sCaterpieSprites14:
+ax_sprite sCaterpieGfx14, 0x100
+ax_sprite_terminator
+sCaterpieGfx15:
+.incbin "baserom.gba", 0x5869BC, 0x100
+sCaterpieSprites15:
+ax_sprite sCaterpieGfx15, 0x100
+ax_sprite_terminator
+sCaterpieGfx16:
+.incbin "baserom.gba", 0x586ACC, 0xC0
+sCaterpieSprites16:
+ax_sprite sCaterpieGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx17:
+.incbin "baserom.gba", 0x586BA4, 0xC0
+sCaterpieSprites17:
+ax_sprite sCaterpieGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx18:
+.incbin "baserom.gba", 0x586C7C, 0xC0
+sCaterpieSprites18:
+ax_sprite sCaterpieGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx19:
+.incbin "baserom.gba", 0x586D54, 0xC0
+sCaterpieSprites19:
+ax_sprite sCaterpieGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx20:
+.incbin "baserom.gba", 0x586E2C, 0x20
+sCaterpieGfx20_1:
+.incbin "baserom.gba", 0x586E4C, 0x40
+sCaterpieGfx20_2:
+.incbin "baserom.gba", 0x586E8C, 0x60
+sCaterpieSprites20:
+ax_sprite sCaterpieGfx20, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCaterpieGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCaterpieGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCaterpieGfx21:
+.incbin "baserom.gba", 0x586F24, 0xC0
+sCaterpieSprites21:
+ax_sprite sCaterpieGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx22:
+.incbin "baserom.gba", 0x586FFC, 0xC0
+sCaterpieSprites22:
+ax_sprite sCaterpieGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx23:
+.incbin "baserom.gba", 0x5870D4, 0xC0
+sCaterpieSprites23:
+ax_sprite sCaterpieGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx24:
+.incbin "baserom.gba", 0x5871AC, 0xC0
+sCaterpieSprites24:
+ax_sprite sCaterpieGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx25:
+.incbin "baserom.gba", 0x587284, 0xC0
+sCaterpieSprites25:
+ax_sprite sCaterpieGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx26:
+.incbin "baserom.gba", 0x58735C, 0x80
+sCaterpieSprites26:
+ax_sprite sCaterpieGfx26, 0x80
+ax_sprite_terminator
+sCaterpieGfx27:
+.incbin "baserom.gba", 0x5873EC, 0x60
+sCaterpieGfx27_1:
+.incbin "baserom.gba", 0x58744C, 0x60
+sCaterpieSprites27:
+ax_sprite sCaterpieGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCaterpieGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCaterpieGfx28:
+.incbin "baserom.gba", 0x5874D4, 0x60
+sCaterpieGfx28_1:
+.incbin "baserom.gba", 0x587534, 0x60
+sCaterpieSprites28:
+ax_sprite sCaterpieGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCaterpieGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCaterpieGfx29:
+.incbin "baserom.gba", 0x5875BC, 0x60
+sCaterpieGfx29_1:
+.incbin "baserom.gba", 0x58761C, 0x60
+sCaterpieSprites29:
+ax_sprite sCaterpieGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCaterpieGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCaterpieGfx30:
+.incbin "baserom.gba", 0x5876A4, 0xC0
+sCaterpieSprites30:
+ax_sprite sCaterpieGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCaterpieGfx31:
+.incbin "baserom.gba", 0x58777C, 0x100
+sCaterpieSprites31:
+ax_sprite sCaterpieGfx31, 0x100
+ax_sprite_terminator
+sCaterpieGfx32:
+.incbin "baserom.gba", 0x58788C, 0x100
+sCaterpieSprites32:
+ax_sprite sCaterpieGfx32, 0x100
+ax_sprite_terminator
+sCaterpieGfx33:
+.incbin "baserom.gba", 0x58799C, 0x100
+sCaterpieSprites33:
+ax_sprite sCaterpieGfx33, 0x100
+ax_sprite_terminator
+sCaterpieGfx34:
+.incbin "baserom.gba", 0x587AAC, 0x200
+sCaterpieSprites34:
+ax_sprite sCaterpieGfx34, 0x200
+ax_sprite_terminator
+sCaterpieGfx35:
+.incbin "baserom.gba", 0x587CBC, 0x200
+sCaterpieSprites35:
+ax_sprite sCaterpieGfx35, 0x200
+ax_sprite_terminator
+sCaterpieGfx36:
+.incbin "baserom.gba", 0x587ECC, 0x200
+sCaterpieSprites36:
+ax_sprite sCaterpieGfx36, 0x200
+ax_sprite_terminator
+sCaterpieGfx37:
+.incbin "baserom.gba", 0x5880DC, 0x200
+sCaterpieSprites37:
+ax_sprite sCaterpieGfx37, 0x200
+ax_sprite_terminator
+sAxPosesCaterpie:
+.4byte sCaterpiePose1
+.4byte sCaterpiePose2
+.4byte sCaterpiePose3
+.4byte sCaterpiePose4
+.4byte sCaterpiePose5
+.4byte sCaterpiePose6
+.4byte sCaterpiePose7
+.4byte sCaterpiePose8
+.4byte sCaterpiePose9
+.4byte sCaterpiePose10
+.4byte sCaterpiePose11
+.4byte sCaterpiePose12
+.4byte sCaterpiePose13
+.4byte sCaterpiePose14
+.4byte sCaterpiePose15
+.4byte sCaterpiePose16
+.4byte sCaterpiePose17
+.4byte sCaterpiePose18
+.4byte sCaterpiePose19
+.4byte sCaterpiePose20
+.4byte sCaterpiePose21
+.4byte sCaterpiePose22
+.4byte sCaterpiePose23
+.4byte sCaterpiePose24
+.4byte sCaterpiePose25
+.4byte sCaterpiePose26
+.4byte sCaterpiePose27
+.4byte sCaterpiePose28
+.4byte sCaterpiePose29
+.4byte sCaterpiePose30
+.4byte sCaterpiePose31
+.4byte sCaterpiePose32
+.4byte sCaterpiePose33
+.4byte sCaterpiePose34
+.4byte sCaterpiePose35
+.4byte sCaterpiePose36
+.4byte sCaterpiePose37
+.4byte sCaterpiePose38
+.4byte sCaterpiePose39
+.4byte sCaterpiePose40
+.4byte sCaterpiePose41
+.4byte sCaterpiePose42
+.4byte sCaterpiePose43
+.4byte sCaterpiePose44
+.4byte sCaterpiePose45
+.4byte sCaterpiePose46
+.4byte sCaterpiePose47
+.4byte sCaterpiePose48
+.4byte sCaterpiePose49
+.4byte sCaterpiePose50
+.4byte sCaterpiePose51
+.4byte sCaterpiePose52
+.4byte sCaterpiePose53
+.4byte sCaterpiePose54
+.4byte sCaterpiePose55
+.4byte sCaterpiePose56
+.4byte sCaterpiePose57
+.4byte sCaterpiePose58
+.4byte sCaterpiePose59
+.4byte sCaterpiePose60
+.4byte sCaterpiePose61
+.4byte sCaterpiePose62
+.4byte sCaterpiePose63
+.4byte sCaterpiePose64
+.4byte sCaterpiePose65
+.4byte sCaterpiePose66
+.4byte sCaterpiePose67
+.4byte sCaterpiePose68
+.4byte sCaterpiePose69
+.4byte sCaterpiePose70
+.4byte sCaterpiePose71
+.4byte sCaterpiePose72
+.4byte sCaterpiePose73
+.4byte sCaterpiePose74
+.4byte sCaterpiePose75
+.4byte sCaterpiePose76
+.4byte sCaterpiePose77
+.4byte sCaterpiePose78
+.4byte sCaterpiePose79
+.4byte sCaterpiePose80
+.4byte sCaterpiePose81
+.4byte sCaterpiePose82
+.4byte sCaterpiePose83
+.4byte sCaterpiePose84
+.4byte sCaterpiePose85
+.4byte sCaterpiePose86
+.4byte sCaterpiePose87
+.4byte sCaterpiePose88
+.4byte sCaterpiePose89
+.4byte sCaterpiePose90
+.4byte sCaterpiePose91
+.4byte sCaterpiePose92
+.4byte sCaterpiePose93
+.4byte sCaterpiePose94
+.4byte sCaterpiePose95
+.4byte sCaterpiePose96
+.4byte sCaterpiePose97
+.4byte sCaterpiePose98
+.4byte sCaterpiePose99
+.4byte sCaterpiePose100
+.4byte sCaterpiePose101
+.4byte sCaterpiePose102
+.4byte sCaterpiePose103
+.4byte sCaterpiePose104
+.4byte sCaterpiePose105
+.4byte sCaterpiePose106
+.4byte sCaterpiePose107
+.4byte sCaterpiePose108
+.4byte sCaterpiePose109
+.4byte sCaterpiePose110
+.4byte sCaterpiePose111
+.4byte sCaterpiePose112
+.4byte sCaterpiePose113
+.4byte sCaterpiePose114
+.4byte sCaterpiePose115
+.4byte sCaterpiePose116
+.4byte sCaterpiePose117
+.4byte sCaterpiePose118
+.4byte sCaterpiePose119
+.4byte sCaterpiePose120
+.4byte sCaterpiePose121
+.4byte sCaterpiePose122
+.4byte sCaterpiePose123
+.4byte sCaterpiePose124
+.4byte sCaterpiePose125
+.4byte sCaterpiePose126
+.4byte sCaterpiePose127
+.4byte sCaterpiePose128
+.4byte sCaterpiePose129
+.4byte sCaterpiePose130
+.4byte sCaterpiePose131
+.4byte sCaterpiePose132
+.4byte sCaterpiePose133
+.4byte sCaterpiePose134
+.4byte sCaterpiePose135
+.4byte sCaterpiePose136
+.4byte sCaterpiePose137
+.4byte sCaterpiePose138
+.4byte sCaterpiePose139
+.4byte sCaterpiePose140
+.4byte sCaterpiePose141
+.4byte sCaterpiePose142
+.4byte sCaterpiePose143
+.4byte sCaterpiePose144
+.4byte sCaterpiePose145
+.4byte sCaterpiePose146
+.4byte sCaterpiePose147
+.4byte sCaterpiePose148
+.4byte sCaterpiePose149
+.4byte sCaterpiePose150
+.4byte sCaterpiePose151
+.4byte sCaterpiePose152
+.4byte sCaterpiePose153
+.4byte sCaterpiePose154
+.4byte sCaterpiePose155
+.4byte sCaterpiePose156
+.4byte sCaterpiePose157
+.4byte sCaterpiePose158
+.4byte sCaterpiePose159
+.4byte sCaterpiePose160
+.4byte sCaterpiePose161
+.4byte sCaterpiePose162
+.4byte sCaterpiePose163
+.4byte sCaterpiePose164
+.4byte sCaterpiePose165
+.4byte sCaterpiePose166
+.4byte sCaterpiePose167
+.4byte sCaterpiePose168
+.4byte sCaterpiePose169
+.4byte sCaterpiePose170
+.4byte sCaterpiePose171
+.4byte sCaterpiePose172
+.4byte sCaterpiePose173
+.4byte sCaterpiePose174
+.4byte sCaterpiePose175
+.4byte sCaterpiePose176
+.4byte sCaterpiePose177
+.4byte sCaterpiePose178
+.4byte sCaterpiePose179
+.4byte sCaterpiePose180
+.4byte sCaterpiePose181
+.4byte sCaterpiePose182
+.4byte sCaterpiePose183
+.4byte sCaterpiePose184
+.4byte sCaterpiePose185
+.4byte sCaterpiePose186
+.4byte sCaterpiePose187
+.4byte sCaterpiePose188
+.4byte sCaterpiePose189
+.4byte sCaterpiePose190
+.4byte sCaterpiePose191
+.4byte sCaterpiePose192
+.4byte sCaterpiePose193
+.4byte sCaterpiePose194
+.4byte sCaterpiePose195
+.4byte sCaterpiePose196
+.4byte sCaterpiePose197
+.4byte sCaterpiePose198
+.4byte sCaterpiePose199
+.4byte sCaterpiePose200
+.4byte sCaterpiePose201
+.4byte sCaterpiePose202
+.4byte sCaterpiePose203
+.4byte sCaterpiePose204
+.4byte sCaterpiePose205
+.4byte sCaterpiePose206
+.4byte sCaterpiePose207
+.4byte sCaterpiePose208
+.4byte sCaterpiePose209
+.4byte sCaterpiePose210
+.4byte sCaterpiePose211
+.4byte sCaterpiePose212
+.4byte sCaterpiePose213
+.4byte sCaterpiePose214
+.4byte sCaterpiePose215
+.4byte sCaterpiePose216
+.4byte sCaterpiePose217
+.4byte sCaterpiePose218
+.4byte sCaterpiePose219
+.4byte sCaterpiePose220
+.4byte sCaterpiePose221
+.4byte sCaterpiePose222
+.4byte sCaterpiePose223
+.4byte sCaterpiePose224
+.4byte sCaterpiePose225
+.4byte sCaterpiePose226
+.4byte sCaterpiePose227
+.4byte sCaterpiePose228
+.4byte sCaterpiePose229
+.4byte sCaterpiePose230
+.4byte sCaterpiePose231
+.4byte sCaterpiePose232
+.4byte sCaterpiePose233
+.4byte sCaterpiePose234
+sAxPositionsCaterpie:
+.2byte   -1,    0, 	  -3,    0, 	   2,    0, 	   0,   -4
+.2byte   -1,    1, 	  -3,    1, 	   2,    1, 	   0,   -4
+.2byte   -1,    2, 	  -3,    2, 	   2,    2, 	   0,   -4
+.2byte    7,   -2, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    8,   -1, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    9,    0, 	   5,    1, 	   2,    2, 	   0,   -2
+.2byte    9,   -5, 	   3,   -2, 	   2,   -1, 	   0,   -4
+.2byte   10,   -4, 	   3,   -2, 	   2,   -1, 	   0,   -5
+.2byte   11,   -4, 	   5,   -2, 	   4,   -1, 	   0,   -4
+.2byte    6,   -6, 	   0,   -5, 	   4,   -2, 	  -1,   -3
+.2byte    7,   -5, 	   0,   -5, 	   4,   -2, 	   0,   -6
+.2byte    8,   -6, 	   2,   -5, 	   6,   -3, 	   1,   -4
+.2byte   -1,  -10, 	   2,   -7, 	  -3,   -7, 	   0,   -4
+.2byte    0,   -9, 	   2,   -6, 	  -3,   -6, 	   0,   -4
+.2byte    0,  -13, 	   2,  -10, 	  -3,  -10, 	  -1,   -6
+.2byte   -7,   -6, 	  -1,   -5, 	  -5,   -2, 	   0,   -3
+.2byte   -8,   -5, 	  -1,   -5, 	  -5,   -2, 	  -1,   -6
+.2byte   -9,   -6, 	  -3,   -5, 	  -7,   -3, 	  -2,   -4
+.2byte  -10,   -5, 	  -4,   -2, 	  -3,   -1, 	  -1,   -4
+.2byte  -11,   -4, 	  -4,   -2, 	  -3,   -1, 	  -1,   -5
+.2byte  -12,   -4, 	  -6,   -2, 	  -5,   -1, 	  -1,   -4
+.2byte  -10,   -2, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -11,   -1, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -12,    0, 	  -8,    1, 	  -5,    2, 	  -3,   -2
+.2byte   -1,    0, 	  -3,    0, 	   2,    0, 	   0,   -4
+.2byte   -1,    1, 	  -3,    1, 	   2,    1, 	   0,   -4
+.2byte   -1,    2, 	  -3,    2, 	   2,    2, 	   0,   -4
+.2byte   -1,   -5, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    0,  -10, 	  -3,   -7, 	   1,   -7, 	   0,   -7
+.2byte    7,   -2, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    8,   -1, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    9,    0, 	   5,    1, 	   2,    2, 	   0,   -2
+.2byte    5,   -5, 	   3,   -3, 	   0,   -3, 	   1,   -6
+.2byte    1,  -12, 	   1,   -6, 	  -1,   -6, 	  -3,   -8
+.2byte    9,   -5, 	   3,   -2, 	   2,   -1, 	   0,   -4
+.2byte   10,   -4, 	   3,   -2, 	   2,   -1, 	   0,   -5
+.2byte   11,   -4, 	   5,   -2, 	   4,   -1, 	   0,   -4
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    0,  -15, 	  -2,  -10, 	   0,   -7, 	  -4,   -7
+.2byte    6,   -6, 	   0,   -5, 	   4,   -2, 	  -1,   -3
+.2byte    7,   -5, 	   0,   -5, 	   4,   -2, 	   0,   -6
+.2byte    8,   -6, 	   2,   -5, 	   6,   -3, 	   1,   -4
+.2byte    5,   -8, 	  -1,   -6, 	   2,   -2, 	   0,   -6
+.2byte    1,  -16, 	  -4,   -9, 	   1,   -6, 	  -3,   -6
+.2byte   -1,  -10, 	   2,   -7, 	  -3,   -7, 	   0,   -4
+.2byte    0,   -9, 	   2,   -6, 	  -3,   -6, 	   0,   -4
+.2byte    0,  -13, 	   2,  -10, 	  -3,  -10, 	  -1,   -6
+.2byte   -1,  -13, 	   2,   -9, 	  -3,   -9, 	   0,   -6
+.2byte    0,  -15, 	   1,   -7, 	  -2,   -7, 	   0,   -6
+.2byte   -7,   -6, 	  -1,   -5, 	  -5,   -2, 	   0,   -3
+.2byte   -8,   -5, 	  -1,   -5, 	  -5,   -2, 	  -1,   -6
+.2byte   -9,   -6, 	  -3,   -5, 	  -7,   -3, 	  -2,   -4
+.2byte   -6,   -8, 	   0,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -2,  -16, 	   3,   -9, 	  -2,   -6, 	   2,   -6
+.2byte  -10,   -5, 	  -4,   -2, 	  -3,   -1, 	  -1,   -4
+.2byte  -11,   -4, 	  -4,   -2, 	  -3,   -1, 	  -1,   -5
+.2byte  -12,   -4, 	  -6,   -2, 	  -5,   -1, 	  -1,   -4
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte   -1,  -15, 	   1,  -10, 	  -1,   -7, 	   3,   -7
+.2byte  -10,   -2, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -11,   -1, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -12,    0, 	  -8,    1, 	  -5,    2, 	  -3,   -2
+.2byte   -6,   -5, 	  -4,   -3, 	  -1,   -3, 	  -2,   -6
+.2byte   -2,  -12, 	  -2,   -6, 	   0,   -6, 	   2,   -8
+.2byte   -1,    0, 	  -3,    0, 	   2,    0, 	   0,   -4
+.2byte   -1,    1, 	  -3,    1, 	   2,    1, 	   0,   -4
+.2byte   -1,    2, 	  -3,    2, 	   2,    2, 	   0,   -4
+.2byte   -1,   -5, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    0,  -10, 	  -3,   -7, 	   1,   -7, 	   0,   -7
+.2byte    7,   -2, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    8,   -1, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    9,    0, 	   5,    1, 	   2,    2, 	   0,   -2
+.2byte    5,   -5, 	   3,   -3, 	   0,   -3, 	   1,   -6
+.2byte    1,  -12, 	   1,   -6, 	  -1,   -6, 	  -3,   -8
+.2byte    9,   -5, 	   3,   -2, 	   2,   -1, 	   0,   -4
+.2byte   10,   -4, 	   3,   -2, 	   2,   -1, 	   0,   -5
+.2byte   11,   -4, 	   5,   -2, 	   4,   -1, 	   0,   -4
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    0,  -15, 	  -2,  -10, 	   0,   -7, 	  -4,   -7
+.2byte    6,   -6, 	   0,   -5, 	   4,   -2, 	  -1,   -3
+.2byte    7,   -5, 	   0,   -5, 	   4,   -2, 	   0,   -6
+.2byte    8,   -6, 	   2,   -5, 	   6,   -3, 	   1,   -4
+.2byte    5,   -8, 	  -1,   -6, 	   2,   -2, 	   0,   -6
+.2byte    1,  -16, 	  -4,   -9, 	   1,   -6, 	  -3,   -6
+.2byte   -1,  -10, 	   2,   -7, 	  -3,   -7, 	   0,   -4
+.2byte    0,   -9, 	   2,   -6, 	  -3,   -6, 	   0,   -4
+.2byte    0,  -13, 	   2,  -10, 	  -3,  -10, 	  -1,   -6
+.2byte   -1,  -13, 	   2,   -9, 	  -3,   -9, 	   0,   -6
+.2byte    0,  -15, 	   1,   -7, 	  -2,   -7, 	   0,   -6
+.2byte   -7,   -6, 	  -1,   -5, 	  -5,   -2, 	   0,   -3
+.2byte   -8,   -5, 	  -1,   -5, 	  -5,   -2, 	  -1,   -6
+.2byte   -9,   -6, 	  -3,   -5, 	  -7,   -3, 	  -2,   -4
+.2byte   -6,   -8, 	   0,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -2,  -16, 	   3,   -9, 	  -2,   -6, 	   2,   -6
+.2byte  -10,   -5, 	  -4,   -2, 	  -3,   -1, 	  -1,   -4
+.2byte  -11,   -4, 	  -4,   -2, 	  -3,   -1, 	  -1,   -5
+.2byte  -12,   -4, 	  -6,   -2, 	  -5,   -1, 	  -1,   -4
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte   -1,  -15, 	   1,  -10, 	  -1,   -7, 	   3,   -7
+.2byte  -10,   -2, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -11,   -1, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -12,    0, 	  -8,    1, 	  -5,    2, 	  -3,   -2
+.2byte   -6,   -5, 	  -4,   -3, 	  -1,   -3, 	  -2,   -6
+.2byte   -2,  -12, 	  -2,   -6, 	   0,   -6, 	   2,   -8
+.2byte   -1,   -5, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    0,  -11, 	  -3,   -8, 	   1,   -8, 	   0,   -8
+.2byte   -1,   -4, 	  -3,   -2, 	   2,   -2, 	  -1,   -7
+.2byte    5,   -5, 	   3,   -3, 	   0,   -3, 	   1,   -6
+.2byte    3,  -11, 	   3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte    2,    0, 	   3,   -2, 	  -1,   -1, 	   0,   -7
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    3,  -15, 	   1,  -10, 	   3,   -7, 	  -1,   -7
+.2byte    0,   -2, 	   0,   -4, 	  -2,   -2, 	   0,   -6
+.2byte    5,   -8, 	  -1,   -6, 	   2,   -2, 	   0,   -6
+.2byte    3,  -17, 	  -2,  -10, 	   3,   -7, 	  -1,   -7
+.2byte    4,   -3, 	  -1,   -5, 	  -1,   -2, 	  -2,   -6
+.2byte   -1,  -13, 	   2,   -9, 	  -3,   -9, 	   0,   -6
+.2byte    0,  -17, 	   1,   -9, 	  -2,   -9, 	   0,   -8
+.2byte    0,   -8, 	   1,   -6, 	  -2,   -6, 	  -1,   -2
+.2byte   -6,   -8, 	   0,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -5,  -17, 	   0,  -10, 	  -5,   -7, 	  -1,   -7
+.2byte   -6,   -3, 	  -1,   -5, 	  -1,   -2, 	   0,   -6
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte   -5,  -15, 	  -3,  -10, 	  -5,   -7, 	  -1,   -7
+.2byte   -1,   -2, 	  -1,   -4, 	   1,   -2, 	  -1,   -6
+.2byte   -6,   -5, 	  -4,   -3, 	  -1,   -3, 	  -2,   -6
+.2byte   -6,  -11, 	  -6,   -5, 	  -4,   -5, 	  -2,   -7
+.2byte   -3,    0, 	  -4,   -2, 	   0,   -1, 	  -1,   -7
+.2byte   -1,   -5, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte   -6,   -5, 	  -4,   -3, 	  -1,   -3, 	  -2,   -6
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte   -6,   -8, 	   0,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -13, 	   2,   -9, 	  -3,   -9, 	   0,   -6
+.2byte    5,   -8, 	  -1,   -6, 	   2,   -2, 	   0,   -6
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    5,   -5, 	   3,   -3, 	   0,   -3, 	   1,   -6
+.2byte   -7,   -2, 	  -4,   -1, 	  -2,   -1, 	   0,   -3
+.2byte   -7,   -1, 	  -4,    0, 	  -1,    0, 	   0,   -2
+.2byte    0,  -11, 	  -5,   -8, 	   4,   -8, 	   0,   -8
+.2byte    0,  -11, 	   2,   -9, 	  -1,   -7, 	  -3,   -8
+.2byte    3,  -13, 	   2,   -9, 	   2,   -6, 	  -2,   -7
+.2byte    0,  -15, 	  -1,   -8, 	   4,   -6, 	  -1,   -6
+.2byte    0,  -15, 	   2,   -7, 	  -3,   -7, 	   0,   -6
+.2byte    0,  -15, 	   1,   -8, 	  -4,   -6, 	   1,   -6
+.2byte   -4,  -13, 	  -3,   -9, 	  -3,   -6, 	   1,   -7
+.2byte   -1,  -11, 	  -3,   -9, 	   0,   -7, 	   2,   -8
+.2byte   -1,    0, 	  -3,    0, 	   2,    0, 	   0,   -4
+.2byte   -1,    1, 	  -3,    1, 	   2,    1, 	   0,   -4
+.2byte   -1,    2, 	  -3,    2, 	   2,    2, 	   0,   -4
+.2byte   -1,   -6, 	  -3,   -4, 	   1,   -4, 	  -1,   -8
+.2byte    7,   -2, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    8,   -1, 	   3,    0, 	   0,    1, 	   0,   -3
+.2byte    9,    0, 	   5,    1, 	   2,    2, 	   0,   -2
+.2byte    6,   -6, 	   4,   -4, 	   1,   -4, 	   2,   -7
+.2byte    9,   -5, 	   3,   -2, 	   2,   -1, 	   0,   -4
+.2byte   10,   -4, 	   3,   -2, 	   2,   -1, 	   0,   -5
+.2byte   11,   -4, 	   5,   -2, 	   4,   -1, 	   0,   -4
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    6,   -6, 	   0,   -5, 	   4,   -2, 	  -1,   -3
+.2byte    7,   -5, 	   0,   -5, 	   4,   -2, 	   0,   -6
+.2byte    8,   -6, 	   2,   -5, 	   6,   -3, 	   1,   -4
+.2byte    5,   -9, 	  -1,   -7, 	   2,   -3, 	   0,   -7
+.2byte   -1,  -10, 	   2,   -7, 	  -3,   -7, 	   0,   -4
+.2byte    0,   -9, 	   2,   -6, 	  -3,   -6, 	   0,   -4
+.2byte    0,  -13, 	   2,  -10, 	  -3,  -10, 	  -1,   -6
+.2byte   -1,  -14, 	   2,  -10, 	  -3,  -10, 	   0,   -7
+.2byte   -7,   -6, 	  -1,   -5, 	  -5,   -2, 	   0,   -3
+.2byte   -8,   -5, 	  -1,   -5, 	  -5,   -2, 	  -1,   -6
+.2byte   -9,   -6, 	  -3,   -5, 	  -7,   -3, 	  -2,   -4
+.2byte   -6,   -9, 	   0,   -7, 	  -3,   -3, 	  -1,   -7
+.2byte  -10,   -5, 	  -4,   -2, 	  -3,   -1, 	  -1,   -4
+.2byte  -11,   -4, 	  -4,   -2, 	  -3,   -1, 	  -1,   -5
+.2byte  -12,   -4, 	  -6,   -2, 	  -5,   -1, 	  -1,   -4
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte  -10,   -2, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -11,   -1, 	  -6,    0, 	  -3,    1, 	  -3,   -3
+.2byte  -12,    0, 	  -8,    1, 	  -5,    2, 	  -3,   -2
+.2byte   -5,   -6, 	  -3,   -4, 	   0,   -4, 	  -1,   -7
+.2byte   -1,    3, 	  -3,    3, 	   2,    3, 	   0,   -3
+.2byte   -8,    1, 	  -4,    2, 	  -1,    3, 	   1,   -1
+.2byte  -10,   -2, 	  -4,    0, 	  -3,    1, 	   1,   -2
+.2byte   -7,   -4, 	  -1,   -3, 	  -5,   -1, 	   0,   -2
+.2byte    0,   -9, 	   2,   -6, 	  -3,   -6, 	  -1,   -2
+.2byte    6,   -4, 	   0,   -3, 	   4,   -1, 	  -1,   -2
+.2byte    8,   -2, 	   2,    0, 	   1,    1, 	  -3,   -2
+.2byte    7,    1, 	   3,    2, 	   0,    3, 	  -2,   -1
+.2byte   -1,   -5, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    5,   -5, 	   3,   -3, 	   0,   -3, 	   1,   -6
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    5,   -8, 	  -1,   -6, 	   2,   -2, 	   0,   -6
+.2byte   -1,  -13, 	   2,   -9, 	  -3,   -9, 	   0,   -6
+.2byte   -6,   -8, 	   0,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte   -6,   -5, 	  -4,   -3, 	  -1,   -3, 	  -2,   -6
+.2byte   -1,   -5, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte    0,  -11, 	  -3,   -8, 	   1,   -8, 	   0,   -8
+.2byte   -1,    0, 	  -3,    0, 	   2,    0, 	   0,   -4
+.2byte    5,   -5, 	   3,   -3, 	   0,   -3, 	   1,   -6
+.2byte    4,  -12, 	   4,   -6, 	   2,   -6, 	   0,   -8
+.2byte    8,   -2, 	   4,    0, 	   1,    1, 	   1,   -3
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    3,  -15, 	   1,  -10, 	   3,   -7, 	  -1,   -7
+.2byte    9,   -5, 	   3,   -2, 	   2,   -1, 	   0,   -4
+.2byte    5,   -8, 	  -1,   -6, 	   2,   -2, 	   0,   -6
+.2byte    3,  -16, 	  -2,   -9, 	   3,   -6, 	  -1,   -6
+.2byte    6,   -6, 	   0,   -5, 	   4,   -2, 	  -1,   -3
+.2byte   -1,  -13, 	   2,   -9, 	  -3,   -9, 	   0,   -6
+.2byte    0,  -15, 	   1,   -7, 	  -2,   -7, 	   0,   -6
+.2byte   -1,  -10, 	   2,   -7, 	  -3,   -7, 	   0,   -4
+.2byte   -6,   -8, 	   0,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -4,  -16, 	   1,   -9, 	  -4,   -6, 	   0,   -6
+.2byte   -7,   -6, 	  -1,   -5, 	  -5,   -2, 	   0,   -3
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte   -4,  -15, 	  -2,  -10, 	  -4,   -7, 	   0,   -7
+.2byte  -10,   -5, 	  -4,   -2, 	  -3,   -1, 	  -1,   -4
+.2byte   -6,   -5, 	  -4,   -3, 	  -1,   -3, 	  -2,   -6
+.2byte   -5,  -12, 	  -5,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte   -9,   -2, 	  -5,    0, 	  -2,    1, 	  -2,   -3
+.2byte    0,  -11, 	  -3,   -8, 	   1,   -8, 	   0,   -8
+.2byte   -5,  -12, 	  -5,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte   -4,  -15, 	  -2,  -10, 	  -4,   -7, 	   0,   -7
+.2byte   -4,  -16, 	   1,   -9, 	  -4,   -6, 	   0,   -6
+.2byte    0,  -15, 	   1,   -7, 	  -2,   -7, 	   0,   -6
+.2byte    3,  -16, 	  -2,   -9, 	   3,   -6, 	  -1,   -6
+.2byte    3,  -15, 	   1,  -10, 	   3,   -7, 	  -1,   -7
+.2byte    4,  -12, 	   4,   -6, 	   2,   -6, 	   0,   -8
+.2byte   -1,   -5, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte   -6,   -5, 	  -4,   -3, 	  -1,   -3, 	  -2,   -6
+.2byte   -9,   -7, 	  -6,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte   -6,   -8, 	   0,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -13, 	   2,   -9, 	  -3,   -9, 	   0,   -6
+.2byte    5,   -8, 	  -1,   -6, 	   2,   -2, 	   0,   -6
+.2byte    8,   -7, 	   5,   -4, 	   4,   -3, 	   1,   -5
+.2byte    5,   -5, 	   3,   -3, 	   0,   -3, 	   1,   -6
+sCaterpieAnimTable1:
+.4byte sCaterpieAnims_1_1
+.4byte sCaterpieAnims_1_2
+.4byte sCaterpieAnims_1_3
+.4byte sCaterpieAnims_1_4
+.4byte sCaterpieAnims_1_5
+.4byte sCaterpieAnims_1_6
+.4byte sCaterpieAnims_1_7
+.4byte sCaterpieAnims_1_8
+sCaterpieAnimTable2:
+.4byte sCaterpieAnims_2_1
+.4byte sCaterpieAnims_2_2
+.4byte sCaterpieAnims_2_3
+.4byte sCaterpieAnims_2_4
+.4byte sCaterpieAnims_2_5
+.4byte sCaterpieAnims_2_6
+.4byte sCaterpieAnims_2_7
+.4byte sCaterpieAnims_2_8
+sCaterpieAnimTable3:
+.4byte sCaterpieAnims_3_1
+.4byte sCaterpieAnims_3_2
+.4byte sCaterpieAnims_3_3
+.4byte sCaterpieAnims_3_4
+.4byte sCaterpieAnims_3_5
+.4byte sCaterpieAnims_3_6
+.4byte sCaterpieAnims_3_7
+.4byte sCaterpieAnims_3_8
+sCaterpieAnimTable4:
+.4byte sCaterpieAnims_4_1
+.4byte sCaterpieAnims_4_2
+.4byte sCaterpieAnims_4_3
+.4byte sCaterpieAnims_4_4
+.4byte sCaterpieAnims_4_5
+.4byte sCaterpieAnims_4_6
+.4byte sCaterpieAnims_4_7
+.4byte sCaterpieAnims_4_8
+sCaterpieAnimTable5:
+.4byte sCaterpieAnims_5_1
+.4byte sCaterpieAnims_5_2
+.4byte sCaterpieAnims_5_3
+.4byte sCaterpieAnims_5_4
+.4byte sCaterpieAnims_5_5
+.4byte sCaterpieAnims_5_6
+.4byte sCaterpieAnims_5_7
+.4byte sCaterpieAnims_5_8
+sCaterpieAnimTable6:
+.4byte sCaterpieAnims_6_1
+.4byte sCaterpieAnims_6_1
+.4byte sCaterpieAnims_6_1
+.4byte sCaterpieAnims_6_1
+.4byte sCaterpieAnims_6_1
+.4byte sCaterpieAnims_6_1
+.4byte sCaterpieAnims_6_1
+.4byte sCaterpieAnims_6_1
+sCaterpieAnimTable7:
+.4byte sCaterpieAnims_7_1
+.4byte sCaterpieAnims_7_2
+.4byte sCaterpieAnims_7_3
+.4byte sCaterpieAnims_7_4
+.4byte sCaterpieAnims_7_5
+.4byte sCaterpieAnims_7_6
+.4byte sCaterpieAnims_7_7
+.4byte sCaterpieAnims_7_8
+sCaterpieAnimTable8:
+.4byte sCaterpieAnims_8_1
+.4byte sCaterpieAnims_8_2
+.4byte sCaterpieAnims_8_3
+.4byte sCaterpieAnims_8_4
+.4byte sCaterpieAnims_8_5
+.4byte sCaterpieAnims_8_6
+.4byte sCaterpieAnims_8_7
+.4byte sCaterpieAnims_8_8
+sCaterpieAnimTable9:
+.4byte sCaterpieAnims_9_1
+.4byte sCaterpieAnims_9_2
+.4byte sCaterpieAnims_9_3
+.4byte sCaterpieAnims_9_4
+.4byte sCaterpieAnims_9_5
+.4byte sCaterpieAnims_9_6
+.4byte sCaterpieAnims_9_7
+.4byte sCaterpieAnims_9_8
+sCaterpieAnimTable10:
+.4byte sCaterpieAnims_10_1
+.4byte sCaterpieAnims_10_2
+.4byte sCaterpieAnims_10_3
+.4byte sCaterpieAnims_10_4
+.4byte sCaterpieAnims_10_5
+.4byte sCaterpieAnims_10_6
+.4byte sCaterpieAnims_10_7
+.4byte sCaterpieAnims_10_8
+sCaterpieAnimTable11:
+.4byte sCaterpieAnims_11_1
+.4byte sCaterpieAnims_11_2
+.4byte sCaterpieAnims_11_3
+.4byte sCaterpieAnims_11_4
+.4byte sCaterpieAnims_11_5
+.4byte sCaterpieAnims_11_6
+.4byte sCaterpieAnims_11_7
+.4byte sCaterpieAnims_11_8
+sCaterpieAnimTable12:
+.4byte sCaterpieAnims_12_1
+.4byte sCaterpieAnims_12_2
+.4byte sCaterpieAnims_12_3
+.4byte sCaterpieAnims_12_4
+.4byte sCaterpieAnims_12_5
+.4byte sCaterpieAnims_12_6
+.4byte sCaterpieAnims_12_7
+.4byte sCaterpieAnims_12_8
+sCaterpieAnimTable13:
+.4byte sCaterpieAnims_13_1
+.4byte sCaterpieAnims_13_2
+.4byte sCaterpieAnims_13_3
+.4byte sCaterpieAnims_13_4
+.4byte sCaterpieAnims_13_5
+.4byte sCaterpieAnims_13_6
+.4byte sCaterpieAnims_13_7
+.4byte sCaterpieAnims_13_8
+sAxAnimationsCaterpie:
+.4byte sCaterpieAnimTable1
+.4byte sCaterpieAnimTable2
+.4byte sCaterpieAnimTable3
+.4byte sCaterpieAnimTable4
+.4byte sCaterpieAnimTable5
+.4byte sCaterpieAnimTable6
+.4byte sCaterpieAnimTable7
+.4byte sCaterpieAnimTable8
+.4byte sCaterpieAnimTable9
+.4byte sCaterpieAnimTable10
+.4byte sCaterpieAnimTable11
+.4byte sCaterpieAnimTable12
+.4byte sCaterpieAnimTable13
+sAxSpritesCaterpie:
+.4byte sCaterpieSprites1
+.4byte sCaterpieSprites2
+.4byte sCaterpieSprites3
+.4byte sCaterpieSprites4
+.4byte sCaterpieSprites5
+.4byte sCaterpieSprites6
+.4byte sCaterpieSprites7
+.4byte sCaterpieSprites8
+.4byte sCaterpieSprites9
+.4byte sCaterpieSprites10
+.4byte sCaterpieSprites11
+.4byte sCaterpieSprites12
+.4byte sCaterpieSprites13
+.4byte sCaterpieSprites14
+.4byte sCaterpieSprites15
+.4byte sCaterpieSprites16
+.4byte sCaterpieSprites17
+.4byte sCaterpieSprites18
+.4byte sCaterpieSprites19
+.4byte sCaterpieSprites20
+.4byte sCaterpieSprites21
+.4byte sCaterpieSprites22
+.4byte sCaterpieSprites23
+.4byte sCaterpieSprites24
+.4byte sCaterpieSprites25
+.4byte sCaterpieSprites26
+.4byte sCaterpieSprites27
+.4byte sCaterpieSprites28
+.4byte sCaterpieSprites29
+.4byte sCaterpieSprites30
+.4byte sCaterpieSprites31
+.4byte sCaterpieSprites32
+.4byte sCaterpieSprites33
+.4byte sCaterpieSprites34
+.4byte sCaterpieSprites35
+.4byte sCaterpieSprites36
+.4byte sCaterpieSprites37
+sAxMainCaterpie:
+ax_main sAxPosesCaterpie, sAxAnimationsCaterpie, 13, sAxSpritesCaterpie, sAxPositionsCaterpie

--- a/data/ax/celebi.inc
+++ b/data/ax/celebi.inc
@@ -1,0 +1,2776 @@
+.global gAxCelebi
+gAxCelebi:
+ax_siro sAxMainCelebi
+sCelebiPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose4:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose5:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose6:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose7:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose8:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose9:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose10:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose11:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose12:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose13:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose14:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose15:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose16:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose17:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose18:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose19:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose20:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose21:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose22:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose23:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose24:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose28:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose29:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose30:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose31:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose32:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose33:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose34:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose35:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose36:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose37:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose38:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose39:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose40:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose41:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose42:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose43:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose44:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose45:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose46:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose47:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose48:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose50:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose51:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose52:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose53:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose54:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose55:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose56:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose57:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose58:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose59:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose60:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose61:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose62:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose63:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose64:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose65:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose66:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose67:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose68:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose69:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose70:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose71:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose72:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose73:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose74:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose75:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose76:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose77:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose78:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose79:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose80:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose81:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose82:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose83:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose84:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose85:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose86:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose87:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose88:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose89:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose90:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose91:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose92:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose93:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose94:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose95:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose96:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose97:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose98:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose99:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose100:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose101:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose102:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose103:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose104:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose105:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose106:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose107:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose108:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose109:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose110:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose111:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose112:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose113:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose114:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose115:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose116:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose117:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose118:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose119:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose120:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose121:
+ax_pose 15, 0x01e2, 0x80f6, 0x3c00
+ax_pose_terminator
+sCelebiPose122:
+ax_pose 16, 0x01e2, 0x80f6, 0x3c00
+ax_pose_terminator
+sCelebiPose123:
+ax_pose 17, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose124:
+ax_pose 18, 0x01de, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose125:
+ax_pose 19, 0x01df, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose126:
+ax_pose 20, 0x01e1, 0x90ea, 0x3c00
+ax_pose_terminator
+sCelebiPose127:
+ax_pose 21, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose128:
+ax_pose 20, 0x01e1, 0x80f6, 0x3c00
+ax_pose_terminator
+sCelebiPose129:
+ax_pose 19, 0x01df, 0x80f5, 0x3c00
+ax_pose_terminator
+sCelebiPose130:
+ax_pose 18, 0x01de, 0x80f5, 0x3c00
+ax_pose_terminator
+sCelebiPose131:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose132:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose133:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose134:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose135:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose136:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose137:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose138:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose139:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose140:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose141:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose142:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose143:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose144:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose145:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose146:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose147:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose148:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose149:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose150:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose151:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose152:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose153:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose154:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose155:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose156:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose157:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose158:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose159:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose160:
+ax_pose 10, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose161:
+ax_pose 7, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose162:
+ax_pose 4, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sCelebiPose163:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose164:
+ax_pose 4, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sCelebiPose165:
+ax_pose 7, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose166:
+ax_pose 10, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose167:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose168:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose169:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose170:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose171:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose172:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose173:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose174:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose175:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose176:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose177:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose178:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose179:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose180:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose181:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose182:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose183:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose184:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose185:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose186:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose187:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose188:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose189:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose190:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose191:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose192:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose193:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose194:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose195:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose196:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose197:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose198:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose199:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose200:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose201:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose202:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose203:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose204:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose205:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose206:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose207:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose208:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose209:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose210:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose211:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose212:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose213:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose214:
+ax_pose 3, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose215:
+ax_pose 4, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose216:
+ax_pose 5, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sCelebiPose217:
+ax_pose 6, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose218:
+ax_pose 7, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose219:
+ax_pose 8, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose220:
+ax_pose 9, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose221:
+ax_pose 10, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose222:
+ax_pose 11, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sCelebiPose223:
+ax_pose 12, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose224:
+ax_pose 13, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose225:
+ax_pose 14, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sCelebiPose226:
+ax_pose 9, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose227:
+ax_pose 10, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose228:
+ax_pose 11, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose229:
+ax_pose 6, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose230:
+ax_pose 7, 0x01e0, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose231:
+ax_pose 8, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sCelebiPose232:
+ax_pose 3, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose233:
+ax_pose 5, 0x01e0, 0x80f3, 0x3c00
+ax_pose_terminator
+sCelebiPose234:
+ax_pose 4, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+.align 2
+sCelebiAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 4, 0, 0, 0, 1, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 4, 0, 3, 0, 1, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 4, 0, 6, 0, 1, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 4, 0, 9, 0, 1, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 12, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 4, 0, 12, 0, 1, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, -1, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 4, 0, 15, 0, 1, 0, 0,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, -1, 0, 0,
+ax_anim 4, 0, 18, 0, -1, 0, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 4, 0, 18, 0, 1, 0, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 4, 0, 21, 0, -1, 0, 0,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 4, 0, 21, 0, 1, 0, 0,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_2_1:
+ax_anim 1, 0, 24, 0, -1, 0, -1,
+ax_anim 1, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, -2, 0, -2,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 12, 0, 11,
+ax_anim 2, 0, 24, 0, 25, 0, 22,
+ax_anim 2, 1, 24, 1, 25, 1, 22,
+ax_anim 2, 0, 24, 0, 25, 0, 22,
+ax_anim 2, 0, 24, 1, 25, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCelebiAnims_2_2:
+ax_anim 1, 0, 27, -1, -1, -1, -1,
+ax_anim 1, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, -2, -2, -2, -2,
+ax_anim 6, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 12, 13, 12, 13,
+ax_anim 2, 0, 27, 23, 25, 22, 23,
+ax_anim 2, 1, 27, 24, 24, 23, 22,
+ax_anim 2, 0, 27, 23, 25, 22, 23,
+ax_anim 2, 0, 27, 24, 24, 23, 22,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sCelebiAnims_2_3:
+ax_anim 1, 0, 30, -1, 0, -1, 0,
+ax_anim 1, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, -2, 0, -2, 0,
+ax_anim 6, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 30, 23, 1, 23, 0,
+ax_anim 2, 1, 30, 23, 2, 23, 1,
+ax_anim 2, 0, 30, 23, 1, 23, 0,
+ax_anim 2, 0, 30, 23, 2, 23, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sCelebiAnims_2_4:
+ax_anim 1, 0, 33, -1, 1, -1, 1,
+ax_anim 1, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, -2, 2, -2, 2,
+ax_anim 6, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 5, -3, 5, -3,
+ax_anim 1, 0, 35, 15, -10, 14, -11,
+ax_anim 2, 0, 33, 23, -16, 22, -17,
+ax_anim 2, 1, 33, 24, -15, 23, -16,
+ax_anim 2, 0, 33, 23, -16, 22, -17,
+ax_anim 2, 0, 33, 24, -15, 23, -16,
+ax_anim 2, 0, 33, 7, -5, 7, -5,
+ax_anim_terminator
+sCelebiAnims_2_5:
+ax_anim 1, 0, 36, 0, 1, 0, 1,
+ax_anim 1, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 2, 0, 2,
+ax_anim 6, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -12, 0, -13,
+ax_anim 2, 0, 36, 0, -17, 0, -19,
+ax_anim 2, 1, 36, 1, -17, 1, -19,
+ax_anim 2, 0, 36, 0, -17, 0, -19,
+ax_anim 2, 0, 36, 1, -17, 1, -19,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sCelebiAnims_2_6:
+ax_anim 1, 0, 39, 1, 1, 1, 1,
+ax_anim 1, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 2, 2, 2, 2,
+ax_anim 6, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -5, -3, -5, -3,
+ax_anim 1, 0, 41, -15, -10, -14, -11,
+ax_anim 2, 0, 39, -23, -16, -22, -17,
+ax_anim 2, 1, 39, -24, -15, -23, -16,
+ax_anim 2, 0, 39, -23, -16, -22, -17,
+ax_anim 2, 0, 39, -24, -15, -23, -16,
+ax_anim 2, 0, 39, -7, -5, -7, -5,
+ax_anim_terminator
+sCelebiAnims_2_7:
+ax_anim 1, 0, 42, 1, 0, 1, 0,
+ax_anim 1, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 2, 0, 2, 0,
+ax_anim 6, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 2, 0, 42, -23, 1, -23, 0,
+ax_anim 2, 1, 42, -23, 2, -23, 1,
+ax_anim 2, 0, 42, -23, 1, -23, 0,
+ax_anim 2, 0, 42, -23, 2, -23, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sCelebiAnims_2_8:
+ax_anim 1, 0, 45, 1, -1, 1, -1,
+ax_anim 1, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 2, -2, 2, -2,
+ax_anim 6, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -12, 13, -12, 13,
+ax_anim 2, 0, 45, -23, 25, -22, 23,
+ax_anim 2, 1, 45, -24, 24, -23, 22,
+ax_anim 2, 0, 45, -23, 25, -22, 23,
+ax_anim 2, 0, 45, -24, 24, -23, 22,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCelebiAnims_3_1:
+ax_anim 1, 0, 48, 0, -1, 0, -1,
+ax_anim 1, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, -2, 0, -2,
+ax_anim 6, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 12, 0, 11,
+ax_anim 2, 0, 48, 0, 25, 0, 22,
+ax_anim 2, 1, 48, 1, 25, 1, 22,
+ax_anim 2, 0, 48, 0, 25, 0, 22,
+ax_anim 2, 0, 48, 1, 25, 1, 22,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sCelebiAnims_3_2:
+ax_anim 1, 0, 51, -1, -1, -1, -1,
+ax_anim 1, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 12, 13, 12, 13,
+ax_anim 2, 0, 51, 23, 25, 22, 23,
+ax_anim 2, 1, 51, 24, 24, 23, 22,
+ax_anim 2, 0, 51, 23, 25, 22, 23,
+ax_anim 2, 0, 51, 24, 24, 23, 22,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sCelebiAnims_3_3:
+ax_anim 1, 0, 54, -1, 0, -1, 0,
+ax_anim 1, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, -2, 0, -2, 0,
+ax_anim 6, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 12, 0, 12, 0,
+ax_anim 2, 0, 54, 23, 1, 23, 0,
+ax_anim 2, 1, 54, 23, 2, 23, 1,
+ax_anim 2, 0, 54, 23, 1, 23, 0,
+ax_anim 2, 0, 54, 23, 2, 23, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sCelebiAnims_3_4:
+ax_anim 1, 0, 57, -1, 1, -1, 1,
+ax_anim 1, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, -2, 2, -2, 2,
+ax_anim 6, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 5, -3, 5, -3,
+ax_anim 1, 0, 59, 15, -10, 14, -11,
+ax_anim 2, 0, 57, 23, -16, 22, -17,
+ax_anim 2, 1, 57, 24, -15, 23, -16,
+ax_anim 2, 0, 57, 23, -16, 22, -17,
+ax_anim 2, 0, 57, 24, -15, 23, -16,
+ax_anim 2, 0, 57, 7, -5, 7, -5,
+ax_anim_terminator
+sCelebiAnims_3_5:
+ax_anim 1, 0, 60, 0, 1, 0, 1,
+ax_anim 1, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 2, 0, 2,
+ax_anim 6, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -12, 0, -13,
+ax_anim 2, 0, 60, 0, -17, 0, -19,
+ax_anim 2, 1, 60, 1, -17, 1, -19,
+ax_anim 2, 0, 60, 0, -17, 0, -19,
+ax_anim 2, 0, 60, 1, -17, 1, -19,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sCelebiAnims_3_6:
+ax_anim 1, 0, 63, 1, 1, 1, 1,
+ax_anim 1, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 2, 2, 2, 2,
+ax_anim 6, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 64, -5, -3, -5, -3,
+ax_anim 1, 0, 65, -15, -10, -14, -11,
+ax_anim 2, 0, 63, -23, -16, -22, -17,
+ax_anim 2, 1, 63, -24, -15, -23, -16,
+ax_anim 2, 0, 63, -23, -16, -22, -17,
+ax_anim 2, 0, 63, -24, -15, -23, -16,
+ax_anim 2, 0, 63, -7, -5, -7, -5,
+ax_anim_terminator
+sCelebiAnims_3_7:
+ax_anim 1, 0, 66, 1, 0, 1, 0,
+ax_anim 1, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 2, 0, 2, 0,
+ax_anim 6, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -12, 0, -12, 0,
+ax_anim 2, 0, 66, -23, 1, -23, 0,
+ax_anim 2, 1, 66, -23, 2, -23, 1,
+ax_anim 2, 0, 66, -23, 1, -23, 0,
+ax_anim 2, 0, 66, -23, 2, -23, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sCelebiAnims_3_8:
+ax_anim 1, 0, 69, 1, -1, 1, -1,
+ax_anim 1, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 2, -2, 2, -2,
+ax_anim 6, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -12, 13, -12, 13,
+ax_anim 2, 0, 69, -23, 25, -22, 23,
+ax_anim 2, 1, 69, -24, 24, -23, 22,
+ax_anim 2, 0, 69, -23, 25, -22, 23,
+ax_anim 2, 0, 69, -24, 24, -23, 22,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCelebiAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 2, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 1, 72, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -6, 0, -6,
+ax_anim 2, 0, 72, 0, -5, 0, -5,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim_terminator
+sCelebiAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 2, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 75, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 1, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 76, -4, -6, -6, -6,
+ax_anim 2, 0, 75, -4, -5, -5, -5,
+ax_anim 2, 0, 77, -3, -4, -4, -4,
+ax_anim 2, 0, 75, -2, -2, -2, -2,
+ax_anim_terminator
+sCelebiAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 2, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 78, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 1, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, -6, -2, -6, 0,
+ax_anim 2, 0, 78, -5, -1, -5, 0,
+ax_anim 2, 0, 80, -4, -1, -4, 0,
+ax_anim 2, 0, 78, -2, 0, -2, 0,
+ax_anim_terminator
+sCelebiAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 2, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 2, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 81, 0, -3, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 2, 1, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 82, -6, 4, -6, 6,
+ax_anim 2, 0, 81, -5, 4, -5, 5,
+ax_anim 2, 0, 83, -4, 3, -4, 4,
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim_terminator
+sCelebiAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 84, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 2, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 1, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, 4, 0, 6,
+ax_anim 2, 0, 84, 0, 4, 0, 5,
+ax_anim 2, 0, 86, 0, 3, 0, 4,
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim_terminator
+sCelebiAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -1, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 2, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 87, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 1, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 6, 4, 6, 6,
+ax_anim 2, 0, 87, 5, 4, 5, 5,
+ax_anim 2, 0, 89, 4, 3, 4, 4,
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim_terminator
+sCelebiAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 2, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 1, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 6, -2, 6, 0,
+ax_anim 2, 0, 90, 5, -1, 5, 0,
+ax_anim 2, 0, 92, 4, -1, 4, 0,
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim_terminator
+sCelebiAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim 2, 0, 93, 0, -1, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 2, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 1, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 6, -8, 6, -6,
+ax_anim 2, 0, 93, 5, -6, 5, -5,
+ax_anim 2, 0, 95, 4, -5, 4, -4,
+ax_anim 2, 0, 93, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sCelebiAnims_5_1:
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 1, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -3, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_5_2:
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, 0,
+ax_anim 2, 1, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_5_3:
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim 2, 1, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_5_4:
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim 2, 1, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_5_5:
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 1, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_5_6:
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, 0,
+ax_anim 2, 1, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_5_7:
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim 2, 1, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_5_8:
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim 2, 1, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_6_1:
+ax_anim 8, 0, 120, 0, 0, 0, 0,
+ax_anim 8, 0, 120, 0, -1, 0, 0,
+ax_anim 26, 0, 120, 0, -2, 0, 0,
+ax_anim 8, 0, 121, 0, -2, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim 26, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sCelebiAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sCelebiAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sCelebiAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sCelebiAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sCelebiAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sCelebiAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sCelebiAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCelebiAnims_8_1:
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 7, 0, 132, 0, -1, 0, 0,
+ax_anim 6, 0, 132, 0, -2, 0, 0,
+ax_anim 6, 0, 130, 0, -3, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 7, 0, 131, 0, -1, 0, 0,
+ax_anim_terminator
+sCelebiAnims_8_2:
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 7, 0, 135, 0, -1, 0, 0,
+ax_anim 6, 0, 135, 0, -2, 0, 0,
+ax_anim 6, 0, 133, 0, -3, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 7, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sCelebiAnims_8_3:
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 7, 0, 138, 0, -1, 0, 0,
+ax_anim 6, 0, 138, 0, -2, 0, 0,
+ax_anim 6, 0, 136, 0, -3, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 7, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+sCelebiAnims_8_4:
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 7, 0, 141, 0, -1, 0, 0,
+ax_anim 6, 0, 141, 0, -2, 0, 0,
+ax_anim 6, 0, 139, 0, -3, 0, 0,
+ax_anim 6, 0, 140, 0, -2, 0, 0,
+ax_anim 7, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sCelebiAnims_8_5:
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 7, 0, 144, 0, -1, 0, 0,
+ax_anim 6, 0, 144, 0, -2, 0, 0,
+ax_anim 6, 0, 142, 0, -3, 0, 0,
+ax_anim 6, 0, 143, 0, -2, 0, 0,
+ax_anim 7, 0, 143, 0, -1, 0, 0,
+ax_anim_terminator
+sCelebiAnims_8_6:
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 7, 0, 147, 0, -1, 0, 0,
+ax_anim 6, 0, 147, 0, -2, 0, 0,
+ax_anim 6, 0, 145, 0, -3, 0, 0,
+ax_anim 6, 0, 146, 0, -2, 0, 0,
+ax_anim 7, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sCelebiAnims_8_7:
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim 7, 0, 150, 0, -1, 0, 0,
+ax_anim 6, 0, 150, 0, -2, 0, 0,
+ax_anim 6, 0, 148, 0, -3, 0, 0,
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 7, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sCelebiAnims_8_8:
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 7, 0, 153, 0, -1, 0, 0,
+ax_anim 6, 0, 153, 0, -2, 0, 0,
+ax_anim 6, 0, 151, 0, -3, 0, 0,
+ax_anim 6, 0, 152, 0, -2, 0, 0,
+ax_anim 7, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 11, 8, 11,
+ax_anim 2, 0, 157, 7, 19, 7, 18,
+ax_anim 3, 0, 158, 0, 23, 0, 22,
+ax_anim 2, 3, 159, -7, 19, -7, 18,
+ax_anim 2, 0, 160, -8, 11, -8, 11,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 21, 14, 21, 13,
+ax_anim 3, 0, 157, 22, 23, 22, 22,
+ax_anim 2, 3, 158, 13, 25, 13, 24,
+ax_anim 2, 0, 159, 4, 17, 4, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 18, -3, 18, -4,
+ax_anim 3, 0, 156, 22, 1, 22, 0,
+ax_anim 2, 3, 157, 20, 4, 20, 3,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 4,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 14, -20, 14, -21,
+ax_anim 3, 0, 155, 22, -19, 22, -21,
+ax_anim 2, 3, 156, 22, -12, 22, -13,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -13,
+ax_anim 2, 0, 161, -7, -17, -7, -19,
+ax_anim 3, 0, 154, 0, -19, 0, -22,
+ax_anim 2, 3, 155, 7, -17, 7, -19,
+ax_anim 2, 0, 156, 9, -12, 9, -13,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -14, -20, -14, -21,
+ax_anim 3, 0, 161, -22, -19, -22, -21,
+ax_anim 2, 3, 160, -22, -12, -22, -13,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -18, -3, -18, -4,
+ax_anim 3, 0, 160, -22, 1, -22, 0,
+ax_anim 2, 3, 159, -20, 4, -20, 3,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 4,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -21, 14, -21, 13,
+ax_anim 3, 0, 159, -22, 23, -22, 22,
+ax_anim 2, 3, 158, -13, 25, -13, 24,
+ax_anim 2, 0, 157, -4, 17, -4, 17,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 2, 170, 0, 4, 0, 0,
+ax_anim_terminator
+sCelebiAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 174, 0, -21, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 3, 0, 0,
+ax_anim_terminator
+sCelebiAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 2, 0, 0,
+ax_anim_terminator
+sCelebiAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -17, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 2, 0, 0,
+ax_anim_terminator
+sCelebiAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 2, 0, 0,
+ax_anim_terminator
+sCelebiAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -17, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 2, 0, 0,
+ax_anim_terminator
+sCelebiAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 2, 0, 0,
+ax_anim_terminator
+sCelebiAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCelebiAnims_14_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -4, 0, 0,
+ax_anim 2, 0, 211, 0, -8, 0, 0,
+ax_anim 2, 0, 210, 0, -11, 0, 0,
+ax_anim 2, 0, 212, 0, -14, 0, 0,
+ax_anim 3, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -17, 0, 0,
+ax_anim 3, 0, 212, 0, -16, 0, 0,
+ax_anim 2, 0, 211, 0, -14, 0, 0,
+ax_anim 2, 0, 210, 0, -11, 0, 0,
+ax_anim 2, 0, 212, 0, -8, 0, 0,
+ax_anim 2, 0, 211, 0, -4, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -2, -4, -2, -2,
+ax_anim 1, 0, 217, -4, -8, -4, -4,
+ax_anim 2, 0, 219, -6, -12, -6, -6,
+ax_anim 2, 0, 224, -8, -16, -8, -8,
+ax_anim 2, 0, 226, -10, -19, -10, -10,
+ax_anim 2, 0, 228, -12, -22, -12, -12,
+ax_anim 2, 0, 233, -14, -25, -14, -14,
+ax_anim 2, 0, 211, -16, -27, -16, -16,
+ax_anim 2, 0, 213, -18, -29, -18, -18,
+ax_anim 2, 0, 218, -20, -30, -20, -20,
+ax_anim 2, 0, 219, -22, -31, -22, -22,
+ax_anim 2, 0, 224, -24, -32, -24, -24,
+ax_anim 1, 0, 226, -26, -32, -26, -26,
+ax_anim 1, 0, 228, -28, -32, -28, -28,
+ax_anim 1, 0, 233, -30, -32, -30, -30,
+ax_anim 1, 1, 210, -32, -32, -32, -32,
+ax_anim 1, 0, 215, -28, -34, -28, -32,
+ax_anim 1, 0, 217, -24, -36, -24, -32,
+ax_anim 2, 0, 219, -20, -38, -20, -32,
+ax_anim 2, 0, 224, -16, -40, -16, -32,
+ax_anim 2, 0, 226, -12, -41, -12, -32,
+ax_anim 2, 0, 228, -8, -42, -8, -32,
+ax_anim 2, 0, 233, -4, -43, -4, -32,
+ax_anim 2, 0, 211, 0, -43, 0, -32,
+ax_anim 2, 0, 213, 4, -43, 4, -32,
+ax_anim 2, 0, 218, 8, -42, 8, -32,
+ax_anim 2, 0, 219, 12, -41, 12, -32,
+ax_anim 2, 0, 224, 16, -40, 16, -32,
+ax_anim 1, 0, 226, 20, -38, 20, -32,
+ax_anim 1, 0, 228, 24, -36, 24, -32,
+ax_anim 1, 0, 233, 28, -34, 28, -32,
+ax_anim 1, 1, 210, 32, -32, 32, -32,
+ax_anim 1, 0, 215, 30, -32, 30, -30,
+ax_anim 1, 0, 217, 28, -32, 28, -28,
+ax_anim 2, 0, 219, 26, -32, 26, -26,
+ax_anim 2, 0, 224, 24, -32, 24, -24,
+ax_anim 2, 0, 226, 22, -31, 22, -22,
+ax_anim 2, 0, 228, 20, -30, 20, -20,
+ax_anim 2, 0, 233, 18, -29, 18, -18,
+ax_anim 2, 0, 211, 16, -27, 16, -16,
+ax_anim 2, 0, 213, 14, -25, 14, -14,
+ax_anim 2, 0, 218, 12, -22, 12, -12,
+ax_anim 2, 0, 219, 10, -19, 10, -10,
+ax_anim 2, 0, 224, 8, -16, 8, -8,
+ax_anim 1, 0, 226, 6, -12, 6, -6,
+ax_anim 1, 0, 228, 4, -8, 4, -4,
+ax_anim 1, 0, 233, 2, -4, 2, -2,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCelebiGfx1:
+.incbin "baserom.gba", 0x1047E58, 0x200
+sCelebiSprites1:
+ax_sprite sCelebiGfx1, 0x200
+ax_sprite_terminator
+sCelebiGfx2:
+.incbin "baserom.gba", 0x1048068, 0x200
+sCelebiSprites2:
+ax_sprite sCelebiGfx2, 0x200
+ax_sprite_terminator
+sCelebiGfx3:
+.incbin "baserom.gba", 0x1048278, 0x200
+sCelebiSprites3:
+ax_sprite sCelebiGfx3, 0x200
+ax_sprite_terminator
+sCelebiGfx4:
+.incbin "baserom.gba", 0x1048488, 0x200
+sCelebiSprites4:
+ax_sprite sCelebiGfx4, 0x200
+ax_sprite_terminator
+sCelebiGfx5:
+.incbin "baserom.gba", 0x1048698, 0x200
+sCelebiSprites5:
+ax_sprite sCelebiGfx5, 0x200
+ax_sprite_terminator
+sCelebiGfx6:
+.incbin "baserom.gba", 0x10488A8, 0x200
+sCelebiSprites6:
+ax_sprite sCelebiGfx6, 0x200
+ax_sprite_terminator
+sCelebiGfx7:
+.incbin "baserom.gba", 0x1048AB8, 0x200
+sCelebiSprites7:
+ax_sprite sCelebiGfx7, 0x200
+ax_sprite_terminator
+sCelebiGfx8:
+.incbin "baserom.gba", 0x1048CC8, 0x200
+sCelebiSprites8:
+ax_sprite sCelebiGfx8, 0x200
+ax_sprite_terminator
+sCelebiGfx9:
+.incbin "baserom.gba", 0x1048ED8, 0x200
+sCelebiSprites9:
+ax_sprite sCelebiGfx9, 0x200
+ax_sprite_terminator
+sCelebiGfx10:
+.incbin "baserom.gba", 0x10490E8, 0x200
+sCelebiSprites10:
+ax_sprite sCelebiGfx10, 0x200
+ax_sprite_terminator
+sCelebiGfx11:
+.incbin "baserom.gba", 0x10492F8, 0x200
+sCelebiSprites11:
+ax_sprite sCelebiGfx11, 0x200
+ax_sprite_terminator
+sCelebiGfx12:
+.incbin "baserom.gba", 0x1049508, 0x200
+sCelebiSprites12:
+ax_sprite sCelebiGfx12, 0x200
+ax_sprite_terminator
+sCelebiGfx13:
+.incbin "baserom.gba", 0x1049718, 0x200
+sCelebiSprites13:
+ax_sprite sCelebiGfx13, 0x200
+ax_sprite_terminator
+sCelebiGfx14:
+.incbin "baserom.gba", 0x1049928, 0x200
+sCelebiSprites14:
+ax_sprite sCelebiGfx14, 0x200
+ax_sprite_terminator
+sCelebiGfx15:
+.incbin "baserom.gba", 0x1049B38, 0x200
+sCelebiSprites15:
+ax_sprite sCelebiGfx15, 0x200
+ax_sprite_terminator
+sCelebiGfx16:
+.incbin "baserom.gba", 0x1049D48, 0x200
+sCelebiSprites16:
+ax_sprite sCelebiGfx16, 0x200
+ax_sprite_terminator
+sCelebiGfx17:
+.incbin "baserom.gba", 0x1049F58, 0x200
+sCelebiSprites17:
+ax_sprite sCelebiGfx17, 0x200
+ax_sprite_terminator
+sCelebiGfx18:
+.incbin "baserom.gba", 0x104A168, 0x200
+sCelebiSprites18:
+ax_sprite sCelebiGfx18, 0x200
+ax_sprite_terminator
+sCelebiGfx19:
+.incbin "baserom.gba", 0x104A378, 0x200
+sCelebiSprites19:
+ax_sprite sCelebiGfx19, 0x200
+ax_sprite_terminator
+sCelebiGfx20:
+.incbin "baserom.gba", 0x104A588, 0x200
+sCelebiSprites20:
+ax_sprite sCelebiGfx20, 0x200
+ax_sprite_terminator
+sCelebiGfx21:
+.incbin "baserom.gba", 0x104A798, 0x200
+sCelebiSprites21:
+ax_sprite sCelebiGfx21, 0x200
+ax_sprite_terminator
+sCelebiGfx22:
+.incbin "baserom.gba", 0x104A9A8, 0x200
+sCelebiSprites22:
+ax_sprite sCelebiGfx22, 0x200
+ax_sprite_terminator
+sAxPosesCelebi:
+.4byte sCelebiPose1
+.4byte sCelebiPose2
+.4byte sCelebiPose3
+.4byte sCelebiPose4
+.4byte sCelebiPose5
+.4byte sCelebiPose6
+.4byte sCelebiPose7
+.4byte sCelebiPose8
+.4byte sCelebiPose9
+.4byte sCelebiPose10
+.4byte sCelebiPose11
+.4byte sCelebiPose12
+.4byte sCelebiPose13
+.4byte sCelebiPose14
+.4byte sCelebiPose15
+.4byte sCelebiPose16
+.4byte sCelebiPose17
+.4byte sCelebiPose18
+.4byte sCelebiPose19
+.4byte sCelebiPose20
+.4byte sCelebiPose21
+.4byte sCelebiPose22
+.4byte sCelebiPose23
+.4byte sCelebiPose24
+.4byte sCelebiPose25
+.4byte sCelebiPose26
+.4byte sCelebiPose27
+.4byte sCelebiPose28
+.4byte sCelebiPose29
+.4byte sCelebiPose30
+.4byte sCelebiPose31
+.4byte sCelebiPose32
+.4byte sCelebiPose33
+.4byte sCelebiPose34
+.4byte sCelebiPose35
+.4byte sCelebiPose36
+.4byte sCelebiPose37
+.4byte sCelebiPose38
+.4byte sCelebiPose39
+.4byte sCelebiPose40
+.4byte sCelebiPose41
+.4byte sCelebiPose42
+.4byte sCelebiPose43
+.4byte sCelebiPose44
+.4byte sCelebiPose45
+.4byte sCelebiPose46
+.4byte sCelebiPose47
+.4byte sCelebiPose48
+.4byte sCelebiPose49
+.4byte sCelebiPose50
+.4byte sCelebiPose51
+.4byte sCelebiPose52
+.4byte sCelebiPose53
+.4byte sCelebiPose54
+.4byte sCelebiPose55
+.4byte sCelebiPose56
+.4byte sCelebiPose57
+.4byte sCelebiPose58
+.4byte sCelebiPose59
+.4byte sCelebiPose60
+.4byte sCelebiPose61
+.4byte sCelebiPose62
+.4byte sCelebiPose63
+.4byte sCelebiPose64
+.4byte sCelebiPose65
+.4byte sCelebiPose66
+.4byte sCelebiPose67
+.4byte sCelebiPose68
+.4byte sCelebiPose69
+.4byte sCelebiPose70
+.4byte sCelebiPose71
+.4byte sCelebiPose72
+.4byte sCelebiPose73
+.4byte sCelebiPose74
+.4byte sCelebiPose75
+.4byte sCelebiPose76
+.4byte sCelebiPose77
+.4byte sCelebiPose78
+.4byte sCelebiPose79
+.4byte sCelebiPose80
+.4byte sCelebiPose81
+.4byte sCelebiPose82
+.4byte sCelebiPose83
+.4byte sCelebiPose84
+.4byte sCelebiPose85
+.4byte sCelebiPose86
+.4byte sCelebiPose87
+.4byte sCelebiPose88
+.4byte sCelebiPose89
+.4byte sCelebiPose90
+.4byte sCelebiPose91
+.4byte sCelebiPose92
+.4byte sCelebiPose93
+.4byte sCelebiPose94
+.4byte sCelebiPose95
+.4byte sCelebiPose96
+.4byte sCelebiPose97
+.4byte sCelebiPose98
+.4byte sCelebiPose99
+.4byte sCelebiPose100
+.4byte sCelebiPose101
+.4byte sCelebiPose102
+.4byte sCelebiPose103
+.4byte sCelebiPose104
+.4byte sCelebiPose105
+.4byte sCelebiPose106
+.4byte sCelebiPose107
+.4byte sCelebiPose108
+.4byte sCelebiPose109
+.4byte sCelebiPose110
+.4byte sCelebiPose111
+.4byte sCelebiPose112
+.4byte sCelebiPose113
+.4byte sCelebiPose114
+.4byte sCelebiPose115
+.4byte sCelebiPose116
+.4byte sCelebiPose117
+.4byte sCelebiPose118
+.4byte sCelebiPose119
+.4byte sCelebiPose120
+.4byte sCelebiPose121
+.4byte sCelebiPose122
+.4byte sCelebiPose123
+.4byte sCelebiPose124
+.4byte sCelebiPose125
+.4byte sCelebiPose126
+.4byte sCelebiPose127
+.4byte sCelebiPose128
+.4byte sCelebiPose129
+.4byte sCelebiPose130
+.4byte sCelebiPose131
+.4byte sCelebiPose132
+.4byte sCelebiPose133
+.4byte sCelebiPose134
+.4byte sCelebiPose135
+.4byte sCelebiPose136
+.4byte sCelebiPose137
+.4byte sCelebiPose138
+.4byte sCelebiPose139
+.4byte sCelebiPose140
+.4byte sCelebiPose141
+.4byte sCelebiPose142
+.4byte sCelebiPose143
+.4byte sCelebiPose144
+.4byte sCelebiPose145
+.4byte sCelebiPose146
+.4byte sCelebiPose147
+.4byte sCelebiPose148
+.4byte sCelebiPose149
+.4byte sCelebiPose150
+.4byte sCelebiPose151
+.4byte sCelebiPose152
+.4byte sCelebiPose153
+.4byte sCelebiPose154
+.4byte sCelebiPose155
+.4byte sCelebiPose156
+.4byte sCelebiPose157
+.4byte sCelebiPose158
+.4byte sCelebiPose159
+.4byte sCelebiPose160
+.4byte sCelebiPose161
+.4byte sCelebiPose162
+.4byte sCelebiPose163
+.4byte sCelebiPose164
+.4byte sCelebiPose165
+.4byte sCelebiPose166
+.4byte sCelebiPose167
+.4byte sCelebiPose168
+.4byte sCelebiPose169
+.4byte sCelebiPose170
+.4byte sCelebiPose171
+.4byte sCelebiPose172
+.4byte sCelebiPose173
+.4byte sCelebiPose174
+.4byte sCelebiPose175
+.4byte sCelebiPose176
+.4byte sCelebiPose177
+.4byte sCelebiPose178
+.4byte sCelebiPose179
+.4byte sCelebiPose180
+.4byte sCelebiPose181
+.4byte sCelebiPose182
+.4byte sCelebiPose183
+.4byte sCelebiPose184
+.4byte sCelebiPose185
+.4byte sCelebiPose186
+.4byte sCelebiPose187
+.4byte sCelebiPose188
+.4byte sCelebiPose189
+.4byte sCelebiPose190
+.4byte sCelebiPose191
+.4byte sCelebiPose192
+.4byte sCelebiPose193
+.4byte sCelebiPose194
+.4byte sCelebiPose195
+.4byte sCelebiPose196
+.4byte sCelebiPose197
+.4byte sCelebiPose198
+.4byte sCelebiPose199
+.4byte sCelebiPose200
+.4byte sCelebiPose201
+.4byte sCelebiPose202
+.4byte sCelebiPose203
+.4byte sCelebiPose204
+.4byte sCelebiPose205
+.4byte sCelebiPose206
+.4byte sCelebiPose207
+.4byte sCelebiPose208
+.4byte sCelebiPose209
+.4byte sCelebiPose210
+.4byte sCelebiPose211
+.4byte sCelebiPose212
+.4byte sCelebiPose213
+.4byte sCelebiPose214
+.4byte sCelebiPose215
+.4byte sCelebiPose216
+.4byte sCelebiPose217
+.4byte sCelebiPose218
+.4byte sCelebiPose219
+.4byte sCelebiPose220
+.4byte sCelebiPose221
+.4byte sCelebiPose222
+.4byte sCelebiPose223
+.4byte sCelebiPose224
+.4byte sCelebiPose225
+.4byte sCelebiPose226
+.4byte sCelebiPose227
+.4byte sCelebiPose228
+.4byte sCelebiPose229
+.4byte sCelebiPose230
+.4byte sCelebiPose231
+.4byte sCelebiPose232
+.4byte sCelebiPose233
+.4byte sCelebiPose234
+sAxPositionsCelebi:
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -2,  -13, 	  -3,  -11, 	   5,   -9, 	   2,  -13
+.2byte   -3,  -11, 	  -4,  -10, 	   5,   -8, 	   1,  -11
+.2byte   -1,  -12, 	  -8,  -14, 	   6,  -14, 	  -1,  -13
+.2byte    1,  -12, 	   1,  -16, 	  -9,  -14, 	  -4,  -12
+.2byte    1,  -11, 	  -5,  -16, 	  -7,  -13, 	  -3,  -11
+.2byte    3,  -11, 	  -7,  -13, 	   5,  -11, 	  -2,  -10
+.2byte   -1,  -11, 	   6,  -11, 	  -8,  -11, 	  -1,   -9
+.2byte   -4,  -11, 	   6,  -13, 	  -6,  -11, 	   1,  -10
+.2byte   -2,  -11, 	   4,  -16, 	   6,  -13, 	   2,  -11
+.2byte   -2,  -12, 	  -2,  -16, 	   8,  -14, 	   3,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte    3,  -12, 	  -5,   -8, 	   3,   -6, 	  -1,  -11
+.2byte    5,  -11, 	  -4,  -10, 	  -3,   -6, 	  -1,  -11
+.2byte    4,  -11, 	   4,  -10, 	  -5,   -7, 	   0,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    4,  -11, 	   4,  -10, 	  -5,   -7, 	   0,  -11
+.2byte    5,  -11, 	  -4,  -10, 	  -3,   -6, 	  -1,  -11
+.2byte    3,  -12, 	  -5,   -8, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   3,  -10, 	  -6,   -7, 	  -1,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    4,  -11, 	  -5,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte    2,  -12, 	  -6,   -8, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	   5,   -8, 	  -7,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -4,  -12, 	   4,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -6,  -11, 	   3,   -9, 	   2,   -6, 	   0,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	  -5,  -10, 	   4,   -7, 	  -1,  -11
+sCelebiAnimTable1:
+.4byte sCelebiAnims_1_1
+.4byte sCelebiAnims_1_2
+.4byte sCelebiAnims_1_3
+.4byte sCelebiAnims_1_4
+.4byte sCelebiAnims_1_5
+.4byte sCelebiAnims_1_6
+.4byte sCelebiAnims_1_7
+.4byte sCelebiAnims_1_8
+sCelebiAnimTable2:
+.4byte sCelebiAnims_2_1
+.4byte sCelebiAnims_2_2
+.4byte sCelebiAnims_2_3
+.4byte sCelebiAnims_2_4
+.4byte sCelebiAnims_2_5
+.4byte sCelebiAnims_2_6
+.4byte sCelebiAnims_2_7
+.4byte sCelebiAnims_2_8
+sCelebiAnimTable3:
+.4byte sCelebiAnims_3_1
+.4byte sCelebiAnims_3_2
+.4byte sCelebiAnims_3_3
+.4byte sCelebiAnims_3_4
+.4byte sCelebiAnims_3_5
+.4byte sCelebiAnims_3_6
+.4byte sCelebiAnims_3_7
+.4byte sCelebiAnims_3_8
+sCelebiAnimTable4:
+.4byte sCelebiAnims_4_1
+.4byte sCelebiAnims_4_2
+.4byte sCelebiAnims_4_3
+.4byte sCelebiAnims_4_4
+.4byte sCelebiAnims_4_5
+.4byte sCelebiAnims_4_6
+.4byte sCelebiAnims_4_7
+.4byte sCelebiAnims_4_8
+sCelebiAnimTable5:
+.4byte sCelebiAnims_5_1
+.4byte sCelebiAnims_5_2
+.4byte sCelebiAnims_5_3
+.4byte sCelebiAnims_5_4
+.4byte sCelebiAnims_5_5
+.4byte sCelebiAnims_5_6
+.4byte sCelebiAnims_5_7
+.4byte sCelebiAnims_5_8
+sCelebiAnimTable6:
+.4byte sCelebiAnims_6_1
+.4byte sCelebiAnims_6_1
+.4byte sCelebiAnims_6_1
+.4byte sCelebiAnims_6_1
+.4byte sCelebiAnims_6_1
+.4byte sCelebiAnims_6_1
+.4byte sCelebiAnims_6_1
+.4byte sCelebiAnims_6_1
+sCelebiAnimTable7:
+.4byte sCelebiAnims_7_1
+.4byte sCelebiAnims_7_2
+.4byte sCelebiAnims_7_3
+.4byte sCelebiAnims_7_4
+.4byte sCelebiAnims_7_5
+.4byte sCelebiAnims_7_6
+.4byte sCelebiAnims_7_7
+.4byte sCelebiAnims_7_8
+sCelebiAnimTable8:
+.4byte sCelebiAnims_8_1
+.4byte sCelebiAnims_8_2
+.4byte sCelebiAnims_8_3
+.4byte sCelebiAnims_8_4
+.4byte sCelebiAnims_8_5
+.4byte sCelebiAnims_8_6
+.4byte sCelebiAnims_8_7
+.4byte sCelebiAnims_8_8
+sCelebiAnimTable9:
+.4byte sCelebiAnims_9_1
+.4byte sCelebiAnims_9_2
+.4byte sCelebiAnims_9_3
+.4byte sCelebiAnims_9_4
+.4byte sCelebiAnims_9_5
+.4byte sCelebiAnims_9_6
+.4byte sCelebiAnims_9_7
+.4byte sCelebiAnims_9_8
+sCelebiAnimTable10:
+.4byte sCelebiAnims_10_1
+.4byte sCelebiAnims_10_2
+.4byte sCelebiAnims_10_3
+.4byte sCelebiAnims_10_4
+.4byte sCelebiAnims_10_5
+.4byte sCelebiAnims_10_6
+.4byte sCelebiAnims_10_7
+.4byte sCelebiAnims_10_8
+sCelebiAnimTable11:
+.4byte sCelebiAnims_11_1
+.4byte sCelebiAnims_11_2
+.4byte sCelebiAnims_11_3
+.4byte sCelebiAnims_11_4
+.4byte sCelebiAnims_11_5
+.4byte sCelebiAnims_11_6
+.4byte sCelebiAnims_11_7
+.4byte sCelebiAnims_11_8
+sCelebiAnimTable12:
+.4byte sCelebiAnims_12_1
+.4byte sCelebiAnims_12_2
+.4byte sCelebiAnims_12_3
+.4byte sCelebiAnims_12_4
+.4byte sCelebiAnims_12_5
+.4byte sCelebiAnims_12_6
+.4byte sCelebiAnims_12_7
+.4byte sCelebiAnims_12_8
+sCelebiAnimTable13:
+.4byte sCelebiAnims_13_1
+.4byte sCelebiAnims_13_2
+.4byte sCelebiAnims_13_3
+.4byte sCelebiAnims_13_4
+.4byte sCelebiAnims_13_5
+.4byte sCelebiAnims_13_6
+.4byte sCelebiAnims_13_7
+.4byte sCelebiAnims_13_8
+sCelebiAnimTable14:
+.4byte sCelebiAnims_14_1
+.4byte sCelebiAnims_14_1
+.4byte sCelebiAnims_14_1
+.4byte sCelebiAnims_14_1
+.4byte sCelebiAnims_14_1
+.4byte sCelebiAnims_14_1
+.4byte sCelebiAnims_14_1
+.4byte sCelebiAnims_14_1
+sAxAnimationsCelebi:
+.4byte sCelebiAnimTable1
+.4byte sCelebiAnimTable2
+.4byte sCelebiAnimTable3
+.4byte sCelebiAnimTable4
+.4byte sCelebiAnimTable5
+.4byte sCelebiAnimTable6
+.4byte sCelebiAnimTable7
+.4byte sCelebiAnimTable8
+.4byte sCelebiAnimTable9
+.4byte sCelebiAnimTable10
+.4byte sCelebiAnimTable11
+.4byte sCelebiAnimTable12
+.4byte sCelebiAnimTable13
+.4byte sCelebiAnimTable14
+sAxSpritesCelebi:
+.4byte sCelebiSprites1
+.4byte sCelebiSprites2
+.4byte sCelebiSprites3
+.4byte sCelebiSprites4
+.4byte sCelebiSprites5
+.4byte sCelebiSprites6
+.4byte sCelebiSprites7
+.4byte sCelebiSprites8
+.4byte sCelebiSprites9
+.4byte sCelebiSprites10
+.4byte sCelebiSprites11
+.4byte sCelebiSprites12
+.4byte sCelebiSprites13
+.4byte sCelebiSprites14
+.4byte sCelebiSprites15
+.4byte sCelebiSprites16
+.4byte sCelebiSprites17
+.4byte sCelebiSprites18
+.4byte sCelebiSprites19
+.4byte sCelebiSprites20
+.4byte sCelebiSprites21
+.4byte sCelebiSprites22
+sAxMainCelebi:
+ax_main sAxPosesCelebi, sAxAnimationsCelebi, 14, sAxSpritesCelebi, sAxPositionsCelebi

--- a/data/ax/chansey.inc
+++ b/data/ax/chansey.inc
@@ -1,0 +1,2800 @@
+.global gAxChansey
+gAxChansey:
+ax_siro sAxMainChansey
+sChanseyPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose6:
+ax_pose 5, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose7:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose8:
+ax_pose 7, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose9:
+ax_pose 8, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose10:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose11:
+ax_pose 10, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose19:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose21:
+ax_pose 8, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose28:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose29:
+ax_pose 4, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose30:
+ax_pose 5, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose31:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose32:
+ax_pose 7, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose33:
+ax_pose 8, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose34:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose35:
+ax_pose 10, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose36:
+ax_pose 11, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose37:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose38:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose39:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose41:
+ax_pose 10, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose43:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose44:
+ax_pose 7, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose45:
+ax_pose 8, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose47:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose48:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose50:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose51:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose52:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose53:
+ax_pose 4, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose54:
+ax_pose 5, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose55:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose56:
+ax_pose 7, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose57:
+ax_pose 8, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose58:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose59:
+ax_pose 10, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose60:
+ax_pose 11, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose61:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose62:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose63:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose64:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose65:
+ax_pose 10, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose66:
+ax_pose 11, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose67:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose68:
+ax_pose 7, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose69:
+ax_pose 8, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose71:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose72:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose73:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose74:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose75:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose76:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose77:
+ax_pose 17, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose78:
+ax_pose 18, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose79:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose80:
+ax_pose 19, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose81:
+ax_pose 20, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose82:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose83:
+ax_pose 21, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose84:
+ax_pose 22, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose85:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose86:
+ax_pose 23, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose87:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose88:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose89:
+ax_pose 21, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose90:
+ax_pose 22, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose91:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose92:
+ax_pose 19, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose93:
+ax_pose 20, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose94:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose95:
+ax_pose 17, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose96:
+ax_pose 18, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose97:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose98:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose99:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose100:
+ax_pose 25, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose101:
+ax_pose 26, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose102:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose103:
+ax_pose 17, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose104:
+ax_pose 18, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose105:
+ax_pose 27, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose106:
+ax_pose 28, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose107:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose108:
+ax_pose 19, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose109:
+ax_pose 20, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose110:
+ax_pose 29, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose111:
+ax_pose 30, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose112:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose113:
+ax_pose 21, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose114:
+ax_pose 22, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sChanseyPose115:
+ax_pose 31, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose116:
+ax_pose 32, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose117:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose118:
+ax_pose 23, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose119:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose120:
+ax_pose 33, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sChanseyPose121:
+ax_pose 34, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sChanseyPose122:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose123:
+ax_pose 21, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose124:
+ax_pose 22, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose125:
+ax_pose 31, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose126:
+ax_pose 32, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose127:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose128:
+ax_pose 19, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose129:
+ax_pose 20, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose130:
+ax_pose 29, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose131:
+ax_pose 30, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose132:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose133:
+ax_pose 17, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose134:
+ax_pose 18, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sChanseyPose135:
+ax_pose 27, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose136:
+ax_pose 28, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose137:
+ax_pose 35, 0x01ee, 0x80f6, 0x4c00
+ax_pose_terminator
+sChanseyPose138:
+ax_pose 36, 0x01ee, 0x80f6, 0x4c00
+ax_pose_terminator
+sChanseyPose139:
+ax_pose 37, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose140:
+ax_pose 38, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sChanseyPose141:
+ax_pose 39, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sChanseyPose142:
+ax_pose 40, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose143:
+ax_pose 41, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose144:
+ax_pose 40, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose145:
+ax_pose 39, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sChanseyPose146:
+ax_pose 38, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sChanseyPose147:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose148:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose149:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose150:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose151:
+ax_pose 4, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose152:
+ax_pose 5, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose153:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose154:
+ax_pose 7, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose155:
+ax_pose 8, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose156:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose157:
+ax_pose 10, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose158:
+ax_pose 11, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose159:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose160:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose161:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose162:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose163:
+ax_pose 10, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose164:
+ax_pose 11, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose165:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose166:
+ax_pose 7, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose167:
+ax_pose 8, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose168:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose169:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose170:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose171:
+ax_pose 25, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose172:
+ax_pose 27, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose173:
+ax_pose 29, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sChanseyPose174:
+ax_pose 31, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sChanseyPose175:
+ax_pose 33, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sChanseyPose176:
+ax_pose 31, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sChanseyPose177:
+ax_pose 29, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sChanseyPose178:
+ax_pose 27, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose179:
+ax_pose 26, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose180:
+ax_pose 28, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose181:
+ax_pose 30, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose182:
+ax_pose 32, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose183:
+ax_pose 34, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sChanseyPose184:
+ax_pose 32, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose185:
+ax_pose 30, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose186:
+ax_pose 28, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose187:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose188:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose189:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose190:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose191:
+ax_pose 4, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose192:
+ax_pose 5, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose193:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose194:
+ax_pose 7, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose195:
+ax_pose 8, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose196:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose197:
+ax_pose 10, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose198:
+ax_pose 11, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose199:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose200:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose201:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose202:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose203:
+ax_pose 10, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose204:
+ax_pose 11, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose205:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose206:
+ax_pose 7, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose207:
+ax_pose 8, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose208:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose209:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose210:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose211:
+ax_pose 26, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose212:
+ax_pose 28, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose213:
+ax_pose 30, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose214:
+ax_pose 32, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose215:
+ax_pose 34, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sChanseyPose216:
+ax_pose 32, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose217:
+ax_pose 30, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose218:
+ax_pose 28, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose219:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose220:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose221:
+ax_pose 6, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose222:
+ax_pose 9, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose223:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sChanseyPose224:
+ax_pose 9, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose225:
+ax_pose 6, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+sChanseyPose226:
+ax_pose 3, 0x01ec, 0x90ec, 0x4c00
+ax_pose_terminator
+.align 2
+sChanseyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChanseyAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sChanseyAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sChanseyAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sChanseyAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sChanseyAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sChanseyAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sChanseyAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sChanseyAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sChanseyAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 1, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sChanseyAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sChanseyAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sChanseyAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 1, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 0, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sChanseyAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 1, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 0, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sChanseyAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 1, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 0, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sChanseyAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sChanseyAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sChanseyAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 1, -3, 1, 0,
+ax_anim 2, 2, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 1, -3, 1, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 1, 0, 73, 0, -2, 0, 0,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 1, 74, 0, -2, 0, -2,
+ax_anim 2, 0, 74, 1, -2, 1, -2,
+ax_anim 2, 0, 74, 0, -3, 0, -3,
+ax_anim 2, 0, 74, 1, -3, 1, -3,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim 2, 0, 74, 1, -4, 1, -4,
+ax_anim_terminator
+sChanseyAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 1, -4, 1, -1,
+ax_anim 2, 2, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 1, -4, 1, -1,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 1, 0, 76, 0, -2, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 1, 77, -2, -2, -2, -2,
+ax_anim 2, 0, 77, -1, -3, -1, -3,
+ax_anim 2, 0, 77, -3, -3, -3, -3,
+ax_anim 2, 0, 77, -2, -4, -2, -4,
+ax_anim 2, 0, 77, -4, -4, -4, -4,
+ax_anim 2, 0, 77, -3, -5, -3, -5,
+ax_anim_terminator
+sChanseyAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 2, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, -1,
+ax_anim 2, 2, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, -1,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 1, 0, 79, 0, -2, 0, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 1, 80, -2, 0, -2, 0,
+ax_anim 2, 0, 80, -2, -1, -2, -1,
+ax_anim 2, 0, 80, -3, 0, -3, 0,
+ax_anim 2, 0, 80, -3, -1, -3, -1,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim 2, 0, 80, -4, -1, -4, -1,
+ax_anim_terminator
+sChanseyAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 1, -2, 1, 1,
+ax_anim 2, 2, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 1, -2, 1, 1,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 1, 0, 82, 0, -2, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 1, 83, -2, 2, -2, 2,
+ax_anim 2, 0, 83, -3, 1, -3, 1,
+ax_anim 2, 0, 83, -3, 3, -3, 3,
+ax_anim 2, 0, 83, -4, 2, -4, 2,
+ax_anim 2, 0, 83, -4, 4, -4, 4,
+ax_anim 2, 0, 83, -5, 3, -5, 3,
+ax_anim_terminator
+sChanseyAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 1, -3, 1, 0,
+ax_anim 2, 2, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 1, -3, 1, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 1, 0, 85, 0, -2, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 86, 0, 2, 0, -2,
+ax_anim 2, 0, 86, 1, 2, 1, -2,
+ax_anim 2, 0, 86, 0, 3, 0, -3,
+ax_anim 2, 0, 86, 1, 3, 1, -3,
+ax_anim 2, 0, 86, 0, 4, 0, -4,
+ax_anim 2, 0, 86, 1, 4, 1, -4,
+ax_anim_terminator
+sChanseyAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -1, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 1, -4, 1, -1,
+ax_anim 2, 2, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 1, -4, 1, -1,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 1, 0, 88, 0, -2, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 1, 89, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 3, 1, 3, 1,
+ax_anim 2, 0, 89, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 4, 2, 4, 2,
+ax_anim 2, 0, 89, 4, 4, 4, 4,
+ax_anim 2, 0, 89, 5, 3, 5, 3,
+ax_anim_terminator
+sChanseyAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, -1,
+ax_anim 2, 2, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, -1,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 92, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 2, -1, 2, -1,
+ax_anim 2, 0, 92, 3, 0, 3, 0,
+ax_anim 2, 0, 92, 3, -1, 3, -1,
+ax_anim 2, 0, 92, 4, 0, 4, 0,
+ax_anim 2, 0, 92, 4, -1, 4, -1,
+ax_anim_terminator
+sChanseyAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 94, -1, -4, -1, -1,
+ax_anim 2, 2, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 94, -1, -4, -1, -1,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 1, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 1, -3, 1, -3,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 2, -4, 2, -4,
+ax_anim 2, 0, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 3, -5, 3, -5,
+ax_anim_terminator
+.align 2
+sChanseyAnims_5_1:
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 4, 0, 96, 0, -3, 0, -3,
+ax_anim 1, 0, 98, 0, -3, 0, -3,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 3, 0, 3,
+ax_anim 3, 0, 99, 0, 3, 0, 3,
+ax_anim 3, 0, 100, 0, 3, 0, 3,
+ax_anim 2, 1, 99, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 3, 0, 3,
+ax_anim 2, 0, 99, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim_terminator
+sChanseyAnims_5_2:
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 4, 0, 101, -3, -3, -3, -3,
+ax_anim 1, 0, 103, -3, -3, -3, -3,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 105, 3, 3, 3, 3,
+ax_anim 3, 0, 104, 3, 3, 3, 3,
+ax_anim 3, 0, 105, 3, 3, 3, 3,
+ax_anim 2, 1, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 105, 3, 3, 3, 3,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 105, 3, 3, 3, 3,
+ax_anim 2, 0, 101, 1, 1, 1, 1,
+ax_anim_terminator
+sChanseyAnims_5_3:
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim 4, 0, 106, -3, 0, -3, 0,
+ax_anim 1, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 3, 0, 109, 3, 0, 3, 0,
+ax_anim 3, 0, 110, 3, 0, 3, 0,
+ax_anim 2, 1, 109, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 109, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim_terminator
+sChanseyAnims_5_4:
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 4, 0, 111, -3, 3, -3, 3,
+ax_anim 1, 0, 113, -3, 3, -3, 3,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 3, 0, 114, 3, -3, 3, -3,
+ax_anim 3, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 1, 114, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 114, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim_terminator
+sChanseyAnims_5_5:
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 4, 0, 116, 0, 3, 0, 3,
+ax_anim 1, 0, 118, 0, 3, 0, 3,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 120, 0, -3, 0, -3,
+ax_anim 3, 0, 119, 0, -3, 0, -3,
+ax_anim 3, 0, 120, 0, -3, 0, -3,
+ax_anim 2, 1, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 120, 0, -3, 0, -3,
+ax_anim 2, 0, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 120, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sChanseyAnims_5_6:
+ax_anim 2, 0, 121, 1, 1, 1, 1,
+ax_anim 4, 0, 121, 3, 3, 3, 3,
+ax_anim 1, 0, 123, 3, 3, 3, 3,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim 2, 0, 125, -3, -3, -3, -3,
+ax_anim 3, 0, 124, -3, -3, -3, -3,
+ax_anim 3, 0, 125, -3, -3, -3, -3,
+ax_anim 2, 1, 124, -3, -3, -3, -3,
+ax_anim 2, 0, 125, -3, -3, -3, -3,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim 2, 0, 125, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim_terminator
+sChanseyAnims_5_7:
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 4, 0, 126, 3, 0, 3, 0,
+ax_anim 1, 0, 128, 3, 0, 3, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -3, 0, -3, 0,
+ax_anim 2, 0, 130, -3, 0, -3, 0,
+ax_anim 3, 0, 129, -3, 0, -3, 0,
+ax_anim 3, 0, 130, -3, 0, -3, 0,
+ax_anim 2, 1, 129, -3, 0, -3, 0,
+ax_anim 2, 0, 130, -3, 0, -3, 0,
+ax_anim 2, 0, 129, -3, 0, -3, 0,
+ax_anim 2, 0, 130, -3, 0, -3, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim_terminator
+sChanseyAnims_5_8:
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 4, 0, 131, 3, -3, 3, -3,
+ax_anim 1, 0, 133, 3, -3, 3, -3,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, -3, 3, -3, 3,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 3, 0, 134, -3, 3, -3, 3,
+ax_anim 3, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 1, 134, -3, 3, -3, 3,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 134, -3, 3, -3, 3,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 131, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sChanseyAnims_6_1:
+ax_anim 35, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChanseyAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sChanseyAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sChanseyAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sChanseyAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sChanseyAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sChanseyAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sChanseyAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sChanseyAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sChanseyAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 3, 0, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 3, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 148, 0, -3, 0, 0,
+ax_anim_terminator
+sChanseyAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -3, 0, 0,
+ax_anim 3, 0, 150, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 3, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 151, 0, -3, 0, 0,
+ax_anim_terminator
+sChanseyAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, -3, 0, 0,
+ax_anim 3, 0, 153, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 3, 0, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 154, 0, -3, 0, 0,
+ax_anim_terminator
+sChanseyAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -3, 0, 0,
+ax_anim 3, 0, 156, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, -4, 0, 0,
+ax_anim 3, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim_terminator
+sChanseyAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, -3, 0, 0,
+ax_anim 3, 0, 159, 0, -4, 0, 0,
+ax_anim 4, 0, 158, 0, -4, 0, 0,
+ax_anim 3, 0, 160, 0, -4, 0, 0,
+ax_anim 2, 0, 160, 0, -3, 0, 0,
+ax_anim_terminator
+sChanseyAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -3, 0, 0,
+ax_anim 3, 0, 162, 0, -4, 0, 0,
+ax_anim 4, 0, 161, 0, -4, 0, 0,
+ax_anim 3, 0, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 163, 0, -3, 0, 0,
+ax_anim_terminator
+sChanseyAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, -3, 0, 0,
+ax_anim 3, 0, 165, 0, -4, 0, 0,
+ax_anim 4, 0, 164, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -4, 0, 0,
+ax_anim 2, 0, 166, 0, -3, 0, 0,
+ax_anim_terminator
+sChanseyAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -3, 0, 0,
+ax_anim 3, 0, 168, 0, -4, 0, 0,
+ax_anim 4, 0, 167, 0, -4, 0, 0,
+ax_anim 3, 0, 169, 0, -4, 0, 0,
+ax_anim 2, 0, 169, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sChanseyAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 17, 7, 17,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 17, -7, 17,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 19, 10, 19, 10,
+ax_anim 3, 0, 173, 19, 20, 19, 20,
+ax_anim 2, 3, 174, 10, 20, 10, 20,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 19, -2, 19, -2,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 19, -21, 19, -21,
+ax_anim 2, 3, 172, 20, -15, 20, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -19, -21, -19, -21,
+ax_anim 2, 3, 176, -20, -15, -20, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -19, -2, -19, -2,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -19, 10, -19, 10,
+ax_anim 3, 0, 175, -19, 20, -19, 20,
+ax_anim 2, 3, 174, -10, 20, -10, 20,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChanseyAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChanseyAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChanseyAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChanseyAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sChanseyGfx1:
+.incbin "baserom.gba", 0x9E20CC, 0x200
+sChanseySprites1:
+ax_sprite sChanseyGfx1, 0x200
+ax_sprite_terminator
+sChanseyGfx2:
+.incbin "baserom.gba", 0x9E22DC, 0x200
+sChanseySprites2:
+ax_sprite sChanseyGfx2, 0x200
+ax_sprite_terminator
+sChanseyGfx3:
+.incbin "baserom.gba", 0x9E24EC, 0x200
+sChanseySprites3:
+ax_sprite sChanseyGfx3, 0x200
+ax_sprite_terminator
+sChanseyGfx4:
+.incbin "baserom.gba", 0x9E26FC, 0x200
+sChanseySprites4:
+ax_sprite sChanseyGfx4, 0x200
+ax_sprite_terminator
+sChanseyGfx5:
+.incbin "baserom.gba", 0x9E290C, 0x200
+sChanseySprites5:
+ax_sprite sChanseyGfx5, 0x200
+ax_sprite_terminator
+sChanseyGfx6:
+.incbin "baserom.gba", 0x9E2B1C, 0x200
+sChanseySprites6:
+ax_sprite sChanseyGfx6, 0x200
+ax_sprite_terminator
+sChanseyGfx7:
+.incbin "baserom.gba", 0x9E2D2C, 0x200
+sChanseySprites7:
+ax_sprite sChanseyGfx7, 0x200
+ax_sprite_terminator
+sChanseyGfx8:
+.incbin "baserom.gba", 0x9E2F3C, 0x200
+sChanseySprites8:
+ax_sprite sChanseyGfx8, 0x200
+ax_sprite_terminator
+sChanseyGfx9:
+.incbin "baserom.gba", 0x9E314C, 0x200
+sChanseySprites9:
+ax_sprite sChanseyGfx9, 0x200
+ax_sprite_terminator
+sChanseyGfx10:
+.incbin "baserom.gba", 0x9E335C, 0x200
+sChanseySprites10:
+ax_sprite sChanseyGfx10, 0x200
+ax_sprite_terminator
+sChanseyGfx11:
+.incbin "baserom.gba", 0x9E356C, 0x200
+sChanseySprites11:
+ax_sprite sChanseyGfx11, 0x200
+ax_sprite_terminator
+sChanseyGfx12:
+.incbin "baserom.gba", 0x9E377C, 0x200
+sChanseySprites12:
+ax_sprite sChanseyGfx12, 0x200
+ax_sprite_terminator
+sChanseyGfx13:
+.incbin "baserom.gba", 0x9E398C, 0x200
+sChanseySprites13:
+ax_sprite sChanseyGfx13, 0x200
+ax_sprite_terminator
+sChanseyGfx14:
+.incbin "baserom.gba", 0x9E3B9C, 0x200
+sChanseySprites14:
+ax_sprite sChanseyGfx14, 0x200
+ax_sprite_terminator
+sChanseyGfx15:
+.incbin "baserom.gba", 0x9E3DAC, 0x200
+sChanseySprites15:
+ax_sprite sChanseyGfx15, 0x200
+ax_sprite_terminator
+sChanseyGfx16:
+.incbin "baserom.gba", 0x9E3FBC, 0x200
+sChanseySprites16:
+ax_sprite sChanseyGfx16, 0x200
+ax_sprite_terminator
+sChanseyGfx17:
+.incbin "baserom.gba", 0x9E41CC, 0x40
+sChanseyGfx17_1:
+.incbin "baserom.gba", 0x9E420C, 0x180
+sChanseySprites17:
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx17_1, 0x180
+ax_sprite_terminator
+sChanseyGfx18:
+.incbin "baserom.gba", 0x9E43B4, 0x1E0
+sChanseySprites18:
+ax_sprite sChanseyGfx18, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx19:
+.incbin "baserom.gba", 0x9E45AC, 0x40
+sChanseyGfx19_1:
+.incbin "baserom.gba", 0x9E45EC, 0x160
+sChanseySprites19:
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx20:
+.incbin "baserom.gba", 0x9E477C, 0x160
+sChanseyGfx20_1:
+.incbin "baserom.gba", 0x9E48DC, 0x60
+sChanseySprites20:
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx20, 0x160
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx20_1, 0x60
+ax_sprite_terminator
+sChanseyGfx21:
+.incbin "baserom.gba", 0x9E4964, 0x60
+sChanseyGfx21_1:
+.incbin "baserom.gba", 0x9E49C4, 0x60
+sChanseyGfx21_2:
+.incbin "baserom.gba", 0x9E4A24, 0xE0
+sChanseySprites21:
+ax_sprite sChanseyGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx21_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx22:
+.incbin "baserom.gba", 0x9E4B3C, 0x180
+sChanseyGfx22_1:
+.incbin "baserom.gba", 0x9E4CBC, 0x60
+sChanseySprites22:
+ax_sprite sChanseyGfx22, 0x180
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx22_1, 0x60
+ax_sprite_terminator
+sChanseyGfx23:
+.incbin "baserom.gba", 0x9E4D3C, 0x60
+sChanseyGfx23_1:
+.incbin "baserom.gba", 0x9E4D9C, 0x100
+sChanseyGfx23_2:
+.incbin "baserom.gba", 0x9E4E9C, 0x40
+sChanseySprites23:
+ax_sprite sChanseyGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx24:
+.incbin "baserom.gba", 0x9E4F14, 0x200
+sChanseySprites24:
+ax_sprite sChanseyGfx24, 0x200
+ax_sprite_terminator
+sChanseyGfx25:
+.incbin "baserom.gba", 0x9E5124, 0x180
+sChanseyGfx25_1:
+.incbin "baserom.gba", 0x9E52A4, 0x40
+sChanseySprites25:
+ax_sprite sChanseyGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx26:
+.incbin "baserom.gba", 0x9E530C, 0x60
+sChanseyGfx26_1:
+.incbin "baserom.gba", 0x9E536C, 0x60
+sChanseyGfx26_2:
+.incbin "baserom.gba", 0x9E53CC, 0x60
+sChanseyGfx26_3:
+.incbin "baserom.gba", 0x9E542C, 0x60
+sChanseySprites26:
+ax_sprite sChanseyGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx27:
+.incbin "baserom.gba", 0x9E54D4, 0x60
+sChanseyGfx27_1:
+.incbin "baserom.gba", 0x9E5534, 0x60
+sChanseyGfx27_2:
+.incbin "baserom.gba", 0x9E5594, 0x60
+sChanseyGfx27_3:
+.incbin "baserom.gba", 0x9E55F4, 0x60
+sChanseySprites27:
+ax_sprite sChanseyGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx28:
+.incbin "baserom.gba", 0x9E569C, 0x60
+sChanseyGfx28_1:
+.incbin "baserom.gba", 0x9E56FC, 0x60
+sChanseyGfx28_2:
+.incbin "baserom.gba", 0x9E575C, 0x60
+sChanseyGfx28_3:
+.incbin "baserom.gba", 0x9E57BC, 0x60
+sChanseySprites28:
+ax_sprite sChanseyGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx29:
+.incbin "baserom.gba", 0x9E5864, 0x60
+sChanseyGfx29_1:
+.incbin "baserom.gba", 0x9E58C4, 0x60
+sChanseyGfx29_2:
+.incbin "baserom.gba", 0x9E5924, 0x60
+sChanseyGfx29_3:
+.incbin "baserom.gba", 0x9E5984, 0x40
+sChanseySprites29:
+ax_sprite sChanseyGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChanseyGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChanseyGfx30:
+.incbin "baserom.gba", 0x9E5A0C, 0x60
+sChanseyGfx30_1:
+.incbin "baserom.gba", 0x9E5A6C, 0x60
+sChanseyGfx30_2:
+.incbin "baserom.gba", 0x9E5ACC, 0x60
+sChanseyGfx30_3:
+.incbin "baserom.gba", 0x9E5B2C, 0x20
+sChanseySprites30:
+ax_sprite sChanseyGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChanseyGfx30_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChanseyGfx31:
+.incbin "baserom.gba", 0x9E5B94, 0x60
+sChanseyGfx31_1:
+.incbin "baserom.gba", 0x9E5BF4, 0x60
+sChanseyGfx31_2:
+.incbin "baserom.gba", 0x9E5C54, 0x80
+sChanseyGfx31_3:
+.incbin "baserom.gba", 0x9E5CD4, 0x20
+sChanseySprites31:
+ax_sprite sChanseyGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx31_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx31_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChanseyGfx32:
+.incbin "baserom.gba", 0x9E5D3C, 0x60
+sChanseyGfx32_1:
+.incbin "baserom.gba", 0x9E5D9C, 0x60
+sChanseyGfx32_2:
+.incbin "baserom.gba", 0x9E5DFC, 0x60
+sChanseyGfx32_3:
+.incbin "baserom.gba", 0x9E5E5C, 0x20
+sChanseySprites32:
+ax_sprite sChanseyGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx32_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sChanseyGfx33:
+.incbin "baserom.gba", 0x9E5EC4, 0x60
+sChanseyGfx33_1:
+.incbin "baserom.gba", 0x9E5F24, 0x60
+sChanseyGfx33_2:
+.incbin "baserom.gba", 0x9E5F84, 0x60
+sChanseyGfx33_3:
+.incbin "baserom.gba", 0x9E5FE4, 0x40
+sChanseySprites33:
+ax_sprite sChanseyGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChanseyGfx33_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChanseyGfx34:
+.incbin "baserom.gba", 0x9E606C, 0x160
+sChanseySprites34:
+ax_sprite sChanseyGfx34, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sChanseyGfx35:
+.incbin "baserom.gba", 0x9E61E4, 0x160
+sChanseySprites35:
+ax_sprite sChanseyGfx35, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sChanseyGfx36:
+.incbin "baserom.gba", 0x9E635C, 0x200
+sChanseySprites36:
+ax_sprite sChanseyGfx36, 0x200
+ax_sprite_terminator
+sChanseyGfx37:
+.incbin "baserom.gba", 0x9E656C, 0x200
+sChanseySprites37:
+ax_sprite sChanseyGfx37, 0x200
+ax_sprite_terminator
+sChanseyGfx38:
+.incbin "baserom.gba", 0x9E677C, 0x200
+sChanseySprites38:
+ax_sprite sChanseyGfx38, 0x200
+ax_sprite_terminator
+sChanseyGfx39:
+.incbin "baserom.gba", 0x9E698C, 0x200
+sChanseySprites39:
+ax_sprite sChanseyGfx39, 0x200
+ax_sprite_terminator
+sChanseyGfx40:
+.incbin "baserom.gba", 0x9E6B9C, 0x200
+sChanseySprites40:
+ax_sprite sChanseyGfx40, 0x200
+ax_sprite_terminator
+sChanseyGfx41:
+.incbin "baserom.gba", 0x9E6DAC, 0x200
+sChanseySprites41:
+ax_sprite sChanseyGfx41, 0x200
+ax_sprite_terminator
+sChanseyGfx42:
+.incbin "baserom.gba", 0x9E6FBC, 0x200
+sChanseySprites42:
+ax_sprite sChanseyGfx42, 0x200
+ax_sprite_terminator
+sAxPosesChansey:
+.4byte sChanseyPose1
+.4byte sChanseyPose2
+.4byte sChanseyPose3
+.4byte sChanseyPose4
+.4byte sChanseyPose5
+.4byte sChanseyPose6
+.4byte sChanseyPose7
+.4byte sChanseyPose8
+.4byte sChanseyPose9
+.4byte sChanseyPose10
+.4byte sChanseyPose11
+.4byte sChanseyPose12
+.4byte sChanseyPose13
+.4byte sChanseyPose14
+.4byte sChanseyPose15
+.4byte sChanseyPose16
+.4byte sChanseyPose17
+.4byte sChanseyPose18
+.4byte sChanseyPose19
+.4byte sChanseyPose20
+.4byte sChanseyPose21
+.4byte sChanseyPose22
+.4byte sChanseyPose23
+.4byte sChanseyPose24
+.4byte sChanseyPose25
+.4byte sChanseyPose26
+.4byte sChanseyPose27
+.4byte sChanseyPose28
+.4byte sChanseyPose29
+.4byte sChanseyPose30
+.4byte sChanseyPose31
+.4byte sChanseyPose32
+.4byte sChanseyPose33
+.4byte sChanseyPose34
+.4byte sChanseyPose35
+.4byte sChanseyPose36
+.4byte sChanseyPose37
+.4byte sChanseyPose38
+.4byte sChanseyPose39
+.4byte sChanseyPose40
+.4byte sChanseyPose41
+.4byte sChanseyPose42
+.4byte sChanseyPose43
+.4byte sChanseyPose44
+.4byte sChanseyPose45
+.4byte sChanseyPose46
+.4byte sChanseyPose47
+.4byte sChanseyPose48
+.4byte sChanseyPose49
+.4byte sChanseyPose50
+.4byte sChanseyPose51
+.4byte sChanseyPose52
+.4byte sChanseyPose53
+.4byte sChanseyPose54
+.4byte sChanseyPose55
+.4byte sChanseyPose56
+.4byte sChanseyPose57
+.4byte sChanseyPose58
+.4byte sChanseyPose59
+.4byte sChanseyPose60
+.4byte sChanseyPose61
+.4byte sChanseyPose62
+.4byte sChanseyPose63
+.4byte sChanseyPose64
+.4byte sChanseyPose65
+.4byte sChanseyPose66
+.4byte sChanseyPose67
+.4byte sChanseyPose68
+.4byte sChanseyPose69
+.4byte sChanseyPose70
+.4byte sChanseyPose71
+.4byte sChanseyPose72
+.4byte sChanseyPose73
+.4byte sChanseyPose74
+.4byte sChanseyPose75
+.4byte sChanseyPose76
+.4byte sChanseyPose77
+.4byte sChanseyPose78
+.4byte sChanseyPose79
+.4byte sChanseyPose80
+.4byte sChanseyPose81
+.4byte sChanseyPose82
+.4byte sChanseyPose83
+.4byte sChanseyPose84
+.4byte sChanseyPose85
+.4byte sChanseyPose86
+.4byte sChanseyPose87
+.4byte sChanseyPose88
+.4byte sChanseyPose89
+.4byte sChanseyPose90
+.4byte sChanseyPose91
+.4byte sChanseyPose92
+.4byte sChanseyPose93
+.4byte sChanseyPose94
+.4byte sChanseyPose95
+.4byte sChanseyPose96
+.4byte sChanseyPose97
+.4byte sChanseyPose98
+.4byte sChanseyPose99
+.4byte sChanseyPose100
+.4byte sChanseyPose101
+.4byte sChanseyPose102
+.4byte sChanseyPose103
+.4byte sChanseyPose104
+.4byte sChanseyPose105
+.4byte sChanseyPose106
+.4byte sChanseyPose107
+.4byte sChanseyPose108
+.4byte sChanseyPose109
+.4byte sChanseyPose110
+.4byte sChanseyPose111
+.4byte sChanseyPose112
+.4byte sChanseyPose113
+.4byte sChanseyPose114
+.4byte sChanseyPose115
+.4byte sChanseyPose116
+.4byte sChanseyPose117
+.4byte sChanseyPose118
+.4byte sChanseyPose119
+.4byte sChanseyPose120
+.4byte sChanseyPose121
+.4byte sChanseyPose122
+.4byte sChanseyPose123
+.4byte sChanseyPose124
+.4byte sChanseyPose125
+.4byte sChanseyPose126
+.4byte sChanseyPose127
+.4byte sChanseyPose128
+.4byte sChanseyPose129
+.4byte sChanseyPose130
+.4byte sChanseyPose131
+.4byte sChanseyPose132
+.4byte sChanseyPose133
+.4byte sChanseyPose134
+.4byte sChanseyPose135
+.4byte sChanseyPose136
+.4byte sChanseyPose137
+.4byte sChanseyPose138
+.4byte sChanseyPose139
+.4byte sChanseyPose140
+.4byte sChanseyPose141
+.4byte sChanseyPose142
+.4byte sChanseyPose143
+.4byte sChanseyPose144
+.4byte sChanseyPose145
+.4byte sChanseyPose146
+.4byte sChanseyPose147
+.4byte sChanseyPose148
+.4byte sChanseyPose149
+.4byte sChanseyPose150
+.4byte sChanseyPose151
+.4byte sChanseyPose152
+.4byte sChanseyPose153
+.4byte sChanseyPose154
+.4byte sChanseyPose155
+.4byte sChanseyPose156
+.4byte sChanseyPose157
+.4byte sChanseyPose158
+.4byte sChanseyPose159
+.4byte sChanseyPose160
+.4byte sChanseyPose161
+.4byte sChanseyPose162
+.4byte sChanseyPose163
+.4byte sChanseyPose164
+.4byte sChanseyPose165
+.4byte sChanseyPose166
+.4byte sChanseyPose167
+.4byte sChanseyPose168
+.4byte sChanseyPose169
+.4byte sChanseyPose170
+.4byte sChanseyPose171
+.4byte sChanseyPose172
+.4byte sChanseyPose173
+.4byte sChanseyPose174
+.4byte sChanseyPose175
+.4byte sChanseyPose176
+.4byte sChanseyPose177
+.4byte sChanseyPose178
+.4byte sChanseyPose179
+.4byte sChanseyPose180
+.4byte sChanseyPose181
+.4byte sChanseyPose182
+.4byte sChanseyPose183
+.4byte sChanseyPose184
+.4byte sChanseyPose185
+.4byte sChanseyPose186
+.4byte sChanseyPose187
+.4byte sChanseyPose188
+.4byte sChanseyPose189
+.4byte sChanseyPose190
+.4byte sChanseyPose191
+.4byte sChanseyPose192
+.4byte sChanseyPose193
+.4byte sChanseyPose194
+.4byte sChanseyPose195
+.4byte sChanseyPose196
+.4byte sChanseyPose197
+.4byte sChanseyPose198
+.4byte sChanseyPose199
+.4byte sChanseyPose200
+.4byte sChanseyPose201
+.4byte sChanseyPose202
+.4byte sChanseyPose203
+.4byte sChanseyPose204
+.4byte sChanseyPose205
+.4byte sChanseyPose206
+.4byte sChanseyPose207
+.4byte sChanseyPose208
+.4byte sChanseyPose209
+.4byte sChanseyPose210
+.4byte sChanseyPose211
+.4byte sChanseyPose212
+.4byte sChanseyPose213
+.4byte sChanseyPose214
+.4byte sChanseyPose215
+.4byte sChanseyPose216
+.4byte sChanseyPose217
+.4byte sChanseyPose218
+.4byte sChanseyPose219
+.4byte sChanseyPose220
+.4byte sChanseyPose221
+.4byte sChanseyPose222
+.4byte sChanseyPose223
+.4byte sChanseyPose224
+.4byte sChanseyPose225
+.4byte sChanseyPose226
+sAxPositionsChansey:
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte    0,   -8, 	  -3,   -6, 	   4,   -6, 	   0,   -9
+.2byte    0,   -8, 	  -5,   -6, 	   2,   -6, 	   0,   -9
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	   5,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   6,   -7, 	   1,   -6, 	   0,   -7
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    6,   -9, 	   7,   -7, 	   4,   -7, 	  -2,   -7
+.2byte    6,   -9, 	   8,   -7, 	   5,   -7, 	  -1,   -6
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    4,  -12, 	   7,  -10, 	   8,   -6, 	  -3,   -7
+.2byte    4,  -12, 	   4,  -10, 	   7,   -8, 	  -2,   -9
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte   -1,  -13, 	   1,  -13, 	  -5,  -12, 	   0,  -10
+.2byte    0,  -13, 	   3,  -11, 	  -2,  -13, 	  -1,  -10
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	   2,   -7
+.2byte   -5,  -12, 	  -5,  -10, 	  -8,   -8, 	   1,   -9
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -7,   -9, 	  -8,   -7, 	  -5,   -7, 	   1,   -7
+.2byte   -7,   -9, 	  -9,   -7, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -2,   -8, 	  -6,   -7, 	   0,   -6, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte    0,   -8, 	  -3,   -6, 	   4,   -6, 	   0,   -9
+.2byte    0,   -8, 	  -5,   -6, 	   2,   -6, 	   0,   -9
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	   5,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   6,   -7, 	   1,   -6, 	   0,   -7
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    6,   -9, 	   7,   -7, 	   4,   -7, 	  -2,   -7
+.2byte    6,   -9, 	   8,   -7, 	   5,   -7, 	  -1,   -6
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    4,  -12, 	   7,  -10, 	   8,   -6, 	  -3,   -7
+.2byte    4,  -12, 	   4,  -10, 	   7,   -8, 	  -2,   -9
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte   -1,  -13, 	   1,  -13, 	  -5,  -12, 	   0,  -10
+.2byte    0,  -13, 	   3,  -11, 	  -2,  -13, 	  -1,  -10
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	   2,   -7
+.2byte   -5,  -12, 	  -5,  -10, 	  -8,   -8, 	   1,   -9
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -7,   -9, 	  -8,   -7, 	  -5,   -7, 	   1,   -7
+.2byte   -7,   -9, 	  -9,   -7, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -2,   -8, 	  -6,   -7, 	   0,   -6, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte    0,   -8, 	  -3,   -6, 	   4,   -6, 	   0,   -9
+.2byte    0,   -8, 	  -5,   -6, 	   2,   -6, 	   0,   -9
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	   5,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   6,   -7, 	   1,   -6, 	   0,   -7
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    6,   -9, 	   7,   -7, 	   4,   -7, 	  -2,   -7
+.2byte    6,   -9, 	   8,   -7, 	   5,   -7, 	  -1,   -6
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    4,  -12, 	   7,  -10, 	   8,   -6, 	  -3,   -7
+.2byte    4,  -12, 	   4,  -10, 	   7,   -8, 	  -2,   -9
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte   -1,  -13, 	   1,  -13, 	  -5,  -12, 	   0,  -10
+.2byte    0,  -13, 	   3,  -11, 	  -2,  -13, 	  -1,  -10
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	   2,   -7
+.2byte   -5,  -12, 	  -5,  -10, 	  -8,   -8, 	   1,   -9
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -7,   -9, 	  -8,   -7, 	  -5,   -7, 	   1,   -7
+.2byte   -7,   -9, 	  -9,   -7, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -2,   -8, 	  -6,   -7, 	   0,   -6, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte    0,  -18, 	  -3,  -15, 	   2,  -15, 	  -1,  -13
+.2byte    0,   -8, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+.2byte    0,  -15, 	   6,  -14, 	  -1,  -12, 	  -2,  -12
+.2byte    2,   -8, 	   9,   -8, 	  -4,   -3, 	  -1,   -8
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    5,  -16, 	   7,  -15, 	   5,  -11, 	  -1,  -12
+.2byte    7,   -8, 	   8,   -9, 	   3,   -4, 	   0,   -9
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    5,  -17, 	   7,  -15, 	   9,  -12, 	  -2,  -10
+.2byte    6,  -11, 	   0,  -12, 	   9,   -5, 	  -1,   -9
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte    0,  -21, 	   4,  -20, 	  -4,  -20, 	  -1,  -14
+.2byte    0,  -14, 	   9,   -8, 	 -11,   -8, 	   0,  -11
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte   -6,  -17, 	  -8,  -15, 	 -10,  -12, 	   1,  -10
+.2byte   -7,  -11, 	  -1,  -12, 	 -10,   -5, 	   0,   -9
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -6,  -16, 	  -8,  -15, 	  -6,  -11, 	   0,  -12
+.2byte   -8,   -8, 	  -9,   -9, 	  -4,   -4, 	  -1,   -9
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -1,  -15, 	  -7,  -14, 	   0,  -12, 	   1,  -12
+.2byte   -3,   -8, 	 -10,   -8, 	   3,   -3, 	   0,   -8
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte    0,  -18, 	  -3,  -15, 	   2,  -15, 	  -1,  -13
+.2byte    0,   -8, 	  -9,   -4, 	   8,   -4, 	   0,   -7
+.2byte    0,   -8, 	  -3,   -7, 	   2,   -7, 	   0,   -7
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+.2byte    0,  -15, 	   6,  -14, 	  -1,  -12, 	  -2,  -12
+.2byte    2,   -8, 	   9,   -8, 	  -4,   -3, 	  -1,   -8
+.2byte    2,   -8, 	   5,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    2,   -9, 	   5,   -8, 	   1,   -7, 	   0,   -9
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    5,  -16, 	   7,  -15, 	   5,  -11, 	  -1,  -12
+.2byte    7,   -8, 	   8,   -9, 	   3,   -4, 	   0,   -9
+.2byte    8,   -8, 	   8,   -7, 	   6,   -8, 	   0,   -9
+.2byte    6,   -9, 	   7,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    5,  -17, 	   7,  -15, 	   9,  -12, 	  -2,  -10
+.2byte    6,  -11, 	   0,  -12, 	   9,   -5, 	  -1,   -9
+.2byte    5,  -12, 	   6,  -12, 	   8,   -9, 	   0,  -11
+.2byte    4,  -12, 	   6,  -12, 	   8,   -7, 	  -2,  -10
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte    0,  -21, 	   4,  -20, 	  -4,  -20, 	  -1,  -14
+.2byte    0,  -14, 	   9,   -8, 	 -11,   -8, 	   0,  -11
+.2byte    0,  -15, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    0,  -13, 	  10,  -10, 	 -11,  -10, 	   0,  -10
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte   -6,  -17, 	  -8,  -15, 	 -10,  -12, 	   1,  -10
+.2byte   -7,  -11, 	  -1,  -12, 	 -10,   -5, 	   0,   -9
+.2byte   -6,  -12, 	  -7,  -12, 	  -9,   -9, 	  -1,  -11
+.2byte   -5,  -12, 	  -7,  -12, 	  -9,   -7, 	   1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -6,  -16, 	  -8,  -15, 	  -6,  -11, 	   0,  -12
+.2byte   -8,   -8, 	  -9,   -9, 	  -4,   -4, 	  -1,   -9
+.2byte   -9,   -8, 	  -9,   -7, 	  -7,   -8, 	  -1,   -9
+.2byte   -7,   -9, 	  -8,   -9, 	  -5,   -8, 	   0,   -9
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -1,  -15, 	  -7,  -14, 	   0,  -12, 	   1,  -12
+.2byte   -3,   -8, 	 -10,   -8, 	   3,   -3, 	   0,   -8
+.2byte   -3,   -8, 	  -6,   -7, 	  -3,   -6, 	   0,   -9
+.2byte   -3,   -9, 	  -6,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte   -2,   -6, 	  -6,   -5, 	  -1,   -4, 	   1,   -6
+.2byte   -1,   -5, 	  -5,   -5, 	   0,   -3, 	   2,   -5
+.2byte    0,   -7, 	  -2,   -6, 	   1,   -6, 	   0,   -9
+.2byte    2,   -7, 	   3,   -5, 	   1,   -4, 	  -1,   -7
+.2byte    4,   -8, 	   5,   -6, 	   3,   -6, 	  -3,   -8
+.2byte    5,  -12, 	   6,  -10, 	   8,   -8, 	  -1,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -5,  -10, 	   0,   -8
+.2byte   -6,  -12, 	  -7,  -10, 	  -9,   -8, 	   0,   -9
+.2byte   -5,   -8, 	  -6,   -6, 	  -4,   -6, 	   2,   -8
+.2byte   -3,   -7, 	  -4,   -5, 	  -2,   -4, 	   0,   -7
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte    0,   -8, 	  -3,   -6, 	   4,   -6, 	   0,   -9
+.2byte    0,   -8, 	  -5,   -6, 	   2,   -6, 	   0,   -9
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	   5,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   6,   -7, 	   1,   -6, 	   0,   -7
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    6,   -9, 	   7,   -7, 	   4,   -7, 	  -2,   -7
+.2byte    6,   -9, 	   8,   -7, 	   5,   -7, 	  -1,   -6
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    4,  -12, 	   7,  -10, 	   8,   -6, 	  -3,   -7
+.2byte    4,  -12, 	   4,  -10, 	   7,   -8, 	  -2,   -9
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte   -1,  -13, 	   1,  -13, 	  -5,  -12, 	   0,  -10
+.2byte    0,  -13, 	   3,  -11, 	  -2,  -13, 	  -1,  -10
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	   2,   -7
+.2byte   -5,  -12, 	  -5,  -10, 	  -8,   -8, 	   1,   -9
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -7,   -9, 	  -8,   -7, 	  -5,   -7, 	   1,   -7
+.2byte   -7,   -9, 	  -9,   -7, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -2,   -8, 	  -6,   -7, 	   0,   -6, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    0,   -8, 	  -3,   -7, 	   2,   -7, 	   0,   -7
+.2byte   -3,   -8, 	  -6,   -7, 	  -3,   -6, 	   0,   -9
+.2byte   -8,   -8, 	  -8,   -7, 	  -6,   -8, 	   0,   -9
+.2byte   -5,  -11, 	  -6,  -11, 	  -8,   -8, 	   0,  -10
+.2byte    0,  -13, 	   3,  -13, 	  -4,  -13, 	   0,  -10
+.2byte    4,  -11, 	   5,  -11, 	   7,   -8, 	  -1,  -10
+.2byte    7,   -8, 	   7,   -7, 	   5,   -8, 	  -1,   -9
+.2byte    2,   -8, 	   5,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    2,   -9, 	   5,   -8, 	   1,   -7, 	   0,   -9
+.2byte    6,   -9, 	   7,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    4,  -12, 	   6,  -12, 	   8,   -7, 	  -2,  -10
+.2byte    0,  -13, 	  10,  -10, 	 -11,  -10, 	   0,  -10
+.2byte   -5,  -12, 	  -7,  -12, 	  -9,   -7, 	   1,  -10
+.2byte   -7,   -9, 	  -8,   -9, 	  -5,   -8, 	   0,   -9
+.2byte   -3,   -9, 	  -6,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte    0,   -8, 	  -3,   -6, 	   4,   -6, 	   0,   -9
+.2byte    0,   -8, 	  -5,   -6, 	   2,   -6, 	   0,   -9
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	   5,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   6,   -7, 	   1,   -6, 	   0,   -7
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    6,   -9, 	   7,   -7, 	   4,   -7, 	  -2,   -7
+.2byte    6,   -9, 	   8,   -7, 	   5,   -7, 	  -1,   -6
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    4,  -12, 	   7,  -10, 	   8,   -6, 	  -3,   -7
+.2byte    4,  -12, 	   4,  -10, 	   7,   -8, 	  -2,   -9
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte   -1,  -13, 	   1,  -13, 	  -5,  -12, 	   0,  -10
+.2byte    0,  -13, 	   3,  -11, 	  -2,  -13, 	  -1,  -10
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	   2,   -7
+.2byte   -5,  -12, 	  -5,  -10, 	  -8,   -8, 	   1,   -9
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -7,   -9, 	  -8,   -7, 	  -5,   -7, 	   1,   -7
+.2byte   -7,   -9, 	  -9,   -7, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -2,   -8, 	  -6,   -7, 	   0,   -6, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte   -3,   -9, 	  -6,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte   -7,   -9, 	  -8,   -9, 	  -5,   -8, 	   0,   -9
+.2byte   -5,  -12, 	  -7,  -12, 	  -9,   -7, 	   1,  -10
+.2byte    0,  -13, 	  10,  -10, 	 -11,  -10, 	   0,  -10
+.2byte    4,  -12, 	   6,  -12, 	   8,   -7, 	  -2,  -10
+.2byte    6,   -9, 	   7,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    2,   -9, 	   5,   -8, 	   1,   -7, 	   0,   -9
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -7, 	   0,  -10
+.2byte   -2,   -9, 	  -7,   -8, 	  -1,   -7, 	   0,   -8
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -5,  -12, 	  -7,  -11, 	  -9,   -9, 	   1,   -9
+.2byte    0,  -14, 	   2,  -13, 	  -3,  -13, 	   0,  -11
+.2byte    4,  -12, 	   6,  -11, 	   8,   -9, 	  -2,   -9
+.2byte    6,  -10, 	   7,   -8, 	   5,   -7, 	   0,   -8
+.2byte    1,   -9, 	   6,   -8, 	   0,   -7, 	  -1,   -8
+sChanseyAnimTable1:
+.4byte sChanseyAnims_1_1
+.4byte sChanseyAnims_1_2
+.4byte sChanseyAnims_1_3
+.4byte sChanseyAnims_1_4
+.4byte sChanseyAnims_1_5
+.4byte sChanseyAnims_1_6
+.4byte sChanseyAnims_1_7
+.4byte sChanseyAnims_1_8
+sChanseyAnimTable2:
+.4byte sChanseyAnims_2_1
+.4byte sChanseyAnims_2_2
+.4byte sChanseyAnims_2_3
+.4byte sChanseyAnims_2_4
+.4byte sChanseyAnims_2_5
+.4byte sChanseyAnims_2_6
+.4byte sChanseyAnims_2_7
+.4byte sChanseyAnims_2_8
+sChanseyAnimTable3:
+.4byte sChanseyAnims_3_1
+.4byte sChanseyAnims_3_2
+.4byte sChanseyAnims_3_3
+.4byte sChanseyAnims_3_4
+.4byte sChanseyAnims_3_5
+.4byte sChanseyAnims_3_6
+.4byte sChanseyAnims_3_7
+.4byte sChanseyAnims_3_8
+sChanseyAnimTable4:
+.4byte sChanseyAnims_4_1
+.4byte sChanseyAnims_4_2
+.4byte sChanseyAnims_4_3
+.4byte sChanseyAnims_4_4
+.4byte sChanseyAnims_4_5
+.4byte sChanseyAnims_4_6
+.4byte sChanseyAnims_4_7
+.4byte sChanseyAnims_4_8
+sChanseyAnimTable5:
+.4byte sChanseyAnims_5_1
+.4byte sChanseyAnims_5_2
+.4byte sChanseyAnims_5_3
+.4byte sChanseyAnims_5_4
+.4byte sChanseyAnims_5_5
+.4byte sChanseyAnims_5_6
+.4byte sChanseyAnims_5_7
+.4byte sChanseyAnims_5_8
+sChanseyAnimTable6:
+.4byte sChanseyAnims_6_1
+.4byte sChanseyAnims_6_1
+.4byte sChanseyAnims_6_1
+.4byte sChanseyAnims_6_1
+.4byte sChanseyAnims_6_1
+.4byte sChanseyAnims_6_1
+.4byte sChanseyAnims_6_1
+.4byte sChanseyAnims_6_1
+sChanseyAnimTable7:
+.4byte sChanseyAnims_7_1
+.4byte sChanseyAnims_7_2
+.4byte sChanseyAnims_7_3
+.4byte sChanseyAnims_7_4
+.4byte sChanseyAnims_7_5
+.4byte sChanseyAnims_7_6
+.4byte sChanseyAnims_7_7
+.4byte sChanseyAnims_7_8
+sChanseyAnimTable8:
+.4byte sChanseyAnims_8_1
+.4byte sChanseyAnims_8_2
+.4byte sChanseyAnims_8_3
+.4byte sChanseyAnims_8_4
+.4byte sChanseyAnims_8_5
+.4byte sChanseyAnims_8_6
+.4byte sChanseyAnims_8_7
+.4byte sChanseyAnims_8_8
+sChanseyAnimTable9:
+.4byte sChanseyAnims_9_1
+.4byte sChanseyAnims_9_2
+.4byte sChanseyAnims_9_3
+.4byte sChanseyAnims_9_4
+.4byte sChanseyAnims_9_5
+.4byte sChanseyAnims_9_6
+.4byte sChanseyAnims_9_7
+.4byte sChanseyAnims_9_8
+sChanseyAnimTable10:
+.4byte sChanseyAnims_10_1
+.4byte sChanseyAnims_10_2
+.4byte sChanseyAnims_10_3
+.4byte sChanseyAnims_10_4
+.4byte sChanseyAnims_10_5
+.4byte sChanseyAnims_10_6
+.4byte sChanseyAnims_10_7
+.4byte sChanseyAnims_10_8
+sChanseyAnimTable11:
+.4byte sChanseyAnims_11_1
+.4byte sChanseyAnims_11_2
+.4byte sChanseyAnims_11_3
+.4byte sChanseyAnims_11_4
+.4byte sChanseyAnims_11_5
+.4byte sChanseyAnims_11_6
+.4byte sChanseyAnims_11_7
+.4byte sChanseyAnims_11_8
+sChanseyAnimTable12:
+.4byte sChanseyAnims_12_1
+.4byte sChanseyAnims_12_2
+.4byte sChanseyAnims_12_3
+.4byte sChanseyAnims_12_4
+.4byte sChanseyAnims_12_5
+.4byte sChanseyAnims_12_6
+.4byte sChanseyAnims_12_7
+.4byte sChanseyAnims_12_8
+sChanseyAnimTable13:
+.4byte sChanseyAnims_13_1
+.4byte sChanseyAnims_13_2
+.4byte sChanseyAnims_13_3
+.4byte sChanseyAnims_13_4
+.4byte sChanseyAnims_13_5
+.4byte sChanseyAnims_13_6
+.4byte sChanseyAnims_13_7
+.4byte sChanseyAnims_13_8
+sAxAnimationsChansey:
+.4byte sChanseyAnimTable1
+.4byte sChanseyAnimTable2
+.4byte sChanseyAnimTable3
+.4byte sChanseyAnimTable4
+.4byte sChanseyAnimTable5
+.4byte sChanseyAnimTable6
+.4byte sChanseyAnimTable7
+.4byte sChanseyAnimTable8
+.4byte sChanseyAnimTable9
+.4byte sChanseyAnimTable10
+.4byte sChanseyAnimTable11
+.4byte sChanseyAnimTable12
+.4byte sChanseyAnimTable13
+sAxSpritesChansey:
+.4byte sChanseySprites1
+.4byte sChanseySprites2
+.4byte sChanseySprites3
+.4byte sChanseySprites4
+.4byte sChanseySprites5
+.4byte sChanseySprites6
+.4byte sChanseySprites7
+.4byte sChanseySprites8
+.4byte sChanseySprites9
+.4byte sChanseySprites10
+.4byte sChanseySprites11
+.4byte sChanseySprites12
+.4byte sChanseySprites13
+.4byte sChanseySprites14
+.4byte sChanseySprites15
+.4byte sChanseySprites16
+.4byte sChanseySprites17
+.4byte sChanseySprites18
+.4byte sChanseySprites19
+.4byte sChanseySprites20
+.4byte sChanseySprites21
+.4byte sChanseySprites22
+.4byte sChanseySprites23
+.4byte sChanseySprites24
+.4byte sChanseySprites25
+.4byte sChanseySprites26
+.4byte sChanseySprites27
+.4byte sChanseySprites28
+.4byte sChanseySprites29
+.4byte sChanseySprites30
+.4byte sChanseySprites31
+.4byte sChanseySprites32
+.4byte sChanseySprites33
+.4byte sChanseySprites34
+.4byte sChanseySprites35
+.4byte sChanseySprites36
+.4byte sChanseySprites37
+.4byte sChanseySprites38
+.4byte sChanseySprites39
+.4byte sChanseySprites40
+.4byte sChanseySprites41
+.4byte sChanseySprites42
+sAxMainChansey:
+ax_main sAxPosesChansey, sAxAnimationsChansey, 13, sAxSpritesChansey, sAxPositionsChansey

--- a/data/ax/charizard.inc
+++ b/data/ax/charizard.inc
@@ -1,0 +1,3478 @@
+.global gAxCharizard
+gAxCharizard:
+ax_siro sAxMainCharizard
+sCharizardPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose6:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose9:
+ax_pose 8, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose10:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose11:
+ax_pose 10, 0x81e7, 0x90f0, 0x2c00
+ax_pose 11, 0x01e7, 0x5100, 0x2c08
+ax_pose 12, 0x41f7, 0x1100, 0x2c0c
+ax_pose 13, 0x01ff, 0x1100, 0x2c0e
+ax_pose 14, 0x01ed, 0x10e8, 0x2c0f
+ax_pose_terminator
+sCharizardPose12:
+ax_pose 15, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose13:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose14:
+ax_pose 17, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose15:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose16:
+ax_pose 9, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose17:
+ax_pose 10, 0x81e7, 0x8100, 0x2c00
+ax_pose 11, 0x01e7, 0x40f0, 0x2c08
+ax_pose 12, 0x41f7, 0x00f0, 0x2c0c
+ax_pose 13, 0x01ff, 0x00f8, 0x2c0e
+ax_pose 14, 0x01ed, 0x0110, 0x2c0f
+ax_pose_terminator
+sCharizardPose18:
+ax_pose 15, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose19:
+ax_pose 6, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose20:
+ax_pose 7, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose21:
+ax_pose 8, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose22:
+ax_pose 3, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose23:
+ax_pose 4, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose24:
+ax_pose 5, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose28:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose29:
+ax_pose 4, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose30:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose31:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose32:
+ax_pose 7, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose33:
+ax_pose 8, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose34:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose35:
+ax_pose 10, 0x81e7, 0x90f0, 0x2c00
+ax_pose 11, 0x01e7, 0x5100, 0x2c08
+ax_pose 12, 0x41f7, 0x1100, 0x2c0c
+ax_pose 13, 0x01ff, 0x1100, 0x2c0e
+ax_pose 14, 0x01ed, 0x10e8, 0x2c0f
+ax_pose_terminator
+sCharizardPose36:
+ax_pose 15, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose37:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose38:
+ax_pose 17, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose39:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose40:
+ax_pose 9, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose41:
+ax_pose 10, 0x81e7, 0x8100, 0x2c00
+ax_pose 11, 0x01e7, 0x40f0, 0x2c08
+ax_pose 12, 0x41f7, 0x00f0, 0x2c0c
+ax_pose 13, 0x01ff, 0x00f8, 0x2c0e
+ax_pose 14, 0x01ed, 0x0110, 0x2c0f
+ax_pose_terminator
+sCharizardPose42:
+ax_pose 15, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose43:
+ax_pose 6, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose44:
+ax_pose 7, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose45:
+ax_pose 8, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose46:
+ax_pose 3, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose47:
+ax_pose 4, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose48:
+ax_pose 5, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose50:
+ax_pose 19, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose51:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose 21, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sCharizardPose52:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose53:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose54:
+ax_pose 22, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose55:
+ax_pose 23, 0x81e7, 0x90ff, 0x2c00
+ax_pose 24, 0x81e5, 0x90ff, 0x2c08
+ax_pose 25, 0x81e5, 0x50f7, 0x2c10
+ax_pose_terminator
+sCharizardPose56:
+ax_pose 24, 0x81e5, 0x90ff, 0x2c00
+ax_pose 25, 0x81e5, 0x50f7, 0x2c08
+ax_pose_terminator
+sCharizardPose57:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose58:
+ax_pose 26, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose59:
+ax_pose 27, 0x81e5, 0x9103, 0x2c00
+ax_pose 28, 0x81e5, 0x5101, 0x2c08
+ax_pose 29, 0x81e5, 0x90f1, 0x2c0c
+ax_pose 30, 0x81ed, 0x1109, 0x2c14
+ax_pose 31, 0x01ed, 0x10e9, 0x2c16
+ax_pose 32, 0x01f5, 0x10e9, 0x2c17
+ax_pose_terminator
+sCharizardPose60:
+ax_pose 28, 0x81e5, 0x5101, 0x2c00
+ax_pose 29, 0x81e5, 0x90f1, 0x2c04
+ax_pose 30, 0x81ed, 0x1109, 0x2c0c
+ax_pose 31, 0x01ed, 0x10e9, 0x2c0e
+ax_pose 32, 0x01f5, 0x10e9, 0x2c0f
+ax_pose_terminator
+sCharizardPose61:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose62:
+ax_pose 33, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose63:
+ax_pose 34, 0x81e5, 0x90ff, 0x2c00
+ax_pose 35, 0x01fd, 0x10e7, 0x2c08
+ax_pose 36, 0x81ed, 0x1107, 0x2c09
+ax_pose 37, 0x81e5, 0x50ff, 0x2c0b
+ax_pose 38, 0x81e5, 0x90ef, 0x2c0f
+ax_pose 39, 0x01fd, 0x1107, 0x2c17
+ax_pose_terminator
+sCharizardPose64:
+ax_pose 35, 0x01fd, 0x10e7, 0x2c00
+ax_pose 36, 0x81ed, 0x1107, 0x2c01
+ax_pose 37, 0x81e5, 0x50ff, 0x2c03
+ax_pose 38, 0x81e5, 0x90ef, 0x2c07
+ax_pose 39, 0x01fd, 0x1107, 0x2c0f
+ax_pose_terminator
+sCharizardPose65:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose66:
+ax_pose 40, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose67:
+ax_pose 41, 0x81e5, 0x80fc, 0x2c00
+ax_pose 42, 0x01e5, 0x80f0, 0x2c08
+ax_pose_terminator
+sCharizardPose68:
+ax_pose 42, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose69:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose70:
+ax_pose 33, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose71:
+ax_pose 34, 0x81e5, 0x80f0, 0x2c00
+ax_pose 35, 0x01fd, 0x0110, 0x2c08
+ax_pose 36, 0x81ed, 0x00f0, 0x2c09
+ax_pose 37, 0x81e5, 0x40f8, 0x2c0b
+ax_pose 38, 0x81e5, 0x8100, 0x2c0f
+ax_pose 39, 0x01fd, 0x00f0, 0x2c17
+ax_pose_terminator
+sCharizardPose72:
+ax_pose 35, 0x01fd, 0x0110, 0x2c00
+ax_pose 36, 0x81ed, 0x00f0, 0x2c01
+ax_pose 37, 0x81e5, 0x40f8, 0x2c03
+ax_pose 38, 0x81e5, 0x8100, 0x2c07
+ax_pose 39, 0x01fd, 0x00f0, 0x2c0f
+ax_pose_terminator
+sCharizardPose73:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose74:
+ax_pose 26, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose75:
+ax_pose 27, 0x81e5, 0x80ec, 0x2c00
+ax_pose 28, 0x81e5, 0x40f6, 0x2c08
+ax_pose 29, 0x81e5, 0x80fe, 0x2c0c
+ax_pose 30, 0x81ed, 0x00ee, 0x2c14
+ax_pose 31, 0x01ed, 0x010e, 0x2c16
+ax_pose 32, 0x01f5, 0x010e, 0x2c17
+ax_pose_terminator
+sCharizardPose76:
+ax_pose 28, 0x81e5, 0x40f6, 0x2c00
+ax_pose 29, 0x81e5, 0x80fe, 0x2c04
+ax_pose 30, 0x81ed, 0x00ee, 0x2c0c
+ax_pose 31, 0x01ed, 0x010e, 0x2c0e
+ax_pose 32, 0x01f5, 0x010e, 0x2c0f
+ax_pose_terminator
+sCharizardPose77:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose78:
+ax_pose 22, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose79:
+ax_pose 23, 0x81e7, 0x80f0, 0x2c00
+ax_pose 24, 0x81e5, 0x80f0, 0x2c08
+ax_pose 25, 0x81e5, 0x4100, 0x2c10
+ax_pose_terminator
+sCharizardPose80:
+ax_pose 24, 0x81e5, 0x80f0, 0x2c00
+ax_pose 25, 0x81e5, 0x4100, 0x2c08
+ax_pose_terminator
+sCharizardPose81:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose82:
+ax_pose 43, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose83:
+ax_pose 44, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose84:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose85:
+ax_pose 45, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose86:
+ax_pose 46, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose87:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose88:
+ax_pose 47, 0x81e5, 0x90f8, 0x2c00
+ax_pose 48, 0x81e5, 0x50f0, 0x2c08
+ax_pose_terminator
+sCharizardPose89:
+ax_pose 49, 0x41f2, 0x90f5, 0x2c00
+ax_pose 50, 0x41ea, 0x50f5, 0x2c08
+ax_pose 51, 0x81f4, 0x10ed, 0x2c0c
+ax_pose 52, 0x01e2, 0x10fd, 0x2c0e
+ax_pose_terminator
+sCharizardPose90:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose91:
+ax_pose 53, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose92:
+ax_pose 54, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose93:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose94:
+ax_pose 55, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose95:
+ax_pose 56, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose96:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose97:
+ax_pose 53, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose98:
+ax_pose 54, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose99:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose100:
+ax_pose 47, 0x81e5, 0x80f7, 0x2c00
+ax_pose 48, 0x81e5, 0x4107, 0x2c08
+ax_pose_terminator
+sCharizardPose101:
+ax_pose 49, 0x41f2, 0x80ea, 0x2c00
+ax_pose 50, 0x41ea, 0x40ea, 0x2c08
+ax_pose 51, 0x81f4, 0x010a, 0x2c0c
+ax_pose 52, 0x01e2, 0x00fa, 0x2c0e
+ax_pose_terminator
+sCharizardPose102:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose103:
+ax_pose 45, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose104:
+ax_pose 46, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose105:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose106:
+ax_pose 43, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose107:
+ax_pose 44, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose108:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose109:
+ax_pose 45, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose110:
+ax_pose 46, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose111:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose112:
+ax_pose 47, 0x81e5, 0x90f8, 0x2c00
+ax_pose 48, 0x81e5, 0x50f0, 0x2c08
+ax_pose_terminator
+sCharizardPose113:
+ax_pose 49, 0x41f2, 0x90f5, 0x2c00
+ax_pose 50, 0x41ea, 0x50f5, 0x2c08
+ax_pose 51, 0x81f4, 0x10ed, 0x2c0c
+ax_pose 52, 0x01e2, 0x10fd, 0x2c0e
+ax_pose_terminator
+sCharizardPose114:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose115:
+ax_pose 53, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose116:
+ax_pose 54, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose117:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose118:
+ax_pose 55, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose119:
+ax_pose 56, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose120:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose121:
+ax_pose 53, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose122:
+ax_pose 54, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose123:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose124:
+ax_pose 47, 0x81e5, 0x80f7, 0x2c00
+ax_pose 48, 0x81e5, 0x4107, 0x2c08
+ax_pose_terminator
+sCharizardPose125:
+ax_pose 49, 0x41f2, 0x80ea, 0x2c00
+ax_pose 50, 0x41ea, 0x40ea, 0x2c08
+ax_pose 51, 0x81f4, 0x010a, 0x2c0c
+ax_pose 52, 0x01e2, 0x00fa, 0x2c0e
+ax_pose_terminator
+sCharizardPose126:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose127:
+ax_pose 45, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose128:
+ax_pose 46, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose129:
+ax_pose 57, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharizardPose130:
+ax_pose 58, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharizardPose131:
+ax_pose 59, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose132:
+ax_pose 60, 0x01e1, 0x90e8, 0x2c00
+ax_pose_terminator
+sCharizardPose133:
+ax_pose 61, 0x01e3, 0x90e4, 0x2c00
+ax_pose_terminator
+sCharizardPose134:
+ax_pose 62, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharizardPose135:
+ax_pose 63, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose136:
+ax_pose 62, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharizardPose137:
+ax_pose 61, 0x01e3, 0x80fc, 0x2c00
+ax_pose_terminator
+sCharizardPose138:
+ax_pose 60, 0x01e1, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharizardPose139:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose140:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose141:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose142:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose143:
+ax_pose 4, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose144:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose145:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose146:
+ax_pose 7, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose147:
+ax_pose 8, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose148:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose149:
+ax_pose 10, 0x81e7, 0x90f0, 0x2c00
+ax_pose 11, 0x01e7, 0x5100, 0x2c08
+ax_pose 12, 0x41f7, 0x1100, 0x2c0c
+ax_pose 13, 0x01ff, 0x1100, 0x2c0e
+ax_pose 14, 0x01ed, 0x10e8, 0x2c0f
+ax_pose_terminator
+sCharizardPose150:
+ax_pose 15, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose151:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose152:
+ax_pose 17, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose153:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose154:
+ax_pose 9, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose155:
+ax_pose 10, 0x81e7, 0x8100, 0x2c00
+ax_pose 11, 0x01e7, 0x40f0, 0x2c08
+ax_pose 12, 0x41f7, 0x00f0, 0x2c0c
+ax_pose 13, 0x01ff, 0x00f8, 0x2c0e
+ax_pose 14, 0x01ed, 0x0110, 0x2c0f
+ax_pose_terminator
+sCharizardPose156:
+ax_pose 15, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose157:
+ax_pose 6, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose158:
+ax_pose 7, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose159:
+ax_pose 8, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose160:
+ax_pose 3, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose161:
+ax_pose 4, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose162:
+ax_pose 5, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose163:
+ax_pose 44, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose164:
+ax_pose 46, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharizardPose165:
+ax_pose 49, 0x41f3, 0x80ee, 0x2c00
+ax_pose 50, 0x41eb, 0x40ee, 0x2c08
+ax_pose 51, 0x81f5, 0x010e, 0x2c0c
+ax_pose 52, 0x01e3, 0x00fe, 0x2c0e
+ax_pose_terminator
+sCharizardPose166:
+ax_pose 54, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharizardPose167:
+ax_pose 56, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose168:
+ax_pose 54, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharizardPose169:
+ax_pose 49, 0x41f3, 0x90f2, 0x2c00
+ax_pose 50, 0x41eb, 0x50f2, 0x2c08
+ax_pose 51, 0x81f5, 0x10ea, 0x2c0c
+ax_pose 52, 0x01e3, 0x10fa, 0x2c0e
+ax_pose_terminator
+sCharizardPose170:
+ax_pose 46, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharizardPose171:
+ax_pose 44, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose172:
+ax_pose 46, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharizardPose173:
+ax_pose 49, 0x41f3, 0x90f2, 0x2c00
+ax_pose 50, 0x41eb, 0x50f2, 0x2c08
+ax_pose 51, 0x81f5, 0x10ea, 0x2c0c
+ax_pose 52, 0x01e3, 0x10fa, 0x2c0e
+ax_pose_terminator
+sCharizardPose174:
+ax_pose 54, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose175:
+ax_pose 56, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose176:
+ax_pose 54, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose177:
+ax_pose 49, 0x41f4, 0x80ee, 0x2c00
+ax_pose 50, 0x41ec, 0x40ee, 0x2c08
+ax_pose 51, 0x81f6, 0x010e, 0x2c0c
+ax_pose 52, 0x01e4, 0x00fe, 0x2c0e
+ax_pose_terminator
+sCharizardPose178:
+ax_pose 46, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharizardPose179:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose180:
+ax_pose 43, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose181:
+ax_pose 44, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose182:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose183:
+ax_pose 45, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose184:
+ax_pose 46, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharizardPose185:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose186:
+ax_pose 47, 0x81e5, 0x90f8, 0x2c00
+ax_pose 48, 0x81e5, 0x50f0, 0x2c08
+ax_pose_terminator
+sCharizardPose187:
+ax_pose 49, 0x41f2, 0x90f3, 0x2c00
+ax_pose 50, 0x41ea, 0x50f3, 0x2c08
+ax_pose 51, 0x81f4, 0x10eb, 0x2c0c
+ax_pose 52, 0x01e2, 0x10fb, 0x2c0e
+ax_pose_terminator
+sCharizardPose188:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose189:
+ax_pose 53, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose190:
+ax_pose 54, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharizardPose191:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose192:
+ax_pose 55, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose193:
+ax_pose 56, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose194:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose195:
+ax_pose 53, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose196:
+ax_pose 54, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose197:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose198:
+ax_pose 47, 0x81e5, 0x80f7, 0x2c00
+ax_pose 48, 0x81e5, 0x4107, 0x2c08
+ax_pose_terminator
+sCharizardPose199:
+ax_pose 49, 0x41f2, 0x80ec, 0x2c00
+ax_pose 50, 0x41ea, 0x40ec, 0x2c08
+ax_pose 51, 0x81f4, 0x010c, 0x2c0c
+ax_pose 52, 0x01e2, 0x00fc, 0x2c0e
+ax_pose_terminator
+sCharizardPose200:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose201:
+ax_pose 45, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose202:
+ax_pose 46, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharizardPose203:
+ax_pose 44, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose204:
+ax_pose 46, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharizardPose205:
+ax_pose 49, 0x41f3, 0x80ee, 0x2c00
+ax_pose 50, 0x41eb, 0x40ee, 0x2c08
+ax_pose 51, 0x81f5, 0x010e, 0x2c0c
+ax_pose 52, 0x01e3, 0x00fe, 0x2c0e
+ax_pose_terminator
+sCharizardPose206:
+ax_pose 54, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharizardPose207:
+ax_pose 56, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose208:
+ax_pose 54, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharizardPose209:
+ax_pose 49, 0x41f3, 0x90f2, 0x2c00
+ax_pose 50, 0x41eb, 0x50f2, 0x2c08
+ax_pose 51, 0x81f5, 0x10ea, 0x2c0c
+ax_pose 52, 0x01e3, 0x10fa, 0x2c0e
+ax_pose_terminator
+sCharizardPose210:
+ax_pose 46, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharizardPose211:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose212:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose213:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose214:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose215:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose216:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose217:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose218:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose219:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose220:
+ax_pose 64, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose221:
+ax_pose 65, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose222:
+ax_pose 66, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose223:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharizardPose224:
+ax_pose 67, 0x81e6, 0x80fc, 0x2c00
+ax_pose 68, 0x81e6, 0x40f4, 0x2c08
+ax_pose 69, 0x81eb, 0x00ec, 0x2c0c
+ax_pose 70, 0x81ee, 0x010c, 0x2c0e
+ax_pose_terminator
+sCharizardPose225:
+ax_pose 71, 0x41f5, 0x80ed, 0x2c00
+ax_pose 72, 0x41ed, 0x40ed, 0x2c08
+ax_pose 73, 0x01f6, 0x010d, 0x2c0c
+ax_pose_terminator
+sCharizardPose226:
+ax_pose 74, 0x41f6, 0x80ec, 0x2c00
+ax_pose 75, 0x41ee, 0x40ec, 0x2c08
+ax_pose 76, 0x41f9, 0x010c, 0x2c0c
+ax_pose_terminator
+sCharizardPose227:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharizardPose228:
+ax_pose 67, 0x81e6, 0x90f2, 0x2c00
+ax_pose 68, 0x81e6, 0x5102, 0x2c08
+ax_pose 69, 0x81eb, 0x110a, 0x2c0c
+ax_pose 70, 0x81ee, 0x10ea, 0x2c0e
+ax_pose_terminator
+sCharizardPose229:
+ax_pose 71, 0x41f5, 0x90f1, 0x2c00
+ax_pose 72, 0x41ed, 0x50f1, 0x2c08
+ax_pose 73, 0x01f6, 0x10e9, 0x2c0c
+ax_pose_terminator
+sCharizardPose230:
+ax_pose 74, 0x41f6, 0x90f2, 0x2c00
+ax_pose 75, 0x41ee, 0x50f2, 0x2c08
+ax_pose 76, 0x41f9, 0x10e2, 0x2c0c
+ax_pose_terminator
+sCharizardPose231:
+ax_pose 77, 0x81e5, 0x80fd, 0x2c00
+ax_pose 78, 0x81e5, 0x40f5, 0x2c08
+ax_pose 79, 0x81ed, 0x00ed, 0x2c0c
+ax_pose 80, 0x81ee, 0x010d, 0x2c0e
+ax_pose_terminator
+sCharizardPose232:
+ax_pose 81, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose233:
+ax_pose 82, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose234:
+ax_pose 77, 0x81e5, 0x90f3, 0x2c00
+ax_pose 78, 0x81e5, 0x5103, 0x2c08
+ax_pose 79, 0x81ed, 0x110b, 0x2c0c
+ax_pose 80, 0x81ee, 0x10eb, 0x2c0e
+ax_pose_terminator
+sCharizardPose235:
+ax_pose 81, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sCharizardPose236:
+ax_pose 82, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sCharizardPose237:
+ax_pose 77, 0x81e5, 0x80fd, 0x2c00
+ax_pose 78, 0x81e5, 0x40f5, 0x2c08
+ax_pose 79, 0x81ed, 0x00ed, 0x2c0c
+ax_pose 80, 0x81ee, 0x010d, 0x2c0e
+ax_pose_terminator
+sCharizardPose238:
+ax_pose 81, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose239:
+ax_pose 82, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharizardPose240:
+ax_pose 74, 0x41f6, 0x80ec, 0x2c00
+ax_pose 75, 0x41ee, 0x40ec, 0x2c08
+ax_pose 76, 0x41f9, 0x010c, 0x2c0c
+ax_pose_terminator
+sCharizardPose241:
+ax_pose 77, 0x81e5, 0x90f3, 0x2c00
+ax_pose 78, 0x81e5, 0x5103, 0x2c08
+ax_pose 79, 0x81ed, 0x110b, 0x2c0c
+ax_pose 80, 0x81ee, 0x10eb, 0x2c0e
+ax_pose_terminator
+sCharizardPose242:
+ax_pose 81, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sCharizardPose243:
+ax_pose 82, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sCharizardPose244:
+ax_pose 74, 0x41f6, 0x90f3, 0x2c00
+ax_pose 75, 0x41ee, 0x50f3, 0x2c08
+ax_pose 76, 0x41f9, 0x10e3, 0x2c0c
+ax_pose_terminator
+.align 2
+sCharizardAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 25, 0, -6, 0, -6,
+ax_anim 2, 0, 25, 1, -6, 1, -6,
+ax_anim 4, 0, 25, 0, -6, 0, -6,
+ax_anim 1, 2, 26, -1, -2, -1, -2,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 30, 0, 21, 0, 21,
+ax_anim 2, 1, 30, 1, 21, 1, 21,
+ax_anim 2, 0, 30, 0, 21, 0, 21,
+ax_anim 2, 0, 30, 1, 21, 1, 21,
+ax_anim 2, 0, 30, 0, 21, 0, 21,
+ax_anim 2, 0, 30, 1, 21, 1, 21,
+ax_anim 2, 0, 29, 1, 9, 1, 9,
+ax_anim_terminator
+sCharizardAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 2, 0, 28, -6, -6, -6, -6,
+ax_anim 2, 0, 28, -5, -7, -5, -7,
+ax_anim 4, 0, 28, -6, -6, -6, -6,
+ax_anim 1, 2, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 8, 8, 10, 10,
+ax_anim 2, 0, 33, 19, 19, 21, 21,
+ax_anim 2, 1, 33, 20, 18, 22, 20,
+ax_anim 2, 0, 33, 19, 19, 21, 21,
+ax_anim 2, 0, 33, 20, 18, 22, 20,
+ax_anim 2, 0, 33, 19, 19, 21, 21,
+ax_anim 2, 0, 33, 20, 18, 22, 20,
+ax_anim 2, 0, 32, 9, 9, 9, 9,
+ax_anim_terminator
+sCharizardAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 31, -4, 0, -4, 0,
+ax_anim 2, 0, 31, -6, 0, -6, 0,
+ax_anim 2, 0, 31, -5, 0, -5, 0,
+ax_anim 4, 0, 31, -6, 0, -6, 0,
+ax_anim 1, 2, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 3, 0, 10, 0,
+ax_anim 2, 0, 36, 14, 0, 21, 0,
+ax_anim 2, 1, 36, 15, 0, 22, 0,
+ax_anim 2, 0, 36, 14, 0, 21, 0,
+ax_anim 2, 0, 36, 15, 0, 22, 0,
+ax_anim 2, 0, 36, 14, 0, 21, 0,
+ax_anim 2, 0, 36, 15, 0, 22, 0,
+ax_anim 2, 0, 35, 9, 0, 9, 0,
+ax_anim_terminator
+sCharizardAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 2, 0, 34, -6, 6, -6, 6,
+ax_anim 2, 0, 34, -5, 7, -5, 7,
+ax_anim 4, 0, 34, -6, 6, -6, 6,
+ax_anim 1, 2, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 21, -21, 21, -21,
+ax_anim 2, 1, 39, 22, -20, 22, -20,
+ax_anim 2, 0, 39, 21, -21, 21, -21,
+ax_anim 2, 0, 39, 22, -20, 22, -20,
+ax_anim 2, 0, 39, 21, -21, 21, -21,
+ax_anim 2, 0, 39, 22, -20, 22, -20,
+ax_anim 2, 0, 38, 9, -9, 9, -9,
+ax_anim_terminator
+sCharizardAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 6, 0, 6,
+ax_anim 2, 0, 37, 1, 6, 1, 6,
+ax_anim 4, 0, 37, 0, 6, 0, 6,
+ax_anim 1, 2, 38, -1, 2, -1, 2,
+ax_anim 1, 0, 39, 0, -10, 0, -10,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 1, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 0, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 0, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 41, 1, -9, 1, -9,
+ax_anim_terminator
+sCharizardAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 2, 0, 40, 6, 6, 6, 6,
+ax_anim 2, 0, 40, 5, 7, 5, 7,
+ax_anim 4, 0, 40, 6, 6, 6, 6,
+ax_anim 1, 2, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 42, -10, -10, -10, -10,
+ax_anim 2, 0, 45, -21, -21, -21, -21,
+ax_anim 2, 1, 45, -22, -20, -22, -20,
+ax_anim 2, 0, 45, -21, -21, -21, -21,
+ax_anim 2, 0, 45, -22, -20, -22, -20,
+ax_anim 2, 0, 45, -21, -21, -21, -21,
+ax_anim 2, 0, 45, -22, -20, -22, -20,
+ax_anim 2, 0, 44, -9, -9, -9, -9,
+ax_anim_terminator
+sCharizardAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 43, 4, 0, 4, 0,
+ax_anim 2, 0, 43, 6, 0, 6, 0,
+ax_anim 2, 0, 43, 5, 0, 5, 0,
+ax_anim 4, 0, 43, 6, 0, 6, 0,
+ax_anim 1, 2, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 45, -3, 0, -10, 0,
+ax_anim 2, 0, 24, -14, 0, -21, 0,
+ax_anim 2, 1, 24, -15, 0, -22, 0,
+ax_anim 2, 0, 24, -14, 0, -21, 0,
+ax_anim 2, 0, 24, -15, 0, -22, 0,
+ax_anim 2, 0, 24, -14, 0, -21, 0,
+ax_anim 2, 0, 24, -15, 0, -22, 0,
+ax_anim 2, 0, 47, -9, 0, -9, 0,
+ax_anim_terminator
+sCharizardAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 2, 0, 46, 6, -6, 6, -6,
+ax_anim 2, 0, 46, 5, -7, 5, -7,
+ax_anim 4, 0, 46, 6, -6, 6, -6,
+ax_anim 1, 2, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 24, -10, 10, -10, 10,
+ax_anim 2, 0, 27, -19, 19, -21, 21,
+ax_anim 2, 1, 27, -20, 18, -22, 20,
+ax_anim 2, 0, 27, -19, 19, -21, 21,
+ax_anim 2, 0, 27, -20, 18, -22, 20,
+ax_anim 2, 0, 27, -19, 19, -21, 21,
+ax_anim 2, 0, 27, -20, 18, -22, 20,
+ax_anim 2, 0, 26, -9, 9, -9, 9,
+ax_anim_terminator
+.align 2
+sCharizardAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -4, 0, -4,
+ax_anim 6, 0, 77, 3, -5, 3, -5,
+ax_anim 1, 0, 77, 3, 2, 3, 2,
+ax_anim 2, 2, 49, 0, 8, 0, 8,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 1, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim 2, 0, 48, 0, 2, 0, 2,
+ax_anim_terminator
+sCharizardAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -4, -4, -4, -4,
+ax_anim 6, 0, 57, -7, -5, -7, -5,
+ax_anim 1, 0, 57, 1, 2, 1, 2,
+ax_anim 2, 2, 53, 8, 9, 8, 9,
+ax_anim 2, 0, 54, 15, 17, 15, 17,
+ax_anim 2, 1, 55, 14, 18, 14, 18,
+ax_anim 2, 0, 55, 15, 17, 15, 17,
+ax_anim 2, 0, 55, 14, 18, 14, 18,
+ax_anim 2, 0, 55, 15, 17, 15, 17,
+ax_anim 2, 0, 55, 14, 18, 14, 18,
+ax_anim 2, 0, 52, 8, 8, 8, 8,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim_terminator
+sCharizardAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 2, 0, 57, -4, 0, -4, 0,
+ax_anim 6, 0, 61, -6, 1, -6, 1,
+ax_anim 1, 0, 61, 1, 1, 1, 1,
+ax_anim 2, 2, 57, 6, 0, 6, 0,
+ax_anim 2, 0, 58, 14, 0, 14, 0,
+ax_anim 2, 1, 59, 14, -1, 14, -1,
+ax_anim 2, 0, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 59, 14, -1, 14, -1,
+ax_anim 2, 0, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 59, 14, -1, 14, -1,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim_terminator
+sCharizardAnims_3_4:
+ax_anim 2, 0, 60, -1, 1, -1, 1,
+ax_anim 2, 0, 61, -4, 4, -4, 4,
+ax_anim 6, 0, 69, -5, 5, -5, 5,
+ax_anim 1, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 2, 61, 8, -9, 8, -9,
+ax_anim 2, 0, 62, 15, -17, 15, -17,
+ax_anim 2, 1, 63, 14, -18, 14, -18,
+ax_anim 2, 0, 63, 15, -17, 15, -17,
+ax_anim 2, 0, 63, 14, -18, 14, -18,
+ax_anim 2, 0, 63, 15, -17, 15, -17,
+ax_anim 2, 0, 63, 14, -18, 14, -18,
+ax_anim 2, 0, 60, 8, -8, 8, -8,
+ax_anim 2, 0, 60, 2, -2, 2, -2,
+ax_anim_terminator
+sCharizardAnims_3_5:
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 0, 65, 0, 4, 0, 4,
+ax_anim 6, 0, 57, 2, 5, 2, 5,
+ax_anim 1, 0, 57, 2, -2, 2, -2,
+ax_anim 2, 2, 65, 0, -9, 0, -9,
+ax_anim 2, 0, 66, 0, -15, 0, -15,
+ax_anim 2, 1, 67, 1, -15, 1, -15,
+ax_anim 2, 0, 67, 0, -15, 0, -15,
+ax_anim 2, 0, 67, 1, -15, 1, -15,
+ax_anim 2, 0, 67, 0, -15, 0, -15,
+ax_anim 2, 0, 67, 1, -15, 1, -15,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim_terminator
+sCharizardAnims_3_6:
+ax_anim 2, 0, 68, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim 6, 0, 65, 5, 5, 5, 5,
+ax_anim 1, 0, 65, -2, -2, -2, -2,
+ax_anim 2, 2, 69, -8, -9, -8, -9,
+ax_anim 2, 0, 70, -15, -17, -15, -17,
+ax_anim 2, 1, 71, -14, -18, -14, -18,
+ax_anim 2, 0, 71, -15, -17, -15, -17,
+ax_anim 2, 0, 71, -14, -18, -14, -18,
+ax_anim 2, 0, 71, -15, -17, -15, -17,
+ax_anim 2, 0, 71, -14, -18, -14, -18,
+ax_anim 2, 0, 68, -8, -8, -8, -8,
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim_terminator
+sCharizardAnims_3_7:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 4, 0, 4, 0,
+ax_anim 6, 0, 69, 7, 0, 7, 0,
+ax_anim 1, 0, 69, 2, 0, 2, 0,
+ax_anim 2, 2, 73, -6, 0, -6, 0,
+ax_anim 2, 0, 74, -14, 0, -14, 0,
+ax_anim 2, 1, 75, -14, 1, -14, 1,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 75, -14, 1, -14, 1,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 75, -14, 1, -14, 1,
+ax_anim 2, 0, 72, -6, 0, -6, 0,
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_3_8:
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 2, 0, 77, 4, -4, 4, -4,
+ax_anim 6, 0, 73, 7, -5, 7, -5,
+ax_anim 1, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 2, 77, -8, 9, -8, 9,
+ax_anim 2, 0, 78, -15, 17, -15, 17,
+ax_anim 2, 1, 79, -14, 18, -14, 18,
+ax_anim 2, 0, 79, -15, 17, -15, 17,
+ax_anim 2, 0, 79, -14, 18, -14, 18,
+ax_anim 2, 0, 79, -15, 17, -15, 17,
+ax_anim 2, 0, 79, -14, 18, -14, 18,
+ax_anim 2, 0, 76, -8, 8, -8, 8,
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCharizardAnims_4_1:
+ax_anim 4, 0, 81, 0, -1, 0, -1,
+ax_anim 6, 0, 81, 0, -3, 0, -3,
+ax_anim 2, 2, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 2, 0, 2,
+ax_anim 2, 0, 82, 0, 5, 0, 5,
+ax_anim 2, 0, 82, 1, 5, 1, 5,
+ax_anim 2, 1, 82, 0, 5, 0, 5,
+ax_anim 2, 0, 82, 1, 5, 1, 5,
+ax_anim 2, 0, 82, 0, 5, 0, 5,
+ax_anim 2, 0, 82, 1, 5, 1, 5,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sCharizardAnims_4_2:
+ax_anim 4, 0, 84, -1, -1, -1, -1,
+ax_anim 6, 0, 84, -3, -3, -3, -3,
+ax_anim 2, 2, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 5, 5, 5, 5,
+ax_anim 2, 0, 85, 6, 4, 6, 4,
+ax_anim 2, 1, 85, 5, 5, 5, 5,
+ax_anim 2, 0, 85, 6, 4, 6, 4,
+ax_anim 2, 0, 85, 5, 5, 5, 5,
+ax_anim 2, 0, 85, 6, 4, 6, 4,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim_terminator
+sCharizardAnims_4_3:
+ax_anim 4, 0, 87, -1, 0, -1, 0,
+ax_anim 6, 0, 87, -3, 0, -3, 0,
+ax_anim 2, 2, 88, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 5, 0, 5, 0,
+ax_anim 2, 0, 88, 5, 1, 5, 1,
+ax_anim 2, 1, 88, 5, 0, 5, 0,
+ax_anim 2, 0, 88, 5, 1, 5, 1,
+ax_anim 2, 0, 88, 5, 0, 5, 0,
+ax_anim 2, 0, 88, 5, 1, 5, 1,
+ax_anim 2, 0, 86, 2, 0, 2, 0,
+ax_anim_terminator
+sCharizardAnims_4_4:
+ax_anim 4, 0, 90, -1, 1, -1, 1,
+ax_anim 6, 0, 90, -3, 3, -3, 3,
+ax_anim 2, 2, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 91, 6, -4, 6, -4,
+ax_anim 2, 1, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim_terminator
+sCharizardAnims_4_5:
+ax_anim 4, 0, 93, 0, 1, 0, 1,
+ax_anim 6, 0, 93, 0, 3, 0, 3,
+ax_anim 2, 2, 94, 0, 1, 0, 1,
+ax_anim 2, 0, 94, 0, -2, 0, -2,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, 1, -5, 1, -5,
+ax_anim 2, 1, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, 1, -5, 1, -5,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, 1, -5, 1, -5,
+ax_anim 2, 0, 92, 0, -2, 0, -2,
+ax_anim_terminator
+sCharizardAnims_4_6:
+ax_anim 4, 0, 96, 1, 1, 1, 1,
+ax_anim 6, 0, 96, 3, 3, 3, 3,
+ax_anim 2, 2, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -5, -5, -5, -5,
+ax_anim 2, 0, 97, -6, -4, -6, -4,
+ax_anim 2, 1, 97, -5, -5, -5, -5,
+ax_anim 2, 0, 97, -6, -4, -6, -4,
+ax_anim 2, 0, 97, -5, -5, -5, -5,
+ax_anim 2, 0, 97, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim_terminator
+sCharizardAnims_4_7:
+ax_anim 4, 0, 99, 1, 0, 1, 0,
+ax_anim 6, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 2, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -5, 0, -5, 0,
+ax_anim 2, 0, 100, -5, 1, -5, 1,
+ax_anim 2, 1, 100, -5, 0, -5, 0,
+ax_anim 2, 0, 100, -5, 1, -5, 1,
+ax_anim 2, 0, 100, -5, 0, -5, 0,
+ax_anim 2, 0, 100, -5, 1, -5, 1,
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_4_8:
+ax_anim 4, 0, 102, 1, -1, 1, -1,
+ax_anim 6, 0, 102, 3, -3, 3, -3,
+ax_anim 2, 2, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 1, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCharizardAnims_5_1:
+ax_anim 4, 0, 105, 0, -1, 0, -1,
+ax_anim 6, 0, 105, 0, -3, 0, -3,
+ax_anim 2, 2, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 2, 0, 2,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 1, 5, 1, 5,
+ax_anim 2, 1, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 1, 5, 1, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 1, 5, 1, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sCharizardAnims_5_2:
+ax_anim 4, 0, 108, -1, -1, -1, -1,
+ax_anim 6, 0, 108, -3, -3, -3, -3,
+ax_anim 2, 2, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 1, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim_terminator
+sCharizardAnims_5_3:
+ax_anim 4, 0, 111, -1, 0, -1, 0,
+ax_anim 6, 0, 111, -3, 0, -3, 0,
+ax_anim 2, 2, 112, -1, 0, -1, 0,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 1, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sCharizardAnims_5_4:
+ax_anim 4, 0, 114, -1, 1, -1, 1,
+ax_anim 6, 0, 114, -3, 3, -3, 3,
+ax_anim 2, 2, 115, -1, 1, -1, 1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 1, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim_terminator
+sCharizardAnims_5_5:
+ax_anim 4, 0, 117, 0, 1, 0, 1,
+ax_anim 6, 0, 117, 0, 3, 0, 3,
+ax_anim 2, 2, 118, 0, 1, 0, 1,
+ax_anim 2, 0, 118, 0, -2, 0, -2,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, 1, -5, 1, -5,
+ax_anim 2, 1, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, 1, -5, 1, -5,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, 1, -5, 1, -5,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sCharizardAnims_5_6:
+ax_anim 4, 0, 120, 1, 1, 1, 1,
+ax_anim 6, 0, 120, 3, 3, 3, 3,
+ax_anim 2, 2, 121, 1, 1, 1, 1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 1, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim_terminator
+sCharizardAnims_5_7:
+ax_anim 4, 0, 123, 1, 0, 1, 0,
+ax_anim 6, 0, 123, 3, 0, 3, 0,
+ax_anim 2, 2, 124, 1, 0, 1, 0,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 1, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_5_8:
+ax_anim 4, 0, 126, 1, -1, 1, -1,
+ax_anim 6, 0, 126, 3, -3, 3, -3,
+ax_anim 2, 2, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 1, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCharizardAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sCharizardAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sCharizardAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sCharizardAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sCharizardAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sCharizardAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sCharizardAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sCharizardAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCharizardAnims_8_1:
+ax_anim 15, 0, 138, 0, 0, 0, 0,
+ax_anim 15, 0, 139, 0, 0, 0, 0,
+ax_anim 15, 0, 138, 0, 0, 0, 0,
+ax_anim 15, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_8_2:
+ax_anim 15, 0, 141, 0, 0, 0, 0,
+ax_anim 15, 0, 142, 0, 0, 0, 0,
+ax_anim 15, 0, 141, 0, 0, 0, 0,
+ax_anim 15, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_8_3:
+ax_anim 15, 0, 144, 0, 0, 0, 0,
+ax_anim 15, 0, 145, 0, 0, 0, 0,
+ax_anim 15, 0, 144, 0, 0, 0, 0,
+ax_anim 15, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_8_4:
+ax_anim 15, 0, 147, 0, 0, 0, 0,
+ax_anim 15, 0, 148, 0, 0, 0, 0,
+ax_anim 15, 0, 147, 0, 0, 0, 0,
+ax_anim 15, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_8_5:
+ax_anim 15, 0, 150, 0, 0, 0, 0,
+ax_anim 15, 0, 151, 0, 0, 0, 0,
+ax_anim 15, 0, 150, 0, 0, 0, 0,
+ax_anim 15, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_8_6:
+ax_anim 15, 0, 153, 0, 0, 0, 0,
+ax_anim 15, 0, 154, 0, 0, 0, 0,
+ax_anim 15, 0, 153, 0, 0, 0, 0,
+ax_anim 15, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_8_7:
+ax_anim 15, 0, 156, 0, 0, 0, 0,
+ax_anim 15, 0, 157, 0, 0, 0, 0,
+ax_anim 15, 0, 156, 0, 0, 0, 0,
+ax_anim 15, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_8_8:
+ax_anim 15, 0, 159, 0, 0, 0, 0,
+ax_anim 15, 0, 160, 0, 0, 0, 0,
+ax_anim 15, 0, 159, 0, 0, 0, 0,
+ax_anim 15, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 21, 0, 21,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, -2, 6, -2,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 21, 9, 21, 9,
+ax_anim 3, 0, 165, 19, 20, 19, 20,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 15, 2, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 20, 1, 20, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 10, -23, 10, -23,
+ax_anim 3, 0, 163, 19, -24, 19, -24,
+ax_anim 2, 3, 164, 21, -11, 21, -11,
+ax_anim 2, 0, 165, 16, -4, 16, -4,
+ax_anim 1, 0, 166, 7, 1, 7, 1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -24, 0, -24,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 8, -8, 8, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -10, -23, -10, -23,
+ax_anim 3, 0, 169, -19, -24, -19, -24,
+ax_anim 2, 3, 168, -21, -11, -21, -11,
+ax_anim 2, 0, 167, -16, -4, -16, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -20, 1, -20, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, -2, -6, -2,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -21, 9, -21, 9,
+ax_anim 3, 0, 167, -19, 20, -19, 20,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -2, 15, -2, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_14_1:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_14_2:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_14_3:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_14_4:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_14_5:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_14_6:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_14_7:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_14_8:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_15_1:
+ax_anim 20, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 225, -2, 0, -2, 0,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 6, 0, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 10, 0, 225, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_15_2:
+ax_anim 20, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 225, -2, 0, -2, 0,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 6, 0, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 10, 0, 225, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_15_3:
+ax_anim 20, 0, 226, 0, 0, 0, 0,
+ax_anim 6, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 2, 0, 2, 0,
+ax_anim 2, 0, 229, 2, -1, 2, -1,
+ax_anim 6, 0, 229, 2, -2, 2, -2,
+ax_anim 2, 0, 229, 2, -1, 2, -1,
+ax_anim 10, 0, 229, 2, 0, 2, 0,
+ax_anim_terminator
+sCharizardAnims_15_4:
+ax_anim 20, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 225, -2, 0, -2, 0,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 6, 0, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 10, 0, 225, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_15_5:
+ax_anim 20, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 225, -2, 0, -2, 0,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 6, 0, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 10, 0, 225, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_15_6:
+ax_anim 20, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 225, -2, 0, -2, 0,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 6, 0, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 10, 0, 225, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_15_7:
+ax_anim 20, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 225, -2, 0, -2, 0,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 6, 0, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 10, 0, 225, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_15_8:
+ax_anim 20, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 225, -2, 0, -2, 0,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 6, 0, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -2, -1, -2, -1,
+ax_anim 10, 0, 225, -2, 0, -2, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_16_1:
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 231, 0, 0, 0, 0,
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_16_2:
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 231, 0, 0, 0, 0,
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_16_3:
+ax_anim 13, 0, 233, 0, 0, 0, 0,
+ax_anim 20, 0, 234, 0, 0, 0, 0,
+ax_anim 13, 0, 233, 0, 0, 0, 0,
+ax_anim 20, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_16_4:
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 231, 0, 0, 0, 0,
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_16_5:
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 231, 0, 0, 0, 0,
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_16_6:
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 231, 0, 0, 0, 0,
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_16_7:
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 231, 0, 0, 0, 0,
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCharizardAnims_16_8:
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 231, 0, 0, 0, 0,
+ax_anim 13, 0, 230, 0, 0, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharizardAnims_17_1:
+ax_anim 20, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, -1, 0,
+ax_anim 4, 0, 239, -2, 0, -2, 0,
+ax_anim 2, 0, 239, -2, -1, -2, -1,
+ax_anim 6, 0, 239, -2, -2, -2, -2,
+ax_anim 1, 0, 239, -2, -1, -2, -1,
+ax_anim 10, 0, 239, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_17_2:
+ax_anim 20, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, -1, 0,
+ax_anim 4, 0, 239, -2, 0, -2, 0,
+ax_anim 2, 0, 239, -2, -1, -2, -1,
+ax_anim 6, 0, 239, -2, -2, -2, -2,
+ax_anim 1, 0, 239, -2, -1, -2, -1,
+ax_anim 10, 0, 239, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_17_3:
+ax_anim 20, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 1, 0,
+ax_anim 4, 0, 243, 2, 0, 2, 0,
+ax_anim 2, 0, 243, 2, -1, 2, -1,
+ax_anim 6, 0, 243, 2, -2, 2, -2,
+ax_anim 1, 0, 243, 2, -1, 2, -1,
+ax_anim 10, 0, 243, 2, 0, 2, 0,
+ax_anim_terminator
+sCharizardAnims_17_4:
+ax_anim 20, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, -1, 0,
+ax_anim 4, 0, 239, -2, 0, -2, 0,
+ax_anim 2, 0, 239, -2, -1, -2, -1,
+ax_anim 6, 0, 239, -2, -2, -2, -2,
+ax_anim 1, 0, 239, -2, -1, -2, -1,
+ax_anim 10, 0, 239, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_17_5:
+ax_anim 20, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, -1, 0,
+ax_anim 4, 0, 239, -2, 0, -2, 0,
+ax_anim 2, 0, 239, -2, -1, -2, -1,
+ax_anim 6, 0, 239, -2, -2, -2, -2,
+ax_anim 1, 0, 239, -2, -1, -2, -1,
+ax_anim 10, 0, 239, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_17_6:
+ax_anim 20, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, -1, 0,
+ax_anim 4, 0, 239, -2, 0, -2, 0,
+ax_anim 2, 0, 239, -2, -1, -2, -1,
+ax_anim 6, 0, 239, -2, -2, -2, -2,
+ax_anim 1, 0, 239, -2, -1, -2, -1,
+ax_anim 10, 0, 239, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_17_7:
+ax_anim 20, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, -1, 0,
+ax_anim 4, 0, 239, -2, 0, -2, 0,
+ax_anim 2, 0, 239, -2, -1, -2, -1,
+ax_anim 6, 0, 239, -2, -2, -2, -2,
+ax_anim 1, 0, 239, -2, -1, -2, -1,
+ax_anim 10, 0, 239, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardAnims_17_8:
+ax_anim 20, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, -1, 0,
+ax_anim 4, 0, 239, -2, 0, -2, 0,
+ax_anim 2, 0, 239, -2, -1, -2, -1,
+ax_anim 6, 0, 239, -2, -2, -2, -2,
+ax_anim 1, 0, 239, -2, -1, -2, -1,
+ax_anim 10, 0, 239, -2, 0, -2, 0,
+ax_anim_terminator
+sCharizardGfx1:
+.incbin "baserom.gba", 0x554468, 0x200
+sCharizardSprites1:
+ax_sprite sCharizardGfx1, 0x200
+ax_sprite_terminator
+sCharizardGfx2:
+.incbin "baserom.gba", 0x554678, 0x200
+sCharizardSprites2:
+ax_sprite sCharizardGfx2, 0x200
+ax_sprite_terminator
+sCharizardGfx3:
+.incbin "baserom.gba", 0x554888, 0x200
+sCharizardSprites3:
+ax_sprite sCharizardGfx3, 0x200
+ax_sprite_terminator
+sCharizardGfx4:
+.incbin "baserom.gba", 0x554A98, 0x200
+sCharizardSprites4:
+ax_sprite sCharizardGfx4, 0x200
+ax_sprite_terminator
+sCharizardGfx5:
+.incbin "baserom.gba", 0x554CA8, 0x200
+sCharizardSprites5:
+ax_sprite sCharizardGfx5, 0x200
+ax_sprite_terminator
+sCharizardGfx6:
+.incbin "baserom.gba", 0x554EB8, 0x200
+sCharizardSprites6:
+ax_sprite sCharizardGfx6, 0x200
+ax_sprite_terminator
+sCharizardGfx7:
+.incbin "baserom.gba", 0x5550C8, 0x200
+sCharizardSprites7:
+ax_sprite sCharizardGfx7, 0x200
+ax_sprite_terminator
+sCharizardGfx8:
+.incbin "baserom.gba", 0x5552D8, 0x200
+sCharizardSprites8:
+ax_sprite sCharizardGfx8, 0x200
+ax_sprite_terminator
+sCharizardGfx9:
+.incbin "baserom.gba", 0x5554E8, 0x200
+sCharizardSprites9:
+ax_sprite sCharizardGfx9, 0x200
+ax_sprite_terminator
+sCharizardGfx10:
+.incbin "baserom.gba", 0x5556F8, 0x200
+sCharizardSprites10:
+ax_sprite sCharizardGfx10, 0x200
+ax_sprite_terminator
+sCharizardGfx11:
+.incbin "baserom.gba", 0x555908, 0x100
+sCharizardSprites11:
+ax_sprite sCharizardGfx11, 0x100
+ax_sprite_terminator
+sCharizardGfx12:
+.incbin "baserom.gba", 0x555A18, 0x80
+sCharizardSprites12:
+ax_sprite sCharizardGfx12, 0x80
+ax_sprite_terminator
+sCharizardGfx13:
+.incbin "baserom.gba", 0x555AA8, 0x40
+sCharizardSprites13:
+ax_sprite sCharizardGfx13, 0x40
+ax_sprite_terminator
+sCharizardGfx14:
+.incbin "baserom.gba", 0x555AF8, 0x20
+sCharizardSprites14:
+ax_sprite sCharizardGfx14, 0x20
+ax_sprite_terminator
+sCharizardGfx15:
+.incbin "baserom.gba", 0x555B28, 0x20
+sCharizardSprites15:
+ax_sprite sCharizardGfx15, 0x20
+ax_sprite_terminator
+sCharizardGfx16:
+.incbin "baserom.gba", 0x555B58, 0x200
+sCharizardSprites16:
+ax_sprite sCharizardGfx16, 0x200
+ax_sprite_terminator
+sCharizardGfx17:
+.incbin "baserom.gba", 0x555D68, 0x200
+sCharizardSprites17:
+ax_sprite sCharizardGfx17, 0x200
+ax_sprite_terminator
+sCharizardGfx18:
+.incbin "baserom.gba", 0x555F78, 0x200
+sCharizardSprites18:
+ax_sprite sCharizardGfx18, 0x200
+ax_sprite_terminator
+sCharizardGfx19:
+.incbin "baserom.gba", 0x556188, 0x200
+sCharizardSprites19:
+ax_sprite sCharizardGfx19, 0x200
+ax_sprite_terminator
+sCharizardGfx20:
+.incbin "baserom.gba", 0x556398, 0x200
+sCharizardSprites20:
+ax_sprite sCharizardGfx20, 0x200
+ax_sprite_terminator
+sCharizardGfx21:
+.incbin "baserom.gba", 0x5565A8, 0x20
+sCharizardGfx21_1:
+.incbin "baserom.gba", 0x5565C8, 0x40
+sCharizardGfx21_2:
+.incbin "baserom.gba", 0x556608, 0x60
+sCharizardSprites21:
+ax_sprite 0, 0x80
+ax_sprite sCharizardGfx21, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCharizardGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharizardGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharizardGfx22:
+.incbin "baserom.gba", 0x5566A8, 0x60
+sCharizardGfx22_1:
+.incbin "baserom.gba", 0x556708, 0x60
+sCharizardGfx22_2:
+.incbin "baserom.gba", 0x556768, 0x100
+sCharizardSprites22:
+ax_sprite sCharizardGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx22_2, 0x100
+ax_sprite_terminator
+sCharizardGfx23:
+.incbin "baserom.gba", 0x556898, 0x200
+sCharizardSprites23:
+ax_sprite sCharizardGfx23, 0x200
+ax_sprite_terminator
+sCharizardGfx24:
+.incbin "baserom.gba", 0x556AA8, 0x20
+sCharizardGfx24_1:
+.incbin "baserom.gba", 0x556AC8, 0x20
+sCharizardGfx24_2:
+.incbin "baserom.gba", 0x556AE8, 0x40
+sCharizardSprites24:
+ax_sprite 0, 0x40
+ax_sprite sCharizardGfx24, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx24_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx24_2, 0x40
+ax_sprite_terminator
+sCharizardGfx25:
+.incbin "baserom.gba", 0x556B60, 0x100
+sCharizardSprites25:
+ax_sprite sCharizardGfx25, 0x100
+ax_sprite_terminator
+sCharizardGfx26:
+.incbin "baserom.gba", 0x556C70, 0x80
+sCharizardSprites26:
+ax_sprite sCharizardGfx26, 0x80
+ax_sprite_terminator
+sCharizardGfx27:
+.incbin "baserom.gba", 0x556D00, 0x180
+sCharizardGfx27_1:
+.incbin "baserom.gba", 0x556E80, 0x60
+sCharizardSprites27:
+ax_sprite sCharizardGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx27_1, 0x60
+ax_sprite_terminator
+sCharizardGfx28:
+.incbin "baserom.gba", 0x556F00, 0x60
+sCharizardGfx28_1:
+.incbin "baserom.gba", 0x556F60, 0x80
+sCharizardSprites28:
+ax_sprite sCharizardGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx28_1, 0x80
+ax_sprite_terminator
+sCharizardGfx29:
+.incbin "baserom.gba", 0x557000, 0x80
+sCharizardSprites29:
+ax_sprite sCharizardGfx29, 0x80
+ax_sprite_terminator
+sCharizardGfx30:
+.incbin "baserom.gba", 0x557090, 0x60
+sCharizardGfx30_1:
+.incbin "baserom.gba", 0x5570F0, 0x80
+sCharizardSprites30:
+ax_sprite sCharizardGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx30_1, 0x80
+ax_sprite_terminator
+sCharizardGfx31:
+.incbin "baserom.gba", 0x557190, 0x40
+sCharizardSprites31:
+ax_sprite sCharizardGfx31, 0x40
+ax_sprite_terminator
+sCharizardGfx32:
+.incbin "baserom.gba", 0x5571E0, 0x20
+sCharizardSprites32:
+ax_sprite sCharizardGfx32, 0x20
+ax_sprite_terminator
+sCharizardGfx33:
+.incbin "baserom.gba", 0x557210, 0x20
+sCharizardSprites33:
+ax_sprite sCharizardGfx33, 0x20
+ax_sprite_terminator
+sCharizardGfx34:
+.incbin "baserom.gba", 0x557240, 0x200
+sCharizardSprites34:
+ax_sprite sCharizardGfx34, 0x200
+ax_sprite_terminator
+sCharizardGfx35:
+.incbin "baserom.gba", 0x557450, 0x60
+sCharizardGfx35_1:
+.incbin "baserom.gba", 0x5574B0, 0x40
+sCharizardSprites35:
+ax_sprite sCharizardGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCharizardGfx36:
+.incbin "baserom.gba", 0x557518, 0x20
+sCharizardSprites36:
+ax_sprite sCharizardGfx36, 0x20
+ax_sprite_terminator
+sCharizardGfx37:
+.incbin "baserom.gba", 0x557548, 0x40
+sCharizardSprites37:
+ax_sprite sCharizardGfx37, 0x40
+ax_sprite_terminator
+sCharizardGfx38:
+.incbin "baserom.gba", 0x557598, 0x80
+sCharizardSprites38:
+ax_sprite sCharizardGfx38, 0x80
+ax_sprite_terminator
+sCharizardGfx39:
+.incbin "baserom.gba", 0x557628, 0x100
+sCharizardSprites39:
+ax_sprite sCharizardGfx39, 0x100
+ax_sprite_terminator
+sCharizardGfx40:
+.incbin "baserom.gba", 0x557738, 0x20
+sCharizardSprites40:
+ax_sprite sCharizardGfx40, 0x20
+ax_sprite_terminator
+sCharizardGfx41:
+.incbin "baserom.gba", 0x557768, 0x1E0
+sCharizardSprites41:
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx41, 0x1e0
+ax_sprite_terminator
+sCharizardGfx42:
+.incbin "baserom.gba", 0x557960, 0x40
+sCharizardGfx42_1:
+.incbin "baserom.gba", 0x5579A0, 0x20
+sCharizardGfx42_2:
+.incbin "baserom.gba", 0x5579C0, 0x20
+sCharizardSprites42:
+ax_sprite sCharizardGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx42_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx42_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCharizardGfx43:
+.incbin "baserom.gba", 0x557A18, 0x180
+sCharizardGfx43_1:
+.incbin "baserom.gba", 0x557B98, 0x60
+sCharizardSprites43:
+ax_sprite sCharizardGfx43, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx43_1, 0x60
+ax_sprite_terminator
+sCharizardGfx44:
+.incbin "baserom.gba", 0x557C18, 0x40
+sCharizardGfx44_1:
+.incbin "baserom.gba", 0x557C58, 0x180
+sCharizardSprites44:
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx44_1, 0x180
+ax_sprite_terminator
+sCharizardGfx45:
+.incbin "baserom.gba", 0x557E00, 0x200
+sCharizardSprites45:
+ax_sprite sCharizardGfx45, 0x200
+ax_sprite_terminator
+sCharizardGfx46:
+.incbin "baserom.gba", 0x558010, 0x40
+sCharizardGfx46_1:
+.incbin "baserom.gba", 0x558050, 0x80
+sCharizardGfx46_2:
+.incbin "baserom.gba", 0x5580D0, 0xE0
+sCharizardSprites46:
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx46_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx46_2, 0xe0
+ax_sprite_terminator
+sCharizardGfx47:
+.incbin "baserom.gba", 0x5581E8, 0x1E0
+sCharizardSprites47:
+ax_sprite sCharizardGfx47, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharizardGfx48:
+.incbin "baserom.gba", 0x5583E0, 0x100
+sCharizardSprites48:
+ax_sprite sCharizardGfx48, 0x100
+ax_sprite_terminator
+sCharizardGfx49:
+.incbin "baserom.gba", 0x5584F0, 0x80
+sCharizardSprites49:
+ax_sprite sCharizardGfx49, 0x80
+ax_sprite_terminator
+sCharizardGfx50:
+.incbin "baserom.gba", 0x558580, 0x100
+sCharizardSprites50:
+ax_sprite sCharizardGfx50, 0x100
+ax_sprite_terminator
+sCharizardGfx51:
+.incbin "baserom.gba", 0x558690, 0x80
+sCharizardSprites51:
+ax_sprite sCharizardGfx51, 0x80
+ax_sprite_terminator
+sCharizardGfx52:
+.incbin "baserom.gba", 0x558720, 0x40
+sCharizardSprites52:
+ax_sprite sCharizardGfx52, 0x40
+ax_sprite_terminator
+sCharizardGfx53:
+.incbin "baserom.gba", 0x558770, 0x20
+sCharizardSprites53:
+ax_sprite sCharizardGfx53, 0x20
+ax_sprite_terminator
+sCharizardGfx54:
+.incbin "baserom.gba", 0x5587A0, 0x1E0
+sCharizardSprites54:
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx54, 0x1e0
+ax_sprite_terminator
+sCharizardGfx55:
+.incbin "baserom.gba", 0x558998, 0x200
+sCharizardSprites55:
+ax_sprite sCharizardGfx55, 0x200
+ax_sprite_terminator
+sCharizardGfx56:
+.incbin "baserom.gba", 0x558BA8, 0x40
+sCharizardGfx56_1:
+.incbin "baserom.gba", 0x558BE8, 0x180
+sCharizardSprites56:
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx56_1, 0x180
+ax_sprite_terminator
+sCharizardGfx57:
+.incbin "baserom.gba", 0x558D90, 0x180
+sCharizardGfx57_1:
+.incbin "baserom.gba", 0x558F10, 0x40
+sCharizardSprites57:
+ax_sprite sCharizardGfx57, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCharizardGfx57_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharizardGfx58:
+.incbin "baserom.gba", 0x558F78, 0x200
+sCharizardSprites58:
+ax_sprite sCharizardGfx58, 0x200
+ax_sprite_terminator
+sCharizardGfx59:
+.incbin "baserom.gba", 0x559188, 0x200
+sCharizardSprites59:
+ax_sprite sCharizardGfx59, 0x200
+ax_sprite_terminator
+sCharizardGfx60:
+.incbin "baserom.gba", 0x559398, 0x200
+sCharizardSprites60:
+ax_sprite sCharizardGfx60, 0x200
+ax_sprite_terminator
+sCharizardGfx61:
+.incbin "baserom.gba", 0x5595A8, 0x200
+sCharizardSprites61:
+ax_sprite sCharizardGfx61, 0x200
+ax_sprite_terminator
+sCharizardGfx62:
+.incbin "baserom.gba", 0x5597B8, 0x200
+sCharizardSprites62:
+ax_sprite sCharizardGfx62, 0x200
+ax_sprite_terminator
+sCharizardGfx63:
+.incbin "baserom.gba", 0x5599C8, 0x200
+sCharizardSprites63:
+ax_sprite sCharizardGfx63, 0x200
+ax_sprite_terminator
+sCharizardGfx64:
+.incbin "baserom.gba", 0x559BD8, 0x200
+sCharizardSprites64:
+ax_sprite sCharizardGfx64, 0x200
+ax_sprite_terminator
+sCharizardGfx65:
+.incbin "baserom.gba", 0x559DE8, 0x200
+sCharizardSprites65:
+ax_sprite sCharizardGfx65, 0x200
+ax_sprite_terminator
+sCharizardGfx66:
+.incbin "baserom.gba", 0x559FF8, 0x200
+sCharizardSprites66:
+ax_sprite sCharizardGfx66, 0x200
+ax_sprite_terminator
+sCharizardGfx67:
+.incbin "baserom.gba", 0x55A208, 0x200
+sCharizardSprites67:
+ax_sprite sCharizardGfx67, 0x200
+ax_sprite_terminator
+sCharizardGfx68:
+.incbin "baserom.gba", 0x55A418, 0x100
+sCharizardSprites68:
+ax_sprite sCharizardGfx68, 0x100
+ax_sprite_terminator
+sCharizardGfx69:
+.incbin "baserom.gba", 0x55A528, 0x80
+sCharizardSprites69:
+ax_sprite sCharizardGfx69, 0x80
+ax_sprite_terminator
+sCharizardGfx70:
+.incbin "baserom.gba", 0x55A5B8, 0x40
+sCharizardSprites70:
+ax_sprite sCharizardGfx70, 0x40
+ax_sprite_terminator
+sCharizardGfx71:
+.incbin "baserom.gba", 0x55A608, 0x40
+sCharizardSprites71:
+ax_sprite sCharizardGfx71, 0x40
+ax_sprite_terminator
+sCharizardGfx72:
+.incbin "baserom.gba", 0x55A658, 0x100
+sCharizardSprites72:
+ax_sprite sCharizardGfx72, 0x100
+ax_sprite_terminator
+sCharizardGfx73:
+.incbin "baserom.gba", 0x55A768, 0x80
+sCharizardSprites73:
+ax_sprite sCharizardGfx73, 0x80
+ax_sprite_terminator
+sCharizardGfx74:
+.incbin "baserom.gba", 0x55A7F8, 0x20
+sCharizardSprites74:
+ax_sprite sCharizardGfx74, 0x20
+ax_sprite_terminator
+sCharizardGfx75:
+.incbin "baserom.gba", 0x55A828, 0x100
+sCharizardSprites75:
+ax_sprite sCharizardGfx75, 0x100
+ax_sprite_terminator
+sCharizardGfx76:
+.incbin "baserom.gba", 0x55A938, 0x80
+sCharizardSprites76:
+ax_sprite sCharizardGfx76, 0x80
+ax_sprite_terminator
+sCharizardGfx77:
+.incbin "baserom.gba", 0x55A9C8, 0x40
+sCharizardSprites77:
+ax_sprite sCharizardGfx77, 0x40
+ax_sprite_terminator
+sCharizardGfx78:
+.incbin "baserom.gba", 0x55AA18, 0x100
+sCharizardSprites78:
+ax_sprite sCharizardGfx78, 0x100
+ax_sprite_terminator
+sCharizardGfx79:
+.incbin "baserom.gba", 0x55AB28, 0x80
+sCharizardSprites79:
+ax_sprite sCharizardGfx79, 0x80
+ax_sprite_terminator
+sCharizardGfx80:
+.incbin "baserom.gba", 0x55ABB8, 0x40
+sCharizardSprites80:
+ax_sprite sCharizardGfx80, 0x40
+ax_sprite_terminator
+sCharizardGfx81:
+.incbin "baserom.gba", 0x55AC08, 0x40
+sCharizardSprites81:
+ax_sprite sCharizardGfx81, 0x40
+ax_sprite_terminator
+sCharizardGfx82:
+.incbin "baserom.gba", 0x55AC58, 0x200
+sCharizardSprites82:
+ax_sprite sCharizardGfx82, 0x200
+ax_sprite_terminator
+sCharizardGfx83:
+.incbin "baserom.gba", 0x55AE68, 0x200
+sCharizardSprites83:
+ax_sprite sCharizardGfx83, 0x200
+ax_sprite_terminator
+sAxPosesCharizard:
+.4byte sCharizardPose1
+.4byte sCharizardPose2
+.4byte sCharizardPose3
+.4byte sCharizardPose4
+.4byte sCharizardPose5
+.4byte sCharizardPose6
+.4byte sCharizardPose7
+.4byte sCharizardPose8
+.4byte sCharizardPose9
+.4byte sCharizardPose10
+.4byte sCharizardPose11
+.4byte sCharizardPose12
+.4byte sCharizardPose13
+.4byte sCharizardPose14
+.4byte sCharizardPose15
+.4byte sCharizardPose16
+.4byte sCharizardPose17
+.4byte sCharizardPose18
+.4byte sCharizardPose19
+.4byte sCharizardPose20
+.4byte sCharizardPose21
+.4byte sCharizardPose22
+.4byte sCharizardPose23
+.4byte sCharizardPose24
+.4byte sCharizardPose25
+.4byte sCharizardPose26
+.4byte sCharizardPose27
+.4byte sCharizardPose28
+.4byte sCharizardPose29
+.4byte sCharizardPose30
+.4byte sCharizardPose31
+.4byte sCharizardPose32
+.4byte sCharizardPose33
+.4byte sCharizardPose34
+.4byte sCharizardPose35
+.4byte sCharizardPose36
+.4byte sCharizardPose37
+.4byte sCharizardPose38
+.4byte sCharizardPose39
+.4byte sCharizardPose40
+.4byte sCharizardPose41
+.4byte sCharizardPose42
+.4byte sCharizardPose43
+.4byte sCharizardPose44
+.4byte sCharizardPose45
+.4byte sCharizardPose46
+.4byte sCharizardPose47
+.4byte sCharizardPose48
+.4byte sCharizardPose49
+.4byte sCharizardPose50
+.4byte sCharizardPose51
+.4byte sCharizardPose52
+.4byte sCharizardPose53
+.4byte sCharizardPose54
+.4byte sCharizardPose55
+.4byte sCharizardPose56
+.4byte sCharizardPose57
+.4byte sCharizardPose58
+.4byte sCharizardPose59
+.4byte sCharizardPose60
+.4byte sCharizardPose61
+.4byte sCharizardPose62
+.4byte sCharizardPose63
+.4byte sCharizardPose64
+.4byte sCharizardPose65
+.4byte sCharizardPose66
+.4byte sCharizardPose67
+.4byte sCharizardPose68
+.4byte sCharizardPose69
+.4byte sCharizardPose70
+.4byte sCharizardPose71
+.4byte sCharizardPose72
+.4byte sCharizardPose73
+.4byte sCharizardPose74
+.4byte sCharizardPose75
+.4byte sCharizardPose76
+.4byte sCharizardPose77
+.4byte sCharizardPose78
+.4byte sCharizardPose79
+.4byte sCharizardPose80
+.4byte sCharizardPose81
+.4byte sCharizardPose82
+.4byte sCharizardPose83
+.4byte sCharizardPose84
+.4byte sCharizardPose85
+.4byte sCharizardPose86
+.4byte sCharizardPose87
+.4byte sCharizardPose88
+.4byte sCharizardPose89
+.4byte sCharizardPose90
+.4byte sCharizardPose91
+.4byte sCharizardPose92
+.4byte sCharizardPose93
+.4byte sCharizardPose94
+.4byte sCharizardPose95
+.4byte sCharizardPose96
+.4byte sCharizardPose97
+.4byte sCharizardPose98
+.4byte sCharizardPose99
+.4byte sCharizardPose100
+.4byte sCharizardPose101
+.4byte sCharizardPose102
+.4byte sCharizardPose103
+.4byte sCharizardPose104
+.4byte sCharizardPose105
+.4byte sCharizardPose106
+.4byte sCharizardPose107
+.4byte sCharizardPose108
+.4byte sCharizardPose109
+.4byte sCharizardPose110
+.4byte sCharizardPose111
+.4byte sCharizardPose112
+.4byte sCharizardPose113
+.4byte sCharizardPose114
+.4byte sCharizardPose115
+.4byte sCharizardPose116
+.4byte sCharizardPose117
+.4byte sCharizardPose118
+.4byte sCharizardPose119
+.4byte sCharizardPose120
+.4byte sCharizardPose121
+.4byte sCharizardPose122
+.4byte sCharizardPose123
+.4byte sCharizardPose124
+.4byte sCharizardPose125
+.4byte sCharizardPose126
+.4byte sCharizardPose127
+.4byte sCharizardPose128
+.4byte sCharizardPose129
+.4byte sCharizardPose130
+.4byte sCharizardPose131
+.4byte sCharizardPose132
+.4byte sCharizardPose133
+.4byte sCharizardPose134
+.4byte sCharizardPose135
+.4byte sCharizardPose136
+.4byte sCharizardPose137
+.4byte sCharizardPose138
+.4byte sCharizardPose139
+.4byte sCharizardPose140
+.4byte sCharizardPose141
+.4byte sCharizardPose142
+.4byte sCharizardPose143
+.4byte sCharizardPose144
+.4byte sCharizardPose145
+.4byte sCharizardPose146
+.4byte sCharizardPose147
+.4byte sCharizardPose148
+.4byte sCharizardPose149
+.4byte sCharizardPose150
+.4byte sCharizardPose151
+.4byte sCharizardPose152
+.4byte sCharizardPose153
+.4byte sCharizardPose154
+.4byte sCharizardPose155
+.4byte sCharizardPose156
+.4byte sCharizardPose157
+.4byte sCharizardPose158
+.4byte sCharizardPose159
+.4byte sCharizardPose160
+.4byte sCharizardPose161
+.4byte sCharizardPose162
+.4byte sCharizardPose163
+.4byte sCharizardPose164
+.4byte sCharizardPose165
+.4byte sCharizardPose166
+.4byte sCharizardPose167
+.4byte sCharizardPose168
+.4byte sCharizardPose169
+.4byte sCharizardPose170
+.4byte sCharizardPose171
+.4byte sCharizardPose172
+.4byte sCharizardPose173
+.4byte sCharizardPose174
+.4byte sCharizardPose175
+.4byte sCharizardPose176
+.4byte sCharizardPose177
+.4byte sCharizardPose178
+.4byte sCharizardPose179
+.4byte sCharizardPose180
+.4byte sCharizardPose181
+.4byte sCharizardPose182
+.4byte sCharizardPose183
+.4byte sCharizardPose184
+.4byte sCharizardPose185
+.4byte sCharizardPose186
+.4byte sCharizardPose187
+.4byte sCharizardPose188
+.4byte sCharizardPose189
+.4byte sCharizardPose190
+.4byte sCharizardPose191
+.4byte sCharizardPose192
+.4byte sCharizardPose193
+.4byte sCharizardPose194
+.4byte sCharizardPose195
+.4byte sCharizardPose196
+.4byte sCharizardPose197
+.4byte sCharizardPose198
+.4byte sCharizardPose199
+.4byte sCharizardPose200
+.4byte sCharizardPose201
+.4byte sCharizardPose202
+.4byte sCharizardPose203
+.4byte sCharizardPose204
+.4byte sCharizardPose205
+.4byte sCharizardPose206
+.4byte sCharizardPose207
+.4byte sCharizardPose208
+.4byte sCharizardPose209
+.4byte sCharizardPose210
+.4byte sCharizardPose211
+.4byte sCharizardPose212
+.4byte sCharizardPose213
+.4byte sCharizardPose214
+.4byte sCharizardPose215
+.4byte sCharizardPose216
+.4byte sCharizardPose217
+.4byte sCharizardPose218
+.4byte sCharizardPose219
+.4byte sCharizardPose220
+.4byte sCharizardPose221
+.4byte sCharizardPose222
+.4byte sCharizardPose223
+.4byte sCharizardPose224
+.4byte sCharizardPose225
+.4byte sCharizardPose226
+.4byte sCharizardPose227
+.4byte sCharizardPose228
+.4byte sCharizardPose229
+.4byte sCharizardPose230
+.4byte sCharizardPose231
+.4byte sCharizardPose232
+.4byte sCharizardPose233
+.4byte sCharizardPose234
+.4byte sCharizardPose235
+.4byte sCharizardPose236
+.4byte sCharizardPose237
+.4byte sCharizardPose238
+.4byte sCharizardPose239
+.4byte sCharizardPose240
+.4byte sCharizardPose241
+.4byte sCharizardPose242
+.4byte sCharizardPose243
+.4byte sCharizardPose244
+sAxPositionsCharizard:
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -2,   -9, 	 -10,  -12, 	   3,   -7, 	  -2,   -6
+.2byte    0,   -9, 	  -6,   -7, 	   8,  -12, 	   1,   -6
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte    8,  -11, 	   6,   -9, 	   1,   -5, 	   1,   -7
+.2byte    7,  -10, 	  10,  -10, 	  -6,   -7, 	   0,   -7
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte   10,  -12, 	   6,  -12, 	  10,  -10, 	   4,   -9
+.2byte    9,  -11, 	   9,   -9, 	   2,   -7, 	   0,   -8
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte   10,  -17, 	  -1,  -14, 	  13,  -13, 	   1,  -11
+.2byte    8,  -17, 	  -1,  -18, 	   7,  -11, 	  -3,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -20, 	   5,  -11, 	  -6,  -19, 	  -1,   -9
+.2byte   -2,  -20, 	   4,  -19, 	  -8,  -10, 	  -1,   -9
+.2byte  -10,  -18, 	   0,  -17, 	 -10,  -13, 	   0,  -12
+.2byte  -11,  -17, 	   0,  -14, 	 -14,  -13, 	  -2,  -11
+.2byte   -8,  -17, 	   1,  -18, 	  -7,  -11, 	   3,  -12
+.2byte  -10,  -13, 	  -8,  -13, 	  -7,  -10, 	  -3,  -10
+.2byte  -11,  -12, 	  -7,  -12, 	 -11,  -10, 	  -5,   -9
+.2byte  -10,  -11, 	 -10,   -9, 	  -3,   -7, 	  -1,   -8
+.2byte   -8,  -12, 	  -9,  -11, 	   3,   -9, 	  -1,   -8
+.2byte   -9,  -11, 	  -7,   -9, 	  -2,   -5, 	  -2,   -7
+.2byte   -8,  -10, 	 -11,  -10, 	   5,   -7, 	  -1,   -7
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -2,   -9, 	 -10,  -12, 	   3,   -7, 	  -2,   -6
+.2byte    0,   -9, 	  -6,   -7, 	   8,  -12, 	   1,   -6
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte    8,  -11, 	   6,   -9, 	   1,   -5, 	   1,   -7
+.2byte    7,  -10, 	  10,  -10, 	  -6,   -7, 	   0,   -7
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte   10,  -12, 	   6,  -12, 	  10,  -10, 	   4,   -9
+.2byte    9,  -11, 	   9,   -9, 	   2,   -7, 	   0,   -8
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte   10,  -17, 	  -1,  -14, 	  13,  -13, 	   1,  -11
+.2byte    8,  -17, 	  -1,  -18, 	   7,  -11, 	  -3,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -20, 	   5,  -11, 	  -6,  -19, 	  -1,   -9
+.2byte   -2,  -20, 	   4,  -19, 	  -8,  -10, 	  -1,   -9
+.2byte  -10,  -18, 	   0,  -17, 	 -10,  -13, 	   0,  -12
+.2byte  -11,  -17, 	   0,  -14, 	 -14,  -13, 	  -2,  -11
+.2byte   -8,  -17, 	   1,  -18, 	  -7,  -11, 	   3,  -12
+.2byte  -10,  -13, 	  -8,  -13, 	  -7,  -10, 	  -3,  -10
+.2byte  -11,  -12, 	  -7,  -12, 	 -11,  -10, 	  -5,   -9
+.2byte  -10,  -11, 	 -10,   -9, 	  -3,   -7, 	  -1,   -8
+.2byte   -8,  -12, 	  -9,  -11, 	   3,   -9, 	  -1,   -8
+.2byte   -9,  -11, 	  -7,   -9, 	  -2,   -5, 	  -2,   -7
+.2byte   -8,  -10, 	 -11,  -10, 	   5,   -7, 	  -1,   -7
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -6,  -17, 	  -6,  -16, 	   3,   -6, 	   0,   -9
+.2byte    9,    2, 	   2,    2, 	   3,   -9, 	  -1,   -7
+.2byte    9,    2, 	   2,    2, 	   3,   -9, 	  -1,   -7
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte    9,  -18, 	   7,  -18, 	   1,   -7, 	   1,  -10
+.2byte   -1,   -2, 	   2,    2, 	  -6,   -9, 	   0,   -6
+.2byte   -1,   -2, 	   2,    2, 	  -6,   -9, 	   0,   -6
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte    4,  -19, 	  -6,  -18, 	   4,  -12, 	  -3,  -11
+.2byte   10,   -8, 	   5,   -3, 	  -4,   -8, 	  -1,   -9
+.2byte   10,   -8, 	   5,   -3, 	  -4,   -8, 	  -1,   -9
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte   -1,  -22, 	  -9,  -16, 	   7,  -12, 	  -2,  -12
+.2byte   10,  -11, 	   6,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   10,  -11, 	   6,   -5, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte    8,  -20, 	   8,  -10, 	  -3,  -14, 	   1,  -11
+.2byte   -9,  -11, 	  -6,  -12, 	  -6,   -5, 	  -2,  -10
+.2byte   -9,  -11, 	  -6,  -12, 	  -6,   -5, 	  -2,  -10
+.2byte  -11,  -18, 	  -1,  -17, 	 -11,  -13, 	  -1,  -12
+.2byte   -1,  -22, 	   7,  -16, 	  -9,  -12, 	   0,  -12
+.2byte  -12,  -11, 	  -8,   -5, 	   1,   -5, 	  -1,  -10
+.2byte  -12,  -11, 	  -8,   -5, 	   1,   -5, 	  -1,  -10
+.2byte  -11,  -13, 	  -9,  -13, 	  -8,  -10, 	  -4,  -10
+.2byte   -6,  -19, 	   4,  -18, 	  -6,  -12, 	   1,  -11
+.2byte  -12,   -8, 	  -7,   -3, 	   2,   -8, 	  -1,   -9
+.2byte  -12,   -8, 	  -7,   -3, 	   2,   -8, 	  -1,   -9
+.2byte   -9,  -12, 	 -10,  -11, 	   2,   -9, 	  -2,   -8
+.2byte  -11,  -18, 	  -9,  -18, 	  -3,   -7, 	  -3,  -10
+.2byte   -1,   -2, 	  -4,    2, 	   4,   -9, 	  -2,   -6
+.2byte   -1,   -2, 	  -4,    2, 	   4,   -9, 	  -2,   -6
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -1,  -23, 	 -11,  -12, 	   9,  -12, 	  -1,   -8
+.2byte   -1,    1, 	 -12,   -6, 	  10,   -6, 	  -1,   -7
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte   -4,  -25, 	   6,  -16, 	 -12,  -11, 	  -2,   -9
+.2byte    9,   -5, 	  10,   -7, 	  -4,   -5, 	   2,   -8
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte   -4,  -22, 	  -3,  -15, 	  -5,   -8, 	  -2,   -8
+.2byte   14,   -9, 	   7,   -7, 	   3,   -4, 	   3,   -8
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte   -7,  -24, 	 -10,  -17, 	   7,  -10, 	  -3,  -11
+.2byte   12,  -17, 	   0,  -14, 	  10,   -7, 	   2,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte   -1,  -22, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte  -11,  -18, 	  -1,  -17, 	 -11,  -13, 	  -1,  -12
+.2byte    5,  -24, 	   8,  -17, 	  -9,  -10, 	   1,  -11
+.2byte  -14,  -17, 	  -2,  -14, 	 -12,   -7, 	  -4,  -12
+.2byte  -11,  -13, 	  -9,  -13, 	  -8,  -10, 	  -4,  -10
+.2byte    2,  -22, 	   1,  -15, 	   3,   -8, 	   0,   -8
+.2byte  -16,   -9, 	  -9,   -7, 	  -5,   -4, 	  -5,   -8
+.2byte   -9,  -12, 	 -10,  -11, 	   2,   -9, 	  -2,   -8
+.2byte    2,  -25, 	  -8,  -16, 	  10,  -11, 	   0,   -9
+.2byte  -11,   -5, 	 -12,   -7, 	   2,   -5, 	  -4,   -8
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -1,  -23, 	 -11,  -12, 	   9,  -12, 	  -1,   -8
+.2byte   -1,    1, 	 -12,   -6, 	  10,   -6, 	  -1,   -7
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte   -4,  -25, 	   6,  -16, 	 -12,  -11, 	  -2,   -9
+.2byte    9,   -5, 	  10,   -7, 	  -4,   -5, 	   2,   -8
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte   -4,  -22, 	  -3,  -15, 	  -5,   -8, 	  -2,   -8
+.2byte   14,   -9, 	   7,   -7, 	   3,   -4, 	   3,   -8
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte   -7,  -24, 	 -10,  -17, 	   7,  -10, 	  -3,  -11
+.2byte   12,  -17, 	   0,  -14, 	  10,   -7, 	   2,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte   -1,  -22, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte  -11,  -18, 	  -1,  -17, 	 -11,  -13, 	  -1,  -12
+.2byte    5,  -24, 	   8,  -17, 	  -9,  -10, 	   1,  -11
+.2byte  -14,  -17, 	  -2,  -14, 	 -12,   -7, 	  -4,  -12
+.2byte  -11,  -13, 	  -9,  -13, 	  -8,  -10, 	  -4,  -10
+.2byte    2,  -22, 	   1,  -15, 	   3,   -8, 	   0,   -8
+.2byte  -16,   -9, 	  -9,   -7, 	  -5,   -4, 	  -5,   -8
+.2byte   -9,  -12, 	 -10,  -11, 	   2,   -9, 	  -2,   -8
+.2byte    2,  -25, 	  -8,  -16, 	  10,  -11, 	   0,   -9
+.2byte  -11,   -5, 	 -12,   -7, 	   2,   -5, 	  -4,   -8
+.2byte   -6,   -9, 	  -8,   -5, 	   4,   -4, 	   1,   -8
+.2byte   -7,   -8, 	  -8,   -5, 	   4,   -3, 	   0,   -7
+.2byte   -1,  -24, 	 -10,  -13, 	   8,  -13, 	  -1,  -11
+.2byte   -5,  -25, 	   5,  -17, 	 -13,  -12, 	  -3,  -10
+.2byte  -10,  -24, 	  -7,  -12, 	  -9,   -7, 	  -7,   -9
+.2byte   -9,  -20, 	 -11,  -15, 	   4,   -8, 	  -5,   -8
+.2byte   -1,  -20, 	   9,  -12, 	 -10,  -12, 	  -1,   -6
+.2byte    8,  -20, 	  10,  -15, 	  -5,   -8, 	   4,   -8
+.2byte    9,  -24, 	   6,  -12, 	   8,   -7, 	   6,   -9
+.2byte    4,  -25, 	  -6,  -17, 	  12,  -12, 	   2,  -10
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -2,   -9, 	 -10,  -12, 	   3,   -7, 	  -2,   -6
+.2byte    0,   -9, 	  -6,   -7, 	   8,  -12, 	   1,   -6
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte    8,  -11, 	   6,   -9, 	   1,   -5, 	   1,   -7
+.2byte    7,  -10, 	  10,  -10, 	  -6,   -7, 	   0,   -7
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte   10,  -12, 	   6,  -12, 	  10,  -10, 	   4,   -9
+.2byte    9,  -11, 	   9,   -9, 	   2,   -7, 	   0,   -8
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte   10,  -17, 	  -1,  -14, 	  13,  -13, 	   1,  -11
+.2byte    8,  -17, 	  -1,  -18, 	   7,  -11, 	  -3,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -20, 	   5,  -11, 	  -6,  -19, 	  -1,   -9
+.2byte   -2,  -20, 	   4,  -19, 	  -8,  -10, 	  -1,   -9
+.2byte  -10,  -18, 	   0,  -17, 	 -10,  -13, 	   0,  -12
+.2byte  -11,  -17, 	   0,  -14, 	 -14,  -13, 	  -2,  -11
+.2byte   -8,  -17, 	   1,  -18, 	  -7,  -11, 	   3,  -12
+.2byte  -10,  -13, 	  -8,  -13, 	  -7,  -10, 	  -3,  -10
+.2byte  -11,  -12, 	  -7,  -12, 	 -11,  -10, 	  -5,   -9
+.2byte  -10,  -11, 	 -10,   -9, 	  -3,   -7, 	  -1,   -8
+.2byte   -8,  -12, 	  -9,  -11, 	   3,   -9, 	  -1,   -8
+.2byte   -9,  -11, 	  -7,   -9, 	  -2,   -5, 	  -2,   -7
+.2byte   -8,  -10, 	 -11,  -10, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    1, 	 -12,   -6, 	  10,   -6, 	  -1,   -7
+.2byte   -8,   -4, 	  -9,   -6, 	   5,   -4, 	  -1,   -7
+.2byte  -12,   -8, 	  -5,   -6, 	  -1,   -3, 	  -1,   -7
+.2byte  -11,  -15, 	   1,  -12, 	  -9,   -5, 	  -1,  -10
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte    9,  -15, 	  -3,  -12, 	   7,   -5, 	  -1,  -10
+.2byte   11,   -8, 	   4,   -6, 	   0,   -3, 	   0,   -7
+.2byte    7,   -4, 	   8,   -6, 	  -6,   -4, 	   0,   -7
+.2byte   -1,    0, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte    7,   -4, 	   8,   -6, 	  -6,   -4, 	   0,   -7
+.2byte   11,   -8, 	   4,   -6, 	   0,   -3, 	   0,   -7
+.2byte   11,  -14, 	  -1,  -11, 	   9,   -4, 	   1,   -9
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte  -12,  -14, 	   0,  -11, 	 -10,   -4, 	  -2,   -9
+.2byte  -12,   -7, 	  -5,   -5, 	  -1,   -2, 	  -1,   -6
+.2byte   -8,   -4, 	  -9,   -6, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -1,  -23, 	 -11,  -12, 	   9,  -12, 	  -1,   -8
+.2byte   -1,    1, 	 -12,   -6, 	  10,   -6, 	  -1,   -7
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte   -4,  -25, 	   6,  -16, 	 -12,  -11, 	  -2,   -9
+.2byte    7,   -5, 	   8,   -7, 	  -6,   -5, 	   0,   -8
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte   -4,  -22, 	  -3,  -15, 	  -5,   -8, 	  -2,   -8
+.2byte   12,   -9, 	   5,   -7, 	   1,   -4, 	   1,   -8
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte   -7,  -24, 	 -10,  -17, 	   7,  -10, 	  -3,  -11
+.2byte   12,  -17, 	   0,  -14, 	  10,   -7, 	   2,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte   -1,  -22, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte  -11,  -18, 	  -1,  -17, 	 -11,  -13, 	  -1,  -12
+.2byte    5,  -24, 	   8,  -17, 	  -9,  -10, 	   1,  -11
+.2byte  -14,  -17, 	  -2,  -14, 	 -12,   -7, 	  -4,  -12
+.2byte  -11,  -13, 	  -9,  -13, 	  -8,  -10, 	  -4,  -10
+.2byte    2,  -22, 	   1,  -15, 	   3,   -8, 	   0,   -8
+.2byte  -14,   -9, 	  -7,   -7, 	  -3,   -4, 	  -3,   -8
+.2byte   -9,  -12, 	 -10,  -11, 	   2,   -9, 	  -2,   -8
+.2byte    2,  -25, 	  -8,  -16, 	  10,  -11, 	   0,   -9
+.2byte   -9,   -5, 	 -10,   -7, 	   4,   -5, 	  -2,   -8
+.2byte   -1,    1, 	 -12,   -6, 	  10,   -6, 	  -1,   -7
+.2byte   -8,   -4, 	  -9,   -6, 	   5,   -4, 	  -1,   -7
+.2byte  -12,   -8, 	  -5,   -6, 	  -1,   -3, 	  -1,   -7
+.2byte  -11,  -15, 	   1,  -12, 	  -9,   -5, 	  -1,  -10
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte    9,  -15, 	  -3,  -12, 	   7,   -5, 	  -1,  -10
+.2byte   11,   -8, 	   4,   -6, 	   0,   -3, 	   0,   -7
+.2byte    7,   -4, 	   8,   -6, 	  -6,   -4, 	   0,   -7
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -9,  -12, 	 -10,  -11, 	   2,   -9, 	  -2,   -8
+.2byte  -11,  -13, 	  -9,  -13, 	  -8,  -10, 	  -4,  -10
+.2byte  -11,  -18, 	  -1,  -17, 	 -11,  -13, 	  -1,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte    9,  -18, 	  -1,  -17, 	   9,  -13, 	  -1,  -12
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte    7,  -12, 	   8,  -11, 	  -4,   -9, 	   0,   -8
+.2byte   -1,  -10, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte   -2,   -8, 	  -7,   -8, 	   4,   -9, 	  -1,   -7
+.2byte    1,  -13, 	  -8,  -18, 	   8,   -8, 	   0,   -9
+.2byte    1,  -13, 	  -7,  -20, 	   8,   -8, 	   0,   -9
+.2byte  -11,  -13, 	  -9,  -13, 	  -8,  -10, 	  -4,  -10
+.2byte  -13,  -11, 	 -10,  -10, 	  -9,   -6, 	  -3,   -9
+.2byte  -13,   -6, 	 -11,   -8, 	  -9,   -3, 	  -3,   -9
+.2byte   -9,   -2, 	 -11,   -3, 	  -7,    1, 	  -3,   -6
+.2byte    9,  -13, 	   7,  -13, 	   6,  -10, 	   2,  -10
+.2byte   10,  -11, 	   7,  -10, 	   6,   -6, 	   0,   -9
+.2byte   10,   -6, 	   8,   -8, 	   6,   -3, 	   0,   -9
+.2byte    6,   -2, 	   8,   -3, 	   4,    1, 	   0,   -6
+.2byte  -11,   -7, 	  -7,   -6, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -8, 	  -8,   -6, 	  -4,   -3, 	   0,  -10
+.2byte  -11,   -8, 	  -9,   -7, 	  -7,   -3, 	  -1,   -9
+.2byte   10,   -7, 	   6,   -6, 	   4,   -3, 	   1,   -9
+.2byte   10,   -8, 	   7,   -6, 	   3,   -3, 	  -1,  -10
+.2byte   10,   -8, 	   8,   -7, 	   6,   -3, 	   0,   -9
+.2byte  -11,   -7, 	  -7,   -6, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -8, 	  -8,   -6, 	  -4,   -3, 	   0,  -10
+.2byte  -11,   -8, 	  -9,   -7, 	  -7,   -3, 	  -1,   -9
+.2byte   -9,   -2, 	 -11,   -3, 	  -7,    1, 	  -3,   -6
+.2byte   10,   -7, 	   6,   -6, 	   4,   -3, 	   1,   -9
+.2byte   10,   -8, 	   7,   -6, 	   3,   -3, 	  -1,  -10
+.2byte   10,   -8, 	   8,   -7, 	   6,   -3, 	   0,   -9
+.2byte    7,   -2, 	   9,   -3, 	   5,    1, 	   1,   -6
+sCharizardAnimTable1:
+.4byte sCharizardAnims_1_1
+.4byte sCharizardAnims_1_2
+.4byte sCharizardAnims_1_3
+.4byte sCharizardAnims_1_4
+.4byte sCharizardAnims_1_5
+.4byte sCharizardAnims_1_6
+.4byte sCharizardAnims_1_7
+.4byte sCharizardAnims_1_8
+sCharizardAnimTable2:
+.4byte sCharizardAnims_2_1
+.4byte sCharizardAnims_2_2
+.4byte sCharizardAnims_2_3
+.4byte sCharizardAnims_2_4
+.4byte sCharizardAnims_2_5
+.4byte sCharizardAnims_2_6
+.4byte sCharizardAnims_2_7
+.4byte sCharizardAnims_2_8
+sCharizardAnimTable3:
+.4byte sCharizardAnims_3_1
+.4byte sCharizardAnims_3_2
+.4byte sCharizardAnims_3_3
+.4byte sCharizardAnims_3_4
+.4byte sCharizardAnims_3_5
+.4byte sCharizardAnims_3_6
+.4byte sCharizardAnims_3_7
+.4byte sCharizardAnims_3_8
+sCharizardAnimTable4:
+.4byte sCharizardAnims_4_1
+.4byte sCharizardAnims_4_2
+.4byte sCharizardAnims_4_3
+.4byte sCharizardAnims_4_4
+.4byte sCharizardAnims_4_5
+.4byte sCharizardAnims_4_6
+.4byte sCharizardAnims_4_7
+.4byte sCharizardAnims_4_8
+sCharizardAnimTable5:
+.4byte sCharizardAnims_5_1
+.4byte sCharizardAnims_5_2
+.4byte sCharizardAnims_5_3
+.4byte sCharizardAnims_5_4
+.4byte sCharizardAnims_5_5
+.4byte sCharizardAnims_5_6
+.4byte sCharizardAnims_5_7
+.4byte sCharizardAnims_5_8
+sCharizardAnimTable6:
+.4byte sCharizardAnims_6_1
+.4byte sCharizardAnims_6_1
+.4byte sCharizardAnims_6_1
+.4byte sCharizardAnims_6_1
+.4byte sCharizardAnims_6_1
+.4byte sCharizardAnims_6_1
+.4byte sCharizardAnims_6_1
+.4byte sCharizardAnims_6_1
+sCharizardAnimTable7:
+.4byte sCharizardAnims_7_1
+.4byte sCharizardAnims_7_2
+.4byte sCharizardAnims_7_3
+.4byte sCharizardAnims_7_4
+.4byte sCharizardAnims_7_5
+.4byte sCharizardAnims_7_6
+.4byte sCharizardAnims_7_7
+.4byte sCharizardAnims_7_8
+sCharizardAnimTable8:
+.4byte sCharizardAnims_8_1
+.4byte sCharizardAnims_8_2
+.4byte sCharizardAnims_8_3
+.4byte sCharizardAnims_8_4
+.4byte sCharizardAnims_8_5
+.4byte sCharizardAnims_8_6
+.4byte sCharizardAnims_8_7
+.4byte sCharizardAnims_8_8
+sCharizardAnimTable9:
+.4byte sCharizardAnims_9_1
+.4byte sCharizardAnims_9_2
+.4byte sCharizardAnims_9_3
+.4byte sCharizardAnims_9_4
+.4byte sCharizardAnims_9_5
+.4byte sCharizardAnims_9_6
+.4byte sCharizardAnims_9_7
+.4byte sCharizardAnims_9_8
+sCharizardAnimTable10:
+.4byte sCharizardAnims_10_1
+.4byte sCharizardAnims_10_2
+.4byte sCharizardAnims_10_3
+.4byte sCharizardAnims_10_4
+.4byte sCharizardAnims_10_5
+.4byte sCharizardAnims_10_6
+.4byte sCharizardAnims_10_7
+.4byte sCharizardAnims_10_8
+sCharizardAnimTable11:
+.4byte sCharizardAnims_11_1
+.4byte sCharizardAnims_11_2
+.4byte sCharizardAnims_11_3
+.4byte sCharizardAnims_11_4
+.4byte sCharizardAnims_11_5
+.4byte sCharizardAnims_11_6
+.4byte sCharizardAnims_11_7
+.4byte sCharizardAnims_11_8
+sCharizardAnimTable12:
+.4byte sCharizardAnims_12_1
+.4byte sCharizardAnims_12_2
+.4byte sCharizardAnims_12_3
+.4byte sCharizardAnims_12_4
+.4byte sCharizardAnims_12_5
+.4byte sCharizardAnims_12_6
+.4byte sCharizardAnims_12_7
+.4byte sCharizardAnims_12_8
+sCharizardAnimTable13:
+.4byte sCharizardAnims_13_1
+.4byte sCharizardAnims_13_2
+.4byte sCharizardAnims_13_3
+.4byte sCharizardAnims_13_4
+.4byte sCharizardAnims_13_5
+.4byte sCharizardAnims_13_6
+.4byte sCharizardAnims_13_7
+.4byte sCharizardAnims_13_8
+sCharizardAnimTable14:
+.4byte sCharizardAnims_14_1
+.4byte sCharizardAnims_14_2
+.4byte sCharizardAnims_14_3
+.4byte sCharizardAnims_14_4
+.4byte sCharizardAnims_14_5
+.4byte sCharizardAnims_14_6
+.4byte sCharizardAnims_14_7
+.4byte sCharizardAnims_14_8
+sCharizardAnimTable15:
+.4byte sCharizardAnims_15_1
+.4byte sCharizardAnims_15_2
+.4byte sCharizardAnims_15_3
+.4byte sCharizardAnims_15_4
+.4byte sCharizardAnims_15_5
+.4byte sCharizardAnims_15_6
+.4byte sCharizardAnims_15_7
+.4byte sCharizardAnims_15_8
+sCharizardAnimTable16:
+.4byte sCharizardAnims_16_1
+.4byte sCharizardAnims_16_2
+.4byte sCharizardAnims_16_3
+.4byte sCharizardAnims_16_4
+.4byte sCharizardAnims_16_5
+.4byte sCharizardAnims_16_6
+.4byte sCharizardAnims_16_7
+.4byte sCharizardAnims_16_8
+sCharizardAnimTable17:
+.4byte sCharizardAnims_17_1
+.4byte sCharizardAnims_17_2
+.4byte sCharizardAnims_17_3
+.4byte sCharizardAnims_17_4
+.4byte sCharizardAnims_17_5
+.4byte sCharizardAnims_17_6
+.4byte sCharizardAnims_17_7
+.4byte sCharizardAnims_17_8
+sAxAnimationsCharizard:
+.4byte sCharizardAnimTable1
+.4byte sCharizardAnimTable2
+.4byte sCharizardAnimTable3
+.4byte sCharizardAnimTable4
+.4byte sCharizardAnimTable5
+.4byte sCharizardAnimTable6
+.4byte sCharizardAnimTable7
+.4byte sCharizardAnimTable8
+.4byte sCharizardAnimTable9
+.4byte sCharizardAnimTable10
+.4byte sCharizardAnimTable11
+.4byte sCharizardAnimTable12
+.4byte sCharizardAnimTable13
+.4byte sCharizardAnimTable14
+.4byte sCharizardAnimTable15
+.4byte sCharizardAnimTable16
+.4byte sCharizardAnimTable17
+sAxSpritesCharizard:
+.4byte sCharizardSprites1
+.4byte sCharizardSprites2
+.4byte sCharizardSprites3
+.4byte sCharizardSprites4
+.4byte sCharizardSprites5
+.4byte sCharizardSprites6
+.4byte sCharizardSprites7
+.4byte sCharizardSprites8
+.4byte sCharizardSprites9
+.4byte sCharizardSprites10
+.4byte sCharizardSprites11
+.4byte sCharizardSprites12
+.4byte sCharizardSprites13
+.4byte sCharizardSprites14
+.4byte sCharizardSprites15
+.4byte sCharizardSprites16
+.4byte sCharizardSprites17
+.4byte sCharizardSprites18
+.4byte sCharizardSprites19
+.4byte sCharizardSprites20
+.4byte sCharizardSprites21
+.4byte sCharizardSprites22
+.4byte sCharizardSprites23
+.4byte sCharizardSprites24
+.4byte sCharizardSprites25
+.4byte sCharizardSprites26
+.4byte sCharizardSprites27
+.4byte sCharizardSprites28
+.4byte sCharizardSprites29
+.4byte sCharizardSprites30
+.4byte sCharizardSprites31
+.4byte sCharizardSprites32
+.4byte sCharizardSprites33
+.4byte sCharizardSprites34
+.4byte sCharizardSprites35
+.4byte sCharizardSprites36
+.4byte sCharizardSprites37
+.4byte sCharizardSprites38
+.4byte sCharizardSprites39
+.4byte sCharizardSprites40
+.4byte sCharizardSprites41
+.4byte sCharizardSprites42
+.4byte sCharizardSprites43
+.4byte sCharizardSprites44
+.4byte sCharizardSprites45
+.4byte sCharizardSprites46
+.4byte sCharizardSprites47
+.4byte sCharizardSprites48
+.4byte sCharizardSprites49
+.4byte sCharizardSprites50
+.4byte sCharizardSprites51
+.4byte sCharizardSprites52
+.4byte sCharizardSprites53
+.4byte sCharizardSprites54
+.4byte sCharizardSprites55
+.4byte sCharizardSprites56
+.4byte sCharizardSprites57
+.4byte sCharizardSprites58
+.4byte sCharizardSprites59
+.4byte sCharizardSprites60
+.4byte sCharizardSprites61
+.4byte sCharizardSprites62
+.4byte sCharizardSprites63
+.4byte sCharizardSprites64
+.4byte sCharizardSprites65
+.4byte sCharizardSprites66
+.4byte sCharizardSprites67
+.4byte sCharizardSprites68
+.4byte sCharizardSprites69
+.4byte sCharizardSprites70
+.4byte sCharizardSprites71
+.4byte sCharizardSprites72
+.4byte sCharizardSprites73
+.4byte sCharizardSprites74
+.4byte sCharizardSprites75
+.4byte sCharizardSprites76
+.4byte sCharizardSprites77
+.4byte sCharizardSprites78
+.4byte sCharizardSprites79
+.4byte sCharizardSprites80
+.4byte sCharizardSprites81
+.4byte sCharizardSprites82
+.4byte sCharizardSprites83
+sAxMainCharizard:
+ax_main sAxPosesCharizard, sAxAnimationsCharizard, 17, sAxSpritesCharizard, sAxPositionsCharizard

--- a/data/ax/charmander.inc
+++ b/data/ax/charmander.inc
@@ -1,0 +1,4307 @@
+.global gAxCharmander
+gAxCharmander:
+ax_siro sAxMainCharmander
+sCharmanderPose1:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose2:
+ax_pose 1, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose3:
+ax_pose 2, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose4:
+ax_pose 3, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose5:
+ax_pose 4, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose6:
+ax_pose 5, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose7:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose8:
+ax_pose 7, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose9:
+ax_pose 8, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose10:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose11:
+ax_pose 10, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose12:
+ax_pose 11, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose13:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose14:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose15:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose16:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose17:
+ax_pose 10, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose18:
+ax_pose 11, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose19:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose20:
+ax_pose 7, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose21:
+ax_pose 8, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose22:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose23:
+ax_pose 4, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose24:
+ax_pose 5, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose25:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose26:
+ax_pose 1, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose27:
+ax_pose 2, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose28:
+ax_pose 3, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose29:
+ax_pose 4, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose30:
+ax_pose 5, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose31:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose32:
+ax_pose 7, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose33:
+ax_pose 8, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose34:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose35:
+ax_pose 10, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose36:
+ax_pose 11, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose37:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose38:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose39:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose40:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose41:
+ax_pose 10, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose42:
+ax_pose 11, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose43:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose44:
+ax_pose 7, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose45:
+ax_pose 8, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose46:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose47:
+ax_pose 4, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose48:
+ax_pose 5, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose49:
+ax_pose 15, 0x81eb, 0x80f4, 0x2c00
+ax_pose 16, 0x01ed, 0x80f5, 0x2c08
+ax_pose_terminator
+sCharmanderPose50:
+ax_pose 16, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose51:
+ax_pose 17, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose52:
+ax_pose 0, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose53:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose54:
+ax_pose 13, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose55:
+ax_pose 10, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose56:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose57:
+ax_pose 18, 0x01ea, 0x50fe, 0x2c00
+ax_pose 19, 0x41fa, 0x10fe, 0x2c04
+ax_pose 20, 0x01eb, 0x90ec, 0x2c06
+ax_pose_terminator
+sCharmanderPose58:
+ax_pose 20, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose59:
+ax_pose 21, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose60:
+ax_pose 5, 0x01e8, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose61:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose62:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose63:
+ax_pose 14, 0x81eb, 0x90f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose64:
+ax_pose 22, 0x01ec, 0x5100, 0x2c00
+ax_pose 23, 0x01ec, 0x90f0, 0x2c04
+ax_pose_terminator
+sCharmanderPose65:
+ax_pose 23, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharmanderPose66:
+ax_pose 24, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose67:
+ax_pose 25, 0x01ed, 0x90e4, 0x2c00
+ax_pose_terminator
+sCharmanderPose68:
+ax_pose 5, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose69:
+ax_pose 8, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose70:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose71:
+ax_pose 26, 0x01ed, 0x90ee, 0x2c00
+ax_pose 27, 0x41ed, 0x90ee, 0x2c10
+ax_pose_terminator
+sCharmanderPose72:
+ax_pose 26, 0x01ed, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharmanderPose73:
+ax_pose 25, 0x01ee, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose74:
+ax_pose 13, 0x81ee, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose75:
+ax_pose 5, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose76:
+ax_pose 2, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose77:
+ax_pose 8, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose78:
+ax_pose 28, 0x01ee, 0x40fd, 0x2c00
+ax_pose 29, 0x41fe, 0x00fd, 0x2c04
+ax_pose 30, 0x01ee, 0x80f1, 0x2c06
+ax_pose_terminator
+sCharmanderPose79:
+ax_pose 30, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose80:
+ax_pose 24, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose81:
+ax_pose 14, 0x81f1, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose82:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharmanderPose83:
+ax_pose 4, 0x01ee, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose84:
+ax_pose 8, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose85:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose86:
+ax_pose 26, 0x01ed, 0x80f2, 0x2c00
+ax_pose 27, 0x41ed, 0x80f2, 0x2c10
+ax_pose_terminator
+sCharmanderPose87:
+ax_pose 26, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose88:
+ax_pose 25, 0x01ee, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose89:
+ax_pose 13, 0x81ee, 0x90fb, 0x2c00
+ax_pose_terminator
+sCharmanderPose90:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose91:
+ax_pose 2, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose92:
+ax_pose 8, 0x01ed, 0x90f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose93:
+ax_pose 22, 0x01ec, 0x40f0, 0x2c00
+ax_pose 23, 0x01ec, 0x80f0, 0x2c04
+ax_pose_terminator
+sCharmanderPose94:
+ax_pose 23, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharmanderPose95:
+ax_pose 24, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharmanderPose96:
+ax_pose 25, 0x01ed, 0x80fc, 0x2c00
+ax_pose_terminator
+sCharmanderPose97:
+ax_pose 5, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose98:
+ax_pose 8, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose99:
+ax_pose 11, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose100:
+ax_pose 18, 0x01ea, 0x40f2, 0x2c00
+ax_pose 19, 0x41fa, 0x00f2, 0x2c04
+ax_pose 20, 0x01eb, 0x80f4, 0x2c06
+ax_pose_terminator
+sCharmanderPose101:
+ax_pose 20, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose102:
+ax_pose 21, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose103:
+ax_pose 5, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose104:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose105:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose106:
+ax_pose 14, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose107:
+ax_pose 31, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose108:
+ax_pose 32, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose109:
+ax_pose 33, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose110:
+ax_pose 34, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose111:
+ax_pose 35, 0x01ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose112:
+ax_pose 34, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose113:
+ax_pose 33, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose114:
+ax_pose 32, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose115:
+ax_pose 17, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose116:
+ax_pose 36, 0x81ec, 0x80f6, 0x2c00
+ax_pose 37, 0x01ee, 0x80f1, 0x2c08
+ax_pose_terminator
+sCharmanderPose117:
+ax_pose 37, 0x01ef, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose118:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose119:
+ax_pose 21, 0x01ee, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose120:
+ax_pose 38, 0x41f1, 0x90f0, 0x2c00
+ax_pose 39, 0x01ee, 0x90ed, 0x2c08
+ax_pose_terminator
+sCharmanderPose121:
+ax_pose 39, 0x01ee, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose122:
+ax_pose 5, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose123:
+ax_pose 25, 0x01ec, 0x90e8, 0x2c00
+ax_pose_terminator
+sCharmanderPose124:
+ax_pose 40, 0x41f1, 0x50ef, 0x2c00
+ax_pose 41, 0x01ed, 0x90ed, 0x2c04
+ax_pose_terminator
+sCharmanderPose125:
+ax_pose 41, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose126:
+ax_pose 7, 0x01ec, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose127:
+ax_pose 24, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose128:
+ax_pose 42, 0x01ee, 0x50f2, 0x2c00
+ax_pose 43, 0x01ec, 0x90ec, 0x2c04
+ax_pose_terminator
+sCharmanderPose129:
+ax_pose 43, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose130:
+ax_pose 10, 0x01ee, 0x90e8, 0x2c00
+ax_pose_terminator
+sCharmanderPose131:
+ax_pose 44, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose132:
+ax_pose 45, 0x01ef, 0x40fd, 0x2c00
+ax_pose 46, 0x01ed, 0x80f6, 0x2c04
+ax_pose_terminator
+sCharmanderPose133:
+ax_pose 46, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose134:
+ax_pose 14, 0x81f1, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose135:
+ax_pose 24, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose136:
+ax_pose 42, 0x01ee, 0x40fe, 0x2c00
+ax_pose 43, 0x01ec, 0x80f4, 0x2c04
+ax_pose_terminator
+sCharmanderPose137:
+ax_pose 43, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose138:
+ax_pose 10, 0x01ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose139:
+ax_pose 25, 0x01ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose140:
+ax_pose 41, 0x01ed, 0x80f3, 0x2c00
+ax_pose 40, 0x41f1, 0x40f1, 0x2c10
+ax_pose_terminator
+sCharmanderPose141:
+ax_pose 41, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose142:
+ax_pose 7, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose143:
+ax_pose 21, 0x01ee, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose144:
+ax_pose 38, 0x41f1, 0x80f0, 0x2c00
+ax_pose 39, 0x01ee, 0x80f3, 0x2c08
+ax_pose_terminator
+sCharmanderPose145:
+ax_pose 39, 0x01ee, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose146:
+ax_pose 5, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose147:
+ax_pose 47, 0x01ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose148:
+ax_pose 48, 0x01ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose149:
+ax_pose 49, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharmanderPose150:
+ax_pose 50, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharmanderPose151:
+ax_pose 51, 0x01e4, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose152:
+ax_pose 52, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose153:
+ax_pose 53, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose154:
+ax_pose 52, 0x01e2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose155:
+ax_pose 51, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose156:
+ax_pose 50, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose157:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose158:
+ax_pose 1, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose159:
+ax_pose 2, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose160:
+ax_pose 3, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose161:
+ax_pose 4, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose162:
+ax_pose 5, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose163:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose164:
+ax_pose 7, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose165:
+ax_pose 8, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose166:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose167:
+ax_pose 10, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose168:
+ax_pose 11, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose169:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose170:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose171:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose172:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose173:
+ax_pose 10, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose174:
+ax_pose 11, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose175:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose176:
+ax_pose 7, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose177:
+ax_pose 8, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose178:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose179:
+ax_pose 4, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose180:
+ax_pose 5, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose181:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose182:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose183:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose184:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose185:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose186:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose187:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose188:
+ax_pose 3, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose189:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose190:
+ax_pose 3, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose191:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose192:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose193:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose194:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose195:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose196:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose197:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose198:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose199:
+ax_pose 31, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose200:
+ax_pose 3, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose201:
+ax_pose 5, 0x01ec, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose202:
+ax_pose 32, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose203:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose204:
+ax_pose 7, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose205:
+ax_pose 33, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose206:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose207:
+ax_pose 10, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose208:
+ax_pose 34, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose209:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose210:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose211:
+ax_pose 35, 0x01ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose212:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose213:
+ax_pose 10, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose214:
+ax_pose 34, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose215:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose216:
+ax_pose 7, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose217:
+ax_pose 33, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose218:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose219:
+ax_pose 5, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose220:
+ax_pose 32, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose221:
+ax_pose 31, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose222:
+ax_pose 32, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose223:
+ax_pose 33, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose224:
+ax_pose 34, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose225:
+ax_pose 35, 0x01ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCharmanderPose226:
+ax_pose 34, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose227:
+ax_pose 33, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose228:
+ax_pose 32, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose229:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose230:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sCharmanderPose231:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose232:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose233:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose234:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose235:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose236:
+ax_pose 3, 0x01ed, 0x90e9, 0x2c00
+ax_pose_terminator
+sCharmanderPose237:
+ax_pose 54, 0x01f1, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose238:
+ax_pose 55, 0x01f1, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose239:
+ax_pose 54, 0x01f1, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharmanderPose240:
+ax_pose 55, 0x01f1, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose241:
+ax_pose 54, 0x01f1, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose242:
+ax_pose 56, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose243:
+ax_pose 57, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharmanderPose244:
+ax_pose 58, 0x01e9, 0x80ee, 0x2c00
+ax_pose_terminator
+sCharmanderPose245:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose246:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose247:
+ax_pose 59, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose248:
+ax_pose 60, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose249:
+ax_pose 61, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose250:
+ax_pose 62, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose251:
+ax_pose 63, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose252:
+ax_pose 64, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose253:
+ax_pose 65, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose254:
+ax_pose 66, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose255:
+ax_pose 67, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose256:
+ax_pose 67, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose257:
+ax_pose 68, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose258:
+ax_pose 69, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose259:
+ax_pose 70, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose260:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose261:
+ax_pose 71, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sCharmanderPose262:
+ax_pose 72, 0x01e9, 0x80ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose263:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose264:
+ax_pose 73, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose265:
+ax_pose 74, 0x01f0, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose266:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose267:
+ax_pose 62, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose268:
+ax_pose 75, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose269:
+ax_pose 6, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose270:
+ax_pose 76, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose271:
+ax_pose 6, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sCharmanderPose272:
+ax_pose 76, 0x01ed, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharmanderPose273:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCharmanderPose274:
+ax_pose 77, 0x01ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose275:
+ax_pose 78, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose276:
+ax_pose 79, 0x01ec, 0x80ef, 0x2c00
+ax_pose_terminator
+sCharmanderPose277:
+ax_pose 80, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose278:
+ax_pose 81, 0x01ec, 0x80ee, 0x2c00
+ax_pose_terminator
+sCharmanderPose279:
+ax_pose 82, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sCharmanderPose280:
+ax_pose 78, 0x01ec, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharmanderPose281:
+ax_pose 79, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sCharmanderPose282:
+ax_pose 80, 0x01ec, 0x90ee, 0x2c00
+ax_pose_terminator
+sCharmanderPose283:
+ax_pose 81, 0x01ec, 0x90f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose284:
+ax_pose 82, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose285:
+ax_pose 9, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sCharmanderPose286:
+ax_pose 83, 0x01f1, 0x80f3, 0x2c00
+ax_pose_terminator
+sCharmanderPose287:
+ax_pose 9, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sCharmanderPose288:
+ax_pose 83, 0x01ef, 0x90ed, 0x2c00
+ax_pose_terminator
+sCharmanderPose289:
+ax_pose 54, 0x01f1, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose290:
+ax_pose 55, 0x01f1, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose291:
+ax_pose 54, 0x01f1, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharmanderPose292:
+ax_pose 55, 0x01f1, 0x90ec, 0x2c00
+ax_pose_terminator
+sCharmanderPose293:
+ax_pose 54, 0x01f1, 0x80f1, 0x2c00
+ax_pose_terminator
+sCharmanderPose294:
+ax_pose 55, 0x01f1, 0x80f4, 0x2c00
+ax_pose_terminator
+sCharmanderPose295:
+ax_pose 54, 0x01f1, 0x90ef, 0x2c00
+ax_pose_terminator
+sCharmanderPose296:
+ax_pose 55, 0x01f1, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sCharmanderAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 4, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 0, 26, 0, 8, 0, 8,
+ax_anim 2, 2, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 1, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCharmanderAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 4, 0, 28, -3, -3, -3, -3,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim 2, 2, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 17, 19, 17, 19,
+ax_anim 2, 1, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 17, 19, 17, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sCharmanderAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -2, 0, -2, 0,
+ax_anim 4, 0, 31, -3, 0, -3, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 0, 32, 8, 0, 8, 0,
+ax_anim 2, 2, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, -1, 18, -1,
+ax_anim 2, 1, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, -1, 18, -1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sCharmanderAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -2, 2, -2, 2,
+ax_anim 4, 0, 34, -3, 3, -3, 3,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim 2, 0, 35, 8, -8, 8, -8,
+ax_anim 2, 2, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 17, -19, 17, -19,
+ax_anim 2, 1, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 17, -19, 17, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sCharmanderAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 4, 0, 37, 0, 3, 0, 3,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 0, 38, 0, -8, 0, -8,
+ax_anim 2, 2, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 2, 1, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sCharmanderAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 2, 2, 2, 2,
+ax_anim 4, 0, 40, 3, 3, 3, 3,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim 2, 0, 41, -8, -8, -8, -8,
+ax_anim 2, 2, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -17, -19, -17, -19,
+ax_anim 2, 1, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -17, -19, -17, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sCharmanderAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 2, 0, 2, 0,
+ax_anim 4, 0, 43, 3, 0, 3, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 0, 44, -8, 0, -8, 0,
+ax_anim 2, 2, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, -1, -18, -1,
+ax_anim 2, 1, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, -1, -18, -1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sCharmanderAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 2, -2, 2, -2,
+ax_anim 4, 0, 46, 3, -3, 3, -3,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 46, -4, 4, -4, 4,
+ax_anim 2, 0, 47, -8, 8, -8, 8,
+ax_anim 2, 2, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_3_1:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 6, 0, 50, 1, -1, 1, -1,
+ax_anim 2, 0, 51, 0, 6, 0, 6,
+ax_anim 4, 2, 48, 0, 11, 0, 11,
+ax_anim 2, 0, 49, -1, 12, -1, 12,
+ax_anim 2, 1, 49, 0, 12, 0, 12,
+ax_anim 2, 0, 49, -1, 12, -1, 12,
+ax_anim 2, 0, 49, 0, 12, 0, 12,
+ax_anim 2, 0, 52, 2, 6, 2, 6,
+ax_anim 2, 0, 53, 2, 3, 2, 3,
+ax_anim 2, 0, 54, 0, 1, 0, 1,
+ax_anim_terminator
+sCharmanderAnims_3_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 6, 0, 58, -1, -1, -1, -1,
+ax_anim 2, 0, 59, 6, 5, 6, 5,
+ax_anim 4, 2, 56, 11, 11, 11, 11,
+ax_anim 2, 0, 57, 12, 12, 12, 12,
+ax_anim 2, 1, 57, 11, 13, 11, 13,
+ax_anim 2, 0, 57, 12, 12, 12, 12,
+ax_anim 2, 0, 57, 11, 13, 11, 13,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim 2, 0, 61, 3, 3, 3, 3,
+ax_anim 2, 0, 62, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_3_3:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 6, 0, 65, -1, 0, -1, 0,
+ax_anim 2, 0, 66, 6, 0, 6, 0,
+ax_anim 4, 2, 63, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 11, 1, 11, 1,
+ax_anim 2, 1, 64, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 11, 1, 11, 1,
+ax_anim 2, 0, 64, 11, 0, 11, 0,
+ax_anim 2, 0, 67, 6, 0, 6, 0,
+ax_anim 2, 0, 68, 3, 0, 3, 0,
+ax_anim 2, 0, 69, 1, 0, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_3_4:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 6, 0, 72, -1, 1, -1, 1,
+ax_anim 2, 0, 73, 6, -5, 6, -5,
+ax_anim 4, 2, 70, 11, -11, 11, -11,
+ax_anim 2, 0, 71, 12, -12, 12, -12,
+ax_anim 2, 1, 71, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 11, -13, 11, -13,
+ax_anim 2, 0, 74, 6, -6, 6, -6,
+ax_anim 2, 0, 75, 3, -3, 3, -3,
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim_terminator
+sCharmanderAnims_3_5:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 6, 0, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 80, 0, -6, 0, -6,
+ax_anim 4, 2, 77, 0, -11, 0, -11,
+ax_anim 2, 0, 78, 1, -12, 1, -12,
+ax_anim 2, 1, 78, 0, -12, 0, -12,
+ax_anim 2, 0, 78, 1, -12, 1, -12,
+ax_anim 2, 0, 78, 0, -12, 0, -12,
+ax_anim 2, 0, 81, 2, -6, 2, -6,
+ax_anim 2, 0, 82, 2, -3, 2, -3,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim_terminator
+sCharmanderAnims_3_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 6, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 88, -6, -5, -6, -5,
+ax_anim 4, 2, 85, -11, -11, -11, -11,
+ax_anim 2, 0, 86, -12, -12, -12, -12,
+ax_anim 2, 1, 86, -11, -13, -11, -13,
+ax_anim 2, 0, 86, -12, -12, -12, -12,
+ax_anim 2, 0, 86, -11, -13, -11, -13,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 90, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim_terminator
+sCharmanderAnims_3_7:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 94, 1, 0, 1, 0,
+ax_anim 2, 0, 95, -6, 0, -6, 0,
+ax_anim 4, 2, 92, -11, 0, -11, 0,
+ax_anim 2, 0, 93, -11, 1, -11, 1,
+ax_anim 2, 1, 93, -11, 0, -11, 0,
+ax_anim 2, 0, 93, -11, 1, -11, 1,
+ax_anim 2, 0, 93, -11, 0, -11, 0,
+ax_anim 2, 0, 96, -6, 0, -6, 0,
+ax_anim 2, 0, 97, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_3_8:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 102, -6, 5, -6, 5,
+ax_anim 4, 2, 99, -11, 11, -11, 11,
+ax_anim 2, 0, 100, -12, 12, -12, 12,
+ax_anim 2, 1, 100, -11, 13, -11, 13,
+ax_anim 2, 0, 100, -12, 12, -12, 12,
+ax_anim 2, 0, 100, -11, 13, -11, 13,
+ax_anim 2, 0, 103, -6, 6, -6, 6,
+ax_anim 2, 0, 104, -3, 3, -3, 3,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_4_1:
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_4_2:
+ax_anim 2, 0, 113, 1, -1, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, 0,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_4_3:
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_4_4:
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_4_5:
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_4_6:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_4_7:
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_4_8:
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_5_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, -1, 1, -1,
+ax_anim 2, 0, 114, -1, 6, -1, 6,
+ax_anim 4, 2, 115, 1, 11, 1, 11,
+ax_anim 2, 1, 116, 1, 11, 1, 11,
+ax_anim 2, 0, 116, 2, 11, 2, 11,
+ax_anim 2, 0, 116, 1, 11, 1, 11,
+ax_anim 2, 0, 116, 2, 11, 2, 11,
+ax_anim 2, 0, 117, 1, 8, 1, 8,
+ax_anim_terminator
+sCharmanderAnims_5_2:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 118, -1, -1, -1, -1,
+ax_anim 2, 0, 118, 6, 6, 6, 6,
+ax_anim 4, 2, 119, 11, 11, 11, 11,
+ax_anim 2, 1, 120, 11, 11, 11, 11,
+ax_anim 2, 0, 120, 10, 12, 10, 12,
+ax_anim 2, 0, 120, 11, 11, 11, 11,
+ax_anim 2, 0, 120, 10, 12, 10, 12,
+ax_anim 2, 0, 121, 8, 8, 8, 8,
+ax_anim_terminator
+sCharmanderAnims_5_3:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 122, -1, 0, -1, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 4, 2, 123, 11, 0, 11, 0,
+ax_anim 2, 1, 124, 11, 0, 11, 0,
+ax_anim 2, 0, 124, 11, 1, 11, 1,
+ax_anim 2, 0, 124, 11, 0, 11, 0,
+ax_anim 2, 0, 124, 11, 1, 11, 1,
+ax_anim 2, 0, 125, 8, 0, 8, 0,
+ax_anim_terminator
+sCharmanderAnims_5_4:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 126, -1, 1, -1, 1,
+ax_anim 2, 0, 126, 6, -6, 6, -6,
+ax_anim 4, 2, 127, 11, -11, 11, -11,
+ax_anim 2, 1, 128, 11, -11, 11, -11,
+ax_anim 2, 0, 128, 10, -12, 10, -12,
+ax_anim 2, 0, 128, 11, -11, 11, -11,
+ax_anim 2, 0, 128, 10, -12, 10, -12,
+ax_anim 2, 0, 129, 8, -8, 6, -6,
+ax_anim_terminator
+sCharmanderAnims_5_5:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 130, 0, 1, 1, 1,
+ax_anim 2, 0, 130, 1, -6, 1, -6,
+ax_anim 4, 2, 131, 0, -11, 0, -11,
+ax_anim 2, 1, 132, 0, -11, 0, -11,
+ax_anim 2, 0, 132, 1, -11, 1, -11,
+ax_anim 2, 0, 132, 0, -11, 0, -11,
+ax_anim 2, 0, 132, 1, -11, 1, -11,
+ax_anim 2, 0, 133, 0, -8, 0, -4,
+ax_anim_terminator
+sCharmanderAnims_5_6:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 1, 1, 1, 1,
+ax_anim 2, 0, 134, -6, -6, -6, -6,
+ax_anim 4, 2, 135, -11, -11, -11, -11,
+ax_anim 2, 1, 136, -11, -11, -11, -11,
+ax_anim 2, 0, 136, -10, -12, -10, -12,
+ax_anim 2, 0, 136, -11, -11, -11, -11,
+ax_anim 2, 0, 136, -10, -12, -10, -12,
+ax_anim 2, 0, 137, -8, -8, -6, -6,
+ax_anim_terminator
+sCharmanderAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 4, 2, 139, -11, 0, -11, 0,
+ax_anim 2, 1, 140, -11, 0, -11, 0,
+ax_anim 2, 0, 140, -11, 1, -11, 1,
+ax_anim 2, 0, 140, -11, 0, -11, 0,
+ax_anim 2, 0, 140, -11, 1, -11, 1,
+ax_anim 2, 0, 141, -8, 0, -8, 0,
+ax_anim_terminator
+sCharmanderAnims_5_8:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, -6, 6, -6, 6,
+ax_anim 4, 2, 143, -11, 11, -11, 11,
+ax_anim 2, 1, 144, -11, 11, -11, 11,
+ax_anim 2, 0, 144, -10, 12, -10, 12,
+ax_anim 2, 0, 144, -11, 11, -11, 11,
+ax_anim 2, 0, 144, -10, 12, -10, 12,
+ax_anim 2, 0, 145, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_6_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 35, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_7_1:
+ax_anim 2, 0, 148, 0, -2, 0, -2,
+ax_anim 8, 0, 148, 0, -3, 0, -3,
+ax_anim_terminator
+sCharmanderAnims_7_2:
+ax_anim 2, 0, 149, -2, -2, -2, -2,
+ax_anim 8, 0, 149, -3, -3, -3, -3,
+ax_anim_terminator
+sCharmanderAnims_7_3:
+ax_anim 2, 0, 150, -2, 0, -2, 0,
+ax_anim 8, 0, 150, -3, 0, -3, 0,
+ax_anim_terminator
+sCharmanderAnims_7_4:
+ax_anim 2, 0, 151, -2, 2, -2, 2,
+ax_anim 8, 0, 151, -3, 3, -3, 3,
+ax_anim_terminator
+sCharmanderAnims_7_5:
+ax_anim 2, 0, 152, 0, 2, 0, 2,
+ax_anim 8, 0, 152, 0, 3, 0, 3,
+ax_anim_terminator
+sCharmanderAnims_7_6:
+ax_anim 2, 0, 153, 2, 2, 2, 2,
+ax_anim 8, 0, 153, 3, 3, 3, 3,
+ax_anim_terminator
+sCharmanderAnims_7_7:
+ax_anim 2, 0, 154, 2, 0, 2, 0,
+ax_anim 8, 0, 154, 3, 0, 3, 0,
+ax_anim_terminator
+sCharmanderAnims_7_8:
+ax_anim 2, 0, 155, 2, -2, 2, -2,
+ax_anim 8, 0, 155, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_8_1:
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, -3, 0, 0,
+ax_anim 8, 0, 156, 0, -3, 0, 0,
+ax_anim 8, 0, 158, 0, -3, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_8_2:
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, -3, 0, 0,
+ax_anim 8, 0, 159, 0, -3, 0, 0,
+ax_anim 8, 0, 161, 0, -3, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_8_3:
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, -3, 0, 0,
+ax_anim 8, 0, 162, 0, -3, 0, 0,
+ax_anim 8, 0, 164, 0, -3, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_8_4:
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, -3, 0, 0,
+ax_anim 8, 0, 165, 0, -3, 0, 0,
+ax_anim 8, 0, 167, 0, -3, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_8_5:
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, -3, 0, 0,
+ax_anim 8, 0, 168, 0, -3, 0, 0,
+ax_anim 8, 0, 170, 0, -3, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_8_6:
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, -3, 0, 0,
+ax_anim 8, 0, 171, 0, -3, 0, 0,
+ax_anim 8, 0, 173, 0, -3, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_8_7:
+ax_anim 12, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, -3, 0, 0,
+ax_anim 8, 0, 174, 0, -3, 0, 0,
+ax_anim 8, 0, 176, 0, -3, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_8_8:
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 178, 0, -3, 0, 0,
+ax_anim 8, 0, 177, 0, -3, 0, 0,
+ax_anim 8, 0, 179, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_9_1:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 6, 4, 6, 4,
+ax_anim 2, 0, 182, 8, 9, 8, 9,
+ax_anim 2, 0, 183, 7, 17, 7, 17,
+ax_anim 3, 0, 184, 1, 19, 1, 19,
+ax_anim 2, 3, 185, -4, 18, -4, 18,
+ax_anim 2, 0, 186, -5, 8, -5, 8,
+ax_anim 1, 0, 187, -4, 4, -4, 4,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_9_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 6, 0, 6, 0,
+ax_anim 2, 0, 181, 17, 3, 17, 3,
+ax_anim 2, 0, 182, 21, 7, 21, 7,
+ax_anim 3, 0, 183, 25, 18, 25, 18,
+ax_anim 2, 3, 184, 15, 18, 15, 18,
+ax_anim 2, 0, 185, 4, 12, 4, 12,
+ax_anim 1, 0, 186, 3, 7, 3, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_9_3:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 3, -4, 3, -4,
+ax_anim 2, 0, 180, 11, -6, 11, -6,
+ax_anim 2, 0, 181, 19, -4, 19, -4,
+ax_anim 3, 0, 182, 24, 1, 24, 1,
+ax_anim 2, 3, 183, 19, 5, 19, 5,
+ax_anim 2, 0, 184, 12, 7, 12, 7,
+ax_anim 1, 0, 185, 4, 5, 4, 5,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_9_4:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 1, -6, 1, -6,
+ax_anim 2, 0, 187, 4, -16, 4, -16,
+ax_anim 2, 0, 180, 9, -22, 9, -22,
+ax_anim 3, 0, 181, 20, -24, 20, -24,
+ax_anim 2, 3, 182, 18, -13, 18, -13,
+ax_anim 2, 0, 183, 14, -6, 14, -6,
+ax_anim 1, 0, 184, 7, -1, 7, -1,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_9_5:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, -6, -4, -6, -4,
+ax_anim 2, 0, 186, -8, -9, -8, -9,
+ax_anim 2, 0, 187, -7, -15, -7, -15,
+ax_anim 3, 0, 180, -1, -20, -1, -20,
+ax_anim 2, 3, 181, 4, -16, 4, -16,
+ax_anim 2, 0, 182, 5, -8, 5, -8,
+ax_anim 1, 0, 183, 4, -4, 4, -4,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_9_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 182, -1, -6, -1, -6,
+ax_anim 2, 0, 181, -4, -16, -4, -16,
+ax_anim 2, 0, 180, -9, -22, -9, -22,
+ax_anim 3, 0, 187, -20, -24, -20, -24,
+ax_anim 2, 3, 186, -18, -13, -18, -13,
+ax_anim 2, 0, 185, -14, -6, -14, -6,
+ax_anim 1, 0, 184, -7, -1, -7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_9_7:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 181, -3, -4, -3, -4,
+ax_anim 2, 0, 180, -11, -6, -11, -6,
+ax_anim 2, 0, 187, -19, -4, -19, -4,
+ax_anim 3, 0, 186, -24, 1, -24, 1,
+ax_anim 2, 3, 185, -19, 5, -19, 5,
+ax_anim 2, 0, 184, -12, 7, -12, 7,
+ax_anim 1, 0, 183, -4, 5, -4, 5,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_9_8:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -6, 0, -6, 0,
+ax_anim 2, 0, 187, -17, 3, -17, 3,
+ax_anim 2, 0, 186, -21, 7, -21, 7,
+ax_anim 3, 0, 184, -25, 18, -25, 18,
+ax_anim 2, 3, 184, -15, 18, -15, 18,
+ax_anim 2, 0, 183, -4, 12, -4, 12,
+ax_anim 1, 0, 182, -3, 7, -3, 7,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_10_1:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 6, 0, 6, 0,
+ax_anim 2, 0, 188, -6, 0, -6, 0,
+ax_anim 2, 0, 188, 10, 0, 10, 0,
+ax_anim 2, 0, 188, -10, 0, -10, 0,
+ax_anim 2, 0, 188, 12, 0, 12, 0,
+ax_anim 3, 0, 188, -12, 0, -12, 0,
+ax_anim 3, 0, 188, 13, 0, 13, 0,
+ax_anim 3, 0, 188, -13, 0, -13, 0,
+ax_anim 2, 0, 188, 12, 0, 12, 0,
+ax_anim 3, 0, 188, -12, 0, -12, 0,
+ax_anim 2, 0, 188, 10, 0, 10, 0,
+ax_anim 2, 0, 188, -10, 0, -10, 0,
+ax_anim 2, 0, 188, 6, 0, 6, 0,
+ax_anim 2, 0, 188, -6, 0, -6, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_10_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 6, -6, 6, -6,
+ax_anim 2, 0, 189, -6, 6, -6, 6,
+ax_anim 2, 0, 189, 10, -10, 10, -10,
+ax_anim 2, 0, 189, -10, 10, -10, 10,
+ax_anim 2, 0, 189, 12, -12, 12, -12,
+ax_anim 3, 0, 189, -12, 12, -12, 12,
+ax_anim 3, 0, 189, 13, -13, 13, -13,
+ax_anim 3, 0, 189, -13, 13, -13, 13,
+ax_anim 2, 0, 189, 12, -12, 12, -12,
+ax_anim 3, 0, 189, -12, 12, -12, 12,
+ax_anim 2, 0, 189, 10, -10, 10, -10,
+ax_anim 2, 0, 189, -10, 10, -10, 10,
+ax_anim 2, 0, 189, 6, -6, 6, -6,
+ax_anim 2, 0, 189, -6, 6, -6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_10_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, -6, 0, -6,
+ax_anim 2, 0, 190, 0, 6, 0, 6,
+ax_anim 2, 0, 190, 0, -10, 0, -10,
+ax_anim 2, 0, 190, 0, 10, 0, 10,
+ax_anim 2, 0, 190, 0, -12, 0, -12,
+ax_anim 3, 0, 190, 0, 12, 0, 12,
+ax_anim 3, 0, 190, 0, -13, 0, -13,
+ax_anim 3, 0, 190, 0, 13, 0, 13,
+ax_anim 2, 0, 190, 0, -12, 0, -12,
+ax_anim 3, 0, 190, 0, 12, 0, 12,
+ax_anim 2, 0, 190, 0, -10, 0, -10,
+ax_anim 2, 0, 190, 0, 10, 0, 10,
+ax_anim 2, 0, 190, 0, -6, 0, -6,
+ax_anim 2, 0, 190, 0, 6, 0, 6,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_10_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -6, -6, -6, -6,
+ax_anim 2, 0, 191, 6, 6, 6, 6,
+ax_anim 2, 0, 191, -10, -10, -10, -10,
+ax_anim 2, 0, 191, 10, 10, 10, 10,
+ax_anim 2, 0, 191, -12, -12, -12, -12,
+ax_anim 3, 0, 191, 12, 12, 12, 12,
+ax_anim 3, 0, 191, -13, -13, -13, -13,
+ax_anim 3, 0, 191, 13, 13, 13, 13,
+ax_anim 2, 0, 191, -12, -12, -12, -12,
+ax_anim 3, 0, 191, 12, 12, 12, 12,
+ax_anim 2, 0, 191, -10, -10, -10, -10,
+ax_anim 2, 0, 191, 10, 10, 10, 10,
+ax_anim 2, 0, 191, -6, -6, -6, -6,
+ax_anim 2, 0, 191, 6, 6, 6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_10_5:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 6, 0, 6, 0,
+ax_anim 2, 0, 192, -6, 0, -6, 0,
+ax_anim 2, 0, 192, 10, 0, 10, 0,
+ax_anim 2, 0, 192, -10, 0, -10, 0,
+ax_anim 2, 0, 192, 12, 0, 12, 0,
+ax_anim 3, 0, 192, -12, 0, -12, 0,
+ax_anim 3, 0, 192, 13, 0, 13, 0,
+ax_anim 3, 0, 192, -13, 0, -13, 0,
+ax_anim 2, 0, 192, 12, 0, 12, 0,
+ax_anim 3, 0, 192, -12, 0, -12, 0,
+ax_anim 2, 0, 192, 10, 0, 10, 0,
+ax_anim 2, 0, 192, -10, 0, -10, 0,
+ax_anim 2, 0, 192, 6, 0, 6, 0,
+ax_anim 2, 0, 192, -6, 0, -6, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_10_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 6, -6, 6, -6,
+ax_anim 2, 0, 193, -6, 6, -6, 6,
+ax_anim 2, 0, 193, 10, -10, 10, -10,
+ax_anim 2, 0, 193, -10, 10, -10, 10,
+ax_anim 2, 0, 193, 12, -12, 12, -12,
+ax_anim 3, 0, 193, -12, 12, -12, 12,
+ax_anim 3, 0, 193, 13, -13, 13, -13,
+ax_anim 3, 0, 193, -13, 13, -13, 13,
+ax_anim 2, 0, 193, 12, -12, 12, -12,
+ax_anim 3, 0, 193, -12, 12, -12, 12,
+ax_anim 2, 0, 193, 10, -10, 10, -10,
+ax_anim 2, 0, 193, -10, 10, -10, 10,
+ax_anim 2, 0, 193, 6, -6, 6, -6,
+ax_anim 2, 0, 193, -6, 6, -6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_10_7:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, -6, 0, -6,
+ax_anim 2, 0, 194, 0, 6, 0, 6,
+ax_anim 2, 0, 194, 0, -10, 0, -10,
+ax_anim 2, 0, 194, 0, 10, 0, 10,
+ax_anim 2, 0, 194, 0, -12, 0, -12,
+ax_anim 3, 0, 194, 0, 12, 0, 12,
+ax_anim 3, 0, 194, 0, -13, 0, -13,
+ax_anim 3, 0, 194, 0, 13, 0, 13,
+ax_anim 2, 0, 194, 0, -12, 0, -12,
+ax_anim 3, 0, 194, 0, 12, 0, 12,
+ax_anim 2, 0, 194, 0, -10, 0, -10,
+ax_anim 2, 0, 194, 0, 10, 0, 10,
+ax_anim 2, 0, 194, 0, -6, 0, -6,
+ax_anim 2, 0, 194, 0, 6, 0, 6,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_10_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -6, -6, -6, -6,
+ax_anim 2, 0, 195, 6, 6, 6, 6,
+ax_anim 2, 0, 195, -10, -10, -10, -10,
+ax_anim 2, 0, 195, 10, 10, 10, 10,
+ax_anim 2, 0, 195, -12, -12, -12, -12,
+ax_anim 3, 0, 195, 12, 12, 12, 12,
+ax_anim 3, 0, 195, -13, -13, -13, -13,
+ax_anim 3, 0, 195, 13, 13, 13, 13,
+ax_anim 2, 0, 195, -12, -12, -12, -12,
+ax_anim 3, 0, 195, 12, 12, 12, 12,
+ax_anim 2, 0, 195, -10, -10, -10, -10,
+ax_anim 2, 0, 195, 10, 10, 10, 10,
+ax_anim 2, 0, 195, -6, -6, -6, -6,
+ax_anim 2, 0, 195, 6, 6, 6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_11_1:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_11_2:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_11_3:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_11_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 2, 0, 207, 0, -17, 0, 0,
+ax_anim 1, 0, 207, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_11_5:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_11_6:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_11_7:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_11_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_12_1:
+ax_anim 2, 0, 220, 1, 0, 1, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 1, 0, 1, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 1, 0, 1, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 1, 0, 1, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 1, 0, 1, 0,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_12_2:
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_12_3:
+ax_anim 2, 0, 226, 0, -1, 0, -1,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, -1, 0, -1,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, -1, 0, -1,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, -1, 0, -1,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, -1, 0, -1,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_12_4:
+ax_anim 2, 0, 225, -1, -1, -1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -1, -1, -1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -1, -1, -1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -1, -1, -1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -1, -1, -1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_12_5:
+ax_anim 2, 0, 224, 1, 0, 1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, 0, 1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, 0, 1, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, 0, 1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, 0, 1, 0,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_12_6:
+ax_anim 2, 0, 223, 1, -1, 1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 1, -1, 1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 1, -1, 1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 1, -1, 1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 1, -1, 1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_12_7:
+ax_anim 2, 0, 222, 0, -1, 0, -1,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, -1, 0, -1,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, -1, 0, -1,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, -1, 0, -1,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, -1, 0, -1,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_12_8:
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_13_1:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_13_2:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_13_3:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_13_4:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_13_5:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_13_6:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_13_7:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_13_8:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_14_1:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_14_2:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_14_3:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_14_4:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_14_5:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_14_6:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_14_7:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_14_8:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 35, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_15_1:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_15_2:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_15_3:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_15_4:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_15_5:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_15_6:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_15_7:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_15_8:
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 14, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_16_1:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_16_2:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_16_3:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_16_4:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_16_5:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_16_6:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_16_7:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_16_8:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 3, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_17_1:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_17_2:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_17_3:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_17_4:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_17_5:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_17_6:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_17_7:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+sCharmanderAnims_17_8:
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_18_1:
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_18_2:
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_18_3:
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_18_4:
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_18_5:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_18_6:
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_18_7:
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_18_8:
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_19_1:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_19_2:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_19_3:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_19_4:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_19_5:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_19_6:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_19_7:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_19_8:
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_20_1:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 1, 0, 0,
+ax_anim 2, 0, 261, 1, 1, 1, 0,
+ax_anim 2, 0, 261, 0, 1, 0, 0,
+ax_anim 2, 0, 261, 1, 1, 1, 0,
+ax_anim 2, 0, 261, 0, 1, 0, 0,
+ax_anim 2, 0, 261, 1, 1, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_20_2:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_20_3:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_20_4:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_20_5:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_20_6:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_20_7:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim_terminator
+sCharmanderAnims_20_8:
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -2, 0, 0,
+ax_anim 1, 0, 260, 0, -4, 0, 0,
+ax_anim 2, 0, 261, 0, -4, 0, 0,
+ax_anim 1, 0, 261, 0, -2, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_21_1:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_21_2:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_21_3:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_21_4:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_21_5:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_21_6:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_21_7:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_21_8:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_22_1:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_22_2:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_22_3:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_22_4:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_22_5:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_22_6:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_22_7:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_22_8:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 34, 0, 267, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_23_1:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 4, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_23_2:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 4, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_23_3:
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 8, 0, 271, 0, 0, 0, 0,
+ax_anim 12, 0, 270, 0, 0, 0, 0,
+ax_anim 8, 0, 271, 0, 0, 0, 0,
+ax_anim 4, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_23_4:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 4, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_23_5:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 4, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_23_6:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 4, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_23_7:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 4, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_23_8:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 4, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_24_1:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_24_2:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_24_3:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_24_4:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_24_5:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_24_6:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_24_7:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_24_8:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_25_1:
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 280, 0, 0, 0, 0,
+ax_anim 12, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 282, 0, 0, 0, 0,
+ax_anim 12, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_25_2:
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 280, 0, 0, 0, 0,
+ax_anim 12, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 282, 0, 0, 0, 0,
+ax_anim 12, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_25_3:
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 280, 0, 0, 0, 0,
+ax_anim 12, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 282, 0, 0, 0, 0,
+ax_anim 12, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_25_4:
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 280, 0, 0, 0, 0,
+ax_anim 12, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 282, 0, 0, 0, 0,
+ax_anim 12, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_25_5:
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 280, 0, 0, 0, 0,
+ax_anim 12, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 282, 0, 0, 0, 0,
+ax_anim 12, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_25_6:
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 280, 0, 0, 0, 0,
+ax_anim 12, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 282, 0, 0, 0, 0,
+ax_anim 12, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_25_7:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 276, 0, 0, 0, 0,
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 12, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_25_8:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 276, 0, 0, 0, 0,
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 12, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_26_1:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_26_2:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_26_3:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_26_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_26_5:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_26_6:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_26_7:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+sCharmanderAnims_26_8:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_27_1:
+ax_anim 12, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 288, 0, 0, 0, 0,
+ax_anim 16, 0, 288, -1, 0, 0, 0,
+ax_anim 12, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 288, 1, 0, 0, 0,
+ax_anim 16, 0, 288, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmanderAnims_28_1:
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_28_2:
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_28_3:
+ax_anim 12, 0, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_28_4:
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_28_5:
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_28_6:
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_28_7:
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderAnims_28_8:
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmanderGfx1:
+.incbin "baserom.gba", 0x53A540, 0x200
+sCharmanderSprites1:
+ax_sprite sCharmanderGfx1, 0x200
+ax_sprite_terminator
+sCharmanderGfx2:
+.incbin "baserom.gba", 0x53A750, 0x200
+sCharmanderSprites2:
+ax_sprite sCharmanderGfx2, 0x200
+ax_sprite_terminator
+sCharmanderGfx3:
+.incbin "baserom.gba", 0x53A960, 0x200
+sCharmanderSprites3:
+ax_sprite sCharmanderGfx3, 0x200
+ax_sprite_terminator
+sCharmanderGfx4:
+.incbin "baserom.gba", 0x53AB70, 0x200
+sCharmanderSprites4:
+ax_sprite sCharmanderGfx4, 0x200
+ax_sprite_terminator
+sCharmanderGfx5:
+.incbin "baserom.gba", 0x53AD80, 0x200
+sCharmanderSprites5:
+ax_sprite sCharmanderGfx5, 0x200
+ax_sprite_terminator
+sCharmanderGfx6:
+.incbin "baserom.gba", 0x53AF90, 0x200
+sCharmanderSprites6:
+ax_sprite sCharmanderGfx6, 0x200
+ax_sprite_terminator
+sCharmanderGfx7:
+.incbin "baserom.gba", 0x53B1A0, 0x200
+sCharmanderSprites7:
+ax_sprite sCharmanderGfx7, 0x200
+ax_sprite_terminator
+sCharmanderGfx8:
+.incbin "baserom.gba", 0x53B3B0, 0x200
+sCharmanderSprites8:
+ax_sprite sCharmanderGfx8, 0x200
+ax_sprite_terminator
+sCharmanderGfx9:
+.incbin "baserom.gba", 0x53B5C0, 0x200
+sCharmanderSprites9:
+ax_sprite sCharmanderGfx9, 0x200
+ax_sprite_terminator
+sCharmanderGfx10:
+.incbin "baserom.gba", 0x53B7D0, 0x200
+sCharmanderSprites10:
+ax_sprite sCharmanderGfx10, 0x200
+ax_sprite_terminator
+sCharmanderGfx11:
+.incbin "baserom.gba", 0x53B9E0, 0x200
+sCharmanderSprites11:
+ax_sprite sCharmanderGfx11, 0x200
+ax_sprite_terminator
+sCharmanderGfx12:
+.incbin "baserom.gba", 0x53BBF0, 0x200
+sCharmanderSprites12:
+ax_sprite sCharmanderGfx12, 0x200
+ax_sprite_terminator
+sCharmanderGfx13:
+.incbin "baserom.gba", 0x53BE00, 0x100
+sCharmanderSprites13:
+ax_sprite sCharmanderGfx13, 0x100
+ax_sprite_terminator
+sCharmanderGfx14:
+.incbin "baserom.gba", 0x53BF10, 0x100
+sCharmanderSprites14:
+ax_sprite sCharmanderGfx14, 0x100
+ax_sprite_terminator
+sCharmanderGfx15:
+.incbin "baserom.gba", 0x53C020, 0x100
+sCharmanderSprites15:
+ax_sprite sCharmanderGfx15, 0x100
+ax_sprite_terminator
+sCharmanderGfx16:
+.incbin "baserom.gba", 0x53C130, 0x20
+sCharmanderGfx16_1:
+.incbin "baserom.gba", 0x53C150, 0x20
+sCharmanderGfx16_2:
+.incbin "baserom.gba", 0x53C170, 0x40
+sCharmanderGfx16_3:
+.incbin "baserom.gba", 0x53C1B0, 0x20
+sCharmanderSprites16:
+ax_sprite sCharmanderGfx16, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx16_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx16_3, 0x20
+ax_sprite_terminator
+sCharmanderGfx17:
+.incbin "baserom.gba", 0x53C210, 0x60
+sCharmanderGfx17_1:
+.incbin "baserom.gba", 0x53C270, 0x60
+sCharmanderGfx17_2:
+.incbin "baserom.gba", 0x53C2D0, 0x60
+sCharmanderSprites17:
+ax_sprite sCharmanderGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx18:
+.incbin "baserom.gba", 0x53C368, 0x60
+sCharmanderGfx18_1:
+.incbin "baserom.gba", 0x53C3C8, 0x60
+sCharmanderGfx18_2:
+.incbin "baserom.gba", 0x53C428, 0x60
+sCharmanderSprites18:
+ax_sprite sCharmanderGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx19:
+.incbin "baserom.gba", 0x53C4C0, 0x80
+sCharmanderSprites19:
+ax_sprite sCharmanderGfx19, 0x80
+ax_sprite_terminator
+sCharmanderGfx20:
+.incbin "baserom.gba", 0x53C550, 0x40
+sCharmanderSprites20:
+ax_sprite sCharmanderGfx20, 0x40
+ax_sprite_terminator
+sCharmanderGfx21:
+.incbin "baserom.gba", 0x53C5A0, 0x40
+sCharmanderGfx21_1:
+.incbin "baserom.gba", 0x53C5E0, 0x60
+sCharmanderGfx21_2:
+.incbin "baserom.gba", 0x53C640, 0x60
+sCharmanderSprites21:
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx22:
+.incbin "baserom.gba", 0x53C6E0, 0x60
+sCharmanderGfx22_1:
+.incbin "baserom.gba", 0x53C740, 0x60
+sCharmanderGfx22_2:
+.incbin "baserom.gba", 0x53C7A0, 0x60
+sCharmanderSprites22:
+ax_sprite sCharmanderGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx23:
+.incbin "baserom.gba", 0x53C838, 0x80
+sCharmanderSprites23:
+ax_sprite sCharmanderGfx23, 0x80
+ax_sprite_terminator
+sCharmanderGfx24:
+.incbin "baserom.gba", 0x53C8C8, 0x40
+sCharmanderGfx24_1:
+.incbin "baserom.gba", 0x53C908, 0x100
+sCharmanderSprites24:
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx24_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCharmanderGfx25:
+.incbin "baserom.gba", 0x53CA38, 0x60
+sCharmanderGfx25_1:
+.incbin "baserom.gba", 0x53CA98, 0x60
+sCharmanderGfx25_2:
+.incbin "baserom.gba", 0x53CAF8, 0x60
+sCharmanderSprites25:
+ax_sprite sCharmanderGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx26:
+.incbin "baserom.gba", 0x53CB90, 0x40
+sCharmanderGfx26_1:
+.incbin "baserom.gba", 0x53CBD0, 0x60
+sCharmanderGfx26_2:
+.incbin "baserom.gba", 0x53CC30, 0x60
+sCharmanderSprites26:
+ax_sprite sCharmanderGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmanderGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx27:
+.incbin "baserom.gba", 0x53CCC8, 0x60
+sCharmanderGfx27_1:
+.incbin "baserom.gba", 0x53CD28, 0x80
+sCharmanderGfx27_2:
+.incbin "baserom.gba", 0x53CDA8, 0x60
+sCharmanderSprites27:
+ax_sprite sCharmanderGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx27_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCharmanderGfx28:
+.incbin "baserom.gba", 0x53CE40, 0x60
+sCharmanderGfx28_1:
+.incbin "baserom.gba", 0x53CEA0, 0x20
+sCharmanderGfx28_2:
+.incbin "baserom.gba", 0x53CEC0, 0x20
+sCharmanderSprites28:
+ax_sprite sCharmanderGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx28_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx28_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmanderGfx29:
+.incbin "baserom.gba", 0x53CF18, 0x80
+sCharmanderSprites29:
+ax_sprite sCharmanderGfx29, 0x80
+ax_sprite_terminator
+sCharmanderGfx30:
+.incbin "baserom.gba", 0x53CFA8, 0x40
+sCharmanderSprites30:
+ax_sprite sCharmanderGfx30, 0x40
+ax_sprite_terminator
+sCharmanderGfx31:
+.incbin "baserom.gba", 0x53CFF8, 0x60
+sCharmanderGfx31_1:
+.incbin "baserom.gba", 0x53D058, 0x60
+sCharmanderGfx31_2:
+.incbin "baserom.gba", 0x53D0B8, 0x60
+sCharmanderSprites31:
+ax_sprite sCharmanderGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx32:
+.incbin "baserom.gba", 0x53D150, 0x60
+sCharmanderGfx32_1:
+.incbin "baserom.gba", 0x53D1B0, 0x60
+sCharmanderGfx32_2:
+.incbin "baserom.gba", 0x53D210, 0x60
+sCharmanderGfx32_3:
+.incbin "baserom.gba", 0x53D270, 0x60
+sCharmanderSprites32:
+ax_sprite sCharmanderGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmanderGfx33:
+.incbin "baserom.gba", 0x53D318, 0x60
+sCharmanderGfx33_1:
+.incbin "baserom.gba", 0x53D378, 0x60
+sCharmanderGfx33_2:
+.incbin "baserom.gba", 0x53D3D8, 0x40
+sCharmanderSprites33:
+ax_sprite sCharmanderGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx33_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sCharmanderGfx34:
+.incbin "baserom.gba", 0x53D450, 0x60
+sCharmanderGfx34_1:
+.incbin "baserom.gba", 0x53D4B0, 0x60
+sCharmanderGfx34_2:
+.incbin "baserom.gba", 0x53D510, 0x60
+sCharmanderSprites34:
+ax_sprite sCharmanderGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx35:
+.incbin "baserom.gba", 0x53D5A8, 0x60
+sCharmanderGfx35_1:
+.incbin "baserom.gba", 0x53D608, 0x60
+sCharmanderGfx35_2:
+.incbin "baserom.gba", 0x53D668, 0x60
+sCharmanderSprites35:
+ax_sprite sCharmanderGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx36:
+.incbin "baserom.gba", 0x53D700, 0x40
+sCharmanderGfx36_1:
+.incbin "baserom.gba", 0x53D740, 0x40
+sCharmanderGfx36_2:
+.incbin "baserom.gba", 0x53D780, 0x60
+sCharmanderSprites36:
+ax_sprite sCharmanderGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmanderGfx36_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmanderGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx37:
+.incbin "baserom.gba", 0x53D818, 0x20
+sCharmanderGfx37_1:
+.incbin "baserom.gba", 0x53D838, 0x20
+sCharmanderGfx37_2:
+.incbin "baserom.gba", 0x53D858, 0x40
+sCharmanderSprites37:
+ax_sprite sCharmanderGfx37, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx37_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCharmanderGfx38:
+.incbin "baserom.gba", 0x53D8D0, 0x60
+sCharmanderGfx38_1:
+.incbin "baserom.gba", 0x53D930, 0x60
+sCharmanderGfx38_2:
+.incbin "baserom.gba", 0x53D990, 0x40
+sCharmanderSprites38:
+ax_sprite sCharmanderGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx38_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCharmanderGfx38_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx39:
+.incbin "baserom.gba", 0x53DA08, 0x60
+sCharmanderGfx39_1:
+.incbin "baserom.gba", 0x53DA68, 0x20
+sCharmanderSprites39:
+ax_sprite sCharmanderGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx39_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sCharmanderGfx40:
+.incbin "baserom.gba", 0x53DAB0, 0x40
+sCharmanderGfx40_1:
+.incbin "baserom.gba", 0x53DAF0, 0x60
+sCharmanderGfx40_2:
+.incbin "baserom.gba", 0x53DB50, 0x60
+sCharmanderSprites40:
+ax_sprite sCharmanderGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmanderGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx41:
+.incbin "baserom.gba", 0x53DBE8, 0x20
+sCharmanderGfx41_1:
+.incbin "baserom.gba", 0x53DC08, 0x20
+sCharmanderSprites41:
+ax_sprite sCharmanderGfx41, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx41_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmanderGfx42:
+.incbin "baserom.gba", 0x53DC50, 0x60
+sCharmanderGfx42_1:
+.incbin "baserom.gba", 0x53DCB0, 0x60
+sCharmanderGfx42_2:
+.incbin "baserom.gba", 0x53DD10, 0x60
+sCharmanderSprites42:
+ax_sprite sCharmanderGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx42_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx43:
+.incbin "baserom.gba", 0x53DDA8, 0x40
+sCharmanderGfx43_1:
+.incbin "baserom.gba", 0x53DDE8, 0x20
+sCharmanderSprites43:
+ax_sprite sCharmanderGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx43_1, 0x20
+ax_sprite_terminator
+sCharmanderGfx44:
+.incbin "baserom.gba", 0x53DE28, 0x60
+sCharmanderGfx44_1:
+.incbin "baserom.gba", 0x53DE88, 0x60
+sCharmanderGfx44_2:
+.incbin "baserom.gba", 0x53DEE8, 0x60
+sCharmanderSprites44:
+ax_sprite sCharmanderGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx44_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx45:
+.incbin "baserom.gba", 0x53DF80, 0x40
+sCharmanderGfx45_1:
+.incbin "baserom.gba", 0x53DFC0, 0x60
+sCharmanderGfx45_2:
+.incbin "baserom.gba", 0x53E020, 0x60
+sCharmanderSprites45:
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx45_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx46:
+.incbin "baserom.gba", 0x53E0C0, 0x40
+sCharmanderGfx46_1:
+.incbin "baserom.gba", 0x53E100, 0x20
+sCharmanderSprites46:
+ax_sprite sCharmanderGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx46_1, 0x20
+ax_sprite_terminator
+sCharmanderGfx47:
+.incbin "baserom.gba", 0x53E140, 0x40
+sCharmanderGfx47_1:
+.incbin "baserom.gba", 0x53E180, 0x60
+sCharmanderGfx47_2:
+.incbin "baserom.gba", 0x53E1E0, 0x60
+sCharmanderSprites47:
+ax_sprite sCharmanderGfx47, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmanderGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmanderGfx47_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCharmanderGfx48:
+.incbin "baserom.gba", 0x53E278, 0x200
+sCharmanderSprites48:
+ax_sprite sCharmanderGfx48, 0x200
+ax_sprite_terminator
+sCharmanderGfx49:
+.incbin "baserom.gba", 0x53E488, 0x200
+sCharmanderSprites49:
+ax_sprite sCharmanderGfx49, 0x200
+ax_sprite_terminator
+sCharmanderGfx50:
+.incbin "baserom.gba", 0x53E698, 0x200
+sCharmanderSprites50:
+ax_sprite sCharmanderGfx50, 0x200
+ax_sprite_terminator
+sCharmanderGfx51:
+.incbin "baserom.gba", 0x53E8A8, 0x200
+sCharmanderSprites51:
+ax_sprite sCharmanderGfx51, 0x200
+ax_sprite_terminator
+sCharmanderGfx52:
+.incbin "baserom.gba", 0x53EAB8, 0x200
+sCharmanderSprites52:
+ax_sprite sCharmanderGfx52, 0x200
+ax_sprite_terminator
+sCharmanderGfx53:
+.incbin "baserom.gba", 0x53ECC8, 0x200
+sCharmanderSprites53:
+ax_sprite sCharmanderGfx53, 0x200
+ax_sprite_terminator
+sCharmanderGfx54:
+.incbin "baserom.gba", 0x53EED8, 0x200
+sCharmanderSprites54:
+ax_sprite sCharmanderGfx54, 0x200
+ax_sprite_terminator
+sCharmanderGfx55:
+.incbin "baserom.gba", 0x53F0E8, 0x200
+sCharmanderSprites55:
+ax_sprite sCharmanderGfx55, 0x200
+ax_sprite_terminator
+sCharmanderGfx56:
+.incbin "baserom.gba", 0x53F2F8, 0x200
+sCharmanderSprites56:
+ax_sprite sCharmanderGfx56, 0x200
+ax_sprite_terminator
+sCharmanderGfx57:
+.incbin "baserom.gba", 0x53F508, 0x200
+sCharmanderSprites57:
+ax_sprite sCharmanderGfx57, 0x200
+ax_sprite_terminator
+sCharmanderGfx58:
+.incbin "baserom.gba", 0x53F718, 0x200
+sCharmanderSprites58:
+ax_sprite sCharmanderGfx58, 0x200
+ax_sprite_terminator
+sCharmanderGfx59:
+.incbin "baserom.gba", 0x53F928, 0x200
+sCharmanderSprites59:
+ax_sprite sCharmanderGfx59, 0x200
+ax_sprite_terminator
+sCharmanderGfx60:
+.incbin "baserom.gba", 0x53FB38, 0x200
+sCharmanderSprites60:
+ax_sprite sCharmanderGfx60, 0x200
+ax_sprite_terminator
+sCharmanderGfx61:
+.incbin "baserom.gba", 0x53FD48, 0x200
+sCharmanderSprites61:
+ax_sprite sCharmanderGfx61, 0x200
+ax_sprite_terminator
+sCharmanderGfx62:
+.incbin "baserom.gba", 0x53FF58, 0x200
+sCharmanderSprites62:
+ax_sprite sCharmanderGfx62, 0x200
+ax_sprite_terminator
+sCharmanderGfx63:
+.incbin "baserom.gba", 0x540168, 0x200
+sCharmanderSprites63:
+ax_sprite sCharmanderGfx63, 0x200
+ax_sprite_terminator
+sCharmanderGfx64:
+.incbin "baserom.gba", 0x540378, 0x200
+sCharmanderSprites64:
+ax_sprite sCharmanderGfx64, 0x200
+ax_sprite_terminator
+sCharmanderGfx65:
+.incbin "baserom.gba", 0x540588, 0x200
+sCharmanderSprites65:
+ax_sprite sCharmanderGfx65, 0x200
+ax_sprite_terminator
+sCharmanderGfx66:
+.incbin "baserom.gba", 0x540798, 0x200
+sCharmanderSprites66:
+ax_sprite sCharmanderGfx66, 0x200
+ax_sprite_terminator
+sCharmanderGfx67:
+.incbin "baserom.gba", 0x5409A8, 0x200
+sCharmanderSprites67:
+ax_sprite sCharmanderGfx67, 0x200
+ax_sprite_terminator
+sCharmanderGfx68:
+.incbin "baserom.gba", 0x540BB8, 0x200
+sCharmanderSprites68:
+ax_sprite sCharmanderGfx68, 0x200
+ax_sprite_terminator
+sCharmanderGfx69:
+.incbin "baserom.gba", 0x540DC8, 0x200
+sCharmanderSprites69:
+ax_sprite sCharmanderGfx69, 0x200
+ax_sprite_terminator
+sCharmanderGfx70:
+.incbin "baserom.gba", 0x540FD8, 0x200
+sCharmanderSprites70:
+ax_sprite sCharmanderGfx70, 0x200
+ax_sprite_terminator
+sCharmanderGfx71:
+.incbin "baserom.gba", 0x5411E8, 0x200
+sCharmanderSprites71:
+ax_sprite sCharmanderGfx71, 0x200
+ax_sprite_terminator
+sCharmanderGfx72:
+.incbin "baserom.gba", 0x5413F8, 0x200
+sCharmanderSprites72:
+ax_sprite sCharmanderGfx72, 0x200
+ax_sprite_terminator
+sCharmanderGfx73:
+.incbin "baserom.gba", 0x541608, 0x200
+sCharmanderSprites73:
+ax_sprite sCharmanderGfx73, 0x200
+ax_sprite_terminator
+sCharmanderGfx74:
+.incbin "baserom.gba", 0x541818, 0x100
+sCharmanderSprites74:
+ax_sprite sCharmanderGfx74, 0x100
+ax_sprite_terminator
+sCharmanderGfx75:
+.incbin "baserom.gba", 0x541928, 0x200
+sCharmanderSprites75:
+ax_sprite sCharmanderGfx75, 0x200
+ax_sprite_terminator
+sCharmanderGfx76:
+.incbin "baserom.gba", 0x541B38, 0x200
+sCharmanderSprites76:
+ax_sprite sCharmanderGfx76, 0x200
+ax_sprite_terminator
+sCharmanderGfx77:
+.incbin "baserom.gba", 0x541D48, 0x200
+sCharmanderSprites77:
+ax_sprite sCharmanderGfx77, 0x200
+ax_sprite_terminator
+sCharmanderGfx78:
+.incbin "baserom.gba", 0x541F58, 0x200
+sCharmanderSprites78:
+ax_sprite sCharmanderGfx78, 0x200
+ax_sprite_terminator
+sCharmanderGfx79:
+.incbin "baserom.gba", 0x542168, 0x200
+sCharmanderSprites79:
+ax_sprite sCharmanderGfx79, 0x200
+ax_sprite_terminator
+sCharmanderGfx80:
+.incbin "baserom.gba", 0x542378, 0x200
+sCharmanderSprites80:
+ax_sprite sCharmanderGfx80, 0x200
+ax_sprite_terminator
+sCharmanderGfx81:
+.incbin "baserom.gba", 0x542588, 0x200
+sCharmanderSprites81:
+ax_sprite sCharmanderGfx81, 0x200
+ax_sprite_terminator
+sCharmanderGfx82:
+.incbin "baserom.gba", 0x542798, 0x200
+sCharmanderSprites82:
+ax_sprite sCharmanderGfx82, 0x200
+ax_sprite_terminator
+sCharmanderGfx83:
+.incbin "baserom.gba", 0x5429A8, 0x200
+sCharmanderSprites83:
+ax_sprite sCharmanderGfx83, 0x200
+ax_sprite_terminator
+sCharmanderGfx84:
+.incbin "baserom.gba", 0x542BB8, 0x200
+sCharmanderSprites84:
+ax_sprite sCharmanderGfx84, 0x200
+ax_sprite_terminator
+sAxPosesCharmander:
+.4byte sCharmanderPose1
+.4byte sCharmanderPose2
+.4byte sCharmanderPose3
+.4byte sCharmanderPose4
+.4byte sCharmanderPose5
+.4byte sCharmanderPose6
+.4byte sCharmanderPose7
+.4byte sCharmanderPose8
+.4byte sCharmanderPose9
+.4byte sCharmanderPose10
+.4byte sCharmanderPose11
+.4byte sCharmanderPose12
+.4byte sCharmanderPose13
+.4byte sCharmanderPose14
+.4byte sCharmanderPose15
+.4byte sCharmanderPose16
+.4byte sCharmanderPose17
+.4byte sCharmanderPose18
+.4byte sCharmanderPose19
+.4byte sCharmanderPose20
+.4byte sCharmanderPose21
+.4byte sCharmanderPose22
+.4byte sCharmanderPose23
+.4byte sCharmanderPose24
+.4byte sCharmanderPose25
+.4byte sCharmanderPose26
+.4byte sCharmanderPose27
+.4byte sCharmanderPose28
+.4byte sCharmanderPose29
+.4byte sCharmanderPose30
+.4byte sCharmanderPose31
+.4byte sCharmanderPose32
+.4byte sCharmanderPose33
+.4byte sCharmanderPose34
+.4byte sCharmanderPose35
+.4byte sCharmanderPose36
+.4byte sCharmanderPose37
+.4byte sCharmanderPose38
+.4byte sCharmanderPose39
+.4byte sCharmanderPose40
+.4byte sCharmanderPose41
+.4byte sCharmanderPose42
+.4byte sCharmanderPose43
+.4byte sCharmanderPose44
+.4byte sCharmanderPose45
+.4byte sCharmanderPose46
+.4byte sCharmanderPose47
+.4byte sCharmanderPose48
+.4byte sCharmanderPose49
+.4byte sCharmanderPose50
+.4byte sCharmanderPose51
+.4byte sCharmanderPose52
+.4byte sCharmanderPose53
+.4byte sCharmanderPose54
+.4byte sCharmanderPose55
+.4byte sCharmanderPose56
+.4byte sCharmanderPose57
+.4byte sCharmanderPose58
+.4byte sCharmanderPose59
+.4byte sCharmanderPose60
+.4byte sCharmanderPose61
+.4byte sCharmanderPose62
+.4byte sCharmanderPose63
+.4byte sCharmanderPose64
+.4byte sCharmanderPose65
+.4byte sCharmanderPose66
+.4byte sCharmanderPose67
+.4byte sCharmanderPose68
+.4byte sCharmanderPose69
+.4byte sCharmanderPose70
+.4byte sCharmanderPose71
+.4byte sCharmanderPose72
+.4byte sCharmanderPose73
+.4byte sCharmanderPose74
+.4byte sCharmanderPose75
+.4byte sCharmanderPose76
+.4byte sCharmanderPose77
+.4byte sCharmanderPose78
+.4byte sCharmanderPose79
+.4byte sCharmanderPose80
+.4byte sCharmanderPose81
+.4byte sCharmanderPose82
+.4byte sCharmanderPose83
+.4byte sCharmanderPose84
+.4byte sCharmanderPose85
+.4byte sCharmanderPose86
+.4byte sCharmanderPose87
+.4byte sCharmanderPose88
+.4byte sCharmanderPose89
+.4byte sCharmanderPose90
+.4byte sCharmanderPose91
+.4byte sCharmanderPose92
+.4byte sCharmanderPose93
+.4byte sCharmanderPose94
+.4byte sCharmanderPose95
+.4byte sCharmanderPose96
+.4byte sCharmanderPose97
+.4byte sCharmanderPose98
+.4byte sCharmanderPose99
+.4byte sCharmanderPose100
+.4byte sCharmanderPose101
+.4byte sCharmanderPose102
+.4byte sCharmanderPose103
+.4byte sCharmanderPose104
+.4byte sCharmanderPose105
+.4byte sCharmanderPose106
+.4byte sCharmanderPose107
+.4byte sCharmanderPose108
+.4byte sCharmanderPose109
+.4byte sCharmanderPose110
+.4byte sCharmanderPose111
+.4byte sCharmanderPose112
+.4byte sCharmanderPose113
+.4byte sCharmanderPose114
+.4byte sCharmanderPose115
+.4byte sCharmanderPose116
+.4byte sCharmanderPose117
+.4byte sCharmanderPose118
+.4byte sCharmanderPose119
+.4byte sCharmanderPose120
+.4byte sCharmanderPose121
+.4byte sCharmanderPose122
+.4byte sCharmanderPose123
+.4byte sCharmanderPose124
+.4byte sCharmanderPose125
+.4byte sCharmanderPose126
+.4byte sCharmanderPose127
+.4byte sCharmanderPose128
+.4byte sCharmanderPose129
+.4byte sCharmanderPose130
+.4byte sCharmanderPose131
+.4byte sCharmanderPose132
+.4byte sCharmanderPose133
+.4byte sCharmanderPose134
+.4byte sCharmanderPose135
+.4byte sCharmanderPose136
+.4byte sCharmanderPose137
+.4byte sCharmanderPose138
+.4byte sCharmanderPose139
+.4byte sCharmanderPose140
+.4byte sCharmanderPose141
+.4byte sCharmanderPose142
+.4byte sCharmanderPose143
+.4byte sCharmanderPose144
+.4byte sCharmanderPose145
+.4byte sCharmanderPose146
+.4byte sCharmanderPose147
+.4byte sCharmanderPose148
+.4byte sCharmanderPose149
+.4byte sCharmanderPose150
+.4byte sCharmanderPose151
+.4byte sCharmanderPose152
+.4byte sCharmanderPose153
+.4byte sCharmanderPose154
+.4byte sCharmanderPose155
+.4byte sCharmanderPose156
+.4byte sCharmanderPose157
+.4byte sCharmanderPose158
+.4byte sCharmanderPose159
+.4byte sCharmanderPose160
+.4byte sCharmanderPose161
+.4byte sCharmanderPose162
+.4byte sCharmanderPose163
+.4byte sCharmanderPose164
+.4byte sCharmanderPose165
+.4byte sCharmanderPose166
+.4byte sCharmanderPose167
+.4byte sCharmanderPose168
+.4byte sCharmanderPose169
+.4byte sCharmanderPose170
+.4byte sCharmanderPose171
+.4byte sCharmanderPose172
+.4byte sCharmanderPose173
+.4byte sCharmanderPose174
+.4byte sCharmanderPose175
+.4byte sCharmanderPose176
+.4byte sCharmanderPose177
+.4byte sCharmanderPose178
+.4byte sCharmanderPose179
+.4byte sCharmanderPose180
+.4byte sCharmanderPose181
+.4byte sCharmanderPose182
+.4byte sCharmanderPose183
+.4byte sCharmanderPose184
+.4byte sCharmanderPose185
+.4byte sCharmanderPose186
+.4byte sCharmanderPose187
+.4byte sCharmanderPose188
+.4byte sCharmanderPose189
+.4byte sCharmanderPose190
+.4byte sCharmanderPose191
+.4byte sCharmanderPose192
+.4byte sCharmanderPose193
+.4byte sCharmanderPose194
+.4byte sCharmanderPose195
+.4byte sCharmanderPose196
+.4byte sCharmanderPose197
+.4byte sCharmanderPose198
+.4byte sCharmanderPose199
+.4byte sCharmanderPose200
+.4byte sCharmanderPose201
+.4byte sCharmanderPose202
+.4byte sCharmanderPose203
+.4byte sCharmanderPose204
+.4byte sCharmanderPose205
+.4byte sCharmanderPose206
+.4byte sCharmanderPose207
+.4byte sCharmanderPose208
+.4byte sCharmanderPose209
+.4byte sCharmanderPose210
+.4byte sCharmanderPose211
+.4byte sCharmanderPose212
+.4byte sCharmanderPose213
+.4byte sCharmanderPose214
+.4byte sCharmanderPose215
+.4byte sCharmanderPose216
+.4byte sCharmanderPose217
+.4byte sCharmanderPose218
+.4byte sCharmanderPose219
+.4byte sCharmanderPose220
+.4byte sCharmanderPose221
+.4byte sCharmanderPose222
+.4byte sCharmanderPose223
+.4byte sCharmanderPose224
+.4byte sCharmanderPose225
+.4byte sCharmanderPose226
+.4byte sCharmanderPose227
+.4byte sCharmanderPose228
+.4byte sCharmanderPose229
+.4byte sCharmanderPose230
+.4byte sCharmanderPose231
+.4byte sCharmanderPose232
+.4byte sCharmanderPose233
+.4byte sCharmanderPose234
+.4byte sCharmanderPose235
+.4byte sCharmanderPose236
+.4byte sCharmanderPose237
+.4byte sCharmanderPose238
+.4byte sCharmanderPose239
+.4byte sCharmanderPose240
+.4byte sCharmanderPose241
+.4byte sCharmanderPose242
+.4byte sCharmanderPose243
+.4byte sCharmanderPose244
+.4byte sCharmanderPose245
+.4byte sCharmanderPose246
+.4byte sCharmanderPose247
+.4byte sCharmanderPose248
+.4byte sCharmanderPose249
+.4byte sCharmanderPose250
+.4byte sCharmanderPose251
+.4byte sCharmanderPose252
+.4byte sCharmanderPose253
+.4byte sCharmanderPose254
+.4byte sCharmanderPose255
+.4byte sCharmanderPose256
+.4byte sCharmanderPose257
+.4byte sCharmanderPose258
+.4byte sCharmanderPose259
+.4byte sCharmanderPose260
+.4byte sCharmanderPose261
+.4byte sCharmanderPose262
+.4byte sCharmanderPose263
+.4byte sCharmanderPose264
+.4byte sCharmanderPose265
+.4byte sCharmanderPose266
+.4byte sCharmanderPose267
+.4byte sCharmanderPose268
+.4byte sCharmanderPose269
+.4byte sCharmanderPose270
+.4byte sCharmanderPose271
+.4byte sCharmanderPose272
+.4byte sCharmanderPose273
+.4byte sCharmanderPose274
+.4byte sCharmanderPose275
+.4byte sCharmanderPose276
+.4byte sCharmanderPose277
+.4byte sCharmanderPose278
+.4byte sCharmanderPose279
+.4byte sCharmanderPose280
+.4byte sCharmanderPose281
+.4byte sCharmanderPose282
+.4byte sCharmanderPose283
+.4byte sCharmanderPose284
+.4byte sCharmanderPose285
+.4byte sCharmanderPose286
+.4byte sCharmanderPose287
+.4byte sCharmanderPose288
+.4byte sCharmanderPose289
+.4byte sCharmanderPose290
+.4byte sCharmanderPose291
+.4byte sCharmanderPose292
+.4byte sCharmanderPose293
+.4byte sCharmanderPose294
+.4byte sCharmanderPose295
+.4byte sCharmanderPose296
+sAxPositionsCharmander:
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte    0,   -7, 	  -6,   -5, 	   6,   -5, 	   0,   -6
+.2byte    0,   -7, 	  -6,   -5, 	   6,   -5, 	   0,   -6
+.2byte    3,   -8, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte    3,   -7, 	   1,   -8, 	  -3,   -4, 	  -2,   -6
+.2byte    2,   -7, 	   5,   -4, 	  -7,   -4, 	  -2,   -5
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    5,   -9, 	  -5,   -6, 	   1,   -5, 	  -2,   -5
+.2byte    5,   -9, 	   1,   -5, 	  -4,   -4, 	  -2,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte    6,  -11, 	  -5,   -7, 	   4,   -6, 	  -2,   -5
+.2byte    6,  -11, 	  -2,   -9, 	   1,   -5, 	  -2,   -5
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -8, 	  -1,   -5
+.2byte   -1,  -15, 	   4,   -8, 	  -7,   -6, 	  -1,   -4
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -7,  -11, 	   4,   -7, 	  -5,   -6, 	   1,   -5
+.2byte   -7,  -11, 	   1,   -9, 	  -2,   -5, 	   1,   -5
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -7,   -9, 	   3,   -6, 	  -3,   -5, 	   0,   -5
+.2byte   -7,   -9, 	  -3,   -5, 	   2,   -4, 	   0,   -5
+.2byte   -5,   -8, 	  -5,   -6, 	   3,   -6, 	   0,   -6
+.2byte   -5,   -7, 	  -3,   -8, 	   1,   -4, 	   0,   -6
+.2byte   -4,   -7, 	  -7,   -4, 	   5,   -4, 	   0,   -5
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte    0,   -7, 	  -6,   -5, 	   6,   -5, 	   0,   -6
+.2byte    0,   -7, 	  -6,   -5, 	   6,   -5, 	   0,   -6
+.2byte    3,   -8, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte    3,   -7, 	   1,   -8, 	  -3,   -4, 	  -2,   -6
+.2byte    2,   -7, 	   5,   -4, 	  -7,   -4, 	  -2,   -5
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    5,   -9, 	  -5,   -6, 	   1,   -5, 	  -2,   -5
+.2byte    5,   -9, 	   1,   -5, 	  -4,   -4, 	  -2,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte    6,  -11, 	  -5,   -7, 	   4,   -6, 	  -2,   -5
+.2byte    6,  -11, 	  -2,   -9, 	   1,   -5, 	  -2,   -5
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -8, 	  -1,   -5
+.2byte   -1,  -15, 	   4,   -8, 	  -7,   -6, 	  -1,   -4
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -7,  -11, 	   4,   -7, 	  -5,   -6, 	   1,   -5
+.2byte   -7,  -11, 	   1,   -9, 	  -2,   -5, 	   1,   -5
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -7,   -9, 	   3,   -6, 	  -3,   -5, 	   0,   -5
+.2byte   -7,   -9, 	  -3,   -5, 	   2,   -4, 	   0,   -5
+.2byte   -5,   -8, 	  -5,   -6, 	   3,   -6, 	   0,   -6
+.2byte   -5,   -7, 	  -3,   -8, 	   1,   -4, 	   0,   -6
+.2byte   -4,   -7, 	  -7,   -4, 	   5,   -4, 	   0,   -5
+.2byte    6,   -9, 	   4,   -4, 	   8,   -8, 	   0,   -7
+.2byte    6,  -10, 	   4,   -5, 	   8,   -9, 	   0,   -8
+.2byte   -4,   -9, 	  -1,  -10, 	  -2,   -5, 	   1,   -6
+.2byte    0,  -12, 	  -7,  -10, 	   7,  -10, 	   0,  -11
+.2byte    8,  -12, 	  -2,   -8, 	   5,   -7, 	   0,   -6
+.2byte   -1,  -16, 	   4,   -7, 	  -6,   -9, 	  -1,   -6
+.2byte   -9,  -11, 	   2,   -7, 	  -7,   -6, 	  -1,   -5
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte   -2,  -10, 	   2,   -7, 	  -6,   -6, 	   0,   -9
+.2byte   -2,  -10, 	   2,   -7, 	  -6,   -6, 	   0,   -9
+.2byte    5,  -11, 	  -6,   -9, 	   4,   -7, 	  -2,   -7
+.2byte    3,  -12, 	   6,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte   -8,  -10, 	  -3,   -6, 	  -3,   -4, 	   0,   -5
+.2byte   -9,  -12, 	   2,   -8, 	  -7,   -7, 	  -1,   -6
+.2byte    0,  -17, 	  -5,  -10, 	   6,   -8, 	   0,   -6
+.2byte   -1,  -11, 	   2,   -8, 	  -6,   -6, 	  -2,   -7
+.2byte   -1,  -11, 	   2,   -8, 	  -6,   -6, 	  -2,   -7
+.2byte   -2,  -14, 	   4,   -7, 	  -6,  -10, 	  -3,   -8
+.2byte   -1,  -11, 	 -11,   -7, 	  -1,   -8, 	  -7,   -5
+.2byte   -4,   -8, 	  -7,   -5, 	   5,   -5, 	   0,   -6
+.2byte   -9,   -9, 	  -5,   -5, 	   0,   -4, 	  -2,   -5
+.2byte   -8,  -11, 	   0,   -9, 	  -3,   -5, 	   0,   -5
+.2byte    5,  -11, 	   6,   -8, 	   1,   -5, 	  -1,   -6
+.2byte    5,  -11, 	   6,   -8, 	   1,   -5, 	  -1,   -6
+.2byte   -9,  -10, 	   1,   -6, 	  -9,   -7, 	  -3,   -4
+.2byte   -4,  -14, 	   1,   -5, 	  -9,   -7, 	  -4,   -4
+.2byte    5,   -7, 	   8,   -4, 	  -4,   -4, 	   1,   -5
+.2byte   -1,   -6, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte  -10,   -8, 	  -6,   -4, 	  -1,   -3, 	  -3,   -4
+.2byte   -8,  -13, 	  -3,  -12, 	 -11,   -6, 	  -4,   -8
+.2byte   -8,  -13, 	  -3,  -12, 	 -11,   -6, 	  -4,   -8
+.2byte    1,  -12, 	   7,   -5, 	  -3,   -8, 	   0,   -6
+.2byte   -1,  -11, 	   4,   -4, 	  -7,   -2, 	  -1,    0
+.2byte  -12,  -10, 	  -2,   -7, 	  -8,   -6, 	  -5,   -6
+.2byte   -8,   -6, 	  -6,   -7, 	  -2,   -3, 	  -3,   -5
+.2byte    6,   -9, 	   2,   -5, 	  -3,   -4, 	  -1,   -5
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -6,  -11, 	  -7,   -8, 	  -2,   -5, 	   0,   -6
+.2byte   -6,  -11, 	  -7,   -8, 	  -2,   -5, 	   0,   -6
+.2byte    8,  -10, 	  -2,   -6, 	   8,   -7, 	   2,   -4
+.2byte    3,  -14, 	  -2,   -5, 	   8,   -7, 	   3,   -4
+.2byte   -6,   -7, 	  -9,   -4, 	   3,   -4, 	  -2,   -5
+.2byte    0,   -6, 	  -6,   -4, 	   6,   -4, 	   0,   -5
+.2byte   13,   -8, 	   9,   -4, 	   4,   -3, 	   6,   -4
+.2byte    0,  -11, 	  -3,   -8, 	   5,   -6, 	   1,   -7
+.2byte    0,  -11, 	  -3,   -8, 	   5,   -6, 	   1,   -7
+.2byte    1,  -14, 	  -5,   -7, 	   5,  -10, 	   2,   -8
+.2byte    0,  -11, 	  10,   -7, 	   0,   -8, 	   6,   -5
+.2byte    3,   -8, 	   6,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte    8,   -9, 	   4,   -5, 	  -1,   -4, 	   1,   -5
+.2byte    7,  -11, 	  -1,   -9, 	   2,   -5, 	  -1,   -5
+.2byte    1,  -10, 	  -3,   -7, 	   5,   -6, 	  -1,   -9
+.2byte    1,  -10, 	  -3,   -7, 	   5,   -6, 	  -1,   -9
+.2byte   -6,  -11, 	   5,   -9, 	  -5,   -7, 	   1,   -7
+.2byte   -4,  -12, 	  -7,   -9, 	   5,   -9, 	   0,  -10
+.2byte    7,  -10, 	   2,   -6, 	   2,   -4, 	  -1,   -5
+.2byte    8,  -12, 	  -3,   -8, 	   6,   -7, 	   0,   -6
+.2byte   -1,  -17, 	   4,  -10, 	  -7,   -8, 	  -1,   -6
+.2byte    0,   -6, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte   -3,   -7, 	  -5,   -7, 	   4,   -6, 	  -1,   -6
+.2byte   -6,   -8, 	  -3,   -7, 	   0,   -5, 	  -1,   -5
+.2byte   -5,  -10, 	  -1,  -10, 	  -6,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	   5,   -6, 	  -7,   -6, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	   5,   -8, 	   0,   -8
+.2byte    4,   -8, 	   1,   -7, 	  -2,   -5, 	  -1,   -5
+.2byte    1,   -7, 	   3,   -7, 	  -6,   -6, 	  -1,   -6
+.2byte   -3,   -8, 	   0,   -9, 	  -1,   -4, 	   2,   -5
+.2byte    4,   -4, 	  -1,    0, 	   6,   -8, 	  -1,   -4
+.2byte    4,   -3, 	  -1,    1, 	   6,   -7, 	  -1,   -3
+.2byte    0,   -8, 	  -6,   -6, 	   6,   -6, 	   0,   -7
+.2byte    5,  -10, 	  -6,   -8, 	   4,   -6, 	  -2,   -6
+.2byte    1,   -5, 	   9,   -3, 	  -5,   -9, 	   2,   -5
+.2byte    1,   -5, 	   9,   -3, 	  -5,   -9, 	   2,   -5
+.2byte    2,   -9, 	   5,   -6, 	  -7,   -6, 	  -2,   -7
+.2byte    3,  -12, 	  -7,   -8, 	   3,   -9, 	  -3,   -6
+.2byte    3,   -6, 	   9,   -8, 	  -3,   -6, 	   0,   -6
+.2byte    3,   -6, 	   9,   -8, 	  -3,   -6, 	   0,   -6
+.2byte    4,   -9, 	  -6,   -6, 	   0,   -5, 	  -3,   -5
+.2byte   -3,  -14, 	  -9,   -7, 	   1,  -10, 	  -2,   -8
+.2byte    7,   -9, 	   6,  -10, 	   1,   -6, 	  -2,   -6
+.2byte    7,   -9, 	   6,  -10, 	   1,   -6, 	  -2,   -6
+.2byte    3,   -9, 	  -8,   -5, 	   1,   -4, 	  -5,   -3
+.2byte    5,   -8, 	   2,   -5, 	  -1,   -9, 	  -2,   -6
+.2byte   -6,   -8, 	   2,  -11, 	  -5,   -5, 	   0,   -6
+.2byte   -6,   -8, 	   2,  -11, 	  -5,   -5, 	   0,   -6
+.2byte   -1,  -11, 	   4,   -4, 	  -7,   -2, 	  -1,    0
+.2byte    2,  -14, 	   8,   -7, 	  -2,  -10, 	   1,   -8
+.2byte   -8,   -9, 	  -7,  -10, 	  -2,   -6, 	   1,   -6
+.2byte   -8,   -9, 	  -7,  -10, 	  -2,   -6, 	   1,   -6
+.2byte   -4,   -9, 	   7,   -5, 	  -2,   -4, 	   4,   -3
+.2byte   -4,  -12, 	   6,   -8, 	  -4,   -9, 	   2,   -6
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -6, 	  -1,   -6
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -6, 	  -1,   -6
+.2byte   -5,   -9, 	   5,   -6, 	  -1,   -5, 	   2,   -5
+.2byte   -6,  -10, 	   5,   -8, 	  -5,   -6, 	   1,   -6
+.2byte   -2,   -5, 	 -10,   -3, 	   4,   -9, 	  -3,   -5
+.2byte   -2,   -5, 	 -10,   -3, 	   4,   -9, 	  -3,   -5
+.2byte   -3,   -9, 	  -6,   -6, 	   6,   -6, 	   1,   -7
+.2byte   -2,   -5, 	  -6,   -5, 	   2,   -3, 	   0,   -5
+.2byte   -3,   -4, 	  -6,   -4, 	   2,   -2, 	  -1,   -4
+.2byte    0,  -13, 	  -4,  -13, 	   4,  -13, 	   0,   -9
+.2byte    0,  -12, 	   5,  -12, 	  -3,  -11, 	   0,   -9
+.2byte    2,  -12, 	   1,  -13, 	   1,  -11, 	  -1,   -8
+.2byte    2,  -12, 	  -4,  -14, 	   2,  -13, 	  -3,   -9
+.2byte    0,  -16, 	   5,  -11, 	  -5,  -11, 	   1,   -9
+.2byte   -4,  -12, 	   2,  -14, 	  -4,  -13, 	   1,   -9
+.2byte   -3,  -12, 	  -2,  -13, 	  -2,  -11, 	   0,   -8
+.2byte   -1,  -12, 	  -6,  -12, 	   2,  -11, 	  -1,   -9
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte    0,   -7, 	  -6,   -5, 	   6,   -5, 	   0,   -6
+.2byte    0,   -7, 	  -6,   -5, 	   6,   -5, 	   0,   -6
+.2byte    3,   -8, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte    3,   -7, 	   1,   -8, 	  -3,   -4, 	  -2,   -6
+.2byte    2,   -7, 	   5,   -4, 	  -7,   -4, 	  -2,   -5
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    5,   -9, 	  -5,   -6, 	   1,   -5, 	  -2,   -5
+.2byte    5,   -9, 	   1,   -5, 	  -4,   -4, 	  -2,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte    6,  -11, 	  -5,   -7, 	   4,   -6, 	  -2,   -5
+.2byte    6,  -11, 	  -2,   -9, 	   1,   -5, 	  -2,   -5
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -8, 	  -1,   -5
+.2byte   -1,  -15, 	   4,   -8, 	  -7,   -6, 	  -1,   -4
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -7,  -11, 	   4,   -7, 	  -5,   -6, 	   1,   -5
+.2byte   -7,  -11, 	   1,   -9, 	  -2,   -5, 	   1,   -5
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -7,   -9, 	   3,   -6, 	  -3,   -5, 	   0,   -5
+.2byte   -7,   -9, 	  -3,   -5, 	   2,   -4, 	   0,   -5
+.2byte   -5,   -8, 	  -5,   -6, 	   3,   -6, 	   0,   -6
+.2byte   -5,   -7, 	  -3,   -8, 	   1,   -4, 	   0,   -6
+.2byte   -4,   -7, 	  -7,   -4, 	   5,   -4, 	   0,   -5
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -6, 	   3,   -6, 	   0,   -6
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    3,   -8, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte    3,   -8, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -5,   -8, 	  -5,   -6, 	   3,   -6, 	   0,   -6
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte    0,   -8, 	  -6,   -6, 	   6,   -6, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte    3,   -8, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte    2,   -8, 	   5,   -5, 	  -7,   -5, 	  -2,   -6
+.2byte    1,   -7, 	   3,   -7, 	  -6,   -6, 	  -1,   -6
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    6,  -10, 	  -4,   -7, 	   2,   -6, 	  -1,   -6
+.2byte    5,   -8, 	   2,   -7, 	  -1,   -5, 	   0,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte    7,  -11, 	  -4,   -7, 	   5,   -6, 	  -1,   -5
+.2byte    3,  -10, 	  -1,  -10, 	   4,   -8, 	  -1,   -8
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -8, 	  -1,   -5
+.2byte   -1,  -12, 	   5,   -6, 	  -7,   -6, 	  -1,   -6
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -7,  -11, 	   4,   -7, 	  -5,   -6, 	   1,   -5
+.2byte   -4,  -10, 	   0,  -10, 	  -5,   -8, 	   0,   -8
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -7,  -10, 	   3,   -7, 	  -3,   -6, 	   0,   -6
+.2byte   -6,   -8, 	  -3,   -7, 	   0,   -5, 	  -1,   -5
+.2byte   -5,   -8, 	  -5,   -6, 	   3,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -7,   -5, 	   5,   -5, 	   0,   -6
+.2byte   -3,   -7, 	  -5,   -7, 	   4,   -6, 	  -1,   -6
+.2byte    0,   -6, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte   -3,   -7, 	  -5,   -7, 	   4,   -6, 	  -1,   -6
+.2byte   -6,   -8, 	  -3,   -7, 	   0,   -5, 	  -1,   -5
+.2byte   -5,  -10, 	  -1,  -10, 	  -6,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	   5,   -6, 	  -7,   -6, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	   5,   -8, 	   0,   -8
+.2byte    4,   -8, 	   1,   -7, 	  -2,   -5, 	  -1,   -5
+.2byte    1,   -7, 	   3,   -7, 	  -6,   -6, 	  -1,   -6
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -6, 	   3,   -6, 	   0,   -6
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    3,   -8, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte   -2,   -9, 	  -4,    1, 	   0,   -6, 	   1,   -3
+.2byte   -3,   -8, 	  -3,    1, 	   0,   -8, 	  -1,   -5
+.2byte    1,   -9, 	   3,    1, 	  -1,   -6, 	  -2,   -3
+.2byte    2,   -8, 	   2,    1, 	  -1,   -8, 	   0,   -5
+.2byte   -2,   -9, 	  -4,    1, 	   0,   -6, 	   1,   -3
+.2byte    1,   -7, 	  -1,   -5, 	   5,   -8, 	   0,   -5
+.2byte    3,   -5, 	   0,   -2, 	   3,   -3, 	  -1,   -5
+.2byte    5,   -6, 	   0,   -4, 	   2,   -5, 	  -1,   -7
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte    0,   -4, 	  -3,   -5, 	   3,   -5, 	   0,   -7
+.2byte    0,  -12, 	  -7,  -11, 	   7,  -11, 	   0,   -8
+.2byte   -2,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    1,   -9, 	  -5,  -13, 	   7,   -6, 	   1,   -7
+.2byte    1,   -9, 	   5,   -5, 	  -5,   -8, 	  -1,   -7
+.2byte   -2,  -11, 	   5,  -12, 	  -8,   -7, 	  -2,   -8
+.2byte   -2,  -11, 	   5,  -12, 	  -8,   -7, 	  -2,   -8
+.2byte    0,   -7, 	  -6,   -6, 	   6,   -6, 	   0,   -8
+.2byte    0,   -6, 	  -6,   -5, 	   6,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -5, 	   6,   -5, 	   0,   -7
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -3,  -12, 	  -6,  -10, 	  -1,   -6, 	   0,   -7
+.2byte    0,  -12, 	  -5,  -10, 	   7,   -6, 	   0,   -7
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -5
+.2byte   -1,   -7, 	   3,   -3, 	  -5,   -3, 	  -1,   -4
+.2byte    0,   -8, 	  -7,   -6, 	   7,   -6, 	   0,   -7
+.2byte    0,  -12, 	  -7,  -11, 	   7,  -11, 	   0,   -8
+.2byte    0,   -7, 	  -3,   -4, 	   3,   -4, 	   0,   -8
+.2byte   -7,  -10, 	  -2,   -6, 	  -2,   -4, 	   1,   -5
+.2byte   -5,   -6, 	   1,   -5, 	  -1,   -6, 	  -2,   -7
+.2byte    5,  -10, 	   0,   -6, 	   0,   -4, 	  -3,   -5
+.2byte    3,   -6, 	  -3,   -5, 	  -1,   -6, 	   0,   -7
+.2byte   -1,  -16, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,   -8, 	   6,   -8, 	  -6,   -8, 	  -1,   -6
+.2byte   -6,   -7, 	  -2,   -7, 	   4,   -6, 	  -1,   -7
+.2byte   -3,  -10, 	  -6,   -9, 	   6,   -6, 	  -1,   -8
+.2byte   -9,   -7, 	  -8,   -7, 	   2,   -6, 	  -4,   -7
+.2byte   -5,   -9, 	  -7,   -7, 	   5,   -6, 	  -1,   -7
+.2byte   -8,   -7, 	  -6,   -7, 	   3,   -6, 	  -3,   -7
+.2byte    4,   -7, 	   0,   -7, 	  -6,   -6, 	  -1,   -7
+.2byte    1,  -10, 	   4,   -9, 	  -8,   -6, 	  -1,   -8
+.2byte    7,   -7, 	   6,   -7, 	  -4,   -6, 	   2,   -7
+.2byte    3,   -9, 	   5,   -7, 	  -7,   -6, 	  -1,   -7
+.2byte    6,   -7, 	   4,   -7, 	  -5,   -6, 	   1,   -7
+.2byte   -7,  -12, 	   3,   -8, 	  -4,   -7, 	   1,   -6
+.2byte   -4,   -7, 	   0,   -6, 	  -4,   -6, 	   1,   -5
+.2byte    6,  -12, 	  -4,   -8, 	   3,   -7, 	  -2,   -6
+.2byte    3,   -9, 	  -1,   -8, 	   3,   -8, 	  -2,   -7
+.2byte   -2,   -9, 	  -4,    1, 	   0,   -6, 	   1,   -3
+.2byte   -3,   -8, 	  -3,    1, 	   0,   -8, 	  -1,   -5
+.2byte    1,   -9, 	   3,    1, 	  -1,   -6, 	  -2,   -3
+.2byte    2,   -8, 	   2,    1, 	  -1,   -8, 	   0,   -5
+.2byte   -2,   -9, 	  -4,    1, 	   0,   -6, 	   1,   -3
+.2byte   -3,   -8, 	  -3,    1, 	   0,   -8, 	  -1,   -5
+.2byte    1,   -9, 	   3,    1, 	  -1,   -6, 	  -2,   -3
+.2byte    2,   -8, 	   2,    1, 	  -1,   -8, 	   0,   -5
+sCharmanderAnimTable1:
+.4byte sCharmanderAnims_1_1
+.4byte sCharmanderAnims_1_2
+.4byte sCharmanderAnims_1_3
+.4byte sCharmanderAnims_1_4
+.4byte sCharmanderAnims_1_5
+.4byte sCharmanderAnims_1_6
+.4byte sCharmanderAnims_1_7
+.4byte sCharmanderAnims_1_8
+sCharmanderAnimTable2:
+.4byte sCharmanderAnims_2_1
+.4byte sCharmanderAnims_2_2
+.4byte sCharmanderAnims_2_3
+.4byte sCharmanderAnims_2_4
+.4byte sCharmanderAnims_2_5
+.4byte sCharmanderAnims_2_6
+.4byte sCharmanderAnims_2_7
+.4byte sCharmanderAnims_2_8
+sCharmanderAnimTable3:
+.4byte sCharmanderAnims_3_1
+.4byte sCharmanderAnims_3_2
+.4byte sCharmanderAnims_3_3
+.4byte sCharmanderAnims_3_4
+.4byte sCharmanderAnims_3_5
+.4byte sCharmanderAnims_3_6
+.4byte sCharmanderAnims_3_7
+.4byte sCharmanderAnims_3_8
+sCharmanderAnimTable4:
+.4byte sCharmanderAnims_4_1
+.4byte sCharmanderAnims_4_2
+.4byte sCharmanderAnims_4_3
+.4byte sCharmanderAnims_4_4
+.4byte sCharmanderAnims_4_5
+.4byte sCharmanderAnims_4_6
+.4byte sCharmanderAnims_4_7
+.4byte sCharmanderAnims_4_8
+sCharmanderAnimTable5:
+.4byte sCharmanderAnims_5_1
+.4byte sCharmanderAnims_5_2
+.4byte sCharmanderAnims_5_3
+.4byte sCharmanderAnims_5_4
+.4byte sCharmanderAnims_5_5
+.4byte sCharmanderAnims_5_6
+.4byte sCharmanderAnims_5_7
+.4byte sCharmanderAnims_5_8
+sCharmanderAnimTable6:
+.4byte sCharmanderAnims_6_1
+.4byte sCharmanderAnims_6_1
+.4byte sCharmanderAnims_6_1
+.4byte sCharmanderAnims_6_1
+.4byte sCharmanderAnims_6_1
+.4byte sCharmanderAnims_6_1
+.4byte sCharmanderAnims_6_1
+.4byte sCharmanderAnims_6_1
+sCharmanderAnimTable7:
+.4byte sCharmanderAnims_7_1
+.4byte sCharmanderAnims_7_2
+.4byte sCharmanderAnims_7_3
+.4byte sCharmanderAnims_7_4
+.4byte sCharmanderAnims_7_5
+.4byte sCharmanderAnims_7_6
+.4byte sCharmanderAnims_7_7
+.4byte sCharmanderAnims_7_8
+sCharmanderAnimTable8:
+.4byte sCharmanderAnims_8_1
+.4byte sCharmanderAnims_8_2
+.4byte sCharmanderAnims_8_3
+.4byte sCharmanderAnims_8_4
+.4byte sCharmanderAnims_8_5
+.4byte sCharmanderAnims_8_6
+.4byte sCharmanderAnims_8_7
+.4byte sCharmanderAnims_8_8
+sCharmanderAnimTable9:
+.4byte sCharmanderAnims_9_1
+.4byte sCharmanderAnims_9_2
+.4byte sCharmanderAnims_9_3
+.4byte sCharmanderAnims_9_4
+.4byte sCharmanderAnims_9_5
+.4byte sCharmanderAnims_9_6
+.4byte sCharmanderAnims_9_7
+.4byte sCharmanderAnims_9_8
+sCharmanderAnimTable10:
+.4byte sCharmanderAnims_10_1
+.4byte sCharmanderAnims_10_2
+.4byte sCharmanderAnims_10_3
+.4byte sCharmanderAnims_10_4
+.4byte sCharmanderAnims_10_5
+.4byte sCharmanderAnims_10_6
+.4byte sCharmanderAnims_10_7
+.4byte sCharmanderAnims_10_8
+sCharmanderAnimTable11:
+.4byte sCharmanderAnims_11_1
+.4byte sCharmanderAnims_11_2
+.4byte sCharmanderAnims_11_3
+.4byte sCharmanderAnims_11_4
+.4byte sCharmanderAnims_11_5
+.4byte sCharmanderAnims_11_6
+.4byte sCharmanderAnims_11_7
+.4byte sCharmanderAnims_11_8
+sCharmanderAnimTable12:
+.4byte sCharmanderAnims_12_1
+.4byte sCharmanderAnims_12_2
+.4byte sCharmanderAnims_12_3
+.4byte sCharmanderAnims_12_4
+.4byte sCharmanderAnims_12_5
+.4byte sCharmanderAnims_12_6
+.4byte sCharmanderAnims_12_7
+.4byte sCharmanderAnims_12_8
+sCharmanderAnimTable13:
+.4byte sCharmanderAnims_13_1
+.4byte sCharmanderAnims_13_2
+.4byte sCharmanderAnims_13_3
+.4byte sCharmanderAnims_13_4
+.4byte sCharmanderAnims_13_5
+.4byte sCharmanderAnims_13_6
+.4byte sCharmanderAnims_13_7
+.4byte sCharmanderAnims_13_8
+sCharmanderAnimTable14:
+.4byte sCharmanderAnims_14_1
+.4byte sCharmanderAnims_14_2
+.4byte sCharmanderAnims_14_3
+.4byte sCharmanderAnims_14_4
+.4byte sCharmanderAnims_14_5
+.4byte sCharmanderAnims_14_6
+.4byte sCharmanderAnims_14_7
+.4byte sCharmanderAnims_14_8
+sCharmanderAnimTable15:
+.4byte sCharmanderAnims_15_1
+.4byte sCharmanderAnims_15_2
+.4byte sCharmanderAnims_15_3
+.4byte sCharmanderAnims_15_4
+.4byte sCharmanderAnims_15_5
+.4byte sCharmanderAnims_15_6
+.4byte sCharmanderAnims_15_7
+.4byte sCharmanderAnims_15_8
+sCharmanderAnimTable16:
+.4byte sCharmanderAnims_16_1
+.4byte sCharmanderAnims_16_2
+.4byte sCharmanderAnims_16_3
+.4byte sCharmanderAnims_16_4
+.4byte sCharmanderAnims_16_5
+.4byte sCharmanderAnims_16_6
+.4byte sCharmanderAnims_16_7
+.4byte sCharmanderAnims_16_8
+sCharmanderAnimTable17:
+.4byte sCharmanderAnims_17_1
+.4byte sCharmanderAnims_17_2
+.4byte sCharmanderAnims_17_3
+.4byte sCharmanderAnims_17_4
+.4byte sCharmanderAnims_17_5
+.4byte sCharmanderAnims_17_6
+.4byte sCharmanderAnims_17_7
+.4byte sCharmanderAnims_17_8
+sCharmanderAnimTable18:
+.4byte sCharmanderAnims_18_1
+.4byte sCharmanderAnims_18_2
+.4byte sCharmanderAnims_18_3
+.4byte sCharmanderAnims_18_4
+.4byte sCharmanderAnims_18_5
+.4byte sCharmanderAnims_18_6
+.4byte sCharmanderAnims_18_7
+.4byte sCharmanderAnims_18_8
+sCharmanderAnimTable19:
+.4byte sCharmanderAnims_19_1
+.4byte sCharmanderAnims_19_2
+.4byte sCharmanderAnims_19_3
+.4byte sCharmanderAnims_19_4
+.4byte sCharmanderAnims_19_5
+.4byte sCharmanderAnims_19_6
+.4byte sCharmanderAnims_19_7
+.4byte sCharmanderAnims_19_8
+sCharmanderAnimTable20:
+.4byte sCharmanderAnims_20_1
+.4byte sCharmanderAnims_20_2
+.4byte sCharmanderAnims_20_3
+.4byte sCharmanderAnims_20_4
+.4byte sCharmanderAnims_20_5
+.4byte sCharmanderAnims_20_6
+.4byte sCharmanderAnims_20_7
+.4byte sCharmanderAnims_20_8
+sCharmanderAnimTable21:
+.4byte sCharmanderAnims_21_1
+.4byte sCharmanderAnims_21_2
+.4byte sCharmanderAnims_21_3
+.4byte sCharmanderAnims_21_4
+.4byte sCharmanderAnims_21_5
+.4byte sCharmanderAnims_21_6
+.4byte sCharmanderAnims_21_7
+.4byte sCharmanderAnims_21_8
+sCharmanderAnimTable22:
+.4byte sCharmanderAnims_22_1
+.4byte sCharmanderAnims_22_2
+.4byte sCharmanderAnims_22_3
+.4byte sCharmanderAnims_22_4
+.4byte sCharmanderAnims_22_5
+.4byte sCharmanderAnims_22_6
+.4byte sCharmanderAnims_22_7
+.4byte sCharmanderAnims_22_8
+sCharmanderAnimTable23:
+.4byte sCharmanderAnims_23_1
+.4byte sCharmanderAnims_23_2
+.4byte sCharmanderAnims_23_3
+.4byte sCharmanderAnims_23_4
+.4byte sCharmanderAnims_23_5
+.4byte sCharmanderAnims_23_6
+.4byte sCharmanderAnims_23_7
+.4byte sCharmanderAnims_23_8
+sCharmanderAnimTable24:
+.4byte sCharmanderAnims_24_1
+.4byte sCharmanderAnims_24_2
+.4byte sCharmanderAnims_24_3
+.4byte sCharmanderAnims_24_4
+.4byte sCharmanderAnims_24_5
+.4byte sCharmanderAnims_24_6
+.4byte sCharmanderAnims_24_7
+.4byte sCharmanderAnims_24_8
+sCharmanderAnimTable25:
+.4byte sCharmanderAnims_25_1
+.4byte sCharmanderAnims_25_2
+.4byte sCharmanderAnims_25_3
+.4byte sCharmanderAnims_25_4
+.4byte sCharmanderAnims_25_5
+.4byte sCharmanderAnims_25_6
+.4byte sCharmanderAnims_25_7
+.4byte sCharmanderAnims_25_8
+sCharmanderAnimTable26:
+.4byte sCharmanderAnims_26_1
+.4byte sCharmanderAnims_26_2
+.4byte sCharmanderAnims_26_3
+.4byte sCharmanderAnims_26_4
+.4byte sCharmanderAnims_26_5
+.4byte sCharmanderAnims_26_6
+.4byte sCharmanderAnims_26_7
+.4byte sCharmanderAnims_26_8
+sCharmanderAnimTable27:
+.4byte sCharmanderAnims_27_1
+.4byte sCharmanderAnims_27_1
+.4byte sCharmanderAnims_27_1
+.4byte sCharmanderAnims_27_1
+.4byte sCharmanderAnims_27_1
+.4byte sCharmanderAnims_27_1
+.4byte sCharmanderAnims_27_1
+.4byte sCharmanderAnims_27_1
+sCharmanderAnimTable28:
+.4byte sCharmanderAnims_28_1
+.4byte sCharmanderAnims_28_2
+.4byte sCharmanderAnims_28_3
+.4byte sCharmanderAnims_28_4
+.4byte sCharmanderAnims_28_5
+.4byte sCharmanderAnims_28_6
+.4byte sCharmanderAnims_28_7
+.4byte sCharmanderAnims_28_8
+sAxAnimationsCharmander:
+.4byte sCharmanderAnimTable1
+.4byte sCharmanderAnimTable2
+.4byte sCharmanderAnimTable3
+.4byte sCharmanderAnimTable4
+.4byte sCharmanderAnimTable5
+.4byte sCharmanderAnimTable6
+.4byte sCharmanderAnimTable7
+.4byte sCharmanderAnimTable8
+.4byte sCharmanderAnimTable9
+.4byte sCharmanderAnimTable10
+.4byte sCharmanderAnimTable11
+.4byte sCharmanderAnimTable12
+.4byte sCharmanderAnimTable13
+.4byte sCharmanderAnimTable14
+.4byte sCharmanderAnimTable15
+.4byte sCharmanderAnimTable16
+.4byte sCharmanderAnimTable17
+.4byte sCharmanderAnimTable18
+.4byte sCharmanderAnimTable19
+.4byte sCharmanderAnimTable20
+.4byte sCharmanderAnimTable21
+.4byte sCharmanderAnimTable22
+.4byte sCharmanderAnimTable23
+.4byte sCharmanderAnimTable24
+.4byte sCharmanderAnimTable25
+.4byte sCharmanderAnimTable26
+.4byte sCharmanderAnimTable27
+.4byte sCharmanderAnimTable28
+sAxSpritesCharmander:
+.4byte sCharmanderSprites1
+.4byte sCharmanderSprites2
+.4byte sCharmanderSprites3
+.4byte sCharmanderSprites4
+.4byte sCharmanderSprites5
+.4byte sCharmanderSprites6
+.4byte sCharmanderSprites7
+.4byte sCharmanderSprites8
+.4byte sCharmanderSprites9
+.4byte sCharmanderSprites10
+.4byte sCharmanderSprites11
+.4byte sCharmanderSprites12
+.4byte sCharmanderSprites13
+.4byte sCharmanderSprites14
+.4byte sCharmanderSprites15
+.4byte sCharmanderSprites16
+.4byte sCharmanderSprites17
+.4byte sCharmanderSprites18
+.4byte sCharmanderSprites19
+.4byte sCharmanderSprites20
+.4byte sCharmanderSprites21
+.4byte sCharmanderSprites22
+.4byte sCharmanderSprites23
+.4byte sCharmanderSprites24
+.4byte sCharmanderSprites25
+.4byte sCharmanderSprites26
+.4byte sCharmanderSprites27
+.4byte sCharmanderSprites28
+.4byte sCharmanderSprites29
+.4byte sCharmanderSprites30
+.4byte sCharmanderSprites31
+.4byte sCharmanderSprites32
+.4byte sCharmanderSprites33
+.4byte sCharmanderSprites34
+.4byte sCharmanderSprites35
+.4byte sCharmanderSprites36
+.4byte sCharmanderSprites37
+.4byte sCharmanderSprites38
+.4byte sCharmanderSprites39
+.4byte sCharmanderSprites40
+.4byte sCharmanderSprites41
+.4byte sCharmanderSprites42
+.4byte sCharmanderSprites43
+.4byte sCharmanderSprites44
+.4byte sCharmanderSprites45
+.4byte sCharmanderSprites46
+.4byte sCharmanderSprites47
+.4byte sCharmanderSprites48
+.4byte sCharmanderSprites49
+.4byte sCharmanderSprites50
+.4byte sCharmanderSprites51
+.4byte sCharmanderSprites52
+.4byte sCharmanderSprites53
+.4byte sCharmanderSprites54
+.4byte sCharmanderSprites55
+.4byte sCharmanderSprites56
+.4byte sCharmanderSprites57
+.4byte sCharmanderSprites58
+.4byte sCharmanderSprites59
+.4byte sCharmanderSprites60
+.4byte sCharmanderSprites61
+.4byte sCharmanderSprites62
+.4byte sCharmanderSprites63
+.4byte sCharmanderSprites64
+.4byte sCharmanderSprites65
+.4byte sCharmanderSprites66
+.4byte sCharmanderSprites67
+.4byte sCharmanderSprites68
+.4byte sCharmanderSprites69
+.4byte sCharmanderSprites70
+.4byte sCharmanderSprites71
+.4byte sCharmanderSprites72
+.4byte sCharmanderSprites73
+.4byte sCharmanderSprites74
+.4byte sCharmanderSprites75
+.4byte sCharmanderSprites76
+.4byte sCharmanderSprites77
+.4byte sCharmanderSprites78
+.4byte sCharmanderSprites79
+.4byte sCharmanderSprites80
+.4byte sCharmanderSprites81
+.4byte sCharmanderSprites82
+.4byte sCharmanderSprites83
+.4byte sCharmanderSprites84
+sAxMainCharmander:
+ax_main sAxPosesCharmander, sAxAnimationsCharmander, 28, sAxSpritesCharmander, sAxPositionsCharmander

--- a/data/ax/charmeleon.inc
+++ b/data/ax/charmeleon.inc
@@ -1,0 +1,2873 @@
+.global gAxCharmeleon
+gAxCharmeleon:
+ax_siro sAxMainCharmeleon
+sCharmeleonPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose2:
+ax_pose 1, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sCharmeleonPose3:
+ax_pose 2, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose4:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose5:
+ax_pose 4, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose6:
+ax_pose 5, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose7:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose8:
+ax_pose 7, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose9:
+ax_pose 8, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose10:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sCharmeleonPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose13:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose14:
+ax_pose 13, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose15:
+ax_pose 14, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sCharmeleonPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose17:
+ax_pose 10, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose26:
+ax_pose 1, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sCharmeleonPose27:
+ax_pose 2, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose28:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose29:
+ax_pose 4, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose30:
+ax_pose 5, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose31:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose32:
+ax_pose 7, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose33:
+ax_pose 8, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose34:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose35:
+ax_pose 10, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sCharmeleonPose36:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose37:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose38:
+ax_pose 13, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose39:
+ax_pose 14, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sCharmeleonPose40:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose41:
+ax_pose 10, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose43:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose44:
+ax_pose 7, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose45:
+ax_pose 8, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose46:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose47:
+ax_pose 4, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose48:
+ax_pose 5, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose50:
+ax_pose 15, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose51:
+ax_pose 16, 0x81e7, 0x80f2, 0x0c00
+ax_pose 17, 0x01e7, 0x80f0, 0x0c08
+ax_pose_terminator
+sCharmeleonPose52:
+ax_pose 17, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose53:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose54:
+ax_pose 18, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose55:
+ax_pose 19, 0x01e7, 0x90f0, 0x0c00
+ax_pose 20, 0x01e7, 0x90f0, 0x0c10
+ax_pose_terminator
+sCharmeleonPose56:
+ax_pose 20, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose57:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose58:
+ax_pose 21, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose59:
+ax_pose 22, 0x01e7, 0x90f0, 0x0c00
+ax_pose 23, 0x01e7, 0x90f0, 0x0c10
+ax_pose_terminator
+sCharmeleonPose60:
+ax_pose 23, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose61:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose62:
+ax_pose 24, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose63:
+ax_pose 25, 0x41e7, 0x90f0, 0x0c00
+ax_pose 26, 0x01e7, 0x90f0, 0x0c08
+ax_pose_terminator
+sCharmeleonPose64:
+ax_pose 26, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose65:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose66:
+ax_pose 27, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose67:
+ax_pose 28, 0x81e7, 0x8100, 0x0c00
+ax_pose 29, 0x01e7, 0x80f0, 0x0c08
+ax_pose_terminator
+sCharmeleonPose68:
+ax_pose 29, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose69:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose70:
+ax_pose 24, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose71:
+ax_pose 25, 0x41e7, 0x80f0, 0x0c00
+ax_pose 26, 0x01e7, 0x80f0, 0x0c08
+ax_pose_terminator
+sCharmeleonPose72:
+ax_pose 26, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose73:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose74:
+ax_pose 21, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose75:
+ax_pose 22, 0x01e7, 0x80f0, 0x0c00
+ax_pose 23, 0x01e7, 0x80f0, 0x0c10
+ax_pose_terminator
+sCharmeleonPose76:
+ax_pose 23, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose77:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose78:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose79:
+ax_pose 19, 0x01e7, 0x80f0, 0x0c00
+ax_pose 20, 0x01e7, 0x80f0, 0x0c10
+ax_pose_terminator
+sCharmeleonPose80:
+ax_pose 20, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose81:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose82:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose83:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose84:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose85:
+ax_pose 32, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose86:
+ax_pose 33, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose87:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose88:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose89:
+ax_pose 35, 0x01e7, 0x90f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose90:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose91:
+ax_pose 36, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose92:
+ax_pose 37, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sCharmeleonPose93:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose94:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose95:
+ax_pose 39, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose96:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose97:
+ax_pose 36, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose98:
+ax_pose 37, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sCharmeleonPose99:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose100:
+ax_pose 34, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose101:
+ax_pose 35, 0x01e7, 0x80ed, 0x0c00
+ax_pose_terminator
+sCharmeleonPose102:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose103:
+ax_pose 32, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose104:
+ax_pose 33, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose105:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose106:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose107:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose108:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose109:
+ax_pose 32, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose110:
+ax_pose 33, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose111:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose112:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose113:
+ax_pose 35, 0x01e7, 0x90f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose114:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose115:
+ax_pose 36, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose116:
+ax_pose 37, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sCharmeleonPose117:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose118:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose119:
+ax_pose 39, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose120:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose121:
+ax_pose 36, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose122:
+ax_pose 37, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sCharmeleonPose123:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose124:
+ax_pose 34, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose125:
+ax_pose 35, 0x01e7, 0x80ed, 0x0c00
+ax_pose_terminator
+sCharmeleonPose126:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose127:
+ax_pose 32, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose128:
+ax_pose 33, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose129:
+ax_pose 40, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose130:
+ax_pose 41, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose131:
+ax_pose 42, 0x01e1, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose132:
+ax_pose 43, 0x01e4, 0x90ea, 0x0c00
+ax_pose_terminator
+sCharmeleonPose133:
+ax_pose 44, 0x01e4, 0x90e8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose134:
+ax_pose 45, 0x01e6, 0x90e9, 0x0c00
+ax_pose_terminator
+sCharmeleonPose135:
+ax_pose 46, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose136:
+ax_pose 45, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sCharmeleonPose137:
+ax_pose 44, 0x01e4, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose138:
+ax_pose 43, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sCharmeleonPose139:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose140:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose141:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose142:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose143:
+ax_pose 32, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose144:
+ax_pose 33, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose145:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose146:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose147:
+ax_pose 35, 0x01e7, 0x90f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose148:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose149:
+ax_pose 36, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose150:
+ax_pose 37, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sCharmeleonPose151:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose152:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose153:
+ax_pose 39, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose154:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose155:
+ax_pose 36, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose156:
+ax_pose 37, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sCharmeleonPose157:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose158:
+ax_pose 34, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose159:
+ax_pose 35, 0x01e7, 0x80ed, 0x0c00
+ax_pose_terminator
+sCharmeleonPose160:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose161:
+ax_pose 32, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose162:
+ax_pose 33, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose163:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose164:
+ax_pose 33, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose165:
+ax_pose 35, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose166:
+ax_pose 37, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sCharmeleonPose167:
+ax_pose 39, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose168:
+ax_pose 37, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sCharmeleonPose169:
+ax_pose 35, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose170:
+ax_pose 33, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose171:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose172:
+ax_pose 33, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose173:
+ax_pose 35, 0x01e7, 0x90f3, 0x0c00
+ax_pose_terminator
+sCharmeleonPose174:
+ax_pose 37, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sCharmeleonPose175:
+ax_pose 39, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose176:
+ax_pose 37, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sCharmeleonPose177:
+ax_pose 35, 0x01e7, 0x80ed, 0x0c00
+ax_pose_terminator
+sCharmeleonPose178:
+ax_pose 33, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose179:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose180:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose181:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose182:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose183:
+ax_pose 32, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose184:
+ax_pose 33, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose185:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose186:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose187:
+ax_pose 35, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose188:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose189:
+ax_pose 36, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose190:
+ax_pose 37, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose191:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose192:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose193:
+ax_pose 39, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose194:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose195:
+ax_pose 36, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose196:
+ax_pose 37, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose197:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose198:
+ax_pose 34, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose199:
+ax_pose 35, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose200:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose201:
+ax_pose 32, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose202:
+ax_pose 33, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose203:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose204:
+ax_pose 32, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sCharmeleonPose205:
+ax_pose 34, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose206:
+ax_pose 36, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sCharmeleonPose207:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sCharmeleonPose208:
+ax_pose 36, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose209:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sCharmeleonPose210:
+ax_pose 32, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sCharmeleonPose211:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose212:
+ax_pose 3, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose213:
+ax_pose 6, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose214:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sCharmeleonPose215:
+ax_pose 12, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sCharmeleonPose216:
+ax_pose 9, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose217:
+ax_pose 6, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sCharmeleonPose218:
+ax_pose 3, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+.align 2
+sCharmeleonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 25, 0, -6, 0, -6,
+ax_anim 2, 0, 25, 1, -6, 1, -6,
+ax_anim 4, 0, 25, 0, -6, 0, -6,
+ax_anim 1, 2, 26, -1, -2, -1, -2,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 30, 0, 21, 0, 21,
+ax_anim 2, 1, 30, 1, 21, 1, 21,
+ax_anim 2, 0, 30, 0, 21, 0, 21,
+ax_anim 2, 0, 30, 1, 21, 1, 21,
+ax_anim 2, 0, 30, 0, 21, 0, 21,
+ax_anim 2, 0, 30, 1, 21, 1, 21,
+ax_anim 2, 0, 29, 1, 9, 1, 9,
+ax_anim_terminator
+sCharmeleonAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 2, 0, 28, -6, -6, -6, -6,
+ax_anim 2, 0, 28, -5, -7, -5, -7,
+ax_anim 4, 0, 28, -6, -6, -6, -6,
+ax_anim 1, 2, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 19, 19, 21, 21,
+ax_anim 2, 1, 33, 20, 18, 22, 20,
+ax_anim 2, 0, 33, 19, 19, 21, 21,
+ax_anim 2, 0, 33, 20, 18, 22, 20,
+ax_anim 2, 0, 33, 19, 19, 21, 21,
+ax_anim 2, 0, 33, 20, 18, 22, 20,
+ax_anim 2, 0, 32, 9, 9, 9, 9,
+ax_anim_terminator
+sCharmeleonAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 31, -4, 0, -4, 0,
+ax_anim 2, 0, 31, -6, 0, -6, 0,
+ax_anim 2, 0, 31, -6, -1, -6, -1,
+ax_anim 4, 0, 31, -6, 0, -6, 0,
+ax_anim 1, 2, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 7, 0, 7, 0,
+ax_anim 2, 0, 36, 20, 0, 20, 0,
+ax_anim 2, 1, 36, 20, 1, 20, 1,
+ax_anim 2, 0, 36, 20, 0, 20, 0,
+ax_anim 2, 0, 36, 20, 1, 20, 1,
+ax_anim 2, 0, 36, 20, 0, 20, 0,
+ax_anim 2, 0, 36, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 9, 0, 9, 0,
+ax_anim_terminator
+sCharmeleonAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 2, 0, 34, -6, 6, -6, 6,
+ax_anim 2, 0, 34, -5, 7, -5, 7,
+ax_anim 4, 0, 34, -6, 6, -6, 6,
+ax_anim 1, 2, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 1, 39, 21, -21, 21, -21,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 21, -21, 21, -21,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 21, -21, 21, -21,
+ax_anim 2, 0, 38, 9, -9, 9, -9,
+ax_anim_terminator
+sCharmeleonAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 6, 0, 6,
+ax_anim 2, 0, 37, 1, 6, 1, 6,
+ax_anim 4, 0, 37, 0, 6, 0, 6,
+ax_anim 1, 2, 38, -1, 2, -1, 2,
+ax_anim 1, 0, 39, 0, -10, 0, -10,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 1, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 0, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 0, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 41, 1, -9, 1, -9,
+ax_anim_terminator
+sCharmeleonAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 2, 0, 40, 6, 6, 6, 6,
+ax_anim 2, 0, 40, 5, 7, 5, 7,
+ax_anim 4, 0, 40, 6, 6, 6, 6,
+ax_anim 1, 2, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 42, -10, -10, -10, -10,
+ax_anim 2, 0, 45, -20, -22, -20, -22,
+ax_anim 2, 1, 45, -21, -21, -21, -21,
+ax_anim 2, 0, 45, -20, -22, -20, -22,
+ax_anim 2, 0, 45, -21, -21, -21, -21,
+ax_anim 2, 0, 45, -20, -22, -20, -22,
+ax_anim 2, 0, 45, -21, -21, -21, -21,
+ax_anim 2, 0, 44, -9, -9, -9, -9,
+ax_anim_terminator
+sCharmeleonAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 43, 4, 0, 4, 0,
+ax_anim 2, 0, 43, 6, 0, 6, 0,
+ax_anim 2, 0, 43, 6, -1, 6, -1,
+ax_anim 4, 0, 43, 6, 0, 6, 0,
+ax_anim 1, 2, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 45, -6, 0, -6, 0,
+ax_anim 2, 0, 24, -18, 0, -18, 0,
+ax_anim 2, 1, 24, -18, 1, -18, 1,
+ax_anim 2, 0, 24, -18, 0, -18, 0,
+ax_anim 2, 0, 24, -18, 1, -18, 1,
+ax_anim 2, 0, 24, -18, 0, -18, 0,
+ax_anim 2, 0, 24, -18, 1, -18, 1,
+ax_anim 2, 0, 47, -9, 0, -9, 0,
+ax_anim_terminator
+sCharmeleonAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 2, 0, 46, 6, -6, 6, -6,
+ax_anim 2, 0, 46, 5, -7, 5, -7,
+ax_anim 4, 0, 46, 6, -6, 6, -6,
+ax_anim 1, 2, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 24, -10, 10, -10, 10,
+ax_anim 2, 0, 27, -19, 19, -21, 21,
+ax_anim 2, 1, 27, -20, 18, -22, 20,
+ax_anim 2, 0, 27, -19, 19, -21, 21,
+ax_anim 2, 0, 27, -20, 18, -22, 20,
+ax_anim 2, 0, 27, -19, 19, -21, 21,
+ax_anim 2, 0, 27, -20, 18, -22, 20,
+ax_anim 2, 0, 26, -9, 9, -9, 9,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -4, 0, -4,
+ax_anim 6, 0, 49, 0, -5, 0, -5,
+ax_anim 1, 0, 49, 0, 2, 0, 2,
+ax_anim 2, 2, 49, 0, 8, 0, 8,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 1, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim 2, 0, 48, 0, 2, 0, 2,
+ax_anim_terminator
+sCharmeleonAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -4, -4, -4, -4,
+ax_anim 6, 0, 53, -5, -5, -5, -5,
+ax_anim 1, 0, 53, 1, 1, 1, 1,
+ax_anim 2, 2, 53, 8, 9, 8, 9,
+ax_anim 2, 0, 54, 15, 17, 15, 17,
+ax_anim 2, 1, 55, 14, 18, 14, 18,
+ax_anim 2, 0, 55, 15, 17, 15, 17,
+ax_anim 2, 0, 55, 14, 18, 14, 18,
+ax_anim 2, 0, 55, 15, 17, 15, 17,
+ax_anim 2, 0, 55, 14, 18, 14, 18,
+ax_anim 2, 0, 52, 8, 8, 8, 8,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim_terminator
+sCharmeleonAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 2, 0, 57, -4, 0, -4, 0,
+ax_anim 6, 0, 57, -5, 0, -5, 0,
+ax_anim 1, 0, 57, 1, 0, 1, 0,
+ax_anim 2, 2, 57, 6, 0, 6, 0,
+ax_anim 2, 0, 58, 14, 0, 14, 0,
+ax_anim 2, 1, 59, 14, -1, 14, -1,
+ax_anim 2, 0, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 59, 14, -1, 14, -1,
+ax_anim 2, 0, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 59, 14, -1, 14, -1,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim_terminator
+sCharmeleonAnims_3_4:
+ax_anim 2, 0, 60, -1, 1, -1, 1,
+ax_anim 2, 0, 61, -4, 4, -4, 4,
+ax_anim 6, 0, 61, -5, 5, -5, 5,
+ax_anim 1, 0, 61, 2, -2, 2, -2,
+ax_anim 2, 2, 61, 8, -9, 8, -9,
+ax_anim 2, 0, 62, 15, -17, 15, -17,
+ax_anim 2, 1, 63, 14, -18, 14, -18,
+ax_anim 2, 0, 63, 15, -17, 15, -17,
+ax_anim 2, 0, 63, 14, -18, 14, -18,
+ax_anim 2, 0, 63, 15, -17, 15, -17,
+ax_anim 2, 0, 63, 14, -18, 14, -18,
+ax_anim 2, 0, 60, 8, -8, 8, -8,
+ax_anim 2, 0, 60, 2, -2, 2, -2,
+ax_anim_terminator
+sCharmeleonAnims_3_5:
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 0, 65, 0, 4, 0, 4,
+ax_anim 6, 0, 65, 0, 5, 0, 5,
+ax_anim 1, 0, 65, 0, -2, 0, -2,
+ax_anim 2, 2, 65, 0, -9, 0, -9,
+ax_anim 2, 0, 66, 0, -15, 0, -15,
+ax_anim 2, 1, 67, 1, -15, 1, -15,
+ax_anim 2, 0, 67, 0, -15, 0, -15,
+ax_anim 2, 0, 67, 1, -15, 1, -15,
+ax_anim 2, 0, 67, 0, -15, 0, -15,
+ax_anim 2, 0, 67, 1, -15, 1, -15,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim_terminator
+sCharmeleonAnims_3_6:
+ax_anim 2, 0, 68, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim 6, 0, 69, 5, 5, 5, 5,
+ax_anim 1, 0, 69, -2, -2, -2, -2,
+ax_anim 2, 2, 69, -8, -9, -8, -9,
+ax_anim 2, 0, 70, -15, -17, -15, -17,
+ax_anim 2, 1, 71, -14, -18, -14, -18,
+ax_anim 2, 0, 71, -15, -17, -15, -17,
+ax_anim 2, 0, 71, -14, -18, -14, -18,
+ax_anim 2, 0, 71, -15, -17, -15, -17,
+ax_anim 2, 0, 71, -14, -18, -14, -18,
+ax_anim 2, 0, 68, -8, -8, -8, -8,
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim_terminator
+sCharmeleonAnims_3_7:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 4, 0, 4, 0,
+ax_anim 6, 0, 73, 5, 0, 5, 0,
+ax_anim 1, 0, 73, -1, 0, -1, 0,
+ax_anim 2, 2, 73, -6, 0, -6, 0,
+ax_anim 2, 0, 74, -14, 0, -14, 0,
+ax_anim 2, 1, 75, -14, -1, -14, -1,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 75, -14, -1, -14, -1,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 75, -14, -1, -14, -1,
+ax_anim 2, 0, 72, -6, 0, -6, 0,
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim_terminator
+sCharmeleonAnims_3_8:
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 2, 0, 77, 4, -4, 4, -4,
+ax_anim 6, 0, 77, 5, -5, 5, -5,
+ax_anim 1, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 2, 77, -8, 9, -8, 9,
+ax_anim 2, 0, 78, -15, 17, -15, 17,
+ax_anim 2, 1, 79, -14, 18, -14, 18,
+ax_anim 2, 0, 79, -15, 17, -15, 17,
+ax_anim 2, 0, 79, -14, 18, -14, 18,
+ax_anim 2, 0, 79, -15, 17, -15, 17,
+ax_anim 2, 0, 79, -14, 18, -14, 18,
+ax_anim 2, 0, 76, -8, 8, -8, 8,
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_4_1:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 4, 2, 81, 0, -3, 0, -3,
+ax_anim 1, 0, 82, 0, -3, 0, -3,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 5, 0, 5,
+ax_anim 2, 1, 82, -1, 5, -1, 5,
+ax_anim 2, 0, 82, 0, 5, 0, 5,
+ax_anim 2, 0, 82, -1, 5, -1, 5,
+ax_anim 2, 0, 82, 0, 5, 0, 5,
+ax_anim 2, 0, 82, -1, 5, -1, 5,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sCharmeleonAnims_4_2:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -2, -2, -2, -2,
+ax_anim 4, 2, 84, -3, -3, -3, -3,
+ax_anim 1, 0, 85, -3, -3, -3, -3,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 5, 5, 5, 5,
+ax_anim 2, 1, 85, 6, 4, 6, 4,
+ax_anim 2, 0, 85, 5, 5, 5, 5,
+ax_anim 2, 0, 85, 6, 4, 6, 4,
+ax_anim 2, 0, 85, 5, 5, 5, 5,
+ax_anim 2, 0, 85, 6, 4, 6, 4,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim_terminator
+sCharmeleonAnims_4_3:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -2, 0, -2, 0,
+ax_anim 4, 2, 87, -3, 0, -3, 0,
+ax_anim 1, 0, 88, -3, 0, -3, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 5, 0, 5, 0,
+ax_anim 2, 1, 88, 5, 1, 5, 1,
+ax_anim 2, 0, 88, 5, 0, 5, 0,
+ax_anim 2, 0, 88, 5, 1, 5, 1,
+ax_anim 2, 0, 88, 5, 0, 5, 0,
+ax_anim 2, 0, 88, 5, 1, 5, 1,
+ax_anim 2, 0, 86, 2, 0, 2, 0,
+ax_anim_terminator
+sCharmeleonAnims_4_4:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -2, 2, -2, 2,
+ax_anim 4, 2, 90, -3, 3, -3, 3,
+ax_anim 1, 0, 91, -3, 3, -3, 3,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 1, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim_terminator
+sCharmeleonAnims_4_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 4, 2, 93, 0, 3, 0, 3,
+ax_anim 1, 0, 94, 0, 3, 0, 3,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 1, 94, -1, -5, -1, -5,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, -1, -5, -1, -5,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, -1, -5, -1, -5,
+ax_anim 2, 0, 92, 0, -2, 0, -2,
+ax_anim_terminator
+sCharmeleonAnims_4_6:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 4, 2, 96, 3, 3, 3, 3,
+ax_anim 1, 0, 97, 3, 3, 3, 3,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -5, -5, -5, -5,
+ax_anim 2, 1, 97, -6, -4, -6, -4,
+ax_anim 2, 0, 97, -5, -5, -5, -5,
+ax_anim 2, 0, 97, -6, -4, -6, -4,
+ax_anim 2, 0, 97, -5, -5, -5, -5,
+ax_anim 2, 0, 97, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim_terminator
+sCharmeleonAnims_4_7:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 4, 2, 99, 3, 0, 3, 0,
+ax_anim 1, 0, 100, 3, 0, 3, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -5, 0, -5, 0,
+ax_anim 2, 1, 100, -5, 1, -5, 1,
+ax_anim 2, 0, 100, -5, 0, -5, 0,
+ax_anim 2, 0, 100, -5, 1, -5, 1,
+ax_anim 2, 0, 100, -5, 0, -5, 0,
+ax_anim 2, 0, 100, -5, 1, -5, 1,
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim_terminator
+sCharmeleonAnims_4_8:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 4, 2, 102, 3, -3, 3, -3,
+ax_anim 1, 0, 103, 3, -3, 3, -3,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 1, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_5_1:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 4, 2, 105, 0, -3, 0, -3,
+ax_anim 1, 0, 106, 0, -3, 0, -3,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 1, 106, -1, 5, -1, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, -1, 5, -1, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, -1, 5, -1, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sCharmeleonAnims_5_2:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 4, 2, 108, -3, -3, -3, -3,
+ax_anim 1, 0, 109, -3, -3, -3, -3,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 1, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim_terminator
+sCharmeleonAnims_5_3:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 4, 2, 111, -3, 0, -3, 0,
+ax_anim 1, 0, 112, -3, 0, -3, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 1, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sCharmeleonAnims_5_4:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 4, 2, 114, -3, 3, -3, 3,
+ax_anim 1, 0, 115, -3, 3, -3, 3,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 1, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim_terminator
+sCharmeleonAnims_5_5:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 4, 2, 117, 0, 3, 0, 3,
+ax_anim 1, 0, 118, 0, 3, 0, 3,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 1, 118, -1, -5, -1, -5,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, -1, -5, -1, -5,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, -1, -5, -1, -5,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sCharmeleonAnims_5_6:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 4, 2, 120, 3, 3, 3, 3,
+ax_anim 1, 0, 121, 3, 3, 3, 3,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 1, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim_terminator
+sCharmeleonAnims_5_7:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 4, 2, 123, 3, 0, 3, 0,
+ax_anim 1, 0, 124, 3, 0, 3, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 1, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sCharmeleonAnims_5_8:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 4, 2, 126, 3, -3, 3, -3,
+ax_anim 1, 0, 127, 3, -3, 3, -3,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 1, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sCharmeleonAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sCharmeleonAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sCharmeleonAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sCharmeleonAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sCharmeleonAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sCharmeleonAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sCharmeleonAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 3, 0, 139, 0, -4, 0, 0,
+ax_anim 3, 0, 139, 0, -5, 0, 0,
+ax_anim 3, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_8_2:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -3, 0, 0,
+ax_anim 3, 0, 142, 0, -4, 0, 0,
+ax_anim 3, 0, 142, 0, -5, 0, 0,
+ax_anim 3, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -3, 0, 0,
+ax_anim 3, 0, 145, 0, -4, 0, 0,
+ax_anim 3, 0, 145, 0, -5, 0, 0,
+ax_anim 3, 0, 145, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_8_4:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -3, 0, 0,
+ax_anim 3, 0, 148, 0, -4, 0, 0,
+ax_anim 3, 0, 148, 0, -5, 0, 0,
+ax_anim 3, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_8_5:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, -3, 0, 0,
+ax_anim 3, 0, 151, 0, -4, 0, 0,
+ax_anim 3, 0, 151, 0, -5, 0, 0,
+ax_anim 3, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_8_6:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -3, 0, 0,
+ax_anim 3, 0, 154, 0, -4, 0, 0,
+ax_anim 3, 0, 154, 0, -5, 0, 0,
+ax_anim 3, 0, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 3, 0, 157, 0, -4, 0, 0,
+ax_anim 3, 0, 157, 0, -5, 0, 0,
+ax_anim 3, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_8_8:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -4, 0, 0,
+ax_anim 3, 0, 160, 0, -5, 0, 0,
+ax_anim 3, 0, 160, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 24, 9, 24, 9,
+ax_anim 3, 0, 165, 23, 20, 23, 20,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 12, 2, 12,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 20, 0, 20, 0,
+ax_anim 2, 3, 165, 17, 4, 17, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 4, 4, 4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 11, -20, 11, -20,
+ax_anim 3, 0, 163, 20, -22, 20, -22,
+ax_anim 2, 3, 164, 20, -11, 20, -11,
+ax_anim 2, 0, 165, 18, -5, 18, -5,
+ax_anim 1, 0, 166, 7, 0, 7, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 8, -8, 8, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -11, -20, -11, -20,
+ax_anim 3, 0, 169, -20, -22, -20, -22,
+ax_anim 2, 3, 168, -20, -11, -20, -11,
+ax_anim 2, 0, 167, -18, -5, -18, -5,
+ax_anim 1, 0, 166, -7, 0, -7, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -20, 0, -20, 0,
+ax_anim 2, 3, 167, -17, 4, -17, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -24, 9, -24, 9,
+ax_anim 3, 0, 167, -23, 20, -23, 20,
+ax_anim 2, 3, 166, -11, 21, -11, 16,
+ax_anim 2, 0, 165, -2, 12, -4, 12,
+ax_anim 1, 0, 164, 0, 7, -3, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -25, 0, 0,
+ax_anim 3, 0, 178, 0, -24, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -25, 0, 0,
+ax_anim 3, 0, 181, 0, -23, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -24, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -23, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -25, 0, 0,
+ax_anim 3, 0, 199, 0, -23, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCharmeleonAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sCharmeleonGfx1:
+.incbin "baserom.gba", 0x548C28, 0x200
+sCharmeleonSprites1:
+ax_sprite sCharmeleonGfx1, 0x200
+ax_sprite_terminator
+sCharmeleonGfx2:
+.incbin "baserom.gba", 0x548E38, 0x200
+sCharmeleonSprites2:
+ax_sprite sCharmeleonGfx2, 0x200
+ax_sprite_terminator
+sCharmeleonGfx3:
+.incbin "baserom.gba", 0x549048, 0x200
+sCharmeleonSprites3:
+ax_sprite sCharmeleonGfx3, 0x200
+ax_sprite_terminator
+sCharmeleonGfx4:
+.incbin "baserom.gba", 0x549258, 0x200
+sCharmeleonSprites4:
+ax_sprite sCharmeleonGfx4, 0x200
+ax_sprite_terminator
+sCharmeleonGfx5:
+.incbin "baserom.gba", 0x549468, 0x200
+sCharmeleonSprites5:
+ax_sprite sCharmeleonGfx5, 0x200
+ax_sprite_terminator
+sCharmeleonGfx6:
+.incbin "baserom.gba", 0x549678, 0x200
+sCharmeleonSprites6:
+ax_sprite sCharmeleonGfx6, 0x200
+ax_sprite_terminator
+sCharmeleonGfx7:
+.incbin "baserom.gba", 0x549888, 0x200
+sCharmeleonSprites7:
+ax_sprite sCharmeleonGfx7, 0x200
+ax_sprite_terminator
+sCharmeleonGfx8:
+.incbin "baserom.gba", 0x549A98, 0x200
+sCharmeleonSprites8:
+ax_sprite sCharmeleonGfx8, 0x200
+ax_sprite_terminator
+sCharmeleonGfx9:
+.incbin "baserom.gba", 0x549CA8, 0x200
+sCharmeleonSprites9:
+ax_sprite sCharmeleonGfx9, 0x200
+ax_sprite_terminator
+sCharmeleonGfx10:
+.incbin "baserom.gba", 0x549EB8, 0x200
+sCharmeleonSprites10:
+ax_sprite sCharmeleonGfx10, 0x200
+ax_sprite_terminator
+sCharmeleonGfx11:
+.incbin "baserom.gba", 0x54A0C8, 0x200
+sCharmeleonSprites11:
+ax_sprite sCharmeleonGfx11, 0x200
+ax_sprite_terminator
+sCharmeleonGfx12:
+.incbin "baserom.gba", 0x54A2D8, 0x200
+sCharmeleonSprites12:
+ax_sprite sCharmeleonGfx12, 0x200
+ax_sprite_terminator
+sCharmeleonGfx13:
+.incbin "baserom.gba", 0x54A4E8, 0x100
+sCharmeleonSprites13:
+ax_sprite sCharmeleonGfx13, 0x100
+ax_sprite_terminator
+sCharmeleonGfx14:
+.incbin "baserom.gba", 0x54A5F8, 0x200
+sCharmeleonSprites14:
+ax_sprite sCharmeleonGfx14, 0x200
+ax_sprite_terminator
+sCharmeleonGfx15:
+.incbin "baserom.gba", 0x54A808, 0x200
+sCharmeleonSprites15:
+ax_sprite sCharmeleonGfx15, 0x200
+ax_sprite_terminator
+sCharmeleonGfx16:
+.incbin "baserom.gba", 0x54AA18, 0x40
+sCharmeleonGfx16_1:
+.incbin "baserom.gba", 0x54AA58, 0x60
+sCharmeleonGfx16_2:
+.incbin "baserom.gba", 0x54AAB8, 0x60
+sCharmeleonGfx16_3:
+.incbin "baserom.gba", 0x54AB18, 0x60
+sCharmeleonSprites16:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx16_3, 0x60
+ax_sprite_terminator
+sCharmeleonGfx17:
+.incbin "baserom.gba", 0x54ABC0, 0x20
+sCharmeleonGfx17_1:
+.incbin "baserom.gba", 0x54ABE0, 0x80
+sCharmeleonSprites17:
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx17_1, 0x80
+ax_sprite_terminator
+sCharmeleonGfx18:
+.incbin "baserom.gba", 0x54AC88, 0x20
+sCharmeleonGfx18_1:
+.incbin "baserom.gba", 0x54ACA8, 0x60
+sCharmeleonGfx18_2:
+.incbin "baserom.gba", 0x54AD08, 0x60
+sCharmeleonGfx18_3:
+.incbin "baserom.gba", 0x54AD68, 0x60
+sCharmeleonSprites18:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx18, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCharmeleonGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx18_3, 0x60
+ax_sprite_terminator
+sCharmeleonGfx19:
+.incbin "baserom.gba", 0x54AE10, 0x40
+sCharmeleonGfx19_1:
+.incbin "baserom.gba", 0x54AE50, 0xE0
+sCharmeleonGfx19_2:
+.incbin "baserom.gba", 0x54AF30, 0x60
+sCharmeleonSprites19:
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx19_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx19_2, 0x60
+ax_sprite_terminator
+sCharmeleonGfx20:
+.incbin "baserom.gba", 0x54AFC8, 0x40
+sCharmeleonGfx20_1:
+.incbin "baserom.gba", 0x54B008, 0x40
+sCharmeleonGfx20_2:
+.incbin "baserom.gba", 0x54B048, 0x20
+sCharmeleonGfx20_3:
+.incbin "baserom.gba", 0x54B068, 0x20
+sCharmeleonSprites20:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx20_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCharmeleonGfx20_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sCharmeleonGfx21:
+.incbin "baserom.gba", 0x54B0D8, 0x1A0
+sCharmeleonSprites21:
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx21, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx22:
+.incbin "baserom.gba", 0x54B298, 0x140
+sCharmeleonGfx22_1:
+.incbin "baserom.gba", 0x54B3D8, 0x40
+sCharmeleonSprites22:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx22, 0x140
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx23:
+.incbin "baserom.gba", 0x54B448, 0x60
+sCharmeleonGfx23_1:
+.incbin "baserom.gba", 0x54B4A8, 0x60
+sCharmeleonGfx23_2:
+.incbin "baserom.gba", 0x54B508, 0x20
+sCharmeleonSprites23:
+ax_sprite sCharmeleonGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx23_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sCharmeleonGfx24:
+.incbin "baserom.gba", 0x54B560, 0x120
+sCharmeleonGfx24_1:
+.incbin "baserom.gba", 0x54B680, 0x40
+sCharmeleonSprites24:
+ax_sprite 0, 0x60
+ax_sprite sCharmeleonGfx24, 0x120
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx25:
+.incbin "baserom.gba", 0x54B6F0, 0x60
+sCharmeleonGfx25_1:
+.incbin "baserom.gba", 0x54B750, 0x160
+sCharmeleonSprites25:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx25_1, 0x160
+ax_sprite_terminator
+sCharmeleonGfx26:
+.incbin "baserom.gba", 0x54B8D8, 0x60
+sCharmeleonGfx26_1:
+.incbin "baserom.gba", 0x54B938, 0x20
+sCharmeleonGfx26_2:
+.incbin "baserom.gba", 0x54B958, 0x40
+sCharmeleonSprites26:
+ax_sprite sCharmeleonGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx26_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx26_2, 0x40
+ax_sprite_terminator
+sCharmeleonGfx27:
+.incbin "baserom.gba", 0x54B9C8, 0x40
+sCharmeleonGfx27_1:
+.incbin "baserom.gba", 0x54BA08, 0x100
+sCharmeleonGfx27_2:
+.incbin "baserom.gba", 0x54BB08, 0x40
+sCharmeleonSprites27:
+ax_sprite sCharmeleonGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx28:
+.incbin "baserom.gba", 0x54BB80, 0x40
+sCharmeleonGfx28_1:
+.incbin "baserom.gba", 0x54BBC0, 0x140
+sCharmeleonSprites28:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx28_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx29:
+.incbin "baserom.gba", 0x54BD30, 0x80
+sCharmeleonGfx29_1:
+.incbin "baserom.gba", 0x54BDB0, 0x20
+sCharmeleonSprites29:
+ax_sprite sCharmeleonGfx29, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx29_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCharmeleonGfx30:
+.incbin "baserom.gba", 0x54BDF8, 0x60
+sCharmeleonGfx30_1:
+.incbin "baserom.gba", 0x54BE58, 0x100
+sCharmeleonGfx30_2:
+.incbin "baserom.gba", 0x54BF58, 0x60
+sCharmeleonSprites30:
+ax_sprite sCharmeleonGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx30_2, 0x60
+ax_sprite_terminator
+sCharmeleonGfx31:
+.incbin "baserom.gba", 0x54BFE8, 0x40
+sCharmeleonGfx31_1:
+.incbin "baserom.gba", 0x54C028, 0x80
+sCharmeleonGfx31_2:
+.incbin "baserom.gba", 0x54C0A8, 0x40
+sCharmeleonGfx31_3:
+.incbin "baserom.gba", 0x54C0E8, 0x40
+sCharmeleonSprites31:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx31_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx32:
+.incbin "baserom.gba", 0x54C178, 0x40
+sCharmeleonGfx32_1:
+.incbin "baserom.gba", 0x54C1B8, 0x40
+sCharmeleonGfx32_2:
+.incbin "baserom.gba", 0x54C1F8, 0x100
+sCharmeleonSprites32:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx32_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx32_2, 0x100
+ax_sprite_terminator
+sCharmeleonGfx33:
+.incbin "baserom.gba", 0x54C330, 0x160
+sCharmeleonGfx33_1:
+.incbin "baserom.gba", 0x54C490, 0x40
+sCharmeleonSprites33:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx33, 0x160
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx33_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx34:
+.incbin "baserom.gba", 0x54C500, 0x120
+sCharmeleonGfx34_1:
+.incbin "baserom.gba", 0x54C620, 0x60
+sCharmeleonSprites34:
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx34, 0x120
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx35:
+.incbin "baserom.gba", 0x54C6B0, 0x60
+sCharmeleonGfx35_1:
+.incbin "baserom.gba", 0x54C710, 0x60
+sCharmeleonGfx35_2:
+.incbin "baserom.gba", 0x54C770, 0x60
+sCharmeleonGfx35_3:
+.incbin "baserom.gba", 0x54C7D0, 0x60
+sCharmeleonSprites35:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx35_3, 0x60
+ax_sprite_terminator
+sCharmeleonGfx36:
+.incbin "baserom.gba", 0x54C878, 0x120
+sCharmeleonGfx36_1:
+.incbin "baserom.gba", 0x54C998, 0x40
+sCharmeleonSprites36:
+ax_sprite 0, 0x60
+ax_sprite sCharmeleonGfx36, 0x120
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx36_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx37:
+.incbin "baserom.gba", 0x54CA08, 0xE0
+sCharmeleonGfx37_1:
+.incbin "baserom.gba", 0x54CAE8, 0x60
+sCharmeleonGfx37_2:
+.incbin "baserom.gba", 0x54CB48, 0x60
+sCharmeleonSprites37:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx37, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx37_2, 0x60
+ax_sprite_terminator
+sCharmeleonGfx38:
+.incbin "baserom.gba", 0x54CBE0, 0x40
+sCharmeleonGfx38_1:
+.incbin "baserom.gba", 0x54CC20, 0x160
+sCharmeleonSprites38:
+ax_sprite sCharmeleonGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx38_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx39:
+.incbin "baserom.gba", 0x54CDA8, 0x100
+sCharmeleonGfx39_1:
+.incbin "baserom.gba", 0x54CEA8, 0x40
+sCharmeleonGfx39_2:
+.incbin "baserom.gba", 0x54CEE8, 0x40
+sCharmeleonSprites39:
+ax_sprite sCharmeleonGfx39, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx39_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx40:
+.incbin "baserom.gba", 0x54CF60, 0x40
+sCharmeleonGfx40_1:
+.incbin "baserom.gba", 0x54CFA0, 0x40
+sCharmeleonGfx40_2:
+.incbin "baserom.gba", 0x54CFE0, 0x80
+sCharmeleonGfx40_3:
+.incbin "baserom.gba", 0x54D060, 0x40
+sCharmeleonSprites40:
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCharmeleonGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx40_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCharmeleonGfx40_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCharmeleonGfx41:
+.incbin "baserom.gba", 0x54D0F0, 0x200
+sCharmeleonSprites41:
+ax_sprite sCharmeleonGfx41, 0x200
+ax_sprite_terminator
+sCharmeleonGfx42:
+.incbin "baserom.gba", 0x54D300, 0x200
+sCharmeleonSprites42:
+ax_sprite sCharmeleonGfx42, 0x200
+ax_sprite_terminator
+sCharmeleonGfx43:
+.incbin "baserom.gba", 0x54D510, 0x200
+sCharmeleonSprites43:
+ax_sprite sCharmeleonGfx43, 0x200
+ax_sprite_terminator
+sCharmeleonGfx44:
+.incbin "baserom.gba", 0x54D720, 0x200
+sCharmeleonSprites44:
+ax_sprite sCharmeleonGfx44, 0x200
+ax_sprite_terminator
+sCharmeleonGfx45:
+.incbin "baserom.gba", 0x54D930, 0x200
+sCharmeleonSprites45:
+ax_sprite sCharmeleonGfx45, 0x200
+ax_sprite_terminator
+sCharmeleonGfx46:
+.incbin "baserom.gba", 0x54DB40, 0x200
+sCharmeleonSprites46:
+ax_sprite sCharmeleonGfx46, 0x200
+ax_sprite_terminator
+sCharmeleonGfx47:
+.incbin "baserom.gba", 0x54DD50, 0x200
+sCharmeleonSprites47:
+ax_sprite sCharmeleonGfx47, 0x200
+ax_sprite_terminator
+sAxPosesCharmeleon:
+.4byte sCharmeleonPose1
+.4byte sCharmeleonPose2
+.4byte sCharmeleonPose3
+.4byte sCharmeleonPose4
+.4byte sCharmeleonPose5
+.4byte sCharmeleonPose6
+.4byte sCharmeleonPose7
+.4byte sCharmeleonPose8
+.4byte sCharmeleonPose9
+.4byte sCharmeleonPose10
+.4byte sCharmeleonPose11
+.4byte sCharmeleonPose12
+.4byte sCharmeleonPose13
+.4byte sCharmeleonPose14
+.4byte sCharmeleonPose15
+.4byte sCharmeleonPose16
+.4byte sCharmeleonPose17
+.4byte sCharmeleonPose18
+.4byte sCharmeleonPose19
+.4byte sCharmeleonPose20
+.4byte sCharmeleonPose21
+.4byte sCharmeleonPose22
+.4byte sCharmeleonPose23
+.4byte sCharmeleonPose24
+.4byte sCharmeleonPose25
+.4byte sCharmeleonPose26
+.4byte sCharmeleonPose27
+.4byte sCharmeleonPose28
+.4byte sCharmeleonPose29
+.4byte sCharmeleonPose30
+.4byte sCharmeleonPose31
+.4byte sCharmeleonPose32
+.4byte sCharmeleonPose33
+.4byte sCharmeleonPose34
+.4byte sCharmeleonPose35
+.4byte sCharmeleonPose36
+.4byte sCharmeleonPose37
+.4byte sCharmeleonPose38
+.4byte sCharmeleonPose39
+.4byte sCharmeleonPose40
+.4byte sCharmeleonPose41
+.4byte sCharmeleonPose42
+.4byte sCharmeleonPose43
+.4byte sCharmeleonPose44
+.4byte sCharmeleonPose45
+.4byte sCharmeleonPose46
+.4byte sCharmeleonPose47
+.4byte sCharmeleonPose48
+.4byte sCharmeleonPose49
+.4byte sCharmeleonPose50
+.4byte sCharmeleonPose51
+.4byte sCharmeleonPose52
+.4byte sCharmeleonPose53
+.4byte sCharmeleonPose54
+.4byte sCharmeleonPose55
+.4byte sCharmeleonPose56
+.4byte sCharmeleonPose57
+.4byte sCharmeleonPose58
+.4byte sCharmeleonPose59
+.4byte sCharmeleonPose60
+.4byte sCharmeleonPose61
+.4byte sCharmeleonPose62
+.4byte sCharmeleonPose63
+.4byte sCharmeleonPose64
+.4byte sCharmeleonPose65
+.4byte sCharmeleonPose66
+.4byte sCharmeleonPose67
+.4byte sCharmeleonPose68
+.4byte sCharmeleonPose69
+.4byte sCharmeleonPose70
+.4byte sCharmeleonPose71
+.4byte sCharmeleonPose72
+.4byte sCharmeleonPose73
+.4byte sCharmeleonPose74
+.4byte sCharmeleonPose75
+.4byte sCharmeleonPose76
+.4byte sCharmeleonPose77
+.4byte sCharmeleonPose78
+.4byte sCharmeleonPose79
+.4byte sCharmeleonPose80
+.4byte sCharmeleonPose81
+.4byte sCharmeleonPose82
+.4byte sCharmeleonPose83
+.4byte sCharmeleonPose84
+.4byte sCharmeleonPose85
+.4byte sCharmeleonPose86
+.4byte sCharmeleonPose87
+.4byte sCharmeleonPose88
+.4byte sCharmeleonPose89
+.4byte sCharmeleonPose90
+.4byte sCharmeleonPose91
+.4byte sCharmeleonPose92
+.4byte sCharmeleonPose93
+.4byte sCharmeleonPose94
+.4byte sCharmeleonPose95
+.4byte sCharmeleonPose96
+.4byte sCharmeleonPose97
+.4byte sCharmeleonPose98
+.4byte sCharmeleonPose99
+.4byte sCharmeleonPose100
+.4byte sCharmeleonPose101
+.4byte sCharmeleonPose102
+.4byte sCharmeleonPose103
+.4byte sCharmeleonPose104
+.4byte sCharmeleonPose105
+.4byte sCharmeleonPose106
+.4byte sCharmeleonPose107
+.4byte sCharmeleonPose108
+.4byte sCharmeleonPose109
+.4byte sCharmeleonPose110
+.4byte sCharmeleonPose111
+.4byte sCharmeleonPose112
+.4byte sCharmeleonPose113
+.4byte sCharmeleonPose114
+.4byte sCharmeleonPose115
+.4byte sCharmeleonPose116
+.4byte sCharmeleonPose117
+.4byte sCharmeleonPose118
+.4byte sCharmeleonPose119
+.4byte sCharmeleonPose120
+.4byte sCharmeleonPose121
+.4byte sCharmeleonPose122
+.4byte sCharmeleonPose123
+.4byte sCharmeleonPose124
+.4byte sCharmeleonPose125
+.4byte sCharmeleonPose126
+.4byte sCharmeleonPose127
+.4byte sCharmeleonPose128
+.4byte sCharmeleonPose129
+.4byte sCharmeleonPose130
+.4byte sCharmeleonPose131
+.4byte sCharmeleonPose132
+.4byte sCharmeleonPose133
+.4byte sCharmeleonPose134
+.4byte sCharmeleonPose135
+.4byte sCharmeleonPose136
+.4byte sCharmeleonPose137
+.4byte sCharmeleonPose138
+.4byte sCharmeleonPose139
+.4byte sCharmeleonPose140
+.4byte sCharmeleonPose141
+.4byte sCharmeleonPose142
+.4byte sCharmeleonPose143
+.4byte sCharmeleonPose144
+.4byte sCharmeleonPose145
+.4byte sCharmeleonPose146
+.4byte sCharmeleonPose147
+.4byte sCharmeleonPose148
+.4byte sCharmeleonPose149
+.4byte sCharmeleonPose150
+.4byte sCharmeleonPose151
+.4byte sCharmeleonPose152
+.4byte sCharmeleonPose153
+.4byte sCharmeleonPose154
+.4byte sCharmeleonPose155
+.4byte sCharmeleonPose156
+.4byte sCharmeleonPose157
+.4byte sCharmeleonPose158
+.4byte sCharmeleonPose159
+.4byte sCharmeleonPose160
+.4byte sCharmeleonPose161
+.4byte sCharmeleonPose162
+.4byte sCharmeleonPose163
+.4byte sCharmeleonPose164
+.4byte sCharmeleonPose165
+.4byte sCharmeleonPose166
+.4byte sCharmeleonPose167
+.4byte sCharmeleonPose168
+.4byte sCharmeleonPose169
+.4byte sCharmeleonPose170
+.4byte sCharmeleonPose171
+.4byte sCharmeleonPose172
+.4byte sCharmeleonPose173
+.4byte sCharmeleonPose174
+.4byte sCharmeleonPose175
+.4byte sCharmeleonPose176
+.4byte sCharmeleonPose177
+.4byte sCharmeleonPose178
+.4byte sCharmeleonPose179
+.4byte sCharmeleonPose180
+.4byte sCharmeleonPose181
+.4byte sCharmeleonPose182
+.4byte sCharmeleonPose183
+.4byte sCharmeleonPose184
+.4byte sCharmeleonPose185
+.4byte sCharmeleonPose186
+.4byte sCharmeleonPose187
+.4byte sCharmeleonPose188
+.4byte sCharmeleonPose189
+.4byte sCharmeleonPose190
+.4byte sCharmeleonPose191
+.4byte sCharmeleonPose192
+.4byte sCharmeleonPose193
+.4byte sCharmeleonPose194
+.4byte sCharmeleonPose195
+.4byte sCharmeleonPose196
+.4byte sCharmeleonPose197
+.4byte sCharmeleonPose198
+.4byte sCharmeleonPose199
+.4byte sCharmeleonPose200
+.4byte sCharmeleonPose201
+.4byte sCharmeleonPose202
+.4byte sCharmeleonPose203
+.4byte sCharmeleonPose204
+.4byte sCharmeleonPose205
+.4byte sCharmeleonPose206
+.4byte sCharmeleonPose207
+.4byte sCharmeleonPose208
+.4byte sCharmeleonPose209
+.4byte sCharmeleonPose210
+.4byte sCharmeleonPose211
+.4byte sCharmeleonPose212
+.4byte sCharmeleonPose213
+.4byte sCharmeleonPose214
+.4byte sCharmeleonPose215
+.4byte sCharmeleonPose216
+.4byte sCharmeleonPose217
+.4byte sCharmeleonPose218
+sAxPositionsCharmeleon:
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte    1,   -4, 	  -8,   -7, 	   4,   -2, 	   1,   -6
+.2byte   -2,   -4, 	  -5,   -2, 	   7,   -7, 	  -2,   -6
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+.2byte    3,   -5, 	   7,  -10, 	   0,   -3, 	   0,   -7
+.2byte    4,   -6, 	   8,   -5, 	  -6,   -6, 	   0,   -8
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    7,   -8, 	   0,   -8, 	   6,   -5, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    8,  -13, 	  -5,   -9, 	   9,   -8, 	   0,   -7
+.2byte    7,  -13, 	   2,  -10, 	   3,   -4, 	  -2,   -8
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	   5,  -11, 	  -9,   -5, 	  -1,   -7
+.2byte    0,  -12, 	   8,   -5, 	  -6,  -11, 	  -1,   -7
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -9,  -13, 	   4,   -9, 	 -10,   -8, 	  -1,   -7
+.2byte   -8,  -13, 	  -3,  -10, 	  -4,   -4, 	   1,   -8
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -7,   -5, 	   0,   -7
+.2byte   -8,   -8, 	  -7,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte   -4,   -5, 	  -8,  -10, 	  -1,   -3, 	  -1,   -7
+.2byte   -5,   -6, 	  -9,   -5, 	   5,   -6, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte    1,   -4, 	  -8,   -7, 	   4,   -2, 	   1,   -6
+.2byte   -2,   -4, 	  -5,   -2, 	   7,   -7, 	  -2,   -6
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+.2byte    3,   -5, 	   7,  -10, 	   0,   -3, 	   0,   -7
+.2byte    4,   -6, 	   8,   -5, 	  -6,   -6, 	   0,   -8
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    7,   -8, 	   0,   -8, 	   6,   -5, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    8,  -13, 	  -5,   -9, 	   9,   -8, 	   0,   -7
+.2byte    7,  -13, 	   2,  -10, 	   3,   -4, 	  -2,   -8
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	   5,  -11, 	  -9,   -5, 	  -1,   -7
+.2byte    0,  -12, 	   8,   -5, 	  -6,  -11, 	  -1,   -7
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -9,  -13, 	   4,   -9, 	 -10,   -8, 	  -1,   -7
+.2byte   -8,  -13, 	  -3,  -10, 	  -4,   -4, 	   1,   -8
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -7,   -5, 	   0,   -7
+.2byte   -8,   -8, 	  -7,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte   -4,   -5, 	  -8,  -10, 	  -1,   -3, 	  -1,   -7
+.2byte   -5,   -6, 	  -9,   -5, 	   5,   -6, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte    0,  -13, 	  -7,  -12, 	   2,  -10, 	   0,   -9
+.2byte    6,   -2, 	  -1,    3, 	  13,  -11, 	   1,   -6
+.2byte    6,   -2, 	  -1,    3, 	  13,  -11, 	   1,   -6
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+.2byte   -4,  -13, 	   2,  -13, 	   2,  -11, 	  -3,   -9
+.2byte    2,   -3, 	  11,    0, 	  -5,   -7, 	  -1,   -6
+.2byte    2,   -3, 	  11,    0, 	  -5,   -7, 	  -1,   -6
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    0,  -14, 	  -7,  -15, 	   5,  -13, 	  -2,  -10
+.2byte    4,   -3, 	  13,   -6, 	   1,   -4, 	  -1,   -6
+.2byte    4,   -3, 	  13,   -6, 	   1,   -4, 	  -1,   -6
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    0,  -17, 	 -13,  -11, 	   3,  -15, 	  -2,   -9
+.2byte    6,   -9, 	  11,  -17, 	   6,   -7, 	   0,   -8
+.2byte    6,   -9, 	  11,  -17, 	   6,   -7, 	   0,   -8
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte   -1,  -15, 	   7,   -8, 	   6,  -11, 	  -1,   -7
+.2byte   -7,  -13, 	   2,  -20, 	 -11,  -11, 	  -1,  -11
+.2byte   -7,  -13, 	   2,  -20, 	 -11,  -11, 	  -1,  -11
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -1,  -17, 	  12,  -11, 	  -4,  -15, 	   1,   -9
+.2byte   -7,   -9, 	 -12,  -17, 	  -7,   -7, 	  -1,   -8
+.2byte   -7,   -9, 	 -12,  -17, 	  -7,   -7, 	  -1,   -8
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -1,  -14, 	   6,  -15, 	  -6,  -13, 	   1,  -10
+.2byte   -5,   -3, 	 -14,   -6, 	  -2,   -4, 	   0,   -6
+.2byte   -5,   -3, 	 -14,   -6, 	  -2,   -4, 	   0,   -6
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte    3,  -13, 	  -3,  -13, 	  -3,  -11, 	   2,   -9
+.2byte   -3,   -3, 	 -12,    0, 	   4,   -7, 	   0,   -6
+.2byte   -3,   -3, 	 -12,    0, 	   4,   -7, 	   0,   -6
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -18, 	  -9,  -14, 	   9,  -14, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -2, 	   9,   -2, 	   0,   -7
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+.2byte    3,  -19, 	  11,  -14, 	   0,  -11, 	   1,   -9
+.2byte    8,   -4, 	  10,   -5, 	  -5,   -1, 	   1,   -5
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    2,  -17, 	   4,  -17, 	   5,  -12, 	  -1,   -9
+.2byte   13,   -8, 	   5,   -5, 	   3,   -2, 	   3,   -7
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    3,  -18, 	   0,  -17, 	   8,  -14, 	   0,  -10
+.2byte   13,  -12, 	   0,   -8, 	   9,   -3, 	   4,   -9
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte    0,  -21, 	   7,  -18, 	  -8,  -18, 	   0,  -12
+.2byte    0,  -19, 	   7,   -8, 	  -8,   -8, 	   0,  -10
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -4,  -18, 	  -1,  -17, 	  -9,  -14, 	  -1,  -10
+.2byte  -14,  -12, 	  -1,   -8, 	 -10,   -3, 	  -5,   -9
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -3,  -17, 	  -5,  -17, 	  -6,  -12, 	   0,   -9
+.2byte  -14,   -8, 	  -6,   -5, 	  -4,   -2, 	  -4,   -7
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte   -4,  -19, 	 -12,  -14, 	  -1,  -11, 	  -2,   -9
+.2byte   -9,   -4, 	 -11,   -5, 	   4,   -1, 	  -2,   -5
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -18, 	  -9,  -14, 	   9,  -14, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -2, 	   9,   -2, 	   0,   -7
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+.2byte    3,  -19, 	  11,  -14, 	   0,  -11, 	   1,   -9
+.2byte    8,   -4, 	  10,   -5, 	  -5,   -1, 	   1,   -5
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    2,  -17, 	   4,  -17, 	   5,  -12, 	  -1,   -9
+.2byte   13,   -8, 	   5,   -5, 	   3,   -2, 	   3,   -7
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    3,  -18, 	   0,  -17, 	   8,  -14, 	   0,  -10
+.2byte   13,  -12, 	   0,   -8, 	   9,   -3, 	   4,   -9
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte    0,  -21, 	   7,  -18, 	  -8,  -18, 	   0,  -12
+.2byte    0,  -19, 	   7,   -8, 	  -8,   -8, 	   0,  -10
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -4,  -18, 	  -1,  -17, 	  -9,  -14, 	  -1,  -10
+.2byte  -14,  -12, 	  -1,   -8, 	 -10,   -3, 	  -5,   -9
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -3,  -17, 	  -5,  -17, 	  -6,  -12, 	   0,   -9
+.2byte  -14,   -8, 	  -6,   -5, 	  -4,   -2, 	  -4,   -7
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte   -4,  -19, 	 -12,  -14, 	  -1,  -11, 	  -2,   -9
+.2byte   -9,   -4, 	 -11,   -5, 	   4,   -1, 	  -2,   -5
+.2byte   -3,   -6, 	  -8,   -4, 	   4,   -2, 	  -1,   -5
+.2byte   -3,   -5, 	  -8,   -4, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -7, 	  -9,  -13, 	   8,  -13, 	  -1,  -10
+.2byte    0,   -8, 	   4,  -14, 	  -9,  -11, 	  -3,  -10
+.2byte    3,   -9, 	  -4,  -14, 	  -6,  -12, 	  -5,   -7
+.2byte    4,  -12, 	  -8,  -12, 	   5,   -8, 	  -4,   -7
+.2byte   -1,   -9, 	   7,   -9, 	  -8,   -9, 	  -1,   -5
+.2byte   -5,  -12, 	   7,  -12, 	  -6,   -8, 	   3,   -7
+.2byte   -4,   -9, 	   3,  -14, 	   5,  -12, 	   4,   -7
+.2byte   -1,   -8, 	  -5,  -14, 	   8,  -11, 	   2,  -10
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -18, 	  -9,  -14, 	   9,  -14, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -2, 	   9,   -2, 	   0,   -7
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+.2byte    3,  -19, 	  11,  -14, 	   0,  -11, 	   1,   -9
+.2byte    8,   -4, 	  10,   -5, 	  -5,   -1, 	   1,   -5
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    2,  -17, 	   4,  -17, 	   5,  -12, 	  -1,   -9
+.2byte   13,   -8, 	   5,   -5, 	   3,   -2, 	   3,   -7
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    3,  -18, 	   0,  -17, 	   8,  -14, 	   0,  -10
+.2byte   13,  -12, 	   0,   -8, 	   9,   -3, 	   4,   -9
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte    0,  -21, 	   7,  -18, 	  -8,  -18, 	   0,  -12
+.2byte    0,  -19, 	   7,   -8, 	  -8,   -8, 	   0,  -10
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -4,  -18, 	  -1,  -17, 	  -9,  -14, 	  -1,  -10
+.2byte  -14,  -12, 	  -1,   -8, 	 -10,   -3, 	  -5,   -9
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -3,  -17, 	  -5,  -17, 	  -6,  -12, 	   0,   -9
+.2byte  -14,   -8, 	  -6,   -5, 	  -4,   -2, 	  -4,   -7
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte   -4,  -19, 	 -12,  -14, 	  -1,  -11, 	  -2,   -9
+.2byte   -9,   -4, 	 -11,   -5, 	   4,   -1, 	  -2,   -5
+.2byte    0,   -2, 	 -10,   -2, 	   9,   -2, 	   0,   -7
+.2byte   -8,   -4, 	 -10,   -5, 	   5,   -1, 	  -1,   -5
+.2byte  -11,   -8, 	  -3,   -5, 	  -1,   -2, 	  -1,   -7
+.2byte  -10,  -12, 	   3,   -8, 	  -6,   -3, 	  -1,   -9
+.2byte    0,  -18, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   13,  -12, 	   0,   -8, 	   9,   -3, 	   4,   -9
+.2byte   10,   -8, 	   2,   -5, 	   0,   -2, 	   0,   -7
+.2byte    7,   -4, 	   9,   -5, 	  -6,   -1, 	   0,   -5
+.2byte    0,   -2, 	 -10,   -2, 	   9,   -2, 	   0,   -7
+.2byte    8,   -4, 	  10,   -5, 	  -5,   -1, 	   1,   -5
+.2byte   13,   -8, 	   5,   -5, 	   3,   -2, 	   3,   -7
+.2byte   13,  -12, 	   0,   -8, 	   9,   -3, 	   4,   -9
+.2byte    0,  -19, 	   7,   -8, 	  -8,   -8, 	   0,  -10
+.2byte  -14,  -12, 	  -1,   -8, 	 -10,   -3, 	  -5,   -9
+.2byte  -14,   -8, 	  -6,   -5, 	  -4,   -2, 	  -4,   -7
+.2byte   -9,   -4, 	 -11,   -5, 	   4,   -1, 	  -2,   -5
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -18, 	  -9,  -14, 	   9,  -14, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -2, 	   9,   -2, 	   0,   -7
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+.2byte    3,  -19, 	  11,  -14, 	   0,  -11, 	   1,   -9
+.2byte    8,   -4, 	  10,   -5, 	  -5,   -1, 	   1,   -5
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    2,  -17, 	   4,  -17, 	   5,  -12, 	  -1,   -9
+.2byte   11,   -8, 	   3,   -5, 	   1,   -2, 	   1,   -7
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    3,  -18, 	   0,  -17, 	   8,  -14, 	   0,  -10
+.2byte   10,  -12, 	  -3,   -8, 	   6,   -3, 	   1,   -9
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte    0,  -21, 	   7,  -18, 	  -8,  -18, 	   0,  -12
+.2byte    0,  -19, 	   7,   -8, 	  -8,   -8, 	   0,  -10
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -4,  -18, 	  -1,  -17, 	  -9,  -14, 	  -1,  -10
+.2byte  -11,  -12, 	   2,   -8, 	  -7,   -3, 	  -2,   -9
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -3,  -17, 	  -5,  -17, 	  -6,  -12, 	   0,   -9
+.2byte  -12,   -8, 	  -4,   -5, 	  -2,   -2, 	  -2,   -7
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte   -4,  -19, 	 -12,  -14, 	  -1,  -11, 	  -2,   -9
+.2byte   -9,   -4, 	 -11,   -5, 	   4,   -1, 	  -2,   -5
+.2byte   -1,  -18, 	  -9,  -14, 	   9,  -14, 	  -1,  -10
+.2byte   -2,  -19, 	 -10,  -14, 	   1,  -11, 	   0,   -9
+.2byte   -3,  -17, 	  -5,  -17, 	  -6,  -12, 	   0,   -9
+.2byte   -4,  -18, 	  -1,  -17, 	  -9,  -14, 	  -1,  -10
+.2byte    0,  -21, 	   7,  -18, 	  -8,  -18, 	   0,  -12
+.2byte    3,  -18, 	   0,  -17, 	   8,  -14, 	   0,  -10
+.2byte    2,  -17, 	   4,  -17, 	   5,  -12, 	  -1,   -9
+.2byte    1,  -19, 	   9,  -14, 	  -2,  -11, 	  -1,   -9
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -3, 	  -1,   -8
+.2byte   -8,   -9, 	  -6,   -8, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,  -14, 	   0,  -10, 	  -7,   -6, 	   0,   -8
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte    7,  -14, 	  -1,  -10, 	   6,   -6, 	  -1,   -8
+.2byte    7,   -9, 	   5,   -8, 	   4,   -4, 	   0,   -8
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -3, 	   0,   -8
+sCharmeleonAnimTable1:
+.4byte sCharmeleonAnims_1_1
+.4byte sCharmeleonAnims_1_2
+.4byte sCharmeleonAnims_1_3
+.4byte sCharmeleonAnims_1_4
+.4byte sCharmeleonAnims_1_5
+.4byte sCharmeleonAnims_1_6
+.4byte sCharmeleonAnims_1_7
+.4byte sCharmeleonAnims_1_8
+sCharmeleonAnimTable2:
+.4byte sCharmeleonAnims_2_1
+.4byte sCharmeleonAnims_2_2
+.4byte sCharmeleonAnims_2_3
+.4byte sCharmeleonAnims_2_4
+.4byte sCharmeleonAnims_2_5
+.4byte sCharmeleonAnims_2_6
+.4byte sCharmeleonAnims_2_7
+.4byte sCharmeleonAnims_2_8
+sCharmeleonAnimTable3:
+.4byte sCharmeleonAnims_3_1
+.4byte sCharmeleonAnims_3_2
+.4byte sCharmeleonAnims_3_3
+.4byte sCharmeleonAnims_3_4
+.4byte sCharmeleonAnims_3_5
+.4byte sCharmeleonAnims_3_6
+.4byte sCharmeleonAnims_3_7
+.4byte sCharmeleonAnims_3_8
+sCharmeleonAnimTable4:
+.4byte sCharmeleonAnims_4_1
+.4byte sCharmeleonAnims_4_2
+.4byte sCharmeleonAnims_4_3
+.4byte sCharmeleonAnims_4_4
+.4byte sCharmeleonAnims_4_5
+.4byte sCharmeleonAnims_4_6
+.4byte sCharmeleonAnims_4_7
+.4byte sCharmeleonAnims_4_8
+sCharmeleonAnimTable5:
+.4byte sCharmeleonAnims_5_1
+.4byte sCharmeleonAnims_5_2
+.4byte sCharmeleonAnims_5_3
+.4byte sCharmeleonAnims_5_4
+.4byte sCharmeleonAnims_5_5
+.4byte sCharmeleonAnims_5_6
+.4byte sCharmeleonAnims_5_7
+.4byte sCharmeleonAnims_5_8
+sCharmeleonAnimTable6:
+.4byte sCharmeleonAnims_6_1
+.4byte sCharmeleonAnims_6_1
+.4byte sCharmeleonAnims_6_1
+.4byte sCharmeleonAnims_6_1
+.4byte sCharmeleonAnims_6_1
+.4byte sCharmeleonAnims_6_1
+.4byte sCharmeleonAnims_6_1
+.4byte sCharmeleonAnims_6_1
+sCharmeleonAnimTable7:
+.4byte sCharmeleonAnims_7_1
+.4byte sCharmeleonAnims_7_2
+.4byte sCharmeleonAnims_7_3
+.4byte sCharmeleonAnims_7_4
+.4byte sCharmeleonAnims_7_5
+.4byte sCharmeleonAnims_7_6
+.4byte sCharmeleonAnims_7_7
+.4byte sCharmeleonAnims_7_8
+sCharmeleonAnimTable8:
+.4byte sCharmeleonAnims_8_1
+.4byte sCharmeleonAnims_8_2
+.4byte sCharmeleonAnims_8_3
+.4byte sCharmeleonAnims_8_4
+.4byte sCharmeleonAnims_8_5
+.4byte sCharmeleonAnims_8_6
+.4byte sCharmeleonAnims_8_7
+.4byte sCharmeleonAnims_8_8
+sCharmeleonAnimTable9:
+.4byte sCharmeleonAnims_9_1
+.4byte sCharmeleonAnims_9_2
+.4byte sCharmeleonAnims_9_3
+.4byte sCharmeleonAnims_9_4
+.4byte sCharmeleonAnims_9_5
+.4byte sCharmeleonAnims_9_6
+.4byte sCharmeleonAnims_9_7
+.4byte sCharmeleonAnims_9_8
+sCharmeleonAnimTable10:
+.4byte sCharmeleonAnims_10_1
+.4byte sCharmeleonAnims_10_2
+.4byte sCharmeleonAnims_10_3
+.4byte sCharmeleonAnims_10_4
+.4byte sCharmeleonAnims_10_5
+.4byte sCharmeleonAnims_10_6
+.4byte sCharmeleonAnims_10_7
+.4byte sCharmeleonAnims_10_8
+sCharmeleonAnimTable11:
+.4byte sCharmeleonAnims_11_1
+.4byte sCharmeleonAnims_11_2
+.4byte sCharmeleonAnims_11_3
+.4byte sCharmeleonAnims_11_4
+.4byte sCharmeleonAnims_11_5
+.4byte sCharmeleonAnims_11_6
+.4byte sCharmeleonAnims_11_7
+.4byte sCharmeleonAnims_11_8
+sCharmeleonAnimTable12:
+.4byte sCharmeleonAnims_12_1
+.4byte sCharmeleonAnims_12_2
+.4byte sCharmeleonAnims_12_3
+.4byte sCharmeleonAnims_12_4
+.4byte sCharmeleonAnims_12_5
+.4byte sCharmeleonAnims_12_6
+.4byte sCharmeleonAnims_12_7
+.4byte sCharmeleonAnims_12_8
+sCharmeleonAnimTable13:
+.4byte sCharmeleonAnims_13_1
+.4byte sCharmeleonAnims_13_2
+.4byte sCharmeleonAnims_13_3
+.4byte sCharmeleonAnims_13_4
+.4byte sCharmeleonAnims_13_5
+.4byte sCharmeleonAnims_13_6
+.4byte sCharmeleonAnims_13_7
+.4byte sCharmeleonAnims_13_8
+sAxAnimationsCharmeleon:
+.4byte sCharmeleonAnimTable1
+.4byte sCharmeleonAnimTable2
+.4byte sCharmeleonAnimTable3
+.4byte sCharmeleonAnimTable4
+.4byte sCharmeleonAnimTable5
+.4byte sCharmeleonAnimTable6
+.4byte sCharmeleonAnimTable7
+.4byte sCharmeleonAnimTable8
+.4byte sCharmeleonAnimTable9
+.4byte sCharmeleonAnimTable10
+.4byte sCharmeleonAnimTable11
+.4byte sCharmeleonAnimTable12
+.4byte sCharmeleonAnimTable13
+sAxSpritesCharmeleon:
+.4byte sCharmeleonSprites1
+.4byte sCharmeleonSprites2
+.4byte sCharmeleonSprites3
+.4byte sCharmeleonSprites4
+.4byte sCharmeleonSprites5
+.4byte sCharmeleonSprites6
+.4byte sCharmeleonSprites7
+.4byte sCharmeleonSprites8
+.4byte sCharmeleonSprites9
+.4byte sCharmeleonSprites10
+.4byte sCharmeleonSprites11
+.4byte sCharmeleonSprites12
+.4byte sCharmeleonSprites13
+.4byte sCharmeleonSprites14
+.4byte sCharmeleonSprites15
+.4byte sCharmeleonSprites16
+.4byte sCharmeleonSprites17
+.4byte sCharmeleonSprites18
+.4byte sCharmeleonSprites19
+.4byte sCharmeleonSprites20
+.4byte sCharmeleonSprites21
+.4byte sCharmeleonSprites22
+.4byte sCharmeleonSprites23
+.4byte sCharmeleonSprites24
+.4byte sCharmeleonSprites25
+.4byte sCharmeleonSprites26
+.4byte sCharmeleonSprites27
+.4byte sCharmeleonSprites28
+.4byte sCharmeleonSprites29
+.4byte sCharmeleonSprites30
+.4byte sCharmeleonSprites31
+.4byte sCharmeleonSprites32
+.4byte sCharmeleonSprites33
+.4byte sCharmeleonSprites34
+.4byte sCharmeleonSprites35
+.4byte sCharmeleonSprites36
+.4byte sCharmeleonSprites37
+.4byte sCharmeleonSprites38
+.4byte sCharmeleonSprites39
+.4byte sCharmeleonSprites40
+.4byte sCharmeleonSprites41
+.4byte sCharmeleonSprites42
+.4byte sCharmeleonSprites43
+.4byte sCharmeleonSprites44
+.4byte sCharmeleonSprites45
+.4byte sCharmeleonSprites46
+.4byte sCharmeleonSprites47
+sAxMainCharmeleon:
+ax_main sAxPosesCharmeleon, sAxAnimationsCharmeleon, 13, sAxSpritesCharmeleon, sAxPositionsCharmeleon

--- a/data/ax/chikorita.inc
+++ b/data/ax/chikorita.inc
@@ -1,0 +1,4001 @@
+.global gAxChikorita
+gAxChikorita:
+ax_siro sAxMainChikorita
+sChikoritaPose1:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose2:
+ax_pose 1, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose3:
+ax_pose 2, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose4:
+ax_pose 3, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose5:
+ax_pose 4, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose6:
+ax_pose 5, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose7:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose8:
+ax_pose 7, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose9:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose10:
+ax_pose 9, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose11:
+ax_pose 10, 0x81eb, 0x90f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose12:
+ax_pose 11, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose13:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose14:
+ax_pose 13, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose15:
+ax_pose 14, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose16:
+ax_pose 9, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose17:
+ax_pose 10, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose18:
+ax_pose 11, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose22:
+ax_pose 3, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose23:
+ax_pose 4, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose24:
+ax_pose 5, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose25:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose26:
+ax_pose 1, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose27:
+ax_pose 2, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose28:
+ax_pose 3, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose29:
+ax_pose 4, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose30:
+ax_pose 5, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose31:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose32:
+ax_pose 7, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose33:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose34:
+ax_pose 9, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose35:
+ax_pose 10, 0x81eb, 0x90f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose36:
+ax_pose 11, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose37:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose38:
+ax_pose 13, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose39:
+ax_pose 14, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose40:
+ax_pose 9, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose41:
+ax_pose 10, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose42:
+ax_pose 11, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose43:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose44:
+ax_pose 7, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose45:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose46:
+ax_pose 3, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose47:
+ax_pose 4, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose48:
+ax_pose 5, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose49:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose50:
+ax_pose 15, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose51:
+ax_pose 16, 0x81ee, 0x80fa, 0x3c00
+ax_pose 17, 0x41e6, 0x00fa, 0x3c08
+ax_pose 18, 0x81ee, 0x80f8, 0x3c0a
+ax_pose_terminator
+sChikoritaPose52:
+ax_pose 18, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose53:
+ax_pose 3, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose54:
+ax_pose 19, 0x01e9, 0x90f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose55:
+ax_pose 20, 0x01dc, 0x80f6, 0x3c00
+ax_pose 21, 0x01fc, 0x4106, 0x3c10
+ax_pose 22, 0x01eb, 0x90f4, 0x3c14
+ax_pose_terminator
+sChikoritaPose56:
+ax_pose 22, 0x01eb, 0x90f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose57:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose58:
+ax_pose 23, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose59:
+ax_pose 24, 0x01db, 0x80f9, 0x3c00
+ax_pose 25, 0x41fb, 0x0109, 0x3c10
+ax_pose 26, 0x01e9, 0x90f6, 0x3c12
+ax_pose_terminator
+sChikoritaPose60:
+ax_pose 26, 0x01e8, 0x90fb, 0x3c00
+ax_pose_terminator
+sChikoritaPose61:
+ax_pose 9, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose62:
+ax_pose 27, 0x01ea, 0x90ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose63:
+ax_pose 28, 0x01db, 0x80f1, 0x3c00
+ax_pose 29, 0x81ea, 0x0111, 0x3c10
+ax_pose 30, 0x01eb, 0x90f8, 0x3c12
+ax_pose_terminator
+sChikoritaPose64:
+ax_pose 30, 0x01eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose65:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose66:
+ax_pose 31, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose67:
+ax_pose 32, 0x81e6, 0x80f8, 0x3c00
+ax_pose 33, 0x81e6, 0x80f8, 0x3c08
+ax_pose_terminator
+sChikoritaPose68:
+ax_pose 33, 0x81e6, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose69:
+ax_pose 9, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose70:
+ax_pose 27, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose71:
+ax_pose 28, 0x01db, 0x90ef, 0x3c00
+ax_pose 29, 0x81ea, 0x10e7, 0x3c10
+ax_pose 30, 0x01eb, 0x80e8, 0x3c12
+ax_pose_terminator
+sChikoritaPose72:
+ax_pose 30, 0x01eb, 0x80e8, 0x3c00
+ax_pose_terminator
+sChikoritaPose73:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose74:
+ax_pose 23, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose75:
+ax_pose 24, 0x01db, 0x90e7, 0x3c00
+ax_pose 25, 0x41fb, 0x10e7, 0x3c10
+ax_pose 26, 0x01e9, 0x80ea, 0x3c12
+ax_pose_terminator
+sChikoritaPose76:
+ax_pose 26, 0x01e8, 0x80e5, 0x3c00
+ax_pose_terminator
+sChikoritaPose77:
+ax_pose 3, 0x01eb, 0x80f7, 0x3c00
+ax_pose_terminator
+sChikoritaPose78:
+ax_pose 19, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose79:
+ax_pose 20, 0x01dc, 0x90ea, 0x3c00
+ax_pose 21, 0x01fc, 0x50ea, 0x3c10
+ax_pose 22, 0x01eb, 0x80ec, 0x3c14
+ax_pose_terminator
+sChikoritaPose80:
+ax_pose 22, 0x01eb, 0x80ec, 0x3c00
+ax_pose_terminator
+sChikoritaPose81:
+ax_pose 15, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose82:
+ax_pose 34, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose83:
+ax_pose 19, 0x01ea, 0x90f2, 0x3c00
+ax_pose_terminator
+sChikoritaPose84:
+ax_pose 35, 0x01ea, 0x90f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose85:
+ax_pose 23, 0x01e8, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose86:
+ax_pose 36, 0x01e9, 0x90f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose87:
+ax_pose 27, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose88:
+ax_pose 37, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose89:
+ax_pose 31, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose90:
+ax_pose 38, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose91:
+ax_pose 27, 0x01ea, 0x80ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose92:
+ax_pose 37, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose93:
+ax_pose 23, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose94:
+ax_pose 36, 0x01e9, 0x80ec, 0x3c00
+ax_pose_terminator
+sChikoritaPose95:
+ax_pose 19, 0x01ea, 0x80ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose96:
+ax_pose 35, 0x01ea, 0x80ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose97:
+ax_pose 15, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose98:
+ax_pose 34, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose99:
+ax_pose 19, 0x01ea, 0x90f2, 0x3c00
+ax_pose_terminator
+sChikoritaPose100:
+ax_pose 35, 0x01ea, 0x90f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose101:
+ax_pose 23, 0x01e8, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose102:
+ax_pose 36, 0x01e9, 0x90f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose103:
+ax_pose 27, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose104:
+ax_pose 37, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose105:
+ax_pose 31, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose106:
+ax_pose 38, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose107:
+ax_pose 27, 0x01ea, 0x80ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose108:
+ax_pose 37, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose109:
+ax_pose 23, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose110:
+ax_pose 36, 0x01e9, 0x80ec, 0x3c00
+ax_pose_terminator
+sChikoritaPose111:
+ax_pose 19, 0x01ea, 0x80ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose112:
+ax_pose 35, 0x01ea, 0x80ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose113:
+ax_pose 39, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose114:
+ax_pose 40, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose115:
+ax_pose 41, 0x01e4, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose116:
+ax_pose 42, 0x01e3, 0x90ec, 0x3c00
+ax_pose_terminator
+sChikoritaPose117:
+ax_pose 43, 0x01e3, 0x90e8, 0x3c00
+ax_pose_terminator
+sChikoritaPose118:
+ax_pose 44, 0x01e2, 0x90ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose119:
+ax_pose 45, 0x01e3, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose120:
+ax_pose 44, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose121:
+ax_pose 43, 0x01e3, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose122:
+ax_pose 42, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sChikoritaPose123:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose124:
+ax_pose 1, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose125:
+ax_pose 2, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose126:
+ax_pose 34, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose127:
+ax_pose 3, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose128:
+ax_pose 4, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose129:
+ax_pose 5, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose130:
+ax_pose 35, 0x01e8, 0x90f2, 0x3c00
+ax_pose_terminator
+sChikoritaPose131:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose132:
+ax_pose 7, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose133:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose134:
+ax_pose 36, 0x01e8, 0x90f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose135:
+ax_pose 9, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose136:
+ax_pose 10, 0x81eb, 0x90f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose137:
+ax_pose 11, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose138:
+ax_pose 37, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose139:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose140:
+ax_pose 13, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose141:
+ax_pose 14, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose142:
+ax_pose 38, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose143:
+ax_pose 9, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose144:
+ax_pose 10, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose145:
+ax_pose 11, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose146:
+ax_pose 37, 0x01e8, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose147:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose148:
+ax_pose 7, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose149:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose150:
+ax_pose 36, 0x01e8, 0x80ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose151:
+ax_pose 3, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose152:
+ax_pose 4, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose153:
+ax_pose 5, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose154:
+ax_pose 35, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose155:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose156:
+ax_pose 3, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose157:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose158:
+ax_pose 9, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose159:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose160:
+ax_pose 9, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose161:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose162:
+ax_pose 3, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose163:
+ax_pose 15, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose164:
+ax_pose 19, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose165:
+ax_pose 23, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sChikoritaPose166:
+ax_pose 27, 0x01ea, 0x90ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose167:
+ax_pose 31, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose168:
+ax_pose 27, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose169:
+ax_pose 23, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sChikoritaPose170:
+ax_pose 19, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose171:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose172:
+ax_pose 34, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose173:
+ax_pose 2, 0x81ed, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose174:
+ax_pose 3, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose175:
+ax_pose 35, 0x01e9, 0x90f2, 0x3c00
+ax_pose_terminator
+sChikoritaPose176:
+ax_pose 5, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose177:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose178:
+ax_pose 36, 0x01e8, 0x90f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose179:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose180:
+ax_pose 9, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose181:
+ax_pose 37, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose182:
+ax_pose 11, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose183:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose184:
+ax_pose 38, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose185:
+ax_pose 14, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose186:
+ax_pose 9, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose187:
+ax_pose 37, 0x01e8, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose188:
+ax_pose 11, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose189:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose190:
+ax_pose 36, 0x01e8, 0x80ec, 0x3c00
+ax_pose_terminator
+sChikoritaPose191:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose192:
+ax_pose 3, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose193:
+ax_pose 35, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose194:
+ax_pose 5, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose195:
+ax_pose 34, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose196:
+ax_pose 35, 0x01ea, 0x80ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose197:
+ax_pose 36, 0x01e9, 0x80ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose198:
+ax_pose 37, 0x01e8, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose199:
+ax_pose 38, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose200:
+ax_pose 37, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose201:
+ax_pose 36, 0x01e9, 0x90f3, 0x3c00
+ax_pose_terminator
+sChikoritaPose202:
+ax_pose 35, 0x01eb, 0x90f2, 0x3c00
+ax_pose_terminator
+sChikoritaPose203:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose204:
+ax_pose 3, 0x01eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose205:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose206:
+ax_pose 9, 0x81eb, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose207:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose208:
+ax_pose 9, 0x81eb, 0x90f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose209:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose210:
+ax_pose 3, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose211:
+ax_pose 46, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose212:
+ax_pose 47, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose213:
+ax_pose 46, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose214:
+ax_pose 47, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose215:
+ax_pose 46, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose216:
+ax_pose 48, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose217:
+ax_pose 49, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose218:
+ax_pose 50, 0x01eb, 0x90e9, 0x3c00
+ax_pose_terminator
+sChikoritaPose219:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose220:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose221:
+ax_pose 51, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose222:
+ax_pose 52, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose223:
+ax_pose 53, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose224:
+ax_pose 54, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose225:
+ax_pose 55, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose226:
+ax_pose 56, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose227:
+ax_pose 57, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose228:
+ax_pose 58, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sChikoritaPose229:
+ax_pose 59, 0x01ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sChikoritaPose230:
+ax_pose 59, 0x01ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sChikoritaPose231:
+ax_pose 60, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose232:
+ax_pose 61, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose233:
+ax_pose 62, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sChikoritaPose234:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose235:
+ax_pose 63, 0x01ec, 0x80f5, 0x3c00
+ax_pose_terminator
+sChikoritaPose236:
+ax_pose 64, 0x01ec, 0x80f5, 0x3c00
+ax_pose_terminator
+sChikoritaPose237:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose238:
+ax_pose 65, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose239:
+ax_pose 66, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose240:
+ax_pose 0, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose241:
+ax_pose 54, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose242:
+ax_pose 67, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose243:
+ax_pose 6, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sChikoritaPose244:
+ax_pose 68, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose245:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose246:
+ax_pose 68, 0x01ea, 0x90f0, 0x3c00
+ax_pose_terminator
+sChikoritaPose247:
+ax_pose 12, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sChikoritaPose248:
+ax_pose 69, 0x01ed, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose249:
+ax_pose 68, 0x01eb, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose250:
+ax_pose 70, 0x01eb, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose251:
+ax_pose 71, 0x01eb, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose252:
+ax_pose 72, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose253:
+ax_pose 73, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sChikoritaPose254:
+ax_pose 68, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose255:
+ax_pose 70, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose256:
+ax_pose 71, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose257:
+ax_pose 72, 0x01ea, 0x90ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose258:
+ax_pose 73, 0x01ea, 0x90ef, 0x3c00
+ax_pose_terminator
+sChikoritaPose259:
+ax_pose 74, 0x01ea, 0x90ed, 0x3c00
+ax_pose_terminator
+sChikoritaPose260:
+ax_pose 46, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose261:
+ax_pose 47, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose262:
+ax_pose 46, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose263:
+ax_pose 47, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose264:
+ax_pose 46, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose265:
+ax_pose 47, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sChikoritaPose266:
+ax_pose 46, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sChikoritaPose267:
+ax_pose 47, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+.align 2
+sChikoritaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sChikoritaAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sChikoritaAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sChikoritaAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sChikoritaAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sChikoritaAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sChikoritaAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sChikoritaAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_3_1:
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 2, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, 6, 0, 6,
+ax_anim 2, 1, 51, 1, 7, 1, 7,
+ax_anim 2, 0, 51, 0, 7, 0, 7,
+ax_anim 2, 0, 51, 1, 7, 1, 7,
+ax_anim 4, 0, 49, 0, 4, 0, 4,
+ax_anim_terminator
+sChikoritaAnims_3_2:
+ax_anim 2, 0, 52, -2, -2, -2, -2,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 2, 2, 53, -1, -1, -1, -1,
+ax_anim 2, 0, 54, 10, 10, 10, 10,
+ax_anim 2, 1, 55, 11, 9, 11, 9,
+ax_anim 2, 0, 55, 10, 10, 10, 10,
+ax_anim 2, 0, 55, 11, 9, 11, 9,
+ax_anim 4, 0, 53, 3, 3, 3, 3,
+ax_anim_terminator
+sChikoritaAnims_3_3:
+ax_anim 2, 0, 56, -2, 0, -2, 0,
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 6, 0, 57, -3, 0, -3, 0,
+ax_anim 2, 2, 57, -1, 0, -1, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim 2, 1, 59, 4, -1, 4, -1,
+ax_anim 2, 0, 59, 4, 0, 4, 0,
+ax_anim 2, 0, 59, 4, -1, 4, -1,
+ax_anim 4, 0, 57, 3, 0, 3, 0,
+ax_anim_terminator
+sChikoritaAnims_3_4:
+ax_anim 2, 0, 60, -2, 2, -2, 2,
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 2, 2, 61, 1, -2, 1, -2,
+ax_anim 2, 0, 62, 7, -18, 7, -18,
+ax_anim 2, 1, 63, 6, -19, 6, -19,
+ax_anim 2, 0, 63, 7, -18, 7, -18,
+ax_anim 2, 0, 63, 6, -19, 6, -19,
+ax_anim 4, 0, 61, 3, -3, 3, -3,
+ax_anim_terminator
+sChikoritaAnims_3_5:
+ax_anim 2, 0, 64, 0, 2, 0, 2,
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 2, 65, 0, -7, 0, -7,
+ax_anim 2, 0, 66, 0, -19, 0, -19,
+ax_anim 2, 1, 67, 1, -19, 1, -19,
+ax_anim 2, 0, 67, 0, -19, 0, -19,
+ax_anim 2, 0, 67, 1, -19, 1, -19,
+ax_anim 4, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sChikoritaAnims_3_6:
+ax_anim 2, 0, 68, 2, 2, 2, 2,
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 2, 2, 69, -1, -2, -1, -2,
+ax_anim 2, 0, 70, -7, -18, -7, -18,
+ax_anim 2, 1, 71, -6, -19, -6, -19,
+ax_anim 2, 0, 71, -7, -18, -7, -18,
+ax_anim 2, 0, 71, -6, -19, -6, -19,
+ax_anim 4, 0, 69, -3, -3, -3, -3,
+ax_anim_terminator
+sChikoritaAnims_3_7:
+ax_anim 2, 0, 72, 2, 0, 2, 0,
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 6, 0, 73, 3, 0, 3, 0,
+ax_anim 2, 2, 73, 1, 0, 1, 0,
+ax_anim 2, 0, 74, -4, 0, -4, 0,
+ax_anim 2, 1, 75, -4, -1, -4, -1,
+ax_anim 2, 0, 75, -4, 0, -4, 0,
+ax_anim 2, 0, 75, -4, -1, -4, -1,
+ax_anim 4, 0, 73, -3, 0, -3, 0,
+ax_anim_terminator
+sChikoritaAnims_3_8:
+ax_anim 2, 0, 76, 2, -2, 2, -2,
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 2, 77, 1, -1, 1, -1,
+ax_anim 2, 0, 78, -10, 10, -10, 10,
+ax_anim 2, 1, 79, -11, 9, -11, 9,
+ax_anim 2, 0, 79, -10, 10, -10, 10,
+ax_anim 2, 0, 79, -11, 9, -11, 9,
+ax_anim 4, 0, 77, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_4_1:
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim 5, 2, 80, 0, -5, 0, -5,
+ax_anim 1, 0, 81, 0, -2, 0, -2,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 81, -1, 0, -1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_4_2:
+ax_anim 2, 0, 82, -2, -2, -2, -2,
+ax_anim 2, 0, 82, -4, -4, -4, -4,
+ax_anim 5, 2, 82, -5, -5, -5, -5,
+ax_anim 1, 0, 83, -2, -2, -2, -2,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 1, 83, -1, 1, -1, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_4_3:
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 2, 0, 84, -4, 0, -4, 0,
+ax_anim 5, 2, 84, -5, 0, -5, 0,
+ax_anim 1, 0, 85, -2, 0, -2, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 85, 0, -1, 0, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_4_4:
+ax_anim 2, 0, 86, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -4, 4, -4, 4,
+ax_anim 5, 2, 86, -5, 5, -5, 5,
+ax_anim 1, 0, 87, -2, 2, -2, 2,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_4_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim 5, 2, 88, 0, 5, 0, 5,
+ax_anim 1, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 1, 89, -1, 0, -1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_4_6:
+ax_anim 2, 0, 90, 2, 2, 2, 2,
+ax_anim 2, 0, 90, 4, 4, 4, 4,
+ax_anim 5, 2, 90, 5, 5, 5, 5,
+ax_anim 1, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_4_7:
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 4, 0, 4, 0,
+ax_anim 5, 2, 92, 5, 0, 5, 0,
+ax_anim 1, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 93, 0, -1, 0, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, -1, 0, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, -1, 0, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 4, -4, 4, -4,
+ax_anim 5, 2, 94, 5, -5, 5, -5,
+ax_anim 1, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 95, -1, -1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_5_1:
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 0, -4, 0, -4,
+ax_anim 5, 2, 96, 0, -5, 0, -5,
+ax_anim 1, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 1, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_5_2:
+ax_anim 2, 0, 98, -2, -2, -2, -2,
+ax_anim 2, 0, 98, -4, -4, -4, -4,
+ax_anim 5, 2, 98, -5, -5, -5, -5,
+ax_anim 1, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 1, 99, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_5_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim 5, 2, 100, -5, 0, -5, 0,
+ax_anim 1, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 1, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_5_4:
+ax_anim 2, 0, 102, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -4, 4, -4, 4,
+ax_anim 5, 2, 102, -5, 5, -5, 5,
+ax_anim 1, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 1, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_5_5:
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim 2, 0, 104, 0, 4, 0, 4,
+ax_anim 5, 2, 104, 0, 5, 0, 5,
+ax_anim 1, 0, 105, 0, 2, 0, 2,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_5_6:
+ax_anim 2, 0, 106, 2, 2, 2, 2,
+ax_anim 2, 0, 106, 4, 4, 4, 4,
+ax_anim 5, 2, 106, 5, 5, 5, 5,
+ax_anim 1, 0, 107, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 107, -1, 1, -1, 1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 1, -1, 1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 1, -1, 1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_5_7:
+ax_anim 2, 0, 108, 2, 0, 2, 0,
+ax_anim 2, 0, 108, 4, 0, 4, 0,
+ax_anim 5, 2, 108, 5, 0, 5, 0,
+ax_anim 1, 0, 109, 2, 0, 2, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_5_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 110, 4, -4, 4, -4,
+ax_anim 5, 2, 110, 5, -5, 5, -5,
+ax_anim 1, 0, 111, 2, -2, 2, -2,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 111, -1, -1, 1, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, 1, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, 1, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sChikoritaAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sChikoritaAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sChikoritaAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sChikoritaAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sChikoritaAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sChikoritaAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sChikoritaAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 4, 0, 125, 0, -5, 0, 0,
+ax_anim 3, 0, 123, 0, -7, 0, 0,
+ax_anim 1, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 122, 0, -4, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_8_2:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 4, 0, 129, 0, -5, 0, 0,
+ax_anim 3, 0, 128, 0, -7, 0, 0,
+ax_anim 1, 0, 126, 0, -5, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_8_3:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 133, 0, -5, 0, 0,
+ax_anim 3, 0, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_8_4:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, -5, 0, 0,
+ax_anim 3, 0, 136, 0, -7, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -4, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_8_5:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 0, 141, 0, -5, 0, 0,
+ax_anim 3, 0, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -4, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_8_6:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -5, 0, 0,
+ax_anim 3, 0, 144, 0, -7, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -4, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_8_7:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -5, 0, 0,
+ax_anim 3, 0, 148, 0, -7, 0, 0,
+ax_anim 1, 0, 146, 0, -5, 0, 0,
+ax_anim 1, 0, 146, 0, -4, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_8_8:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 4, 0, 153, 0, -5, 0, 0,
+ax_anim 3, 0, 152, 0, -7, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 150, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 19, 7, 19,
+ax_anim 3, 0, 158, 0, 22, 0, 24,
+ax_anim 2, 3, 159, -7, 19, -7, 19,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 24, 9, 24, 9,
+ax_anim 3, 0, 157, 23, 21, 23, 21,
+ax_anim 2, 3, 158, 11, 21, 11, 21,
+ax_anim 2, 0, 159, 2, 12, 2, 12,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -4, 17, -4,
+ax_anim 3, 0, 156, 20, 1, 20, 1,
+ax_anim 2, 3, 157, 17, 5, 17, 5,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 3, -17, 3, -17,
+ax_anim 2, 0, 154, 9, -24, 10, -23,
+ax_anim 3, 0, 155, 19, -24, 16, -20,
+ax_anim 2, 3, 156, 20, -12, 20, -12,
+ax_anim 2, 0, 157, 16, -4, 16, -4,
+ax_anim 1, 0, 158, 8, 0, 8, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -8, -10, -8, -10,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -24, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 8, -8, 8, -8,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -3, -17, -3, -17,
+ax_anim 2, 0, 154, -9, -24, -9, -24,
+ax_anim 3, 0, 161, -19, -24, -19, -24,
+ax_anim 2, 3, 160, -20, -12, -20, -12,
+ax_anim 2, 0, 159, -16, -4, -16, -4,
+ax_anim 1, 0, 158, -8, 0, -8, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -4, -17, -4,
+ax_anim 3, 0, 160, -20, 1, -20, 1,
+ax_anim 2, 3, 159, -17, 5, -17, 5,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -24, 9, -24, 9,
+ax_anim 3, 0, 159, -23, 21, -23, 16,
+ax_anim 2, 3, 158, -11, 21, -11, 16,
+ax_anim 2, 0, 157, -2, 12, -4, 12,
+ax_anim 1, 0, 156, 0, 7, -3, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_14_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_14_2:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_14_3:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_14_4:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_14_5:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_14_6:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_14_7:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_14_8:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_15_1:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_15_2:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_15_3:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_15_4:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_15_5:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_15_6:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_15_7:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_15_8:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_16_1:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_16_2:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_16_3:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_16_4:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_16_5:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_16_6:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_16_7:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_16_8:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_17_1:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sChikoritaAnims_17_2:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sChikoritaAnims_17_3:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sChikoritaAnims_17_4:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sChikoritaAnims_17_5:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sChikoritaAnims_17_6:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sChikoritaAnims_17_7:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sChikoritaAnims_17_8:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_18_1:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_18_2:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_18_3:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_18_4:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_18_5:
+ax_anim 12, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_18_6:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_18_7:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_18_8:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_19_1:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_19_2:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_19_3:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_19_4:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_19_5:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_19_6:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_19_7:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_19_8:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_20_1:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -1, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 1, 0, 0,
+ax_anim 2, 0, 235, 1, 1, 1, 0,
+ax_anim 2, 0, 235, 0, 1, 0, 0,
+ax_anim 2, 0, 235, 1, 1, 1, 0,
+ax_anim 2, 0, 235, 0, 1, 0, 0,
+ax_anim 2, 0, 235, 1, 1, 1, 0,
+ax_anim_terminator
+sChikoritaAnims_20_2:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sChikoritaAnims_20_3:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sChikoritaAnims_20_4:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sChikoritaAnims_20_5:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sChikoritaAnims_20_6:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sChikoritaAnims_20_7:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sChikoritaAnims_20_8:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_21_1:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_21_2:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_21_3:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_21_4:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_21_5:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_21_6:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_21_7:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_21_8:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_22_1:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_22_2:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_22_3:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_22_4:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_22_5:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_22_6:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_22_7:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_22_8:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_23_1:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_23_2:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_23_3:
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_23_4:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_23_5:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_23_6:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_23_7:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_23_8:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_24_1:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_24_2:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_24_3:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_24_4:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_24_5:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_24_6:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_24_7:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_24_8:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_25_1:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_25_2:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_25_3:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_25_4:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_25_5:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_25_6:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_25_7:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_25_8:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_26_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sChikoritaAnims_26_2:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sChikoritaAnims_26_3:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sChikoritaAnims_26_4:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sChikoritaAnims_26_5:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sChikoritaAnims_26_6:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sChikoritaAnims_26_7:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sChikoritaAnims_26_8:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_27_1:
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 16, 0, 259, -1, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 1, 0, 0, 0,
+ax_anim 16, 0, 259, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChikoritaAnims_28_1:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_28_2:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_28_3:
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_28_4:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_28_5:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_28_6:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_28_7:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaAnims_28_8:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChikoritaGfx1:
+.incbin "baserom.gba", 0xBA6138, 0x100
+sChikoritaSprites1:
+ax_sprite sChikoritaGfx1, 0x100
+ax_sprite_terminator
+sChikoritaGfx2:
+.incbin "baserom.gba", 0xBA6248, 0x100
+sChikoritaSprites2:
+ax_sprite sChikoritaGfx2, 0x100
+ax_sprite_terminator
+sChikoritaGfx3:
+.incbin "baserom.gba", 0xBA6358, 0x100
+sChikoritaSprites3:
+ax_sprite sChikoritaGfx3, 0x100
+ax_sprite_terminator
+sChikoritaGfx4:
+.incbin "baserom.gba", 0xBA6468, 0x200
+sChikoritaSprites4:
+ax_sprite sChikoritaGfx4, 0x200
+ax_sprite_terminator
+sChikoritaGfx5:
+.incbin "baserom.gba", 0xBA6678, 0x200
+sChikoritaSprites5:
+ax_sprite sChikoritaGfx5, 0x200
+ax_sprite_terminator
+sChikoritaGfx6:
+.incbin "baserom.gba", 0xBA6888, 0x100
+sChikoritaSprites6:
+ax_sprite sChikoritaGfx6, 0x100
+ax_sprite_terminator
+sChikoritaGfx7:
+.incbin "baserom.gba", 0xBA6998, 0x200
+sChikoritaSprites7:
+ax_sprite sChikoritaGfx7, 0x200
+ax_sprite_terminator
+sChikoritaGfx8:
+.incbin "baserom.gba", 0xBA6BA8, 0x200
+sChikoritaSprites8:
+ax_sprite sChikoritaGfx8, 0x200
+ax_sprite_terminator
+sChikoritaGfx9:
+.incbin "baserom.gba", 0xBA6DB8, 0x200
+sChikoritaSprites9:
+ax_sprite sChikoritaGfx9, 0x200
+ax_sprite_terminator
+sChikoritaGfx10:
+.incbin "baserom.gba", 0xBA6FC8, 0x100
+sChikoritaSprites10:
+ax_sprite sChikoritaGfx10, 0x100
+ax_sprite_terminator
+sChikoritaGfx11:
+.incbin "baserom.gba", 0xBA70D8, 0x100
+sChikoritaSprites11:
+ax_sprite sChikoritaGfx11, 0x100
+ax_sprite_terminator
+sChikoritaGfx12:
+.incbin "baserom.gba", 0xBA71E8, 0x200
+sChikoritaSprites12:
+ax_sprite sChikoritaGfx12, 0x200
+ax_sprite_terminator
+sChikoritaGfx13:
+.incbin "baserom.gba", 0xBA73F8, 0x100
+sChikoritaSprites13:
+ax_sprite sChikoritaGfx13, 0x100
+ax_sprite_terminator
+sChikoritaGfx14:
+.incbin "baserom.gba", 0xBA7508, 0x100
+sChikoritaSprites14:
+ax_sprite sChikoritaGfx14, 0x100
+ax_sprite_terminator
+sChikoritaGfx15:
+.incbin "baserom.gba", 0xBA7618, 0x100
+sChikoritaSprites15:
+ax_sprite sChikoritaGfx15, 0x100
+ax_sprite_terminator
+sChikoritaGfx16:
+.incbin "baserom.gba", 0xBA7728, 0xC0
+sChikoritaSprites16:
+ax_sprite sChikoritaGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChikoritaGfx17:
+.incbin "baserom.gba", 0xBA7800, 0x100
+sChikoritaSprites17:
+ax_sprite sChikoritaGfx17, 0x100
+ax_sprite_terminator
+sChikoritaGfx18:
+.incbin "baserom.gba", 0xBA7910, 0x40
+sChikoritaSprites18:
+ax_sprite sChikoritaGfx18, 0x40
+ax_sprite_terminator
+sChikoritaGfx19:
+.incbin "baserom.gba", 0xBA7960, 0x100
+sChikoritaSprites19:
+ax_sprite sChikoritaGfx19, 0x100
+ax_sprite_terminator
+sChikoritaGfx20:
+.incbin "baserom.gba", 0xBA7A70, 0x60
+sChikoritaGfx20_1:
+.incbin "baserom.gba", 0xBA7AD0, 0x60
+sChikoritaGfx20_2:
+.incbin "baserom.gba", 0xBA7B30, 0x40
+sChikoritaSprites20:
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx20_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sChikoritaGfx21:
+.incbin "baserom.gba", 0xBA7BB0, 0x60
+sChikoritaGfx21_1:
+.incbin "baserom.gba", 0xBA7C10, 0x80
+sChikoritaGfx21_2:
+.incbin "baserom.gba", 0xBA7C90, 0x60
+sChikoritaGfx21_3:
+.incbin "baserom.gba", 0xBA7CF0, 0x40
+sChikoritaSprites21:
+ax_sprite sChikoritaGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx21_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx21_3, 0x40
+ax_sprite_terminator
+sChikoritaGfx22:
+.incbin "baserom.gba", 0xBA7D70, 0x80
+sChikoritaSprites22:
+ax_sprite sChikoritaGfx22, 0x80
+ax_sprite_terminator
+sChikoritaGfx23:
+.incbin "baserom.gba", 0xBA7E00, 0x40
+sChikoritaGfx23_1:
+.incbin "baserom.gba", 0xBA7E40, 0x120
+sChikoritaSprites23:
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx23_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChikoritaGfx24:
+.incbin "baserom.gba", 0xBA7F90, 0x160
+sChikoritaGfx24_1:
+.incbin "baserom.gba", 0xBA80F0, 0x40
+sChikoritaSprites24:
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChikoritaGfx25:
+.incbin "baserom.gba", 0xBA8160, 0x60
+sChikoritaGfx25_1:
+.incbin "baserom.gba", 0xBA81C0, 0x80
+sChikoritaGfx25_2:
+.incbin "baserom.gba", 0xBA8240, 0x60
+sChikoritaGfx25_3:
+.incbin "baserom.gba", 0xBA82A0, 0x40
+sChikoritaSprites25:
+ax_sprite sChikoritaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx25_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx25_3, 0x40
+ax_sprite_terminator
+sChikoritaGfx26:
+.incbin "baserom.gba", 0xBA8320, 0x40
+sChikoritaSprites26:
+ax_sprite sChikoritaGfx26, 0x40
+ax_sprite_terminator
+sChikoritaGfx27:
+.incbin "baserom.gba", 0xBA8370, 0x40
+sChikoritaGfx27_1:
+.incbin "baserom.gba", 0xBA83B0, 0x120
+sChikoritaSprites27:
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx27_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChikoritaGfx28:
+.incbin "baserom.gba", 0xBA8500, 0x160
+sChikoritaGfx28_1:
+.incbin "baserom.gba", 0xBA8660, 0x40
+sChikoritaSprites28:
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx28, 0x160
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChikoritaGfx29:
+.incbin "baserom.gba", 0xBA86D0, 0x180
+sChikoritaGfx29_1:
+.incbin "baserom.gba", 0xBA8850, 0x40
+sChikoritaSprites29:
+ax_sprite sChikoritaGfx29, 0x180
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx29_1, 0x40
+ax_sprite_terminator
+sChikoritaGfx30:
+.incbin "baserom.gba", 0xBA88B0, 0x40
+sChikoritaSprites30:
+ax_sprite sChikoritaGfx30, 0x40
+ax_sprite_terminator
+sChikoritaGfx31:
+.incbin "baserom.gba", 0xBA8900, 0x20
+sChikoritaGfx31_1:
+.incbin "baserom.gba", 0xBA8920, 0xC0
+sChikoritaGfx31_2:
+.incbin "baserom.gba", 0xBA89E0, 0x60
+sChikoritaSprites31:
+ax_sprite sChikoritaGfx31, 0x20
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx31_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx31_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChikoritaGfx32:
+.incbin "baserom.gba", 0xBA8A78, 0x100
+sChikoritaSprites32:
+ax_sprite sChikoritaGfx32, 0x100
+ax_sprite_terminator
+sChikoritaGfx33:
+.incbin "baserom.gba", 0xBA8B88, 0x100
+sChikoritaSprites33:
+ax_sprite sChikoritaGfx33, 0x100
+ax_sprite_terminator
+sChikoritaGfx34:
+.incbin "baserom.gba", 0xBA8C98, 0x100
+sChikoritaSprites34:
+ax_sprite sChikoritaGfx34, 0x100
+ax_sprite_terminator
+sChikoritaGfx35:
+.incbin "baserom.gba", 0xBA8DA8, 0xC0
+sChikoritaSprites35:
+ax_sprite sChikoritaGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChikoritaGfx36:
+.incbin "baserom.gba", 0xBA8E80, 0x60
+sChikoritaGfx36_1:
+.incbin "baserom.gba", 0xBA8EE0, 0x60
+sChikoritaGfx36_2:
+.incbin "baserom.gba", 0xBA8F40, 0x60
+sChikoritaSprites36:
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx36_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChikoritaGfx37:
+.incbin "baserom.gba", 0xBA8FE0, 0x60
+sChikoritaGfx37_1:
+.incbin "baserom.gba", 0xBA9040, 0x60
+sChikoritaGfx37_2:
+.incbin "baserom.gba", 0xBA90A0, 0x60
+sChikoritaGfx37_3:
+.incbin "baserom.gba", 0xBA9100, 0x20
+sChikoritaSprites37:
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx37_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx37_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChikoritaGfx38:
+.incbin "baserom.gba", 0xBA9170, 0x40
+sChikoritaGfx38_1:
+.incbin "baserom.gba", 0xBA91B0, 0x40
+sChikoritaGfx38_2:
+.incbin "baserom.gba", 0xBA91F0, 0x60
+sChikoritaGfx38_3:
+.incbin "baserom.gba", 0xBA9250, 0x40
+sChikoritaSprites38:
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx38_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChikoritaGfx38_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChikoritaGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChikoritaGfx39:
+.incbin "baserom.gba", 0xBA92E0, 0xC0
+sChikoritaSprites39:
+ax_sprite sChikoritaGfx39, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChikoritaGfx40:
+.incbin "baserom.gba", 0xBA93B8, 0x200
+sChikoritaSprites40:
+ax_sprite sChikoritaGfx40, 0x200
+ax_sprite_terminator
+sChikoritaGfx41:
+.incbin "baserom.gba", 0xBA95C8, 0x200
+sChikoritaSprites41:
+ax_sprite sChikoritaGfx41, 0x200
+ax_sprite_terminator
+sChikoritaGfx42:
+.incbin "baserom.gba", 0xBA97D8, 0x200
+sChikoritaSprites42:
+ax_sprite sChikoritaGfx42, 0x200
+ax_sprite_terminator
+sChikoritaGfx43:
+.incbin "baserom.gba", 0xBA99E8, 0x200
+sChikoritaSprites43:
+ax_sprite sChikoritaGfx43, 0x200
+ax_sprite_terminator
+sChikoritaGfx44:
+.incbin "baserom.gba", 0xBA9BF8, 0x200
+sChikoritaSprites44:
+ax_sprite sChikoritaGfx44, 0x200
+ax_sprite_terminator
+sChikoritaGfx45:
+.incbin "baserom.gba", 0xBA9E08, 0x200
+sChikoritaSprites45:
+ax_sprite sChikoritaGfx45, 0x200
+ax_sprite_terminator
+sChikoritaGfx46:
+.incbin "baserom.gba", 0xBAA018, 0x200
+sChikoritaSprites46:
+ax_sprite sChikoritaGfx46, 0x200
+ax_sprite_terminator
+sChikoritaGfx47:
+.incbin "baserom.gba", 0xBAA228, 0x200
+sChikoritaSprites47:
+ax_sprite sChikoritaGfx47, 0x200
+ax_sprite_terminator
+sChikoritaGfx48:
+.incbin "baserom.gba", 0xBAA438, 0x200
+sChikoritaSprites48:
+ax_sprite sChikoritaGfx48, 0x200
+ax_sprite_terminator
+sChikoritaGfx49:
+.incbin "baserom.gba", 0xBAA648, 0x200
+sChikoritaSprites49:
+ax_sprite sChikoritaGfx49, 0x200
+ax_sprite_terminator
+sChikoritaGfx50:
+.incbin "baserom.gba", 0xBAA858, 0x200
+sChikoritaSprites50:
+ax_sprite sChikoritaGfx50, 0x200
+ax_sprite_terminator
+sChikoritaGfx51:
+.incbin "baserom.gba", 0xBAAA68, 0x200
+sChikoritaSprites51:
+ax_sprite sChikoritaGfx51, 0x200
+ax_sprite_terminator
+sChikoritaGfx52:
+.incbin "baserom.gba", 0xBAAC78, 0x100
+sChikoritaSprites52:
+ax_sprite sChikoritaGfx52, 0x100
+ax_sprite_terminator
+sChikoritaGfx53:
+.incbin "baserom.gba", 0xBAAD88, 0x100
+sChikoritaSprites53:
+ax_sprite sChikoritaGfx53, 0x100
+ax_sprite_terminator
+sChikoritaGfx54:
+.incbin "baserom.gba", 0xBAAE98, 0x100
+sChikoritaSprites54:
+ax_sprite sChikoritaGfx54, 0x100
+ax_sprite_terminator
+sChikoritaGfx55:
+.incbin "baserom.gba", 0xBAAFA8, 0x100
+sChikoritaSprites55:
+ax_sprite sChikoritaGfx55, 0x100
+ax_sprite_terminator
+sChikoritaGfx56:
+.incbin "baserom.gba", 0xBAB0B8, 0x100
+sChikoritaSprites56:
+ax_sprite sChikoritaGfx56, 0x100
+ax_sprite_terminator
+sChikoritaGfx57:
+.incbin "baserom.gba", 0xBAB1C8, 0x100
+sChikoritaSprites57:
+ax_sprite sChikoritaGfx57, 0x100
+ax_sprite_terminator
+sChikoritaGfx58:
+.incbin "baserom.gba", 0xBAB2D8, 0x100
+sChikoritaSprites58:
+ax_sprite sChikoritaGfx58, 0x100
+ax_sprite_terminator
+sChikoritaGfx59:
+.incbin "baserom.gba", 0xBAB3E8, 0x100
+sChikoritaSprites59:
+ax_sprite sChikoritaGfx59, 0x100
+ax_sprite_terminator
+sChikoritaGfx60:
+.incbin "baserom.gba", 0xBAB4F8, 0x200
+sChikoritaSprites60:
+ax_sprite sChikoritaGfx60, 0x200
+ax_sprite_terminator
+sChikoritaGfx61:
+.incbin "baserom.gba", 0xBAB708, 0x200
+sChikoritaSprites61:
+ax_sprite sChikoritaGfx61, 0x200
+ax_sprite_terminator
+sChikoritaGfx62:
+.incbin "baserom.gba", 0xBAB918, 0x100
+sChikoritaSprites62:
+ax_sprite sChikoritaGfx62, 0x100
+ax_sprite_terminator
+sChikoritaGfx63:
+.incbin "baserom.gba", 0xBABA28, 0x100
+sChikoritaSprites63:
+ax_sprite sChikoritaGfx63, 0x100
+ax_sprite_terminator
+sChikoritaGfx64:
+.incbin "baserom.gba", 0xBABB38, 0x200
+sChikoritaSprites64:
+ax_sprite sChikoritaGfx64, 0x200
+ax_sprite_terminator
+sChikoritaGfx65:
+.incbin "baserom.gba", 0xBABD48, 0x200
+sChikoritaSprites65:
+ax_sprite sChikoritaGfx65, 0x200
+ax_sprite_terminator
+sChikoritaGfx66:
+.incbin "baserom.gba", 0xBABF58, 0x100
+sChikoritaSprites66:
+ax_sprite sChikoritaGfx66, 0x100
+ax_sprite_terminator
+sChikoritaGfx67:
+.incbin "baserom.gba", 0xBAC068, 0x200
+sChikoritaSprites67:
+ax_sprite sChikoritaGfx67, 0x200
+ax_sprite_terminator
+sChikoritaGfx68:
+.incbin "baserom.gba", 0xBAC278, 0x100
+sChikoritaSprites68:
+ax_sprite sChikoritaGfx68, 0x100
+ax_sprite_terminator
+sChikoritaGfx69:
+.incbin "baserom.gba", 0xBAC388, 0x200
+sChikoritaSprites69:
+ax_sprite sChikoritaGfx69, 0x200
+ax_sprite_terminator
+sChikoritaGfx70:
+.incbin "baserom.gba", 0xBAC598, 0x200
+sChikoritaSprites70:
+ax_sprite sChikoritaGfx70, 0x200
+ax_sprite_terminator
+sChikoritaGfx71:
+.incbin "baserom.gba", 0xBAC7A8, 0x200
+sChikoritaSprites71:
+ax_sprite sChikoritaGfx71, 0x200
+ax_sprite_terminator
+sChikoritaGfx72:
+.incbin "baserom.gba", 0xBAC9B8, 0x200
+sChikoritaSprites72:
+ax_sprite sChikoritaGfx72, 0x200
+ax_sprite_terminator
+sChikoritaGfx73:
+.incbin "baserom.gba", 0xBACBC8, 0x200
+sChikoritaSprites73:
+ax_sprite sChikoritaGfx73, 0x200
+ax_sprite_terminator
+sChikoritaGfx74:
+.incbin "baserom.gba", 0xBACDD8, 0x200
+sChikoritaSprites74:
+ax_sprite sChikoritaGfx74, 0x200
+ax_sprite_terminator
+sChikoritaGfx75:
+.incbin "baserom.gba", 0xBACFE8, 0x200
+sChikoritaSprites75:
+ax_sprite sChikoritaGfx75, 0x200
+ax_sprite_terminator
+sAxPosesChikorita:
+.4byte sChikoritaPose1
+.4byte sChikoritaPose2
+.4byte sChikoritaPose3
+.4byte sChikoritaPose4
+.4byte sChikoritaPose5
+.4byte sChikoritaPose6
+.4byte sChikoritaPose7
+.4byte sChikoritaPose8
+.4byte sChikoritaPose9
+.4byte sChikoritaPose10
+.4byte sChikoritaPose11
+.4byte sChikoritaPose12
+.4byte sChikoritaPose13
+.4byte sChikoritaPose14
+.4byte sChikoritaPose15
+.4byte sChikoritaPose16
+.4byte sChikoritaPose17
+.4byte sChikoritaPose18
+.4byte sChikoritaPose19
+.4byte sChikoritaPose20
+.4byte sChikoritaPose21
+.4byte sChikoritaPose22
+.4byte sChikoritaPose23
+.4byte sChikoritaPose24
+.4byte sChikoritaPose25
+.4byte sChikoritaPose26
+.4byte sChikoritaPose27
+.4byte sChikoritaPose28
+.4byte sChikoritaPose29
+.4byte sChikoritaPose30
+.4byte sChikoritaPose31
+.4byte sChikoritaPose32
+.4byte sChikoritaPose33
+.4byte sChikoritaPose34
+.4byte sChikoritaPose35
+.4byte sChikoritaPose36
+.4byte sChikoritaPose37
+.4byte sChikoritaPose38
+.4byte sChikoritaPose39
+.4byte sChikoritaPose40
+.4byte sChikoritaPose41
+.4byte sChikoritaPose42
+.4byte sChikoritaPose43
+.4byte sChikoritaPose44
+.4byte sChikoritaPose45
+.4byte sChikoritaPose46
+.4byte sChikoritaPose47
+.4byte sChikoritaPose48
+.4byte sChikoritaPose49
+.4byte sChikoritaPose50
+.4byte sChikoritaPose51
+.4byte sChikoritaPose52
+.4byte sChikoritaPose53
+.4byte sChikoritaPose54
+.4byte sChikoritaPose55
+.4byte sChikoritaPose56
+.4byte sChikoritaPose57
+.4byte sChikoritaPose58
+.4byte sChikoritaPose59
+.4byte sChikoritaPose60
+.4byte sChikoritaPose61
+.4byte sChikoritaPose62
+.4byte sChikoritaPose63
+.4byte sChikoritaPose64
+.4byte sChikoritaPose65
+.4byte sChikoritaPose66
+.4byte sChikoritaPose67
+.4byte sChikoritaPose68
+.4byte sChikoritaPose69
+.4byte sChikoritaPose70
+.4byte sChikoritaPose71
+.4byte sChikoritaPose72
+.4byte sChikoritaPose73
+.4byte sChikoritaPose74
+.4byte sChikoritaPose75
+.4byte sChikoritaPose76
+.4byte sChikoritaPose77
+.4byte sChikoritaPose78
+.4byte sChikoritaPose79
+.4byte sChikoritaPose80
+.4byte sChikoritaPose81
+.4byte sChikoritaPose82
+.4byte sChikoritaPose83
+.4byte sChikoritaPose84
+.4byte sChikoritaPose85
+.4byte sChikoritaPose86
+.4byte sChikoritaPose87
+.4byte sChikoritaPose88
+.4byte sChikoritaPose89
+.4byte sChikoritaPose90
+.4byte sChikoritaPose91
+.4byte sChikoritaPose92
+.4byte sChikoritaPose93
+.4byte sChikoritaPose94
+.4byte sChikoritaPose95
+.4byte sChikoritaPose96
+.4byte sChikoritaPose97
+.4byte sChikoritaPose98
+.4byte sChikoritaPose99
+.4byte sChikoritaPose100
+.4byte sChikoritaPose101
+.4byte sChikoritaPose102
+.4byte sChikoritaPose103
+.4byte sChikoritaPose104
+.4byte sChikoritaPose105
+.4byte sChikoritaPose106
+.4byte sChikoritaPose107
+.4byte sChikoritaPose108
+.4byte sChikoritaPose109
+.4byte sChikoritaPose110
+.4byte sChikoritaPose111
+.4byte sChikoritaPose112
+.4byte sChikoritaPose113
+.4byte sChikoritaPose114
+.4byte sChikoritaPose115
+.4byte sChikoritaPose116
+.4byte sChikoritaPose117
+.4byte sChikoritaPose118
+.4byte sChikoritaPose119
+.4byte sChikoritaPose120
+.4byte sChikoritaPose121
+.4byte sChikoritaPose122
+.4byte sChikoritaPose123
+.4byte sChikoritaPose124
+.4byte sChikoritaPose125
+.4byte sChikoritaPose126
+.4byte sChikoritaPose127
+.4byte sChikoritaPose128
+.4byte sChikoritaPose129
+.4byte sChikoritaPose130
+.4byte sChikoritaPose131
+.4byte sChikoritaPose132
+.4byte sChikoritaPose133
+.4byte sChikoritaPose134
+.4byte sChikoritaPose135
+.4byte sChikoritaPose136
+.4byte sChikoritaPose137
+.4byte sChikoritaPose138
+.4byte sChikoritaPose139
+.4byte sChikoritaPose140
+.4byte sChikoritaPose141
+.4byte sChikoritaPose142
+.4byte sChikoritaPose143
+.4byte sChikoritaPose144
+.4byte sChikoritaPose145
+.4byte sChikoritaPose146
+.4byte sChikoritaPose147
+.4byte sChikoritaPose148
+.4byte sChikoritaPose149
+.4byte sChikoritaPose150
+.4byte sChikoritaPose151
+.4byte sChikoritaPose152
+.4byte sChikoritaPose153
+.4byte sChikoritaPose154
+.4byte sChikoritaPose155
+.4byte sChikoritaPose156
+.4byte sChikoritaPose157
+.4byte sChikoritaPose158
+.4byte sChikoritaPose159
+.4byte sChikoritaPose160
+.4byte sChikoritaPose161
+.4byte sChikoritaPose162
+.4byte sChikoritaPose163
+.4byte sChikoritaPose164
+.4byte sChikoritaPose165
+.4byte sChikoritaPose166
+.4byte sChikoritaPose167
+.4byte sChikoritaPose168
+.4byte sChikoritaPose169
+.4byte sChikoritaPose170
+.4byte sChikoritaPose171
+.4byte sChikoritaPose172
+.4byte sChikoritaPose173
+.4byte sChikoritaPose174
+.4byte sChikoritaPose175
+.4byte sChikoritaPose176
+.4byte sChikoritaPose177
+.4byte sChikoritaPose178
+.4byte sChikoritaPose179
+.4byte sChikoritaPose180
+.4byte sChikoritaPose181
+.4byte sChikoritaPose182
+.4byte sChikoritaPose183
+.4byte sChikoritaPose184
+.4byte sChikoritaPose185
+.4byte sChikoritaPose186
+.4byte sChikoritaPose187
+.4byte sChikoritaPose188
+.4byte sChikoritaPose189
+.4byte sChikoritaPose190
+.4byte sChikoritaPose191
+.4byte sChikoritaPose192
+.4byte sChikoritaPose193
+.4byte sChikoritaPose194
+.4byte sChikoritaPose195
+.4byte sChikoritaPose196
+.4byte sChikoritaPose197
+.4byte sChikoritaPose198
+.4byte sChikoritaPose199
+.4byte sChikoritaPose200
+.4byte sChikoritaPose201
+.4byte sChikoritaPose202
+.4byte sChikoritaPose203
+.4byte sChikoritaPose204
+.4byte sChikoritaPose205
+.4byte sChikoritaPose206
+.4byte sChikoritaPose207
+.4byte sChikoritaPose208
+.4byte sChikoritaPose209
+.4byte sChikoritaPose210
+.4byte sChikoritaPose211
+.4byte sChikoritaPose212
+.4byte sChikoritaPose213
+.4byte sChikoritaPose214
+.4byte sChikoritaPose215
+.4byte sChikoritaPose216
+.4byte sChikoritaPose217
+.4byte sChikoritaPose218
+.4byte sChikoritaPose219
+.4byte sChikoritaPose220
+.4byte sChikoritaPose221
+.4byte sChikoritaPose222
+.4byte sChikoritaPose223
+.4byte sChikoritaPose224
+.4byte sChikoritaPose225
+.4byte sChikoritaPose226
+.4byte sChikoritaPose227
+.4byte sChikoritaPose228
+.4byte sChikoritaPose229
+.4byte sChikoritaPose230
+.4byte sChikoritaPose231
+.4byte sChikoritaPose232
+.4byte sChikoritaPose233
+.4byte sChikoritaPose234
+.4byte sChikoritaPose235
+.4byte sChikoritaPose236
+.4byte sChikoritaPose237
+.4byte sChikoritaPose238
+.4byte sChikoritaPose239
+.4byte sChikoritaPose240
+.4byte sChikoritaPose241
+.4byte sChikoritaPose242
+.4byte sChikoritaPose243
+.4byte sChikoritaPose244
+.4byte sChikoritaPose245
+.4byte sChikoritaPose246
+.4byte sChikoritaPose247
+.4byte sChikoritaPose248
+.4byte sChikoritaPose249
+.4byte sChikoritaPose250
+.4byte sChikoritaPose251
+.4byte sChikoritaPose252
+.4byte sChikoritaPose253
+.4byte sChikoritaPose254
+.4byte sChikoritaPose255
+.4byte sChikoritaPose256
+.4byte sChikoritaPose257
+.4byte sChikoritaPose258
+.4byte sChikoritaPose259
+.4byte sChikoritaPose260
+.4byte sChikoritaPose261
+.4byte sChikoritaPose262
+.4byte sChikoritaPose263
+.4byte sChikoritaPose264
+.4byte sChikoritaPose265
+.4byte sChikoritaPose266
+.4byte sChikoritaPose267
+sAxPositionsChikorita:
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -3, 	  -4,    2, 	   4,   -1, 	   0,   -6
+.2byte    0,   -3, 	  -4,   -1, 	   4,    2, 	   0,   -6
+.2byte    3,   -5, 	   5,   -1, 	   0,    0, 	  -1,   -5
+.2byte    3,   -4, 	   7,    0, 	  -1,    0, 	  -1,   -5
+.2byte    3,   -4, 	   5,   -2, 	   1,    1, 	   0,   -4
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    7,   -5, 	   7,   -2, 	   4,   -1, 	   0,   -5
+.2byte    7,   -5, 	   2,   -2, 	   6,   -1, 	   1,   -5
+.2byte    4,  -10, 	   1,   -5, 	   6,   -3, 	   1,   -6
+.2byte    4,   -9, 	   4,   -7, 	   5,   -2, 	   1,   -5
+.2byte    4,   -9, 	  -1,   -5, 	   7,   -3, 	   1,   -5
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    1,   -7, 	   5,   -6, 	  -5,   -4, 	   0,   -4
+.2byte   -1,   -8, 	   5,   -3, 	  -5,   -6, 	   1,   -4
+.2byte   -4,  -10, 	  -1,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -4,   -7, 	  -5,   -2, 	  -1,   -5
+.2byte   -4,   -9, 	   1,   -5, 	  -7,   -3, 	  -1,   -5
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -2, 	  -4,   -1, 	   0,   -5
+.2byte   -7,   -5, 	  -2,   -2, 	  -6,   -1, 	  -1,   -5
+.2byte   -3,   -5, 	  -5,   -1, 	   0,    0, 	   1,   -5
+.2byte   -3,   -4, 	  -7,    0, 	   1,    0, 	   1,   -5
+.2byte   -3,   -4, 	  -5,   -2, 	  -1,    1, 	   0,   -4
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -3, 	  -4,    2, 	   4,   -1, 	   0,   -6
+.2byte    0,   -3, 	  -4,   -1, 	   4,    2, 	   0,   -6
+.2byte    3,   -5, 	   5,   -1, 	   0,    0, 	  -1,   -5
+.2byte    3,   -4, 	   7,    0, 	  -1,    0, 	  -1,   -5
+.2byte    3,   -4, 	   5,   -2, 	   1,    1, 	   0,   -4
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    7,   -5, 	   7,   -2, 	   4,   -1, 	   0,   -5
+.2byte    7,   -5, 	   2,   -2, 	   6,   -1, 	   1,   -5
+.2byte    4,  -10, 	   1,   -5, 	   6,   -3, 	   1,   -6
+.2byte    4,   -9, 	   4,   -7, 	   5,   -2, 	   1,   -5
+.2byte    4,   -9, 	  -1,   -5, 	   7,   -3, 	   1,   -5
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    1,   -7, 	   5,   -6, 	  -5,   -4, 	   0,   -4
+.2byte   -1,   -8, 	   5,   -3, 	  -5,   -6, 	   1,   -4
+.2byte   -4,  -10, 	  -1,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -4,   -7, 	  -5,   -2, 	  -1,   -5
+.2byte   -4,   -9, 	   1,   -5, 	  -7,   -3, 	  -1,   -5
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -2, 	  -4,   -1, 	   0,   -5
+.2byte   -7,   -5, 	  -2,   -2, 	  -6,   -1, 	  -1,   -5
+.2byte   -3,   -5, 	  -5,   -1, 	   0,    0, 	   1,   -5
+.2byte   -3,   -4, 	  -7,    0, 	   1,    0, 	   1,   -5
+.2byte   -3,   -4, 	  -5,   -2, 	  -1,    1, 	   0,   -4
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    2,  -12, 	  -1,   -3, 	   5,   -3, 	   1,   -9
+.2byte   -1,    1, 	  -5,   -4, 	   3,   -4, 	  -1,   -8
+.2byte   -1,    1, 	  -5,   -4, 	   3,   -4, 	  -1,   -8
+.2byte    3,   -5, 	   5,   -1, 	   0,    0, 	  -1,   -5
+.2byte    0,  -13, 	   4,   -5, 	   1,   -4, 	  -1,   -8
+.2byte    1,   -4, 	   3,   -6, 	  -5,   -3, 	  -1,  -10
+.2byte    1,   -4, 	   3,   -6, 	  -5,   -3, 	  -1,  -10
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    0,  -16, 	   6,   -9, 	   5,   -7, 	  -2,   -8
+.2byte    2,   -4, 	   1,   -6, 	  -2,   -2, 	   0,  -10
+.2byte    7,   -5, 	   6,   -7, 	   3,   -3, 	   5,  -11
+.2byte    4,  -10, 	   1,   -5, 	   6,   -3, 	   1,   -6
+.2byte    1,  -15, 	   5,   -9, 	   6,   -7, 	  -2,   -5
+.2byte    4,   -2, 	  -3,   -2, 	   2,    0, 	   2,   -9
+.2byte    4,   -2, 	  -3,   -2, 	   2,    0, 	   2,   -9
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte   -2,  -16, 	   4,  -12, 	  -6,  -12, 	  -1,   -6
+.2byte   -1,   -2, 	   4,    0, 	  -6,    0, 	  -1,   -7
+.2byte   -1,   -2, 	   4,    0, 	  -6,    0, 	  -1,   -7
+.2byte   -5,  -10, 	  -2,   -5, 	  -7,   -3, 	  -2,   -6
+.2byte   -2,  -15, 	  -6,   -9, 	  -7,   -7, 	   1,   -5
+.2byte   -5,   -2, 	   2,   -2, 	  -3,    0, 	  -3,   -9
+.2byte   -5,   -2, 	   2,   -2, 	  -3,    0, 	  -3,   -9
+.2byte   -8,   -6, 	  -7,   -3, 	  -6,   -1, 	  -2,   -6
+.2byte   -1,  -16, 	  -7,   -9, 	  -6,   -7, 	   1,   -8
+.2byte   -3,   -4, 	  -2,   -6, 	   1,   -2, 	  -1,  -10
+.2byte   -8,   -5, 	  -7,   -7, 	  -4,   -3, 	  -6,  -11
+.2byte   -4,   -5, 	  -6,   -1, 	  -1,    0, 	   0,   -5
+.2byte   -1,  -13, 	  -5,   -5, 	  -2,   -4, 	   0,   -8
+.2byte   -2,   -4, 	  -4,   -6, 	   4,   -3, 	   0,  -10
+.2byte   -2,   -4, 	  -4,   -6, 	   4,   -3, 	   0,  -10
+.2byte    2,  -13, 	  -1,   -4, 	   5,   -4, 	   1,  -10
+.2byte    0,  -12, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte    2,  -12, 	   6,   -4, 	   3,   -3, 	   1,   -7
+.2byte    4,  -12, 	   8,   -4, 	   1,   -1, 	   0,   -7
+.2byte    0,  -15, 	   6,   -8, 	   5,   -6, 	  -2,   -7
+.2byte    7,  -12, 	   6,   -7, 	   6,   -4, 	   0,   -7
+.2byte    0,  -15, 	   4,   -9, 	   5,   -7, 	  -3,   -5
+.2byte    5,  -15, 	  -1,  -10, 	   7,   -7, 	   1,   -6
+.2byte   -2,  -16, 	   4,  -12, 	  -6,  -12, 	  -1,   -6
+.2byte    0,  -16, 	   5,   -9, 	  -5,   -9, 	   0,   -9
+.2byte   -5,  -15, 	  -9,   -9, 	 -10,   -7, 	  -2,   -5
+.2byte   -6,  -15, 	   0,  -10, 	  -8,   -7, 	  -2,   -6
+.2byte   -1,  -15, 	  -7,   -8, 	  -6,   -6, 	   1,   -7
+.2byte   -8,  -12, 	  -7,   -7, 	  -7,   -4, 	  -1,   -7
+.2byte   -3,  -12, 	  -7,   -4, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,  -12, 	  -9,   -4, 	  -2,   -1, 	  -1,   -7
+.2byte    2,  -13, 	  -1,   -4, 	   5,   -4, 	   1,  -10
+.2byte    0,  -12, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte    2,  -12, 	   6,   -4, 	   3,   -3, 	   1,   -7
+.2byte    4,  -12, 	   8,   -4, 	   1,   -1, 	   0,   -7
+.2byte    0,  -15, 	   6,   -8, 	   5,   -6, 	  -2,   -7
+.2byte    7,  -12, 	   6,   -7, 	   6,   -4, 	   0,   -7
+.2byte    0,  -15, 	   4,   -9, 	   5,   -7, 	  -3,   -5
+.2byte    5,  -15, 	  -1,  -10, 	   7,   -7, 	   1,   -6
+.2byte   -2,  -16, 	   4,  -12, 	  -6,  -12, 	  -1,   -6
+.2byte    0,  -16, 	   5,   -9, 	  -5,   -9, 	   0,   -9
+.2byte   -5,  -15, 	  -9,   -9, 	 -10,   -7, 	  -2,   -5
+.2byte   -6,  -15, 	   0,  -10, 	  -8,   -7, 	  -2,   -6
+.2byte   -1,  -15, 	  -7,   -8, 	  -6,   -6, 	   1,   -7
+.2byte   -8,  -12, 	  -7,   -7, 	  -7,   -4, 	  -1,   -7
+.2byte   -3,  -12, 	  -7,   -4, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,  -12, 	  -9,   -4, 	  -2,   -1, 	  -1,   -7
+.2byte   -4,   -3, 	  -5,    0, 	  -2,    1, 	   1,   -3
+.2byte   -4,   -4, 	  -5,    0, 	  -2,    1, 	   1,   -4
+.2byte    0,  -10, 	  -5,  -10, 	   5,  -10, 	   0,   -8
+.2byte    3,  -11, 	   8,  -11, 	   2,   -9, 	   0,   -9
+.2byte    4,  -12, 	   4,  -11, 	   3,  -10, 	  -3,   -8
+.2byte    3,  -16, 	  -2,  -15, 	   8,  -12, 	   0,   -9
+.2byte    0,  -16, 	   6,  -12, 	  -6,  -12, 	   0,   -8
+.2byte   -3,  -16, 	   2,  -15, 	  -8,  -12, 	   0,   -9
+.2byte   -4,  -12, 	  -4,  -11, 	  -3,  -10, 	   3,   -8
+.2byte   -3,  -11, 	  -8,  -11, 	  -2,   -9, 	   0,   -9
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -3, 	  -4,    2, 	   4,   -1, 	   0,   -6
+.2byte    0,   -3, 	  -4,   -1, 	   4,    2, 	   0,   -6
+.2byte    0,  -12, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte    3,   -5, 	   5,   -1, 	   0,    0, 	  -1,   -5
+.2byte    3,   -4, 	   7,    0, 	  -1,    0, 	  -1,   -5
+.2byte    3,   -4, 	   5,   -2, 	   1,    1, 	   0,   -4
+.2byte    3,  -14, 	   7,   -6, 	   0,   -3, 	  -1,   -9
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    7,   -5, 	   7,   -2, 	   4,   -1, 	   0,   -5
+.2byte    7,   -5, 	   2,   -2, 	   6,   -1, 	   1,   -5
+.2byte    7,  -13, 	   6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    4,  -10, 	   1,   -5, 	   6,   -3, 	   1,   -6
+.2byte    4,   -9, 	   4,   -7, 	   5,   -2, 	   1,   -5
+.2byte    4,   -9, 	  -1,   -5, 	   7,   -3, 	   1,   -5
+.2byte    5,  -15, 	  -1,  -10, 	   7,   -7, 	   1,   -6
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    1,   -7, 	   5,   -6, 	  -5,   -4, 	   0,   -4
+.2byte   -1,   -8, 	   5,   -3, 	  -5,   -6, 	   1,   -4
+.2byte    0,  -16, 	   5,   -9, 	  -5,   -9, 	   0,   -9
+.2byte   -4,  -10, 	  -1,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -4,   -9, 	  -4,   -7, 	  -5,   -2, 	  -1,   -5
+.2byte   -4,   -9, 	   1,   -5, 	  -7,   -3, 	  -1,   -5
+.2byte   -5,  -15, 	   1,  -10, 	  -7,   -7, 	  -1,   -6
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -2, 	  -4,   -1, 	   0,   -5
+.2byte   -7,   -5, 	  -2,   -2, 	  -6,   -1, 	  -1,   -5
+.2byte   -7,  -13, 	  -6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte   -3,   -5, 	  -5,   -1, 	   0,    0, 	   1,   -5
+.2byte   -3,   -4, 	  -7,    0, 	   1,    0, 	   1,   -5
+.2byte   -3,   -4, 	  -5,   -2, 	  -1,    1, 	   0,   -4
+.2byte   -3,  -14, 	  -7,   -6, 	   0,   -3, 	   1,   -9
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte   -3,   -5, 	  -5,   -1, 	   0,    0, 	   1,   -5
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -4,  -10, 	  -1,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    4,  -10, 	   1,   -5, 	   6,   -3, 	   1,   -6
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    3,   -5, 	   5,   -1, 	   0,    0, 	  -1,   -5
+.2byte    2,  -13, 	  -1,   -4, 	   5,   -4, 	   1,  -10
+.2byte    1,  -13, 	   5,   -5, 	   2,   -4, 	   0,   -8
+.2byte    1,  -16, 	   7,   -9, 	   6,   -7, 	  -1,   -8
+.2byte    1,  -15, 	   5,   -9, 	   6,   -7, 	  -2,   -5
+.2byte   -2,  -16, 	   4,  -12, 	  -6,  -12, 	  -1,   -6
+.2byte   -2,  -15, 	  -6,   -9, 	  -7,   -7, 	   1,   -5
+.2byte   -2,  -16, 	  -8,   -9, 	  -7,   -7, 	   0,   -8
+.2byte   -2,  -13, 	  -6,   -5, 	  -3,   -4, 	  -1,   -8
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,  -11, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,   -3, 	  -4,   -1, 	   4,    2, 	   0,   -6
+.2byte    3,   -5, 	   5,   -1, 	   0,    0, 	  -1,   -5
+.2byte    3,  -13, 	   7,   -5, 	   0,   -2, 	  -1,   -8
+.2byte    3,   -4, 	   5,   -2, 	   1,    1, 	   0,   -4
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    7,  -13, 	   6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    7,   -5, 	   2,   -2, 	   6,   -1, 	   1,   -5
+.2byte    4,  -10, 	   1,   -5, 	   6,   -3, 	   1,   -6
+.2byte    5,  -15, 	  -1,  -10, 	   7,   -7, 	   1,   -6
+.2byte    4,   -9, 	  -1,   -5, 	   7,   -3, 	   1,   -5
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    0,  -16, 	   5,   -9, 	  -5,   -9, 	   0,   -9
+.2byte   -1,   -8, 	   5,   -3, 	  -5,   -6, 	   1,   -4
+.2byte   -4,  -10, 	  -1,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -5,  -15, 	   1,  -10, 	  -7,   -7, 	  -1,   -6
+.2byte   -4,   -9, 	   1,   -5, 	  -7,   -3, 	  -1,   -5
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -8,  -13, 	  -7,   -8, 	  -7,   -5, 	  -1,   -8
+.2byte   -7,   -5, 	  -2,   -2, 	  -6,   -1, 	  -1,   -5
+.2byte   -3,   -5, 	  -5,   -1, 	   0,    0, 	   1,   -5
+.2byte   -3,  -14, 	  -7,   -6, 	   0,   -3, 	   1,   -9
+.2byte   -3,   -4, 	  -5,   -2, 	  -1,    1, 	   0,   -4
+.2byte    0,  -11, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte   -3,  -12, 	  -7,   -4, 	   0,   -1, 	   1,   -7
+.2byte   -7,  -12, 	  -6,   -7, 	  -6,   -4, 	   0,   -7
+.2byte   -5,  -15, 	   1,  -10, 	  -7,   -7, 	  -1,   -6
+.2byte    0,  -16, 	   5,   -9, 	  -5,   -9, 	   0,   -9
+.2byte    5,  -15, 	  -1,  -10, 	   7,   -7, 	   1,   -6
+.2byte    6,  -12, 	   5,   -7, 	   5,   -4, 	  -1,   -7
+.2byte    3,  -11, 	   7,   -3, 	   0,    0, 	  -1,   -6
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte   -3,   -5, 	  -5,   -1, 	   0,    0, 	   1,   -5
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -4,  -10, 	  -1,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    4,  -10, 	   1,   -5, 	   6,   -3, 	   1,   -6
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    3,   -5, 	   5,   -1, 	   0,    0, 	  -1,   -5
+.2byte    7,   -4, 	   6,   -3, 	   5,   -1, 	   1,   -5
+.2byte    6,   -6, 	   6,   -4, 	   6,   -2, 	   0,   -6
+.2byte   -8,   -4, 	  -7,   -3, 	  -6,   -1, 	  -2,   -5
+.2byte   -7,   -6, 	  -7,   -4, 	  -7,   -2, 	  -1,   -6
+.2byte    7,   -4, 	   6,   -3, 	   5,   -1, 	   1,   -5
+.2byte    6,   -5, 	   5,   -3, 	   5,   -1, 	  -1,   -5
+.2byte    4,   -6, 	   4,   -3, 	   4,   -1, 	  -3,   -5
+.2byte    5,   -4, 	   4,   -3, 	   5,   -1, 	  -1,   -4
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    0,   -8, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -5, 	   5,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -5
+.2byte    0,   -8, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -3, 	  -4,    0, 	   4,    0, 	   0,   -5
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -5, 	  -7,   -6, 	   4,    0, 	   0,   -7
+.2byte    0,   -7, 	   5,   -4, 	  -5,   -4, 	   0,   -5
+.2byte    1,  -12, 	   7,   -9, 	  -5,   -4, 	   0,   -6
+.2byte    1,  -12, 	   7,   -9, 	  -5,   -4, 	   0,   -6
+.2byte    0,   -9, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte    0,   -8, 	  -6,   -7, 	   6,   -7, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -7, 	   6,   -7, 	   0,   -6
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -7,   -6, 	  -6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte   -7,   -9, 	  -6,   -2, 	  -4,   -8, 	  -2,   -7
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    0,   -7, 	   6,   -6, 	  -6,   -6, 	   0,   -4
+.2byte    0,   -4, 	   7,   -5, 	  -7,   -5, 	   0,   -3
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -8, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -2, 	  -4,    0, 	   4,    0, 	   0,   -5
+.2byte   -7,   -6, 	  -6,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -7,   -4, 	  -6,   -3, 	  -5,   -1, 	  -2,   -6
+.2byte    7,   -6, 	   6,   -3, 	   5,   -1, 	   1,   -6
+.2byte    7,   -4, 	   6,   -3, 	   5,   -1, 	   2,   -6
+.2byte    0,   -8, 	   5,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    0,   -8, 	   7,   -8, 	  -7,   -8, 	   0,   -5
+.2byte   -7,   -3, 	  -6,   -2, 	  -5,    0, 	  -2,   -5
+.2byte   -6,   -5, 	  -9,   -4, 	  -2,   -1, 	  -2,   -7
+.2byte   -6,   -4, 	  -9,   -1, 	  -1,    0, 	  -2,   -6
+.2byte   -9,   -6, 	  -1,   -4, 	  -7,   -5, 	  -2,   -7
+.2byte   -9,   -5, 	   0,   -3, 	  -7,   -1, 	  -2,   -6
+.2byte    6,   -3, 	   5,   -2, 	   4,    0, 	   1,   -5
+.2byte    5,   -5, 	   8,   -4, 	   1,   -1, 	   1,   -7
+.2byte    5,   -4, 	   8,   -1, 	   0,    0, 	   1,   -6
+.2byte    8,   -6, 	   0,   -4, 	   6,   -5, 	   1,   -7
+.2byte    8,   -5, 	  -1,   -3, 	   6,   -1, 	   1,   -6
+.2byte    1,   -8, 	  -1,  -10, 	   6,   -6, 	  -2,   -5
+.2byte    7,   -4, 	   6,   -3, 	   5,   -1, 	   1,   -5
+.2byte    6,   -6, 	   6,   -4, 	   6,   -2, 	   0,   -6
+.2byte   -8,   -4, 	  -7,   -3, 	  -6,   -1, 	  -2,   -5
+.2byte   -7,   -6, 	  -7,   -4, 	  -7,   -2, 	  -1,   -6
+.2byte    7,   -4, 	   6,   -3, 	   5,   -1, 	   1,   -5
+.2byte    6,   -6, 	   6,   -4, 	   6,   -2, 	   0,   -6
+.2byte   -8,   -4, 	  -7,   -3, 	  -6,   -1, 	  -2,   -5
+.2byte   -7,   -6, 	  -7,   -4, 	  -7,   -2, 	  -1,   -6
+sChikoritaAnimTable1:
+.4byte sChikoritaAnims_1_1
+.4byte sChikoritaAnims_1_2
+.4byte sChikoritaAnims_1_3
+.4byte sChikoritaAnims_1_4
+.4byte sChikoritaAnims_1_5
+.4byte sChikoritaAnims_1_6
+.4byte sChikoritaAnims_1_7
+.4byte sChikoritaAnims_1_8
+sChikoritaAnimTable2:
+.4byte sChikoritaAnims_2_1
+.4byte sChikoritaAnims_2_2
+.4byte sChikoritaAnims_2_3
+.4byte sChikoritaAnims_2_4
+.4byte sChikoritaAnims_2_5
+.4byte sChikoritaAnims_2_6
+.4byte sChikoritaAnims_2_7
+.4byte sChikoritaAnims_2_8
+sChikoritaAnimTable3:
+.4byte sChikoritaAnims_3_1
+.4byte sChikoritaAnims_3_2
+.4byte sChikoritaAnims_3_3
+.4byte sChikoritaAnims_3_4
+.4byte sChikoritaAnims_3_5
+.4byte sChikoritaAnims_3_6
+.4byte sChikoritaAnims_3_7
+.4byte sChikoritaAnims_3_8
+sChikoritaAnimTable4:
+.4byte sChikoritaAnims_4_1
+.4byte sChikoritaAnims_4_2
+.4byte sChikoritaAnims_4_3
+.4byte sChikoritaAnims_4_4
+.4byte sChikoritaAnims_4_5
+.4byte sChikoritaAnims_4_6
+.4byte sChikoritaAnims_4_7
+.4byte sChikoritaAnims_4_8
+sChikoritaAnimTable5:
+.4byte sChikoritaAnims_5_1
+.4byte sChikoritaAnims_5_2
+.4byte sChikoritaAnims_5_3
+.4byte sChikoritaAnims_5_4
+.4byte sChikoritaAnims_5_5
+.4byte sChikoritaAnims_5_6
+.4byte sChikoritaAnims_5_7
+.4byte sChikoritaAnims_5_8
+sChikoritaAnimTable6:
+.4byte sChikoritaAnims_6_1
+.4byte sChikoritaAnims_6_1
+.4byte sChikoritaAnims_6_1
+.4byte sChikoritaAnims_6_1
+.4byte sChikoritaAnims_6_1
+.4byte sChikoritaAnims_6_1
+.4byte sChikoritaAnims_6_1
+.4byte sChikoritaAnims_6_1
+sChikoritaAnimTable7:
+.4byte sChikoritaAnims_7_1
+.4byte sChikoritaAnims_7_2
+.4byte sChikoritaAnims_7_3
+.4byte sChikoritaAnims_7_4
+.4byte sChikoritaAnims_7_5
+.4byte sChikoritaAnims_7_6
+.4byte sChikoritaAnims_7_7
+.4byte sChikoritaAnims_7_8
+sChikoritaAnimTable8:
+.4byte sChikoritaAnims_8_1
+.4byte sChikoritaAnims_8_2
+.4byte sChikoritaAnims_8_3
+.4byte sChikoritaAnims_8_4
+.4byte sChikoritaAnims_8_5
+.4byte sChikoritaAnims_8_6
+.4byte sChikoritaAnims_8_7
+.4byte sChikoritaAnims_8_8
+sChikoritaAnimTable9:
+.4byte sChikoritaAnims_9_1
+.4byte sChikoritaAnims_9_2
+.4byte sChikoritaAnims_9_3
+.4byte sChikoritaAnims_9_4
+.4byte sChikoritaAnims_9_5
+.4byte sChikoritaAnims_9_6
+.4byte sChikoritaAnims_9_7
+.4byte sChikoritaAnims_9_8
+sChikoritaAnimTable10:
+.4byte sChikoritaAnims_10_1
+.4byte sChikoritaAnims_10_2
+.4byte sChikoritaAnims_10_3
+.4byte sChikoritaAnims_10_4
+.4byte sChikoritaAnims_10_5
+.4byte sChikoritaAnims_10_6
+.4byte sChikoritaAnims_10_7
+.4byte sChikoritaAnims_10_8
+sChikoritaAnimTable11:
+.4byte sChikoritaAnims_11_1
+.4byte sChikoritaAnims_11_2
+.4byte sChikoritaAnims_11_3
+.4byte sChikoritaAnims_11_4
+.4byte sChikoritaAnims_11_5
+.4byte sChikoritaAnims_11_6
+.4byte sChikoritaAnims_11_7
+.4byte sChikoritaAnims_11_8
+sChikoritaAnimTable12:
+.4byte sChikoritaAnims_12_1
+.4byte sChikoritaAnims_12_2
+.4byte sChikoritaAnims_12_3
+.4byte sChikoritaAnims_12_4
+.4byte sChikoritaAnims_12_5
+.4byte sChikoritaAnims_12_6
+.4byte sChikoritaAnims_12_7
+.4byte sChikoritaAnims_12_8
+sChikoritaAnimTable13:
+.4byte sChikoritaAnims_13_1
+.4byte sChikoritaAnims_13_2
+.4byte sChikoritaAnims_13_3
+.4byte sChikoritaAnims_13_4
+.4byte sChikoritaAnims_13_5
+.4byte sChikoritaAnims_13_6
+.4byte sChikoritaAnims_13_7
+.4byte sChikoritaAnims_13_8
+sChikoritaAnimTable14:
+.4byte sChikoritaAnims_14_1
+.4byte sChikoritaAnims_14_2
+.4byte sChikoritaAnims_14_3
+.4byte sChikoritaAnims_14_4
+.4byte sChikoritaAnims_14_5
+.4byte sChikoritaAnims_14_6
+.4byte sChikoritaAnims_14_7
+.4byte sChikoritaAnims_14_8
+sChikoritaAnimTable15:
+.4byte sChikoritaAnims_15_1
+.4byte sChikoritaAnims_15_2
+.4byte sChikoritaAnims_15_3
+.4byte sChikoritaAnims_15_4
+.4byte sChikoritaAnims_15_5
+.4byte sChikoritaAnims_15_6
+.4byte sChikoritaAnims_15_7
+.4byte sChikoritaAnims_15_8
+sChikoritaAnimTable16:
+.4byte sChikoritaAnims_16_1
+.4byte sChikoritaAnims_16_2
+.4byte sChikoritaAnims_16_3
+.4byte sChikoritaAnims_16_4
+.4byte sChikoritaAnims_16_5
+.4byte sChikoritaAnims_16_6
+.4byte sChikoritaAnims_16_7
+.4byte sChikoritaAnims_16_8
+sChikoritaAnimTable17:
+.4byte sChikoritaAnims_17_1
+.4byte sChikoritaAnims_17_2
+.4byte sChikoritaAnims_17_3
+.4byte sChikoritaAnims_17_4
+.4byte sChikoritaAnims_17_5
+.4byte sChikoritaAnims_17_6
+.4byte sChikoritaAnims_17_7
+.4byte sChikoritaAnims_17_8
+sChikoritaAnimTable18:
+.4byte sChikoritaAnims_18_1
+.4byte sChikoritaAnims_18_2
+.4byte sChikoritaAnims_18_3
+.4byte sChikoritaAnims_18_4
+.4byte sChikoritaAnims_18_5
+.4byte sChikoritaAnims_18_6
+.4byte sChikoritaAnims_18_7
+.4byte sChikoritaAnims_18_8
+sChikoritaAnimTable19:
+.4byte sChikoritaAnims_19_1
+.4byte sChikoritaAnims_19_2
+.4byte sChikoritaAnims_19_3
+.4byte sChikoritaAnims_19_4
+.4byte sChikoritaAnims_19_5
+.4byte sChikoritaAnims_19_6
+.4byte sChikoritaAnims_19_7
+.4byte sChikoritaAnims_19_8
+sChikoritaAnimTable20:
+.4byte sChikoritaAnims_20_1
+.4byte sChikoritaAnims_20_2
+.4byte sChikoritaAnims_20_3
+.4byte sChikoritaAnims_20_4
+.4byte sChikoritaAnims_20_5
+.4byte sChikoritaAnims_20_6
+.4byte sChikoritaAnims_20_7
+.4byte sChikoritaAnims_20_8
+sChikoritaAnimTable21:
+.4byte sChikoritaAnims_21_1
+.4byte sChikoritaAnims_21_2
+.4byte sChikoritaAnims_21_3
+.4byte sChikoritaAnims_21_4
+.4byte sChikoritaAnims_21_5
+.4byte sChikoritaAnims_21_6
+.4byte sChikoritaAnims_21_7
+.4byte sChikoritaAnims_21_8
+sChikoritaAnimTable22:
+.4byte sChikoritaAnims_22_1
+.4byte sChikoritaAnims_22_2
+.4byte sChikoritaAnims_22_3
+.4byte sChikoritaAnims_22_4
+.4byte sChikoritaAnims_22_5
+.4byte sChikoritaAnims_22_6
+.4byte sChikoritaAnims_22_7
+.4byte sChikoritaAnims_22_8
+sChikoritaAnimTable23:
+.4byte sChikoritaAnims_23_1
+.4byte sChikoritaAnims_23_2
+.4byte sChikoritaAnims_23_3
+.4byte sChikoritaAnims_23_4
+.4byte sChikoritaAnims_23_5
+.4byte sChikoritaAnims_23_6
+.4byte sChikoritaAnims_23_7
+.4byte sChikoritaAnims_23_8
+sChikoritaAnimTable24:
+.4byte sChikoritaAnims_24_1
+.4byte sChikoritaAnims_24_2
+.4byte sChikoritaAnims_24_3
+.4byte sChikoritaAnims_24_4
+.4byte sChikoritaAnims_24_5
+.4byte sChikoritaAnims_24_6
+.4byte sChikoritaAnims_24_7
+.4byte sChikoritaAnims_24_8
+sChikoritaAnimTable25:
+.4byte sChikoritaAnims_25_1
+.4byte sChikoritaAnims_25_2
+.4byte sChikoritaAnims_25_3
+.4byte sChikoritaAnims_25_4
+.4byte sChikoritaAnims_25_5
+.4byte sChikoritaAnims_25_6
+.4byte sChikoritaAnims_25_7
+.4byte sChikoritaAnims_25_8
+sChikoritaAnimTable26:
+.4byte sChikoritaAnims_26_1
+.4byte sChikoritaAnims_26_2
+.4byte sChikoritaAnims_26_3
+.4byte sChikoritaAnims_26_4
+.4byte sChikoritaAnims_26_5
+.4byte sChikoritaAnims_26_6
+.4byte sChikoritaAnims_26_7
+.4byte sChikoritaAnims_26_8
+sChikoritaAnimTable27:
+.4byte sChikoritaAnims_27_1
+.4byte sChikoritaAnims_27_1
+.4byte sChikoritaAnims_27_1
+.4byte sChikoritaAnims_27_1
+.4byte sChikoritaAnims_27_1
+.4byte sChikoritaAnims_27_1
+.4byte sChikoritaAnims_27_1
+.4byte sChikoritaAnims_27_1
+sChikoritaAnimTable28:
+.4byte sChikoritaAnims_28_1
+.4byte sChikoritaAnims_28_2
+.4byte sChikoritaAnims_28_3
+.4byte sChikoritaAnims_28_4
+.4byte sChikoritaAnims_28_5
+.4byte sChikoritaAnims_28_6
+.4byte sChikoritaAnims_28_7
+.4byte sChikoritaAnims_28_8
+sAxAnimationsChikorita:
+.4byte sChikoritaAnimTable1
+.4byte sChikoritaAnimTable2
+.4byte sChikoritaAnimTable3
+.4byte sChikoritaAnimTable4
+.4byte sChikoritaAnimTable5
+.4byte sChikoritaAnimTable6
+.4byte sChikoritaAnimTable7
+.4byte sChikoritaAnimTable8
+.4byte sChikoritaAnimTable9
+.4byte sChikoritaAnimTable10
+.4byte sChikoritaAnimTable11
+.4byte sChikoritaAnimTable12
+.4byte sChikoritaAnimTable13
+.4byte sChikoritaAnimTable14
+.4byte sChikoritaAnimTable15
+.4byte sChikoritaAnimTable16
+.4byte sChikoritaAnimTable17
+.4byte sChikoritaAnimTable18
+.4byte sChikoritaAnimTable19
+.4byte sChikoritaAnimTable20
+.4byte sChikoritaAnimTable21
+.4byte sChikoritaAnimTable22
+.4byte sChikoritaAnimTable23
+.4byte sChikoritaAnimTable24
+.4byte sChikoritaAnimTable25
+.4byte sChikoritaAnimTable26
+.4byte sChikoritaAnimTable27
+.4byte sChikoritaAnimTable28
+sAxSpritesChikorita:
+.4byte sChikoritaSprites1
+.4byte sChikoritaSprites2
+.4byte sChikoritaSprites3
+.4byte sChikoritaSprites4
+.4byte sChikoritaSprites5
+.4byte sChikoritaSprites6
+.4byte sChikoritaSprites7
+.4byte sChikoritaSprites8
+.4byte sChikoritaSprites9
+.4byte sChikoritaSprites10
+.4byte sChikoritaSprites11
+.4byte sChikoritaSprites12
+.4byte sChikoritaSprites13
+.4byte sChikoritaSprites14
+.4byte sChikoritaSprites15
+.4byte sChikoritaSprites16
+.4byte sChikoritaSprites17
+.4byte sChikoritaSprites18
+.4byte sChikoritaSprites19
+.4byte sChikoritaSprites20
+.4byte sChikoritaSprites21
+.4byte sChikoritaSprites22
+.4byte sChikoritaSprites23
+.4byte sChikoritaSprites24
+.4byte sChikoritaSprites25
+.4byte sChikoritaSprites26
+.4byte sChikoritaSprites27
+.4byte sChikoritaSprites28
+.4byte sChikoritaSprites29
+.4byte sChikoritaSprites30
+.4byte sChikoritaSprites31
+.4byte sChikoritaSprites32
+.4byte sChikoritaSprites33
+.4byte sChikoritaSprites34
+.4byte sChikoritaSprites35
+.4byte sChikoritaSprites36
+.4byte sChikoritaSprites37
+.4byte sChikoritaSprites38
+.4byte sChikoritaSprites39
+.4byte sChikoritaSprites40
+.4byte sChikoritaSprites41
+.4byte sChikoritaSprites42
+.4byte sChikoritaSprites43
+.4byte sChikoritaSprites44
+.4byte sChikoritaSprites45
+.4byte sChikoritaSprites46
+.4byte sChikoritaSprites47
+.4byte sChikoritaSprites48
+.4byte sChikoritaSprites49
+.4byte sChikoritaSprites50
+.4byte sChikoritaSprites51
+.4byte sChikoritaSprites52
+.4byte sChikoritaSprites53
+.4byte sChikoritaSprites54
+.4byte sChikoritaSprites55
+.4byte sChikoritaSprites56
+.4byte sChikoritaSprites57
+.4byte sChikoritaSprites58
+.4byte sChikoritaSprites59
+.4byte sChikoritaSprites60
+.4byte sChikoritaSprites61
+.4byte sChikoritaSprites62
+.4byte sChikoritaSprites63
+.4byte sChikoritaSprites64
+.4byte sChikoritaSprites65
+.4byte sChikoritaSprites66
+.4byte sChikoritaSprites67
+.4byte sChikoritaSprites68
+.4byte sChikoritaSprites69
+.4byte sChikoritaSprites70
+.4byte sChikoritaSprites71
+.4byte sChikoritaSprites72
+.4byte sChikoritaSprites73
+.4byte sChikoritaSprites74
+.4byte sChikoritaSprites75
+sAxMainChikorita:
+ax_main sAxPosesChikorita, sAxAnimationsChikorita, 28, sAxSpritesChikorita, sAxPositionsChikorita

--- a/data/ax/chimecho.inc
+++ b/data/ax/chimecho.inc
@@ -1,0 +1,2983 @@
+.global gAxChimecho
+gAxChimecho:
+ax_siro sAxMainChimecho
+sChimechoPose1:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose2:
+ax_pose 1, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose3:
+ax_pose 2, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose4:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose5:
+ax_pose 4, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose6:
+ax_pose 5, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose7:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose8:
+ax_pose 7, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose9:
+ax_pose 8, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose10:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose11:
+ax_pose 10, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose12:
+ax_pose 11, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose13:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose14:
+ax_pose 13, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose15:
+ax_pose 14, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose16:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose17:
+ax_pose 10, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose18:
+ax_pose 11, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose19:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose20:
+ax_pose 7, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose21:
+ax_pose 8, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose22:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose23:
+ax_pose 4, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose24:
+ax_pose 5, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose25:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose26:
+ax_pose 1, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose27:
+ax_pose 2, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose28:
+ax_pose 15, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose29:
+ax_pose 16, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose30:
+ax_pose 17, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose31:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose32:
+ax_pose 4, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose33:
+ax_pose 5, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose34:
+ax_pose 18, 0x81e6, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose35:
+ax_pose 19, 0x81e5, 0x90f8, 0x5c00
+ax_pose 20, 0x01f4, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose36:
+ax_pose 21, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose37:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose38:
+ax_pose 7, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose39:
+ax_pose 8, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose40:
+ax_pose 22, 0x81e5, 0x90f8, 0x5c00
+ax_pose 23, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose41:
+ax_pose 24, 0x81e3, 0x90f8, 0x5c00
+ax_pose 25, 0x01f3, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose42:
+ax_pose 26, 0x81e5, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose43:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose44:
+ax_pose 10, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose45:
+ax_pose 11, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose46:
+ax_pose 27, 0x81e5, 0x90f8, 0x5c00
+ax_pose 28, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose47:
+ax_pose 29, 0x81e5, 0x90f8, 0x5c00
+ax_pose 30, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose48:
+ax_pose 31, 0x81e5, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose49:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose50:
+ax_pose 13, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose51:
+ax_pose 14, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose52:
+ax_pose 32, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose53:
+ax_pose 33, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose54:
+ax_pose 34, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose55:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose56:
+ax_pose 10, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose57:
+ax_pose 11, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose58:
+ax_pose 27, 0x81e5, 0x80f8, 0x5c00
+ax_pose 28, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose59:
+ax_pose 29, 0x81e5, 0x80f8, 0x5c00
+ax_pose 30, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose60:
+ax_pose 31, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose61:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose62:
+ax_pose 7, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose63:
+ax_pose 8, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose64:
+ax_pose 22, 0x81e5, 0x80f8, 0x5c00
+ax_pose 23, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose65:
+ax_pose 24, 0x81e3, 0x80f8, 0x5c00
+ax_pose 25, 0x01f3, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose66:
+ax_pose 26, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose67:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose68:
+ax_pose 4, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose69:
+ax_pose 5, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose70:
+ax_pose 18, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose71:
+ax_pose 19, 0x81e5, 0x80f8, 0x5c00
+ax_pose 20, 0x01f4, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose72:
+ax_pose 21, 0x81e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sChimechoPose73:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose74:
+ax_pose 1, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose75:
+ax_pose 2, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose76:
+ax_pose 15, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose77:
+ax_pose 16, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose78:
+ax_pose 17, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose79:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose80:
+ax_pose 4, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose81:
+ax_pose 5, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose82:
+ax_pose 18, 0x81e6, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose83:
+ax_pose 19, 0x81e5, 0x90f8, 0x5c00
+ax_pose 20, 0x01f4, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose84:
+ax_pose 21, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose85:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose86:
+ax_pose 7, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose87:
+ax_pose 8, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose88:
+ax_pose 22, 0x81e5, 0x90f8, 0x5c00
+ax_pose 23, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose89:
+ax_pose 24, 0x81e3, 0x90f8, 0x5c00
+ax_pose 25, 0x01f3, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose90:
+ax_pose 26, 0x81e5, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose91:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose92:
+ax_pose 10, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose93:
+ax_pose 11, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose94:
+ax_pose 27, 0x81e5, 0x90f8, 0x5c00
+ax_pose 28, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose95:
+ax_pose 29, 0x81e5, 0x90f8, 0x5c00
+ax_pose 30, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose96:
+ax_pose 31, 0x81e5, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose97:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose98:
+ax_pose 13, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose99:
+ax_pose 14, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose100:
+ax_pose 32, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose101:
+ax_pose 33, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose102:
+ax_pose 34, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose103:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose104:
+ax_pose 10, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose105:
+ax_pose 11, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose106:
+ax_pose 27, 0x81e5, 0x80f8, 0x5c00
+ax_pose 28, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose107:
+ax_pose 29, 0x81e5, 0x80f8, 0x5c00
+ax_pose 30, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose108:
+ax_pose 31, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose109:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose110:
+ax_pose 7, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose111:
+ax_pose 8, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose112:
+ax_pose 22, 0x81e5, 0x80f8, 0x5c00
+ax_pose 23, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose113:
+ax_pose 24, 0x81e3, 0x80f8, 0x5c00
+ax_pose 25, 0x01f3, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose114:
+ax_pose 26, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose115:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose116:
+ax_pose 4, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose117:
+ax_pose 5, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose118:
+ax_pose 18, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose119:
+ax_pose 19, 0x81e5, 0x80f8, 0x5c00
+ax_pose 20, 0x01f4, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose120:
+ax_pose 21, 0x81e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sChimechoPose121:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose122:
+ax_pose 1, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose123:
+ax_pose 2, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose124:
+ax_pose 15, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose125:
+ax_pose 16, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose126:
+ax_pose 17, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose127:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose128:
+ax_pose 4, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose129:
+ax_pose 5, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose130:
+ax_pose 18, 0x81e6, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose131:
+ax_pose 19, 0x81e5, 0x90f8, 0x5c00
+ax_pose 20, 0x01f4, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose132:
+ax_pose 21, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose133:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose134:
+ax_pose 7, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose135:
+ax_pose 8, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose136:
+ax_pose 22, 0x81e5, 0x90f9, 0x5c00
+ax_pose 23, 0x01f5, 0x10f1, 0x5c08
+ax_pose_terminator
+sChimechoPose137:
+ax_pose 24, 0x81e3, 0x90f9, 0x5c00
+ax_pose 25, 0x01f3, 0x10f1, 0x5c08
+ax_pose_terminator
+sChimechoPose138:
+ax_pose 26, 0x81e5, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose139:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose140:
+ax_pose 10, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose141:
+ax_pose 11, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose142:
+ax_pose 27, 0x81e5, 0x90f8, 0x5c00
+ax_pose 28, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose143:
+ax_pose 29, 0x81e5, 0x90f8, 0x5c00
+ax_pose 30, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose144:
+ax_pose 31, 0x81e5, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose145:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose146:
+ax_pose 13, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose147:
+ax_pose 14, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose148:
+ax_pose 32, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose149:
+ax_pose 33, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose150:
+ax_pose 34, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose151:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose152:
+ax_pose 10, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose153:
+ax_pose 11, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose154:
+ax_pose 27, 0x81e5, 0x80f8, 0x5c00
+ax_pose 28, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose155:
+ax_pose 29, 0x81e5, 0x80f8, 0x5c00
+ax_pose 30, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose156:
+ax_pose 31, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose157:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose158:
+ax_pose 7, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose159:
+ax_pose 8, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose160:
+ax_pose 22, 0x81e5, 0x80f7, 0x5c00
+ax_pose 23, 0x01f5, 0x0107, 0x5c08
+ax_pose_terminator
+sChimechoPose161:
+ax_pose 24, 0x81e3, 0x80f7, 0x5c00
+ax_pose 25, 0x01f3, 0x0107, 0x5c08
+ax_pose_terminator
+sChimechoPose162:
+ax_pose 26, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose163:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose164:
+ax_pose 4, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose165:
+ax_pose 5, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose166:
+ax_pose 18, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose167:
+ax_pose 19, 0x81e5, 0x80f8, 0x5c00
+ax_pose 20, 0x01f4, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose168:
+ax_pose 21, 0x81e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sChimechoPose169:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose170:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose171:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose172:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose173:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose174:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose175:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose176:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose177:
+ax_pose 35, 0x81e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose178:
+ax_pose 36, 0x81e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose179:
+ax_pose 37, 0x01e5, 0x0108, 0x5c00
+ax_pose 38, 0x81e5, 0x80f8, 0x5c01
+ax_pose_terminator
+sChimechoPose180:
+ax_pose 39, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sChimechoPose181:
+ax_pose 40, 0x01e5, 0x90eb, 0x5c00
+ax_pose_terminator
+sChimechoPose182:
+ax_pose 41, 0x01e5, 0x90eb, 0x5c00
+ax_pose_terminator
+sChimechoPose183:
+ax_pose 42, 0x01e4, 0x010a, 0x5c00
+ax_pose 43, 0x81e4, 0x80fa, 0x5c01
+ax_pose_terminator
+sChimechoPose184:
+ax_pose 41, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sChimechoPose185:
+ax_pose 40, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sChimechoPose186:
+ax_pose 39, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sChimechoPose187:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose188:
+ax_pose 15, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose189:
+ax_pose 17, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose190:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose191:
+ax_pose 18, 0x81e6, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose192:
+ax_pose 21, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose193:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose194:
+ax_pose 22, 0x81e5, 0x90f8, 0x5c00
+ax_pose 23, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose195:
+ax_pose 26, 0x81e6, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose196:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose197:
+ax_pose 27, 0x81e5, 0x90f8, 0x5c00
+ax_pose 28, 0x01f5, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose198:
+ax_pose 31, 0x81e6, 0x90f8, 0x5c00
+ax_pose_terminator
+sChimechoPose199:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose200:
+ax_pose 32, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose201:
+ax_pose 34, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose202:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose203:
+ax_pose 27, 0x81e5, 0x80f8, 0x5c00
+ax_pose 28, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose204:
+ax_pose 31, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose205:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose206:
+ax_pose 22, 0x81e5, 0x80f8, 0x5c00
+ax_pose 23, 0x01f5, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose207:
+ax_pose 26, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose208:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose209:
+ax_pose 18, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose210:
+ax_pose 21, 0x81e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sChimechoPose211:
+ax_pose 16, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose212:
+ax_pose 19, 0x81e5, 0x80f9, 0x5c00
+ax_pose 20, 0x01f4, 0x0109, 0x5c08
+ax_pose_terminator
+sChimechoPose213:
+ax_pose 24, 0x81e3, 0x80f9, 0x5c00
+ax_pose 25, 0x01f3, 0x0109, 0x5c08
+ax_pose_terminator
+sChimechoPose214:
+ax_pose 29, 0x81e5, 0x80f9, 0x5c00
+ax_pose 30, 0x01f5, 0x0109, 0x5c08
+ax_pose_terminator
+sChimechoPose215:
+ax_pose 32, 0x81e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose216:
+ax_pose 29, 0x81e5, 0x90f7, 0x5c00
+ax_pose 30, 0x01f5, 0x10ef, 0x5c08
+ax_pose_terminator
+sChimechoPose217:
+ax_pose 24, 0x81e3, 0x90f7, 0x5c00
+ax_pose 25, 0x01f3, 0x10ef, 0x5c08
+ax_pose_terminator
+sChimechoPose218:
+ax_pose 19, 0x81e5, 0x90f7, 0x5c00
+ax_pose 20, 0x01f4, 0x10ef, 0x5c08
+ax_pose_terminator
+sChimechoPose219:
+ax_pose 16, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose220:
+ax_pose 19, 0x81e5, 0x90f7, 0x5c00
+ax_pose 20, 0x01f4, 0x10ef, 0x5c08
+ax_pose_terminator
+sChimechoPose221:
+ax_pose 24, 0x81e3, 0x90f7, 0x5c00
+ax_pose 25, 0x01f3, 0x10ef, 0x5c08
+ax_pose_terminator
+sChimechoPose222:
+ax_pose 29, 0x81e5, 0x90f7, 0x5c00
+ax_pose 30, 0x01f5, 0x10ef, 0x5c08
+ax_pose_terminator
+sChimechoPose223:
+ax_pose 32, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose224:
+ax_pose 29, 0x81e5, 0x80f9, 0x5c00
+ax_pose 30, 0x01f5, 0x0109, 0x5c08
+ax_pose_terminator
+sChimechoPose225:
+ax_pose 24, 0x81e3, 0x80f9, 0x5c00
+ax_pose 25, 0x01f3, 0x0109, 0x5c08
+ax_pose_terminator
+sChimechoPose226:
+ax_pose 19, 0x81e5, 0x80f9, 0x5c00
+ax_pose 20, 0x01f4, 0x0109, 0x5c08
+ax_pose_terminator
+sChimechoPose227:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose228:
+ax_pose 16, 0x81e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose229:
+ax_pose 17, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose230:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose231:
+ax_pose 19, 0x81e4, 0x90f8, 0x5c00
+ax_pose 20, 0x01f3, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose232:
+ax_pose 21, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose233:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose234:
+ax_pose 24, 0x81e3, 0x90f8, 0x5c00
+ax_pose 25, 0x01f3, 0x10f0, 0x5c08
+ax_pose_terminator
+sChimechoPose235:
+ax_pose 26, 0x81e5, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose236:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose237:
+ax_pose 29, 0x81e5, 0x90f7, 0x5c00
+ax_pose 30, 0x01f5, 0x10ef, 0x5c08
+ax_pose_terminator
+sChimechoPose238:
+ax_pose 31, 0x81e5, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose239:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose240:
+ax_pose 32, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose241:
+ax_pose 34, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose242:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose243:
+ax_pose 29, 0x81e5, 0x80f9, 0x5c00
+ax_pose 30, 0x01f5, 0x0109, 0x5c08
+ax_pose_terminator
+sChimechoPose244:
+ax_pose 31, 0x81e5, 0x80f7, 0x5c00
+ax_pose_terminator
+sChimechoPose245:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose246:
+ax_pose 24, 0x81e3, 0x80f8, 0x5c00
+ax_pose 25, 0x01f3, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose247:
+ax_pose 26, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose248:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose249:
+ax_pose 19, 0x81e4, 0x80f8, 0x5c00
+ax_pose 20, 0x01f3, 0x0108, 0x5c08
+ax_pose_terminator
+sChimechoPose250:
+ax_pose 21, 0x81e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sChimechoPose251:
+ax_pose 17, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose252:
+ax_pose 21, 0x81e5, 0x80f6, 0x5c00
+ax_pose_terminator
+sChimechoPose253:
+ax_pose 26, 0x81e5, 0x80f6, 0x5c00
+ax_pose_terminator
+sChimechoPose254:
+ax_pose 31, 0x81e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sChimechoPose255:
+ax_pose 34, 0x81e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose256:
+ax_pose 31, 0x81e4, 0x90f9, 0x5c00
+ax_pose_terminator
+sChimechoPose257:
+ax_pose 26, 0x81e5, 0x90fa, 0x5c00
+ax_pose_terminator
+sChimechoPose258:
+ax_pose 21, 0x81e5, 0x90fa, 0x5c00
+ax_pose_terminator
+sChimechoPose259:
+ax_pose 0, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose260:
+ax_pose 3, 0x81e6, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose261:
+ax_pose 6, 0x81e5, 0x80fb, 0x5c00
+ax_pose_terminator
+sChimechoPose262:
+ax_pose 9, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sChimechoPose263:
+ax_pose 12, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sChimechoPose264:
+ax_pose 9, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sChimechoPose265:
+ax_pose 6, 0x81e5, 0x90f5, 0x5c00
+ax_pose_terminator
+sChimechoPose266:
+ax_pose 3, 0x81e6, 0x90f6, 0x5c00
+ax_pose_terminator
+.align 2
+sChimechoAnims_1_1:
+ax_anim 4, 0, 0, 1, 0, 1, 0,
+ax_anim 4, 0, 1, 2, 0, 2, 0,
+ax_anim 6, 0, 2, 3, -1, 3, 0,
+ax_anim 6, 0, 1, 3, -1, 3, 0,
+ax_anim 4, 0, 0, 2, 0, 2, 0,
+ax_anim 4, 0, 1, 1, 0, 1, 0,
+ax_anim 4, 0, 2, -1, 0, -1, 0,
+ax_anim 4, 0, 1, -2, 0, -2, 0,
+ax_anim 6, 0, 0, -3, -1, -3, 0,
+ax_anim 6, 0, 1, -3, -1, -3, 0,
+ax_anim 4, 0, 2, -2, 0, -2, 0,
+ax_anim 4, 0, 1, -1, 0, -1, 0,
+ax_anim_terminator
+sChimechoAnims_1_2:
+ax_anim 4, 0, 3, -1, 1, -1, 1,
+ax_anim 4, 0, 4, -2, 1, -2, 2,
+ax_anim 6, 0, 5, -3, 0, -3, 3,
+ax_anim 6, 0, 4, -3, 0, -3, 3,
+ax_anim 4, 0, 3, -2, 1, -2, 2,
+ax_anim 4, 0, 4, -1, 1, -1, 1,
+ax_anim 4, 0, 5, 1, 0, 1, 0,
+ax_anim 4, 0, 4, 2, -1, 2, -2,
+ax_anim 6, 0, 3, 3, -2, 3, -3,
+ax_anim 6, 0, 4, 3, -2, 3, -3,
+ax_anim 4, 0, 5, 2, -1, 2, -2,
+ax_anim 4, 0, 4, 1, 0, 1, -1,
+ax_anim_terminator
+sChimechoAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, -1, -1, 0, 2,
+ax_anim 6, 0, 8, -1, -2, -1, 4,
+ax_anim 6, 0, 7, -1, -2, -1, 4,
+ax_anim 4, 0, 6, -1, -1, 0, 2,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 1, -1, 1, -1,
+ax_anim 4, 0, 7, 1, -3, 1, -3,
+ax_anim 6, 0, 6, 1, -4, 1, -4,
+ax_anim 6, 0, 7, 1, -4, 1, -4,
+ax_anim 4, 0, 8, 1, -3, 1, -3,
+ax_anim 4, 0, 7, 1, -1, 1, -1,
+ax_anim_terminator
+sChimechoAnims_1_4:
+ax_anim 4, 0, 9, 1, 1, 1, 1,
+ax_anim 4, 0, 10, 2, 1, 2, 2,
+ax_anim 6, 0, 11, 3, 0, 3, 3,
+ax_anim 6, 0, 10, 3, 0, 3, 3,
+ax_anim 4, 0, 9, 2, 1, 2, 2,
+ax_anim 4, 0, 10, 1, 1, 1, 1,
+ax_anim 4, 0, 11, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, -1, -2, -1,
+ax_anim 6, 0, 9, -3, -2, -3, -2,
+ax_anim 6, 0, 10, -3, -2, -3, -2,
+ax_anim 4, 0, 11, -2, -1, -2, -1,
+ax_anim 4, 0, 10, -1, 0, -1, 0,
+ax_anim_terminator
+sChimechoAnims_1_5:
+ax_anim 4, 0, 12, 1, 0, 1, 0,
+ax_anim 4, 0, 13, 2, 0, 2, 0,
+ax_anim 6, 0, 14, 3, -1, 3, 0,
+ax_anim 6, 0, 13, 3, -1, 3, 0,
+ax_anim 4, 0, 12, 2, 0, 2, 0,
+ax_anim 4, 0, 13, 1, 0, 1, 0,
+ax_anim 4, 0, 14, -1, 0, -1, 0,
+ax_anim 4, 0, 13, -2, 0, -2, 0,
+ax_anim 6, 0, 12, -3, -1, -3, 0,
+ax_anim 6, 0, 13, -3, -1, -3, 0,
+ax_anim 4, 0, 14, -2, 0, -2, 0,
+ax_anim 4, 0, 13, -1, 0, -1, 0,
+ax_anim_terminator
+sChimechoAnims_1_6:
+ax_anim 4, 0, 15, -1, 1, -1, 1,
+ax_anim 4, 0, 16, -2, 1, -2, 2,
+ax_anim 6, 0, 17, -3, 0, -3, 3,
+ax_anim 6, 0, 16, -3, 0, -3, 3,
+ax_anim 4, 0, 15, -2, 1, -2, 2,
+ax_anim 4, 0, 16, -1, 1, -1, 1,
+ax_anim 4, 0, 17, 1, 0, 1, 0,
+ax_anim 4, 0, 16, 2, -1, 2, -1,
+ax_anim 6, 0, 15, 3, -2, 3, -2,
+ax_anim 6, 0, 16, 3, -2, 3, -2,
+ax_anim 4, 0, 17, 2, -1, 2, -1,
+ax_anim 4, 0, 16, 1, 0, 1, 0,
+ax_anim_terminator
+sChimechoAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 1, -1, 0, 2,
+ax_anim 6, 0, 20, 1, -2, 1, 4,
+ax_anim 6, 0, 19, 1, -2, 1, 4,
+ax_anim 4, 0, 18, 1, -1, 0, 2,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 20, -1, -1, -1, -1,
+ax_anim 4, 0, 19, -1, -3, -1, -3,
+ax_anim 6, 0, 18, -1, -4, -1, -4,
+ax_anim 6, 0, 19, -1, -4, -1, -4,
+ax_anim 4, 0, 20, -1, -3, -1, -3,
+ax_anim 4, 0, 19, -1, -1, -1, -1,
+ax_anim_terminator
+sChimechoAnims_1_8:
+ax_anim 4, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 22, 2, 1, 2, 2,
+ax_anim 6, 0, 23, 3, 0, 3, 3,
+ax_anim 6, 0, 22, 3, 0, 3, 3,
+ax_anim 4, 0, 21, 2, 1, 2, 2,
+ax_anim 4, 0, 22, 1, 1, 1, 1,
+ax_anim 4, 0, 23, -1, 0, -1, 0,
+ax_anim 4, 0, 22, -2, -1, -2, -2,
+ax_anim 6, 0, 21, -3, -2, -3, -3,
+ax_anim 6, 0, 22, -3, -2, -3, -3,
+ax_anim 4, 0, 23, -2, -1, -2, -2,
+ax_anim 4, 0, 22, -1, 0, -1, -1,
+ax_anim_terminator
+.align 2
+sChimechoAnims_2_1:
+ax_anim 2, 0, 29, 0, -1, 0, -1,
+ax_anim 4, 0, 29, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 6, 0, 5,
+ax_anim 1, 0, 27, 0, 15, 0, 14,
+ax_anim 2, 0, 28, 0, 26, 0, 22,
+ax_anim 2, 1, 27, 0, 27, 0, 23,
+ax_anim 2, 0, 28, 0, 26, 0, 22,
+ax_anim 2, 0, 27, 0, 27, 0, 23,
+ax_anim 2, 0, 24, 0, 8, 0, 6,
+ax_anim_terminator
+sChimechoAnims_2_2:
+ax_anim 2, 0, 35, -1, -1, -1, -1,
+ax_anim 4, 0, 35, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 6, 6, 6, 6,
+ax_anim 1, 0, 33, 15, 15, 15, 15,
+ax_anim 2, 0, 34, 23, 26, 23, 22,
+ax_anim 2, 1, 33, 24, 27, 24, 23,
+ax_anim 2, 0, 34, 23, 26, 23, 22,
+ax_anim 2, 0, 33, 24, 27, 24, 23,
+ax_anim 2, 0, 30, 8, 8, 8, 8,
+ax_anim_terminator
+sChimechoAnims_2_3:
+ax_anim 2, 0, 41, -1, 0, -1, 0,
+ax_anim 4, 0, 41, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 6, 1, 6, 0,
+ax_anim 1, 0, 39, 15, 2, 15, 0,
+ax_anim 2, 0, 40, 23, 4, 23, 0,
+ax_anim 2, 1, 39, 24, 4, 24, 0,
+ax_anim 2, 0, 40, 23, 4, 23, 0,
+ax_anim 2, 0, 39, 24, 4, 24, 0,
+ax_anim 2, 0, 36, 8, 2, 8, 0,
+ax_anim_terminator
+sChimechoAnims_2_4:
+ax_anim 2, 0, 47, -1, 1, -1, 1,
+ax_anim 4, 0, 47, -2, 2, -2, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 8, -6, 8, -7,
+ax_anim 1, 0, 45, 16, -11, 16, -13,
+ax_anim 2, 0, 46, 21, -14, 21, -18,
+ax_anim 2, 1, 45, 22, -15, 22, -19,
+ax_anim 2, 0, 46, 21, -14, 21, -18,
+ax_anim 2, 0, 45, 22, -15, 22, -19,
+ax_anim 2, 0, 42, 10, -7, 10, -8,
+ax_anim_terminator
+sChimechoAnims_2_5:
+ax_anim 2, 0, 53, 0, 1, 0, 1,
+ax_anim 4, 0, 53, 0, 2, 0, 2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 0, -6, 0, -6,
+ax_anim 1, 0, 51, 0, -11, 0, -11,
+ax_anim 2, 0, 52, 0, -16, 0, -19,
+ax_anim 2, 1, 51, 0, -17, 0, -20,
+ax_anim 2, 0, 52, 0, -16, 0, -19,
+ax_anim 2, 0, 51, 0, -17, 0, -20,
+ax_anim 2, 0, 48, 0, -7, 0, -7,
+ax_anim_terminator
+sChimechoAnims_2_6:
+ax_anim 2, 0, 59, 1, 1, 1, 1,
+ax_anim 4, 0, 59, 2, 2, 2, 2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 57, -8, -6, -8, -7,
+ax_anim 1, 0, 57, -16, -11, -16, -13,
+ax_anim 2, 0, 58, -21, -14, -21, -18,
+ax_anim 2, 1, 57, -22, -15, -22, -19,
+ax_anim 2, 0, 58, -21, -14, -21, -18,
+ax_anim 2, 0, 57, -22, -15, -22, -19,
+ax_anim 2, 0, 54, -10, -7, -10, -8,
+ax_anim_terminator
+sChimechoAnims_2_7:
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim 4, 0, 65, 2, 0, 2, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 63, -6, 1, -6, 0,
+ax_anim 1, 0, 63, -15, 2, -15, 0,
+ax_anim 2, 0, 64, -23, 4, -23, 0,
+ax_anim 2, 1, 63, -24, 4, -24, 0,
+ax_anim 2, 0, 64, -23, 4, -23, 0,
+ax_anim 2, 0, 63, -24, 4, -24, 0,
+ax_anim 2, 0, 60, -8, 2, -8, 0,
+ax_anim_terminator
+sChimechoAnims_2_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 4, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -6, 6, -6, 6,
+ax_anim 1, 0, 69, -15, 15, -15, 15,
+ax_anim 2, 0, 70, -23, 26, -23, 22,
+ax_anim 2, 1, 69, -24, 27, -24, 23,
+ax_anim 2, 0, 70, -23, 26, -23, 22,
+ax_anim 2, 0, 69, -24, 27, -24, 23,
+ax_anim 2, 0, 66, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sChimechoAnims_3_1:
+ax_anim 2, 0, 77, 0, -1, 0, -1,
+ax_anim 4, 0, 77, 0, -2, 0, -2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, 6, 0, 5,
+ax_anim 1, 0, 75, 0, 15, 0, 14,
+ax_anim 2, 0, 76, 0, 26, 0, 22,
+ax_anim 2, 1, 75, 0, 27, 0, 23,
+ax_anim 2, 0, 76, 0, 26, 0, 22,
+ax_anim 2, 0, 75, 0, 27, 0, 23,
+ax_anim 2, 0, 72, 0, 8, 0, 6,
+ax_anim_terminator
+sChimechoAnims_3_2:
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 4, 0, 83, -2, -2, -2, -2,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 2, 81, 6, 6, 6, 6,
+ax_anim 1, 0, 81, 15, 15, 15, 15,
+ax_anim 2, 0, 82, 23, 26, 23, 22,
+ax_anim 2, 1, 81, 24, 27, 24, 23,
+ax_anim 2, 0, 82, 23, 26, 23, 22,
+ax_anim 2, 0, 81, 24, 27, 24, 23,
+ax_anim 2, 0, 78, 8, 8, 8, 8,
+ax_anim_terminator
+sChimechoAnims_3_3:
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim 4, 0, 89, -2, 0, -2, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 87, 6, 1, 6, 0,
+ax_anim 1, 0, 87, 15, 2, 15, 0,
+ax_anim 2, 0, 88, 23, 4, 23, 0,
+ax_anim 2, 1, 87, 24, 4, 24, 0,
+ax_anim 2, 0, 88, 23, 4, 23, 0,
+ax_anim 2, 0, 87, 24, 4, 24, 0,
+ax_anim 2, 0, 84, 8, 2, 8, 0,
+ax_anim_terminator
+sChimechoAnims_3_4:
+ax_anim 2, 0, 95, -1, 1, -1, 1,
+ax_anim 4, 0, 95, -2, 2, -2, 2,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 2, 93, 8, -6, 8, -7,
+ax_anim 1, 0, 93, 16, -11, 16, -13,
+ax_anim 2, 0, 94, 21, -14, 21, -18,
+ax_anim 2, 1, 93, 22, -15, 22, -19,
+ax_anim 2, 0, 94, 21, -14, 21, -18,
+ax_anim 2, 0, 93, 22, -15, 22, -19,
+ax_anim 2, 0, 90, 10, -7, 10, -8,
+ax_anim_terminator
+sChimechoAnims_3_5:
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 4, 0, 101, 0, 2, 0, 2,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 99, 0, -6, 0, -6,
+ax_anim 1, 0, 99, 0, -11, 0, -11,
+ax_anim 2, 0, 100, 0, -16, 0, -19,
+ax_anim 2, 1, 99, 0, -17, 0, -20,
+ax_anim 2, 0, 100, 0, -16, 0, -19,
+ax_anim 2, 0, 99, 0, -17, 0, -20,
+ax_anim 2, 0, 96, 0, -7, 0, -7,
+ax_anim_terminator
+sChimechoAnims_3_6:
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 4, 0, 107, 2, 2, 2, 2,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 2, 105, -8, -6, -8, -7,
+ax_anim 1, 0, 105, -16, -11, -16, -13,
+ax_anim 2, 0, 106, -21, -14, -21, -18,
+ax_anim 2, 1, 105, -22, -15, -22, -19,
+ax_anim 2, 0, 106, -21, -14, -21, -18,
+ax_anim 2, 0, 105, -22, -15, -22, -19,
+ax_anim 2, 0, 102, -10, -7, -10, -8,
+ax_anim_terminator
+sChimechoAnims_3_7:
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 4, 0, 113, 2, 0, 2, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 2, 111, -6, 1, -6, 0,
+ax_anim 1, 0, 111, -15, 2, -15, 0,
+ax_anim 2, 0, 112, -23, 4, -23, 0,
+ax_anim 2, 1, 111, -24, 4, -24, 0,
+ax_anim 2, 0, 112, -23, 4, -23, 0,
+ax_anim 2, 0, 111, -24, 4, -24, 0,
+ax_anim 2, 0, 108, -8, 2, -8, 0,
+ax_anim_terminator
+sChimechoAnims_3_8:
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 4, 0, 119, 2, -2, 2, -2,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 2, 117, -6, 6, -6, 6,
+ax_anim 1, 0, 117, -15, 15, -15, 15,
+ax_anim 2, 0, 118, -23, 26, -23, 22,
+ax_anim 2, 1, 117, -24, 27, -24, 23,
+ax_anim 2, 0, 118, -23, 26, -23, 22,
+ax_anim 2, 0, 117, -24, 27, -24, 23,
+ax_anim 2, 0, 114, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sChimechoAnims_4_1:
+ax_anim 2, 0, 125, 0, -2, 0, -2,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 4, 2, 125, 0, -3, 0, -3,
+ax_anim 1, 0, 120, 0, -3, 0, -3,
+ax_anim 1, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 0, 123, 0, 2, 0, 2,
+ax_anim 2, 1, 124, 0, 4, 0, 4,
+ax_anim 2, 0, 124, -1, 4, -1, 4,
+ax_anim 2, 0, 124, 0, 4, 0, 4,
+ax_anim 2, 0, 124, -1, 4, -1, 4,
+ax_anim 2, 0, 124, 0, 4, 0, 4,
+ax_anim 2, 0, 124, -1, 4, -1, 4,
+ax_anim 2, 0, 120, 0, 2, 0, 2,
+ax_anim_terminator
+sChimechoAnims_4_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 2, 0, 131, -3, -3, -3, -3,
+ax_anim 4, 2, 131, -3, -3, -3, -3,
+ax_anim 1, 0, 126, -3, -3, -3, -3,
+ax_anim 1, 0, 129, -3, -3, -3, -3,
+ax_anim 2, 0, 129, 2, 2, 2, 2,
+ax_anim 2, 1, 130, 4, 4, 4, 4,
+ax_anim 2, 0, 130, 3, 5, 3, 5,
+ax_anim 2, 0, 130, 4, 4, 4, 4,
+ax_anim 2, 0, 130, 3, 5, 3, 5,
+ax_anim 2, 0, 130, 4, 4, 4, 4,
+ax_anim 2, 0, 130, 3, 5, 3, 5,
+ax_anim 2, 0, 126, 2, 2, 2, 2,
+ax_anim_terminator
+sChimechoAnims_4_3:
+ax_anim 2, 0, 137, -2, 0, -2, 0,
+ax_anim 2, 0, 137, -3, 0, -3, 0,
+ax_anim 4, 2, 137, -3, 0, -3, 0,
+ax_anim 1, 0, 132, -3, 0, -3, 0,
+ax_anim 1, 0, 135, -3, 0, -3, 0,
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim 2, 1, 136, 4, 0, 4, 0,
+ax_anim 2, 0, 136, 4, 1, 4, 1,
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 2, 0, 136, 4, 1, 4, 1,
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 2, 0, 136, 4, 1, 4, 1,
+ax_anim 2, 0, 132, 2, 0, 2, 0,
+ax_anim_terminator
+sChimechoAnims_4_4:
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 4, 2, 143, -3, 3, -3, 3,
+ax_anim 1, 0, 138, -3, 3, -3, 3,
+ax_anim 1, 0, 141, -3, 3, -3, 3,
+ax_anim 2, 0, 141, 2, -2, 2, -2,
+ax_anim 2, 1, 142, 4, -4, 4, -4,
+ax_anim 2, 0, 142, 3, -5, 3, -5,
+ax_anim 2, 0, 142, 4, -4, 4, -4,
+ax_anim 2, 0, 142, 3, -5, 3, -5,
+ax_anim 2, 0, 142, 4, -4, 4, -4,
+ax_anim 2, 0, 142, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 2, -2, 2, -2,
+ax_anim_terminator
+sChimechoAnims_4_5:
+ax_anim 2, 0, 149, 0, 2, 0, 2,
+ax_anim 2, 0, 149, 0, 3, 0, 3,
+ax_anim 4, 2, 149, 0, 3, 0, 3,
+ax_anim 1, 0, 144, 0, 3, 0, 3,
+ax_anim 1, 0, 147, 0, 3, 0, 3,
+ax_anim 2, 0, 147, 0, -2, 0, -2,
+ax_anim 2, 1, 148, 0, -4, 0, -4,
+ax_anim 2, 0, 148, -1, -4, -1, -4,
+ax_anim 2, 0, 148, 0, -4, 0, -4,
+ax_anim 2, 0, 148, -1, -4, -1, -4,
+ax_anim 2, 0, 148, 0, -4, 0, -4,
+ax_anim 2, 0, 148, -1, -4, -1, -4,
+ax_anim 2, 0, 144, 0, -2, 0, -2,
+ax_anim_terminator
+sChimechoAnims_4_6:
+ax_anim 2, 0, 155, 2, 2, 2, 2,
+ax_anim 2, 0, 155, 3, 3, 3, 3,
+ax_anim 4, 2, 155, 3, 3, 3, 3,
+ax_anim 1, 0, 150, 3, 3, 3, 3,
+ax_anim 1, 0, 153, 3, 3, 3, 3,
+ax_anim 2, 0, 153, -2, -2, -2, -2,
+ax_anim 2, 1, 154, -4, -4, -4, -4,
+ax_anim 2, 0, 154, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -4, -4, -4, -4,
+ax_anim 2, 0, 154, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -4, -4, -4, -4,
+ax_anim 2, 0, 154, -3, -5, -3, -5,
+ax_anim 2, 0, 150, -2, -2, -2, -2,
+ax_anim_terminator
+sChimechoAnims_4_7:
+ax_anim 2, 0, 161, 2, 0, 2, 0,
+ax_anim 2, 0, 161, 3, 0, 3, 0,
+ax_anim 4, 2, 161, 3, 0, 3, 0,
+ax_anim 1, 0, 156, 3, 0, 3, 0,
+ax_anim 1, 0, 159, 3, 0, 3, 0,
+ax_anim 2, 0, 159, -2, 0, -2, 0,
+ax_anim 2, 1, 160, -4, 0, -4, 0,
+ax_anim 2, 0, 160, -4, 1, -4, 1,
+ax_anim 2, 0, 160, -4, 0, -4, 0,
+ax_anim 2, 0, 160, -4, 1, -4, 1,
+ax_anim 2, 0, 160, -4, 0, -4, 0,
+ax_anim 2, 0, 160, -4, 1, -4, 1,
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim_terminator
+sChimechoAnims_4_8:
+ax_anim 2, 0, 167, 2, -2, 2, -2,
+ax_anim 2, 0, 167, 3, -3, 3, -3,
+ax_anim 4, 2, 167, 3, -3, 3, -3,
+ax_anim 1, 0, 162, 3, -3, 3, -3,
+ax_anim 1, 0, 165, 3, -3, 3, -3,
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 2, 1, 166, -4, 4, -4, 4,
+ax_anim 2, 0, 166, -3, 5, -3, 5,
+ax_anim 2, 0, 166, -4, 4, -4, 4,
+ax_anim 2, 0, 166, -3, 5, -3, 5,
+ax_anim 2, 0, 166, -4, 4, -4, 4,
+ax_anim 2, 0, 166, -3, 5, -3, 5,
+ax_anim 2, 0, 162, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sChimechoAnims_5_1:
+ax_anim 3, 0, 169, 0, -1, 0, 0,
+ax_anim 2, 0, 170, 0, -3, 0, 0,
+ax_anim 2, 0, 171, 0, -5, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 0, 174, 0, -6, 0, 0,
+ax_anim 1, 0, 175, 0, -6, 0, 0,
+ax_anim 1, 0, 168, 0, -6, 0, 0,
+ax_anim 1, 0, 169, 0, -6, 0, 0,
+ax_anim 1, 0, 170, 0, -6, 0, 0,
+ax_anim 1, 2, 171, 0, -6, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, 0,
+ax_anim 2, 0, 173, 0, -5, 0, 0,
+ax_anim 2, 0, 174, 0, -3, 0, 0,
+ax_anim 3, 0, 175, 0, -1, 0, 0,
+ax_anim 3, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_5_2:
+ax_anim 3, 0, 168, 0, -1, 0, 0,
+ax_anim 2, 0, 169, 0, -3, 0, 0,
+ax_anim 2, 0, 170, 0, -5, 0, 0,
+ax_anim 2, 0, 171, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 0, 174, 0, -6, 0, 0,
+ax_anim 1, 0, 175, 0, -6, 0, 0,
+ax_anim 1, 0, 168, 0, -6, 0, 0,
+ax_anim 1, 0, 169, 0, -6, 0, 0,
+ax_anim 1, 2, 170, 0, -6, 0, 0,
+ax_anim 2, 0, 171, 0, -6, 0, 0,
+ax_anim 2, 0, 172, 0, -5, 0, 0,
+ax_anim 2, 0, 173, 0, -3, 0, 0,
+ax_anim 3, 0, 174, 0, -1, 0, 0,
+ax_anim 3, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_5_3:
+ax_anim 3, 0, 175, 0, -1, 0, 0,
+ax_anim 2, 0, 168, 0, -3, 0, 0,
+ax_anim 2, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 170, 0, -6, 0, 0,
+ax_anim 1, 0, 171, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 0, 174, 0, -6, 0, 0,
+ax_anim 1, 0, 175, 0, -6, 0, 0,
+ax_anim 1, 0, 168, 0, -6, 0, 0,
+ax_anim 1, 2, 169, 0, -6, 0, 0,
+ax_anim 2, 0, 170, 0, -6, 0, 0,
+ax_anim 2, 0, 171, 0, -5, 0, 0,
+ax_anim 2, 0, 172, 0, -3, 0, 0,
+ax_anim 3, 0, 173, 0, -1, 0, 0,
+ax_anim 3, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_5_4:
+ax_anim 3, 0, 174, 0, -1, 0, 0,
+ax_anim 2, 0, 175, 0, -3, 0, 0,
+ax_anim 2, 0, 168, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -6, 0, 0,
+ax_anim 1, 0, 170, 0, -6, 0, 0,
+ax_anim 1, 0, 171, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 0, 174, 0, -6, 0, 0,
+ax_anim 1, 0, 175, 0, -6, 0, 0,
+ax_anim 1, 2, 168, 0, -6, 0, 0,
+ax_anim 2, 0, 169, 0, -6, 0, 0,
+ax_anim 2, 0, 170, 0, -5, 0, 0,
+ax_anim 2, 0, 171, 0, -3, 0, 0,
+ax_anim 3, 0, 172, 0, -1, 0, 0,
+ax_anim 3, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_5_5:
+ax_anim 3, 0, 173, 0, -1, 0, 0,
+ax_anim 2, 0, 174, 0, -3, 0, 0,
+ax_anim 2, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, 0,
+ax_anim 1, 0, 169, 0, -6, 0, 0,
+ax_anim 1, 0, 170, 0, -6, 0, 0,
+ax_anim 1, 0, 171, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 0, 174, 0, -6, 0, 0,
+ax_anim 1, 2, 175, 0, -6, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, 0,
+ax_anim 2, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 170, 0, -3, 0, 0,
+ax_anim 3, 0, 171, 0, -1, 0, 0,
+ax_anim 3, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_5_6:
+ax_anim 3, 0, 172, 0, -1, 0, 0,
+ax_anim 2, 0, 173, 0, -3, 0, 0,
+ax_anim 2, 0, 174, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 0, -6, 0, 0,
+ax_anim 1, 0, 168, 0, -6, 0, 0,
+ax_anim 1, 0, 169, 0, -6, 0, 0,
+ax_anim 1, 0, 170, 0, -6, 0, 0,
+ax_anim 1, 0, 171, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 2, 174, 0, -6, 0, 0,
+ax_anim 2, 0, 175, 0, -6, 0, 0,
+ax_anim 2, 0, 168, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -3, 0, 0,
+ax_anim 3, 0, 170, 0, -1, 0, 0,
+ax_anim 3, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_5_7:
+ax_anim 3, 0, 171, 0, -1, 0, 0,
+ax_anim 2, 0, 172, 0, -3, 0, 0,
+ax_anim 2, 0, 173, 0, -5, 0, 0,
+ax_anim 2, 0, 174, 0, -6, 0, 0,
+ax_anim 1, 0, 175, 0, -6, 0, 0,
+ax_anim 1, 0, 168, 0, -6, 0, 0,
+ax_anim 1, 0, 169, 0, -6, 0, 0,
+ax_anim 1, 0, 170, 0, -6, 0, 0,
+ax_anim 1, 0, 171, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 2, 173, 0, -6, 0, 0,
+ax_anim 2, 0, 174, 0, -6, 0, 0,
+ax_anim 2, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 168, 0, -3, 0, 0,
+ax_anim 3, 0, 169, 0, -1, 0, 0,
+ax_anim 3, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_5_8:
+ax_anim 3, 0, 170, 0, -1, 0, 0,
+ax_anim 2, 0, 171, 0, -3, 0, 0,
+ax_anim 2, 0, 172, 0, -5, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, 0,
+ax_anim 1, 0, 174, 0, -6, 0, 0,
+ax_anim 1, 0, 175, 0, -6, 0, 0,
+ax_anim 1, 0, 168, 0, -6, 0, 0,
+ax_anim 1, 0, 169, 0, -6, 0, 0,
+ax_anim 1, 0, 170, 0, -6, 0, 0,
+ax_anim 1, 0, 171, 0, -6, 0, 0,
+ax_anim 1, 2, 172, 0, -6, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, 0,
+ax_anim 2, 0, 174, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 0, -3, 0, 0,
+ax_anim 3, 0, 168, 0, -1, 0, 0,
+ax_anim 3, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChimechoAnims_6_1:
+ax_anim 28, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, -1, 0, 0,
+ax_anim 10, 0, 176, 0, -2, 0, 0,
+ax_anim 28, 0, 177, 0, -3, 0, 0,
+ax_anim 10, 0, 177, 0, -2, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sChimechoAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sChimechoAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sChimechoAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sChimechoAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sChimechoAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sChimechoAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sChimechoAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sChimechoAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sChimechoAnims_8_1:
+ax_anim 18, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 18, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_8_2:
+ax_anim 18, 0, 190, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim 18, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_8_3:
+ax_anim 18, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim 18, 0, 194, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_8_4:
+ax_anim 18, 0, 196, 0, 0, 0, 0,
+ax_anim 8, 0, 195, 0, 0, 0, 0,
+ax_anim 18, 0, 197, 0, 0, 0, 0,
+ax_anim 8, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_8_5:
+ax_anim 18, 0, 199, 0, 0, 0, 0,
+ax_anim 8, 0, 198, 0, 0, 0, 0,
+ax_anim 18, 0, 200, 0, 0, 0, 0,
+ax_anim 8, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_8_6:
+ax_anim 18, 0, 202, 0, 0, 0, 0,
+ax_anim 8, 0, 201, 0, 0, 0, 0,
+ax_anim 18, 0, 203, 0, 0, 0, 0,
+ax_anim 8, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_8_7:
+ax_anim 18, 0, 205, 0, 0, 0, 0,
+ax_anim 8, 0, 204, 0, 0, 0, 0,
+ax_anim 18, 0, 206, 0, 0, 0, 0,
+ax_anim 8, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_8_8:
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 209, 0, 0, 0, 0,
+ax_anim 8, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChimechoAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 7, 7, 7, 7,
+ax_anim 2, 0, 212, 9, 14, 9, 14,
+ax_anim 2, 0, 213, 9, 23, 9, 20,
+ax_anim 3, 0, 214, 0, 29, 0, 24,
+ax_anim 2, 3, 215, -9, 23, -9, 20,
+ax_anim 2, 0, 216, -9, 14, -9, 14,
+ax_anim 1, 0, 217, -7, 7, -7, 7,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 8, 2, 8, 2,
+ax_anim 2, 0, 211, 15, 7, 15, 7,
+ax_anim 2, 0, 212, 20, 19, 20, 16,
+ax_anim 3, 0, 213, 21, 28, 21, 24,
+ax_anim 2, 3, 214, 12, 30, 12, 24,
+ax_anim 2, 0, 215, 3, 20, 3, 20,
+ax_anim 1, 0, 216, 0, 9, 0, 9,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 6, -3, 6, -3,
+ax_anim 2, 0, 210, 11, -5, 11, -5,
+ax_anim 2, 0, 211, 17, -2, 17, -3,
+ax_anim 3, 0, 212, 20, 2, 20, 0,
+ax_anim 2, 3, 213, 18, 7, 18, 4,
+ax_anim 2, 0, 214, 10, 10, 10, 7,
+ax_anim 1, 0, 215, 4, 7, 4, 4,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 1, -7, 1, -7,
+ax_anim 2, 0, 217, 5, -15, 5, -15,
+ax_anim 2, 0, 210, 11, -18, 11, -18,
+ax_anim 3, 0, 211, 21, -16, 21, -20,
+ax_anim 2, 3, 212, 22, -9, 22, -12,
+ax_anim 2, 0, 213, 17, -3, 17, -3,
+ax_anim 1, 0, 214, 9, 1, 9, 1,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -8, -3, -8, -3,
+ax_anim 2, 0, 216, -9, -7, -9, -11,
+ax_anim 2, 0, 217, -7, -13, -7, -18,
+ax_anim 3, 0, 210, 0, -17, 0, -23,
+ax_anim 2, 3, 211, 7, -13, 7, -18,
+ax_anim 2, 0, 212, 9, -7, 9, -11,
+ax_anim 1, 0, 213, 8, -3, 8, -3,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, -1, -7, -1, -7,
+ax_anim 2, 0, 211, -5, -15, -5, -15,
+ax_anim 2, 0, 210, -11, -18, -11, -18,
+ax_anim 3, 0, 217, -21, -16, -21, -20,
+ax_anim 2, 3, 216, -22, -9, -22, -12,
+ax_anim 2, 0, 215, -17, -3, -17, -3,
+ax_anim 1, 0, 214, -9, 1, -9, 1,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, -6, -3, -6, -3,
+ax_anim 2, 0, 214, -11, -5, -11, -5,
+ax_anim 2, 0, 215, -17, -2, -17, -3,
+ax_anim 3, 0, 216, -20, 2, -20, 0,
+ax_anim 2, 3, 217, -18, 7, -18, 4,
+ax_anim 2, 0, 210, -10, 10, -10, 7,
+ax_anim 1, 0, 211, -4, 7, -4, 4,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -8, 2, -8, 2,
+ax_anim 2, 0, 217, -15, 7, -15, 7,
+ax_anim 2, 0, 216, -20, 19, -20, 16,
+ax_anim 3, 0, 215, -21, 28, -21, 24,
+ax_anim 2, 3, 214, -12, 30, -12, 27,
+ax_anim 2, 0, 213, -3, 20, -3, 20,
+ax_anim 1, 0, 212, 0, 9, 0, 9,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChimechoAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChimechoAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -13, 0, 0,
+ax_anim 1, 0, 227, 0, -6, 0, 0,
+ax_anim 2, 2, 227, 0, 9, 0, 0,
+ax_anim_terminator
+sChimechoAnims_11_2:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -15, 0, 0,
+ax_anim 1, 0, 230, 0, -4, 0, 0,
+ax_anim 2, 2, 230, 0, 9, 0, 0,
+ax_anim_terminator
+sChimechoAnims_11_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -12, 0, 0,
+ax_anim 1, 0, 233, 0, -6, 0, 0,
+ax_anim 2, 2, 233, 0, 10, 0, 0,
+ax_anim_terminator
+sChimechoAnims_11_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -22, 0, 0,
+ax_anim 3, 0, 236, 0, -21, 0, 0,
+ax_anim 2, 0, 236, 0, -13, 0, 0,
+ax_anim 1, 0, 236, 0, -6, 0, 0,
+ax_anim 2, 2, 236, 0, 10, 0, 0,
+ax_anim_terminator
+sChimechoAnims_11_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -22, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 2, 0, 239, 0, -10, 0, 0,
+ax_anim 1, 0, 239, 0, -4, 0, 0,
+ax_anim 2, 2, 239, 0, 9, 0, 0,
+ax_anim_terminator
+sChimechoAnims_11_6:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 243, 0, -20, 0, 0,
+ax_anim 4, 0, 243, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -22, 0, 0,
+ax_anim 3, 0, 242, 0, -21, 0, 0,
+ax_anim 2, 0, 242, 0, -13, 0, 0,
+ax_anim 1, 0, 242, 0, -6, 0, 0,
+ax_anim 2, 2, 242, 0, 10, 0, 0,
+ax_anim_terminator
+sChimechoAnims_11_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 246, 0, -20, 0, 0,
+ax_anim 4, 0, 246, 0, -21, 0, 0,
+ax_anim 4, 0, 244, 0, -23, 0, 0,
+ax_anim 3, 0, 245, 0, -22, 0, 0,
+ax_anim 2, 0, 245, 0, -12, 0, 0,
+ax_anim 1, 0, 245, 0, -6, 0, 0,
+ax_anim 2, 2, 245, 0, 10, 0, 0,
+ax_anim_terminator
+sChimechoAnims_11_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 0, -10, 0, 0,
+ax_anim 2, 0, 249, 0, -16, 0, 0,
+ax_anim 3, 0, 249, 0, -20, 0, 0,
+ax_anim 4, 0, 249, 0, -21, 0, 0,
+ax_anim 4, 0, 247, 0, -22, 0, 0,
+ax_anim 3, 0, 248, 0, -21, 0, 0,
+ax_anim 2, 0, 248, 0, -15, 0, 0,
+ax_anim 1, 0, 248, 0, -4, 0, 0,
+ax_anim 2, 2, 248, 0, 9, 0, 0,
+ax_anim_terminator
+.align 2
+sChimechoAnims_12_1:
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_12_2:
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 1, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_12_3:
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 1, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_12_4:
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 1, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_12_5:
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 1, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_12_6:
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 1, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_12_7:
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 1, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_12_8:
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 1, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChimechoAnims_13_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_13_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_13_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_13_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_13_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_13_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_13_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoAnims_13_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sChimechoGfx1:
+.incbin "baserom.gba", 0x14CCE98, 0x100
+sChimechoSprites1:
+ax_sprite sChimechoGfx1, 0x100
+ax_sprite_terminator
+sChimechoGfx2:
+.incbin "baserom.gba", 0x14CCFA8, 0x100
+sChimechoSprites2:
+ax_sprite sChimechoGfx2, 0x100
+ax_sprite_terminator
+sChimechoGfx3:
+.incbin "baserom.gba", 0x14CD0B8, 0x100
+sChimechoSprites3:
+ax_sprite sChimechoGfx3, 0x100
+ax_sprite_terminator
+sChimechoGfx4:
+.incbin "baserom.gba", 0x14CD1C8, 0x100
+sChimechoSprites4:
+ax_sprite sChimechoGfx4, 0x100
+ax_sprite_terminator
+sChimechoGfx5:
+.incbin "baserom.gba", 0x14CD2D8, 0x100
+sChimechoSprites5:
+ax_sprite sChimechoGfx5, 0x100
+ax_sprite_terminator
+sChimechoGfx6:
+.incbin "baserom.gba", 0x14CD3E8, 0x100
+sChimechoSprites6:
+ax_sprite sChimechoGfx6, 0x100
+ax_sprite_terminator
+sChimechoGfx7:
+.incbin "baserom.gba", 0x14CD4F8, 0x100
+sChimechoSprites7:
+ax_sprite sChimechoGfx7, 0x100
+ax_sprite_terminator
+sChimechoGfx8:
+.incbin "baserom.gba", 0x14CD608, 0x100
+sChimechoSprites8:
+ax_sprite sChimechoGfx8, 0x100
+ax_sprite_terminator
+sChimechoGfx9:
+.incbin "baserom.gba", 0x14CD718, 0x100
+sChimechoSprites9:
+ax_sprite sChimechoGfx9, 0x100
+ax_sprite_terminator
+sChimechoGfx10:
+.incbin "baserom.gba", 0x14CD828, 0x100
+sChimechoSprites10:
+ax_sprite sChimechoGfx10, 0x100
+ax_sprite_terminator
+sChimechoGfx11:
+.incbin "baserom.gba", 0x14CD938, 0x100
+sChimechoSprites11:
+ax_sprite sChimechoGfx11, 0x100
+ax_sprite_terminator
+sChimechoGfx12:
+.incbin "baserom.gba", 0x14CDA48, 0x100
+sChimechoSprites12:
+ax_sprite sChimechoGfx12, 0x100
+ax_sprite_terminator
+sChimechoGfx13:
+.incbin "baserom.gba", 0x14CDB58, 0x100
+sChimechoSprites13:
+ax_sprite sChimechoGfx13, 0x100
+ax_sprite_terminator
+sChimechoGfx14:
+.incbin "baserom.gba", 0x14CDC68, 0x100
+sChimechoSprites14:
+ax_sprite sChimechoGfx14, 0x100
+ax_sprite_terminator
+sChimechoGfx15:
+.incbin "baserom.gba", 0x14CDD78, 0x100
+sChimechoSprites15:
+ax_sprite sChimechoGfx15, 0x100
+ax_sprite_terminator
+sChimechoGfx16:
+.incbin "baserom.gba", 0x14CDE88, 0xC0
+sChimechoSprites16:
+ax_sprite sChimechoGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx17:
+.incbin "baserom.gba", 0x14CDF60, 0xC0
+sChimechoSprites17:
+ax_sprite sChimechoGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx18:
+.incbin "baserom.gba", 0x14CE038, 0xC0
+sChimechoSprites18:
+ax_sprite sChimechoGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx19:
+.incbin "baserom.gba", 0x14CE110, 0xC0
+sChimechoSprites19:
+ax_sprite sChimechoGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx20:
+.incbin "baserom.gba", 0x14CE1E8, 0xC0
+sChimechoSprites20:
+ax_sprite sChimechoGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx21:
+.incbin "baserom.gba", 0x14CE2C0, 0x20
+sChimechoSprites21:
+ax_sprite sChimechoGfx21, 0x20
+ax_sprite_terminator
+sChimechoGfx22:
+.incbin "baserom.gba", 0x14CE2F0, 0xC0
+sChimechoSprites22:
+ax_sprite sChimechoGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx23:
+.incbin "baserom.gba", 0x14CE3C8, 0xC0
+sChimechoSprites23:
+ax_sprite sChimechoGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx24:
+.incbin "baserom.gba", 0x14CE4A0, 0x20
+sChimechoSprites24:
+ax_sprite sChimechoGfx24, 0x20
+ax_sprite_terminator
+sChimechoGfx25:
+.incbin "baserom.gba", 0x14CE4D0, 0xC0
+sChimechoSprites25:
+ax_sprite sChimechoGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx26:
+.incbin "baserom.gba", 0x14CE5A8, 0x20
+sChimechoSprites26:
+ax_sprite sChimechoGfx26, 0x20
+ax_sprite_terminator
+sChimechoGfx27:
+.incbin "baserom.gba", 0x14CE5D8, 0xC0
+sChimechoSprites27:
+ax_sprite sChimechoGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx28:
+.incbin "baserom.gba", 0x14CE6B0, 0xC0
+sChimechoSprites28:
+ax_sprite sChimechoGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx29:
+.incbin "baserom.gba", 0x14CE788, 0x20
+sChimechoSprites29:
+ax_sprite sChimechoGfx29, 0x20
+ax_sprite_terminator
+sChimechoGfx30:
+.incbin "baserom.gba", 0x14CE7B8, 0xC0
+sChimechoSprites30:
+ax_sprite sChimechoGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx31:
+.incbin "baserom.gba", 0x14CE890, 0x20
+sChimechoSprites31:
+ax_sprite sChimechoGfx31, 0x20
+ax_sprite_terminator
+sChimechoGfx32:
+.incbin "baserom.gba", 0x14CE8C0, 0xC0
+sChimechoSprites32:
+ax_sprite sChimechoGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx33:
+.incbin "baserom.gba", 0x14CE998, 0xC0
+sChimechoSprites33:
+ax_sprite sChimechoGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx34:
+.incbin "baserom.gba", 0x14CEA70, 0xC0
+sChimechoSprites34:
+ax_sprite sChimechoGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx35:
+.incbin "baserom.gba", 0x14CEB48, 0xC0
+sChimechoSprites35:
+ax_sprite sChimechoGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChimechoGfx36:
+.incbin "baserom.gba", 0x14CEC20, 0x100
+sChimechoSprites36:
+ax_sprite sChimechoGfx36, 0x100
+ax_sprite_terminator
+sChimechoGfx37:
+.incbin "baserom.gba", 0x14CED30, 0x100
+sChimechoSprites37:
+ax_sprite sChimechoGfx37, 0x100
+ax_sprite_terminator
+sChimechoGfx38:
+.incbin "baserom.gba", 0x14CEE40, 0x20
+sChimechoSprites38:
+ax_sprite sChimechoGfx38, 0x20
+ax_sprite_terminator
+sChimechoGfx39:
+.incbin "baserom.gba", 0x14CEE70, 0x100
+sChimechoSprites39:
+ax_sprite sChimechoGfx39, 0x100
+ax_sprite_terminator
+sChimechoGfx40:
+.incbin "baserom.gba", 0x14CEF80, 0x200
+sChimechoSprites40:
+ax_sprite sChimechoGfx40, 0x200
+ax_sprite_terminator
+sChimechoGfx41:
+.incbin "baserom.gba", 0x14CF190, 0x200
+sChimechoSprites41:
+ax_sprite sChimechoGfx41, 0x200
+ax_sprite_terminator
+sChimechoGfx42:
+.incbin "baserom.gba", 0x14CF3A0, 0x200
+sChimechoSprites42:
+ax_sprite sChimechoGfx42, 0x200
+ax_sprite_terminator
+sChimechoGfx43:
+.incbin "baserom.gba", 0x14CF5B0, 0x20
+sChimechoSprites43:
+ax_sprite sChimechoGfx43, 0x20
+ax_sprite_terminator
+sChimechoGfx44:
+.incbin "baserom.gba", 0x14CF5E0, 0x100
+sChimechoSprites44:
+ax_sprite sChimechoGfx44, 0x100
+ax_sprite_terminator
+sAxPosesChimecho:
+.4byte sChimechoPose1
+.4byte sChimechoPose2
+.4byte sChimechoPose3
+.4byte sChimechoPose4
+.4byte sChimechoPose5
+.4byte sChimechoPose6
+.4byte sChimechoPose7
+.4byte sChimechoPose8
+.4byte sChimechoPose9
+.4byte sChimechoPose10
+.4byte sChimechoPose11
+.4byte sChimechoPose12
+.4byte sChimechoPose13
+.4byte sChimechoPose14
+.4byte sChimechoPose15
+.4byte sChimechoPose16
+.4byte sChimechoPose17
+.4byte sChimechoPose18
+.4byte sChimechoPose19
+.4byte sChimechoPose20
+.4byte sChimechoPose21
+.4byte sChimechoPose22
+.4byte sChimechoPose23
+.4byte sChimechoPose24
+.4byte sChimechoPose25
+.4byte sChimechoPose26
+.4byte sChimechoPose27
+.4byte sChimechoPose28
+.4byte sChimechoPose29
+.4byte sChimechoPose30
+.4byte sChimechoPose31
+.4byte sChimechoPose32
+.4byte sChimechoPose33
+.4byte sChimechoPose34
+.4byte sChimechoPose35
+.4byte sChimechoPose36
+.4byte sChimechoPose37
+.4byte sChimechoPose38
+.4byte sChimechoPose39
+.4byte sChimechoPose40
+.4byte sChimechoPose41
+.4byte sChimechoPose42
+.4byte sChimechoPose43
+.4byte sChimechoPose44
+.4byte sChimechoPose45
+.4byte sChimechoPose46
+.4byte sChimechoPose47
+.4byte sChimechoPose48
+.4byte sChimechoPose49
+.4byte sChimechoPose50
+.4byte sChimechoPose51
+.4byte sChimechoPose52
+.4byte sChimechoPose53
+.4byte sChimechoPose54
+.4byte sChimechoPose55
+.4byte sChimechoPose56
+.4byte sChimechoPose57
+.4byte sChimechoPose58
+.4byte sChimechoPose59
+.4byte sChimechoPose60
+.4byte sChimechoPose61
+.4byte sChimechoPose62
+.4byte sChimechoPose63
+.4byte sChimechoPose64
+.4byte sChimechoPose65
+.4byte sChimechoPose66
+.4byte sChimechoPose67
+.4byte sChimechoPose68
+.4byte sChimechoPose69
+.4byte sChimechoPose70
+.4byte sChimechoPose71
+.4byte sChimechoPose72
+.4byte sChimechoPose73
+.4byte sChimechoPose74
+.4byte sChimechoPose75
+.4byte sChimechoPose76
+.4byte sChimechoPose77
+.4byte sChimechoPose78
+.4byte sChimechoPose79
+.4byte sChimechoPose80
+.4byte sChimechoPose81
+.4byte sChimechoPose82
+.4byte sChimechoPose83
+.4byte sChimechoPose84
+.4byte sChimechoPose85
+.4byte sChimechoPose86
+.4byte sChimechoPose87
+.4byte sChimechoPose88
+.4byte sChimechoPose89
+.4byte sChimechoPose90
+.4byte sChimechoPose91
+.4byte sChimechoPose92
+.4byte sChimechoPose93
+.4byte sChimechoPose94
+.4byte sChimechoPose95
+.4byte sChimechoPose96
+.4byte sChimechoPose97
+.4byte sChimechoPose98
+.4byte sChimechoPose99
+.4byte sChimechoPose100
+.4byte sChimechoPose101
+.4byte sChimechoPose102
+.4byte sChimechoPose103
+.4byte sChimechoPose104
+.4byte sChimechoPose105
+.4byte sChimechoPose106
+.4byte sChimechoPose107
+.4byte sChimechoPose108
+.4byte sChimechoPose109
+.4byte sChimechoPose110
+.4byte sChimechoPose111
+.4byte sChimechoPose112
+.4byte sChimechoPose113
+.4byte sChimechoPose114
+.4byte sChimechoPose115
+.4byte sChimechoPose116
+.4byte sChimechoPose117
+.4byte sChimechoPose118
+.4byte sChimechoPose119
+.4byte sChimechoPose120
+.4byte sChimechoPose121
+.4byte sChimechoPose122
+.4byte sChimechoPose123
+.4byte sChimechoPose124
+.4byte sChimechoPose125
+.4byte sChimechoPose126
+.4byte sChimechoPose127
+.4byte sChimechoPose128
+.4byte sChimechoPose129
+.4byte sChimechoPose130
+.4byte sChimechoPose131
+.4byte sChimechoPose132
+.4byte sChimechoPose133
+.4byte sChimechoPose134
+.4byte sChimechoPose135
+.4byte sChimechoPose136
+.4byte sChimechoPose137
+.4byte sChimechoPose138
+.4byte sChimechoPose139
+.4byte sChimechoPose140
+.4byte sChimechoPose141
+.4byte sChimechoPose142
+.4byte sChimechoPose143
+.4byte sChimechoPose144
+.4byte sChimechoPose145
+.4byte sChimechoPose146
+.4byte sChimechoPose147
+.4byte sChimechoPose148
+.4byte sChimechoPose149
+.4byte sChimechoPose150
+.4byte sChimechoPose151
+.4byte sChimechoPose152
+.4byte sChimechoPose153
+.4byte sChimechoPose154
+.4byte sChimechoPose155
+.4byte sChimechoPose156
+.4byte sChimechoPose157
+.4byte sChimechoPose158
+.4byte sChimechoPose159
+.4byte sChimechoPose160
+.4byte sChimechoPose161
+.4byte sChimechoPose162
+.4byte sChimechoPose163
+.4byte sChimechoPose164
+.4byte sChimechoPose165
+.4byte sChimechoPose166
+.4byte sChimechoPose167
+.4byte sChimechoPose168
+.4byte sChimechoPose169
+.4byte sChimechoPose170
+.4byte sChimechoPose171
+.4byte sChimechoPose172
+.4byte sChimechoPose173
+.4byte sChimechoPose174
+.4byte sChimechoPose175
+.4byte sChimechoPose176
+.4byte sChimechoPose177
+.4byte sChimechoPose178
+.4byte sChimechoPose179
+.4byte sChimechoPose180
+.4byte sChimechoPose181
+.4byte sChimechoPose182
+.4byte sChimechoPose183
+.4byte sChimechoPose184
+.4byte sChimechoPose185
+.4byte sChimechoPose186
+.4byte sChimechoPose187
+.4byte sChimechoPose188
+.4byte sChimechoPose189
+.4byte sChimechoPose190
+.4byte sChimechoPose191
+.4byte sChimechoPose192
+.4byte sChimechoPose193
+.4byte sChimechoPose194
+.4byte sChimechoPose195
+.4byte sChimechoPose196
+.4byte sChimechoPose197
+.4byte sChimechoPose198
+.4byte sChimechoPose199
+.4byte sChimechoPose200
+.4byte sChimechoPose201
+.4byte sChimechoPose202
+.4byte sChimechoPose203
+.4byte sChimechoPose204
+.4byte sChimechoPose205
+.4byte sChimechoPose206
+.4byte sChimechoPose207
+.4byte sChimechoPose208
+.4byte sChimechoPose209
+.4byte sChimechoPose210
+.4byte sChimechoPose211
+.4byte sChimechoPose212
+.4byte sChimechoPose213
+.4byte sChimechoPose214
+.4byte sChimechoPose215
+.4byte sChimechoPose216
+.4byte sChimechoPose217
+.4byte sChimechoPose218
+.4byte sChimechoPose219
+.4byte sChimechoPose220
+.4byte sChimechoPose221
+.4byte sChimechoPose222
+.4byte sChimechoPose223
+.4byte sChimechoPose224
+.4byte sChimechoPose225
+.4byte sChimechoPose226
+.4byte sChimechoPose227
+.4byte sChimechoPose228
+.4byte sChimechoPose229
+.4byte sChimechoPose230
+.4byte sChimechoPose231
+.4byte sChimechoPose232
+.4byte sChimechoPose233
+.4byte sChimechoPose234
+.4byte sChimechoPose235
+.4byte sChimechoPose236
+.4byte sChimechoPose237
+.4byte sChimechoPose238
+.4byte sChimechoPose239
+.4byte sChimechoPose240
+.4byte sChimechoPose241
+.4byte sChimechoPose242
+.4byte sChimechoPose243
+.4byte sChimechoPose244
+.4byte sChimechoPose245
+.4byte sChimechoPose246
+.4byte sChimechoPose247
+.4byte sChimechoPose248
+.4byte sChimechoPose249
+.4byte sChimechoPose250
+.4byte sChimechoPose251
+.4byte sChimechoPose252
+.4byte sChimechoPose253
+.4byte sChimechoPose254
+.4byte sChimechoPose255
+.4byte sChimechoPose256
+.4byte sChimechoPose257
+.4byte sChimechoPose258
+.4byte sChimechoPose259
+.4byte sChimechoPose260
+.4byte sChimechoPose261
+.4byte sChimechoPose262
+.4byte sChimechoPose263
+.4byte sChimechoPose264
+.4byte sChimechoPose265
+.4byte sChimechoPose266
+sAxPositionsChimecho:
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte    0,  -17, 	  -4,  -17, 	   3,  -17, 	  -1,  -16
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -1,  -18, 	   0,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -2,  -18, 	  -2,  -16, 	  -2,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte   -1,  -20, 	   4,  -19, 	  -5,  -19, 	  -1,  -17
+.2byte   -1,  -20, 	   3,  -18, 	  -4,  -18, 	  -1,  -17
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   0,  -18, 	  -1,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   1,  -18, 	   1,  -16, 	   1,  -17
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte    0,  -17, 	  -4,  -17, 	   3,  -17, 	  -1,  -16
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte   -1,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    0,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    0,  -19, 	  -5,  -20, 	   4,  -20, 	   0,  -18
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte    4,  -15, 	   6,  -17, 	  -1,  -15, 	   1,  -16
+.2byte    4,  -15, 	   6,  -17, 	  -1,  -15, 	   1,  -16
+.2byte   -1,  -17, 	   2,  -19, 	  -5,  -17, 	  -2,  -18
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -1,  -18, 	   0,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -2,  -18, 	  -2,  -16, 	  -2,  -17
+.2byte    5,  -16, 	   1,  -18, 	   1,  -15, 	   2,  -16
+.2byte    5,  -16, 	   1,  -18, 	   1,  -15, 	   1,  -16
+.2byte   -1,  -19, 	  -3,  -19, 	  -3,  -16, 	  -4,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte    3,  -18, 	  -2,  -19, 	   5,  -16, 	   1,  -17
+.2byte    3,  -18, 	  -2,  -19, 	   5,  -16, 	   1,  -17
+.2byte   -2,  -20, 	  -7,  -18, 	   1,  -18, 	  -3,  -17
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte   -1,  -20, 	   4,  -19, 	  -5,  -19, 	  -1,  -17
+.2byte   -1,  -20, 	   3,  -18, 	  -4,  -18, 	  -1,  -17
+.2byte    0,  -18, 	   4,  -17, 	  -5,  -17, 	   0,  -16
+.2byte   -1,  -18, 	   4,  -17, 	  -5,  -17, 	   0,  -16
+.2byte    0,  -21, 	   4,  -20, 	  -5,  -20, 	  -1,  -18
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte   -4,  -18, 	   1,  -19, 	  -6,  -16, 	  -2,  -17
+.2byte   -4,  -18, 	   1,  -19, 	  -6,  -16, 	  -2,  -17
+.2byte    1,  -20, 	   6,  -18, 	  -2,  -18, 	   2,  -17
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   0,  -18, 	  -1,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   1,  -18, 	   1,  -16, 	   1,  -17
+.2byte   -6,  -16, 	  -2,  -18, 	  -2,  -15, 	  -3,  -16
+.2byte   -6,  -16, 	  -2,  -18, 	  -2,  -15, 	  -2,  -16
+.2byte    0,  -19, 	   2,  -19, 	   2,  -16, 	   3,  -17
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte   -5,  -15, 	  -7,  -17, 	   0,  -15, 	  -2,  -16
+.2byte   -5,  -15, 	  -7,  -17, 	   0,  -15, 	  -2,  -16
+.2byte    0,  -17, 	  -3,  -19, 	   4,  -17, 	   1,  -18
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte    0,  -17, 	  -4,  -17, 	   3,  -17, 	  -1,  -16
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte   -1,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    0,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    0,  -19, 	  -5,  -20, 	   4,  -20, 	   0,  -18
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte    4,  -15, 	   6,  -17, 	  -1,  -15, 	   1,  -16
+.2byte    4,  -15, 	   6,  -17, 	  -1,  -15, 	   1,  -16
+.2byte   -1,  -17, 	   2,  -19, 	  -5,  -17, 	  -2,  -18
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -1,  -18, 	   0,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -2,  -18, 	  -2,  -16, 	  -2,  -17
+.2byte    5,  -16, 	   1,  -18, 	   1,  -15, 	   2,  -16
+.2byte    5,  -16, 	   1,  -18, 	   1,  -15, 	   1,  -16
+.2byte   -1,  -19, 	  -3,  -19, 	  -3,  -16, 	  -4,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte    3,  -18, 	  -2,  -19, 	   5,  -16, 	   1,  -17
+.2byte    3,  -18, 	  -2,  -19, 	   5,  -16, 	   1,  -17
+.2byte   -2,  -20, 	  -7,  -18, 	   1,  -18, 	  -3,  -17
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte   -1,  -20, 	   4,  -19, 	  -5,  -19, 	  -1,  -17
+.2byte   -1,  -20, 	   3,  -18, 	  -4,  -18, 	  -1,  -17
+.2byte    0,  -18, 	   4,  -17, 	  -5,  -17, 	   0,  -16
+.2byte   -1,  -18, 	   4,  -17, 	  -5,  -17, 	   0,  -16
+.2byte    0,  -21, 	   4,  -20, 	  -5,  -20, 	  -1,  -18
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte   -4,  -18, 	   1,  -19, 	  -6,  -16, 	  -2,  -17
+.2byte   -4,  -18, 	   1,  -19, 	  -6,  -16, 	  -2,  -17
+.2byte    1,  -20, 	   6,  -18, 	  -2,  -18, 	   2,  -17
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   0,  -18, 	  -1,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   1,  -18, 	   1,  -16, 	   1,  -17
+.2byte   -6,  -16, 	  -2,  -18, 	  -2,  -15, 	  -3,  -16
+.2byte   -6,  -16, 	  -2,  -18, 	  -2,  -15, 	  -2,  -16
+.2byte    0,  -19, 	   2,  -19, 	   2,  -16, 	   3,  -17
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte   -5,  -15, 	  -7,  -17, 	   0,  -15, 	  -2,  -16
+.2byte   -5,  -15, 	  -7,  -17, 	   0,  -15, 	  -2,  -16
+.2byte    0,  -17, 	  -3,  -19, 	   4,  -17, 	   1,  -18
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte    0,  -17, 	  -4,  -17, 	   3,  -17, 	  -1,  -16
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte   -1,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    0,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    0,  -19, 	  -5,  -20, 	   4,  -20, 	   0,  -18
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte    1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte    4,  -15, 	   6,  -17, 	  -1,  -15, 	   1,  -16
+.2byte    4,  -15, 	   6,  -17, 	  -1,  -15, 	   1,  -16
+.2byte   -1,  -17, 	   2,  -19, 	  -5,  -17, 	  -2,  -18
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -1,  -18, 	   0,  -16, 	  -1,  -17
+.2byte    2,  -17, 	  -2,  -18, 	  -2,  -16, 	  -2,  -17
+.2byte    6,  -16, 	   2,  -18, 	   2,  -15, 	   3,  -16
+.2byte    6,  -16, 	   2,  -18, 	   2,  -15, 	   2,  -16
+.2byte   -1,  -19, 	  -3,  -19, 	  -3,  -16, 	  -4,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte    3,  -18, 	  -2,  -19, 	   5,  -16, 	   1,  -17
+.2byte    3,  -18, 	  -2,  -19, 	   5,  -16, 	   1,  -17
+.2byte   -2,  -20, 	  -7,  -18, 	   1,  -18, 	  -3,  -17
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte   -1,  -20, 	   4,  -19, 	  -5,  -19, 	  -1,  -17
+.2byte   -1,  -20, 	   3,  -18, 	  -4,  -18, 	  -1,  -17
+.2byte    0,  -19, 	   4,  -18, 	  -5,  -18, 	   0,  -17
+.2byte   -1,  -19, 	   4,  -18, 	  -5,  -18, 	   0,  -17
+.2byte    0,  -20, 	   4,  -19, 	  -5,  -19, 	  -1,  -17
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -20, 	  -5,  -18, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -18, 	  -3,  -17, 	   0,  -17
+.2byte   -4,  -18, 	   1,  -19, 	  -6,  -16, 	  -2,  -17
+.2byte   -4,  -18, 	   1,  -19, 	  -6,  -16, 	  -2,  -17
+.2byte    1,  -20, 	   6,  -18, 	  -2,  -18, 	   2,  -17
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   0,  -18, 	  -1,  -16, 	   0,  -17
+.2byte   -3,  -17, 	   1,  -18, 	   1,  -16, 	   1,  -17
+.2byte   -7,  -16, 	  -3,  -18, 	  -3,  -15, 	  -4,  -16
+.2byte   -7,  -16, 	  -3,  -18, 	  -3,  -15, 	  -3,  -16
+.2byte    0,  -19, 	   2,  -19, 	   2,  -16, 	   3,  -17
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -18, 	   2,  -17, 	  -1,  -17
+.2byte   -2,  -18, 	  -5,  -20, 	   4,  -18, 	  -1,  -17
+.2byte   -5,  -15, 	  -7,  -17, 	   0,  -15, 	  -2,  -16
+.2byte   -5,  -15, 	  -7,  -17, 	   0,  -15, 	  -2,  -16
+.2byte    0,  -17, 	  -3,  -19, 	   4,  -17, 	   1,  -18
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -1,  -17, 	  -5,  -17, 	   4,  -17, 	   0,  -17
+.2byte   -1,  -16, 	  -5,  -17, 	   4,  -17, 	   0,  -16
+.2byte    0,  -10, 	  -5,  -13, 	   4,  -13, 	   0,  -12
+.2byte    4,  -11, 	   7,  -14, 	  -2,  -12, 	   1,  -11
+.2byte    3,  -10, 	   1,  -14, 	   0,  -12, 	   1,  -12
+.2byte    2,  -12, 	  -3,  -15, 	   4,  -11, 	   0,  -12
+.2byte    2,  -13, 	   6,  -13, 	  -3,  -13, 	   1,  -11
+.2byte   -3,  -12, 	   2,  -15, 	  -5,  -11, 	  -1,  -12
+.2byte   -4,  -10, 	  -2,  -14, 	  -1,  -12, 	  -2,  -12
+.2byte   -5,  -11, 	  -8,  -14, 	   1,  -12, 	  -2,  -11
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte   -1,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    0,  -19, 	  -5,  -20, 	   4,  -20, 	   0,  -18
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte    4,  -15, 	   6,  -17, 	  -1,  -15, 	   1,  -16
+.2byte   -1,  -17, 	   2,  -19, 	  -5,  -17, 	  -2,  -18
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    5,  -16, 	   1,  -18, 	   1,  -15, 	   2,  -16
+.2byte   -1,  -18, 	  -3,  -18, 	  -3,  -15, 	  -4,  -16
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    3,  -18, 	  -2,  -19, 	   5,  -16, 	   1,  -17
+.2byte   -2,  -19, 	  -7,  -17, 	   1,  -17, 	  -3,  -16
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte    0,  -18, 	   4,  -17, 	  -5,  -17, 	   0,  -16
+.2byte    0,  -20, 	   4,  -19, 	  -5,  -19, 	  -1,  -17
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -4,  -18, 	   1,  -19, 	  -6,  -16, 	  -2,  -17
+.2byte    1,  -19, 	   6,  -17, 	  -2,  -17, 	   2,  -16
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -6,  -16, 	  -2,  -18, 	  -2,  -15, 	  -3,  -16
+.2byte    0,  -18, 	   2,  -18, 	   2,  -15, 	   3,  -16
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -5,  -15, 	  -7,  -17, 	   0,  -15, 	  -2,  -16
+.2byte    0,  -17, 	  -3,  -19, 	   4,  -17, 	   1,  -18
+.2byte    0,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte   -4,  -15, 	  -6,  -17, 	   1,  -15, 	  -1,  -16
+.2byte   -5,  -16, 	  -1,  -18, 	  -1,  -15, 	  -1,  -16
+.2byte   -3,  -18, 	   2,  -19, 	  -5,  -16, 	  -1,  -17
+.2byte    0,  -20, 	   4,  -19, 	  -5,  -19, 	   0,  -18
+.2byte    2,  -18, 	  -3,  -19, 	   4,  -16, 	   0,  -17
+.2byte    4,  -16, 	   0,  -18, 	   0,  -15, 	   0,  -16
+.2byte    3,  -15, 	   5,  -17, 	  -2,  -15, 	   0,  -16
+.2byte    0,  -14, 	  -5,  -16, 	   4,  -16, 	   0,  -15
+.2byte    3,  -15, 	   5,  -17, 	  -2,  -15, 	   0,  -16
+.2byte    4,  -16, 	   0,  -18, 	   0,  -15, 	   0,  -16
+.2byte    2,  -18, 	  -3,  -19, 	   4,  -16, 	   0,  -17
+.2byte    0,  -18, 	   4,  -17, 	  -5,  -17, 	   0,  -16
+.2byte   -3,  -18, 	   2,  -19, 	  -5,  -16, 	  -1,  -17
+.2byte   -5,  -16, 	  -1,  -18, 	  -1,  -15, 	  -1,  -16
+.2byte   -4,  -15, 	  -6,  -17, 	   1,  -15, 	  -1,  -16
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte    0,  -16, 	  -5,  -18, 	   4,  -18, 	   0,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   4,  -19, 	   0,  -17
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte    4,  -16, 	   6,  -18, 	  -1,  -16, 	   1,  -17
+.2byte   -1,  -17, 	   2,  -19, 	  -5,  -17, 	  -2,  -18
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    5,  -16, 	   1,  -18, 	   1,  -15, 	   1,  -16
+.2byte    0,  -19, 	  -2,  -19, 	  -2,  -16, 	  -3,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    2,  -18, 	  -3,  -19, 	   4,  -16, 	   0,  -17
+.2byte   -1,  -20, 	  -6,  -18, 	   2,  -18, 	  -2,  -17
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte    0,  -19, 	   4,  -18, 	  -5,  -18, 	   0,  -17
+.2byte    0,  -21, 	   4,  -20, 	  -5,  -20, 	  -1,  -18
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -3,  -18, 	   2,  -19, 	  -5,  -16, 	  -1,  -17
+.2byte    0,  -20, 	   5,  -18, 	  -3,  -18, 	   1,  -17
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -6,  -16, 	  -2,  -18, 	  -2,  -15, 	  -2,  -16
+.2byte    0,  -19, 	   2,  -19, 	   2,  -16, 	   3,  -17
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -5,  -16, 	  -7,  -18, 	   0,  -16, 	  -2,  -17
+.2byte    0,  -17, 	  -3,  -19, 	   4,  -17, 	   1,  -18
+.2byte    0,  -19, 	  -5,  -20, 	   4,  -20, 	   0,  -18
+.2byte   -1,  -18, 	  -4,  -20, 	   3,  -18, 	   0,  -19
+.2byte   -2,  -19, 	   0,  -19, 	   0,  -16, 	   1,  -17
+.2byte    0,  -21, 	   5,  -19, 	  -3,  -19, 	   1,  -18
+.2byte    0,  -21, 	   4,  -20, 	  -5,  -20, 	  -1,  -18
+.2byte   -1,  -21, 	  -6,  -19, 	   2,  -19, 	  -2,  -18
+.2byte    1,  -19, 	  -1,  -19, 	  -1,  -16, 	  -2,  -17
+.2byte    0,  -18, 	   3,  -20, 	  -4,  -18, 	  -1,  -19
+.2byte    0,  -17, 	  -5,  -18, 	   4,  -18, 	  -1,  -16
+.2byte   -2,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte   -3,  -17, 	   0,  -18, 	   0,  -16, 	   0,  -17
+.2byte   -1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+.2byte   -1,  -20, 	   4,  -18, 	  -5,  -18, 	  -1,  -17
+.2byte    0,  -18, 	  -5,  -19, 	   3,  -17, 	  -1,  -17
+.2byte    2,  -17, 	  -1,  -18, 	  -1,  -16, 	  -1,  -17
+.2byte    1,  -18, 	   4,  -19, 	  -4,  -17, 	   0,  -17
+sChimechoAnimTable1:
+.4byte sChimechoAnims_1_1
+.4byte sChimechoAnims_1_2
+.4byte sChimechoAnims_1_3
+.4byte sChimechoAnims_1_4
+.4byte sChimechoAnims_1_5
+.4byte sChimechoAnims_1_6
+.4byte sChimechoAnims_1_7
+.4byte sChimechoAnims_1_8
+sChimechoAnimTable2:
+.4byte sChimechoAnims_2_1
+.4byte sChimechoAnims_2_2
+.4byte sChimechoAnims_2_3
+.4byte sChimechoAnims_2_4
+.4byte sChimechoAnims_2_5
+.4byte sChimechoAnims_2_6
+.4byte sChimechoAnims_2_7
+.4byte sChimechoAnims_2_8
+sChimechoAnimTable3:
+.4byte sChimechoAnims_3_1
+.4byte sChimechoAnims_3_2
+.4byte sChimechoAnims_3_3
+.4byte sChimechoAnims_3_4
+.4byte sChimechoAnims_3_5
+.4byte sChimechoAnims_3_6
+.4byte sChimechoAnims_3_7
+.4byte sChimechoAnims_3_8
+sChimechoAnimTable4:
+.4byte sChimechoAnims_4_1
+.4byte sChimechoAnims_4_2
+.4byte sChimechoAnims_4_3
+.4byte sChimechoAnims_4_4
+.4byte sChimechoAnims_4_5
+.4byte sChimechoAnims_4_6
+.4byte sChimechoAnims_4_7
+.4byte sChimechoAnims_4_8
+sChimechoAnimTable5:
+.4byte sChimechoAnims_5_1
+.4byte sChimechoAnims_5_2
+.4byte sChimechoAnims_5_3
+.4byte sChimechoAnims_5_4
+.4byte sChimechoAnims_5_5
+.4byte sChimechoAnims_5_6
+.4byte sChimechoAnims_5_7
+.4byte sChimechoAnims_5_8
+sChimechoAnimTable6:
+.4byte sChimechoAnims_6_1
+.4byte sChimechoAnims_6_1
+.4byte sChimechoAnims_6_1
+.4byte sChimechoAnims_6_1
+.4byte sChimechoAnims_6_1
+.4byte sChimechoAnims_6_1
+.4byte sChimechoAnims_6_1
+.4byte sChimechoAnims_6_1
+sChimechoAnimTable7:
+.4byte sChimechoAnims_7_1
+.4byte sChimechoAnims_7_2
+.4byte sChimechoAnims_7_3
+.4byte sChimechoAnims_7_4
+.4byte sChimechoAnims_7_5
+.4byte sChimechoAnims_7_6
+.4byte sChimechoAnims_7_7
+.4byte sChimechoAnims_7_8
+sChimechoAnimTable8:
+.4byte sChimechoAnims_8_1
+.4byte sChimechoAnims_8_2
+.4byte sChimechoAnims_8_3
+.4byte sChimechoAnims_8_4
+.4byte sChimechoAnims_8_5
+.4byte sChimechoAnims_8_6
+.4byte sChimechoAnims_8_7
+.4byte sChimechoAnims_8_8
+sChimechoAnimTable9:
+.4byte sChimechoAnims_9_1
+.4byte sChimechoAnims_9_2
+.4byte sChimechoAnims_9_3
+.4byte sChimechoAnims_9_4
+.4byte sChimechoAnims_9_5
+.4byte sChimechoAnims_9_6
+.4byte sChimechoAnims_9_7
+.4byte sChimechoAnims_9_8
+sChimechoAnimTable10:
+.4byte sChimechoAnims_10_1
+.4byte sChimechoAnims_10_2
+.4byte sChimechoAnims_10_3
+.4byte sChimechoAnims_10_4
+.4byte sChimechoAnims_10_5
+.4byte sChimechoAnims_10_6
+.4byte sChimechoAnims_10_7
+.4byte sChimechoAnims_10_8
+sChimechoAnimTable11:
+.4byte sChimechoAnims_11_1
+.4byte sChimechoAnims_11_2
+.4byte sChimechoAnims_11_3
+.4byte sChimechoAnims_11_4
+.4byte sChimechoAnims_11_5
+.4byte sChimechoAnims_11_6
+.4byte sChimechoAnims_11_7
+.4byte sChimechoAnims_11_8
+sChimechoAnimTable12:
+.4byte sChimechoAnims_12_1
+.4byte sChimechoAnims_12_2
+.4byte sChimechoAnims_12_3
+.4byte sChimechoAnims_12_4
+.4byte sChimechoAnims_12_5
+.4byte sChimechoAnims_12_6
+.4byte sChimechoAnims_12_7
+.4byte sChimechoAnims_12_8
+sChimechoAnimTable13:
+.4byte sChimechoAnims_13_1
+.4byte sChimechoAnims_13_2
+.4byte sChimechoAnims_13_3
+.4byte sChimechoAnims_13_4
+.4byte sChimechoAnims_13_5
+.4byte sChimechoAnims_13_6
+.4byte sChimechoAnims_13_7
+.4byte sChimechoAnims_13_8
+sAxAnimationsChimecho:
+.4byte sChimechoAnimTable1
+.4byte sChimechoAnimTable2
+.4byte sChimechoAnimTable3
+.4byte sChimechoAnimTable4
+.4byte sChimechoAnimTable5
+.4byte sChimechoAnimTable6
+.4byte sChimechoAnimTable7
+.4byte sChimechoAnimTable8
+.4byte sChimechoAnimTable9
+.4byte sChimechoAnimTable10
+.4byte sChimechoAnimTable11
+.4byte sChimechoAnimTable12
+.4byte sChimechoAnimTable13
+sAxSpritesChimecho:
+.4byte sChimechoSprites1
+.4byte sChimechoSprites2
+.4byte sChimechoSprites3
+.4byte sChimechoSprites4
+.4byte sChimechoSprites5
+.4byte sChimechoSprites6
+.4byte sChimechoSprites7
+.4byte sChimechoSprites8
+.4byte sChimechoSprites9
+.4byte sChimechoSprites10
+.4byte sChimechoSprites11
+.4byte sChimechoSprites12
+.4byte sChimechoSprites13
+.4byte sChimechoSprites14
+.4byte sChimechoSprites15
+.4byte sChimechoSprites16
+.4byte sChimechoSprites17
+.4byte sChimechoSprites18
+.4byte sChimechoSprites19
+.4byte sChimechoSprites20
+.4byte sChimechoSprites21
+.4byte sChimechoSprites22
+.4byte sChimechoSprites23
+.4byte sChimechoSprites24
+.4byte sChimechoSprites25
+.4byte sChimechoSprites26
+.4byte sChimechoSprites27
+.4byte sChimechoSprites28
+.4byte sChimechoSprites29
+.4byte sChimechoSprites30
+.4byte sChimechoSprites31
+.4byte sChimechoSprites32
+.4byte sChimechoSprites33
+.4byte sChimechoSprites34
+.4byte sChimechoSprites35
+.4byte sChimechoSprites36
+.4byte sChimechoSprites37
+.4byte sChimechoSprites38
+.4byte sChimechoSprites39
+.4byte sChimechoSprites40
+.4byte sChimechoSprites41
+.4byte sChimechoSprites42
+.4byte sChimechoSprites43
+.4byte sChimechoSprites44
+sAxMainChimecho:
+ax_main sAxPosesChimecho, sAxAnimationsChimecho, 13, sAxSpritesChimecho, sAxPositionsChimecho

--- a/data/ax/chinchou.inc
+++ b/data/ax/chinchou.inc
@@ -1,0 +1,2908 @@
+.global gAxChinchou
+gAxChinchou:
+ax_siro sAxMainChinchou
+sChinchouPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose4:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose5:
+ax_pose 4, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose6:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose7:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose8:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose9:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose10:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose11:
+ax_pose 10, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose12:
+ax_pose 11, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose16:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose17:
+ax_pose 10, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose18:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose22:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose23:
+ax_pose 4, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose24:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose28:
+ax_pose 15, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sChinchouPose29:
+ax_pose 16, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose30:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose31:
+ax_pose 4, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose32:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose33:
+ax_pose 17, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sChinchouPose34:
+ax_pose 18, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sChinchouPose35:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose36:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose37:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose38:
+ax_pose 19, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose39:
+ax_pose 20, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose40:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose41:
+ax_pose 10, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose42:
+ax_pose 11, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose43:
+ax_pose 21, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose44:
+ax_pose 22, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose45:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose46:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose47:
+ax_pose 14, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose48:
+ax_pose 23, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose49:
+ax_pose 24, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose50:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose51:
+ax_pose 10, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose52:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose53:
+ax_pose 21, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose54:
+ax_pose 22, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose55:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose56:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose57:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose58:
+ax_pose 19, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose59:
+ax_pose 20, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose60:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose61:
+ax_pose 4, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose62:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose63:
+ax_pose 17, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose64:
+ax_pose 18, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sChinchouPose65:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose66:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose67:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose68:
+ax_pose 15, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sChinchouPose69:
+ax_pose 16, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose70:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose71:
+ax_pose 4, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose72:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose73:
+ax_pose 17, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sChinchouPose74:
+ax_pose 18, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sChinchouPose75:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose76:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose77:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose78:
+ax_pose 19, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose79:
+ax_pose 20, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose80:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose81:
+ax_pose 10, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose82:
+ax_pose 11, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose83:
+ax_pose 21, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose84:
+ax_pose 22, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose85:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose86:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose87:
+ax_pose 14, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose88:
+ax_pose 23, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose89:
+ax_pose 24, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose90:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose91:
+ax_pose 10, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose92:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose93:
+ax_pose 21, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose94:
+ax_pose 22, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose95:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose96:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose97:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose98:
+ax_pose 19, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose99:
+ax_pose 20, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose100:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose101:
+ax_pose 4, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose102:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose103:
+ax_pose 17, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose104:
+ax_pose 18, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sChinchouPose105:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose106:
+ax_pose 16, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose107:
+ax_pose 25, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose108:
+ax_pose 26, 0x01ed, 0x80ef, 0x0c00
+ax_pose_terminator
+sChinchouPose109:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose110:
+ax_pose 18, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sChinchouPose111:
+ax_pose 27, 0x01ed, 0x90f5, 0x0c00
+ax_pose_terminator
+sChinchouPose112:
+ax_pose 28, 0x01ee, 0x90f3, 0x0c00
+ax_pose_terminator
+sChinchouPose113:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose114:
+ax_pose 20, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose115:
+ax_pose 29, 0x01ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sChinchouPose116:
+ax_pose 30, 0x01ec, 0x90f6, 0x0c00
+ax_pose_terminator
+sChinchouPose117:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose118:
+ax_pose 22, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose119:
+ax_pose 31, 0x01e2, 0x90f4, 0x0c00
+ax_pose_terminator
+sChinchouPose120:
+ax_pose 32, 0x01e4, 0x90f4, 0x0c00
+ax_pose_terminator
+sChinchouPose121:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose122:
+ax_pose 24, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose123:
+ax_pose 33, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose124:
+ax_pose 34, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose125:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose126:
+ax_pose 22, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose127:
+ax_pose 31, 0x01e2, 0x80eb, 0x0c00
+ax_pose_terminator
+sChinchouPose128:
+ax_pose 32, 0x01e4, 0x80eb, 0x0c00
+ax_pose_terminator
+sChinchouPose129:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose130:
+ax_pose 20, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose131:
+ax_pose 29, 0x01ea, 0x80e9, 0x0c00
+ax_pose_terminator
+sChinchouPose132:
+ax_pose 30, 0x01ec, 0x80ea, 0x0c00
+ax_pose_terminator
+sChinchouPose133:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose134:
+ax_pose 18, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sChinchouPose135:
+ax_pose 27, 0x01ed, 0x80eb, 0x0c00
+ax_pose_terminator
+sChinchouPose136:
+ax_pose 28, 0x01ee, 0x80ed, 0x0c00
+ax_pose_terminator
+sChinchouPose137:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose138:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose139:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose140:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose141:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose142:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose143:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose144:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose145:
+ax_pose 35, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose146:
+ax_pose 36, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose147:
+ax_pose 37, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose148:
+ax_pose 38, 0x01e3, 0x90ea, 0x0c00
+ax_pose_terminator
+sChinchouPose149:
+ax_pose 39, 0x01e3, 0x90e8, 0x0c00
+ax_pose_terminator
+sChinchouPose150:
+ax_pose 40, 0x01e4, 0x90ea, 0x0c00
+ax_pose_terminator
+sChinchouPose151:
+ax_pose 41, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose152:
+ax_pose 40, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sChinchouPose153:
+ax_pose 39, 0x01e3, 0x80f6, 0x0c00
+ax_pose_terminator
+sChinchouPose154:
+ax_pose 38, 0x01e3, 0x80f6, 0x0c00
+ax_pose_terminator
+sChinchouPose155:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose156:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose157:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose158:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose159:
+ax_pose 4, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose160:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose161:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose162:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose163:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose164:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose165:
+ax_pose 10, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose166:
+ax_pose 11, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose167:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose168:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose169:
+ax_pose 14, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose170:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose171:
+ax_pose 10, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose172:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose173:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose174:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose175:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose176:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose177:
+ax_pose 4, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose178:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose179:
+ax_pose 26, 0x01ed, 0x80ef, 0x0c00
+ax_pose_terminator
+sChinchouPose180:
+ax_pose 28, 0x01ee, 0x80ed, 0x0c00
+ax_pose_terminator
+sChinchouPose181:
+ax_pose 30, 0x01ed, 0x80eb, 0x0c00
+ax_pose_terminator
+sChinchouPose182:
+ax_pose 32, 0x01e7, 0x80eb, 0x0c00
+ax_pose_terminator
+sChinchouPose183:
+ax_pose 34, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose184:
+ax_pose 32, 0x01e7, 0x90f4, 0x0c00
+ax_pose_terminator
+sChinchouPose185:
+ax_pose 30, 0x01ed, 0x90f5, 0x0c00
+ax_pose_terminator
+sChinchouPose186:
+ax_pose 28, 0x01ee, 0x90f3, 0x0c00
+ax_pose_terminator
+sChinchouPose187:
+ax_pose 16, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose188:
+ax_pose 18, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sChinchouPose189:
+ax_pose 20, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose190:
+ax_pose 22, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose191:
+ax_pose 24, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose192:
+ax_pose 22, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose193:
+ax_pose 20, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose194:
+ax_pose 18, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sChinchouPose195:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose196:
+ax_pose 16, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose197:
+ax_pose 25, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose198:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sChinchouPose199:
+ax_pose 18, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sChinchouPose200:
+ax_pose 27, 0x01ed, 0x90f6, 0x0c00
+ax_pose_terminator
+sChinchouPose201:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose202:
+ax_pose 20, 0x01e3, 0x90ef, 0x0c00
+ax_pose_terminator
+sChinchouPose203:
+ax_pose 29, 0x01ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sChinchouPose204:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose205:
+ax_pose 22, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose206:
+ax_pose 31, 0x01e2, 0x90f5, 0x0c00
+ax_pose_terminator
+sChinchouPose207:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose208:
+ax_pose 24, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose209:
+ax_pose 33, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose210:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose211:
+ax_pose 22, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose212:
+ax_pose 31, 0x01e2, 0x80ea, 0x0c00
+ax_pose_terminator
+sChinchouPose213:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose214:
+ax_pose 20, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose215:
+ax_pose 29, 0x01ea, 0x80ea, 0x0c00
+ax_pose_terminator
+sChinchouPose216:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose217:
+ax_pose 18, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sChinchouPose218:
+ax_pose 27, 0x01ed, 0x80eb, 0x0c00
+ax_pose_terminator
+sChinchouPose219:
+ax_pose 15, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sChinchouPose220:
+ax_pose 17, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose221:
+ax_pose 19, 0x01ec, 0x80ee, 0x0c00
+ax_pose_terminator
+sChinchouPose222:
+ax_pose 21, 0x01ec, 0x80ee, 0x0c00
+ax_pose_terminator
+sChinchouPose223:
+ax_pose 23, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose224:
+ax_pose 21, 0x01ec, 0x90f2, 0x0c00
+ax_pose_terminator
+sChinchouPose225:
+ax_pose 19, 0x01ec, 0x90f2, 0x0c00
+ax_pose_terminator
+sChinchouPose226:
+ax_pose 17, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sChinchouPose227:
+ax_pose 19, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose228:
+ax_pose 21, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose229:
+ax_pose 23, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose230:
+ax_pose 21, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose231:
+ax_pose 19, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose232:
+ax_pose 17, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sChinchouPose233:
+ax_pose 17, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sChinchouPose234:
+ax_pose 19, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose235:
+ax_pose 21, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose236:
+ax_pose 23, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose237:
+ax_pose 21, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose238:
+ax_pose 19, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose239:
+ax_pose 17, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sChinchouPose240:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose241:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sChinchouPose242:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose243:
+ax_pose 9, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sChinchouPose244:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sChinchouPose245:
+ax_pose 9, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose246:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sChinchouPose247:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sChinchouAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 6, 0, 27, 0, -4, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 1, 28, 1, 21, 1, 21,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 0, 28, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sChinchouAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 32, -3, -3, -3, -3,
+ax_anim 6, 0, 32, -4, -4, -4, -4,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 21, 22, 21, 22,
+ax_anim 2, 1, 33, 22, 21, 22, 21,
+ax_anim 2, 0, 33, 21, 22, 21, 22,
+ax_anim 2, 0, 33, 22, 21, 22, 21,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sChinchouAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 2, 0, 37, -2, 0, -2, 0,
+ax_anim 6, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 21, 0, 21, 0,
+ax_anim 2, 1, 38, 21, 1, 21, 1,
+ax_anim 2, 0, 38, 21, 0, 21, 0,
+ax_anim 2, 0, 38, 21, 1, 21, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sChinchouAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 2, 0, 42, -2, 2, -2, 2,
+ax_anim 6, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, 5, -5, 5, -5,
+ax_anim 1, 0, 41, 11, -11, 11, -11,
+ax_anim 2, 0, 43, 20, -20, 20, -20,
+ax_anim 2, 1, 43, 21, -19, 21, -19,
+ax_anim 2, 0, 43, 20, -20, 20, -20,
+ax_anim 2, 0, 43, 21, -19, 21, -19,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sChinchouAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 2, 0, 47, 0, 2, 0, 2,
+ax_anim 6, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, -4,
+ax_anim 1, 0, 46, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 1, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 0, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sChinchouAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim 6, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 50, -5, -5, -5, -5,
+ax_anim 1, 0, 51, -11, -11, -11, -11,
+ax_anim 2, 0, 53, -20, -20, -20, -20,
+ax_anim 2, 1, 53, -21, -19, -21, -19,
+ax_anim 2, 0, 53, -20, -20, -20, -20,
+ax_anim 2, 0, 53, -21, -19, -21, -19,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sChinchouAnims_2_7:
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 2, 0, 57, 2, 0, 2, 0,
+ax_anim 6, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 56, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -21, 0, -21, 0,
+ax_anim 2, 1, 58, -21, 1, -21, 1,
+ax_anim 2, 0, 58, -21, 0, -21, 0,
+ax_anim 2, 0, 58, -21, 1, -21, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sChinchouAnims_2_8:
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 2, 0, 62, 3, -3, 3, -3,
+ax_anim 6, 0, 62, 4, -4, 4, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 61, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -21, 22, -21, 22,
+ax_anim 2, 1, 63, -22, 21, -22, 21,
+ax_anim 2, 0, 63, -21, 22, -21, 22,
+ax_anim 2, 0, 63, -22, 21, -22, 21,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sChinchouAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 2, 0, 67, 0, -2, 0, -2,
+ax_anim 6, 0, 67, 0, -4, 0, -3,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 21, 0, 21,
+ax_anim 2, 1, 68, 1, 21, 1, 21,
+ax_anim 2, 0, 68, 0, 21, 0, 21,
+ax_anim 2, 0, 68, 1, 21, 1, 21,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sChinchouAnims_3_2:
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 0, 72, -3, -3, -3, -3,
+ax_anim 6, 0, 72, -4, -4, -4, -4,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, 4, 4, 4,
+ax_anim 1, 0, 71, 10, 10, 10, 10,
+ax_anim 2, 0, 73, 21, 22, 21, 22,
+ax_anim 2, 1, 73, 22, 21, 22, 21,
+ax_anim 2, 0, 73, 21, 22, 21, 22,
+ax_anim 2, 0, 73, 22, 21, 22, 21,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sChinchouAnims_3_3:
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 77, -2, 0, -2, 0,
+ax_anim 6, 0, 77, -2, 0, -2, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 4, 0, 4, 0,
+ax_anim 1, 0, 76, 10, 0, 10, 0,
+ax_anim 2, 0, 78, 21, 0, 21, 0,
+ax_anim 2, 1, 78, 21, 1, 21, 1,
+ax_anim 2, 0, 78, 21, 0, 21, 0,
+ax_anim 2, 0, 78, 21, 1, 21, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sChinchouAnims_3_4:
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 0, 82, -2, 2, -2, 2,
+ax_anim 1, 0, 81, 0, -1, 0, -1,
+ax_anim 1, 2, 80, 5, -5, 5, -5,
+ax_anim 1, 0, 81, 11, -11, 11, -11,
+ax_anim 2, 0, 83, 20, -20, 20, -20,
+ax_anim 2, 1, 83, 21, -19, 21, -19,
+ax_anim 2, 0, 83, 20, -20, 20, -20,
+ax_anim 2, 0, 83, 21, -19, 21, -19,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sChinchouAnims_3_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 0, 87, 0, 2, 0, 2,
+ax_anim 6, 0, 87, 0, 2, 0, 2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, 0, -4, 0, -4,
+ax_anim 1, 0, 86, 0, -11, 0, -11,
+ax_anim 2, 0, 88, 0, -21, 0, -21,
+ax_anim 2, 1, 88, 1, -21, 1, -21,
+ax_anim 2, 0, 88, 0, -21, 0, -21,
+ax_anim 2, 0, 88, 1, -21, 1, -21,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sChinchouAnims_3_6:
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 6, 0, 92, 2, 2, 2, 2,
+ax_anim 1, 0, 91, 0, -1, 0, -1,
+ax_anim 1, 2, 90, -5, -5, -5, -5,
+ax_anim 1, 0, 91, -11, -11, -11, -11,
+ax_anim 2, 0, 93, -20, -20, -20, -20,
+ax_anim 2, 1, 93, -21, -19, -21, -19,
+ax_anim 2, 0, 93, -20, -20, -20, -20,
+ax_anim 2, 0, 93, -21, -19, -21, -19,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sChinchouAnims_3_7:
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 6, 0, 97, 2, 0, 2, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 95, -4, 0, -4, 0,
+ax_anim 1, 0, 96, -10, 0, -10, 0,
+ax_anim 2, 0, 98, -21, 0, -21, 0,
+ax_anim 2, 1, 98, -21, 1, -21, 1,
+ax_anim 2, 0, 98, -21, 0, -21, 0,
+ax_anim 2, 0, 98, -21, 1, -21, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sChinchouAnims_3_8:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 102, 3, -3, 3, -3,
+ax_anim 6, 0, 102, 4, -4, 4, -4,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 100, -4, 4, -4, 4,
+ax_anim 1, 0, 101, -10, 10, -10, 10,
+ax_anim 2, 0, 103, -21, 22, -21, 22,
+ax_anim 2, 1, 103, -22, 21, -22, 21,
+ax_anim 2, 0, 103, -21, 22, -21, 22,
+ax_anim 2, 0, 103, -22, 21, -22, 21,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sChinchouAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 6, 2, 105, 0, -4, 0, -4,
+ax_anim 1, 0, 105, 0, -1, 0, -1,
+ax_anim 1, 0, 105, 0, 5, 0, 5,
+ax_anim 2, 1, 106, 0, 8, 0, 8,
+ax_anim 2, 0, 107, 0, 8, 0, 8,
+ax_anim 2, 0, 106, 0, 8, 0, 8,
+ax_anim 2, 0, 107, 0, 8, 0, 8,
+ax_anim 2, 0, 106, 0, 8, 0, 8,
+ax_anim 2, 0, 107, 0, 8, 0, 8,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim_terminator
+sChinchouAnims_4_2:
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 109, -3, -3, -3, -3,
+ax_anim 6, 2, 109, -4, -4, -4, -4,
+ax_anim 1, 0, 109, 0, -1, 0, -1,
+ax_anim 1, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 1, 110, 8, 8, 8, 8,
+ax_anim 2, 0, 111, 8, 8, 8, 8,
+ax_anim 2, 0, 110, 8, 8, 8, 8,
+ax_anim 2, 0, 111, 8, 8, 8, 8,
+ax_anim 2, 0, 110, 8, 8, 8, 8,
+ax_anim 2, 0, 111, 8, 8, 8, 8,
+ax_anim 2, 0, 108, 3, 3, 3, 3,
+ax_anim_terminator
+sChinchouAnims_4_3:
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 6, 2, 113, -4, 0, -4, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 5, 0, 5, 0,
+ax_anim 2, 1, 114, 8, 0, 8, 0,
+ax_anim 2, 0, 115, 8, 0, 8, 0,
+ax_anim 2, 0, 114, 8, 0, 8, 0,
+ax_anim 2, 0, 115, 8, 0, 8, 0,
+ax_anim 2, 0, 114, 8, 0, 8, 0,
+ax_anim 2, 0, 115, 8, 0, 8, 0,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sChinchouAnims_4_4:
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim 2, 0, 117, -3, 3, -3, 3,
+ax_anim 6, 2, 117, -4, 4, -4, 4,
+ax_anim 1, 0, 117, 0, 1, 0, 1,
+ax_anim 1, 0, 117, 5, -5, 5, -5,
+ax_anim 2, 1, 118, 8, -8, 8, -8,
+ax_anim 2, 0, 119, 8, -8, 8, -8,
+ax_anim 2, 0, 118, 8, -8, 8, -8,
+ax_anim 2, 0, 119, 8, -8, 8, -8,
+ax_anim 2, 0, 118, 8, -8, 8, -8,
+ax_anim 2, 0, 119, 8, -8, 8, -8,
+ax_anim 2, 0, 116, 3, -3, 3, -3,
+ax_anim_terminator
+sChinchouAnims_4_5:
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 121, 0, 3, 0, 3,
+ax_anim 6, 2, 121, 0, 4, 0, 4,
+ax_anim 1, 0, 121, 0, 1, 0, 1,
+ax_anim 1, 0, 121, 0, -5, 0, -5,
+ax_anim 2, 1, 122, 0, -8, 0, -8,
+ax_anim 2, 0, 123, 0, -8, 0, -8,
+ax_anim 2, 0, 122, 0, -8, 0, -8,
+ax_anim 2, 0, 123, 0, -8, 0, -8,
+ax_anim 2, 0, 122, 0, -8, 0, -8,
+ax_anim 2, 0, 123, 0, -8, 0, -8,
+ax_anim 2, 0, 120, 0, -3, 0, -3,
+ax_anim_terminator
+sChinchouAnims_4_6:
+ax_anim 2, 0, 124, 1, 1, 1, 1,
+ax_anim 2, 0, 125, 3, 3, 3, 3,
+ax_anim 6, 2, 125, 4, 4, 4, 4,
+ax_anim 1, 0, 125, 0, 1, 0, 1,
+ax_anim 1, 0, 125, -5, -5, -5, -5,
+ax_anim 2, 1, 126, -8, -8, -8, -8,
+ax_anim 2, 0, 127, -8, -8, -8, -8,
+ax_anim 2, 0, 126, -8, -8, -8, -8,
+ax_anim 2, 0, 127, -8, -8, -8, -8,
+ax_anim 2, 0, 126, -8, -8, -8, -8,
+ax_anim 2, 0, 127, -8, -8, -8, -8,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim_terminator
+sChinchouAnims_4_7:
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 3, 0, 3, 0,
+ax_anim 6, 2, 129, 4, 0, 4, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 129, -5, 0, -5, 0,
+ax_anim 2, 1, 130, -8, 0, -8, 0,
+ax_anim 2, 0, 131, -8, 0, -8, 0,
+ax_anim 2, 0, 130, -8, 0, -8, 0,
+ax_anim 2, 0, 131, -8, 0, -8, 0,
+ax_anim 2, 0, 130, -8, 0, -8, 0,
+ax_anim 2, 0, 131, -8, 0, -8, 0,
+ax_anim 2, 0, 128, -3, 0, -3, 0,
+ax_anim_terminator
+sChinchouAnims_4_8:
+ax_anim 2, 0, 132, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 3, -3, 3, -3,
+ax_anim 6, 2, 133, 4, -4, 4, -4,
+ax_anim 1, 0, 133, 0, -1, 0, -1,
+ax_anim 1, 0, 133, -5, 5, -5, 5,
+ax_anim 2, 1, 134, -8, 8, -8, 8,
+ax_anim 2, 0, 135, -8, 8, -8, 8,
+ax_anim 2, 0, 134, -8, 8, -8, 8,
+ax_anim 2, 0, 135, -8, 8, -8, 8,
+ax_anim 2, 0, 134, -8, 8, -8, 8,
+ax_anim 2, 0, 135, -8, 8, -8, 8,
+ax_anim 2, 0, 132, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sChinchouAnims_5_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_5_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_5_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_5_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_6_1:
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, -1, 0, 0,
+ax_anim 8, 0, 144, 0, -2, 0, 0,
+ax_anim 16, 0, 144, 0, -3, 0, 0,
+ax_anim 8, 0, 145, 0, -3, 0, 0,
+ax_anim 8, 0, 145, 0, -2, 0, 0,
+ax_anim 8, 0, 145, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sChinchouAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sChinchouAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sChinchouAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sChinchouAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sChinchouAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sChinchouAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sChinchouAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sChinchouAnims_8_1:
+ax_anim 14, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, -1, 0, 0,
+ax_anim 14, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_8_2:
+ax_anim 14, 0, 157, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, -1, 0, 0,
+ax_anim 14, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_8_3:
+ax_anim 14, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 14, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_8_4:
+ax_anim 14, 0, 163, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, -1, 0, 0,
+ax_anim 12, 0, 164, 0, -1, 0, 0,
+ax_anim 14, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_8_5:
+ax_anim 14, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, -1, 0, 0,
+ax_anim 12, 0, 167, 0, -1, 0, 0,
+ax_anim 14, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_8_6:
+ax_anim 14, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, -1, 0, 0,
+ax_anim 12, 0, 170, 0, -1, 0, 0,
+ax_anim 14, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_8_7:
+ax_anim 14, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 172, 0, -1, 0, 0,
+ax_anim 12, 0, 173, 0, -1, 0, 0,
+ax_anim 14, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_8_8:
+ax_anim 14, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 12, 0, 175, 0, -1, 0, 0,
+ax_anim 12, 0, 176, 0, -1, 0, 0,
+ax_anim 14, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 12, 8, 12,
+ax_anim 2, 0, 181, 7, 18, 7, 18,
+ax_anim 3, 0, 182, 0, 21, 0, 21,
+ax_anim 2, 3, 183, -7, 18, -7, 18,
+ax_anim 2, 0, 184, -8, 12, -8, 12,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 2, 8, 2,
+ax_anim 2, 0, 179, 20, 11, 20, 11,
+ax_anim 2, 0, 180, 24, 18, 24, 18,
+ax_anim 3, 0, 181, 21, 21, 21, 21,
+ax_anim 2, 3, 182, 12, 21, 12, 21,
+ax_anim 2, 0, 183, 5, 15, 5, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 21, 0, 21, 0,
+ax_anim 2, 3, 181, 19, 4, 19, 4,
+ax_anim 2, 0, 182, 10, 6, 10, 6,
+ax_anim 1, 0, 183, 4, 3, 4, 3,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 3, -8, 3, -8,
+ax_anim 2, 0, 185, 7, -16, 7, -16,
+ax_anim 2, 0, 178, 15, -22, 15, -22,
+ax_anim 3, 0, 179, 21, -23, 21, -23,
+ax_anim 2, 3, 180, 22, -13, 22, -13,
+ax_anim 2, 0, 181, 18, -8, 18, -8,
+ax_anim 1, 0, 182, 7, -2, 7, -2,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -4, -3, -4, -3,
+ax_anim 2, 0, 184, -9, -10, -9, -10,
+ax_anim 2, 0, 185, -8, -18, -8, -18,
+ax_anim 3, 0, 178, 0, -23, 0, -23,
+ax_anim 2, 3, 179, 8, -18, 8, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 4, -3, 4, -3,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -3, -8, -3, -8,
+ax_anim 2, 0, 179, -7, -16, -7, -16,
+ax_anim 2, 0, 178, -15, -22, -15, -22,
+ax_anim 3, 0, 185, -21, -23, -21, -23,
+ax_anim 2, 3, 184, -22, -13, -22, -13,
+ax_anim 2, 0, 183, -18, -8, -18, -8,
+ax_anim 1, 0, 182, -7, -2, -7, -2,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -5, -11, -5,
+ax_anim 2, 0, 185, -17, -4, -17, -4,
+ax_anim 3, 0, 184, -21, 0, -21, 0,
+ax_anim 2, 3, 183, -19, 4, -19, 4,
+ax_anim 2, 0, 182, -10, 6, -10, 6,
+ax_anim 1, 0, 181, -4, 3, -4, 3,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 2, -8, 2,
+ax_anim 2, 0, 185, -20, 11, -20, 11,
+ax_anim 2, 0, 184, -24, 18, -24, 18,
+ax_anim 3, 0, 183, -21, 21, -21, 21,
+ax_anim 2, 3, 182, -12, 21, -12, 21,
+ax_anim 2, 0, 181, -5, 15, -5, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 2, 0, 0,
+ax_anim_terminator
+sChinchouAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 2, 0, 0,
+ax_anim_terminator
+sChinchouAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 2, 0, 0,
+ax_anim_terminator
+sChinchouAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 2, 0, 0,
+ax_anim_terminator
+sChinchouAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 2, 0, 0,
+ax_anim_terminator
+sChinchouAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 2, 0, 0,
+ax_anim_terminator
+sChinchouAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 2, 0, 0,
+ax_anim_terminator
+sChinchouAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sChinchouAnims_13_1:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_13_2:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_13_3:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_13_4:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_13_5:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_13_6:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_13_7:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouAnims_13_8:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sChinchouGfx1:
+.incbin "baserom.gba", 0xC70494, 0x200
+sChinchouSprites1:
+ax_sprite sChinchouGfx1, 0x200
+ax_sprite_terminator
+sChinchouGfx2:
+.incbin "baserom.gba", 0xC706A4, 0x200
+sChinchouSprites2:
+ax_sprite sChinchouGfx2, 0x200
+ax_sprite_terminator
+sChinchouGfx3:
+.incbin "baserom.gba", 0xC708B4, 0x200
+sChinchouSprites3:
+ax_sprite sChinchouGfx3, 0x200
+ax_sprite_terminator
+sChinchouGfx4:
+.incbin "baserom.gba", 0xC70AC4, 0x200
+sChinchouSprites4:
+ax_sprite sChinchouGfx4, 0x200
+ax_sprite_terminator
+sChinchouGfx5:
+.incbin "baserom.gba", 0xC70CD4, 0x200
+sChinchouSprites5:
+ax_sprite sChinchouGfx5, 0x200
+ax_sprite_terminator
+sChinchouGfx6:
+.incbin "baserom.gba", 0xC70EE4, 0x200
+sChinchouSprites6:
+ax_sprite sChinchouGfx6, 0x200
+ax_sprite_terminator
+sChinchouGfx7:
+.incbin "baserom.gba", 0xC710F4, 0x200
+sChinchouSprites7:
+ax_sprite sChinchouGfx7, 0x200
+ax_sprite_terminator
+sChinchouGfx8:
+.incbin "baserom.gba", 0xC71304, 0x200
+sChinchouSprites8:
+ax_sprite sChinchouGfx8, 0x200
+ax_sprite_terminator
+sChinchouGfx9:
+.incbin "baserom.gba", 0xC71514, 0x200
+sChinchouSprites9:
+ax_sprite sChinchouGfx9, 0x200
+ax_sprite_terminator
+sChinchouGfx10:
+.incbin "baserom.gba", 0xC71724, 0x200
+sChinchouSprites10:
+ax_sprite sChinchouGfx10, 0x200
+ax_sprite_terminator
+sChinchouGfx11:
+.incbin "baserom.gba", 0xC71934, 0x200
+sChinchouSprites11:
+ax_sprite sChinchouGfx11, 0x200
+ax_sprite_terminator
+sChinchouGfx12:
+.incbin "baserom.gba", 0xC71B44, 0x200
+sChinchouSprites12:
+ax_sprite sChinchouGfx12, 0x200
+ax_sprite_terminator
+sChinchouGfx13:
+.incbin "baserom.gba", 0xC71D54, 0x200
+sChinchouSprites13:
+ax_sprite sChinchouGfx13, 0x200
+ax_sprite_terminator
+sChinchouGfx14:
+.incbin "baserom.gba", 0xC71F64, 0x200
+sChinchouSprites14:
+ax_sprite sChinchouGfx14, 0x200
+ax_sprite_terminator
+sChinchouGfx15:
+.incbin "baserom.gba", 0xC72174, 0x200
+sChinchouSprites15:
+ax_sprite sChinchouGfx15, 0x200
+ax_sprite_terminator
+sChinchouGfx16:
+.incbin "baserom.gba", 0xC72384, 0x60
+sChinchouGfx16_1:
+.incbin "baserom.gba", 0xC723E4, 0x120
+sChinchouGfx16_2:
+.incbin "baserom.gba", 0xC72504, 0x20
+sChinchouSprites16:
+ax_sprite sChinchouGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx16_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx16_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx17:
+.incbin "baserom.gba", 0xC7255C, 0x180
+sChinchouGfx17_1:
+.incbin "baserom.gba", 0xC726DC, 0x40
+sChinchouSprites17:
+ax_sprite sChinchouGfx17, 0x180
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx18:
+.incbin "baserom.gba", 0xC72744, 0x60
+sChinchouGfx18_1:
+.incbin "baserom.gba", 0xC727A4, 0x60
+sChinchouGfx18_2:
+.incbin "baserom.gba", 0xC72804, 0x60
+sChinchouGfx18_3:
+.incbin "baserom.gba", 0xC72864, 0x20
+sChinchouSprites18:
+ax_sprite sChinchouGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sChinchouGfx19:
+.incbin "baserom.gba", 0xC728CC, 0x60
+sChinchouGfx19_1:
+.incbin "baserom.gba", 0xC7292C, 0x60
+sChinchouGfx19_2:
+.incbin "baserom.gba", 0xC7298C, 0x60
+sChinchouGfx19_3:
+.incbin "baserom.gba", 0xC729EC, 0x20
+sChinchouSprites19:
+ax_sprite sChinchouGfx19, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx19_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx20:
+.incbin "baserom.gba", 0xC72A54, 0x60
+sChinchouGfx20_1:
+.incbin "baserom.gba", 0xC72AB4, 0x100
+sChinchouSprites20:
+ax_sprite sChinchouGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChinchouGfx21:
+.incbin "baserom.gba", 0xC72BDC, 0x40
+sChinchouGfx21_1:
+.incbin "baserom.gba", 0xC72C1C, 0x60
+sChinchouGfx21_2:
+.incbin "baserom.gba", 0xC72C7C, 0x40
+sChinchouGfx21_3:
+.incbin "baserom.gba", 0xC72CBC, 0x40
+sChinchouSprites21:
+ax_sprite sChinchouGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx21_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx22:
+.incbin "baserom.gba", 0xC72D44, 0x60
+sChinchouGfx22_1:
+.incbin "baserom.gba", 0xC72DA4, 0x100
+sChinchouSprites22:
+ax_sprite sChinchouGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx22_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChinchouGfx23:
+.incbin "baserom.gba", 0xC72ECC, 0x60
+sChinchouGfx23_1:
+.incbin "baserom.gba", 0xC72F2C, 0x60
+sChinchouGfx23_2:
+.incbin "baserom.gba", 0xC72F8C, 0x60
+sChinchouGfx23_3:
+.incbin "baserom.gba", 0xC72FEC, 0x40
+sChinchouSprites23:
+ax_sprite sChinchouGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx24:
+.incbin "baserom.gba", 0xC73074, 0x60
+sChinchouGfx24_1:
+.incbin "baserom.gba", 0xC730D4, 0x60
+sChinchouGfx24_2:
+.incbin "baserom.gba", 0xC73134, 0x60
+sChinchouSprites24:
+ax_sprite sChinchouGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sChinchouGfx25:
+.incbin "baserom.gba", 0xC731CC, 0x80
+sChinchouGfx25_1:
+.incbin "baserom.gba", 0xC7324C, 0x40
+sChinchouGfx25_2:
+.incbin "baserom.gba", 0xC7328C, 0x80
+sChinchouGfx25_3:
+.incbin "baserom.gba", 0xC7330C, 0x40
+sChinchouSprites25:
+ax_sprite sChinchouGfx25, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx26:
+.incbin "baserom.gba", 0xC73394, 0x40
+sChinchouGfx26_1:
+.incbin "baserom.gba", 0xC733D4, 0x100
+sChinchouSprites26:
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx26_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChinchouGfx27:
+.incbin "baserom.gba", 0xC73504, 0x40
+sChinchouGfx27_1:
+.incbin "baserom.gba", 0xC73544, 0x100
+sChinchouGfx27_2:
+.incbin "baserom.gba", 0xC73644, 0x40
+sChinchouSprites27:
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx28:
+.incbin "baserom.gba", 0xC736C4, 0x160
+sChinchouSprites28:
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx28, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChinchouGfx29:
+.incbin "baserom.gba", 0xC73844, 0xE0
+sChinchouGfx29_1:
+.incbin "baserom.gba", 0xC73924, 0x60
+sChinchouSprites29:
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx29, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx29_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChinchouGfx30:
+.incbin "baserom.gba", 0xC739B4, 0x100
+sChinchouGfx30_1:
+.incbin "baserom.gba", 0xC73AB4, 0x60
+sChinchouSprites30:
+ax_sprite sChinchouGfx30, 0x100
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx30_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChinchouGfx31:
+.incbin "baserom.gba", 0xC73B3C, 0x100
+sChinchouGfx31_1:
+.incbin "baserom.gba", 0xC73C3C, 0x60
+sChinchouSprites31:
+ax_sprite sChinchouGfx31, 0x100
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx31_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sChinchouGfx32:
+.incbin "baserom.gba", 0xC73CC4, 0x40
+sChinchouGfx32_1:
+.incbin "baserom.gba", 0xC73D04, 0x80
+sChinchouGfx32_2:
+.incbin "baserom.gba", 0xC73D84, 0x60
+sChinchouGfx32_3:
+.incbin "baserom.gba", 0xC73DE4, 0x60
+sChinchouSprites32:
+ax_sprite sChinchouGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx32_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx32_3, 0x60
+ax_sprite_terminator
+sChinchouGfx33:
+.incbin "baserom.gba", 0xC73E84, 0x60
+sChinchouGfx33_1:
+.incbin "baserom.gba", 0xC73EE4, 0x80
+sChinchouGfx33_2:
+.incbin "baserom.gba", 0xC73F64, 0x60
+sChinchouGfx33_3:
+.incbin "baserom.gba", 0xC73FC4, 0x60
+sChinchouSprites33:
+ax_sprite sChinchouGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx33_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx33_3, 0x60
+ax_sprite_terminator
+sChinchouGfx34:
+.incbin "baserom.gba", 0xC74064, 0x40
+sChinchouGfx34_1:
+.incbin "baserom.gba", 0xC740A4, 0x40
+sChinchouGfx34_2:
+.incbin "baserom.gba", 0xC740E4, 0xE0
+sChinchouSprites34:
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx34_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx35:
+.incbin "baserom.gba", 0xC74204, 0x40
+sChinchouGfx35_1:
+.incbin "baserom.gba", 0xC74244, 0x40
+sChinchouGfx35_2:
+.incbin "baserom.gba", 0xC74284, 0x80
+sChinchouGfx35_3:
+.incbin "baserom.gba", 0xC74304, 0x40
+sChinchouSprites35:
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sChinchouGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx35_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sChinchouGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sChinchouGfx36:
+.incbin "baserom.gba", 0xC74394, 0x200
+sChinchouSprites36:
+ax_sprite sChinchouGfx36, 0x200
+ax_sprite_terminator
+sChinchouGfx37:
+.incbin "baserom.gba", 0xC745A4, 0x200
+sChinchouSprites37:
+ax_sprite sChinchouGfx37, 0x200
+ax_sprite_terminator
+sChinchouGfx38:
+.incbin "baserom.gba", 0xC747B4, 0x200
+sChinchouSprites38:
+ax_sprite sChinchouGfx38, 0x200
+ax_sprite_terminator
+sChinchouGfx39:
+.incbin "baserom.gba", 0xC749C4, 0x200
+sChinchouSprites39:
+ax_sprite sChinchouGfx39, 0x200
+ax_sprite_terminator
+sChinchouGfx40:
+.incbin "baserom.gba", 0xC74BD4, 0x200
+sChinchouSprites40:
+ax_sprite sChinchouGfx40, 0x200
+ax_sprite_terminator
+sChinchouGfx41:
+.incbin "baserom.gba", 0xC74DE4, 0x200
+sChinchouSprites41:
+ax_sprite sChinchouGfx41, 0x200
+ax_sprite_terminator
+sChinchouGfx42:
+.incbin "baserom.gba", 0xC74FF4, 0x200
+sChinchouSprites42:
+ax_sprite sChinchouGfx42, 0x200
+ax_sprite_terminator
+sAxPosesChinchou:
+.4byte sChinchouPose1
+.4byte sChinchouPose2
+.4byte sChinchouPose3
+.4byte sChinchouPose4
+.4byte sChinchouPose5
+.4byte sChinchouPose6
+.4byte sChinchouPose7
+.4byte sChinchouPose8
+.4byte sChinchouPose9
+.4byte sChinchouPose10
+.4byte sChinchouPose11
+.4byte sChinchouPose12
+.4byte sChinchouPose13
+.4byte sChinchouPose14
+.4byte sChinchouPose15
+.4byte sChinchouPose16
+.4byte sChinchouPose17
+.4byte sChinchouPose18
+.4byte sChinchouPose19
+.4byte sChinchouPose20
+.4byte sChinchouPose21
+.4byte sChinchouPose22
+.4byte sChinchouPose23
+.4byte sChinchouPose24
+.4byte sChinchouPose25
+.4byte sChinchouPose26
+.4byte sChinchouPose27
+.4byte sChinchouPose28
+.4byte sChinchouPose29
+.4byte sChinchouPose30
+.4byte sChinchouPose31
+.4byte sChinchouPose32
+.4byte sChinchouPose33
+.4byte sChinchouPose34
+.4byte sChinchouPose35
+.4byte sChinchouPose36
+.4byte sChinchouPose37
+.4byte sChinchouPose38
+.4byte sChinchouPose39
+.4byte sChinchouPose40
+.4byte sChinchouPose41
+.4byte sChinchouPose42
+.4byte sChinchouPose43
+.4byte sChinchouPose44
+.4byte sChinchouPose45
+.4byte sChinchouPose46
+.4byte sChinchouPose47
+.4byte sChinchouPose48
+.4byte sChinchouPose49
+.4byte sChinchouPose50
+.4byte sChinchouPose51
+.4byte sChinchouPose52
+.4byte sChinchouPose53
+.4byte sChinchouPose54
+.4byte sChinchouPose55
+.4byte sChinchouPose56
+.4byte sChinchouPose57
+.4byte sChinchouPose58
+.4byte sChinchouPose59
+.4byte sChinchouPose60
+.4byte sChinchouPose61
+.4byte sChinchouPose62
+.4byte sChinchouPose63
+.4byte sChinchouPose64
+.4byte sChinchouPose65
+.4byte sChinchouPose66
+.4byte sChinchouPose67
+.4byte sChinchouPose68
+.4byte sChinchouPose69
+.4byte sChinchouPose70
+.4byte sChinchouPose71
+.4byte sChinchouPose72
+.4byte sChinchouPose73
+.4byte sChinchouPose74
+.4byte sChinchouPose75
+.4byte sChinchouPose76
+.4byte sChinchouPose77
+.4byte sChinchouPose78
+.4byte sChinchouPose79
+.4byte sChinchouPose80
+.4byte sChinchouPose81
+.4byte sChinchouPose82
+.4byte sChinchouPose83
+.4byte sChinchouPose84
+.4byte sChinchouPose85
+.4byte sChinchouPose86
+.4byte sChinchouPose87
+.4byte sChinchouPose88
+.4byte sChinchouPose89
+.4byte sChinchouPose90
+.4byte sChinchouPose91
+.4byte sChinchouPose92
+.4byte sChinchouPose93
+.4byte sChinchouPose94
+.4byte sChinchouPose95
+.4byte sChinchouPose96
+.4byte sChinchouPose97
+.4byte sChinchouPose98
+.4byte sChinchouPose99
+.4byte sChinchouPose100
+.4byte sChinchouPose101
+.4byte sChinchouPose102
+.4byte sChinchouPose103
+.4byte sChinchouPose104
+.4byte sChinchouPose105
+.4byte sChinchouPose106
+.4byte sChinchouPose107
+.4byte sChinchouPose108
+.4byte sChinchouPose109
+.4byte sChinchouPose110
+.4byte sChinchouPose111
+.4byte sChinchouPose112
+.4byte sChinchouPose113
+.4byte sChinchouPose114
+.4byte sChinchouPose115
+.4byte sChinchouPose116
+.4byte sChinchouPose117
+.4byte sChinchouPose118
+.4byte sChinchouPose119
+.4byte sChinchouPose120
+.4byte sChinchouPose121
+.4byte sChinchouPose122
+.4byte sChinchouPose123
+.4byte sChinchouPose124
+.4byte sChinchouPose125
+.4byte sChinchouPose126
+.4byte sChinchouPose127
+.4byte sChinchouPose128
+.4byte sChinchouPose129
+.4byte sChinchouPose130
+.4byte sChinchouPose131
+.4byte sChinchouPose132
+.4byte sChinchouPose133
+.4byte sChinchouPose134
+.4byte sChinchouPose135
+.4byte sChinchouPose136
+.4byte sChinchouPose137
+.4byte sChinchouPose138
+.4byte sChinchouPose139
+.4byte sChinchouPose140
+.4byte sChinchouPose141
+.4byte sChinchouPose142
+.4byte sChinchouPose143
+.4byte sChinchouPose144
+.4byte sChinchouPose145
+.4byte sChinchouPose146
+.4byte sChinchouPose147
+.4byte sChinchouPose148
+.4byte sChinchouPose149
+.4byte sChinchouPose150
+.4byte sChinchouPose151
+.4byte sChinchouPose152
+.4byte sChinchouPose153
+.4byte sChinchouPose154
+.4byte sChinchouPose155
+.4byte sChinchouPose156
+.4byte sChinchouPose157
+.4byte sChinchouPose158
+.4byte sChinchouPose159
+.4byte sChinchouPose160
+.4byte sChinchouPose161
+.4byte sChinchouPose162
+.4byte sChinchouPose163
+.4byte sChinchouPose164
+.4byte sChinchouPose165
+.4byte sChinchouPose166
+.4byte sChinchouPose167
+.4byte sChinchouPose168
+.4byte sChinchouPose169
+.4byte sChinchouPose170
+.4byte sChinchouPose171
+.4byte sChinchouPose172
+.4byte sChinchouPose173
+.4byte sChinchouPose174
+.4byte sChinchouPose175
+.4byte sChinchouPose176
+.4byte sChinchouPose177
+.4byte sChinchouPose178
+.4byte sChinchouPose179
+.4byte sChinchouPose180
+.4byte sChinchouPose181
+.4byte sChinchouPose182
+.4byte sChinchouPose183
+.4byte sChinchouPose184
+.4byte sChinchouPose185
+.4byte sChinchouPose186
+.4byte sChinchouPose187
+.4byte sChinchouPose188
+.4byte sChinchouPose189
+.4byte sChinchouPose190
+.4byte sChinchouPose191
+.4byte sChinchouPose192
+.4byte sChinchouPose193
+.4byte sChinchouPose194
+.4byte sChinchouPose195
+.4byte sChinchouPose196
+.4byte sChinchouPose197
+.4byte sChinchouPose198
+.4byte sChinchouPose199
+.4byte sChinchouPose200
+.4byte sChinchouPose201
+.4byte sChinchouPose202
+.4byte sChinchouPose203
+.4byte sChinchouPose204
+.4byte sChinchouPose205
+.4byte sChinchouPose206
+.4byte sChinchouPose207
+.4byte sChinchouPose208
+.4byte sChinchouPose209
+.4byte sChinchouPose210
+.4byte sChinchouPose211
+.4byte sChinchouPose212
+.4byte sChinchouPose213
+.4byte sChinchouPose214
+.4byte sChinchouPose215
+.4byte sChinchouPose216
+.4byte sChinchouPose217
+.4byte sChinchouPose218
+.4byte sChinchouPose219
+.4byte sChinchouPose220
+.4byte sChinchouPose221
+.4byte sChinchouPose222
+.4byte sChinchouPose223
+.4byte sChinchouPose224
+.4byte sChinchouPose225
+.4byte sChinchouPose226
+.4byte sChinchouPose227
+.4byte sChinchouPose228
+.4byte sChinchouPose229
+.4byte sChinchouPose230
+.4byte sChinchouPose231
+.4byte sChinchouPose232
+.4byte sChinchouPose233
+.4byte sChinchouPose234
+.4byte sChinchouPose235
+.4byte sChinchouPose236
+.4byte sChinchouPose237
+.4byte sChinchouPose238
+.4byte sChinchouPose239
+.4byte sChinchouPose240
+.4byte sChinchouPose241
+.4byte sChinchouPose242
+.4byte sChinchouPose243
+.4byte sChinchouPose244
+.4byte sChinchouPose245
+.4byte sChinchouPose246
+.4byte sChinchouPose247
+sAxPositionsChinchou:
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -9,   -8, 	   8,   -8, 	   0,   -6
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+.2byte    4,   -4, 	   6,  -12, 	  -8,   -4, 	  -1,   -7
+.2byte    4,   -6, 	   7,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -3, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -8, 	  -2,   -2, 	  -1,   -8
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    1,   -8, 	  -7,  -12, 	   7,   -4, 	  -1,   -7
+.2byte    2,   -9, 	  -8,  -10, 	   7,   -4, 	  -1,   -9
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -7, 	   0,   -7
+.2byte    0,   -9, 	   8,   -6, 	  -9,   -6, 	  -1,   -9
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -2,   -8, 	   6,  -12, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -9
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -3, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -5,   -4, 	  -7,  -12, 	   7,   -4, 	   0,   -7
+.2byte   -5,   -6, 	  -8,  -11, 	   6,   -4, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -9,   -8, 	   8,   -8, 	   0,   -6
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte   -1,   -2, 	 -12,   -5, 	  11,   -5, 	   0,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	  10,  -10, 	  -1,   -8
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+.2byte    4,   -4, 	   6,  -12, 	  -8,   -4, 	  -1,   -7
+.2byte    4,   -6, 	   7,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    4,   -2, 	   6,   -5, 	  -7,   -2, 	   0,   -7
+.2byte    5,   -8, 	   2,  -13, 	  -8,   -9, 	  -1,   -9
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -3, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -8, 	  -2,   -2, 	  -1,   -8
+.2byte    2,   -2, 	  -3,   -7, 	  -5,   -5, 	  -1,   -7
+.2byte    5,   -6, 	  -2,  -12, 	  -4,   -9, 	  -1,   -8
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    1,   -8, 	  -7,  -12, 	   7,   -4, 	  -1,   -7
+.2byte    2,   -9, 	  -8,  -10, 	   7,   -4, 	  -1,   -9
+.2byte    2,   -8, 	  -7,  -10, 	   4,   -4, 	  -1,   -9
+.2byte    1,  -10, 	  -3,  -13, 	   7,   -8, 	  -2,   -9
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -7, 	   0,   -7
+.2byte    0,   -9, 	   8,   -6, 	  -9,   -6, 	  -1,   -9
+.2byte    0,  -10, 	   9,   -6, 	 -10,   -6, 	   0,   -8
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -2,   -8, 	   6,  -12, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -9
+.2byte   -3,   -8, 	   6,  -10, 	  -5,   -4, 	   0,   -9
+.2byte   -2,  -10, 	   2,  -13, 	  -8,   -8, 	   1,   -9
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -3, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -3,   -2, 	   2,   -7, 	   4,   -5, 	   0,   -7
+.2byte   -6,   -6, 	   1,  -12, 	   3,   -9, 	   0,   -8
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -5,   -4, 	  -7,  -12, 	   7,   -4, 	   0,   -7
+.2byte   -5,   -6, 	  -8,  -11, 	   6,   -4, 	   0,   -8
+.2byte   -5,   -2, 	  -7,   -5, 	   6,   -2, 	  -1,   -7
+.2byte   -6,   -8, 	  -3,  -13, 	   7,   -9, 	   0,   -9
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -9,   -8, 	   8,   -8, 	   0,   -6
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte   -1,   -2, 	 -12,   -5, 	  11,   -5, 	   0,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	  10,  -10, 	  -1,   -8
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+.2byte    4,   -4, 	   6,  -12, 	  -8,   -4, 	  -1,   -7
+.2byte    4,   -6, 	   7,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    4,   -2, 	   6,   -5, 	  -7,   -2, 	   0,   -7
+.2byte    5,   -8, 	   2,  -13, 	  -8,   -9, 	  -1,   -9
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -3, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -8, 	  -2,   -2, 	  -1,   -8
+.2byte    2,   -2, 	  -3,   -7, 	  -5,   -5, 	  -1,   -7
+.2byte    5,   -6, 	  -2,  -12, 	  -4,   -9, 	  -1,   -8
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    1,   -8, 	  -7,  -12, 	   7,   -4, 	  -1,   -7
+.2byte    2,   -9, 	  -8,  -10, 	   7,   -4, 	  -1,   -9
+.2byte    2,   -8, 	  -7,  -10, 	   4,   -4, 	  -1,   -9
+.2byte    1,  -10, 	  -3,  -13, 	   7,   -8, 	  -2,   -9
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -7, 	   0,   -7
+.2byte    0,   -9, 	   8,   -6, 	  -9,   -6, 	  -1,   -9
+.2byte    0,  -10, 	   9,   -6, 	 -10,   -6, 	   0,   -8
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -2,   -8, 	   6,  -12, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -9
+.2byte   -3,   -8, 	   6,  -10, 	  -5,   -4, 	   0,   -9
+.2byte   -2,  -10, 	   2,  -13, 	  -8,   -8, 	   1,   -9
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -3, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -3,   -2, 	   2,   -7, 	   4,   -5, 	   0,   -7
+.2byte   -6,   -6, 	   1,  -12, 	   3,   -9, 	   0,   -8
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -5,   -4, 	  -7,  -12, 	   7,   -4, 	   0,   -7
+.2byte   -5,   -6, 	  -8,  -11, 	   6,   -4, 	   0,   -8
+.2byte   -5,   -2, 	  -7,   -5, 	   6,   -2, 	  -1,   -7
+.2byte   -6,   -8, 	  -3,  -13, 	   7,   -9, 	   0,   -9
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	  10,  -10, 	  -1,   -8
+.2byte   -1,   -1, 	 -12,   -4, 	  11,   -4, 	   0,   -5
+.2byte   -1,    0, 	 -12,   -5, 	  11,   -5, 	   0,   -5
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+.2byte    5,   -8, 	   2,  -13, 	  -8,   -9, 	  -1,   -9
+.2byte    4,   -2, 	   3,   -4, 	  -8,   -1, 	  -1,   -6
+.2byte    4,    0, 	   7,   -3, 	 -10,   -1, 	  -1,   -5
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    5,   -6, 	  -2,  -12, 	  -4,   -9, 	  -1,   -8
+.2byte    4,   -2, 	  -3,   -8, 	  -3,   -5, 	   1,   -8
+.2byte    4,   -1, 	   1,   -7, 	  -1,   -3, 	   0,   -7
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    1,  -10, 	  -3,  -13, 	   7,   -8, 	  -2,   -9
+.2byte    0,   -5, 	  -4,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -2,   -4, 	  -6,   -9, 	   2,   -3, 	  -1,   -9
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte    0,   -9, 	   9,   -6, 	 -10,   -6, 	   0,   -8
+.2byte    0,   -8, 	   9,   -7, 	 -10,   -7, 	   0,   -7
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -2,  -10, 	   2,  -13, 	  -8,   -8, 	   1,   -9
+.2byte   -2,   -5, 	   2,   -9, 	  -6,   -4, 	  -1,   -9
+.2byte    0,   -4, 	   4,   -9, 	  -4,   -3, 	  -1,   -9
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -6,   -6, 	   1,  -12, 	   3,   -9, 	   0,   -8
+.2byte   -5,   -2, 	   2,   -8, 	   2,   -5, 	  -2,   -8
+.2byte   -5,   -1, 	  -2,   -7, 	   0,   -3, 	  -1,   -7
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -6,   -8, 	  -3,  -13, 	   7,   -9, 	   0,   -9
+.2byte   -5,   -2, 	  -4,   -4, 	   7,   -1, 	   0,   -6
+.2byte   -5,    0, 	  -8,   -3, 	   9,   -1, 	   0,   -5
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+.2byte   -5,   -5, 	  -8,   -9, 	   5,   -3, 	   0,   -8
+.2byte   -5,   -5, 	  -8,   -9, 	   5,   -3, 	   0,   -8
+.2byte   -1,  -13, 	 -10,   -7, 	   9,   -7, 	   0,   -7
+.2byte   -2,  -13, 	   8,  -11, 	 -10,   -6, 	  -1,   -7
+.2byte   -4,  -12, 	  -4,  -10, 	  -6,   -4, 	  -2,   -7
+.2byte   -3,   -9, 	  -8,   -6, 	   0,    0, 	  -2,   -4
+.2byte   -1,   -8, 	   9,   -2, 	 -10,   -2, 	   0,   -3
+.2byte    2,   -9, 	   7,   -6, 	  -1,    0, 	   1,   -4
+.2byte    1,  -12, 	   1,  -10, 	   3,   -4, 	  -1,   -7
+.2byte    1,  -13, 	  -9,  -11, 	   9,   -6, 	   0,   -7
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -9,   -8, 	   8,   -8, 	   0,   -6
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+.2byte    4,   -4, 	   6,  -12, 	  -8,   -4, 	  -1,   -7
+.2byte    4,   -6, 	   7,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -3, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -8, 	  -2,   -2, 	  -1,   -8
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    1,   -8, 	  -7,  -12, 	   7,   -4, 	  -1,   -7
+.2byte    2,   -9, 	  -8,  -10, 	   7,   -4, 	  -1,   -9
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -7, 	   0,   -7
+.2byte    0,   -9, 	   8,   -6, 	  -9,   -6, 	  -1,   -9
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -2,   -8, 	   6,  -12, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -9
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -3, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -5,   -4, 	  -7,  -12, 	   7,   -4, 	   0,   -7
+.2byte   -5,   -6, 	  -8,  -11, 	   6,   -4, 	   0,   -8
+.2byte   -1,    0, 	 -12,   -5, 	  11,   -5, 	   0,   -5
+.2byte   -5,    0, 	  -8,   -3, 	   9,   -1, 	   0,   -5
+.2byte   -4,    0, 	  -1,   -6, 	   1,   -2, 	   0,   -6
+.2byte    0,   -1, 	   4,   -6, 	  -4,    0, 	  -1,   -6
+.2byte    0,   -6, 	   9,   -5, 	 -10,   -5, 	   0,   -5
+.2byte   -2,   -1, 	  -6,   -6, 	   2,    0, 	  -1,   -6
+.2byte    3,    0, 	   0,   -6, 	  -2,   -2, 	  -1,   -6
+.2byte    4,    0, 	   7,   -3, 	 -10,   -1, 	  -1,   -5
+.2byte   -1,   -7, 	 -11,  -10, 	  10,  -10, 	  -1,   -8
+.2byte    5,   -7, 	   2,  -12, 	  -8,   -8, 	  -1,   -8
+.2byte    5,   -6, 	  -2,  -12, 	  -4,   -9, 	  -1,   -8
+.2byte    1,   -9, 	  -3,  -12, 	   7,   -7, 	  -2,   -8
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte   -2,   -9, 	   2,  -12, 	  -8,   -7, 	   1,   -8
+.2byte   -6,   -6, 	   1,  -12, 	   3,   -9, 	   0,   -8
+.2byte   -6,   -7, 	  -3,  -12, 	   7,   -8, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	  10,  -10, 	  -1,   -8
+.2byte   -1,   -1, 	 -12,   -4, 	  11,   -4, 	   0,   -5
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+.2byte    5,   -8, 	   2,  -13, 	  -8,   -9, 	  -1,   -9
+.2byte    5,   -2, 	   4,   -4, 	  -7,   -1, 	   0,   -6
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    4,   -6, 	  -3,  -12, 	  -5,   -9, 	  -2,   -8
+.2byte    3,   -2, 	  -4,   -8, 	  -4,   -5, 	   0,   -8
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    1,  -10, 	  -3,  -13, 	   7,   -8, 	  -2,   -9
+.2byte    1,   -5, 	  -3,   -9, 	   5,   -4, 	   0,   -9
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte    0,   -9, 	   9,   -6, 	 -10,   -6, 	   0,   -8
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -2,  -10, 	   2,  -13, 	  -8,   -8, 	   1,   -9
+.2byte   -3,   -5, 	   1,   -9, 	  -7,   -4, 	  -2,   -9
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -6,   -6, 	   1,  -12, 	   3,   -9, 	   0,   -8
+.2byte   -4,   -2, 	   3,   -8, 	   3,   -5, 	  -1,   -8
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -6,   -8, 	  -3,  -13, 	   7,   -9, 	   0,   -9
+.2byte   -5,   -2, 	  -4,   -4, 	   7,   -1, 	   0,   -6
+.2byte   -1,   -2, 	 -12,   -5, 	  11,   -5, 	   0,   -8
+.2byte   -5,   -2, 	  -7,   -5, 	   6,   -2, 	  -1,   -7
+.2byte   -5,   -2, 	   0,   -7, 	   2,   -5, 	  -2,   -7
+.2byte   -5,   -6, 	   4,   -8, 	  -7,   -2, 	  -2,   -7
+.2byte    0,   -9, 	   9,   -5, 	 -10,   -5, 	   0,   -7
+.2byte    4,   -6, 	  -5,   -8, 	   6,   -2, 	   1,   -7
+.2byte    4,   -2, 	  -1,   -7, 	  -3,   -5, 	   1,   -7
+.2byte    4,   -2, 	   6,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -3,   -2, 	   2,   -7, 	   4,   -5, 	   0,   -7
+.2byte   -3,   -8, 	   6,  -10, 	  -5,   -4, 	   0,   -9
+.2byte    0,  -10, 	   9,   -6, 	 -10,   -6, 	   0,   -8
+.2byte    2,   -8, 	  -7,  -10, 	   4,   -4, 	  -1,   -9
+.2byte    2,   -2, 	  -3,   -7, 	  -5,   -5, 	  -1,   -7
+.2byte    4,   -2, 	   6,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -5,   -2, 	  -7,   -5, 	   6,   -2, 	  -1,   -7
+.2byte   -3,   -2, 	   2,   -7, 	   4,   -5, 	   0,   -7
+.2byte   -3,   -8, 	   6,  -10, 	  -5,   -4, 	   0,   -9
+.2byte    0,  -10, 	   9,   -6, 	 -10,   -6, 	   0,   -8
+.2byte    2,   -8, 	  -7,  -10, 	   4,   -4, 	  -1,   -9
+.2byte    2,   -2, 	  -3,   -7, 	  -5,   -5, 	  -1,   -7
+.2byte    4,   -2, 	   6,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -1,   -4, 	 -10,   -7, 	   9,   -7, 	   0,   -8
+.2byte   -5,   -5, 	  -8,  -12, 	   7,   -4, 	   0,   -8
+.2byte   -4,   -4, 	   0,  -14, 	   0,   -2, 	   0,   -7
+.2byte   -3,   -9, 	   8,  -12, 	  -8,   -4, 	   0,   -8
+.2byte    0,   -8, 	   8,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte    2,   -9, 	  -9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    3,   -4, 	  -1,  -14, 	  -1,   -2, 	  -1,   -7
+.2byte    4,   -5, 	   7,  -12, 	  -8,   -4, 	  -1,   -8
+sChinchouAnimTable1:
+.4byte sChinchouAnims_1_1
+.4byte sChinchouAnims_1_2
+.4byte sChinchouAnims_1_3
+.4byte sChinchouAnims_1_4
+.4byte sChinchouAnims_1_5
+.4byte sChinchouAnims_1_6
+.4byte sChinchouAnims_1_7
+.4byte sChinchouAnims_1_8
+sChinchouAnimTable2:
+.4byte sChinchouAnims_2_1
+.4byte sChinchouAnims_2_2
+.4byte sChinchouAnims_2_3
+.4byte sChinchouAnims_2_4
+.4byte sChinchouAnims_2_5
+.4byte sChinchouAnims_2_6
+.4byte sChinchouAnims_2_7
+.4byte sChinchouAnims_2_8
+sChinchouAnimTable3:
+.4byte sChinchouAnims_3_1
+.4byte sChinchouAnims_3_2
+.4byte sChinchouAnims_3_3
+.4byte sChinchouAnims_3_4
+.4byte sChinchouAnims_3_5
+.4byte sChinchouAnims_3_6
+.4byte sChinchouAnims_3_7
+.4byte sChinchouAnims_3_8
+sChinchouAnimTable4:
+.4byte sChinchouAnims_4_1
+.4byte sChinchouAnims_4_2
+.4byte sChinchouAnims_4_3
+.4byte sChinchouAnims_4_4
+.4byte sChinchouAnims_4_5
+.4byte sChinchouAnims_4_6
+.4byte sChinchouAnims_4_7
+.4byte sChinchouAnims_4_8
+sChinchouAnimTable5:
+.4byte sChinchouAnims_5_1
+.4byte sChinchouAnims_5_2
+.4byte sChinchouAnims_5_3
+.4byte sChinchouAnims_5_4
+.4byte sChinchouAnims_5_5
+.4byte sChinchouAnims_5_6
+.4byte sChinchouAnims_5_7
+.4byte sChinchouAnims_5_8
+sChinchouAnimTable6:
+.4byte sChinchouAnims_6_1
+.4byte sChinchouAnims_6_1
+.4byte sChinchouAnims_6_1
+.4byte sChinchouAnims_6_1
+.4byte sChinchouAnims_6_1
+.4byte sChinchouAnims_6_1
+.4byte sChinchouAnims_6_1
+.4byte sChinchouAnims_6_1
+sChinchouAnimTable7:
+.4byte sChinchouAnims_7_1
+.4byte sChinchouAnims_7_2
+.4byte sChinchouAnims_7_3
+.4byte sChinchouAnims_7_4
+.4byte sChinchouAnims_7_5
+.4byte sChinchouAnims_7_6
+.4byte sChinchouAnims_7_7
+.4byte sChinchouAnims_7_8
+sChinchouAnimTable8:
+.4byte sChinchouAnims_8_1
+.4byte sChinchouAnims_8_2
+.4byte sChinchouAnims_8_3
+.4byte sChinchouAnims_8_4
+.4byte sChinchouAnims_8_5
+.4byte sChinchouAnims_8_6
+.4byte sChinchouAnims_8_7
+.4byte sChinchouAnims_8_8
+sChinchouAnimTable9:
+.4byte sChinchouAnims_9_1
+.4byte sChinchouAnims_9_2
+.4byte sChinchouAnims_9_3
+.4byte sChinchouAnims_9_4
+.4byte sChinchouAnims_9_5
+.4byte sChinchouAnims_9_6
+.4byte sChinchouAnims_9_7
+.4byte sChinchouAnims_9_8
+sChinchouAnimTable10:
+.4byte sChinchouAnims_10_1
+.4byte sChinchouAnims_10_2
+.4byte sChinchouAnims_10_3
+.4byte sChinchouAnims_10_4
+.4byte sChinchouAnims_10_5
+.4byte sChinchouAnims_10_6
+.4byte sChinchouAnims_10_7
+.4byte sChinchouAnims_10_8
+sChinchouAnimTable11:
+.4byte sChinchouAnims_11_1
+.4byte sChinchouAnims_11_2
+.4byte sChinchouAnims_11_3
+.4byte sChinchouAnims_11_4
+.4byte sChinchouAnims_11_5
+.4byte sChinchouAnims_11_6
+.4byte sChinchouAnims_11_7
+.4byte sChinchouAnims_11_8
+sChinchouAnimTable12:
+.4byte sChinchouAnims_12_1
+.4byte sChinchouAnims_12_2
+.4byte sChinchouAnims_12_3
+.4byte sChinchouAnims_12_4
+.4byte sChinchouAnims_12_5
+.4byte sChinchouAnims_12_6
+.4byte sChinchouAnims_12_7
+.4byte sChinchouAnims_12_8
+sChinchouAnimTable13:
+.4byte sChinchouAnims_13_1
+.4byte sChinchouAnims_13_2
+.4byte sChinchouAnims_13_3
+.4byte sChinchouAnims_13_4
+.4byte sChinchouAnims_13_5
+.4byte sChinchouAnims_13_6
+.4byte sChinchouAnims_13_7
+.4byte sChinchouAnims_13_8
+sAxAnimationsChinchou:
+.4byte sChinchouAnimTable1
+.4byte sChinchouAnimTable2
+.4byte sChinchouAnimTable3
+.4byte sChinchouAnimTable4
+.4byte sChinchouAnimTable5
+.4byte sChinchouAnimTable6
+.4byte sChinchouAnimTable7
+.4byte sChinchouAnimTable8
+.4byte sChinchouAnimTable9
+.4byte sChinchouAnimTable10
+.4byte sChinchouAnimTable11
+.4byte sChinchouAnimTable12
+.4byte sChinchouAnimTable13
+sAxSpritesChinchou:
+.4byte sChinchouSprites1
+.4byte sChinchouSprites2
+.4byte sChinchouSprites3
+.4byte sChinchouSprites4
+.4byte sChinchouSprites5
+.4byte sChinchouSprites6
+.4byte sChinchouSprites7
+.4byte sChinchouSprites8
+.4byte sChinchouSprites9
+.4byte sChinchouSprites10
+.4byte sChinchouSprites11
+.4byte sChinchouSprites12
+.4byte sChinchouSprites13
+.4byte sChinchouSprites14
+.4byte sChinchouSprites15
+.4byte sChinchouSprites16
+.4byte sChinchouSprites17
+.4byte sChinchouSprites18
+.4byte sChinchouSprites19
+.4byte sChinchouSprites20
+.4byte sChinchouSprites21
+.4byte sChinchouSprites22
+.4byte sChinchouSprites23
+.4byte sChinchouSprites24
+.4byte sChinchouSprites25
+.4byte sChinchouSprites26
+.4byte sChinchouSprites27
+.4byte sChinchouSprites28
+.4byte sChinchouSprites29
+.4byte sChinchouSprites30
+.4byte sChinchouSprites31
+.4byte sChinchouSprites32
+.4byte sChinchouSprites33
+.4byte sChinchouSprites34
+.4byte sChinchouSprites35
+.4byte sChinchouSprites36
+.4byte sChinchouSprites37
+.4byte sChinchouSprites38
+.4byte sChinchouSprites39
+.4byte sChinchouSprites40
+.4byte sChinchouSprites41
+.4byte sChinchouSprites42
+sAxMainChinchou:
+ax_main sAxPosesChinchou, sAxAnimationsChinchou, 13, sAxSpritesChinchou, sAxPositionsChinchou

--- a/data/ax/clamperl.inc
+++ b/data/ax/clamperl.inc
@@ -1,0 +1,2534 @@
+.global gAxClamperl
+gAxClamperl:
+ax_siro sAxMainClamperl
+sClamperlPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose4:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose5:
+ax_pose 4, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose6:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose8:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose28:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose29:
+ax_pose 4, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose30:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose31:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose32:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose33:
+ax_pose 8, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose34:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose35:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose36:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose37:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose38:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose39:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose40:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose41:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose42:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose43:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose44:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose45:
+ax_pose 8, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose46:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose47:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose48:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose50:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose51:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose52:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose53:
+ax_pose 4, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose54:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose55:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose56:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose57:
+ax_pose 8, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose58:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose59:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose60:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose61:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose62:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose63:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose64:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose65:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose66:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose67:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose68:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose69:
+ax_pose 8, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose70:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose71:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose72:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose73:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose74:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose75:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose76:
+ax_pose 15, 0x81e9, 0x80f4, 0x1c00
+ax_pose 16, 0x81e9, 0x4104, 0x1c08
+ax_pose_terminator
+sClamperlPose77:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose78:
+ax_pose 4, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose79:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose80:
+ax_pose 17, 0x81e4, 0x90f1, 0x1c00
+ax_pose 18, 0x81e4, 0x5101, 0x1c08
+ax_pose_terminator
+sClamperlPose81:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose82:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose83:
+ax_pose 8, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose84:
+ax_pose 19, 0x41f3, 0x90e9, 0x1c00
+ax_pose 20, 0x41eb, 0x10f1, 0x1c08
+ax_pose_terminator
+sClamperlPose85:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose86:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose87:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose88:
+ax_pose 21, 0x41f3, 0x90ea, 0x1c00
+ax_pose 22, 0x41eb, 0x10f2, 0x1c08
+ax_pose_terminator
+sClamperlPose89:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose90:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose91:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose92:
+ax_pose 23, 0x81e9, 0x80f6, 0x1c00
+ax_pose 24, 0x81f1, 0x0106, 0x1c08
+ax_pose_terminator
+sClamperlPose93:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose94:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose95:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose96:
+ax_pose 21, 0x41f3, 0x80f5, 0x1c00
+ax_pose 22, 0x41eb, 0x00fd, 0x1c08
+ax_pose_terminator
+sClamperlPose97:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose98:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose99:
+ax_pose 8, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose100:
+ax_pose 19, 0x41f3, 0x80f6, 0x1c00
+ax_pose 20, 0x41eb, 0x00fe, 0x1c08
+ax_pose_terminator
+sClamperlPose101:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose102:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose103:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose104:
+ax_pose 17, 0x81e4, 0x80fe, 0x1c00
+ax_pose 18, 0x81e4, 0x40f6, 0x1c08
+ax_pose_terminator
+sClamperlPose105:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose106:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose107:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose108:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose109:
+ax_pose 4, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose110:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose111:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose112:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose113:
+ax_pose 8, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose114:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose115:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose116:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose117:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose118:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose119:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose120:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose121:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose122:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose123:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose124:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose125:
+ax_pose 8, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose126:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose127:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose128:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose129:
+ax_pose 25, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose130:
+ax_pose 26, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose131:
+ax_pose 27, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose132:
+ax_pose 28, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sClamperlPose133:
+ax_pose 29, 0x01e6, 0x90ea, 0x1c00
+ax_pose_terminator
+sClamperlPose134:
+ax_pose 30, 0x01e6, 0x90ea, 0x1c00
+ax_pose_terminator
+sClamperlPose135:
+ax_pose 31, 0x01e5, 0x80f5, 0x1c00
+ax_pose_terminator
+sClamperlPose136:
+ax_pose 30, 0x01e6, 0x80f6, 0x1c00
+ax_pose_terminator
+sClamperlPose137:
+ax_pose 29, 0x01e6, 0x80f6, 0x1c00
+ax_pose_terminator
+sClamperlPose138:
+ax_pose 28, 0x01e6, 0x80f3, 0x1c00
+ax_pose_terminator
+sClamperlPose139:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose140:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose141:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose142:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose143:
+ax_pose 4, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose144:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose145:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose146:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose147:
+ax_pose 8, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose148:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose149:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose150:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose151:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose152:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose153:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose154:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose155:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose156:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose157:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose158:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose159:
+ax_pose 8, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose160:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose161:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose162:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose163:
+ax_pose 2, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sClamperlPose164:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose165:
+ax_pose 8, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sClamperlPose166:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose167:
+ax_pose 14, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sClamperlPose168:
+ax_pose 11, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClamperlPose169:
+ax_pose 8, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClamperlPose170:
+ax_pose 5, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sClamperlPose171:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose172:
+ax_pose 4, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClamperlPose173:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose174:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose175:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose176:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose177:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose178:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose179:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose180:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose181:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose182:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose183:
+ax_pose 4, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose184:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose185:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose186:
+ax_pose 7, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose187:
+ax_pose 8, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose188:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose189:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose190:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose191:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose192:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose193:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose194:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose195:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose196:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose197:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose198:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose199:
+ax_pose 8, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose200:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose201:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose202:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose203:
+ax_pose 15, 0x81e9, 0x80f4, 0x1c00
+ax_pose 16, 0x81e9, 0x4104, 0x1c08
+ax_pose_terminator
+sClamperlPose204:
+ax_pose 17, 0x81e4, 0x80fd, 0x1c00
+ax_pose 18, 0x81e4, 0x40f5, 0x1c08
+ax_pose_terminator
+sClamperlPose205:
+ax_pose 19, 0x41f3, 0x80f6, 0x1c00
+ax_pose 20, 0x41eb, 0x00fe, 0x1c08
+ax_pose_terminator
+sClamperlPose206:
+ax_pose 21, 0x41f3, 0x80f4, 0x1c00
+ax_pose 22, 0x41eb, 0x00fc, 0x1c08
+ax_pose_terminator
+sClamperlPose207:
+ax_pose 23, 0x81e9, 0x80f6, 0x1c00
+ax_pose 24, 0x81f1, 0x0106, 0x1c08
+ax_pose_terminator
+sClamperlPose208:
+ax_pose 21, 0x41f3, 0x90eb, 0x1c00
+ax_pose 22, 0x41eb, 0x10f3, 0x1c08
+ax_pose_terminator
+sClamperlPose209:
+ax_pose 19, 0x41f3, 0x90ea, 0x1c00
+ax_pose 20, 0x41eb, 0x10f2, 0x1c08
+ax_pose_terminator
+sClamperlPose210:
+ax_pose 17, 0x81e4, 0x90f2, 0x1c00
+ax_pose 18, 0x81e4, 0x5102, 0x1c08
+ax_pose_terminator
+sClamperlPose211:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose212:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose213:
+ax_pose 6, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose214:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose215:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClamperlPose216:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose217:
+ax_pose 6, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sClamperlPose218:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+.align 2
+sClamperlAnims_1_1:
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sClamperlAnims_1_2:
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sClamperlAnims_1_3:
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sClamperlAnims_1_4:
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sClamperlAnims_1_5:
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sClamperlAnims_1_6:
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sClamperlAnims_1_7:
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sClamperlAnims_1_8:
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sClamperlAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 9, 10, 9,
+ax_anim 2, 0, 29, 22, 19, 22, 19,
+ax_anim 2, 1, 29, 23, 18, 23, 18,
+ax_anim 2, 0, 29, 22, 19, 22, 19,
+ax_anim 2, 0, 29, 23, 18, 23, 18,
+ax_anim 2, 0, 27, 7, 6, 7, 6,
+ax_anim_terminator
+sClamperlAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 21, 0, 21, 0,
+ax_anim 2, 1, 32, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 21, 0, 21, 0,
+ax_anim 2, 0, 32, 21, 1, 21, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sClamperlAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 4, -6, 4, -6,
+ax_anim 1, 0, 34, 11, -12, 11, -12,
+ax_anim 2, 0, 35, 22, -23, 22, -23,
+ax_anim 2, 1, 35, 23, -22, 23, -22,
+ax_anim 2, 0, 35, 22, -23, 22, -23,
+ax_anim 2, 0, 35, 23, -22, 23, -22,
+ax_anim 2, 0, 33, 6, -7, 6, -7,
+ax_anim_terminator
+sClamperlAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 1, 38, 1, -24, 1, -24,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 0, 38, 1, -24, 1, -24,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sClamperlAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -4, -6, -4, -6,
+ax_anim 1, 0, 40, -11, -12, -11, -12,
+ax_anim 2, 0, 41, -22, -23, -22, -23,
+ax_anim 2, 1, 41, -23, -22, -23, -22,
+ax_anim 2, 0, 41, -22, -23, -22, -23,
+ax_anim 2, 0, 41, -23, -22, -23, -22,
+ax_anim 2, 0, 39, -6, -7, -6, -7,
+ax_anim_terminator
+sClamperlAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 1, 44, -21, 1, -21, 1,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 0, 44, -21, 1, -21, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sClamperlAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 9, -10, 9,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 1, 47, -23, 18, -23, 18,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 47, -23, 18, -23, 18,
+ax_anim 2, 0, 45, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sClamperlAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 1, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 0, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sClamperlAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 9, 10, 9,
+ax_anim 2, 0, 53, 22, 19, 22, 19,
+ax_anim 2, 1, 53, 23, 18, 23, 18,
+ax_anim 2, 0, 53, 22, 19, 22, 19,
+ax_anim 2, 0, 53, 23, 18, 23, 18,
+ax_anim 2, 0, 51, 7, 6, 7, 6,
+ax_anim_terminator
+sClamperlAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 21, 0, 21, 0,
+ax_anim 2, 1, 56, 21, 1, 21, 1,
+ax_anim 2, 0, 56, 21, 0, 21, 0,
+ax_anim 2, 0, 56, 21, 1, 21, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sClamperlAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 4, -6, 4, -6,
+ax_anim 1, 0, 58, 11, -12, 11, -12,
+ax_anim 2, 0, 59, 22, -23, 22, -23,
+ax_anim 2, 1, 59, 23, -22, 23, -22,
+ax_anim 2, 0, 59, 22, -23, 22, -23,
+ax_anim 2, 0, 59, 23, -22, 23, -22,
+ax_anim 2, 0, 57, 6, -7, 6, -7,
+ax_anim_terminator
+sClamperlAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -11, 0, -11,
+ax_anim 2, 0, 62, 0, -24, 0, -24,
+ax_anim 2, 1, 62, 1, -24, 1, -24,
+ax_anim 2, 0, 62, 0, -24, 0, -24,
+ax_anim 2, 0, 62, 1, -24, 1, -24,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sClamperlAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -4, -6, -4, -6,
+ax_anim 1, 0, 64, -11, -12, -11, -12,
+ax_anim 2, 0, 65, -22, -23, -22, -23,
+ax_anim 2, 1, 65, -23, -22, -23, -22,
+ax_anim 2, 0, 65, -22, -23, -22, -23,
+ax_anim 2, 0, 65, -23, -22, -23, -22,
+ax_anim 2, 0, 63, -6, -7, -6, -7,
+ax_anim_terminator
+sClamperlAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 68, -21, 0, -21, 0,
+ax_anim 2, 1, 68, -21, 1, -21, 1,
+ax_anim 2, 0, 68, -21, 0, -21, 0,
+ax_anim 2, 0, 68, -21, 1, -21, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sClamperlAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 9, -10, 9,
+ax_anim 2, 0, 71, -22, 19, -22, 19,
+ax_anim 2, 1, 71, -23, 18, -23, 18,
+ax_anim 2, 0, 71, -22, 19, -22, 19,
+ax_anim 2, 0, 71, -23, 18, -23, 18,
+ax_anim 2, 0, 69, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sClamperlAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim 8, 2, 74, 0, -5, 0, -5,
+ax_anim 1, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sClamperlAnims_4_2:
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 0, 78, -4, -4, -4, -4,
+ax_anim 8, 2, 78, -5, -5, -5, -5,
+ax_anim 1, 0, 76, -1, -1, -1, -1,
+ax_anim 2, 1, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sClamperlAnims_4_3:
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 2, 0, 82, -4, 0, -4, 0,
+ax_anim 8, 2, 82, -5, 0, -5, 0,
+ax_anim 1, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 1, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sClamperlAnims_4_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -4, 4, -4, 4,
+ax_anim 8, 2, 86, -5, 5, -5, 5,
+ax_anim 1, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 1, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sClamperlAnims_4_5:
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 8, 2, 90, 0, 5, 0, 5,
+ax_anim 1, 0, 88, 0, 1, 0, 1,
+ax_anim 2, 1, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sClamperlAnims_4_6:
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 8, 2, 94, 5, 5, 5, 5,
+ax_anim 1, 0, 92, 1, 1, 1, 1,
+ax_anim 2, 1, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sClamperlAnims_4_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 8, 2, 98, 5, 0, 5, 0,
+ax_anim 1, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 1, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sClamperlAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 8, 2, 102, 5, -5, 5, -5,
+ax_anim 1, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sClamperlAnims_5_1:
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_5_2:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_5_3:
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_5_4:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_5_5:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_5_6:
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_5_7:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 1, 124, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_5_8:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 1, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sClamperlAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sClamperlAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sClamperlAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sClamperlAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sClamperlAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sClamperlAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sClamperlAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sClamperlAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_8_2:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_8_4:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_8_5:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_8_6:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_8_8:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 7, 4, 7, 4,
+ax_anim 2, 0, 164, 10, 9, 10, 9,
+ax_anim 2, 0, 165, 8, 15, 8, 15,
+ax_anim 3, 0, 166, 0, 19, 0, 19,
+ax_anim 2, 3, 167, -8, 16, -8, 16,
+ax_anim 2, 0, 168, -10, 9, -10, 9,
+ax_anim 1, 0, 169, -7, 4, -7, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 10, -1, 10, -1,
+ax_anim 2, 0, 163, 17, 4, 17, 4,
+ax_anim 2, 0, 164, 21, 11, 21, 11,
+ax_anim 3, 0, 165, 23, 19, 23, 19,
+ax_anim 2, 3, 166, 14, 21, 14, 21,
+ax_anim 2, 0, 167, 5, 16, 5, 16,
+ax_anim 1, 0, 168, 0, 8, 0, 8,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 18, -4, 18, -4,
+ax_anim 3, 0, 164, 23, 2, 23, 2,
+ax_anim 2, 3, 165, 19, 5, 19, 5,
+ax_anim 2, 0, 166, 13, 6, 13, 6,
+ax_anim 1, 0, 167, 7, 5, 7, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 22, -22, 22, -22,
+ax_anim 2, 3, 164, 24, -16, 24, -16,
+ax_anim 2, 0, 165, 20, -7, 20, -7,
+ax_anim 1, 0, 166, 9, -1, 9, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -10, -3, -10, -3,
+ax_anim 2, 0, 168, -12, -11, -12, -11,
+ax_anim 2, 0, 169, -8, -20, -8, -20,
+ax_anim 3, 0, 162, 0, -24, 0, -24,
+ax_anim 2, 3, 163, 8, -20, 8, -20,
+ax_anim 2, 0, 164, 12, -11, 12, -11,
+ax_anim 1, 0, 165, 10, -3, 10, -3,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -7, 1, -7,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -22, -22, -22, -22,
+ax_anim 2, 3, 168, -24, -16, -24, -16,
+ax_anim 2, 0, 167, -20, -7, -20, -7,
+ax_anim 1, 0, 166, -9, -1, -9, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -18, -4, -18, -4,
+ax_anim 3, 0, 168, -23, 2, -23, 2,
+ax_anim 2, 3, 167, -19, 5, -19, 5,
+ax_anim 2, 0, 166, -13, 6, -13, 6,
+ax_anim 1, 0, 165, -7, 5, -7, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -10, -1, -10, -1,
+ax_anim 2, 0, 169, -17, 4, -17, 4,
+ax_anim 2, 0, 168, -21, 11, -21, 11,
+ax_anim 3, 0, 167, -23, 19, -23, 19,
+ax_anim 2, 3, 166, -14, 21, -14, 21,
+ax_anim 2, 0, 165, -5, 16, -5, 16,
+ax_anim 1, 0, 164, 0, 8, 0, 8,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClamperlAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sClamperlGfx1:
+.incbin "baserom.gba", 0x151B758, 0x200
+sClamperlSprites1:
+ax_sprite sClamperlGfx1, 0x200
+ax_sprite_terminator
+sClamperlGfx2:
+.incbin "baserom.gba", 0x151B968, 0x200
+sClamperlSprites2:
+ax_sprite sClamperlGfx2, 0x200
+ax_sprite_terminator
+sClamperlGfx3:
+.incbin "baserom.gba", 0x151BB78, 0x200
+sClamperlSprites3:
+ax_sprite sClamperlGfx3, 0x200
+ax_sprite_terminator
+sClamperlGfx4:
+.incbin "baserom.gba", 0x151BD88, 0x200
+sClamperlSprites4:
+ax_sprite sClamperlGfx4, 0x200
+ax_sprite_terminator
+sClamperlGfx5:
+.incbin "baserom.gba", 0x151BF98, 0x200
+sClamperlSprites5:
+ax_sprite sClamperlGfx5, 0x200
+ax_sprite_terminator
+sClamperlGfx6:
+.incbin "baserom.gba", 0x151C1A8, 0x200
+sClamperlSprites6:
+ax_sprite sClamperlGfx6, 0x200
+ax_sprite_terminator
+sClamperlGfx7:
+.incbin "baserom.gba", 0x151C3B8, 0x200
+sClamperlSprites7:
+ax_sprite sClamperlGfx7, 0x200
+ax_sprite_terminator
+sClamperlGfx8:
+.incbin "baserom.gba", 0x151C5C8, 0x200
+sClamperlSprites8:
+ax_sprite sClamperlGfx8, 0x200
+ax_sprite_terminator
+sClamperlGfx9:
+.incbin "baserom.gba", 0x151C7D8, 0x200
+sClamperlSprites9:
+ax_sprite sClamperlGfx9, 0x200
+ax_sprite_terminator
+sClamperlGfx10:
+.incbin "baserom.gba", 0x151C9E8, 0x200
+sClamperlSprites10:
+ax_sprite sClamperlGfx10, 0x200
+ax_sprite_terminator
+sClamperlGfx11:
+.incbin "baserom.gba", 0x151CBF8, 0x200
+sClamperlSprites11:
+ax_sprite sClamperlGfx11, 0x200
+ax_sprite_terminator
+sClamperlGfx12:
+.incbin "baserom.gba", 0x151CE08, 0x200
+sClamperlSprites12:
+ax_sprite sClamperlGfx12, 0x200
+ax_sprite_terminator
+sClamperlGfx13:
+.incbin "baserom.gba", 0x151D018, 0x200
+sClamperlSprites13:
+ax_sprite sClamperlGfx13, 0x200
+ax_sprite_terminator
+sClamperlGfx14:
+.incbin "baserom.gba", 0x151D228, 0x200
+sClamperlSprites14:
+ax_sprite sClamperlGfx14, 0x200
+ax_sprite_terminator
+sClamperlGfx15:
+.incbin "baserom.gba", 0x151D438, 0x200
+sClamperlSprites15:
+ax_sprite sClamperlGfx15, 0x200
+ax_sprite_terminator
+sClamperlGfx16:
+.incbin "baserom.gba", 0x151D648, 0xC0
+sClamperlGfx16_1:
+.incbin "baserom.gba", 0x151D708, 0x20
+sClamperlSprites16:
+ax_sprite sClamperlGfx16, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sClamperlGfx16_1, 0x20
+ax_sprite_terminator
+sClamperlGfx17:
+.incbin "baserom.gba", 0x151D748, 0x60
+sClamperlSprites17:
+ax_sprite sClamperlGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClamperlGfx18:
+.incbin "baserom.gba", 0x151D7C0, 0x100
+sClamperlSprites18:
+ax_sprite sClamperlGfx18, 0x100
+ax_sprite_terminator
+sClamperlGfx19:
+.incbin "baserom.gba", 0x151D8D0, 0x60
+sClamperlSprites19:
+ax_sprite 0, 0x20
+ax_sprite sClamperlGfx19, 0x60
+ax_sprite_terminator
+sClamperlGfx20:
+.incbin "baserom.gba", 0x151D948, 0x60
+sClamperlGfx20_1:
+.incbin "baserom.gba", 0x151D9A8, 0x60
+sClamperlSprites20:
+ax_sprite sClamperlGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClamperlGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClamperlGfx21:
+.incbin "baserom.gba", 0x151DA30, 0x40
+sClamperlSprites21:
+ax_sprite sClamperlGfx21, 0x40
+ax_sprite_terminator
+sClamperlGfx22:
+.incbin "baserom.gba", 0x151DA80, 0x60
+sClamperlGfx22_1:
+.incbin "baserom.gba", 0x151DAE0, 0x60
+sClamperlSprites22:
+ax_sprite sClamperlGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClamperlGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClamperlGfx23:
+.incbin "baserom.gba", 0x151DB68, 0x40
+sClamperlSprites23:
+ax_sprite sClamperlGfx23, 0x40
+ax_sprite_terminator
+sClamperlGfx24:
+.incbin "baserom.gba", 0x151DBB8, 0x100
+sClamperlSprites24:
+ax_sprite sClamperlGfx24, 0x100
+ax_sprite_terminator
+sClamperlGfx25:
+.incbin "baserom.gba", 0x151DCC8, 0x40
+sClamperlSprites25:
+ax_sprite sClamperlGfx25, 0x40
+ax_sprite_terminator
+sClamperlGfx26:
+.incbin "baserom.gba", 0x151DD18, 0x200
+sClamperlSprites26:
+ax_sprite sClamperlGfx26, 0x200
+ax_sprite_terminator
+sClamperlGfx27:
+.incbin "baserom.gba", 0x151DF28, 0x200
+sClamperlSprites27:
+ax_sprite sClamperlGfx27, 0x200
+ax_sprite_terminator
+sClamperlGfx28:
+.incbin "baserom.gba", 0x151E138, 0x200
+sClamperlSprites28:
+ax_sprite sClamperlGfx28, 0x200
+ax_sprite_terminator
+sClamperlGfx29:
+.incbin "baserom.gba", 0x151E348, 0x200
+sClamperlSprites29:
+ax_sprite sClamperlGfx29, 0x200
+ax_sprite_terminator
+sClamperlGfx30:
+.incbin "baserom.gba", 0x151E558, 0x200
+sClamperlSprites30:
+ax_sprite sClamperlGfx30, 0x200
+ax_sprite_terminator
+sClamperlGfx31:
+.incbin "baserom.gba", 0x151E768, 0x200
+sClamperlSprites31:
+ax_sprite sClamperlGfx31, 0x200
+ax_sprite_terminator
+sClamperlGfx32:
+.incbin "baserom.gba", 0x151E978, 0x200
+sClamperlSprites32:
+ax_sprite sClamperlGfx32, 0x200
+ax_sprite_terminator
+sAxPosesClamperl:
+.4byte sClamperlPose1
+.4byte sClamperlPose2
+.4byte sClamperlPose3
+.4byte sClamperlPose4
+.4byte sClamperlPose5
+.4byte sClamperlPose6
+.4byte sClamperlPose7
+.4byte sClamperlPose8
+.4byte sClamperlPose9
+.4byte sClamperlPose10
+.4byte sClamperlPose11
+.4byte sClamperlPose12
+.4byte sClamperlPose13
+.4byte sClamperlPose14
+.4byte sClamperlPose15
+.4byte sClamperlPose16
+.4byte sClamperlPose17
+.4byte sClamperlPose18
+.4byte sClamperlPose19
+.4byte sClamperlPose20
+.4byte sClamperlPose21
+.4byte sClamperlPose22
+.4byte sClamperlPose23
+.4byte sClamperlPose24
+.4byte sClamperlPose25
+.4byte sClamperlPose26
+.4byte sClamperlPose27
+.4byte sClamperlPose28
+.4byte sClamperlPose29
+.4byte sClamperlPose30
+.4byte sClamperlPose31
+.4byte sClamperlPose32
+.4byte sClamperlPose33
+.4byte sClamperlPose34
+.4byte sClamperlPose35
+.4byte sClamperlPose36
+.4byte sClamperlPose37
+.4byte sClamperlPose38
+.4byte sClamperlPose39
+.4byte sClamperlPose40
+.4byte sClamperlPose41
+.4byte sClamperlPose42
+.4byte sClamperlPose43
+.4byte sClamperlPose44
+.4byte sClamperlPose45
+.4byte sClamperlPose46
+.4byte sClamperlPose47
+.4byte sClamperlPose48
+.4byte sClamperlPose49
+.4byte sClamperlPose50
+.4byte sClamperlPose51
+.4byte sClamperlPose52
+.4byte sClamperlPose53
+.4byte sClamperlPose54
+.4byte sClamperlPose55
+.4byte sClamperlPose56
+.4byte sClamperlPose57
+.4byte sClamperlPose58
+.4byte sClamperlPose59
+.4byte sClamperlPose60
+.4byte sClamperlPose61
+.4byte sClamperlPose62
+.4byte sClamperlPose63
+.4byte sClamperlPose64
+.4byte sClamperlPose65
+.4byte sClamperlPose66
+.4byte sClamperlPose67
+.4byte sClamperlPose68
+.4byte sClamperlPose69
+.4byte sClamperlPose70
+.4byte sClamperlPose71
+.4byte sClamperlPose72
+.4byte sClamperlPose73
+.4byte sClamperlPose74
+.4byte sClamperlPose75
+.4byte sClamperlPose76
+.4byte sClamperlPose77
+.4byte sClamperlPose78
+.4byte sClamperlPose79
+.4byte sClamperlPose80
+.4byte sClamperlPose81
+.4byte sClamperlPose82
+.4byte sClamperlPose83
+.4byte sClamperlPose84
+.4byte sClamperlPose85
+.4byte sClamperlPose86
+.4byte sClamperlPose87
+.4byte sClamperlPose88
+.4byte sClamperlPose89
+.4byte sClamperlPose90
+.4byte sClamperlPose91
+.4byte sClamperlPose92
+.4byte sClamperlPose93
+.4byte sClamperlPose94
+.4byte sClamperlPose95
+.4byte sClamperlPose96
+.4byte sClamperlPose97
+.4byte sClamperlPose98
+.4byte sClamperlPose99
+.4byte sClamperlPose100
+.4byte sClamperlPose101
+.4byte sClamperlPose102
+.4byte sClamperlPose103
+.4byte sClamperlPose104
+.4byte sClamperlPose105
+.4byte sClamperlPose106
+.4byte sClamperlPose107
+.4byte sClamperlPose108
+.4byte sClamperlPose109
+.4byte sClamperlPose110
+.4byte sClamperlPose111
+.4byte sClamperlPose112
+.4byte sClamperlPose113
+.4byte sClamperlPose114
+.4byte sClamperlPose115
+.4byte sClamperlPose116
+.4byte sClamperlPose117
+.4byte sClamperlPose118
+.4byte sClamperlPose119
+.4byte sClamperlPose120
+.4byte sClamperlPose121
+.4byte sClamperlPose122
+.4byte sClamperlPose123
+.4byte sClamperlPose124
+.4byte sClamperlPose125
+.4byte sClamperlPose126
+.4byte sClamperlPose127
+.4byte sClamperlPose128
+.4byte sClamperlPose129
+.4byte sClamperlPose130
+.4byte sClamperlPose131
+.4byte sClamperlPose132
+.4byte sClamperlPose133
+.4byte sClamperlPose134
+.4byte sClamperlPose135
+.4byte sClamperlPose136
+.4byte sClamperlPose137
+.4byte sClamperlPose138
+.4byte sClamperlPose139
+.4byte sClamperlPose140
+.4byte sClamperlPose141
+.4byte sClamperlPose142
+.4byte sClamperlPose143
+.4byte sClamperlPose144
+.4byte sClamperlPose145
+.4byte sClamperlPose146
+.4byte sClamperlPose147
+.4byte sClamperlPose148
+.4byte sClamperlPose149
+.4byte sClamperlPose150
+.4byte sClamperlPose151
+.4byte sClamperlPose152
+.4byte sClamperlPose153
+.4byte sClamperlPose154
+.4byte sClamperlPose155
+.4byte sClamperlPose156
+.4byte sClamperlPose157
+.4byte sClamperlPose158
+.4byte sClamperlPose159
+.4byte sClamperlPose160
+.4byte sClamperlPose161
+.4byte sClamperlPose162
+.4byte sClamperlPose163
+.4byte sClamperlPose164
+.4byte sClamperlPose165
+.4byte sClamperlPose166
+.4byte sClamperlPose167
+.4byte sClamperlPose168
+.4byte sClamperlPose169
+.4byte sClamperlPose170
+.4byte sClamperlPose171
+.4byte sClamperlPose172
+.4byte sClamperlPose173
+.4byte sClamperlPose174
+.4byte sClamperlPose175
+.4byte sClamperlPose176
+.4byte sClamperlPose177
+.4byte sClamperlPose178
+.4byte sClamperlPose179
+.4byte sClamperlPose180
+.4byte sClamperlPose181
+.4byte sClamperlPose182
+.4byte sClamperlPose183
+.4byte sClamperlPose184
+.4byte sClamperlPose185
+.4byte sClamperlPose186
+.4byte sClamperlPose187
+.4byte sClamperlPose188
+.4byte sClamperlPose189
+.4byte sClamperlPose190
+.4byte sClamperlPose191
+.4byte sClamperlPose192
+.4byte sClamperlPose193
+.4byte sClamperlPose194
+.4byte sClamperlPose195
+.4byte sClamperlPose196
+.4byte sClamperlPose197
+.4byte sClamperlPose198
+.4byte sClamperlPose199
+.4byte sClamperlPose200
+.4byte sClamperlPose201
+.4byte sClamperlPose202
+.4byte sClamperlPose203
+.4byte sClamperlPose204
+.4byte sClamperlPose205
+.4byte sClamperlPose206
+.4byte sClamperlPose207
+.4byte sClamperlPose208
+.4byte sClamperlPose209
+.4byte sClamperlPose210
+.4byte sClamperlPose211
+.4byte sClamperlPose212
+.4byte sClamperlPose213
+.4byte sClamperlPose214
+.4byte sClamperlPose215
+.4byte sClamperlPose216
+.4byte sClamperlPose217
+.4byte sClamperlPose218
+sAxPositionsClamperl:
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -7, 	  -6,   -3, 	  -2,   -8
+.2byte    2,   -6, 	   4,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -6, 	   2,  -14, 	  -2,   -1, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte    1,  -10, 	  -6,  -12, 	   4,   -4, 	  -2,   -7
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -14, 	   0,   -1, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -7, 	  -6,   -3, 	  -2,   -8
+.2byte    2,   -6, 	   4,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -6, 	   2,  -14, 	  -2,   -1, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte    1,  -10, 	  -6,  -12, 	   4,   -4, 	  -2,   -7
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -14, 	   0,   -1, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -7, 	  -6,   -3, 	  -2,   -8
+.2byte    2,   -6, 	   4,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -6, 	   2,  -14, 	  -2,   -1, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte    1,  -10, 	  -6,  -12, 	   4,   -4, 	  -2,   -7
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -14, 	   0,   -1, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -7, 	  -6,   -3, 	  -2,   -8
+.2byte    2,   -6, 	   4,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    0,   -7, 	   4,  -10, 	  -7,   -4, 	  -3,   -9
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -6, 	   2,  -14, 	  -2,   -1, 	  -1,   -8
+.2byte    1,   -6, 	   1,  -11, 	   0,   -1, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte    1,  -10, 	  -6,  -12, 	   4,   -4, 	  -2,   -7
+.2byte    0,   -8, 	  -6,  -10, 	   3,   -2, 	  -3,   -7
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	   6,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte   -2,   -8, 	   4,  -10, 	  -5,   -2, 	   1,   -7
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -14, 	   0,   -1, 	  -1,   -8
+.2byte   -3,   -6, 	  -3,  -11, 	  -2,   -1, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -2,   -7, 	  -6,  -10, 	   5,   -4, 	   1,   -9
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -7, 	  -6,   -3, 	  -2,   -8
+.2byte    2,   -6, 	   4,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -6, 	   2,  -14, 	  -2,   -1, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte    1,  -10, 	  -6,  -12, 	   4,   -4, 	  -2,   -7
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -14, 	   0,   -1, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -3,   -6, 	  -6,  -13, 	   6,   -4, 	  -1,  -10
+.2byte   -3,   -5, 	  -6,  -12, 	   5,   -4, 	  -1,   -9
+.2byte   -1,   -3, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte    3,   -5, 	   6,  -11, 	  -4,   -4, 	   0,   -8
+.2byte    3,   -6, 	   3,  -14, 	   2,   -2, 	   1,   -8
+.2byte    4,   -9, 	  -2,  -15, 	   5,   -4, 	  -1,   -9
+.2byte    0,  -10, 	   7,   -8, 	  -7,   -8, 	   0,   -9
+.2byte   -5,   -9, 	   1,  -15, 	  -6,   -4, 	   0,   -9
+.2byte   -4,   -6, 	  -4,  -14, 	  -3,   -2, 	  -2,   -8
+.2byte   -4,   -5, 	  -7,  -11, 	   3,   -4, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -7, 	  -6,   -3, 	  -2,   -8
+.2byte    2,   -6, 	   4,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -6, 	   2,  -14, 	  -2,   -1, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte    1,  -10, 	  -6,  -12, 	   4,   -4, 	  -2,   -7
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -14, 	   0,   -1, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte    0,   -5, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -4,   -6, 	  -3,  -14, 	   1,   -1, 	   0,   -8
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte    0,   -9, 	   8,   -5, 	  -7,   -5, 	   0,   -6
+.2byte    2,  -10, 	  -5,  -12, 	   5,   -4, 	  -1,   -7
+.2byte    4,   -6, 	   3,  -14, 	  -1,   -1, 	   0,   -8
+.2byte    4,   -6, 	   6,  -11, 	  -5,   -4, 	   1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte    1,   -6, 	   6,   -7, 	  -5,   -3, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -7, 	  -6,   -3, 	  -2,   -8
+.2byte    2,   -6, 	   4,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   2,  -10, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -6, 	   2,  -14, 	  -2,   -1, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -8, 	  -5,   -9, 	   3,   -3, 	  -3,   -7
+.2byte    1,  -10, 	  -6,  -12, 	   4,   -4, 	  -2,   -7
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -3,  -10, 	   4,  -12, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	  -4,  -10, 	   0,   -2, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -14, 	   0,   -1, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -7, 	   4,   -3, 	   0,   -8
+.2byte   -4,   -6, 	  -6,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -1,   -6, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -3,   -7, 	  -7,  -10, 	   4,   -4, 	   0,   -9
+.2byte   -3,   -6, 	  -3,  -11, 	  -2,   -1, 	  -1,   -8
+.2byte   -3,   -8, 	   3,  -10, 	  -6,   -2, 	   0,   -7
+.2byte   -1,  -10, 	   6,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte    1,   -8, 	  -5,  -10, 	   4,   -2, 	  -2,   -7
+.2byte    2,   -6, 	   2,  -11, 	   1,   -1, 	   0,   -8
+.2byte    1,   -7, 	   5,  -10, 	  -6,   -4, 	  -2,   -9
+.2byte   -1,   -6, 	  -7,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -2,   -6, 	  -7,   -8, 	   4,   -3, 	   0,   -8
+.2byte   -3,   -7, 	  -2,  -11, 	   0,   -2, 	  -1,   -8
+.2byte   -2,   -8, 	   3,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -1,  -10, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte    0,   -8, 	  -5,  -10, 	   3,   -3, 	  -4,   -8
+.2byte    1,   -7, 	   0,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -8, 	  -6,   -3, 	  -2,   -8
+sClamperlAnimTable1:
+.4byte sClamperlAnims_1_1
+.4byte sClamperlAnims_1_2
+.4byte sClamperlAnims_1_3
+.4byte sClamperlAnims_1_4
+.4byte sClamperlAnims_1_5
+.4byte sClamperlAnims_1_6
+.4byte sClamperlAnims_1_7
+.4byte sClamperlAnims_1_8
+sClamperlAnimTable2:
+.4byte sClamperlAnims_2_1
+.4byte sClamperlAnims_2_2
+.4byte sClamperlAnims_2_3
+.4byte sClamperlAnims_2_4
+.4byte sClamperlAnims_2_5
+.4byte sClamperlAnims_2_6
+.4byte sClamperlAnims_2_7
+.4byte sClamperlAnims_2_8
+sClamperlAnimTable3:
+.4byte sClamperlAnims_3_1
+.4byte sClamperlAnims_3_2
+.4byte sClamperlAnims_3_3
+.4byte sClamperlAnims_3_4
+.4byte sClamperlAnims_3_5
+.4byte sClamperlAnims_3_6
+.4byte sClamperlAnims_3_7
+.4byte sClamperlAnims_3_8
+sClamperlAnimTable4:
+.4byte sClamperlAnims_4_1
+.4byte sClamperlAnims_4_2
+.4byte sClamperlAnims_4_3
+.4byte sClamperlAnims_4_4
+.4byte sClamperlAnims_4_5
+.4byte sClamperlAnims_4_6
+.4byte sClamperlAnims_4_7
+.4byte sClamperlAnims_4_8
+sClamperlAnimTable5:
+.4byte sClamperlAnims_5_1
+.4byte sClamperlAnims_5_2
+.4byte sClamperlAnims_5_3
+.4byte sClamperlAnims_5_4
+.4byte sClamperlAnims_5_5
+.4byte sClamperlAnims_5_6
+.4byte sClamperlAnims_5_7
+.4byte sClamperlAnims_5_8
+sClamperlAnimTable6:
+.4byte sClamperlAnims_6_1
+.4byte sClamperlAnims_6_1
+.4byte sClamperlAnims_6_1
+.4byte sClamperlAnims_6_1
+.4byte sClamperlAnims_6_1
+.4byte sClamperlAnims_6_1
+.4byte sClamperlAnims_6_1
+.4byte sClamperlAnims_6_1
+sClamperlAnimTable7:
+.4byte sClamperlAnims_7_1
+.4byte sClamperlAnims_7_2
+.4byte sClamperlAnims_7_3
+.4byte sClamperlAnims_7_4
+.4byte sClamperlAnims_7_5
+.4byte sClamperlAnims_7_6
+.4byte sClamperlAnims_7_7
+.4byte sClamperlAnims_7_8
+sClamperlAnimTable8:
+.4byte sClamperlAnims_8_1
+.4byte sClamperlAnims_8_2
+.4byte sClamperlAnims_8_3
+.4byte sClamperlAnims_8_4
+.4byte sClamperlAnims_8_5
+.4byte sClamperlAnims_8_6
+.4byte sClamperlAnims_8_7
+.4byte sClamperlAnims_8_8
+sClamperlAnimTable9:
+.4byte sClamperlAnims_9_1
+.4byte sClamperlAnims_9_2
+.4byte sClamperlAnims_9_3
+.4byte sClamperlAnims_9_4
+.4byte sClamperlAnims_9_5
+.4byte sClamperlAnims_9_6
+.4byte sClamperlAnims_9_7
+.4byte sClamperlAnims_9_8
+sClamperlAnimTable10:
+.4byte sClamperlAnims_10_1
+.4byte sClamperlAnims_10_2
+.4byte sClamperlAnims_10_3
+.4byte sClamperlAnims_10_4
+.4byte sClamperlAnims_10_5
+.4byte sClamperlAnims_10_6
+.4byte sClamperlAnims_10_7
+.4byte sClamperlAnims_10_8
+sClamperlAnimTable11:
+.4byte sClamperlAnims_11_1
+.4byte sClamperlAnims_11_2
+.4byte sClamperlAnims_11_3
+.4byte sClamperlAnims_11_4
+.4byte sClamperlAnims_11_5
+.4byte sClamperlAnims_11_6
+.4byte sClamperlAnims_11_7
+.4byte sClamperlAnims_11_8
+sClamperlAnimTable12:
+.4byte sClamperlAnims_12_1
+.4byte sClamperlAnims_12_2
+.4byte sClamperlAnims_12_3
+.4byte sClamperlAnims_12_4
+.4byte sClamperlAnims_12_5
+.4byte sClamperlAnims_12_6
+.4byte sClamperlAnims_12_7
+.4byte sClamperlAnims_12_8
+sClamperlAnimTable13:
+.4byte sClamperlAnims_13_1
+.4byte sClamperlAnims_13_2
+.4byte sClamperlAnims_13_3
+.4byte sClamperlAnims_13_4
+.4byte sClamperlAnims_13_5
+.4byte sClamperlAnims_13_6
+.4byte sClamperlAnims_13_7
+.4byte sClamperlAnims_13_8
+sAxAnimationsClamperl:
+.4byte sClamperlAnimTable1
+.4byte sClamperlAnimTable2
+.4byte sClamperlAnimTable3
+.4byte sClamperlAnimTable4
+.4byte sClamperlAnimTable5
+.4byte sClamperlAnimTable6
+.4byte sClamperlAnimTable7
+.4byte sClamperlAnimTable8
+.4byte sClamperlAnimTable9
+.4byte sClamperlAnimTable10
+.4byte sClamperlAnimTable11
+.4byte sClamperlAnimTable12
+.4byte sClamperlAnimTable13
+sAxSpritesClamperl:
+.4byte sClamperlSprites1
+.4byte sClamperlSprites2
+.4byte sClamperlSprites3
+.4byte sClamperlSprites4
+.4byte sClamperlSprites5
+.4byte sClamperlSprites6
+.4byte sClamperlSprites7
+.4byte sClamperlSprites8
+.4byte sClamperlSprites9
+.4byte sClamperlSprites10
+.4byte sClamperlSprites11
+.4byte sClamperlSprites12
+.4byte sClamperlSprites13
+.4byte sClamperlSprites14
+.4byte sClamperlSprites15
+.4byte sClamperlSprites16
+.4byte sClamperlSprites17
+.4byte sClamperlSprites18
+.4byte sClamperlSprites19
+.4byte sClamperlSprites20
+.4byte sClamperlSprites21
+.4byte sClamperlSprites22
+.4byte sClamperlSprites23
+.4byte sClamperlSprites24
+.4byte sClamperlSprites25
+.4byte sClamperlSprites26
+.4byte sClamperlSprites27
+.4byte sClamperlSprites28
+.4byte sClamperlSprites29
+.4byte sClamperlSprites30
+.4byte sClamperlSprites31
+.4byte sClamperlSprites32
+sAxMainClamperl:
+ax_main sAxPosesClamperl, sAxAnimationsClamperl, 13, sAxSpritesClamperl, sAxPositionsClamperl

--- a/data/ax/claydol.inc
+++ b/data/ax/claydol.inc
@@ -1,0 +1,2647 @@
+.global gAxClaydol
+gAxClaydol:
+ax_siro sAxMainClaydol
+sClaydolPose1:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose3:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose4:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose5:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose6:
+ax_pose 5, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose7:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose8:
+ax_pose 7, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose9:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose10:
+ax_pose 9, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose11:
+ax_pose 6, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose12:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose13:
+ax_pose 4, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose14:
+ax_pose 5, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose15:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose16:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose17:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose18:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose19:
+ax_pose 4, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose20:
+ax_pose 6, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose21:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose22:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose23:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose24:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose25:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose26:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose27:
+ax_pose 4, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose28:
+ax_pose 6, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose29:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose30:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose31:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose32:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose33:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose34:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose35:
+ax_pose 10, 0x01f4, 0x00f5, 0x5c00
+ax_pose 11, 0x01f4, 0x1104, 0x5c01
+ax_pose 12, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose36:
+ax_pose 10, 0x01f4, 0x00f1, 0x5c00
+ax_pose 11, 0x01f4, 0x1108, 0x5c01
+ax_pose 12, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose37:
+ax_pose 10, 0x01f4, 0x00ef, 0x5c00
+ax_pose 11, 0x01f4, 0x110a, 0x5c01
+ax_pose 12, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose38:
+ax_pose 10, 0x01eb, 0x00ef, 0x5c00
+ax_pose 11, 0x01eb, 0x110a, 0x5c01
+ax_pose 12, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose39:
+ax_pose 10, 0x01e8, 0x00ef, 0x5c00
+ax_pose 11, 0x01e8, 0x110a, 0x5c01
+ax_pose 12, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose40:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose41:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose42:
+ax_pose 13, 0x01f4, 0x10f6, 0x5c00
+ax_pose 14, 0x01e7, 0x90ed, 0x5c01
+ax_pose 15, 0x01f0, 0x1104, 0x5c11
+ax_pose_terminator
+sClaydolPose43:
+ax_pose 13, 0x01f5, 0x10f4, 0x5c00
+ax_pose 14, 0x01e7, 0x90ed, 0x5c01
+ax_pose 15, 0x01ef, 0x1107, 0x5c11
+ax_pose_terminator
+sClaydolPose44:
+ax_pose 13, 0x01f6, 0x10f2, 0x5c00
+ax_pose 14, 0x01e7, 0x90ed, 0x5c01
+ax_pose 15, 0x01ef, 0x1109, 0x5c11
+ax_pose_terminator
+sClaydolPose45:
+ax_pose 13, 0x01ef, 0x10ea, 0x5c00
+ax_pose 14, 0x01e7, 0x90ed, 0x5c01
+ax_pose 15, 0x01e8, 0x1101, 0x5c11
+ax_pose_terminator
+sClaydolPose46:
+ax_pose 13, 0x01ed, 0x10e8, 0x5c00
+ax_pose 14, 0x01e7, 0x90ed, 0x5c01
+ax_pose 15, 0x01e6, 0x10ff, 0x5c11
+ax_pose_terminator
+sClaydolPose47:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose48:
+ax_pose 5, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose49:
+ax_pose 16, 0x01f6, 0x10fd, 0x5c00
+ax_pose 17, 0x01e7, 0x90ed, 0x5c01
+ax_pose 18, 0x01ec, 0x10fc, 0x5c11
+ax_pose_terminator
+sClaydolPose50:
+ax_pose 16, 0x01fa, 0x10fd, 0x5c00
+ax_pose 17, 0x01e7, 0x90ed, 0x5c01
+ax_pose 18, 0x01ec, 0x10fc, 0x5c11
+ax_pose_terminator
+sClaydolPose51:
+ax_pose 16, 0x01fd, 0x10fd, 0x5c00
+ax_pose 17, 0x01e7, 0x90ed, 0x5c01
+ax_pose 18, 0x01ec, 0x10fc, 0x5c11
+ax_pose_terminator
+sClaydolPose52:
+ax_pose 16, 0x01fd, 0x10f0, 0x5c00
+ax_pose 17, 0x01e7, 0x90ed, 0x5c01
+ax_pose 18, 0x01ec, 0x10f0, 0x5c11
+ax_pose_terminator
+sClaydolPose53:
+ax_pose 16, 0x01fd, 0x10ee, 0x5c00
+ax_pose 17, 0x01e7, 0x90ed, 0x5c01
+ax_pose 18, 0x01ec, 0x10ee, 0x5c11
+ax_pose_terminator
+sClaydolPose54:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose55:
+ax_pose 7, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose56:
+ax_pose 19, 0x01f5, 0x1104, 0x5c00
+ax_pose 20, 0x01e7, 0x90ed, 0x5c01
+ax_pose 21, 0x01f1, 0x10f7, 0x5c11
+ax_pose_terminator
+sClaydolPose57:
+ax_pose 19, 0x01f7, 0x1106, 0x5c00
+ax_pose 20, 0x01e7, 0x90ed, 0x5c01
+ax_pose 21, 0x01f0, 0x10f5, 0x5c11
+ax_pose_terminator
+sClaydolPose58:
+ax_pose 19, 0x01f8, 0x1108, 0x5c00
+ax_pose 20, 0x01e7, 0x90ed, 0x5c01
+ax_pose 21, 0x01ef, 0x10f3, 0x5c11
+ax_pose_terminator
+sClaydolPose59:
+ax_pose 19, 0x01ff, 0x10ff, 0x5c00
+ax_pose 20, 0x01e7, 0x90ed, 0x5c01
+ax_pose 21, 0x01f4, 0x10eb, 0x5c11
+ax_pose_terminator
+sClaydolPose60:
+ax_pose 19, 0x0202, 0x10fb, 0x5c00
+ax_pose 20, 0x01e7, 0x90ed, 0x5c01
+ax_pose 21, 0x01f6, 0x10e8, 0x5c11
+ax_pose_terminator
+sClaydolPose61:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose62:
+ax_pose 9, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose63:
+ax_pose 22, 0x01f4, 0x00f4, 0x5c00
+ax_pose 23, 0x01f4, 0x0103, 0x5c01
+ax_pose 24, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose64:
+ax_pose 22, 0x01f4, 0x00f0, 0x5c00
+ax_pose 23, 0x01f4, 0x0107, 0x5c01
+ax_pose 24, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose65:
+ax_pose 22, 0x01f4, 0x00ee, 0x5c00
+ax_pose 23, 0x01f4, 0x0109, 0x5c01
+ax_pose 24, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose66:
+ax_pose 22, 0x01fd, 0x00ee, 0x5c00
+ax_pose 23, 0x01fd, 0x0109, 0x5c01
+ax_pose 24, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose67:
+ax_pose 22, 0x0200, 0x00ee, 0x5c00
+ax_pose 23, 0x0200, 0x0109, 0x5c01
+ax_pose 24, 0x01e7, 0x80f4, 0x5c02
+ax_pose_terminator
+sClaydolPose68:
+ax_pose 6, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose69:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose70:
+ax_pose 21, 0x01f5, 0x00f5, 0x5c00
+ax_pose 20, 0x01e7, 0x80f4, 0x5c01
+ax_pose 19, 0x01f1, 0x0102, 0x5c11
+ax_pose_terminator
+sClaydolPose71:
+ax_pose 21, 0x01f7, 0x00f3, 0x5c00
+ax_pose 20, 0x01e7, 0x80f4, 0x5c01
+ax_pose 19, 0x01f0, 0x0104, 0x5c11
+ax_pose_terminator
+sClaydolPose72:
+ax_pose 21, 0x01f8, 0x00f1, 0x5c00
+ax_pose 20, 0x01e7, 0x80f4, 0x5c01
+ax_pose 19, 0x01ef, 0x0106, 0x5c11
+ax_pose_terminator
+sClaydolPose73:
+ax_pose 21, 0x01ff, 0x00fa, 0x5c00
+ax_pose 20, 0x01e7, 0x80f4, 0x5c01
+ax_pose 19, 0x01f4, 0x010e, 0x5c11
+ax_pose_terminator
+sClaydolPose74:
+ax_pose 21, 0x0202, 0x00fe, 0x5c00
+ax_pose 20, 0x01e7, 0x80f4, 0x5c01
+ax_pose 19, 0x01f6, 0x0111, 0x5c11
+ax_pose_terminator
+sClaydolPose75:
+ax_pose 4, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose76:
+ax_pose 5, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose77:
+ax_pose 18, 0x01f6, 0x00fc, 0x5c00
+ax_pose 17, 0x01e7, 0x80f4, 0x5c01
+ax_pose 16, 0x01ec, 0x00fd, 0x5c11
+ax_pose_terminator
+sClaydolPose78:
+ax_pose 18, 0x01fa, 0x00fc, 0x5c00
+ax_pose 17, 0x01e7, 0x80f4, 0x5c01
+ax_pose 16, 0x01ec, 0x00fd, 0x5c11
+ax_pose_terminator
+sClaydolPose79:
+ax_pose 18, 0x01fd, 0x00fc, 0x5c00
+ax_pose 17, 0x01e7, 0x80f4, 0x5c01
+ax_pose 16, 0x01ec, 0x00fd, 0x5c11
+ax_pose_terminator
+sClaydolPose80:
+ax_pose 18, 0x01fd, 0x0109, 0x5c00
+ax_pose 17, 0x01e7, 0x80f4, 0x5c01
+ax_pose 16, 0x01ec, 0x0109, 0x5c11
+ax_pose_terminator
+sClaydolPose81:
+ax_pose 18, 0x01fd, 0x010b, 0x5c00
+ax_pose 17, 0x01e7, 0x80f4, 0x5c01
+ax_pose 16, 0x01ec, 0x010b, 0x5c11
+ax_pose_terminator
+sClaydolPose82:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose83:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose84:
+ax_pose 15, 0x01f4, 0x0103, 0x5c00
+ax_pose 14, 0x01e7, 0x80f4, 0x5c01
+ax_pose 13, 0x01f0, 0x00f5, 0x5c11
+ax_pose_terminator
+sClaydolPose85:
+ax_pose 15, 0x01f5, 0x0105, 0x5c00
+ax_pose 14, 0x01e7, 0x80f4, 0x5c01
+ax_pose 13, 0x01ef, 0x00f2, 0x5c11
+ax_pose_terminator
+sClaydolPose86:
+ax_pose 15, 0x01f6, 0x0107, 0x5c00
+ax_pose 14, 0x01e7, 0x80f4, 0x5c01
+ax_pose 13, 0x01ef, 0x00f0, 0x5c11
+ax_pose_terminator
+sClaydolPose87:
+ax_pose 15, 0x01ef, 0x010f, 0x5c00
+ax_pose 14, 0x01e7, 0x80f4, 0x5c01
+ax_pose 13, 0x01e8, 0x00f8, 0x5c11
+ax_pose_terminator
+sClaydolPose88:
+ax_pose 15, 0x01ed, 0x0111, 0x5c00
+ax_pose 14, 0x01e7, 0x80f4, 0x5c01
+ax_pose 13, 0x01e6, 0x00fa, 0x5c11
+ax_pose_terminator
+sClaydolPose89:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose90:
+ax_pose 25, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose91:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose92:
+ax_pose 26, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose93:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose94:
+ax_pose 27, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose95:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose96:
+ax_pose 28, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose97:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose98:
+ax_pose 29, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose99:
+ax_pose 6, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose100:
+ax_pose 28, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose101:
+ax_pose 4, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose102:
+ax_pose 27, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose103:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose104:
+ax_pose 26, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose105:
+ax_pose 30, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose106:
+ax_pose 31, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose107:
+ax_pose 32, 0x81e1, 0x4103, 0x5c00
+ax_pose 33, 0x01e9, 0x00eb, 0x5c04
+ax_pose 34, 0x81f1, 0x010b, 0x5c05
+ax_pose 35, 0x81e1, 0x80f3, 0x5c07
+ax_pose_terminator
+sClaydolPose108:
+ax_pose 36, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sClaydolPose109:
+ax_pose 37, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sClaydolPose110:
+ax_pose 38, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sClaydolPose111:
+ax_pose 39, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sClaydolPose112:
+ax_pose 38, 0x01e3, 0x80ef, 0x5c00
+ax_pose_terminator
+sClaydolPose113:
+ax_pose 37, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sClaydolPose114:
+ax_pose 36, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sClaydolPose115:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose116:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose117:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose118:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose119:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose120:
+ax_pose 5, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose121:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose122:
+ax_pose 7, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose123:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose124:
+ax_pose 9, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose125:
+ax_pose 6, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose126:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose127:
+ax_pose 4, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose128:
+ax_pose 5, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose129:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose130:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose131:
+ax_pose 25, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose132:
+ax_pose 26, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sClaydolPose133:
+ax_pose 27, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sClaydolPose134:
+ax_pose 28, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sClaydolPose135:
+ax_pose 29, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose136:
+ax_pose 28, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose137:
+ax_pose 27, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sClaydolPose138:
+ax_pose 26, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sClaydolPose139:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose140:
+ax_pose 3, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose141:
+ax_pose 5, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose142:
+ax_pose 7, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose143:
+ax_pose 9, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose144:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose145:
+ax_pose 5, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose146:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose147:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose148:
+ax_pose 25, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose149:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose150:
+ax_pose 26, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sClaydolPose151:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose152:
+ax_pose 27, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sClaydolPose153:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose154:
+ax_pose 28, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose155:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose156:
+ax_pose 29, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose157:
+ax_pose 6, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sClaydolPose158:
+ax_pose 28, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sClaydolPose159:
+ax_pose 4, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sClaydolPose160:
+ax_pose 27, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sClaydolPose161:
+ax_pose 2, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sClaydolPose162:
+ax_pose 26, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sClaydolPose163:
+ax_pose 25, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose164:
+ax_pose 26, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sClaydolPose165:
+ax_pose 27, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sClaydolPose166:
+ax_pose 28, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose167:
+ax_pose 29, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose168:
+ax_pose 28, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sClaydolPose169:
+ax_pose 27, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose170:
+ax_pose 26, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sClaydolPose171:
+ax_pose 0, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose172:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose173:
+ax_pose 4, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose174:
+ax_pose 6, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose175:
+ax_pose 8, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sClaydolPose176:
+ax_pose 6, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose177:
+ax_pose 4, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sClaydolPose178:
+ax_pose 2, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+.align 2
+sClaydolAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_1_2:
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_1_3:
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_1_4:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_1_5:
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_1_6:
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_1_7:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_1_8:
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_2_1:
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 2, 20, 0, 4, 0, 4,
+ax_anim 2, 0, 21, 0, 11, 0, 11,
+ax_anim 2, 0, 22, 0, 21, 0, 21,
+ax_anim 1, 1, 23, 0, 22, 0, 22,
+ax_anim 1, 0, 16, 0, 22, 0, 22,
+ax_anim 1, 0, 17, 0, 22, 0, 22,
+ax_anim 1, 0, 18, 0, 22, 0, 22,
+ax_anim 1, 0, 19, 0, 22, 0, 22,
+ax_anim 1, 0, 20, 0, 22, 0, 22,
+ax_anim 2, 0, 21, 0, 14, 0, 14,
+ax_anim 2, 0, 22, 0, 6, 0, 6,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_2_2:
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 2, 19, 4, 4, 4, 4,
+ax_anim 2, 0, 20, 11, 11, 11, 11,
+ax_anim 2, 0, 21, 21, 21, 21, 21,
+ax_anim 1, 1, 22, 22, 22, 22, 22,
+ax_anim 1, 0, 23, 22, 22, 22, 22,
+ax_anim 1, 0, 16, 22, 22, 22, 22,
+ax_anim 1, 0, 17, 22, 22, 22, 22,
+ax_anim 1, 0, 18, 22, 22, 22, 22,
+ax_anim 1, 0, 19, 22, 22, 22, 22,
+ax_anim 2, 0, 20, 14, 14, 14, 14,
+ax_anim 2, 0, 21, 6, 6, 6, 6,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_2_3:
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 2, 18, 4, 0, 4, 0,
+ax_anim 2, 0, 19, 11, 0, 11, 0,
+ax_anim 2, 0, 20, 21, 0, 21, 0,
+ax_anim 1, 1, 21, 22, 0, 22, 0,
+ax_anim 1, 0, 22, 22, 0, 22, 0,
+ax_anim 1, 0, 23, 22, 0, 22, 0,
+ax_anim 1, 0, 16, 22, 0, 22, 0,
+ax_anim 1, 0, 17, 22, 0, 22, 0,
+ax_anim 1, 0, 18, 22, 0, 22, 0,
+ax_anim 2, 0, 19, 14, 0, 14, 0,
+ax_anim 2, 0, 20, 6, 0, 6, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_2_4:
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 2, 17, 4, -4, 4, -4,
+ax_anim 2, 0, 18, 11, -9, 11, -9,
+ax_anim 2, 0, 19, 21, -17, 21, -17,
+ax_anim 1, 1, 20, 22, -18, 22, -18,
+ax_anim 1, 0, 21, 22, -18, 22, -18,
+ax_anim 1, 0, 22, 22, -18, 22, -18,
+ax_anim 1, 0, 23, 22, -18, 22, -18,
+ax_anim 1, 0, 16, 22, -18, 22, -18,
+ax_anim 1, 0, 17, 22, -18, 22, -18,
+ax_anim 2, 0, 18, 14, -12, 14, -12,
+ax_anim 2, 0, 19, 6, -5, 6, -5,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_2_5:
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 2, 16, 0, -4, 0, -4,
+ax_anim 2, 0, 17, 0, -9, 0, -9,
+ax_anim 2, 0, 18, 0, -17, 0, -17,
+ax_anim 1, 1, 19, 0, -18, 0, -18,
+ax_anim 1, 0, 20, 0, -18, 0, -18,
+ax_anim 1, 0, 21, 0, -18, 0, -18,
+ax_anim 1, 0, 22, 0, -18, 0, -18,
+ax_anim 1, 0, 23, 0, -18, 0, -18,
+ax_anim 1, 0, 16, 0, -18, 0, -18,
+ax_anim 2, 0, 17, 0, -12, 0, -12,
+ax_anim 2, 0, 18, 0, -5, 0, -5,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_2_6:
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 2, 23, -4, -4, -4, -4,
+ax_anim 2, 0, 16, -11, -9, -11, -9,
+ax_anim 2, 0, 17, -21, -17, -21, -17,
+ax_anim 1, 1, 18, -22, -18, -22, -18,
+ax_anim 1, 0, 19, -22, -18, -22, -18,
+ax_anim 1, 0, 20, -22, -18, -22, -18,
+ax_anim 1, 0, 21, -22, -18, -22, -18,
+ax_anim 1, 0, 22, -22, -18, -22, -18,
+ax_anim 1, 0, 23, -22, -18, -22, -18,
+ax_anim 2, 0, 16, -14, -12, -14, -12,
+ax_anim 2, 0, 17, -6, -5, -6, -5,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_2_7:
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 2, 22, -4, 0, -4, 0,
+ax_anim 2, 0, 23, -11, 0, -11, 0,
+ax_anim 2, 0, 16, -21, 0, -21, 0,
+ax_anim 1, 1, 17, -22, 0, -22, 0,
+ax_anim 1, 0, 18, -22, 0, -22, 0,
+ax_anim 1, 0, 19, -22, 0, -22, 0,
+ax_anim 1, 0, 20, -22, 0, -22, 0,
+ax_anim 1, 0, 21, -22, 0, -22, 0,
+ax_anim 1, 0, 22, -22, 0, -22, 0,
+ax_anim 2, 0, 23, -14, 0, -14, 0,
+ax_anim 2, 0, 16, -6, 0, -6, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_2_8:
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim 2, 2, 21, -4, 4, -4, 4,
+ax_anim 2, 0, 22, -11, 11, -11, 11,
+ax_anim 2, 0, 23, -21, 21, -21, 21,
+ax_anim 1, 1, 16, -22, 22, -22, 22,
+ax_anim 1, 0, 17, -22, 22, -22, 22,
+ax_anim 1, 0, 18, -22, 22, -22, 22,
+ax_anim 1, 0, 19, -22, 22, -22, 22,
+ax_anim 1, 0, 20, -22, 22, -22, 22,
+ax_anim 1, 0, 21, -22, 22, -22, 22,
+ax_anim 2, 0, 22, -14, 14, -14, 14,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_3_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 0, 8, 0, 8,
+ax_anim 1, 0, 29, 0, 22, 0, 22,
+ax_anim 1, 0, 30, 0, 44, 0, 44,
+ax_anim 1, 1, 31, 0, 46, 0, 46,
+ax_anim 1, 0, 24, 0, 46, 0, 46,
+ax_anim 1, 0, 25, 0, 46, 0, 46,
+ax_anim 1, 0, 26, 0, 46, 0, 46,
+ax_anim 1, 0, 27, 0, 46, 0, 46,
+ax_anim 1, 0, 28, 0, 46, 0, 46,
+ax_anim 2, 0, 29, 0, 28, 0, 28,
+ax_anim 2, 0, 30, 0, 12, 0, 12,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_3_2:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 8, 8, 8, 8,
+ax_anim 1, 0, 28, 22, 22, 22, 22,
+ax_anim 1, 0, 29, 42, 42, 42, 42,
+ax_anim 1, 1, 30, 46, 46, 46, 46,
+ax_anim 1, 0, 31, 46, 46, 46, 46,
+ax_anim 1, 0, 24, 46, 46, 46, 46,
+ax_anim 1, 0, 25, 46, 46, 46, 46,
+ax_anim 1, 0, 26, 46, 46, 46, 46,
+ax_anim 1, 0, 27, 46, 46, 46, 46,
+ax_anim 2, 0, 28, 28, 28, 28, 28,
+ax_anim 2, 0, 29, 12, 12, 12, 12,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_3_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 8, 0, 8, 0,
+ax_anim 1, 0, 27, 22, 0, 22, 0,
+ax_anim 1, 0, 28, 44, 0, 44, 0,
+ax_anim 1, 1, 29, 46, 0, 46, 0,
+ax_anim 1, 0, 30, 46, 0, 46, 0,
+ax_anim 1, 0, 31, 46, 0, 46, 0,
+ax_anim 1, 0, 24, 46, 0, 46, 0,
+ax_anim 1, 0, 25, 46, 0, 46, 0,
+ax_anim 1, 0, 26, 46, 0, 46, 0,
+ax_anim 2, 0, 27, 28, 0, 28, 0,
+ax_anim 2, 0, 28, 12, 0, 12, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_3_4:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 8, -8, 8, -8,
+ax_anim 1, 0, 26, 22, -21, 22, -21,
+ax_anim 1, 0, 27, 44, -40, 44, -40,
+ax_anim 1, 1, 28, 46, -42, 46, -42,
+ax_anim 1, 0, 29, 46, -42, 46, -42,
+ax_anim 1, 0, 30, 46, -42, 46, -42,
+ax_anim 1, 0, 31, 46, -42, 46, -42,
+ax_anim 1, 0, 24, 46, -42, 46, -42,
+ax_anim 1, 0, 25, 46, -42, 46, -42,
+ax_anim 2, 0, 26, 28, -26, 28, -26,
+ax_anim 2, 0, 27, 12, -11, 12, -11,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_3_5:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, -8, 0, -8,
+ax_anim 1, 0, 25, 0, -18, 0, -18,
+ax_anim 1, 0, 26, 0, -34, 0, -34,
+ax_anim 1, 1, 28, 0, -40, 0, -40,
+ax_anim 1, 0, 29, 0, -42, 0, -42,
+ax_anim 1, 0, 29, 0, -42, 0, -42,
+ax_anim 1, 0, 30, 0, -42, 0, -42,
+ax_anim 1, 0, 31, 0, -42, 0, -42,
+ax_anim 1, 0, 24, 0, -42, 0, -42,
+ax_anim 2, 0, 25, 0, -24, 0, -24,
+ax_anim 2, 0, 26, 0, -10, 0, -10,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_3_6:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, -8, -8, -8, -8,
+ax_anim 1, 0, 24, -22, -21, -22, -21,
+ax_anim 1, 0, 25, -44, -40, -44, -40,
+ax_anim 1, 1, 26, -46, -42, -46, -42,
+ax_anim 1, 0, 27, -46, -42, -46, -42,
+ax_anim 1, 0, 28, -46, -42, -46, -42,
+ax_anim 1, 0, 29, -46, -42, -46, -42,
+ax_anim 1, 0, 30, -46, -42, -46, -42,
+ax_anim 1, 0, 31, -46, -42, -46, -42,
+ax_anim 2, 0, 24, -28, -26, -28, -26,
+ax_anim 2, 0, 25, -12, -11, -12, -11,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_3_7:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 24, -8, 0, -8, 0,
+ax_anim 1, 0, 25, -22, 0, -22, 0,
+ax_anim 1, 0, 26, -44, 0, -44, 0,
+ax_anim 1, 1, 27, -46, 0, -46, 0,
+ax_anim 1, 0, 28, -46, 0, -46, 0,
+ax_anim 1, 0, 29, -46, 0, -46, 0,
+ax_anim 1, 0, 30, -46, 0, -46, 0,
+ax_anim 1, 0, 31, -46, 0, -46, 0,
+ax_anim 1, 0, 24, -46, 0, -46, 0,
+ax_anim 2, 0, 25, -28, 0, -28, 0,
+ax_anim 2, 0, 26, -12, 0, -12, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_3_8:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, -8, 8, -8, 8,
+ax_anim 1, 0, 30, -22, 22, -22, 22,
+ax_anim 1, 0, 31, -42, 42, -42, 42,
+ax_anim 1, 1, 24, -46, 46, -46, 46,
+ax_anim 1, 0, 25, -46, 46, -46, 46,
+ax_anim 1, 0, 26, -46, 46, -46, 46,
+ax_anim 1, 0, 27, -46, 46, -46, 46,
+ax_anim 1, 0, 28, -46, 46, -46, 46,
+ax_anim 1, 0, 29, -46, 46, -46, 46,
+ax_anim 2, 0, 30, -28, 28, -28, 28,
+ax_anim 2, 0, 31, -12, 12, -12, 12,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_4_1:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 4, 2, 35, 0, 0, 0, 0,
+ax_anim 6, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 1, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, -3, 0, -3,
+ax_anim 1, 0, 38, 0, -4, 0, -4,
+ax_anim 4, 0, 38, 0, -5, 0, -5,
+ax_anim 2, 0, 37, 0, -5, 0, -5,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 0, 36, 0, -3, 0, -3,
+ax_anim 2, 0, 35, 0, -2, 0, -2,
+ax_anim_terminator
+sClaydolAnims_4_2:
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 4, 2, 42, 0, 0, 0, 0,
+ax_anim 6, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 1, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 44, -3, -3, -3, -3,
+ax_anim 1, 0, 45, -4, -4, -4, -4,
+ax_anim 4, 0, 45, -5, -5, -5, -5,
+ax_anim 2, 0, 44, -5, -5, -5, -5,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim 2, 0, 43, -3, -3, -3, -3,
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim_terminator
+sClaydolAnims_4_3:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 4, 2, 49, 0, 0, 0, 0,
+ax_anim 6, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 1, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 51, -3, 0, -3, 0,
+ax_anim 1, 0, 52, -4, 0, -4, 0,
+ax_anim 4, 0, 52, -5, 0, -5, 0,
+ax_anim 2, 0, 51, -5, 0, -5, 0,
+ax_anim 2, 0, 51, -4, 0, -4, 0,
+ax_anim 2, 0, 50, -3, 0, -3, 0,
+ax_anim 2, 0, 49, -2, 0, -2, 0,
+ax_anim_terminator
+sClaydolAnims_4_4:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 4, 2, 56, 0, 0, 0, 0,
+ax_anim 6, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 1, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 58, -3, 3, -3, 3,
+ax_anim 1, 0, 59, -4, 4, -4, 4,
+ax_anim 4, 0, 59, -5, 5, -5, 5,
+ax_anim 2, 0, 58, -5, 5, -5, 5,
+ax_anim 2, 0, 58, -4, 4, -4, 4,
+ax_anim 2, 0, 57, -3, 3, -3, 3,
+ax_anim 2, 0, 56, -2, 2, -2, 2,
+ax_anim_terminator
+sClaydolAnims_4_5:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 4, 2, 63, 0, 0, 0, 0,
+ax_anim 6, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 1, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 65, 0, 3, 0, 3,
+ax_anim 1, 0, 66, 0, 4, 0, 4,
+ax_anim 4, 0, 66, 0, 5, 0, 5,
+ax_anim 2, 0, 65, 0, 5, 0, 5,
+ax_anim 2, 0, 65, 0, 4, 0, 4,
+ax_anim 2, 0, 64, 0, 3, 0, 3,
+ax_anim 2, 0, 63, 0, 2, 0, 2,
+ax_anim_terminator
+sClaydolAnims_4_6:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 4, 2, 70, 0, 0, 0, 0,
+ax_anim 6, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 1, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 3, 3, 3, 3,
+ax_anim 1, 0, 73, 4, 4, 4, 4,
+ax_anim 4, 0, 73, 5, 5, 5, 5,
+ax_anim 2, 0, 72, 5, 5, 5, 5,
+ax_anim 2, 0, 72, 4, 4, 4, 4,
+ax_anim 2, 0, 71, 3, 3, 3, 3,
+ax_anim 2, 0, 70, 2, 2, 2, 2,
+ax_anim_terminator
+sClaydolAnims_4_7:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 2, 77, 0, 0, 0, 0,
+ax_anim 6, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 1, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 3, 0, 3, 0,
+ax_anim 1, 0, 80, 4, 0, 4, 0,
+ax_anim 4, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 79, 5, 0, 5, 0,
+ax_anim 2, 0, 79, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim_terminator
+sClaydolAnims_4_8:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 2, 84, 0, 0, 0, 0,
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 1, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 3, -3, 3, -3,
+ax_anim 1, 0, 87, 4, -4, 4, -4,
+ax_anim 4, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 86, 4, -4, 4, -4,
+ax_anim 2, 0, 85, 3, -3, 3, -3,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sClaydolAnims_5_1:
+ax_anim 3, 0, 88, 0, -2, 0, 0,
+ax_anim 3, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 1, -5, 1, 0,
+ax_anim 2, 2, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 1, -5, 1, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 1, -5, 1, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 4, 0, 89, 1, -5, 1, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_5_2:
+ax_anim 3, 0, 90, 0, -2, 0, 0,
+ax_anim 3, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 1, -6, 1, -1,
+ax_anim 2, 2, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 1, -6, 1, -1,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 1, -6, 1, -1,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 4, 0, 91, 1, -6, 1, -1,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_5_3:
+ax_anim 3, 0, 92, 0, -2, 0, 0,
+ax_anim 3, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -6, 0, -1,
+ax_anim 2, 2, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -6, 0, -1,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -6, 0, -1,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 4, 0, 93, 0, -6, 0, -1,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_5_4:
+ax_anim 3, 0, 94, 0, -2, 0, 0,
+ax_anim 3, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 95, -1, -6, -1, -1,
+ax_anim 2, 2, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 95, -1, -6, -1, -1,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 95, -1, -6, -1, -1,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 4, 0, 95, -1, -6, -1, -1,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_5_5:
+ax_anim 3, 0, 96, 0, -2, 0, 0,
+ax_anim 3, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 1, -5, 1, 0,
+ax_anim 2, 2, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 1, -5, 1, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 1, -5, 1, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 4, 0, 97, 1, -5, 1, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_5_6:
+ax_anim 3, 0, 98, 0, -2, 0, 0,
+ax_anim 3, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 1, -6, 1, -1,
+ax_anim 2, 2, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 1, -6, 1, -1,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 1, -6, 1, -1,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 4, 0, 99, 1, -6, 1, -1,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_5_7:
+ax_anim 3, 0, 100, 0, -2, 0, 0,
+ax_anim 3, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, -1,
+ax_anim 2, 2, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, -1,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, -1,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 4, 0, 101, 0, -6, 0, -1,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_5_8:
+ax_anim 3, 0, 102, 0, -2, 0, 0,
+ax_anim 3, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 103, -1, -6, -1, -1,
+ax_anim 2, 2, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 103, -1, -6, -1, -1,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 103, -1, -6, -1, -1,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 4, 0, 103, -1, -6, -1, -1,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_6_1:
+ax_anim 16, 0, 104, 0, 0, 0, 0,
+ax_anim 12, 0, 104, 0, -1, 0, 0,
+ax_anim 16, 0, 104, 0, -2, 0, 0,
+ax_anim 16, 0, 105, 0, -2, 0, 0,
+ax_anim 12, 0, 105, 0, -1, 0, 0,
+ax_anim 16, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sClaydolAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sClaydolAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sClaydolAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sClaydolAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sClaydolAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sClaydolAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sClaydolAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sClaydolAnims_8_1:
+ax_anim 8, 0, 114, 0, 2, 0, 0,
+ax_anim 8, 0, 115, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_8_2:
+ax_anim 8, 0, 116, 0, 2, 0, 0,
+ax_anim 8, 0, 117, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_8_3:
+ax_anim 8, 0, 118, 0, 2, 0, 0,
+ax_anim 8, 0, 119, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_8_4:
+ax_anim 8, 0, 120, 0, 2, 0, 0,
+ax_anim 8, 0, 121, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_8_5:
+ax_anim 8, 0, 122, 0, 2, 0, 0,
+ax_anim 8, 0, 123, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_8_6:
+ax_anim 8, 0, 124, 0, 2, 0, 0,
+ax_anim 8, 0, 125, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_8_7:
+ax_anim 8, 0, 126, 0, 2, 0, 0,
+ax_anim 8, 0, 127, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_8_8:
+ax_anim 8, 0, 128, 0, 2, 0, 0,
+ax_anim 8, 0, 129, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 8, 3, 8, 3,
+ax_anim 2, 0, 132, 12, 10, 12, 10,
+ax_anim 2, 0, 133, 8, 20, 8, 20,
+ax_anim 3, 0, 134, 0, 23, 0, 23,
+ax_anim 2, 3, 135, -8, 20, -8, 20,
+ax_anim 2, 0, 136, -12, 10, -12, 10,
+ax_anim 1, 0, 137, -8, 3, -8, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 9, 1, 9, 1,
+ax_anim 2, 0, 131, 17, 6, 17, 6,
+ax_anim 2, 0, 132, 21, 15, 21, 15,
+ax_anim 3, 0, 133, 20, 23, 20, 23,
+ax_anim 2, 3, 134, 9, 24, 9, 24,
+ax_anim 2, 0, 135, 1, 18, 1, 18,
+ax_anim 1, 0, 136, -1, 8, -1, 8,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -4, 3, -4,
+ax_anim 2, 0, 130, 9, -6, 9, -6,
+ax_anim 2, 0, 131, 16, -4, 16, -4,
+ax_anim 3, 0, 132, 21, 2, 21, 2,
+ax_anim 2, 3, 133, 15, 7, 15, 7,
+ax_anim 2, 0, 134, 8, 8, 8, 8,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -6, -1, -6,
+ax_anim 2, 0, 137, 4, -14, 4, -14,
+ax_anim 2, 0, 130, 12, -19, 12, -19,
+ax_anim 3, 0, 131, 20, -18, 20, -18,
+ax_anim 2, 3, 132, 21, -12, 21, -12,
+ax_anim 2, 0, 133, 18, -5, 18, -5,
+ax_anim 1, 0, 134, 9, -1, 9, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -9, -3, -9, -3,
+ax_anim 2, 0, 136, -10, -9, -10, -9,
+ax_anim 2, 0, 137, -7, -16, -7, -16,
+ax_anim 3, 0, 130, 0, -19, 0, -19,
+ax_anim 2, 3, 131, 7, -16, 7, -16,
+ax_anim 2, 0, 132, 10, -9, 10, -9,
+ax_anim 1, 0, 133, 9, -3, 9, -3,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -6, 1, -6,
+ax_anim 2, 0, 131, -4, -14, -4, -14,
+ax_anim 2, 0, 130, -12, -19, -12, -19,
+ax_anim 3, 0, 137, -20, -18, -20, -18,
+ax_anim 2, 3, 136, -21, -12, -21, -12,
+ax_anim 2, 0, 135, -18, -5, -18, -5,
+ax_anim 1, 0, 134, -9, -1, -9, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -4, -3, -4,
+ax_anim 2, 0, 130, -9, -6, -9, -6,
+ax_anim 2, 0, 137, -16, -4, -16, -4,
+ax_anim 3, 0, 136, -21, 2, -21, 2,
+ax_anim 2, 3, 135, -15, 7, -15, 7,
+ax_anim 2, 0, 134, -8, 8, -8, 8,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -9, 1, -9, 1,
+ax_anim 2, 0, 137, -17, 6, -17, 6,
+ax_anim 2, 0, 136, -21, 15, -21, 15,
+ax_anim 3, 0, 135, -20, 23, -20, 23,
+ax_anim 2, 3, 134, -9, 24, -9, 24,
+ax_anim 2, 0, 133, -1, 18, -1, 18,
+ax_anim 1, 0, 132, 1, 8, 1, 8,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -22, 0, 0,
+ax_anim 3, 0, 146, 0, -21, 0, 0,
+ax_anim 2, 0, 146, 0, -17, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 2, 146, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_11_2:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -23, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 1, 0, 148, 0, -9, 0, 0,
+ax_anim 2, 2, 148, 0, 3, 0, 0,
+ax_anim_terminator
+sClaydolAnims_11_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -22, 0, 0,
+ax_anim 3, 0, 150, 0, -21, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 2, 150, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_11_4:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 1, 0, 152, 0, -9, 0, 0,
+ax_anim 2, 2, 152, 0, 3, 0, 0,
+ax_anim_terminator
+sClaydolAnims_11_5:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 154, 0, -21, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 2, 154, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_11_6:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 1, 0, 156, 0, -9, 0, 0,
+ax_anim 2, 2, 156, 0, 3, 0, 0,
+ax_anim_terminator
+sClaydolAnims_11_7:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 158, 0, -22, 0, 0,
+ax_anim 3, 0, 158, 0, -21, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 2, 158, 0, 2, 0, 0,
+ax_anim_terminator
+sClaydolAnims_11_8:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 1, 0, 160, 0, -9, 0, 0,
+ax_anim 2, 2, 160, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClaydolAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sClaydolGfx1:
+.incbin "baserom.gba", 0x14075EC, 0x200
+sClaydolSprites1:
+ax_sprite sClaydolGfx1, 0x200
+ax_sprite_terminator
+sClaydolGfx2:
+.incbin "baserom.gba", 0x14077FC, 0x200
+sClaydolSprites2:
+ax_sprite sClaydolGfx2, 0x200
+ax_sprite_terminator
+sClaydolGfx3:
+.incbin "baserom.gba", 0x1407A0C, 0x200
+sClaydolSprites3:
+ax_sprite sClaydolGfx3, 0x200
+ax_sprite_terminator
+sClaydolGfx4:
+.incbin "baserom.gba", 0x1407C1C, 0x200
+sClaydolSprites4:
+ax_sprite sClaydolGfx4, 0x200
+ax_sprite_terminator
+sClaydolGfx5:
+.incbin "baserom.gba", 0x1407E2C, 0x200
+sClaydolSprites5:
+ax_sprite sClaydolGfx5, 0x200
+ax_sprite_terminator
+sClaydolGfx6:
+.incbin "baserom.gba", 0x140803C, 0x200
+sClaydolSprites6:
+ax_sprite sClaydolGfx6, 0x200
+ax_sprite_terminator
+sClaydolGfx7:
+.incbin "baserom.gba", 0x140824C, 0x200
+sClaydolSprites7:
+ax_sprite sClaydolGfx7, 0x200
+ax_sprite_terminator
+sClaydolGfx8:
+.incbin "baserom.gba", 0x140845C, 0x200
+sClaydolSprites8:
+ax_sprite sClaydolGfx8, 0x200
+ax_sprite_terminator
+sClaydolGfx9:
+.incbin "baserom.gba", 0x140866C, 0x200
+sClaydolSprites9:
+ax_sprite sClaydolGfx9, 0x200
+ax_sprite_terminator
+sClaydolGfx10:
+.incbin "baserom.gba", 0x140887C, 0x200
+sClaydolSprites10:
+ax_sprite sClaydolGfx10, 0x200
+ax_sprite_terminator
+sClaydolGfx11:
+.incbin "baserom.gba", 0x1408A8C, 0x20
+sClaydolSprites11:
+ax_sprite sClaydolGfx11, 0x20
+ax_sprite_terminator
+sClaydolGfx12:
+.incbin "baserom.gba", 0x1408ABC, 0x20
+sClaydolSprites12:
+ax_sprite sClaydolGfx12, 0x20
+ax_sprite_terminator
+sClaydolGfx13:
+.incbin "baserom.gba", 0x1408AEC, 0x60
+sClaydolGfx13_1:
+.incbin "baserom.gba", 0x1408B4C, 0x60
+sClaydolGfx13_2:
+.incbin "baserom.gba", 0x1408BAC, 0x60
+sClaydolSprites13:
+ax_sprite sClaydolGfx13, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx13_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx13_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx14:
+.incbin "baserom.gba", 0x1408C44, 0x20
+sClaydolSprites14:
+ax_sprite sClaydolGfx14, 0x20
+ax_sprite_terminator
+sClaydolGfx15:
+.incbin "baserom.gba", 0x1408C74, 0x60
+sClaydolGfx15_1:
+.incbin "baserom.gba", 0x1408CD4, 0x60
+sClaydolGfx15_2:
+.incbin "baserom.gba", 0x1408D34, 0x60
+sClaydolSprites15:
+ax_sprite sClaydolGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx15_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx15_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx16:
+.incbin "baserom.gba", 0x1408DCC, 0x20
+sClaydolSprites16:
+ax_sprite sClaydolGfx16, 0x20
+ax_sprite_terminator
+sClaydolGfx17:
+.incbin "baserom.gba", 0x1408DFC, 0x20
+sClaydolSprites17:
+ax_sprite sClaydolGfx17, 0x20
+ax_sprite_terminator
+sClaydolGfx18:
+.incbin "baserom.gba", 0x1408E2C, 0x60
+sClaydolGfx18_1:
+.incbin "baserom.gba", 0x1408E8C, 0x60
+sClaydolGfx18_2:
+.incbin "baserom.gba", 0x1408EEC, 0x60
+sClaydolSprites18:
+ax_sprite sClaydolGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx19:
+.incbin "baserom.gba", 0x1408F84, 0x20
+sClaydolSprites19:
+ax_sprite sClaydolGfx19, 0x20
+ax_sprite_terminator
+sClaydolGfx20:
+.incbin "baserom.gba", 0x1408FB4, 0x20
+sClaydolSprites20:
+ax_sprite sClaydolGfx20, 0x20
+ax_sprite_terminator
+sClaydolGfx21:
+.incbin "baserom.gba", 0x1408FE4, 0x60
+sClaydolGfx21_1:
+.incbin "baserom.gba", 0x1409044, 0x60
+sClaydolGfx21_2:
+.incbin "baserom.gba", 0x14090A4, 0x60
+sClaydolSprites21:
+ax_sprite sClaydolGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx22:
+.incbin "baserom.gba", 0x140913C, 0x20
+sClaydolSprites22:
+ax_sprite sClaydolGfx22, 0x20
+ax_sprite_terminator
+sClaydolGfx23:
+.incbin "baserom.gba", 0x140916C, 0x20
+sClaydolSprites23:
+ax_sprite sClaydolGfx23, 0x20
+ax_sprite_terminator
+sClaydolGfx24:
+.incbin "baserom.gba", 0x140919C, 0x20
+sClaydolSprites24:
+ax_sprite sClaydolGfx24, 0x20
+ax_sprite_terminator
+sClaydolGfx25:
+.incbin "baserom.gba", 0x14091CC, 0x60
+sClaydolGfx25_1:
+.incbin "baserom.gba", 0x140922C, 0x60
+sClaydolGfx25_2:
+.incbin "baserom.gba", 0x140928C, 0x60
+sClaydolSprites25:
+ax_sprite sClaydolGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx26:
+.incbin "baserom.gba", 0x1409324, 0x60
+sClaydolGfx26_1:
+.incbin "baserom.gba", 0x1409384, 0x60
+sClaydolGfx26_2:
+.incbin "baserom.gba", 0x14093E4, 0x60
+sClaydolSprites26:
+ax_sprite sClaydolGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx27:
+.incbin "baserom.gba", 0x140947C, 0x60
+sClaydolGfx27_1:
+.incbin "baserom.gba", 0x14094DC, 0x100
+sClaydolGfx27_2:
+.incbin "baserom.gba", 0x14095DC, 0x40
+sClaydolSprites27:
+ax_sprite sClaydolGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClaydolGfx28:
+.incbin "baserom.gba", 0x1409654, 0x60
+sClaydolGfx28_1:
+.incbin "baserom.gba", 0x14096B4, 0xE0
+sClaydolGfx28_2:
+.incbin "baserom.gba", 0x1409794, 0x20
+sClaydolSprites28:
+ax_sprite sClaydolGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx28_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sClaydolGfx28_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClaydolGfx29:
+.incbin "baserom.gba", 0x14097EC, 0x60
+sClaydolGfx29_1:
+.incbin "baserom.gba", 0x140984C, 0x60
+sClaydolGfx29_2:
+.incbin "baserom.gba", 0x14098AC, 0x60
+sClaydolSprites29:
+ax_sprite sClaydolGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx30:
+.incbin "baserom.gba", 0x1409944, 0x60
+sClaydolGfx30_1:
+.incbin "baserom.gba", 0x14099A4, 0x60
+sClaydolGfx30_2:
+.incbin "baserom.gba", 0x1409A04, 0x60
+sClaydolSprites30:
+ax_sprite sClaydolGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClaydolGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClaydolGfx31:
+.incbin "baserom.gba", 0x1409A9C, 0x200
+sClaydolSprites31:
+ax_sprite sClaydolGfx31, 0x200
+ax_sprite_terminator
+sClaydolGfx32:
+.incbin "baserom.gba", 0x1409CAC, 0x200
+sClaydolSprites32:
+ax_sprite sClaydolGfx32, 0x200
+ax_sprite_terminator
+sClaydolGfx33:
+.incbin "baserom.gba", 0x1409EBC, 0x80
+sClaydolSprites33:
+ax_sprite sClaydolGfx33, 0x80
+ax_sprite_terminator
+sClaydolGfx34:
+.incbin "baserom.gba", 0x1409F4C, 0x20
+sClaydolSprites34:
+ax_sprite sClaydolGfx34, 0x20
+ax_sprite_terminator
+sClaydolGfx35:
+.incbin "baserom.gba", 0x1409F7C, 0x40
+sClaydolSprites35:
+ax_sprite sClaydolGfx35, 0x40
+ax_sprite_terminator
+sClaydolGfx36:
+.incbin "baserom.gba", 0x1409FCC, 0x100
+sClaydolSprites36:
+ax_sprite sClaydolGfx36, 0x100
+ax_sprite_terminator
+sClaydolGfx37:
+.incbin "baserom.gba", 0x140A0DC, 0x200
+sClaydolSprites37:
+ax_sprite sClaydolGfx37, 0x200
+ax_sprite_terminator
+sClaydolGfx38:
+.incbin "baserom.gba", 0x140A2EC, 0x200
+sClaydolSprites38:
+ax_sprite sClaydolGfx38, 0x200
+ax_sprite_terminator
+sClaydolGfx39:
+.incbin "baserom.gba", 0x140A4FC, 0x200
+sClaydolSprites39:
+ax_sprite sClaydolGfx39, 0x200
+ax_sprite_terminator
+sClaydolGfx40:
+.incbin "baserom.gba", 0x140A70C, 0x200
+sClaydolSprites40:
+ax_sprite sClaydolGfx40, 0x200
+ax_sprite_terminator
+sAxPosesClaydol:
+.4byte sClaydolPose1
+.4byte sClaydolPose2
+.4byte sClaydolPose3
+.4byte sClaydolPose4
+.4byte sClaydolPose5
+.4byte sClaydolPose6
+.4byte sClaydolPose7
+.4byte sClaydolPose8
+.4byte sClaydolPose9
+.4byte sClaydolPose10
+.4byte sClaydolPose11
+.4byte sClaydolPose12
+.4byte sClaydolPose13
+.4byte sClaydolPose14
+.4byte sClaydolPose15
+.4byte sClaydolPose16
+.4byte sClaydolPose17
+.4byte sClaydolPose18
+.4byte sClaydolPose19
+.4byte sClaydolPose20
+.4byte sClaydolPose21
+.4byte sClaydolPose22
+.4byte sClaydolPose23
+.4byte sClaydolPose24
+.4byte sClaydolPose25
+.4byte sClaydolPose26
+.4byte sClaydolPose27
+.4byte sClaydolPose28
+.4byte sClaydolPose29
+.4byte sClaydolPose30
+.4byte sClaydolPose31
+.4byte sClaydolPose32
+.4byte sClaydolPose33
+.4byte sClaydolPose34
+.4byte sClaydolPose35
+.4byte sClaydolPose36
+.4byte sClaydolPose37
+.4byte sClaydolPose38
+.4byte sClaydolPose39
+.4byte sClaydolPose40
+.4byte sClaydolPose41
+.4byte sClaydolPose42
+.4byte sClaydolPose43
+.4byte sClaydolPose44
+.4byte sClaydolPose45
+.4byte sClaydolPose46
+.4byte sClaydolPose47
+.4byte sClaydolPose48
+.4byte sClaydolPose49
+.4byte sClaydolPose50
+.4byte sClaydolPose51
+.4byte sClaydolPose52
+.4byte sClaydolPose53
+.4byte sClaydolPose54
+.4byte sClaydolPose55
+.4byte sClaydolPose56
+.4byte sClaydolPose57
+.4byte sClaydolPose58
+.4byte sClaydolPose59
+.4byte sClaydolPose60
+.4byte sClaydolPose61
+.4byte sClaydolPose62
+.4byte sClaydolPose63
+.4byte sClaydolPose64
+.4byte sClaydolPose65
+.4byte sClaydolPose66
+.4byte sClaydolPose67
+.4byte sClaydolPose68
+.4byte sClaydolPose69
+.4byte sClaydolPose70
+.4byte sClaydolPose71
+.4byte sClaydolPose72
+.4byte sClaydolPose73
+.4byte sClaydolPose74
+.4byte sClaydolPose75
+.4byte sClaydolPose76
+.4byte sClaydolPose77
+.4byte sClaydolPose78
+.4byte sClaydolPose79
+.4byte sClaydolPose80
+.4byte sClaydolPose81
+.4byte sClaydolPose82
+.4byte sClaydolPose83
+.4byte sClaydolPose84
+.4byte sClaydolPose85
+.4byte sClaydolPose86
+.4byte sClaydolPose87
+.4byte sClaydolPose88
+.4byte sClaydolPose89
+.4byte sClaydolPose90
+.4byte sClaydolPose91
+.4byte sClaydolPose92
+.4byte sClaydolPose93
+.4byte sClaydolPose94
+.4byte sClaydolPose95
+.4byte sClaydolPose96
+.4byte sClaydolPose97
+.4byte sClaydolPose98
+.4byte sClaydolPose99
+.4byte sClaydolPose100
+.4byte sClaydolPose101
+.4byte sClaydolPose102
+.4byte sClaydolPose103
+.4byte sClaydolPose104
+.4byte sClaydolPose105
+.4byte sClaydolPose106
+.4byte sClaydolPose107
+.4byte sClaydolPose108
+.4byte sClaydolPose109
+.4byte sClaydolPose110
+.4byte sClaydolPose111
+.4byte sClaydolPose112
+.4byte sClaydolPose113
+.4byte sClaydolPose114
+.4byte sClaydolPose115
+.4byte sClaydolPose116
+.4byte sClaydolPose117
+.4byte sClaydolPose118
+.4byte sClaydolPose119
+.4byte sClaydolPose120
+.4byte sClaydolPose121
+.4byte sClaydolPose122
+.4byte sClaydolPose123
+.4byte sClaydolPose124
+.4byte sClaydolPose125
+.4byte sClaydolPose126
+.4byte sClaydolPose127
+.4byte sClaydolPose128
+.4byte sClaydolPose129
+.4byte sClaydolPose130
+.4byte sClaydolPose131
+.4byte sClaydolPose132
+.4byte sClaydolPose133
+.4byte sClaydolPose134
+.4byte sClaydolPose135
+.4byte sClaydolPose136
+.4byte sClaydolPose137
+.4byte sClaydolPose138
+.4byte sClaydolPose139
+.4byte sClaydolPose140
+.4byte sClaydolPose141
+.4byte sClaydolPose142
+.4byte sClaydolPose143
+.4byte sClaydolPose144
+.4byte sClaydolPose145
+.4byte sClaydolPose146
+.4byte sClaydolPose147
+.4byte sClaydolPose148
+.4byte sClaydolPose149
+.4byte sClaydolPose150
+.4byte sClaydolPose151
+.4byte sClaydolPose152
+.4byte sClaydolPose153
+.4byte sClaydolPose154
+.4byte sClaydolPose155
+.4byte sClaydolPose156
+.4byte sClaydolPose157
+.4byte sClaydolPose158
+.4byte sClaydolPose159
+.4byte sClaydolPose160
+.4byte sClaydolPose161
+.4byte sClaydolPose162
+.4byte sClaydolPose163
+.4byte sClaydolPose164
+.4byte sClaydolPose165
+.4byte sClaydolPose166
+.4byte sClaydolPose167
+.4byte sClaydolPose168
+.4byte sClaydolPose169
+.4byte sClaydolPose170
+.4byte sClaydolPose171
+.4byte sClaydolPose172
+.4byte sClaydolPose173
+.4byte sClaydolPose174
+.4byte sClaydolPose175
+.4byte sClaydolPose176
+.4byte sClaydolPose177
+.4byte sClaydolPose178
+sAxPositionsClaydol:
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    2,  -16, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte   -3,  -17, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -2,  -16, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -3,  -17, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -3,  -17, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    0,   -9, 	  -7,   -7, 	   7,   -7, 	   0,  -10
+.2byte    0,   -9, 	 -11,   -7, 	  11,   -7, 	   0,  -10
+.2byte    0,   -9, 	 -13,   -7, 	  13,   -7, 	   0,  -10
+.2byte    0,   -9, 	 -13,  -16, 	  13,  -16, 	   0,  -10
+.2byte    0,   -9, 	 -13,  -19, 	  13,  -19, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    4,   -9, 	  -6,   -8, 	   8,  -12, 	   0,  -10
+.2byte    4,   -9, 	  -8,   -7, 	  11,  -13, 	   0,  -10
+.2byte    4,   -9, 	 -10,   -6, 	  13,  -13, 	   0,  -10
+.2byte    4,   -9, 	 -18,  -13, 	   5,  -20, 	   0,  -10
+.2byte    4,   -9, 	 -20,  -15, 	   3,  -22, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    7,  -11, 	   0,   -6, 	  -1,  -16, 	   0,  -10
+.2byte    7,  -11, 	   0,   -2, 	  -1,  -16, 	   0,  -10
+.2byte    7,  -11, 	   0,    1, 	  -1,  -16, 	   0,  -10
+.2byte    7,  -11, 	 -13,    1, 	 -13,  -16, 	   0,  -10
+.2byte    7,  -11, 	 -15,    1, 	 -15,  -16, 	   0,  -10
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    2,  -16, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    3,  -16, 	   7,   -7, 	  -6,  -11, 	   0,  -10
+.2byte    3,  -16, 	   9,   -5, 	  -8,  -12, 	   0,  -10
+.2byte    3,  -16, 	  11,   -4, 	 -10,  -13, 	   0,  -10
+.2byte    3,  -16, 	   2,    3, 	 -18,   -8, 	   0,  -10
+.2byte    3,  -16, 	  -2,    6, 	 -21,   -6, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    0,  -19, 	   8,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    0,  -19, 	  12,   -8, 	 -11,   -8, 	   0,  -10
+.2byte    0,  -19, 	  14,   -8, 	 -13,   -8, 	   0,  -10
+.2byte    0,  -19, 	  14,    1, 	 -13,    1, 	   0,  -10
+.2byte    0,  -19, 	  14,    4, 	 -13,    4, 	   0,  -10
+.2byte   -3,  -17, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -2,  -16, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,  -16, 	   6,  -11, 	  -7,   -7, 	   0,  -10
+.2byte   -3,  -16, 	   8,  -12, 	  -9,   -5, 	   0,  -10
+.2byte   -3,  -16, 	  10,  -13, 	 -11,   -4, 	   0,  -10
+.2byte   -3,  -16, 	  18,   -8, 	  -2,    3, 	   0,  -10
+.2byte   -3,  -16, 	  21,   -6, 	   2,    6, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -7,  -11, 	   1,  -16, 	   0,   -6, 	   0,  -10
+.2byte   -7,  -11, 	   1,  -16, 	   0,   -2, 	   0,  -10
+.2byte   -7,  -11, 	   1,  -16, 	   0,    1, 	   0,  -10
+.2byte   -7,  -11, 	  13,  -16, 	  13,    1, 	   0,  -10
+.2byte   -7,  -11, 	  15,  -16, 	  15,    1, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -4,   -9, 	  -8,  -12, 	   6,   -8, 	   0,  -10
+.2byte   -4,   -9, 	 -11,  -13, 	   8,   -7, 	   0,  -10
+.2byte   -4,   -9, 	 -13,  -13, 	  10,   -6, 	   0,  -10
+.2byte   -4,   -9, 	  -5,  -20, 	  18,  -13, 	   0,  -10
+.2byte   -4,   -9, 	  -3,  -22, 	  20,  -15, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    0,  -12, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    3,  -14, 	   5,  -13, 	  -8,   -5, 	  -1,  -11
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    5,  -13, 	   0,   -9, 	   1,   -6, 	  -2,   -9
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    3,  -17, 	  -6,   -8, 	   7,   -7, 	  -1,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    0,  -18, 	   8,   -7, 	  -8,   -7, 	   0,  -10
+.2byte   -3,  -17, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,  -17, 	   6,   -8, 	  -7,   -7, 	   1,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -5,  -13, 	   0,   -9, 	  -1,   -6, 	   2,   -9
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -3,  -14, 	  -5,  -13, 	   8,   -5, 	   1,  -11
+.2byte    0,   -8, 	  -8,   -8, 	   8,   -8, 	   0,   -9
+.2byte    0,   -7, 	  -8,   -6, 	   8,   -7, 	   0,   -8
+.2byte    0,  -14, 	 -16,  -19, 	  15,  -10, 	   0,  -13
+.2byte    1,  -14, 	  10,  -25, 	 -11,   -1, 	   0,  -12
+.2byte    1,  -17, 	   5,  -25, 	  -7,   -1, 	  -1,  -11
+.2byte    3,  -17, 	 -11,  -25, 	  11,   -3, 	  -1,  -10
+.2byte    0,  -20, 	  12,   -2, 	 -11,   -1, 	   0,  -11
+.2byte   -4,  -17, 	  10,  -25, 	 -12,   -3, 	   0,  -10
+.2byte   -3,  -17, 	  -7,  -25, 	   5,   -1, 	  -1,  -11
+.2byte   -2,  -14, 	 -11,  -25, 	  10,   -1, 	  -1,  -12
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    2,  -16, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte   -3,  -17, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -2,  -16, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    0,  -12, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte   -5,  -13, 	  -7,  -12, 	   6,   -4, 	  -1,  -10
+.2byte   -7,  -13, 	  -2,   -9, 	  -3,   -6, 	   0,   -9
+.2byte   -4,  -17, 	   5,   -8, 	  -8,   -7, 	   0,  -10
+.2byte    0,  -18, 	   8,   -7, 	  -8,   -7, 	   0,  -10
+.2byte    3,  -17, 	  -6,   -8, 	   7,   -7, 	  -1,  -10
+.2byte    6,  -13, 	   1,   -9, 	   2,   -6, 	  -1,   -9
+.2byte    4,  -13, 	   6,  -12, 	  -7,   -4, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    2,  -16, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte   -2,  -16, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    0,  -12, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    4,  -14, 	   6,  -13, 	  -7,   -5, 	   0,  -11
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    6,  -13, 	   1,   -9, 	   2,   -6, 	  -1,   -9
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    3,  -18, 	  -6,   -9, 	   7,   -8, 	  -1,  -11
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    0,  -19, 	   8,   -8, 	  -8,   -8, 	   0,  -11
+.2byte   -4,  -17, 	   6,   -9, 	  -8,   -7, 	  -1,  -10
+.2byte   -4,  -18, 	   5,   -9, 	  -8,   -8, 	   0,  -11
+.2byte   -9,  -12, 	  -1,   -8, 	   0,   -6, 	  -1,  -10
+.2byte   -7,  -13, 	  -2,   -9, 	  -3,   -6, 	   0,   -9
+.2byte   -7,  -10, 	  -8,   -9, 	   6,   -7, 	  -1,  -10
+.2byte   -5,  -14, 	  -7,  -13, 	   6,   -5, 	  -1,  -11
+.2byte    0,   -9, 	  -8,   -5, 	   8,   -5, 	   0,   -7
+.2byte   -5,  -11, 	  -7,  -10, 	   6,   -2, 	  -1,   -8
+.2byte   -6,  -10, 	  -1,   -6, 	  -2,   -3, 	   1,   -6
+.2byte   -3,  -16, 	   6,   -7, 	  -7,   -6, 	   1,   -9
+.2byte    0,  -17, 	   8,   -6, 	  -8,   -6, 	   0,   -9
+.2byte    2,  -16, 	  -7,   -7, 	   6,   -6, 	  -2,   -9
+.2byte    5,  -10, 	   0,   -6, 	   1,   -3, 	  -2,   -6
+.2byte    4,  -11, 	   6,  -10, 	  -7,   -2, 	   0,   -8
+.2byte    0,   -9, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte   -6,  -10, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte   -8,  -12, 	   0,   -8, 	   1,   -6, 	   0,  -10
+.2byte   -3,  -17, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,  -10
+.2byte    3,  -17, 	  -7,   -9, 	   7,   -7, 	   0,  -10
+.2byte    8,  -12, 	   0,   -8, 	  -1,   -6, 	   0,  -10
+.2byte    6,  -10, 	   7,   -9, 	  -7,   -7, 	   0,  -10
+sClaydolAnimTable1:
+.4byte sClaydolAnims_1_1
+.4byte sClaydolAnims_1_2
+.4byte sClaydolAnims_1_3
+.4byte sClaydolAnims_1_4
+.4byte sClaydolAnims_1_5
+.4byte sClaydolAnims_1_6
+.4byte sClaydolAnims_1_7
+.4byte sClaydolAnims_1_8
+sClaydolAnimTable2:
+.4byte sClaydolAnims_2_1
+.4byte sClaydolAnims_2_2
+.4byte sClaydolAnims_2_3
+.4byte sClaydolAnims_2_4
+.4byte sClaydolAnims_2_5
+.4byte sClaydolAnims_2_6
+.4byte sClaydolAnims_2_7
+.4byte sClaydolAnims_2_8
+sClaydolAnimTable3:
+.4byte sClaydolAnims_3_1
+.4byte sClaydolAnims_3_2
+.4byte sClaydolAnims_3_3
+.4byte sClaydolAnims_3_4
+.4byte sClaydolAnims_3_5
+.4byte sClaydolAnims_3_6
+.4byte sClaydolAnims_3_7
+.4byte sClaydolAnims_3_8
+sClaydolAnimTable4:
+.4byte sClaydolAnims_4_1
+.4byte sClaydolAnims_4_2
+.4byte sClaydolAnims_4_3
+.4byte sClaydolAnims_4_4
+.4byte sClaydolAnims_4_5
+.4byte sClaydolAnims_4_6
+.4byte sClaydolAnims_4_7
+.4byte sClaydolAnims_4_8
+sClaydolAnimTable5:
+.4byte sClaydolAnims_5_1
+.4byte sClaydolAnims_5_2
+.4byte sClaydolAnims_5_3
+.4byte sClaydolAnims_5_4
+.4byte sClaydolAnims_5_5
+.4byte sClaydolAnims_5_6
+.4byte sClaydolAnims_5_7
+.4byte sClaydolAnims_5_8
+sClaydolAnimTable6:
+.4byte sClaydolAnims_6_1
+.4byte sClaydolAnims_6_1
+.4byte sClaydolAnims_6_1
+.4byte sClaydolAnims_6_1
+.4byte sClaydolAnims_6_1
+.4byte sClaydolAnims_6_1
+.4byte sClaydolAnims_6_1
+.4byte sClaydolAnims_6_1
+sClaydolAnimTable7:
+.4byte sClaydolAnims_7_1
+.4byte sClaydolAnims_7_2
+.4byte sClaydolAnims_7_3
+.4byte sClaydolAnims_7_4
+.4byte sClaydolAnims_7_5
+.4byte sClaydolAnims_7_6
+.4byte sClaydolAnims_7_7
+.4byte sClaydolAnims_7_8
+sClaydolAnimTable8:
+.4byte sClaydolAnims_8_1
+.4byte sClaydolAnims_8_2
+.4byte sClaydolAnims_8_3
+.4byte sClaydolAnims_8_4
+.4byte sClaydolAnims_8_5
+.4byte sClaydolAnims_8_6
+.4byte sClaydolAnims_8_7
+.4byte sClaydolAnims_8_8
+sClaydolAnimTable9:
+.4byte sClaydolAnims_9_1
+.4byte sClaydolAnims_9_2
+.4byte sClaydolAnims_9_3
+.4byte sClaydolAnims_9_4
+.4byte sClaydolAnims_9_5
+.4byte sClaydolAnims_9_6
+.4byte sClaydolAnims_9_7
+.4byte sClaydolAnims_9_8
+sClaydolAnimTable10:
+.4byte sClaydolAnims_10_1
+.4byte sClaydolAnims_10_2
+.4byte sClaydolAnims_10_3
+.4byte sClaydolAnims_10_4
+.4byte sClaydolAnims_10_5
+.4byte sClaydolAnims_10_6
+.4byte sClaydolAnims_10_7
+.4byte sClaydolAnims_10_8
+sClaydolAnimTable11:
+.4byte sClaydolAnims_11_1
+.4byte sClaydolAnims_11_2
+.4byte sClaydolAnims_11_3
+.4byte sClaydolAnims_11_4
+.4byte sClaydolAnims_11_5
+.4byte sClaydolAnims_11_6
+.4byte sClaydolAnims_11_7
+.4byte sClaydolAnims_11_8
+sClaydolAnimTable12:
+.4byte sClaydolAnims_12_1
+.4byte sClaydolAnims_12_2
+.4byte sClaydolAnims_12_3
+.4byte sClaydolAnims_12_4
+.4byte sClaydolAnims_12_5
+.4byte sClaydolAnims_12_6
+.4byte sClaydolAnims_12_7
+.4byte sClaydolAnims_12_8
+sClaydolAnimTable13:
+.4byte sClaydolAnims_13_1
+.4byte sClaydolAnims_13_2
+.4byte sClaydolAnims_13_3
+.4byte sClaydolAnims_13_4
+.4byte sClaydolAnims_13_5
+.4byte sClaydolAnims_13_6
+.4byte sClaydolAnims_13_7
+.4byte sClaydolAnims_13_8
+sAxAnimationsClaydol:
+.4byte sClaydolAnimTable1
+.4byte sClaydolAnimTable2
+.4byte sClaydolAnimTable3
+.4byte sClaydolAnimTable4
+.4byte sClaydolAnimTable5
+.4byte sClaydolAnimTable6
+.4byte sClaydolAnimTable7
+.4byte sClaydolAnimTable8
+.4byte sClaydolAnimTable9
+.4byte sClaydolAnimTable10
+.4byte sClaydolAnimTable11
+.4byte sClaydolAnimTable12
+.4byte sClaydolAnimTable13
+sAxSpritesClaydol:
+.4byte sClaydolSprites1
+.4byte sClaydolSprites2
+.4byte sClaydolSprites3
+.4byte sClaydolSprites4
+.4byte sClaydolSprites5
+.4byte sClaydolSprites6
+.4byte sClaydolSprites7
+.4byte sClaydolSprites8
+.4byte sClaydolSprites9
+.4byte sClaydolSprites10
+.4byte sClaydolSprites11
+.4byte sClaydolSprites12
+.4byte sClaydolSprites13
+.4byte sClaydolSprites14
+.4byte sClaydolSprites15
+.4byte sClaydolSprites16
+.4byte sClaydolSprites17
+.4byte sClaydolSprites18
+.4byte sClaydolSprites19
+.4byte sClaydolSprites20
+.4byte sClaydolSprites21
+.4byte sClaydolSprites22
+.4byte sClaydolSprites23
+.4byte sClaydolSprites24
+.4byte sClaydolSprites25
+.4byte sClaydolSprites26
+.4byte sClaydolSprites27
+.4byte sClaydolSprites28
+.4byte sClaydolSprites29
+.4byte sClaydolSprites30
+.4byte sClaydolSprites31
+.4byte sClaydolSprites32
+.4byte sClaydolSprites33
+.4byte sClaydolSprites34
+.4byte sClaydolSprites35
+.4byte sClaydolSprites36
+.4byte sClaydolSprites37
+.4byte sClaydolSprites38
+.4byte sClaydolSprites39
+.4byte sClaydolSprites40
+sAxMainClaydol:
+ax_main sAxPosesClaydol, sAxAnimationsClaydol, 13, sAxSpritesClaydol, sAxPositionsClaydol

--- a/data/ax/clefable.inc
+++ b/data/ax/clefable.inc
@@ -1,0 +1,2801 @@
+.global gAxClefable
+gAxClefable:
+ax_siro sAxMainClefable
+sClefablePose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose3:
+ax_pose 2, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose4:
+ax_pose 3, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose5:
+ax_pose 4, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose6:
+ax_pose 5, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose7:
+ax_pose 6, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose8:
+ax_pose 7, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose9:
+ax_pose 8, 0x01e9, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose10:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose11:
+ax_pose 10, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose12:
+ax_pose 11, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sClefablePose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose16:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose17:
+ax_pose 16, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose18:
+ax_pose 17, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose19:
+ax_pose 6, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose20:
+ax_pose 7, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose21:
+ax_pose 8, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose22:
+ax_pose 3, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose23:
+ax_pose 4, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose24:
+ax_pose 5, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose25:
+ax_pose 0, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose26:
+ax_pose 1, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose27:
+ax_pose 2, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose28:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose29:
+ax_pose 3, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose30:
+ax_pose 4, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose31:
+ax_pose 5, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose32:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose33:
+ax_pose 6, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose34:
+ax_pose 7, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose35:
+ax_pose 8, 0x01e9, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose36:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose37:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose38:
+ax_pose 10, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose39:
+ax_pose 11, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sClefablePose40:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose42:
+ax_pose 13, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose43:
+ax_pose 14, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose44:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose45:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose46:
+ax_pose 16, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose47:
+ax_pose 17, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose48:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose49:
+ax_pose 6, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose50:
+ax_pose 7, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose51:
+ax_pose 8, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose52:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose53:
+ax_pose 3, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose54:
+ax_pose 4, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose55:
+ax_pose 5, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose56:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose57:
+ax_pose 0, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose58:
+ax_pose 1, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose59:
+ax_pose 2, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose60:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose61:
+ax_pose 3, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose62:
+ax_pose 4, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose63:
+ax_pose 5, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose64:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose65:
+ax_pose 6, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose66:
+ax_pose 7, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose67:
+ax_pose 8, 0x01e9, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose68:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose69:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose70:
+ax_pose 10, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose71:
+ax_pose 11, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sClefablePose72:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose74:
+ax_pose 13, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose75:
+ax_pose 14, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose76:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose77:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose78:
+ax_pose 16, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose79:
+ax_pose 17, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose80:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose81:
+ax_pose 6, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose82:
+ax_pose 7, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose83:
+ax_pose 8, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose84:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose85:
+ax_pose 3, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose86:
+ax_pose 4, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose87:
+ax_pose 5, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose88:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose89:
+ax_pose 0, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose90:
+ax_pose 23, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sClefablePose91:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose92:
+ax_pose 3, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose93:
+ax_pose 24, 0x81ef, 0x90f7, 0x1c00
+ax_pose_terminator
+sClefablePose94:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose95:
+ax_pose 6, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose96:
+ax_pose 25, 0x01f3, 0x50f6, 0x1c00
+ax_pose_terminator
+sClefablePose97:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose98:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose99:
+ax_pose 26, 0x01f2, 0x50f8, 0x1c00
+ax_pose_terminator
+sClefablePose100:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose102:
+ax_pose 27, 0x01f3, 0x40f7, 0x1c00
+ax_pose_terminator
+sClefablePose103:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose104:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose105:
+ax_pose 26, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sClefablePose106:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose107:
+ax_pose 6, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose108:
+ax_pose 25, 0x01f3, 0x40fa, 0x1c00
+ax_pose_terminator
+sClefablePose109:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose110:
+ax_pose 3, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose111:
+ax_pose 24, 0x81ef, 0x80f9, 0x1c00
+ax_pose_terminator
+sClefablePose112:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose113:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose114:
+ax_pose 28, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose115:
+ax_pose 29, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose116:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose117:
+ax_pose 30, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose118:
+ax_pose 31, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose119:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose120:
+ax_pose 32, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose121:
+ax_pose 33, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose122:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose123:
+ax_pose 34, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose124:
+ax_pose 35, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose125:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose126:
+ax_pose 36, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose127:
+ax_pose 37, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose128:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose129:
+ax_pose 34, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose130:
+ax_pose 35, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose131:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose132:
+ax_pose 32, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose133:
+ax_pose 33, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose134:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose135:
+ax_pose 30, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose136:
+ax_pose 31, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose137:
+ax_pose 38, 0x01ec, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose138:
+ax_pose 39, 0x01ec, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose139:
+ax_pose 40, 0x01e4, 0x80f1, 0x1c00
+ax_pose_terminator
+sClefablePose140:
+ax_pose 41, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose141:
+ax_pose 42, 0x01e5, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose142:
+ax_pose 43, 0x01e8, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose143:
+ax_pose 44, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sClefablePose144:
+ax_pose 43, 0x01e8, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose145:
+ax_pose 42, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose146:
+ax_pose 41, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose147:
+ax_pose 0, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose148:
+ax_pose 1, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose149:
+ax_pose 2, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose150:
+ax_pose 3, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose151:
+ax_pose 4, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose152:
+ax_pose 5, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose153:
+ax_pose 6, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose154:
+ax_pose 7, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose155:
+ax_pose 8, 0x01e9, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose156:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose157:
+ax_pose 10, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose158:
+ax_pose 11, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sClefablePose159:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose160:
+ax_pose 13, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose161:
+ax_pose 14, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose162:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose163:
+ax_pose 16, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose164:
+ax_pose 17, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose165:
+ax_pose 6, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose166:
+ax_pose 7, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose167:
+ax_pose 8, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose168:
+ax_pose 3, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose169:
+ax_pose 4, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose170:
+ax_pose 5, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose171:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose172:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose173:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose174:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose175:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose176:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose177:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose178:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose179:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose180:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose181:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose182:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose183:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose184:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose185:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose186:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose187:
+ax_pose 0, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose188:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose189:
+ax_pose 3, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose190:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose191:
+ax_pose 6, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose192:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose193:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose194:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose195:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose196:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose197:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose198:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose199:
+ax_pose 6, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose200:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose201:
+ax_pose 3, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose202:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose203:
+ax_pose 18, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose204:
+ax_pose 19, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefablePose205:
+ax_pose 20, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose206:
+ax_pose 21, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose207:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose208:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose209:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose210:
+ax_pose 19, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose211:
+ax_pose 0, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefablePose212:
+ax_pose 3, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefablePose213:
+ax_pose 6, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose214:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose215:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose216:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefablePose217:
+ax_pose 6, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefablePose218:
+ax_pose 3, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+.align 2
+sClefableAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, -1, 1, 0, 0,
+ax_anim 6, 0, 11, -1, 0, 0, 0,
+ax_anim 6, 0, 11, -1, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 1, 1, 0, 0,
+ax_anim 6, 0, 17, 1, 0, 0, 0,
+ax_anim 6, 0, 17, 1, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sClefableAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 1, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 0, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sClefableAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 1, 35, 21, -1, 21, -1,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 21, -1, 21, -1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sClefableAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -4, 4, -4,
+ax_anim 1, 0, 38, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 2, 1, 39, 21, -19, 21, -19,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 2, 0, 39, 21, -19, 21, -19,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sClefableAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 1, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sClefableAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -4, -4, -4,
+ax_anim 1, 0, 46, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -20, -20, -20, -20,
+ax_anim 2, 1, 47, -21, -19, -21, -19,
+ax_anim 2, 0, 47, -20, -20, -20, -20,
+ax_anim 2, 0, 47, -21, -19, -21, -19,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sClefableAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 1, 51, -21, -1, -21, -1,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -21, -1, -21, -1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sClefableAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 1, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 0, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sClefableAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sClefableAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 21, 20, 21, 20,
+ax_anim 2, 1, 63, 22, 19, 22, 19,
+ax_anim 2, 0, 63, 21, 20, 21, 20,
+ax_anim 2, 0, 63, 22, 19, 22, 19,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sClefableAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 1, 67, 21, -1, 21, -1,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 0, 67, 21, -1, 21, -1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sClefableAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -4, 4, -4,
+ax_anim 1, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 20, -20, 20, -20,
+ax_anim 2, 1, 71, 21, -19, 21, -19,
+ax_anim 2, 0, 71, 20, -20, 20, -20,
+ax_anim 2, 0, 71, 21, -19, 21, -19,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sClefableAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 1, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 0, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sClefableAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -4, -4, -4,
+ax_anim 1, 0, 78, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -20, -20, -20, -20,
+ax_anim 2, 1, 79, -21, -19, -21, -19,
+ax_anim 2, 0, 79, -20, -20, -20, -20,
+ax_anim 2, 0, 79, -21, -19, -21, -19,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sClefableAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 1, 83, -21, -1, -21, -1,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 0, 83, -21, -1, -21, -1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sClefableAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -21, 20, -21, 20,
+ax_anim 2, 1, 87, -22, 19, -22, 19,
+ax_anim 2, 0, 87, -21, 20, -21, 20,
+ax_anim 2, 0, 87, -22, 19, -22, 19,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sClefableAnims_4_1:
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -8, 0, 0,
+ax_anim 2, 0, 89, 0, -7, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 1, 0, 1, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 1, 0, 1, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 1, 0, 1, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -2, 0, 0,
+ax_anim 1, 0, 89, 0, -8, 0, 0,
+ax_anim 1, 2, 89, 0, -10, 0, 0,
+ax_anim 1, 0, 89, 0, -11, 0, 0,
+ax_anim 1, 0, 89, 0, -10, 0, 0,
+ax_anim 1, 0, 89, 0, -8, 0, 0,
+ax_anim 1, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -2, 0, 0,
+ax_anim 1, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_4_2:
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -8, 0, 0,
+ax_anim 2, 0, 92, 0, -7, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 1, -1, 1, -1,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 1, -1, 1, -1,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 1, -1, 1, -1,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 1, 0, 92, 0, -8, 0, 0,
+ax_anim 1, 2, 92, 0, -10, 0, 0,
+ax_anim 1, 0, 92, 0, -11, 0, 0,
+ax_anim 1, 0, 92, 0, -10, 0, 0,
+ax_anim 1, 0, 92, 0, -8, 0, 0,
+ax_anim 1, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 1, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_4_3:
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -9, 0, 0,
+ax_anim 2, 0, 95, 0, -8, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -1, 0, -1, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -1, 0, -1, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -1, 0, -1, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 1, 0, 95, 0, -8, 0, 0,
+ax_anim 1, 2, 95, 0, -10, 0, 0,
+ax_anim 1, 0, 95, 0, -11, 0, 0,
+ax_anim 1, 0, 95, 0, -10, 0, 0,
+ax_anim 1, 0, 95, 0, -8, 0, 0,
+ax_anim 1, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 1, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_4_4:
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -9, 0, 0,
+ax_anim 2, 0, 98, 0, -8, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 98, -1, -1, -1, -1,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 98, -1, -1, -1, -1,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 98, -1, -1, -1, -1,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 1, 0, 98, 0, -8, 0, 0,
+ax_anim 1, 2, 98, 0, -10, 0, 0,
+ax_anim 1, 0, 98, 0, -11, 0, 0,
+ax_anim 1, 0, 98, 0, -10, 0, 0,
+ax_anim 1, 0, 98, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 1, 1, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_4_5:
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -10, 0, 0,
+ax_anim 2, 0, 101, 0, -9, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 1, 0, 1, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 1, 0, 1, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 1, 0, 1, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 1, 0, 101, 0, -8, 0, 0,
+ax_anim 1, 2, 101, 0, -10, 0, 0,
+ax_anim 1, 0, 101, 0, -11, 0, 0,
+ax_anim 1, 0, 101, 0, -10, 0, 0,
+ax_anim 1, 0, 101, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 1, 1, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_4_6:
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -9, 0, 0,
+ax_anim 2, 0, 104, 0, -8, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 1, -1, 1, -1,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 1, -1, 1, -1,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 1, -1, 1, -1,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 1, 0, 104, 0, -8, 0, 0,
+ax_anim 1, 2, 104, 0, -10, 0, 0,
+ax_anim 1, 0, 104, 0, -11, 0, 0,
+ax_anim 1, 0, 104, 0, -10, 0, 0,
+ax_anim 1, 0, 104, 0, -8, 0, 0,
+ax_anim 1, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 1, 1, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_4_7:
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -9, 0, 0,
+ax_anim 2, 0, 107, 0, -8, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 1, 0, 1, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 1, 0, 1, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 1, 0, 1, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, -8, 0, 0,
+ax_anim 1, 2, 107, 0, -10, 0, 0,
+ax_anim 1, 0, 107, 0, -11, 0, 0,
+ax_anim 1, 0, 107, 0, -10, 0, 0,
+ax_anim 1, 0, 107, 0, -8, 0, 0,
+ax_anim 1, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 1, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_4_8:
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 0, -8, 0, 0,
+ax_anim 2, 0, 110, 0, -7, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, -1, -1, -1, -1,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, -1, -1, -1, -1,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, -1, -1, -1, -1,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 1, 0, 110, 0, -8, 0, 0,
+ax_anim 1, 2, 110, 0, -10, 0, 0,
+ax_anim 1, 0, 110, 0, -11, 0, 0,
+ax_anim 1, 0, 110, 0, -10, 0, 0,
+ax_anim 1, 0, 110, 0, -8, 0, 0,
+ax_anim 1, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 1, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_5_1:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 2, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_5_2:
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 2, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_5_3:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 2, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_5_4:
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 2, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_5_5:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 2, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_5_6:
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 2, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_5_7:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 2, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_5_8:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 2, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sClefableAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sClefableAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sClefableAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sClefableAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sClefableAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sClefableAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sClefableAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sClefableAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 2, 0, 0,
+ax_anim 6, 0, 147, 0, 1, 0, 0,
+ax_anim 6, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 148, 0, 1, 0, 0,
+ax_anim 6, 0, 148, 0, 2, 0, 0,
+ax_anim_terminator
+sClefableAnims_8_2:
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 2, 2, 0, 0,
+ax_anim 6, 0, 150, 2, 1, 0, 0,
+ax_anim 6, 0, 149, 1, -3, 0, 0,
+ax_anim 6, 0, 151, 2, 0, 0, 0,
+ax_anim 6, 0, 151, 2, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_8_3:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 2, 1, 0, 0,
+ax_anim 6, 0, 153, 2, 0, 0, 0,
+ax_anim 6, 0, 152, 1, -3, 0, 0,
+ax_anim 6, 0, 154, 1, -1, 0, 0,
+ax_anim 6, 0, 154, 1, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_8_4:
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 1, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, -2, 0, 0,
+ax_anim 6, 0, 156, 0, -1, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_8_5:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 1, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 158, 0, -3, 0, 0,
+ax_anim 6, 0, 160, 1, 0, 0, 0,
+ax_anim 6, 0, 160, 1, 1, 0, 0,
+ax_anim_terminator
+sClefableAnims_8_6:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, 1, 0, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, -2, 0, 0,
+ax_anim 6, 0, 162, 0, -1, 0, 0,
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_8_7:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, -1, 1, 0, 0,
+ax_anim 6, 0, 165, -1, 0, 0, 0,
+ax_anim 6, 0, 164, 0, -3, 0, 0,
+ax_anim 6, 0, 166, 0, -1, 0, 0,
+ax_anim 6, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_8_8:
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 168, -2, 2, 0, 0,
+ax_anim 6, 0, 168, -2, 1, 0, 0,
+ax_anim 6, 0, 167, -1, -3, 0, 0,
+ax_anim 6, 0, 169, -2, 0, 0, 0,
+ax_anim 6, 0, 169, -2, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 3, 19, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 20, 20, 20, 20,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 19, -2, 19, -2,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 20, -20, 20, -20,
+ax_anim 2, 3, 172, 22, -12, 22, -12,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -21, 0, -21,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -20, -20, -20, -20,
+ax_anim 2, 3, 176, -22, -12, -22, -12,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -19, -2, -19, -2,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 3, -19, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -20, 20, -20, 20,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_11_2:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_11_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_11_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_11_6:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_11_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_12_2:
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_12_3:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_12_4:
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_12_6:
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_12_7:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_12_8:
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefableAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sClefableGfx1:
+.incbin "baserom.gba", 0x692964, 0x200
+sClefableSprites1:
+ax_sprite sClefableGfx1, 0x200
+ax_sprite_terminator
+sClefableGfx2:
+.incbin "baserom.gba", 0x692B74, 0x200
+sClefableSprites2:
+ax_sprite sClefableGfx2, 0x200
+ax_sprite_terminator
+sClefableGfx3:
+.incbin "baserom.gba", 0x692D84, 0x200
+sClefableSprites3:
+ax_sprite sClefableGfx3, 0x200
+ax_sprite_terminator
+sClefableGfx4:
+.incbin "baserom.gba", 0x692F94, 0x200
+sClefableSprites4:
+ax_sprite sClefableGfx4, 0x200
+ax_sprite_terminator
+sClefableGfx5:
+.incbin "baserom.gba", 0x6931A4, 0x200
+sClefableSprites5:
+ax_sprite sClefableGfx5, 0x200
+ax_sprite_terminator
+sClefableGfx6:
+.incbin "baserom.gba", 0x6933B4, 0x200
+sClefableSprites6:
+ax_sprite sClefableGfx6, 0x200
+ax_sprite_terminator
+sClefableGfx7:
+.incbin "baserom.gba", 0x6935C4, 0x200
+sClefableSprites7:
+ax_sprite sClefableGfx7, 0x200
+ax_sprite_terminator
+sClefableGfx8:
+.incbin "baserom.gba", 0x6937D4, 0x200
+sClefableSprites8:
+ax_sprite sClefableGfx8, 0x200
+ax_sprite_terminator
+sClefableGfx9:
+.incbin "baserom.gba", 0x6939E4, 0x200
+sClefableSprites9:
+ax_sprite sClefableGfx9, 0x200
+ax_sprite_terminator
+sClefableGfx10:
+.incbin "baserom.gba", 0x693BF4, 0x200
+sClefableSprites10:
+ax_sprite sClefableGfx10, 0x200
+ax_sprite_terminator
+sClefableGfx11:
+.incbin "baserom.gba", 0x693E04, 0x200
+sClefableSprites11:
+ax_sprite sClefableGfx11, 0x200
+ax_sprite_terminator
+sClefableGfx12:
+.incbin "baserom.gba", 0x694014, 0x200
+sClefableSprites12:
+ax_sprite sClefableGfx12, 0x200
+ax_sprite_terminator
+sClefableGfx13:
+.incbin "baserom.gba", 0x694224, 0x200
+sClefableSprites13:
+ax_sprite sClefableGfx13, 0x200
+ax_sprite_terminator
+sClefableGfx14:
+.incbin "baserom.gba", 0x694434, 0x200
+sClefableSprites14:
+ax_sprite sClefableGfx14, 0x200
+ax_sprite_terminator
+sClefableGfx15:
+.incbin "baserom.gba", 0x694644, 0x200
+sClefableSprites15:
+ax_sprite sClefableGfx15, 0x200
+ax_sprite_terminator
+sClefableGfx16:
+.incbin "baserom.gba", 0x694854, 0x200
+sClefableSprites16:
+ax_sprite sClefableGfx16, 0x200
+ax_sprite_terminator
+sClefableGfx17:
+.incbin "baserom.gba", 0x694A64, 0x200
+sClefableSprites17:
+ax_sprite sClefableGfx17, 0x200
+ax_sprite_terminator
+sClefableGfx18:
+.incbin "baserom.gba", 0x694C74, 0x200
+sClefableSprites18:
+ax_sprite sClefableGfx18, 0x200
+ax_sprite_terminator
+sClefableGfx19:
+.incbin "baserom.gba", 0x694E84, 0x100
+sClefableGfx19_1:
+.incbin "baserom.gba", 0x694F84, 0x40
+sClefableSprites19:
+ax_sprite sClefableGfx19, 0x100
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx19_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefableGfx20:
+.incbin "baserom.gba", 0x694FEC, 0x40
+sClefableGfx20_1:
+.incbin "baserom.gba", 0x69502C, 0x60
+sClefableGfx20_2:
+.incbin "baserom.gba", 0x69508C, 0x60
+sClefableGfx20_3:
+.incbin "baserom.gba", 0x6950EC, 0x40
+sClefableSprites20:
+ax_sprite sClefableGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sClefableGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx20_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClefableGfx21:
+.incbin "baserom.gba", 0x695174, 0x40
+sClefableGfx21_1:
+.incbin "baserom.gba", 0x6951B4, 0x60
+sClefableGfx21_2:
+.incbin "baserom.gba", 0x695214, 0x60
+sClefableGfx21_3:
+.incbin "baserom.gba", 0x695274, 0x60
+sClefableSprites21:
+ax_sprite sClefableGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sClefableGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClefableGfx22:
+.incbin "baserom.gba", 0x69531C, 0x60
+sClefableGfx22_1:
+.incbin "baserom.gba", 0x69537C, 0x60
+sClefableGfx22_2:
+.incbin "baserom.gba", 0x6953DC, 0x60
+sClefableSprites22:
+ax_sprite sClefableGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefableGfx23:
+.incbin "baserom.gba", 0x695474, 0x60
+sClefableGfx23_1:
+.incbin "baserom.gba", 0x6954D4, 0x60
+sClefableGfx23_2:
+.incbin "baserom.gba", 0x695534, 0x60
+sClefableGfx23_3:
+.incbin "baserom.gba", 0x695594, 0x20
+sClefableSprites23:
+ax_sprite sClefableGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sClefableGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClefableGfx24:
+.incbin "baserom.gba", 0x6955FC, 0x80
+sClefableSprites24:
+ax_sprite sClefableGfx24, 0x80
+ax_sprite_terminator
+sClefableGfx25:
+.incbin "baserom.gba", 0x69568C, 0xC0
+sClefableSprites25:
+ax_sprite sClefableGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClefableGfx26:
+.incbin "baserom.gba", 0x695764, 0x80
+sClefableSprites26:
+ax_sprite sClefableGfx26, 0x80
+ax_sprite_terminator
+sClefableGfx27:
+.incbin "baserom.gba", 0x6957F4, 0x80
+sClefableSprites27:
+ax_sprite sClefableGfx27, 0x80
+ax_sprite_terminator
+sClefableGfx28:
+.incbin "baserom.gba", 0x695884, 0x80
+sClefableSprites28:
+ax_sprite sClefableGfx28, 0x80
+ax_sprite_terminator
+sClefableGfx29:
+.incbin "baserom.gba", 0x695914, 0x180
+sClefableSprites29:
+ax_sprite sClefableGfx29, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sClefableGfx30:
+.incbin "baserom.gba", 0x695AAC, 0x180
+sClefableSprites30:
+ax_sprite sClefableGfx30, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sClefableGfx31:
+.incbin "baserom.gba", 0x695C44, 0x40
+sClefableGfx31_1:
+.incbin "baserom.gba", 0x695C84, 0x60
+sClefableGfx31_2:
+.incbin "baserom.gba", 0x695CE4, 0x60
+sClefableGfx31_3:
+.incbin "baserom.gba", 0x695D44, 0x60
+sClefableSprites31:
+ax_sprite sClefableGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sClefableGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClefableGfx32:
+.incbin "baserom.gba", 0x695DEC, 0x60
+sClefableGfx32_1:
+.incbin "baserom.gba", 0x695E4C, 0x60
+sClefableGfx32_2:
+.incbin "baserom.gba", 0x695EAC, 0x60
+sClefableGfx32_3:
+.incbin "baserom.gba", 0x695F0C, 0x40
+sClefableSprites32:
+ax_sprite sClefableGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx32_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClefableGfx33:
+.incbin "baserom.gba", 0x695F94, 0x60
+sClefableGfx33_1:
+.incbin "baserom.gba", 0x695FF4, 0x60
+sClefableGfx33_2:
+.incbin "baserom.gba", 0x696054, 0x60
+sClefableGfx33_3:
+.incbin "baserom.gba", 0x6960B4, 0x60
+sClefableSprites33:
+ax_sprite sClefableGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx33_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClefableGfx34:
+.incbin "baserom.gba", 0x69615C, 0x40
+sClefableGfx34_1:
+.incbin "baserom.gba", 0x69619C, 0x60
+sClefableGfx34_2:
+.incbin "baserom.gba", 0x6961FC, 0x60
+sClefableGfx34_3:
+.incbin "baserom.gba", 0x69625C, 0x60
+sClefableSprites34:
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClefableGfx35:
+.incbin "baserom.gba", 0x69630C, 0x60
+sClefableGfx35_1:
+.incbin "baserom.gba", 0x69636C, 0x60
+sClefableGfx35_2:
+.incbin "baserom.gba", 0x6963CC, 0x60
+sClefableGfx35_3:
+.incbin "baserom.gba", 0x69642C, 0x40
+sClefableSprites35:
+ax_sprite sClefableGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sClefableGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClefableGfx36:
+.incbin "baserom.gba", 0x6964B4, 0x60
+sClefableGfx36_1:
+.incbin "baserom.gba", 0x696514, 0x60
+sClefableGfx36_2:
+.incbin "baserom.gba", 0x696574, 0x60
+sClefableSprites36:
+ax_sprite sClefableGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefableGfx37:
+.incbin "baserom.gba", 0x69660C, 0x60
+sClefableGfx37_1:
+.incbin "baserom.gba", 0x69666C, 0x60
+sClefableGfx37_2:
+.incbin "baserom.gba", 0x6966CC, 0x60
+sClefableSprites37:
+ax_sprite sClefableGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefableGfx38:
+.incbin "baserom.gba", 0x696764, 0x60
+sClefableGfx38_1:
+.incbin "baserom.gba", 0x6967C4, 0x60
+sClefableGfx38_2:
+.incbin "baserom.gba", 0x696824, 0x60
+sClefableSprites38:
+ax_sprite sClefableGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefableGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefableGfx39:
+.incbin "baserom.gba", 0x6968BC, 0x200
+sClefableSprites39:
+ax_sprite sClefableGfx39, 0x200
+ax_sprite_terminator
+sClefableGfx40:
+.incbin "baserom.gba", 0x696ACC, 0x200
+sClefableSprites40:
+ax_sprite sClefableGfx40, 0x200
+ax_sprite_terminator
+sClefableGfx41:
+.incbin "baserom.gba", 0x696CDC, 0x200
+sClefableSprites41:
+ax_sprite sClefableGfx41, 0x200
+ax_sprite_terminator
+sClefableGfx42:
+.incbin "baserom.gba", 0x696EEC, 0x200
+sClefableSprites42:
+ax_sprite sClefableGfx42, 0x200
+ax_sprite_terminator
+sClefableGfx43:
+.incbin "baserom.gba", 0x6970FC, 0x200
+sClefableSprites43:
+ax_sprite sClefableGfx43, 0x200
+ax_sprite_terminator
+sClefableGfx44:
+.incbin "baserom.gba", 0x69730C, 0x200
+sClefableSprites44:
+ax_sprite sClefableGfx44, 0x200
+ax_sprite_terminator
+sClefableGfx45:
+.incbin "baserom.gba", 0x69751C, 0x200
+sClefableSprites45:
+ax_sprite sClefableGfx45, 0x200
+ax_sprite_terminator
+sAxPosesClefable:
+.4byte sClefablePose1
+.4byte sClefablePose2
+.4byte sClefablePose3
+.4byte sClefablePose4
+.4byte sClefablePose5
+.4byte sClefablePose6
+.4byte sClefablePose7
+.4byte sClefablePose8
+.4byte sClefablePose9
+.4byte sClefablePose10
+.4byte sClefablePose11
+.4byte sClefablePose12
+.4byte sClefablePose13
+.4byte sClefablePose14
+.4byte sClefablePose15
+.4byte sClefablePose16
+.4byte sClefablePose17
+.4byte sClefablePose18
+.4byte sClefablePose19
+.4byte sClefablePose20
+.4byte sClefablePose21
+.4byte sClefablePose22
+.4byte sClefablePose23
+.4byte sClefablePose24
+.4byte sClefablePose25
+.4byte sClefablePose26
+.4byte sClefablePose27
+.4byte sClefablePose28
+.4byte sClefablePose29
+.4byte sClefablePose30
+.4byte sClefablePose31
+.4byte sClefablePose32
+.4byte sClefablePose33
+.4byte sClefablePose34
+.4byte sClefablePose35
+.4byte sClefablePose36
+.4byte sClefablePose37
+.4byte sClefablePose38
+.4byte sClefablePose39
+.4byte sClefablePose40
+.4byte sClefablePose41
+.4byte sClefablePose42
+.4byte sClefablePose43
+.4byte sClefablePose44
+.4byte sClefablePose45
+.4byte sClefablePose46
+.4byte sClefablePose47
+.4byte sClefablePose48
+.4byte sClefablePose49
+.4byte sClefablePose50
+.4byte sClefablePose51
+.4byte sClefablePose52
+.4byte sClefablePose53
+.4byte sClefablePose54
+.4byte sClefablePose55
+.4byte sClefablePose56
+.4byte sClefablePose57
+.4byte sClefablePose58
+.4byte sClefablePose59
+.4byte sClefablePose60
+.4byte sClefablePose61
+.4byte sClefablePose62
+.4byte sClefablePose63
+.4byte sClefablePose64
+.4byte sClefablePose65
+.4byte sClefablePose66
+.4byte sClefablePose67
+.4byte sClefablePose68
+.4byte sClefablePose69
+.4byte sClefablePose70
+.4byte sClefablePose71
+.4byte sClefablePose72
+.4byte sClefablePose73
+.4byte sClefablePose74
+.4byte sClefablePose75
+.4byte sClefablePose76
+.4byte sClefablePose77
+.4byte sClefablePose78
+.4byte sClefablePose79
+.4byte sClefablePose80
+.4byte sClefablePose81
+.4byte sClefablePose82
+.4byte sClefablePose83
+.4byte sClefablePose84
+.4byte sClefablePose85
+.4byte sClefablePose86
+.4byte sClefablePose87
+.4byte sClefablePose88
+.4byte sClefablePose89
+.4byte sClefablePose90
+.4byte sClefablePose91
+.4byte sClefablePose92
+.4byte sClefablePose93
+.4byte sClefablePose94
+.4byte sClefablePose95
+.4byte sClefablePose96
+.4byte sClefablePose97
+.4byte sClefablePose98
+.4byte sClefablePose99
+.4byte sClefablePose100
+.4byte sClefablePose101
+.4byte sClefablePose102
+.4byte sClefablePose103
+.4byte sClefablePose104
+.4byte sClefablePose105
+.4byte sClefablePose106
+.4byte sClefablePose107
+.4byte sClefablePose108
+.4byte sClefablePose109
+.4byte sClefablePose110
+.4byte sClefablePose111
+.4byte sClefablePose112
+.4byte sClefablePose113
+.4byte sClefablePose114
+.4byte sClefablePose115
+.4byte sClefablePose116
+.4byte sClefablePose117
+.4byte sClefablePose118
+.4byte sClefablePose119
+.4byte sClefablePose120
+.4byte sClefablePose121
+.4byte sClefablePose122
+.4byte sClefablePose123
+.4byte sClefablePose124
+.4byte sClefablePose125
+.4byte sClefablePose126
+.4byte sClefablePose127
+.4byte sClefablePose128
+.4byte sClefablePose129
+.4byte sClefablePose130
+.4byte sClefablePose131
+.4byte sClefablePose132
+.4byte sClefablePose133
+.4byte sClefablePose134
+.4byte sClefablePose135
+.4byte sClefablePose136
+.4byte sClefablePose137
+.4byte sClefablePose138
+.4byte sClefablePose139
+.4byte sClefablePose140
+.4byte sClefablePose141
+.4byte sClefablePose142
+.4byte sClefablePose143
+.4byte sClefablePose144
+.4byte sClefablePose145
+.4byte sClefablePose146
+.4byte sClefablePose147
+.4byte sClefablePose148
+.4byte sClefablePose149
+.4byte sClefablePose150
+.4byte sClefablePose151
+.4byte sClefablePose152
+.4byte sClefablePose153
+.4byte sClefablePose154
+.4byte sClefablePose155
+.4byte sClefablePose156
+.4byte sClefablePose157
+.4byte sClefablePose158
+.4byte sClefablePose159
+.4byte sClefablePose160
+.4byte sClefablePose161
+.4byte sClefablePose162
+.4byte sClefablePose163
+.4byte sClefablePose164
+.4byte sClefablePose165
+.4byte sClefablePose166
+.4byte sClefablePose167
+.4byte sClefablePose168
+.4byte sClefablePose169
+.4byte sClefablePose170
+.4byte sClefablePose171
+.4byte sClefablePose172
+.4byte sClefablePose173
+.4byte sClefablePose174
+.4byte sClefablePose175
+.4byte sClefablePose176
+.4byte sClefablePose177
+.4byte sClefablePose178
+.4byte sClefablePose179
+.4byte sClefablePose180
+.4byte sClefablePose181
+.4byte sClefablePose182
+.4byte sClefablePose183
+.4byte sClefablePose184
+.4byte sClefablePose185
+.4byte sClefablePose186
+.4byte sClefablePose187
+.4byte sClefablePose188
+.4byte sClefablePose189
+.4byte sClefablePose190
+.4byte sClefablePose191
+.4byte sClefablePose192
+.4byte sClefablePose193
+.4byte sClefablePose194
+.4byte sClefablePose195
+.4byte sClefablePose196
+.4byte sClefablePose197
+.4byte sClefablePose198
+.4byte sClefablePose199
+.4byte sClefablePose200
+.4byte sClefablePose201
+.4byte sClefablePose202
+.4byte sClefablePose203
+.4byte sClefablePose204
+.4byte sClefablePose205
+.4byte sClefablePose206
+.4byte sClefablePose207
+.4byte sClefablePose208
+.4byte sClefablePose209
+.4byte sClefablePose210
+.4byte sClefablePose211
+.4byte sClefablePose212
+.4byte sClefablePose213
+.4byte sClefablePose214
+.4byte sClefablePose215
+.4byte sClefablePose216
+.4byte sClefablePose217
+.4byte sClefablePose218
+sAxPositionsClefable:
+.2byte   -1,   -7, 	 -10,   -8, 	   9,   -8, 	  -1,   -6
+.2byte    1,   -9, 	  -9,  -14, 	  10,   -7, 	   1,  -10
+.2byte   -2,   -9, 	 -11,   -7, 	   8,  -14, 	  -2,  -10
+.2byte    2,   -7, 	   8,  -10, 	  -7,   -6, 	  -1,   -8
+.2byte    1,  -10, 	   8,  -15, 	  -7,   -8, 	  -1,  -10
+.2byte    2,   -9, 	   8,   -9, 	  -8,  -11, 	  -1,  -11
+.2byte    5,   -9, 	   1,   -6, 	  -1,   -5, 	   0,   -8
+.2byte    5,   -8, 	   2,   -8, 	  -1,   -4, 	   0,   -9
+.2byte    4,  -13, 	  -2,   -8, 	   0,  -10, 	   0,  -11
+.2byte    3,   -9, 	   9,   -5, 	  -4,   -9, 	   1,   -9
+.2byte    5,   -8, 	   9,   -3, 	  -2,  -10, 	   2,   -9
+.2byte   -1,  -12, 	   8,  -11, 	  -7,  -10, 	  -2,  -12
+.2byte   -1,  -10, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -2,  -13, 	   9,  -10, 	  -8,   -5, 	  -1,  -11
+.2byte    1,  -13, 	   7,   -5, 	 -10,  -10, 	   0,  -11
+.2byte   -4,  -11, 	   5,   -8, 	 -10,   -5, 	  -2,  -10
+.2byte   -5,   -9, 	   1,  -11, 	 -10,   -3, 	  -2,  -11
+.2byte   -1,  -13, 	   6,   -9, 	  -9,  -12, 	   1,  -12
+.2byte   -6,   -9, 	  -2,   -6, 	   0,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	  -3,   -8, 	   0,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	   1,   -8, 	  -1,  -10, 	  -1,  -11
+.2byte   -3,   -7, 	  -9,  -10, 	   6,   -6, 	   0,   -8
+.2byte   -2,  -10, 	  -9,  -15, 	   6,   -8, 	   0,  -10
+.2byte   -3,   -9, 	  -9,   -9, 	   7,  -11, 	   0,  -11
+.2byte   -1,   -7, 	 -10,   -8, 	   9,   -8, 	  -1,   -6
+.2byte    1,   -9, 	  -9,  -14, 	  10,   -7, 	   1,  -10
+.2byte   -2,   -9, 	 -11,   -7, 	   8,  -14, 	  -2,  -10
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte    2,   -7, 	   8,  -10, 	  -7,   -6, 	  -1,   -8
+.2byte    1,  -10, 	   8,  -15, 	  -7,   -8, 	  -1,  -10
+.2byte    2,   -9, 	   8,   -9, 	  -8,  -11, 	  -1,  -11
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte    5,   -9, 	   1,   -6, 	  -1,   -5, 	   0,   -8
+.2byte    5,   -8, 	   2,   -8, 	  -1,   -4, 	   0,   -9
+.2byte    4,  -13, 	  -2,   -8, 	   0,  -10, 	   0,  -11
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    3,   -9, 	   9,   -5, 	  -4,   -9, 	   1,   -9
+.2byte    5,   -8, 	   9,   -3, 	  -2,  -10, 	   2,   -9
+.2byte   -1,  -12, 	   8,  -11, 	  -7,  -10, 	  -2,  -12
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -10, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -2,  -13, 	   9,  -10, 	  -8,   -5, 	  -1,  -11
+.2byte    1,  -13, 	   7,   -5, 	 -10,  -10, 	   0,  -11
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte   -4,  -11, 	   5,   -8, 	 -10,   -5, 	  -2,  -10
+.2byte   -5,   -9, 	   1,  -11, 	 -10,   -3, 	  -2,  -11
+.2byte   -1,  -13, 	   6,   -9, 	  -9,  -12, 	   1,  -12
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,   -6, 	   0,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	  -3,   -8, 	   0,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	   1,   -8, 	  -1,  -10, 	  -1,  -11
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,  -10, 	   6,   -6, 	   0,   -8
+.2byte   -2,  -10, 	  -9,  -15, 	   6,   -8, 	   0,  -10
+.2byte   -3,   -9, 	  -9,   -9, 	   7,  -11, 	   0,  -11
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -1,   -7, 	 -10,   -8, 	   9,   -8, 	  -1,   -6
+.2byte    1,   -9, 	  -9,  -14, 	  10,   -7, 	   1,  -10
+.2byte   -2,   -9, 	 -11,   -7, 	   8,  -14, 	  -2,  -10
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte    2,   -7, 	   8,  -10, 	  -7,   -6, 	  -1,   -8
+.2byte    1,  -10, 	   8,  -15, 	  -7,   -8, 	  -1,  -10
+.2byte    2,   -9, 	   8,   -9, 	  -8,  -11, 	  -1,  -11
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte    5,   -9, 	   1,   -6, 	  -1,   -5, 	   0,   -8
+.2byte    5,   -8, 	   2,   -8, 	  -1,   -4, 	   0,   -9
+.2byte    4,  -13, 	  -2,   -8, 	   0,  -10, 	   0,  -11
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    3,   -9, 	   9,   -5, 	  -4,   -9, 	   1,   -9
+.2byte    5,   -8, 	   9,   -3, 	  -2,  -10, 	   2,   -9
+.2byte   -1,  -12, 	   8,  -11, 	  -7,  -10, 	  -2,  -12
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -10, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -2,  -13, 	   9,  -10, 	  -8,   -5, 	  -1,  -11
+.2byte    1,  -13, 	   7,   -5, 	 -10,  -10, 	   0,  -11
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte   -4,  -11, 	   5,   -8, 	 -10,   -5, 	  -2,  -10
+.2byte   -5,   -9, 	   1,  -11, 	 -10,   -3, 	  -2,  -11
+.2byte   -1,  -13, 	   6,   -9, 	  -9,  -12, 	   1,  -12
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,   -6, 	   0,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	  -3,   -8, 	   0,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	   1,   -8, 	  -1,  -10, 	  -1,  -11
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,  -10, 	   6,   -6, 	   0,   -8
+.2byte   -2,  -10, 	  -9,  -15, 	   6,   -8, 	   0,  -10
+.2byte   -3,   -9, 	  -9,   -9, 	   7,  -11, 	   0,  -11
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -1,   -7, 	 -10,   -8, 	   9,   -8, 	  -1,   -6
+.2byte   -1,   -4, 	  -7,   -5, 	   6,   -5, 	  -1,   -5
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte    2,   -7, 	   8,  -10, 	  -7,   -6, 	  -1,   -8
+.2byte    2,   -4, 	   4,   -6, 	  -4,   -3, 	   0,   -5
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte    5,   -9, 	   1,   -6, 	  -1,   -5, 	   0,   -8
+.2byte    4,   -4, 	   1,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    3,   -9, 	   9,   -5, 	  -4,   -9, 	   1,   -9
+.2byte    2,   -6, 	  -5,   -6, 	   6,   -3, 	   0,   -6
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -10, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -1,   -7, 	   4,   -4, 	  -6,   -4, 	  -1,   -5
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte   -4,  -11, 	   5,   -8, 	 -10,   -5, 	  -2,  -10
+.2byte   -3,   -6, 	   4,   -6, 	  -7,   -3, 	  -1,   -6
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,   -6, 	   0,   -5, 	  -1,   -8
+.2byte   -5,   -4, 	  -2,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,  -10, 	   6,   -6, 	   0,   -8
+.2byte   -3,   -4, 	  -5,   -6, 	   3,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte   -3,   -7, 	 -11,  -10, 	   3,  -10, 	  -3,   -8
+.2byte    2,   -7, 	  -4,  -10, 	  10,  -10, 	   2,   -8
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte    3,   -7, 	   8,  -12, 	  -2,  -11, 	  -1,   -7
+.2byte    1,   -7, 	   7,  -13, 	  -6,   -7, 	  -2,   -8
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    5,  -10, 	   1,  -12, 	   2,  -14, 	  -1,   -8
+.2byte    5,   -8, 	   7,  -13, 	   1,   -8, 	  -2,   -8
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte    1,  -11, 	  -7,  -15, 	   7,  -14, 	   0,  -10
+.2byte    3,  -10, 	  -2,  -13, 	  10,   -9, 	   0,   -9
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte    1,  -12, 	   8,  -15, 	  -4,  -17, 	  -1,  -10
+.2byte   -2,  -11, 	   3,  -17, 	  -9,  -15, 	   0,   -9
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -2,  -11, 	   6,  -15, 	  -8,  -14, 	  -1,  -10
+.2byte   -4,  -10, 	   1,  -13, 	 -11,   -9, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -6,  -10, 	  -2,  -12, 	  -3,  -14, 	   0,   -8
+.2byte   -6,   -8, 	  -8,  -13, 	  -2,   -8, 	   1,   -8
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -4,   -7, 	  -9,  -12, 	   1,  -11, 	   0,   -7
+.2byte   -2,   -7, 	  -8,  -13, 	   5,   -7, 	   1,   -8
+.2byte   -2,   -6, 	  -8,   -4, 	   6,   -3, 	   0,   -8
+.2byte   -2,   -4, 	  -8,   -4, 	   6,   -1, 	   0,   -7
+.2byte   -1,   -6, 	 -10,   -9, 	   9,   -9, 	  -1,   -5
+.2byte    0,   -6, 	   4,  -13, 	  -9,   -7, 	  -3,   -6
+.2byte    1,   -7, 	  -4,  -14, 	  -5,  -11, 	  -3,   -7
+.2byte    1,   -7, 	  -7,  -11, 	   5,   -9, 	  -2,   -7
+.2byte    0,   -7, 	   8,   -8, 	  -8,   -8, 	   0,   -5
+.2byte   -2,   -7, 	   6,  -11, 	  -6,   -9, 	   1,   -7
+.2byte   -2,   -7, 	   3,  -14, 	   4,  -11, 	   2,   -7
+.2byte   -1,   -6, 	  -5,  -13, 	   8,   -7, 	   2,   -6
+.2byte   -1,   -7, 	 -10,   -8, 	   9,   -8, 	  -1,   -6
+.2byte    1,   -9, 	  -9,  -14, 	  10,   -7, 	   1,  -10
+.2byte   -2,   -9, 	 -11,   -7, 	   8,  -14, 	  -2,  -10
+.2byte    2,   -7, 	   8,  -10, 	  -7,   -6, 	  -1,   -8
+.2byte    1,  -10, 	   8,  -15, 	  -7,   -8, 	  -1,  -10
+.2byte    2,   -9, 	   8,   -9, 	  -8,  -11, 	  -1,  -11
+.2byte    5,   -9, 	   1,   -6, 	  -1,   -5, 	   0,   -8
+.2byte    5,   -8, 	   2,   -8, 	  -1,   -4, 	   0,   -9
+.2byte    4,  -13, 	  -2,   -8, 	   0,  -10, 	   0,  -11
+.2byte    3,   -9, 	   9,   -5, 	  -4,   -9, 	   1,   -9
+.2byte    5,   -8, 	   9,   -3, 	  -2,  -10, 	   2,   -9
+.2byte   -1,  -12, 	   8,  -11, 	  -7,  -10, 	  -2,  -12
+.2byte   -1,  -10, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -2,  -13, 	   9,  -10, 	  -8,   -5, 	  -1,  -11
+.2byte    1,  -13, 	   7,   -5, 	 -10,  -10, 	   0,  -11
+.2byte   -4,  -11, 	   5,   -8, 	 -10,   -5, 	  -2,  -10
+.2byte   -5,   -9, 	   1,  -11, 	 -10,   -3, 	  -2,  -11
+.2byte   -1,  -13, 	   6,   -9, 	  -9,  -12, 	   1,  -12
+.2byte   -6,   -9, 	  -2,   -6, 	   0,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	  -3,   -8, 	   0,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	   1,   -8, 	  -1,  -10, 	  -1,  -11
+.2byte   -3,   -7, 	  -9,  -10, 	   6,   -6, 	   0,   -8
+.2byte   -2,  -10, 	  -9,  -15, 	   6,   -8, 	   0,  -10
+.2byte   -3,   -9, 	  -9,   -9, 	   7,  -11, 	   0,  -11
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -1,   -7, 	 -10,   -8, 	   9,   -8, 	  -1,   -6
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte    2,   -7, 	   8,  -10, 	  -7,   -6, 	  -1,   -8
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte    5,   -9, 	   1,   -6, 	  -1,   -5, 	   0,   -8
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    3,   -9, 	   9,   -5, 	  -4,   -9, 	   1,   -9
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -10, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte   -4,  -11, 	   5,   -8, 	 -10,   -5, 	  -2,  -10
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,   -6, 	   0,   -5, 	  -1,   -8
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,  -10, 	   6,   -6, 	   0,   -8
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -1,   -7, 	 -10,  -11, 	   9,  -11, 	  -1,   -8
+.2byte    2,   -7, 	   8,  -15, 	  -4,  -10, 	  -1,   -8
+.2byte    5,   -9, 	   2,  -14, 	   0,  -12, 	   0,   -8
+.2byte    3,  -10, 	  -6,  -16, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -11, 	   7,  -14, 	  -8,  -14, 	  -1,   -9
+.2byte   -4,  -10, 	   5,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,  -14, 	  -1,  -12, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,  -15, 	   3,  -10, 	   0,   -8
+.2byte   -1,   -7, 	 -10,   -8, 	   9,   -8, 	  -1,   -6
+.2byte   -3,   -7, 	  -9,  -10, 	   6,   -6, 	   0,   -8
+.2byte   -6,   -9, 	  -2,   -6, 	   0,   -5, 	  -1,   -8
+.2byte   -4,  -11, 	   5,   -8, 	 -10,   -5, 	  -2,  -10
+.2byte   -1,  -10, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte    3,   -9, 	   9,   -5, 	  -4,   -9, 	   1,   -9
+.2byte    5,   -9, 	   1,   -6, 	  -1,   -5, 	   0,   -8
+.2byte    2,   -7, 	   8,  -10, 	  -7,   -6, 	  -1,   -8
+sClefableAnimTable1:
+.4byte sClefableAnims_1_1
+.4byte sClefableAnims_1_2
+.4byte sClefableAnims_1_3
+.4byte sClefableAnims_1_4
+.4byte sClefableAnims_1_5
+.4byte sClefableAnims_1_6
+.4byte sClefableAnims_1_7
+.4byte sClefableAnims_1_8
+sClefableAnimTable2:
+.4byte sClefableAnims_2_1
+.4byte sClefableAnims_2_2
+.4byte sClefableAnims_2_3
+.4byte sClefableAnims_2_4
+.4byte sClefableAnims_2_5
+.4byte sClefableAnims_2_6
+.4byte sClefableAnims_2_7
+.4byte sClefableAnims_2_8
+sClefableAnimTable3:
+.4byte sClefableAnims_3_1
+.4byte sClefableAnims_3_2
+.4byte sClefableAnims_3_3
+.4byte sClefableAnims_3_4
+.4byte sClefableAnims_3_5
+.4byte sClefableAnims_3_6
+.4byte sClefableAnims_3_7
+.4byte sClefableAnims_3_8
+sClefableAnimTable4:
+.4byte sClefableAnims_4_1
+.4byte sClefableAnims_4_2
+.4byte sClefableAnims_4_3
+.4byte sClefableAnims_4_4
+.4byte sClefableAnims_4_5
+.4byte sClefableAnims_4_6
+.4byte sClefableAnims_4_7
+.4byte sClefableAnims_4_8
+sClefableAnimTable5:
+.4byte sClefableAnims_5_1
+.4byte sClefableAnims_5_2
+.4byte sClefableAnims_5_3
+.4byte sClefableAnims_5_4
+.4byte sClefableAnims_5_5
+.4byte sClefableAnims_5_6
+.4byte sClefableAnims_5_7
+.4byte sClefableAnims_5_8
+sClefableAnimTable6:
+.4byte sClefableAnims_6_1
+.4byte sClefableAnims_6_1
+.4byte sClefableAnims_6_1
+.4byte sClefableAnims_6_1
+.4byte sClefableAnims_6_1
+.4byte sClefableAnims_6_1
+.4byte sClefableAnims_6_1
+.4byte sClefableAnims_6_1
+sClefableAnimTable7:
+.4byte sClefableAnims_7_1
+.4byte sClefableAnims_7_2
+.4byte sClefableAnims_7_3
+.4byte sClefableAnims_7_4
+.4byte sClefableAnims_7_5
+.4byte sClefableAnims_7_6
+.4byte sClefableAnims_7_7
+.4byte sClefableAnims_7_8
+sClefableAnimTable8:
+.4byte sClefableAnims_8_1
+.4byte sClefableAnims_8_2
+.4byte sClefableAnims_8_3
+.4byte sClefableAnims_8_4
+.4byte sClefableAnims_8_5
+.4byte sClefableAnims_8_6
+.4byte sClefableAnims_8_7
+.4byte sClefableAnims_8_8
+sClefableAnimTable9:
+.4byte sClefableAnims_9_1
+.4byte sClefableAnims_9_2
+.4byte sClefableAnims_9_3
+.4byte sClefableAnims_9_4
+.4byte sClefableAnims_9_5
+.4byte sClefableAnims_9_6
+.4byte sClefableAnims_9_7
+.4byte sClefableAnims_9_8
+sClefableAnimTable10:
+.4byte sClefableAnims_10_1
+.4byte sClefableAnims_10_2
+.4byte sClefableAnims_10_3
+.4byte sClefableAnims_10_4
+.4byte sClefableAnims_10_5
+.4byte sClefableAnims_10_6
+.4byte sClefableAnims_10_7
+.4byte sClefableAnims_10_8
+sClefableAnimTable11:
+.4byte sClefableAnims_11_1
+.4byte sClefableAnims_11_2
+.4byte sClefableAnims_11_3
+.4byte sClefableAnims_11_4
+.4byte sClefableAnims_11_5
+.4byte sClefableAnims_11_6
+.4byte sClefableAnims_11_7
+.4byte sClefableAnims_11_8
+sClefableAnimTable12:
+.4byte sClefableAnims_12_1
+.4byte sClefableAnims_12_2
+.4byte sClefableAnims_12_3
+.4byte sClefableAnims_12_4
+.4byte sClefableAnims_12_5
+.4byte sClefableAnims_12_6
+.4byte sClefableAnims_12_7
+.4byte sClefableAnims_12_8
+sClefableAnimTable13:
+.4byte sClefableAnims_13_1
+.4byte sClefableAnims_13_2
+.4byte sClefableAnims_13_3
+.4byte sClefableAnims_13_4
+.4byte sClefableAnims_13_5
+.4byte sClefableAnims_13_6
+.4byte sClefableAnims_13_7
+.4byte sClefableAnims_13_8
+sAxAnimationsClefable:
+.4byte sClefableAnimTable1
+.4byte sClefableAnimTable2
+.4byte sClefableAnimTable3
+.4byte sClefableAnimTable4
+.4byte sClefableAnimTable5
+.4byte sClefableAnimTable6
+.4byte sClefableAnimTable7
+.4byte sClefableAnimTable8
+.4byte sClefableAnimTable9
+.4byte sClefableAnimTable10
+.4byte sClefableAnimTable11
+.4byte sClefableAnimTable12
+.4byte sClefableAnimTable13
+sAxSpritesClefable:
+.4byte sClefableSprites1
+.4byte sClefableSprites2
+.4byte sClefableSprites3
+.4byte sClefableSprites4
+.4byte sClefableSprites5
+.4byte sClefableSprites6
+.4byte sClefableSprites7
+.4byte sClefableSprites8
+.4byte sClefableSprites9
+.4byte sClefableSprites10
+.4byte sClefableSprites11
+.4byte sClefableSprites12
+.4byte sClefableSprites13
+.4byte sClefableSprites14
+.4byte sClefableSprites15
+.4byte sClefableSprites16
+.4byte sClefableSprites17
+.4byte sClefableSprites18
+.4byte sClefableSprites19
+.4byte sClefableSprites20
+.4byte sClefableSprites21
+.4byte sClefableSprites22
+.4byte sClefableSprites23
+.4byte sClefableSprites24
+.4byte sClefableSprites25
+.4byte sClefableSprites26
+.4byte sClefableSprites27
+.4byte sClefableSprites28
+.4byte sClefableSprites29
+.4byte sClefableSprites30
+.4byte sClefableSprites31
+.4byte sClefableSprites32
+.4byte sClefableSprites33
+.4byte sClefableSprites34
+.4byte sClefableSprites35
+.4byte sClefableSprites36
+.4byte sClefableSprites37
+.4byte sClefableSprites38
+.4byte sClefableSprites39
+.4byte sClefableSprites40
+.4byte sClefableSprites41
+.4byte sClefableSprites42
+.4byte sClefableSprites43
+.4byte sClefableSprites44
+.4byte sClefableSprites45
+sAxMainClefable:
+ax_main sAxPosesClefable, sAxAnimationsClefable, 13, sAxSpritesClefable, sAxPositionsClefable

--- a/data/ax/clefairy.inc
+++ b/data/ax/clefairy.inc
@@ -1,0 +1,2836 @@
+.global gAxClefairy
+gAxClefairy:
+ax_siro sAxMainClefairy
+sClefairyPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose4:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose7:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose8:
+ax_pose 7, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose9:
+ax_pose 8, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose10:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose11:
+ax_pose 10, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose12:
+ax_pose 11, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose16:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose17:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose18:
+ax_pose 17, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose19:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose20:
+ax_pose 19, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose21:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose22:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose23:
+ax_pose 22, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose24:
+ax_pose 23, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose28:
+ax_pose 24, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose29:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose30:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose31:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose32:
+ax_pose 25, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose33:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose34:
+ax_pose 7, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose35:
+ax_pose 8, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose36:
+ax_pose 26, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose37:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose38:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose39:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose40:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose42:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose43:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose44:
+ax_pose 28, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose45:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose46:
+ax_pose 16, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose47:
+ax_pose 17, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose48:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose49:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose50:
+ax_pose 19, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose51:
+ax_pose 20, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose52:
+ax_pose 26, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose53:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose54:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose55:
+ax_pose 23, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose56:
+ax_pose 25, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose57:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose58:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose59:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose60:
+ax_pose 24, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose61:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose62:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose63:
+ax_pose 5, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose64:
+ax_pose 25, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose65:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose66:
+ax_pose 7, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose67:
+ax_pose 8, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose68:
+ax_pose 26, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose69:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose70:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose71:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose72:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose74:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose75:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose76:
+ax_pose 28, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose77:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose78:
+ax_pose 16, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose79:
+ax_pose 17, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose80:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose81:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose82:
+ax_pose 19, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose83:
+ax_pose 20, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose84:
+ax_pose 26, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose85:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose86:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose87:
+ax_pose 23, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose88:
+ax_pose 25, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose89:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose90:
+ax_pose 29, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose91:
+ax_pose 24, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose92:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose93:
+ax_pose 30, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose94:
+ax_pose 25, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose95:
+ax_pose 18, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose96:
+ax_pose 31, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose97:
+ax_pose 26, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose98:
+ax_pose 15, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose99:
+ax_pose 32, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose100:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose102:
+ax_pose 33, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose103:
+ax_pose 28, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose104:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose105:
+ax_pose 32, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose106:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose107:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose108:
+ax_pose 31, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose109:
+ax_pose 26, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose110:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose111:
+ax_pose 30, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose112:
+ax_pose 25, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose113:
+ax_pose 24, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose114:
+ax_pose 34, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose115:
+ax_pose 35, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose116:
+ax_pose 25, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose117:
+ax_pose 36, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose118:
+ax_pose 37, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sClefairyPose119:
+ax_pose 26, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose120:
+ax_pose 38, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose121:
+ax_pose 39, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose122:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose123:
+ax_pose 40, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose124:
+ax_pose 41, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose125:
+ax_pose 28, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose126:
+ax_pose 42, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose127:
+ax_pose 43, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose128:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose129:
+ax_pose 40, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose130:
+ax_pose 41, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose131:
+ax_pose 26, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose132:
+ax_pose 38, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose133:
+ax_pose 39, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose134:
+ax_pose 25, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose135:
+ax_pose 36, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose136:
+ax_pose 37, 0x01ea, 0x80f5, 0x1c00
+ax_pose_terminator
+sClefairyPose137:
+ax_pose 44, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose138:
+ax_pose 45, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose139:
+ax_pose 46, 0x01e2, 0x80f0, 0x1c00
+ax_pose_terminator
+sClefairyPose140:
+ax_pose 47, 0x01e5, 0x90ea, 0x1c00
+ax_pose_terminator
+sClefairyPose141:
+ax_pose 48, 0x01e4, 0x90e8, 0x1c00
+ax_pose_terminator
+sClefairyPose142:
+ax_pose 49, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sClefairyPose143:
+ax_pose 50, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose144:
+ax_pose 49, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sClefairyPose145:
+ax_pose 48, 0x01e4, 0x80f8, 0x1c00
+ax_pose_terminator
+sClefairyPose146:
+ax_pose 47, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sClefairyPose147:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose148:
+ax_pose 1, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose149:
+ax_pose 2, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose150:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose151:
+ax_pose 4, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose152:
+ax_pose 5, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose153:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose154:
+ax_pose 7, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose155:
+ax_pose 8, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose156:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose157:
+ax_pose 10, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose158:
+ax_pose 11, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose159:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose160:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose161:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose162:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose163:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose164:
+ax_pose 17, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose165:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose166:
+ax_pose 19, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose167:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose168:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose169:
+ax_pose 22, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose170:
+ax_pose 23, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose171:
+ax_pose 29, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose172:
+ax_pose 30, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose173:
+ax_pose 31, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose174:
+ax_pose 32, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose175:
+ax_pose 33, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose176:
+ax_pose 32, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose177:
+ax_pose 31, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose178:
+ax_pose 30, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose179:
+ax_pose 24, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose180:
+ax_pose 25, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose181:
+ax_pose 26, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose182:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose183:
+ax_pose 28, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose184:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose185:
+ax_pose 26, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose186:
+ax_pose 25, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose187:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose188:
+ax_pose 24, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose189:
+ax_pose 29, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose190:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose191:
+ax_pose 25, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose192:
+ax_pose 30, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose193:
+ax_pose 18, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose194:
+ax_pose 26, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose195:
+ax_pose 31, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose196:
+ax_pose 15, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose197:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose198:
+ax_pose 32, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose199:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose200:
+ax_pose 28, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose201:
+ax_pose 33, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose202:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose203:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose204:
+ax_pose 32, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose205:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose206:
+ax_pose 26, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose207:
+ax_pose 31, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose208:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose209:
+ax_pose 25, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose210:
+ax_pose 30, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose211:
+ax_pose 29, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose212:
+ax_pose 30, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose213:
+ax_pose 31, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose214:
+ax_pose 32, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sClefairyPose215:
+ax_pose 33, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose216:
+ax_pose 32, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose217:
+ax_pose 31, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose218:
+ax_pose 30, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sClefairyPose219:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose220:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose221:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose222:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose223:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose224:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose225:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sClefairyPose226:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+.align 2
+sClefairyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sClefairyAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 1, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 0, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sClefairyAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 1, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sClefairyAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -12, 11, -12,
+ax_anim 2, 0, 39, 22, -23, 22, -23,
+ax_anim 2, 1, 39, 23, -22, 23, -22,
+ax_anim 2, 0, 39, 22, -23, 22, -23,
+ax_anim 2, 0, 39, 23, -22, 23, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sClefairyAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -22, 0, -22,
+ax_anim 2, 1, 43, 1, -22, 1, -22,
+ax_anim 2, 0, 43, 0, -22, 0, -22,
+ax_anim 2, 0, 43, 1, -22, 1, -22,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sClefairyAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -12, -11, -12,
+ax_anim 2, 0, 47, -22, -23, -22, -23,
+ax_anim 2, 1, 47, -23, -22, -23, -22,
+ax_anim 2, 0, 47, -22, -23, -22, -23,
+ax_anim 2, 0, 47, -23, -22, -23, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sClefairyAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 1, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sClefairyAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 1, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 0, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sClefairyAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sClefairyAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 21, 20, 21, 20,
+ax_anim 2, 1, 63, 22, 19, 22, 19,
+ax_anim 2, 0, 63, 21, 20, 21, 20,
+ax_anim 2, 0, 63, 22, 19, 22, 19,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sClefairyAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 1, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 0, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sClefairyAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 11, -12, 11, -12,
+ax_anim 2, 0, 71, 22, -23, 22, -23,
+ax_anim 2, 1, 71, 23, -22, 23, -22,
+ax_anim 2, 0, 71, 22, -23, 22, -23,
+ax_anim 2, 0, 71, 23, -22, 23, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sClefairyAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -22, 0, -22,
+ax_anim 2, 1, 75, 1, -22, 1, -22,
+ax_anim 2, 0, 75, 0, -22, 0, -22,
+ax_anim 2, 0, 75, 1, -22, 1, -22,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sClefairyAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -11, -12, -11, -12,
+ax_anim 2, 0, 79, -22, -23, -22, -23,
+ax_anim 2, 1, 79, -23, -22, -23, -22,
+ax_anim 2, 0, 79, -22, -23, -22, -23,
+ax_anim 2, 0, 79, -23, -22, -23, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sClefairyAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 1, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 0, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sClefairyAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -21, 20, -21, 20,
+ax_anim 2, 1, 87, -22, 19, -22, 19,
+ax_anim 2, 0, 87, -21, 20, -21, 20,
+ax_anim 2, 0, 87, -22, 19, -22, 19,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sClefairyAnims_4_1:
+ax_anim 1, 0, 90, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 4, 2, 90, 0, -4, 0, -4,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, -2, 0, -2,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 1, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim_terminator
+sClefairyAnims_4_2:
+ax_anim 1, 0, 93, 0, -2, 0, -2,
+ax_anim 2, 0, 93, 0, -3, 0, -3,
+ax_anim 4, 2, 93, 0, -4, 0, -4,
+ax_anim 2, 0, 93, 0, -3, 0, -3,
+ax_anim 1, 0, 91, 0, -2, 0, -2,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 1, 92, 1, -1, 1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim_terminator
+sClefairyAnims_4_3:
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 4, 2, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 95, 0, 1, 0, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 1, 0, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 1, 0, 1,
+ax_anim_terminator
+sClefairyAnims_4_4:
+ax_anim 1, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 4, 2, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 1, 0, 97, 0, -2, 0, -2,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 98, 1, 1, 1, 1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim_terminator
+sClefairyAnims_4_5:
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 4, 2, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 1, 0, 100, 0, -1, 0, -2,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 1, 101, 1, 0, 1, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, 0, 1, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, 0, 1, 0,
+ax_anim_terminator
+sClefairyAnims_4_6:
+ax_anim 1, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 4, 2, 105, 0, -4, 0, -4,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 1, 0, 103, 0, -2, 0, -2,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 1, 104, -1, 1, -1, 1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, -1, 1, -1, 1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, -1, 1, -1, 1,
+ax_anim_terminator
+sClefairyAnims_4_7:
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 4, 2, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 107, 0, 1, 0, 1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 1,
+ax_anim_terminator
+sClefairyAnims_4_8:
+ax_anim 1, 0, 111, 0, -2, 0, -2,
+ax_anim 2, 0, 111, 0, -3, 0, -3,
+ax_anim 4, 2, 111, 0, -4, 0, -4,
+ax_anim 2, 0, 111, 0, -3, 0, -3,
+ax_anim 1, 0, 109, 0, -2, 0, -2,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 110, -1, -1, -1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -1, -1, -1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sClefairyAnims_5_1:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 2, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_5_2:
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 2, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_5_3:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 2, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_5_4:
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 2, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 1, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_5_5:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 2, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 1, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_5_6:
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 2, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 1, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_5_7:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 2, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 1, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_5_8:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 2, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 1, 133, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sClefairyAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sClefairyAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sClefairyAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sClefairyAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sClefairyAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sClefairyAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sClefairyAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sClefairyAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 2, 2, 0, 0,
+ax_anim 4, 0, 147, 2, 1, 0, 0,
+ax_anim 5, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 148, -1, 1, 0, 0,
+ax_anim 3, 0, 148, -1, 2, 0, 0,
+ax_anim_terminator
+sClefairyAnims_8_2:
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, 2, 0, 0,
+ax_anim 4, 0, 150, 0, 1, 0, 0,
+ax_anim 5, 0, 149, 1, -3, 0, 0,
+ax_anim 4, 0, 151, 1, 1, 0, 0,
+ax_anim 3, 0, 151, 1, 2, 0, 0,
+ax_anim_terminator
+sClefairyAnims_8_3:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 2, 1, 0, 0,
+ax_anim 4, 0, 153, 2, 0, 0, 0,
+ax_anim 5, 0, 152, 0, -3, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_8_4:
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 1, 1, 0, 0,
+ax_anim 4, 0, 157, 1, 0, 0, 0,
+ax_anim 5, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 156, 0, -1, 0, 0,
+ax_anim 3, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_8_5:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 159, -1, 2, 0, 0,
+ax_anim 4, 0, 159, -1, 1, 0, 0,
+ax_anim 5, 0, 158, 0, -3, 0, 0,
+ax_anim 4, 0, 160, 1, 0, 0, 0,
+ax_anim 3, 0, 160, 1, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_8_6:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, 1, 0, 0,
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim 5, 0, 161, 0, -3, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_8_7:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 3, 0, 165, -1, 1, 0, 0,
+ax_anim 4, 0, 165, -1, 0, 0, 0,
+ax_anim 5, 0, 164, -1, -3, 0, 0,
+ax_anim 4, 0, 166, -1, 0, 0, 0,
+ax_anim 3, 0, 166, -1, 1, 0, 0,
+ax_anim_terminator
+sClefairyAnims_8_8:
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 168, 0, 2, 0, 0,
+ax_anim 4, 0, 168, 0, 1, 0, 0,
+ax_anim 5, 0, 167, -1, -3, 0, 0,
+ax_anim 4, 0, 169, 0, 1, 0, 0,
+ax_anim 3, 0, 169, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 3, 19, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 20, 20, 20, 20,
+ax_anim 2, 3, 174, 13, 20, 13, 20,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 20, -2, 20, -2,
+ax_anim 2, 3, 173, 17, 4, 17, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 3, -16, 3, -16,
+ax_anim 2, 0, 170, 11, -24, 11, -24,
+ax_anim 3, 0, 171, 21, -25, 21, -25,
+ax_anim 2, 3, 172, 24, -14, 24, -14,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -20, -7, -20,
+ax_anim 3, 0, 170, 0, -25, 0, -25,
+ax_anim 2, 3, 171, 7, -20, 7, -20,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -3, -16, -3, -16,
+ax_anim 2, 0, 170, -11, -24, -11, -24,
+ax_anim 3, 0, 177, -21, -25, -21, -25,
+ax_anim 2, 3, 176, -24, -14, -24, -14,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -20, -2, -20, -2,
+ax_anim 2, 3, 175, -17, 4, -17, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 3, -19, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -20, 20, -20, 20,
+ax_anim 2, 3, 174, -13, 20, -13, 20,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -24, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -24, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -24, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sClefairyAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sClefairyGfx1:
+.incbin "baserom.gba", 0x68775C, 0x200
+sClefairySprites1:
+ax_sprite sClefairyGfx1, 0x200
+ax_sprite_terminator
+sClefairyGfx2:
+.incbin "baserom.gba", 0x68796C, 0x200
+sClefairySprites2:
+ax_sprite sClefairyGfx2, 0x200
+ax_sprite_terminator
+sClefairyGfx3:
+.incbin "baserom.gba", 0x687B7C, 0x200
+sClefairySprites3:
+ax_sprite sClefairyGfx3, 0x200
+ax_sprite_terminator
+sClefairyGfx4:
+.incbin "baserom.gba", 0x687D8C, 0x200
+sClefairySprites4:
+ax_sprite sClefairyGfx4, 0x200
+ax_sprite_terminator
+sClefairyGfx5:
+.incbin "baserom.gba", 0x687F9C, 0x200
+sClefairySprites5:
+ax_sprite sClefairyGfx5, 0x200
+ax_sprite_terminator
+sClefairyGfx6:
+.incbin "baserom.gba", 0x6881AC, 0x200
+sClefairySprites6:
+ax_sprite sClefairyGfx6, 0x200
+ax_sprite_terminator
+sClefairyGfx7:
+.incbin "baserom.gba", 0x6883BC, 0x200
+sClefairySprites7:
+ax_sprite sClefairyGfx7, 0x200
+ax_sprite_terminator
+sClefairyGfx8:
+.incbin "baserom.gba", 0x6885CC, 0x200
+sClefairySprites8:
+ax_sprite sClefairyGfx8, 0x200
+ax_sprite_terminator
+sClefairyGfx9:
+.incbin "baserom.gba", 0x6887DC, 0x200
+sClefairySprites9:
+ax_sprite sClefairyGfx9, 0x200
+ax_sprite_terminator
+sClefairyGfx10:
+.incbin "baserom.gba", 0x6889EC, 0x200
+sClefairySprites10:
+ax_sprite sClefairyGfx10, 0x200
+ax_sprite_terminator
+sClefairyGfx11:
+.incbin "baserom.gba", 0x688BFC, 0x200
+sClefairySprites11:
+ax_sprite sClefairyGfx11, 0x200
+ax_sprite_terminator
+sClefairyGfx12:
+.incbin "baserom.gba", 0x688E0C, 0x200
+sClefairySprites12:
+ax_sprite sClefairyGfx12, 0x200
+ax_sprite_terminator
+sClefairyGfx13:
+.incbin "baserom.gba", 0x68901C, 0x200
+sClefairySprites13:
+ax_sprite sClefairyGfx13, 0x200
+ax_sprite_terminator
+sClefairyGfx14:
+.incbin "baserom.gba", 0x68922C, 0x200
+sClefairySprites14:
+ax_sprite sClefairyGfx14, 0x200
+ax_sprite_terminator
+sClefairyGfx15:
+.incbin "baserom.gba", 0x68943C, 0x200
+sClefairySprites15:
+ax_sprite sClefairyGfx15, 0x200
+ax_sprite_terminator
+sClefairyGfx16:
+.incbin "baserom.gba", 0x68964C, 0x200
+sClefairySprites16:
+ax_sprite sClefairyGfx16, 0x200
+ax_sprite_terminator
+sClefairyGfx17:
+.incbin "baserom.gba", 0x68985C, 0x200
+sClefairySprites17:
+ax_sprite sClefairyGfx17, 0x200
+ax_sprite_terminator
+sClefairyGfx18:
+.incbin "baserom.gba", 0x689A6C, 0x200
+sClefairySprites18:
+ax_sprite sClefairyGfx18, 0x200
+ax_sprite_terminator
+sClefairyGfx19:
+.incbin "baserom.gba", 0x689C7C, 0x200
+sClefairySprites19:
+ax_sprite sClefairyGfx19, 0x200
+ax_sprite_terminator
+sClefairyGfx20:
+.incbin "baserom.gba", 0x689E8C, 0x200
+sClefairySprites20:
+ax_sprite sClefairyGfx20, 0x200
+ax_sprite_terminator
+sClefairyGfx21:
+.incbin "baserom.gba", 0x68A09C, 0x200
+sClefairySprites21:
+ax_sprite sClefairyGfx21, 0x200
+ax_sprite_terminator
+sClefairyGfx22:
+.incbin "baserom.gba", 0x68A2AC, 0x200
+sClefairySprites22:
+ax_sprite sClefairyGfx22, 0x200
+ax_sprite_terminator
+sClefairyGfx23:
+.incbin "baserom.gba", 0x68A4BC, 0x200
+sClefairySprites23:
+ax_sprite sClefairyGfx23, 0x200
+ax_sprite_terminator
+sClefairyGfx24:
+.incbin "baserom.gba", 0x68A6CC, 0x200
+sClefairySprites24:
+ax_sprite sClefairyGfx24, 0x200
+ax_sprite_terminator
+sClefairyGfx25:
+.incbin "baserom.gba", 0x68A8DC, 0x60
+sClefairyGfx25_1:
+.incbin "baserom.gba", 0x68A93C, 0x60
+sClefairyGfx25_2:
+.incbin "baserom.gba", 0x68A99C, 0x60
+sClefairySprites25:
+ax_sprite sClefairyGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx26:
+.incbin "baserom.gba", 0x68AA34, 0x60
+sClefairyGfx26_1:
+.incbin "baserom.gba", 0x68AA94, 0x60
+sClefairyGfx26_2:
+.incbin "baserom.gba", 0x68AAF4, 0x60
+sClefairyGfx26_3:
+.incbin "baserom.gba", 0x68AB54, 0x20
+sClefairySprites26:
+ax_sprite sClefairyGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sClefairyGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClefairyGfx27:
+.incbin "baserom.gba", 0x68ABBC, 0x60
+sClefairyGfx27_1:
+.incbin "baserom.gba", 0x68AC1C, 0x60
+sClefairyGfx27_2:
+.incbin "baserom.gba", 0x68AC7C, 0x60
+sClefairyGfx27_3:
+.incbin "baserom.gba", 0x68ACDC, 0x20
+sClefairySprites27:
+ax_sprite sClefairyGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sClefairyGfx27_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClefairyGfx28:
+.incbin "baserom.gba", 0x68AD44, 0x60
+sClefairyGfx28_1:
+.incbin "baserom.gba", 0x68ADA4, 0x60
+sClefairyGfx28_2:
+.incbin "baserom.gba", 0x68AE04, 0x60
+sClefairyGfx28_3:
+.incbin "baserom.gba", 0x68AE64, 0x40
+sClefairySprites28:
+ax_sprite sClefairyGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sClefairyGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sClefairyGfx29:
+.incbin "baserom.gba", 0x68AEEC, 0x60
+sClefairyGfx29_1:
+.incbin "baserom.gba", 0x68AF4C, 0x60
+sClefairyGfx29_2:
+.incbin "baserom.gba", 0x68AFAC, 0x60
+sClefairySprites29:
+ax_sprite sClefairyGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx30:
+.incbin "baserom.gba", 0x68B044, 0x60
+sClefairyGfx30_1:
+.incbin "baserom.gba", 0x68B0A4, 0x60
+sClefairyGfx30_2:
+.incbin "baserom.gba", 0x68B104, 0x60
+sClefairySprites30:
+ax_sprite sClefairyGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx31:
+.incbin "baserom.gba", 0x68B19C, 0x60
+sClefairyGfx31_1:
+.incbin "baserom.gba", 0x68B1FC, 0x60
+sClefairyGfx31_2:
+.incbin "baserom.gba", 0x68B25C, 0x60
+sClefairySprites31:
+ax_sprite sClefairyGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx32:
+.incbin "baserom.gba", 0x68B2F4, 0x60
+sClefairyGfx32_1:
+.incbin "baserom.gba", 0x68B354, 0x60
+sClefairyGfx32_2:
+.incbin "baserom.gba", 0x68B3B4, 0x60
+sClefairySprites32:
+ax_sprite sClefairyGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx33:
+.incbin "baserom.gba", 0x68B44C, 0x60
+sClefairyGfx33_1:
+.incbin "baserom.gba", 0x68B4AC, 0x60
+sClefairyGfx33_2:
+.incbin "baserom.gba", 0x68B50C, 0x60
+sClefairySprites33:
+ax_sprite sClefairyGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx34:
+.incbin "baserom.gba", 0x68B5A4, 0x60
+sClefairyGfx34_1:
+.incbin "baserom.gba", 0x68B604, 0x60
+sClefairyGfx34_2:
+.incbin "baserom.gba", 0x68B664, 0x60
+sClefairySprites34:
+ax_sprite sClefairyGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx35:
+.incbin "baserom.gba", 0x68B6FC, 0x60
+sClefairyGfx35_1:
+.incbin "baserom.gba", 0x68B75C, 0x60
+sClefairyGfx35_2:
+.incbin "baserom.gba", 0x68B7BC, 0x60
+sClefairySprites35:
+ax_sprite sClefairyGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx36:
+.incbin "baserom.gba", 0x68B854, 0x60
+sClefairyGfx36_1:
+.incbin "baserom.gba", 0x68B8B4, 0x60
+sClefairyGfx36_2:
+.incbin "baserom.gba", 0x68B914, 0x60
+sClefairySprites36:
+ax_sprite sClefairyGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx37:
+.incbin "baserom.gba", 0x68B9AC, 0x60
+sClefairyGfx37_1:
+.incbin "baserom.gba", 0x68BA0C, 0x60
+sClefairyGfx37_2:
+.incbin "baserom.gba", 0x68BA6C, 0x60
+sClefairySprites37:
+ax_sprite sClefairyGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx38:
+.incbin "baserom.gba", 0x68BB04, 0x60
+sClefairyGfx38_1:
+.incbin "baserom.gba", 0x68BB64, 0x60
+sClefairyGfx38_2:
+.incbin "baserom.gba", 0x68BBC4, 0x60
+sClefairySprites38:
+ax_sprite sClefairyGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx39:
+.incbin "baserom.gba", 0x68BC5C, 0x60
+sClefairyGfx39_1:
+.incbin "baserom.gba", 0x68BCBC, 0x60
+sClefairyGfx39_2:
+.incbin "baserom.gba", 0x68BD1C, 0x60
+sClefairySprites39:
+ax_sprite sClefairyGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx39_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx40:
+.incbin "baserom.gba", 0x68BDB4, 0x60
+sClefairyGfx40_1:
+.incbin "baserom.gba", 0x68BE14, 0x60
+sClefairyGfx40_2:
+.incbin "baserom.gba", 0x68BE74, 0x60
+sClefairyGfx40_3:
+.incbin "baserom.gba", 0x68BED4, 0x20
+sClefairySprites40:
+ax_sprite sClefairyGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx40_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sClefairyGfx40_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sClefairyGfx41:
+.incbin "baserom.gba", 0x68BF3C, 0x60
+sClefairyGfx41_1:
+.incbin "baserom.gba", 0x68BF9C, 0x60
+sClefairyGfx41_2:
+.incbin "baserom.gba", 0x68BFFC, 0x60
+sClefairySprites41:
+ax_sprite sClefairyGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx41_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx42:
+.incbin "baserom.gba", 0x68C094, 0x60
+sClefairyGfx42_1:
+.incbin "baserom.gba", 0x68C0F4, 0x60
+sClefairyGfx42_2:
+.incbin "baserom.gba", 0x68C154, 0x60
+sClefairySprites42:
+ax_sprite sClefairyGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx42_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx43:
+.incbin "baserom.gba", 0x68C1EC, 0x60
+sClefairyGfx43_1:
+.incbin "baserom.gba", 0x68C24C, 0x60
+sClefairyGfx43_2:
+.incbin "baserom.gba", 0x68C2AC, 0x60
+sClefairySprites43:
+ax_sprite sClefairyGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx43_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx44:
+.incbin "baserom.gba", 0x68C344, 0x60
+sClefairyGfx44_1:
+.incbin "baserom.gba", 0x68C3A4, 0x60
+sClefairyGfx44_2:
+.incbin "baserom.gba", 0x68C404, 0x60
+sClefairySprites44:
+ax_sprite sClefairyGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sClefairyGfx44_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sClefairyGfx45:
+.incbin "baserom.gba", 0x68C49C, 0x200
+sClefairySprites45:
+ax_sprite sClefairyGfx45, 0x200
+ax_sprite_terminator
+sClefairyGfx46:
+.incbin "baserom.gba", 0x68C6AC, 0x200
+sClefairySprites46:
+ax_sprite sClefairyGfx46, 0x200
+ax_sprite_terminator
+sClefairyGfx47:
+.incbin "baserom.gba", 0x68C8BC, 0x200
+sClefairySprites47:
+ax_sprite sClefairyGfx47, 0x200
+ax_sprite_terminator
+sClefairyGfx48:
+.incbin "baserom.gba", 0x68CACC, 0x200
+sClefairySprites48:
+ax_sprite sClefairyGfx48, 0x200
+ax_sprite_terminator
+sClefairyGfx49:
+.incbin "baserom.gba", 0x68CCDC, 0x200
+sClefairySprites49:
+ax_sprite sClefairyGfx49, 0x200
+ax_sprite_terminator
+sClefairyGfx50:
+.incbin "baserom.gba", 0x68CEEC, 0x200
+sClefairySprites50:
+ax_sprite sClefairyGfx50, 0x200
+ax_sprite_terminator
+sClefairyGfx51:
+.incbin "baserom.gba", 0x68D0FC, 0x200
+sClefairySprites51:
+ax_sprite sClefairyGfx51, 0x200
+ax_sprite_terminator
+sAxPosesClefairy:
+.4byte sClefairyPose1
+.4byte sClefairyPose2
+.4byte sClefairyPose3
+.4byte sClefairyPose4
+.4byte sClefairyPose5
+.4byte sClefairyPose6
+.4byte sClefairyPose7
+.4byte sClefairyPose8
+.4byte sClefairyPose9
+.4byte sClefairyPose10
+.4byte sClefairyPose11
+.4byte sClefairyPose12
+.4byte sClefairyPose13
+.4byte sClefairyPose14
+.4byte sClefairyPose15
+.4byte sClefairyPose16
+.4byte sClefairyPose17
+.4byte sClefairyPose18
+.4byte sClefairyPose19
+.4byte sClefairyPose20
+.4byte sClefairyPose21
+.4byte sClefairyPose22
+.4byte sClefairyPose23
+.4byte sClefairyPose24
+.4byte sClefairyPose25
+.4byte sClefairyPose26
+.4byte sClefairyPose27
+.4byte sClefairyPose28
+.4byte sClefairyPose29
+.4byte sClefairyPose30
+.4byte sClefairyPose31
+.4byte sClefairyPose32
+.4byte sClefairyPose33
+.4byte sClefairyPose34
+.4byte sClefairyPose35
+.4byte sClefairyPose36
+.4byte sClefairyPose37
+.4byte sClefairyPose38
+.4byte sClefairyPose39
+.4byte sClefairyPose40
+.4byte sClefairyPose41
+.4byte sClefairyPose42
+.4byte sClefairyPose43
+.4byte sClefairyPose44
+.4byte sClefairyPose45
+.4byte sClefairyPose46
+.4byte sClefairyPose47
+.4byte sClefairyPose48
+.4byte sClefairyPose49
+.4byte sClefairyPose50
+.4byte sClefairyPose51
+.4byte sClefairyPose52
+.4byte sClefairyPose53
+.4byte sClefairyPose54
+.4byte sClefairyPose55
+.4byte sClefairyPose56
+.4byte sClefairyPose57
+.4byte sClefairyPose58
+.4byte sClefairyPose59
+.4byte sClefairyPose60
+.4byte sClefairyPose61
+.4byte sClefairyPose62
+.4byte sClefairyPose63
+.4byte sClefairyPose64
+.4byte sClefairyPose65
+.4byte sClefairyPose66
+.4byte sClefairyPose67
+.4byte sClefairyPose68
+.4byte sClefairyPose69
+.4byte sClefairyPose70
+.4byte sClefairyPose71
+.4byte sClefairyPose72
+.4byte sClefairyPose73
+.4byte sClefairyPose74
+.4byte sClefairyPose75
+.4byte sClefairyPose76
+.4byte sClefairyPose77
+.4byte sClefairyPose78
+.4byte sClefairyPose79
+.4byte sClefairyPose80
+.4byte sClefairyPose81
+.4byte sClefairyPose82
+.4byte sClefairyPose83
+.4byte sClefairyPose84
+.4byte sClefairyPose85
+.4byte sClefairyPose86
+.4byte sClefairyPose87
+.4byte sClefairyPose88
+.4byte sClefairyPose89
+.4byte sClefairyPose90
+.4byte sClefairyPose91
+.4byte sClefairyPose92
+.4byte sClefairyPose93
+.4byte sClefairyPose94
+.4byte sClefairyPose95
+.4byte sClefairyPose96
+.4byte sClefairyPose97
+.4byte sClefairyPose98
+.4byte sClefairyPose99
+.4byte sClefairyPose100
+.4byte sClefairyPose101
+.4byte sClefairyPose102
+.4byte sClefairyPose103
+.4byte sClefairyPose104
+.4byte sClefairyPose105
+.4byte sClefairyPose106
+.4byte sClefairyPose107
+.4byte sClefairyPose108
+.4byte sClefairyPose109
+.4byte sClefairyPose110
+.4byte sClefairyPose111
+.4byte sClefairyPose112
+.4byte sClefairyPose113
+.4byte sClefairyPose114
+.4byte sClefairyPose115
+.4byte sClefairyPose116
+.4byte sClefairyPose117
+.4byte sClefairyPose118
+.4byte sClefairyPose119
+.4byte sClefairyPose120
+.4byte sClefairyPose121
+.4byte sClefairyPose122
+.4byte sClefairyPose123
+.4byte sClefairyPose124
+.4byte sClefairyPose125
+.4byte sClefairyPose126
+.4byte sClefairyPose127
+.4byte sClefairyPose128
+.4byte sClefairyPose129
+.4byte sClefairyPose130
+.4byte sClefairyPose131
+.4byte sClefairyPose132
+.4byte sClefairyPose133
+.4byte sClefairyPose134
+.4byte sClefairyPose135
+.4byte sClefairyPose136
+.4byte sClefairyPose137
+.4byte sClefairyPose138
+.4byte sClefairyPose139
+.4byte sClefairyPose140
+.4byte sClefairyPose141
+.4byte sClefairyPose142
+.4byte sClefairyPose143
+.4byte sClefairyPose144
+.4byte sClefairyPose145
+.4byte sClefairyPose146
+.4byte sClefairyPose147
+.4byte sClefairyPose148
+.4byte sClefairyPose149
+.4byte sClefairyPose150
+.4byte sClefairyPose151
+.4byte sClefairyPose152
+.4byte sClefairyPose153
+.4byte sClefairyPose154
+.4byte sClefairyPose155
+.4byte sClefairyPose156
+.4byte sClefairyPose157
+.4byte sClefairyPose158
+.4byte sClefairyPose159
+.4byte sClefairyPose160
+.4byte sClefairyPose161
+.4byte sClefairyPose162
+.4byte sClefairyPose163
+.4byte sClefairyPose164
+.4byte sClefairyPose165
+.4byte sClefairyPose166
+.4byte sClefairyPose167
+.4byte sClefairyPose168
+.4byte sClefairyPose169
+.4byte sClefairyPose170
+.4byte sClefairyPose171
+.4byte sClefairyPose172
+.4byte sClefairyPose173
+.4byte sClefairyPose174
+.4byte sClefairyPose175
+.4byte sClefairyPose176
+.4byte sClefairyPose177
+.4byte sClefairyPose178
+.4byte sClefairyPose179
+.4byte sClefairyPose180
+.4byte sClefairyPose181
+.4byte sClefairyPose182
+.4byte sClefairyPose183
+.4byte sClefairyPose184
+.4byte sClefairyPose185
+.4byte sClefairyPose186
+.4byte sClefairyPose187
+.4byte sClefairyPose188
+.4byte sClefairyPose189
+.4byte sClefairyPose190
+.4byte sClefairyPose191
+.4byte sClefairyPose192
+.4byte sClefairyPose193
+.4byte sClefairyPose194
+.4byte sClefairyPose195
+.4byte sClefairyPose196
+.4byte sClefairyPose197
+.4byte sClefairyPose198
+.4byte sClefairyPose199
+.4byte sClefairyPose200
+.4byte sClefairyPose201
+.4byte sClefairyPose202
+.4byte sClefairyPose203
+.4byte sClefairyPose204
+.4byte sClefairyPose205
+.4byte sClefairyPose206
+.4byte sClefairyPose207
+.4byte sClefairyPose208
+.4byte sClefairyPose209
+.4byte sClefairyPose210
+.4byte sClefairyPose211
+.4byte sClefairyPose212
+.4byte sClefairyPose213
+.4byte sClefairyPose214
+.4byte sClefairyPose215
+.4byte sClefairyPose216
+.4byte sClefairyPose217
+.4byte sClefairyPose218
+.4byte sClefairyPose219
+.4byte sClefairyPose220
+.4byte sClefairyPose221
+.4byte sClefairyPose222
+.4byte sClefairyPose223
+.4byte sClefairyPose224
+.4byte sClefairyPose225
+.4byte sClefairyPose226
+sAxPositionsClefairy:
+.2byte    0,   -5, 	  -9,   -5, 	   8,   -5, 	   0,   -6
+.2byte    0,   -9, 	  -9,  -12, 	   7,   -6, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -6, 	   8,  -12, 	  -1,  -10
+.2byte    2,   -6, 	  -7,   -3, 	   7,   -8, 	   0,   -7
+.2byte    2,  -10, 	  -5,   -5, 	   8,  -14, 	   0,  -11
+.2byte    4,   -9, 	  -6,  -10, 	   9,   -8, 	   2,  -10
+.2byte    6,   -7, 	   0,   -2, 	   1,   -6, 	  -1,   -8
+.2byte    5,   -6, 	   0,   -3, 	   1,  -13, 	  -1,  -10
+.2byte    6,  -10, 	   0,   -8, 	   1,   -7, 	   0,  -10
+.2byte    1,   -8, 	   6,   -3, 	  -5,   -8, 	  -1,   -8
+.2byte    2,   -8, 	   5,   -4, 	  -6,  -10, 	   0,   -9
+.2byte   -2,  -12, 	   6,  -11, 	  -8,   -9, 	  -2,  -11
+.2byte   -1,   -9, 	   8,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -2,  -10, 	   8,  -10, 	  -8,   -4, 	  -1,   -9
+.2byte    1,  -10, 	   7,   -4, 	  -9,  -10, 	   0,   -9
+.2byte   -2,   -9, 	   6,   -7, 	  -7,   -3, 	   0,   -8
+.2byte   -3,  -10, 	   1,  -11, 	  -6,   -4, 	   0,  -10
+.2byte    0,  -12, 	   7,   -9, 	  -7,  -11, 	   1,  -11
+.2byte   -7,   -7, 	  -2,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -7, 	  -3,  -11, 	  -1,   -3, 	   0,  -10
+.2byte   -7,  -10, 	   0,  -11, 	  -1,   -8, 	   0,  -10
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -3, 	   0,   -6
+.2byte   -3,  -10, 	  -9,  -14, 	   4,   -5, 	   0,  -10
+.2byte   -5,   -9, 	 -10,   -8, 	   5,  -10, 	  -2,  -10
+.2byte    0,   -5, 	  -9,   -5, 	   8,   -5, 	   0,   -6
+.2byte    0,   -7, 	  -9,  -10, 	   7,   -4, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -4, 	   8,  -10, 	  -1,   -8
+.2byte    0,   -5, 	  -9,   -9, 	   8,   -9, 	  -1,   -8
+.2byte    2,   -6, 	  -7,   -3, 	   7,   -8, 	   0,   -7
+.2byte    2,   -7, 	  -5,   -2, 	   8,  -11, 	   0,   -8
+.2byte    4,   -6, 	  -6,   -7, 	   9,   -5, 	   2,   -7
+.2byte    2,   -6, 	   7,  -11, 	  -7,   -7, 	  -1,   -8
+.2byte    6,   -7, 	   0,   -2, 	   1,   -6, 	  -1,   -8
+.2byte    5,   -4, 	   0,   -1, 	   1,  -11, 	  -1,   -8
+.2byte    6,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte    6,   -7, 	   2,  -13, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	   6,   -3, 	  -5,   -8, 	  -1,   -8
+.2byte    2,   -6, 	   5,   -2, 	  -6,   -8, 	   0,   -7
+.2byte   -2,  -10, 	   6,   -9, 	  -8,   -7, 	  -2,   -9
+.2byte    1,   -8, 	  -6,  -12, 	   7,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   8,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -2,   -8, 	   8,   -8, 	  -8,   -2, 	  -1,   -7
+.2byte    1,   -8, 	   7,   -2, 	  -9,   -8, 	   0,   -7
+.2byte   -1,  -10, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -2,   -9, 	   6,   -7, 	  -7,   -3, 	   0,   -8
+.2byte   -3,   -8, 	   1,   -9, 	  -6,   -2, 	   0,   -8
+.2byte    0,  -10, 	   7,   -7, 	  -7,   -9, 	   1,   -9
+.2byte   -2,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -8
+.2byte   -7,   -7, 	  -2,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -5, 	  -3,   -9, 	  -1,   -1, 	   0,   -8
+.2byte   -7,   -8, 	   0,   -9, 	  -1,   -6, 	   0,   -8
+.2byte   -7,   -7, 	  -3,  -13, 	  -1,   -7, 	   0,   -8
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -3, 	   0,   -6
+.2byte   -3,   -7, 	  -9,  -11, 	   4,   -2, 	   0,   -7
+.2byte   -5,   -6, 	 -10,   -5, 	   5,   -7, 	  -2,   -7
+.2byte   -3,   -6, 	  -8,  -11, 	   6,   -7, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -5, 	   8,   -5, 	   0,   -6
+.2byte    0,   -7, 	  -9,  -10, 	   7,   -4, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -4, 	   8,  -10, 	  -1,   -8
+.2byte    0,   -5, 	  -9,   -9, 	   8,   -9, 	  -1,   -8
+.2byte    2,   -6, 	  -7,   -3, 	   7,   -8, 	   0,   -7
+.2byte    2,   -7, 	  -5,   -2, 	   8,  -11, 	   0,   -8
+.2byte    4,   -6, 	  -6,   -7, 	   9,   -5, 	   2,   -7
+.2byte    2,   -6, 	   7,  -11, 	  -7,   -7, 	  -1,   -8
+.2byte    6,   -7, 	   0,   -2, 	   1,   -6, 	  -1,   -8
+.2byte    5,   -4, 	   0,   -1, 	   1,  -11, 	  -1,   -8
+.2byte    6,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte    6,   -7, 	   2,  -13, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	   6,   -3, 	  -5,   -8, 	  -1,   -8
+.2byte    2,   -6, 	   5,   -2, 	  -6,   -8, 	   0,   -7
+.2byte   -2,  -10, 	   6,   -9, 	  -8,   -7, 	  -2,   -9
+.2byte    1,   -8, 	  -6,  -12, 	   7,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   8,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -2,   -8, 	   8,   -8, 	  -8,   -2, 	  -1,   -7
+.2byte    1,   -8, 	   7,   -2, 	  -9,   -8, 	   0,   -7
+.2byte   -1,  -10, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -2,   -9, 	   6,   -7, 	  -7,   -3, 	   0,   -8
+.2byte   -3,   -8, 	   1,   -9, 	  -6,   -2, 	   0,   -8
+.2byte    0,  -10, 	   7,   -7, 	  -7,   -9, 	   1,   -9
+.2byte   -2,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -8
+.2byte   -7,   -7, 	  -2,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -5, 	  -3,   -9, 	  -1,   -1, 	   0,   -8
+.2byte   -7,   -8, 	   0,   -9, 	  -1,   -6, 	   0,   -8
+.2byte   -7,   -7, 	  -3,  -13, 	  -1,   -7, 	   0,   -8
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -3, 	   0,   -6
+.2byte   -3,   -7, 	  -9,  -11, 	   4,   -2, 	   0,   -7
+.2byte   -5,   -6, 	 -10,   -5, 	   5,   -7, 	  -2,   -7
+.2byte   -3,   -6, 	  -8,  -11, 	   6,   -7, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -5, 	   8,   -5, 	   0,   -6
+.2byte   -1,   -2, 	  -6,   -3, 	   5,   -3, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -9, 	   8,   -9, 	  -1,   -8
+.2byte    2,   -6, 	  -7,   -3, 	   7,   -8, 	   0,   -7
+.2byte    3,   -4, 	   6,   -6, 	  -2,   -4, 	   0,   -6
+.2byte    2,   -6, 	   7,  -11, 	  -7,   -7, 	  -1,   -8
+.2byte    6,   -7, 	   1,   -8, 	   0,   -2, 	  -1,   -7
+.2byte    7,   -4, 	   6,   -7, 	   3,   -4, 	   0,   -7
+.2byte    6,   -7, 	   2,  -13, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -9, 	  -7,   -7, 	   6,   -3, 	  -1,   -8
+.2byte    3,   -8, 	  -2,   -9, 	   6,   -6, 	   0,   -7
+.2byte    1,   -8, 	  -6,  -12, 	   7,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   8,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -8, 	   3,   -8, 	  -5,   -8, 	  -1,   -7
+.2byte   -1,  -10, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -2,   -9, 	   6,   -7, 	  -7,   -3, 	   0,   -8
+.2byte   -4,   -8, 	   1,   -9, 	  -7,   -6, 	  -1,   -7
+.2byte   -2,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -8
+.2byte   -7,   -7, 	  -2,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -8,   -4, 	  -7,   -7, 	  -4,   -4, 	  -1,   -7
+.2byte   -7,   -7, 	  -3,  -13, 	  -1,   -7, 	   0,   -8
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -3, 	   0,   -6
+.2byte   -4,   -4, 	  -7,   -6, 	   1,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -8,  -11, 	   6,   -7, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -9, 	   8,   -9, 	  -1,   -8
+.2byte   -2,   -7, 	 -10,  -10, 	   4,  -13, 	  -2,   -9
+.2byte    1,   -7, 	  -5,  -13, 	   9,  -10, 	   1,   -9
+.2byte    2,   -6, 	   7,  -11, 	  -7,   -7, 	  -1,   -8
+.2byte    3,   -8, 	   9,   -9, 	  -3,  -12, 	   0,  -10
+.2byte    0,   -8, 	   4,  -15, 	  -8,   -6, 	  -3,   -9
+.2byte    6,   -7, 	   2,  -13, 	   0,   -7, 	  -1,   -8
+.2byte    6,  -10, 	   3,  -18, 	   1,  -15, 	  -1,  -10
+.2byte    6,   -4, 	   7,  -14, 	   2,   -5, 	  -1,   -8
+.2byte    1,   -8, 	  -6,  -12, 	   7,   -7, 	  -1,   -8
+.2byte   -1,  -10, 	 -10,  -12, 	   3,  -14, 	  -2,   -9
+.2byte    2,   -9, 	  -4,  -14, 	   8,   -6, 	  -1,   -8
+.2byte   -1,  -10, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte    1,  -11, 	   9,   -7, 	  -6,  -14, 	   0,   -9
+.2byte   -3,  -11, 	   4,  -13, 	 -10,   -8, 	  -3,   -9
+.2byte   -2,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -8
+.2byte    0,  -10, 	   9,  -12, 	  -4,  -14, 	   1,   -9
+.2byte   -3,   -9, 	   3,  -14, 	  -9,   -6, 	   0,   -8
+.2byte   -7,   -7, 	  -3,  -13, 	  -1,   -7, 	   0,   -8
+.2byte   -7,  -10, 	  -4,  -18, 	  -2,  -15, 	   0,  -10
+.2byte   -7,   -4, 	  -8,  -14, 	  -3,   -5, 	   0,   -8
+.2byte   -3,   -6, 	  -8,  -11, 	   6,   -7, 	   0,   -8
+.2byte   -4,   -8, 	 -10,   -9, 	   2,  -12, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,  -15, 	   7,   -6, 	   2,   -9
+.2byte   -3,   -3, 	  -8,   -6, 	   5,   -1, 	   0,   -7
+.2byte   -3,   -2, 	  -8,   -5, 	   5,    0, 	   0,   -6
+.2byte   -1,   -8, 	  -9,  -13, 	   8,  -13, 	   0,   -9
+.2byte    0,   -9, 	   4,  -14, 	 -10,   -8, 	  -4,   -9
+.2byte    2,  -11, 	  -4,  -14, 	  -6,  -10, 	  -3,   -9
+.2byte    1,  -10, 	 -10,   -9, 	   3,  -10, 	  -4,   -6
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -7, 	  -1,   -5
+.2byte   -2,  -10, 	   9,   -9, 	  -4,  -10, 	   3,   -6
+.2byte   -3,  -11, 	   3,  -14, 	   5,  -10, 	   2,   -9
+.2byte   -1,   -9, 	  -5,  -14, 	   9,   -8, 	   3,   -9
+.2byte    0,   -5, 	  -9,   -5, 	   8,   -5, 	   0,   -6
+.2byte    0,   -9, 	  -9,  -12, 	   7,   -6, 	   0,  -10
+.2byte    0,   -9, 	  -8,   -6, 	   8,  -12, 	  -1,  -10
+.2byte    2,   -6, 	  -7,   -3, 	   7,   -8, 	   0,   -7
+.2byte    2,  -10, 	  -5,   -5, 	   8,  -14, 	   0,  -11
+.2byte    4,   -9, 	  -6,  -10, 	   9,   -8, 	   2,  -10
+.2byte    6,   -7, 	   0,   -2, 	   1,   -6, 	  -1,   -8
+.2byte    5,   -6, 	   0,   -3, 	   1,  -13, 	  -1,  -10
+.2byte    6,  -10, 	   0,   -8, 	   1,   -7, 	   0,  -10
+.2byte    1,   -8, 	   6,   -3, 	  -5,   -8, 	  -1,   -8
+.2byte    2,   -8, 	   5,   -4, 	  -6,  -10, 	   0,   -9
+.2byte   -2,  -12, 	   6,  -11, 	  -8,   -9, 	  -2,  -11
+.2byte   -1,   -9, 	   8,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -2,  -10, 	   8,  -10, 	  -8,   -4, 	  -1,   -9
+.2byte    1,  -10, 	   7,   -4, 	  -9,  -10, 	   0,   -9
+.2byte   -2,   -9, 	   6,   -7, 	  -7,   -3, 	   0,   -8
+.2byte   -3,  -10, 	   1,  -11, 	  -6,   -4, 	   0,  -10
+.2byte    0,  -12, 	   7,   -9, 	  -7,  -11, 	   1,  -11
+.2byte   -7,   -7, 	  -2,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -7, 	  -3,  -11, 	  -1,   -3, 	   0,  -10
+.2byte   -7,  -10, 	   0,  -11, 	  -1,   -8, 	   0,  -10
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -3, 	   0,   -6
+.2byte   -3,  -10, 	  -9,  -14, 	   4,   -5, 	   0,  -10
+.2byte   -5,   -9, 	 -10,   -8, 	   5,  -10, 	  -2,  -10
+.2byte   -1,   -2, 	  -6,   -3, 	   5,   -3, 	  -1,   -6
+.2byte   -4,   -4, 	  -7,   -6, 	   1,   -4, 	  -1,   -6
+.2byte   -8,   -4, 	  -7,   -7, 	  -4,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	   1,   -9, 	  -7,   -6, 	  -1,   -7
+.2byte   -1,   -8, 	   3,   -8, 	  -5,   -8, 	  -1,   -7
+.2byte    3,   -8, 	  -2,   -9, 	   6,   -6, 	   0,   -7
+.2byte    7,   -4, 	   6,   -7, 	   3,   -4, 	   0,   -7
+.2byte    3,   -4, 	   6,   -6, 	  -2,   -4, 	   0,   -6
+.2byte    0,   -5, 	  -9,   -9, 	   8,   -9, 	  -1,   -8
+.2byte    2,   -6, 	   7,  -11, 	  -7,   -7, 	  -1,   -8
+.2byte    6,   -7, 	   2,  -13, 	   0,   -7, 	  -1,   -8
+.2byte    1,   -8, 	  -6,  -12, 	   7,   -7, 	  -1,   -8
+.2byte   -1,  -10, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -2,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -8
+.2byte   -7,   -7, 	  -3,  -13, 	  -1,   -7, 	   0,   -8
+.2byte   -3,   -6, 	  -8,  -11, 	   6,   -7, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -5, 	   8,   -5, 	   0,   -6
+.2byte    0,   -5, 	  -9,   -9, 	   8,   -9, 	  -1,   -8
+.2byte   -1,   -2, 	  -6,   -3, 	   5,   -3, 	  -1,   -6
+.2byte    2,   -6, 	  -7,   -3, 	   7,   -8, 	   0,   -7
+.2byte    2,   -6, 	   7,  -11, 	  -7,   -7, 	  -1,   -8
+.2byte    3,   -4, 	   6,   -6, 	  -2,   -4, 	   0,   -6
+.2byte    6,   -7, 	   1,   -8, 	   0,   -2, 	  -1,   -7
+.2byte    6,   -7, 	   2,  -13, 	   0,   -7, 	  -1,   -8
+.2byte    7,   -4, 	   6,   -7, 	   3,   -4, 	   0,   -7
+.2byte    1,   -9, 	  -7,   -7, 	   6,   -3, 	  -1,   -8
+.2byte    1,   -8, 	  -6,  -12, 	   7,   -7, 	  -1,   -8
+.2byte    3,   -8, 	  -2,   -9, 	   6,   -6, 	   0,   -7
+.2byte   -1,   -9, 	   8,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,  -10, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   3,   -8, 	  -5,   -8, 	  -1,   -7
+.2byte   -2,   -9, 	   6,   -7, 	  -7,   -3, 	   0,   -8
+.2byte   -2,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -8
+.2byte   -4,   -8, 	   1,   -9, 	  -7,   -6, 	  -1,   -7
+.2byte   -7,   -7, 	  -2,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -7,   -7, 	  -3,  -13, 	  -1,   -7, 	   0,   -8
+.2byte   -8,   -4, 	  -7,   -7, 	  -4,   -4, 	  -1,   -7
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -3, 	   0,   -6
+.2byte   -3,   -6, 	  -8,  -11, 	   6,   -7, 	   0,   -8
+.2byte   -4,   -4, 	  -7,   -6, 	   1,   -4, 	  -1,   -6
+.2byte   -1,   -2, 	  -6,   -3, 	   5,   -3, 	  -1,   -6
+.2byte   -4,   -4, 	  -7,   -6, 	   1,   -4, 	  -1,   -6
+.2byte   -8,   -4, 	  -7,   -7, 	  -4,   -4, 	  -1,   -7
+.2byte   -5,   -8, 	   0,   -9, 	  -8,   -6, 	  -2,   -7
+.2byte   -1,   -8, 	   3,   -8, 	  -5,   -8, 	  -1,   -7
+.2byte    3,   -8, 	  -2,   -9, 	   6,   -6, 	   0,   -7
+.2byte    7,   -4, 	   6,   -7, 	   3,   -4, 	   0,   -7
+.2byte    3,   -4, 	   6,   -6, 	  -2,   -4, 	   0,   -6
+.2byte    0,   -5, 	  -9,   -5, 	   8,   -5, 	   0,   -6
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -3, 	   0,   -6
+.2byte   -7,   -7, 	  -2,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -2,   -9, 	   6,   -7, 	  -7,   -3, 	   0,   -8
+.2byte   -1,   -9, 	   8,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   6,   -3, 	  -5,   -8, 	  -1,   -8
+.2byte    6,   -7, 	   0,   -2, 	   1,   -6, 	  -1,   -8
+.2byte    2,   -6, 	  -7,   -3, 	   7,   -8, 	   0,   -7
+sClefairyAnimTable1:
+.4byte sClefairyAnims_1_1
+.4byte sClefairyAnims_1_2
+.4byte sClefairyAnims_1_3
+.4byte sClefairyAnims_1_4
+.4byte sClefairyAnims_1_5
+.4byte sClefairyAnims_1_6
+.4byte sClefairyAnims_1_7
+.4byte sClefairyAnims_1_8
+sClefairyAnimTable2:
+.4byte sClefairyAnims_2_1
+.4byte sClefairyAnims_2_2
+.4byte sClefairyAnims_2_3
+.4byte sClefairyAnims_2_4
+.4byte sClefairyAnims_2_5
+.4byte sClefairyAnims_2_6
+.4byte sClefairyAnims_2_7
+.4byte sClefairyAnims_2_8
+sClefairyAnimTable3:
+.4byte sClefairyAnims_3_1
+.4byte sClefairyAnims_3_2
+.4byte sClefairyAnims_3_3
+.4byte sClefairyAnims_3_4
+.4byte sClefairyAnims_3_5
+.4byte sClefairyAnims_3_6
+.4byte sClefairyAnims_3_7
+.4byte sClefairyAnims_3_8
+sClefairyAnimTable4:
+.4byte sClefairyAnims_4_1
+.4byte sClefairyAnims_4_2
+.4byte sClefairyAnims_4_3
+.4byte sClefairyAnims_4_4
+.4byte sClefairyAnims_4_5
+.4byte sClefairyAnims_4_6
+.4byte sClefairyAnims_4_7
+.4byte sClefairyAnims_4_8
+sClefairyAnimTable5:
+.4byte sClefairyAnims_5_1
+.4byte sClefairyAnims_5_2
+.4byte sClefairyAnims_5_3
+.4byte sClefairyAnims_5_4
+.4byte sClefairyAnims_5_5
+.4byte sClefairyAnims_5_6
+.4byte sClefairyAnims_5_7
+.4byte sClefairyAnims_5_8
+sClefairyAnimTable6:
+.4byte sClefairyAnims_6_1
+.4byte sClefairyAnims_6_1
+.4byte sClefairyAnims_6_1
+.4byte sClefairyAnims_6_1
+.4byte sClefairyAnims_6_1
+.4byte sClefairyAnims_6_1
+.4byte sClefairyAnims_6_1
+.4byte sClefairyAnims_6_1
+sClefairyAnimTable7:
+.4byte sClefairyAnims_7_1
+.4byte sClefairyAnims_7_2
+.4byte sClefairyAnims_7_3
+.4byte sClefairyAnims_7_4
+.4byte sClefairyAnims_7_5
+.4byte sClefairyAnims_7_6
+.4byte sClefairyAnims_7_7
+.4byte sClefairyAnims_7_8
+sClefairyAnimTable8:
+.4byte sClefairyAnims_8_1
+.4byte sClefairyAnims_8_2
+.4byte sClefairyAnims_8_3
+.4byte sClefairyAnims_8_4
+.4byte sClefairyAnims_8_5
+.4byte sClefairyAnims_8_6
+.4byte sClefairyAnims_8_7
+.4byte sClefairyAnims_8_8
+sClefairyAnimTable9:
+.4byte sClefairyAnims_9_1
+.4byte sClefairyAnims_9_2
+.4byte sClefairyAnims_9_3
+.4byte sClefairyAnims_9_4
+.4byte sClefairyAnims_9_5
+.4byte sClefairyAnims_9_6
+.4byte sClefairyAnims_9_7
+.4byte sClefairyAnims_9_8
+sClefairyAnimTable10:
+.4byte sClefairyAnims_10_1
+.4byte sClefairyAnims_10_2
+.4byte sClefairyAnims_10_3
+.4byte sClefairyAnims_10_4
+.4byte sClefairyAnims_10_5
+.4byte sClefairyAnims_10_6
+.4byte sClefairyAnims_10_7
+.4byte sClefairyAnims_10_8
+sClefairyAnimTable11:
+.4byte sClefairyAnims_11_1
+.4byte sClefairyAnims_11_2
+.4byte sClefairyAnims_11_3
+.4byte sClefairyAnims_11_4
+.4byte sClefairyAnims_11_5
+.4byte sClefairyAnims_11_6
+.4byte sClefairyAnims_11_7
+.4byte sClefairyAnims_11_8
+sClefairyAnimTable12:
+.4byte sClefairyAnims_12_1
+.4byte sClefairyAnims_12_2
+.4byte sClefairyAnims_12_3
+.4byte sClefairyAnims_12_4
+.4byte sClefairyAnims_12_5
+.4byte sClefairyAnims_12_6
+.4byte sClefairyAnims_12_7
+.4byte sClefairyAnims_12_8
+sClefairyAnimTable13:
+.4byte sClefairyAnims_13_1
+.4byte sClefairyAnims_13_2
+.4byte sClefairyAnims_13_3
+.4byte sClefairyAnims_13_4
+.4byte sClefairyAnims_13_5
+.4byte sClefairyAnims_13_6
+.4byte sClefairyAnims_13_7
+.4byte sClefairyAnims_13_8
+sAxAnimationsClefairy:
+.4byte sClefairyAnimTable1
+.4byte sClefairyAnimTable2
+.4byte sClefairyAnimTable3
+.4byte sClefairyAnimTable4
+.4byte sClefairyAnimTable5
+.4byte sClefairyAnimTable6
+.4byte sClefairyAnimTable7
+.4byte sClefairyAnimTable8
+.4byte sClefairyAnimTable9
+.4byte sClefairyAnimTable10
+.4byte sClefairyAnimTable11
+.4byte sClefairyAnimTable12
+.4byte sClefairyAnimTable13
+sAxSpritesClefairy:
+.4byte sClefairySprites1
+.4byte sClefairySprites2
+.4byte sClefairySprites3
+.4byte sClefairySprites4
+.4byte sClefairySprites5
+.4byte sClefairySprites6
+.4byte sClefairySprites7
+.4byte sClefairySprites8
+.4byte sClefairySprites9
+.4byte sClefairySprites10
+.4byte sClefairySprites11
+.4byte sClefairySprites12
+.4byte sClefairySprites13
+.4byte sClefairySprites14
+.4byte sClefairySprites15
+.4byte sClefairySprites16
+.4byte sClefairySprites17
+.4byte sClefairySprites18
+.4byte sClefairySprites19
+.4byte sClefairySprites20
+.4byte sClefairySprites21
+.4byte sClefairySprites22
+.4byte sClefairySprites23
+.4byte sClefairySprites24
+.4byte sClefairySprites25
+.4byte sClefairySprites26
+.4byte sClefairySprites27
+.4byte sClefairySprites28
+.4byte sClefairySprites29
+.4byte sClefairySprites30
+.4byte sClefairySprites31
+.4byte sClefairySprites32
+.4byte sClefairySprites33
+.4byte sClefairySprites34
+.4byte sClefairySprites35
+.4byte sClefairySprites36
+.4byte sClefairySprites37
+.4byte sClefairySprites38
+.4byte sClefairySprites39
+.4byte sClefairySprites40
+.4byte sClefairySprites41
+.4byte sClefairySprites42
+.4byte sClefairySprites43
+.4byte sClefairySprites44
+.4byte sClefairySprites45
+.4byte sClefairySprites46
+.4byte sClefairySprites47
+.4byte sClefairySprites48
+.4byte sClefairySprites49
+.4byte sClefairySprites50
+.4byte sClefairySprites51
+sAxMainClefairy:
+ax_main sAxPosesClefairy, sAxAnimationsClefairy, 13, sAxSpritesClefairy, sAxPositionsClefairy

--- a/data/ax/cleffa.inc
+++ b/data/ax/cleffa.inc
@@ -1,0 +1,2448 @@
+.global gAxCleffa
+gAxCleffa:
+ax_siro sAxMainCleffa
+sCleffaPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose3:
+ax_pose 2, 0x01ed, 0x80f3, 0x1c00
+ax_pose_terminator
+sCleffaPose4:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose5:
+ax_pose 4, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose7:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose8:
+ax_pose 7, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose9:
+ax_pose 8, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose10:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose11:
+ax_pose 10, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose14:
+ax_pose 13, 0x01ee, 0x80f3, 0x1c00
+ax_pose_terminator
+sCleffaPose15:
+ax_pose 14, 0x01ee, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose19:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose20:
+ax_pose 7, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose21:
+ax_pose 8, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose22:
+ax_pose 3, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose23:
+ax_pose 4, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose26:
+ax_pose 15, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose27:
+ax_pose 16, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose28:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose29:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose30:
+ax_pose 18, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose31:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose32:
+ax_pose 19, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose33:
+ax_pose 20, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose34:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose35:
+ax_pose 21, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose36:
+ax_pose 22, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose37:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose38:
+ax_pose 23, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose39:
+ax_pose 24, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose40:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose41:
+ax_pose 21, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose42:
+ax_pose 22, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose43:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose44:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose45:
+ax_pose 20, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose46:
+ax_pose 3, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose47:
+ax_pose 17, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose48:
+ax_pose 18, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose49:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose50:
+ax_pose 15, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose51:
+ax_pose 16, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose52:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose53:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose54:
+ax_pose 18, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose55:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose56:
+ax_pose 19, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose57:
+ax_pose 20, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose58:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose59:
+ax_pose 21, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose60:
+ax_pose 22, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose61:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose62:
+ax_pose 23, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose63:
+ax_pose 24, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose64:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose65:
+ax_pose 21, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose66:
+ax_pose 22, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose67:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose68:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose69:
+ax_pose 20, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose70:
+ax_pose 3, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose71:
+ax_pose 17, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose72:
+ax_pose 18, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose73:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose74:
+ax_pose 15, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose75:
+ax_pose 16, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose76:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose77:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose78:
+ax_pose 18, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose79:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose80:
+ax_pose 19, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose81:
+ax_pose 20, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose82:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose83:
+ax_pose 21, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose84:
+ax_pose 22, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose85:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose86:
+ax_pose 23, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose87:
+ax_pose 24, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose88:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose89:
+ax_pose 21, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose90:
+ax_pose 22, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose91:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose92:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose93:
+ax_pose 20, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose94:
+ax_pose 3, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose95:
+ax_pose 17, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose96:
+ax_pose 18, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose97:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose98:
+ax_pose 1, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose99:
+ax_pose 2, 0x01ee, 0x80f3, 0x1c00
+ax_pose_terminator
+sCleffaPose100:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose101:
+ax_pose 4, 0x01ee, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose102:
+ax_pose 5, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sCleffaPose103:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose104:
+ax_pose 7, 0x01ee, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose105:
+ax_pose 8, 0x01ee, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose106:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose107:
+ax_pose 10, 0x01ee, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose108:
+ax_pose 11, 0x01ee, 0x90ea, 0x1c00
+ax_pose_terminator
+sCleffaPose109:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose110:
+ax_pose 13, 0x01ef, 0x80f3, 0x1c00
+ax_pose_terminator
+sCleffaPose111:
+ax_pose 14, 0x01ef, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose112:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose113:
+ax_pose 10, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose114:
+ax_pose 11, 0x01ee, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose115:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose116:
+ax_pose 7, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose117:
+ax_pose 8, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose118:
+ax_pose 3, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose119:
+ax_pose 4, 0x01ee, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose120:
+ax_pose 5, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose121:
+ax_pose 25, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose122:
+ax_pose 26, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose123:
+ax_pose 27, 0x01e4, 0x80f1, 0x1c00
+ax_pose_terminator
+sCleffaPose124:
+ax_pose 28, 0x01e5, 0x90ed, 0x1c00
+ax_pose_terminator
+sCleffaPose125:
+ax_pose 29, 0x01e5, 0x90ed, 0x1c00
+ax_pose_terminator
+sCleffaPose126:
+ax_pose 30, 0x01e6, 0x90ee, 0x1c00
+ax_pose_terminator
+sCleffaPose127:
+ax_pose 31, 0x01e5, 0x80f2, 0x1c00
+ax_pose_terminator
+sCleffaPose128:
+ax_pose 30, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sCleffaPose129:
+ax_pose 29, 0x01e5, 0x80f3, 0x1c00
+ax_pose_terminator
+sCleffaPose130:
+ax_pose 28, 0x01e5, 0x80f3, 0x1c00
+ax_pose_terminator
+sCleffaPose131:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose132:
+ax_pose 15, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose133:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose134:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose135:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose136:
+ax_pose 19, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose137:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose138:
+ax_pose 21, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose139:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose140:
+ax_pose 23, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose141:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose142:
+ax_pose 21, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose143:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose144:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose145:
+ax_pose 3, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose146:
+ax_pose 17, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose147:
+ax_pose 15, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose148:
+ax_pose 17, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose149:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose150:
+ax_pose 21, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose151:
+ax_pose 23, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose152:
+ax_pose 21, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose153:
+ax_pose 19, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose154:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose155:
+ax_pose 15, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose156:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose157:
+ax_pose 19, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose158:
+ax_pose 21, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose159:
+ax_pose 23, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose160:
+ax_pose 21, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose161:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose162:
+ax_pose 17, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sCleffaPose163:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose164:
+ax_pose 15, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose165:
+ax_pose 16, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose166:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose167:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose168:
+ax_pose 18, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose169:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose170:
+ax_pose 19, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose171:
+ax_pose 20, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose172:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose173:
+ax_pose 21, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose174:
+ax_pose 22, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose175:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose176:
+ax_pose 23, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose177:
+ax_pose 24, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose178:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose179:
+ax_pose 21, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose180:
+ax_pose 22, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose181:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose182:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose183:
+ax_pose 20, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose184:
+ax_pose 3, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose185:
+ax_pose 17, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose186:
+ax_pose 18, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose187:
+ax_pose 16, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose188:
+ax_pose 18, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose189:
+ax_pose 20, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose190:
+ax_pose 22, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose191:
+ax_pose 24, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose192:
+ax_pose 22, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose193:
+ax_pose 20, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose194:
+ax_pose 18, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose195:
+ax_pose 0, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose196:
+ax_pose 3, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose197:
+ax_pose 6, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose198:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose199:
+ax_pose 12, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sCleffaPose200:
+ax_pose 9, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose201:
+ax_pose 6, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCleffaPose202:
+ax_pose 3, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+.align 2
+sCleffaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 1, 0,
+ax_anim 6, 0, 1, 0, -1, 1, 0,
+ax_anim 6, 0, 1, 0, 0, 1, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, -1, 0,
+ax_anim 6, 0, 2, 0, -1, -1, 0,
+ax_anim 6, 0, 2, 0, 0, -1, 0,
+ax_anim_terminator
+sCleffaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, -1, 1,
+ax_anim 6, 0, 4, 0, -1, -1, 1,
+ax_anim 6, 0, 4, 0, 0, -1, 1,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, 0, 1, -1,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 6, 0, 5, 1, 0, 1, -1,
+ax_anim_terminator
+sCleffaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 1,
+ax_anim 6, 0, 7, 0, -1, 0, 1,
+ax_anim 6, 0, 7, 0, 0, 0, 1,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, -1,
+ax_anim 6, 0, 8, 0, -1, 0, -1,
+ax_anim 6, 0, 8, 0, 0, 0, -1,
+ax_anim_terminator
+sCleffaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 1, 1,
+ax_anim 6, 0, 10, 0, -1, 1, 1,
+ax_anim 6, 0, 10, 0, 0, 1, 1,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, 0, -1, -1,
+ax_anim 6, 0, 11, 0, -1, -1, -1,
+ax_anim 6, 0, 11, 0, 0, -1, -1,
+ax_anim_terminator
+sCleffaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, -1, 0,
+ax_anim 6, 0, 13, 0, -1, -1, 0,
+ax_anim 6, 0, 13, 0, 0, -1, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 1, 0,
+ax_anim 6, 0, 14, 0, -1, 1, 0,
+ax_anim 6, 0, 14, 0, 0, 1, 0,
+ax_anim_terminator
+sCleffaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, -1, 1,
+ax_anim 6, 0, 16, 0, -1, -1, 1,
+ax_anim 6, 0, 16, 0, 0, -1, 1,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 1, -1,
+ax_anim 6, 0, 17, 0, -1, 1, -1,
+ax_anim 6, 0, 17, 0, 0, 1, -1,
+ax_anim_terminator
+sCleffaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 1,
+ax_anim 6, 0, 19, 0, -1, 0, 1,
+ax_anim 6, 0, 19, 0, 0, 0, 1,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, -1,
+ax_anim 6, 0, 20, 0, -1, 0, -1,
+ax_anim 6, 0, 20, 0, 0, 0, -1,
+ax_anim_terminator
+sCleffaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 1, 1,
+ax_anim 6, 0, 22, 0, -1, 1, 1,
+ax_anim 6, 0, 22, 0, 0, 1, 1,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 1, 0, -1, -1,
+ax_anim 6, 0, 23, 1, -1, -1, -1,
+ax_anim 6, 0, 23, 1, 0, -1, -1,
+ax_anim_terminator
+.align 2
+sCleffaAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 7, 0, 7,
+ax_anim_terminator
+sCleffaAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 20, 20, 20, 20,
+ax_anim 2, 1, 29, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 20, 20, 20, 20,
+ax_anim 2, 0, 29, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 7, 7, 7, 7,
+ax_anim_terminator
+sCleffaAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 22, 0, 22, 0,
+ax_anim 2, 1, 32, 22, 1, 22, 1,
+ax_anim 2, 0, 32, 22, 0, 22, 0,
+ax_anim 2, 0, 32, 22, 1, 22, 1,
+ax_anim 2, 0, 30, 7, 0, 7, 0,
+ax_anim_terminator
+sCleffaAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 12, -13, 12, -13,
+ax_anim 2, 0, 35, 21, -22, 21, -22,
+ax_anim 2, 1, 35, 22, -21, 22, -21,
+ax_anim 2, 0, 35, 21, -22, 21, -22,
+ax_anim 2, 0, 35, 22, -21, 22, -21,
+ax_anim 2, 0, 33, 7, -7, 7, -7,
+ax_anim_terminator
+sCleffaAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 1, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 0, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -7, 0, -7,
+ax_anim_terminator
+sCleffaAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 41, -12, -13, -12, -13,
+ax_anim 2, 0, 41, -21, -22, -21, -22,
+ax_anim 2, 1, 41, -22, -21, -22, -21,
+ax_anim 2, 0, 41, -21, -22, -21, -22,
+ax_anim 2, 0, 41, -22, -21, -22, -21,
+ax_anim 2, 0, 39, -7, -7, -7, -7,
+ax_anim_terminator
+sCleffaAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -22, 0, -22, 0,
+ax_anim 2, 1, 44, -22, 1, -22, 1,
+ax_anim 2, 0, 44, -22, 0, -22, 0,
+ax_anim 2, 0, 44, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -7, 0, -7, 0,
+ax_anim_terminator
+sCleffaAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 47, -20, 20, -20, 20,
+ax_anim 2, 1, 47, -21, 19, -21, 19,
+ax_anim 2, 0, 47, -20, 20, -20, 20,
+ax_anim 2, 0, 47, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -7, 7, -7, 7,
+ax_anim_terminator
+.align 2
+sCleffaAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 1, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 0, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 7, 0, 7,
+ax_anim_terminator
+sCleffaAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 20, 20, 20, 20,
+ax_anim 2, 1, 53, 21, 19, 21, 19,
+ax_anim 2, 0, 53, 20, 20, 20, 20,
+ax_anim 2, 0, 53, 21, 19, 21, 19,
+ax_anim 2, 0, 51, 7, 7, 7, 7,
+ax_anim_terminator
+sCleffaAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 6, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 22, 0, 22, 0,
+ax_anim 2, 1, 56, 22, 1, 22, 1,
+ax_anim 2, 0, 56, 22, 0, 22, 0,
+ax_anim 2, 0, 56, 22, 1, 22, 1,
+ax_anim 2, 0, 54, 7, 0, 7, 0,
+ax_anim_terminator
+sCleffaAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 5, -6, 5, -6,
+ax_anim 1, 0, 59, 12, -13, 12, -13,
+ax_anim 2, 0, 59, 21, -22, 21, -22,
+ax_anim 2, 1, 59, 22, -21, 22, -21,
+ax_anim 2, 0, 59, 21, -22, 21, -22,
+ax_anim 2, 0, 59, 22, -21, 22, -21,
+ax_anim 2, 0, 57, 7, -7, 7, -7,
+ax_anim_terminator
+sCleffaAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 62, 0, -21, 0, -21,
+ax_anim 2, 1, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 62, 0, -21, 0, -21,
+ax_anim 2, 0, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -7, 0, -7,
+ax_anim_terminator
+sCleffaAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -5, -6, -5, -6,
+ax_anim 1, 0, 65, -12, -13, -12, -13,
+ax_anim 2, 0, 65, -21, -22, -21, -22,
+ax_anim 2, 1, 65, -22, -21, -22, -21,
+ax_anim 2, 0, 65, -21, -22, -21, -22,
+ax_anim 2, 0, 65, -22, -21, -22, -21,
+ax_anim 2, 0, 63, -7, -7, -7, -7,
+ax_anim_terminator
+sCleffaAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 6, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 68, -22, 0, -22, 0,
+ax_anim 2, 1, 68, -22, 1, -22, 1,
+ax_anim 2, 0, 68, -22, 0, -22, 0,
+ax_anim 2, 0, 68, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -7, 0, -7, 0,
+ax_anim_terminator
+sCleffaAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -20, 20, -20, 20,
+ax_anim 2, 1, 71, -21, 19, -21, 19,
+ax_anim 2, 0, 71, -20, 20, -20, 20,
+ax_anim 2, 0, 71, -21, 19, -21, 19,
+ax_anim 2, 0, 69, -7, 7, -7, 7,
+ax_anim_terminator
+.align 2
+sCleffaAnims_4_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 2, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 1, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_4_2:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 2, 77, 0, 0, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 1, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_4_3:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 2, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 1, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_4_4:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 2, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 1, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_4_5:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 2, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_4_6:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 2, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 1, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_4_7:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 2, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 1, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_4_8:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 2, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_5_1:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 5, 2, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 5, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 1, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_5_2:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 5, 2, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 5, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 1, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_5_3:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 5, 2, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 5, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 1, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_5_4:
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 5, 2, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 5, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_5_5:
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 5, 2, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 5, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_5_6:
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 5, 2, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 5, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_5_7:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 5, 2, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 5, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_5_8:
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 5, 2, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 5, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sCleffaAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sCleffaAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sCleffaAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sCleffaAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sCleffaAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sCleffaAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sCleffaAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sCleffaAnims_8_1:
+ax_anim 36, 0, 130, 0, 0, 0, 0,
+ax_anim 18, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_8_2:
+ax_anim 36, 0, 132, 0, 0, 0, 0,
+ax_anim 18, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_8_3:
+ax_anim 36, 0, 134, 0, 0, 0, 0,
+ax_anim 18, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_8_4:
+ax_anim 36, 0, 136, 0, 0, 0, 0,
+ax_anim 18, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_8_5:
+ax_anim 36, 0, 138, 0, 0, 0, 0,
+ax_anim 18, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_8_6:
+ax_anim 36, 0, 140, 0, 0, 0, 0,
+ax_anim 18, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_8_7:
+ax_anim 36, 0, 142, 0, 0, 0, 0,
+ax_anim 18, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_8_8:
+ax_anim 36, 0, 144, 0, 0, 0, 0,
+ax_anim 18, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 7, 3, 7, 3,
+ax_anim 2, 0, 148, 10, 9, 10, 9,
+ax_anim 2, 0, 149, 8, 19, 8, 19,
+ax_anim 3, 0, 150, 0, 21, 0, 21,
+ax_anim 2, 3, 151, -8, 19, -8, 19,
+ax_anim 2, 0, 152, -10, 9, -10, 9,
+ax_anim 1, 0, 153, -7, 3, -7, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 9, 1, 9, 1,
+ax_anim 2, 0, 147, 17, 4, 17, 4,
+ax_anim 2, 0, 148, 22, 14, 22, 14,
+ax_anim 3, 0, 149, 21, 21, 21, 21,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 18, -5, 18, -5,
+ax_anim 3, 0, 148, 21, 0, 21, 0,
+ax_anim 2, 3, 149, 18, 4, 18, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 3, -16, 3, -16,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 21, -22, 21, -22,
+ax_anim 2, 3, 148, 22, -14, 22, -14,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -8, -19, -8, -19,
+ax_anim 3, 0, 146, 0, -22, 0, -22,
+ax_anim 2, 3, 147, 9, -19, 9, -19,
+ax_anim 2, 0, 148, 11, -10, 11, -10,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -3, -16, -3, -16,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -21, -22, -21, -22,
+ax_anim 2, 3, 152, -22, -14, -22, -14,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -18, -5, -18, -5,
+ax_anim 3, 0, 152, -21, 0, -21, 0,
+ax_anim 2, 3, 151, -18, 4, -18, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -9, 1, -9, 1,
+ax_anim 2, 0, 153, -17, 4, -17, 4,
+ax_anim 2, 0, 152, -22, 14, -22, 14,
+ax_anim 3, 0, 151, -21, 21, -21, 21,
+ax_anim 2, 3, 150, -11, 21, -11, 21,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -24, 0, 0,
+ax_anim 3, 0, 164, 0, -23, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -24, 0, 0,
+ax_anim 3, 0, 170, 0, -23, 0, 0,
+ax_anim 2, 0, 170, 0, -20, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -23, 0, 0,
+ax_anim 2, 0, 173, 0, -19, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -23, 0, 0,
+ax_anim 2, 0, 179, 0, -19, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -24, 0, 0,
+ax_anim 3, 0, 182, 0, -23, 0, 0,
+ax_anim 2, 0, 182, 0, -20, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCleffaAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sCleffaGfx1:
+.incbin "baserom.gba", 0xC8E31C, 0x200
+sCleffaSprites1:
+ax_sprite sCleffaGfx1, 0x200
+ax_sprite_terminator
+sCleffaGfx2:
+.incbin "baserom.gba", 0xC8E52C, 0x200
+sCleffaSprites2:
+ax_sprite sCleffaGfx2, 0x200
+ax_sprite_terminator
+sCleffaGfx3:
+.incbin "baserom.gba", 0xC8E73C, 0x200
+sCleffaSprites3:
+ax_sprite sCleffaGfx3, 0x200
+ax_sprite_terminator
+sCleffaGfx4:
+.incbin "baserom.gba", 0xC8E94C, 0x200
+sCleffaSprites4:
+ax_sprite sCleffaGfx4, 0x200
+ax_sprite_terminator
+sCleffaGfx5:
+.incbin "baserom.gba", 0xC8EB5C, 0x200
+sCleffaSprites5:
+ax_sprite sCleffaGfx5, 0x200
+ax_sprite_terminator
+sCleffaGfx6:
+.incbin "baserom.gba", 0xC8ED6C, 0x200
+sCleffaSprites6:
+ax_sprite sCleffaGfx6, 0x200
+ax_sprite_terminator
+sCleffaGfx7:
+.incbin "baserom.gba", 0xC8EF7C, 0x200
+sCleffaSprites7:
+ax_sprite sCleffaGfx7, 0x200
+ax_sprite_terminator
+sCleffaGfx8:
+.incbin "baserom.gba", 0xC8F18C, 0x200
+sCleffaSprites8:
+ax_sprite sCleffaGfx8, 0x200
+ax_sprite_terminator
+sCleffaGfx9:
+.incbin "baserom.gba", 0xC8F39C, 0x200
+sCleffaSprites9:
+ax_sprite sCleffaGfx9, 0x200
+ax_sprite_terminator
+sCleffaGfx10:
+.incbin "baserom.gba", 0xC8F5AC, 0x200
+sCleffaSprites10:
+ax_sprite sCleffaGfx10, 0x200
+ax_sprite_terminator
+sCleffaGfx11:
+.incbin "baserom.gba", 0xC8F7BC, 0x200
+sCleffaSprites11:
+ax_sprite sCleffaGfx11, 0x200
+ax_sprite_terminator
+sCleffaGfx12:
+.incbin "baserom.gba", 0xC8F9CC, 0x200
+sCleffaSprites12:
+ax_sprite sCleffaGfx12, 0x200
+ax_sprite_terminator
+sCleffaGfx13:
+.incbin "baserom.gba", 0xC8FBDC, 0x200
+sCleffaSprites13:
+ax_sprite sCleffaGfx13, 0x200
+ax_sprite_terminator
+sCleffaGfx14:
+.incbin "baserom.gba", 0xC8FDEC, 0x200
+sCleffaSprites14:
+ax_sprite sCleffaGfx14, 0x200
+ax_sprite_terminator
+sCleffaGfx15:
+.incbin "baserom.gba", 0xC8FFFC, 0x200
+sCleffaSprites15:
+ax_sprite sCleffaGfx15, 0x200
+ax_sprite_terminator
+sCleffaGfx16:
+.incbin "baserom.gba", 0xC9020C, 0x60
+sCleffaGfx16_1:
+.incbin "baserom.gba", 0xC9026C, 0x60
+sCleffaGfx16_2:
+.incbin "baserom.gba", 0xC902CC, 0x60
+sCleffaSprites16:
+ax_sprite sCleffaGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx17:
+.incbin "baserom.gba", 0xC90364, 0x60
+sCleffaGfx17_1:
+.incbin "baserom.gba", 0xC903C4, 0x60
+sCleffaGfx17_2:
+.incbin "baserom.gba", 0xC90424, 0x60
+sCleffaSprites17:
+ax_sprite sCleffaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx18:
+.incbin "baserom.gba", 0xC904BC, 0x60
+sCleffaGfx18_1:
+.incbin "baserom.gba", 0xC9051C, 0x60
+sCleffaGfx18_2:
+.incbin "baserom.gba", 0xC9057C, 0x60
+sCleffaSprites18:
+ax_sprite sCleffaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx19:
+.incbin "baserom.gba", 0xC90614, 0x40
+sCleffaGfx19_1:
+.incbin "baserom.gba", 0xC90654, 0x60
+sCleffaGfx19_2:
+.incbin "baserom.gba", 0xC906B4, 0x60
+sCleffaSprites19:
+ax_sprite sCleffaGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCleffaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx20:
+.incbin "baserom.gba", 0xC9074C, 0x60
+sCleffaGfx20_1:
+.incbin "baserom.gba", 0xC907AC, 0x60
+sCleffaGfx20_2:
+.incbin "baserom.gba", 0xC9080C, 0x60
+sCleffaSprites20:
+ax_sprite sCleffaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx21:
+.incbin "baserom.gba", 0xC908A4, 0x40
+sCleffaGfx21_1:
+.incbin "baserom.gba", 0xC908E4, 0x60
+sCleffaGfx21_2:
+.incbin "baserom.gba", 0xC90944, 0x60
+sCleffaSprites21:
+ax_sprite sCleffaGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCleffaGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx22:
+.incbin "baserom.gba", 0xC909DC, 0x60
+sCleffaGfx22_1:
+.incbin "baserom.gba", 0xC90A3C, 0x60
+sCleffaGfx22_2:
+.incbin "baserom.gba", 0xC90A9C, 0x60
+sCleffaSprites22:
+ax_sprite sCleffaGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx23:
+.incbin "baserom.gba", 0xC90B34, 0x60
+sCleffaGfx23_1:
+.incbin "baserom.gba", 0xC90B94, 0x60
+sCleffaGfx23_2:
+.incbin "baserom.gba", 0xC90BF4, 0x60
+sCleffaSprites23:
+ax_sprite sCleffaGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx24:
+.incbin "baserom.gba", 0xC90C8C, 0x60
+sCleffaGfx24_1:
+.incbin "baserom.gba", 0xC90CEC, 0x60
+sCleffaGfx24_2:
+.incbin "baserom.gba", 0xC90D4C, 0x60
+sCleffaSprites24:
+ax_sprite sCleffaGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx25:
+.incbin "baserom.gba", 0xC90DE4, 0x60
+sCleffaGfx25_1:
+.incbin "baserom.gba", 0xC90E44, 0x60
+sCleffaGfx25_2:
+.incbin "baserom.gba", 0xC90EA4, 0x60
+sCleffaSprites25:
+ax_sprite sCleffaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCleffaGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCleffaGfx26:
+.incbin "baserom.gba", 0xC90F3C, 0x200
+sCleffaSprites26:
+ax_sprite sCleffaGfx26, 0x200
+ax_sprite_terminator
+sCleffaGfx27:
+.incbin "baserom.gba", 0xC9114C, 0x200
+sCleffaSprites27:
+ax_sprite sCleffaGfx27, 0x200
+ax_sprite_terminator
+sCleffaGfx28:
+.incbin "baserom.gba", 0xC9135C, 0x200
+sCleffaSprites28:
+ax_sprite sCleffaGfx28, 0x200
+ax_sprite_terminator
+sCleffaGfx29:
+.incbin "baserom.gba", 0xC9156C, 0x200
+sCleffaSprites29:
+ax_sprite sCleffaGfx29, 0x200
+ax_sprite_terminator
+sCleffaGfx30:
+.incbin "baserom.gba", 0xC9177C, 0x200
+sCleffaSprites30:
+ax_sprite sCleffaGfx30, 0x200
+ax_sprite_terminator
+sCleffaGfx31:
+.incbin "baserom.gba", 0xC9198C, 0x200
+sCleffaSprites31:
+ax_sprite sCleffaGfx31, 0x200
+ax_sprite_terminator
+sCleffaGfx32:
+.incbin "baserom.gba", 0xC91B9C, 0x200
+sCleffaSprites32:
+ax_sprite sCleffaGfx32, 0x200
+ax_sprite_terminator
+sAxPosesCleffa:
+.4byte sCleffaPose1
+.4byte sCleffaPose2
+.4byte sCleffaPose3
+.4byte sCleffaPose4
+.4byte sCleffaPose5
+.4byte sCleffaPose6
+.4byte sCleffaPose7
+.4byte sCleffaPose8
+.4byte sCleffaPose9
+.4byte sCleffaPose10
+.4byte sCleffaPose11
+.4byte sCleffaPose12
+.4byte sCleffaPose13
+.4byte sCleffaPose14
+.4byte sCleffaPose15
+.4byte sCleffaPose16
+.4byte sCleffaPose17
+.4byte sCleffaPose18
+.4byte sCleffaPose19
+.4byte sCleffaPose20
+.4byte sCleffaPose21
+.4byte sCleffaPose22
+.4byte sCleffaPose23
+.4byte sCleffaPose24
+.4byte sCleffaPose25
+.4byte sCleffaPose26
+.4byte sCleffaPose27
+.4byte sCleffaPose28
+.4byte sCleffaPose29
+.4byte sCleffaPose30
+.4byte sCleffaPose31
+.4byte sCleffaPose32
+.4byte sCleffaPose33
+.4byte sCleffaPose34
+.4byte sCleffaPose35
+.4byte sCleffaPose36
+.4byte sCleffaPose37
+.4byte sCleffaPose38
+.4byte sCleffaPose39
+.4byte sCleffaPose40
+.4byte sCleffaPose41
+.4byte sCleffaPose42
+.4byte sCleffaPose43
+.4byte sCleffaPose44
+.4byte sCleffaPose45
+.4byte sCleffaPose46
+.4byte sCleffaPose47
+.4byte sCleffaPose48
+.4byte sCleffaPose49
+.4byte sCleffaPose50
+.4byte sCleffaPose51
+.4byte sCleffaPose52
+.4byte sCleffaPose53
+.4byte sCleffaPose54
+.4byte sCleffaPose55
+.4byte sCleffaPose56
+.4byte sCleffaPose57
+.4byte sCleffaPose58
+.4byte sCleffaPose59
+.4byte sCleffaPose60
+.4byte sCleffaPose61
+.4byte sCleffaPose62
+.4byte sCleffaPose63
+.4byte sCleffaPose64
+.4byte sCleffaPose65
+.4byte sCleffaPose66
+.4byte sCleffaPose67
+.4byte sCleffaPose68
+.4byte sCleffaPose69
+.4byte sCleffaPose70
+.4byte sCleffaPose71
+.4byte sCleffaPose72
+.4byte sCleffaPose73
+.4byte sCleffaPose74
+.4byte sCleffaPose75
+.4byte sCleffaPose76
+.4byte sCleffaPose77
+.4byte sCleffaPose78
+.4byte sCleffaPose79
+.4byte sCleffaPose80
+.4byte sCleffaPose81
+.4byte sCleffaPose82
+.4byte sCleffaPose83
+.4byte sCleffaPose84
+.4byte sCleffaPose85
+.4byte sCleffaPose86
+.4byte sCleffaPose87
+.4byte sCleffaPose88
+.4byte sCleffaPose89
+.4byte sCleffaPose90
+.4byte sCleffaPose91
+.4byte sCleffaPose92
+.4byte sCleffaPose93
+.4byte sCleffaPose94
+.4byte sCleffaPose95
+.4byte sCleffaPose96
+.4byte sCleffaPose97
+.4byte sCleffaPose98
+.4byte sCleffaPose99
+.4byte sCleffaPose100
+.4byte sCleffaPose101
+.4byte sCleffaPose102
+.4byte sCleffaPose103
+.4byte sCleffaPose104
+.4byte sCleffaPose105
+.4byte sCleffaPose106
+.4byte sCleffaPose107
+.4byte sCleffaPose108
+.4byte sCleffaPose109
+.4byte sCleffaPose110
+.4byte sCleffaPose111
+.4byte sCleffaPose112
+.4byte sCleffaPose113
+.4byte sCleffaPose114
+.4byte sCleffaPose115
+.4byte sCleffaPose116
+.4byte sCleffaPose117
+.4byte sCleffaPose118
+.4byte sCleffaPose119
+.4byte sCleffaPose120
+.4byte sCleffaPose121
+.4byte sCleffaPose122
+.4byte sCleffaPose123
+.4byte sCleffaPose124
+.4byte sCleffaPose125
+.4byte sCleffaPose126
+.4byte sCleffaPose127
+.4byte sCleffaPose128
+.4byte sCleffaPose129
+.4byte sCleffaPose130
+.4byte sCleffaPose131
+.4byte sCleffaPose132
+.4byte sCleffaPose133
+.4byte sCleffaPose134
+.4byte sCleffaPose135
+.4byte sCleffaPose136
+.4byte sCleffaPose137
+.4byte sCleffaPose138
+.4byte sCleffaPose139
+.4byte sCleffaPose140
+.4byte sCleffaPose141
+.4byte sCleffaPose142
+.4byte sCleffaPose143
+.4byte sCleffaPose144
+.4byte sCleffaPose145
+.4byte sCleffaPose146
+.4byte sCleffaPose147
+.4byte sCleffaPose148
+.4byte sCleffaPose149
+.4byte sCleffaPose150
+.4byte sCleffaPose151
+.4byte sCleffaPose152
+.4byte sCleffaPose153
+.4byte sCleffaPose154
+.4byte sCleffaPose155
+.4byte sCleffaPose156
+.4byte sCleffaPose157
+.4byte sCleffaPose158
+.4byte sCleffaPose159
+.4byte sCleffaPose160
+.4byte sCleffaPose161
+.4byte sCleffaPose162
+.4byte sCleffaPose163
+.4byte sCleffaPose164
+.4byte sCleffaPose165
+.4byte sCleffaPose166
+.4byte sCleffaPose167
+.4byte sCleffaPose168
+.4byte sCleffaPose169
+.4byte sCleffaPose170
+.4byte sCleffaPose171
+.4byte sCleffaPose172
+.4byte sCleffaPose173
+.4byte sCleffaPose174
+.4byte sCleffaPose175
+.4byte sCleffaPose176
+.4byte sCleffaPose177
+.4byte sCleffaPose178
+.4byte sCleffaPose179
+.4byte sCleffaPose180
+.4byte sCleffaPose181
+.4byte sCleffaPose182
+.4byte sCleffaPose183
+.4byte sCleffaPose184
+.4byte sCleffaPose185
+.4byte sCleffaPose186
+.4byte sCleffaPose187
+.4byte sCleffaPose188
+.4byte sCleffaPose189
+.4byte sCleffaPose190
+.4byte sCleffaPose191
+.4byte sCleffaPose192
+.4byte sCleffaPose193
+.4byte sCleffaPose194
+.4byte sCleffaPose195
+.4byte sCleffaPose196
+.4byte sCleffaPose197
+.4byte sCleffaPose198
+.4byte sCleffaPose199
+.4byte sCleffaPose200
+.4byte sCleffaPose201
+.4byte sCleffaPose202
+sAxPositionsCleffa:
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte    0,   -4, 	  -4,   -6, 	   4,   -4, 	   1,   -7
+.2byte   -2,   -4, 	  -6,   -4, 	   2,   -6, 	  -3,   -7
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte    0,   -5, 	   4,   -7, 	  -4,   -4, 	  -2,   -7
+.2byte    0,   -4, 	   4,   -4, 	  -4,   -6, 	  -1,   -7
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    4,   -4, 	  -1,  -11, 	   2,   -2, 	  -2,   -8
+.2byte    4,   -6, 	   2,   -7, 	   1,   -6, 	  -1,   -8
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    1,   -9, 	  -4,  -11, 	   5,   -4, 	  -1,   -8
+.2byte   -2,   -9, 	  -6,   -7, 	   5,   -8, 	  -2,   -8
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte   -4,  -10, 	   2,   -9, 	  -6,   -5, 	  -3,   -8
+.2byte    2,  -10, 	   4,   -5, 	  -4,   -9, 	   1,   -8
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	   2,  -11, 	  -7,   -4, 	  -1,   -8
+.2byte    0,   -9, 	   4,   -7, 	  -7,   -8, 	   0,   -8
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -6,   -4, 	  -1,  -11, 	  -4,   -2, 	   0,   -8
+.2byte   -6,   -6, 	  -4,   -7, 	  -3,   -6, 	  -1,   -8
+.2byte   -2,   -3, 	  -6,   -4, 	   2,   -3, 	   0,   -5
+.2byte   -1,   -5, 	  -5,   -7, 	   3,   -4, 	   1,   -7
+.2byte   -2,   -4, 	  -6,   -4, 	   2,   -6, 	  -1,   -7
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -2, 	   3,   -2, 	  -1,   -4
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -4, 	   6,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte    1,   -3, 	   5,   -5, 	  -3,   -3, 	  -1,   -6
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   1,   -7, 	   0,   -5, 	  -1,   -7
+.2byte    4,   -2, 	   2,   -4, 	   1,   -1, 	  -2,   -5
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -8, 	   4,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	  -4,   -5, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -6
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -8, 	  -6,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	   2,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -3,   -7, 	  -2,   -5, 	  -1,   -7
+.2byte   -6,   -2, 	  -4,   -4, 	  -3,   -1, 	   0,   -5
+.2byte   -3,   -3, 	  -7,   -4, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -4, 	  -8,   -5, 	   2,   -4, 	  -1,   -7
+.2byte   -3,   -3, 	  -7,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -2, 	   3,   -2, 	  -1,   -4
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -4, 	   6,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte    1,   -3, 	   5,   -5, 	  -3,   -3, 	  -1,   -6
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   1,   -7, 	   0,   -5, 	  -1,   -7
+.2byte    4,   -2, 	   2,   -4, 	   1,   -1, 	  -2,   -5
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -8, 	   4,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	  -4,   -5, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -6
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -8, 	  -6,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	   2,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -3,   -7, 	  -2,   -5, 	  -1,   -7
+.2byte   -6,   -2, 	  -4,   -4, 	  -3,   -1, 	   0,   -5
+.2byte   -3,   -3, 	  -7,   -4, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -4, 	  -8,   -5, 	   2,   -4, 	  -1,   -7
+.2byte   -3,   -3, 	  -7,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -2, 	   3,   -2, 	  -1,   -4
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -4, 	   6,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte    1,   -3, 	   5,   -5, 	  -3,   -3, 	  -1,   -6
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   1,   -7, 	   0,   -5, 	  -1,   -7
+.2byte    4,   -2, 	   2,   -4, 	   1,   -1, 	  -2,   -5
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -8, 	   4,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	  -4,   -5, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -6
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -8, 	  -6,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	   2,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -3,   -7, 	  -2,   -5, 	  -1,   -7
+.2byte   -6,   -2, 	  -4,   -4, 	  -3,   -1, 	   0,   -5
+.2byte   -3,   -3, 	  -7,   -4, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -4, 	  -8,   -5, 	   2,   -4, 	  -1,   -7
+.2byte   -3,   -3, 	  -7,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte    0,   -3, 	  -4,   -5, 	   4,   -3, 	   1,   -6
+.2byte   -2,   -3, 	  -6,   -3, 	   2,   -5, 	  -3,   -6
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte    0,   -4, 	   4,   -6, 	  -4,   -3, 	  -2,   -6
+.2byte    1,   -4, 	   5,   -4, 	  -3,   -6, 	   0,   -7
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    4,   -3, 	  -1,  -10, 	   2,   -1, 	  -2,   -7
+.2byte    4,   -5, 	   2,   -6, 	   1,   -5, 	  -1,   -7
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    1,   -8, 	  -4,  -10, 	   5,   -3, 	  -1,   -7
+.2byte   -3,   -8, 	  -7,   -6, 	   4,   -7, 	  -3,   -7
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte   -4,   -9, 	   2,   -8, 	  -6,   -4, 	  -3,   -7
+.2byte    2,   -9, 	   4,   -4, 	  -4,   -8, 	   1,   -7
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -3,   -8, 	   2,  -10, 	  -7,   -3, 	  -1,   -7
+.2byte    1,   -8, 	   5,   -6, 	  -6,   -7, 	   1,   -7
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -6,   -3, 	  -1,  -10, 	  -4,   -1, 	   0,   -7
+.2byte   -6,   -5, 	  -4,   -6, 	  -3,   -5, 	  -1,   -7
+.2byte   -2,   -3, 	  -6,   -4, 	   2,   -3, 	   0,   -5
+.2byte   -1,   -4, 	  -5,   -6, 	   3,   -3, 	   1,   -6
+.2byte   -2,   -3, 	  -6,   -3, 	   2,   -5, 	  -1,   -6
+.2byte   -3,   -1, 	  -6,   -2, 	   3,   -1, 	   0,   -5
+.2byte   -2,   -1, 	  -5,   -1, 	   3,    0, 	  -1,   -5
+.2byte    0,   -5, 	  -4,   -6, 	   4,   -6, 	   0,   -7
+.2byte    1,   -5, 	   5,   -8, 	  -3,   -5, 	  -1,   -7
+.2byte    5,   -5, 	   2,   -9, 	   1,   -6, 	  -1,   -7
+.2byte    1,  -10, 	  -3,  -11, 	   3,  -10, 	  -1,   -7
+.2byte    0,   -8, 	   3,   -6, 	  -3,   -6, 	   0,   -6
+.2byte   -2,  -10, 	   2,  -11, 	  -4,  -10, 	   0,   -7
+.2byte   -6,   -5, 	  -3,   -9, 	  -2,   -6, 	   0,   -7
+.2byte   -2,   -5, 	  -6,   -8, 	   2,   -5, 	   0,   -7
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -4, 	   6,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   1,   -7, 	   0,   -5, 	  -1,   -7
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -8, 	   4,   -5, 	  -1,   -8
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -8, 	  -6,   -5, 	  -1,   -8
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -3,   -7, 	  -2,   -5, 	  -1,   -7
+.2byte   -3,   -3, 	  -7,   -4, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -4, 	  -8,   -5, 	   2,   -4, 	  -1,   -7
+.2byte   -1,   -5, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -2,   -4, 	  -7,   -5, 	   3,   -4, 	   0,   -7
+.2byte   -6,   -5, 	  -3,   -7, 	  -2,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -8, 	  -6,   -5, 	  -1,   -8
+.2byte   -1,  -11, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -8, 	   4,   -5, 	  -1,   -8
+.2byte    4,   -5, 	   1,   -7, 	   0,   -5, 	  -1,   -7
+.2byte    1,   -4, 	   6,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -1,   -5, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte    1,   -4, 	   6,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte    4,   -5, 	   1,   -7, 	   0,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -8, 	   4,   -5, 	  -1,   -8
+.2byte   -1,  -11, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -8, 	  -6,   -5, 	  -1,   -8
+.2byte   -6,   -5, 	  -3,   -7, 	  -2,   -5, 	  -1,   -7
+.2byte   -2,   -4, 	  -7,   -5, 	   3,   -4, 	   0,   -7
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -2, 	   3,   -2, 	  -1,   -4
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -4, 	   6,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte    1,   -3, 	   5,   -5, 	  -3,   -3, 	  -1,   -6
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   1,   -7, 	   0,   -5, 	  -1,   -7
+.2byte    4,   -2, 	   2,   -4, 	   1,   -1, 	  -2,   -5
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -8, 	   4,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	  -4,   -5, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	   6,   -6, 	  -8,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -6
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -8, 	  -6,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	   2,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -3,   -7, 	  -2,   -5, 	  -1,   -7
+.2byte   -6,   -2, 	  -4,   -4, 	  -3,   -1, 	   0,   -5
+.2byte   -3,   -3, 	  -7,   -4, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -4, 	  -8,   -5, 	   2,   -4, 	  -1,   -7
+.2byte   -3,   -3, 	  -7,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -2, 	   3,   -2, 	  -1,   -4
+.2byte   -3,   -3, 	  -7,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -2, 	  -4,   -4, 	  -3,   -1, 	   0,   -5
+.2byte   -1,   -7, 	   2,   -5, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -4,   -5, 	   4,   -3, 	  -1,   -6
+.2byte    4,   -2, 	   2,   -4, 	   1,   -1, 	  -2,   -5
+.2byte    1,   -3, 	   5,   -5, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -5
+.2byte   -3,   -3, 	  -7,   -4, 	   1,   -3, 	  -1,   -5
+.2byte   -6,   -3, 	  -5,   -7, 	  -3,   -3, 	  -1,   -6
+.2byte   -2,   -7, 	   3,   -7, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte    0,   -7, 	  -5,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    4,   -3, 	   3,   -7, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -3, 	   5,   -4, 	  -3,   -3, 	  -1,   -5
+sCleffaAnimTable1:
+.4byte sCleffaAnims_1_1
+.4byte sCleffaAnims_1_2
+.4byte sCleffaAnims_1_3
+.4byte sCleffaAnims_1_4
+.4byte sCleffaAnims_1_5
+.4byte sCleffaAnims_1_6
+.4byte sCleffaAnims_1_7
+.4byte sCleffaAnims_1_8
+sCleffaAnimTable2:
+.4byte sCleffaAnims_2_1
+.4byte sCleffaAnims_2_2
+.4byte sCleffaAnims_2_3
+.4byte sCleffaAnims_2_4
+.4byte sCleffaAnims_2_5
+.4byte sCleffaAnims_2_6
+.4byte sCleffaAnims_2_7
+.4byte sCleffaAnims_2_8
+sCleffaAnimTable3:
+.4byte sCleffaAnims_3_1
+.4byte sCleffaAnims_3_2
+.4byte sCleffaAnims_3_3
+.4byte sCleffaAnims_3_4
+.4byte sCleffaAnims_3_5
+.4byte sCleffaAnims_3_6
+.4byte sCleffaAnims_3_7
+.4byte sCleffaAnims_3_8
+sCleffaAnimTable4:
+.4byte sCleffaAnims_4_1
+.4byte sCleffaAnims_4_2
+.4byte sCleffaAnims_4_3
+.4byte sCleffaAnims_4_4
+.4byte sCleffaAnims_4_5
+.4byte sCleffaAnims_4_6
+.4byte sCleffaAnims_4_7
+.4byte sCleffaAnims_4_8
+sCleffaAnimTable5:
+.4byte sCleffaAnims_5_1
+.4byte sCleffaAnims_5_2
+.4byte sCleffaAnims_5_3
+.4byte sCleffaAnims_5_4
+.4byte sCleffaAnims_5_5
+.4byte sCleffaAnims_5_6
+.4byte sCleffaAnims_5_7
+.4byte sCleffaAnims_5_8
+sCleffaAnimTable6:
+.4byte sCleffaAnims_6_1
+.4byte sCleffaAnims_6_1
+.4byte sCleffaAnims_6_1
+.4byte sCleffaAnims_6_1
+.4byte sCleffaAnims_6_1
+.4byte sCleffaAnims_6_1
+.4byte sCleffaAnims_6_1
+.4byte sCleffaAnims_6_1
+sCleffaAnimTable7:
+.4byte sCleffaAnims_7_1
+.4byte sCleffaAnims_7_2
+.4byte sCleffaAnims_7_3
+.4byte sCleffaAnims_7_4
+.4byte sCleffaAnims_7_5
+.4byte sCleffaAnims_7_6
+.4byte sCleffaAnims_7_7
+.4byte sCleffaAnims_7_8
+sCleffaAnimTable8:
+.4byte sCleffaAnims_8_1
+.4byte sCleffaAnims_8_2
+.4byte sCleffaAnims_8_3
+.4byte sCleffaAnims_8_4
+.4byte sCleffaAnims_8_5
+.4byte sCleffaAnims_8_6
+.4byte sCleffaAnims_8_7
+.4byte sCleffaAnims_8_8
+sCleffaAnimTable9:
+.4byte sCleffaAnims_9_1
+.4byte sCleffaAnims_9_2
+.4byte sCleffaAnims_9_3
+.4byte sCleffaAnims_9_4
+.4byte sCleffaAnims_9_5
+.4byte sCleffaAnims_9_6
+.4byte sCleffaAnims_9_7
+.4byte sCleffaAnims_9_8
+sCleffaAnimTable10:
+.4byte sCleffaAnims_10_1
+.4byte sCleffaAnims_10_2
+.4byte sCleffaAnims_10_3
+.4byte sCleffaAnims_10_4
+.4byte sCleffaAnims_10_5
+.4byte sCleffaAnims_10_6
+.4byte sCleffaAnims_10_7
+.4byte sCleffaAnims_10_8
+sCleffaAnimTable11:
+.4byte sCleffaAnims_11_1
+.4byte sCleffaAnims_11_2
+.4byte sCleffaAnims_11_3
+.4byte sCleffaAnims_11_4
+.4byte sCleffaAnims_11_5
+.4byte sCleffaAnims_11_6
+.4byte sCleffaAnims_11_7
+.4byte sCleffaAnims_11_8
+sCleffaAnimTable12:
+.4byte sCleffaAnims_12_1
+.4byte sCleffaAnims_12_2
+.4byte sCleffaAnims_12_3
+.4byte sCleffaAnims_12_4
+.4byte sCleffaAnims_12_5
+.4byte sCleffaAnims_12_6
+.4byte sCleffaAnims_12_7
+.4byte sCleffaAnims_12_8
+sCleffaAnimTable13:
+.4byte sCleffaAnims_13_1
+.4byte sCleffaAnims_13_2
+.4byte sCleffaAnims_13_3
+.4byte sCleffaAnims_13_4
+.4byte sCleffaAnims_13_5
+.4byte sCleffaAnims_13_6
+.4byte sCleffaAnims_13_7
+.4byte sCleffaAnims_13_8
+sAxAnimationsCleffa:
+.4byte sCleffaAnimTable1
+.4byte sCleffaAnimTable2
+.4byte sCleffaAnimTable3
+.4byte sCleffaAnimTable4
+.4byte sCleffaAnimTable5
+.4byte sCleffaAnimTable6
+.4byte sCleffaAnimTable7
+.4byte sCleffaAnimTable8
+.4byte sCleffaAnimTable9
+.4byte sCleffaAnimTable10
+.4byte sCleffaAnimTable11
+.4byte sCleffaAnimTable12
+.4byte sCleffaAnimTable13
+sAxSpritesCleffa:
+.4byte sCleffaSprites1
+.4byte sCleffaSprites2
+.4byte sCleffaSprites3
+.4byte sCleffaSprites4
+.4byte sCleffaSprites5
+.4byte sCleffaSprites6
+.4byte sCleffaSprites7
+.4byte sCleffaSprites8
+.4byte sCleffaSprites9
+.4byte sCleffaSprites10
+.4byte sCleffaSprites11
+.4byte sCleffaSprites12
+.4byte sCleffaSprites13
+.4byte sCleffaSprites14
+.4byte sCleffaSprites15
+.4byte sCleffaSprites16
+.4byte sCleffaSprites17
+.4byte sCleffaSprites18
+.4byte sCleffaSprites19
+.4byte sCleffaSprites20
+.4byte sCleffaSprites21
+.4byte sCleffaSprites22
+.4byte sCleffaSprites23
+.4byte sCleffaSprites24
+.4byte sCleffaSprites25
+.4byte sCleffaSprites26
+.4byte sCleffaSprites27
+.4byte sCleffaSprites28
+.4byte sCleffaSprites29
+.4byte sCleffaSprites30
+.4byte sCleffaSprites31
+.4byte sCleffaSprites32
+sAxMainCleffa:
+ax_main sAxPosesCleffa, sAxAnimationsCleffa, 13, sAxSpritesCleffa, sAxPositionsCleffa

--- a/data/ax/cloyster.inc
+++ b/data/ax/cloyster.inc
@@ -1,0 +1,2674 @@
+.global gAxCloyster
+gAxCloyster:
+ax_siro sAxMainCloyster
+sCloysterPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCloysterPose4:
+ax_pose 3, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose5:
+ax_pose 4, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose7:
+ax_pose 6, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose8:
+ax_pose 7, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose9:
+ax_pose 8, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose10:
+ax_pose 9, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose11:
+ax_pose 10, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose12:
+ax_pose 11, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose15:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose16:
+ax_pose 9, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose17:
+ax_pose 10, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose18:
+ax_pose 11, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose19:
+ax_pose 6, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose21:
+ax_pose 8, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sCloysterPose22:
+ax_pose 3, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose24:
+ax_pose 5, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose27:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCloysterPose28:
+ax_pose 15, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose29:
+ax_pose 3, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose30:
+ax_pose 4, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose31:
+ax_pose 5, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose32:
+ax_pose 16, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sCloysterPose33:
+ax_pose 6, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose34:
+ax_pose 7, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose35:
+ax_pose 8, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose36:
+ax_pose 17, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose37:
+ax_pose 9, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose38:
+ax_pose 10, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose39:
+ax_pose 11, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose40:
+ax_pose 18, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose41:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose42:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose43:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose44:
+ax_pose 19, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose45:
+ax_pose 9, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose46:
+ax_pose 10, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose47:
+ax_pose 11, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose48:
+ax_pose 18, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose49:
+ax_pose 6, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose50:
+ax_pose 7, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose51:
+ax_pose 8, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sCloysterPose52:
+ax_pose 17, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose53:
+ax_pose 3, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose54:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose55:
+ax_pose 5, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose56:
+ax_pose 16, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sCloysterPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose58:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose59:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCloysterPose60:
+ax_pose 15, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose61:
+ax_pose 3, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose62:
+ax_pose 4, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose63:
+ax_pose 5, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose64:
+ax_pose 16, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sCloysterPose65:
+ax_pose 6, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose66:
+ax_pose 7, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose67:
+ax_pose 8, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose68:
+ax_pose 17, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose69:
+ax_pose 9, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose70:
+ax_pose 10, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose71:
+ax_pose 11, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose72:
+ax_pose 18, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose73:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose74:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose75:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose76:
+ax_pose 19, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose77:
+ax_pose 9, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose78:
+ax_pose 10, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose79:
+ax_pose 11, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose80:
+ax_pose 18, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose81:
+ax_pose 6, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose82:
+ax_pose 7, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose83:
+ax_pose 8, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sCloysterPose84:
+ax_pose 17, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose85:
+ax_pose 3, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose86:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose87:
+ax_pose 5, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose88:
+ax_pose 16, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sCloysterPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose90:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose91:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCloysterPose92:
+ax_pose 20, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose93:
+ax_pose 3, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose94:
+ax_pose 4, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose95:
+ax_pose 5, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose96:
+ax_pose 21, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose97:
+ax_pose 6, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose98:
+ax_pose 7, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose99:
+ax_pose 8, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose100:
+ax_pose 22, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose101:
+ax_pose 9, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose102:
+ax_pose 10, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose103:
+ax_pose 11, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose104:
+ax_pose 23, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose105:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose106:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose107:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose108:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose109:
+ax_pose 9, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose110:
+ax_pose 10, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose111:
+ax_pose 11, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose112:
+ax_pose 23, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose113:
+ax_pose 6, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose114:
+ax_pose 7, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose115:
+ax_pose 8, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sCloysterPose116:
+ax_pose 22, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose117:
+ax_pose 3, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose118:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose119:
+ax_pose 5, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose120:
+ax_pose 21, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose121:
+ax_pose 25, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose122:
+ax_pose 26, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sCloysterPose123:
+ax_pose 27, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose124:
+ax_pose 28, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose125:
+ax_pose 29, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose126:
+ax_pose 28, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose127:
+ax_pose 27, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose128:
+ax_pose 26, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sCloysterPose129:
+ax_pose 30, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose130:
+ax_pose 31, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose131:
+ax_pose 32, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose132:
+ax_pose 33, 0x01e1, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose133:
+ax_pose 34, 0x01e2, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose134:
+ax_pose 35, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose135:
+ax_pose 36, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose136:
+ax_pose 35, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose137:
+ax_pose 34, 0x01e2, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose138:
+ax_pose 33, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sCloysterPose139:
+ax_pose 0, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose140:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose141:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCloysterPose142:
+ax_pose 3, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose143:
+ax_pose 4, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose144:
+ax_pose 5, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose145:
+ax_pose 6, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose146:
+ax_pose 7, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose147:
+ax_pose 8, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose148:
+ax_pose 9, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose149:
+ax_pose 10, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose150:
+ax_pose 11, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose151:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose152:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose153:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose154:
+ax_pose 9, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose155:
+ax_pose 10, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose156:
+ax_pose 11, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose157:
+ax_pose 6, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose158:
+ax_pose 7, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose159:
+ax_pose 8, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sCloysterPose160:
+ax_pose 3, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose161:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose162:
+ax_pose 5, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose163:
+ax_pose 20, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose164:
+ax_pose 21, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose165:
+ax_pose 22, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose166:
+ax_pose 23, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose167:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose168:
+ax_pose 23, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose169:
+ax_pose 22, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose170:
+ax_pose 21, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose171:
+ax_pose 20, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose172:
+ax_pose 21, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose173:
+ax_pose 22, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose174:
+ax_pose 23, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose175:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose176:
+ax_pose 23, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose177:
+ax_pose 22, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose178:
+ax_pose 21, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose179:
+ax_pose 0, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose180:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose181:
+ax_pose 2, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sCloysterPose182:
+ax_pose 3, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose183:
+ax_pose 4, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose184:
+ax_pose 5, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+sCloysterPose185:
+ax_pose 6, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose186:
+ax_pose 7, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose187:
+ax_pose 8, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose188:
+ax_pose 9, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose189:
+ax_pose 10, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose190:
+ax_pose 11, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose191:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose192:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose193:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose194:
+ax_pose 9, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose195:
+ax_pose 10, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose196:
+ax_pose 11, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose197:
+ax_pose 6, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose198:
+ax_pose 7, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose199:
+ax_pose 8, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sCloysterPose200:
+ax_pose 3, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose201:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose202:
+ax_pose 5, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose203:
+ax_pose 20, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose204:
+ax_pose 21, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose205:
+ax_pose 22, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sCloysterPose206:
+ax_pose 23, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose207:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose208:
+ax_pose 23, 0x01e7, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose209:
+ax_pose 22, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sCloysterPose210:
+ax_pose 21, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sCloysterPose211:
+ax_pose 0, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose212:
+ax_pose 3, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sCloysterPose213:
+ax_pose 6, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose214:
+ax_pose 9, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sCloysterPose215:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCloysterPose216:
+ax_pose 9, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sCloysterPose217:
+ax_pose 6, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sCloysterPose218:
+ax_pose 3, 0x01e6, 0x90ec, 0x7c00
+ax_pose_terminator
+.align 2
+sCloysterAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 10, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 10, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 10, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 10, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 10, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 10, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 10, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 10, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCloysterAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 6, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 2, 27, 0, 1, 0, 1,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sCloysterAnims_2_2:
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 2, 0, 28, -3, -3, -3, -3,
+ax_anim 6, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 2, 31, 1, 1, 1, 1,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sCloysterAnims_2_3:
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 32, -3, 0, -3, 0,
+ax_anim 6, 0, 33, -4, 0, -4, 0,
+ax_anim 1, 2, 35, 1, 0, 1, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 1, 35, 17, 1, 17, 1,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 35, 17, 1, 17, 1,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 35, 17, 1, 17, 1,
+ax_anim 2, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sCloysterAnims_2_4:
+ax_anim 2, 0, 38, -2, 2, -2, 2,
+ax_anim 2, 0, 36, -3, 3, -3, 3,
+ax_anim 6, 0, 37, -4, 4, -4, 4,
+ax_anim 1, 2, 39, 1, -1, 1, -1,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 17, -17, 17, -17,
+ax_anim 2, 1, 39, 18, -16, 18, -16,
+ax_anim 2, 0, 39, 17, -17, 17, -17,
+ax_anim 2, 0, 39, 18, -16, 18, -16,
+ax_anim 2, 0, 39, 17, -17, 17, -17,
+ax_anim 2, 0, 39, 18, -16, 18, -16,
+ax_anim 2, 0, 36, 10, -10, 10, -10,
+ax_anim 2, 0, 36, 4, -4, 4, -4,
+ax_anim_terminator
+sCloysterAnims_2_5:
+ax_anim 2, 0, 42, 0, 2, 0, 2,
+ax_anim 2, 0, 40, 0, 3, 0, 3,
+ax_anim 6, 0, 41, 0, 4, 0, 4,
+ax_anim 1, 2, 43, 0, -1, 0, -1,
+ax_anim 1, 0, 43, 0, -10, 0, -10,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 1, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -10, 0, -10,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sCloysterAnims_2_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 2, 0, 44, 3, 3, 3, 3,
+ax_anim 6, 0, 45, 4, 4, 4, 4,
+ax_anim 1, 2, 47, -1, -1, -1, -1,
+ax_anim 1, 0, 47, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -16, -17, -16, -17,
+ax_anim 2, 1, 47, -17, -16, -17, -16,
+ax_anim 2, 0, 47, -16, -17, -16, -17,
+ax_anim 2, 0, 47, -17, -16, -17, -16,
+ax_anim 2, 0, 47, -16, -17, -16, -17,
+ax_anim 2, 0, 47, -17, -16, -17, -16,
+ax_anim 2, 0, 44, -10, -10, -10, -10,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim_terminator
+sCloysterAnims_2_7:
+ax_anim 2, 0, 50, 2, 0, 2, 0,
+ax_anim 2, 0, 48, 3, 0, 3, 0,
+ax_anim 6, 0, 49, 4, 0, 4, 0,
+ax_anim 1, 2, 51, -1, 0, -1, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 1, 51, -17, 1, -17, 1,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 51, -17, 1, -17, 1,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 51, -17, 1, -17, 1,
+ax_anim 2, 0, 48, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sCloysterAnims_2_8:
+ax_anim 2, 0, 54, 2, -2, 2, -2,
+ax_anim 2, 0, 52, 3, -3, 3, -3,
+ax_anim 6, 0, 53, 4, -4, 4, -4,
+ax_anim 1, 2, 55, -1, 1, -1, 1,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 1, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 0, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 0, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 52, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sCloysterAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 2, 0, 56, 0, -3, 0, -3,
+ax_anim 6, 0, 57, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, 1, 0, 1,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sCloysterAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 60, -3, -3, -3, -3,
+ax_anim 6, 0, 61, -4, -4, -4, -4,
+ax_anim 1, 2, 63, 1, 1, 1, 1,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 1, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 60, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sCloysterAnims_3_3:
+ax_anim 2, 0, 66, -2, 0, -2, 0,
+ax_anim 2, 0, 64, -3, 0, -3, 0,
+ax_anim 6, 0, 65, -4, 0, -4, 0,
+ax_anim 1, 2, 67, 1, 0, 1, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 1, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sCloysterAnims_3_4:
+ax_anim 2, 0, 70, -2, 2, -2, 2,
+ax_anim 2, 0, 68, -3, 3, -3, 3,
+ax_anim 6, 0, 69, -4, 4, -4, 4,
+ax_anim 1, 2, 71, 1, -1, 1, -1,
+ax_anim 1, 0, 71, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 17, -17, 17, -17,
+ax_anim 2, 1, 71, 18, -16, 18, -16,
+ax_anim 2, 0, 71, 17, -17, 17, -17,
+ax_anim 2, 0, 71, 18, -16, 18, -16,
+ax_anim 2, 0, 71, 17, -17, 17, -17,
+ax_anim 2, 0, 71, 18, -16, 18, -16,
+ax_anim 2, 0, 68, 10, -10, 10, -10,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sCloysterAnims_3_5:
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim 6, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 2, 75, 0, -1, 0, -1,
+ax_anim 1, 0, 75, 0, -10, 0, -10,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 1, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 72, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sCloysterAnims_3_6:
+ax_anim 2, 0, 78, 2, 2, 2, 2,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 6, 0, 77, 4, 4, 4, 4,
+ax_anim 1, 2, 79, -1, -1, -1, -1,
+ax_anim 1, 0, 79, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -16, -17, -16, -17,
+ax_anim 2, 1, 79, -17, -16, -17, -16,
+ax_anim 2, 0, 79, -16, -17, -16, -17,
+ax_anim 2, 0, 79, -17, -16, -17, -16,
+ax_anim 2, 0, 79, -16, -17, -16, -17,
+ax_anim 2, 0, 79, -17, -16, -17, -16,
+ax_anim 2, 0, 76, -10, -10, -10, -10,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim_terminator
+sCloysterAnims_3_7:
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 6, 0, 81, 4, 0, 4, 0,
+ax_anim 1, 2, 83, -1, 0, -1, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 1, 83, -17, 1, -17, 1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, 1, -17, 1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, 1, -17, 1,
+ax_anim 2, 0, 80, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sCloysterAnims_3_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 2, 0, 84, 3, -3, 3, -3,
+ax_anim 6, 0, 85, 4, -4, 4, -4,
+ax_anim 1, 2, 87, -1, 1, -1, 1,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 19, -18, 19,
+ax_anim 2, 1, 87, -19, 18, -19, 18,
+ax_anim 2, 0, 87, -18, 19, -18, 19,
+ax_anim 2, 0, 87, -19, 18, -19, 18,
+ax_anim 2, 0, 87, -18, 19, -18, 19,
+ax_anim 2, 0, 87, -19, 18, -19, 18,
+ax_anim 2, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sCloysterAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, -4, 0, -4,
+ax_anim 4, 2, 90, 0, -5, 0, -5,
+ax_anim 1, 0, 91, 0, -5, 0, -5,
+ax_anim 1, 0, 91, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 1, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sCloysterAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 2, 0, 94, -4, -4, -4, -4,
+ax_anim 4, 2, 94, -5, -5, -5, -5,
+ax_anim 1, 0, 95, -5, -5, -5, -5,
+ax_anim 1, 0, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 1, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sCloysterAnims_4_3:
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim 2, 0, 98, -4, 0, -4, 0,
+ax_anim 4, 2, 98, -5, 0, -5, 0,
+ax_anim 1, 0, 99, -5, 0, -5, 0,
+ax_anim 1, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 1, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sCloysterAnims_4_4:
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -4, 4, -4, 4,
+ax_anim 4, 2, 102, -5, 5, -5, 5,
+ax_anim 1, 0, 103, -5, 5, -5, 5,
+ax_anim 1, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 1, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim_terminator
+sCloysterAnims_4_5:
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim 2, 0, 106, 0, 4, 0, 4,
+ax_anim 4, 2, 106, 0, 5, 0, 5,
+ax_anim 1, 0, 107, 0, 5, 0, 5,
+ax_anim 1, 0, 107, 0, 2, 0, 2,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 1, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim_terminator
+sCloysterAnims_4_6:
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim 2, 0, 110, 4, 4, 4, 4,
+ax_anim 4, 2, 110, 5, 5, 5, 5,
+ax_anim 1, 0, 111, 5, 5, 5, 5,
+ax_anim 1, 0, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 1, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim_terminator
+sCloysterAnims_4_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 114, 4, 0, 4, 0,
+ax_anim 4, 2, 114, 5, 0, 5, 0,
+ax_anim 1, 0, 115, 5, 0, 5, 0,
+ax_anim 1, 0, 115, 2, 0, 2, 0,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 1, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim_terminator
+sCloysterAnims_4_8:
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim 2, 0, 118, 4, -4, 4, -4,
+ax_anim 4, 2, 118, 5, -5, 5, -5,
+ax_anim 1, 0, 119, 5, -5, 5, -5,
+ax_anim 1, 0, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 1, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCloysterAnims_5_1:
+ax_anim 20, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim_terminator
+sCloysterAnims_5_2:
+ax_anim 20, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim_terminator
+sCloysterAnims_5_3:
+ax_anim 20, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 1, 0, 1,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 1, 0, 1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 1, 0, 1,
+ax_anim_terminator
+sCloysterAnims_5_4:
+ax_anim 20, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim_terminator
+sCloysterAnims_5_5:
+ax_anim 20, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim_terminator
+sCloysterAnims_5_6:
+ax_anim 20, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+sCloysterAnims_5_7:
+ax_anim 20, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 1,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 1,
+ax_anim_terminator
+sCloysterAnims_5_8:
+ax_anim 20, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sCloysterAnims_6_1:
+ax_anim 22, 0, 128, 0, 0, 0, 0,
+ax_anim 15, 0, 128, 0, -1, 0, 0,
+ax_anim 10, 0, 128, 0, -2, 0, 0,
+ax_anim 22, 0, 129, 0, -3, 0, 0,
+ax_anim 15, 0, 129, 0, -2, 0, 0,
+ax_anim 10, 0, 129, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sCloysterAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sCloysterAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sCloysterAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sCloysterAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sCloysterAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sCloysterAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sCloysterAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sCloysterAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCloysterAnims_8_1:
+ax_anim 12, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 139, 0, -1, 0, 0,
+ax_anim 12, 0, 138, 0, -2, 0, 0,
+ax_anim 14, 0, 140, 0, -2, 0, 0,
+ax_anim 12, 0, 140, 0, -1, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_8_2:
+ax_anim 12, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, -1, 0, 0,
+ax_anim 12, 0, 141, 0, -2, 0, 0,
+ax_anim 14, 0, 143, 0, -2, 0, 0,
+ax_anim 12, 0, 143, 0, -1, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_8_3:
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, -1, 0, 0,
+ax_anim 12, 0, 144, 0, -2, 0, 0,
+ax_anim 14, 0, 146, 0, -2, 0, 0,
+ax_anim 12, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_8_4:
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, -1, 0, 0,
+ax_anim 12, 0, 147, 0, -2, 0, 0,
+ax_anim 14, 0, 149, 0, -2, 0, 0,
+ax_anim 12, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_8_5:
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, -1, 0, 0,
+ax_anim 12, 0, 150, 0, -2, 0, 0,
+ax_anim 14, 0, 152, 0, -2, 0, 0,
+ax_anim 12, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_8_6:
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, -1, 0, 0,
+ax_anim 12, 0, 153, 0, -2, 0, 0,
+ax_anim 14, 0, 155, 0, -2, 0, 0,
+ax_anim 12, 0, 155, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_8_7:
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, -1, 0, 0,
+ax_anim 12, 0, 156, 0, -2, 0, 0,
+ax_anim 14, 0, 158, 0, -2, 0, 0,
+ax_anim 12, 0, 158, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_8_8:
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, -1, 0, 0,
+ax_anim 12, 0, 159, 0, -2, 0, 0,
+ax_anim 14, 0, 161, 0, -2, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCloysterAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 21, 0, 21,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 20, 11, 20, 11,
+ax_anim 3, 0, 165, 19, 21, 19, 21,
+ax_anim 2, 3, 166, 10, 21, 10, 21,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 19, 0, 19, 0,
+ax_anim 2, 3, 165, 18, 5, 18, 5,
+ax_anim 2, 0, 166, 12, 6, 12, 6,
+ax_anim 1, 0, 167, 5, 5, 5, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -20, 12, -20,
+ax_anim 3, 0, 163, 19, -18, 19, -18,
+ax_anim 2, 3, 164, 20, -13, 20, -13,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -11, -9, -11,
+ax_anim 2, 0, 169, -7, -16, -7, -16,
+ax_anim 3, 0, 162, 0, -18, 0, -18,
+ax_anim 2, 3, 163, 7, -16, 7, -16,
+ax_anim 2, 0, 164, 9, -9, 9, -9,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -20, -12, -20,
+ax_anim 3, 0, 169, -19, -18, -19, -18,
+ax_anim 2, 3, 168, -20, -13, -20, -13,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -19, 0, -19, 0,
+ax_anim 2, 3, 167, -18, 5, -18, 5,
+ax_anim 2, 0, 166, -12, 6, -12, 6,
+ax_anim 1, 0, 165, -5, 5, -5, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -20, 11, -20, 11,
+ax_anim 3, 0, 167, -19, 21, -19, 21,
+ax_anim 2, 3, 166, -10, 21, -10, 21,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCloysterAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCloysterAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 1, 0, 0,
+ax_anim_terminator
+sCloysterAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 2, 0, 0,
+ax_anim_terminator
+sCloysterAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 2, 0, 0,
+ax_anim_terminator
+sCloysterAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 2, 0, 0,
+ax_anim_terminator
+sCloysterAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 1, 0, 0,
+ax_anim_terminator
+sCloysterAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCloysterAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCloysterAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sCloysterGfx1:
+.incbin "baserom.gba", 0x8E0A8C, 0x200
+sCloysterSprites1:
+ax_sprite sCloysterGfx1, 0x200
+ax_sprite_terminator
+sCloysterGfx2:
+.incbin "baserom.gba", 0x8E0C9C, 0x200
+sCloysterSprites2:
+ax_sprite sCloysterGfx2, 0x200
+ax_sprite_terminator
+sCloysterGfx3:
+.incbin "baserom.gba", 0x8E0EAC, 0x200
+sCloysterSprites3:
+ax_sprite sCloysterGfx3, 0x200
+ax_sprite_terminator
+sCloysterGfx4:
+.incbin "baserom.gba", 0x8E10BC, 0x200
+sCloysterSprites4:
+ax_sprite sCloysterGfx4, 0x200
+ax_sprite_terminator
+sCloysterGfx5:
+.incbin "baserom.gba", 0x8E12CC, 0x200
+sCloysterSprites5:
+ax_sprite sCloysterGfx5, 0x200
+ax_sprite_terminator
+sCloysterGfx6:
+.incbin "baserom.gba", 0x8E14DC, 0x200
+sCloysterSprites6:
+ax_sprite sCloysterGfx6, 0x200
+ax_sprite_terminator
+sCloysterGfx7:
+.incbin "baserom.gba", 0x8E16EC, 0x200
+sCloysterSprites7:
+ax_sprite sCloysterGfx7, 0x200
+ax_sprite_terminator
+sCloysterGfx8:
+.incbin "baserom.gba", 0x8E18FC, 0x200
+sCloysterSprites8:
+ax_sprite sCloysterGfx8, 0x200
+ax_sprite_terminator
+sCloysterGfx9:
+.incbin "baserom.gba", 0x8E1B0C, 0x200
+sCloysterSprites9:
+ax_sprite sCloysterGfx9, 0x200
+ax_sprite_terminator
+sCloysterGfx10:
+.incbin "baserom.gba", 0x8E1D1C, 0x200
+sCloysterSprites10:
+ax_sprite sCloysterGfx10, 0x200
+ax_sprite_terminator
+sCloysterGfx11:
+.incbin "baserom.gba", 0x8E1F2C, 0x200
+sCloysterSprites11:
+ax_sprite sCloysterGfx11, 0x200
+ax_sprite_terminator
+sCloysterGfx12:
+.incbin "baserom.gba", 0x8E213C, 0x200
+sCloysterSprites12:
+ax_sprite sCloysterGfx12, 0x200
+ax_sprite_terminator
+sCloysterGfx13:
+.incbin "baserom.gba", 0x8E234C, 0x200
+sCloysterSprites13:
+ax_sprite sCloysterGfx13, 0x200
+ax_sprite_terminator
+sCloysterGfx14:
+.incbin "baserom.gba", 0x8E255C, 0x200
+sCloysterSprites14:
+ax_sprite sCloysterGfx14, 0x200
+ax_sprite_terminator
+sCloysterGfx15:
+.incbin "baserom.gba", 0x8E276C, 0x200
+sCloysterSprites15:
+ax_sprite sCloysterGfx15, 0x200
+ax_sprite_terminator
+sCloysterGfx16:
+.incbin "baserom.gba", 0x8E297C, 0x40
+sCloysterGfx16_1:
+.incbin "baserom.gba", 0x8E29BC, 0x100
+sCloysterGfx16_2:
+.incbin "baserom.gba", 0x8E2ABC, 0x40
+sCloysterSprites16:
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx17:
+.incbin "baserom.gba", 0x8E2B3C, 0x20
+sCloysterGfx17_1:
+.incbin "baserom.gba", 0x8E2B5C, 0x100
+sCloysterGfx17_2:
+.incbin "baserom.gba", 0x8E2C5C, 0x40
+sCloysterSprites17:
+ax_sprite 0, 0x40
+ax_sprite sCloysterGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx18:
+.incbin "baserom.gba", 0x8E2CDC, 0x40
+sCloysterGfx18_1:
+.incbin "baserom.gba", 0x8E2D1C, 0x100
+sCloysterGfx18_2:
+.incbin "baserom.gba", 0x8E2E1C, 0x60
+sCloysterSprites18:
+ax_sprite sCloysterGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCloysterGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx18_2, 0x60
+ax_sprite_terminator
+sCloysterGfx19:
+.incbin "baserom.gba", 0x8E2EAC, 0x60
+sCloysterGfx19_1:
+.incbin "baserom.gba", 0x8E2F0C, 0x180
+sCloysterSprites19:
+ax_sprite sCloysterGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx19_1, 0x180
+ax_sprite_terminator
+sCloysterGfx20:
+.incbin "baserom.gba", 0x8E30AC, 0x180
+sCloysterGfx20_1:
+.incbin "baserom.gba", 0x8E322C, 0x40
+sCloysterSprites20:
+ax_sprite sCloysterGfx20, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx21:
+.incbin "baserom.gba", 0x8E3294, 0x200
+sCloysterSprites21:
+ax_sprite sCloysterGfx21, 0x200
+ax_sprite_terminator
+sCloysterGfx22:
+.incbin "baserom.gba", 0x8E34A4, 0x60
+sCloysterGfx22_1:
+.incbin "baserom.gba", 0x8E3504, 0xE0
+sCloysterGfx22_2:
+.incbin "baserom.gba", 0x8E35E4, 0x60
+sCloysterSprites22:
+ax_sprite sCloysterGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx23:
+.incbin "baserom.gba", 0x8E367C, 0x40
+sCloysterGfx23_1:
+.incbin "baserom.gba", 0x8E36BC, 0x180
+sCloysterSprites23:
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx23_1, 0x180
+ax_sprite_terminator
+sCloysterGfx24:
+.incbin "baserom.gba", 0x8E3864, 0x60
+sCloysterGfx24_1:
+.incbin "baserom.gba", 0x8E38C4, 0x60
+sCloysterGfx24_2:
+.incbin "baserom.gba", 0x8E3924, 0x60
+sCloysterGfx24_3:
+.incbin "baserom.gba", 0x8E3984, 0x60
+sCloysterSprites24:
+ax_sprite sCloysterGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx25:
+.incbin "baserom.gba", 0x8E3A2C, 0x40
+sCloysterGfx25_1:
+.incbin "baserom.gba", 0x8E3A6C, 0x100
+sCloysterGfx25_2:
+.incbin "baserom.gba", 0x8E3B6C, 0x40
+sCloysterSprites25:
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx26:
+.incbin "baserom.gba", 0x8E3BEC, 0x40
+sCloysterGfx26_1:
+.incbin "baserom.gba", 0x8E3C2C, 0x180
+sCloysterSprites26:
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx26_1, 0x180
+ax_sprite_terminator
+sCloysterGfx27:
+.incbin "baserom.gba", 0x8E3DD4, 0x60
+sCloysterGfx27_1:
+.incbin "baserom.gba", 0x8E3E34, 0x160
+sCloysterSprites27:
+ax_sprite sCloysterGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx28:
+.incbin "baserom.gba", 0x8E3FBC, 0x20
+sCloysterGfx28_1:
+.incbin "baserom.gba", 0x8E3FDC, 0x180
+sCloysterSprites28:
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCloysterGfx28_1, 0x180
+ax_sprite_terminator
+sCloysterGfx29:
+.incbin "baserom.gba", 0x8E4184, 0x60
+sCloysterGfx29_1:
+.incbin "baserom.gba", 0x8E41E4, 0x180
+sCloysterSprites29:
+ax_sprite sCloysterGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx29_1, 0x180
+ax_sprite_terminator
+sCloysterGfx30:
+.incbin "baserom.gba", 0x8E4384, 0x180
+sCloysterGfx30_1:
+.incbin "baserom.gba", 0x8E4504, 0x40
+sCloysterSprites30:
+ax_sprite sCloysterGfx30, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCloysterGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCloysterGfx31:
+.incbin "baserom.gba", 0x8E456C, 0x200
+sCloysterSprites31:
+ax_sprite sCloysterGfx31, 0x200
+ax_sprite_terminator
+sCloysterGfx32:
+.incbin "baserom.gba", 0x8E477C, 0x200
+sCloysterSprites32:
+ax_sprite sCloysterGfx32, 0x200
+ax_sprite_terminator
+sCloysterGfx33:
+.incbin "baserom.gba", 0x8E498C, 0x200
+sCloysterSprites33:
+ax_sprite sCloysterGfx33, 0x200
+ax_sprite_terminator
+sCloysterGfx34:
+.incbin "baserom.gba", 0x8E4B9C, 0x200
+sCloysterSprites34:
+ax_sprite sCloysterGfx34, 0x200
+ax_sprite_terminator
+sCloysterGfx35:
+.incbin "baserom.gba", 0x8E4DAC, 0x200
+sCloysterSprites35:
+ax_sprite sCloysterGfx35, 0x200
+ax_sprite_terminator
+sCloysterGfx36:
+.incbin "baserom.gba", 0x8E4FBC, 0x200
+sCloysterSprites36:
+ax_sprite sCloysterGfx36, 0x200
+ax_sprite_terminator
+sCloysterGfx37:
+.incbin "baserom.gba", 0x8E51CC, 0x200
+sCloysterSprites37:
+ax_sprite sCloysterGfx37, 0x200
+ax_sprite_terminator
+sAxPosesCloyster:
+.4byte sCloysterPose1
+.4byte sCloysterPose2
+.4byte sCloysterPose3
+.4byte sCloysterPose4
+.4byte sCloysterPose5
+.4byte sCloysterPose6
+.4byte sCloysterPose7
+.4byte sCloysterPose8
+.4byte sCloysterPose9
+.4byte sCloysterPose10
+.4byte sCloysterPose11
+.4byte sCloysterPose12
+.4byte sCloysterPose13
+.4byte sCloysterPose14
+.4byte sCloysterPose15
+.4byte sCloysterPose16
+.4byte sCloysterPose17
+.4byte sCloysterPose18
+.4byte sCloysterPose19
+.4byte sCloysterPose20
+.4byte sCloysterPose21
+.4byte sCloysterPose22
+.4byte sCloysterPose23
+.4byte sCloysterPose24
+.4byte sCloysterPose25
+.4byte sCloysterPose26
+.4byte sCloysterPose27
+.4byte sCloysterPose28
+.4byte sCloysterPose29
+.4byte sCloysterPose30
+.4byte sCloysterPose31
+.4byte sCloysterPose32
+.4byte sCloysterPose33
+.4byte sCloysterPose34
+.4byte sCloysterPose35
+.4byte sCloysterPose36
+.4byte sCloysterPose37
+.4byte sCloysterPose38
+.4byte sCloysterPose39
+.4byte sCloysterPose40
+.4byte sCloysterPose41
+.4byte sCloysterPose42
+.4byte sCloysterPose43
+.4byte sCloysterPose44
+.4byte sCloysterPose45
+.4byte sCloysterPose46
+.4byte sCloysterPose47
+.4byte sCloysterPose48
+.4byte sCloysterPose49
+.4byte sCloysterPose50
+.4byte sCloysterPose51
+.4byte sCloysterPose52
+.4byte sCloysterPose53
+.4byte sCloysterPose54
+.4byte sCloysterPose55
+.4byte sCloysterPose56
+.4byte sCloysterPose57
+.4byte sCloysterPose58
+.4byte sCloysterPose59
+.4byte sCloysterPose60
+.4byte sCloysterPose61
+.4byte sCloysterPose62
+.4byte sCloysterPose63
+.4byte sCloysterPose64
+.4byte sCloysterPose65
+.4byte sCloysterPose66
+.4byte sCloysterPose67
+.4byte sCloysterPose68
+.4byte sCloysterPose69
+.4byte sCloysterPose70
+.4byte sCloysterPose71
+.4byte sCloysterPose72
+.4byte sCloysterPose73
+.4byte sCloysterPose74
+.4byte sCloysterPose75
+.4byte sCloysterPose76
+.4byte sCloysterPose77
+.4byte sCloysterPose78
+.4byte sCloysterPose79
+.4byte sCloysterPose80
+.4byte sCloysterPose81
+.4byte sCloysterPose82
+.4byte sCloysterPose83
+.4byte sCloysterPose84
+.4byte sCloysterPose85
+.4byte sCloysterPose86
+.4byte sCloysterPose87
+.4byte sCloysterPose88
+.4byte sCloysterPose89
+.4byte sCloysterPose90
+.4byte sCloysterPose91
+.4byte sCloysterPose92
+.4byte sCloysterPose93
+.4byte sCloysterPose94
+.4byte sCloysterPose95
+.4byte sCloysterPose96
+.4byte sCloysterPose97
+.4byte sCloysterPose98
+.4byte sCloysterPose99
+.4byte sCloysterPose100
+.4byte sCloysterPose101
+.4byte sCloysterPose102
+.4byte sCloysterPose103
+.4byte sCloysterPose104
+.4byte sCloysterPose105
+.4byte sCloysterPose106
+.4byte sCloysterPose107
+.4byte sCloysterPose108
+.4byte sCloysterPose109
+.4byte sCloysterPose110
+.4byte sCloysterPose111
+.4byte sCloysterPose112
+.4byte sCloysterPose113
+.4byte sCloysterPose114
+.4byte sCloysterPose115
+.4byte sCloysterPose116
+.4byte sCloysterPose117
+.4byte sCloysterPose118
+.4byte sCloysterPose119
+.4byte sCloysterPose120
+.4byte sCloysterPose121
+.4byte sCloysterPose122
+.4byte sCloysterPose123
+.4byte sCloysterPose124
+.4byte sCloysterPose125
+.4byte sCloysterPose126
+.4byte sCloysterPose127
+.4byte sCloysterPose128
+.4byte sCloysterPose129
+.4byte sCloysterPose130
+.4byte sCloysterPose131
+.4byte sCloysterPose132
+.4byte sCloysterPose133
+.4byte sCloysterPose134
+.4byte sCloysterPose135
+.4byte sCloysterPose136
+.4byte sCloysterPose137
+.4byte sCloysterPose138
+.4byte sCloysterPose139
+.4byte sCloysterPose140
+.4byte sCloysterPose141
+.4byte sCloysterPose142
+.4byte sCloysterPose143
+.4byte sCloysterPose144
+.4byte sCloysterPose145
+.4byte sCloysterPose146
+.4byte sCloysterPose147
+.4byte sCloysterPose148
+.4byte sCloysterPose149
+.4byte sCloysterPose150
+.4byte sCloysterPose151
+.4byte sCloysterPose152
+.4byte sCloysterPose153
+.4byte sCloysterPose154
+.4byte sCloysterPose155
+.4byte sCloysterPose156
+.4byte sCloysterPose157
+.4byte sCloysterPose158
+.4byte sCloysterPose159
+.4byte sCloysterPose160
+.4byte sCloysterPose161
+.4byte sCloysterPose162
+.4byte sCloysterPose163
+.4byte sCloysterPose164
+.4byte sCloysterPose165
+.4byte sCloysterPose166
+.4byte sCloysterPose167
+.4byte sCloysterPose168
+.4byte sCloysterPose169
+.4byte sCloysterPose170
+.4byte sCloysterPose171
+.4byte sCloysterPose172
+.4byte sCloysterPose173
+.4byte sCloysterPose174
+.4byte sCloysterPose175
+.4byte sCloysterPose176
+.4byte sCloysterPose177
+.4byte sCloysterPose178
+.4byte sCloysterPose179
+.4byte sCloysterPose180
+.4byte sCloysterPose181
+.4byte sCloysterPose182
+.4byte sCloysterPose183
+.4byte sCloysterPose184
+.4byte sCloysterPose185
+.4byte sCloysterPose186
+.4byte sCloysterPose187
+.4byte sCloysterPose188
+.4byte sCloysterPose189
+.4byte sCloysterPose190
+.4byte sCloysterPose191
+.4byte sCloysterPose192
+.4byte sCloysterPose193
+.4byte sCloysterPose194
+.4byte sCloysterPose195
+.4byte sCloysterPose196
+.4byte sCloysterPose197
+.4byte sCloysterPose198
+.4byte sCloysterPose199
+.4byte sCloysterPose200
+.4byte sCloysterPose201
+.4byte sCloysterPose202
+.4byte sCloysterPose203
+.4byte sCloysterPose204
+.4byte sCloysterPose205
+.4byte sCloysterPose206
+.4byte sCloysterPose207
+.4byte sCloysterPose208
+.4byte sCloysterPose209
+.4byte sCloysterPose210
+.4byte sCloysterPose211
+.4byte sCloysterPose212
+.4byte sCloysterPose213
+.4byte sCloysterPose214
+.4byte sCloysterPose215
+.4byte sCloysterPose216
+.4byte sCloysterPose217
+.4byte sCloysterPose218
+sAxPositionsCloyster:
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -1, 	 -10,   -9, 	   7,   -9, 	  -1,  -12
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte    5,   -2, 	   8,  -12, 	  -5,   -3, 	   0,   -9
+.2byte    5,   -2, 	   9,  -12, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -2, 	   7,  -11, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -7, 	   9,  -13, 	   5,   -4, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   3,   -3, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   4,   -5, 	   0,   -9
+.2byte    7,  -10, 	  -2,  -17, 	   8,   -7, 	   1,  -10
+.2byte    6,  -10, 	  -2,  -17, 	   8,   -7, 	   0,  -10
+.2byte    8,  -10, 	  -2,  -16, 	   8,   -8, 	   0,  -10
+.2byte   -1,  -16, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte   -1,  -15, 	   7,  -12, 	  -9,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   6,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -9,  -10, 	   0,  -17, 	 -10,   -7, 	  -3,  -10
+.2byte   -8,  -10, 	   0,  -17, 	 -10,   -7, 	  -2,  -10
+.2byte  -10,  -10, 	   0,  -16, 	 -10,   -8, 	  -2,  -10
+.2byte  -11,   -7, 	 -11,  -13, 	  -7,   -4, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -6,   -5, 	  -2,   -9
+.2byte   -7,   -2, 	 -10,  -12, 	   3,   -3, 	  -2,   -9
+.2byte   -7,   -2, 	 -11,  -12, 	   2,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	  -9,  -11, 	   2,   -3, 	  -1,   -9
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -1, 	 -10,   -9, 	   7,   -9, 	  -1,  -12
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -2, 	 -10,   -6, 	   8,   -6, 	  -1,  -11
+.2byte    5,   -2, 	   8,  -12, 	  -5,   -3, 	   0,   -9
+.2byte    5,   -2, 	   9,  -12, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -2, 	   7,  -11, 	  -4,   -3, 	  -1,   -9
+.2byte    4,   -3, 	   8,   -9, 	  -3,   -1, 	   0,   -9
+.2byte    9,   -7, 	   9,  -13, 	   5,   -4, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   3,   -3, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   4,   -5, 	   0,   -9
+.2byte    8,   -5, 	   7,  -14, 	   6,   -3, 	  -1,   -9
+.2byte    7,  -10, 	  -2,  -17, 	   8,   -7, 	   1,  -10
+.2byte    6,  -10, 	  -2,  -17, 	   8,   -7, 	   0,  -10
+.2byte    8,  -10, 	  -2,  -16, 	   8,   -8, 	   0,  -10
+.2byte    7,   -9, 	  -1,  -17, 	   7,   -8, 	   1,  -11
+.2byte   -1,  -16, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte   -1,  -15, 	   7,  -12, 	  -9,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   6,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -1,  -17, 	   6,  -13, 	  -8,  -13, 	  -1,  -13
+.2byte   -9,  -10, 	   0,  -17, 	 -10,   -7, 	  -3,  -10
+.2byte   -8,  -10, 	   0,  -17, 	 -10,   -7, 	  -2,  -10
+.2byte  -10,  -10, 	   0,  -16, 	 -10,   -8, 	  -2,  -10
+.2byte   -9,   -9, 	  -1,  -17, 	  -9,   -8, 	  -3,  -11
+.2byte  -11,   -7, 	 -11,  -13, 	  -7,   -4, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -6,   -5, 	  -2,   -9
+.2byte  -10,   -5, 	  -9,  -14, 	  -8,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	 -10,  -12, 	   3,   -3, 	  -2,   -9
+.2byte   -7,   -2, 	 -11,  -12, 	   2,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	  -9,  -11, 	   2,   -3, 	  -1,   -9
+.2byte   -6,   -3, 	 -10,   -9, 	   1,   -1, 	  -2,   -9
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -1, 	 -10,   -9, 	   7,   -9, 	  -1,  -12
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -2, 	 -10,   -6, 	   8,   -6, 	  -1,  -11
+.2byte    5,   -2, 	   8,  -12, 	  -5,   -3, 	   0,   -9
+.2byte    5,   -2, 	   9,  -12, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -2, 	   7,  -11, 	  -4,   -3, 	  -1,   -9
+.2byte    4,   -3, 	   8,   -9, 	  -3,   -1, 	   0,   -9
+.2byte    9,   -7, 	   9,  -13, 	   5,   -4, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   3,   -3, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   4,   -5, 	   0,   -9
+.2byte    8,   -5, 	   7,  -14, 	   6,   -3, 	  -1,   -9
+.2byte    7,  -10, 	  -2,  -17, 	   8,   -7, 	   1,  -10
+.2byte    6,  -10, 	  -2,  -17, 	   8,   -7, 	   0,  -10
+.2byte    8,  -10, 	  -2,  -16, 	   8,   -8, 	   0,  -10
+.2byte    7,   -9, 	  -1,  -17, 	   7,   -8, 	   1,  -11
+.2byte   -1,  -16, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte   -1,  -15, 	   7,  -12, 	  -9,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   6,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -1,  -17, 	   6,  -13, 	  -8,  -13, 	  -1,  -13
+.2byte   -9,  -10, 	   0,  -17, 	 -10,   -7, 	  -3,  -10
+.2byte   -8,  -10, 	   0,  -17, 	 -10,   -7, 	  -2,  -10
+.2byte  -10,  -10, 	   0,  -16, 	 -10,   -8, 	  -2,  -10
+.2byte   -9,   -9, 	  -1,  -17, 	  -9,   -8, 	  -3,  -11
+.2byte  -11,   -7, 	 -11,  -13, 	  -7,   -4, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -6,   -5, 	  -2,   -9
+.2byte  -10,   -5, 	  -9,  -14, 	  -8,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	 -10,  -12, 	   3,   -3, 	  -2,   -9
+.2byte   -7,   -2, 	 -11,  -12, 	   2,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	  -9,  -11, 	   2,   -3, 	  -1,   -9
+.2byte   -6,   -3, 	 -10,   -9, 	   1,   -1, 	  -2,   -9
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -1, 	 -10,   -9, 	   7,   -9, 	  -1,  -12
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -2, 	 -10,   -5, 	   9,   -5, 	  -1,  -12
+.2byte    5,   -2, 	   8,  -12, 	  -5,   -3, 	   0,   -9
+.2byte    5,   -2, 	   9,  -12, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -2, 	   7,  -11, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -3, 	  10,   -8, 	  -5,   -1, 	  -1,  -10
+.2byte    9,   -7, 	   9,  -13, 	   5,   -4, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   3,   -3, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   4,   -5, 	   0,   -9
+.2byte   10,   -6, 	   9,  -11, 	   6,   -1, 	   0,   -9
+.2byte    7,  -10, 	  -2,  -17, 	   8,   -7, 	   1,  -10
+.2byte    6,  -10, 	  -2,  -17, 	   8,   -7, 	   0,  -10
+.2byte    8,  -10, 	  -2,  -16, 	   8,   -8, 	   0,  -10
+.2byte    6,   -9, 	  -4,  -17, 	   8,   -9, 	   0,   -9
+.2byte   -1,  -16, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte   -1,  -15, 	   7,  -12, 	  -9,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   6,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   8,  -12, 	  -9,  -12, 	  -1,  -12
+.2byte   -9,  -10, 	   0,  -17, 	 -10,   -7, 	  -3,  -10
+.2byte   -8,  -10, 	   0,  -17, 	 -10,   -7, 	  -2,  -10
+.2byte  -10,  -10, 	   0,  -16, 	 -10,   -8, 	  -2,  -10
+.2byte   -8,   -9, 	   2,  -17, 	 -10,   -9, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -13, 	  -7,   -4, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -6,   -5, 	  -2,   -9
+.2byte  -12,   -6, 	 -11,  -11, 	  -8,   -1, 	  -2,   -9
+.2byte   -7,   -2, 	 -10,  -12, 	   3,   -3, 	  -2,   -9
+.2byte   -7,   -2, 	 -11,  -12, 	   2,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	  -9,  -11, 	   2,   -3, 	  -1,   -9
+.2byte   -7,   -3, 	 -12,   -8, 	   3,   -1, 	  -1,  -10
+.2byte   -1,   -2, 	  -8,   -6, 	   7,   -6, 	  -1,  -11
+.2byte    5,   -1, 	   8,   -7, 	  -2,    0, 	   0,   -9
+.2byte    9,   -4, 	   9,  -10, 	   7,   -3, 	   2,   -9
+.2byte    7,   -9, 	  -2,  -17, 	   8,   -8, 	   0,  -10
+.2byte   -1,  -17, 	   6,  -13, 	  -8,  -13, 	  -1,  -12
+.2byte   -9,   -9, 	   0,  -17, 	 -10,   -8, 	  -2,  -10
+.2byte  -11,   -4, 	 -11,  -10, 	  -9,   -3, 	  -4,   -9
+.2byte   -7,   -1, 	 -10,   -7, 	   0,    0, 	  -2,   -9
+.2byte   -7,   -6, 	 -10,  -16, 	   2,   -7, 	  -1,  -13
+.2byte   -7,   -6, 	  -9,  -14, 	   1,   -7, 	   0,  -12
+.2byte   -1,   -3, 	  -8,   -9, 	   6,   -9, 	  -1,  -11
+.2byte    6,   -8, 	   8,  -13, 	  -1,   -6, 	  -1,  -11
+.2byte    9,  -10, 	   7,  -15, 	   5,   -7, 	   0,  -11
+.2byte    5,  -12, 	  -5,  -17, 	   5,   -9, 	  -2,  -10
+.2byte   -1,  -16, 	   6,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -6,  -12, 	   4,  -17, 	  -6,   -9, 	   1,  -10
+.2byte  -10,  -10, 	  -8,  -15, 	  -6,   -7, 	  -1,  -11
+.2byte   -7,   -8, 	  -9,  -13, 	   0,   -6, 	   0,  -11
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -1, 	 -10,   -9, 	   7,   -9, 	  -1,  -12
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte    5,   -2, 	   8,  -12, 	  -5,   -3, 	   0,   -9
+.2byte    5,   -2, 	   9,  -12, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -2, 	   7,  -11, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -7, 	   9,  -13, 	   5,   -4, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   3,   -3, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   4,   -5, 	   0,   -9
+.2byte    7,  -10, 	  -2,  -17, 	   8,   -7, 	   1,  -10
+.2byte    6,  -10, 	  -2,  -17, 	   8,   -7, 	   0,  -10
+.2byte    8,  -10, 	  -2,  -16, 	   8,   -8, 	   0,  -10
+.2byte   -1,  -16, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte   -1,  -15, 	   7,  -12, 	  -9,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   6,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -9,  -10, 	   0,  -17, 	 -10,   -7, 	  -3,  -10
+.2byte   -8,  -10, 	   0,  -17, 	 -10,   -7, 	  -2,  -10
+.2byte  -10,  -10, 	   0,  -16, 	 -10,   -8, 	  -2,  -10
+.2byte  -11,   -7, 	 -11,  -13, 	  -7,   -4, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -6,   -5, 	  -2,   -9
+.2byte   -7,   -2, 	 -10,  -12, 	   3,   -3, 	  -2,   -9
+.2byte   -7,   -2, 	 -11,  -12, 	   2,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	  -9,  -11, 	   2,   -3, 	  -1,   -9
+.2byte   -1,   -2, 	 -10,   -5, 	   9,   -5, 	  -1,  -12
+.2byte   -7,   -3, 	 -12,   -8, 	   3,   -1, 	  -1,  -10
+.2byte  -10,   -6, 	  -9,  -11, 	  -6,   -1, 	   0,   -9
+.2byte   -7,   -9, 	   3,  -17, 	  -9,   -9, 	  -1,   -9
+.2byte   -1,  -16, 	   8,  -12, 	  -9,  -12, 	  -1,  -12
+.2byte    5,   -9, 	  -5,  -17, 	   7,   -9, 	  -1,   -9
+.2byte    9,   -6, 	   8,  -11, 	   5,   -1, 	  -1,   -9
+.2byte    5,   -3, 	  10,   -8, 	  -5,   -1, 	  -1,  -10
+.2byte   -1,   -2, 	 -10,   -5, 	   9,   -5, 	  -1,  -12
+.2byte    5,   -3, 	  10,   -8, 	  -5,   -1, 	  -1,  -10
+.2byte    9,   -6, 	   8,  -11, 	   5,   -1, 	  -1,   -9
+.2byte    5,   -9, 	  -5,  -17, 	   7,   -9, 	  -1,   -9
+.2byte   -1,  -16, 	   8,  -12, 	  -9,  -12, 	  -1,  -12
+.2byte   -7,   -9, 	   3,  -17, 	  -9,   -9, 	  -1,   -9
+.2byte  -10,   -6, 	  -9,  -11, 	  -6,   -1, 	   0,   -9
+.2byte   -7,   -3, 	 -12,   -8, 	   3,   -1, 	  -1,  -10
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -1,   -1, 	 -10,   -9, 	   7,   -9, 	  -1,  -12
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte    5,   -2, 	   8,  -12, 	  -5,   -3, 	   0,   -9
+.2byte    5,   -2, 	   9,  -12, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -2, 	   7,  -11, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -7, 	   9,  -13, 	   5,   -4, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   3,   -3, 	   0,   -9
+.2byte    9,   -7, 	   9,  -12, 	   4,   -5, 	   0,   -9
+.2byte    7,  -10, 	  -2,  -17, 	   8,   -7, 	   1,  -10
+.2byte    6,  -10, 	  -2,  -17, 	   8,   -7, 	   0,  -10
+.2byte    8,  -10, 	  -2,  -16, 	   8,   -8, 	   0,  -10
+.2byte   -1,  -16, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte   -1,  -15, 	   7,  -12, 	  -9,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   6,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -9,  -10, 	   0,  -17, 	 -10,   -7, 	  -3,  -10
+.2byte   -8,  -10, 	   0,  -17, 	 -10,   -7, 	  -2,  -10
+.2byte  -10,  -10, 	   0,  -16, 	 -10,   -8, 	  -2,  -10
+.2byte  -11,   -7, 	 -11,  -13, 	  -7,   -4, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -5,   -3, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -12, 	  -6,   -5, 	  -2,   -9
+.2byte   -7,   -2, 	 -10,  -12, 	   3,   -3, 	  -2,   -9
+.2byte   -7,   -2, 	 -11,  -12, 	   2,   -3, 	  -1,   -9
+.2byte   -7,   -2, 	  -9,  -11, 	   2,   -3, 	  -1,   -9
+.2byte   -1,   -2, 	 -10,   -5, 	   9,   -5, 	  -1,  -12
+.2byte   -7,   -4, 	 -12,   -9, 	   3,   -2, 	  -1,  -11
+.2byte  -11,   -6, 	 -10,  -11, 	  -7,   -1, 	  -1,   -9
+.2byte   -7,   -8, 	   3,  -16, 	  -9,   -8, 	  -1,   -8
+.2byte   -1,  -16, 	   8,  -12, 	  -9,  -12, 	  -1,  -12
+.2byte    7,   -8, 	  -3,  -16, 	   9,   -8, 	   1,   -8
+.2byte    9,   -6, 	   8,  -11, 	   5,   -1, 	  -1,   -9
+.2byte    9,   -3, 	  14,   -8, 	  -1,   -1, 	   3,  -10
+.2byte   -1,   -1, 	  -9,   -8, 	   7,   -8, 	  -1,  -12
+.2byte   -7,   -2, 	 -10,  -12, 	   3,   -3, 	  -2,   -9
+.2byte  -11,   -7, 	 -11,  -13, 	  -7,   -4, 	  -2,   -9
+.2byte   -9,  -10, 	   0,  -17, 	 -10,   -7, 	  -3,  -10
+.2byte   -1,  -16, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte    7,  -10, 	  -2,  -17, 	   8,   -7, 	   1,  -10
+.2byte    9,   -7, 	   9,  -13, 	   5,   -4, 	   0,   -9
+.2byte    5,   -2, 	   8,  -12, 	  -5,   -3, 	   0,   -9
+sCloysterAnimTable1:
+.4byte sCloysterAnims_1_1
+.4byte sCloysterAnims_1_2
+.4byte sCloysterAnims_1_3
+.4byte sCloysterAnims_1_4
+.4byte sCloysterAnims_1_5
+.4byte sCloysterAnims_1_6
+.4byte sCloysterAnims_1_7
+.4byte sCloysterAnims_1_8
+sCloysterAnimTable2:
+.4byte sCloysterAnims_2_1
+.4byte sCloysterAnims_2_2
+.4byte sCloysterAnims_2_3
+.4byte sCloysterAnims_2_4
+.4byte sCloysterAnims_2_5
+.4byte sCloysterAnims_2_6
+.4byte sCloysterAnims_2_7
+.4byte sCloysterAnims_2_8
+sCloysterAnimTable3:
+.4byte sCloysterAnims_3_1
+.4byte sCloysterAnims_3_2
+.4byte sCloysterAnims_3_3
+.4byte sCloysterAnims_3_4
+.4byte sCloysterAnims_3_5
+.4byte sCloysterAnims_3_6
+.4byte sCloysterAnims_3_7
+.4byte sCloysterAnims_3_8
+sCloysterAnimTable4:
+.4byte sCloysterAnims_4_1
+.4byte sCloysterAnims_4_2
+.4byte sCloysterAnims_4_3
+.4byte sCloysterAnims_4_4
+.4byte sCloysterAnims_4_5
+.4byte sCloysterAnims_4_6
+.4byte sCloysterAnims_4_7
+.4byte sCloysterAnims_4_8
+sCloysterAnimTable5:
+.4byte sCloysterAnims_5_1
+.4byte sCloysterAnims_5_2
+.4byte sCloysterAnims_5_3
+.4byte sCloysterAnims_5_4
+.4byte sCloysterAnims_5_5
+.4byte sCloysterAnims_5_6
+.4byte sCloysterAnims_5_7
+.4byte sCloysterAnims_5_8
+sCloysterAnimTable6:
+.4byte sCloysterAnims_6_1
+.4byte sCloysterAnims_6_1
+.4byte sCloysterAnims_6_1
+.4byte sCloysterAnims_6_1
+.4byte sCloysterAnims_6_1
+.4byte sCloysterAnims_6_1
+.4byte sCloysterAnims_6_1
+.4byte sCloysterAnims_6_1
+sCloysterAnimTable7:
+.4byte sCloysterAnims_7_1
+.4byte sCloysterAnims_7_2
+.4byte sCloysterAnims_7_3
+.4byte sCloysterAnims_7_4
+.4byte sCloysterAnims_7_5
+.4byte sCloysterAnims_7_6
+.4byte sCloysterAnims_7_7
+.4byte sCloysterAnims_7_8
+sCloysterAnimTable8:
+.4byte sCloysterAnims_8_1
+.4byte sCloysterAnims_8_2
+.4byte sCloysterAnims_8_3
+.4byte sCloysterAnims_8_4
+.4byte sCloysterAnims_8_5
+.4byte sCloysterAnims_8_6
+.4byte sCloysterAnims_8_7
+.4byte sCloysterAnims_8_8
+sCloysterAnimTable9:
+.4byte sCloysterAnims_9_1
+.4byte sCloysterAnims_9_2
+.4byte sCloysterAnims_9_3
+.4byte sCloysterAnims_9_4
+.4byte sCloysterAnims_9_5
+.4byte sCloysterAnims_9_6
+.4byte sCloysterAnims_9_7
+.4byte sCloysterAnims_9_8
+sCloysterAnimTable10:
+.4byte sCloysterAnims_10_1
+.4byte sCloysterAnims_10_2
+.4byte sCloysterAnims_10_3
+.4byte sCloysterAnims_10_4
+.4byte sCloysterAnims_10_5
+.4byte sCloysterAnims_10_6
+.4byte sCloysterAnims_10_7
+.4byte sCloysterAnims_10_8
+sCloysterAnimTable11:
+.4byte sCloysterAnims_11_1
+.4byte sCloysterAnims_11_2
+.4byte sCloysterAnims_11_3
+.4byte sCloysterAnims_11_4
+.4byte sCloysterAnims_11_5
+.4byte sCloysterAnims_11_6
+.4byte sCloysterAnims_11_7
+.4byte sCloysterAnims_11_8
+sCloysterAnimTable12:
+.4byte sCloysterAnims_12_1
+.4byte sCloysterAnims_12_2
+.4byte sCloysterAnims_12_3
+.4byte sCloysterAnims_12_4
+.4byte sCloysterAnims_12_5
+.4byte sCloysterAnims_12_6
+.4byte sCloysterAnims_12_7
+.4byte sCloysterAnims_12_8
+sCloysterAnimTable13:
+.4byte sCloysterAnims_13_1
+.4byte sCloysterAnims_13_2
+.4byte sCloysterAnims_13_3
+.4byte sCloysterAnims_13_4
+.4byte sCloysterAnims_13_5
+.4byte sCloysterAnims_13_6
+.4byte sCloysterAnims_13_7
+.4byte sCloysterAnims_13_8
+sAxAnimationsCloyster:
+.4byte sCloysterAnimTable1
+.4byte sCloysterAnimTable2
+.4byte sCloysterAnimTable3
+.4byte sCloysterAnimTable4
+.4byte sCloysterAnimTable5
+.4byte sCloysterAnimTable6
+.4byte sCloysterAnimTable7
+.4byte sCloysterAnimTable8
+.4byte sCloysterAnimTable9
+.4byte sCloysterAnimTable10
+.4byte sCloysterAnimTable11
+.4byte sCloysterAnimTable12
+.4byte sCloysterAnimTable13
+sAxSpritesCloyster:
+.4byte sCloysterSprites1
+.4byte sCloysterSprites2
+.4byte sCloysterSprites3
+.4byte sCloysterSprites4
+.4byte sCloysterSprites5
+.4byte sCloysterSprites6
+.4byte sCloysterSprites7
+.4byte sCloysterSprites8
+.4byte sCloysterSprites9
+.4byte sCloysterSprites10
+.4byte sCloysterSprites11
+.4byte sCloysterSprites12
+.4byte sCloysterSprites13
+.4byte sCloysterSprites14
+.4byte sCloysterSprites15
+.4byte sCloysterSprites16
+.4byte sCloysterSprites17
+.4byte sCloysterSprites18
+.4byte sCloysterSprites19
+.4byte sCloysterSprites20
+.4byte sCloysterSprites21
+.4byte sCloysterSprites22
+.4byte sCloysterSprites23
+.4byte sCloysterSprites24
+.4byte sCloysterSprites25
+.4byte sCloysterSprites26
+.4byte sCloysterSprites27
+.4byte sCloysterSprites28
+.4byte sCloysterSprites29
+.4byte sCloysterSprites30
+.4byte sCloysterSprites31
+.4byte sCloysterSprites32
+.4byte sCloysterSprites33
+.4byte sCloysterSprites34
+.4byte sCloysterSprites35
+.4byte sCloysterSprites36
+.4byte sCloysterSprites37
+sAxMainCloyster:
+ax_main sAxPosesCloyster, sAxAnimationsCloyster, 13, sAxSpritesCloyster, sAxPositionsCloyster

--- a/data/ax/combusken.inc
+++ b/data/ax/combusken.inc
@@ -1,0 +1,2873 @@
+.global gAxCombusken
+gAxCombusken:
+ax_siro sAxMainCombusken
+sCombuskenPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose4:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose5:
+ax_pose 4, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose6:
+ax_pose 5, 0x81ea, 0x90f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose7:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose8:
+ax_pose 7, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose9:
+ax_pose 8, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose10:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose13:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose16:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose19:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose20:
+ax_pose 7, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose21:
+ax_pose 8, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose22:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose23:
+ax_pose 4, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose24:
+ax_pose 5, 0x81ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose26:
+ax_pose 15, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose28:
+ax_pose 16, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose29:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose30:
+ax_pose 17, 0x81e7, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose31:
+ax_pose 5, 0x81ea, 0x90f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose32:
+ax_pose 18, 0x81e5, 0x90f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose33:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose34:
+ax_pose 19, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose35:
+ax_pose 8, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose36:
+ax_pose 20, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose37:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose38:
+ax_pose 21, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose39:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose40:
+ax_pose 22, 0x01e7, 0x90e8, 0x4c00
+ax_pose_terminator
+sCombuskenPose41:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose42:
+ax_pose 23, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose43:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose44:
+ax_pose 24, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose45:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose46:
+ax_pose 21, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sCombuskenPose47:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose48:
+ax_pose 22, 0x01e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose49:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose50:
+ax_pose 19, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose51:
+ax_pose 8, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose52:
+ax_pose 20, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sCombuskenPose53:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose54:
+ax_pose 17, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose55:
+ax_pose 5, 0x81ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose56:
+ax_pose 18, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose57:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose58:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose59:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose60:
+ax_pose 17, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose61:
+ax_pose 25, 0x81e9, 0x80f4, 0x4c00
+ax_pose 26, 0x81e9, 0x80f9, 0x4c08
+ax_pose_terminator
+sCombuskenPose62:
+ax_pose 26, 0x81e9, 0x80f9, 0x4c00
+ax_pose_terminator
+sCombuskenPose63:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose64:
+ax_pose 4, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose65:
+ax_pose 5, 0x81ea, 0x90f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose66:
+ax_pose 19, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sCombuskenPose67:
+ax_pose 27, 0x81e2, 0x90fe, 0x4c00
+ax_pose 28, 0x01e5, 0x90e9, 0x4c08
+ax_pose_terminator
+sCombuskenPose68:
+ax_pose 28, 0x01e5, 0x90e9, 0x4c00
+ax_pose_terminator
+sCombuskenPose69:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose70:
+ax_pose 7, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose71:
+ax_pose 8, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose72:
+ax_pose 21, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose73:
+ax_pose 29, 0x81e0, 0x9100, 0x4c00
+ax_pose 30, 0x01e4, 0x90ea, 0x4c08
+ax_pose_terminator
+sCombuskenPose74:
+ax_pose 30, 0x01e4, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose75:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose76:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose77:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose78:
+ax_pose 23, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sCombuskenPose79:
+ax_pose 31, 0x81e0, 0x90fd, 0x4c00
+ax_pose 32, 0x81e5, 0x90f7, 0x4c08
+ax_pose_terminator
+sCombuskenPose80:
+ax_pose 32, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose81:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose82:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose83:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose84:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose85:
+ax_pose 34, 0x81e0, 0x80fb, 0x4c00
+ax_pose 35, 0x01e3, 0x80f4, 0x4c08
+ax_pose_terminator
+sCombuskenPose86:
+ax_pose 35, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose87:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose88:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose89:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose90:
+ax_pose 23, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sCombuskenPose91:
+ax_pose 31, 0x81e0, 0x80f2, 0x4c00
+ax_pose 32, 0x81e5, 0x80f8, 0x4c08
+ax_pose_terminator
+sCombuskenPose92:
+ax_pose 32, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose93:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose94:
+ax_pose 7, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose95:
+ax_pose 8, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose96:
+ax_pose 21, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose97:
+ax_pose 29, 0x81e0, 0x80ef, 0x4c00
+ax_pose 30, 0x01e4, 0x80f5, 0x4c08
+ax_pose_terminator
+sCombuskenPose98:
+ax_pose 30, 0x01e4, 0x80f5, 0x4c00
+ax_pose_terminator
+sCombuskenPose99:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose100:
+ax_pose 4, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose101:
+ax_pose 5, 0x81ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose102:
+ax_pose 19, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sCombuskenPose103:
+ax_pose 27, 0x81e2, 0x80f1, 0x4c00
+ax_pose 28, 0x01e5, 0x80f7, 0x4c08
+ax_pose_terminator
+sCombuskenPose104:
+ax_pose 28, 0x01e5, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose105:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose106:
+ax_pose 16, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose107:
+ax_pose 36, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose108:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose109:
+ax_pose 18, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose110:
+ax_pose 37, 0x01e5, 0x90e8, 0x4c00
+ax_pose_terminator
+sCombuskenPose111:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose112:
+ax_pose 20, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose113:
+ax_pose 38, 0x01e5, 0x90e9, 0x4c00
+ax_pose_terminator
+sCombuskenPose114:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose115:
+ax_pose 22, 0x01e7, 0x90e8, 0x4c00
+ax_pose_terminator
+sCombuskenPose116:
+ax_pose 39, 0x01eb, 0x90e7, 0x4c00
+ax_pose_terminator
+sCombuskenPose117:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose118:
+ax_pose 24, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose119:
+ax_pose 40, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose120:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose121:
+ax_pose 22, 0x01e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose122:
+ax_pose 39, 0x01eb, 0x80f9, 0x4c00
+ax_pose_terminator
+sCombuskenPose123:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose124:
+ax_pose 20, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sCombuskenPose125:
+ax_pose 38, 0x01e5, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose126:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose127:
+ax_pose 18, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose128:
+ax_pose 37, 0x01e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose129:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose130:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose131:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose132:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose133:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose134:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose135:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose136:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose137:
+ax_pose 41, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose138:
+ax_pose 42, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose139:
+ax_pose 43, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sCombuskenPose140:
+ax_pose 44, 0x01e3, 0x90e9, 0x4c00
+ax_pose_terminator
+sCombuskenPose141:
+ax_pose 45, 0x01e3, 0x90e6, 0x4c00
+ax_pose_terminator
+sCombuskenPose142:
+ax_pose 46, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose143:
+ax_pose 47, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sCombuskenPose144:
+ax_pose 46, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sCombuskenPose145:
+ax_pose 45, 0x01e3, 0x80f9, 0x4c00
+ax_pose_terminator
+sCombuskenPose146:
+ax_pose 44, 0x01e3, 0x80f6, 0x4c00
+ax_pose_terminator
+sCombuskenPose147:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose148:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose149:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose150:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose151:
+ax_pose 4, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose152:
+ax_pose 5, 0x81ea, 0x90f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose153:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose154:
+ax_pose 7, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose155:
+ax_pose 8, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose156:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose157:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose158:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sCombuskenPose159:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose160:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose161:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose162:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose163:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose164:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose165:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose166:
+ax_pose 7, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose167:
+ax_pose 8, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose168:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose169:
+ax_pose 4, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose170:
+ax_pose 5, 0x81ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose171:
+ax_pose 16, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose172:
+ax_pose 18, 0x81e6, 0x80f6, 0x4c00
+ax_pose_terminator
+sCombuskenPose173:
+ax_pose 20, 0x01e6, 0x80f5, 0x4c00
+ax_pose_terminator
+sCombuskenPose174:
+ax_pose 22, 0x01e8, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose175:
+ax_pose 24, 0x01e8, 0x80f6, 0x4c00
+ax_pose_terminator
+sCombuskenPose176:
+ax_pose 22, 0x01e8, 0x90e9, 0x4c00
+ax_pose_terminator
+sCombuskenPose177:
+ax_pose 20, 0x01e6, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose178:
+ax_pose 18, 0x81e5, 0x90f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose179:
+ax_pose 48, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sCombuskenPose180:
+ax_pose 49, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose181:
+ax_pose 50, 0x01e4, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose182:
+ax_pose 51, 0x81e6, 0x90f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose183:
+ax_pose 52, 0x01e6, 0x80f5, 0x4c00
+ax_pose_terminator
+sCombuskenPose184:
+ax_pose 51, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose185:
+ax_pose 50, 0x01e4, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose186:
+ax_pose 49, 0x01e5, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose187:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose188:
+ax_pose 16, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose189:
+ax_pose 36, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose190:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose191:
+ax_pose 18, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose192:
+ax_pose 37, 0x01e5, 0x90e7, 0x4c00
+ax_pose_terminator
+sCombuskenPose193:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose194:
+ax_pose 20, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sCombuskenPose195:
+ax_pose 38, 0x01e5, 0x90e8, 0x4c00
+ax_pose_terminator
+sCombuskenPose196:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose197:
+ax_pose 22, 0x01e7, 0x90e8, 0x4c00
+ax_pose_terminator
+sCombuskenPose198:
+ax_pose 39, 0x01eb, 0x90e7, 0x4c00
+ax_pose_terminator
+sCombuskenPose199:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose200:
+ax_pose 24, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose201:
+ax_pose 40, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose202:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose203:
+ax_pose 22, 0x01e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose204:
+ax_pose 39, 0x01eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose205:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose206:
+ax_pose 20, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sCombuskenPose207:
+ax_pose 38, 0x01e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose208:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose209:
+ax_pose 18, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose210:
+ax_pose 37, 0x01e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose211:
+ax_pose 36, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose212:
+ax_pose 37, 0x01e4, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose213:
+ax_pose 38, 0x01e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose214:
+ax_pose 39, 0x01ec, 0x80f9, 0x4c00
+ax_pose_terminator
+sCombuskenPose215:
+ax_pose 40, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose216:
+ax_pose 39, 0x01ec, 0x90e7, 0x4c00
+ax_pose_terminator
+sCombuskenPose217:
+ax_pose 38, 0x01e5, 0x90e8, 0x4c00
+ax_pose_terminator
+sCombuskenPose218:
+ax_pose 37, 0x01e4, 0x90e8, 0x4c00
+ax_pose_terminator
+sCombuskenPose219:
+ax_pose 0, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose220:
+ax_pose 3, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose221:
+ax_pose 6, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose222:
+ax_pose 9, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sCombuskenPose223:
+ax_pose 12, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sCombuskenPose224:
+ax_pose 9, 0x81ea, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose225:
+ax_pose 6, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+sCombuskenPose226:
+ax_pose 3, 0x81e5, 0x90f7, 0x4c00
+ax_pose_terminator
+.align 2
+sCombuskenAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 27, 0, 0, 0, 3,
+ax_anim 2, 0, 27, 0, 2, 0, 9,
+ax_anim 2, 2, 27, 0, 8, 0, 15,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sCombuskenAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 31, 2, 0, 2, 2,
+ax_anim 2, 0, 31, 9, 2, 9, 9,
+ax_anim 2, 2, 31, 15, 8, 15, 15,
+ax_anim 2, 0, 31, 21, 21, 21, 21,
+ax_anim 2, 1, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 31, 21, 21, 21, 21,
+ax_anim 2, 0, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 30, 8, 2, 6, 6,
+ax_anim_terminator
+sCombuskenAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 6, 0, 33, -2, 0, -2, 0,
+ax_anim 2, 0, 35, 2, -2, 2, 0,
+ax_anim 2, 0, 35, 6, -5, 9, 0,
+ax_anim 2, 2, 35, 13, -5, 15, 0,
+ax_anim 2, 0, 35, 21, -2, 21, 0,
+ax_anim 2, 1, 35, 21, -3, 21, -1,
+ax_anim 2, 0, 35, 21, -2, 21, 0,
+ax_anim 2, 0, 35, 21, -3, 21, -1,
+ax_anim 2, 0, 34, 8, 0, 6, 0,
+ax_anim_terminator
+sCombuskenAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 2, 0, 39, 2, -2, 2, -2,
+ax_anim 2, 0, 39, 9, -13, 9, -9,
+ax_anim 2, 2, 39, 15, -22, 15, -15,
+ax_anim 2, 0, 39, 21, -23, 21, -21,
+ax_anim 2, 1, 39, 22, -22, 22, -20,
+ax_anim 2, 0, 39, 21, -23, 21, -21,
+ax_anim 2, 0, 39, 22, -22, 22, -20,
+ax_anim 2, 0, 38, 8, -10, 6, -6,
+ax_anim_terminator
+sCombuskenAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 2, 0, 43, 0, -6, 0, -2,
+ax_anim 2, 0, 43, 0, -12, 0, -9,
+ax_anim 2, 2, 43, 0, -18, 0, -15,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 42, 0, -6, 0, -6,
+ax_anim_terminator
+sCombuskenAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 2, 0, 47, -2, -2, -2, -2,
+ax_anim 2, 0, 47, -9, -13, -9, -9,
+ax_anim 2, 2, 47, -15, -22, -15, -15,
+ax_anim 2, 0, 47, -21, -23, -21, -21,
+ax_anim 2, 1, 47, -22, -22, -22, -20,
+ax_anim 2, 0, 47, -21, -23, -21, -21,
+ax_anim 2, 0, 47, -22, -22, -22, -20,
+ax_anim 2, 0, 46, -8, -10, -6, -6,
+ax_anim_terminator
+sCombuskenAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 2, 0, 2, 0,
+ax_anim 2, 0, 51, -2, -2, -2, 0,
+ax_anim 2, 0, 51, -6, -5, -9, 0,
+ax_anim 2, 2, 51, -13, -5, -15, 0,
+ax_anim 2, 0, 51, -21, -2, -21, 0,
+ax_anim 2, 1, 51, -21, -3, -21, -1,
+ax_anim 2, 0, 51, -21, -2, -21, 0,
+ax_anim 2, 0, 51, -21, -3, -21, -1,
+ax_anim 2, 0, 50, -8, 0, -6, 0,
+ax_anim_terminator
+sCombuskenAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 0, 55, -2, 0, -2, 2,
+ax_anim 2, 0, 55, -9, 2, -9, 9,
+ax_anim 2, 2, 55, -15, 8, -15, 15,
+ax_anim 2, 0, 55, -21, 21, -21, 21,
+ax_anim 2, 1, 55, -22, 20, -22, 20,
+ax_anim 2, 0, 55, -21, 21, -21, 21,
+ax_anim 2, 0, 55, -22, 20, -22, 20,
+ax_anim 2, 0, 54, -8, 2, -6, 6,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_3_1:
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 4, 0, 59, 0, -4, 0, -4,
+ax_anim 1, 0, 59, 0, 2, 0, 2,
+ax_anim 1, 0, 59, 0, 9, 0, 9,
+ax_anim 6, 2, 59, 0, 19, 0, 19,
+ax_anim 1, 0, 60, 0, 19, 0, 19,
+ax_anim 1, 1, 61, 0, 12, 0, 19,
+ax_anim 3, 0, 61, 0, 10, 0, 19,
+ax_anim 3, 0, 61, 0, 9, 0, 19,
+ax_anim 3, 0, 61, 0, 12, 0, 19,
+ax_anim 2, 0, 61, 0, 16, 0, 19,
+ax_anim 2, 0, 56, 0, 19, 0, 11,
+ax_anim 2, 0, 57, 0, 6, 0, 6,
+ax_anim_terminator
+sCombuskenAnims_3_2:
+ax_anim 2, 0, 65, -2, -2, -2, -2,
+ax_anim 4, 0, 65, -4, -4, -4, -4,
+ax_anim 1, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 9, 9, 9, 9,
+ax_anim 6, 2, 65, 21, 19, 21, 19,
+ax_anim 1, 0, 66, 21, 19, 21, 19,
+ax_anim 1, 1, 67, 21, 12, 21, 19,
+ax_anim 3, 0, 67, 21, 10, 21, 19,
+ax_anim 3, 0, 67, 21, 9, 21, 19,
+ax_anim 3, 0, 67, 21, 12, 21, 19,
+ax_anim 2, 0, 67, 21, 19, 21, 19,
+ax_anim 2, 0, 62, 11, 11, 11, 11,
+ax_anim 2, 0, 63, 6, 6, 6, 6,
+ax_anim_terminator
+sCombuskenAnims_3_3:
+ax_anim 2, 0, 71, -2, 0, -2, 0,
+ax_anim 4, 0, 71, -4, 0, -4, 0,
+ax_anim 1, 0, 71, 2, 0, 2, 0,
+ax_anim 1, 0, 71, 9, 0, 9, 0,
+ax_anim 6, 2, 71, 20, 0, 20, 0,
+ax_anim 1, 0, 72, 20, 0, 20, 0,
+ax_anim 1, 1, 73, 20, -7, 20, 0,
+ax_anim 3, 0, 73, 20, -9, 20, 0,
+ax_anim 3, 0, 73, 20, -10, 20, 0,
+ax_anim 3, 0, 73, 20, -7, 20, 0,
+ax_anim 2, 0, 73, 20, 0, 20, 0,
+ax_anim 2, 0, 68, 11, 0, 11, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim_terminator
+sCombuskenAnims_3_4:
+ax_anim 2, 0, 77, -2, 2, -2, 2,
+ax_anim 4, 0, 77, -4, 4, -4, 4,
+ax_anim 1, 0, 77, 2, -2, 2, -2,
+ax_anim 1, 0, 77, 9, -9, 9, -9,
+ax_anim 6, 2, 77, 20, -19, 21, -19,
+ax_anim 1, 0, 78, 20, -19, 21, -19,
+ax_anim 1, 1, 79, 20, -26, 21, -19,
+ax_anim 3, 0, 79, 20, -28, 21, -19,
+ax_anim 3, 0, 79, 20, -29, 21, -19,
+ax_anim 3, 0, 79, 20, -26, 21, -19,
+ax_anim 2, 0, 79, 20, -19, 21, -19,
+ax_anim 2, 0, 74, 12, -11, 12, -11,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim_terminator
+sCombuskenAnims_3_5:
+ax_anim 2, 0, 83, 0, 2, 0, 2,
+ax_anim 4, 0, 83, 0, 4, 0, 4,
+ax_anim 1, 0, 83, 0, -2, 0, -2,
+ax_anim 1, 0, 83, 0, -9, 0, -9,
+ax_anim 6, 2, 83, 0, -18, 0, -18,
+ax_anim 1, 0, 84, 0, -18, 0, -18,
+ax_anim 1, 1, 85, 0, -25, 0, -18,
+ax_anim 3, 0, 85, 0, -27, 0, -18,
+ax_anim 3, 0, 85, 0, -28, 0, -18,
+ax_anim 3, 0, 85, 0, -25, 0, -18,
+ax_anim 2, 0, 85, 0, -18, 0, -18,
+ax_anim 2, 0, 80, 0, -11, 0, -11,
+ax_anim 2, 0, 81, 0, -6, 0, -6,
+ax_anim_terminator
+sCombuskenAnims_3_6:
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 4, 0, 89, 4, 4, 4, 4,
+ax_anim 1, 0, 89, -2, -2, -2, -2,
+ax_anim 1, 0, 89, -9, -9, -9, -9,
+ax_anim 6, 2, 89, -20, -19, -21, -19,
+ax_anim 1, 0, 90, -20, -19, -21, -19,
+ax_anim 1, 1, 91, -20, -26, -21, -19,
+ax_anim 3, 0, 91, -20, -28, -21, -19,
+ax_anim 3, 0, 91, -20, -29, -21, -19,
+ax_anim 3, 0, 91, -20, -26, -21, -19,
+ax_anim 2, 0, 91, -20, -19, -21, -19,
+ax_anim 2, 0, 86, -12, -11, -12, -11,
+ax_anim 2, 0, 87, -6, -6, -6, -6,
+ax_anim_terminator
+sCombuskenAnims_3_7:
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 4, 0, 95, 4, 0, 4, 0,
+ax_anim 1, 0, 95, -2, 0, -2, 0,
+ax_anim 1, 0, 95, -9, 0, -9, 0,
+ax_anim 6, 2, 95, -20, 0, -20, 0,
+ax_anim 1, 0, 96, -20, 0, -20, 0,
+ax_anim 1, 1, 97, -20, -7, -20, 0,
+ax_anim 3, 0, 97, -20, -9, -20, 0,
+ax_anim 3, 0, 97, -20, -10, -20, 0,
+ax_anim 3, 0, 97, -20, -7, -20, 0,
+ax_anim 2, 0, 97, -20, 0, -20, 0,
+ax_anim 2, 0, 92, -11, 0, -11, 0,
+ax_anim 2, 0, 93, -6, 0, -6, 0,
+ax_anim_terminator
+sCombuskenAnims_3_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 4, 0, 101, 4, -4, 4, -4,
+ax_anim 1, 0, 101, -2, 2, -2, 2,
+ax_anim 1, 0, 101, -9, 9, -9, 9,
+ax_anim 6, 2, 101, -21, 19, -21, 19,
+ax_anim 1, 0, 102, -21, 19, -21, 19,
+ax_anim 1, 1, 103, -21, 12, -21, 19,
+ax_anim 3, 0, 103, -21, 10, -21, 19,
+ax_anim 3, 0, 103, -21, 9, -21, 19,
+ax_anim 3, 0, 103, -21, 12, -21, 19,
+ax_anim 2, 0, 103, -21, 19, -21, 19,
+ax_anim 2, 0, 98, -11, 11, -11, 11,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sCombuskenAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sCombuskenAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sCombuskenAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sCombuskenAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sCombuskenAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sCombuskenAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sCombuskenAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sCombuskenAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sCombuskenAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sCombuskenAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sCombuskenAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sCombuskenAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sCombuskenAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sCombuskenAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, -2, 0, 0,
+ax_anim 6, 0, 147, 0, -3, 0, 0,
+ax_anim 6, 0, 148, 0, -3, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, -2, 0, 0,
+ax_anim 6, 0, 150, 0, -3, 0, 0,
+ax_anim 6, 0, 151, 0, -3, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, -2, 0, 0,
+ax_anim 6, 0, 153, 0, -3, 0, 0,
+ax_anim 6, 0, 154, 0, -3, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, -2, 0, 0,
+ax_anim 6, 0, 156, 0, -3, 0, 0,
+ax_anim 6, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 6, 0, 159, 0, -3, 0, 0,
+ax_anim 6, 0, 160, 0, -3, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, -2, 0, 0,
+ax_anim 6, 0, 162, 0, -3, 0, 0,
+ax_anim 6, 0, 163, 0, -3, 0, 0,
+ax_anim 4, 0, 163, 0, -2, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 165, 0, -2, 0, 0,
+ax_anim 6, 0, 165, 0, -3, 0, 0,
+ax_anim 6, 0, 166, 0, -3, 0, 0,
+ax_anim 4, 0, 166, 0, -2, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 168, 0, -2, 0, 0,
+ax_anim 6, 0, 168, 0, -3, 0, 0,
+ax_anim 6, 0, 169, 0, -3, 0, 0,
+ax_anim 4, 0, 169, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 17, 7, 17,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -7, 17, -7, 17,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 22, 14, 22, 14,
+ax_anim 3, 0, 173, 21, 21, 21, 21,
+ax_anim 2, 3, 174, 12, 21, 12, 21,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 23, -1, 21, -1,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 13, -20, 13, -20,
+ax_anim 3, 0, 171, 23, -19, 23, -22,
+ax_anim 2, 3, 172, 22, -13, 22, -13,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -17, -7, -19,
+ax_anim 3, 0, 170, 0, -20, 0, -23,
+ax_anim 2, 3, 171, 7, -17, 7, -19,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -13, -20, -12, -22,
+ax_anim 3, 0, 177, -23, -19, -18, -22,
+ax_anim 2, 3, 176, -22, -13, -20, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -16, -5,
+ax_anim 3, 0, 176, -23, -1, -18, -2,
+ax_anim 2, 3, 175, -18, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -22, 14, -19, 10,
+ax_anim 3, 0, 175, -21, 21, -17, 19,
+ax_anim 2, 3, 174, -12, 21, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -7, 0, 0,
+ax_anim 2, 0, 187, 0, -13, 0, 0,
+ax_anim 3, 0, 187, 0, -17, 0, 0,
+ax_anim 4, 0, 187, 0, -18, 0, 0,
+ax_anim 4, 0, 186, 1, -22, 0, 0,
+ax_anim 3, 0, 188, 1, -23, 0, 0,
+ax_anim 2, 0, 188, 1, -18, 0, 0,
+ax_anim 1, 0, 188, 1, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -7, 0, 0,
+ax_anim 2, 0, 190, 0, -13, 0, 0,
+ax_anim 3, 0, 190, 0, -17, 0, 0,
+ax_anim 4, 0, 190, 0, -19, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, -1, -23, 0, 0,
+ax_anim 2, 0, 191, -1, -18, 0, 0,
+ax_anim 1, 0, 191, -1, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -7, 0, 0,
+ax_anim 2, 0, 193, 0, -13, 0, 0,
+ax_anim 3, 0, 193, 0, -17, 0, 0,
+ax_anim 4, 0, 193, 0, -18, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -7, 0, 0,
+ax_anim 2, 0, 196, 0, -13, 0, 0,
+ax_anim 3, 0, 196, 0, -17, 0, 0,
+ax_anim 4, 0, 196, 0, -18, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 1, -7, 0, 0,
+ax_anim 2, 0, 199, 1, -13, 0, 0,
+ax_anim 3, 0, 199, 1, -17, 0, 0,
+ax_anim 4, 0, 199, 1, -18, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 2, 0, 200, 0, -17, 0, 0,
+ax_anim 1, 0, 200, 0, -11, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -7, 0, 0,
+ax_anim 2, 0, 202, 0, -13, 0, 0,
+ax_anim 3, 0, 202, 0, -17, 0, 0,
+ax_anim 4, 0, 202, 0, -18, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -7, 0, 0,
+ax_anim 2, 0, 205, 0, -13, 0, 0,
+ax_anim 3, 0, 205, 0, -17, 0, 0,
+ax_anim 4, 0, 205, 0, -18, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -7, 0, 0,
+ax_anim 2, 0, 208, 0, -13, 0, 0,
+ax_anim 3, 0, 208, 0, -17, 0, 0,
+ax_anim 4, 0, 208, 0, -19, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 1, -23, 0, 0,
+ax_anim 2, 0, 209, 1, -18, 0, 0,
+ax_anim 1, 0, 209, 1, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCombuskenAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sCombuskenGfx1:
+.incbin "baserom.gba", 0x1081F68, 0x200
+sCombuskenSprites1:
+ax_sprite sCombuskenGfx1, 0x200
+ax_sprite_terminator
+sCombuskenGfx2:
+.incbin "baserom.gba", 0x1082178, 0x200
+sCombuskenSprites2:
+ax_sprite sCombuskenGfx2, 0x200
+ax_sprite_terminator
+sCombuskenGfx3:
+.incbin "baserom.gba", 0x1082388, 0x200
+sCombuskenSprites3:
+ax_sprite sCombuskenGfx3, 0x200
+ax_sprite_terminator
+sCombuskenGfx4:
+.incbin "baserom.gba", 0x1082598, 0x100
+sCombuskenSprites4:
+ax_sprite sCombuskenGfx4, 0x100
+ax_sprite_terminator
+sCombuskenGfx5:
+.incbin "baserom.gba", 0x10826A8, 0x200
+sCombuskenSprites5:
+ax_sprite sCombuskenGfx5, 0x200
+ax_sprite_terminator
+sCombuskenGfx6:
+.incbin "baserom.gba", 0x10828B8, 0x100
+sCombuskenSprites6:
+ax_sprite sCombuskenGfx6, 0x100
+ax_sprite_terminator
+sCombuskenGfx7:
+.incbin "baserom.gba", 0x10829C8, 0x100
+sCombuskenSprites7:
+ax_sprite sCombuskenGfx7, 0x100
+ax_sprite_terminator
+sCombuskenGfx8:
+.incbin "baserom.gba", 0x1082AD8, 0x200
+sCombuskenSprites8:
+ax_sprite sCombuskenGfx8, 0x200
+ax_sprite_terminator
+sCombuskenGfx9:
+.incbin "baserom.gba", 0x1082CE8, 0x200
+sCombuskenSprites9:
+ax_sprite sCombuskenGfx9, 0x200
+ax_sprite_terminator
+sCombuskenGfx10:
+.incbin "baserom.gba", 0x1082EF8, 0x100
+sCombuskenSprites10:
+ax_sprite sCombuskenGfx10, 0x100
+ax_sprite_terminator
+sCombuskenGfx11:
+.incbin "baserom.gba", 0x1083008, 0x200
+sCombuskenSprites11:
+ax_sprite sCombuskenGfx11, 0x200
+ax_sprite_terminator
+sCombuskenGfx12:
+.incbin "baserom.gba", 0x1083218, 0x200
+sCombuskenSprites12:
+ax_sprite sCombuskenGfx12, 0x200
+ax_sprite_terminator
+sCombuskenGfx13:
+.incbin "baserom.gba", 0x1083428, 0x200
+sCombuskenSprites13:
+ax_sprite sCombuskenGfx13, 0x200
+ax_sprite_terminator
+sCombuskenGfx14:
+.incbin "baserom.gba", 0x1083638, 0x200
+sCombuskenSprites14:
+ax_sprite sCombuskenGfx14, 0x200
+ax_sprite_terminator
+sCombuskenGfx15:
+.incbin "baserom.gba", 0x1083848, 0x200
+sCombuskenSprites15:
+ax_sprite sCombuskenGfx15, 0x200
+ax_sprite_terminator
+sCombuskenGfx16:
+.incbin "baserom.gba", 0x1083A58, 0x40
+sCombuskenGfx16_1:
+.incbin "baserom.gba", 0x1083A98, 0x60
+sCombuskenGfx16_2:
+.incbin "baserom.gba", 0x1083AF8, 0x60
+sCombuskenSprites16:
+ax_sprite sCombuskenGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCombuskenGfx17:
+.incbin "baserom.gba", 0x1083B90, 0x100
+sCombuskenSprites17:
+ax_sprite sCombuskenGfx17, 0x100
+ax_sprite_terminator
+sCombuskenGfx18:
+.incbin "baserom.gba", 0x1083CA0, 0x100
+sCombuskenSprites18:
+ax_sprite sCombuskenGfx18, 0x100
+ax_sprite_terminator
+sCombuskenGfx19:
+.incbin "baserom.gba", 0x1083DB0, 0x100
+sCombuskenSprites19:
+ax_sprite sCombuskenGfx19, 0x100
+ax_sprite_terminator
+sCombuskenGfx20:
+.incbin "baserom.gba", 0x1083EC0, 0x20
+sCombuskenGfx20_1:
+.incbin "baserom.gba", 0x1083EE0, 0x60
+sCombuskenGfx20_2:
+.incbin "baserom.gba", 0x1083F40, 0x60
+sCombuskenGfx20_3:
+.incbin "baserom.gba", 0x1083FA0, 0x60
+sCombuskenSprites20:
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCombuskenGfx21:
+.incbin "baserom.gba", 0x1084050, 0x60
+sCombuskenGfx21_1:
+.incbin "baserom.gba", 0x10840B0, 0x60
+sCombuskenGfx21_2:
+.incbin "baserom.gba", 0x1084110, 0x60
+sCombuskenGfx21_3:
+.incbin "baserom.gba", 0x1084170, 0x20
+sCombuskenSprites21:
+ax_sprite sCombuskenGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCombuskenGfx22:
+.incbin "baserom.gba", 0x10841D8, 0x40
+sCombuskenGfx22_1:
+.incbin "baserom.gba", 0x1084218, 0x60
+sCombuskenGfx22_2:
+.incbin "baserom.gba", 0x1084278, 0x60
+sCombuskenSprites22:
+ax_sprite sCombuskenGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCombuskenGfx23:
+.incbin "baserom.gba", 0x1084310, 0x40
+sCombuskenGfx23_1:
+.incbin "baserom.gba", 0x1084350, 0x40
+sCombuskenGfx23_2:
+.incbin "baserom.gba", 0x1084390, 0x60
+sCombuskenGfx23_3:
+.incbin "baserom.gba", 0x10843F0, 0x40
+sCombuskenSprites23:
+ax_sprite sCombuskenGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx23_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCombuskenGfx24:
+.incbin "baserom.gba", 0x1084478, 0x60
+sCombuskenGfx24_1:
+.incbin "baserom.gba", 0x10844D8, 0x60
+sCombuskenGfx24_2:
+.incbin "baserom.gba", 0x1084538, 0x60
+sCombuskenGfx24_3:
+.incbin "baserom.gba", 0x1084598, 0x40
+sCombuskenSprites24:
+ax_sprite sCombuskenGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCombuskenGfx25:
+.incbin "baserom.gba", 0x1084620, 0x40
+sCombuskenGfx25_1:
+.incbin "baserom.gba", 0x1084660, 0x60
+sCombuskenGfx25_2:
+.incbin "baserom.gba", 0x10846C0, 0x60
+sCombuskenGfx25_3:
+.incbin "baserom.gba", 0x1084720, 0x40
+sCombuskenSprites25:
+ax_sprite sCombuskenGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx25_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCombuskenGfx26:
+.incbin "baserom.gba", 0x10847A8, 0x100
+sCombuskenSprites26:
+ax_sprite sCombuskenGfx26, 0x100
+ax_sprite_terminator
+sCombuskenGfx27:
+.incbin "baserom.gba", 0x10848B8, 0x100
+sCombuskenSprites27:
+ax_sprite sCombuskenGfx27, 0x100
+ax_sprite_terminator
+sCombuskenGfx28:
+.incbin "baserom.gba", 0x10849C8, 0xA0
+sCombuskenGfx28_1:
+.incbin "baserom.gba", 0x1084A68, 0x40
+sCombuskenSprites28:
+ax_sprite sCombuskenGfx28, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx28_1, 0x40
+ax_sprite_terminator
+sCombuskenGfx29:
+.incbin "baserom.gba", 0x1084AC8, 0x40
+sCombuskenGfx29_1:
+.incbin "baserom.gba", 0x1084B08, 0x60
+sCombuskenGfx29_2:
+.incbin "baserom.gba", 0x1084B68, 0x60
+sCombuskenGfx29_3:
+.incbin "baserom.gba", 0x1084BC8, 0x40
+sCombuskenSprites29:
+ax_sprite sCombuskenGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx29_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCombuskenGfx30:
+.incbin "baserom.gba", 0x1084C50, 0xA0
+sCombuskenGfx30_1:
+.incbin "baserom.gba", 0x1084CF0, 0x20
+sCombuskenSprites30:
+ax_sprite sCombuskenGfx30, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx30_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCombuskenGfx31:
+.incbin "baserom.gba", 0x1084D38, 0x40
+sCombuskenGfx31_1:
+.incbin "baserom.gba", 0x1084D78, 0x40
+sCombuskenGfx31_2:
+.incbin "baserom.gba", 0x1084DB8, 0x40
+sCombuskenGfx31_3:
+.incbin "baserom.gba", 0x1084DF8, 0x40
+sCombuskenSprites31:
+ax_sprite sCombuskenGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCombuskenGfx32:
+.incbin "baserom.gba", 0x1084E80, 0xA0
+sCombuskenGfx32_1:
+.incbin "baserom.gba", 0x1084F20, 0x40
+sCombuskenSprites32:
+ax_sprite sCombuskenGfx32, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx32_1, 0x40
+ax_sprite_terminator
+sCombuskenGfx33:
+.incbin "baserom.gba", 0x1084F80, 0x100
+sCombuskenSprites33:
+ax_sprite sCombuskenGfx33, 0x100
+ax_sprite_terminator
+sCombuskenGfx34:
+.incbin "baserom.gba", 0x1085090, 0x40
+sCombuskenGfx34_1:
+.incbin "baserom.gba", 0x10850D0, 0x60
+sCombuskenGfx34_2:
+.incbin "baserom.gba", 0x1085130, 0x60
+sCombuskenSprites34:
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCombuskenGfx35:
+.incbin "baserom.gba", 0x10851D0, 0xC0
+sCombuskenGfx35_1:
+.incbin "baserom.gba", 0x1085290, 0x20
+sCombuskenSprites35:
+ax_sprite sCombuskenGfx35, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx35_1, 0x20
+ax_sprite_terminator
+sCombuskenGfx36:
+.incbin "baserom.gba", 0x10852D0, 0x40
+sCombuskenGfx36_1:
+.incbin "baserom.gba", 0x1085310, 0x40
+sCombuskenGfx36_2:
+.incbin "baserom.gba", 0x1085350, 0x60
+sCombuskenGfx36_3:
+.incbin "baserom.gba", 0x10853B0, 0x60
+sCombuskenSprites36:
+ax_sprite sCombuskenGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx36_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx36_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCombuskenGfx37:
+.incbin "baserom.gba", 0x1085458, 0x20
+sCombuskenGfx37_1:
+.incbin "baserom.gba", 0x1085478, 0x60
+sCombuskenGfx37_2:
+.incbin "baserom.gba", 0x10854D8, 0x60
+sCombuskenGfx37_3:
+.incbin "baserom.gba", 0x1085538, 0x40
+sCombuskenSprites37:
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx37, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx37_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCombuskenGfx38:
+.incbin "baserom.gba", 0x10855C8, 0x60
+sCombuskenGfx38_1:
+.incbin "baserom.gba", 0x1085628, 0x60
+sCombuskenGfx38_2:
+.incbin "baserom.gba", 0x1085688, 0x40
+sCombuskenSprites38:
+ax_sprite 0, 0x80
+ax_sprite sCombuskenGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCombuskenGfx39:
+.incbin "baserom.gba", 0x1085708, 0x40
+sCombuskenGfx39_1:
+.incbin "baserom.gba", 0x1085748, 0x40
+sCombuskenGfx39_2:
+.incbin "baserom.gba", 0x1085788, 0x60
+sCombuskenGfx39_3:
+.incbin "baserom.gba", 0x10857E8, 0x60
+sCombuskenSprites39:
+ax_sprite sCombuskenGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCombuskenGfx40:
+.incbin "baserom.gba", 0x1085890, 0x40
+sCombuskenGfx40_1:
+.incbin "baserom.gba", 0x10858D0, 0x60
+sCombuskenGfx40_2:
+.incbin "baserom.gba", 0x1085930, 0x40
+sCombuskenSprites40:
+ax_sprite sCombuskenGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCombuskenGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx40_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sCombuskenGfx41:
+.incbin "baserom.gba", 0x10859A8, 0x60
+sCombuskenGfx41_1:
+.incbin "baserom.gba", 0x1085A08, 0x60
+sCombuskenGfx41_2:
+.incbin "baserom.gba", 0x1085A68, 0x60
+sCombuskenSprites41:
+ax_sprite sCombuskenGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCombuskenGfx41_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCombuskenGfx42:
+.incbin "baserom.gba", 0x1085B00, 0x200
+sCombuskenSprites42:
+ax_sprite sCombuskenGfx42, 0x200
+ax_sprite_terminator
+sCombuskenGfx43:
+.incbin "baserom.gba", 0x1085D10, 0x200
+sCombuskenSprites43:
+ax_sprite sCombuskenGfx43, 0x200
+ax_sprite_terminator
+sCombuskenGfx44:
+.incbin "baserom.gba", 0x1085F20, 0x200
+sCombuskenSprites44:
+ax_sprite sCombuskenGfx44, 0x200
+ax_sprite_terminator
+sCombuskenGfx45:
+.incbin "baserom.gba", 0x1086130, 0x200
+sCombuskenSprites45:
+ax_sprite sCombuskenGfx45, 0x200
+ax_sprite_terminator
+sCombuskenGfx46:
+.incbin "baserom.gba", 0x1086340, 0x200
+sCombuskenSprites46:
+ax_sprite sCombuskenGfx46, 0x200
+ax_sprite_terminator
+sCombuskenGfx47:
+.incbin "baserom.gba", 0x1086550, 0x200
+sCombuskenSprites47:
+ax_sprite sCombuskenGfx47, 0x200
+ax_sprite_terminator
+sCombuskenGfx48:
+.incbin "baserom.gba", 0x1086760, 0x200
+sCombuskenSprites48:
+ax_sprite sCombuskenGfx48, 0x200
+ax_sprite_terminator
+sCombuskenGfx49:
+.incbin "baserom.gba", 0x1086970, 0x200
+sCombuskenSprites49:
+ax_sprite sCombuskenGfx49, 0x200
+ax_sprite_terminator
+sCombuskenGfx50:
+.incbin "baserom.gba", 0x1086B80, 0x200
+sCombuskenSprites50:
+ax_sprite sCombuskenGfx50, 0x200
+ax_sprite_terminator
+sCombuskenGfx51:
+.incbin "baserom.gba", 0x1086D90, 0x200
+sCombuskenSprites51:
+ax_sprite sCombuskenGfx51, 0x200
+ax_sprite_terminator
+sCombuskenGfx52:
+.incbin "baserom.gba", 0x1086FA0, 0x100
+sCombuskenSprites52:
+ax_sprite sCombuskenGfx52, 0x100
+ax_sprite_terminator
+sCombuskenGfx53:
+.incbin "baserom.gba", 0x10870B0, 0x200
+sCombuskenSprites53:
+ax_sprite sCombuskenGfx53, 0x200
+ax_sprite_terminator
+sAxPosesCombusken:
+.4byte sCombuskenPose1
+.4byte sCombuskenPose2
+.4byte sCombuskenPose3
+.4byte sCombuskenPose4
+.4byte sCombuskenPose5
+.4byte sCombuskenPose6
+.4byte sCombuskenPose7
+.4byte sCombuskenPose8
+.4byte sCombuskenPose9
+.4byte sCombuskenPose10
+.4byte sCombuskenPose11
+.4byte sCombuskenPose12
+.4byte sCombuskenPose13
+.4byte sCombuskenPose14
+.4byte sCombuskenPose15
+.4byte sCombuskenPose16
+.4byte sCombuskenPose17
+.4byte sCombuskenPose18
+.4byte sCombuskenPose19
+.4byte sCombuskenPose20
+.4byte sCombuskenPose21
+.4byte sCombuskenPose22
+.4byte sCombuskenPose23
+.4byte sCombuskenPose24
+.4byte sCombuskenPose25
+.4byte sCombuskenPose26
+.4byte sCombuskenPose27
+.4byte sCombuskenPose28
+.4byte sCombuskenPose29
+.4byte sCombuskenPose30
+.4byte sCombuskenPose31
+.4byte sCombuskenPose32
+.4byte sCombuskenPose33
+.4byte sCombuskenPose34
+.4byte sCombuskenPose35
+.4byte sCombuskenPose36
+.4byte sCombuskenPose37
+.4byte sCombuskenPose38
+.4byte sCombuskenPose39
+.4byte sCombuskenPose40
+.4byte sCombuskenPose41
+.4byte sCombuskenPose42
+.4byte sCombuskenPose43
+.4byte sCombuskenPose44
+.4byte sCombuskenPose45
+.4byte sCombuskenPose46
+.4byte sCombuskenPose47
+.4byte sCombuskenPose48
+.4byte sCombuskenPose49
+.4byte sCombuskenPose50
+.4byte sCombuskenPose51
+.4byte sCombuskenPose52
+.4byte sCombuskenPose53
+.4byte sCombuskenPose54
+.4byte sCombuskenPose55
+.4byte sCombuskenPose56
+.4byte sCombuskenPose57
+.4byte sCombuskenPose58
+.4byte sCombuskenPose59
+.4byte sCombuskenPose60
+.4byte sCombuskenPose61
+.4byte sCombuskenPose62
+.4byte sCombuskenPose63
+.4byte sCombuskenPose64
+.4byte sCombuskenPose65
+.4byte sCombuskenPose66
+.4byte sCombuskenPose67
+.4byte sCombuskenPose68
+.4byte sCombuskenPose69
+.4byte sCombuskenPose70
+.4byte sCombuskenPose71
+.4byte sCombuskenPose72
+.4byte sCombuskenPose73
+.4byte sCombuskenPose74
+.4byte sCombuskenPose75
+.4byte sCombuskenPose76
+.4byte sCombuskenPose77
+.4byte sCombuskenPose78
+.4byte sCombuskenPose79
+.4byte sCombuskenPose80
+.4byte sCombuskenPose81
+.4byte sCombuskenPose82
+.4byte sCombuskenPose83
+.4byte sCombuskenPose84
+.4byte sCombuskenPose85
+.4byte sCombuskenPose86
+.4byte sCombuskenPose87
+.4byte sCombuskenPose88
+.4byte sCombuskenPose89
+.4byte sCombuskenPose90
+.4byte sCombuskenPose91
+.4byte sCombuskenPose92
+.4byte sCombuskenPose93
+.4byte sCombuskenPose94
+.4byte sCombuskenPose95
+.4byte sCombuskenPose96
+.4byte sCombuskenPose97
+.4byte sCombuskenPose98
+.4byte sCombuskenPose99
+.4byte sCombuskenPose100
+.4byte sCombuskenPose101
+.4byte sCombuskenPose102
+.4byte sCombuskenPose103
+.4byte sCombuskenPose104
+.4byte sCombuskenPose105
+.4byte sCombuskenPose106
+.4byte sCombuskenPose107
+.4byte sCombuskenPose108
+.4byte sCombuskenPose109
+.4byte sCombuskenPose110
+.4byte sCombuskenPose111
+.4byte sCombuskenPose112
+.4byte sCombuskenPose113
+.4byte sCombuskenPose114
+.4byte sCombuskenPose115
+.4byte sCombuskenPose116
+.4byte sCombuskenPose117
+.4byte sCombuskenPose118
+.4byte sCombuskenPose119
+.4byte sCombuskenPose120
+.4byte sCombuskenPose121
+.4byte sCombuskenPose122
+.4byte sCombuskenPose123
+.4byte sCombuskenPose124
+.4byte sCombuskenPose125
+.4byte sCombuskenPose126
+.4byte sCombuskenPose127
+.4byte sCombuskenPose128
+.4byte sCombuskenPose129
+.4byte sCombuskenPose130
+.4byte sCombuskenPose131
+.4byte sCombuskenPose132
+.4byte sCombuskenPose133
+.4byte sCombuskenPose134
+.4byte sCombuskenPose135
+.4byte sCombuskenPose136
+.4byte sCombuskenPose137
+.4byte sCombuskenPose138
+.4byte sCombuskenPose139
+.4byte sCombuskenPose140
+.4byte sCombuskenPose141
+.4byte sCombuskenPose142
+.4byte sCombuskenPose143
+.4byte sCombuskenPose144
+.4byte sCombuskenPose145
+.4byte sCombuskenPose146
+.4byte sCombuskenPose147
+.4byte sCombuskenPose148
+.4byte sCombuskenPose149
+.4byte sCombuskenPose150
+.4byte sCombuskenPose151
+.4byte sCombuskenPose152
+.4byte sCombuskenPose153
+.4byte sCombuskenPose154
+.4byte sCombuskenPose155
+.4byte sCombuskenPose156
+.4byte sCombuskenPose157
+.4byte sCombuskenPose158
+.4byte sCombuskenPose159
+.4byte sCombuskenPose160
+.4byte sCombuskenPose161
+.4byte sCombuskenPose162
+.4byte sCombuskenPose163
+.4byte sCombuskenPose164
+.4byte sCombuskenPose165
+.4byte sCombuskenPose166
+.4byte sCombuskenPose167
+.4byte sCombuskenPose168
+.4byte sCombuskenPose169
+.4byte sCombuskenPose170
+.4byte sCombuskenPose171
+.4byte sCombuskenPose172
+.4byte sCombuskenPose173
+.4byte sCombuskenPose174
+.4byte sCombuskenPose175
+.4byte sCombuskenPose176
+.4byte sCombuskenPose177
+.4byte sCombuskenPose178
+.4byte sCombuskenPose179
+.4byte sCombuskenPose180
+.4byte sCombuskenPose181
+.4byte sCombuskenPose182
+.4byte sCombuskenPose183
+.4byte sCombuskenPose184
+.4byte sCombuskenPose185
+.4byte sCombuskenPose186
+.4byte sCombuskenPose187
+.4byte sCombuskenPose188
+.4byte sCombuskenPose189
+.4byte sCombuskenPose190
+.4byte sCombuskenPose191
+.4byte sCombuskenPose192
+.4byte sCombuskenPose193
+.4byte sCombuskenPose194
+.4byte sCombuskenPose195
+.4byte sCombuskenPose196
+.4byte sCombuskenPose197
+.4byte sCombuskenPose198
+.4byte sCombuskenPose199
+.4byte sCombuskenPose200
+.4byte sCombuskenPose201
+.4byte sCombuskenPose202
+.4byte sCombuskenPose203
+.4byte sCombuskenPose204
+.4byte sCombuskenPose205
+.4byte sCombuskenPose206
+.4byte sCombuskenPose207
+.4byte sCombuskenPose208
+.4byte sCombuskenPose209
+.4byte sCombuskenPose210
+.4byte sCombuskenPose211
+.4byte sCombuskenPose212
+.4byte sCombuskenPose213
+.4byte sCombuskenPose214
+.4byte sCombuskenPose215
+.4byte sCombuskenPose216
+.4byte sCombuskenPose217
+.4byte sCombuskenPose218
+.4byte sCombuskenPose219
+.4byte sCombuskenPose220
+.4byte sCombuskenPose221
+.4byte sCombuskenPose222
+.4byte sCombuskenPose223
+.4byte sCombuskenPose224
+.4byte sCombuskenPose225
+.4byte sCombuskenPose226
+sAxPositionsCombusken:
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -3, 	   7,   -7, 	  -1,   -8
+.2byte   -1,  -11, 	  -9,   -7, 	   3,   -3, 	  -1,   -8
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+.2byte    1,  -11, 	   7,   -6, 	  -9,   -6, 	   0,   -8
+.2byte    1,  -11, 	  -2,   -5, 	   0,   -3, 	   0,   -8
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    2,  -11, 	   6,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte    2,  -11, 	  -6,   -5, 	   4,   -3, 	   0,   -8
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    2,  -12, 	   0,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte    2,  -12, 	  -8,   -5, 	   6,   -5, 	  -2,   -7
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -8,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	   6,   -1, 	  -8,   -8, 	  -1,   -7
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -4,  -12, 	  -2,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte   -4,  -12, 	   6,   -5, 	  -8,   -5, 	   0,   -7
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -4,  -11, 	  -8,   -5, 	   5,   -3, 	  -1,   -7
+.2byte   -4,  -11, 	   4,   -5, 	  -6,   -3, 	  -2,   -8
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -3,  -11, 	  -9,   -6, 	   7,   -6, 	  -2,   -8
+.2byte   -3,  -11, 	   0,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte   -2,  -10, 	  -9,  -10, 	   3,   -3, 	  -2,   -6
+.2byte   -1,  -11, 	  -9,   -7, 	   3,   -3, 	  -1,   -8
+.2byte    0,  -14, 	  -3,  -17, 	   4,  -10, 	   0,  -10
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+.2byte    3,   -9, 	  -6,  -12, 	   3,   -2, 	  -2,   -6
+.2byte    1,  -11, 	  -2,   -5, 	   0,   -3, 	   0,   -8
+.2byte    0,  -13, 	   2,  -17, 	  -2,   -9, 	  -1,   -9
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    4,  -11, 	  -8,  -10, 	   7,   -7, 	  -1,   -8
+.2byte    2,  -11, 	  -6,   -5, 	   4,   -3, 	   0,   -8
+.2byte    0,  -14, 	   4,  -20, 	   1,  -10, 	   0,  -10
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    4,  -11, 	  -7,   -8, 	   7,   -9, 	   0,   -7
+.2byte    2,  -12, 	  -8,   -5, 	   6,   -5, 	  -2,   -7
+.2byte    1,  -15, 	   1,  -19, 	   4,  -12, 	  -2,  -11
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte    0,  -12, 	   6,   -5, 	  -6,  -14, 	  -1,   -8
+.2byte   -1,  -11, 	   6,   -1, 	  -8,   -8, 	  -1,   -7
+.2byte   -2,  -14, 	   2,  -15, 	  -8,  -12, 	  -2,  -11
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -5,  -11, 	   6,   -8, 	  -8,   -9, 	  -1,   -7
+.2byte   -4,  -12, 	   6,   -5, 	  -8,   -5, 	   0,   -7
+.2byte   -2,  -15, 	  -2,  -19, 	  -5,  -12, 	   1,  -11
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -7,  -11, 	   5,  -10, 	 -10,   -7, 	  -2,   -8
+.2byte   -4,  -11, 	   4,   -5, 	  -6,   -3, 	  -2,   -8
+.2byte   -1,  -14, 	  -5,  -20, 	  -2,  -10, 	  -1,  -10
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -5,   -9, 	   4,  -12, 	  -5,   -2, 	   0,   -6
+.2byte   -3,  -11, 	   0,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte   -1,  -13, 	  -3,  -17, 	   1,   -9, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -3, 	   7,   -7, 	  -1,   -8
+.2byte   -1,  -11, 	  -9,   -7, 	   3,   -3, 	  -1,   -8
+.2byte   -5,   -9, 	   4,  -12, 	  -5,   -2, 	   0,   -6
+.2byte    1,  -12, 	  -4,  -19, 	   6,   -7, 	   0,   -7
+.2byte    1,  -12, 	  -4,  -19, 	   6,   -7, 	   0,   -7
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+.2byte    1,  -11, 	   7,   -6, 	  -9,   -6, 	   0,   -8
+.2byte    1,  -11, 	  -2,   -5, 	   0,   -3, 	   0,   -8
+.2byte    6,  -11, 	  -6,  -10, 	   9,   -7, 	   1,   -8
+.2byte    0,  -16, 	   4,  -23, 	  -8,  -11, 	  -2,  -11
+.2byte    0,  -16, 	   4,  -23, 	  -8,  -11, 	  -2,  -11
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    2,  -11, 	   6,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte    2,  -11, 	  -6,   -5, 	   4,   -3, 	   0,   -8
+.2byte    4,  -12, 	  -7,   -9, 	   7,  -10, 	   0,   -8
+.2byte    4,  -16, 	   6,  -24, 	  -3,  -10, 	   2,  -11
+.2byte    4,  -16, 	   6,  -24, 	  -3,  -10, 	   2,  -11
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    2,  -12, 	   0,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte    2,  -12, 	  -8,   -5, 	   6,   -5, 	  -2,   -7
+.2byte   -1,  -13, 	  -7,   -6, 	   5,  -15, 	   0,   -9
+.2byte    2,  -16, 	   3,  -24, 	   0,   -8, 	  -1,  -10
+.2byte    2,  -16, 	   3,  -24, 	   0,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -8,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	   6,   -1, 	  -8,   -8, 	  -1,   -7
+.2byte    3,  -11, 	   4,   -6, 	   2,  -11, 	  -2,   -8
+.2byte   -3,  -16, 	   0,  -23, 	  -9,   -9, 	  -2,  -12
+.2byte   -3,  -16, 	   0,  -23, 	  -9,   -9, 	  -2,  -12
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -4,  -12, 	  -2,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte   -4,  -12, 	   6,   -5, 	  -8,   -5, 	   0,   -7
+.2byte   -1,  -13, 	   5,   -6, 	  -7,  -15, 	  -2,   -9
+.2byte   -4,  -16, 	  -5,  -24, 	  -2,   -8, 	  -1,  -10
+.2byte   -4,  -16, 	  -5,  -24, 	  -2,   -8, 	  -1,  -10
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -4,  -11, 	  -8,   -5, 	   5,   -3, 	  -1,   -7
+.2byte   -4,  -11, 	   4,   -5, 	  -6,   -3, 	  -2,   -8
+.2byte   -6,  -12, 	   5,   -9, 	  -9,  -10, 	  -2,   -8
+.2byte   -6,  -16, 	  -8,  -24, 	   1,  -10, 	  -4,  -11
+.2byte   -6,  -16, 	  -8,  -24, 	   1,  -10, 	  -4,  -11
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -3,  -11, 	  -9,   -6, 	   7,   -6, 	  -2,   -8
+.2byte   -3,  -11, 	   0,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte   -8,  -11, 	   4,  -10, 	 -11,   -7, 	  -3,   -8
+.2byte   -1,  -16, 	  -5,  -23, 	   7,  -11, 	   1,  -11
+.2byte   -1,  -16, 	  -5,  -23, 	   7,  -11, 	   1,  -11
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte    0,  -14, 	  -3,  -17, 	   4,  -10, 	   0,  -10
+.2byte   -1,   -9, 	  -8,  -14, 	   6,  -14, 	  -1,   -6
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+.2byte   -1,  -13, 	   1,  -17, 	  -3,   -9, 	  -2,   -9
+.2byte    4,   -8, 	  -3,  -14, 	  -8,  -10, 	   0,   -5
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    0,  -14, 	   4,  -20, 	   1,  -10, 	   0,  -10
+.2byte    6,  -11, 	  -5,  -12, 	  -6,   -8, 	   1,   -7
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    1,  -15, 	   1,  -19, 	   4,  -12, 	  -2,  -11
+.2byte    3,  -13, 	  -9,   -9, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte   -2,  -14, 	   2,  -15, 	  -8,  -12, 	  -2,  -11
+.2byte   -1,  -14, 	   6,   -4, 	  -8,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -2,  -15, 	  -2,  -19, 	  -5,  -12, 	   1,  -11
+.2byte   -4,  -13, 	   8,   -9, 	   0,   -4, 	   1,   -9
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -1,  -14, 	  -5,  -20, 	  -2,  -10, 	  -1,  -10
+.2byte   -7,  -11, 	   4,  -12, 	   5,   -8, 	  -2,   -7
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -1,  -13, 	  -3,  -17, 	   1,   -9, 	   0,   -9
+.2byte   -5,   -8, 	   2,  -14, 	   7,  -10, 	  -1,   -5
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+.2byte    2,  -11, 	   2,   -4, 	  -3,   -8, 	  -1,   -6
+.2byte    1,  -10, 	   2,   -4, 	  -3,   -9, 	  -1,   -7
+.2byte    0,  -12, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte   -5,  -16, 	  -1,  -15, 	 -13,   -8, 	  -4,  -10
+.2byte   -5,  -12, 	  -2,  -17, 	 -10,   -7, 	  -5,   -9
+.2byte   -1,   -9, 	  -5,  -12, 	   5,   -9, 	  -4,   -5
+.2byte    0,   -7, 	   9,   -6, 	  -9,   -6, 	   0,   -4
+.2byte   -1,   -9, 	   3,  -12, 	  -7,   -9, 	   2,   -5
+.2byte    3,  -12, 	   0,  -17, 	   8,   -7, 	   3,   -9
+.2byte    3,  -16, 	  -1,  -15, 	  11,   -8, 	   2,  -10
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -3, 	   7,   -7, 	  -1,   -8
+.2byte   -1,  -11, 	  -9,   -7, 	   3,   -3, 	  -1,   -8
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+.2byte    1,  -11, 	   7,   -6, 	  -9,   -6, 	   0,   -8
+.2byte    1,  -11, 	  -2,   -5, 	   0,   -3, 	   0,   -8
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    2,  -11, 	   6,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte    2,  -11, 	  -6,   -5, 	   4,   -3, 	   0,   -8
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    2,  -12, 	   0,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte    2,  -12, 	  -8,   -5, 	   6,   -5, 	  -2,   -7
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -8,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	   6,   -1, 	  -8,   -8, 	  -1,   -7
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -4,  -12, 	  -2,   -6, 	  -1,   -1, 	  -1,   -8
+.2byte   -4,  -12, 	   6,   -5, 	  -8,   -5, 	   0,   -7
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -4,  -11, 	  -8,   -5, 	   5,   -3, 	  -1,   -7
+.2byte   -4,  -11, 	   4,   -5, 	  -6,   -3, 	  -2,   -8
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -3,  -11, 	  -9,   -6, 	   7,   -6, 	  -2,   -8
+.2byte   -3,  -11, 	   0,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte    0,  -12, 	  -3,  -15, 	   4,   -8, 	   0,   -8
+.2byte   -3,  -12, 	  -5,  -16, 	  -1,   -8, 	  -2,   -8
+.2byte   -2,  -13, 	  -6,  -19, 	  -3,   -9, 	  -2,   -9
+.2byte   -3,  -14, 	  -3,  -18, 	  -6,  -11, 	   0,  -10
+.2byte    0,  -14, 	   4,  -15, 	  -6,  -12, 	   0,  -11
+.2byte    2,  -14, 	   2,  -18, 	   5,  -11, 	  -1,  -10
+.2byte    0,  -13, 	   4,  -19, 	   1,   -9, 	   0,   -9
+.2byte    0,  -13, 	   2,  -17, 	  -2,   -9, 	  -1,   -9
+.2byte    2,  -17, 	  -4,  -24, 	   7,  -12, 	   1,  -12
+.2byte    1,  -16, 	   4,  -23, 	  -7,  -11, 	   0,  -11
+.2byte    1,  -16, 	   2,  -24, 	  -6,  -10, 	  -1,  -12
+.2byte    3,  -16, 	  -5,  -22, 	   1,   -8, 	   0,  -12
+.2byte   -1,  -16, 	   4,  -23, 	  -7,   -9, 	   0,  -14
+.2byte   -4,  -16, 	   4,  -22, 	  -2,   -8, 	  -1,  -12
+.2byte   -1,  -16, 	  -2,  -24, 	   6,  -10, 	   1,  -12
+.2byte   -1,  -16, 	  -4,  -23, 	   7,  -11, 	   0,  -11
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte    0,  -14, 	  -3,  -17, 	   4,  -10, 	   0,  -10
+.2byte   -1,   -9, 	  -8,  -14, 	   6,  -14, 	  -1,   -6
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+.2byte   -1,  -13, 	   1,  -17, 	  -3,   -9, 	  -2,   -9
+.2byte    3,   -8, 	  -4,  -14, 	  -9,  -10, 	  -1,   -5
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    0,  -14, 	   4,  -20, 	   1,  -10, 	   0,  -10
+.2byte    5,  -11, 	  -6,  -12, 	  -7,   -8, 	   0,   -7
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    1,  -15, 	   1,  -19, 	   4,  -12, 	  -2,  -11
+.2byte    3,  -13, 	  -9,   -9, 	  -1,   -4, 	  -2,   -9
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte   -2,  -14, 	   2,  -15, 	  -8,  -12, 	  -2,  -11
+.2byte   -1,  -13, 	   6,   -3, 	  -8,   -3, 	  -1,   -9
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -3,  -15, 	  -3,  -19, 	  -6,  -12, 	   0,  -11
+.2byte   -5,  -13, 	   7,   -9, 	  -1,   -4, 	   0,   -9
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -1,  -14, 	  -5,  -20, 	  -2,  -10, 	  -1,  -10
+.2byte   -6,  -11, 	   5,  -12, 	   6,   -8, 	  -1,   -7
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -1,  -13, 	  -3,  -17, 	   1,   -9, 	   0,   -9
+.2byte   -5,   -8, 	   2,  -14, 	   7,  -10, 	  -1,   -5
+.2byte   -1,   -9, 	  -8,  -14, 	   6,  -14, 	  -1,   -6
+.2byte   -5,   -9, 	   2,  -15, 	   7,  -11, 	  -1,   -6
+.2byte   -6,  -11, 	   5,  -12, 	   6,   -8, 	  -1,   -7
+.2byte   -4,  -12, 	   8,   -8, 	   0,   -3, 	   1,   -8
+.2byte   -1,  -14, 	   6,   -4, 	  -8,   -4, 	  -1,  -10
+.2byte    3,  -12, 	  -9,   -8, 	  -1,   -3, 	  -2,   -8
+.2byte    5,  -11, 	  -6,  -12, 	  -7,   -8, 	   0,   -7
+.2byte    4,   -9, 	  -3,  -15, 	  -8,  -11, 	   0,   -6
+.2byte   -1,  -12, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte   -3,  -12, 	  -7,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -4,  -12, 	   2,   -5, 	   2,   -2, 	  -2,   -8
+.2byte   -4,  -13, 	   4,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -8
+.2byte    2,  -13, 	  -6,   -6, 	   3,   -3, 	  -2,   -8
+.2byte    2,  -12, 	  -4,   -5, 	  -4,   -2, 	   0,   -8
+.2byte    1,  -12, 	   5,   -6, 	  -7,   -4, 	   0,   -9
+sCombuskenAnimTable1:
+.4byte sCombuskenAnims_1_1
+.4byte sCombuskenAnims_1_2
+.4byte sCombuskenAnims_1_3
+.4byte sCombuskenAnims_1_4
+.4byte sCombuskenAnims_1_5
+.4byte sCombuskenAnims_1_6
+.4byte sCombuskenAnims_1_7
+.4byte sCombuskenAnims_1_8
+sCombuskenAnimTable2:
+.4byte sCombuskenAnims_2_1
+.4byte sCombuskenAnims_2_2
+.4byte sCombuskenAnims_2_3
+.4byte sCombuskenAnims_2_4
+.4byte sCombuskenAnims_2_5
+.4byte sCombuskenAnims_2_6
+.4byte sCombuskenAnims_2_7
+.4byte sCombuskenAnims_2_8
+sCombuskenAnimTable3:
+.4byte sCombuskenAnims_3_1
+.4byte sCombuskenAnims_3_2
+.4byte sCombuskenAnims_3_3
+.4byte sCombuskenAnims_3_4
+.4byte sCombuskenAnims_3_5
+.4byte sCombuskenAnims_3_6
+.4byte sCombuskenAnims_3_7
+.4byte sCombuskenAnims_3_8
+sCombuskenAnimTable4:
+.4byte sCombuskenAnims_4_1
+.4byte sCombuskenAnims_4_2
+.4byte sCombuskenAnims_4_3
+.4byte sCombuskenAnims_4_4
+.4byte sCombuskenAnims_4_5
+.4byte sCombuskenAnims_4_6
+.4byte sCombuskenAnims_4_7
+.4byte sCombuskenAnims_4_8
+sCombuskenAnimTable5:
+.4byte sCombuskenAnims_5_1
+.4byte sCombuskenAnims_5_2
+.4byte sCombuskenAnims_5_3
+.4byte sCombuskenAnims_5_4
+.4byte sCombuskenAnims_5_5
+.4byte sCombuskenAnims_5_6
+.4byte sCombuskenAnims_5_7
+.4byte sCombuskenAnims_5_8
+sCombuskenAnimTable6:
+.4byte sCombuskenAnims_6_1
+.4byte sCombuskenAnims_6_1
+.4byte sCombuskenAnims_6_1
+.4byte sCombuskenAnims_6_1
+.4byte sCombuskenAnims_6_1
+.4byte sCombuskenAnims_6_1
+.4byte sCombuskenAnims_6_1
+.4byte sCombuskenAnims_6_1
+sCombuskenAnimTable7:
+.4byte sCombuskenAnims_7_1
+.4byte sCombuskenAnims_7_2
+.4byte sCombuskenAnims_7_3
+.4byte sCombuskenAnims_7_4
+.4byte sCombuskenAnims_7_5
+.4byte sCombuskenAnims_7_6
+.4byte sCombuskenAnims_7_7
+.4byte sCombuskenAnims_7_8
+sCombuskenAnimTable8:
+.4byte sCombuskenAnims_8_1
+.4byte sCombuskenAnims_8_2
+.4byte sCombuskenAnims_8_3
+.4byte sCombuskenAnims_8_4
+.4byte sCombuskenAnims_8_5
+.4byte sCombuskenAnims_8_6
+.4byte sCombuskenAnims_8_7
+.4byte sCombuskenAnims_8_8
+sCombuskenAnimTable9:
+.4byte sCombuskenAnims_9_1
+.4byte sCombuskenAnims_9_2
+.4byte sCombuskenAnims_9_3
+.4byte sCombuskenAnims_9_4
+.4byte sCombuskenAnims_9_5
+.4byte sCombuskenAnims_9_6
+.4byte sCombuskenAnims_9_7
+.4byte sCombuskenAnims_9_8
+sCombuskenAnimTable10:
+.4byte sCombuskenAnims_10_1
+.4byte sCombuskenAnims_10_2
+.4byte sCombuskenAnims_10_3
+.4byte sCombuskenAnims_10_4
+.4byte sCombuskenAnims_10_5
+.4byte sCombuskenAnims_10_6
+.4byte sCombuskenAnims_10_7
+.4byte sCombuskenAnims_10_8
+sCombuskenAnimTable11:
+.4byte sCombuskenAnims_11_1
+.4byte sCombuskenAnims_11_2
+.4byte sCombuskenAnims_11_3
+.4byte sCombuskenAnims_11_4
+.4byte sCombuskenAnims_11_5
+.4byte sCombuskenAnims_11_6
+.4byte sCombuskenAnims_11_7
+.4byte sCombuskenAnims_11_8
+sCombuskenAnimTable12:
+.4byte sCombuskenAnims_12_1
+.4byte sCombuskenAnims_12_2
+.4byte sCombuskenAnims_12_3
+.4byte sCombuskenAnims_12_4
+.4byte sCombuskenAnims_12_5
+.4byte sCombuskenAnims_12_6
+.4byte sCombuskenAnims_12_7
+.4byte sCombuskenAnims_12_8
+sCombuskenAnimTable13:
+.4byte sCombuskenAnims_13_1
+.4byte sCombuskenAnims_13_2
+.4byte sCombuskenAnims_13_3
+.4byte sCombuskenAnims_13_4
+.4byte sCombuskenAnims_13_5
+.4byte sCombuskenAnims_13_6
+.4byte sCombuskenAnims_13_7
+.4byte sCombuskenAnims_13_8
+sAxAnimationsCombusken:
+.4byte sCombuskenAnimTable1
+.4byte sCombuskenAnimTable2
+.4byte sCombuskenAnimTable3
+.4byte sCombuskenAnimTable4
+.4byte sCombuskenAnimTable5
+.4byte sCombuskenAnimTable6
+.4byte sCombuskenAnimTable7
+.4byte sCombuskenAnimTable8
+.4byte sCombuskenAnimTable9
+.4byte sCombuskenAnimTable10
+.4byte sCombuskenAnimTable11
+.4byte sCombuskenAnimTable12
+.4byte sCombuskenAnimTable13
+sAxSpritesCombusken:
+.4byte sCombuskenSprites1
+.4byte sCombuskenSprites2
+.4byte sCombuskenSprites3
+.4byte sCombuskenSprites4
+.4byte sCombuskenSprites5
+.4byte sCombuskenSprites6
+.4byte sCombuskenSprites7
+.4byte sCombuskenSprites8
+.4byte sCombuskenSprites9
+.4byte sCombuskenSprites10
+.4byte sCombuskenSprites11
+.4byte sCombuskenSprites12
+.4byte sCombuskenSprites13
+.4byte sCombuskenSprites14
+.4byte sCombuskenSprites15
+.4byte sCombuskenSprites16
+.4byte sCombuskenSprites17
+.4byte sCombuskenSprites18
+.4byte sCombuskenSprites19
+.4byte sCombuskenSprites20
+.4byte sCombuskenSprites21
+.4byte sCombuskenSprites22
+.4byte sCombuskenSprites23
+.4byte sCombuskenSprites24
+.4byte sCombuskenSprites25
+.4byte sCombuskenSprites26
+.4byte sCombuskenSprites27
+.4byte sCombuskenSprites28
+.4byte sCombuskenSprites29
+.4byte sCombuskenSprites30
+.4byte sCombuskenSprites31
+.4byte sCombuskenSprites32
+.4byte sCombuskenSprites33
+.4byte sCombuskenSprites34
+.4byte sCombuskenSprites35
+.4byte sCombuskenSprites36
+.4byte sCombuskenSprites37
+.4byte sCombuskenSprites38
+.4byte sCombuskenSprites39
+.4byte sCombuskenSprites40
+.4byte sCombuskenSprites41
+.4byte sCombuskenSprites42
+.4byte sCombuskenSprites43
+.4byte sCombuskenSprites44
+.4byte sCombuskenSprites45
+.4byte sCombuskenSprites46
+.4byte sCombuskenSprites47
+.4byte sCombuskenSprites48
+.4byte sCombuskenSprites49
+.4byte sCombuskenSprites50
+.4byte sCombuskenSprites51
+.4byte sCombuskenSprites52
+.4byte sCombuskenSprites53
+sAxMainCombusken:
+ax_main sAxPosesCombusken, sAxAnimationsCombusken, 13, sAxSpritesCombusken, sAxPositionsCombusken

--- a/data/ax/corphish.inc
+++ b/data/ax/corphish.inc
@@ -1,0 +1,2701 @@
+.global gAxCorphish
+gAxCorphish:
+ax_siro sAxMainCorphish
+sCorphishPose1:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose2:
+ax_pose 1, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose3:
+ax_pose 2, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose4:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose5:
+ax_pose 4, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose6:
+ax_pose 5, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose7:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose8:
+ax_pose 7, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose9:
+ax_pose 8, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose10:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose11:
+ax_pose 10, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose12:
+ax_pose 11, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose13:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose14:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose15:
+ax_pose 14, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose16:
+ax_pose 9, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose17:
+ax_pose 10, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose18:
+ax_pose 11, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose19:
+ax_pose 6, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose20:
+ax_pose 7, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose21:
+ax_pose 8, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose22:
+ax_pose 3, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose23:
+ax_pose 4, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose24:
+ax_pose 5, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose25:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose26:
+ax_pose 1, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose27:
+ax_pose 2, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose28:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose29:
+ax_pose 16, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose30:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose31:
+ax_pose 4, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose32:
+ax_pose 5, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose33:
+ax_pose 17, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose34:
+ax_pose 18, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose35:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose36:
+ax_pose 7, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose37:
+ax_pose 8, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose38:
+ax_pose 19, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose39:
+ax_pose 20, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sCorphishPose40:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose41:
+ax_pose 10, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose42:
+ax_pose 11, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose43:
+ax_pose 21, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose44:
+ax_pose 22, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose45:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose46:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose47:
+ax_pose 14, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose48:
+ax_pose 23, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose49:
+ax_pose 24, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose50:
+ax_pose 9, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose51:
+ax_pose 10, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose52:
+ax_pose 11, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose53:
+ax_pose 21, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose54:
+ax_pose 22, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose55:
+ax_pose 6, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose56:
+ax_pose 7, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose57:
+ax_pose 8, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose58:
+ax_pose 19, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose59:
+ax_pose 20, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sCorphishPose60:
+ax_pose 3, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose61:
+ax_pose 4, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose62:
+ax_pose 5, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose63:
+ax_pose 17, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose64:
+ax_pose 18, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose65:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose66:
+ax_pose 25, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose67:
+ax_pose 16, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose68:
+ax_pose 26, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose69:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose70:
+ax_pose 27, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose71:
+ax_pose 18, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose72:
+ax_pose 28, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose73:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose74:
+ax_pose 29, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose75:
+ax_pose 20, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sCorphishPose76:
+ax_pose 30, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sCorphishPose77:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose78:
+ax_pose 31, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose79:
+ax_pose 22, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose80:
+ax_pose 32, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose81:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose82:
+ax_pose 23, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose83:
+ax_pose 24, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose84:
+ax_pose 33, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose85:
+ax_pose 9, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose86:
+ax_pose 31, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose87:
+ax_pose 22, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose88:
+ax_pose 32, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose89:
+ax_pose 6, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose90:
+ax_pose 29, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose91:
+ax_pose 20, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sCorphishPose92:
+ax_pose 30, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sCorphishPose93:
+ax_pose 3, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose94:
+ax_pose 27, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose95:
+ax_pose 18, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose96:
+ax_pose 28, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose97:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose98:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose99:
+ax_pose 16, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose100:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose101:
+ax_pose 17, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose102:
+ax_pose 18, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose103:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose104:
+ax_pose 19, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose105:
+ax_pose 20, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sCorphishPose106:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose107:
+ax_pose 21, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose108:
+ax_pose 22, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose109:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose110:
+ax_pose 23, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose111:
+ax_pose 24, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose112:
+ax_pose 9, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose113:
+ax_pose 21, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose114:
+ax_pose 22, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose115:
+ax_pose 6, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose116:
+ax_pose 19, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose117:
+ax_pose 20, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sCorphishPose118:
+ax_pose 3, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose119:
+ax_pose 17, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose120:
+ax_pose 18, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose121:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose122:
+ax_pose 34, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose123:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose124:
+ax_pose 35, 0x01ed, 0x90ed, 0x0c00
+ax_pose_terminator
+sCorphishPose125:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose126:
+ax_pose 36, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose127:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose128:
+ax_pose 37, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose129:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose130:
+ax_pose 38, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose131:
+ax_pose 9, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose132:
+ax_pose 37, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose133:
+ax_pose 6, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose134:
+ax_pose 36, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose135:
+ax_pose 3, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose136:
+ax_pose 35, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sCorphishPose137:
+ax_pose 39, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose138:
+ax_pose 40, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose139:
+ax_pose 41, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose140:
+ax_pose 42, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sCorphishPose141:
+ax_pose 43, 0x01e4, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose142:
+ax_pose 44, 0x01e4, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose143:
+ax_pose 45, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose144:
+ax_pose 44, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose145:
+ax_pose 43, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose146:
+ax_pose 42, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose147:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose148:
+ax_pose 1, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose149:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose150:
+ax_pose 4, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose151:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose152:
+ax_pose 7, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose153:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose154:
+ax_pose 10, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose155:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose156:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose157:
+ax_pose 9, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose158:
+ax_pose 10, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose159:
+ax_pose 6, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose160:
+ax_pose 7, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose161:
+ax_pose 3, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose162:
+ax_pose 4, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose163:
+ax_pose 15, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose164:
+ax_pose 17, 0x01ec, 0x80ee, 0x0c00
+ax_pose_terminator
+sCorphishPose165:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose166:
+ax_pose 21, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose167:
+ax_pose 23, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose168:
+ax_pose 21, 0x01e9, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose169:
+ax_pose 19, 0x01e9, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose170:
+ax_pose 17, 0x01ec, 0x90f2, 0x0c00
+ax_pose_terminator
+sCorphishPose171:
+ax_pose 15, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose172:
+ax_pose 17, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sCorphishPose173:
+ax_pose 19, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose174:
+ax_pose 21, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose175:
+ax_pose 23, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose176:
+ax_pose 21, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose177:
+ax_pose 19, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose178:
+ax_pose 17, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose179:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose180:
+ax_pose 15, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose181:
+ax_pose 16, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose182:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose183:
+ax_pose 17, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sCorphishPose184:
+ax_pose 18, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sCorphishPose185:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose186:
+ax_pose 19, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sCorphishPose187:
+ax_pose 20, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose188:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose189:
+ax_pose 21, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sCorphishPose190:
+ax_pose 22, 0x01ed, 0x90ef, 0x0c00
+ax_pose_terminator
+sCorphishPose191:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose192:
+ax_pose 23, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose193:
+ax_pose 24, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose194:
+ax_pose 9, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose195:
+ax_pose 21, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sCorphishPose196:
+ax_pose 22, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose197:
+ax_pose 6, 0x01ee, 0x80f5, 0x0c00
+ax_pose_terminator
+sCorphishPose198:
+ax_pose 19, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose199:
+ax_pose 20, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose200:
+ax_pose 3, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose201:
+ax_pose 17, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose202:
+ax_pose 18, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose203:
+ax_pose 25, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sCorphishPose204:
+ax_pose 27, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sCorphishPose205:
+ax_pose 29, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose206:
+ax_pose 31, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose207:
+ax_pose 23, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose208:
+ax_pose 31, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose209:
+ax_pose 29, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sCorphishPose210:
+ax_pose 27, 0x01ec, 0x90f1, 0x0c00
+ax_pose_terminator
+sCorphishPose211:
+ax_pose 0, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sCorphishPose212:
+ax_pose 3, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose213:
+ax_pose 6, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sCorphishPose214:
+ax_pose 9, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose215:
+ax_pose 12, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sCorphishPose216:
+ax_pose 9, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sCorphishPose217:
+ax_pose 6, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sCorphishPose218:
+ax_pose 3, 0x01ef, 0x90ec, 0x0c00
+ax_pose_terminator
+.align 2
+sCorphishAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 1, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCorphishAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 4, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 0, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sCorphishAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 4, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 1, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 0, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sCorphishAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 4, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 1, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sCorphishAnims_2_5:
+ax_anim 2, 0, 47, 0, 1, 0, 1,
+ax_anim 4, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 0, -4, 0, -4,
+ax_anim 1, 0, 44, 0, -11, 0, -11,
+ax_anim 2, 0, 44, 0, -23, 0, -23,
+ax_anim 2, 1, 44, 1, -23, 1, -23,
+ax_anim 2, 0, 44, 0, -23, 0, -23,
+ax_anim 2, 0, 44, 1, -23, 1, -23,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sCorphishAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 4, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 49, -4, -6, -4, -6,
+ax_anim 1, 0, 49, -10, -13, -10, -13,
+ax_anim 2, 0, 49, -19, -23, -19, -23,
+ax_anim 2, 1, 49, -20, -22, -20, -22,
+ax_anim 2, 0, 49, -19, -23, -19, -23,
+ax_anim 2, 0, 49, -20, -22, -20, -22,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sCorphishAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 4, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 0, -4, 0,
+ax_anim 1, 0, 54, -10, 0, -10, 0,
+ax_anim 2, 0, 54, -19, 0, -19, 0,
+ax_anim 2, 1, 54, -19, 1, -19, 1,
+ax_anim 2, 0, 54, -19, 0, -19, 0,
+ax_anim 2, 0, 54, -19, 1, -19, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sCorphishAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 4, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 59, -4, 4, -4, 4,
+ax_anim 1, 0, 59, -10, 10, -10, 10,
+ax_anim 2, 0, 59, -18, 18, -18, 18,
+ax_anim 2, 1, 59, -19, 17, -19, 17,
+ax_anim 2, 0, 59, -18, 18, -18, 18,
+ax_anim 2, 0, 59, -19, 17, -19, 17,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCorphishAnims_3_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 65, 0, -4, 0, -4,
+ax_anim 6, 0, 65, 0, -5, 0, -5,
+ax_anim 1, 0, 66, 0, -2, 0, -2,
+ax_anim 2, 2, 66, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 1, 66, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 66, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 66, 1, 17, 1, 17,
+ax_anim 2, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sCorphishAnims_3_2:
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -4, -4, -4, -4,
+ax_anim 6, 0, 69, -5, -5, -5, -5,
+ax_anim 1, 0, 70, -2, -2, -2, -2,
+ax_anim 2, 2, 70, 7, 6, 7, 6,
+ax_anim 2, 0, 71, 18, 17, 18, 17,
+ax_anim 2, 1, 70, 19, 16, 19, 16,
+ax_anim 2, 0, 71, 18, 17, 18, 17,
+ax_anim 2, 0, 70, 19, 16, 19, 16,
+ax_anim 2, 0, 71, 18, 17, 18, 17,
+ax_anim 2, 0, 70, 19, 16, 19, 16,
+ax_anim 2, 0, 68, 11, 10, 11, 10,
+ax_anim 2, 0, 68, 5, 4, 5, 4,
+ax_anim_terminator
+sCorphishAnims_3_3:
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim 2, 0, 73, -4, 0, -4, 0,
+ax_anim 6, 0, 73, -5, 0, -5, 0,
+ax_anim 1, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 2, 74, 7, 0, 7, 0,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 2, 1, 74, 18, 1, 18, 1,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 18, 1, 18, 1,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 18, 1, 18, 1,
+ax_anim 2, 0, 72, 11, 0, 11, 0,
+ax_anim 2, 0, 72, 5, 0, 5, 0,
+ax_anim_terminator
+sCorphishAnims_3_4:
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 2, 0, 77, -4, 4, -4, 4,
+ax_anim 6, 0, 77, -5, 5, -5, 5,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 78, 8, -12, 8, -12,
+ax_anim 2, 0, 79, 18, -24, 18, -24,
+ax_anim 2, 1, 78, 19, -23, 19, -23,
+ax_anim 2, 0, 79, 18, -24, 18, -24,
+ax_anim 2, 0, 78, 19, -23, 19, -23,
+ax_anim 2, 0, 79, 18, -24, 18, -24,
+ax_anim 2, 0, 78, 19, -23, 19, -23,
+ax_anim 2, 0, 76, 9, -12, 9, -12,
+ax_anim 2, 0, 76, 4, -5, 4, -5,
+ax_anim_terminator
+sCorphishAnims_3_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 2, 0, 81, 0, 4, 0, 4,
+ax_anim 6, 0, 81, 0, 5, 0, 5,
+ax_anim 1, 0, 82, 0, -2, 0, -2,
+ax_anim 2, 2, 82, 0, -10, 0, -10,
+ax_anim 2, 0, 83, 0, -23, 0, -23,
+ax_anim 2, 1, 82, 1, -23, 1, -23,
+ax_anim 2, 0, 83, 0, -23, 0, -23,
+ax_anim 2, 0, 82, 1, -23, 1, -23,
+ax_anim 2, 0, 83, 0, -23, 0, -23,
+ax_anim 2, 0, 82, 1, -23, 1, -23,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sCorphishAnims_3_6:
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 6, 0, 85, 5, 5, 5, 5,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 2, 86, -8, -12, -8, -12,
+ax_anim 2, 0, 87, -18, -24, -18, -24,
+ax_anim 2, 1, 86, -19, -23, -19, -23,
+ax_anim 2, 0, 87, -18, -24, -18, -24,
+ax_anim 2, 0, 86, -19, -23, -19, -23,
+ax_anim 2, 0, 87, -18, -24, -18, -24,
+ax_anim 2, 0, 86, -19, -23, -19, -23,
+ax_anim 2, 0, 84, -9, -12, -9, -12,
+ax_anim 2, 0, 84, -4, -5, -4, -5,
+ax_anim_terminator
+sCorphishAnims_3_7:
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 89, 4, 0, 4, 0,
+ax_anim 6, 0, 89, 5, 0, 5, 0,
+ax_anim 1, 0, 90, 2, 0, 2, 0,
+ax_anim 2, 2, 90, -7, 0, -7, 0,
+ax_anim 2, 0, 91, -18, 0, -18, 0,
+ax_anim 2, 1, 90, -18, 1, -18, 1,
+ax_anim 2, 0, 91, -18, 0, -18, 0,
+ax_anim 2, 0, 90, -18, 1, -18, 1,
+ax_anim 2, 0, 91, -18, 0, -18, 0,
+ax_anim 2, 0, 90, -18, 1, -18, 1,
+ax_anim 2, 0, 88, -11, 0, -11, 0,
+ax_anim 2, 0, 88, -5, 0, -5, 0,
+ax_anim_terminator
+sCorphishAnims_3_8:
+ax_anim 2, 0, 92, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 4, -4, 4, -4,
+ax_anim 6, 0, 93, 5, -5, 5, -5,
+ax_anim 1, 0, 94, 2, -2, 2, -2,
+ax_anim 2, 2, 94, -7, 6, -7, 6,
+ax_anim 2, 0, 95, -18, 17, -18, 17,
+ax_anim 2, 1, 94, -19, 16, -19, 16,
+ax_anim 2, 0, 95, -18, 17, -18, 17,
+ax_anim 2, 0, 94, -19, 16, -19, 16,
+ax_anim 2, 0, 95, -18, 17, -18, 17,
+ax_anim 2, 0, 94, -19, 16, -19, 16,
+ax_anim 2, 0, 92, -11, 10, -11, 10,
+ax_anim 2, 0, 92, -5, 4, -5, 4,
+ax_anim_terminator
+.align 2
+sCorphishAnims_4_1:
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 6, 2, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim_terminator
+sCorphishAnims_4_2:
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim 6, 2, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sCorphishAnims_4_3:
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim 6, 2, 103, -3, 0, -3, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 1, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim_terminator
+sCorphishAnims_4_4:
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 6, 2, 106, -3, 3, -3, 3,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 1, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim_terminator
+sCorphishAnims_4_5:
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim 6, 2, 109, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 1, 0, 1,
+ax_anim 2, 1, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sCorphishAnims_4_6:
+ax_anim 2, 0, 112, 2, 2, 2, 2,
+ax_anim 6, 2, 112, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 1, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+sCorphishAnims_4_7:
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 6, 2, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim_terminator
+sCorphishAnims_4_8:
+ax_anim 2, 0, 118, 2, -2, 2, -2,
+ax_anim 6, 2, 118, 3, -3, 3, -3,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCorphishAnims_5_1:
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 2, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_5_2:
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 2, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_5_3:
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 2, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_5_4:
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 2, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_5_5:
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_5_6:
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 2, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_5_7:
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 2, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_5_8:
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 2, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sCorphishAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sCorphishAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sCorphishAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sCorphishAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sCorphishAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sCorphishAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sCorphishAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sCorphishAnims_8_1:
+ax_anim 24, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_8_2:
+ax_anim 24, 0, 148, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_8_3:
+ax_anim 24, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_8_4:
+ax_anim 24, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_8_5:
+ax_anim 24, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_8_6:
+ax_anim 24, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_8_7:
+ax_anim 24, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_8_8:
+ax_anim 24, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 10, 10, 10, 10,
+ax_anim 2, 0, 165, 9, 18, 9, 18,
+ax_anim 3, 0, 166, 0, 19, 0, 19,
+ax_anim 2, 3, 167, -9, 18, -9, 18,
+ax_anim 2, 0, 168, -10, 10, -10, 10,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, 0, 9, 0,
+ax_anim 2, 0, 163, 18, 4, 18, 4,
+ax_anim 2, 0, 164, 22, 14, 22, 14,
+ax_anim 3, 0, 165, 21, 20, 21, 20,
+ax_anim 2, 3, 166, 9, 21, 9, 21,
+ax_anim 2, 0, 167, 1, 17, 1, 17,
+ax_anim 1, 0, 168, -3, 9, -3, 9,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 6, -5, 6, -5,
+ax_anim 2, 0, 162, 16, -6, 16, -6,
+ax_anim 2, 0, 163, 20, -4, 20, -4,
+ax_anim 3, 0, 164, 21, 1, 21, 1,
+ax_anim 2, 3, 165, 19, 4, 19, 4,
+ax_anim 2, 0, 166, 13, 5, 13, 5,
+ax_anim 1, 0, 167, 7, 5, 7, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -8, 0, -8,
+ax_anim 2, 0, 169, 6, -16, 6, -16,
+ax_anim 2, 0, 162, 15, -21, 15, -21,
+ax_anim 3, 0, 163, 23, -20, 23, -20,
+ax_anim 2, 3, 164, 25, -11, 25, -11,
+ax_anim 2, 0, 165, 22, -3, 22, -3,
+ax_anim 1, 0, 166, 11, 2, 11, 2,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -9, -2, -9, -2,
+ax_anim 2, 0, 168, -12, -8, -12, -8,
+ax_anim 2, 0, 169, -8, -19, -8, -19,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 8, -19, 8, -19,
+ax_anim 2, 0, 164, 12, -8, 12, -8,
+ax_anim 1, 0, 165, 9, -2, 9, -2,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -8, 0, -8,
+ax_anim 2, 0, 163, -5, -16, -5, -16,
+ax_anim 2, 0, 162, -14, -21, -14, -21,
+ax_anim 3, 0, 169, -23, -20, -23, -20,
+ax_anim 2, 3, 168, -24, -12, -24, -12,
+ax_anim 2, 0, 167, -21, -2, -21, -2,
+ax_anim 1, 0, 166, -11, 1, -11, 1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -6, -4, -6, -4,
+ax_anim 2, 0, 162, -16, -6, -16, -6,
+ax_anim 2, 0, 169, -21, -4, -21, -4,
+ax_anim 3, 0, 168, -22, 1, -22, 1,
+ax_anim 2, 3, 167, -21, 6, -21, 6,
+ax_anim 2, 0, 166, -13, 5, -13, 5,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, 0, -9, 0,
+ax_anim 2, 0, 169, -18, 4, -18, 4,
+ax_anim 2, 0, 168, -22, 14, -22, 14,
+ax_anim 3, 0, 167, -21, 20, -21, 20,
+ax_anim 2, 3, 166, -9, 21, -9, 21,
+ax_anim 2, 0, 165, -1, 17, -1, 17,
+ax_anim 1, 0, 164, 3, 9, 3, 9,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorphishAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sCorphishGfx1:
+.incbin "baserom.gba", 0x13EA6A4, 0x200
+sCorphishSprites1:
+ax_sprite sCorphishGfx1, 0x200
+ax_sprite_terminator
+sCorphishGfx2:
+.incbin "baserom.gba", 0x13EA8B4, 0x200
+sCorphishSprites2:
+ax_sprite sCorphishGfx2, 0x200
+ax_sprite_terminator
+sCorphishGfx3:
+.incbin "baserom.gba", 0x13EAAC4, 0x200
+sCorphishSprites3:
+ax_sprite sCorphishGfx3, 0x200
+ax_sprite_terminator
+sCorphishGfx4:
+.incbin "baserom.gba", 0x13EACD4, 0x200
+sCorphishSprites4:
+ax_sprite sCorphishGfx4, 0x200
+ax_sprite_terminator
+sCorphishGfx5:
+.incbin "baserom.gba", 0x13EAEE4, 0x200
+sCorphishSprites5:
+ax_sprite sCorphishGfx5, 0x200
+ax_sprite_terminator
+sCorphishGfx6:
+.incbin "baserom.gba", 0x13EB0F4, 0x200
+sCorphishSprites6:
+ax_sprite sCorphishGfx6, 0x200
+ax_sprite_terminator
+sCorphishGfx7:
+.incbin "baserom.gba", 0x13EB304, 0x200
+sCorphishSprites7:
+ax_sprite sCorphishGfx7, 0x200
+ax_sprite_terminator
+sCorphishGfx8:
+.incbin "baserom.gba", 0x13EB514, 0x200
+sCorphishSprites8:
+ax_sprite sCorphishGfx8, 0x200
+ax_sprite_terminator
+sCorphishGfx9:
+.incbin "baserom.gba", 0x13EB724, 0x200
+sCorphishSprites9:
+ax_sprite sCorphishGfx9, 0x200
+ax_sprite_terminator
+sCorphishGfx10:
+.incbin "baserom.gba", 0x13EB934, 0x200
+sCorphishSprites10:
+ax_sprite sCorphishGfx10, 0x200
+ax_sprite_terminator
+sCorphishGfx11:
+.incbin "baserom.gba", 0x13EBB44, 0x200
+sCorphishSprites11:
+ax_sprite sCorphishGfx11, 0x200
+ax_sprite_terminator
+sCorphishGfx12:
+.incbin "baserom.gba", 0x13EBD54, 0x200
+sCorphishSprites12:
+ax_sprite sCorphishGfx12, 0x200
+ax_sprite_terminator
+sCorphishGfx13:
+.incbin "baserom.gba", 0x13EBF64, 0x200
+sCorphishSprites13:
+ax_sprite sCorphishGfx13, 0x200
+ax_sprite_terminator
+sCorphishGfx14:
+.incbin "baserom.gba", 0x13EC174, 0x200
+sCorphishSprites14:
+ax_sprite sCorphishGfx14, 0x200
+ax_sprite_terminator
+sCorphishGfx15:
+.incbin "baserom.gba", 0x13EC384, 0x200
+sCorphishSprites15:
+ax_sprite sCorphishGfx15, 0x200
+ax_sprite_terminator
+sCorphishGfx16:
+.incbin "baserom.gba", 0x13EC594, 0x180
+sCorphishSprites16:
+ax_sprite sCorphishGfx16, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx17:
+.incbin "baserom.gba", 0x13EC72C, 0x40
+sCorphishGfx17_1:
+.incbin "baserom.gba", 0x13EC76C, 0x100
+sCorphishSprites17:
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx17_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx18:
+.incbin "baserom.gba", 0x13EC89C, 0x100
+sCorphishGfx18_1:
+.incbin "baserom.gba", 0x13EC99C, 0x60
+sCorphishSprites18:
+ax_sprite sCorphishGfx18, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx18_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx19:
+.incbin "baserom.gba", 0x13ECA24, 0x40
+sCorphishGfx19_1:
+.incbin "baserom.gba", 0x13ECA64, 0x100
+sCorphishGfx19_2:
+.incbin "baserom.gba", 0x13ECB64, 0x20
+sCorphishSprites19:
+ax_sprite sCorphishGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx19_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx19_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCorphishGfx20:
+.incbin "baserom.gba", 0x13ECBBC, 0x60
+sCorphishGfx20_1:
+.incbin "baserom.gba", 0x13ECC1C, 0x60
+sCorphishGfx20_2:
+.incbin "baserom.gba", 0x13ECC7C, 0x60
+sCorphishGfx20_3:
+.incbin "baserom.gba", 0x13ECCDC, 0x20
+sCorphishSprites20:
+ax_sprite sCorphishGfx20, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx20_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCorphishGfx21:
+.incbin "baserom.gba", 0x13ECD44, 0x40
+sCorphishGfx21_1:
+.incbin "baserom.gba", 0x13ECD84, 0x100
+sCorphishGfx21_2:
+.incbin "baserom.gba", 0x13ECE84, 0x20
+sCorphishSprites21:
+ax_sprite sCorphishGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx21_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx21_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCorphishGfx22:
+.incbin "baserom.gba", 0x13ECEDC, 0x60
+sCorphishGfx22_1:
+.incbin "baserom.gba", 0x13ECF3C, 0x100
+sCorphishGfx22_2:
+.incbin "baserom.gba", 0x13ED03C, 0x20
+sCorphishSprites22:
+ax_sprite sCorphishGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx22_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCorphishGfx23:
+.incbin "baserom.gba", 0x13ED094, 0x60
+sCorphishGfx23_1:
+.incbin "baserom.gba", 0x13ED0F4, 0x100
+sCorphishGfx23_2:
+.incbin "baserom.gba", 0x13ED1F4, 0x20
+sCorphishSprites23:
+ax_sprite sCorphishGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx23_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCorphishGfx24:
+.incbin "baserom.gba", 0x13ED24C, 0x60
+sCorphishGfx24_1:
+.incbin "baserom.gba", 0x13ED2AC, 0x60
+sCorphishGfx24_2:
+.incbin "baserom.gba", 0x13ED30C, 0x60
+sCorphishGfx24_3:
+.incbin "baserom.gba", 0x13ED36C, 0x40
+sCorphishSprites24:
+ax_sprite sCorphishGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCorphishGfx25:
+.incbin "baserom.gba", 0x13ED3F4, 0x60
+sCorphishGfx25_1:
+.incbin "baserom.gba", 0x13ED454, 0x60
+sCorphishGfx25_2:
+.incbin "baserom.gba", 0x13ED4B4, 0x60
+sCorphishSprites25:
+ax_sprite sCorphishGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorphishGfx26:
+.incbin "baserom.gba", 0x13ED54C, 0x180
+sCorphishSprites26:
+ax_sprite sCorphishGfx26, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx27:
+.incbin "baserom.gba", 0x13ED6E4, 0x40
+sCorphishGfx27_1:
+.incbin "baserom.gba", 0x13ED724, 0x100
+sCorphishSprites27:
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx27_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx28:
+.incbin "baserom.gba", 0x13ED854, 0x180
+sCorphishSprites28:
+ax_sprite sCorphishGfx28, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx29:
+.incbin "baserom.gba", 0x13ED9EC, 0x40
+sCorphishGfx29_1:
+.incbin "baserom.gba", 0x13EDA2C, 0x100
+sCorphishGfx29_2:
+.incbin "baserom.gba", 0x13EDB2C, 0x20
+sCorphishSprites29:
+ax_sprite sCorphishGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx29_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx29_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCorphishGfx30:
+.incbin "baserom.gba", 0x13EDB84, 0x40
+sCorphishGfx30_1:
+.incbin "baserom.gba", 0x13EDBC4, 0x60
+sCorphishGfx30_2:
+.incbin "baserom.gba", 0x13EDC24, 0x80
+sCorphishGfx30_3:
+.incbin "baserom.gba", 0x13EDCA4, 0x40
+sCorphishSprites30:
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx30_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCorphishGfx31:
+.incbin "baserom.gba", 0x13EDD34, 0x20
+sCorphishGfx31_1:
+.incbin "baserom.gba", 0x13EDD54, 0x100
+sCorphishGfx31_2:
+.incbin "baserom.gba", 0x13EDE54, 0x20
+sCorphishSprites31:
+ax_sprite sCorphishGfx31, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCorphishGfx31_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx31_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCorphishGfx32:
+.incbin "baserom.gba", 0x13EDEAC, 0x60
+sCorphishGfx32_1:
+.incbin "baserom.gba", 0x13EDF0C, 0x100
+sCorphishGfx32_2:
+.incbin "baserom.gba", 0x13EE00C, 0x20
+sCorphishSprites32:
+ax_sprite sCorphishGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx32_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCorphishGfx33:
+.incbin "baserom.gba", 0x13EE064, 0x60
+sCorphishGfx33_1:
+.incbin "baserom.gba", 0x13EE0C4, 0x100
+sCorphishGfx33_2:
+.incbin "baserom.gba", 0x13EE1C4, 0x20
+sCorphishSprites33:
+ax_sprite sCorphishGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx33_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCorphishGfx34:
+.incbin "baserom.gba", 0x13EE21C, 0x60
+sCorphishGfx34_1:
+.incbin "baserom.gba", 0x13EE27C, 0x60
+sCorphishGfx34_2:
+.incbin "baserom.gba", 0x13EE2DC, 0x60
+sCorphishSprites34:
+ax_sprite sCorphishGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorphishGfx35:
+.incbin "baserom.gba", 0x13EE374, 0x180
+sCorphishSprites35:
+ax_sprite sCorphishGfx35, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx36:
+.incbin "baserom.gba", 0x13EE50C, 0x60
+sCorphishGfx36_1:
+.incbin "baserom.gba", 0x13EE56C, 0x100
+sCorphishSprites36:
+ax_sprite sCorphishGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx36_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx37:
+.incbin "baserom.gba", 0x13EE694, 0x40
+sCorphishGfx37_1:
+.incbin "baserom.gba", 0x13EE6D4, 0x100
+sCorphishSprites37:
+ax_sprite sCorphishGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCorphishGfx37_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCorphishGfx38:
+.incbin "baserom.gba", 0x13EE7FC, 0x60
+sCorphishGfx38_1:
+.incbin "baserom.gba", 0x13EE85C, 0x100
+sCorphishGfx38_2:
+.incbin "baserom.gba", 0x13EE95C, 0x20
+sCorphishSprites38:
+ax_sprite sCorphishGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCorphishGfx38_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCorphishGfx39:
+.incbin "baserom.gba", 0x13EE9B4, 0x160
+sCorphishSprites39:
+ax_sprite sCorphishGfx39, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorphishGfx40:
+.incbin "baserom.gba", 0x13EEB2C, 0x200
+sCorphishSprites40:
+ax_sprite sCorphishGfx40, 0x200
+ax_sprite_terminator
+sCorphishGfx41:
+.incbin "baserom.gba", 0x13EED3C, 0x200
+sCorphishSprites41:
+ax_sprite sCorphishGfx41, 0x200
+ax_sprite_terminator
+sCorphishGfx42:
+.incbin "baserom.gba", 0x13EEF4C, 0x200
+sCorphishSprites42:
+ax_sprite sCorphishGfx42, 0x200
+ax_sprite_terminator
+sCorphishGfx43:
+.incbin "baserom.gba", 0x13EF15C, 0x200
+sCorphishSprites43:
+ax_sprite sCorphishGfx43, 0x200
+ax_sprite_terminator
+sCorphishGfx44:
+.incbin "baserom.gba", 0x13EF36C, 0x200
+sCorphishSprites44:
+ax_sprite sCorphishGfx44, 0x200
+ax_sprite_terminator
+sCorphishGfx45:
+.incbin "baserom.gba", 0x13EF57C, 0x200
+sCorphishSprites45:
+ax_sprite sCorphishGfx45, 0x200
+ax_sprite_terminator
+sCorphishGfx46:
+.incbin "baserom.gba", 0x13EF78C, 0x200
+sCorphishSprites46:
+ax_sprite sCorphishGfx46, 0x200
+ax_sprite_terminator
+sAxPosesCorphish:
+.4byte sCorphishPose1
+.4byte sCorphishPose2
+.4byte sCorphishPose3
+.4byte sCorphishPose4
+.4byte sCorphishPose5
+.4byte sCorphishPose6
+.4byte sCorphishPose7
+.4byte sCorphishPose8
+.4byte sCorphishPose9
+.4byte sCorphishPose10
+.4byte sCorphishPose11
+.4byte sCorphishPose12
+.4byte sCorphishPose13
+.4byte sCorphishPose14
+.4byte sCorphishPose15
+.4byte sCorphishPose16
+.4byte sCorphishPose17
+.4byte sCorphishPose18
+.4byte sCorphishPose19
+.4byte sCorphishPose20
+.4byte sCorphishPose21
+.4byte sCorphishPose22
+.4byte sCorphishPose23
+.4byte sCorphishPose24
+.4byte sCorphishPose25
+.4byte sCorphishPose26
+.4byte sCorphishPose27
+.4byte sCorphishPose28
+.4byte sCorphishPose29
+.4byte sCorphishPose30
+.4byte sCorphishPose31
+.4byte sCorphishPose32
+.4byte sCorphishPose33
+.4byte sCorphishPose34
+.4byte sCorphishPose35
+.4byte sCorphishPose36
+.4byte sCorphishPose37
+.4byte sCorphishPose38
+.4byte sCorphishPose39
+.4byte sCorphishPose40
+.4byte sCorphishPose41
+.4byte sCorphishPose42
+.4byte sCorphishPose43
+.4byte sCorphishPose44
+.4byte sCorphishPose45
+.4byte sCorphishPose46
+.4byte sCorphishPose47
+.4byte sCorphishPose48
+.4byte sCorphishPose49
+.4byte sCorphishPose50
+.4byte sCorphishPose51
+.4byte sCorphishPose52
+.4byte sCorphishPose53
+.4byte sCorphishPose54
+.4byte sCorphishPose55
+.4byte sCorphishPose56
+.4byte sCorphishPose57
+.4byte sCorphishPose58
+.4byte sCorphishPose59
+.4byte sCorphishPose60
+.4byte sCorphishPose61
+.4byte sCorphishPose62
+.4byte sCorphishPose63
+.4byte sCorphishPose64
+.4byte sCorphishPose65
+.4byte sCorphishPose66
+.4byte sCorphishPose67
+.4byte sCorphishPose68
+.4byte sCorphishPose69
+.4byte sCorphishPose70
+.4byte sCorphishPose71
+.4byte sCorphishPose72
+.4byte sCorphishPose73
+.4byte sCorphishPose74
+.4byte sCorphishPose75
+.4byte sCorphishPose76
+.4byte sCorphishPose77
+.4byte sCorphishPose78
+.4byte sCorphishPose79
+.4byte sCorphishPose80
+.4byte sCorphishPose81
+.4byte sCorphishPose82
+.4byte sCorphishPose83
+.4byte sCorphishPose84
+.4byte sCorphishPose85
+.4byte sCorphishPose86
+.4byte sCorphishPose87
+.4byte sCorphishPose88
+.4byte sCorphishPose89
+.4byte sCorphishPose90
+.4byte sCorphishPose91
+.4byte sCorphishPose92
+.4byte sCorphishPose93
+.4byte sCorphishPose94
+.4byte sCorphishPose95
+.4byte sCorphishPose96
+.4byte sCorphishPose97
+.4byte sCorphishPose98
+.4byte sCorphishPose99
+.4byte sCorphishPose100
+.4byte sCorphishPose101
+.4byte sCorphishPose102
+.4byte sCorphishPose103
+.4byte sCorphishPose104
+.4byte sCorphishPose105
+.4byte sCorphishPose106
+.4byte sCorphishPose107
+.4byte sCorphishPose108
+.4byte sCorphishPose109
+.4byte sCorphishPose110
+.4byte sCorphishPose111
+.4byte sCorphishPose112
+.4byte sCorphishPose113
+.4byte sCorphishPose114
+.4byte sCorphishPose115
+.4byte sCorphishPose116
+.4byte sCorphishPose117
+.4byte sCorphishPose118
+.4byte sCorphishPose119
+.4byte sCorphishPose120
+.4byte sCorphishPose121
+.4byte sCorphishPose122
+.4byte sCorphishPose123
+.4byte sCorphishPose124
+.4byte sCorphishPose125
+.4byte sCorphishPose126
+.4byte sCorphishPose127
+.4byte sCorphishPose128
+.4byte sCorphishPose129
+.4byte sCorphishPose130
+.4byte sCorphishPose131
+.4byte sCorphishPose132
+.4byte sCorphishPose133
+.4byte sCorphishPose134
+.4byte sCorphishPose135
+.4byte sCorphishPose136
+.4byte sCorphishPose137
+.4byte sCorphishPose138
+.4byte sCorphishPose139
+.4byte sCorphishPose140
+.4byte sCorphishPose141
+.4byte sCorphishPose142
+.4byte sCorphishPose143
+.4byte sCorphishPose144
+.4byte sCorphishPose145
+.4byte sCorphishPose146
+.4byte sCorphishPose147
+.4byte sCorphishPose148
+.4byte sCorphishPose149
+.4byte sCorphishPose150
+.4byte sCorphishPose151
+.4byte sCorphishPose152
+.4byte sCorphishPose153
+.4byte sCorphishPose154
+.4byte sCorphishPose155
+.4byte sCorphishPose156
+.4byte sCorphishPose157
+.4byte sCorphishPose158
+.4byte sCorphishPose159
+.4byte sCorphishPose160
+.4byte sCorphishPose161
+.4byte sCorphishPose162
+.4byte sCorphishPose163
+.4byte sCorphishPose164
+.4byte sCorphishPose165
+.4byte sCorphishPose166
+.4byte sCorphishPose167
+.4byte sCorphishPose168
+.4byte sCorphishPose169
+.4byte sCorphishPose170
+.4byte sCorphishPose171
+.4byte sCorphishPose172
+.4byte sCorphishPose173
+.4byte sCorphishPose174
+.4byte sCorphishPose175
+.4byte sCorphishPose176
+.4byte sCorphishPose177
+.4byte sCorphishPose178
+.4byte sCorphishPose179
+.4byte sCorphishPose180
+.4byte sCorphishPose181
+.4byte sCorphishPose182
+.4byte sCorphishPose183
+.4byte sCorphishPose184
+.4byte sCorphishPose185
+.4byte sCorphishPose186
+.4byte sCorphishPose187
+.4byte sCorphishPose188
+.4byte sCorphishPose189
+.4byte sCorphishPose190
+.4byte sCorphishPose191
+.4byte sCorphishPose192
+.4byte sCorphishPose193
+.4byte sCorphishPose194
+.4byte sCorphishPose195
+.4byte sCorphishPose196
+.4byte sCorphishPose197
+.4byte sCorphishPose198
+.4byte sCorphishPose199
+.4byte sCorphishPose200
+.4byte sCorphishPose201
+.4byte sCorphishPose202
+.4byte sCorphishPose203
+.4byte sCorphishPose204
+.4byte sCorphishPose205
+.4byte sCorphishPose206
+.4byte sCorphishPose207
+.4byte sCorphishPose208
+.4byte sCorphishPose209
+.4byte sCorphishPose210
+.4byte sCorphishPose211
+.4byte sCorphishPose212
+.4byte sCorphishPose213
+.4byte sCorphishPose214
+.4byte sCorphishPose215
+.4byte sCorphishPose216
+.4byte sCorphishPose217
+.4byte sCorphishPose218
+sAxPositionsCorphish:
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,   -4
+.2byte   -1,   -7, 	 -10,   -7, 	   8,   -7, 	  -1,   -5
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+.2byte    2,   -5, 	   8,  -11, 	  -5,   -7, 	  -1,   -4
+.2byte    1,   -6, 	   8,  -10, 	  -5,   -4, 	  -2,   -5
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte    3,   -7, 	   6,  -12, 	   5,   -5, 	  -3,   -6
+.2byte    2,   -8, 	   4,  -14, 	   5,   -3, 	  -3,   -6
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte    1,   -9, 	  -4,  -14, 	   8,   -8, 	  -2,   -5
+.2byte    0,  -10, 	  -5,  -13, 	   9,   -7, 	  -3,   -6
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte   -1,  -10, 	   8,  -13, 	  -9,  -13, 	  -1,   -5
+.2byte   -1,  -11, 	   8,  -11, 	  -9,  -11, 	  -1,   -6
+.2byte   -2,   -9, 	   3,  -12, 	 -11,   -9, 	   0,   -5
+.2byte   -3,   -9, 	   2,  -14, 	 -10,   -8, 	   0,   -5
+.2byte   -2,  -10, 	   3,  -13, 	 -11,   -7, 	   1,   -6
+.2byte   -5,   -7, 	  -7,  -13, 	  -7,   -4, 	   1,   -6
+.2byte   -5,   -7, 	  -8,  -12, 	  -7,   -5, 	   1,   -6
+.2byte   -4,   -8, 	  -6,  -14, 	  -7,   -3, 	   1,   -6
+.2byte   -3,   -5, 	 -10,  -11, 	   3,   -5, 	   0,   -4
+.2byte   -4,   -5, 	 -10,  -11, 	   3,   -7, 	  -1,   -4
+.2byte   -3,   -6, 	 -10,  -10, 	   3,   -4, 	   0,   -5
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,   -4
+.2byte   -1,   -7, 	 -10,   -7, 	   8,   -7, 	  -1,   -5
+.2byte   -1,   -8, 	 -10,  -12, 	   8,  -12, 	  -1,   -4
+.2byte   -1,   -2, 	 -11,   -3, 	   8,   -3, 	  -1,   -5
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+.2byte    2,   -5, 	   8,  -11, 	  -5,   -7, 	  -1,   -4
+.2byte    1,   -6, 	   8,  -10, 	  -5,   -4, 	  -2,   -5
+.2byte    1,   -8, 	   5,  -14, 	  -9,   -9, 	  -3,   -5
+.2byte    3,   -4, 	  10,   -7, 	  -3,   -2, 	   0,   -5
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte    3,   -7, 	   6,  -12, 	   5,   -5, 	  -3,   -6
+.2byte    2,   -8, 	   4,  -14, 	   5,   -3, 	  -3,   -6
+.2byte    0,  -11, 	   4,  -18, 	   3,  -11, 	  -4,   -7
+.2byte    3,   -6, 	   7,  -13, 	   5,   -3, 	  -3,   -5
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte    1,   -9, 	  -4,  -14, 	   8,   -8, 	  -2,   -5
+.2byte    0,  -10, 	  -5,  -13, 	   9,   -7, 	  -3,   -6
+.2byte   -2,  -11, 	  -7,  -16, 	   6,  -12, 	  -4,   -5
+.2byte    2,   -8, 	  -1,  -12, 	   7,   -6, 	  -3,   -5
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte   -1,  -10, 	   8,  -13, 	  -9,  -13, 	  -1,   -5
+.2byte   -1,  -11, 	   8,  -11, 	  -9,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	   8,  -17, 	 -10,  -16, 	  -1,   -6
+.2byte   -1,  -10, 	   7,  -13, 	  -9,  -13, 	  -1,   -6
+.2byte   -2,   -9, 	   3,  -12, 	 -11,   -9, 	   0,   -5
+.2byte   -3,   -9, 	   2,  -14, 	 -10,   -8, 	   0,   -5
+.2byte   -2,  -10, 	   3,  -13, 	 -11,   -7, 	   1,   -6
+.2byte    0,  -11, 	   5,  -16, 	  -8,  -12, 	   2,   -5
+.2byte   -4,   -8, 	  -1,  -12, 	  -9,   -6, 	   1,   -5
+.2byte   -5,   -7, 	  -7,  -13, 	  -7,   -4, 	   1,   -6
+.2byte   -5,   -7, 	  -8,  -12, 	  -7,   -5, 	   1,   -6
+.2byte   -4,   -8, 	  -6,  -14, 	  -7,   -3, 	   1,   -6
+.2byte   -2,  -11, 	  -6,  -18, 	  -5,  -11, 	   2,   -7
+.2byte   -5,   -6, 	  -9,  -13, 	  -7,   -3, 	   1,   -5
+.2byte   -3,   -5, 	 -10,  -11, 	   3,   -5, 	   0,   -4
+.2byte   -4,   -5, 	 -10,  -11, 	   3,   -7, 	  -1,   -4
+.2byte   -3,   -6, 	 -10,  -10, 	   3,   -4, 	   0,   -5
+.2byte   -3,   -8, 	  -7,  -14, 	   7,   -9, 	   1,   -5
+.2byte   -5,   -4, 	 -12,   -7, 	   1,   -2, 	  -2,   -5
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,  -12, 	   8,  -12, 	  -1,   -4
+.2byte   -1,   -2, 	 -11,   -3, 	   8,   -3, 	  -1,   -5
+.2byte   -1,   -2, 	 -11,   -1, 	   9,   -1, 	  -1,   -5
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+.2byte    0,   -7, 	   5,  -15, 	  -8,   -8, 	  -2,   -5
+.2byte    3,   -4, 	  10,   -7, 	  -3,   -2, 	   0,   -5
+.2byte    3,   -4, 	  12,   -7, 	  -2,   -1, 	  -1,   -5
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte   -1,  -10, 	   2,  -16, 	   1,   -7, 	  -4,   -7
+.2byte    3,   -6, 	   7,  -13, 	   5,   -3, 	  -3,   -5
+.2byte    3,   -6, 	   8,  -10, 	   9,   -3, 	  -2,   -5
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte   -2,  -10, 	  -7,  -17, 	   4,   -8, 	  -5,   -5
+.2byte    2,   -8, 	  -1,  -12, 	   7,   -6, 	  -3,   -5
+.2byte    2,   -7, 	  -2,  -11, 	  10,   -5, 	  -2,   -5
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte   -1,  -11, 	   8,  -17, 	 -10,  -16, 	  -1,   -6
+.2byte   -1,  -10, 	   7,  -13, 	  -9,  -13, 	  -1,   -6
+.2byte   -1,  -10, 	   7,  -11, 	  -9,  -11, 	  -1,   -6
+.2byte   -2,   -9, 	   3,  -12, 	 -11,   -9, 	   0,   -5
+.2byte    0,  -10, 	   5,  -17, 	  -6,   -8, 	   3,   -5
+.2byte   -4,   -8, 	  -1,  -12, 	  -9,   -6, 	   1,   -5
+.2byte   -4,   -7, 	   0,  -11, 	 -12,   -5, 	   0,   -5
+.2byte   -5,   -7, 	  -7,  -13, 	  -7,   -4, 	   1,   -6
+.2byte   -1,  -10, 	  -4,  -16, 	  -3,   -7, 	   2,   -7
+.2byte   -5,   -6, 	  -9,  -13, 	  -7,   -3, 	   1,   -5
+.2byte   -5,   -6, 	 -10,  -10, 	 -11,   -3, 	   0,   -5
+.2byte   -3,   -5, 	 -10,  -11, 	   3,   -5, 	   0,   -4
+.2byte   -2,   -7, 	  -7,  -15, 	   6,   -8, 	   0,   -5
+.2byte   -5,   -4, 	 -12,   -7, 	   1,   -2, 	  -2,   -5
+.2byte   -5,   -4, 	 -14,   -7, 	   0,   -1, 	  -1,   -5
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -1,   -8, 	 -10,  -12, 	   8,  -12, 	  -1,   -4
+.2byte   -1,   -2, 	 -11,   -3, 	   8,   -3, 	  -1,   -5
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+.2byte    1,   -8, 	   5,  -14, 	  -9,   -9, 	  -3,   -5
+.2byte    3,   -4, 	  10,   -7, 	  -3,   -2, 	   0,   -5
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte    0,  -11, 	   4,  -18, 	   3,  -11, 	  -4,   -7
+.2byte    3,   -6, 	   7,  -13, 	   5,   -3, 	  -3,   -5
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte   -2,  -11, 	  -7,  -16, 	   6,  -12, 	  -4,   -5
+.2byte    2,   -8, 	  -1,  -12, 	   7,   -6, 	  -3,   -5
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte   -1,  -10, 	   8,  -16, 	 -10,  -15, 	  -1,   -5
+.2byte   -1,  -10, 	   7,  -13, 	  -9,  -13, 	  -1,   -6
+.2byte   -2,   -9, 	   3,  -12, 	 -11,   -9, 	   0,   -5
+.2byte    0,  -11, 	   5,  -16, 	  -8,  -12, 	   2,   -5
+.2byte   -4,   -8, 	  -1,  -12, 	  -9,   -6, 	   1,   -5
+.2byte   -5,   -7, 	  -7,  -13, 	  -7,   -4, 	   1,   -6
+.2byte   -2,  -11, 	  -6,  -18, 	  -5,  -11, 	   2,   -7
+.2byte   -5,   -6, 	  -9,  -13, 	  -7,   -3, 	   1,   -5
+.2byte   -3,   -5, 	 -10,  -11, 	   3,   -5, 	   0,   -4
+.2byte   -3,   -8, 	  -7,  -14, 	   7,   -9, 	   1,   -5
+.2byte   -5,   -4, 	 -12,   -7, 	   1,   -2, 	  -2,   -5
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -1,   -8, 	 -12,  -10, 	  11,  -10, 	  -1,   -6
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+.2byte    1,   -7, 	   9,  -14, 	  -6,   -6, 	  -2,   -6
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte    3,   -8, 	   6,  -16, 	   7,   -6, 	  -3,   -7
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte    1,  -11, 	  -5,  -16, 	  11,  -10, 	  -2,   -7
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte   -1,  -11, 	   9,  -14, 	 -11,  -14, 	  -1,   -6
+.2byte   -2,   -9, 	   3,  -12, 	 -11,   -9, 	   0,   -5
+.2byte   -3,  -11, 	   3,  -16, 	 -13,  -10, 	   0,   -7
+.2byte   -5,   -7, 	  -7,  -13, 	  -7,   -4, 	   1,   -6
+.2byte   -5,   -8, 	  -8,  -16, 	  -9,   -6, 	   1,   -7
+.2byte   -3,   -5, 	 -10,  -11, 	   3,   -5, 	   0,   -4
+.2byte   -3,   -7, 	 -11,  -14, 	   4,   -6, 	   0,   -6
+.2byte   -3,   -4, 	  -9,   -2, 	  -3,    2, 	   2,   -4
+.2byte   -3,   -3, 	  -9,   -2, 	  -3,    2, 	   2,   -3
+.2byte    1,   -9, 	 -13,  -13, 	  10,  -15, 	   0,   -6
+.2byte    1,   -9, 	   8,  -15, 	  -9,   -9, 	  -1,   -6
+.2byte    4,   -8, 	   4,  -18, 	  -7,  -11, 	   0,   -5
+.2byte    0,  -10, 	  -6,  -17, 	   4,  -11, 	  -2,   -5
+.2byte    0,  -11, 	  11,  -15, 	 -10,  -14, 	   0,   -5
+.2byte   -1,  -10, 	   5,  -17, 	  -5,  -11, 	   1,   -5
+.2byte   -5,   -8, 	  -5,  -18, 	   6,  -11, 	  -1,   -5
+.2byte   -2,   -9, 	  -9,  -15, 	   8,   -9, 	   0,   -6
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,   -4
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+.2byte    2,   -5, 	   8,  -11, 	  -5,   -7, 	  -1,   -4
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte    3,   -7, 	   6,  -12, 	   5,   -5, 	  -3,   -6
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte    1,   -9, 	  -4,  -14, 	   8,   -8, 	  -2,   -5
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte   -1,  -10, 	   8,  -13, 	  -9,  -13, 	  -1,   -5
+.2byte   -2,   -9, 	   3,  -12, 	 -11,   -9, 	   0,   -5
+.2byte   -3,   -9, 	   2,  -14, 	 -10,   -8, 	   0,   -5
+.2byte   -5,   -7, 	  -7,  -13, 	  -7,   -4, 	   1,   -6
+.2byte   -5,   -7, 	  -8,  -12, 	  -7,   -5, 	   1,   -6
+.2byte   -3,   -5, 	 -10,  -11, 	   3,   -5, 	   0,   -4
+.2byte   -4,   -5, 	 -10,  -11, 	   3,   -7, 	  -1,   -4
+.2byte    0,  -11, 	  -9,  -15, 	   9,  -15, 	   0,   -7
+.2byte   -4,  -10, 	  -8,  -16, 	   6,  -11, 	   0,   -7
+.2byte   -3,  -13, 	  -7,  -20, 	  -6,  -13, 	   1,   -9
+.2byte   -1,  -14, 	   4,  -19, 	  -9,  -15, 	   1,   -8
+.2byte    0,  -13, 	   9,  -19, 	  -9,  -18, 	   0,   -8
+.2byte    0,  -14, 	  -5,  -19, 	   8,  -15, 	  -2,   -8
+.2byte    2,  -13, 	   6,  -20, 	   5,  -13, 	  -2,   -9
+.2byte    3,  -10, 	   7,  -16, 	  -7,  -11, 	  -1,   -7
+.2byte    0,   -8, 	  -9,  -12, 	   9,  -12, 	   0,   -4
+.2byte    2,   -7, 	   6,  -13, 	  -8,   -8, 	  -2,   -4
+.2byte    2,  -10, 	   6,  -17, 	   5,  -10, 	  -2,   -6
+.2byte    0,  -11, 	  -5,  -16, 	   8,  -12, 	  -2,   -5
+.2byte    0,  -11, 	   9,  -17, 	  -9,  -16, 	   0,   -6
+.2byte   -1,  -11, 	   4,  -16, 	  -9,  -12, 	   1,   -5
+.2byte   -3,  -10, 	  -7,  -17, 	  -6,  -10, 	   1,   -6
+.2byte   -3,   -7, 	  -7,  -13, 	   7,   -8, 	   1,   -4
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -1,   -7, 	 -10,  -11, 	   8,  -11, 	  -1,   -3
+.2byte   -1,   -4, 	 -11,   -5, 	   8,   -5, 	  -1,   -7
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+.2byte    2,   -8, 	   6,  -14, 	  -8,   -9, 	  -2,   -5
+.2byte    2,   -4, 	   9,   -7, 	  -4,   -2, 	  -1,   -5
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte    1,  -11, 	   5,  -18, 	   4,  -11, 	  -3,   -7
+.2byte    4,   -6, 	   8,  -13, 	   6,   -3, 	  -2,   -5
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte   -2,  -11, 	  -7,  -16, 	   6,  -12, 	  -4,   -5
+.2byte    3,   -8, 	   0,  -12, 	   8,   -6, 	  -2,   -5
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte   -1,  -10, 	   8,  -16, 	 -10,  -15, 	  -1,   -5
+.2byte   -1,  -11, 	   7,  -14, 	  -9,  -14, 	  -1,   -7
+.2byte   -1,   -9, 	   4,  -12, 	 -10,   -9, 	   1,   -5
+.2byte    1,  -11, 	   6,  -16, 	  -7,  -12, 	   3,   -5
+.2byte   -4,   -8, 	  -1,  -12, 	  -9,   -6, 	   1,   -5
+.2byte   -4,   -7, 	  -6,  -13, 	  -6,   -4, 	   2,   -6
+.2byte   -2,  -11, 	  -6,  -18, 	  -5,  -11, 	   2,   -7
+.2byte   -4,   -6, 	  -8,  -13, 	  -6,   -3, 	   2,   -5
+.2byte   -2,   -5, 	  -9,  -11, 	   4,   -5, 	   1,   -4
+.2byte   -3,   -8, 	  -7,  -14, 	   7,   -9, 	   1,   -5
+.2byte   -3,   -4, 	 -10,   -7, 	   3,   -2, 	   0,   -5
+.2byte    0,   -8, 	  -8,  -12, 	   9,  -12, 	   0,   -4
+.2byte   -2,   -7, 	  -7,  -15, 	   6,   -8, 	   0,   -5
+.2byte   -2,   -9, 	  -5,  -15, 	  -4,   -6, 	   1,   -6
+.2byte   -1,  -10, 	   4,  -17, 	  -7,   -8, 	   2,   -5
+.2byte    0,  -11, 	   9,  -17, 	  -9,  -16, 	   0,   -6
+.2byte    0,  -10, 	  -5,  -17, 	   6,   -8, 	  -3,   -5
+.2byte    1,   -9, 	   4,  -15, 	   3,   -6, 	  -2,   -6
+.2byte    1,   -7, 	   6,  -15, 	  -7,   -8, 	  -1,   -5
+.2byte   -1,   -6, 	 -10,   -7, 	   8,   -8, 	  -1,   -5
+.2byte   -3,   -5, 	 -10,  -11, 	   3,   -5, 	   0,   -4
+.2byte   -5,   -7, 	  -7,  -13, 	  -7,   -4, 	   1,   -6
+.2byte   -2,   -9, 	   3,  -12, 	 -11,   -9, 	   0,   -5
+.2byte   -1,  -11, 	   8,  -12, 	  -9,  -12, 	  -1,   -6
+.2byte    0,   -9, 	  -5,  -12, 	   9,   -9, 	  -2,   -5
+.2byte    3,   -7, 	   5,  -13, 	   5,   -4, 	  -3,   -6
+.2byte    1,   -5, 	   8,  -11, 	  -5,   -5, 	  -2,   -4
+sCorphishAnimTable1:
+.4byte sCorphishAnims_1_1
+.4byte sCorphishAnims_1_2
+.4byte sCorphishAnims_1_3
+.4byte sCorphishAnims_1_4
+.4byte sCorphishAnims_1_5
+.4byte sCorphishAnims_1_6
+.4byte sCorphishAnims_1_7
+.4byte sCorphishAnims_1_8
+sCorphishAnimTable2:
+.4byte sCorphishAnims_2_1
+.4byte sCorphishAnims_2_2
+.4byte sCorphishAnims_2_3
+.4byte sCorphishAnims_2_4
+.4byte sCorphishAnims_2_5
+.4byte sCorphishAnims_2_6
+.4byte sCorphishAnims_2_7
+.4byte sCorphishAnims_2_8
+sCorphishAnimTable3:
+.4byte sCorphishAnims_3_1
+.4byte sCorphishAnims_3_2
+.4byte sCorphishAnims_3_3
+.4byte sCorphishAnims_3_4
+.4byte sCorphishAnims_3_5
+.4byte sCorphishAnims_3_6
+.4byte sCorphishAnims_3_7
+.4byte sCorphishAnims_3_8
+sCorphishAnimTable4:
+.4byte sCorphishAnims_4_1
+.4byte sCorphishAnims_4_2
+.4byte sCorphishAnims_4_3
+.4byte sCorphishAnims_4_4
+.4byte sCorphishAnims_4_5
+.4byte sCorphishAnims_4_6
+.4byte sCorphishAnims_4_7
+.4byte sCorphishAnims_4_8
+sCorphishAnimTable5:
+.4byte sCorphishAnims_5_1
+.4byte sCorphishAnims_5_2
+.4byte sCorphishAnims_5_3
+.4byte sCorphishAnims_5_4
+.4byte sCorphishAnims_5_5
+.4byte sCorphishAnims_5_6
+.4byte sCorphishAnims_5_7
+.4byte sCorphishAnims_5_8
+sCorphishAnimTable6:
+.4byte sCorphishAnims_6_1
+.4byte sCorphishAnims_6_1
+.4byte sCorphishAnims_6_1
+.4byte sCorphishAnims_6_1
+.4byte sCorphishAnims_6_1
+.4byte sCorphishAnims_6_1
+.4byte sCorphishAnims_6_1
+.4byte sCorphishAnims_6_1
+sCorphishAnimTable7:
+.4byte sCorphishAnims_7_1
+.4byte sCorphishAnims_7_2
+.4byte sCorphishAnims_7_3
+.4byte sCorphishAnims_7_4
+.4byte sCorphishAnims_7_5
+.4byte sCorphishAnims_7_6
+.4byte sCorphishAnims_7_7
+.4byte sCorphishAnims_7_8
+sCorphishAnimTable8:
+.4byte sCorphishAnims_8_1
+.4byte sCorphishAnims_8_2
+.4byte sCorphishAnims_8_3
+.4byte sCorphishAnims_8_4
+.4byte sCorphishAnims_8_5
+.4byte sCorphishAnims_8_6
+.4byte sCorphishAnims_8_7
+.4byte sCorphishAnims_8_8
+sCorphishAnimTable9:
+.4byte sCorphishAnims_9_1
+.4byte sCorphishAnims_9_2
+.4byte sCorphishAnims_9_3
+.4byte sCorphishAnims_9_4
+.4byte sCorphishAnims_9_5
+.4byte sCorphishAnims_9_6
+.4byte sCorphishAnims_9_7
+.4byte sCorphishAnims_9_8
+sCorphishAnimTable10:
+.4byte sCorphishAnims_10_1
+.4byte sCorphishAnims_10_2
+.4byte sCorphishAnims_10_3
+.4byte sCorphishAnims_10_4
+.4byte sCorphishAnims_10_5
+.4byte sCorphishAnims_10_6
+.4byte sCorphishAnims_10_7
+.4byte sCorphishAnims_10_8
+sCorphishAnimTable11:
+.4byte sCorphishAnims_11_1
+.4byte sCorphishAnims_11_2
+.4byte sCorphishAnims_11_3
+.4byte sCorphishAnims_11_4
+.4byte sCorphishAnims_11_5
+.4byte sCorphishAnims_11_6
+.4byte sCorphishAnims_11_7
+.4byte sCorphishAnims_11_8
+sCorphishAnimTable12:
+.4byte sCorphishAnims_12_1
+.4byte sCorphishAnims_12_2
+.4byte sCorphishAnims_12_3
+.4byte sCorphishAnims_12_4
+.4byte sCorphishAnims_12_5
+.4byte sCorphishAnims_12_6
+.4byte sCorphishAnims_12_7
+.4byte sCorphishAnims_12_8
+sCorphishAnimTable13:
+.4byte sCorphishAnims_13_1
+.4byte sCorphishAnims_13_2
+.4byte sCorphishAnims_13_3
+.4byte sCorphishAnims_13_4
+.4byte sCorphishAnims_13_5
+.4byte sCorphishAnims_13_6
+.4byte sCorphishAnims_13_7
+.4byte sCorphishAnims_13_8
+sAxAnimationsCorphish:
+.4byte sCorphishAnimTable1
+.4byte sCorphishAnimTable2
+.4byte sCorphishAnimTable3
+.4byte sCorphishAnimTable4
+.4byte sCorphishAnimTable5
+.4byte sCorphishAnimTable6
+.4byte sCorphishAnimTable7
+.4byte sCorphishAnimTable8
+.4byte sCorphishAnimTable9
+.4byte sCorphishAnimTable10
+.4byte sCorphishAnimTable11
+.4byte sCorphishAnimTable12
+.4byte sCorphishAnimTable13
+sAxSpritesCorphish:
+.4byte sCorphishSprites1
+.4byte sCorphishSprites2
+.4byte sCorphishSprites3
+.4byte sCorphishSprites4
+.4byte sCorphishSprites5
+.4byte sCorphishSprites6
+.4byte sCorphishSprites7
+.4byte sCorphishSprites8
+.4byte sCorphishSprites9
+.4byte sCorphishSprites10
+.4byte sCorphishSprites11
+.4byte sCorphishSprites12
+.4byte sCorphishSprites13
+.4byte sCorphishSprites14
+.4byte sCorphishSprites15
+.4byte sCorphishSprites16
+.4byte sCorphishSprites17
+.4byte sCorphishSprites18
+.4byte sCorphishSprites19
+.4byte sCorphishSprites20
+.4byte sCorphishSprites21
+.4byte sCorphishSprites22
+.4byte sCorphishSprites23
+.4byte sCorphishSprites24
+.4byte sCorphishSprites25
+.4byte sCorphishSprites26
+.4byte sCorphishSprites27
+.4byte sCorphishSprites28
+.4byte sCorphishSprites29
+.4byte sCorphishSprites30
+.4byte sCorphishSprites31
+.4byte sCorphishSprites32
+.4byte sCorphishSprites33
+.4byte sCorphishSprites34
+.4byte sCorphishSprites35
+.4byte sCorphishSprites36
+.4byte sCorphishSprites37
+.4byte sCorphishSprites38
+.4byte sCorphishSprites39
+.4byte sCorphishSprites40
+.4byte sCorphishSprites41
+.4byte sCorphishSprites42
+.4byte sCorphishSprites43
+.4byte sCorphishSprites44
+.4byte sCorphishSprites45
+.4byte sCorphishSprites46
+sAxMainCorphish:
+ax_main sAxPosesCorphish, sAxAnimationsCorphish, 13, sAxSpritesCorphish, sAxPositionsCorphish

--- a/data/ax/corsola.inc
+++ b/data/ax/corsola.inc
@@ -1,0 +1,2341 @@
+.global gAxCorsola
+gAxCorsola:
+ax_siro sAxMainCorsola
+sCorsolaPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose6:
+ax_pose 5, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose7:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose8:
+ax_pose 7, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose9:
+ax_pose 8, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose10:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose11:
+ax_pose 10, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose19:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose21:
+ax_pose 8, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose28:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose29:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose30:
+ax_pose 5, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose31:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose32:
+ax_pose 7, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose33:
+ax_pose 8, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose34:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose35:
+ax_pose 10, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose36:
+ax_pose 11, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose41:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose43:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose44:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose45:
+ax_pose 8, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose47:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose48:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose50:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose51:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose52:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose53:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose54:
+ax_pose 5, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose55:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose56:
+ax_pose 7, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose57:
+ax_pose 8, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose58:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose59:
+ax_pose 10, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose60:
+ax_pose 11, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose61:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose62:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose63:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose64:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose65:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose66:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose67:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose68:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose69:
+ax_pose 8, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose71:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose72:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose73:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose74:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose75:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose76:
+ax_pose 16, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose77:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose78:
+ax_pose 17, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose79:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose80:
+ax_pose 18, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose81:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose82:
+ax_pose 19, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose83:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose84:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose85:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose86:
+ax_pose 17, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose87:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose88:
+ax_pose 16, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose89:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose90:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose91:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose92:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose93:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose94:
+ax_pose 5, 0x01ee, 0x90eb, 0x1c00
+ax_pose_terminator
+sCorsolaPose95:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose96:
+ax_pose 7, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose97:
+ax_pose 8, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sCorsolaPose98:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose99:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sCorsolaPose100:
+ax_pose 11, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose102:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose103:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose104:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose105:
+ax_pose 10, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sCorsolaPose106:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose107:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose108:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose109:
+ax_pose 8, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sCorsolaPose110:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose111:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose112:
+ax_pose 5, 0x01ee, 0x80f5, 0x1c00
+ax_pose_terminator
+sCorsolaPose113:
+ax_pose 20, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose114:
+ax_pose 21, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose115:
+ax_pose 22, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose116:
+ax_pose 23, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sCorsolaPose117:
+ax_pose 24, 0x01e4, 0x90ea, 0x1c00
+ax_pose_terminator
+sCorsolaPose118:
+ax_pose 25, 0x01e4, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose119:
+ax_pose 26, 0x01e6, 0x80f5, 0x1c00
+ax_pose_terminator
+sCorsolaPose120:
+ax_pose 25, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose121:
+ax_pose 24, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sCorsolaPose122:
+ax_pose 23, 0x01e6, 0x80f3, 0x1c00
+ax_pose_terminator
+sCorsolaPose123:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose124:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose125:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose126:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose127:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose128:
+ax_pose 5, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose129:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose130:
+ax_pose 7, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose131:
+ax_pose 8, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose132:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose133:
+ax_pose 10, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose134:
+ax_pose 11, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose135:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose136:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose137:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose138:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose139:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose140:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose141:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose142:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose143:
+ax_pose 8, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose144:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose145:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose146:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose147:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose148:
+ax_pose 16, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose149:
+ax_pose 17, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose150:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose151:
+ax_pose 19, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose152:
+ax_pose 18, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose153:
+ax_pose 17, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose154:
+ax_pose 16, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose155:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose156:
+ax_pose 16, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose157:
+ax_pose 17, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose158:
+ax_pose 18, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose159:
+ax_pose 19, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose160:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose161:
+ax_pose 17, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose162:
+ax_pose 16, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose163:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose164:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose165:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose166:
+ax_pose 16, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose167:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose168:
+ax_pose 17, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose169:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose170:
+ax_pose 18, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose171:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose172:
+ax_pose 19, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose173:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose174:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose175:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose176:
+ax_pose 17, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose177:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose178:
+ax_pose 16, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose179:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose180:
+ax_pose 16, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose181:
+ax_pose 17, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose182:
+ax_pose 18, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose183:
+ax_pose 19, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose184:
+ax_pose 18, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose185:
+ax_pose 17, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose186:
+ax_pose 16, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose187:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose188:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose189:
+ax_pose 6, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose190:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose191:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sCorsolaPose192:
+ax_pose 9, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose193:
+ax_pose 6, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sCorsolaPose194:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+.align 2
+sCorsolaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCorsolaAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 20, 20, 20, 20,
+ax_anim 2, 1, 27, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 20, 20, 20, 20,
+ax_anim 2, 0, 27, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sCorsolaAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 20, 0, 20, 0,
+ax_anim 2, 1, 30, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 20, 0, 20, 0,
+ax_anim 2, 0, 30, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sCorsolaAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 33, 20, -20, 20, -20,
+ax_anim 2, 1, 33, 21, -19, 21, -19,
+ax_anim 2, 0, 33, 20, -20, 20, -20,
+ax_anim 2, 0, 33, 21, -19, 21, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sCorsolaAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 1, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 0, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sCorsolaAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 39, -20, -20, -20, -20,
+ax_anim 2, 1, 39, -21, -19, -21, -19,
+ax_anim 2, 0, 39, -20, -20, -20, -20,
+ax_anim 2, 0, 39, -21, -19, -21, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sCorsolaAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -20, 0, -20, 0,
+ax_anim 2, 1, 42, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -20, 0, -20, 0,
+ax_anim 2, 0, 42, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sCorsolaAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -20, 20, -20, 20,
+ax_anim 2, 1, 45, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -20, 20, -20, 20,
+ax_anim 2, 0, 45, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sCorsolaAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 20, 20, 20, 20,
+ax_anim 2, 1, 51, 21, 19, 21, 19,
+ax_anim 2, 0, 51, 20, 20, 20, 20,
+ax_anim 2, 0, 51, 21, 19, 21, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sCorsolaAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 20, 0, 20, 0,
+ax_anim 2, 1, 54, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 20, 0, 20, 0,
+ax_anim 2, 0, 54, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sCorsolaAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -4, 4, -4,
+ax_anim 1, 0, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 57, 20, -20, 20, -20,
+ax_anim 2, 1, 57, 21, -19, 21, -19,
+ax_anim 2, 0, 57, 20, -20, 20, -20,
+ax_anim 2, 0, 57, 21, -19, 21, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sCorsolaAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 60, 0, -21, 0, -21,
+ax_anim 2, 1, 60, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -21, 0, -21,
+ax_anim 2, 0, 60, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sCorsolaAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -4, -4, -4,
+ax_anim 1, 0, 65, -10, -10, -10, -10,
+ax_anim 2, 0, 63, -20, -20, -20, -20,
+ax_anim 2, 1, 63, -21, -19, -21, -19,
+ax_anim 2, 0, 63, -20, -20, -20, -20,
+ax_anim 2, 0, 63, -21, -19, -21, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sCorsolaAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -20, 0, -20, 0,
+ax_anim 2, 1, 66, -20, 1, -20, 1,
+ax_anim 2, 0, 66, -20, 0, -20, 0,
+ax_anim 2, 0, 66, -20, 1, -20, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sCorsolaAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -20, 20, -20, 20,
+ax_anim 2, 1, 69, -21, 19, -21, 19,
+ax_anim 2, 0, 69, -20, 20, -20, 20,
+ax_anim 2, 0, 69, -21, 19, -21, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 6, 2, 72, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 73, 0, 3, 0, 2,
+ax_anim 2, 0, 73, 1, 3, 1, 2,
+ax_anim 2, 0, 73, 0, 3, 0, 2,
+ax_anim 2, 0, 73, 1, 3, 1, 2,
+ax_anim 2, 0, 73, 0, 3, 0, 2,
+ax_anim 2, 0, 73, 1, 3, 1, 2,
+ax_anim 2, 0, 73, 0, 3, 0, 2,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sCorsolaAnims_4_2:
+ax_anim 2, 0, 74, -2, -2, -2, -2,
+ax_anim 6, 2, 74, -3, -3, -3, -3,
+ax_anim 2, 0, 74, -1, -1, -1, -1,
+ax_anim 2, 1, 75, 2, 2, 1, 1,
+ax_anim 2, 0, 75, 3, 1, 2, 0,
+ax_anim 2, 0, 75, 2, 2, 1, 1,
+ax_anim 2, 0, 75, 3, 1, 2, 0,
+ax_anim 2, 0, 75, 2, 2, 1, 1,
+ax_anim 2, 0, 75, 3, 1, 2, 0,
+ax_anim 2, 0, 75, 2, 2, 1, 1,
+ax_anim 2, 0, 74, 1, 1, 1, 1,
+ax_anim_terminator
+sCorsolaAnims_4_3:
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 6, 2, 76, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 2, 1, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 77, 2, 1, 2, 1,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 77, 2, 1, 2, 1,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 77, 2, 1, 2, 1,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim_terminator
+sCorsolaAnims_4_4:
+ax_anim 2, 0, 78, -2, 2, -2, 2,
+ax_anim 6, 2, 78, -3, 3, -3, 3,
+ax_anim 2, 0, 78, -1, 1, -1, 1,
+ax_anim 2, 1, 79, 2, -2, 1, -1,
+ax_anim 2, 0, 79, 3, -1, 2, 0,
+ax_anim 2, 0, 79, 2, -2, 1, -1,
+ax_anim 2, 0, 79, 3, -1, 2, 0,
+ax_anim 2, 0, 79, 2, -2, 1, -1,
+ax_anim 2, 0, 79, 3, -1, 2, 0,
+ax_anim 2, 0, 79, 2, -2, 1, -1,
+ax_anim 2, 0, 78, 1, -1, 1, -1,
+ax_anim_terminator
+sCorsolaAnims_4_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 6, 2, 80, 0, 3, 0, 3,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 1, 81, 0, -3, 0, -2,
+ax_anim 2, 0, 81, 1, -3, 1, -2,
+ax_anim 2, 0, 81, 0, -3, 0, -2,
+ax_anim 2, 0, 81, 1, -3, 1, -2,
+ax_anim 2, 0, 81, 0, -3, 0, -2,
+ax_anim 2, 0, 81, 1, -3, 1, -2,
+ax_anim 2, 0, 81, 0, -3, 0, -2,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim_terminator
+sCorsolaAnims_4_6:
+ax_anim 2, 0, 82, 2, 2, 2, 2,
+ax_anim 6, 2, 82, 3, 3, 3, 3,
+ax_anim 2, 0, 82, 1, 1, 1, 1,
+ax_anim 2, 1, 83, -2, -2, -1, -1,
+ax_anim 2, 0, 83, -3, -1, -2, 0,
+ax_anim 2, 0, 83, -2, -2, -1, -1,
+ax_anim 2, 0, 83, -3, -1, -2, 0,
+ax_anim 2, 0, 83, -2, -2, -1, -1,
+ax_anim 2, 0, 83, -3, -1, -2, 0,
+ax_anim 2, 0, 83, -2, -2, -1, -1,
+ax_anim 2, 0, 82, -1, -1, -1, -1,
+ax_anim_terminator
+sCorsolaAnims_4_7:
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 6, 2, 84, 3, 0, 3, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 85, -2, 0, -2, 0,
+ax_anim 2, 0, 85, -2, 1, -2, 1,
+ax_anim 2, 0, 85, -2, 0, -2, 0,
+ax_anim 2, 0, 85, -2, 1, -2, 1,
+ax_anim 2, 0, 85, -2, 0, -2, 0,
+ax_anim 2, 0, 85, -2, 1, -2, 1,
+ax_anim 2, 0, 85, -2, 0, -2, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim_terminator
+sCorsolaAnims_4_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 6, 2, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 87, -2, 2, -1, 1,
+ax_anim 2, 0, 87, -3, 1, -2, 0,
+ax_anim 2, 0, 87, -2, 2, -1, 1,
+ax_anim 2, 0, 87, -3, 1, -2, 0,
+ax_anim 2, 0, 87, -2, 2, -1, 1,
+ax_anim 2, 0, 87, -3, 1, -2, 0,
+ax_anim 2, 0, 87, -2, 2, -1, 1,
+ax_anim 2, 0, 86, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_5_1:
+ax_anim 5, 0, 89, 0, 0, -1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 5, 0, 90, 0, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 5, 0, 89, 0, 0, -1, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 5, 0, 90, 0, 0, 1, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_5_2:
+ax_anim 5, 0, 92, 0, 0, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 5, 0, 93, 0, 0, 0, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 5, 0, 92, 0, 0, 1, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 5, 0, 93, 0, 0, 0, 1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_5_3:
+ax_anim 5, 0, 95, 0, 0, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 5, 0, 96, 0, 0, 0, 1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 5, 0, 95, 0, 0, 0, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 5, 0, 96, 0, 0, 0, 1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_5_4:
+ax_anim 5, 0, 98, 0, 0, 1, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 5, 0, 99, 0, 0, 0, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 5, 0, 98, 0, 0, 1, 1,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 5, 0, 99, 0, 0, 0, -1,
+ax_anim 2, 1, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_5_5:
+ax_anim 5, 0, 101, 0, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 5, 0, 102, 0, 0, -1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 5, 0, 101, 0, 0, 1, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 5, 0, 102, 0, 0, -1, 0,
+ax_anim 2, 1, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_5_6:
+ax_anim 5, 0, 104, 0, 0, -1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 5, 0, 105, 0, 0, 0, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 5, 0, 104, 0, 0, -1, 1,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 5, 0, 105, 0, 0, 0, -1,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_5_7:
+ax_anim 5, 0, 107, 0, 0, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 5, 0, 108, 0, 0, 0, 1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 5, 0, 107, 0, 0, 0, -1,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 5, 0, 108, 0, 0, 0, 1,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_5_8:
+ax_anim 5, 0, 110, 0, 0, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 5, 0, 111, 0, 0, 0, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 5, 0, 110, 0, 0, -1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 5, 0, 111, 0, 0, 0, 1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sCorsolaAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sCorsolaAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sCorsolaAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sCorsolaAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sCorsolaAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sCorsolaAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sCorsolaAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_8_1:
+ax_anim 52, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_8_2:
+ax_anim 52, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_8_3:
+ax_anim 52, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_8_4:
+ax_anim 52, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_8_5:
+ax_anim 52, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_8_6:
+ax_anim 52, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_8_7:
+ax_anim 52, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_8_8:
+ax_anim 52, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 11, 8, 11,
+ax_anim 2, 0, 149, 7, 18, 7, 18,
+ax_anim 3, 0, 150, 0, 21, 0, 21,
+ax_anim 2, 3, 151, -7, 18, -7, 18,
+ax_anim 2, 0, 152, -8, 11, -8, 11,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 19, 10, 19, 10,
+ax_anim 3, 0, 149, 20, 21, 20, 21,
+ax_anim 2, 3, 150, 13, 22, 13, 22,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -7, 11, -7,
+ax_anim 2, 0, 147, 16, -5, 16, -5,
+ax_anim 3, 0, 148, 21, -1, 21, -1,
+ax_anim 2, 3, 149, 19, 4, 19, 4,
+ax_anim 2, 0, 150, 12, 6, 12, 6,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 4, -17, 4, -17,
+ax_anim 2, 0, 146, 14, -23, 14, -23,
+ax_anim 3, 0, 147, 21, -22, 21, -22,
+ax_anim 2, 3, 148, 22, -14, 22, -14,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -7, -19, -7, -19,
+ax_anim 3, 0, 146, 0, -24, 0, -24,
+ax_anim 2, 3, 147, 7, -19, 7, -19,
+ax_anim 2, 0, 148, 9, -12, 9, -12,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -4, -17, -4, -17,
+ax_anim 2, 0, 146, -14, -23, -14, -23,
+ax_anim 3, 0, 153, -21, -22, -21, -22,
+ax_anim 2, 3, 152, -22, -14, -22, -14,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -7, -11, -7,
+ax_anim 2, 0, 153, -16, -5, -16, -5,
+ax_anim 3, 0, 152, -21, -1, -21, -1,
+ax_anim 2, 3, 151, -16, 4, -16, 4,
+ax_anim 2, 0, 150, -12, 6, -12, 6,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -19, 10, -19, 10,
+ax_anim 3, 0, 151, -20, 21, -20, 21,
+ax_anim 2, 3, 150, -13, 22, -13, 22,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_11_2:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -22, 0, 0,
+ax_anim 3, 0, 164, 0, -21, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_11_3:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -22, 0, 0,
+ax_anim 3, 0, 166, 0, -21, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_11_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -22, 0, 0,
+ax_anim 3, 0, 168, 0, -21, 0, 0,
+ax_anim 2, 0, 168, 0, -17, 0, 0,
+ax_anim 1, 0, 168, 0, -11, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_11_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 3, 0, 170, 0, -21, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_11_6:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 172, 0, -21, 0, 0,
+ax_anim 2, 0, 172, 0, -17, 0, 0,
+ax_anim 1, 0, 172, 0, -11, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_11_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -22, 0, 0,
+ax_anim 3, 0, 174, 0, -21, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_11_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 176, 0, -21, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCorsolaAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sCorsolaGfx1:
+.incbin "baserom.gba", 0xF00448, 0x200
+sCorsolaSprites1:
+ax_sprite sCorsolaGfx1, 0x200
+ax_sprite_terminator
+sCorsolaGfx2:
+.incbin "baserom.gba", 0xF00658, 0x200
+sCorsolaSprites2:
+ax_sprite sCorsolaGfx2, 0x200
+ax_sprite_terminator
+sCorsolaGfx3:
+.incbin "baserom.gba", 0xF00868, 0x200
+sCorsolaSprites3:
+ax_sprite sCorsolaGfx3, 0x200
+ax_sprite_terminator
+sCorsolaGfx4:
+.incbin "baserom.gba", 0xF00A78, 0x200
+sCorsolaSprites4:
+ax_sprite sCorsolaGfx4, 0x200
+ax_sprite_terminator
+sCorsolaGfx5:
+.incbin "baserom.gba", 0xF00C88, 0x200
+sCorsolaSprites5:
+ax_sprite sCorsolaGfx5, 0x200
+ax_sprite_terminator
+sCorsolaGfx6:
+.incbin "baserom.gba", 0xF00E98, 0x200
+sCorsolaSprites6:
+ax_sprite sCorsolaGfx6, 0x200
+ax_sprite_terminator
+sCorsolaGfx7:
+.incbin "baserom.gba", 0xF010A8, 0x200
+sCorsolaSprites7:
+ax_sprite sCorsolaGfx7, 0x200
+ax_sprite_terminator
+sCorsolaGfx8:
+.incbin "baserom.gba", 0xF012B8, 0x200
+sCorsolaSprites8:
+ax_sprite sCorsolaGfx8, 0x200
+ax_sprite_terminator
+sCorsolaGfx9:
+.incbin "baserom.gba", 0xF014C8, 0x200
+sCorsolaSprites9:
+ax_sprite sCorsolaGfx9, 0x200
+ax_sprite_terminator
+sCorsolaGfx10:
+.incbin "baserom.gba", 0xF016D8, 0x200
+sCorsolaSprites10:
+ax_sprite sCorsolaGfx10, 0x200
+ax_sprite_terminator
+sCorsolaGfx11:
+.incbin "baserom.gba", 0xF018E8, 0x200
+sCorsolaSprites11:
+ax_sprite sCorsolaGfx11, 0x200
+ax_sprite_terminator
+sCorsolaGfx12:
+.incbin "baserom.gba", 0xF01AF8, 0x200
+sCorsolaSprites12:
+ax_sprite sCorsolaGfx12, 0x200
+ax_sprite_terminator
+sCorsolaGfx13:
+.incbin "baserom.gba", 0xF01D08, 0x200
+sCorsolaSprites13:
+ax_sprite sCorsolaGfx13, 0x200
+ax_sprite_terminator
+sCorsolaGfx14:
+.incbin "baserom.gba", 0xF01F18, 0x200
+sCorsolaSprites14:
+ax_sprite sCorsolaGfx14, 0x200
+ax_sprite_terminator
+sCorsolaGfx15:
+.incbin "baserom.gba", 0xF02128, 0x200
+sCorsolaSprites15:
+ax_sprite sCorsolaGfx15, 0x200
+ax_sprite_terminator
+sCorsolaGfx16:
+.incbin "baserom.gba", 0xF02338, 0x60
+sCorsolaGfx16_1:
+.incbin "baserom.gba", 0xF02398, 0x60
+sCorsolaGfx16_2:
+.incbin "baserom.gba", 0xF023F8, 0x60
+sCorsolaSprites16:
+ax_sprite sCorsolaGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorsolaGfx17:
+.incbin "baserom.gba", 0xF02490, 0x60
+sCorsolaGfx17_1:
+.incbin "baserom.gba", 0xF024F0, 0x60
+sCorsolaGfx17_2:
+.incbin "baserom.gba", 0xF02550, 0x60
+sCorsolaSprites17:
+ax_sprite sCorsolaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorsolaGfx18:
+.incbin "baserom.gba", 0xF025E8, 0x60
+sCorsolaGfx18_1:
+.incbin "baserom.gba", 0xF02648, 0x60
+sCorsolaGfx18_2:
+.incbin "baserom.gba", 0xF026A8, 0x60
+sCorsolaSprites18:
+ax_sprite sCorsolaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorsolaGfx19:
+.incbin "baserom.gba", 0xF02740, 0x60
+sCorsolaGfx19_1:
+.incbin "baserom.gba", 0xF027A0, 0x60
+sCorsolaGfx19_2:
+.incbin "baserom.gba", 0xF02800, 0x60
+sCorsolaSprites19:
+ax_sprite sCorsolaGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorsolaGfx20:
+.incbin "baserom.gba", 0xF02898, 0x60
+sCorsolaGfx20_1:
+.incbin "baserom.gba", 0xF028F8, 0x60
+sCorsolaGfx20_2:
+.incbin "baserom.gba", 0xF02958, 0x60
+sCorsolaSprites20:
+ax_sprite sCorsolaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCorsolaGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCorsolaGfx21:
+.incbin "baserom.gba", 0xF029F0, 0x200
+sCorsolaSprites21:
+ax_sprite sCorsolaGfx21, 0x200
+ax_sprite_terminator
+sCorsolaGfx22:
+.incbin "baserom.gba", 0xF02C00, 0x200
+sCorsolaSprites22:
+ax_sprite sCorsolaGfx22, 0x200
+ax_sprite_terminator
+sCorsolaGfx23:
+.incbin "baserom.gba", 0xF02E10, 0x200
+sCorsolaSprites23:
+ax_sprite sCorsolaGfx23, 0x200
+ax_sprite_terminator
+sCorsolaGfx24:
+.incbin "baserom.gba", 0xF03020, 0x200
+sCorsolaSprites24:
+ax_sprite sCorsolaGfx24, 0x200
+ax_sprite_terminator
+sCorsolaGfx25:
+.incbin "baserom.gba", 0xF03230, 0x200
+sCorsolaSprites25:
+ax_sprite sCorsolaGfx25, 0x200
+ax_sprite_terminator
+sCorsolaGfx26:
+.incbin "baserom.gba", 0xF03440, 0x200
+sCorsolaSprites26:
+ax_sprite sCorsolaGfx26, 0x200
+ax_sprite_terminator
+sCorsolaGfx27:
+.incbin "baserom.gba", 0xF03650, 0x200
+sCorsolaSprites27:
+ax_sprite sCorsolaGfx27, 0x200
+ax_sprite_terminator
+sAxPosesCorsola:
+.4byte sCorsolaPose1
+.4byte sCorsolaPose2
+.4byte sCorsolaPose3
+.4byte sCorsolaPose4
+.4byte sCorsolaPose5
+.4byte sCorsolaPose6
+.4byte sCorsolaPose7
+.4byte sCorsolaPose8
+.4byte sCorsolaPose9
+.4byte sCorsolaPose10
+.4byte sCorsolaPose11
+.4byte sCorsolaPose12
+.4byte sCorsolaPose13
+.4byte sCorsolaPose14
+.4byte sCorsolaPose15
+.4byte sCorsolaPose16
+.4byte sCorsolaPose17
+.4byte sCorsolaPose18
+.4byte sCorsolaPose19
+.4byte sCorsolaPose20
+.4byte sCorsolaPose21
+.4byte sCorsolaPose22
+.4byte sCorsolaPose23
+.4byte sCorsolaPose24
+.4byte sCorsolaPose25
+.4byte sCorsolaPose26
+.4byte sCorsolaPose27
+.4byte sCorsolaPose28
+.4byte sCorsolaPose29
+.4byte sCorsolaPose30
+.4byte sCorsolaPose31
+.4byte sCorsolaPose32
+.4byte sCorsolaPose33
+.4byte sCorsolaPose34
+.4byte sCorsolaPose35
+.4byte sCorsolaPose36
+.4byte sCorsolaPose37
+.4byte sCorsolaPose38
+.4byte sCorsolaPose39
+.4byte sCorsolaPose40
+.4byte sCorsolaPose41
+.4byte sCorsolaPose42
+.4byte sCorsolaPose43
+.4byte sCorsolaPose44
+.4byte sCorsolaPose45
+.4byte sCorsolaPose46
+.4byte sCorsolaPose47
+.4byte sCorsolaPose48
+.4byte sCorsolaPose49
+.4byte sCorsolaPose50
+.4byte sCorsolaPose51
+.4byte sCorsolaPose52
+.4byte sCorsolaPose53
+.4byte sCorsolaPose54
+.4byte sCorsolaPose55
+.4byte sCorsolaPose56
+.4byte sCorsolaPose57
+.4byte sCorsolaPose58
+.4byte sCorsolaPose59
+.4byte sCorsolaPose60
+.4byte sCorsolaPose61
+.4byte sCorsolaPose62
+.4byte sCorsolaPose63
+.4byte sCorsolaPose64
+.4byte sCorsolaPose65
+.4byte sCorsolaPose66
+.4byte sCorsolaPose67
+.4byte sCorsolaPose68
+.4byte sCorsolaPose69
+.4byte sCorsolaPose70
+.4byte sCorsolaPose71
+.4byte sCorsolaPose72
+.4byte sCorsolaPose73
+.4byte sCorsolaPose74
+.4byte sCorsolaPose75
+.4byte sCorsolaPose76
+.4byte sCorsolaPose77
+.4byte sCorsolaPose78
+.4byte sCorsolaPose79
+.4byte sCorsolaPose80
+.4byte sCorsolaPose81
+.4byte sCorsolaPose82
+.4byte sCorsolaPose83
+.4byte sCorsolaPose84
+.4byte sCorsolaPose85
+.4byte sCorsolaPose86
+.4byte sCorsolaPose87
+.4byte sCorsolaPose88
+.4byte sCorsolaPose89
+.4byte sCorsolaPose90
+.4byte sCorsolaPose91
+.4byte sCorsolaPose92
+.4byte sCorsolaPose93
+.4byte sCorsolaPose94
+.4byte sCorsolaPose95
+.4byte sCorsolaPose96
+.4byte sCorsolaPose97
+.4byte sCorsolaPose98
+.4byte sCorsolaPose99
+.4byte sCorsolaPose100
+.4byte sCorsolaPose101
+.4byte sCorsolaPose102
+.4byte sCorsolaPose103
+.4byte sCorsolaPose104
+.4byte sCorsolaPose105
+.4byte sCorsolaPose106
+.4byte sCorsolaPose107
+.4byte sCorsolaPose108
+.4byte sCorsolaPose109
+.4byte sCorsolaPose110
+.4byte sCorsolaPose111
+.4byte sCorsolaPose112
+.4byte sCorsolaPose113
+.4byte sCorsolaPose114
+.4byte sCorsolaPose115
+.4byte sCorsolaPose116
+.4byte sCorsolaPose117
+.4byte sCorsolaPose118
+.4byte sCorsolaPose119
+.4byte sCorsolaPose120
+.4byte sCorsolaPose121
+.4byte sCorsolaPose122
+.4byte sCorsolaPose123
+.4byte sCorsolaPose124
+.4byte sCorsolaPose125
+.4byte sCorsolaPose126
+.4byte sCorsolaPose127
+.4byte sCorsolaPose128
+.4byte sCorsolaPose129
+.4byte sCorsolaPose130
+.4byte sCorsolaPose131
+.4byte sCorsolaPose132
+.4byte sCorsolaPose133
+.4byte sCorsolaPose134
+.4byte sCorsolaPose135
+.4byte sCorsolaPose136
+.4byte sCorsolaPose137
+.4byte sCorsolaPose138
+.4byte sCorsolaPose139
+.4byte sCorsolaPose140
+.4byte sCorsolaPose141
+.4byte sCorsolaPose142
+.4byte sCorsolaPose143
+.4byte sCorsolaPose144
+.4byte sCorsolaPose145
+.4byte sCorsolaPose146
+.4byte sCorsolaPose147
+.4byte sCorsolaPose148
+.4byte sCorsolaPose149
+.4byte sCorsolaPose150
+.4byte sCorsolaPose151
+.4byte sCorsolaPose152
+.4byte sCorsolaPose153
+.4byte sCorsolaPose154
+.4byte sCorsolaPose155
+.4byte sCorsolaPose156
+.4byte sCorsolaPose157
+.4byte sCorsolaPose158
+.4byte sCorsolaPose159
+.4byte sCorsolaPose160
+.4byte sCorsolaPose161
+.4byte sCorsolaPose162
+.4byte sCorsolaPose163
+.4byte sCorsolaPose164
+.4byte sCorsolaPose165
+.4byte sCorsolaPose166
+.4byte sCorsolaPose167
+.4byte sCorsolaPose168
+.4byte sCorsolaPose169
+.4byte sCorsolaPose170
+.4byte sCorsolaPose171
+.4byte sCorsolaPose172
+.4byte sCorsolaPose173
+.4byte sCorsolaPose174
+.4byte sCorsolaPose175
+.4byte sCorsolaPose176
+.4byte sCorsolaPose177
+.4byte sCorsolaPose178
+.4byte sCorsolaPose179
+.4byte sCorsolaPose180
+.4byte sCorsolaPose181
+.4byte sCorsolaPose182
+.4byte sCorsolaPose183
+.4byte sCorsolaPose184
+.4byte sCorsolaPose185
+.4byte sCorsolaPose186
+.4byte sCorsolaPose187
+.4byte sCorsolaPose188
+.4byte sCorsolaPose189
+.4byte sCorsolaPose190
+.4byte sCorsolaPose191
+.4byte sCorsolaPose192
+.4byte sCorsolaPose193
+.4byte sCorsolaPose194
+sAxPositionsCorsola:
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   4,   -3, 	  -2,   -6
+.2byte   -2,   -3, 	  -6,   -3, 	   4,    0, 	   0,   -6
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    4,   -3, 	   8,   -2, 	   0,   -1, 	   2,   -5
+.2byte    5,   -4, 	   7,   -4, 	   2,    0, 	   1,   -5
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    6,   -6, 	   7,   -3, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -4, 	   4,   -6, 	   7,   -1, 	   0,   -5
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    4,   -5, 	   2,   -6, 	   7,   -4, 	   0,   -6
+.2byte    3,   -7, 	  -1,   -6, 	   7,   -7, 	   0,   -7
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    1,   -8, 	   3,   -6, 	  -2,   -7, 	   1,   -7
+.2byte   -3,   -8, 	   0,   -8, 	  -5,   -6, 	  -2,   -8
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -5,   -5, 	  -3,   -6, 	  -8,   -4, 	  -1,   -6
+.2byte   -4,   -7, 	   0,   -6, 	  -8,   -7, 	  -1,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -7,   -6, 	  -8,   -3, 	  -6,   -3, 	   0,   -7
+.2byte   -7,   -4, 	  -5,   -6, 	  -8,   -1, 	  -1,   -5
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -2, 	  -1,   -1, 	  -3,   -5
+.2byte   -6,   -4, 	  -8,   -4, 	  -3,    0, 	  -2,   -5
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   4,   -3, 	  -2,   -6
+.2byte   -2,   -3, 	  -6,   -3, 	   4,    0, 	   0,   -6
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    4,   -3, 	   8,   -2, 	   0,   -1, 	   2,   -5
+.2byte    5,   -4, 	   7,   -4, 	   2,    0, 	   1,   -5
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    6,   -6, 	   7,   -3, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -4, 	   4,   -6, 	   7,   -1, 	   0,   -5
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    4,   -5, 	   2,   -6, 	   7,   -4, 	   0,   -6
+.2byte    3,   -7, 	  -1,   -6, 	   7,   -7, 	   0,   -7
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    1,   -8, 	   3,   -6, 	  -2,   -7, 	   1,   -7
+.2byte   -3,   -8, 	   0,   -8, 	  -5,   -6, 	  -2,   -8
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -5,   -5, 	  -3,   -6, 	  -8,   -4, 	  -1,   -6
+.2byte   -4,   -7, 	   0,   -6, 	  -8,   -7, 	  -1,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -7,   -6, 	  -8,   -3, 	  -6,   -3, 	   0,   -7
+.2byte   -7,   -4, 	  -5,   -6, 	  -8,   -1, 	  -1,   -5
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -2, 	  -1,   -1, 	  -3,   -5
+.2byte   -6,   -4, 	  -8,   -4, 	  -3,    0, 	  -2,   -5
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   4,   -3, 	  -2,   -6
+.2byte   -2,   -3, 	  -6,   -3, 	   4,    0, 	   0,   -6
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    4,   -3, 	   8,   -2, 	   0,   -1, 	   2,   -5
+.2byte    5,   -4, 	   7,   -4, 	   2,    0, 	   1,   -5
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    6,   -6, 	   7,   -3, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -4, 	   4,   -6, 	   7,   -1, 	   0,   -5
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    4,   -5, 	   2,   -6, 	   7,   -4, 	   0,   -6
+.2byte    3,   -7, 	  -1,   -6, 	   7,   -7, 	   0,   -7
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    1,   -8, 	   3,   -6, 	  -2,   -7, 	   1,   -7
+.2byte   -3,   -8, 	   0,   -8, 	  -5,   -6, 	  -2,   -8
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -5,   -5, 	  -3,   -6, 	  -8,   -4, 	  -1,   -6
+.2byte   -4,   -7, 	   0,   -6, 	  -8,   -7, 	  -1,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -7,   -6, 	  -8,   -3, 	  -6,   -3, 	   0,   -7
+.2byte   -7,   -4, 	  -5,   -6, 	  -8,   -1, 	  -1,   -5
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -2, 	  -1,   -1, 	  -3,   -5
+.2byte   -6,   -4, 	  -8,   -4, 	  -3,    0, 	  -2,   -5
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    4,   -4, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    3,   -7, 	   0,   -7, 	   7,   -6, 	  -1,   -6
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   2,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -4,   -7, 	  -1,   -7, 	  -8,   -6, 	   0,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -5,   -4, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   4,   -3, 	  -2,   -6
+.2byte   -2,   -3, 	  -6,   -3, 	   4,    0, 	   0,   -6
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    4,   -3, 	   8,   -2, 	   0,   -1, 	   2,   -5
+.2byte    4,   -2, 	   6,   -2, 	   1,    2, 	   0,   -3
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    6,   -6, 	   7,   -3, 	   5,   -3, 	  -1,   -7
+.2byte    5,   -3, 	   3,   -5, 	   6,    0, 	  -1,   -4
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    5,   -5, 	   3,   -6, 	   8,   -4, 	   1,   -6
+.2byte    3,   -8, 	  -1,   -7, 	   7,   -8, 	   0,   -8
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    1,   -8, 	   3,   -6, 	  -2,   -7, 	   1,   -7
+.2byte   -3,   -8, 	   0,   -8, 	  -5,   -6, 	  -2,   -8
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -6,   -5, 	  -4,   -6, 	  -9,   -4, 	  -2,   -6
+.2byte   -4,   -8, 	   0,   -7, 	  -8,   -8, 	  -1,   -8
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -7,   -6, 	  -8,   -3, 	  -6,   -3, 	   0,   -7
+.2byte   -6,   -3, 	  -4,   -5, 	  -7,    0, 	   0,   -4
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -2, 	  -1,   -1, 	  -3,   -5
+.2byte   -5,   -2, 	  -7,   -2, 	  -2,    2, 	  -1,   -3
+.2byte   -5,   -2, 	  -7,   -3, 	  -1,    1, 	  -1,   -4
+.2byte   -5,   -2, 	  -8,   -2, 	  -2,    1, 	  -2,   -5
+.2byte   -1,   -4, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   8,   -8, 	   1,   -3, 	   0,   -6
+.2byte    5,  -10, 	   7,   -7, 	   7,   -6, 	  -1,   -7
+.2byte    2,   -8, 	  -1,  -10, 	   7,   -8, 	   0,   -5
+.2byte    0,   -6, 	   3,   -5, 	  -3,   -5, 	   0,   -5
+.2byte   -3,   -8, 	   0,  -10, 	  -8,   -8, 	  -1,   -5
+.2byte   -6,   -9, 	  -8,   -6, 	  -8,   -5, 	   0,   -6
+.2byte   -5,   -5, 	  -9,   -8, 	  -2,   -3, 	  -1,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   4,   -3, 	  -2,   -6
+.2byte   -2,   -3, 	  -6,   -3, 	   4,    0, 	   0,   -6
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    4,   -3, 	   8,   -2, 	   0,   -1, 	   2,   -5
+.2byte    5,   -4, 	   7,   -4, 	   2,    0, 	   1,   -5
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    6,   -6, 	   7,   -3, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -4, 	   4,   -6, 	   7,   -1, 	   0,   -5
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    4,   -5, 	   2,   -6, 	   7,   -4, 	   0,   -6
+.2byte    3,   -7, 	  -1,   -6, 	   7,   -7, 	   0,   -7
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    1,   -8, 	   3,   -6, 	  -2,   -7, 	   1,   -7
+.2byte   -3,   -8, 	   0,   -8, 	  -5,   -6, 	  -2,   -8
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -5,   -5, 	  -3,   -6, 	  -8,   -4, 	  -1,   -6
+.2byte   -4,   -7, 	   0,   -6, 	  -8,   -7, 	  -1,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -7,   -6, 	  -8,   -3, 	  -6,   -3, 	   0,   -7
+.2byte   -7,   -4, 	  -5,   -6, 	  -8,   -1, 	  -1,   -5
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -2, 	  -1,   -1, 	  -3,   -5
+.2byte   -6,   -4, 	  -8,   -4, 	  -3,    0, 	  -2,   -5
+.2byte   -1,   -3, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -5,   -4, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,   -7, 	  -1,   -7, 	  -8,   -6, 	   0,   -6
+.2byte   -1,   -7, 	   2,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte    3,   -7, 	   0,   -7, 	   7,   -6, 	  -1,   -6
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    4,   -4, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte   -1,   -3, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte    4,   -4, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    3,   -7, 	   0,   -7, 	   7,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	   2,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte   -4,   -7, 	  -1,   -7, 	  -8,   -6, 	   0,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -5,   -4, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    4,   -4, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    3,   -7, 	   0,   -7, 	   7,   -6, 	  -1,   -6
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   2,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -4,   -7, 	  -1,   -7, 	  -8,   -6, 	   0,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -5,   -4, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -1,   -3, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -5,   -4, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,   -7, 	  -1,   -7, 	  -8,   -6, 	   0,   -6
+.2byte   -1,   -7, 	   2,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte    3,   -7, 	   0,   -7, 	   7,   -6, 	  -1,   -6
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    4,   -4, 	   7,   -3, 	   1,    0, 	   0,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   4,   -1, 	  -1,   -5
+.2byte   -4,   -3, 	  -8,   -3, 	  -2,    0, 	  -1,   -6
+.2byte   -7,   -5, 	  -7,   -6, 	  -7,   -2, 	  -1,   -6
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -6, 	   0,   -7
+.2byte   -1,   -8, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    4,   -7, 	   1,   -8, 	   7,   -6, 	  -1,   -7
+.2byte    6,   -5, 	   6,   -6, 	   6,   -2, 	   0,   -6
+.2byte    3,   -3, 	   7,   -3, 	   1,    0, 	   0,   -6
+sCorsolaAnimTable1:
+.4byte sCorsolaAnims_1_1
+.4byte sCorsolaAnims_1_2
+.4byte sCorsolaAnims_1_3
+.4byte sCorsolaAnims_1_4
+.4byte sCorsolaAnims_1_5
+.4byte sCorsolaAnims_1_6
+.4byte sCorsolaAnims_1_7
+.4byte sCorsolaAnims_1_8
+sCorsolaAnimTable2:
+.4byte sCorsolaAnims_2_1
+.4byte sCorsolaAnims_2_2
+.4byte sCorsolaAnims_2_3
+.4byte sCorsolaAnims_2_4
+.4byte sCorsolaAnims_2_5
+.4byte sCorsolaAnims_2_6
+.4byte sCorsolaAnims_2_7
+.4byte sCorsolaAnims_2_8
+sCorsolaAnimTable3:
+.4byte sCorsolaAnims_3_1
+.4byte sCorsolaAnims_3_2
+.4byte sCorsolaAnims_3_3
+.4byte sCorsolaAnims_3_4
+.4byte sCorsolaAnims_3_5
+.4byte sCorsolaAnims_3_6
+.4byte sCorsolaAnims_3_7
+.4byte sCorsolaAnims_3_8
+sCorsolaAnimTable4:
+.4byte sCorsolaAnims_4_1
+.4byte sCorsolaAnims_4_2
+.4byte sCorsolaAnims_4_3
+.4byte sCorsolaAnims_4_4
+.4byte sCorsolaAnims_4_5
+.4byte sCorsolaAnims_4_6
+.4byte sCorsolaAnims_4_7
+.4byte sCorsolaAnims_4_8
+sCorsolaAnimTable5:
+.4byte sCorsolaAnims_5_1
+.4byte sCorsolaAnims_5_2
+.4byte sCorsolaAnims_5_3
+.4byte sCorsolaAnims_5_4
+.4byte sCorsolaAnims_5_5
+.4byte sCorsolaAnims_5_6
+.4byte sCorsolaAnims_5_7
+.4byte sCorsolaAnims_5_8
+sCorsolaAnimTable6:
+.4byte sCorsolaAnims_6_1
+.4byte sCorsolaAnims_6_1
+.4byte sCorsolaAnims_6_1
+.4byte sCorsolaAnims_6_1
+.4byte sCorsolaAnims_6_1
+.4byte sCorsolaAnims_6_1
+.4byte sCorsolaAnims_6_1
+.4byte sCorsolaAnims_6_1
+sCorsolaAnimTable7:
+.4byte sCorsolaAnims_7_1
+.4byte sCorsolaAnims_7_2
+.4byte sCorsolaAnims_7_3
+.4byte sCorsolaAnims_7_4
+.4byte sCorsolaAnims_7_5
+.4byte sCorsolaAnims_7_6
+.4byte sCorsolaAnims_7_7
+.4byte sCorsolaAnims_7_8
+sCorsolaAnimTable8:
+.4byte sCorsolaAnims_8_1
+.4byte sCorsolaAnims_8_2
+.4byte sCorsolaAnims_8_3
+.4byte sCorsolaAnims_8_4
+.4byte sCorsolaAnims_8_5
+.4byte sCorsolaAnims_8_6
+.4byte sCorsolaAnims_8_7
+.4byte sCorsolaAnims_8_8
+sCorsolaAnimTable9:
+.4byte sCorsolaAnims_9_1
+.4byte sCorsolaAnims_9_2
+.4byte sCorsolaAnims_9_3
+.4byte sCorsolaAnims_9_4
+.4byte sCorsolaAnims_9_5
+.4byte sCorsolaAnims_9_6
+.4byte sCorsolaAnims_9_7
+.4byte sCorsolaAnims_9_8
+sCorsolaAnimTable10:
+.4byte sCorsolaAnims_10_1
+.4byte sCorsolaAnims_10_2
+.4byte sCorsolaAnims_10_3
+.4byte sCorsolaAnims_10_4
+.4byte sCorsolaAnims_10_5
+.4byte sCorsolaAnims_10_6
+.4byte sCorsolaAnims_10_7
+.4byte sCorsolaAnims_10_8
+sCorsolaAnimTable11:
+.4byte sCorsolaAnims_11_1
+.4byte sCorsolaAnims_11_2
+.4byte sCorsolaAnims_11_3
+.4byte sCorsolaAnims_11_4
+.4byte sCorsolaAnims_11_5
+.4byte sCorsolaAnims_11_6
+.4byte sCorsolaAnims_11_7
+.4byte sCorsolaAnims_11_8
+sCorsolaAnimTable12:
+.4byte sCorsolaAnims_12_1
+.4byte sCorsolaAnims_12_2
+.4byte sCorsolaAnims_12_3
+.4byte sCorsolaAnims_12_4
+.4byte sCorsolaAnims_12_5
+.4byte sCorsolaAnims_12_6
+.4byte sCorsolaAnims_12_7
+.4byte sCorsolaAnims_12_8
+sCorsolaAnimTable13:
+.4byte sCorsolaAnims_13_1
+.4byte sCorsolaAnims_13_2
+.4byte sCorsolaAnims_13_3
+.4byte sCorsolaAnims_13_4
+.4byte sCorsolaAnims_13_5
+.4byte sCorsolaAnims_13_6
+.4byte sCorsolaAnims_13_7
+.4byte sCorsolaAnims_13_8
+sAxAnimationsCorsola:
+.4byte sCorsolaAnimTable1
+.4byte sCorsolaAnimTable2
+.4byte sCorsolaAnimTable3
+.4byte sCorsolaAnimTable4
+.4byte sCorsolaAnimTable5
+.4byte sCorsolaAnimTable6
+.4byte sCorsolaAnimTable7
+.4byte sCorsolaAnimTable8
+.4byte sCorsolaAnimTable9
+.4byte sCorsolaAnimTable10
+.4byte sCorsolaAnimTable11
+.4byte sCorsolaAnimTable12
+.4byte sCorsolaAnimTable13
+sAxSpritesCorsola:
+.4byte sCorsolaSprites1
+.4byte sCorsolaSprites2
+.4byte sCorsolaSprites3
+.4byte sCorsolaSprites4
+.4byte sCorsolaSprites5
+.4byte sCorsolaSprites6
+.4byte sCorsolaSprites7
+.4byte sCorsolaSprites8
+.4byte sCorsolaSprites9
+.4byte sCorsolaSprites10
+.4byte sCorsolaSprites11
+.4byte sCorsolaSprites12
+.4byte sCorsolaSprites13
+.4byte sCorsolaSprites14
+.4byte sCorsolaSprites15
+.4byte sCorsolaSprites16
+.4byte sCorsolaSprites17
+.4byte sCorsolaSprites18
+.4byte sCorsolaSprites19
+.4byte sCorsolaSprites20
+.4byte sCorsolaSprites21
+.4byte sCorsolaSprites22
+.4byte sCorsolaSprites23
+.4byte sCorsolaSprites24
+.4byte sCorsolaSprites25
+.4byte sCorsolaSprites26
+.4byte sCorsolaSprites27
+sAxMainCorsola:
+ax_main sAxPosesCorsola, sAxAnimationsCorsola, 13, sAxSpritesCorsola, sAxPositionsCorsola

--- a/data/ax/cradily.inc
+++ b/data/ax/cradily.inc
@@ -1,0 +1,3439 @@
+.global gAxCradily
+gAxCradily:
+ax_siro sAxMainCradily
+sCradilyPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose5:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose8:
+ax_pose 7, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose10:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose11:
+ax_pose 10, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose12:
+ax_pose 11, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose16:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose17:
+ax_pose 10, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose18:
+ax_pose 11, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose26:
+ax_pose 15, 0x81e5, 0x80f4, 0xac00
+ax_pose 16, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose27:
+ax_pose 17, 0x81e5, 0x80f4, 0xac00
+ax_pose 18, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose28:
+ax_pose 19, 0x81e5, 0x80f4, 0xac00
+ax_pose 20, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose29:
+ax_pose 21, 0x81e5, 0x80f4, 0xac00
+ax_pose 22, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose30:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose31:
+ax_pose 23, 0x41eb, 0x90f4, 0xac00
+ax_pose 24, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose32:
+ax_pose 25, 0x41eb, 0x90f4, 0xac00
+ax_pose 26, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose33:
+ax_pose 27, 0x81e6, 0x90f7, 0xac00
+ax_pose 28, 0x81e6, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose34:
+ax_pose 29, 0x41eb, 0x90f4, 0xac00
+ax_pose 30, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose35:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose36:
+ax_pose 31, 0x41f3, 0x90f6, 0xac00
+ax_pose 32, 0x41eb, 0x10fe, 0xac08
+ax_pose_terminator
+sCradilyPose37:
+ax_pose 33, 0x41f3, 0x90f8, 0xac00
+ax_pose 34, 0x41eb, 0x1100, 0xac08
+ax_pose_terminator
+sCradilyPose38:
+ax_pose 35, 0x81e5, 0x90f6, 0xac00
+ax_pose 36, 0x01ed, 0x10ee, 0xac08
+ax_pose_terminator
+sCradilyPose39:
+ax_pose 37, 0x41f3, 0x90f6, 0xac00
+ax_pose 38, 0x01eb, 0x1106, 0xac08
+ax_pose_terminator
+sCradilyPose40:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose41:
+ax_pose 39, 0x81e3, 0x90f9, 0xac00
+ax_pose 40, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose42:
+ax_pose 41, 0x81e3, 0x90f9, 0xac00
+ax_pose 42, 0x81eb, 0x1109, 0xac08
+ax_pose_terminator
+sCradilyPose43:
+ax_pose 43, 0x81e3, 0x90f7, 0xac00
+ax_pose 44, 0x81eb, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose44:
+ax_pose 45, 0x81e3, 0x90f9, 0xac00
+ax_pose 46, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose45:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose46:
+ax_pose 47, 0x41e6, 0x80ef, 0xac00
+ax_pose 48, 0x01f6, 0x40f7, 0xac08
+ax_pose_terminator
+sCradilyPose47:
+ax_pose 49, 0x41e5, 0x80f0, 0xac00
+ax_pose 50, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose48:
+ax_pose 51, 0x81e7, 0x80f7, 0xac00
+ax_pose 52, 0x01ef, 0x0107, 0xac08
+ax_pose_terminator
+sCradilyPose49:
+ax_pose 53, 0x41e5, 0x80f0, 0xac00
+ax_pose 54, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose50:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose51:
+ax_pose 39, 0x81e3, 0x80f7, 0xac00
+ax_pose 40, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose52:
+ax_pose 41, 0x81e3, 0x80f7, 0xac00
+ax_pose 42, 0x81eb, 0x00ef, 0xac08
+ax_pose_terminator
+sCradilyPose53:
+ax_pose 43, 0x81e3, 0x80f9, 0xac00
+ax_pose 44, 0x81eb, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose54:
+ax_pose 45, 0x81e3, 0x80f7, 0xac00
+ax_pose 46, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose55:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose56:
+ax_pose 31, 0x41f3, 0x80ea, 0xac00
+ax_pose 32, 0x41eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose57:
+ax_pose 33, 0x41f3, 0x80e8, 0xac00
+ax_pose 34, 0x41eb, 0x00f0, 0xac08
+ax_pose_terminator
+sCradilyPose58:
+ax_pose 35, 0x81e5, 0x80fa, 0xac00
+ax_pose 36, 0x01ed, 0x010a, 0xac08
+ax_pose_terminator
+sCradilyPose59:
+ax_pose 37, 0x41f3, 0x80ea, 0xac00
+ax_pose 38, 0x01eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose60:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose61:
+ax_pose 23, 0x41eb, 0x80ec, 0xac00
+ax_pose 24, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose62:
+ax_pose 25, 0x41eb, 0x80ec, 0xac00
+ax_pose 26, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose63:
+ax_pose 27, 0x81e6, 0x80f9, 0xac00
+ax_pose 28, 0x81e6, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose64:
+ax_pose 29, 0x41eb, 0x80ec, 0xac00
+ax_pose 30, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose65:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose66:
+ax_pose 15, 0x81e5, 0x80f4, 0xac00
+ax_pose 16, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose67:
+ax_pose 17, 0x81e5, 0x80f4, 0xac00
+ax_pose 18, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose68:
+ax_pose 19, 0x81e5, 0x80f4, 0xac00
+ax_pose 20, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose69:
+ax_pose 21, 0x81e5, 0x80f4, 0xac00
+ax_pose 22, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose70:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose71:
+ax_pose 23, 0x41eb, 0x90f4, 0xac00
+ax_pose 24, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose72:
+ax_pose 25, 0x41eb, 0x90f4, 0xac00
+ax_pose 26, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose73:
+ax_pose 27, 0x81e6, 0x90f7, 0xac00
+ax_pose 28, 0x81e6, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose74:
+ax_pose 29, 0x41eb, 0x90f4, 0xac00
+ax_pose 30, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose75:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose76:
+ax_pose 31, 0x41f3, 0x90f6, 0xac00
+ax_pose 32, 0x41eb, 0x10fe, 0xac08
+ax_pose_terminator
+sCradilyPose77:
+ax_pose 33, 0x41f3, 0x90f8, 0xac00
+ax_pose 34, 0x41eb, 0x1100, 0xac08
+ax_pose_terminator
+sCradilyPose78:
+ax_pose 35, 0x81e5, 0x90f6, 0xac00
+ax_pose 36, 0x01ed, 0x10ee, 0xac08
+ax_pose_terminator
+sCradilyPose79:
+ax_pose 37, 0x41f3, 0x90f6, 0xac00
+ax_pose 38, 0x01eb, 0x1106, 0xac08
+ax_pose_terminator
+sCradilyPose80:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose81:
+ax_pose 39, 0x81e3, 0x90f9, 0xac00
+ax_pose 40, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose82:
+ax_pose 41, 0x81e3, 0x90f9, 0xac00
+ax_pose 42, 0x81eb, 0x1109, 0xac08
+ax_pose_terminator
+sCradilyPose83:
+ax_pose 43, 0x81e3, 0x90f7, 0xac00
+ax_pose 44, 0x81eb, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose84:
+ax_pose 45, 0x81e3, 0x90f9, 0xac00
+ax_pose 46, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose85:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose86:
+ax_pose 47, 0x41e6, 0x80ef, 0xac00
+ax_pose 48, 0x01f6, 0x40f7, 0xac08
+ax_pose_terminator
+sCradilyPose87:
+ax_pose 49, 0x41e5, 0x80f0, 0xac00
+ax_pose 50, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose88:
+ax_pose 51, 0x81e7, 0x80f7, 0xac00
+ax_pose 52, 0x01ef, 0x0107, 0xac08
+ax_pose_terminator
+sCradilyPose89:
+ax_pose 53, 0x41e5, 0x80f0, 0xac00
+ax_pose 54, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose90:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose91:
+ax_pose 39, 0x81e3, 0x80f7, 0xac00
+ax_pose 40, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose92:
+ax_pose 41, 0x81e3, 0x80f7, 0xac00
+ax_pose 42, 0x81eb, 0x00ef, 0xac08
+ax_pose_terminator
+sCradilyPose93:
+ax_pose 43, 0x81e3, 0x80f9, 0xac00
+ax_pose 44, 0x81eb, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose94:
+ax_pose 45, 0x81e3, 0x80f7, 0xac00
+ax_pose 46, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose95:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose96:
+ax_pose 31, 0x41f3, 0x80ea, 0xac00
+ax_pose 32, 0x41eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose97:
+ax_pose 33, 0x41f3, 0x80e8, 0xac00
+ax_pose 34, 0x41eb, 0x00f0, 0xac08
+ax_pose_terminator
+sCradilyPose98:
+ax_pose 35, 0x81e5, 0x80fa, 0xac00
+ax_pose 36, 0x01ed, 0x010a, 0xac08
+ax_pose_terminator
+sCradilyPose99:
+ax_pose 37, 0x41f3, 0x80ea, 0xac00
+ax_pose 38, 0x01eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose100:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose101:
+ax_pose 23, 0x41eb, 0x80ec, 0xac00
+ax_pose 24, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose102:
+ax_pose 25, 0x41eb, 0x80ec, 0xac00
+ax_pose 26, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose103:
+ax_pose 27, 0x81e6, 0x80f9, 0xac00
+ax_pose 28, 0x81e6, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose104:
+ax_pose 29, 0x41eb, 0x80ec, 0xac00
+ax_pose 30, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose105:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose106:
+ax_pose 15, 0x81e5, 0x80f4, 0xac00
+ax_pose 16, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose107:
+ax_pose 17, 0x81e5, 0x80f4, 0xac00
+ax_pose 18, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose108:
+ax_pose 19, 0x81e5, 0x80f4, 0xac00
+ax_pose 20, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose109:
+ax_pose 21, 0x81e5, 0x80f4, 0xac00
+ax_pose 22, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose110:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose111:
+ax_pose 23, 0x41eb, 0x90f4, 0xac00
+ax_pose 24, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose112:
+ax_pose 25, 0x41eb, 0x90f4, 0xac00
+ax_pose 26, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose113:
+ax_pose 27, 0x81e6, 0x90f7, 0xac00
+ax_pose 28, 0x81e6, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose114:
+ax_pose 29, 0x41eb, 0x90f4, 0xac00
+ax_pose 30, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose115:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose116:
+ax_pose 31, 0x41f3, 0x90f6, 0xac00
+ax_pose 32, 0x41eb, 0x10fe, 0xac08
+ax_pose_terminator
+sCradilyPose117:
+ax_pose 33, 0x41f3, 0x90f8, 0xac00
+ax_pose 34, 0x41eb, 0x1100, 0xac08
+ax_pose_terminator
+sCradilyPose118:
+ax_pose 35, 0x81e5, 0x90f6, 0xac00
+ax_pose 36, 0x01ed, 0x10ee, 0xac08
+ax_pose_terminator
+sCradilyPose119:
+ax_pose 37, 0x41f3, 0x90f6, 0xac00
+ax_pose 38, 0x01eb, 0x1106, 0xac08
+ax_pose_terminator
+sCradilyPose120:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose121:
+ax_pose 39, 0x81e3, 0x90f9, 0xac00
+ax_pose 40, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose122:
+ax_pose 41, 0x81e3, 0x90f9, 0xac00
+ax_pose 42, 0x81eb, 0x1109, 0xac08
+ax_pose_terminator
+sCradilyPose123:
+ax_pose 43, 0x81e3, 0x90f7, 0xac00
+ax_pose 44, 0x81eb, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose124:
+ax_pose 45, 0x81e3, 0x90f9, 0xac00
+ax_pose 46, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose125:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose126:
+ax_pose 47, 0x41e6, 0x80ef, 0xac00
+ax_pose 48, 0x01f6, 0x40f7, 0xac08
+ax_pose_terminator
+sCradilyPose127:
+ax_pose 49, 0x41e5, 0x80f0, 0xac00
+ax_pose 50, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose128:
+ax_pose 51, 0x81e7, 0x80f7, 0xac00
+ax_pose 52, 0x01ef, 0x0107, 0xac08
+ax_pose_terminator
+sCradilyPose129:
+ax_pose 53, 0x41e5, 0x80f0, 0xac00
+ax_pose 54, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose130:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose131:
+ax_pose 39, 0x81e3, 0x80f7, 0xac00
+ax_pose 40, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose132:
+ax_pose 41, 0x81e3, 0x80f7, 0xac00
+ax_pose 42, 0x81eb, 0x00ef, 0xac08
+ax_pose_terminator
+sCradilyPose133:
+ax_pose 43, 0x81e3, 0x80f9, 0xac00
+ax_pose 44, 0x81eb, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose134:
+ax_pose 45, 0x81e3, 0x80f7, 0xac00
+ax_pose 46, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose135:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose136:
+ax_pose 31, 0x41f3, 0x80ea, 0xac00
+ax_pose 32, 0x41eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose137:
+ax_pose 33, 0x41f3, 0x80e8, 0xac00
+ax_pose 34, 0x41eb, 0x00f0, 0xac08
+ax_pose_terminator
+sCradilyPose138:
+ax_pose 35, 0x81e5, 0x80fa, 0xac00
+ax_pose 36, 0x01ed, 0x010a, 0xac08
+ax_pose_terminator
+sCradilyPose139:
+ax_pose 37, 0x41f3, 0x80ea, 0xac00
+ax_pose 38, 0x01eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose140:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose141:
+ax_pose 23, 0x41eb, 0x80ec, 0xac00
+ax_pose 24, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose142:
+ax_pose 25, 0x41eb, 0x80ec, 0xac00
+ax_pose 26, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose143:
+ax_pose 27, 0x81e6, 0x80f9, 0xac00
+ax_pose 28, 0x81e6, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose144:
+ax_pose 29, 0x41eb, 0x80ec, 0xac00
+ax_pose 30, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose145:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose146:
+ax_pose 19, 0x81e5, 0x80f4, 0xac00
+ax_pose 20, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose147:
+ax_pose 21, 0x81e5, 0x80f4, 0xac00
+ax_pose 22, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose148:
+ax_pose 55, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose149:
+ax_pose 56, 0x01f4, 0x0101, 0xac00
+ax_pose -1, 0x01f4, 0x00f6, 0xac00
+ax_pose 55, 0x01e4, 0x80f3, 0xac01
+ax_pose_terminator
+sCradilyPose150:
+ax_pose 57, 0x01f4, 0x0101, 0xac00
+ax_pose -1, 0x01f4, 0x00f6, 0xac00
+ax_pose 55, 0x01e4, 0x80f3, 0xac01
+ax_pose_terminator
+sCradilyPose151:
+ax_pose 58, 0x01f0, 0x40fd, 0xac00
+ax_pose -1, 0x01f0, 0x40f2, 0xac00
+ax_pose 55, 0x01e4, 0x80f3, 0xac04
+ax_pose_terminator
+sCradilyPose152:
+ax_pose 59, 0x01f0, 0x40fd, 0xac00
+ax_pose -1, 0x01f0, 0x40f2, 0xac00
+ax_pose 55, 0x01e4, 0x80f3, 0xac04
+ax_pose_terminator
+sCradilyPose153:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose154:
+ax_pose 27, 0x81e6, 0x90f7, 0xac00
+ax_pose 28, 0x81e6, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose155:
+ax_pose 29, 0x41eb, 0x90f4, 0xac00
+ax_pose 30, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose156:
+ax_pose 60, 0x81e3, 0x90fe, 0xac00
+ax_pose 61, 0x81e3, 0x50f6, 0xac08
+ax_pose_terminator
+sCradilyPose157:
+ax_pose 56, 0x01f3, 0x00fd, 0xac00
+ax_pose 60, 0x81e3, 0x90fe, 0xac01
+ax_pose 61, 0x81e3, 0x50f6, 0xac09
+ax_pose -1, 0x01f0, 0x0107, 0xac00
+ax_pose_terminator
+sCradilyPose158:
+ax_pose 57, 0x01f3, 0x00fd, 0xac00
+ax_pose 60, 0x81e3, 0x90fe, 0xac01
+ax_pose 61, 0x81e3, 0x50f6, 0xac09
+ax_pose -1, 0x01f0, 0x0107, 0xac00
+ax_pose_terminator
+sCradilyPose159:
+ax_pose 58, 0x01ef, 0x40f9, 0xac00
+ax_pose 60, 0x81e3, 0x90fe, 0xac04
+ax_pose 61, 0x81e3, 0x50f6, 0xac0c
+ax_pose -1, 0x01ec, 0x4103, 0xac00
+ax_pose_terminator
+sCradilyPose160:
+ax_pose 59, 0x01ef, 0x40f9, 0xac00
+ax_pose 60, 0x81e3, 0x90fe, 0xac04
+ax_pose 61, 0x81e3, 0x50f6, 0xac0c
+ax_pose -1, 0x01ec, 0x4103, 0xac00
+ax_pose_terminator
+sCradilyPose161:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose162:
+ax_pose 35, 0x81e5, 0x90f6, 0xac00
+ax_pose 36, 0x01ed, 0x10ee, 0xac08
+ax_pose_terminator
+sCradilyPose163:
+ax_pose 37, 0x41f3, 0x90f6, 0xac00
+ax_pose 38, 0x01eb, 0x1106, 0xac08
+ax_pose_terminator
+sCradilyPose164:
+ax_pose 62, 0x81e3, 0x9100, 0xac00
+ax_pose 63, 0x81e3, 0x50f8, 0xac08
+ax_pose_terminator
+sCradilyPose165:
+ax_pose 56, 0x01f1, 0x0103, 0xac00
+ax_pose 62, 0x81e3, 0x9100, 0xac01
+ax_pose 63, 0x81e3, 0x50f8, 0xac09
+ax_pose -1, 0x01e8, 0x0103, 0xac00
+ax_pose_terminator
+sCradilyPose166:
+ax_pose 57, 0x01f1, 0x0103, 0xac00
+ax_pose 62, 0x81e3, 0x9100, 0xac01
+ax_pose 63, 0x81e3, 0x50f8, 0xac09
+ax_pose -1, 0x01e8, 0x0103, 0xac00
+ax_pose_terminator
+sCradilyPose167:
+ax_pose 58, 0x01ed, 0x40ff, 0xac00
+ax_pose 62, 0x81e3, 0x9100, 0xac04
+ax_pose 63, 0x81e3, 0x50f8, 0xac0c
+ax_pose -1, 0x01e4, 0x40ff, 0xac00
+ax_pose_terminator
+sCradilyPose168:
+ax_pose 59, 0x01ed, 0x40ff, 0xac00
+ax_pose 62, 0x81e3, 0x9100, 0xac04
+ax_pose 63, 0x81e3, 0x50f8, 0xac0c
+ax_pose -1, 0x01e4, 0x40ff, 0xac00
+ax_pose_terminator
+sCradilyPose169:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose170:
+ax_pose 43, 0x81e3, 0x90f7, 0xac00
+ax_pose 44, 0x81eb, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose171:
+ax_pose 45, 0x81e3, 0x90f9, 0xac00
+ax_pose 46, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose172:
+ax_pose 64, 0x81e3, 0x90f5, 0xac00
+ax_pose 65, 0x81e3, 0x5105, 0xac08
+ax_pose_terminator
+sCradilyPose173:
+ax_pose 64, 0x81e3, 0x90f5, 0xac00
+ax_pose 65, 0x81e3, 0x5105, 0xac08
+ax_pose 56, 0x01e9, 0x00f6, 0xac0c
+ax_pose -1, 0x01ed, 0x0108, 0xac0c
+ax_pose_terminator
+sCradilyPose174:
+ax_pose 64, 0x81e3, 0x90f5, 0xac00
+ax_pose 65, 0x81e3, 0x5105, 0xac08
+ax_pose 57, 0x01e9, 0x00f6, 0xac0c
+ax_pose -1, 0x01ed, 0x0108, 0xac0c
+ax_pose_terminator
+sCradilyPose175:
+ax_pose 64, 0x81e3, 0x90f5, 0xac00
+ax_pose 65, 0x81e3, 0x5105, 0xac08
+ax_pose 58, 0x01e5, 0x40f2, 0xac0c
+ax_pose -1, 0x01e9, 0x4104, 0xac0c
+ax_pose_terminator
+sCradilyPose176:
+ax_pose 64, 0x81e3, 0x90f5, 0xac00
+ax_pose 65, 0x81e3, 0x5105, 0xac08
+ax_pose 59, 0x01e5, 0x40f2, 0xac0c
+ax_pose -1, 0x01e9, 0x4104, 0xac0c
+ax_pose_terminator
+sCradilyPose177:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose178:
+ax_pose 51, 0x81e7, 0x80f7, 0xac00
+ax_pose 52, 0x01ef, 0x0107, 0xac08
+ax_pose_terminator
+sCradilyPose179:
+ax_pose 53, 0x41e5, 0x80f0, 0xac00
+ax_pose 54, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose180:
+ax_pose 66, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sCradilyPose181:
+ax_pose 66, 0x01e4, 0x80f2, 0xac00
+ax_pose 56, 0x01e6, 0x0103, 0xac10
+ax_pose -1, 0x01e6, 0x00f4, 0xac10
+ax_pose_terminator
+sCradilyPose182:
+ax_pose 66, 0x01e4, 0x80f2, 0xac00
+ax_pose 57, 0x01e6, 0x0103, 0xac10
+ax_pose -1, 0x01e6, 0x00f4, 0xac10
+ax_pose_terminator
+sCradilyPose183:
+ax_pose 66, 0x01e4, 0x80f2, 0xac00
+ax_pose 58, 0x01e2, 0x40ff, 0xac10
+ax_pose -1, 0x01e2, 0x40f0, 0xac10
+ax_pose_terminator
+sCradilyPose184:
+ax_pose 66, 0x01e4, 0x80f2, 0xac00
+ax_pose 59, 0x01e2, 0x40ff, 0xac10
+ax_pose -1, 0x01e2, 0x40f0, 0xac10
+ax_pose_terminator
+sCradilyPose185:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose186:
+ax_pose 43, 0x81e3, 0x80f9, 0xac00
+ax_pose 44, 0x81eb, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose187:
+ax_pose 45, 0x81e3, 0x80f7, 0xac00
+ax_pose 46, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose188:
+ax_pose 64, 0x81e3, 0x80fb, 0xac00
+ax_pose 65, 0x81e3, 0x40f3, 0xac08
+ax_pose_terminator
+sCradilyPose189:
+ax_pose 64, 0x81e3, 0x80fb, 0xac00
+ax_pose 65, 0x81e3, 0x40f3, 0xac08
+ax_pose 56, 0x01e9, 0x0101, 0xac0c
+ax_pose -1, 0x01ed, 0x00ef, 0xac0c
+ax_pose_terminator
+sCradilyPose190:
+ax_pose 64, 0x81e3, 0x80fb, 0xac00
+ax_pose 65, 0x81e3, 0x40f3, 0xac08
+ax_pose 57, 0x01e9, 0x0101, 0xac0c
+ax_pose -1, 0x01ed, 0x00ef, 0xac0c
+ax_pose_terminator
+sCradilyPose191:
+ax_pose 64, 0x81e3, 0x80fb, 0xac00
+ax_pose 65, 0x81e3, 0x40f3, 0xac08
+ax_pose 58, 0x01e5, 0x40fd, 0xac0c
+ax_pose -1, 0x01e9, 0x40eb, 0xac0c
+ax_pose_terminator
+sCradilyPose192:
+ax_pose 64, 0x81e3, 0x80fb, 0xac00
+ax_pose 65, 0x81e3, 0x40f3, 0xac08
+ax_pose 59, 0x01e5, 0x40fd, 0xac0c
+ax_pose -1, 0x01e9, 0x40eb, 0xac0c
+ax_pose_terminator
+sCradilyPose193:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose194:
+ax_pose 35, 0x81e5, 0x80fa, 0xac00
+ax_pose 36, 0x01ed, 0x010a, 0xac08
+ax_pose_terminator
+sCradilyPose195:
+ax_pose 37, 0x41f3, 0x80ea, 0xac00
+ax_pose 38, 0x01eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose196:
+ax_pose 62, 0x81e3, 0x80f0, 0xac00
+ax_pose 63, 0x81e3, 0x4100, 0xac08
+ax_pose_terminator
+sCradilyPose197:
+ax_pose 56, 0x01f1, 0x10f5, 0xac00
+ax_pose 62, 0x81e3, 0x80f0, 0xac01
+ax_pose 63, 0x81e3, 0x4100, 0xac09
+ax_pose -1, 0x01e8, 0x10f5, 0xac00
+ax_pose_terminator
+sCradilyPose198:
+ax_pose 57, 0x01f1, 0x10f5, 0xac00
+ax_pose 62, 0x81e3, 0x80f0, 0xac01
+ax_pose 63, 0x81e3, 0x4100, 0xac09
+ax_pose -1, 0x01e8, 0x10f5, 0xac00
+ax_pose_terminator
+sCradilyPose199:
+ax_pose 58, 0x01ed, 0x50f1, 0xac00
+ax_pose 62, 0x81e3, 0x80f0, 0xac04
+ax_pose 63, 0x81e3, 0x4100, 0xac0c
+ax_pose -1, 0x01e4, 0x50f1, 0xac00
+ax_pose_terminator
+sCradilyPose200:
+ax_pose 59, 0x01ed, 0x50f1, 0xac00
+ax_pose 62, 0x81e3, 0x80f0, 0xac04
+ax_pose 63, 0x81e3, 0x4100, 0xac0c
+ax_pose -1, 0x01e4, 0x50f1, 0xac00
+ax_pose_terminator
+sCradilyPose201:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose202:
+ax_pose 27, 0x81e6, 0x80f9, 0xac00
+ax_pose 28, 0x81e6, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose203:
+ax_pose 29, 0x41eb, 0x80ec, 0xac00
+ax_pose 30, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose204:
+ax_pose 60, 0x81e3, 0x80f2, 0xac00
+ax_pose 61, 0x81e3, 0x4102, 0xac08
+ax_pose_terminator
+sCradilyPose205:
+ax_pose 56, 0x01f3, 0x00fa, 0xac00
+ax_pose 60, 0x81e3, 0x80f2, 0xac01
+ax_pose 61, 0x81e3, 0x4102, 0xac09
+ax_pose -1, 0x01f0, 0x00f0, 0xac00
+ax_pose_terminator
+sCradilyPose206:
+ax_pose 57, 0x01f3, 0x00fa, 0xac00
+ax_pose 60, 0x81e3, 0x80f2, 0xac01
+ax_pose 61, 0x81e3, 0x4102, 0xac09
+ax_pose -1, 0x01f0, 0x00f0, 0xac00
+ax_pose_terminator
+sCradilyPose207:
+ax_pose 58, 0x01ef, 0x40f6, 0xac00
+ax_pose 60, 0x81e3, 0x80f2, 0xac04
+ax_pose 61, 0x81e3, 0x4102, 0xac0c
+ax_pose -1, 0x01ec, 0x40ec, 0xac00
+ax_pose_terminator
+sCradilyPose208:
+ax_pose 59, 0x01ef, 0x40f6, 0xac00
+ax_pose 60, 0x81e3, 0x80f2, 0xac04
+ax_pose 61, 0x81e3, 0x4102, 0xac0c
+ax_pose -1, 0x01ec, 0x40ec, 0xac00
+ax_pose_terminator
+sCradilyPose209:
+ax_pose 67, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose210:
+ax_pose 68, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose211:
+ax_pose 69, 0x01e1, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose212:
+ax_pose 70, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sCradilyPose213:
+ax_pose 71, 0x01e4, 0x90e7, 0xac00
+ax_pose_terminator
+sCradilyPose214:
+ax_pose 72, 0x01e2, 0x90ec, 0xac00
+ax_pose_terminator
+sCradilyPose215:
+ax_pose 73, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose216:
+ax_pose 72, 0x01e2, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose217:
+ax_pose 71, 0x01e4, 0x80f9, 0xac00
+ax_pose_terminator
+sCradilyPose218:
+ax_pose 70, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sCradilyPose219:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose220:
+ax_pose 21, 0x81e5, 0x80f4, 0xac00
+ax_pose 22, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose221:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose222:
+ax_pose 29, 0x41eb, 0x90f4, 0xac00
+ax_pose 30, 0x41fb, 0x50f4, 0xac08
+ax_pose_terminator
+sCradilyPose223:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose224:
+ax_pose 37, 0x41f3, 0x90f6, 0xac00
+ax_pose 38, 0x01eb, 0x1106, 0xac08
+ax_pose_terminator
+sCradilyPose225:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose226:
+ax_pose 45, 0x81e3, 0x90f9, 0xac00
+ax_pose 46, 0x81e3, 0x5109, 0xac08
+ax_pose_terminator
+sCradilyPose227:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose228:
+ax_pose 53, 0x41e5, 0x80f0, 0xac00
+ax_pose 54, 0x01f5, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose229:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose230:
+ax_pose 45, 0x81e3, 0x80f7, 0xac00
+ax_pose 46, 0x81e3, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose231:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose232:
+ax_pose 37, 0x41f3, 0x80ea, 0xac00
+ax_pose 38, 0x01eb, 0x00f2, 0xac08
+ax_pose_terminator
+sCradilyPose233:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose234:
+ax_pose 29, 0x41eb, 0x80ec, 0xac00
+ax_pose 30, 0x41fb, 0x40ec, 0xac08
+ax_pose_terminator
+sCradilyPose235:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose236:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose237:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose238:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose239:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose240:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose241:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose242:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose243:
+ax_pose 21, 0x81e5, 0x80f4, 0xac00
+ax_pose 22, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose244:
+ax_pose 29, 0x41eb, 0x90ef, 0xac00
+ax_pose 30, 0x41fb, 0x50ef, 0xac08
+ax_pose_terminator
+sCradilyPose245:
+ax_pose 37, 0x41f3, 0x90ef, 0xac00
+ax_pose 38, 0x01eb, 0x10ff, 0xac08
+ax_pose_terminator
+sCradilyPose246:
+ax_pose 45, 0x81e5, 0x90f6, 0xac00
+ax_pose 46, 0x81e5, 0x5106, 0xac08
+ax_pose_terminator
+sCradilyPose247:
+ax_pose 53, 0x41e9, 0x80f0, 0xac00
+ax_pose 54, 0x01f9, 0x40f8, 0xac08
+ax_pose_terminator
+sCradilyPose248:
+ax_pose 45, 0x81e5, 0x80fa, 0xac00
+ax_pose 46, 0x81e5, 0x40f2, 0xac08
+ax_pose_terminator
+sCradilyPose249:
+ax_pose 37, 0x41f3, 0x80f1, 0xac00
+ax_pose 38, 0x01eb, 0x00f9, 0xac08
+ax_pose_terminator
+sCradilyPose250:
+ax_pose 29, 0x41eb, 0x80ef, 0xac00
+ax_pose 30, 0x41fb, 0x40ef, 0xac08
+ax_pose_terminator
+sCradilyPose251:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose252:
+ax_pose 2, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose253:
+ax_pose 1, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose254:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose255:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose256:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose257:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose258:
+ax_pose 8, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose259:
+ax_pose 7, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose260:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose261:
+ax_pose 11, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose262:
+ax_pose 10, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose263:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose264:
+ax_pose 14, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose265:
+ax_pose 13, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose266:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose267:
+ax_pose 11, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose268:
+ax_pose 10, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose269:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose270:
+ax_pose 8, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose271:
+ax_pose 7, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose272:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose273:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose274:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose275:
+ax_pose 19, 0x81e5, 0x80f4, 0xac00
+ax_pose 20, 0x81e5, 0x4104, 0xac08
+ax_pose_terminator
+sCradilyPose276:
+ax_pose 27, 0x81e6, 0x80f9, 0xac00
+ax_pose 28, 0x81e6, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose277:
+ax_pose 35, 0x81e5, 0x80fa, 0xac00
+ax_pose 36, 0x01ed, 0x010a, 0xac08
+ax_pose_terminator
+sCradilyPose278:
+ax_pose 43, 0x81e3, 0x80f9, 0xac00
+ax_pose 44, 0x81eb, 0x0109, 0xac08
+ax_pose_terminator
+sCradilyPose279:
+ax_pose 51, 0x81e7, 0x80f7, 0xac00
+ax_pose 52, 0x01ef, 0x0107, 0xac08
+ax_pose_terminator
+sCradilyPose280:
+ax_pose 43, 0x81e3, 0x90f7, 0xac00
+ax_pose 44, 0x81eb, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose281:
+ax_pose 35, 0x81e5, 0x90f6, 0xac00
+ax_pose 36, 0x01ed, 0x10ee, 0xac08
+ax_pose_terminator
+sCradilyPose282:
+ax_pose 27, 0x81e6, 0x90f7, 0xac00
+ax_pose 28, 0x81e6, 0x10ef, 0xac08
+ax_pose_terminator
+sCradilyPose283:
+ax_pose 0, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose284:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose285:
+ax_pose 6, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sCradilyPose286:
+ax_pose 9, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sCradilyPose287:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sCradilyPose288:
+ax_pose 9, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sCradilyPose289:
+ax_pose 6, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sCradilyPose290:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+.align 2
+sCradilyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_2_1:
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 8, 0, 27, 0, -3, 0, -3,
+ax_anim 1, 2, 28, 0, 2, 0, 2,
+ax_anim 1, 0, 28, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 28, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sCradilyAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 8, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 2, 33, 2, 3, 2, 3,
+ax_anim 1, 0, 33, 7, 10, 7, 10,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 1, 30, 16, 19, 16, 19,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 0, 30, 16, 19, 16, 19,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 0, 30, 16, 19, 16, 19,
+ax_anim 2, 0, 33, 9, 10, 9, 10,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sCradilyAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 8, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 2, 38, 1, 0, 1, 0,
+ax_anim 1, 0, 38, 6, 0, 6, 0,
+ax_anim 2, 0, 36, 11, 0, 11, 0,
+ax_anim 2, 1, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 36, 11, 0, 11, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 36, 11, 0, 11, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 38, 9, 0, 9, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sCradilyAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 8, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 2, 43, 3, -3, 3, -3,
+ax_anim 1, 0, 43, 8, -8, 8, -8,
+ax_anim 2, 0, 41, 16, -16, 16, -16,
+ax_anim 2, 1, 40, 16, -16, 16, -16,
+ax_anim 2, 0, 41, 16, -16, 16, -16,
+ax_anim 2, 0, 40, 16, -16, 16, -16,
+ax_anim 2, 0, 41, 16, -16, 16, -16,
+ax_anim 2, 0, 40, 16, -16, 16, -16,
+ax_anim 2, 0, 43, 9, -10, 9, -10,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sCradilyAnims_2_5:
+ax_anim 2, 0, 47, 0, 2, 0, 2,
+ax_anim 8, 0, 47, 0, 3, 0, 3,
+ax_anim 1, 2, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, -7, 0, -7,
+ax_anim 2, 0, 46, 0, -16, 0, -16,
+ax_anim 2, 1, 45, 0, -16, 0, -16,
+ax_anim 2, 0, 46, 0, -16, 0, -16,
+ax_anim 2, 0, 45, 0, -16, 0, -16,
+ax_anim 2, 0, 46, 0, -16, 0, -16,
+ax_anim 2, 0, 45, 0, -16, 0, -16,
+ax_anim 2, 0, 48, 0, -10, 0, -10,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sCradilyAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 8, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 2, 53, -3, -3, -3, -3,
+ax_anim 1, 0, 53, -8, -8, -8, -8,
+ax_anim 2, 0, 51, -16, -16, -16, -16,
+ax_anim 2, 1, 50, -16, -16, -16, -16,
+ax_anim 2, 0, 51, -16, -16, -16, -16,
+ax_anim 2, 0, 50, -16, -16, -16, -16,
+ax_anim 2, 0, 51, -16, -16, -16, -16,
+ax_anim 2, 0, 50, -16, -16, -16, -16,
+ax_anim 2, 0, 53, -9, -10, -9, -10,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sCradilyAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 8, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 2, 58, -1, 0, -1, 0,
+ax_anim 1, 0, 58, -6, 0, -6, 0,
+ax_anim 2, 0, 56, -11, 0, -11, 0,
+ax_anim 2, 1, 55, -11, 0, -11, 0,
+ax_anim 2, 0, 56, -11, 0, -11, 0,
+ax_anim 2, 0, 55, -11, 0, -11, 0,
+ax_anim 2, 0, 56, -11, 0, -11, 0,
+ax_anim 2, 0, 55, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -9, 0, -9, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sCradilyAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 8, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 2, 63, -2, 3, -2, 3,
+ax_anim 1, 0, 63, -7, 10, -7, 10,
+ax_anim 2, 0, 61, -16, 19, -16, 19,
+ax_anim 2, 1, 60, -16, 19, -16, 19,
+ax_anim 2, 0, 61, -16, 19, -16, 19,
+ax_anim 2, 0, 60, -16, 19, -16, 19,
+ax_anim 2, 0, 61, -16, 19, -16, 19,
+ax_anim 2, 0, 60, -16, 19, -16, 19,
+ax_anim 2, 0, 63, -9, 10, -9, 10,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sCradilyAnims_3_1:
+ax_anim 2, 0, 67, 0, -2, 0, -2,
+ax_anim 8, 0, 67, 0, -3, 0, -3,
+ax_anim 1, 2, 68, 0, 2, 0, 2,
+ax_anim 1, 0, 68, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 0, 19, 0, 19,
+ax_anim 2, 1, 65, 0, 19, 0, 19,
+ax_anim 2, 0, 66, 0, 19, 0, 19,
+ax_anim 2, 0, 65, 0, 19, 0, 19,
+ax_anim 2, 0, 66, 0, 19, 0, 19,
+ax_anim 2, 0, 65, 0, 19, 0, 19,
+ax_anim 2, 0, 68, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sCradilyAnims_3_2:
+ax_anim 2, 0, 72, -1, -1, -1, -1,
+ax_anim 8, 0, 72, -2, -2, -2, -2,
+ax_anim 1, 2, 73, 2, 3, 2, 3,
+ax_anim 1, 0, 73, 7, 10, 7, 10,
+ax_anim 2, 0, 71, 16, 19, 16, 19,
+ax_anim 2, 1, 70, 16, 19, 16, 19,
+ax_anim 2, 0, 71, 16, 19, 16, 19,
+ax_anim 2, 0, 70, 16, 19, 16, 19,
+ax_anim 2, 0, 71, 16, 19, 16, 19,
+ax_anim 2, 0, 70, 16, 19, 16, 19,
+ax_anim 2, 0, 73, 9, 10, 9, 10,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sCradilyAnims_3_3:
+ax_anim 2, 0, 77, -1, 0, -1, 0,
+ax_anim 8, 0, 77, -2, 0, -2, 0,
+ax_anim 1, 2, 78, 1, 0, 1, 0,
+ax_anim 1, 0, 78, 6, 0, 6, 0,
+ax_anim 2, 0, 76, 11, 0, 11, 0,
+ax_anim 2, 1, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 76, 11, 0, 11, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 76, 11, 0, 11, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 78, 9, 0, 9, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sCradilyAnims_3_4:
+ax_anim 2, 0, 82, -1, 1, -1, 1,
+ax_anim 8, 0, 82, -2, 2, -2, 2,
+ax_anim 1, 2, 83, 3, -3, 3, -3,
+ax_anim 1, 0, 83, 8, -8, 8, -8,
+ax_anim 2, 0, 81, 16, -16, 16, -16,
+ax_anim 2, 1, 80, 16, -16, 16, -16,
+ax_anim 2, 0, 81, 16, -16, 16, -16,
+ax_anim 2, 0, 80, 16, -16, 16, -16,
+ax_anim 2, 0, 81, 16, -16, 16, -16,
+ax_anim 2, 0, 80, 16, -16, 16, -16,
+ax_anim 2, 0, 83, 9, -10, 9, -10,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sCradilyAnims_3_5:
+ax_anim 2, 0, 87, 0, 2, 0, 2,
+ax_anim 8, 0, 87, 0, 3, 0, 3,
+ax_anim 1, 2, 88, 0, -2, 0, -2,
+ax_anim 1, 0, 88, 0, -7, 0, -7,
+ax_anim 2, 0, 86, 0, -16, 0, -16,
+ax_anim 2, 1, 85, 0, -16, 0, -16,
+ax_anim 2, 0, 86, 0, -16, 0, -16,
+ax_anim 2, 0, 85, 0, -16, 0, -16,
+ax_anim 2, 0, 86, 0, -16, 0, -16,
+ax_anim 2, 0, 85, 0, -16, 0, -16,
+ax_anim 2, 0, 88, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sCradilyAnims_3_6:
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 8, 0, 92, 2, 2, 2, 2,
+ax_anim 1, 2, 93, -3, -3, -3, -3,
+ax_anim 1, 0, 93, -8, -8, -8, -8,
+ax_anim 2, 0, 91, -16, -16, -16, -16,
+ax_anim 2, 1, 90, -16, -16, -16, -16,
+ax_anim 2, 0, 91, -16, -16, -16, -16,
+ax_anim 2, 0, 90, -16, -16, -16, -16,
+ax_anim 2, 0, 91, -16, -16, -16, -16,
+ax_anim 2, 0, 90, -16, -16, -16, -16,
+ax_anim 2, 0, 93, -9, -10, -9, -10,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sCradilyAnims_3_7:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 8, 0, 97, 2, 0, 2, 0,
+ax_anim 1, 2, 98, -1, 0, -1, 0,
+ax_anim 1, 0, 98, -6, 0, -6, 0,
+ax_anim 2, 0, 96, -11, 0, -11, 0,
+ax_anim 2, 1, 95, -11, 0, -11, 0,
+ax_anim 2, 0, 96, -11, 0, -11, 0,
+ax_anim 2, 0, 95, -11, 0, -11, 0,
+ax_anim 2, 0, 96, -11, 0, -11, 0,
+ax_anim 2, 0, 95, -11, 0, -11, 0,
+ax_anim 2, 0, 98, -9, 0, -9, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sCradilyAnims_3_8:
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 8, 0, 102, 2, -2, 2, -2,
+ax_anim 1, 2, 103, -2, 3, -2, 3,
+ax_anim 1, 0, 103, -7, 10, -7, 10,
+ax_anim 2, 0, 101, -16, 19, -16, 19,
+ax_anim 2, 1, 100, -16, 19, -16, 19,
+ax_anim 2, 0, 101, -16, 19, -16, 19,
+ax_anim 2, 0, 100, -16, 19, -16, 19,
+ax_anim 2, 0, 101, -16, 19, -16, 19,
+ax_anim 2, 0, 100, -16, 19, -16, 19,
+ax_anim 2, 0, 103, -9, 10, -9, 10,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sCradilyAnims_4_1:
+ax_anim 2, 0, 107, 0, -2, 0, -2,
+ax_anim 6, 2, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 105, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 105, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sCradilyAnims_4_2:
+ax_anim 2, 0, 112, -2, -2, -2, -2,
+ax_anim 6, 2, 112, -3, -3, -3, -3,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 2, 0, 110, 2, 2, 2, 2,
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 2, 0, 110, 2, 2, 2, 2,
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim_terminator
+sCradilyAnims_4_3:
+ax_anim 2, 0, 117, -2, 0, -2, 0,
+ax_anim 6, 2, 117, -3, 0, -3, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 1, 116, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 2, 0, 116, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 2, 0, 116, 2, 0, 2, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sCradilyAnims_4_4:
+ax_anim 2, 0, 122, -2, 2, -2, 2,
+ax_anim 6, 2, 122, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 1, 121, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 120, 2, -2, 2, -2,
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 120, 2, -2, 2, -2,
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim_terminator
+sCradilyAnims_4_5:
+ax_anim 2, 0, 127, 0, 2, 0, 2,
+ax_anim 6, 2, 127, 0, 3, 0, 3,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 1, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sCradilyAnims_4_6:
+ax_anim 2, 0, 132, 2, 2, 2, 2,
+ax_anim 6, 2, 132, 3, 3, 3, 3,
+ax_anim 2, 0, 129, 1, 1, 1, 1,
+ax_anim 2, 1, 131, -2, -2, -2, -2,
+ax_anim 2, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 0, 130, -2, -2, -2, -2,
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 2, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 0, 130, -2, -2, -2, -2,
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim_terminator
+sCradilyAnims_4_7:
+ax_anim 2, 0, 137, 2, 0, 2, 0,
+ax_anim 6, 2, 137, 3, 0, 3, 0,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 1, 136, -2, 0, -2, 0,
+ax_anim 2, 0, 138, -2, 0, -2, 0,
+ax_anim 2, 0, 135, -2, 0, -2, 0,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim 2, 0, 138, -2, 0, -2, 0,
+ax_anim 2, 0, 135, -2, 0, -2, 0,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim_terminator
+sCradilyAnims_4_8:
+ax_anim 2, 0, 142, 2, -2, 2, -2,
+ax_anim 6, 2, 142, 3, -3, 3, -3,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 1, 141, -2, 2, -2, 2,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 0, 140, -2, 2, -2, 2,
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 0, 140, -2, 2, -2, 2,
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCradilyAnims_5_1:
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 2, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_5_2:
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 1, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_5_3:
+ax_anim 6, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 2, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_5_4:
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 6, 2, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_5_5:
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 2, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_5_6:
+ax_anim 6, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 6, 2, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_5_7:
+ax_anim 6, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 4, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 6, 2, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_5_8:
+ax_anim 6, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 4, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 6, 2, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 4, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_6_1:
+ax_anim 30, 0, 208, 0, 0, 0, 0,
+ax_anim 35, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_7_1:
+ax_anim 2, 0, 210, 0, -2, 0, -2,
+ax_anim 8, 0, 210, 0, -3, 0, -3,
+ax_anim_terminator
+sCradilyAnims_7_2:
+ax_anim 2, 0, 211, -2, -2, -2, -2,
+ax_anim 8, 0, 211, -3, -3, -3, -3,
+ax_anim_terminator
+sCradilyAnims_7_3:
+ax_anim 2, 0, 212, -2, 0, -2, 0,
+ax_anim 8, 0, 212, -3, 0, -3, 0,
+ax_anim_terminator
+sCradilyAnims_7_4:
+ax_anim 2, 0, 213, -2, 2, -2, 2,
+ax_anim 8, 0, 213, -3, 3, -3, 3,
+ax_anim_terminator
+sCradilyAnims_7_5:
+ax_anim 2, 0, 214, 0, 2, 0, 2,
+ax_anim 8, 0, 214, 0, 3, 0, 3,
+ax_anim_terminator
+sCradilyAnims_7_6:
+ax_anim 2, 0, 215, 2, 2, 2, 2,
+ax_anim 8, 0, 215, 3, 3, 3, 3,
+ax_anim_terminator
+sCradilyAnims_7_7:
+ax_anim 2, 0, 216, 2, 0, 2, 0,
+ax_anim 8, 0, 216, 3, 0, 3, 0,
+ax_anim_terminator
+sCradilyAnims_7_8:
+ax_anim 2, 0, 217, 2, -2, 2, -2,
+ax_anim 8, 0, 217, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCradilyAnims_8_1:
+ax_anim 40, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 10, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_8_2:
+ax_anim 40, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_8_3:
+ax_anim 40, 0, 222, 0, 0, 0, 0,
+ax_anim 4, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_8_4:
+ax_anim 40, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, 1, 1, 1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, 1, 1, 1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, 1, 1, 1,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_8_5:
+ax_anim 40, 0, 226, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_8_6:
+ax_anim 40, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, 1, -1, 1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, 1, -1, 1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, 1, -1, 1,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_8_7:
+ax_anim 40, 0, 230, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_8_8:
+ax_anim 40, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_9_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 6, 3, 6, 3,
+ax_anim 2, 0, 236, 10, 7, 10, 7,
+ax_anim 2, 0, 237, 7, 17, 7, 17,
+ax_anim 3, 0, 238, 0, 19, 0, 19,
+ax_anim 2, 3, 239, -7, 17, -7, 17,
+ax_anim 2, 0, 240, -8, 7, -8, 7,
+ax_anim 1, 0, 241, -6, 3, -6, 3,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_9_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 8, 0, 8, 0,
+ax_anim 2, 0, 235, 17, 3, 17, 3,
+ax_anim 2, 0, 236, 22, 11, 22, 11,
+ax_anim 3, 0, 237, 22, 19, 22, 19,
+ax_anim 2, 3, 238, 11, 20, 11, 20,
+ax_anim 2, 0, 239, 3, 15, 3, 15,
+ax_anim 1, 0, 240, 0, 7, 0, 7,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_9_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 3, -5, 3, -5,
+ax_anim 2, 0, 234, 10, -7, 10, -7,
+ax_anim 2, 0, 235, 18, -6, 18, -6,
+ax_anim 3, 0, 236, 23, -2, 23, -2,
+ax_anim 2, 3, 237, 18, 5, 18, 5,
+ax_anim 2, 0, 238, 11, 6, 11, 6,
+ax_anim 1, 0, 239, 4, 5, 4, 5,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_9_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, -1, -8, -1, -8,
+ax_anim 2, 0, 241, 4, -16, 4, -16,
+ax_anim 2, 0, 234, 12, -22, 12, -22,
+ax_anim 3, 0, 235, 21, -22, 21, -22,
+ax_anim 2, 3, 236, 23, -14, 23, -14,
+ax_anim 2, 0, 237, 17, -4, 17, -4,
+ax_anim 1, 0, 238, 7, -1, 7, -1,
+ax_anim 1, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_9_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, -8, -4, -8, -4,
+ax_anim 2, 0, 240, -10, -12, -10, -12,
+ax_anim 2, 0, 241, -7, -18, -7, -18,
+ax_anim 3, 0, 234, 0, -22, 0, -22,
+ax_anim 2, 3, 235, 7, -18, 7, -18,
+ax_anim 2, 0, 236, 10, -10, 10, -10,
+ax_anim 1, 0, 237, 8, -4, 8, -4,
+ax_anim 1, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_9_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 1, -8, 1, -8,
+ax_anim 2, 0, 235, -4, -16, -4, -16,
+ax_anim 2, 0, 234, -12, -22, -12, -22,
+ax_anim 3, 0, 241, -18, -22, -18, -22,
+ax_anim 2, 3, 240, -23, -14, -23, -14,
+ax_anim 2, 0, 239, -17, -4, -17, -4,
+ax_anim 1, 0, 238, -7, -1, -7, -1,
+ax_anim 1, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_9_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -3, -5, -3, -5,
+ax_anim 2, 0, 234, -10, -7, -10, -7,
+ax_anim 2, 0, 241, -18, -6, -18, -6,
+ax_anim 3, 0, 240, -23, -2, -23, -2,
+ax_anim 2, 3, 239, -18, 5, -18, 5,
+ax_anim 2, 0, 238, -11, 5, -11, 5,
+ax_anim 1, 0, 237, -4, 5, -4, 5,
+ax_anim 1, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_9_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 234, -8, 0, -8, 0,
+ax_anim 2, 0, 241, -17, 3, -17, 3,
+ax_anim 2, 0, 240, -22, 11, -22, 11,
+ax_anim 3, 0, 239, -22, 19, -22, 19,
+ax_anim 2, 3, 238, -11, 20, -11, 20,
+ax_anim 2, 0, 237, -3, 15, -3, 15,
+ax_anim 1, 0, 236, 0, 7, 0, 7,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_10_1:
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 2, 0, 242, 6, 1, 6, 1,
+ax_anim 2, 0, 242, -6, 1, -6, 1,
+ax_anim 2, 0, 242, 10, 1, 10, 1,
+ax_anim 2, 0, 242, -10, 1, -10, 1,
+ax_anim 2, 0, 242, 12, 1, 12, 1,
+ax_anim 3, 0, 242, -12, 1, -12, 1,
+ax_anim 3, 0, 242, 13, 1, 13, 1,
+ax_anim 3, 0, 242, -13, 1, -13, 1,
+ax_anim 2, 0, 242, 12, 1, 12, 1,
+ax_anim 3, 0, 242, -12, 1, -12, 1,
+ax_anim 2, 0, 242, 10, 1, 10, 1,
+ax_anim 2, 0, 242, -10, 1, -10, 1,
+ax_anim 2, 0, 242, 6, 1, 6, 1,
+ax_anim 2, 0, 242, -6, 1, -6, 1,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim_terminator
+sCradilyAnims_10_2:
+ax_anim 2, 0, 243, 3, 0, 3, 0,
+ax_anim 2, 0, 243, 9, -6, 9, -6,
+ax_anim 2, 0, 243, -3, 6, -3, 6,
+ax_anim 2, 0, 243, 13, -10, 13, -10,
+ax_anim 2, 0, 243, -7, 10, -7, 10,
+ax_anim 2, 0, 243, 15, -12, 15, -12,
+ax_anim 3, 0, 243, -9, 12, -9, 12,
+ax_anim 3, 0, 243, 16, -13, 16, -13,
+ax_anim 3, 0, 243, -10, 13, -10, 13,
+ax_anim 2, 0, 243, 15, -12, 15, -12,
+ax_anim 3, 0, 243, -9, 12, -9, 12,
+ax_anim 2, 0, 243, 13, -10, 13, -10,
+ax_anim 2, 0, 243, -7, 10, -7, 10,
+ax_anim 2, 0, 243, 9, -6, 9, -6,
+ax_anim 2, 0, 243, -3, 6, -3, 6,
+ax_anim 2, 0, 243, 3, 0, 3, 0,
+ax_anim_terminator
+sCradilyAnims_10_3:
+ax_anim 2, 0, 244, 6, 0, 6, 0,
+ax_anim 2, 0, 244, 6, -6, 6, -6,
+ax_anim 2, 0, 244, 6, 6, 6, 6,
+ax_anim 2, 0, 244, 6, -10, 6, -10,
+ax_anim 2, 0, 244, 6, 10, 6, 10,
+ax_anim 2, 0, 244, 6, -12, 6, -12,
+ax_anim 3, 0, 244, 6, 12, 6, 12,
+ax_anim 3, 0, 244, 6, -13, 6, -13,
+ax_anim 3, 0, 244, 6, 13, 6, 13,
+ax_anim 2, 0, 244, 6, -12, 6, -12,
+ax_anim 3, 0, 244, 6, 12, 6, 12,
+ax_anim 2, 0, 244, 6, -10, 6, -10,
+ax_anim 2, 0, 244, 6, 10, 6, 10,
+ax_anim 2, 0, 244, 6, -6, 6, -6,
+ax_anim 2, 0, 244, 6, 6, 6, 6,
+ax_anim 2, 0, 244, 6, 0, 6, 0,
+ax_anim_terminator
+sCradilyAnims_10_4:
+ax_anim 2, 0, 245, 3, -2, 3, -2,
+ax_anim 2, 0, 245, -3, -8, -3, -8,
+ax_anim 2, 0, 245, 9, 4, 9, 4,
+ax_anim 2, 0, 245, -7, -12, -7, -12,
+ax_anim 2, 0, 245, 13, 8, 13, 8,
+ax_anim 2, 0, 245, -9, -14, -9, -14,
+ax_anim 3, 0, 245, 15, 10, 15, 10,
+ax_anim 3, 0, 245, -10, -15, -10, -15,
+ax_anim 3, 0, 245, 16, 11, 16, 11,
+ax_anim 2, 0, 245, -9, -14, -9, -14,
+ax_anim 3, 0, 245, 15, 10, 15, 10,
+ax_anim 2, 0, 245, -7, -12, -7, -12,
+ax_anim 2, 0, 245, 13, 8, 13, 8,
+ax_anim 2, 0, 245, -3, -8, -3, -8,
+ax_anim 2, 0, 245, 9, 4, 9, 4,
+ax_anim 2, 0, 245, 3, -2, 3, -2,
+ax_anim_terminator
+sCradilyAnims_10_5:
+ax_anim 2, 0, 246, 0, -3, 0, -3,
+ax_anim 2, 0, 246, 6, -3, 6, -3,
+ax_anim 2, 0, 246, -6, -3, -6, -3,
+ax_anim 2, 0, 246, 10, -3, 10, -3,
+ax_anim 2, 0, 246, -10, -3, -10, -3,
+ax_anim 2, 0, 246, 12, -3, 12, -3,
+ax_anim 3, 0, 246, -12, -3, -12, -3,
+ax_anim 3, 0, 246, 13, -3, 13, -3,
+ax_anim 3, 0, 246, -13, -3, -13, -3,
+ax_anim 2, 0, 246, 12, -3, 12, -3,
+ax_anim 3, 0, 246, -12, -3, -12, -3,
+ax_anim 2, 0, 246, 10, -3, 10, -3,
+ax_anim 2, 0, 246, -10, -3, -10, -3,
+ax_anim 2, 0, 246, 6, -3, 6, -3,
+ax_anim 2, 0, 246, -6, -3, -6, -3,
+ax_anim 2, 0, 246, 0, -3, 0, -3,
+ax_anim_terminator
+sCradilyAnims_10_6:
+ax_anim 2, 0, 247, -3, -2, -3, -2,
+ax_anim 2, 0, 247, 3, -8, 3, -8,
+ax_anim 2, 0, 247, -9, 4, -9, 4,
+ax_anim 2, 0, 247, 7, -12, 7, -12,
+ax_anim 2, 0, 247, -13, 8, -13, 8,
+ax_anim 2, 0, 247, 9, -14, 9, -14,
+ax_anim 3, 0, 247, -15, 10, -15, 10,
+ax_anim 3, 0, 247, 10, -15, 10, -15,
+ax_anim 3, 0, 247, -16, 11, -16, 11,
+ax_anim 2, 0, 247, 9, -14, 9, -14,
+ax_anim 3, 0, 247, -15, 10, -15, 10,
+ax_anim 2, 0, 247, 7, -12, 7, -12,
+ax_anim 2, 0, 247, -13, 8, -13, 8,
+ax_anim 2, 0, 247, 3, -8, 3, -8,
+ax_anim 2, 0, 247, -9, 4, -9, 4,
+ax_anim 2, 0, 247, -3, -2, -3, -2,
+ax_anim_terminator
+sCradilyAnims_10_7:
+ax_anim 2, 0, 248, -6, 0, -6, 0,
+ax_anim 2, 0, 248, -6, -6, -6, -6,
+ax_anim 2, 0, 248, -6, 6, -6, 6,
+ax_anim 2, 0, 248, -6, -10, -6, -10,
+ax_anim 2, 0, 248, -6, 10, -6, 10,
+ax_anim 2, 0, 248, -6, -12, -6, -12,
+ax_anim 3, 0, 248, -6, 12, -6, 12,
+ax_anim 3, 0, 248, -6, -13, -6, -13,
+ax_anim 3, 0, 248, -6, 13, -6, 13,
+ax_anim 2, 0, 248, -6, -12, -6, -12,
+ax_anim 3, 0, 248, -6, 12, -6, 12,
+ax_anim 2, 0, 248, -6, -10, -6, -10,
+ax_anim 2, 0, 248, -6, 10, -6, 10,
+ax_anim 2, 0, 248, -6, -6, -6, -6,
+ax_anim 2, 0, 248, -6, 6, -6, 6,
+ax_anim 2, 0, 248, -6, 0, -6, 0,
+ax_anim_terminator
+sCradilyAnims_10_8:
+ax_anim 2, 0, 249, -2, 0, -2, 0,
+ax_anim 2, 0, 249, -8, -6, -8, -6,
+ax_anim 2, 0, 249, 4, 6, 4, 6,
+ax_anim 2, 0, 249, -12, -10, -12, -10,
+ax_anim 2, 0, 249, 8, 10, 8, 10,
+ax_anim 2, 0, 249, -14, -12, -14, -12,
+ax_anim 3, 0, 249, 10, 12, 10, 12,
+ax_anim 3, 0, 249, -15, -13, -15, -13,
+ax_anim 3, 0, 249, 11, 13, 11, 13,
+ax_anim 2, 0, 249, -14, -12, -14, -12,
+ax_anim 3, 0, 249, 10, 12, 10, 12,
+ax_anim 2, 0, 249, -12, -10, -12, -10,
+ax_anim 2, 0, 249, 8, 10, 8, 10,
+ax_anim 2, 0, 249, -8, -6, -8, -6,
+ax_anim 2, 0, 249, 4, 6, 4, 6,
+ax_anim 2, 0, 249, -2, 0, -2, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_11_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -10, 0, 0,
+ax_anim 2, 0, 251, 0, -16, 0, 0,
+ax_anim 3, 0, 251, 0, -20, 0, 0,
+ax_anim 4, 0, 251, 0, -21, 0, 0,
+ax_anim 4, 0, 250, 0, -23, 0, 0,
+ax_anim 3, 0, 252, 0, -22, 0, 0,
+ax_anim 2, 0, 252, 0, -18, 0, 0,
+ax_anim 1, 0, 252, 0, -12, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_11_2:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 254, 0, -10, 0, 0,
+ax_anim 2, 0, 254, 0, -16, 0, 0,
+ax_anim 3, 0, 254, 0, -20, 0, 0,
+ax_anim 4, 0, 254, 0, -21, 0, 0,
+ax_anim 4, 0, 253, 0, -23, 0, 0,
+ax_anim 3, 0, 255, 0, -22, 0, 0,
+ax_anim 2, 0, 255, 0, -18, 0, 0,
+ax_anim 1, 0, 255, 0, -12, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_11_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 0, -10, 0, 0,
+ax_anim 2, 0, 257, 0, -16, 0, 0,
+ax_anim 3, 0, 257, 0, -20, 0, 0,
+ax_anim 4, 0, 257, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 258, 0, -22, 0, 0,
+ax_anim 2, 0, 258, 0, -18, 0, 0,
+ax_anim 1, 0, 258, 0, -12, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_11_4:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -10, 0, 0,
+ax_anim 2, 0, 260, 0, -16, 0, 0,
+ax_anim 3, 0, 260, 0, -20, 0, 0,
+ax_anim 4, 0, 260, 0, -21, 0, 0,
+ax_anim 4, 0, 259, 0, -22, 0, 0,
+ax_anim 3, 0, 261, 0, -21, 0, 0,
+ax_anim 2, 0, 261, 0, -17, 0, 0,
+ax_anim 1, 0, 261, 0, -11, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_11_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -23, 0, 0,
+ax_anim 3, 0, 264, 0, -20, 0, 0,
+ax_anim 2, 0, 264, 0, -18, 0, 0,
+ax_anim 1, 0, 264, 0, -12, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_11_6:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -22, 0, 0,
+ax_anim 3, 0, 267, 0, -21, 0, 0,
+ax_anim 2, 0, 267, 0, -17, 0, 0,
+ax_anim 1, 0, 267, 0, -11, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_11_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 268, 0, -23, 0, 0,
+ax_anim 3, 0, 270, 0, -22, 0, 0,
+ax_anim 2, 0, 270, 0, -18, 0, 0,
+ax_anim 1, 0, 270, 0, -12, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_11_8:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 271, 0, -23, 0, 0,
+ax_anim 3, 0, 273, 0, -22, 0, 0,
+ax_anim 2, 0, 273, 0, -18, 0, 0,
+ax_anim 1, 0, 273, 0, -12, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_12_1:
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 1, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_12_2:
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 1, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_12_3:
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 1, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_12_4:
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 1, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_12_5:
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 1, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_12_6:
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 1, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_12_7:
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 1, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_12_8:
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 1, 275, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCradilyAnims_13_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_13_2:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_13_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_13_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_13_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_13_6:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_13_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyAnims_13_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sCradilyGfx1:
+.incbin "baserom.gba", 0x141DE1C, 0x200
+sCradilySprites1:
+ax_sprite sCradilyGfx1, 0x200
+ax_sprite_terminator
+sCradilyGfx2:
+.incbin "baserom.gba", 0x141E02C, 0x200
+sCradilySprites2:
+ax_sprite sCradilyGfx2, 0x200
+ax_sprite_terminator
+sCradilyGfx3:
+.incbin "baserom.gba", 0x141E23C, 0x200
+sCradilySprites3:
+ax_sprite sCradilyGfx3, 0x200
+ax_sprite_terminator
+sCradilyGfx4:
+.incbin "baserom.gba", 0x141E44C, 0x200
+sCradilySprites4:
+ax_sprite sCradilyGfx4, 0x200
+ax_sprite_terminator
+sCradilyGfx5:
+.incbin "baserom.gba", 0x141E65C, 0x200
+sCradilySprites5:
+ax_sprite sCradilyGfx5, 0x200
+ax_sprite_terminator
+sCradilyGfx6:
+.incbin "baserom.gba", 0x141E86C, 0x200
+sCradilySprites6:
+ax_sprite sCradilyGfx6, 0x200
+ax_sprite_terminator
+sCradilyGfx7:
+.incbin "baserom.gba", 0x141EA7C, 0x200
+sCradilySprites7:
+ax_sprite sCradilyGfx7, 0x200
+ax_sprite_terminator
+sCradilyGfx8:
+.incbin "baserom.gba", 0x141EC8C, 0x200
+sCradilySprites8:
+ax_sprite sCradilyGfx8, 0x200
+ax_sprite_terminator
+sCradilyGfx9:
+.incbin "baserom.gba", 0x141EE9C, 0x200
+sCradilySprites9:
+ax_sprite sCradilyGfx9, 0x200
+ax_sprite_terminator
+sCradilyGfx10:
+.incbin "baserom.gba", 0x141F0AC, 0x200
+sCradilySprites10:
+ax_sprite sCradilyGfx10, 0x200
+ax_sprite_terminator
+sCradilyGfx11:
+.incbin "baserom.gba", 0x141F2BC, 0x200
+sCradilySprites11:
+ax_sprite sCradilyGfx11, 0x200
+ax_sprite_terminator
+sCradilyGfx12:
+.incbin "baserom.gba", 0x141F4CC, 0x200
+sCradilySprites12:
+ax_sprite sCradilyGfx12, 0x200
+ax_sprite_terminator
+sCradilyGfx13:
+.incbin "baserom.gba", 0x141F6DC, 0x200
+sCradilySprites13:
+ax_sprite sCradilyGfx13, 0x200
+ax_sprite_terminator
+sCradilyGfx14:
+.incbin "baserom.gba", 0x141F8EC, 0x200
+sCradilySprites14:
+ax_sprite sCradilyGfx14, 0x200
+ax_sprite_terminator
+sCradilyGfx15:
+.incbin "baserom.gba", 0x141FAFC, 0x200
+sCradilySprites15:
+ax_sprite sCradilyGfx15, 0x200
+ax_sprite_terminator
+sCradilyGfx16:
+.incbin "baserom.gba", 0x141FD0C, 0x100
+sCradilySprites16:
+ax_sprite sCradilyGfx16, 0x100
+ax_sprite_terminator
+sCradilyGfx17:
+.incbin "baserom.gba", 0x141FE1C, 0x60
+sCradilySprites17:
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx17, 0x60
+ax_sprite_terminator
+sCradilyGfx18:
+.incbin "baserom.gba", 0x141FE94, 0xE0
+sCradilySprites18:
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx18, 0xe0
+ax_sprite_terminator
+sCradilyGfx19:
+.incbin "baserom.gba", 0x141FF8C, 0x80
+sCradilySprites19:
+ax_sprite sCradilyGfx19, 0x80
+ax_sprite_terminator
+sCradilyGfx20:
+.incbin "baserom.gba", 0x142001C, 0x100
+sCradilySprites20:
+ax_sprite sCradilyGfx20, 0x100
+ax_sprite_terminator
+sCradilyGfx21:
+.incbin "baserom.gba", 0x142012C, 0x80
+sCradilySprites21:
+ax_sprite sCradilyGfx21, 0x80
+ax_sprite_terminator
+sCradilyGfx22:
+.incbin "baserom.gba", 0x14201BC, 0x100
+sCradilySprites22:
+ax_sprite sCradilyGfx22, 0x100
+ax_sprite_terminator
+sCradilyGfx23:
+.incbin "baserom.gba", 0x14202CC, 0x80
+sCradilySprites23:
+ax_sprite sCradilyGfx23, 0x80
+ax_sprite_terminator
+sCradilyGfx24:
+.incbin "baserom.gba", 0x142035C, 0x60
+sCradilyGfx24_1:
+.incbin "baserom.gba", 0x14203BC, 0x60
+sCradilySprites24:
+ax_sprite sCradilyGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCradilyGfx25:
+.incbin "baserom.gba", 0x1420444, 0x80
+sCradilySprites25:
+ax_sprite sCradilyGfx25, 0x80
+ax_sprite_terminator
+sCradilyGfx26:
+.incbin "baserom.gba", 0x14204D4, 0x60
+sCradilyGfx26_1:
+.incbin "baserom.gba", 0x1420534, 0x60
+sCradilySprites26:
+ax_sprite sCradilyGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCradilyGfx27:
+.incbin "baserom.gba", 0x14205BC, 0x80
+sCradilySprites27:
+ax_sprite sCradilyGfx27, 0x80
+ax_sprite_terminator
+sCradilyGfx28:
+.incbin "baserom.gba", 0x142064C, 0x100
+sCradilySprites28:
+ax_sprite sCradilyGfx28, 0x100
+ax_sprite_terminator
+sCradilyGfx29:
+.incbin "baserom.gba", 0x142075C, 0x40
+sCradilySprites29:
+ax_sprite sCradilyGfx29, 0x40
+ax_sprite_terminator
+sCradilyGfx30:
+.incbin "baserom.gba", 0x14207AC, 0x60
+sCradilyGfx30_1:
+.incbin "baserom.gba", 0x142080C, 0x60
+sCradilySprites30:
+ax_sprite sCradilyGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCradilyGfx31:
+.incbin "baserom.gba", 0x1420894, 0x80
+sCradilySprites31:
+ax_sprite sCradilyGfx31, 0x80
+ax_sprite_terminator
+sCradilyGfx32:
+.incbin "baserom.gba", 0x1420924, 0x60
+sCradilyGfx32_1:
+.incbin "baserom.gba", 0x1420984, 0x80
+sCradilySprites32:
+ax_sprite sCradilyGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx32_1, 0x80
+ax_sprite_terminator
+sCradilyGfx33:
+.incbin "baserom.gba", 0x1420A24, 0x40
+sCradilySprites33:
+ax_sprite sCradilyGfx33, 0x40
+ax_sprite_terminator
+sCradilyGfx34:
+.incbin "baserom.gba", 0x1420A74, 0x60
+sCradilyGfx34_1:
+.incbin "baserom.gba", 0x1420AD4, 0x80
+sCradilySprites34:
+ax_sprite sCradilyGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx34_1, 0x80
+ax_sprite_terminator
+sCradilyGfx35:
+.incbin "baserom.gba", 0x1420B74, 0x40
+sCradilySprites35:
+ax_sprite sCradilyGfx35, 0x40
+ax_sprite_terminator
+sCradilyGfx36:
+.incbin "baserom.gba", 0x1420BC4, 0x100
+sCradilySprites36:
+ax_sprite sCradilyGfx36, 0x100
+ax_sprite_terminator
+sCradilyGfx37:
+.incbin "baserom.gba", 0x1420CD4, 0x20
+sCradilySprites37:
+ax_sprite sCradilyGfx37, 0x20
+ax_sprite_terminator
+sCradilyGfx38:
+.incbin "baserom.gba", 0x1420D04, 0x60
+sCradilyGfx38_1:
+.incbin "baserom.gba", 0x1420D64, 0x80
+sCradilySprites38:
+ax_sprite sCradilyGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx38_1, 0x80
+ax_sprite_terminator
+sCradilyGfx39:
+.incbin "baserom.gba", 0x1420E04, 0x20
+sCradilySprites39:
+ax_sprite sCradilyGfx39, 0x20
+ax_sprite_terminator
+sCradilyGfx40:
+.incbin "baserom.gba", 0x1420E34, 0x100
+sCradilySprites40:
+ax_sprite sCradilyGfx40, 0x100
+ax_sprite_terminator
+sCradilyGfx41:
+.incbin "baserom.gba", 0x1420F44, 0x60
+sCradilySprites41:
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx41, 0x60
+ax_sprite_terminator
+sCradilyGfx42:
+.incbin "baserom.gba", 0x1420FBC, 0x100
+sCradilySprites42:
+ax_sprite sCradilyGfx42, 0x100
+ax_sprite_terminator
+sCradilyGfx43:
+.incbin "baserom.gba", 0x14210CC, 0x40
+sCradilySprites43:
+ax_sprite sCradilyGfx43, 0x40
+ax_sprite_terminator
+sCradilyGfx44:
+.incbin "baserom.gba", 0x142111C, 0xE0
+sCradilySprites44:
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx44, 0xe0
+ax_sprite_terminator
+sCradilyGfx45:
+.incbin "baserom.gba", 0x1421214, 0x40
+sCradilySprites45:
+ax_sprite sCradilyGfx45, 0x40
+ax_sprite_terminator
+sCradilyGfx46:
+.incbin "baserom.gba", 0x1421264, 0x100
+sCradilySprites46:
+ax_sprite sCradilyGfx46, 0x100
+ax_sprite_terminator
+sCradilyGfx47:
+.incbin "baserom.gba", 0x1421374, 0x60
+sCradilySprites47:
+ax_sprite sCradilyGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCradilyGfx48:
+.incbin "baserom.gba", 0x14213EC, 0x80
+sCradilyGfx48_1:
+.incbin "baserom.gba", 0x142146C, 0x60
+sCradilySprites48:
+ax_sprite sCradilyGfx48, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx48_1, 0x60
+ax_sprite_terminator
+sCradilyGfx49:
+.incbin "baserom.gba", 0x14214EC, 0x80
+sCradilySprites49:
+ax_sprite sCradilyGfx49, 0x80
+ax_sprite_terminator
+sCradilyGfx50:
+.incbin "baserom.gba", 0x142157C, 0x40
+sCradilyGfx50_1:
+.incbin "baserom.gba", 0x14215BC, 0x80
+sCradilySprites50:
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx50_1, 0x80
+ax_sprite_terminator
+sCradilyGfx51:
+.incbin "baserom.gba", 0x1421664, 0x80
+sCradilySprites51:
+ax_sprite sCradilyGfx51, 0x80
+ax_sprite_terminator
+sCradilyGfx52:
+.incbin "baserom.gba", 0x14216F4, 0x100
+sCradilySprites52:
+ax_sprite sCradilyGfx52, 0x100
+ax_sprite_terminator
+sCradilyGfx53:
+.incbin "baserom.gba", 0x1421804, 0x20
+sCradilySprites53:
+ax_sprite sCradilyGfx53, 0x20
+ax_sprite_terminator
+sCradilyGfx54:
+.incbin "baserom.gba", 0x1421834, 0x100
+sCradilySprites54:
+ax_sprite sCradilyGfx54, 0x100
+ax_sprite_terminator
+sCradilyGfx55:
+.incbin "baserom.gba", 0x1421944, 0x80
+sCradilySprites55:
+ax_sprite sCradilyGfx55, 0x80
+ax_sprite_terminator
+sCradilyGfx56:
+.incbin "baserom.gba", 0x14219D4, 0x60
+sCradilyGfx56_1:
+.incbin "baserom.gba", 0x1421A34, 0x160
+sCradilySprites56:
+ax_sprite sCradilyGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx56_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCradilyGfx57:
+.incbin "baserom.gba", 0x1421BBC, 0x20
+sCradilySprites57:
+ax_sprite sCradilyGfx57, 0x20
+ax_sprite_terminator
+sCradilyGfx58:
+.incbin "baserom.gba", 0x1421BEC, 0x20
+sCradilySprites58:
+ax_sprite sCradilyGfx58, 0x20
+ax_sprite_terminator
+sCradilyGfx59:
+.incbin "baserom.gba", 0x1421C1C, 0x80
+sCradilySprites59:
+ax_sprite sCradilyGfx59, 0x80
+ax_sprite_terminator
+sCradilyGfx60:
+.incbin "baserom.gba", 0x1421CAC, 0x80
+sCradilySprites60:
+ax_sprite sCradilyGfx60, 0x80
+ax_sprite_terminator
+sCradilyGfx61:
+.incbin "baserom.gba", 0x1421D3C, 0x100
+sCradilySprites61:
+ax_sprite sCradilyGfx61, 0x100
+ax_sprite_terminator
+sCradilyGfx62:
+.incbin "baserom.gba", 0x1421E4C, 0x80
+sCradilySprites62:
+ax_sprite sCradilyGfx62, 0x80
+ax_sprite_terminator
+sCradilyGfx63:
+.incbin "baserom.gba", 0x1421EDC, 0xC0
+sCradilyGfx63_1:
+.incbin "baserom.gba", 0x1421F9C, 0x20
+sCradilySprites63:
+ax_sprite sCradilyGfx63, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx63_1, 0x20
+ax_sprite_terminator
+sCradilyGfx64:
+.incbin "baserom.gba", 0x1421FDC, 0x80
+sCradilySprites64:
+ax_sprite sCradilyGfx64, 0x80
+ax_sprite_terminator
+sCradilyGfx65:
+.incbin "baserom.gba", 0x142206C, 0x100
+sCradilySprites65:
+ax_sprite sCradilyGfx65, 0x100
+ax_sprite_terminator
+sCradilyGfx66:
+.incbin "baserom.gba", 0x142217C, 0x80
+sCradilySprites66:
+ax_sprite sCradilyGfx66, 0x80
+ax_sprite_terminator
+sCradilyGfx67:
+.incbin "baserom.gba", 0x142220C, 0x180
+sCradilyGfx67_1:
+.incbin "baserom.gba", 0x142238C, 0x40
+sCradilySprites67:
+ax_sprite sCradilyGfx67, 0x180
+ax_sprite 0, 0x20
+ax_sprite sCradilyGfx67_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCradilyGfx68:
+.incbin "baserom.gba", 0x14223F4, 0x200
+sCradilySprites68:
+ax_sprite sCradilyGfx68, 0x200
+ax_sprite_terminator
+sCradilyGfx69:
+.incbin "baserom.gba", 0x1422604, 0x200
+sCradilySprites69:
+ax_sprite sCradilyGfx69, 0x200
+ax_sprite_terminator
+sCradilyGfx70:
+.incbin "baserom.gba", 0x1422814, 0x200
+sCradilySprites70:
+ax_sprite sCradilyGfx70, 0x200
+ax_sprite_terminator
+sCradilyGfx71:
+.incbin "baserom.gba", 0x1422A24, 0x200
+sCradilySprites71:
+ax_sprite sCradilyGfx71, 0x200
+ax_sprite_terminator
+sCradilyGfx72:
+.incbin "baserom.gba", 0x1422C34, 0x200
+sCradilySprites72:
+ax_sprite sCradilyGfx72, 0x200
+ax_sprite_terminator
+sCradilyGfx73:
+.incbin "baserom.gba", 0x1422E44, 0x200
+sCradilySprites73:
+ax_sprite sCradilyGfx73, 0x200
+ax_sprite_terminator
+sCradilyGfx74:
+.incbin "baserom.gba", 0x1423054, 0x200
+sCradilySprites74:
+ax_sprite sCradilyGfx74, 0x200
+ax_sprite_terminator
+sAxPosesCradily:
+.4byte sCradilyPose1
+.4byte sCradilyPose2
+.4byte sCradilyPose3
+.4byte sCradilyPose4
+.4byte sCradilyPose5
+.4byte sCradilyPose6
+.4byte sCradilyPose7
+.4byte sCradilyPose8
+.4byte sCradilyPose9
+.4byte sCradilyPose10
+.4byte sCradilyPose11
+.4byte sCradilyPose12
+.4byte sCradilyPose13
+.4byte sCradilyPose14
+.4byte sCradilyPose15
+.4byte sCradilyPose16
+.4byte sCradilyPose17
+.4byte sCradilyPose18
+.4byte sCradilyPose19
+.4byte sCradilyPose20
+.4byte sCradilyPose21
+.4byte sCradilyPose22
+.4byte sCradilyPose23
+.4byte sCradilyPose24
+.4byte sCradilyPose25
+.4byte sCradilyPose26
+.4byte sCradilyPose27
+.4byte sCradilyPose28
+.4byte sCradilyPose29
+.4byte sCradilyPose30
+.4byte sCradilyPose31
+.4byte sCradilyPose32
+.4byte sCradilyPose33
+.4byte sCradilyPose34
+.4byte sCradilyPose35
+.4byte sCradilyPose36
+.4byte sCradilyPose37
+.4byte sCradilyPose38
+.4byte sCradilyPose39
+.4byte sCradilyPose40
+.4byte sCradilyPose41
+.4byte sCradilyPose42
+.4byte sCradilyPose43
+.4byte sCradilyPose44
+.4byte sCradilyPose45
+.4byte sCradilyPose46
+.4byte sCradilyPose47
+.4byte sCradilyPose48
+.4byte sCradilyPose49
+.4byte sCradilyPose50
+.4byte sCradilyPose51
+.4byte sCradilyPose52
+.4byte sCradilyPose53
+.4byte sCradilyPose54
+.4byte sCradilyPose55
+.4byte sCradilyPose56
+.4byte sCradilyPose57
+.4byte sCradilyPose58
+.4byte sCradilyPose59
+.4byte sCradilyPose60
+.4byte sCradilyPose61
+.4byte sCradilyPose62
+.4byte sCradilyPose63
+.4byte sCradilyPose64
+.4byte sCradilyPose65
+.4byte sCradilyPose66
+.4byte sCradilyPose67
+.4byte sCradilyPose68
+.4byte sCradilyPose69
+.4byte sCradilyPose70
+.4byte sCradilyPose71
+.4byte sCradilyPose72
+.4byte sCradilyPose73
+.4byte sCradilyPose74
+.4byte sCradilyPose75
+.4byte sCradilyPose76
+.4byte sCradilyPose77
+.4byte sCradilyPose78
+.4byte sCradilyPose79
+.4byte sCradilyPose80
+.4byte sCradilyPose81
+.4byte sCradilyPose82
+.4byte sCradilyPose83
+.4byte sCradilyPose84
+.4byte sCradilyPose85
+.4byte sCradilyPose86
+.4byte sCradilyPose87
+.4byte sCradilyPose88
+.4byte sCradilyPose89
+.4byte sCradilyPose90
+.4byte sCradilyPose91
+.4byte sCradilyPose92
+.4byte sCradilyPose93
+.4byte sCradilyPose94
+.4byte sCradilyPose95
+.4byte sCradilyPose96
+.4byte sCradilyPose97
+.4byte sCradilyPose98
+.4byte sCradilyPose99
+.4byte sCradilyPose100
+.4byte sCradilyPose101
+.4byte sCradilyPose102
+.4byte sCradilyPose103
+.4byte sCradilyPose104
+.4byte sCradilyPose105
+.4byte sCradilyPose106
+.4byte sCradilyPose107
+.4byte sCradilyPose108
+.4byte sCradilyPose109
+.4byte sCradilyPose110
+.4byte sCradilyPose111
+.4byte sCradilyPose112
+.4byte sCradilyPose113
+.4byte sCradilyPose114
+.4byte sCradilyPose115
+.4byte sCradilyPose116
+.4byte sCradilyPose117
+.4byte sCradilyPose118
+.4byte sCradilyPose119
+.4byte sCradilyPose120
+.4byte sCradilyPose121
+.4byte sCradilyPose122
+.4byte sCradilyPose123
+.4byte sCradilyPose124
+.4byte sCradilyPose125
+.4byte sCradilyPose126
+.4byte sCradilyPose127
+.4byte sCradilyPose128
+.4byte sCradilyPose129
+.4byte sCradilyPose130
+.4byte sCradilyPose131
+.4byte sCradilyPose132
+.4byte sCradilyPose133
+.4byte sCradilyPose134
+.4byte sCradilyPose135
+.4byte sCradilyPose136
+.4byte sCradilyPose137
+.4byte sCradilyPose138
+.4byte sCradilyPose139
+.4byte sCradilyPose140
+.4byte sCradilyPose141
+.4byte sCradilyPose142
+.4byte sCradilyPose143
+.4byte sCradilyPose144
+.4byte sCradilyPose145
+.4byte sCradilyPose146
+.4byte sCradilyPose147
+.4byte sCradilyPose148
+.4byte sCradilyPose149
+.4byte sCradilyPose150
+.4byte sCradilyPose151
+.4byte sCradilyPose152
+.4byte sCradilyPose153
+.4byte sCradilyPose154
+.4byte sCradilyPose155
+.4byte sCradilyPose156
+.4byte sCradilyPose157
+.4byte sCradilyPose158
+.4byte sCradilyPose159
+.4byte sCradilyPose160
+.4byte sCradilyPose161
+.4byte sCradilyPose162
+.4byte sCradilyPose163
+.4byte sCradilyPose164
+.4byte sCradilyPose165
+.4byte sCradilyPose166
+.4byte sCradilyPose167
+.4byte sCradilyPose168
+.4byte sCradilyPose169
+.4byte sCradilyPose170
+.4byte sCradilyPose171
+.4byte sCradilyPose172
+.4byte sCradilyPose173
+.4byte sCradilyPose174
+.4byte sCradilyPose175
+.4byte sCradilyPose176
+.4byte sCradilyPose177
+.4byte sCradilyPose178
+.4byte sCradilyPose179
+.4byte sCradilyPose180
+.4byte sCradilyPose181
+.4byte sCradilyPose182
+.4byte sCradilyPose183
+.4byte sCradilyPose184
+.4byte sCradilyPose185
+.4byte sCradilyPose186
+.4byte sCradilyPose187
+.4byte sCradilyPose188
+.4byte sCradilyPose189
+.4byte sCradilyPose190
+.4byte sCradilyPose191
+.4byte sCradilyPose192
+.4byte sCradilyPose193
+.4byte sCradilyPose194
+.4byte sCradilyPose195
+.4byte sCradilyPose196
+.4byte sCradilyPose197
+.4byte sCradilyPose198
+.4byte sCradilyPose199
+.4byte sCradilyPose200
+.4byte sCradilyPose201
+.4byte sCradilyPose202
+.4byte sCradilyPose203
+.4byte sCradilyPose204
+.4byte sCradilyPose205
+.4byte sCradilyPose206
+.4byte sCradilyPose207
+.4byte sCradilyPose208
+.4byte sCradilyPose209
+.4byte sCradilyPose210
+.4byte sCradilyPose211
+.4byte sCradilyPose212
+.4byte sCradilyPose213
+.4byte sCradilyPose214
+.4byte sCradilyPose215
+.4byte sCradilyPose216
+.4byte sCradilyPose217
+.4byte sCradilyPose218
+.4byte sCradilyPose219
+.4byte sCradilyPose220
+.4byte sCradilyPose221
+.4byte sCradilyPose222
+.4byte sCradilyPose223
+.4byte sCradilyPose224
+.4byte sCradilyPose225
+.4byte sCradilyPose226
+.4byte sCradilyPose227
+.4byte sCradilyPose228
+.4byte sCradilyPose229
+.4byte sCradilyPose230
+.4byte sCradilyPose231
+.4byte sCradilyPose232
+.4byte sCradilyPose233
+.4byte sCradilyPose234
+.4byte sCradilyPose235
+.4byte sCradilyPose236
+.4byte sCradilyPose237
+.4byte sCradilyPose238
+.4byte sCradilyPose239
+.4byte sCradilyPose240
+.4byte sCradilyPose241
+.4byte sCradilyPose242
+.4byte sCradilyPose243
+.4byte sCradilyPose244
+.4byte sCradilyPose245
+.4byte sCradilyPose246
+.4byte sCradilyPose247
+.4byte sCradilyPose248
+.4byte sCradilyPose249
+.4byte sCradilyPose250
+.4byte sCradilyPose251
+.4byte sCradilyPose252
+.4byte sCradilyPose253
+.4byte sCradilyPose254
+.4byte sCradilyPose255
+.4byte sCradilyPose256
+.4byte sCradilyPose257
+.4byte sCradilyPose258
+.4byte sCradilyPose259
+.4byte sCradilyPose260
+.4byte sCradilyPose261
+.4byte sCradilyPose262
+.4byte sCradilyPose263
+.4byte sCradilyPose264
+.4byte sCradilyPose265
+.4byte sCradilyPose266
+.4byte sCradilyPose267
+.4byte sCradilyPose268
+.4byte sCradilyPose269
+.4byte sCradilyPose270
+.4byte sCradilyPose271
+.4byte sCradilyPose272
+.4byte sCradilyPose273
+.4byte sCradilyPose274
+.4byte sCradilyPose275
+.4byte sCradilyPose276
+.4byte sCradilyPose277
+.4byte sCradilyPose278
+.4byte sCradilyPose279
+.4byte sCradilyPose280
+.4byte sCradilyPose281
+.4byte sCradilyPose282
+.4byte sCradilyPose283
+.4byte sCradilyPose284
+.4byte sCradilyPose285
+.4byte sCradilyPose286
+.4byte sCradilyPose287
+.4byte sCradilyPose288
+.4byte sCradilyPose289
+.4byte sCradilyPose290
+sAxPositionsCradily:
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte    0,   -5, 	  -6,   -1, 	   4,    0, 	  -1,   -4
+.2byte    0,   -9, 	  -5,    0, 	   5,   -2, 	   0,   -7
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte    7,   -5, 	   4,   -1, 	  -1,    1, 	   2,   -5
+.2byte    3,   -9, 	   5,   -1, 	  -4,    0, 	  -1,   -7
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte    9,   -8, 	   4,   -3, 	   5,    1, 	   2,   -7
+.2byte    6,   -9, 	   5,   -3, 	   3,    1, 	   1,   -7
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte    6,  -16, 	   0,   -5, 	   5,   -3, 	   1,   -8
+.2byte    6,  -15, 	  -1,   -3, 	   4,   -2, 	  -2,   -7
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -20, 	   3,   -3, 	  -4,   -5, 	  -1,  -10
+.2byte   -1,  -18, 	   3,   -4, 	  -4,   -3, 	  -1,   -9
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -7,  -16, 	  -1,   -5, 	  -6,   -3, 	  -2,   -8
+.2byte   -7,  -15, 	   0,   -3, 	  -5,   -2, 	   1,   -7
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte  -10,   -8, 	  -5,   -3, 	  -6,    1, 	  -3,   -7
+.2byte   -7,   -9, 	  -6,   -3, 	  -4,    1, 	  -2,   -7
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -8,   -5, 	  -5,   -1, 	   0,    1, 	  -3,   -5
+.2byte   -4,   -9, 	  -6,   -1, 	   3,    0, 	   0,   -7
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    0,   -4, 	  -6,    0, 	   5,    0, 	   0,   -5
+.2byte    0,  -24, 	  -6,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -5
+.2byte   12,   -3, 	   4,   -1, 	  -3,    1, 	   3,   -5
+.2byte   -8,  -21, 	   5,   -1, 	  -3,    1, 	  -3,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -4
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -5
+.2byte   17,   -1, 	   4,   -1, 	   4,    1, 	   5,   -6
+.2byte   -1,  -22, 	   4,   -2, 	   4,    1, 	  -3,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -6
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte   11,  -15, 	  -1,   -3, 	   5,   -1, 	   2,   -9
+.2byte   10,  -14, 	  -2,   -3, 	   5,   -1, 	   2,  -10
+.2byte   -2,  -19, 	  -1,   -3, 	   5,   -1, 	  -3,   -8
+.2byte   11,  -15, 	  -1,   -4, 	   5,   -1, 	   2,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -21, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte    0,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte  -12,  -15, 	   0,   -3, 	  -6,   -1, 	  -3,   -9
+.2byte  -11,  -14, 	   1,   -3, 	  -6,   -1, 	  -3,  -10
+.2byte    1,  -19, 	   0,   -3, 	  -6,   -1, 	   2,   -8
+.2byte  -12,  -15, 	   0,   -4, 	  -6,   -1, 	  -3,  -10
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -5
+.2byte  -18,   -1, 	  -5,   -1, 	  -5,    1, 	  -6,   -6
+.2byte    0,  -22, 	  -5,   -2, 	  -5,    1, 	   2,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -6
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -5
+.2byte  -13,   -3, 	  -5,   -1, 	   2,    1, 	  -4,   -5
+.2byte    7,  -21, 	  -6,   -1, 	   2,    1, 	   2,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -4
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    0,   -4, 	  -6,    0, 	   5,    0, 	   0,   -5
+.2byte    0,  -24, 	  -6,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -5
+.2byte   12,   -3, 	   4,   -1, 	  -3,    1, 	   3,   -5
+.2byte   -8,  -21, 	   5,   -1, 	  -3,    1, 	  -3,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -4
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -5
+.2byte   17,   -1, 	   4,   -1, 	   4,    1, 	   5,   -6
+.2byte   -1,  -22, 	   4,   -2, 	   4,    1, 	  -3,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -6
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte   11,  -15, 	  -1,   -3, 	   5,   -1, 	   2,   -9
+.2byte   10,  -14, 	  -2,   -3, 	   5,   -1, 	   2,  -10
+.2byte   -2,  -19, 	  -1,   -3, 	   5,   -1, 	  -3,   -8
+.2byte   11,  -15, 	  -1,   -4, 	   5,   -1, 	   2,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -21, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte    0,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte  -12,  -15, 	   0,   -3, 	  -6,   -1, 	  -3,   -9
+.2byte  -11,  -14, 	   1,   -3, 	  -6,   -1, 	  -3,  -10
+.2byte    1,  -19, 	   0,   -3, 	  -6,   -1, 	   2,   -8
+.2byte  -12,  -15, 	   0,   -4, 	  -6,   -1, 	  -3,  -10
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -5
+.2byte  -18,   -1, 	  -5,   -1, 	  -5,    1, 	  -6,   -6
+.2byte    0,  -22, 	  -5,   -2, 	  -5,    1, 	   2,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -6
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -5
+.2byte  -13,   -3, 	  -5,   -1, 	   2,    1, 	  -4,   -5
+.2byte    7,  -21, 	  -6,   -1, 	   2,    1, 	   2,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -4
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    0,   -4, 	  -6,    0, 	   5,    0, 	   0,   -5
+.2byte    0,  -24, 	  -6,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -5
+.2byte   12,   -3, 	   4,   -1, 	  -3,    1, 	   3,   -5
+.2byte   -8,  -21, 	   5,   -1, 	  -3,    1, 	  -3,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -4
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -5
+.2byte   17,   -1, 	   4,   -1, 	   4,    1, 	   5,   -6
+.2byte   -1,  -22, 	   4,   -2, 	   4,    1, 	  -3,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -6
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte   11,  -15, 	  -1,   -3, 	   5,   -1, 	   2,   -9
+.2byte   10,  -14, 	  -2,   -3, 	   5,   -1, 	   2,  -10
+.2byte   -2,  -19, 	  -1,   -3, 	   5,   -1, 	  -3,   -8
+.2byte   11,  -15, 	  -1,   -4, 	   5,   -1, 	   2,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -21, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte    0,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte  -12,  -15, 	   0,   -3, 	  -6,   -1, 	  -3,   -9
+.2byte  -11,  -14, 	   1,   -3, 	  -6,   -1, 	  -3,  -10
+.2byte    1,  -19, 	   0,   -3, 	  -6,   -1, 	   2,   -8
+.2byte  -12,  -15, 	   0,   -4, 	  -6,   -1, 	  -3,  -10
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -5
+.2byte  -18,   -1, 	  -5,   -1, 	  -5,    1, 	  -6,   -6
+.2byte    0,  -22, 	  -5,   -2, 	  -5,    1, 	   2,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -6
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -5
+.2byte  -13,   -3, 	  -5,   -1, 	   2,    1, 	  -4,   -5
+.2byte    7,  -21, 	  -6,   -1, 	   2,    1, 	   2,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -4
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte    0,  -24, 	  -6,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    0,   -8, 	  -6,    0, 	   5,    0, 	   0,  -10
+.2byte    0,   -8, 	  -6,    0, 	   5,    0, 	   0,  -10
+.2byte    0,   -8, 	  -6,    0, 	   5,    0, 	   0,  -10
+.2byte    0,   -8, 	  -6,    0, 	   5,    0, 	   0,  -10
+.2byte    0,   -8, 	  -6,    0, 	   5,    0, 	   0,  -10
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -8,  -21, 	   5,   -1, 	  -3,    1, 	  -3,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -4
+.2byte    6,  -10, 	   5,   -1, 	  -3,    1, 	   0,   -9
+.2byte    6,  -10, 	   5,   -1, 	  -3,    1, 	   0,   -9
+.2byte    6,  -10, 	   5,   -1, 	  -3,    1, 	   0,   -9
+.2byte    6,  -10, 	   5,   -1, 	  -3,    1, 	   0,   -9
+.2byte    6,  -10, 	   5,   -1, 	  -3,    1, 	   0,   -9
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte   -1,  -22, 	   4,   -2, 	   4,    1, 	  -3,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -6
+.2byte   11,  -11, 	   4,   -2, 	   4,    1, 	   1,  -13
+.2byte   11,  -11, 	   4,   -2, 	   4,    1, 	   1,  -13
+.2byte   11,  -11, 	   4,   -2, 	   4,    1, 	   1,  -13
+.2byte   11,  -11, 	   4,   -2, 	   4,    1, 	   1,  -13
+.2byte   11,  -11, 	   4,   -2, 	   4,    1, 	   1,  -13
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte   -2,  -19, 	  -1,   -3, 	   5,   -1, 	  -3,   -8
+.2byte   11,  -15, 	  -1,   -4, 	   5,   -1, 	   2,  -10
+.2byte    6,  -20, 	   0,   -4, 	   5,   -2, 	  -1,  -12
+.2byte    6,  -20, 	   0,   -4, 	   5,   -2, 	  -1,  -12
+.2byte    6,  -20, 	   0,   -4, 	   5,   -2, 	  -1,  -12
+.2byte    6,  -20, 	   0,   -4, 	   5,   -2, 	  -1,  -12
+.2byte    6,  -20, 	   0,   -4, 	   5,   -2, 	  -1,  -12
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte    0,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -1,  -22, 	   4,   -4, 	  -5,   -4, 	   0,  -11
+.2byte   -1,  -22, 	   4,   -4, 	  -5,   -4, 	   0,  -11
+.2byte   -1,  -22, 	   4,   -4, 	  -5,   -4, 	   0,  -11
+.2byte   -1,  -22, 	   4,   -4, 	  -5,   -4, 	   0,  -11
+.2byte   -1,  -22, 	   4,   -4, 	  -5,   -4, 	   0,  -11
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte    1,  -19, 	   0,   -3, 	  -6,   -1, 	   2,   -8
+.2byte  -12,  -15, 	   0,   -4, 	  -6,   -1, 	  -3,  -10
+.2byte   -7,  -20, 	  -1,   -4, 	  -6,   -2, 	   0,  -12
+.2byte   -7,  -20, 	  -1,   -4, 	  -6,   -2, 	   0,  -12
+.2byte   -7,  -20, 	  -1,   -4, 	  -6,   -2, 	   0,  -12
+.2byte   -7,  -20, 	  -1,   -4, 	  -6,   -2, 	   0,  -12
+.2byte   -7,  -20, 	  -1,   -4, 	  -6,   -2, 	   0,  -12
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte    0,  -22, 	  -5,   -2, 	  -5,    1, 	   2,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -6
+.2byte  -12,  -11, 	  -5,   -2, 	  -5,    1, 	  -2,  -13
+.2byte  -12,  -11, 	  -5,   -2, 	  -5,    1, 	  -2,  -13
+.2byte  -12,  -11, 	  -5,   -2, 	  -5,    1, 	  -2,  -13
+.2byte  -12,  -11, 	  -5,   -2, 	  -5,    1, 	  -2,  -13
+.2byte  -12,  -11, 	  -5,   -2, 	  -5,    1, 	  -2,  -13
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte    7,  -21, 	  -6,   -1, 	   2,    1, 	   2,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -4
+.2byte   -7,  -10, 	  -6,   -1, 	   2,    1, 	  -1,   -9
+.2byte   -7,  -10, 	  -6,   -1, 	   2,    1, 	  -1,   -9
+.2byte   -7,  -10, 	  -6,   -1, 	   2,    1, 	  -1,   -9
+.2byte   -7,  -10, 	  -6,   -1, 	   2,    1, 	  -1,   -9
+.2byte   -7,  -10, 	  -6,   -1, 	   2,    1, 	  -1,   -9
+.2byte   -6,   -8, 	  -6,   -1, 	   0,    2, 	  -1,   -7
+.2byte   -6,   -7, 	  -6,   -1, 	   0,    2, 	  -1,   -6
+.2byte    0,  -12, 	  -6,   -5, 	   5,   -5, 	   0,   -9
+.2byte    3,  -15, 	   5,   -6, 	  -4,   -4, 	  -2,   -9
+.2byte    3,  -16, 	   3,   -7, 	   4,   -3, 	  -4,   -8
+.2byte    4,  -16, 	   0,   -6, 	   5,   -6, 	  -3,   -8
+.2byte   -1,  -17, 	   4,   -2, 	  -4,   -3, 	  -1,   -7
+.2byte   -6,  -16, 	  -2,   -6, 	  -7,   -6, 	   1,   -8
+.2byte   -4,  -16, 	  -4,   -7, 	  -5,   -3, 	   3,   -8
+.2byte   -4,  -15, 	  -6,   -6, 	   3,   -4, 	   1,   -9
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte   12,   -4, 	   5,   -1, 	  -3,    1, 	   3,   -4
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte   17,   -2, 	   4,   -2, 	   4,    1, 	   5,   -6
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte   11,  -15, 	  -1,   -4, 	   5,   -1, 	   2,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte  -12,  -15, 	   0,   -4, 	  -6,   -1, 	  -3,  -10
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte  -18,   -2, 	  -5,   -2, 	  -5,    1, 	  -6,   -6
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte  -13,   -4, 	  -6,   -1, 	   2,    1, 	  -4,   -4
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte    0,   -5, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    7,   -4, 	   0,   -1, 	  -8,    1, 	  -2,   -4
+.2byte   10,   -2, 	  -3,   -2, 	  -3,    1, 	  -2,   -6
+.2byte    8,  -13, 	  -4,   -2, 	   2,    1, 	  -1,   -8
+.2byte   -1,  -16, 	   4,    0, 	  -5,    0, 	   0,   -6
+.2byte   -9,  -13, 	   3,   -2, 	  -3,    1, 	   0,   -8
+.2byte  -11,   -2, 	   2,   -2, 	   2,    1, 	   1,   -6
+.2byte  -10,   -4, 	  -3,   -1, 	   5,    1, 	  -1,   -4
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte    0,   -9, 	  -5,    0, 	   5,   -2, 	   0,   -7
+.2byte    0,   -5, 	  -6,   -1, 	   4,    0, 	  -1,   -4
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+.2byte    3,   -9, 	   5,   -1, 	  -4,    0, 	  -1,   -7
+.2byte    7,   -5, 	   4,   -1, 	  -1,    1, 	   2,   -5
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte    6,   -9, 	   5,   -3, 	   3,    1, 	   1,   -7
+.2byte    9,   -8, 	   4,   -3, 	   5,    1, 	   2,   -7
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte    6,  -15, 	  -1,   -3, 	   4,   -2, 	  -2,   -7
+.2byte    6,  -16, 	   0,   -5, 	   5,   -3, 	   1,   -8
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -18, 	   3,   -4, 	  -4,   -3, 	  -1,   -9
+.2byte   -1,  -20, 	   3,   -3, 	  -4,   -5, 	  -1,  -10
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -7,  -15, 	   0,   -3, 	  -5,   -2, 	   1,   -7
+.2byte   -7,  -16, 	  -1,   -5, 	  -6,   -3, 	  -2,   -8
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte   -7,   -9, 	  -6,   -3, 	  -4,    1, 	  -2,   -7
+.2byte  -10,   -8, 	  -5,   -3, 	  -6,    1, 	  -3,   -7
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -4,   -9, 	  -6,   -1, 	   3,    0, 	   0,   -7
+.2byte   -8,   -5, 	  -5,   -1, 	   0,    1, 	  -3,   -5
+.2byte    0,  -24, 	  -6,    0, 	   5,    0, 	   0,  -11
+.2byte    7,  -21, 	  -6,   -1, 	   2,    1, 	   2,   -7
+.2byte    0,  -22, 	  -5,   -2, 	  -5,    1, 	   2,   -7
+.2byte    1,  -19, 	   0,   -3, 	  -6,   -1, 	   2,   -8
+.2byte    0,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -2,  -19, 	  -1,   -3, 	   5,   -1, 	  -3,   -8
+.2byte   -1,  -22, 	   4,   -2, 	   4,    1, 	  -3,   -7
+.2byte   -8,  -21, 	   5,   -1, 	  -3,    1, 	  -3,   -7
+.2byte    0,   -7, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte   -6,   -8, 	  -6,   -1, 	   2,    1, 	  -1,   -7
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,   -7
+.2byte   -6,  -15, 	   0,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -1,  -20, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte    5,  -15, 	  -1,   -4, 	   5,   -2, 	   0,   -7
+.2byte    8,   -9, 	   4,   -3, 	   4,    1, 	   0,   -7
+.2byte    5,   -8, 	   5,   -1, 	  -3,    1, 	   0,   -7
+sCradilyAnimTable1:
+.4byte sCradilyAnims_1_1
+.4byte sCradilyAnims_1_2
+.4byte sCradilyAnims_1_3
+.4byte sCradilyAnims_1_4
+.4byte sCradilyAnims_1_5
+.4byte sCradilyAnims_1_6
+.4byte sCradilyAnims_1_7
+.4byte sCradilyAnims_1_8
+sCradilyAnimTable2:
+.4byte sCradilyAnims_2_1
+.4byte sCradilyAnims_2_2
+.4byte sCradilyAnims_2_3
+.4byte sCradilyAnims_2_4
+.4byte sCradilyAnims_2_5
+.4byte sCradilyAnims_2_6
+.4byte sCradilyAnims_2_7
+.4byte sCradilyAnims_2_8
+sCradilyAnimTable3:
+.4byte sCradilyAnims_3_1
+.4byte sCradilyAnims_3_2
+.4byte sCradilyAnims_3_3
+.4byte sCradilyAnims_3_4
+.4byte sCradilyAnims_3_5
+.4byte sCradilyAnims_3_6
+.4byte sCradilyAnims_3_7
+.4byte sCradilyAnims_3_8
+sCradilyAnimTable4:
+.4byte sCradilyAnims_4_1
+.4byte sCradilyAnims_4_2
+.4byte sCradilyAnims_4_3
+.4byte sCradilyAnims_4_4
+.4byte sCradilyAnims_4_5
+.4byte sCradilyAnims_4_6
+.4byte sCradilyAnims_4_7
+.4byte sCradilyAnims_4_8
+sCradilyAnimTable5:
+.4byte sCradilyAnims_5_1
+.4byte sCradilyAnims_5_2
+.4byte sCradilyAnims_5_3
+.4byte sCradilyAnims_5_4
+.4byte sCradilyAnims_5_5
+.4byte sCradilyAnims_5_6
+.4byte sCradilyAnims_5_7
+.4byte sCradilyAnims_5_8
+sCradilyAnimTable6:
+.4byte sCradilyAnims_6_1
+.4byte sCradilyAnims_6_1
+.4byte sCradilyAnims_6_1
+.4byte sCradilyAnims_6_1
+.4byte sCradilyAnims_6_1
+.4byte sCradilyAnims_6_1
+.4byte sCradilyAnims_6_1
+.4byte sCradilyAnims_6_1
+sCradilyAnimTable7:
+.4byte sCradilyAnims_7_1
+.4byte sCradilyAnims_7_2
+.4byte sCradilyAnims_7_3
+.4byte sCradilyAnims_7_4
+.4byte sCradilyAnims_7_5
+.4byte sCradilyAnims_7_6
+.4byte sCradilyAnims_7_7
+.4byte sCradilyAnims_7_8
+sCradilyAnimTable8:
+.4byte sCradilyAnims_8_1
+.4byte sCradilyAnims_8_2
+.4byte sCradilyAnims_8_3
+.4byte sCradilyAnims_8_4
+.4byte sCradilyAnims_8_5
+.4byte sCradilyAnims_8_6
+.4byte sCradilyAnims_8_7
+.4byte sCradilyAnims_8_8
+sCradilyAnimTable9:
+.4byte sCradilyAnims_9_1
+.4byte sCradilyAnims_9_2
+.4byte sCradilyAnims_9_3
+.4byte sCradilyAnims_9_4
+.4byte sCradilyAnims_9_5
+.4byte sCradilyAnims_9_6
+.4byte sCradilyAnims_9_7
+.4byte sCradilyAnims_9_8
+sCradilyAnimTable10:
+.4byte sCradilyAnims_10_1
+.4byte sCradilyAnims_10_2
+.4byte sCradilyAnims_10_3
+.4byte sCradilyAnims_10_4
+.4byte sCradilyAnims_10_5
+.4byte sCradilyAnims_10_6
+.4byte sCradilyAnims_10_7
+.4byte sCradilyAnims_10_8
+sCradilyAnimTable11:
+.4byte sCradilyAnims_11_1
+.4byte sCradilyAnims_11_2
+.4byte sCradilyAnims_11_3
+.4byte sCradilyAnims_11_4
+.4byte sCradilyAnims_11_5
+.4byte sCradilyAnims_11_6
+.4byte sCradilyAnims_11_7
+.4byte sCradilyAnims_11_8
+sCradilyAnimTable12:
+.4byte sCradilyAnims_12_1
+.4byte sCradilyAnims_12_2
+.4byte sCradilyAnims_12_3
+.4byte sCradilyAnims_12_4
+.4byte sCradilyAnims_12_5
+.4byte sCradilyAnims_12_6
+.4byte sCradilyAnims_12_7
+.4byte sCradilyAnims_12_8
+sCradilyAnimTable13:
+.4byte sCradilyAnims_13_1
+.4byte sCradilyAnims_13_2
+.4byte sCradilyAnims_13_3
+.4byte sCradilyAnims_13_4
+.4byte sCradilyAnims_13_5
+.4byte sCradilyAnims_13_6
+.4byte sCradilyAnims_13_7
+.4byte sCradilyAnims_13_8
+sAxAnimationsCradily:
+.4byte sCradilyAnimTable1
+.4byte sCradilyAnimTable2
+.4byte sCradilyAnimTable3
+.4byte sCradilyAnimTable4
+.4byte sCradilyAnimTable5
+.4byte sCradilyAnimTable6
+.4byte sCradilyAnimTable7
+.4byte sCradilyAnimTable8
+.4byte sCradilyAnimTable9
+.4byte sCradilyAnimTable10
+.4byte sCradilyAnimTable11
+.4byte sCradilyAnimTable12
+.4byte sCradilyAnimTable13
+sAxSpritesCradily:
+.4byte sCradilySprites1
+.4byte sCradilySprites2
+.4byte sCradilySprites3
+.4byte sCradilySprites4
+.4byte sCradilySprites5
+.4byte sCradilySprites6
+.4byte sCradilySprites7
+.4byte sCradilySprites8
+.4byte sCradilySprites9
+.4byte sCradilySprites10
+.4byte sCradilySprites11
+.4byte sCradilySprites12
+.4byte sCradilySprites13
+.4byte sCradilySprites14
+.4byte sCradilySprites15
+.4byte sCradilySprites16
+.4byte sCradilySprites17
+.4byte sCradilySprites18
+.4byte sCradilySprites19
+.4byte sCradilySprites20
+.4byte sCradilySprites21
+.4byte sCradilySprites22
+.4byte sCradilySprites23
+.4byte sCradilySprites24
+.4byte sCradilySprites25
+.4byte sCradilySprites26
+.4byte sCradilySprites27
+.4byte sCradilySprites28
+.4byte sCradilySprites29
+.4byte sCradilySprites30
+.4byte sCradilySprites31
+.4byte sCradilySprites32
+.4byte sCradilySprites33
+.4byte sCradilySprites34
+.4byte sCradilySprites35
+.4byte sCradilySprites36
+.4byte sCradilySprites37
+.4byte sCradilySprites38
+.4byte sCradilySprites39
+.4byte sCradilySprites40
+.4byte sCradilySprites41
+.4byte sCradilySprites42
+.4byte sCradilySprites43
+.4byte sCradilySprites44
+.4byte sCradilySprites45
+.4byte sCradilySprites46
+.4byte sCradilySprites47
+.4byte sCradilySprites48
+.4byte sCradilySprites49
+.4byte sCradilySprites50
+.4byte sCradilySprites51
+.4byte sCradilySprites52
+.4byte sCradilySprites53
+.4byte sCradilySprites54
+.4byte sCradilySprites55
+.4byte sCradilySprites56
+.4byte sCradilySprites57
+.4byte sCradilySprites58
+.4byte sCradilySprites59
+.4byte sCradilySprites60
+.4byte sCradilySprites61
+.4byte sCradilySprites62
+.4byte sCradilySprites63
+.4byte sCradilySprites64
+.4byte sCradilySprites65
+.4byte sCradilySprites66
+.4byte sCradilySprites67
+.4byte sCradilySprites68
+.4byte sCradilySprites69
+.4byte sCradilySprites70
+.4byte sCradilySprites71
+.4byte sCradilySprites72
+.4byte sCradilySprites73
+.4byte sCradilySprites74
+sAxMainCradily:
+ax_main sAxPosesCradily, sAxAnimationsCradily, 13, sAxSpritesCradily, sAxPositionsCradily

--- a/data/ax/crawdaunt.inc
+++ b/data/ax/crawdaunt.inc
@@ -1,0 +1,2864 @@
+.global gAxCrawdaunt
+gAxCrawdaunt:
+ax_siro sAxMainCrawdaunt
+sCrawdauntPose1:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose2:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose4:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose5:
+ax_pose 4, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose6:
+ax_pose 5, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose7:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose8:
+ax_pose 7, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose9:
+ax_pose 8, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose10:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose11:
+ax_pose 10, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose12:
+ax_pose 11, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose13:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose14:
+ax_pose 13, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose15:
+ax_pose 14, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose16:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose17:
+ax_pose 10, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose18:
+ax_pose 11, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose19:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose22:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose23:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose24:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose25:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose26:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose27:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose28:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose29:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose30:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose31:
+ax_pose 4, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose32:
+ax_pose 5, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose33:
+ax_pose 17, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose34:
+ax_pose 18, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose35:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose36:
+ax_pose 7, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose37:
+ax_pose 8, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose38:
+ax_pose 19, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose39:
+ax_pose 20, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose40:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose41:
+ax_pose 10, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose42:
+ax_pose 11, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose43:
+ax_pose 21, 0x01ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose44:
+ax_pose 22, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose45:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose46:
+ax_pose 13, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose47:
+ax_pose 14, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose48:
+ax_pose 23, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose49:
+ax_pose 24, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose50:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose51:
+ax_pose 10, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose52:
+ax_pose 11, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose53:
+ax_pose 21, 0x01ea, 0x80ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose54:
+ax_pose 22, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose55:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose56:
+ax_pose 7, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose57:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose58:
+ax_pose 19, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose59:
+ax_pose 20, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose60:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose61:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose62:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose63:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose64:
+ax_pose 18, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose65:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose66:
+ax_pose 25, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose67:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose68:
+ax_pose 26, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose69:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose70:
+ax_pose 27, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose71:
+ax_pose 18, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose72:
+ax_pose 28, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose73:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose74:
+ax_pose 29, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose75:
+ax_pose 20, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose76:
+ax_pose 30, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose77:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose78:
+ax_pose 31, 0x01ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose79:
+ax_pose 22, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose80:
+ax_pose 32, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose81:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose82:
+ax_pose 23, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose83:
+ax_pose 24, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose84:
+ax_pose 33, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose85:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose86:
+ax_pose 31, 0x01ea, 0x80ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose87:
+ax_pose 22, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose88:
+ax_pose 32, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose89:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose90:
+ax_pose 29, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose91:
+ax_pose 20, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose92:
+ax_pose 30, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose93:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose94:
+ax_pose 27, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose95:
+ax_pose 18, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose96:
+ax_pose 28, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose97:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose98:
+ax_pose 15, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose99:
+ax_pose 34, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose100:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose101:
+ax_pose 17, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose102:
+ax_pose 35, 0x01ed, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose103:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose104:
+ax_pose 19, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose105:
+ax_pose 36, 0x81ea, 0x9101, 0x5c00
+ax_pose 37, 0x81ea, 0x50f9, 0x5c08
+ax_pose 38, 0x81f2, 0x10f1, 0x5c0c
+ax_pose 39, 0x01f2, 0x1111, 0x5c0e
+ax_pose_terminator
+sCrawdauntPose106:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose107:
+ax_pose 21, 0x01ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose108:
+ax_pose 40, 0x01ea, 0x90f4, 0x5c00
+ax_pose_terminator
+sCrawdauntPose109:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose110:
+ax_pose 23, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose111:
+ax_pose 41, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose112:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose113:
+ax_pose 21, 0x01ea, 0x80ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose114:
+ax_pose 40, 0x01ea, 0x80ed, 0x5c00
+ax_pose_terminator
+sCrawdauntPose115:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose116:
+ax_pose 19, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose117:
+ax_pose 36, 0x81ea, 0x80f0, 0x5c00
+ax_pose 37, 0x81ea, 0x4100, 0x5c08
+ax_pose 38, 0x81f2, 0x0108, 0x5c0c
+ax_pose 39, 0x01f2, 0x00e8, 0x5c0e
+ax_pose_terminator
+sCrawdauntPose118:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose119:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose120:
+ax_pose 35, 0x01ed, 0x80ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose121:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose122:
+ax_pose 42, 0x01fa, 0x40ef, 0x5c00
+ax_pose 43, 0x41ea, 0x80ef, 0x5c04
+ax_pose 44, 0x01f4, 0x010f, 0x5c0c
+ax_pose 45, 0x0202, 0x00ff, 0x5c0d
+ax_pose 46, 0x41fa, 0x00ff, 0x5c0e
+ax_pose_terminator
+sCrawdauntPose123:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose124:
+ax_pose 47, 0x01f4, 0x50f1, 0x5c00
+ax_pose 48, 0x81e4, 0x9101, 0x5c04
+ax_pose 49, 0x01f2, 0x10e9, 0x5c0c
+ax_pose 50, 0x41ec, 0x10f1, 0x5c0d
+ax_pose_terminator
+sCrawdauntPose125:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose126:
+ax_pose 51, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose127:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose128:
+ax_pose 52, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sCrawdauntPose129:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose130:
+ax_pose 53, 0x01e5, 0x80ef, 0x5c00
+ax_pose 49, 0x01ee, 0x010f, 0x5c10
+ax_pose_terminator
+sCrawdauntPose131:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose132:
+ax_pose 52, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose133:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose134:
+ax_pose 51, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sCrawdauntPose135:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose136:
+ax_pose 47, 0x01f4, 0x4100, 0x5c00
+ax_pose 48, 0x81e4, 0x80f0, 0x5c04
+ax_pose 49, 0x01f2, 0x0110, 0x5c0c
+ax_pose 50, 0x41ec, 0x0100, 0x5c0d
+ax_pose_terminator
+sCrawdauntPose137:
+ax_pose 54, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose138:
+ax_pose 55, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose139:
+ax_pose 56, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose140:
+ax_pose 57, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sCrawdauntPose141:
+ax_pose 58, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sCrawdauntPose142:
+ax_pose 59, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose143:
+ax_pose 60, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose144:
+ax_pose 59, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sCrawdauntPose145:
+ax_pose 58, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sCrawdauntPose146:
+ax_pose 57, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sCrawdauntPose147:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose148:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose149:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose150:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose151:
+ax_pose 4, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose152:
+ax_pose 5, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose153:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose154:
+ax_pose 7, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose155:
+ax_pose 8, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose156:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose157:
+ax_pose 10, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose158:
+ax_pose 11, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose159:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose160:
+ax_pose 13, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose161:
+ax_pose 14, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose162:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose163:
+ax_pose 10, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose164:
+ax_pose 11, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose165:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose166:
+ax_pose 7, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose167:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose168:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose169:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose170:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose171:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose172:
+ax_pose 18, 0x01ed, 0x80f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose173:
+ax_pose 20, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose174:
+ax_pose 22, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose175:
+ax_pose 24, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose176:
+ax_pose 22, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose177:
+ax_pose 20, 0x01ea, 0x90ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose178:
+ax_pose 18, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose179:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose180:
+ax_pose 17, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose181:
+ax_pose 19, 0x01e9, 0x90f2, 0x5c00
+ax_pose_terminator
+sCrawdauntPose182:
+ax_pose 21, 0x01e9, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose183:
+ax_pose 23, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose184:
+ax_pose 21, 0x01e9, 0x80ed, 0x5c00
+ax_pose_terminator
+sCrawdauntPose185:
+ax_pose 19, 0x01e9, 0x80ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose186:
+ax_pose 17, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose187:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose188:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose189:
+ax_pose 34, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose190:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose191:
+ax_pose 17, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose192:
+ax_pose 35, 0x01ed, 0x90f2, 0x5c00
+ax_pose_terminator
+sCrawdauntPose193:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose194:
+ax_pose 19, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose195:
+ax_pose 36, 0x81ea, 0x9100, 0x5c00
+ax_pose 37, 0x81ea, 0x50f8, 0x5c08
+ax_pose 38, 0x81f2, 0x10f0, 0x5c0c
+ax_pose 39, 0x01f2, 0x1110, 0x5c0e
+ax_pose_terminator
+sCrawdauntPose196:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose197:
+ax_pose 21, 0x01ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose198:
+ax_pose 40, 0x01ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose199:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose200:
+ax_pose 23, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose201:
+ax_pose 41, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose202:
+ax_pose 9, 0x01ea, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose203:
+ax_pose 21, 0x01ea, 0x80ed, 0x5c00
+ax_pose_terminator
+sCrawdauntPose204:
+ax_pose 40, 0x01ea, 0x80ed, 0x5c00
+ax_pose_terminator
+sCrawdauntPose205:
+ax_pose 6, 0x01ea, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose206:
+ax_pose 19, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose207:
+ax_pose 36, 0x81ea, 0x80f0, 0x5c00
+ax_pose 37, 0x81ea, 0x4100, 0x5c08
+ax_pose 38, 0x81f2, 0x0108, 0x5c0c
+ax_pose 39, 0x01f2, 0x00e8, 0x5c0e
+ax_pose_terminator
+sCrawdauntPose208:
+ax_pose 3, 0x01ed, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose209:
+ax_pose 17, 0x01ec, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose210:
+ax_pose 35, 0x01ed, 0x80ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose211:
+ax_pose 25, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose212:
+ax_pose 27, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose213:
+ax_pose 29, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sCrawdauntPose214:
+ax_pose 31, 0x01ea, 0x80ee, 0x5c00
+ax_pose_terminator
+sCrawdauntPose215:
+ax_pose 23, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose216:
+ax_pose 31, 0x01ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sCrawdauntPose217:
+ax_pose 29, 0x01e9, 0x90f2, 0x5c00
+ax_pose_terminator
+sCrawdauntPose218:
+ax_pose 27, 0x01ec, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose219:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose220:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose221:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose222:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose223:
+ax_pose 12, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sCrawdauntPose224:
+ax_pose 9, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose225:
+ax_pose 6, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sCrawdauntPose226:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+.align 2
+sCrawdauntAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 1, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCrawdauntAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 4, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 9, 11, 9, 11,
+ax_anim 2, 0, 29, 16, 18, 16, 18,
+ax_anim 2, 1, 29, 17, 17, 17, 17,
+ax_anim 2, 0, 29, 16, 18, 16, 18,
+ax_anim 2, 0, 29, 17, 17, 17, 17,
+ax_anim 2, 0, 29, 6, 7, 6, 7,
+ax_anim_terminator
+sCrawdauntAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 4, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 16, 0, 16, 0,
+ax_anim 2, 1, 34, 16, 1, 16, 1,
+ax_anim 2, 0, 34, 16, 0, 16, 0,
+ax_anim 2, 0, 34, 16, 1, 16, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sCrawdauntAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 4, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 9, -14, 9, -14,
+ax_anim 2, 0, 39, 16, -22, 16, -22,
+ax_anim 2, 1, 39, 17, -21, 17, -21,
+ax_anim 2, 0, 39, 16, -22, 16, -22,
+ax_anim 2, 0, 39, 17, -21, 17, -21,
+ax_anim 2, 0, 39, 5, -7, 5, -7,
+ax_anim_terminator
+sCrawdauntAnims_2_5:
+ax_anim 2, 0, 47, 0, 1, 0, 1,
+ax_anim 4, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, -2, 0, -2,
+ax_anim 1, 2, 44, 0, -4, 0, -4,
+ax_anim 1, 0, 44, 0, -11, 0, -11,
+ax_anim 2, 0, 44, 0, -21, 0, -21,
+ax_anim 2, 1, 44, 1, -21, 1, -21,
+ax_anim 2, 0, 44, 0, -21, 0, -21,
+ax_anim 2, 0, 44, 1, -21, 1, -21,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sCrawdauntAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 4, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 2, 49, -4, -6, -4, -6,
+ax_anim 1, 0, 49, -9, -14, -9, -14,
+ax_anim 2, 0, 49, -16, -22, -16, -22,
+ax_anim 2, 1, 49, -17, -21, -17, -21,
+ax_anim 2, 0, 49, -16, -22, -16, -22,
+ax_anim 2, 0, 49, -17, -21, -17, -21,
+ax_anim 2, 0, 49, -5, -7, -5, -7,
+ax_anim_terminator
+sCrawdauntAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 4, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 0, -4, 0,
+ax_anim 1, 0, 54, -10, 0, -10, 0,
+ax_anim 2, 0, 54, -16, 0, -16, 0,
+ax_anim 2, 1, 54, -16, 1, -16, 1,
+ax_anim 2, 0, 54, -16, 0, -16, 0,
+ax_anim 2, 0, 54, -16, 1, -16, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sCrawdauntAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 4, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, -4, 4, -4, 4,
+ax_anim 1, 0, 59, -9, 11, -9, 11,
+ax_anim 2, 0, 59, -16, 18, -16, 18,
+ax_anim 2, 1, 59, -17, 17, -17, 17,
+ax_anim 2, 0, 59, -16, 18, -16, 18,
+ax_anim 2, 0, 59, -17, 17, -17, 17,
+ax_anim 2, 0, 59, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_3_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 65, 0, -4, 0, -4,
+ax_anim 6, 0, 65, 0, -5, 0, -5,
+ax_anim 1, 0, 66, 0, -2, 0, -2,
+ax_anim 2, 2, 66, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 1, 66, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 66, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 66, 1, 17, 1, 17,
+ax_anim 2, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sCrawdauntAnims_3_2:
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -4, -4, -4, -4,
+ax_anim 6, 0, 69, -5, -5, -5, -5,
+ax_anim 1, 0, 70, -2, -2, -2, -2,
+ax_anim 2, 2, 70, 7, 6, 7, 6,
+ax_anim 2, 0, 71, 18, 17, 18, 17,
+ax_anim 2, 1, 70, 19, 16, 19, 16,
+ax_anim 2, 0, 71, 18, 17, 18, 17,
+ax_anim 2, 0, 70, 19, 16, 19, 16,
+ax_anim 2, 0, 71, 18, 17, 18, 17,
+ax_anim 2, 0, 70, 19, 16, 19, 16,
+ax_anim 2, 0, 68, 11, 10, 11, 10,
+ax_anim 2, 0, 68, 5, 4, 5, 4,
+ax_anim_terminator
+sCrawdauntAnims_3_3:
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim 2, 0, 73, -4, 0, -4, 0,
+ax_anim 6, 0, 73, -5, 0, -5, 0,
+ax_anim 1, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 2, 74, 7, 0, 7, 0,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 2, 1, 74, 18, 1, 18, 1,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 18, 1, 18, 1,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 18, 1, 18, 1,
+ax_anim 2, 0, 72, 11, 0, 11, 0,
+ax_anim 2, 0, 72, 5, 0, 5, 0,
+ax_anim_terminator
+sCrawdauntAnims_3_4:
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 2, 0, 77, -4, 4, -4, 4,
+ax_anim 6, 0, 77, -5, 5, -5, 5,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 78, 8, -12, 8, -12,
+ax_anim 2, 0, 79, 18, -24, 18, -24,
+ax_anim 2, 1, 78, 19, -23, 19, -23,
+ax_anim 2, 0, 79, 18, -24, 18, -24,
+ax_anim 2, 0, 78, 19, -23, 19, -23,
+ax_anim 2, 0, 79, 18, -24, 18, -24,
+ax_anim 2, 0, 78, 19, -23, 19, -23,
+ax_anim 2, 0, 76, 9, -12, 9, -12,
+ax_anim 2, 0, 76, 4, -5, 4, -5,
+ax_anim_terminator
+sCrawdauntAnims_3_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 2, 0, 81, 0, 4, 0, 4,
+ax_anim 6, 0, 81, 0, 5, 0, 5,
+ax_anim 1, 0, 82, 0, -2, 0, -2,
+ax_anim 2, 2, 82, 0, -10, 0, -10,
+ax_anim 2, 0, 83, 0, -23, 0, -23,
+ax_anim 2, 1, 82, 1, -23, 1, -23,
+ax_anim 2, 0, 83, 0, -23, 0, -23,
+ax_anim 2, 0, 82, 1, -23, 1, -23,
+ax_anim 2, 0, 83, 0, -23, 0, -23,
+ax_anim 2, 0, 82, 1, -23, 1, -23,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sCrawdauntAnims_3_6:
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 6, 0, 85, 5, 5, 5, 5,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 2, 86, -8, -12, -8, -12,
+ax_anim 2, 0, 87, -18, -24, -18, -24,
+ax_anim 2, 1, 86, -19, -23, -19, -23,
+ax_anim 2, 0, 87, -18, -24, -18, -24,
+ax_anim 2, 0, 86, -19, -23, -19, -23,
+ax_anim 2, 0, 87, -18, -24, -18, -24,
+ax_anim 2, 0, 86, -19, -23, -19, -23,
+ax_anim 2, 0, 84, -9, -12, -9, -12,
+ax_anim 2, 0, 84, -4, -5, -4, -5,
+ax_anim_terminator
+sCrawdauntAnims_3_7:
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 89, 4, 0, 4, 0,
+ax_anim 6, 0, 89, 5, 0, 5, 0,
+ax_anim 1, 0, 90, 2, 0, 2, 0,
+ax_anim 2, 2, 90, -7, 0, -7, 0,
+ax_anim 2, 0, 91, -18, 0, -18, 0,
+ax_anim 2, 1, 90, -18, 1, -18, 1,
+ax_anim 2, 0, 91, -18, 0, -18, 0,
+ax_anim 2, 0, 90, -18, 1, -18, 1,
+ax_anim 2, 0, 91, -18, 0, -18, 0,
+ax_anim 2, 0, 90, -18, 1, -18, 1,
+ax_anim 2, 0, 88, -11, 0, -11, 0,
+ax_anim 2, 0, 88, -5, 0, -5, 0,
+ax_anim_terminator
+sCrawdauntAnims_3_8:
+ax_anim 2, 0, 92, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 4, -4, 4, -4,
+ax_anim 6, 0, 93, 5, -5, 5, -5,
+ax_anim 1, 0, 94, 2, -2, 2, -2,
+ax_anim 2, 2, 94, -7, 6, -7, 6,
+ax_anim 2, 0, 95, -18, 17, -18, 17,
+ax_anim 2, 1, 94, -19, 16, -19, 16,
+ax_anim 2, 0, 95, -18, 17, -18, 17,
+ax_anim 2, 0, 94, -19, 16, -19, 16,
+ax_anim 2, 0, 95, -18, 17, -18, 17,
+ax_anim 2, 0, 94, -19, 16, -19, 16,
+ax_anim 2, 0, 92, -11, 10, -11, 10,
+ax_anim 2, 0, 92, -5, 4, -5, 4,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_4_1:
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 6, 2, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim_terminator
+sCrawdauntAnims_4_2:
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim 6, 2, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sCrawdauntAnims_4_3:
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim 6, 2, 103, -3, 0, -3, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 1, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim_terminator
+sCrawdauntAnims_4_4:
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 6, 2, 106, -3, 3, -3, 3,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 1, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim_terminator
+sCrawdauntAnims_4_5:
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim 6, 2, 109, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 1, 0, 1,
+ax_anim 2, 1, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sCrawdauntAnims_4_6:
+ax_anim 2, 0, 112, 2, 2, 2, 2,
+ax_anim 6, 2, 112, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 1, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+sCrawdauntAnims_4_7:
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 6, 2, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim_terminator
+sCrawdauntAnims_4_8:
+ax_anim 2, 0, 118, 2, -2, 2, -2,
+ax_anim 6, 2, 118, 3, -3, 3, -3,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_5_1:
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 2, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_5_2:
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 2, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_5_3:
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 2, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_5_4:
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 2, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_5_5:
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_5_6:
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 2, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_5_7:
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 2, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_5_8:
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 2, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sCrawdauntAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sCrawdauntAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sCrawdauntAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sCrawdauntAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sCrawdauntAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sCrawdauntAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sCrawdauntAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_8_1:
+ax_anim 24, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, -1, 0, 0,
+ax_anim 24, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_8_2:
+ax_anim 24, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, -1, -1, 0, 0,
+ax_anim 24, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_8_3:
+ax_anim 24, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 24, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_8_4:
+ax_anim 24, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, -1, 0, 0,
+ax_anim 24, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_8_5:
+ax_anim 24, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 24, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, -1, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_8_6:
+ax_anim 24, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, -1, 0, 0,
+ax_anim 24, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_8_7:
+ax_anim 24, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 24, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_8_8:
+ax_anim 24, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 1, -1, 0, 0,
+ax_anim 24, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 10, 8, 10, 8,
+ax_anim 2, 0, 173, 9, 15, 9, 15,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -9, 15, -9, 15,
+ax_anim 2, 0, 176, -10, 8, -10, 8,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 9, 0, 9, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 20, 12, 20, 12,
+ax_anim 3, 0, 173, 18, 18, 18, 18,
+ax_anim 2, 3, 174, 9, 19, 9, 19,
+ax_anim 2, 0, 175, 4, 17, 4, 17,
+ax_anim 1, 0, 176, 0, 9, 0, 9,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 4, -4, 4, -4,
+ax_anim 2, 0, 170, 10, -5, 10, -5,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 18, 1, 18, 1,
+ax_anim 2, 3, 173, 15, 4, 15, 4,
+ax_anim 2, 0, 174, 10, 4, 10, 4,
+ax_anim 1, 0, 175, 4, 3, 4, 3,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -8, 0, -8,
+ax_anim 2, 0, 177, 5, -17, 5, -17,
+ax_anim 2, 0, 170, 12, -24, 12, -24,
+ax_anim 3, 0, 171, 20, -23, 20, -23,
+ax_anim 2, 3, 172, 25, -14, 25, -14,
+ax_anim 2, 0, 173, 21, -4, 21, -4,
+ax_anim 1, 0, 174, 11, 1, 11, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -9, -4, -9, -4,
+ax_anim 2, 0, 176, -13, -11, -13, -11,
+ax_anim 2, 0, 177, -10, -20, -10, -20,
+ax_anim 3, 0, 170, 0, -25, 0, -25,
+ax_anim 2, 3, 171, 10, -20, 10, -20,
+ax_anim 2, 0, 172, 13, -11, 13, -11,
+ax_anim 1, 0, 173, 9, -4, 9, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -8, 0, -8,
+ax_anim 2, 0, 171, -5, -17, -5, -17,
+ax_anim 2, 0, 170, -12, -24, -12, -24,
+ax_anim 3, 0, 177, -20, -23, -20, -23,
+ax_anim 2, 3, 176, -25, -14, -25, -14,
+ax_anim 2, 0, 175, -21, -4, -21, -4,
+ax_anim 1, 0, 174, -11, 1, -11, 1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -4, -4, -4, -4,
+ax_anim 2, 0, 170, -10, -5, -10, -5,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -18, 1, -18, 1,
+ax_anim 2, 3, 175, -15, 4, -15, 4,
+ax_anim 2, 0, 174, -10, 4, -10, 4,
+ax_anim 1, 0, 173, -4, 3, -4, 3,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -9, 0, -9, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -20, 12, -20, 12,
+ax_anim 3, 0, 175, -18, 18, -18, 18,
+ax_anim 2, 3, 174, -9, 19, -9, 19,
+ax_anim 2, 0, 173, -4, 17, -4, 17,
+ax_anim 1, 0, 172, 0, 9, 0, 9,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrawdauntAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sCrawdauntGfx1:
+.incbin "baserom.gba", 0x13F4B88, 0x200
+sCrawdauntSprites1:
+ax_sprite sCrawdauntGfx1, 0x200
+ax_sprite_terminator
+sCrawdauntGfx2:
+.incbin "baserom.gba", 0x13F4D98, 0x200
+sCrawdauntSprites2:
+ax_sprite sCrawdauntGfx2, 0x200
+ax_sprite_terminator
+sCrawdauntGfx3:
+.incbin "baserom.gba", 0x13F4FA8, 0x200
+sCrawdauntSprites3:
+ax_sprite sCrawdauntGfx3, 0x200
+ax_sprite_terminator
+sCrawdauntGfx4:
+.incbin "baserom.gba", 0x13F51B8, 0x200
+sCrawdauntSprites4:
+ax_sprite sCrawdauntGfx4, 0x200
+ax_sprite_terminator
+sCrawdauntGfx5:
+.incbin "baserom.gba", 0x13F53C8, 0x200
+sCrawdauntSprites5:
+ax_sprite sCrawdauntGfx5, 0x200
+ax_sprite_terminator
+sCrawdauntGfx6:
+.incbin "baserom.gba", 0x13F55D8, 0x200
+sCrawdauntSprites6:
+ax_sprite sCrawdauntGfx6, 0x200
+ax_sprite_terminator
+sCrawdauntGfx7:
+.incbin "baserom.gba", 0x13F57E8, 0x200
+sCrawdauntSprites7:
+ax_sprite sCrawdauntGfx7, 0x200
+ax_sprite_terminator
+sCrawdauntGfx8:
+.incbin "baserom.gba", 0x13F59F8, 0x200
+sCrawdauntSprites8:
+ax_sprite sCrawdauntGfx8, 0x200
+ax_sprite_terminator
+sCrawdauntGfx9:
+.incbin "baserom.gba", 0x13F5C08, 0x200
+sCrawdauntSprites9:
+ax_sprite sCrawdauntGfx9, 0x200
+ax_sprite_terminator
+sCrawdauntGfx10:
+.incbin "baserom.gba", 0x13F5E18, 0x200
+sCrawdauntSprites10:
+ax_sprite sCrawdauntGfx10, 0x200
+ax_sprite_terminator
+sCrawdauntGfx11:
+.incbin "baserom.gba", 0x13F6028, 0x200
+sCrawdauntSprites11:
+ax_sprite sCrawdauntGfx11, 0x200
+ax_sprite_terminator
+sCrawdauntGfx12:
+.incbin "baserom.gba", 0x13F6238, 0x200
+sCrawdauntSprites12:
+ax_sprite sCrawdauntGfx12, 0x200
+ax_sprite_terminator
+sCrawdauntGfx13:
+.incbin "baserom.gba", 0x13F6448, 0x200
+sCrawdauntSprites13:
+ax_sprite sCrawdauntGfx13, 0x200
+ax_sprite_terminator
+sCrawdauntGfx14:
+.incbin "baserom.gba", 0x13F6658, 0x200
+sCrawdauntSprites14:
+ax_sprite sCrawdauntGfx14, 0x200
+ax_sprite_terminator
+sCrawdauntGfx15:
+.incbin "baserom.gba", 0x13F6868, 0x200
+sCrawdauntSprites15:
+ax_sprite sCrawdauntGfx15, 0x200
+ax_sprite_terminator
+sCrawdauntGfx16:
+.incbin "baserom.gba", 0x13F6A78, 0x180
+sCrawdauntSprites16:
+ax_sprite sCrawdauntGfx16, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx17:
+.incbin "baserom.gba", 0x13F6C10, 0x180
+sCrawdauntSprites17:
+ax_sprite sCrawdauntGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx18:
+.incbin "baserom.gba", 0x13F6DA8, 0x60
+sCrawdauntGfx18_1:
+.incbin "baserom.gba", 0x13F6E08, 0x100
+sCrawdauntSprites18:
+ax_sprite sCrawdauntGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx18_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx19:
+.incbin "baserom.gba", 0x13F6F30, 0x60
+sCrawdauntGfx19_1:
+.incbin "baserom.gba", 0x13F6F90, 0x100
+sCrawdauntSprites19:
+ax_sprite sCrawdauntGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx19_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx20:
+.incbin "baserom.gba", 0x13F70B8, 0x40
+sCrawdauntGfx20_1:
+.incbin "baserom.gba", 0x13F70F8, 0x40
+sCrawdauntGfx20_2:
+.incbin "baserom.gba", 0x13F7138, 0x60
+sCrawdauntGfx20_3:
+.incbin "baserom.gba", 0x13F7198, 0x40
+sCrawdauntSprites20:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx20_3, 0x40
+ax_sprite_terminator
+sCrawdauntGfx21:
+.incbin "baserom.gba", 0x13F7220, 0x40
+sCrawdauntGfx21_1:
+.incbin "baserom.gba", 0x13F7260, 0x100
+sCrawdauntGfx21_2:
+.incbin "baserom.gba", 0x13F7360, 0x40
+sCrawdauntSprites21:
+ax_sprite sCrawdauntGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx22:
+.incbin "baserom.gba", 0x13F73D8, 0xE0
+sCrawdauntGfx22_1:
+.incbin "baserom.gba", 0x13F74B8, 0x60
+sCrawdauntGfx22_2:
+.incbin "baserom.gba", 0x13F7518, 0x60
+sCrawdauntSprites22:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx22, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx22_2, 0x60
+ax_sprite_terminator
+sCrawdauntGfx23:
+.incbin "baserom.gba", 0x13F75B0, 0x60
+sCrawdauntGfx23_1:
+.incbin "baserom.gba", 0x13F7610, 0x100
+sCrawdauntGfx23_2:
+.incbin "baserom.gba", 0x13F7710, 0x40
+sCrawdauntSprites23:
+ax_sprite sCrawdauntGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx24:
+.incbin "baserom.gba", 0x13F7788, 0x1E0
+sCrawdauntSprites24:
+ax_sprite sCrawdauntGfx24, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx25:
+.incbin "baserom.gba", 0x13F7980, 0x1E0
+sCrawdauntSprites25:
+ax_sprite sCrawdauntGfx25, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx26:
+.incbin "baserom.gba", 0x13F7B78, 0x180
+sCrawdauntSprites26:
+ax_sprite sCrawdauntGfx26, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx27:
+.incbin "baserom.gba", 0x13F7D10, 0x40
+sCrawdauntGfx27_1:
+.incbin "baserom.gba", 0x13F7D50, 0x100
+sCrawdauntSprites27:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx27_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx28:
+.incbin "baserom.gba", 0x13F7E80, 0x60
+sCrawdauntGfx28_1:
+.incbin "baserom.gba", 0x13F7EE0, 0x100
+sCrawdauntSprites28:
+ax_sprite sCrawdauntGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx28_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx29:
+.incbin "baserom.gba", 0x13F8008, 0x60
+sCrawdauntGfx29_1:
+.incbin "baserom.gba", 0x13F8068, 0x100
+sCrawdauntSprites29:
+ax_sprite sCrawdauntGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx29_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCrawdauntGfx30:
+.incbin "baserom.gba", 0x13F8190, 0x60
+sCrawdauntGfx30_1:
+.incbin "baserom.gba", 0x13F81F0, 0x60
+sCrawdauntGfx30_2:
+.incbin "baserom.gba", 0x13F8250, 0x60
+sCrawdauntGfx30_3:
+.incbin "baserom.gba", 0x13F82B0, 0x40
+sCrawdauntSprites30:
+ax_sprite sCrawdauntGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx30_3, 0x40
+ax_sprite_terminator
+sCrawdauntGfx31:
+.incbin "baserom.gba", 0x13F8330, 0x40
+sCrawdauntGfx31_1:
+.incbin "baserom.gba", 0x13F8370, 0x100
+sCrawdauntGfx31_2:
+.incbin "baserom.gba", 0x13F8470, 0x40
+sCrawdauntSprites31:
+ax_sprite sCrawdauntGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx32:
+.incbin "baserom.gba", 0x13F84E8, 0x100
+sCrawdauntGfx32_1:
+.incbin "baserom.gba", 0x13F85E8, 0x60
+sCrawdauntGfx32_2:
+.incbin "baserom.gba", 0x13F8648, 0x60
+sCrawdauntSprites32:
+ax_sprite sCrawdauntGfx32, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx32_2, 0x60
+ax_sprite_terminator
+sCrawdauntGfx33:
+.incbin "baserom.gba", 0x13F86D8, 0x60
+sCrawdauntGfx33_1:
+.incbin "baserom.gba", 0x13F8738, 0x100
+sCrawdauntGfx33_2:
+.incbin "baserom.gba", 0x13F8838, 0x40
+sCrawdauntSprites33:
+ax_sprite sCrawdauntGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx34:
+.incbin "baserom.gba", 0x13F88B0, 0x1E0
+sCrawdauntSprites34:
+ax_sprite sCrawdauntGfx34, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx35:
+.incbin "baserom.gba", 0x13F8AA8, 0x40
+sCrawdauntGfx35_1:
+.incbin "baserom.gba", 0x13F8AE8, 0x100
+sCrawdauntGfx35_2:
+.incbin "baserom.gba", 0x13F8BE8, 0x40
+sCrawdauntSprites35:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx36:
+.incbin "baserom.gba", 0x13F8C68, 0x160
+sCrawdauntGfx36_1:
+.incbin "baserom.gba", 0x13F8DC8, 0x20
+sCrawdauntSprites36:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx36, 0x160
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx36_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx37:
+.incbin "baserom.gba", 0x13F8E18, 0x100
+sCrawdauntSprites37:
+ax_sprite sCrawdauntGfx37, 0x100
+ax_sprite_terminator
+sCrawdauntGfx38:
+.incbin "baserom.gba", 0x13F8F28, 0x60
+sCrawdauntSprites38:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx38, 0x60
+ax_sprite_terminator
+sCrawdauntGfx39:
+.incbin "baserom.gba", 0x13F8FA0, 0x40
+sCrawdauntSprites39:
+ax_sprite sCrawdauntGfx39, 0x40
+ax_sprite_terminator
+sCrawdauntGfx40:
+.incbin "baserom.gba", 0x13F8FF0, 0x20
+sCrawdauntSprites40:
+ax_sprite sCrawdauntGfx40, 0x20
+ax_sprite_terminator
+sCrawdauntGfx41:
+.incbin "baserom.gba", 0x13F9020, 0x60
+sCrawdauntGfx41_1:
+.incbin "baserom.gba", 0x13F9080, 0x100
+sCrawdauntGfx41_2:
+.incbin "baserom.gba", 0x13F9180, 0x40
+sCrawdauntSprites41:
+ax_sprite sCrawdauntGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx41_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx41_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx42:
+.incbin "baserom.gba", 0x13F91F8, 0x1E0
+sCrawdauntSprites42:
+ax_sprite sCrawdauntGfx42, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrawdauntGfx43:
+.incbin "baserom.gba", 0x13F93F0, 0x40
+sCrawdauntGfx43_1:
+.incbin "baserom.gba", 0x13F9430, 0x20
+sCrawdauntSprites43:
+ax_sprite sCrawdauntGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx43_1, 0x20
+ax_sprite_terminator
+sCrawdauntGfx44:
+.incbin "baserom.gba", 0x13F9470, 0x40
+sCrawdauntGfx44_1:
+.incbin "baserom.gba", 0x13F94B0, 0x80
+sCrawdauntSprites44:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx44_1, 0x80
+ax_sprite_terminator
+sCrawdauntGfx45:
+.incbin "baserom.gba", 0x13F9558, 0x20
+sCrawdauntSprites45:
+ax_sprite sCrawdauntGfx45, 0x20
+ax_sprite_terminator
+sCrawdauntGfx46:
+.incbin "baserom.gba", 0x13F9588, 0x20
+sCrawdauntSprites46:
+ax_sprite sCrawdauntGfx46, 0x20
+ax_sprite_terminator
+sCrawdauntGfx47:
+.incbin "baserom.gba", 0x13F95B8, 0x40
+sCrawdauntSprites47:
+ax_sprite sCrawdauntGfx47, 0x40
+ax_sprite_terminator
+sCrawdauntGfx48:
+.incbin "baserom.gba", 0x13F9608, 0x80
+sCrawdauntSprites48:
+ax_sprite sCrawdauntGfx48, 0x80
+ax_sprite_terminator
+sCrawdauntGfx49:
+.incbin "baserom.gba", 0x13F9698, 0xE0
+sCrawdauntSprites49:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx49, 0xe0
+ax_sprite_terminator
+sCrawdauntGfx50:
+.incbin "baserom.gba", 0x13F9790, 0x20
+sCrawdauntSprites50:
+ax_sprite sCrawdauntGfx50, 0x20
+ax_sprite_terminator
+sCrawdauntGfx51:
+.incbin "baserom.gba", 0x13F97C0, 0x40
+sCrawdauntSprites51:
+ax_sprite sCrawdauntGfx51, 0x40
+ax_sprite_terminator
+sCrawdauntGfx52:
+.incbin "baserom.gba", 0x13F9810, 0x40
+sCrawdauntGfx52_1:
+.incbin "baserom.gba", 0x13F9850, 0x100
+sCrawdauntGfx52_2:
+.incbin "baserom.gba", 0x13F9950, 0x60
+sCrawdauntSprites52:
+ax_sprite sCrawdauntGfx52, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCrawdauntGfx52_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx52_2, 0x60
+ax_sprite_terminator
+sCrawdauntGfx53:
+.incbin "baserom.gba", 0x13F99E0, 0x160
+sCrawdauntGfx53_1:
+.incbin "baserom.gba", 0x13F9B40, 0x60
+sCrawdauntSprites53:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx53, 0x160
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx53_1, 0x60
+ax_sprite_terminator
+sCrawdauntGfx54:
+.incbin "baserom.gba", 0x13F9BC8, 0x40
+sCrawdauntGfx54_1:
+.incbin "baserom.gba", 0x13F9C08, 0x180
+sCrawdauntSprites54:
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx54, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCrawdauntGfx54_1, 0x180
+ax_sprite_terminator
+sCrawdauntGfx55:
+.incbin "baserom.gba", 0x13F9DB0, 0x200
+sCrawdauntSprites55:
+ax_sprite sCrawdauntGfx55, 0x200
+ax_sprite_terminator
+sCrawdauntGfx56:
+.incbin "baserom.gba", 0x13F9FC0, 0x200
+sCrawdauntSprites56:
+ax_sprite sCrawdauntGfx56, 0x200
+ax_sprite_terminator
+sCrawdauntGfx57:
+.incbin "baserom.gba", 0x13FA1D0, 0x200
+sCrawdauntSprites57:
+ax_sprite sCrawdauntGfx57, 0x200
+ax_sprite_terminator
+sCrawdauntGfx58:
+.incbin "baserom.gba", 0x13FA3E0, 0x200
+sCrawdauntSprites58:
+ax_sprite sCrawdauntGfx58, 0x200
+ax_sprite_terminator
+sCrawdauntGfx59:
+.incbin "baserom.gba", 0x13FA5F0, 0x200
+sCrawdauntSprites59:
+ax_sprite sCrawdauntGfx59, 0x200
+ax_sprite_terminator
+sCrawdauntGfx60:
+.incbin "baserom.gba", 0x13FA800, 0x200
+sCrawdauntSprites60:
+ax_sprite sCrawdauntGfx60, 0x200
+ax_sprite_terminator
+sCrawdauntGfx61:
+.incbin "baserom.gba", 0x13FAA10, 0x200
+sCrawdauntSprites61:
+ax_sprite sCrawdauntGfx61, 0x200
+ax_sprite_terminator
+sAxPosesCrawdaunt:
+.4byte sCrawdauntPose1
+.4byte sCrawdauntPose2
+.4byte sCrawdauntPose3
+.4byte sCrawdauntPose4
+.4byte sCrawdauntPose5
+.4byte sCrawdauntPose6
+.4byte sCrawdauntPose7
+.4byte sCrawdauntPose8
+.4byte sCrawdauntPose9
+.4byte sCrawdauntPose10
+.4byte sCrawdauntPose11
+.4byte sCrawdauntPose12
+.4byte sCrawdauntPose13
+.4byte sCrawdauntPose14
+.4byte sCrawdauntPose15
+.4byte sCrawdauntPose16
+.4byte sCrawdauntPose17
+.4byte sCrawdauntPose18
+.4byte sCrawdauntPose19
+.4byte sCrawdauntPose20
+.4byte sCrawdauntPose21
+.4byte sCrawdauntPose22
+.4byte sCrawdauntPose23
+.4byte sCrawdauntPose24
+.4byte sCrawdauntPose25
+.4byte sCrawdauntPose26
+.4byte sCrawdauntPose27
+.4byte sCrawdauntPose28
+.4byte sCrawdauntPose29
+.4byte sCrawdauntPose30
+.4byte sCrawdauntPose31
+.4byte sCrawdauntPose32
+.4byte sCrawdauntPose33
+.4byte sCrawdauntPose34
+.4byte sCrawdauntPose35
+.4byte sCrawdauntPose36
+.4byte sCrawdauntPose37
+.4byte sCrawdauntPose38
+.4byte sCrawdauntPose39
+.4byte sCrawdauntPose40
+.4byte sCrawdauntPose41
+.4byte sCrawdauntPose42
+.4byte sCrawdauntPose43
+.4byte sCrawdauntPose44
+.4byte sCrawdauntPose45
+.4byte sCrawdauntPose46
+.4byte sCrawdauntPose47
+.4byte sCrawdauntPose48
+.4byte sCrawdauntPose49
+.4byte sCrawdauntPose50
+.4byte sCrawdauntPose51
+.4byte sCrawdauntPose52
+.4byte sCrawdauntPose53
+.4byte sCrawdauntPose54
+.4byte sCrawdauntPose55
+.4byte sCrawdauntPose56
+.4byte sCrawdauntPose57
+.4byte sCrawdauntPose58
+.4byte sCrawdauntPose59
+.4byte sCrawdauntPose60
+.4byte sCrawdauntPose61
+.4byte sCrawdauntPose62
+.4byte sCrawdauntPose63
+.4byte sCrawdauntPose64
+.4byte sCrawdauntPose65
+.4byte sCrawdauntPose66
+.4byte sCrawdauntPose67
+.4byte sCrawdauntPose68
+.4byte sCrawdauntPose69
+.4byte sCrawdauntPose70
+.4byte sCrawdauntPose71
+.4byte sCrawdauntPose72
+.4byte sCrawdauntPose73
+.4byte sCrawdauntPose74
+.4byte sCrawdauntPose75
+.4byte sCrawdauntPose76
+.4byte sCrawdauntPose77
+.4byte sCrawdauntPose78
+.4byte sCrawdauntPose79
+.4byte sCrawdauntPose80
+.4byte sCrawdauntPose81
+.4byte sCrawdauntPose82
+.4byte sCrawdauntPose83
+.4byte sCrawdauntPose84
+.4byte sCrawdauntPose85
+.4byte sCrawdauntPose86
+.4byte sCrawdauntPose87
+.4byte sCrawdauntPose88
+.4byte sCrawdauntPose89
+.4byte sCrawdauntPose90
+.4byte sCrawdauntPose91
+.4byte sCrawdauntPose92
+.4byte sCrawdauntPose93
+.4byte sCrawdauntPose94
+.4byte sCrawdauntPose95
+.4byte sCrawdauntPose96
+.4byte sCrawdauntPose97
+.4byte sCrawdauntPose98
+.4byte sCrawdauntPose99
+.4byte sCrawdauntPose100
+.4byte sCrawdauntPose101
+.4byte sCrawdauntPose102
+.4byte sCrawdauntPose103
+.4byte sCrawdauntPose104
+.4byte sCrawdauntPose105
+.4byte sCrawdauntPose106
+.4byte sCrawdauntPose107
+.4byte sCrawdauntPose108
+.4byte sCrawdauntPose109
+.4byte sCrawdauntPose110
+.4byte sCrawdauntPose111
+.4byte sCrawdauntPose112
+.4byte sCrawdauntPose113
+.4byte sCrawdauntPose114
+.4byte sCrawdauntPose115
+.4byte sCrawdauntPose116
+.4byte sCrawdauntPose117
+.4byte sCrawdauntPose118
+.4byte sCrawdauntPose119
+.4byte sCrawdauntPose120
+.4byte sCrawdauntPose121
+.4byte sCrawdauntPose122
+.4byte sCrawdauntPose123
+.4byte sCrawdauntPose124
+.4byte sCrawdauntPose125
+.4byte sCrawdauntPose126
+.4byte sCrawdauntPose127
+.4byte sCrawdauntPose128
+.4byte sCrawdauntPose129
+.4byte sCrawdauntPose130
+.4byte sCrawdauntPose131
+.4byte sCrawdauntPose132
+.4byte sCrawdauntPose133
+.4byte sCrawdauntPose134
+.4byte sCrawdauntPose135
+.4byte sCrawdauntPose136
+.4byte sCrawdauntPose137
+.4byte sCrawdauntPose138
+.4byte sCrawdauntPose139
+.4byte sCrawdauntPose140
+.4byte sCrawdauntPose141
+.4byte sCrawdauntPose142
+.4byte sCrawdauntPose143
+.4byte sCrawdauntPose144
+.4byte sCrawdauntPose145
+.4byte sCrawdauntPose146
+.4byte sCrawdauntPose147
+.4byte sCrawdauntPose148
+.4byte sCrawdauntPose149
+.4byte sCrawdauntPose150
+.4byte sCrawdauntPose151
+.4byte sCrawdauntPose152
+.4byte sCrawdauntPose153
+.4byte sCrawdauntPose154
+.4byte sCrawdauntPose155
+.4byte sCrawdauntPose156
+.4byte sCrawdauntPose157
+.4byte sCrawdauntPose158
+.4byte sCrawdauntPose159
+.4byte sCrawdauntPose160
+.4byte sCrawdauntPose161
+.4byte sCrawdauntPose162
+.4byte sCrawdauntPose163
+.4byte sCrawdauntPose164
+.4byte sCrawdauntPose165
+.4byte sCrawdauntPose166
+.4byte sCrawdauntPose167
+.4byte sCrawdauntPose168
+.4byte sCrawdauntPose169
+.4byte sCrawdauntPose170
+.4byte sCrawdauntPose171
+.4byte sCrawdauntPose172
+.4byte sCrawdauntPose173
+.4byte sCrawdauntPose174
+.4byte sCrawdauntPose175
+.4byte sCrawdauntPose176
+.4byte sCrawdauntPose177
+.4byte sCrawdauntPose178
+.4byte sCrawdauntPose179
+.4byte sCrawdauntPose180
+.4byte sCrawdauntPose181
+.4byte sCrawdauntPose182
+.4byte sCrawdauntPose183
+.4byte sCrawdauntPose184
+.4byte sCrawdauntPose185
+.4byte sCrawdauntPose186
+.4byte sCrawdauntPose187
+.4byte sCrawdauntPose188
+.4byte sCrawdauntPose189
+.4byte sCrawdauntPose190
+.4byte sCrawdauntPose191
+.4byte sCrawdauntPose192
+.4byte sCrawdauntPose193
+.4byte sCrawdauntPose194
+.4byte sCrawdauntPose195
+.4byte sCrawdauntPose196
+.4byte sCrawdauntPose197
+.4byte sCrawdauntPose198
+.4byte sCrawdauntPose199
+.4byte sCrawdauntPose200
+.4byte sCrawdauntPose201
+.4byte sCrawdauntPose202
+.4byte sCrawdauntPose203
+.4byte sCrawdauntPose204
+.4byte sCrawdauntPose205
+.4byte sCrawdauntPose206
+.4byte sCrawdauntPose207
+.4byte sCrawdauntPose208
+.4byte sCrawdauntPose209
+.4byte sCrawdauntPose210
+.4byte sCrawdauntPose211
+.4byte sCrawdauntPose212
+.4byte sCrawdauntPose213
+.4byte sCrawdauntPose214
+.4byte sCrawdauntPose215
+.4byte sCrawdauntPose216
+.4byte sCrawdauntPose217
+.4byte sCrawdauntPose218
+.4byte sCrawdauntPose219
+.4byte sCrawdauntPose220
+.4byte sCrawdauntPose221
+.4byte sCrawdauntPose222
+.4byte sCrawdauntPose223
+.4byte sCrawdauntPose224
+.4byte sCrawdauntPose225
+.4byte sCrawdauntPose226
+sAxPositionsCrawdaunt:
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte   -2,   -6, 	  -9,   -3, 	  11,   -6, 	   0,   -4
+.2byte    3,   -6, 	 -10,   -6, 	  10,   -3, 	   0,   -3
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+.2byte    5,   -6, 	   9,   -6, 	  -3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  11,   -8, 	  -7,   -1, 	   1,   -3
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    6,   -7, 	   2,   -8, 	   7,   -4, 	  -1,   -6
+.2byte    7,   -7, 	   9,  -11, 	   4,   -2, 	  -2,   -5
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -11, 	  10,   -9, 	   0,   -7
+.2byte    2,  -10, 	  -3,  -15, 	  10,   -4, 	   0,   -6
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte    0,  -10, 	   9,   -8, 	 -11,  -12, 	  -1,   -7
+.2byte   -2,  -10, 	  10,  -12, 	 -11,   -7, 	  -1,   -6
+.2byte   -2,  -11, 	   4,  -13, 	 -11,   -7, 	   0,   -8
+.2byte   -1,  -10, 	   5,  -11, 	 -10,   -9, 	   0,   -7
+.2byte   -2,  -10, 	   3,  -15, 	 -10,   -4, 	   0,   -6
+.2byte   -7,   -9, 	  -6,  -10, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	  -2,   -8, 	  -7,   -4, 	   1,   -6
+.2byte   -7,   -7, 	  -9,  -11, 	  -4,   -2, 	   2,   -5
+.2byte   -5,   -7, 	  -9,   -9, 	   5,   -3, 	   0,   -5
+.2byte   -5,   -6, 	  -9,   -6, 	   3,   -3, 	   0,   -4
+.2byte   -4,   -5, 	 -11,   -8, 	   7,   -1, 	  -1,   -3
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte   -2,   -6, 	  -9,   -3, 	  11,   -6, 	   0,   -4
+.2byte    3,   -6, 	 -10,   -6, 	  10,   -3, 	   0,   -3
+.2byte    0,   -9, 	  -8,  -12, 	   9,  -12, 	   0,   -6
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -4
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+.2byte    5,   -6, 	   9,   -6, 	  -3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  11,   -8, 	  -7,   -1, 	   1,   -3
+.2byte    3,   -8, 	   7,  -14, 	  -7,   -6, 	   0,   -7
+.2byte    6,   -4, 	  11,   -6, 	  -2,   -1, 	   2,   -5
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    6,   -7, 	   2,   -8, 	   7,   -4, 	  -1,   -6
+.2byte    7,   -7, 	   9,  -11, 	   4,   -2, 	  -2,   -5
+.2byte    3,  -11, 	   3,  -16, 	   3,  -10, 	  -1,   -8
+.2byte    7,   -7, 	  10,  -11, 	   6,   -3, 	   2,   -6
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -11, 	  10,   -9, 	   0,   -7
+.2byte    2,  -10, 	  -3,  -15, 	  10,   -4, 	   0,   -6
+.2byte    0,  -12, 	  -4,  -16, 	   7,  -11, 	  -1,   -9
+.2byte    2,  -10, 	  -1,  -13, 	  10,   -5, 	   0,   -7
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte    0,  -10, 	   9,   -8, 	 -11,  -12, 	  -1,   -7
+.2byte   -2,  -10, 	  10,  -12, 	 -11,   -7, 	  -1,   -6
+.2byte   -1,  -12, 	   9,  -14, 	 -11,  -15, 	  -1,   -7
+.2byte   -1,  -12, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -2,  -11, 	   4,  -13, 	 -11,   -7, 	   0,   -8
+.2byte   -1,  -10, 	   5,  -11, 	 -10,   -9, 	   0,   -7
+.2byte   -2,  -10, 	   3,  -15, 	 -10,   -4, 	   0,   -6
+.2byte    0,  -12, 	   4,  -16, 	  -7,  -11, 	   1,   -9
+.2byte   -2,  -10, 	   1,  -13, 	 -10,   -5, 	   0,   -7
+.2byte   -7,   -9, 	  -6,  -10, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	  -2,   -8, 	  -7,   -4, 	   1,   -6
+.2byte   -7,   -7, 	  -9,  -11, 	  -4,   -2, 	   2,   -5
+.2byte   -3,  -11, 	  -3,  -16, 	  -3,  -10, 	   1,   -8
+.2byte   -7,   -7, 	 -10,  -11, 	  -6,   -3, 	  -2,   -6
+.2byte   -5,   -7, 	  -9,   -9, 	   5,   -3, 	   0,   -5
+.2byte   -5,   -6, 	  -9,   -6, 	   3,   -3, 	   0,   -4
+.2byte   -4,   -5, 	 -11,   -8, 	   7,   -1, 	  -1,   -3
+.2byte   -3,   -8, 	  -7,  -14, 	   7,   -6, 	   0,   -7
+.2byte   -6,   -4, 	 -11,   -6, 	   2,   -1, 	  -2,   -5
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte    0,   -9, 	  -8,  -12, 	   9,  -12, 	   0,   -7
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -4
+.2byte    0,   -3, 	 -10,   -4, 	  10,   -4, 	   0,   -4
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+.2byte    4,   -8, 	   7,  -12, 	  -6,   -6, 	   0,   -6
+.2byte    6,   -4, 	  11,   -6, 	  -2,   -1, 	   2,   -5
+.2byte    6,   -4, 	  12,   -4, 	  -2,    0, 	   0,   -4
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    2,  -10, 	   5,  -13, 	   4,  -10, 	  -2,   -7
+.2byte    7,   -7, 	  10,  -11, 	   6,   -3, 	   2,   -6
+.2byte    9,   -7, 	   9,   -9, 	   8,   -2, 	   2,   -5
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    1,  -12, 	  -5,  -16, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -10, 	  -1,  -13, 	  10,   -5, 	   0,   -7
+.2byte    3,   -9, 	  -2,  -11, 	  11,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   9,  -14, 	 -11,  -15, 	  -1,   -7
+.2byte   -1,  -12, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -11, 	   8,  -10, 	  -9,  -11, 	  -1,   -8
+.2byte   -2,  -11, 	   4,  -13, 	 -11,   -7, 	   0,   -8
+.2byte   -1,  -12, 	   5,  -16, 	  -8,  -10, 	   1,   -9
+.2byte   -2,  -10, 	   1,  -13, 	 -10,   -5, 	   0,   -7
+.2byte   -3,   -9, 	   2,  -11, 	 -11,   -6, 	   1,   -7
+.2byte   -7,   -9, 	  -6,  -10, 	  -6,   -4, 	   0,   -6
+.2byte   -2,  -10, 	  -5,  -13, 	  -4,  -10, 	   2,   -7
+.2byte   -7,   -7, 	 -10,  -11, 	  -6,   -3, 	  -2,   -6
+.2byte   -9,   -7, 	  -9,   -9, 	  -8,   -2, 	  -2,   -5
+.2byte   -5,   -7, 	  -9,   -9, 	   5,   -3, 	   0,   -5
+.2byte   -4,   -8, 	  -7,  -12, 	   6,   -6, 	   0,   -6
+.2byte   -6,   -4, 	 -11,   -6, 	   2,   -1, 	  -2,   -5
+.2byte   -6,   -4, 	 -12,   -4, 	   2,    0, 	   0,   -4
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte    0,  -11, 	  -8,  -14, 	   9,  -14, 	   0,   -8
+.2byte    0,   -3, 	  -8,   -2, 	   8,   -1, 	   0,   -4
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+.2byte    3,   -8, 	   7,  -14, 	  -7,   -6, 	   0,   -7
+.2byte    7,   -4, 	  12,   -5, 	  -1,    0, 	   1,   -5
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    3,  -11, 	   3,  -16, 	   3,  -10, 	  -1,   -8
+.2byte    8,   -7, 	  12,   -9, 	  10,   -2, 	   1,   -6
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    0,  -12, 	  -4,  -16, 	   7,  -11, 	  -1,   -9
+.2byte    5,   -9, 	   1,  -15, 	  14,   -8, 	   2,   -8
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   9,  -14, 	 -11,  -15, 	  -1,   -7
+.2byte   -1,  -12, 	   7,  -14, 	  -9,  -14, 	  -1,   -9
+.2byte   -2,  -11, 	   4,  -13, 	 -11,   -7, 	   0,   -8
+.2byte    0,  -12, 	   4,  -16, 	  -7,  -11, 	   1,   -9
+.2byte   -5,   -9, 	  -1,  -15, 	 -14,   -8, 	  -2,   -8
+.2byte   -7,   -9, 	  -6,  -10, 	  -6,   -4, 	   0,   -6
+.2byte   -3,  -11, 	  -3,  -16, 	  -3,  -10, 	   1,   -8
+.2byte   -8,   -7, 	 -12,   -9, 	 -10,   -2, 	  -1,   -6
+.2byte   -5,   -7, 	  -9,   -9, 	   5,   -3, 	   0,   -5
+.2byte   -3,   -8, 	  -7,  -14, 	   7,   -6, 	   0,   -7
+.2byte   -7,   -4, 	 -12,   -5, 	   1,    0, 	  -1,   -5
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte    0,   -9, 	 -11,   -7, 	  12,   -6, 	   0,   -5
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+.2byte    5,   -8, 	  10,  -11, 	  -7,   -3, 	   1,   -6
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    8,  -11, 	   7,  -13, 	   8,   -4, 	   0,   -8
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    2,  -14, 	  -4,  -17, 	  12,  -10, 	   0,  -10
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte   -1,  -16, 	  11,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte   -2,  -11, 	   4,  -13, 	 -11,   -7, 	   0,   -8
+.2byte   -2,  -14, 	   4,  -17, 	 -12,  -10, 	   0,  -10
+.2byte   -7,   -9, 	  -6,  -10, 	  -6,   -4, 	   0,   -6
+.2byte   -8,  -11, 	  -7,  -13, 	  -8,   -4, 	   0,   -8
+.2byte   -5,   -7, 	  -9,   -9, 	   5,   -3, 	   0,   -5
+.2byte   -5,   -8, 	 -10,  -11, 	   7,   -3, 	  -1,   -6
+.2byte   -4,   -5, 	 -10,   -3, 	   5,    0, 	  -1,   -5
+.2byte   -5,   -4, 	 -11,   -2, 	   5,    1, 	  -1,   -4
+.2byte   -1,  -10, 	 -12,  -17, 	  10,  -15, 	  -1,   -7
+.2byte    3,  -12, 	   5,  -20, 	  -9,  -12, 	   0,   -9
+.2byte    4,  -11, 	   4,  -18, 	  -7,  -11, 	   0,   -9
+.2byte    0,  -14, 	  -7,  -17, 	   4,  -11, 	  -2,   -9
+.2byte   -1,  -12, 	   9,  -15, 	 -11,  -15, 	  -1,   -7
+.2byte   -1,  -14, 	   6,  -17, 	  -5,  -11, 	   1,   -9
+.2byte   -5,  -11, 	  -5,  -18, 	   6,  -11, 	  -1,   -9
+.2byte   -4,  -12, 	  -6,  -20, 	   8,  -12, 	  -1,   -9
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte   -2,   -6, 	  -9,   -3, 	  11,   -6, 	   0,   -4
+.2byte    3,   -6, 	 -10,   -6, 	  10,   -3, 	   0,   -3
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+.2byte    5,   -6, 	   9,   -6, 	  -3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  11,   -8, 	  -7,   -1, 	   1,   -3
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    6,   -7, 	   2,   -8, 	   7,   -4, 	  -1,   -6
+.2byte    7,   -7, 	   9,  -11, 	   4,   -2, 	  -2,   -5
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -11, 	  10,   -9, 	   0,   -7
+.2byte    2,  -10, 	  -3,  -15, 	  10,   -4, 	   0,   -6
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte    0,  -10, 	   9,   -8, 	 -11,  -12, 	  -1,   -7
+.2byte   -2,  -10, 	  10,  -12, 	 -11,   -7, 	  -1,   -6
+.2byte   -2,  -11, 	   4,  -13, 	 -11,   -7, 	   0,   -8
+.2byte   -1,  -10, 	   5,  -11, 	 -10,   -9, 	   0,   -7
+.2byte   -2,  -10, 	   3,  -15, 	 -10,   -4, 	   0,   -6
+.2byte   -7,   -9, 	  -6,  -10, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	  -2,   -8, 	  -7,   -4, 	   1,   -6
+.2byte   -7,   -7, 	  -9,  -11, 	  -4,   -2, 	   2,   -5
+.2byte   -5,   -7, 	  -9,   -9, 	   5,   -3, 	   0,   -5
+.2byte   -5,   -6, 	  -9,   -6, 	   3,   -3, 	   0,   -4
+.2byte   -4,   -5, 	 -11,   -8, 	   7,   -1, 	  -1,   -3
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -4
+.2byte   -5,   -4, 	 -10,   -6, 	   3,   -1, 	  -1,   -5
+.2byte   -6,   -7, 	  -9,  -11, 	  -5,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   2,  -13, 	  -9,   -5, 	   1,   -7
+.2byte   -1,  -11, 	   8,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte    0,  -10, 	  -3,  -13, 	   8,   -5, 	  -2,   -7
+.2byte    5,   -7, 	   8,  -11, 	   4,   -3, 	   0,   -6
+.2byte    4,   -4, 	   9,   -6, 	  -4,   -1, 	   0,   -5
+.2byte    0,   -8, 	  -8,  -11, 	   9,  -11, 	   0,   -5
+.2byte    3,   -8, 	   7,  -14, 	  -7,   -6, 	   0,   -7
+.2byte    4,  -11, 	   4,  -16, 	   4,  -10, 	   0,   -8
+.2byte    0,  -13, 	  -4,  -17, 	   7,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   9,  -15, 	 -11,  -16, 	  -1,   -8
+.2byte   -1,  -13, 	   3,  -17, 	  -8,  -12, 	   0,  -10
+.2byte   -5,  -11, 	  -5,  -16, 	  -5,  -10, 	  -1,   -8
+.2byte   -4,   -8, 	  -8,  -14, 	   6,   -6, 	  -1,   -7
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte    0,   -8, 	  -8,  -11, 	   9,  -11, 	   0,   -5
+.2byte    0,   -5, 	  -8,   -4, 	   8,   -3, 	   0,   -6
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+.2byte    3,   -8, 	   7,  -14, 	  -7,   -6, 	   0,   -7
+.2byte    6,   -4, 	  11,   -5, 	  -2,    0, 	   0,   -5
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    3,  -11, 	   3,  -16, 	   3,  -10, 	  -1,   -8
+.2byte    7,   -7, 	  11,   -9, 	   9,   -2, 	   0,   -6
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    0,  -12, 	  -4,  -16, 	   7,  -11, 	  -1,   -9
+.2byte    4,   -9, 	   0,  -15, 	  13,   -8, 	   1,   -8
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   9,  -14, 	 -11,  -15, 	  -1,   -7
+.2byte   -1,  -11, 	   7,  -13, 	  -9,  -13, 	  -1,   -8
+.2byte   -3,  -11, 	   3,  -13, 	 -12,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	   3,  -16, 	  -8,  -11, 	   0,   -9
+.2byte   -5,   -9, 	  -1,  -15, 	 -14,   -8, 	  -2,   -8
+.2byte   -8,   -9, 	  -7,  -10, 	  -7,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -4,  -16, 	  -4,  -10, 	   0,   -8
+.2byte   -8,   -7, 	 -12,   -9, 	 -10,   -2, 	  -1,   -6
+.2byte   -6,   -7, 	 -10,   -9, 	   4,   -3, 	  -1,   -5
+.2byte   -4,   -8, 	  -8,  -14, 	   6,   -6, 	  -1,   -7
+.2byte   -7,   -4, 	 -12,   -5, 	   1,    0, 	  -1,   -5
+.2byte    0,   -9, 	  -8,  -12, 	   9,  -12, 	   0,   -7
+.2byte   -4,   -8, 	  -7,  -12, 	   6,   -6, 	   0,   -6
+.2byte   -3,  -10, 	  -6,  -13, 	  -5,  -10, 	   1,   -7
+.2byte   -1,  -12, 	   5,  -16, 	  -8,  -10, 	   1,   -9
+.2byte   -1,  -12, 	   9,  -14, 	 -11,  -15, 	  -1,   -7
+.2byte    1,  -12, 	  -5,  -16, 	   8,  -10, 	  -1,   -9
+.2byte    3,  -10, 	   6,  -13, 	   5,  -10, 	  -1,   -7
+.2byte    4,   -8, 	   7,  -12, 	  -6,   -6, 	   0,   -6
+.2byte    0,   -7, 	 -10,   -6, 	  11,   -6, 	   0,   -5
+.2byte   -5,   -7, 	  -9,   -9, 	   5,   -3, 	   0,   -5
+.2byte   -7,   -9, 	  -6,  -10, 	  -6,   -4, 	   0,   -6
+.2byte   -2,  -11, 	   4,  -13, 	 -11,   -7, 	   0,   -8
+.2byte   -1,  -12, 	   9,  -10, 	 -11,  -10, 	  -1,   -9
+.2byte    2,  -11, 	  -4,  -13, 	  11,   -7, 	   0,   -8
+.2byte    7,   -9, 	   6,  -10, 	   6,   -4, 	   0,   -6
+.2byte    5,   -7, 	   9,   -9, 	  -5,   -3, 	   0,   -5
+sCrawdauntAnimTable1:
+.4byte sCrawdauntAnims_1_1
+.4byte sCrawdauntAnims_1_2
+.4byte sCrawdauntAnims_1_3
+.4byte sCrawdauntAnims_1_4
+.4byte sCrawdauntAnims_1_5
+.4byte sCrawdauntAnims_1_6
+.4byte sCrawdauntAnims_1_7
+.4byte sCrawdauntAnims_1_8
+sCrawdauntAnimTable2:
+.4byte sCrawdauntAnims_2_1
+.4byte sCrawdauntAnims_2_2
+.4byte sCrawdauntAnims_2_3
+.4byte sCrawdauntAnims_2_4
+.4byte sCrawdauntAnims_2_5
+.4byte sCrawdauntAnims_2_6
+.4byte sCrawdauntAnims_2_7
+.4byte sCrawdauntAnims_2_8
+sCrawdauntAnimTable3:
+.4byte sCrawdauntAnims_3_1
+.4byte sCrawdauntAnims_3_2
+.4byte sCrawdauntAnims_3_3
+.4byte sCrawdauntAnims_3_4
+.4byte sCrawdauntAnims_3_5
+.4byte sCrawdauntAnims_3_6
+.4byte sCrawdauntAnims_3_7
+.4byte sCrawdauntAnims_3_8
+sCrawdauntAnimTable4:
+.4byte sCrawdauntAnims_4_1
+.4byte sCrawdauntAnims_4_2
+.4byte sCrawdauntAnims_4_3
+.4byte sCrawdauntAnims_4_4
+.4byte sCrawdauntAnims_4_5
+.4byte sCrawdauntAnims_4_6
+.4byte sCrawdauntAnims_4_7
+.4byte sCrawdauntAnims_4_8
+sCrawdauntAnimTable5:
+.4byte sCrawdauntAnims_5_1
+.4byte sCrawdauntAnims_5_2
+.4byte sCrawdauntAnims_5_3
+.4byte sCrawdauntAnims_5_4
+.4byte sCrawdauntAnims_5_5
+.4byte sCrawdauntAnims_5_6
+.4byte sCrawdauntAnims_5_7
+.4byte sCrawdauntAnims_5_8
+sCrawdauntAnimTable6:
+.4byte sCrawdauntAnims_6_1
+.4byte sCrawdauntAnims_6_1
+.4byte sCrawdauntAnims_6_1
+.4byte sCrawdauntAnims_6_1
+.4byte sCrawdauntAnims_6_1
+.4byte sCrawdauntAnims_6_1
+.4byte sCrawdauntAnims_6_1
+.4byte sCrawdauntAnims_6_1
+sCrawdauntAnimTable7:
+.4byte sCrawdauntAnims_7_1
+.4byte sCrawdauntAnims_7_2
+.4byte sCrawdauntAnims_7_3
+.4byte sCrawdauntAnims_7_4
+.4byte sCrawdauntAnims_7_5
+.4byte sCrawdauntAnims_7_6
+.4byte sCrawdauntAnims_7_7
+.4byte sCrawdauntAnims_7_8
+sCrawdauntAnimTable8:
+.4byte sCrawdauntAnims_8_1
+.4byte sCrawdauntAnims_8_2
+.4byte sCrawdauntAnims_8_3
+.4byte sCrawdauntAnims_8_4
+.4byte sCrawdauntAnims_8_5
+.4byte sCrawdauntAnims_8_6
+.4byte sCrawdauntAnims_8_7
+.4byte sCrawdauntAnims_8_8
+sCrawdauntAnimTable9:
+.4byte sCrawdauntAnims_9_1
+.4byte sCrawdauntAnims_9_2
+.4byte sCrawdauntAnims_9_3
+.4byte sCrawdauntAnims_9_4
+.4byte sCrawdauntAnims_9_5
+.4byte sCrawdauntAnims_9_6
+.4byte sCrawdauntAnims_9_7
+.4byte sCrawdauntAnims_9_8
+sCrawdauntAnimTable10:
+.4byte sCrawdauntAnims_10_1
+.4byte sCrawdauntAnims_10_2
+.4byte sCrawdauntAnims_10_3
+.4byte sCrawdauntAnims_10_4
+.4byte sCrawdauntAnims_10_5
+.4byte sCrawdauntAnims_10_6
+.4byte sCrawdauntAnims_10_7
+.4byte sCrawdauntAnims_10_8
+sCrawdauntAnimTable11:
+.4byte sCrawdauntAnims_11_1
+.4byte sCrawdauntAnims_11_2
+.4byte sCrawdauntAnims_11_3
+.4byte sCrawdauntAnims_11_4
+.4byte sCrawdauntAnims_11_5
+.4byte sCrawdauntAnims_11_6
+.4byte sCrawdauntAnims_11_7
+.4byte sCrawdauntAnims_11_8
+sCrawdauntAnimTable12:
+.4byte sCrawdauntAnims_12_1
+.4byte sCrawdauntAnims_12_2
+.4byte sCrawdauntAnims_12_3
+.4byte sCrawdauntAnims_12_4
+.4byte sCrawdauntAnims_12_5
+.4byte sCrawdauntAnims_12_6
+.4byte sCrawdauntAnims_12_7
+.4byte sCrawdauntAnims_12_8
+sCrawdauntAnimTable13:
+.4byte sCrawdauntAnims_13_1
+.4byte sCrawdauntAnims_13_2
+.4byte sCrawdauntAnims_13_3
+.4byte sCrawdauntAnims_13_4
+.4byte sCrawdauntAnims_13_5
+.4byte sCrawdauntAnims_13_6
+.4byte sCrawdauntAnims_13_7
+.4byte sCrawdauntAnims_13_8
+sAxAnimationsCrawdaunt:
+.4byte sCrawdauntAnimTable1
+.4byte sCrawdauntAnimTable2
+.4byte sCrawdauntAnimTable3
+.4byte sCrawdauntAnimTable4
+.4byte sCrawdauntAnimTable5
+.4byte sCrawdauntAnimTable6
+.4byte sCrawdauntAnimTable7
+.4byte sCrawdauntAnimTable8
+.4byte sCrawdauntAnimTable9
+.4byte sCrawdauntAnimTable10
+.4byte sCrawdauntAnimTable11
+.4byte sCrawdauntAnimTable12
+.4byte sCrawdauntAnimTable13
+sAxSpritesCrawdaunt:
+.4byte sCrawdauntSprites1
+.4byte sCrawdauntSprites2
+.4byte sCrawdauntSprites3
+.4byte sCrawdauntSprites4
+.4byte sCrawdauntSprites5
+.4byte sCrawdauntSprites6
+.4byte sCrawdauntSprites7
+.4byte sCrawdauntSprites8
+.4byte sCrawdauntSprites9
+.4byte sCrawdauntSprites10
+.4byte sCrawdauntSprites11
+.4byte sCrawdauntSprites12
+.4byte sCrawdauntSprites13
+.4byte sCrawdauntSprites14
+.4byte sCrawdauntSprites15
+.4byte sCrawdauntSprites16
+.4byte sCrawdauntSprites17
+.4byte sCrawdauntSprites18
+.4byte sCrawdauntSprites19
+.4byte sCrawdauntSprites20
+.4byte sCrawdauntSprites21
+.4byte sCrawdauntSprites22
+.4byte sCrawdauntSprites23
+.4byte sCrawdauntSprites24
+.4byte sCrawdauntSprites25
+.4byte sCrawdauntSprites26
+.4byte sCrawdauntSprites27
+.4byte sCrawdauntSprites28
+.4byte sCrawdauntSprites29
+.4byte sCrawdauntSprites30
+.4byte sCrawdauntSprites31
+.4byte sCrawdauntSprites32
+.4byte sCrawdauntSprites33
+.4byte sCrawdauntSprites34
+.4byte sCrawdauntSprites35
+.4byte sCrawdauntSprites36
+.4byte sCrawdauntSprites37
+.4byte sCrawdauntSprites38
+.4byte sCrawdauntSprites39
+.4byte sCrawdauntSprites40
+.4byte sCrawdauntSprites41
+.4byte sCrawdauntSprites42
+.4byte sCrawdauntSprites43
+.4byte sCrawdauntSprites44
+.4byte sCrawdauntSprites45
+.4byte sCrawdauntSprites46
+.4byte sCrawdauntSprites47
+.4byte sCrawdauntSprites48
+.4byte sCrawdauntSprites49
+.4byte sCrawdauntSprites50
+.4byte sCrawdauntSprites51
+.4byte sCrawdauntSprites52
+.4byte sCrawdauntSprites53
+.4byte sCrawdauntSprites54
+.4byte sCrawdauntSprites55
+.4byte sCrawdauntSprites56
+.4byte sCrawdauntSprites57
+.4byte sCrawdauntSprites58
+.4byte sCrawdauntSprites59
+.4byte sCrawdauntSprites60
+.4byte sCrawdauntSprites61
+sAxMainCrawdaunt:
+ax_main sAxPosesCrawdaunt, sAxAnimationsCrawdaunt, 13, sAxSpritesCrawdaunt, sAxPositionsCrawdaunt

--- a/data/ax/crobat.inc
+++ b/data/ax/crobat.inc
@@ -1,0 +1,2641 @@
+.global gAxCrobat
+gAxCrobat:
+ax_siro sAxMainCrobat
+sCrobatPose1:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose2:
+ax_pose 1, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose4:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose5:
+ax_pose 4, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose6:
+ax_pose 5, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose7:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose8:
+ax_pose 7, 0x01e1, 0x90e6, 0x7c00
+ax_pose_terminator
+sCrobatPose9:
+ax_pose 8, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose10:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose11:
+ax_pose 10, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose12:
+ax_pose 11, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose15:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose16:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose17:
+ax_pose 10, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose18:
+ax_pose 11, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose19:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose20:
+ax_pose 7, 0x01e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose21:
+ax_pose 8, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose22:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose23:
+ax_pose 4, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose24:
+ax_pose 5, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose25:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose26:
+ax_pose 1, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose28:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose29:
+ax_pose 4, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose30:
+ax_pose 5, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose31:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose32:
+ax_pose 7, 0x01e1, 0x90e6, 0x7c00
+ax_pose_terminator
+sCrobatPose33:
+ax_pose 8, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose34:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose35:
+ax_pose 10, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose36:
+ax_pose 11, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose37:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose39:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose40:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose41:
+ax_pose 10, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose42:
+ax_pose 11, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose43:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose44:
+ax_pose 7, 0x01e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose45:
+ax_pose 8, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose46:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose47:
+ax_pose 4, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose48:
+ax_pose 5, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose49:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose50:
+ax_pose 1, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose51:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose52:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose53:
+ax_pose 4, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose54:
+ax_pose 5, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose55:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose56:
+ax_pose 7, 0x01e1, 0x90e6, 0x7c00
+ax_pose_terminator
+sCrobatPose57:
+ax_pose 8, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose58:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose59:
+ax_pose 10, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose60:
+ax_pose 11, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose61:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose62:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose63:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose64:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose65:
+ax_pose 10, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose66:
+ax_pose 11, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose67:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose68:
+ax_pose 7, 0x01e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose69:
+ax_pose 8, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose70:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose71:
+ax_pose 4, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose72:
+ax_pose 5, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose73:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose74:
+ax_pose 1, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose75:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose76:
+ax_pose 15, 0x41eb, 0x80f7, 0x7c00
+ax_pose_terminator
+sCrobatPose77:
+ax_pose 16, 0x01e1, 0x00f0, 0x7c00
+ax_pose 17, 0x01e1, 0x0108, 0x7c01
+ax_pose 18, 0x41e9, 0x80f0, 0x7c02
+ax_pose 19, 0x01e9, 0x00e8, 0x7c0a
+ax_pose 20, 0x01e9, 0x0110, 0x7c0b
+ax_pose_terminator
+sCrobatPose78:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose79:
+ax_pose 4, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose80:
+ax_pose 5, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose81:
+ax_pose 21, 0x81e2, 0x90f8, 0x7c00
+ax_pose_terminator
+sCrobatPose82:
+ax_pose 22, 0x01e0, 0x90e9, 0x7c00
+ax_pose_terminator
+sCrobatPose83:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose84:
+ax_pose 7, 0x01e1, 0x90e6, 0x7c00
+ax_pose_terminator
+sCrobatPose85:
+ax_pose 8, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose86:
+ax_pose 23, 0x81df, 0x90f9, 0x7c00
+ax_pose_terminator
+sCrobatPose87:
+ax_pose 24, 0x81e1, 0x90f5, 0x7c00
+ax_pose 25, 0x01f1, 0x10ed, 0x7c08
+ax_pose_terminator
+sCrobatPose88:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose89:
+ax_pose 10, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose90:
+ax_pose 11, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose91:
+ax_pose 26, 0x81e1, 0x90f9, 0x7c00
+ax_pose_terminator
+sCrobatPose92:
+ax_pose 27, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sCrobatPose93:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose94:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose95:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose96:
+ax_pose 28, 0x81e0, 0x80f8, 0x7c00
+ax_pose_terminator
+sCrobatPose97:
+ax_pose 29, 0x41e5, 0x80f0, 0x7c00
+ax_pose 30, 0x41f5, 0x40f0, 0x7c08
+ax_pose 31, 0x01eb, 0x00e8, 0x7c0c
+ax_pose 32, 0x01eb, 0x0110, 0x7c0d
+ax_pose_terminator
+sCrobatPose98:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose99:
+ax_pose 10, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose100:
+ax_pose 11, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose101:
+ax_pose 26, 0x81e1, 0x80f7, 0x7c00
+ax_pose_terminator
+sCrobatPose102:
+ax_pose 27, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sCrobatPose103:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose104:
+ax_pose 7, 0x01e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose105:
+ax_pose 8, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose106:
+ax_pose 23, 0x81df, 0x80f7, 0x7c00
+ax_pose_terminator
+sCrobatPose107:
+ax_pose 24, 0x81e1, 0x80fb, 0x7c00
+ax_pose 25, 0x01f1, 0x010b, 0x7c08
+ax_pose_terminator
+sCrobatPose108:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose109:
+ax_pose 4, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose110:
+ax_pose 5, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose111:
+ax_pose 21, 0x81e2, 0x80f8, 0x7c00
+ax_pose_terminator
+sCrobatPose112:
+ax_pose 22, 0x01e0, 0x80f7, 0x7c00
+ax_pose_terminator
+sCrobatPose113:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose114:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose115:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose116:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose117:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose118:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose119:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose120:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose121:
+ax_pose 33, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sCrobatPose122:
+ax_pose 34, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sCrobatPose123:
+ax_pose 35, 0x01dd, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose124:
+ax_pose 36, 0x01dd, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose125:
+ax_pose 37, 0x01dd, 0x90ed, 0x7c00
+ax_pose_terminator
+sCrobatPose126:
+ax_pose 38, 0x01df, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose127:
+ax_pose 39, 0x01de, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose128:
+ax_pose 38, 0x01df, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose129:
+ax_pose 37, 0x01dd, 0x80f3, 0x7c00
+ax_pose_terminator
+sCrobatPose130:
+ax_pose 36, 0x01dd, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose131:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose132:
+ax_pose 1, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose133:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose134:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose135:
+ax_pose 4, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose136:
+ax_pose 5, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose137:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose138:
+ax_pose 7, 0x01e1, 0x90e6, 0x7c00
+ax_pose_terminator
+sCrobatPose139:
+ax_pose 8, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose140:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose141:
+ax_pose 10, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose142:
+ax_pose 11, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose143:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose144:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose145:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose146:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose147:
+ax_pose 10, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose148:
+ax_pose 11, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose149:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose150:
+ax_pose 7, 0x01e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose151:
+ax_pose 8, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose152:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose153:
+ax_pose 4, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose154:
+ax_pose 5, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose155:
+ax_pose 16, 0x01e1, 0x00f0, 0x7c00
+ax_pose 17, 0x01e1, 0x0108, 0x7c01
+ax_pose 18, 0x41e9, 0x80f0, 0x7c02
+ax_pose 19, 0x01e9, 0x00e8, 0x7c0a
+ax_pose 20, 0x01e9, 0x0110, 0x7c0b
+ax_pose_terminator
+sCrobatPose156:
+ax_pose 22, 0x01e0, 0x80f7, 0x7c00
+ax_pose_terminator
+sCrobatPose157:
+ax_pose 24, 0x81e1, 0x80fb, 0x7c00
+ax_pose 25, 0x01f1, 0x010b, 0x7c08
+ax_pose_terminator
+sCrobatPose158:
+ax_pose 27, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sCrobatPose159:
+ax_pose 29, 0x41e6, 0x80f0, 0x7c00
+ax_pose 30, 0x41f6, 0x40f0, 0x7c08
+ax_pose 31, 0x01ec, 0x00e8, 0x7c0c
+ax_pose 32, 0x01ec, 0x0110, 0x7c0d
+ax_pose_terminator
+sCrobatPose160:
+ax_pose 27, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sCrobatPose161:
+ax_pose 24, 0x81e1, 0x90f5, 0x7c00
+ax_pose 25, 0x01f1, 0x10ed, 0x7c08
+ax_pose_terminator
+sCrobatPose162:
+ax_pose 22, 0x01e0, 0x90e9, 0x7c00
+ax_pose_terminator
+sCrobatPose163:
+ax_pose 16, 0x01e1, 0x00f0, 0x7c00
+ax_pose 17, 0x01e1, 0x0108, 0x7c01
+ax_pose 18, 0x41e9, 0x80f0, 0x7c02
+ax_pose 19, 0x01e9, 0x00e8, 0x7c0a
+ax_pose 20, 0x01e9, 0x0110, 0x7c0b
+ax_pose_terminator
+sCrobatPose164:
+ax_pose 22, 0x01e0, 0x90ea, 0x7c00
+ax_pose_terminator
+sCrobatPose165:
+ax_pose 24, 0x81e1, 0x90f6, 0x7c00
+ax_pose 25, 0x01f1, 0x10ee, 0x7c08
+ax_pose_terminator
+sCrobatPose166:
+ax_pose 27, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose167:
+ax_pose 29, 0x41e5, 0x80f0, 0x7c00
+ax_pose 30, 0x41f5, 0x40f0, 0x7c08
+ax_pose 31, 0x01eb, 0x00e8, 0x7c0c
+ax_pose 32, 0x01eb, 0x0110, 0x7c0d
+ax_pose_terminator
+sCrobatPose168:
+ax_pose 27, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose169:
+ax_pose 24, 0x81e1, 0x80f9, 0x7c00
+ax_pose 25, 0x01f1, 0x0109, 0x7c08
+ax_pose_terminator
+sCrobatPose170:
+ax_pose 22, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sCrobatPose171:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose172:
+ax_pose 1, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose173:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose174:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose175:
+ax_pose 4, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose176:
+ax_pose 5, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose177:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose178:
+ax_pose 7, 0x01e1, 0x90e6, 0x7c00
+ax_pose_terminator
+sCrobatPose179:
+ax_pose 8, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose180:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose181:
+ax_pose 10, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose182:
+ax_pose 11, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose183:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose184:
+ax_pose 13, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose185:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose186:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose187:
+ax_pose 10, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose188:
+ax_pose 11, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose189:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose190:
+ax_pose 7, 0x01e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose191:
+ax_pose 8, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose192:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose193:
+ax_pose 4, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose194:
+ax_pose 5, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose195:
+ax_pose 1, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose196:
+ax_pose 4, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose197:
+ax_pose 7, 0x01e1, 0x80f9, 0x7c00
+ax_pose_terminator
+sCrobatPose198:
+ax_pose 10, 0x01e1, 0x80ef, 0x7c00
+ax_pose_terminator
+sCrobatPose199:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose200:
+ax_pose 10, 0x01e1, 0x90f1, 0x7c00
+ax_pose_terminator
+sCrobatPose201:
+ax_pose 7, 0x01e1, 0x90e7, 0x7c00
+ax_pose_terminator
+sCrobatPose202:
+ax_pose 4, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sCrobatPose203:
+ax_pose 0, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose204:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sCrobatPose205:
+ax_pose 6, 0x81e1, 0x80fa, 0x7c00
+ax_pose_terminator
+sCrobatPose206:
+ax_pose 9, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose207:
+ax_pose 12, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sCrobatPose208:
+ax_pose 9, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sCrobatPose209:
+ax_pose 6, 0x81e1, 0x90f6, 0x7c00
+ax_pose_terminator
+sCrobatPose210:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+.align 2
+sCrobatAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 0, -1, 0, -1, 0,
+ax_anim 6, 0, 2, -1, 1, -1, 0,
+ax_anim 6, 0, 0, 0, 2, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 0, 1, 0, 1, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sCrobatAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 1,
+ax_anim 6, 0, 3, -2, 0, -2, 0,
+ax_anim 6, 0, 5, -2, 1, -2, 1,
+ax_anim 6, 0, 3, -1, 3, -1, 1,
+ax_anim 6, 0, 4, -2, 1, -2, 1,
+ax_anim 6, 0, 3, -1, 0, -1, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 1,
+ax_anim_terminator
+sCrobatAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -1, 1, -1, 0,
+ax_anim 6, 0, 6, -2, 0, -2, 0,
+ax_anim 6, 0, 8, -2, 1, -2, 0,
+ax_anim 6, 0, 6, -1, 2, -1, 0,
+ax_anim 6, 0, 7, 0, 3, 0, 0,
+ax_anim 6, 0, 6, 0, 1, 0, 0,
+ax_anim 6, 0, 8, -1, 2, -1, 0,
+ax_anim_terminator
+sCrobatAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 1,
+ax_anim 6, 0, 9, -2, 2, -2, 1,
+ax_anim 6, 0, 11, -2, 1, -2, 1,
+ax_anim 6, 0, 9, -1, 3, -1, 1,
+ax_anim 6, 0, 10, -2, 2, -2, 1,
+ax_anim 6, 0, 9, -1, 0, -1, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 1,
+ax_anim_terminator
+sCrobatAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 12, -1, 0, -1, 0,
+ax_anim 6, 0, 14, -1, 1, -1, 0,
+ax_anim 6, 0, 12, 0, 2, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 12, 1, 0, 1, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sCrobatAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 1,
+ax_anim 6, 0, 15, 2, 2, 2, 1,
+ax_anim 6, 0, 17, 2, 1, 2, 1,
+ax_anim 6, 0, 15, 1, 3, 1, 1,
+ax_anim 6, 0, 16, 2, 2, 2, 1,
+ax_anim 6, 0, 15, 1, 0, 1, 0,
+ax_anim 6, 0, 17, 0, 1, 0, 1,
+ax_anim_terminator
+sCrobatAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 1, 1, 1, 0,
+ax_anim 6, 0, 18, 2, 0, 2, 0,
+ax_anim 6, 0, 20, 2, 1, 2, 0,
+ax_anim 6, 0, 18, 1, 2, 1, 0,
+ax_anim 6, 0, 19, 0, 3, 0, 0,
+ax_anim 6, 0, 18, -1, 1, -1, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sCrobatAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 1,
+ax_anim 6, 0, 21, 2, 0, 2, 0,
+ax_anim 6, 0, 23, 2, 1, 2, 1,
+ax_anim 6, 0, 21, 1, 3, 1, 1,
+ax_anim 6, 0, 22, 2, 1, 2, 1,
+ax_anim 6, 0, 21, 1, 0, 1, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 1,
+ax_anim_terminator
+.align 2
+sCrobatAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 8,
+ax_anim 2, 2, 25, 0, 20, 0, 16,
+ax_anim 2, 0, 28, 0, 29, 0, 20,
+ax_anim 1, 1, 25, 0, 29, 1, 20,
+ax_anim 2, 0, 46, 0, 29, 0, 20,
+ax_anim 1, 0, 25, 0, 29, 1, 20,
+ax_anim 2, 0, 28, 0, 29, 0, 20,
+ax_anim 1, 0, 25, 0, 29, 1, 20,
+ax_anim 2, 0, 24, 0, 14, 0, 14,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sCrobatAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 12, 10, 10,
+ax_anim 2, 2, 28, 15, 18, 15, 15,
+ax_anim 2, 0, 31, 23, 28, 23, 21,
+ax_anim 1, 1, 28, 23, 28, 23, 21,
+ax_anim 2, 0, 25, 23, 28, 23, 21,
+ax_anim 1, 0, 31, 23, 28, 23, 21,
+ax_anim 2, 0, 25, 23, 28, 23, 21,
+ax_anim 1, 0, 28, 23, 28, 23, 21,
+ax_anim 2, 0, 27, 14, 17, 14, 14,
+ax_anim 2, 0, 27, 4, 4, 4, 4,
+ax_anim_terminator
+sCrobatAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 2, 10, 0,
+ax_anim 2, 2, 31, 15, 4, 15, 0,
+ax_anim 2, 0, 34, 23, 7, 23, 0,
+ax_anim 1, 1, 31, 23, 7, 23, 0,
+ax_anim 2, 0, 28, 23, 7, 23, 0,
+ax_anim 1, 0, 31, 23, 7, 23, 0,
+ax_anim 2, 0, 34, 23, 7, 23, 0,
+ax_anim 1, 0, 31, 23, 7, 23, 0,
+ax_anim 2, 0, 30, 14, 3, 14, 0,
+ax_anim 2, 0, 30, 4, 1, 4, 0,
+ax_anim_terminator
+sCrobatAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 4, -3, 4, -4,
+ax_anim 1, 0, 34, 10, -6, 10, -10,
+ax_anim 2, 2, 34, 15, -10, 15, -15,
+ax_anim 2, 0, 37, 23, -15, 23, -22,
+ax_anim 1, 1, 34, 23, -15, 23, -22,
+ax_anim 2, 0, 31, 23, -15, 23, -22,
+ax_anim 1, 0, 37, 23, -15, 23, -22,
+ax_anim 2, 0, 31, 23, -15, 23, -22,
+ax_anim 1, 0, 34, 23, -15, 23, -22,
+ax_anim 2, 0, 33, 14, -12, 14, -15,
+ax_anim 2, 0, 33, 4, -3, 4, -4,
+ax_anim_terminator
+sCrobatAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, -2, 0, -3,
+ax_anim 1, 0, 37, 0, -7, 0, -10,
+ax_anim 2, 2, 37, 0, -12, 0, -16,
+ax_anim 2, 0, 40, 0, -16, 0, -22,
+ax_anim 1, 1, 37, 0, -16, 0, -22,
+ax_anim 2, 0, 34, 0, -16, 0, -22,
+ax_anim 1, 0, 37, 0, -16, 0, -22,
+ax_anim 2, 0, 40, 0, -16, 0, -22,
+ax_anim 1, 0, 37, 0, -16, 0, -22,
+ax_anim 2, 0, 36, 0, -8, 0, -12,
+ax_anim 2, 0, 36, 0, -3, 0, -4,
+ax_anim_terminator
+sCrobatAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 40, -4, -3, -4, -4,
+ax_anim 1, 0, 40, -10, -6, -10, -10,
+ax_anim 2, 2, 40, -15, -10, -15, -15,
+ax_anim 2, 0, 43, -23, -15, -23, -22,
+ax_anim 1, 1, 40, -23, -15, -23, -22,
+ax_anim 2, 0, 37, -23, -15, -23, -22,
+ax_anim 1, 0, 40, -23, -15, -23, -22,
+ax_anim 2, 0, 43, -23, -15, -23, -22,
+ax_anim 1, 0, 40, -23, -15, -23, -22,
+ax_anim 2, 0, 39, -14, -12, -14, -15,
+ax_anim 2, 0, 39, -4, -3, -4, -4,
+ax_anim_terminator
+sCrobatAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 2, -10, 0,
+ax_anim 2, 2, 43, -15, 4, -15, 0,
+ax_anim 2, 0, 46, -23, 7, -23, 0,
+ax_anim 1, 1, 43, -23, 7, -23, 0,
+ax_anim 2, 0, 40, -23, 7, -23, 0,
+ax_anim 1, 0, 43, -23, 7, -23, 0,
+ax_anim 2, 0, 46, -23, 7, -23, 0,
+ax_anim 1, 0, 43, -23, 7, -23, 0,
+ax_anim 2, 0, 42, -14, 3, -14, 0,
+ax_anim 2, 0, 42, -4, 1, -4, 0,
+ax_anim_terminator
+sCrobatAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 12, -10, 10,
+ax_anim 2, 2, 46, -15, 18, -15, 15,
+ax_anim 2, 0, 25, -23, 28, -23, 21,
+ax_anim 1, 1, 46, -23, 28, -23, 21,
+ax_anim 2, 0, 43, -23, 28, -23, 21,
+ax_anim 1, 0, 46, -23, 28, -23, 21,
+ax_anim 2, 0, 25, -23, 28, -23, 21,
+ax_anim 1, 0, 46, -23, 28, -23, 21,
+ax_anim 2, 0, 45, -14, 17, -14, 14,
+ax_anim 2, 0, 45, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sCrobatAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 8,
+ax_anim 2, 2, 49, 0, 20, 0, 16,
+ax_anim 2, 0, 52, 0, 29, 0, 20,
+ax_anim 1, 1, 49, 0, 29, 1, 20,
+ax_anim 2, 0, 70, 0, 29, 0, 20,
+ax_anim 1, 0, 49, 0, 29, 1, 20,
+ax_anim 2, 0, 52, 0, 29, 0, 20,
+ax_anim 1, 0, 49, 0, 29, 1, 20,
+ax_anim 2, 0, 48, 0, 14, 0, 14,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sCrobatAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 12, 10, 10,
+ax_anim 2, 2, 52, 15, 18, 15, 15,
+ax_anim 2, 0, 55, 23, 28, 23, 21,
+ax_anim 1, 1, 52, 23, 28, 23, 21,
+ax_anim 2, 0, 49, 23, 28, 23, 21,
+ax_anim 1, 0, 55, 23, 28, 23, 21,
+ax_anim 2, 0, 49, 23, 28, 23, 21,
+ax_anim 1, 0, 52, 23, 28, 23, 21,
+ax_anim 2, 0, 51, 14, 17, 14, 14,
+ax_anim 2, 0, 51, 4, 4, 4, 4,
+ax_anim_terminator
+sCrobatAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 2, 10, 0,
+ax_anim 2, 2, 55, 15, 4, 15, 0,
+ax_anim 2, 0, 58, 23, 7, 23, 0,
+ax_anim 1, 1, 55, 23, 7, 23, 0,
+ax_anim 2, 0, 52, 23, 7, 23, 0,
+ax_anim 1, 0, 55, 23, 7, 23, 0,
+ax_anim 2, 0, 58, 23, 7, 23, 0,
+ax_anim 1, 0, 55, 23, 7, 23, 0,
+ax_anim 2, 0, 54, 14, 3, 14, 0,
+ax_anim 2, 0, 54, 4, 1, 4, 0,
+ax_anim_terminator
+sCrobatAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 4, -3, 4, -4,
+ax_anim 1, 0, 58, 10, -6, 10, -10,
+ax_anim 2, 2, 58, 15, -10, 15, -15,
+ax_anim 2, 0, 61, 23, -15, 23, -22,
+ax_anim 1, 1, 58, 23, -15, 23, -22,
+ax_anim 2, 0, 55, 23, -15, 23, -22,
+ax_anim 1, 0, 61, 23, -15, 23, -22,
+ax_anim 2, 0, 55, 23, -15, 23, -22,
+ax_anim 1, 0, 58, 23, -15, 23, -22,
+ax_anim 2, 0, 57, 14, -12, 14, -15,
+ax_anim 2, 0, 57, 4, -3, 4, -4,
+ax_anim_terminator
+sCrobatAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 0, -2, 0, -3,
+ax_anim 1, 0, 61, 0, -7, 0, -10,
+ax_anim 2, 2, 61, 0, -12, 0, -16,
+ax_anim 2, 0, 64, 0, -16, 0, -22,
+ax_anim 1, 1, 61, 0, -16, 0, -22,
+ax_anim 2, 0, 58, 0, -16, 0, -22,
+ax_anim 1, 0, 61, 0, -16, 0, -22,
+ax_anim 2, 0, 64, 0, -16, 0, -22,
+ax_anim 1, 0, 61, 0, -16, 0, -22,
+ax_anim 2, 0, 60, 0, -8, 0, -12,
+ax_anim 2, 0, 60, 0, -3, 0, -4,
+ax_anim_terminator
+sCrobatAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -4, -3, -4, -4,
+ax_anim 1, 0, 64, -10, -6, -10, -10,
+ax_anim 2, 2, 64, -15, -10, -15, -15,
+ax_anim 2, 0, 67, -23, -15, -23, -22,
+ax_anim 1, 1, 64, -23, -15, -23, -22,
+ax_anim 2, 0, 61, -23, -15, -23, -22,
+ax_anim 1, 0, 64, -23, -15, -23, -22,
+ax_anim 2, 0, 67, -23, -15, -23, -22,
+ax_anim 1, 0, 64, -23, -15, -23, -22,
+ax_anim 2, 0, 63, -14, -12, -14, -15,
+ax_anim 2, 0, 63, -4, -3, -4, -4,
+ax_anim_terminator
+sCrobatAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 2, -10, 0,
+ax_anim 2, 2, 67, -15, 4, -15, 0,
+ax_anim 2, 0, 70, -23, 7, -23, 0,
+ax_anim 1, 1, 67, -23, 7, -23, 0,
+ax_anim 2, 0, 64, -23, 7, -23, 0,
+ax_anim 1, 0, 67, -23, 7, -23, 0,
+ax_anim 2, 0, 70, -23, 7, -23, 0,
+ax_anim 1, 0, 67, -23, 7, -23, 0,
+ax_anim 2, 0, 66, -14, 3, -14, 0,
+ax_anim 2, 0, 66, -4, 1, -4, 0,
+ax_anim_terminator
+sCrobatAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 12, -10, 10,
+ax_anim 2, 2, 70, -15, 18, -15, 15,
+ax_anim 2, 0, 49, -23, 28, -23, 21,
+ax_anim 1, 1, 70, -23, 28, -23, 21,
+ax_anim 2, 0, 67, -23, 28, -23, 21,
+ax_anim 1, 0, 70, -23, 28, -23, 21,
+ax_anim 2, 0, 49, -23, 28, -23, 21,
+ax_anim 1, 0, 70, -23, 28, -23, 21,
+ax_anim 2, 0, 69, -14, 17, -14, 14,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sCrobatAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, -3, 0, -3,
+ax_anim 8, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 2, 1, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 76, 1, 2, 1, 2,
+ax_anim 2, 0, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 76, 1, 2, 1, 2,
+ax_anim 2, 0, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 76, 1, 2, 1, 2,
+ax_anim_terminator
+sCrobatAnims_4_2:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 79, -3, -3, -3, -3,
+ax_anim 8, 2, 80, -4, -4, -4, -4,
+ax_anim 1, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 1, 81, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 1, 3, 1,
+ax_anim 2, 0, 81, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 1, 3, 1,
+ax_anim 2, 0, 81, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 1, 3, 1,
+ax_anim_terminator
+sCrobatAnims_4_3:
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 2, 0, 84, -3, 0, -3, 0,
+ax_anim 8, 2, 85, -4, 0, -4, 0,
+ax_anim 1, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 1, 86, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 2, 1, 2, 1,
+ax_anim 2, 0, 86, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 2, 1, 2, 1,
+ax_anim 2, 0, 86, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 2, 1, 2, 1,
+ax_anim_terminator
+sCrobatAnims_4_4:
+ax_anim 2, 0, 87, -1, 1, -1, 1,
+ax_anim 2, 0, 89, -3, 3, -3, 3,
+ax_anim 8, 2, 90, -4, 4, -4, 4,
+ax_anim 1, 0, 91, -1, 1, -1, 1,
+ax_anim 2, 1, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim_terminator
+sCrobatAnims_4_5:
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 2, 0, 94, 0, 3, 0, 3,
+ax_anim 8, 2, 95, 0, 4, 0, 4,
+ax_anim 1, 0, 96, 0, 1, 0, 1,
+ax_anim 2, 1, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 1, -2, 1, -2,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 1, -2, 1, -2,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 1, -2, 1, -2,
+ax_anim_terminator
+sCrobatAnims_4_6:
+ax_anim 2, 0, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 3, 3, 3, 3,
+ax_anim 8, 2, 100, 4, 4, 4, 4,
+ax_anim 1, 0, 101, 1, 1, 1, 1,
+ax_anim 2, 1, 101, -2, -2, -2, -2,
+ax_anim 2, 0, 101, -3, -1, -3, -1,
+ax_anim 2, 0, 101, -2, -2, -2, -2,
+ax_anim 2, 0, 101, -3, -1, -3, -1,
+ax_anim 2, 0, 101, -2, -2, -2, -2,
+ax_anim 2, 0, 101, -3, -1, -3, -1,
+ax_anim_terminator
+sCrobatAnims_4_7:
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 3, 0, 3, 0,
+ax_anim 8, 2, 105, 4, 0, 4, 0,
+ax_anim 1, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 106, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -2, 1, -2, 1,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -2, 1, -2, 1,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -2, 1, -2, 1,
+ax_anim_terminator
+sCrobatAnims_4_8:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 3, -3, 3, -3,
+ax_anim 8, 2, 110, 4, -4, 4, -4,
+ax_anim 1, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim_terminator
+.align 2
+sCrobatAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrobatAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrobatAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sCrobatAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sCrobatAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sCrobatAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sCrobatAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sCrobatAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sCrobatAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sCrobatAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sCrobatAnims_8_1:
+ax_anim 12, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 131, 0, 1, 0, 0,
+ax_anim 12, 0, 130, -1, 0, -1, 0,
+ax_anim 12, 0, 132, -1, 1, -1, 0,
+ax_anim 12, 0, 130, 0, 2, 0, 0,
+ax_anim 12, 0, 131, 0, 1, 0, 0,
+ax_anim 12, 0, 130, 1, 0, 1, 0,
+ax_anim 12, 0, 132, 0, 1, 0, 0,
+ax_anim_terminator
+sCrobatAnims_8_2:
+ax_anim 12, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 1, 0, 1,
+ax_anim 12, 0, 133, -2, 0, -2, 0,
+ax_anim 12, 0, 135, -2, 1, -2, 1,
+ax_anim 12, 0, 133, -1, 3, -1, 1,
+ax_anim 12, 0, 134, -2, 1, -2, 1,
+ax_anim 12, 0, 133, -1, 0, -1, 0,
+ax_anim 12, 0, 135, 0, 1, 0, 1,
+ax_anim_terminator
+sCrobatAnims_8_3:
+ax_anim 12, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 137, -1, 1, -1, 0,
+ax_anim 12, 0, 136, -2, 0, -2, 0,
+ax_anim 12, 0, 138, -2, 1, -2, 0,
+ax_anim 12, 0, 136, -1, 2, -1, 0,
+ax_anim 12, 0, 137, 0, 3, 0, 0,
+ax_anim 12, 0, 136, 0, 1, 0, 0,
+ax_anim 12, 0, 138, -1, 2, -1, 0,
+ax_anim_terminator
+sCrobatAnims_8_4:
+ax_anim 12, 0, 139, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 1, 0, 1,
+ax_anim 12, 0, 139, -2, 2, -2, 1,
+ax_anim 12, 0, 141, -2, 1, -2, 1,
+ax_anim 12, 0, 139, -1, 3, -1, 1,
+ax_anim 12, 0, 140, -2, 2, -2, 1,
+ax_anim 12, 0, 139, -1, 0, -1, 0,
+ax_anim 12, 0, 141, 0, 1, 0, 1,
+ax_anim_terminator
+sCrobatAnims_8_5:
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, 1, 0, 0,
+ax_anim 12, 0, 142, -1, 0, -1, 0,
+ax_anim 12, 0, 144, -1, 1, -1, 0,
+ax_anim 12, 0, 142, 0, 2, 0, 0,
+ax_anim 12, 0, 143, 0, 1, 0, 0,
+ax_anim 12, 0, 142, 1, 0, 1, 0,
+ax_anim 12, 0, 144, 0, 1, 0, 0,
+ax_anim_terminator
+sCrobatAnims_8_6:
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim 12, 0, 146, 0, 1, 0, 1,
+ax_anim 12, 0, 145, 2, 2, 2, 1,
+ax_anim 12, 0, 147, 2, 1, 2, 1,
+ax_anim 12, 0, 145, 1, 3, 1, 1,
+ax_anim 12, 0, 146, 2, 2, 2, 1,
+ax_anim 12, 0, 145, 1, 0, 1, 0,
+ax_anim 12, 0, 147, 0, 1, 0, 1,
+ax_anim_terminator
+sCrobatAnims_8_7:
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 1, 1, 1, 0,
+ax_anim 12, 0, 148, 2, 0, 2, 0,
+ax_anim 12, 0, 150, 2, 1, 2, 0,
+ax_anim 12, 0, 148, 1, 2, 1, 0,
+ax_anim 12, 0, 149, 0, 3, 0, 0,
+ax_anim 12, 0, 148, -1, 1, -1, 0,
+ax_anim 12, 0, 150, 0, 1, 0, 0,
+ax_anim_terminator
+sCrobatAnims_8_8:
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, 1, 0, 1,
+ax_anim 12, 0, 151, 2, 0, 2, 0,
+ax_anim 12, 0, 153, 2, 1, 2, 1,
+ax_anim 12, 0, 151, 1, 3, 1, 1,
+ax_anim 12, 0, 152, 2, 1, 2, 1,
+ax_anim 12, 0, 151, 1, 0, 1, 0,
+ax_anim 12, 0, 153, 0, 1, 0, 1,
+ax_anim_terminator
+.align 2
+sCrobatAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 10, 15, 10, 15,
+ax_anim 2, 0, 157, 9, 22, 9, 22,
+ax_anim 3, 0, 158, 0, 26, 0, 24,
+ax_anim 2, 3, 159, -9, 22, -9, 22,
+ax_anim 2, 0, 160, -10, 15, -10, 15,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 1, 8, 1,
+ax_anim 2, 0, 155, 20, 6, 20, 6,
+ax_anim 2, 0, 156, 23, 17, 23, 17,
+ax_anim 3, 0, 157, 21, 25, 21, 25,
+ax_anim 2, 3, 158, 11, 26, 11, 25,
+ax_anim 2, 0, 159, 1, 19, 1, 19,
+ax_anim 1, 0, 160, -2, 7, -2, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 5, -2, 5, -2,
+ax_anim 2, 0, 154, 10, -3, 10, -3,
+ax_anim 2, 0, 155, 18, 1, 18, 1,
+ax_anim 3, 0, 156, 19, 7, 19, 7,
+ax_anim 2, 3, 157, 18, 11, 18, 11,
+ax_anim 2, 0, 158, 12, 12, 12, 12,
+ax_anim 1, 0, 159, 2, 7, 2, 7,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 3, -8, 3, -8,
+ax_anim 2, 0, 161, 7, -16, 7, -16,
+ax_anim 2, 0, 154, 14, -19, 14, -19,
+ax_anim 3, 0, 155, 21, -15, 21, -15,
+ax_anim 2, 3, 156, 24, -9, 24, -9,
+ax_anim 2, 0, 157, 22, -3, 22, -3,
+ax_anim 1, 0, 158, 11, 2, 11, 2,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -9, -2, -9, -2,
+ax_anim 2, 0, 160, -11, -8, -11, -8,
+ax_anim 2, 0, 161, -8, -13, -8, -13,
+ax_anim 3, 0, 154, 0, -15, 0, -15,
+ax_anim 2, 3, 155, 8, -13, 8, -13,
+ax_anim 2, 0, 156, 12, -8, 12, -8,
+ax_anim 1, 0, 157, 9, -2, 9, -2,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, -3, -8, -3, -8,
+ax_anim 2, 0, 155, -6, -15, -6, -15,
+ax_anim 2, 0, 154, -12, -18, -12, -23,
+ax_anim 3, 0, 161, -21, -15, -21, -22,
+ax_anim 2, 3, 160, -24, -9, -22, -13,
+ax_anim 2, 0, 159, -22, -2, -21, -4,
+ax_anim 1, 0, 158, -11, 2, -11, 2,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -5, -3, -5, -3,
+ax_anim 2, 0, 154, -10, -5, -10, -5,
+ax_anim 2, 0, 161, -16, -1, -16, -1,
+ax_anim 3, 0, 160, -19, 3, -19, 3,
+ax_anim 2, 3, 159, -19, 11, -19, 9,
+ax_anim 2, 0, 158, -12, 12, -12, 11,
+ax_anim 1, 0, 157, -3, 7, -3, 7,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -19, 5, -19, 5,
+ax_anim 2, 0, 160, -25, 13, -25, 13,
+ax_anim 3, 0, 159, -22, 23, -22, 23,
+ax_anim 2, 3, 158, -10, 26, -10, 26,
+ax_anim 2, 0, 157, 0, 19, 0, 19,
+ax_anim 1, 0, 156, 2, 9, 2, 9,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrobatAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrobatAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -8, 0, 0,
+ax_anim 2, 2, 170, 0, 8, 0, 0,
+ax_anim_terminator
+sCrobatAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -8, 0, 0,
+ax_anim 2, 2, 173, 0, 8, 0, 0,
+ax_anim_terminator
+sCrobatAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -8, 0, 0,
+ax_anim 2, 2, 176, 0, 8, 0, 0,
+ax_anim_terminator
+sCrobatAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -17, 0, 0,
+ax_anim 1, 0, 180, 0, -7, 0, 0,
+ax_anim 2, 2, 179, 0, 8, 0, 0,
+ax_anim_terminator
+sCrobatAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -8, 0, 0,
+ax_anim 2, 2, 182, 0, 8, 0, 0,
+ax_anim_terminator
+sCrobatAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -17, 0, 0,
+ax_anim 1, 0, 186, 0, -7, 0, 0,
+ax_anim 2, 2, 185, 0, 8, 0, 0,
+ax_anim_terminator
+sCrobatAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -8, 0, 0,
+ax_anim 2, 2, 188, 0, 8, 0, 0,
+ax_anim_terminator
+sCrobatAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, 0,
+ax_anim 2, 2, 191, 0, 8, 0, 0,
+ax_anim_terminator
+.align 2
+sCrobatAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCrobatAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCrobatGfx1:
+.incbin "baserom.gba", 0xC676A8, 0x200
+sCrobatSprites1:
+ax_sprite sCrobatGfx1, 0x200
+ax_sprite_terminator
+sCrobatGfx2:
+.incbin "baserom.gba", 0xC678B8, 0x200
+sCrobatSprites2:
+ax_sprite sCrobatGfx2, 0x200
+ax_sprite_terminator
+sCrobatGfx3:
+.incbin "baserom.gba", 0xC67AC8, 0x200
+sCrobatSprites3:
+ax_sprite sCrobatGfx3, 0x200
+ax_sprite_terminator
+sCrobatGfx4:
+.incbin "baserom.gba", 0xC67CD8, 0x200
+sCrobatSprites4:
+ax_sprite sCrobatGfx4, 0x200
+ax_sprite_terminator
+sCrobatGfx5:
+.incbin "baserom.gba", 0xC67EE8, 0x200
+sCrobatSprites5:
+ax_sprite sCrobatGfx5, 0x200
+ax_sprite_terminator
+sCrobatGfx6:
+.incbin "baserom.gba", 0xC680F8, 0x200
+sCrobatSprites6:
+ax_sprite sCrobatGfx6, 0x200
+ax_sprite_terminator
+sCrobatGfx7:
+.incbin "baserom.gba", 0xC68308, 0x100
+sCrobatSprites7:
+ax_sprite sCrobatGfx7, 0x100
+ax_sprite_terminator
+sCrobatGfx8:
+.incbin "baserom.gba", 0xC68418, 0x200
+sCrobatSprites8:
+ax_sprite sCrobatGfx8, 0x200
+ax_sprite_terminator
+sCrobatGfx9:
+.incbin "baserom.gba", 0xC68628, 0x200
+sCrobatSprites9:
+ax_sprite sCrobatGfx9, 0x200
+ax_sprite_terminator
+sCrobatGfx10:
+.incbin "baserom.gba", 0xC68838, 0x200
+sCrobatSprites10:
+ax_sprite sCrobatGfx10, 0x200
+ax_sprite_terminator
+sCrobatGfx11:
+.incbin "baserom.gba", 0xC68A48, 0x200
+sCrobatSprites11:
+ax_sprite sCrobatGfx11, 0x200
+ax_sprite_terminator
+sCrobatGfx12:
+.incbin "baserom.gba", 0xC68C58, 0x200
+sCrobatSprites12:
+ax_sprite sCrobatGfx12, 0x200
+ax_sprite_terminator
+sCrobatGfx13:
+.incbin "baserom.gba", 0xC68E68, 0x200
+sCrobatSprites13:
+ax_sprite sCrobatGfx13, 0x200
+ax_sprite_terminator
+sCrobatGfx14:
+.incbin "baserom.gba", 0xC69078, 0x200
+sCrobatSprites14:
+ax_sprite sCrobatGfx14, 0x200
+ax_sprite_terminator
+sCrobatGfx15:
+.incbin "baserom.gba", 0xC69288, 0x200
+sCrobatSprites15:
+ax_sprite sCrobatGfx15, 0x200
+ax_sprite_terminator
+sCrobatGfx16:
+.incbin "baserom.gba", 0xC69498, 0x60
+sCrobatGfx16_1:
+.incbin "baserom.gba", 0xC694F8, 0x60
+sCrobatSprites16:
+ax_sprite sCrobatGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCrobatGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrobatGfx17:
+.incbin "baserom.gba", 0xC69580, 0x20
+sCrobatSprites17:
+ax_sprite sCrobatGfx17, 0x20
+ax_sprite_terminator
+sCrobatGfx18:
+.incbin "baserom.gba", 0xC695B0, 0x20
+sCrobatSprites18:
+ax_sprite sCrobatGfx18, 0x20
+ax_sprite_terminator
+sCrobatGfx19:
+.incbin "baserom.gba", 0xC695E0, 0x100
+sCrobatSprites19:
+ax_sprite sCrobatGfx19, 0x100
+ax_sprite_terminator
+sCrobatGfx20:
+.incbin "baserom.gba", 0xC696F0, 0x20
+sCrobatSprites20:
+ax_sprite sCrobatGfx20, 0x20
+ax_sprite_terminator
+sCrobatGfx21:
+.incbin "baserom.gba", 0xC69720, 0x20
+sCrobatSprites21:
+ax_sprite sCrobatGfx21, 0x20
+ax_sprite_terminator
+sCrobatGfx22:
+.incbin "baserom.gba", 0xC69750, 0xC0
+sCrobatSprites22:
+ax_sprite sCrobatGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCrobatGfx23:
+.incbin "baserom.gba", 0xC69828, 0x20
+sCrobatGfx23_1:
+.incbin "baserom.gba", 0xC69848, 0x100
+sCrobatGfx23_2:
+.incbin "baserom.gba", 0xC69948, 0x40
+sCrobatSprites23:
+ax_sprite sCrobatGfx23, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCrobatGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCrobatGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCrobatGfx24:
+.incbin "baserom.gba", 0xC699C0, 0xE0
+sCrobatSprites24:
+ax_sprite 0, 0x20
+ax_sprite sCrobatGfx24, 0xe0
+ax_sprite_terminator
+sCrobatGfx25:
+.incbin "baserom.gba", 0xC69AB8, 0x100
+sCrobatSprites25:
+ax_sprite sCrobatGfx25, 0x100
+ax_sprite_terminator
+sCrobatGfx26:
+.incbin "baserom.gba", 0xC69BC8, 0x20
+sCrobatSprites26:
+ax_sprite sCrobatGfx26, 0x20
+ax_sprite_terminator
+sCrobatGfx27:
+.incbin "baserom.gba", 0xC69BF8, 0x80
+sCrobatGfx27_1:
+.incbin "baserom.gba", 0xC69C78, 0x20
+sCrobatSprites27:
+ax_sprite 0, 0x40
+ax_sprite sCrobatGfx27, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCrobatGfx27_1, 0x20
+ax_sprite_terminator
+sCrobatGfx28:
+.incbin "baserom.gba", 0xC69CC0, 0x1A0
+sCrobatSprites28:
+ax_sprite 0, 0x20
+ax_sprite sCrobatGfx28, 0x1a0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCrobatGfx29:
+.incbin "baserom.gba", 0xC69E80, 0xC0
+sCrobatSprites29:
+ax_sprite 0, 0x40
+ax_sprite sCrobatGfx29, 0xc0
+ax_sprite_terminator
+sCrobatGfx30:
+.incbin "baserom.gba", 0xC69F58, 0x100
+sCrobatSprites30:
+ax_sprite sCrobatGfx30, 0x100
+ax_sprite_terminator
+sCrobatGfx31:
+.incbin "baserom.gba", 0xC6A068, 0x80
+sCrobatSprites31:
+ax_sprite sCrobatGfx31, 0x80
+ax_sprite_terminator
+sCrobatGfx32:
+.incbin "baserom.gba", 0xC6A0F8, 0x20
+sCrobatSprites32:
+ax_sprite sCrobatGfx32, 0x20
+ax_sprite_terminator
+sCrobatGfx33:
+.incbin "baserom.gba", 0xC6A128, 0x20
+sCrobatSprites33:
+ax_sprite sCrobatGfx33, 0x20
+ax_sprite_terminator
+sCrobatGfx34:
+.incbin "baserom.gba", 0xC6A158, 0x200
+sCrobatSprites34:
+ax_sprite sCrobatGfx34, 0x200
+ax_sprite_terminator
+sCrobatGfx35:
+.incbin "baserom.gba", 0xC6A368, 0x200
+sCrobatSprites35:
+ax_sprite sCrobatGfx35, 0x200
+ax_sprite_terminator
+sCrobatGfx36:
+.incbin "baserom.gba", 0xC6A578, 0x200
+sCrobatSprites36:
+ax_sprite sCrobatGfx36, 0x200
+ax_sprite_terminator
+sCrobatGfx37:
+.incbin "baserom.gba", 0xC6A788, 0x200
+sCrobatSprites37:
+ax_sprite sCrobatGfx37, 0x200
+ax_sprite_terminator
+sCrobatGfx38:
+.incbin "baserom.gba", 0xC6A998, 0x200
+sCrobatSprites38:
+ax_sprite sCrobatGfx38, 0x200
+ax_sprite_terminator
+sCrobatGfx39:
+.incbin "baserom.gba", 0xC6ABA8, 0x200
+sCrobatSprites39:
+ax_sprite sCrobatGfx39, 0x200
+ax_sprite_terminator
+sCrobatGfx40:
+.incbin "baserom.gba", 0xC6ADB8, 0x200
+sCrobatSprites40:
+ax_sprite sCrobatGfx40, 0x200
+ax_sprite_terminator
+sAxPosesCrobat:
+.4byte sCrobatPose1
+.4byte sCrobatPose2
+.4byte sCrobatPose3
+.4byte sCrobatPose4
+.4byte sCrobatPose5
+.4byte sCrobatPose6
+.4byte sCrobatPose7
+.4byte sCrobatPose8
+.4byte sCrobatPose9
+.4byte sCrobatPose10
+.4byte sCrobatPose11
+.4byte sCrobatPose12
+.4byte sCrobatPose13
+.4byte sCrobatPose14
+.4byte sCrobatPose15
+.4byte sCrobatPose16
+.4byte sCrobatPose17
+.4byte sCrobatPose18
+.4byte sCrobatPose19
+.4byte sCrobatPose20
+.4byte sCrobatPose21
+.4byte sCrobatPose22
+.4byte sCrobatPose23
+.4byte sCrobatPose24
+.4byte sCrobatPose25
+.4byte sCrobatPose26
+.4byte sCrobatPose27
+.4byte sCrobatPose28
+.4byte sCrobatPose29
+.4byte sCrobatPose30
+.4byte sCrobatPose31
+.4byte sCrobatPose32
+.4byte sCrobatPose33
+.4byte sCrobatPose34
+.4byte sCrobatPose35
+.4byte sCrobatPose36
+.4byte sCrobatPose37
+.4byte sCrobatPose38
+.4byte sCrobatPose39
+.4byte sCrobatPose40
+.4byte sCrobatPose41
+.4byte sCrobatPose42
+.4byte sCrobatPose43
+.4byte sCrobatPose44
+.4byte sCrobatPose45
+.4byte sCrobatPose46
+.4byte sCrobatPose47
+.4byte sCrobatPose48
+.4byte sCrobatPose49
+.4byte sCrobatPose50
+.4byte sCrobatPose51
+.4byte sCrobatPose52
+.4byte sCrobatPose53
+.4byte sCrobatPose54
+.4byte sCrobatPose55
+.4byte sCrobatPose56
+.4byte sCrobatPose57
+.4byte sCrobatPose58
+.4byte sCrobatPose59
+.4byte sCrobatPose60
+.4byte sCrobatPose61
+.4byte sCrobatPose62
+.4byte sCrobatPose63
+.4byte sCrobatPose64
+.4byte sCrobatPose65
+.4byte sCrobatPose66
+.4byte sCrobatPose67
+.4byte sCrobatPose68
+.4byte sCrobatPose69
+.4byte sCrobatPose70
+.4byte sCrobatPose71
+.4byte sCrobatPose72
+.4byte sCrobatPose73
+.4byte sCrobatPose74
+.4byte sCrobatPose75
+.4byte sCrobatPose76
+.4byte sCrobatPose77
+.4byte sCrobatPose78
+.4byte sCrobatPose79
+.4byte sCrobatPose80
+.4byte sCrobatPose81
+.4byte sCrobatPose82
+.4byte sCrobatPose83
+.4byte sCrobatPose84
+.4byte sCrobatPose85
+.4byte sCrobatPose86
+.4byte sCrobatPose87
+.4byte sCrobatPose88
+.4byte sCrobatPose89
+.4byte sCrobatPose90
+.4byte sCrobatPose91
+.4byte sCrobatPose92
+.4byte sCrobatPose93
+.4byte sCrobatPose94
+.4byte sCrobatPose95
+.4byte sCrobatPose96
+.4byte sCrobatPose97
+.4byte sCrobatPose98
+.4byte sCrobatPose99
+.4byte sCrobatPose100
+.4byte sCrobatPose101
+.4byte sCrobatPose102
+.4byte sCrobatPose103
+.4byte sCrobatPose104
+.4byte sCrobatPose105
+.4byte sCrobatPose106
+.4byte sCrobatPose107
+.4byte sCrobatPose108
+.4byte sCrobatPose109
+.4byte sCrobatPose110
+.4byte sCrobatPose111
+.4byte sCrobatPose112
+.4byte sCrobatPose113
+.4byte sCrobatPose114
+.4byte sCrobatPose115
+.4byte sCrobatPose116
+.4byte sCrobatPose117
+.4byte sCrobatPose118
+.4byte sCrobatPose119
+.4byte sCrobatPose120
+.4byte sCrobatPose121
+.4byte sCrobatPose122
+.4byte sCrobatPose123
+.4byte sCrobatPose124
+.4byte sCrobatPose125
+.4byte sCrobatPose126
+.4byte sCrobatPose127
+.4byte sCrobatPose128
+.4byte sCrobatPose129
+.4byte sCrobatPose130
+.4byte sCrobatPose131
+.4byte sCrobatPose132
+.4byte sCrobatPose133
+.4byte sCrobatPose134
+.4byte sCrobatPose135
+.4byte sCrobatPose136
+.4byte sCrobatPose137
+.4byte sCrobatPose138
+.4byte sCrobatPose139
+.4byte sCrobatPose140
+.4byte sCrobatPose141
+.4byte sCrobatPose142
+.4byte sCrobatPose143
+.4byte sCrobatPose144
+.4byte sCrobatPose145
+.4byte sCrobatPose146
+.4byte sCrobatPose147
+.4byte sCrobatPose148
+.4byte sCrobatPose149
+.4byte sCrobatPose150
+.4byte sCrobatPose151
+.4byte sCrobatPose152
+.4byte sCrobatPose153
+.4byte sCrobatPose154
+.4byte sCrobatPose155
+.4byte sCrobatPose156
+.4byte sCrobatPose157
+.4byte sCrobatPose158
+.4byte sCrobatPose159
+.4byte sCrobatPose160
+.4byte sCrobatPose161
+.4byte sCrobatPose162
+.4byte sCrobatPose163
+.4byte sCrobatPose164
+.4byte sCrobatPose165
+.4byte sCrobatPose166
+.4byte sCrobatPose167
+.4byte sCrobatPose168
+.4byte sCrobatPose169
+.4byte sCrobatPose170
+.4byte sCrobatPose171
+.4byte sCrobatPose172
+.4byte sCrobatPose173
+.4byte sCrobatPose174
+.4byte sCrobatPose175
+.4byte sCrobatPose176
+.4byte sCrobatPose177
+.4byte sCrobatPose178
+.4byte sCrobatPose179
+.4byte sCrobatPose180
+.4byte sCrobatPose181
+.4byte sCrobatPose182
+.4byte sCrobatPose183
+.4byte sCrobatPose184
+.4byte sCrobatPose185
+.4byte sCrobatPose186
+.4byte sCrobatPose187
+.4byte sCrobatPose188
+.4byte sCrobatPose189
+.4byte sCrobatPose190
+.4byte sCrobatPose191
+.4byte sCrobatPose192
+.4byte sCrobatPose193
+.4byte sCrobatPose194
+.4byte sCrobatPose195
+.4byte sCrobatPose196
+.4byte sCrobatPose197
+.4byte sCrobatPose198
+.4byte sCrobatPose199
+.4byte sCrobatPose200
+.4byte sCrobatPose201
+.4byte sCrobatPose202
+.4byte sCrobatPose203
+.4byte sCrobatPose204
+.4byte sCrobatPose205
+.4byte sCrobatPose206
+.4byte sCrobatPose207
+.4byte sCrobatPose208
+.4byte sCrobatPose209
+.4byte sCrobatPose210
+sAxPositionsCrobat:
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -1,  -12, 	 -10,  -26, 	   9,  -26, 	   0,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	   9,   -9, 	   0,  -13
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+.2byte    2,  -13, 	  -1,  -27, 	 -13,  -22, 	  -1,  -14
+.2byte    2,  -13, 	  11,  -15, 	  -2,   -7, 	   0,  -14
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    3,  -13, 	 -10,  -22, 	 -12,  -13, 	  -1,  -13
+.2byte    3,  -14, 	   8,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    1,  -15, 	 -14,  -18, 	  -1,   -9, 	  -2,  -15
+.2byte    1,  -15, 	  -3,  -29, 	  11,  -22, 	  -1,  -14
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	  11,  -10, 	 -12,  -10, 	  -1,  -15
+.2byte    0,  -16, 	   8,  -26, 	  -9,  -26, 	   0,  -15
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte   -2,  -15, 	  13,  -18, 	   0,   -9, 	   1,  -15
+.2byte   -2,  -15, 	   2,  -29, 	 -12,  -22, 	   0,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -4,  -13, 	   9,  -22, 	  11,  -13, 	   0,  -13
+.2byte   -4,  -14, 	  -9,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -3,  -13, 	   0,  -27, 	  12,  -22, 	   0,  -14
+.2byte   -3,  -13, 	 -12,  -15, 	   1,   -7, 	  -1,  -14
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -1,  -12, 	 -10,  -26, 	   9,  -26, 	   0,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	   9,   -9, 	   0,  -13
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+.2byte    2,  -13, 	  -1,  -27, 	 -13,  -22, 	  -1,  -14
+.2byte    2,  -13, 	  11,  -15, 	  -2,   -7, 	   0,  -14
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    3,  -13, 	 -10,  -22, 	 -12,  -13, 	  -1,  -13
+.2byte    3,  -14, 	   8,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    1,  -15, 	 -14,  -18, 	  -1,   -9, 	  -2,  -15
+.2byte    1,  -15, 	  -3,  -29, 	  11,  -22, 	  -1,  -14
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	  11,  -10, 	 -12,  -10, 	  -1,  -15
+.2byte    0,  -16, 	   8,  -26, 	  -9,  -26, 	   0,  -15
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte   -2,  -15, 	  13,  -18, 	   0,   -9, 	   1,  -15
+.2byte   -2,  -15, 	   2,  -29, 	 -12,  -22, 	   0,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -4,  -13, 	   9,  -22, 	  11,  -13, 	   0,  -13
+.2byte   -4,  -14, 	  -9,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -3,  -13, 	   0,  -27, 	  12,  -22, 	   0,  -14
+.2byte   -3,  -13, 	 -12,  -15, 	   1,   -7, 	  -1,  -14
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -1,  -12, 	 -10,  -26, 	   9,  -26, 	   0,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	   9,   -9, 	   0,  -13
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+.2byte    2,  -13, 	  -1,  -27, 	 -13,  -22, 	  -1,  -14
+.2byte    2,  -13, 	  11,  -15, 	  -2,   -7, 	   0,  -14
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    3,  -13, 	 -10,  -22, 	 -12,  -13, 	  -1,  -13
+.2byte    3,  -14, 	   8,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    1,  -15, 	 -14,  -18, 	  -1,   -9, 	  -2,  -15
+.2byte    1,  -15, 	  -3,  -29, 	  11,  -22, 	  -1,  -14
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	  11,  -10, 	 -12,  -10, 	  -1,  -15
+.2byte    0,  -16, 	   8,  -26, 	  -9,  -26, 	   0,  -15
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte   -2,  -15, 	  13,  -18, 	   0,   -9, 	   1,  -15
+.2byte   -2,  -15, 	   2,  -29, 	 -12,  -22, 	   0,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -4,  -13, 	   9,  -22, 	  11,  -13, 	   0,  -13
+.2byte   -4,  -14, 	  -9,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -3,  -13, 	   0,  -27, 	  12,  -22, 	   0,  -14
+.2byte   -3,  -13, 	 -12,  -15, 	   1,   -7, 	  -1,  -14
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -1,  -12, 	 -10,  -26, 	   9,  -26, 	   0,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	   9,   -9, 	   0,  -13
+.2byte   -1,  -13, 	   6,  -19, 	  -7,  -15, 	  -1,  -14
+.2byte   -1,  -12, 	 -18,  -21, 	  17,  -21, 	   0,  -14
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+.2byte    2,  -13, 	  -1,  -27, 	 -13,  -22, 	  -1,  -14
+.2byte    2,  -13, 	  11,  -15, 	  -2,   -7, 	   0,  -14
+.2byte    0,  -18, 	  -6,  -17, 	   4,  -19, 	  -1,  -17
+.2byte    2,  -12, 	   6,  -24, 	 -19,  -14, 	   0,  -14
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    3,  -13, 	 -10,  -22, 	 -12,  -13, 	  -1,  -13
+.2byte    3,  -14, 	   8,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    1,  -16, 	  -1,  -16, 	   4,  -20, 	  -2,  -14
+.2byte    3,  -12, 	  -9,  -23, 	 -11,  -11, 	   0,  -13
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    1,  -15, 	 -14,  -18, 	  -1,   -9, 	  -2,  -15
+.2byte    1,  -15, 	  -3,  -29, 	  11,  -22, 	  -1,  -14
+.2byte   -1,  -14, 	   5,  -19, 	  -1,  -22, 	  -3,  -13
+.2byte    0,  -15, 	 -14,  -21, 	  12,   -8, 	  -1,  -14
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	  11,  -10, 	 -12,  -10, 	  -1,  -15
+.2byte    0,  -16, 	   8,  -26, 	  -9,  -26, 	   0,  -15
+.2byte    0,  -15, 	  -5,  -21, 	   5,  -21, 	   0,  -13
+.2byte    0,  -16, 	  17,  -15, 	 -18,  -15, 	   0,  -14
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte   -2,  -15, 	  13,  -18, 	   0,   -9, 	   1,  -15
+.2byte   -2,  -15, 	   2,  -29, 	 -12,  -22, 	   0,  -14
+.2byte    0,  -14, 	  -6,  -19, 	   0,  -22, 	   2,  -13
+.2byte   -1,  -15, 	  13,  -21, 	 -13,   -8, 	   0,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -4,  -13, 	   9,  -22, 	  11,  -13, 	   0,  -13
+.2byte   -4,  -14, 	  -9,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -2,  -16, 	   0,  -16, 	  -5,  -20, 	   1,  -14
+.2byte   -4,  -12, 	   8,  -23, 	  10,  -11, 	  -1,  -13
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -3,  -13, 	   0,  -27, 	  12,  -22, 	   0,  -14
+.2byte   -3,  -13, 	 -12,  -15, 	   1,   -7, 	  -1,  -14
+.2byte   -1,  -18, 	   5,  -17, 	  -5,  -19, 	   0,  -17
+.2byte   -3,  -12, 	  -7,  -24, 	  18,  -14, 	  -1,  -14
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+.2byte   -1,   -5, 	  -7,    0, 	   6,    0, 	   0,   -6
+.2byte   -1,   -4, 	  -8,    0, 	   7,    0, 	   0,   -5
+.2byte   -1,  -11, 	  -4,  -24, 	   3,  -24, 	   0,  -11
+.2byte    0,  -13, 	   2,  -25, 	  -4,  -24, 	  -1,  -12
+.2byte   -1,  -13, 	  -4,  -23, 	   0,  -21, 	  -1,  -11
+.2byte   -1,  -13, 	  -6,  -22, 	   2,  -19, 	  -2,  -10
+.2byte   -1,  -12, 	   3,  -24, 	  -4,  -24, 	   0,   -9
+.2byte    0,  -13, 	   5,  -22, 	  -3,  -19, 	   1,  -10
+.2byte    0,  -13, 	   3,  -23, 	  -1,  -21, 	   0,  -11
+.2byte   -1,  -13, 	  -3,  -25, 	   3,  -24, 	   0,  -12
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -1,  -12, 	 -10,  -26, 	   9,  -26, 	   0,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	   9,   -9, 	   0,  -13
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+.2byte    2,  -13, 	  -1,  -27, 	 -13,  -22, 	  -1,  -14
+.2byte    2,  -13, 	  11,  -15, 	  -2,   -7, 	   0,  -14
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    3,  -13, 	 -10,  -22, 	 -12,  -13, 	  -1,  -13
+.2byte    3,  -14, 	   8,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    1,  -15, 	 -14,  -18, 	  -1,   -9, 	  -2,  -15
+.2byte    1,  -15, 	  -3,  -29, 	  11,  -22, 	  -1,  -14
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	  11,  -10, 	 -12,  -10, 	  -1,  -15
+.2byte    0,  -16, 	   8,  -26, 	  -9,  -26, 	   0,  -15
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte   -2,  -15, 	  13,  -18, 	   0,   -9, 	   1,  -15
+.2byte   -2,  -15, 	   2,  -29, 	 -12,  -22, 	   0,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -4,  -13, 	   9,  -22, 	  11,  -13, 	   0,  -13
+.2byte   -4,  -14, 	  -9,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -3,  -13, 	   0,  -27, 	  12,  -22, 	   0,  -14
+.2byte   -3,  -13, 	 -12,  -15, 	   1,   -7, 	  -1,  -14
+.2byte   -1,  -12, 	 -18,  -21, 	  17,  -21, 	   0,  -14
+.2byte   -3,  -12, 	  -7,  -24, 	  18,  -14, 	  -1,  -14
+.2byte   -4,  -12, 	   8,  -23, 	  10,  -11, 	  -1,  -13
+.2byte   -1,  -15, 	  13,  -21, 	 -13,   -8, 	   0,  -14
+.2byte    0,  -15, 	  17,  -14, 	 -18,  -14, 	   0,  -13
+.2byte    0,  -15, 	 -14,  -21, 	  12,   -8, 	  -1,  -14
+.2byte    3,  -12, 	  -9,  -23, 	 -11,  -11, 	   0,  -13
+.2byte    2,  -12, 	   6,  -24, 	 -19,  -14, 	   0,  -14
+.2byte   -1,  -12, 	 -18,  -21, 	  17,  -21, 	   0,  -14
+.2byte    3,  -12, 	   7,  -24, 	 -18,  -14, 	   1,  -14
+.2byte    4,  -12, 	  -8,  -23, 	 -10,  -11, 	   1,  -13
+.2byte    1,  -15, 	 -13,  -21, 	  13,   -8, 	   0,  -14
+.2byte    0,  -16, 	  17,  -15, 	 -18,  -15, 	   0,  -14
+.2byte   -2,  -15, 	  12,  -21, 	 -14,   -8, 	  -1,  -14
+.2byte   -6,  -12, 	   6,  -23, 	   8,  -11, 	  -3,  -13
+.2byte   -4,  -12, 	  -8,  -24, 	  17,  -14, 	  -2,  -14
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -1,  -12, 	 -10,  -26, 	   9,  -26, 	   0,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	   9,   -9, 	   0,  -13
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+.2byte    2,  -13, 	  -1,  -27, 	 -13,  -22, 	  -1,  -14
+.2byte    2,  -13, 	  11,  -15, 	  -2,   -7, 	   0,  -14
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    3,  -13, 	 -10,  -22, 	 -12,  -13, 	  -1,  -13
+.2byte    3,  -14, 	   8,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    1,  -15, 	 -14,  -18, 	  -1,   -9, 	  -2,  -15
+.2byte    1,  -15, 	  -3,  -29, 	  11,  -22, 	  -1,  -14
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	  11,  -10, 	 -12,  -10, 	  -1,  -15
+.2byte    0,  -16, 	   8,  -26, 	  -9,  -26, 	   0,  -15
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte   -2,  -15, 	  13,  -18, 	   0,   -9, 	   1,  -15
+.2byte   -2,  -15, 	   2,  -29, 	 -12,  -22, 	   0,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -4,  -13, 	   9,  -22, 	  11,  -13, 	   0,  -13
+.2byte   -4,  -14, 	  -9,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -3,  -13, 	   0,  -27, 	  12,  -22, 	   0,  -14
+.2byte   -3,  -13, 	 -12,  -15, 	   1,   -7, 	  -1,  -14
+.2byte   -1,  -12, 	 -10,  -26, 	   9,  -26, 	   0,  -13
+.2byte   -3,  -13, 	   0,  -27, 	  12,  -22, 	   0,  -14
+.2byte   -5,  -13, 	   8,  -22, 	  10,  -13, 	  -1,  -13
+.2byte   -3,  -15, 	  12,  -18, 	  -1,   -9, 	   0,  -15
+.2byte    0,  -17, 	  11,  -11, 	 -12,  -11, 	  -1,  -16
+.2byte    2,  -15, 	 -13,  -18, 	   0,   -9, 	  -1,  -15
+.2byte    4,  -13, 	  -9,  -22, 	 -11,  -13, 	   0,  -13
+.2byte    2,  -13, 	  -1,  -27, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -12, 	 -14,  -19, 	  13,  -19, 	   0,  -13
+.2byte   -3,  -13, 	  -5,  -23, 	  14,  -14, 	  -1,  -14
+.2byte   -4,  -13, 	   5,  -23, 	   7,  -11, 	   0,  -14
+.2byte   -1,  -16, 	  11,  -21, 	 -11,   -9, 	   1,  -15
+.2byte    0,  -16, 	  14,  -16, 	 -15,  -16, 	  -1,  -15
+.2byte    0,  -16, 	 -12,  -21, 	  10,   -9, 	  -2,  -15
+.2byte    3,  -13, 	  -6,  -23, 	  -8,  -11, 	  -1,  -14
+.2byte    2,  -13, 	   4,  -23, 	 -15,  -14, 	   0,  -14
+sCrobatAnimTable1:
+.4byte sCrobatAnims_1_1
+.4byte sCrobatAnims_1_2
+.4byte sCrobatAnims_1_3
+.4byte sCrobatAnims_1_4
+.4byte sCrobatAnims_1_5
+.4byte sCrobatAnims_1_6
+.4byte sCrobatAnims_1_7
+.4byte sCrobatAnims_1_8
+sCrobatAnimTable2:
+.4byte sCrobatAnims_2_1
+.4byte sCrobatAnims_2_2
+.4byte sCrobatAnims_2_3
+.4byte sCrobatAnims_2_4
+.4byte sCrobatAnims_2_5
+.4byte sCrobatAnims_2_6
+.4byte sCrobatAnims_2_7
+.4byte sCrobatAnims_2_8
+sCrobatAnimTable3:
+.4byte sCrobatAnims_3_1
+.4byte sCrobatAnims_3_2
+.4byte sCrobatAnims_3_3
+.4byte sCrobatAnims_3_4
+.4byte sCrobatAnims_3_5
+.4byte sCrobatAnims_3_6
+.4byte sCrobatAnims_3_7
+.4byte sCrobatAnims_3_8
+sCrobatAnimTable4:
+.4byte sCrobatAnims_4_1
+.4byte sCrobatAnims_4_2
+.4byte sCrobatAnims_4_3
+.4byte sCrobatAnims_4_4
+.4byte sCrobatAnims_4_5
+.4byte sCrobatAnims_4_6
+.4byte sCrobatAnims_4_7
+.4byte sCrobatAnims_4_8
+sCrobatAnimTable5:
+.4byte sCrobatAnims_5_1
+.4byte sCrobatAnims_5_2
+.4byte sCrobatAnims_5_3
+.4byte sCrobatAnims_5_4
+.4byte sCrobatAnims_5_5
+.4byte sCrobatAnims_5_6
+.4byte sCrobatAnims_5_7
+.4byte sCrobatAnims_5_8
+sCrobatAnimTable6:
+.4byte sCrobatAnims_6_1
+.4byte sCrobatAnims_6_1
+.4byte sCrobatAnims_6_1
+.4byte sCrobatAnims_6_1
+.4byte sCrobatAnims_6_1
+.4byte sCrobatAnims_6_1
+.4byte sCrobatAnims_6_1
+.4byte sCrobatAnims_6_1
+sCrobatAnimTable7:
+.4byte sCrobatAnims_7_1
+.4byte sCrobatAnims_7_2
+.4byte sCrobatAnims_7_3
+.4byte sCrobatAnims_7_4
+.4byte sCrobatAnims_7_5
+.4byte sCrobatAnims_7_6
+.4byte sCrobatAnims_7_7
+.4byte sCrobatAnims_7_8
+sCrobatAnimTable8:
+.4byte sCrobatAnims_8_1
+.4byte sCrobatAnims_8_2
+.4byte sCrobatAnims_8_3
+.4byte sCrobatAnims_8_4
+.4byte sCrobatAnims_8_5
+.4byte sCrobatAnims_8_6
+.4byte sCrobatAnims_8_7
+.4byte sCrobatAnims_8_8
+sCrobatAnimTable9:
+.4byte sCrobatAnims_9_1
+.4byte sCrobatAnims_9_2
+.4byte sCrobatAnims_9_3
+.4byte sCrobatAnims_9_4
+.4byte sCrobatAnims_9_5
+.4byte sCrobatAnims_9_6
+.4byte sCrobatAnims_9_7
+.4byte sCrobatAnims_9_8
+sCrobatAnimTable10:
+.4byte sCrobatAnims_10_1
+.4byte sCrobatAnims_10_2
+.4byte sCrobatAnims_10_3
+.4byte sCrobatAnims_10_4
+.4byte sCrobatAnims_10_5
+.4byte sCrobatAnims_10_6
+.4byte sCrobatAnims_10_7
+.4byte sCrobatAnims_10_8
+sCrobatAnimTable11:
+.4byte sCrobatAnims_11_1
+.4byte sCrobatAnims_11_2
+.4byte sCrobatAnims_11_3
+.4byte sCrobatAnims_11_4
+.4byte sCrobatAnims_11_5
+.4byte sCrobatAnims_11_6
+.4byte sCrobatAnims_11_7
+.4byte sCrobatAnims_11_8
+sCrobatAnimTable12:
+.4byte sCrobatAnims_12_1
+.4byte sCrobatAnims_12_2
+.4byte sCrobatAnims_12_3
+.4byte sCrobatAnims_12_4
+.4byte sCrobatAnims_12_5
+.4byte sCrobatAnims_12_6
+.4byte sCrobatAnims_12_7
+.4byte sCrobatAnims_12_8
+sCrobatAnimTable13:
+.4byte sCrobatAnims_13_1
+.4byte sCrobatAnims_13_2
+.4byte sCrobatAnims_13_3
+.4byte sCrobatAnims_13_4
+.4byte sCrobatAnims_13_5
+.4byte sCrobatAnims_13_6
+.4byte sCrobatAnims_13_7
+.4byte sCrobatAnims_13_8
+sAxAnimationsCrobat:
+.4byte sCrobatAnimTable1
+.4byte sCrobatAnimTable2
+.4byte sCrobatAnimTable3
+.4byte sCrobatAnimTable4
+.4byte sCrobatAnimTable5
+.4byte sCrobatAnimTable6
+.4byte sCrobatAnimTable7
+.4byte sCrobatAnimTable8
+.4byte sCrobatAnimTable9
+.4byte sCrobatAnimTable10
+.4byte sCrobatAnimTable11
+.4byte sCrobatAnimTable12
+.4byte sCrobatAnimTable13
+sAxSpritesCrobat:
+.4byte sCrobatSprites1
+.4byte sCrobatSprites2
+.4byte sCrobatSprites3
+.4byte sCrobatSprites4
+.4byte sCrobatSprites5
+.4byte sCrobatSprites6
+.4byte sCrobatSprites7
+.4byte sCrobatSprites8
+.4byte sCrobatSprites9
+.4byte sCrobatSprites10
+.4byte sCrobatSprites11
+.4byte sCrobatSprites12
+.4byte sCrobatSprites13
+.4byte sCrobatSprites14
+.4byte sCrobatSprites15
+.4byte sCrobatSprites16
+.4byte sCrobatSprites17
+.4byte sCrobatSprites18
+.4byte sCrobatSprites19
+.4byte sCrobatSprites20
+.4byte sCrobatSprites21
+.4byte sCrobatSprites22
+.4byte sCrobatSprites23
+.4byte sCrobatSprites24
+.4byte sCrobatSprites25
+.4byte sCrobatSprites26
+.4byte sCrobatSprites27
+.4byte sCrobatSprites28
+.4byte sCrobatSprites29
+.4byte sCrobatSprites30
+.4byte sCrobatSprites31
+.4byte sCrobatSprites32
+.4byte sCrobatSprites33
+.4byte sCrobatSprites34
+.4byte sCrobatSprites35
+.4byte sCrobatSprites36
+.4byte sCrobatSprites37
+.4byte sCrobatSprites38
+.4byte sCrobatSprites39
+.4byte sCrobatSprites40
+sAxMainCrobat:
+ax_main sAxPosesCrobat, sAxAnimationsCrobat, 13, sAxSpritesCrobat, sAxPositionsCrobat

--- a/data/ax/croconaw.inc
+++ b/data/ax/croconaw.inc
@@ -1,0 +1,2957 @@
+.global gAxCroconaw
+gAxCroconaw:
+ax_siro sAxMainCroconaw
+sCroconawPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose4:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose7:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose8:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose9:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose10:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose11:
+ax_pose 10, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose12:
+ax_pose 11, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose16:
+ax_pose 15, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose17:
+ax_pose 16, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose18:
+ax_pose 17, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose19:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose20:
+ax_pose 19, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose21:
+ax_pose 20, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose22:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose23:
+ax_pose 22, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose24:
+ax_pose 23, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose26:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose27:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose28:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose31:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose32:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose33:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose34:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose35:
+ax_pose 10, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose36:
+ax_pose 11, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose37:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose38:
+ax_pose 13, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose39:
+ax_pose 14, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose40:
+ax_pose 15, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose41:
+ax_pose 16, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose42:
+ax_pose 17, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose43:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose44:
+ax_pose 19, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose45:
+ax_pose 20, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose46:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose47:
+ax_pose 22, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose48:
+ax_pose 23, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose49:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose50:
+ax_pose 24, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose51:
+ax_pose 25, 0x81e9, 0x40f8, 0x0c00
+ax_pose 26, 0x81e6, 0x40f4, 0x0c04
+ax_pose 27, 0x81e6, 0x80fc, 0x0c08
+ax_pose_terminator
+sCroconawPose52:
+ax_pose 26, 0x81e6, 0x40f4, 0x0c00
+ax_pose 27, 0x81e6, 0x80fc, 0x0c04
+ax_pose_terminator
+sCroconawPose53:
+ax_pose 26, 0x81e6, 0x5104, 0x0c00
+ax_pose 27, 0x81e6, 0x90f4, 0x0c04
+ax_pose_terminator
+sCroconawPose54:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose55:
+ax_pose 28, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose56:
+ax_pose 29, 0x81ef, 0x1107, 0x0c00
+ax_pose 30, 0x01e7, 0x1107, 0x0c02
+ax_pose 31, 0x01e7, 0x10ff, 0x0c03
+ax_pose 32, 0x01e6, 0x80f1, 0x0c04
+ax_pose_terminator
+sCroconawPose57:
+ax_pose 32, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose58:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose59:
+ax_pose 33, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose60:
+ax_pose 34, 0x01f4, 0x1109, 0x0c00
+ax_pose 35, 0x01ec, 0x1109, 0x0c01
+ax_pose 36, 0x01ec, 0x10f9, 0x0c02
+ax_pose 37, 0x01e5, 0x80f0, 0x0c03
+ax_pose_terminator
+sCroconawPose61:
+ax_pose 37, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose62:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose63:
+ax_pose 38, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose64:
+ax_pose 39, 0x41e7, 0x10fa, 0x0c00
+ax_pose 40, 0x01e7, 0x10f2, 0x0c02
+ax_pose 41, 0x01ef, 0x10f2, 0x0c03
+ax_pose 42, 0x01e6, 0x80ee, 0x0c04
+ax_pose_terminator
+sCroconawPose65:
+ax_pose 42, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose66:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose67:
+ax_pose 43, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose68:
+ax_pose 44, 0x81e5, 0x4102, 0x0c00
+ax_pose 45, 0x81e6, 0x80f3, 0x0c04
+ax_pose 46, 0x81e6, 0x4103, 0x0c0c
+ax_pose_terminator
+sCroconawPose69:
+ax_pose 45, 0x81e6, 0x80f3, 0x0c00
+ax_pose 46, 0x81e6, 0x4103, 0x0c08
+ax_pose_terminator
+sCroconawPose70:
+ax_pose 43, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sCroconawPose71:
+ax_pose 15, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose72:
+ax_pose 47, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose73:
+ax_pose 39, 0x41e7, 0x00f6, 0x0c00
+ax_pose 40, 0x01e7, 0x0106, 0x0c02
+ax_pose 41, 0x01ef, 0x0106, 0x0c03
+ax_pose 48, 0x01e6, 0x80f2, 0x0c04
+ax_pose_terminator
+sCroconawPose74:
+ax_pose 48, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose75:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose76:
+ax_pose 49, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose77:
+ax_pose 34, 0x01f4, 0x00ef, 0x0c00
+ax_pose 35, 0x01ec, 0x00ef, 0x0c01
+ax_pose 36, 0x01ec, 0x00ff, 0x0c02
+ax_pose 50, 0x01e5, 0x80f0, 0x0c03
+ax_pose_terminator
+sCroconawPose78:
+ax_pose 50, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose79:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose80:
+ax_pose 51, 0x81e6, 0x40f7, 0x0c00
+ax_pose 52, 0x81e6, 0x80ff, 0x0c04
+ax_pose_terminator
+sCroconawPose81:
+ax_pose 29, 0x81ef, 0x00f1, 0x0c00
+ax_pose 30, 0x01e7, 0x00f1, 0x0c02
+ax_pose 31, 0x01e7, 0x00f9, 0x0c03
+ax_pose 53, 0x41ec, 0x40ef, 0x0c04
+ax_pose 54, 0x41f4, 0x80ef, 0x0c08
+ax_pose_terminator
+sCroconawPose82:
+ax_pose 53, 0x41ec, 0x40ef, 0x0c00
+ax_pose 54, 0x41f4, 0x80ef, 0x0c04
+ax_pose_terminator
+sCroconawPose83:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose84:
+ax_pose 55, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose85:
+ax_pose 56, 0x41eb, 0x40f1, 0x0c00
+ax_pose 57, 0x41f3, 0x80f1, 0x0c04
+ax_pose_terminator
+sCroconawPose86:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose87:
+ax_pose 58, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose88:
+ax_pose 59, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose89:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose90:
+ax_pose 60, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose91:
+ax_pose 61, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose92:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose93:
+ax_pose 62, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose94:
+ax_pose 63, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sCroconawPose95:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose96:
+ax_pose 64, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose97:
+ax_pose 65, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose98:
+ax_pose 15, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose99:
+ax_pose 66, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sCroconawPose100:
+ax_pose 67, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose101:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose102:
+ax_pose 68, 0x01e4, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose103:
+ax_pose 69, 0x01e4, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose104:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose105:
+ax_pose 70, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose106:
+ax_pose 71, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose107:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose108:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose109:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose110:
+ax_pose 15, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose111:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose112:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose113:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose114:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose115:
+ax_pose 72, 0x01ec, 0x80f6, 0x0c00
+ax_pose_terminator
+sCroconawPose116:
+ax_pose 73, 0x01ec, 0x80f6, 0x0c00
+ax_pose_terminator
+sCroconawPose117:
+ax_pose 74, 0x01e1, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose118:
+ax_pose 75, 0x01e2, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose119:
+ax_pose 76, 0x01e1, 0x80ec, 0x0c00
+ax_pose_terminator
+sCroconawPose120:
+ax_pose 77, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose121:
+ax_pose 78, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose122:
+ax_pose 79, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose123:
+ax_pose 80, 0x01e1, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose124:
+ax_pose 81, 0x01e2, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose125:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose126:
+ax_pose 24, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose127:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose128:
+ax_pose 28, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose129:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose130:
+ax_pose 33, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose131:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose132:
+ax_pose 38, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose133:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose134:
+ax_pose 43, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose135:
+ax_pose 15, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose136:
+ax_pose 47, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose137:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose138:
+ax_pose 49, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose139:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose140:
+ax_pose 51, 0x81e7, 0x40f6, 0x0c00
+ax_pose 52, 0x81e7, 0x80fe, 0x0c04
+ax_pose_terminator
+sCroconawPose141:
+ax_pose 56, 0x41eb, 0x40f1, 0x0c00
+ax_pose 57, 0x41f3, 0x80f1, 0x0c04
+ax_pose_terminator
+sCroconawPose142:
+ax_pose 71, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose143:
+ax_pose 69, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose144:
+ax_pose 67, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose145:
+ax_pose 65, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose146:
+ax_pose 63, 0x01e6, 0x80ef, 0x0c00
+ax_pose_terminator
+sCroconawPose147:
+ax_pose 61, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose148:
+ax_pose 59, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose149:
+ax_pose 55, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose150:
+ax_pose 58, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sCroconawPose151:
+ax_pose 60, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose152:
+ax_pose 62, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose153:
+ax_pose 64, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose154:
+ax_pose 66, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sCroconawPose155:
+ax_pose 68, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose156:
+ax_pose 70, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose157:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose158:
+ax_pose 55, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose159:
+ax_pose 56, 0x41eb, 0x40f1, 0x0c00
+ax_pose 57, 0x41f3, 0x80f1, 0x0c04
+ax_pose_terminator
+sCroconawPose160:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose161:
+ax_pose 58, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose162:
+ax_pose 59, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose163:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose164:
+ax_pose 60, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose165:
+ax_pose 61, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sCroconawPose166:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose167:
+ax_pose 62, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose168:
+ax_pose 63, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose169:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose170:
+ax_pose 64, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose171:
+ax_pose 65, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose172:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sCroconawPose173:
+ax_pose 66, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose174:
+ax_pose 67, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sCroconawPose175:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose176:
+ax_pose 68, 0x01e4, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose177:
+ax_pose 69, 0x01e4, 0x80ee, 0x0c00
+ax_pose_terminator
+sCroconawPose178:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose179:
+ax_pose 70, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose180:
+ax_pose 71, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose181:
+ax_pose 56, 0x41eb, 0x40f1, 0x0c00
+ax_pose 57, 0x41f3, 0x80f1, 0x0c04
+ax_pose_terminator
+sCroconawPose182:
+ax_pose 71, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose183:
+ax_pose 69, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose184:
+ax_pose 67, 0x01e6, 0x80ef, 0x0c00
+ax_pose_terminator
+sCroconawPose185:
+ax_pose 65, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose186:
+ax_pose 63, 0x01e6, 0x80ef, 0x0c00
+ax_pose_terminator
+sCroconawPose187:
+ax_pose 61, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose188:
+ax_pose 59, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose189:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose190:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose191:
+ax_pose 18, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose192:
+ax_pose 15, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sCroconawPose193:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sCroconawPose194:
+ax_pose 9, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sCroconawPose195:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sCroconawPose196:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+.align 2
+sCroconawAnims_1_1:
+ax_anim 12, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 12, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_1_2:
+ax_anim 12, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 12, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_1_3:
+ax_anim 12, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 12, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_1_4:
+ax_anim 12, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 12, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_1_5:
+ax_anim 12, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 12, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_1_6:
+ax_anim 12, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 12, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_1_7:
+ax_anim 12, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 12, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_1_8:
+ax_anim 12, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 12, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCroconawAnims_2_1:
+ax_anim 2, 0, 45, 0, -2, 0, -2,
+ax_anim 4, 0, 45, 1, -3, 1, -3,
+ax_anim 1, 0, 47, 0, 1, 0, 1,
+ax_anim 1, 2, 26, 0, 6, 0, 6,
+ax_anim 1, 0, 29, 0, 10, 0, 10,
+ax_anim 2, 0, 29, 0, 23, 0, 23,
+ax_anim 2, 1, 29, 1, 23, 1, 23,
+ax_anim 2, 0, 29, 0, 23, 0, 23,
+ax_anim 2, 0, 29, 1, 23, 1, 23,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim 2, 0, 26, 0, 3, 0, 3,
+ax_anim_terminator
+sCroconawAnims_2_2:
+ax_anim 2, 0, 24, -2, -2, -2, -2,
+ax_anim 4, 0, 24, -3, -3, -3, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 32, 10, 12, 10, 12,
+ax_anim 2, 0, 32, 19, 23, 19, 23,
+ax_anim 2, 1, 32, 20, 22, 20, 22,
+ax_anim 2, 0, 32, 19, 23, 19, 23,
+ax_anim 2, 0, 32, 20, 22, 20, 22,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim 2, 0, 29, 3, 3, 3, 3,
+ax_anim_terminator
+sCroconawAnims_2_3:
+ax_anim 2, 0, 27, -2, 0, -1, 0,
+ax_anim 4, 0, 27, -3, 0, -2, 0,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim_terminator
+sCroconawAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 4, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 32, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 4, -5, 4, -5,
+ax_anim 1, 0, 38, 10, -11, 10, -11,
+ax_anim 2, 0, 38, 18, -18, 18, -18,
+ax_anim 2, 1, 38, 19, -17, 19, -17,
+ax_anim 2, 0, 38, 18, -18, 18, -18,
+ax_anim 2, 0, 38, 19, -17, 19, -17,
+ax_anim 2, 0, 35, 6, -6, 6, -6,
+ax_anim 2, 0, 35, 3, -3, 3, -3,
+ax_anim_terminator
+sCroconawAnims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 4, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 41, 0, -11, 0, -11,
+ax_anim 2, 0, 41, 0, -16, 0, -16,
+ax_anim 2, 1, 41, 1, -16, 1, -16,
+ax_anim 2, 0, 41, 0, -16, 0, -16,
+ax_anim 2, 0, 41, 1, -16, 1, -16,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim 2, 0, 38, 0, -3, 0, -3,
+ax_anim_terminator
+sCroconawAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 4, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -4, -5, -4, -5,
+ax_anim 1, 0, 44, -10, -11, -10, -11,
+ax_anim 2, 0, 44, -18, -17, -18, -17,
+ax_anim 2, 1, 44, -19, -16, -19, -16,
+ax_anim 2, 0, 44, -18, -17, -18, -17,
+ax_anim 2, 0, 44, -19, -16, -19, -16,
+ax_anim 2, 0, 41, -6, -6, -6, -6,
+ax_anim 2, 0, 41, -3, -3, -3, -3,
+ax_anim_terminator
+sCroconawAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 4, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 47, -10, 0, -10, 0,
+ax_anim 2, 0, 47, -18, 0, -18, 0,
+ax_anim 2, 1, 47, -18, 1, -18, 1,
+ax_anim 2, 0, 47, -18, 0, -18, 0,
+ax_anim 2, 0, 47, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -6, 0, -6, 0,
+ax_anim 2, 0, 44, -3, 0, -3, 0,
+ax_anim_terminator
+sCroconawAnims_2_8:
+ax_anim 2, 0, 42, 1, -1, 1, -1,
+ax_anim 4, 0, 42, 2, -2, 2, -2,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 26, -10, 12, -10, 12,
+ax_anim 2, 0, 26, -19, 23, -19, 23,
+ax_anim 2, 1, 26, -20, 22, -20, 22,
+ax_anim 2, 0, 26, -19, 23, -19, 23,
+ax_anim 2, 0, 26, -20, 22, -20, 22,
+ax_anim 2, 0, 47, -6, 6, -6, 6,
+ax_anim 2, 0, 47, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sCroconawAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 4, 0, 79, 0, -3, 0, -3,
+ax_anim 1, 0, 79, -1, 6, -1, 6,
+ax_anim 2, 2, 50, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 1, 19, 1, 19,
+ax_anim 2, 1, 51, 0, 19, 0, 19,
+ax_anim 2, 0, 51, 1, 19, 1, 19,
+ax_anim 2, 0, 51, 0, 19, 0, 19,
+ax_anim 2, 0, 51, 1, 19, 1, 19,
+ax_anim 2, 0, 51, 0, 19, 0, 19,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sCroconawAnims_3_2:
+ax_anim 2, 0, 54, -2, -2, -2, -2,
+ax_anim 4, 0, 58, -3, -3, -3, -3,
+ax_anim 1, 0, 58, 7, 8, 7, 8,
+ax_anim 2, 2, 55, 14, 20, 14, 20,
+ax_anim 2, 0, 52, 18, 21, 18, 21,
+ax_anim 2, 1, 52, 17, 22, 17, 22,
+ax_anim 2, 0, 52, 18, 21, 18, 21,
+ax_anim 2, 0, 52, 17, 22, 17, 22,
+ax_anim 2, 0, 52, 18, 21, 18, 21,
+ax_anim 2, 0, 52, 17, 22, 17, 22,
+ax_anim 2, 0, 53, 9, 13, 9, 13,
+ax_anim 2, 0, 53, 3, 5, 3, 5,
+ax_anim_terminator
+sCroconawAnims_3_3:
+ax_anim 2, 0, 58, -2, 0, -2, 0,
+ax_anim 4, 0, 62, -3, 0, -3, 0,
+ax_anim 1, 0, 62, 7, -1, 7, -1,
+ax_anim 2, 2, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 1, 56, 18, 2, 18, 2,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 2, 18, 2,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 2, 18, 2,
+ax_anim 2, 0, 57, 9, 0, 9, 0,
+ax_anim 2, 0, 57, 3, 0, 3, 0,
+ax_anim_terminator
+sCroconawAnims_3_4:
+ax_anim 2, 0, 62, -2, 2, -2, 2,
+ax_anim 4, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 0, 69, 7, -5, 7, -5,
+ax_anim 2, 2, 63, 18, -14, 18, -14,
+ax_anim 2, 0, 60, 20, -15, 20, -15,
+ax_anim 2, 1, 60, 21, -14, 21, -14,
+ax_anim 2, 0, 60, 20, -15, 20, -15,
+ax_anim 2, 0, 60, 21, -14, 21, -14,
+ax_anim 2, 0, 60, 20, -15, 20, -15,
+ax_anim 2, 0, 60, 21, -14, 21, -14,
+ax_anim 2, 0, 61, 10, -7, 10, -7,
+ax_anim 2, 0, 61, 4, -2, 4, -2,
+ax_anim_terminator
+sCroconawAnims_3_5:
+ax_anim 2, 0, 66, 0, 2, 0, 2,
+ax_anim 4, 0, 66, 0, 3, 0, 3,
+ax_anim 1, 0, 66, 1, -5, 1, -5,
+ax_anim 2, 2, 67, 0, -14, 0, -14,
+ax_anim 2, 0, 73, 0, -16, 0, -16,
+ax_anim 2, 1, 73, -1, -16, -1, -16,
+ax_anim 2, 0, 73, 0, -16, 0, -16,
+ax_anim 2, 0, 73, -1, -16, -1, -16,
+ax_anim 2, 0, 73, 0, -16, 0, -16,
+ax_anim 2, 0, 73, -1, -16, -1, -16,
+ax_anim 2, 0, 65, 0, -7, 0, -7,
+ax_anim 2, 0, 65, 0, -2, 0, -2,
+ax_anim_terminator
+sCroconawAnims_3_6:
+ax_anim 2, 0, 71, 2, 2, 2, 2,
+ax_anim 4, 0, 66, 3, 3, 3, 3,
+ax_anim 1, 0, 66, -7, -5, -7, -5,
+ax_anim 2, 2, 72, -18, -14, -18, -14,
+ax_anim 2, 0, 77, -20, -15, -20, -15,
+ax_anim 2, 1, 77, -21, -14, -21, -14,
+ax_anim 2, 0, 77, -20, -15, -20, -15,
+ax_anim 2, 0, 77, -21, -14, -21, -14,
+ax_anim 2, 0, 77, -20, -15, -20, -15,
+ax_anim 2, 0, 77, -21, -14, -21, -14,
+ax_anim 2, 0, 70, -10, -7, -10, -7,
+ax_anim 2, 0, 70, -4, -2, -4, -2,
+ax_anim_terminator
+sCroconawAnims_3_7:
+ax_anim 2, 0, 75, 2, 0, 2, 0,
+ax_anim 4, 0, 71, 3, 0, 3, 0,
+ax_anim 1, 0, 71, -7, -1, -7, -1,
+ax_anim 2, 2, 76, -14, 0, -14, 0,
+ax_anim 2, 0, 81, -18, 1, -18, 1,
+ax_anim 2, 1, 81, -18, 2, -18, 2,
+ax_anim 2, 0, 81, -18, 1, -18, 1,
+ax_anim 2, 0, 81, -18, 2, -18, 2,
+ax_anim 2, 0, 81, -18, 1, -18, 1,
+ax_anim 2, 0, 81, -18, 2, -18, 2,
+ax_anim 2, 0, 74, -9, 0, -9, 0,
+ax_anim 2, 0, 74, -3, 0, -3, 0,
+ax_anim_terminator
+sCroconawAnims_3_8:
+ax_anim 2, 0, 79, 2, -2, 2, -2,
+ax_anim 4, 0, 75, 3, -3, 3, -3,
+ax_anim 1, 0, 75, -7, 8, -7, 8,
+ax_anim 2, 2, 80, -14, 20, -14, 20,
+ax_anim 2, 0, 51, -18, 21, -18, 21,
+ax_anim 2, 1, 51, -17, 22, -17, 22,
+ax_anim 2, 0, 51, -18, 21, -18, 21,
+ax_anim 2, 0, 51, -17, 22, -17, 22,
+ax_anim 2, 0, 51, -18, 21, -18, 21,
+ax_anim 2, 0, 51, -17, 22, -17, 22,
+ax_anim 2, 0, 78, -9, 13, -9, 13,
+ax_anim 2, 0, 78, -3, 5, -3, 5,
+ax_anim_terminator
+.align 2
+sCroconawAnims_4_1:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, -2, 0, -2,
+ax_anim 6, 2, 83, 0, -3, 0, -2,
+ax_anim 1, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 1, 84, 1, 5, 1, 5,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, 1, 5, 1, 5,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, 1, 5, 1, 5,
+ax_anim 2, 0, 82, 0, 2, 0, 2,
+ax_anim_terminator
+sCroconawAnims_4_2:
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 86, -2, -2, -2, -2,
+ax_anim 6, 2, 86, -3, -3, -3, -3,
+ax_anim 1, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, 5, 5, 5, 5,
+ax_anim 2, 1, 87, 6, 4, 6, 4,
+ax_anim 2, 0, 87, 5, 5, 5, 5,
+ax_anim 2, 0, 87, 6, 4, 6, 4,
+ax_anim 2, 0, 87, 5, 5, 5, 5,
+ax_anim 2, 0, 87, 6, 4, 6, 4,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim_terminator
+sCroconawAnims_4_3:
+ax_anim 2, 0, 88, -1, 0, -1, 0,
+ax_anim 2, 0, 89, -2, 0, -2, 0,
+ax_anim 6, 2, 89, -3, 0, -3, 0,
+ax_anim 1, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 90, 5, 0, 5, 0,
+ax_anim 2, 1, 90, 5, 1, 5, 1,
+ax_anim 2, 0, 90, 5, 0, 5, 0,
+ax_anim 2, 0, 90, 5, 1, 5, 1,
+ax_anim 2, 0, 90, 5, 0, 5, 0,
+ax_anim 2, 0, 90, 5, 1, 5, 1,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim_terminator
+sCroconawAnims_4_4:
+ax_anim 2, 0, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 92, -2, 2, -2, 2,
+ax_anim 6, 2, 92, -3, 3, -3, 3,
+ax_anim 1, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 0, 93, 5, -5, 5, -5,
+ax_anim 2, 1, 93, 6, -4, 6, -4,
+ax_anim 2, 0, 93, 5, -5, 5, -5,
+ax_anim 2, 0, 93, 6, -4, 6, -4,
+ax_anim 2, 0, 93, 5, -5, 5, -5,
+ax_anim 2, 0, 93, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim_terminator
+sCroconawAnims_4_5:
+ax_anim 2, 0, 94, 0, 1, 0, 1,
+ax_anim 2, 0, 95, 0, 2, 0, 2,
+ax_anim 6, 2, 95, 0, 3, 0, 3,
+ax_anim 1, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 0, 96, 0, -5, 0, -5,
+ax_anim 2, 1, 96, 1, -5, 1, -5,
+ax_anim 2, 0, 96, 0, -5, 0, -5,
+ax_anim 2, 0, 96, 1, -5, 1, -5,
+ax_anim 2, 0, 96, 0, -5, 0, -5,
+ax_anim 2, 0, 96, 1, -5, 1, -5,
+ax_anim 2, 0, 94, 0, -2, 0, -2,
+ax_anim_terminator
+sCroconawAnims_4_6:
+ax_anim 2, 0, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 98, 2, 2, 2, 2,
+ax_anim 6, 2, 98, 3, 3, 3, 3,
+ax_anim 1, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, -5, -5, -5, -5,
+ax_anim 2, 1, 99, -6, -4, -6, -4,
+ax_anim 2, 0, 99, -5, -5, -5, -5,
+ax_anim 2, 0, 99, -6, -4, -6, -4,
+ax_anim 2, 0, 99, -5, -5, -5, -5,
+ax_anim 2, 0, 99, -6, -4, -6, -4,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim_terminator
+sCroconawAnims_4_7:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 6, 2, 101, 3, 0, 3, 0,
+ax_anim 1, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 0, 102, -5, 0, -5, 0,
+ax_anim 2, 1, 102, -5, 1, -5, 1,
+ax_anim 2, 0, 102, -5, 0, -5, 0,
+ax_anim 2, 0, 102, -5, 1, -5, 1,
+ax_anim 2, 0, 102, -5, 0, -5, 0,
+ax_anim 2, 0, 102, -5, 1, -5, 1,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim_terminator
+sCroconawAnims_4_8:
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 104, 2, -2, 2, -2,
+ax_anim 6, 2, 104, 3, -3, 3, -3,
+ax_anim 1, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 105, -5, 5, -5, 5,
+ax_anim 2, 1, 105, -6, 4, -6, 4,
+ax_anim 2, 0, 105, -5, 5, -5, 5,
+ax_anim 2, 0, 105, -6, 4, -6, 4,
+ax_anim 2, 0, 105, -5, 5, -5, 5,
+ax_anim 2, 0, 105, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCroconawAnims_5_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_5_2:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_5_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_5_4:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_5_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_5_6:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_5_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_5_8:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCroconawAnims_6_1:
+ax_anim 30, 0, 114, 0, 0, 0, 0,
+ax_anim 35, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCroconawAnims_7_1:
+ax_anim 2, 0, 116, 0, -4, 0, -4,
+ax_anim 8, 0, 116, 0, -5, 0, -5,
+ax_anim_terminator
+sCroconawAnims_7_2:
+ax_anim 2, 0, 117, -4, -4, -4, -4,
+ax_anim 8, 0, 117, -5, -5, -5, -5,
+ax_anim_terminator
+sCroconawAnims_7_3:
+ax_anim 2, 0, 118, -4, 0, -4, 0,
+ax_anim 8, 0, 118, -5, 0, -5, 0,
+ax_anim_terminator
+sCroconawAnims_7_4:
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 8, 0, 119, -5, 5, -5, 5,
+ax_anim_terminator
+sCroconawAnims_7_5:
+ax_anim 2, 0, 120, 0, 4, 0, 4,
+ax_anim 8, 0, 120, 0, 5, 0, 5,
+ax_anim_terminator
+sCroconawAnims_7_6:
+ax_anim 2, 0, 121, 4, 4, 4, 4,
+ax_anim 8, 0, 121, 5, 5, 5, 5,
+ax_anim_terminator
+sCroconawAnims_7_7:
+ax_anim 2, 0, 122, 4, 0, 4, 0,
+ax_anim 8, 0, 122, 5, 0, 5, 0,
+ax_anim_terminator
+sCroconawAnims_7_8:
+ax_anim 2, 0, 123, 4, -4, 4, -4,
+ax_anim 8, 0, 123, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sCroconawAnims_8_1:
+ax_anim 40, 0, 124, 0, 0, 0, 0,
+ax_anim 25, 0, 125, 0, -2, 0, -2,
+ax_anim_terminator
+sCroconawAnims_8_2:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 25, 0, 127, -2, -2, -2, -2,
+ax_anim_terminator
+sCroconawAnims_8_3:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 25, 0, 129, -2, 0, -2, 0,
+ax_anim_terminator
+sCroconawAnims_8_4:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 25, 0, 131, -1, 1, -1, 1,
+ax_anim_terminator
+sCroconawAnims_8_5:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 25, 0, 133, -1, 1, -1, 1,
+ax_anim_terminator
+sCroconawAnims_8_6:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 25, 0, 135, 1, 1, 1, 1,
+ax_anim_terminator
+sCroconawAnims_8_7:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 25, 0, 137, 2, 0, 2, 0,
+ax_anim_terminator
+sCroconawAnims_8_8:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 25, 0, 139, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sCroconawAnims_9_1:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 7, 4, 7, 4,
+ax_anim 2, 0, 142, 10, 10, 10, 10,
+ax_anim 2, 0, 143, 9, 16, 9, 16,
+ax_anim 3, 0, 144, 0, 20, 0, 20,
+ax_anim 2, 3, 145, -9, 16, -9, 16,
+ax_anim 2, 0, 146, -10, 10, -10, 10,
+ax_anim 1, 0, 147, -7, 4, -7, 4,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_9_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 8, 0, 8, 0,
+ax_anim 2, 0, 141, 16, 4, 16, 4,
+ax_anim 2, 0, 142, 22, 12, 22, 12,
+ax_anim 3, 0, 143, 22, 20, 22, 20,
+ax_anim 2, 3, 144, 10, 20, 10, 20,
+ax_anim 2, 0, 145, 3, 15, 3, 15,
+ax_anim 1, 0, 146, -1, 7, -1, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_9_3:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 3, -5, 3, -5,
+ax_anim 2, 0, 140, 11, -6, 11, -6,
+ax_anim 2, 0, 141, 17, -5, 17, -5,
+ax_anim 3, 0, 142, 22, 0, 22, 0,
+ax_anim 2, 3, 143, 18, 5, 18, 5,
+ax_anim 2, 0, 144, 10, 7, 10, 7,
+ax_anim 1, 0, 145, 4, 5, 4, 5,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_9_4:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -1, -8, -1, -8,
+ax_anim 2, 0, 147, 3, -16, 3, -16,
+ax_anim 2, 0, 140, 12, -21, 12, -21,
+ax_anim 3, 0, 141, 21, -21, 21, -21,
+ax_anim 2, 3, 142, 24, -13, 24, -13,
+ax_anim 2, 0, 143, 20, -4, 20, -4,
+ax_anim 1, 0, 144, 9, 0, 9, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_9_5:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, -8, -3, -8, -3,
+ax_anim 2, 0, 146, -12, -11, -12, -11,
+ax_anim 2, 0, 147, -9, -18, -9, -18,
+ax_anim 3, 0, 140, 0, -21, 0, -21,
+ax_anim 2, 3, 141, 9, -18, 9, -18,
+ax_anim 2, 0, 142, 12, -11, 12, -11,
+ax_anim 1, 0, 143, 8, -3, 8, -3,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_9_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 1, -8, 1, -8,
+ax_anim 2, 0, 141, -3, -16, -3, -16,
+ax_anim 2, 0, 140, -12, -21, -12, -21,
+ax_anim 3, 0, 147, -21, -21, -21, -21,
+ax_anim 2, 3, 146, -24, -13, -24, -13,
+ax_anim 2, 0, 145, -20, -4, -20, -4,
+ax_anim 1, 0, 144, -9, 0, -9, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_9_7:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, -3, -5, -3, -5,
+ax_anim 2, 0, 140, -11, -6, -11, -6,
+ax_anim 2, 0, 147, -17, -5, -17, -5,
+ax_anim 3, 0, 146, -22, 0, -22, 0,
+ax_anim 2, 3, 145, -18, 5, -18, 5,
+ax_anim 2, 0, 144, -10, 7, -10, 7,
+ax_anim 1, 0, 143, -4, 5, -4, 5,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_9_8:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -8, 0, -8, 0,
+ax_anim 2, 0, 147, -16, 4, -16, 4,
+ax_anim 2, 0, 146, -22, 12, -22, 12,
+ax_anim 3, 0, 145, -22, 20, -22, 20,
+ax_anim 2, 3, 144, -10, 20, -10, 20,
+ax_anim 2, 0, 143, -3, 15, -3, 15,
+ax_anim 1, 0, 142, 1, 7, 1, 7,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCroconawAnims_10_1:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 6, 0, 6, 0,
+ax_anim 2, 0, 148, -6, 0, -6, 0,
+ax_anim 2, 0, 148, 10, 0, 10, 0,
+ax_anim 2, 0, 148, -10, 0, -10, 0,
+ax_anim 2, 0, 148, 12, 0, 12, 0,
+ax_anim 3, 0, 148, -12, 0, -12, 0,
+ax_anim 3, 0, 148, 13, 0, 13, 0,
+ax_anim 3, 0, 148, -13, 0, -13, 0,
+ax_anim 2, 0, 148, 12, 0, 12, 0,
+ax_anim 3, 0, 148, -12, 0, -12, 0,
+ax_anim 2, 0, 148, 10, 0, 10, 0,
+ax_anim 2, 0, 148, -10, 0, -10, 0,
+ax_anim 2, 0, 148, 6, 0, 6, 0,
+ax_anim 2, 0, 148, -6, 0, -6, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_10_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 6, -6, 6, -6,
+ax_anim 2, 0, 149, -6, 6, -6, 6,
+ax_anim 2, 0, 149, 10, -10, 10, -10,
+ax_anim 2, 0, 149, -10, 10, -10, 10,
+ax_anim 2, 0, 149, 12, -12, 12, -12,
+ax_anim 3, 0, 149, -12, 12, -12, 12,
+ax_anim 3, 0, 149, 13, -13, 13, -13,
+ax_anim 3, 0, 149, -13, 13, -13, 13,
+ax_anim 2, 0, 149, 12, -12, 12, -12,
+ax_anim 3, 0, 149, -12, 12, -12, 12,
+ax_anim 2, 0, 149, 10, -10, 10, -10,
+ax_anim 2, 0, 149, -10, 10, -10, 10,
+ax_anim 2, 0, 149, 6, -6, 6, -6,
+ax_anim 2, 0, 149, -6, 6, -6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_10_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -6, 0, -6,
+ax_anim 2, 0, 150, 0, 6, 0, 6,
+ax_anim 2, 0, 150, 0, -10, 0, -10,
+ax_anim 2, 0, 150, 0, 10, 0, 10,
+ax_anim 2, 0, 150, 0, -12, 0, -12,
+ax_anim 3, 0, 150, 0, 12, 0, 12,
+ax_anim 3, 0, 150, 0, -13, 0, -13,
+ax_anim 3, 0, 150, 0, 13, 0, 13,
+ax_anim 2, 0, 150, 0, -12, 0, -12,
+ax_anim 3, 0, 150, 0, 12, 0, 12,
+ax_anim 2, 0, 150, 0, -10, 0, -10,
+ax_anim 2, 0, 150, 0, 10, 0, 10,
+ax_anim 2, 0, 150, 0, -6, 0, -6,
+ax_anim 2, 0, 150, 0, 6, 0, 6,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_10_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -6, -6, -6, -6,
+ax_anim 2, 0, 151, 6, 6, 6, 6,
+ax_anim 2, 0, 151, -10, -10, -10, -10,
+ax_anim 2, 0, 151, 10, 10, 10, 10,
+ax_anim 2, 0, 151, -12, -12, -12, -12,
+ax_anim 3, 0, 151, 12, 12, 12, 12,
+ax_anim 3, 0, 151, -13, -13, -13, -13,
+ax_anim 3, 0, 151, 13, 13, 13, 13,
+ax_anim 2, 0, 151, -12, -12, -12, -12,
+ax_anim 3, 0, 151, 12, 12, 12, 12,
+ax_anim 2, 0, 151, -10, -10, -10, -10,
+ax_anim 2, 0, 151, 10, 10, 10, 10,
+ax_anim 2, 0, 151, -6, -6, -6, -6,
+ax_anim 2, 0, 151, 6, 6, 6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_10_5:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 6, 0, 6, 0,
+ax_anim 2, 0, 152, -6, 0, -6, 0,
+ax_anim 2, 0, 152, 10, 0, 10, 0,
+ax_anim 2, 0, 152, -10, 0, -10, 0,
+ax_anim 2, 0, 152, 12, 0, 12, 0,
+ax_anim 3, 0, 152, -12, 0, -12, 0,
+ax_anim 3, 0, 152, 13, 0, 13, 0,
+ax_anim 3, 0, 152, -13, 0, -13, 0,
+ax_anim 2, 0, 152, 12, 0, 12, 0,
+ax_anim 3, 0, 152, -12, 0, -12, 0,
+ax_anim 2, 0, 152, 10, 0, 10, 0,
+ax_anim 2, 0, 152, -10, 0, -10, 0,
+ax_anim 2, 0, 152, 6, 0, 6, 0,
+ax_anim 2, 0, 152, -6, 0, -6, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_10_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 6, -6, 6, -6,
+ax_anim 2, 0, 153, -6, 6, -6, 6,
+ax_anim 2, 0, 153, 10, -10, 10, -10,
+ax_anim 2, 0, 153, -10, 10, -10, 10,
+ax_anim 2, 0, 153, 12, -12, 12, -12,
+ax_anim 3, 0, 153, -12, 12, -12, 12,
+ax_anim 3, 0, 153, 13, -13, 13, -13,
+ax_anim 3, 0, 153, -13, 13, -13, 13,
+ax_anim 2, 0, 153, 12, -12, 12, -12,
+ax_anim 3, 0, 153, -12, 12, -12, 12,
+ax_anim 2, 0, 153, 10, -10, 10, -10,
+ax_anim 2, 0, 153, -10, 10, -10, 10,
+ax_anim 2, 0, 153, 6, -6, 6, -6,
+ax_anim 2, 0, 153, -6, 6, -6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_10_7:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -6, 0, -6,
+ax_anim 2, 0, 154, 0, 6, 0, 6,
+ax_anim 2, 0, 154, 0, -10, 0, -10,
+ax_anim 2, 0, 154, 0, 10, 0, 10,
+ax_anim 2, 0, 154, 0, -12, 0, -12,
+ax_anim 3, 0, 154, 0, 12, 0, 12,
+ax_anim 3, 0, 154, 0, -13, 0, -13,
+ax_anim 3, 0, 154, 0, 13, 0, 13,
+ax_anim 2, 0, 154, 0, -12, 0, -12,
+ax_anim 3, 0, 154, 0, 12, 0, 12,
+ax_anim 2, 0, 154, 0, -10, 0, -10,
+ax_anim 2, 0, 154, 0, 10, 0, 10,
+ax_anim 2, 0, 154, 0, -6, 0, -6,
+ax_anim 2, 0, 154, 0, 6, 0, 6,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_10_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -6, -6, -6, -6,
+ax_anim 2, 0, 155, 6, 6, 6, 6,
+ax_anim 2, 0, 155, -10, -10, -10, -10,
+ax_anim 2, 0, 155, 10, 10, 10, 10,
+ax_anim 2, 0, 155, -12, -12, -12, -12,
+ax_anim 3, 0, 155, 12, 12, 12, 12,
+ax_anim 3, 0, 155, -13, -13, -13, -13,
+ax_anim 3, 0, 155, 13, 13, 13, 13,
+ax_anim 2, 0, 155, -12, -12, -12, -12,
+ax_anim 3, 0, 155, 12, 12, 12, 12,
+ax_anim 2, 0, 155, -10, -10, -10, -10,
+ax_anim 2, 0, 155, 10, 10, 10, 10,
+ax_anim 2, 0, 155, -6, -6, -6, -6,
+ax_anim 2, 0, 155, 6, 6, 6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCroconawAnims_11_1:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -25, 0, 0,
+ax_anim 3, 0, 158, 0, -24, 0, 0,
+ax_anim 2, 0, 158, 0, -19, 0, 0,
+ax_anim 1, 0, 158, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_11_2:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -25, 0, 0,
+ax_anim 3, 0, 161, 0, -24, 0, 0,
+ax_anim 2, 0, 161, 0, -20, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_11_3:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -24, 0, 0,
+ax_anim 3, 0, 164, 0, -23, 0, 0,
+ax_anim 2, 0, 164, 0, -20, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_11_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -11, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_11_5:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -24, 0, 0,
+ax_anim 3, 0, 170, 0, -23, 0, 0,
+ax_anim 2, 0, 170, 0, -20, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_11_6:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_11_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -24, 0, 0,
+ax_anim 3, 0, 176, 0, -23, 0, 0,
+ax_anim 2, 0, 176, 0, -20, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_11_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -25, 0, 0,
+ax_anim 3, 0, 179, 0, -24, 0, 0,
+ax_anim 2, 0, 179, 0, -20, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCroconawAnims_12_1:
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_12_2:
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_12_3:
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_12_4:
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_12_5:
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_12_6:
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_12_7:
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_12_8:
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCroconawAnims_13_1:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_13_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_13_3:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_13_4:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_13_5:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_13_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_13_7:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawAnims_13_8:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCroconawGfx1:
+.incbin "baserom.gba", 0xBFC750, 0x200
+sCroconawSprites1:
+ax_sprite sCroconawGfx1, 0x200
+ax_sprite_terminator
+sCroconawGfx2:
+.incbin "baserom.gba", 0xBFC960, 0x200
+sCroconawSprites2:
+ax_sprite sCroconawGfx2, 0x200
+ax_sprite_terminator
+sCroconawGfx3:
+.incbin "baserom.gba", 0xBFCB70, 0x200
+sCroconawSprites3:
+ax_sprite sCroconawGfx3, 0x200
+ax_sprite_terminator
+sCroconawGfx4:
+.incbin "baserom.gba", 0xBFCD80, 0x200
+sCroconawSprites4:
+ax_sprite sCroconawGfx4, 0x200
+ax_sprite_terminator
+sCroconawGfx5:
+.incbin "baserom.gba", 0xBFCF90, 0x200
+sCroconawSprites5:
+ax_sprite sCroconawGfx5, 0x200
+ax_sprite_terminator
+sCroconawGfx6:
+.incbin "baserom.gba", 0xBFD1A0, 0x200
+sCroconawSprites6:
+ax_sprite sCroconawGfx6, 0x200
+ax_sprite_terminator
+sCroconawGfx7:
+.incbin "baserom.gba", 0xBFD3B0, 0x200
+sCroconawSprites7:
+ax_sprite sCroconawGfx7, 0x200
+ax_sprite_terminator
+sCroconawGfx8:
+.incbin "baserom.gba", 0xBFD5C0, 0x200
+sCroconawSprites8:
+ax_sprite sCroconawGfx8, 0x200
+ax_sprite_terminator
+sCroconawGfx9:
+.incbin "baserom.gba", 0xBFD7D0, 0x200
+sCroconawSprites9:
+ax_sprite sCroconawGfx9, 0x200
+ax_sprite_terminator
+sCroconawGfx10:
+.incbin "baserom.gba", 0xBFD9E0, 0x200
+sCroconawSprites10:
+ax_sprite sCroconawGfx10, 0x200
+ax_sprite_terminator
+sCroconawGfx11:
+.incbin "baserom.gba", 0xBFDBF0, 0x200
+sCroconawSprites11:
+ax_sprite sCroconawGfx11, 0x200
+ax_sprite_terminator
+sCroconawGfx12:
+.incbin "baserom.gba", 0xBFDE00, 0x200
+sCroconawSprites12:
+ax_sprite sCroconawGfx12, 0x200
+ax_sprite_terminator
+sCroconawGfx13:
+.incbin "baserom.gba", 0xBFE010, 0x200
+sCroconawSprites13:
+ax_sprite sCroconawGfx13, 0x200
+ax_sprite_terminator
+sCroconawGfx14:
+.incbin "baserom.gba", 0xBFE220, 0x200
+sCroconawSprites14:
+ax_sprite sCroconawGfx14, 0x200
+ax_sprite_terminator
+sCroconawGfx15:
+.incbin "baserom.gba", 0xBFE430, 0x200
+sCroconawSprites15:
+ax_sprite sCroconawGfx15, 0x200
+ax_sprite_terminator
+sCroconawGfx16:
+.incbin "baserom.gba", 0xBFE640, 0x200
+sCroconawSprites16:
+ax_sprite sCroconawGfx16, 0x200
+ax_sprite_terminator
+sCroconawGfx17:
+.incbin "baserom.gba", 0xBFE850, 0x200
+sCroconawSprites17:
+ax_sprite sCroconawGfx17, 0x200
+ax_sprite_terminator
+sCroconawGfx18:
+.incbin "baserom.gba", 0xBFEA60, 0x200
+sCroconawSprites18:
+ax_sprite sCroconawGfx18, 0x200
+ax_sprite_terminator
+sCroconawGfx19:
+.incbin "baserom.gba", 0xBFEC70, 0x200
+sCroconawSprites19:
+ax_sprite sCroconawGfx19, 0x200
+ax_sprite_terminator
+sCroconawGfx20:
+.incbin "baserom.gba", 0xBFEE80, 0x200
+sCroconawSprites20:
+ax_sprite sCroconawGfx20, 0x200
+ax_sprite_terminator
+sCroconawGfx21:
+.incbin "baserom.gba", 0xBFF090, 0x200
+sCroconawSprites21:
+ax_sprite sCroconawGfx21, 0x200
+ax_sprite_terminator
+sCroconawGfx22:
+.incbin "baserom.gba", 0xBFF2A0, 0x200
+sCroconawSprites22:
+ax_sprite sCroconawGfx22, 0x200
+ax_sprite_terminator
+sCroconawGfx23:
+.incbin "baserom.gba", 0xBFF4B0, 0x200
+sCroconawSprites23:
+ax_sprite sCroconawGfx23, 0x200
+ax_sprite_terminator
+sCroconawGfx24:
+.incbin "baserom.gba", 0xBFF6C0, 0x200
+sCroconawSprites24:
+ax_sprite sCroconawGfx24, 0x200
+ax_sprite_terminator
+sCroconawGfx25:
+.incbin "baserom.gba", 0xBFF8D0, 0x40
+sCroconawGfx25_1:
+.incbin "baserom.gba", 0xBFF910, 0x180
+sCroconawSprites25:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx25_1, 0x180
+ax_sprite_terminator
+sCroconawGfx26:
+.incbin "baserom.gba", 0xBFFAB8, 0x60
+sCroconawSprites26:
+ax_sprite sCroconawGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx27:
+.incbin "baserom.gba", 0xBFFB30, 0x60
+sCroconawSprites27:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx27, 0x60
+ax_sprite_terminator
+sCroconawGfx28:
+.incbin "baserom.gba", 0xBFFBA8, 0x20
+sCroconawGfx28_1:
+.incbin "baserom.gba", 0xBFFBC8, 0xC0
+sCroconawSprites28:
+ax_sprite sCroconawGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx28_1, 0xc0
+ax_sprite_terminator
+sCroconawGfx29:
+.incbin "baserom.gba", 0xBFFCA8, 0x40
+sCroconawGfx29_1:
+.incbin "baserom.gba", 0xBFFCE8, 0x60
+sCroconawGfx29_2:
+.incbin "baserom.gba", 0xBFFD48, 0x60
+sCroconawGfx29_3:
+.incbin "baserom.gba", 0xBFFDA8, 0x40
+sCroconawSprites29:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx29_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCroconawGfx30:
+.incbin "baserom.gba", 0xBFFE38, 0x40
+sCroconawSprites30:
+ax_sprite sCroconawGfx30, 0x40
+ax_sprite_terminator
+sCroconawGfx31:
+.incbin "baserom.gba", 0xBFFE88, 0x20
+sCroconawSprites31:
+ax_sprite sCroconawGfx31, 0x20
+ax_sprite_terminator
+sCroconawGfx32:
+.incbin "baserom.gba", 0xBFFEB8, 0x20
+sCroconawSprites32:
+ax_sprite sCroconawGfx32, 0x20
+ax_sprite_terminator
+sCroconawGfx33:
+.incbin "baserom.gba", 0xBFFEE8, 0x40
+sCroconawGfx33_1:
+.incbin "baserom.gba", 0xBFFF28, 0x60
+sCroconawGfx33_2:
+.incbin "baserom.gba", 0xBFFF88, 0xE0
+sCroconawSprites33:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx33_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx34:
+.incbin "baserom.gba", 0xC000A8, 0x40
+sCroconawGfx34_1:
+.incbin "baserom.gba", 0xC000E8, 0x60
+sCroconawGfx34_2:
+.incbin "baserom.gba", 0xC00148, 0x60
+sCroconawGfx34_3:
+.incbin "baserom.gba", 0xC001A8, 0x60
+sCroconawSprites34:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx35:
+.incbin "baserom.gba", 0xC00258, 0x20
+sCroconawSprites35:
+ax_sprite sCroconawGfx35, 0x20
+ax_sprite_terminator
+sCroconawGfx36:
+.incbin "baserom.gba", 0xC00288, 0x20
+sCroconawSprites36:
+ax_sprite sCroconawGfx36, 0x20
+ax_sprite_terminator
+sCroconawGfx37:
+.incbin "baserom.gba", 0xC002B8, 0x20
+sCroconawSprites37:
+ax_sprite sCroconawGfx37, 0x20
+ax_sprite_terminator
+sCroconawGfx38:
+.incbin "baserom.gba", 0xC002E8, 0x140
+sCroconawGfx38_1:
+.incbin "baserom.gba", 0xC00428, 0x40
+sCroconawSprites38:
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx38, 0x140
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx38_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx39:
+.incbin "baserom.gba", 0xC00498, 0x40
+sCroconawGfx39_1:
+.incbin "baserom.gba", 0xC004D8, 0x180
+sCroconawSprites39:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx39_1, 0x180
+ax_sprite_terminator
+sCroconawGfx40:
+.incbin "baserom.gba", 0xC00680, 0x40
+sCroconawSprites40:
+ax_sprite sCroconawGfx40, 0x40
+ax_sprite_terminator
+sCroconawGfx41:
+.incbin "baserom.gba", 0xC006D0, 0x20
+sCroconawSprites41:
+ax_sprite sCroconawGfx41, 0x20
+ax_sprite_terminator
+sCroconawGfx42:
+.incbin "baserom.gba", 0xC00700, 0x20
+sCroconawSprites42:
+ax_sprite sCroconawGfx42, 0x20
+ax_sprite_terminator
+sCroconawGfx43:
+.incbin "baserom.gba", 0xC00730, 0x40
+sCroconawGfx43_1:
+.incbin "baserom.gba", 0xC00770, 0xE0
+sCroconawGfx43_2:
+.incbin "baserom.gba", 0xC00850, 0x60
+sCroconawSprites43:
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx43_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx43_2, 0x60
+ax_sprite_terminator
+sCroconawGfx44:
+.incbin "baserom.gba", 0xC008E8, 0x40
+sCroconawGfx44_1:
+.incbin "baserom.gba", 0xC00928, 0x60
+sCroconawGfx44_2:
+.incbin "baserom.gba", 0xC00988, 0x60
+sCroconawGfx44_3:
+.incbin "baserom.gba", 0xC009E8, 0x60
+sCroconawSprites44:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx44_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx45:
+.incbin "baserom.gba", 0xC00A98, 0x60
+sCroconawSprites45:
+ax_sprite sCroconawGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx46:
+.incbin "baserom.gba", 0xC00B10, 0x100
+sCroconawSprites46:
+ax_sprite sCroconawGfx46, 0x100
+ax_sprite_terminator
+sCroconawGfx47:
+.incbin "baserom.gba", 0xC00C20, 0x80
+sCroconawSprites47:
+ax_sprite sCroconawGfx47, 0x80
+ax_sprite_terminator
+sCroconawGfx48:
+.incbin "baserom.gba", 0xC00CB0, 0x40
+sCroconawGfx48_1:
+.incbin "baserom.gba", 0xC00CF0, 0x180
+sCroconawSprites48:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx48_1, 0x180
+ax_sprite_terminator
+sCroconawGfx49:
+.incbin "baserom.gba", 0xC00E98, 0x40
+sCroconawGfx49_1:
+.incbin "baserom.gba", 0xC00ED8, 0x60
+sCroconawGfx49_2:
+.incbin "baserom.gba", 0xC00F38, 0xE0
+sCroconawSprites49:
+ax_sprite sCroconawGfx49, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx49_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx50:
+.incbin "baserom.gba", 0xC01050, 0x40
+sCroconawGfx50_1:
+.incbin "baserom.gba", 0xC01090, 0x60
+sCroconawGfx50_2:
+.incbin "baserom.gba", 0xC010F0, 0x60
+sCroconawGfx50_3:
+.incbin "baserom.gba", 0xC01150, 0x60
+sCroconawSprites50:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx50, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx50_3, 0x60
+ax_sprite_terminator
+sCroconawGfx51:
+.incbin "baserom.gba", 0xC011F8, 0x40
+sCroconawGfx51_1:
+.incbin "baserom.gba", 0xC01238, 0x100
+sCroconawGfx51_2:
+.incbin "baserom.gba", 0xC01338, 0x40
+sCroconawSprites51:
+ax_sprite sCroconawGfx51, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx51_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx51_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx52:
+.incbin "baserom.gba", 0xC013B0, 0x60
+sCroconawSprites52:
+ax_sprite sCroconawGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx53:
+.incbin "baserom.gba", 0xC01428, 0x20
+sCroconawGfx53_1:
+.incbin "baserom.gba", 0xC01448, 0xC0
+sCroconawSprites53:
+ax_sprite sCroconawGfx53, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx53_1, 0xc0
+ax_sprite_terminator
+sCroconawGfx54:
+.incbin "baserom.gba", 0xC01528, 0x60
+sCroconawSprites54:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx54, 0x60
+ax_sprite_terminator
+sCroconawGfx55:
+.incbin "baserom.gba", 0xC015A0, 0x100
+sCroconawSprites55:
+ax_sprite sCroconawGfx55, 0x100
+ax_sprite_terminator
+sCroconawGfx56:
+.incbin "baserom.gba", 0xC016B0, 0x40
+sCroconawGfx56_1:
+.incbin "baserom.gba", 0xC016F0, 0x160
+sCroconawSprites56:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx56_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx57:
+.incbin "baserom.gba", 0xC01880, 0x80
+sCroconawSprites57:
+ax_sprite sCroconawGfx57, 0x80
+ax_sprite_terminator
+sCroconawGfx58:
+.incbin "baserom.gba", 0xC01910, 0x100
+sCroconawSprites58:
+ax_sprite sCroconawGfx58, 0x100
+ax_sprite_terminator
+sCroconawGfx59:
+.incbin "baserom.gba", 0xC01A20, 0x40
+sCroconawGfx59_1:
+.incbin "baserom.gba", 0xC01A60, 0xE0
+sCroconawGfx59_2:
+.incbin "baserom.gba", 0xC01B40, 0x60
+sCroconawSprites59:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx59_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx59_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx60:
+.incbin "baserom.gba", 0xC01BE0, 0x20
+sCroconawGfx60_1:
+.incbin "baserom.gba", 0xC01C00, 0x160
+sCroconawSprites60:
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx60, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx60_1, 0x160
+ax_sprite_terminator
+sCroconawGfx61:
+.incbin "baserom.gba", 0xC01D88, 0x40
+sCroconawGfx61_1:
+.incbin "baserom.gba", 0xC01DC8, 0x40
+sCroconawGfx61_2:
+.incbin "baserom.gba", 0xC01E08, 0x60
+sCroconawGfx61_3:
+.incbin "baserom.gba", 0xC01E68, 0x60
+sCroconawSprites61:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx61, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx61_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx61_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx61_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx62:
+.incbin "baserom.gba", 0xC01F18, 0x40
+sCroconawGfx62_1:
+.incbin "baserom.gba", 0xC01F58, 0x140
+sCroconawSprites62:
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx62, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx62_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx63:
+.incbin "baserom.gba", 0xC020C8, 0x40
+sCroconawGfx63_1:
+.incbin "baserom.gba", 0xC02108, 0x40
+sCroconawGfx63_2:
+.incbin "baserom.gba", 0xC02148, 0x40
+sCroconawGfx63_3:
+.incbin "baserom.gba", 0xC02188, 0x60
+sCroconawSprites63:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx63, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx63_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx63_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx63_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCroconawGfx64:
+.incbin "baserom.gba", 0xC02238, 0x60
+sCroconawGfx64_1:
+.incbin "baserom.gba", 0xC02298, 0x160
+sCroconawSprites64:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx64_1, 0x160
+ax_sprite_terminator
+sCroconawGfx65:
+.incbin "baserom.gba", 0xC02420, 0x40
+sCroconawGfx65_1:
+.incbin "baserom.gba", 0xC02460, 0x180
+sCroconawSprites65:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx65, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx65_1, 0x180
+ax_sprite_terminator
+sCroconawGfx66:
+.incbin "baserom.gba", 0xC02608, 0x40
+sCroconawGfx66_1:
+.incbin "baserom.gba", 0xC02648, 0x180
+sCroconawSprites66:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx66, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx66_1, 0x180
+ax_sprite_terminator
+sCroconawGfx67:
+.incbin "baserom.gba", 0xC027F0, 0x40
+sCroconawGfx67_1:
+.incbin "baserom.gba", 0xC02830, 0x40
+sCroconawGfx67_2:
+.incbin "baserom.gba", 0xC02870, 0x40
+sCroconawGfx67_3:
+.incbin "baserom.gba", 0xC028B0, 0x60
+sCroconawSprites67:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx67, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx67_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx67_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx67_3, 0x60
+ax_sprite_terminator
+sCroconawGfx68:
+.incbin "baserom.gba", 0xC02958, 0x60
+sCroconawGfx68_1:
+.incbin "baserom.gba", 0xC029B8, 0x60
+sCroconawGfx68_2:
+.incbin "baserom.gba", 0xC02A18, 0x100
+sCroconawSprites68:
+ax_sprite sCroconawGfx68, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx68_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx68_2, 0x100
+ax_sprite_terminator
+sCroconawGfx69:
+.incbin "baserom.gba", 0xC02B48, 0x40
+sCroconawGfx69_1:
+.incbin "baserom.gba", 0xC02B88, 0x40
+sCroconawGfx69_2:
+.incbin "baserom.gba", 0xC02BC8, 0x60
+sCroconawGfx69_3:
+.incbin "baserom.gba", 0xC02C28, 0x60
+sCroconawSprites69:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx69, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx69_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx69_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx69_3, 0x60
+ax_sprite_terminator
+sCroconawGfx70:
+.incbin "baserom.gba", 0xC02CD0, 0x40
+sCroconawGfx70_1:
+.incbin "baserom.gba", 0xC02D10, 0x60
+sCroconawGfx70_2:
+.incbin "baserom.gba", 0xC02D70, 0x80
+sCroconawGfx70_3:
+.incbin "baserom.gba", 0xC02DF0, 0x60
+sCroconawSprites70:
+ax_sprite sCroconawGfx70, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx70_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx70_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx70_3, 0x60
+ax_sprite_terminator
+sCroconawGfx71:
+.incbin "baserom.gba", 0xC02E90, 0x40
+sCroconawGfx71_1:
+.incbin "baserom.gba", 0xC02ED0, 0x80
+sCroconawGfx71_2:
+.incbin "baserom.gba", 0xC02F50, 0x60
+sCroconawGfx71_3:
+.incbin "baserom.gba", 0xC02FB0, 0x60
+sCroconawSprites71:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx71, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx71_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx71_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx71_3, 0x60
+ax_sprite_terminator
+sCroconawGfx72:
+.incbin "baserom.gba", 0xC03058, 0x20
+sCroconawGfx72_1:
+.incbin "baserom.gba", 0xC03078, 0x60
+sCroconawGfx72_2:
+.incbin "baserom.gba", 0xC030D8, 0x100
+sCroconawSprites72:
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx72, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCroconawGfx72_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCroconawGfx72_2, 0x100
+ax_sprite_terminator
+sCroconawGfx73:
+.incbin "baserom.gba", 0xC03210, 0x200
+sCroconawSprites73:
+ax_sprite sCroconawGfx73, 0x200
+ax_sprite_terminator
+sCroconawGfx74:
+.incbin "baserom.gba", 0xC03420, 0x200
+sCroconawSprites74:
+ax_sprite sCroconawGfx74, 0x200
+ax_sprite_terminator
+sCroconawGfx75:
+.incbin "baserom.gba", 0xC03630, 0x200
+sCroconawSprites75:
+ax_sprite sCroconawGfx75, 0x200
+ax_sprite_terminator
+sCroconawGfx76:
+.incbin "baserom.gba", 0xC03840, 0x200
+sCroconawSprites76:
+ax_sprite sCroconawGfx76, 0x200
+ax_sprite_terminator
+sCroconawGfx77:
+.incbin "baserom.gba", 0xC03A50, 0x200
+sCroconawSprites77:
+ax_sprite sCroconawGfx77, 0x200
+ax_sprite_terminator
+sCroconawGfx78:
+.incbin "baserom.gba", 0xC03C60, 0x200
+sCroconawSprites78:
+ax_sprite sCroconawGfx78, 0x200
+ax_sprite_terminator
+sCroconawGfx79:
+.incbin "baserom.gba", 0xC03E70, 0x200
+sCroconawSprites79:
+ax_sprite sCroconawGfx79, 0x200
+ax_sprite_terminator
+sCroconawGfx80:
+.incbin "baserom.gba", 0xC04080, 0x200
+sCroconawSprites80:
+ax_sprite sCroconawGfx80, 0x200
+ax_sprite_terminator
+sCroconawGfx81:
+.incbin "baserom.gba", 0xC04290, 0x200
+sCroconawSprites81:
+ax_sprite sCroconawGfx81, 0x200
+ax_sprite_terminator
+sCroconawGfx82:
+.incbin "baserom.gba", 0xC044A0, 0x200
+sCroconawSprites82:
+ax_sprite sCroconawGfx82, 0x200
+ax_sprite_terminator
+sAxPosesCroconaw:
+.4byte sCroconawPose1
+.4byte sCroconawPose2
+.4byte sCroconawPose3
+.4byte sCroconawPose4
+.4byte sCroconawPose5
+.4byte sCroconawPose6
+.4byte sCroconawPose7
+.4byte sCroconawPose8
+.4byte sCroconawPose9
+.4byte sCroconawPose10
+.4byte sCroconawPose11
+.4byte sCroconawPose12
+.4byte sCroconawPose13
+.4byte sCroconawPose14
+.4byte sCroconawPose15
+.4byte sCroconawPose16
+.4byte sCroconawPose17
+.4byte sCroconawPose18
+.4byte sCroconawPose19
+.4byte sCroconawPose20
+.4byte sCroconawPose21
+.4byte sCroconawPose22
+.4byte sCroconawPose23
+.4byte sCroconawPose24
+.4byte sCroconawPose25
+.4byte sCroconawPose26
+.4byte sCroconawPose27
+.4byte sCroconawPose28
+.4byte sCroconawPose29
+.4byte sCroconawPose30
+.4byte sCroconawPose31
+.4byte sCroconawPose32
+.4byte sCroconawPose33
+.4byte sCroconawPose34
+.4byte sCroconawPose35
+.4byte sCroconawPose36
+.4byte sCroconawPose37
+.4byte sCroconawPose38
+.4byte sCroconawPose39
+.4byte sCroconawPose40
+.4byte sCroconawPose41
+.4byte sCroconawPose42
+.4byte sCroconawPose43
+.4byte sCroconawPose44
+.4byte sCroconawPose45
+.4byte sCroconawPose46
+.4byte sCroconawPose47
+.4byte sCroconawPose48
+.4byte sCroconawPose49
+.4byte sCroconawPose50
+.4byte sCroconawPose51
+.4byte sCroconawPose52
+.4byte sCroconawPose53
+.4byte sCroconawPose54
+.4byte sCroconawPose55
+.4byte sCroconawPose56
+.4byte sCroconawPose57
+.4byte sCroconawPose58
+.4byte sCroconawPose59
+.4byte sCroconawPose60
+.4byte sCroconawPose61
+.4byte sCroconawPose62
+.4byte sCroconawPose63
+.4byte sCroconawPose64
+.4byte sCroconawPose65
+.4byte sCroconawPose66
+.4byte sCroconawPose67
+.4byte sCroconawPose68
+.4byte sCroconawPose69
+.4byte sCroconawPose70
+.4byte sCroconawPose71
+.4byte sCroconawPose72
+.4byte sCroconawPose73
+.4byte sCroconawPose74
+.4byte sCroconawPose75
+.4byte sCroconawPose76
+.4byte sCroconawPose77
+.4byte sCroconawPose78
+.4byte sCroconawPose79
+.4byte sCroconawPose80
+.4byte sCroconawPose81
+.4byte sCroconawPose82
+.4byte sCroconawPose83
+.4byte sCroconawPose84
+.4byte sCroconawPose85
+.4byte sCroconawPose86
+.4byte sCroconawPose87
+.4byte sCroconawPose88
+.4byte sCroconawPose89
+.4byte sCroconawPose90
+.4byte sCroconawPose91
+.4byte sCroconawPose92
+.4byte sCroconawPose93
+.4byte sCroconawPose94
+.4byte sCroconawPose95
+.4byte sCroconawPose96
+.4byte sCroconawPose97
+.4byte sCroconawPose98
+.4byte sCroconawPose99
+.4byte sCroconawPose100
+.4byte sCroconawPose101
+.4byte sCroconawPose102
+.4byte sCroconawPose103
+.4byte sCroconawPose104
+.4byte sCroconawPose105
+.4byte sCroconawPose106
+.4byte sCroconawPose107
+.4byte sCroconawPose108
+.4byte sCroconawPose109
+.4byte sCroconawPose110
+.4byte sCroconawPose111
+.4byte sCroconawPose112
+.4byte sCroconawPose113
+.4byte sCroconawPose114
+.4byte sCroconawPose115
+.4byte sCroconawPose116
+.4byte sCroconawPose117
+.4byte sCroconawPose118
+.4byte sCroconawPose119
+.4byte sCroconawPose120
+.4byte sCroconawPose121
+.4byte sCroconawPose122
+.4byte sCroconawPose123
+.4byte sCroconawPose124
+.4byte sCroconawPose125
+.4byte sCroconawPose126
+.4byte sCroconawPose127
+.4byte sCroconawPose128
+.4byte sCroconawPose129
+.4byte sCroconawPose130
+.4byte sCroconawPose131
+.4byte sCroconawPose132
+.4byte sCroconawPose133
+.4byte sCroconawPose134
+.4byte sCroconawPose135
+.4byte sCroconawPose136
+.4byte sCroconawPose137
+.4byte sCroconawPose138
+.4byte sCroconawPose139
+.4byte sCroconawPose140
+.4byte sCroconawPose141
+.4byte sCroconawPose142
+.4byte sCroconawPose143
+.4byte sCroconawPose144
+.4byte sCroconawPose145
+.4byte sCroconawPose146
+.4byte sCroconawPose147
+.4byte sCroconawPose148
+.4byte sCroconawPose149
+.4byte sCroconawPose150
+.4byte sCroconawPose151
+.4byte sCroconawPose152
+.4byte sCroconawPose153
+.4byte sCroconawPose154
+.4byte sCroconawPose155
+.4byte sCroconawPose156
+.4byte sCroconawPose157
+.4byte sCroconawPose158
+.4byte sCroconawPose159
+.4byte sCroconawPose160
+.4byte sCroconawPose161
+.4byte sCroconawPose162
+.4byte sCroconawPose163
+.4byte sCroconawPose164
+.4byte sCroconawPose165
+.4byte sCroconawPose166
+.4byte sCroconawPose167
+.4byte sCroconawPose168
+.4byte sCroconawPose169
+.4byte sCroconawPose170
+.4byte sCroconawPose171
+.4byte sCroconawPose172
+.4byte sCroconawPose173
+.4byte sCroconawPose174
+.4byte sCroconawPose175
+.4byte sCroconawPose176
+.4byte sCroconawPose177
+.4byte sCroconawPose178
+.4byte sCroconawPose179
+.4byte sCroconawPose180
+.4byte sCroconawPose181
+.4byte sCroconawPose182
+.4byte sCroconawPose183
+.4byte sCroconawPose184
+.4byte sCroconawPose185
+.4byte sCroconawPose186
+.4byte sCroconawPose187
+.4byte sCroconawPose188
+.4byte sCroconawPose189
+.4byte sCroconawPose190
+.4byte sCroconawPose191
+.4byte sCroconawPose192
+.4byte sCroconawPose193
+.4byte sCroconawPose194
+.4byte sCroconawPose195
+.4byte sCroconawPose196
+sAxPositionsCroconaw:
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte   -1,  -11, 	  -8,   -8, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -11, 	 -11,  -12, 	   7,   -8, 	   0,   -9
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+.2byte    5,  -11, 	  -1,   -8, 	   3,  -14, 	   2,   -9
+.2byte    5,  -11, 	  -6,   -9, 	  10,  -11, 	   1,   -9
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte   10,  -13, 	   7,   -9, 	   0,  -13, 	  -2,   -8
+.2byte   10,  -13, 	  -1,   -7, 	   9,  -10, 	  -1,   -6
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte    8,  -17, 	   6,  -11, 	  -4,  -14, 	  -1,   -7
+.2byte    8,  -17, 	   5,   -8, 	   3,  -16, 	  -2,   -8
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    0,  -16, 	   7,  -13, 	 -10,  -10, 	   0,   -8
+.2byte   -1,  -16, 	   9,   -9, 	  -8,  -13, 	   0,   -8
+.2byte   -9,  -16, 	   1,  -15, 	  -8,   -9, 	   0,   -9
+.2byte   -9,  -17, 	  -2,  -17, 	  -7,   -9, 	   0,  -11
+.2byte   -9,  -17, 	   5,  -13, 	  -7,  -12, 	   0,  -10
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte  -10,  -13, 	 -10,  -10, 	  -2,   -8, 	  -2,   -9
+.2byte  -10,  -13, 	   0,  -12, 	  -8,   -9, 	  -1,   -9
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte   -6,  -12, 	 -10,  -11, 	   4,   -8, 	  -1,  -10
+.2byte   -6,  -12, 	  -1,  -14, 	  -1,   -8, 	  -2,  -10
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte   -1,  -11, 	  -8,   -8, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -11, 	 -11,  -12, 	   7,   -8, 	   0,   -9
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+.2byte    5,  -11, 	  -1,   -8, 	   3,  -14, 	   2,   -9
+.2byte    5,  -11, 	  -6,   -9, 	  10,  -11, 	   1,   -9
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte   10,  -13, 	   7,   -9, 	   0,  -13, 	  -2,   -8
+.2byte   10,  -13, 	  -1,   -7, 	   9,  -10, 	  -1,   -6
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte    8,  -17, 	   6,  -11, 	  -4,  -14, 	  -1,   -7
+.2byte    8,  -17, 	   5,   -8, 	   3,  -16, 	  -2,   -8
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    0,  -16, 	   7,  -13, 	 -10,  -10, 	   0,   -8
+.2byte   -1,  -16, 	   9,   -9, 	  -8,  -13, 	   0,   -8
+.2byte   -9,  -16, 	   1,  -15, 	  -8,   -9, 	   0,   -9
+.2byte   -9,  -17, 	  -2,  -17, 	  -7,   -9, 	   0,  -11
+.2byte   -9,  -17, 	   5,  -13, 	  -7,  -12, 	   0,  -10
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte  -10,  -13, 	 -10,  -10, 	  -2,   -8, 	  -2,   -9
+.2byte  -10,  -13, 	   0,  -12, 	  -8,   -9, 	  -1,   -9
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte   -6,  -12, 	 -10,  -11, 	   4,   -8, 	  -1,  -10
+.2byte   -6,  -12, 	  -1,  -14, 	  -1,   -8, 	  -2,  -10
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte   -1,  -12, 	  -8,  -14, 	   5,   -6, 	   0,   -7
+.2byte    2,   -4, 	  -4,   -2, 	   9,  -12, 	  -1,   -6
+.2byte    2,   -4, 	  -4,   -2, 	   9,  -12, 	  -1,   -6
+.2byte   -3,   -4, 	   3,   -2, 	 -10,  -12, 	   0,   -6
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+.2byte    4,  -13, 	  -1,   -6, 	   4,  -17, 	  -1,   -9
+.2byte    3,   -5, 	  -8,   -9, 	  11,   -4, 	  -2,   -8
+.2byte    3,   -5, 	  -8,   -9, 	  11,   -4, 	  -2,   -8
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte    7,  -14, 	   5,   -8, 	   3,  -14, 	  -1,   -7
+.2byte    9,   -7, 	  -3,   -9, 	  13,   -9, 	  -1,   -7
+.2byte    9,   -7, 	  -3,   -9, 	  13,   -9, 	  -1,   -7
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte    6,  -18, 	   8,  -12, 	  -8,  -16, 	  -2,   -8
+.2byte    8,  -13, 	   3,   -7, 	   7,  -23, 	  -3,   -8
+.2byte    8,  -13, 	   3,   -7, 	   7,  -23, 	  -3,   -8
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    1,  -17, 	   9,   -7, 	  -8,  -14, 	   0,   -7
+.2byte   -7,  -16, 	   4,  -20, 	  -8,   -8, 	   0,   -9
+.2byte   -7,  -16, 	   4,  -20, 	  -8,   -8, 	   0,   -9
+.2byte   -2,  -17, 	 -10,   -7, 	   7,  -14, 	  -1,   -7
+.2byte   -9,  -16, 	   1,  -15, 	  -8,   -9, 	   0,   -9
+.2byte   -6,  -19, 	   7,  -16, 	  -9,  -12, 	   1,   -7
+.2byte   -7,  -12, 	  -8,  -23, 	  -3,   -8, 	   1,  -10
+.2byte   -7,  -12, 	  -8,  -23, 	  -3,   -8, 	   1,  -10
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -8,  -14, 	   1,  -14, 	  -6,   -7, 	   1,   -7
+.2byte   -8,   -7, 	 -14,  -10, 	   2,   -9, 	   0,   -7
+.2byte   -8,   -7, 	 -14,  -10, 	   2,   -9, 	   0,   -7
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte   -3,  -13, 	  -6,   -9, 	   1,   -6, 	   2,   -9
+.2byte   -4,   -5, 	 -12,   -4, 	   7,   -9, 	   0,   -8
+.2byte   -4,   -5, 	 -12,   -4, 	   7,   -9, 	   0,   -8
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte    0,  -27, 	 -10,  -15, 	   8,  -15, 	  -1,  -13
+.2byte    0,   -7, 	 -10,  -12, 	   9,  -12, 	   0,   -9
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+.2byte    1,  -26, 	  -9,  -12, 	   8,  -17, 	   0,  -11
+.2byte    5,   -8, 	  -8,   -6, 	   8,  -10, 	   0,   -7
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte    5,  -23, 	   2,  -11, 	   2,  -15, 	   0,   -9
+.2byte   11,  -11, 	   0,   -7, 	   8,  -12, 	   3,   -8
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte    5,  -25, 	   4,  -14, 	  -6,  -18, 	   0,  -10
+.2byte    5,  -15, 	   3,   -7, 	  -7,  -14, 	  -2,   -9
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    0,  -20, 	   9,  -13, 	 -10,  -13, 	   0,   -8
+.2byte    0,  -15, 	  10,  -11, 	 -11,  -11, 	   0,   -8
+.2byte   -9,  -16, 	   1,  -15, 	  -8,   -9, 	   0,   -9
+.2byte   -6,  -25, 	   5,  -18, 	  -5,  -12, 	   1,  -11
+.2byte   -6,  -15, 	   5,  -14, 	  -4,   -7, 	   1,  -10
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -5,  -23, 	  -1,  -14, 	  -3,  -10, 	  -2,   -9
+.2byte  -10,  -11, 	  -5,  -13, 	  -2,   -7, 	  -4,   -8
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte   -1,  -26, 	  -9,  -17, 	   8,  -10, 	  -1,  -10
+.2byte   -6,   -8, 	  -7,  -12, 	   7,   -6, 	  -1,   -7
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -9,  -16, 	   1,  -15, 	  -8,   -9, 	   0,   -9
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+.2byte   -4,   -5, 	  -6,   -3, 	   1,   -3, 	   3,   -5
+.2byte   -4,   -4, 	  -5,   -2, 	   0,   -2, 	   1,   -5
+.2byte    0,  -15, 	  -9,  -14, 	   9,   -8, 	   0,  -10
+.2byte    3,  -19, 	   7,  -19, 	  -6,   -7, 	   1,  -11
+.2byte    2,  -18, 	   4,  -19, 	  -1,   -7, 	   1,  -11
+.2byte    4,  -20, 	  -2,  -18, 	   5,   -8, 	  -1,   -9
+.2byte    0,  -19, 	   8,  -17, 	  -9,  -12, 	  -1,  -10
+.2byte   -4,  -21, 	   2,  -17, 	  -6,   -8, 	  -1,  -10
+.2byte   -3,  -18, 	  -5,  -19, 	   0,   -6, 	  -2,  -10
+.2byte   -3,  -19, 	  -9,  -19, 	   5,   -7, 	  -2,  -10
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte   -1,  -12, 	  -8,  -14, 	   5,   -6, 	   0,   -7
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+.2byte    5,  -12, 	   0,   -5, 	   5,  -16, 	   0,   -8
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte    7,  -14, 	   5,   -8, 	   3,  -14, 	  -1,   -7
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte    6,  -18, 	   8,  -12, 	  -8,  -16, 	  -2,   -8
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    1,  -17, 	   9,   -7, 	  -8,  -14, 	   0,   -7
+.2byte   -9,  -16, 	   1,  -15, 	  -8,   -9, 	   0,   -9
+.2byte   -6,  -19, 	   7,  -16, 	  -9,  -12, 	   1,   -7
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -8,  -14, 	   1,  -14, 	  -6,   -7, 	   1,   -7
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte   -4,  -12, 	  -7,   -8, 	   0,   -5, 	   1,   -8
+.2byte    0,   -7, 	 -10,  -12, 	   9,  -12, 	   0,   -9
+.2byte   -6,   -8, 	  -7,  -12, 	   7,   -6, 	  -1,   -7
+.2byte   -8,  -10, 	  -3,  -12, 	   0,   -6, 	  -2,   -7
+.2byte   -6,  -13, 	   5,  -12, 	  -4,   -5, 	   1,   -8
+.2byte    0,  -14, 	  10,  -10, 	 -11,  -10, 	   0,   -7
+.2byte    5,  -13, 	   3,   -5, 	  -7,  -12, 	  -2,   -7
+.2byte    9,  -10, 	  -2,   -6, 	   6,  -11, 	   1,   -7
+.2byte    5,   -8, 	  -8,   -6, 	   8,  -10, 	   0,   -7
+.2byte    0,  -27, 	 -10,  -15, 	   8,  -15, 	  -1,  -13
+.2byte    0,  -26, 	 -10,  -12, 	   7,  -17, 	  -1,  -11
+.2byte    3,  -24, 	   0,  -12, 	   0,  -16, 	  -2,  -10
+.2byte    5,  -25, 	   4,  -14, 	  -6,  -18, 	   0,  -10
+.2byte    0,  -21, 	   9,  -14, 	 -10,  -14, 	   0,   -9
+.2byte   -6,  -25, 	   5,  -18, 	  -5,  -12, 	   1,  -11
+.2byte   -3,  -24, 	   1,  -15, 	  -1,  -11, 	   0,  -10
+.2byte    0,  -26, 	  -8,  -17, 	   9,  -10, 	   0,  -10
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte    0,  -27, 	 -10,  -15, 	   8,  -15, 	  -1,  -13
+.2byte    0,   -7, 	 -10,  -12, 	   9,  -12, 	   0,   -9
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+.2byte    1,  -26, 	  -9,  -12, 	   8,  -17, 	   0,  -11
+.2byte    5,   -8, 	  -8,   -6, 	   8,  -10, 	   0,   -7
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte    5,  -23, 	   2,  -11, 	   2,  -15, 	   0,   -9
+.2byte   11,  -11, 	   0,   -7, 	   8,  -12, 	   3,   -8
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte    5,  -25, 	   4,  -14, 	  -6,  -18, 	   0,  -10
+.2byte    6,  -15, 	   4,   -7, 	  -6,  -14, 	  -1,   -9
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    0,  -20, 	   9,  -13, 	 -10,  -13, 	   0,   -8
+.2byte    0,  -15, 	  10,  -11, 	 -11,  -11, 	   0,   -8
+.2byte   -8,  -16, 	   2,  -15, 	  -7,   -9, 	   1,   -9
+.2byte   -5,  -25, 	   6,  -18, 	  -4,  -12, 	   2,  -11
+.2byte   -6,  -15, 	   5,  -14, 	  -4,   -7, 	   1,  -10
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -5,  -23, 	  -1,  -14, 	  -3,  -10, 	  -2,   -9
+.2byte  -10,  -11, 	  -5,  -13, 	  -2,   -7, 	  -4,   -8
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte   -1,  -26, 	  -9,  -17, 	   8,  -10, 	  -1,  -10
+.2byte   -6,   -8, 	  -7,  -12, 	   7,   -6, 	  -1,   -7
+.2byte    0,   -7, 	 -10,  -12, 	   9,  -12, 	   0,   -9
+.2byte   -6,   -8, 	  -7,  -12, 	   7,   -6, 	  -1,   -7
+.2byte   -8,  -10, 	  -3,  -12, 	   0,   -6, 	  -2,   -7
+.2byte   -8,  -13, 	   3,  -12, 	  -6,   -5, 	  -1,   -8
+.2byte    0,  -14, 	  10,  -10, 	 -11,  -10, 	   0,   -7
+.2byte    5,  -13, 	   3,   -5, 	  -7,  -12, 	  -2,   -7
+.2byte    9,  -10, 	  -2,   -6, 	   6,  -11, 	   1,   -7
+.2byte    5,   -8, 	  -8,   -6, 	   8,  -10, 	   0,   -7
+.2byte   -1,  -10, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte   -6,  -11, 	  -9,  -11, 	   2,   -7, 	  -1,   -8
+.2byte  -10,  -12, 	  -6,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -9,  -16, 	   1,  -15, 	  -8,   -9, 	   0,   -9
+.2byte    0,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    8,  -16, 	   7,   -9, 	  -1,  -14, 	  -2,   -8
+.2byte   10,  -12, 	   5,   -7, 	   5,  -11, 	  -1,   -7
+.2byte    5,  -10, 	  -2,   -7, 	   8,  -11, 	   1,   -8
+sCroconawAnimTable1:
+.4byte sCroconawAnims_1_1
+.4byte sCroconawAnims_1_2
+.4byte sCroconawAnims_1_3
+.4byte sCroconawAnims_1_4
+.4byte sCroconawAnims_1_5
+.4byte sCroconawAnims_1_6
+.4byte sCroconawAnims_1_7
+.4byte sCroconawAnims_1_8
+sCroconawAnimTable2:
+.4byte sCroconawAnims_2_1
+.4byte sCroconawAnims_2_2
+.4byte sCroconawAnims_2_3
+.4byte sCroconawAnims_2_4
+.4byte sCroconawAnims_2_5
+.4byte sCroconawAnims_2_6
+.4byte sCroconawAnims_2_7
+.4byte sCroconawAnims_2_8
+sCroconawAnimTable3:
+.4byte sCroconawAnims_3_1
+.4byte sCroconawAnims_3_2
+.4byte sCroconawAnims_3_3
+.4byte sCroconawAnims_3_4
+.4byte sCroconawAnims_3_5
+.4byte sCroconawAnims_3_6
+.4byte sCroconawAnims_3_7
+.4byte sCroconawAnims_3_8
+sCroconawAnimTable4:
+.4byte sCroconawAnims_4_1
+.4byte sCroconawAnims_4_2
+.4byte sCroconawAnims_4_3
+.4byte sCroconawAnims_4_4
+.4byte sCroconawAnims_4_5
+.4byte sCroconawAnims_4_6
+.4byte sCroconawAnims_4_7
+.4byte sCroconawAnims_4_8
+sCroconawAnimTable5:
+.4byte sCroconawAnims_5_1
+.4byte sCroconawAnims_5_2
+.4byte sCroconawAnims_5_3
+.4byte sCroconawAnims_5_4
+.4byte sCroconawAnims_5_5
+.4byte sCroconawAnims_5_6
+.4byte sCroconawAnims_5_7
+.4byte sCroconawAnims_5_8
+sCroconawAnimTable6:
+.4byte sCroconawAnims_6_1
+.4byte sCroconawAnims_6_1
+.4byte sCroconawAnims_6_1
+.4byte sCroconawAnims_6_1
+.4byte sCroconawAnims_6_1
+.4byte sCroconawAnims_6_1
+.4byte sCroconawAnims_6_1
+.4byte sCroconawAnims_6_1
+sCroconawAnimTable7:
+.4byte sCroconawAnims_7_1
+.4byte sCroconawAnims_7_2
+.4byte sCroconawAnims_7_3
+.4byte sCroconawAnims_7_4
+.4byte sCroconawAnims_7_5
+.4byte sCroconawAnims_7_6
+.4byte sCroconawAnims_7_7
+.4byte sCroconawAnims_7_8
+sCroconawAnimTable8:
+.4byte sCroconawAnims_8_1
+.4byte sCroconawAnims_8_2
+.4byte sCroconawAnims_8_3
+.4byte sCroconawAnims_8_4
+.4byte sCroconawAnims_8_5
+.4byte sCroconawAnims_8_6
+.4byte sCroconawAnims_8_7
+.4byte sCroconawAnims_8_8
+sCroconawAnimTable9:
+.4byte sCroconawAnims_9_1
+.4byte sCroconawAnims_9_2
+.4byte sCroconawAnims_9_3
+.4byte sCroconawAnims_9_4
+.4byte sCroconawAnims_9_5
+.4byte sCroconawAnims_9_6
+.4byte sCroconawAnims_9_7
+.4byte sCroconawAnims_9_8
+sCroconawAnimTable10:
+.4byte sCroconawAnims_10_1
+.4byte sCroconawAnims_10_2
+.4byte sCroconawAnims_10_3
+.4byte sCroconawAnims_10_4
+.4byte sCroconawAnims_10_5
+.4byte sCroconawAnims_10_6
+.4byte sCroconawAnims_10_7
+.4byte sCroconawAnims_10_8
+sCroconawAnimTable11:
+.4byte sCroconawAnims_11_1
+.4byte sCroconawAnims_11_2
+.4byte sCroconawAnims_11_3
+.4byte sCroconawAnims_11_4
+.4byte sCroconawAnims_11_5
+.4byte sCroconawAnims_11_6
+.4byte sCroconawAnims_11_7
+.4byte sCroconawAnims_11_8
+sCroconawAnimTable12:
+.4byte sCroconawAnims_12_1
+.4byte sCroconawAnims_12_2
+.4byte sCroconawAnims_12_3
+.4byte sCroconawAnims_12_4
+.4byte sCroconawAnims_12_5
+.4byte sCroconawAnims_12_6
+.4byte sCroconawAnims_12_7
+.4byte sCroconawAnims_12_8
+sCroconawAnimTable13:
+.4byte sCroconawAnims_13_1
+.4byte sCroconawAnims_13_2
+.4byte sCroconawAnims_13_3
+.4byte sCroconawAnims_13_4
+.4byte sCroconawAnims_13_5
+.4byte sCroconawAnims_13_6
+.4byte sCroconawAnims_13_7
+.4byte sCroconawAnims_13_8
+sAxAnimationsCroconaw:
+.4byte sCroconawAnimTable1
+.4byte sCroconawAnimTable2
+.4byte sCroconawAnimTable3
+.4byte sCroconawAnimTable4
+.4byte sCroconawAnimTable5
+.4byte sCroconawAnimTable6
+.4byte sCroconawAnimTable7
+.4byte sCroconawAnimTable8
+.4byte sCroconawAnimTable9
+.4byte sCroconawAnimTable10
+.4byte sCroconawAnimTable11
+.4byte sCroconawAnimTable12
+.4byte sCroconawAnimTable13
+sAxSpritesCroconaw:
+.4byte sCroconawSprites1
+.4byte sCroconawSprites2
+.4byte sCroconawSprites3
+.4byte sCroconawSprites4
+.4byte sCroconawSprites5
+.4byte sCroconawSprites6
+.4byte sCroconawSprites7
+.4byte sCroconawSprites8
+.4byte sCroconawSprites9
+.4byte sCroconawSprites10
+.4byte sCroconawSprites11
+.4byte sCroconawSprites12
+.4byte sCroconawSprites13
+.4byte sCroconawSprites14
+.4byte sCroconawSprites15
+.4byte sCroconawSprites16
+.4byte sCroconawSprites17
+.4byte sCroconawSprites18
+.4byte sCroconawSprites19
+.4byte sCroconawSprites20
+.4byte sCroconawSprites21
+.4byte sCroconawSprites22
+.4byte sCroconawSprites23
+.4byte sCroconawSprites24
+.4byte sCroconawSprites25
+.4byte sCroconawSprites26
+.4byte sCroconawSprites27
+.4byte sCroconawSprites28
+.4byte sCroconawSprites29
+.4byte sCroconawSprites30
+.4byte sCroconawSprites31
+.4byte sCroconawSprites32
+.4byte sCroconawSprites33
+.4byte sCroconawSprites34
+.4byte sCroconawSprites35
+.4byte sCroconawSprites36
+.4byte sCroconawSprites37
+.4byte sCroconawSprites38
+.4byte sCroconawSprites39
+.4byte sCroconawSprites40
+.4byte sCroconawSprites41
+.4byte sCroconawSprites42
+.4byte sCroconawSprites43
+.4byte sCroconawSprites44
+.4byte sCroconawSprites45
+.4byte sCroconawSprites46
+.4byte sCroconawSprites47
+.4byte sCroconawSprites48
+.4byte sCroconawSprites49
+.4byte sCroconawSprites50
+.4byte sCroconawSprites51
+.4byte sCroconawSprites52
+.4byte sCroconawSprites53
+.4byte sCroconawSprites54
+.4byte sCroconawSprites55
+.4byte sCroconawSprites56
+.4byte sCroconawSprites57
+.4byte sCroconawSprites58
+.4byte sCroconawSprites59
+.4byte sCroconawSprites60
+.4byte sCroconawSprites61
+.4byte sCroconawSprites62
+.4byte sCroconawSprites63
+.4byte sCroconawSprites64
+.4byte sCroconawSprites65
+.4byte sCroconawSprites66
+.4byte sCroconawSprites67
+.4byte sCroconawSprites68
+.4byte sCroconawSprites69
+.4byte sCroconawSprites70
+.4byte sCroconawSprites71
+.4byte sCroconawSprites72
+.4byte sCroconawSprites73
+.4byte sCroconawSprites74
+.4byte sCroconawSprites75
+.4byte sCroconawSprites76
+.4byte sCroconawSprites77
+.4byte sCroconawSprites78
+.4byte sCroconawSprites79
+.4byte sCroconawSprites80
+.4byte sCroconawSprites81
+.4byte sCroconawSprites82
+sAxMainCroconaw:
+ax_main sAxPosesCroconaw, sAxAnimationsCroconaw, 13, sAxSpritesCroconaw, sAxPositionsCroconaw

--- a/data/ax/cubone.inc
+++ b/data/ax/cubone.inc
@@ -1,0 +1,4416 @@
+.global gAxCubone
+gAxCubone:
+ax_siro sAxMainCubone
+sCubonePose1:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose2:
+ax_pose 1, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose3:
+ax_pose 2, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose4:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose5:
+ax_pose 4, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose6:
+ax_pose 5, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose7:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose8:
+ax_pose 7, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose9:
+ax_pose 8, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose10:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose11:
+ax_pose 10, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose12:
+ax_pose 11, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose13:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose14:
+ax_pose 13, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose15:
+ax_pose 14, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose16:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose17:
+ax_pose 16, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose18:
+ax_pose 17, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose19:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose20:
+ax_pose 19, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose21:
+ax_pose 20, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose22:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose23:
+ax_pose 22, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose24:
+ax_pose 23, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose25:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose26:
+ax_pose 1, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose27:
+ax_pose 2, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose28:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose29:
+ax_pose 4, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose30:
+ax_pose 5, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose31:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose32:
+ax_pose 7, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose33:
+ax_pose 8, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose34:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose35:
+ax_pose 10, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose36:
+ax_pose 11, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose37:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose38:
+ax_pose 13, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose39:
+ax_pose 14, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose40:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose41:
+ax_pose 16, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose42:
+ax_pose 17, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose43:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose44:
+ax_pose 19, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose45:
+ax_pose 20, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose46:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose47:
+ax_pose 22, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose48:
+ax_pose 23, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose49:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose50:
+ax_pose 24, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose51:
+ax_pose 25, 0x81e9, 0x80f0, 0x6c00
+ax_pose 26, 0x01e9, 0x80f0, 0x6c08
+ax_pose_terminator
+sCubonePose52:
+ax_pose 26, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose53:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose54:
+ax_pose 27, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose55:
+ax_pose 28, 0x01ea, 0x80f6, 0x6c00
+ax_pose 29, 0x01e7, 0x80f5, 0x6c10
+ax_pose_terminator
+sCubonePose56:
+ax_pose 29, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose57:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose58:
+ax_pose 30, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose59:
+ax_pose 31, 0x01e7, 0x80f5, 0x6c00
+ax_pose 32, 0x01e7, 0x80f5, 0x6c10
+ax_pose_terminator
+sCubonePose60:
+ax_pose 32, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose61:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose62:
+ax_pose 33, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose63:
+ax_pose 34, 0x41ee, 0x80f1, 0x6c00
+ax_pose 35, 0x01e7, 0x80f5, 0x6c08
+ax_pose_terminator
+sCubonePose64:
+ax_pose 35, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose65:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose66:
+ax_pose 36, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose67:
+ax_pose 37, 0x81e7, 0x0103, 0x6c00
+ax_pose 38, 0x01e9, 0x80f0, 0x6c02
+ax_pose_terminator
+sCubonePose68:
+ax_pose 38, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose69:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose70:
+ax_pose 39, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose71:
+ax_pose 40, 0x01ea, 0x80ef, 0x6c00
+ax_pose 41, 0x01ea, 0x80ef, 0x6c10
+ax_pose_terminator
+sCubonePose72:
+ax_pose 40, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose73:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose74:
+ax_pose 42, 0x01e8, 0x80ed, 0x6c00
+ax_pose_terminator
+sCubonePose75:
+ax_pose 43, 0x01e8, 0x80ed, 0x6c00
+ax_pose 44, 0x01e8, 0x80ed, 0x6c10
+ax_pose_terminator
+sCubonePose76:
+ax_pose 44, 0x01e8, 0x80ed, 0x6c00
+ax_pose_terminator
+sCubonePose77:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose78:
+ax_pose 45, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose79:
+ax_pose 46, 0x01e9, 0x80ef, 0x6c00
+ax_pose 47, 0x01e9, 0x80ef, 0x6c10
+ax_pose_terminator
+sCubonePose80:
+ax_pose 47, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose81:
+ax_pose 26, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose82:
+ax_pose 47, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose83:
+ax_pose 44, 0x01e8, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose84:
+ax_pose 40, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sCubonePose85:
+ax_pose 38, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose86:
+ax_pose 35, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose87:
+ax_pose 32, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose88:
+ax_pose 29, 0x01e8, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose89:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose90:
+ax_pose 24, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose91:
+ax_pose 48, 0x81e9, 0x80ed, 0x6c00
+ax_pose 49, 0x01e9, 0x80f0, 0x6c08
+ax_pose_terminator
+sCubonePose92:
+ax_pose 49, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose93:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose94:
+ax_pose 27, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose95:
+ax_pose 50, 0x01e7, 0x80f5, 0x6c00
+ax_pose 51, 0x01e8, 0x80f5, 0x6c10
+ax_pose_terminator
+sCubonePose96:
+ax_pose 51, 0x01e8, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose97:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose98:
+ax_pose 30, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose99:
+ax_pose 52, 0x41f0, 0x80f5, 0x6c00
+ax_pose 53, 0x01e8, 0x80f5, 0x6c08
+ax_pose_terminator
+sCubonePose100:
+ax_pose 53, 0x01e8, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose101:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose102:
+ax_pose 33, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose103:
+ax_pose 54, 0x41eb, 0x80f5, 0x6c00
+ax_pose 55, 0x01ea, 0x80f5, 0x6c08
+ax_pose_terminator
+sCubonePose104:
+ax_pose 55, 0x01ea, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose105:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose106:
+ax_pose 36, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose107:
+ax_pose 56, 0x81ea, 0x0105, 0x6c00
+ax_pose 57, 0x01e9, 0x80f0, 0x6c02
+ax_pose_terminator
+sCubonePose108:
+ax_pose 57, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose109:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose110:
+ax_pose 39, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose111:
+ax_pose 58, 0x01ea, 0x80ef, 0x6c00
+ax_pose 59, 0x41ea, 0x80ef, 0x6c10
+ax_pose_terminator
+sCubonePose112:
+ax_pose 58, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose113:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose114:
+ax_pose 42, 0x01e8, 0x80ed, 0x6c00
+ax_pose_terminator
+sCubonePose115:
+ax_pose 60, 0x01e8, 0x80ed, 0x6c00
+ax_pose 61, 0x01e8, 0x80ed, 0x6c10
+ax_pose_terminator
+sCubonePose116:
+ax_pose 61, 0x01e8, 0x80ed, 0x6c00
+ax_pose_terminator
+sCubonePose117:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose118:
+ax_pose 45, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose119:
+ax_pose 62, 0x01e9, 0x80ef, 0x6c00
+ax_pose 63, 0x01e9, 0x80ef, 0x6c10
+ax_pose_terminator
+sCubonePose120:
+ax_pose 63, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose121:
+ax_pose 64, 0x01ec, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose122:
+ax_pose 65, 0x01ec, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose123:
+ax_pose 66, 0x01e2, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose124:
+ax_pose 67, 0x01e3, 0x90ec, 0x6c00
+ax_pose_terminator
+sCubonePose125:
+ax_pose 68, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sCubonePose126:
+ax_pose 69, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sCubonePose127:
+ax_pose 70, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose128:
+ax_pose 69, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose129:
+ax_pose 68, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose130:
+ax_pose 67, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose131:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose132:
+ax_pose 1, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose133:
+ax_pose 2, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose134:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose135:
+ax_pose 4, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose136:
+ax_pose 5, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose137:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose138:
+ax_pose 7, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose139:
+ax_pose 8, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose140:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose141:
+ax_pose 10, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose142:
+ax_pose 11, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose143:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose144:
+ax_pose 13, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose145:
+ax_pose 14, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose146:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose147:
+ax_pose 16, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose148:
+ax_pose 17, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose149:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose150:
+ax_pose 19, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose151:
+ax_pose 20, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose152:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose153:
+ax_pose 22, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose154:
+ax_pose 23, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose155:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose156:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose157:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose158:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose159:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose160:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose161:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose162:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose163:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose164:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose165:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose166:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose167:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose168:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose169:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose170:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose171:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose172:
+ax_pose 24, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose173:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose174:
+ax_pose 27, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose175:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose176:
+ax_pose 30, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose177:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose178:
+ax_pose 33, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose179:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose180:
+ax_pose 36, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose181:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose182:
+ax_pose 39, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose183:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose184:
+ax_pose 42, 0x01e8, 0x80ed, 0x6c00
+ax_pose_terminator
+sCubonePose185:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose186:
+ax_pose 45, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose187:
+ax_pose 26, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose188:
+ax_pose 47, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose189:
+ax_pose 44, 0x01e8, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose190:
+ax_pose 40, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sCubonePose191:
+ax_pose 38, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose192:
+ax_pose 35, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose193:
+ax_pose 32, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose194:
+ax_pose 29, 0x01e8, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose195:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose196:
+ax_pose 21, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose197:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose198:
+ax_pose 15, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose199:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose200:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose201:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose202:
+ax_pose 3, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose203:
+ax_pose 71, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose204:
+ax_pose 72, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose205:
+ax_pose 73, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sCubonePose206:
+ax_pose 73, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sCubonePose207:
+ax_pose 71, 0x01ec, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose208:
+ax_pose 74, 0x01ec, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose209:
+ax_pose 75, 0x01ec, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose210:
+ax_pose 76, 0x01ec, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose211:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose212:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose213:
+ax_pose 77, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose214:
+ax_pose 78, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sCubonePose215:
+ax_pose 79, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose216:
+ax_pose 80, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose217:
+ax_pose 81, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose218:
+ax_pose 82, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose219:
+ax_pose 83, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose220:
+ax_pose 84, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose221:
+ax_pose 85, 0x01e9, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose222:
+ax_pose 85, 0x01e9, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose223:
+ax_pose 86, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sCubonePose224:
+ax_pose 87, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose225:
+ax_pose 88, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose226:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose227:
+ax_pose 89, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose228:
+ax_pose 90, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose229:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose230:
+ax_pose 91, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose231:
+ax_pose 92, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose232:
+ax_pose 0, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose233:
+ax_pose 80, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose234:
+ax_pose 93, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose235:
+ax_pose 18, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sCubonePose236:
+ax_pose 94, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sCubonePose237:
+ax_pose 6, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose238:
+ax_pose 95, 0x01ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sCubonePose239:
+ax_pose 12, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sCubonePose240:
+ax_pose 96, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sCubonePose241:
+ax_pose 97, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sCubonePose242:
+ax_pose 98, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sCubonePose243:
+ax_pose 99, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sCubonePose244:
+ax_pose 100, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sCubonePose245:
+ax_pose 101, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sCubonePose246:
+ax_pose 102, 0x01eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sCubonePose247:
+ax_pose 103, 0x01eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sCubonePose248:
+ax_pose 104, 0x01eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sCubonePose249:
+ax_pose 105, 0x01eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sCubonePose250:
+ax_pose 106, 0x01eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sCubonePose251:
+ax_pose 107, 0x01ed, 0x90ec, 0x6c00
+ax_pose_terminator
+sCubonePose252:
+ax_pose 71, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose253:
+ax_pose 72, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose254:
+ax_pose 73, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sCubonePose255:
+ax_pose 73, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sCubonePose256:
+ax_pose 71, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose257:
+ax_pose 72, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sCubonePose258:
+ax_pose 73, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sCubonePose259:
+ax_pose 73, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+.align 2
+sCuboneAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCuboneAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sCuboneAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sCuboneAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sCuboneAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sCuboneAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sCuboneAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sCuboneAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCuboneAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 50, 0, 8, 0, 8,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 1, 51, -1, 16, -1, 16,
+ax_anim 2, 0, 51, 0, 16, 0, 16,
+ax_anim 2, 0, 51, -1, 16, -1, 16,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sCuboneAnims_3_2:
+ax_anim 4, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 2, 54, 8, 8, 8, 8,
+ax_anim 2, 0, 54, 16, 16, 16, 16,
+ax_anim 2, 1, 55, 17, 15, 17, 15,
+ax_anim 2, 0, 55, 16, 16, 16, 16,
+ax_anim 2, 0, 55, 17, 15, 17, 15,
+ax_anim 4, 0, 52, 6, 6, 6, 6,
+ax_anim_terminator
+sCuboneAnims_3_3:
+ax_anim 4, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 6, 0, 57, -3, 0, -3, 0,
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 2, 58, 6, 0, 6, 0,
+ax_anim 2, 0, 58, 14, 0, 14, 0,
+ax_anim 2, 1, 59, 14, -1, 14, -1,
+ax_anim 2, 0, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 59, 14, -1, 14, -1,
+ax_anim 4, 0, 56, 4, 0, 4, 0,
+ax_anim_terminator
+sCuboneAnims_3_4:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 2, 62, 5, -10, 5, -10,
+ax_anim 2, 0, 62, 14, -21, 14, -21,
+ax_anim 2, 1, 63, 13, -22, 13, -22,
+ax_anim 2, 0, 63, 14, -21, 14, -21,
+ax_anim 2, 0, 63, 13, -22, 13, -22,
+ax_anim 4, 0, 60, 4, -6, 4, -6,
+ax_anim_terminator
+sCuboneAnims_3_5:
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 66, 0, -8, 0, -8,
+ax_anim 2, 0, 66, 0, -21, 0, -21,
+ax_anim 2, 1, 67, 1, -21, 1, -21,
+ax_anim 2, 0, 67, 0, -21, 0, -21,
+ax_anim 2, 0, 67, 1, -21, 1, -21,
+ax_anim 4, 0, 64, 0, -6, 0, -6,
+ax_anim_terminator
+sCuboneAnims_3_6:
+ax_anim 4, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 2, 70, -6, -9, -6, -9,
+ax_anim 2, 0, 70, -16, -23, -16, -23,
+ax_anim 2, 1, 71, -15, -24, -15, -24,
+ax_anim 2, 0, 71, -16, -23, -16, -23,
+ax_anim 2, 0, 71, -15, -24, -15, -24,
+ax_anim 4, 0, 68, -6, -6, -6, -6,
+ax_anim_terminator
+sCuboneAnims_3_7:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 6, 0, 73, 3, 0, 3, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 74, -6, 0, -6, 0,
+ax_anim 2, 0, 74, -12, 0, -12, 0,
+ax_anim 2, 1, 75, -12, -1, -12, -1,
+ax_anim 2, 0, 75, -12, 0, -12, 0,
+ax_anim 2, 0, 75, -12, -1, -12, -1,
+ax_anim 4, 0, 72, -4, 0, -4, 0,
+ax_anim_terminator
+sCuboneAnims_3_8:
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 78, -8, 8, -8, 8,
+ax_anim 2, 0, 78, -16, 16, -16, 16,
+ax_anim 2, 1, 79, -17, 15, -17, 15,
+ax_anim 2, 0, 79, -16, 16, -16, 16,
+ax_anim 2, 0, 79, -17, 15, -17, 15,
+ax_anim 4, 0, 76, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCuboneAnims_4_1:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_4_2:
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_4_3:
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_4_4:
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_4_5:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_4_6:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_4_7:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_4_8:
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_5_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -4, 0, -4,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 0, 1, 0, 1,
+ax_anim 5, 0, 91, 0, 2, 0, 2,
+ax_anim_terminator
+sCuboneAnims_5_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 2, 93, -4, -4, -4, -4,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 1, 95, 1, 1, 1, 1,
+ax_anim 5, 0, 95, 2, 2, 2, 2,
+ax_anim_terminator
+sCuboneAnims_5_3:
+ax_anim 2, 0, 97, -2, 0, -2, -2,
+ax_anim 6, 2, 97, -4, 0, -4, -4,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 99, 1, 0, 1, 0,
+ax_anim 5, 0, 99, 2, 0, 2, 0,
+ax_anim_terminator
+sCuboneAnims_5_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 6, 2, 101, -4, 4, -4, 4,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 1, 103, 1, -1, 1, -1,
+ax_anim 5, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sCuboneAnims_5_5:
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim 6, 2, 105, 0, 4, 0, 4,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 107, 0, -1, 0, -1,
+ax_anim 5, 0, 107, 0, -2, 0, -2,
+ax_anim_terminator
+sCuboneAnims_5_6:
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 6, 2, 109, 4, 4, 4, 4,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 111, -1, -1, -1, -1,
+ax_anim 5, 0, 111, -2, -2, -2, -2,
+ax_anim_terminator
+sCuboneAnims_5_7:
+ax_anim 2, 0, 113, 2, 0, 2, -2,
+ax_anim 6, 2, 113, 4, 0, 4, -4,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 115, -1, 0, -1, 1,
+ax_anim 5, 0, 115, -2, 0, -2, 0,
+ax_anim_terminator
+sCuboneAnims_5_8:
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 6, 2, 117, 4, -4, 4, -4,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, 1, -1, 1,
+ax_anim 5, 0, 119, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sCuboneAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sCuboneAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sCuboneAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sCuboneAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sCuboneAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sCuboneAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sCuboneAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sCuboneAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCuboneAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 1, -3, 0, 0,
+ax_anim 2, 0, 131, 1, -4, 0, 0,
+ax_anim 3, 0, 131, 1, -5, 0, 0,
+ax_anim 2, 0, 131, 1, -4, 0, 0,
+ax_anim 1, 0, 131, 1, -3, 0, 0,
+ax_anim_terminator
+sCuboneAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 3, 0, 134, 0, -6, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -4, 0, 0,
+ax_anim_terminator
+sCuboneAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 3, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -4, 0, 0,
+ax_anim_terminator
+sCuboneAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -1, -4, 0, 0,
+ax_anim 2, 0, 140, -1, -5, 0, 0,
+ax_anim 3, 0, 140, -1, -6, 0, 0,
+ax_anim 2, 0, 140, -1, -5, 0, 0,
+ax_anim 1, 0, 140, -1, -4, 0, 0,
+ax_anim_terminator
+sCuboneAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -1, -4, 0, 0,
+ax_anim 2, 0, 143, -1, -5, 0, 0,
+ax_anim 3, 0, 143, -1, -6, 0, 0,
+ax_anim 2, 0, 143, -1, -5, 0, 0,
+ax_anim 1, 0, 143, -1, -4, 0, 0,
+ax_anim_terminator
+sCuboneAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -1, -4, 0, 0,
+ax_anim 2, 0, 146, -1, -5, 0, 0,
+ax_anim 3, 0, 146, -1, -6, 0, 0,
+ax_anim 2, 0, 146, -1, -5, 0, 0,
+ax_anim 1, 0, 146, -1, -4, 0, 0,
+ax_anim_terminator
+sCuboneAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -5, 0, 0,
+ax_anim 3, 0, 149, 0, -6, 0, 0,
+ax_anim 2, 0, 149, 0, -5, 0, 0,
+ax_anim 1, 0, 149, 0, -4, 0, 0,
+ax_anim_terminator
+sCuboneAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -4, 0, 0,
+ax_anim 2, 0, 152, 0, -5, 0, 0,
+ax_anim 3, 0, 152, 0, -6, 0, 0,
+ax_anim 2, 0, 152, 0, -5, 0, 0,
+ax_anim 1, 0, 152, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 19, 7, 19,
+ax_anim 3, 0, 158, 0, 21, 0, 21,
+ax_anim 2, 3, 159, -7, 19, -7, 19,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, -1, 8, -1,
+ax_anim 2, 0, 155, 19, 3, 19, 3,
+ax_anim 2, 0, 156, 24, 9, 24, 9,
+ax_anim 3, 0, 157, 23, 21, 23, 21,
+ax_anim 2, 3, 158, 11, 24, 11, 24,
+ax_anim 2, 0, 159, 1, 14, 1, 14,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 19, -4, 19, -4,
+ax_anim 3, 0, 156, 24, 1, 24, 1,
+ax_anim 2, 3, 157, 19, 5, 19, 5,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 2, -18, 2, -18,
+ax_anim 2, 0, 154, 10, -26, 10, -26,
+ax_anim 3, 0, 155, 20, -25, 20, -25,
+ax_anim 2, 3, 156, 21, -11, 21, -11,
+ax_anim 2, 0, 157, 16, -4, 16, -4,
+ax_anim 1, 0, 158, 7, 0, 7, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -8, -10, -8, -10,
+ax_anim 2, 0, 161, -7, -20, -7, -20,
+ax_anim 3, 0, 154, 0, -25, 0, -25,
+ax_anim 2, 3, 155, 7, -20, 7, -20,
+ax_anim 2, 0, 156, 8, -8, 8, -8,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -2, -18, -2, -18,
+ax_anim 2, 0, 154, -10, -26, -10, -26,
+ax_anim 3, 0, 161, -20, -25, -20, -25,
+ax_anim 2, 3, 160, -21, -11, -21, -11,
+ax_anim 2, 0, 159, -16, -4, -16, -4,
+ax_anim 1, 0, 158, -7, 0, -7, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -19, -4, -19, -4,
+ax_anim 3, 0, 160, -24, 1, -24, 1,
+ax_anim 2, 3, 159, -19, 5, -19, 5,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, -1, -6, 0,
+ax_anim 2, 0, 161, -19, 3, -17, 3,
+ax_anim 2, 0, 160, -24, 9, -24, 9,
+ax_anim 3, 0, 159, -23, 21, -23, 16,
+ax_anim 2, 3, 158, -11, 24, -11, 16,
+ax_anim 2, 0, 157, -1, 14, -4, 12,
+ax_anim 1, 0, 156, 0, 7, -3, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_11_2:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -22, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_11_3:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_11_4:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -17, 0, 0,
+ax_anim 1, 0, 176, 0, -11, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_11_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_11_6:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 180, 0, -11, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_11_7:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_11_8:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_14_1:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_14_2:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_14_3:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_14_4:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_14_5:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_14_6:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_14_7:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_14_8:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_15_1:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_15_2:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_15_3:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_15_4:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_15_5:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_15_6:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_15_7:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_15_8:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_16_1:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_16_2:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_16_3:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_16_4:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_16_5:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_16_6:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_16_7:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_16_8:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_17_1:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sCuboneAnims_17_2:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sCuboneAnims_17_3:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sCuboneAnims_17_4:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sCuboneAnims_17_5:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sCuboneAnims_17_6:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sCuboneAnims_17_7:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sCuboneAnims_17_8:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_18_1:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_18_2:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_18_3:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_18_4:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_18_5:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_18_6:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_18_7:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_18_8:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_19_1:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_19_2:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_19_3:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_19_4:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_19_5:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_19_6:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_19_7:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_19_8:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_20_1:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+sCuboneAnims_20_2:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+sCuboneAnims_20_3:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+sCuboneAnims_20_4:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+sCuboneAnims_20_5:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+sCuboneAnims_20_6:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+sCuboneAnims_20_7:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+sCuboneAnims_20_8:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -1, 0, 0,
+ax_anim 1, 0, 226, 0, -3, 0, 0,
+ax_anim 3, 0, 226, 0, -4, 0, 0,
+ax_anim 3, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim 2, 0, 227, 0, 3, 0, 0,
+ax_anim 2, 0, 227, 1, 3, 1, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_21_1:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_21_2:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_21_3:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_21_4:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_21_5:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_21_6:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_21_7:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_21_8:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_22_1:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_22_2:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_22_3:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_22_4:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_22_5:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_22_6:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_22_7:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_22_8:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_23_1:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_23_2:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_23_3:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_23_4:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_23_5:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_23_6:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_23_7:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_23_8:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_24_1:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_24_2:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_24_3:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_24_4:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_24_5:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_24_6:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_24_7:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_24_8:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_25_1:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_25_2:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_25_3:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_25_4:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_25_5:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_25_6:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_25_7:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_25_8:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_26_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sCuboneAnims_26_2:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sCuboneAnims_26_3:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sCuboneAnims_26_4:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sCuboneAnims_26_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sCuboneAnims_26_6:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sCuboneAnims_26_7:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sCuboneAnims_26_8:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sCuboneAnims_27_1:
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 16, 0, 251, -1, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 1, 0, 0, 0,
+ax_anim 16, 0, 251, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCuboneAnims_28_1:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_28_2:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_28_3:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_28_4:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_28_5:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_28_6:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_28_7:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneAnims_28_8:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sCuboneGfx1:
+.incbin "baserom.gba", 0x9705D4, 0x200
+sCuboneSprites1:
+ax_sprite sCuboneGfx1, 0x200
+ax_sprite_terminator
+sCuboneGfx2:
+.incbin "baserom.gba", 0x9707E4, 0x200
+sCuboneSprites2:
+ax_sprite sCuboneGfx2, 0x200
+ax_sprite_terminator
+sCuboneGfx3:
+.incbin "baserom.gba", 0x9709F4, 0x200
+sCuboneSprites3:
+ax_sprite sCuboneGfx3, 0x200
+ax_sprite_terminator
+sCuboneGfx4:
+.incbin "baserom.gba", 0x970C04, 0x200
+sCuboneSprites4:
+ax_sprite sCuboneGfx4, 0x200
+ax_sprite_terminator
+sCuboneGfx5:
+.incbin "baserom.gba", 0x970E14, 0x200
+sCuboneSprites5:
+ax_sprite sCuboneGfx5, 0x200
+ax_sprite_terminator
+sCuboneGfx6:
+.incbin "baserom.gba", 0x971024, 0x200
+sCuboneSprites6:
+ax_sprite sCuboneGfx6, 0x200
+ax_sprite_terminator
+sCuboneGfx7:
+.incbin "baserom.gba", 0x971234, 0x200
+sCuboneSprites7:
+ax_sprite sCuboneGfx7, 0x200
+ax_sprite_terminator
+sCuboneGfx8:
+.incbin "baserom.gba", 0x971444, 0x200
+sCuboneSprites8:
+ax_sprite sCuboneGfx8, 0x200
+ax_sprite_terminator
+sCuboneGfx9:
+.incbin "baserom.gba", 0x971654, 0x200
+sCuboneSprites9:
+ax_sprite sCuboneGfx9, 0x200
+ax_sprite_terminator
+sCuboneGfx10:
+.incbin "baserom.gba", 0x971864, 0x200
+sCuboneSprites10:
+ax_sprite sCuboneGfx10, 0x200
+ax_sprite_terminator
+sCuboneGfx11:
+.incbin "baserom.gba", 0x971A74, 0x200
+sCuboneSprites11:
+ax_sprite sCuboneGfx11, 0x200
+ax_sprite_terminator
+sCuboneGfx12:
+.incbin "baserom.gba", 0x971C84, 0x200
+sCuboneSprites12:
+ax_sprite sCuboneGfx12, 0x200
+ax_sprite_terminator
+sCuboneGfx13:
+.incbin "baserom.gba", 0x971E94, 0x200
+sCuboneSprites13:
+ax_sprite sCuboneGfx13, 0x200
+ax_sprite_terminator
+sCuboneGfx14:
+.incbin "baserom.gba", 0x9720A4, 0x200
+sCuboneSprites14:
+ax_sprite sCuboneGfx14, 0x200
+ax_sprite_terminator
+sCuboneGfx15:
+.incbin "baserom.gba", 0x9722B4, 0x200
+sCuboneSprites15:
+ax_sprite sCuboneGfx15, 0x200
+ax_sprite_terminator
+sCuboneGfx16:
+.incbin "baserom.gba", 0x9724C4, 0x200
+sCuboneSprites16:
+ax_sprite sCuboneGfx16, 0x200
+ax_sprite_terminator
+sCuboneGfx17:
+.incbin "baserom.gba", 0x9726D4, 0x200
+sCuboneSprites17:
+ax_sprite sCuboneGfx17, 0x200
+ax_sprite_terminator
+sCuboneGfx18:
+.incbin "baserom.gba", 0x9728E4, 0x200
+sCuboneSprites18:
+ax_sprite sCuboneGfx18, 0x200
+ax_sprite_terminator
+sCuboneGfx19:
+.incbin "baserom.gba", 0x972AF4, 0x200
+sCuboneSprites19:
+ax_sprite sCuboneGfx19, 0x200
+ax_sprite_terminator
+sCuboneGfx20:
+.incbin "baserom.gba", 0x972D04, 0x200
+sCuboneSprites20:
+ax_sprite sCuboneGfx20, 0x200
+ax_sprite_terminator
+sCuboneGfx21:
+.incbin "baserom.gba", 0x972F14, 0x200
+sCuboneSprites21:
+ax_sprite sCuboneGfx21, 0x200
+ax_sprite_terminator
+sCuboneGfx22:
+.incbin "baserom.gba", 0x973124, 0x200
+sCuboneSprites22:
+ax_sprite sCuboneGfx22, 0x200
+ax_sprite_terminator
+sCuboneGfx23:
+.incbin "baserom.gba", 0x973334, 0x200
+sCuboneSprites23:
+ax_sprite sCuboneGfx23, 0x200
+ax_sprite_terminator
+sCuboneGfx24:
+.incbin "baserom.gba", 0x973544, 0x200
+sCuboneSprites24:
+ax_sprite sCuboneGfx24, 0x200
+ax_sprite_terminator
+sCuboneGfx25:
+.incbin "baserom.gba", 0x973754, 0x60
+sCuboneGfx25_1:
+.incbin "baserom.gba", 0x9737B4, 0x60
+sCuboneGfx25_2:
+.incbin "baserom.gba", 0x973814, 0x60
+sCuboneGfx25_3:
+.incbin "baserom.gba", 0x973874, 0x20
+sCuboneSprites25:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx25_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx26:
+.incbin "baserom.gba", 0x9738E4, 0x100
+sCuboneSprites26:
+ax_sprite sCuboneGfx26, 0x100
+ax_sprite_terminator
+sCuboneGfx27:
+.incbin "baserom.gba", 0x9739F4, 0x60
+sCuboneGfx27_1:
+.incbin "baserom.gba", 0x973A54, 0x60
+sCuboneGfx27_2:
+.incbin "baserom.gba", 0x973AB4, 0x40
+sCuboneSprites27:
+ax_sprite 0, 0xa0
+ax_sprite sCuboneGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx28:
+.incbin "baserom.gba", 0x973B34, 0x60
+sCuboneGfx28_1:
+.incbin "baserom.gba", 0x973B94, 0x60
+sCuboneGfx28_2:
+.incbin "baserom.gba", 0x973BF4, 0x60
+sCuboneGfx28_3:
+.incbin "baserom.gba", 0x973C54, 0x60
+sCuboneSprites28:
+ax_sprite sCuboneGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx29:
+.incbin "baserom.gba", 0x973CFC, 0x40
+sCuboneGfx29_1:
+.incbin "baserom.gba", 0x973D3C, 0x60
+sCuboneGfx29_2:
+.incbin "baserom.gba", 0x973D9C, 0x20
+sCuboneGfx29_3:
+.incbin "baserom.gba", 0x973DBC, 0x20
+sCuboneSprites29:
+ax_sprite sCuboneGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx29_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx29_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx29_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx30:
+.incbin "baserom.gba", 0x973E24, 0x20
+sCuboneGfx30_1:
+.incbin "baserom.gba", 0x973E44, 0x40
+sCuboneGfx30_2:
+.incbin "baserom.gba", 0x973E84, 0x60
+sCuboneGfx30_3:
+.incbin "baserom.gba", 0x973EE4, 0x60
+sCuboneSprites30:
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx31:
+.incbin "baserom.gba", 0x973F94, 0x20
+sCuboneGfx31_1:
+.incbin "baserom.gba", 0x973FB4, 0x60
+sCuboneGfx31_2:
+.incbin "baserom.gba", 0x974014, 0x60
+sCuboneGfx31_3:
+.incbin "baserom.gba", 0x974074, 0x40
+sCuboneSprites31:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx31, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCuboneGfx32:
+.incbin "baserom.gba", 0x974104, 0x40
+sCuboneGfx32_1:
+.incbin "baserom.gba", 0x974144, 0x80
+sCuboneGfx32_2:
+.incbin "baserom.gba", 0x9741C4, 0x40
+sCuboneGfx32_3:
+.incbin "baserom.gba", 0x974204, 0x20
+sCuboneSprites32:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx32_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx32_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx32_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx33:
+.incbin "baserom.gba", 0x974274, 0x40
+sCuboneGfx33_1:
+.incbin "baserom.gba", 0x9742B4, 0x40
+sCuboneGfx33_2:
+.incbin "baserom.gba", 0x9742F4, 0xE0
+sCuboneSprites33:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx33_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx33_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx34:
+.incbin "baserom.gba", 0x974414, 0x40
+sCuboneGfx34_1:
+.incbin "baserom.gba", 0x974454, 0x60
+sCuboneGfx34_2:
+.incbin "baserom.gba", 0x9744B4, 0x60
+sCuboneGfx34_3:
+.incbin "baserom.gba", 0x974514, 0x60
+sCuboneSprites34:
+ax_sprite sCuboneGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx35:
+.incbin "baserom.gba", 0x9745BC, 0x40
+sCuboneGfx35_1:
+.incbin "baserom.gba", 0x9745FC, 0x60
+sCuboneSprites35:
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx35_1, 0x60
+ax_sprite_terminator
+sCuboneGfx36:
+.incbin "baserom.gba", 0x974684, 0x20
+sCuboneGfx36_1:
+.incbin "baserom.gba", 0x9746A4, 0x60
+sCuboneGfx36_2:
+.incbin "baserom.gba", 0x974704, 0x80
+sCuboneGfx36_3:
+.incbin "baserom.gba", 0x974784, 0x40
+sCuboneSprites36:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx36_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx37:
+.incbin "baserom.gba", 0x974814, 0x40
+sCuboneGfx37_1:
+.incbin "baserom.gba", 0x974854, 0x60
+sCuboneGfx37_2:
+.incbin "baserom.gba", 0x9748B4, 0x60
+sCuboneGfx37_3:
+.incbin "baserom.gba", 0x974914, 0x40
+sCuboneSprites37:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx38:
+.incbin "baserom.gba", 0x9749A4, 0x40
+sCuboneSprites38:
+ax_sprite sCuboneGfx38, 0x40
+ax_sprite_terminator
+sCuboneGfx39:
+.incbin "baserom.gba", 0x9749F4, 0x40
+sCuboneGfx39_1:
+.incbin "baserom.gba", 0x974A34, 0x40
+sCuboneGfx39_2:
+.incbin "baserom.gba", 0x974A74, 0x40
+sCuboneGfx39_3:
+.incbin "baserom.gba", 0x974AB4, 0x40
+sCuboneSprites39:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx39_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx40:
+.incbin "baserom.gba", 0x974B44, 0x40
+sCuboneGfx40_1:
+.incbin "baserom.gba", 0x974B84, 0x60
+sCuboneGfx40_2:
+.incbin "baserom.gba", 0x974BE4, 0x60
+sCuboneGfx40_3:
+.incbin "baserom.gba", 0x974C44, 0x40
+sCuboneSprites40:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx40_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx41:
+.incbin "baserom.gba", 0x974CD4, 0x40
+sCuboneGfx41_1:
+.incbin "baserom.gba", 0x974D14, 0x60
+sCuboneGfx41_2:
+.incbin "baserom.gba", 0x974D74, 0x80
+sCuboneGfx41_3:
+.incbin "baserom.gba", 0x974DF4, 0x20
+sCuboneSprites41:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx41_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx41_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCuboneGfx42:
+.incbin "baserom.gba", 0x974E64, 0x100
+sCuboneSprites42:
+ax_sprite sCuboneGfx42, 0x100
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sCuboneGfx43:
+.incbin "baserom.gba", 0x974F7C, 0x60
+sCuboneGfx43_1:
+.incbin "baserom.gba", 0x974FDC, 0x60
+sCuboneGfx43_2:
+.incbin "baserom.gba", 0x97503C, 0x60
+sCuboneGfx43_3:
+.incbin "baserom.gba", 0x97509C, 0x40
+sCuboneSprites43:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx43_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx43_3, 0x40
+ax_sprite_terminator
+sCuboneGfx44:
+.incbin "baserom.gba", 0x975124, 0x60
+sCuboneGfx44_1:
+.incbin "baserom.gba", 0x975184, 0xA0
+sCuboneSprites44:
+ax_sprite sCuboneGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx44_1, 0xa0
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sCuboneGfx45:
+.incbin "baserom.gba", 0x97524C, 0x40
+sCuboneGfx45_1:
+.incbin "baserom.gba", 0x97528C, 0x60
+sCuboneGfx45_2:
+.incbin "baserom.gba", 0x9752EC, 0xE0
+sCuboneSprites45:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx45_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx46:
+.incbin "baserom.gba", 0x97540C, 0x40
+sCuboneGfx46_1:
+.incbin "baserom.gba", 0x97544C, 0x60
+sCuboneGfx46_2:
+.incbin "baserom.gba", 0x9754AC, 0x60
+sCuboneGfx46_3:
+.incbin "baserom.gba", 0x97550C, 0x20
+sCuboneSprites46:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx46_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx46_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx47:
+.incbin "baserom.gba", 0x97557C, 0x60
+sCuboneGfx47_1:
+.incbin "baserom.gba", 0x9755DC, 0x40
+sCuboneGfx47_2:
+.incbin "baserom.gba", 0x97561C, 0x20
+sCuboneGfx47_3:
+.incbin "baserom.gba", 0x97563C, 0x20
+sCuboneSprites47:
+ax_sprite sCuboneGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx47_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx47_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx47_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sCuboneGfx48:
+.incbin "baserom.gba", 0x9756A4, 0x20
+sCuboneGfx48_1:
+.incbin "baserom.gba", 0x9756C4, 0x140
+sCuboneSprites48:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx48, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx48_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx49:
+.incbin "baserom.gba", 0x975834, 0x60
+sCuboneGfx49_1:
+.incbin "baserom.gba", 0x975894, 0x20
+sCuboneGfx49_2:
+.incbin "baserom.gba", 0x9758B4, 0x20
+sCuboneSprites49:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx49_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx49_2, 0x20
+ax_sprite_terminator
+sCuboneGfx50:
+.incbin "baserom.gba", 0x97590C, 0x60
+sCuboneGfx50_1:
+.incbin "baserom.gba", 0x97596C, 0x60
+sCuboneGfx50_2:
+.incbin "baserom.gba", 0x9759CC, 0x40
+sCuboneSprites50:
+ax_sprite 0, 0xa0
+ax_sprite sCuboneGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx50_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx51:
+.incbin "baserom.gba", 0x975A4C, 0x60
+sCuboneGfx51_1:
+.incbin "baserom.gba", 0x975AAC, 0x40
+sCuboneGfx51_2:
+.incbin "baserom.gba", 0x975AEC, 0x20
+sCuboneSprites51:
+ax_sprite 0, 0x80
+ax_sprite sCuboneGfx51, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx51_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx51_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx52:
+.incbin "baserom.gba", 0x975B4C, 0x20
+sCuboneGfx52_1:
+.incbin "baserom.gba", 0x975B6C, 0x40
+sCuboneGfx52_2:
+.incbin "baserom.gba", 0x975BAC, 0x60
+sCuboneGfx52_3:
+.incbin "baserom.gba", 0x975C0C, 0x40
+sCuboneSprites52:
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx52, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx52_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx52_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCuboneGfx53:
+.incbin "baserom.gba", 0x975C9C, 0x60
+sCuboneGfx53_1:
+.incbin "baserom.gba", 0x975CFC, 0x20
+sCuboneSprites53:
+ax_sprite sCuboneGfx53, 0x60
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx53_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx54:
+.incbin "baserom.gba", 0x975D44, 0x40
+sCuboneGfx54_1:
+.incbin "baserom.gba", 0x975D84, 0x40
+sCuboneGfx54_2:
+.incbin "baserom.gba", 0x975DC4, 0x80
+sCuboneGfx54_3:
+.incbin "baserom.gba", 0x975E44, 0x20
+sCuboneSprites54:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx54, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx54_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx54_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx54_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCuboneGfx55:
+.incbin "baserom.gba", 0x975EB4, 0x40
+sCuboneGfx55_1:
+.incbin "baserom.gba", 0x975EF4, 0x60
+sCuboneSprites55:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx55, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx55_1, 0x60
+ax_sprite_terminator
+sCuboneGfx56:
+.incbin "baserom.gba", 0x975F7C, 0x40
+sCuboneGfx56_1:
+.incbin "baserom.gba", 0x975FBC, 0x60
+sCuboneGfx56_2:
+.incbin "baserom.gba", 0x97601C, 0x60
+sCuboneSprites56:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx56_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCuboneGfx57:
+.incbin "baserom.gba", 0x9760BC, 0x40
+sCuboneSprites57:
+ax_sprite sCuboneGfx57, 0x40
+ax_sprite_terminator
+sCuboneGfx58:
+.incbin "baserom.gba", 0x97610C, 0x40
+sCuboneGfx58_1:
+.incbin "baserom.gba", 0x97614C, 0x40
+sCuboneGfx58_2:
+.incbin "baserom.gba", 0x97618C, 0x40
+sCuboneGfx58_3:
+.incbin "baserom.gba", 0x9761CC, 0x40
+sCuboneSprites58:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx58, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx58_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx58_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx58_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx59:
+.incbin "baserom.gba", 0x97625C, 0x40
+sCuboneGfx59_1:
+.incbin "baserom.gba", 0x97629C, 0x60
+sCuboneGfx59_2:
+.incbin "baserom.gba", 0x9762FC, 0x80
+sCuboneGfx59_3:
+.incbin "baserom.gba", 0x97637C, 0x20
+sCuboneSprites59:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx59_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx59_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx59_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCuboneGfx60:
+.incbin "baserom.gba", 0x9763EC, 0x60
+sCuboneGfx60_1:
+.incbin "baserom.gba", 0x97644C, 0x20
+sCuboneGfx60_2:
+.incbin "baserom.gba", 0x97646C, 0x20
+sCuboneSprites60:
+ax_sprite sCuboneGfx60, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx60_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCuboneGfx60_2, 0x20
+ax_sprite_terminator
+sCuboneGfx61:
+.incbin "baserom.gba", 0x9764BC, 0x40
+sCuboneGfx61_1:
+.incbin "baserom.gba", 0x9764FC, 0x60
+sCuboneGfx61_2:
+.incbin "baserom.gba", 0x97655C, 0x20
+sCuboneSprites61:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx61, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx61_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx61_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sCuboneGfx62:
+.incbin "baserom.gba", 0x9765BC, 0x40
+sCuboneGfx62_1:
+.incbin "baserom.gba", 0x9765FC, 0x60
+sCuboneGfx62_2:
+.incbin "baserom.gba", 0x97665C, 0x80
+sCuboneGfx62_3:
+.incbin "baserom.gba", 0x9766DC, 0x40
+sCuboneSprites62:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx62, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx62_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx62_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx62_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx63:
+.incbin "baserom.gba", 0x97676C, 0x60
+sCuboneGfx63_1:
+.incbin "baserom.gba", 0x9767CC, 0x20
+sCuboneGfx63_2:
+.incbin "baserom.gba", 0x9767EC, 0x20
+sCuboneSprites63:
+ax_sprite sCuboneGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx63_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx63_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sCuboneGfx64:
+.incbin "baserom.gba", 0x976844, 0x20
+sCuboneGfx64_1:
+.incbin "baserom.gba", 0x976864, 0xE0
+sCuboneGfx64_2:
+.incbin "baserom.gba", 0x976944, 0x40
+sCuboneSprites64:
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx64, 0x20
+ax_sprite 0, 0x60
+ax_sprite sCuboneGfx64_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sCuboneGfx64_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sCuboneGfx65:
+.incbin "baserom.gba", 0x9769C4, 0x200
+sCuboneSprites65:
+ax_sprite sCuboneGfx65, 0x200
+ax_sprite_terminator
+sCuboneGfx66:
+.incbin "baserom.gba", 0x976BD4, 0x200
+sCuboneSprites66:
+ax_sprite sCuboneGfx66, 0x200
+ax_sprite_terminator
+sCuboneGfx67:
+.incbin "baserom.gba", 0x976DE4, 0x200
+sCuboneSprites67:
+ax_sprite sCuboneGfx67, 0x200
+ax_sprite_terminator
+sCuboneGfx68:
+.incbin "baserom.gba", 0x976FF4, 0x200
+sCuboneSprites68:
+ax_sprite sCuboneGfx68, 0x200
+ax_sprite_terminator
+sCuboneGfx69:
+.incbin "baserom.gba", 0x977204, 0x200
+sCuboneSprites69:
+ax_sprite sCuboneGfx69, 0x200
+ax_sprite_terminator
+sCuboneGfx70:
+.incbin "baserom.gba", 0x977414, 0x200
+sCuboneSprites70:
+ax_sprite sCuboneGfx70, 0x200
+ax_sprite_terminator
+sCuboneGfx71:
+.incbin "baserom.gba", 0x977624, 0x200
+sCuboneSprites71:
+ax_sprite sCuboneGfx71, 0x200
+ax_sprite_terminator
+sCuboneGfx72:
+.incbin "baserom.gba", 0x977834, 0x200
+sCuboneSprites72:
+ax_sprite sCuboneGfx72, 0x200
+ax_sprite_terminator
+sCuboneGfx73:
+.incbin "baserom.gba", 0x977A44, 0x200
+sCuboneSprites73:
+ax_sprite sCuboneGfx73, 0x200
+ax_sprite_terminator
+sCuboneGfx74:
+.incbin "baserom.gba", 0x977C54, 0x200
+sCuboneSprites74:
+ax_sprite sCuboneGfx74, 0x200
+ax_sprite_terminator
+sCuboneGfx75:
+.incbin "baserom.gba", 0x977E64, 0x200
+sCuboneSprites75:
+ax_sprite sCuboneGfx75, 0x200
+ax_sprite_terminator
+sCuboneGfx76:
+.incbin "baserom.gba", 0x978074, 0x200
+sCuboneSprites76:
+ax_sprite sCuboneGfx76, 0x200
+ax_sprite_terminator
+sCuboneGfx77:
+.incbin "baserom.gba", 0x978284, 0x200
+sCuboneSprites77:
+ax_sprite sCuboneGfx77, 0x200
+ax_sprite_terminator
+sCuboneGfx78:
+.incbin "baserom.gba", 0x978494, 0x200
+sCuboneSprites78:
+ax_sprite sCuboneGfx78, 0x200
+ax_sprite_terminator
+sCuboneGfx79:
+.incbin "baserom.gba", 0x9786A4, 0x200
+sCuboneSprites79:
+ax_sprite sCuboneGfx79, 0x200
+ax_sprite_terminator
+sCuboneGfx80:
+.incbin "baserom.gba", 0x9788B4, 0x200
+sCuboneSprites80:
+ax_sprite sCuboneGfx80, 0x200
+ax_sprite_terminator
+sCuboneGfx81:
+.incbin "baserom.gba", 0x978AC4, 0x200
+sCuboneSprites81:
+ax_sprite sCuboneGfx81, 0x200
+ax_sprite_terminator
+sCuboneGfx82:
+.incbin "baserom.gba", 0x978CD4, 0x200
+sCuboneSprites82:
+ax_sprite sCuboneGfx82, 0x200
+ax_sprite_terminator
+sCuboneGfx83:
+.incbin "baserom.gba", 0x978EE4, 0x200
+sCuboneSprites83:
+ax_sprite sCuboneGfx83, 0x200
+ax_sprite_terminator
+sCuboneGfx84:
+.incbin "baserom.gba", 0x9790F4, 0x200
+sCuboneSprites84:
+ax_sprite sCuboneGfx84, 0x200
+ax_sprite_terminator
+sCuboneGfx85:
+.incbin "baserom.gba", 0x979304, 0x200
+sCuboneSprites85:
+ax_sprite sCuboneGfx85, 0x200
+ax_sprite_terminator
+sCuboneGfx86:
+.incbin "baserom.gba", 0x979514, 0x200
+sCuboneSprites86:
+ax_sprite sCuboneGfx86, 0x200
+ax_sprite_terminator
+sCuboneGfx87:
+.incbin "baserom.gba", 0x979724, 0x200
+sCuboneSprites87:
+ax_sprite sCuboneGfx87, 0x200
+ax_sprite_terminator
+sCuboneGfx88:
+.incbin "baserom.gba", 0x979934, 0x200
+sCuboneSprites88:
+ax_sprite sCuboneGfx88, 0x200
+ax_sprite_terminator
+sCuboneGfx89:
+.incbin "baserom.gba", 0x979B44, 0x200
+sCuboneSprites89:
+ax_sprite sCuboneGfx89, 0x200
+ax_sprite_terminator
+sCuboneGfx90:
+.incbin "baserom.gba", 0x979D54, 0x200
+sCuboneSprites90:
+ax_sprite sCuboneGfx90, 0x200
+ax_sprite_terminator
+sCuboneGfx91:
+.incbin "baserom.gba", 0x979F64, 0x200
+sCuboneSprites91:
+ax_sprite sCuboneGfx91, 0x200
+ax_sprite_terminator
+sCuboneGfx92:
+.incbin "baserom.gba", 0x97A174, 0x200
+sCuboneSprites92:
+ax_sprite sCuboneGfx92, 0x200
+ax_sprite_terminator
+sCuboneGfx93:
+.incbin "baserom.gba", 0x97A384, 0x200
+sCuboneSprites93:
+ax_sprite sCuboneGfx93, 0x200
+ax_sprite_terminator
+sCuboneGfx94:
+.incbin "baserom.gba", 0x97A594, 0x200
+sCuboneSprites94:
+ax_sprite sCuboneGfx94, 0x200
+ax_sprite_terminator
+sCuboneGfx95:
+.incbin "baserom.gba", 0x97A7A4, 0x200
+sCuboneSprites95:
+ax_sprite sCuboneGfx95, 0x200
+ax_sprite_terminator
+sCuboneGfx96:
+.incbin "baserom.gba", 0x97A9B4, 0x200
+sCuboneSprites96:
+ax_sprite sCuboneGfx96, 0x200
+ax_sprite_terminator
+sCuboneGfx97:
+.incbin "baserom.gba", 0x97ABC4, 0x200
+sCuboneSprites97:
+ax_sprite sCuboneGfx97, 0x200
+ax_sprite_terminator
+sCuboneGfx98:
+.incbin "baserom.gba", 0x97ADD4, 0x200
+sCuboneSprites98:
+ax_sprite sCuboneGfx98, 0x200
+ax_sprite_terminator
+sCuboneGfx99:
+.incbin "baserom.gba", 0x97AFE4, 0x200
+sCuboneSprites99:
+ax_sprite sCuboneGfx99, 0x200
+ax_sprite_terminator
+sCuboneGfx100:
+.incbin "baserom.gba", 0x97B1F4, 0x200
+sCuboneSprites100:
+ax_sprite sCuboneGfx100, 0x200
+ax_sprite_terminator
+sCuboneGfx101:
+.incbin "baserom.gba", 0x97B404, 0x200
+sCuboneSprites101:
+ax_sprite sCuboneGfx101, 0x200
+ax_sprite_terminator
+sCuboneGfx102:
+.incbin "baserom.gba", 0x97B614, 0x200
+sCuboneSprites102:
+ax_sprite sCuboneGfx102, 0x200
+ax_sprite_terminator
+sCuboneGfx103:
+.incbin "baserom.gba", 0x97B824, 0x200
+sCuboneSprites103:
+ax_sprite sCuboneGfx103, 0x200
+ax_sprite_terminator
+sCuboneGfx104:
+.incbin "baserom.gba", 0x97BA34, 0x200
+sCuboneSprites104:
+ax_sprite sCuboneGfx104, 0x200
+ax_sprite_terminator
+sCuboneGfx105:
+.incbin "baserom.gba", 0x97BC44, 0x200
+sCuboneSprites105:
+ax_sprite sCuboneGfx105, 0x200
+ax_sprite_terminator
+sCuboneGfx106:
+.incbin "baserom.gba", 0x97BE54, 0x200
+sCuboneSprites106:
+ax_sprite sCuboneGfx106, 0x200
+ax_sprite_terminator
+sCuboneGfx107:
+.incbin "baserom.gba", 0x97C064, 0x200
+sCuboneSprites107:
+ax_sprite sCuboneGfx107, 0x200
+ax_sprite_terminator
+sCuboneGfx108:
+.incbin "baserom.gba", 0x97C274, 0x200
+sCuboneSprites108:
+ax_sprite sCuboneGfx108, 0x200
+ax_sprite_terminator
+sAxPosesCubone:
+.4byte sCubonePose1
+.4byte sCubonePose2
+.4byte sCubonePose3
+.4byte sCubonePose4
+.4byte sCubonePose5
+.4byte sCubonePose6
+.4byte sCubonePose7
+.4byte sCubonePose8
+.4byte sCubonePose9
+.4byte sCubonePose10
+.4byte sCubonePose11
+.4byte sCubonePose12
+.4byte sCubonePose13
+.4byte sCubonePose14
+.4byte sCubonePose15
+.4byte sCubonePose16
+.4byte sCubonePose17
+.4byte sCubonePose18
+.4byte sCubonePose19
+.4byte sCubonePose20
+.4byte sCubonePose21
+.4byte sCubonePose22
+.4byte sCubonePose23
+.4byte sCubonePose24
+.4byte sCubonePose25
+.4byte sCubonePose26
+.4byte sCubonePose27
+.4byte sCubonePose28
+.4byte sCubonePose29
+.4byte sCubonePose30
+.4byte sCubonePose31
+.4byte sCubonePose32
+.4byte sCubonePose33
+.4byte sCubonePose34
+.4byte sCubonePose35
+.4byte sCubonePose36
+.4byte sCubonePose37
+.4byte sCubonePose38
+.4byte sCubonePose39
+.4byte sCubonePose40
+.4byte sCubonePose41
+.4byte sCubonePose42
+.4byte sCubonePose43
+.4byte sCubonePose44
+.4byte sCubonePose45
+.4byte sCubonePose46
+.4byte sCubonePose47
+.4byte sCubonePose48
+.4byte sCubonePose49
+.4byte sCubonePose50
+.4byte sCubonePose51
+.4byte sCubonePose52
+.4byte sCubonePose53
+.4byte sCubonePose54
+.4byte sCubonePose55
+.4byte sCubonePose56
+.4byte sCubonePose57
+.4byte sCubonePose58
+.4byte sCubonePose59
+.4byte sCubonePose60
+.4byte sCubonePose61
+.4byte sCubonePose62
+.4byte sCubonePose63
+.4byte sCubonePose64
+.4byte sCubonePose65
+.4byte sCubonePose66
+.4byte sCubonePose67
+.4byte sCubonePose68
+.4byte sCubonePose69
+.4byte sCubonePose70
+.4byte sCubonePose71
+.4byte sCubonePose72
+.4byte sCubonePose73
+.4byte sCubonePose74
+.4byte sCubonePose75
+.4byte sCubonePose76
+.4byte sCubonePose77
+.4byte sCubonePose78
+.4byte sCubonePose79
+.4byte sCubonePose80
+.4byte sCubonePose81
+.4byte sCubonePose82
+.4byte sCubonePose83
+.4byte sCubonePose84
+.4byte sCubonePose85
+.4byte sCubonePose86
+.4byte sCubonePose87
+.4byte sCubonePose88
+.4byte sCubonePose89
+.4byte sCubonePose90
+.4byte sCubonePose91
+.4byte sCubonePose92
+.4byte sCubonePose93
+.4byte sCubonePose94
+.4byte sCubonePose95
+.4byte sCubonePose96
+.4byte sCubonePose97
+.4byte sCubonePose98
+.4byte sCubonePose99
+.4byte sCubonePose100
+.4byte sCubonePose101
+.4byte sCubonePose102
+.4byte sCubonePose103
+.4byte sCubonePose104
+.4byte sCubonePose105
+.4byte sCubonePose106
+.4byte sCubonePose107
+.4byte sCubonePose108
+.4byte sCubonePose109
+.4byte sCubonePose110
+.4byte sCubonePose111
+.4byte sCubonePose112
+.4byte sCubonePose113
+.4byte sCubonePose114
+.4byte sCubonePose115
+.4byte sCubonePose116
+.4byte sCubonePose117
+.4byte sCubonePose118
+.4byte sCubonePose119
+.4byte sCubonePose120
+.4byte sCubonePose121
+.4byte sCubonePose122
+.4byte sCubonePose123
+.4byte sCubonePose124
+.4byte sCubonePose125
+.4byte sCubonePose126
+.4byte sCubonePose127
+.4byte sCubonePose128
+.4byte sCubonePose129
+.4byte sCubonePose130
+.4byte sCubonePose131
+.4byte sCubonePose132
+.4byte sCubonePose133
+.4byte sCubonePose134
+.4byte sCubonePose135
+.4byte sCubonePose136
+.4byte sCubonePose137
+.4byte sCubonePose138
+.4byte sCubonePose139
+.4byte sCubonePose140
+.4byte sCubonePose141
+.4byte sCubonePose142
+.4byte sCubonePose143
+.4byte sCubonePose144
+.4byte sCubonePose145
+.4byte sCubonePose146
+.4byte sCubonePose147
+.4byte sCubonePose148
+.4byte sCubonePose149
+.4byte sCubonePose150
+.4byte sCubonePose151
+.4byte sCubonePose152
+.4byte sCubonePose153
+.4byte sCubonePose154
+.4byte sCubonePose155
+.4byte sCubonePose156
+.4byte sCubonePose157
+.4byte sCubonePose158
+.4byte sCubonePose159
+.4byte sCubonePose160
+.4byte sCubonePose161
+.4byte sCubonePose162
+.4byte sCubonePose163
+.4byte sCubonePose164
+.4byte sCubonePose165
+.4byte sCubonePose166
+.4byte sCubonePose167
+.4byte sCubonePose168
+.4byte sCubonePose169
+.4byte sCubonePose170
+.4byte sCubonePose171
+.4byte sCubonePose172
+.4byte sCubonePose173
+.4byte sCubonePose174
+.4byte sCubonePose175
+.4byte sCubonePose176
+.4byte sCubonePose177
+.4byte sCubonePose178
+.4byte sCubonePose179
+.4byte sCubonePose180
+.4byte sCubonePose181
+.4byte sCubonePose182
+.4byte sCubonePose183
+.4byte sCubonePose184
+.4byte sCubonePose185
+.4byte sCubonePose186
+.4byte sCubonePose187
+.4byte sCubonePose188
+.4byte sCubonePose189
+.4byte sCubonePose190
+.4byte sCubonePose191
+.4byte sCubonePose192
+.4byte sCubonePose193
+.4byte sCubonePose194
+.4byte sCubonePose195
+.4byte sCubonePose196
+.4byte sCubonePose197
+.4byte sCubonePose198
+.4byte sCubonePose199
+.4byte sCubonePose200
+.4byte sCubonePose201
+.4byte sCubonePose202
+.4byte sCubonePose203
+.4byte sCubonePose204
+.4byte sCubonePose205
+.4byte sCubonePose206
+.4byte sCubonePose207
+.4byte sCubonePose208
+.4byte sCubonePose209
+.4byte sCubonePose210
+.4byte sCubonePose211
+.4byte sCubonePose212
+.4byte sCubonePose213
+.4byte sCubonePose214
+.4byte sCubonePose215
+.4byte sCubonePose216
+.4byte sCubonePose217
+.4byte sCubonePose218
+.4byte sCubonePose219
+.4byte sCubonePose220
+.4byte sCubonePose221
+.4byte sCubonePose222
+.4byte sCubonePose223
+.4byte sCubonePose224
+.4byte sCubonePose225
+.4byte sCubonePose226
+.4byte sCubonePose227
+.4byte sCubonePose228
+.4byte sCubonePose229
+.4byte sCubonePose230
+.4byte sCubonePose231
+.4byte sCubonePose232
+.4byte sCubonePose233
+.4byte sCubonePose234
+.4byte sCubonePose235
+.4byte sCubonePose236
+.4byte sCubonePose237
+.4byte sCubonePose238
+.4byte sCubonePose239
+.4byte sCubonePose240
+.4byte sCubonePose241
+.4byte sCubonePose242
+.4byte sCubonePose243
+.4byte sCubonePose244
+.4byte sCubonePose245
+.4byte sCubonePose246
+.4byte sCubonePose247
+.4byte sCubonePose248
+.4byte sCubonePose249
+.4byte sCubonePose250
+.4byte sCubonePose251
+.4byte sCubonePose252
+.4byte sCubonePose253
+.4byte sCubonePose254
+.4byte sCubonePose255
+.4byte sCubonePose256
+.4byte sCubonePose257
+.4byte sCubonePose258
+.4byte sCubonePose259
+sAxPositionsCubone:
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -1,   -2, 	  -8,   -4, 	   6,   -3, 	  -1,   -6
+.2byte    1,   -2, 	  -6,   -1, 	   7,   -5, 	   1,   -6
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    5,   -3, 	  -6,   -3, 	   4,   -4, 	   0,   -2
+.2byte    6,   -4, 	  -2,   -2, 	   4,   -6, 	   1,   -3
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    6,   -6, 	  -1,   -2, 	   3,   -6, 	   0,   -4
+.2byte    7,   -7, 	   4,   -3, 	  -3,   -7, 	   1,   -4
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    7,   -9, 	   3,   -2, 	  -3,   -4, 	   1,   -4
+.2byte    5,   -9, 	   6,   -3, 	  -7,   -4, 	   1,   -4
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    1,  -15, 	   6,   -4, 	  -8,   -6, 	   1,   -4
+.2byte   -1,  -15, 	   6,   -7, 	  -7,   -3, 	  -1,   -4
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -7,  -10, 	   1,   -6, 	  -6,   -3, 	   0,   -4
+.2byte   -9,   -9, 	  -2,   -8, 	  -4,   -1, 	  -1,   -3
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte  -10,   -7, 	  -8,   -6, 	  -4,   -2, 	  -2,   -4
+.2byte  -10,   -6, 	  -8,   -5, 	   1,   -2, 	  -1,   -4
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -8,   -4, 	 -11,   -4, 	   0,   -1, 	  -2,   -4
+.2byte   -7,   -3, 	 -11,   -2, 	   4,   -3, 	  -1,   -3
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -1,   -2, 	  -8,   -4, 	   6,   -3, 	  -1,   -6
+.2byte    1,   -2, 	  -6,   -1, 	   7,   -5, 	   1,   -6
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    5,   -3, 	  -6,   -3, 	   4,   -4, 	   0,   -2
+.2byte    6,   -4, 	  -2,   -2, 	   4,   -6, 	   1,   -3
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    6,   -6, 	  -1,   -2, 	   3,   -6, 	   0,   -4
+.2byte    7,   -7, 	   4,   -3, 	  -3,   -7, 	   1,   -4
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    7,   -9, 	   3,   -2, 	  -3,   -4, 	   1,   -4
+.2byte    5,   -9, 	   6,   -3, 	  -7,   -4, 	   1,   -4
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    1,  -15, 	   6,   -4, 	  -8,   -6, 	   1,   -4
+.2byte   -1,  -15, 	   6,   -7, 	  -7,   -3, 	  -1,   -4
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -7,  -10, 	   1,   -6, 	  -6,   -3, 	   0,   -4
+.2byte   -9,   -9, 	  -2,   -8, 	  -4,   -1, 	  -1,   -3
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte  -10,   -7, 	  -8,   -6, 	  -4,   -2, 	  -2,   -4
+.2byte  -10,   -6, 	  -8,   -5, 	   1,   -2, 	  -1,   -4
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -8,   -4, 	 -11,   -4, 	   0,   -1, 	  -2,   -4
+.2byte   -7,   -3, 	 -11,   -2, 	   4,   -3, 	  -1,   -3
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -6,   -7, 	  -4,  -13, 	   5,   -4, 	   1,   -5
+.2byte    0,   -1, 	  -4,   -1, 	   7,   -5, 	   0,   -4
+.2byte    0,   -1, 	  -4,   -1, 	   7,   -5, 	   0,   -4
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    3,   -5, 	  -4,   -9, 	   5,   -5, 	   0,   -5
+.2byte    4,   -4, 	   1,   -2, 	  -1,   -9, 	   2,   -6
+.2byte    4,   -4, 	   1,   -2, 	  -1,   -9, 	   2,   -6
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    2,   -6, 	  -3,   -9, 	   4,   -5, 	  -1,   -5
+.2byte    8,   -4, 	   5,   -2, 	  -3,   -8, 	   1,   -5
+.2byte    8,   -4, 	   5,   -2, 	  -3,   -8, 	   1,   -5
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    8,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -4
+.2byte    8,   -8, 	   8,   -6, 	  -5,   -8, 	   1,   -6
+.2byte    8,   -8, 	   8,   -6, 	  -5,   -8, 	   1,   -6
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    6,  -14, 	   7,   -8, 	  -7,   -7, 	   0,   -5
+.2byte    0,  -13, 	   6,  -10, 	  -6,   -3, 	   0,   -5
+.2byte    0,  -13, 	   6,  -10, 	  -6,   -3, 	   0,   -5
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte    0,  -15, 	   6,   -7, 	  -7,   -3, 	   1,   -4
+.2byte   -7,   -5, 	  -5,   -9, 	  -3,   -2, 	  -2,   -5
+.2byte   -7,   -5, 	  -5,   -9, 	  -3,   -2, 	  -2,   -5
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -5,  -11, 	   3,  -15, 	  -4,   -4, 	   2,   -5
+.2byte   -9,   -5, 	  -9,   -3, 	   2,   -5, 	  -2,   -4
+.2byte   -9,   -5, 	  -9,   -3, 	   2,   -5, 	  -2,   -4
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -6,   -9, 	  -3,  -13, 	   1,   -5, 	   1,   -6
+.2byte   -7,   -3, 	  -9,   -2, 	   5,   -6, 	  -2,   -3
+.2byte   -7,   -3, 	  -9,   -2, 	   5,   -6, 	  -2,   -3
+.2byte    0,   -1, 	  -4,   -1, 	   7,   -5, 	   0,   -4
+.2byte   -7,   -3, 	  -9,   -2, 	   5,   -6, 	  -2,   -3
+.2byte   -7,   -5, 	  -7,   -3, 	   4,   -5, 	   0,   -4
+.2byte   -5,   -5, 	  -3,   -9, 	  -1,   -2, 	   0,   -5
+.2byte    0,  -12, 	   6,   -9, 	  -6,   -2, 	   0,   -4
+.2byte    6,   -6, 	   6,   -4, 	  -7,   -6, 	  -1,   -4
+.2byte    6,   -3, 	   3,   -1, 	  -5,   -7, 	  -1,   -4
+.2byte    4,   -3, 	   1,   -1, 	  -1,   -8, 	   2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -6,   -7, 	  -4,  -13, 	   5,   -4, 	   1,   -5
+.2byte    0,   -1, 	  -5,   -1, 	   7,   -5, 	   0,   -4
+.2byte    0,   -1, 	  -5,   -1, 	   7,   -5, 	   0,   -4
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    3,   -5, 	  -4,   -9, 	   5,   -5, 	   0,   -5
+.2byte    6,   -3, 	   3,   -3, 	   0,   -8, 	  -1,   -5
+.2byte    6,   -3, 	   3,   -3, 	   0,   -8, 	  -1,   -5
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    2,   -6, 	  -3,   -9, 	   4,   -5, 	  -1,   -5
+.2byte    8,   -4, 	   7,   -3, 	   1,   -8, 	   1,   -6
+.2byte    8,   -4, 	   7,   -3, 	   1,   -8, 	   1,   -6
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    8,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -4
+.2byte    7,   -8, 	   8,   -6, 	  -5,   -8, 	   1,   -7
+.2byte    7,   -8, 	   8,   -6, 	  -5,   -8, 	   1,   -7
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    6,  -14, 	   7,   -8, 	  -7,   -7, 	   0,   -5
+.2byte    0,  -12, 	   5,  -10, 	  -6,   -3, 	   0,   -6
+.2byte    0,  -12, 	   5,  -10, 	  -6,   -3, 	   0,   -6
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte    0,  -15, 	   6,   -7, 	  -7,   -3, 	   1,   -4
+.2byte   -7,   -5, 	  -7,  -10, 	  -3,   -2, 	  -1,   -5
+.2byte   -7,   -5, 	  -7,  -10, 	  -3,   -2, 	  -1,   -5
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -5,  -11, 	   3,  -15, 	  -4,   -4, 	   2,   -5
+.2byte  -10,   -5, 	  -8,   -3, 	   2,   -4, 	  -1,   -5
+.2byte  -10,   -5, 	  -8,   -3, 	   2,   -4, 	  -1,   -5
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -6,   -9, 	  -3,  -13, 	   1,   -5, 	   1,   -6
+.2byte   -7,   -3, 	  -8,   -2, 	   5,   -6, 	  -2,   -4
+.2byte   -7,   -3, 	  -8,   -2, 	   5,   -6, 	  -2,   -4
+.2byte   -3,   -6, 	  -7,   -5, 	   5,   -2, 	   0,   -4
+.2byte   -2,   -5, 	  -7,   -4, 	   5,   -2, 	   0,   -4
+.2byte    0,  -11, 	  -7,  -10, 	   7,  -10, 	   0,   -8
+.2byte    4,  -13, 	   3,  -13, 	  -8,   -8, 	  -1,   -7
+.2byte    5,  -13, 	  -5,  -13, 	  -5,  -10, 	  -1,   -5
+.2byte    4,  -11, 	  -6,  -13, 	   0,  -10, 	  -1,   -4
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	   0,   -4
+.2byte   -5,  -11, 	   5,  -13, 	  -1,  -10, 	   0,   -4
+.2byte   -7,  -13, 	   3,  -13, 	   3,  -10, 	  -1,   -5
+.2byte   -5,  -13, 	  -4,  -13, 	   7,   -8, 	   0,   -7
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -1,   -2, 	  -8,   -4, 	   6,   -3, 	  -1,   -6
+.2byte    1,   -2, 	  -6,   -1, 	   7,   -5, 	   1,   -6
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    5,   -3, 	  -6,   -3, 	   4,   -4, 	   0,   -2
+.2byte    6,   -4, 	  -2,   -2, 	   4,   -6, 	   1,   -3
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    6,   -6, 	  -1,   -2, 	   3,   -6, 	   0,   -4
+.2byte    7,   -7, 	   4,   -3, 	  -3,   -7, 	   1,   -4
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    7,   -9, 	   3,   -2, 	  -3,   -4, 	   1,   -4
+.2byte    5,   -9, 	   6,   -3, 	  -7,   -4, 	   1,   -4
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    1,  -15, 	   6,   -4, 	  -8,   -6, 	   1,   -4
+.2byte   -1,  -15, 	   6,   -7, 	  -7,   -3, 	  -1,   -4
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -7,  -10, 	   1,   -6, 	  -6,   -3, 	   0,   -4
+.2byte   -9,   -9, 	  -2,   -8, 	  -4,   -1, 	  -1,   -3
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte  -10,   -7, 	  -8,   -6, 	  -4,   -2, 	  -2,   -4
+.2byte  -10,   -6, 	  -8,   -5, 	   1,   -2, 	  -1,   -4
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -8,   -4, 	 -11,   -4, 	   0,   -1, 	  -2,   -4
+.2byte   -7,   -3, 	 -11,   -2, 	   4,   -3, 	  -1,   -3
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -6,   -7, 	  -4,  -13, 	   5,   -4, 	   1,   -5
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte    3,   -5, 	  -4,   -9, 	   5,   -5, 	   0,   -5
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    2,   -6, 	  -3,   -9, 	   4,   -5, 	  -1,   -5
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    8,  -10, 	   1,   -9, 	   2,   -5, 	   0,   -4
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    6,  -14, 	   7,   -8, 	  -7,   -7, 	   0,   -5
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte    0,  -15, 	   6,   -7, 	  -7,   -3, 	   1,   -4
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -5,  -11, 	   3,  -15, 	  -4,   -4, 	   2,   -5
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -6,   -9, 	  -3,  -13, 	   1,   -5, 	   1,   -6
+.2byte    0,   -1, 	  -4,   -1, 	   7,   -5, 	   0,   -4
+.2byte   -7,   -3, 	  -9,   -2, 	   5,   -6, 	  -2,   -3
+.2byte   -7,   -5, 	  -7,   -3, 	   4,   -5, 	   0,   -4
+.2byte   -5,   -5, 	  -3,   -9, 	  -1,   -2, 	   0,   -5
+.2byte    0,  -12, 	   6,   -9, 	  -6,   -2, 	   0,   -4
+.2byte    6,   -6, 	   6,   -4, 	  -7,   -6, 	  -1,   -4
+.2byte    6,   -3, 	   3,   -1, 	  -5,   -7, 	  -1,   -4
+.2byte    4,   -3, 	   1,   -1, 	  -1,   -8, 	   2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -7,   -5, 	 -10,   -5, 	   4,   -2, 	  -1,   -5
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -8,  -11, 	   4,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    6,  -10, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    5,   -5, 	  -5,   -3, 	   5,   -4, 	   0,   -4
+.2byte   -3,  -12, 	  -1,    0, 	  -2,   -5, 	   0,   -5
+.2byte   -2,  -12, 	  -1,    1, 	  -3,   -6, 	  -1,   -3
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -3,  -13, 	  -1,   -1, 	  -2,   -6, 	   0,   -6
+.2byte    1,   -9, 	   0,    0, 	   0,   -7, 	   0,   -4
+.2byte    4,   -4, 	   0,   -1, 	   4,  -10, 	   0,   -4
+.2byte    4,   -4, 	   0,   -1, 	   3,   -4, 	   0,   -5
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    0,  -14, 	   7,   -7, 	  -8,   -7, 	   0,   -7
+.2byte    0,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -7
+.2byte    0,   -2, 	  -5,   -4, 	   6,   -5, 	   0,   -6
+.2byte    0,   -8, 	  -8,   -8, 	   8,   -8, 	   0,   -6
+.2byte    0,   -3, 	  -6,   -5, 	   6,   -5, 	   0,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    1,   -7, 	  -8,  -15, 	   8,   -7, 	   1,   -9
+.2byte    0,  -13, 	   6,   -4, 	  -7,   -5, 	  -1,   -6
+.2byte   -1,  -15, 	   7,  -14, 	  -8,   -5, 	   0,   -6
+.2byte   -1,  -15, 	   7,  -14, 	  -8,   -5, 	   0,   -6
+.2byte    0,   -3, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -6
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -6
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -7,   -9, 	   1,  -11, 	  -8,   -7, 	  -1,   -7
+.2byte   -7,   -5, 	  -2,  -10, 	  -4,   -6, 	   1,   -7
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    0,  -14, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -12, 	   5,   -3, 	  -6,   -5, 	   0,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -8,   -8, 	   8,   -8, 	   0,   -6
+.2byte    0,   -1, 	  -4,   -2, 	   4,   -2, 	   0,   -5
+.2byte   -9,   -8, 	  -8,   -6, 	  -2,   -2, 	  -2,   -5
+.2byte   -3,   -5, 	  -4,   -5, 	  -1,   -2, 	  -3,   -7
+.2byte    6,   -8, 	   1,   -2, 	  -1,   -5, 	   1,   -5
+.2byte    3,   -5, 	   0,   -2, 	   2,   -3, 	   2,   -6
+.2byte    0,  -16, 	   6,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte    0,  -12, 	   6,   -6, 	  -7,   -6, 	   0,   -5
+.2byte   -8,   -8, 	  -4,   -7, 	  -2,   -3, 	  -1,   -7
+.2byte   -7,  -10, 	  -4,   -8, 	  -2,   -4, 	  -1,   -7
+.2byte   -8,   -6, 	  -6,   -5, 	  -3,   -2, 	  -2,   -6
+.2byte   -8,  -10, 	  -6,   -8, 	   2,   -5, 	  -2,   -8
+.2byte   -7,   -6, 	  -5,   -5, 	   1,   -2, 	  -2,   -5
+.2byte    7,   -8, 	   1,   -2, 	   2,   -5, 	   1,   -6
+.2byte    6,  -10, 	   1,   -3, 	   3,   -7, 	   2,   -7
+.2byte    7,   -6, 	   2,   -2, 	   5,   -5, 	   1,   -6
+.2byte    5,   -9, 	  -1,   -5, 	   2,   -6, 	   0,   -8
+.2byte    6,   -6, 	   1,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    2,   -8, 	  -5,   -9, 	   5,   -7, 	  -1,   -7
+.2byte   -3,  -12, 	  -1,    0, 	  -2,   -5, 	   0,   -5
+.2byte   -2,  -12, 	  -1,    1, 	  -3,   -6, 	  -1,   -3
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -3,  -12, 	  -1,    0, 	  -2,   -5, 	   0,   -5
+.2byte   -2,  -12, 	  -1,    1, 	  -3,   -6, 	  -1,   -3
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+sCuboneAnimTable1:
+.4byte sCuboneAnims_1_1
+.4byte sCuboneAnims_1_2
+.4byte sCuboneAnims_1_3
+.4byte sCuboneAnims_1_4
+.4byte sCuboneAnims_1_5
+.4byte sCuboneAnims_1_6
+.4byte sCuboneAnims_1_7
+.4byte sCuboneAnims_1_8
+sCuboneAnimTable2:
+.4byte sCuboneAnims_2_1
+.4byte sCuboneAnims_2_2
+.4byte sCuboneAnims_2_3
+.4byte sCuboneAnims_2_4
+.4byte sCuboneAnims_2_5
+.4byte sCuboneAnims_2_6
+.4byte sCuboneAnims_2_7
+.4byte sCuboneAnims_2_8
+sCuboneAnimTable3:
+.4byte sCuboneAnims_3_1
+.4byte sCuboneAnims_3_2
+.4byte sCuboneAnims_3_3
+.4byte sCuboneAnims_3_4
+.4byte sCuboneAnims_3_5
+.4byte sCuboneAnims_3_6
+.4byte sCuboneAnims_3_7
+.4byte sCuboneAnims_3_8
+sCuboneAnimTable4:
+.4byte sCuboneAnims_4_1
+.4byte sCuboneAnims_4_2
+.4byte sCuboneAnims_4_3
+.4byte sCuboneAnims_4_4
+.4byte sCuboneAnims_4_5
+.4byte sCuboneAnims_4_6
+.4byte sCuboneAnims_4_7
+.4byte sCuboneAnims_4_8
+sCuboneAnimTable5:
+.4byte sCuboneAnims_5_1
+.4byte sCuboneAnims_5_2
+.4byte sCuboneAnims_5_3
+.4byte sCuboneAnims_5_4
+.4byte sCuboneAnims_5_5
+.4byte sCuboneAnims_5_6
+.4byte sCuboneAnims_5_7
+.4byte sCuboneAnims_5_8
+sCuboneAnimTable6:
+.4byte sCuboneAnims_6_1
+.4byte sCuboneAnims_6_1
+.4byte sCuboneAnims_6_1
+.4byte sCuboneAnims_6_1
+.4byte sCuboneAnims_6_1
+.4byte sCuboneAnims_6_1
+.4byte sCuboneAnims_6_1
+.4byte sCuboneAnims_6_1
+sCuboneAnimTable7:
+.4byte sCuboneAnims_7_1
+.4byte sCuboneAnims_7_2
+.4byte sCuboneAnims_7_3
+.4byte sCuboneAnims_7_4
+.4byte sCuboneAnims_7_5
+.4byte sCuboneAnims_7_6
+.4byte sCuboneAnims_7_7
+.4byte sCuboneAnims_7_8
+sCuboneAnimTable8:
+.4byte sCuboneAnims_8_1
+.4byte sCuboneAnims_8_2
+.4byte sCuboneAnims_8_3
+.4byte sCuboneAnims_8_4
+.4byte sCuboneAnims_8_5
+.4byte sCuboneAnims_8_6
+.4byte sCuboneAnims_8_7
+.4byte sCuboneAnims_8_8
+sCuboneAnimTable9:
+.4byte sCuboneAnims_9_1
+.4byte sCuboneAnims_9_2
+.4byte sCuboneAnims_9_3
+.4byte sCuboneAnims_9_4
+.4byte sCuboneAnims_9_5
+.4byte sCuboneAnims_9_6
+.4byte sCuboneAnims_9_7
+.4byte sCuboneAnims_9_8
+sCuboneAnimTable10:
+.4byte sCuboneAnims_10_1
+.4byte sCuboneAnims_10_2
+.4byte sCuboneAnims_10_3
+.4byte sCuboneAnims_10_4
+.4byte sCuboneAnims_10_5
+.4byte sCuboneAnims_10_6
+.4byte sCuboneAnims_10_7
+.4byte sCuboneAnims_10_8
+sCuboneAnimTable11:
+.4byte sCuboneAnims_11_1
+.4byte sCuboneAnims_11_2
+.4byte sCuboneAnims_11_3
+.4byte sCuboneAnims_11_4
+.4byte sCuboneAnims_11_5
+.4byte sCuboneAnims_11_6
+.4byte sCuboneAnims_11_7
+.4byte sCuboneAnims_11_8
+sCuboneAnimTable12:
+.4byte sCuboneAnims_12_1
+.4byte sCuboneAnims_12_2
+.4byte sCuboneAnims_12_3
+.4byte sCuboneAnims_12_4
+.4byte sCuboneAnims_12_5
+.4byte sCuboneAnims_12_6
+.4byte sCuboneAnims_12_7
+.4byte sCuboneAnims_12_8
+sCuboneAnimTable13:
+.4byte sCuboneAnims_13_1
+.4byte sCuboneAnims_13_2
+.4byte sCuboneAnims_13_3
+.4byte sCuboneAnims_13_4
+.4byte sCuboneAnims_13_5
+.4byte sCuboneAnims_13_6
+.4byte sCuboneAnims_13_7
+.4byte sCuboneAnims_13_8
+sCuboneAnimTable14:
+.4byte sCuboneAnims_14_1
+.4byte sCuboneAnims_14_2
+.4byte sCuboneAnims_14_3
+.4byte sCuboneAnims_14_4
+.4byte sCuboneAnims_14_5
+.4byte sCuboneAnims_14_6
+.4byte sCuboneAnims_14_7
+.4byte sCuboneAnims_14_8
+sCuboneAnimTable15:
+.4byte sCuboneAnims_15_1
+.4byte sCuboneAnims_15_2
+.4byte sCuboneAnims_15_3
+.4byte sCuboneAnims_15_4
+.4byte sCuboneAnims_15_5
+.4byte sCuboneAnims_15_6
+.4byte sCuboneAnims_15_7
+.4byte sCuboneAnims_15_8
+sCuboneAnimTable16:
+.4byte sCuboneAnims_16_1
+.4byte sCuboneAnims_16_2
+.4byte sCuboneAnims_16_3
+.4byte sCuboneAnims_16_4
+.4byte sCuboneAnims_16_5
+.4byte sCuboneAnims_16_6
+.4byte sCuboneAnims_16_7
+.4byte sCuboneAnims_16_8
+sCuboneAnimTable17:
+.4byte sCuboneAnims_17_1
+.4byte sCuboneAnims_17_2
+.4byte sCuboneAnims_17_3
+.4byte sCuboneAnims_17_4
+.4byte sCuboneAnims_17_5
+.4byte sCuboneAnims_17_6
+.4byte sCuboneAnims_17_7
+.4byte sCuboneAnims_17_8
+sCuboneAnimTable18:
+.4byte sCuboneAnims_18_1
+.4byte sCuboneAnims_18_2
+.4byte sCuboneAnims_18_3
+.4byte sCuboneAnims_18_4
+.4byte sCuboneAnims_18_5
+.4byte sCuboneAnims_18_6
+.4byte sCuboneAnims_18_7
+.4byte sCuboneAnims_18_8
+sCuboneAnimTable19:
+.4byte sCuboneAnims_19_1
+.4byte sCuboneAnims_19_2
+.4byte sCuboneAnims_19_3
+.4byte sCuboneAnims_19_4
+.4byte sCuboneAnims_19_5
+.4byte sCuboneAnims_19_6
+.4byte sCuboneAnims_19_7
+.4byte sCuboneAnims_19_8
+sCuboneAnimTable20:
+.4byte sCuboneAnims_20_1
+.4byte sCuboneAnims_20_2
+.4byte sCuboneAnims_20_3
+.4byte sCuboneAnims_20_4
+.4byte sCuboneAnims_20_5
+.4byte sCuboneAnims_20_6
+.4byte sCuboneAnims_20_7
+.4byte sCuboneAnims_20_8
+sCuboneAnimTable21:
+.4byte sCuboneAnims_21_1
+.4byte sCuboneAnims_21_2
+.4byte sCuboneAnims_21_3
+.4byte sCuboneAnims_21_4
+.4byte sCuboneAnims_21_5
+.4byte sCuboneAnims_21_6
+.4byte sCuboneAnims_21_7
+.4byte sCuboneAnims_21_8
+sCuboneAnimTable22:
+.4byte sCuboneAnims_22_1
+.4byte sCuboneAnims_22_2
+.4byte sCuboneAnims_22_3
+.4byte sCuboneAnims_22_4
+.4byte sCuboneAnims_22_5
+.4byte sCuboneAnims_22_6
+.4byte sCuboneAnims_22_7
+.4byte sCuboneAnims_22_8
+sCuboneAnimTable23:
+.4byte sCuboneAnims_23_1
+.4byte sCuboneAnims_23_2
+.4byte sCuboneAnims_23_3
+.4byte sCuboneAnims_23_4
+.4byte sCuboneAnims_23_5
+.4byte sCuboneAnims_23_6
+.4byte sCuboneAnims_23_7
+.4byte sCuboneAnims_23_8
+sCuboneAnimTable24:
+.4byte sCuboneAnims_24_1
+.4byte sCuboneAnims_24_2
+.4byte sCuboneAnims_24_3
+.4byte sCuboneAnims_24_4
+.4byte sCuboneAnims_24_5
+.4byte sCuboneAnims_24_6
+.4byte sCuboneAnims_24_7
+.4byte sCuboneAnims_24_8
+sCuboneAnimTable25:
+.4byte sCuboneAnims_25_1
+.4byte sCuboneAnims_25_2
+.4byte sCuboneAnims_25_3
+.4byte sCuboneAnims_25_4
+.4byte sCuboneAnims_25_5
+.4byte sCuboneAnims_25_6
+.4byte sCuboneAnims_25_7
+.4byte sCuboneAnims_25_8
+sCuboneAnimTable26:
+.4byte sCuboneAnims_26_1
+.4byte sCuboneAnims_26_2
+.4byte sCuboneAnims_26_3
+.4byte sCuboneAnims_26_4
+.4byte sCuboneAnims_26_5
+.4byte sCuboneAnims_26_6
+.4byte sCuboneAnims_26_7
+.4byte sCuboneAnims_26_8
+sCuboneAnimTable27:
+.4byte sCuboneAnims_27_1
+.4byte sCuboneAnims_27_1
+.4byte sCuboneAnims_27_1
+.4byte sCuboneAnims_27_1
+.4byte sCuboneAnims_27_1
+.4byte sCuboneAnims_27_1
+.4byte sCuboneAnims_27_1
+.4byte sCuboneAnims_27_1
+sCuboneAnimTable28:
+.4byte sCuboneAnims_28_1
+.4byte sCuboneAnims_28_2
+.4byte sCuboneAnims_28_3
+.4byte sCuboneAnims_28_4
+.4byte sCuboneAnims_28_5
+.4byte sCuboneAnims_28_6
+.4byte sCuboneAnims_28_7
+.4byte sCuboneAnims_28_8
+sAxAnimationsCubone:
+.4byte sCuboneAnimTable1
+.4byte sCuboneAnimTable2
+.4byte sCuboneAnimTable3
+.4byte sCuboneAnimTable4
+.4byte sCuboneAnimTable5
+.4byte sCuboneAnimTable6
+.4byte sCuboneAnimTable7
+.4byte sCuboneAnimTable8
+.4byte sCuboneAnimTable9
+.4byte sCuboneAnimTable10
+.4byte sCuboneAnimTable11
+.4byte sCuboneAnimTable12
+.4byte sCuboneAnimTable13
+.4byte sCuboneAnimTable14
+.4byte sCuboneAnimTable15
+.4byte sCuboneAnimTable16
+.4byte sCuboneAnimTable17
+.4byte sCuboneAnimTable18
+.4byte sCuboneAnimTable19
+.4byte sCuboneAnimTable20
+.4byte sCuboneAnimTable21
+.4byte sCuboneAnimTable22
+.4byte sCuboneAnimTable23
+.4byte sCuboneAnimTable24
+.4byte sCuboneAnimTable25
+.4byte sCuboneAnimTable26
+.4byte sCuboneAnimTable27
+.4byte sCuboneAnimTable28
+sAxSpritesCubone:
+.4byte sCuboneSprites1
+.4byte sCuboneSprites2
+.4byte sCuboneSprites3
+.4byte sCuboneSprites4
+.4byte sCuboneSprites5
+.4byte sCuboneSprites6
+.4byte sCuboneSprites7
+.4byte sCuboneSprites8
+.4byte sCuboneSprites9
+.4byte sCuboneSprites10
+.4byte sCuboneSprites11
+.4byte sCuboneSprites12
+.4byte sCuboneSprites13
+.4byte sCuboneSprites14
+.4byte sCuboneSprites15
+.4byte sCuboneSprites16
+.4byte sCuboneSprites17
+.4byte sCuboneSprites18
+.4byte sCuboneSprites19
+.4byte sCuboneSprites20
+.4byte sCuboneSprites21
+.4byte sCuboneSprites22
+.4byte sCuboneSprites23
+.4byte sCuboneSprites24
+.4byte sCuboneSprites25
+.4byte sCuboneSprites26
+.4byte sCuboneSprites27
+.4byte sCuboneSprites28
+.4byte sCuboneSprites29
+.4byte sCuboneSprites30
+.4byte sCuboneSprites31
+.4byte sCuboneSprites32
+.4byte sCuboneSprites33
+.4byte sCuboneSprites34
+.4byte sCuboneSprites35
+.4byte sCuboneSprites36
+.4byte sCuboneSprites37
+.4byte sCuboneSprites38
+.4byte sCuboneSprites39
+.4byte sCuboneSprites40
+.4byte sCuboneSprites41
+.4byte sCuboneSprites42
+.4byte sCuboneSprites43
+.4byte sCuboneSprites44
+.4byte sCuboneSprites45
+.4byte sCuboneSprites46
+.4byte sCuboneSprites47
+.4byte sCuboneSprites48
+.4byte sCuboneSprites49
+.4byte sCuboneSprites50
+.4byte sCuboneSprites51
+.4byte sCuboneSprites52
+.4byte sCuboneSprites53
+.4byte sCuboneSprites54
+.4byte sCuboneSprites55
+.4byte sCuboneSprites56
+.4byte sCuboneSprites57
+.4byte sCuboneSprites58
+.4byte sCuboneSprites59
+.4byte sCuboneSprites60
+.4byte sCuboneSprites61
+.4byte sCuboneSprites62
+.4byte sCuboneSprites63
+.4byte sCuboneSprites64
+.4byte sCuboneSprites65
+.4byte sCuboneSprites66
+.4byte sCuboneSprites67
+.4byte sCuboneSprites68
+.4byte sCuboneSprites69
+.4byte sCuboneSprites70
+.4byte sCuboneSprites71
+.4byte sCuboneSprites72
+.4byte sCuboneSprites73
+.4byte sCuboneSprites74
+.4byte sCuboneSprites75
+.4byte sCuboneSprites76
+.4byte sCuboneSprites77
+.4byte sCuboneSprites78
+.4byte sCuboneSprites79
+.4byte sCuboneSprites80
+.4byte sCuboneSprites81
+.4byte sCuboneSprites82
+.4byte sCuboneSprites83
+.4byte sCuboneSprites84
+.4byte sCuboneSprites85
+.4byte sCuboneSprites86
+.4byte sCuboneSprites87
+.4byte sCuboneSprites88
+.4byte sCuboneSprites89
+.4byte sCuboneSprites90
+.4byte sCuboneSprites91
+.4byte sCuboneSprites92
+.4byte sCuboneSprites93
+.4byte sCuboneSprites94
+.4byte sCuboneSprites95
+.4byte sCuboneSprites96
+.4byte sCuboneSprites97
+.4byte sCuboneSprites98
+.4byte sCuboneSprites99
+.4byte sCuboneSprites100
+.4byte sCuboneSprites101
+.4byte sCuboneSprites102
+.4byte sCuboneSprites103
+.4byte sCuboneSprites104
+.4byte sCuboneSprites105
+.4byte sCuboneSprites106
+.4byte sCuboneSprites107
+.4byte sCuboneSprites108
+sAxMainCubone:
+ax_main sAxPosesCubone, sAxAnimationsCubone, 28, sAxSpritesCubone, sAxPositionsCubone

--- a/data/ax/cyndaquil.inc
+++ b/data/ax/cyndaquil.inc
@@ -1,0 +1,4214 @@
+.global gAxCyndaquil
+gAxCyndaquil:
+ax_siro sAxMainCyndaquil
+sCyndaquilPose1:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose2:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose3:
+ax_pose 2, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose4:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose5:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose7:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose8:
+ax_pose 7, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose9:
+ax_pose 8, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose10:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose11:
+ax_pose 10, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose13:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose14:
+ax_pose 13, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose15:
+ax_pose 14, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose19:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose20:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose21:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose23:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose25:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose 15, 0x01e7, 0x80f4, 0x2c08
+ax_pose_terminator
+sCyndaquilPose26:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose 16, 0x01e7, 0x80f4, 0x2c08
+ax_pose_terminator
+sCyndaquilPose27:
+ax_pose 2, 0x81eb, 0x80f8, 0x2c00
+ax_pose 17, 0x01e7, 0x80f3, 0x2c08
+ax_pose_terminator
+sCyndaquilPose28:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose 18, 0x01ea, 0x90e8, 0x2c10
+ax_pose_terminator
+sCyndaquilPose29:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose 19, 0x01e9, 0x90e9, 0x2c10
+ax_pose_terminator
+sCyndaquilPose30:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose 20, 0x01e8, 0x90ea, 0x2c10
+ax_pose_terminator
+sCyndaquilPose31:
+ax_pose 21, 0x01ed, 0x90eb, 0x2c00
+ax_pose 6, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose32:
+ax_pose 22, 0x01ed, 0x90eb, 0x2c00
+ax_pose 7, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose33:
+ax_pose 23, 0x01ed, 0x90eb, 0x2c00
+ax_pose 8, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose34:
+ax_pose 24, 0x01ed, 0x90eb, 0x2c00
+ax_pose 9, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose35:
+ax_pose 25, 0x01ed, 0x90eb, 0x2c00
+ax_pose 10, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose36:
+ax_pose 26, 0x01ed, 0x90eb, 0x2c00
+ax_pose 11, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose37:
+ax_pose 27, 0x81ed, 0x80f7, 0x2c00
+ax_pose 12, 0x81ed, 0x80f7, 0x2c08
+ax_pose_terminator
+sCyndaquilPose38:
+ax_pose 28, 0x01ed, 0x80f7, 0x2c00
+ax_pose 13, 0x81ed, 0x80f7, 0x2c10
+ax_pose_terminator
+sCyndaquilPose39:
+ax_pose 29, 0x81ed, 0x80f4, 0x2c00
+ax_pose 14, 0x81ed, 0x80f7, 0x2c08
+ax_pose_terminator
+sCyndaquilPose40:
+ax_pose 24, 0x01ed, 0x80f4, 0x2c00
+ax_pose 9, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose41:
+ax_pose 25, 0x01ed, 0x80f4, 0x2c00
+ax_pose 10, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose42:
+ax_pose 26, 0x01ed, 0x80f4, 0x2c00
+ax_pose 11, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose43:
+ax_pose 21, 0x01ed, 0x80f4, 0x2c00
+ax_pose 6, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose44:
+ax_pose 22, 0x01ed, 0x80f4, 0x2c00
+ax_pose 7, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose45:
+ax_pose 23, 0x01ed, 0x80f4, 0x2c00
+ax_pose 8, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose46:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose 18, 0x01ea, 0x80f7, 0x2c10
+ax_pose_terminator
+sCyndaquilPose47:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose 19, 0x01e9, 0x80f6, 0x2c10
+ax_pose_terminator
+sCyndaquilPose48:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose 20, 0x01e8, 0x80f5, 0x2c10
+ax_pose_terminator
+sCyndaquilPose49:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose 15, 0x01e7, 0x80f4, 0x2c08
+ax_pose_terminator
+sCyndaquilPose50:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose 16, 0x01e7, 0x80f4, 0x2c08
+ax_pose_terminator
+sCyndaquilPose51:
+ax_pose 2, 0x81eb, 0x80f8, 0x2c00
+ax_pose 17, 0x01e7, 0x80f3, 0x2c08
+ax_pose_terminator
+sCyndaquilPose52:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose 18, 0x01ea, 0x90e8, 0x2c10
+ax_pose_terminator
+sCyndaquilPose53:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose 19, 0x01e9, 0x90e9, 0x2c10
+ax_pose_terminator
+sCyndaquilPose54:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose 20, 0x01e8, 0x90ea, 0x2c10
+ax_pose_terminator
+sCyndaquilPose55:
+ax_pose 21, 0x01ed, 0x90eb, 0x2c00
+ax_pose 6, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose56:
+ax_pose 22, 0x01ed, 0x90eb, 0x2c00
+ax_pose 7, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose57:
+ax_pose 23, 0x01ed, 0x90eb, 0x2c00
+ax_pose 8, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose58:
+ax_pose 24, 0x01ed, 0x90eb, 0x2c00
+ax_pose 9, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose59:
+ax_pose 25, 0x01ed, 0x90eb, 0x2c00
+ax_pose 10, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose60:
+ax_pose 26, 0x01ed, 0x90eb, 0x2c00
+ax_pose 11, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose61:
+ax_pose 27, 0x81ed, 0x80f7, 0x2c00
+ax_pose 12, 0x81ed, 0x80f7, 0x2c08
+ax_pose_terminator
+sCyndaquilPose62:
+ax_pose 28, 0x01ed, 0x80f7, 0x2c00
+ax_pose 13, 0x81ed, 0x80f7, 0x2c10
+ax_pose_terminator
+sCyndaquilPose63:
+ax_pose 29, 0x81ed, 0x80f4, 0x2c00
+ax_pose 14, 0x81ed, 0x80f7, 0x2c08
+ax_pose_terminator
+sCyndaquilPose64:
+ax_pose 24, 0x01ed, 0x80f4, 0x2c00
+ax_pose 9, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose65:
+ax_pose 25, 0x01ed, 0x80f4, 0x2c00
+ax_pose 10, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose66:
+ax_pose 26, 0x01ed, 0x80f4, 0x2c00
+ax_pose 11, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose67:
+ax_pose 21, 0x01ed, 0x80f4, 0x2c00
+ax_pose 6, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose68:
+ax_pose 22, 0x01ed, 0x80f4, 0x2c00
+ax_pose 7, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose69:
+ax_pose 23, 0x01ed, 0x80f4, 0x2c00
+ax_pose 8, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose70:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose 18, 0x01ea, 0x80f7, 0x2c10
+ax_pose_terminator
+sCyndaquilPose71:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose 19, 0x01e9, 0x80f6, 0x2c10
+ax_pose_terminator
+sCyndaquilPose72:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose 20, 0x01e8, 0x80f5, 0x2c10
+ax_pose_terminator
+sCyndaquilPose73:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose74:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose75:
+ax_pose 2, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose76:
+ax_pose 30, 0x01e7, 0x80f7, 0x2c00
+ax_pose 31, 0x81eb, 0x80f8, 0x2c10
+ax_pose_terminator
+sCyndaquilPose77:
+ax_pose 32, 0x01e7, 0x80f7, 0x2c00
+ax_pose 31, 0x81eb, 0x80f8, 0x2c10
+ax_pose_terminator
+sCyndaquilPose78:
+ax_pose 31, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose79:
+ax_pose 3, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose80:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose81:
+ax_pose 5, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose82:
+ax_pose 33, 0x01ea, 0x90ed, 0x2c00
+ax_pose 34, 0x01ed, 0x90ed, 0x2c10
+ax_pose_terminator
+sCyndaquilPose83:
+ax_pose 35, 0x01ea, 0x90ed, 0x2c00
+ax_pose 34, 0x01ed, 0x90ed, 0x2c10
+ax_pose_terminator
+sCyndaquilPose84:
+ax_pose 34, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose85:
+ax_pose 6, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose86:
+ax_pose 7, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose87:
+ax_pose 8, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose88:
+ax_pose 36, 0x01ea, 0x90ed, 0x2c00
+ax_pose 37, 0x01ed, 0x90ed, 0x2c10
+ax_pose_terminator
+sCyndaquilPose89:
+ax_pose 38, 0x01ea, 0x90ed, 0x2c00
+ax_pose 37, 0x01ed, 0x90ed, 0x2c10
+ax_pose_terminator
+sCyndaquilPose90:
+ax_pose 37, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose91:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose92:
+ax_pose 10, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose93:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose94:
+ax_pose 39, 0x01ec, 0x90eb, 0x2c00
+ax_pose 40, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose95:
+ax_pose 41, 0x01ec, 0x90eb, 0x2c00
+ax_pose 40, 0x01ed, 0x90eb, 0x2c10
+ax_pose_terminator
+sCyndaquilPose96:
+ax_pose 40, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose97:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose98:
+ax_pose 13, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose99:
+ax_pose 14, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose100:
+ax_pose 42, 0x01ea, 0x80f7, 0x2c00
+ax_pose 43, 0x81ed, 0x80f7, 0x2c10
+ax_pose_terminator
+sCyndaquilPose101:
+ax_pose 44, 0x01ea, 0x80f7, 0x2c00
+ax_pose 43, 0x81ed, 0x80f7, 0x2c10
+ax_pose_terminator
+sCyndaquilPose102:
+ax_pose 43, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose103:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose104:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose105:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose106:
+ax_pose 39, 0x01ec, 0x80f4, 0x2c00
+ax_pose 40, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose107:
+ax_pose 41, 0x01ec, 0x80f4, 0x2c00
+ax_pose 40, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose108:
+ax_pose 40, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose109:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose110:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose111:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose112:
+ax_pose 36, 0x01ea, 0x80f4, 0x2c00
+ax_pose 37, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose113:
+ax_pose 38, 0x01ea, 0x80f4, 0x2c00
+ax_pose 37, 0x01ed, 0x80f4, 0x2c10
+ax_pose_terminator
+sCyndaquilPose114:
+ax_pose 37, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose115:
+ax_pose 3, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose116:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose117:
+ax_pose 5, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose118:
+ax_pose 33, 0x01ea, 0x80f3, 0x2c00
+ax_pose 34, 0x01ed, 0x80f3, 0x2c10
+ax_pose_terminator
+sCyndaquilPose119:
+ax_pose 35, 0x01ea, 0x80f3, 0x2c00
+ax_pose 34, 0x01ed, 0x80f3, 0x2c10
+ax_pose_terminator
+sCyndaquilPose120:
+ax_pose 34, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose121:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose122:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose123:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose124:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose125:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose126:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose127:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose128:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose129:
+ax_pose 45, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose130:
+ax_pose 46, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose131:
+ax_pose 47, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sCyndaquilPose132:
+ax_pose 48, 0x01e4, 0x90e8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose133:
+ax_pose 49, 0x01ea, 0x90e9, 0x2c00
+ax_pose_terminator
+sCyndaquilPose134:
+ax_pose 50, 0x01e7, 0x90e7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose135:
+ax_pose 51, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose136:
+ax_pose 50, 0x01e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose137:
+ax_pose 49, 0x01ea, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose138:
+ax_pose 48, 0x01e4, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose139:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose140:
+ax_pose 31, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose141:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose142:
+ax_pose 34, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose143:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose144:
+ax_pose 37, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose145:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose146:
+ax_pose 40, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose147:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose148:
+ax_pose 43, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose149:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose150:
+ax_pose 40, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose151:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose152:
+ax_pose 37, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose153:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose154:
+ax_pose 34, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose155:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose156:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose157:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose158:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose159:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose160:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose161:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose162:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose163:
+ax_pose 31, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose164:
+ax_pose 34, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose165:
+ax_pose 37, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose166:
+ax_pose 40, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose167:
+ax_pose 43, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose168:
+ax_pose 40, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose169:
+ax_pose 37, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose170:
+ax_pose 34, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose171:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose172:
+ax_pose 31, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose173:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose174:
+ax_pose 34, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose175:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose176:
+ax_pose 37, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose177:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose178:
+ax_pose 40, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose179:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose180:
+ax_pose 43, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose181:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose182:
+ax_pose 40, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose183:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose184:
+ax_pose 37, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose185:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose186:
+ax_pose 34, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose187:
+ax_pose 31, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose188:
+ax_pose 34, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose189:
+ax_pose 37, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose190:
+ax_pose 40, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose191:
+ax_pose 43, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose192:
+ax_pose 40, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose193:
+ax_pose 37, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose194:
+ax_pose 34, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose195:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose196:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose197:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose198:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose199:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose200:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose201:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose202:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose203:
+ax_pose 52, 0x41f2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose204:
+ax_pose 53, 0x41f2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose205:
+ax_pose 52, 0x41f2, 0x90ee, 0x2c00
+ax_pose_terminator
+sCyndaquilPose206:
+ax_pose 53, 0x41f2, 0x90ee, 0x2c00
+ax_pose_terminator
+sCyndaquilPose207:
+ax_pose 52, 0x41f2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose208:
+ax_pose 54, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sCyndaquilPose209:
+ax_pose 55, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose210:
+ax_pose 56, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose211:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose212:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose213:
+ax_pose 57, 0x01ee, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose214:
+ax_pose 58, 0x01ee, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose215:
+ax_pose 59, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sCyndaquilPose216:
+ax_pose 60, 0x41e9, 0x80f0, 0x2c00
+ax_pose 61, 0x01f0, 0x40f7, 0x2c08
+ax_pose_terminator
+sCyndaquilPose217:
+ax_pose 62, 0x41e7, 0x80f0, 0x2c00
+ax_pose 63, 0x41f7, 0x00f8, 0x2c08
+ax_pose 61, 0x01f0, 0x40f7, 0x2c0a
+ax_pose_terminator
+sCyndaquilPose218:
+ax_pose 61, 0x01f0, 0x40f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose219:
+ax_pose 64, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose220:
+ax_pose 65, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sCyndaquilPose221:
+ax_pose 66, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose222:
+ax_pose 67, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose223:
+ax_pose 68, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose224:
+ax_pose 68, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose225:
+ax_pose 69, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sCyndaquilPose226:
+ax_pose 70, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose227:
+ax_pose 71, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose228:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose229:
+ax_pose 72, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose230:
+ax_pose 73, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose231:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose232:
+ax_pose 74, 0x81f0, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose233:
+ax_pose 75, 0x81f0, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose234:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose235:
+ax_pose 59, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sCyndaquilPose236:
+ax_pose 76, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sCyndaquilPose237:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose238:
+ax_pose 77, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose239:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose240:
+ax_pose 77, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose241:
+ax_pose 12, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sCyndaquilPose242:
+ax_pose 78, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sCyndaquilPose243:
+ax_pose 79, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sCyndaquilPose244:
+ax_pose 80, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose245:
+ax_pose 81, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sCyndaquilPose246:
+ax_pose 82, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sCyndaquilPose247:
+ax_pose 83, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sCyndaquilPose248:
+ax_pose 79, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sCyndaquilPose249:
+ax_pose 80, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose250:
+ax_pose 81, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose251:
+ax_pose 82, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sCyndaquilPose252:
+ax_pose 83, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sCyndaquilPose253:
+ax_pose 84, 0x81ee, 0x90f6, 0x2c00
+ax_pose_terminator
+sCyndaquilPose254:
+ax_pose 52, 0x41f2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose255:
+ax_pose 53, 0x41f2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose256:
+ax_pose 52, 0x41f2, 0x90ee, 0x2c00
+ax_pose_terminator
+sCyndaquilPose257:
+ax_pose 53, 0x41f2, 0x90ee, 0x2c00
+ax_pose_terminator
+sCyndaquilPose258:
+ax_pose 52, 0x41f2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose259:
+ax_pose 53, 0x41f2, 0x80f2, 0x2c00
+ax_pose_terminator
+sCyndaquilPose260:
+ax_pose 52, 0x41f2, 0x90ee, 0x2c00
+ax_pose_terminator
+sCyndaquilPose261:
+ax_pose 53, 0x41f2, 0x90ee, 0x2c00
+ax_pose_terminator
+.align 2
+sCyndaquilAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sCyndaquilAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sCyndaquilAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sCyndaquilAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 35, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 35, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sCyndaquilAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sCyndaquilAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 41, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 41, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sCyndaquilAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sCyndaquilAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sCyndaquilAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 53, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 53, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sCyndaquilAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sCyndaquilAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 11, -12, 11, -12,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 1, 59, 19, -22, 19, -22,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 0, 59, 19, -22, 19, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sCyndaquilAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 1, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 0, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sCyndaquilAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -11, -12, -11, -12,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 1, 65, -19, -22, -19, -22,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 0, 65, -19, -22, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sCyndaquilAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sCyndaquilAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 71, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_4_1:
+ax_anim 3, 0, 74, 0, -2, 0, -2,
+ax_anim 6, 2, 74, 0, -3, 0, -3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 1, 76, 1, 3, 1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 1, 3, 1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 1, 3, 1, 3,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim_terminator
+sCyndaquilAnims_4_2:
+ax_anim 3, 0, 80, -2, -2, -2, -2,
+ax_anim 6, 2, 80, -3, -3, -3, -3,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 1, 82, 2, 4, 2, 4,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 0, 82, 2, 4, 2, 4,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 0, 82, 2, 4, 2, 4,
+ax_anim 2, 0, 83, 3, 3, 3, 3,
+ax_anim 2, 0, 78, 3, 3, 3, 3,
+ax_anim_terminator
+sCyndaquilAnims_4_3:
+ax_anim 3, 0, 86, -2, 0, -2, 0,
+ax_anim 6, 2, 86, -3, 0, -3, 0,
+ax_anim 2, 0, 87, 3, 0, 3, 0,
+ax_anim 2, 1, 88, 3, -1, 3, -1,
+ax_anim 2, 0, 87, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, -1, 3, -1,
+ax_anim 2, 0, 87, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, -1, 3, -1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 84, 3, 0, 3, 0,
+ax_anim_terminator
+sCyndaquilAnims_4_4:
+ax_anim 3, 0, 92, -2, 2, -2, 2,
+ax_anim 6, 2, 92, -3, 3, -3, 3,
+ax_anim 2, 0, 93, 3, -3, 3, -3,
+ax_anim 2, 1, 94, 2, -4, 2, -4,
+ax_anim 2, 0, 93, 3, -3, 3, -3,
+ax_anim 2, 0, 94, 2, -4, 2, -4,
+ax_anim 2, 0, 93, 3, -3, 3, -3,
+ax_anim 2, 0, 94, 2, -4, 2, -4,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 90, 3, -3, 3, -3,
+ax_anim_terminator
+sCyndaquilAnims_4_5:
+ax_anim 3, 0, 98, 0, 2, 0, 2,
+ax_anim 6, 2, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 2, 1, 100, 1, -3, 1, -3,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 1, -3, 1, -3,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 1, -3, 1, -3,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim_terminator
+sCyndaquilAnims_4_6:
+ax_anim 3, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 1, 106, -2, -4, -2, -4,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 106, -2, -4, -2, -4,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 106, -2, -4, -2, -4,
+ax_anim 2, 0, 107, -3, -3, -3, -3,
+ax_anim 2, 0, 102, -3, -3, -3, -3,
+ax_anim_terminator
+sCyndaquilAnims_4_7:
+ax_anim 3, 0, 110, 2, 0, 2, 0,
+ax_anim 6, 2, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 2, 1, 112, -3, -1, -3, -1,
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, -1, -3, -1,
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sCyndaquilAnims_4_8:
+ax_anim 3, 0, 116, 2, -2, 2, -2,
+ax_anim 6, 0, 116, 3, -3, 3, -3,
+ax_anim 2, 0, 117, -3, 3, -3, 3,
+ax_anim 2, 2, 118, -2, 4, -2, 4,
+ax_anim 2, 0, 117, -3, 3, -3, 3,
+ax_anim 2, 0, 118, -2, 4, -2, 4,
+ax_anim 2, 0, 117, -3, 3, -3, 3,
+ax_anim 2, 0, 118, -2, 4, -2, 4,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 114, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sCyndaquilAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sCyndaquilAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sCyndaquilAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sCyndaquilAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sCyndaquilAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sCyndaquilAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sCyndaquilAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_8_2:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_8_3:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 16, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_8_4:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_8_5:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_8_6:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 16, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_8_7:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_8_8:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 16, 7, 16,
+ax_anim 3, 0, 158, 0, 18, 0, 18,
+ax_anim 2, 3, 159, -7, 16, -7, 16,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 21, 11, 21, 11,
+ax_anim 3, 0, 157, 23, 21, 23, 21,
+ax_anim 2, 3, 158, 11, 20, 11, 20,
+ax_anim 2, 0, 159, 2, 12, 2, 12,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -4, 17, -4,
+ax_anim 3, 0, 156, 22, 1, 22, 1,
+ax_anim 2, 3, 157, 19, 5, 19, 5,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 4, -17, 4, -17,
+ax_anim 2, 0, 154, 11, -22, 11, -22,
+ax_anim 3, 0, 155, 18, -22, 18, -22,
+ax_anim 2, 3, 156, 20, -14, 20, -14,
+ax_anim 2, 0, 157, 16, -5, 16, -5,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -8, -10, -8, -10,
+ax_anim 2, 0, 161, -6, -19, -6, -19,
+ax_anim 3, 0, 154, 0, -24, 0, -24,
+ax_anim 2, 3, 155, 6, -19, 6, -19,
+ax_anim 2, 0, 156, 8, -8, 8, -8,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -17, -4, -17,
+ax_anim 2, 0, 154, -11, -22, -11, -22,
+ax_anim 3, 0, 161, -18, -22, -18, -22,
+ax_anim 2, 3, 160, -20, -14, -20, -14,
+ax_anim 2, 0, 159, -16, -5, -16, -5,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -4, -17, -4,
+ax_anim 3, 0, 160, -22, 1, -22, 1,
+ax_anim 2, 3, 159, -19, 5, -19, 5,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -21, 11, -21, 11,
+ax_anim 3, 0, 159, -23, 21, -23, 21,
+ax_anim 2, 3, 158, -11, 20, -11, 20,
+ax_anim 2, 0, 157, -2, 12, -2, 12,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_11_2:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -22, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_11_3:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_11_4:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -17, 0, 0,
+ax_anim 1, 0, 177, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_11_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_11_6:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_11_7:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_11_8:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_14_1:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_14_2:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_14_3:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_14_4:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_14_5:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_14_6:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_14_7:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_14_8:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_15_1:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_15_2:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_15_3:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_15_4:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_15_5:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_15_6:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_15_7:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_15_8:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_16_1:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_16_2:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_16_3:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_16_4:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_16_5:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_16_6:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_16_7:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_16_8:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_17_1:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_17_2:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_17_3:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_17_4:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_17_5:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_17_6:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_17_7:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_17_8:
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -1, 0, -1, 0,
+ax_anim 1, 0, 216, -1, 0, -1, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_18_1:
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 2, 0, 2,
+ax_anim 8, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sCyndaquilAnims_18_2:
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 2, 0, 2,
+ax_anim 8, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sCyndaquilAnims_18_3:
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 2, 0, 2,
+ax_anim 8, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sCyndaquilAnims_18_4:
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 2, 0, 2,
+ax_anim 8, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sCyndaquilAnims_18_5:
+ax_anim 12, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 2, 0, 2,
+ax_anim 8, 0, 223, 0, 2, 0, 2,
+ax_anim_terminator
+sCyndaquilAnims_18_6:
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 2, 0, 2,
+ax_anim 8, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sCyndaquilAnims_18_7:
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 2, 0, 2,
+ax_anim 8, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sCyndaquilAnims_18_8:
+ax_anim 12, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 2, 0, 2,
+ax_anim 8, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_19_1:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_19_2:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_19_3:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_19_4:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_19_5:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_19_6:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_19_7:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_19_8:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_20_1:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 1, 0, 0,
+ax_anim 2, 0, 229, 1, 1, 1, 0,
+ax_anim 2, 0, 229, 0, 1, 0, 0,
+ax_anim 2, 0, 229, 1, 1, 1, 0,
+ax_anim 2, 0, 229, 0, 1, 0, 0,
+ax_anim 2, 0, 229, 1, 1, 1, 0,
+ax_anim_terminator
+sCyndaquilAnims_20_2:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim_terminator
+sCyndaquilAnims_20_3:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim_terminator
+sCyndaquilAnims_20_4:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim_terminator
+sCyndaquilAnims_20_5:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim_terminator
+sCyndaquilAnims_20_6:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim_terminator
+sCyndaquilAnims_20_7:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim_terminator
+sCyndaquilAnims_20_8:
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 1, 0, 228, 0, -4, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_21_1:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_21_2:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_21_3:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_21_4:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_21_5:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_21_6:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_21_7:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_21_8:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_22_1:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_22_2:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_22_3:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_22_4:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_22_5:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_22_6:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_22_7:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_22_8:
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim 34, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_23_1:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_23_2:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_23_3:
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 12, 0, 238, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_23_4:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_23_5:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_23_6:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_23_7:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_23_8:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_24_1:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_24_2:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_24_3:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_24_4:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_24_5:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_24_6:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_24_7:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_24_8:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_25_1:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_25_2:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_25_3:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_25_4:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_25_5:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_25_6:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_25_7:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_25_8:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_26_1:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+sCyndaquilAnims_26_2:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+sCyndaquilAnims_26_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+sCyndaquilAnims_26_4:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+sCyndaquilAnims_26_5:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+sCyndaquilAnims_26_6:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+sCyndaquilAnims_26_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+sCyndaquilAnims_26_8:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_27_1:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 16, 0, 253, -1, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 1, 0, 0, 0,
+ax_anim 16, 0, 253, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sCyndaquilAnims_28_1:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_28_2:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_28_3:
+ax_anim 12, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_28_4:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_28_5:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_28_6:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_28_7:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilAnims_28_8:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sCyndaquilGfx1:
+.incbin "baserom.gba", 0xBC8234, 0x100
+sCyndaquilSprites1:
+ax_sprite sCyndaquilGfx1, 0x100
+ax_sprite_terminator
+sCyndaquilGfx2:
+.incbin "baserom.gba", 0xBC8344, 0x100
+sCyndaquilSprites2:
+ax_sprite sCyndaquilGfx2, 0x100
+ax_sprite_terminator
+sCyndaquilGfx3:
+.incbin "baserom.gba", 0xBC8454, 0x100
+sCyndaquilSprites3:
+ax_sprite sCyndaquilGfx3, 0x100
+ax_sprite_terminator
+sCyndaquilGfx4:
+.incbin "baserom.gba", 0xBC8564, 0x200
+sCyndaquilSprites4:
+ax_sprite sCyndaquilGfx4, 0x200
+ax_sprite_terminator
+sCyndaquilGfx5:
+.incbin "baserom.gba", 0xBC8774, 0x200
+sCyndaquilSprites5:
+ax_sprite sCyndaquilGfx5, 0x200
+ax_sprite_terminator
+sCyndaquilGfx6:
+.incbin "baserom.gba", 0xBC8984, 0x200
+sCyndaquilSprites6:
+ax_sprite sCyndaquilGfx6, 0x200
+ax_sprite_terminator
+sCyndaquilGfx7:
+.incbin "baserom.gba", 0xBC8B94, 0x200
+sCyndaquilSprites7:
+ax_sprite sCyndaquilGfx7, 0x200
+ax_sprite_terminator
+sCyndaquilGfx8:
+.incbin "baserom.gba", 0xBC8DA4, 0x200
+sCyndaquilSprites8:
+ax_sprite sCyndaquilGfx8, 0x200
+ax_sprite_terminator
+sCyndaquilGfx9:
+.incbin "baserom.gba", 0xBC8FB4, 0x200
+sCyndaquilSprites9:
+ax_sprite sCyndaquilGfx9, 0x200
+ax_sprite_terminator
+sCyndaquilGfx10:
+.incbin "baserom.gba", 0xBC91C4, 0x200
+sCyndaquilSprites10:
+ax_sprite sCyndaquilGfx10, 0x200
+ax_sprite_terminator
+sCyndaquilGfx11:
+.incbin "baserom.gba", 0xBC93D4, 0x200
+sCyndaquilSprites11:
+ax_sprite sCyndaquilGfx11, 0x200
+ax_sprite_terminator
+sCyndaquilGfx12:
+.incbin "baserom.gba", 0xBC95E4, 0x200
+sCyndaquilSprites12:
+ax_sprite sCyndaquilGfx12, 0x200
+ax_sprite_terminator
+sCyndaquilGfx13:
+.incbin "baserom.gba", 0xBC97F4, 0x100
+sCyndaquilSprites13:
+ax_sprite sCyndaquilGfx13, 0x100
+ax_sprite_terminator
+sCyndaquilGfx14:
+.incbin "baserom.gba", 0xBC9904, 0x100
+sCyndaquilSprites14:
+ax_sprite sCyndaquilGfx14, 0x100
+ax_sprite_terminator
+sCyndaquilGfx15:
+.incbin "baserom.gba", 0xBC9A14, 0x100
+sCyndaquilSprites15:
+ax_sprite sCyndaquilGfx15, 0x100
+ax_sprite_terminator
+sCyndaquilGfx16:
+.incbin "baserom.gba", 0xBC9B24, 0x60
+sCyndaquilGfx16_1:
+.incbin "baserom.gba", 0xBC9B84, 0x60
+sCyndaquilGfx16_2:
+.incbin "baserom.gba", 0xBC9BE4, 0x20
+sCyndaquilGfx16_3:
+.incbin "baserom.gba", 0xBC9C04, 0x20
+sCyndaquilSprites16:
+ax_sprite sCyndaquilGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx16_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx16_3, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx17:
+.incbin "baserom.gba", 0xBC9C6C, 0x40
+sCyndaquilGfx17_1:
+.incbin "baserom.gba", 0xBC9CAC, 0x40
+sCyndaquilGfx17_2:
+.incbin "baserom.gba", 0xBC9CEC, 0x20
+sCyndaquilSprites17:
+ax_sprite sCyndaquilGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx17_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sCyndaquilGfx18:
+.incbin "baserom.gba", 0xBC9D44, 0x40
+sCyndaquilGfx18_1:
+.incbin "baserom.gba", 0xBC9D84, 0x40
+sCyndaquilGfx18_2:
+.incbin "baserom.gba", 0xBC9DC4, 0x20
+sCyndaquilSprites18:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx18_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sCyndaquilGfx18_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx19:
+.incbin "baserom.gba", 0xBC9E24, 0x20
+sCyndaquilGfx19_1:
+.incbin "baserom.gba", 0xBC9E44, 0x60
+sCyndaquilGfx19_2:
+.incbin "baserom.gba", 0xBC9EA4, 0x40
+sCyndaquilSprites19:
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx19_2, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCyndaquilGfx20:
+.incbin "baserom.gba", 0xBC9F24, 0x20
+sCyndaquilGfx20_1:
+.incbin "baserom.gba", 0xBC9F44, 0x40
+sCyndaquilGfx20_2:
+.incbin "baserom.gba", 0xBC9F84, 0x20
+sCyndaquilSprites20:
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx20_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sCyndaquilGfx20_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx21:
+.incbin "baserom.gba", 0xBC9FE4, 0x60
+sCyndaquilGfx21_1:
+.incbin "baserom.gba", 0xBCA044, 0x40
+sCyndaquilSprites21:
+ax_sprite 0, 0xa0
+ax_sprite sCyndaquilGfx21, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx21_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCyndaquilGfx22:
+.incbin "baserom.gba", 0xBCA0B4, 0x60
+sCyndaquilGfx22_1:
+.incbin "baserom.gba", 0xBCA114, 0x60
+sCyndaquilSprites22:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx22_1, 0x60
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sCyndaquilGfx23:
+.incbin "baserom.gba", 0xBCA1A4, 0x60
+sCyndaquilGfx23_1:
+.incbin "baserom.gba", 0xBCA204, 0x60
+sCyndaquilSprites23:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx23_1, 0x60
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sCyndaquilGfx24:
+.incbin "baserom.gba", 0xBCA294, 0x40
+sCyndaquilGfx24_1:
+.incbin "baserom.gba", 0xBCA2D4, 0x60
+sCyndaquilGfx24_2:
+.incbin "baserom.gba", 0xBCA334, 0x40
+sCyndaquilSprites24:
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx24_2, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCyndaquilGfx25:
+.incbin "baserom.gba", 0xBCA3B4, 0x60
+sCyndaquilGfx25_1:
+.incbin "baserom.gba", 0xBCA414, 0x60
+sCyndaquilGfx25_2:
+.incbin "baserom.gba", 0xBCA474, 0x40
+sCyndaquilSprites25:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx26:
+.incbin "baserom.gba", 0xBCA4F4, 0x60
+sCyndaquilGfx26_1:
+.incbin "baserom.gba", 0xBCA554, 0x60
+sCyndaquilGfx26_2:
+.incbin "baserom.gba", 0xBCA5B4, 0x40
+sCyndaquilSprites26:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx26_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx27:
+.incbin "baserom.gba", 0xBCA634, 0x40
+sCyndaquilGfx27_1:
+.incbin "baserom.gba", 0xBCA674, 0x40
+sCyndaquilGfx27_2:
+.incbin "baserom.gba", 0xBCA6B4, 0x40
+sCyndaquilSprites27:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx28:
+.incbin "baserom.gba", 0xBCA734, 0xC0
+sCyndaquilSprites28:
+ax_sprite sCyndaquilGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCyndaquilGfx29:
+.incbin "baserom.gba", 0xBCA80C, 0x40
+sCyndaquilGfx29_1:
+.incbin "baserom.gba", 0xBCA84C, 0x60
+sCyndaquilGfx29_2:
+.incbin "baserom.gba", 0xBCA8AC, 0x60
+sCyndaquilSprites29:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx30:
+.incbin "baserom.gba", 0xBCA94C, 0x20
+sCyndaquilGfx30_1:
+.incbin "baserom.gba", 0xBCA96C, 0x80
+sCyndaquilSprites30:
+ax_sprite sCyndaquilGfx30, 0x20
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx30_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCyndaquilGfx31:
+.incbin "baserom.gba", 0xBCAA14, 0x40
+sCyndaquilGfx31_1:
+.incbin "baserom.gba", 0xBCAA54, 0x60
+sCyndaquilGfx31_2:
+.incbin "baserom.gba", 0xBCAAB4, 0x40
+sCyndaquilSprites31:
+ax_sprite sCyndaquilGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx31_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sCyndaquilGfx32:
+.incbin "baserom.gba", 0xBCAB2C, 0xC0
+sCyndaquilSprites32:
+ax_sprite sCyndaquilGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCyndaquilGfx33:
+.incbin "baserom.gba", 0xBCAC04, 0x60
+sCyndaquilGfx33_1:
+.incbin "baserom.gba", 0xBCAC64, 0x60
+sCyndaquilGfx33_2:
+.incbin "baserom.gba", 0xBCACC4, 0x40
+sCyndaquilSprites33:
+ax_sprite sCyndaquilGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx33_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sCyndaquilGfx34:
+.incbin "baserom.gba", 0xBCAD3C, 0x60
+sCyndaquilGfx34_1:
+.incbin "baserom.gba", 0xBCAD9C, 0x60
+sCyndaquilGfx34_2:
+.incbin "baserom.gba", 0xBCADFC, 0x20
+sCyndaquilSprites34:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx34_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx35:
+.incbin "baserom.gba", 0xBCAE5C, 0x40
+sCyndaquilGfx35_1:
+.incbin "baserom.gba", 0xBCAE9C, 0x60
+sCyndaquilGfx35_2:
+.incbin "baserom.gba", 0xBCAEFC, 0x40
+sCyndaquilSprites35:
+ax_sprite sCyndaquilGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx35_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx35_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx36:
+.incbin "baserom.gba", 0xBCAF74, 0x60
+sCyndaquilGfx36_1:
+.incbin "baserom.gba", 0xBCAFD4, 0x60
+sCyndaquilGfx36_2:
+.incbin "baserom.gba", 0xBCB034, 0x20
+sCyndaquilSprites36:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx36_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx36_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx37:
+.incbin "baserom.gba", 0xBCB094, 0x60
+sCyndaquilGfx37_1:
+.incbin "baserom.gba", 0xBCB0F4, 0x60
+sCyndaquilGfx37_2:
+.incbin "baserom.gba", 0xBCB154, 0x60
+sCyndaquilSprites37:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx37_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCyndaquilGfx38:
+.incbin "baserom.gba", 0xBCB1F4, 0x40
+sCyndaquilGfx38_1:
+.incbin "baserom.gba", 0xBCB234, 0x60
+sCyndaquilGfx38_2:
+.incbin "baserom.gba", 0xBCB294, 0x40
+sCyndaquilSprites38:
+ax_sprite sCyndaquilGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx38_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx38_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx39:
+.incbin "baserom.gba", 0xBCB30C, 0x60
+sCyndaquilGfx39_1:
+.incbin "baserom.gba", 0xBCB36C, 0x60
+sCyndaquilGfx39_2:
+.incbin "baserom.gba", 0xBCB3CC, 0x40
+sCyndaquilSprites39:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx39_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx40:
+.incbin "baserom.gba", 0xBCB44C, 0x60
+sCyndaquilGfx40_1:
+.incbin "baserom.gba", 0xBCB4AC, 0x60
+sCyndaquilGfx40_2:
+.incbin "baserom.gba", 0xBCB50C, 0x60
+sCyndaquilSprites40:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx40_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sCyndaquilGfx41:
+.incbin "baserom.gba", 0xBCB5AC, 0x40
+sCyndaquilGfx41_1:
+.incbin "baserom.gba", 0xBCB5EC, 0x60
+sCyndaquilGfx41_2:
+.incbin "baserom.gba", 0xBCB64C, 0x60
+sCyndaquilSprites41:
+ax_sprite sCyndaquilGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx41_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx42:
+.incbin "baserom.gba", 0xBCB6E4, 0x60
+sCyndaquilGfx42_1:
+.incbin "baserom.gba", 0xBCB744, 0x60
+sCyndaquilGfx42_2:
+.incbin "baserom.gba", 0xBCB7A4, 0x40
+sCyndaquilSprites42:
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx42_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sCyndaquilGfx43:
+.incbin "baserom.gba", 0xBCB824, 0x40
+sCyndaquilGfx43_1:
+.incbin "baserom.gba", 0xBCB864, 0x60
+sCyndaquilGfx43_2:
+.incbin "baserom.gba", 0xBCB8C4, 0x40
+sCyndaquilSprites43:
+ax_sprite sCyndaquilGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sCyndaquilGfx43_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sCyndaquilGfx44:
+.incbin "baserom.gba", 0xBCB93C, 0xC0
+sCyndaquilSprites44:
+ax_sprite sCyndaquilGfx44, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sCyndaquilGfx45:
+.incbin "baserom.gba", 0xBCBA14, 0x40
+sCyndaquilGfx45_1:
+.incbin "baserom.gba", 0xBCBA54, 0x40
+sCyndaquilGfx45_2:
+.incbin "baserom.gba", 0xBCBA94, 0x40
+sCyndaquilSprites45:
+ax_sprite sCyndaquilGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx45_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sCyndaquilGfx45_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sCyndaquilGfx46:
+.incbin "baserom.gba", 0xBCBB0C, 0x200
+sCyndaquilSprites46:
+ax_sprite sCyndaquilGfx46, 0x200
+ax_sprite_terminator
+sCyndaquilGfx47:
+.incbin "baserom.gba", 0xBCBD1C, 0x200
+sCyndaquilSprites47:
+ax_sprite sCyndaquilGfx47, 0x200
+ax_sprite_terminator
+sCyndaquilGfx48:
+.incbin "baserom.gba", 0xBCBF2C, 0x200
+sCyndaquilSprites48:
+ax_sprite sCyndaquilGfx48, 0x200
+ax_sprite_terminator
+sCyndaquilGfx49:
+.incbin "baserom.gba", 0xBCC13C, 0x200
+sCyndaquilSprites49:
+ax_sprite sCyndaquilGfx49, 0x200
+ax_sprite_terminator
+sCyndaquilGfx50:
+.incbin "baserom.gba", 0xBCC34C, 0x200
+sCyndaquilSprites50:
+ax_sprite sCyndaquilGfx50, 0x200
+ax_sprite_terminator
+sCyndaquilGfx51:
+.incbin "baserom.gba", 0xBCC55C, 0x200
+sCyndaquilSprites51:
+ax_sprite sCyndaquilGfx51, 0x200
+ax_sprite_terminator
+sCyndaquilGfx52:
+.incbin "baserom.gba", 0xBCC76C, 0x200
+sCyndaquilSprites52:
+ax_sprite sCyndaquilGfx52, 0x200
+ax_sprite_terminator
+sCyndaquilGfx53:
+.incbin "baserom.gba", 0xBCC97C, 0x100
+sCyndaquilSprites53:
+ax_sprite sCyndaquilGfx53, 0x100
+ax_sprite_terminator
+sCyndaquilGfx54:
+.incbin "baserom.gba", 0xBCCA8C, 0x100
+sCyndaquilSprites54:
+ax_sprite sCyndaquilGfx54, 0x100
+ax_sprite_terminator
+sCyndaquilGfx55:
+.incbin "baserom.gba", 0xBCCB9C, 0x200
+sCyndaquilSprites55:
+ax_sprite sCyndaquilGfx55, 0x200
+ax_sprite_terminator
+sCyndaquilGfx56:
+.incbin "baserom.gba", 0xBCCDAC, 0x100
+sCyndaquilSprites56:
+ax_sprite sCyndaquilGfx56, 0x100
+ax_sprite_terminator
+sCyndaquilGfx57:
+.incbin "baserom.gba", 0xBCCEBC, 0x200
+sCyndaquilSprites57:
+ax_sprite sCyndaquilGfx57, 0x200
+ax_sprite_terminator
+sCyndaquilGfx58:
+.incbin "baserom.gba", 0xBCD0CC, 0x200
+sCyndaquilSprites58:
+ax_sprite sCyndaquilGfx58, 0x200
+ax_sprite_terminator
+sCyndaquilGfx59:
+.incbin "baserom.gba", 0xBCD2DC, 0x200
+sCyndaquilSprites59:
+ax_sprite sCyndaquilGfx59, 0x200
+ax_sprite_terminator
+sCyndaquilGfx60:
+.incbin "baserom.gba", 0xBCD4EC, 0x200
+sCyndaquilSprites60:
+ax_sprite sCyndaquilGfx60, 0x200
+ax_sprite_terminator
+sCyndaquilGfx61:
+.incbin "baserom.gba", 0xBCD6FC, 0x100
+sCyndaquilSprites61:
+ax_sprite sCyndaquilGfx61, 0x100
+ax_sprite_terminator
+sCyndaquilGfx62:
+.incbin "baserom.gba", 0xBCD80C, 0x80
+sCyndaquilSprites62:
+ax_sprite sCyndaquilGfx62, 0x80
+ax_sprite_terminator
+sCyndaquilGfx63:
+.incbin "baserom.gba", 0xBCD89C, 0x100
+sCyndaquilSprites63:
+ax_sprite sCyndaquilGfx63, 0x100
+ax_sprite_terminator
+sCyndaquilGfx64:
+.incbin "baserom.gba", 0xBCD9AC, 0x40
+sCyndaquilSprites64:
+ax_sprite sCyndaquilGfx64, 0x40
+ax_sprite_terminator
+sCyndaquilGfx65:
+.incbin "baserom.gba", 0xBCD9FC, 0x100
+sCyndaquilSprites65:
+ax_sprite sCyndaquilGfx65, 0x100
+ax_sprite_terminator
+sCyndaquilGfx66:
+.incbin "baserom.gba", 0xBCDB0C, 0x200
+sCyndaquilSprites66:
+ax_sprite sCyndaquilGfx66, 0x200
+ax_sprite_terminator
+sCyndaquilGfx67:
+.incbin "baserom.gba", 0xBCDD1C, 0x100
+sCyndaquilSprites67:
+ax_sprite sCyndaquilGfx67, 0x100
+ax_sprite_terminator
+sCyndaquilGfx68:
+.incbin "baserom.gba", 0xBCDE2C, 0x100
+sCyndaquilSprites68:
+ax_sprite sCyndaquilGfx68, 0x100
+ax_sprite_terminator
+sCyndaquilGfx69:
+.incbin "baserom.gba", 0xBCDF3C, 0x100
+sCyndaquilSprites69:
+ax_sprite sCyndaquilGfx69, 0x100
+ax_sprite_terminator
+sCyndaquilGfx70:
+.incbin "baserom.gba", 0xBCE04C, 0x200
+sCyndaquilSprites70:
+ax_sprite sCyndaquilGfx70, 0x200
+ax_sprite_terminator
+sCyndaquilGfx71:
+.incbin "baserom.gba", 0xBCE25C, 0x100
+sCyndaquilSprites71:
+ax_sprite sCyndaquilGfx71, 0x100
+ax_sprite_terminator
+sCyndaquilGfx72:
+.incbin "baserom.gba", 0xBCE36C, 0x100
+sCyndaquilSprites72:
+ax_sprite sCyndaquilGfx72, 0x100
+ax_sprite_terminator
+sCyndaquilGfx73:
+.incbin "baserom.gba", 0xBCE47C, 0x100
+sCyndaquilSprites73:
+ax_sprite sCyndaquilGfx73, 0x100
+ax_sprite_terminator
+sCyndaquilGfx74:
+.incbin "baserom.gba", 0xBCE58C, 0x100
+sCyndaquilSprites74:
+ax_sprite sCyndaquilGfx74, 0x100
+ax_sprite_terminator
+sCyndaquilGfx75:
+.incbin "baserom.gba", 0xBCE69C, 0x100
+sCyndaquilSprites75:
+ax_sprite sCyndaquilGfx75, 0x100
+ax_sprite_terminator
+sCyndaquilGfx76:
+.incbin "baserom.gba", 0xBCE7AC, 0x100
+sCyndaquilSprites76:
+ax_sprite sCyndaquilGfx76, 0x100
+ax_sprite_terminator
+sCyndaquilGfx77:
+.incbin "baserom.gba", 0xBCE8BC, 0x100
+sCyndaquilSprites77:
+ax_sprite sCyndaquilGfx77, 0x100
+ax_sprite_terminator
+sCyndaquilGfx78:
+.incbin "baserom.gba", 0xBCE9CC, 0x200
+sCyndaquilSprites78:
+ax_sprite sCyndaquilGfx78, 0x200
+ax_sprite_terminator
+sCyndaquilGfx79:
+.incbin "baserom.gba", 0xBCEBDC, 0x200
+sCyndaquilSprites79:
+ax_sprite sCyndaquilGfx79, 0x200
+ax_sprite_terminator
+sCyndaquilGfx80:
+.incbin "baserom.gba", 0xBCEDEC, 0x200
+sCyndaquilSprites80:
+ax_sprite sCyndaquilGfx80, 0x200
+ax_sprite_terminator
+sCyndaquilGfx81:
+.incbin "baserom.gba", 0xBCEFFC, 0x200
+sCyndaquilSprites81:
+ax_sprite sCyndaquilGfx81, 0x200
+ax_sprite_terminator
+sCyndaquilGfx82:
+.incbin "baserom.gba", 0xBCF20C, 0x200
+sCyndaquilSprites82:
+ax_sprite sCyndaquilGfx82, 0x200
+ax_sprite_terminator
+sCyndaquilGfx83:
+.incbin "baserom.gba", 0xBCF41C, 0x200
+sCyndaquilSprites83:
+ax_sprite sCyndaquilGfx83, 0x200
+ax_sprite_terminator
+sCyndaquilGfx84:
+.incbin "baserom.gba", 0xBCF62C, 0x200
+sCyndaquilSprites84:
+ax_sprite sCyndaquilGfx84, 0x200
+ax_sprite_terminator
+sCyndaquilGfx85:
+.incbin "baserom.gba", 0xBCF83C, 0x100
+sCyndaquilSprites85:
+ax_sprite sCyndaquilGfx85, 0x100
+ax_sprite_terminator
+sAxPosesCyndaquil:
+.4byte sCyndaquilPose1
+.4byte sCyndaquilPose2
+.4byte sCyndaquilPose3
+.4byte sCyndaquilPose4
+.4byte sCyndaquilPose5
+.4byte sCyndaquilPose6
+.4byte sCyndaquilPose7
+.4byte sCyndaquilPose8
+.4byte sCyndaquilPose9
+.4byte sCyndaquilPose10
+.4byte sCyndaquilPose11
+.4byte sCyndaquilPose12
+.4byte sCyndaquilPose13
+.4byte sCyndaquilPose14
+.4byte sCyndaquilPose15
+.4byte sCyndaquilPose16
+.4byte sCyndaquilPose17
+.4byte sCyndaquilPose18
+.4byte sCyndaquilPose19
+.4byte sCyndaquilPose20
+.4byte sCyndaquilPose21
+.4byte sCyndaquilPose22
+.4byte sCyndaquilPose23
+.4byte sCyndaquilPose24
+.4byte sCyndaquilPose25
+.4byte sCyndaquilPose26
+.4byte sCyndaquilPose27
+.4byte sCyndaquilPose28
+.4byte sCyndaquilPose29
+.4byte sCyndaquilPose30
+.4byte sCyndaquilPose31
+.4byte sCyndaquilPose32
+.4byte sCyndaquilPose33
+.4byte sCyndaquilPose34
+.4byte sCyndaquilPose35
+.4byte sCyndaquilPose36
+.4byte sCyndaquilPose37
+.4byte sCyndaquilPose38
+.4byte sCyndaquilPose39
+.4byte sCyndaquilPose40
+.4byte sCyndaquilPose41
+.4byte sCyndaquilPose42
+.4byte sCyndaquilPose43
+.4byte sCyndaquilPose44
+.4byte sCyndaquilPose45
+.4byte sCyndaquilPose46
+.4byte sCyndaquilPose47
+.4byte sCyndaquilPose48
+.4byte sCyndaquilPose49
+.4byte sCyndaquilPose50
+.4byte sCyndaquilPose51
+.4byte sCyndaquilPose52
+.4byte sCyndaquilPose53
+.4byte sCyndaquilPose54
+.4byte sCyndaquilPose55
+.4byte sCyndaquilPose56
+.4byte sCyndaquilPose57
+.4byte sCyndaquilPose58
+.4byte sCyndaquilPose59
+.4byte sCyndaquilPose60
+.4byte sCyndaquilPose61
+.4byte sCyndaquilPose62
+.4byte sCyndaquilPose63
+.4byte sCyndaquilPose64
+.4byte sCyndaquilPose65
+.4byte sCyndaquilPose66
+.4byte sCyndaquilPose67
+.4byte sCyndaquilPose68
+.4byte sCyndaquilPose69
+.4byte sCyndaquilPose70
+.4byte sCyndaquilPose71
+.4byte sCyndaquilPose72
+.4byte sCyndaquilPose73
+.4byte sCyndaquilPose74
+.4byte sCyndaquilPose75
+.4byte sCyndaquilPose76
+.4byte sCyndaquilPose77
+.4byte sCyndaquilPose78
+.4byte sCyndaquilPose79
+.4byte sCyndaquilPose80
+.4byte sCyndaquilPose81
+.4byte sCyndaquilPose82
+.4byte sCyndaquilPose83
+.4byte sCyndaquilPose84
+.4byte sCyndaquilPose85
+.4byte sCyndaquilPose86
+.4byte sCyndaquilPose87
+.4byte sCyndaquilPose88
+.4byte sCyndaquilPose89
+.4byte sCyndaquilPose90
+.4byte sCyndaquilPose91
+.4byte sCyndaquilPose92
+.4byte sCyndaquilPose93
+.4byte sCyndaquilPose94
+.4byte sCyndaquilPose95
+.4byte sCyndaquilPose96
+.4byte sCyndaquilPose97
+.4byte sCyndaquilPose98
+.4byte sCyndaquilPose99
+.4byte sCyndaquilPose100
+.4byte sCyndaquilPose101
+.4byte sCyndaquilPose102
+.4byte sCyndaquilPose103
+.4byte sCyndaquilPose104
+.4byte sCyndaquilPose105
+.4byte sCyndaquilPose106
+.4byte sCyndaquilPose107
+.4byte sCyndaquilPose108
+.4byte sCyndaquilPose109
+.4byte sCyndaquilPose110
+.4byte sCyndaquilPose111
+.4byte sCyndaquilPose112
+.4byte sCyndaquilPose113
+.4byte sCyndaquilPose114
+.4byte sCyndaquilPose115
+.4byte sCyndaquilPose116
+.4byte sCyndaquilPose117
+.4byte sCyndaquilPose118
+.4byte sCyndaquilPose119
+.4byte sCyndaquilPose120
+.4byte sCyndaquilPose121
+.4byte sCyndaquilPose122
+.4byte sCyndaquilPose123
+.4byte sCyndaquilPose124
+.4byte sCyndaquilPose125
+.4byte sCyndaquilPose126
+.4byte sCyndaquilPose127
+.4byte sCyndaquilPose128
+.4byte sCyndaquilPose129
+.4byte sCyndaquilPose130
+.4byte sCyndaquilPose131
+.4byte sCyndaquilPose132
+.4byte sCyndaquilPose133
+.4byte sCyndaquilPose134
+.4byte sCyndaquilPose135
+.4byte sCyndaquilPose136
+.4byte sCyndaquilPose137
+.4byte sCyndaquilPose138
+.4byte sCyndaquilPose139
+.4byte sCyndaquilPose140
+.4byte sCyndaquilPose141
+.4byte sCyndaquilPose142
+.4byte sCyndaquilPose143
+.4byte sCyndaquilPose144
+.4byte sCyndaquilPose145
+.4byte sCyndaquilPose146
+.4byte sCyndaquilPose147
+.4byte sCyndaquilPose148
+.4byte sCyndaquilPose149
+.4byte sCyndaquilPose150
+.4byte sCyndaquilPose151
+.4byte sCyndaquilPose152
+.4byte sCyndaquilPose153
+.4byte sCyndaquilPose154
+.4byte sCyndaquilPose155
+.4byte sCyndaquilPose156
+.4byte sCyndaquilPose157
+.4byte sCyndaquilPose158
+.4byte sCyndaquilPose159
+.4byte sCyndaquilPose160
+.4byte sCyndaquilPose161
+.4byte sCyndaquilPose162
+.4byte sCyndaquilPose163
+.4byte sCyndaquilPose164
+.4byte sCyndaquilPose165
+.4byte sCyndaquilPose166
+.4byte sCyndaquilPose167
+.4byte sCyndaquilPose168
+.4byte sCyndaquilPose169
+.4byte sCyndaquilPose170
+.4byte sCyndaquilPose171
+.4byte sCyndaquilPose172
+.4byte sCyndaquilPose173
+.4byte sCyndaquilPose174
+.4byte sCyndaquilPose175
+.4byte sCyndaquilPose176
+.4byte sCyndaquilPose177
+.4byte sCyndaquilPose178
+.4byte sCyndaquilPose179
+.4byte sCyndaquilPose180
+.4byte sCyndaquilPose181
+.4byte sCyndaquilPose182
+.4byte sCyndaquilPose183
+.4byte sCyndaquilPose184
+.4byte sCyndaquilPose185
+.4byte sCyndaquilPose186
+.4byte sCyndaquilPose187
+.4byte sCyndaquilPose188
+.4byte sCyndaquilPose189
+.4byte sCyndaquilPose190
+.4byte sCyndaquilPose191
+.4byte sCyndaquilPose192
+.4byte sCyndaquilPose193
+.4byte sCyndaquilPose194
+.4byte sCyndaquilPose195
+.4byte sCyndaquilPose196
+.4byte sCyndaquilPose197
+.4byte sCyndaquilPose198
+.4byte sCyndaquilPose199
+.4byte sCyndaquilPose200
+.4byte sCyndaquilPose201
+.4byte sCyndaquilPose202
+.4byte sCyndaquilPose203
+.4byte sCyndaquilPose204
+.4byte sCyndaquilPose205
+.4byte sCyndaquilPose206
+.4byte sCyndaquilPose207
+.4byte sCyndaquilPose208
+.4byte sCyndaquilPose209
+.4byte sCyndaquilPose210
+.4byte sCyndaquilPose211
+.4byte sCyndaquilPose212
+.4byte sCyndaquilPose213
+.4byte sCyndaquilPose214
+.4byte sCyndaquilPose215
+.4byte sCyndaquilPose216
+.4byte sCyndaquilPose217
+.4byte sCyndaquilPose218
+.4byte sCyndaquilPose219
+.4byte sCyndaquilPose220
+.4byte sCyndaquilPose221
+.4byte sCyndaquilPose222
+.4byte sCyndaquilPose223
+.4byte sCyndaquilPose224
+.4byte sCyndaquilPose225
+.4byte sCyndaquilPose226
+.4byte sCyndaquilPose227
+.4byte sCyndaquilPose228
+.4byte sCyndaquilPose229
+.4byte sCyndaquilPose230
+.4byte sCyndaquilPose231
+.4byte sCyndaquilPose232
+.4byte sCyndaquilPose233
+.4byte sCyndaquilPose234
+.4byte sCyndaquilPose235
+.4byte sCyndaquilPose236
+.4byte sCyndaquilPose237
+.4byte sCyndaquilPose238
+.4byte sCyndaquilPose239
+.4byte sCyndaquilPose240
+.4byte sCyndaquilPose241
+.4byte sCyndaquilPose242
+.4byte sCyndaquilPose243
+.4byte sCyndaquilPose244
+.4byte sCyndaquilPose245
+.4byte sCyndaquilPose246
+.4byte sCyndaquilPose247
+.4byte sCyndaquilPose248
+.4byte sCyndaquilPose249
+.4byte sCyndaquilPose250
+.4byte sCyndaquilPose251
+.4byte sCyndaquilPose252
+.4byte sCyndaquilPose253
+.4byte sCyndaquilPose254
+.4byte sCyndaquilPose255
+.4byte sCyndaquilPose256
+.4byte sCyndaquilPose257
+.4byte sCyndaquilPose258
+.4byte sCyndaquilPose259
+.4byte sCyndaquilPose260
+.4byte sCyndaquilPose261
+sAxPositionsCyndaquil:
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    0,   -8, 	  -3,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -2,   -8, 	  -5,   -4, 	   1,   -4, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte    1,   -7, 	   1,   -4, 	  -5,   -4, 	  -3,   -4
+.2byte    2,   -7, 	   3,   -6, 	  -3,   -4, 	  -5,   -4
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    3,   -8, 	   1,   -5, 	  -1,   -3, 	  -5,   -5
+.2byte    3,   -8, 	   1,   -6, 	   1,   -4, 	  -5,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,  -10, 	  -4,   -6, 	   1,   -3, 	  -6,   -4
+.2byte    2,  -10, 	  -5,   -8, 	   2,   -5, 	  -6,   -4
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -2,  -14, 	   2,   -6, 	  -4,   -5, 	  -1,   -4
+.2byte    0,  -14, 	   2,   -5, 	  -3,   -6, 	  -1,   -4
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -5,  -10, 	   2,   -6, 	  -3,   -3, 	   4,   -4
+.2byte   -4,  -10, 	   3,   -8, 	  -4,   -5, 	   4,   -4
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -5,   -8, 	  -3,   -5, 	  -1,   -3, 	   3,   -5
+.2byte   -5,   -8, 	  -3,   -6, 	  -3,   -4, 	   3,   -5
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -3,   -7, 	  -3,   -4, 	   3,   -4, 	   1,   -4
+.2byte   -4,   -7, 	  -5,   -6, 	   1,   -4, 	   3,   -4
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    0,   -8, 	  -3,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -2,   -8, 	  -5,   -4, 	   1,   -4, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte    1,   -7, 	   1,   -4, 	  -5,   -4, 	  -3,   -4
+.2byte    2,   -7, 	   3,   -6, 	  -3,   -4, 	  -5,   -4
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    3,   -8, 	   1,   -5, 	  -1,   -3, 	  -5,   -5
+.2byte    3,   -8, 	   1,   -6, 	   1,   -4, 	  -5,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,  -10, 	  -4,   -6, 	   1,   -3, 	  -6,   -4
+.2byte    2,  -10, 	  -5,   -8, 	   2,   -5, 	  -6,   -4
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -2,  -14, 	   2,   -6, 	  -4,   -5, 	  -1,   -4
+.2byte    0,  -14, 	   2,   -5, 	  -3,   -6, 	  -1,   -4
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -5,  -10, 	   2,   -6, 	  -3,   -3, 	   4,   -4
+.2byte   -4,  -10, 	   3,   -8, 	  -4,   -5, 	   4,   -4
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -5,   -8, 	  -3,   -5, 	  -1,   -3, 	   3,   -5
+.2byte   -5,   -8, 	  -3,   -6, 	  -3,   -4, 	   3,   -5
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -3,   -7, 	  -3,   -4, 	   3,   -4, 	   1,   -4
+.2byte   -4,   -7, 	  -5,   -6, 	   1,   -4, 	   3,   -4
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    0,   -8, 	  -3,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -2,   -8, 	  -5,   -4, 	   1,   -4, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte    1,   -7, 	   1,   -4, 	  -5,   -4, 	  -3,   -4
+.2byte    2,   -7, 	   3,   -6, 	  -3,   -4, 	  -5,   -4
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    3,   -8, 	   1,   -5, 	  -1,   -3, 	  -5,   -5
+.2byte    3,   -8, 	   1,   -6, 	   1,   -4, 	  -5,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,  -10, 	  -4,   -6, 	   1,   -3, 	  -6,   -4
+.2byte    2,  -10, 	  -5,   -8, 	   2,   -5, 	  -6,   -4
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -2,  -14, 	   2,   -6, 	  -4,   -5, 	  -1,   -4
+.2byte    0,  -14, 	   2,   -5, 	  -3,   -6, 	  -1,   -4
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -5,  -10, 	   2,   -6, 	  -3,   -3, 	   4,   -4
+.2byte   -4,  -10, 	   3,   -8, 	  -4,   -5, 	   4,   -4
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -5,   -8, 	  -3,   -5, 	  -1,   -3, 	   3,   -5
+.2byte   -5,   -8, 	  -3,   -6, 	  -3,   -4, 	   3,   -5
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -3,   -7, 	  -3,   -4, 	   3,   -4, 	   1,   -4
+.2byte   -4,   -7, 	  -5,   -6, 	   1,   -4, 	   3,   -4
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    0,   -8, 	  -3,   -4, 	   3,   -4, 	  -1,   -5
+.2byte   -2,   -8, 	  -5,   -4, 	   1,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte    3,   -8, 	   4,   -6, 	  -2,   -5, 	  -1,   -5
+.2byte    3,   -7, 	   3,   -4, 	  -3,   -4, 	  -1,   -4
+.2byte    4,   -7, 	   5,   -6, 	  -1,   -4, 	  -3,   -4
+.2byte    4,   -6, 	   6,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    4,   -6, 	   6,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    4,   -6, 	   6,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    5,   -9, 	   3,   -6, 	   2,   -4, 	  -3,   -6
+.2byte    5,   -8, 	   3,   -5, 	   1,   -3, 	  -3,   -5
+.2byte    5,   -8, 	   3,   -6, 	   3,   -4, 	  -3,   -5
+.2byte    6,   -7, 	   4,   -4, 	   2,   -2, 	  -1,   -5
+.2byte    6,   -7, 	   4,   -4, 	   2,   -2, 	  -1,   -5
+.2byte    6,   -7, 	   4,   -4, 	   2,   -2, 	  -1,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,  -10, 	  -4,   -6, 	   1,   -3, 	  -6,   -4
+.2byte    2,  -10, 	  -5,   -8, 	   2,   -5, 	  -6,   -4
+.2byte    3,   -9, 	  -3,   -6, 	   3,   -3, 	  -4,   -4
+.2byte    3,   -9, 	  -3,   -6, 	   3,   -3, 	  -4,   -4
+.2byte    3,   -9, 	  -3,   -6, 	   3,   -3, 	  -4,   -4
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -2,  -14, 	   2,   -6, 	  -4,   -5, 	  -1,   -4
+.2byte    0,  -14, 	   2,   -5, 	  -3,   -6, 	  -1,   -4
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -4
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -4
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -4
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -5,  -10, 	   2,   -6, 	  -3,   -3, 	   4,   -4
+.2byte   -4,  -10, 	   3,   -8, 	  -4,   -5, 	   4,   -4
+.2byte   -5,   -9, 	   1,   -6, 	  -5,   -3, 	   2,   -4
+.2byte   -5,   -9, 	   1,   -6, 	  -5,   -3, 	   2,   -4
+.2byte   -5,   -9, 	   1,   -6, 	  -5,   -3, 	   2,   -4
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -5,   -8, 	  -3,   -5, 	  -1,   -3, 	   3,   -5
+.2byte   -5,   -8, 	  -3,   -6, 	  -3,   -4, 	   3,   -5
+.2byte   -6,   -7, 	  -4,   -4, 	  -2,   -2, 	   1,   -5
+.2byte   -6,   -7, 	  -4,   -4, 	  -2,   -2, 	   1,   -5
+.2byte   -6,   -7, 	  -4,   -4, 	  -2,   -2, 	   1,   -5
+.2byte   -4,   -8, 	  -5,   -6, 	   1,   -5, 	   0,   -5
+.2byte   -4,   -7, 	  -4,   -4, 	   2,   -4, 	   0,   -4
+.2byte   -5,   -7, 	  -6,   -6, 	   0,   -4, 	   2,   -4
+.2byte   -5,   -6, 	  -7,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -5,   -6, 	  -7,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -5,   -6, 	  -7,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte   -4,   -6, 	  -4,   -3, 	   0,   -3, 	   0,   -5
+.2byte   -5,   -5, 	  -4,   -3, 	   0,   -2, 	  -1,   -5
+.2byte   -1,   -8, 	  -4,   -9, 	   2,   -9, 	  -1,   -6
+.2byte    3,   -6, 	   3,   -8, 	  -3,   -6, 	  -1,   -6
+.2byte    2,   -6, 	   1,   -9, 	   0,   -7, 	  -5,   -5
+.2byte    2,   -8, 	  -4,   -9, 	   0,   -8, 	  -6,   -4
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,   -4
+.2byte   -4,   -8, 	   2,   -9, 	  -2,   -8, 	   4,   -4
+.2byte   -3,   -6, 	  -2,   -9, 	  -1,   -7, 	   4,   -5
+.2byte   -4,   -6, 	  -4,   -8, 	   2,   -6, 	   0,   -6
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte    2,   -6, 	   4,   -5, 	  -4,   -3, 	  -3,   -6
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    4,   -7, 	   2,   -4, 	   0,   -2, 	  -3,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,   -9, 	  -3,   -6, 	   3,   -3, 	  -4,   -4
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -4
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -5,   -9, 	   1,   -6, 	  -5,   -3, 	   2,   -4
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -6,   -7, 	  -4,   -4, 	  -2,   -2, 	   1,   -5
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	   2,   -3, 	   1,   -6
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte    2,   -6, 	   4,   -5, 	  -4,   -3, 	  -3,   -6
+.2byte    4,   -7, 	   2,   -4, 	   0,   -2, 	  -3,   -5
+.2byte    3,   -9, 	  -3,   -6, 	   3,   -3, 	  -4,   -4
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -4
+.2byte   -5,   -9, 	   1,   -6, 	  -5,   -3, 	   2,   -4
+.2byte   -6,   -7, 	  -4,   -4, 	  -2,   -2, 	   1,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	   2,   -3, 	   1,   -6
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte    2,   -6, 	   4,   -5, 	  -4,   -3, 	  -3,   -6
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    4,   -7, 	   2,   -4, 	   0,   -2, 	  -3,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,   -9, 	  -3,   -6, 	   3,   -3, 	  -4,   -4
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -4
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -5,   -9, 	   1,   -6, 	  -5,   -3, 	   2,   -4
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -6,   -7, 	  -4,   -4, 	  -2,   -2, 	   1,   -5
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	   2,   -3, 	   1,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	   2,   -3, 	   1,   -6
+.2byte   -6,   -7, 	  -4,   -4, 	  -2,   -2, 	   1,   -5
+.2byte   -5,   -9, 	   1,   -6, 	  -5,   -3, 	   2,   -4
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -4
+.2byte    3,   -9, 	  -3,   -6, 	   3,   -3, 	  -4,   -4
+.2byte    4,   -7, 	   2,   -4, 	   0,   -2, 	  -3,   -5
+.2byte    2,   -6, 	   4,   -5, 	  -4,   -3, 	  -3,   -6
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	  -4,   -6, 	   2,   -5, 	   1,   -5
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -4,  -11, 	   2,   -8, 	  -4,   -5, 	   3,   -5
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte    2,  -11, 	  -4,   -8, 	   2,   -5, 	  -5,   -5
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    1,   -8, 	   2,   -6, 	  -4,   -5, 	  -3,   -5
+.2byte   -3,   -8, 	  -5,   -1, 	  -2,   -7, 	  -1,   -4
+.2byte   -4,   -9, 	  -5,   -1, 	  -2,   -7, 	   0,   -5
+.2byte    2,   -8, 	   4,   -1, 	   1,   -7, 	   0,   -4
+.2byte    3,   -9, 	   4,   -1, 	   1,   -7, 	  -1,   -5
+.2byte   -3,   -8, 	  -5,   -1, 	  -2,   -7, 	  -1,   -4
+.2byte   -1,   -9, 	  -2,   -5, 	   2,   -7, 	   0,   -4
+.2byte    0,   -8, 	  -1,   -3, 	   2,   -5, 	  -4,   -5
+.2byte    1,   -8, 	  -1,   -4, 	   0,   -6, 	  -5,   -6
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -1,  -13, 	   6,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -7, 	  -9,   -7, 	  -1,   -5
+.2byte   -1,  -15, 	  -8,  -11, 	   6,  -11, 	  -1,   -8
+.2byte   -1,   -5, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -2,   -8, 	  -4,   -5, 	   1,   -5, 	  -1,   -5
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    1,   -9, 	  -6,  -11, 	   6,   -6, 	   0,   -6
+.2byte    0,  -13, 	   5,   -5, 	  -6,   -6, 	  -1,   -5
+.2byte   -2,  -14, 	   5,  -11, 	  -8,   -6, 	  -1,   -6
+.2byte   -2,  -14, 	   5,  -11, 	  -8,   -6, 	  -1,   -6
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -1,   -8, 	  -4,   -4, 	   2,   -4, 	  -1,   -6
+.2byte   -1,   -8, 	  -4,   -4, 	   2,   -4, 	  -1,   -6
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -4,  -11, 	  -5,   -7, 	   1,   -6, 	   1,   -7
+.2byte   -1,  -14, 	  -5,  -10, 	   6,   -5, 	   0,   -6
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -3
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -3
+.2byte   -1,   -9, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -1,  -15, 	  -8,  -11, 	   6,  -11, 	  -1,   -8
+.2byte   -1,   -6, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte   -5,   -9, 	  -3,   -6, 	  -2,   -4, 	   3,   -6
+.2byte   -4,   -6, 	  -3,   -5, 	  -2,   -4, 	   1,   -7
+.2byte    3,   -9, 	   1,   -6, 	   0,   -4, 	  -5,   -6
+.2byte    2,   -6, 	   1,   -5, 	   0,   -4, 	  -3,   -7
+.2byte   -1,  -15, 	   2,   -6, 	  -4,   -6, 	  -1,   -5
+.2byte   -1,  -11, 	   6,   -8, 	  -8,   -8, 	  -1,   -4
+.2byte   -5,   -9, 	   3,   -7, 	   5,   -6, 	   2,   -6
+.2byte   -2,  -10, 	   6,   -8, 	   2,   -7, 	   3,   -6
+.2byte   -6,   -9, 	   3,   -8, 	   0,   -6, 	   2,   -5
+.2byte   -2,  -10, 	  -2,   -8, 	   7,   -7, 	   2,   -7
+.2byte   -6,   -9, 	  -4,   -6, 	   4,   -6, 	   1,   -6
+.2byte    4,   -9, 	  -4,   -7, 	  -6,   -6, 	  -3,   -6
+.2byte    1,  -10, 	  -7,   -8, 	  -3,   -7, 	  -4,   -6
+.2byte    5,   -9, 	  -4,   -8, 	  -1,   -6, 	  -3,   -5
+.2byte    1,  -10, 	   1,   -8, 	  -8,   -7, 	  -3,   -7
+.2byte    5,   -9, 	   3,   -6, 	  -5,   -6, 	  -2,   -6
+.2byte    1,   -8, 	  -2,   -9, 	   2,   -8, 	  -4,   -5
+.2byte   -3,   -8, 	  -5,   -1, 	  -2,   -7, 	  -1,   -4
+.2byte   -4,   -9, 	  -5,   -1, 	  -2,   -7, 	   0,   -5
+.2byte    2,   -8, 	   4,   -1, 	   1,   -7, 	   0,   -4
+.2byte    3,   -9, 	   4,   -1, 	   1,   -7, 	  -1,   -5
+.2byte   -3,   -8, 	  -5,   -1, 	  -2,   -7, 	  -1,   -4
+.2byte   -4,   -9, 	  -5,   -1, 	  -2,   -7, 	   0,   -5
+.2byte    2,   -8, 	   4,   -1, 	   1,   -7, 	   0,   -4
+.2byte    3,   -9, 	   4,   -1, 	   1,   -7, 	  -1,   -5
+sCyndaquilAnimTable1:
+.4byte sCyndaquilAnims_1_1
+.4byte sCyndaquilAnims_1_2
+.4byte sCyndaquilAnims_1_3
+.4byte sCyndaquilAnims_1_4
+.4byte sCyndaquilAnims_1_5
+.4byte sCyndaquilAnims_1_6
+.4byte sCyndaquilAnims_1_7
+.4byte sCyndaquilAnims_1_8
+sCyndaquilAnimTable2:
+.4byte sCyndaquilAnims_2_1
+.4byte sCyndaquilAnims_2_2
+.4byte sCyndaquilAnims_2_3
+.4byte sCyndaquilAnims_2_4
+.4byte sCyndaquilAnims_2_5
+.4byte sCyndaquilAnims_2_6
+.4byte sCyndaquilAnims_2_7
+.4byte sCyndaquilAnims_2_8
+sCyndaquilAnimTable3:
+.4byte sCyndaquilAnims_3_1
+.4byte sCyndaquilAnims_3_2
+.4byte sCyndaquilAnims_3_3
+.4byte sCyndaquilAnims_3_4
+.4byte sCyndaquilAnims_3_5
+.4byte sCyndaquilAnims_3_6
+.4byte sCyndaquilAnims_3_7
+.4byte sCyndaquilAnims_3_8
+sCyndaquilAnimTable4:
+.4byte sCyndaquilAnims_4_1
+.4byte sCyndaquilAnims_4_2
+.4byte sCyndaquilAnims_4_3
+.4byte sCyndaquilAnims_4_4
+.4byte sCyndaquilAnims_4_5
+.4byte sCyndaquilAnims_4_6
+.4byte sCyndaquilAnims_4_7
+.4byte sCyndaquilAnims_4_8
+sCyndaquilAnimTable5:
+.4byte sCyndaquilAnims_5_1
+.4byte sCyndaquilAnims_5_2
+.4byte sCyndaquilAnims_5_3
+.4byte sCyndaquilAnims_5_4
+.4byte sCyndaquilAnims_5_5
+.4byte sCyndaquilAnims_5_6
+.4byte sCyndaquilAnims_5_7
+.4byte sCyndaquilAnims_5_8
+sCyndaquilAnimTable6:
+.4byte sCyndaquilAnims_6_1
+.4byte sCyndaquilAnims_6_1
+.4byte sCyndaquilAnims_6_1
+.4byte sCyndaquilAnims_6_1
+.4byte sCyndaquilAnims_6_1
+.4byte sCyndaquilAnims_6_1
+.4byte sCyndaquilAnims_6_1
+.4byte sCyndaquilAnims_6_1
+sCyndaquilAnimTable7:
+.4byte sCyndaquilAnims_7_1
+.4byte sCyndaquilAnims_7_2
+.4byte sCyndaquilAnims_7_3
+.4byte sCyndaquilAnims_7_4
+.4byte sCyndaquilAnims_7_5
+.4byte sCyndaquilAnims_7_6
+.4byte sCyndaquilAnims_7_7
+.4byte sCyndaquilAnims_7_8
+sCyndaquilAnimTable8:
+.4byte sCyndaquilAnims_8_1
+.4byte sCyndaquilAnims_8_2
+.4byte sCyndaquilAnims_8_3
+.4byte sCyndaquilAnims_8_4
+.4byte sCyndaquilAnims_8_5
+.4byte sCyndaquilAnims_8_6
+.4byte sCyndaquilAnims_8_7
+.4byte sCyndaquilAnims_8_8
+sCyndaquilAnimTable9:
+.4byte sCyndaquilAnims_9_1
+.4byte sCyndaquilAnims_9_2
+.4byte sCyndaquilAnims_9_3
+.4byte sCyndaquilAnims_9_4
+.4byte sCyndaquilAnims_9_5
+.4byte sCyndaquilAnims_9_6
+.4byte sCyndaquilAnims_9_7
+.4byte sCyndaquilAnims_9_8
+sCyndaquilAnimTable10:
+.4byte sCyndaquilAnims_10_1
+.4byte sCyndaquilAnims_10_2
+.4byte sCyndaquilAnims_10_3
+.4byte sCyndaquilAnims_10_4
+.4byte sCyndaquilAnims_10_5
+.4byte sCyndaquilAnims_10_6
+.4byte sCyndaquilAnims_10_7
+.4byte sCyndaquilAnims_10_8
+sCyndaquilAnimTable11:
+.4byte sCyndaquilAnims_11_1
+.4byte sCyndaquilAnims_11_2
+.4byte sCyndaquilAnims_11_3
+.4byte sCyndaquilAnims_11_4
+.4byte sCyndaquilAnims_11_5
+.4byte sCyndaquilAnims_11_6
+.4byte sCyndaquilAnims_11_7
+.4byte sCyndaquilAnims_11_8
+sCyndaquilAnimTable12:
+.4byte sCyndaquilAnims_12_1
+.4byte sCyndaquilAnims_12_2
+.4byte sCyndaquilAnims_12_3
+.4byte sCyndaquilAnims_12_4
+.4byte sCyndaquilAnims_12_5
+.4byte sCyndaquilAnims_12_6
+.4byte sCyndaquilAnims_12_7
+.4byte sCyndaquilAnims_12_8
+sCyndaquilAnimTable13:
+.4byte sCyndaquilAnims_13_1
+.4byte sCyndaquilAnims_13_2
+.4byte sCyndaquilAnims_13_3
+.4byte sCyndaquilAnims_13_4
+.4byte sCyndaquilAnims_13_5
+.4byte sCyndaquilAnims_13_6
+.4byte sCyndaquilAnims_13_7
+.4byte sCyndaquilAnims_13_8
+sCyndaquilAnimTable14:
+.4byte sCyndaquilAnims_14_1
+.4byte sCyndaquilAnims_14_2
+.4byte sCyndaquilAnims_14_3
+.4byte sCyndaquilAnims_14_4
+.4byte sCyndaquilAnims_14_5
+.4byte sCyndaquilAnims_14_6
+.4byte sCyndaquilAnims_14_7
+.4byte sCyndaquilAnims_14_8
+sCyndaquilAnimTable15:
+.4byte sCyndaquilAnims_15_1
+.4byte sCyndaquilAnims_15_2
+.4byte sCyndaquilAnims_15_3
+.4byte sCyndaquilAnims_15_4
+.4byte sCyndaquilAnims_15_5
+.4byte sCyndaquilAnims_15_6
+.4byte sCyndaquilAnims_15_7
+.4byte sCyndaquilAnims_15_8
+sCyndaquilAnimTable16:
+.4byte sCyndaquilAnims_16_1
+.4byte sCyndaquilAnims_16_2
+.4byte sCyndaquilAnims_16_3
+.4byte sCyndaquilAnims_16_4
+.4byte sCyndaquilAnims_16_5
+.4byte sCyndaquilAnims_16_6
+.4byte sCyndaquilAnims_16_7
+.4byte sCyndaquilAnims_16_8
+sCyndaquilAnimTable17:
+.4byte sCyndaquilAnims_17_1
+.4byte sCyndaquilAnims_17_2
+.4byte sCyndaquilAnims_17_3
+.4byte sCyndaquilAnims_17_4
+.4byte sCyndaquilAnims_17_5
+.4byte sCyndaquilAnims_17_6
+.4byte sCyndaquilAnims_17_7
+.4byte sCyndaquilAnims_17_8
+sCyndaquilAnimTable18:
+.4byte sCyndaquilAnims_18_1
+.4byte sCyndaquilAnims_18_2
+.4byte sCyndaquilAnims_18_3
+.4byte sCyndaquilAnims_18_4
+.4byte sCyndaquilAnims_18_5
+.4byte sCyndaquilAnims_18_6
+.4byte sCyndaquilAnims_18_7
+.4byte sCyndaquilAnims_18_8
+sCyndaquilAnimTable19:
+.4byte sCyndaquilAnims_19_1
+.4byte sCyndaquilAnims_19_2
+.4byte sCyndaquilAnims_19_3
+.4byte sCyndaquilAnims_19_4
+.4byte sCyndaquilAnims_19_5
+.4byte sCyndaquilAnims_19_6
+.4byte sCyndaquilAnims_19_7
+.4byte sCyndaquilAnims_19_8
+sCyndaquilAnimTable20:
+.4byte sCyndaquilAnims_20_1
+.4byte sCyndaquilAnims_20_2
+.4byte sCyndaquilAnims_20_3
+.4byte sCyndaquilAnims_20_4
+.4byte sCyndaquilAnims_20_5
+.4byte sCyndaquilAnims_20_6
+.4byte sCyndaquilAnims_20_7
+.4byte sCyndaquilAnims_20_8
+sCyndaquilAnimTable21:
+.4byte sCyndaquilAnims_21_1
+.4byte sCyndaquilAnims_21_2
+.4byte sCyndaquilAnims_21_3
+.4byte sCyndaquilAnims_21_4
+.4byte sCyndaquilAnims_21_5
+.4byte sCyndaquilAnims_21_6
+.4byte sCyndaquilAnims_21_7
+.4byte sCyndaquilAnims_21_8
+sCyndaquilAnimTable22:
+.4byte sCyndaquilAnims_22_1
+.4byte sCyndaquilAnims_22_2
+.4byte sCyndaquilAnims_22_3
+.4byte sCyndaquilAnims_22_4
+.4byte sCyndaquilAnims_22_5
+.4byte sCyndaquilAnims_22_6
+.4byte sCyndaquilAnims_22_7
+.4byte sCyndaquilAnims_22_8
+sCyndaquilAnimTable23:
+.4byte sCyndaquilAnims_23_1
+.4byte sCyndaquilAnims_23_2
+.4byte sCyndaquilAnims_23_3
+.4byte sCyndaquilAnims_23_4
+.4byte sCyndaquilAnims_23_5
+.4byte sCyndaquilAnims_23_6
+.4byte sCyndaquilAnims_23_7
+.4byte sCyndaquilAnims_23_8
+sCyndaquilAnimTable24:
+.4byte sCyndaquilAnims_24_1
+.4byte sCyndaquilAnims_24_2
+.4byte sCyndaquilAnims_24_3
+.4byte sCyndaquilAnims_24_4
+.4byte sCyndaquilAnims_24_5
+.4byte sCyndaquilAnims_24_6
+.4byte sCyndaquilAnims_24_7
+.4byte sCyndaquilAnims_24_8
+sCyndaquilAnimTable25:
+.4byte sCyndaquilAnims_25_1
+.4byte sCyndaquilAnims_25_2
+.4byte sCyndaquilAnims_25_3
+.4byte sCyndaquilAnims_25_4
+.4byte sCyndaquilAnims_25_5
+.4byte sCyndaquilAnims_25_6
+.4byte sCyndaquilAnims_25_7
+.4byte sCyndaquilAnims_25_8
+sCyndaquilAnimTable26:
+.4byte sCyndaquilAnims_26_1
+.4byte sCyndaquilAnims_26_2
+.4byte sCyndaquilAnims_26_3
+.4byte sCyndaquilAnims_26_4
+.4byte sCyndaquilAnims_26_5
+.4byte sCyndaquilAnims_26_6
+.4byte sCyndaquilAnims_26_7
+.4byte sCyndaquilAnims_26_8
+sCyndaquilAnimTable27:
+.4byte sCyndaquilAnims_27_1
+.4byte sCyndaquilAnims_27_1
+.4byte sCyndaquilAnims_27_1
+.4byte sCyndaquilAnims_27_1
+.4byte sCyndaquilAnims_27_1
+.4byte sCyndaquilAnims_27_1
+.4byte sCyndaquilAnims_27_1
+.4byte sCyndaquilAnims_27_1
+sCyndaquilAnimTable28:
+.4byte sCyndaquilAnims_28_1
+.4byte sCyndaquilAnims_28_2
+.4byte sCyndaquilAnims_28_3
+.4byte sCyndaquilAnims_28_4
+.4byte sCyndaquilAnims_28_5
+.4byte sCyndaquilAnims_28_6
+.4byte sCyndaquilAnims_28_7
+.4byte sCyndaquilAnims_28_8
+sAxAnimationsCyndaquil:
+.4byte sCyndaquilAnimTable1
+.4byte sCyndaquilAnimTable2
+.4byte sCyndaquilAnimTable3
+.4byte sCyndaquilAnimTable4
+.4byte sCyndaquilAnimTable5
+.4byte sCyndaquilAnimTable6
+.4byte sCyndaquilAnimTable7
+.4byte sCyndaquilAnimTable8
+.4byte sCyndaquilAnimTable9
+.4byte sCyndaquilAnimTable10
+.4byte sCyndaquilAnimTable11
+.4byte sCyndaquilAnimTable12
+.4byte sCyndaquilAnimTable13
+.4byte sCyndaquilAnimTable14
+.4byte sCyndaquilAnimTable15
+.4byte sCyndaquilAnimTable16
+.4byte sCyndaquilAnimTable17
+.4byte sCyndaquilAnimTable18
+.4byte sCyndaquilAnimTable19
+.4byte sCyndaquilAnimTable20
+.4byte sCyndaquilAnimTable21
+.4byte sCyndaquilAnimTable22
+.4byte sCyndaquilAnimTable23
+.4byte sCyndaquilAnimTable24
+.4byte sCyndaquilAnimTable25
+.4byte sCyndaquilAnimTable26
+.4byte sCyndaquilAnimTable27
+.4byte sCyndaquilAnimTable28
+sAxSpritesCyndaquil:
+.4byte sCyndaquilSprites1
+.4byte sCyndaquilSprites2
+.4byte sCyndaquilSprites3
+.4byte sCyndaquilSprites4
+.4byte sCyndaquilSprites5
+.4byte sCyndaquilSprites6
+.4byte sCyndaquilSprites7
+.4byte sCyndaquilSprites8
+.4byte sCyndaquilSprites9
+.4byte sCyndaquilSprites10
+.4byte sCyndaquilSprites11
+.4byte sCyndaquilSprites12
+.4byte sCyndaquilSprites13
+.4byte sCyndaquilSprites14
+.4byte sCyndaquilSprites15
+.4byte sCyndaquilSprites16
+.4byte sCyndaquilSprites17
+.4byte sCyndaquilSprites18
+.4byte sCyndaquilSprites19
+.4byte sCyndaquilSprites20
+.4byte sCyndaquilSprites21
+.4byte sCyndaquilSprites22
+.4byte sCyndaquilSprites23
+.4byte sCyndaquilSprites24
+.4byte sCyndaquilSprites25
+.4byte sCyndaquilSprites26
+.4byte sCyndaquilSprites27
+.4byte sCyndaquilSprites28
+.4byte sCyndaquilSprites29
+.4byte sCyndaquilSprites30
+.4byte sCyndaquilSprites31
+.4byte sCyndaquilSprites32
+.4byte sCyndaquilSprites33
+.4byte sCyndaquilSprites34
+.4byte sCyndaquilSprites35
+.4byte sCyndaquilSprites36
+.4byte sCyndaquilSprites37
+.4byte sCyndaquilSprites38
+.4byte sCyndaquilSprites39
+.4byte sCyndaquilSprites40
+.4byte sCyndaquilSprites41
+.4byte sCyndaquilSprites42
+.4byte sCyndaquilSprites43
+.4byte sCyndaquilSprites44
+.4byte sCyndaquilSprites45
+.4byte sCyndaquilSprites46
+.4byte sCyndaquilSprites47
+.4byte sCyndaquilSprites48
+.4byte sCyndaquilSprites49
+.4byte sCyndaquilSprites50
+.4byte sCyndaquilSprites51
+.4byte sCyndaquilSprites52
+.4byte sCyndaquilSprites53
+.4byte sCyndaquilSprites54
+.4byte sCyndaquilSprites55
+.4byte sCyndaquilSprites56
+.4byte sCyndaquilSprites57
+.4byte sCyndaquilSprites58
+.4byte sCyndaquilSprites59
+.4byte sCyndaquilSprites60
+.4byte sCyndaquilSprites61
+.4byte sCyndaquilSprites62
+.4byte sCyndaquilSprites63
+.4byte sCyndaquilSprites64
+.4byte sCyndaquilSprites65
+.4byte sCyndaquilSprites66
+.4byte sCyndaquilSprites67
+.4byte sCyndaquilSprites68
+.4byte sCyndaquilSprites69
+.4byte sCyndaquilSprites70
+.4byte sCyndaquilSprites71
+.4byte sCyndaquilSprites72
+.4byte sCyndaquilSprites73
+.4byte sCyndaquilSprites74
+.4byte sCyndaquilSprites75
+.4byte sCyndaquilSprites76
+.4byte sCyndaquilSprites77
+.4byte sCyndaquilSprites78
+.4byte sCyndaquilSprites79
+.4byte sCyndaquilSprites80
+.4byte sCyndaquilSprites81
+.4byte sCyndaquilSprites82
+.4byte sCyndaquilSprites83
+.4byte sCyndaquilSprites84
+.4byte sCyndaquilSprites85
+sAxMainCyndaquil:
+ax_main sAxPosesCyndaquil, sAxAnimationsCyndaquil, 28, sAxSpritesCyndaquil, sAxPositionsCyndaquil

--- a/data/ax/decoy.inc
+++ b/data/ax/decoy.inc
@@ -1,0 +1,2284 @@
+.global gAxDecoy
+gAxDecoy:
+ax_siro sAxMainDecoy
+sDecoyPose1:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose2:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose3:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose4:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose5:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose6:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose7:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose8:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose9:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose10:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose11:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose12:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose13:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose14:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose15:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose16:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose17:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose18:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose19:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose20:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose21:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose22:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose23:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose24:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose25:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose26:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose27:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose28:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose29:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose30:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose31:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose32:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose33:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose34:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose35:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose36:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose37:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose38:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose39:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose40:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose41:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose42:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose43:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose44:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose45:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose46:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose47:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose48:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose49:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose50:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose51:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose52:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose53:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose54:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose55:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose56:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose57:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose58:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose59:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose60:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose61:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose62:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose63:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose64:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose65:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose66:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose67:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose68:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose69:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose70:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose71:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose72:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose73:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose74:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose75:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose76:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose77:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose78:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose79:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose80:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose81:
+ax_pose 10, 0x01ee, 0x80ee, 0x3c00
+ax_pose_terminator
+sDecoyPose82:
+ax_pose 11, 0x01ee, 0x80ee, 0x3c00
+ax_pose_terminator
+sDecoyPose83:
+ax_pose 12, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose84:
+ax_pose 13, 0x01e7, 0x90f0, 0x3c00
+ax_pose_terminator
+sDecoyPose85:
+ax_pose 14, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose86:
+ax_pose 15, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose87:
+ax_pose 16, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sDecoyPose88:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose89:
+ax_pose 14, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose90:
+ax_pose 13, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sDecoyPose91:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose92:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose93:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose94:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose95:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose96:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose97:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose98:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose99:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose100:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose101:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose102:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose103:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose104:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose105:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose106:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose107:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose108:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose109:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose110:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose111:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose112:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose113:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose114:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose115:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose116:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose117:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose118:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose119:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose120:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose121:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose122:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose123:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose124:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose125:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose126:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose127:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose128:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose129:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose130:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose131:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose132:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose133:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose134:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose135:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose136:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose137:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose138:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose139:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose140:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose141:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose142:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose143:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose144:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose145:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose146:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose147:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose148:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose149:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose150:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose151:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose152:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose153:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose154:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose155:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose156:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose157:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose158:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose159:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose160:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose161:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose162:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose163:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose164:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose165:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose166:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose167:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose168:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose169:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose170:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sDecoyPose171:
+ax_pose 0, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose172:
+ax_pose 1, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sDecoyPose173:
+ax_pose 2, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose174:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sDecoyPose175:
+ax_pose 4, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose176:
+ax_pose 3, 0x01ee, 0x80f6, 0x3c00
+ax_pose_terminator
+sDecoyPose177:
+ax_pose 2, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose178:
+ax_pose 1, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sDecoyPose179:
+ax_pose 5, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose180:
+ax_pose 6, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sDecoyPose181:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose182:
+ax_pose 8, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sDecoyPose183:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose184:
+ax_pose 8, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sDecoyPose185:
+ax_pose 7, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sDecoyPose186:
+ax_pose 6, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+.align 2
+sDecoyAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 1, 0, 0, 0, -2, 0, 0,
+ax_anim 1, 0, 0, 0, -3, 0, 0,
+ax_anim 3, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -5, 0, 0,
+ax_anim 3, 0, 0, 0, -4, 0, 0,
+ax_anim 1, 0, 0, 0, -3, 0, 0,
+ax_anim 1, 0, 0, 0, -2, 0, 0,
+ax_anim 3, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_1_2:
+ax_anim 5, 0, 1, 0, 0, 0, 0,
+ax_anim 1, 0, 1, 0, -2, 0, 0,
+ax_anim 1, 0, 1, 0, -3, 0, 0,
+ax_anim 3, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 1, 0, -5, 0, 0,
+ax_anim 3, 0, 1, 0, -4, 0, 0,
+ax_anim 1, 0, 1, 0, -3, 0, 0,
+ax_anim 1, 0, 1, 0, -2, 0, 0,
+ax_anim 5, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_1_3:
+ax_anim 5, 0, 2, 0, 0, 0, 0,
+ax_anim 1, 0, 2, 0, -2, 0, 0,
+ax_anim 1, 0, 2, 0, -3, 0, 0,
+ax_anim 3, 0, 2, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -5, 0, 0,
+ax_anim 3, 0, 2, 0, -4, 0, 0,
+ax_anim 1, 0, 2, 0, -3, 0, 0,
+ax_anim 1, 0, 2, 0, -2, 0, 0,
+ax_anim 5, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_1_4:
+ax_anim 5, 0, 3, 0, 0, 0, 0,
+ax_anim 1, 0, 3, 0, -2, 0, 0,
+ax_anim 1, 0, 3, 0, -3, 0, 0,
+ax_anim 3, 0, 3, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -5, 0, 0,
+ax_anim 3, 0, 3, 0, -4, 0, 0,
+ax_anim 1, 0, 3, 0, -3, 0, 0,
+ax_anim 1, 0, 3, 0, -2, 0, 0,
+ax_anim 5, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_1_5:
+ax_anim 5, 0, 4, 0, 0, 0, 0,
+ax_anim 1, 0, 4, 0, -2, 0, 0,
+ax_anim 1, 0, 4, 0, -3, 0, 0,
+ax_anim 3, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 4, 0, -5, 0, 0,
+ax_anim 3, 0, 4, 0, -4, 0, 0,
+ax_anim 1, 0, 4, 0, -3, 0, 0,
+ax_anim 1, 0, 4, 0, -2, 0, 0,
+ax_anim 5, 0, 12, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_1_6:
+ax_anim 5, 0, 5, 0, 0, 0, 0,
+ax_anim 1, 0, 5, 0, -2, 0, 0,
+ax_anim 1, 0, 5, 0, -3, 0, 0,
+ax_anim 3, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 0, -5, 0, 0,
+ax_anim 3, 0, 5, 0, -4, 0, 0,
+ax_anim 1, 0, 5, 0, -3, 0, 0,
+ax_anim 1, 0, 5, 0, -2, 0, 0,
+ax_anim 5, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_1_7:
+ax_anim 5, 0, 6, 0, 0, 0, 0,
+ax_anim 1, 0, 6, 0, -2, 0, 0,
+ax_anim 1, 0, 6, 0, -3, 0, 0,
+ax_anim 3, 0, 6, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -5, 0, 0,
+ax_anim 3, 0, 6, 0, -4, 0, 0,
+ax_anim 1, 0, 6, 0, -3, 0, 0,
+ax_anim 1, 0, 6, 0, -2, 0, 0,
+ax_anim 5, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_1_8:
+ax_anim 5, 0, 7, 0, 0, 0, 0,
+ax_anim 1, 0, 7, 0, -2, 0, 0,
+ax_anim 1, 0, 7, 0, -3, 0, 0,
+ax_anim 3, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 7, 0, -5, 0, 0,
+ax_anim 3, 0, 7, 0, -4, 0, 0,
+ax_anim 1, 0, 7, 0, -3, 0, 0,
+ax_anim 1, 0, 7, 0, -2, 0, 0,
+ax_anim 5, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 24, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sDecoyAnims_2_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 25, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sDecoyAnims_2_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 26, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sDecoyAnims_2_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 27, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sDecoyAnims_2_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 28, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sDecoyAnims_2_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 29, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sDecoyAnims_2_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 30, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sDecoyAnims_2_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 31, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDecoyAnims_3_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 4, 0, 32, 0, -2, 0, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 0, 4, 0, 4,
+ax_anim 1, 0, 32, 0, 10, 0, 8,
+ax_anim 2, 0, 40, 0, 24, 0, 21,
+ax_anim 2, 1, 32, 1, 24, 1, 21,
+ax_anim 2, 0, 32, 0, 24, 0, 21,
+ax_anim 2, 0, 32, 1, 24, 1, 21,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sDecoyAnims_3_2:
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 4, 0, 33, -2, -2, -2, -2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 4, 4, 4,
+ax_anim 1, 0, 33, 10, 10, 10, 9,
+ax_anim 2, 0, 41, 23, 24, 23, 21,
+ax_anim 2, 1, 33, 24, 23, 24, 20,
+ax_anim 2, 0, 33, 23, 24, 23, 21,
+ax_anim 2, 0, 33, 24, 23, 24, 20,
+ax_anim 2, 0, 33, 6, 6, 6, 6,
+ax_anim_terminator
+sDecoyAnims_3_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 1, 10, 0,
+ax_anim 2, 0, 42, 23, 2, 23, 0,
+ax_anim 2, 1, 34, 23, 1, 23, -1,
+ax_anim 2, 0, 34, 23, 2, 23, 0,
+ax_anim 2, 0, 34, 23, 1, 23, -1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sDecoyAnims_3_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 4, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 6, -5, 6, -5,
+ax_anim 1, 0, 35, 14, -11, 14, -13,
+ax_anim 2, 0, 43, 23, -17, 23, -20,
+ax_anim 2, 1, 35, 22, -18, 22, -21,
+ax_anim 2, 0, 35, 23, -17, 23, -20,
+ax_anim 2, 0, 35, 22, -18, 22, -21,
+ax_anim 2, 0, 35, 7, -5, 7, -6,
+ax_anim_terminator
+sDecoyAnims_3_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -11, 0, -12,
+ax_anim 2, 0, 44, 0, -17, 0, -20,
+ax_anim 2, 1, 36, 1, -17, 1, -20,
+ax_anim 2, 0, 36, 0, -17, 0, -20,
+ax_anim 2, 0, 36, 1, -17, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sDecoyAnims_3_6:
+ax_anim 2, 0, 37, 1, 1, 1, 1,
+ax_anim 4, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, -6, -5, -6, -5,
+ax_anim 1, 0, 37, -14, -11, -14, -13,
+ax_anim 2, 0, 45, -23, -17, -23, -20,
+ax_anim 2, 1, 37, -24, -16, -24, -19,
+ax_anim 2, 0, 37, -23, -17, -23, -20,
+ax_anim 2, 0, 37, -24, -16, -24, -19,
+ax_anim 2, 0, 37, -7, -5, -7, -6,
+ax_anim_terminator
+sDecoyAnims_3_7:
+ax_anim 2, 0, 38, 1, 0, 1, 0,
+ax_anim 4, 0, 38, 2, 0, 2, 0,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, -4, 0, -4, 0,
+ax_anim 1, 0, 38, -10, 1, -10, 0,
+ax_anim 2, 0, 46, -23, 2, -23, 0,
+ax_anim 2, 1, 38, -23, 1, -23, -1,
+ax_anim 2, 0, 38, -23, 2, -23, 0,
+ax_anim 2, 0, 38, -23, 1, -23, -1,
+ax_anim 2, 0, 38, -6, 0, -6, 0,
+ax_anim_terminator
+sDecoyAnims_3_8:
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 4, 0, 39, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, -4, 4, -4, 4,
+ax_anim 1, 0, 39, -10, 10, -10, 9,
+ax_anim 2, 0, 47, -23, 24, -23, 21,
+ax_anim 2, 1, 39, -24, 23, -24, 20,
+ax_anim 2, 0, 39, -23, 24, -23, 21,
+ax_anim 2, 0, 39, -24, 23, -24, 20,
+ax_anim 2, 0, 39, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDecoyAnims_4_1:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 2, 2, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 2, 1, 48, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_4_2:
+ax_anim 2, 0, 49, 1, -1, 1, -1,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, -1, 1, -1,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, -1, 1, -1,
+ax_anim 2, 2, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, -1, 1, -1,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, -1, 1, -1,
+ax_anim 2, 1, 49, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_4_3:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 2, 2, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 2, 1, 50, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_4_4:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 2, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 1, 51, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_4_5:
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 2, 2, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 2, 1, 52, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_4_6:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 2, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 1, 53, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_4_7:
+ax_anim 2, 0, 54, 0, -1, 0, -1,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, -1, 0, -1,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, -1, 0, -1,
+ax_anim 2, 2, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, -1, 0, -1,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, -1, 0, -1,
+ax_anim 2, 1, 54, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_4_8:
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 2, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 1, 55, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_5_1:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 2, 64, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_5_2:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 2, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_5_3:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_5_4:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 2, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_5_5:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 2, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_5_6:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 2, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_5_7:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 2, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_5_8:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 2, 71, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_6_1:
+ax_anim 30, 0, 80, 0, 0, 0, 0,
+ax_anim 35, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_7_1:
+ax_anim 2, 0, 82, 0, -2, 0, -2,
+ax_anim 8, 0, 82, 0, -3, 0, -3,
+ax_anim_terminator
+sDecoyAnims_7_2:
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 8, 0, 83, -3, -3, -3, -3,
+ax_anim_terminator
+sDecoyAnims_7_3:
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 8, 0, 84, -3, 0, -3, 0,
+ax_anim_terminator
+sDecoyAnims_7_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 8, 0, 85, -3, 3, -3, 3,
+ax_anim_terminator
+sDecoyAnims_7_5:
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 8, 0, 86, 0, 3, 0, 3,
+ax_anim_terminator
+sDecoyAnims_7_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 8, 0, 87, 3, 3, 3, 3,
+ax_anim_terminator
+sDecoyAnims_7_7:
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 8, 0, 88, 3, 0, 3, 0,
+ax_anim_terminator
+sDecoyAnims_7_8:
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim 8, 0, 89, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDecoyAnims_8_1:
+ax_anim 32, 0, 90, 0, 0, 0, 0,
+ax_anim 8, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 3, 0, 90, 0, -4, 0, 0,
+ax_anim 4, 0, 90, 0, -5, 0, 0,
+ax_anim 3, 0, 90, 0, -4, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim_terminator
+sDecoyAnims_8_2:
+ax_anim 32, 0, 91, 0, 0, 0, 0,
+ax_anim 8, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 3, 0, 91, 0, -4, 0, 0,
+ax_anim 4, 0, 91, 0, -5, 0, 0,
+ax_anim 3, 0, 91, 0, -4, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim_terminator
+sDecoyAnims_8_3:
+ax_anim 32, 0, 92, 0, 0, 0, 0,
+ax_anim 8, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 3, 0, 92, 0, -4, 0, 0,
+ax_anim 4, 0, 92, 0, -5, 0, 0,
+ax_anim 3, 0, 92, 0, -4, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim_terminator
+sDecoyAnims_8_4:
+ax_anim 32, 0, 93, 0, 0, 0, 0,
+ax_anim 8, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 3, 0, 93, 0, -4, 0, 0,
+ax_anim 4, 0, 93, 0, -5, 0, 0,
+ax_anim 3, 0, 93, 0, -4, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim_terminator
+sDecoyAnims_8_5:
+ax_anim 32, 0, 94, 0, 0, 0, 0,
+ax_anim 8, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 3, 0, 94, 0, -4, 0, 0,
+ax_anim 4, 0, 94, 0, -5, 0, 0,
+ax_anim 3, 0, 94, 0, -4, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim_terminator
+sDecoyAnims_8_6:
+ax_anim 32, 0, 95, 0, 0, 0, 0,
+ax_anim 8, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 3, 0, 95, 0, -4, 0, 0,
+ax_anim 4, 0, 95, 0, -5, 0, 0,
+ax_anim 3, 0, 95, 0, -4, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim_terminator
+sDecoyAnims_8_7:
+ax_anim 32, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 1, 0, 96, 0, -3, 0, 0,
+ax_anim 3, 0, 96, 0, -4, 0, 0,
+ax_anim 4, 0, 96, 0, -5, 0, 0,
+ax_anim 3, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -3, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim_terminator
+sDecoyAnims_8_8:
+ax_anim 32, 0, 97, 0, 0, 0, 0,
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 1, 0, 97, 0, -3, 0, 0,
+ax_anim 3, 0, 97, 0, -4, 0, 0,
+ax_anim 4, 0, 97, 0, -5, 0, 0,
+ax_anim 3, 0, 97, 0, -4, 0, 0,
+ax_anim 1, 0, 97, 0, -3, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_9_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 6, 3, 6, 3,
+ax_anim 2, 0, 112, 8, 9, 8, 9,
+ax_anim 2, 0, 111, 7, 18, 7, 18,
+ax_anim 3, 0, 110, 0, 22, 0, 22,
+ax_anim 2, 3, 109, -7, 18, -7, 18,
+ax_anim 2, 0, 108, -8, 9, -8, 9,
+ax_anim 1, 0, 107, -6, 3, -6, 3,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_9_2:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 11, 0, 11, 0,
+ax_anim 2, 0, 113, 21, 3, 21, 3,
+ax_anim 2, 0, 112, 26, 10, 26, 10,
+ax_anim 3, 0, 111, 20, 18, 20, 18,
+ax_anim 2, 3, 110, 11, 19, 11, 19,
+ax_anim 2, 0, 109, 3, 15, 3, 15,
+ax_anim 1, 0, 108, 0, 7, 0, 7,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_9_3:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 106, 13, -6, 13, -6,
+ax_anim 2, 0, 113, 20, -5, 20, -5,
+ax_anim 3, 0, 112, 23, 0, 23, 0,
+ax_anim 2, 3, 111, 20, 4, 20, 4,
+ax_anim 2, 0, 110, 14, 7, 14, 7,
+ax_anim 1, 0, 109, 6, 5, 6, 5,
+ax_anim 1, 0, 108, 2, 0, 2, 0,
+ax_anim_terminator
+sDecoyAnims_9_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, -1, -6, -1, -6,
+ax_anim 2, 0, 107, 4, -17, 4, -17,
+ax_anim 2, 0, 106, 15, -22, 15, -22,
+ax_anim 3, 0, 113, 21, -21, 21, -21,
+ax_anim 2, 3, 112, 24, -13, 24, -13,
+ax_anim 2, 0, 111, 19, -4, 19, -4,
+ax_anim 1, 0, 110, 9, 0, 9, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_9_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, -8, -4, -8, -4,
+ax_anim 2, 0, 108, -9, -12, -9, -12,
+ax_anim 2, 0, 107, -7, -20, -7, -20,
+ax_anim 3, 0, 106, 0, -22, 0, -22,
+ax_anim 2, 3, 113, 7, -20, 7, -20,
+ax_anim 2, 0, 112, 9, -10, 9, -10,
+ax_anim 1, 0, 111, 8, -4, 8, -4,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_9_6:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 1, -6, 1, -6,
+ax_anim 2, 0, 113, -4, -17, -4, -17,
+ax_anim 2, 0, 106, -15, -22, -15, -22,
+ax_anim 3, 0, 107, -21, -21, -21, -21,
+ax_anim 2, 3, 108, -24, -13, -24, -13,
+ax_anim 2, 0, 109, -19, -4, -19, -4,
+ax_anim 1, 0, 110, -9, 0, -9, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_9_7:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, -5, -5, -5, -5,
+ax_anim 2, 0, 106, -13, -6, -13, -6,
+ax_anim 2, 0, 107, -20, -5, -20, -5,
+ax_anim 3, 0, 108, -23, 0, -23, 0,
+ax_anim 2, 3, 109, -20, 4, -20, 4,
+ax_anim 2, 0, 110, -14, 7, -14, 7,
+ax_anim 1, 0, 111, -6, 5, -6, 5,
+ax_anim 1, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sDecoyAnims_9_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, -11, 0, -11, 0,
+ax_anim 2, 0, 107, -21, 3, -21, 3,
+ax_anim 2, 0, 108, -26, 10, -26, 10,
+ax_anim 3, 0, 109, -20, 18, -20, 18,
+ax_anim 2, 3, 110, -11, 19, -11, 19,
+ax_anim 2, 0, 111, -3, 15, -3, 15,
+ax_anim 1, 0, 112, 0, 7, 0, 7,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_10_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 3, 0, 122, 13, 0, 13, 0,
+ax_anim 3, 0, 122, -13, 0, -13, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_10_2:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 3, 0, 123, 13, -13, 13, -13,
+ax_anim 3, 0, 123, -13, 13, -13, 13,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_10_3:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 3, 0, 124, 0, -13, 0, -13,
+ax_anim 3, 0, 124, 0, 13, 0, 13,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_10_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 3, 0, 125, -13, -13, -13, -13,
+ax_anim 3, 0, 125, 13, 13, 13, 13,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_10_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 3, 0, 126, 13, 0, 13, 0,
+ax_anim 3, 0, 126, -13, 0, -13, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_10_6:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 3, 0, 127, 13, -13, 13, -13,
+ax_anim 3, 0, 127, -13, 13, -13, 13,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_10_7:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 3, 0, 128, 0, -13, 0, -13,
+ax_anim 3, 0, 128, 0, 13, 0, 13,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_10_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 3, 0, 129, -13, -13, -13, -13,
+ax_anim 3, 0, 129, 13, 13, 13, 13,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, -10, 0, 0,
+ax_anim 2, 0, 138, 0, -16, 0, 0,
+ax_anim 3, 0, 138, 0, -20, 0, 0,
+ax_anim 4, 0, 138, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -22, 0, 0,
+ax_anim 3, 0, 138, 0, -21, 0, 0,
+ax_anim 2, 0, 138, 0, -18, 0, 0,
+ax_anim 1, 0, 138, 0, -12, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_11_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 139, 0, -22, 0, 0,
+ax_anim 3, 0, 139, 0, -21, 0, 0,
+ax_anim 2, 0, 139, 0, -18, 0, 0,
+ax_anim 1, 0, 139, 0, -12, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_11_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -10, 0, 0,
+ax_anim 2, 0, 140, 0, -16, 0, 0,
+ax_anim 3, 0, 140, 0, -20, 0, 0,
+ax_anim 4, 0, 140, 0, -21, 0, 0,
+ax_anim 4, 0, 140, 0, -22, 0, 0,
+ax_anim 3, 0, 140, 0, -21, 0, 0,
+ax_anim 2, 0, 140, 0, -18, 0, 0,
+ax_anim 1, 0, 140, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_11_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -10, 0, 0,
+ax_anim 2, 0, 141, 0, -16, 0, 0,
+ax_anim 3, 0, 141, 0, -20, 0, 0,
+ax_anim 4, 0, 141, 0, -21, 0, 0,
+ax_anim 4, 0, 141, 0, -22, 0, 0,
+ax_anim 3, 0, 141, 0, -21, 0, 0,
+ax_anim 2, 0, 141, 0, -18, 0, 0,
+ax_anim 1, 0, 141, 0, -12, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -10, 0, 0,
+ax_anim 2, 0, 142, 0, -16, 0, 0,
+ax_anim 3, 0, 142, 0, -20, 0, 0,
+ax_anim 4, 0, 142, 0, -21, 0, 0,
+ax_anim 4, 0, 142, 0, -22, 0, 0,
+ax_anim 3, 0, 142, 0, -21, 0, 0,
+ax_anim 2, 0, 142, 0, -18, 0, 0,
+ax_anim 1, 0, 142, 0, -12, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_11_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 0, 143, 0, -16, 0, 0,
+ax_anim 3, 0, 143, 0, -20, 0, 0,
+ax_anim 4, 0, 143, 0, -21, 0, 0,
+ax_anim 4, 0, 143, 0, -22, 0, 0,
+ax_anim 3, 0, 143, 0, -21, 0, 0,
+ax_anim 2, 0, 143, 0, -18, 0, 0,
+ax_anim 1, 0, 143, 0, -12, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_11_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -10, 0, 0,
+ax_anim 2, 0, 144, 0, -16, 0, 0,
+ax_anim 3, 0, 144, 0, -20, 0, 0,
+ax_anim 4, 0, 144, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -22, 0, 0,
+ax_anim 3, 0, 144, 0, -21, 0, 0,
+ax_anim 2, 0, 144, 0, -18, 0, 0,
+ax_anim 1, 0, 144, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_11_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 145, 0, -22, 0, 0,
+ax_anim 3, 0, 145, 0, -21, 0, 0,
+ax_anim 2, 0, 145, 0, -18, 0, 0,
+ax_anim 1, 0, 145, 0, -12, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_12_1:
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 1, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_12_2:
+ax_anim 2, 0, 155, 1, -1, 1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, -1, 1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, -1, 1, -1,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, -1, 1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, -1, 1, -1,
+ax_anim 2, 1, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_12_3:
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 1, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_12_4:
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 1, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_12_5:
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 1, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_12_6:
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 1, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_12_7:
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_12_8:
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 1, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDecoyAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_13_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_13_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_13_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_13_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_13_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyAnims_13_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sDecoyGfx1:
+.incbin "baserom.gba", 0x165670C, 0x200
+sDecoySprites1:
+ax_sprite sDecoyGfx1, 0x200
+ax_sprite_terminator
+sDecoyGfx2:
+.incbin "baserom.gba", 0x165691C, 0x200
+sDecoySprites2:
+ax_sprite sDecoyGfx2, 0x200
+ax_sprite_terminator
+sDecoyGfx3:
+.incbin "baserom.gba", 0x1656B2C, 0x200
+sDecoySprites3:
+ax_sprite sDecoyGfx3, 0x200
+ax_sprite_terminator
+sDecoyGfx4:
+.incbin "baserom.gba", 0x1656D3C, 0x200
+sDecoySprites4:
+ax_sprite sDecoyGfx4, 0x200
+ax_sprite_terminator
+sDecoyGfx5:
+.incbin "baserom.gba", 0x1656F4C, 0x200
+sDecoySprites5:
+ax_sprite sDecoyGfx5, 0x200
+ax_sprite_terminator
+sDecoyGfx6:
+.incbin "baserom.gba", 0x165715C, 0x200
+sDecoySprites6:
+ax_sprite sDecoyGfx6, 0x200
+ax_sprite_terminator
+sDecoyGfx7:
+.incbin "baserom.gba", 0x165736C, 0x200
+sDecoySprites7:
+ax_sprite sDecoyGfx7, 0x200
+ax_sprite_terminator
+sDecoyGfx8:
+.incbin "baserom.gba", 0x165757C, 0x200
+sDecoySprites8:
+ax_sprite sDecoyGfx8, 0x200
+ax_sprite_terminator
+sDecoyGfx9:
+.incbin "baserom.gba", 0x165778C, 0x200
+sDecoySprites9:
+ax_sprite sDecoyGfx9, 0x200
+ax_sprite_terminator
+sDecoyGfx10:
+.incbin "baserom.gba", 0x165799C, 0x200
+sDecoySprites10:
+ax_sprite sDecoyGfx10, 0x200
+ax_sprite_terminator
+sDecoyGfx11:
+.incbin "baserom.gba", 0x1657BAC, 0x200
+sDecoySprites11:
+ax_sprite sDecoyGfx11, 0x200
+ax_sprite_terminator
+sDecoyGfx12:
+.incbin "baserom.gba", 0x1657DBC, 0x200
+sDecoySprites12:
+ax_sprite sDecoyGfx12, 0x200
+ax_sprite_terminator
+sDecoyGfx13:
+.incbin "baserom.gba", 0x1657FCC, 0x200
+sDecoySprites13:
+ax_sprite sDecoyGfx13, 0x200
+ax_sprite_terminator
+sDecoyGfx14:
+.incbin "baserom.gba", 0x16581DC, 0x200
+sDecoySprites14:
+ax_sprite sDecoyGfx14, 0x200
+ax_sprite_terminator
+sDecoyGfx15:
+.incbin "baserom.gba", 0x16583EC, 0x200
+sDecoySprites15:
+ax_sprite sDecoyGfx15, 0x200
+ax_sprite_terminator
+sDecoyGfx16:
+.incbin "baserom.gba", 0x16585FC, 0x200
+sDecoySprites16:
+ax_sprite sDecoyGfx16, 0x200
+ax_sprite_terminator
+sDecoyGfx17:
+.incbin "baserom.gba", 0x165880C, 0x200
+sDecoySprites17:
+ax_sprite sDecoyGfx17, 0x200
+ax_sprite_terminator
+sAxPosesDecoy:
+.4byte sDecoyPose1
+.4byte sDecoyPose2
+.4byte sDecoyPose3
+.4byte sDecoyPose4
+.4byte sDecoyPose5
+.4byte sDecoyPose6
+.4byte sDecoyPose7
+.4byte sDecoyPose8
+.4byte sDecoyPose9
+.4byte sDecoyPose10
+.4byte sDecoyPose11
+.4byte sDecoyPose12
+.4byte sDecoyPose13
+.4byte sDecoyPose14
+.4byte sDecoyPose15
+.4byte sDecoyPose16
+.4byte sDecoyPose17
+.4byte sDecoyPose18
+.4byte sDecoyPose19
+.4byte sDecoyPose20
+.4byte sDecoyPose21
+.4byte sDecoyPose22
+.4byte sDecoyPose23
+.4byte sDecoyPose24
+.4byte sDecoyPose25
+.4byte sDecoyPose26
+.4byte sDecoyPose27
+.4byte sDecoyPose28
+.4byte sDecoyPose29
+.4byte sDecoyPose30
+.4byte sDecoyPose31
+.4byte sDecoyPose32
+.4byte sDecoyPose33
+.4byte sDecoyPose34
+.4byte sDecoyPose35
+.4byte sDecoyPose36
+.4byte sDecoyPose37
+.4byte sDecoyPose38
+.4byte sDecoyPose39
+.4byte sDecoyPose40
+.4byte sDecoyPose41
+.4byte sDecoyPose42
+.4byte sDecoyPose43
+.4byte sDecoyPose44
+.4byte sDecoyPose45
+.4byte sDecoyPose46
+.4byte sDecoyPose47
+.4byte sDecoyPose48
+.4byte sDecoyPose49
+.4byte sDecoyPose50
+.4byte sDecoyPose51
+.4byte sDecoyPose52
+.4byte sDecoyPose53
+.4byte sDecoyPose54
+.4byte sDecoyPose55
+.4byte sDecoyPose56
+.4byte sDecoyPose57
+.4byte sDecoyPose58
+.4byte sDecoyPose59
+.4byte sDecoyPose60
+.4byte sDecoyPose61
+.4byte sDecoyPose62
+.4byte sDecoyPose63
+.4byte sDecoyPose64
+.4byte sDecoyPose65
+.4byte sDecoyPose66
+.4byte sDecoyPose67
+.4byte sDecoyPose68
+.4byte sDecoyPose69
+.4byte sDecoyPose70
+.4byte sDecoyPose71
+.4byte sDecoyPose72
+.4byte sDecoyPose73
+.4byte sDecoyPose74
+.4byte sDecoyPose75
+.4byte sDecoyPose76
+.4byte sDecoyPose77
+.4byte sDecoyPose78
+.4byte sDecoyPose79
+.4byte sDecoyPose80
+.4byte sDecoyPose81
+.4byte sDecoyPose82
+.4byte sDecoyPose83
+.4byte sDecoyPose84
+.4byte sDecoyPose85
+.4byte sDecoyPose86
+.4byte sDecoyPose87
+.4byte sDecoyPose88
+.4byte sDecoyPose89
+.4byte sDecoyPose90
+.4byte sDecoyPose91
+.4byte sDecoyPose92
+.4byte sDecoyPose93
+.4byte sDecoyPose94
+.4byte sDecoyPose95
+.4byte sDecoyPose96
+.4byte sDecoyPose97
+.4byte sDecoyPose98
+.4byte sDecoyPose99
+.4byte sDecoyPose100
+.4byte sDecoyPose101
+.4byte sDecoyPose102
+.4byte sDecoyPose103
+.4byte sDecoyPose104
+.4byte sDecoyPose105
+.4byte sDecoyPose106
+.4byte sDecoyPose107
+.4byte sDecoyPose108
+.4byte sDecoyPose109
+.4byte sDecoyPose110
+.4byte sDecoyPose111
+.4byte sDecoyPose112
+.4byte sDecoyPose113
+.4byte sDecoyPose114
+.4byte sDecoyPose115
+.4byte sDecoyPose116
+.4byte sDecoyPose117
+.4byte sDecoyPose118
+.4byte sDecoyPose119
+.4byte sDecoyPose120
+.4byte sDecoyPose121
+.4byte sDecoyPose122
+.4byte sDecoyPose123
+.4byte sDecoyPose124
+.4byte sDecoyPose125
+.4byte sDecoyPose126
+.4byte sDecoyPose127
+.4byte sDecoyPose128
+.4byte sDecoyPose129
+.4byte sDecoyPose130
+.4byte sDecoyPose131
+.4byte sDecoyPose132
+.4byte sDecoyPose133
+.4byte sDecoyPose134
+.4byte sDecoyPose135
+.4byte sDecoyPose136
+.4byte sDecoyPose137
+.4byte sDecoyPose138
+.4byte sDecoyPose139
+.4byte sDecoyPose140
+.4byte sDecoyPose141
+.4byte sDecoyPose142
+.4byte sDecoyPose143
+.4byte sDecoyPose144
+.4byte sDecoyPose145
+.4byte sDecoyPose146
+.4byte sDecoyPose147
+.4byte sDecoyPose148
+.4byte sDecoyPose149
+.4byte sDecoyPose150
+.4byte sDecoyPose151
+.4byte sDecoyPose152
+.4byte sDecoyPose153
+.4byte sDecoyPose154
+.4byte sDecoyPose155
+.4byte sDecoyPose156
+.4byte sDecoyPose157
+.4byte sDecoyPose158
+.4byte sDecoyPose159
+.4byte sDecoyPose160
+.4byte sDecoyPose161
+.4byte sDecoyPose162
+.4byte sDecoyPose163
+.4byte sDecoyPose164
+.4byte sDecoyPose165
+.4byte sDecoyPose166
+.4byte sDecoyPose167
+.4byte sDecoyPose168
+.4byte sDecoyPose169
+.4byte sDecoyPose170
+.4byte sDecoyPose171
+.4byte sDecoyPose172
+.4byte sDecoyPose173
+.4byte sDecoyPose174
+.4byte sDecoyPose175
+.4byte sDecoyPose176
+.4byte sDecoyPose177
+.4byte sDecoyPose178
+.4byte sDecoyPose179
+.4byte sDecoyPose180
+.4byte sDecoyPose181
+.4byte sDecoyPose182
+.4byte sDecoyPose183
+.4byte sDecoyPose184
+.4byte sDecoyPose185
+.4byte sDecoyPose186
+sAxPositionsDecoy:
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte  -10,    1, 	  -9,   -3, 	   2,    4, 	   0,   -5
+.2byte  -10,    1, 	  -9,   -2, 	   2,    4, 	   1,   -5
+.2byte    0,    2, 	  -9,    2, 	   9,    2, 	  -1,   -6
+.2byte    9,    1, 	   8,   -3, 	  -3,    4, 	   0,   -4
+.2byte   11,   -2, 	   5,   -7, 	   3,    2, 	   0,   -4
+.2byte    7,   -8, 	  -2,   -7, 	   8,   -2, 	  -2,   -4
+.2byte    0,   -8, 	  10,   -4, 	  -9,   -5, 	   0,   -3
+.2byte   -8,   -8, 	   1,   -7, 	  -9,   -2, 	   1,   -4
+.2byte  -12,   -2, 	  -6,   -7, 	  -4,    2, 	  -1,   -4
+.2byte   -9,    1, 	  -8,   -3, 	   3,    4, 	   0,   -4
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -4, 	   0,   -6
+.2byte    8,   -9, 	   7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    6,  -12, 	  -1,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,  -13, 	   7,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	   1,  -10, 	  -8,   -7, 	   0,   -6
+.2byte   -9,   -9, 	  -8,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -4, 	  -1,   -6
+.2byte    0,   -5, 	  -9,   -4, 	   7,   -4, 	   0,   -4
+.2byte    5,   -6, 	  10,   -4, 	  -5,   -3, 	   0,   -5
+.2byte    9,   -7, 	   8,   -4, 	   6,   -3, 	  -1,   -5
+.2byte    6,  -11, 	  -2,   -8, 	   9,   -5, 	  -1,   -5
+.2byte    0,  -10, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -6,  -11, 	   2,   -8, 	  -9,   -5, 	   1,   -5
+.2byte  -10,   -7, 	  -9,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -6, 	 -11,   -4, 	   4,   -3, 	  -1,   -5
+sDecoyAnimTable1:
+.4byte sDecoyAnims_1_1
+.4byte sDecoyAnims_1_2
+.4byte sDecoyAnims_1_3
+.4byte sDecoyAnims_1_4
+.4byte sDecoyAnims_1_5
+.4byte sDecoyAnims_1_6
+.4byte sDecoyAnims_1_7
+.4byte sDecoyAnims_1_8
+sDecoyAnimTable2:
+.4byte sDecoyAnims_2_1
+.4byte sDecoyAnims_2_2
+.4byte sDecoyAnims_2_3
+.4byte sDecoyAnims_2_4
+.4byte sDecoyAnims_2_5
+.4byte sDecoyAnims_2_6
+.4byte sDecoyAnims_2_7
+.4byte sDecoyAnims_2_8
+sDecoyAnimTable3:
+.4byte sDecoyAnims_3_1
+.4byte sDecoyAnims_3_2
+.4byte sDecoyAnims_3_3
+.4byte sDecoyAnims_3_4
+.4byte sDecoyAnims_3_5
+.4byte sDecoyAnims_3_6
+.4byte sDecoyAnims_3_7
+.4byte sDecoyAnims_3_8
+sDecoyAnimTable4:
+.4byte sDecoyAnims_4_1
+.4byte sDecoyAnims_4_2
+.4byte sDecoyAnims_4_3
+.4byte sDecoyAnims_4_4
+.4byte sDecoyAnims_4_5
+.4byte sDecoyAnims_4_6
+.4byte sDecoyAnims_4_7
+.4byte sDecoyAnims_4_8
+sDecoyAnimTable5:
+.4byte sDecoyAnims_5_1
+.4byte sDecoyAnims_5_2
+.4byte sDecoyAnims_5_3
+.4byte sDecoyAnims_5_4
+.4byte sDecoyAnims_5_5
+.4byte sDecoyAnims_5_6
+.4byte sDecoyAnims_5_7
+.4byte sDecoyAnims_5_8
+sDecoyAnimTable6:
+.4byte sDecoyAnims_6_1
+.4byte sDecoyAnims_6_1
+.4byte sDecoyAnims_6_1
+.4byte sDecoyAnims_6_1
+.4byte sDecoyAnims_6_1
+.4byte sDecoyAnims_6_1
+.4byte sDecoyAnims_6_1
+.4byte sDecoyAnims_6_1
+sDecoyAnimTable7:
+.4byte sDecoyAnims_7_1
+.4byte sDecoyAnims_7_2
+.4byte sDecoyAnims_7_3
+.4byte sDecoyAnims_7_4
+.4byte sDecoyAnims_7_5
+.4byte sDecoyAnims_7_6
+.4byte sDecoyAnims_7_7
+.4byte sDecoyAnims_7_8
+sDecoyAnimTable8:
+.4byte sDecoyAnims_8_1
+.4byte sDecoyAnims_8_2
+.4byte sDecoyAnims_8_3
+.4byte sDecoyAnims_8_4
+.4byte sDecoyAnims_8_5
+.4byte sDecoyAnims_8_6
+.4byte sDecoyAnims_8_7
+.4byte sDecoyAnims_8_8
+sDecoyAnimTable9:
+.4byte sDecoyAnims_9_1
+.4byte sDecoyAnims_9_2
+.4byte sDecoyAnims_9_3
+.4byte sDecoyAnims_9_4
+.4byte sDecoyAnims_9_5
+.4byte sDecoyAnims_9_6
+.4byte sDecoyAnims_9_7
+.4byte sDecoyAnims_9_8
+sDecoyAnimTable10:
+.4byte sDecoyAnims_10_1
+.4byte sDecoyAnims_10_2
+.4byte sDecoyAnims_10_3
+.4byte sDecoyAnims_10_4
+.4byte sDecoyAnims_10_5
+.4byte sDecoyAnims_10_6
+.4byte sDecoyAnims_10_7
+.4byte sDecoyAnims_10_8
+sDecoyAnimTable11:
+.4byte sDecoyAnims_11_1
+.4byte sDecoyAnims_11_2
+.4byte sDecoyAnims_11_3
+.4byte sDecoyAnims_11_4
+.4byte sDecoyAnims_11_5
+.4byte sDecoyAnims_11_6
+.4byte sDecoyAnims_11_7
+.4byte sDecoyAnims_11_8
+sDecoyAnimTable12:
+.4byte sDecoyAnims_12_1
+.4byte sDecoyAnims_12_2
+.4byte sDecoyAnims_12_3
+.4byte sDecoyAnims_12_4
+.4byte sDecoyAnims_12_5
+.4byte sDecoyAnims_12_6
+.4byte sDecoyAnims_12_7
+.4byte sDecoyAnims_12_8
+sDecoyAnimTable13:
+.4byte sDecoyAnims_13_1
+.4byte sDecoyAnims_13_2
+.4byte sDecoyAnims_13_3
+.4byte sDecoyAnims_13_4
+.4byte sDecoyAnims_13_5
+.4byte sDecoyAnims_13_6
+.4byte sDecoyAnims_13_7
+.4byte sDecoyAnims_13_8
+sAxAnimationsDecoy:
+.4byte sDecoyAnimTable1
+.4byte sDecoyAnimTable2
+.4byte sDecoyAnimTable3
+.4byte sDecoyAnimTable4
+.4byte sDecoyAnimTable5
+.4byte sDecoyAnimTable6
+.4byte sDecoyAnimTable7
+.4byte sDecoyAnimTable8
+.4byte sDecoyAnimTable9
+.4byte sDecoyAnimTable10
+.4byte sDecoyAnimTable11
+.4byte sDecoyAnimTable12
+.4byte sDecoyAnimTable13
+sAxSpritesDecoy:
+.4byte sDecoySprites1
+.4byte sDecoySprites2
+.4byte sDecoySprites3
+.4byte sDecoySprites4
+.4byte sDecoySprites5
+.4byte sDecoySprites6
+.4byte sDecoySprites7
+.4byte sDecoySprites8
+.4byte sDecoySprites9
+.4byte sDecoySprites10
+.4byte sDecoySprites11
+.4byte sDecoySprites12
+.4byte sDecoySprites13
+.4byte sDecoySprites14
+.4byte sDecoySprites15
+.4byte sDecoySprites16
+.4byte sDecoySprites17
+sAxMainDecoy:
+ax_main sAxPosesDecoy, sAxAnimationsDecoy, 13, sAxSpritesDecoy, sAxPositionsDecoy

--- a/data/ax/delcatty.inc
+++ b/data/ax/delcatty.inc
@@ -1,0 +1,2999 @@
+.global gAxDelcatty
+gAxDelcatty:
+ax_siro sAxMainDelcatty
+sDelcattyPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose9:
+ax_pose 8, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose10:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose12:
+ax_pose 11, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose14:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose15:
+ax_pose 14, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose26:
+ax_pose 15, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose27:
+ax_pose 16, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose28:
+ax_pose 17, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose29:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose30:
+ax_pose 18, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose31:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose32:
+ax_pose 20, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose33:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose34:
+ax_pose 21, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose35:
+ax_pose 22, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose36:
+ax_pose 23, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose37:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose38:
+ax_pose 24, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose39:
+ax_pose 25, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose40:
+ax_pose 26, 0x01e7, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose41:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose42:
+ax_pose 27, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose43:
+ax_pose 28, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose44:
+ax_pose 29, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose45:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose46:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose47:
+ax_pose 25, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose48:
+ax_pose 26, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose49:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose50:
+ax_pose 21, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose51:
+ax_pose 22, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose52:
+ax_pose 23, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose53:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose54:
+ax_pose 18, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose55:
+ax_pose 19, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose56:
+ax_pose 20, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose57:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose58:
+ax_pose 15, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose59:
+ax_pose 16, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose60:
+ax_pose 17, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose61:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose62:
+ax_pose 18, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose63:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose64:
+ax_pose 20, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose65:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose66:
+ax_pose 21, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose67:
+ax_pose 22, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose68:
+ax_pose 23, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose69:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose70:
+ax_pose 24, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose71:
+ax_pose 25, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose72:
+ax_pose 26, 0x01e7, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose73:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose74:
+ax_pose 27, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose75:
+ax_pose 28, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose76:
+ax_pose 29, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose77:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose78:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose79:
+ax_pose 25, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose80:
+ax_pose 26, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose81:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose82:
+ax_pose 21, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose83:
+ax_pose 22, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose84:
+ax_pose 23, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose85:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose86:
+ax_pose 18, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose87:
+ax_pose 19, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose88:
+ax_pose 20, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose89:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose90:
+ax_pose 15, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose91:
+ax_pose 16, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose92:
+ax_pose 17, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose93:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose94:
+ax_pose 18, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose95:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose96:
+ax_pose 20, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose97:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose98:
+ax_pose 21, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose99:
+ax_pose 22, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose100:
+ax_pose 23, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose101:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose102:
+ax_pose 24, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose103:
+ax_pose 25, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose104:
+ax_pose 26, 0x01e7, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose105:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose106:
+ax_pose 27, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose107:
+ax_pose 28, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose108:
+ax_pose 29, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose109:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose110:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose111:
+ax_pose 25, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose112:
+ax_pose 26, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose113:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose114:
+ax_pose 21, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose115:
+ax_pose 22, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose116:
+ax_pose 23, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose117:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose118:
+ax_pose 18, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose119:
+ax_pose 19, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose120:
+ax_pose 20, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose121:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose122:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose123:
+ax_pose 31, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose124:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose125:
+ax_pose 32, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose126:
+ax_pose 33, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose127:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose128:
+ax_pose 34, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose129:
+ax_pose 35, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose130:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose131:
+ax_pose 36, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose132:
+ax_pose 37, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose133:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose134:
+ax_pose 38, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose135:
+ax_pose 39, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose136:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose137:
+ax_pose 36, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose138:
+ax_pose 37, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose139:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose140:
+ax_pose 34, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose141:
+ax_pose 35, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose142:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose143:
+ax_pose 32, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose144:
+ax_pose 33, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose145:
+ax_pose 40, 0x01eb, 0x80f5, 0x7c00
+ax_pose_terminator
+sDelcattyPose146:
+ax_pose 41, 0x01eb, 0x80f5, 0x7c00
+ax_pose_terminator
+sDelcattyPose147:
+ax_pose 42, 0x81e2, 0x4105, 0x7c00
+ax_pose 43, 0x01da, 0x0100, 0x7c04
+ax_pose 44, 0x81e2, 0x80f5, 0x7c05
+ax_pose_terminator
+sDelcattyPose148:
+ax_pose 45, 0x81e3, 0x90fc, 0x7c00
+ax_pose 46, 0x01db, 0x10f4, 0x7c08
+ax_pose 47, 0x81e3, 0x10ec, 0x7c09
+ax_pose 48, 0x81e3, 0x50f4, 0x7c0b
+ax_pose_terminator
+sDelcattyPose149:
+ax_pose 49, 0x01e3, 0x90ea, 0x7c00
+ax_pose_terminator
+sDelcattyPose150:
+ax_pose 50, 0x01e3, 0x90ea, 0x7c00
+ax_pose_terminator
+sDelcattyPose151:
+ax_pose 51, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sDelcattyPose152:
+ax_pose 50, 0x01e3, 0x80f6, 0x7c00
+ax_pose_terminator
+sDelcattyPose153:
+ax_pose 49, 0x01e3, 0x80f6, 0x7c00
+ax_pose_terminator
+sDelcattyPose154:
+ax_pose 45, 0x81e3, 0x80f4, 0x7c00
+ax_pose 46, 0x01db, 0x0104, 0x7c08
+ax_pose 47, 0x81e3, 0x010c, 0x7c09
+ax_pose 48, 0x81e3, 0x4104, 0x7c0b
+ax_pose_terminator
+sDelcattyPose155:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose156:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose157:
+ax_pose 31, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose158:
+ax_pose 17, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose159:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose160:
+ax_pose 32, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose161:
+ax_pose 33, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose162:
+ax_pose 20, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose163:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose164:
+ax_pose 34, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose165:
+ax_pose 35, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose166:
+ax_pose 23, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose167:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose168:
+ax_pose 36, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose169:
+ax_pose 37, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose170:
+ax_pose 26, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose171:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose172:
+ax_pose 38, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose173:
+ax_pose 39, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose174:
+ax_pose 29, 0x01e8, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose175:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose176:
+ax_pose 36, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose177:
+ax_pose 37, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose178:
+ax_pose 26, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose179:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose180:
+ax_pose 34, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose181:
+ax_pose 35, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose182:
+ax_pose 23, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose183:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose184:
+ax_pose 32, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose185:
+ax_pose 33, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose186:
+ax_pose 20, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose187:
+ax_pose 16, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose188:
+ax_pose 19, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose189:
+ax_pose 22, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose190:
+ax_pose 25, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose191:
+ax_pose 28, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose192:
+ax_pose 25, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose193:
+ax_pose 22, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose194:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose195:
+ax_pose 15, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose196:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sDelcattyPose197:
+ax_pose 21, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose198:
+ax_pose 24, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose199:
+ax_pose 27, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose200:
+ax_pose 24, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose201:
+ax_pose 21, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose202:
+ax_pose 18, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose203:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose204:
+ax_pose 15, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose205:
+ax_pose 16, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose206:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose207:
+ax_pose 18, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose208:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose209:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose210:
+ax_pose 21, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose211:
+ax_pose 22, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sDelcattyPose212:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose213:
+ax_pose 24, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose214:
+ax_pose 25, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sDelcattyPose215:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose216:
+ax_pose 27, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose217:
+ax_pose 28, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose218:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose219:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose220:
+ax_pose 25, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sDelcattyPose221:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose222:
+ax_pose 21, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose223:
+ax_pose 22, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sDelcattyPose224:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose225:
+ax_pose 18, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose226:
+ax_pose 19, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose227:
+ax_pose 16, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose228:
+ax_pose 19, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose229:
+ax_pose 22, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose230:
+ax_pose 25, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose231:
+ax_pose 28, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose232:
+ax_pose 25, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose233:
+ax_pose 22, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose234:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose235:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose236:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose237:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose238:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose239:
+ax_pose 12, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sDelcattyPose240:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose241:
+ax_pose 6, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sDelcattyPose242:
+ax_pose 3, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+.align 2
+sDelcattyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 1, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 0, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDelcattyAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 30, 21, 19, 21, 19,
+ax_anim 2, 1, 30, 22, 18, 22, 18,
+ax_anim 2, 0, 30, 21, 19, 21, 19,
+ax_anim 2, 0, 30, 22, 18, 22, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sDelcattyAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 1, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 0, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sDelcattyAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -1, 0, -1,
+ax_anim 1, 2, 36, 5, -6, 5, -6,
+ax_anim 1, 0, 36, 11, -12, 11, -12,
+ax_anim 2, 0, 38, 19, -18, 19, -18,
+ax_anim 2, 1, 38, 20, -17, 20, -17,
+ax_anim 2, 0, 38, 19, -18, 19, -18,
+ax_anim 2, 0, 38, 20, -17, 20, -17,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sDelcattyAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 0, -4, 0, -4,
+ax_anim 1, 0, 40, 0, -11, 0, -11,
+ax_anim 2, 0, 42, 0, -20, 0, -20,
+ax_anim 2, 1, 42, 1, -20, 1, -20,
+ax_anim 2, 0, 42, 0, -20, 0, -20,
+ax_anim 2, 0, 42, 1, -20, 1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sDelcattyAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -1, 0, -1,
+ax_anim 1, 2, 44, -5, -6, -5, -6,
+ax_anim 1, 0, 44, -11, -12, -11, -12,
+ax_anim 2, 0, 46, -19, -18, -19, -18,
+ax_anim 2, 1, 46, -20, -17, -20, -17,
+ax_anim 2, 0, 46, -19, -18, -19, -18,
+ax_anim 2, 0, 46, -20, -17, -20, -17,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sDelcattyAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 48, -4, 0, -4, 0,
+ax_anim 1, 0, 48, -12, 0, -12, 0,
+ax_anim 2, 0, 50, -19, 0, -19, 0,
+ax_anim 2, 1, 50, -19, 1, -19, 1,
+ax_anim 2, 0, 50, -19, 0, -19, 0,
+ax_anim 2, 0, 50, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sDelcattyAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, -4, 4, -4, 4,
+ax_anim 1, 0, 52, -10, 10, -10, 10,
+ax_anim 2, 0, 54, -21, 19, -21, 19,
+ax_anim 2, 1, 54, -22, 18, -22, 18,
+ax_anim 2, 0, 54, -21, 19, -21, 19,
+ax_anim 2, 0, 54, -22, 18, -22, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 0, 4, 0, 4,
+ax_anim 1, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 58, 0, 20, 0, 20,
+ax_anim 2, 1, 58, 1, 20, 1, 20,
+ax_anim 2, 0, 58, 0, 20, 0, 20,
+ax_anim 2, 0, 58, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sDelcattyAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 4, 4, 4, 4,
+ax_anim 1, 0, 60, 10, 10, 10, 10,
+ax_anim 2, 0, 62, 21, 19, 21, 19,
+ax_anim 2, 1, 62, 22, 18, 22, 18,
+ax_anim 2, 0, 62, 21, 19, 21, 19,
+ax_anim 2, 0, 62, 22, 18, 22, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sDelcattyAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 4, 0, 4, 0,
+ax_anim 1, 0, 64, 12, 0, 12, 0,
+ax_anim 2, 0, 66, 19, 0, 19, 0,
+ax_anim 2, 1, 66, 19, 1, 19, 1,
+ax_anim 2, 0, 66, 19, 0, 19, 0,
+ax_anim 2, 0, 66, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sDelcattyAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -1, 0, -1,
+ax_anim 1, 2, 68, 5, -6, 5, -6,
+ax_anim 1, 0, 68, 11, -12, 11, -12,
+ax_anim 2, 0, 70, 19, -18, 19, -18,
+ax_anim 2, 1, 70, 20, -17, 20, -17,
+ax_anim 2, 0, 70, 19, -18, 19, -18,
+ax_anim 2, 0, 70, 20, -17, 20, -17,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sDelcattyAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 72, 0, -4, 0, -4,
+ax_anim 1, 0, 72, 0, -11, 0, -11,
+ax_anim 2, 0, 74, 0, -20, 0, -20,
+ax_anim 2, 1, 74, 1, -20, 1, -20,
+ax_anim 2, 0, 74, 0, -20, 0, -20,
+ax_anim 2, 0, 74, 1, -20, 1, -20,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sDelcattyAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -1, 0, -1,
+ax_anim 1, 2, 76, -5, -6, -5, -6,
+ax_anim 1, 0, 76, -11, -12, -11, -12,
+ax_anim 2, 0, 78, -19, -18, -19, -18,
+ax_anim 2, 1, 78, -20, -17, -20, -17,
+ax_anim 2, 0, 78, -19, -18, -19, -18,
+ax_anim 2, 0, 78, -20, -17, -20, -17,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sDelcattyAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 2, 80, -4, 0, -4, 0,
+ax_anim 1, 0, 80, -12, 0, -12, 0,
+ax_anim 2, 0, 82, -19, 0, -19, 0,
+ax_anim 2, 1, 82, -19, 1, -19, 1,
+ax_anim 2, 0, 82, -19, 0, -19, 0,
+ax_anim 2, 0, 82, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sDelcattyAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 84, -4, 4, -4, 4,
+ax_anim 1, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 86, -21, 19, -21, 19,
+ax_anim 2, 1, 86, -22, 18, -22, 18,
+ax_anim 2, 0, 86, -21, 19, -21, 19,
+ax_anim 2, 0, 86, -22, 18, -22, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_4_1:
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 2, 89, 0, -3, 0, -3,
+ax_anim 4, 0, 89, 0, -4, 0, -4,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 1, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sDelcattyAnims_4_2:
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -2, -2, -1, -1,
+ax_anim 2, 2, 93, -3, -3, -3, -3,
+ax_anim 4, 0, 93, -4, -4, -4, -4,
+ax_anim 1, 0, 94, -1, -1, -1, -1,
+ax_anim 1, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 1, 94, 6, 6, 6, 6,
+ax_anim 2, 0, 94, 7, 5, 7, 5,
+ax_anim 2, 0, 94, 6, 6, 6, 6,
+ax_anim 2, 0, 94, 7, 5, 7, 5,
+ax_anim 2, 0, 94, 6, 6, 6, 6,
+ax_anim 2, 0, 94, 7, 5, 7, 5,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sDelcattyAnims_4_3:
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim 2, 2, 97, -3, 0, -3, 0,
+ax_anim 4, 0, 97, -4, 0, -4, 0,
+ax_anim 1, 0, 98, -1, 0, -1, 0,
+ax_anim 1, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 1, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, 6, 1, 6, 1,
+ax_anim 2, 0, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, 6, 1, 6, 1,
+ax_anim 2, 0, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, 6, 1, 6, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sDelcattyAnims_4_4:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 2, 101, -3, 3, -3, 3,
+ax_anim 4, 0, 101, -4, 4, -4, 4,
+ax_anim 1, 0, 102, -1, 1, -1, 1,
+ax_anim 1, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 1, 102, 6, -6, 6, -6,
+ax_anim 2, 0, 102, 7, -5, 7, -5,
+ax_anim 2, 0, 102, 6, -6, 6, -6,
+ax_anim 2, 0, 102, 7, -5, 7, -5,
+ax_anim 2, 0, 102, 6, -6, 6, -6,
+ax_anim 2, 0, 102, 7, -5, 7, -5,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sDelcattyAnims_4_5:
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 1, 0, 1,
+ax_anim 2, 2, 105, 0, 3, 0, 3,
+ax_anim 4, 0, 105, 0, 4, 0, 4,
+ax_anim 1, 0, 106, 0, 1, 0, 1,
+ax_anim 1, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 1, 106, 0, -6, 0, -5,
+ax_anim 2, 0, 106, 1, -6, 1, -5,
+ax_anim 2, 0, 106, 0, -6, 0, -5,
+ax_anim 2, 0, 106, 1, -6, 1, -5,
+ax_anim 2, 0, 106, 0, -6, 0, -5,
+ax_anim 2, 0, 106, 1, -6, 1, -5,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sDelcattyAnims_4_6:
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim 2, 2, 109, 3, 3, 3, 3,
+ax_anim 4, 0, 109, 4, 4, 4, 4,
+ax_anim 1, 0, 110, 1, 1, 1, 1,
+ax_anim 1, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 1, 110, -6, -6, -6, -6,
+ax_anim 2, 0, 110, -7, -5, -7, -5,
+ax_anim 2, 0, 110, -6, -6, -6, -6,
+ax_anim 2, 0, 110, -7, -5, -7, -5,
+ax_anim 2, 0, 110, -6, -6, -6, -6,
+ax_anim 2, 0, 110, -7, -5, -7, -5,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sDelcattyAnims_4_7:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 2, 0, 2, 0,
+ax_anim 2, 2, 113, 3, 0, 3, 0,
+ax_anim 4, 0, 113, 4, 0, 4, 0,
+ax_anim 1, 0, 114, 1, 0, 1, 0,
+ax_anim 1, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 1, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, -6, 1, -6, 1,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, -6, 1, -6, 1,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, -6, 1, -6, 1,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sDelcattyAnims_4_8:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 2, 2, 117, 3, -3, 3, -3,
+ax_anim 4, 0, 117, 4, -4, 4, -4,
+ax_anim 1, 0, 118, 1, -1, 1, -1,
+ax_anim 1, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 1, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_5_1:
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_5_2:
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_5_3:
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_5_4:
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_5_5:
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_5_6:
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_5_7:
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_5_8:
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sDelcattyAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sDelcattyAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sDelcattyAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sDelcattyAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sDelcattyAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sDelcattyAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sDelcattyAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_8_1:
+ax_anim 60, 0, 157, 0, 0, 0, 0,
+ax_anim 10, 0, 154, 0, 0, 0, 0,
+ax_anim 5, 0, 155, 0, 0, 0, 0,
+ax_anim 5, 0, 156, 0, 0, 0, 0,
+ax_anim 5, 0, 155, 0, 0, 0, 0,
+ax_anim 5, 0, 156, 0, 0, 0, 0,
+ax_anim 5, 0, 155, 0, 0, 0, 0,
+ax_anim 5, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_8_2:
+ax_anim 60, 0, 161, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 5, 0, 159, 0, 0, 0, 0,
+ax_anim 5, 0, 160, 0, 0, 0, 0,
+ax_anim 5, 0, 159, 0, 0, 0, 0,
+ax_anim 5, 0, 160, 0, 0, 0, 0,
+ax_anim 5, 0, 159, 0, 0, 0, 0,
+ax_anim 5, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_8_3:
+ax_anim 60, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim 5, 0, 163, 0, 0, 0, 0,
+ax_anim 5, 0, 164, 0, 0, 0, 0,
+ax_anim 5, 0, 163, 0, 0, 0, 0,
+ax_anim 5, 0, 164, 0, 0, 0, 0,
+ax_anim 5, 0, 163, 0, 0, 0, 0,
+ax_anim 5, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_8_4:
+ax_anim 60, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 5, 0, 167, 0, 0, 0, 0,
+ax_anim 5, 0, 168, 0, 0, 0, 0,
+ax_anim 5, 0, 167, 0, 0, 0, 0,
+ax_anim 5, 0, 168, 0, 0, 0, 0,
+ax_anim 5, 0, 167, 0, 0, 0, 0,
+ax_anim 5, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_8_5:
+ax_anim 60, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 5, 0, 171, 0, 0, 0, 0,
+ax_anim 5, 0, 172, 0, 0, 0, 0,
+ax_anim 5, 0, 171, 0, 0, 0, 0,
+ax_anim 5, 0, 172, 0, 0, 0, 0,
+ax_anim 5, 0, 171, 0, 0, 0, 0,
+ax_anim 5, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_8_6:
+ax_anim 60, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim 5, 0, 175, 0, 0, 0, 0,
+ax_anim 5, 0, 176, 0, 0, 0, 0,
+ax_anim 5, 0, 175, 0, 0, 0, 0,
+ax_anim 5, 0, 176, 0, 0, 0, 0,
+ax_anim 5, 0, 175, 0, 0, 0, 0,
+ax_anim 5, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_8_7:
+ax_anim 60, 0, 181, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 5, 0, 179, 0, 0, 0, 0,
+ax_anim 5, 0, 180, 0, 0, 0, 0,
+ax_anim 5, 0, 179, 0, 0, 0, 0,
+ax_anim 5, 0, 180, 0, 0, 0, 0,
+ax_anim 5, 0, 179, 0, 0, 0, 0,
+ax_anim 5, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_8_8:
+ax_anim 60, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim 5, 0, 183, 0, 0, 0, 0,
+ax_anim 5, 0, 184, 0, 0, 0, 0,
+ax_anim 5, 0, 183, 0, 0, 0, 0,
+ax_anim 5, 0, 184, 0, 0, 0, 0,
+ax_anim 5, 0, 183, 0, 0, 0, 0,
+ax_anim 5, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 4, 7, 4,
+ax_anim 2, 0, 188, 10, 10, 10, 10,
+ax_anim 2, 0, 189, 7, 16, 7, 16,
+ax_anim 3, 0, 190, 0, 19, 0, 19,
+ax_anim 2, 3, 191, -7, 16, -7, 16,
+ax_anim 2, 0, 192, -10, 10, -10, 10,
+ax_anim 1, 0, 193, -7, 4, -7, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 25, 10, 25, 10,
+ax_anim 3, 0, 189, 23, 19, 23, 19,
+ax_anim 2, 3, 190, 12, 19, 12, 19,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 16, -5, 16, -5,
+ax_anim 3, 0, 188, 24, 0, 24, 0,
+ax_anim 2, 3, 189, 20, 4, 20, 4,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 23, -21, 23, -21,
+ax_anim 2, 3, 188, 25, -14, 25, -14,
+ax_anim 2, 0, 189, 19, -4, 19, -4,
+ax_anim 1, 0, 190, 10, -1, 10, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -9, -2, -9, -2,
+ax_anim 2, 0, 192, -11, -11, -11, -11,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -22, 0, -22,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 11, -11, 11, -11,
+ax_anim 1, 0, 189, 9, -2, 9, -2,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -23, -21, -23, -21,
+ax_anim 2, 3, 192, -25, -14, -25, -14,
+ax_anim 2, 0, 191, -19, -5, -19, -5,
+ax_anim 1, 0, 190, -10, -1, -10, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -16, -5, -16, -5,
+ax_anim 3, 0, 192, -24, 0, -24, 0,
+ax_anim 2, 3, 191, -20, 4, -20, 4,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -25, 10, -25, 10,
+ax_anim 3, 0, 191, -23, 19, -23, 19,
+ax_anim 2, 3, 190, -12, 19, -12, 19,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -19, 0, 0,
+ax_anim 4, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -24, 0, 0,
+ax_anim 3, 0, 204, 0, -24, 0, 0,
+ax_anim 2, 0, 204, 0, -20, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 2, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 207, 0, -23, 0, 0,
+ax_anim 2, 0, 207, 0, -19, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 210, 0, -23, 0, 0,
+ax_anim 2, 0, 210, 0, -19, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -23, 0, 0,
+ax_anim 2, 0, 213, 0, -20, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -23, 0, 0,
+ax_anim 2, 0, 219, 0, -20, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -22, 0, 0,
+ax_anim 3, 0, 222, 0, -23, 0, 0,
+ax_anim 2, 0, 222, 0, -19, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -22, 0, 0,
+ax_anim 3, 0, 225, 0, -23, 0, 0,
+ax_anim 2, 0, 225, 0, -19, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelcattyAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sDelcattyGfx1:
+.incbin "baserom.gba", 0x123E058, 0x200
+sDelcattySprites1:
+ax_sprite sDelcattyGfx1, 0x200
+ax_sprite_terminator
+sDelcattyGfx2:
+.incbin "baserom.gba", 0x123E268, 0x200
+sDelcattySprites2:
+ax_sprite sDelcattyGfx2, 0x200
+ax_sprite_terminator
+sDelcattyGfx3:
+.incbin "baserom.gba", 0x123E478, 0x200
+sDelcattySprites3:
+ax_sprite sDelcattyGfx3, 0x200
+ax_sprite_terminator
+sDelcattyGfx4:
+.incbin "baserom.gba", 0x123E688, 0x200
+sDelcattySprites4:
+ax_sprite sDelcattyGfx4, 0x200
+ax_sprite_terminator
+sDelcattyGfx5:
+.incbin "baserom.gba", 0x123E898, 0x200
+sDelcattySprites5:
+ax_sprite sDelcattyGfx5, 0x200
+ax_sprite_terminator
+sDelcattyGfx6:
+.incbin "baserom.gba", 0x123EAA8, 0x200
+sDelcattySprites6:
+ax_sprite sDelcattyGfx6, 0x200
+ax_sprite_terminator
+sDelcattyGfx7:
+.incbin "baserom.gba", 0x123ECB8, 0x200
+sDelcattySprites7:
+ax_sprite sDelcattyGfx7, 0x200
+ax_sprite_terminator
+sDelcattyGfx8:
+.incbin "baserom.gba", 0x123EEC8, 0x200
+sDelcattySprites8:
+ax_sprite sDelcattyGfx8, 0x200
+ax_sprite_terminator
+sDelcattyGfx9:
+.incbin "baserom.gba", 0x123F0D8, 0x200
+sDelcattySprites9:
+ax_sprite sDelcattyGfx9, 0x200
+ax_sprite_terminator
+sDelcattyGfx10:
+.incbin "baserom.gba", 0x123F2E8, 0x200
+sDelcattySprites10:
+ax_sprite sDelcattyGfx10, 0x200
+ax_sprite_terminator
+sDelcattyGfx11:
+.incbin "baserom.gba", 0x123F4F8, 0x200
+sDelcattySprites11:
+ax_sprite sDelcattyGfx11, 0x200
+ax_sprite_terminator
+sDelcattyGfx12:
+.incbin "baserom.gba", 0x123F708, 0x200
+sDelcattySprites12:
+ax_sprite sDelcattyGfx12, 0x200
+ax_sprite_terminator
+sDelcattyGfx13:
+.incbin "baserom.gba", 0x123F918, 0x200
+sDelcattySprites13:
+ax_sprite sDelcattyGfx13, 0x200
+ax_sprite_terminator
+sDelcattyGfx14:
+.incbin "baserom.gba", 0x123FB28, 0x200
+sDelcattySprites14:
+ax_sprite sDelcattyGfx14, 0x200
+ax_sprite_terminator
+sDelcattyGfx15:
+.incbin "baserom.gba", 0x123FD38, 0x200
+sDelcattySprites15:
+ax_sprite sDelcattyGfx15, 0x200
+ax_sprite_terminator
+sDelcattyGfx16:
+.incbin "baserom.gba", 0x123FF48, 0x160
+sDelcattyGfx16_1:
+.incbin "baserom.gba", 0x12400A8, 0x40
+sDelcattySprites16:
+ax_sprite sDelcattyGfx16, 0x160
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx17:
+.incbin "baserom.gba", 0x1240110, 0x40
+sDelcattyGfx17_1:
+.incbin "baserom.gba", 0x1240150, 0x80
+sDelcattyGfx17_2:
+.incbin "baserom.gba", 0x12401D0, 0x40
+sDelcattyGfx17_3:
+.incbin "baserom.gba", 0x1240210, 0x40
+sDelcattySprites17:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx17_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx17_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx18:
+.incbin "baserom.gba", 0x12402A0, 0x160
+sDelcattyGfx18_1:
+.incbin "baserom.gba", 0x1240400, 0x40
+sDelcattySprites18:
+ax_sprite sDelcattyGfx18, 0x160
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx19:
+.incbin "baserom.gba", 0x1240468, 0x60
+sDelcattyGfx19_1:
+.incbin "baserom.gba", 0x12404C8, 0x60
+sDelcattyGfx19_2:
+.incbin "baserom.gba", 0x1240528, 0x60
+sDelcattyGfx19_3:
+.incbin "baserom.gba", 0x1240588, 0x40
+sDelcattySprites19:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx20:
+.incbin "baserom.gba", 0x1240618, 0x160
+sDelcattyGfx20_1:
+.incbin "baserom.gba", 0x1240778, 0x60
+sDelcattySprites20:
+ax_sprite sDelcattyGfx20, 0x160
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx21:
+.incbin "baserom.gba", 0x1240800, 0x60
+sDelcattyGfx21_1:
+.incbin "baserom.gba", 0x1240860, 0x60
+sDelcattyGfx21_2:
+.incbin "baserom.gba", 0x12408C0, 0x60
+sDelcattyGfx21_3:
+.incbin "baserom.gba", 0x1240920, 0x40
+sDelcattySprites21:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx22:
+.incbin "baserom.gba", 0x12409B0, 0x40
+sDelcattyGfx22_1:
+.incbin "baserom.gba", 0x12409F0, 0xE0
+sDelcattyGfx22_2:
+.incbin "baserom.gba", 0x1240AD0, 0x40
+sDelcattySprites22:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx23:
+.incbin "baserom.gba", 0x1240B50, 0x20
+sDelcattyGfx23_1:
+.incbin "baserom.gba", 0x1240B70, 0x180
+sDelcattySprites23:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx23_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx24:
+.incbin "baserom.gba", 0x1240D20, 0x40
+sDelcattyGfx24_1:
+.incbin "baserom.gba", 0x1240D60, 0x60
+sDelcattyGfx24_2:
+.incbin "baserom.gba", 0x1240DC0, 0x60
+sDelcattyGfx24_3:
+.incbin "baserom.gba", 0x1240E20, 0x40
+sDelcattySprites24:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx25:
+.incbin "baserom.gba", 0x1240EB0, 0x60
+sDelcattyGfx25_1:
+.incbin "baserom.gba", 0x1240F10, 0x60
+sDelcattyGfx25_2:
+.incbin "baserom.gba", 0x1240F70, 0x60
+sDelcattyGfx25_3:
+.incbin "baserom.gba", 0x1240FD0, 0x60
+sDelcattySprites25:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx25_3, 0x60
+ax_sprite_terminator
+sDelcattyGfx26:
+.incbin "baserom.gba", 0x1241078, 0x40
+sDelcattyGfx26_1:
+.incbin "baserom.gba", 0x12410B8, 0x100
+sDelcattyGfx26_2:
+.incbin "baserom.gba", 0x12411B8, 0x40
+sDelcattySprites26:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx27:
+.incbin "baserom.gba", 0x1241238, 0x100
+sDelcattyGfx27_1:
+.incbin "baserom.gba", 0x1241338, 0x60
+sDelcattyGfx27_2:
+.incbin "baserom.gba", 0x1241398, 0x60
+sDelcattySprites27:
+ax_sprite sDelcattyGfx27, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx27_2, 0x60
+ax_sprite_terminator
+sDelcattyGfx28:
+.incbin "baserom.gba", 0x1241428, 0x40
+sDelcattyGfx28_1:
+.incbin "baserom.gba", 0x1241468, 0xE0
+sDelcattyGfx28_2:
+.incbin "baserom.gba", 0x1241548, 0x40
+sDelcattySprites28:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx28_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx29:
+.incbin "baserom.gba", 0x12415C8, 0x100
+sDelcattyGfx29_1:
+.incbin "baserom.gba", 0x12416C8, 0x40
+sDelcattyGfx29_2:
+.incbin "baserom.gba", 0x1241708, 0x40
+sDelcattySprites29:
+ax_sprite sDelcattyGfx29, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx29_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx30:
+.incbin "baserom.gba", 0x1241780, 0x100
+sDelcattyGfx30_1:
+.incbin "baserom.gba", 0x1241880, 0x40
+sDelcattyGfx30_2:
+.incbin "baserom.gba", 0x12418C0, 0x40
+sDelcattySprites30:
+ax_sprite sDelcattyGfx30, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx31:
+.incbin "baserom.gba", 0x1241938, 0x160
+sDelcattyGfx31_1:
+.incbin "baserom.gba", 0x1241A98, 0x40
+sDelcattySprites31:
+ax_sprite sDelcattyGfx31, 0x160
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx32:
+.incbin "baserom.gba", 0x1241B00, 0x100
+sDelcattyGfx32_1:
+.incbin "baserom.gba", 0x1241C00, 0x60
+sDelcattyGfx32_2:
+.incbin "baserom.gba", 0x1241C60, 0x40
+sDelcattySprites32:
+ax_sprite sDelcattyGfx32, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx33:
+.incbin "baserom.gba", 0x1241CD8, 0x40
+sDelcattyGfx33_1:
+.incbin "baserom.gba", 0x1241D18, 0x120
+sDelcattyGfx33_2:
+.incbin "baserom.gba", 0x1241E38, 0x40
+sDelcattySprites33:
+ax_sprite sDelcattyGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx33_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx34:
+.incbin "baserom.gba", 0x1241EB0, 0x60
+sDelcattyGfx34_1:
+.incbin "baserom.gba", 0x1241F10, 0x60
+sDelcattyGfx34_2:
+.incbin "baserom.gba", 0x1241F70, 0x60
+sDelcattyGfx34_3:
+.incbin "baserom.gba", 0x1241FD0, 0x40
+sDelcattySprites34:
+ax_sprite sDelcattyGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx35:
+.incbin "baserom.gba", 0x1242058, 0x60
+sDelcattyGfx35_1:
+.incbin "baserom.gba", 0x12420B8, 0x100
+sDelcattyGfx35_2:
+.incbin "baserom.gba", 0x12421B8, 0x40
+sDelcattySprites35:
+ax_sprite sDelcattyGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx36:
+.incbin "baserom.gba", 0x1242230, 0x160
+sDelcattyGfx36_1:
+.incbin "baserom.gba", 0x1242390, 0x40
+sDelcattySprites36:
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx36, 0x160
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx36_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx37:
+.incbin "baserom.gba", 0x1242400, 0x180
+sDelcattyGfx37_1:
+.incbin "baserom.gba", 0x1242580, 0x40
+sDelcattySprites37:
+ax_sprite sDelcattyGfx37, 0x180
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx38:
+.incbin "baserom.gba", 0x12425E8, 0x60
+sDelcattyGfx38_1:
+.incbin "baserom.gba", 0x1242648, 0x100
+sDelcattyGfx38_2:
+.incbin "baserom.gba", 0x1242748, 0x40
+sDelcattySprites38:
+ax_sprite sDelcattyGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx39:
+.incbin "baserom.gba", 0x12427C0, 0x100
+sDelcattyGfx39_1:
+.incbin "baserom.gba", 0x12428C0, 0x60
+sDelcattyGfx39_2:
+.incbin "baserom.gba", 0x1242920, 0x40
+sDelcattySprites39:
+ax_sprite sDelcattyGfx39, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelcattyGfx39_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx40:
+.incbin "baserom.gba", 0x1242998, 0x160
+sDelcattyGfx40_1:
+.incbin "baserom.gba", 0x1242AF8, 0x40
+sDelcattySprites40:
+ax_sprite sDelcattyGfx40, 0x160
+ax_sprite 0, 0x40
+ax_sprite sDelcattyGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelcattyGfx41:
+.incbin "baserom.gba", 0x1242B60, 0x200
+sDelcattySprites41:
+ax_sprite sDelcattyGfx41, 0x200
+ax_sprite_terminator
+sDelcattyGfx42:
+.incbin "baserom.gba", 0x1242D70, 0x200
+sDelcattySprites42:
+ax_sprite sDelcattyGfx42, 0x200
+ax_sprite_terminator
+sDelcattyGfx43:
+.incbin "baserom.gba", 0x1242F80, 0x80
+sDelcattySprites43:
+ax_sprite sDelcattyGfx43, 0x80
+ax_sprite_terminator
+sDelcattyGfx44:
+.incbin "baserom.gba", 0x1243010, 0x20
+sDelcattySprites44:
+ax_sprite sDelcattyGfx44, 0x20
+ax_sprite_terminator
+sDelcattyGfx45:
+.incbin "baserom.gba", 0x1243040, 0x100
+sDelcattySprites45:
+ax_sprite sDelcattyGfx45, 0x100
+ax_sprite_terminator
+sDelcattyGfx46:
+.incbin "baserom.gba", 0x1243150, 0x100
+sDelcattySprites46:
+ax_sprite sDelcattyGfx46, 0x100
+ax_sprite_terminator
+sDelcattyGfx47:
+.incbin "baserom.gba", 0x1243260, 0x20
+sDelcattySprites47:
+ax_sprite sDelcattyGfx47, 0x20
+ax_sprite_terminator
+sDelcattyGfx48:
+.incbin "baserom.gba", 0x1243290, 0x40
+sDelcattySprites48:
+ax_sprite sDelcattyGfx48, 0x40
+ax_sprite_terminator
+sDelcattyGfx49:
+.incbin "baserom.gba", 0x12432E0, 0x80
+sDelcattySprites49:
+ax_sprite sDelcattyGfx49, 0x80
+ax_sprite_terminator
+sDelcattyGfx50:
+.incbin "baserom.gba", 0x1243370, 0x200
+sDelcattySprites50:
+ax_sprite sDelcattyGfx50, 0x200
+ax_sprite_terminator
+sDelcattyGfx51:
+.incbin "baserom.gba", 0x1243580, 0x200
+sDelcattySprites51:
+ax_sprite sDelcattyGfx51, 0x200
+ax_sprite_terminator
+sDelcattyGfx52:
+.incbin "baserom.gba", 0x1243790, 0x200
+sDelcattySprites52:
+ax_sprite sDelcattyGfx52, 0x200
+ax_sprite_terminator
+sAxPosesDelcatty:
+.4byte sDelcattyPose1
+.4byte sDelcattyPose2
+.4byte sDelcattyPose3
+.4byte sDelcattyPose4
+.4byte sDelcattyPose5
+.4byte sDelcattyPose6
+.4byte sDelcattyPose7
+.4byte sDelcattyPose8
+.4byte sDelcattyPose9
+.4byte sDelcattyPose10
+.4byte sDelcattyPose11
+.4byte sDelcattyPose12
+.4byte sDelcattyPose13
+.4byte sDelcattyPose14
+.4byte sDelcattyPose15
+.4byte sDelcattyPose16
+.4byte sDelcattyPose17
+.4byte sDelcattyPose18
+.4byte sDelcattyPose19
+.4byte sDelcattyPose20
+.4byte sDelcattyPose21
+.4byte sDelcattyPose22
+.4byte sDelcattyPose23
+.4byte sDelcattyPose24
+.4byte sDelcattyPose25
+.4byte sDelcattyPose26
+.4byte sDelcattyPose27
+.4byte sDelcattyPose28
+.4byte sDelcattyPose29
+.4byte sDelcattyPose30
+.4byte sDelcattyPose31
+.4byte sDelcattyPose32
+.4byte sDelcattyPose33
+.4byte sDelcattyPose34
+.4byte sDelcattyPose35
+.4byte sDelcattyPose36
+.4byte sDelcattyPose37
+.4byte sDelcattyPose38
+.4byte sDelcattyPose39
+.4byte sDelcattyPose40
+.4byte sDelcattyPose41
+.4byte sDelcattyPose42
+.4byte sDelcattyPose43
+.4byte sDelcattyPose44
+.4byte sDelcattyPose45
+.4byte sDelcattyPose46
+.4byte sDelcattyPose47
+.4byte sDelcattyPose48
+.4byte sDelcattyPose49
+.4byte sDelcattyPose50
+.4byte sDelcattyPose51
+.4byte sDelcattyPose52
+.4byte sDelcattyPose53
+.4byte sDelcattyPose54
+.4byte sDelcattyPose55
+.4byte sDelcattyPose56
+.4byte sDelcattyPose57
+.4byte sDelcattyPose58
+.4byte sDelcattyPose59
+.4byte sDelcattyPose60
+.4byte sDelcattyPose61
+.4byte sDelcattyPose62
+.4byte sDelcattyPose63
+.4byte sDelcattyPose64
+.4byte sDelcattyPose65
+.4byte sDelcattyPose66
+.4byte sDelcattyPose67
+.4byte sDelcattyPose68
+.4byte sDelcattyPose69
+.4byte sDelcattyPose70
+.4byte sDelcattyPose71
+.4byte sDelcattyPose72
+.4byte sDelcattyPose73
+.4byte sDelcattyPose74
+.4byte sDelcattyPose75
+.4byte sDelcattyPose76
+.4byte sDelcattyPose77
+.4byte sDelcattyPose78
+.4byte sDelcattyPose79
+.4byte sDelcattyPose80
+.4byte sDelcattyPose81
+.4byte sDelcattyPose82
+.4byte sDelcattyPose83
+.4byte sDelcattyPose84
+.4byte sDelcattyPose85
+.4byte sDelcattyPose86
+.4byte sDelcattyPose87
+.4byte sDelcattyPose88
+.4byte sDelcattyPose89
+.4byte sDelcattyPose90
+.4byte sDelcattyPose91
+.4byte sDelcattyPose92
+.4byte sDelcattyPose93
+.4byte sDelcattyPose94
+.4byte sDelcattyPose95
+.4byte sDelcattyPose96
+.4byte sDelcattyPose97
+.4byte sDelcattyPose98
+.4byte sDelcattyPose99
+.4byte sDelcattyPose100
+.4byte sDelcattyPose101
+.4byte sDelcattyPose102
+.4byte sDelcattyPose103
+.4byte sDelcattyPose104
+.4byte sDelcattyPose105
+.4byte sDelcattyPose106
+.4byte sDelcattyPose107
+.4byte sDelcattyPose108
+.4byte sDelcattyPose109
+.4byte sDelcattyPose110
+.4byte sDelcattyPose111
+.4byte sDelcattyPose112
+.4byte sDelcattyPose113
+.4byte sDelcattyPose114
+.4byte sDelcattyPose115
+.4byte sDelcattyPose116
+.4byte sDelcattyPose117
+.4byte sDelcattyPose118
+.4byte sDelcattyPose119
+.4byte sDelcattyPose120
+.4byte sDelcattyPose121
+.4byte sDelcattyPose122
+.4byte sDelcattyPose123
+.4byte sDelcattyPose124
+.4byte sDelcattyPose125
+.4byte sDelcattyPose126
+.4byte sDelcattyPose127
+.4byte sDelcattyPose128
+.4byte sDelcattyPose129
+.4byte sDelcattyPose130
+.4byte sDelcattyPose131
+.4byte sDelcattyPose132
+.4byte sDelcattyPose133
+.4byte sDelcattyPose134
+.4byte sDelcattyPose135
+.4byte sDelcattyPose136
+.4byte sDelcattyPose137
+.4byte sDelcattyPose138
+.4byte sDelcattyPose139
+.4byte sDelcattyPose140
+.4byte sDelcattyPose141
+.4byte sDelcattyPose142
+.4byte sDelcattyPose143
+.4byte sDelcattyPose144
+.4byte sDelcattyPose145
+.4byte sDelcattyPose146
+.4byte sDelcattyPose147
+.4byte sDelcattyPose148
+.4byte sDelcattyPose149
+.4byte sDelcattyPose150
+.4byte sDelcattyPose151
+.4byte sDelcattyPose152
+.4byte sDelcattyPose153
+.4byte sDelcattyPose154
+.4byte sDelcattyPose155
+.4byte sDelcattyPose156
+.4byte sDelcattyPose157
+.4byte sDelcattyPose158
+.4byte sDelcattyPose159
+.4byte sDelcattyPose160
+.4byte sDelcattyPose161
+.4byte sDelcattyPose162
+.4byte sDelcattyPose163
+.4byte sDelcattyPose164
+.4byte sDelcattyPose165
+.4byte sDelcattyPose166
+.4byte sDelcattyPose167
+.4byte sDelcattyPose168
+.4byte sDelcattyPose169
+.4byte sDelcattyPose170
+.4byte sDelcattyPose171
+.4byte sDelcattyPose172
+.4byte sDelcattyPose173
+.4byte sDelcattyPose174
+.4byte sDelcattyPose175
+.4byte sDelcattyPose176
+.4byte sDelcattyPose177
+.4byte sDelcattyPose178
+.4byte sDelcattyPose179
+.4byte sDelcattyPose180
+.4byte sDelcattyPose181
+.4byte sDelcattyPose182
+.4byte sDelcattyPose183
+.4byte sDelcattyPose184
+.4byte sDelcattyPose185
+.4byte sDelcattyPose186
+.4byte sDelcattyPose187
+.4byte sDelcattyPose188
+.4byte sDelcattyPose189
+.4byte sDelcattyPose190
+.4byte sDelcattyPose191
+.4byte sDelcattyPose192
+.4byte sDelcattyPose193
+.4byte sDelcattyPose194
+.4byte sDelcattyPose195
+.4byte sDelcattyPose196
+.4byte sDelcattyPose197
+.4byte sDelcattyPose198
+.4byte sDelcattyPose199
+.4byte sDelcattyPose200
+.4byte sDelcattyPose201
+.4byte sDelcattyPose202
+.4byte sDelcattyPose203
+.4byte sDelcattyPose204
+.4byte sDelcattyPose205
+.4byte sDelcattyPose206
+.4byte sDelcattyPose207
+.4byte sDelcattyPose208
+.4byte sDelcattyPose209
+.4byte sDelcattyPose210
+.4byte sDelcattyPose211
+.4byte sDelcattyPose212
+.4byte sDelcattyPose213
+.4byte sDelcattyPose214
+.4byte sDelcattyPose215
+.4byte sDelcattyPose216
+.4byte sDelcattyPose217
+.4byte sDelcattyPose218
+.4byte sDelcattyPose219
+.4byte sDelcattyPose220
+.4byte sDelcattyPose221
+.4byte sDelcattyPose222
+.4byte sDelcattyPose223
+.4byte sDelcattyPose224
+.4byte sDelcattyPose225
+.4byte sDelcattyPose226
+.4byte sDelcattyPose227
+.4byte sDelcattyPose228
+.4byte sDelcattyPose229
+.4byte sDelcattyPose230
+.4byte sDelcattyPose231
+.4byte sDelcattyPose232
+.4byte sDelcattyPose233
+.4byte sDelcattyPose234
+.4byte sDelcattyPose235
+.4byte sDelcattyPose236
+.4byte sDelcattyPose237
+.4byte sDelcattyPose238
+.4byte sDelcattyPose239
+.4byte sDelcattyPose240
+.4byte sDelcattyPose241
+.4byte sDelcattyPose242
+sAxPositionsDelcatty:
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -2,   -8, 	  -2,    2, 	  -1,    0, 	  -1,   -7
+.2byte    0,   -8, 	  -1,    0, 	   0,    2, 	  -1,   -7
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    4,   -8, 	   4,    2, 	  -2,    0, 	   0,   -7
+.2byte    2,   -8, 	   1,   -1, 	   1,    3, 	   0,   -7
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    7,  -11, 	   6,   -1, 	  -1,    1, 	   1,   -7
+.2byte    6,  -10, 	   1,   -2, 	   6,    0, 	   1,   -7
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    2,  -12, 	  -2,   -4, 	   1,    1, 	  -1,   -8
+.2byte    2,  -12, 	  -2,   -2, 	   6,   -2, 	   0,   -8
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte    2,  -12, 	   0,   -5, 	  -3,   -2, 	  -1,  -10
+.2byte   -4,  -12, 	   1,   -2, 	  -3,   -5, 	  -1,  -10
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -4,  -12, 	   0,   -4, 	  -3,    1, 	  -1,   -8
+.2byte   -4,  -12, 	   0,   -2, 	  -8,   -2, 	  -2,   -8
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -9,  -11, 	  -8,   -1, 	  -1,    1, 	  -3,   -7
+.2byte   -8,  -10, 	  -3,   -2, 	  -8,    0, 	  -3,   -7
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -6,   -8, 	  -6,    2, 	   0,    0, 	  -2,   -7
+.2byte   -4,   -8, 	  -3,   -1, 	  -3,    3, 	  -2,   -7
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -1,  -12, 	  -3,    0, 	   1,    0, 	  -1,  -10
+.2byte   -1,   -6, 	  -5,    0, 	   3,    0, 	  -1,   -8
+.2byte   -1,  -11, 	  -2,    0, 	   0,    0, 	  -1,  -10
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    2,  -11, 	   3,   -1, 	  -1,    1, 	  -1,   -9
+.2byte    4,   -7, 	   4,   -1, 	  -3,    1, 	   0,   -7
+.2byte    2,  -10, 	   2,   -1, 	  -1,    1, 	  -2,   -9
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    4,  -12, 	   4,   -3, 	   2,    0, 	  -1,   -8
+.2byte    9,   -9, 	   4,   -3, 	   1,    0, 	   1,   -7
+.2byte    5,  -12, 	   1,   -3, 	   1,   -1, 	   0,   -9
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    2,  -12, 	  -3,   -3, 	   3,   -1, 	  -2,   -9
+.2byte    6,  -12, 	  -3,   -5, 	   4,   -1, 	   1,   -9
+.2byte    3,  -12, 	   0,   -1, 	   2,    0, 	   0,   -9
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -4, 	  -6,   -4, 	  -1,  -10
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -4,  -12, 	   1,   -3, 	  -5,   -1, 	   0,   -9
+.2byte   -8,  -12, 	   1,   -5, 	  -6,   -1, 	  -3,   -9
+.2byte   -5,  -12, 	  -2,   -1, 	  -4,    0, 	  -2,   -9
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -6,  -12, 	  -6,   -3, 	  -4,    0, 	  -1,   -8
+.2byte  -11,   -9, 	  -6,   -3, 	  -3,    0, 	  -3,   -7
+.2byte   -7,  -12, 	  -3,   -3, 	  -3,   -1, 	  -2,   -9
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,  -11, 	  -5,   -1, 	  -1,    1, 	  -1,   -9
+.2byte   -6,   -7, 	  -6,   -1, 	   1,    1, 	  -2,   -7
+.2byte   -4,  -10, 	  -4,   -1, 	  -1,    1, 	   0,   -9
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -1,  -12, 	  -3,    0, 	   1,    0, 	  -1,  -10
+.2byte   -1,   -6, 	  -5,    0, 	   3,    0, 	  -1,   -8
+.2byte   -1,  -11, 	  -2,    0, 	   0,    0, 	  -1,  -10
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    2,  -11, 	   3,   -1, 	  -1,    1, 	  -1,   -9
+.2byte    4,   -7, 	   4,   -1, 	  -3,    1, 	   0,   -7
+.2byte    2,  -10, 	   2,   -1, 	  -1,    1, 	  -2,   -9
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    4,  -12, 	   4,   -3, 	   2,    0, 	  -1,   -8
+.2byte    9,   -9, 	   4,   -3, 	   1,    0, 	   1,   -7
+.2byte    5,  -12, 	   1,   -3, 	   1,   -1, 	   0,   -9
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    2,  -12, 	  -3,   -3, 	   3,   -1, 	  -2,   -9
+.2byte    6,  -12, 	  -3,   -5, 	   4,   -1, 	   1,   -9
+.2byte    3,  -12, 	   0,   -1, 	   2,    0, 	   0,   -9
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -4, 	  -6,   -4, 	  -1,  -10
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -4,  -12, 	   1,   -3, 	  -5,   -1, 	   0,   -9
+.2byte   -8,  -12, 	   1,   -5, 	  -6,   -1, 	  -3,   -9
+.2byte   -5,  -12, 	  -2,   -1, 	  -4,    0, 	  -2,   -9
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -6,  -12, 	  -6,   -3, 	  -4,    0, 	  -1,   -8
+.2byte  -11,   -9, 	  -6,   -3, 	  -3,    0, 	  -3,   -7
+.2byte   -7,  -12, 	  -3,   -3, 	  -3,   -1, 	  -2,   -9
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,  -11, 	  -5,   -1, 	  -1,    1, 	  -1,   -9
+.2byte   -6,   -7, 	  -6,   -1, 	   1,    1, 	  -2,   -7
+.2byte   -4,  -10, 	  -4,   -1, 	  -1,    1, 	   0,   -9
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -1,  -12, 	  -3,    0, 	   1,    0, 	  -1,  -10
+.2byte   -1,   -6, 	  -5,    0, 	   3,    0, 	  -1,   -8
+.2byte   -1,  -11, 	  -2,    0, 	   0,    0, 	  -1,  -10
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    2,  -11, 	   3,   -1, 	  -1,    1, 	  -1,   -9
+.2byte    4,   -7, 	   4,   -1, 	  -3,    1, 	   0,   -7
+.2byte    2,  -10, 	   2,   -1, 	  -1,    1, 	  -2,   -9
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    4,  -12, 	   4,   -3, 	   2,    0, 	  -1,   -8
+.2byte    9,   -9, 	   4,   -3, 	   1,    0, 	   1,   -7
+.2byte    5,  -12, 	   1,   -3, 	   1,   -1, 	   0,   -9
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    2,  -12, 	  -3,   -3, 	   3,   -1, 	  -2,   -9
+.2byte    6,  -12, 	  -3,   -5, 	   4,   -1, 	   1,   -9
+.2byte    3,  -12, 	   0,   -1, 	   2,    0, 	   0,   -9
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -4, 	  -6,   -4, 	  -1,  -10
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -4,  -12, 	   1,   -3, 	  -5,   -1, 	   0,   -9
+.2byte   -8,  -12, 	   1,   -5, 	  -6,   -1, 	  -3,   -9
+.2byte   -5,  -12, 	  -2,   -1, 	  -4,    0, 	  -2,   -9
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -6,  -12, 	  -6,   -3, 	  -4,    0, 	  -1,   -8
+.2byte  -11,   -9, 	  -6,   -3, 	  -3,    0, 	  -3,   -7
+.2byte   -7,  -12, 	  -3,   -3, 	  -3,   -1, 	  -2,   -9
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,  -11, 	  -5,   -1, 	  -1,    1, 	  -1,   -9
+.2byte   -6,   -7, 	  -6,   -1, 	   1,    1, 	  -2,   -7
+.2byte   -4,  -10, 	  -4,   -1, 	  -1,    1, 	   0,   -9
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -3,   -9, 	  -3,    0, 	   1,    0, 	  -2,   -8
+.2byte    1,   -9, 	  -3,    0, 	   1,    0, 	   0,   -8
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    4,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    2,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    6,  -12, 	   4,   -3, 	   2,    0, 	   0,   -9
+.2byte    6,  -10, 	   4,   -3, 	   2,    0, 	   0,   -7
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    0,  -13, 	  -3,   -4, 	   3,   -1, 	   0,  -10
+.2byte    4,  -12, 	  -3,   -4, 	   3,   -1, 	   0,   -9
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte    2,  -13, 	   1,   -2, 	  -3,   -2, 	  -1,  -11
+.2byte   -4,  -13, 	   1,   -2, 	  -3,   -2, 	  -2,  -11
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -2,  -13, 	   1,   -4, 	  -5,   -1, 	  -2,  -10
+.2byte   -6,  -12, 	   1,   -4, 	  -5,   -1, 	  -2,   -9
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -8,  -12, 	  -6,   -3, 	  -4,    0, 	  -2,   -9
+.2byte   -8,  -10, 	  -6,   -3, 	  -4,    0, 	  -2,   -7
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -6,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,   -4, 	  -6,    0, 	  -4,    0, 	   0,   -4
+.2byte   -5,   -3, 	  -6,    0, 	  -4,    0, 	  -1,   -4
+.2byte    0,   -9, 	  -4,    0, 	   4,    0, 	   0,   -8
+.2byte    2,   -9, 	   6,   -3, 	   2,    1, 	   0,   -8
+.2byte    4,   -8, 	   8,   -3, 	   5,    0, 	  -1,   -7
+.2byte    1,  -12, 	  -1,   -5, 	   5,   -3, 	  -2,  -10
+.2byte    0,  -10, 	   3,   -5, 	  -3,   -5, 	   0,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -6,   -3, 	   1,  -10
+.2byte   -5,   -8, 	  -9,   -3, 	  -6,    0, 	   0,   -7
+.2byte   -3,   -9, 	  -7,   -3, 	  -3,    1, 	  -1,   -8
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -3,   -9, 	  -3,    0, 	   1,    0, 	  -2,   -8
+.2byte    1,   -9, 	  -3,    0, 	   1,    0, 	   0,   -8
+.2byte   -1,  -10, 	  -2,    1, 	   0,    1, 	  -1,   -9
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    4,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    2,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    2,  -10, 	   2,   -1, 	  -1,    1, 	  -2,   -9
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    6,  -12, 	   4,   -3, 	   2,    0, 	   0,   -9
+.2byte    6,  -10, 	   4,   -3, 	   2,    0, 	   0,   -7
+.2byte    5,  -11, 	   1,   -2, 	   1,    0, 	   0,   -8
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    0,  -13, 	  -3,   -4, 	   3,   -1, 	   0,  -10
+.2byte    4,  -12, 	  -3,   -4, 	   3,   -1, 	   0,   -9
+.2byte    3,  -13, 	   0,   -2, 	   2,   -1, 	   0,  -10
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte    2,  -13, 	   1,   -2, 	  -3,   -2, 	  -1,  -11
+.2byte   -4,  -13, 	   1,   -2, 	  -3,   -2, 	  -2,  -11
+.2byte   -1,  -14, 	   1,   -4, 	  -3,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -2,  -13, 	   1,   -4, 	  -5,   -1, 	  -2,  -10
+.2byte   -6,  -12, 	   1,   -4, 	  -5,   -1, 	  -2,   -9
+.2byte   -5,  -13, 	  -2,   -2, 	  -4,   -1, 	  -2,  -10
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -8,  -12, 	  -6,   -3, 	  -4,    0, 	  -2,   -9
+.2byte   -8,  -10, 	  -6,   -3, 	  -4,    0, 	  -2,   -7
+.2byte   -7,  -11, 	  -3,   -2, 	  -3,    0, 	  -2,   -8
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -6,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,  -10, 	  -4,   -1, 	  -1,    1, 	   0,   -9
+.2byte   -1,   -6, 	  -5,    0, 	   3,    0, 	  -1,   -8
+.2byte   -6,   -7, 	  -6,   -1, 	   1,    1, 	  -2,   -7
+.2byte  -11,   -9, 	  -6,   -3, 	  -3,    0, 	  -3,   -7
+.2byte   -8,  -12, 	   1,   -5, 	  -6,   -1, 	  -3,   -9
+.2byte   -1,  -12, 	   4,   -4, 	  -6,   -4, 	  -1,  -10
+.2byte    6,  -12, 	  -3,   -5, 	   4,   -1, 	   1,   -9
+.2byte    9,   -9, 	   4,   -3, 	   1,    0, 	   1,   -7
+.2byte    4,   -7, 	   4,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -1,  -11, 	  -3,    1, 	   1,    1, 	  -1,   -9
+.2byte    4,  -11, 	   5,   -1, 	   1,    1, 	   1,   -9
+.2byte    5,  -12, 	   5,   -3, 	   3,    0, 	   0,   -8
+.2byte    3,  -12, 	  -2,   -3, 	   4,   -1, 	  -1,   -9
+.2byte   -1,  -14, 	   1,   -4, 	  -3,   -4, 	  -1,  -10
+.2byte   -5,  -12, 	   0,   -3, 	  -6,   -1, 	  -1,   -9
+.2byte   -7,  -12, 	  -7,   -3, 	  -5,    0, 	  -2,   -8
+.2byte   -5,  -11, 	  -6,   -1, 	  -2,    1, 	  -2,   -9
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -1,  -12, 	  -3,    0, 	   1,    0, 	  -1,  -10
+.2byte   -1,   -6, 	  -5,    0, 	   3,    0, 	  -1,   -8
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+.2byte    2,  -11, 	   3,   -1, 	  -1,    1, 	  -1,   -9
+.2byte    4,   -7, 	   4,   -1, 	  -3,    1, 	   0,   -7
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    4,  -12, 	   4,   -3, 	   2,    0, 	  -1,   -8
+.2byte    8,   -9, 	   3,   -3, 	   0,    0, 	   0,   -7
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    2,  -12, 	  -3,   -3, 	   3,   -1, 	  -2,   -9
+.2byte    5,  -12, 	  -4,   -5, 	   3,   -1, 	   0,   -9
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -14, 	   4,   -6, 	  -6,   -6, 	  -1,  -12
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -4,  -12, 	   1,   -3, 	  -5,   -1, 	   0,   -9
+.2byte   -7,  -12, 	   2,   -5, 	  -5,   -1, 	  -2,   -9
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -6,  -12, 	  -6,   -3, 	  -4,    0, 	  -1,   -8
+.2byte  -10,   -9, 	  -5,   -3, 	  -2,    0, 	  -2,   -7
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -4,  -11, 	  -5,   -1, 	  -1,    1, 	  -1,   -9
+.2byte   -6,   -7, 	  -6,   -1, 	   1,    1, 	  -2,   -7
+.2byte   -1,   -6, 	  -5,    0, 	   3,    0, 	  -1,   -8
+.2byte   -6,   -7, 	  -6,   -1, 	   1,    1, 	  -2,   -7
+.2byte  -11,   -9, 	  -6,   -3, 	  -3,    0, 	  -3,   -7
+.2byte   -8,  -12, 	   1,   -5, 	  -6,   -1, 	  -3,   -9
+.2byte   -1,  -12, 	   4,   -4, 	  -6,   -4, 	  -1,  -10
+.2byte    6,  -12, 	  -3,   -5, 	   4,   -1, 	   1,   -9
+.2byte    9,   -9, 	   4,   -3, 	   1,    0, 	   1,   -7
+.2byte    4,   -7, 	   4,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -1,   -9, 	  -3,    0, 	   1,    0, 	  -1,   -8
+.2byte   -5,   -9, 	  -5,   -1, 	  -1,    1, 	  -2,   -8
+.2byte   -8,  -11, 	  -6,   -3, 	  -4,    0, 	  -2,   -8
+.2byte   -4,  -13, 	   0,   -2, 	  -5,   -1, 	  -1,   -9
+.2byte   -1,  -14, 	   1,   -3, 	  -3,   -3, 	  -1,  -11
+.2byte    2,  -13, 	  -2,   -2, 	   3,   -1, 	  -1,   -9
+.2byte    6,  -11, 	   4,   -3, 	   2,    0, 	   0,   -8
+.2byte    3,   -9, 	   3,   -1, 	  -1,    1, 	   0,   -8
+sDelcattyAnimTable1:
+.4byte sDelcattyAnims_1_1
+.4byte sDelcattyAnims_1_2
+.4byte sDelcattyAnims_1_3
+.4byte sDelcattyAnims_1_4
+.4byte sDelcattyAnims_1_5
+.4byte sDelcattyAnims_1_6
+.4byte sDelcattyAnims_1_7
+.4byte sDelcattyAnims_1_8
+sDelcattyAnimTable2:
+.4byte sDelcattyAnims_2_1
+.4byte sDelcattyAnims_2_2
+.4byte sDelcattyAnims_2_3
+.4byte sDelcattyAnims_2_4
+.4byte sDelcattyAnims_2_5
+.4byte sDelcattyAnims_2_6
+.4byte sDelcattyAnims_2_7
+.4byte sDelcattyAnims_2_8
+sDelcattyAnimTable3:
+.4byte sDelcattyAnims_3_1
+.4byte sDelcattyAnims_3_2
+.4byte sDelcattyAnims_3_3
+.4byte sDelcattyAnims_3_4
+.4byte sDelcattyAnims_3_5
+.4byte sDelcattyAnims_3_6
+.4byte sDelcattyAnims_3_7
+.4byte sDelcattyAnims_3_8
+sDelcattyAnimTable4:
+.4byte sDelcattyAnims_4_1
+.4byte sDelcattyAnims_4_2
+.4byte sDelcattyAnims_4_3
+.4byte sDelcattyAnims_4_4
+.4byte sDelcattyAnims_4_5
+.4byte sDelcattyAnims_4_6
+.4byte sDelcattyAnims_4_7
+.4byte sDelcattyAnims_4_8
+sDelcattyAnimTable5:
+.4byte sDelcattyAnims_5_1
+.4byte sDelcattyAnims_5_2
+.4byte sDelcattyAnims_5_3
+.4byte sDelcattyAnims_5_4
+.4byte sDelcattyAnims_5_5
+.4byte sDelcattyAnims_5_6
+.4byte sDelcattyAnims_5_7
+.4byte sDelcattyAnims_5_8
+sDelcattyAnimTable6:
+.4byte sDelcattyAnims_6_1
+.4byte sDelcattyAnims_6_1
+.4byte sDelcattyAnims_6_1
+.4byte sDelcattyAnims_6_1
+.4byte sDelcattyAnims_6_1
+.4byte sDelcattyAnims_6_1
+.4byte sDelcattyAnims_6_1
+.4byte sDelcattyAnims_6_1
+sDelcattyAnimTable7:
+.4byte sDelcattyAnims_7_1
+.4byte sDelcattyAnims_7_2
+.4byte sDelcattyAnims_7_3
+.4byte sDelcattyAnims_7_4
+.4byte sDelcattyAnims_7_5
+.4byte sDelcattyAnims_7_6
+.4byte sDelcattyAnims_7_7
+.4byte sDelcattyAnims_7_8
+sDelcattyAnimTable8:
+.4byte sDelcattyAnims_8_1
+.4byte sDelcattyAnims_8_2
+.4byte sDelcattyAnims_8_3
+.4byte sDelcattyAnims_8_4
+.4byte sDelcattyAnims_8_5
+.4byte sDelcattyAnims_8_6
+.4byte sDelcattyAnims_8_7
+.4byte sDelcattyAnims_8_8
+sDelcattyAnimTable9:
+.4byte sDelcattyAnims_9_1
+.4byte sDelcattyAnims_9_2
+.4byte sDelcattyAnims_9_3
+.4byte sDelcattyAnims_9_4
+.4byte sDelcattyAnims_9_5
+.4byte sDelcattyAnims_9_6
+.4byte sDelcattyAnims_9_7
+.4byte sDelcattyAnims_9_8
+sDelcattyAnimTable10:
+.4byte sDelcattyAnims_10_1
+.4byte sDelcattyAnims_10_2
+.4byte sDelcattyAnims_10_3
+.4byte sDelcattyAnims_10_4
+.4byte sDelcattyAnims_10_5
+.4byte sDelcattyAnims_10_6
+.4byte sDelcattyAnims_10_7
+.4byte sDelcattyAnims_10_8
+sDelcattyAnimTable11:
+.4byte sDelcattyAnims_11_1
+.4byte sDelcattyAnims_11_2
+.4byte sDelcattyAnims_11_3
+.4byte sDelcattyAnims_11_4
+.4byte sDelcattyAnims_11_5
+.4byte sDelcattyAnims_11_6
+.4byte sDelcattyAnims_11_7
+.4byte sDelcattyAnims_11_8
+sDelcattyAnimTable12:
+.4byte sDelcattyAnims_12_1
+.4byte sDelcattyAnims_12_2
+.4byte sDelcattyAnims_12_3
+.4byte sDelcattyAnims_12_4
+.4byte sDelcattyAnims_12_5
+.4byte sDelcattyAnims_12_6
+.4byte sDelcattyAnims_12_7
+.4byte sDelcattyAnims_12_8
+sDelcattyAnimTable13:
+.4byte sDelcattyAnims_13_1
+.4byte sDelcattyAnims_13_2
+.4byte sDelcattyAnims_13_3
+.4byte sDelcattyAnims_13_4
+.4byte sDelcattyAnims_13_5
+.4byte sDelcattyAnims_13_6
+.4byte sDelcattyAnims_13_7
+.4byte sDelcattyAnims_13_8
+sAxAnimationsDelcatty:
+.4byte sDelcattyAnimTable1
+.4byte sDelcattyAnimTable2
+.4byte sDelcattyAnimTable3
+.4byte sDelcattyAnimTable4
+.4byte sDelcattyAnimTable5
+.4byte sDelcattyAnimTable6
+.4byte sDelcattyAnimTable7
+.4byte sDelcattyAnimTable8
+.4byte sDelcattyAnimTable9
+.4byte sDelcattyAnimTable10
+.4byte sDelcattyAnimTable11
+.4byte sDelcattyAnimTable12
+.4byte sDelcattyAnimTable13
+sAxSpritesDelcatty:
+.4byte sDelcattySprites1
+.4byte sDelcattySprites2
+.4byte sDelcattySprites3
+.4byte sDelcattySprites4
+.4byte sDelcattySprites5
+.4byte sDelcattySprites6
+.4byte sDelcattySprites7
+.4byte sDelcattySprites8
+.4byte sDelcattySprites9
+.4byte sDelcattySprites10
+.4byte sDelcattySprites11
+.4byte sDelcattySprites12
+.4byte sDelcattySprites13
+.4byte sDelcattySprites14
+.4byte sDelcattySprites15
+.4byte sDelcattySprites16
+.4byte sDelcattySprites17
+.4byte sDelcattySprites18
+.4byte sDelcattySprites19
+.4byte sDelcattySprites20
+.4byte sDelcattySprites21
+.4byte sDelcattySprites22
+.4byte sDelcattySprites23
+.4byte sDelcattySprites24
+.4byte sDelcattySprites25
+.4byte sDelcattySprites26
+.4byte sDelcattySprites27
+.4byte sDelcattySprites28
+.4byte sDelcattySprites29
+.4byte sDelcattySprites30
+.4byte sDelcattySprites31
+.4byte sDelcattySprites32
+.4byte sDelcattySprites33
+.4byte sDelcattySprites34
+.4byte sDelcattySprites35
+.4byte sDelcattySprites36
+.4byte sDelcattySprites37
+.4byte sDelcattySprites38
+.4byte sDelcattySprites39
+.4byte sDelcattySprites40
+.4byte sDelcattySprites41
+.4byte sDelcattySprites42
+.4byte sDelcattySprites43
+.4byte sDelcattySprites44
+.4byte sDelcattySprites45
+.4byte sDelcattySprites46
+.4byte sDelcattySprites47
+.4byte sDelcattySprites48
+.4byte sDelcattySprites49
+.4byte sDelcattySprites50
+.4byte sDelcattySprites51
+.4byte sDelcattySprites52
+sAxMainDelcatty:
+ax_main sAxPosesDelcatty, sAxAnimationsDelcatty, 13, sAxSpritesDelcatty, sAxPositionsDelcatty

--- a/data/ax/delibird.inc
+++ b/data/ax/delibird.inc
@@ -1,0 +1,2829 @@
+.global gAxDelibird
+gAxDelibird:
+ax_siro sAxMainDelibird
+sDelibirdPose1:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose2:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose3:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose4:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose5:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose6:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose7:
+ax_pose 6, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose8:
+ax_pose 7, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose9:
+ax_pose 8, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose10:
+ax_pose 9, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose11:
+ax_pose 10, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose12:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose13:
+ax_pose 12, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose14:
+ax_pose 13, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose15:
+ax_pose 14, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose16:
+ax_pose 15, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose17:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose18:
+ax_pose 17, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose19:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose20:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose21:
+ax_pose 20, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose22:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose23:
+ax_pose 22, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose24:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose25:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose26:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose27:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose28:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose29:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose30:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose31:
+ax_pose 6, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose32:
+ax_pose 7, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose33:
+ax_pose 8, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose34:
+ax_pose 9, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose35:
+ax_pose 10, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose36:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose37:
+ax_pose 12, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose38:
+ax_pose 13, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose39:
+ax_pose 14, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose40:
+ax_pose 15, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose41:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose42:
+ax_pose 17, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose43:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose44:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose45:
+ax_pose 20, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose46:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose47:
+ax_pose 22, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose48:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose49:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose50:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose51:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose52:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose53:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose54:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose55:
+ax_pose 6, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose56:
+ax_pose 7, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose57:
+ax_pose 8, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose58:
+ax_pose 9, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose59:
+ax_pose 10, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose60:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose61:
+ax_pose 12, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose62:
+ax_pose 13, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose63:
+ax_pose 14, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose64:
+ax_pose 15, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose65:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose66:
+ax_pose 17, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose67:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose68:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose69:
+ax_pose 20, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose70:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose71:
+ax_pose 22, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose72:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose73:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose74:
+ax_pose 23, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sDelibirdPose75:
+ax_pose 20, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose76:
+ax_pose 17, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose77:
+ax_pose 14, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose78:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose79:
+ax_pose 8, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose80:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose81:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose82:
+ax_pose 24, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose83:
+ax_pose 25, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose84:
+ax_pose 26, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sDelibirdPose85:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose86:
+ax_pose 27, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose87:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose88:
+ax_pose 29, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sDelibirdPose89:
+ax_pose 6, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose90:
+ax_pose 30, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose91:
+ax_pose 31, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose92:
+ax_pose 32, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sDelibirdPose93:
+ax_pose 9, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose94:
+ax_pose 33, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose95:
+ax_pose 34, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose96:
+ax_pose 35, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sDelibirdPose97:
+ax_pose 12, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose98:
+ax_pose 36, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose99:
+ax_pose 37, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose100:
+ax_pose 38, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose101:
+ax_pose 15, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose102:
+ax_pose 39, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose103:
+ax_pose 40, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose104:
+ax_pose 41, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose105:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose106:
+ax_pose 42, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sDelibirdPose107:
+ax_pose 43, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sDelibirdPose108:
+ax_pose 44, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose109:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose110:
+ax_pose 45, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose111:
+ax_pose 46, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose112:
+ax_pose 47, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose113:
+ax_pose 48, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose114:
+ax_pose 49, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose115:
+ax_pose 50, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose116:
+ax_pose 51, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sDelibirdPose117:
+ax_pose 52, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sDelibirdPose118:
+ax_pose 53, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sDelibirdPose119:
+ax_pose 54, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose120:
+ax_pose 53, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sDelibirdPose121:
+ax_pose 52, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sDelibirdPose122:
+ax_pose 51, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose123:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose124:
+ax_pose 24, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose125:
+ax_pose 25, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose126:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose127:
+ax_pose 27, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose128:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose129:
+ax_pose 6, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose130:
+ax_pose 30, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose131:
+ax_pose 31, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose132:
+ax_pose 9, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose133:
+ax_pose 33, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose134:
+ax_pose 34, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose135:
+ax_pose 12, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose136:
+ax_pose 36, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose137:
+ax_pose 37, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose138:
+ax_pose 15, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose139:
+ax_pose 39, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose140:
+ax_pose 40, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose141:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose142:
+ax_pose 42, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sDelibirdPose143:
+ax_pose 43, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sDelibirdPose144:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose145:
+ax_pose 45, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose146:
+ax_pose 46, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose147:
+ax_pose 26, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose148:
+ax_pose 47, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sDelibirdPose149:
+ax_pose 44, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sDelibirdPose150:
+ax_pose 41, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose151:
+ax_pose 38, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose152:
+ax_pose 35, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose153:
+ax_pose 32, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sDelibirdPose154:
+ax_pose 29, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose155:
+ax_pose 26, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose156:
+ax_pose 29, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose157:
+ax_pose 32, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sDelibirdPose158:
+ax_pose 35, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose159:
+ax_pose 38, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose160:
+ax_pose 41, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose161:
+ax_pose 44, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sDelibirdPose162:
+ax_pose 47, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sDelibirdPose163:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose164:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose165:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose166:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose167:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose168:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose169:
+ax_pose 6, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose170:
+ax_pose 7, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose171:
+ax_pose 8, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose172:
+ax_pose 9, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose173:
+ax_pose 10, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose174:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose175:
+ax_pose 12, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose176:
+ax_pose 13, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose177:
+ax_pose 14, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose178:
+ax_pose 15, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose179:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose180:
+ax_pose 17, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose181:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose182:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose183:
+ax_pose 20, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose184:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose185:
+ax_pose 22, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose186:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose187:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose188:
+ax_pose 23, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sDelibirdPose189:
+ax_pose 20, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose190:
+ax_pose 17, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose191:
+ax_pose 14, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose192:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose193:
+ax_pose 8, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose194:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose195:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose196:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose197:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sDelibirdPose198:
+ax_pose 15, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose199:
+ax_pose 12, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sDelibirdPose200:
+ax_pose 9, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose201:
+ax_pose 6, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sDelibirdPose202:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+.align 2
+sDelibirdAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDelibirdAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 1, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sDelibirdAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sDelibirdAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 12, -12, 12, -12,
+ax_anim 2, 0, 34, 21, -19, 21, -19,
+ax_anim 2, 1, 34, 22, -18, 22, -18,
+ax_anim 2, 0, 34, 21, -19, 21, -19,
+ax_anim 2, 0, 34, 22, -18, 22, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sDelibirdAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -9, 0, -9,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 1, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 0, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sDelibirdAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 41, -12, -12, -12, -12,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 1, 40, -20, -18, -20, -18,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -20, -18, -20, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sDelibirdAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 1, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 0, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sDelibirdAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 1, 46, -21, 18, -21, 18,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -21, 18, -21, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 1, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 0, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sDelibirdAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 1, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 0, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sDelibirdAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 1, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sDelibirdAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 5, -6, 5, -6,
+ax_anim 1, 0, 59, 12, -12, 12, -12,
+ax_anim 2, 0, 58, 21, -19, 21, -19,
+ax_anim 2, 1, 58, 22, -18, 22, -18,
+ax_anim 2, 0, 58, 21, -19, 21, -19,
+ax_anim 2, 0, 58, 22, -18, 22, -18,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sDelibirdAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -9, 0, -9,
+ax_anim 2, 0, 61, 0, -19, 0, -19,
+ax_anim 2, 1, 61, 1, -19, 1, -19,
+ax_anim 2, 0, 61, 0, -19, 0, -19,
+ax_anim 2, 0, 61, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sDelibirdAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -5, -6, -5, -6,
+ax_anim 1, 0, 65, -12, -12, -12, -12,
+ax_anim 2, 0, 64, -19, -19, -19, -19,
+ax_anim 2, 1, 64, -20, -18, -20, -18,
+ax_anim 2, 0, 64, -19, -19, -19, -19,
+ax_anim 2, 0, 64, -20, -18, -20, -18,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sDelibirdAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -19, 0, -19, 0,
+ax_anim 2, 1, 67, -19, 1, -19, 1,
+ax_anim 2, 0, 67, -19, 0, -19, 0,
+ax_anim 2, 0, 67, -19, 1, -19, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sDelibirdAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 1, 70, -21, 18, -21, 18,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 70, -21, 18, -21, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_5_1:
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 8, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, -3, 0, 0,
+ax_anim 1, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -5, 0, 0,
+ax_anim 1, 0, 83, 0, -4, 0, 0,
+ax_anim 1, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_5_2:
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 8, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, -3, 0, 0,
+ax_anim 1, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -5, 0, 0,
+ax_anim 1, 0, 87, 0, -4, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_5_3:
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 8, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 1, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 1, 0, 91, 0, -4, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_5_4:
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 8, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 1, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -4, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_5_5:
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 8, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -3, 0, 0,
+ax_anim 1, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 0, 99, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_5_6:
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 8, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -3, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_5_7:
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 8, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 1, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -4, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_5_8:
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 8, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sDelibirdAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sDelibirdAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sDelibirdAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sDelibirdAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sDelibirdAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sDelibirdAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sDelibirdAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_8_1:
+ax_anim 12, 0, 123, 0, 0, 0, 0,
+ax_anim 12, 0, 124, 0, 0, 0, 0,
+ax_anim 12, 0, 123, 0, 0, 0, 0,
+ax_anim 12, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_8_2:
+ax_anim 12, 0, 126, 0, 0, 0, 0,
+ax_anim 12, 0, 127, 0, 0, 0, 0,
+ax_anim 12, 0, 126, 0, 0, 0, 0,
+ax_anim 12, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_8_3:
+ax_anim 12, 0, 129, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 129, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_8_4:
+ax_anim 12, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_8_5:
+ax_anim 12, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_8_6:
+ax_anim 12, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 139, 0, 0, 0, 0,
+ax_anim 12, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_8_7:
+ax_anim 12, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim 12, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_8_8:
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 11, 8, 11,
+ax_anim 2, 0, 149, 7, 18, 7, 18,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 18, -7, 18,
+ax_anim 2, 0, 152, -8, 11, -8, 11,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 20, 13, 20, 13,
+ax_anim 3, 0, 149, 21, 20, 21, 20,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 17, -5, 17, -5,
+ax_anim 3, 0, 148, 20, -2, 20, -2,
+ax_anim 2, 3, 149, 19, 4, 19, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 3, 4, 3,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 1, -8, -1, -8,
+ax_anim 2, 0, 153, 3, -18, 3, -18,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 20, -19, 20, -19,
+ax_anim 2, 3, 148, 22, -12, 22, -12,
+ax_anim 2, 0, 149, 18, -5, 18, -5,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -7, -18, -7, -18,
+ax_anim 3, 0, 146, 0, -20, 0, -20,
+ax_anim 2, 3, 147, 7, -18, 7, -18,
+ax_anim 2, 0, 148, 9, -12, 9, -12,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -3, -18, -3, -18,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -20, -19, -20, -19,
+ax_anim 2, 3, 152, -22, -12, -22, -12,
+ax_anim 2, 0, 151, -18, -5, -18, -5,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -17, -5, -17, -5,
+ax_anim 3, 0, 152, -20, -2, -20, -2,
+ax_anim 2, 3, 151, -19, 4, -19, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 3, -4, 3,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -20, 13, -20, 13,
+ax_anim 3, 0, 151, -21, 20, -21, 20,
+ax_anim 2, 3, 150, -11, 21, -11, 21,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDelibirdAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDelibirdGfx1:
+.incbin "baserom.gba", 0xF1BF58, 0x200
+sDelibirdSprites1:
+ax_sprite sDelibirdGfx1, 0x200
+ax_sprite_terminator
+sDelibirdGfx2:
+.incbin "baserom.gba", 0xF1C168, 0x200
+sDelibirdSprites2:
+ax_sprite sDelibirdGfx2, 0x200
+ax_sprite_terminator
+sDelibirdGfx3:
+.incbin "baserom.gba", 0xF1C378, 0x200
+sDelibirdSprites3:
+ax_sprite sDelibirdGfx3, 0x200
+ax_sprite_terminator
+sDelibirdGfx4:
+.incbin "baserom.gba", 0xF1C588, 0x200
+sDelibirdSprites4:
+ax_sprite sDelibirdGfx4, 0x200
+ax_sprite_terminator
+sDelibirdGfx5:
+.incbin "baserom.gba", 0xF1C798, 0x200
+sDelibirdSprites5:
+ax_sprite sDelibirdGfx5, 0x200
+ax_sprite_terminator
+sDelibirdGfx6:
+.incbin "baserom.gba", 0xF1C9A8, 0x200
+sDelibirdSprites6:
+ax_sprite sDelibirdGfx6, 0x200
+ax_sprite_terminator
+sDelibirdGfx7:
+.incbin "baserom.gba", 0xF1CBB8, 0x200
+sDelibirdSprites7:
+ax_sprite sDelibirdGfx7, 0x200
+ax_sprite_terminator
+sDelibirdGfx8:
+.incbin "baserom.gba", 0xF1CDC8, 0x200
+sDelibirdSprites8:
+ax_sprite sDelibirdGfx8, 0x200
+ax_sprite_terminator
+sDelibirdGfx9:
+.incbin "baserom.gba", 0xF1CFD8, 0x200
+sDelibirdSprites9:
+ax_sprite sDelibirdGfx9, 0x200
+ax_sprite_terminator
+sDelibirdGfx10:
+.incbin "baserom.gba", 0xF1D1E8, 0x200
+sDelibirdSprites10:
+ax_sprite sDelibirdGfx10, 0x200
+ax_sprite_terminator
+sDelibirdGfx11:
+.incbin "baserom.gba", 0xF1D3F8, 0x200
+sDelibirdSprites11:
+ax_sprite sDelibirdGfx11, 0x200
+ax_sprite_terminator
+sDelibirdGfx12:
+.incbin "baserom.gba", 0xF1D608, 0x200
+sDelibirdSprites12:
+ax_sprite sDelibirdGfx12, 0x200
+ax_sprite_terminator
+sDelibirdGfx13:
+.incbin "baserom.gba", 0xF1D818, 0x200
+sDelibirdSprites13:
+ax_sprite sDelibirdGfx13, 0x200
+ax_sprite_terminator
+sDelibirdGfx14:
+.incbin "baserom.gba", 0xF1DA28, 0x200
+sDelibirdSprites14:
+ax_sprite sDelibirdGfx14, 0x200
+ax_sprite_terminator
+sDelibirdGfx15:
+.incbin "baserom.gba", 0xF1DC38, 0x200
+sDelibirdSprites15:
+ax_sprite sDelibirdGfx15, 0x200
+ax_sprite_terminator
+sDelibirdGfx16:
+.incbin "baserom.gba", 0xF1DE48, 0x200
+sDelibirdSprites16:
+ax_sprite sDelibirdGfx16, 0x200
+ax_sprite_terminator
+sDelibirdGfx17:
+.incbin "baserom.gba", 0xF1E058, 0x200
+sDelibirdSprites17:
+ax_sprite sDelibirdGfx17, 0x200
+ax_sprite_terminator
+sDelibirdGfx18:
+.incbin "baserom.gba", 0xF1E268, 0x200
+sDelibirdSprites18:
+ax_sprite sDelibirdGfx18, 0x200
+ax_sprite_terminator
+sDelibirdGfx19:
+.incbin "baserom.gba", 0xF1E478, 0x200
+sDelibirdSprites19:
+ax_sprite sDelibirdGfx19, 0x200
+ax_sprite_terminator
+sDelibirdGfx20:
+.incbin "baserom.gba", 0xF1E688, 0x200
+sDelibirdSprites20:
+ax_sprite sDelibirdGfx20, 0x200
+ax_sprite_terminator
+sDelibirdGfx21:
+.incbin "baserom.gba", 0xF1E898, 0x200
+sDelibirdSprites21:
+ax_sprite sDelibirdGfx21, 0x200
+ax_sprite_terminator
+sDelibirdGfx22:
+.incbin "baserom.gba", 0xF1EAA8, 0x200
+sDelibirdSprites22:
+ax_sprite sDelibirdGfx22, 0x200
+ax_sprite_terminator
+sDelibirdGfx23:
+.incbin "baserom.gba", 0xF1ECB8, 0x200
+sDelibirdSprites23:
+ax_sprite sDelibirdGfx23, 0x200
+ax_sprite_terminator
+sDelibirdGfx24:
+.incbin "baserom.gba", 0xF1EEC8, 0x200
+sDelibirdSprites24:
+ax_sprite sDelibirdGfx24, 0x200
+ax_sprite_terminator
+sDelibirdGfx25:
+.incbin "baserom.gba", 0xF1F0D8, 0x60
+sDelibirdGfx25_1:
+.incbin "baserom.gba", 0xF1F138, 0x60
+sDelibirdGfx25_2:
+.incbin "baserom.gba", 0xF1F198, 0x60
+sDelibirdGfx25_3:
+.incbin "baserom.gba", 0xF1F1F8, 0x60
+sDelibirdSprites25:
+ax_sprite sDelibirdGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx26:
+.incbin "baserom.gba", 0xF1F2A0, 0x60
+sDelibirdGfx26_1:
+.incbin "baserom.gba", 0xF1F300, 0x60
+sDelibirdGfx26_2:
+.incbin "baserom.gba", 0xF1F360, 0x60
+sDelibirdGfx26_3:
+.incbin "baserom.gba", 0xF1F3C0, 0x20
+sDelibirdGfx26_4:
+.incbin "baserom.gba", 0xF1F3E0, 0x20
+sDelibirdSprites26:
+ax_sprite sDelibirdGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx26_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx26_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx27:
+.incbin "baserom.gba", 0xF1F458, 0x60
+sDelibirdGfx27_1:
+.incbin "baserom.gba", 0xF1F4B8, 0x160
+sDelibirdSprites27:
+ax_sprite sDelibirdGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx28:
+.incbin "baserom.gba", 0xF1F640, 0x60
+sDelibirdGfx28_1:
+.incbin "baserom.gba", 0xF1F6A0, 0x60
+sDelibirdGfx28_2:
+.incbin "baserom.gba", 0xF1F700, 0x60
+sDelibirdGfx28_3:
+.incbin "baserom.gba", 0xF1F760, 0x60
+sDelibirdSprites28:
+ax_sprite sDelibirdGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx29:
+.incbin "baserom.gba", 0xF1F808, 0x40
+sDelibirdGfx29_1:
+.incbin "baserom.gba", 0xF1F848, 0x60
+sDelibirdGfx29_2:
+.incbin "baserom.gba", 0xF1F8A8, 0x60
+sDelibirdGfx29_3:
+.incbin "baserom.gba", 0xF1F908, 0x60
+sDelibirdSprites29:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx30:
+.incbin "baserom.gba", 0xF1F9B8, 0x40
+sDelibirdGfx30_1:
+.incbin "baserom.gba", 0xF1F9F8, 0x60
+sDelibirdGfx30_2:
+.incbin "baserom.gba", 0xF1FA58, 0x60
+sDelibirdGfx30_3:
+.incbin "baserom.gba", 0xF1FAB8, 0x60
+sDelibirdSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx31:
+.incbin "baserom.gba", 0xF1FB68, 0x40
+sDelibirdGfx31_1:
+.incbin "baserom.gba", 0xF1FBA8, 0x60
+sDelibirdGfx31_2:
+.incbin "baserom.gba", 0xF1FC08, 0x60
+sDelibirdGfx31_3:
+.incbin "baserom.gba", 0xF1FC68, 0x60
+sDelibirdSprites31:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx32:
+.incbin "baserom.gba", 0xF1FD18, 0x40
+sDelibirdGfx32_1:
+.incbin "baserom.gba", 0xF1FD58, 0x60
+sDelibirdGfx32_2:
+.incbin "baserom.gba", 0xF1FDB8, 0x60
+sDelibirdGfx32_3:
+.incbin "baserom.gba", 0xF1FE18, 0x60
+sDelibirdSprites32:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx33:
+.incbin "baserom.gba", 0xF1FEC8, 0x40
+sDelibirdGfx33_1:
+.incbin "baserom.gba", 0xF1FF08, 0xE0
+sDelibirdGfx33_2:
+.incbin "baserom.gba", 0xF1FFE8, 0x60
+sDelibirdSprites33:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx33_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx34:
+.incbin "baserom.gba", 0xF20088, 0x40
+sDelibirdGfx34_1:
+.incbin "baserom.gba", 0xF200C8, 0xE0
+sDelibirdGfx34_2:
+.incbin "baserom.gba", 0xF201A8, 0x60
+sDelibirdSprites34:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx34_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx35:
+.incbin "baserom.gba", 0xF20248, 0x60
+sDelibirdGfx35_1:
+.incbin "baserom.gba", 0xF202A8, 0x60
+sDelibirdGfx35_2:
+.incbin "baserom.gba", 0xF20308, 0x60
+sDelibirdGfx35_3:
+.incbin "baserom.gba", 0xF20368, 0x60
+sDelibirdSprites35:
+ax_sprite sDelibirdGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx36:
+.incbin "baserom.gba", 0xF20410, 0x40
+sDelibirdGfx36_1:
+.incbin "baserom.gba", 0xF20450, 0xE0
+sDelibirdGfx36_2:
+.incbin "baserom.gba", 0xF20530, 0x60
+sDelibirdSprites36:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx36_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx37:
+.incbin "baserom.gba", 0xF205D0, 0x60
+sDelibirdGfx37_1:
+.incbin "baserom.gba", 0xF20630, 0x60
+sDelibirdGfx37_2:
+.incbin "baserom.gba", 0xF20690, 0x60
+sDelibirdGfx37_3:
+.incbin "baserom.gba", 0xF206F0, 0x60
+sDelibirdSprites37:
+ax_sprite sDelibirdGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx38:
+.incbin "baserom.gba", 0xF20798, 0x60
+sDelibirdGfx38_1:
+.incbin "baserom.gba", 0xF207F8, 0x60
+sDelibirdGfx38_2:
+.incbin "baserom.gba", 0xF20858, 0x60
+sDelibirdGfx38_3:
+.incbin "baserom.gba", 0xF208B8, 0x60
+sDelibirdSprites38:
+ax_sprite sDelibirdGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx39:
+.incbin "baserom.gba", 0xF20960, 0x60
+sDelibirdGfx39_1:
+.incbin "baserom.gba", 0xF209C0, 0x60
+sDelibirdGfx39_2:
+.incbin "baserom.gba", 0xF20A20, 0x60
+sDelibirdGfx39_3:
+.incbin "baserom.gba", 0xF20A80, 0x60
+sDelibirdSprites39:
+ax_sprite sDelibirdGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx40:
+.incbin "baserom.gba", 0xF20B28, 0x60
+sDelibirdGfx40_1:
+.incbin "baserom.gba", 0xF20B88, 0x60
+sDelibirdGfx40_2:
+.incbin "baserom.gba", 0xF20BE8, 0x60
+sDelibirdGfx40_3:
+.incbin "baserom.gba", 0xF20C48, 0x60
+sDelibirdSprites40:
+ax_sprite sDelibirdGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx40_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx41:
+.incbin "baserom.gba", 0xF20CF0, 0x60
+sDelibirdGfx41_1:
+.incbin "baserom.gba", 0xF20D50, 0x60
+sDelibirdGfx41_2:
+.incbin "baserom.gba", 0xF20DB0, 0x60
+sDelibirdGfx41_3:
+.incbin "baserom.gba", 0xF20E10, 0x60
+sDelibirdSprites41:
+ax_sprite sDelibirdGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx41_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx42:
+.incbin "baserom.gba", 0xF20EB8, 0x60
+sDelibirdGfx42_1:
+.incbin "baserom.gba", 0xF20F18, 0x60
+sDelibirdGfx42_2:
+.incbin "baserom.gba", 0xF20F78, 0x60
+sDelibirdGfx42_3:
+.incbin "baserom.gba", 0xF20FD8, 0x60
+sDelibirdSprites42:
+ax_sprite sDelibirdGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx42_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx43:
+.incbin "baserom.gba", 0xF21080, 0x40
+sDelibirdGfx43_1:
+.incbin "baserom.gba", 0xF210C0, 0x60
+sDelibirdGfx43_2:
+.incbin "baserom.gba", 0xF21120, 0x60
+sDelibirdGfx43_3:
+.incbin "baserom.gba", 0xF21180, 0x60
+sDelibirdSprites43:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx43_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx44:
+.incbin "baserom.gba", 0xF21230, 0x40
+sDelibirdGfx44_1:
+.incbin "baserom.gba", 0xF21270, 0x60
+sDelibirdGfx44_2:
+.incbin "baserom.gba", 0xF212D0, 0x60
+sDelibirdGfx44_3:
+.incbin "baserom.gba", 0xF21330, 0x40
+sDelibirdSprites44:
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx44_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDelibirdGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx45:
+.incbin "baserom.gba", 0xF213C0, 0x40
+sDelibirdGfx45_1:
+.incbin "baserom.gba", 0xF21400, 0x60
+sDelibirdGfx45_2:
+.incbin "baserom.gba", 0xF21460, 0xE0
+sDelibirdSprites45:
+ax_sprite sDelibirdGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDelibirdGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx45_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx46:
+.incbin "baserom.gba", 0xF21578, 0x40
+sDelibirdGfx46_1:
+.incbin "baserom.gba", 0xF215B8, 0x60
+sDelibirdGfx46_2:
+.incbin "baserom.gba", 0xF21618, 0x60
+sDelibirdGfx46_3:
+.incbin "baserom.gba", 0xF21678, 0x60
+sDelibirdSprites46:
+ax_sprite sDelibirdGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDelibirdGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx46_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx47:
+.incbin "baserom.gba", 0xF21720, 0x60
+sDelibirdGfx47_1:
+.incbin "baserom.gba", 0xF21780, 0x60
+sDelibirdGfx47_2:
+.incbin "baserom.gba", 0xF217E0, 0x60
+sDelibirdGfx47_3:
+.incbin "baserom.gba", 0xF21840, 0x60
+sDelibirdSprites47:
+ax_sprite sDelibirdGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx47_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx47_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx48:
+.incbin "baserom.gba", 0xF218E8, 0x60
+sDelibirdGfx48_1:
+.incbin "baserom.gba", 0xF21948, 0x60
+sDelibirdGfx48_2:
+.incbin "baserom.gba", 0xF219A8, 0x60
+sDelibirdGfx48_3:
+.incbin "baserom.gba", 0xF21A08, 0x60
+sDelibirdSprites48:
+ax_sprite sDelibirdGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDelibirdGfx48_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDelibirdGfx49:
+.incbin "baserom.gba", 0xF21AB0, 0x200
+sDelibirdSprites49:
+ax_sprite sDelibirdGfx49, 0x200
+ax_sprite_terminator
+sDelibirdGfx50:
+.incbin "baserom.gba", 0xF21CC0, 0x200
+sDelibirdSprites50:
+ax_sprite sDelibirdGfx50, 0x200
+ax_sprite_terminator
+sDelibirdGfx51:
+.incbin "baserom.gba", 0xF21ED0, 0x200
+sDelibirdSprites51:
+ax_sprite sDelibirdGfx51, 0x200
+ax_sprite_terminator
+sDelibirdGfx52:
+.incbin "baserom.gba", 0xF220E0, 0x200
+sDelibirdSprites52:
+ax_sprite sDelibirdGfx52, 0x200
+ax_sprite_terminator
+sDelibirdGfx53:
+.incbin "baserom.gba", 0xF222F0, 0x200
+sDelibirdSprites53:
+ax_sprite sDelibirdGfx53, 0x200
+ax_sprite_terminator
+sDelibirdGfx54:
+.incbin "baserom.gba", 0xF22500, 0x200
+sDelibirdSprites54:
+ax_sprite sDelibirdGfx54, 0x200
+ax_sprite_terminator
+sDelibirdGfx55:
+.incbin "baserom.gba", 0xF22710, 0x200
+sDelibirdSprites55:
+ax_sprite sDelibirdGfx55, 0x200
+ax_sprite_terminator
+sAxPosesDelibird:
+.4byte sDelibirdPose1
+.4byte sDelibirdPose2
+.4byte sDelibirdPose3
+.4byte sDelibirdPose4
+.4byte sDelibirdPose5
+.4byte sDelibirdPose6
+.4byte sDelibirdPose7
+.4byte sDelibirdPose8
+.4byte sDelibirdPose9
+.4byte sDelibirdPose10
+.4byte sDelibirdPose11
+.4byte sDelibirdPose12
+.4byte sDelibirdPose13
+.4byte sDelibirdPose14
+.4byte sDelibirdPose15
+.4byte sDelibirdPose16
+.4byte sDelibirdPose17
+.4byte sDelibirdPose18
+.4byte sDelibirdPose19
+.4byte sDelibirdPose20
+.4byte sDelibirdPose21
+.4byte sDelibirdPose22
+.4byte sDelibirdPose23
+.4byte sDelibirdPose24
+.4byte sDelibirdPose25
+.4byte sDelibirdPose26
+.4byte sDelibirdPose27
+.4byte sDelibirdPose28
+.4byte sDelibirdPose29
+.4byte sDelibirdPose30
+.4byte sDelibirdPose31
+.4byte sDelibirdPose32
+.4byte sDelibirdPose33
+.4byte sDelibirdPose34
+.4byte sDelibirdPose35
+.4byte sDelibirdPose36
+.4byte sDelibirdPose37
+.4byte sDelibirdPose38
+.4byte sDelibirdPose39
+.4byte sDelibirdPose40
+.4byte sDelibirdPose41
+.4byte sDelibirdPose42
+.4byte sDelibirdPose43
+.4byte sDelibirdPose44
+.4byte sDelibirdPose45
+.4byte sDelibirdPose46
+.4byte sDelibirdPose47
+.4byte sDelibirdPose48
+.4byte sDelibirdPose49
+.4byte sDelibirdPose50
+.4byte sDelibirdPose51
+.4byte sDelibirdPose52
+.4byte sDelibirdPose53
+.4byte sDelibirdPose54
+.4byte sDelibirdPose55
+.4byte sDelibirdPose56
+.4byte sDelibirdPose57
+.4byte sDelibirdPose58
+.4byte sDelibirdPose59
+.4byte sDelibirdPose60
+.4byte sDelibirdPose61
+.4byte sDelibirdPose62
+.4byte sDelibirdPose63
+.4byte sDelibirdPose64
+.4byte sDelibirdPose65
+.4byte sDelibirdPose66
+.4byte sDelibirdPose67
+.4byte sDelibirdPose68
+.4byte sDelibirdPose69
+.4byte sDelibirdPose70
+.4byte sDelibirdPose71
+.4byte sDelibirdPose72
+.4byte sDelibirdPose73
+.4byte sDelibirdPose74
+.4byte sDelibirdPose75
+.4byte sDelibirdPose76
+.4byte sDelibirdPose77
+.4byte sDelibirdPose78
+.4byte sDelibirdPose79
+.4byte sDelibirdPose80
+.4byte sDelibirdPose81
+.4byte sDelibirdPose82
+.4byte sDelibirdPose83
+.4byte sDelibirdPose84
+.4byte sDelibirdPose85
+.4byte sDelibirdPose86
+.4byte sDelibirdPose87
+.4byte sDelibirdPose88
+.4byte sDelibirdPose89
+.4byte sDelibirdPose90
+.4byte sDelibirdPose91
+.4byte sDelibirdPose92
+.4byte sDelibirdPose93
+.4byte sDelibirdPose94
+.4byte sDelibirdPose95
+.4byte sDelibirdPose96
+.4byte sDelibirdPose97
+.4byte sDelibirdPose98
+.4byte sDelibirdPose99
+.4byte sDelibirdPose100
+.4byte sDelibirdPose101
+.4byte sDelibirdPose102
+.4byte sDelibirdPose103
+.4byte sDelibirdPose104
+.4byte sDelibirdPose105
+.4byte sDelibirdPose106
+.4byte sDelibirdPose107
+.4byte sDelibirdPose108
+.4byte sDelibirdPose109
+.4byte sDelibirdPose110
+.4byte sDelibirdPose111
+.4byte sDelibirdPose112
+.4byte sDelibirdPose113
+.4byte sDelibirdPose114
+.4byte sDelibirdPose115
+.4byte sDelibirdPose116
+.4byte sDelibirdPose117
+.4byte sDelibirdPose118
+.4byte sDelibirdPose119
+.4byte sDelibirdPose120
+.4byte sDelibirdPose121
+.4byte sDelibirdPose122
+.4byte sDelibirdPose123
+.4byte sDelibirdPose124
+.4byte sDelibirdPose125
+.4byte sDelibirdPose126
+.4byte sDelibirdPose127
+.4byte sDelibirdPose128
+.4byte sDelibirdPose129
+.4byte sDelibirdPose130
+.4byte sDelibirdPose131
+.4byte sDelibirdPose132
+.4byte sDelibirdPose133
+.4byte sDelibirdPose134
+.4byte sDelibirdPose135
+.4byte sDelibirdPose136
+.4byte sDelibirdPose137
+.4byte sDelibirdPose138
+.4byte sDelibirdPose139
+.4byte sDelibirdPose140
+.4byte sDelibirdPose141
+.4byte sDelibirdPose142
+.4byte sDelibirdPose143
+.4byte sDelibirdPose144
+.4byte sDelibirdPose145
+.4byte sDelibirdPose146
+.4byte sDelibirdPose147
+.4byte sDelibirdPose148
+.4byte sDelibirdPose149
+.4byte sDelibirdPose150
+.4byte sDelibirdPose151
+.4byte sDelibirdPose152
+.4byte sDelibirdPose153
+.4byte sDelibirdPose154
+.4byte sDelibirdPose155
+.4byte sDelibirdPose156
+.4byte sDelibirdPose157
+.4byte sDelibirdPose158
+.4byte sDelibirdPose159
+.4byte sDelibirdPose160
+.4byte sDelibirdPose161
+.4byte sDelibirdPose162
+.4byte sDelibirdPose163
+.4byte sDelibirdPose164
+.4byte sDelibirdPose165
+.4byte sDelibirdPose166
+.4byte sDelibirdPose167
+.4byte sDelibirdPose168
+.4byte sDelibirdPose169
+.4byte sDelibirdPose170
+.4byte sDelibirdPose171
+.4byte sDelibirdPose172
+.4byte sDelibirdPose173
+.4byte sDelibirdPose174
+.4byte sDelibirdPose175
+.4byte sDelibirdPose176
+.4byte sDelibirdPose177
+.4byte sDelibirdPose178
+.4byte sDelibirdPose179
+.4byte sDelibirdPose180
+.4byte sDelibirdPose181
+.4byte sDelibirdPose182
+.4byte sDelibirdPose183
+.4byte sDelibirdPose184
+.4byte sDelibirdPose185
+.4byte sDelibirdPose186
+.4byte sDelibirdPose187
+.4byte sDelibirdPose188
+.4byte sDelibirdPose189
+.4byte sDelibirdPose190
+.4byte sDelibirdPose191
+.4byte sDelibirdPose192
+.4byte sDelibirdPose193
+.4byte sDelibirdPose194
+.4byte sDelibirdPose195
+.4byte sDelibirdPose196
+.4byte sDelibirdPose197
+.4byte sDelibirdPose198
+.4byte sDelibirdPose199
+.4byte sDelibirdPose200
+.4byte sDelibirdPose201
+.4byte sDelibirdPose202
+sAxPositionsDelibird:
+.2byte   -1,   -7, 	 -11,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -2,   -6, 	  -8,   -5, 	   6,   -6, 	  -2,   -8
+.2byte    0,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -8
+.2byte    4,  -10, 	  -7,   -5, 	   6,   -9, 	   1,   -8
+.2byte    3,   -9, 	  -3,   -3, 	   6,   -7, 	  -1,   -7
+.2byte    5,  -10, 	 -10,   -8, 	   7,   -8, 	   0,   -8
+.2byte    7,  -12, 	  -3,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    6,  -11, 	   2,   -3, 	   1,   -8, 	   0,   -7
+.2byte    8,  -11, 	  -5,   -3, 	   1,   -7, 	   0,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -7,   -7, 	  -1,  -11
+.2byte    5,  -14, 	   2,   -3, 	  -7,   -6, 	  -2,   -9
+.2byte    7,  -14, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   8,   -8, 	 -10,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -10, 	 -10,   -6, 	   0,  -10
+.2byte   -2,  -13, 	   9,   -5, 	 -11,   -9, 	  -1,   -9
+.2byte   -8,  -15, 	   6,   -9, 	  -7,   -5, 	   0,   -9
+.2byte   -9,  -14, 	  -1,   -8, 	  -7,   -5, 	  -1,   -9
+.2byte   -7,  -14, 	   8,   -8, 	  -7,   -4, 	   1,   -8
+.2byte   -9,  -12, 	  -6,   -7, 	   0,   -4, 	  -1,   -6
+.2byte  -10,  -11, 	  -7,   -7, 	   1,   -3, 	  -2,   -6
+.2byte   -8,  -11, 	  -6,   -7, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -9, 	  -9,   -9, 	   6,   -5, 	  -2,   -7
+.2byte   -5,   -8, 	  -9,   -5, 	   5,   -4, 	  -2,   -6
+.2byte   -7,   -9, 	 -11,   -6, 	   6,   -5, 	  -2,   -5
+.2byte   -1,   -7, 	 -11,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -2,   -6, 	  -8,   -5, 	   6,   -6, 	  -2,   -8
+.2byte    0,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -8
+.2byte    4,  -10, 	  -7,   -5, 	   6,   -9, 	   1,   -8
+.2byte    3,   -9, 	  -3,   -3, 	   6,   -7, 	  -1,   -7
+.2byte    5,  -10, 	 -10,   -8, 	   7,   -8, 	   0,   -8
+.2byte    7,  -12, 	  -3,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    6,  -11, 	   2,   -3, 	   1,   -8, 	   0,   -7
+.2byte    8,  -11, 	  -5,   -3, 	   1,   -7, 	   0,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -7,   -7, 	  -1,  -11
+.2byte    5,  -14, 	   2,   -3, 	  -7,   -6, 	  -2,   -9
+.2byte    7,  -14, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   8,   -8, 	 -10,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -10, 	 -10,   -6, 	   0,  -10
+.2byte   -2,  -13, 	   9,   -5, 	 -11,   -9, 	  -1,   -9
+.2byte   -8,  -15, 	   6,   -9, 	  -7,   -5, 	   0,   -9
+.2byte   -9,  -14, 	  -1,   -8, 	  -7,   -5, 	  -1,   -9
+.2byte   -7,  -14, 	   8,   -8, 	  -7,   -4, 	   1,   -8
+.2byte   -9,  -12, 	  -6,   -7, 	   0,   -4, 	  -1,   -6
+.2byte  -10,  -11, 	  -7,   -7, 	   1,   -3, 	  -2,   -6
+.2byte   -8,  -11, 	  -6,   -7, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -9, 	  -9,   -9, 	   6,   -5, 	  -2,   -7
+.2byte   -5,   -8, 	  -9,   -5, 	   5,   -4, 	  -2,   -6
+.2byte   -7,   -9, 	 -11,   -6, 	   6,   -5, 	  -2,   -5
+.2byte   -1,   -7, 	 -11,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -2,   -6, 	  -8,   -5, 	   6,   -6, 	  -2,   -8
+.2byte    0,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -8
+.2byte    4,  -10, 	  -7,   -5, 	   6,   -9, 	   1,   -8
+.2byte    3,   -9, 	  -3,   -3, 	   6,   -7, 	  -1,   -7
+.2byte    5,  -10, 	 -10,   -8, 	   7,   -8, 	   0,   -8
+.2byte    7,  -12, 	  -3,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    6,  -11, 	   2,   -3, 	   1,   -8, 	   0,   -7
+.2byte    8,  -11, 	  -5,   -3, 	   1,   -7, 	   0,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -7,   -7, 	  -1,  -11
+.2byte    5,  -14, 	   2,   -3, 	  -7,   -6, 	  -2,   -9
+.2byte    7,  -14, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   8,   -8, 	 -10,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -10, 	 -10,   -6, 	   0,  -10
+.2byte   -2,  -13, 	   9,   -5, 	 -11,   -9, 	  -1,   -9
+.2byte   -8,  -15, 	   6,   -9, 	  -7,   -5, 	   0,   -9
+.2byte   -9,  -14, 	  -1,   -8, 	  -7,   -5, 	  -1,   -9
+.2byte   -7,  -14, 	   8,   -8, 	  -7,   -4, 	   1,   -8
+.2byte   -9,  -12, 	  -6,   -7, 	   0,   -4, 	  -1,   -6
+.2byte  -10,  -11, 	  -7,   -7, 	   1,   -3, 	  -2,   -6
+.2byte   -8,  -11, 	  -6,   -7, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -9, 	  -9,   -9, 	   6,   -5, 	  -2,   -7
+.2byte   -5,   -8, 	  -9,   -5, 	   5,   -4, 	  -2,   -6
+.2byte   -7,   -9, 	 -11,   -6, 	   6,   -5, 	  -2,   -5
+.2byte    0,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -8
+.2byte   -6,   -9, 	 -10,   -6, 	   7,   -5, 	  -1,   -5
+.2byte   -8,  -11, 	  -6,   -7, 	   0,   -3, 	   0,   -7
+.2byte   -8,  -14, 	   7,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -2,  -13, 	   9,   -5, 	 -11,   -9, 	  -1,   -9
+.2byte    7,  -14, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    8,  -11, 	  -5,   -3, 	   1,   -7, 	   0,   -7
+.2byte    5,  -10, 	 -10,   -8, 	   7,   -8, 	   0,   -8
+.2byte   -1,   -7, 	 -11,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -2,   -7, 	  -7,   -6, 	   1,   -6, 	  -3,   -7
+.2byte   -2,   -7, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -3,  -12, 	 -12,  -14, 	   5,   -7, 	  -3,   -9
+.2byte    4,  -10, 	  -7,   -5, 	   6,   -9, 	   1,   -8
+.2byte    3,   -9, 	   0,   -3, 	   3,   -8, 	  -3,   -8
+.2byte    3,   -8, 	   1,   -5, 	   2,   -7, 	  -2,   -8
+.2byte    3,  -11, 	  -4,  -12, 	   2,   -9, 	  -3,   -8
+.2byte    7,  -12, 	  -3,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    7,   -8, 	   4,   -3, 	   3,   -8, 	  -1,   -7
+.2byte    7,  -13, 	   4,   -6, 	   3,   -8, 	  -1,   -9
+.2byte    5,  -11, 	   0,  -14, 	  -3,   -8, 	  -2,   -8
+.2byte    6,  -15, 	   5,   -5, 	  -7,   -7, 	  -1,  -11
+.2byte    7,  -13, 	   6,   -6, 	  -2,   -9, 	   0,   -9
+.2byte    3,  -14, 	   5,   -7, 	  -4,   -7, 	  -1,   -9
+.2byte    6,  -15, 	   7,  -13, 	  -6,   -7, 	   0,   -8
+.2byte   -1,  -14, 	   8,   -8, 	 -10,   -8, 	  -1,  -11
+.2byte    0,  -14, 	   4,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -2,  -14, 	   4,   -8, 	  -8,   -6, 	  -1,   -9
+.2byte   -1,  -13, 	   8,  -14, 	  -8,   -5, 	   0,   -9
+.2byte   -8,  -15, 	   6,   -9, 	  -7,   -5, 	   0,   -9
+.2byte   -4,  -14, 	   3,   -8, 	  -5,   -7, 	   2,   -8
+.2byte   -8,  -13, 	  -2,   -8, 	  -6,   -6, 	   0,  -10
+.2byte   -9,  -15, 	   6,  -15, 	  -8,   -5, 	  -1,  -11
+.2byte   -9,  -12, 	  -6,   -7, 	   0,   -4, 	  -1,   -6
+.2byte   -8,  -11, 	  -7,   -8, 	  -5,   -5, 	  -1,   -8
+.2byte   -7,  -10, 	  -7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte   -5,  -11, 	  -9,  -18, 	   4,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -9,   -9, 	   6,   -5, 	  -2,   -7
+.2byte   -6,   -9, 	  -8,   -7, 	  -1,   -5, 	  -3,   -7
+.2byte   -5,   -9, 	  -7,   -7, 	   0,   -5, 	  -2,   -6
+.2byte   -4,  -10, 	  -9,  -17, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,   -5, 	   5,   -3, 	  -1,   -4
+.2byte   -1,   -4, 	  -7,   -5, 	   5,   -3, 	  -1,   -5
+.2byte    0,  -10, 	  -9,  -16, 	   9,  -16, 	   0,  -12
+.2byte    3,  -12, 	   7,  -17, 	  -9,  -12, 	  -1,  -10
+.2byte    6,  -14, 	   2,  -17, 	  -3,  -14, 	   0,  -11
+.2byte    7,  -16, 	  -3,  -18, 	   5,  -14, 	  -1,  -11
+.2byte    0,  -14, 	   9,  -11, 	  -9,  -11, 	   0,  -10
+.2byte   -8,  -16, 	   2,  -18, 	  -6,  -14, 	   0,  -11
+.2byte   -7,  -14, 	  -3,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -4,  -12, 	  -8,  -17, 	   8,  -12, 	   0,  -10
+.2byte   -1,   -7, 	 -11,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -2,   -7, 	  -7,   -6, 	   1,   -6, 	  -3,   -7
+.2byte   -2,   -7, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte    4,  -10, 	  -7,   -5, 	   6,   -9, 	   1,   -8
+.2byte    3,   -9, 	   0,   -3, 	   3,   -8, 	  -3,   -8
+.2byte    3,   -8, 	   1,   -5, 	   2,   -7, 	  -2,   -8
+.2byte    7,  -12, 	  -3,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    7,   -8, 	   4,   -3, 	   3,   -8, 	  -1,   -7
+.2byte    7,  -13, 	   4,   -6, 	   3,   -8, 	  -1,   -9
+.2byte    6,  -15, 	   5,   -5, 	  -7,   -7, 	  -1,  -11
+.2byte    7,  -13, 	   6,   -6, 	  -2,   -9, 	   0,   -9
+.2byte    3,  -14, 	   5,   -7, 	  -4,   -7, 	  -1,   -9
+.2byte   -1,  -14, 	   8,   -8, 	 -10,   -8, 	  -1,  -11
+.2byte    0,  -14, 	   4,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -2,  -14, 	   4,   -8, 	  -8,   -6, 	  -1,   -9
+.2byte   -8,  -15, 	   6,   -9, 	  -7,   -5, 	   0,   -9
+.2byte   -4,  -14, 	   3,   -8, 	  -5,   -7, 	   2,   -8
+.2byte   -8,  -13, 	  -2,   -8, 	  -6,   -6, 	   0,  -10
+.2byte   -9,  -12, 	  -6,   -7, 	   0,   -4, 	  -1,   -6
+.2byte   -8,  -11, 	  -7,   -8, 	  -5,   -5, 	  -1,   -8
+.2byte   -7,  -10, 	  -7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte   -6,   -9, 	  -9,   -9, 	   6,   -5, 	  -2,   -7
+.2byte   -6,   -9, 	  -8,   -7, 	  -1,   -5, 	  -3,   -7
+.2byte   -5,   -9, 	  -7,   -7, 	   0,   -5, 	  -2,   -6
+.2byte   -1,  -12, 	 -10,  -14, 	   7,   -7, 	  -1,   -9
+.2byte   -3,  -10, 	  -8,  -17, 	   7,   -5, 	   0,   -6
+.2byte   -4,  -11, 	  -8,  -18, 	   5,   -4, 	  -1,   -8
+.2byte   -8,  -15, 	   7,  -15, 	  -7,   -5, 	   0,  -11
+.2byte   -1,  -13, 	   8,  -14, 	  -8,   -5, 	   0,   -9
+.2byte    7,  -15, 	   8,  -13, 	  -5,   -7, 	   1,   -8
+.2byte    5,  -11, 	   0,  -14, 	  -3,   -8, 	  -2,   -8
+.2byte    4,  -11, 	  -3,  -12, 	   3,   -9, 	  -2,   -8
+.2byte   -1,  -12, 	 -10,  -14, 	   7,   -7, 	  -1,   -9
+.2byte    4,  -11, 	  -3,  -12, 	   3,   -9, 	  -2,   -8
+.2byte    5,  -11, 	   0,  -14, 	  -3,   -8, 	  -2,   -8
+.2byte    7,  -15, 	   8,  -13, 	  -5,   -7, 	   1,   -8
+.2byte   -1,  -13, 	   8,  -14, 	  -8,   -5, 	   0,   -9
+.2byte   -8,  -15, 	   7,  -15, 	  -7,   -5, 	   0,  -11
+.2byte   -4,  -11, 	  -8,  -18, 	   5,   -4, 	  -1,   -8
+.2byte   -3,  -10, 	  -8,  -17, 	   7,   -5, 	   0,   -6
+.2byte   -1,   -7, 	 -11,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -2,   -6, 	  -8,   -5, 	   6,   -6, 	  -2,   -8
+.2byte    0,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -8
+.2byte    4,  -10, 	  -7,   -5, 	   6,   -9, 	   1,   -8
+.2byte    3,   -9, 	  -3,   -3, 	   6,   -7, 	  -1,   -7
+.2byte    5,  -10, 	 -10,   -8, 	   7,   -8, 	   0,   -8
+.2byte    7,  -12, 	  -3,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    6,  -11, 	   2,   -3, 	   1,   -8, 	   0,   -7
+.2byte    8,  -11, 	  -5,   -3, 	   1,   -7, 	   0,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -7,   -7, 	  -1,  -11
+.2byte    5,  -14, 	   2,   -3, 	  -7,   -6, 	  -2,   -9
+.2byte    7,  -14, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   8,   -8, 	 -10,   -8, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -10, 	 -10,   -6, 	   0,  -10
+.2byte   -2,  -13, 	   9,   -5, 	 -11,   -9, 	  -1,   -9
+.2byte   -8,  -15, 	   6,   -9, 	  -7,   -5, 	   0,   -9
+.2byte   -9,  -14, 	  -1,   -8, 	  -7,   -5, 	  -1,   -9
+.2byte   -7,  -14, 	   8,   -8, 	  -7,   -4, 	   1,   -8
+.2byte   -9,  -12, 	  -6,   -7, 	   0,   -4, 	  -1,   -6
+.2byte  -10,  -11, 	  -7,   -7, 	   1,   -3, 	  -2,   -6
+.2byte   -8,  -11, 	  -6,   -7, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -9, 	  -9,   -9, 	   6,   -5, 	  -2,   -7
+.2byte   -5,   -8, 	  -9,   -5, 	   5,   -4, 	  -2,   -6
+.2byte   -7,   -9, 	 -11,   -6, 	   6,   -5, 	  -2,   -5
+.2byte    0,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -8
+.2byte   -6,   -9, 	 -10,   -6, 	   7,   -5, 	  -1,   -5
+.2byte   -8,  -11, 	  -6,   -7, 	   0,   -3, 	   0,   -7
+.2byte   -8,  -14, 	   7,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -2,  -13, 	   9,   -5, 	 -11,   -9, 	  -1,   -9
+.2byte    7,  -14, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    8,  -11, 	  -5,   -3, 	   1,   -7, 	   0,   -7
+.2byte    5,  -10, 	 -10,   -8, 	   7,   -8, 	   0,   -8
+.2byte   -1,   -7, 	 -11,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -6,   -9, 	  -9,   -9, 	   6,   -5, 	  -2,   -7
+.2byte   -9,  -12, 	  -6,   -7, 	   0,   -4, 	  -1,   -6
+.2byte   -8,  -15, 	   6,   -9, 	  -7,   -5, 	   0,   -9
+.2byte   -1,  -14, 	   8,   -8, 	 -10,   -8, 	  -1,  -11
+.2byte    6,  -15, 	   5,   -5, 	  -7,   -7, 	  -1,  -11
+.2byte    7,  -12, 	  -3,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    4,  -10, 	  -7,   -5, 	   6,   -9, 	   1,   -8
+sDelibirdAnimTable1:
+.4byte sDelibirdAnims_1_1
+.4byte sDelibirdAnims_1_2
+.4byte sDelibirdAnims_1_3
+.4byte sDelibirdAnims_1_4
+.4byte sDelibirdAnims_1_5
+.4byte sDelibirdAnims_1_6
+.4byte sDelibirdAnims_1_7
+.4byte sDelibirdAnims_1_8
+sDelibirdAnimTable2:
+.4byte sDelibirdAnims_2_1
+.4byte sDelibirdAnims_2_2
+.4byte sDelibirdAnims_2_3
+.4byte sDelibirdAnims_2_4
+.4byte sDelibirdAnims_2_5
+.4byte sDelibirdAnims_2_6
+.4byte sDelibirdAnims_2_7
+.4byte sDelibirdAnims_2_8
+sDelibirdAnimTable3:
+.4byte sDelibirdAnims_3_1
+.4byte sDelibirdAnims_3_2
+.4byte sDelibirdAnims_3_3
+.4byte sDelibirdAnims_3_4
+.4byte sDelibirdAnims_3_5
+.4byte sDelibirdAnims_3_6
+.4byte sDelibirdAnims_3_7
+.4byte sDelibirdAnims_3_8
+sDelibirdAnimTable4:
+.4byte sDelibirdAnims_4_1
+.4byte sDelibirdAnims_4_2
+.4byte sDelibirdAnims_4_3
+.4byte sDelibirdAnims_4_4
+.4byte sDelibirdAnims_4_5
+.4byte sDelibirdAnims_4_6
+.4byte sDelibirdAnims_4_7
+.4byte sDelibirdAnims_4_8
+sDelibirdAnimTable5:
+.4byte sDelibirdAnims_5_1
+.4byte sDelibirdAnims_5_2
+.4byte sDelibirdAnims_5_3
+.4byte sDelibirdAnims_5_4
+.4byte sDelibirdAnims_5_5
+.4byte sDelibirdAnims_5_6
+.4byte sDelibirdAnims_5_7
+.4byte sDelibirdAnims_5_8
+sDelibirdAnimTable6:
+.4byte sDelibirdAnims_6_1
+.4byte sDelibirdAnims_6_1
+.4byte sDelibirdAnims_6_1
+.4byte sDelibirdAnims_6_1
+.4byte sDelibirdAnims_6_1
+.4byte sDelibirdAnims_6_1
+.4byte sDelibirdAnims_6_1
+.4byte sDelibirdAnims_6_1
+sDelibirdAnimTable7:
+.4byte sDelibirdAnims_7_1
+.4byte sDelibirdAnims_7_2
+.4byte sDelibirdAnims_7_3
+.4byte sDelibirdAnims_7_4
+.4byte sDelibirdAnims_7_5
+.4byte sDelibirdAnims_7_6
+.4byte sDelibirdAnims_7_7
+.4byte sDelibirdAnims_7_8
+sDelibirdAnimTable8:
+.4byte sDelibirdAnims_8_1
+.4byte sDelibirdAnims_8_2
+.4byte sDelibirdAnims_8_3
+.4byte sDelibirdAnims_8_4
+.4byte sDelibirdAnims_8_5
+.4byte sDelibirdAnims_8_6
+.4byte sDelibirdAnims_8_7
+.4byte sDelibirdAnims_8_8
+sDelibirdAnimTable9:
+.4byte sDelibirdAnims_9_1
+.4byte sDelibirdAnims_9_2
+.4byte sDelibirdAnims_9_3
+.4byte sDelibirdAnims_9_4
+.4byte sDelibirdAnims_9_5
+.4byte sDelibirdAnims_9_6
+.4byte sDelibirdAnims_9_7
+.4byte sDelibirdAnims_9_8
+sDelibirdAnimTable10:
+.4byte sDelibirdAnims_10_1
+.4byte sDelibirdAnims_10_2
+.4byte sDelibirdAnims_10_3
+.4byte sDelibirdAnims_10_4
+.4byte sDelibirdAnims_10_5
+.4byte sDelibirdAnims_10_6
+.4byte sDelibirdAnims_10_7
+.4byte sDelibirdAnims_10_8
+sDelibirdAnimTable11:
+.4byte sDelibirdAnims_11_1
+.4byte sDelibirdAnims_11_2
+.4byte sDelibirdAnims_11_3
+.4byte sDelibirdAnims_11_4
+.4byte sDelibirdAnims_11_5
+.4byte sDelibirdAnims_11_6
+.4byte sDelibirdAnims_11_7
+.4byte sDelibirdAnims_11_8
+sDelibirdAnimTable12:
+.4byte sDelibirdAnims_12_1
+.4byte sDelibirdAnims_12_2
+.4byte sDelibirdAnims_12_3
+.4byte sDelibirdAnims_12_4
+.4byte sDelibirdAnims_12_5
+.4byte sDelibirdAnims_12_6
+.4byte sDelibirdAnims_12_7
+.4byte sDelibirdAnims_12_8
+sDelibirdAnimTable13:
+.4byte sDelibirdAnims_13_1
+.4byte sDelibirdAnims_13_2
+.4byte sDelibirdAnims_13_3
+.4byte sDelibirdAnims_13_4
+.4byte sDelibirdAnims_13_5
+.4byte sDelibirdAnims_13_6
+.4byte sDelibirdAnims_13_7
+.4byte sDelibirdAnims_13_8
+sAxAnimationsDelibird:
+.4byte sDelibirdAnimTable1
+.4byte sDelibirdAnimTable2
+.4byte sDelibirdAnimTable3
+.4byte sDelibirdAnimTable4
+.4byte sDelibirdAnimTable5
+.4byte sDelibirdAnimTable6
+.4byte sDelibirdAnimTable7
+.4byte sDelibirdAnimTable8
+.4byte sDelibirdAnimTable9
+.4byte sDelibirdAnimTable10
+.4byte sDelibirdAnimTable11
+.4byte sDelibirdAnimTable12
+.4byte sDelibirdAnimTable13
+sAxSpritesDelibird:
+.4byte sDelibirdSprites1
+.4byte sDelibirdSprites2
+.4byte sDelibirdSprites3
+.4byte sDelibirdSprites4
+.4byte sDelibirdSprites5
+.4byte sDelibirdSprites6
+.4byte sDelibirdSprites7
+.4byte sDelibirdSprites8
+.4byte sDelibirdSprites9
+.4byte sDelibirdSprites10
+.4byte sDelibirdSprites11
+.4byte sDelibirdSprites12
+.4byte sDelibirdSprites13
+.4byte sDelibirdSprites14
+.4byte sDelibirdSprites15
+.4byte sDelibirdSprites16
+.4byte sDelibirdSprites17
+.4byte sDelibirdSprites18
+.4byte sDelibirdSprites19
+.4byte sDelibirdSprites20
+.4byte sDelibirdSprites21
+.4byte sDelibirdSprites22
+.4byte sDelibirdSprites23
+.4byte sDelibirdSprites24
+.4byte sDelibirdSprites25
+.4byte sDelibirdSprites26
+.4byte sDelibirdSprites27
+.4byte sDelibirdSprites28
+.4byte sDelibirdSprites29
+.4byte sDelibirdSprites30
+.4byte sDelibirdSprites31
+.4byte sDelibirdSprites32
+.4byte sDelibirdSprites33
+.4byte sDelibirdSprites34
+.4byte sDelibirdSprites35
+.4byte sDelibirdSprites36
+.4byte sDelibirdSprites37
+.4byte sDelibirdSprites38
+.4byte sDelibirdSprites39
+.4byte sDelibirdSprites40
+.4byte sDelibirdSprites41
+.4byte sDelibirdSprites42
+.4byte sDelibirdSprites43
+.4byte sDelibirdSprites44
+.4byte sDelibirdSprites45
+.4byte sDelibirdSprites46
+.4byte sDelibirdSprites47
+.4byte sDelibirdSprites48
+.4byte sDelibirdSprites49
+.4byte sDelibirdSprites50
+.4byte sDelibirdSprites51
+.4byte sDelibirdSprites52
+.4byte sDelibirdSprites53
+.4byte sDelibirdSprites54
+.4byte sDelibirdSprites55
+sAxMainDelibird:
+ax_main sAxPosesDelibird, sAxAnimationsDelibird, 13, sAxSpritesDelibird, sAxPositionsDelibird

--- a/data/ax/deoxysattack.inc
+++ b/data/ax/deoxysattack.inc
@@ -1,0 +1,4179 @@
+.global gAxDeoxysAttack
+gAxDeoxysAttack:
+ax_siro sAxMainDeoxysAttack
+sDeoxysAttackPose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose3:
+ax_pose 0, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose4:
+ax_pose 1, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose5:
+ax_pose 2, 0x01e3, 0x90f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose6:
+ax_pose 3, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose7:
+ax_pose 4, 0x01e3, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose8:
+ax_pose 5, 0x01e3, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose9:
+ax_pose 6, 0x81e3, 0x90f9, 0x9c00
+ax_pose 7, 0x01eb, 0x10f1, 0x9c08
+ax_pose 8, 0x81f3, 0x10f1, 0x9c09
+ax_pose 9, 0x01db, 0x1101, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose10:
+ax_pose 10, 0x01e3, 0x90e9, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose11:
+ax_pose 11, 0x81e3, 0x90f9, 0x9c00
+ax_pose 12, 0x01eb, 0x10f1, 0x9c08
+ax_pose 13, 0x81f3, 0x10f1, 0x9c09
+ax_pose 14, 0x01db, 0x10f9, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose12:
+ax_pose 15, 0x01e3, 0x90ea, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose13:
+ax_pose 16, 0x81e3, 0x90fa, 0x9c00
+ax_pose 17, 0x81eb, 0x10f2, 0x9c08
+ax_pose 18, 0x01fb, 0x10f2, 0x9c0a
+ax_pose 19, 0x01db, 0x1100, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose14:
+ax_pose 20, 0x01e3, 0x90ea, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose15:
+ax_pose 21, 0x81e3, 0x90fa, 0x9c00
+ax_pose 22, 0x81eb, 0x10f2, 0x9c08
+ax_pose 23, 0x01fb, 0x10f2, 0x9c0a
+ax_pose 19, 0x01db, 0x1102, 0x9c0b
+ax_pose 24, 0x01f3, 0x10ea, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose16:
+ax_pose 25, 0x01e3, 0x90e9, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose17:
+ax_pose 26, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose18:
+ax_pose 27, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose19:
+ax_pose 26, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose20:
+ax_pose 27, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose21:
+ax_pose 16, 0x81e3, 0x80f7, 0x9c00
+ax_pose 17, 0x81eb, 0x0107, 0x9c08
+ax_pose 18, 0x01fb, 0x0107, 0x9c0a
+ax_pose 19, 0x01db, 0x00f8, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose22:
+ax_pose 20, 0x01e3, 0x80f7, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose23:
+ax_pose 21, 0x81e3, 0x80f7, 0x9c00
+ax_pose 22, 0x81eb, 0x0107, 0x9c08
+ax_pose 23, 0x01fb, 0x0107, 0x9c0a
+ax_pose 19, 0x01db, 0x00f7, 0x9c0b
+ax_pose 24, 0x01f3, 0x010f, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose24:
+ax_pose 25, 0x01e3, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose25:
+ax_pose 6, 0x81e3, 0x80f8, 0x9c00
+ax_pose 7, 0x01eb, 0x0108, 0x9c08
+ax_pose 8, 0x81f3, 0x0108, 0x9c09
+ax_pose 9, 0x01db, 0x00f8, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose26:
+ax_pose 10, 0x01e3, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose27:
+ax_pose 11, 0x81e3, 0x80f8, 0x9c00
+ax_pose 12, 0x01eb, 0x0108, 0x9c08
+ax_pose 13, 0x81f3, 0x0108, 0x9c09
+ax_pose 14, 0x01db, 0x0100, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose28:
+ax_pose 15, 0x01e3, 0x80f7, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose29:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose30:
+ax_pose 3, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose31:
+ax_pose 4, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose32:
+ax_pose 5, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose33:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose34:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose35:
+ax_pose 0, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose36:
+ax_pose 1, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose37:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose38:
+ax_pose 2, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose39:
+ax_pose 3, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose40:
+ax_pose 4, 0x01e3, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose41:
+ax_pose 5, 0x01e3, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose42:
+ax_pose 29, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose43:
+ax_pose 6, 0x81e3, 0x90f9, 0x9c00
+ax_pose 7, 0x01eb, 0x10f1, 0x9c08
+ax_pose 8, 0x81f3, 0x10f1, 0x9c09
+ax_pose 9, 0x01db, 0x1101, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose44:
+ax_pose 10, 0x01e3, 0x90e9, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose45:
+ax_pose 11, 0x81e3, 0x90f9, 0x9c00
+ax_pose 12, 0x01eb, 0x10f1, 0x9c08
+ax_pose 13, 0x81f3, 0x10f1, 0x9c09
+ax_pose 14, 0x01db, 0x10f9, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose46:
+ax_pose 15, 0x01e3, 0x90ea, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose47:
+ax_pose 30, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose48:
+ax_pose 16, 0x81e3, 0x90fa, 0x9c00
+ax_pose 17, 0x81eb, 0x10f2, 0x9c08
+ax_pose 18, 0x01fb, 0x10f2, 0x9c0a
+ax_pose 19, 0x01db, 0x1100, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose49:
+ax_pose 20, 0x01e3, 0x90ea, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose50:
+ax_pose 21, 0x81e3, 0x90fa, 0x9c00
+ax_pose 22, 0x81eb, 0x10f2, 0x9c08
+ax_pose 23, 0x01fb, 0x10f2, 0x9c0a
+ax_pose 19, 0x01db, 0x1102, 0x9c0b
+ax_pose 24, 0x01f3, 0x10ea, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose51:
+ax_pose 25, 0x01e3, 0x90e9, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose52:
+ax_pose 31, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose53:
+ax_pose 26, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose54:
+ax_pose 27, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose55:
+ax_pose 26, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose56:
+ax_pose 27, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose57:
+ax_pose 32, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose58:
+ax_pose 16, 0x81e3, 0x80f7, 0x9c00
+ax_pose 17, 0x81eb, 0x0107, 0x9c08
+ax_pose 18, 0x01fb, 0x0107, 0x9c0a
+ax_pose 19, 0x01db, 0x00f8, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose59:
+ax_pose 20, 0x01e3, 0x80f7, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose60:
+ax_pose 21, 0x81e3, 0x80f7, 0x9c00
+ax_pose 22, 0x81eb, 0x0107, 0x9c08
+ax_pose 23, 0x01fb, 0x0107, 0x9c0a
+ax_pose 19, 0x01db, 0x00f7, 0x9c0b
+ax_pose 24, 0x01f3, 0x010f, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose61:
+ax_pose 25, 0x01e3, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose62:
+ax_pose 31, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose63:
+ax_pose 6, 0x81e3, 0x80f8, 0x9c00
+ax_pose 7, 0x01eb, 0x0108, 0x9c08
+ax_pose 8, 0x81f3, 0x0108, 0x9c09
+ax_pose 9, 0x01db, 0x00f8, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose64:
+ax_pose 10, 0x01e3, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose65:
+ax_pose 11, 0x81e3, 0x80f8, 0x9c00
+ax_pose 12, 0x01eb, 0x0108, 0x9c08
+ax_pose 13, 0x81f3, 0x0108, 0x9c09
+ax_pose 14, 0x01db, 0x0100, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose66:
+ax_pose 15, 0x01e3, 0x80f7, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose67:
+ax_pose 30, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose68:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose69:
+ax_pose 3, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose70:
+ax_pose 4, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose71:
+ax_pose 5, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose72:
+ax_pose 29, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose73:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose74:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose75:
+ax_pose 0, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose76:
+ax_pose 1, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose77:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose78:
+ax_pose 2, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose79:
+ax_pose 3, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose80:
+ax_pose 4, 0x01e3, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose81:
+ax_pose 5, 0x01e3, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose82:
+ax_pose 29, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose83:
+ax_pose 6, 0x81e3, 0x90f9, 0x9c00
+ax_pose 7, 0x01eb, 0x10f1, 0x9c08
+ax_pose 8, 0x81f3, 0x10f1, 0x9c09
+ax_pose 9, 0x01db, 0x1101, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose84:
+ax_pose 10, 0x01e3, 0x90e9, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose85:
+ax_pose 11, 0x81e3, 0x90f9, 0x9c00
+ax_pose 12, 0x01eb, 0x10f1, 0x9c08
+ax_pose 13, 0x81f3, 0x10f1, 0x9c09
+ax_pose 14, 0x01db, 0x10f9, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose86:
+ax_pose 15, 0x01e3, 0x90ea, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose87:
+ax_pose 30, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose88:
+ax_pose 16, 0x81e3, 0x90fa, 0x9c00
+ax_pose 17, 0x81eb, 0x10f2, 0x9c08
+ax_pose 18, 0x01fb, 0x10f2, 0x9c0a
+ax_pose 19, 0x01db, 0x1100, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose89:
+ax_pose 20, 0x01e3, 0x90ea, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose90:
+ax_pose 21, 0x81e3, 0x90fa, 0x9c00
+ax_pose 22, 0x81eb, 0x10f2, 0x9c08
+ax_pose 23, 0x01fb, 0x10f2, 0x9c0a
+ax_pose 19, 0x01db, 0x1102, 0x9c0b
+ax_pose 24, 0x01f3, 0x10ea, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose91:
+ax_pose 25, 0x01e3, 0x90e9, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose92:
+ax_pose 31, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose93:
+ax_pose 26, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose94:
+ax_pose 27, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose95:
+ax_pose 26, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose96:
+ax_pose 27, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose97:
+ax_pose 32, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose98:
+ax_pose 16, 0x81e3, 0x80f7, 0x9c00
+ax_pose 17, 0x81eb, 0x0107, 0x9c08
+ax_pose 18, 0x01fb, 0x0107, 0x9c0a
+ax_pose 19, 0x01db, 0x00f8, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose99:
+ax_pose 20, 0x01e3, 0x80f7, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose100:
+ax_pose 21, 0x81e3, 0x80f7, 0x9c00
+ax_pose 22, 0x81eb, 0x0107, 0x9c08
+ax_pose 23, 0x01fb, 0x0107, 0x9c0a
+ax_pose 19, 0x01db, 0x00f7, 0x9c0b
+ax_pose 24, 0x01f3, 0x010f, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose101:
+ax_pose 25, 0x01e3, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose102:
+ax_pose 31, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose103:
+ax_pose 6, 0x81e3, 0x80f8, 0x9c00
+ax_pose 7, 0x01eb, 0x0108, 0x9c08
+ax_pose 8, 0x81f3, 0x0108, 0x9c09
+ax_pose 9, 0x01db, 0x00f8, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose104:
+ax_pose 10, 0x01e3, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose105:
+ax_pose 11, 0x81e3, 0x80f8, 0x9c00
+ax_pose 12, 0x01eb, 0x0108, 0x9c08
+ax_pose 13, 0x81f3, 0x0108, 0x9c09
+ax_pose 14, 0x01db, 0x0100, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose106:
+ax_pose 15, 0x01e3, 0x80f7, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose107:
+ax_pose 30, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose108:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose109:
+ax_pose 3, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose110:
+ax_pose 4, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose111:
+ax_pose 5, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose112:
+ax_pose 29, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose113:
+ax_pose 33, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose114:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose115:
+ax_pose 34, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose116:
+ax_pose 35, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose117:
+ax_pose 36, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose118:
+ax_pose 29, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose119:
+ax_pose 37, 0x01e3, 0x90f4, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose120:
+ax_pose 38, 0x01e1, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose121:
+ax_pose 39, 0x81e3, 0x9101, 0x9c00
+ax_pose 40, 0x81e3, 0x50f9, 0x9c08
+ax_pose 41, 0x81f3, 0x10f1, 0x9c0c
+ax_pose 42, 0x01db, 0x10fd, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose122:
+ax_pose 30, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose123:
+ax_pose 43, 0x41e3, 0x90f3, 0x9c00
+ax_pose 44, 0x41f3, 0x50f3, 0x9c08
+ax_pose 45, 0x41fb, 0x10f3, 0x9c0c
+ax_pose 46, 0x01f2, 0x1113, 0x9c0e
+ax_pose 47, 0x01db, 0x10fb, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose124:
+ax_pose 48, 0x01e2, 0x90f3, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose125:
+ax_pose 49, 0x41e3, 0x90f1, 0x9c00
+ax_pose 50, 0x41f3, 0x50f1, 0x9c08
+ax_pose 51, 0x41fb, 0x10f1, 0x9c0c
+ax_pose 52, 0x01fb, 0x1101, 0x9c0e
+ax_pose 53, 0x01db, 0x10fd, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose126:
+ax_pose 31, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose127:
+ax_pose 54, 0x81e3, 0x90f3, 0x9c00
+ax_pose 55, 0x81e3, 0x5103, 0x9c08
+ax_pose 56, 0x81e3, 0x110b, 0x9c0c
+ax_pose 57, 0x01db, 0x1100, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose128:
+ax_pose 58, 0x01e3, 0x90f4, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose129:
+ax_pose 59, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose130:
+ax_pose 32, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose131:
+ax_pose 60, 0x01e2, 0x80f0, 0x9c00
+ax_pose 61, 0x01da, 0x00f8, 0x9c10
+ax_pose -1, 0x01da, 0x1101, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose132:
+ax_pose 62, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose133:
+ax_pose 49, 0x41e3, 0x80f0, 0x9c00
+ax_pose 50, 0x41f3, 0x40f0, 0x9c08
+ax_pose 51, 0x41fb, 0x0100, 0x9c0c
+ax_pose 52, 0x01fb, 0x00f8, 0x9c0e
+ax_pose 53, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose134:
+ax_pose 31, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose135:
+ax_pose 54, 0x81e3, 0x80fe, 0x9c00
+ax_pose 55, 0x81e3, 0x40f6, 0x9c08
+ax_pose 56, 0x81e3, 0x00ee, 0x9c0c
+ax_pose 57, 0x01db, 0x00f9, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose136:
+ax_pose 58, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose137:
+ax_pose 39, 0x81e3, 0x80f0, 0x9c00
+ax_pose 40, 0x81e3, 0x4100, 0x9c08
+ax_pose 41, 0x81f3, 0x0108, 0x9c0c
+ax_pose 42, 0x01db, 0x00fc, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose138:
+ax_pose 30, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose139:
+ax_pose 43, 0x41e3, 0x80ee, 0x9c00
+ax_pose 44, 0x41f3, 0x40ee, 0x9c08
+ax_pose 45, 0x41fb, 0x00fe, 0x9c0c
+ax_pose 46, 0x01f2, 0x00e6, 0x9c0e
+ax_pose 47, 0x01db, 0x00fe, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose140:
+ax_pose 48, 0x01e2, 0x80ec, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose141:
+ax_pose 36, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose142:
+ax_pose 29, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose143:
+ax_pose 37, 0x01e3, 0x80ed, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose144:
+ax_pose 38, 0x01e1, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose145:
+ax_pose 33, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose146:
+ax_pose 63, 0x01e7, 0x04fd, 0x0c00
+ax_pose -1, 0x01e7, 0x04f9, 0x0c00
+ax_pose 64, 0x41e3, 0x80ee, 0x9c01
+ax_pose 65, 0x41f3, 0x40ee, 0x9c09
+ax_pose 66, 0x01fb, 0x0103, 0x9c0d
+ax_pose 67, 0x01fb, 0x00f3, 0x9c0e
+ax_pose 68, 0x01db, 0x00fe, 0x9c0f
+ax_pose 69, 0x81e3, 0x010e, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose147:
+ax_pose 70, 0x01e7, 0x04fd, 0x2c00
+ax_pose -1, 0x01e7, 0x04f9, 0x2c00
+ax_pose 64, 0x41e3, 0x80ee, 0x9c01
+ax_pose 65, 0x41f3, 0x40ee, 0x9c09
+ax_pose 66, 0x01fb, 0x0103, 0x9c0d
+ax_pose 67, 0x01fb, 0x00f3, 0x9c0e
+ax_pose 68, 0x01db, 0x00fe, 0x9c0f
+ax_pose 69, 0x81e3, 0x010e, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose148:
+ax_pose 71, 0x01e3, 0x44f9, 0x2c00
+ax_pose -1, 0x01e3, 0x44f5, 0x2c00
+ax_pose 64, 0x41e3, 0x80ee, 0x9c04
+ax_pose 65, 0x41f3, 0x40ee, 0x9c0c
+ax_pose 66, 0x01fb, 0x0103, 0x9c10
+ax_pose 67, 0x01fb, 0x00f3, 0x9c11
+ax_pose 68, 0x01db, 0x00fe, 0x9c12
+ax_pose 69, 0x81e3, 0x010e, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose149:
+ax_pose 72, 0x01e3, 0x44f9, 0x2c00
+ax_pose -1, 0x01e3, 0x44f5, 0x2c00
+ax_pose 64, 0x41e3, 0x80ee, 0x9c04
+ax_pose 65, 0x41f3, 0x40ee, 0x9c0c
+ax_pose 66, 0x01fb, 0x0103, 0x9c10
+ax_pose 67, 0x01fb, 0x00f3, 0x9c11
+ax_pose 68, 0x01db, 0x00fe, 0x9c12
+ax_pose 69, 0x81e3, 0x010e, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose150:
+ax_pose 73, 0x01e3, 0x44f9, 0x2c00
+ax_pose -1, 0x01e3, 0x44f5, 0x2c00
+ax_pose 64, 0x41e3, 0x80ee, 0x9c04
+ax_pose 65, 0x41f3, 0x40ee, 0x9c0c
+ax_pose 66, 0x01fb, 0x0103, 0x9c10
+ax_pose 67, 0x01fb, 0x00f3, 0x9c11
+ax_pose 68, 0x01db, 0x00fe, 0x9c12
+ax_pose 69, 0x81e3, 0x010e, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose151:
+ax_pose 74, 0x01e3, 0x44f9, 0x2c00
+ax_pose -1, 0x01e3, 0x44f5, 0x2c00
+ax_pose 64, 0x41e3, 0x80ee, 0x9c04
+ax_pose 65, 0x41f3, 0x40ee, 0x9c0c
+ax_pose 66, 0x01fb, 0x0103, 0x9c10
+ax_pose 67, 0x01fb, 0x00f3, 0x9c11
+ax_pose 68, 0x01db, 0x00fe, 0x9c12
+ax_pose 69, 0x81e3, 0x010e, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose152:
+ax_pose 64, 0x41e3, 0x80ee, 0x9c00
+ax_pose 65, 0x41f3, 0x40ee, 0x9c08
+ax_pose 66, 0x01fb, 0x0103, 0x9c0c
+ax_pose 67, 0x01fb, 0x00f3, 0x9c0d
+ax_pose 68, 0x01db, 0x00fe, 0x9c0e
+ax_pose 69, 0x81e3, 0x010e, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose153:
+ax_pose 36, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose154:
+ax_pose 63, 0x01e7, 0x04fe, 0x2c00
+ax_pose -1, 0x01e6, 0x0501, 0x2c00
+ax_pose 75, 0x41e3, 0x90f3, 0x9c01
+ax_pose 76, 0x41f3, 0x10fc, 0x9c09
+ax_pose 77, 0x01f3, 0x10f4, 0x9c0b
+ax_pose 78, 0x41fb, 0x10f3, 0x9c0c
+ax_pose 79, 0x01fb, 0x1103, 0x9c0e
+ax_pose 80, 0x01db, 0x1103, 0x9c0f
+ax_pose 81, 0x01db, 0x10fb, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose155:
+ax_pose 70, 0x01e7, 0x04fe, 0x2c00
+ax_pose -1, 0x01e6, 0x0501, 0x2c00
+ax_pose 75, 0x41e3, 0x90f3, 0x9c01
+ax_pose 76, 0x41f3, 0x10fc, 0x9c09
+ax_pose 77, 0x01f3, 0x10f4, 0x9c0b
+ax_pose 78, 0x41fb, 0x10f3, 0x9c0c
+ax_pose 79, 0x01fb, 0x1103, 0x9c0e
+ax_pose 80, 0x01db, 0x1103, 0x9c0f
+ax_pose 81, 0x01db, 0x10fb, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose156:
+ax_pose 71, 0x01e3, 0x44fa, 0x2c00
+ax_pose -1, 0x01e2, 0x44fd, 0x2c00
+ax_pose 75, 0x41e3, 0x90f3, 0x9c04
+ax_pose 76, 0x41f3, 0x10fc, 0x9c0c
+ax_pose 77, 0x01f3, 0x10f4, 0x9c0e
+ax_pose 78, 0x41fb, 0x10f3, 0x9c0f
+ax_pose 79, 0x01fb, 0x1103, 0x9c11
+ax_pose 80, 0x01db, 0x1103, 0x9c12
+ax_pose 81, 0x01db, 0x10fb, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose157:
+ax_pose 72, 0x01e3, 0x44fa, 0x2c00
+ax_pose -1, 0x01e2, 0x44fd, 0x2c00
+ax_pose 75, 0x41e3, 0x90f3, 0x9c04
+ax_pose 76, 0x41f3, 0x10fc, 0x9c0c
+ax_pose 77, 0x01f3, 0x10f4, 0x9c0e
+ax_pose 78, 0x41fb, 0x10f3, 0x9c0f
+ax_pose 79, 0x01fb, 0x1103, 0x9c11
+ax_pose 80, 0x01db, 0x1103, 0x9c12
+ax_pose 81, 0x01db, 0x10fb, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose158:
+ax_pose 73, 0x01e3, 0x44fa, 0x2c00
+ax_pose -1, 0x01e2, 0x44fd, 0x2c00
+ax_pose 75, 0x41e3, 0x90f3, 0x9c04
+ax_pose 76, 0x41f3, 0x10fc, 0x9c0c
+ax_pose 77, 0x01f3, 0x10f4, 0x9c0e
+ax_pose 78, 0x41fb, 0x10f3, 0x9c0f
+ax_pose 79, 0x01fb, 0x1103, 0x9c11
+ax_pose 80, 0x01db, 0x1103, 0x9c12
+ax_pose 81, 0x01db, 0x10fb, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose159:
+ax_pose 74, 0x01e3, 0x44fa, 0x2c00
+ax_pose -1, 0x01e2, 0x44fd, 0x2c00
+ax_pose 75, 0x41e3, 0x90f3, 0x9c04
+ax_pose 76, 0x41f3, 0x10fc, 0x9c0c
+ax_pose 77, 0x01f3, 0x10f4, 0x9c0e
+ax_pose 78, 0x41fb, 0x10f3, 0x9c0f
+ax_pose 79, 0x01fb, 0x1103, 0x9c11
+ax_pose 80, 0x01db, 0x1103, 0x9c12
+ax_pose 81, 0x01db, 0x10fb, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose160:
+ax_pose 75, 0x41e3, 0x90f3, 0x9c00
+ax_pose 76, 0x41f3, 0x10fc, 0x9c08
+ax_pose 77, 0x01f3, 0x10f4, 0x9c0a
+ax_pose 78, 0x41fb, 0x10f3, 0x9c0b
+ax_pose 79, 0x01fb, 0x1103, 0x9c0d
+ax_pose 80, 0x01db, 0x1103, 0x9c0e
+ax_pose 81, 0x01db, 0x10fb, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose161:
+ax_pose 39, 0x81e3, 0x9101, 0x9c00
+ax_pose 40, 0x81e3, 0x50f9, 0x9c08
+ax_pose 41, 0x81f3, 0x10f1, 0x9c0c
+ax_pose 42, 0x01db, 0x10fd, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose162:
+ax_pose 63, 0x01e6, 0x0501, 0x2c00
+ax_pose 82, 0x81e3, 0x90f4, 0x9c01
+ax_pose 83, 0x81e3, 0x1104, 0x9c09
+ax_pose 84, 0x01f3, 0x1104, 0x9c0b
+ax_pose -1, 0x01e5, 0x0505, 0x2c00
+ax_pose 85, 0x01e3, 0x1108, 0x9c0c
+ax_pose 86, 0x41db, 0x10fc, 0x9c0d
+ax_pose_terminator
+sDeoxysAttackPose163:
+ax_pose 70, 0x01e6, 0x0501, 0x2c00
+ax_pose 82, 0x81e3, 0x90f4, 0x9c01
+ax_pose 83, 0x81e3, 0x1104, 0x9c09
+ax_pose 84, 0x01f3, 0x1104, 0x9c0b
+ax_pose -1, 0x01e5, 0x0505, 0x2c00
+ax_pose 85, 0x01e3, 0x1108, 0x9c0c
+ax_pose 86, 0x41db, 0x10fc, 0x9c0d
+ax_pose_terminator
+sDeoxysAttackPose164:
+ax_pose 71, 0x01e2, 0x44fd, 0x2c00
+ax_pose 82, 0x81e3, 0x90f4, 0x9c04
+ax_pose 83, 0x81e3, 0x1104, 0x9c0c
+ax_pose 84, 0x01f3, 0x1104, 0x9c0e
+ax_pose -1, 0x01e1, 0x4501, 0x2c00
+ax_pose 85, 0x01e3, 0x1108, 0x9c0f
+ax_pose 86, 0x41db, 0x10fc, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose165:
+ax_pose 72, 0x01e2, 0x44fd, 0x2c00
+ax_pose 82, 0x81e3, 0x90f4, 0x9c04
+ax_pose 83, 0x81e3, 0x1104, 0x9c0c
+ax_pose 84, 0x01f3, 0x1104, 0x9c0e
+ax_pose -1, 0x01e1, 0x4501, 0x2c00
+ax_pose 85, 0x01e3, 0x1108, 0x9c0f
+ax_pose 86, 0x41db, 0x10fc, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose166:
+ax_pose 73, 0x01e2, 0x44fd, 0x2c00
+ax_pose 82, 0x81e3, 0x90f4, 0x9c04
+ax_pose 83, 0x81e3, 0x1104, 0x9c0c
+ax_pose 84, 0x01f3, 0x1104, 0x9c0e
+ax_pose -1, 0x01e1, 0x4501, 0x2c00
+ax_pose 85, 0x01e3, 0x1108, 0x9c0f
+ax_pose 86, 0x41db, 0x10fc, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose167:
+ax_pose 74, 0x01e2, 0x44fd, 0x2c00
+ax_pose 82, 0x81e3, 0x90f4, 0x9c04
+ax_pose 83, 0x81e3, 0x1104, 0x9c0c
+ax_pose 84, 0x01f3, 0x1104, 0x9c0e
+ax_pose -1, 0x01e1, 0x4501, 0x2c00
+ax_pose 85, 0x01e3, 0x1108, 0x9c0f
+ax_pose 86, 0x41db, 0x10fc, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose168:
+ax_pose 82, 0x81e3, 0x90f4, 0x9c00
+ax_pose 83, 0x81e3, 0x1104, 0x9c08
+ax_pose 84, 0x01f3, 0x1104, 0x9c0a
+ax_pose 85, 0x01e3, 0x1108, 0x9c0b
+ax_pose 86, 0x41db, 0x10fc, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose169:
+ax_pose 49, 0x41e3, 0x90f1, 0x9c00
+ax_pose 50, 0x41f3, 0x50f1, 0x9c08
+ax_pose 51, 0x41fb, 0x10f1, 0x9c0c
+ax_pose 52, 0x01fb, 0x1101, 0x9c0e
+ax_pose 53, 0x01db, 0x10fd, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose170:
+ax_pose 87, 0x41e3, 0x90f4, 0x9c00
+ax_pose 88, 0x41f3, 0x10fd, 0x9c08
+ax_pose 89, 0x01f3, 0x10f5, 0x9c0a
+ax_pose 90, 0x41fb, 0x10f7, 0x9c0b
+ax_pose 91, 0x41db, 0x10fc, 0x9c0d
+ax_pose 92, 0x01db, 0x10f4, 0x9c0f
+ax_pose 63, 0x01e3, 0x0505, 0x2c10
+ax_pose -1, 0x01e0, 0x0500, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose171:
+ax_pose 87, 0x41e3, 0x90f4, 0x9c00
+ax_pose 88, 0x41f3, 0x10fd, 0x9c08
+ax_pose 89, 0x01f3, 0x10f5, 0x9c0a
+ax_pose 90, 0x41fb, 0x10f7, 0x9c0b
+ax_pose 91, 0x41db, 0x10fc, 0x9c0d
+ax_pose 92, 0x01db, 0x10f4, 0x9c0f
+ax_pose 70, 0x01e3, 0x0505, 0x2c10
+ax_pose -1, 0x01e0, 0x0500, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose172:
+ax_pose 87, 0x41e3, 0x90f4, 0x9c00
+ax_pose 88, 0x41f3, 0x10fd, 0x9c08
+ax_pose 89, 0x01f3, 0x10f5, 0x9c0a
+ax_pose 90, 0x41fb, 0x10f7, 0x9c0b
+ax_pose 91, 0x41db, 0x10fc, 0x9c0d
+ax_pose 92, 0x01db, 0x10f4, 0x9c0f
+ax_pose 71, 0x01df, 0x4501, 0x2c10
+ax_pose -1, 0x01dc, 0x44fc, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose173:
+ax_pose 87, 0x41e3, 0x90f4, 0x9c00
+ax_pose 88, 0x41f3, 0x10fd, 0x9c08
+ax_pose 89, 0x01f3, 0x10f5, 0x9c0a
+ax_pose 90, 0x41fb, 0x10f7, 0x9c0b
+ax_pose 91, 0x41db, 0x10fc, 0x9c0d
+ax_pose 92, 0x01db, 0x10f4, 0x9c0f
+ax_pose 72, 0x01df, 0x4501, 0x2c10
+ax_pose -1, 0x01dc, 0x44fc, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose174:
+ax_pose 87, 0x41e3, 0x90f4, 0x9c00
+ax_pose 88, 0x41f3, 0x10fd, 0x9c08
+ax_pose 89, 0x01f3, 0x10f5, 0x9c0a
+ax_pose 90, 0x41fb, 0x10f7, 0x9c0b
+ax_pose 91, 0x41db, 0x10fc, 0x9c0d
+ax_pose 92, 0x01db, 0x10f4, 0x9c0f
+ax_pose 73, 0x01df, 0x4501, 0x2c10
+ax_pose -1, 0x01dc, 0x44fc, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose175:
+ax_pose 87, 0x41e3, 0x90f4, 0x9c00
+ax_pose 88, 0x41f3, 0x10fd, 0x9c08
+ax_pose 89, 0x01f3, 0x10f5, 0x9c0a
+ax_pose 90, 0x41fb, 0x10f7, 0x9c0b
+ax_pose 91, 0x41db, 0x10fc, 0x9c0d
+ax_pose 92, 0x01db, 0x10f4, 0x9c0f
+ax_pose 74, 0x01df, 0x4501, 0x2c10
+ax_pose -1, 0x01dc, 0x44fc, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose176:
+ax_pose 87, 0x41e3, 0x90f4, 0x9c00
+ax_pose 88, 0x41f3, 0x10fd, 0x9c08
+ax_pose 89, 0x01f3, 0x10f5, 0x9c0a
+ax_pose 90, 0x41fb, 0x10f7, 0x9c0b
+ax_pose 91, 0x41db, 0x10fc, 0x9c0d
+ax_pose 92, 0x01db, 0x10f4, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose177:
+ax_pose 59, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose178:
+ax_pose 93, 0x41e2, 0x80f1, 0x9c00
+ax_pose 94, 0x41f2, 0x40f1, 0x9c08
+ax_pose 95, 0x41fa, 0x00f4, 0x9c0c
+ax_pose 96, 0x01fa, 0x0104, 0x9c0e
+ax_pose 97, 0x01da, 0x00fa, 0x9c0f
+ax_pose 63, 0x01e2, 0x04ff, 0x2c10
+ax_pose -1, 0x01e2, 0x04fa, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose179:
+ax_pose 93, 0x41e2, 0x80f1, 0x9c00
+ax_pose 94, 0x41f2, 0x40f1, 0x9c08
+ax_pose 95, 0x41fa, 0x00f4, 0x9c0c
+ax_pose 96, 0x01fa, 0x0104, 0x9c0e
+ax_pose 97, 0x01da, 0x00fa, 0x9c0f
+ax_pose 70, 0x01e2, 0x04ff, 0x2c10
+ax_pose -1, 0x01e2, 0x04fa, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose180:
+ax_pose 93, 0x41e2, 0x80f1, 0x9c00
+ax_pose 94, 0x41f2, 0x40f1, 0x9c08
+ax_pose 95, 0x41fa, 0x00f4, 0x9c0c
+ax_pose 96, 0x01fa, 0x0104, 0x9c0e
+ax_pose 97, 0x01da, 0x00fa, 0x9c0f
+ax_pose 71, 0x01de, 0x44fb, 0x2c10
+ax_pose -1, 0x01de, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose181:
+ax_pose 93, 0x41e2, 0x80f1, 0x9c00
+ax_pose 94, 0x41f2, 0x40f1, 0x9c08
+ax_pose 95, 0x41fa, 0x00f4, 0x9c0c
+ax_pose 96, 0x01fa, 0x0104, 0x9c0e
+ax_pose 97, 0x01da, 0x00fa, 0x9c0f
+ax_pose 72, 0x01de, 0x44fb, 0x2c10
+ax_pose -1, 0x01de, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose182:
+ax_pose 93, 0x41e2, 0x80f1, 0x9c00
+ax_pose 94, 0x41f2, 0x40f1, 0x9c08
+ax_pose 95, 0x41fa, 0x00f4, 0x9c0c
+ax_pose 96, 0x01fa, 0x0104, 0x9c0e
+ax_pose 97, 0x01da, 0x00fa, 0x9c0f
+ax_pose 73, 0x01de, 0x44fb, 0x2c10
+ax_pose -1, 0x01de, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose183:
+ax_pose 93, 0x41e2, 0x80f1, 0x9c00
+ax_pose 94, 0x41f2, 0x40f1, 0x9c08
+ax_pose 95, 0x41fa, 0x00f4, 0x9c0c
+ax_pose 96, 0x01fa, 0x0104, 0x9c0e
+ax_pose 97, 0x01da, 0x00fa, 0x9c0f
+ax_pose 74, 0x01de, 0x44fb, 0x2c10
+ax_pose -1, 0x01de, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose184:
+ax_pose 93, 0x41e2, 0x80f1, 0x9c00
+ax_pose 94, 0x41f2, 0x40f1, 0x9c08
+ax_pose 95, 0x41fa, 0x00f4, 0x9c0c
+ax_pose 96, 0x01fa, 0x0104, 0x9c0e
+ax_pose 97, 0x01da, 0x00fa, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose185:
+ax_pose 49, 0x41e3, 0x80f0, 0x9c00
+ax_pose 50, 0x41f3, 0x40f0, 0x9c08
+ax_pose 51, 0x41fb, 0x0100, 0x9c0c
+ax_pose 52, 0x01fb, 0x00f8, 0x9c0e
+ax_pose 53, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose186:
+ax_pose 87, 0x41e3, 0x80ed, 0x9c00
+ax_pose 88, 0x41f3, 0x00f4, 0x9c08
+ax_pose 89, 0x01f3, 0x0104, 0x9c0a
+ax_pose 90, 0x41fb, 0x00fa, 0x9c0b
+ax_pose 91, 0x41db, 0x00f5, 0x9c0d
+ax_pose 92, 0x01db, 0x0105, 0x9c0f
+ax_pose 63, 0x01e3, 0x04f3, 0x2c10
+ax_pose -1, 0x01e0, 0x04f8, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose187:
+ax_pose 87, 0x41e3, 0x80ed, 0x9c00
+ax_pose 88, 0x41f3, 0x00f4, 0x9c08
+ax_pose 89, 0x01f3, 0x0104, 0x9c0a
+ax_pose 90, 0x41fb, 0x00fa, 0x9c0b
+ax_pose 91, 0x41db, 0x00f5, 0x9c0d
+ax_pose 92, 0x01db, 0x0105, 0x9c0f
+ax_pose 70, 0x01e3, 0x04f3, 0x2c10
+ax_pose -1, 0x01e0, 0x04f8, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose188:
+ax_pose 87, 0x41e3, 0x80ed, 0x9c00
+ax_pose 88, 0x41f3, 0x00f4, 0x9c08
+ax_pose 89, 0x01f3, 0x0104, 0x9c0a
+ax_pose 90, 0x41fb, 0x00fa, 0x9c0b
+ax_pose 91, 0x41db, 0x00f5, 0x9c0d
+ax_pose 92, 0x01db, 0x0105, 0x9c0f
+ax_pose 71, 0x01df, 0x44ef, 0x2c10
+ax_pose -1, 0x01dc, 0x44f4, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose189:
+ax_pose 87, 0x41e3, 0x80ed, 0x9c00
+ax_pose 88, 0x41f3, 0x00f4, 0x9c08
+ax_pose 89, 0x01f3, 0x0104, 0x9c0a
+ax_pose 90, 0x41fb, 0x00fa, 0x9c0b
+ax_pose 91, 0x41db, 0x00f5, 0x9c0d
+ax_pose 92, 0x01db, 0x0105, 0x9c0f
+ax_pose 72, 0x01df, 0x44ef, 0x2c10
+ax_pose -1, 0x01dc, 0x44f4, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose190:
+ax_pose 87, 0x41e3, 0x80ed, 0x9c00
+ax_pose 88, 0x41f3, 0x00f4, 0x9c08
+ax_pose 89, 0x01f3, 0x0104, 0x9c0a
+ax_pose 90, 0x41fb, 0x00fa, 0x9c0b
+ax_pose 91, 0x41db, 0x00f5, 0x9c0d
+ax_pose 92, 0x01db, 0x0105, 0x9c0f
+ax_pose 73, 0x01df, 0x44ef, 0x2c10
+ax_pose -1, 0x01dc, 0x44f4, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose191:
+ax_pose 87, 0x41e3, 0x80ed, 0x9c00
+ax_pose 88, 0x41f3, 0x00f4, 0x9c08
+ax_pose 89, 0x01f3, 0x0104, 0x9c0a
+ax_pose 90, 0x41fb, 0x00fa, 0x9c0b
+ax_pose 91, 0x41db, 0x00f5, 0x9c0d
+ax_pose 92, 0x01db, 0x0105, 0x9c0f
+ax_pose 74, 0x01df, 0x44ef, 0x2c10
+ax_pose -1, 0x01dc, 0x44f4, 0x2c10
+ax_pose_terminator
+sDeoxysAttackPose192:
+ax_pose 87, 0x41e3, 0x80ed, 0x9c00
+ax_pose 88, 0x41f3, 0x00f4, 0x9c08
+ax_pose 89, 0x01f3, 0x0104, 0x9c0a
+ax_pose 90, 0x41fb, 0x00fa, 0x9c0b
+ax_pose 91, 0x41db, 0x00f5, 0x9c0d
+ax_pose 92, 0x01db, 0x0105, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose193:
+ax_pose 39, 0x81e3, 0x80f0, 0x9c00
+ax_pose 40, 0x81e3, 0x4100, 0x9c08
+ax_pose 41, 0x81f3, 0x0108, 0x9c0c
+ax_pose 42, 0x01db, 0x00fc, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose194:
+ax_pose 63, 0x01e6, 0x04f7, 0x2c00
+ax_pose 82, 0x81e3, 0x80fd, 0x9c01
+ax_pose 83, 0x81e3, 0x00f5, 0x9c09
+ax_pose 84, 0x01f3, 0x00f5, 0x9c0b
+ax_pose -1, 0x01e5, 0x04f3, 0x2c00
+ax_pose 85, 0x01e3, 0x00f1, 0x9c0c
+ax_pose 86, 0x41db, 0x00f5, 0x9c0d
+ax_pose_terminator
+sDeoxysAttackPose195:
+ax_pose 70, 0x01e6, 0x04f7, 0x2c00
+ax_pose 82, 0x81e3, 0x80fd, 0x9c01
+ax_pose 83, 0x81e3, 0x00f5, 0x9c09
+ax_pose 84, 0x01f3, 0x00f5, 0x9c0b
+ax_pose -1, 0x01e5, 0x04f3, 0x2c00
+ax_pose 85, 0x01e3, 0x00f1, 0x9c0c
+ax_pose 86, 0x41db, 0x00f5, 0x9c0d
+ax_pose_terminator
+sDeoxysAttackPose196:
+ax_pose 71, 0x01e2, 0x44f3, 0x2c00
+ax_pose 82, 0x81e3, 0x80fd, 0x9c04
+ax_pose 83, 0x81e3, 0x00f5, 0x9c0c
+ax_pose 84, 0x01f3, 0x00f5, 0x9c0e
+ax_pose -1, 0x01e1, 0x44ef, 0x2c00
+ax_pose 85, 0x01e3, 0x00f1, 0x9c0f
+ax_pose 86, 0x41db, 0x00f5, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose197:
+ax_pose 72, 0x01e2, 0x44f3, 0x2c00
+ax_pose 82, 0x81e3, 0x80fd, 0x9c04
+ax_pose 83, 0x81e3, 0x00f5, 0x9c0c
+ax_pose 84, 0x01f3, 0x00f5, 0x9c0e
+ax_pose -1, 0x01e1, 0x44ef, 0x2c00
+ax_pose 85, 0x01e3, 0x00f1, 0x9c0f
+ax_pose 86, 0x41db, 0x00f5, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose198:
+ax_pose 73, 0x01e2, 0x44f3, 0x2c00
+ax_pose 82, 0x81e3, 0x80fd, 0x9c04
+ax_pose 83, 0x81e3, 0x00f5, 0x9c0c
+ax_pose 84, 0x01f3, 0x00f5, 0x9c0e
+ax_pose -1, 0x01e1, 0x44ef, 0x2c00
+ax_pose 85, 0x01e3, 0x00f1, 0x9c0f
+ax_pose 86, 0x41db, 0x00f5, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose199:
+ax_pose 74, 0x01e2, 0x44f3, 0x2c00
+ax_pose 82, 0x81e3, 0x80fd, 0x9c04
+ax_pose 83, 0x81e3, 0x00f5, 0x9c0c
+ax_pose 84, 0x01f3, 0x00f5, 0x9c0e
+ax_pose -1, 0x01e1, 0x44ef, 0x2c00
+ax_pose 85, 0x01e3, 0x00f1, 0x9c0f
+ax_pose 86, 0x41db, 0x00f5, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose200:
+ax_pose 82, 0x81e3, 0x80fd, 0x9c00
+ax_pose 83, 0x81e3, 0x00f5, 0x9c08
+ax_pose 84, 0x01f3, 0x00f5, 0x9c0a
+ax_pose 85, 0x01e3, 0x00f1, 0x9c0b
+ax_pose 86, 0x41db, 0x00f5, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose201:
+ax_pose 36, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose202:
+ax_pose 63, 0x01e7, 0x04fa, 0x2c00
+ax_pose -1, 0x01e6, 0x04f6, 0x2c00
+ax_pose 75, 0x41e3, 0x80ee, 0x9c01
+ax_pose 76, 0x41f3, 0x00f5, 0x9c09
+ax_pose 77, 0x01f3, 0x0105, 0x9c0b
+ax_pose 78, 0x41fb, 0x00fe, 0x9c0c
+ax_pose 79, 0x01fb, 0x00f6, 0x9c0e
+ax_pose 80, 0x01db, 0x00f6, 0x9c0f
+ax_pose 81, 0x01db, 0x00fe, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose203:
+ax_pose 70, 0x01e7, 0x04fa, 0x2c00
+ax_pose -1, 0x01e6, 0x04f6, 0x2c00
+ax_pose 75, 0x41e3, 0x80ee, 0x9c01
+ax_pose 76, 0x41f3, 0x00f5, 0x9c09
+ax_pose 77, 0x01f3, 0x0105, 0x9c0b
+ax_pose 78, 0x41fb, 0x00fe, 0x9c0c
+ax_pose 79, 0x01fb, 0x00f6, 0x9c0e
+ax_pose 80, 0x01db, 0x00f6, 0x9c0f
+ax_pose 81, 0x01db, 0x00fe, 0x9c10
+ax_pose_terminator
+sDeoxysAttackPose204:
+ax_pose 71, 0x01e3, 0x44f6, 0x2c00
+ax_pose -1, 0x01e2, 0x44f2, 0x2c00
+ax_pose 75, 0x41e3, 0x80ee, 0x9c04
+ax_pose 76, 0x41f3, 0x00f5, 0x9c0c
+ax_pose 77, 0x01f3, 0x0105, 0x9c0e
+ax_pose 78, 0x41fb, 0x00fe, 0x9c0f
+ax_pose 79, 0x01fb, 0x00f6, 0x9c11
+ax_pose 80, 0x01db, 0x00f6, 0x9c12
+ax_pose 81, 0x01db, 0x00fe, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose205:
+ax_pose 72, 0x01e3, 0x44f6, 0x2c00
+ax_pose -1, 0x01e2, 0x44f2, 0x2c00
+ax_pose 75, 0x41e3, 0x80ee, 0x9c04
+ax_pose 76, 0x41f3, 0x00f5, 0x9c0c
+ax_pose 77, 0x01f3, 0x0105, 0x9c0e
+ax_pose 78, 0x41fb, 0x00fe, 0x9c0f
+ax_pose 79, 0x01fb, 0x00f6, 0x9c11
+ax_pose 80, 0x01db, 0x00f6, 0x9c12
+ax_pose 81, 0x01db, 0x00fe, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose206:
+ax_pose 73, 0x01e3, 0x44f6, 0x2c00
+ax_pose -1, 0x01e2, 0x44f2, 0x2c00
+ax_pose 75, 0x41e3, 0x80ee, 0x9c04
+ax_pose 76, 0x41f3, 0x00f5, 0x9c0c
+ax_pose 77, 0x01f3, 0x0105, 0x9c0e
+ax_pose 78, 0x41fb, 0x00fe, 0x9c0f
+ax_pose 79, 0x01fb, 0x00f6, 0x9c11
+ax_pose 80, 0x01db, 0x00f6, 0x9c12
+ax_pose 81, 0x01db, 0x00fe, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose207:
+ax_pose 74, 0x01e3, 0x44f6, 0x2c00
+ax_pose -1, 0x01e2, 0x44f2, 0x2c00
+ax_pose 75, 0x41e3, 0x80ee, 0x9c04
+ax_pose 76, 0x41f3, 0x00f5, 0x9c0c
+ax_pose 77, 0x01f3, 0x0105, 0x9c0e
+ax_pose 78, 0x41fb, 0x00fe, 0x9c0f
+ax_pose 79, 0x01fb, 0x00f6, 0x9c11
+ax_pose 80, 0x01db, 0x00f6, 0x9c12
+ax_pose 81, 0x01db, 0x00fe, 0x9c13
+ax_pose_terminator
+sDeoxysAttackPose208:
+ax_pose 75, 0x41e3, 0x80ee, 0x9c00
+ax_pose 76, 0x41f3, 0x00f5, 0x9c08
+ax_pose 77, 0x01f3, 0x0105, 0x9c0a
+ax_pose 78, 0x41fb, 0x00fe, 0x9c0b
+ax_pose 79, 0x01fb, 0x00f6, 0x9c0d
+ax_pose 80, 0x01db, 0x00f6, 0x9c0e
+ax_pose 81, 0x01db, 0x00fe, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose209:
+ax_pose 98, 0x01e2, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose210:
+ax_pose 99, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose211:
+ax_pose 35, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose212:
+ax_pose 38, 0x01e1, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose213:
+ax_pose 48, 0x01e2, 0x90f4, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose214:
+ax_pose 58, 0x01e3, 0x90f4, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose215:
+ax_pose 62, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose216:
+ax_pose 58, 0x01e3, 0x80ec, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose217:
+ax_pose 48, 0x01e2, 0x80ec, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose218:
+ax_pose 38, 0x01e1, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose219:
+ax_pose 33, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose220:
+ax_pose 100, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose221:
+ax_pose 33, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose222:
+ax_pose 100, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose223:
+ax_pose 36, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose224:
+ax_pose 101, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose225:
+ax_pose 102, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose226:
+ax_pose 103, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose227:
+ax_pose 39, 0x81e3, 0x9101, 0x9c00
+ax_pose 40, 0x81e3, 0x50f9, 0x9c08
+ax_pose 41, 0x81f3, 0x10f1, 0x9c0c
+ax_pose 42, 0x01db, 0x10fd, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose228:
+ax_pose 104, 0x81e3, 0x90fb, 0x9c00
+ax_pose 105, 0x81eb, 0x10f3, 0x9c08
+ax_pose 106, 0x01fb, 0x10f3, 0x9c0a
+ax_pose 107, 0x01db, 0x10fb, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose229:
+ax_pose 108, 0x81e3, 0x90fb, 0x9c00
+ax_pose 109, 0x81eb, 0x10f3, 0x9c08
+ax_pose 107, 0x01db, 0x10fb, 0x9c0a
+ax_pose_terminator
+sDeoxysAttackPose230:
+ax_pose 110, 0x81e3, 0x90fb, 0x9c00
+ax_pose 111, 0x81eb, 0x10f3, 0x9c08
+ax_pose 112, 0x01fb, 0x10f3, 0x9c0a
+ax_pose 107, 0x01db, 0x10fb, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose231:
+ax_pose 49, 0x41e3, 0x90f1, 0x9c00
+ax_pose 50, 0x41f3, 0x50f1, 0x9c08
+ax_pose 51, 0x41fb, 0x10f1, 0x9c0c
+ax_pose 52, 0x01fb, 0x1101, 0x9c0e
+ax_pose 53, 0x01db, 0x10fd, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose232:
+ax_pose 113, 0x81e3, 0x90fe, 0x9c00
+ax_pose 114, 0x81e3, 0x50f6, 0x9c08
+ax_pose 115, 0x01db, 0x10fe, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose233:
+ax_pose 116, 0x81e3, 0x90fe, 0x9c00
+ax_pose 117, 0x81e3, 0x50f6, 0x9c08
+ax_pose 115, 0x01db, 0x10fe, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose234:
+ax_pose 118, 0x81e3, 0x90fd, 0x9c00
+ax_pose 119, 0x81e3, 0x50f5, 0x9c08
+ax_pose 115, 0x01db, 0x10fe, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose235:
+ax_pose 59, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose236:
+ax_pose 120, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose237:
+ax_pose 59, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose238:
+ax_pose 120, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose239:
+ax_pose 49, 0x41e3, 0x80f0, 0x9c00
+ax_pose 50, 0x41f3, 0x40f0, 0x9c08
+ax_pose 51, 0x41fb, 0x0100, 0x9c0c
+ax_pose 52, 0x01fb, 0x00f8, 0x9c0e
+ax_pose 53, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose240:
+ax_pose 113, 0x81e3, 0x80f3, 0x9c00
+ax_pose 114, 0x81e3, 0x4103, 0x9c08
+ax_pose 115, 0x01db, 0x00fb, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose241:
+ax_pose 116, 0x81e3, 0x80f3, 0x9c00
+ax_pose 117, 0x81e3, 0x4103, 0x9c08
+ax_pose 115, 0x01db, 0x00fb, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose242:
+ax_pose 118, 0x81e3, 0x80f4, 0x9c00
+ax_pose 119, 0x81e3, 0x4104, 0x9c08
+ax_pose 115, 0x01db, 0x00fb, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose243:
+ax_pose 39, 0x81e3, 0x80f0, 0x9c00
+ax_pose 40, 0x81e3, 0x4100, 0x9c08
+ax_pose 41, 0x81f3, 0x0108, 0x9c0c
+ax_pose 42, 0x01db, 0x00fc, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose244:
+ax_pose 104, 0x81e3, 0x80f6, 0x9c00
+ax_pose 105, 0x81eb, 0x0106, 0x9c08
+ax_pose 106, 0x01fb, 0x0106, 0x9c0a
+ax_pose 107, 0x01db, 0x00fe, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose245:
+ax_pose 108, 0x81e3, 0x80f6, 0x9c00
+ax_pose 109, 0x81eb, 0x0106, 0x9c08
+ax_pose 107, 0x01db, 0x00ff, 0x9c0a
+ax_pose_terminator
+sDeoxysAttackPose246:
+ax_pose 110, 0x81e3, 0x80f6, 0x9c00
+ax_pose 111, 0x81eb, 0x0106, 0x9c08
+ax_pose 112, 0x01fb, 0x0106, 0x9c0a
+ax_pose 107, 0x01db, 0x00fe, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose247:
+ax_pose 36, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose248:
+ax_pose 101, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose249:
+ax_pose 102, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose250:
+ax_pose 103, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose251:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose252:
+ax_pose 29, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose253:
+ax_pose 30, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose254:
+ax_pose 31, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose255:
+ax_pose 32, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose256:
+ax_pose 31, 0x01e3, 0x90f3, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose257:
+ax_pose 30, 0x01e3, 0x90f3, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose258:
+ax_pose 29, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose259:
+ax_pose 35, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose260:
+ax_pose 38, 0x01e1, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose261:
+ax_pose 48, 0x01e2, 0x90f5, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose262:
+ax_pose 58, 0x01e2, 0x90f4, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose263:
+ax_pose 62, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose264:
+ax_pose 58, 0x01e2, 0x80ed, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose265:
+ax_pose 48, 0x01e2, 0x80eb, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose266:
+ax_pose 38, 0x01e1, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose267:
+ax_pose 33, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose268:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose269:
+ax_pose 35, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose270:
+ax_pose 36, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose271:
+ax_pose 29, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose272:
+ax_pose 38, 0x01e1, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose273:
+ax_pose 39, 0x81e3, 0x9101, 0x9c00
+ax_pose 40, 0x81e3, 0x50f9, 0x9c08
+ax_pose 41, 0x81f3, 0x10f1, 0x9c0c
+ax_pose 42, 0x01db, 0x10fd, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose274:
+ax_pose 30, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose275:
+ax_pose 48, 0x01e2, 0x90f3, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose276:
+ax_pose 49, 0x41e3, 0x90f1, 0x9c00
+ax_pose 50, 0x41f3, 0x50f1, 0x9c08
+ax_pose 51, 0x41fb, 0x10f1, 0x9c0c
+ax_pose 52, 0x01fb, 0x1101, 0x9c0e
+ax_pose 53, 0x01db, 0x10fd, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose277:
+ax_pose 31, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose278:
+ax_pose 58, 0x01e3, 0x90f3, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose279:
+ax_pose 59, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose280:
+ax_pose 32, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose281:
+ax_pose 62, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose282:
+ax_pose 49, 0x41e3, 0x80f0, 0x9c00
+ax_pose 50, 0x41f3, 0x40f0, 0x9c08
+ax_pose 51, 0x41fb, 0x0100, 0x9c0c
+ax_pose 52, 0x01fb, 0x00f8, 0x9c0e
+ax_pose 53, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose283:
+ax_pose 31, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose284:
+ax_pose 58, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose285:
+ax_pose 39, 0x81e3, 0x80f0, 0x9c00
+ax_pose 40, 0x81e3, 0x4100, 0x9c08
+ax_pose 41, 0x81f3, 0x0108, 0x9c0c
+ax_pose 42, 0x01db, 0x00fc, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose286:
+ax_pose 30, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose287:
+ax_pose 48, 0x01e2, 0x80ec, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose288:
+ax_pose 36, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose289:
+ax_pose 29, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose290:
+ax_pose 38, 0x01e1, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose291:
+ax_pose 100, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose292:
+ax_pose 101, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose293:
+ax_pose 104, 0x81e3, 0x80f6, 0x9c00
+ax_pose 105, 0x81eb, 0x0106, 0x9c08
+ax_pose 106, 0x01fb, 0x0106, 0x9c0a
+ax_pose 107, 0x01db, 0x00fe, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose294:
+ax_pose 113, 0x81e3, 0x80f3, 0x9c00
+ax_pose 114, 0x81e3, 0x4103, 0x9c08
+ax_pose 115, 0x01db, 0x00fb, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose295:
+ax_pose 120, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose296:
+ax_pose 113, 0x81e3, 0x90fe, 0x9c00
+ax_pose 114, 0x81e3, 0x50f6, 0x9c08
+ax_pose 115, 0x01db, 0x10fe, 0x9c0c
+ax_pose_terminator
+sDeoxysAttackPose297:
+ax_pose 104, 0x81e3, 0x90fb, 0x9c00
+ax_pose 105, 0x81eb, 0x10f3, 0x9c08
+ax_pose 106, 0x01fb, 0x10f3, 0x9c0a
+ax_pose 107, 0x01db, 0x10fb, 0x9c0b
+ax_pose_terminator
+sDeoxysAttackPose298:
+ax_pose 101, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose299:
+ax_pose 33, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose300:
+ax_pose 36, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose301:
+ax_pose 39, 0x81e3, 0x80f0, 0x9c00
+ax_pose 40, 0x81e3, 0x4100, 0x9c08
+ax_pose 41, 0x81f3, 0x0108, 0x9c0c
+ax_pose 42, 0x01db, 0x00fc, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose302:
+ax_pose 49, 0x41e3, 0x80f0, 0x9c00
+ax_pose 50, 0x41f3, 0x40f0, 0x9c08
+ax_pose 51, 0x41fb, 0x0100, 0x9c0c
+ax_pose 52, 0x01fb, 0x00f8, 0x9c0e
+ax_pose 53, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose303:
+ax_pose 59, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysAttackPose304:
+ax_pose 49, 0x41e3, 0x90f1, 0x9c00
+ax_pose 50, 0x41f3, 0x50f1, 0x9c08
+ax_pose 51, 0x41fb, 0x10f1, 0x9c0c
+ax_pose 52, 0x01fb, 0x1101, 0x9c0e
+ax_pose 53, 0x01db, 0x10fd, 0x9c0f
+ax_pose_terminator
+sDeoxysAttackPose305:
+ax_pose 39, 0x81e3, 0x9101, 0x9c00
+ax_pose 40, 0x81e3, 0x50f9, 0x9c08
+ax_pose 41, 0x81f3, 0x10f1, 0x9c0c
+ax_pose 42, 0x01db, 0x10fd, 0x9c0e
+ax_pose_terminator
+sDeoxysAttackPose306:
+ax_pose 36, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+.align 2
+sDeoxysAttackAnims_1_1:
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 1,
+ax_anim 8, 0, 0, 0, -4, 0, 2,
+ax_anim 8, 0, 1, 0, -5, 0, 2,
+ax_anim 8, 0, 3, 0, -5, 0, 1,
+ax_anim 8, 0, 2, 0, -4, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_1_2:
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 1,
+ax_anim 8, 0, 4, 0, -4, 0, 2,
+ax_anim 8, 0, 5, 0, -5, 0, 2,
+ax_anim 8, 0, 7, 0, -5, 0, 1,
+ax_anim 8, 0, 6, 0, -4, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_1_3:
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 1,
+ax_anim 8, 0, 8, 0, -4, 0, 2,
+ax_anim 8, 0, 9, 0, -5, 0, 2,
+ax_anim 8, 0, 11, 0, -5, 0, 1,
+ax_anim 8, 0, 10, 0, -4, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_1_4:
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 1,
+ax_anim 8, 0, 12, 0, -4, 0, 2,
+ax_anim 8, 0, 13, 0, -5, 0, 2,
+ax_anim 8, 0, 15, 0, -5, 0, 1,
+ax_anim 8, 0, 14, 0, -4, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_1_5:
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 1,
+ax_anim 8, 0, 16, 0, -4, 0, 2,
+ax_anim 8, 0, 17, 0, -5, 0, 2,
+ax_anim 8, 0, 19, 0, -5, 0, 1,
+ax_anim 8, 0, 18, 0, -4, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_1_6:
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -3, 0, 1,
+ax_anim 8, 0, 20, 0, -4, 0, 2,
+ax_anim 8, 0, 21, 0, -5, 0, 2,
+ax_anim 8, 0, 23, 0, -5, 0, 1,
+ax_anim 8, 0, 22, 0, -4, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_1_7:
+ax_anim 8, 0, 24, 0, -2, 0, 0,
+ax_anim 8, 0, 24, 0, -3, 0, 1,
+ax_anim 8, 0, 24, 0, -4, 0, 2,
+ax_anim 8, 0, 25, 0, -5, 0, 2,
+ax_anim 8, 0, 27, 0, -5, 0, 1,
+ax_anim 8, 0, 26, 0, -4, 0, 0,
+ax_anim 8, 0, 26, 0, -3, 0, 0,
+ax_anim 8, 0, 26, 0, -2, 0, 0,
+ax_anim 8, 0, 27, 0, -2, 0, 0,
+ax_anim 8, 0, 25, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_1_8:
+ax_anim 8, 0, 28, 0, -2, 0, 0,
+ax_anim 8, 0, 28, 0, -3, 0, 1,
+ax_anim 8, 0, 28, 0, -4, 0, 2,
+ax_anim 8, 0, 29, 0, -5, 0, 2,
+ax_anim 8, 0, 31, 0, -5, 0, 1,
+ax_anim 8, 0, 30, 0, -4, 0, 0,
+ax_anim 8, 0, 30, 0, -3, 0, 0,
+ax_anim 8, 0, 30, 0, -2, 0, 0,
+ax_anim 8, 0, 31, 0, -2, 0, 0,
+ax_anim 8, 0, 29, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 4, 0, 32, 0, -2, 0, -2,
+ax_anim 4, 0, 34, 0, -2, 0, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 0, 4, 0, 4,
+ax_anim 1, 0, 32, 0, 10, 0, 10,
+ax_anim 2, 0, 36, 0, 20, 0, 20,
+ax_anim 2, 1, 36, 1, 20, 1, 20,
+ax_anim 2, 0, 36, 0, 20, 0, 20,
+ax_anim 2, 0, 36, 1, 20, 1, 20,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysAttackAnims_2_2:
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 4, 0, 37, -2, -2, -2, -2,
+ax_anim 4, 0, 39, -2, -2, -2, -2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 4, 4, 4, 4,
+ax_anim 1, 0, 37, 10, 10, 10, 10,
+ax_anim 2, 0, 41, 19, 20, 19, 20,
+ax_anim 2, 1, 41, 20, 19, 20, 19,
+ax_anim 2, 0, 41, 19, 20, 19, 20,
+ax_anim 2, 0, 41, 20, 19, 20, 19,
+ax_anim 2, 0, 37, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysAttackAnims_2_3:
+ax_anim 2, 0, 42, -1, 0, -1, 0,
+ax_anim 4, 0, 42, -2, 0, -2, 0,
+ax_anim 4, 0, 44, -2, 0, -2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 6, 0, 6, 0,
+ax_anim 1, 0, 42, 12, 0, 12, 0,
+ax_anim 2, 0, 46, 22, 0, 22, 0,
+ax_anim 2, 1, 46, 22, 1, 22, 1,
+ax_anim 2, 0, 46, 22, 0, 22, 0,
+ax_anim 2, 0, 46, 22, 1, 22, 1,
+ax_anim 2, 0, 42, 8, 0, 8, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_2_4:
+ax_anim 2, 0, 47, -1, 1, -1, 1,
+ax_anim 4, 0, 47, -2, 2, -2, 2,
+ax_anim 4, 0, 49, -2, 2, -2, 2,
+ax_anim 1, 0, 47, 0, -1, 0, -1,
+ax_anim 1, 2, 49, 7, -4, 7, -4,
+ax_anim 1, 0, 47, 12, -8, 12, -8,
+ax_anim 2, 0, 51, 23, -14, 23, -14,
+ax_anim 2, 1, 51, 24, -13, 24, -13,
+ax_anim 2, 0, 51, 23, -14, 23, -14,
+ax_anim 2, 0, 51, 24, -13, 24, -13,
+ax_anim 2, 0, 47, 8, -5, 8, -5,
+ax_anim_terminator
+sDeoxysAttackAnims_2_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 4, 0, 52, 0, 2, 0, 2,
+ax_anim 4, 0, 54, 0, 2, 0, 2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 0, -2, 0, -2,
+ax_anim 1, 0, 52, 0, -8, 0, -8,
+ax_anim 2, 0, 56, 0, -15, 0, -15,
+ax_anim 2, 1, 56, 1, -15, 1, -15,
+ax_anim 2, 0, 56, 0, -15, 0, -15,
+ax_anim 2, 0, 56, 1, -15, 1, -15,
+ax_anim 2, 0, 52, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysAttackAnims_2_6:
+ax_anim 2, 0, 57, 1, 1, 1, 1,
+ax_anim 4, 0, 57, 2, 2, 2, 2,
+ax_anim 4, 0, 59, 2, 2, 2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 59, -7, -4, -7, -4,
+ax_anim 1, 0, 57, -12, -8, -12, -8,
+ax_anim 2, 0, 61, -23, -14, -23, -14,
+ax_anim 2, 1, 61, -24, -13, -24, -13,
+ax_anim 2, 0, 61, -23, -14, -23, -14,
+ax_anim 2, 0, 61, -24, -13, -24, -13,
+ax_anim 2, 0, 57, -8, -5, -8, -5,
+ax_anim_terminator
+sDeoxysAttackAnims_2_7:
+ax_anim 2, 0, 62, 1, 0, 1, 0,
+ax_anim 4, 0, 62, 2, 0, 2, 0,
+ax_anim 4, 0, 64, 2, 0, 2, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 64, -6, 0, -6, 0,
+ax_anim 1, 0, 62, -12, 0, -12, 0,
+ax_anim 2, 0, 66, -22, 0, -22, 0,
+ax_anim 2, 1, 66, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -22, 0, -22, 0,
+ax_anim 2, 0, 66, -22, 1, -22, 1,
+ax_anim 2, 0, 62, -8, 0, -8, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_2_8:
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 4, 0, 67, 2, -2, 2, -2,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 67, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -19, 20, -19, 20,
+ax_anim 2, 1, 71, -20, 19, -20, 19,
+ax_anim 2, 0, 71, -19, 20, -19, 20,
+ax_anim 2, 0, 71, -20, 19, -20, 19,
+ax_anim 2, 0, 67, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_3_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 4, 0, 72, 0, -2, 0, -2,
+ax_anim 4, 0, 74, 0, -2, 0, -2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, 4, 0, 4,
+ax_anim 1, 0, 72, 0, 10, 0, 10,
+ax_anim 2, 0, 76, 0, 20, 0, 20,
+ax_anim 2, 1, 76, 1, 20, 1, 20,
+ax_anim 2, 0, 76, 0, 20, 0, 20,
+ax_anim 2, 0, 76, 1, 20, 1, 20,
+ax_anim 2, 0, 72, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysAttackAnims_3_2:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 4, 0, 77, -2, -2, -2, -2,
+ax_anim 4, 0, 79, -2, -2, -2, -2,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 2, 79, 4, 4, 4, 4,
+ax_anim 1, 0, 77, 10, 10, 10, 10,
+ax_anim 2, 0, 81, 19, 20, 19, 20,
+ax_anim 2, 1, 81, 20, 19, 20, 19,
+ax_anim 2, 0, 81, 19, 20, 19, 20,
+ax_anim 2, 0, 81, 20, 19, 20, 19,
+ax_anim 2, 0, 77, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysAttackAnims_3_3:
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 4, 0, 82, -2, 0, -2, 0,
+ax_anim 4, 0, 84, -2, 0, -2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 84, 6, 0, 6, 0,
+ax_anim 1, 0, 82, 12, 0, 12, 0,
+ax_anim 2, 0, 86, 22, 0, 22, 0,
+ax_anim 2, 1, 86, 22, 1, 22, 1,
+ax_anim 2, 0, 86, 22, 0, 22, 0,
+ax_anim 2, 0, 86, 22, 1, 22, 1,
+ax_anim 2, 0, 82, 8, 0, 8, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_3_4:
+ax_anim 2, 0, 87, -1, 1, -1, 1,
+ax_anim 4, 0, 87, -2, 2, -2, 2,
+ax_anim 4, 0, 89, -2, 2, -2, 2,
+ax_anim 1, 0, 87, 0, -1, 0, -1,
+ax_anim 1, 2, 89, 7, -4, 7, -4,
+ax_anim 1, 0, 87, 12, -8, 12, -8,
+ax_anim 2, 0, 91, 23, -14, 23, -14,
+ax_anim 2, 1, 91, 24, -13, 24, -13,
+ax_anim 2, 0, 91, 23, -14, 23, -14,
+ax_anim 2, 0, 91, 24, -13, 24, -13,
+ax_anim 2, 0, 87, 8, -5, 8, -5,
+ax_anim_terminator
+sDeoxysAttackAnims_3_5:
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 4, 0, 92, 0, 2, 0, 2,
+ax_anim 4, 0, 94, 0, 2, 0, 2,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 2, 94, 0, -2, 0, -2,
+ax_anim 1, 0, 92, 0, -8, 0, -8,
+ax_anim 2, 0, 96, 0, -15, 0, -15,
+ax_anim 2, 1, 96, 1, -15, 1, -15,
+ax_anim 2, 0, 96, 0, -15, 0, -15,
+ax_anim 2, 0, 96, 1, -15, 1, -15,
+ax_anim 2, 0, 92, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysAttackAnims_3_6:
+ax_anim 2, 0, 97, 1, 1, 1, 1,
+ax_anim 4, 0, 97, 2, 2, 2, 2,
+ax_anim 4, 0, 99, 2, 2, 2, 2,
+ax_anim 1, 0, 97, 0, -1, 0, -1,
+ax_anim 1, 2, 99, -7, -4, -7, -4,
+ax_anim 1, 0, 97, -12, -8, -12, -8,
+ax_anim 2, 0, 101, -23, -14, -23, -14,
+ax_anim 2, 1, 101, -24, -13, -24, -13,
+ax_anim 2, 0, 101, -23, -14, -23, -14,
+ax_anim 2, 0, 101, -24, -13, -24, -13,
+ax_anim 2, 0, 97, -8, -5, -8, -5,
+ax_anim_terminator
+sDeoxysAttackAnims_3_7:
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 4, 0, 102, 2, 0, 2, 0,
+ax_anim 4, 0, 104, 2, 0, 2, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 2, 104, -6, 0, -6, 0,
+ax_anim 1, 0, 102, -12, 0, -12, 0,
+ax_anim 2, 0, 106, -22, 0, -22, 0,
+ax_anim 2, 1, 106, -22, 1, -22, 1,
+ax_anim 2, 0, 106, -22, 0, -22, 0,
+ax_anim 2, 0, 106, -22, 1, -22, 1,
+ax_anim 2, 0, 102, -8, 0, -8, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_3_8:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 4, 0, 107, 2, -2, 2, -2,
+ax_anim 4, 0, 109, 2, -2, 2, -2,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 2, 109, -4, 4, -4, 4,
+ax_anim 1, 0, 107, -10, 10, -10, 10,
+ax_anim 2, 0, 111, -19, 20, -19, 20,
+ax_anim 2, 1, 111, -20, 19, -20, 19,
+ax_anim 2, 0, 111, -19, 20, -19, 20,
+ax_anim 2, 0, 111, -20, 19, -20, 19,
+ax_anim 2, 0, 107, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_4_1:
+ax_anim 2, 0, 115, 0, -2, 0, -2,
+ax_anim 4, 0, 115, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 4, 0, 114, 0, 3, 0, 3,
+ax_anim 4, 2, 114, 1, 3, 1, 3,
+ax_anim 2, 0, 114, 0, 3, 0, 3,
+ax_anim 2, 0, 114, 1, 3, 1, 3,
+ax_anim 2, 1, 114, 0, 3, 0, 3,
+ax_anim 2, 0, 115, 0, -5, 0, -5,
+ax_anim 4, 0, 115, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysAttackAnims_4_2:
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim 4, 0, 119, -3, -3, -3, -3,
+ax_anim 2, 0, 116, -1, -1, -1, -1,
+ax_anim 4, 0, 118, 2, 2, 2, 2,
+ax_anim 4, 2, 118, 3, 1, 3, 1,
+ax_anim 2, 0, 118, 2, 2, 2, 2,
+ax_anim 2, 0, 118, 3, 1, 3, 1,
+ax_anim 2, 1, 118, 2, 2, 2, 2,
+ax_anim 2, 0, 119, -5, -5, -5, -5,
+ax_anim 4, 0, 119, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysAttackAnims_4_3:
+ax_anim 2, 0, 123, -2, 0, -2, 0,
+ax_anim 4, 0, 123, -3, 0, -3, 0,
+ax_anim 2, 0, 120, -1, 0, -1, 0,
+ax_anim 4, 0, 122, 3, 0, 3, 0,
+ax_anim 4, 2, 122, 3, -1, 3, -1,
+ax_anim 2, 0, 122, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 3, -1, 3, -1,
+ax_anim 2, 1, 122, 3, 0, 3, 0,
+ax_anim 2, 0, 123, -5, 0, -5, 0,
+ax_anim 4, 0, 123, -6, 0, -6, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_4_4:
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 4, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 124, -1, 1, -1, 1,
+ax_anim 4, 0, 126, 2, -2, 2, -2,
+ax_anim 4, 2, 126, 3, -1, 3, -1,
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 3, -1, 3, -1,
+ax_anim 2, 1, 126, 2, -2, 2, -2,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 4, 0, 127, -6, 6, -6, 6,
+ax_anim_terminator
+sDeoxysAttackAnims_4_5:
+ax_anim 2, 0, 131, 0, 2, 0, 2,
+ax_anim 4, 0, 131, 0, 3, 0, 3,
+ax_anim 2, 0, 128, 0, 1, 0, 1,
+ax_anim 4, 0, 130, 0, -3, 0, -3,
+ax_anim 4, 2, 130, 1, -3, 1, -3,
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 2, 0, 130, 1, -3, 1, -3,
+ax_anim 2, 1, 130, 0, -3, 0, -3,
+ax_anim 2, 0, 131, 0, 5, 0, 5,
+ax_anim 4, 0, 131, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysAttackAnims_4_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 4, 0, 135, 3, 3, 3, 3,
+ax_anim 2, 0, 132, 1, 1, 1, 1,
+ax_anim 4, 0, 134, -2, -2, -2, -2,
+ax_anim 4, 2, 134, -3, -1, -3, -1,
+ax_anim 2, 0, 134, -2, -2, -2, -2,
+ax_anim 2, 0, 134, -3, -1, -3, -1,
+ax_anim 2, 1, 134, -2, -2, -2, -2,
+ax_anim 2, 0, 135, 5, 5, 5, 5,
+ax_anim 4, 0, 135, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysAttackAnims_4_7:
+ax_anim 2, 0, 139, 2, 0, 2, 0,
+ax_anim 4, 0, 139, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 4, 0, 138, -3, 0, -3, 0,
+ax_anim 4, 2, 138, -3, -1, -3, -1,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 138, -3, -1, -3, -1,
+ax_anim 2, 1, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 139, 5, 0, 5, 0,
+ax_anim 4, 0, 139, 6, 0, 6, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_4_8:
+ax_anim 2, 0, 143, 2, -2, 2, -2,
+ax_anim 4, 0, 143, 3, -3, 3, -3,
+ax_anim 2, 0, 140, 1, -1, 1, -1,
+ax_anim 4, 0, 142, -2, 2, -2, 2,
+ax_anim 4, 2, 142, -3, 1, -3, 1,
+ax_anim 2, 0, 142, -2, 2, -2, 2,
+ax_anim 2, 0, 142, -3, 1, -3, 1,
+ax_anim 2, 1, 142, -2, 2, -2, 2,
+ax_anim 2, 0, 143, 5, -5, 5, -5,
+ax_anim 4, 0, 143, 6, -6, 6, -6,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_5_1:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_5_2:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_5_3:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_5_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 6, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_5_5:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_5_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 6, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 4, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_5_7:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 6, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 4, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_5_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 4, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_6_1:
+ax_anim 30, 0, 208, 0, 0, 0, 0,
+ax_anim 35, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_7_1:
+ax_anim 2, 0, 210, 0, -2, 0, -2,
+ax_anim 8, 0, 210, 0, -3, 0, -3,
+ax_anim_terminator
+sDeoxysAttackAnims_7_2:
+ax_anim 2, 0, 211, -2, -2, -2, -2,
+ax_anim 8, 0, 211, -3, -3, -3, -3,
+ax_anim_terminator
+sDeoxysAttackAnims_7_3:
+ax_anim 2, 0, 212, -2, 0, -2, 0,
+ax_anim 8, 0, 212, -3, 0, -3, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_7_4:
+ax_anim 2, 0, 213, -2, 2, -2, 2,
+ax_anim 8, 0, 213, -3, 3, -3, 3,
+ax_anim_terminator
+sDeoxysAttackAnims_7_5:
+ax_anim 2, 0, 214, 0, 2, 0, 2,
+ax_anim 8, 0, 214, 0, 3, 0, 3,
+ax_anim_terminator
+sDeoxysAttackAnims_7_6:
+ax_anim 2, 0, 215, 2, 2, 2, 2,
+ax_anim 8, 0, 215, 3, 3, 3, 3,
+ax_anim_terminator
+sDeoxysAttackAnims_7_7:
+ax_anim 2, 0, 216, 2, 0, 2, 0,
+ax_anim 8, 0, 216, 3, 0, 3, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_7_8:
+ax_anim 2, 0, 217, 2, -2, 2, -2,
+ax_anim 8, 0, 217, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_8_1:
+ax_anim 14, 0, 218, 0, -2, 0, 0,
+ax_anim 14, 0, 219, 0, -3, 0, 0,
+ax_anim 15, 0, 220, 0, -2, 0, 0,
+ax_anim 14, 0, 221, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_8_2:
+ax_anim 14, 0, 222, 0, -2, 0, 0,
+ax_anim 14, 0, 223, 0, -3, 0, 0,
+ax_anim 15, 0, 224, 0, -2, 0, 0,
+ax_anim 14, 0, 225, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_8_3:
+ax_anim 14, 0, 226, 0, -2, 0, 0,
+ax_anim 14, 0, 227, 0, -3, 0, 0,
+ax_anim 15, 0, 228, 0, -2, 0, 0,
+ax_anim 14, 0, 229, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_8_4:
+ax_anim 14, 0, 230, 0, -2, 0, 0,
+ax_anim 14, 0, 231, 0, -3, 0, 0,
+ax_anim 15, 0, 232, 0, -2, 0, 0,
+ax_anim 14, 0, 233, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_8_5:
+ax_anim 14, 0, 234, 0, -2, 0, 0,
+ax_anim 14, 0, 235, 0, -3, 0, 0,
+ax_anim 15, 0, 236, 0, -2, 0, 0,
+ax_anim 14, 0, 237, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_8_6:
+ax_anim 14, 0, 238, 0, -2, 0, 0,
+ax_anim 14, 0, 239, 0, -3, 0, 0,
+ax_anim 15, 0, 240, 0, -2, 0, 0,
+ax_anim 14, 0, 241, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_8_7:
+ax_anim 14, 0, 242, 0, -2, 0, 0,
+ax_anim 14, 0, 243, 0, -3, 0, 0,
+ax_anim 15, 0, 244, 0, -2, 0, 0,
+ax_anim 14, 0, 245, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_8_8:
+ax_anim 14, 0, 246, 0, -2, 0, 0,
+ax_anim 14, 0, 247, 0, -3, 0, 0,
+ax_anim 15, 0, 248, 0, -2, 0, 0,
+ax_anim 14, 0, 249, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_9_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 7, 4, 7, 4,
+ax_anim 2, 0, 252, 10, 10, 10, 10,
+ax_anim 2, 0, 253, 8, 17, 8, 17,
+ax_anim 3, 0, 254, 0, 19, 0, 19,
+ax_anim 2, 3, 255, -8, 17, -8, 17,
+ax_anim 2, 0, 256, -10, 10, -10, 10,
+ax_anim 1, 0, 257, -7, 4, -7, 4,
+ax_anim 1, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_9_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 250, 8, 0, 8, 0,
+ax_anim 2, 0, 251, 16, 3, 16, 3,
+ax_anim 2, 0, 252, 24, 9, 24, 9,
+ax_anim 3, 0, 253, 22, 19, 22, 19,
+ax_anim 2, 3, 254, 13, 20, 13, 20,
+ax_anim 2, 0, 255, 1, 18, 1, 18,
+ax_anim 1, 0, 256, -2, 7, -2, 7,
+ax_anim 1, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_9_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 3, -5, 3, -5,
+ax_anim 2, 0, 250, 11, -7, 11, -7,
+ax_anim 2, 0, 251, 19, -6, 19, -6,
+ax_anim 3, 0, 252, 23, -2, 23, -2,
+ax_anim 2, 3, 253, 21, 5, 21, 5,
+ax_anim 2, 0, 254, 12, 6, 12, 6,
+ax_anim 1, 0, 255, 1, 5, 1, 5,
+ax_anim 1, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_9_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 1, 0, 256, 0, -8, 0, -8,
+ax_anim 2, 0, 257, 4, -17, 4, -17,
+ax_anim 2, 0, 250, 12, -20, 12, -20,
+ax_anim 3, 0, 251, 21, -20, 21, -20,
+ax_anim 2, 3, 252, 26, -14, 26, -14,
+ax_anim 2, 0, 253, 21, -5, 21, -5,
+ax_anim 1, 0, 254, 13, 0, 13, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_9_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, -8, -4, -8, -4,
+ax_anim 2, 0, 256, -9, -11, -9, -11,
+ax_anim 2, 0, 257, -7, -18, -7, -18,
+ax_anim 3, 0, 250, 0, -20, 0, -20,
+ax_anim 2, 3, 251, 8, -18, 8, -18,
+ax_anim 2, 0, 252, 10, -10, 10, -10,
+ax_anim 1, 0, 253, 9, -2, 9, -2,
+ax_anim 1, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_9_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -8, 0, -8,
+ax_anim 2, 0, 251, -4, -17, -4, -17,
+ax_anim 2, 0, 250, -12, -20, -12, -20,
+ax_anim 3, 0, 257, -21, -20, -21, -20,
+ax_anim 2, 3, 256, -26, -14, -26, -14,
+ax_anim 2, 0, 255, -21, -5, -21, -5,
+ax_anim 1, 0, 254, -13, 0, -13, 0,
+ax_anim 1, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_9_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 251, -3, -5, -3, -5,
+ax_anim 2, 0, 250, -11, -7, -11, -7,
+ax_anim 2, 0, 257, -19, -6, -19, -6,
+ax_anim 3, 0, 256, -23, -2, -23, -2,
+ax_anim 2, 3, 255, -21, 5, -21, 5,
+ax_anim 2, 0, 254, -12, 6, -12, 6,
+ax_anim 1, 0, 253, -1, 5, -1, 5,
+ax_anim 1, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_9_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 250, -8, 0, -8, 0,
+ax_anim 2, 0, 257, -16, 3, -16, 3,
+ax_anim 2, 0, 256, -24, 9, -24, 9,
+ax_anim 3, 0, 255, -22, 19, -22, 19,
+ax_anim 2, 3, 254, -13, 20, -13, 20,
+ax_anim 2, 0, 253, -1, 18, -1, 18,
+ax_anim 1, 0, 252, 2, 7, 2, 7,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_10_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 6, 0, 6, 0,
+ax_anim 2, 0, 258, -6, 0, -6, 0,
+ax_anim 2, 0, 258, 10, 0, 10, 0,
+ax_anim 2, 0, 258, -10, 0, -10, 0,
+ax_anim 2, 0, 258, 12, 0, 12, 0,
+ax_anim 3, 0, 258, -12, 0, -12, 0,
+ax_anim 3, 0, 258, 13, 0, 13, 0,
+ax_anim 3, 0, 258, -13, 0, -13, 0,
+ax_anim 2, 0, 258, 12, 0, 12, 0,
+ax_anim 3, 0, 258, -12, 0, -12, 0,
+ax_anim 2, 0, 258, 10, 0, 10, 0,
+ax_anim 2, 0, 258, -10, 0, -10, 0,
+ax_anim 2, 0, 258, 6, 0, 6, 0,
+ax_anim 2, 0, 258, -6, 0, -6, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_10_2:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 6, -6, 6, -6,
+ax_anim 2, 0, 259, -6, 6, -6, 6,
+ax_anim 2, 0, 259, 10, -10, 10, -10,
+ax_anim 2, 0, 259, -10, 10, -10, 10,
+ax_anim 2, 0, 259, 12, -12, 12, -12,
+ax_anim 3, 0, 259, -12, 12, -12, 12,
+ax_anim 3, 0, 259, 13, -13, 13, -13,
+ax_anim 3, 0, 259, -13, 13, -13, 13,
+ax_anim 2, 0, 259, 12, -12, 12, -12,
+ax_anim 3, 0, 259, -12, 12, -12, 12,
+ax_anim 2, 0, 259, 10, -10, 10, -10,
+ax_anim 2, 0, 259, -10, 10, -10, 10,
+ax_anim 2, 0, 259, 6, -6, 6, -6,
+ax_anim 2, 0, 259, -6, 6, -6, 6,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_10_3:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -6, 0, -6,
+ax_anim 2, 0, 260, 0, 6, 0, 6,
+ax_anim 2, 0, 260, 0, -10, 0, -10,
+ax_anim 2, 0, 260, 0, 10, 0, 10,
+ax_anim 2, 0, 260, 0, -12, 0, -12,
+ax_anim 3, 0, 260, 0, 12, 0, 12,
+ax_anim 3, 0, 260, 0, -13, 0, -13,
+ax_anim 3, 0, 260, 0, 13, 0, 13,
+ax_anim 2, 0, 260, 0, -12, 0, -12,
+ax_anim 3, 0, 260, 0, 12, 0, 12,
+ax_anim 2, 0, 260, 0, -10, 0, -10,
+ax_anim 2, 0, 260, 0, 10, 0, 10,
+ax_anim 2, 0, 260, 0, -6, 0, -6,
+ax_anim 2, 0, 260, 0, 6, 0, 6,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_10_4:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, -6, -6, -6, -6,
+ax_anim 2, 0, 261, 6, 6, 6, 6,
+ax_anim 2, 0, 261, -10, -10, -10, -10,
+ax_anim 2, 0, 261, 10, 10, 10, 10,
+ax_anim 2, 0, 261, -12, -12, -12, -12,
+ax_anim 3, 0, 261, 12, 12, 12, 12,
+ax_anim 3, 0, 261, -13, -13, -13, -13,
+ax_anim 3, 0, 261, 13, 13, 13, 13,
+ax_anim 2, 0, 261, -12, -12, -12, -12,
+ax_anim 3, 0, 261, 12, 12, 12, 12,
+ax_anim 2, 0, 261, -10, -10, -10, -10,
+ax_anim 2, 0, 261, 10, 10, 10, 10,
+ax_anim 2, 0, 261, -6, -6, -6, -6,
+ax_anim 2, 0, 261, 6, 6, 6, 6,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_10_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 6, 0, 6, 0,
+ax_anim 2, 0, 262, -6, 0, -6, 0,
+ax_anim 2, 0, 262, 10, 0, 10, 0,
+ax_anim 2, 0, 262, -10, 0, -10, 0,
+ax_anim 2, 0, 262, 12, 0, 12, 0,
+ax_anim 3, 0, 262, -12, 0, -12, 0,
+ax_anim 3, 0, 262, 13, 0, 13, 0,
+ax_anim 3, 0, 262, -13, 0, -13, 0,
+ax_anim 2, 0, 262, 12, 0, 12, 0,
+ax_anim 3, 0, 262, -12, 0, -12, 0,
+ax_anim 2, 0, 262, 10, 0, 10, 0,
+ax_anim 2, 0, 262, -10, 0, -10, 0,
+ax_anim 2, 0, 262, 6, 0, 6, 0,
+ax_anim 2, 0, 262, -6, 0, -6, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_10_6:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 6, -6, 6, -6,
+ax_anim 2, 0, 263, -6, 6, -6, 6,
+ax_anim 2, 0, 263, 10, -10, 10, -10,
+ax_anim 2, 0, 263, -10, 10, -10, 10,
+ax_anim 2, 0, 263, 12, -12, 12, -12,
+ax_anim 3, 0, 263, -12, 12, -12, 12,
+ax_anim 3, 0, 263, 13, -13, 13, -13,
+ax_anim 3, 0, 263, -13, 13, -13, 13,
+ax_anim 2, 0, 263, 12, -12, 12, -12,
+ax_anim 3, 0, 263, -12, 12, -12, 12,
+ax_anim 2, 0, 263, 10, -10, 10, -10,
+ax_anim 2, 0, 263, -10, 10, -10, 10,
+ax_anim 2, 0, 263, 6, -6, 6, -6,
+ax_anim 2, 0, 263, -6, 6, -6, 6,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_10_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -6, 0, -6,
+ax_anim 2, 0, 264, 0, 6, 0, 6,
+ax_anim 2, 0, 264, 0, -10, 0, -10,
+ax_anim 2, 0, 264, 0, 10, 0, 10,
+ax_anim 2, 0, 264, 0, -12, 0, -12,
+ax_anim 3, 0, 264, 0, 12, 0, 12,
+ax_anim 3, 0, 264, 0, -13, 0, -13,
+ax_anim 3, 0, 264, 0, 13, 0, 13,
+ax_anim 2, 0, 264, 0, -12, 0, -12,
+ax_anim 3, 0, 264, 0, 12, 0, 12,
+ax_anim 2, 0, 264, 0, -10, 0, -10,
+ax_anim 2, 0, 264, 0, 10, 0, 10,
+ax_anim 2, 0, 264, 0, -6, 0, -6,
+ax_anim 2, 0, 264, 0, 6, 0, 6,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_10_8:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, -6, -6, -6, -6,
+ax_anim 2, 0, 265, 6, 6, 6, 6,
+ax_anim 2, 0, 265, -10, -10, -10, -10,
+ax_anim 2, 0, 265, 10, 10, 10, 10,
+ax_anim 2, 0, 265, -12, -12, -12, -12,
+ax_anim 3, 0, 265, 12, 12, 12, 12,
+ax_anim 3, 0, 265, -13, -13, -13, -13,
+ax_anim 3, 0, 265, 13, 13, 13, 13,
+ax_anim 2, 0, 265, -12, -12, -12, -12,
+ax_anim 3, 0, 265, 12, 12, 12, 12,
+ax_anim 2, 0, 265, -10, -10, -10, -10,
+ax_anim 2, 0, 265, 10, 10, 10, 10,
+ax_anim 2, 0, 265, -6, -6, -6, -6,
+ax_anim 2, 0, 265, 6, 6, 6, 6,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_11_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 266, 0, -23, 0, 0,
+ax_anim 3, 0, 267, 0, -22, 0, 0,
+ax_anim 2, 0, 267, 0, -18, 0, 0,
+ax_anim 1, 0, 267, 0, -12, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_11_2:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 269, 0, -23, 0, 0,
+ax_anim 3, 0, 270, 0, -20, 0, 0,
+ax_anim 2, 0, 270, 0, -18, 0, 0,
+ax_anim 1, 0, 270, 0, -12, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_11_3:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 272, 0, -23, 0, 0,
+ax_anim 3, 0, 273, 0, -22, 0, 0,
+ax_anim 2, 0, 273, 0, -18, 0, 0,
+ax_anim 1, 0, 273, 0, -12, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_11_4:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 1, 0, 275, 0, -10, 0, 0,
+ax_anim 2, 0, 275, 0, -16, 0, 0,
+ax_anim 3, 0, 275, 0, -20, 0, 0,
+ax_anim 4, 0, 275, 0, -21, 0, 0,
+ax_anim 4, 0, 275, 0, -22, 0, 0,
+ax_anim 3, 0, 276, 0, -21, 0, 0,
+ax_anim 2, 0, 276, 0, -17, 0, 0,
+ax_anim 1, 0, 276, 0, -11, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_11_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 1, 0, 278, 0, -10, 0, 0,
+ax_anim 2, 0, 278, 0, -16, 0, 0,
+ax_anim 3, 0, 278, 0, -20, 0, 0,
+ax_anim 4, 0, 278, 0, -21, 0, 0,
+ax_anim 4, 0, 278, 0, -23, 0, 0,
+ax_anim 3, 0, 279, 0, -22, 0, 0,
+ax_anim 2, 0, 279, 0, -18, 0, 0,
+ax_anim 1, 0, 279, 0, -12, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_11_6:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 1, 0, 281, 0, -10, 0, 0,
+ax_anim 2, 0, 281, 0, -16, 0, 0,
+ax_anim 3, 0, 281, 0, -20, 0, 0,
+ax_anim 4, 0, 281, 0, -21, 0, 0,
+ax_anim 4, 0, 281, 0, -22, 0, 0,
+ax_anim 3, 0, 282, 0, -21, 0, 0,
+ax_anim 2, 0, 282, 0, -17, 0, 0,
+ax_anim 1, 0, 282, 0, -11, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_11_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 1, 0, 284, 0, -10, 0, 0,
+ax_anim 2, 0, 284, 0, -16, 0, 0,
+ax_anim 3, 0, 284, 0, -20, 0, 0,
+ax_anim 4, 0, 284, 0, -21, 0, 0,
+ax_anim 4, 0, 284, 0, -23, 0, 0,
+ax_anim 3, 0, 285, 0, -22, 0, 0,
+ax_anim 2, 0, 285, 0, -18, 0, 0,
+ax_anim 1, 0, 285, 0, -12, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_11_8:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 1, 0, 287, 0, -10, 0, 0,
+ax_anim 2, 0, 287, 0, -16, 0, 0,
+ax_anim 3, 0, 287, 0, -20, 0, 0,
+ax_anim 4, 0, 287, 0, -21, 0, 0,
+ax_anim 4, 0, 287, 0, -23, 0, 0,
+ax_anim 3, 0, 288, 0, -20, 0, 0,
+ax_anim 2, 0, 288, 0, -18, 0, 0,
+ax_anim 1, 0, 288, 0, -12, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_12_1:
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 2, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 0, 1, 0,
+ax_anim 2, 1, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_12_2:
+ax_anim 2, 0, 297, 1, -1, 1, -1,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 1, -1, 1, -1,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 1, -1, 1, -1,
+ax_anim 2, 2, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 1, -1, 1, -1,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 1, -1, 1, -1,
+ax_anim 2, 1, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_12_3:
+ax_anim 2, 0, 296, 0, -1, 0, -1,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, -1, 0, -1,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, -1, 0, -1,
+ax_anim 2, 2, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, -1, 0, -1,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, -1, 0, -1,
+ax_anim 2, 1, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_12_4:
+ax_anim 2, 0, 295, -1, -1, -1, -1,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 295, -1, -1, -1, -1,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 295, -1, -1, -1, -1,
+ax_anim 2, 2, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 295, -1, -1, -1, -1,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 295, -1, -1, -1, -1,
+ax_anim 2, 1, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_12_5:
+ax_anim 2, 0, 294, 1, 0, 1, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 1, 0, 1, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 1, 0, 1, 0,
+ax_anim 2, 2, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 1, 0, 1, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 1, 0, 1, 0,
+ax_anim 2, 1, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_12_6:
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 2, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 1, -1, 1, -1,
+ax_anim 2, 1, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_12_7:
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 2, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -1, 0, -1,
+ax_anim 2, 1, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_12_8:
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 2, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, -1, -1, -1, -1,
+ax_anim 2, 1, 291, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysAttackAnims_13_1:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 2, 298, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_13_2:
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 2, 305, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_13_3:
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 2, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_13_4:
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 2, 303, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_13_5:
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 2, 302, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_13_6:
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 2, 301, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_13_7:
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 2, 300, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackAnims_13_8:
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 2, 299, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysAttackGfx1:
+.incbin "baserom.gba", 0x16282C0, 0x200
+sDeoxysAttackSprites1:
+ax_sprite sDeoxysAttackGfx1, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx2:
+.incbin "baserom.gba", 0x16284D0, 0x200
+sDeoxysAttackSprites2:
+ax_sprite sDeoxysAttackGfx2, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx3:
+.incbin "baserom.gba", 0x16286E0, 0x200
+sDeoxysAttackSprites3:
+ax_sprite sDeoxysAttackGfx3, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx4:
+.incbin "baserom.gba", 0x16288F0, 0x200
+sDeoxysAttackSprites4:
+ax_sprite sDeoxysAttackGfx4, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx5:
+.incbin "baserom.gba", 0x1628B00, 0x200
+sDeoxysAttackSprites5:
+ax_sprite sDeoxysAttackGfx5, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx6:
+.incbin "baserom.gba", 0x1628D10, 0x200
+sDeoxysAttackSprites6:
+ax_sprite sDeoxysAttackGfx6, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx7:
+.incbin "baserom.gba", 0x1628F20, 0x100
+sDeoxysAttackSprites7:
+ax_sprite sDeoxysAttackGfx7, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx8:
+.incbin "baserom.gba", 0x1629030, 0x20
+sDeoxysAttackSprites8:
+ax_sprite sDeoxysAttackGfx8, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx9:
+.incbin "baserom.gba", 0x1629060, 0x40
+sDeoxysAttackSprites9:
+ax_sprite sDeoxysAttackGfx9, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx10:
+.incbin "baserom.gba", 0x16290B0, 0x20
+sDeoxysAttackSprites10:
+ax_sprite sDeoxysAttackGfx10, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx11:
+.incbin "baserom.gba", 0x16290E0, 0x200
+sDeoxysAttackSprites11:
+ax_sprite sDeoxysAttackGfx11, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx12:
+.incbin "baserom.gba", 0x16292F0, 0x100
+sDeoxysAttackSprites12:
+ax_sprite sDeoxysAttackGfx12, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx13:
+.incbin "baserom.gba", 0x1629400, 0x20
+sDeoxysAttackSprites13:
+ax_sprite sDeoxysAttackGfx13, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx14:
+.incbin "baserom.gba", 0x1629430, 0x40
+sDeoxysAttackSprites14:
+ax_sprite sDeoxysAttackGfx14, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx15:
+.incbin "baserom.gba", 0x1629480, 0x20
+sDeoxysAttackSprites15:
+ax_sprite sDeoxysAttackGfx15, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx16:
+.incbin "baserom.gba", 0x16294B0, 0x200
+sDeoxysAttackSprites16:
+ax_sprite sDeoxysAttackGfx16, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx17:
+.incbin "baserom.gba", 0x16296C0, 0x100
+sDeoxysAttackSprites17:
+ax_sprite sDeoxysAttackGfx17, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx18:
+.incbin "baserom.gba", 0x16297D0, 0x40
+sDeoxysAttackSprites18:
+ax_sprite sDeoxysAttackGfx18, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx19:
+.incbin "baserom.gba", 0x1629820, 0x20
+sDeoxysAttackSprites19:
+ax_sprite sDeoxysAttackGfx19, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx20:
+.incbin "baserom.gba", 0x1629850, 0x20
+sDeoxysAttackSprites20:
+ax_sprite sDeoxysAttackGfx20, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx21:
+.incbin "baserom.gba", 0x1629880, 0x200
+sDeoxysAttackSprites21:
+ax_sprite sDeoxysAttackGfx21, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx22:
+.incbin "baserom.gba", 0x1629A90, 0x100
+sDeoxysAttackSprites22:
+ax_sprite sDeoxysAttackGfx22, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx23:
+.incbin "baserom.gba", 0x1629BA0, 0x40
+sDeoxysAttackSprites23:
+ax_sprite sDeoxysAttackGfx23, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx24:
+.incbin "baserom.gba", 0x1629BF0, 0x20
+sDeoxysAttackSprites24:
+ax_sprite sDeoxysAttackGfx24, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx25:
+.incbin "baserom.gba", 0x1629C20, 0x20
+sDeoxysAttackSprites25:
+ax_sprite sDeoxysAttackGfx25, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx26:
+.incbin "baserom.gba", 0x1629C50, 0x200
+sDeoxysAttackSprites26:
+ax_sprite sDeoxysAttackGfx26, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx27:
+.incbin "baserom.gba", 0x1629E60, 0x200
+sDeoxysAttackSprites27:
+ax_sprite sDeoxysAttackGfx27, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx28:
+.incbin "baserom.gba", 0x162A070, 0x200
+sDeoxysAttackSprites28:
+ax_sprite sDeoxysAttackGfx28, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx29:
+.incbin "baserom.gba", 0x162A280, 0x60
+sDeoxysAttackGfx29_1:
+.incbin "baserom.gba", 0x162A2E0, 0x180
+sDeoxysAttackSprites29:
+ax_sprite sDeoxysAttackGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx29_1, 0x180
+ax_sprite_terminator
+sDeoxysAttackGfx30:
+.incbin "baserom.gba", 0x162A480, 0x40
+sDeoxysAttackGfx30_1:
+.incbin "baserom.gba", 0x162A4C0, 0x180
+sDeoxysAttackSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx30_1, 0x180
+ax_sprite_terminator
+sDeoxysAttackGfx31:
+.incbin "baserom.gba", 0x162A668, 0x40
+sDeoxysAttackGfx31_1:
+.incbin "baserom.gba", 0x162A6A8, 0x60
+sDeoxysAttackGfx31_2:
+.incbin "baserom.gba", 0x162A708, 0x60
+sDeoxysAttackGfx31_3:
+.incbin "baserom.gba", 0x162A768, 0x60
+sDeoxysAttackSprites31:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDeoxysAttackGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx31_3, 0x60
+ax_sprite_terminator
+sDeoxysAttackGfx32:
+.incbin "baserom.gba", 0x162A810, 0x40
+sDeoxysAttackGfx32_1:
+.incbin "baserom.gba", 0x162A850, 0x60
+sDeoxysAttackGfx32_2:
+.incbin "baserom.gba", 0x162A8B0, 0x60
+sDeoxysAttackGfx32_3:
+.incbin "baserom.gba", 0x162A910, 0x40
+sDeoxysAttackSprites32:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDeoxysAttackGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx33:
+.incbin "baserom.gba", 0x162A9A0, 0x200
+sDeoxysAttackSprites33:
+ax_sprite sDeoxysAttackGfx33, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx34:
+.incbin "baserom.gba", 0x162ABB0, 0x60
+sDeoxysAttackGfx34_1:
+.incbin "baserom.gba", 0x162AC10, 0x180
+sDeoxysAttackSprites34:
+ax_sprite sDeoxysAttackGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx34_1, 0x180
+ax_sprite_terminator
+sDeoxysAttackGfx35:
+.incbin "baserom.gba", 0x162ADB0, 0x60
+sDeoxysAttackGfx35_1:
+.incbin "baserom.gba", 0x162AE10, 0x180
+sDeoxysAttackSprites35:
+ax_sprite sDeoxysAttackGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx35_1, 0x180
+ax_sprite_terminator
+sDeoxysAttackGfx36:
+.incbin "baserom.gba", 0x162AFB0, 0x200
+sDeoxysAttackSprites36:
+ax_sprite sDeoxysAttackGfx36, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx37:
+.incbin "baserom.gba", 0x162B1C0, 0x60
+sDeoxysAttackGfx37_1:
+.incbin "baserom.gba", 0x162B220, 0x100
+sDeoxysAttackGfx37_2:
+.incbin "baserom.gba", 0x162B320, 0x60
+sDeoxysAttackSprites37:
+ax_sprite sDeoxysAttackGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx37_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx37_2, 0x60
+ax_sprite_terminator
+sDeoxysAttackGfx38:
+.incbin "baserom.gba", 0x162B3B0, 0x1E0
+sDeoxysAttackSprites38:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx38, 0x1e0
+ax_sprite_terminator
+sDeoxysAttackGfx39:
+.incbin "baserom.gba", 0x162B5A8, 0x1E0
+sDeoxysAttackSprites39:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx39, 0x1e0
+ax_sprite_terminator
+sDeoxysAttackGfx40:
+.incbin "baserom.gba", 0x162B7A0, 0xC0
+sDeoxysAttackGfx40_1:
+.incbin "baserom.gba", 0x162B860, 0x20
+sDeoxysAttackSprites40:
+ax_sprite sDeoxysAttackGfx40, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx40_1, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx41:
+.incbin "baserom.gba", 0x162B8A0, 0x80
+sDeoxysAttackSprites41:
+ax_sprite sDeoxysAttackGfx41, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx42:
+.incbin "baserom.gba", 0x162B930, 0x40
+sDeoxysAttackSprites42:
+ax_sprite sDeoxysAttackGfx42, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx43:
+.incbin "baserom.gba", 0x162B980, 0x20
+sDeoxysAttackSprites43:
+ax_sprite sDeoxysAttackGfx43, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx44:
+.incbin "baserom.gba", 0x162B9B0, 0x40
+sDeoxysAttackGfx44_1:
+.incbin "baserom.gba", 0x162B9F0, 0x80
+sDeoxysAttackSprites44:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx44_1, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx45:
+.incbin "baserom.gba", 0x162BA98, 0x80
+sDeoxysAttackSprites45:
+ax_sprite sDeoxysAttackGfx45, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx46:
+.incbin "baserom.gba", 0x162BB28, 0x40
+sDeoxysAttackSprites46:
+ax_sprite sDeoxysAttackGfx46, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx47:
+.incbin "baserom.gba", 0x162BB78, 0x20
+sDeoxysAttackSprites47:
+ax_sprite sDeoxysAttackGfx47, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx48:
+.incbin "baserom.gba", 0x162BBA8, 0x20
+sDeoxysAttackSprites48:
+ax_sprite sDeoxysAttackGfx48, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx49:
+.incbin "baserom.gba", 0x162BBD8, 0x40
+sDeoxysAttackGfx49_1:
+.incbin "baserom.gba", 0x162BC18, 0x60
+sDeoxysAttackGfx49_2:
+.incbin "baserom.gba", 0x162BC78, 0x60
+sDeoxysAttackGfx49_3:
+.incbin "baserom.gba", 0x162BCD8, 0x40
+sDeoxysAttackSprites49:
+ax_sprite 0, 0x40
+ax_sprite sDeoxysAttackGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx49_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDeoxysAttackGfx49_3, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx50:
+.incbin "baserom.gba", 0x162BD60, 0xE0
+sDeoxysAttackSprites50:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx50, 0xe0
+ax_sprite_terminator
+sDeoxysAttackGfx51:
+.incbin "baserom.gba", 0x162BE58, 0x80
+sDeoxysAttackSprites51:
+ax_sprite sDeoxysAttackGfx51, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx52:
+.incbin "baserom.gba", 0x162BEE8, 0x20
+sDeoxysAttackSprites52:
+ax_sprite sDeoxysAttackGfx52, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx53:
+.incbin "baserom.gba", 0x162BF20, 0x20
+sDeoxysAttackSprites53:
+ax_sprite sDeoxysAttackGfx53, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx54:
+.incbin "baserom.gba", 0x162BF50, 0x20
+sDeoxysAttackSprites54:
+ax_sprite sDeoxysAttackGfx54, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx55:
+.incbin "baserom.gba", 0x162BF80, 0x100
+sDeoxysAttackSprites55:
+ax_sprite sDeoxysAttackGfx55, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx56:
+.incbin "baserom.gba", 0x162C090, 0x80
+sDeoxysAttackSprites56:
+ax_sprite sDeoxysAttackGfx56, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx57:
+.incbin "baserom.gba", 0x162C120, 0x40
+sDeoxysAttackSprites57:
+ax_sprite sDeoxysAttackGfx57, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx58:
+.incbin "baserom.gba", 0x162C170, 0x20
+sDeoxysAttackSprites58:
+ax_sprite sDeoxysAttackGfx58, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx59:
+.incbin "baserom.gba", 0x162C1A0, 0xE0
+sDeoxysAttackGfx59_1:
+.incbin "baserom.gba", 0x162C280, 0x60
+sDeoxysAttackGfx59_2:
+.incbin "baserom.gba", 0x162C2E0, 0x60
+sDeoxysAttackSprites59:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx59, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx59_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx59_2, 0x60
+ax_sprite_terminator
+sDeoxysAttackGfx60:
+.incbin "baserom.gba", 0x162C378, 0x200
+sDeoxysAttackSprites60:
+ax_sprite sDeoxysAttackGfx60, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx61:
+.incbin "baserom.gba", 0x162C588, 0x200
+sDeoxysAttackSprites61:
+ax_sprite sDeoxysAttackGfx61, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx62:
+.incbin "baserom.gba", 0x162C798, 0x20
+sDeoxysAttackSprites62:
+ax_sprite sDeoxysAttackGfx62, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx63:
+.incbin "baserom.gba", 0x162C7C8, 0x60
+sDeoxysAttackGfx63_1:
+.incbin "baserom.gba", 0x162C828, 0x180
+sDeoxysAttackSprites63:
+ax_sprite sDeoxysAttackGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx63_1, 0x180
+ax_sprite_terminator
+sDeoxysAttackGfx64:
+.incbin "baserom.gba", 0x162C9C8, 0x20
+sDeoxysAttackSprites64:
+ax_sprite sDeoxysAttackGfx64, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx65:
+.incbin "baserom.gba", 0x162C9F8, 0x100
+sDeoxysAttackSprites65:
+ax_sprite sDeoxysAttackGfx65, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx66:
+.incbin "baserom.gba", 0x162CB08, 0x80
+sDeoxysAttackSprites66:
+ax_sprite sDeoxysAttackGfx66, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx67:
+.incbin "baserom.gba", 0x162CB98, 0x20
+sDeoxysAttackSprites67:
+ax_sprite sDeoxysAttackGfx67, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx68:
+.incbin "baserom.gba", 0x162CBC8, 0x20
+sDeoxysAttackSprites68:
+ax_sprite sDeoxysAttackGfx68, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx69:
+.incbin "baserom.gba", 0x162CBF8, 0x20
+sDeoxysAttackSprites69:
+ax_sprite sDeoxysAttackGfx69, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx70:
+.incbin "baserom.gba", 0x162CC28, 0x40
+sDeoxysAttackSprites70:
+ax_sprite sDeoxysAttackGfx70, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx71:
+.incbin "baserom.gba", 0x162CC78, 0x20
+sDeoxysAttackSprites71:
+ax_sprite sDeoxysAttackGfx71, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx72:
+.incbin "baserom.gba", 0x162CCA8, 0x80
+sDeoxysAttackSprites72:
+ax_sprite sDeoxysAttackGfx72, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx73:
+.incbin "baserom.gba", 0x162CD38, 0x80
+sDeoxysAttackSprites73:
+ax_sprite sDeoxysAttackGfx73, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx74:
+.incbin "baserom.gba", 0x162CDC8, 0x80
+sDeoxysAttackSprites74:
+ax_sprite sDeoxysAttackGfx74, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx75:
+.incbin "baserom.gba", 0x162CE58, 0x80
+sDeoxysAttackSprites75:
+ax_sprite sDeoxysAttackGfx75, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx76:
+.incbin "baserom.gba", 0x162CEE8, 0x100
+sDeoxysAttackSprites76:
+ax_sprite sDeoxysAttackGfx76, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx77:
+.incbin "baserom.gba", 0x162CFF8, 0x40
+sDeoxysAttackSprites77:
+ax_sprite sDeoxysAttackGfx77, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx78:
+.incbin "baserom.gba", 0x162D048, 0x20
+sDeoxysAttackSprites78:
+ax_sprite sDeoxysAttackGfx78, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx79:
+.incbin "baserom.gba", 0x162D078, 0x40
+sDeoxysAttackSprites79:
+ax_sprite sDeoxysAttackGfx79, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx80:
+.incbin "baserom.gba", 0x162D0C8, 0x20
+sDeoxysAttackSprites80:
+ax_sprite sDeoxysAttackGfx80, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx81:
+.incbin "baserom.gba", 0x162D0F8, 0x20
+sDeoxysAttackSprites81:
+ax_sprite sDeoxysAttackGfx81, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx82:
+.incbin "baserom.gba", 0x162D128, 0x20
+sDeoxysAttackSprites82:
+ax_sprite sDeoxysAttackGfx82, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx83:
+.incbin "baserom.gba", 0x162D158, 0x100
+sDeoxysAttackSprites83:
+ax_sprite sDeoxysAttackGfx83, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx84:
+.incbin "baserom.gba", 0x162D268, 0x40
+sDeoxysAttackSprites84:
+ax_sprite sDeoxysAttackGfx84, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx85:
+.incbin "baserom.gba", 0x162D2B8, 0x20
+sDeoxysAttackSprites85:
+ax_sprite sDeoxysAttackGfx85, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx86:
+.incbin "baserom.gba", 0x162D2E8, 0x20
+sDeoxysAttackSprites86:
+ax_sprite sDeoxysAttackGfx86, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx87:
+.incbin "baserom.gba", 0x162D318, 0x40
+sDeoxysAttackSprites87:
+ax_sprite sDeoxysAttackGfx87, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx88:
+.incbin "baserom.gba", 0x162D368, 0xE0
+sDeoxysAttackSprites88:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysAttackGfx88, 0xe0
+ax_sprite_terminator
+sDeoxysAttackGfx89:
+.incbin "baserom.gba", 0x162D460, 0x40
+sDeoxysAttackSprites89:
+ax_sprite sDeoxysAttackGfx89, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx90:
+.incbin "baserom.gba", 0x162D4B0, 0x20
+sDeoxysAttackSprites90:
+ax_sprite sDeoxysAttackGfx90, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx91:
+.incbin "baserom.gba", 0x162D4E0, 0x40
+sDeoxysAttackSprites91:
+ax_sprite sDeoxysAttackGfx91, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx92:
+.incbin "baserom.gba", 0x162D530, 0x40
+sDeoxysAttackSprites92:
+ax_sprite sDeoxysAttackGfx92, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx93:
+.incbin "baserom.gba", 0x162D580, 0x20
+sDeoxysAttackSprites93:
+ax_sprite sDeoxysAttackGfx93, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx94:
+.incbin "baserom.gba", 0x162D5B0, 0x100
+sDeoxysAttackSprites94:
+ax_sprite sDeoxysAttackGfx94, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx95:
+.incbin "baserom.gba", 0x162D6C0, 0x80
+sDeoxysAttackSprites95:
+ax_sprite sDeoxysAttackGfx95, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx96:
+.incbin "baserom.gba", 0x162D750, 0x40
+sDeoxysAttackSprites96:
+ax_sprite sDeoxysAttackGfx96, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx97:
+.incbin "baserom.gba", 0x162D7A0, 0x20
+sDeoxysAttackSprites97:
+ax_sprite sDeoxysAttackGfx97, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx98:
+.incbin "baserom.gba", 0x162D7D0, 0x20
+sDeoxysAttackSprites98:
+ax_sprite sDeoxysAttackGfx98, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx99:
+.incbin "baserom.gba", 0x162D800, 0x200
+sDeoxysAttackSprites99:
+ax_sprite sDeoxysAttackGfx99, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx100:
+.incbin "baserom.gba", 0x162DA10, 0x200
+sDeoxysAttackSprites100:
+ax_sprite sDeoxysAttackGfx100, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx101:
+.incbin "baserom.gba", 0x162DC20, 0x200
+sDeoxysAttackSprites101:
+ax_sprite sDeoxysAttackGfx101, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx102:
+.incbin "baserom.gba", 0x162DE30, 0x200
+sDeoxysAttackSprites102:
+ax_sprite sDeoxysAttackGfx102, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx103:
+.incbin "baserom.gba", 0x162E040, 0x200
+sDeoxysAttackSprites103:
+ax_sprite sDeoxysAttackGfx103, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx104:
+.incbin "baserom.gba", 0x162E250, 0x200
+sDeoxysAttackSprites104:
+ax_sprite sDeoxysAttackGfx104, 0x200
+ax_sprite_terminator
+sDeoxysAttackGfx105:
+.incbin "baserom.gba", 0x162E460, 0x100
+sDeoxysAttackSprites105:
+ax_sprite sDeoxysAttackGfx105, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx106:
+.incbin "baserom.gba", 0x162E570, 0x40
+sDeoxysAttackSprites106:
+ax_sprite sDeoxysAttackGfx106, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx107:
+.incbin "baserom.gba", 0x162E5C0, 0x20
+sDeoxysAttackSprites107:
+ax_sprite sDeoxysAttackGfx107, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx108:
+.incbin "baserom.gba", 0x162E5F0, 0x20
+sDeoxysAttackSprites108:
+ax_sprite sDeoxysAttackGfx108, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx109:
+.incbin "baserom.gba", 0x162E620, 0x100
+sDeoxysAttackSprites109:
+ax_sprite sDeoxysAttackGfx109, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx110:
+.incbin "baserom.gba", 0x162E730, 0x40
+sDeoxysAttackSprites110:
+ax_sprite sDeoxysAttackGfx110, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx111:
+.incbin "baserom.gba", 0x162E780, 0x100
+sDeoxysAttackSprites111:
+ax_sprite sDeoxysAttackGfx111, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx112:
+.incbin "baserom.gba", 0x162E890, 0x40
+sDeoxysAttackSprites112:
+ax_sprite sDeoxysAttackGfx112, 0x40
+ax_sprite_terminator
+sDeoxysAttackGfx113:
+.incbin "baserom.gba", 0x162E8E0, 0x20
+sDeoxysAttackSprites113:
+ax_sprite sDeoxysAttackGfx113, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx114:
+.incbin "baserom.gba", 0x162E910, 0x100
+sDeoxysAttackSprites114:
+ax_sprite sDeoxysAttackGfx114, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx115:
+.incbin "baserom.gba", 0x162EA20, 0x80
+sDeoxysAttackSprites115:
+ax_sprite sDeoxysAttackGfx115, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx116:
+.incbin "baserom.gba", 0x162EAB0, 0x20
+sDeoxysAttackSprites116:
+ax_sprite sDeoxysAttackGfx116, 0x20
+ax_sprite_terminator
+sDeoxysAttackGfx117:
+.incbin "baserom.gba", 0x162EAE0, 0x100
+sDeoxysAttackSprites117:
+ax_sprite sDeoxysAttackGfx117, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx118:
+.incbin "baserom.gba", 0x162EBF0, 0x80
+sDeoxysAttackSprites118:
+ax_sprite sDeoxysAttackGfx118, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx119:
+.incbin "baserom.gba", 0x162EC80, 0x100
+sDeoxysAttackSprites119:
+ax_sprite sDeoxysAttackGfx119, 0x100
+ax_sprite_terminator
+sDeoxysAttackGfx120:
+.incbin "baserom.gba", 0x162ED90, 0x80
+sDeoxysAttackSprites120:
+ax_sprite sDeoxysAttackGfx120, 0x80
+ax_sprite_terminator
+sDeoxysAttackGfx121:
+.incbin "baserom.gba", 0x162EE20, 0x200
+sDeoxysAttackSprites121:
+ax_sprite sDeoxysAttackGfx121, 0x200
+ax_sprite_terminator
+sAxPosesDeoxysAttack:
+.4byte sDeoxysAttackPose1
+.4byte sDeoxysAttackPose2
+.4byte sDeoxysAttackPose3
+.4byte sDeoxysAttackPose4
+.4byte sDeoxysAttackPose5
+.4byte sDeoxysAttackPose6
+.4byte sDeoxysAttackPose7
+.4byte sDeoxysAttackPose8
+.4byte sDeoxysAttackPose9
+.4byte sDeoxysAttackPose10
+.4byte sDeoxysAttackPose11
+.4byte sDeoxysAttackPose12
+.4byte sDeoxysAttackPose13
+.4byte sDeoxysAttackPose14
+.4byte sDeoxysAttackPose15
+.4byte sDeoxysAttackPose16
+.4byte sDeoxysAttackPose17
+.4byte sDeoxysAttackPose18
+.4byte sDeoxysAttackPose19
+.4byte sDeoxysAttackPose20
+.4byte sDeoxysAttackPose21
+.4byte sDeoxysAttackPose22
+.4byte sDeoxysAttackPose23
+.4byte sDeoxysAttackPose24
+.4byte sDeoxysAttackPose25
+.4byte sDeoxysAttackPose26
+.4byte sDeoxysAttackPose27
+.4byte sDeoxysAttackPose28
+.4byte sDeoxysAttackPose29
+.4byte sDeoxysAttackPose30
+.4byte sDeoxysAttackPose31
+.4byte sDeoxysAttackPose32
+.4byte sDeoxysAttackPose33
+.4byte sDeoxysAttackPose34
+.4byte sDeoxysAttackPose35
+.4byte sDeoxysAttackPose36
+.4byte sDeoxysAttackPose37
+.4byte sDeoxysAttackPose38
+.4byte sDeoxysAttackPose39
+.4byte sDeoxysAttackPose40
+.4byte sDeoxysAttackPose41
+.4byte sDeoxysAttackPose42
+.4byte sDeoxysAttackPose43
+.4byte sDeoxysAttackPose44
+.4byte sDeoxysAttackPose45
+.4byte sDeoxysAttackPose46
+.4byte sDeoxysAttackPose47
+.4byte sDeoxysAttackPose48
+.4byte sDeoxysAttackPose49
+.4byte sDeoxysAttackPose50
+.4byte sDeoxysAttackPose51
+.4byte sDeoxysAttackPose52
+.4byte sDeoxysAttackPose53
+.4byte sDeoxysAttackPose54
+.4byte sDeoxysAttackPose55
+.4byte sDeoxysAttackPose56
+.4byte sDeoxysAttackPose57
+.4byte sDeoxysAttackPose58
+.4byte sDeoxysAttackPose59
+.4byte sDeoxysAttackPose60
+.4byte sDeoxysAttackPose61
+.4byte sDeoxysAttackPose62
+.4byte sDeoxysAttackPose63
+.4byte sDeoxysAttackPose64
+.4byte sDeoxysAttackPose65
+.4byte sDeoxysAttackPose66
+.4byte sDeoxysAttackPose67
+.4byte sDeoxysAttackPose68
+.4byte sDeoxysAttackPose69
+.4byte sDeoxysAttackPose70
+.4byte sDeoxysAttackPose71
+.4byte sDeoxysAttackPose72
+.4byte sDeoxysAttackPose73
+.4byte sDeoxysAttackPose74
+.4byte sDeoxysAttackPose75
+.4byte sDeoxysAttackPose76
+.4byte sDeoxysAttackPose77
+.4byte sDeoxysAttackPose78
+.4byte sDeoxysAttackPose79
+.4byte sDeoxysAttackPose80
+.4byte sDeoxysAttackPose81
+.4byte sDeoxysAttackPose82
+.4byte sDeoxysAttackPose83
+.4byte sDeoxysAttackPose84
+.4byte sDeoxysAttackPose85
+.4byte sDeoxysAttackPose86
+.4byte sDeoxysAttackPose87
+.4byte sDeoxysAttackPose88
+.4byte sDeoxysAttackPose89
+.4byte sDeoxysAttackPose90
+.4byte sDeoxysAttackPose91
+.4byte sDeoxysAttackPose92
+.4byte sDeoxysAttackPose93
+.4byte sDeoxysAttackPose94
+.4byte sDeoxysAttackPose95
+.4byte sDeoxysAttackPose96
+.4byte sDeoxysAttackPose97
+.4byte sDeoxysAttackPose98
+.4byte sDeoxysAttackPose99
+.4byte sDeoxysAttackPose100
+.4byte sDeoxysAttackPose101
+.4byte sDeoxysAttackPose102
+.4byte sDeoxysAttackPose103
+.4byte sDeoxysAttackPose104
+.4byte sDeoxysAttackPose105
+.4byte sDeoxysAttackPose106
+.4byte sDeoxysAttackPose107
+.4byte sDeoxysAttackPose108
+.4byte sDeoxysAttackPose109
+.4byte sDeoxysAttackPose110
+.4byte sDeoxysAttackPose111
+.4byte sDeoxysAttackPose112
+.4byte sDeoxysAttackPose113
+.4byte sDeoxysAttackPose114
+.4byte sDeoxysAttackPose115
+.4byte sDeoxysAttackPose116
+.4byte sDeoxysAttackPose117
+.4byte sDeoxysAttackPose118
+.4byte sDeoxysAttackPose119
+.4byte sDeoxysAttackPose120
+.4byte sDeoxysAttackPose121
+.4byte sDeoxysAttackPose122
+.4byte sDeoxysAttackPose123
+.4byte sDeoxysAttackPose124
+.4byte sDeoxysAttackPose125
+.4byte sDeoxysAttackPose126
+.4byte sDeoxysAttackPose127
+.4byte sDeoxysAttackPose128
+.4byte sDeoxysAttackPose129
+.4byte sDeoxysAttackPose130
+.4byte sDeoxysAttackPose131
+.4byte sDeoxysAttackPose132
+.4byte sDeoxysAttackPose133
+.4byte sDeoxysAttackPose134
+.4byte sDeoxysAttackPose135
+.4byte sDeoxysAttackPose136
+.4byte sDeoxysAttackPose137
+.4byte sDeoxysAttackPose138
+.4byte sDeoxysAttackPose139
+.4byte sDeoxysAttackPose140
+.4byte sDeoxysAttackPose141
+.4byte sDeoxysAttackPose142
+.4byte sDeoxysAttackPose143
+.4byte sDeoxysAttackPose144
+.4byte sDeoxysAttackPose145
+.4byte sDeoxysAttackPose146
+.4byte sDeoxysAttackPose147
+.4byte sDeoxysAttackPose148
+.4byte sDeoxysAttackPose149
+.4byte sDeoxysAttackPose150
+.4byte sDeoxysAttackPose151
+.4byte sDeoxysAttackPose152
+.4byte sDeoxysAttackPose153
+.4byte sDeoxysAttackPose154
+.4byte sDeoxysAttackPose155
+.4byte sDeoxysAttackPose156
+.4byte sDeoxysAttackPose157
+.4byte sDeoxysAttackPose158
+.4byte sDeoxysAttackPose159
+.4byte sDeoxysAttackPose160
+.4byte sDeoxysAttackPose161
+.4byte sDeoxysAttackPose162
+.4byte sDeoxysAttackPose163
+.4byte sDeoxysAttackPose164
+.4byte sDeoxysAttackPose165
+.4byte sDeoxysAttackPose166
+.4byte sDeoxysAttackPose167
+.4byte sDeoxysAttackPose168
+.4byte sDeoxysAttackPose169
+.4byte sDeoxysAttackPose170
+.4byte sDeoxysAttackPose171
+.4byte sDeoxysAttackPose172
+.4byte sDeoxysAttackPose173
+.4byte sDeoxysAttackPose174
+.4byte sDeoxysAttackPose175
+.4byte sDeoxysAttackPose176
+.4byte sDeoxysAttackPose177
+.4byte sDeoxysAttackPose178
+.4byte sDeoxysAttackPose179
+.4byte sDeoxysAttackPose180
+.4byte sDeoxysAttackPose181
+.4byte sDeoxysAttackPose182
+.4byte sDeoxysAttackPose183
+.4byte sDeoxysAttackPose184
+.4byte sDeoxysAttackPose185
+.4byte sDeoxysAttackPose186
+.4byte sDeoxysAttackPose187
+.4byte sDeoxysAttackPose188
+.4byte sDeoxysAttackPose189
+.4byte sDeoxysAttackPose190
+.4byte sDeoxysAttackPose191
+.4byte sDeoxysAttackPose192
+.4byte sDeoxysAttackPose193
+.4byte sDeoxysAttackPose194
+.4byte sDeoxysAttackPose195
+.4byte sDeoxysAttackPose196
+.4byte sDeoxysAttackPose197
+.4byte sDeoxysAttackPose198
+.4byte sDeoxysAttackPose199
+.4byte sDeoxysAttackPose200
+.4byte sDeoxysAttackPose201
+.4byte sDeoxysAttackPose202
+.4byte sDeoxysAttackPose203
+.4byte sDeoxysAttackPose204
+.4byte sDeoxysAttackPose205
+.4byte sDeoxysAttackPose206
+.4byte sDeoxysAttackPose207
+.4byte sDeoxysAttackPose208
+.4byte sDeoxysAttackPose209
+.4byte sDeoxysAttackPose210
+.4byte sDeoxysAttackPose211
+.4byte sDeoxysAttackPose212
+.4byte sDeoxysAttackPose213
+.4byte sDeoxysAttackPose214
+.4byte sDeoxysAttackPose215
+.4byte sDeoxysAttackPose216
+.4byte sDeoxysAttackPose217
+.4byte sDeoxysAttackPose218
+.4byte sDeoxysAttackPose219
+.4byte sDeoxysAttackPose220
+.4byte sDeoxysAttackPose221
+.4byte sDeoxysAttackPose222
+.4byte sDeoxysAttackPose223
+.4byte sDeoxysAttackPose224
+.4byte sDeoxysAttackPose225
+.4byte sDeoxysAttackPose226
+.4byte sDeoxysAttackPose227
+.4byte sDeoxysAttackPose228
+.4byte sDeoxysAttackPose229
+.4byte sDeoxysAttackPose230
+.4byte sDeoxysAttackPose231
+.4byte sDeoxysAttackPose232
+.4byte sDeoxysAttackPose233
+.4byte sDeoxysAttackPose234
+.4byte sDeoxysAttackPose235
+.4byte sDeoxysAttackPose236
+.4byte sDeoxysAttackPose237
+.4byte sDeoxysAttackPose238
+.4byte sDeoxysAttackPose239
+.4byte sDeoxysAttackPose240
+.4byte sDeoxysAttackPose241
+.4byte sDeoxysAttackPose242
+.4byte sDeoxysAttackPose243
+.4byte sDeoxysAttackPose244
+.4byte sDeoxysAttackPose245
+.4byte sDeoxysAttackPose246
+.4byte sDeoxysAttackPose247
+.4byte sDeoxysAttackPose248
+.4byte sDeoxysAttackPose249
+.4byte sDeoxysAttackPose250
+.4byte sDeoxysAttackPose251
+.4byte sDeoxysAttackPose252
+.4byte sDeoxysAttackPose253
+.4byte sDeoxysAttackPose254
+.4byte sDeoxysAttackPose255
+.4byte sDeoxysAttackPose256
+.4byte sDeoxysAttackPose257
+.4byte sDeoxysAttackPose258
+.4byte sDeoxysAttackPose259
+.4byte sDeoxysAttackPose260
+.4byte sDeoxysAttackPose261
+.4byte sDeoxysAttackPose262
+.4byte sDeoxysAttackPose263
+.4byte sDeoxysAttackPose264
+.4byte sDeoxysAttackPose265
+.4byte sDeoxysAttackPose266
+.4byte sDeoxysAttackPose267
+.4byte sDeoxysAttackPose268
+.4byte sDeoxysAttackPose269
+.4byte sDeoxysAttackPose270
+.4byte sDeoxysAttackPose271
+.4byte sDeoxysAttackPose272
+.4byte sDeoxysAttackPose273
+.4byte sDeoxysAttackPose274
+.4byte sDeoxysAttackPose275
+.4byte sDeoxysAttackPose276
+.4byte sDeoxysAttackPose277
+.4byte sDeoxysAttackPose278
+.4byte sDeoxysAttackPose279
+.4byte sDeoxysAttackPose280
+.4byte sDeoxysAttackPose281
+.4byte sDeoxysAttackPose282
+.4byte sDeoxysAttackPose283
+.4byte sDeoxysAttackPose284
+.4byte sDeoxysAttackPose285
+.4byte sDeoxysAttackPose286
+.4byte sDeoxysAttackPose287
+.4byte sDeoxysAttackPose288
+.4byte sDeoxysAttackPose289
+.4byte sDeoxysAttackPose290
+.4byte sDeoxysAttackPose291
+.4byte sDeoxysAttackPose292
+.4byte sDeoxysAttackPose293
+.4byte sDeoxysAttackPose294
+.4byte sDeoxysAttackPose295
+.4byte sDeoxysAttackPose296
+.4byte sDeoxysAttackPose297
+.4byte sDeoxysAttackPose298
+.4byte sDeoxysAttackPose299
+.4byte sDeoxysAttackPose300
+.4byte sDeoxysAttackPose301
+.4byte sDeoxysAttackPose302
+.4byte sDeoxysAttackPose303
+.4byte sDeoxysAttackPose304
+.4byte sDeoxysAttackPose305
+.4byte sDeoxysAttackPose306
+sAxPositionsDeoxysAttack:
+.2byte    0,  -14, 	 -11,   -2, 	  12,   -8, 	  -1,  -13
+.2byte   -1,  -13, 	 -10,   -2, 	  11,   -5, 	  -1,  -12
+.2byte   -2,  -14, 	   9,   -2, 	 -14,   -8, 	  -1,  -13
+.2byte   -1,  -13, 	   8,   -2, 	 -13,   -5, 	  -1,  -12
+.2byte   -1,  -16, 	   8,   -7, 	 -12,   -6, 	  -1,  -15
+.2byte    1,  -15, 	   8,   -7, 	 -10,   -5, 	   0,  -14
+.2byte    2,  -16, 	  11,  -10, 	 -10,   -3, 	   1,  -15
+.2byte    1,  -15, 	   9,   -8, 	  -9,   -2, 	  -1,  -15
+.2byte    0,  -16, 	  -9,  -12, 	  -8,   -6, 	  -3,  -15
+.2byte    0,  -15, 	  -9,  -12, 	  -7,   -4, 	  -3,  -14
+.2byte    0,  -16, 	  -7,   -5, 	  -8,   -3, 	  -3,  -15
+.2byte    0,  -15, 	  -7,   -4, 	  -8,   -2, 	  -3,  -15
+.2byte    0,  -17, 	 -10,   -7, 	   1,   -4, 	  -2,  -16
+.2byte    0,  -16, 	 -10,   -6, 	   2,   -1, 	  -2,  -15
+.2byte    0,  -17, 	 -11,   -9, 	   3,   -1, 	  -2,  -16
+.2byte    0,  -16, 	 -10,   -7, 	   2,    0, 	  -2,  -15
+.2byte    0,  -17, 	  12,   -3, 	 -13,   -6, 	   0,  -14
+.2byte    0,  -16, 	  11,   -3, 	 -11,   -5, 	   0,  -13
+.2byte    0,  -17, 	 -12,   -3, 	  13,   -6, 	   0,  -14
+.2byte    0,  -16, 	 -11,   -3, 	  11,   -5, 	   0,  -13
+.2byte    0,  -17, 	  10,   -7, 	  -1,   -4, 	   2,  -16
+.2byte    0,  -16, 	  10,   -6, 	  -2,   -1, 	   2,  -15
+.2byte    0,  -17, 	  11,   -9, 	  -3,   -1, 	   2,  -16
+.2byte    0,  -16, 	  10,   -7, 	  -2,    0, 	   2,  -15
+.2byte    0,  -16, 	   9,  -12, 	   8,   -6, 	   3,  -15
+.2byte    0,  -15, 	   9,  -12, 	   7,   -4, 	   3,  -14
+.2byte    0,  -16, 	   7,   -5, 	   8,   -3, 	   3,  -15
+.2byte    0,  -15, 	   7,   -4, 	   8,   -2, 	   3,  -15
+.2byte    0,  -16, 	  -9,   -7, 	  11,   -6, 	   0,  -15
+.2byte   -1,  -15, 	  -8,   -7, 	  10,   -5, 	   0,  -14
+.2byte   -2,  -16, 	 -11,  -10, 	  10,   -3, 	  -1,  -15
+.2byte   -1,  -15, 	  -9,   -8, 	   9,   -2, 	   1,  -15
+.2byte    0,  -14, 	 -11,   -2, 	  12,   -8, 	  -1,  -13
+.2byte   -1,  -13, 	 -10,   -2, 	  11,   -5, 	  -1,  -12
+.2byte   -2,  -14, 	   9,   -2, 	 -14,   -8, 	  -1,  -13
+.2byte   -1,  -13, 	   8,   -2, 	 -13,   -5, 	  -1,  -12
+.2byte   -1,  -13, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte    0,  -16, 	   9,   -7, 	 -11,   -6, 	   0,  -15
+.2byte    1,  -15, 	   8,   -7, 	 -10,   -5, 	   0,  -14
+.2byte    2,  -16, 	  11,  -10, 	 -10,   -3, 	   1,  -15
+.2byte    1,  -15, 	   9,   -8, 	  -9,   -2, 	  -1,  -15
+.2byte    1,  -14, 	  10,   -8, 	 -11,   -2, 	   0,  -14
+.2byte    0,  -16, 	  -9,  -12, 	  -8,   -6, 	  -3,  -15
+.2byte    0,  -15, 	  -9,  -12, 	  -7,   -4, 	  -3,  -14
+.2byte    0,  -16, 	  -7,   -5, 	  -8,   -3, 	  -3,  -15
+.2byte    0,  -15, 	  -7,   -4, 	  -8,   -2, 	  -3,  -15
+.2byte    1,  -15, 	  -7,   -3, 	  -9,   -1, 	  -2,  -15
+.2byte    0,  -17, 	 -10,   -7, 	   1,   -4, 	  -2,  -16
+.2byte    0,  -16, 	 -10,   -6, 	   2,   -1, 	  -2,  -15
+.2byte    0,  -17, 	 -11,   -9, 	   3,   -1, 	  -2,  -16
+.2byte    0,  -16, 	 -10,   -7, 	   2,    0, 	  -2,  -15
+.2byte   -1,  -15, 	 -12,   -8, 	   1,    0, 	  -3,  -15
+.2byte    0,  -17, 	  12,   -3, 	 -13,   -6, 	   0,  -14
+.2byte    0,  -16, 	  11,   -3, 	 -11,   -5, 	   0,  -13
+.2byte    0,  -17, 	 -12,   -3, 	  13,   -6, 	   0,  -14
+.2byte    0,  -16, 	 -11,   -3, 	  11,   -5, 	   0,  -13
+.2byte    0,  -17, 	  10,   -3, 	 -10,   -4, 	   0,  -14
+.2byte    0,  -17, 	  10,   -7, 	  -1,   -4, 	   2,  -16
+.2byte    0,  -16, 	  10,   -6, 	  -2,   -1, 	   2,  -15
+.2byte    0,  -17, 	  11,   -9, 	  -3,   -1, 	   2,  -16
+.2byte    0,  -16, 	  10,   -7, 	  -2,    0, 	   2,  -15
+.2byte    1,  -15, 	  12,   -8, 	  -1,    0, 	   3,  -15
+.2byte    0,  -16, 	   9,  -12, 	   8,   -6, 	   3,  -15
+.2byte    0,  -15, 	   9,  -12, 	   7,   -4, 	   3,  -14
+.2byte    0,  -16, 	   7,   -5, 	   8,   -3, 	   3,  -15
+.2byte    0,  -15, 	   7,   -4, 	   8,   -2, 	   3,  -15
+.2byte   -1,  -15, 	   7,   -3, 	   9,   -1, 	   2,  -15
+.2byte    0,  -16, 	  -9,   -7, 	  11,   -6, 	   0,  -15
+.2byte   -1,  -15, 	  -8,   -7, 	  10,   -5, 	   0,  -14
+.2byte   -2,  -16, 	 -11,  -10, 	  10,   -3, 	  -1,  -15
+.2byte   -1,  -15, 	  -9,   -8, 	   9,   -2, 	   1,  -15
+.2byte   -1,  -14, 	 -10,   -8, 	  11,   -2, 	   0,  -14
+.2byte    0,  -14, 	 -11,   -2, 	  12,   -8, 	  -1,  -13
+.2byte   -1,  -13, 	 -10,   -2, 	  11,   -5, 	  -1,  -12
+.2byte   -2,  -14, 	   9,   -2, 	 -14,   -8, 	  -1,  -13
+.2byte   -1,  -13, 	   8,   -2, 	 -13,   -5, 	  -1,  -12
+.2byte   -1,  -13, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte    0,  -16, 	   9,   -7, 	 -11,   -6, 	   0,  -15
+.2byte    1,  -15, 	   8,   -7, 	 -10,   -5, 	   0,  -14
+.2byte    2,  -16, 	  11,  -10, 	 -10,   -3, 	   1,  -15
+.2byte    1,  -15, 	   9,   -8, 	  -9,   -2, 	  -1,  -15
+.2byte    1,  -14, 	  10,   -8, 	 -11,   -2, 	   0,  -14
+.2byte    0,  -16, 	  -9,  -12, 	  -8,   -6, 	  -3,  -15
+.2byte    0,  -15, 	  -9,  -12, 	  -7,   -4, 	  -3,  -14
+.2byte    0,  -16, 	  -7,   -5, 	  -8,   -3, 	  -3,  -15
+.2byte    0,  -15, 	  -7,   -4, 	  -8,   -2, 	  -3,  -15
+.2byte    1,  -15, 	  -7,   -3, 	  -9,   -1, 	  -2,  -15
+.2byte    0,  -17, 	 -10,   -7, 	   1,   -4, 	  -2,  -16
+.2byte    0,  -16, 	 -10,   -6, 	   2,   -1, 	  -2,  -15
+.2byte    0,  -17, 	 -11,   -9, 	   3,   -1, 	  -2,  -16
+.2byte    0,  -16, 	 -10,   -7, 	   2,    0, 	  -2,  -15
+.2byte   -1,  -15, 	 -12,   -8, 	   1,    0, 	  -3,  -15
+.2byte    0,  -17, 	  12,   -3, 	 -13,   -6, 	   0,  -14
+.2byte    0,  -16, 	  11,   -3, 	 -11,   -5, 	   0,  -13
+.2byte    0,  -17, 	 -12,   -3, 	  13,   -6, 	   0,  -14
+.2byte    0,  -16, 	 -11,   -3, 	  11,   -5, 	   0,  -13
+.2byte    0,  -17, 	  10,   -3, 	 -10,   -4, 	   0,  -14
+.2byte    0,  -17, 	  10,   -7, 	  -1,   -4, 	   2,  -16
+.2byte    0,  -16, 	  10,   -6, 	  -2,   -1, 	   2,  -15
+.2byte    0,  -17, 	  11,   -9, 	  -3,   -1, 	   2,  -16
+.2byte    0,  -16, 	  10,   -7, 	  -2,    0, 	   2,  -15
+.2byte    1,  -15, 	  12,   -8, 	  -1,    0, 	   3,  -15
+.2byte    0,  -16, 	   9,  -12, 	   8,   -6, 	   3,  -15
+.2byte    0,  -15, 	   9,  -12, 	   7,   -4, 	   3,  -14
+.2byte    0,  -16, 	   7,   -5, 	   8,   -3, 	   3,  -15
+.2byte    0,  -15, 	   7,   -4, 	   8,   -2, 	   3,  -15
+.2byte   -1,  -15, 	   7,   -3, 	   9,   -1, 	   2,  -15
+.2byte    0,  -16, 	  -9,   -7, 	  11,   -6, 	   0,  -15
+.2byte   -1,  -15, 	  -8,   -7, 	  10,   -5, 	   0,  -14
+.2byte   -2,  -16, 	 -11,  -10, 	  10,   -3, 	  -1,  -15
+.2byte   -1,  -15, 	  -9,   -8, 	   9,   -2, 	   1,  -15
+.2byte   -1,  -14, 	 -10,   -8, 	  11,   -2, 	   0,  -14
+.2byte   -1,  -15, 	 -12,  -22, 	   7,  -16, 	  -1,  -13
+.2byte   -1,  -13, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,  -14, 	  -8,   -2, 	   6,   -2, 	  -1,  -13
+.2byte   -1,  -18, 	 -13,   -8, 	  11,  -27, 	  -1,  -15
+.2byte    2,  -16, 	  11,  -22, 	  -3,  -15, 	   0,  -14
+.2byte    1,  -14, 	  10,   -8, 	 -11,   -2, 	   0,  -14
+.2byte    2,  -14, 	  17,   -8, 	   8,   -3, 	   1,  -13
+.2byte    0,  -20, 	  13,  -12, 	 -13,  -23, 	  -1,  -19
+.2byte    1,  -16, 	   7,  -26, 	   7,  -14, 	  -1,  -14
+.2byte    1,  -15, 	  -7,   -3, 	  -9,   -1, 	  -2,  -15
+.2byte    3,  -16, 	  17,  -19, 	  16,  -13, 	   0,  -15
+.2byte    1,  -17, 	   6,  -11, 	  -1,  -19, 	  -1,  -16
+.2byte    1,  -16, 	  -5,  -25, 	   9,  -17, 	  -1,  -15
+.2byte   -1,  -15, 	 -12,   -8, 	   1,    0, 	  -3,  -15
+.2byte    1,  -16, 	   5,  -31, 	  16,  -24, 	  -2,  -15
+.2byte    1,  -16, 	   2,   -8, 	   8,  -22, 	   0,  -13
+.2byte    0,  -17, 	  11,  -21, 	  -5,  -18, 	   0,  -14
+.2byte    0,  -17, 	  10,   -3, 	 -10,   -4, 	   0,  -14
+.2byte    0,  -16, 	   7,  -30, 	  -7,  -30, 	   0,  -14
+.2byte    0,  -16, 	  12,   -7, 	 -13,  -25, 	   0,  -13
+.2byte   -1,  -16, 	   5,  -25, 	  -9,  -17, 	   1,  -15
+.2byte    1,  -15, 	  12,   -8, 	  -1,    0, 	   3,  -15
+.2byte   -1,  -16, 	  -5,  -31, 	 -16,  -24, 	   2,  -15
+.2byte    0,  -16, 	  -1,   -8, 	  -7,  -22, 	   1,  -13
+.2byte   -1,  -16, 	  -7,  -26, 	  -7,  -14, 	   1,  -14
+.2byte   -1,  -15, 	   7,   -3, 	   9,   -1, 	   2,  -15
+.2byte   -3,  -16, 	 -17,  -19, 	 -16,  -13, 	   0,  -15
+.2byte   -3,  -17, 	  -8,  -11, 	  -1,  -19, 	  -1,  -16
+.2byte   -2,  -16, 	 -11,  -22, 	   3,  -15, 	   0,  -14
+.2byte   -1,  -14, 	 -10,   -8, 	  11,   -2, 	   0,  -14
+.2byte   -2,  -14, 	 -17,   -8, 	  -8,   -3, 	  -1,  -13
+.2byte   -1,  -20, 	 -14,  -12, 	  12,  -23, 	   0,  -19
+.2byte   -1,  -15, 	 -12,  -22, 	   7,  -16, 	  -1,  -13
+.2byte   -1,  -16, 	 -13,  -24, 	   7,  -17, 	  -1,  -14
+.2byte   -1,  -16, 	 -13,  -24, 	   7,  -17, 	  -1,  -14
+.2byte   -1,  -16, 	 -13,  -24, 	   7,  -17, 	  -1,  -14
+.2byte   -1,  -16, 	 -13,  -24, 	   7,  -17, 	  -1,  -14
+.2byte   -1,  -16, 	 -13,  -24, 	   7,  -17, 	  -1,  -14
+.2byte   -1,  -16, 	 -13,  -24, 	   7,  -17, 	  -1,  -14
+.2byte   -1,  -16, 	 -13,  -24, 	   7,  -17, 	  -1,  -14
+.2byte    2,  -16, 	  11,  -22, 	  -3,  -15, 	   0,  -14
+.2byte    2,  -17, 	  12,  -24, 	  -3,  -16, 	  -1,  -15
+.2byte    2,  -17, 	  12,  -24, 	  -3,  -16, 	  -1,  -15
+.2byte    2,  -17, 	  12,  -24, 	  -3,  -16, 	  -1,  -15
+.2byte    2,  -17, 	  12,  -24, 	  -3,  -16, 	  -1,  -15
+.2byte    2,  -17, 	  12,  -24, 	  -3,  -16, 	  -1,  -15
+.2byte    2,  -17, 	  12,  -24, 	  -3,  -16, 	  -1,  -15
+.2byte    2,  -17, 	  12,  -24, 	  -3,  -16, 	  -1,  -15
+.2byte    1,  -16, 	   7,  -26, 	   7,  -14, 	  -1,  -14
+.2byte    2,  -18, 	   7,  -27, 	   9,  -14, 	  -1,  -15
+.2byte    2,  -18, 	   7,  -27, 	   9,  -14, 	  -1,  -15
+.2byte    2,  -18, 	   7,  -27, 	   9,  -14, 	  -1,  -15
+.2byte    2,  -18, 	   7,  -27, 	   9,  -14, 	  -1,  -15
+.2byte    2,  -18, 	   7,  -27, 	   9,  -14, 	  -1,  -15
+.2byte    2,  -18, 	   7,  -27, 	   9,  -14, 	  -1,  -15
+.2byte    2,  -18, 	   7,  -27, 	   9,  -14, 	  -1,  -15
+.2byte    1,  -16, 	  -5,  -25, 	   9,  -17, 	  -1,  -15
+.2byte    1,  -18, 	  -5,  -28, 	   9,  -20, 	  -2,  -17
+.2byte    1,  -18, 	  -5,  -28, 	   9,  -20, 	  -2,  -17
+.2byte    1,  -18, 	  -5,  -28, 	   9,  -20, 	  -2,  -17
+.2byte    1,  -18, 	  -5,  -28, 	   9,  -20, 	  -2,  -17
+.2byte    1,  -18, 	  -5,  -28, 	   9,  -20, 	  -2,  -17
+.2byte    1,  -18, 	  -5,  -28, 	   9,  -20, 	  -2,  -17
+.2byte    1,  -18, 	  -5,  -28, 	   9,  -20, 	  -2,  -17
+.2byte    0,  -17, 	  11,  -21, 	  -5,  -18, 	   0,  -14
+.2byte    0,  -18, 	  12,  -23, 	  -6,  -19, 	   0,  -15
+.2byte    0,  -18, 	  12,  -23, 	  -6,  -19, 	   0,  -15
+.2byte    0,  -18, 	  12,  -23, 	  -6,  -19, 	   0,  -15
+.2byte    0,  -18, 	  12,  -23, 	  -6,  -19, 	   0,  -15
+.2byte    0,  -18, 	  12,  -23, 	  -6,  -19, 	   0,  -15
+.2byte    0,  -18, 	  12,  -23, 	  -6,  -19, 	   0,  -15
+.2byte    0,  -18, 	  12,  -23, 	  -6,  -19, 	   0,  -15
+.2byte   -1,  -16, 	   5,  -25, 	  -9,  -17, 	   1,  -15
+.2byte   -1,  -18, 	   5,  -28, 	  -9,  -20, 	   2,  -17
+.2byte   -1,  -18, 	   5,  -28, 	  -9,  -20, 	   2,  -17
+.2byte   -1,  -18, 	   5,  -28, 	  -9,  -20, 	   2,  -17
+.2byte   -1,  -18, 	   5,  -28, 	  -9,  -20, 	   2,  -17
+.2byte   -1,  -18, 	   5,  -28, 	  -9,  -20, 	   2,  -17
+.2byte   -1,  -18, 	   5,  -28, 	  -9,  -20, 	   2,  -17
+.2byte   -1,  -18, 	   5,  -28, 	  -9,  -20, 	   2,  -17
+.2byte   -1,  -16, 	  -7,  -26, 	  -7,  -14, 	   1,  -14
+.2byte   -2,  -18, 	  -7,  -27, 	  -9,  -14, 	   1,  -15
+.2byte   -2,  -18, 	  -7,  -27, 	  -9,  -14, 	   1,  -15
+.2byte   -2,  -18, 	  -7,  -27, 	  -9,  -14, 	   1,  -15
+.2byte   -2,  -18, 	  -7,  -27, 	  -9,  -14, 	   1,  -15
+.2byte   -2,  -18, 	  -7,  -27, 	  -9,  -14, 	   1,  -15
+.2byte   -2,  -18, 	  -7,  -27, 	  -9,  -14, 	   1,  -15
+.2byte   -2,  -18, 	  -7,  -27, 	  -9,  -14, 	   1,  -15
+.2byte   -2,  -16, 	 -11,  -22, 	   3,  -15, 	   0,  -14
+.2byte   -2,  -17, 	 -12,  -24, 	   3,  -16, 	   1,  -15
+.2byte   -2,  -17, 	 -12,  -24, 	   3,  -16, 	   1,  -15
+.2byte   -2,  -17, 	 -12,  -24, 	   3,  -16, 	   1,  -15
+.2byte   -2,  -17, 	 -12,  -24, 	   3,  -16, 	   1,  -15
+.2byte   -2,  -17, 	 -12,  -24, 	   3,  -16, 	   1,  -15
+.2byte   -2,  -17, 	 -12,  -24, 	   3,  -16, 	   1,  -15
+.2byte   -2,  -17, 	 -12,  -24, 	   3,  -16, 	   1,  -15
+.2byte   -2,  -17, 	  -9,   -3, 	   9,   -2, 	  -1,  -15
+.2byte   -2,  -16, 	  -9,   -1, 	   9,    0, 	  -1,  -15
+.2byte   -1,  -18, 	 -13,   -8, 	  11,  -27, 	  -1,  -15
+.2byte    0,  -20, 	  13,  -12, 	 -13,  -23, 	  -1,  -19
+.2byte    2,  -17, 	   7,  -11, 	   0,  -19, 	   0,  -16
+.2byte    1,  -16, 	   2,   -8, 	   8,  -22, 	   0,  -13
+.2byte    0,  -16, 	  12,   -7, 	 -13,  -25, 	   0,  -13
+.2byte   -2,  -16, 	  -3,   -8, 	  -9,  -22, 	  -1,  -13
+.2byte   -3,  -17, 	  -8,  -11, 	  -1,  -19, 	  -1,  -16
+.2byte   -1,  -20, 	 -14,  -12, 	  12,  -23, 	   0,  -19
+.2byte   -1,  -15, 	 -12,  -22, 	   7,  -16, 	  -1,  -13
+.2byte   -1,  -15, 	  -6,  -19, 	   6,  -20, 	  -1,  -13
+.2byte   -1,  -15, 	  10,  -22, 	  -9,  -16, 	  -1,  -13
+.2byte   -1,  -15, 	   4,  -19, 	  -8,  -20, 	  -1,  -13
+.2byte    2,  -16, 	  11,  -22, 	  -3,  -15, 	   0,  -14
+.2byte    2,  -16, 	   7,  -19, 	  -4,  -19, 	  -1,  -15
+.2byte    2,  -16, 	   8,  -15, 	  -9,  -22, 	   0,  -15
+.2byte    2,  -16, 	   9,  -19, 	  -2,  -18, 	   0,  -15
+.2byte    1,  -16, 	   7,  -26, 	   7,  -14, 	  -1,  -14
+.2byte    2,  -15, 	   6,  -20, 	   6,  -18, 	  -1,  -15
+.2byte    1,  -16, 	   6,  -15, 	  -4,  -20, 	  -2,  -16
+.2byte    1,  -14, 	   8,  -21, 	   6,  -16, 	  -1,  -15
+.2byte    1,  -16, 	  -5,  -25, 	   9,  -17, 	  -1,  -15
+.2byte    0,  -16, 	  -3,  -22, 	   9,  -18, 	  -2,  -15
+.2byte    0,  -16, 	  -3,  -18, 	  10,  -22, 	  -2,  -15
+.2byte    0,  -16, 	  -6,  -21, 	   7,  -19, 	  -2,  -15
+.2byte    0,  -17, 	  11,  -21, 	  -5,  -18, 	   0,  -14
+.2byte    0,  -17, 	   7,  -20, 	  -8,  -20, 	   0,  -14
+.2byte    0,  -17, 	 -11,  -21, 	   5,  -18, 	   0,  -14
+.2byte    0,  -17, 	  -7,  -20, 	   8,  -20, 	   0,  -14
+.2byte   -1,  -16, 	   5,  -25, 	  -9,  -17, 	   1,  -15
+.2byte    0,  -16, 	   3,  -22, 	  -9,  -18, 	   2,  -15
+.2byte    0,  -16, 	   3,  -18, 	 -10,  -22, 	   2,  -15
+.2byte    0,  -16, 	   6,  -21, 	  -7,  -19, 	   2,  -15
+.2byte   -1,  -16, 	  -7,  -26, 	  -7,  -14, 	   1,  -14
+.2byte   -2,  -15, 	  -6,  -20, 	  -6,  -18, 	   1,  -15
+.2byte   -1,  -16, 	  -6,  -15, 	   4,  -20, 	   2,  -16
+.2byte   -1,  -14, 	  -8,  -21, 	  -6,  -16, 	   1,  -15
+.2byte   -2,  -16, 	 -11,  -22, 	   3,  -15, 	   0,  -14
+.2byte   -2,  -16, 	  -7,  -19, 	   4,  -19, 	   1,  -15
+.2byte   -2,  -16, 	  -8,  -15, 	   9,  -22, 	   0,  -15
+.2byte   -2,  -16, 	  -9,  -19, 	   2,  -18, 	   0,  -15
+.2byte   -1,  -13, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,  -14, 	 -10,   -8, 	  11,   -2, 	   0,  -14
+.2byte   -3,  -15, 	   5,   -3, 	   7,   -1, 	   0,  -15
+.2byte   -1,  -15, 	  10,   -8, 	  -3,    0, 	   1,  -15
+.2byte    0,  -17, 	  10,   -3, 	 -10,   -4, 	   0,  -14
+.2byte    1,  -15, 	 -10,   -8, 	   3,    0, 	  -1,  -15
+.2byte    3,  -15, 	  -5,   -3, 	  -7,   -1, 	   0,  -15
+.2byte    1,  -14, 	  10,   -8, 	 -11,   -2, 	   0,  -14
+.2byte   -1,  -18, 	 -13,   -8, 	  11,  -27, 	  -1,  -15
+.2byte    0,  -20, 	  13,  -12, 	 -13,  -23, 	  -1,  -19
+.2byte    3,  -17, 	   8,  -11, 	   1,  -19, 	   1,  -16
+.2byte    1,  -17, 	   2,   -9, 	   8,  -23, 	   0,  -14
+.2byte    0,  -16, 	  12,   -7, 	 -13,  -25, 	   0,  -13
+.2byte   -1,  -17, 	  -2,   -9, 	  -8,  -23, 	   0,  -14
+.2byte   -4,  -17, 	  -9,  -11, 	  -2,  -19, 	  -2,  -16
+.2byte   -1,  -20, 	 -14,  -12, 	  12,  -23, 	   0,  -19
+.2byte   -1,  -15, 	 -12,  -22, 	   7,  -16, 	  -1,  -13
+.2byte   -1,  -13, 	 -11,   -6, 	   9,   -6, 	  -1,  -12
+.2byte   -1,  -17, 	 -13,   -7, 	  11,  -26, 	  -1,  -14
+.2byte    2,  -16, 	  11,  -22, 	  -3,  -15, 	   0,  -14
+.2byte    1,  -14, 	  10,   -8, 	 -11,   -2, 	   0,  -14
+.2byte    0,  -20, 	  13,  -12, 	 -13,  -23, 	  -1,  -19
+.2byte    1,  -16, 	   7,  -26, 	   7,  -14, 	  -1,  -14
+.2byte    1,  -15, 	  -7,   -3, 	  -9,   -1, 	  -2,  -15
+.2byte    1,  -17, 	   6,  -11, 	  -1,  -19, 	  -1,  -16
+.2byte    1,  -16, 	  -5,  -25, 	   9,  -17, 	  -1,  -15
+.2byte   -1,  -15, 	 -12,   -8, 	   1,    0, 	  -3,  -15
+.2byte    0,  -16, 	   1,   -8, 	   7,  -22, 	  -1,  -13
+.2byte    0,  -17, 	  11,  -21, 	  -5,  -18, 	   0,  -14
+.2byte    0,  -17, 	  10,   -3, 	 -10,   -4, 	   0,  -14
+.2byte    0,  -16, 	  12,   -7, 	 -13,  -25, 	   0,  -13
+.2byte   -1,  -16, 	   5,  -25, 	  -9,  -17, 	   1,  -15
+.2byte    1,  -15, 	  12,   -8, 	  -1,    0, 	   3,  -15
+.2byte    0,  -16, 	  -1,   -8, 	  -7,  -22, 	   1,  -13
+.2byte   -1,  -16, 	  -7,  -26, 	  -7,  -14, 	   1,  -14
+.2byte   -1,  -15, 	   7,   -3, 	   9,   -1, 	   2,  -15
+.2byte   -3,  -17, 	  -8,  -11, 	  -1,  -19, 	  -1,  -16
+.2byte   -2,  -16, 	 -11,  -22, 	   3,  -15, 	   0,  -14
+.2byte   -1,  -14, 	 -10,   -8, 	  11,   -2, 	   0,  -14
+.2byte   -1,  -20, 	 -14,  -12, 	  12,  -23, 	   0,  -19
+.2byte   -1,  -15, 	  -6,  -19, 	   6,  -20, 	  -1,  -13
+.2byte   -2,  -16, 	  -7,  -19, 	   4,  -19, 	   1,  -15
+.2byte   -2,  -15, 	  -6,  -20, 	  -6,  -18, 	   1,  -15
+.2byte    0,  -16, 	   3,  -22, 	  -9,  -18, 	   2,  -15
+.2byte    0,  -17, 	   7,  -20, 	  -8,  -20, 	   0,  -14
+.2byte    0,  -16, 	  -3,  -22, 	   9,  -18, 	  -2,  -15
+.2byte    2,  -15, 	   6,  -20, 	   6,  -18, 	  -1,  -15
+.2byte    2,  -16, 	   7,  -19, 	  -4,  -19, 	  -1,  -15
+.2byte    0,  -15, 	 -11,  -22, 	   8,  -16, 	   0,  -13
+.2byte   -2,  -16, 	 -11,  -22, 	   3,  -15, 	   0,  -14
+.2byte   -1,  -16, 	  -7,  -26, 	  -7,  -14, 	   1,  -14
+.2byte   -1,  -16, 	   5,  -25, 	  -9,  -17, 	   1,  -15
+.2byte    0,  -17, 	  11,  -21, 	  -5,  -18, 	   0,  -14
+.2byte    1,  -16, 	  -5,  -25, 	   9,  -17, 	  -1,  -15
+.2byte    1,  -16, 	   7,  -26, 	   7,  -14, 	  -1,  -14
+.2byte    2,  -16, 	  11,  -22, 	  -3,  -15, 	   0,  -14
+sDeoxysAttackAnimTable1:
+.4byte sDeoxysAttackAnims_1_1
+.4byte sDeoxysAttackAnims_1_2
+.4byte sDeoxysAttackAnims_1_3
+.4byte sDeoxysAttackAnims_1_4
+.4byte sDeoxysAttackAnims_1_5
+.4byte sDeoxysAttackAnims_1_6
+.4byte sDeoxysAttackAnims_1_7
+.4byte sDeoxysAttackAnims_1_8
+sDeoxysAttackAnimTable2:
+.4byte sDeoxysAttackAnims_2_1
+.4byte sDeoxysAttackAnims_2_2
+.4byte sDeoxysAttackAnims_2_3
+.4byte sDeoxysAttackAnims_2_4
+.4byte sDeoxysAttackAnims_2_5
+.4byte sDeoxysAttackAnims_2_6
+.4byte sDeoxysAttackAnims_2_7
+.4byte sDeoxysAttackAnims_2_8
+sDeoxysAttackAnimTable3:
+.4byte sDeoxysAttackAnims_3_1
+.4byte sDeoxysAttackAnims_3_2
+.4byte sDeoxysAttackAnims_3_3
+.4byte sDeoxysAttackAnims_3_4
+.4byte sDeoxysAttackAnims_3_5
+.4byte sDeoxysAttackAnims_3_6
+.4byte sDeoxysAttackAnims_3_7
+.4byte sDeoxysAttackAnims_3_8
+sDeoxysAttackAnimTable4:
+.4byte sDeoxysAttackAnims_4_1
+.4byte sDeoxysAttackAnims_4_2
+.4byte sDeoxysAttackAnims_4_3
+.4byte sDeoxysAttackAnims_4_4
+.4byte sDeoxysAttackAnims_4_5
+.4byte sDeoxysAttackAnims_4_6
+.4byte sDeoxysAttackAnims_4_7
+.4byte sDeoxysAttackAnims_4_8
+sDeoxysAttackAnimTable5:
+.4byte sDeoxysAttackAnims_5_1
+.4byte sDeoxysAttackAnims_5_2
+.4byte sDeoxysAttackAnims_5_3
+.4byte sDeoxysAttackAnims_5_4
+.4byte sDeoxysAttackAnims_5_5
+.4byte sDeoxysAttackAnims_5_6
+.4byte sDeoxysAttackAnims_5_7
+.4byte sDeoxysAttackAnims_5_8
+sDeoxysAttackAnimTable6:
+.4byte sDeoxysAttackAnims_6_1
+.4byte sDeoxysAttackAnims_6_1
+.4byte sDeoxysAttackAnims_6_1
+.4byte sDeoxysAttackAnims_6_1
+.4byte sDeoxysAttackAnims_6_1
+.4byte sDeoxysAttackAnims_6_1
+.4byte sDeoxysAttackAnims_6_1
+.4byte sDeoxysAttackAnims_6_1
+sDeoxysAttackAnimTable7:
+.4byte sDeoxysAttackAnims_7_1
+.4byte sDeoxysAttackAnims_7_2
+.4byte sDeoxysAttackAnims_7_3
+.4byte sDeoxysAttackAnims_7_4
+.4byte sDeoxysAttackAnims_7_5
+.4byte sDeoxysAttackAnims_7_6
+.4byte sDeoxysAttackAnims_7_7
+.4byte sDeoxysAttackAnims_7_8
+sDeoxysAttackAnimTable8:
+.4byte sDeoxysAttackAnims_8_1
+.4byte sDeoxysAttackAnims_8_2
+.4byte sDeoxysAttackAnims_8_3
+.4byte sDeoxysAttackAnims_8_4
+.4byte sDeoxysAttackAnims_8_5
+.4byte sDeoxysAttackAnims_8_6
+.4byte sDeoxysAttackAnims_8_7
+.4byte sDeoxysAttackAnims_8_8
+sDeoxysAttackAnimTable9:
+.4byte sDeoxysAttackAnims_9_1
+.4byte sDeoxysAttackAnims_9_2
+.4byte sDeoxysAttackAnims_9_3
+.4byte sDeoxysAttackAnims_9_4
+.4byte sDeoxysAttackAnims_9_5
+.4byte sDeoxysAttackAnims_9_6
+.4byte sDeoxysAttackAnims_9_7
+.4byte sDeoxysAttackAnims_9_8
+sDeoxysAttackAnimTable10:
+.4byte sDeoxysAttackAnims_10_1
+.4byte sDeoxysAttackAnims_10_2
+.4byte sDeoxysAttackAnims_10_3
+.4byte sDeoxysAttackAnims_10_4
+.4byte sDeoxysAttackAnims_10_5
+.4byte sDeoxysAttackAnims_10_6
+.4byte sDeoxysAttackAnims_10_7
+.4byte sDeoxysAttackAnims_10_8
+sDeoxysAttackAnimTable11:
+.4byte sDeoxysAttackAnims_11_1
+.4byte sDeoxysAttackAnims_11_2
+.4byte sDeoxysAttackAnims_11_3
+.4byte sDeoxysAttackAnims_11_4
+.4byte sDeoxysAttackAnims_11_5
+.4byte sDeoxysAttackAnims_11_6
+.4byte sDeoxysAttackAnims_11_7
+.4byte sDeoxysAttackAnims_11_8
+sDeoxysAttackAnimTable12:
+.4byte sDeoxysAttackAnims_12_1
+.4byte sDeoxysAttackAnims_12_2
+.4byte sDeoxysAttackAnims_12_3
+.4byte sDeoxysAttackAnims_12_4
+.4byte sDeoxysAttackAnims_12_5
+.4byte sDeoxysAttackAnims_12_6
+.4byte sDeoxysAttackAnims_12_7
+.4byte sDeoxysAttackAnims_12_8
+sDeoxysAttackAnimTable13:
+.4byte sDeoxysAttackAnims_13_1
+.4byte sDeoxysAttackAnims_13_2
+.4byte sDeoxysAttackAnims_13_3
+.4byte sDeoxysAttackAnims_13_4
+.4byte sDeoxysAttackAnims_13_5
+.4byte sDeoxysAttackAnims_13_6
+.4byte sDeoxysAttackAnims_13_7
+.4byte sDeoxysAttackAnims_13_8
+sAxAnimationsDeoxysAttack:
+.4byte sDeoxysAttackAnimTable1
+.4byte sDeoxysAttackAnimTable2
+.4byte sDeoxysAttackAnimTable3
+.4byte sDeoxysAttackAnimTable4
+.4byte sDeoxysAttackAnimTable5
+.4byte sDeoxysAttackAnimTable6
+.4byte sDeoxysAttackAnimTable7
+.4byte sDeoxysAttackAnimTable8
+.4byte sDeoxysAttackAnimTable9
+.4byte sDeoxysAttackAnimTable10
+.4byte sDeoxysAttackAnimTable11
+.4byte sDeoxysAttackAnimTable12
+.4byte sDeoxysAttackAnimTable13
+sAxSpritesDeoxysAttack:
+.4byte sDeoxysAttackSprites1
+.4byte sDeoxysAttackSprites2
+.4byte sDeoxysAttackSprites3
+.4byte sDeoxysAttackSprites4
+.4byte sDeoxysAttackSprites5
+.4byte sDeoxysAttackSprites6
+.4byte sDeoxysAttackSprites7
+.4byte sDeoxysAttackSprites8
+.4byte sDeoxysAttackSprites9
+.4byte sDeoxysAttackSprites10
+.4byte sDeoxysAttackSprites11
+.4byte sDeoxysAttackSprites12
+.4byte sDeoxysAttackSprites13
+.4byte sDeoxysAttackSprites14
+.4byte sDeoxysAttackSprites15
+.4byte sDeoxysAttackSprites16
+.4byte sDeoxysAttackSprites17
+.4byte sDeoxysAttackSprites18
+.4byte sDeoxysAttackSprites19
+.4byte sDeoxysAttackSprites20
+.4byte sDeoxysAttackSprites21
+.4byte sDeoxysAttackSprites22
+.4byte sDeoxysAttackSprites23
+.4byte sDeoxysAttackSprites24
+.4byte sDeoxysAttackSprites25
+.4byte sDeoxysAttackSprites26
+.4byte sDeoxysAttackSprites27
+.4byte sDeoxysAttackSprites28
+.4byte sDeoxysAttackSprites29
+.4byte sDeoxysAttackSprites30
+.4byte sDeoxysAttackSprites31
+.4byte sDeoxysAttackSprites32
+.4byte sDeoxysAttackSprites33
+.4byte sDeoxysAttackSprites34
+.4byte sDeoxysAttackSprites35
+.4byte sDeoxysAttackSprites36
+.4byte sDeoxysAttackSprites37
+.4byte sDeoxysAttackSprites38
+.4byte sDeoxysAttackSprites39
+.4byte sDeoxysAttackSprites40
+.4byte sDeoxysAttackSprites41
+.4byte sDeoxysAttackSprites42
+.4byte sDeoxysAttackSprites43
+.4byte sDeoxysAttackSprites44
+.4byte sDeoxysAttackSprites45
+.4byte sDeoxysAttackSprites46
+.4byte sDeoxysAttackSprites47
+.4byte sDeoxysAttackSprites48
+.4byte sDeoxysAttackSprites49
+.4byte sDeoxysAttackSprites50
+.4byte sDeoxysAttackSprites51
+.4byte sDeoxysAttackSprites52
+.4byte sDeoxysAttackSprites53
+.4byte sDeoxysAttackSprites54
+.4byte sDeoxysAttackSprites55
+.4byte sDeoxysAttackSprites56
+.4byte sDeoxysAttackSprites57
+.4byte sDeoxysAttackSprites58
+.4byte sDeoxysAttackSprites59
+.4byte sDeoxysAttackSprites60
+.4byte sDeoxysAttackSprites61
+.4byte sDeoxysAttackSprites62
+.4byte sDeoxysAttackSprites63
+.4byte sDeoxysAttackSprites64
+.4byte sDeoxysAttackSprites65
+.4byte sDeoxysAttackSprites66
+.4byte sDeoxysAttackSprites67
+.4byte sDeoxysAttackSprites68
+.4byte sDeoxysAttackSprites69
+.4byte sDeoxysAttackSprites70
+.4byte sDeoxysAttackSprites71
+.4byte sDeoxysAttackSprites72
+.4byte sDeoxysAttackSprites73
+.4byte sDeoxysAttackSprites74
+.4byte sDeoxysAttackSprites75
+.4byte sDeoxysAttackSprites76
+.4byte sDeoxysAttackSprites77
+.4byte sDeoxysAttackSprites78
+.4byte sDeoxysAttackSprites79
+.4byte sDeoxysAttackSprites80
+.4byte sDeoxysAttackSprites81
+.4byte sDeoxysAttackSprites82
+.4byte sDeoxysAttackSprites83
+.4byte sDeoxysAttackSprites84
+.4byte sDeoxysAttackSprites85
+.4byte sDeoxysAttackSprites86
+.4byte sDeoxysAttackSprites87
+.4byte sDeoxysAttackSprites88
+.4byte sDeoxysAttackSprites89
+.4byte sDeoxysAttackSprites90
+.4byte sDeoxysAttackSprites91
+.4byte sDeoxysAttackSprites92
+.4byte sDeoxysAttackSprites93
+.4byte sDeoxysAttackSprites94
+.4byte sDeoxysAttackSprites95
+.4byte sDeoxysAttackSprites96
+.4byte sDeoxysAttackSprites97
+.4byte sDeoxysAttackSprites98
+.4byte sDeoxysAttackSprites99
+.4byte sDeoxysAttackSprites100
+.4byte sDeoxysAttackSprites101
+.4byte sDeoxysAttackSprites102
+.4byte sDeoxysAttackSprites103
+.4byte sDeoxysAttackSprites104
+.4byte sDeoxysAttackSprites105
+.4byte sDeoxysAttackSprites106
+.4byte sDeoxysAttackSprites107
+.4byte sDeoxysAttackSprites108
+.4byte sDeoxysAttackSprites109
+.4byte sDeoxysAttackSprites110
+.4byte sDeoxysAttackSprites111
+.4byte sDeoxysAttackSprites112
+.4byte sDeoxysAttackSprites113
+.4byte sDeoxysAttackSprites114
+.4byte sDeoxysAttackSprites115
+.4byte sDeoxysAttackSprites116
+.4byte sDeoxysAttackSprites117
+.4byte sDeoxysAttackSprites118
+.4byte sDeoxysAttackSprites119
+.4byte sDeoxysAttackSprites120
+.4byte sDeoxysAttackSprites121
+sAxMainDeoxysAttack:
+ax_main sAxPosesDeoxysAttack, sAxAnimationsDeoxysAttack, 13, sAxSpritesDeoxysAttack, sAxPositionsDeoxysAttack

--- a/data/ax/deoxysdefense.inc
+++ b/data/ax/deoxysdefense.inc
@@ -1,0 +1,2684 @@
+.global gAxDeoxysDefense
+gAxDeoxysDefense:
+ax_siro sAxMainDeoxysDefense
+sDeoxysDefensePose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose3:
+ax_pose 2, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose4:
+ax_pose 3, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose5:
+ax_pose 4, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose6:
+ax_pose 5, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose7:
+ax_pose 6, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose8:
+ax_pose 7, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose9:
+ax_pose 8, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose10:
+ax_pose 9, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose11:
+ax_pose 6, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose12:
+ax_pose 7, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose13:
+ax_pose 4, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose14:
+ax_pose 5, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose15:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose16:
+ax_pose 3, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose17:
+ax_pose 10, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose18:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose19:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose20:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose21:
+ax_pose 16, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose22:
+ax_pose 2, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose23:
+ax_pose 3, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose24:
+ax_pose 17, 0x41f7, 0x90f2, 0x9c00
+ax_pose 18, 0x41ef, 0x50f2, 0x9c08
+ax_pose 19, 0x41e7, 0x10fe, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose25:
+ax_pose 20, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose26:
+ax_pose 4, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose27:
+ax_pose 5, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose28:
+ax_pose 21, 0x81e4, 0x90fd, 0x9c00
+ax_pose 22, 0x81ec, 0x10f5, 0x9c08
+ax_pose 23, 0x01fc, 0x10f5, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose29:
+ax_pose 24, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose30:
+ax_pose 6, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose31:
+ax_pose 7, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose32:
+ax_pose 25, 0x81e3, 0x9100, 0x9c00
+ax_pose 26, 0x81e3, 0x50f8, 0x9c08
+ax_pose 27, 0x81f3, 0x10f0, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose33:
+ax_pose 28, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose34:
+ax_pose 8, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose35:
+ax_pose 9, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose36:
+ax_pose 29, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose37:
+ax_pose 24, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose38:
+ax_pose 6, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose39:
+ax_pose 7, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose40:
+ax_pose 25, 0x81e3, 0x80ef, 0x9c00
+ax_pose 26, 0x81e3, 0x40ff, 0x9c08
+ax_pose 27, 0x81f3, 0x0107, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose41:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose42:
+ax_pose 4, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose43:
+ax_pose 5, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose44:
+ax_pose 21, 0x81e4, 0x80f3, 0x9c00
+ax_pose 22, 0x81ec, 0x0103, 0x9c08
+ax_pose 23, 0x01fc, 0x0103, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose45:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose46:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose47:
+ax_pose 3, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose48:
+ax_pose 17, 0x41f6, 0x80ef, 0x9c00
+ax_pose 18, 0x41ee, 0x40ef, 0x9c08
+ax_pose 19, 0x41e6, 0x00f3, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose49:
+ax_pose 10, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose50:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose51:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose52:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose53:
+ax_pose 16, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose54:
+ax_pose 2, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose55:
+ax_pose 3, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose56:
+ax_pose 17, 0x41f7, 0x90f2, 0x9c00
+ax_pose 18, 0x41ef, 0x50f2, 0x9c08
+ax_pose 19, 0x41e7, 0x10fe, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose57:
+ax_pose 20, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose58:
+ax_pose 4, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose59:
+ax_pose 5, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose60:
+ax_pose 21, 0x81e4, 0x90fd, 0x9c00
+ax_pose 22, 0x81ec, 0x10f5, 0x9c08
+ax_pose 23, 0x01fc, 0x10f5, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose61:
+ax_pose 24, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose62:
+ax_pose 6, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose63:
+ax_pose 7, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose64:
+ax_pose 25, 0x81e3, 0x9100, 0x9c00
+ax_pose 26, 0x81e3, 0x50f8, 0x9c08
+ax_pose 27, 0x81f3, 0x10f0, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose65:
+ax_pose 28, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose66:
+ax_pose 8, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose67:
+ax_pose 9, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose68:
+ax_pose 29, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose69:
+ax_pose 24, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose70:
+ax_pose 6, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose71:
+ax_pose 7, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose72:
+ax_pose 25, 0x81e3, 0x80ef, 0x9c00
+ax_pose 26, 0x81e3, 0x40ff, 0x9c08
+ax_pose 27, 0x81f3, 0x0107, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose73:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose74:
+ax_pose 4, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose75:
+ax_pose 5, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose76:
+ax_pose 21, 0x81e4, 0x80f3, 0x9c00
+ax_pose 22, 0x81ec, 0x0103, 0x9c08
+ax_pose 23, 0x01fc, 0x0103, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose77:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose78:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose79:
+ax_pose 3, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose80:
+ax_pose 17, 0x41f6, 0x80ef, 0x9c00
+ax_pose 18, 0x41ee, 0x40ef, 0x9c08
+ax_pose 19, 0x41e6, 0x00f3, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose81:
+ax_pose 10, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose82:
+ax_pose 30, 0x01e2, 0x80e8, 0x9c00
+ax_pose 31, 0x81e2, 0x8108, 0x9c10
+ax_pose 32, 0x41da, 0x00f8, 0x9c18
+ax_pose_terminator
+sDeoxysDefensePose83:
+ax_pose 16, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose84:
+ax_pose 33, 0x81e3, 0x90fc, 0x9c00
+ax_pose 34, 0x81e3, 0x50f4, 0x9c08
+ax_pose 35, 0x01db, 0x00fa, 0x9c0c
+ax_pose 36, 0x81eb, 0x110c, 0x9c0d
+ax_pose 37, 0x81eb, 0x10ec, 0x9c0f
+ax_pose 38, 0x01fb, 0x10ec, 0x9c11
+ax_pose_terminator
+sDeoxysDefensePose85:
+ax_pose 20, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose86:
+ax_pose 39, 0x81e2, 0x90f4, 0x9c00
+ax_pose 40, 0x81e2, 0x5104, 0x9c08
+ax_pose_terminator
+sDeoxysDefensePose87:
+ax_pose 24, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose88:
+ax_pose 41, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose89:
+ax_pose 28, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose90:
+ax_pose 42, 0x01e2, 0x80ec, 0x9c00
+ax_pose 43, 0x81e2, 0x810c, 0x9c10
+ax_pose_terminator
+sDeoxysDefensePose91:
+ax_pose 24, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose92:
+ax_pose 41, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose93:
+ax_pose 20, 0x01e2, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose94:
+ax_pose 39, 0x81e2, 0x80fc, 0x9c00
+ax_pose 40, 0x81e2, 0x40f4, 0x9c08
+ax_pose_terminator
+sDeoxysDefensePose95:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose96:
+ax_pose 33, 0x81e2, 0x80f5, 0x9c00
+ax_pose 34, 0x81e2, 0x4105, 0x9c08
+ax_pose 35, 0x01da, 0x10ff, 0x9c0c
+ax_pose 36, 0x81ea, 0x00ed, 0x9c0d
+ax_pose 37, 0x81ea, 0x010d, 0x9c0f
+ax_pose 38, 0x01fa, 0x010d, 0x9c11
+ax_pose_terminator
+sDeoxysDefensePose97:
+ax_pose 10, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose98:
+ax_pose 16, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose99:
+ax_pose 20, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose100:
+ax_pose 24, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose101:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose102:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose103:
+ax_pose 20, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose104:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose105:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose106:
+ax_pose 2, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose107:
+ax_pose 4, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose108:
+ax_pose 6, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose109:
+ax_pose 8, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose110:
+ax_pose 6, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose111:
+ax_pose 4, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose112:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose113:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose114:
+ax_pose 17, 0x41f7, 0x90f2, 0x9c00
+ax_pose 18, 0x41ef, 0x50f2, 0x9c08
+ax_pose 19, 0x41e7, 0x10fe, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose115:
+ax_pose 21, 0x81e4, 0x90fd, 0x9c00
+ax_pose 22, 0x81ec, 0x10f5, 0x9c08
+ax_pose 23, 0x01fc, 0x10f5, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose116:
+ax_pose 25, 0x81e4, 0x90ff, 0x9c00
+ax_pose 26, 0x81e4, 0x50f7, 0x9c08
+ax_pose 27, 0x81f4, 0x10ef, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose117:
+ax_pose 29, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose118:
+ax_pose 25, 0x81e3, 0x80ef, 0x9c00
+ax_pose 26, 0x81e3, 0x40ff, 0x9c08
+ax_pose 27, 0x81f3, 0x0107, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose119:
+ax_pose 21, 0x81e4, 0x80f3, 0x9c00
+ax_pose 22, 0x81ec, 0x0103, 0x9c08
+ax_pose 23, 0x01fc, 0x0103, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose120:
+ax_pose 17, 0x41f6, 0x80ef, 0x9c00
+ax_pose 18, 0x41ee, 0x40ef, 0x9c08
+ax_pose 19, 0x41e6, 0x00f3, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose121:
+ax_pose 44, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose122:
+ax_pose 45, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose123:
+ax_pose 46, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose124:
+ax_pose 47, 0x01e6, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose125:
+ax_pose 48, 0x01e5, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose126:
+ax_pose 49, 0x01e3, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose127:
+ax_pose 50, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose128:
+ax_pose 49, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose129:
+ax_pose 48, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose130:
+ax_pose 47, 0x01e6, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose131:
+ax_pose 10, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose132:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose133:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose134:
+ax_pose 24, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose135:
+ax_pose 28, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose136:
+ax_pose 24, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose137:
+ax_pose 20, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose138:
+ax_pose 16, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose139:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose140:
+ax_pose 17, 0x41f5, 0x80f1, 0x9c00
+ax_pose 18, 0x41ed, 0x40f1, 0x9c08
+ax_pose 19, 0x41e5, 0x00f5, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose141:
+ax_pose 21, 0x81e4, 0x80f4, 0x9c00
+ax_pose 22, 0x81ec, 0x0104, 0x9c08
+ax_pose 23, 0x01fc, 0x0104, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose142:
+ax_pose 25, 0x81e4, 0x80f2, 0x9c00
+ax_pose 26, 0x81e4, 0x4102, 0x9c08
+ax_pose 27, 0x81f4, 0x010a, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose143:
+ax_pose 29, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose144:
+ax_pose 25, 0x81e4, 0x90fe, 0x9c00
+ax_pose 26, 0x81e4, 0x50f6, 0x9c08
+ax_pose 27, 0x81f4, 0x10ee, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose145:
+ax_pose 21, 0x81e4, 0x90fc, 0x9c00
+ax_pose 22, 0x81ec, 0x10f4, 0x9c08
+ax_pose 23, 0x01fc, 0x10f4, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose146:
+ax_pose 17, 0x41f5, 0x90ef, 0x9c00
+ax_pose 18, 0x41ed, 0x50ef, 0x9c08
+ax_pose 19, 0x41e5, 0x10fb, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose147:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose148:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose149:
+ax_pose 17, 0x41f5, 0x90ef, 0x9c00
+ax_pose 18, 0x41ed, 0x50ef, 0x9c08
+ax_pose 19, 0x41e5, 0x10fb, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose150:
+ax_pose 21, 0x81e4, 0x90fc, 0x9c00
+ax_pose 22, 0x81ec, 0x10f4, 0x9c08
+ax_pose 23, 0x01fc, 0x10f4, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose151:
+ax_pose 25, 0x81e4, 0x90fe, 0x9c00
+ax_pose 26, 0x81e4, 0x50f6, 0x9c08
+ax_pose 27, 0x81f4, 0x10ee, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose152:
+ax_pose 29, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose153:
+ax_pose 25, 0x81e4, 0x80f2, 0x9c00
+ax_pose 26, 0x81e4, 0x4102, 0x9c08
+ax_pose 27, 0x81f4, 0x010a, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose154:
+ax_pose 21, 0x81e4, 0x80f4, 0x9c00
+ax_pose 22, 0x81ec, 0x0104, 0x9c08
+ax_pose 23, 0x01fc, 0x0104, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose155:
+ax_pose 17, 0x41f5, 0x80f1, 0x9c00
+ax_pose 18, 0x41ed, 0x40f1, 0x9c08
+ax_pose 19, 0x41e5, 0x00f5, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose156:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose157:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose158:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose159:
+ax_pose 11, 0x41f3, 0x80f0, 0x9c00
+ax_pose 12, 0x41eb, 0x40f0, 0x9c08
+ax_pose 13, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 14, 0x01fb, 0x0110, 0x9c0e
+ax_pose 15, 0x01f3, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysDefensePose160:
+ax_pose 2, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose161:
+ax_pose 3, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose162:
+ax_pose 17, 0x41f7, 0x90f0, 0x9c00
+ax_pose 18, 0x41ef, 0x50f0, 0x9c08
+ax_pose 19, 0x41e7, 0x10fc, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose163:
+ax_pose 4, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose164:
+ax_pose 5, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose165:
+ax_pose 21, 0x81e4, 0x90fd, 0x9c00
+ax_pose 22, 0x81ec, 0x10f5, 0x9c08
+ax_pose 23, 0x01fc, 0x10f5, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose166:
+ax_pose 6, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose167:
+ax_pose 7, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose168:
+ax_pose 25, 0x81e3, 0x9100, 0x9c00
+ax_pose 26, 0x81e3, 0x50f8, 0x9c08
+ax_pose 27, 0x81f3, 0x10f0, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose169:
+ax_pose 8, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose170:
+ax_pose 9, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose171:
+ax_pose 29, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose172:
+ax_pose 6, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose173:
+ax_pose 7, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose174:
+ax_pose 25, 0x81e3, 0x80f1, 0x9c00
+ax_pose 26, 0x81e3, 0x4101, 0x9c08
+ax_pose 27, 0x81f3, 0x0109, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose175:
+ax_pose 4, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose176:
+ax_pose 5, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose177:
+ax_pose 21, 0x81e4, 0x80f3, 0x9c00
+ax_pose 22, 0x81ec, 0x0103, 0x9c08
+ax_pose 23, 0x01fc, 0x0103, 0x9c0a
+ax_pose_terminator
+sDeoxysDefensePose178:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose179:
+ax_pose 3, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose180:
+ax_pose 17, 0x41f6, 0x80f1, 0x9c00
+ax_pose 18, 0x41ee, 0x40f1, 0x9c08
+ax_pose 19, 0x41e6, 0x00f5, 0x9c0c
+ax_pose_terminator
+sDeoxysDefensePose181:
+ax_pose 10, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose182:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose183:
+ax_pose 20, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose184:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose185:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose186:
+ax_pose 24, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose187:
+ax_pose 20, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose188:
+ax_pose 16, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose189:
+ax_pose 10, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose190:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose191:
+ax_pose 20, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose192:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose193:
+ax_pose 28, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose194:
+ax_pose 24, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose195:
+ax_pose 20, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysDefensePose196:
+ax_pose 16, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+.align 2
+sDeoxysDefenseAnims_1_1:
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -4, 0, 0,
+ax_anim 8, 0, 0, 0, -4, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_1_2:
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -4, 0, 0,
+ax_anim 8, 0, 2, 0, -4, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_1_3:
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -4, 0, 0,
+ax_anim 8, 0, 4, 0, -4, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_1_4:
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -4, 0, 0,
+ax_anim 8, 0, 6, 0, -4, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_1_5:
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -4, 0, 0,
+ax_anim 8, 0, 8, 0, -4, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_1_6:
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -4, 0, 0,
+ax_anim 8, 0, 10, 0, -4, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_1_7:
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -4, 0, 0,
+ax_anim 8, 0, 12, 0, -4, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_1_8:
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -4, 0, 0,
+ax_anim 8, 0, 14, 0, -4, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 0, 4, 0, 4,
+ax_anim 1, 0, 18, 0, 10, 0, 10,
+ax_anim 2, 0, 19, 0, 20, 0, 20,
+ax_anim 2, 1, 19, 1, 20, 1, 20,
+ax_anim 2, 0, 19, 0, 20, 0, 20,
+ax_anim 2, 0, 19, 1, 20, 1, 20,
+ax_anim 2, 0, 17, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysDefenseAnims_2_2:
+ax_anim 2, 0, 20, -1, -1, -1, -1,
+ax_anim 6, 0, 20, -2, -2, -2, -2,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 21, 4, 4, 4, 4,
+ax_anim 1, 0, 22, 10, 10, 10, 10,
+ax_anim 2, 0, 23, 15, 16, 15, 16,
+ax_anim 2, 1, 23, 16, 15, 16, 15,
+ax_anim 2, 0, 23, 15, 16, 15, 16,
+ax_anim 2, 0, 23, 16, 15, 16, 15,
+ax_anim 2, 0, 21, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysDefenseAnims_2_3:
+ax_anim 2, 0, 24, -1, 0, -1, 0,
+ax_anim 6, 0, 24, -2, 0, -2, 0,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 4, 0, 4, 0,
+ax_anim 1, 0, 26, 10, 0, 10, 0,
+ax_anim 2, 0, 27, 18, 0, 18, 0,
+ax_anim 2, 1, 27, 18, 1, 18, 1,
+ax_anim 2, 0, 27, 18, 0, 18, 0,
+ax_anim 2, 0, 27, 18, 1, 18, 1,
+ax_anim 2, 0, 25, 6, 0, 6, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_2_4:
+ax_anim 2, 0, 28, -1, 1, -1, 1,
+ax_anim 6, 0, 28, -2, 2, -2, 2,
+ax_anim 1, 0, 30, 0, -1, 0, -1,
+ax_anim 1, 2, 29, 4, -4, 4, -4,
+ax_anim 1, 0, 30, 10, -10, 10, -10,
+ax_anim 2, 0, 31, 16, -15, 16, -15,
+ax_anim 2, 1, 31, 17, -14, 17, -14,
+ax_anim 2, 0, 31, 16, -15, 16, -15,
+ax_anim 2, 0, 31, 17, -14, 17, -14,
+ax_anim 2, 0, 29, 6, -6, 6, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_2_5:
+ax_anim 2, 0, 32, 0, 1, 0, 1,
+ax_anim 6, 0, 32, 0, 2, 0, 2,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, -4, 0, -4,
+ax_anim 1, 0, 34, 0, -11, 0, -11,
+ax_anim 2, 0, 35, 0, -17, 0, -17,
+ax_anim 2, 1, 35, 1, -17, 1, -17,
+ax_anim 2, 0, 35, 0, -17, 0, -17,
+ax_anim 2, 0, 35, 1, -17, 1, -17,
+ax_anim 2, 0, 33, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 6, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, -4, -4, -4, -4,
+ax_anim 1, 0, 38, -10, -10, -10, -10,
+ax_anim 2, 0, 39, -16, -15, -16, -15,
+ax_anim 2, 1, 39, -17, -14, -17, -14,
+ax_anim 2, 0, 39, -16, -15, -16, -15,
+ax_anim 2, 0, 39, -17, -14, -17, -14,
+ax_anim 2, 0, 37, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_2_7:
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 6, 0, 40, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 41, -6, 0, -6, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_2_8:
+ax_anim 2, 0, 44, 1, -1, 1, -1,
+ax_anim 6, 0, 44, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 47, -15, 16, -15, 16,
+ax_anim 2, 1, 47, -16, 15, -16, 15,
+ax_anim 2, 0, 47, -15, 16, -15, 16,
+ax_anim 2, 0, 47, -16, 15, -16, 15,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 1, 51, 1, 20, 1, 20,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 0, 51, 1, 20, 1, 20,
+ax_anim 2, 0, 49, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysDefenseAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 54, 10, 10, 10, 10,
+ax_anim 2, 0, 55, 15, 16, 15, 16,
+ax_anim 2, 1, 55, 16, 15, 16, 15,
+ax_anim 2, 0, 55, 15, 16, 15, 16,
+ax_anim 2, 0, 55, 16, 15, 16, 15,
+ax_anim 2, 0, 53, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysDefenseAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 6, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 4, 0, 4, 0,
+ax_anim 1, 0, 58, 10, 0, 10, 0,
+ax_anim 2, 0, 59, 18, 0, 18, 0,
+ax_anim 2, 1, 59, 18, 1, 18, 1,
+ax_anim 2, 0, 59, 18, 0, 18, 0,
+ax_anim 2, 0, 59, 18, 1, 18, 1,
+ax_anim 2, 0, 57, 6, 0, 6, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_3_4:
+ax_anim 2, 0, 60, -1, 1, -1, 1,
+ax_anim 6, 0, 60, -2, 2, -2, 2,
+ax_anim 1, 0, 62, 0, -1, 0, -1,
+ax_anim 1, 2, 61, 4, -4, 4, -4,
+ax_anim 1, 0, 62, 10, -10, 10, -10,
+ax_anim 2, 0, 63, 16, -15, 16, -15,
+ax_anim 2, 1, 63, 17, -14, 17, -14,
+ax_anim 2, 0, 63, 16, -15, 16, -15,
+ax_anim 2, 0, 63, 17, -14, 17, -14,
+ax_anim 2, 0, 61, 6, -6, 6, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_3_5:
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 6, 0, 64, 0, 2, 0, 2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, -4, 0, -4,
+ax_anim 1, 0, 66, 0, -11, 0, -11,
+ax_anim 2, 0, 67, 0, -17, 0, -17,
+ax_anim 2, 1, 67, 1, -17, 1, -17,
+ax_anim 2, 0, 67, 0, -17, 0, -17,
+ax_anim 2, 0, 67, 1, -17, 1, -17,
+ax_anim 2, 0, 65, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_3_6:
+ax_anim 2, 0, 68, 1, 1, 1, 1,
+ax_anim 6, 0, 68, 2, 2, 2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, -4, -4, -4, -4,
+ax_anim 1, 0, 70, -10, -10, -10, -10,
+ax_anim 2, 0, 71, -16, -15, -16, -15,
+ax_anim 2, 1, 71, -17, -14, -17, -14,
+ax_anim 2, 0, 71, -16, -15, -16, -15,
+ax_anim 2, 0, 71, -17, -14, -17, -14,
+ax_anim 2, 0, 69, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_3_7:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 6, 0, 72, 2, 0, 2, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, -4, 0, -4, 0,
+ax_anim 1, 0, 74, -10, 0, -10, 0,
+ax_anim 2, 0, 75, -18, 0, -18, 0,
+ax_anim 2, 1, 75, -18, 1, -18, 1,
+ax_anim 2, 0, 75, -18, 0, -18, 0,
+ax_anim 2, 0, 75, -18, 1, -18, 1,
+ax_anim 2, 0, 73, -6, 0, -6, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_3_8:
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 6, 0, 76, 2, -2, 2, -2,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 2, 77, -4, 4, -4, 4,
+ax_anim 1, 0, 78, -10, 10, -10, 10,
+ax_anim 2, 0, 79, -15, 16, -15, 16,
+ax_anim 2, 1, 79, -16, 15, -16, 15,
+ax_anim 2, 0, 79, -15, 16, -15, 16,
+ax_anim 2, 0, 79, -16, 15, -16, 15,
+ax_anim 2, 0, 77, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_4_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 2, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 1, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, -3, 0, -3,
+ax_anim 1, 0, 81, 0, -5, 0, -5,
+ax_anim 3, 0, 81, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_4_2:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 1, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, -3, -3, -3, -3,
+ax_anim 1, 0, 83, -5, -5, -5, -5,
+ax_anim 3, 0, 83, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysDefenseAnims_4_3:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 84, 0, -1, 0, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 1, 85, -3, 0, 0, 0,
+ax_anim 1, 0, 85, -6, 0, -3, 0,
+ax_anim 1, 0, 85, -8, 0, -5, 0,
+ax_anim 3, 0, 85, -9, 0, -6, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_4_4:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 1, 1, 1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 2, 86, 1, 1, 1, 1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 1, 1, 1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 1, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 87, -3, 3, -3, 3,
+ax_anim 1, 0, 87, -5, 5, -5, 5,
+ax_anim 3, 0, 87, -6, 6, -6, 6,
+ax_anim_terminator
+sDeoxysDefenseAnims_4_5:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 88, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 1, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, 3, 0, 3,
+ax_anim 1, 0, 89, 0, 5, 0, 5,
+ax_anim 3, 0, 89, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysDefenseAnims_4_6:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, 1, -1, 1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 90, -1, 1, -1, 1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, 1, -1, 1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 1, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 3, 3, 3, 3,
+ax_anim 1, 0, 91, 5, 5, 5, 5,
+ax_anim 3, 0, 91, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysDefenseAnims_4_7:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, -1, 0, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 1, 93, 3, 0, 0, 0,
+ax_anim 1, 0, 93, 6, 0, 3, 0,
+ax_anim 1, 0, 93, 8, 0, 5, 0,
+ax_anim 3, 0, 93, 9, 0, 6, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_4_8:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 1, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 3, -3, 3, -3,
+ax_anim 1, 0, 95, 5, -5, 5, -5,
+ax_anim 3, 0, 95, 6, -6, 6, -6,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_5_1:
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 1, 0, 96, 0, -3, 0, 0,
+ax_anim 4, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_5_2:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 1, 0, 97, 0, -3, 0, 0,
+ax_anim 4, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_5_3:
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim 4, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_5_4:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 0, 99, 0, -3, 0, 0,
+ax_anim 4, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_5_5:
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 1, 0, 100, 0, -3, 0, 0,
+ax_anim 4, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_5_6:
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim 4, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_5_7:
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 0, 102, 0, -3, 0, 0,
+ax_anim 4, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_5_8:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 1, 0, 103, 0, -3, 0, 0,
+ax_anim 4, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sDeoxysDefenseAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sDeoxysDefenseAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sDeoxysDefenseAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sDeoxysDefenseAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sDeoxysDefenseAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_8_1:
+ax_anim 12, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, -1, 0, 0,
+ax_anim 8, 0, 130, 0, -2, 0, 0,
+ax_anim 12, 0, 130, 0, -3, 0, 0,
+ax_anim 8, 0, 130, 0, -2, 0, 0,
+ax_anim 8, 0, 130, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_8_2:
+ax_anim 12, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim 8, 0, 137, 0, -2, 0, 0,
+ax_anim 12, 0, 137, 0, -3, 0, 0,
+ax_anim 8, 0, 137, 0, -2, 0, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_8_3:
+ax_anim 12, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim 8, 0, 136, 0, -2, 0, 0,
+ax_anim 12, 0, 136, 0, -3, 0, 0,
+ax_anim 8, 0, 136, 0, -2, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_8_4:
+ax_anim 12, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, -1, 0, 0,
+ax_anim 8, 0, 135, 0, -2, 0, 0,
+ax_anim 12, 0, 135, 0, -3, 0, 0,
+ax_anim 8, 0, 135, 0, -2, 0, 0,
+ax_anim 8, 0, 135, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_8_5:
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, -2, 0, 0,
+ax_anim 12, 0, 134, 0, -3, 0, 0,
+ax_anim 8, 0, 134, 0, -2, 0, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_8_6:
+ax_anim 12, 0, 133, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, -1, 0, 0,
+ax_anim 8, 0, 133, 0, -2, 0, 0,
+ax_anim 12, 0, 133, 0, -3, 0, 0,
+ax_anim 8, 0, 133, 0, -2, 0, 0,
+ax_anim 8, 0, 133, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_8_7:
+ax_anim 12, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, -1, 0, 0,
+ax_anim 8, 0, 132, 0, -2, 0, 0,
+ax_anim 12, 0, 132, 0, -3, 0, 0,
+ax_anim 8, 0, 132, 0, -2, 0, 0,
+ax_anim 8, 0, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_8_8:
+ax_anim 12, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, -1, 0, 0,
+ax_anim 8, 0, 131, 0, -2, 0, 0,
+ax_anim 12, 0, 131, 0, -3, 0, 0,
+ax_anim 8, 0, 131, 0, -2, 0, 0,
+ax_anim 8, 0, 131, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 7, 4, 7, 4,
+ax_anim 2, 0, 140, 10, 10, 10, 10,
+ax_anim 2, 0, 141, 8, 17, 8, 17,
+ax_anim 3, 0, 142, 0, 19, 0, 19,
+ax_anim 2, 3, 143, -8, 17, -8, 17,
+ax_anim 2, 0, 144, -10, 10, -10, 10,
+ax_anim 1, 0, 145, -7, 4, -7, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 16, 3, 16, 3,
+ax_anim 2, 0, 140, 24, 9, 24, 9,
+ax_anim 3, 0, 141, 22, 19, 22, 19,
+ax_anim 2, 3, 142, 13, 20, 13, 20,
+ax_anim 2, 0, 143, 1, 18, 1, 18,
+ax_anim 1, 0, 144, -2, 7, -2, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -7, 11, -7,
+ax_anim 2, 0, 139, 19, -6, 19, -6,
+ax_anim 3, 0, 140, 23, -2, 23, -2,
+ax_anim 2, 3, 141, 21, 5, 21, 5,
+ax_anim 2, 0, 142, 12, 6, 12, 6,
+ax_anim 1, 0, 143, 1, 5, 1, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -8, 0, -8,
+ax_anim 2, 0, 145, 4, -17, 4, -17,
+ax_anim 2, 0, 138, 12, -20, 12, -20,
+ax_anim 3, 0, 139, 21, -20, 21, -20,
+ax_anim 2, 3, 140, 26, -14, 26, -14,
+ax_anim 2, 0, 141, 21, -5, 21, -5,
+ax_anim 1, 0, 142, 13, 0, 13, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -11, -9, -11,
+ax_anim 2, 0, 145, -7, -18, -7, -18,
+ax_anim 3, 0, 138, 0, -20, 0, -20,
+ax_anim 2, 3, 139, 8, -18, 8, -18,
+ax_anim 2, 0, 140, 10, -10, 10, -10,
+ax_anim 1, 0, 141, 9, -2, 9, -2,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -8, 0, -8,
+ax_anim 2, 0, 139, -4, -17, -4, -17,
+ax_anim 2, 0, 138, -12, -20, -12, -20,
+ax_anim 3, 0, 145, -21, -20, -21, -20,
+ax_anim 2, 3, 144, -26, -14, -26, -14,
+ax_anim 2, 0, 143, -21, -5, -21, -5,
+ax_anim 1, 0, 142, -13, 0, -13, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -7, -11, -7,
+ax_anim 2, 0, 145, -19, -6, -19, -6,
+ax_anim 3, 0, 144, -23, -2, -23, -2,
+ax_anim 2, 3, 143, -21, 5, -21, 5,
+ax_anim 2, 0, 142, -12, 6, -12, 6,
+ax_anim 1, 0, 141, -1, 5, -1, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -16, 3, -16, 3,
+ax_anim 2, 0, 144, -24, 9, -24, 9,
+ax_anim 3, 0, 143, -22, 19, -22, 19,
+ax_anim 2, 3, 142, -13, 20, -13, 20,
+ax_anim 2, 0, 141, -1, 18, -1, 18,
+ax_anim 1, 0, 140, 2, 7, 2, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_10_1:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, 0, 6, 0,
+ax_anim 2, 0, 147, -6, 0, -6, 0,
+ax_anim 2, 0, 147, 10, 0, 10, 0,
+ax_anim 2, 0, 147, -10, 0, -10, 0,
+ax_anim 2, 0, 147, 12, 0, 12, 0,
+ax_anim 3, 0, 147, -12, 0, -12, 0,
+ax_anim 3, 0, 147, 13, 0, 13, 0,
+ax_anim 3, 0, 147, -13, 0, -13, 0,
+ax_anim 2, 0, 147, 12, 0, 12, 0,
+ax_anim 3, 0, 147, -12, 0, -12, 0,
+ax_anim 2, 0, 147, 10, 0, 10, 0,
+ax_anim 2, 0, 147, -10, 0, -10, 0,
+ax_anim 2, 0, 147, 6, 0, 6, 0,
+ax_anim 2, 0, 147, -6, 0, -6, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_10_2:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 6, -6, 6, -6,
+ax_anim 2, 0, 148, -6, 6, -6, 6,
+ax_anim 2, 0, 148, 10, -10, 10, -10,
+ax_anim 2, 0, 148, -10, 10, -10, 10,
+ax_anim 2, 0, 148, 12, -12, 12, -12,
+ax_anim 3, 0, 148, -12, 12, -12, 12,
+ax_anim 3, 0, 148, 13, -13, 13, -13,
+ax_anim 3, 0, 148, -13, 13, -13, 13,
+ax_anim 2, 0, 148, 12, -12, 12, -12,
+ax_anim 3, 0, 148, -12, 12, -12, 12,
+ax_anim 2, 0, 148, 10, -10, 10, -10,
+ax_anim 2, 0, 148, -10, 10, -10, 10,
+ax_anim 2, 0, 148, 6, -6, 6, -6,
+ax_anim 2, 0, 148, -6, 6, -6, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_10_3:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, -6,
+ax_anim 2, 0, 149, 0, 6, 0, 6,
+ax_anim 2, 0, 149, 0, -10, 0, -10,
+ax_anim 2, 0, 149, 0, 10, 0, 10,
+ax_anim 2, 0, 149, 0, -12, 0, -12,
+ax_anim 3, 0, 149, 0, 12, 0, 12,
+ax_anim 3, 0, 149, 0, -13, 0, -13,
+ax_anim 3, 0, 149, 0, 13, 0, 13,
+ax_anim 2, 0, 149, 0, -12, 0, -12,
+ax_anim 3, 0, 149, 0, 12, 0, 12,
+ax_anim 2, 0, 149, 0, -10, 0, -10,
+ax_anim 2, 0, 149, 0, 10, 0, 10,
+ax_anim 2, 0, 149, 0, -6, 0, -6,
+ax_anim 2, 0, 149, 0, 6, 0, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_10_4:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -6, -6, -6, -6,
+ax_anim 2, 0, 150, 6, 6, 6, 6,
+ax_anim 2, 0, 150, -10, -10, -10, -10,
+ax_anim 2, 0, 150, 10, 10, 10, 10,
+ax_anim 2, 0, 150, -12, -12, -12, -12,
+ax_anim 3, 0, 150, 12, 12, 12, 12,
+ax_anim 3, 0, 150, -13, -13, -13, -13,
+ax_anim 3, 0, 150, 13, 13, 13, 13,
+ax_anim 2, 0, 150, -12, -12, -12, -12,
+ax_anim 3, 0, 150, 12, 12, 12, 12,
+ax_anim 2, 0, 150, -10, -10, -10, -10,
+ax_anim 2, 0, 150, 10, 10, 10, 10,
+ax_anim 2, 0, 150, -6, -6, -6, -6,
+ax_anim 2, 0, 150, 6, 6, 6, 6,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_10_5:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, 0, 6, 0,
+ax_anim 2, 0, 151, -6, 0, -6, 0,
+ax_anim 2, 0, 151, 10, 0, 10, 0,
+ax_anim 2, 0, 151, -10, 0, -10, 0,
+ax_anim 2, 0, 151, 12, 0, 12, 0,
+ax_anim 3, 0, 151, -12, 0, -12, 0,
+ax_anim 3, 0, 151, 13, 0, 13, 0,
+ax_anim 3, 0, 151, -13, 0, -13, 0,
+ax_anim 2, 0, 151, 12, 0, 12, 0,
+ax_anim 3, 0, 151, -12, 0, -12, 0,
+ax_anim 2, 0, 151, 10, 0, 10, 0,
+ax_anim 2, 0, 151, -10, 0, -10, 0,
+ax_anim 2, 0, 151, 6, 0, 6, 0,
+ax_anim 2, 0, 151, -6, 0, -6, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_10_6:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 6, -6, 6, -6,
+ax_anim 2, 0, 152, -6, 6, -6, 6,
+ax_anim 2, 0, 152, 10, -10, 10, -10,
+ax_anim 2, 0, 152, -10, 10, -10, 10,
+ax_anim 2, 0, 152, 12, -12, 12, -12,
+ax_anim 3, 0, 152, -12, 12, -12, 12,
+ax_anim 3, 0, 152, 13, -13, 13, -13,
+ax_anim 3, 0, 152, -13, 13, -13, 13,
+ax_anim 2, 0, 152, 12, -12, 12, -12,
+ax_anim 3, 0, 152, -12, 12, -12, 12,
+ax_anim 2, 0, 152, 10, -10, 10, -10,
+ax_anim 2, 0, 152, -10, 10, -10, 10,
+ax_anim 2, 0, 152, 6, -6, 6, -6,
+ax_anim 2, 0, 152, -6, 6, -6, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_10_7:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, -6, 0, -6,
+ax_anim 2, 0, 153, 0, 6, 0, 6,
+ax_anim 2, 0, 153, 0, -10, 0, -10,
+ax_anim 2, 0, 153, 0, 10, 0, 10,
+ax_anim 2, 0, 153, 0, -12, 0, -12,
+ax_anim 3, 0, 153, 0, 12, 0, 12,
+ax_anim 3, 0, 153, 0, -13, 0, -13,
+ax_anim 3, 0, 153, 0, 13, 0, 13,
+ax_anim 2, 0, 153, 0, -12, 0, -12,
+ax_anim 3, 0, 153, 0, 12, 0, 12,
+ax_anim 2, 0, 153, 0, -10, 0, -10,
+ax_anim 2, 0, 153, 0, 10, 0, 10,
+ax_anim 2, 0, 153, 0, -6, 0, -6,
+ax_anim 2, 0, 153, 0, 6, 0, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_10_8:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -6, -6, -6, -6,
+ax_anim 2, 0, 154, 6, 6, 6, 6,
+ax_anim 2, 0, 154, -10, -10, -10, -10,
+ax_anim 2, 0, 154, 10, 10, 10, 10,
+ax_anim 2, 0, 154, -12, -12, -12, -12,
+ax_anim 3, 0, 154, 12, 12, 12, 12,
+ax_anim 3, 0, 154, -13, -13, -13, -13,
+ax_anim 3, 0, 154, 13, 13, 13, 13,
+ax_anim 2, 0, 154, -12, -12, -12, -12,
+ax_anim 3, 0, 154, 12, 12, 12, 12,
+ax_anim 2, 0, 154, -10, -10, -10, -10,
+ax_anim 2, 0, 154, 10, 10, 10, 10,
+ax_anim 2, 0, 154, -6, -6, -6, -6,
+ax_anim 2, 0, 154, 6, 6, 6, 6,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_11_1:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 158, 0, -22, 0, 0,
+ax_anim 2, 0, 158, 0, -18, 0, 0,
+ax_anim 1, 0, 158, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_11_2:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 161, 0, -22, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_11_3:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_11_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 167, 0, -21, 0, 0,
+ax_anim 2, 0, 167, 0, -17, 0, 0,
+ax_anim 1, 0, 167, 0, -11, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_11_5:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_11_6:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_11_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_11_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_12_1:
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 1, 0, 1, 0,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_12_2:
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_12_3:
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, -1,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_12_4:
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, -1, -1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_12_5:
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_12_6:
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, -1, 1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_12_7:
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, -1, 0, -1,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_12_8:
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, -1, -1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysDefenseAnims_13_1:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_13_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_13_3:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_13_4:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_13_5:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_13_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_13_7:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseAnims_13_8:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysDefenseGfx1:
+.incbin "baserom.gba", 0x1634E90, 0x200
+sDeoxysDefenseSprites1:
+ax_sprite sDeoxysDefenseGfx1, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx2:
+.incbin "baserom.gba", 0x16350A0, 0x200
+sDeoxysDefenseSprites2:
+ax_sprite sDeoxysDefenseGfx2, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx3:
+.incbin "baserom.gba", 0x16352B0, 0x200
+sDeoxysDefenseSprites3:
+ax_sprite sDeoxysDefenseGfx3, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx4:
+.incbin "baserom.gba", 0x16354C0, 0x200
+sDeoxysDefenseSprites4:
+ax_sprite sDeoxysDefenseGfx4, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx5:
+.incbin "baserom.gba", 0x16356D0, 0x200
+sDeoxysDefenseSprites5:
+ax_sprite sDeoxysDefenseGfx5, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx6:
+.incbin "baserom.gba", 0x16358E0, 0x200
+sDeoxysDefenseSprites6:
+ax_sprite sDeoxysDefenseGfx6, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx7:
+.incbin "baserom.gba", 0x1635AF0, 0x200
+sDeoxysDefenseSprites7:
+ax_sprite sDeoxysDefenseGfx7, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx8:
+.incbin "baserom.gba", 0x1635D00, 0x200
+sDeoxysDefenseSprites8:
+ax_sprite sDeoxysDefenseGfx8, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx9:
+.incbin "baserom.gba", 0x1635F10, 0x200
+sDeoxysDefenseSprites9:
+ax_sprite sDeoxysDefenseGfx9, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx10:
+.incbin "baserom.gba", 0x1636120, 0x200
+sDeoxysDefenseSprites10:
+ax_sprite sDeoxysDefenseGfx10, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx11:
+.incbin "baserom.gba", 0x1636330, 0x200
+sDeoxysDefenseSprites11:
+ax_sprite sDeoxysDefenseGfx11, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx12:
+.incbin "baserom.gba", 0x1636540, 0x100
+sDeoxysDefenseSprites12:
+ax_sprite sDeoxysDefenseGfx12, 0x100
+ax_sprite_terminator
+sDeoxysDefenseGfx13:
+.incbin "baserom.gba", 0x1636650, 0x80
+sDeoxysDefenseSprites13:
+ax_sprite sDeoxysDefenseGfx13, 0x80
+ax_sprite_terminator
+sDeoxysDefenseGfx14:
+.incbin "baserom.gba", 0x16366E0, 0x40
+sDeoxysDefenseSprites14:
+ax_sprite sDeoxysDefenseGfx14, 0x40
+ax_sprite_terminator
+sDeoxysDefenseGfx15:
+.incbin "baserom.gba", 0x1636730, 0x20
+sDeoxysDefenseSprites15:
+ax_sprite sDeoxysDefenseGfx15, 0x20
+ax_sprite_terminator
+sDeoxysDefenseGfx16:
+.incbin "baserom.gba", 0x1636760, 0x20
+sDeoxysDefenseSprites16:
+ax_sprite sDeoxysDefenseGfx16, 0x20
+ax_sprite_terminator
+sDeoxysDefenseGfx17:
+.incbin "baserom.gba", 0x1636790, 0x200
+sDeoxysDefenseSprites17:
+ax_sprite sDeoxysDefenseGfx17, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx18:
+.incbin "baserom.gba", 0x16369A0, 0x100
+sDeoxysDefenseSprites18:
+ax_sprite sDeoxysDefenseGfx18, 0x100
+ax_sprite_terminator
+sDeoxysDefenseGfx19:
+.incbin "baserom.gba", 0x1636AB0, 0x80
+sDeoxysDefenseSprites19:
+ax_sprite sDeoxysDefenseGfx19, 0x80
+ax_sprite_terminator
+sDeoxysDefenseGfx20:
+.incbin "baserom.gba", 0x1636B40, 0x40
+sDeoxysDefenseSprites20:
+ax_sprite sDeoxysDefenseGfx20, 0x40
+ax_sprite_terminator
+sDeoxysDefenseGfx21:
+.incbin "baserom.gba", 0x1636B90, 0x40
+sDeoxysDefenseGfx21_1:
+.incbin "baserom.gba", 0x1636BD0, 0x60
+sDeoxysDefenseGfx21_2:
+.incbin "baserom.gba", 0x1636C30, 0x60
+sDeoxysDefenseGfx21_3:
+.incbin "baserom.gba", 0x1636C90, 0x60
+sDeoxysDefenseSprites21:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysDefenseGfx22:
+.incbin "baserom.gba", 0x1636D40, 0x100
+sDeoxysDefenseSprites22:
+ax_sprite sDeoxysDefenseGfx22, 0x100
+ax_sprite_terminator
+sDeoxysDefenseGfx23:
+.incbin "baserom.gba", 0x1636E50, 0x40
+sDeoxysDefenseSprites23:
+ax_sprite sDeoxysDefenseGfx23, 0x40
+ax_sprite_terminator
+sDeoxysDefenseGfx24:
+.incbin "baserom.gba", 0x1636EA0, 0x20
+sDeoxysDefenseSprites24:
+ax_sprite sDeoxysDefenseGfx24, 0x20
+ax_sprite_terminator
+sDeoxysDefenseGfx25:
+.incbin "baserom.gba", 0x1636ED0, 0x160
+sDeoxysDefenseGfx25_1:
+.incbin "baserom.gba", 0x1637030, 0x60
+sDeoxysDefenseSprites25:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx25, 0x160
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx25_1, 0x60
+ax_sprite_terminator
+sDeoxysDefenseGfx26:
+.incbin "baserom.gba", 0x16370B8, 0x100
+sDeoxysDefenseSprites26:
+ax_sprite sDeoxysDefenseGfx26, 0x100
+ax_sprite_terminator
+sDeoxysDefenseGfx27:
+.incbin "baserom.gba", 0x16371C8, 0x80
+sDeoxysDefenseSprites27:
+ax_sprite sDeoxysDefenseGfx27, 0x80
+ax_sprite_terminator
+sDeoxysDefenseGfx28:
+.incbin "baserom.gba", 0x1637258, 0x40
+sDeoxysDefenseSprites28:
+ax_sprite sDeoxysDefenseGfx28, 0x40
+ax_sprite_terminator
+sDeoxysDefenseGfx29:
+.incbin "baserom.gba", 0x16372A8, 0x200
+sDeoxysDefenseSprites29:
+ax_sprite sDeoxysDefenseGfx29, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx30:
+.incbin "baserom.gba", 0x16374B8, 0x1E0
+sDeoxysDefenseSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx30, 0x1e0
+ax_sprite_terminator
+sDeoxysDefenseGfx31:
+.incbin "baserom.gba", 0x16376B0, 0x1E0
+sDeoxysDefenseSprites31:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx31, 0x1e0
+ax_sprite_terminator
+sDeoxysDefenseGfx32:
+.incbin "baserom.gba", 0x16378A8, 0x20
+sDeoxysDefenseGfx32_1:
+.incbin "baserom.gba", 0x16378C8, 0xC0
+sDeoxysDefenseSprites32:
+ax_sprite sDeoxysDefenseGfx32, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx32_1, 0xc0
+ax_sprite_terminator
+sDeoxysDefenseGfx33:
+.incbin "baserom.gba", 0x16379A8, 0x40
+sDeoxysDefenseSprites33:
+ax_sprite sDeoxysDefenseGfx33, 0x40
+ax_sprite_terminator
+sDeoxysDefenseGfx34:
+.incbin "baserom.gba", 0x16379F8, 0x100
+sDeoxysDefenseSprites34:
+ax_sprite sDeoxysDefenseGfx34, 0x100
+ax_sprite_terminator
+sDeoxysDefenseGfx35:
+.incbin "baserom.gba", 0x1637B08, 0x80
+sDeoxysDefenseSprites35:
+ax_sprite sDeoxysDefenseGfx35, 0x80
+ax_sprite_terminator
+sDeoxysDefenseGfx36:
+.incbin "baserom.gba", 0x1637B98, 0x20
+sDeoxysDefenseSprites36:
+ax_sprite sDeoxysDefenseGfx36, 0x20
+ax_sprite_terminator
+sDeoxysDefenseGfx37:
+.incbin "baserom.gba", 0x1637BC8, 0x40
+sDeoxysDefenseSprites37:
+ax_sprite sDeoxysDefenseGfx37, 0x40
+ax_sprite_terminator
+sDeoxysDefenseGfx38:
+.incbin "baserom.gba", 0x1637C18, 0x40
+sDeoxysDefenseSprites38:
+ax_sprite sDeoxysDefenseGfx38, 0x40
+ax_sprite_terminator
+sDeoxysDefenseGfx39:
+.incbin "baserom.gba", 0x1637C68, 0x20
+sDeoxysDefenseSprites39:
+ax_sprite sDeoxysDefenseGfx39, 0x20
+ax_sprite_terminator
+sDeoxysDefenseGfx40:
+.incbin "baserom.gba", 0x1637C98, 0x100
+sDeoxysDefenseSprites40:
+ax_sprite sDeoxysDefenseGfx40, 0x100
+ax_sprite_terminator
+sDeoxysDefenseGfx41:
+.incbin "baserom.gba", 0x1637DA8, 0x80
+sDeoxysDefenseSprites41:
+ax_sprite sDeoxysDefenseGfx41, 0x80
+ax_sprite_terminator
+sDeoxysDefenseGfx42:
+.incbin "baserom.gba", 0x1637E38, 0x200
+sDeoxysDefenseSprites42:
+ax_sprite sDeoxysDefenseGfx42, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx43:
+.incbin "baserom.gba", 0x1638048, 0x1A0
+sDeoxysDefenseGfx43_1:
+.incbin "baserom.gba", 0x16381E8, 0x20
+sDeoxysDefenseSprites43:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx43, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx43_1, 0x20
+ax_sprite_terminator
+sDeoxysDefenseGfx44:
+.incbin "baserom.gba", 0x1638230, 0x20
+sDeoxysDefenseGfx44_1:
+.incbin "baserom.gba", 0x1638250, 0x80
+sDeoxysDefenseSprites44:
+ax_sprite 0, 0x40
+ax_sprite sDeoxysDefenseGfx44, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDeoxysDefenseGfx44_1, 0x80
+ax_sprite_terminator
+sDeoxysDefenseGfx45:
+.incbin "baserom.gba", 0x16382F8, 0x200
+sDeoxysDefenseSprites45:
+ax_sprite sDeoxysDefenseGfx45, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx46:
+.incbin "baserom.gba", 0x1638508, 0x200
+sDeoxysDefenseSprites46:
+ax_sprite sDeoxysDefenseGfx46, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx47:
+.incbin "baserom.gba", 0x1638718, 0x200
+sDeoxysDefenseSprites47:
+ax_sprite sDeoxysDefenseGfx47, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx48:
+.incbin "baserom.gba", 0x1638928, 0x200
+sDeoxysDefenseSprites48:
+ax_sprite sDeoxysDefenseGfx48, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx49:
+.incbin "baserom.gba", 0x1638B38, 0x200
+sDeoxysDefenseSprites49:
+ax_sprite sDeoxysDefenseGfx49, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx50:
+.incbin "baserom.gba", 0x1638D48, 0x200
+sDeoxysDefenseSprites50:
+ax_sprite sDeoxysDefenseGfx50, 0x200
+ax_sprite_terminator
+sDeoxysDefenseGfx51:
+.incbin "baserom.gba", 0x1638F58, 0x200
+sDeoxysDefenseSprites51:
+ax_sprite sDeoxysDefenseGfx51, 0x200
+ax_sprite_terminator
+sAxPosesDeoxysDefense:
+.4byte sDeoxysDefensePose1
+.4byte sDeoxysDefensePose2
+.4byte sDeoxysDefensePose3
+.4byte sDeoxysDefensePose4
+.4byte sDeoxysDefensePose5
+.4byte sDeoxysDefensePose6
+.4byte sDeoxysDefensePose7
+.4byte sDeoxysDefensePose8
+.4byte sDeoxysDefensePose9
+.4byte sDeoxysDefensePose10
+.4byte sDeoxysDefensePose11
+.4byte sDeoxysDefensePose12
+.4byte sDeoxysDefensePose13
+.4byte sDeoxysDefensePose14
+.4byte sDeoxysDefensePose15
+.4byte sDeoxysDefensePose16
+.4byte sDeoxysDefensePose17
+.4byte sDeoxysDefensePose18
+.4byte sDeoxysDefensePose19
+.4byte sDeoxysDefensePose20
+.4byte sDeoxysDefensePose21
+.4byte sDeoxysDefensePose22
+.4byte sDeoxysDefensePose23
+.4byte sDeoxysDefensePose24
+.4byte sDeoxysDefensePose25
+.4byte sDeoxysDefensePose26
+.4byte sDeoxysDefensePose27
+.4byte sDeoxysDefensePose28
+.4byte sDeoxysDefensePose29
+.4byte sDeoxysDefensePose30
+.4byte sDeoxysDefensePose31
+.4byte sDeoxysDefensePose32
+.4byte sDeoxysDefensePose33
+.4byte sDeoxysDefensePose34
+.4byte sDeoxysDefensePose35
+.4byte sDeoxysDefensePose36
+.4byte sDeoxysDefensePose37
+.4byte sDeoxysDefensePose38
+.4byte sDeoxysDefensePose39
+.4byte sDeoxysDefensePose40
+.4byte sDeoxysDefensePose41
+.4byte sDeoxysDefensePose42
+.4byte sDeoxysDefensePose43
+.4byte sDeoxysDefensePose44
+.4byte sDeoxysDefensePose45
+.4byte sDeoxysDefensePose46
+.4byte sDeoxysDefensePose47
+.4byte sDeoxysDefensePose48
+.4byte sDeoxysDefensePose49
+.4byte sDeoxysDefensePose50
+.4byte sDeoxysDefensePose51
+.4byte sDeoxysDefensePose52
+.4byte sDeoxysDefensePose53
+.4byte sDeoxysDefensePose54
+.4byte sDeoxysDefensePose55
+.4byte sDeoxysDefensePose56
+.4byte sDeoxysDefensePose57
+.4byte sDeoxysDefensePose58
+.4byte sDeoxysDefensePose59
+.4byte sDeoxysDefensePose60
+.4byte sDeoxysDefensePose61
+.4byte sDeoxysDefensePose62
+.4byte sDeoxysDefensePose63
+.4byte sDeoxysDefensePose64
+.4byte sDeoxysDefensePose65
+.4byte sDeoxysDefensePose66
+.4byte sDeoxysDefensePose67
+.4byte sDeoxysDefensePose68
+.4byte sDeoxysDefensePose69
+.4byte sDeoxysDefensePose70
+.4byte sDeoxysDefensePose71
+.4byte sDeoxysDefensePose72
+.4byte sDeoxysDefensePose73
+.4byte sDeoxysDefensePose74
+.4byte sDeoxysDefensePose75
+.4byte sDeoxysDefensePose76
+.4byte sDeoxysDefensePose77
+.4byte sDeoxysDefensePose78
+.4byte sDeoxysDefensePose79
+.4byte sDeoxysDefensePose80
+.4byte sDeoxysDefensePose81
+.4byte sDeoxysDefensePose82
+.4byte sDeoxysDefensePose83
+.4byte sDeoxysDefensePose84
+.4byte sDeoxysDefensePose85
+.4byte sDeoxysDefensePose86
+.4byte sDeoxysDefensePose87
+.4byte sDeoxysDefensePose88
+.4byte sDeoxysDefensePose89
+.4byte sDeoxysDefensePose90
+.4byte sDeoxysDefensePose91
+.4byte sDeoxysDefensePose92
+.4byte sDeoxysDefensePose93
+.4byte sDeoxysDefensePose94
+.4byte sDeoxysDefensePose95
+.4byte sDeoxysDefensePose96
+.4byte sDeoxysDefensePose97
+.4byte sDeoxysDefensePose98
+.4byte sDeoxysDefensePose99
+.4byte sDeoxysDefensePose100
+.4byte sDeoxysDefensePose101
+.4byte sDeoxysDefensePose102
+.4byte sDeoxysDefensePose103
+.4byte sDeoxysDefensePose104
+.4byte sDeoxysDefensePose105
+.4byte sDeoxysDefensePose106
+.4byte sDeoxysDefensePose107
+.4byte sDeoxysDefensePose108
+.4byte sDeoxysDefensePose109
+.4byte sDeoxysDefensePose110
+.4byte sDeoxysDefensePose111
+.4byte sDeoxysDefensePose112
+.4byte sDeoxysDefensePose113
+.4byte sDeoxysDefensePose114
+.4byte sDeoxysDefensePose115
+.4byte sDeoxysDefensePose116
+.4byte sDeoxysDefensePose117
+.4byte sDeoxysDefensePose118
+.4byte sDeoxysDefensePose119
+.4byte sDeoxysDefensePose120
+.4byte sDeoxysDefensePose121
+.4byte sDeoxysDefensePose122
+.4byte sDeoxysDefensePose123
+.4byte sDeoxysDefensePose124
+.4byte sDeoxysDefensePose125
+.4byte sDeoxysDefensePose126
+.4byte sDeoxysDefensePose127
+.4byte sDeoxysDefensePose128
+.4byte sDeoxysDefensePose129
+.4byte sDeoxysDefensePose130
+.4byte sDeoxysDefensePose131
+.4byte sDeoxysDefensePose132
+.4byte sDeoxysDefensePose133
+.4byte sDeoxysDefensePose134
+.4byte sDeoxysDefensePose135
+.4byte sDeoxysDefensePose136
+.4byte sDeoxysDefensePose137
+.4byte sDeoxysDefensePose138
+.4byte sDeoxysDefensePose139
+.4byte sDeoxysDefensePose140
+.4byte sDeoxysDefensePose141
+.4byte sDeoxysDefensePose142
+.4byte sDeoxysDefensePose143
+.4byte sDeoxysDefensePose144
+.4byte sDeoxysDefensePose145
+.4byte sDeoxysDefensePose146
+.4byte sDeoxysDefensePose147
+.4byte sDeoxysDefensePose148
+.4byte sDeoxysDefensePose149
+.4byte sDeoxysDefensePose150
+.4byte sDeoxysDefensePose151
+.4byte sDeoxysDefensePose152
+.4byte sDeoxysDefensePose153
+.4byte sDeoxysDefensePose154
+.4byte sDeoxysDefensePose155
+.4byte sDeoxysDefensePose156
+.4byte sDeoxysDefensePose157
+.4byte sDeoxysDefensePose158
+.4byte sDeoxysDefensePose159
+.4byte sDeoxysDefensePose160
+.4byte sDeoxysDefensePose161
+.4byte sDeoxysDefensePose162
+.4byte sDeoxysDefensePose163
+.4byte sDeoxysDefensePose164
+.4byte sDeoxysDefensePose165
+.4byte sDeoxysDefensePose166
+.4byte sDeoxysDefensePose167
+.4byte sDeoxysDefensePose168
+.4byte sDeoxysDefensePose169
+.4byte sDeoxysDefensePose170
+.4byte sDeoxysDefensePose171
+.4byte sDeoxysDefensePose172
+.4byte sDeoxysDefensePose173
+.4byte sDeoxysDefensePose174
+.4byte sDeoxysDefensePose175
+.4byte sDeoxysDefensePose176
+.4byte sDeoxysDefensePose177
+.4byte sDeoxysDefensePose178
+.4byte sDeoxysDefensePose179
+.4byte sDeoxysDefensePose180
+.4byte sDeoxysDefensePose181
+.4byte sDeoxysDefensePose182
+.4byte sDeoxysDefensePose183
+.4byte sDeoxysDefensePose184
+.4byte sDeoxysDefensePose185
+.4byte sDeoxysDefensePose186
+.4byte sDeoxysDefensePose187
+.4byte sDeoxysDefensePose188
+.4byte sDeoxysDefensePose189
+.4byte sDeoxysDefensePose190
+.4byte sDeoxysDefensePose191
+.4byte sDeoxysDefensePose192
+.4byte sDeoxysDefensePose193
+.4byte sDeoxysDefensePose194
+.4byte sDeoxysDefensePose195
+.4byte sDeoxysDefensePose196
+sAxPositionsDeoxysDefense:
+.2byte    0,  -14, 	 -12,   -1, 	  12,   -1, 	   0,  -13
+.2byte    0,  -15, 	 -11,   -1, 	  10,   -1, 	   0,  -14
+.2byte    2,  -15, 	  13,   -4, 	  -9,   -1, 	   1,  -15
+.2byte    2,  -16, 	  11,   -4, 	  -7,   -1, 	   1,  -16
+.2byte    6,  -16, 	   7,   -6, 	   5,    0, 	   2,  -16
+.2byte    6,  -16, 	   7,   -5, 	   6,   -1, 	   2,  -16
+.2byte    3,  -17, 	  -5,   -7, 	  12,   -1, 	   0,  -17
+.2byte    3,  -18, 	  -4,   -7, 	  10,   -2, 	   0,  -18
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -14
+.2byte    0,  -17, 	  11,   -4, 	 -11,   -4, 	   0,  -14
+.2byte   -3,  -17, 	   5,   -7, 	 -12,   -1, 	   0,  -17
+.2byte   -3,  -18, 	   4,   -7, 	 -10,   -2, 	   0,  -18
+.2byte   -6,  -16, 	  -7,   -6, 	  -5,    0, 	  -2,  -16
+.2byte   -6,  -16, 	  -7,   -5, 	  -6,   -1, 	  -2,  -16
+.2byte   -2,  -15, 	 -13,   -4, 	   9,   -1, 	  -1,  -15
+.2byte   -2,  -16, 	 -11,   -4, 	   7,   -1, 	  -1,  -16
+.2byte    0,  -17, 	   6,  -12, 	  -6,  -14, 	   0,  -15
+.2byte    0,  -14, 	 -12,   -1, 	  12,   -1, 	   0,  -13
+.2byte    0,  -15, 	 -11,   -1, 	  10,   -1, 	   0,  -14
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte    2,  -16, 	   2,   -8, 	   9,  -13, 	   1,  -16
+.2byte    2,  -15, 	  13,   -4, 	  -9,   -1, 	   1,  -15
+.2byte    2,  -16, 	  11,   -4, 	  -7,   -1, 	   1,  -16
+.2byte    6,   -8, 	  14,   -2, 	  -7,    3, 	   2,  -12
+.2byte    3,  -17, 	  10,   -9, 	   9,  -16, 	   0,  -17
+.2byte    6,  -16, 	   7,   -6, 	   5,    0, 	   2,  -16
+.2byte    6,  -16, 	   7,   -5, 	   6,   -1, 	   2,  -16
+.2byte    7,  -12, 	   6,   -5, 	   2,    1, 	   1,  -14
+.2byte    2,  -20, 	  10,  -16, 	   1,  -19, 	  -1,  -20
+.2byte    3,  -17, 	  -5,   -7, 	  12,   -1, 	   0,  -17
+.2byte    3,  -18, 	  -4,   -7, 	  10,   -2, 	   0,  -18
+.2byte    4,  -16, 	  -4,   -8, 	  12,   -1, 	   1,  -17
+.2byte    0,  -20, 	  -7,  -13, 	   7,  -13, 	   0,  -17
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -14
+.2byte    0,  -17, 	  11,   -4, 	 -11,   -4, 	   0,  -14
+.2byte    0,  -16, 	  13,   -4, 	 -13,   -4, 	   0,  -14
+.2byte   -2,  -20, 	 -10,  -16, 	  -1,  -19, 	   1,  -20
+.2byte   -3,  -17, 	   5,   -7, 	 -12,   -1, 	   0,  -17
+.2byte   -3,  -18, 	   4,   -7, 	 -10,   -2, 	   0,  -18
+.2byte   -6,  -16, 	   2,   -8, 	 -14,   -1, 	  -3,  -17
+.2byte   -3,  -17, 	 -10,   -9, 	  -9,  -16, 	   0,  -17
+.2byte   -6,  -16, 	  -7,   -6, 	  -5,    0, 	  -2,  -16
+.2byte   -6,  -16, 	  -7,   -5, 	  -6,   -1, 	  -2,  -16
+.2byte   -8,  -12, 	  -7,   -5, 	  -3,    1, 	  -2,  -14
+.2byte   -2,  -17, 	  -2,   -9, 	  -9,  -14, 	  -1,  -17
+.2byte   -2,  -15, 	 -13,   -4, 	   9,   -1, 	  -1,  -15
+.2byte   -2,  -16, 	 -11,   -4, 	   7,   -1, 	  -1,  -16
+.2byte   -6,   -9, 	 -14,   -3, 	   7,    2, 	  -2,  -13
+.2byte    0,  -17, 	   6,  -12, 	  -6,  -14, 	   0,  -15
+.2byte    0,  -14, 	 -12,   -1, 	  12,   -1, 	   0,  -13
+.2byte    0,  -15, 	 -11,   -1, 	  10,   -1, 	   0,  -14
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte    2,  -16, 	   2,   -8, 	   9,  -13, 	   1,  -16
+.2byte    2,  -15, 	  13,   -4, 	  -9,   -1, 	   1,  -15
+.2byte    2,  -16, 	  11,   -4, 	  -7,   -1, 	   1,  -16
+.2byte    6,   -8, 	  14,   -2, 	  -7,    3, 	   2,  -12
+.2byte    3,  -17, 	  10,   -9, 	   9,  -16, 	   0,  -17
+.2byte    6,  -16, 	   7,   -6, 	   5,    0, 	   2,  -16
+.2byte    6,  -16, 	   7,   -5, 	   6,   -1, 	   2,  -16
+.2byte    7,  -12, 	   6,   -5, 	   2,    1, 	   1,  -14
+.2byte    2,  -20, 	  10,  -16, 	   1,  -19, 	  -1,  -20
+.2byte    3,  -17, 	  -5,   -7, 	  12,   -1, 	   0,  -17
+.2byte    3,  -18, 	  -4,   -7, 	  10,   -2, 	   0,  -18
+.2byte    4,  -16, 	  -4,   -8, 	  12,   -1, 	   1,  -17
+.2byte    0,  -20, 	  -7,  -13, 	   7,  -13, 	   0,  -17
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -14
+.2byte    0,  -17, 	  11,   -4, 	 -11,   -4, 	   0,  -14
+.2byte    0,  -16, 	  13,   -4, 	 -13,   -4, 	   0,  -14
+.2byte   -2,  -20, 	 -10,  -16, 	  -1,  -19, 	   1,  -20
+.2byte   -3,  -17, 	   5,   -7, 	 -12,   -1, 	   0,  -17
+.2byte   -3,  -18, 	   4,   -7, 	 -10,   -2, 	   0,  -18
+.2byte   -6,  -16, 	   2,   -8, 	 -14,   -1, 	  -3,  -17
+.2byte   -3,  -17, 	 -10,   -9, 	  -9,  -16, 	   0,  -17
+.2byte   -6,  -16, 	  -7,   -6, 	  -5,    0, 	  -2,  -16
+.2byte   -6,  -16, 	  -7,   -5, 	  -6,   -1, 	  -2,  -16
+.2byte   -8,  -12, 	  -7,   -5, 	  -3,    1, 	  -2,  -14
+.2byte   -2,  -17, 	  -2,   -9, 	  -9,  -14, 	  -1,  -17
+.2byte   -2,  -15, 	 -13,   -4, 	   9,   -1, 	  -1,  -15
+.2byte   -2,  -16, 	 -11,   -4, 	   7,   -1, 	  -1,  -16
+.2byte   -6,   -9, 	 -14,   -3, 	   7,    2, 	  -2,  -13
+.2byte    0,  -17, 	   6,  -12, 	  -6,  -14, 	   0,  -15
+.2byte    0,  -19, 	 -21,   -9, 	  21,   -9, 	   0,  -18
+.2byte    2,  -16, 	   2,   -8, 	   9,  -13, 	   1,  -16
+.2byte    1,  -18, 	  12,  -12, 	 -17,   -3, 	  -1,  -18
+.2byte    3,  -17, 	  10,   -9, 	   9,  -16, 	   0,  -17
+.2byte    4,  -19, 	  -7,   -8, 	  -9,   -2, 	  -1,  -17
+.2byte    2,  -20, 	  10,  -16, 	   1,  -19, 	  -1,  -20
+.2byte    0,  -19, 	 -15,   -7, 	   9,   -2, 	  -3,  -18
+.2byte    0,  -20, 	  -7,  -13, 	   7,  -13, 	   0,  -17
+.2byte    0,  -19, 	  18,   -4, 	 -18,   -4, 	   0,  -17
+.2byte   -2,  -20, 	 -10,  -16, 	  -1,  -19, 	   1,  -20
+.2byte    0,  -19, 	  15,   -7, 	  -9,   -2, 	   3,  -18
+.2byte   -4,  -17, 	 -11,   -9, 	 -10,  -16, 	  -1,  -17
+.2byte   -5,  -19, 	   6,   -8, 	   8,   -2, 	   0,  -17
+.2byte   -2,  -17, 	  -2,   -9, 	  -9,  -14, 	  -1,  -17
+.2byte   -1,  -19, 	 -12,  -13, 	  17,   -4, 	   1,  -19
+.2byte    0,  -16, 	   6,  -11, 	  -6,  -13, 	   0,  -14
+.2byte    2,  -16, 	   2,   -8, 	   9,  -13, 	   1,  -16
+.2byte    3,  -16, 	  10,   -8, 	   9,  -15, 	   0,  -16
+.2byte    2,  -19, 	  10,  -15, 	   1,  -18, 	  -1,  -19
+.2byte    0,  -19, 	  -7,  -12, 	   7,  -12, 	   0,  -16
+.2byte   -2,  -19, 	 -10,  -15, 	  -1,  -18, 	   1,  -19
+.2byte   -3,  -16, 	 -10,   -8, 	  -9,  -15, 	   0,  -16
+.2byte   -2,  -16, 	  -2,   -8, 	  -9,  -13, 	  -1,  -16
+.2byte    0,  -14, 	 -12,   -1, 	  12,   -1, 	   0,  -13
+.2byte    2,  -15, 	  13,   -4, 	  -9,   -1, 	   1,  -15
+.2byte    6,  -16, 	   7,   -6, 	   5,    0, 	   2,  -16
+.2byte    3,  -17, 	  -5,   -7, 	  12,   -1, 	   0,  -17
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -14
+.2byte   -3,  -17, 	   5,   -7, 	 -12,   -1, 	   0,  -17
+.2byte   -6,  -16, 	  -7,   -6, 	  -5,    0, 	  -2,  -16
+.2byte   -2,  -15, 	 -13,   -4, 	   9,   -1, 	  -1,  -15
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte    6,   -8, 	  14,   -2, 	  -7,    3, 	   2,  -12
+.2byte    7,  -12, 	   6,   -5, 	   2,    1, 	   1,  -14
+.2byte    3,  -15, 	  -5,   -7, 	  11,    0, 	   0,  -16
+.2byte    0,  -17, 	  13,   -5, 	 -13,   -5, 	   0,  -15
+.2byte   -6,  -16, 	   2,   -8, 	 -14,   -1, 	  -3,  -17
+.2byte   -8,  -12, 	  -7,   -5, 	  -3,    1, 	  -2,  -14
+.2byte   -6,   -9, 	 -14,   -3, 	   7,    2, 	  -2,  -13
+.2byte   -2,  -14, 	 -12,   -3, 	   8,    0, 	   0,  -13
+.2byte   -3,  -13, 	 -12,   -2, 	   8,    1, 	  -1,  -13
+.2byte   -1,  -12, 	   3,  -14, 	  -5,  -16, 	  -1,  -13
+.2byte    0,  -12, 	   1,  -13, 	   7,  -18, 	  -2,  -13
+.2byte    2,  -11, 	   6,  -14, 	   8,  -19, 	  -1,  -12
+.2byte    1,  -14, 	   9,  -21, 	   1,  -23, 	  -1,  -15
+.2byte    0,  -12, 	  -5,  -22, 	   4,  -22, 	   0,  -13
+.2byte   -2,  -14, 	 -10,  -21, 	  -2,  -23, 	   0,  -15
+.2byte   -3,  -11, 	  -7,  -14, 	  -9,  -19, 	   0,  -12
+.2byte   -1,  -12, 	  -2,  -13, 	  -8,  -18, 	   1,  -13
+.2byte    0,  -17, 	   6,  -12, 	  -6,  -14, 	   0,  -15
+.2byte   -2,  -17, 	  -2,   -9, 	  -9,  -14, 	  -1,  -17
+.2byte   -3,  -17, 	 -10,   -9, 	  -9,  -16, 	   0,  -17
+.2byte   -2,  -20, 	 -10,  -16, 	  -1,  -19, 	   1,  -20
+.2byte    0,  -20, 	  -7,  -13, 	   7,  -13, 	   0,  -17
+.2byte    2,  -20, 	  10,  -16, 	   1,  -19, 	  -1,  -20
+.2byte    3,  -17, 	  10,   -9, 	   9,  -16, 	   0,  -17
+.2byte    2,  -17, 	   2,   -9, 	   9,  -14, 	   1,  -17
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte   -4,  -10, 	 -12,   -4, 	   9,    1, 	   0,  -14
+.2byte   -7,  -12, 	  -6,   -5, 	  -2,    1, 	  -1,  -14
+.2byte   -3,  -15, 	   5,   -7, 	 -11,    0, 	   0,  -16
+.2byte    0,  -16, 	  13,   -4, 	 -13,   -4, 	   0,  -14
+.2byte    2,  -15, 	  -6,   -7, 	  10,    0, 	  -1,  -16
+.2byte    6,  -12, 	   5,   -5, 	   1,    1, 	   0,  -14
+.2byte    3,  -10, 	  11,   -4, 	 -10,    1, 	  -1,  -14
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte    3,  -10, 	  11,   -4, 	 -10,    1, 	  -1,  -14
+.2byte    6,  -12, 	   5,   -5, 	   1,    1, 	   0,  -14
+.2byte    2,  -15, 	  -6,   -7, 	  10,    0, 	  -1,  -16
+.2byte    0,  -16, 	  13,   -4, 	 -13,   -4, 	   0,  -14
+.2byte   -3,  -15, 	   5,   -7, 	 -11,    0, 	   0,  -16
+.2byte   -7,  -12, 	  -6,   -5, 	  -2,    1, 	  -1,  -14
+.2byte   -4,  -10, 	 -12,   -4, 	   9,    1, 	   0,  -14
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte    0,  -14, 	 -12,   -1, 	  12,   -1, 	   0,  -13
+.2byte    0,  -15, 	 -11,   -1, 	  10,   -1, 	   0,  -14
+.2byte    0,  -10, 	 -12,   -1, 	  12,   -1, 	   0,  -14
+.2byte    2,  -15, 	  13,   -4, 	  -9,   -1, 	   1,  -15
+.2byte    2,  -16, 	  11,   -4, 	  -7,   -1, 	   1,  -16
+.2byte    4,   -8, 	  12,   -2, 	  -9,    3, 	   0,  -12
+.2byte    6,  -16, 	   7,   -6, 	   5,    0, 	   2,  -16
+.2byte    6,  -16, 	   7,   -5, 	   6,   -1, 	   2,  -16
+.2byte    7,  -12, 	   6,   -5, 	   2,    1, 	   1,  -14
+.2byte    3,  -17, 	  -5,   -7, 	  12,   -1, 	   0,  -17
+.2byte    3,  -18, 	  -4,   -7, 	  10,   -2, 	   0,  -18
+.2byte    4,  -16, 	  -4,   -8, 	  12,   -1, 	   1,  -17
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -14
+.2byte    0,  -17, 	  11,   -4, 	 -11,   -4, 	   0,  -14
+.2byte    0,  -16, 	  13,   -4, 	 -13,   -4, 	   0,  -14
+.2byte   -3,  -17, 	   5,   -7, 	 -12,   -1, 	   0,  -17
+.2byte   -3,  -18, 	   4,   -7, 	 -10,   -2, 	   0,  -18
+.2byte   -4,  -16, 	   4,   -8, 	 -12,   -1, 	  -1,  -17
+.2byte   -6,  -16, 	  -7,   -6, 	  -5,    0, 	  -2,  -16
+.2byte   -6,  -16, 	  -7,   -5, 	  -6,   -1, 	  -2,  -16
+.2byte   -8,  -12, 	  -7,   -5, 	  -3,    1, 	  -2,  -14
+.2byte   -2,  -15, 	 -13,   -4, 	   9,   -1, 	  -1,  -15
+.2byte   -2,  -16, 	 -11,   -4, 	   7,   -1, 	  -1,  -16
+.2byte   -4,   -9, 	 -12,   -3, 	   9,    2, 	   0,  -13
+.2byte    0,  -16, 	   6,  -11, 	  -6,  -13, 	   0,  -14
+.2byte   -2,  -16, 	  -2,   -8, 	  -9,  -13, 	  -1,  -16
+.2byte   -3,  -16, 	 -10,   -8, 	  -9,  -15, 	   0,  -16
+.2byte   -2,  -19, 	 -10,  -15, 	  -1,  -18, 	   1,  -19
+.2byte    0,  -19, 	  -7,  -12, 	   7,  -12, 	   0,  -16
+.2byte    2,  -19, 	  10,  -15, 	   1,  -18, 	  -1,  -19
+.2byte    3,  -16, 	  10,   -8, 	   9,  -15, 	   0,  -16
+.2byte    2,  -16, 	   2,   -8, 	   9,  -13, 	   1,  -16
+.2byte    0,  -16, 	   6,  -11, 	  -6,  -13, 	   0,  -14
+.2byte   -2,  -16, 	  -2,   -8, 	  -9,  -13, 	  -1,  -16
+.2byte   -3,  -16, 	 -10,   -8, 	  -9,  -15, 	   0,  -16
+.2byte   -2,  -19, 	 -10,  -15, 	  -1,  -18, 	   1,  -19
+.2byte    0,  -19, 	  -7,  -12, 	   7,  -12, 	   0,  -16
+.2byte    2,  -19, 	  10,  -15, 	   1,  -18, 	  -1,  -19
+.2byte    3,  -16, 	  10,   -8, 	   9,  -15, 	   0,  -16
+.2byte    2,  -16, 	   2,   -8, 	   9,  -13, 	   1,  -16
+sDeoxysDefenseAnimTable1:
+.4byte sDeoxysDefenseAnims_1_1
+.4byte sDeoxysDefenseAnims_1_2
+.4byte sDeoxysDefenseAnims_1_3
+.4byte sDeoxysDefenseAnims_1_4
+.4byte sDeoxysDefenseAnims_1_5
+.4byte sDeoxysDefenseAnims_1_6
+.4byte sDeoxysDefenseAnims_1_7
+.4byte sDeoxysDefenseAnims_1_8
+sDeoxysDefenseAnimTable2:
+.4byte sDeoxysDefenseAnims_2_1
+.4byte sDeoxysDefenseAnims_2_2
+.4byte sDeoxysDefenseAnims_2_3
+.4byte sDeoxysDefenseAnims_2_4
+.4byte sDeoxysDefenseAnims_2_5
+.4byte sDeoxysDefenseAnims_2_6
+.4byte sDeoxysDefenseAnims_2_7
+.4byte sDeoxysDefenseAnims_2_8
+sDeoxysDefenseAnimTable3:
+.4byte sDeoxysDefenseAnims_3_1
+.4byte sDeoxysDefenseAnims_3_2
+.4byte sDeoxysDefenseAnims_3_3
+.4byte sDeoxysDefenseAnims_3_4
+.4byte sDeoxysDefenseAnims_3_5
+.4byte sDeoxysDefenseAnims_3_6
+.4byte sDeoxysDefenseAnims_3_7
+.4byte sDeoxysDefenseAnims_3_8
+sDeoxysDefenseAnimTable4:
+.4byte sDeoxysDefenseAnims_4_1
+.4byte sDeoxysDefenseAnims_4_2
+.4byte sDeoxysDefenseAnims_4_3
+.4byte sDeoxysDefenseAnims_4_4
+.4byte sDeoxysDefenseAnims_4_5
+.4byte sDeoxysDefenseAnims_4_6
+.4byte sDeoxysDefenseAnims_4_7
+.4byte sDeoxysDefenseAnims_4_8
+sDeoxysDefenseAnimTable5:
+.4byte sDeoxysDefenseAnims_5_1
+.4byte sDeoxysDefenseAnims_5_2
+.4byte sDeoxysDefenseAnims_5_3
+.4byte sDeoxysDefenseAnims_5_4
+.4byte sDeoxysDefenseAnims_5_5
+.4byte sDeoxysDefenseAnims_5_6
+.4byte sDeoxysDefenseAnims_5_7
+.4byte sDeoxysDefenseAnims_5_8
+sDeoxysDefenseAnimTable6:
+.4byte sDeoxysDefenseAnims_6_1
+.4byte sDeoxysDefenseAnims_6_1
+.4byte sDeoxysDefenseAnims_6_1
+.4byte sDeoxysDefenseAnims_6_1
+.4byte sDeoxysDefenseAnims_6_1
+.4byte sDeoxysDefenseAnims_6_1
+.4byte sDeoxysDefenseAnims_6_1
+.4byte sDeoxysDefenseAnims_6_1
+sDeoxysDefenseAnimTable7:
+.4byte sDeoxysDefenseAnims_7_1
+.4byte sDeoxysDefenseAnims_7_2
+.4byte sDeoxysDefenseAnims_7_3
+.4byte sDeoxysDefenseAnims_7_4
+.4byte sDeoxysDefenseAnims_7_5
+.4byte sDeoxysDefenseAnims_7_6
+.4byte sDeoxysDefenseAnims_7_7
+.4byte sDeoxysDefenseAnims_7_8
+sDeoxysDefenseAnimTable8:
+.4byte sDeoxysDefenseAnims_8_1
+.4byte sDeoxysDefenseAnims_8_2
+.4byte sDeoxysDefenseAnims_8_3
+.4byte sDeoxysDefenseAnims_8_4
+.4byte sDeoxysDefenseAnims_8_5
+.4byte sDeoxysDefenseAnims_8_6
+.4byte sDeoxysDefenseAnims_8_7
+.4byte sDeoxysDefenseAnims_8_8
+sDeoxysDefenseAnimTable9:
+.4byte sDeoxysDefenseAnims_9_1
+.4byte sDeoxysDefenseAnims_9_2
+.4byte sDeoxysDefenseAnims_9_3
+.4byte sDeoxysDefenseAnims_9_4
+.4byte sDeoxysDefenseAnims_9_5
+.4byte sDeoxysDefenseAnims_9_6
+.4byte sDeoxysDefenseAnims_9_7
+.4byte sDeoxysDefenseAnims_9_8
+sDeoxysDefenseAnimTable10:
+.4byte sDeoxysDefenseAnims_10_1
+.4byte sDeoxysDefenseAnims_10_2
+.4byte sDeoxysDefenseAnims_10_3
+.4byte sDeoxysDefenseAnims_10_4
+.4byte sDeoxysDefenseAnims_10_5
+.4byte sDeoxysDefenseAnims_10_6
+.4byte sDeoxysDefenseAnims_10_7
+.4byte sDeoxysDefenseAnims_10_8
+sDeoxysDefenseAnimTable11:
+.4byte sDeoxysDefenseAnims_11_1
+.4byte sDeoxysDefenseAnims_11_2
+.4byte sDeoxysDefenseAnims_11_3
+.4byte sDeoxysDefenseAnims_11_4
+.4byte sDeoxysDefenseAnims_11_5
+.4byte sDeoxysDefenseAnims_11_6
+.4byte sDeoxysDefenseAnims_11_7
+.4byte sDeoxysDefenseAnims_11_8
+sDeoxysDefenseAnimTable12:
+.4byte sDeoxysDefenseAnims_12_1
+.4byte sDeoxysDefenseAnims_12_2
+.4byte sDeoxysDefenseAnims_12_3
+.4byte sDeoxysDefenseAnims_12_4
+.4byte sDeoxysDefenseAnims_12_5
+.4byte sDeoxysDefenseAnims_12_6
+.4byte sDeoxysDefenseAnims_12_7
+.4byte sDeoxysDefenseAnims_12_8
+sDeoxysDefenseAnimTable13:
+.4byte sDeoxysDefenseAnims_13_1
+.4byte sDeoxysDefenseAnims_13_2
+.4byte sDeoxysDefenseAnims_13_3
+.4byte sDeoxysDefenseAnims_13_4
+.4byte sDeoxysDefenseAnims_13_5
+.4byte sDeoxysDefenseAnims_13_6
+.4byte sDeoxysDefenseAnims_13_7
+.4byte sDeoxysDefenseAnims_13_8
+sAxAnimationsDeoxysDefense:
+.4byte sDeoxysDefenseAnimTable1
+.4byte sDeoxysDefenseAnimTable2
+.4byte sDeoxysDefenseAnimTable3
+.4byte sDeoxysDefenseAnimTable4
+.4byte sDeoxysDefenseAnimTable5
+.4byte sDeoxysDefenseAnimTable6
+.4byte sDeoxysDefenseAnimTable7
+.4byte sDeoxysDefenseAnimTable8
+.4byte sDeoxysDefenseAnimTable9
+.4byte sDeoxysDefenseAnimTable10
+.4byte sDeoxysDefenseAnimTable11
+.4byte sDeoxysDefenseAnimTable12
+.4byte sDeoxysDefenseAnimTable13
+sAxSpritesDeoxysDefense:
+.4byte sDeoxysDefenseSprites1
+.4byte sDeoxysDefenseSprites2
+.4byte sDeoxysDefenseSprites3
+.4byte sDeoxysDefenseSprites4
+.4byte sDeoxysDefenseSprites5
+.4byte sDeoxysDefenseSprites6
+.4byte sDeoxysDefenseSprites7
+.4byte sDeoxysDefenseSprites8
+.4byte sDeoxysDefenseSprites9
+.4byte sDeoxysDefenseSprites10
+.4byte sDeoxysDefenseSprites11
+.4byte sDeoxysDefenseSprites12
+.4byte sDeoxysDefenseSprites13
+.4byte sDeoxysDefenseSprites14
+.4byte sDeoxysDefenseSprites15
+.4byte sDeoxysDefenseSprites16
+.4byte sDeoxysDefenseSprites17
+.4byte sDeoxysDefenseSprites18
+.4byte sDeoxysDefenseSprites19
+.4byte sDeoxysDefenseSprites20
+.4byte sDeoxysDefenseSprites21
+.4byte sDeoxysDefenseSprites22
+.4byte sDeoxysDefenseSprites23
+.4byte sDeoxysDefenseSprites24
+.4byte sDeoxysDefenseSprites25
+.4byte sDeoxysDefenseSprites26
+.4byte sDeoxysDefenseSprites27
+.4byte sDeoxysDefenseSprites28
+.4byte sDeoxysDefenseSprites29
+.4byte sDeoxysDefenseSprites30
+.4byte sDeoxysDefenseSprites31
+.4byte sDeoxysDefenseSprites32
+.4byte sDeoxysDefenseSprites33
+.4byte sDeoxysDefenseSprites34
+.4byte sDeoxysDefenseSprites35
+.4byte sDeoxysDefenseSprites36
+.4byte sDeoxysDefenseSprites37
+.4byte sDeoxysDefenseSprites38
+.4byte sDeoxysDefenseSprites39
+.4byte sDeoxysDefenseSprites40
+.4byte sDeoxysDefenseSprites41
+.4byte sDeoxysDefenseSprites42
+.4byte sDeoxysDefenseSprites43
+.4byte sDeoxysDefenseSprites44
+.4byte sDeoxysDefenseSprites45
+.4byte sDeoxysDefenseSprites46
+.4byte sDeoxysDefenseSprites47
+.4byte sDeoxysDefenseSprites48
+.4byte sDeoxysDefenseSprites49
+.4byte sDeoxysDefenseSprites50
+.4byte sDeoxysDefenseSprites51
+sAxMainDeoxysDefense:
+ax_main sAxPosesDeoxysDefense, sAxAnimationsDeoxysDefense, 13, sAxSpritesDeoxysDefense, sAxPositionsDeoxysDefense

--- a/data/ax/deoxysnormal.inc
+++ b/data/ax/deoxysnormal.inc
@@ -1,0 +1,3161 @@
+.global gAxDeoxysNormal
+gAxDeoxysNormal:
+ax_siro sAxMainDeoxysNormal
+sDeoxysNormalPose1:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose2:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose3:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose4:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 7, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose5:
+ax_pose 8, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose6:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose7:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose8:
+ax_pose 11, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose9:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose10:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose11:
+ax_pose 14, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose12:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose13:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose14:
+ax_pose 17, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose15:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose16:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose17:
+ax_pose 14, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose18:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose19:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose20:
+ax_pose 11, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose21:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose22:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 7, 0x0202, 0x0100, 0x0c0f
+ax_pose_terminator
+sDeoxysNormalPose23:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose24:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose25:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose26:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose27:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose28:
+ax_pose 19, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose29:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 7, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose30:
+ax_pose 8, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose31:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose32:
+ax_pose 20, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose33:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose34:
+ax_pose 11, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose35:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose36:
+ax_pose 21, 0x01e2, 0x90f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose37:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose38:
+ax_pose 14, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose39:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose40:
+ax_pose 22, 0x01e2, 0x90f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose41:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose42:
+ax_pose 17, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose43:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose44:
+ax_pose 23, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose45:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose46:
+ax_pose 14, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose47:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose48:
+ax_pose 22, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose49:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose50:
+ax_pose 11, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose51:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose52:
+ax_pose 21, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose53:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 7, 0x0202, 0x0100, 0x0c0f
+ax_pose_terminator
+sDeoxysNormalPose54:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose55:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose56:
+ax_pose 20, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose57:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose58:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose59:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose60:
+ax_pose 19, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose61:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 7, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose62:
+ax_pose 8, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose63:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose64:
+ax_pose 20, 0x01e3, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose65:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose66:
+ax_pose 11, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose67:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose68:
+ax_pose 21, 0x01e2, 0x90f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose69:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose70:
+ax_pose 14, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose71:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose72:
+ax_pose 22, 0x01e2, 0x90f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose73:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose74:
+ax_pose 17, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose75:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose76:
+ax_pose 23, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose77:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose78:
+ax_pose 14, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose79:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose80:
+ax_pose 22, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose81:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose82:
+ax_pose 11, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose83:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose84:
+ax_pose 21, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose85:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 7, 0x0202, 0x0100, 0x0c0f
+ax_pose_terminator
+sDeoxysNormalPose86:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose87:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose88:
+ax_pose 20, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose89:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose90:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose91:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose92:
+ax_pose 24, 0x81e2, 0x80f1, 0x9c00
+ax_pose 25, 0x81e2, 0x4101, 0x9c08
+ax_pose 26, 0x81eb, 0x00e9, 0x9c0c
+ax_pose 27, 0x01e9, 0x0109, 0x9c0e
+ax_pose 28, 0x01e9, 0x0111, 0x9c0f
+ax_pose 29, 0x01da, 0x00ff, 0x9c10
+ax_pose 30, 0x01f1, 0x0111, 0x9c11
+ax_pose_terminator
+sDeoxysNormalPose93:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 7, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose94:
+ax_pose 8, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose95:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose96:
+ax_pose 31, 0x41e2, 0x90f1, 0x9c00
+ax_pose 32, 0x41f2, 0x10f9, 0x9c08
+ax_pose 33, 0x01f2, 0x10f1, 0x9c0a
+ax_pose 34, 0x81ea, 0x10e9, 0x9c0b
+ax_pose 35, 0x01fa, 0x10e9, 0x9c0d
+ax_pose 29, 0x01da, 0x00fe, 0x9c0e
+ax_pose 36, 0x41fa, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose97:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose98:
+ax_pose 11, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose99:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose100:
+ax_pose 37, 0x81e2, 0x90f9, 0x9c00
+ax_pose 38, 0x0202, 0x10f9, 0x9c08
+ax_pose 39, 0x81f2, 0x10f1, 0x9c09
+ax_pose 40, 0x01ea, 0x10f1, 0x9c0b
+ax_pose_terminator
+sDeoxysNormalPose101:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose102:
+ax_pose 14, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose103:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose104:
+ax_pose 41, 0x81e3, 0x9100, 0x9c00
+ax_pose 42, 0x81e3, 0x50f8, 0x9c08
+ax_pose 43, 0x81e3, 0x10f0, 0x9c0c
+ax_pose_terminator
+sDeoxysNormalPose105:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose106:
+ax_pose 17, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose107:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose108:
+ax_pose 44, 0x81e2, 0x80f9, 0x9c00
+ax_pose 45, 0x81e2, 0x40f1, 0x9c08
+ax_pose 46, 0x81ee, 0x00e9, 0x9c0c
+ax_pose 47, 0x81ea, 0x0109, 0x9c0e
+ax_pose 48, 0x81ed, 0x0111, 0x9c10
+ax_pose_terminator
+sDeoxysNormalPose109:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose110:
+ax_pose 14, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose111:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose112:
+ax_pose 41, 0x81e3, 0x80f0, 0x9c00
+ax_pose 42, 0x81e3, 0x4100, 0x9c08
+ax_pose 43, 0x81e4, 0x0108, 0x9c0c
+ax_pose_terminator
+sDeoxysNormalPose113:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose114:
+ax_pose 11, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose115:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose116:
+ax_pose 37, 0x81e2, 0x80f8, 0x9c00
+ax_pose 38, 0x0202, 0x0100, 0x9c08
+ax_pose 39, 0x81f2, 0x0108, 0x9c09
+ax_pose 40, 0x01ea, 0x0108, 0x9c0b
+ax_pose_terminator
+sDeoxysNormalPose117:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 7, 0x0202, 0x0100, 0x0c0f
+ax_pose_terminator
+sDeoxysNormalPose118:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose119:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose120:
+ax_pose 31, 0x41e3, 0x80f0, 0x9c00
+ax_pose 32, 0x41f3, 0x00f8, 0x9c08
+ax_pose 33, 0x01f3, 0x0108, 0x9c0a
+ax_pose 34, 0x81eb, 0x0110, 0x9c0b
+ax_pose 35, 0x01fb, 0x0110, 0x9c0d
+ax_pose 29, 0x01db, 0x10fb, 0x9c0e
+ax_pose 36, 0x41fb, 0x00f8, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose121:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose122:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose123:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose124:
+ax_pose 49, 0x81e3, 0x80ff, 0x9c00
+ax_pose 50, 0x81e3, 0x40f7, 0x9c08
+ax_pose 51, 0x81eb, 0x00ef, 0x9c0c
+ax_pose 52, 0x01eb, 0x010f, 0x9c0e
+ax_pose_terminator
+sDeoxysNormalPose125:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 7, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose126:
+ax_pose 8, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose127:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose128:
+ax_pose 53, 0x01e2, 0x90f3, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose129:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose130:
+ax_pose 11, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose131:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose132:
+ax_pose 54, 0x01e2, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose133:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose134:
+ax_pose 14, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose135:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose136:
+ax_pose 55, 0x41e3, 0x90f6, 0x9c00
+ax_pose 56, 0x01f3, 0x50fe, 0x9c08
+ax_pose 57, 0x81f3, 0x10f6, 0x9c0c
+ax_pose 58, 0x01db, 0x1106, 0x9c0e
+ax_pose 59, 0x01db, 0x10fe, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose137:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose138:
+ax_pose 17, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose139:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose140:
+ax_pose 60, 0x81e2, 0x80ff, 0x9c00
+ax_pose 61, 0x81e2, 0x40f7, 0x9c08
+ax_pose 62, 0x81e2, 0x00ef, 0x9c0c
+ax_pose 63, 0x0202, 0x00f7, 0x9c0e
+ax_pose 64, 0x01e2, 0x010f, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose141:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose142:
+ax_pose 14, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose143:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose144:
+ax_pose 55, 0x41e3, 0x80eb, 0x9c00
+ax_pose 56, 0x01f3, 0x40f3, 0x9c08
+ax_pose 57, 0x81f3, 0x0103, 0x9c0c
+ax_pose 58, 0x01db, 0x00f3, 0x9c0e
+ax_pose 59, 0x01db, 0x00fb, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose145:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose146:
+ax_pose 11, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose147:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose148:
+ax_pose 54, 0x01e2, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose149:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 7, 0x0202, 0x0100, 0x0c0f
+ax_pose_terminator
+sDeoxysNormalPose150:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose151:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose152:
+ax_pose 53, 0x01e2, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose153:
+ax_pose 65, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose154:
+ax_pose 66, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose155:
+ax_pose 19, 0x01e1, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose156:
+ax_pose 20, 0x01e2, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose157:
+ax_pose 21, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose158:
+ax_pose 22, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose159:
+ax_pose 23, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose160:
+ax_pose 22, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose161:
+ax_pose 21, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose162:
+ax_pose 20, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose163:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose164:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose165:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose166:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 7, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose167:
+ax_pose 8, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose168:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose169:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose170:
+ax_pose 11, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose171:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose172:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose173:
+ax_pose 14, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose174:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose175:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose176:
+ax_pose 17, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose177:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose178:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose179:
+ax_pose 14, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose180:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose181:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose182:
+ax_pose 11, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose183:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose184:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 7, 0x0202, 0x0100, 0x0c0f
+ax_pose_terminator
+sDeoxysNormalPose185:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose186:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose187:
+ax_pose 49, 0x81e3, 0x80ff, 0x9c00
+ax_pose 50, 0x81e3, 0x40f7, 0x9c08
+ax_pose 51, 0x81eb, 0x00ef, 0x9c0c
+ax_pose 52, 0x01eb, 0x010f, 0x9c0e
+ax_pose_terminator
+sDeoxysNormalPose188:
+ax_pose 53, 0x01e1, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose189:
+ax_pose 54, 0x01e2, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose190:
+ax_pose 55, 0x41e3, 0x80ec, 0x9c00
+ax_pose 56, 0x01f3, 0x40f4, 0x9c08
+ax_pose 57, 0x81f3, 0x0104, 0x9c0c
+ax_pose 58, 0x01db, 0x00f4, 0x9c0e
+ax_pose 59, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose191:
+ax_pose 60, 0x81e2, 0x80ff, 0x9c00
+ax_pose 61, 0x81e2, 0x40f7, 0x9c08
+ax_pose 62, 0x81e2, 0x00ef, 0x9c0c
+ax_pose 63, 0x0202, 0x00f7, 0x9c0e
+ax_pose_terminator
+sDeoxysNormalPose192:
+ax_pose 55, 0x41e3, 0x90f4, 0x9c00
+ax_pose 56, 0x01f3, 0x50fc, 0x9c08
+ax_pose 57, 0x81f3, 0x10f4, 0x9c0c
+ax_pose 58, 0x01db, 0x1104, 0x9c0e
+ax_pose 59, 0x01db, 0x10fc, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose193:
+ax_pose 54, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose194:
+ax_pose 53, 0x01e1, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose195:
+ax_pose 49, 0x81e3, 0x80ff, 0x9c00
+ax_pose 50, 0x81e3, 0x40f7, 0x9c08
+ax_pose 51, 0x81eb, 0x00ef, 0x9c0c
+ax_pose 52, 0x01eb, 0x010f, 0x9c0e
+ax_pose_terminator
+sDeoxysNormalPose196:
+ax_pose 53, 0x01e1, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose197:
+ax_pose 54, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose198:
+ax_pose 55, 0x41e3, 0x90f4, 0x9c00
+ax_pose 56, 0x01f3, 0x50fc, 0x9c08
+ax_pose 57, 0x81f3, 0x10f4, 0x9c0c
+ax_pose 58, 0x01db, 0x1104, 0x9c0e
+ax_pose 59, 0x01db, 0x10fc, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose199:
+ax_pose 60, 0x81e2, 0x80ff, 0x9c00
+ax_pose 61, 0x81e2, 0x40f7, 0x9c08
+ax_pose 62, 0x81e2, 0x00ef, 0x9c0c
+ax_pose 63, 0x0202, 0x00f7, 0x9c0e
+ax_pose_terminator
+sDeoxysNormalPose200:
+ax_pose 55, 0x41e3, 0x80ec, 0x9c00
+ax_pose 56, 0x01f3, 0x40f4, 0x9c08
+ax_pose 57, 0x81f3, 0x0104, 0x9c0c
+ax_pose 58, 0x01db, 0x00f4, 0x9c0e
+ax_pose 59, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose201:
+ax_pose 54, 0x01e2, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose202:
+ax_pose 53, 0x01e1, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose203:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose204:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose205:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose206:
+ax_pose 49, 0x81e3, 0x80ff, 0x9c00
+ax_pose 50, 0x81e3, 0x40f7, 0x9c08
+ax_pose 51, 0x81eb, 0x00ef, 0x9c0c
+ax_pose 52, 0x01eb, 0x010f, 0x9c0e
+ax_pose_terminator
+sDeoxysNormalPose207:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 7, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose208:
+ax_pose 8, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose209:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose210:
+ax_pose 53, 0x01e2, 0x90f3, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose211:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose212:
+ax_pose 11, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose213:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose214:
+ax_pose 54, 0x01e2, 0x90f2, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose215:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose216:
+ax_pose 14, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose217:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose218:
+ax_pose 55, 0x41e3, 0x90f5, 0x9c00
+ax_pose 56, 0x01f3, 0x50fd, 0x9c08
+ax_pose 57, 0x81f3, 0x10f5, 0x9c0c
+ax_pose 58, 0x01db, 0x1105, 0x9c0e
+ax_pose 59, 0x01db, 0x10fd, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose219:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose220:
+ax_pose 17, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose221:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose222:
+ax_pose 60, 0x81e2, 0x80ff, 0x9c00
+ax_pose 61, 0x81e2, 0x40f7, 0x9c08
+ax_pose 62, 0x81e2, 0x00ef, 0x9c0c
+ax_pose 63, 0x0202, 0x00f7, 0x9c0e
+ax_pose_terminator
+sDeoxysNormalPose223:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose224:
+ax_pose 14, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose225:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose226:
+ax_pose 55, 0x41e3, 0x80ec, 0x9c00
+ax_pose 56, 0x01f3, 0x40f4, 0x9c08
+ax_pose 57, 0x81f3, 0x0104, 0x9c0c
+ax_pose 58, 0x01db, 0x00f4, 0x9c0e
+ax_pose 59, 0x01db, 0x00fc, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose227:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose228:
+ax_pose 11, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose229:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose230:
+ax_pose 54, 0x01e2, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose231:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 7, 0x0202, 0x0100, 0x0c0f
+ax_pose_terminator
+sDeoxysNormalPose232:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose233:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose234:
+ax_pose 53, 0x01e2, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose235:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose236:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose237:
+ax_pose 12, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose238:
+ax_pose 15, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose239:
+ax_pose 18, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose240:
+ax_pose 15, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose241:
+ax_pose 12, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose242:
+ax_pose 9, 0x01e2, 0x90f1, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose243:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose244:
+ax_pose 3, 0x81e2, 0x8100, 0x9c00
+ax_pose 4, 0x81e2, 0x40f8, 0x9c08
+ax_pose 5, 0x81f2, 0x00f0, 0x9c0c
+ax_pose 6, 0x01ea, 0x00f0, 0x9c0e
+ax_pose 67, 0x0202, 0x0100, 0x9c0f
+ax_pose_terminator
+sDeoxysNormalPose245:
+ax_pose 10, 0x81e2, 0x80f8, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose246:
+ax_pose 13, 0x01e2, 0x80f4, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose247:
+ax_pose 16, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose248:
+ax_pose 13, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose249:
+ax_pose 10, 0x81e2, 0x90f9, 0x9c00
+ax_pose_terminator
+sDeoxysNormalPose250:
+ax_pose 3, 0x81e2, 0x90f1, 0x9c00
+ax_pose 4, 0x81e2, 0x5101, 0x9c08
+ax_pose 5, 0x81f2, 0x1109, 0x9c0c
+ax_pose 6, 0x01ea, 0x1109, 0x9c0e
+ax_pose 67, 0x0202, 0x10f9, 0x9c0f
+ax_pose_terminator
+.align 2
+sDeoxysNormalAnims_1_1:
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 1,
+ax_anim 8, 0, 0, 0, -4, 0, 2,
+ax_anim 8, 0, 2, 0, -5, 0, 2,
+ax_anim 8, 0, 0, 0, -5, 0, 2,
+ax_anim 8, 0, 1, 0, -4, 0, 2,
+ax_anim 8, 0, 0, 0, -3, 0, 1,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_1_2:
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 1, -3, 1, 1,
+ax_anim 8, 0, 3, 2, -4, 2, 2,
+ax_anim 8, 0, 5, 2, -5, 2, 2,
+ax_anim 8, 0, 3, 2, -5, 2, 2,
+ax_anim 8, 0, 4, 2, -4, 2, 2,
+ax_anim 8, 0, 3, 1, -3, 1, 1,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_1_3:
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 1, -3, 1, 0,
+ax_anim 8, 0, 6, 2, -4, 2, 0,
+ax_anim 8, 0, 8, 2, -5, 2, 0,
+ax_anim 8, 0, 6, 2, -5, 2, 0,
+ax_anim 8, 0, 7, 2, -4, 2, 0,
+ax_anim 8, 0, 6, 1, -3, 1, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_1_4:
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 1, -3, 1, -1,
+ax_anim 8, 0, 9, 2, -4, 2, -2,
+ax_anim 8, 0, 11, 2, -5, 2, -2,
+ax_anim 8, 0, 9, 2, -5, 2, -2,
+ax_anim 8, 0, 10, 2, -4, 2, -2,
+ax_anim 8, 0, 9, 1, -3, 1, -1,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_1_5:
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, -1,
+ax_anim 8, 0, 12, 0, -4, 0, -2,
+ax_anim 8, 0, 14, 0, -5, 0, -2,
+ax_anim 8, 0, 12, 0, -5, 0, -2,
+ax_anim 8, 0, 13, 0, -4, 0, -2,
+ax_anim 8, 0, 12, 0, -3, 0, -1,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_1_6:
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, -1, -3, -1, -1,
+ax_anim 8, 0, 15, -2, -4, -2, -2,
+ax_anim 8, 0, 17, -2, -5, -2, -2,
+ax_anim 8, 0, 15, -2, -5, -2, -2,
+ax_anim 8, 0, 16, -2, -4, -2, -2,
+ax_anim 8, 0, 15, -1, -3, -1, -1,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_1_7:
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, -1, -3, -1, 0,
+ax_anim 8, 0, 18, -2, -4, -2, 0,
+ax_anim 8, 0, 20, -2, -5, -2, 0,
+ax_anim 8, 0, 18, -2, -5, -2, 0,
+ax_anim 8, 0, 19, -2, -4, -2, 0,
+ax_anim 8, 0, 18, -1, -3, -1, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_1_8:
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, -1, -3, -1, 1,
+ax_anim 8, 0, 21, -2, -4, -2, 2,
+ax_anim 8, 0, 23, -2, -5, -2, 2,
+ax_anim 8, 0, 21, -2, -5, -2, 2,
+ax_anim 8, 0, 22, -2, -4, -2, 2,
+ax_anim 8, 0, 21, -1, -3, -1, 1,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysNormalAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 20, 19, 20,
+ax_anim 2, 1, 31, 20, 19, 20, 19,
+ax_anim 2, 0, 31, 19, 20, 19, 20,
+ax_anim 2, 0, 31, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysNormalAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -5, 5, -5,
+ax_anim 1, 0, 38, 12, -11, 12, -11,
+ax_anim 2, 0, 39, 18, -15, 18, -15,
+ax_anim 2, 1, 39, 19, -14, 19, -14,
+ax_anim 2, 0, 39, 18, -15, 18, -15,
+ax_anim 2, 0, 39, 19, -14, 19, -14,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sDeoxysNormalAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -2, 0, -2,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 1, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysNormalAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -5, -5, -5,
+ax_anim 1, 0, 46, -12, -11, -12, -11,
+ax_anim 2, 0, 47, -18, -15, -18, -15,
+ax_anim 2, 1, 47, -19, -14, -19, -14,
+ax_anim 2, 0, 47, -18, -15, -18, -15,
+ax_anim 2, 0, 47, -19, -14, -19, -14,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysNormalAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -19, 20, -19, 20,
+ax_anim 2, 1, 55, -20, 19, -20, 19,
+ax_anim 2, 0, 55, -19, 20, -19, 20,
+ax_anim 2, 0, 55, -20, 19, -20, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 6, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysNormalAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 6, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 19, 20, 19, 20,
+ax_anim 2, 1, 63, 20, 19, 20, 19,
+ax_anim 2, 0, 63, 19, 20, 19, 20,
+ax_anim 2, 0, 63, 20, 19, 20, 19,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysNormalAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 6, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 1, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 0, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 6, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 5, -5, 5, -5,
+ax_anim 1, 0, 70, 12, -11, 12, -11,
+ax_anim 2, 0, 71, 18, -15, 18, -15,
+ax_anim 2, 1, 71, 19, -14, 19, -14,
+ax_anim 2, 0, 71, 18, -15, 18, -15,
+ax_anim 2, 0, 71, 19, -14, 19, -14,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sDeoxysNormalAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -2, 0, -2,
+ax_anim 1, 0, 74, 0, -9, 0, -9,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 1, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysNormalAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 6, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -5, -5, -5, -5,
+ax_anim 1, 0, 78, -12, -11, -12, -11,
+ax_anim 2, 0, 79, -18, -15, -18, -15,
+ax_anim 2, 1, 79, -19, -14, -19, -14,
+ax_anim 2, 0, 79, -18, -15, -18, -15,
+ax_anim 2, 0, 79, -19, -14, -19, -14,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysNormalAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 6, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 1, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 0, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 6, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -19, 20, -19, 20,
+ax_anim 2, 1, 87, -20, 19, -20, 19,
+ax_anim 2, 0, 87, -19, 20, -19, 20,
+ax_anim 2, 0, 87, -20, 19, -20, 19,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 8, 2, 91, 0, -5, 0, 0,
+ax_anim 1, 1, 91, 0, -5, 0, 0,
+ax_anim 1, 0, 91, 0, -13, 0, -8,
+ax_anim 2, 0, 91, 0, -15, 0, -10,
+ax_anim 3, 0, 91, 0, -16, 0, -11,
+ax_anim 2, 0, 91, 0, -14, 0, -9,
+ax_anim 2, 0, 91, 0, -9, 0, -4,
+ax_anim 4, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_4_2:
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 8, 2, 95, 0, -5, 0, 0,
+ax_anim 1, 1, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, -8, -13, -8, -8,
+ax_anim 2, 0, 95, -10, -15, -10, -10,
+ax_anim 3, 0, 95, -11, -16, -11, -11,
+ax_anim 2, 0, 95, -9, -14, -9, -9,
+ax_anim 2, 0, 95, -4, -9, -4, -4,
+ax_anim 4, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_4_3:
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 8, 2, 99, 0, -5, 0, 0,
+ax_anim 1, 1, 99, 0, -5, 0, 0,
+ax_anim 1, 0, 99, -8, -5, -8, 0,
+ax_anim 2, 0, 99, -10, -5, -10, 0,
+ax_anim 3, 0, 99, -11, -5, -11, 0,
+ax_anim 2, 0, 99, -9, -5, -9, 0,
+ax_anim 2, 0, 99, -4, -5, -4, 0,
+ax_anim 4, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_4_4:
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 8, 2, 103, 0, -5, 0, 0,
+ax_anim 1, 1, 103, 0, -5, 0, 0,
+ax_anim 1, 0, 103, -8, 3, -8, 8,
+ax_anim 2, 0, 103, -10, 5, -10, 10,
+ax_anim 3, 0, 103, -11, 6, -11, 11,
+ax_anim 2, 0, 103, -9, 4, -9, 9,
+ax_anim 2, 0, 103, -4, -1, -4, 4,
+ax_anim 4, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_4_5:
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 8, 2, 107, 0, -5, 0, 0,
+ax_anim 1, 1, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, 3, 0, 8,
+ax_anim 2, 0, 107, 0, 5, 0, 10,
+ax_anim 3, 0, 107, 0, 6, 0, 11,
+ax_anim 2, 0, 107, 0, 5, 0, 9,
+ax_anim 2, 0, 107, 0, -4, 0, 1,
+ax_anim 4, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_4_6:
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 8, 2, 111, 0, -5, 0, 0,
+ax_anim 1, 1, 111, 0, -5, 0, 0,
+ax_anim 1, 0, 111, 8, 3, 8, 8,
+ax_anim 2, 0, 111, 10, 5, 10, 10,
+ax_anim 3, 0, 111, 11, 6, 11, 11,
+ax_anim 2, 0, 111, 9, 4, 9, 9,
+ax_anim 2, 0, 111, 4, -1, 4, 4,
+ax_anim 4, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_4_7:
+ax_anim 2, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 8, 2, 115, 0, -5, 0, 0,
+ax_anim 1, 1, 115, 0, -5, 0, 0,
+ax_anim 1, 0, 115, 8, -5, 8, 0,
+ax_anim 2, 0, 115, 10, -5, 10, 0,
+ax_anim 3, 0, 115, 11, -5, 11, 0,
+ax_anim 2, 0, 115, 9, -5, 9, 0,
+ax_anim 2, 0, 115, 4, -5, 4, 0,
+ax_anim 4, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_4_8:
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 8, 2, 119, 0, -5, 0, 0,
+ax_anim 1, 1, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 8, -13, 8, -8,
+ax_anim 2, 0, 119, 10, -15, 10, -10,
+ax_anim 3, 0, 119, 11, -16, 11, -11,
+ax_anim 2, 0, 119, 9, -14, 9, -9,
+ax_anim 2, 0, 119, 4, -9, 4, -4,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_5_1:
+ax_anim 2, 0, 121, 0, -2, 0, -2,
+ax_anim 2, 0, 120, 0, -3, 0, -3,
+ax_anim 6, 0, 122, 0, -4, 0, -4,
+ax_anim 1, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_5_2:
+ax_anim 2, 0, 125, -2, -2, -2, -2,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim 6, 0, 126, -4, -4, -4, -4,
+ax_anim 1, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim_terminator
+sDeoxysNormalAnims_5_3:
+ax_anim 2, 0, 129, -2, 0, -2, 0,
+ax_anim 2, 0, 128, -3, 0, -3, 0,
+ax_anim 6, 0, 130, -4, 0, -4, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim_terminator
+sDeoxysNormalAnims_5_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 2, 0, 132, -3, 3, -3, 3,
+ax_anim 6, 0, 134, -4, 4, -4, 4,
+ax_anim 1, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+sDeoxysNormalAnims_5_5:
+ax_anim 2, 0, 137, 0, 2, 0, 2,
+ax_anim 2, 0, 136, 0, 3, 0, 3,
+ax_anim 6, 0, 138, 0, 4, 0, 4,
+ax_anim 1, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_5_6:
+ax_anim 2, 0, 141, 2, 2, 2, 2,
+ax_anim 2, 0, 140, 3, 3, 3, 3,
+ax_anim 6, 0, 142, 4, 4, 4, 4,
+ax_anim 1, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim_terminator
+sDeoxysNormalAnims_5_7:
+ax_anim 2, 0, 145, 2, 0, 2, 0,
+ax_anim 2, 0, 144, 3, 0, 3, 0,
+ax_anim 6, 0, 146, 4, 0, 4, 0,
+ax_anim 1, 2, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim_terminator
+sDeoxysNormalAnims_5_8:
+ax_anim 2, 0, 149, 2, -2, 2, -2,
+ax_anim 2, 0, 148, 3, -3, 3, -3,
+ax_anim 6, 0, 150, 4, -4, 4, -4,
+ax_anim 1, 2, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sDeoxysNormalAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sDeoxysNormalAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sDeoxysNormalAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sDeoxysNormalAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sDeoxysNormalAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_8_1:
+ax_anim 12, 0, 162, 0, -2, 0, 0,
+ax_anim 12, 0, 163, 0, -3, 0, 0,
+ax_anim 12, 0, 162, 0, -4, 0, 0,
+ax_anim 12, 0, 164, 0, -5, 0, 0,
+ax_anim 12, 0, 162, 0, -5, 0, 0,
+ax_anim 12, 0, 163, 0, -4, 0, 0,
+ax_anim 12, 0, 162, 0, -3, 0, 0,
+ax_anim 12, 0, 164, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_8_2:
+ax_anim 12, 0, 165, 0, -2, 0, 0,
+ax_anim 12, 0, 166, 0, -3, 0, 0,
+ax_anim 12, 0, 165, 0, -4, 0, 0,
+ax_anim 12, 0, 167, 0, -5, 0, 0,
+ax_anim 12, 0, 165, 0, -5, 0, 0,
+ax_anim 12, 0, 166, 0, -4, 0, 0,
+ax_anim 12, 0, 165, 0, -3, 0, 0,
+ax_anim 12, 0, 167, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_8_3:
+ax_anim 12, 0, 168, 0, -2, 0, 0,
+ax_anim 12, 0, 169, 0, -3, 0, 0,
+ax_anim 12, 0, 168, 0, -4, 0, 0,
+ax_anim 12, 0, 170, 0, -5, 0, 0,
+ax_anim 12, 0, 168, 0, -5, 0, 0,
+ax_anim 12, 0, 169, 0, -4, 0, 0,
+ax_anim 12, 0, 168, 0, -3, 0, 0,
+ax_anim 12, 0, 170, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_8_4:
+ax_anim 12, 0, 171, 0, -2, 0, 0,
+ax_anim 12, 0, 172, 0, -3, 0, 0,
+ax_anim 12, 0, 171, 0, -4, 0, 0,
+ax_anim 12, 0, 173, 0, -5, 0, 0,
+ax_anim 12, 0, 171, 0, -5, 0, 0,
+ax_anim 12, 0, 172, 0, -4, 0, 0,
+ax_anim 12, 0, 171, 0, -3, 0, 0,
+ax_anim 12, 0, 173, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_8_5:
+ax_anim 12, 0, 174, 0, -2, 0, 0,
+ax_anim 12, 0, 175, 0, -3, 0, 0,
+ax_anim 12, 0, 174, 0, -4, 0, 0,
+ax_anim 12, 0, 176, 0, -5, 0, 0,
+ax_anim 12, 0, 174, 0, -5, 0, 0,
+ax_anim 12, 0, 175, 0, -4, 0, 0,
+ax_anim 12, 0, 174, 0, -3, 0, 0,
+ax_anim 12, 0, 176, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_8_6:
+ax_anim 12, 0, 177, 0, -2, 0, 0,
+ax_anim 12, 0, 178, 0, -3, 0, 0,
+ax_anim 12, 0, 177, 0, -4, 0, 0,
+ax_anim 12, 0, 179, 0, -5, 0, 0,
+ax_anim 12, 0, 177, 0, -5, 0, 0,
+ax_anim 12, 0, 178, 0, -4, 0, 0,
+ax_anim 12, 0, 177, 0, -3, 0, 0,
+ax_anim 12, 0, 179, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_8_7:
+ax_anim 12, 0, 180, 0, -2, 0, 0,
+ax_anim 12, 0, 181, 0, -3, 0, 0,
+ax_anim 12, 0, 180, 0, -4, 0, 0,
+ax_anim 12, 0, 182, 0, -5, 0, 0,
+ax_anim 12, 0, 180, 0, -5, 0, 0,
+ax_anim 12, 0, 181, 0, -4, 0, 0,
+ax_anim 12, 0, 180, 0, -3, 0, 0,
+ax_anim 12, 0, 182, 0, -2, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_8_8:
+ax_anim 12, 0, 183, 0, -2, 0, 0,
+ax_anim 12, 0, 184, 0, -3, 0, 0,
+ax_anim 12, 0, 183, 0, -4, 0, 0,
+ax_anim 12, 0, 185, 0, -5, 0, 0,
+ax_anim 12, 0, 183, 0, -5, 0, 0,
+ax_anim 12, 0, 184, 0, -4, 0, 0,
+ax_anim 12, 0, 183, 0, -3, 0, 0,
+ax_anim 12, 0, 185, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 4, 7, 4,
+ax_anim 2, 0, 188, 10, 10, 10, 10,
+ax_anim 2, 0, 189, 8, 17, 8, 17,
+ax_anim 3, 0, 190, 0, 19, 0, 19,
+ax_anim 2, 3, 191, -8, 17, -8, 17,
+ax_anim 2, 0, 192, -10, 10, -10, 10,
+ax_anim 1, 0, 193, -7, 4, -7, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 16, 3, 16, 3,
+ax_anim 2, 0, 188, 24, 9, 24, 9,
+ax_anim 3, 0, 189, 22, 19, 22, 19,
+ax_anim 2, 3, 190, 13, 20, 13, 20,
+ax_anim 2, 0, 191, 1, 18, 1, 18,
+ax_anim 1, 0, 192, -2, 7, -2, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -7, 11, -7,
+ax_anim 2, 0, 187, 19, -6, 19, -6,
+ax_anim 3, 0, 188, 23, -2, 23, -2,
+ax_anim 2, 3, 189, 21, 5, 21, 5,
+ax_anim 2, 0, 190, 12, 6, 12, 6,
+ax_anim 1, 0, 191, 1, 5, 1, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, -8,
+ax_anim 2, 0, 193, 4, -17, 4, -17,
+ax_anim 2, 0, 186, 12, -20, 12, -20,
+ax_anim 3, 0, 187, 21, -20, 21, -20,
+ax_anim 2, 3, 188, 26, -14, 26, -14,
+ax_anim 2, 0, 189, 21, -5, 21, -5,
+ax_anim 1, 0, 190, 13, 0, 13, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -11, -9, -11,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -20, 0, -20,
+ax_anim 2, 3, 187, 8, -18, 8, -18,
+ax_anim 2, 0, 188, 10, -10, 10, -10,
+ax_anim 1, 0, 189, 9, -2, 9, -2,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -8, 0, -8,
+ax_anim 2, 0, 187, -4, -17, -4, -17,
+ax_anim 2, 0, 186, -12, -20, -12, -20,
+ax_anim 3, 0, 193, -21, -20, -21, -20,
+ax_anim 2, 3, 192, -26, -14, -26, -14,
+ax_anim 2, 0, 191, -21, -5, -21, -5,
+ax_anim 1, 0, 190, -13, 0, -13, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -7, -11, -7,
+ax_anim 2, 0, 193, -19, -6, -19, -6,
+ax_anim 3, 0, 192, -23, -2, -23, -2,
+ax_anim 2, 3, 191, -21, 5, -21, 5,
+ax_anim 2, 0, 190, -12, 6, -12, 6,
+ax_anim 1, 0, 189, -1, 5, -1, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -16, 3, -16, 3,
+ax_anim 2, 0, 192, -24, 9, -24, 9,
+ax_anim 3, 0, 191, -22, 19, -22, 19,
+ax_anim 2, 3, 190, -13, 20, -13, 20,
+ax_anim 2, 0, 189, -1, 18, -1, 18,
+ax_anim 1, 0, 188, 2, 7, 2, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_11_2:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_11_3:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_11_4:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -17, 0, 0,
+ax_anim 1, 0, 217, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_11_5:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -18, 0, 0,
+ax_anim 1, 0, 221, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_11_6:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -22, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 2, 0, 225, 0, -17, 0, 0,
+ax_anim 1, 0, 225, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_11_7:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 229, 0, -22, 0, 0,
+ax_anim 2, 0, 229, 0, -18, 0, 0,
+ax_anim 1, 0, 229, 0, -12, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_11_8:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysNormalAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysNormalGfx1:
+.incbin "baserom.gba", 0x161178C, 0x200
+sDeoxysNormalSprites1:
+ax_sprite sDeoxysNormalGfx1, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx2:
+.incbin "baserom.gba", 0x161199C, 0x200
+sDeoxysNormalSprites2:
+ax_sprite sDeoxysNormalGfx2, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx3:
+.incbin "baserom.gba", 0x1611BAC, 0x200
+sDeoxysNormalSprites3:
+ax_sprite sDeoxysNormalGfx3, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx4:
+.incbin "baserom.gba", 0x1611DBC, 0x100
+sDeoxysNormalSprites4:
+ax_sprite sDeoxysNormalGfx4, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx5:
+.incbin "baserom.gba", 0x1611ECC, 0x80
+sDeoxysNormalSprites5:
+ax_sprite sDeoxysNormalGfx5, 0x80
+ax_sprite_terminator
+sDeoxysNormalGfx6:
+.incbin "baserom.gba", 0x1611F5C, 0x40
+sDeoxysNormalSprites6:
+ax_sprite sDeoxysNormalGfx6, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx7:
+.incbin "baserom.gba", 0x1611FAC, 0x20
+sDeoxysNormalSprites7:
+ax_sprite sDeoxysNormalGfx7, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx8:
+.incbin "baserom.gba", 0x1611FDC, 0x20
+sDeoxysNormalSprites8:
+ax_sprite sDeoxysNormalGfx8, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx9:
+.incbin "baserom.gba", 0x161200C, 0x200
+sDeoxysNormalSprites9:
+ax_sprite sDeoxysNormalGfx9, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx10:
+.incbin "baserom.gba", 0x161221C, 0x200
+sDeoxysNormalSprites10:
+ax_sprite sDeoxysNormalGfx10, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx11:
+.incbin "baserom.gba", 0x161242C, 0x100
+sDeoxysNormalSprites11:
+ax_sprite sDeoxysNormalGfx11, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx12:
+.incbin "baserom.gba", 0x161253C, 0x100
+sDeoxysNormalSprites12:
+ax_sprite sDeoxysNormalGfx12, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx13:
+.incbin "baserom.gba", 0x161264C, 0x100
+sDeoxysNormalSprites13:
+ax_sprite sDeoxysNormalGfx13, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx14:
+.incbin "baserom.gba", 0x161275C, 0x200
+sDeoxysNormalSprites14:
+ax_sprite sDeoxysNormalGfx14, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx15:
+.incbin "baserom.gba", 0x161296C, 0x200
+sDeoxysNormalSprites15:
+ax_sprite sDeoxysNormalGfx15, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx16:
+.incbin "baserom.gba", 0x1612B7C, 0x200
+sDeoxysNormalSprites16:
+ax_sprite sDeoxysNormalGfx16, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx17:
+.incbin "baserom.gba", 0x1612D8C, 0x200
+sDeoxysNormalSprites17:
+ax_sprite sDeoxysNormalGfx17, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx18:
+.incbin "baserom.gba", 0x1612F9C, 0x200
+sDeoxysNormalSprites18:
+ax_sprite sDeoxysNormalGfx18, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx19:
+.incbin "baserom.gba", 0x16131AC, 0x200
+sDeoxysNormalSprites19:
+ax_sprite sDeoxysNormalGfx19, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx20:
+.incbin "baserom.gba", 0x16133BC, 0x40
+sDeoxysNormalGfx20_1:
+.incbin "baserom.gba", 0x16133FC, 0x180
+sDeoxysNormalSprites20:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx20_1, 0x180
+ax_sprite_terminator
+sDeoxysNormalGfx21:
+.incbin "baserom.gba", 0x16135A4, 0x60
+sDeoxysNormalGfx21_1:
+.incbin "baserom.gba", 0x1613604, 0x100
+sDeoxysNormalGfx21_2:
+.incbin "baserom.gba", 0x1613704, 0x60
+sDeoxysNormalSprites21:
+ax_sprite sDeoxysNormalGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx21_2, 0x60
+ax_sprite_terminator
+sDeoxysNormalGfx22:
+.incbin "baserom.gba", 0x1613794, 0x40
+sDeoxysNormalGfx22_1:
+.incbin "baserom.gba", 0x16137D4, 0x60
+sDeoxysNormalGfx22_2:
+.incbin "baserom.gba", 0x1613834, 0x80
+sDeoxysNormalGfx22_3:
+.incbin "baserom.gba", 0x16138B4, 0x60
+sDeoxysNormalSprites22:
+ax_sprite sDeoxysNormalGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDeoxysNormalGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx22_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx22_3, 0x60
+ax_sprite_terminator
+sDeoxysNormalGfx23:
+.incbin "baserom.gba", 0x1613954, 0x60
+sDeoxysNormalGfx23_1:
+.incbin "baserom.gba", 0x16139B4, 0x60
+sDeoxysNormalGfx23_2:
+.incbin "baserom.gba", 0x1613A14, 0x60
+sDeoxysNormalGfx23_3:
+.incbin "baserom.gba", 0x1613A74, 0x60
+sDeoxysNormalSprites23:
+ax_sprite sDeoxysNormalGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx24:
+.incbin "baserom.gba", 0x1613B1C, 0x40
+sDeoxysNormalGfx24_1:
+.incbin "baserom.gba", 0x1613B5C, 0x180
+sDeoxysNormalSprites24:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx24_1, 0x180
+ax_sprite_terminator
+sDeoxysNormalGfx25:
+.incbin "baserom.gba", 0x1613D04, 0x100
+sDeoxysNormalSprites25:
+ax_sprite sDeoxysNormalGfx25, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx26:
+.incbin "baserom.gba", 0x1613E14, 0x80
+sDeoxysNormalSprites26:
+ax_sprite sDeoxysNormalGfx26, 0x80
+ax_sprite_terminator
+sDeoxysNormalGfx27:
+.incbin "baserom.gba", 0x1613EA4, 0x40
+sDeoxysNormalSprites27:
+ax_sprite sDeoxysNormalGfx27, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx28:
+.incbin "baserom.gba", 0x1613EF4, 0x20
+sDeoxysNormalSprites28:
+ax_sprite sDeoxysNormalGfx28, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx29:
+.incbin "baserom.gba", 0x1613F24, 0x20
+sDeoxysNormalSprites29:
+ax_sprite sDeoxysNormalGfx29, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx30:
+.incbin "baserom.gba", 0x1613F54, 0x20
+sDeoxysNormalSprites30:
+ax_sprite sDeoxysNormalGfx30, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx31:
+.incbin "baserom.gba", 0x1613F84, 0x20
+sDeoxysNormalSprites31:
+ax_sprite sDeoxysNormalGfx31, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx32:
+.incbin "baserom.gba", 0x1613FB4, 0x100
+sDeoxysNormalSprites32:
+ax_sprite sDeoxysNormalGfx32, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx33:
+.incbin "baserom.gba", 0x16140C4, 0x40
+sDeoxysNormalSprites33:
+ax_sprite sDeoxysNormalGfx33, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx34:
+.incbin "baserom.gba", 0x1614114, 0x20
+sDeoxysNormalSprites34:
+ax_sprite sDeoxysNormalGfx34, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx35:
+.incbin "baserom.gba", 0x1614144, 0x40
+sDeoxysNormalSprites35:
+ax_sprite sDeoxysNormalGfx35, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx36:
+.incbin "baserom.gba", 0x1614194, 0x20
+sDeoxysNormalSprites36:
+ax_sprite sDeoxysNormalGfx36, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx37:
+.incbin "baserom.gba", 0x16141C4, 0x40
+sDeoxysNormalSprites37:
+ax_sprite sDeoxysNormalGfx37, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx38:
+.incbin "baserom.gba", 0x1614214, 0x100
+sDeoxysNormalSprites38:
+ax_sprite sDeoxysNormalGfx38, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx39:
+.incbin "baserom.gba", 0x1614324, 0x20
+sDeoxysNormalSprites39:
+ax_sprite sDeoxysNormalGfx39, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx40:
+.incbin "baserom.gba", 0x1614354, 0x40
+sDeoxysNormalSprites40:
+ax_sprite sDeoxysNormalGfx40, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx41:
+.incbin "baserom.gba", 0x16143A4, 0x20
+sDeoxysNormalSprites41:
+ax_sprite sDeoxysNormalGfx41, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx42:
+.incbin "baserom.gba", 0x16143D4, 0xE0
+sDeoxysNormalSprites42:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx42, 0xe0
+ax_sprite_terminator
+sDeoxysNormalGfx43:
+.incbin "baserom.gba", 0x16144CC, 0x80
+sDeoxysNormalSprites43:
+ax_sprite sDeoxysNormalGfx43, 0x80
+ax_sprite_terminator
+sDeoxysNormalGfx44:
+.incbin "baserom.gba", 0x161455C, 0x40
+sDeoxysNormalSprites44:
+ax_sprite sDeoxysNormalGfx44, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx45:
+.incbin "baserom.gba", 0x16145AC, 0x100
+sDeoxysNormalSprites45:
+ax_sprite sDeoxysNormalGfx45, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx46:
+.incbin "baserom.gba", 0x16146BC, 0x80
+sDeoxysNormalSprites46:
+ax_sprite sDeoxysNormalGfx46, 0x80
+ax_sprite_terminator
+sDeoxysNormalGfx47:
+.incbin "baserom.gba", 0x161474C, 0x40
+sDeoxysNormalSprites47:
+ax_sprite sDeoxysNormalGfx47, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx48:
+.incbin "baserom.gba", 0x161479C, 0x40
+sDeoxysNormalSprites48:
+ax_sprite sDeoxysNormalGfx48, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx49:
+.incbin "baserom.gba", 0x16147EC, 0x40
+sDeoxysNormalSprites49:
+ax_sprite sDeoxysNormalGfx49, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx50:
+.incbin "baserom.gba", 0x161483C, 0x100
+sDeoxysNormalSprites50:
+ax_sprite sDeoxysNormalGfx50, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx51:
+.incbin "baserom.gba", 0x161494C, 0x80
+sDeoxysNormalSprites51:
+ax_sprite sDeoxysNormalGfx51, 0x80
+ax_sprite_terminator
+sDeoxysNormalGfx52:
+.incbin "baserom.gba", 0x16149DC, 0x40
+sDeoxysNormalSprites52:
+ax_sprite sDeoxysNormalGfx52, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx53:
+.incbin "baserom.gba", 0x1614A2C, 0x20
+sDeoxysNormalSprites53:
+ax_sprite sDeoxysNormalGfx53, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx54:
+.incbin "baserom.gba", 0x1614A5C, 0x40
+sDeoxysNormalGfx54_1:
+.incbin "baserom.gba", 0x1614A9C, 0x100
+sDeoxysNormalGfx54_2:
+.incbin "baserom.gba", 0x1614B9C, 0x60
+sDeoxysNormalSprites54:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx54, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx54_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx54_2, 0x60
+ax_sprite_terminator
+sDeoxysNormalGfx55:
+.incbin "baserom.gba", 0x1614C34, 0x60
+sDeoxysNormalGfx55_1:
+.incbin "baserom.gba", 0x1614C94, 0x60
+sDeoxysNormalGfx55_2:
+.incbin "baserom.gba", 0x1614CF4, 0x80
+sDeoxysNormalGfx55_3:
+.incbin "baserom.gba", 0x1614D74, 0x60
+sDeoxysNormalSprites55:
+ax_sprite sDeoxysNormalGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx55_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDeoxysNormalGfx55_3, 0x60
+ax_sprite_terminator
+sDeoxysNormalGfx56:
+.incbin "baserom.gba", 0x1614E14, 0x100
+sDeoxysNormalSprites56:
+ax_sprite sDeoxysNormalGfx56, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx57:
+.incbin "baserom.gba", 0x1614F24, 0x80
+sDeoxysNormalSprites57:
+ax_sprite sDeoxysNormalGfx57, 0x80
+ax_sprite_terminator
+sDeoxysNormalGfx58:
+.incbin "baserom.gba", 0x1614FB4, 0x20
+sDeoxysNormalSprites58:
+ax_sprite sDeoxysNormalGfx58, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx59:
+.incbin "baserom.gba", 0x1614FEC, 0x20
+sDeoxysNormalSprites59:
+ax_sprite sDeoxysNormalGfx59, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx60:
+.incbin "baserom.gba", 0x161501C, 0x20
+sDeoxysNormalSprites60:
+ax_sprite sDeoxysNormalGfx60, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx61:
+.incbin "baserom.gba", 0x161504C, 0x100
+sDeoxysNormalSprites61:
+ax_sprite sDeoxysNormalGfx61, 0x100
+ax_sprite_terminator
+sDeoxysNormalGfx62:
+.incbin "baserom.gba", 0x161515C, 0x80
+sDeoxysNormalSprites62:
+ax_sprite sDeoxysNormalGfx62, 0x80
+ax_sprite_terminator
+sDeoxysNormalGfx63:
+.incbin "baserom.gba", 0x16151EC, 0x40
+sDeoxysNormalSprites63:
+ax_sprite sDeoxysNormalGfx63, 0x40
+ax_sprite_terminator
+sDeoxysNormalGfx64:
+.incbin "baserom.gba", 0x161523C, 0x20
+sDeoxysNormalSprites64:
+ax_sprite sDeoxysNormalGfx64, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx65:
+.incbin "baserom.gba", 0x161526C, 0x20
+sDeoxysNormalSprites65:
+ax_sprite sDeoxysNormalGfx65, 0x20
+ax_sprite_terminator
+sDeoxysNormalGfx66:
+.incbin "baserom.gba", 0x161529C, 0x200
+sDeoxysNormalSprites66:
+ax_sprite sDeoxysNormalGfx66, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx67:
+.incbin "baserom.gba", 0x16154AC, 0x200
+sDeoxysNormalSprites67:
+ax_sprite sDeoxysNormalGfx67, 0x200
+ax_sprite_terminator
+sDeoxysNormalGfx68:
+.incbin "baserom.gba", 0x16156BC, 0x20
+sDeoxysNormalSprites68:
+ax_sprite sDeoxysNormalGfx68, 0x20
+ax_sprite_terminator
+sAxPosesDeoxysNormal:
+.4byte sDeoxysNormalPose1
+.4byte sDeoxysNormalPose2
+.4byte sDeoxysNormalPose3
+.4byte sDeoxysNormalPose4
+.4byte sDeoxysNormalPose5
+.4byte sDeoxysNormalPose6
+.4byte sDeoxysNormalPose7
+.4byte sDeoxysNormalPose8
+.4byte sDeoxysNormalPose9
+.4byte sDeoxysNormalPose10
+.4byte sDeoxysNormalPose11
+.4byte sDeoxysNormalPose12
+.4byte sDeoxysNormalPose13
+.4byte sDeoxysNormalPose14
+.4byte sDeoxysNormalPose15
+.4byte sDeoxysNormalPose16
+.4byte sDeoxysNormalPose17
+.4byte sDeoxysNormalPose18
+.4byte sDeoxysNormalPose19
+.4byte sDeoxysNormalPose20
+.4byte sDeoxysNormalPose21
+.4byte sDeoxysNormalPose22
+.4byte sDeoxysNormalPose23
+.4byte sDeoxysNormalPose24
+.4byte sDeoxysNormalPose25
+.4byte sDeoxysNormalPose26
+.4byte sDeoxysNormalPose27
+.4byte sDeoxysNormalPose28
+.4byte sDeoxysNormalPose29
+.4byte sDeoxysNormalPose30
+.4byte sDeoxysNormalPose31
+.4byte sDeoxysNormalPose32
+.4byte sDeoxysNormalPose33
+.4byte sDeoxysNormalPose34
+.4byte sDeoxysNormalPose35
+.4byte sDeoxysNormalPose36
+.4byte sDeoxysNormalPose37
+.4byte sDeoxysNormalPose38
+.4byte sDeoxysNormalPose39
+.4byte sDeoxysNormalPose40
+.4byte sDeoxysNormalPose41
+.4byte sDeoxysNormalPose42
+.4byte sDeoxysNormalPose43
+.4byte sDeoxysNormalPose44
+.4byte sDeoxysNormalPose45
+.4byte sDeoxysNormalPose46
+.4byte sDeoxysNormalPose47
+.4byte sDeoxysNormalPose48
+.4byte sDeoxysNormalPose49
+.4byte sDeoxysNormalPose50
+.4byte sDeoxysNormalPose51
+.4byte sDeoxysNormalPose52
+.4byte sDeoxysNormalPose53
+.4byte sDeoxysNormalPose54
+.4byte sDeoxysNormalPose55
+.4byte sDeoxysNormalPose56
+.4byte sDeoxysNormalPose57
+.4byte sDeoxysNormalPose58
+.4byte sDeoxysNormalPose59
+.4byte sDeoxysNormalPose60
+.4byte sDeoxysNormalPose61
+.4byte sDeoxysNormalPose62
+.4byte sDeoxysNormalPose63
+.4byte sDeoxysNormalPose64
+.4byte sDeoxysNormalPose65
+.4byte sDeoxysNormalPose66
+.4byte sDeoxysNormalPose67
+.4byte sDeoxysNormalPose68
+.4byte sDeoxysNormalPose69
+.4byte sDeoxysNormalPose70
+.4byte sDeoxysNormalPose71
+.4byte sDeoxysNormalPose72
+.4byte sDeoxysNormalPose73
+.4byte sDeoxysNormalPose74
+.4byte sDeoxysNormalPose75
+.4byte sDeoxysNormalPose76
+.4byte sDeoxysNormalPose77
+.4byte sDeoxysNormalPose78
+.4byte sDeoxysNormalPose79
+.4byte sDeoxysNormalPose80
+.4byte sDeoxysNormalPose81
+.4byte sDeoxysNormalPose82
+.4byte sDeoxysNormalPose83
+.4byte sDeoxysNormalPose84
+.4byte sDeoxysNormalPose85
+.4byte sDeoxysNormalPose86
+.4byte sDeoxysNormalPose87
+.4byte sDeoxysNormalPose88
+.4byte sDeoxysNormalPose89
+.4byte sDeoxysNormalPose90
+.4byte sDeoxysNormalPose91
+.4byte sDeoxysNormalPose92
+.4byte sDeoxysNormalPose93
+.4byte sDeoxysNormalPose94
+.4byte sDeoxysNormalPose95
+.4byte sDeoxysNormalPose96
+.4byte sDeoxysNormalPose97
+.4byte sDeoxysNormalPose98
+.4byte sDeoxysNormalPose99
+.4byte sDeoxysNormalPose100
+.4byte sDeoxysNormalPose101
+.4byte sDeoxysNormalPose102
+.4byte sDeoxysNormalPose103
+.4byte sDeoxysNormalPose104
+.4byte sDeoxysNormalPose105
+.4byte sDeoxysNormalPose106
+.4byte sDeoxysNormalPose107
+.4byte sDeoxysNormalPose108
+.4byte sDeoxysNormalPose109
+.4byte sDeoxysNormalPose110
+.4byte sDeoxysNormalPose111
+.4byte sDeoxysNormalPose112
+.4byte sDeoxysNormalPose113
+.4byte sDeoxysNormalPose114
+.4byte sDeoxysNormalPose115
+.4byte sDeoxysNormalPose116
+.4byte sDeoxysNormalPose117
+.4byte sDeoxysNormalPose118
+.4byte sDeoxysNormalPose119
+.4byte sDeoxysNormalPose120
+.4byte sDeoxysNormalPose121
+.4byte sDeoxysNormalPose122
+.4byte sDeoxysNormalPose123
+.4byte sDeoxysNormalPose124
+.4byte sDeoxysNormalPose125
+.4byte sDeoxysNormalPose126
+.4byte sDeoxysNormalPose127
+.4byte sDeoxysNormalPose128
+.4byte sDeoxysNormalPose129
+.4byte sDeoxysNormalPose130
+.4byte sDeoxysNormalPose131
+.4byte sDeoxysNormalPose132
+.4byte sDeoxysNormalPose133
+.4byte sDeoxysNormalPose134
+.4byte sDeoxysNormalPose135
+.4byte sDeoxysNormalPose136
+.4byte sDeoxysNormalPose137
+.4byte sDeoxysNormalPose138
+.4byte sDeoxysNormalPose139
+.4byte sDeoxysNormalPose140
+.4byte sDeoxysNormalPose141
+.4byte sDeoxysNormalPose142
+.4byte sDeoxysNormalPose143
+.4byte sDeoxysNormalPose144
+.4byte sDeoxysNormalPose145
+.4byte sDeoxysNormalPose146
+.4byte sDeoxysNormalPose147
+.4byte sDeoxysNormalPose148
+.4byte sDeoxysNormalPose149
+.4byte sDeoxysNormalPose150
+.4byte sDeoxysNormalPose151
+.4byte sDeoxysNormalPose152
+.4byte sDeoxysNormalPose153
+.4byte sDeoxysNormalPose154
+.4byte sDeoxysNormalPose155
+.4byte sDeoxysNormalPose156
+.4byte sDeoxysNormalPose157
+.4byte sDeoxysNormalPose158
+.4byte sDeoxysNormalPose159
+.4byte sDeoxysNormalPose160
+.4byte sDeoxysNormalPose161
+.4byte sDeoxysNormalPose162
+.4byte sDeoxysNormalPose163
+.4byte sDeoxysNormalPose164
+.4byte sDeoxysNormalPose165
+.4byte sDeoxysNormalPose166
+.4byte sDeoxysNormalPose167
+.4byte sDeoxysNormalPose168
+.4byte sDeoxysNormalPose169
+.4byte sDeoxysNormalPose170
+.4byte sDeoxysNormalPose171
+.4byte sDeoxysNormalPose172
+.4byte sDeoxysNormalPose173
+.4byte sDeoxysNormalPose174
+.4byte sDeoxysNormalPose175
+.4byte sDeoxysNormalPose176
+.4byte sDeoxysNormalPose177
+.4byte sDeoxysNormalPose178
+.4byte sDeoxysNormalPose179
+.4byte sDeoxysNormalPose180
+.4byte sDeoxysNormalPose181
+.4byte sDeoxysNormalPose182
+.4byte sDeoxysNormalPose183
+.4byte sDeoxysNormalPose184
+.4byte sDeoxysNormalPose185
+.4byte sDeoxysNormalPose186
+.4byte sDeoxysNormalPose187
+.4byte sDeoxysNormalPose188
+.4byte sDeoxysNormalPose189
+.4byte sDeoxysNormalPose190
+.4byte sDeoxysNormalPose191
+.4byte sDeoxysNormalPose192
+.4byte sDeoxysNormalPose193
+.4byte sDeoxysNormalPose194
+.4byte sDeoxysNormalPose195
+.4byte sDeoxysNormalPose196
+.4byte sDeoxysNormalPose197
+.4byte sDeoxysNormalPose198
+.4byte sDeoxysNormalPose199
+.4byte sDeoxysNormalPose200
+.4byte sDeoxysNormalPose201
+.4byte sDeoxysNormalPose202
+.4byte sDeoxysNormalPose203
+.4byte sDeoxysNormalPose204
+.4byte sDeoxysNormalPose205
+.4byte sDeoxysNormalPose206
+.4byte sDeoxysNormalPose207
+.4byte sDeoxysNormalPose208
+.4byte sDeoxysNormalPose209
+.4byte sDeoxysNormalPose210
+.4byte sDeoxysNormalPose211
+.4byte sDeoxysNormalPose212
+.4byte sDeoxysNormalPose213
+.4byte sDeoxysNormalPose214
+.4byte sDeoxysNormalPose215
+.4byte sDeoxysNormalPose216
+.4byte sDeoxysNormalPose217
+.4byte sDeoxysNormalPose218
+.4byte sDeoxysNormalPose219
+.4byte sDeoxysNormalPose220
+.4byte sDeoxysNormalPose221
+.4byte sDeoxysNormalPose222
+.4byte sDeoxysNormalPose223
+.4byte sDeoxysNormalPose224
+.4byte sDeoxysNormalPose225
+.4byte sDeoxysNormalPose226
+.4byte sDeoxysNormalPose227
+.4byte sDeoxysNormalPose228
+.4byte sDeoxysNormalPose229
+.4byte sDeoxysNormalPose230
+.4byte sDeoxysNormalPose231
+.4byte sDeoxysNormalPose232
+.4byte sDeoxysNormalPose233
+.4byte sDeoxysNormalPose234
+.4byte sDeoxysNormalPose235
+.4byte sDeoxysNormalPose236
+.4byte sDeoxysNormalPose237
+.4byte sDeoxysNormalPose238
+.4byte sDeoxysNormalPose239
+.4byte sDeoxysNormalPose240
+.4byte sDeoxysNormalPose241
+.4byte sDeoxysNormalPose242
+.4byte sDeoxysNormalPose243
+.4byte sDeoxysNormalPose244
+.4byte sDeoxysNormalPose245
+.4byte sDeoxysNormalPose246
+.4byte sDeoxysNormalPose247
+.4byte sDeoxysNormalPose248
+.4byte sDeoxysNormalPose249
+.4byte sDeoxysNormalPose250
+sAxPositionsDeoxysNormal:
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,   -4, 	   9,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -17, 	  11,   -7, 	  -7,   -2, 	   2,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -17, 	   1,   -6, 	   0,   -4, 	   1,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -7, 	   6,   -3, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  12,   -3, 	  -9,   -3, 	   0,  -15
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -7, 	  -6,   -3, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	  -1,   -6, 	   0,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -17, 	 -11,   -7, 	   7,   -2, 	  -2,  -16
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,   -4, 	   9,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte    0,  -14, 	 -13,   -7, 	  15,   -9, 	   0,  -12
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -17, 	  11,   -7, 	  -7,   -2, 	   2,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -14, 	  12,  -10, 	 -14,   -8, 	   1,  -12
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -17, 	   1,   -6, 	   0,   -4, 	   1,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -15, 	   8,  -11, 	 -10,   -7, 	   1,  -14
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -7, 	   6,   -3, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    5,  -15, 	   2,  -14, 	   3,   -6, 	   3,  -15
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  12,   -3, 	  -9,   -3, 	   0,  -15
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -14, 	  12,   -6, 	 -14,   -7, 	   0,  -13
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -7, 	  -6,   -3, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte   -5,  -15, 	  -2,  -14, 	  -3,   -6, 	  -3,  -15
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	  -1,   -6, 	   0,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -15, 	  -8,  -11, 	  10,   -7, 	  -1,  -14
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -17, 	 -11,   -7, 	   7,   -2, 	  -2,  -16
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -14, 	 -12,  -10, 	  14,   -8, 	  -1,  -12
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,   -4, 	   9,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte    0,  -14, 	 -13,   -7, 	  15,   -9, 	   0,  -12
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -17, 	  11,   -7, 	  -7,   -2, 	   2,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -14, 	  12,  -10, 	 -14,   -8, 	   1,  -12
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -17, 	   1,   -6, 	   0,   -4, 	   1,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -15, 	   8,  -11, 	 -10,   -7, 	   1,  -14
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -7, 	   6,   -3, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    5,  -15, 	   2,  -14, 	   3,   -6, 	   3,  -15
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  12,   -3, 	  -9,   -3, 	   0,  -15
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -14, 	  12,   -6, 	 -14,   -7, 	   0,  -13
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -7, 	  -6,   -3, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte   -5,  -15, 	  -2,  -14, 	  -3,   -6, 	  -3,  -15
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	  -1,   -6, 	   0,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -15, 	  -8,  -11, 	  10,   -7, 	  -1,  -14
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -17, 	 -11,   -7, 	   7,   -2, 	  -2,  -16
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -14, 	 -12,  -10, 	  14,   -8, 	  -1,  -12
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,   -4, 	   9,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte    0,  -18, 	 -21,  -13, 	  21,  -13, 	   0,  -16
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -17, 	  11,   -7, 	  -7,   -2, 	   2,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    0,  -18, 	  14,  -20, 	 -17,   -8, 	  -1,  -17
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -17, 	   1,   -6, 	   0,   -4, 	   1,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    3,  -17, 	 -10,   -6, 	 -10,   -5, 	   0,  -16
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -7, 	   6,   -3, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    1,  -16, 	 -14,  -21, 	  12,   -7, 	  -1,  -15
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  12,   -3, 	  -9,   -3, 	   0,  -15
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  19,   -9, 	 -19,   -9, 	   0,  -14
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -7, 	  -6,   -3, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte   -2,  -16, 	  13,  -20, 	 -13,   -7, 	   0,  -15
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	  -1,   -6, 	   0,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -3,  -17, 	  10,   -6, 	  10,   -5, 	   0,  -16
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -17, 	 -11,   -7, 	   7,   -2, 	  -2,  -16
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte    0,  -17, 	 -14,  -19, 	  17,   -7, 	   1,  -16
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,   -4, 	   9,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,  -15, 	  12,  -18, 	   0,  -15
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -17, 	  11,   -7, 	  -7,   -2, 	   2,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -15, 	  14,  -16, 	  -2,  -11, 	   1,  -14
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -17, 	   1,   -6, 	   0,   -4, 	   1,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    3,  -16, 	  14,  -22, 	  10,  -13, 	   0,  -14
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -7, 	   6,   -3, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    2,  -17, 	   8,  -28, 	  17,  -20, 	   0,  -16
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  12,   -3, 	  -9,   -3, 	   0,  -15
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -18, 	  11,  -24, 	 -12,  -23, 	   0,  -16
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -7, 	  -6,   -3, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte   -2,  -17, 	  -8,  -28, 	 -17,  -20, 	   0,  -16
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	  -1,   -6, 	   0,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -3,  -16, 	 -14,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -17, 	 -11,   -7, 	   7,   -2, 	  -2,  -16
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -15, 	 -14,  -16, 	   2,  -11, 	  -1,  -14
+.2byte   -2,  -17, 	  -9,   -5, 	   7,   -3, 	  -1,  -15
+.2byte   -2,  -17, 	  -9,   -4, 	   7,   -2, 	  -1,  -15
+.2byte    0,  -15, 	 -13,   -8, 	  15,  -10, 	   0,  -13
+.2byte    0,  -15, 	  10,  -11, 	 -16,   -9, 	  -1,  -13
+.2byte    3,  -14, 	   7,  -10, 	 -11,   -6, 	   0,  -13
+.2byte    4,  -13, 	   1,  -12, 	   2,   -4, 	   2,  -13
+.2byte    0,  -13, 	  12,   -5, 	 -14,   -6, 	   0,  -12
+.2byte   -5,  -13, 	  -2,  -12, 	  -3,   -4, 	  -3,  -13
+.2byte   -4,  -14, 	  -8,  -10, 	  10,   -6, 	  -1,  -13
+.2byte   -1,  -15, 	 -11,  -11, 	  15,   -9, 	   0,  -13
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,   -4, 	   9,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -17, 	  11,   -7, 	  -7,   -2, 	   2,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -17, 	   1,   -6, 	   0,   -4, 	   1,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -7, 	   6,   -3, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  12,   -3, 	  -9,   -3, 	   0,  -15
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -7, 	  -6,   -3, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	  -1,   -6, 	   0,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -17, 	 -11,   -7, 	   7,   -2, 	  -2,  -16
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte    0,  -17, 	 -12,  -15, 	  12,  -18, 	   0,  -15
+.2byte   -1,  -16, 	 -13,  -17, 	   3,  -12, 	   0,  -15
+.2byte   -3,  -16, 	 -14,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -1,  -17, 	  -7,  -28, 	 -16,  -20, 	   1,  -16
+.2byte    0,  -18, 	  11,  -24, 	 -12,  -23, 	   0,  -16
+.2byte    0,  -17, 	   6,  -28, 	  15,  -20, 	  -2,  -16
+.2byte    2,  -16, 	  13,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    1,  -16, 	  13,  -17, 	  -3,  -12, 	   0,  -15
+.2byte    0,  -17, 	 -12,  -15, 	  12,  -18, 	   0,  -15
+.2byte    1,  -16, 	  13,  -17, 	  -3,  -12, 	   0,  -15
+.2byte    2,  -16, 	  13,  -22, 	   9,  -13, 	  -1,  -14
+.2byte    0,  -17, 	   6,  -28, 	  15,  -20, 	  -2,  -16
+.2byte    0,  -18, 	  11,  -24, 	 -12,  -23, 	   0,  -16
+.2byte   -1,  -17, 	  -7,  -28, 	 -16,  -20, 	   1,  -16
+.2byte   -3,  -16, 	 -14,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -1,  -16, 	 -13,  -17, 	   3,  -12, 	   0,  -15
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,   -4, 	   9,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte    0,  -17, 	 -12,  -15, 	  12,  -18, 	   0,  -15
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -17, 	  11,   -7, 	  -7,   -2, 	   2,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    2,  -15, 	  14,  -16, 	  -2,  -11, 	   1,  -14
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    4,  -17, 	   1,   -6, 	   0,   -4, 	   1,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    3,  -16, 	  14,  -22, 	  10,  -13, 	   0,  -14
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -7, 	   6,   -3, 	   0,  -16
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    1,  -17, 	   7,  -28, 	  16,  -20, 	  -1,  -16
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -17, 	  12,   -3, 	  -9,   -3, 	   0,  -15
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte    0,  -18, 	  11,  -24, 	 -12,  -23, 	   0,  -16
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -7, 	  -6,   -3, 	   0,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte   -1,  -17, 	  -7,  -28, 	 -16,  -20, 	   1,  -16
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	  -1,   -6, 	   0,   -4, 	  -1,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -3,  -16, 	 -14,  -22, 	 -10,  -13, 	   0,  -14
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -17, 	 -11,   -7, 	   7,   -2, 	  -2,  -16
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte   -2,  -15, 	 -14,  -16, 	   2,  -11, 	  -1,  -14
+.2byte    0,  -17, 	 -11,   -3, 	  10,   -3, 	   0,  -14
+.2byte   -2,  -17, 	 -10,   -6, 	   8,   -3, 	  -2,  -16
+.2byte   -4,  -17, 	   1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -2,  -18, 	   6,   -6, 	  -5,   -2, 	   0,  -16
+.2byte    0,  -17, 	  10,   -4, 	 -12,   -3, 	   0,  -15
+.2byte    2,  -18, 	  -6,   -6, 	   5,   -2, 	   0,  -16
+.2byte    4,  -17, 	  -1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    2,  -17, 	  10,   -6, 	  -8,   -3, 	   2,  -16
+.2byte    0,  -17, 	 -11,   -3, 	  11,   -3, 	   0,  -14
+.2byte   -2,  -17, 	  -9,   -8, 	   8,   -3, 	  -2,  -16
+.2byte   -4,  -17, 	  -1,   -5, 	  -1,   -4, 	  -1,  -16
+.2byte   -2,  -18, 	   5,   -6, 	  -6,   -2, 	   0,  -16
+.2byte    0,  -17, 	  12,   -3, 	 -12,   -3, 	   0,  -15
+.2byte    2,  -18, 	  -5,   -6, 	   6,   -2, 	   0,  -16
+.2byte    4,  -17, 	   1,   -5, 	   1,   -4, 	   1,  -16
+.2byte    2,  -17, 	   9,   -8, 	  -8,   -3, 	   2,  -16
+sDeoxysNormalAnimTable1:
+.4byte sDeoxysNormalAnims_1_1
+.4byte sDeoxysNormalAnims_1_2
+.4byte sDeoxysNormalAnims_1_3
+.4byte sDeoxysNormalAnims_1_4
+.4byte sDeoxysNormalAnims_1_5
+.4byte sDeoxysNormalAnims_1_6
+.4byte sDeoxysNormalAnims_1_7
+.4byte sDeoxysNormalAnims_1_8
+sDeoxysNormalAnimTable2:
+.4byte sDeoxysNormalAnims_2_1
+.4byte sDeoxysNormalAnims_2_2
+.4byte sDeoxysNormalAnims_2_3
+.4byte sDeoxysNormalAnims_2_4
+.4byte sDeoxysNormalAnims_2_5
+.4byte sDeoxysNormalAnims_2_6
+.4byte sDeoxysNormalAnims_2_7
+.4byte sDeoxysNormalAnims_2_8
+sDeoxysNormalAnimTable3:
+.4byte sDeoxysNormalAnims_3_1
+.4byte sDeoxysNormalAnims_3_2
+.4byte sDeoxysNormalAnims_3_3
+.4byte sDeoxysNormalAnims_3_4
+.4byte sDeoxysNormalAnims_3_5
+.4byte sDeoxysNormalAnims_3_6
+.4byte sDeoxysNormalAnims_3_7
+.4byte sDeoxysNormalAnims_3_8
+sDeoxysNormalAnimTable4:
+.4byte sDeoxysNormalAnims_4_1
+.4byte sDeoxysNormalAnims_4_2
+.4byte sDeoxysNormalAnims_4_3
+.4byte sDeoxysNormalAnims_4_4
+.4byte sDeoxysNormalAnims_4_5
+.4byte sDeoxysNormalAnims_4_6
+.4byte sDeoxysNormalAnims_4_7
+.4byte sDeoxysNormalAnims_4_8
+sDeoxysNormalAnimTable5:
+.4byte sDeoxysNormalAnims_5_1
+.4byte sDeoxysNormalAnims_5_2
+.4byte sDeoxysNormalAnims_5_3
+.4byte sDeoxysNormalAnims_5_4
+.4byte sDeoxysNormalAnims_5_5
+.4byte sDeoxysNormalAnims_5_6
+.4byte sDeoxysNormalAnims_5_7
+.4byte sDeoxysNormalAnims_5_8
+sDeoxysNormalAnimTable6:
+.4byte sDeoxysNormalAnims_6_1
+.4byte sDeoxysNormalAnims_6_1
+.4byte sDeoxysNormalAnims_6_1
+.4byte sDeoxysNormalAnims_6_1
+.4byte sDeoxysNormalAnims_6_1
+.4byte sDeoxysNormalAnims_6_1
+.4byte sDeoxysNormalAnims_6_1
+.4byte sDeoxysNormalAnims_6_1
+sDeoxysNormalAnimTable7:
+.4byte sDeoxysNormalAnims_7_1
+.4byte sDeoxysNormalAnims_7_2
+.4byte sDeoxysNormalAnims_7_3
+.4byte sDeoxysNormalAnims_7_4
+.4byte sDeoxysNormalAnims_7_5
+.4byte sDeoxysNormalAnims_7_6
+.4byte sDeoxysNormalAnims_7_7
+.4byte sDeoxysNormalAnims_7_8
+sDeoxysNormalAnimTable8:
+.4byte sDeoxysNormalAnims_8_1
+.4byte sDeoxysNormalAnims_8_2
+.4byte sDeoxysNormalAnims_8_3
+.4byte sDeoxysNormalAnims_8_4
+.4byte sDeoxysNormalAnims_8_5
+.4byte sDeoxysNormalAnims_8_6
+.4byte sDeoxysNormalAnims_8_7
+.4byte sDeoxysNormalAnims_8_8
+sDeoxysNormalAnimTable9:
+.4byte sDeoxysNormalAnims_9_1
+.4byte sDeoxysNormalAnims_9_2
+.4byte sDeoxysNormalAnims_9_3
+.4byte sDeoxysNormalAnims_9_4
+.4byte sDeoxysNormalAnims_9_5
+.4byte sDeoxysNormalAnims_9_6
+.4byte sDeoxysNormalAnims_9_7
+.4byte sDeoxysNormalAnims_9_8
+sDeoxysNormalAnimTable10:
+.4byte sDeoxysNormalAnims_10_1
+.4byte sDeoxysNormalAnims_10_2
+.4byte sDeoxysNormalAnims_10_3
+.4byte sDeoxysNormalAnims_10_4
+.4byte sDeoxysNormalAnims_10_5
+.4byte sDeoxysNormalAnims_10_6
+.4byte sDeoxysNormalAnims_10_7
+.4byte sDeoxysNormalAnims_10_8
+sDeoxysNormalAnimTable11:
+.4byte sDeoxysNormalAnims_11_1
+.4byte sDeoxysNormalAnims_11_2
+.4byte sDeoxysNormalAnims_11_3
+.4byte sDeoxysNormalAnims_11_4
+.4byte sDeoxysNormalAnims_11_5
+.4byte sDeoxysNormalAnims_11_6
+.4byte sDeoxysNormalAnims_11_7
+.4byte sDeoxysNormalAnims_11_8
+sDeoxysNormalAnimTable12:
+.4byte sDeoxysNormalAnims_12_1
+.4byte sDeoxysNormalAnims_12_2
+.4byte sDeoxysNormalAnims_12_3
+.4byte sDeoxysNormalAnims_12_4
+.4byte sDeoxysNormalAnims_12_5
+.4byte sDeoxysNormalAnims_12_6
+.4byte sDeoxysNormalAnims_12_7
+.4byte sDeoxysNormalAnims_12_8
+sDeoxysNormalAnimTable13:
+.4byte sDeoxysNormalAnims_13_1
+.4byte sDeoxysNormalAnims_13_2
+.4byte sDeoxysNormalAnims_13_3
+.4byte sDeoxysNormalAnims_13_4
+.4byte sDeoxysNormalAnims_13_5
+.4byte sDeoxysNormalAnims_13_6
+.4byte sDeoxysNormalAnims_13_7
+.4byte sDeoxysNormalAnims_13_8
+sAxAnimationsDeoxysNormal:
+.4byte sDeoxysNormalAnimTable1
+.4byte sDeoxysNormalAnimTable2
+.4byte sDeoxysNormalAnimTable3
+.4byte sDeoxysNormalAnimTable4
+.4byte sDeoxysNormalAnimTable5
+.4byte sDeoxysNormalAnimTable6
+.4byte sDeoxysNormalAnimTable7
+.4byte sDeoxysNormalAnimTable8
+.4byte sDeoxysNormalAnimTable9
+.4byte sDeoxysNormalAnimTable10
+.4byte sDeoxysNormalAnimTable11
+.4byte sDeoxysNormalAnimTable12
+.4byte sDeoxysNormalAnimTable13
+sAxSpritesDeoxysNormal:
+.4byte sDeoxysNormalSprites1
+.4byte sDeoxysNormalSprites2
+.4byte sDeoxysNormalSprites3
+.4byte sDeoxysNormalSprites4
+.4byte sDeoxysNormalSprites5
+.4byte sDeoxysNormalSprites6
+.4byte sDeoxysNormalSprites7
+.4byte sDeoxysNormalSprites8
+.4byte sDeoxysNormalSprites9
+.4byte sDeoxysNormalSprites10
+.4byte sDeoxysNormalSprites11
+.4byte sDeoxysNormalSprites12
+.4byte sDeoxysNormalSprites13
+.4byte sDeoxysNormalSprites14
+.4byte sDeoxysNormalSprites15
+.4byte sDeoxysNormalSprites16
+.4byte sDeoxysNormalSprites17
+.4byte sDeoxysNormalSprites18
+.4byte sDeoxysNormalSprites19
+.4byte sDeoxysNormalSprites20
+.4byte sDeoxysNormalSprites21
+.4byte sDeoxysNormalSprites22
+.4byte sDeoxysNormalSprites23
+.4byte sDeoxysNormalSprites24
+.4byte sDeoxysNormalSprites25
+.4byte sDeoxysNormalSprites26
+.4byte sDeoxysNormalSprites27
+.4byte sDeoxysNormalSprites28
+.4byte sDeoxysNormalSprites29
+.4byte sDeoxysNormalSprites30
+.4byte sDeoxysNormalSprites31
+.4byte sDeoxysNormalSprites32
+.4byte sDeoxysNormalSprites33
+.4byte sDeoxysNormalSprites34
+.4byte sDeoxysNormalSprites35
+.4byte sDeoxysNormalSprites36
+.4byte sDeoxysNormalSprites37
+.4byte sDeoxysNormalSprites38
+.4byte sDeoxysNormalSprites39
+.4byte sDeoxysNormalSprites40
+.4byte sDeoxysNormalSprites41
+.4byte sDeoxysNormalSprites42
+.4byte sDeoxysNormalSprites43
+.4byte sDeoxysNormalSprites44
+.4byte sDeoxysNormalSprites45
+.4byte sDeoxysNormalSprites46
+.4byte sDeoxysNormalSprites47
+.4byte sDeoxysNormalSprites48
+.4byte sDeoxysNormalSprites49
+.4byte sDeoxysNormalSprites50
+.4byte sDeoxysNormalSprites51
+.4byte sDeoxysNormalSprites52
+.4byte sDeoxysNormalSprites53
+.4byte sDeoxysNormalSprites54
+.4byte sDeoxysNormalSprites55
+.4byte sDeoxysNormalSprites56
+.4byte sDeoxysNormalSprites57
+.4byte sDeoxysNormalSprites58
+.4byte sDeoxysNormalSprites59
+.4byte sDeoxysNormalSprites60
+.4byte sDeoxysNormalSprites61
+.4byte sDeoxysNormalSprites62
+.4byte sDeoxysNormalSprites63
+.4byte sDeoxysNormalSprites64
+.4byte sDeoxysNormalSprites65
+.4byte sDeoxysNormalSprites66
+.4byte sDeoxysNormalSprites67
+.4byte sDeoxysNormalSprites68
+sAxMainDeoxysNormal:
+ax_main sAxPosesDeoxysNormal, sAxAnimationsDeoxysNormal, 13, sAxSpritesDeoxysNormal, sAxPositionsDeoxysNormal

--- a/data/ax/deoxysspeed.inc
+++ b/data/ax/deoxysspeed.inc
@@ -1,0 +1,3555 @@
+.global gAxDeoxysSpeed
+gAxDeoxysSpeed:
+ax_siro sAxMainDeoxysSpeed
+sDeoxysSpeedPose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose3:
+ax_pose 2, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose4:
+ax_pose 3, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose5:
+ax_pose 4, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose6:
+ax_pose 5, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose7:
+ax_pose 6, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose8:
+ax_pose 7, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose9:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose10:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose11:
+ax_pose 10, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose12:
+ax_pose 11, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose13:
+ax_pose 12, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose14:
+ax_pose 13, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose15:
+ax_pose 14, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose16:
+ax_pose 15, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose17:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose18:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose19:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose20:
+ax_pose 17, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose21:
+ax_pose 2, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose22:
+ax_pose 3, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose23:
+ax_pose 18, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose24:
+ax_pose 4, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose25:
+ax_pose 5, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose26:
+ax_pose 19, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose27:
+ax_pose 6, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose28:
+ax_pose 7, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose29:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose30:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose31:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose32:
+ax_pose 21, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose33:
+ax_pose 10, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose34:
+ax_pose 11, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose35:
+ax_pose 22, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose36:
+ax_pose 12, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose37:
+ax_pose 13, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose38:
+ax_pose 23, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose39:
+ax_pose 14, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose40:
+ax_pose 15, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose41:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose42:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose43:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose44:
+ax_pose 17, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose45:
+ax_pose 2, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose46:
+ax_pose 3, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose47:
+ax_pose 18, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose48:
+ax_pose 4, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose49:
+ax_pose 5, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose50:
+ax_pose 19, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose51:
+ax_pose 6, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose52:
+ax_pose 7, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose53:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose54:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose55:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose56:
+ax_pose 21, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose57:
+ax_pose 10, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose58:
+ax_pose 11, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose59:
+ax_pose 22, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose60:
+ax_pose 12, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose61:
+ax_pose 13, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose62:
+ax_pose 23, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose63:
+ax_pose 14, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose64:
+ax_pose 15, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose65:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose66:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose67:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose68:
+ax_pose 24, 0x41e3, 0x80f0, 0x9c00
+ax_pose 25, 0x41f3, 0x40f0, 0x9c08
+ax_pose 26, 0x41fb, 0x00f8, 0x9c0c
+ax_pose 27, 0x01fb, 0x0108, 0x9c0e
+ax_pose 28, 0x01db, 0x00fe, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose69:
+ax_pose 17, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose70:
+ax_pose 2, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose71:
+ax_pose 3, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose72:
+ax_pose 29, 0x81e2, 0x80fe, 0x9c00
+ax_pose 30, 0x81e2, 0x40f6, 0x9c08
+ax_pose 31, 0x81ea, 0x00ee, 0x9c0c
+ax_pose 32, 0x01da, 0x00f9, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose73:
+ax_pose 18, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose74:
+ax_pose 4, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose75:
+ax_pose 5, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose76:
+ax_pose 33, 0x41f3, 0x80f0, 0x9c00
+ax_pose 34, 0x01e3, 0x40f8, 0x9c08
+ax_pose 35, 0x01eb, 0x00f0, 0x9c0c
+ax_pose 36, 0x41db, 0x00f8, 0x9c0d
+ax_pose_terminator
+sDeoxysSpeedPose77:
+ax_pose 19, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose78:
+ax_pose 6, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose79:
+ax_pose 7, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose80:
+ax_pose 37, 0x01e5, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose81:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose82:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose83:
+ax_pose 9, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose84:
+ax_pose 38, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose85:
+ax_pose 21, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose86:
+ax_pose 10, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose87:
+ax_pose 11, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose88:
+ax_pose 39, 0x01e5, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose89:
+ax_pose 22, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose90:
+ax_pose 12, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose91:
+ax_pose 13, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose92:
+ax_pose 40, 0x41f1, 0x80f2, 0x9c00
+ax_pose 41, 0x0201, 0x0102, 0x9c08
+ax_pose 42, 0x41e9, 0x40f2, 0x9c09
+ax_pose 43, 0x41e1, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDeoxysSpeedPose93:
+ax_pose 23, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose94:
+ax_pose 14, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose95:
+ax_pose 15, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose96:
+ax_pose 44, 0x41f2, 0x80f2, 0x9c00
+ax_pose 45, 0x41ea, 0x40f2, 0x9c08
+ax_pose 46, 0x41e2, 0x00fa, 0x9c0c
+ax_pose 47, 0x01da, 0x0100, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose97:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose98:
+ax_pose 48, 0x01e9, 0x04fe, 0x2c00
+ax_pose -1, 0x01e9, 0x04fa, 0x2c00
+ax_pose 49, 0x41f3, 0x80f0, 0x9c01
+ax_pose 50, 0x41eb, 0x40f0, 0x9c09
+ax_pose 51, 0x41e3, 0x00f8, 0x9c0d
+ax_pose 52, 0x01db, 0x00ff, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose99:
+ax_pose 53, 0x01e9, 0x04fe, 0x2c00
+ax_pose -1, 0x01e9, 0x04fa, 0x2c00
+ax_pose 49, 0x41f3, 0x80f0, 0x9c01
+ax_pose 50, 0x41eb, 0x40f0, 0x9c09
+ax_pose 51, 0x41e3, 0x00f8, 0x9c0d
+ax_pose 52, 0x01db, 0x00ff, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose100:
+ax_pose 54, 0x01e5, 0x44fa, 0x2c00
+ax_pose -1, 0x01e5, 0x44f6, 0x2c00
+ax_pose 49, 0x41f3, 0x80f0, 0x9c04
+ax_pose 50, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 51, 0x41e3, 0x00f8, 0x9c10
+ax_pose 52, 0x01db, 0x00ff, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose101:
+ax_pose 55, 0x01e5, 0x44fa, 0x2c00
+ax_pose -1, 0x01e5, 0x44f6, 0x2c00
+ax_pose 49, 0x41f3, 0x80f0, 0x9c04
+ax_pose 50, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 51, 0x41e3, 0x00f8, 0x9c10
+ax_pose 52, 0x01db, 0x00ff, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose102:
+ax_pose 56, 0x01e5, 0x44fa, 0x2c00
+ax_pose -1, 0x01e5, 0x44f6, 0x2c00
+ax_pose 49, 0x41f3, 0x80f0, 0x9c04
+ax_pose 50, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 51, 0x41e3, 0x00f8, 0x9c10
+ax_pose 52, 0x01db, 0x00ff, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose103:
+ax_pose 57, 0x01e5, 0x44fa, 0x2c00
+ax_pose -1, 0x01e5, 0x44f6, 0x2c00
+ax_pose 49, 0x41f3, 0x80f0, 0x9c04
+ax_pose 50, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 51, 0x41e3, 0x00f8, 0x9c10
+ax_pose 52, 0x01db, 0x00ff, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose104:
+ax_pose 49, 0x41f3, 0x80f0, 0x9c00
+ax_pose 50, 0x41eb, 0x40f0, 0x9c08
+ax_pose 51, 0x41e3, 0x00f8, 0x9c0c
+ax_pose 52, 0x01db, 0x00ff, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose105:
+ax_pose 17, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose106:
+ax_pose 48, 0x01e9, 0x0501, 0x2c00
+ax_pose -1, 0x01e7, 0x0505, 0x2c00
+ax_pose 58, 0x41f2, 0x80f3, 0x9c01
+ax_pose 59, 0x01e2, 0x40fb, 0x9c09
+ax_pose 60, 0x01ea, 0x00f3, 0x9c0d
+ax_pose 61, 0x81f2, 0x00eb, 0x9c0e
+ax_pose 62, 0x01da, 0x00fb, 0x9c10
+ax_pose_terminator
+sDeoxysSpeedPose107:
+ax_pose 53, 0x01e9, 0x0501, 0x2c00
+ax_pose -1, 0x01e7, 0x0505, 0x2c00
+ax_pose 58, 0x41f2, 0x80f3, 0x9c01
+ax_pose 59, 0x01e2, 0x40fb, 0x9c09
+ax_pose 60, 0x01ea, 0x00f3, 0x9c0d
+ax_pose 61, 0x81f2, 0x00eb, 0x9c0e
+ax_pose 62, 0x01da, 0x00fb, 0x9c10
+ax_pose_terminator
+sDeoxysSpeedPose108:
+ax_pose 54, 0x01e5, 0x44fd, 0x2c00
+ax_pose -1, 0x01e3, 0x4501, 0x2c00
+ax_pose 58, 0x41f2, 0x80f3, 0x9c04
+ax_pose 59, 0x01e2, 0x40fb, 0x9c0c
+ax_pose 60, 0x01ea, 0x00f3, 0x9c10
+ax_pose 61, 0x81f2, 0x00eb, 0x9c11
+ax_pose 62, 0x01da, 0x00fb, 0x9c13
+ax_pose_terminator
+sDeoxysSpeedPose109:
+ax_pose 55, 0x01e5, 0x44fd, 0x2c00
+ax_pose -1, 0x01e3, 0x4501, 0x2c00
+ax_pose 58, 0x41f2, 0x80f3, 0x9c04
+ax_pose 59, 0x01e2, 0x40fb, 0x9c0c
+ax_pose 60, 0x01ea, 0x00f3, 0x9c10
+ax_pose 61, 0x81f2, 0x00eb, 0x9c11
+ax_pose 62, 0x01da, 0x00fb, 0x9c13
+ax_pose_terminator
+sDeoxysSpeedPose110:
+ax_pose 56, 0x01e5, 0x44fd, 0x2c00
+ax_pose -1, 0x01e3, 0x4501, 0x2c00
+ax_pose 58, 0x41f2, 0x80f3, 0x9c04
+ax_pose 59, 0x01e2, 0x40fb, 0x9c0c
+ax_pose 60, 0x01ea, 0x00f3, 0x9c10
+ax_pose 61, 0x81f2, 0x00eb, 0x9c11
+ax_pose 62, 0x01da, 0x00fb, 0x9c13
+ax_pose_terminator
+sDeoxysSpeedPose111:
+ax_pose 57, 0x01e5, 0x44fd, 0x2c00
+ax_pose -1, 0x01e3, 0x4501, 0x2c00
+ax_pose 58, 0x41f2, 0x80f3, 0x9c04
+ax_pose 59, 0x01e2, 0x40fb, 0x9c0c
+ax_pose 60, 0x01ea, 0x00f3, 0x9c10
+ax_pose 61, 0x81f2, 0x00eb, 0x9c11
+ax_pose 62, 0x01da, 0x00fb, 0x9c13
+ax_pose_terminator
+sDeoxysSpeedPose112:
+ax_pose 58, 0x41f2, 0x80f3, 0x9c00
+ax_pose 59, 0x01e2, 0x40fb, 0x9c08
+ax_pose 60, 0x01ea, 0x00f3, 0x9c0c
+ax_pose 61, 0x81f2, 0x00eb, 0x9c0d
+ax_pose 62, 0x01da, 0x00fb, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose113:
+ax_pose 18, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose114:
+ax_pose 48, 0x01e6, 0x0505, 0x2c00
+ax_pose 63, 0x81e4, 0x80ff, 0x9c01
+ax_pose 64, 0x01f4, 0x40ef, 0x9c09
+ax_pose 65, 0x41ec, 0x00ef, 0x9c0d
+ax_pose 66, 0x41dc, 0x00fc, 0x9c0f
+ax_pose -1, 0x01e5, 0x0509, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose115:
+ax_pose 53, 0x01e6, 0x0505, 0x2c00
+ax_pose 63, 0x81e4, 0x80ff, 0x9c01
+ax_pose 64, 0x01f4, 0x40ef, 0x9c09
+ax_pose 65, 0x41ec, 0x00ef, 0x9c0d
+ax_pose 66, 0x41dc, 0x00fc, 0x9c0f
+ax_pose -1, 0x01e5, 0x0509, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose116:
+ax_pose 54, 0x01e2, 0x4501, 0x2c00
+ax_pose 63, 0x81e4, 0x80ff, 0x9c04
+ax_pose 64, 0x01f4, 0x40ef, 0x9c0c
+ax_pose 65, 0x41ec, 0x00ef, 0x9c10
+ax_pose 66, 0x41dc, 0x00fc, 0x9c12
+ax_pose -1, 0x01e1, 0x4505, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose117:
+ax_pose 55, 0x01e2, 0x4501, 0x2c00
+ax_pose 63, 0x81e4, 0x80ff, 0x9c04
+ax_pose 64, 0x01f4, 0x40ef, 0x9c0c
+ax_pose 65, 0x41ec, 0x00ef, 0x9c10
+ax_pose 66, 0x41dc, 0x00fc, 0x9c12
+ax_pose -1, 0x01e1, 0x4505, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose118:
+ax_pose 56, 0x01e2, 0x4501, 0x2c00
+ax_pose 63, 0x81e4, 0x80ff, 0x9c04
+ax_pose 64, 0x01f4, 0x40ef, 0x9c0c
+ax_pose 65, 0x41ec, 0x00ef, 0x9c10
+ax_pose 66, 0x41dc, 0x00fc, 0x9c12
+ax_pose -1, 0x01e1, 0x4505, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose119:
+ax_pose 57, 0x01e2, 0x4501, 0x2c00
+ax_pose 63, 0x81e4, 0x80ff, 0x9c04
+ax_pose 64, 0x01f4, 0x40ef, 0x9c0c
+ax_pose 65, 0x41ec, 0x00ef, 0x9c10
+ax_pose 66, 0x41dc, 0x00fc, 0x9c12
+ax_pose -1, 0x01e1, 0x4505, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose120:
+ax_pose 63, 0x81e4, 0x80ff, 0x9c00
+ax_pose 64, 0x01f4, 0x40ef, 0x9c08
+ax_pose 65, 0x41ec, 0x00ef, 0x9c0c
+ax_pose 66, 0x41dc, 0x00fc, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose121:
+ax_pose 19, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose122:
+ax_pose 67, 0x81e3, 0x80fb, 0x9c00
+ax_pose 68, 0x41db, 0x00fb, 0x9c08
+ax_pose 69, 0x01eb, 0x00f3, 0x9c0a
+ax_pose 48, 0x01e3, 0x0507, 0x2c0b
+ax_pose -1, 0x01df, 0x0502, 0x2c0b
+ax_pose_terminator
+sDeoxysSpeedPose123:
+ax_pose 67, 0x81e3, 0x80fb, 0x9c00
+ax_pose 68, 0x41db, 0x00fb, 0x9c08
+ax_pose 69, 0x01eb, 0x00f3, 0x9c0a
+ax_pose 53, 0x01e3, 0x0507, 0x2c0b
+ax_pose -1, 0x01df, 0x0502, 0x2c0b
+ax_pose_terminator
+sDeoxysSpeedPose124:
+ax_pose 67, 0x81e3, 0x80fb, 0x9c00
+ax_pose 68, 0x41db, 0x00fb, 0x9c08
+ax_pose 69, 0x01eb, 0x00f3, 0x9c0a
+ax_pose 54, 0x01df, 0x4503, 0x2c0b
+ax_pose -1, 0x01db, 0x44fe, 0x2c0b
+ax_pose_terminator
+sDeoxysSpeedPose125:
+ax_pose 67, 0x81e3, 0x80fb, 0x9c00
+ax_pose 68, 0x41db, 0x00fb, 0x9c08
+ax_pose 69, 0x01eb, 0x00f3, 0x9c0a
+ax_pose 55, 0x01df, 0x4503, 0x2c0b
+ax_pose -1, 0x01db, 0x44fe, 0x2c0b
+ax_pose_terminator
+sDeoxysSpeedPose126:
+ax_pose 67, 0x81e3, 0x80fb, 0x9c00
+ax_pose 68, 0x41db, 0x00fb, 0x9c08
+ax_pose 69, 0x01eb, 0x00f3, 0x9c0a
+ax_pose 56, 0x01df, 0x4503, 0x2c0b
+ax_pose -1, 0x01db, 0x44fe, 0x2c0b
+ax_pose_terminator
+sDeoxysSpeedPose127:
+ax_pose 67, 0x81e3, 0x80fb, 0x9c00
+ax_pose 68, 0x41db, 0x00fb, 0x9c08
+ax_pose 69, 0x01eb, 0x00f3, 0x9c0a
+ax_pose 57, 0x01df, 0x4503, 0x2c0b
+ax_pose -1, 0x01db, 0x44fe, 0x2c0b
+ax_pose_terminator
+sDeoxysSpeedPose128:
+ax_pose 67, 0x81e3, 0x80fb, 0x9c00
+ax_pose 68, 0x41db, 0x00fb, 0x9c08
+ax_pose 69, 0x01eb, 0x00f3, 0x9c0a
+ax_pose_terminator
+sDeoxysSpeedPose129:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose130:
+ax_pose 70, 0x41f2, 0x80f0, 0x9c00
+ax_pose 71, 0x41ea, 0x40f0, 0x9c08
+ax_pose 72, 0x41e2, 0x00f8, 0x9c0c
+ax_pose 73, 0x01da, 0x0100, 0x9c0e
+ax_pose 74, 0x01da, 0x00f8, 0x9c0f
+ax_pose 48, 0x01df, 0x04fe, 0x2c10
+ax_pose -1, 0x01df, 0x04fa, 0x2c10
+ax_pose_terminator
+sDeoxysSpeedPose131:
+ax_pose 70, 0x41f2, 0x80f0, 0x9c00
+ax_pose 71, 0x41ea, 0x40f0, 0x9c08
+ax_pose 72, 0x41e2, 0x00f8, 0x9c0c
+ax_pose 73, 0x01da, 0x0100, 0x9c0e
+ax_pose 74, 0x01da, 0x00f8, 0x9c0f
+ax_pose 53, 0x01df, 0x04fe, 0x2c10
+ax_pose -1, 0x01df, 0x04fa, 0x2c10
+ax_pose_terminator
+sDeoxysSpeedPose132:
+ax_pose 70, 0x41f2, 0x80f0, 0x9c00
+ax_pose 71, 0x41ea, 0x40f0, 0x9c08
+ax_pose 72, 0x41e2, 0x00f8, 0x9c0c
+ax_pose 73, 0x01da, 0x0100, 0x9c0e
+ax_pose 74, 0x01da, 0x00f8, 0x9c0f
+ax_pose 54, 0x01db, 0x44fa, 0x2c10
+ax_pose -1, 0x01db, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysSpeedPose133:
+ax_pose 70, 0x41f2, 0x80f0, 0x9c00
+ax_pose 71, 0x41ea, 0x40f0, 0x9c08
+ax_pose 72, 0x41e2, 0x00f8, 0x9c0c
+ax_pose 73, 0x01da, 0x0100, 0x9c0e
+ax_pose 74, 0x01da, 0x00f8, 0x9c0f
+ax_pose 55, 0x01db, 0x44fa, 0x2c10
+ax_pose -1, 0x01db, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysSpeedPose134:
+ax_pose 70, 0x41f2, 0x80f0, 0x9c00
+ax_pose 71, 0x41ea, 0x40f0, 0x9c08
+ax_pose 72, 0x41e2, 0x00f8, 0x9c0c
+ax_pose 73, 0x01da, 0x0100, 0x9c0e
+ax_pose 74, 0x01da, 0x00f8, 0x9c0f
+ax_pose 56, 0x01db, 0x44fa, 0x2c10
+ax_pose -1, 0x01db, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysSpeedPose135:
+ax_pose 70, 0x41f2, 0x80f0, 0x9c00
+ax_pose 71, 0x41ea, 0x40f0, 0x9c08
+ax_pose 72, 0x41e2, 0x00f8, 0x9c0c
+ax_pose 73, 0x01da, 0x0100, 0x9c0e
+ax_pose 74, 0x01da, 0x00f8, 0x9c0f
+ax_pose 57, 0x01db, 0x44fa, 0x2c10
+ax_pose -1, 0x01db, 0x44f6, 0x2c10
+ax_pose_terminator
+sDeoxysSpeedPose136:
+ax_pose 70, 0x41f2, 0x80f0, 0x9c00
+ax_pose 71, 0x41ea, 0x40f0, 0x9c08
+ax_pose 72, 0x41e2, 0x00f8, 0x9c0c
+ax_pose 73, 0x01da, 0x0100, 0x9c0e
+ax_pose 74, 0x01da, 0x00f8, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose137:
+ax_pose 21, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose138:
+ax_pose 75, 0x81e3, 0x80f0, 0x9c00
+ax_pose 76, 0x81e3, 0x4100, 0x9c08
+ax_pose 77, 0x01eb, 0x0108, 0x9c0c
+ax_pose 78, 0x01db, 0x00f8, 0x9c0d
+ax_pose 79, 0x01db, 0x0100, 0x9c0e
+ax_pose 48, 0x01e3, 0x04f1, 0x2c0f
+ax_pose -1, 0x01df, 0x04f7, 0x2c0f
+ax_pose_terminator
+sDeoxysSpeedPose139:
+ax_pose 75, 0x81e3, 0x80f0, 0x9c00
+ax_pose 76, 0x81e3, 0x4100, 0x9c08
+ax_pose 77, 0x01eb, 0x0108, 0x9c0c
+ax_pose 78, 0x01db, 0x00f8, 0x9c0d
+ax_pose 79, 0x01db, 0x0100, 0x9c0e
+ax_pose 53, 0x01e3, 0x04f1, 0x2c0f
+ax_pose -1, 0x01df, 0x04f7, 0x2c0f
+ax_pose_terminator
+sDeoxysSpeedPose140:
+ax_pose 75, 0x81e3, 0x80f0, 0x9c00
+ax_pose 76, 0x81e3, 0x4100, 0x9c08
+ax_pose 77, 0x01eb, 0x0108, 0x9c0c
+ax_pose 78, 0x01db, 0x00f8, 0x9c0d
+ax_pose 79, 0x01db, 0x0100, 0x9c0e
+ax_pose 54, 0x01df, 0x44ed, 0x2c0f
+ax_pose -1, 0x01db, 0x44f3, 0x2c0f
+ax_pose_terminator
+sDeoxysSpeedPose141:
+ax_pose 75, 0x81e3, 0x80f0, 0x9c00
+ax_pose 76, 0x81e3, 0x4100, 0x9c08
+ax_pose 77, 0x01eb, 0x0108, 0x9c0c
+ax_pose 78, 0x01db, 0x00f8, 0x9c0d
+ax_pose 79, 0x01db, 0x0100, 0x9c0e
+ax_pose 55, 0x01df, 0x44ed, 0x2c0f
+ax_pose -1, 0x01db, 0x44f3, 0x2c0f
+ax_pose_terminator
+sDeoxysSpeedPose142:
+ax_pose 75, 0x81e3, 0x80f0, 0x9c00
+ax_pose 76, 0x81e3, 0x4100, 0x9c08
+ax_pose 77, 0x01eb, 0x0108, 0x9c0c
+ax_pose 78, 0x01db, 0x00f8, 0x9c0d
+ax_pose 79, 0x01db, 0x0100, 0x9c0e
+ax_pose 56, 0x01df, 0x44ed, 0x2c0f
+ax_pose -1, 0x01db, 0x44f3, 0x2c0f
+ax_pose_terminator
+sDeoxysSpeedPose143:
+ax_pose 75, 0x81e3, 0x80f0, 0x9c00
+ax_pose 76, 0x81e3, 0x4100, 0x9c08
+ax_pose 77, 0x01eb, 0x0108, 0x9c0c
+ax_pose 78, 0x01db, 0x00f8, 0x9c0d
+ax_pose 79, 0x01db, 0x0100, 0x9c0e
+ax_pose 57, 0x01df, 0x44ed, 0x2c0f
+ax_pose -1, 0x01db, 0x44f3, 0x2c0f
+ax_pose_terminator
+sDeoxysSpeedPose144:
+ax_pose 75, 0x81e3, 0x80f0, 0x9c00
+ax_pose 76, 0x81e3, 0x4100, 0x9c08
+ax_pose 77, 0x01eb, 0x0108, 0x9c0c
+ax_pose 78, 0x01db, 0x00f8, 0x9c0d
+ax_pose 79, 0x01db, 0x0100, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose145:
+ax_pose 22, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose146:
+ax_pose 48, 0x01e6, 0x04f3, 0x2c00
+ax_pose 80, 0x41f3, 0x80f0, 0x9c01
+ax_pose 81, 0x41eb, 0x40f0, 0x9c09
+ax_pose 82, 0x41e3, 0x00f3, 0x9c0d
+ax_pose 83, 0x41db, 0x00f8, 0x9c0f
+ax_pose -1, 0x01e5, 0x04ef, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose147:
+ax_pose 53, 0x01e6, 0x04f3, 0x2c00
+ax_pose 80, 0x41f3, 0x80f0, 0x9c01
+ax_pose 81, 0x41eb, 0x40f0, 0x9c09
+ax_pose 82, 0x41e3, 0x00f3, 0x9c0d
+ax_pose 83, 0x41db, 0x00f8, 0x9c0f
+ax_pose -1, 0x01e5, 0x04ef, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose148:
+ax_pose 54, 0x01e2, 0x44ef, 0x2c00
+ax_pose 80, 0x41f3, 0x80f0, 0x9c04
+ax_pose 81, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 82, 0x41e3, 0x00f3, 0x9c10
+ax_pose 83, 0x41db, 0x00f8, 0x9c12
+ax_pose -1, 0x01e1, 0x44eb, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose149:
+ax_pose 55, 0x01e2, 0x44ef, 0x2c00
+ax_pose 80, 0x41f3, 0x80f0, 0x9c04
+ax_pose 81, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 82, 0x41e3, 0x00f3, 0x9c10
+ax_pose 83, 0x41db, 0x00f8, 0x9c12
+ax_pose -1, 0x01e1, 0x44eb, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose150:
+ax_pose 56, 0x01e2, 0x44ef, 0x2c00
+ax_pose 80, 0x41f3, 0x80f0, 0x9c04
+ax_pose 81, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 82, 0x41e3, 0x00f3, 0x9c10
+ax_pose 83, 0x41db, 0x00f8, 0x9c12
+ax_pose -1, 0x01e1, 0x44eb, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose151:
+ax_pose 57, 0x01e2, 0x44ef, 0x2c00
+ax_pose 80, 0x41f3, 0x80f0, 0x9c04
+ax_pose 81, 0x41eb, 0x40f0, 0x9c0c
+ax_pose 82, 0x41e3, 0x00f3, 0x9c10
+ax_pose 83, 0x41db, 0x00f8, 0x9c12
+ax_pose -1, 0x01e1, 0x44eb, 0x2c00
+ax_pose_terminator
+sDeoxysSpeedPose152:
+ax_pose 80, 0x41f3, 0x80f0, 0x9c00
+ax_pose 81, 0x41eb, 0x40f0, 0x9c08
+ax_pose 82, 0x41e3, 0x00f3, 0x9c0c
+ax_pose 83, 0x41db, 0x00f8, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose153:
+ax_pose 23, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose154:
+ax_pose 48, 0x01e9, 0x04f7, 0x2c00
+ax_pose -1, 0x01e7, 0x04f3, 0x2c00
+ax_pose 84, 0x41f2, 0x80f0, 0x9c01
+ax_pose 85, 0x01e2, 0x40f6, 0x9c09
+ax_pose 86, 0x01ea, 0x0106, 0x9c0d
+ax_pose 87, 0x01da, 0x00fe, 0x9c0e
+ax_pose 88, 0x81f2, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose155:
+ax_pose 53, 0x01e9, 0x04f7, 0x2c00
+ax_pose -1, 0x01e7, 0x04f3, 0x2c00
+ax_pose 84, 0x41f2, 0x80f0, 0x9c01
+ax_pose 85, 0x01e2, 0x40f6, 0x9c09
+ax_pose 86, 0x01ea, 0x0106, 0x9c0d
+ax_pose 87, 0x01da, 0x00fe, 0x9c0e
+ax_pose 88, 0x81f2, 0x0110, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose156:
+ax_pose 54, 0x01e5, 0x44f3, 0x2c00
+ax_pose -1, 0x01e3, 0x44ef, 0x2c00
+ax_pose 84, 0x41f2, 0x80f0, 0x9c04
+ax_pose 85, 0x01e2, 0x40f6, 0x9c0c
+ax_pose 86, 0x01ea, 0x0106, 0x9c10
+ax_pose 87, 0x01da, 0x00fe, 0x9c11
+ax_pose 88, 0x81f2, 0x0110, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose157:
+ax_pose 55, 0x01e5, 0x44f3, 0x2c00
+ax_pose -1, 0x01e3, 0x44ef, 0x2c00
+ax_pose 84, 0x41f2, 0x80f0, 0x9c04
+ax_pose 85, 0x01e2, 0x40f6, 0x9c0c
+ax_pose 86, 0x01ea, 0x0106, 0x9c10
+ax_pose 87, 0x01da, 0x00fe, 0x9c11
+ax_pose 88, 0x81f2, 0x0110, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose158:
+ax_pose 56, 0x01e5, 0x44f3, 0x2c00
+ax_pose -1, 0x01e3, 0x44ef, 0x2c00
+ax_pose 84, 0x41f2, 0x80f0, 0x9c04
+ax_pose 85, 0x01e2, 0x40f6, 0x9c0c
+ax_pose 86, 0x01ea, 0x0106, 0x9c10
+ax_pose 87, 0x01da, 0x00fe, 0x9c11
+ax_pose 88, 0x81f2, 0x0110, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose159:
+ax_pose 57, 0x01e5, 0x44f3, 0x2c00
+ax_pose -1, 0x01e3, 0x44ef, 0x2c00
+ax_pose 84, 0x41f2, 0x80f0, 0x9c04
+ax_pose 85, 0x01e2, 0x40f6, 0x9c0c
+ax_pose 86, 0x01ea, 0x0106, 0x9c10
+ax_pose 87, 0x01da, 0x00fe, 0x9c11
+ax_pose 88, 0x81f2, 0x0110, 0x9c12
+ax_pose_terminator
+sDeoxysSpeedPose160:
+ax_pose 84, 0x41f2, 0x80f0, 0x9c00
+ax_pose 85, 0x01e2, 0x40f6, 0x9c08
+ax_pose 86, 0x01ea, 0x0106, 0x9c0c
+ax_pose 87, 0x01da, 0x00fe, 0x9c0d
+ax_pose 88, 0x81f2, 0x0110, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose161:
+ax_pose 89, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose162:
+ax_pose 90, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose163:
+ax_pose 91, 0x01e0, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose164:
+ax_pose 92, 0x01e0, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose165:
+ax_pose 93, 0x01e1, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose166:
+ax_pose 94, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose167:
+ax_pose 95, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose168:
+ax_pose 96, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose169:
+ax_pose 97, 0x01e1, 0x80f2, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose170:
+ax_pose 98, 0x01e0, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose171:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose172:
+ax_pose 23, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose173:
+ax_pose 22, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose174:
+ax_pose 21, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose175:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose176:
+ax_pose 19, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose177:
+ax_pose 18, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose178:
+ax_pose 17, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose179:
+ax_pose 99, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose180:
+ax_pose 100, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose181:
+ax_pose 101, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose182:
+ax_pose 102, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose183:
+ax_pose 103, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose184:
+ax_pose 104, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose185:
+ax_pose 105, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose186:
+ax_pose 106, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose187:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose188:
+ax_pose 14, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose189:
+ax_pose 12, 0x01e3, 0x80f2, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose190:
+ax_pose 10, 0x01e3, 0x80f3, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose191:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose192:
+ax_pose 6, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose193:
+ax_pose 4, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose194:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose195:
+ax_pose 24, 0x41e3, 0x80f0, 0x9c00
+ax_pose 25, 0x41f3, 0x40f0, 0x9c08
+ax_pose 26, 0x41fb, 0x00f8, 0x9c0c
+ax_pose 27, 0x01fb, 0x0108, 0x9c0e
+ax_pose 28, 0x01db, 0x00fe, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose196:
+ax_pose 29, 0x81e2, 0x80ff, 0x9c00
+ax_pose 30, 0x81e2, 0x40f7, 0x9c08
+ax_pose 31, 0x81ea, 0x00ef, 0x9c0c
+ax_pose 32, 0x01da, 0x00fa, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose197:
+ax_pose 33, 0x41f3, 0x80ef, 0x9c00
+ax_pose 34, 0x01e3, 0x40f7, 0x9c08
+ax_pose 35, 0x01eb, 0x00ef, 0x9c0c
+ax_pose 36, 0x41db, 0x00f7, 0x9c0d
+ax_pose_terminator
+sDeoxysSpeedPose198:
+ax_pose 37, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose199:
+ax_pose 38, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose200:
+ax_pose 39, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose201:
+ax_pose 40, 0x41f1, 0x80f2, 0x9c00
+ax_pose 41, 0x0201, 0x0102, 0x9c08
+ax_pose 42, 0x41e9, 0x40f2, 0x9c09
+ax_pose 43, 0x41e1, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDeoxysSpeedPose202:
+ax_pose 44, 0x41f2, 0x80f2, 0x9c00
+ax_pose 45, 0x41ea, 0x40f2, 0x9c08
+ax_pose 46, 0x41e2, 0x00fa, 0x9c0c
+ax_pose 47, 0x01da, 0x0100, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose203:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose204:
+ax_pose 24, 0x41e3, 0x80f0, 0x9c00
+ax_pose 25, 0x41f3, 0x40f0, 0x9c08
+ax_pose 26, 0x41fb, 0x00f8, 0x9c0c
+ax_pose 27, 0x01fb, 0x0108, 0x9c0e
+ax_pose 28, 0x01db, 0x00fe, 0x9c0f
+ax_pose_terminator
+sDeoxysSpeedPose205:
+ax_pose 99, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose206:
+ax_pose 17, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose207:
+ax_pose 29, 0x81e2, 0x8100, 0x9c00
+ax_pose 30, 0x81e2, 0x40f8, 0x9c08
+ax_pose 31, 0x81ea, 0x00f0, 0x9c0c
+ax_pose 32, 0x01da, 0x00fb, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose208:
+ax_pose 106, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose209:
+ax_pose 18, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose210:
+ax_pose 33, 0x41f3, 0x80f0, 0x9c00
+ax_pose 34, 0x01e3, 0x40f8, 0x9c08
+ax_pose 35, 0x01eb, 0x00f0, 0x9c0c
+ax_pose 36, 0x41db, 0x00f8, 0x9c0d
+ax_pose_terminator
+sDeoxysSpeedPose211:
+ax_pose 105, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose212:
+ax_pose 19, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose213:
+ax_pose 37, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose214:
+ax_pose 104, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose215:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose216:
+ax_pose 38, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose217:
+ax_pose 103, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose218:
+ax_pose 21, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose219:
+ax_pose 39, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose220:
+ax_pose 102, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose221:
+ax_pose 22, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose222:
+ax_pose 40, 0x41f1, 0x80f2, 0x9c00
+ax_pose 41, 0x0201, 0x0102, 0x9c08
+ax_pose 42, 0x41e9, 0x40f2, 0x9c09
+ax_pose 43, 0x41e1, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDeoxysSpeedPose223:
+ax_pose 101, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose224:
+ax_pose 23, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose225:
+ax_pose 44, 0x41f2, 0x80f1, 0x9c00
+ax_pose 45, 0x41ea, 0x40f1, 0x9c08
+ax_pose 46, 0x41e2, 0x00f9, 0x9c0c
+ax_pose 47, 0x01da, 0x00ff, 0x9c0e
+ax_pose_terminator
+sDeoxysSpeedPose226:
+ax_pose 100, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose227:
+ax_pose 0, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose228:
+ax_pose 14, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose229:
+ax_pose 12, 0x01e3, 0x80f2, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose230:
+ax_pose 10, 0x01e3, 0x80f3, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose231:
+ax_pose 8, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose232:
+ax_pose 6, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose233:
+ax_pose 4, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose234:
+ax_pose 2, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose235:
+ax_pose 16, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose236:
+ax_pose 23, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose237:
+ax_pose 22, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose238:
+ax_pose 21, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose239:
+ax_pose 20, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose240:
+ax_pose 19, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose241:
+ax_pose 18, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sDeoxysSpeedPose242:
+ax_pose 17, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+.align 2
+sDeoxysSpeedAnims_1_1:
+ax_anim 2, 0, 0, 0, -2, 0, 0,
+ax_anim 2, 0, 1, 1, -2, 1, 0,
+ax_anim 6, 0, 0, 3, -3, 3, 0,
+ax_anim 4, 0, 1, 2, -2, 2, 0,
+ax_anim 2, 0, 0, 0, -2, 0, 0,
+ax_anim 2, 0, 1, -1, -2, -1, 0,
+ax_anim 6, 0, 0, -3, -3, -3, 0,
+ax_anim 4, 0, 1, -2, -2, -2, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_1_2:
+ax_anim 2, 0, 2, 0, -2, 0, 0,
+ax_anim 2, 0, 3, 1, -3, 1, -1,
+ax_anim 6, 0, 2, 3, -5, 3, -3,
+ax_anim 4, 0, 3, 2, -3, 2, -2,
+ax_anim 2, 0, 2, 0, -2, 0, 0,
+ax_anim 2, 0, 3, -1, -2, -1, 1,
+ax_anim 6, 0, 2, -3, -3, -2, 2,
+ax_anim 4, 0, 3, -2, -2, -1, 1,
+ax_anim_terminator
+sDeoxysSpeedAnims_1_3:
+ax_anim 2, 0, 4, 0, -2, 0, 0,
+ax_anim 2, 0, 5, 1, 0, 1, 1,
+ax_anim 6, 0, 4, 2, -1, 2, 2,
+ax_anim 4, 0, 5, 1, -1, 1, 1,
+ax_anim 2, 0, 4, 0, -2, 0, 0,
+ax_anim 2, 0, 5, 0, -3, 0, -1,
+ax_anim 6, 0, 4, 0, -5, 0, -3,
+ax_anim 4, 0, 5, 0, -3, 0, -1,
+ax_anim_terminator
+sDeoxysSpeedAnims_1_4:
+ax_anim 2, 0, 6, 0, -2, 0, 0,
+ax_anim 2, 0, 7, -1, -3, -1, -1,
+ax_anim 6, 0, 6, -3, -5, -3, -3,
+ax_anim 4, 0, 7, -2, -3, -2, -2,
+ax_anim 2, 0, 6, 0, -2, 0, 0,
+ax_anim 2, 0, 7, 1, -2, 1, 1,
+ax_anim 6, 0, 6, 3, -3, 2, 2,
+ax_anim 4, 0, 7, 2, -2, 1, 1,
+ax_anim_terminator
+sDeoxysSpeedAnims_1_5:
+ax_anim 2, 0, 8, 0, -2, 0, 0,
+ax_anim 2, 0, 9, -1, -2, -1, 0,
+ax_anim 6, 0, 8, -3, -3, -3, 0,
+ax_anim 4, 0, 9, -2, -2, -2, 0,
+ax_anim 2, 0, 8, 0, -2, 0, 0,
+ax_anim 2, 0, 9, 1, -2, 1, 0,
+ax_anim 6, 0, 8, 3, -3, 3, 0,
+ax_anim 4, 0, 9, 2, -2, 2, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_1_6:
+ax_anim 2, 0, 10, 0, -2, 0, 0,
+ax_anim 2, 0, 11, 1, -3, 1, -1,
+ax_anim 6, 0, 10, 3, -5, 3, -3,
+ax_anim 4, 0, 11, 2, -3, 2, -2,
+ax_anim 2, 0, 10, 0, -2, 0, 0,
+ax_anim 2, 0, 11, -1, -2, -1, 1,
+ax_anim 6, 0, 10, -3, -3, -2, 2,
+ax_anim 4, 0, 11, -2, -2, -1, 1,
+ax_anim_terminator
+sDeoxysSpeedAnims_1_7:
+ax_anim 2, 0, 12, 0, -2, 0, 0,
+ax_anim 2, 0, 13, -1, 0, -1, 1,
+ax_anim 6, 0, 12, -2, -1, -2, 2,
+ax_anim 4, 0, 13, -1, -1, -1, 1,
+ax_anim 2, 0, 12, 0, -2, 0, 0,
+ax_anim 2, 0, 13, 0, -3, 0, -1,
+ax_anim 6, 0, 12, 0, -5, 0, -3,
+ax_anim 4, 0, 13, 0, -3, 0, -1,
+ax_anim_terminator
+sDeoxysSpeedAnims_1_8:
+ax_anim 2, 0, 14, 0, -2, 0, 0,
+ax_anim 2, 0, 15, -1, -3, -1, -1,
+ax_anim 6, 0, 14, -3, -5, -3, -3,
+ax_anim 4, 0, 15, -2, -3, -2, -2,
+ax_anim 2, 0, 14, 0, -2, 0, 0,
+ax_anim 2, 0, 15, 1, -2, 1, 1,
+ax_anim 6, 0, 14, 3, -3, 2, 2,
+ax_anim 4, 0, 15, 2, -2, 1, 1,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 0, 4, 0, 4,
+ax_anim 1, 0, 18, 0, 10, 0, 10,
+ax_anim 2, 0, 17, 0, 20, 0, 20,
+ax_anim 2, 1, 17, 1, 20, 1, 20,
+ax_anim 2, 0, 17, 0, 20, 0, 20,
+ax_anim 2, 0, 17, 1, 20, 1, 20,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysSpeedAnims_2_2:
+ax_anim 2, 0, 19, -1, -1, -1, -1,
+ax_anim 6, 0, 19, -2, -2, -2, -2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 4, 4, 4, 4,
+ax_anim 1, 0, 21, 10, 11, 10, 11,
+ax_anim 2, 0, 20, 18, 20, 18, 20,
+ax_anim 2, 1, 20, 19, 19, 19, 19,
+ax_anim 2, 0, 20, 18, 20, 18, 20,
+ax_anim 2, 0, 20, 19, 19, 19, 19,
+ax_anim 2, 0, 19, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysSpeedAnims_2_3:
+ax_anim 2, 0, 22, -1, 0, -1, 0,
+ax_anim 6, 0, 22, -2, 0, -2, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 23, 4, 0, 4, 0,
+ax_anim 1, 0, 24, 10, 0, 10, 0,
+ax_anim 2, 0, 23, 17, 0, 17, 0,
+ax_anim 2, 1, 23, 17, 1, 17, 1,
+ax_anim 2, 0, 23, 17, 0, 17, 0,
+ax_anim 2, 0, 23, 17, 1, 17, 1,
+ax_anim 2, 0, 22, 6, 0, 6, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_2_4:
+ax_anim 2, 0, 25, -1, 1, -1, 1,
+ax_anim 6, 0, 25, -2, 2, -2, 2,
+ax_anim 1, 0, 27, 0, -1, 0, -1,
+ax_anim 1, 2, 26, 5, -5, 5, -5,
+ax_anim 1, 0, 27, 12, -11, 12, -11,
+ax_anim 2, 0, 26, 18, -16, 18, -16,
+ax_anim 2, 1, 26, 19, -15, 19, -15,
+ax_anim 2, 0, 26, 18, -16, 18, -16,
+ax_anim 2, 0, 26, 19, -15, 19, -15,
+ax_anim 2, 0, 25, 6, -6, 6, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_2_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 6, 0, 28, 0, 2, 0, 2,
+ax_anim 1, 0, 30, 0, 1, 0, 1,
+ax_anim 1, 2, 29, 0, -2, 0, -2,
+ax_anim 1, 0, 30, 0, -9, 0, -9,
+ax_anim 2, 0, 29, 0, -16, 0, -16,
+ax_anim 2, 1, 29, 1, -16, 1, -16,
+ax_anim 2, 0, 29, 0, -16, 0, -16,
+ax_anim 2, 0, 29, 1, -16, 1, -16,
+ax_anim 2, 0, 28, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_2_6:
+ax_anim 2, 0, 31, 1, 1, 1, 1,
+ax_anim 6, 0, 31, 2, 2, 2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 32, -5, -5, -5, -5,
+ax_anim 1, 0, 33, -12, -11, -12, -11,
+ax_anim 2, 0, 32, -18, -16, -18, -16,
+ax_anim 2, 1, 32, -19, -15, -19, -15,
+ax_anim 2, 0, 32, -18, -16, -18, -16,
+ax_anim 2, 0, 32, -19, -15, -19, -15,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_2_7:
+ax_anim 2, 0, 34, 1, 0, 1, 0,
+ax_anim 6, 0, 34, 2, 0, 2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 35, -4, 0, -4, 0,
+ax_anim 1, 0, 36, -10, 0, -10, 0,
+ax_anim 2, 0, 35, -17, 0, -17, 0,
+ax_anim 2, 1, 35, -17, 1, -17, 1,
+ax_anim 2, 0, 35, -17, 0, -17, 0,
+ax_anim 2, 0, 35, -17, 1, -17, 1,
+ax_anim 2, 0, 34, -6, 0, -6, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_2_8:
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 6, 0, 37, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 38, -4, 4, -4, 4,
+ax_anim 1, 0, 39, -10, 11, -10, 11,
+ax_anim 2, 0, 38, -18, 20, -18, 20,
+ax_anim 2, 1, 38, -19, 19, -19, 19,
+ax_anim 2, 0, 38, -18, 20, -18, 20,
+ax_anim 2, 0, 38, -19, 19, -19, 19,
+ax_anim 2, 0, 37, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 6, 0, 40, 0, -2, 0, -2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, 8, 0, 8,
+ax_anim 1, 0, 42, 0, 20, 0, 20,
+ax_anim 2, 0, 41, 0, 44, 0, 44,
+ax_anim 2, 1, 41, 1, 44, 1, 44,
+ax_anim 2, 0, 41, 0, 44, 0, 44,
+ax_anim 2, 0, 41, 1, 44, 1, 44,
+ax_anim 1, 0, 40, 0, 18, 0, 18,
+ax_anim 2, 0, 40, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysSpeedAnims_3_2:
+ax_anim 2, 0, 43, -1, -1, -1, -1,
+ax_anim 6, 0, 43, -2, -2, -2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 8, 8, 8, 8,
+ax_anim 1, 0, 45, 20, 20, 20, 20,
+ax_anim 2, 0, 44, 42, 44, 42, 44,
+ax_anim 2, 1, 44, 43, 43, 43, 43,
+ax_anim 2, 0, 44, 42, 44, 42, 44,
+ax_anim 2, 0, 44, 43, 43, 43, 43,
+ax_anim 1, 0, 43, 18, 18, 18, 18,
+ax_anim 2, 0, 43, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysSpeedAnims_3_3:
+ax_anim 2, 0, 46, -1, 0, -1, 0,
+ax_anim 6, 0, 46, -2, 0, -2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 47, 8, 0, 8, 0,
+ax_anim 1, 0, 48, 20, 0, 20, 0,
+ax_anim 2, 0, 47, 41, 0, 41, 0,
+ax_anim 2, 1, 47, 41, 1, 41, 1,
+ax_anim 2, 0, 47, 41, 0, 41, 0,
+ax_anim 2, 0, 47, 41, 1, 41, 1,
+ax_anim 1, 0, 46, 18, 0, 18, 0,
+ax_anim 2, 0, 46, 6, 0, 6, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_3_4:
+ax_anim 2, 0, 49, -1, 1, -1, 1,
+ax_anim 6, 0, 49, -2, 2, -2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 50, 8, -8, 8, -8,
+ax_anim 1, 0, 51, 21, -20, 21, -20,
+ax_anim 2, 0, 50, 42, -40, 42, -40,
+ax_anim 2, 1, 50, 43, -39, 43, -39,
+ax_anim 2, 0, 50, 42, -40, 42, -40,
+ax_anim 2, 0, 50, 43, -39, 43, -39,
+ax_anim 1, 0, 49, 18, -18, 18, -18,
+ax_anim 2, 0, 49, 6, -6, 6, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_3_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 6, 0, 52, 0, 2, 0, 2,
+ax_anim 1, 0, 54, 0, -1, 0, -1,
+ax_anim 1, 2, 53, 0, -8, 0, -8,
+ax_anim 1, 0, 54, 0, -20, 0, -20,
+ax_anim 2, 0, 53, 0, -40, 0, -40,
+ax_anim 2, 1, 53, 1, -40, 1, -40,
+ax_anim 2, 0, 53, 0, -40, 0, -40,
+ax_anim 2, 0, 53, 1, -40, 1, -40,
+ax_anim 1, 0, 52, 0, -18, 0, -18,
+ax_anim 2, 0, 52, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_3_6:
+ax_anim 2, 0, 55, 1, 1, 1, 1,
+ax_anim 6, 0, 55, 2, 2, 2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 56, -8, -8, -8, -8,
+ax_anim 1, 0, 57, -21, -20, -21, -20,
+ax_anim 2, 0, 56, -42, -40, -42, -40,
+ax_anim 2, 1, 56, -43, -39, -43, -39,
+ax_anim 2, 0, 56, -42, -40, -42, -40,
+ax_anim 2, 0, 56, -43, -39, -43, -39,
+ax_anim 1, 0, 55, -18, -18, -18, -18,
+ax_anim 2, 0, 55, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_3_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 6, 0, 58, 2, 0, 2, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 59, -8, 0, -8, 0,
+ax_anim 1, 0, 60, -20, 0, -20, 0,
+ax_anim 2, 0, 59, -41, 0, -41, 0,
+ax_anim 2, 1, 59, -41, 1, -41, 1,
+ax_anim 2, 0, 59, -41, 0, -41, 0,
+ax_anim 2, 0, 59, -41, 1, -41, 1,
+ax_anim 1, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -6, 0, -6, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_3_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 6, 0, 61, 2, -2, 2, -2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 62, -8, 8, -8, 8,
+ax_anim 1, 0, 63, -20, 20, -20, 20,
+ax_anim 2, 0, 62, -42, 44, -42, 44,
+ax_anim 2, 1, 62, -43, 43, -43, 43,
+ax_anim 2, 0, 62, -42, 44, -42, 44,
+ax_anim 2, 0, 62, -43, 43, -43, 43,
+ax_anim 1, 0, 61, -18, 18, -18, 18,
+ax_anim 2, 0, 61, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_4_1:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 2, 64, -1, 0, -1, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 1, 67, 0, 0, 0, 0,
+ax_anim 1, 0, 67, 0, -3, 0, -3,
+ax_anim 1, 0, 67, 0, -5, 0, -5,
+ax_anim 3, 0, 67, 0, -6, 0, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_4_2:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, -1, 1, -1,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 2, 68, 1, -1, 1, -1,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, -1, 1, -1,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 1, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 71, -3, -3, -3, -3,
+ax_anim 1, 0, 71, -5, -5, -5, -5,
+ax_anim 3, 0, 71, -6, -6, -6, -6,
+ax_anim_terminator
+sDeoxysSpeedAnims_4_3:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 1, 75, -3, 0, 0, 0,
+ax_anim 1, 0, 75, -6, 0, -3, 0,
+ax_anim 1, 0, 75, -8, 0, -5, 0,
+ax_anim 3, 0, 75, -9, 0, -6, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_4_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 2, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 1, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, -3, 3, -3, 3,
+ax_anim 1, 0, 79, -5, 5, -5, 5,
+ax_anim 3, 0, 79, -6, 6, -6, 6,
+ax_anim_terminator
+sDeoxysSpeedAnims_4_5:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 2, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 1, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, 3, 0, 3,
+ax_anim 1, 0, 83, 0, 5, 0, 5,
+ax_anim 3, 0, 83, 0, 6, 0, 6,
+ax_anim_terminator
+sDeoxysSpeedAnims_4_6:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 84, -1, 1, -1, 1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 1, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 3, 3, 3, 3,
+ax_anim 1, 0, 87, 5, 5, 5, 5,
+ax_anim 3, 0, 87, 6, 6, 6, 6,
+ax_anim_terminator
+sDeoxysSpeedAnims_4_7:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 1, 91, 3, 0, 0, 0,
+ax_anim 1, 0, 91, 6, 0, 3, 0,
+ax_anim 1, 0, 91, 8, 0, 5, 0,
+ax_anim 3, 0, 91, 9, 0, 6, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_4_8:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 92, -1, -1, -1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 1, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 3, -3, 3, -3,
+ax_anim 1, 0, 95, 5, -5, 5, -5,
+ax_anim 3, 0, 95, 6, -6, 6, -6,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_5_1:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_5_3:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_5_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_5_5:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_5_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_5_7:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_5_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sDeoxysSpeedAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sDeoxysSpeedAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sDeoxysSpeedAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sDeoxysSpeedAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sDeoxysSpeedAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_8_1:
+ax_anim 4, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -4, 0, 0,
+ax_anim 4, 0, 170, 0, -5, 0, 0,
+ax_anim 4, 0, 170, 0, -5, 0, 0,
+ax_anim 4, 0, 170, 0, -4, 0, 0,
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_8_2:
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, -4, 0, 0,
+ax_anim 4, 0, 177, 0, -5, 0, 0,
+ax_anim 4, 0, 177, 0, -5, 0, 0,
+ax_anim 4, 0, 177, 0, -4, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_8_3:
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -4, 0, 0,
+ax_anim 4, 0, 176, 0, -5, 0, 0,
+ax_anim 4, 0, 176, 0, -5, 0, 0,
+ax_anim 4, 0, 176, 0, -4, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_8_4:
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, -4, 0, 0,
+ax_anim 4, 0, 175, 0, -5, 0, 0,
+ax_anim 4, 0, 175, 0, -5, 0, 0,
+ax_anim 4, 0, 175, 0, -4, 0, 0,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_8_5:
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 174, 0, -4, 0, 0,
+ax_anim 4, 0, 174, 0, -5, 0, 0,
+ax_anim 4, 0, 174, 0, -5, 0, 0,
+ax_anim 4, 0, 174, 0, -4, 0, 0,
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_8_6:
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -4, 0, 0,
+ax_anim 4, 0, 173, 0, -5, 0, 0,
+ax_anim 4, 0, 173, 0, -5, 0, 0,
+ax_anim 4, 0, 173, 0, -4, 0, 0,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_8_7:
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim 4, 0, 172, 0, -5, 0, 0,
+ax_anim 4, 0, 172, 0, -5, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_8_8:
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, -4, 0, 0,
+ax_anim 4, 0, 171, 0, -5, 0, 0,
+ax_anim 4, 0, 171, 0, -5, 0, 0,
+ax_anim 4, 0, 171, 0, -4, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 4, 7, 4,
+ax_anim 2, 0, 188, 10, 10, 10, 10,
+ax_anim 2, 0, 189, 8, 17, 8, 17,
+ax_anim 3, 0, 190, 0, 19, 0, 19,
+ax_anim 2, 3, 191, -8, 17, -8, 17,
+ax_anim 2, 0, 192, -10, 10, -10, 10,
+ax_anim 1, 0, 193, -7, 4, -7, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 16, 3, 16, 3,
+ax_anim 2, 0, 188, 24, 9, 24, 9,
+ax_anim 3, 0, 189, 22, 19, 22, 19,
+ax_anim 2, 3, 190, 13, 20, 13, 20,
+ax_anim 2, 0, 191, 1, 18, 1, 18,
+ax_anim 1, 0, 192, -2, 7, -2, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -7, 11, -7,
+ax_anim 2, 0, 187, 19, -6, 19, -6,
+ax_anim 3, 0, 188, 23, -2, 23, -2,
+ax_anim 2, 3, 189, 21, 5, 21, 5,
+ax_anim 2, 0, 190, 12, 6, 12, 6,
+ax_anim 1, 0, 191, 1, 5, 1, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, -8,
+ax_anim 2, 0, 193, 4, -17, 4, -17,
+ax_anim 2, 0, 186, 12, -20, 12, -20,
+ax_anim 3, 0, 187, 21, -20, 21, -20,
+ax_anim 2, 3, 188, 26, -14, 26, -14,
+ax_anim 2, 0, 189, 21, -5, 21, -5,
+ax_anim 1, 0, 190, 13, 0, 13, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -11, -9, -11,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -20, 0, -20,
+ax_anim 2, 3, 187, 8, -18, 8, -18,
+ax_anim 2, 0, 188, 10, -10, 10, -10,
+ax_anim 1, 0, 189, 9, -2, 9, -2,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -8, 0, -8,
+ax_anim 2, 0, 187, -4, -17, -4, -17,
+ax_anim 2, 0, 186, -12, -20, -12, -20,
+ax_anim 3, 0, 193, -21, -20, -21, -20,
+ax_anim 2, 3, 192, -26, -14, -26, -14,
+ax_anim 2, 0, 191, -21, -5, -21, -5,
+ax_anim 1, 0, 190, -13, 0, -13, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -7, -11, -7,
+ax_anim 2, 0, 193, -19, -6, -19, -6,
+ax_anim 3, 0, 192, -23, -2, -23, -2,
+ax_anim 2, 3, 191, -21, 5, -21, 5,
+ax_anim 2, 0, 190, -12, 6, -12, 6,
+ax_anim 1, 0, 189, -1, 5, -1, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -16, 3, -16, 3,
+ax_anim 2, 0, 192, -24, 9, -24, 9,
+ax_anim 3, 0, 191, -22, 19, -22, 19,
+ax_anim 2, 3, 190, -13, 20, -13, 20,
+ax_anim 2, 0, 189, -1, 18, -1, 18,
+ax_anim 1, 0, 188, 2, 7, 2, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -14, 0, 0,
+ax_anim 3, 0, 203, 0, -17, 0, 0,
+ax_anim 4, 0, 203, 0, -18, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -14, 0, 0,
+ax_anim 3, 0, 206, 0, -18, 0, 0,
+ax_anim 4, 0, 206, 0, -19, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -14, 0, 0,
+ax_anim 3, 0, 224, 0, -18, 0, 0,
+ax_anim 4, 0, 224, 0, -19, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDeoxysSpeedAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sDeoxysSpeedGfx1:
+.incbin "baserom.gba", 0x163F2CC, 0x200
+sDeoxysSpeedSprites1:
+ax_sprite sDeoxysSpeedGfx1, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx2:
+.incbin "baserom.gba", 0x163F4DC, 0x200
+sDeoxysSpeedSprites2:
+ax_sprite sDeoxysSpeedGfx2, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx3:
+.incbin "baserom.gba", 0x163F6EC, 0x200
+sDeoxysSpeedSprites3:
+ax_sprite sDeoxysSpeedGfx3, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx4:
+.incbin "baserom.gba", 0x163F8FC, 0x200
+sDeoxysSpeedSprites4:
+ax_sprite sDeoxysSpeedGfx4, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx5:
+.incbin "baserom.gba", 0x163FB0C, 0x200
+sDeoxysSpeedSprites5:
+ax_sprite sDeoxysSpeedGfx5, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx6:
+.incbin "baserom.gba", 0x163FD1C, 0x200
+sDeoxysSpeedSprites6:
+ax_sprite sDeoxysSpeedGfx6, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx7:
+.incbin "baserom.gba", 0x163FF2C, 0x200
+sDeoxysSpeedSprites7:
+ax_sprite sDeoxysSpeedGfx7, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx8:
+.incbin "baserom.gba", 0x164013C, 0x200
+sDeoxysSpeedSprites8:
+ax_sprite sDeoxysSpeedGfx8, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx9:
+.incbin "baserom.gba", 0x164034C, 0x200
+sDeoxysSpeedSprites9:
+ax_sprite sDeoxysSpeedGfx9, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx10:
+.incbin "baserom.gba", 0x164055C, 0x200
+sDeoxysSpeedSprites10:
+ax_sprite sDeoxysSpeedGfx10, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx11:
+.incbin "baserom.gba", 0x164076C, 0x200
+sDeoxysSpeedSprites11:
+ax_sprite sDeoxysSpeedGfx11, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx12:
+.incbin "baserom.gba", 0x164097C, 0x200
+sDeoxysSpeedSprites12:
+ax_sprite sDeoxysSpeedGfx12, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx13:
+.incbin "baserom.gba", 0x1640B8C, 0x200
+sDeoxysSpeedSprites13:
+ax_sprite sDeoxysSpeedGfx13, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx14:
+.incbin "baserom.gba", 0x1640D9C, 0x200
+sDeoxysSpeedSprites14:
+ax_sprite sDeoxysSpeedGfx14, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx15:
+.incbin "baserom.gba", 0x1640FAC, 0x200
+sDeoxysSpeedSprites15:
+ax_sprite sDeoxysSpeedGfx15, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx16:
+.incbin "baserom.gba", 0x16411BC, 0x200
+sDeoxysSpeedSprites16:
+ax_sprite sDeoxysSpeedGfx16, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx17:
+.incbin "baserom.gba", 0x16413CC, 0x40
+sDeoxysSpeedGfx17_1:
+.incbin "baserom.gba", 0x164140C, 0x160
+sDeoxysSpeedSprites17:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDeoxysSpeedGfx17_1, 0x160
+ax_sprite_terminator
+sDeoxysSpeedGfx18:
+.incbin "baserom.gba", 0x1641594, 0x1E0
+sDeoxysSpeedSprites18:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx18, 0x1e0
+ax_sprite_terminator
+sDeoxysSpeedGfx19:
+.incbin "baserom.gba", 0x164178C, 0x60
+sDeoxysSpeedGfx19_1:
+.incbin "baserom.gba", 0x16417EC, 0x160
+sDeoxysSpeedSprites19:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx19_1, 0x160
+ax_sprite_terminator
+sDeoxysSpeedGfx20:
+.incbin "baserom.gba", 0x1641974, 0x60
+sDeoxysSpeedGfx20_1:
+.incbin "baserom.gba", 0x16419D4, 0x60
+sDeoxysSpeedGfx20_2:
+.incbin "baserom.gba", 0x1641A34, 0x60
+sDeoxysSpeedGfx20_3:
+.incbin "baserom.gba", 0x1641A94, 0x40
+sDeoxysSpeedSprites20:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx21:
+.incbin "baserom.gba", 0x1641B24, 0x40
+sDeoxysSpeedGfx21_1:
+.incbin "baserom.gba", 0x1641B64, 0x180
+sDeoxysSpeedSprites21:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx21_1, 0x180
+ax_sprite_terminator
+sDeoxysSpeedGfx22:
+.incbin "baserom.gba", 0x1641D0C, 0x60
+sDeoxysSpeedGfx22_1:
+.incbin "baserom.gba", 0x1641D6C, 0x60
+sDeoxysSpeedGfx22_2:
+.incbin "baserom.gba", 0x1641DCC, 0x60
+sDeoxysSpeedGfx22_3:
+.incbin "baserom.gba", 0x1641E2C, 0x40
+sDeoxysSpeedSprites22:
+ax_sprite sDeoxysSpeedGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDeoxysSpeedGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx23:
+.incbin "baserom.gba", 0x1641EB4, 0x60
+sDeoxysSpeedGfx23_1:
+.incbin "baserom.gba", 0x1641F14, 0x60
+sDeoxysSpeedGfx23_2:
+.incbin "baserom.gba", 0x1641F74, 0x100
+sDeoxysSpeedSprites23:
+ax_sprite sDeoxysSpeedGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx23_2, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx24:
+.incbin "baserom.gba", 0x16420A4, 0x60
+sDeoxysSpeedGfx24_1:
+.incbin "baserom.gba", 0x1642104, 0x180
+sDeoxysSpeedSprites24:
+ax_sprite sDeoxysSpeedGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx24_1, 0x180
+ax_sprite_terminator
+sDeoxysSpeedGfx25:
+.incbin "baserom.gba", 0x16422A4, 0x100
+sDeoxysSpeedSprites25:
+ax_sprite sDeoxysSpeedGfx25, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx26:
+.incbin "baserom.gba", 0x16423B4, 0x80
+sDeoxysSpeedSprites26:
+ax_sprite sDeoxysSpeedGfx26, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx27:
+.incbin "baserom.gba", 0x1642444, 0x40
+sDeoxysSpeedSprites27:
+ax_sprite sDeoxysSpeedGfx27, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx28:
+.incbin "baserom.gba", 0x1642494, 0x20
+sDeoxysSpeedSprites28:
+ax_sprite sDeoxysSpeedGfx28, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx29:
+.incbin "baserom.gba", 0x16424C4, 0x20
+sDeoxysSpeedSprites29:
+ax_sprite sDeoxysSpeedGfx29, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx30:
+.incbin "baserom.gba", 0x16424F4, 0x20
+sDeoxysSpeedGfx30_1:
+.incbin "baserom.gba", 0x1642514, 0x20
+sDeoxysSpeedGfx30_2:
+.incbin "baserom.gba", 0x1642534, 0x80
+sDeoxysSpeedSprites30:
+ax_sprite sDeoxysSpeedGfx30, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx30_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx30_2, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx31:
+.incbin "baserom.gba", 0x16425E4, 0x80
+sDeoxysSpeedSprites31:
+ax_sprite sDeoxysSpeedGfx31, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx32:
+.incbin "baserom.gba", 0x1642674, 0x40
+sDeoxysSpeedSprites32:
+ax_sprite sDeoxysSpeedGfx32, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx33:
+.incbin "baserom.gba", 0x16426C4, 0x20
+sDeoxysSpeedSprites33:
+ax_sprite sDeoxysSpeedGfx33, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx34:
+.incbin "baserom.gba", 0x16426F4, 0x100
+sDeoxysSpeedSprites34:
+ax_sprite sDeoxysSpeedGfx34, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx35:
+.incbin "baserom.gba", 0x1642804, 0x80
+sDeoxysSpeedSprites35:
+ax_sprite sDeoxysSpeedGfx35, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx36:
+.incbin "baserom.gba", 0x1642894, 0x20
+sDeoxysSpeedSprites36:
+ax_sprite sDeoxysSpeedGfx36, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx37:
+.incbin "baserom.gba", 0x16428C4, 0x40
+sDeoxysSpeedSprites37:
+ax_sprite sDeoxysSpeedGfx37, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx38:
+.incbin "baserom.gba", 0x1642914, 0x40
+sDeoxysSpeedGfx38_1:
+.incbin "baserom.gba", 0x1642954, 0x60
+sDeoxysSpeedGfx38_2:
+.incbin "baserom.gba", 0x16429B4, 0x60
+sDeoxysSpeedGfx38_3:
+.incbin "baserom.gba", 0x1642A14, 0x60
+sDeoxysSpeedSprites38:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx39:
+.incbin "baserom.gba", 0x1642AC4, 0x40
+sDeoxysSpeedGfx39_1:
+.incbin "baserom.gba", 0x1642B04, 0x180
+sDeoxysSpeedSprites39:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx39_1, 0x180
+ax_sprite_terminator
+sDeoxysSpeedGfx40:
+.incbin "baserom.gba", 0x1642CAC, 0x40
+sDeoxysSpeedGfx40_1:
+.incbin "baserom.gba", 0x1642CEC, 0x60
+sDeoxysSpeedGfx40_2:
+.incbin "baserom.gba", 0x1642D4C, 0x60
+sDeoxysSpeedGfx40_3:
+.incbin "baserom.gba", 0x1642DAC, 0x60
+sDeoxysSpeedSprites40:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDeoxysSpeedGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx40_3, 0x60
+ax_sprite_terminator
+sDeoxysSpeedGfx41:
+.incbin "baserom.gba", 0x1642E54, 0x100
+sDeoxysSpeedSprites41:
+ax_sprite sDeoxysSpeedGfx41, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx42:
+.incbin "baserom.gba", 0x1642F64, 0x20
+sDeoxysSpeedSprites42:
+ax_sprite sDeoxysSpeedGfx42, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx43:
+.incbin "baserom.gba", 0x1642F94, 0x60
+sDeoxysSpeedSprites43:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx43, 0x60
+ax_sprite_terminator
+sDeoxysSpeedGfx44:
+.incbin "baserom.gba", 0x164300C, 0x40
+sDeoxysSpeedSprites44:
+ax_sprite sDeoxysSpeedGfx44, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx45:
+.incbin "baserom.gba", 0x164305C, 0xE0
+sDeoxysSpeedSprites45:
+ax_sprite sDeoxysSpeedGfx45, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx46:
+.incbin "baserom.gba", 0x1643154, 0x60
+sDeoxysSpeedSprites46:
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx46, 0x60
+ax_sprite_terminator
+sDeoxysSpeedGfx47:
+.incbin "baserom.gba", 0x16431CC, 0x40
+sDeoxysSpeedSprites47:
+ax_sprite sDeoxysSpeedGfx47, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx48:
+.incbin "baserom.gba", 0x164321C, 0x20
+sDeoxysSpeedSprites48:
+ax_sprite sDeoxysSpeedGfx48, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx49:
+.incbin "baserom.gba", 0x164324C, 0x20
+sDeoxysSpeedSprites49:
+ax_sprite sDeoxysSpeedGfx49, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx50:
+.incbin "baserom.gba", 0x164327C, 0x100
+sDeoxysSpeedSprites50:
+ax_sprite sDeoxysSpeedGfx50, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx51:
+.incbin "baserom.gba", 0x164338C, 0x80
+sDeoxysSpeedSprites51:
+ax_sprite sDeoxysSpeedGfx51, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx52:
+.incbin "baserom.gba", 0x164341C, 0x40
+sDeoxysSpeedSprites52:
+ax_sprite sDeoxysSpeedGfx52, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx53:
+.incbin "baserom.gba", 0x164346C, 0x20
+sDeoxysSpeedSprites53:
+ax_sprite sDeoxysSpeedGfx53, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx54:
+.incbin "baserom.gba", 0x164349C, 0x20
+sDeoxysSpeedSprites54:
+ax_sprite sDeoxysSpeedGfx54, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx55:
+.incbin "baserom.gba", 0x16434CC, 0x80
+sDeoxysSpeedSprites55:
+ax_sprite sDeoxysSpeedGfx55, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx56:
+.incbin "baserom.gba", 0x164355C, 0x80
+sDeoxysSpeedSprites56:
+ax_sprite sDeoxysSpeedGfx56, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx57:
+.incbin "baserom.gba", 0x16435EC, 0x80
+sDeoxysSpeedSprites57:
+ax_sprite sDeoxysSpeedGfx57, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx58:
+.incbin "baserom.gba", 0x164367C, 0x80
+sDeoxysSpeedSprites58:
+ax_sprite sDeoxysSpeedGfx58, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx59:
+.incbin "baserom.gba", 0x164370C, 0x100
+sDeoxysSpeedSprites59:
+ax_sprite sDeoxysSpeedGfx59, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx60:
+.incbin "baserom.gba", 0x164381C, 0x80
+sDeoxysSpeedSprites60:
+ax_sprite sDeoxysSpeedGfx60, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx61:
+.incbin "baserom.gba", 0x16438AC, 0x20
+sDeoxysSpeedSprites61:
+ax_sprite sDeoxysSpeedGfx61, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx62:
+.incbin "baserom.gba", 0x16438DC, 0x40
+sDeoxysSpeedSprites62:
+ax_sprite sDeoxysSpeedGfx62, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx63:
+.incbin "baserom.gba", 0x164392C, 0x20
+sDeoxysSpeedSprites63:
+ax_sprite sDeoxysSpeedGfx63, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx64:
+.incbin "baserom.gba", 0x164395C, 0xC0
+sDeoxysSpeedGfx64_1:
+.incbin "baserom.gba", 0x1643A1C, 0x20
+sDeoxysSpeedSprites64:
+ax_sprite sDeoxysSpeedGfx64, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx64_1, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx65:
+.incbin "baserom.gba", 0x1643A5C, 0x80
+sDeoxysSpeedSprites65:
+ax_sprite sDeoxysSpeedGfx65, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx66:
+.incbin "baserom.gba", 0x1643AEC, 0x40
+sDeoxysSpeedSprites66:
+ax_sprite sDeoxysSpeedGfx66, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx67:
+.incbin "baserom.gba", 0x1643B3C, 0x40
+sDeoxysSpeedSprites67:
+ax_sprite sDeoxysSpeedGfx67, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx68:
+.incbin "baserom.gba", 0x1643B8C, 0x100
+sDeoxysSpeedSprites68:
+ax_sprite sDeoxysSpeedGfx68, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx69:
+.incbin "baserom.gba", 0x1643C9C, 0x40
+sDeoxysSpeedSprites69:
+ax_sprite sDeoxysSpeedGfx69, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx70:
+.incbin "baserom.gba", 0x1643CEC, 0x20
+sDeoxysSpeedSprites70:
+ax_sprite sDeoxysSpeedGfx70, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx71:
+.incbin "baserom.gba", 0x1643D1C, 0x100
+sDeoxysSpeedSprites71:
+ax_sprite sDeoxysSpeedGfx71, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx72:
+.incbin "baserom.gba", 0x1643E2C, 0x80
+sDeoxysSpeedSprites72:
+ax_sprite sDeoxysSpeedGfx72, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx73:
+.incbin "baserom.gba", 0x1643EBC, 0x40
+sDeoxysSpeedSprites73:
+ax_sprite sDeoxysSpeedGfx73, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx74:
+.incbin "baserom.gba", 0x1643F0C, 0x20
+sDeoxysSpeedSprites74:
+ax_sprite sDeoxysSpeedGfx74, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx75:
+.incbin "baserom.gba", 0x1643F3C, 0x20
+sDeoxysSpeedSprites75:
+ax_sprite sDeoxysSpeedGfx75, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx76:
+.incbin "baserom.gba", 0x1643F6C, 0x40
+sDeoxysSpeedGfx76_1:
+.incbin "baserom.gba", 0x1643FAC, 0x60
+sDeoxysSpeedGfx76_2:
+.incbin "baserom.gba", 0x164400C, 0x20
+sDeoxysSpeedSprites76:
+ax_sprite sDeoxysSpeedGfx76, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx76_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDeoxysSpeedGfx76_2, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx77:
+.incbin "baserom.gba", 0x164405C, 0x80
+sDeoxysSpeedSprites77:
+ax_sprite sDeoxysSpeedGfx77, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx78:
+.incbin "baserom.gba", 0x16440EC, 0x20
+sDeoxysSpeedSprites78:
+ax_sprite sDeoxysSpeedGfx78, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx79:
+.incbin "baserom.gba", 0x164411C, 0x20
+sDeoxysSpeedSprites79:
+ax_sprite sDeoxysSpeedGfx79, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx80:
+.incbin "baserom.gba", 0x164414C, 0x20
+sDeoxysSpeedSprites80:
+ax_sprite sDeoxysSpeedGfx80, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx81:
+.incbin "baserom.gba", 0x164417C, 0x100
+sDeoxysSpeedSprites81:
+ax_sprite sDeoxysSpeedGfx81, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx82:
+.incbin "baserom.gba", 0x164428C, 0x80
+sDeoxysSpeedSprites82:
+ax_sprite sDeoxysSpeedGfx82, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx83:
+.incbin "baserom.gba", 0x164431C, 0x40
+sDeoxysSpeedSprites83:
+ax_sprite sDeoxysSpeedGfx83, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx84:
+.incbin "baserom.gba", 0x164436C, 0x40
+sDeoxysSpeedSprites84:
+ax_sprite sDeoxysSpeedGfx84, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx85:
+.incbin "baserom.gba", 0x16443BC, 0x100
+sDeoxysSpeedSprites85:
+ax_sprite sDeoxysSpeedGfx85, 0x100
+ax_sprite_terminator
+sDeoxysSpeedGfx86:
+.incbin "baserom.gba", 0x16444CC, 0x80
+sDeoxysSpeedSprites86:
+ax_sprite sDeoxysSpeedGfx86, 0x80
+ax_sprite_terminator
+sDeoxysSpeedGfx87:
+.incbin "baserom.gba", 0x164455C, 0x20
+sDeoxysSpeedSprites87:
+ax_sprite sDeoxysSpeedGfx87, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx88:
+.incbin "baserom.gba", 0x164458C, 0x20
+sDeoxysSpeedSprites88:
+ax_sprite sDeoxysSpeedGfx88, 0x20
+ax_sprite_terminator
+sDeoxysSpeedGfx89:
+.incbin "baserom.gba", 0x16445BC, 0x40
+sDeoxysSpeedSprites89:
+ax_sprite sDeoxysSpeedGfx89, 0x40
+ax_sprite_terminator
+sDeoxysSpeedGfx90:
+.incbin "baserom.gba", 0x164460C, 0x200
+sDeoxysSpeedSprites90:
+ax_sprite sDeoxysSpeedGfx90, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx91:
+.incbin "baserom.gba", 0x164481C, 0x200
+sDeoxysSpeedSprites91:
+ax_sprite sDeoxysSpeedGfx91, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx92:
+.incbin "baserom.gba", 0x1644A2C, 0x200
+sDeoxysSpeedSprites92:
+ax_sprite sDeoxysSpeedGfx92, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx93:
+.incbin "baserom.gba", 0x1644C3C, 0x200
+sDeoxysSpeedSprites93:
+ax_sprite sDeoxysSpeedGfx93, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx94:
+.incbin "baserom.gba", 0x1644E4C, 0x200
+sDeoxysSpeedSprites94:
+ax_sprite sDeoxysSpeedGfx94, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx95:
+.incbin "baserom.gba", 0x164505C, 0x200
+sDeoxysSpeedSprites95:
+ax_sprite sDeoxysSpeedGfx95, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx96:
+.incbin "baserom.gba", 0x164526C, 0x200
+sDeoxysSpeedSprites96:
+ax_sprite sDeoxysSpeedGfx96, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx97:
+.incbin "baserom.gba", 0x164547C, 0x200
+sDeoxysSpeedSprites97:
+ax_sprite sDeoxysSpeedGfx97, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx98:
+.incbin "baserom.gba", 0x164568C, 0x200
+sDeoxysSpeedSprites98:
+ax_sprite sDeoxysSpeedGfx98, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx99:
+.incbin "baserom.gba", 0x164589C, 0x200
+sDeoxysSpeedSprites99:
+ax_sprite sDeoxysSpeedGfx99, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx100:
+.incbin "baserom.gba", 0x1645AAC, 0x200
+sDeoxysSpeedSprites100:
+ax_sprite sDeoxysSpeedGfx100, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx101:
+.incbin "baserom.gba", 0x1645CBC, 0x200
+sDeoxysSpeedSprites101:
+ax_sprite sDeoxysSpeedGfx101, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx102:
+.incbin "baserom.gba", 0x1645ECC, 0x200
+sDeoxysSpeedSprites102:
+ax_sprite sDeoxysSpeedGfx102, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx103:
+.incbin "baserom.gba", 0x16460DC, 0x200
+sDeoxysSpeedSprites103:
+ax_sprite sDeoxysSpeedGfx103, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx104:
+.incbin "baserom.gba", 0x16462EC, 0x200
+sDeoxysSpeedSprites104:
+ax_sprite sDeoxysSpeedGfx104, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx105:
+.incbin "baserom.gba", 0x16464FC, 0x200
+sDeoxysSpeedSprites105:
+ax_sprite sDeoxysSpeedGfx105, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx106:
+.incbin "baserom.gba", 0x164670C, 0x200
+sDeoxysSpeedSprites106:
+ax_sprite sDeoxysSpeedGfx106, 0x200
+ax_sprite_terminator
+sDeoxysSpeedGfx107:
+.incbin "baserom.gba", 0x164691C, 0x200
+sDeoxysSpeedSprites107:
+ax_sprite sDeoxysSpeedGfx107, 0x200
+ax_sprite_terminator
+sAxPosesDeoxysSpeed:
+.4byte sDeoxysSpeedPose1
+.4byte sDeoxysSpeedPose2
+.4byte sDeoxysSpeedPose3
+.4byte sDeoxysSpeedPose4
+.4byte sDeoxysSpeedPose5
+.4byte sDeoxysSpeedPose6
+.4byte sDeoxysSpeedPose7
+.4byte sDeoxysSpeedPose8
+.4byte sDeoxysSpeedPose9
+.4byte sDeoxysSpeedPose10
+.4byte sDeoxysSpeedPose11
+.4byte sDeoxysSpeedPose12
+.4byte sDeoxysSpeedPose13
+.4byte sDeoxysSpeedPose14
+.4byte sDeoxysSpeedPose15
+.4byte sDeoxysSpeedPose16
+.4byte sDeoxysSpeedPose17
+.4byte sDeoxysSpeedPose18
+.4byte sDeoxysSpeedPose19
+.4byte sDeoxysSpeedPose20
+.4byte sDeoxysSpeedPose21
+.4byte sDeoxysSpeedPose22
+.4byte sDeoxysSpeedPose23
+.4byte sDeoxysSpeedPose24
+.4byte sDeoxysSpeedPose25
+.4byte sDeoxysSpeedPose26
+.4byte sDeoxysSpeedPose27
+.4byte sDeoxysSpeedPose28
+.4byte sDeoxysSpeedPose29
+.4byte sDeoxysSpeedPose30
+.4byte sDeoxysSpeedPose31
+.4byte sDeoxysSpeedPose32
+.4byte sDeoxysSpeedPose33
+.4byte sDeoxysSpeedPose34
+.4byte sDeoxysSpeedPose35
+.4byte sDeoxysSpeedPose36
+.4byte sDeoxysSpeedPose37
+.4byte sDeoxysSpeedPose38
+.4byte sDeoxysSpeedPose39
+.4byte sDeoxysSpeedPose40
+.4byte sDeoxysSpeedPose41
+.4byte sDeoxysSpeedPose42
+.4byte sDeoxysSpeedPose43
+.4byte sDeoxysSpeedPose44
+.4byte sDeoxysSpeedPose45
+.4byte sDeoxysSpeedPose46
+.4byte sDeoxysSpeedPose47
+.4byte sDeoxysSpeedPose48
+.4byte sDeoxysSpeedPose49
+.4byte sDeoxysSpeedPose50
+.4byte sDeoxysSpeedPose51
+.4byte sDeoxysSpeedPose52
+.4byte sDeoxysSpeedPose53
+.4byte sDeoxysSpeedPose54
+.4byte sDeoxysSpeedPose55
+.4byte sDeoxysSpeedPose56
+.4byte sDeoxysSpeedPose57
+.4byte sDeoxysSpeedPose58
+.4byte sDeoxysSpeedPose59
+.4byte sDeoxysSpeedPose60
+.4byte sDeoxysSpeedPose61
+.4byte sDeoxysSpeedPose62
+.4byte sDeoxysSpeedPose63
+.4byte sDeoxysSpeedPose64
+.4byte sDeoxysSpeedPose65
+.4byte sDeoxysSpeedPose66
+.4byte sDeoxysSpeedPose67
+.4byte sDeoxysSpeedPose68
+.4byte sDeoxysSpeedPose69
+.4byte sDeoxysSpeedPose70
+.4byte sDeoxysSpeedPose71
+.4byte sDeoxysSpeedPose72
+.4byte sDeoxysSpeedPose73
+.4byte sDeoxysSpeedPose74
+.4byte sDeoxysSpeedPose75
+.4byte sDeoxysSpeedPose76
+.4byte sDeoxysSpeedPose77
+.4byte sDeoxysSpeedPose78
+.4byte sDeoxysSpeedPose79
+.4byte sDeoxysSpeedPose80
+.4byte sDeoxysSpeedPose81
+.4byte sDeoxysSpeedPose82
+.4byte sDeoxysSpeedPose83
+.4byte sDeoxysSpeedPose84
+.4byte sDeoxysSpeedPose85
+.4byte sDeoxysSpeedPose86
+.4byte sDeoxysSpeedPose87
+.4byte sDeoxysSpeedPose88
+.4byte sDeoxysSpeedPose89
+.4byte sDeoxysSpeedPose90
+.4byte sDeoxysSpeedPose91
+.4byte sDeoxysSpeedPose92
+.4byte sDeoxysSpeedPose93
+.4byte sDeoxysSpeedPose94
+.4byte sDeoxysSpeedPose95
+.4byte sDeoxysSpeedPose96
+.4byte sDeoxysSpeedPose97
+.4byte sDeoxysSpeedPose98
+.4byte sDeoxysSpeedPose99
+.4byte sDeoxysSpeedPose100
+.4byte sDeoxysSpeedPose101
+.4byte sDeoxysSpeedPose102
+.4byte sDeoxysSpeedPose103
+.4byte sDeoxysSpeedPose104
+.4byte sDeoxysSpeedPose105
+.4byte sDeoxysSpeedPose106
+.4byte sDeoxysSpeedPose107
+.4byte sDeoxysSpeedPose108
+.4byte sDeoxysSpeedPose109
+.4byte sDeoxysSpeedPose110
+.4byte sDeoxysSpeedPose111
+.4byte sDeoxysSpeedPose112
+.4byte sDeoxysSpeedPose113
+.4byte sDeoxysSpeedPose114
+.4byte sDeoxysSpeedPose115
+.4byte sDeoxysSpeedPose116
+.4byte sDeoxysSpeedPose117
+.4byte sDeoxysSpeedPose118
+.4byte sDeoxysSpeedPose119
+.4byte sDeoxysSpeedPose120
+.4byte sDeoxysSpeedPose121
+.4byte sDeoxysSpeedPose122
+.4byte sDeoxysSpeedPose123
+.4byte sDeoxysSpeedPose124
+.4byte sDeoxysSpeedPose125
+.4byte sDeoxysSpeedPose126
+.4byte sDeoxysSpeedPose127
+.4byte sDeoxysSpeedPose128
+.4byte sDeoxysSpeedPose129
+.4byte sDeoxysSpeedPose130
+.4byte sDeoxysSpeedPose131
+.4byte sDeoxysSpeedPose132
+.4byte sDeoxysSpeedPose133
+.4byte sDeoxysSpeedPose134
+.4byte sDeoxysSpeedPose135
+.4byte sDeoxysSpeedPose136
+.4byte sDeoxysSpeedPose137
+.4byte sDeoxysSpeedPose138
+.4byte sDeoxysSpeedPose139
+.4byte sDeoxysSpeedPose140
+.4byte sDeoxysSpeedPose141
+.4byte sDeoxysSpeedPose142
+.4byte sDeoxysSpeedPose143
+.4byte sDeoxysSpeedPose144
+.4byte sDeoxysSpeedPose145
+.4byte sDeoxysSpeedPose146
+.4byte sDeoxysSpeedPose147
+.4byte sDeoxysSpeedPose148
+.4byte sDeoxysSpeedPose149
+.4byte sDeoxysSpeedPose150
+.4byte sDeoxysSpeedPose151
+.4byte sDeoxysSpeedPose152
+.4byte sDeoxysSpeedPose153
+.4byte sDeoxysSpeedPose154
+.4byte sDeoxysSpeedPose155
+.4byte sDeoxysSpeedPose156
+.4byte sDeoxysSpeedPose157
+.4byte sDeoxysSpeedPose158
+.4byte sDeoxysSpeedPose159
+.4byte sDeoxysSpeedPose160
+.4byte sDeoxysSpeedPose161
+.4byte sDeoxysSpeedPose162
+.4byte sDeoxysSpeedPose163
+.4byte sDeoxysSpeedPose164
+.4byte sDeoxysSpeedPose165
+.4byte sDeoxysSpeedPose166
+.4byte sDeoxysSpeedPose167
+.4byte sDeoxysSpeedPose168
+.4byte sDeoxysSpeedPose169
+.4byte sDeoxysSpeedPose170
+.4byte sDeoxysSpeedPose171
+.4byte sDeoxysSpeedPose172
+.4byte sDeoxysSpeedPose173
+.4byte sDeoxysSpeedPose174
+.4byte sDeoxysSpeedPose175
+.4byte sDeoxysSpeedPose176
+.4byte sDeoxysSpeedPose177
+.4byte sDeoxysSpeedPose178
+.4byte sDeoxysSpeedPose179
+.4byte sDeoxysSpeedPose180
+.4byte sDeoxysSpeedPose181
+.4byte sDeoxysSpeedPose182
+.4byte sDeoxysSpeedPose183
+.4byte sDeoxysSpeedPose184
+.4byte sDeoxysSpeedPose185
+.4byte sDeoxysSpeedPose186
+.4byte sDeoxysSpeedPose187
+.4byte sDeoxysSpeedPose188
+.4byte sDeoxysSpeedPose189
+.4byte sDeoxysSpeedPose190
+.4byte sDeoxysSpeedPose191
+.4byte sDeoxysSpeedPose192
+.4byte sDeoxysSpeedPose193
+.4byte sDeoxysSpeedPose194
+.4byte sDeoxysSpeedPose195
+.4byte sDeoxysSpeedPose196
+.4byte sDeoxysSpeedPose197
+.4byte sDeoxysSpeedPose198
+.4byte sDeoxysSpeedPose199
+.4byte sDeoxysSpeedPose200
+.4byte sDeoxysSpeedPose201
+.4byte sDeoxysSpeedPose202
+.4byte sDeoxysSpeedPose203
+.4byte sDeoxysSpeedPose204
+.4byte sDeoxysSpeedPose205
+.4byte sDeoxysSpeedPose206
+.4byte sDeoxysSpeedPose207
+.4byte sDeoxysSpeedPose208
+.4byte sDeoxysSpeedPose209
+.4byte sDeoxysSpeedPose210
+.4byte sDeoxysSpeedPose211
+.4byte sDeoxysSpeedPose212
+.4byte sDeoxysSpeedPose213
+.4byte sDeoxysSpeedPose214
+.4byte sDeoxysSpeedPose215
+.4byte sDeoxysSpeedPose216
+.4byte sDeoxysSpeedPose217
+.4byte sDeoxysSpeedPose218
+.4byte sDeoxysSpeedPose219
+.4byte sDeoxysSpeedPose220
+.4byte sDeoxysSpeedPose221
+.4byte sDeoxysSpeedPose222
+.4byte sDeoxysSpeedPose223
+.4byte sDeoxysSpeedPose224
+.4byte sDeoxysSpeedPose225
+.4byte sDeoxysSpeedPose226
+.4byte sDeoxysSpeedPose227
+.4byte sDeoxysSpeedPose228
+.4byte sDeoxysSpeedPose229
+.4byte sDeoxysSpeedPose230
+.4byte sDeoxysSpeedPose231
+.4byte sDeoxysSpeedPose232
+.4byte sDeoxysSpeedPose233
+.4byte sDeoxysSpeedPose234
+.4byte sDeoxysSpeedPose235
+.4byte sDeoxysSpeedPose236
+.4byte sDeoxysSpeedPose237
+.4byte sDeoxysSpeedPose238
+.4byte sDeoxysSpeedPose239
+.4byte sDeoxysSpeedPose240
+.4byte sDeoxysSpeedPose241
+.4byte sDeoxysSpeedPose242
+sAxPositionsDeoxysSpeed:
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    6,  -16, 	   0,   -2, 	  10,   -8, 	   3,  -15
+.2byte    6,  -16, 	   0,   -2, 	  10,   -8, 	   3,  -15
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte   -5,  -16, 	 -10,   -8, 	   0,   -2, 	  -2,  -14
+.2byte   -5,  -16, 	 -10,   -8, 	   0,   -2, 	  -2,  -14
+.2byte   -5,  -16, 	 -12,   -2, 	  10,   -2, 	  -3,  -13
+.2byte   -5,  -16, 	 -12,   -2, 	  11,   -2, 	  -3,  -13
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte    0,  -14, 	 -10,    0, 	  12,   -6, 	   0,  -12
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    4,  -15, 	 -13,   -4, 	  13,   -2, 	   2,  -14
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    5,  -17, 	 -12,   -1, 	  12,   -4, 	   3,  -15
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    6,  -17, 	  -2,    0, 	   8,   -8, 	   2,  -16
+.2byte    6,  -16, 	   0,   -2, 	  10,   -8, 	   3,  -15
+.2byte    6,  -16, 	   0,   -2, 	  10,   -8, 	   3,  -15
+.2byte    0,  -18, 	   8,   -7, 	 -11,   -3, 	   0,  -15
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte   -4,  -17, 	  -7,   -8, 	   3,    0, 	  -1,  -15
+.2byte   -5,  -16, 	 -10,   -8, 	   0,   -2, 	  -2,  -14
+.2byte   -5,  -16, 	 -10,   -8, 	   0,   -2, 	  -2,  -14
+.2byte   -4,  -17, 	 -11,   -4, 	  12,   -1, 	  -2,  -14
+.2byte   -5,  -16, 	 -12,   -2, 	  10,   -2, 	  -3,  -13
+.2byte   -5,  -16, 	 -12,   -2, 	  11,   -2, 	  -3,  -13
+.2byte   -3,  -15, 	 -12,   -2, 	  14,   -4, 	  -1,  -14
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte    0,  -14, 	 -10,    0, 	  12,   -6, 	   0,  -12
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    4,  -15, 	 -13,   -4, 	  13,   -2, 	   2,  -14
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    5,  -17, 	 -12,   -1, 	  12,   -4, 	   3,  -15
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    6,  -17, 	  -2,    0, 	   8,   -8, 	   2,  -16
+.2byte    6,  -16, 	   0,   -2, 	  10,   -8, 	   3,  -15
+.2byte    6,  -16, 	   0,   -2, 	  10,   -8, 	   3,  -15
+.2byte    0,  -18, 	   8,   -7, 	 -11,   -3, 	   0,  -15
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte   -4,  -17, 	  -7,   -8, 	   3,    0, 	  -1,  -15
+.2byte   -5,  -16, 	 -10,   -8, 	   0,   -2, 	  -2,  -14
+.2byte   -5,  -16, 	 -10,   -8, 	   0,   -2, 	  -2,  -14
+.2byte   -4,  -17, 	 -11,   -4, 	  12,   -1, 	  -2,  -14
+.2byte   -5,  -16, 	 -12,   -2, 	  10,   -2, 	  -3,  -13
+.2byte   -5,  -16, 	 -12,   -2, 	  11,   -2, 	  -3,  -13
+.2byte   -3,  -15, 	 -12,   -2, 	  14,   -4, 	  -1,  -14
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte    0,  -14, 	 -10,    0, 	  12,   -6, 	   0,  -12
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte    0,  -17, 	 -13,  -12, 	  12,  -11, 	   0,  -16
+.2byte    4,  -15, 	 -13,   -4, 	  13,   -2, 	   2,  -14
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    4,  -14, 	 -12,   -3, 	  11,   -2, 	   2,  -13
+.2byte    2,  -17, 	 -16,  -10, 	  -4,  -14, 	  -1,  -16
+.2byte    5,  -17, 	 -12,   -1, 	  12,   -4, 	   3,  -15
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    5,  -16, 	 -11,   -2, 	  12,   -2, 	   3,  -15
+.2byte    5,  -17, 	 -14,   -5, 	  -7,  -12, 	   2,  -16
+.2byte    6,  -17, 	  -2,    0, 	   8,   -8, 	   2,  -16
+.2byte    5,  -16, 	  -1,   -2, 	   9,   -8, 	   2,  -15
+.2byte    5,  -16, 	  -1,   -2, 	   9,   -8, 	   2,  -15
+.2byte    4,  -16, 	  -5,    1, 	 -14,   -4, 	   1,  -14
+.2byte    0,  -18, 	   8,   -7, 	 -11,   -3, 	   0,  -15
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte    0,  -17, 	  13,   -6, 	 -13,   -6, 	   0,  -14
+.2byte   -4,  -17, 	  -7,   -8, 	   3,    0, 	  -1,  -15
+.2byte   -4,  -16, 	  -9,   -8, 	   1,   -2, 	  -1,  -14
+.2byte   -4,  -16, 	  -9,   -8, 	   1,   -2, 	  -1,  -14
+.2byte   -3,  -16, 	  15,   -4, 	   6,    1, 	  -1,  -14
+.2byte   -4,  -17, 	 -11,   -4, 	  12,   -1, 	  -2,  -14
+.2byte   -5,  -16, 	 -12,   -2, 	  10,   -2, 	  -3,  -13
+.2byte   -5,  -16, 	 -12,   -2, 	  11,   -2, 	  -3,  -13
+.2byte   -4,  -17, 	   8,  -12, 	  15,   -5, 	  -1,  -16
+.2byte   -3,  -15, 	 -12,   -2, 	  14,   -4, 	  -1,  -14
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte   -4,  -14, 	 -11,   -1, 	  11,   -3, 	  -2,  -13
+.2byte   -3,  -17, 	   3,  -14, 	  15,  -10, 	   0,  -16
+.2byte    0,  -14, 	 -10,    0, 	  12,   -6, 	   0,  -12
+.2byte    0,  -16, 	 -11,    0, 	  13,   -7, 	   0,  -15
+.2byte    0,  -16, 	 -11,    0, 	  13,   -7, 	   0,  -15
+.2byte    0,  -16, 	 -11,    0, 	  13,   -7, 	   0,  -15
+.2byte    0,  -16, 	 -11,    0, 	  13,   -7, 	   0,  -15
+.2byte    0,  -16, 	 -11,    0, 	  13,   -7, 	   0,  -15
+.2byte    0,  -16, 	 -11,    0, 	  13,   -7, 	   0,  -15
+.2byte    0,  -16, 	 -11,    0, 	  13,   -7, 	   0,  -15
+.2byte    4,  -15, 	 -13,   -4, 	  13,   -2, 	   2,  -14
+.2byte    4,  -17, 	 -15,   -4, 	  14,   -2, 	   2,  -15
+.2byte    4,  -17, 	 -15,   -4, 	  14,   -2, 	   2,  -15
+.2byte    4,  -17, 	 -15,   -4, 	  14,   -2, 	   2,  -15
+.2byte    4,  -17, 	 -15,   -4, 	  14,   -2, 	   2,  -15
+.2byte    4,  -17, 	 -15,   -4, 	  14,   -2, 	   2,  -15
+.2byte    4,  -17, 	 -15,   -4, 	  14,   -2, 	   2,  -15
+.2byte    4,  -17, 	 -15,   -4, 	  14,   -2, 	   2,  -15
+.2byte    5,  -17, 	 -12,   -1, 	  12,   -4, 	   3,  -15
+.2byte    5,  -19, 	 -13,   -1, 	  13,   -4, 	   3,  -17
+.2byte    5,  -19, 	 -13,   -1, 	  13,   -4, 	   3,  -17
+.2byte    5,  -19, 	 -13,   -1, 	  13,   -4, 	   3,  -17
+.2byte    5,  -19, 	 -13,   -1, 	  13,   -4, 	   3,  -17
+.2byte    5,  -19, 	 -13,   -1, 	  13,   -4, 	   3,  -17
+.2byte    5,  -19, 	 -13,   -1, 	  13,   -4, 	   3,  -17
+.2byte    5,  -19, 	 -13,   -1, 	  13,   -4, 	   3,  -17
+.2byte    6,  -17, 	  -2,    0, 	   8,   -8, 	   2,  -16
+.2byte    7,  -19, 	  -2,   -1, 	   8,   -9, 	   2,  -17
+.2byte    7,  -19, 	  -2,   -1, 	   8,   -9, 	   2,  -17
+.2byte    7,  -19, 	  -2,   -1, 	   8,   -9, 	   2,  -17
+.2byte    7,  -19, 	  -2,   -1, 	   8,   -9, 	   2,  -17
+.2byte    7,  -19, 	  -2,   -1, 	   8,   -9, 	   2,  -17
+.2byte    7,  -19, 	  -2,   -1, 	   8,   -9, 	   2,  -17
+.2byte    7,  -19, 	  -2,   -1, 	   8,   -9, 	   2,  -17
+.2byte    0,  -18, 	   8,   -7, 	 -11,   -3, 	   0,  -15
+.2byte    0,  -19, 	   9,   -8, 	 -13,   -3, 	   0,  -17
+.2byte    0,  -19, 	   9,   -8, 	 -13,   -3, 	   0,  -17
+.2byte    0,  -19, 	   9,   -8, 	 -13,   -3, 	   0,  -17
+.2byte    0,  -19, 	   9,   -8, 	 -13,   -3, 	   0,  -17
+.2byte    0,  -19, 	   9,   -8, 	 -13,   -3, 	   0,  -17
+.2byte    0,  -19, 	   9,   -8, 	 -13,   -3, 	   0,  -17
+.2byte    0,  -19, 	   9,   -8, 	 -13,   -3, 	   0,  -17
+.2byte   -5,  -17, 	  -8,   -8, 	   2,    0, 	  -2,  -15
+.2byte   -7,  -19, 	  -8,   -9, 	   2,   -1, 	  -2,  -17
+.2byte   -7,  -19, 	  -8,   -9, 	   2,   -1, 	  -2,  -17
+.2byte   -7,  -19, 	  -8,   -9, 	   2,   -1, 	  -2,  -17
+.2byte   -7,  -19, 	  -8,   -9, 	   2,   -1, 	  -2,  -17
+.2byte   -7,  -19, 	  -8,   -9, 	   2,   -1, 	  -2,  -17
+.2byte   -7,  -19, 	  -8,   -9, 	   2,   -1, 	  -2,  -17
+.2byte   -7,  -19, 	  -8,   -9, 	   2,   -1, 	  -2,  -17
+.2byte   -5,  -17, 	 -12,   -4, 	  11,   -1, 	  -3,  -14
+.2byte   -5,  -19, 	 -13,   -4, 	  13,   -1, 	  -3,  -17
+.2byte   -5,  -19, 	 -13,   -4, 	  13,   -1, 	  -3,  -17
+.2byte   -5,  -19, 	 -13,   -4, 	  13,   -1, 	  -3,  -17
+.2byte   -5,  -19, 	 -13,   -4, 	  13,   -1, 	  -3,  -17
+.2byte   -5,  -19, 	 -13,   -4, 	  13,   -1, 	  -3,  -17
+.2byte   -5,  -19, 	 -13,   -4, 	  13,   -1, 	  -3,  -17
+.2byte   -5,  -19, 	 -13,   -4, 	  13,   -1, 	  -3,  -17
+.2byte   -4,  -15, 	 -13,   -2, 	  13,   -4, 	  -2,  -14
+.2byte   -4,  -17, 	 -14,   -2, 	  15,   -4, 	  -2,  -16
+.2byte   -4,  -17, 	 -14,   -2, 	  15,   -4, 	  -2,  -16
+.2byte   -4,  -17, 	 -14,   -2, 	  15,   -4, 	  -2,  -16
+.2byte   -4,  -17, 	 -14,   -2, 	  15,   -4, 	  -2,  -16
+.2byte   -4,  -17, 	 -14,   -2, 	  15,   -4, 	  -2,  -16
+.2byte   -4,  -17, 	 -14,   -2, 	  15,   -4, 	  -2,  -16
+.2byte   -4,  -17, 	 -14,   -2, 	  15,   -4, 	  -2,  -16
+.2byte   -4,  -15, 	 -10,   -2, 	   7,   -1, 	  -1,  -15
+.2byte   -4,  -15, 	 -10,   -1, 	   7,    0, 	  -1,  -15
+.2byte   -1,  -14, 	  -3,  -15, 	   3,  -15, 	  -1,  -13
+.2byte    2,  -15, 	   1,  -14, 	   6,  -16, 	   0,  -15
+.2byte    2,  -16, 	   6,  -15, 	   9,  -16, 	  -1,  -15
+.2byte    4,  -15, 	   9,  -16, 	   6,  -17, 	   0,  -14
+.2byte   -1,  -14, 	   0,  -17, 	  -4,  -17, 	  -1,  -13
+.2byte   -5,  -15, 	  -7,  -17, 	 -10,  -16, 	  -1,  -14
+.2byte   -3,  -16, 	 -10,  -16, 	  -7,  -15, 	   0,  -15
+.2byte   -3,  -14, 	  -7,  -16, 	  -2,  -14, 	  -1,  -15
+.2byte    0,  -14, 	 -10,    0, 	  12,   -6, 	   0,  -12
+.2byte   -4,  -15, 	 -13,   -2, 	  13,   -4, 	  -2,  -14
+.2byte   -5,  -17, 	 -12,   -4, 	  11,   -1, 	  -3,  -14
+.2byte   -5,  -17, 	  -8,   -8, 	   2,    0, 	  -2,  -15
+.2byte    0,  -18, 	   8,   -7, 	 -11,   -3, 	   0,  -15
+.2byte    6,  -17, 	  -2,    0, 	   8,   -8, 	   2,  -16
+.2byte    5,  -17, 	 -12,   -1, 	  12,   -4, 	   3,  -15
+.2byte    4,  -15, 	 -13,   -4, 	  13,   -2, 	   2,  -14
+.2byte    0,  -12, 	 -11,    0, 	  14,   -5, 	   0,  -10
+.2byte   -4,  -13, 	 -12,   -2, 	  14,   -5, 	  -2,  -12
+.2byte   -5,  -15, 	 -12,   -5, 	  13,   -2, 	  -3,  -12
+.2byte   -5,  -15, 	  -8,   -9, 	   2,   -1, 	  -2,  -13
+.2byte    0,  -16, 	   8,   -8, 	 -12,   -3, 	   0,  -13
+.2byte    6,  -15, 	  -2,   -1, 	   8,   -9, 	   3,  -14
+.2byte    5,  -15, 	 -13,   -2, 	  12,   -5, 	   2,  -14
+.2byte    4,  -13, 	 -14,   -5, 	  12,   -2, 	   2,  -12
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte   -3,  -14, 	 -10,   -1, 	  12,   -3, 	  -1,  -13
+.2byte   -3,  -16, 	 -10,   -2, 	  12,   -2, 	  -1,  -13
+.2byte   -2,  -16, 	  -7,   -8, 	   3,   -2, 	   1,  -14
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte    3,  -16, 	  -3,   -2, 	   7,   -8, 	   0,  -15
+.2byte    3,  -16, 	 -13,   -2, 	  10,   -2, 	   1,  -15
+.2byte    3,  -14, 	 -13,   -3, 	  10,   -2, 	   1,  -13
+.2byte    0,  -17, 	 -13,  -12, 	  12,  -11, 	   0,  -16
+.2byte    3,  -17, 	 -15,  -10, 	  -3,  -14, 	   0,  -16
+.2byte    4,  -17, 	 -15,   -5, 	  -8,  -12, 	   1,  -16
+.2byte    4,  -17, 	  -5,    0, 	 -14,   -5, 	   1,  -15
+.2byte    0,  -17, 	  13,   -6, 	 -13,   -6, 	   0,  -14
+.2byte   -4,  -17, 	  14,   -5, 	   5,    0, 	  -2,  -15
+.2byte   -4,  -17, 	   8,  -12, 	  15,   -5, 	  -1,  -16
+.2byte   -3,  -17, 	   3,  -14, 	  15,  -10, 	   0,  -16
+.2byte    0,  -14, 	 -10,    0, 	  12,   -6, 	   0,  -12
+.2byte    0,  -17, 	 -13,  -12, 	  12,  -11, 	   0,  -16
+.2byte    0,  -12, 	 -11,    0, 	  14,   -5, 	   0,  -10
+.2byte    4,  -15, 	 -13,   -4, 	  13,   -2, 	   2,  -14
+.2byte    4,  -17, 	 -14,  -10, 	  -2,  -14, 	   1,  -16
+.2byte    4,  -13, 	 -14,   -5, 	  12,   -2, 	   2,  -12
+.2byte    5,  -17, 	 -12,   -1, 	  12,   -4, 	   3,  -15
+.2byte    5,  -17, 	 -14,   -5, 	  -7,  -12, 	   2,  -16
+.2byte    5,  -15, 	 -13,   -2, 	  12,   -5, 	   2,  -14
+.2byte    6,  -17, 	  -2,    0, 	   8,   -8, 	   2,  -16
+.2byte    6,  -16, 	  -3,    1, 	 -12,   -4, 	   3,  -14
+.2byte    6,  -15, 	  -2,   -1, 	   8,   -9, 	   3,  -14
+.2byte    0,  -18, 	   8,   -7, 	 -11,   -3, 	   0,  -15
+.2byte    0,  -17, 	  13,   -6, 	 -13,   -6, 	   0,  -14
+.2byte    0,  -16, 	   8,   -8, 	 -12,   -3, 	   0,  -13
+.2byte   -4,  -17, 	  -7,   -8, 	   3,    0, 	  -1,  -15
+.2byte   -5,  -16, 	  13,   -4, 	   4,    1, 	  -3,  -14
+.2byte   -5,  -15, 	  -8,   -9, 	   2,   -1, 	  -2,  -13
+.2byte   -4,  -17, 	 -11,   -4, 	  12,   -1, 	  -2,  -14
+.2byte   -4,  -17, 	   8,  -12, 	  15,   -5, 	  -1,  -16
+.2byte   -4,  -15, 	 -11,   -5, 	  14,   -2, 	  -2,  -12
+.2byte   -3,  -15, 	 -12,   -2, 	  14,   -4, 	  -1,  -14
+.2byte   -4,  -17, 	   2,  -14, 	  14,  -10, 	  -1,  -16
+.2byte   -4,  -13, 	 -12,   -2, 	  14,   -5, 	  -2,  -12
+.2byte    0,  -11, 	  -9,    0, 	  11,   -5, 	   0,  -10
+.2byte   -3,  -14, 	 -10,   -1, 	  12,   -3, 	  -1,  -13
+.2byte   -3,  -16, 	 -10,   -2, 	  12,   -2, 	  -1,  -13
+.2byte   -2,  -16, 	  -7,   -8, 	   3,   -2, 	   1,  -14
+.2byte    0,  -17, 	   7,   -8, 	 -12,   -5, 	   0,  -14
+.2byte    3,  -16, 	  -3,   -2, 	   7,   -8, 	   0,  -15
+.2byte    3,  -16, 	 -13,   -2, 	  10,   -2, 	   1,  -15
+.2byte    3,  -14, 	 -13,   -3, 	  10,   -2, 	   1,  -13
+.2byte    0,  -14, 	 -10,    0, 	  12,   -6, 	   0,  -12
+.2byte   -4,  -15, 	 -13,   -2, 	  13,   -4, 	  -2,  -14
+.2byte   -5,  -17, 	 -12,   -4, 	  11,   -1, 	  -3,  -14
+.2byte   -5,  -17, 	  -8,   -8, 	   2,    0, 	  -2,  -15
+.2byte    0,  -18, 	   8,   -7, 	 -11,   -3, 	   0,  -15
+.2byte    6,  -17, 	  -2,    0, 	   8,   -8, 	   2,  -16
+.2byte    5,  -17, 	 -12,   -1, 	  12,   -4, 	   3,  -15
+.2byte    4,  -15, 	 -13,   -4, 	  13,   -2, 	   2,  -14
+sDeoxysSpeedAnimTable1:
+.4byte sDeoxysSpeedAnims_1_1
+.4byte sDeoxysSpeedAnims_1_2
+.4byte sDeoxysSpeedAnims_1_3
+.4byte sDeoxysSpeedAnims_1_4
+.4byte sDeoxysSpeedAnims_1_5
+.4byte sDeoxysSpeedAnims_1_6
+.4byte sDeoxysSpeedAnims_1_7
+.4byte sDeoxysSpeedAnims_1_8
+sDeoxysSpeedAnimTable2:
+.4byte sDeoxysSpeedAnims_2_1
+.4byte sDeoxysSpeedAnims_2_2
+.4byte sDeoxysSpeedAnims_2_3
+.4byte sDeoxysSpeedAnims_2_4
+.4byte sDeoxysSpeedAnims_2_5
+.4byte sDeoxysSpeedAnims_2_6
+.4byte sDeoxysSpeedAnims_2_7
+.4byte sDeoxysSpeedAnims_2_8
+sDeoxysSpeedAnimTable3:
+.4byte sDeoxysSpeedAnims_3_1
+.4byte sDeoxysSpeedAnims_3_2
+.4byte sDeoxysSpeedAnims_3_3
+.4byte sDeoxysSpeedAnims_3_4
+.4byte sDeoxysSpeedAnims_3_5
+.4byte sDeoxysSpeedAnims_3_6
+.4byte sDeoxysSpeedAnims_3_7
+.4byte sDeoxysSpeedAnims_3_8
+sDeoxysSpeedAnimTable4:
+.4byte sDeoxysSpeedAnims_4_1
+.4byte sDeoxysSpeedAnims_4_2
+.4byte sDeoxysSpeedAnims_4_3
+.4byte sDeoxysSpeedAnims_4_4
+.4byte sDeoxysSpeedAnims_4_5
+.4byte sDeoxysSpeedAnims_4_6
+.4byte sDeoxysSpeedAnims_4_7
+.4byte sDeoxysSpeedAnims_4_8
+sDeoxysSpeedAnimTable5:
+.4byte sDeoxysSpeedAnims_5_1
+.4byte sDeoxysSpeedAnims_5_2
+.4byte sDeoxysSpeedAnims_5_3
+.4byte sDeoxysSpeedAnims_5_4
+.4byte sDeoxysSpeedAnims_5_5
+.4byte sDeoxysSpeedAnims_5_6
+.4byte sDeoxysSpeedAnims_5_7
+.4byte sDeoxysSpeedAnims_5_8
+sDeoxysSpeedAnimTable6:
+.4byte sDeoxysSpeedAnims_6_1
+.4byte sDeoxysSpeedAnims_6_1
+.4byte sDeoxysSpeedAnims_6_1
+.4byte sDeoxysSpeedAnims_6_1
+.4byte sDeoxysSpeedAnims_6_1
+.4byte sDeoxysSpeedAnims_6_1
+.4byte sDeoxysSpeedAnims_6_1
+.4byte sDeoxysSpeedAnims_6_1
+sDeoxysSpeedAnimTable7:
+.4byte sDeoxysSpeedAnims_7_1
+.4byte sDeoxysSpeedAnims_7_2
+.4byte sDeoxysSpeedAnims_7_3
+.4byte sDeoxysSpeedAnims_7_4
+.4byte sDeoxysSpeedAnims_7_5
+.4byte sDeoxysSpeedAnims_7_6
+.4byte sDeoxysSpeedAnims_7_7
+.4byte sDeoxysSpeedAnims_7_8
+sDeoxysSpeedAnimTable8:
+.4byte sDeoxysSpeedAnims_8_1
+.4byte sDeoxysSpeedAnims_8_2
+.4byte sDeoxysSpeedAnims_8_3
+.4byte sDeoxysSpeedAnims_8_4
+.4byte sDeoxysSpeedAnims_8_5
+.4byte sDeoxysSpeedAnims_8_6
+.4byte sDeoxysSpeedAnims_8_7
+.4byte sDeoxysSpeedAnims_8_8
+sDeoxysSpeedAnimTable9:
+.4byte sDeoxysSpeedAnims_9_1
+.4byte sDeoxysSpeedAnims_9_2
+.4byte sDeoxysSpeedAnims_9_3
+.4byte sDeoxysSpeedAnims_9_4
+.4byte sDeoxysSpeedAnims_9_5
+.4byte sDeoxysSpeedAnims_9_6
+.4byte sDeoxysSpeedAnims_9_7
+.4byte sDeoxysSpeedAnims_9_8
+sDeoxysSpeedAnimTable10:
+.4byte sDeoxysSpeedAnims_10_1
+.4byte sDeoxysSpeedAnims_10_2
+.4byte sDeoxysSpeedAnims_10_3
+.4byte sDeoxysSpeedAnims_10_4
+.4byte sDeoxysSpeedAnims_10_5
+.4byte sDeoxysSpeedAnims_10_6
+.4byte sDeoxysSpeedAnims_10_7
+.4byte sDeoxysSpeedAnims_10_8
+sDeoxysSpeedAnimTable11:
+.4byte sDeoxysSpeedAnims_11_1
+.4byte sDeoxysSpeedAnims_11_2
+.4byte sDeoxysSpeedAnims_11_3
+.4byte sDeoxysSpeedAnims_11_4
+.4byte sDeoxysSpeedAnims_11_5
+.4byte sDeoxysSpeedAnims_11_6
+.4byte sDeoxysSpeedAnims_11_7
+.4byte sDeoxysSpeedAnims_11_8
+sDeoxysSpeedAnimTable12:
+.4byte sDeoxysSpeedAnims_12_1
+.4byte sDeoxysSpeedAnims_12_2
+.4byte sDeoxysSpeedAnims_12_3
+.4byte sDeoxysSpeedAnims_12_4
+.4byte sDeoxysSpeedAnims_12_5
+.4byte sDeoxysSpeedAnims_12_6
+.4byte sDeoxysSpeedAnims_12_7
+.4byte sDeoxysSpeedAnims_12_8
+sDeoxysSpeedAnimTable13:
+.4byte sDeoxysSpeedAnims_13_1
+.4byte sDeoxysSpeedAnims_13_2
+.4byte sDeoxysSpeedAnims_13_3
+.4byte sDeoxysSpeedAnims_13_4
+.4byte sDeoxysSpeedAnims_13_5
+.4byte sDeoxysSpeedAnims_13_6
+.4byte sDeoxysSpeedAnims_13_7
+.4byte sDeoxysSpeedAnims_13_8
+sAxAnimationsDeoxysSpeed:
+.4byte sDeoxysSpeedAnimTable1
+.4byte sDeoxysSpeedAnimTable2
+.4byte sDeoxysSpeedAnimTable3
+.4byte sDeoxysSpeedAnimTable4
+.4byte sDeoxysSpeedAnimTable5
+.4byte sDeoxysSpeedAnimTable6
+.4byte sDeoxysSpeedAnimTable7
+.4byte sDeoxysSpeedAnimTable8
+.4byte sDeoxysSpeedAnimTable9
+.4byte sDeoxysSpeedAnimTable10
+.4byte sDeoxysSpeedAnimTable11
+.4byte sDeoxysSpeedAnimTable12
+.4byte sDeoxysSpeedAnimTable13
+sAxSpritesDeoxysSpeed:
+.4byte sDeoxysSpeedSprites1
+.4byte sDeoxysSpeedSprites2
+.4byte sDeoxysSpeedSprites3
+.4byte sDeoxysSpeedSprites4
+.4byte sDeoxysSpeedSprites5
+.4byte sDeoxysSpeedSprites6
+.4byte sDeoxysSpeedSprites7
+.4byte sDeoxysSpeedSprites8
+.4byte sDeoxysSpeedSprites9
+.4byte sDeoxysSpeedSprites10
+.4byte sDeoxysSpeedSprites11
+.4byte sDeoxysSpeedSprites12
+.4byte sDeoxysSpeedSprites13
+.4byte sDeoxysSpeedSprites14
+.4byte sDeoxysSpeedSprites15
+.4byte sDeoxysSpeedSprites16
+.4byte sDeoxysSpeedSprites17
+.4byte sDeoxysSpeedSprites18
+.4byte sDeoxysSpeedSprites19
+.4byte sDeoxysSpeedSprites20
+.4byte sDeoxysSpeedSprites21
+.4byte sDeoxysSpeedSprites22
+.4byte sDeoxysSpeedSprites23
+.4byte sDeoxysSpeedSprites24
+.4byte sDeoxysSpeedSprites25
+.4byte sDeoxysSpeedSprites26
+.4byte sDeoxysSpeedSprites27
+.4byte sDeoxysSpeedSprites28
+.4byte sDeoxysSpeedSprites29
+.4byte sDeoxysSpeedSprites30
+.4byte sDeoxysSpeedSprites31
+.4byte sDeoxysSpeedSprites32
+.4byte sDeoxysSpeedSprites33
+.4byte sDeoxysSpeedSprites34
+.4byte sDeoxysSpeedSprites35
+.4byte sDeoxysSpeedSprites36
+.4byte sDeoxysSpeedSprites37
+.4byte sDeoxysSpeedSprites38
+.4byte sDeoxysSpeedSprites39
+.4byte sDeoxysSpeedSprites40
+.4byte sDeoxysSpeedSprites41
+.4byte sDeoxysSpeedSprites42
+.4byte sDeoxysSpeedSprites43
+.4byte sDeoxysSpeedSprites44
+.4byte sDeoxysSpeedSprites45
+.4byte sDeoxysSpeedSprites46
+.4byte sDeoxysSpeedSprites47
+.4byte sDeoxysSpeedSprites48
+.4byte sDeoxysSpeedSprites49
+.4byte sDeoxysSpeedSprites50
+.4byte sDeoxysSpeedSprites51
+.4byte sDeoxysSpeedSprites52
+.4byte sDeoxysSpeedSprites53
+.4byte sDeoxysSpeedSprites54
+.4byte sDeoxysSpeedSprites55
+.4byte sDeoxysSpeedSprites56
+.4byte sDeoxysSpeedSprites57
+.4byte sDeoxysSpeedSprites58
+.4byte sDeoxysSpeedSprites59
+.4byte sDeoxysSpeedSprites60
+.4byte sDeoxysSpeedSprites61
+.4byte sDeoxysSpeedSprites62
+.4byte sDeoxysSpeedSprites63
+.4byte sDeoxysSpeedSprites64
+.4byte sDeoxysSpeedSprites65
+.4byte sDeoxysSpeedSprites66
+.4byte sDeoxysSpeedSprites67
+.4byte sDeoxysSpeedSprites68
+.4byte sDeoxysSpeedSprites69
+.4byte sDeoxysSpeedSprites70
+.4byte sDeoxysSpeedSprites71
+.4byte sDeoxysSpeedSprites72
+.4byte sDeoxysSpeedSprites73
+.4byte sDeoxysSpeedSprites74
+.4byte sDeoxysSpeedSprites75
+.4byte sDeoxysSpeedSprites76
+.4byte sDeoxysSpeedSprites77
+.4byte sDeoxysSpeedSprites78
+.4byte sDeoxysSpeedSprites79
+.4byte sDeoxysSpeedSprites80
+.4byte sDeoxysSpeedSprites81
+.4byte sDeoxysSpeedSprites82
+.4byte sDeoxysSpeedSprites83
+.4byte sDeoxysSpeedSprites84
+.4byte sDeoxysSpeedSprites85
+.4byte sDeoxysSpeedSprites86
+.4byte sDeoxysSpeedSprites87
+.4byte sDeoxysSpeedSprites88
+.4byte sDeoxysSpeedSprites89
+.4byte sDeoxysSpeedSprites90
+.4byte sDeoxysSpeedSprites91
+.4byte sDeoxysSpeedSprites92
+.4byte sDeoxysSpeedSprites93
+.4byte sDeoxysSpeedSprites94
+.4byte sDeoxysSpeedSprites95
+.4byte sDeoxysSpeedSprites96
+.4byte sDeoxysSpeedSprites97
+.4byte sDeoxysSpeedSprites98
+.4byte sDeoxysSpeedSprites99
+.4byte sDeoxysSpeedSprites100
+.4byte sDeoxysSpeedSprites101
+.4byte sDeoxysSpeedSprites102
+.4byte sDeoxysSpeedSprites103
+.4byte sDeoxysSpeedSprites104
+.4byte sDeoxysSpeedSprites105
+.4byte sDeoxysSpeedSprites106
+.4byte sDeoxysSpeedSprites107
+sAxMainDeoxysSpeed:
+ax_main sAxPosesDeoxysSpeed, sAxAnimationsDeoxysSpeed, 13, sAxSpritesDeoxysSpeed, sAxPositionsDeoxysSpeed

--- a/data/ax/dewgong.inc
+++ b/data/ax/dewgong.inc
@@ -1,0 +1,2689 @@
+.global gAxDewgong
+gAxDewgong:
+ax_siro sAxMainDewgong
+sDewgongPose1:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose2:
+ax_pose 1, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose3:
+ax_pose 2, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose4:
+ax_pose 3, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose5:
+ax_pose 4, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose6:
+ax_pose 5, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sDewgongPose8:
+ax_pose 7, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose9:
+ax_pose 8, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose10:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose11:
+ax_pose 10, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose13:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose14:
+ax_pose 13, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose15:
+ax_pose 14, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose16:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose17:
+ax_pose 10, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose19:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sDewgongPose20:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose21:
+ax_pose 8, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose22:
+ax_pose 3, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose23:
+ax_pose 4, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose24:
+ax_pose 5, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose25:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose26:
+ax_pose 1, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose27:
+ax_pose 2, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose28:
+ax_pose 15, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose29:
+ax_pose 3, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose30:
+ax_pose 4, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose31:
+ax_pose 5, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose32:
+ax_pose 16, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sDewgongPose33:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sDewgongPose34:
+ax_pose 7, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose35:
+ax_pose 8, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose36:
+ax_pose 17, 0x41ef, 0x90f3, 0x5c00
+ax_pose 18, 0x41ff, 0x10fb, 0x5c08
+ax_pose 19, 0x81ef, 0x10eb, 0x5c0a
+ax_pose_terminator
+sDewgongPose37:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose38:
+ax_pose 10, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose39:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose40:
+ax_pose 20, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose41:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose42:
+ax_pose 13, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose43:
+ax_pose 14, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose44:
+ax_pose 21, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose45:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose46:
+ax_pose 10, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose47:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose48:
+ax_pose 20, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose49:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sDewgongPose50:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose51:
+ax_pose 8, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose52:
+ax_pose 17, 0x41ef, 0x80ed, 0x5c00
+ax_pose 18, 0x41ff, 0x00f5, 0x5c08
+ax_pose 19, 0x81ef, 0x010d, 0x5c0a
+ax_pose_terminator
+sDewgongPose53:
+ax_pose 3, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose54:
+ax_pose 4, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose55:
+ax_pose 5, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose56:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose57:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose58:
+ax_pose 1, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose59:
+ax_pose 2, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose60:
+ax_pose 15, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose61:
+ax_pose 3, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose62:
+ax_pose 4, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose63:
+ax_pose 5, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose64:
+ax_pose 16, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sDewgongPose65:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sDewgongPose66:
+ax_pose 7, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose67:
+ax_pose 8, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose68:
+ax_pose 17, 0x41ef, 0x90f3, 0x5c00
+ax_pose 18, 0x41ff, 0x10fb, 0x5c08
+ax_pose 19, 0x81ef, 0x10eb, 0x5c0a
+ax_pose_terminator
+sDewgongPose69:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose70:
+ax_pose 10, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose71:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose72:
+ax_pose 20, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose73:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose74:
+ax_pose 13, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose75:
+ax_pose 14, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose76:
+ax_pose 21, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose77:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose78:
+ax_pose 10, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose79:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose80:
+ax_pose 20, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose81:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sDewgongPose82:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose83:
+ax_pose 8, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose84:
+ax_pose 17, 0x41ef, 0x80ed, 0x5c00
+ax_pose 18, 0x41ff, 0x00f5, 0x5c08
+ax_pose 19, 0x81ef, 0x010d, 0x5c0a
+ax_pose_terminator
+sDewgongPose85:
+ax_pose 3, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose86:
+ax_pose 4, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose87:
+ax_pose 5, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose88:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose89:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose90:
+ax_pose 1, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose91:
+ax_pose 2, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose92:
+ax_pose 15, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose93:
+ax_pose 22, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose94:
+ax_pose 3, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose95:
+ax_pose 4, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose96:
+ax_pose 5, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose97:
+ax_pose 16, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sDewgongPose98:
+ax_pose 23, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose99:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sDewgongPose100:
+ax_pose 7, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose101:
+ax_pose 8, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose102:
+ax_pose 17, 0x41ef, 0x90f3, 0x5c00
+ax_pose 18, 0x41ff, 0x10fb, 0x5c08
+ax_pose 19, 0x81ef, 0x10eb, 0x5c0a
+ax_pose_terminator
+sDewgongPose103:
+ax_pose 24, 0x41ec, 0x90ef, 0x5c00
+ax_pose 25, 0x01fc, 0x1107, 0x5c08
+ax_pose 26, 0x41fc, 0x10f7, 0x5c09
+ax_pose 27, 0x81ec, 0x10e7, 0x5c0b
+ax_pose_terminator
+sDewgongPose104:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose105:
+ax_pose 10, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose106:
+ax_pose 11, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose107:
+ax_pose 20, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose108:
+ax_pose 28, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose109:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose110:
+ax_pose 13, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose111:
+ax_pose 14, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose112:
+ax_pose 21, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose113:
+ax_pose 29, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose114:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose115:
+ax_pose 10, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose116:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose117:
+ax_pose 20, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose118:
+ax_pose 28, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose119:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sDewgongPose120:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose121:
+ax_pose 8, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose122:
+ax_pose 17, 0x41ef, 0x80ed, 0x5c00
+ax_pose 18, 0x41ff, 0x00f5, 0x5c08
+ax_pose 19, 0x81ef, 0x010d, 0x5c0a
+ax_pose_terminator
+sDewgongPose123:
+ax_pose 24, 0x41ec, 0x80f1, 0x5c00
+ax_pose 25, 0x01fc, 0x00f1, 0x5c08
+ax_pose 26, 0x41fc, 0x00f9, 0x5c09
+ax_pose 27, 0x81ec, 0x0111, 0x5c0b
+ax_pose_terminator
+sDewgongPose124:
+ax_pose 3, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose125:
+ax_pose 4, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose126:
+ax_pose 5, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose127:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose128:
+ax_pose 23, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose129:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose130:
+ax_pose 3, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose131:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose132:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose133:
+ax_pose 12, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose134:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose135:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose136:
+ax_pose 3, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose137:
+ax_pose 30, 0x01f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose138:
+ax_pose 31, 0x01f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose139:
+ax_pose 32, 0x01e1, 0x80ef, 0x5c00
+ax_pose_terminator
+sDewgongPose140:
+ax_pose 33, 0x01e3, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose141:
+ax_pose 34, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose142:
+ax_pose 35, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose143:
+ax_pose 36, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose144:
+ax_pose 35, 0x01e2, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose145:
+ax_pose 34, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose146:
+ax_pose 33, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose147:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose148:
+ax_pose 1, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose149:
+ax_pose 2, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose150:
+ax_pose 3, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose151:
+ax_pose 4, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose152:
+ax_pose 5, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose153:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sDewgongPose154:
+ax_pose 7, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose155:
+ax_pose 8, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose156:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose157:
+ax_pose 10, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose158:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose159:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose160:
+ax_pose 13, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose161:
+ax_pose 14, 0x01ef, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose162:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose163:
+ax_pose 10, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose164:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose165:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sDewgongPose166:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose167:
+ax_pose 8, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose168:
+ax_pose 3, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose169:
+ax_pose 4, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose170:
+ax_pose 5, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose171:
+ax_pose 15, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose172:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose173:
+ax_pose 17, 0x41ef, 0x80ee, 0x5c00
+ax_pose 18, 0x41ff, 0x00f6, 0x5c08
+ax_pose 19, 0x81ef, 0x010e, 0x5c0a
+ax_pose_terminator
+sDewgongPose174:
+ax_pose 20, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose175:
+ax_pose 21, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose176:
+ax_pose 20, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose177:
+ax_pose 17, 0x41ef, 0x90f2, 0x5c00
+ax_pose 18, 0x41ff, 0x10fa, 0x5c08
+ax_pose 19, 0x81ef, 0x10ea, 0x5c0a
+ax_pose_terminator
+sDewgongPose178:
+ax_pose 16, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sDewgongPose179:
+ax_pose 22, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose180:
+ax_pose 23, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose181:
+ax_pose 24, 0x41ec, 0x90ee, 0x5c00
+ax_pose 25, 0x01fc, 0x1106, 0x5c08
+ax_pose 26, 0x41fc, 0x10f6, 0x5c09
+ax_pose 27, 0x81ec, 0x10e6, 0x5c0b
+ax_pose_terminator
+sDewgongPose182:
+ax_pose 28, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose183:
+ax_pose 29, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose184:
+ax_pose 28, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose185:
+ax_pose 24, 0x41ec, 0x80f2, 0x5c00
+ax_pose 25, 0x01fc, 0x00f2, 0x5c08
+ax_pose 26, 0x41fc, 0x00fa, 0x5c09
+ax_pose 27, 0x81ec, 0x0112, 0x5c0b
+ax_pose_terminator
+sDewgongPose186:
+ax_pose 23, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose187:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose188:
+ax_pose 1, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose189:
+ax_pose 15, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose190:
+ax_pose 3, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose191:
+ax_pose 4, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose192:
+ax_pose 16, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sDewgongPose193:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sDewgongPose194:
+ax_pose 7, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose195:
+ax_pose 17, 0x41ef, 0x90f1, 0x5c00
+ax_pose 18, 0x41ff, 0x10f9, 0x5c08
+ax_pose 19, 0x81ef, 0x10e9, 0x5c0a
+ax_pose_terminator
+sDewgongPose196:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose197:
+ax_pose 10, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDewgongPose198:
+ax_pose 20, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose199:
+ax_pose 12, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose200:
+ax_pose 13, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose201:
+ax_pose 21, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose202:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose203:
+ax_pose 10, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose204:
+ax_pose 20, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose205:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sDewgongPose206:
+ax_pose 7, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose207:
+ax_pose 17, 0x41ef, 0x80ef, 0x5c00
+ax_pose 18, 0x41ff, 0x00f7, 0x5c08
+ax_pose 19, 0x81ef, 0x010f, 0x5c0a
+ax_pose_terminator
+sDewgongPose208:
+ax_pose 3, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose209:
+ax_pose 4, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose210:
+ax_pose 16, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose211:
+ax_pose 22, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose212:
+ax_pose 23, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sDewgongPose213:
+ax_pose 24, 0x41ec, 0x90ee, 0x5c00
+ax_pose 25, 0x01fc, 0x1106, 0x5c08
+ax_pose 26, 0x41fc, 0x10f6, 0x5c09
+ax_pose 27, 0x81ec, 0x10e6, 0x5c0b
+ax_pose_terminator
+sDewgongPose214:
+ax_pose 28, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose215:
+ax_pose 29, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose216:
+ax_pose 28, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose217:
+ax_pose 24, 0x41ec, 0x80f2, 0x5c00
+ax_pose 25, 0x01fc, 0x00f2, 0x5c08
+ax_pose 26, 0x41fc, 0x00fa, 0x5c09
+ax_pose 27, 0x81ec, 0x0112, 0x5c0b
+ax_pose_terminator
+sDewgongPose218:
+ax_pose 23, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose219:
+ax_pose 0, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDewgongPose220:
+ax_pose 3, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDewgongPose221:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sDewgongPose222:
+ax_pose 9, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDewgongPose223:
+ax_pose 12, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sDewgongPose224:
+ax_pose 9, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sDewgongPose225:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sDewgongPose226:
+ax_pose 3, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+.align 2
+sDewgongAnims_1_1:
+ax_anim 8, 0, 2, 0, -1, 0, -1,
+ax_anim 6, 0, 0, 0, 1, 0, 1,
+ax_anim 6, 0, 1, 0, 2, 0, 4,
+ax_anim 6, 0, 1, 0, 3, 0, 5,
+ax_anim 10, 0, 0, 0, 4, 0, 4,
+ax_anim 8, 0, 2, 0, 2, 0, 2,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_1_2:
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 2, 2, 2, 2,
+ax_anim 6, 0, 4, 4, 4, 4, 4,
+ax_anim 6, 0, 4, 5, 5, 5, 5,
+ax_anim 10, 0, 3, 5, 5, 5, 5,
+ax_anim 8, 0, 5, 3, 3, 3, 3,
+ax_anim 8, 0, 5, 1, 1, 1, 1,
+ax_anim_terminator
+sDewgongAnims_1_3:
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 4, 0, 3, 0,
+ax_anim 6, 0, 7, 7, 0, 6, 0,
+ax_anim 6, 0, 7, 8, 0, 7, 0,
+ax_anim 10, 0, 6, 6, 0, 4, 0,
+ax_anim 8, 0, 8, 2, 0, 2, 0,
+ax_anim 8, 0, 8, 1, 0, 1, 0,
+ax_anim_terminator
+sDewgongAnims_1_4:
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 1, -1,
+ax_anim 6, 0, 10, 4, -4, 4, -4,
+ax_anim 6, 0, 10, 5, -5, 5, -5,
+ax_anim 10, 0, 9, 3, -3, 4, -4,
+ax_anim 8, 0, 11, 2, -2, 2, -2,
+ax_anim 8, 0, 11, 1, -1, 1, -1,
+ax_anim_terminator
+sDewgongAnims_1_5:
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, -1,
+ax_anim 6, 0, 13, 0, -3, 0, -3,
+ax_anim 6, 0, 13, 0, -4, 0, -4,
+ax_anim 10, 0, 12, 0, -4, 0, -4,
+ax_anim 8, 0, 14, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, -1, 0, -1,
+ax_anim_terminator
+sDewgongAnims_1_6:
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, -1, -1,
+ax_anim 6, 0, 16, -4, -4, -4, -4,
+ax_anim 6, 0, 16, -5, -5, -5, -5,
+ax_anim 10, 0, 15, -3, -3, -4, -4,
+ax_anim 8, 0, 17, -2, -2, -2, -2,
+ax_anim 8, 0, 17, -1, -1, -1, -1,
+ax_anim_terminator
+sDewgongAnims_1_7:
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 18, -4, 0, -3, 0,
+ax_anim 6, 0, 19, -7, 0, -6, 0,
+ax_anim 6, 0, 19, -8, 0, -7, 0,
+ax_anim 10, 0, 18, -6, 0, -4, 0,
+ax_anim 8, 0, 20, -2, 0, -2, 0,
+ax_anim 8, 0, 20, -1, 0, -1, 0,
+ax_anim_terminator
+sDewgongAnims_1_8:
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 21, -2, 2, -2, 2,
+ax_anim 6, 0, 22, -4, 4, -4, 4,
+ax_anim 6, 0, 22, -5, 5, -5, 5,
+ax_anim 10, 0, 21, -5, 5, -5, 5,
+ax_anim 8, 0, 23, -3, 3, -3, 3,
+ax_anim 8, 0, 23, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sDewgongAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 4, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDewgongAnims_2_2:
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 4, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sDewgongAnims_2_3:
+ax_anim 2, 0, 33, -2, 0, -2, 0,
+ax_anim 4, 0, 33, -4, 0, -4, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 9, 0, 9, 0,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 1, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 0, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sDewgongAnims_2_4:
+ax_anim 2, 0, 37, -2, 2, -2, 2,
+ax_anim 4, 0, 37, -4, 4, -4, 4,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 18, -23, 18, -23,
+ax_anim 2, 1, 39, 19, -22, 19, -22,
+ax_anim 2, 0, 39, 18, -23, 18, -23,
+ax_anim 2, 0, 39, 19, -22, 19, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sDewgongAnims_2_5:
+ax_anim 2, 0, 41, 0, 2, 0, 2,
+ax_anim 4, 0, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sDewgongAnims_2_6:
+ax_anim 2, 0, 45, 2, 2, 2, 2,
+ax_anim 4, 0, 45, 4, 4, 4, 4,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 1, 47, -19, -22, -19, -22,
+ax_anim 2, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 0, 47, -19, -22, -19, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sDewgongAnims_2_7:
+ax_anim 2, 0, 49, 2, 0, 2, 0,
+ax_anim 4, 0, 49, 4, 0, 4, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -9, 0, -9, 0,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 1, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sDewgongAnims_2_8:
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 4, 0, 53, 4, -4, 4, -4,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 1, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDewgongAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 4, 0, 57, 0, -4, 0, -4,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sDewgongAnims_3_2:
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 4, 0, 61, -4, -4, -4, -4,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 1, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sDewgongAnims_3_3:
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 4, 0, 65, -4, 0, -4, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 9, 0, 9, 0,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 1, 67, 15, 1, 15, 1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 67, 15, 1, 15, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sDewgongAnims_3_4:
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 4, 0, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 71, 4, -6, 4, -6,
+ax_anim 1, 0, 71, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 18, -23, 18, -23,
+ax_anim 2, 1, 71, 19, -22, 19, -22,
+ax_anim 2, 0, 71, 18, -23, 18, -23,
+ax_anim 2, 0, 71, 19, -22, 19, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sDewgongAnims_3_5:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 4, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 1, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sDewgongAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 4, 0, 77, 4, 4, 4, 4,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 79, -4, -6, -4, -6,
+ax_anim 1, 0, 79, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -18, -23, -18, -23,
+ax_anim 2, 1, 79, -19, -22, -19, -22,
+ax_anim 2, 0, 79, -18, -23, -18, -23,
+ax_anim 2, 0, 79, -19, -22, -19, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sDewgongAnims_3_7:
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 4, 0, 81, 4, 0, 4, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -9, 0, -9, 0,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 1, 83, -15, 1, -15, 1,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 83, -15, 1, -15, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sDewgongAnims_3_8:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 4, 0, 85, 4, -4, 4, -4,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 1, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDewgongAnims_4_1:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 4, 0, 90, 0, -4, 0, -4,
+ax_anim 1, 0, 89, 0, -1, 0, -1,
+ax_anim 2, 2, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 1, 92, 1, 5, 1, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 1, 5, 1, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 1, 5, 1, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sDewgongAnims_4_2:
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 4, 0, 95, -4, -4, -4, -4,
+ax_anim 1, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 2, 94, 3, 3, 3, 3,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 1, 97, 4, 6, 4, 6,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 4, 6, 4, 6,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 4, 6, 4, 6,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sDewgongAnims_4_3:
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 4, 0, 100, -4, 0, -4, 0,
+ax_anim 1, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 2, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 1, 102, 5, 1, 5, 1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, 1, 5, 1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, 1, 5, 1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sDewgongAnims_4_4:
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 105, -3, 3, -3, 3,
+ax_anim 4, 0, 105, -4, 4, -4, 4,
+ax_anim 1, 0, 104, -1, 1, -1, 1,
+ax_anim 2, 2, 104, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 1, 107, 4, -6, 4, -6,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 4, -6, 4, -6,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 4, -6, 4, -6,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sDewgongAnims_4_5:
+ax_anim 2, 0, 110, 0, 1, 0, 1,
+ax_anim 2, 0, 110, 0, 3, 0, 3,
+ax_anim 4, 0, 110, 0, 4, 0, 4,
+ax_anim 1, 0, 109, 0, 1, 0, 1,
+ax_anim 2, 2, 109, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 1, 112, 1, -5, 1, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 112, 1, -5, 1, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 112, 1, -5, 1, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim_terminator
+sDewgongAnims_4_6:
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 3, 3, 3, 3,
+ax_anim 4, 0, 115, 4, 4, 4, 4,
+ax_anim 1, 0, 114, 1, 1, 1, 1,
+ax_anim 2, 2, 114, -3, -3, -3, -3,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 1, 117, -4, -6, -4, -6,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -4, -6, -4, -6,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -4, -6, -4, -6,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sDewgongAnims_4_7:
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 3, 0, 3, 0,
+ax_anim 4, 0, 120, 4, 0, 4, 0,
+ax_anim 1, 0, 119, 1, 0, 1, 0,
+ax_anim 2, 2, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 1, 122, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sDewgongAnims_4_8:
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 125, 3, -3, 3, -3,
+ax_anim 4, 0, 125, 4, -4, 4, -4,
+ax_anim 1, 0, 124, 1, -1, 1, -1,
+ax_anim 2, 2, 124, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 1, 127, -4, 6, -4, 6,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -4, 6, -4, 6,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -4, 6, -4, 6,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sDewgongAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDewgongAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDewgongAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sDewgongAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sDewgongAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sDewgongAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sDewgongAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sDewgongAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sDewgongAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sDewgongAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDewgongAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_8_2:
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_8_3:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_8_4:
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_8_5:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_8_6:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_8_7:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_8_8:
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDewgongAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 17, 7, 17,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -7, 17, -7, 17,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 20, 10, 20, 10,
+ax_anim 3, 0, 173, 19, 21, 19, 21,
+ax_anim 2, 3, 174, 11, 20, 11, 20,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -5, 17, -5,
+ax_anim 3, 0, 172, 20, -2, 20, -2,
+ax_anim 2, 3, 173, 18, 3, 18, 3,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -20, 12, -20,
+ax_anim 3, 0, 171, 20, -22, 20, -22,
+ax_anim 2, 3, 172, 20, -14, 20, -14,
+ax_anim 2, 0, 173, 16, -7, 16, -7,
+ax_anim 1, 0, 174, 9, -3, 9, -3,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -20, -12, -20,
+ax_anim 3, 0, 177, -20, -22, -20, -22,
+ax_anim 2, 3, 176, -20, -14, -20, -14,
+ax_anim 2, 0, 175, -16, -7, -16, -7,
+ax_anim 1, 0, 174, -9, -3, -9, -3,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -5, -17, -5,
+ax_anim 3, 0, 176, -20, -2, -20, -2,
+ax_anim 2, 3, 175, -18, 3, -18, 3,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -20, 10, -20, 10,
+ax_anim 3, 0, 175, -19, 21, -19, 21,
+ax_anim 2, 3, 174, -11, 20, -11, 20,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDewgongAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDewgongAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDewgongAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_12_2:
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_12_3:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_12_4:
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_12_6:
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_12_7:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_12_8:
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDewgongAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sDewgongGfx1:
+.incbin "baserom.gba", 0x8B918C, 0x200
+sDewgongSprites1:
+ax_sprite sDewgongGfx1, 0x200
+ax_sprite_terminator
+sDewgongGfx2:
+.incbin "baserom.gba", 0x8B939C, 0x200
+sDewgongSprites2:
+ax_sprite sDewgongGfx2, 0x200
+ax_sprite_terminator
+sDewgongGfx3:
+.incbin "baserom.gba", 0x8B95AC, 0x200
+sDewgongSprites3:
+ax_sprite sDewgongGfx3, 0x200
+ax_sprite_terminator
+sDewgongGfx4:
+.incbin "baserom.gba", 0x8B97BC, 0x200
+sDewgongSprites4:
+ax_sprite sDewgongGfx4, 0x200
+ax_sprite_terminator
+sDewgongGfx5:
+.incbin "baserom.gba", 0x8B99CC, 0x200
+sDewgongSprites5:
+ax_sprite sDewgongGfx5, 0x200
+ax_sprite_terminator
+sDewgongGfx6:
+.incbin "baserom.gba", 0x8B9BDC, 0x200
+sDewgongSprites6:
+ax_sprite sDewgongGfx6, 0x200
+ax_sprite_terminator
+sDewgongGfx7:
+.incbin "baserom.gba", 0x8B9DEC, 0x200
+sDewgongSprites7:
+ax_sprite sDewgongGfx7, 0x200
+ax_sprite_terminator
+sDewgongGfx8:
+.incbin "baserom.gba", 0x8B9FFC, 0x200
+sDewgongSprites8:
+ax_sprite sDewgongGfx8, 0x200
+ax_sprite_terminator
+sDewgongGfx9:
+.incbin "baserom.gba", 0x8BA20C, 0x200
+sDewgongSprites9:
+ax_sprite sDewgongGfx9, 0x200
+ax_sprite_terminator
+sDewgongGfx10:
+.incbin "baserom.gba", 0x8BA41C, 0x200
+sDewgongSprites10:
+ax_sprite sDewgongGfx10, 0x200
+ax_sprite_terminator
+sDewgongGfx11:
+.incbin "baserom.gba", 0x8BA62C, 0x200
+sDewgongSprites11:
+ax_sprite sDewgongGfx11, 0x200
+ax_sprite_terminator
+sDewgongGfx12:
+.incbin "baserom.gba", 0x8BA83C, 0x200
+sDewgongSprites12:
+ax_sprite sDewgongGfx12, 0x200
+ax_sprite_terminator
+sDewgongGfx13:
+.incbin "baserom.gba", 0x8BAA4C, 0x200
+sDewgongSprites13:
+ax_sprite sDewgongGfx13, 0x200
+ax_sprite_terminator
+sDewgongGfx14:
+.incbin "baserom.gba", 0x8BAC5C, 0x200
+sDewgongSprites14:
+ax_sprite sDewgongGfx14, 0x200
+ax_sprite_terminator
+sDewgongGfx15:
+.incbin "baserom.gba", 0x8BAE6C, 0x200
+sDewgongSprites15:
+ax_sprite sDewgongGfx15, 0x200
+ax_sprite_terminator
+sDewgongGfx16:
+.incbin "baserom.gba", 0x8BB07C, 0x40
+sDewgongGfx16_1:
+.incbin "baserom.gba", 0x8BB0BC, 0x40
+sDewgongGfx16_2:
+.incbin "baserom.gba", 0x8BB0FC, 0x100
+sDewgongSprites16:
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx16_2, 0x100
+ax_sprite_terminator
+sDewgongGfx17:
+.incbin "baserom.gba", 0x8BB234, 0x120
+sDewgongGfx17_1:
+.incbin "baserom.gba", 0x8BB354, 0x40
+sDewgongSprites17:
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx17, 0x120
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDewgongGfx18:
+.incbin "baserom.gba", 0x8BB3C4, 0x100
+sDewgongSprites18:
+ax_sprite sDewgongGfx18, 0x100
+ax_sprite_terminator
+sDewgongGfx19:
+.incbin "baserom.gba", 0x8BB4D4, 0x40
+sDewgongSprites19:
+ax_sprite sDewgongGfx19, 0x40
+ax_sprite_terminator
+sDewgongGfx20:
+.incbin "baserom.gba", 0x8BB524, 0x40
+sDewgongSprites20:
+ax_sprite sDewgongGfx20, 0x40
+ax_sprite_terminator
+sDewgongGfx21:
+.incbin "baserom.gba", 0x8BB574, 0x40
+sDewgongGfx21_1:
+.incbin "baserom.gba", 0x8BB5B4, 0x140
+sDewgongSprites21:
+ax_sprite sDewgongGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx21_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDewgongGfx22:
+.incbin "baserom.gba", 0x8BB71C, 0x40
+sDewgongGfx22_1:
+.incbin "baserom.gba", 0x8BB75C, 0x40
+sDewgongGfx22_2:
+.incbin "baserom.gba", 0x8BB79C, 0x80
+sDewgongSprites22:
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx22_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDewgongGfx23:
+.incbin "baserom.gba", 0x8BB85C, 0x40
+sDewgongGfx23_1:
+.incbin "baserom.gba", 0x8BB89C, 0x40
+sDewgongGfx23_2:
+.incbin "baserom.gba", 0x8BB8DC, 0x100
+sDewgongSprites23:
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx23_2, 0x100
+ax_sprite_terminator
+sDewgongGfx24:
+.incbin "baserom.gba", 0x8BBA14, 0x20
+sDewgongGfx24_1:
+.incbin "baserom.gba", 0x8BBA34, 0x120
+sDewgongGfx24_2:
+.incbin "baserom.gba", 0x8BBB54, 0x40
+sDewgongSprites24:
+ax_sprite sDewgongGfx24, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx24_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDewgongGfx25:
+.incbin "baserom.gba", 0x8BBBCC, 0x100
+sDewgongSprites25:
+ax_sprite sDewgongGfx25, 0x100
+ax_sprite_terminator
+sDewgongGfx26:
+.incbin "baserom.gba", 0x8BBCDC, 0x20
+sDewgongSprites26:
+ax_sprite sDewgongGfx26, 0x20
+ax_sprite_terminator
+sDewgongGfx27:
+.incbin "baserom.gba", 0x8BBD0C, 0x40
+sDewgongSprites27:
+ax_sprite sDewgongGfx27, 0x40
+ax_sprite_terminator
+sDewgongGfx28:
+.incbin "baserom.gba", 0x8BBD5C, 0x40
+sDewgongSprites28:
+ax_sprite sDewgongGfx28, 0x40
+ax_sprite_terminator
+sDewgongGfx29:
+.incbin "baserom.gba", 0x8BBDAC, 0x40
+sDewgongGfx29_1:
+.incbin "baserom.gba", 0x8BBDEC, 0x140
+sDewgongSprites29:
+ax_sprite sDewgongGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx29_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDewgongGfx30:
+.incbin "baserom.gba", 0x8BBF54, 0x40
+sDewgongGfx30_1:
+.incbin "baserom.gba", 0x8BBF94, 0x40
+sDewgongGfx30_2:
+.incbin "baserom.gba", 0x8BBFD4, 0x80
+sDewgongSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDewgongGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDewgongGfx30_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDewgongGfx31:
+.incbin "baserom.gba", 0x8BC094, 0x200
+sDewgongSprites31:
+ax_sprite sDewgongGfx31, 0x200
+ax_sprite_terminator
+sDewgongGfx32:
+.incbin "baserom.gba", 0x8BC2A4, 0x200
+sDewgongSprites32:
+ax_sprite sDewgongGfx32, 0x200
+ax_sprite_terminator
+sDewgongGfx33:
+.incbin "baserom.gba", 0x8BC4B4, 0x200
+sDewgongSprites33:
+ax_sprite sDewgongGfx33, 0x200
+ax_sprite_terminator
+sDewgongGfx34:
+.incbin "baserom.gba", 0x8BC6C4, 0x200
+sDewgongSprites34:
+ax_sprite sDewgongGfx34, 0x200
+ax_sprite_terminator
+sDewgongGfx35:
+.incbin "baserom.gba", 0x8BC8D4, 0x200
+sDewgongSprites35:
+ax_sprite sDewgongGfx35, 0x200
+ax_sprite_terminator
+sDewgongGfx36:
+.incbin "baserom.gba", 0x8BCAE4, 0x200
+sDewgongSprites36:
+ax_sprite sDewgongGfx36, 0x200
+ax_sprite_terminator
+sDewgongGfx37:
+.incbin "baserom.gba", 0x8BCCF4, 0x200
+sDewgongSprites37:
+ax_sprite sDewgongGfx37, 0x200
+ax_sprite_terminator
+sAxPosesDewgong:
+.4byte sDewgongPose1
+.4byte sDewgongPose2
+.4byte sDewgongPose3
+.4byte sDewgongPose4
+.4byte sDewgongPose5
+.4byte sDewgongPose6
+.4byte sDewgongPose7
+.4byte sDewgongPose8
+.4byte sDewgongPose9
+.4byte sDewgongPose10
+.4byte sDewgongPose11
+.4byte sDewgongPose12
+.4byte sDewgongPose13
+.4byte sDewgongPose14
+.4byte sDewgongPose15
+.4byte sDewgongPose16
+.4byte sDewgongPose17
+.4byte sDewgongPose18
+.4byte sDewgongPose19
+.4byte sDewgongPose20
+.4byte sDewgongPose21
+.4byte sDewgongPose22
+.4byte sDewgongPose23
+.4byte sDewgongPose24
+.4byte sDewgongPose25
+.4byte sDewgongPose26
+.4byte sDewgongPose27
+.4byte sDewgongPose28
+.4byte sDewgongPose29
+.4byte sDewgongPose30
+.4byte sDewgongPose31
+.4byte sDewgongPose32
+.4byte sDewgongPose33
+.4byte sDewgongPose34
+.4byte sDewgongPose35
+.4byte sDewgongPose36
+.4byte sDewgongPose37
+.4byte sDewgongPose38
+.4byte sDewgongPose39
+.4byte sDewgongPose40
+.4byte sDewgongPose41
+.4byte sDewgongPose42
+.4byte sDewgongPose43
+.4byte sDewgongPose44
+.4byte sDewgongPose45
+.4byte sDewgongPose46
+.4byte sDewgongPose47
+.4byte sDewgongPose48
+.4byte sDewgongPose49
+.4byte sDewgongPose50
+.4byte sDewgongPose51
+.4byte sDewgongPose52
+.4byte sDewgongPose53
+.4byte sDewgongPose54
+.4byte sDewgongPose55
+.4byte sDewgongPose56
+.4byte sDewgongPose57
+.4byte sDewgongPose58
+.4byte sDewgongPose59
+.4byte sDewgongPose60
+.4byte sDewgongPose61
+.4byte sDewgongPose62
+.4byte sDewgongPose63
+.4byte sDewgongPose64
+.4byte sDewgongPose65
+.4byte sDewgongPose66
+.4byte sDewgongPose67
+.4byte sDewgongPose68
+.4byte sDewgongPose69
+.4byte sDewgongPose70
+.4byte sDewgongPose71
+.4byte sDewgongPose72
+.4byte sDewgongPose73
+.4byte sDewgongPose74
+.4byte sDewgongPose75
+.4byte sDewgongPose76
+.4byte sDewgongPose77
+.4byte sDewgongPose78
+.4byte sDewgongPose79
+.4byte sDewgongPose80
+.4byte sDewgongPose81
+.4byte sDewgongPose82
+.4byte sDewgongPose83
+.4byte sDewgongPose84
+.4byte sDewgongPose85
+.4byte sDewgongPose86
+.4byte sDewgongPose87
+.4byte sDewgongPose88
+.4byte sDewgongPose89
+.4byte sDewgongPose90
+.4byte sDewgongPose91
+.4byte sDewgongPose92
+.4byte sDewgongPose93
+.4byte sDewgongPose94
+.4byte sDewgongPose95
+.4byte sDewgongPose96
+.4byte sDewgongPose97
+.4byte sDewgongPose98
+.4byte sDewgongPose99
+.4byte sDewgongPose100
+.4byte sDewgongPose101
+.4byte sDewgongPose102
+.4byte sDewgongPose103
+.4byte sDewgongPose104
+.4byte sDewgongPose105
+.4byte sDewgongPose106
+.4byte sDewgongPose107
+.4byte sDewgongPose108
+.4byte sDewgongPose109
+.4byte sDewgongPose110
+.4byte sDewgongPose111
+.4byte sDewgongPose112
+.4byte sDewgongPose113
+.4byte sDewgongPose114
+.4byte sDewgongPose115
+.4byte sDewgongPose116
+.4byte sDewgongPose117
+.4byte sDewgongPose118
+.4byte sDewgongPose119
+.4byte sDewgongPose120
+.4byte sDewgongPose121
+.4byte sDewgongPose122
+.4byte sDewgongPose123
+.4byte sDewgongPose124
+.4byte sDewgongPose125
+.4byte sDewgongPose126
+.4byte sDewgongPose127
+.4byte sDewgongPose128
+.4byte sDewgongPose129
+.4byte sDewgongPose130
+.4byte sDewgongPose131
+.4byte sDewgongPose132
+.4byte sDewgongPose133
+.4byte sDewgongPose134
+.4byte sDewgongPose135
+.4byte sDewgongPose136
+.4byte sDewgongPose137
+.4byte sDewgongPose138
+.4byte sDewgongPose139
+.4byte sDewgongPose140
+.4byte sDewgongPose141
+.4byte sDewgongPose142
+.4byte sDewgongPose143
+.4byte sDewgongPose144
+.4byte sDewgongPose145
+.4byte sDewgongPose146
+.4byte sDewgongPose147
+.4byte sDewgongPose148
+.4byte sDewgongPose149
+.4byte sDewgongPose150
+.4byte sDewgongPose151
+.4byte sDewgongPose152
+.4byte sDewgongPose153
+.4byte sDewgongPose154
+.4byte sDewgongPose155
+.4byte sDewgongPose156
+.4byte sDewgongPose157
+.4byte sDewgongPose158
+.4byte sDewgongPose159
+.4byte sDewgongPose160
+.4byte sDewgongPose161
+.4byte sDewgongPose162
+.4byte sDewgongPose163
+.4byte sDewgongPose164
+.4byte sDewgongPose165
+.4byte sDewgongPose166
+.4byte sDewgongPose167
+.4byte sDewgongPose168
+.4byte sDewgongPose169
+.4byte sDewgongPose170
+.4byte sDewgongPose171
+.4byte sDewgongPose172
+.4byte sDewgongPose173
+.4byte sDewgongPose174
+.4byte sDewgongPose175
+.4byte sDewgongPose176
+.4byte sDewgongPose177
+.4byte sDewgongPose178
+.4byte sDewgongPose179
+.4byte sDewgongPose180
+.4byte sDewgongPose181
+.4byte sDewgongPose182
+.4byte sDewgongPose183
+.4byte sDewgongPose184
+.4byte sDewgongPose185
+.4byte sDewgongPose186
+.4byte sDewgongPose187
+.4byte sDewgongPose188
+.4byte sDewgongPose189
+.4byte sDewgongPose190
+.4byte sDewgongPose191
+.4byte sDewgongPose192
+.4byte sDewgongPose193
+.4byte sDewgongPose194
+.4byte sDewgongPose195
+.4byte sDewgongPose196
+.4byte sDewgongPose197
+.4byte sDewgongPose198
+.4byte sDewgongPose199
+.4byte sDewgongPose200
+.4byte sDewgongPose201
+.4byte sDewgongPose202
+.4byte sDewgongPose203
+.4byte sDewgongPose204
+.4byte sDewgongPose205
+.4byte sDewgongPose206
+.4byte sDewgongPose207
+.4byte sDewgongPose208
+.4byte sDewgongPose209
+.4byte sDewgongPose210
+.4byte sDewgongPose211
+.4byte sDewgongPose212
+.4byte sDewgongPose213
+.4byte sDewgongPose214
+.4byte sDewgongPose215
+.4byte sDewgongPose216
+.4byte sDewgongPose217
+.4byte sDewgongPose218
+.4byte sDewgongPose219
+.4byte sDewgongPose220
+.4byte sDewgongPose221
+.4byte sDewgongPose222
+.4byte sDewgongPose223
+.4byte sDewgongPose224
+.4byte sDewgongPose225
+.4byte sDewgongPose226
+sAxPositionsDewgong:
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -1,   -8, 	 -10,   -2, 	   8,   -2, 	  -1,   -5
+.2byte   -1,   -5, 	  -9,    0, 	   7,    0, 	  -1,   -4
+.2byte    6,  -10, 	   8,   -4, 	  -4,    0, 	   0,   -6
+.2byte    5,  -11, 	   5,   -5, 	  -5,    0, 	  -1,   -6
+.2byte    7,   -8, 	   8,   -2, 	   0,    1, 	  -1,   -5
+.2byte    7,  -11, 	   6,   -5, 	   1,    0, 	   0,   -6
+.2byte    7,  -13, 	   4,   -4, 	  -2,   -1, 	  -1,   -6
+.2byte    9,  -10, 	   6,   -4, 	   4,   -1, 	   0,   -5
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    6,  -16, 	  -4,   -5, 	   4,    1, 	  -2,   -6
+.2byte    7,  -13, 	  -4,   -7, 	   8,   -4, 	  -1,   -5
+.2byte   -1,  -15, 	   9,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte   -1,  -18, 	   9,   -1, 	  -9,   -2, 	  -1,   -9
+.2byte   -1,  -10, 	   9,   -5, 	  -9,   -4, 	  -1,   -4
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -7,  -16, 	   3,   -5, 	  -5,    1, 	   1,   -6
+.2byte   -8,  -13, 	   3,   -7, 	  -9,   -4, 	   0,   -5
+.2byte   -8,  -11, 	  -7,   -5, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -13, 	  -5,   -4, 	   1,   -1, 	   0,   -6
+.2byte  -10,  -10, 	  -7,   -4, 	  -5,   -1, 	  -1,   -5
+.2byte   -7,  -10, 	  -9,   -4, 	   3,    0, 	  -1,   -6
+.2byte   -6,  -11, 	  -6,   -5, 	   4,    0, 	   0,   -6
+.2byte   -8,   -8, 	  -9,   -2, 	  -1,    1, 	   0,   -5
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -1,   -8, 	 -10,   -2, 	   8,   -2, 	  -1,   -5
+.2byte   -1,   -5, 	  -9,    0, 	   7,    0, 	  -1,   -4
+.2byte   -1,   -4, 	 -11,   -3, 	   9,   -3, 	  -1,   -6
+.2byte    6,  -10, 	   8,   -4, 	  -4,    0, 	   0,   -6
+.2byte    5,  -11, 	   5,   -5, 	  -5,    0, 	  -1,   -6
+.2byte    7,   -8, 	   8,   -2, 	   0,    1, 	  -1,   -5
+.2byte    7,   -4, 	   4,   -2, 	  -4,   -1, 	   1,   -5
+.2byte    7,  -11, 	   6,   -5, 	   1,    0, 	   0,   -6
+.2byte    7,  -13, 	   4,   -4, 	  -2,   -1, 	  -1,   -6
+.2byte    9,  -10, 	   6,   -4, 	   4,   -1, 	   0,   -5
+.2byte   11,   -6, 	   6,   -1, 	   0,   -1, 	   5,   -6
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    6,  -16, 	  -4,   -5, 	   4,    1, 	  -2,   -6
+.2byte    7,  -13, 	  -4,   -7, 	   8,   -4, 	  -1,   -5
+.2byte    8,   -9, 	  -1,   -6, 	   7,   -3, 	   3,   -6
+.2byte   -1,  -15, 	   9,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte   -1,  -18, 	   9,   -1, 	  -9,   -2, 	  -1,   -9
+.2byte   -1,  -10, 	   9,   -5, 	  -9,   -4, 	  -1,   -4
+.2byte   -1,  -12, 	   8,   -2, 	  -9,   -4, 	  -1,   -9
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -7,  -16, 	   3,   -5, 	  -5,    1, 	   1,   -6
+.2byte   -8,  -13, 	   3,   -7, 	  -9,   -4, 	   0,   -5
+.2byte   -9,   -9, 	   0,   -6, 	  -8,   -3, 	  -4,   -6
+.2byte   -8,  -11, 	  -7,   -5, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -13, 	  -5,   -4, 	   1,   -1, 	   0,   -6
+.2byte  -10,  -10, 	  -7,   -4, 	  -5,   -1, 	  -1,   -5
+.2byte  -12,   -6, 	  -7,   -1, 	  -1,   -1, 	  -6,   -6
+.2byte   -7,  -10, 	  -9,   -4, 	   3,    0, 	  -1,   -6
+.2byte   -6,  -11, 	  -6,   -5, 	   4,    0, 	   0,   -6
+.2byte   -8,   -8, 	  -9,   -2, 	  -1,    1, 	   0,   -5
+.2byte   -8,   -4, 	  -5,   -2, 	   3,   -1, 	  -2,   -5
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -1,   -8, 	 -10,   -2, 	   8,   -2, 	  -1,   -5
+.2byte   -1,   -5, 	  -9,    0, 	   7,    0, 	  -1,   -4
+.2byte   -1,   -4, 	 -11,   -3, 	   9,   -3, 	  -1,   -6
+.2byte    6,  -10, 	   8,   -4, 	  -4,    0, 	   0,   -6
+.2byte    5,  -11, 	   5,   -5, 	  -5,    0, 	  -1,   -6
+.2byte    7,   -8, 	   8,   -2, 	   0,    1, 	  -1,   -5
+.2byte    7,   -4, 	   4,   -2, 	  -4,   -1, 	   1,   -5
+.2byte    7,  -11, 	   6,   -5, 	   1,    0, 	   0,   -6
+.2byte    7,  -13, 	   4,   -4, 	  -2,   -1, 	  -1,   -6
+.2byte    9,  -10, 	   6,   -4, 	   4,   -1, 	   0,   -5
+.2byte   11,   -6, 	   6,   -1, 	   0,   -1, 	   5,   -6
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    6,  -16, 	  -4,   -5, 	   4,    1, 	  -2,   -6
+.2byte    7,  -13, 	  -4,   -7, 	   8,   -4, 	  -1,   -5
+.2byte    8,   -9, 	  -1,   -6, 	   7,   -3, 	   3,   -6
+.2byte   -1,  -15, 	   9,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte   -1,  -18, 	   9,   -1, 	  -9,   -2, 	  -1,   -9
+.2byte   -1,  -10, 	   9,   -5, 	  -9,   -4, 	  -1,   -4
+.2byte   -1,  -12, 	   8,   -2, 	  -9,   -4, 	  -1,   -9
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -7,  -16, 	   3,   -5, 	  -5,    1, 	   1,   -6
+.2byte   -8,  -13, 	   3,   -7, 	  -9,   -4, 	   0,   -5
+.2byte   -9,   -9, 	   0,   -6, 	  -8,   -3, 	  -4,   -6
+.2byte   -8,  -11, 	  -7,   -5, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -13, 	  -5,   -4, 	   1,   -1, 	   0,   -6
+.2byte  -10,  -10, 	  -7,   -4, 	  -5,   -1, 	  -1,   -5
+.2byte  -12,   -6, 	  -7,   -1, 	  -1,   -1, 	  -6,   -6
+.2byte   -7,  -10, 	  -9,   -4, 	   3,    0, 	  -1,   -6
+.2byte   -6,  -11, 	  -6,   -5, 	   4,    0, 	   0,   -6
+.2byte   -8,   -8, 	  -9,   -2, 	  -1,    1, 	   0,   -5
+.2byte   -8,   -4, 	  -5,   -2, 	   3,   -1, 	  -2,   -5
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -1,   -8, 	 -10,   -2, 	   8,   -2, 	  -1,   -5
+.2byte   -1,   -5, 	  -9,    0, 	   7,    0, 	  -1,   -4
+.2byte   -1,   -4, 	 -11,   -3, 	   9,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte    6,  -10, 	   8,   -4, 	  -4,    0, 	   0,   -6
+.2byte    5,  -11, 	   5,   -5, 	  -5,    0, 	  -1,   -6
+.2byte    7,   -8, 	   8,   -2, 	   0,    1, 	  -1,   -5
+.2byte    7,   -4, 	   4,   -2, 	  -4,   -1, 	   1,   -5
+.2byte   10,   -8, 	   9,   -4, 	  -3,    0, 	   2,   -6
+.2byte    7,  -11, 	   6,   -5, 	   1,    0, 	   0,   -6
+.2byte    7,  -13, 	   4,   -4, 	  -2,   -1, 	  -1,   -6
+.2byte    9,  -10, 	   6,   -4, 	   4,   -1, 	   0,   -5
+.2byte   11,   -6, 	   6,   -1, 	   0,   -1, 	   5,   -6
+.2byte   11,  -10, 	   6,   -4, 	   1,   -1, 	   2,   -7
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    6,  -16, 	  -4,   -5, 	   4,    1, 	  -2,   -6
+.2byte    7,  -14, 	  -4,   -8, 	   8,   -5, 	  -1,   -6
+.2byte    8,   -9, 	  -1,   -6, 	   7,   -3, 	   3,   -6
+.2byte    9,  -11, 	  -2,   -7, 	   9,   -3, 	   2,   -7
+.2byte   -1,  -15, 	   9,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte   -1,  -18, 	   9,   -1, 	  -9,   -2, 	  -1,   -9
+.2byte   -1,  -10, 	   9,   -5, 	  -9,   -4, 	  -1,   -4
+.2byte   -1,  -12, 	   8,   -2, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -3, 	  -9,   -4, 	  -1,   -9
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -7,  -16, 	   3,   -5, 	  -5,    1, 	   1,   -6
+.2byte   -8,  -14, 	   3,   -8, 	  -9,   -5, 	   0,   -6
+.2byte   -9,   -9, 	   0,   -6, 	  -8,   -3, 	  -4,   -6
+.2byte  -10,  -11, 	   1,   -7, 	 -10,   -3, 	  -3,   -7
+.2byte   -8,  -11, 	  -7,   -5, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -13, 	  -5,   -4, 	   1,   -1, 	   0,   -6
+.2byte  -10,  -10, 	  -7,   -4, 	  -5,   -1, 	  -1,   -5
+.2byte  -12,   -6, 	  -7,   -1, 	  -1,   -1, 	  -6,   -6
+.2byte  -12,  -10, 	  -7,   -4, 	  -2,   -1, 	  -3,   -7
+.2byte   -7,  -10, 	  -9,   -4, 	   3,    0, 	  -1,   -6
+.2byte   -6,  -11, 	  -6,   -5, 	   4,    0, 	   0,   -6
+.2byte   -8,   -8, 	  -9,   -2, 	  -1,    1, 	   0,   -5
+.2byte   -8,   -4, 	  -5,   -2, 	   3,   -1, 	  -2,   -5
+.2byte  -11,   -8, 	 -10,   -4, 	   2,    0, 	  -3,   -6
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -8,  -10, 	 -10,   -4, 	   2,    0, 	  -2,   -6
+.2byte   -9,  -11, 	  -8,   -5, 	  -3,    0, 	  -2,   -6
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -1,  -16, 	   9,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    8,  -11, 	   7,   -5, 	   2,    0, 	   1,   -6
+.2byte    7,  -10, 	   9,   -4, 	  -3,    0, 	   1,   -6
+.2byte  -11,    0, 	   2,   -3, 	   1,    0, 	  -1,   -4
+.2byte  -11,    0, 	   2,   -4, 	   3,    0, 	  -1,   -3
+.2byte   -4,  -11, 	 -14,   -4, 	   1,  -22, 	  -2,   -7
+.2byte    6,  -11, 	   9,   -7, 	  -2,  -21, 	  -1,   -5
+.2byte    6,  -12, 	   5,   -6, 	   0,  -22, 	  -1,   -6
+.2byte    3,  -17, 	  -5,   -9, 	   5,  -21, 	  -1,   -7
+.2byte    7,  -13, 	  10,   -4, 	  -1,  -21, 	   1,   -8
+.2byte   -4,  -17, 	   4,   -9, 	  -6,  -21, 	   0,   -7
+.2byte   -7,  -12, 	  -6,   -6, 	  -1,  -22, 	   0,   -6
+.2byte   -7,  -11, 	 -10,   -7, 	   1,  -21, 	   0,   -5
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -1,   -9, 	 -10,   -3, 	   8,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	  -9,    0, 	   7,    0, 	  -1,   -4
+.2byte    6,  -10, 	   8,   -4, 	  -4,    0, 	   0,   -6
+.2byte    5,  -11, 	   5,   -5, 	  -5,    0, 	  -1,   -6
+.2byte    7,   -8, 	   8,   -2, 	   0,    1, 	  -1,   -5
+.2byte    7,  -11, 	   6,   -5, 	   1,    0, 	   0,   -6
+.2byte    7,  -13, 	   4,   -4, 	  -2,   -1, 	  -1,   -6
+.2byte    9,  -10, 	   6,   -4, 	   4,   -1, 	   0,   -5
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    6,  -16, 	  -4,   -5, 	   4,    1, 	  -2,   -6
+.2byte    7,  -13, 	  -4,   -7, 	   8,   -4, 	  -1,   -5
+.2byte   -1,  -15, 	   9,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte   -1,  -18, 	   9,   -1, 	  -9,   -2, 	  -1,   -9
+.2byte   -1,  -10, 	   9,   -5, 	  -9,   -4, 	  -1,   -4
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -7,  -16, 	   3,   -5, 	  -5,    1, 	   1,   -6
+.2byte   -8,  -13, 	   3,   -7, 	  -9,   -4, 	   0,   -5
+.2byte   -8,  -11, 	  -7,   -5, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -13, 	  -5,   -4, 	   1,   -1, 	   0,   -6
+.2byte  -10,  -10, 	  -7,   -4, 	  -5,   -1, 	  -1,   -5
+.2byte   -7,  -10, 	  -9,   -4, 	   3,    0, 	  -1,   -6
+.2byte   -6,  -11, 	  -6,   -5, 	   4,    0, 	   0,   -6
+.2byte   -8,   -8, 	  -9,   -2, 	  -1,    1, 	   0,   -5
+.2byte   -1,   -4, 	 -11,   -3, 	   9,   -3, 	  -1,   -6
+.2byte   -8,   -4, 	  -5,   -2, 	   3,   -1, 	  -2,   -5
+.2byte  -11,   -6, 	  -6,   -1, 	   0,   -1, 	  -5,   -6
+.2byte   -7,   -9, 	   2,   -6, 	  -6,   -3, 	  -2,   -6
+.2byte   -1,  -12, 	   8,   -2, 	  -9,   -4, 	  -1,   -9
+.2byte    6,   -9, 	  -3,   -6, 	   5,   -3, 	   1,   -6
+.2byte   10,   -6, 	   5,   -1, 	  -1,   -1, 	   4,   -6
+.2byte    7,   -4, 	   4,   -2, 	  -4,   -1, 	   1,   -5
+.2byte   -1,   -5, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   10,   -8, 	   9,   -4, 	  -3,    0, 	   2,   -6
+.2byte   10,  -10, 	   5,   -4, 	   0,   -1, 	   1,   -7
+.2byte    7,  -11, 	  -4,   -7, 	   7,   -3, 	   0,   -7
+.2byte   -1,  -13, 	   8,   -3, 	  -9,   -4, 	  -1,   -9
+.2byte   -8,  -11, 	   3,   -7, 	  -8,   -3, 	  -1,   -7
+.2byte  -11,  -10, 	  -6,   -4, 	  -1,   -1, 	  -2,   -7
+.2byte  -11,   -8, 	 -10,   -4, 	   2,    0, 	  -3,   -6
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -1,   -8, 	 -10,   -2, 	   8,   -2, 	  -1,   -5
+.2byte   -1,   -4, 	 -11,   -3, 	   9,   -3, 	  -1,   -6
+.2byte    6,  -10, 	   8,   -4, 	  -4,    0, 	   0,   -6
+.2byte    5,  -11, 	   5,   -5, 	  -5,    0, 	  -1,   -6
+.2byte    7,   -4, 	   4,   -2, 	  -4,   -1, 	   1,   -5
+.2byte    7,  -11, 	   6,   -5, 	   1,    0, 	   0,   -6
+.2byte    7,  -13, 	   4,   -4, 	  -2,   -1, 	  -1,   -6
+.2byte    9,   -6, 	   4,   -1, 	  -2,   -1, 	   3,   -6
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    6,  -16, 	  -4,   -5, 	   4,    1, 	  -2,   -6
+.2byte    6,   -9, 	  -3,   -6, 	   5,   -3, 	   1,   -6
+.2byte   -1,  -15, 	   9,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte   -1,  -18, 	   9,   -1, 	  -9,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	   8,   -2, 	  -9,   -4, 	  -1,   -9
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -7,  -16, 	   3,   -5, 	  -5,    1, 	   1,   -6
+.2byte   -7,   -9, 	   2,   -6, 	  -6,   -3, 	  -2,   -6
+.2byte   -8,  -11, 	  -7,   -5, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -13, 	  -5,   -4, 	   1,   -1, 	   0,   -6
+.2byte  -10,   -6, 	  -5,   -1, 	   1,   -1, 	  -4,   -6
+.2byte   -7,  -10, 	  -9,   -4, 	   3,    0, 	  -1,   -6
+.2byte   -6,  -11, 	  -6,   -5, 	   4,    0, 	   0,   -6
+.2byte   -8,   -4, 	  -5,   -2, 	   3,   -1, 	  -2,   -5
+.2byte   -1,   -5, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   10,   -8, 	   9,   -4, 	  -3,    0, 	   2,   -6
+.2byte   10,  -10, 	   5,   -4, 	   0,   -1, 	   1,   -7
+.2byte    7,  -11, 	  -4,   -7, 	   7,   -3, 	   0,   -7
+.2byte   -1,  -13, 	   8,   -3, 	  -9,   -4, 	  -1,   -9
+.2byte   -8,  -11, 	   3,   -7, 	  -8,   -3, 	  -1,   -7
+.2byte  -11,  -10, 	  -6,   -4, 	  -1,   -1, 	  -2,   -7
+.2byte  -11,   -8, 	 -10,   -4, 	   2,    0, 	  -3,   -6
+.2byte   -1,   -8, 	 -11,   -1, 	   9,   -1, 	  -1,   -6
+.2byte   -8,  -10, 	 -10,   -4, 	   2,    0, 	  -2,   -6
+.2byte   -9,  -11, 	  -8,   -5, 	  -3,    0, 	  -2,   -6
+.2byte   -7,  -15, 	   1,   -7, 	 -10,   -2, 	  -2,   -6
+.2byte   -1,  -16, 	   9,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte    6,  -15, 	  -2,   -7, 	   9,   -2, 	   1,   -6
+.2byte    8,  -11, 	   7,   -5, 	   2,    0, 	   1,   -6
+.2byte    7,  -10, 	   9,   -4, 	  -3,    0, 	   1,   -6
+sDewgongAnimTable1:
+.4byte sDewgongAnims_1_1
+.4byte sDewgongAnims_1_2
+.4byte sDewgongAnims_1_3
+.4byte sDewgongAnims_1_4
+.4byte sDewgongAnims_1_5
+.4byte sDewgongAnims_1_6
+.4byte sDewgongAnims_1_7
+.4byte sDewgongAnims_1_8
+sDewgongAnimTable2:
+.4byte sDewgongAnims_2_1
+.4byte sDewgongAnims_2_2
+.4byte sDewgongAnims_2_3
+.4byte sDewgongAnims_2_4
+.4byte sDewgongAnims_2_5
+.4byte sDewgongAnims_2_6
+.4byte sDewgongAnims_2_7
+.4byte sDewgongAnims_2_8
+sDewgongAnimTable3:
+.4byte sDewgongAnims_3_1
+.4byte sDewgongAnims_3_2
+.4byte sDewgongAnims_3_3
+.4byte sDewgongAnims_3_4
+.4byte sDewgongAnims_3_5
+.4byte sDewgongAnims_3_6
+.4byte sDewgongAnims_3_7
+.4byte sDewgongAnims_3_8
+sDewgongAnimTable4:
+.4byte sDewgongAnims_4_1
+.4byte sDewgongAnims_4_2
+.4byte sDewgongAnims_4_3
+.4byte sDewgongAnims_4_4
+.4byte sDewgongAnims_4_5
+.4byte sDewgongAnims_4_6
+.4byte sDewgongAnims_4_7
+.4byte sDewgongAnims_4_8
+sDewgongAnimTable5:
+.4byte sDewgongAnims_5_1
+.4byte sDewgongAnims_5_2
+.4byte sDewgongAnims_5_3
+.4byte sDewgongAnims_5_4
+.4byte sDewgongAnims_5_5
+.4byte sDewgongAnims_5_6
+.4byte sDewgongAnims_5_7
+.4byte sDewgongAnims_5_8
+sDewgongAnimTable6:
+.4byte sDewgongAnims_6_1
+.4byte sDewgongAnims_6_1
+.4byte sDewgongAnims_6_1
+.4byte sDewgongAnims_6_1
+.4byte sDewgongAnims_6_1
+.4byte sDewgongAnims_6_1
+.4byte sDewgongAnims_6_1
+.4byte sDewgongAnims_6_1
+sDewgongAnimTable7:
+.4byte sDewgongAnims_7_1
+.4byte sDewgongAnims_7_2
+.4byte sDewgongAnims_7_3
+.4byte sDewgongAnims_7_4
+.4byte sDewgongAnims_7_5
+.4byte sDewgongAnims_7_6
+.4byte sDewgongAnims_7_7
+.4byte sDewgongAnims_7_8
+sDewgongAnimTable8:
+.4byte sDewgongAnims_8_1
+.4byte sDewgongAnims_8_2
+.4byte sDewgongAnims_8_3
+.4byte sDewgongAnims_8_4
+.4byte sDewgongAnims_8_5
+.4byte sDewgongAnims_8_6
+.4byte sDewgongAnims_8_7
+.4byte sDewgongAnims_8_8
+sDewgongAnimTable9:
+.4byte sDewgongAnims_9_1
+.4byte sDewgongAnims_9_2
+.4byte sDewgongAnims_9_3
+.4byte sDewgongAnims_9_4
+.4byte sDewgongAnims_9_5
+.4byte sDewgongAnims_9_6
+.4byte sDewgongAnims_9_7
+.4byte sDewgongAnims_9_8
+sDewgongAnimTable10:
+.4byte sDewgongAnims_10_1
+.4byte sDewgongAnims_10_2
+.4byte sDewgongAnims_10_3
+.4byte sDewgongAnims_10_4
+.4byte sDewgongAnims_10_5
+.4byte sDewgongAnims_10_6
+.4byte sDewgongAnims_10_7
+.4byte sDewgongAnims_10_8
+sDewgongAnimTable11:
+.4byte sDewgongAnims_11_1
+.4byte sDewgongAnims_11_2
+.4byte sDewgongAnims_11_3
+.4byte sDewgongAnims_11_4
+.4byte sDewgongAnims_11_5
+.4byte sDewgongAnims_11_6
+.4byte sDewgongAnims_11_7
+.4byte sDewgongAnims_11_8
+sDewgongAnimTable12:
+.4byte sDewgongAnims_12_1
+.4byte sDewgongAnims_12_2
+.4byte sDewgongAnims_12_3
+.4byte sDewgongAnims_12_4
+.4byte sDewgongAnims_12_5
+.4byte sDewgongAnims_12_6
+.4byte sDewgongAnims_12_7
+.4byte sDewgongAnims_12_8
+sDewgongAnimTable13:
+.4byte sDewgongAnims_13_1
+.4byte sDewgongAnims_13_2
+.4byte sDewgongAnims_13_3
+.4byte sDewgongAnims_13_4
+.4byte sDewgongAnims_13_5
+.4byte sDewgongAnims_13_6
+.4byte sDewgongAnims_13_7
+.4byte sDewgongAnims_13_8
+sAxAnimationsDewgong:
+.4byte sDewgongAnimTable1
+.4byte sDewgongAnimTable2
+.4byte sDewgongAnimTable3
+.4byte sDewgongAnimTable4
+.4byte sDewgongAnimTable5
+.4byte sDewgongAnimTable6
+.4byte sDewgongAnimTable7
+.4byte sDewgongAnimTable8
+.4byte sDewgongAnimTable9
+.4byte sDewgongAnimTable10
+.4byte sDewgongAnimTable11
+.4byte sDewgongAnimTable12
+.4byte sDewgongAnimTable13
+sAxSpritesDewgong:
+.4byte sDewgongSprites1
+.4byte sDewgongSprites2
+.4byte sDewgongSprites3
+.4byte sDewgongSprites4
+.4byte sDewgongSprites5
+.4byte sDewgongSprites6
+.4byte sDewgongSprites7
+.4byte sDewgongSprites8
+.4byte sDewgongSprites9
+.4byte sDewgongSprites10
+.4byte sDewgongSprites11
+.4byte sDewgongSprites12
+.4byte sDewgongSprites13
+.4byte sDewgongSprites14
+.4byte sDewgongSprites15
+.4byte sDewgongSprites16
+.4byte sDewgongSprites17
+.4byte sDewgongSprites18
+.4byte sDewgongSprites19
+.4byte sDewgongSprites20
+.4byte sDewgongSprites21
+.4byte sDewgongSprites22
+.4byte sDewgongSprites23
+.4byte sDewgongSprites24
+.4byte sDewgongSprites25
+.4byte sDewgongSprites26
+.4byte sDewgongSprites27
+.4byte sDewgongSprites28
+.4byte sDewgongSprites29
+.4byte sDewgongSprites30
+.4byte sDewgongSprites31
+.4byte sDewgongSprites32
+.4byte sDewgongSprites33
+.4byte sDewgongSprites34
+.4byte sDewgongSprites35
+.4byte sDewgongSprites36
+.4byte sDewgongSprites37
+sAxMainDewgong:
+ax_main sAxPosesDewgong, sAxAnimationsDewgong, 13, sAxSpritesDewgong, sAxPositionsDewgong

--- a/data/ax/diglett.inc
+++ b/data/ax/diglett.inc
@@ -1,0 +1,4753 @@
+.global gAxDiglett
+gAxDiglett:
+ax_siro sAxMainDiglett
+sDiglettPose1:
+ax_pose 0, 0x01ff, 0x00fc, 0x4c00
+ax_pose 1, 0x41fa, 0x40f0, 0x4c01
+ax_pose 2, 0x41f3, 0x00f8, 0x4c05
+ax_pose -1, 0x01ef, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose2:
+ax_pose 3, 0x41fe, 0x00f8, 0x4c00
+ax_pose 4, 0x41f7, 0x40f0, 0x4c02
+ax_pose -1, 0x41f2, 0x00f8, 0x4c00
+ax_pose 5, 0x01ed, 0x00fc, 0x4c06
+ax_pose_terminator
+sDiglettPose3:
+ax_pose 4, 0x41fc, 0x40f0, 0x4c00
+ax_pose 6, 0x41f6, 0x40f0, 0x4c04
+ax_pose 7, 0x41f1, 0x00f8, 0x4c08
+ax_pose 8, 0x01ec, 0x00fc, 0x4c0a
+ax_pose_terminator
+sDiglettPose4:
+ax_pose 0, 0x01fe, 0x0104, 0x4c00
+ax_pose 1, 0x41f9, 0x40f2, 0x4c01
+ax_pose 2, 0x41f2, 0x00f4, 0x4c05
+ax_pose -1, 0x01ee, 0x00f3, 0x4c00
+ax_pose_terminator
+sDiglettPose5:
+ax_pose 3, 0x41fd, 0x00fd, 0x4c00
+ax_pose 4, 0x41f7, 0x40f0, 0x4c02
+ax_pose -1, 0x41f2, 0x00f2, 0x4c00
+ax_pose 5, 0x01ed, 0x00f1, 0x4c06
+ax_pose_terminator
+sDiglettPose6:
+ax_pose 4, 0x41fb, 0x40f4, 0x4c00
+ax_pose 6, 0x41f6, 0x40ef, 0x4c04
+ax_pose 7, 0x41f1, 0x00f1, 0x4c08
+ax_pose 8, 0x01ec, 0x00f0, 0x4c0a
+ax_pose_terminator
+sDiglettPose7:
+ax_pose 0, 0x01fa, 0x0105, 0x4c00
+ax_pose 1, 0x41f9, 0x40f2, 0x4c01
+ax_pose 2, 0x41fa, 0x00f3, 0x4c05
+ax_pose -1, 0x01f9, 0x00f0, 0x4c00
+ax_pose_terminator
+sDiglettPose8:
+ax_pose 3, 0x41fa, 0x00fe, 0x4c00
+ax_pose 4, 0x41f9, 0x40ef, 0x4c02
+ax_pose -1, 0x41fa, 0x00f1, 0x4c00
+ax_pose 5, 0x01fa, 0x00ee, 0x4c06
+ax_pose_terminator
+sDiglettPose9:
+ax_pose 4, 0x41f9, 0x40f4, 0x4c00
+ax_pose 6, 0x41fa, 0x40ed, 0x4c04
+ax_pose 7, 0x41f9, 0x00ee, 0x4c08
+ax_pose 8, 0x01fa, 0x00ed, 0x4c0a
+ax_pose_terminator
+sDiglettPose10:
+ax_pose 0, 0x0203, 0x00f1, 0x4c00
+ax_pose 2, 0x41fe, 0x00f3, 0x4c01
+ax_pose 1, 0x41fa, 0x40f2, 0x4c03
+ax_pose -1, 0x01f5, 0x0103, 0x4c00
+ax_pose_terminator
+sDiglettPose11:
+ax_pose 5, 0x0205, 0x00ef, 0x4c00
+ax_pose 3, 0x4201, 0x00f1, 0x4c01
+ax_pose 4, 0x41fb, 0x40f0, 0x4c03
+ax_pose -1, 0x41f6, 0x00ff, 0x4c01
+ax_pose_terminator
+sDiglettPose12:
+ax_pose 8, 0x0207, 0x00ed, 0x4c00
+ax_pose 7, 0x4203, 0x00ef, 0x4c01
+ax_pose 6, 0x41fd, 0x40ee, 0x4c03
+ax_pose 4, 0x41f7, 0x40f5, 0x4c07
+ax_pose_terminator
+sDiglettPose13:
+ax_pose 0, 0x0204, 0x00fc, 0x4c00
+ax_pose 2, 0x41fe, 0x00f8, 0x4c01
+ax_pose 1, 0x41f9, 0x40f0, 0x4c03
+ax_pose -1, 0x01f4, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose14:
+ax_pose 5, 0x0206, 0x00fc, 0x4c00
+ax_pose 3, 0x4201, 0x00f8, 0x4c01
+ax_pose 4, 0x41fb, 0x40f0, 0x4c03
+ax_pose -1, 0x41f6, 0x00f8, 0x4c01
+ax_pose_terminator
+sDiglettPose15:
+ax_pose 8, 0x0207, 0x00fc, 0x4c00
+ax_pose 7, 0x4203, 0x00f8, 0x4c01
+ax_pose 6, 0x41fd, 0x40f0, 0x4c03
+ax_pose 4, 0x41f7, 0x40f0, 0x4c07
+ax_pose_terminator
+sDiglettPose16:
+ax_pose 0, 0x0203, 0x1107, 0x4c00
+ax_pose 2, 0x41fe, 0x10fd, 0x4c01
+ax_pose 1, 0x41fa, 0x50ee, 0x4c03
+ax_pose -1, 0x01f5, 0x10f5, 0x4c00
+ax_pose_terminator
+sDiglettPose17:
+ax_pose 5, 0x0205, 0x1109, 0x4c00
+ax_pose 3, 0x4201, 0x10ff, 0x4c01
+ax_pose 4, 0x41fb, 0x50f0, 0x4c03
+ax_pose -1, 0x41f6, 0x10f1, 0x4c01
+ax_pose_terminator
+sDiglettPose18:
+ax_pose 8, 0x0207, 0x110b, 0x4c00
+ax_pose 7, 0x4203, 0x1101, 0x4c01
+ax_pose 6, 0x41fd, 0x50f2, 0x4c03
+ax_pose 4, 0x41f7, 0x50eb, 0x4c07
+ax_pose_terminator
+sDiglettPose19:
+ax_pose 0, 0x01fa, 0x10f3, 0x4c00
+ax_pose 1, 0x41f9, 0x50ee, 0x4c01
+ax_pose 2, 0x41fa, 0x10fd, 0x4c05
+ax_pose -1, 0x01f9, 0x1108, 0x4c00
+ax_pose_terminator
+sDiglettPose20:
+ax_pose 3, 0x41fa, 0x10f2, 0x4c00
+ax_pose 4, 0x41f9, 0x50f1, 0x4c02
+ax_pose -1, 0x41fa, 0x10ff, 0x4c00
+ax_pose 5, 0x01fa, 0x110a, 0x4c06
+ax_pose_terminator
+sDiglettPose21:
+ax_pose 4, 0x41f9, 0x50ec, 0x4c00
+ax_pose 6, 0x41fa, 0x50f3, 0x4c04
+ax_pose 7, 0x41f9, 0x1102, 0x4c08
+ax_pose 8, 0x01fa, 0x110b, 0x4c0a
+ax_pose_terminator
+sDiglettPose22:
+ax_pose 0, 0x01fe, 0x10f4, 0x4c00
+ax_pose 1, 0x41f9, 0x50ee, 0x4c01
+ax_pose 2, 0x41f2, 0x10fc, 0x4c05
+ax_pose -1, 0x01ee, 0x1105, 0x4c00
+ax_pose_terminator
+sDiglettPose23:
+ax_pose 3, 0x41fd, 0x10f3, 0x4c00
+ax_pose 4, 0x41f7, 0x50f0, 0x4c02
+ax_pose -1, 0x41f2, 0x10fe, 0x4c00
+ax_pose 5, 0x01ed, 0x1107, 0x4c06
+ax_pose_terminator
+sDiglettPose24:
+ax_pose 4, 0x41fb, 0x50ec, 0x4c00
+ax_pose 6, 0x41f6, 0x50f1, 0x4c04
+ax_pose 7, 0x41f1, 0x10ff, 0x4c08
+ax_pose 8, 0x01ec, 0x1108, 0x4c0a
+ax_pose_terminator
+sDiglettPose25:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01ff, 0x00fc, 0x4c08
+ax_pose 1, 0x41fa, 0x40f0, 0x4c09
+ax_pose 2, 0x41f3, 0x00f8, 0x4c0d
+ax_pose -1, 0x01ef, 0x00fc, 0x4c08
+ax_pose_terminator
+sDiglettPose26:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose 3, 0x41fe, 0x00f8, 0x4c08
+ax_pose 4, 0x41f7, 0x40f0, 0x4c0a
+ax_pose -1, 0x41f2, 0x00f8, 0x4c08
+ax_pose 5, 0x01ed, 0x00fc, 0x4c0e
+ax_pose_terminator
+sDiglettPose27:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose 4, 0x41fc, 0x40f0, 0x4c08
+ax_pose 6, 0x41f6, 0x40f0, 0x4c0c
+ax_pose 7, 0x41f1, 0x00f8, 0x4c10
+ax_pose 8, 0x01ec, 0x00fc, 0x4c12
+ax_pose_terminator
+sDiglettPose28:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose29:
+ax_pose 11, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose30:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose31:
+ax_pose 11, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x0204, 0x00fc, 0x4c10
+ax_pose 2, 0x41fe, 0x00f8, 0x4c11
+ax_pose 1, 0x41f9, 0x40f0, 0x4c13
+ax_pose -1, 0x01f4, 0x00fc, 0x4c10
+ax_pose_terminator
+sDiglettPose32:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose 0, 0x01fe, 0x0100, 0x4c08
+ax_pose 1, 0x41f9, 0x40ee, 0x4c09
+ax_pose 2, 0x41f2, 0x00f0, 0x4c0d
+ax_pose -1, 0x01ee, 0x00ef, 0x4c08
+ax_pose_terminator
+sDiglettPose33:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose 3, 0x41fd, 0x00f9, 0x4c08
+ax_pose 4, 0x41f7, 0x40ec, 0x4c0a
+ax_pose -1, 0x41f2, 0x00ee, 0x4c08
+ax_pose 5, 0x01ed, 0x00ed, 0x4c0e
+ax_pose_terminator
+sDiglettPose34:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose 4, 0x41fb, 0x40f0, 0x4c08
+ax_pose 6, 0x41f6, 0x40eb, 0x4c0c
+ax_pose 7, 0x41f1, 0x00ed, 0x4c10
+ax_pose 8, 0x01ec, 0x00ec, 0x4c12
+ax_pose_terminator
+sDiglettPose35:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose36:
+ax_pose 14, 0x01f3, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose37:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose_terminator
+sDiglettPose38:
+ax_pose 14, 0x01f3, 0x90eb, 0x4c00
+ax_pose 0, 0x0203, 0x1107, 0x4c10
+ax_pose 2, 0x41fe, 0x10fd, 0x4c11
+ax_pose 1, 0x41fa, 0x50ee, 0x4c13
+ax_pose -1, 0x01f5, 0x10f5, 0x4c10
+ax_pose_terminator
+sDiglettPose39:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose 0, 0x01fc, 0x0105, 0x4c08
+ax_pose 1, 0x41fb, 0x40f2, 0x4c09
+ax_pose 2, 0x41fc, 0x00f3, 0x4c0d
+ax_pose -1, 0x01fb, 0x00f0, 0x4c08
+ax_pose_terminator
+sDiglettPose40:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose 3, 0x41fc, 0x00fe, 0x4c08
+ax_pose 4, 0x41fb, 0x40ef, 0x4c0a
+ax_pose -1, 0x41fc, 0x00f1, 0x4c08
+ax_pose 5, 0x01fc, 0x00ee, 0x4c0e
+ax_pose_terminator
+sDiglettPose41:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose 4, 0x41fb, 0x40f4, 0x4c08
+ax_pose 6, 0x41fc, 0x40ed, 0x4c0c
+ax_pose 7, 0x41fb, 0x00ee, 0x4c10
+ax_pose 8, 0x01fc, 0x00ed, 0x4c12
+ax_pose_terminator
+sDiglettPose42:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose43:
+ax_pose 17, 0x01f4, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose44:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose45:
+ax_pose 17, 0x01f4, 0x90eb, 0x4c00
+ax_pose 0, 0x01fc, 0x10f3, 0x4c10
+ax_pose 1, 0x41fb, 0x50ee, 0x4c11
+ax_pose 2, 0x41fc, 0x10fd, 0x4c15
+ax_pose -1, 0x01fb, 0x1108, 0x4c10
+ax_pose_terminator
+sDiglettPose46:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose 0, 0x0205, 0x00ee, 0x4c08
+ax_pose 2, 0x4200, 0x00f0, 0x4c09
+ax_pose 1, 0x41fc, 0x40ef, 0x4c0b
+ax_pose -1, 0x01f7, 0x0100, 0x4c08
+ax_pose_terminator
+sDiglettPose47:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose 5, 0x0207, 0x00ec, 0x4c08
+ax_pose 3, 0x4203, 0x00ee, 0x4c09
+ax_pose 4, 0x41fd, 0x40ed, 0x4c0b
+ax_pose -1, 0x41f8, 0x00fc, 0x4c09
+ax_pose_terminator
+sDiglettPose48:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose 8, 0x0209, 0x00ea, 0x4c08
+ax_pose 7, 0x4205, 0x00ec, 0x4c09
+ax_pose 6, 0x41ff, 0x40eb, 0x4c0b
+ax_pose 4, 0x41f9, 0x40f2, 0x4c0f
+ax_pose_terminator
+sDiglettPose49:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose50:
+ax_pose 20, 0x01f4, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose51:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose52:
+ax_pose 20, 0x01f4, 0x90eb, 0x4c00
+ax_pose 0, 0x01fe, 0x10f7, 0x4c10
+ax_pose 1, 0x41f9, 0x50f1, 0x4c11
+ax_pose 2, 0x41f2, 0x10ff, 0x4c15
+ax_pose -1, 0x01ee, 0x1108, 0x4c10
+ax_pose_terminator
+sDiglettPose53:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x0206, 0x00fc, 0x4c08
+ax_pose 2, 0x4200, 0x00f8, 0x4c09
+ax_pose 1, 0x41fb, 0x40f0, 0x4c0b
+ax_pose -1, 0x01f6, 0x00fc, 0x4c08
+ax_pose_terminator
+sDiglettPose54:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose 5, 0x0208, 0x00fc, 0x4c08
+ax_pose 3, 0x4203, 0x00f8, 0x4c09
+ax_pose 4, 0x41fd, 0x40f0, 0x4c0b
+ax_pose -1, 0x41f8, 0x00f8, 0x4c09
+ax_pose_terminator
+sDiglettPose55:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose 8, 0x0209, 0x00fc, 0x4c08
+ax_pose 7, 0x4205, 0x00f8, 0x4c09
+ax_pose 6, 0x41ff, 0x40f0, 0x4c0b
+ax_pose 4, 0x41f9, 0x40f0, 0x4c0f
+ax_pose_terminator
+sDiglettPose56:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose57:
+ax_pose 23, 0x01f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose58:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose59:
+ax_pose 23, 0x01f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01ff, 0x00fc, 0x4c10
+ax_pose 1, 0x41fa, 0x40f0, 0x4c11
+ax_pose 2, 0x41f3, 0x00f8, 0x4c15
+ax_pose -1, 0x01ef, 0x00fc, 0x4c10
+ax_pose_terminator
+sDiglettPose60:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x0205, 0x110a, 0x4c08
+ax_pose 2, 0x4200, 0x1100, 0x4c09
+ax_pose 1, 0x41fc, 0x50f1, 0x4c0b
+ax_pose -1, 0x01f7, 0x10f8, 0x4c08
+ax_pose_terminator
+sDiglettPose61:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose 5, 0x0207, 0x110c, 0x4c08
+ax_pose 3, 0x4203, 0x1102, 0x4c09
+ax_pose 4, 0x41fd, 0x50f3, 0x4c0b
+ax_pose -1, 0x41f8, 0x10f4, 0x4c09
+ax_pose_terminator
+sDiglettPose62:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose 8, 0x0209, 0x110e, 0x4c08
+ax_pose 7, 0x4205, 0x1104, 0x4c09
+ax_pose 6, 0x41ff, 0x50f5, 0x4c0b
+ax_pose 4, 0x41f9, 0x50ee, 0x4c0f
+ax_pose_terminator
+sDiglettPose63:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose64:
+ax_pose 20, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose65:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose66:
+ax_pose 20, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x01fd, 0x00fe, 0x4c10
+ax_pose 1, 0x41f8, 0x40ec, 0x4c11
+ax_pose 2, 0x41f1, 0x00ee, 0x4c15
+ax_pose -1, 0x01ed, 0x00ed, 0x4c10
+ax_pose_terminator
+sDiglettPose67:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01fc, 0x10f3, 0x4c08
+ax_pose 1, 0x41fb, 0x50ee, 0x4c09
+ax_pose 2, 0x41fc, 0x10fd, 0x4c0d
+ax_pose -1, 0x01fb, 0x1108, 0x4c08
+ax_pose_terminator
+sDiglettPose68:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose 3, 0x41fc, 0x10f2, 0x4c08
+ax_pose 4, 0x41fb, 0x50f1, 0x4c0a
+ax_pose -1, 0x41fc, 0x10ff, 0x4c08
+ax_pose 5, 0x01fc, 0x110a, 0x4c0e
+ax_pose_terminator
+sDiglettPose69:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose 4, 0x41fb, 0x50ec, 0x4c08
+ax_pose 6, 0x41fc, 0x50f3, 0x4c0c
+ax_pose 7, 0x41fb, 0x1102, 0x4c10
+ax_pose 8, 0x01fc, 0x110b, 0x4c12
+ax_pose_terminator
+sDiglettPose70:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose71:
+ax_pose 17, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose72:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose73:
+ax_pose 17, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x01fc, 0x0105, 0x4c10
+ax_pose 1, 0x41fb, 0x40f2, 0x4c11
+ax_pose 2, 0x41fc, 0x00f3, 0x4c15
+ax_pose -1, 0x01fb, 0x00f0, 0x4c10
+ax_pose_terminator
+sDiglettPose74:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01fe, 0x10f9, 0x4c08
+ax_pose 1, 0x41f9, 0x50f3, 0x4c09
+ax_pose 2, 0x41f2, 0x1101, 0x4c0d
+ax_pose -1, 0x01ee, 0x110a, 0x4c08
+ax_pose_terminator
+sDiglettPose75:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose 3, 0x41fd, 0x10f8, 0x4c08
+ax_pose 4, 0x41f7, 0x50f5, 0x4c0a
+ax_pose -1, 0x41f2, 0x1103, 0x4c08
+ax_pose 5, 0x01ed, 0x110c, 0x4c0e
+ax_pose_terminator
+sDiglettPose76:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose 4, 0x41fb, 0x50f1, 0x4c08
+ax_pose 6, 0x41f6, 0x50f6, 0x4c0c
+ax_pose 7, 0x41f1, 0x1104, 0x4c10
+ax_pose 8, 0x01ec, 0x110d, 0x4c12
+ax_pose_terminator
+sDiglettPose77:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose78:
+ax_pose 14, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose79:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose80:
+ax_pose 14, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x0205, 0x00ee, 0x4c10
+ax_pose 2, 0x4200, 0x00f0, 0x4c11
+ax_pose 1, 0x41fc, 0x40ef, 0x4c13
+ax_pose -1, 0x01f7, 0x0100, 0x4c10
+ax_pose_terminator
+sDiglettPose81:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01ff, 0x00fc, 0x4c08
+ax_pose 1, 0x41fa, 0x40f0, 0x4c09
+ax_pose 2, 0x41f3, 0x00f8, 0x4c0d
+ax_pose -1, 0x01ef, 0x00fc, 0x4c08
+ax_pose_terminator
+sDiglettPose82:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose 3, 0x41fe, 0x00f8, 0x4c08
+ax_pose 4, 0x41f7, 0x40f0, 0x4c0a
+ax_pose -1, 0x41f2, 0x00f8, 0x4c08
+ax_pose 5, 0x01ed, 0x00fc, 0x4c0e
+ax_pose_terminator
+sDiglettPose83:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose 4, 0x41fc, 0x40f0, 0x4c08
+ax_pose 6, 0x41f6, 0x40f0, 0x4c0c
+ax_pose 7, 0x41f1, 0x00f8, 0x4c10
+ax_pose 8, 0x01ec, 0x00fc, 0x4c12
+ax_pose_terminator
+sDiglettPose84:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose85:
+ax_pose 11, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose86:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose87:
+ax_pose 11, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x0204, 0x00fc, 0x4c10
+ax_pose 2, 0x41fe, 0x00f8, 0x4c11
+ax_pose 1, 0x41f9, 0x40f0, 0x4c13
+ax_pose -1, 0x01f4, 0x00fc, 0x4c10
+ax_pose_terminator
+sDiglettPose88:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose 0, 0x01fe, 0x0100, 0x4c08
+ax_pose 1, 0x41f9, 0x40ee, 0x4c09
+ax_pose 2, 0x41f2, 0x00f0, 0x4c0d
+ax_pose -1, 0x01ee, 0x00ef, 0x4c08
+ax_pose_terminator
+sDiglettPose89:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose 3, 0x41fd, 0x00f9, 0x4c08
+ax_pose 4, 0x41f7, 0x40ec, 0x4c0a
+ax_pose -1, 0x41f2, 0x00ee, 0x4c08
+ax_pose 5, 0x01ed, 0x00ed, 0x4c0e
+ax_pose_terminator
+sDiglettPose90:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose 4, 0x41fb, 0x40f0, 0x4c08
+ax_pose 6, 0x41f6, 0x40eb, 0x4c0c
+ax_pose 7, 0x41f1, 0x00ed, 0x4c10
+ax_pose 8, 0x01ec, 0x00ec, 0x4c12
+ax_pose_terminator
+sDiglettPose91:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose92:
+ax_pose 14, 0x01f3, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose93:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose_terminator
+sDiglettPose94:
+ax_pose 14, 0x01f3, 0x90eb, 0x4c00
+ax_pose 0, 0x0203, 0x1107, 0x4c10
+ax_pose 2, 0x41fe, 0x10fd, 0x4c11
+ax_pose 1, 0x41fa, 0x50ee, 0x4c13
+ax_pose -1, 0x01f5, 0x10f5, 0x4c10
+ax_pose_terminator
+sDiglettPose95:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose 0, 0x01fc, 0x0105, 0x4c08
+ax_pose 1, 0x41fb, 0x40f2, 0x4c09
+ax_pose 2, 0x41fc, 0x00f3, 0x4c0d
+ax_pose -1, 0x01fb, 0x00f0, 0x4c08
+ax_pose_terminator
+sDiglettPose96:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose 3, 0x41fc, 0x00fe, 0x4c08
+ax_pose 4, 0x41fb, 0x40ef, 0x4c0a
+ax_pose -1, 0x41fc, 0x00f1, 0x4c08
+ax_pose 5, 0x01fc, 0x00ee, 0x4c0e
+ax_pose_terminator
+sDiglettPose97:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose 4, 0x41fb, 0x40f4, 0x4c08
+ax_pose 6, 0x41fc, 0x40ed, 0x4c0c
+ax_pose 7, 0x41fb, 0x00ee, 0x4c10
+ax_pose 8, 0x01fc, 0x00ed, 0x4c12
+ax_pose_terminator
+sDiglettPose98:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose99:
+ax_pose 17, 0x01f4, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose100:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose101:
+ax_pose 17, 0x01f4, 0x90eb, 0x4c00
+ax_pose 0, 0x01fc, 0x10f3, 0x4c10
+ax_pose 1, 0x41fb, 0x50ee, 0x4c11
+ax_pose 2, 0x41fc, 0x10fd, 0x4c15
+ax_pose -1, 0x01fb, 0x1108, 0x4c10
+ax_pose_terminator
+sDiglettPose102:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose 0, 0x0205, 0x00ee, 0x4c08
+ax_pose 2, 0x4200, 0x00f0, 0x4c09
+ax_pose 1, 0x41fc, 0x40ef, 0x4c0b
+ax_pose -1, 0x01f7, 0x0100, 0x4c08
+ax_pose_terminator
+sDiglettPose103:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose 5, 0x0207, 0x00ec, 0x4c08
+ax_pose 3, 0x4203, 0x00ee, 0x4c09
+ax_pose 4, 0x41fd, 0x40ed, 0x4c0b
+ax_pose -1, 0x41f8, 0x00fc, 0x4c09
+ax_pose_terminator
+sDiglettPose104:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose 8, 0x0209, 0x00ea, 0x4c08
+ax_pose 7, 0x4205, 0x00ec, 0x4c09
+ax_pose 6, 0x41ff, 0x40eb, 0x4c0b
+ax_pose 4, 0x41f9, 0x40f2, 0x4c0f
+ax_pose_terminator
+sDiglettPose105:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose106:
+ax_pose 20, 0x01f4, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose107:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose108:
+ax_pose 20, 0x01f4, 0x90eb, 0x4c00
+ax_pose 0, 0x01fe, 0x10f7, 0x4c10
+ax_pose 1, 0x41f9, 0x50f1, 0x4c11
+ax_pose 2, 0x41f2, 0x10ff, 0x4c15
+ax_pose -1, 0x01ee, 0x1108, 0x4c10
+ax_pose_terminator
+sDiglettPose109:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x0206, 0x00fc, 0x4c08
+ax_pose 2, 0x4200, 0x00f8, 0x4c09
+ax_pose 1, 0x41fb, 0x40f0, 0x4c0b
+ax_pose -1, 0x01f6, 0x00fc, 0x4c08
+ax_pose_terminator
+sDiglettPose110:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose 5, 0x0208, 0x00fc, 0x4c08
+ax_pose 3, 0x4203, 0x00f8, 0x4c09
+ax_pose 4, 0x41fd, 0x40f0, 0x4c0b
+ax_pose -1, 0x41f8, 0x00f8, 0x4c09
+ax_pose_terminator
+sDiglettPose111:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose 8, 0x0209, 0x00fc, 0x4c08
+ax_pose 7, 0x4205, 0x00f8, 0x4c09
+ax_pose 6, 0x41ff, 0x40f0, 0x4c0b
+ax_pose 4, 0x41f9, 0x40f0, 0x4c0f
+ax_pose_terminator
+sDiglettPose112:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose113:
+ax_pose 23, 0x01f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose114:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose115:
+ax_pose 23, 0x01f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01ff, 0x00fc, 0x4c10
+ax_pose 1, 0x41fa, 0x40f0, 0x4c11
+ax_pose 2, 0x41f3, 0x00f8, 0x4c15
+ax_pose -1, 0x01ef, 0x00fc, 0x4c10
+ax_pose_terminator
+sDiglettPose116:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x0205, 0x110a, 0x4c08
+ax_pose 2, 0x4200, 0x1100, 0x4c09
+ax_pose 1, 0x41fc, 0x50f1, 0x4c0b
+ax_pose -1, 0x01f7, 0x10f8, 0x4c08
+ax_pose_terminator
+sDiglettPose117:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose 5, 0x0207, 0x110c, 0x4c08
+ax_pose 3, 0x4203, 0x1102, 0x4c09
+ax_pose 4, 0x41fd, 0x50f3, 0x4c0b
+ax_pose -1, 0x41f8, 0x10f4, 0x4c09
+ax_pose_terminator
+sDiglettPose118:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose 8, 0x0209, 0x110e, 0x4c08
+ax_pose 7, 0x4205, 0x1104, 0x4c09
+ax_pose 6, 0x41ff, 0x50f5, 0x4c0b
+ax_pose 4, 0x41f9, 0x50ee, 0x4c0f
+ax_pose_terminator
+sDiglettPose119:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose120:
+ax_pose 20, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose121:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose122:
+ax_pose 20, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x01fd, 0x00fe, 0x4c10
+ax_pose 1, 0x41f8, 0x40ec, 0x4c11
+ax_pose 2, 0x41f1, 0x00ee, 0x4c15
+ax_pose -1, 0x01ed, 0x00ed, 0x4c10
+ax_pose_terminator
+sDiglettPose123:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01fc, 0x10f3, 0x4c08
+ax_pose 1, 0x41fb, 0x50ee, 0x4c09
+ax_pose 2, 0x41fc, 0x10fd, 0x4c0d
+ax_pose -1, 0x01fb, 0x1108, 0x4c08
+ax_pose_terminator
+sDiglettPose124:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose 3, 0x41fc, 0x10f2, 0x4c08
+ax_pose 4, 0x41fb, 0x50f1, 0x4c0a
+ax_pose -1, 0x41fc, 0x10ff, 0x4c08
+ax_pose 5, 0x01fc, 0x110a, 0x4c0e
+ax_pose_terminator
+sDiglettPose125:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose 4, 0x41fb, 0x50ec, 0x4c08
+ax_pose 6, 0x41fc, 0x50f3, 0x4c0c
+ax_pose 7, 0x41fb, 0x1102, 0x4c10
+ax_pose 8, 0x01fc, 0x110b, 0x4c12
+ax_pose_terminator
+sDiglettPose126:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose127:
+ax_pose 17, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose128:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose129:
+ax_pose 17, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x01fc, 0x0105, 0x4c10
+ax_pose 1, 0x41fb, 0x40f2, 0x4c11
+ax_pose 2, 0x41fc, 0x00f3, 0x4c15
+ax_pose -1, 0x01fb, 0x00f0, 0x4c10
+ax_pose_terminator
+sDiglettPose130:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01fe, 0x10f9, 0x4c08
+ax_pose 1, 0x41f9, 0x50f3, 0x4c09
+ax_pose 2, 0x41f2, 0x1101, 0x4c0d
+ax_pose -1, 0x01ee, 0x110a, 0x4c08
+ax_pose_terminator
+sDiglettPose131:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose 3, 0x41fd, 0x10f8, 0x4c08
+ax_pose 4, 0x41f7, 0x50f5, 0x4c0a
+ax_pose -1, 0x41f2, 0x1103, 0x4c08
+ax_pose 5, 0x01ed, 0x110c, 0x4c0e
+ax_pose_terminator
+sDiglettPose132:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose 4, 0x41fb, 0x50f1, 0x4c08
+ax_pose 6, 0x41f6, 0x50f6, 0x4c0c
+ax_pose 7, 0x41f1, 0x1104, 0x4c10
+ax_pose 8, 0x01ec, 0x110d, 0x4c12
+ax_pose_terminator
+sDiglettPose133:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose134:
+ax_pose 14, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose135:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose136:
+ax_pose 14, 0x01f4, 0x80f4, 0x4c00
+ax_pose 0, 0x0205, 0x00ee, 0x4c10
+ax_pose 2, 0x4200, 0x00f0, 0x4c11
+ax_pose 1, 0x41fc, 0x40ef, 0x4c13
+ax_pose -1, 0x01f7, 0x0100, 0x4c10
+ax_pose_terminator
+sDiglettPose137:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose138:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose139:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose140:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose141:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose142:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose143:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose144:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose145:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose146:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose147:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose148:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose149:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose150:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose151:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose152:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose153:
+ax_pose 27, 0x41f5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDiglettPose154:
+ax_pose 28, 0x41f5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDiglettPose155:
+ax_pose 29, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDiglettPose156:
+ax_pose 30, 0x01ee, 0x90f1, 0x4c00
+ax_pose_terminator
+sDiglettPose157:
+ax_pose 31, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sDiglettPose158:
+ax_pose 32, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sDiglettPose159:
+ax_pose 33, 0x01ed, 0x80f1, 0x4c00
+ax_pose_terminator
+sDiglettPose160:
+ax_pose 32, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDiglettPose161:
+ax_pose 31, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sDiglettPose162:
+ax_pose 30, 0x01ee, 0x80ef, 0x4c00
+ax_pose_terminator
+sDiglettPose163:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose164:
+ax_pose 34, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose165:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose166:
+ax_pose 35, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose167:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose168:
+ax_pose 36, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose169:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose170:
+ax_pose 37, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose171:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose172:
+ax_pose 38, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose173:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose174:
+ax_pose 39, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose175:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose176:
+ax_pose 40, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose177:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose178:
+ax_pose 41, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose179:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose180:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f6, 0x00f2, 0x4c08
+ax_pose 0, 0x01f6, 0x00f1, 0x4c0a
+ax_pose_terminator
+sDiglettPose181:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f4, 0x00f6, 0x4c08
+ax_pose 0, 0x01f3, 0x00f5, 0x4c0a
+ax_pose_terminator
+sDiglettPose182:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f4, 0x00f9, 0x4c08
+ax_pose 0, 0x01f1, 0x00fc, 0x4c0a
+ax_pose_terminator
+sDiglettPose183:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f4, 0x00fe, 0x4c08
+ax_pose 0, 0x01f1, 0x0106, 0x4c0a
+ax_pose_terminator
+sDiglettPose184:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41fb, 0x0100, 0x4c08
+ax_pose 0, 0x01f9, 0x010a, 0x4c0a
+ax_pose_terminator
+sDiglettPose185:
+ax_pose 0, 0x0201, 0x0104, 0x4c00
+ax_pose 2, 0x41ff, 0x00fc, 0x4c01
+ax_pose 16, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose186:
+ax_pose 0, 0x0203, 0x00fd, 0x4c00
+ax_pose 2, 0x41ff, 0x00f7, 0x4c01
+ax_pose 13, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose187:
+ax_pose 0, 0x0203, 0x00f5, 0x4c00
+ax_pose 2, 0x41ff, 0x00f2, 0x4c01
+ax_pose 10, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose188:
+ax_pose 0, 0x0203, 0x00f5, 0x4c00
+ax_pose 2, 0x41ff, 0x00f4, 0x4c01
+ax_pose 26, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose189:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41fa, 0x00ef, 0x4c08
+ax_pose_terminator
+sDiglettPose190:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f8, 0x00f0, 0x4c08
+ax_pose 0, 0x01f8, 0x00ef, 0x4c0a
+ax_pose_terminator
+sDiglettPose191:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f4, 0x00f4, 0x4c08
+ax_pose 0, 0x01f2, 0x00f2, 0x4c0a
+ax_pose_terminator
+sDiglettPose192:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f4, 0x00fa, 0x4c08
+ax_pose 0, 0x01f1, 0x0100, 0x4c0a
+ax_pose_terminator
+sDiglettPose193:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f6, 0x0100, 0x4c08
+ax_pose 0, 0x01f3, 0x0108, 0x4c0a
+ax_pose_terminator
+sDiglettPose194:
+ax_pose 2, 0x41fd, 0x0102, 0x4c00
+ax_pose 0, 0x01fb, 0x010d, 0x4c02
+ax_pose 19, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose195:
+ax_pose 0, 0x0201, 0x0100, 0x4c00
+ax_pose 2, 0x41ff, 0x00fa, 0x4c01
+ax_pose 16, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose196:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose197:
+ax_pose 0, 0x0201, 0x00f2, 0x4c00
+ax_pose 2, 0x41fe, 0x00f2, 0x4c01
+ax_pose 10, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose198:
+ax_pose 0, 0x01fa, 0x00ec, 0x4c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c01
+ax_pose 2, 0x41f9, 0x00ef, 0x4c09
+ax_pose_terminator
+sDiglettPose199:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose200:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose201:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose202:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f9, 0x0100, 0x4c08
+ax_pose 0, 0x01f7, 0x010a, 0x4c0a
+ax_pose_terminator
+sDiglettPose203:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose204:
+ax_pose 0, 0x0202, 0x00f9, 0x4c00
+ax_pose 2, 0x41ff, 0x00f5, 0x4c01
+ax_pose 13, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose205:
+ax_pose 0, 0x0204, 0x00ff, 0x4c00
+ax_pose 2, 0x4200, 0x00fa, 0x4c01
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose206:
+ax_pose 0, 0x0203, 0x0104, 0x4c00
+ax_pose 2, 0x41ff, 0x00fd, 0x4c01
+ax_pose 10, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose207:
+ax_pose 0, 0x01ff, 0x00eb, 0x4c00
+ax_pose 2, 0x41fc, 0x00ed, 0x4c01
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose208:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f2, 0x00f8, 0x4c08
+ax_pose 0, 0x01ee, 0x00f9, 0x4c0a
+ax_pose_terminator
+sDiglettPose209:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f9, 0x00ee, 0x4c08
+ax_pose 0, 0x01f7, 0x00ec, 0x4c0a
+ax_pose_terminator
+sDiglettPose210:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f6, 0x00ef, 0x4c08
+ax_pose 0, 0x01f4, 0x00ee, 0x4c0a
+ax_pose_terminator
+sDiglettPose211:
+ax_pose 0, 0x0201, 0x0106, 0x4c00
+ax_pose 2, 0x41ff, 0x00ff, 0x4c01
+ax_pose 19, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose212:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f3, 0x00f8, 0x4c08
+ax_pose 0, 0x01f2, 0x0102, 0x4c0a
+ax_pose_terminator
+sDiglettPose213:
+ax_pose 0, 0x01fe, 0x010b, 0x4c00
+ax_pose 2, 0x41fc, 0x0103, 0x4c01
+ax_pose 13, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose214:
+ax_pose 0, 0x0201, 0x0106, 0x4c00
+ax_pose 2, 0x41fe, 0x00ff, 0x4c01
+ax_pose 10, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose215:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f6, 0x00f1, 0x4c08
+ax_pose 0, 0x01f5, 0x00ee, 0x4c0a
+ax_pose_terminator
+sDiglettPose216:
+ax_pose 0, 0x0201, 0x00fc, 0x4c00
+ax_pose 2, 0x41fe, 0x00f8, 0x4c01
+ax_pose 25, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose217:
+ax_pose 2, 0x41fe, 0x00ec, 0x4c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c02
+ax_pose 0, 0x01fe, 0x00e9, 0x4c0a
+ax_pose_terminator
+sDiglettPose218:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f6, 0x00f1, 0x4c08
+ax_pose 0, 0x01f3, 0x00f4, 0x4c0a
+ax_pose_terminator
+sDiglettPose219:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose220:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f5, 0x00fc, 0x4c08
+ax_pose 0, 0x01f4, 0x0106, 0x4c0a
+ax_pose_terminator
+sDiglettPose221:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose 0, 0x01fb, 0x010b, 0x4c08
+ax_pose 2, 0x41f9, 0x0101, 0x4c09
+ax_pose_terminator
+sDiglettPose222:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41fa, 0x0101, 0x4c08
+ax_pose_terminator
+sDiglettPose223:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose224:
+ax_pose 0, 0x01ff, 0x00ee, 0x4c00
+ax_pose 2, 0x41fe, 0x00f0, 0x4c01
+ax_pose 25, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose225:
+ax_pose 0, 0x0201, 0x00ff, 0x4c00
+ax_pose 2, 0x41fe, 0x00fa, 0x4c01
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose226:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f4, 0x00f7, 0x4c08
+ax_pose 0, 0x01f1, 0x00ff, 0x4c0a
+ax_pose_terminator
+sDiglettPose227:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f3, 0x00f4, 0x4c08
+ax_pose 0, 0x01ef, 0x00f7, 0x4c0a
+ax_pose_terminator
+sDiglettPose228:
+ax_pose 0, 0x0202, 0x00ee, 0x4c00
+ax_pose 2, 0x4200, 0x00f0, 0x4c01
+ax_pose 25, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose229:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose 2, 0x41f7, 0x0101, 0x4c08
+ax_pose 0, 0x01f7, 0x010b, 0x4c0a
+ax_pose_terminator
+sDiglettPose230:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose231:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose232:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose233:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose234:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose235:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose236:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose237:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose238:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose239:
+ax_pose 11, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose240:
+ax_pose 9, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose241:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose242:
+ax_pose 14, 0x01f3, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose243:
+ax_pose 12, 0x41f5, 0x90ec, 0x4c00
+ax_pose_terminator
+sDiglettPose244:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose245:
+ax_pose 17, 0x01f4, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose246:
+ax_pose 15, 0x41f5, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose247:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose248:
+ax_pose 20, 0x01f4, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose249:
+ax_pose 18, 0x41f5, 0x90eb, 0x4c00
+ax_pose_terminator
+sDiglettPose250:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose251:
+ax_pose 23, 0x01f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose252:
+ax_pose 21, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose253:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose254:
+ax_pose 20, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose255:
+ax_pose 18, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose256:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose257:
+ax_pose 17, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose258:
+ax_pose 15, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose259:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose260:
+ax_pose 14, 0x01f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose261:
+ax_pose 12, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose262:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose263:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose264:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose265:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose266:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose267:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose268:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose269:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose270:
+ax_pose 10, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose271:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose272:
+ax_pose 25, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose273:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose274:
+ax_pose 22, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose275:
+ax_pose 19, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose276:
+ax_pose 16, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose277:
+ax_pose 13, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose278:
+ax_pose 8, 0x01fc, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose279:
+ax_pose 5, 0x01fc, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose280:
+ax_pose 0, 0x01fc, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose281:
+ax_pose 7, 0x41fc, 0x00f8, 0x4c00
+ax_pose_terminator
+sDiglettPose282:
+ax_pose 3, 0x41fc, 0x00f8, 0x4c00
+ax_pose_terminator
+sDiglettPose283:
+ax_pose 2, 0x41fb, 0x00f8, 0x4c00
+ax_pose_terminator
+sDiglettPose284:
+ax_pose 6, 0x41fb, 0x40f0, 0x4c00
+ax_pose_terminator
+sDiglettPose285:
+ax_pose 4, 0x41fb, 0x40f0, 0x4c00
+ax_pose_terminator
+sDiglettPose286:
+ax_pose 1, 0x41fb, 0x40f0, 0x4c00
+ax_pose_terminator
+sDiglettPose287:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose288:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose289:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose290:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose291:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose292:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose293:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose294:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose295:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c02
+ax_pose_terminator
+sDiglettPose296:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 10, 0x41f5, 0x80f5, 0x4c02
+ax_pose_terminator
+sDiglettPose297:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 10, 0x41f5, 0x80f5, 0x4c01
+ax_pose_terminator
+sDiglettPose298:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose299:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose300:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose301:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose302:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose303:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose304:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose305:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose306:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c02
+ax_pose_terminator
+sDiglettPose307:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 26, 0x41f5, 0x90ec, 0x4c02
+ax_pose_terminator
+sDiglettPose308:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 26, 0x41f5, 0x90ec, 0x4c01
+ax_pose_terminator
+sDiglettPose309:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose310:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose311:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose312:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose313:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose314:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose315:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose316:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose317:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c02
+ax_pose_terminator
+sDiglettPose318:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 25, 0x41f5, 0x90ec, 0x4c02
+ax_pose_terminator
+sDiglettPose319:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 25, 0x41f5, 0x90ec, 0x4c01
+ax_pose_terminator
+sDiglettPose320:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose321:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose322:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose323:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose324:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose325:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose326:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose327:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c03
+ax_pose_terminator
+sDiglettPose328:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c02
+ax_pose_terminator
+sDiglettPose329:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 24, 0x41f5, 0x90ec, 0x4c02
+ax_pose_terminator
+sDiglettPose330:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 24, 0x41f5, 0x90ec, 0x4c01
+ax_pose_terminator
+sDiglettPose331:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose332:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose333:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose334:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose335:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose336:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose337:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose338:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose339:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c02
+ax_pose_terminator
+sDiglettPose340:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 22, 0x41f5, 0x80f5, 0x4c02
+ax_pose_terminator
+sDiglettPose341:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 22, 0x41f5, 0x80f5, 0x4c01
+ax_pose_terminator
+sDiglettPose342:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose343:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose344:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose345:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose346:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose347:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose348:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose349:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose350:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c02
+ax_pose_terminator
+sDiglettPose351:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 24, 0x41f5, 0x80f4, 0x4c02
+ax_pose_terminator
+sDiglettPose352:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 24, 0x41f5, 0x80f4, 0x4c01
+ax_pose_terminator
+sDiglettPose353:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose354:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose355:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose356:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose357:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose358:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose359:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose360:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c03
+ax_pose_terminator
+sDiglettPose361:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c02
+ax_pose_terminator
+sDiglettPose362:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 25, 0x41f5, 0x80f5, 0x4c02
+ax_pose_terminator
+sDiglettPose363:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 25, 0x41f5, 0x80f5, 0x4c01
+ax_pose_terminator
+sDiglettPose364:
+ax_pose 42, 0x01f9, 0x04fa, 0x6c00
+ax_pose 43, 0x01fd, 0x0500, 0x6c01
+ax_pose -1, 0x01f7, 0x04fe, 0x6c00
+ax_pose -1, 0x01fd, 0x04fb, 0x6c01
+ax_pose 44, 0x01f5, 0x04fa, 0x6c02
+ax_pose -1, 0x01fa, 0x0502, 0x6c02
+ax_pose -1, 0x01fa, 0x04f6, 0x6c02
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose365:
+ax_pose 42, 0x01f5, 0x14f6, 0x6c00
+ax_pose 43, 0x01ff, 0x2504, 0x6c01
+ax_pose -1, 0x01f3, 0x2500, 0x6c00
+ax_pose -1, 0x01ff, 0x14f7, 0x6c01
+ax_pose 44, 0x01ed, 0x14f7, 0x6c02
+ax_pose -1, 0x01f7, 0x1504, 0x6c02
+ax_pose -1, 0x01f9, 0x24f2, 0x6c02
+ax_pose -1, 0x01f9, 0x04fc, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose366:
+ax_pose 42, 0x01f1, 0x34f2, 0x6c00
+ax_pose 43, 0x0201, 0x3508, 0x6c01
+ax_pose -1, 0x01ef, 0x3502, 0x6c00
+ax_pose -1, 0x0201, 0x24f3, 0x6c01
+ax_pose 44, 0x01e7, 0x34f3, 0x6c02
+ax_pose -1, 0x01f5, 0x350a, 0x6c02
+ax_pose -1, 0x01fa, 0x34ee, 0x6c02
+ax_pose -1, 0x01f7, 0x14fd, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose367:
+ax_pose 42, 0x01ee, 0x24ef, 0x6c00
+ax_pose 43, 0x0204, 0x150b, 0x6c01
+ax_pose -1, 0x01ec, 0x1505, 0x6c00
+ax_pose -1, 0x0202, 0x34f0, 0x6c01
+ax_pose 44, 0x01e3, 0x24f0, 0x6c02
+ax_pose -1, 0x01f4, 0x250e, 0x6c02
+ax_pose -1, 0x01fc, 0x14ea, 0x6c02
+ax_pose -1, 0x01f6, 0x34fd, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose368:
+ax_pose 42, 0x01ec, 0x04eb, 0x6c00
+ax_pose 43, 0x0205, 0x050c, 0x6c01
+ax_pose -1, 0x01ea, 0x0508, 0x6c00
+ax_pose -1, 0x0204, 0x14ee, 0x6c01
+ax_pose 44, 0x01e0, 0x04ed, 0x6c02
+ax_pose -1, 0x01f4, 0x0511, 0x6c02
+ax_pose -1, 0x01ff, 0x04e7, 0x6c02
+ax_pose -1, 0x01f8, 0x24fe, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose369:
+ax_pose 42, 0x01eb, 0x14e7, 0x6c00
+ax_pose 43, 0x0207, 0x250d, 0x6c01
+ax_pose -1, 0x01e8, 0x250a, 0x6c00
+ax_pose -1, 0x0206, 0x04ed, 0x6c01
+ax_pose 44, 0x01de, 0x14ea, 0x6c02
+ax_pose -1, 0x01f5, 0x1514, 0x6c02
+ax_pose -1, 0x0202, 0x24e4, 0x6c02
+ax_pose -1, 0x01fb, 0x04ff, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose370:
+ax_pose 42, 0x01eb, 0x34e4, 0x6c00
+ax_pose -1, 0x01e7, 0x350c, 0x6c00
+ax_pose 43, 0x0209, 0x24ec, 0x6c01
+ax_pose 44, 0x01dd, 0x34e8, 0x6c02
+ax_pose -1, 0x01f7, 0x3517, 0x6c02
+ax_pose -1, 0x0206, 0x34e2, 0x6c02
+ax_pose -1, 0x01fe, 0x14ff, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose371:
+ax_pose 42, 0x01ec, 0x24e2, 0x6c00
+ax_pose 43, 0x0209, 0x150f, 0x6c01
+ax_pose -1, 0x01e7, 0x150e, 0x6c00
+ax_pose -1, 0x020d, 0x34eb, 0x6c01
+ax_pose 44, 0x01dd, 0x24e6, 0x6c02
+ax_pose -1, 0x01fa, 0x251a, 0x6c02
+ax_pose -1, 0x0201, 0x34ff, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c03
+ax_pose_terminator
+sDiglettPose372:
+ax_pose 42, 0x01ef, 0x04df, 0x6c00
+ax_pose -1, 0x01e8, 0x0512, 0x6c00
+ax_pose 44, 0x01df, 0x04e3, 0x6c01
+ax_pose -1, 0x01fe, 0x051c, 0x6c01
+ax_pose -1, 0x0210, 0x04e0, 0x6c01
+ax_pose -1, 0x0202, 0x151d, 0x6c01
+ax_pose -1, 0x0208, 0x0500, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c02
+ax_pose_terminator
+sDiglettPose373:
+ax_pose 42, 0x01f2, 0x14dd, 0x6c00
+ax_pose -1, 0x01ea, 0x2515, 0x6c00
+ax_pose 44, 0x01e2, 0x14e1, 0x6c01
+ax_pose 26, 0x41f5, 0x80f4, 0x4c02
+ax_pose_terminator
+sDiglettPose374:
+ax_pose 44, 0x0207, 0x351e, 0x6c00
+ax_pose 26, 0x41f5, 0x80f4, 0x4c01
+ax_pose_terminator
+sDiglettPose375:
+ax_pose 8, 0x01fc, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose376:
+ax_pose 5, 0x01fc, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose377:
+ax_pose 0, 0x01fc, 0x00fc, 0x4c00
+ax_pose_terminator
+sDiglettPose378:
+ax_pose 7, 0x41fc, 0x00f8, 0x4c00
+ax_pose_terminator
+sDiglettPose379:
+ax_pose 3, 0x41fc, 0x00f8, 0x4c00
+ax_pose_terminator
+sDiglettPose380:
+ax_pose 2, 0x41fb, 0x00f8, 0x4c00
+ax_pose_terminator
+sDiglettPose381:
+ax_pose 6, 0x41fb, 0x40f0, 0x4c00
+ax_pose_terminator
+sDiglettPose382:
+ax_pose 4, 0x41fb, 0x40f0, 0x4c00
+ax_pose_terminator
+sDiglettPose383:
+ax_pose 1, 0x41fb, 0x40f0, 0x4c00
+ax_pose_terminator
+sDiglettPose384:
+ax_pose 10, 0x41f5, 0x80f5, 0x4c00
+ax_pose_terminator
+sDiglettPose385:
+ax_pose 26, 0x41f5, 0x90ec, 0x4c00
+ax_pose_terminator
+sDiglettPose386:
+ax_pose 25, 0x41f5, 0x90ec, 0x4c00
+ax_pose_terminator
+sDiglettPose387:
+ax_pose 24, 0x41f5, 0x90ec, 0x4c00
+ax_pose_terminator
+sDiglettPose388:
+ax_pose 22, 0x41f5, 0x80f5, 0x4c00
+ax_pose_terminator
+sDiglettPose389:
+ax_pose 24, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+sDiglettPose390:
+ax_pose 25, 0x41f5, 0x80f5, 0x4c00
+ax_pose_terminator
+sDiglettPose391:
+ax_pose 26, 0x41f5, 0x80f4, 0x4c00
+ax_pose_terminator
+.align 2
+sDiglettAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_2_1:
+ax_anim 2, 0, 28, 0, -2, 0, -2,
+ax_anim 6, 0, 28, 0, -3, 0, -3,
+ax_anim 2, 2, 25, 0, 9, 0, 9,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 30, 0, 6, 0, 6,
+ax_anim 2, 0, 30, 0, 3, 0, 3,
+ax_anim_terminator
+sDiglettAnims_2_2:
+ax_anim 2, 0, 35, -2, -2, -2, -2,
+ax_anim 6, 0, 35, -3, -3, -3, -3,
+ax_anim 2, 2, 32, 9, 9, 9, 9,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 32, 17, 19, 17, 19,
+ax_anim 2, 0, 33, 18, 18, 18, 18,
+ax_anim 2, 0, 33, 17, 19, 17, 19,
+ax_anim 2, 0, 37, 6, 6, 6, 6,
+ax_anim 2, 0, 37, 3, 3, 3, 3,
+ax_anim_terminator
+sDiglettAnims_2_3:
+ax_anim 2, 0, 42, -2, 0, -2, 0,
+ax_anim 6, 0, 42, -3, 0, -3, 0,
+ax_anim 2, 2, 40, 8, 0, 8, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 39, 18, -1, 18, -1,
+ax_anim 2, 0, 40, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, -1, 18, -1,
+ax_anim 2, 0, 44, 6, 0, 6, 0,
+ax_anim 2, 0, 44, 3, 0, 3, 0,
+ax_anim_terminator
+sDiglettAnims_2_4:
+ax_anim 2, 0, 49, -2, 2, -2, 2,
+ax_anim 6, 0, 49, -3, 3, -3, 3,
+ax_anim 2, 2, 47, 9, -9, 9, -9,
+ax_anim 2, 0, 45, 18, -18, 18, -18,
+ax_anim 2, 1, 46, 17, -19, 17, -19,
+ax_anim 2, 0, 47, 18, -18, 18, -18,
+ax_anim 2, 0, 45, 17, -19, 17, -19,
+ax_anim 2, 0, 51, 6, -6, 6, -6,
+ax_anim 2, 0, 51, 3, -3, 3, -3,
+ax_anim_terminator
+sDiglettAnims_2_5:
+ax_anim 2, 0, 56, 0, 2, 0, 2,
+ax_anim 6, 0, 56, 0, 3, 0, 3,
+ax_anim 2, 2, 54, 0, -10, 0, -10,
+ax_anim 2, 0, 52, 0, -18, 0, -18,
+ax_anim 2, 1, 53, 1, -18, 1, -18,
+ax_anim 2, 0, 54, 0, -18, 0, -18,
+ax_anim 2, 0, 52, 1, -18, 1, -18,
+ax_anim 2, 0, 58, 0, -6, 0, -6,
+ax_anim 2, 0, 58, 0, -3, 0, -3,
+ax_anim_terminator
+sDiglettAnims_2_6:
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 6, 0, 63, 3, 3, 3, 3,
+ax_anim 2, 2, 61, -9, -9, -9, -9,
+ax_anim 2, 0, 59, -18, -18, -18, -18,
+ax_anim 2, 1, 60, -17, -19, -17, -19,
+ax_anim 2, 0, 61, -18, -18, -18, -18,
+ax_anim 2, 0, 59, -17, -19, -17, -19,
+ax_anim 2, 0, 65, -6, -6, -6, -6,
+ax_anim 2, 0, 65, -3, -3, -3, -3,
+ax_anim_terminator
+sDiglettAnims_2_7:
+ax_anim 2, 0, 42, -2, 0, -2, 0,
+ax_anim 6, 0, 70, 3, 0, 3, 0,
+ax_anim 2, 2, 68, -8, 0, -8, 0,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, -1, -18, -1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -18, -1, -18, -1,
+ax_anim 2, 0, 72, -6, 0, -6, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sDiglettAnims_2_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 2, 74, -9, 9, -9, 9,
+ax_anim 2, 0, 73, -18, 18, -18, 18,
+ax_anim 2, 1, 74, -17, 19, -17, 19,
+ax_anim 2, 0, 75, -18, 18, -18, 18,
+ax_anim 2, 0, 75, -17, 19, -17, 19,
+ax_anim 2, 0, 79, -6, 6, -6, 6,
+ax_anim 2, 0, 79, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDiglettAnims_3_1:
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim 6, 0, 84, 0, -3, 0, -3,
+ax_anim 2, 2, 81, 0, 9, 0, 9,
+ax_anim 2, 0, 80, 0, 18, 0, 18,
+ax_anim 2, 1, 81, 1, 18, 1, 18,
+ax_anim 2, 0, 82, 0, 18, 0, 18,
+ax_anim 2, 0, 80, 1, 18, 1, 18,
+ax_anim 2, 0, 86, 0, 6, 0, 6,
+ax_anim 2, 0, 86, 0, 3, 0, 3,
+ax_anim_terminator
+sDiglettAnims_3_2:
+ax_anim 2, 0, 91, -2, -2, -2, -2,
+ax_anim 6, 0, 91, -3, -3, -3, -3,
+ax_anim 2, 2, 88, 9, 9, 9, 9,
+ax_anim 2, 0, 87, 18, 18, 18, 18,
+ax_anim 2, 1, 88, 17, 19, 17, 19,
+ax_anim 2, 0, 89, 18, 18, 18, 18,
+ax_anim 2, 0, 89, 17, 19, 17, 19,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim_terminator
+sDiglettAnims_3_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 6, 0, 98, -3, 0, -3, 0,
+ax_anim 2, 2, 96, 8, 0, 8, 0,
+ax_anim 2, 0, 94, 18, 0, 18, 0,
+ax_anim 2, 1, 95, 18, -1, 18, -1,
+ax_anim 2, 0, 96, 18, 0, 18, 0,
+ax_anim 2, 0, 94, 18, -1, 18, -1,
+ax_anim 2, 0, 100, 6, 0, 6, 0,
+ax_anim 2, 0, 100, 3, 0, 3, 0,
+ax_anim_terminator
+sDiglettAnims_3_4:
+ax_anim 2, 0, 105, -2, 2, -2, 2,
+ax_anim 6, 0, 105, -3, 3, -3, 3,
+ax_anim 2, 2, 103, 9, -9, 9, -9,
+ax_anim 2, 0, 101, 18, -18, 18, -18,
+ax_anim 2, 1, 102, 17, -19, 17, -19,
+ax_anim 2, 0, 103, 18, -18, 18, -18,
+ax_anim 2, 0, 101, 17, -19, 17, -19,
+ax_anim 2, 0, 107, 6, -6, 6, -6,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim_terminator
+sDiglettAnims_3_5:
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim 6, 0, 112, 0, 3, 0, 3,
+ax_anim 2, 2, 110, 0, -10, 0, -10,
+ax_anim 2, 0, 108, 0, -18, 0, -18,
+ax_anim 2, 1, 109, 1, -18, 1, -18,
+ax_anim 2, 0, 110, 0, -18, 0, -18,
+ax_anim 2, 0, 108, 1, -18, 1, -18,
+ax_anim 2, 0, 114, 0, -6, 0, -6,
+ax_anim 2, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sDiglettAnims_3_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 6, 0, 119, 3, 3, 3, 3,
+ax_anim 2, 2, 117, -9, -9, -9, -9,
+ax_anim 2, 0, 115, -18, -18, -18, -18,
+ax_anim 2, 1, 116, -17, -19, -17, -19,
+ax_anim 2, 0, 117, -18, -18, -18, -18,
+ax_anim 2, 0, 115, -17, -19, -17, -19,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim_terminator
+sDiglettAnims_3_7:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 6, 0, 126, 3, 0, 3, 0,
+ax_anim 2, 2, 124, -8, 0, -8, 0,
+ax_anim 2, 0, 122, -18, 0, -18, 0,
+ax_anim 2, 1, 123, -18, -1, -18, -1,
+ax_anim 2, 0, 124, -18, 0, -18, 0,
+ax_anim 2, 0, 122, -18, -1, -18, -1,
+ax_anim 2, 0, 128, -6, 0, -6, 0,
+ax_anim 2, 0, 128, -3, 0, -3, 0,
+ax_anim_terminator
+sDiglettAnims_3_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 6, 0, 133, 3, -3, 3, -3,
+ax_anim 2, 2, 130, -9, 9, -9, 9,
+ax_anim 2, 0, 129, -18, 18, -18, 18,
+ax_anim 2, 1, 130, -17, 19, -17, 19,
+ax_anim 2, 0, 131, -18, 18, -18, 18,
+ax_anim 2, 0, 131, -17, 19, -17, 19,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDiglettAnims_4_1:
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 1, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_4_2:
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_4_3:
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_4_4:
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_4_5:
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 1, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_4_6:
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_4_7:
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_4_8:
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 1, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_5_1:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_5_2:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_5_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_5_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_5_5:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_5_6:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_5_7:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_5_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sDiglettAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sDiglettAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sDiglettAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sDiglettAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sDiglettAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sDiglettAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sDiglettAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDiglettAnims_8_1:
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_8_2:
+ax_anim 16, 0, 176, 0, 0, 0, 0,
+ax_anim 16, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_8_3:
+ax_anim 16, 0, 174, 0, 0, 0, 0,
+ax_anim 16, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_8_4:
+ax_anim 16, 0, 172, 0, 0, 0, 0,
+ax_anim 16, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_8_5:
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim 16, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_8_6:
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_8_7:
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim 16, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_8_8:
+ax_anim 16, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 16, 7, 16,
+ax_anim 3, 0, 182, 0, 18, 0, 18,
+ax_anim 2, 3, 183, -7, 16, -7, 16,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_9_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 6, 0, 6, 0,
+ax_anim 2, 0, 189, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 24, 9, 24, 9,
+ax_anim 3, 0, 191, 19, 17, 19, 17,
+ax_anim 2, 3, 192, 11, 17, 11, 17,
+ax_anim 2, 0, 193, 2, 12, 2, 12,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_9_3:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 3, -4, 3, -4,
+ax_anim 2, 0, 196, 11, -6, 11, -6,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 20, 1, 20, 1,
+ax_anim 2, 3, 191, 17, 5, 17, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_9_4:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -1, -6, -1, -6,
+ax_anim 2, 0, 203, 3, -16, 3, -16,
+ax_anim 2, 0, 196, 11, -25, 11, -25,
+ax_anim 3, 0, 206, 19, -26, 19, -26,
+ax_anim 2, 3, 190, 21, -17, 21, -17,
+ax_anim 2, 0, 191, 16, -6, 16, -6,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_9_5:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -8, -10, -8, -10,
+ax_anim 2, 0, 185, -7, -20, -7, -20,
+ax_anim 3, 0, 196, 0, -26, 0, -26,
+ax_anim 2, 3, 214, 7, -20, 7, -20,
+ax_anim 2, 0, 207, 10, -8, 10, -8,
+ax_anim 1, 0, 191, 4, -2, 4, -2,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_9_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 1, -6, 1, -6,
+ax_anim 2, 0, 204, -3, -16, -3, -16,
+ax_anim 2, 0, 205, -11, -25, -11, -25,
+ax_anim 3, 0, 212, -19, -26, -19, -26,
+ax_anim 2, 3, 211, -21, -17, -21, -17,
+ax_anim 2, 0, 226, -16, -6, -16, -6,
+ax_anim 1, 0, 209, -7, -1, -7, -1,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_9_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 224, -3, -4, -3, -4,
+ax_anim 2, 0, 213, -11, -6, -11, -6,
+ax_anim 2, 0, 220, -17, -4, -17, -4,
+ax_anim 3, 0, 219, -20, 1, -20, 1,
+ax_anim 2, 3, 225, -17, 5, -17, 5,
+ax_anim 2, 0, 217, -12, 7, -12, 7,
+ax_anim 1, 0, 208, -4, 5, -4, 5,
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_9_8:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 221, -6, 0, -6, 0,
+ax_anim 2, 0, 228, -17, 3, -17, 3,
+ax_anim 2, 0, 219, -24, 9, -24, 9,
+ax_anim 3, 0, 226, -19, 17, -19, 17,
+ax_anim 2, 3, 209, -11, 17, -11, 17,
+ax_anim 2, 0, 216, -2, 12, -2, 12,
+ax_anim 1, 0, 227, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_10_1:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 6, 0, 6, 0,
+ax_anim 2, 0, 229, -6, 0, -6, 0,
+ax_anim 2, 0, 229, 10, 0, 10, 0,
+ax_anim 2, 0, 229, -10, 0, -10, 0,
+ax_anim 2, 0, 229, 12, 0, 12, 0,
+ax_anim 3, 0, 229, -12, 0, -12, 0,
+ax_anim 3, 0, 229, 13, 0, 13, 0,
+ax_anim 3, 0, 229, -13, 0, -13, 0,
+ax_anim 2, 0, 229, 12, 0, 12, 0,
+ax_anim 3, 0, 229, -12, 0, -12, 0,
+ax_anim 2, 0, 229, 10, 0, 10, 0,
+ax_anim 2, 0, 229, -10, 0, -10, 0,
+ax_anim 2, 0, 229, 6, 0, 6, 0,
+ax_anim 2, 0, 229, -6, 0, -6, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_10_2:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 6, -6, 6, -6,
+ax_anim 2, 0, 230, -6, 6, -6, 6,
+ax_anim 2, 0, 230, 10, -10, 10, -10,
+ax_anim 2, 0, 230, -10, 10, -10, 10,
+ax_anim 2, 0, 230, 12, -12, 12, -12,
+ax_anim 3, 0, 230, -12, 12, -12, 12,
+ax_anim 3, 0, 230, 13, -13, 13, -13,
+ax_anim 3, 0, 230, -13, 13, -13, 13,
+ax_anim 2, 0, 230, 12, -12, 12, -12,
+ax_anim 3, 0, 230, -12, 12, -12, 12,
+ax_anim 2, 0, 230, 10, -10, 10, -10,
+ax_anim 2, 0, 230, -10, 10, -10, 10,
+ax_anim 2, 0, 230, 6, -6, 6, -6,
+ax_anim 2, 0, 230, -6, 6, -6, 6,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_10_3:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -6, 0, -6,
+ax_anim 2, 0, 231, 0, 6, 0, 6,
+ax_anim 2, 0, 231, 0, -10, 0, -10,
+ax_anim 2, 0, 231, 0, 10, 0, 10,
+ax_anim 2, 0, 231, 0, -12, 0, -12,
+ax_anim 3, 0, 231, 0, 12, 0, 12,
+ax_anim 3, 0, 231, 0, -13, 0, -13,
+ax_anim 3, 0, 231, 0, 13, 0, 13,
+ax_anim 2, 0, 231, 0, -12, 0, -12,
+ax_anim 3, 0, 231, 0, 12, 0, 12,
+ax_anim 2, 0, 231, 0, -10, 0, -10,
+ax_anim 2, 0, 231, 0, 10, 0, 10,
+ax_anim 2, 0, 231, 0, -6, 0, -6,
+ax_anim 2, 0, 231, 0, 6, 0, 6,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_10_4:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -6, -6, -6, -6,
+ax_anim 2, 0, 232, 6, 6, 6, 6,
+ax_anim 2, 0, 232, -10, -10, -10, -10,
+ax_anim 2, 0, 232, 10, 10, 10, 10,
+ax_anim 2, 0, 232, -12, -12, -12, -12,
+ax_anim 3, 0, 232, 12, 12, 12, 12,
+ax_anim 3, 0, 232, -13, -13, -13, -13,
+ax_anim 3, 0, 232, 13, 13, 13, 13,
+ax_anim 2, 0, 232, -12, -12, -12, -12,
+ax_anim 3, 0, 232, 12, 12, 12, 12,
+ax_anim 2, 0, 232, -10, -10, -10, -10,
+ax_anim 2, 0, 232, 10, 10, 10, 10,
+ax_anim 2, 0, 232, -6, -6, -6, -6,
+ax_anim 2, 0, 232, 6, 6, 6, 6,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_10_5:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 6, 0, 6, 0,
+ax_anim 2, 0, 233, -6, 0, -6, 0,
+ax_anim 2, 0, 233, 10, 0, 10, 0,
+ax_anim 2, 0, 233, -10, 0, -10, 0,
+ax_anim 2, 0, 233, 12, 0, 12, 0,
+ax_anim 3, 0, 233, -12, 0, -12, 0,
+ax_anim 3, 0, 233, 13, 0, 13, 0,
+ax_anim 3, 0, 233, -13, 0, -13, 0,
+ax_anim 2, 0, 233, 12, 0, 12, 0,
+ax_anim 3, 0, 233, -12, 0, -12, 0,
+ax_anim 2, 0, 233, 10, 0, 10, 0,
+ax_anim 2, 0, 233, -10, 0, -10, 0,
+ax_anim 2, 0, 233, 6, 0, 6, 0,
+ax_anim 2, 0, 233, -6, 0, -6, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_10_6:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 6, -6, 6, -6,
+ax_anim 2, 0, 234, -6, 6, -6, 6,
+ax_anim 2, 0, 234, 10, -10, 10, -10,
+ax_anim 2, 0, 234, -10, 10, -10, 10,
+ax_anim 2, 0, 234, 12, -12, 12, -12,
+ax_anim 3, 0, 234, -12, 12, -12, 12,
+ax_anim 3, 0, 234, 13, -13, 13, -13,
+ax_anim 3, 0, 234, -13, 13, -13, 13,
+ax_anim 2, 0, 234, 12, -12, 12, -12,
+ax_anim 3, 0, 234, -12, 12, -12, 12,
+ax_anim 2, 0, 234, 10, -10, 10, -10,
+ax_anim 2, 0, 234, -10, 10, -10, 10,
+ax_anim 2, 0, 234, 6, -6, 6, -6,
+ax_anim 2, 0, 234, -6, 6, -6, 6,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_10_7:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, -6, 0, -6,
+ax_anim 2, 0, 235, 0, 6, 0, 6,
+ax_anim 2, 0, 235, 0, -10, 0, -10,
+ax_anim 2, 0, 235, 0, 10, 0, 10,
+ax_anim 2, 0, 235, 0, -12, 0, -12,
+ax_anim 3, 0, 235, 0, 12, 0, 12,
+ax_anim 3, 0, 235, 0, -13, 0, -13,
+ax_anim 3, 0, 235, 0, 13, 0, 13,
+ax_anim 2, 0, 235, 0, -12, 0, -12,
+ax_anim 3, 0, 235, 0, 12, 0, 12,
+ax_anim 2, 0, 235, 0, -10, 0, -10,
+ax_anim 2, 0, 235, 0, 10, 0, 10,
+ax_anim 2, 0, 235, 0, -6, 0, -6,
+ax_anim 2, 0, 235, 0, 6, 0, 6,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_10_8:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, -6, -6, -6, -6,
+ax_anim 2, 0, 236, 6, 6, 6, 6,
+ax_anim 2, 0, 236, -10, -10, -10, -10,
+ax_anim 2, 0, 236, 10, 10, 10, 10,
+ax_anim 2, 0, 236, -12, -12, -12, -12,
+ax_anim 3, 0, 236, 12, 12, 12, 12,
+ax_anim 3, 0, 236, -13, -13, -13, -13,
+ax_anim 3, 0, 236, 13, 13, 13, 13,
+ax_anim 2, 0, 236, -12, -12, -12, -12,
+ax_anim 3, 0, 236, 12, 12, 12, 12,
+ax_anim 2, 0, 236, -10, -10, -10, -10,
+ax_anim 2, 0, 236, 10, 10, 10, 10,
+ax_anim 2, 0, 236, -6, -6, -6, -6,
+ax_anim 2, 0, 236, 6, 6, 6, 6,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_11_1:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, -1, 0, -1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, -1, 0, -1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_11_2:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_11_3:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_11_4:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_11_5:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, -1, 0, -1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, -1, 0, -1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_11_6:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_11_7:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_11_8:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, 0, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, 0, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_12_1:
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, 0, 1, 0,
+ax_anim 2, 1, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_12_2:
+ax_anim 2, 0, 268, 1, -1, 1, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 1, -1, 1, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 1, -1, 1, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 1, -1, 1, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 1, -1, 1, 0,
+ax_anim 2, 1, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_12_3:
+ax_anim 2, 0, 267, 0, -1, 0, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, -1, 0, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, -1, 0, -1,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, -1, 0, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, -1, 0, -1,
+ax_anim 2, 1, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_12_4:
+ax_anim 2, 0, 266, -1, -1, -1, -1,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, -1, -1, -1, -1,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, -1, -1, -1, -1,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, -1, -1, -1, -1,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, -1, -1, -1, -1,
+ax_anim 2, 1, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_12_5:
+ax_anim 2, 0, 265, 1, 0, 1, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, 0, 1, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, 0, 1, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, 0, 1, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, 0, 1, 0,
+ax_anim 2, 1, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_12_6:
+ax_anim 2, 0, 264, 1, -1, 1, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, -1, 1, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, -1, 1, -1,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, -1, 1, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, -1, 1, -1,
+ax_anim 2, 1, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_12_7:
+ax_anim 2, 0, 263, 0, -1, 0, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, -1, 0, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, -1, 0, -1,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, -1, 0, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, -1, 0, -1,
+ax_anim 2, 1, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_12_8:
+ax_anim 2, 0, 262, -1, -1, -1, -1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, -1, -1, -1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, -1, -1, -1,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, -1, -1, -1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, -1, -1, -1,
+ax_anim 2, 1, 262, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_13_1:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_13_2:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_13_3:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_13_4:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_13_5:
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_13_6:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_13_7:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_13_8:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_14_1:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 1, 0, 295, 0, 0, 0, 0,
+ax_anim 1, 0, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_14_2:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 1, 0, 306, 0, 0, 0, 0,
+ax_anim 1, 0, 307, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_14_3:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 1, 0, 317, 0, 0, 0, 0,
+ax_anim 1, 0, 318, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_14_4:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 1, 0, 328, 0, 0, 0, 0,
+ax_anim 1, 0, 329, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_14_5:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 1, 0, 339, 0, 0, 0, 0,
+ax_anim 1, 0, 340, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_14_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 346, 0, 0, 0, 0,
+ax_anim 2, 0, 347, 0, 0, 0, 0,
+ax_anim 2, 0, 348, 0, 0, 0, 0,
+ax_anim 2, 0, 349, 0, 0, 0, 0,
+ax_anim 1, 0, 350, 0, 0, 0, 0,
+ax_anim 1, 0, 351, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_14_7:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 352, 0, 0, 0, 0,
+ax_anim 2, 0, 353, 0, 0, 0, 0,
+ax_anim 2, 0, 354, 0, 0, 0, 0,
+ax_anim 2, 0, 355, 0, 0, 0, 0,
+ax_anim 2, 0, 356, 0, 0, 0, 0,
+ax_anim 2, 0, 357, 0, 0, 0, 0,
+ax_anim 2, 0, 358, 0, 0, 0, 0,
+ax_anim 2, 0, 359, 0, 0, 0, 0,
+ax_anim 2, 0, 360, 0, 0, 0, 0,
+ax_anim 1, 0, 361, 0, 0, 0, 0,
+ax_anim 1, 0, 362, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_14_8:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 363, 0, 0, 0, 0,
+ax_anim 2, 0, 364, 0, 0, 0, 0,
+ax_anim 2, 0, 365, 0, 0, 0, 0,
+ax_anim 2, 0, 366, 0, 0, 0, 0,
+ax_anim 2, 0, 367, 0, 0, 0, 0,
+ax_anim 2, 0, 368, 0, 0, 0, 0,
+ax_anim 2, 0, 369, 0, 0, 0, 0,
+ax_anim 2, 0, 370, 0, 0, 0, 0,
+ax_anim 2, 0, 371, 0, 0, 0, 0,
+ax_anim 1, 0, 372, 0, 0, 0, 0,
+ax_anim 1, 0, 373, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDiglettAnims_15_1:
+ax_anim 2, 0, 383, 0, 0, 0, 0,
+ax_anim 2, 0, 383, 1, 0, 0, 0,
+ax_anim 2, 0, 383, 0, 0, 0, 0,
+ax_anim 2, 0, 383, 1, 0, 0, 0,
+ax_anim 2, 0, 383, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_15_2:
+ax_anim 2, 0, 384, 0, 0, 0, 0,
+ax_anim 2, 0, 384, 1, 0, 0, 0,
+ax_anim 2, 0, 384, 0, 0, 0, 0,
+ax_anim 2, 0, 384, 1, 0, 0, 0,
+ax_anim 2, 0, 384, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_15_3:
+ax_anim 2, 0, 385, 0, 0, 0, 0,
+ax_anim 2, 0, 385, 1, 0, 0, 0,
+ax_anim 2, 0, 385, 0, 0, 0, 0,
+ax_anim 2, 0, 385, 1, 0, 0, 0,
+ax_anim 2, 0, 385, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_15_4:
+ax_anim 2, 0, 386, 0, 0, 0, 0,
+ax_anim 2, 0, 386, 1, 0, 0, 0,
+ax_anim 2, 0, 386, 0, 0, 0, 0,
+ax_anim 2, 0, 386, 1, 0, 0, 0,
+ax_anim 2, 0, 386, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_15_5:
+ax_anim 2, 0, 387, 0, 0, 0, 0,
+ax_anim 2, 0, 387, 1, 0, 0, 0,
+ax_anim 2, 0, 387, 0, 0, 0, 0,
+ax_anim 2, 0, 387, 1, 0, 0, 0,
+ax_anim 2, 0, 387, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_15_6:
+ax_anim 2, 0, 388, 0, 0, 0, 0,
+ax_anim 2, 0, 388, 1, 0, 0, 0,
+ax_anim 2, 0, 388, 0, 0, 0, 0,
+ax_anim 2, 0, 388, 1, 0, 0, 0,
+ax_anim 2, 0, 388, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_15_7:
+ax_anim 2, 0, 389, 0, 0, 0, 0,
+ax_anim 2, 0, 389, 1, 0, 0, 0,
+ax_anim 2, 0, 389, 0, 0, 0, 0,
+ax_anim 2, 0, 389, 1, 0, 0, 0,
+ax_anim 2, 0, 389, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettAnims_15_8:
+ax_anim 2, 0, 390, 0, 0, 0, 0,
+ax_anim 2, 0, 390, 1, 0, 0, 0,
+ax_anim 2, 0, 390, 0, 0, 0, 0,
+ax_anim 2, 0, 390, 1, 0, 0, 0,
+ax_anim 2, 0, 390, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim_terminator
+sDiglettGfx1:
+.incbin "baserom.gba", 0x71D8CC, 0x20
+sDiglettSprites1:
+ax_sprite sDiglettGfx1, 0x20
+ax_sprite_terminator
+sDiglettGfx2:
+.incbin "baserom.gba", 0x71D8FC, 0x80
+sDiglettSprites2:
+ax_sprite sDiglettGfx2, 0x80
+ax_sprite_terminator
+sDiglettGfx3:
+.incbin "baserom.gba", 0x71D98C, 0x40
+sDiglettSprites3:
+ax_sprite sDiglettGfx3, 0x40
+ax_sprite_terminator
+sDiglettGfx4:
+.incbin "baserom.gba", 0x71D9DC, 0x40
+sDiglettSprites4:
+ax_sprite sDiglettGfx4, 0x40
+ax_sprite_terminator
+sDiglettGfx5:
+.incbin "baserom.gba", 0x71DA2C, 0x80
+sDiglettSprites5:
+ax_sprite sDiglettGfx5, 0x80
+ax_sprite_terminator
+sDiglettGfx6:
+.incbin "baserom.gba", 0x71DABC, 0x20
+sDiglettSprites6:
+ax_sprite sDiglettGfx6, 0x20
+ax_sprite_terminator
+sDiglettGfx7:
+.incbin "baserom.gba", 0x71DAEC, 0x80
+sDiglettSprites7:
+ax_sprite sDiglettGfx7, 0x80
+ax_sprite_terminator
+sDiglettGfx8:
+.incbin "baserom.gba", 0x71DB7C, 0x40
+sDiglettSprites8:
+ax_sprite sDiglettGfx8, 0x40
+ax_sprite_terminator
+sDiglettGfx9:
+.incbin "baserom.gba", 0x71DBCC, 0x20
+sDiglettSprites9:
+ax_sprite sDiglettGfx9, 0x20
+ax_sprite_terminator
+sDiglettGfx10:
+.incbin "baserom.gba", 0x71DBFC, 0x60
+sDiglettGfx10_1:
+.incbin "baserom.gba", 0x71DC5C, 0x60
+sDiglettSprites10:
+ax_sprite sDiglettGfx10, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx10_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx11:
+.incbin "baserom.gba", 0x71DCE4, 0x60
+sDiglettGfx11_1:
+.incbin "baserom.gba", 0x71DD44, 0x60
+sDiglettSprites11:
+ax_sprite sDiglettGfx11, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx11_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx12:
+.incbin "baserom.gba", 0x71DDCC, 0x60
+sDiglettGfx12_1:
+.incbin "baserom.gba", 0x71DE2C, 0x60
+sDiglettGfx12_2:
+.incbin "baserom.gba", 0x71DE8C, 0x20
+sDiglettSprites12:
+ax_sprite sDiglettGfx12, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx12_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDiglettGfx12_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sDiglettGfx13:
+.incbin "baserom.gba", 0x71DEE4, 0x60
+sDiglettGfx13_1:
+.incbin "baserom.gba", 0x71DF44, 0x60
+sDiglettSprites13:
+ax_sprite sDiglettGfx13, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx13_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx14:
+.incbin "baserom.gba", 0x71DFCC, 0x60
+sDiglettGfx14_1:
+.incbin "baserom.gba", 0x71E02C, 0x60
+sDiglettSprites14:
+ax_sprite sDiglettGfx14, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx14_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx15:
+.incbin "baserom.gba", 0x71E0B4, 0x60
+sDiglettGfx15_1:
+.incbin "baserom.gba", 0x71E114, 0x60
+sDiglettGfx15_2:
+.incbin "baserom.gba", 0x71E174, 0x20
+sDiglettSprites15:
+ax_sprite sDiglettGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx15_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDiglettGfx15_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sDiglettGfx16:
+.incbin "baserom.gba", 0x71E1CC, 0x60
+sDiglettGfx16_1:
+.incbin "baserom.gba", 0x71E22C, 0x60
+sDiglettSprites16:
+ax_sprite sDiglettGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx17:
+.incbin "baserom.gba", 0x71E2B4, 0x60
+sDiglettGfx17_1:
+.incbin "baserom.gba", 0x71E314, 0x60
+sDiglettSprites17:
+ax_sprite sDiglettGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx18:
+.incbin "baserom.gba", 0x71E39C, 0x60
+sDiglettGfx18_1:
+.incbin "baserom.gba", 0x71E3FC, 0x60
+sDiglettGfx18_2:
+.incbin "baserom.gba", 0x71E45C, 0x20
+sDiglettSprites18:
+ax_sprite sDiglettGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDiglettGfx18_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sDiglettGfx19:
+.incbin "baserom.gba", 0x71E4B4, 0x60
+sDiglettGfx19_1:
+.incbin "baserom.gba", 0x71E514, 0x60
+sDiglettSprites19:
+ax_sprite sDiglettGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx20:
+.incbin "baserom.gba", 0x71E59C, 0x60
+sDiglettGfx20_1:
+.incbin "baserom.gba", 0x71E5FC, 0x60
+sDiglettSprites20:
+ax_sprite sDiglettGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx21:
+.incbin "baserom.gba", 0x71E684, 0x60
+sDiglettGfx21_1:
+.incbin "baserom.gba", 0x71E6E4, 0x60
+sDiglettGfx21_2:
+.incbin "baserom.gba", 0x71E744, 0x20
+sDiglettSprites21:
+ax_sprite sDiglettGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDiglettGfx21_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sDiglettGfx22:
+.incbin "baserom.gba", 0x71E79C, 0x60
+sDiglettGfx22_1:
+.incbin "baserom.gba", 0x71E7FC, 0x60
+sDiglettSprites22:
+ax_sprite sDiglettGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx23:
+.incbin "baserom.gba", 0x71E884, 0x60
+sDiglettGfx23_1:
+.incbin "baserom.gba", 0x71E8E4, 0x60
+sDiglettSprites23:
+ax_sprite sDiglettGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx24:
+.incbin "baserom.gba", 0x71E96C, 0x60
+sDiglettGfx24_1:
+.incbin "baserom.gba", 0x71E9CC, 0x60
+sDiglettSprites24:
+ax_sprite sDiglettGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx24_1, 0x60
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sDiglettGfx25:
+.incbin "baserom.gba", 0x71EA54, 0x60
+sDiglettGfx25_1:
+.incbin "baserom.gba", 0x71EAB4, 0x60
+sDiglettSprites25:
+ax_sprite sDiglettGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx26:
+.incbin "baserom.gba", 0x71EB3C, 0x60
+sDiglettGfx26_1:
+.incbin "baserom.gba", 0x71EB9C, 0x60
+sDiglettSprites26:
+ax_sprite sDiglettGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx27:
+.incbin "baserom.gba", 0x71EC24, 0x60
+sDiglettGfx27_1:
+.incbin "baserom.gba", 0x71EC84, 0x60
+sDiglettSprites27:
+ax_sprite sDiglettGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDiglettGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDiglettGfx28:
+.incbin "baserom.gba", 0x71ED0C, 0x100
+sDiglettSprites28:
+ax_sprite sDiglettGfx28, 0x100
+ax_sprite_terminator
+sDiglettGfx29:
+.incbin "baserom.gba", 0x71EE1C, 0x100
+sDiglettSprites29:
+ax_sprite sDiglettGfx29, 0x100
+ax_sprite_terminator
+sDiglettGfx30:
+.incbin "baserom.gba", 0x71EF2C, 0x200
+sDiglettSprites30:
+ax_sprite sDiglettGfx30, 0x200
+ax_sprite_terminator
+sDiglettGfx31:
+.incbin "baserom.gba", 0x71F13C, 0x200
+sDiglettSprites31:
+ax_sprite sDiglettGfx31, 0x200
+ax_sprite_terminator
+sDiglettGfx32:
+.incbin "baserom.gba", 0x71F34C, 0x200
+sDiglettSprites32:
+ax_sprite sDiglettGfx32, 0x200
+ax_sprite_terminator
+sDiglettGfx33:
+.incbin "baserom.gba", 0x71F55C, 0x200
+sDiglettSprites33:
+ax_sprite sDiglettGfx33, 0x200
+ax_sprite_terminator
+sDiglettGfx34:
+.incbin "baserom.gba", 0x71F76C, 0x200
+sDiglettSprites34:
+ax_sprite sDiglettGfx34, 0x200
+ax_sprite_terminator
+sDiglettGfx35:
+.incbin "baserom.gba", 0x71F97C, 0x100
+sDiglettSprites35:
+ax_sprite sDiglettGfx35, 0x100
+ax_sprite_terminator
+sDiglettGfx36:
+.incbin "baserom.gba", 0x71FA8C, 0x100
+sDiglettSprites36:
+ax_sprite sDiglettGfx36, 0x100
+ax_sprite_terminator
+sDiglettGfx37:
+.incbin "baserom.gba", 0x71FB9C, 0x100
+sDiglettSprites37:
+ax_sprite sDiglettGfx37, 0x100
+ax_sprite_terminator
+sDiglettGfx38:
+.incbin "baserom.gba", 0x71FCAC, 0x100
+sDiglettSprites38:
+ax_sprite sDiglettGfx38, 0x100
+ax_sprite_terminator
+sDiglettGfx39:
+.incbin "baserom.gba", 0x71FDBC, 0x100
+sDiglettSprites39:
+ax_sprite sDiglettGfx39, 0x100
+ax_sprite_terminator
+sDiglettGfx40:
+.incbin "baserom.gba", 0x71FECC, 0x100
+sDiglettSprites40:
+ax_sprite sDiglettGfx40, 0x100
+ax_sprite_terminator
+sDiglettGfx41:
+.incbin "baserom.gba", 0x71FFDC, 0x100
+sDiglettSprites41:
+ax_sprite sDiglettGfx41, 0x100
+ax_sprite_terminator
+sDiglettGfx42:
+.incbin "baserom.gba", 0x7200EC, 0x100
+sDiglettSprites42:
+ax_sprite sDiglettGfx42, 0x100
+ax_sprite_terminator
+sDiglettGfx43:
+.incbin "baserom.gba", 0x7201FC, 0x20
+sDiglettSprites43:
+ax_sprite sDiglettGfx43, 0x20
+ax_sprite_terminator
+sDiglettGfx44:
+.incbin "baserom.gba", 0x72022C, 0x20
+sDiglettSprites44:
+ax_sprite sDiglettGfx44, 0x20
+ax_sprite_terminator
+sDiglettGfx45:
+.incbin "baserom.gba", 0x72025C, 0x20
+sDiglettSprites45:
+ax_sprite sDiglettGfx45, 0x20
+ax_sprite_terminator
+sAxPosesDiglett:
+.4byte sDiglettPose1
+.4byte sDiglettPose2
+.4byte sDiglettPose3
+.4byte sDiglettPose4
+.4byte sDiglettPose5
+.4byte sDiglettPose6
+.4byte sDiglettPose7
+.4byte sDiglettPose8
+.4byte sDiglettPose9
+.4byte sDiglettPose10
+.4byte sDiglettPose11
+.4byte sDiglettPose12
+.4byte sDiglettPose13
+.4byte sDiglettPose14
+.4byte sDiglettPose15
+.4byte sDiglettPose16
+.4byte sDiglettPose17
+.4byte sDiglettPose18
+.4byte sDiglettPose19
+.4byte sDiglettPose20
+.4byte sDiglettPose21
+.4byte sDiglettPose22
+.4byte sDiglettPose23
+.4byte sDiglettPose24
+.4byte sDiglettPose25
+.4byte sDiglettPose26
+.4byte sDiglettPose27
+.4byte sDiglettPose28
+.4byte sDiglettPose29
+.4byte sDiglettPose30
+.4byte sDiglettPose31
+.4byte sDiglettPose32
+.4byte sDiglettPose33
+.4byte sDiglettPose34
+.4byte sDiglettPose35
+.4byte sDiglettPose36
+.4byte sDiglettPose37
+.4byte sDiglettPose38
+.4byte sDiglettPose39
+.4byte sDiglettPose40
+.4byte sDiglettPose41
+.4byte sDiglettPose42
+.4byte sDiglettPose43
+.4byte sDiglettPose44
+.4byte sDiglettPose45
+.4byte sDiglettPose46
+.4byte sDiglettPose47
+.4byte sDiglettPose48
+.4byte sDiglettPose49
+.4byte sDiglettPose50
+.4byte sDiglettPose51
+.4byte sDiglettPose52
+.4byte sDiglettPose53
+.4byte sDiglettPose54
+.4byte sDiglettPose55
+.4byte sDiglettPose56
+.4byte sDiglettPose57
+.4byte sDiglettPose58
+.4byte sDiglettPose59
+.4byte sDiglettPose60
+.4byte sDiglettPose61
+.4byte sDiglettPose62
+.4byte sDiglettPose63
+.4byte sDiglettPose64
+.4byte sDiglettPose65
+.4byte sDiglettPose66
+.4byte sDiglettPose67
+.4byte sDiglettPose68
+.4byte sDiglettPose69
+.4byte sDiglettPose70
+.4byte sDiglettPose71
+.4byte sDiglettPose72
+.4byte sDiglettPose73
+.4byte sDiglettPose74
+.4byte sDiglettPose75
+.4byte sDiglettPose76
+.4byte sDiglettPose77
+.4byte sDiglettPose78
+.4byte sDiglettPose79
+.4byte sDiglettPose80
+.4byte sDiglettPose81
+.4byte sDiglettPose82
+.4byte sDiglettPose83
+.4byte sDiglettPose84
+.4byte sDiglettPose85
+.4byte sDiglettPose86
+.4byte sDiglettPose87
+.4byte sDiglettPose88
+.4byte sDiglettPose89
+.4byte sDiglettPose90
+.4byte sDiglettPose91
+.4byte sDiglettPose92
+.4byte sDiglettPose93
+.4byte sDiglettPose94
+.4byte sDiglettPose95
+.4byte sDiglettPose96
+.4byte sDiglettPose97
+.4byte sDiglettPose98
+.4byte sDiglettPose99
+.4byte sDiglettPose100
+.4byte sDiglettPose101
+.4byte sDiglettPose102
+.4byte sDiglettPose103
+.4byte sDiglettPose104
+.4byte sDiglettPose105
+.4byte sDiglettPose106
+.4byte sDiglettPose107
+.4byte sDiglettPose108
+.4byte sDiglettPose109
+.4byte sDiglettPose110
+.4byte sDiglettPose111
+.4byte sDiglettPose112
+.4byte sDiglettPose113
+.4byte sDiglettPose114
+.4byte sDiglettPose115
+.4byte sDiglettPose116
+.4byte sDiglettPose117
+.4byte sDiglettPose118
+.4byte sDiglettPose119
+.4byte sDiglettPose120
+.4byte sDiglettPose121
+.4byte sDiglettPose122
+.4byte sDiglettPose123
+.4byte sDiglettPose124
+.4byte sDiglettPose125
+.4byte sDiglettPose126
+.4byte sDiglettPose127
+.4byte sDiglettPose128
+.4byte sDiglettPose129
+.4byte sDiglettPose130
+.4byte sDiglettPose131
+.4byte sDiglettPose132
+.4byte sDiglettPose133
+.4byte sDiglettPose134
+.4byte sDiglettPose135
+.4byte sDiglettPose136
+.4byte sDiglettPose137
+.4byte sDiglettPose138
+.4byte sDiglettPose139
+.4byte sDiglettPose140
+.4byte sDiglettPose141
+.4byte sDiglettPose142
+.4byte sDiglettPose143
+.4byte sDiglettPose144
+.4byte sDiglettPose145
+.4byte sDiglettPose146
+.4byte sDiglettPose147
+.4byte sDiglettPose148
+.4byte sDiglettPose149
+.4byte sDiglettPose150
+.4byte sDiglettPose151
+.4byte sDiglettPose152
+.4byte sDiglettPose153
+.4byte sDiglettPose154
+.4byte sDiglettPose155
+.4byte sDiglettPose156
+.4byte sDiglettPose157
+.4byte sDiglettPose158
+.4byte sDiglettPose159
+.4byte sDiglettPose160
+.4byte sDiglettPose161
+.4byte sDiglettPose162
+.4byte sDiglettPose163
+.4byte sDiglettPose164
+.4byte sDiglettPose165
+.4byte sDiglettPose166
+.4byte sDiglettPose167
+.4byte sDiglettPose168
+.4byte sDiglettPose169
+.4byte sDiglettPose170
+.4byte sDiglettPose171
+.4byte sDiglettPose172
+.4byte sDiglettPose173
+.4byte sDiglettPose174
+.4byte sDiglettPose175
+.4byte sDiglettPose176
+.4byte sDiglettPose177
+.4byte sDiglettPose178
+.4byte sDiglettPose179
+.4byte sDiglettPose180
+.4byte sDiglettPose181
+.4byte sDiglettPose182
+.4byte sDiglettPose183
+.4byte sDiglettPose184
+.4byte sDiglettPose185
+.4byte sDiglettPose186
+.4byte sDiglettPose187
+.4byte sDiglettPose188
+.4byte sDiglettPose189
+.4byte sDiglettPose190
+.4byte sDiglettPose191
+.4byte sDiglettPose192
+.4byte sDiglettPose193
+.4byte sDiglettPose194
+.4byte sDiglettPose195
+.4byte sDiglettPose196
+.4byte sDiglettPose197
+.4byte sDiglettPose198
+.4byte sDiglettPose199
+.4byte sDiglettPose200
+.4byte sDiglettPose201
+.4byte sDiglettPose202
+.4byte sDiglettPose203
+.4byte sDiglettPose204
+.4byte sDiglettPose205
+.4byte sDiglettPose206
+.4byte sDiglettPose207
+.4byte sDiglettPose208
+.4byte sDiglettPose209
+.4byte sDiglettPose210
+.4byte sDiglettPose211
+.4byte sDiglettPose212
+.4byte sDiglettPose213
+.4byte sDiglettPose214
+.4byte sDiglettPose215
+.4byte sDiglettPose216
+.4byte sDiglettPose217
+.4byte sDiglettPose218
+.4byte sDiglettPose219
+.4byte sDiglettPose220
+.4byte sDiglettPose221
+.4byte sDiglettPose222
+.4byte sDiglettPose223
+.4byte sDiglettPose224
+.4byte sDiglettPose225
+.4byte sDiglettPose226
+.4byte sDiglettPose227
+.4byte sDiglettPose228
+.4byte sDiglettPose229
+.4byte sDiglettPose230
+.4byte sDiglettPose231
+.4byte sDiglettPose232
+.4byte sDiglettPose233
+.4byte sDiglettPose234
+.4byte sDiglettPose235
+.4byte sDiglettPose236
+.4byte sDiglettPose237
+.4byte sDiglettPose238
+.4byte sDiglettPose239
+.4byte sDiglettPose240
+.4byte sDiglettPose241
+.4byte sDiglettPose242
+.4byte sDiglettPose243
+.4byte sDiglettPose244
+.4byte sDiglettPose245
+.4byte sDiglettPose246
+.4byte sDiglettPose247
+.4byte sDiglettPose248
+.4byte sDiglettPose249
+.4byte sDiglettPose250
+.4byte sDiglettPose251
+.4byte sDiglettPose252
+.4byte sDiglettPose253
+.4byte sDiglettPose254
+.4byte sDiglettPose255
+.4byte sDiglettPose256
+.4byte sDiglettPose257
+.4byte sDiglettPose258
+.4byte sDiglettPose259
+.4byte sDiglettPose260
+.4byte sDiglettPose261
+.4byte sDiglettPose262
+.4byte sDiglettPose263
+.4byte sDiglettPose264
+.4byte sDiglettPose265
+.4byte sDiglettPose266
+.4byte sDiglettPose267
+.4byte sDiglettPose268
+.4byte sDiglettPose269
+.4byte sDiglettPose270
+.4byte sDiglettPose271
+.4byte sDiglettPose272
+.4byte sDiglettPose273
+.4byte sDiglettPose274
+.4byte sDiglettPose275
+.4byte sDiglettPose276
+.4byte sDiglettPose277
+.4byte sDiglettPose278
+.4byte sDiglettPose279
+.4byte sDiglettPose280
+.4byte sDiglettPose281
+.4byte sDiglettPose282
+.4byte sDiglettPose283
+.4byte sDiglettPose284
+.4byte sDiglettPose285
+.4byte sDiglettPose286
+.4byte sDiglettPose287
+.4byte sDiglettPose288
+.4byte sDiglettPose289
+.4byte sDiglettPose290
+.4byte sDiglettPose291
+.4byte sDiglettPose292
+.4byte sDiglettPose293
+.4byte sDiglettPose294
+.4byte sDiglettPose295
+.4byte sDiglettPose296
+.4byte sDiglettPose297
+.4byte sDiglettPose298
+.4byte sDiglettPose299
+.4byte sDiglettPose300
+.4byte sDiglettPose301
+.4byte sDiglettPose302
+.4byte sDiglettPose303
+.4byte sDiglettPose304
+.4byte sDiglettPose305
+.4byte sDiglettPose306
+.4byte sDiglettPose307
+.4byte sDiglettPose308
+.4byte sDiglettPose309
+.4byte sDiglettPose310
+.4byte sDiglettPose311
+.4byte sDiglettPose312
+.4byte sDiglettPose313
+.4byte sDiglettPose314
+.4byte sDiglettPose315
+.4byte sDiglettPose316
+.4byte sDiglettPose317
+.4byte sDiglettPose318
+.4byte sDiglettPose319
+.4byte sDiglettPose320
+.4byte sDiglettPose321
+.4byte sDiglettPose322
+.4byte sDiglettPose323
+.4byte sDiglettPose324
+.4byte sDiglettPose325
+.4byte sDiglettPose326
+.4byte sDiglettPose327
+.4byte sDiglettPose328
+.4byte sDiglettPose329
+.4byte sDiglettPose330
+.4byte sDiglettPose331
+.4byte sDiglettPose332
+.4byte sDiglettPose333
+.4byte sDiglettPose334
+.4byte sDiglettPose335
+.4byte sDiglettPose336
+.4byte sDiglettPose337
+.4byte sDiglettPose338
+.4byte sDiglettPose339
+.4byte sDiglettPose340
+.4byte sDiglettPose341
+.4byte sDiglettPose342
+.4byte sDiglettPose343
+.4byte sDiglettPose344
+.4byte sDiglettPose345
+.4byte sDiglettPose346
+.4byte sDiglettPose347
+.4byte sDiglettPose348
+.4byte sDiglettPose349
+.4byte sDiglettPose350
+.4byte sDiglettPose351
+.4byte sDiglettPose352
+.4byte sDiglettPose353
+.4byte sDiglettPose354
+.4byte sDiglettPose355
+.4byte sDiglettPose356
+.4byte sDiglettPose357
+.4byte sDiglettPose358
+.4byte sDiglettPose359
+.4byte sDiglettPose360
+.4byte sDiglettPose361
+.4byte sDiglettPose362
+.4byte sDiglettPose363
+.4byte sDiglettPose364
+.4byte sDiglettPose365
+.4byte sDiglettPose366
+.4byte sDiglettPose367
+.4byte sDiglettPose368
+.4byte sDiglettPose369
+.4byte sDiglettPose370
+.4byte sDiglettPose371
+.4byte sDiglettPose372
+.4byte sDiglettPose373
+.4byte sDiglettPose374
+.4byte sDiglettPose375
+.4byte sDiglettPose376
+.4byte sDiglettPose377
+.4byte sDiglettPose378
+.4byte sDiglettPose379
+.4byte sDiglettPose380
+.4byte sDiglettPose381
+.4byte sDiglettPose382
+.4byte sDiglettPose383
+.4byte sDiglettPose384
+.4byte sDiglettPose385
+.4byte sDiglettPose386
+.4byte sDiglettPose387
+.4byte sDiglettPose388
+.4byte sDiglettPose389
+.4byte sDiglettPose390
+.4byte sDiglettPose391
+sAxPositionsDiglett:
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -5
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -5
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte    0,   -9, 	   1,   -8, 	  -4,   -5, 	  -2,   -5
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    0,   -9, 	   1,   -8, 	  -4,   -5, 	  -2,   -5
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    1,   -8, 	  -4,   -6, 	  -4,   -4, 	  -2,   -4
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    1,   -8, 	  -4,   -6, 	  -4,   -4, 	  -2,   -4
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    2,   -7, 	  -5,   -3, 	   0,   -4, 	  -2,   -5
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    2,   -7, 	  -5,   -3, 	   0,   -4, 	  -2,   -5
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	   3,   -4, 	  -5,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -8, 	   3,   -4, 	  -5,   -4, 	  -1,   -4
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -4,   -7, 	   3,   -3, 	  -2,   -4, 	   0,   -5
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -4,   -7, 	   3,   -3, 	  -2,   -4, 	   0,   -5
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -3,   -8, 	   2,   -6, 	   2,   -4, 	   0,   -4
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -3,   -8, 	   2,   -6, 	   2,   -4, 	   0,   -4
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -2,   -8, 	  -3,   -7, 	   2,   -4, 	   0,   -4
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -2,   -8, 	  -3,   -7, 	   2,   -4, 	   0,   -4
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -5
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -5
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte    0,   -9, 	   1,   -8, 	  -4,   -5, 	  -2,   -5
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    0,   -9, 	   1,   -8, 	  -4,   -5, 	  -2,   -5
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    1,   -8, 	  -4,   -6, 	  -4,   -4, 	  -2,   -4
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    1,   -8, 	  -4,   -6, 	  -4,   -4, 	  -2,   -4
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    2,   -7, 	  -5,   -3, 	   0,   -4, 	  -2,   -5
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte    2,   -7, 	  -5,   -3, 	   0,   -4, 	  -2,   -5
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	   3,   -4, 	  -5,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -1,   -8, 	   3,   -4, 	  -5,   -4, 	  -1,   -4
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -4,   -7, 	   3,   -3, 	  -2,   -4, 	   0,   -5
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -4,   -7, 	   3,   -3, 	  -2,   -4, 	   0,   -5
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -3,   -8, 	   2,   -6, 	   2,   -4, 	   0,   -4
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -3,   -8, 	   2,   -6, 	   2,   -4, 	   0,   -4
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -2,   -8, 	  -3,   -7, 	   2,   -4, 	   0,   -4
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -2,   -8, 	  -3,   -7, 	   2,   -4, 	   0,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -4
+.2byte   -1,   -1, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte    0,   -7, 	  -4,   -7, 	   3,   -7, 	   0,   -5
+.2byte    2,   -7, 	   0,   -6, 	  -3,   -3, 	  -1,   -4
+.2byte    3,   -9, 	  -1,   -8, 	  -1,   -4, 	  -1,   -6
+.2byte    1,  -10, 	  -4,   -6, 	   2,   -4, 	  -1,   -5
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -5
+.2byte   -2,  -10, 	   3,   -6, 	  -3,   -4, 	   0,   -5
+.2byte   -4,   -9, 	   0,   -8, 	   0,   -4, 	   0,   -6
+.2byte   -3,   -7, 	  -1,   -6, 	   2,   -3, 	   0,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -1,   -1, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -2, 	  -5,   -5, 	   2,   -2, 	  -1,   -3
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -6,   -3, 	  -2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -4, 	   0,   -6, 	  -4,   -2, 	   0,   -3
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte   -1,   -3, 	   4,   -3, 	  -5,   -3, 	   0,   -3
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    2,   -3, 	  -2,   -3, 	  -3,   -6, 	   0,   -3
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    4,   -2, 	  -1,   -2, 	   1,   -5, 	  -1,   -3
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte    2,   -2, 	  -4,   -3, 	   2,   -5, 	  -1,   -3
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -3,   -3, 	  -4,   -6, 	   3,   -3, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -5
+.2byte   -1,    0, 	  -5,   -2, 	   3,   -2, 	  -1,   -3
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte    0,   -9, 	   1,   -8, 	  -4,   -5, 	  -2,   -5
+.2byte    4,   -2, 	   4,   -4, 	  -2,   -4, 	   0,   -3
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    1,   -8, 	  -4,   -6, 	  -4,   -4, 	  -2,   -4
+.2byte    4,   -2, 	   0,   -3, 	  -2,   -3, 	  -2,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    2,   -7, 	  -5,   -3, 	   0,   -4, 	  -2,   -5
+.2byte    4,   -4, 	  -3,   -6, 	   5,   -6, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	   3,   -4, 	  -5,   -4, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -3, 	  -5,   -3, 	  -1,   -3
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -4,   -7, 	   3,   -3, 	  -2,   -4, 	   0,   -5
+.2byte   -6,   -4, 	   1,   -6, 	  -7,   -6, 	  -1,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -3,   -8, 	   2,   -6, 	   2,   -4, 	   0,   -4
+.2byte   -6,   -2, 	  -2,   -3, 	   0,   -3, 	   0,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -2,   -8, 	  -3,   -7, 	   2,   -4, 	   0,   -4
+.2byte   -5,   -2, 	  -5,   -4, 	   1,   -4, 	  -1,   -3
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,   -3, 	   3,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -6,   -3, 	   1,   -3, 	  -1,   -2, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -4
+.2byte    3,   -5, 	  -1,   -4, 	  -4,   -8, 	  -1,   -5
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -6, 	  -1,   -4
+.2byte    2,   -3, 	  -4,   -3, 	   2,   -6, 	  -1,   -4
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -2, 	  -4,   -3, 	   4,   -3, 	   0,   -4
+.2byte    3,   -3, 	   4,   -6, 	  -3,   -3, 	   1,   -4
+.2byte    5,   -3, 	  -2,   -3, 	   0,   -2, 	   0,   -4
+.2byte    4,   -5, 	  -2,   -5, 	   3,   -3, 	   0,   -4
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte   -5,   -5, 	   1,   -5, 	  -4,   -3, 	  -1,   -4
+.2byte   -5,   -3, 	   2,   -3, 	   0,   -2, 	   0,   -4
+.2byte   -4,   -3, 	  -5,   -6, 	   2,   -3, 	  -2,   -4
+sDiglettAnimTable1:
+.4byte sDiglettAnims_1_1
+.4byte sDiglettAnims_1_2
+.4byte sDiglettAnims_1_3
+.4byte sDiglettAnims_1_4
+.4byte sDiglettAnims_1_5
+.4byte sDiglettAnims_1_6
+.4byte sDiglettAnims_1_7
+.4byte sDiglettAnims_1_8
+sDiglettAnimTable2:
+.4byte sDiglettAnims_2_1
+.4byte sDiglettAnims_2_2
+.4byte sDiglettAnims_2_3
+.4byte sDiglettAnims_2_4
+.4byte sDiglettAnims_2_5
+.4byte sDiglettAnims_2_6
+.4byte sDiglettAnims_2_7
+.4byte sDiglettAnims_2_8
+sDiglettAnimTable3:
+.4byte sDiglettAnims_3_1
+.4byte sDiglettAnims_3_2
+.4byte sDiglettAnims_3_3
+.4byte sDiglettAnims_3_4
+.4byte sDiglettAnims_3_5
+.4byte sDiglettAnims_3_6
+.4byte sDiglettAnims_3_7
+.4byte sDiglettAnims_3_8
+sDiglettAnimTable4:
+.4byte sDiglettAnims_4_1
+.4byte sDiglettAnims_4_2
+.4byte sDiglettAnims_4_3
+.4byte sDiglettAnims_4_4
+.4byte sDiglettAnims_4_5
+.4byte sDiglettAnims_4_6
+.4byte sDiglettAnims_4_7
+.4byte sDiglettAnims_4_8
+sDiglettAnimTable5:
+.4byte sDiglettAnims_5_1
+.4byte sDiglettAnims_5_2
+.4byte sDiglettAnims_5_3
+.4byte sDiglettAnims_5_4
+.4byte sDiglettAnims_5_5
+.4byte sDiglettAnims_5_6
+.4byte sDiglettAnims_5_7
+.4byte sDiglettAnims_5_8
+sDiglettAnimTable6:
+.4byte sDiglettAnims_6_1
+.4byte sDiglettAnims_6_1
+.4byte sDiglettAnims_6_1
+.4byte sDiglettAnims_6_1
+.4byte sDiglettAnims_6_1
+.4byte sDiglettAnims_6_1
+.4byte sDiglettAnims_6_1
+.4byte sDiglettAnims_6_1
+sDiglettAnimTable7:
+.4byte sDiglettAnims_7_1
+.4byte sDiglettAnims_7_2
+.4byte sDiglettAnims_7_3
+.4byte sDiglettAnims_7_4
+.4byte sDiglettAnims_7_5
+.4byte sDiglettAnims_7_6
+.4byte sDiglettAnims_7_7
+.4byte sDiglettAnims_7_8
+sDiglettAnimTable8:
+.4byte sDiglettAnims_8_1
+.4byte sDiglettAnims_8_2
+.4byte sDiglettAnims_8_3
+.4byte sDiglettAnims_8_4
+.4byte sDiglettAnims_8_5
+.4byte sDiglettAnims_8_6
+.4byte sDiglettAnims_8_7
+.4byte sDiglettAnims_8_8
+sDiglettAnimTable9:
+.4byte sDiglettAnims_9_1
+.4byte sDiglettAnims_9_2
+.4byte sDiglettAnims_9_3
+.4byte sDiglettAnims_9_4
+.4byte sDiglettAnims_9_5
+.4byte sDiglettAnims_9_6
+.4byte sDiglettAnims_9_7
+.4byte sDiglettAnims_9_8
+sDiglettAnimTable10:
+.4byte sDiglettAnims_10_1
+.4byte sDiglettAnims_10_2
+.4byte sDiglettAnims_10_3
+.4byte sDiglettAnims_10_4
+.4byte sDiglettAnims_10_5
+.4byte sDiglettAnims_10_6
+.4byte sDiglettAnims_10_7
+.4byte sDiglettAnims_10_8
+sDiglettAnimTable11:
+.4byte sDiglettAnims_11_1
+.4byte sDiglettAnims_11_2
+.4byte sDiglettAnims_11_3
+.4byte sDiglettAnims_11_4
+.4byte sDiglettAnims_11_5
+.4byte sDiglettAnims_11_6
+.4byte sDiglettAnims_11_7
+.4byte sDiglettAnims_11_8
+sDiglettAnimTable12:
+.4byte sDiglettAnims_12_1
+.4byte sDiglettAnims_12_2
+.4byte sDiglettAnims_12_3
+.4byte sDiglettAnims_12_4
+.4byte sDiglettAnims_12_5
+.4byte sDiglettAnims_12_6
+.4byte sDiglettAnims_12_7
+.4byte sDiglettAnims_12_8
+sDiglettAnimTable13:
+.4byte sDiglettAnims_13_1
+.4byte sDiglettAnims_13_2
+.4byte sDiglettAnims_13_3
+.4byte sDiglettAnims_13_4
+.4byte sDiglettAnims_13_5
+.4byte sDiglettAnims_13_6
+.4byte sDiglettAnims_13_7
+.4byte sDiglettAnims_13_8
+sDiglettAnimTable14:
+.4byte sDiglettAnims_14_1
+.4byte sDiglettAnims_14_2
+.4byte sDiglettAnims_14_3
+.4byte sDiglettAnims_14_4
+.4byte sDiglettAnims_14_5
+.4byte sDiglettAnims_14_6
+.4byte sDiglettAnims_14_7
+.4byte sDiglettAnims_14_8
+sDiglettAnimTable15:
+.4byte sDiglettAnims_15_1
+.4byte sDiglettAnims_15_2
+.4byte sDiglettAnims_15_3
+.4byte sDiglettAnims_15_4
+.4byte sDiglettAnims_15_5
+.4byte sDiglettAnims_15_6
+.4byte sDiglettAnims_15_7
+.4byte sDiglettAnims_15_8
+sAxAnimationsDiglett:
+.4byte sDiglettAnimTable1
+.4byte sDiglettAnimTable2
+.4byte sDiglettAnimTable3
+.4byte sDiglettAnimTable4
+.4byte sDiglettAnimTable5
+.4byte sDiglettAnimTable6
+.4byte sDiglettAnimTable7
+.4byte sDiglettAnimTable8
+.4byte sDiglettAnimTable9
+.4byte sDiglettAnimTable10
+.4byte sDiglettAnimTable11
+.4byte sDiglettAnimTable12
+.4byte sDiglettAnimTable13
+.4byte sDiglettAnimTable14
+.4byte sDiglettAnimTable15
+sAxSpritesDiglett:
+.4byte sDiglettSprites1
+.4byte sDiglettSprites2
+.4byte sDiglettSprites3
+.4byte sDiglettSprites4
+.4byte sDiglettSprites5
+.4byte sDiglettSprites6
+.4byte sDiglettSprites7
+.4byte sDiglettSprites8
+.4byte sDiglettSprites9
+.4byte sDiglettSprites10
+.4byte sDiglettSprites11
+.4byte sDiglettSprites12
+.4byte sDiglettSprites13
+.4byte sDiglettSprites14
+.4byte sDiglettSprites15
+.4byte sDiglettSprites16
+.4byte sDiglettSprites17
+.4byte sDiglettSprites18
+.4byte sDiglettSprites19
+.4byte sDiglettSprites20
+.4byte sDiglettSprites21
+.4byte sDiglettSprites22
+.4byte sDiglettSprites23
+.4byte sDiglettSprites24
+.4byte sDiglettSprites25
+.4byte sDiglettSprites26
+.4byte sDiglettSprites27
+.4byte sDiglettSprites28
+.4byte sDiglettSprites29
+.4byte sDiglettSprites30
+.4byte sDiglettSprites31
+.4byte sDiglettSprites32
+.4byte sDiglettSprites33
+.4byte sDiglettSprites34
+.4byte sDiglettSprites35
+.4byte sDiglettSprites36
+.4byte sDiglettSprites37
+.4byte sDiglettSprites38
+.4byte sDiglettSprites39
+.4byte sDiglettSprites40
+.4byte sDiglettSprites41
+.4byte sDiglettSprites42
+.4byte sDiglettSprites43
+.4byte sDiglettSprites44
+.4byte sDiglettSprites45
+sAxMainDiglett:
+ax_main sAxPosesDiglett, sAxAnimationsDiglett, 15, sAxSpritesDiglett, sAxPositionsDiglett

--- a/data/ax/ditto.inc
+++ b/data/ax/ditto.inc
@@ -1,0 +1,2200 @@
+.global gAxDitto
+gAxDitto:
+ax_siro sAxMainDitto
+sDittoPose1:
+ax_pose 0, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose2:
+ax_pose 1, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose3:
+ax_pose 2, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose4:
+ax_pose 3, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose5:
+ax_pose 4, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose6:
+ax_pose 5, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose7:
+ax_pose 6, 0x81ed, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose8:
+ax_pose 7, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose9:
+ax_pose 8, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose10:
+ax_pose 9, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose11:
+ax_pose 10, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose12:
+ax_pose 11, 0x41f4, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose14:
+ax_pose 13, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose15:
+ax_pose 14, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose16:
+ax_pose 15, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose17:
+ax_pose 16, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose18:
+ax_pose 17, 0x41f3, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose19:
+ax_pose 18, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sDittoPose20:
+ax_pose 19, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose21:
+ax_pose 20, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose22:
+ax_pose 21, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose23:
+ax_pose 22, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose24:
+ax_pose 23, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose25:
+ax_pose 0, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose26:
+ax_pose 1, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose27:
+ax_pose 2, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose28:
+ax_pose 3, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose29:
+ax_pose 4, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose30:
+ax_pose 5, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose31:
+ax_pose 6, 0x81ed, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose32:
+ax_pose 7, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose33:
+ax_pose 8, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose34:
+ax_pose 9, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose35:
+ax_pose 10, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose36:
+ax_pose 11, 0x41f4, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose37:
+ax_pose 12, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose38:
+ax_pose 13, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose39:
+ax_pose 14, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose40:
+ax_pose 15, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose41:
+ax_pose 16, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose42:
+ax_pose 17, 0x41f3, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose43:
+ax_pose 18, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sDittoPose44:
+ax_pose 19, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose45:
+ax_pose 20, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose46:
+ax_pose 21, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose47:
+ax_pose 22, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose48:
+ax_pose 23, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose49:
+ax_pose 0, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose50:
+ax_pose 1, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose51:
+ax_pose 2, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose52:
+ax_pose 3, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose53:
+ax_pose 4, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose54:
+ax_pose 5, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose55:
+ax_pose 6, 0x81ed, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose56:
+ax_pose 7, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose57:
+ax_pose 8, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose58:
+ax_pose 9, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose59:
+ax_pose 10, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose60:
+ax_pose 11, 0x41f4, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose61:
+ax_pose 12, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose62:
+ax_pose 13, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose63:
+ax_pose 14, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose64:
+ax_pose 15, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose65:
+ax_pose 16, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose66:
+ax_pose 17, 0x41f3, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose67:
+ax_pose 18, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sDittoPose68:
+ax_pose 19, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose69:
+ax_pose 20, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose70:
+ax_pose 21, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose71:
+ax_pose 22, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose72:
+ax_pose 23, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose73:
+ax_pose 1, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose74:
+ax_pose 22, 0x01ed, 0x80f5, 0x7c00
+ax_pose_terminator
+sDittoPose75:
+ax_pose 19, 0x01ed, 0x80f2, 0x7c00
+ax_pose_terminator
+sDittoPose76:
+ax_pose 16, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose77:
+ax_pose 13, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose78:
+ax_pose 10, 0x01ee, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose79:
+ax_pose 7, 0x01ed, 0x80f2, 0x7c00
+ax_pose_terminator
+sDittoPose80:
+ax_pose 4, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose81:
+ax_pose 0, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose82:
+ax_pose 21, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose83:
+ax_pose 18, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sDittoPose84:
+ax_pose 15, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose85:
+ax_pose 12, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose86:
+ax_pose 9, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose87:
+ax_pose 6, 0x81ed, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose88:
+ax_pose 3, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose89:
+ax_pose 24, 0x41f5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose90:
+ax_pose 25, 0x41f5, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose91:
+ax_pose 26, 0x01e3, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose92:
+ax_pose 27, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sDittoPose93:
+ax_pose 28, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sDittoPose94:
+ax_pose 29, 0x01e4, 0x90f2, 0x7c00
+ax_pose_terminator
+sDittoPose95:
+ax_pose 30, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose96:
+ax_pose 29, 0x01e4, 0x80ee, 0x7c00
+ax_pose_terminator
+sDittoPose97:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose98:
+ax_pose 27, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose99:
+ax_pose 0, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose100:
+ax_pose 1, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose101:
+ax_pose 3, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose102:
+ax_pose 4, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose103:
+ax_pose 6, 0x81ed, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose104:
+ax_pose 7, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose105:
+ax_pose 9, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose106:
+ax_pose 10, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose107:
+ax_pose 12, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose108:
+ax_pose 13, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose109:
+ax_pose 15, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose110:
+ax_pose 16, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose111:
+ax_pose 18, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sDittoPose112:
+ax_pose 19, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose113:
+ax_pose 21, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose114:
+ax_pose 22, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose115:
+ax_pose 2, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose116:
+ax_pose 23, 0x01ed, 0x80f6, 0x7c00
+ax_pose_terminator
+sDittoPose117:
+ax_pose 20, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose118:
+ax_pose 17, 0x41f5, 0x80f6, 0x7c00
+ax_pose_terminator
+sDittoPose119:
+ax_pose 14, 0x01ef, 0x80f5, 0x7c00
+ax_pose_terminator
+sDittoPose120:
+ax_pose 11, 0x41f5, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose121:
+ax_pose 8, 0x01ee, 0x80f2, 0x7c00
+ax_pose_terminator
+sDittoPose122:
+ax_pose 5, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose123:
+ax_pose 26, 0x01e3, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose124:
+ax_pose 27, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sDittoPose125:
+ax_pose 28, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sDittoPose126:
+ax_pose 29, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sDittoPose127:
+ax_pose 30, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose128:
+ax_pose 29, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sDittoPose129:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sDittoPose130:
+ax_pose 27, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose131:
+ax_pose 0, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose132:
+ax_pose 1, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose133:
+ax_pose 2, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose134:
+ax_pose 3, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose135:
+ax_pose 4, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose136:
+ax_pose 5, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose137:
+ax_pose 6, 0x81ed, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose138:
+ax_pose 7, 0x01ed, 0x80f2, 0x7c00
+ax_pose_terminator
+sDittoPose139:
+ax_pose 8, 0x01ed, 0x80f1, 0x7c00
+ax_pose_terminator
+sDittoPose140:
+ax_pose 9, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose141:
+ax_pose 10, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose142:
+ax_pose 11, 0x41f4, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose143:
+ax_pose 12, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose144:
+ax_pose 13, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose145:
+ax_pose 14, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose146:
+ax_pose 15, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose147:
+ax_pose 16, 0x01ed, 0x80f5, 0x7c00
+ax_pose_terminator
+sDittoPose148:
+ax_pose 17, 0x41f3, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose149:
+ax_pose 18, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sDittoPose150:
+ax_pose 19, 0x01ed, 0x80f2, 0x7c00
+ax_pose_terminator
+sDittoPose151:
+ax_pose 20, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose152:
+ax_pose 21, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose153:
+ax_pose 22, 0x01ed, 0x80f5, 0x7c00
+ax_pose_terminator
+sDittoPose154:
+ax_pose 23, 0x01ed, 0x80f6, 0x7c00
+ax_pose_terminator
+sDittoPose155:
+ax_pose 1, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose156:
+ax_pose 22, 0x01ed, 0x80f5, 0x7c00
+ax_pose_terminator
+sDittoPose157:
+ax_pose 19, 0x01ed, 0x80f2, 0x7c00
+ax_pose_terminator
+sDittoPose158:
+ax_pose 16, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose159:
+ax_pose 13, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose160:
+ax_pose 10, 0x01ee, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose161:
+ax_pose 7, 0x01ed, 0x80f2, 0x7c00
+ax_pose_terminator
+sDittoPose162:
+ax_pose 4, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose163:
+ax_pose 0, 0x01ef, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose164:
+ax_pose 21, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose165:
+ax_pose 18, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sDittoPose166:
+ax_pose 15, 0x01ed, 0x80f3, 0x7c00
+ax_pose_terminator
+sDittoPose167:
+ax_pose 12, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose168:
+ax_pose 9, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+sDittoPose169:
+ax_pose 6, 0x81ed, 0x80f7, 0x7c00
+ax_pose_terminator
+sDittoPose170:
+ax_pose 3, 0x01ed, 0x80f4, 0x7c00
+ax_pose_terminator
+.align 2
+sDittoAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 1,
+ax_anim 10, 0, 2, 0, 1, 0, 2,
+ax_anim 8, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 0, 0, 1, 0, 0,
+ax_anim_terminator
+sDittoAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 1, 1,
+ax_anim 10, 0, 5, 1, 1, 2, 2,
+ax_anim 8, 0, 4, 2, 2, 1, 1,
+ax_anim 8, 0, 3, 1, 1, 0, 0,
+ax_anim_terminator
+sDittoAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 1, 0,
+ax_anim 10, 0, 8, 1, 0, 2, 0,
+ax_anim 8, 0, 7, 2, 0, 1, 0,
+ax_anim 8, 0, 6, 1, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 1, -1,
+ax_anim 10, 0, 11, 1, -1, 2, -2,
+ax_anim 8, 0, 10, 2, -2, 2, -2,
+ax_anim 8, 0, 9, 1, -1, 0, 0,
+ax_anim_terminator
+sDittoAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, -1,
+ax_anim 10, 0, 14, 0, -2, 0, -2,
+ax_anim 8, 0, 13, 0, -1, 0, -1,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim_terminator
+sDittoAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, -1, -1,
+ax_anim 10, 0, 17, -1, -1, -2, -2,
+ax_anim 8, 0, 16, -2, -2, -2, -2,
+ax_anim 8, 0, 15, -1, -1, 0, 0,
+ax_anim_terminator
+sDittoAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, -1, 0,
+ax_anim 10, 0, 20, -1, 0, -2, 0,
+ax_anim 8, 0, 19, -2, 0, -1, 0,
+ax_anim 8, 0, 18, -1, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, -1, 1,
+ax_anim 10, 0, 23, -1, 1, -2, 2,
+ax_anim 8, 0, 22, -2, 2, -1, 1,
+ax_anim 8, 0, 21, -1, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 1, 26, 1, 16, 1, 16,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 0, 26, 1, 16, 1, 16,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sDittoAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 19, 18, 19, 18,
+ax_anim 2, 1, 29, 20, 17, 20, 17,
+ax_anim 2, 0, 29, 19, 18, 19, 18,
+ax_anim 2, 0, 29, 20, 17, 20, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sDittoAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 6, 0, 6, 0,
+ax_anim_terminator
+sDittoAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 35, 18, -24, 18, -24,
+ax_anim 2, 1, 35, 19, -23, 19, -23,
+ax_anim 2, 0, 35, 18, -24, 18, -24,
+ax_anim 2, 0, 35, 19, -23, 19, -23,
+ax_anim 2, 0, 34, 5, -6, 5, -6,
+ax_anim_terminator
+sDittoAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -13, 0, -13,
+ax_anim 2, 0, 38, 0, -23, 0, -23,
+ax_anim 2, 1, 38, 1, -23, 1, -23,
+ax_anim 2, 0, 38, 0, -23, 0, -23,
+ax_anim 2, 0, 38, 1, -23, 1, -23,
+ax_anim 2, 0, 37, 0, -7, 0, -7,
+ax_anim_terminator
+sDittoAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 41, -18, -24, -18, -24,
+ax_anim 2, 1, 41, -19, -23, -19, -23,
+ax_anim 2, 0, 41, -18, -24, -18, -24,
+ax_anim 2, 0, 41, -19, -23, -19, -23,
+ax_anim 2, 0, 40, -5, -6, -5, -6,
+ax_anim_terminator
+sDittoAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim_terminator
+sDittoAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 47, -19, 18, -19, 18,
+ax_anim 2, 1, 47, -20, 17, -20, 17,
+ax_anim 2, 0, 47, -19, 18, -19, 18,
+ax_anim 2, 0, 47, -20, 17, -20, 17,
+ax_anim 2, 0, 46, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDittoAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 1, 50, 1, 16, 1, 16,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 0, 50, 1, 16, 1, 16,
+ax_anim 2, 0, 49, 0, 6, 0, 6,
+ax_anim_terminator
+sDittoAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 19, 18, 19, 18,
+ax_anim 2, 1, 53, 20, 17, 20, 17,
+ax_anim 2, 0, 53, 19, 18, 19, 18,
+ax_anim 2, 0, 53, 20, 17, 20, 17,
+ax_anim 2, 0, 52, 6, 6, 6, 6,
+ax_anim_terminator
+sDittoAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 6, 0, 6, 0,
+ax_anim_terminator
+sDittoAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 59, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 59, 18, -24, 18, -24,
+ax_anim 2, 1, 59, 19, -23, 19, -23,
+ax_anim 2, 0, 59, 18, -24, 18, -24,
+ax_anim 2, 0, 59, 19, -23, 19, -23,
+ax_anim 2, 0, 58, 5, -6, 5, -6,
+ax_anim_terminator
+sDittoAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -13, 0, -13,
+ax_anim 2, 0, 62, 0, -23, 0, -23,
+ax_anim 2, 1, 62, 1, -23, 1, -23,
+ax_anim 2, 0, 62, 0, -23, 0, -23,
+ax_anim 2, 0, 62, 1, -23, 1, -23,
+ax_anim 2, 0, 61, 0, -7, 0, -7,
+ax_anim_terminator
+sDittoAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 65, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 65, -18, -24, -18, -24,
+ax_anim 2, 1, 65, -19, -23, -19, -23,
+ax_anim 2, 0, 65, -18, -24, -18, -24,
+ax_anim 2, 0, 65, -19, -23, -19, -23,
+ax_anim 2, 0, 64, -5, -6, -5, -6,
+ax_anim_terminator
+sDittoAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -6, 0, -6, 0,
+ax_anim_terminator
+sDittoAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -19, 18, -19, 18,
+ax_anim 2, 1, 71, -20, 17, -20, 17,
+ax_anim 2, 0, 71, -19, 18, -19, 18,
+ax_anim 2, 0, 71, -20, 17, -20, 17,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDittoAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_5_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_5_2:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_5_3:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_5_4:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_5_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_5_6:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_5_7:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_5_8:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_6_1:
+ax_anim 30, 0, 88, 0, 0, 0, 0,
+ax_anim 35, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_7_1:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 8, 0, 90, 0, -3, 0, -3,
+ax_anim_terminator
+sDittoAnims_7_2:
+ax_anim 2, 0, 91, -2, -2, -2, -2,
+ax_anim 8, 0, 91, -3, -3, -3, -3,
+ax_anim_terminator
+sDittoAnims_7_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 8, 0, 92, -3, 0, -3, 0,
+ax_anim_terminator
+sDittoAnims_7_4:
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim 8, 0, 93, -3, 3, -3, 3,
+ax_anim_terminator
+sDittoAnims_7_5:
+ax_anim 2, 0, 94, 0, 2, 0, 2,
+ax_anim 8, 0, 94, 0, 3, 0, 3,
+ax_anim_terminator
+sDittoAnims_7_6:
+ax_anim 2, 0, 95, 2, 2, 2, 2,
+ax_anim 8, 0, 95, 3, 3, 3, 3,
+ax_anim_terminator
+sDittoAnims_7_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 8, 0, 96, 3, 0, 3, 0,
+ax_anim_terminator
+sDittoAnims_7_8:
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim 8, 0, 97, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDittoAnims_8_1:
+ax_anim 16, 0, 98, 0, 0, 0, 0,
+ax_anim 16, 0, 99, 0, -2, 0, 0,
+ax_anim_terminator
+sDittoAnims_8_2:
+ax_anim 16, 0, 100, 0, 0, 0, 0,
+ax_anim 16, 0, 101, -1, -2, 0, 0,
+ax_anim_terminator
+sDittoAnims_8_3:
+ax_anim 16, 0, 102, 0, 0, 0, 0,
+ax_anim 16, 0, 103, -2, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_8_4:
+ax_anim 16, 0, 104, 0, 0, 0, 0,
+ax_anim 16, 0, 105, -1, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_8_5:
+ax_anim 16, 0, 106, 0, 0, 0, 0,
+ax_anim 16, 0, 107, 0, 1, 0, 0,
+ax_anim_terminator
+sDittoAnims_8_6:
+ax_anim 16, 0, 108, 0, 0, 0, 0,
+ax_anim 16, 0, 109, 1, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_8_7:
+ax_anim 16, 0, 110, 0, 0, 0, 0,
+ax_anim 16, 0, 111, 2, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_8_8:
+ax_anim 16, 0, 112, 0, 0, 0, 0,
+ax_anim 16, 0, 113, 1, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_9_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 6, 3, 6, 3,
+ax_anim 2, 0, 116, 8, 9, 8, 9,
+ax_anim 2, 0, 117, 7, 15, 7, 15,
+ax_anim 3, 0, 118, 0, 18, 0, 18,
+ax_anim 2, 3, 119, -7, 15, -7, 15,
+ax_anim 2, 0, 120, -8, 9, -8, 9,
+ax_anim 1, 0, 121, -6, 3, -6, 3,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_9_2:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 8, 0, 8, 0,
+ax_anim 2, 0, 115, 17, 3, 17, 3,
+ax_anim 2, 0, 116, 20, 10, 20, 10,
+ax_anim 3, 0, 117, 19, 18, 19, 18,
+ax_anim 2, 3, 118, 13, 19, 13, 19,
+ax_anim 2, 0, 119, 3, 15, 3, 15,
+ax_anim 1, 0, 120, 0, 7, 0, 7,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_9_3:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 3, -5, 3, -5,
+ax_anim 2, 0, 114, 11, -6, 11, -6,
+ax_anim 2, 0, 115, 18, -5, 18, -5,
+ax_anim 3, 0, 116, 20, -2, 20, -2,
+ax_anim 2, 3, 117, 18, 4, 18, 4,
+ax_anim 2, 0, 118, 12, 5, 12, 5,
+ax_anim 1, 0, 119, 4, 5, 4, 5,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_9_4:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, -1, -8, -1, -8,
+ax_anim 2, 0, 121, 4, -16, 4, -16,
+ax_anim 2, 0, 114, 13, -23, 13, -23,
+ax_anim 3, 0, 115, 20, -22, 20, -22,
+ax_anim 2, 3, 116, 20, -15, 20, -15,
+ax_anim 2, 0, 117, 17, -4, 17, -4,
+ax_anim 1, 0, 118, 7, -1, 7, -1,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_9_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, -8, -4, -8, -4,
+ax_anim 2, 0, 120, -9, -12, -9, -12,
+ax_anim 2, 0, 121, -7, -19, -7, -19,
+ax_anim 3, 0, 114, 0, -23, 0, -23,
+ax_anim 2, 3, 115, 7, -19, 7, -19,
+ax_anim 2, 0, 116, 9, -10, 9, -10,
+ax_anim 1, 0, 117, 8, -4, 8, -4,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_9_6:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 1, -8, 1, -8,
+ax_anim 2, 0, 115, -4, -16, -4, -16,
+ax_anim 2, 0, 114, -13, -23, -13, -23,
+ax_anim 3, 0, 121, -20, -22, -20, -22,
+ax_anim 2, 3, 120, -20, -15, -20, -15,
+ax_anim 2, 0, 119, -17, -4, -17, -4,
+ax_anim 1, 0, 118, -7, -1, -7, -1,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_9_7:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, -3, -5, -3, -5,
+ax_anim 2, 0, 114, -11, -6, -11, -6,
+ax_anim 2, 0, 121, -19, -5, -19, -5,
+ax_anim 3, 0, 120, -21, -2, -21, -2,
+ax_anim 2, 3, 119, -19, 4, -19, 4,
+ax_anim 2, 0, 118, -12, 5, -12, 5,
+ax_anim 1, 0, 117, -4, 5, -4, 5,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_9_8:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, -9, -1, -9, -1,
+ax_anim 2, 0, 121, -17, 3, -17, 3,
+ax_anim 2, 0, 120, -20, 10, -20, 10,
+ax_anim 3, 0, 119, -19, 18, -19, 18,
+ax_anim 2, 3, 118, -13, 19, -13, 19,
+ax_anim 2, 0, 117, -3, 15, -3, 15,
+ax_anim 1, 0, 116, 0, 7, 0, 7,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_10_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 3, 0, 122, 13, 0, 13, 0,
+ax_anim 3, 0, 122, -13, 0, -13, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_10_2:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 3, 0, 123, 13, -13, 13, -13,
+ax_anim 3, 0, 123, -13, 13, -13, 13,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_10_3:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 3, 0, 124, 0, -13, 0, -13,
+ax_anim 3, 0, 124, 0, 13, 0, 13,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_10_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 3, 0, 125, -13, -13, -13, -13,
+ax_anim 3, 0, 125, 13, 13, 13, 13,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_10_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 3, 0, 126, 13, 0, 13, 0,
+ax_anim 3, 0, 126, -13, 0, -13, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_10_6:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 3, 0, 127, 13, -13, 13, -13,
+ax_anim 3, 0, 127, -13, 13, -13, 13,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_10_7:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 3, 0, 128, 0, -13, 0, -13,
+ax_anim 3, 0, 128, 0, 13, 0, 13,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_10_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 3, 0, 129, -13, -13, -13, -13,
+ax_anim 3, 0, 129, 13, 13, 13, 13,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_11_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 2, 0, 131, 0, -16, 0, 0,
+ax_anim 3, 0, 131, 0, -20, 0, 0,
+ax_anim 4, 0, 131, 0, -21, 0, 0,
+ax_anim 4, 0, 132, 0, -23, 0, 0,
+ax_anim 3, 0, 132, 0, -22, 0, 0,
+ax_anim 2, 0, 132, 0, -18, 0, 0,
+ax_anim 1, 0, 132, 0, -12, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_11_2:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 2, 0, 134, 0, -16, 0, 0,
+ax_anim 3, 0, 134, 0, -20, 0, 0,
+ax_anim 4, 0, 134, 0, -21, 0, 0,
+ax_anim 4, 0, 135, 0, -23, 0, 0,
+ax_anim 3, 0, 135, 0, -22, 0, 0,
+ax_anim 2, 0, 135, 0, -18, 0, 0,
+ax_anim 1, 0, 135, 0, -12, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_11_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -10, 0, 0,
+ax_anim 2, 0, 137, 0, -16, 0, 0,
+ax_anim 3, 0, 137, 0, -20, 0, 0,
+ax_anim 4, 0, 137, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -23, 0, 0,
+ax_anim 3, 0, 138, 0, -22, 0, 0,
+ax_anim 2, 0, 138, 0, -18, 0, 0,
+ax_anim 1, 0, 138, 0, -12, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_11_4:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -10, 0, 0,
+ax_anim 2, 0, 140, 0, -16, 0, 0,
+ax_anim 3, 0, 140, 0, -20, 0, 0,
+ax_anim 4, 0, 140, 0, -21, 0, 0,
+ax_anim 4, 0, 141, 0, -22, 0, 0,
+ax_anim 3, 0, 141, 0, -21, 0, 0,
+ax_anim 2, 0, 141, 0, -17, 0, 0,
+ax_anim 1, 0, 141, 0, -11, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_11_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 0, 143, 0, -16, 0, 0,
+ax_anim 3, 0, 143, 0, -20, 0, 0,
+ax_anim 4, 0, 143, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -23, 0, 0,
+ax_anim 3, 0, 144, 0, -22, 0, 0,
+ax_anim 2, 0, 144, 0, -18, 0, 0,
+ax_anim 1, 0, 144, 0, -12, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_11_6:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 0, 146, 0, -16, 0, 0,
+ax_anim 3, 0, 146, 0, -20, 0, 0,
+ax_anim 4, 0, 146, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -22, 0, 0,
+ax_anim 3, 0, 147, 0, -21, 0, 0,
+ax_anim 2, 0, 147, 0, -17, 0, 0,
+ax_anim 1, 0, 147, 0, -11, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_11_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -23, 0, 0,
+ax_anim 3, 0, 150, 0, -22, 0, 0,
+ax_anim 2, 0, 150, 0, -18, 0, 0,
+ax_anim 1, 0, 150, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_11_8:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -23, 0, 0,
+ax_anim 3, 0, 153, 0, -22, 0, 0,
+ax_anim 2, 0, 153, 0, -18, 0, 0,
+ax_anim 1, 0, 153, 0, -12, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_12_1:
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 1, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_12_2:
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 1, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_12_3:
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_12_4:
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 1, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_12_5:
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 1, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_12_6:
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 1, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_12_7:
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 1, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_12_8:
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 1, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDittoAnims_13_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_13_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_13_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_13_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_13_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_13_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_13_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoAnims_13_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sDittoGfx1:
+.incbin "baserom.gba", 0xAB7664, 0x200
+sDittoSprites1:
+ax_sprite sDittoGfx1, 0x200
+ax_sprite_terminator
+sDittoGfx2:
+.incbin "baserom.gba", 0xAB7874, 0x200
+sDittoSprites2:
+ax_sprite sDittoGfx2, 0x200
+ax_sprite_terminator
+sDittoGfx3:
+.incbin "baserom.gba", 0xAB7A84, 0x200
+sDittoSprites3:
+ax_sprite sDittoGfx3, 0x200
+ax_sprite_terminator
+sDittoGfx4:
+.incbin "baserom.gba", 0xAB7C94, 0x200
+sDittoSprites4:
+ax_sprite sDittoGfx4, 0x200
+ax_sprite_terminator
+sDittoGfx5:
+.incbin "baserom.gba", 0xAB7EA4, 0x200
+sDittoSprites5:
+ax_sprite sDittoGfx5, 0x200
+ax_sprite_terminator
+sDittoGfx6:
+.incbin "baserom.gba", 0xAB80B4, 0x200
+sDittoSprites6:
+ax_sprite sDittoGfx6, 0x200
+ax_sprite_terminator
+sDittoGfx7:
+.incbin "baserom.gba", 0xAB82C4, 0x100
+sDittoSprites7:
+ax_sprite sDittoGfx7, 0x100
+ax_sprite_terminator
+sDittoGfx8:
+.incbin "baserom.gba", 0xAB83D4, 0x200
+sDittoSprites8:
+ax_sprite sDittoGfx8, 0x200
+ax_sprite_terminator
+sDittoGfx9:
+.incbin "baserom.gba", 0xAB85E4, 0x200
+sDittoSprites9:
+ax_sprite sDittoGfx9, 0x200
+ax_sprite_terminator
+sDittoGfx10:
+.incbin "baserom.gba", 0xAB87F4, 0x200
+sDittoSprites10:
+ax_sprite sDittoGfx10, 0x200
+ax_sprite_terminator
+sDittoGfx11:
+.incbin "baserom.gba", 0xAB8A04, 0x200
+sDittoSprites11:
+ax_sprite sDittoGfx11, 0x200
+ax_sprite_terminator
+sDittoGfx12:
+.incbin "baserom.gba", 0xAB8C14, 0x100
+sDittoSprites12:
+ax_sprite sDittoGfx12, 0x100
+ax_sprite_terminator
+sDittoGfx13:
+.incbin "baserom.gba", 0xAB8D24, 0x200
+sDittoSprites13:
+ax_sprite sDittoGfx13, 0x200
+ax_sprite_terminator
+sDittoGfx14:
+.incbin "baserom.gba", 0xAB8F34, 0x200
+sDittoSprites14:
+ax_sprite sDittoGfx14, 0x200
+ax_sprite_terminator
+sDittoGfx15:
+.incbin "baserom.gba", 0xAB9144, 0x200
+sDittoSprites15:
+ax_sprite sDittoGfx15, 0x200
+ax_sprite_terminator
+sDittoGfx16:
+.incbin "baserom.gba", 0xAB9354, 0x200
+sDittoSprites16:
+ax_sprite sDittoGfx16, 0x200
+ax_sprite_terminator
+sDittoGfx17:
+.incbin "baserom.gba", 0xAB9564, 0x200
+sDittoSprites17:
+ax_sprite sDittoGfx17, 0x200
+ax_sprite_terminator
+sDittoGfx18:
+.incbin "baserom.gba", 0xAB9774, 0x100
+sDittoSprites18:
+ax_sprite sDittoGfx18, 0x100
+ax_sprite_terminator
+sDittoGfx19:
+.incbin "baserom.gba", 0xAB9884, 0x100
+sDittoSprites19:
+ax_sprite sDittoGfx19, 0x100
+ax_sprite_terminator
+sDittoGfx20:
+.incbin "baserom.gba", 0xAB9994, 0x200
+sDittoSprites20:
+ax_sprite sDittoGfx20, 0x200
+ax_sprite_terminator
+sDittoGfx21:
+.incbin "baserom.gba", 0xAB9BA4, 0x200
+sDittoSprites21:
+ax_sprite sDittoGfx21, 0x200
+ax_sprite_terminator
+sDittoGfx22:
+.incbin "baserom.gba", 0xAB9DB4, 0x200
+sDittoSprites22:
+ax_sprite sDittoGfx22, 0x200
+ax_sprite_terminator
+sDittoGfx23:
+.incbin "baserom.gba", 0xAB9FC4, 0x200
+sDittoSprites23:
+ax_sprite sDittoGfx23, 0x200
+ax_sprite_terminator
+sDittoGfx24:
+.incbin "baserom.gba", 0xABA1D4, 0x200
+sDittoSprites24:
+ax_sprite sDittoGfx24, 0x200
+ax_sprite_terminator
+sDittoGfx25:
+.incbin "baserom.gba", 0xABA3E4, 0x100
+sDittoSprites25:
+ax_sprite sDittoGfx25, 0x100
+ax_sprite_terminator
+sDittoGfx26:
+.incbin "baserom.gba", 0xABA4F4, 0x100
+sDittoSprites26:
+ax_sprite sDittoGfx26, 0x100
+ax_sprite_terminator
+sDittoGfx27:
+.incbin "baserom.gba", 0xABA604, 0x200
+sDittoSprites27:
+ax_sprite sDittoGfx27, 0x200
+ax_sprite_terminator
+sDittoGfx28:
+.incbin "baserom.gba", 0xABA814, 0x200
+sDittoSprites28:
+ax_sprite sDittoGfx28, 0x200
+ax_sprite_terminator
+sDittoGfx29:
+.incbin "baserom.gba", 0xABAA24, 0x200
+sDittoSprites29:
+ax_sprite sDittoGfx29, 0x200
+ax_sprite_terminator
+sDittoGfx30:
+.incbin "baserom.gba", 0xABAC34, 0x200
+sDittoSprites30:
+ax_sprite sDittoGfx30, 0x200
+ax_sprite_terminator
+sDittoGfx31:
+.incbin "baserom.gba", 0xABAE44, 0x200
+sDittoSprites31:
+ax_sprite sDittoGfx31, 0x200
+ax_sprite_terminator
+sAxPosesDitto:
+.4byte sDittoPose1
+.4byte sDittoPose2
+.4byte sDittoPose3
+.4byte sDittoPose4
+.4byte sDittoPose5
+.4byte sDittoPose6
+.4byte sDittoPose7
+.4byte sDittoPose8
+.4byte sDittoPose9
+.4byte sDittoPose10
+.4byte sDittoPose11
+.4byte sDittoPose12
+.4byte sDittoPose13
+.4byte sDittoPose14
+.4byte sDittoPose15
+.4byte sDittoPose16
+.4byte sDittoPose17
+.4byte sDittoPose18
+.4byte sDittoPose19
+.4byte sDittoPose20
+.4byte sDittoPose21
+.4byte sDittoPose22
+.4byte sDittoPose23
+.4byte sDittoPose24
+.4byte sDittoPose25
+.4byte sDittoPose26
+.4byte sDittoPose27
+.4byte sDittoPose28
+.4byte sDittoPose29
+.4byte sDittoPose30
+.4byte sDittoPose31
+.4byte sDittoPose32
+.4byte sDittoPose33
+.4byte sDittoPose34
+.4byte sDittoPose35
+.4byte sDittoPose36
+.4byte sDittoPose37
+.4byte sDittoPose38
+.4byte sDittoPose39
+.4byte sDittoPose40
+.4byte sDittoPose41
+.4byte sDittoPose42
+.4byte sDittoPose43
+.4byte sDittoPose44
+.4byte sDittoPose45
+.4byte sDittoPose46
+.4byte sDittoPose47
+.4byte sDittoPose48
+.4byte sDittoPose49
+.4byte sDittoPose50
+.4byte sDittoPose51
+.4byte sDittoPose52
+.4byte sDittoPose53
+.4byte sDittoPose54
+.4byte sDittoPose55
+.4byte sDittoPose56
+.4byte sDittoPose57
+.4byte sDittoPose58
+.4byte sDittoPose59
+.4byte sDittoPose60
+.4byte sDittoPose61
+.4byte sDittoPose62
+.4byte sDittoPose63
+.4byte sDittoPose64
+.4byte sDittoPose65
+.4byte sDittoPose66
+.4byte sDittoPose67
+.4byte sDittoPose68
+.4byte sDittoPose69
+.4byte sDittoPose70
+.4byte sDittoPose71
+.4byte sDittoPose72
+.4byte sDittoPose73
+.4byte sDittoPose74
+.4byte sDittoPose75
+.4byte sDittoPose76
+.4byte sDittoPose77
+.4byte sDittoPose78
+.4byte sDittoPose79
+.4byte sDittoPose80
+.4byte sDittoPose81
+.4byte sDittoPose82
+.4byte sDittoPose83
+.4byte sDittoPose84
+.4byte sDittoPose85
+.4byte sDittoPose86
+.4byte sDittoPose87
+.4byte sDittoPose88
+.4byte sDittoPose89
+.4byte sDittoPose90
+.4byte sDittoPose91
+.4byte sDittoPose92
+.4byte sDittoPose93
+.4byte sDittoPose94
+.4byte sDittoPose95
+.4byte sDittoPose96
+.4byte sDittoPose97
+.4byte sDittoPose98
+.4byte sDittoPose99
+.4byte sDittoPose100
+.4byte sDittoPose101
+.4byte sDittoPose102
+.4byte sDittoPose103
+.4byte sDittoPose104
+.4byte sDittoPose105
+.4byte sDittoPose106
+.4byte sDittoPose107
+.4byte sDittoPose108
+.4byte sDittoPose109
+.4byte sDittoPose110
+.4byte sDittoPose111
+.4byte sDittoPose112
+.4byte sDittoPose113
+.4byte sDittoPose114
+.4byte sDittoPose115
+.4byte sDittoPose116
+.4byte sDittoPose117
+.4byte sDittoPose118
+.4byte sDittoPose119
+.4byte sDittoPose120
+.4byte sDittoPose121
+.4byte sDittoPose122
+.4byte sDittoPose123
+.4byte sDittoPose124
+.4byte sDittoPose125
+.4byte sDittoPose126
+.4byte sDittoPose127
+.4byte sDittoPose128
+.4byte sDittoPose129
+.4byte sDittoPose130
+.4byte sDittoPose131
+.4byte sDittoPose132
+.4byte sDittoPose133
+.4byte sDittoPose134
+.4byte sDittoPose135
+.4byte sDittoPose136
+.4byte sDittoPose137
+.4byte sDittoPose138
+.4byte sDittoPose139
+.4byte sDittoPose140
+.4byte sDittoPose141
+.4byte sDittoPose142
+.4byte sDittoPose143
+.4byte sDittoPose144
+.4byte sDittoPose145
+.4byte sDittoPose146
+.4byte sDittoPose147
+.4byte sDittoPose148
+.4byte sDittoPose149
+.4byte sDittoPose150
+.4byte sDittoPose151
+.4byte sDittoPose152
+.4byte sDittoPose153
+.4byte sDittoPose154
+.4byte sDittoPose155
+.4byte sDittoPose156
+.4byte sDittoPose157
+.4byte sDittoPose158
+.4byte sDittoPose159
+.4byte sDittoPose160
+.4byte sDittoPose161
+.4byte sDittoPose162
+.4byte sDittoPose163
+.4byte sDittoPose164
+.4byte sDittoPose165
+.4byte sDittoPose166
+.4byte sDittoPose167
+.4byte sDittoPose168
+.4byte sDittoPose169
+.4byte sDittoPose170
+sAxPositionsDitto:
+.2byte   -1,   -5, 	  -8,  -12, 	   8,   -8, 	  -1,   -4
+.2byte   -1,   -4, 	  -8,  -11, 	   8,   -6, 	  -1,   -3
+.2byte   -1,   -1, 	  -7,  -10, 	   8,   -6, 	  -1,    0
+.2byte    2,   -5, 	  -8,   -8, 	   6,  -11, 	  -1,   -5
+.2byte    3,   -4, 	  -9,   -9, 	   6,   -9, 	  -2,   -6
+.2byte    4,   -3, 	  -8,   -8, 	   5,  -10, 	  -2,   -5
+.2byte    4,   -6, 	  -1,   -7, 	  -1,  -12, 	  -1,   -5
+.2byte    6,   -5, 	  -2,   -7, 	  -2,  -13, 	   0,   -5
+.2byte    8,   -5, 	  -1,   -6, 	   0,  -12, 	   2,   -4
+.2byte    3,   -7, 	   7,   -8, 	  -6,  -11, 	  -1,   -5
+.2byte    3,   -7, 	   5,   -7, 	  -7,  -10, 	  -1,   -5
+.2byte    4,   -7, 	   6,   -7, 	  -7,   -8, 	   0,   -4
+.2byte   -1,   -8, 	   7,  -12, 	  -8,   -7, 	   0,   -6
+.2byte   -1,   -8, 	   8,  -11, 	  -8,   -8, 	   0,   -6
+.2byte   -1,   -6, 	   8,  -10, 	  -8,   -7, 	   0,   -4
+.2byte   -1,   -6, 	   5,  -15, 	  -6,   -6, 	   1,   -7
+.2byte   -4,   -8, 	   6,  -14, 	  -7,   -6, 	  -1,   -6
+.2byte   -5,   -7, 	   5,  -11, 	  -8,   -6, 	  -2,   -6
+.2byte   -5,   -6, 	  -1,  -16, 	   0,   -5, 	   0,   -6
+.2byte   -7,   -5, 	   0,  -16, 	  -2,   -4, 	  -2,   -5
+.2byte  -10,   -5, 	   0,  -13, 	  -5,   -3, 	  -5,   -4
+.2byte   -3,   -6, 	  -5,  -14, 	   7,   -5, 	  -1,   -5
+.2byte   -4,   -5, 	  -5,  -13, 	   5,   -9, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,  -13, 	   5,   -7, 	  -3,   -4
+.2byte   -1,   -5, 	  -8,  -12, 	   8,   -8, 	  -1,   -4
+.2byte   -1,   -4, 	  -8,  -11, 	   8,   -6, 	  -1,   -3
+.2byte   -1,   -1, 	  -7,  -10, 	   8,   -6, 	  -1,    0
+.2byte    2,   -5, 	  -8,   -8, 	   6,  -11, 	  -1,   -5
+.2byte    3,   -4, 	  -9,   -9, 	   6,   -9, 	  -2,   -6
+.2byte    4,   -3, 	  -8,   -8, 	   5,  -10, 	  -2,   -5
+.2byte    4,   -6, 	  -1,   -7, 	  -1,  -12, 	  -1,   -5
+.2byte    6,   -5, 	  -2,   -7, 	  -2,  -13, 	   0,   -5
+.2byte    8,   -5, 	  -1,   -6, 	   0,  -12, 	   2,   -4
+.2byte    3,   -7, 	   7,   -8, 	  -6,  -11, 	  -1,   -5
+.2byte    3,   -7, 	   5,   -7, 	  -7,  -10, 	  -1,   -5
+.2byte    4,   -7, 	   6,   -7, 	  -7,   -8, 	   0,   -4
+.2byte   -1,   -8, 	   7,  -12, 	  -8,   -7, 	   0,   -6
+.2byte   -1,   -8, 	   8,  -11, 	  -8,   -8, 	   0,   -6
+.2byte   -1,   -6, 	   8,  -10, 	  -8,   -7, 	   0,   -4
+.2byte   -1,   -6, 	   5,  -15, 	  -6,   -6, 	   1,   -7
+.2byte   -4,   -8, 	   6,  -14, 	  -7,   -6, 	  -1,   -6
+.2byte   -5,   -7, 	   5,  -11, 	  -8,   -6, 	  -2,   -6
+.2byte   -5,   -6, 	  -1,  -16, 	   0,   -5, 	   0,   -6
+.2byte   -7,   -5, 	   0,  -16, 	  -2,   -4, 	  -2,   -5
+.2byte  -10,   -5, 	   0,  -13, 	  -5,   -3, 	  -5,   -4
+.2byte   -3,   -6, 	  -5,  -14, 	   7,   -5, 	  -1,   -5
+.2byte   -4,   -5, 	  -5,  -13, 	   5,   -9, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,  -13, 	   5,   -7, 	  -3,   -4
+.2byte   -1,   -5, 	  -8,  -12, 	   8,   -8, 	  -1,   -4
+.2byte   -1,   -4, 	  -8,  -11, 	   8,   -6, 	  -1,   -3
+.2byte   -1,   -1, 	  -7,  -10, 	   8,   -6, 	  -1,    0
+.2byte    2,   -5, 	  -8,   -8, 	   6,  -11, 	  -1,   -5
+.2byte    3,   -4, 	  -9,   -9, 	   6,   -9, 	  -2,   -6
+.2byte    4,   -3, 	  -8,   -8, 	   5,  -10, 	  -2,   -5
+.2byte    4,   -6, 	  -1,   -7, 	  -1,  -12, 	  -1,   -5
+.2byte    6,   -5, 	  -2,   -7, 	  -2,  -13, 	   0,   -5
+.2byte    8,   -5, 	  -1,   -6, 	   0,  -12, 	   2,   -4
+.2byte    3,   -7, 	   7,   -8, 	  -6,  -11, 	  -1,   -5
+.2byte    3,   -7, 	   5,   -7, 	  -7,  -10, 	  -1,   -5
+.2byte    4,   -7, 	   6,   -7, 	  -7,   -8, 	   0,   -4
+.2byte   -1,   -8, 	   7,  -12, 	  -8,   -7, 	   0,   -6
+.2byte   -1,   -8, 	   8,  -11, 	  -8,   -8, 	   0,   -6
+.2byte   -1,   -6, 	   8,  -10, 	  -8,   -7, 	   0,   -4
+.2byte   -1,   -6, 	   5,  -15, 	  -6,   -6, 	   1,   -7
+.2byte   -4,   -8, 	   6,  -14, 	  -7,   -6, 	  -1,   -6
+.2byte   -5,   -7, 	   5,  -11, 	  -8,   -6, 	  -2,   -6
+.2byte   -5,   -6, 	  -1,  -16, 	   0,   -5, 	   0,   -6
+.2byte   -7,   -5, 	   0,  -16, 	  -2,   -4, 	  -2,   -5
+.2byte  -10,   -5, 	   0,  -13, 	  -5,   -3, 	  -5,   -4
+.2byte   -3,   -6, 	  -5,  -14, 	   7,   -5, 	  -1,   -5
+.2byte   -4,   -5, 	  -5,  -13, 	   5,   -9, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,  -13, 	   5,   -7, 	  -3,   -4
+.2byte   -1,   -4, 	  -8,  -11, 	   8,   -6, 	  -1,   -3
+.2byte   -3,   -5, 	  -4,  -13, 	   6,   -9, 	   0,   -5
+.2byte   -5,   -5, 	   2,  -16, 	   0,   -4, 	   0,   -5
+.2byte   -3,   -7, 	   7,  -13, 	  -6,   -5, 	   0,   -5
+.2byte   -1,   -6, 	   8,   -9, 	  -8,   -6, 	   0,   -4
+.2byte    2,   -6, 	   4,   -6, 	  -8,   -9, 	  -2,   -4
+.2byte    4,   -5, 	  -4,   -7, 	  -4,  -13, 	  -2,   -5
+.2byte    3,   -4, 	  -9,   -9, 	   6,   -9, 	  -2,   -6
+.2byte   -1,   -5, 	  -8,  -12, 	   8,   -8, 	  -1,   -4
+.2byte   -3,   -6, 	  -5,  -14, 	   7,   -5, 	  -1,   -5
+.2byte   -5,   -6, 	  -1,  -16, 	   0,   -5, 	   0,   -6
+.2byte   -1,   -6, 	   5,  -15, 	  -6,   -6, 	   1,   -7
+.2byte   -1,   -8, 	   7,  -12, 	  -8,   -7, 	   0,   -6
+.2byte    3,   -7, 	   7,   -8, 	  -6,  -11, 	  -1,   -5
+.2byte    4,   -6, 	  -1,   -7, 	  -1,  -12, 	  -1,   -5
+.2byte    2,   -5, 	  -8,   -8, 	   6,  -11, 	  -1,   -5
+.2byte    0,   -1, 	  -9,   -5, 	  10,   -4, 	   0,   -3
+.2byte    0,    0, 	  -8,   -3, 	  10,   -3, 	   0,   -2
+.2byte    0,  -10, 	  -7,  -16, 	  11,  -15, 	   0,   -8
+.2byte    0,  -10, 	   5,  -19, 	 -10,  -12, 	   0,   -9
+.2byte    2,  -10, 	   3,  -20, 	  -5,  -13, 	   0,   -8
+.2byte    3,  -12, 	  -5,  -18, 	   8,  -13, 	   1,   -8
+.2byte   -1,  -13, 	   7,  -16, 	 -10,  -15, 	  -1,  -10
+.2byte   -4,  -12, 	   4,  -18, 	  -9,  -13, 	  -2,   -8
+.2byte   -3,  -10, 	  -4,  -20, 	   4,  -13, 	  -1,   -8
+.2byte   -1,  -10, 	  -6,  -19, 	   9,  -12, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,  -12, 	   8,   -8, 	  -1,   -4
+.2byte   -1,   -4, 	  -8,  -11, 	   8,   -6, 	  -1,   -3
+.2byte    2,   -5, 	  -8,   -8, 	   6,  -11, 	  -1,   -5
+.2byte    3,   -4, 	  -9,   -9, 	   6,   -9, 	  -2,   -6
+.2byte    4,   -6, 	  -1,   -7, 	  -1,  -12, 	  -1,   -5
+.2byte    6,   -5, 	  -2,   -7, 	  -2,  -13, 	   0,   -5
+.2byte    3,   -7, 	   7,   -8, 	  -6,  -11, 	  -1,   -5
+.2byte    3,   -7, 	   5,   -7, 	  -7,  -10, 	  -1,   -5
+.2byte   -1,   -8, 	   7,  -12, 	  -8,   -7, 	   0,   -6
+.2byte   -1,   -8, 	   8,  -11, 	  -8,   -8, 	   0,   -6
+.2byte   -1,   -6, 	   5,  -15, 	  -6,   -6, 	   1,   -7
+.2byte   -4,   -8, 	   6,  -14, 	  -7,   -6, 	  -1,   -6
+.2byte   -5,   -6, 	  -1,  -16, 	   0,   -5, 	   0,   -6
+.2byte   -7,   -5, 	   0,  -16, 	  -2,   -4, 	  -2,   -5
+.2byte   -3,   -6, 	  -5,  -14, 	   7,   -5, 	  -1,   -5
+.2byte   -4,   -5, 	  -5,  -13, 	   5,   -9, 	  -1,   -5
+.2byte   -1,   -2, 	  -7,  -11, 	   8,   -7, 	  -1,   -1
+.2byte   -3,   -3, 	  -1,  -13, 	   7,   -7, 	  -1,   -4
+.2byte   -6,   -4, 	   4,  -12, 	  -1,   -2, 	  -1,   -3
+.2byte   -2,   -5, 	   8,   -9, 	  -5,   -4, 	   1,   -4
+.2byte    0,   -4, 	   9,   -8, 	  -7,   -5, 	   1,   -2
+.2byte    3,   -6, 	   5,   -6, 	  -8,   -7, 	  -1,   -3
+.2byte    6,   -4, 	  -3,   -5, 	  -2,  -11, 	   0,   -3
+.2byte    4,   -3, 	  -8,   -8, 	   5,  -10, 	  -2,   -5
+.2byte    0,  -10, 	  -7,  -16, 	  11,  -15, 	   0,   -8
+.2byte    0,  -10, 	   5,  -19, 	 -10,  -12, 	   0,   -9
+.2byte    2,  -10, 	   3,  -20, 	  -5,  -13, 	   0,   -8
+.2byte    2,  -12, 	  -6,  -18, 	   7,  -13, 	   0,   -8
+.2byte   -1,  -13, 	   7,  -16, 	 -10,  -15, 	  -1,  -10
+.2byte   -3,  -12, 	   5,  -18, 	  -8,  -13, 	  -1,   -8
+.2byte   -3,  -10, 	  -4,  -20, 	   4,  -13, 	  -1,   -8
+.2byte   -1,  -10, 	  -6,  -19, 	   9,  -12, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,  -12, 	   8,   -8, 	  -1,   -4
+.2byte   -1,   -4, 	  -8,  -11, 	   8,   -6, 	  -1,   -3
+.2byte   -1,   -1, 	  -7,  -10, 	   8,   -6, 	  -1,    0
+.2byte    2,   -5, 	  -8,   -8, 	   6,  -11, 	  -1,   -5
+.2byte    3,   -4, 	  -9,   -9, 	   6,   -9, 	  -2,   -6
+.2byte    3,   -3, 	  -9,   -8, 	   4,  -10, 	  -3,   -5
+.2byte    4,   -6, 	  -1,   -7, 	  -1,  -12, 	  -1,   -5
+.2byte    4,   -5, 	  -4,   -7, 	  -4,  -13, 	  -2,   -5
+.2byte    5,   -5, 	  -4,   -6, 	  -3,  -12, 	  -1,   -4
+.2byte    3,   -7, 	   7,   -8, 	  -6,  -11, 	  -1,   -5
+.2byte    3,   -7, 	   5,   -7, 	  -7,  -10, 	  -1,   -5
+.2byte    3,   -7, 	   5,   -7, 	  -8,   -8, 	  -1,   -4
+.2byte   -1,   -8, 	   7,  -12, 	  -8,   -7, 	   0,   -6
+.2byte   -1,   -8, 	   8,  -11, 	  -8,   -8, 	   0,   -6
+.2byte   -1,   -6, 	   8,  -10, 	  -8,   -7, 	   0,   -4
+.2byte   -1,   -6, 	   5,  -15, 	  -6,   -6, 	   1,   -7
+.2byte   -2,   -8, 	   8,  -14, 	  -5,   -6, 	   1,   -6
+.2byte   -1,   -7, 	   9,  -11, 	  -4,   -6, 	   2,   -6
+.2byte   -5,   -6, 	  -1,  -16, 	   0,   -5, 	   0,   -6
+.2byte   -5,   -5, 	   2,  -16, 	   0,   -4, 	   0,   -5
+.2byte   -6,   -5, 	   4,  -13, 	  -1,   -3, 	  -1,   -4
+.2byte   -3,   -6, 	  -5,  -14, 	   7,   -5, 	  -1,   -5
+.2byte   -3,   -5, 	  -4,  -13, 	   6,   -9, 	   0,   -5
+.2byte   -3,   -3, 	  -1,  -13, 	   7,   -7, 	  -1,   -4
+.2byte   -1,   -4, 	  -8,  -11, 	   8,   -6, 	  -1,   -3
+.2byte   -3,   -5, 	  -4,  -13, 	   6,   -9, 	   0,   -5
+.2byte   -5,   -5, 	   2,  -16, 	   0,   -4, 	   0,   -5
+.2byte   -3,   -7, 	   7,  -13, 	  -6,   -5, 	   0,   -5
+.2byte   -1,   -6, 	   8,   -9, 	  -8,   -6, 	   0,   -4
+.2byte    2,   -6, 	   4,   -6, 	  -8,   -9, 	  -2,   -4
+.2byte    4,   -5, 	  -4,   -7, 	  -4,  -13, 	  -2,   -5
+.2byte    3,   -4, 	  -9,   -9, 	   6,   -9, 	  -2,   -6
+.2byte   -1,   -5, 	  -8,  -12, 	   8,   -8, 	  -1,   -4
+.2byte   -3,   -6, 	  -5,  -14, 	   7,   -5, 	  -1,   -5
+.2byte   -5,   -6, 	  -1,  -16, 	   0,   -5, 	   0,   -6
+.2byte   -1,   -6, 	   5,  -15, 	  -6,   -6, 	   1,   -7
+.2byte   -1,   -8, 	   7,  -12, 	  -8,   -7, 	   0,   -6
+.2byte    3,   -7, 	   7,   -8, 	  -6,  -11, 	  -1,   -5
+.2byte    4,   -6, 	  -1,   -7, 	  -1,  -12, 	  -1,   -5
+.2byte    2,   -5, 	  -8,   -8, 	   6,  -11, 	  -1,   -5
+sDittoAnimTable1:
+.4byte sDittoAnims_1_1
+.4byte sDittoAnims_1_2
+.4byte sDittoAnims_1_3
+.4byte sDittoAnims_1_4
+.4byte sDittoAnims_1_5
+.4byte sDittoAnims_1_6
+.4byte sDittoAnims_1_7
+.4byte sDittoAnims_1_8
+sDittoAnimTable2:
+.4byte sDittoAnims_2_1
+.4byte sDittoAnims_2_2
+.4byte sDittoAnims_2_3
+.4byte sDittoAnims_2_4
+.4byte sDittoAnims_2_5
+.4byte sDittoAnims_2_6
+.4byte sDittoAnims_2_7
+.4byte sDittoAnims_2_8
+sDittoAnimTable3:
+.4byte sDittoAnims_3_1
+.4byte sDittoAnims_3_2
+.4byte sDittoAnims_3_3
+.4byte sDittoAnims_3_4
+.4byte sDittoAnims_3_5
+.4byte sDittoAnims_3_6
+.4byte sDittoAnims_3_7
+.4byte sDittoAnims_3_8
+sDittoAnimTable4:
+.4byte sDittoAnims_4_1
+.4byte sDittoAnims_4_2
+.4byte sDittoAnims_4_3
+.4byte sDittoAnims_4_4
+.4byte sDittoAnims_4_5
+.4byte sDittoAnims_4_6
+.4byte sDittoAnims_4_7
+.4byte sDittoAnims_4_8
+sDittoAnimTable5:
+.4byte sDittoAnims_5_1
+.4byte sDittoAnims_5_2
+.4byte sDittoAnims_5_3
+.4byte sDittoAnims_5_4
+.4byte sDittoAnims_5_5
+.4byte sDittoAnims_5_6
+.4byte sDittoAnims_5_7
+.4byte sDittoAnims_5_8
+sDittoAnimTable6:
+.4byte sDittoAnims_6_1
+.4byte sDittoAnims_6_1
+.4byte sDittoAnims_6_1
+.4byte sDittoAnims_6_1
+.4byte sDittoAnims_6_1
+.4byte sDittoAnims_6_1
+.4byte sDittoAnims_6_1
+.4byte sDittoAnims_6_1
+sDittoAnimTable7:
+.4byte sDittoAnims_7_1
+.4byte sDittoAnims_7_2
+.4byte sDittoAnims_7_3
+.4byte sDittoAnims_7_4
+.4byte sDittoAnims_7_5
+.4byte sDittoAnims_7_6
+.4byte sDittoAnims_7_7
+.4byte sDittoAnims_7_8
+sDittoAnimTable8:
+.4byte sDittoAnims_8_1
+.4byte sDittoAnims_8_2
+.4byte sDittoAnims_8_3
+.4byte sDittoAnims_8_4
+.4byte sDittoAnims_8_5
+.4byte sDittoAnims_8_6
+.4byte sDittoAnims_8_7
+.4byte sDittoAnims_8_8
+sDittoAnimTable9:
+.4byte sDittoAnims_9_1
+.4byte sDittoAnims_9_2
+.4byte sDittoAnims_9_3
+.4byte sDittoAnims_9_4
+.4byte sDittoAnims_9_5
+.4byte sDittoAnims_9_6
+.4byte sDittoAnims_9_7
+.4byte sDittoAnims_9_8
+sDittoAnimTable10:
+.4byte sDittoAnims_10_1
+.4byte sDittoAnims_10_2
+.4byte sDittoAnims_10_3
+.4byte sDittoAnims_10_4
+.4byte sDittoAnims_10_5
+.4byte sDittoAnims_10_6
+.4byte sDittoAnims_10_7
+.4byte sDittoAnims_10_8
+sDittoAnimTable11:
+.4byte sDittoAnims_11_1
+.4byte sDittoAnims_11_2
+.4byte sDittoAnims_11_3
+.4byte sDittoAnims_11_4
+.4byte sDittoAnims_11_5
+.4byte sDittoAnims_11_6
+.4byte sDittoAnims_11_7
+.4byte sDittoAnims_11_8
+sDittoAnimTable12:
+.4byte sDittoAnims_12_1
+.4byte sDittoAnims_12_2
+.4byte sDittoAnims_12_3
+.4byte sDittoAnims_12_4
+.4byte sDittoAnims_12_5
+.4byte sDittoAnims_12_6
+.4byte sDittoAnims_12_7
+.4byte sDittoAnims_12_8
+sDittoAnimTable13:
+.4byte sDittoAnims_13_1
+.4byte sDittoAnims_13_2
+.4byte sDittoAnims_13_3
+.4byte sDittoAnims_13_4
+.4byte sDittoAnims_13_5
+.4byte sDittoAnims_13_6
+.4byte sDittoAnims_13_7
+.4byte sDittoAnims_13_8
+sAxAnimationsDitto:
+.4byte sDittoAnimTable1
+.4byte sDittoAnimTable2
+.4byte sDittoAnimTable3
+.4byte sDittoAnimTable4
+.4byte sDittoAnimTable5
+.4byte sDittoAnimTable6
+.4byte sDittoAnimTable7
+.4byte sDittoAnimTable8
+.4byte sDittoAnimTable9
+.4byte sDittoAnimTable10
+.4byte sDittoAnimTable11
+.4byte sDittoAnimTable12
+.4byte sDittoAnimTable13
+sAxSpritesDitto:
+.4byte sDittoSprites1
+.4byte sDittoSprites2
+.4byte sDittoSprites3
+.4byte sDittoSprites4
+.4byte sDittoSprites5
+.4byte sDittoSprites6
+.4byte sDittoSprites7
+.4byte sDittoSprites8
+.4byte sDittoSprites9
+.4byte sDittoSprites10
+.4byte sDittoSprites11
+.4byte sDittoSprites12
+.4byte sDittoSprites13
+.4byte sDittoSprites14
+.4byte sDittoSprites15
+.4byte sDittoSprites16
+.4byte sDittoSprites17
+.4byte sDittoSprites18
+.4byte sDittoSprites19
+.4byte sDittoSprites20
+.4byte sDittoSprites21
+.4byte sDittoSprites22
+.4byte sDittoSprites23
+.4byte sDittoSprites24
+.4byte sDittoSprites25
+.4byte sDittoSprites26
+.4byte sDittoSprites27
+.4byte sDittoSprites28
+.4byte sDittoSprites29
+.4byte sDittoSprites30
+.4byte sDittoSprites31
+sAxMainDitto:
+ax_main sAxPosesDitto, sAxAnimationsDitto, 13, sAxSpritesDitto, sAxPositionsDitto

--- a/data/ax/dodrio.inc
+++ b/data/ax/dodrio.inc
@@ -1,0 +1,3061 @@
+.global gAxDodrio
+gAxDodrio:
+ax_siro sAxMainDodrio
+sDodrioPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose5:
+ax_pose 4, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose8:
+ax_pose 7, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose10:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose11:
+ax_pose 10, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose12:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose28:
+ax_pose 15, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose29:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose30:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose31:
+ax_pose 4, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose32:
+ax_pose 5, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose33:
+ax_pose 17, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDodrioPose34:
+ax_pose 18, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sDodrioPose35:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose36:
+ax_pose 7, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose37:
+ax_pose 8, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose38:
+ax_pose 19, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDodrioPose39:
+ax_pose 20, 0x01e6, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose40:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose41:
+ax_pose 10, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose42:
+ax_pose 11, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose43:
+ax_pose 21, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDodrioPose44:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sDodrioPose45:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose46:
+ax_pose 13, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose47:
+ax_pose 14, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose48:
+ax_pose 23, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose49:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose50:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose51:
+ax_pose 10, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose52:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose53:
+ax_pose 21, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose54:
+ax_pose 22, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose55:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose56:
+ax_pose 7, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose57:
+ax_pose 8, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose58:
+ax_pose 19, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose59:
+ax_pose 20, 0x01e6, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose60:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose61:
+ax_pose 4, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose62:
+ax_pose 5, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose63:
+ax_pose 17, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose64:
+ax_pose 18, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose65:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose66:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose67:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose68:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose69:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose70:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose71:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose72:
+ax_pose 4, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose73:
+ax_pose 5, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose74:
+ax_pose 26, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose75:
+ax_pose 17, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose76:
+ax_pose 18, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose77:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose78:
+ax_pose 7, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose79:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose80:
+ax_pose 27, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose81:
+ax_pose 19, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose82:
+ax_pose 20, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose83:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose84:
+ax_pose 10, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose85:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose86:
+ax_pose 28, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose87:
+ax_pose 21, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose88:
+ax_pose 22, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose89:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose90:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose91:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose92:
+ax_pose 23, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose93:
+ax_pose 29, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose94:
+ax_pose 24, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose95:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose96:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose97:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose98:
+ax_pose 28, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose99:
+ax_pose 21, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose100:
+ax_pose 22, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose101:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose102:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose103:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose104:
+ax_pose 27, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose105:
+ax_pose 19, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose106:
+ax_pose 20, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose107:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose108:
+ax_pose 4, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose109:
+ax_pose 5, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose110:
+ax_pose 26, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose111:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose112:
+ax_pose 18, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose113:
+ax_pose 30, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose114:
+ax_pose 31, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose115:
+ax_pose 32, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose116:
+ax_pose 33, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose117:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose118:
+ax_pose 33, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose119:
+ax_pose 32, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose120:
+ax_pose 31, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose121:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose122:
+ax_pose 30, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose123:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose124:
+ax_pose 35, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose125:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose126:
+ax_pose 31, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose127:
+ax_pose 18, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose128:
+ax_pose 36, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose129:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose130:
+ax_pose 32, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose131:
+ax_pose 20, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose132:
+ax_pose 37, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose133:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose134:
+ax_pose 33, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose135:
+ax_pose 22, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose136:
+ax_pose 38, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose137:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose138:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose139:
+ax_pose 24, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose140:
+ax_pose 39, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose141:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose142:
+ax_pose 33, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose143:
+ax_pose 22, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose144:
+ax_pose 38, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose145:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose146:
+ax_pose 32, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose147:
+ax_pose 20, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose148:
+ax_pose 37, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose149:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose150:
+ax_pose 31, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose151:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose152:
+ax_pose 36, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose153:
+ax_pose 40, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose154:
+ax_pose 41, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose155:
+ax_pose 42, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose156:
+ax_pose 43, 0x01e1, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose157:
+ax_pose 44, 0x01e2, 0x90ef, 0x4c00
+ax_pose_terminator
+sDodrioPose158:
+ax_pose 45, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sDodrioPose159:
+ax_pose 46, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose160:
+ax_pose 45, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sDodrioPose161:
+ax_pose 44, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose162:
+ax_pose 43, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose163:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose164:
+ax_pose 30, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose165:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose166:
+ax_pose 35, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose167:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose168:
+ax_pose 31, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose169:
+ax_pose 18, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose170:
+ax_pose 36, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose171:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose172:
+ax_pose 32, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose173:
+ax_pose 20, 0x01e5, 0x90f2, 0x4c00
+ax_pose_terminator
+sDodrioPose174:
+ax_pose 37, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose175:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose176:
+ax_pose 33, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose177:
+ax_pose 22, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sDodrioPose178:
+ax_pose 38, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose179:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose180:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose181:
+ax_pose 24, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose182:
+ax_pose 39, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose183:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose184:
+ax_pose 33, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose185:
+ax_pose 22, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sDodrioPose186:
+ax_pose 38, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose187:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose188:
+ax_pose 32, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose189:
+ax_pose 20, 0x01e5, 0x80ee, 0x4c00
+ax_pose_terminator
+sDodrioPose190:
+ax_pose 37, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose191:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose192:
+ax_pose 31, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose193:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose194:
+ax_pose 36, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose195:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose196:
+ax_pose 17, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose197:
+ax_pose 27, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sDodrioPose198:
+ax_pose 21, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose199:
+ax_pose 23, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sDodrioPose200:
+ax_pose 21, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose201:
+ax_pose 27, 0x01e4, 0x90f1, 0x4c00
+ax_pose_terminator
+sDodrioPose202:
+ax_pose 17, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose203:
+ax_pose 30, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose204:
+ax_pose 31, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose205:
+ax_pose 32, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose206:
+ax_pose 33, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose207:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose208:
+ax_pose 33, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose209:
+ax_pose 32, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose210:
+ax_pose 31, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose211:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose212:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose213:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose214:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose215:
+ax_pose 4, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose216:
+ax_pose 5, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose217:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose218:
+ax_pose 7, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose219:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose220:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose221:
+ax_pose 10, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose222:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose223:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose224:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose225:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose226:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose227:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose228:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose229:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose230:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose231:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose232:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose233:
+ax_pose 4, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose234:
+ax_pose 5, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose235:
+ax_pose 30, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose236:
+ax_pose 31, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose237:
+ax_pose 32, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sDodrioPose238:
+ax_pose 33, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose239:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose240:
+ax_pose 33, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose241:
+ax_pose 32, 0x01e5, 0x90f3, 0x4c00
+ax_pose_terminator
+sDodrioPose242:
+ax_pose 31, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose243:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose244:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose245:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose246:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose247:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sDodrioPose248:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose249:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sDodrioPose250:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+.align 2
+sDodrioAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_2_1:
+ax_anim 1, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -3, 0, -2,
+ax_anim 4, 0, 26, 0, -4, 0, -5,
+ax_anim 3, 0, 24, 0, -4, 0, -2,
+ax_anim 2, 0, 25, 0, -4, 0, -2,
+ax_anim 2, 0, 24, 0, -4, 0, -2,
+ax_anim 1, 0, 26, 0, -2, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 6, 0, 6,
+ax_anim_terminator
+sDodrioAnims_2_2:
+ax_anim 1, 0, 30, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 4, 0, 31, -4, -4, -4, -4,
+ax_anim 3, 0, 29, -4, -4, -4, -4,
+ax_anim 2, 0, 30, -4, -4, -4, -4,
+ax_anim 2, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 2, 32, 4, 4, 4, 4,
+ax_anim 1, 0, 32, 10, 10, 10, 10,
+ax_anim 2, 0, 32, 20, 20, 20, 20,
+ax_anim 2, 1, 32, 21, 19, 21, 19,
+ax_anim 2, 0, 32, 20, 20, 20, 20,
+ax_anim 2, 0, 32, 21, 19, 21, 19,
+ax_anim 2, 0, 33, 6, 6, 6, 6,
+ax_anim_terminator
+sDodrioAnims_2_3:
+ax_anim 1, 0, 35, -1, 0, -1, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 4, 0, 36, -4, 0, -4, 0,
+ax_anim 3, 0, 34, -4, 0, -4, 0,
+ax_anim 2, 0, 35, -4, 0, -4, 0,
+ax_anim 2, 0, 34, -4, 0, -4, 0,
+ax_anim 1, 0, 36, -2, 0, -2, 0,
+ax_anim 1, 2, 37, 4, 0, 4, 0,
+ax_anim 1, 0, 37, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 20, 0, 20, 0,
+ax_anim 2, 1, 37, 20, -1, 20, -1,
+ax_anim 2, 0, 37, 20, 0, 20, 0,
+ax_anim 2, 0, 37, 20, -1, 20, -1,
+ax_anim 2, 0, 38, 6, 0, 6, 0,
+ax_anim_terminator
+sDodrioAnims_2_4:
+ax_anim 1, 0, 40, -1, 1, -1, 1,
+ax_anim 2, 0, 39, -3, 3, -3, 3,
+ax_anim 4, 0, 41, -4, 4, -4, 4,
+ax_anim 3, 0, 39, -4, 4, -4, 4,
+ax_anim 2, 0, 40, -4, 4, -4, 4,
+ax_anim 2, 0, 39, -4, 4, -4, 4,
+ax_anim 1, 0, 41, -2, 2, -2, 2,
+ax_anim 1, 2, 42, 4, -4, 4, -4,
+ax_anim 1, 0, 42, 10, -10, 10, -10,
+ax_anim 2, 0, 42, 20, -20, 20, -20,
+ax_anim 2, 1, 42, 21, -19, 21, -19,
+ax_anim 2, 0, 42, 20, -20, 20, -20,
+ax_anim 2, 0, 42, 21, -19, 21, -19,
+ax_anim 2, 0, 43, 6, -6, 6, -6,
+ax_anim_terminator
+sDodrioAnims_2_5:
+ax_anim 1, 0, 45, 0, 1, 0, 1,
+ax_anim 2, 0, 44, 0, 3, 0, 3,
+ax_anim 4, 0, 46, 0, 4, 0, 4,
+ax_anim 3, 0, 44, 0, 4, 0, 4,
+ax_anim 2, 0, 45, 0, 4, 0, 4,
+ax_anim 2, 0, 44, 0, 4, 0, 4,
+ax_anim 1, 0, 46, 0, 2, 0, 2,
+ax_anim 1, 2, 47, 0, -4, 0, -4,
+ax_anim 1, 0, 47, 0, -10, 0, -10,
+ax_anim 2, 0, 47, 0, -20, 0, -20,
+ax_anim 2, 1, 47, -1, -20, -1, -20,
+ax_anim 2, 0, 47, 0, -20, 0, -20,
+ax_anim 2, 0, 47, -1, -20, -1, -20,
+ax_anim 2, 0, 48, 0, -6, 0, -6,
+ax_anim_terminator
+sDodrioAnims_2_6:
+ax_anim 1, 0, 50, 1, 1, 1, 1,
+ax_anim 2, 0, 49, 3, 3, 3, 3,
+ax_anim 4, 0, 51, 4, 4, 4, 4,
+ax_anim 3, 0, 49, 4, 4, 4, 4,
+ax_anim 2, 0, 50, 4, 4, 4, 4,
+ax_anim 2, 0, 49, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 2, 2, 2, 2,
+ax_anim 1, 2, 52, -4, -4, -4, -4,
+ax_anim 1, 0, 52, -10, -10, -10, -10,
+ax_anim 2, 0, 52, -20, -20, -20, -20,
+ax_anim 2, 1, 52, -21, -19, -21, -19,
+ax_anim 2, 0, 52, -20, -20, -20, -20,
+ax_anim 2, 0, 52, -21, -19, -21, -19,
+ax_anim 2, 0, 53, -6, -6, -6, -6,
+ax_anim_terminator
+sDodrioAnims_2_7:
+ax_anim 1, 0, 55, 1, 0, 1, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim 4, 0, 56, 4, 0, 4, 0,
+ax_anim 3, 0, 54, 4, 0, 4, 0,
+ax_anim 2, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 2, 0, 2, 0,
+ax_anim 1, 2, 57, -4, 0, -4, 0,
+ax_anim 1, 0, 57, -10, 0, -10, 0,
+ax_anim 2, 0, 57, -20, 0, -20, 0,
+ax_anim 2, 1, 57, -20, -1, -20, -1,
+ax_anim 2, 0, 57, -20, 0, -20, 0,
+ax_anim 2, 0, 57, -20, -1, -20, -1,
+ax_anim 2, 0, 58, -6, 0, -6, 0,
+ax_anim_terminator
+sDodrioAnims_2_8:
+ax_anim 1, 0, 60, 1, -1, 1, -1,
+ax_anim 2, 0, 59, 3, -3, 3, -3,
+ax_anim 4, 0, 61, 4, -4, 4, -4,
+ax_anim 3, 0, 59, 4, -4, 4, -4,
+ax_anim 2, 0, 60, 4, -4, 4, -4,
+ax_anim 2, 0, 59, 4, -4, 4, -4,
+ax_anim 1, 0, 61, 2, -2, 2, -2,
+ax_anim 1, 2, 62, -4, 4, -4, 4,
+ax_anim 1, 0, 62, -10, 10, -10, 10,
+ax_anim 2, 0, 62, -20, 20, -20, 20,
+ax_anim 2, 1, 62, -21, 19, -21, 19,
+ax_anim 2, 0, 62, -20, 20, -20, 20,
+ax_anim 2, 0, 62, -21, 19, -21, 19,
+ax_anim 2, 0, 63, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDodrioAnims_3_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim 2, 0, 65, 0, -4, 0, -3,
+ax_anim 2, 0, 66, 0, -4, 0, -3,
+ax_anim 1, 0, 69, 0, -2, 0, -2,
+ax_anim 1, 0, 67, 0, 2, 0, 2,
+ax_anim 2, 2, 67, 0, 8, 0, 8,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 2, 1, 68, 0, 20, 0, 20,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 0, 69, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 3, 0, 3,
+ax_anim_terminator
+sDodrioAnims_3_2:
+ax_anim 2, 0, 70, -2, -2, -2, -2,
+ax_anim 2, 0, 70, -3, -3, -3, -3,
+ax_anim 2, 0, 71, -4, -5, -3, -3,
+ax_anim 2, 0, 72, -4, -5, -3, -3,
+ax_anim 1, 0, 75, -2, -2, -2, -2,
+ax_anim 1, 0, 73, 2, 3, 2, 3,
+ax_anim 2, 2, 73, 8, 10, 8, 10,
+ax_anim 2, 0, 73, 16, 20, 16, 20,
+ax_anim 2, 1, 74, 16, 20, 16, 20,
+ax_anim 2, 0, 73, 16, 20, 16, 20,
+ax_anim 2, 0, 74, 16, 20, 16, 20,
+ax_anim 2, 0, 73, 16, 20, 16, 20,
+ax_anim 2, 0, 74, 16, 20, 16, 20,
+ax_anim 2, 0, 75, 10, 12, 10, 12,
+ax_anim 2, 0, 70, 3, 4, 3, 4,
+ax_anim_terminator
+sDodrioAnims_3_3:
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 2, 0, 76, -3, 0, -3, 0,
+ax_anim 2, 0, 77, -4, -1, -4, 0,
+ax_anim 2, 0, 78, -4, -1, -4, 0,
+ax_anim 1, 0, 81, -2, 0, -2, 0,
+ax_anim 1, 0, 79, 2, 0, 2, 0,
+ax_anim 2, 2, 79, 6, 0, 6, 0,
+ax_anim 2, 0, 79, 13, 0, 13, 0,
+ax_anim 2, 1, 80, 13, 0, 13, 0,
+ax_anim 2, 0, 79, 13, 0, 13, 0,
+ax_anim 2, 0, 80, 13, 0, 13, 0,
+ax_anim 2, 0, 79, 13, 0, 13, 0,
+ax_anim 2, 0, 80, 13, 0, 13, 0,
+ax_anim 2, 0, 81, 8, 0, 8, 0,
+ax_anim 2, 0, 76, 3, 0, 3, 0,
+ax_anim_terminator
+sDodrioAnims_3_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 2, 0, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 83, -4, 3, -4, 4,
+ax_anim 2, 0, 84, -4, 3, -4, 4,
+ax_anim 1, 0, 87, -2, 2, -2, 2,
+ax_anim 1, 0, 85, 2, -3, 2, -3,
+ax_anim 2, 2, 85, 8, -10, 8, -10,
+ax_anim 2, 0, 85, 14, -18, 14, -18,
+ax_anim 2, 1, 86, 14, -18, 14, -18,
+ax_anim 2, 0, 85, 14, -18, 14, -18,
+ax_anim 2, 0, 86, 14, -18, 14, -18,
+ax_anim 2, 0, 85, 14, -18, 14, -18,
+ax_anim 2, 0, 86, 14, -18, 14, -18,
+ax_anim 2, 0, 87, 10, -12, 10, -12,
+ax_anim 2, 0, 82, 3, -4, 3, -4,
+ax_anim_terminator
+sDodrioAnims_3_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 1, 0, 93, 0, 2, 0, 2,
+ax_anim 1, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 2, 91, 0, -10, 0, -10,
+ax_anim 2, 0, 91, 0, -18, 0, -18,
+ax_anim 2, 1, 92, 0, -18, 0, -18,
+ax_anim 2, 0, 91, 0, -18, 0, -18,
+ax_anim 2, 0, 92, 0, -18, 0, -18,
+ax_anim 2, 0, 91, 0, -18, 0, -18,
+ax_anim 2, 0, 92, 0, -18, 0, -18,
+ax_anim 2, 0, 93, 0, -12, 0, -12,
+ax_anim 2, 0, 88, 0, -4, 0, -4,
+ax_anim_terminator
+sDodrioAnims_3_6:
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 3, 4, 4,
+ax_anim 2, 0, 96, 4, 3, 4, 4,
+ax_anim 1, 0, 99, 2, 2, 2, 2,
+ax_anim 1, 0, 97, -2, -3, -2, -3,
+ax_anim 2, 2, 97, -8, -10, -8, -10,
+ax_anim 2, 0, 97, -14, -18, -14, -18,
+ax_anim 2, 1, 98, -14, -18, -14, -18,
+ax_anim 2, 0, 97, -14, -18, -14, -18,
+ax_anim 2, 0, 98, -14, -18, -14, -18,
+ax_anim 2, 0, 97, -14, -18, -14, -18,
+ax_anim 2, 0, 98, -14, -18, -14, -18,
+ax_anim 2, 0, 99, -10, -12, -10, -12,
+ax_anim 2, 0, 94, -3, -4, -3, -4,
+ax_anim_terminator
+sDodrioAnims_3_7:
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 2, 0, 100, 3, 0, 3, 0,
+ax_anim 2, 0, 101, 4, -1, 4, 0,
+ax_anim 2, 0, 102, 4, -1, 4, 0,
+ax_anim 1, 0, 105, 2, 0, 2, 0,
+ax_anim 1, 0, 103, -2, 0, -2, 0,
+ax_anim 2, 2, 103, -6, 0, -6, 0,
+ax_anim 2, 0, 103, -13, 0, -13, 0,
+ax_anim 2, 1, 104, -13, 0, -13, 0,
+ax_anim 2, 0, 103, -13, 0, -13, 0,
+ax_anim 2, 0, 104, -13, 0, -13, 0,
+ax_anim 2, 0, 103, -13, 0, -13, 0,
+ax_anim 2, 0, 104, -13, 0, -13, 0,
+ax_anim 2, 0, 105, -8, 0, -8, 0,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sDodrioAnims_3_8:
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 106, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 4, -5, 3, -3,
+ax_anim 2, 0, 108, 4, -5, 3, -3,
+ax_anim 1, 0, 111, 2, -2, 2, -2,
+ax_anim 1, 0, 109, -2, 3, -2, 3,
+ax_anim 2, 2, 109, -8, 10, -8, 10,
+ax_anim 2, 0, 109, -16, 20, -16, 20,
+ax_anim 2, 1, 110, -16, 20, -16, 20,
+ax_anim 2, 0, 109, -16, 20, -16, 20,
+ax_anim 2, 0, 110, -16, 20, -16, 20,
+ax_anim 2, 0, 109, -16, 20, -16, 20,
+ax_anim 2, 0, 110, -16, 20, -16, 20,
+ax_anim 2, 0, 111, -10, 12, -10, 12,
+ax_anim 2, 0, 106, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sDodrioAnims_4_1:
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_4_2:
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_4_3:
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_4_4:
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_4_5:
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_4_6:
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_4_7:
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_4_8:
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_5_1:
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim 4, 0, 120, 0, -3, 0, -3,
+ax_anim 1, 2, 120, 0, 3, 0, 3,
+ax_anim 1, 0, 120, 0, 8, 0, 8,
+ax_anim 2, 0, 121, 0, 18, 0, 18,
+ax_anim 4, 1, 121, 0, 16, 0, 16,
+ax_anim 2, 0, 122, 0, 18, 0, 18,
+ax_anim 4, 0, 122, 0, 16, 0, 16,
+ax_anim 2, 0, 123, 0, 18, 0, 18,
+ax_anim 2, 0, 123, 0, 16, 0, 16,
+ax_anim 2, 0, 122, 0, 18, 0, 18,
+ax_anim 1, 0, 122, 0, 16, 0, 16,
+ax_anim 1, 0, 121, 0, 18, 0, 18,
+ax_anim 1, 0, 121, 0, 16, 0, 16,
+ax_anim 1, 0, 120, 0, 8, 0, 8,
+ax_anim 1, 0, 120, 0, 2, 0, 2,
+ax_anim_terminator
+sDodrioAnims_5_2:
+ax_anim 2, 0, 124, -2, -2, -2, -2,
+ax_anim 4, 0, 124, -3, -3, -3, -3,
+ax_anim 1, 2, 124, 3, 3, 3, 3,
+ax_anim 1, 0, 124, 8, 9, 8, 9,
+ax_anim 2, 0, 125, 15, 18, 15, 18,
+ax_anim 4, 1, 125, 13, 16, 13, 16,
+ax_anim 2, 0, 126, 15, 18, 15, 18,
+ax_anim 4, 0, 126, 13, 16, 13, 16,
+ax_anim 2, 0, 127, 15, 18, 15, 18,
+ax_anim 2, 0, 127, 13, 16, 13, 16,
+ax_anim 2, 0, 126, 15, 18, 15, 18,
+ax_anim 1, 0, 126, 13, 16, 13, 16,
+ax_anim 1, 0, 125, 15, 18, 15, 18,
+ax_anim 1, 0, 125, 13, 16, 13, 16,
+ax_anim 1, 0, 124, 8, 9, 8, 9,
+ax_anim 1, 0, 124, 2, 2, 2, 2,
+ax_anim_terminator
+sDodrioAnims_5_3:
+ax_anim 2, 0, 128, -2, 0, -2, 0,
+ax_anim 4, 0, 128, -3, 0, -3, 0,
+ax_anim 1, 2, 128, 3, 0, 3, 0,
+ax_anim 1, 0, 128, 8, 0, 8, 0,
+ax_anim 2, 0, 129, 12, 0, 12, 0,
+ax_anim 4, 1, 129, 10, 0, 10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 4, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 131, 12, 0, 12, 0,
+ax_anim 2, 0, 131, 10, 0, 10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 1, 0, 130, 10, 0, 10, 0,
+ax_anim 1, 0, 129, 12, 0, 12, 0,
+ax_anim 1, 0, 129, 10, 0, 10, 0,
+ax_anim 1, 0, 128, 8, 0, 8, 0,
+ax_anim 1, 0, 128, 2, 0, 2, 0,
+ax_anim_terminator
+sDodrioAnims_5_4:
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim 4, 0, 132, -3, 3, -3, 3,
+ax_anim 1, 2, 132, 3, -3, 3, -3,
+ax_anim 1, 0, 132, 8, -9, 8, -9,
+ax_anim 2, 0, 133, 14, -16, 14, -16,
+ax_anim 4, 1, 133, 12, -14, 12, -14,
+ax_anim 2, 0, 134, 14, -16, 14, -16,
+ax_anim 4, 0, 134, 12, -14, 12, -14,
+ax_anim 2, 0, 135, 14, -16, 14, -16,
+ax_anim 2, 0, 135, 12, -14, 12, -14,
+ax_anim 2, 0, 134, 14, -16, 14, -16,
+ax_anim 1, 0, 134, 12, -14, 12, -14,
+ax_anim 1, 0, 133, 14, -16, 14, -16,
+ax_anim 1, 0, 133, 12, -14, 12, -14,
+ax_anim 1, 0, 132, 8, -9, 8, -9,
+ax_anim 1, 0, 132, 2, -2, 2, -2,
+ax_anim_terminator
+sDodrioAnims_5_5:
+ax_anim 2, 0, 136, 0, 2, 0, 2,
+ax_anim 4, 0, 136, 0, 3, 0, 3,
+ax_anim 1, 2, 136, 0, -3, 0, -3,
+ax_anim 1, 0, 136, 0, -9, 0, -9,
+ax_anim 2, 0, 137, 0, -16, 0, -16,
+ax_anim 4, 1, 137, 0, -14, 0, -14,
+ax_anim 2, 0, 138, 0, -16, 0, -16,
+ax_anim 4, 0, 138, 0, -14, 0, -14,
+ax_anim 2, 0, 139, 0, -16, 0, -16,
+ax_anim 2, 0, 139, 0, -14, 0, -14,
+ax_anim 2, 0, 138, 0, -16, 0, -16,
+ax_anim 1, 0, 138, 0, -14, 0, -14,
+ax_anim 1, 0, 137, 0, -16, 0, -16,
+ax_anim 1, 0, 137, 0, -14, 0, -14,
+ax_anim 1, 0, 136, 0, -9, 0, -9,
+ax_anim 1, 0, 136, 0, -2, 0, -2,
+ax_anim_terminator
+sDodrioAnims_5_6:
+ax_anim 2, 0, 140, 2, 2, 2, 2,
+ax_anim 4, 0, 140, 3, 3, 3, 3,
+ax_anim 1, 2, 140, -3, -3, -3, -3,
+ax_anim 1, 0, 140, -8, -9, -8, -9,
+ax_anim 2, 0, 141, -14, -16, -14, -16,
+ax_anim 4, 1, 141, -12, -14, -12, -14,
+ax_anim 2, 0, 142, -14, -16, -14, -16,
+ax_anim 4, 0, 142, -12, -14, -12, -14,
+ax_anim 2, 0, 143, -14, -16, -14, -16,
+ax_anim 2, 0, 143, -12, -14, -12, -14,
+ax_anim 2, 0, 142, -14, -16, -14, -16,
+ax_anim 1, 0, 142, -12, -14, -12, -14,
+ax_anim 1, 0, 141, -14, -16, -14, -16,
+ax_anim 1, 0, 141, -12, -14, -12, -14,
+ax_anim 1, 0, 140, -8, -9, -8, -9,
+ax_anim 1, 0, 140, -2, -2, -2, -2,
+ax_anim_terminator
+sDodrioAnims_5_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 4, 0, 144, 3, 0, 3, 0,
+ax_anim 1, 2, 144, -3, 0, -3, 0,
+ax_anim 1, 0, 144, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -12, 0, -12, 0,
+ax_anim 4, 1, 145, -10, 0, -10, 0,
+ax_anim 2, 0, 146, -12, 0, -12, 0,
+ax_anim 4, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 147, -12, 0, -12, 0,
+ax_anim 2, 0, 147, -10, 0, -10, 0,
+ax_anim 2, 0, 146, -12, 0, -12, 0,
+ax_anim 1, 0, 146, -10, 0, -10, 0,
+ax_anim 1, 0, 145, -12, 0, -12, 0,
+ax_anim 1, 0, 145, -10, 0, -10, 0,
+ax_anim 1, 0, 144, -8, 0, -8, 0,
+ax_anim 1, 0, 144, -2, 0, -2, 0,
+ax_anim_terminator
+sDodrioAnims_5_8:
+ax_anim 2, 0, 148, 2, -2, 2, -2,
+ax_anim 4, 0, 148, 3, -3, 3, -3,
+ax_anim 1, 2, 148, -3, 3, -3, 3,
+ax_anim 1, 0, 148, -8, 9, -8, 9,
+ax_anim 2, 0, 149, -15, 18, -15, 18,
+ax_anim 4, 1, 149, -13, 16, -13, 16,
+ax_anim 2, 0, 150, -15, 18, -15, 18,
+ax_anim 4, 0, 150, -13, 16, -13, 16,
+ax_anim 2, 0, 151, -15, 18, -15, 18,
+ax_anim 2, 0, 151, -13, 16, -13, 16,
+ax_anim 2, 0, 150, -15, 18, -15, 18,
+ax_anim 1, 0, 150, -13, 16, -13, 16,
+ax_anim 1, 0, 149, -15, 18, -15, 18,
+ax_anim 1, 0, 149, -13, 16, -13, 16,
+ax_anim 1, 0, 148, -8, 9, -8, 9,
+ax_anim 1, 0, 148, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sDodrioAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sDodrioAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sDodrioAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sDodrioAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sDodrioAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sDodrioAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sDodrioAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sDodrioAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDodrioAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_8_2:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_8_3:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_8_4:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 16, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 16, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_8_5:
+ax_anim 40, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 16, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, 0, 0, 0,
+ax_anim 16, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_8_6:
+ax_anim 40, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 16, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 16, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_8_7:
+ax_anim 40, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim 16, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 16, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_8_8:
+ax_anim 40, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim 16, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 192, 0, 0, 0, 0,
+ax_anim 16, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 11, 8, 11,
+ax_anim 2, 0, 197, 7, 17, 7, 17,
+ax_anim 3, 0, 198, 0, 20, 0, 20,
+ax_anim 2, 3, 199, -7, 17, -7, 17,
+ax_anim 2, 0, 200, -8, 11, -8, 11,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 195, 18, 4, 18, 4,
+ax_anim 2, 0, 196, 22, 12, 22, 12,
+ax_anim 3, 0, 197, 21, 21, 21, 21,
+ax_anim 2, 3, 198, 11, 22, 11, 22,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -5, 16, -5,
+ax_anim 3, 0, 196, 21, 2, 21, 2,
+ax_anim 2, 3, 197, 19, 6, 19, 6,
+ax_anim 2, 0, 198, 12, 6, 12, 6,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 11, -19, 11, -19,
+ax_anim 3, 0, 195, 20, -19, 20, -19,
+ax_anim 2, 3, 196, 21, -12, 21, -12,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -9, -10, -9, -10,
+ax_anim 2, 0, 201, -7, -18, -7, -18,
+ax_anim 3, 0, 194, 0, -22, 0, -22,
+ax_anim 2, 3, 195, 7, -18, 7, -18,
+ax_anim 2, 0, 196, 9, -8, 9, -8,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -11, -19, -11, -19,
+ax_anim 3, 0, 201, -20, -19, -20, -19,
+ax_anim 2, 3, 200, -21, -12, -21, -12,
+ax_anim 2, 0, 199, -17, -4, -17, -4,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -5, -16, -5,
+ax_anim 3, 0, 200, -21, 2, -21, 2,
+ax_anim 2, 3, 199, -19, 6, -19, 6,
+ax_anim 2, 0, 198, -12, 6, -12, 6,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 201, -18, 4, -18, 4,
+ax_anim 2, 0, 200, -22, 12, -22, 12,
+ax_anim 3, 0, 199, -21, 21, -21, 21,
+ax_anim 2, 3, 198, -11, 22, -11, 22,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDodrioAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sDodrioGfx1:
+.incbin "baserom.gba", 0x8A4FB0, 0x200
+sDodrioSprites1:
+ax_sprite sDodrioGfx1, 0x200
+ax_sprite_terminator
+sDodrioGfx2:
+.incbin "baserom.gba", 0x8A51C0, 0x200
+sDodrioSprites2:
+ax_sprite sDodrioGfx2, 0x200
+ax_sprite_terminator
+sDodrioGfx3:
+.incbin "baserom.gba", 0x8A53D0, 0x200
+sDodrioSprites3:
+ax_sprite sDodrioGfx3, 0x200
+ax_sprite_terminator
+sDodrioGfx4:
+.incbin "baserom.gba", 0x8A55E0, 0x200
+sDodrioSprites4:
+ax_sprite sDodrioGfx4, 0x200
+ax_sprite_terminator
+sDodrioGfx5:
+.incbin "baserom.gba", 0x8A57F0, 0x200
+sDodrioSprites5:
+ax_sprite sDodrioGfx5, 0x200
+ax_sprite_terminator
+sDodrioGfx6:
+.incbin "baserom.gba", 0x8A5A00, 0x200
+sDodrioSprites6:
+ax_sprite sDodrioGfx6, 0x200
+ax_sprite_terminator
+sDodrioGfx7:
+.incbin "baserom.gba", 0x8A5C10, 0x200
+sDodrioSprites7:
+ax_sprite sDodrioGfx7, 0x200
+ax_sprite_terminator
+sDodrioGfx8:
+.incbin "baserom.gba", 0x8A5E20, 0x200
+sDodrioSprites8:
+ax_sprite sDodrioGfx8, 0x200
+ax_sprite_terminator
+sDodrioGfx9:
+.incbin "baserom.gba", 0x8A6030, 0x200
+sDodrioSprites9:
+ax_sprite sDodrioGfx9, 0x200
+ax_sprite_terminator
+sDodrioGfx10:
+.incbin "baserom.gba", 0x8A6240, 0x200
+sDodrioSprites10:
+ax_sprite sDodrioGfx10, 0x200
+ax_sprite_terminator
+sDodrioGfx11:
+.incbin "baserom.gba", 0x8A6450, 0x200
+sDodrioSprites11:
+ax_sprite sDodrioGfx11, 0x200
+ax_sprite_terminator
+sDodrioGfx12:
+.incbin "baserom.gba", 0x8A6660, 0x200
+sDodrioSprites12:
+ax_sprite sDodrioGfx12, 0x200
+ax_sprite_terminator
+sDodrioGfx13:
+.incbin "baserom.gba", 0x8A6870, 0x200
+sDodrioSprites13:
+ax_sprite sDodrioGfx13, 0x200
+ax_sprite_terminator
+sDodrioGfx14:
+.incbin "baserom.gba", 0x8A6A80, 0x200
+sDodrioSprites14:
+ax_sprite sDodrioGfx14, 0x200
+ax_sprite_terminator
+sDodrioGfx15:
+.incbin "baserom.gba", 0x8A6C90, 0x200
+sDodrioSprites15:
+ax_sprite sDodrioGfx15, 0x200
+ax_sprite_terminator
+sDodrioGfx16:
+.incbin "baserom.gba", 0x8A6EA0, 0x40
+sDodrioGfx16_1:
+.incbin "baserom.gba", 0x8A6EE0, 0x160
+sDodrioSprites16:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx16_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx17:
+.incbin "baserom.gba", 0x8A7070, 0x60
+sDodrioGfx17_1:
+.incbin "baserom.gba", 0x8A70D0, 0x60
+sDodrioGfx17_2:
+.incbin "baserom.gba", 0x8A7130, 0x80
+sDodrioGfx17_3:
+.incbin "baserom.gba", 0x8A71B0, 0x60
+sDodrioSprites17:
+ax_sprite sDodrioGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx17_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx17_3, 0x60
+ax_sprite_terminator
+sDodrioGfx18:
+.incbin "baserom.gba", 0x8A7250, 0x40
+sDodrioGfx18_1:
+.incbin "baserom.gba", 0x8A7290, 0xE0
+sDodrioGfx18_2:
+.incbin "baserom.gba", 0x8A7370, 0x60
+sDodrioSprites18:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx18_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx19:
+.incbin "baserom.gba", 0x8A7410, 0x60
+sDodrioGfx19_1:
+.incbin "baserom.gba", 0x8A7470, 0x80
+sDodrioGfx19_2:
+.incbin "baserom.gba", 0x8A74F0, 0xC0
+sDodrioSprites19:
+ax_sprite sDodrioGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx19_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx20:
+.incbin "baserom.gba", 0x8A75E8, 0x20
+sDodrioGfx20_1:
+.incbin "baserom.gba", 0x8A7608, 0x20
+sDodrioGfx20_2:
+.incbin "baserom.gba", 0x8A7628, 0x100
+sDodrioSprites20:
+ax_sprite sDodrioGfx20, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx20_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx20_2, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDodrioGfx21:
+.incbin "baserom.gba", 0x8A7760, 0x60
+sDodrioGfx21_1:
+.incbin "baserom.gba", 0x8A77C0, 0x100
+sDodrioGfx21_2:
+.incbin "baserom.gba", 0x8A78C0, 0x60
+sDodrioSprites21:
+ax_sprite sDodrioGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx21_2, 0x60
+ax_sprite_terminator
+sDodrioGfx22:
+.incbin "baserom.gba", 0x8A7950, 0x60
+sDodrioGfx22_1:
+.incbin "baserom.gba", 0x8A79B0, 0x60
+sDodrioGfx22_2:
+.incbin "baserom.gba", 0x8A7A10, 0x60
+sDodrioGfx22_3:
+.incbin "baserom.gba", 0x8A7A70, 0x20
+sDodrioSprites22:
+ax_sprite sDodrioGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx22_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sDodrioGfx22_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx23:
+.incbin "baserom.gba", 0x8A7AD8, 0x40
+sDodrioGfx23_1:
+.incbin "baserom.gba", 0x8A7B18, 0x60
+sDodrioGfx23_2:
+.incbin "baserom.gba", 0x8A7B78, 0x60
+sDodrioGfx23_3:
+.incbin "baserom.gba", 0x8A7BD8, 0x60
+sDodrioSprites23:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx24:
+.incbin "baserom.gba", 0x8A7C88, 0x100
+sDodrioGfx24_1:
+.incbin "baserom.gba", 0x8A7D88, 0x40
+sDodrioGfx24_2:
+.incbin "baserom.gba", 0x8A7DC8, 0x40
+sDodrioSprites24:
+ax_sprite sDodrioGfx24, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx25:
+.incbin "baserom.gba", 0x8A7E40, 0x100
+sDodrioGfx25_1:
+.incbin "baserom.gba", 0x8A7F40, 0x40
+sDodrioGfx25_2:
+.incbin "baserom.gba", 0x8A7F80, 0x40
+sDodrioSprites25:
+ax_sprite sDodrioGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx26:
+.incbin "baserom.gba", 0x8A7FF8, 0x40
+sDodrioGfx26_1:
+.incbin "baserom.gba", 0x8A8038, 0x100
+sDodrioGfx26_2:
+.incbin "baserom.gba", 0x8A8138, 0x40
+sDodrioSprites26:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx27:
+.incbin "baserom.gba", 0x8A81B8, 0x20
+sDodrioGfx27_1:
+.incbin "baserom.gba", 0x8A81D8, 0x160
+sDodrioSprites27:
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx28:
+.incbin "baserom.gba", 0x8A8368, 0x120
+sDodrioGfx28_1:
+.incbin "baserom.gba", 0x8A8488, 0x20
+sDodrioSprites28:
+ax_sprite 0, 0x80
+ax_sprite sDodrioGfx28, 0x120
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx28_1, 0x20
+ax_sprite_terminator
+sDodrioGfx29:
+.incbin "baserom.gba", 0x8A84D0, 0x60
+sDodrioGfx29_1:
+.incbin "baserom.gba", 0x8A8530, 0x60
+sDodrioGfx29_2:
+.incbin "baserom.gba", 0x8A8590, 0x80
+sDodrioGfx29_3:
+.incbin "baserom.gba", 0x8A8610, 0x60
+sDodrioSprites29:
+ax_sprite sDodrioGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx29_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx29_3, 0x60
+ax_sprite_terminator
+sDodrioGfx30:
+.incbin "baserom.gba", 0x8A86B0, 0x100
+sDodrioGfx30_1:
+.incbin "baserom.gba", 0x8A87B0, 0x40
+sDodrioGfx30_2:
+.incbin "baserom.gba", 0x8A87F0, 0x40
+sDodrioSprites30:
+ax_sprite sDodrioGfx30, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx31:
+.incbin "baserom.gba", 0x8A8868, 0x160
+sDodrioGfx31_1:
+.incbin "baserom.gba", 0x8A89C8, 0x40
+sDodrioSprites31:
+ax_sprite sDodrioGfx31, 0x160
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx32:
+.incbin "baserom.gba", 0x8A8A30, 0x1E0
+sDodrioSprites32:
+ax_sprite sDodrioGfx32, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx33:
+.incbin "baserom.gba", 0x8A8C28, 0x40
+sDodrioGfx33_1:
+.incbin "baserom.gba", 0x8A8C68, 0x100
+sDodrioGfx33_2:
+.incbin "baserom.gba", 0x8A8D68, 0x60
+sDodrioSprites33:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx33_2, 0x60
+ax_sprite_terminator
+sDodrioGfx34:
+.incbin "baserom.gba", 0x8A8E00, 0x60
+sDodrioGfx34_1:
+.incbin "baserom.gba", 0x8A8E60, 0x60
+sDodrioGfx34_2:
+.incbin "baserom.gba", 0x8A8EC0, 0x60
+sDodrioGfx34_3:
+.incbin "baserom.gba", 0x8A8F20, 0x60
+sDodrioSprites34:
+ax_sprite sDodrioGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx35:
+.incbin "baserom.gba", 0x8A8FC8, 0x100
+sDodrioGfx35_1:
+.incbin "baserom.gba", 0x8A90C8, 0x40
+sDodrioGfx35_2:
+.incbin "baserom.gba", 0x8A9108, 0x40
+sDodrioSprites35:
+ax_sprite sDodrioGfx35, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx36:
+.incbin "baserom.gba", 0x8A9180, 0x60
+sDodrioGfx36_1:
+.incbin "baserom.gba", 0x8A91E0, 0xC0
+sDodrioGfx36_2:
+.incbin "baserom.gba", 0x8A92A0, 0x60
+sDodrioSprites36:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx36_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx37:
+.incbin "baserom.gba", 0x8A9340, 0x1C0
+sDodrioSprites37:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx37, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx38:
+.incbin "baserom.gba", 0x8A9520, 0x160
+sDodrioGfx38_1:
+.incbin "baserom.gba", 0x8A9680, 0x60
+sDodrioSprites38:
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx38, 0x160
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx38_1, 0x60
+ax_sprite_terminator
+sDodrioGfx39:
+.incbin "baserom.gba", 0x8A9708, 0x60
+sDodrioGfx39_1:
+.incbin "baserom.gba", 0x8A9768, 0x60
+sDodrioGfx39_2:
+.incbin "baserom.gba", 0x8A97C8, 0xC0
+sDodrioSprites39:
+ax_sprite sDodrioGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx39_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDodrioGfx39_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx40:
+.incbin "baserom.gba", 0x8A98C0, 0x100
+sDodrioGfx40_1:
+.incbin "baserom.gba", 0x8A99C0, 0x60
+sDodrioGfx40_2:
+.incbin "baserom.gba", 0x8A9A20, 0x40
+sDodrioSprites40:
+ax_sprite sDodrioGfx40, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDodrioGfx40_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDodrioGfx41:
+.incbin "baserom.gba", 0x8A9A98, 0x200
+sDodrioSprites41:
+ax_sprite sDodrioGfx41, 0x200
+ax_sprite_terminator
+sDodrioGfx42:
+.incbin "baserom.gba", 0x8A9CA8, 0x200
+sDodrioSprites42:
+ax_sprite sDodrioGfx42, 0x200
+ax_sprite_terminator
+sDodrioGfx43:
+.incbin "baserom.gba", 0x8A9EB8, 0x200
+sDodrioSprites43:
+ax_sprite sDodrioGfx43, 0x200
+ax_sprite_terminator
+sDodrioGfx44:
+.incbin "baserom.gba", 0x8AA0C8, 0x200
+sDodrioSprites44:
+ax_sprite sDodrioGfx44, 0x200
+ax_sprite_terminator
+sDodrioGfx45:
+.incbin "baserom.gba", 0x8AA2D8, 0x200
+sDodrioSprites45:
+ax_sprite sDodrioGfx45, 0x200
+ax_sprite_terminator
+sDodrioGfx46:
+.incbin "baserom.gba", 0x8AA4E8, 0x200
+sDodrioSprites46:
+ax_sprite sDodrioGfx46, 0x200
+ax_sprite_terminator
+sDodrioGfx47:
+.incbin "baserom.gba", 0x8AA6F8, 0x200
+sDodrioSprites47:
+ax_sprite sDodrioGfx47, 0x200
+ax_sprite_terminator
+sAxPosesDodrio:
+.4byte sDodrioPose1
+.4byte sDodrioPose2
+.4byte sDodrioPose3
+.4byte sDodrioPose4
+.4byte sDodrioPose5
+.4byte sDodrioPose6
+.4byte sDodrioPose7
+.4byte sDodrioPose8
+.4byte sDodrioPose9
+.4byte sDodrioPose10
+.4byte sDodrioPose11
+.4byte sDodrioPose12
+.4byte sDodrioPose13
+.4byte sDodrioPose14
+.4byte sDodrioPose15
+.4byte sDodrioPose16
+.4byte sDodrioPose17
+.4byte sDodrioPose18
+.4byte sDodrioPose19
+.4byte sDodrioPose20
+.4byte sDodrioPose21
+.4byte sDodrioPose22
+.4byte sDodrioPose23
+.4byte sDodrioPose24
+.4byte sDodrioPose25
+.4byte sDodrioPose26
+.4byte sDodrioPose27
+.4byte sDodrioPose28
+.4byte sDodrioPose29
+.4byte sDodrioPose30
+.4byte sDodrioPose31
+.4byte sDodrioPose32
+.4byte sDodrioPose33
+.4byte sDodrioPose34
+.4byte sDodrioPose35
+.4byte sDodrioPose36
+.4byte sDodrioPose37
+.4byte sDodrioPose38
+.4byte sDodrioPose39
+.4byte sDodrioPose40
+.4byte sDodrioPose41
+.4byte sDodrioPose42
+.4byte sDodrioPose43
+.4byte sDodrioPose44
+.4byte sDodrioPose45
+.4byte sDodrioPose46
+.4byte sDodrioPose47
+.4byte sDodrioPose48
+.4byte sDodrioPose49
+.4byte sDodrioPose50
+.4byte sDodrioPose51
+.4byte sDodrioPose52
+.4byte sDodrioPose53
+.4byte sDodrioPose54
+.4byte sDodrioPose55
+.4byte sDodrioPose56
+.4byte sDodrioPose57
+.4byte sDodrioPose58
+.4byte sDodrioPose59
+.4byte sDodrioPose60
+.4byte sDodrioPose61
+.4byte sDodrioPose62
+.4byte sDodrioPose63
+.4byte sDodrioPose64
+.4byte sDodrioPose65
+.4byte sDodrioPose66
+.4byte sDodrioPose67
+.4byte sDodrioPose68
+.4byte sDodrioPose69
+.4byte sDodrioPose70
+.4byte sDodrioPose71
+.4byte sDodrioPose72
+.4byte sDodrioPose73
+.4byte sDodrioPose74
+.4byte sDodrioPose75
+.4byte sDodrioPose76
+.4byte sDodrioPose77
+.4byte sDodrioPose78
+.4byte sDodrioPose79
+.4byte sDodrioPose80
+.4byte sDodrioPose81
+.4byte sDodrioPose82
+.4byte sDodrioPose83
+.4byte sDodrioPose84
+.4byte sDodrioPose85
+.4byte sDodrioPose86
+.4byte sDodrioPose87
+.4byte sDodrioPose88
+.4byte sDodrioPose89
+.4byte sDodrioPose90
+.4byte sDodrioPose91
+.4byte sDodrioPose92
+.4byte sDodrioPose93
+.4byte sDodrioPose94
+.4byte sDodrioPose95
+.4byte sDodrioPose96
+.4byte sDodrioPose97
+.4byte sDodrioPose98
+.4byte sDodrioPose99
+.4byte sDodrioPose100
+.4byte sDodrioPose101
+.4byte sDodrioPose102
+.4byte sDodrioPose103
+.4byte sDodrioPose104
+.4byte sDodrioPose105
+.4byte sDodrioPose106
+.4byte sDodrioPose107
+.4byte sDodrioPose108
+.4byte sDodrioPose109
+.4byte sDodrioPose110
+.4byte sDodrioPose111
+.4byte sDodrioPose112
+.4byte sDodrioPose113
+.4byte sDodrioPose114
+.4byte sDodrioPose115
+.4byte sDodrioPose116
+.4byte sDodrioPose117
+.4byte sDodrioPose118
+.4byte sDodrioPose119
+.4byte sDodrioPose120
+.4byte sDodrioPose121
+.4byte sDodrioPose122
+.4byte sDodrioPose123
+.4byte sDodrioPose124
+.4byte sDodrioPose125
+.4byte sDodrioPose126
+.4byte sDodrioPose127
+.4byte sDodrioPose128
+.4byte sDodrioPose129
+.4byte sDodrioPose130
+.4byte sDodrioPose131
+.4byte sDodrioPose132
+.4byte sDodrioPose133
+.4byte sDodrioPose134
+.4byte sDodrioPose135
+.4byte sDodrioPose136
+.4byte sDodrioPose137
+.4byte sDodrioPose138
+.4byte sDodrioPose139
+.4byte sDodrioPose140
+.4byte sDodrioPose141
+.4byte sDodrioPose142
+.4byte sDodrioPose143
+.4byte sDodrioPose144
+.4byte sDodrioPose145
+.4byte sDodrioPose146
+.4byte sDodrioPose147
+.4byte sDodrioPose148
+.4byte sDodrioPose149
+.4byte sDodrioPose150
+.4byte sDodrioPose151
+.4byte sDodrioPose152
+.4byte sDodrioPose153
+.4byte sDodrioPose154
+.4byte sDodrioPose155
+.4byte sDodrioPose156
+.4byte sDodrioPose157
+.4byte sDodrioPose158
+.4byte sDodrioPose159
+.4byte sDodrioPose160
+.4byte sDodrioPose161
+.4byte sDodrioPose162
+.4byte sDodrioPose163
+.4byte sDodrioPose164
+.4byte sDodrioPose165
+.4byte sDodrioPose166
+.4byte sDodrioPose167
+.4byte sDodrioPose168
+.4byte sDodrioPose169
+.4byte sDodrioPose170
+.4byte sDodrioPose171
+.4byte sDodrioPose172
+.4byte sDodrioPose173
+.4byte sDodrioPose174
+.4byte sDodrioPose175
+.4byte sDodrioPose176
+.4byte sDodrioPose177
+.4byte sDodrioPose178
+.4byte sDodrioPose179
+.4byte sDodrioPose180
+.4byte sDodrioPose181
+.4byte sDodrioPose182
+.4byte sDodrioPose183
+.4byte sDodrioPose184
+.4byte sDodrioPose185
+.4byte sDodrioPose186
+.4byte sDodrioPose187
+.4byte sDodrioPose188
+.4byte sDodrioPose189
+.4byte sDodrioPose190
+.4byte sDodrioPose191
+.4byte sDodrioPose192
+.4byte sDodrioPose193
+.4byte sDodrioPose194
+.4byte sDodrioPose195
+.4byte sDodrioPose196
+.4byte sDodrioPose197
+.4byte sDodrioPose198
+.4byte sDodrioPose199
+.4byte sDodrioPose200
+.4byte sDodrioPose201
+.4byte sDodrioPose202
+.4byte sDodrioPose203
+.4byte sDodrioPose204
+.4byte sDodrioPose205
+.4byte sDodrioPose206
+.4byte sDodrioPose207
+.4byte sDodrioPose208
+.4byte sDodrioPose209
+.4byte sDodrioPose210
+.4byte sDodrioPose211
+.4byte sDodrioPose212
+.4byte sDodrioPose213
+.4byte sDodrioPose214
+.4byte sDodrioPose215
+.4byte sDodrioPose216
+.4byte sDodrioPose217
+.4byte sDodrioPose218
+.4byte sDodrioPose219
+.4byte sDodrioPose220
+.4byte sDodrioPose221
+.4byte sDodrioPose222
+.4byte sDodrioPose223
+.4byte sDodrioPose224
+.4byte sDodrioPose225
+.4byte sDodrioPose226
+.4byte sDodrioPose227
+.4byte sDodrioPose228
+.4byte sDodrioPose229
+.4byte sDodrioPose230
+.4byte sDodrioPose231
+.4byte sDodrioPose232
+.4byte sDodrioPose233
+.4byte sDodrioPose234
+.4byte sDodrioPose235
+.4byte sDodrioPose236
+.4byte sDodrioPose237
+.4byte sDodrioPose238
+.4byte sDodrioPose239
+.4byte sDodrioPose240
+.4byte sDodrioPose241
+.4byte sDodrioPose242
+.4byte sDodrioPose243
+.4byte sDodrioPose244
+.4byte sDodrioPose245
+.4byte sDodrioPose246
+.4byte sDodrioPose247
+.4byte sDodrioPose248
+.4byte sDodrioPose249
+.4byte sDodrioPose250
+sAxPositionsDodrio:
+.2byte   -1,  -12, 	 -11,  -16, 	  11,  -15, 	   0,   -9
+.2byte    0,  -10, 	 -10,  -14, 	  12,  -13, 	   0,   -8
+.2byte   -2,   -9, 	 -12,  -14, 	  10,  -13, 	   0,   -8
+.2byte    8,  -14, 	  13,  -18, 	  -3,  -13, 	  -1,   -9
+.2byte    6,  -12, 	  11,  -17, 	  -4,  -11, 	  -1,   -8
+.2byte    8,  -12, 	  13,  -17, 	  -2,  -11, 	  -1,   -8
+.2byte   13,  -15, 	   6,  -22, 	   5,  -13, 	  -1,   -9
+.2byte   13,  -13, 	   6,  -20, 	   5,  -10, 	   0,   -8
+.2byte   13,  -13, 	   6,  -20, 	   5,  -11, 	  -1,   -8
+.2byte    6,  -22, 	  -4,  -22, 	  13,  -16, 	   0,  -11
+.2byte    5,  -20, 	  -4,  -20, 	  13,  -14, 	   0,  -10
+.2byte    5,  -19, 	  -5,  -20, 	  12,  -14, 	   0,   -9
+.2byte    0,  -21, 	  10,  -17, 	 -12,  -18, 	   0,  -11
+.2byte   -1,  -19, 	  10,  -15, 	 -13,  -16, 	   0,  -10
+.2byte    2,  -18, 	  12,  -15, 	 -11,  -16, 	   0,  -10
+.2byte   -7,  -22, 	   3,  -22, 	 -14,  -16, 	  -1,  -11
+.2byte   -6,  -20, 	   3,  -20, 	 -14,  -14, 	  -1,  -10
+.2byte   -6,  -19, 	   4,  -20, 	 -13,  -14, 	  -1,   -9
+.2byte  -14,  -15, 	  -7,  -22, 	  -6,  -13, 	   0,   -9
+.2byte  -14,  -13, 	  -7,  -20, 	  -6,  -10, 	  -1,   -8
+.2byte  -14,  -13, 	  -7,  -20, 	  -6,  -11, 	   0,   -8
+.2byte   -9,  -14, 	 -14,  -18, 	   2,  -13, 	   0,   -9
+.2byte   -7,  -12, 	 -12,  -17, 	   3,  -11, 	   0,   -8
+.2byte   -9,  -12, 	 -14,  -17, 	   1,  -11, 	   0,   -8
+.2byte   -1,  -12, 	 -11,  -16, 	  11,  -15, 	   0,   -9
+.2byte    0,  -11, 	 -10,  -15, 	  12,  -14, 	   0,   -9
+.2byte   -2,  -10, 	 -12,  -15, 	  10,  -14, 	   0,   -9
+.2byte   -1,    5, 	 -10,    3, 	   7,    3, 	  -1,   -6
+.2byte   -1,  -12, 	  -9,  -12, 	   3,    0, 	   0,   -9
+.2byte    8,  -14, 	  13,  -18, 	  -3,  -13, 	  -1,   -9
+.2byte    6,  -13, 	  11,  -18, 	  -4,  -12, 	  -1,   -9
+.2byte    8,  -13, 	  13,  -18, 	  -2,  -12, 	  -1,   -9
+.2byte    8,    0, 	  12,   -4, 	  -1,   -2, 	  -1,  -12
+.2byte    5,  -15, 	  10,  -17, 	   5,   -5, 	  -3,  -12
+.2byte   13,  -15, 	   6,  -22, 	   5,  -13, 	  -1,   -9
+.2byte   13,  -14, 	   6,  -21, 	   5,  -11, 	   0,   -9
+.2byte   13,  -14, 	   6,  -21, 	   5,  -12, 	  -1,   -9
+.2byte   13,   -5, 	  12,   -9, 	  11,   -6, 	  -2,   -8
+.2byte   13,  -15, 	   5,  -19, 	  11,   -6, 	  -1,   -9
+.2byte    6,  -22, 	  -4,  -22, 	  13,  -16, 	   0,  -11
+.2byte    5,  -21, 	  -4,  -21, 	  13,  -15, 	   0,  -11
+.2byte    5,  -20, 	  -5,  -21, 	  12,  -15, 	   0,  -10
+.2byte    6,  -16, 	  -3,  -18, 	  10,  -11, 	  -1,   -9
+.2byte    6,  -17, 	  -3,  -20, 	  11,   -8, 	  -1,   -9
+.2byte    0,  -21, 	  10,  -17, 	 -12,  -18, 	   0,  -11
+.2byte   -1,  -20, 	  10,  -16, 	 -13,  -17, 	   0,  -11
+.2byte    2,  -19, 	  12,  -16, 	 -11,  -17, 	   0,  -11
+.2byte   -1,  -15, 	   6,  -14, 	  -7,  -14, 	   0,   -9
+.2byte    0,  -20, 	   8,  -18, 	  -7,  -14, 	   0,  -11
+.2byte   -7,  -22, 	   3,  -22, 	 -14,  -16, 	  -1,  -11
+.2byte   -6,  -21, 	   3,  -21, 	 -14,  -15, 	  -1,  -11
+.2byte   -6,  -20, 	   4,  -21, 	 -13,  -15, 	  -1,  -10
+.2byte   -7,  -16, 	   2,  -18, 	 -11,  -11, 	   0,   -9
+.2byte   -7,  -17, 	   2,  -20, 	 -12,   -8, 	   0,   -9
+.2byte  -14,  -15, 	  -7,  -22, 	  -6,  -13, 	   0,   -9
+.2byte  -14,  -14, 	  -7,  -21, 	  -6,  -11, 	  -1,   -9
+.2byte  -14,  -14, 	  -7,  -21, 	  -6,  -12, 	   0,   -9
+.2byte  -14,   -5, 	 -13,   -9, 	 -12,   -6, 	   1,   -8
+.2byte  -14,  -15, 	  -6,  -19, 	 -12,   -6, 	   0,   -9
+.2byte   -9,  -14, 	 -14,  -18, 	   2,  -13, 	   0,   -9
+.2byte   -7,  -13, 	 -12,  -18, 	   3,  -12, 	   0,   -9
+.2byte   -9,  -13, 	 -14,  -18, 	   1,  -12, 	   0,   -9
+.2byte   -9,    0, 	 -13,   -4, 	   0,   -2, 	   0,  -12
+.2byte   -6,  -15, 	 -11,  -17, 	  -6,   -5, 	   2,  -12
+.2byte   -1,  -12, 	 -11,  -16, 	  11,  -15, 	   0,   -9
+.2byte    0,  -10, 	 -10,  -14, 	  12,  -13, 	   0,   -8
+.2byte   -2,   -9, 	 -12,  -14, 	  10,  -13, 	   0,   -8
+.2byte   -1,    1, 	 -10,   -1, 	   7,   -1, 	  -1,  -10
+.2byte   -1,   -1, 	 -10,   -3, 	   7,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	  -9,  -12, 	   3,    0, 	   0,   -9
+.2byte    8,  -14, 	  13,  -18, 	  -3,  -13, 	  -1,   -9
+.2byte    6,  -12, 	  11,  -17, 	  -4,  -11, 	  -1,   -8
+.2byte    8,  -12, 	  13,  -17, 	  -2,  -11, 	  -1,   -8
+.2byte    8,    1, 	  12,   -3, 	  -1,    0, 	  -1,  -11
+.2byte    9,    0, 	  13,   -4, 	   0,   -2, 	   0,  -12
+.2byte    6,  -14, 	  11,  -16, 	   6,   -4, 	  -2,  -11
+.2byte   13,  -15, 	   6,  -22, 	   5,  -13, 	  -1,   -9
+.2byte   13,  -13, 	   6,  -20, 	   5,  -10, 	   0,   -8
+.2byte   13,  -13, 	   6,  -20, 	   5,  -11, 	  -1,   -8
+.2byte   13,   -5, 	  13,  -10, 	  11,   -5, 	  -1,  -10
+.2byte   14,   -7, 	  13,  -11, 	  12,   -8, 	  -1,  -10
+.2byte   13,  -16, 	   5,  -20, 	  11,   -7, 	  -1,  -10
+.2byte    6,  -22, 	  -4,  -22, 	  13,  -16, 	   0,  -11
+.2byte    5,  -20, 	  -4,  -20, 	  13,  -14, 	   0,  -10
+.2byte    5,  -19, 	  -5,  -20, 	  12,  -14, 	   0,   -9
+.2byte    8,  -17, 	  -2,  -19, 	  10,  -12, 	   0,  -12
+.2byte    7,  -18, 	  -2,  -20, 	  11,  -13, 	   0,  -11
+.2byte    7,  -18, 	  -2,  -21, 	  12,   -9, 	   0,  -10
+.2byte    0,  -21, 	  10,  -17, 	 -12,  -18, 	   0,  -11
+.2byte   -1,  -19, 	  10,  -15, 	 -13,  -16, 	   0,  -10
+.2byte    2,  -18, 	  12,  -15, 	 -11,  -16, 	   0,  -10
+.2byte   -1,  -16, 	   6,  -15, 	  -7,  -15, 	   0,  -10
+.2byte    0,  -17, 	   6,  -16, 	  -7,  -16, 	   0,  -11
+.2byte    0,  -21, 	   8,  -19, 	  -7,  -15, 	   0,  -12
+.2byte   -7,  -22, 	   3,  -22, 	 -14,  -16, 	  -1,  -11
+.2byte   -6,  -20, 	   3,  -20, 	 -14,  -14, 	  -1,  -10
+.2byte   -6,  -19, 	   4,  -20, 	 -13,  -14, 	  -1,   -9
+.2byte   -9,  -17, 	   1,  -19, 	 -11,  -12, 	  -1,  -12
+.2byte   -8,  -18, 	   1,  -20, 	 -12,  -13, 	  -1,  -11
+.2byte   -8,  -18, 	   1,  -21, 	 -13,   -9, 	  -1,  -10
+.2byte  -14,  -15, 	  -7,  -22, 	  -6,  -13, 	   0,   -9
+.2byte  -14,  -13, 	  -7,  -20, 	  -6,  -10, 	  -1,   -8
+.2byte  -14,  -13, 	  -7,  -20, 	  -6,  -11, 	   0,   -8
+.2byte  -14,   -5, 	 -14,  -10, 	 -12,   -5, 	   0,  -10
+.2byte  -15,   -7, 	 -14,  -11, 	 -13,   -8, 	   0,  -10
+.2byte  -14,  -16, 	  -6,  -20, 	 -12,   -7, 	   0,  -10
+.2byte   -9,  -14, 	 -14,  -18, 	   2,  -13, 	   0,   -9
+.2byte   -7,  -12, 	 -12,  -17, 	   3,  -11, 	   0,   -8
+.2byte   -9,  -12, 	 -14,  -17, 	   1,  -11, 	   0,   -8
+.2byte   -9,    1, 	 -13,   -3, 	   0,    0, 	   0,  -11
+.2byte  -10,    0, 	 -14,   -4, 	  -1,   -2, 	  -1,  -12
+.2byte   -7,  -14, 	 -12,  -16, 	  -7,   -4, 	   1,  -11
+.2byte   -1,    1, 	 -10,  -13, 	   9,  -14, 	   0,  -10
+.2byte  -12,   -5, 	 -11,  -15, 	   1,  -13, 	   0,  -10
+.2byte  -17,   -6, 	  -9,  -17, 	  -6,  -12, 	  -1,   -9
+.2byte  -10,  -10, 	   3,  -21, 	 -14,  -15, 	  -2,  -10
+.2byte    0,  -18, 	   8,  -21, 	  -7,  -20, 	   0,  -12
+.2byte    9,  -10, 	  -4,  -21, 	  13,  -15, 	   1,  -10
+.2byte   16,   -6, 	   8,  -17, 	   5,  -12, 	   0,   -9
+.2byte   11,   -5, 	  10,  -15, 	  -2,  -13, 	  -1,  -10
+.2byte   -1,  -12, 	 -11,  -16, 	  11,  -15, 	   0,   -9
+.2byte   -1,    1, 	 -10,  -13, 	   9,  -14, 	   0,  -10
+.2byte   -1,  -12, 	  -9,  -12, 	   3,    0, 	   0,   -9
+.2byte   -1,  -11, 	  -5,    1, 	  10,  -16, 	   0,   -9
+.2byte    8,  -14, 	  13,  -18, 	  -3,  -13, 	  -1,   -9
+.2byte   11,   -5, 	  10,  -15, 	  -2,  -13, 	  -1,  -10
+.2byte    6,  -15, 	  11,  -17, 	   6,   -5, 	  -2,  -12
+.2byte    8,  -14, 	  13,   -7, 	  -4,  -14, 	  -1,  -11
+.2byte   13,  -15, 	   6,  -22, 	   5,  -13, 	  -1,   -9
+.2byte   16,   -6, 	   8,  -17, 	   5,  -12, 	   0,   -9
+.2byte   13,  -16, 	   5,  -20, 	  11,   -7, 	  -1,  -10
+.2byte   12,  -14, 	  13,   -9, 	   2,  -15, 	  -1,   -9
+.2byte    6,  -22, 	  -4,  -22, 	  13,  -16, 	   0,  -11
+.2byte    9,  -10, 	  -4,  -21, 	  13,  -15, 	   1,  -10
+.2byte    7,  -18, 	  -2,  -21, 	  12,   -9, 	   0,  -10
+.2byte    6,  -20, 	  -1,  -15, 	  10,  -17, 	  -2,  -10
+.2byte    0,  -21, 	  10,  -17, 	 -12,  -18, 	   0,  -11
+.2byte    0,  -18, 	   8,  -21, 	  -7,  -20, 	   0,  -12
+.2byte    0,  -21, 	   8,  -19, 	  -7,  -15, 	   0,  -12
+.2byte    1,  -19, 	   6,  -13, 	  -7,  -18, 	   0,  -10
+.2byte   -7,  -22, 	   3,  -22, 	 -14,  -16, 	  -1,  -11
+.2byte  -10,  -10, 	   3,  -21, 	 -14,  -15, 	  -2,  -10
+.2byte   -8,  -18, 	   1,  -21, 	 -13,   -9, 	  -1,  -10
+.2byte   -7,  -20, 	   0,  -15, 	 -11,  -17, 	   1,  -10
+.2byte  -14,  -15, 	  -7,  -22, 	  -6,  -13, 	   0,   -9
+.2byte  -17,   -6, 	  -9,  -17, 	  -6,  -12, 	  -1,   -9
+.2byte  -14,  -16, 	  -6,  -20, 	 -12,   -7, 	   0,  -10
+.2byte  -13,  -14, 	 -14,   -9, 	  -3,  -15, 	   0,   -9
+.2byte   -9,  -14, 	 -14,  -18, 	   2,  -13, 	   0,   -9
+.2byte  -12,   -5, 	 -11,  -15, 	   1,  -13, 	   0,  -10
+.2byte   -7,  -15, 	 -12,  -17, 	  -7,   -5, 	   1,  -12
+.2byte   -9,  -14, 	 -14,   -7, 	   3,  -14, 	   0,  -11
+.2byte   -9,   -8, 	 -13,  -12, 	   2,   -5, 	   0,   -5
+.2byte   -9,   -7, 	 -13,  -13, 	   2,   -6, 	  -1,   -5
+.2byte    1,   -6, 	  -8,  -26, 	  12,  -20, 	   1,  -10
+.2byte    8,  -11, 	  10,  -27, 	  -6,  -19, 	  -1,  -11
+.2byte   12,  -13, 	   0,  -27, 	  -1,  -16, 	  -5,   -9
+.2byte    6,  -17, 	  -6,  -25, 	  10,  -16, 	  -3,  -10
+.2byte    0,  -17, 	   9,  -22, 	 -12,  -18, 	   0,  -10
+.2byte   -7,  -17, 	   5,  -25, 	 -11,  -16, 	   2,  -10
+.2byte  -13,  -13, 	  -1,  -27, 	   0,  -16, 	   4,   -9
+.2byte   -9,  -11, 	 -11,  -27, 	   5,  -19, 	   0,  -11
+.2byte   -1,  -12, 	 -11,  -16, 	  11,  -15, 	   0,   -9
+.2byte   -1,    1, 	 -10,  -13, 	   9,  -14, 	   0,  -10
+.2byte   -1,  -12, 	  -9,  -12, 	   3,    0, 	   0,   -9
+.2byte   -1,  -12, 	  -5,    0, 	  10,  -17, 	   0,  -10
+.2byte    8,  -14, 	  13,  -18, 	  -3,  -13, 	  -1,   -9
+.2byte   11,   -5, 	  10,  -15, 	  -2,  -13, 	  -1,  -10
+.2byte    6,  -15, 	  11,  -17, 	   6,   -5, 	  -2,  -12
+.2byte    8,  -14, 	  13,   -7, 	  -4,  -14, 	  -1,  -11
+.2byte   13,  -15, 	   6,  -22, 	   5,  -13, 	  -1,   -9
+.2byte   16,   -6, 	   8,  -17, 	   5,  -12, 	   0,   -9
+.2byte   12,  -16, 	   4,  -20, 	  10,   -7, 	  -2,  -10
+.2byte   12,  -14, 	  13,   -9, 	   2,  -15, 	  -1,   -9
+.2byte    6,  -22, 	  -4,  -22, 	  13,  -16, 	   0,  -11
+.2byte    9,  -10, 	  -4,  -21, 	  13,  -15, 	   1,  -10
+.2byte    8,  -18, 	  -1,  -21, 	  13,   -9, 	   1,  -10
+.2byte    6,  -20, 	  -1,  -15, 	  10,  -17, 	  -2,  -10
+.2byte    0,  -21, 	  10,  -17, 	 -12,  -18, 	   0,  -11
+.2byte    0,  -18, 	   8,  -21, 	  -7,  -20, 	   0,  -12
+.2byte    0,  -21, 	   8,  -19, 	  -7,  -15, 	   0,  -12
+.2byte    1,  -19, 	   6,  -13, 	  -7,  -18, 	   0,  -10
+.2byte   -7,  -22, 	   3,  -22, 	 -14,  -16, 	  -1,  -11
+.2byte  -10,  -10, 	   3,  -21, 	 -14,  -15, 	  -2,  -10
+.2byte   -9,  -18, 	   0,  -21, 	 -14,   -9, 	  -2,  -10
+.2byte   -7,  -20, 	   0,  -15, 	 -11,  -17, 	   1,  -10
+.2byte  -14,  -15, 	  -7,  -22, 	  -6,  -13, 	   0,   -9
+.2byte  -17,   -6, 	  -9,  -17, 	  -6,  -12, 	  -1,   -9
+.2byte  -13,  -16, 	  -5,  -20, 	 -11,   -7, 	   1,  -10
+.2byte  -13,  -14, 	 -14,   -9, 	  -3,  -15, 	   0,   -9
+.2byte   -9,  -14, 	 -14,  -18, 	   2,  -13, 	   0,   -9
+.2byte  -12,   -5, 	 -11,  -15, 	   1,  -13, 	   0,  -10
+.2byte   -7,  -15, 	 -12,  -17, 	  -7,   -5, 	   1,  -12
+.2byte   -9,  -14, 	 -14,   -7, 	   3,  -14, 	   0,  -11
+.2byte   -1,   -1, 	 -10,   -3, 	   7,   -4, 	  -1,  -10
+.2byte  -10,    1, 	 -14,   -3, 	  -1,   -1, 	  -1,  -11
+.2byte  -15,   -6, 	 -15,  -11, 	 -13,   -6, 	  -1,  -11
+.2byte   -8,  -18, 	   1,  -20, 	 -12,  -13, 	  -1,  -11
+.2byte   -1,  -18, 	   6,  -17, 	  -7,  -17, 	   0,  -12
+.2byte    7,  -18, 	  -2,  -20, 	  11,  -13, 	   0,  -11
+.2byte   14,   -6, 	  14,  -11, 	  12,   -6, 	   0,  -11
+.2byte    9,    1, 	  13,   -3, 	   0,   -1, 	   0,  -11
+.2byte   -1,    1, 	 -10,  -13, 	   9,  -14, 	   0,  -10
+.2byte   11,   -5, 	  10,  -15, 	  -2,  -13, 	  -1,  -10
+.2byte   16,   -6, 	   8,  -17, 	   5,  -12, 	   0,   -9
+.2byte    9,  -10, 	  -4,  -21, 	  13,  -15, 	   1,  -10
+.2byte    0,  -18, 	   8,  -21, 	  -7,  -20, 	   0,  -12
+.2byte  -10,  -10, 	   3,  -21, 	 -14,  -15, 	  -2,  -10
+.2byte  -17,   -6, 	  -9,  -17, 	  -6,  -12, 	  -1,   -9
+.2byte  -12,   -5, 	 -11,  -15, 	   1,  -13, 	   0,  -10
+.2byte   -1,  -12, 	 -11,  -16, 	  11,  -15, 	   0,   -9
+.2byte    0,  -10, 	 -10,  -14, 	  12,  -13, 	   0,   -8
+.2byte   -2,   -9, 	 -12,  -14, 	  10,  -13, 	   0,   -8
+.2byte    8,  -14, 	  13,  -18, 	  -3,  -13, 	  -1,   -9
+.2byte    6,  -12, 	  11,  -17, 	  -4,  -11, 	  -1,   -8
+.2byte    8,  -12, 	  13,  -17, 	  -2,  -11, 	  -1,   -8
+.2byte   13,  -15, 	   6,  -22, 	   5,  -13, 	  -1,   -9
+.2byte   13,  -13, 	   6,  -20, 	   5,  -10, 	   0,   -8
+.2byte   13,  -13, 	   6,  -20, 	   5,  -11, 	  -1,   -8
+.2byte    6,  -22, 	  -4,  -22, 	  13,  -16, 	   0,  -11
+.2byte    5,  -20, 	  -4,  -20, 	  13,  -14, 	   0,  -10
+.2byte    5,  -19, 	  -5,  -20, 	  12,  -14, 	   0,   -9
+.2byte    0,  -21, 	  10,  -17, 	 -12,  -18, 	   0,  -11
+.2byte   -1,  -19, 	  10,  -15, 	 -13,  -16, 	   0,  -10
+.2byte    2,  -18, 	  12,  -15, 	 -11,  -16, 	   0,  -10
+.2byte   -7,  -22, 	   3,  -22, 	 -14,  -16, 	  -1,  -11
+.2byte   -6,  -20, 	   3,  -20, 	 -14,  -14, 	  -1,  -10
+.2byte   -6,  -19, 	   4,  -20, 	 -13,  -14, 	  -1,   -9
+.2byte  -14,  -15, 	  -7,  -22, 	  -6,  -13, 	   0,   -9
+.2byte  -14,  -13, 	  -7,  -20, 	  -6,  -10, 	  -1,   -8
+.2byte  -14,  -13, 	  -7,  -20, 	  -6,  -11, 	   0,   -8
+.2byte   -9,  -14, 	 -14,  -18, 	   2,  -13, 	   0,   -9
+.2byte   -7,  -12, 	 -12,  -17, 	   3,  -11, 	   0,   -8
+.2byte   -9,  -12, 	 -14,  -17, 	   1,  -11, 	   0,   -8
+.2byte   -1,    1, 	 -10,  -13, 	   9,  -14, 	   0,  -10
+.2byte  -12,   -5, 	 -11,  -15, 	   1,  -13, 	   0,  -10
+.2byte  -17,   -6, 	  -9,  -17, 	  -6,  -12, 	  -1,   -9
+.2byte  -10,  -10, 	   3,  -21, 	 -14,  -15, 	  -2,  -10
+.2byte    0,  -18, 	   8,  -21, 	  -7,  -20, 	   0,  -12
+.2byte    9,  -10, 	  -4,  -21, 	  13,  -15, 	   1,  -10
+.2byte   16,   -6, 	   8,  -17, 	   5,  -12, 	   0,   -9
+.2byte   11,   -5, 	  10,  -15, 	  -2,  -13, 	  -1,  -10
+.2byte   -1,  -12, 	 -11,  -16, 	  11,  -15, 	   0,   -9
+.2byte   -9,  -14, 	 -14,  -18, 	   2,  -13, 	   0,   -9
+.2byte  -14,  -15, 	  -7,  -22, 	  -6,  -13, 	   0,   -9
+.2byte   -7,  -22, 	   3,  -22, 	 -14,  -16, 	  -1,  -11
+.2byte    0,  -21, 	  10,  -17, 	 -12,  -18, 	   0,  -11
+.2byte    6,  -22, 	  -4,  -22, 	  13,  -16, 	   0,  -11
+.2byte   13,  -15, 	   6,  -22, 	   5,  -13, 	  -1,   -9
+.2byte    8,  -14, 	  13,  -18, 	  -3,  -13, 	  -1,   -9
+sDodrioAnimTable1:
+.4byte sDodrioAnims_1_1
+.4byte sDodrioAnims_1_2
+.4byte sDodrioAnims_1_3
+.4byte sDodrioAnims_1_4
+.4byte sDodrioAnims_1_5
+.4byte sDodrioAnims_1_6
+.4byte sDodrioAnims_1_7
+.4byte sDodrioAnims_1_8
+sDodrioAnimTable2:
+.4byte sDodrioAnims_2_1
+.4byte sDodrioAnims_2_2
+.4byte sDodrioAnims_2_3
+.4byte sDodrioAnims_2_4
+.4byte sDodrioAnims_2_5
+.4byte sDodrioAnims_2_6
+.4byte sDodrioAnims_2_7
+.4byte sDodrioAnims_2_8
+sDodrioAnimTable3:
+.4byte sDodrioAnims_3_1
+.4byte sDodrioAnims_3_2
+.4byte sDodrioAnims_3_3
+.4byte sDodrioAnims_3_4
+.4byte sDodrioAnims_3_5
+.4byte sDodrioAnims_3_6
+.4byte sDodrioAnims_3_7
+.4byte sDodrioAnims_3_8
+sDodrioAnimTable4:
+.4byte sDodrioAnims_4_1
+.4byte sDodrioAnims_4_2
+.4byte sDodrioAnims_4_3
+.4byte sDodrioAnims_4_4
+.4byte sDodrioAnims_4_5
+.4byte sDodrioAnims_4_6
+.4byte sDodrioAnims_4_7
+.4byte sDodrioAnims_4_8
+sDodrioAnimTable5:
+.4byte sDodrioAnims_5_1
+.4byte sDodrioAnims_5_2
+.4byte sDodrioAnims_5_3
+.4byte sDodrioAnims_5_4
+.4byte sDodrioAnims_5_5
+.4byte sDodrioAnims_5_6
+.4byte sDodrioAnims_5_7
+.4byte sDodrioAnims_5_8
+sDodrioAnimTable6:
+.4byte sDodrioAnims_6_1
+.4byte sDodrioAnims_6_1
+.4byte sDodrioAnims_6_1
+.4byte sDodrioAnims_6_1
+.4byte sDodrioAnims_6_1
+.4byte sDodrioAnims_6_1
+.4byte sDodrioAnims_6_1
+.4byte sDodrioAnims_6_1
+sDodrioAnimTable7:
+.4byte sDodrioAnims_7_1
+.4byte sDodrioAnims_7_2
+.4byte sDodrioAnims_7_3
+.4byte sDodrioAnims_7_4
+.4byte sDodrioAnims_7_5
+.4byte sDodrioAnims_7_6
+.4byte sDodrioAnims_7_7
+.4byte sDodrioAnims_7_8
+sDodrioAnimTable8:
+.4byte sDodrioAnims_8_1
+.4byte sDodrioAnims_8_2
+.4byte sDodrioAnims_8_3
+.4byte sDodrioAnims_8_4
+.4byte sDodrioAnims_8_5
+.4byte sDodrioAnims_8_6
+.4byte sDodrioAnims_8_7
+.4byte sDodrioAnims_8_8
+sDodrioAnimTable9:
+.4byte sDodrioAnims_9_1
+.4byte sDodrioAnims_9_2
+.4byte sDodrioAnims_9_3
+.4byte sDodrioAnims_9_4
+.4byte sDodrioAnims_9_5
+.4byte sDodrioAnims_9_6
+.4byte sDodrioAnims_9_7
+.4byte sDodrioAnims_9_8
+sDodrioAnimTable10:
+.4byte sDodrioAnims_10_1
+.4byte sDodrioAnims_10_2
+.4byte sDodrioAnims_10_3
+.4byte sDodrioAnims_10_4
+.4byte sDodrioAnims_10_5
+.4byte sDodrioAnims_10_6
+.4byte sDodrioAnims_10_7
+.4byte sDodrioAnims_10_8
+sDodrioAnimTable11:
+.4byte sDodrioAnims_11_1
+.4byte sDodrioAnims_11_2
+.4byte sDodrioAnims_11_3
+.4byte sDodrioAnims_11_4
+.4byte sDodrioAnims_11_5
+.4byte sDodrioAnims_11_6
+.4byte sDodrioAnims_11_7
+.4byte sDodrioAnims_11_8
+sDodrioAnimTable12:
+.4byte sDodrioAnims_12_1
+.4byte sDodrioAnims_12_2
+.4byte sDodrioAnims_12_3
+.4byte sDodrioAnims_12_4
+.4byte sDodrioAnims_12_5
+.4byte sDodrioAnims_12_6
+.4byte sDodrioAnims_12_7
+.4byte sDodrioAnims_12_8
+sDodrioAnimTable13:
+.4byte sDodrioAnims_13_1
+.4byte sDodrioAnims_13_2
+.4byte sDodrioAnims_13_3
+.4byte sDodrioAnims_13_4
+.4byte sDodrioAnims_13_5
+.4byte sDodrioAnims_13_6
+.4byte sDodrioAnims_13_7
+.4byte sDodrioAnims_13_8
+sAxAnimationsDodrio:
+.4byte sDodrioAnimTable1
+.4byte sDodrioAnimTable2
+.4byte sDodrioAnimTable3
+.4byte sDodrioAnimTable4
+.4byte sDodrioAnimTable5
+.4byte sDodrioAnimTable6
+.4byte sDodrioAnimTable7
+.4byte sDodrioAnimTable8
+.4byte sDodrioAnimTable9
+.4byte sDodrioAnimTable10
+.4byte sDodrioAnimTable11
+.4byte sDodrioAnimTable12
+.4byte sDodrioAnimTable13
+sAxSpritesDodrio:
+.4byte sDodrioSprites1
+.4byte sDodrioSprites2
+.4byte sDodrioSprites3
+.4byte sDodrioSprites4
+.4byte sDodrioSprites5
+.4byte sDodrioSprites6
+.4byte sDodrioSprites7
+.4byte sDodrioSprites8
+.4byte sDodrioSprites9
+.4byte sDodrioSprites10
+.4byte sDodrioSprites11
+.4byte sDodrioSprites12
+.4byte sDodrioSprites13
+.4byte sDodrioSprites14
+.4byte sDodrioSprites15
+.4byte sDodrioSprites16
+.4byte sDodrioSprites17
+.4byte sDodrioSprites18
+.4byte sDodrioSprites19
+.4byte sDodrioSprites20
+.4byte sDodrioSprites21
+.4byte sDodrioSprites22
+.4byte sDodrioSprites23
+.4byte sDodrioSprites24
+.4byte sDodrioSprites25
+.4byte sDodrioSprites26
+.4byte sDodrioSprites27
+.4byte sDodrioSprites28
+.4byte sDodrioSprites29
+.4byte sDodrioSprites30
+.4byte sDodrioSprites31
+.4byte sDodrioSprites32
+.4byte sDodrioSprites33
+.4byte sDodrioSprites34
+.4byte sDodrioSprites35
+.4byte sDodrioSprites36
+.4byte sDodrioSprites37
+.4byte sDodrioSprites38
+.4byte sDodrioSprites39
+.4byte sDodrioSprites40
+.4byte sDodrioSprites41
+.4byte sDodrioSprites42
+.4byte sDodrioSprites43
+.4byte sDodrioSprites44
+.4byte sDodrioSprites45
+.4byte sDodrioSprites46
+.4byte sDodrioSprites47
+sAxMainDodrio:
+ax_main sAxPosesDodrio, sAxAnimationsDodrio, 13, sAxSpritesDodrio, sAxPositionsDodrio

--- a/data/ax/doduo.inc
+++ b/data/ax/doduo.inc
@@ -1,0 +1,3243 @@
+.global gAxDoduo
+gAxDoduo:
+ax_siro sAxMainDoduo
+sDoduoPose1:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose2:
+ax_pose 1, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose3:
+ax_pose 2, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sDoduoPose4:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose5:
+ax_pose 4, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose6:
+ax_pose 5, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose7:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose8:
+ax_pose 7, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose9:
+ax_pose 8, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose10:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose11:
+ax_pose 10, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose12:
+ax_pose 11, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose14:
+ax_pose 13, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose16:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose17:
+ax_pose 10, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose18:
+ax_pose 11, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose19:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose20:
+ax_pose 7, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose21:
+ax_pose 8, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose22:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose23:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose24:
+ax_pose 5, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose25:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose26:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose27:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose28:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose29:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose30:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose31:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose32:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose33:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose34:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose35:
+ax_pose 2, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sDoduoPose36:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose37:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose38:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose39:
+ax_pose 4, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose40:
+ax_pose 5, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose41:
+ax_pose 17, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose42:
+ax_pose 18, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose43:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose44:
+ax_pose 7, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose45:
+ax_pose 8, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose46:
+ax_pose 19, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose47:
+ax_pose 20, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sDoduoPose48:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose49:
+ax_pose 10, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose50:
+ax_pose 11, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose51:
+ax_pose 21, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose52:
+ax_pose 22, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose53:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose54:
+ax_pose 13, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose55:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose56:
+ax_pose 23, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose57:
+ax_pose 24, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose58:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose59:
+ax_pose 10, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose60:
+ax_pose 11, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose61:
+ax_pose 21, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose62:
+ax_pose 22, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose63:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose64:
+ax_pose 7, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose65:
+ax_pose 8, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose66:
+ax_pose 19, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose67:
+ax_pose 20, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose68:
+ax_pose 3, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose69:
+ax_pose 4, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose70:
+ax_pose 5, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose71:
+ax_pose 17, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose72:
+ax_pose 18, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose73:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose74:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose75:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose76:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose77:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose78:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose79:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose80:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose81:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose82:
+ax_pose 1, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose83:
+ax_pose 2, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sDoduoPose84:
+ax_pose 25, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose85:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose86:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose87:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose88:
+ax_pose 4, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose89:
+ax_pose 5, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose90:
+ax_pose 26, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose91:
+ax_pose 17, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose92:
+ax_pose 27, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sDoduoPose93:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose94:
+ax_pose 7, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose95:
+ax_pose 8, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose96:
+ax_pose 19, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose97:
+ax_pose 28, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose98:
+ax_pose 29, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose99:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose100:
+ax_pose 10, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose101:
+ax_pose 11, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose102:
+ax_pose 30, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose103:
+ax_pose 21, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose104:
+ax_pose 31, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sDoduoPose105:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose106:
+ax_pose 13, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose107:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose108:
+ax_pose 32, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose109:
+ax_pose 23, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose110:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose111:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose112:
+ax_pose 10, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose113:
+ax_pose 11, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose114:
+ax_pose 30, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose115:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose116:
+ax_pose 31, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose117:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose118:
+ax_pose 7, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose119:
+ax_pose 8, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose120:
+ax_pose 19, 0x01e7, 0x80ee, 0x4c00
+ax_pose_terminator
+sDoduoPose121:
+ax_pose 28, 0x01e7, 0x80ee, 0x4c00
+ax_pose_terminator
+sDoduoPose122:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose123:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose124:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose125:
+ax_pose 5, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose126:
+ax_pose 26, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose127:
+ax_pose 17, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose128:
+ax_pose 27, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose129:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose130:
+ax_pose 27, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose131:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose132:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose133:
+ax_pose 33, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose134:
+ax_pose 31, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose135:
+ax_pose 29, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose136:
+ax_pose 27, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose137:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose138:
+ax_pose 3, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose139:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose140:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose141:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose142:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose143:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose144:
+ax_pose 3, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose145:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose146:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose147:
+ax_pose 34, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose148:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose149:
+ax_pose 27, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sDoduoPose150:
+ax_pose 18, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sDoduoPose151:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose152:
+ax_pose 29, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose153:
+ax_pose 20, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose154:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose155:
+ax_pose 31, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose156:
+ax_pose 22, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose157:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose158:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose159:
+ax_pose 24, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose160:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose161:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose162:
+ax_pose 22, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose163:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose164:
+ax_pose 29, 0x01e7, 0x80ee, 0x4c00
+ax_pose_terminator
+sDoduoPose165:
+ax_pose 20, 0x01e7, 0x80ee, 0x4c00
+ax_pose_terminator
+sDoduoPose166:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose167:
+ax_pose 27, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose168:
+ax_pose 18, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose169:
+ax_pose 35, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose170:
+ax_pose 36, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose171:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose172:
+ax_pose 3, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose173:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose174:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose175:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose176:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose177:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose178:
+ax_pose 3, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose179:
+ax_pose 37, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose180:
+ax_pose 38, 0x01e8, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose181:
+ax_pose 39, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose182:
+ax_pose 40, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose183:
+ax_pose 41, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose184:
+ax_pose 40, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose185:
+ax_pose 39, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose186:
+ax_pose 38, 0x01e8, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose187:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose188:
+ax_pose 3, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose189:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose190:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose191:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose192:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose193:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose194:
+ax_pose 3, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose195:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose196:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose197:
+ax_pose 34, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose198:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose199:
+ax_pose 27, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sDoduoPose200:
+ax_pose 18, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sDoduoPose201:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose202:
+ax_pose 29, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sDoduoPose203:
+ax_pose 20, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sDoduoPose204:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose205:
+ax_pose 31, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose206:
+ax_pose 22, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose207:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose208:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose209:
+ax_pose 24, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose210:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose211:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose212:
+ax_pose 22, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose213:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose214:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose215:
+ax_pose 20, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose216:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose217:
+ax_pose 27, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose218:
+ax_pose 18, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sDoduoPose219:
+ax_pose 25, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose220:
+ax_pose 26, 0x01ed, 0x80f2, 0x4c00
+ax_pose_terminator
+sDoduoPose221:
+ax_pose 19, 0x01e8, 0x80ee, 0x4c00
+ax_pose_terminator
+sDoduoPose222:
+ax_pose 30, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose223:
+ax_pose 32, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose224:
+ax_pose 30, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose225:
+ax_pose 19, 0x01e8, 0x90f1, 0x4c00
+ax_pose_terminator
+sDoduoPose226:
+ax_pose 26, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sDoduoPose227:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose228:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose229:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose230:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose231:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose232:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose233:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose234:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose235:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose236:
+ax_pose 3, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose237:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose238:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose239:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose240:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose241:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose242:
+ax_pose 3, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose243:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose244:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose245:
+ax_pose 25, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose246:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose247:
+ax_pose 27, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sDoduoPose248:
+ax_pose 26, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose249:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose250:
+ax_pose 29, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose251:
+ax_pose 19, 0x01e7, 0x90f2, 0x4c00
+ax_pose_terminator
+sDoduoPose252:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose253:
+ax_pose 31, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sDoduoPose254:
+ax_pose 30, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose255:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose256:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose257:
+ax_pose 32, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose258:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose259:
+ax_pose 31, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose260:
+ax_pose 30, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose261:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose262:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose263:
+ax_pose 19, 0x01e7, 0x80ed, 0x4c00
+ax_pose_terminator
+sDoduoPose264:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose265:
+ax_pose 27, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sDoduoPose266:
+ax_pose 26, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose267:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose268:
+ax_pose 27, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose269:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose270:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose271:
+ax_pose 33, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose272:
+ax_pose 31, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose273:
+ax_pose 29, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose274:
+ax_pose 27, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose275:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose276:
+ax_pose 3, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose277:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose278:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose279:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose280:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose281:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose282:
+ax_pose 3, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose283:
+ax_pose 0, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDoduoPose284:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose285:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose286:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose287:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDoduoPose288:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose289:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose290:
+ax_pose 3, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose291:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose292:
+ax_pose 3, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose293:
+ax_pose 6, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose294:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose295:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sDoduoPose296:
+ax_pose 9, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose297:
+ax_pose 6, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sDoduoPose298:
+ax_pose 3, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+.align 2
+sDoduoAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_2_1:
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 2, 0, 32, 0, -3, 0, -2,
+ax_anim 4, 0, 34, 0, -4, 0, -5,
+ax_anim 3, 0, 32, 0, -4, 0, -2,
+ax_anim 2, 0, 33, 0, -4, 0, -2,
+ax_anim 2, 0, 32, 0, -4, 0, -2,
+ax_anim 1, 0, 34, 0, -2, 0, 0,
+ax_anim 1, 2, 35, 0, 4, 0, 4,
+ax_anim 1, 0, 35, 0, 10, 0, 10,
+ax_anim 2, 0, 35, 0, 20, 0, 20,
+ax_anim 2, 1, 35, 1, 20, 1, 20,
+ax_anim 2, 0, 35, 0, 20, 0, 20,
+ax_anim 2, 0, 35, 1, 20, 1, 20,
+ax_anim 2, 0, 36, 0, 6, 0, 6,
+ax_anim_terminator
+sDoduoAnims_2_2:
+ax_anim 1, 0, 38, -1, -1, -1, -1,
+ax_anim 2, 0, 37, -3, -3, -3, -3,
+ax_anim 4, 0, 39, -4, -4, -4, -4,
+ax_anim 3, 0, 37, -4, -4, -4, -4,
+ax_anim 2, 0, 38, -4, -4, -4, -4,
+ax_anim 2, 0, 37, -4, -4, -4, -4,
+ax_anim 1, 0, 39, -2, -2, -2, -2,
+ax_anim 1, 2, 40, 4, 4, 4, 4,
+ax_anim 1, 0, 40, 10, 10, 10, 10,
+ax_anim 2, 0, 40, 20, 20, 20, 20,
+ax_anim 2, 1, 40, 21, 19, 21, 19,
+ax_anim 2, 0, 40, 20, 20, 20, 20,
+ax_anim 2, 0, 40, 21, 19, 21, 19,
+ax_anim 2, 0, 41, 6, 6, 6, 6,
+ax_anim_terminator
+sDoduoAnims_2_3:
+ax_anim 1, 0, 43, -1, 0, -1, 0,
+ax_anim 2, 0, 42, -3, 0, -3, 0,
+ax_anim 4, 0, 44, -4, 0, -4, 0,
+ax_anim 3, 0, 42, -4, 0, -4, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 0, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -2, 0, -2, 0,
+ax_anim 1, 2, 45, 4, 0, 4, 0,
+ax_anim 1, 0, 45, 10, 0, 10, 0,
+ax_anim 2, 0, 45, 20, 0, 20, 0,
+ax_anim 2, 1, 45, 20, -1, 20, -1,
+ax_anim 2, 0, 45, 20, 0, 20, 0,
+ax_anim 2, 0, 45, 20, -1, 20, -1,
+ax_anim 2, 0, 46, 6, 0, 6, 0,
+ax_anim_terminator
+sDoduoAnims_2_4:
+ax_anim 1, 0, 48, -1, 1, -1, 1,
+ax_anim 2, 0, 47, -3, 3, -3, 3,
+ax_anim 4, 0, 49, -4, 4, -4, 4,
+ax_anim 3, 0, 47, -4, 4, -4, 4,
+ax_anim 2, 0, 48, -4, 4, -4, 4,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 49, -2, 2, -2, 2,
+ax_anim 1, 2, 50, 4, -4, 4, -4,
+ax_anim 1, 0, 50, 10, -10, 10, -10,
+ax_anim 2, 0, 50, 20, -20, 20, -20,
+ax_anim 2, 1, 50, 21, -19, 21, -19,
+ax_anim 2, 0, 50, 20, -20, 20, -20,
+ax_anim 2, 0, 50, 21, -19, 21, -19,
+ax_anim 2, 0, 51, 6, -6, 6, -6,
+ax_anim_terminator
+sDoduoAnims_2_5:
+ax_anim 1, 0, 53, 0, 1, 0, 1,
+ax_anim 2, 0, 52, 0, 3, 0, 3,
+ax_anim 4, 0, 54, 0, 4, 0, 4,
+ax_anim 3, 0, 52, 0, 4, 0, 4,
+ax_anim 2, 0, 53, 0, 4, 0, 4,
+ax_anim 2, 0, 52, 0, 4, 0, 4,
+ax_anim 1, 0, 54, 0, 2, 0, 2,
+ax_anim 1, 2, 55, 0, -4, 0, -4,
+ax_anim 1, 0, 55, 0, -10, 0, -10,
+ax_anim 2, 0, 55, 0, -20, 0, -20,
+ax_anim 2, 1, 55, -1, -20, -1, -20,
+ax_anim 2, 0, 55, 0, -20, 0, -20,
+ax_anim 2, 0, 55, -1, -20, -1, -20,
+ax_anim 2, 0, 56, 0, -6, 0, -6,
+ax_anim_terminator
+sDoduoAnims_2_6:
+ax_anim 1, 0, 58, 1, 1, 1, 1,
+ax_anim 2, 0, 57, 3, 3, 3, 3,
+ax_anim 4, 0, 59, 4, 4, 4, 4,
+ax_anim 3, 0, 57, 4, 4, 4, 4,
+ax_anim 2, 0, 58, 4, 4, 4, 4,
+ax_anim 2, 0, 57, 4, 4, 4, 4,
+ax_anim 1, 0, 59, 2, 2, 2, 2,
+ax_anim 1, 2, 60, -4, -4, -4, -4,
+ax_anim 1, 0, 60, -10, -10, -10, -10,
+ax_anim 2, 0, 60, -20, -20, -20, -20,
+ax_anim 2, 1, 60, -21, -19, -21, -19,
+ax_anim 2, 0, 60, -20, -20, -20, -20,
+ax_anim 2, 0, 60, -21, -19, -21, -19,
+ax_anim 2, 0, 61, -6, -6, -6, -6,
+ax_anim_terminator
+sDoduoAnims_2_7:
+ax_anim 1, 0, 63, 1, 0, 1, 0,
+ax_anim 2, 0, 62, 3, 0, 3, 0,
+ax_anim 4, 0, 64, 4, 0, 4, 0,
+ax_anim 3, 0, 62, 4, 0, 4, 0,
+ax_anim 2, 0, 63, 4, 0, 4, 0,
+ax_anim 2, 0, 62, 4, 0, 4, 0,
+ax_anim 1, 0, 64, 2, 0, 2, 0,
+ax_anim 1, 2, 65, -4, 0, -4, 0,
+ax_anim 1, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, -20, 0, -20, 0,
+ax_anim 2, 1, 65, -20, -1, -20, -1,
+ax_anim 2, 0, 65, -20, 0, -20, 0,
+ax_anim 2, 0, 65, -20, -1, -20, -1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sDoduoAnims_2_8:
+ax_anim 1, 0, 68, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 3, -3, 3, -3,
+ax_anim 4, 0, 69, 4, -4, 4, -4,
+ax_anim 3, 0, 67, 4, -4, 4, -4,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim 2, 0, 67, 4, -4, 4, -4,
+ax_anim 1, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -20, 20, -20, 20,
+ax_anim 2, 1, 70, -21, 19, -21, 19,
+ax_anim 2, 0, 70, -20, 20, -20, 20,
+ax_anim 2, 0, 70, -21, 19, -21, 19,
+ax_anim 2, 0, 71, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDoduoAnims_3_1:
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim 2, 0, 81, 0, -4, 0, -3,
+ax_anim 2, 0, 82, 0, -4, 0, -3,
+ax_anim 1, 0, 85, 0, -2, 0, -2,
+ax_anim 1, 0, 83, 0, 2, 0, 2,
+ax_anim 2, 2, 83, 0, 8, 0, 8,
+ax_anim 2, 0, 83, 0, 20, 0, 20,
+ax_anim 2, 1, 84, 0, 20, 0, 20,
+ax_anim 2, 0, 83, 0, 20, 0, 20,
+ax_anim 2, 0, 84, 0, 20, 0, 20,
+ax_anim 2, 0, 83, 0, 20, 0, 20,
+ax_anim 2, 0, 84, 0, 20, 0, 20,
+ax_anim 2, 0, 85, 0, 10, 0, 10,
+ax_anim 2, 0, 80, 0, 3, 0, 3,
+ax_anim_terminator
+sDoduoAnims_3_2:
+ax_anim 2, 0, 86, -2, -2, -2, -2,
+ax_anim 2, 0, 86, -3, -3, -3, -3,
+ax_anim 2, 0, 87, -4, -5, -3, -3,
+ax_anim 2, 0, 88, -4, -5, -3, -3,
+ax_anim 1, 0, 91, -2, -2, -2, -2,
+ax_anim 1, 0, 89, 2, 3, 2, 3,
+ax_anim 2, 2, 89, 8, 10, 8, 10,
+ax_anim 2, 0, 89, 16, 20, 16, 20,
+ax_anim 2, 1, 90, 16, 20, 16, 20,
+ax_anim 2, 0, 89, 16, 20, 16, 20,
+ax_anim 2, 0, 90, 16, 20, 16, 20,
+ax_anim 2, 0, 89, 16, 20, 16, 20,
+ax_anim 2, 0, 90, 16, 20, 16, 20,
+ax_anim 2, 0, 91, 10, 12, 10, 12,
+ax_anim 2, 0, 86, 3, 4, 3, 4,
+ax_anim_terminator
+sDoduoAnims_3_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 93, -4, -1, -4, 0,
+ax_anim 2, 0, 94, -4, -1, -4, 0,
+ax_anim 1, 0, 97, -2, 0, -2, 0,
+ax_anim 1, 0, 95, 2, 0, 2, 0,
+ax_anim 2, 2, 95, 6, 0, 6, 0,
+ax_anim 2, 0, 95, 13, 0, 13, 0,
+ax_anim 2, 1, 96, 13, 0, 13, 0,
+ax_anim 2, 0, 95, 13, 0, 13, 0,
+ax_anim 2, 0, 96, 13, 0, 13, 0,
+ax_anim 2, 0, 95, 13, 0, 13, 0,
+ax_anim 2, 0, 96, 13, 0, 13, 0,
+ax_anim 2, 0, 97, 8, 0, 8, 0,
+ax_anim 2, 0, 92, 3, 0, 3, 0,
+ax_anim_terminator
+sDoduoAnims_3_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 99, -4, 3, -4, 4,
+ax_anim 2, 0, 100, -4, 3, -4, 4,
+ax_anim 1, 0, 103, -2, 2, -2, 2,
+ax_anim 1, 0, 101, 2, -3, 2, -3,
+ax_anim 2, 2, 101, 8, -10, 8, -10,
+ax_anim 2, 0, 101, 14, -18, 14, -18,
+ax_anim 2, 1, 102, 14, -18, 14, -18,
+ax_anim 2, 0, 101, 14, -18, 14, -18,
+ax_anim 2, 0, 102, 14, -18, 14, -18,
+ax_anim 2, 0, 101, 14, -18, 14, -18,
+ax_anim 2, 0, 102, 14, -18, 14, -18,
+ax_anim 2, 0, 103, 10, -12, 10, -12,
+ax_anim 2, 0, 98, 3, -4, 3, -4,
+ax_anim_terminator
+sDoduoAnims_3_5:
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim 2, 0, 105, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 1, 0, 109, 0, 2, 0, 2,
+ax_anim 1, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 2, 107, 0, -10, 0, -10,
+ax_anim 2, 0, 107, 0, -18, 0, -18,
+ax_anim 2, 1, 108, 0, -18, 0, -18,
+ax_anim 2, 0, 107, 0, -18, 0, -18,
+ax_anim 2, 0, 108, 0, -18, 0, -18,
+ax_anim 2, 0, 107, 0, -18, 0, -18,
+ax_anim 2, 0, 108, 0, -18, 0, -18,
+ax_anim 2, 0, 109, 0, -12, 0, -12,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim_terminator
+sDoduoAnims_3_6:
+ax_anim 2, 0, 110, 2, 2, 2, 2,
+ax_anim 2, 0, 110, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 4, 3, 4, 4,
+ax_anim 2, 0, 112, 4, 3, 4, 4,
+ax_anim 1, 0, 115, 2, 2, 2, 2,
+ax_anim 1, 0, 113, -2, -3, -2, -3,
+ax_anim 2, 2, 113, -8, -10, -8, -10,
+ax_anim 2, 0, 113, -14, -18, -14, -18,
+ax_anim 2, 1, 114, -14, -18, -14, -18,
+ax_anim 2, 0, 113, -14, -18, -14, -18,
+ax_anim 2, 0, 114, -14, -18, -14, -18,
+ax_anim 2, 0, 113, -14, -18, -14, -18,
+ax_anim 2, 0, 114, -14, -18, -14, -18,
+ax_anim 2, 0, 115, -10, -12, -10, -12,
+ax_anim 2, 0, 110, -3, -4, -3, -4,
+ax_anim_terminator
+sDoduoAnims_3_7:
+ax_anim 2, 0, 116, 2, 0, 2, 0,
+ax_anim 2, 0, 116, 3, 0, 3, 0,
+ax_anim 2, 0, 117, 4, -1, 4, 0,
+ax_anim 2, 0, 118, 4, -1, 4, 0,
+ax_anim 1, 0, 121, 2, 0, 2, 0,
+ax_anim 1, 0, 119, -2, 0, -2, 0,
+ax_anim 2, 2, 119, -6, 0, -6, 0,
+ax_anim 2, 0, 119, -13, 0, -13, 0,
+ax_anim 2, 1, 120, -13, 0, -13, 0,
+ax_anim 2, 0, 119, -13, 0, -13, 0,
+ax_anim 2, 0, 120, -13, 0, -13, 0,
+ax_anim 2, 0, 119, -13, 0, -13, 0,
+ax_anim 2, 0, 120, -13, 0, -13, 0,
+ax_anim 2, 0, 121, -8, 0, -8, 0,
+ax_anim 2, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sDoduoAnims_3_8:
+ax_anim 2, 0, 122, 2, -2, 2, -2,
+ax_anim 2, 0, 122, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 4, -5, 3, -3,
+ax_anim 2, 0, 124, 4, -5, 3, -3,
+ax_anim 1, 0, 127, 2, -2, 2, -2,
+ax_anim 1, 0, 125, -2, 3, -2, 3,
+ax_anim 2, 2, 125, -8, 10, -8, 10,
+ax_anim 2, 0, 125, -16, 20, -16, 20,
+ax_anim 2, 1, 126, -16, 20, -16, 20,
+ax_anim 2, 0, 125, -16, 20, -16, 20,
+ax_anim 2, 0, 126, -16, 20, -16, 20,
+ax_anim 2, 0, 125, -16, 20, -16, 20,
+ax_anim 2, 0, 126, -16, 20, -16, 20,
+ax_anim 2, 0, 127, -10, 12, -10, 12,
+ax_anim 2, 0, 122, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sDoduoAnims_4_1:
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 1, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_4_2:
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_4_3:
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 1, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_4_4:
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 1, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_4_5:
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_4_6:
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 1, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_4_7:
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 1, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_4_8:
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_5_1:
+ax_anim 2, 0, 144, 0, -2, 0, -2,
+ax_anim 4, 0, 144, 0, -3, 0, -3,
+ax_anim 1, 2, 144, 0, 3, 0, 3,
+ax_anim 1, 0, 144, 0, 8, 0, 8,
+ax_anim 2, 0, 145, 0, 18, 0, 18,
+ax_anim 4, 1, 145, 0, 16, 0, 16,
+ax_anim 2, 0, 146, 0, 18, 0, 18,
+ax_anim 4, 0, 146, 0, 16, 0, 16,
+ax_anim 2, 0, 145, 0, 18, 0, 18,
+ax_anim 2, 0, 145, 0, 16, 0, 16,
+ax_anim 2, 0, 146, 0, 18, 0, 18,
+ax_anim 1, 0, 146, 0, 16, 0, 16,
+ax_anim 1, 0, 145, 0, 18, 0, 18,
+ax_anim 1, 0, 145, 0, 16, 0, 16,
+ax_anim 1, 0, 144, 0, 8, 0, 8,
+ax_anim 1, 0, 144, 0, 2, 0, 2,
+ax_anim_terminator
+sDoduoAnims_5_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 4, 0, 147, -3, -3, -3, -3,
+ax_anim 1, 2, 147, 3, 3, 3, 3,
+ax_anim 1, 0, 147, 8, 9, 8, 9,
+ax_anim 2, 0, 148, 15, 18, 15, 18,
+ax_anim 4, 1, 148, 13, 16, 13, 16,
+ax_anim 2, 0, 149, 15, 18, 15, 18,
+ax_anim 4, 0, 149, 13, 16, 13, 16,
+ax_anim 2, 0, 148, 15, 18, 15, 18,
+ax_anim 2, 0, 148, 13, 16, 13, 16,
+ax_anim 2, 0, 149, 15, 18, 15, 18,
+ax_anim 1, 0, 149, 13, 16, 13, 16,
+ax_anim 1, 0, 148, 15, 18, 15, 18,
+ax_anim 1, 0, 148, 13, 16, 13, 16,
+ax_anim 1, 0, 147, 8, 9, 8, 9,
+ax_anim 1, 0, 147, 2, 2, 2, 2,
+ax_anim_terminator
+sDoduoAnims_5_3:
+ax_anim 2, 0, 150, -2, 0, -2, 0,
+ax_anim 4, 0, 150, -3, 0, -3, 0,
+ax_anim 1, 2, 150, 3, 0, 3, 0,
+ax_anim 1, 0, 150, 8, 0, 8, 0,
+ax_anim 2, 0, 151, 12, 0, 12, 0,
+ax_anim 4, 1, 151, 10, 0, 10, 0,
+ax_anim 2, 0, 152, 12, 0, 12, 0,
+ax_anim 4, 0, 152, 10, 0, 10, 0,
+ax_anim 2, 0, 151, 12, 0, 12, 0,
+ax_anim 2, 0, 151, 10, 0, 10, 0,
+ax_anim 2, 0, 152, 12, 0, 12, 0,
+ax_anim 1, 0, 152, 10, 0, 10, 0,
+ax_anim 1, 0, 151, 12, 0, 12, 0,
+ax_anim 1, 0, 151, 10, 0, 10, 0,
+ax_anim 1, 0, 150, 8, 0, 8, 0,
+ax_anim 1, 0, 150, 2, 0, 2, 0,
+ax_anim_terminator
+sDoduoAnims_5_4:
+ax_anim 2, 0, 153, -2, 2, -2, 2,
+ax_anim 4, 0, 153, -3, 3, -3, 3,
+ax_anim 1, 2, 153, 3, -3, 3, -3,
+ax_anim 1, 0, 153, 8, -9, 8, -9,
+ax_anim 2, 0, 154, 17, -20, 17, -20,
+ax_anim 4, 1, 154, 15, -18, 15, -18,
+ax_anim 2, 0, 155, 17, -20, 17, -20,
+ax_anim 4, 0, 155, 15, -18, 15, -18,
+ax_anim 2, 0, 154, 17, -20, 17, -20,
+ax_anim 2, 0, 154, 15, -18, 15, -18,
+ax_anim 2, 0, 155, 17, -20, 17, -20,
+ax_anim 1, 0, 155, 15, -18, 15, -18,
+ax_anim 1, 0, 154, 17, -20, 17, -20,
+ax_anim 1, 0, 154, 15, -18, 15, -18,
+ax_anim 1, 0, 153, 8, -9, 8, -9,
+ax_anim 1, 0, 153, 2, -2, 2, -2,
+ax_anim_terminator
+sDoduoAnims_5_5:
+ax_anim 2, 0, 156, 0, 2, 0, 2,
+ax_anim 4, 0, 156, 0, 3, 0, 3,
+ax_anim 1, 2, 156, 0, -3, 0, -3,
+ax_anim 1, 0, 156, 0, -9, 0, -9,
+ax_anim 2, 0, 157, 0, -20, 0, -20,
+ax_anim 4, 1, 157, 0, -18, 0, -18,
+ax_anim 2, 0, 158, 0, -20, 0, -20,
+ax_anim 4, 0, 158, 0, -18, 0, -18,
+ax_anim 2, 0, 157, 0, -20, 0, -20,
+ax_anim 2, 0, 157, 0, -18, 0, -18,
+ax_anim 2, 0, 158, 0, -20, 0, -20,
+ax_anim 1, 0, 158, 0, -18, 0, -18,
+ax_anim 1, 0, 157, 0, -20, 0, -20,
+ax_anim 1, 0, 157, 0, -18, 0, -18,
+ax_anim 1, 0, 156, 0, -9, 0, -9,
+ax_anim 1, 0, 156, 0, -2, 0, -2,
+ax_anim_terminator
+sDoduoAnims_5_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 4, 0, 159, 3, 3, 3, 3,
+ax_anim 1, 2, 159, -3, -3, -3, -3,
+ax_anim 1, 0, 159, -8, -9, -8, -9,
+ax_anim 2, 0, 160, -17, -20, -17, -20,
+ax_anim 4, 1, 160, -15, -18, -15, -18,
+ax_anim 2, 0, 161, -17, -20, -17, -20,
+ax_anim 4, 0, 161, -15, -18, -15, -18,
+ax_anim 2, 0, 160, -17, -20, -17, -20,
+ax_anim 2, 0, 160, -15, -18, -15, -18,
+ax_anim 2, 0, 161, -17, -20, -17, -20,
+ax_anim 1, 0, 161, -15, -18, -15, -18,
+ax_anim 1, 0, 160, -17, -20, -17, -20,
+ax_anim 1, 0, 160, -15, -18, -15, -18,
+ax_anim 1, 0, 159, -8, -9, -8, -9,
+ax_anim 1, 0, 159, -2, -2, -2, -2,
+ax_anim_terminator
+sDoduoAnims_5_7:
+ax_anim 2, 0, 162, 2, 0, 2, 0,
+ax_anim 4, 0, 162, 3, 0, 3, 0,
+ax_anim 1, 2, 162, -3, 0, -3, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 163, -12, 0, -12, 0,
+ax_anim 4, 1, 163, -10, 0, -10, 0,
+ax_anim 2, 0, 164, -12, 0, -12, 0,
+ax_anim 4, 0, 164, -10, 0, -10, 0,
+ax_anim 2, 0, 163, -12, 0, -12, 0,
+ax_anim 2, 0, 163, -10, 0, -10, 0,
+ax_anim 2, 0, 164, -12, 0, -12, 0,
+ax_anim 1, 0, 164, -10, 0, -10, 0,
+ax_anim 1, 0, 163, -12, 0, -12, 0,
+ax_anim 1, 0, 163, -10, 0, -10, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 1, 0, 162, -2, 0, -2, 0,
+ax_anim_terminator
+sDoduoAnims_5_8:
+ax_anim 2, 0, 165, 2, -2, 2, -2,
+ax_anim 4, 0, 165, 3, -3, 3, -3,
+ax_anim 1, 2, 165, -3, 3, -3, 3,
+ax_anim 1, 0, 165, -8, 9, -8, 9,
+ax_anim 2, 0, 166, -15, 18, -15, 18,
+ax_anim 4, 1, 166, -13, 16, -13, 16,
+ax_anim 2, 0, 167, -15, 18, -15, 18,
+ax_anim 4, 0, 167, -13, 16, -13, 16,
+ax_anim 2, 0, 166, -15, 18, -15, 18,
+ax_anim 2, 0, 166, -13, 16, -13, 16,
+ax_anim 2, 0, 167, -15, 18, -15, 18,
+ax_anim 1, 0, 167, -13, 16, -13, 16,
+ax_anim 1, 0, 166, -15, 18, -15, 18,
+ax_anim 1, 0, 166, -13, 16, -13, 16,
+ax_anim 1, 0, 165, -8, 9, -8, 9,
+ax_anim 1, 0, 165, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sDoduoAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sDoduoAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sDoduoAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sDoduoAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sDoduoAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sDoduoAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sDoduoAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sDoduoAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sDoduoAnims_8_1:
+ax_anim 40, 0, 194, 0, 0, 0, 0,
+ax_anim 6, 0, 195, 0, 0, 0, 0,
+ax_anim 12, 0, 194, 0, 0, 0, 0,
+ax_anim 6, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_8_2:
+ax_anim 40, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 198, 0, 0, 0, 0,
+ax_anim 12, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_8_3:
+ax_anim 40, 0, 200, 0, 0, 0, 0,
+ax_anim 6, 0, 201, 0, 0, 0, 0,
+ax_anim 12, 0, 200, 0, 0, 0, 0,
+ax_anim 6, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_8_4:
+ax_anim 40, 0, 203, 0, 0, 0, 0,
+ax_anim 6, 0, 204, 0, 0, 0, 0,
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_8_5:
+ax_anim 40, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_8_6:
+ax_anim 40, 0, 209, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 209, 0, 0, 0, 0,
+ax_anim 6, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_8_7:
+ax_anim 40, 0, 212, 0, 0, 0, 0,
+ax_anim 6, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 6, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_8_8:
+ax_anim 40, 0, 215, 0, 0, 0, 0,
+ax_anim 6, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_9_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 6, 3, 6, 3,
+ax_anim 2, 0, 220, 8, 9, 8, 9,
+ax_anim 2, 0, 221, 7, 18, 7, 18,
+ax_anim 3, 0, 222, 0, 21, 0, 21,
+ax_anim 2, 3, 223, -7, 18, -7, 18,
+ax_anim 2, 0, 224, -8, 9, -8, 9,
+ax_anim 1, 0, 225, -6, 3, -6, 3,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_9_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 219, 18, 4, 18, 4,
+ax_anim 2, 0, 220, 23, 12, 23, 12,
+ax_anim 3, 0, 221, 22, 21, 22, 21,
+ax_anim 2, 3, 222, 13, 21, 13, 21,
+ax_anim 2, 0, 223, 6, 17, 6, 17,
+ax_anim 1, 0, 224, 0, 7, 0, 7,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_9_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 3, -5, 3, -5,
+ax_anim 2, 0, 218, 11, -6, 11, -6,
+ax_anim 2, 0, 219, 18, -6, 18, -6,
+ax_anim 3, 0, 220, 22, 0, 22, 0,
+ax_anim 2, 3, 221, 20, 7, 20, 7,
+ax_anim 2, 0, 222, 12, 8, 12, 8,
+ax_anim 1, 0, 223, 4, 7, 4, 7,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_9_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, -1, -8, -1, -8,
+ax_anim 2, 0, 225, 5, -19, 5, -19,
+ax_anim 2, 0, 218, 12, -24, 12, -24,
+ax_anim 3, 0, 219, 23, -24, 23, -24,
+ax_anim 2, 3, 220, 22, -13, 22, -13,
+ax_anim 2, 0, 221, 17, -4, 17, -4,
+ax_anim 1, 0, 222, 7, 1, 7, 1,
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_9_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, -8, -2, -8, -2,
+ax_anim 2, 0, 224, -11, -12, -11, -12,
+ax_anim 2, 0, 225, -7, -22, -7, -22,
+ax_anim 3, 0, 218, 0, -25, 0, -25,
+ax_anim 2, 3, 219, 7, -22, 7, -22,
+ax_anim 2, 0, 220, 11, -10, 11, -10,
+ax_anim 1, 0, 221, 8, -2, 8, -2,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_9_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, -8, 1, -8,
+ax_anim 2, 0, 219, -5, -19, -5, -19,
+ax_anim 2, 0, 218, -12, -24, -12, -24,
+ax_anim 3, 0, 225, -23, -24, -23, -24,
+ax_anim 2, 3, 224, -22, -13, -22, -13,
+ax_anim 2, 0, 223, -17, -4, -17, -4,
+ax_anim 1, 0, 222, -7, -1, -7, -1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_9_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 219, -3, -5, -3, -5,
+ax_anim 2, 0, 218, -11, -6, -11, -6,
+ax_anim 2, 0, 225, -18, -6, -18, -6,
+ax_anim 3, 0, 224, -22, 0, -22, 0,
+ax_anim 2, 3, 223, -20, 7, -20, 7,
+ax_anim 2, 0, 222, -12, 8, -12, 8,
+ax_anim 1, 0, 221, -4, 7, -4, 7,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_9_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 225, -18, 4, -18, 4,
+ax_anim 2, 0, 224, -23, 12, -23, 12,
+ax_anim 3, 0, 223, -22, 21, -22, 21,
+ax_anim 2, 3, 222, -13, 21, -13, 21,
+ax_anim 2, 0, 221, -6, 17, -6, 17,
+ax_anim 1, 0, 220, 0, 7, 0, 7,
+ax_anim 1, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_10_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 3, 0, 226, 13, 0, 13, 0,
+ax_anim 3, 0, 226, -13, 0, -13, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_10_2:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 3, 0, 227, 13, -13, 13, -13,
+ax_anim 3, 0, 227, -13, 13, -13, 13,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_10_3:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 3, 0, 228, 0, -13, 0, -13,
+ax_anim 3, 0, 228, 0, 13, 0, 13,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_10_4:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 3, 0, 229, -13, -13, -13, -13,
+ax_anim 3, 0, 229, 13, 13, 13, 13,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_10_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 3, 0, 230, 13, 0, 13, 0,
+ax_anim 3, 0, 230, -13, 0, -13, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_10_6:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 3, 0, 231, 13, -13, 13, -13,
+ax_anim 3, 0, 231, -13, 13, -13, 13,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_10_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 3, 0, 232, 0, -13, 0, -13,
+ax_anim 3, 0, 232, 0, 13, 0, 13,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_10_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 3, 0, 233, -13, -13, -13, -13,
+ax_anim 3, 0, 233, 13, 13, 13, 13,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_11_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 243, 0, -20, 0, 0,
+ax_anim 4, 0, 243, 0, -21, 0, 0,
+ax_anim 4, 0, 244, 0, -23, 0, 0,
+ax_anim 3, 0, 244, 0, -22, 0, 0,
+ax_anim 2, 0, 244, 0, -18, 0, 0,
+ax_anim 1, 0, 244, 0, -12, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_11_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 246, 0, -20, 0, 0,
+ax_anim 4, 0, 246, 0, -21, 0, 0,
+ax_anim 4, 0, 247, 0, -23, 0, 0,
+ax_anim 3, 0, 247, 0, -22, 0, 0,
+ax_anim 2, 0, 247, 0, -18, 0, 0,
+ax_anim 1, 0, 247, 0, -12, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_11_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 0, -10, 0, 0,
+ax_anim 2, 0, 249, 0, -16, 0, 0,
+ax_anim 3, 0, 249, 0, -20, 0, 0,
+ax_anim 4, 0, 249, 0, -21, 0, 0,
+ax_anim 4, 0, 250, 0, -23, 0, 0,
+ax_anim 3, 0, 250, 0, -22, 0, 0,
+ax_anim 2, 0, 250, 0, -18, 0, 0,
+ax_anim 1, 0, 250, 0, -12, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_11_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -10, 0, 0,
+ax_anim 2, 0, 252, 0, -16, 0, 0,
+ax_anim 3, 0, 252, 0, -20, 0, 0,
+ax_anim 4, 0, 252, 0, -21, 0, 0,
+ax_anim 4, 0, 253, 0, -22, 0, 0,
+ax_anim 3, 0, 253, 0, -21, 0, 0,
+ax_anim 2, 0, 253, 0, -17, 0, 0,
+ax_anim 1, 0, 253, 0, -11, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_11_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, -10, 0, 0,
+ax_anim 2, 0, 255, 0, -16, 0, 0,
+ax_anim 3, 0, 255, 0, -20, 0, 0,
+ax_anim 4, 0, 255, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 256, 0, -22, 0, 0,
+ax_anim 2, 0, 256, 0, -18, 0, 0,
+ax_anim 1, 0, 256, 0, -12, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_11_6:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -16, 0, 0,
+ax_anim 3, 0, 258, 0, -20, 0, 0,
+ax_anim 4, 0, 258, 0, -21, 0, 0,
+ax_anim 4, 0, 259, 0, -22, 0, 0,
+ax_anim 3, 0, 259, 0, -21, 0, 0,
+ax_anim 2, 0, 259, 0, -17, 0, 0,
+ax_anim 1, 0, 259, 0, -11, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_11_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 261, 0, -10, 0, 0,
+ax_anim 2, 0, 261, 0, -16, 0, 0,
+ax_anim 3, 0, 261, 0, -20, 0, 0,
+ax_anim 4, 0, 261, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -23, 0, 0,
+ax_anim 3, 0, 262, 0, -22, 0, 0,
+ax_anim 2, 0, 262, 0, -18, 0, 0,
+ax_anim 1, 0, 262, 0, -12, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_11_8:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 264, 0, -10, 0, 0,
+ax_anim 2, 0, 264, 0, -16, 0, 0,
+ax_anim 3, 0, 264, 0, -20, 0, 0,
+ax_anim 4, 0, 264, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -23, 0, 0,
+ax_anim 3, 0, 265, 0, -22, 0, 0,
+ax_anim 2, 0, 265, 0, -18, 0, 0,
+ax_anim 1, 0, 265, 0, -12, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_12_1:
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 1, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_12_2:
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 1, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_12_3:
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 1, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_12_4:
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 1, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_12_5:
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 1, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_12_6:
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 1, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_12_7:
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 1, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_12_8:
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 1, 267, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDoduoAnims_13_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_13_2:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_13_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_13_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_13_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_13_6:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_13_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoAnims_13_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sDoduoGfx1:
+.incbin "baserom.gba", 0x89A7E4, 0x200
+sDoduoSprites1:
+ax_sprite sDoduoGfx1, 0x200
+ax_sprite_terminator
+sDoduoGfx2:
+.incbin "baserom.gba", 0x89A9F4, 0x200
+sDoduoSprites2:
+ax_sprite sDoduoGfx2, 0x200
+ax_sprite_terminator
+sDoduoGfx3:
+.incbin "baserom.gba", 0x89AC04, 0x200
+sDoduoSprites3:
+ax_sprite sDoduoGfx3, 0x200
+ax_sprite_terminator
+sDoduoGfx4:
+.incbin "baserom.gba", 0x89AE14, 0x200
+sDoduoSprites4:
+ax_sprite sDoduoGfx4, 0x200
+ax_sprite_terminator
+sDoduoGfx5:
+.incbin "baserom.gba", 0x89B024, 0x200
+sDoduoSprites5:
+ax_sprite sDoduoGfx5, 0x200
+ax_sprite_terminator
+sDoduoGfx6:
+.incbin "baserom.gba", 0x89B234, 0x200
+sDoduoSprites6:
+ax_sprite sDoduoGfx6, 0x200
+ax_sprite_terminator
+sDoduoGfx7:
+.incbin "baserom.gba", 0x89B444, 0x200
+sDoduoSprites7:
+ax_sprite sDoduoGfx7, 0x200
+ax_sprite_terminator
+sDoduoGfx8:
+.incbin "baserom.gba", 0x89B654, 0x200
+sDoduoSprites8:
+ax_sprite sDoduoGfx8, 0x200
+ax_sprite_terminator
+sDoduoGfx9:
+.incbin "baserom.gba", 0x89B864, 0x200
+sDoduoSprites9:
+ax_sprite sDoduoGfx9, 0x200
+ax_sprite_terminator
+sDoduoGfx10:
+.incbin "baserom.gba", 0x89BA74, 0x200
+sDoduoSprites10:
+ax_sprite sDoduoGfx10, 0x200
+ax_sprite_terminator
+sDoduoGfx11:
+.incbin "baserom.gba", 0x89BC84, 0x200
+sDoduoSprites11:
+ax_sprite sDoduoGfx11, 0x200
+ax_sprite_terminator
+sDoduoGfx12:
+.incbin "baserom.gba", 0x89BE94, 0x200
+sDoduoSprites12:
+ax_sprite sDoduoGfx12, 0x200
+ax_sprite_terminator
+sDoduoGfx13:
+.incbin "baserom.gba", 0x89C0A4, 0x200
+sDoduoSprites13:
+ax_sprite sDoduoGfx13, 0x200
+ax_sprite_terminator
+sDoduoGfx14:
+.incbin "baserom.gba", 0x89C2B4, 0x200
+sDoduoSprites14:
+ax_sprite sDoduoGfx14, 0x200
+ax_sprite_terminator
+sDoduoGfx15:
+.incbin "baserom.gba", 0x89C4C4, 0x200
+sDoduoSprites15:
+ax_sprite sDoduoGfx15, 0x200
+ax_sprite_terminator
+sDoduoGfx16:
+.incbin "baserom.gba", 0x89C6D4, 0x20
+sDoduoGfx16_1:
+.incbin "baserom.gba", 0x89C6F4, 0x60
+sDoduoGfx16_2:
+.incbin "baserom.gba", 0x89C754, 0x60
+sDoduoSprites16:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx17:
+.incbin "baserom.gba", 0x89C7F4, 0x40
+sDoduoGfx17_1:
+.incbin "baserom.gba", 0x89C834, 0x60
+sDoduoGfx17_2:
+.incbin "baserom.gba", 0x89C894, 0x60
+sDoduoSprites17:
+ax_sprite sDoduoGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx18:
+.incbin "baserom.gba", 0x89C92C, 0x40
+sDoduoGfx18_1:
+.incbin "baserom.gba", 0x89C96C, 0x60
+sDoduoGfx18_2:
+.incbin "baserom.gba", 0x89C9CC, 0x60
+sDoduoSprites18:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx19:
+.incbin "baserom.gba", 0x89CA6C, 0x40
+sDoduoGfx19_1:
+.incbin "baserom.gba", 0x89CAAC, 0x60
+sDoduoGfx19_2:
+.incbin "baserom.gba", 0x89CB0C, 0x60
+sDoduoSprites19:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx20:
+.incbin "baserom.gba", 0x89CBAC, 0x100
+sDoduoGfx20_1:
+.incbin "baserom.gba", 0x89CCAC, 0x40
+sDoduoSprites20:
+ax_sprite 0, 0x80
+ax_sprite sDoduoGfx20, 0x100
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx20_1, 0x40
+ax_sprite_terminator
+sDoduoGfx21:
+.incbin "baserom.gba", 0x89CD14, 0x20
+sDoduoGfx21_1:
+.incbin "baserom.gba", 0x89CD34, 0x60
+sDoduoGfx21_2:
+.incbin "baserom.gba", 0x89CD94, 0x60
+sDoduoGfx21_3:
+.incbin "baserom.gba", 0x89CDF4, 0x40
+sDoduoSprites21:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDoduoGfx22:
+.incbin "baserom.gba", 0x89CE84, 0x40
+sDoduoGfx22_1:
+.incbin "baserom.gba", 0x89CEC4, 0x60
+sDoduoGfx22_2:
+.incbin "baserom.gba", 0x89CF24, 0x60
+sDoduoGfx22_3:
+.incbin "baserom.gba", 0x89CF84, 0x60
+sDoduoSprites22:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx22_3, 0x60
+ax_sprite_terminator
+sDoduoGfx23:
+.incbin "baserom.gba", 0x89D02C, 0x40
+sDoduoGfx23_1:
+.incbin "baserom.gba", 0x89D06C, 0x60
+sDoduoGfx23_2:
+.incbin "baserom.gba", 0x89D0CC, 0x40
+sDoduoGfx23_3:
+.incbin "baserom.gba", 0x89D10C, 0x40
+sDoduoSprites23:
+ax_sprite sDoduoGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx23_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDoduoGfx24:
+.incbin "baserom.gba", 0x89D194, 0x60
+sDoduoGfx24_1:
+.incbin "baserom.gba", 0x89D1F4, 0x60
+sDoduoGfx24_2:
+.incbin "baserom.gba", 0x89D254, 0x60
+sDoduoSprites24:
+ax_sprite sDoduoGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx25:
+.incbin "baserom.gba", 0x89D2EC, 0x40
+sDoduoGfx25_1:
+.incbin "baserom.gba", 0x89D32C, 0x60
+sDoduoGfx25_2:
+.incbin "baserom.gba", 0x89D38C, 0x60
+sDoduoSprites25:
+ax_sprite sDoduoGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx26:
+.incbin "baserom.gba", 0x89D424, 0x40
+sDoduoGfx26_1:
+.incbin "baserom.gba", 0x89D464, 0x60
+sDoduoGfx26_2:
+.incbin "baserom.gba", 0x89D4C4, 0x60
+sDoduoSprites26:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx27:
+.incbin "baserom.gba", 0x89D564, 0x40
+sDoduoGfx27_1:
+.incbin "baserom.gba", 0x89D5A4, 0xE0
+sDoduoSprites27:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx27_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx28:
+.incbin "baserom.gba", 0x89D6B4, 0x40
+sDoduoGfx28_1:
+.incbin "baserom.gba", 0x89D6F4, 0x60
+sDoduoGfx28_2:
+.incbin "baserom.gba", 0x89D754, 0x60
+sDoduoSprites28:
+ax_sprite sDoduoGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx29:
+.incbin "baserom.gba", 0x89D7EC, 0x100
+sDoduoGfx29_1:
+.incbin "baserom.gba", 0x89D8EC, 0x20
+sDoduoSprites29:
+ax_sprite 0, 0x80
+ax_sprite sDoduoGfx29, 0x100
+ax_sprite 0, 0x60
+ax_sprite sDoduoGfx29_1, 0x20
+ax_sprite_terminator
+sDoduoGfx30:
+.incbin "baserom.gba", 0x89D934, 0x40
+sDoduoGfx30_1:
+.incbin "baserom.gba", 0x89D974, 0x60
+sDoduoGfx30_2:
+.incbin "baserom.gba", 0x89D9D4, 0x60
+sDoduoGfx30_3:
+.incbin "baserom.gba", 0x89DA34, 0x40
+sDoduoSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDoduoGfx31:
+.incbin "baserom.gba", 0x89DAC4, 0x40
+sDoduoGfx31_1:
+.incbin "baserom.gba", 0x89DB04, 0x60
+sDoduoGfx31_2:
+.incbin "baserom.gba", 0x89DB64, 0x60
+sDoduoGfx31_3:
+.incbin "baserom.gba", 0x89DBC4, 0x60
+sDoduoSprites31:
+ax_sprite sDoduoGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx31_3, 0x60
+ax_sprite_terminator
+sDoduoGfx32:
+.incbin "baserom.gba", 0x89DC64, 0x40
+sDoduoGfx32_1:
+.incbin "baserom.gba", 0x89DCA4, 0x60
+sDoduoGfx32_2:
+.incbin "baserom.gba", 0x89DD04, 0x60
+sDoduoGfx32_3:
+.incbin "baserom.gba", 0x89DD64, 0x40
+sDoduoSprites32:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDoduoGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDoduoGfx33:
+.incbin "baserom.gba", 0x89DDF4, 0x60
+sDoduoGfx33_1:
+.incbin "baserom.gba", 0x89DE54, 0x60
+sDoduoGfx33_2:
+.incbin "baserom.gba", 0x89DEB4, 0x60
+sDoduoSprites33:
+ax_sprite sDoduoGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx34:
+.incbin "baserom.gba", 0x89DF4C, 0x40
+sDoduoGfx34_1:
+.incbin "baserom.gba", 0x89DF8C, 0x60
+sDoduoGfx34_2:
+.incbin "baserom.gba", 0x89DFEC, 0x60
+sDoduoSprites34:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx35:
+.incbin "baserom.gba", 0x89E08C, 0x40
+sDoduoGfx35_1:
+.incbin "baserom.gba", 0x89E0CC, 0x60
+sDoduoGfx35_2:
+.incbin "baserom.gba", 0x89E12C, 0x60
+sDoduoSprites35:
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDoduoGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDoduoGfx36:
+.incbin "baserom.gba", 0x89E1CC, 0x200
+sDoduoSprites36:
+ax_sprite sDoduoGfx36, 0x200
+ax_sprite_terminator
+sDoduoGfx37:
+.incbin "baserom.gba", 0x89E3DC, 0x200
+sDoduoSprites37:
+ax_sprite sDoduoGfx37, 0x200
+ax_sprite_terminator
+sDoduoGfx38:
+.incbin "baserom.gba", 0x89E5EC, 0x200
+sDoduoSprites38:
+ax_sprite sDoduoGfx38, 0x200
+ax_sprite_terminator
+sDoduoGfx39:
+.incbin "baserom.gba", 0x89E7FC, 0x200
+sDoduoSprites39:
+ax_sprite sDoduoGfx39, 0x200
+ax_sprite_terminator
+sDoduoGfx40:
+.incbin "baserom.gba", 0x89EA0C, 0x200
+sDoduoSprites40:
+ax_sprite sDoduoGfx40, 0x200
+ax_sprite_terminator
+sDoduoGfx41:
+.incbin "baserom.gba", 0x89EC1C, 0x200
+sDoduoSprites41:
+ax_sprite sDoduoGfx41, 0x200
+ax_sprite_terminator
+sDoduoGfx42:
+.incbin "baserom.gba", 0x89EE2C, 0x200
+sDoduoSprites42:
+ax_sprite sDoduoGfx42, 0x200
+ax_sprite_terminator
+sAxPosesDoduo:
+.4byte sDoduoPose1
+.4byte sDoduoPose2
+.4byte sDoduoPose3
+.4byte sDoduoPose4
+.4byte sDoduoPose5
+.4byte sDoduoPose6
+.4byte sDoduoPose7
+.4byte sDoduoPose8
+.4byte sDoduoPose9
+.4byte sDoduoPose10
+.4byte sDoduoPose11
+.4byte sDoduoPose12
+.4byte sDoduoPose13
+.4byte sDoduoPose14
+.4byte sDoduoPose15
+.4byte sDoduoPose16
+.4byte sDoduoPose17
+.4byte sDoduoPose18
+.4byte sDoduoPose19
+.4byte sDoduoPose20
+.4byte sDoduoPose21
+.4byte sDoduoPose22
+.4byte sDoduoPose23
+.4byte sDoduoPose24
+.4byte sDoduoPose25
+.4byte sDoduoPose26
+.4byte sDoduoPose27
+.4byte sDoduoPose28
+.4byte sDoduoPose29
+.4byte sDoduoPose30
+.4byte sDoduoPose31
+.4byte sDoduoPose32
+.4byte sDoduoPose33
+.4byte sDoduoPose34
+.4byte sDoduoPose35
+.4byte sDoduoPose36
+.4byte sDoduoPose37
+.4byte sDoduoPose38
+.4byte sDoduoPose39
+.4byte sDoduoPose40
+.4byte sDoduoPose41
+.4byte sDoduoPose42
+.4byte sDoduoPose43
+.4byte sDoduoPose44
+.4byte sDoduoPose45
+.4byte sDoduoPose46
+.4byte sDoduoPose47
+.4byte sDoduoPose48
+.4byte sDoduoPose49
+.4byte sDoduoPose50
+.4byte sDoduoPose51
+.4byte sDoduoPose52
+.4byte sDoduoPose53
+.4byte sDoduoPose54
+.4byte sDoduoPose55
+.4byte sDoduoPose56
+.4byte sDoduoPose57
+.4byte sDoduoPose58
+.4byte sDoduoPose59
+.4byte sDoduoPose60
+.4byte sDoduoPose61
+.4byte sDoduoPose62
+.4byte sDoduoPose63
+.4byte sDoduoPose64
+.4byte sDoduoPose65
+.4byte sDoduoPose66
+.4byte sDoduoPose67
+.4byte sDoduoPose68
+.4byte sDoduoPose69
+.4byte sDoduoPose70
+.4byte sDoduoPose71
+.4byte sDoduoPose72
+.4byte sDoduoPose73
+.4byte sDoduoPose74
+.4byte sDoduoPose75
+.4byte sDoduoPose76
+.4byte sDoduoPose77
+.4byte sDoduoPose78
+.4byte sDoduoPose79
+.4byte sDoduoPose80
+.4byte sDoduoPose81
+.4byte sDoduoPose82
+.4byte sDoduoPose83
+.4byte sDoduoPose84
+.4byte sDoduoPose85
+.4byte sDoduoPose86
+.4byte sDoduoPose87
+.4byte sDoduoPose88
+.4byte sDoduoPose89
+.4byte sDoduoPose90
+.4byte sDoduoPose91
+.4byte sDoduoPose92
+.4byte sDoduoPose93
+.4byte sDoduoPose94
+.4byte sDoduoPose95
+.4byte sDoduoPose96
+.4byte sDoduoPose97
+.4byte sDoduoPose98
+.4byte sDoduoPose99
+.4byte sDoduoPose100
+.4byte sDoduoPose101
+.4byte sDoduoPose102
+.4byte sDoduoPose103
+.4byte sDoduoPose104
+.4byte sDoduoPose105
+.4byte sDoduoPose106
+.4byte sDoduoPose107
+.4byte sDoduoPose108
+.4byte sDoduoPose109
+.4byte sDoduoPose110
+.4byte sDoduoPose111
+.4byte sDoduoPose112
+.4byte sDoduoPose113
+.4byte sDoduoPose114
+.4byte sDoduoPose115
+.4byte sDoduoPose116
+.4byte sDoduoPose117
+.4byte sDoduoPose118
+.4byte sDoduoPose119
+.4byte sDoduoPose120
+.4byte sDoduoPose121
+.4byte sDoduoPose122
+.4byte sDoduoPose123
+.4byte sDoduoPose124
+.4byte sDoduoPose125
+.4byte sDoduoPose126
+.4byte sDoduoPose127
+.4byte sDoduoPose128
+.4byte sDoduoPose129
+.4byte sDoduoPose130
+.4byte sDoduoPose131
+.4byte sDoduoPose132
+.4byte sDoduoPose133
+.4byte sDoduoPose134
+.4byte sDoduoPose135
+.4byte sDoduoPose136
+.4byte sDoduoPose137
+.4byte sDoduoPose138
+.4byte sDoduoPose139
+.4byte sDoduoPose140
+.4byte sDoduoPose141
+.4byte sDoduoPose142
+.4byte sDoduoPose143
+.4byte sDoduoPose144
+.4byte sDoduoPose145
+.4byte sDoduoPose146
+.4byte sDoduoPose147
+.4byte sDoduoPose148
+.4byte sDoduoPose149
+.4byte sDoduoPose150
+.4byte sDoduoPose151
+.4byte sDoduoPose152
+.4byte sDoduoPose153
+.4byte sDoduoPose154
+.4byte sDoduoPose155
+.4byte sDoduoPose156
+.4byte sDoduoPose157
+.4byte sDoduoPose158
+.4byte sDoduoPose159
+.4byte sDoduoPose160
+.4byte sDoduoPose161
+.4byte sDoduoPose162
+.4byte sDoduoPose163
+.4byte sDoduoPose164
+.4byte sDoduoPose165
+.4byte sDoduoPose166
+.4byte sDoduoPose167
+.4byte sDoduoPose168
+.4byte sDoduoPose169
+.4byte sDoduoPose170
+.4byte sDoduoPose171
+.4byte sDoduoPose172
+.4byte sDoduoPose173
+.4byte sDoduoPose174
+.4byte sDoduoPose175
+.4byte sDoduoPose176
+.4byte sDoduoPose177
+.4byte sDoduoPose178
+.4byte sDoduoPose179
+.4byte sDoduoPose180
+.4byte sDoduoPose181
+.4byte sDoduoPose182
+.4byte sDoduoPose183
+.4byte sDoduoPose184
+.4byte sDoduoPose185
+.4byte sDoduoPose186
+.4byte sDoduoPose187
+.4byte sDoduoPose188
+.4byte sDoduoPose189
+.4byte sDoduoPose190
+.4byte sDoduoPose191
+.4byte sDoduoPose192
+.4byte sDoduoPose193
+.4byte sDoduoPose194
+.4byte sDoduoPose195
+.4byte sDoduoPose196
+.4byte sDoduoPose197
+.4byte sDoduoPose198
+.4byte sDoduoPose199
+.4byte sDoduoPose200
+.4byte sDoduoPose201
+.4byte sDoduoPose202
+.4byte sDoduoPose203
+.4byte sDoduoPose204
+.4byte sDoduoPose205
+.4byte sDoduoPose206
+.4byte sDoduoPose207
+.4byte sDoduoPose208
+.4byte sDoduoPose209
+.4byte sDoduoPose210
+.4byte sDoduoPose211
+.4byte sDoduoPose212
+.4byte sDoduoPose213
+.4byte sDoduoPose214
+.4byte sDoduoPose215
+.4byte sDoduoPose216
+.4byte sDoduoPose217
+.4byte sDoduoPose218
+.4byte sDoduoPose219
+.4byte sDoduoPose220
+.4byte sDoduoPose221
+.4byte sDoduoPose222
+.4byte sDoduoPose223
+.4byte sDoduoPose224
+.4byte sDoduoPose225
+.4byte sDoduoPose226
+.4byte sDoduoPose227
+.4byte sDoduoPose228
+.4byte sDoduoPose229
+.4byte sDoduoPose230
+.4byte sDoduoPose231
+.4byte sDoduoPose232
+.4byte sDoduoPose233
+.4byte sDoduoPose234
+.4byte sDoduoPose235
+.4byte sDoduoPose236
+.4byte sDoduoPose237
+.4byte sDoduoPose238
+.4byte sDoduoPose239
+.4byte sDoduoPose240
+.4byte sDoduoPose241
+.4byte sDoduoPose242
+.4byte sDoduoPose243
+.4byte sDoduoPose244
+.4byte sDoduoPose245
+.4byte sDoduoPose246
+.4byte sDoduoPose247
+.4byte sDoduoPose248
+.4byte sDoduoPose249
+.4byte sDoduoPose250
+.4byte sDoduoPose251
+.4byte sDoduoPose252
+.4byte sDoduoPose253
+.4byte sDoduoPose254
+.4byte sDoduoPose255
+.4byte sDoduoPose256
+.4byte sDoduoPose257
+.4byte sDoduoPose258
+.4byte sDoduoPose259
+.4byte sDoduoPose260
+.4byte sDoduoPose261
+.4byte sDoduoPose262
+.4byte sDoduoPose263
+.4byte sDoduoPose264
+.4byte sDoduoPose265
+.4byte sDoduoPose266
+.4byte sDoduoPose267
+.4byte sDoduoPose268
+.4byte sDoduoPose269
+.4byte sDoduoPose270
+.4byte sDoduoPose271
+.4byte sDoduoPose272
+.4byte sDoduoPose273
+.4byte sDoduoPose274
+.4byte sDoduoPose275
+.4byte sDoduoPose276
+.4byte sDoduoPose277
+.4byte sDoduoPose278
+.4byte sDoduoPose279
+.4byte sDoduoPose280
+.4byte sDoduoPose281
+.4byte sDoduoPose282
+.4byte sDoduoPose283
+.4byte sDoduoPose284
+.4byte sDoduoPose285
+.4byte sDoduoPose286
+.4byte sDoduoPose287
+.4byte sDoduoPose288
+.4byte sDoduoPose289
+.4byte sDoduoPose290
+.4byte sDoduoPose291
+.4byte sDoduoPose292
+.4byte sDoduoPose293
+.4byte sDoduoPose294
+.4byte sDoduoPose295
+.4byte sDoduoPose296
+.4byte sDoduoPose297
+.4byte sDoduoPose298
+sAxPositionsDoduo:
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte    0,  -10, 	 -11,  -10, 	   9,  -10, 	  -1,   -6
+.2byte   -1,  -10, 	 -13,  -10, 	   7,  -10, 	  -1,   -6
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte    3,  -10, 	  10,  -11, 	  -3,   -8, 	   0,   -7
+.2byte    6,   -9, 	  12,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    6,  -13, 	   9,  -16, 	   9,   -8, 	  -1,   -6
+.2byte    6,  -13, 	  10,  -15, 	   9,   -9, 	  -1,   -6
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    3,  -15, 	  -4,  -18, 	  12,  -12, 	  -1,   -7
+.2byte    2,  -15, 	  -5,  -18, 	  10,  -12, 	  -1,   -7
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	   8,  -16, 	 -12,  -14, 	  -1,   -8
+.2byte   -1,  -11, 	  10,  -16, 	 -10,  -14, 	  -1,   -7
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   2,  -18, 	 -14,  -12, 	  -1,   -7
+.2byte   -4,  -15, 	   3,  -18, 	 -12,  -12, 	  -1,   -7
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -8,  -13, 	 -11,  -16, 	 -11,   -8, 	  -1,   -6
+.2byte   -8,  -13, 	 -12,  -15, 	 -11,   -9, 	  -1,   -6
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -5,  -10, 	 -12,  -11, 	   1,   -8, 	  -2,   -7
+.2byte   -8,   -9, 	 -14,  -11, 	  -1,   -8, 	  -2,   -6
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte    1,  -12, 	 -10,  -12, 	  10,  -12, 	   0,   -8
+.2byte   -1,  -12, 	 -13,  -12, 	   7,  -12, 	  -1,   -8
+.2byte   -1,   -1, 	  -6,   -1, 	   4,    1, 	  -1,   -6
+.2byte   -1,   -4, 	  -6,  -11, 	   4,    0, 	  -1,   -5
+.2byte    4,  -13, 	  11,  -14, 	  -2,  -11, 	   0,   -9
+.2byte    3,  -12, 	  10,  -13, 	  -3,  -10, 	   0,   -9
+.2byte    6,  -11, 	  12,  -13, 	  -1,  -10, 	   0,   -8
+.2byte    6,   -6, 	  12,   -3, 	   5,    1, 	   0,   -8
+.2byte    6,   -6, 	  11,   -4, 	   2,   -8, 	  -1,   -7
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    6,  -14, 	   9,  -17, 	   9,   -9, 	  -1,   -7
+.2byte    6,  -14, 	  10,  -16, 	   9,  -10, 	  -1,   -7
+.2byte   12,   -6, 	  13,   -4, 	  14,   -7, 	  -2,   -8
+.2byte   10,   -8, 	  14,   -6, 	   8,  -12, 	   0,   -8
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    3,  -16, 	  -4,  -19, 	  12,  -13, 	  -1,   -8
+.2byte    2,  -16, 	  -5,  -19, 	  10,  -13, 	  -1,   -8
+.2byte   10,  -15, 	   5,  -18, 	  12,  -13, 	   0,   -8
+.2byte    3,  -13, 	   3,  -16, 	   9,  -14, 	   0,   -7
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte   -1,  -12, 	   8,  -17, 	 -12,  -15, 	  -1,   -9
+.2byte   -1,  -12, 	  10,  -17, 	 -10,  -15, 	  -1,   -8
+.2byte   -1,  -15, 	   4,  -14, 	  -5,  -12, 	  -1,   -8
+.2byte   -1,   -9, 	   3,   -8, 	  -6,  -12, 	  -1,   -6
+.2byte   -3,  -16, 	   5,  -19, 	 -11,  -14, 	   0,   -8
+.2byte   -4,  -16, 	   3,  -19, 	 -13,  -13, 	   0,   -8
+.2byte   -3,  -16, 	   4,  -19, 	 -11,  -13, 	   0,   -8
+.2byte  -11,  -15, 	  -6,  -18, 	 -13,  -13, 	  -1,   -8
+.2byte   -4,  -13, 	  -4,  -16, 	 -10,  -14, 	  -1,   -7
+.2byte   -6,  -15, 	  -9,  -18, 	  -9,  -11, 	   0,   -8
+.2byte   -7,  -14, 	 -10,  -17, 	 -10,   -9, 	   0,   -7
+.2byte   -7,  -14, 	 -11,  -16, 	 -10,  -10, 	   0,   -7
+.2byte  -13,   -6, 	 -14,   -4, 	 -15,   -7, 	   1,   -8
+.2byte  -11,   -8, 	 -15,   -6, 	  -9,  -12, 	  -1,   -8
+.2byte   -5,  -13, 	 -12,  -14, 	   1,  -11, 	  -1,   -9
+.2byte   -4,  -12, 	 -11,  -13, 	   2,  -10, 	  -1,   -9
+.2byte   -7,  -11, 	 -13,  -13, 	   0,  -10, 	  -1,   -8
+.2byte   -7,   -6, 	 -13,   -3, 	  -6,    1, 	  -1,   -8
+.2byte   -7,   -6, 	 -12,   -4, 	  -3,   -8, 	   0,   -7
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte    0,  -10, 	 -11,  -10, 	   9,  -10, 	  -1,   -6
+.2byte   -1,  -10, 	 -13,  -10, 	   7,  -10, 	  -1,   -6
+.2byte   -1,   -3, 	  -7,   -1, 	   3,   -3, 	  -1,   -7
+.2byte   -2,   -3, 	  -7,   -3, 	   3,   -1, 	  -2,   -8
+.2byte   -1,   -4, 	  -6,  -11, 	   4,    0, 	  -1,   -5
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte    3,  -10, 	  10,  -11, 	  -3,   -8, 	   0,   -7
+.2byte    6,   -9, 	  12,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    9,   -2, 	  12,   -1, 	   5,   -1, 	  -1,   -8
+.2byte    6,   -6, 	  12,   -3, 	   5,    1, 	   0,   -8
+.2byte    5,   -6, 	   9,  -12, 	   5,    0, 	  -2,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    6,  -13, 	   9,  -16, 	   9,   -8, 	  -1,   -6
+.2byte    6,  -13, 	  10,  -15, 	   9,   -9, 	  -1,   -6
+.2byte   12,   -6, 	  13,   -4, 	  14,   -7, 	  -2,   -8
+.2byte   13,   -7, 	  13,   -9, 	  14,   -5, 	  -1,   -8
+.2byte    9,   -9, 	   6,  -14, 	  13,   -4, 	   0,   -6
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    3,  -15, 	  -4,  -18, 	  12,  -12, 	  -1,   -7
+.2byte    2,  -15, 	  -5,  -18, 	  10,  -12, 	  -1,   -7
+.2byte    9,  -17, 	   2,  -17, 	  12,  -15, 	  -1,   -8
+.2byte   10,  -15, 	   5,  -18, 	  12,  -13, 	   0,   -8
+.2byte    3,  -13, 	   3,  -18, 	  12,   -9, 	   0,   -7
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	   8,  -16, 	 -12,  -14, 	  -1,   -8
+.2byte   -1,  -11, 	  10,  -16, 	 -10,  -14, 	  -1,   -7
+.2byte    0,  -16, 	   4,  -13, 	  -6,  -15, 	  -1,  -10
+.2byte   -1,  -16, 	   4,  -15, 	  -5,  -13, 	  -1,   -9
+.2byte    0,  -14, 	   5,  -13, 	  -5,   -9, 	  -1,   -6
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   2,  -18, 	 -14,  -12, 	  -1,   -7
+.2byte   -4,  -15, 	   3,  -18, 	 -12,  -12, 	  -1,   -7
+.2byte  -11,  -17, 	  -4,  -17, 	 -14,  -15, 	  -1,   -8
+.2byte  -12,  -15, 	  -7,  -18, 	 -14,  -13, 	  -2,   -8
+.2byte   -5,  -13, 	  -5,  -18, 	 -14,   -9, 	  -2,   -7
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -8,  -13, 	 -11,  -16, 	 -11,   -8, 	  -1,   -6
+.2byte   -8,  -13, 	 -12,  -15, 	 -11,   -9, 	  -1,   -6
+.2byte  -14,   -6, 	 -15,   -4, 	 -16,   -7, 	   0,   -8
+.2byte  -15,   -7, 	 -15,   -9, 	 -16,   -5, 	  -1,   -8
+.2byte  -11,   -9, 	  -8,  -14, 	 -15,   -4, 	  -2,   -6
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -5,  -10, 	 -12,  -11, 	   1,   -8, 	  -2,   -7
+.2byte   -8,   -9, 	 -14,  -11, 	  -1,   -8, 	  -2,   -6
+.2byte  -11,   -2, 	 -14,   -1, 	  -7,   -1, 	  -1,   -8
+.2byte   -8,   -6, 	 -14,   -3, 	  -7,    1, 	  -2,   -8
+.2byte   -7,   -6, 	 -11,  -12, 	  -7,    0, 	   0,   -8
+.2byte   -1,   -4, 	  -6,  -11, 	   4,    0, 	  -1,   -5
+.2byte   -8,   -5, 	 -12,  -11, 	  -8,    1, 	  -1,   -7
+.2byte  -11,   -9, 	  -8,  -14, 	 -15,   -4, 	  -2,   -6
+.2byte   -6,  -12, 	  -6,  -17, 	 -15,   -8, 	  -3,   -6
+.2byte    0,  -15, 	   5,  -14, 	  -5,  -10, 	  -1,   -7
+.2byte    4,  -12, 	   4,  -17, 	  13,   -8, 	   1,   -6
+.2byte    9,   -9, 	   6,  -14, 	  13,   -4, 	   0,   -6
+.2byte    6,   -5, 	  10,  -11, 	   6,    1, 	  -1,   -7
+.2byte   -4,  -16, 	 -15,  -16, 	   5,  -16, 	  -4,  -12
+.2byte   -6,  -17, 	 -13,  -18, 	   0,  -15, 	  -2,  -13
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   5,  -21, 	 -15,  -19, 	  -5,  -12
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -17, 	  11,  -18, 	  -2,  -15, 	   0,  -13
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,  -11, 	   4,    0, 	  -1,   -5
+.2byte    1,   -5, 	  -5,    0, 	   4,   -9, 	   0,   -7
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte    7,   -5, 	  11,  -11, 	   7,    1, 	   0,   -7
+.2byte    7,   -5, 	  12,   -3, 	   3,   -7, 	   0,   -6
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte   11,   -9, 	   8,  -14, 	  15,   -4, 	   2,   -6
+.2byte   11,   -8, 	  15,   -6, 	   9,  -12, 	   1,   -8
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    4,  -12, 	   4,  -17, 	  13,   -8, 	   1,   -6
+.2byte    3,  -13, 	   3,  -16, 	   9,  -14, 	   0,   -7
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte    0,  -14, 	   5,  -13, 	  -5,   -9, 	  -1,   -6
+.2byte   -1,  -10, 	   3,   -9, 	  -6,  -13, 	  -1,   -7
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -6,  -12, 	  -6,  -17, 	 -15,   -8, 	  -3,   -6
+.2byte   -5,  -13, 	  -5,  -16, 	 -11,  -14, 	  -2,   -7
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte  -13,   -9, 	 -10,  -14, 	 -17,   -4, 	  -4,   -6
+.2byte  -13,   -8, 	 -17,   -6, 	 -11,  -12, 	  -3,   -8
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -9,   -5, 	 -13,  -11, 	  -9,    1, 	  -2,   -7
+.2byte   -9,   -5, 	 -14,   -3, 	  -5,   -7, 	  -2,   -6
+.2byte   -1,   -5, 	 -11,   -5, 	   8,   -4, 	  -1,   -7
+.2byte   -1,   -5, 	 -11,   -4, 	   8,   -5, 	  -1,   -7
+.2byte   -4,  -16, 	 -15,  -16, 	   5,  -16, 	  -4,  -12
+.2byte   -6,  -17, 	 -13,  -18, 	   0,  -15, 	  -2,  -13
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   5,  -21, 	 -15,  -19, 	  -5,  -12
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -17, 	  11,  -18, 	  -2,  -15, 	   0,  -13
+.2byte   -1,  -13, 	  -9,  -19, 	   8,   -5, 	  -1,   -8
+.2byte    2,  -12, 	   7,  -14, 	  -3,   -4, 	   0,   -7
+.2byte    3,  -14, 	   1,  -20, 	   8,   -5, 	  -2,   -9
+.2byte    1,  -15, 	 -11,  -17, 	  13,   -6, 	  -2,   -8
+.2byte    0,  -11, 	   9,  -17, 	 -10,   -6, 	   0,   -7
+.2byte   -2,  -15, 	  10,  -17, 	 -14,   -6, 	   1,   -8
+.2byte   -4,  -14, 	  -2,  -20, 	  -9,   -5, 	   1,   -9
+.2byte   -3,  -12, 	  -8,  -14, 	   2,   -4, 	  -1,   -7
+.2byte   -4,  -16, 	 -15,  -16, 	   5,  -16, 	  -4,  -12
+.2byte   -6,  -17, 	 -13,  -18, 	   0,  -15, 	  -2,  -13
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   5,  -21, 	 -15,  -19, 	  -5,  -12
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -17, 	  11,  -18, 	  -2,  -15, 	   0,  -13
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,  -11, 	   4,    0, 	  -1,   -5
+.2byte    1,   -5, 	  -5,    0, 	   4,   -9, 	   0,   -7
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte    7,   -5, 	  11,  -11, 	   7,    1, 	   0,   -7
+.2byte    7,   -5, 	  12,   -3, 	   3,   -7, 	   0,   -6
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte   10,   -9, 	   7,  -14, 	  14,   -4, 	   1,   -6
+.2byte   10,   -8, 	  14,   -6, 	   8,  -12, 	   0,   -8
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    4,  -12, 	   4,  -17, 	  13,   -8, 	   1,   -6
+.2byte    3,  -13, 	   3,  -16, 	   9,  -14, 	   0,   -7
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte    0,  -14, 	   5,  -13, 	  -5,   -9, 	  -1,   -6
+.2byte   -1,  -10, 	   3,   -9, 	  -6,  -13, 	  -1,   -7
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -6,  -12, 	  -6,  -17, 	 -15,   -8, 	  -3,   -6
+.2byte   -5,  -13, 	  -5,  -16, 	 -11,  -14, 	  -2,   -7
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte  -12,   -9, 	  -9,  -14, 	 -16,   -4, 	  -3,   -6
+.2byte  -12,   -8, 	 -16,   -6, 	 -10,  -12, 	  -2,   -8
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -9,   -5, 	 -13,  -11, 	  -9,    1, 	  -2,   -7
+.2byte   -9,   -5, 	 -14,   -3, 	  -5,   -7, 	  -2,   -6
+.2byte   -1,   -3, 	  -7,   -1, 	   3,   -3, 	  -1,   -7
+.2byte   -9,   -1, 	 -12,    0, 	  -5,    0, 	   1,   -7
+.2byte  -14,   -5, 	 -15,   -3, 	 -16,   -6, 	   0,   -7
+.2byte  -11,  -17, 	  -4,  -17, 	 -14,  -15, 	  -1,   -8
+.2byte    0,  -14, 	   4,  -11, 	  -6,  -13, 	  -1,   -8
+.2byte    9,  -17, 	   2,  -17, 	  12,  -15, 	  -1,   -8
+.2byte   12,   -5, 	  13,   -3, 	  14,   -6, 	  -2,   -7
+.2byte    7,   -1, 	  10,    0, 	   3,    0, 	  -3,   -7
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -4,  -16, 	 -15,  -16, 	   5,  -16, 	  -4,  -12
+.2byte   -6,  -17, 	 -13,  -18, 	   0,  -15, 	  -2,  -13
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   5,  -21, 	 -15,  -19, 	  -5,  -12
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -17, 	  11,  -18, 	  -2,  -15, 	   0,  -13
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,  -11, 	   4,    0, 	  -1,   -5
+.2byte   -1,   -3, 	  -7,   -1, 	   3,   -3, 	  -1,   -7
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte    5,   -6, 	   9,  -12, 	   5,    0, 	  -2,   -8
+.2byte    9,   -2, 	  12,   -1, 	   5,   -1, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    9,   -9, 	   6,  -14, 	  13,   -4, 	   0,   -6
+.2byte   13,   -6, 	  14,   -4, 	  15,   -7, 	  -1,   -8
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    3,  -13, 	   3,  -18, 	  12,   -9, 	   0,   -7
+.2byte    9,  -17, 	   2,  -17, 	  12,  -15, 	  -1,   -8
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte    0,  -14, 	   5,  -13, 	  -5,   -9, 	  -1,   -6
+.2byte    0,  -16, 	   4,  -13, 	  -6,  -15, 	  -1,  -10
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -13, 	  -5,  -18, 	 -14,   -9, 	  -2,   -7
+.2byte  -11,  -17, 	  -4,  -17, 	 -14,  -15, 	  -1,   -8
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte  -11,   -9, 	  -8,  -14, 	 -15,   -4, 	  -2,   -6
+.2byte  -15,   -6, 	 -16,   -4, 	 -17,   -7, 	  -1,   -8
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -7,   -6, 	 -11,  -12, 	  -7,    0, 	   0,   -8
+.2byte  -11,   -2, 	 -14,   -1, 	  -7,   -1, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,  -11, 	   4,    0, 	  -1,   -5
+.2byte   -8,   -5, 	 -12,  -11, 	  -8,    1, 	  -1,   -7
+.2byte  -11,   -9, 	  -8,  -14, 	 -15,   -4, 	  -2,   -6
+.2byte   -6,  -12, 	  -6,  -17, 	 -15,   -8, 	  -3,   -6
+.2byte    0,  -15, 	   5,  -14, 	  -5,  -10, 	  -1,   -7
+.2byte    4,  -12, 	   4,  -17, 	  13,   -8, 	   1,   -6
+.2byte    9,   -9, 	   6,  -14, 	  13,   -4, 	   0,   -6
+.2byte    6,   -5, 	  10,  -11, 	   6,    1, 	  -1,   -7
+.2byte   -4,  -16, 	 -15,  -16, 	   5,  -16, 	  -4,  -12
+.2byte   -6,  -17, 	 -13,  -18, 	   0,  -15, 	  -2,  -13
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   5,  -21, 	 -15,  -19, 	  -5,  -12
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -17, 	  11,  -18, 	  -2,  -15, 	   0,  -13
+.2byte   -1,  -12, 	 -12,  -12, 	   8,  -12, 	  -1,   -8
+.2byte   -6,  -12, 	 -13,  -13, 	   0,  -10, 	  -2,   -8
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -16, 	  -1,   -9
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -12, 	  11,  -13, 	  -2,  -10, 	   0,   -8
+.2byte   -4,  -16, 	 -15,  -16, 	   5,  -16, 	  -4,  -12
+.2byte   -6,  -17, 	 -13,  -18, 	   0,  -15, 	  -2,  -13
+.2byte   -7,  -15, 	 -10,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -4,  -16, 	   4,  -19, 	 -12,  -14, 	  -1,   -8
+.2byte   -5,  -15, 	   5,  -21, 	 -15,  -19, 	  -5,  -12
+.2byte    2,  -16, 	  -6,  -19, 	  10,  -14, 	  -1,   -8
+.2byte    5,  -15, 	   8,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    4,  -17, 	  11,  -18, 	  -2,  -15, 	   0,  -13
+sDoduoAnimTable1:
+.4byte sDoduoAnims_1_1
+.4byte sDoduoAnims_1_2
+.4byte sDoduoAnims_1_3
+.4byte sDoduoAnims_1_4
+.4byte sDoduoAnims_1_5
+.4byte sDoduoAnims_1_6
+.4byte sDoduoAnims_1_7
+.4byte sDoduoAnims_1_8
+sDoduoAnimTable2:
+.4byte sDoduoAnims_2_1
+.4byte sDoduoAnims_2_2
+.4byte sDoduoAnims_2_3
+.4byte sDoduoAnims_2_4
+.4byte sDoduoAnims_2_5
+.4byte sDoduoAnims_2_6
+.4byte sDoduoAnims_2_7
+.4byte sDoduoAnims_2_8
+sDoduoAnimTable3:
+.4byte sDoduoAnims_3_1
+.4byte sDoduoAnims_3_2
+.4byte sDoduoAnims_3_3
+.4byte sDoduoAnims_3_4
+.4byte sDoduoAnims_3_5
+.4byte sDoduoAnims_3_6
+.4byte sDoduoAnims_3_7
+.4byte sDoduoAnims_3_8
+sDoduoAnimTable4:
+.4byte sDoduoAnims_4_1
+.4byte sDoduoAnims_4_2
+.4byte sDoduoAnims_4_3
+.4byte sDoduoAnims_4_4
+.4byte sDoduoAnims_4_5
+.4byte sDoduoAnims_4_6
+.4byte sDoduoAnims_4_7
+.4byte sDoduoAnims_4_8
+sDoduoAnimTable5:
+.4byte sDoduoAnims_5_1
+.4byte sDoduoAnims_5_2
+.4byte sDoduoAnims_5_3
+.4byte sDoduoAnims_5_4
+.4byte sDoduoAnims_5_5
+.4byte sDoduoAnims_5_6
+.4byte sDoduoAnims_5_7
+.4byte sDoduoAnims_5_8
+sDoduoAnimTable6:
+.4byte sDoduoAnims_6_1
+.4byte sDoduoAnims_6_1
+.4byte sDoduoAnims_6_1
+.4byte sDoduoAnims_6_1
+.4byte sDoduoAnims_6_1
+.4byte sDoduoAnims_6_1
+.4byte sDoduoAnims_6_1
+.4byte sDoduoAnims_6_1
+sDoduoAnimTable7:
+.4byte sDoduoAnims_7_1
+.4byte sDoduoAnims_7_2
+.4byte sDoduoAnims_7_3
+.4byte sDoduoAnims_7_4
+.4byte sDoduoAnims_7_5
+.4byte sDoduoAnims_7_6
+.4byte sDoduoAnims_7_7
+.4byte sDoduoAnims_7_8
+sDoduoAnimTable8:
+.4byte sDoduoAnims_8_1
+.4byte sDoduoAnims_8_2
+.4byte sDoduoAnims_8_3
+.4byte sDoduoAnims_8_4
+.4byte sDoduoAnims_8_5
+.4byte sDoduoAnims_8_6
+.4byte sDoduoAnims_8_7
+.4byte sDoduoAnims_8_8
+sDoduoAnimTable9:
+.4byte sDoduoAnims_9_1
+.4byte sDoduoAnims_9_2
+.4byte sDoduoAnims_9_3
+.4byte sDoduoAnims_9_4
+.4byte sDoduoAnims_9_5
+.4byte sDoduoAnims_9_6
+.4byte sDoduoAnims_9_7
+.4byte sDoduoAnims_9_8
+sDoduoAnimTable10:
+.4byte sDoduoAnims_10_1
+.4byte sDoduoAnims_10_2
+.4byte sDoduoAnims_10_3
+.4byte sDoduoAnims_10_4
+.4byte sDoduoAnims_10_5
+.4byte sDoduoAnims_10_6
+.4byte sDoduoAnims_10_7
+.4byte sDoduoAnims_10_8
+sDoduoAnimTable11:
+.4byte sDoduoAnims_11_1
+.4byte sDoduoAnims_11_2
+.4byte sDoduoAnims_11_3
+.4byte sDoduoAnims_11_4
+.4byte sDoduoAnims_11_5
+.4byte sDoduoAnims_11_6
+.4byte sDoduoAnims_11_7
+.4byte sDoduoAnims_11_8
+sDoduoAnimTable12:
+.4byte sDoduoAnims_12_1
+.4byte sDoduoAnims_12_2
+.4byte sDoduoAnims_12_3
+.4byte sDoduoAnims_12_4
+.4byte sDoduoAnims_12_5
+.4byte sDoduoAnims_12_6
+.4byte sDoduoAnims_12_7
+.4byte sDoduoAnims_12_8
+sDoduoAnimTable13:
+.4byte sDoduoAnims_13_1
+.4byte sDoduoAnims_13_2
+.4byte sDoduoAnims_13_3
+.4byte sDoduoAnims_13_4
+.4byte sDoduoAnims_13_5
+.4byte sDoduoAnims_13_6
+.4byte sDoduoAnims_13_7
+.4byte sDoduoAnims_13_8
+sAxAnimationsDoduo:
+.4byte sDoduoAnimTable1
+.4byte sDoduoAnimTable2
+.4byte sDoduoAnimTable3
+.4byte sDoduoAnimTable4
+.4byte sDoduoAnimTable5
+.4byte sDoduoAnimTable6
+.4byte sDoduoAnimTable7
+.4byte sDoduoAnimTable8
+.4byte sDoduoAnimTable9
+.4byte sDoduoAnimTable10
+.4byte sDoduoAnimTable11
+.4byte sDoduoAnimTable12
+.4byte sDoduoAnimTable13
+sAxSpritesDoduo:
+.4byte sDoduoSprites1
+.4byte sDoduoSprites2
+.4byte sDoduoSprites3
+.4byte sDoduoSprites4
+.4byte sDoduoSprites5
+.4byte sDoduoSprites6
+.4byte sDoduoSprites7
+.4byte sDoduoSprites8
+.4byte sDoduoSprites9
+.4byte sDoduoSprites10
+.4byte sDoduoSprites11
+.4byte sDoduoSprites12
+.4byte sDoduoSprites13
+.4byte sDoduoSprites14
+.4byte sDoduoSprites15
+.4byte sDoduoSprites16
+.4byte sDoduoSprites17
+.4byte sDoduoSprites18
+.4byte sDoduoSprites19
+.4byte sDoduoSprites20
+.4byte sDoduoSprites21
+.4byte sDoduoSprites22
+.4byte sDoduoSprites23
+.4byte sDoduoSprites24
+.4byte sDoduoSprites25
+.4byte sDoduoSprites26
+.4byte sDoduoSprites27
+.4byte sDoduoSprites28
+.4byte sDoduoSprites29
+.4byte sDoduoSprites30
+.4byte sDoduoSprites31
+.4byte sDoduoSprites32
+.4byte sDoduoSprites33
+.4byte sDoduoSprites34
+.4byte sDoduoSprites35
+.4byte sDoduoSprites36
+.4byte sDoduoSprites37
+.4byte sDoduoSprites38
+.4byte sDoduoSprites39
+.4byte sDoduoSprites40
+.4byte sDoduoSprites41
+.4byte sDoduoSprites42
+sAxMainDoduo:
+ax_main sAxPosesDoduo, sAxAnimationsDoduo, 13, sAxSpritesDoduo, sAxPositionsDoduo

--- a/data/ax/donphan.inc
+++ b/data/ax/donphan.inc
@@ -1,0 +1,2679 @@
+.global gAxDonphan
+gAxDonphan:
+ax_siro sAxMainDonphan
+sDonphanPose1:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose2:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose4:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose5:
+ax_pose 4, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose6:
+ax_pose 5, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose7:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose8:
+ax_pose 7, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose9:
+ax_pose 8, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose10:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose11:
+ax_pose 10, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose12:
+ax_pose 11, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose13:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose14:
+ax_pose 13, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose15:
+ax_pose 14, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose16:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose17:
+ax_pose 10, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose18:
+ax_pose 11, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose22:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose23:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose24:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose25:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose26:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose27:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose28:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose29:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose30:
+ax_pose 4, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose31:
+ax_pose 5, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose32:
+ax_pose 16, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose33:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose34:
+ax_pose 7, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose35:
+ax_pose 8, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose36:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose37:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose38:
+ax_pose 10, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose39:
+ax_pose 11, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose40:
+ax_pose 18, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose41:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose42:
+ax_pose 13, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose43:
+ax_pose 14, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose44:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose45:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose46:
+ax_pose 10, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose47:
+ax_pose 11, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose48:
+ax_pose 18, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose49:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose50:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose51:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose52:
+ax_pose 17, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose53:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose54:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose55:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose56:
+ax_pose 16, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose57:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose58:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose59:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose60:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose61:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose62:
+ax_pose 4, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose63:
+ax_pose 5, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose64:
+ax_pose 16, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose65:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose66:
+ax_pose 7, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose67:
+ax_pose 8, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose68:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose69:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose70:
+ax_pose 10, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose71:
+ax_pose 11, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose72:
+ax_pose 18, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose73:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose74:
+ax_pose 13, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose75:
+ax_pose 14, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose76:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose77:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose78:
+ax_pose 10, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose79:
+ax_pose 11, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose80:
+ax_pose 18, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose81:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose82:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose83:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose84:
+ax_pose 17, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose85:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose86:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose87:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose88:
+ax_pose 16, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose89:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose90:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose91:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose92:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose93:
+ax_pose 16, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose94:
+ax_pose 21, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose95:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose96:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose97:
+ax_pose 22, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose98:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose99:
+ax_pose 18, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose100:
+ax_pose 23, 0x01f4, 0x50fd, 0x5c00
+ax_pose 24, 0x41e4, 0x90f5, 0x5c04
+ax_pose 25, 0x81f4, 0x10f5, 0x5c0c
+ax_pose 26, 0x01dc, 0x1105, 0x5c0e
+ax_pose_terminator
+sDonphanPose101:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose102:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose103:
+ax_pose 27, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose104:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose105:
+ax_pose 18, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose106:
+ax_pose 23, 0x01f4, 0x40f4, 0x5c00
+ax_pose 24, 0x41e4, 0x80ec, 0x5c04
+ax_pose 25, 0x81f4, 0x0104, 0x5c0c
+ax_pose 26, 0x01dc, 0x00f4, 0x5c0e
+ax_pose_terminator
+sDonphanPose107:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose108:
+ax_pose 17, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose109:
+ax_pose 22, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose110:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose111:
+ax_pose 16, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose112:
+ax_pose 21, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose113:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose114:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose115:
+ax_pose 28, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose116:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose117:
+ax_pose 21, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose118:
+ax_pose 29, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose119:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose120:
+ax_pose 22, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose121:
+ax_pose 30, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose122:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose123:
+ax_pose 23, 0x01f4, 0x50fd, 0x5c00
+ax_pose 24, 0x41e4, 0x90f5, 0x5c04
+ax_pose 25, 0x81f4, 0x10f5, 0x5c0c
+ax_pose 26, 0x01dc, 0x1105, 0x5c0e
+ax_pose_terminator
+sDonphanPose124:
+ax_pose 31, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose125:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose126:
+ax_pose 27, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose127:
+ax_pose 32, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose128:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose129:
+ax_pose 23, 0x01f4, 0x40f4, 0x5c00
+ax_pose 24, 0x41e4, 0x80ec, 0x5c04
+ax_pose 25, 0x81f4, 0x0104, 0x5c0c
+ax_pose 26, 0x01dc, 0x00f4, 0x5c0e
+ax_pose_terminator
+sDonphanPose130:
+ax_pose 31, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose131:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose132:
+ax_pose 22, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose133:
+ax_pose 30, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose134:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose135:
+ax_pose 21, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose136:
+ax_pose 29, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose137:
+ax_pose 33, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sDonphanPose138:
+ax_pose 34, 0x01ef, 0x80ef, 0x5c00
+ax_pose_terminator
+sDonphanPose139:
+ax_pose 35, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose140:
+ax_pose 36, 0x01e2, 0x90ed, 0x5c00
+ax_pose_terminator
+sDonphanPose141:
+ax_pose 37, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sDonphanPose142:
+ax_pose 38, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sDonphanPose143:
+ax_pose 39, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose144:
+ax_pose 38, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sDonphanPose145:
+ax_pose 37, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sDonphanPose146:
+ax_pose 36, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sDonphanPose147:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose148:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose149:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose150:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose151:
+ax_pose 16, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose152:
+ax_pose 21, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose153:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose154:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose155:
+ax_pose 22, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose156:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose157:
+ax_pose 18, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose158:
+ax_pose 23, 0x01f4, 0x50fd, 0x5c00
+ax_pose 24, 0x41e4, 0x90f5, 0x5c04
+ax_pose 25, 0x81f4, 0x10f5, 0x5c0c
+ax_pose 26, 0x01dc, 0x1105, 0x5c0e
+ax_pose_terminator
+sDonphanPose159:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose160:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose161:
+ax_pose 27, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose162:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose163:
+ax_pose 18, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose164:
+ax_pose 23, 0x01f4, 0x40f4, 0x5c00
+ax_pose 24, 0x41e4, 0x80ec, 0x5c04
+ax_pose 25, 0x81f4, 0x0104, 0x5c0c
+ax_pose 26, 0x01dc, 0x00f4, 0x5c0e
+ax_pose_terminator
+sDonphanPose165:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose166:
+ax_pose 17, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose167:
+ax_pose 22, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose168:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose169:
+ax_pose 16, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose170:
+ax_pose 21, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose171:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose172:
+ax_pose 16, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose173:
+ax_pose 17, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose174:
+ax_pose 18, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose175:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose176:
+ax_pose 18, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose177:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose178:
+ax_pose 16, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose179:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose180:
+ax_pose 21, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose181:
+ax_pose 22, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose182:
+ax_pose 23, 0x01f4, 0x50fd, 0x5c00
+ax_pose 24, 0x41e4, 0x90f5, 0x5c04
+ax_pose 25, 0x81f4, 0x10f5, 0x5c0c
+ax_pose 26, 0x01dc, 0x1105, 0x5c0e
+ax_pose_terminator
+sDonphanPose183:
+ax_pose 27, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose184:
+ax_pose 23, 0x01f4, 0x40f4, 0x5c00
+ax_pose 24, 0x41e4, 0x80ec, 0x5c04
+ax_pose 25, 0x81f4, 0x0104, 0x5c0c
+ax_pose 26, 0x01dc, 0x00f4, 0x5c0e
+ax_pose_terminator
+sDonphanPose185:
+ax_pose 22, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose186:
+ax_pose 21, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose187:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose188:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose189:
+ax_pose 20, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose190:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose191:
+ax_pose 16, 0x01e9, 0x90f2, 0x5c00
+ax_pose_terminator
+sDonphanPose192:
+ax_pose 21, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose193:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose194:
+ax_pose 17, 0x01e9, 0x90f3, 0x5c00
+ax_pose_terminator
+sDonphanPose195:
+ax_pose 22, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose196:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose197:
+ax_pose 18, 0x01eb, 0x90f2, 0x5c00
+ax_pose_terminator
+sDonphanPose198:
+ax_pose 23, 0x01f4, 0x50fd, 0x5c00
+ax_pose 24, 0x41e4, 0x90f5, 0x5c04
+ax_pose 25, 0x81f4, 0x10f5, 0x5c0c
+ax_pose 26, 0x01dc, 0x1105, 0x5c0e
+ax_pose_terminator
+sDonphanPose199:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose200:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose201:
+ax_pose 27, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose202:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose203:
+ax_pose 18, 0x01ea, 0x80ef, 0x5c00
+ax_pose_terminator
+sDonphanPose204:
+ax_pose 23, 0x01f4, 0x40f4, 0x5c00
+ax_pose 24, 0x41e4, 0x80ec, 0x5c04
+ax_pose 25, 0x81f4, 0x0104, 0x5c0c
+ax_pose 26, 0x01dc, 0x00f4, 0x5c0e
+ax_pose_terminator
+sDonphanPose205:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose206:
+ax_pose 17, 0x01e9, 0x80ee, 0x5c00
+ax_pose_terminator
+sDonphanPose207:
+ax_pose 22, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose208:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose209:
+ax_pose 16, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sDonphanPose210:
+ax_pose 21, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose211:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose212:
+ax_pose 16, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose213:
+ax_pose 17, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose214:
+ax_pose 18, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose215:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose216:
+ax_pose 18, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose217:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose218:
+ax_pose 16, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose219:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose220:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose221:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose222:
+ax_pose 9, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose223:
+ax_pose 12, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sDonphanPose224:
+ax_pose 9, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose225:
+ax_pose 6, 0x01eb, 0x90f1, 0x5c00
+ax_pose_terminator
+sDonphanPose226:
+ax_pose 3, 0x01ed, 0x90f1, 0x5c00
+ax_pose_terminator
+.align 2
+sDonphanAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDonphanAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDonphanAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sDonphanAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sDonphanAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 18, -20, 18, -20,
+ax_anim 2, 1, 39, 19, -19, 19, -19,
+ax_anim 2, 0, 39, 18, -20, 18, -20,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 2, 0, 36, 5, -6, 5, -6,
+ax_anim_terminator
+sDonphanAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 1, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sDonphanAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -18, -20, -18, -20,
+ax_anim 2, 1, 47, -19, -19, -19, -19,
+ax_anim 2, 0, 47, -18, -20, -18, -20,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 0, 44, -5, -6, -5, -6,
+ax_anim_terminator
+sDonphanAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sDonphanAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 1, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDonphanAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sDonphanAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 1, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sDonphanAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 1, 67, 16, 1, 16, 1,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 0, 67, 16, 1, 16, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sDonphanAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 18, -20, 18, -20,
+ax_anim 2, 1, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 71, 18, -20, 18, -20,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 68, 5, -6, 5, -6,
+ax_anim_terminator
+sDonphanAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 1, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 0, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sDonphanAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -18, -20, -18, -20,
+ax_anim 2, 1, 79, -19, -19, -19, -19,
+ax_anim 2, 0, 79, -18, -20, -18, -20,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 2, 0, 76, -5, -6, -5, -6,
+ax_anim_terminator
+sDonphanAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -16, 0, -16, 0,
+ax_anim 2, 1, 83, -16, 1, -16, 1,
+ax_anim 2, 0, 83, -16, 0, -16, 0,
+ax_anim 2, 0, 83, -16, 1, -16, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sDonphanAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 1, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDonphanAnims_4_1:
+ax_anim 2, 2, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 0, 4, 0, 4,
+ax_anim 2, 0, 89, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 0, 7, 0, 7,
+ax_anim 2, 1, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 90, -1, 6, -1, 6,
+ax_anim 2, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 90, -1, 6, -1, 6,
+ax_anim 2, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 90, -1, 6, -1, 6,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim_terminator
+sDonphanAnims_4_2:
+ax_anim 2, 2, 92, 2, 2, 2, 2,
+ax_anim 2, 0, 92, 4, 4, 4, 4,
+ax_anim 2, 0, 92, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 7, 7, 7, 7,
+ax_anim 2, 1, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 5, 7, 5, 7,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 5, 7, 5, 7,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 5, 7, 5, 7,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim_terminator
+sDonphanAnims_4_3:
+ax_anim 2, 2, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 4, 0, 4, 0,
+ax_anim 2, 0, 95, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 7, 0, 7, 0,
+ax_anim 2, 1, 96, 6, 0, 6, 0,
+ax_anim 2, 0, 96, 6, -1, 6, -1,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 0, 96, 6, -1, 6, -1,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 0, 96, 6, -1, 6, -1,
+ax_anim 2, 0, 94, 3, 0, 3, 0,
+ax_anim_terminator
+sDonphanAnims_4_4:
+ax_anim 2, 2, 98, 2, -2, 2, -2,
+ax_anim 2, 0, 98, 4, -4, 4, -4,
+ax_anim 2, 0, 98, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 7, -7, 7, -7,
+ax_anim 2, 1, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, 5, -7, 5, -7,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, 5, -7, 5, -7,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, 5, -7, 5, -7,
+ax_anim 2, 0, 97, 3, -3, 3, -3,
+ax_anim_terminator
+sDonphanAnims_4_5:
+ax_anim 2, 2, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 0, -7, 0, -7,
+ax_anim 2, 1, 102, 0, -6, 0, -6,
+ax_anim 2, 0, 102, -1, -6, -1, -6,
+ax_anim 2, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 0, 102, -1, -6, -1, -6,
+ax_anim 2, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 0, 102, -1, -6, -1, -6,
+ax_anim 2, 0, 100, 0, -3, 0, -3,
+ax_anim_terminator
+sDonphanAnims_4_6:
+ax_anim 2, 2, 104, -2, -2, -2, -2,
+ax_anim 2, 0, 104, -4, -4, -4, -4,
+ax_anim 2, 0, 104, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -7, -7, -7, -7,
+ax_anim 2, 1, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, -5, -7, -5, -7,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, -5, -7, -5, -7,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, -5, -7, -5, -7,
+ax_anim 2, 0, 103, -3, -3, -3, -3,
+ax_anim_terminator
+sDonphanAnims_4_7:
+ax_anim 2, 2, 107, -2, 0, -2, 0,
+ax_anim 2, 0, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -7, 0, -7, 0,
+ax_anim 2, 1, 108, -6, 0, -6, 0,
+ax_anim 2, 0, 108, -6, -1, -6, -1,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 0, 108, -6, -1, -6, -1,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 0, 108, -6, -1, -6, -1,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim_terminator
+sDonphanAnims_4_8:
+ax_anim 2, 2, 110, -2, 2, -2, 2,
+ax_anim 2, 0, 110, -4, 4, -4, 4,
+ax_anim 2, 0, 110, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -7, 7, -7, 7,
+ax_anim 2, 1, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 111, -5, 7, -5, 7,
+ax_anim 2, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 111, -5, 7, -5, 7,
+ax_anim 2, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 111, -5, 7, -5, 7,
+ax_anim 2, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDonphanAnims_5_1:
+ax_anim 1, 0, 113, 0, -2, 0, -2,
+ax_anim 2, 0, 113, 0, -3, 0, -3,
+ax_anim 4, 2, 113, 0, -4, 0, -4,
+ax_anim 2, 0, 113, 0, -3, 0, -3,
+ax_anim 1, 0, 112, 0, -2, 0, -2,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sDonphanAnims_5_2:
+ax_anim 1, 0, 116, 0, -2, 0, -2,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 4, 2, 116, 0, -4, 0, -4,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 1, 0, 115, 0, -2, 0, -2,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim_terminator
+sDonphanAnims_5_3:
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 4, 2, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sDonphanAnims_5_4:
+ax_anim 1, 0, 122, 0, -2, 0, -2,
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 4, 2, 122, 0, -4, 0, -4,
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 1, 0, 121, 0, -2, 0, -2,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 1, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim_terminator
+sDonphanAnims_5_5:
+ax_anim 1, 0, 125, 0, -2, 0, -2,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 4, 2, 125, 0, -4, 0, -4,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 1, 0, 124, 0, -1, 0, -2,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim_terminator
+sDonphanAnims_5_6:
+ax_anim 1, 0, 128, 0, -2, 0, -2,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 4, 2, 128, 0, -4, 0, -4,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 1, 0, 127, 0, -2, 0, -2,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 1, 129, -1, 1, -1, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim_terminator
+sDonphanAnims_5_7:
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 2, 131, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 1, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim_terminator
+sDonphanAnims_5_8:
+ax_anim 1, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 4, 2, 134, 0, -4, 0, -4,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 1, 0, 133, 0, -2, 0, -2,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sDonphanAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDonphanAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sDonphanAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sDonphanAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sDonphanAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sDonphanAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sDonphanAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sDonphanAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sDonphanAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDonphanAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 20, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 20, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 20, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 20, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 20, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDonphanAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 4, 7, 4,
+ax_anim 2, 0, 172, 8, 11, 9, 11,
+ax_anim 2, 0, 173, 5, 18, 5, 18,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -5, 18, -5, 18,
+ax_anim 2, 0, 176, -8, 11, -9, 11,
+ax_anim 1, 0, 177, -5, 4, -5, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 12, -1, 12, -1,
+ax_anim 2, 0, 171, 20, 7, 20, 7,
+ax_anim 2, 0, 172, 21, 12, 21, 12,
+ax_anim 3, 0, 173, 18, 19, 18, 19,
+ax_anim 2, 3, 174, 10, 19, 10, 19,
+ax_anim 2, 0, 175, 3, 16, 3, 16,
+ax_anim 1, 0, 176, -3, 8, -3, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 5, -6, 5, -6,
+ax_anim 2, 0, 170, 11, -9, 11, -9,
+ax_anim 2, 0, 171, 15, -5, 15, -5,
+ax_anim 3, 0, 172, 18, 0, 18, 0,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 11, 7, 11, 7,
+ax_anim 1, 0, 175, 5, 5, 5, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -8, 0, -8,
+ax_anim 2, 0, 177, 4, -17, 4, -17,
+ax_anim 2, 0, 170, 9, -21, 9, -21,
+ax_anim 3, 0, 171, 17, -21, 17, -21,
+ax_anim 2, 3, 172, 20, -15, 20, -15,
+ax_anim 2, 0, 173, 16, -5, 16, -5,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -11, -11, -11, -11,
+ax_anim 2, 0, 177, -7, -17, -7, -17,
+ax_anim 3, 0, 170, 0, -21, 0, -21,
+ax_anim 2, 3, 171, 7, -17, 7, -17,
+ax_anim 2, 0, 172, 11, -11, 11, -11,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -8, 0, -8,
+ax_anim 2, 0, 171, -4, -17, -4, -17,
+ax_anim 2, 0, 170, -9, -21, -9, -21,
+ax_anim 3, 0, 177, -17, -21, -17, -21,
+ax_anim 2, 3, 176, -20, -15, -20, -15,
+ax_anim 2, 0, 175, -16, -5, -16, -5,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -5, -6, -5, -6,
+ax_anim 2, 0, 170, -11, -9, -11, -9,
+ax_anim 2, 0, 177, -15, -5, -15, -5,
+ax_anim 3, 0, 176, -18, 0, -18, 0,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -11, 7, -11, 7,
+ax_anim 1, 0, 173, -5, 5, -5, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -12, -1, -12, -1,
+ax_anim 2, 0, 177, -20, 7, -20, 7,
+ax_anim 2, 0, 176, -21, 12, -21, 12,
+ax_anim 3, 0, 175, -18, 19, -18, 19,
+ax_anim 2, 3, 174, -10, 19, -10, 19,
+ax_anim 2, 0, 173, -3, 16, -3, 16,
+ax_anim 1, 0, 172, 3, 8, 3, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDonphanAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDonphanAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDonphanAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDonphanAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sDonphanGfx1:
+.incbin "baserom.gba", 0xF690F8, 0x200
+sDonphanSprites1:
+ax_sprite sDonphanGfx1, 0x200
+ax_sprite_terminator
+sDonphanGfx2:
+.incbin "baserom.gba", 0xF69308, 0x200
+sDonphanSprites2:
+ax_sprite sDonphanGfx2, 0x200
+ax_sprite_terminator
+sDonphanGfx3:
+.incbin "baserom.gba", 0xF69518, 0x200
+sDonphanSprites3:
+ax_sprite sDonphanGfx3, 0x200
+ax_sprite_terminator
+sDonphanGfx4:
+.incbin "baserom.gba", 0xF69728, 0x200
+sDonphanSprites4:
+ax_sprite sDonphanGfx4, 0x200
+ax_sprite_terminator
+sDonphanGfx5:
+.incbin "baserom.gba", 0xF69938, 0x200
+sDonphanSprites5:
+ax_sprite sDonphanGfx5, 0x200
+ax_sprite_terminator
+sDonphanGfx6:
+.incbin "baserom.gba", 0xF69B48, 0x200
+sDonphanSprites6:
+ax_sprite sDonphanGfx6, 0x200
+ax_sprite_terminator
+sDonphanGfx7:
+.incbin "baserom.gba", 0xF69D58, 0x200
+sDonphanSprites7:
+ax_sprite sDonphanGfx7, 0x200
+ax_sprite_terminator
+sDonphanGfx8:
+.incbin "baserom.gba", 0xF69F68, 0x200
+sDonphanSprites8:
+ax_sprite sDonphanGfx8, 0x200
+ax_sprite_terminator
+sDonphanGfx9:
+.incbin "baserom.gba", 0xF6A178, 0x200
+sDonphanSprites9:
+ax_sprite sDonphanGfx9, 0x200
+ax_sprite_terminator
+sDonphanGfx10:
+.incbin "baserom.gba", 0xF6A388, 0x200
+sDonphanSprites10:
+ax_sprite sDonphanGfx10, 0x200
+ax_sprite_terminator
+sDonphanGfx11:
+.incbin "baserom.gba", 0xF6A598, 0x200
+sDonphanSprites11:
+ax_sprite sDonphanGfx11, 0x200
+ax_sprite_terminator
+sDonphanGfx12:
+.incbin "baserom.gba", 0xF6A7A8, 0x200
+sDonphanSprites12:
+ax_sprite sDonphanGfx12, 0x200
+ax_sprite_terminator
+sDonphanGfx13:
+.incbin "baserom.gba", 0xF6A9B8, 0x200
+sDonphanSprites13:
+ax_sprite sDonphanGfx13, 0x200
+ax_sprite_terminator
+sDonphanGfx14:
+.incbin "baserom.gba", 0xF6ABC8, 0x200
+sDonphanSprites14:
+ax_sprite sDonphanGfx14, 0x200
+ax_sprite_terminator
+sDonphanGfx15:
+.incbin "baserom.gba", 0xF6ADD8, 0x200
+sDonphanSprites15:
+ax_sprite sDonphanGfx15, 0x200
+ax_sprite_terminator
+sDonphanGfx16:
+.incbin "baserom.gba", 0xF6AFE8, 0x40
+sDonphanGfx16_1:
+.incbin "baserom.gba", 0xF6B028, 0x100
+sDonphanSprites16:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx16_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDonphanGfx17:
+.incbin "baserom.gba", 0xF6B158, 0x40
+sDonphanGfx17_1:
+.incbin "baserom.gba", 0xF6B198, 0x100
+sDonphanGfx17_2:
+.incbin "baserom.gba", 0xF6B298, 0x40
+sDonphanSprites17:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDonphanGfx18:
+.incbin "baserom.gba", 0xF6B318, 0x1E0
+sDonphanSprites18:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx18, 0x1e0
+ax_sprite_terminator
+sDonphanGfx19:
+.incbin "baserom.gba", 0xF6B510, 0x160
+sDonphanGfx19_1:
+.incbin "baserom.gba", 0xF6B670, 0x40
+sDonphanSprites19:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx19, 0x160
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDonphanGfx20:
+.incbin "baserom.gba", 0xF6B6E0, 0x180
+sDonphanSprites20:
+ax_sprite sDonphanGfx20, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDonphanGfx21:
+.incbin "baserom.gba", 0xF6B878, 0x40
+sDonphanGfx21_1:
+.incbin "baserom.gba", 0xF6B8B8, 0x180
+sDonphanSprites21:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx21_1, 0x180
+ax_sprite_terminator
+sDonphanGfx22:
+.incbin "baserom.gba", 0xF6BA60, 0x40
+sDonphanGfx22_1:
+.incbin "baserom.gba", 0xF6BAA0, 0x180
+sDonphanSprites22:
+ax_sprite sDonphanGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDonphanGfx22_1, 0x180
+ax_sprite_terminator
+sDonphanGfx23:
+.incbin "baserom.gba", 0xF6BC40, 0x40
+sDonphanGfx23_1:
+.incbin "baserom.gba", 0xF6BC80, 0x180
+sDonphanSprites23:
+ax_sprite sDonphanGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDonphanGfx23_1, 0x180
+ax_sprite_terminator
+sDonphanGfx24:
+.incbin "baserom.gba", 0xF6BE20, 0x40
+sDonphanGfx24_1:
+.incbin "baserom.gba", 0xF6BE60, 0x20
+sDonphanSprites24:
+ax_sprite sDonphanGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx24_1, 0x20
+ax_sprite_terminator
+sDonphanGfx25:
+.incbin "baserom.gba", 0xF6BEA0, 0x100
+sDonphanSprites25:
+ax_sprite sDonphanGfx25, 0x100
+ax_sprite_terminator
+sDonphanGfx26:
+.incbin "baserom.gba", 0xF6BFB0, 0x40
+sDonphanSprites26:
+ax_sprite sDonphanGfx26, 0x40
+ax_sprite_terminator
+sDonphanGfx27:
+.incbin "baserom.gba", 0xF6C000, 0x20
+sDonphanSprites27:
+ax_sprite sDonphanGfx27, 0x20
+ax_sprite_terminator
+sDonphanGfx28:
+.incbin "baserom.gba", 0xF6C030, 0x40
+sDonphanGfx28_1:
+.incbin "baserom.gba", 0xF6C070, 0x80
+sDonphanGfx28_2:
+.incbin "baserom.gba", 0xF6C0F0, 0xE0
+sDonphanSprites28:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx28_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx28_2, 0xe0
+ax_sprite_terminator
+sDonphanGfx29:
+.incbin "baserom.gba", 0xF6C208, 0x40
+sDonphanGfx29_1:
+.incbin "baserom.gba", 0xF6C248, 0x100
+sDonphanSprites29:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx29_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDonphanGfx30:
+.incbin "baserom.gba", 0xF6C378, 0x40
+sDonphanGfx30_1:
+.incbin "baserom.gba", 0xF6C3B8, 0x160
+sDonphanSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx30_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDonphanGfx31:
+.incbin "baserom.gba", 0xF6C548, 0x40
+sDonphanGfx31_1:
+.incbin "baserom.gba", 0xF6C588, 0x160
+sDonphanSprites31:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx31_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDonphanGfx32:
+.incbin "baserom.gba", 0xF6C718, 0x60
+sDonphanGfx32_1:
+.incbin "baserom.gba", 0xF6C778, 0x100
+sDonphanGfx32_2:
+.incbin "baserom.gba", 0xF6C878, 0x40
+sDonphanSprites32:
+ax_sprite sDonphanGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDonphanGfx33:
+.incbin "baserom.gba", 0xF6C8F0, 0x40
+sDonphanGfx33_1:
+.incbin "baserom.gba", 0xF6C930, 0x100
+sDonphanSprites33:
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDonphanGfx33_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDonphanGfx34:
+.incbin "baserom.gba", 0xF6CA60, 0x200
+sDonphanSprites34:
+ax_sprite sDonphanGfx34, 0x200
+ax_sprite_terminator
+sDonphanGfx35:
+.incbin "baserom.gba", 0xF6CC70, 0x200
+sDonphanSprites35:
+ax_sprite sDonphanGfx35, 0x200
+ax_sprite_terminator
+sDonphanGfx36:
+.incbin "baserom.gba", 0xF6CE80, 0x200
+sDonphanSprites36:
+ax_sprite sDonphanGfx36, 0x200
+ax_sprite_terminator
+sDonphanGfx37:
+.incbin "baserom.gba", 0xF6D090, 0x200
+sDonphanSprites37:
+ax_sprite sDonphanGfx37, 0x200
+ax_sprite_terminator
+sDonphanGfx38:
+.incbin "baserom.gba", 0xF6D2A0, 0x200
+sDonphanSprites38:
+ax_sprite sDonphanGfx38, 0x200
+ax_sprite_terminator
+sDonphanGfx39:
+.incbin "baserom.gba", 0xF6D4B0, 0x200
+sDonphanSprites39:
+ax_sprite sDonphanGfx39, 0x200
+ax_sprite_terminator
+sDonphanGfx40:
+.incbin "baserom.gba", 0xF6D6C0, 0x200
+sDonphanSprites40:
+ax_sprite sDonphanGfx40, 0x200
+ax_sprite_terminator
+sAxPosesDonphan:
+.4byte sDonphanPose1
+.4byte sDonphanPose2
+.4byte sDonphanPose3
+.4byte sDonphanPose4
+.4byte sDonphanPose5
+.4byte sDonphanPose6
+.4byte sDonphanPose7
+.4byte sDonphanPose8
+.4byte sDonphanPose9
+.4byte sDonphanPose10
+.4byte sDonphanPose11
+.4byte sDonphanPose12
+.4byte sDonphanPose13
+.4byte sDonphanPose14
+.4byte sDonphanPose15
+.4byte sDonphanPose16
+.4byte sDonphanPose17
+.4byte sDonphanPose18
+.4byte sDonphanPose19
+.4byte sDonphanPose20
+.4byte sDonphanPose21
+.4byte sDonphanPose22
+.4byte sDonphanPose23
+.4byte sDonphanPose24
+.4byte sDonphanPose25
+.4byte sDonphanPose26
+.4byte sDonphanPose27
+.4byte sDonphanPose28
+.4byte sDonphanPose29
+.4byte sDonphanPose30
+.4byte sDonphanPose31
+.4byte sDonphanPose32
+.4byte sDonphanPose33
+.4byte sDonphanPose34
+.4byte sDonphanPose35
+.4byte sDonphanPose36
+.4byte sDonphanPose37
+.4byte sDonphanPose38
+.4byte sDonphanPose39
+.4byte sDonphanPose40
+.4byte sDonphanPose41
+.4byte sDonphanPose42
+.4byte sDonphanPose43
+.4byte sDonphanPose44
+.4byte sDonphanPose45
+.4byte sDonphanPose46
+.4byte sDonphanPose47
+.4byte sDonphanPose48
+.4byte sDonphanPose49
+.4byte sDonphanPose50
+.4byte sDonphanPose51
+.4byte sDonphanPose52
+.4byte sDonphanPose53
+.4byte sDonphanPose54
+.4byte sDonphanPose55
+.4byte sDonphanPose56
+.4byte sDonphanPose57
+.4byte sDonphanPose58
+.4byte sDonphanPose59
+.4byte sDonphanPose60
+.4byte sDonphanPose61
+.4byte sDonphanPose62
+.4byte sDonphanPose63
+.4byte sDonphanPose64
+.4byte sDonphanPose65
+.4byte sDonphanPose66
+.4byte sDonphanPose67
+.4byte sDonphanPose68
+.4byte sDonphanPose69
+.4byte sDonphanPose70
+.4byte sDonphanPose71
+.4byte sDonphanPose72
+.4byte sDonphanPose73
+.4byte sDonphanPose74
+.4byte sDonphanPose75
+.4byte sDonphanPose76
+.4byte sDonphanPose77
+.4byte sDonphanPose78
+.4byte sDonphanPose79
+.4byte sDonphanPose80
+.4byte sDonphanPose81
+.4byte sDonphanPose82
+.4byte sDonphanPose83
+.4byte sDonphanPose84
+.4byte sDonphanPose85
+.4byte sDonphanPose86
+.4byte sDonphanPose87
+.4byte sDonphanPose88
+.4byte sDonphanPose89
+.4byte sDonphanPose90
+.4byte sDonphanPose91
+.4byte sDonphanPose92
+.4byte sDonphanPose93
+.4byte sDonphanPose94
+.4byte sDonphanPose95
+.4byte sDonphanPose96
+.4byte sDonphanPose97
+.4byte sDonphanPose98
+.4byte sDonphanPose99
+.4byte sDonphanPose100
+.4byte sDonphanPose101
+.4byte sDonphanPose102
+.4byte sDonphanPose103
+.4byte sDonphanPose104
+.4byte sDonphanPose105
+.4byte sDonphanPose106
+.4byte sDonphanPose107
+.4byte sDonphanPose108
+.4byte sDonphanPose109
+.4byte sDonphanPose110
+.4byte sDonphanPose111
+.4byte sDonphanPose112
+.4byte sDonphanPose113
+.4byte sDonphanPose114
+.4byte sDonphanPose115
+.4byte sDonphanPose116
+.4byte sDonphanPose117
+.4byte sDonphanPose118
+.4byte sDonphanPose119
+.4byte sDonphanPose120
+.4byte sDonphanPose121
+.4byte sDonphanPose122
+.4byte sDonphanPose123
+.4byte sDonphanPose124
+.4byte sDonphanPose125
+.4byte sDonphanPose126
+.4byte sDonphanPose127
+.4byte sDonphanPose128
+.4byte sDonphanPose129
+.4byte sDonphanPose130
+.4byte sDonphanPose131
+.4byte sDonphanPose132
+.4byte sDonphanPose133
+.4byte sDonphanPose134
+.4byte sDonphanPose135
+.4byte sDonphanPose136
+.4byte sDonphanPose137
+.4byte sDonphanPose138
+.4byte sDonphanPose139
+.4byte sDonphanPose140
+.4byte sDonphanPose141
+.4byte sDonphanPose142
+.4byte sDonphanPose143
+.4byte sDonphanPose144
+.4byte sDonphanPose145
+.4byte sDonphanPose146
+.4byte sDonphanPose147
+.4byte sDonphanPose148
+.4byte sDonphanPose149
+.4byte sDonphanPose150
+.4byte sDonphanPose151
+.4byte sDonphanPose152
+.4byte sDonphanPose153
+.4byte sDonphanPose154
+.4byte sDonphanPose155
+.4byte sDonphanPose156
+.4byte sDonphanPose157
+.4byte sDonphanPose158
+.4byte sDonphanPose159
+.4byte sDonphanPose160
+.4byte sDonphanPose161
+.4byte sDonphanPose162
+.4byte sDonphanPose163
+.4byte sDonphanPose164
+.4byte sDonphanPose165
+.4byte sDonphanPose166
+.4byte sDonphanPose167
+.4byte sDonphanPose168
+.4byte sDonphanPose169
+.4byte sDonphanPose170
+.4byte sDonphanPose171
+.4byte sDonphanPose172
+.4byte sDonphanPose173
+.4byte sDonphanPose174
+.4byte sDonphanPose175
+.4byte sDonphanPose176
+.4byte sDonphanPose177
+.4byte sDonphanPose178
+.4byte sDonphanPose179
+.4byte sDonphanPose180
+.4byte sDonphanPose181
+.4byte sDonphanPose182
+.4byte sDonphanPose183
+.4byte sDonphanPose184
+.4byte sDonphanPose185
+.4byte sDonphanPose186
+.4byte sDonphanPose187
+.4byte sDonphanPose188
+.4byte sDonphanPose189
+.4byte sDonphanPose190
+.4byte sDonphanPose191
+.4byte sDonphanPose192
+.4byte sDonphanPose193
+.4byte sDonphanPose194
+.4byte sDonphanPose195
+.4byte sDonphanPose196
+.4byte sDonphanPose197
+.4byte sDonphanPose198
+.4byte sDonphanPose199
+.4byte sDonphanPose200
+.4byte sDonphanPose201
+.4byte sDonphanPose202
+.4byte sDonphanPose203
+.4byte sDonphanPose204
+.4byte sDonphanPose205
+.4byte sDonphanPose206
+.4byte sDonphanPose207
+.4byte sDonphanPose208
+.4byte sDonphanPose209
+.4byte sDonphanPose210
+.4byte sDonphanPose211
+.4byte sDonphanPose212
+.4byte sDonphanPose213
+.4byte sDonphanPose214
+.4byte sDonphanPose215
+.4byte sDonphanPose216
+.4byte sDonphanPose217
+.4byte sDonphanPose218
+.4byte sDonphanPose219
+.4byte sDonphanPose220
+.4byte sDonphanPose221
+.4byte sDonphanPose222
+.4byte sDonphanPose223
+.4byte sDonphanPose224
+.4byte sDonphanPose225
+.4byte sDonphanPose226
+sAxPositionsDonphan:
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte   -1,   -1, 	  -6,   -1, 	   6,    1, 	   0,   -6
+.2byte    1,   -1, 	  -5,    1, 	   6,   -1, 	   1,   -6
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+.2byte    8,   -2, 	   3,   -1, 	   1,    2, 	   0,   -8
+.2byte    5,   -1, 	   9,    0, 	  -4,   -1, 	  -1,   -7
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte   11,   -3, 	   2,   -3, 	   7,   -1, 	   1,   -8
+.2byte    9,   -3, 	   8,   -2, 	   2,   -1, 	   0,   -8
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte    5,   -9, 	  -2,   -6, 	   9,   -5, 	   0,   -8
+.2byte    6,   -8, 	   2,   -5, 	   5,   -2, 	   1,   -9
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    2,   -7, 	   5,   -3, 	  -4,   -5, 	   0,   -9
+.2byte   -1,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -8
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -5,   -9, 	   2,   -6, 	  -9,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -2,   -5, 	  -5,   -2, 	  -1,   -9
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte  -11,   -3, 	  -2,   -3, 	  -7,   -1, 	  -1,   -8
+.2byte   -9,   -3, 	  -8,   -2, 	  -2,   -1, 	   0,   -8
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte   -8,   -2, 	  -3,   -1, 	  -1,    2, 	   0,   -8
+.2byte   -5,   -1, 	  -9,    0, 	   4,   -1, 	   1,   -7
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte   -1,   -1, 	  -6,   -1, 	   6,    1, 	   0,   -6
+.2byte    1,   -1, 	  -5,    1, 	   6,   -1, 	   1,   -6
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+.2byte    8,   -2, 	   3,   -1, 	   1,    2, 	   0,   -8
+.2byte    5,   -1, 	   9,    0, 	  -4,   -1, 	  -1,   -7
+.2byte    5,   -1, 	   6,   -2, 	  -1,    0, 	  -2,   -9
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte   11,   -3, 	   2,   -3, 	   7,   -1, 	   1,   -8
+.2byte    9,   -3, 	   8,   -2, 	   2,   -1, 	   0,   -8
+.2byte    8,   -2, 	   6,   -1, 	   4,    0, 	  -1,   -9
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte    5,   -9, 	  -2,   -6, 	   9,   -5, 	   0,   -8
+.2byte    6,   -8, 	   2,   -5, 	   5,   -2, 	   1,   -9
+.2byte    5,   -7, 	  -2,   -7, 	   6,   -3, 	  -1,   -9
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    2,   -7, 	   5,   -3, 	  -4,   -5, 	   0,   -9
+.2byte   -1,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -8
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -2, 	   0,   -9
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -5,   -9, 	   2,   -6, 	  -9,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -2,   -5, 	  -5,   -2, 	  -1,   -9
+.2byte   -5,   -7, 	   2,   -7, 	  -6,   -3, 	   1,   -9
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte  -11,   -3, 	  -2,   -3, 	  -7,   -1, 	  -1,   -8
+.2byte   -9,   -3, 	  -8,   -2, 	  -2,   -1, 	   0,   -8
+.2byte   -8,   -2, 	  -6,   -1, 	  -4,    0, 	   1,   -9
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte   -8,   -2, 	  -3,   -1, 	  -1,    2, 	   0,   -8
+.2byte   -5,   -1, 	  -9,    0, 	   4,   -1, 	   1,   -7
+.2byte   -5,   -1, 	  -6,   -2, 	   1,    0, 	   2,   -9
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte   -1,   -1, 	  -6,   -1, 	   6,    1, 	   0,   -6
+.2byte    1,   -1, 	  -5,    1, 	   6,   -1, 	   1,   -6
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+.2byte    8,   -2, 	   3,   -1, 	   1,    2, 	   0,   -8
+.2byte    5,   -1, 	   9,    0, 	  -4,   -1, 	  -1,   -7
+.2byte    5,   -1, 	   6,   -2, 	  -1,    0, 	  -2,   -9
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte   11,   -3, 	   2,   -3, 	   7,   -1, 	   1,   -8
+.2byte    9,   -3, 	   8,   -2, 	   2,   -1, 	   0,   -8
+.2byte    8,   -2, 	   6,   -1, 	   4,    0, 	  -1,   -9
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte    5,   -9, 	  -2,   -6, 	   9,   -5, 	   0,   -8
+.2byte    6,   -8, 	   2,   -5, 	   5,   -2, 	   1,   -9
+.2byte    5,   -7, 	  -2,   -7, 	   6,   -3, 	  -1,   -9
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    2,   -7, 	   5,   -3, 	  -4,   -5, 	   0,   -9
+.2byte   -1,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -8
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -2, 	   0,   -9
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -5,   -9, 	   2,   -6, 	  -9,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -2,   -5, 	  -5,   -2, 	  -1,   -9
+.2byte   -5,   -7, 	   2,   -7, 	  -6,   -3, 	   1,   -9
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte  -11,   -3, 	  -2,   -3, 	  -7,   -1, 	  -1,   -8
+.2byte   -9,   -3, 	  -8,   -2, 	  -2,   -1, 	   0,   -8
+.2byte   -8,   -2, 	  -6,   -1, 	  -4,    0, 	   1,   -9
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte   -8,   -2, 	  -3,   -1, 	  -1,    2, 	   0,   -8
+.2byte   -5,   -1, 	  -9,    0, 	   4,   -1, 	   1,   -7
+.2byte   -5,   -1, 	  -6,   -2, 	   1,    0, 	   2,   -9
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -8, 	  -6,   -1, 	   6,   -2, 	   0,   -9
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+.2byte    5,   -1, 	   6,   -2, 	  -1,    0, 	  -2,   -9
+.2byte    5,  -10, 	   7,   -5, 	  -1,   -3, 	  -1,  -11
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte    8,   -2, 	   6,   -1, 	   4,    0, 	  -1,   -9
+.2byte    7,  -12, 	   6,   -6, 	   7,   -4, 	  -1,  -10
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte    5,   -7, 	  -2,   -7, 	   6,   -3, 	  -1,   -9
+.2byte    4,  -14, 	   1,  -12, 	   9,   -8, 	  -1,  -10
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -2, 	   0,   -9
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,  -10
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -5,   -7, 	   2,   -7, 	  -6,   -3, 	   1,   -9
+.2byte   -4,  -14, 	  -1,  -12, 	  -9,   -8, 	   1,  -10
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte   -8,   -2, 	  -6,   -1, 	  -4,    0, 	   1,   -9
+.2byte   -7,  -12, 	  -6,   -6, 	  -7,   -4, 	   1,  -10
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte   -5,   -1, 	  -6,   -2, 	   1,    0, 	   2,   -9
+.2byte   -5,  -10, 	  -7,   -5, 	   1,   -3, 	   1,  -11
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -1, 	   6,   -2, 	   0,   -9
+.2byte    0,   -1, 	  -7,    0, 	   6,    0, 	   0,   -7
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+.2byte    5,  -10, 	   7,   -5, 	  -1,   -3, 	  -1,  -11
+.2byte    4,    0, 	   9,   -3, 	  -1,    1, 	  -1,   -9
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte    7,  -12, 	   6,   -6, 	   7,   -4, 	  -1,  -10
+.2byte    8,   -1, 	   5,   -1, 	   3,    0, 	   0,   -9
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte    4,  -14, 	   1,  -12, 	   9,   -8, 	  -1,  -10
+.2byte    6,   -7, 	  -2,   -8, 	   6,   -4, 	   0,   -8
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,  -10
+.2byte    0,   -4, 	   6,   -2, 	  -6,   -2, 	   0,   -7
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -4,  -14, 	  -1,  -12, 	  -9,   -8, 	   1,  -10
+.2byte   -6,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -8
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte   -7,  -12, 	  -6,   -6, 	  -7,   -4, 	   1,  -10
+.2byte   -8,   -1, 	  -5,   -1, 	  -3,    0, 	   0,   -9
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte   -5,  -10, 	  -7,   -5, 	   1,   -3, 	   1,  -11
+.2byte   -4,    0, 	  -9,   -3, 	   1,    1, 	   1,   -9
+.2byte  -14,    3, 	 -13,   -2, 	  -2,    3, 	   0,   -5
+.2byte  -13,    3, 	 -13,   -3, 	  -2,    3, 	   0,   -7
+.2byte    0,  -13, 	  -6,   -5, 	   6,   -6, 	   0,   -8
+.2byte    5,  -15, 	   9,   -6, 	   0,   -4, 	  -2,  -10
+.2byte    7,  -12, 	   9,  -10, 	   7,   -7, 	  -4,  -11
+.2byte    4,  -17, 	  -3,  -14, 	   7,  -10, 	  -4,  -10
+.2byte    0,  -14, 	   4,   -9, 	  -4,   -9, 	   0,  -11
+.2byte   -5,  -17, 	   2,  -14, 	  -8,  -10, 	   3,  -10
+.2byte   -8,  -12, 	 -10,  -10, 	  -8,   -7, 	   3,  -11
+.2byte   -6,  -15, 	 -10,   -6, 	  -1,   -4, 	   1,  -10
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -8, 	  -6,   -1, 	   6,   -2, 	   0,   -9
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+.2byte    5,   -1, 	   6,   -2, 	  -1,    0, 	  -2,   -9
+.2byte    5,  -10, 	   7,   -5, 	  -1,   -3, 	  -1,  -11
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte    8,   -2, 	   6,   -1, 	   4,    0, 	  -1,   -9
+.2byte    7,  -12, 	   6,   -6, 	   7,   -4, 	  -1,  -10
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte    5,   -7, 	  -2,   -7, 	   6,   -3, 	  -1,   -9
+.2byte    4,  -14, 	   1,  -12, 	   9,   -8, 	  -1,  -10
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -2, 	   0,   -9
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,  -10
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -5,   -7, 	   2,   -7, 	  -6,   -3, 	   1,   -9
+.2byte   -4,  -14, 	  -1,  -12, 	  -9,   -8, 	   1,  -10
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte   -8,   -2, 	  -6,   -1, 	  -4,    0, 	   1,   -9
+.2byte   -7,  -12, 	  -6,   -6, 	  -7,   -4, 	   1,  -10
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte   -5,   -1, 	  -6,   -2, 	   1,    0, 	   2,   -9
+.2byte   -5,  -10, 	  -7,   -5, 	   1,   -3, 	   1,  -11
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte   -5,   -1, 	  -6,   -2, 	   1,    0, 	   2,   -9
+.2byte   -8,   -2, 	  -6,   -1, 	  -4,    0, 	   1,   -9
+.2byte   -5,   -7, 	   2,   -7, 	  -6,   -3, 	   1,   -9
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -2, 	   0,   -9
+.2byte    5,   -7, 	  -2,   -7, 	   6,   -3, 	  -1,   -9
+.2byte    8,   -2, 	   6,   -1, 	   4,    0, 	  -1,   -9
+.2byte    5,   -1, 	   6,   -2, 	  -1,    0, 	  -2,   -9
+.2byte    0,   -8, 	  -6,   -1, 	   6,   -2, 	   0,   -9
+.2byte    5,   -9, 	   7,   -4, 	  -1,   -2, 	  -1,  -10
+.2byte    7,  -12, 	   6,   -6, 	   7,   -4, 	  -1,  -10
+.2byte    4,  -14, 	   1,  -12, 	   9,   -8, 	  -1,  -10
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,  -10
+.2byte   -4,  -14, 	  -1,  -12, 	  -9,   -8, 	   1,  -10
+.2byte   -7,  -12, 	  -6,   -6, 	  -7,   -4, 	   1,  -10
+.2byte   -5,   -9, 	  -7,   -4, 	   1,   -2, 	   1,  -10
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -8, 	  -6,   -1, 	   6,   -2, 	   0,   -9
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+.2byte    6,    0, 	   7,   -1, 	   0,    1, 	  -1,   -8
+.2byte    5,  -10, 	   7,   -5, 	  -1,   -3, 	  -1,  -11
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte   10,   -2, 	   8,   -1, 	   6,    0, 	   1,   -9
+.2byte    7,  -12, 	   6,   -6, 	   7,   -4, 	  -1,  -10
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte    6,   -6, 	  -1,   -6, 	   7,   -2, 	   0,   -8
+.2byte    4,  -14, 	   1,  -12, 	   9,   -8, 	  -1,  -10
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -2, 	   0,   -9
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,  -10
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -6,   -7, 	   1,   -7, 	  -7,   -3, 	   0,   -9
+.2byte   -4,  -14, 	  -1,  -12, 	  -9,   -8, 	   1,  -10
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte  -10,   -2, 	  -8,   -1, 	  -6,    0, 	  -1,   -9
+.2byte   -7,  -12, 	  -6,   -6, 	  -7,   -4, 	   1,  -10
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte   -6,    0, 	  -7,   -1, 	   0,    1, 	   1,   -8
+.2byte   -5,  -10, 	  -7,   -5, 	   1,   -3, 	   1,  -11
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte   -5,   -1, 	  -6,   -2, 	   1,    0, 	   2,   -9
+.2byte   -8,   -2, 	  -6,   -1, 	  -4,    0, 	   1,   -9
+.2byte   -5,   -7, 	   2,   -7, 	  -6,   -3, 	   1,   -9
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -2, 	   0,   -9
+.2byte    5,   -7, 	  -2,   -7, 	   6,   -3, 	  -1,   -9
+.2byte    8,   -2, 	   6,   -1, 	   4,    0, 	  -1,   -9
+.2byte    5,   -1, 	   6,   -2, 	  -1,    0, 	  -2,   -9
+.2byte    0,    0, 	  -7,    0, 	   7,    0, 	   0,   -6
+.2byte   -8,   -2, 	  -5,   -2, 	   1,    1, 	   2,   -8
+.2byte  -11,   -3, 	  -4,   -2, 	  -4,   -1, 	   0,   -8
+.2byte   -5,   -9, 	   2,   -6, 	  -6,   -3, 	   0,   -8
+.2byte    0,   -8, 	   6,   -3, 	  -6,   -3, 	   0,   -9
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -3, 	   0,   -8
+.2byte   11,   -3, 	   4,   -2, 	   4,   -1, 	   0,   -8
+.2byte    8,   -2, 	   5,   -2, 	  -1,    1, 	  -2,   -8
+sDonphanAnimTable1:
+.4byte sDonphanAnims_1_1
+.4byte sDonphanAnims_1_2
+.4byte sDonphanAnims_1_3
+.4byte sDonphanAnims_1_4
+.4byte sDonphanAnims_1_5
+.4byte sDonphanAnims_1_6
+.4byte sDonphanAnims_1_7
+.4byte sDonphanAnims_1_8
+sDonphanAnimTable2:
+.4byte sDonphanAnims_2_1
+.4byte sDonphanAnims_2_2
+.4byte sDonphanAnims_2_3
+.4byte sDonphanAnims_2_4
+.4byte sDonphanAnims_2_5
+.4byte sDonphanAnims_2_6
+.4byte sDonphanAnims_2_7
+.4byte sDonphanAnims_2_8
+sDonphanAnimTable3:
+.4byte sDonphanAnims_3_1
+.4byte sDonphanAnims_3_2
+.4byte sDonphanAnims_3_3
+.4byte sDonphanAnims_3_4
+.4byte sDonphanAnims_3_5
+.4byte sDonphanAnims_3_6
+.4byte sDonphanAnims_3_7
+.4byte sDonphanAnims_3_8
+sDonphanAnimTable4:
+.4byte sDonphanAnims_4_1
+.4byte sDonphanAnims_4_2
+.4byte sDonphanAnims_4_3
+.4byte sDonphanAnims_4_4
+.4byte sDonphanAnims_4_5
+.4byte sDonphanAnims_4_6
+.4byte sDonphanAnims_4_7
+.4byte sDonphanAnims_4_8
+sDonphanAnimTable5:
+.4byte sDonphanAnims_5_1
+.4byte sDonphanAnims_5_2
+.4byte sDonphanAnims_5_3
+.4byte sDonphanAnims_5_4
+.4byte sDonphanAnims_5_5
+.4byte sDonphanAnims_5_6
+.4byte sDonphanAnims_5_7
+.4byte sDonphanAnims_5_8
+sDonphanAnimTable6:
+.4byte sDonphanAnims_6_1
+.4byte sDonphanAnims_6_1
+.4byte sDonphanAnims_6_1
+.4byte sDonphanAnims_6_1
+.4byte sDonphanAnims_6_1
+.4byte sDonphanAnims_6_1
+.4byte sDonphanAnims_6_1
+.4byte sDonphanAnims_6_1
+sDonphanAnimTable7:
+.4byte sDonphanAnims_7_1
+.4byte sDonphanAnims_7_2
+.4byte sDonphanAnims_7_3
+.4byte sDonphanAnims_7_4
+.4byte sDonphanAnims_7_5
+.4byte sDonphanAnims_7_6
+.4byte sDonphanAnims_7_7
+.4byte sDonphanAnims_7_8
+sDonphanAnimTable8:
+.4byte sDonphanAnims_8_1
+.4byte sDonphanAnims_8_2
+.4byte sDonphanAnims_8_3
+.4byte sDonphanAnims_8_4
+.4byte sDonphanAnims_8_5
+.4byte sDonphanAnims_8_6
+.4byte sDonphanAnims_8_7
+.4byte sDonphanAnims_8_8
+sDonphanAnimTable9:
+.4byte sDonphanAnims_9_1
+.4byte sDonphanAnims_9_2
+.4byte sDonphanAnims_9_3
+.4byte sDonphanAnims_9_4
+.4byte sDonphanAnims_9_5
+.4byte sDonphanAnims_9_6
+.4byte sDonphanAnims_9_7
+.4byte sDonphanAnims_9_8
+sDonphanAnimTable10:
+.4byte sDonphanAnims_10_1
+.4byte sDonphanAnims_10_2
+.4byte sDonphanAnims_10_3
+.4byte sDonphanAnims_10_4
+.4byte sDonphanAnims_10_5
+.4byte sDonphanAnims_10_6
+.4byte sDonphanAnims_10_7
+.4byte sDonphanAnims_10_8
+sDonphanAnimTable11:
+.4byte sDonphanAnims_11_1
+.4byte sDonphanAnims_11_2
+.4byte sDonphanAnims_11_3
+.4byte sDonphanAnims_11_4
+.4byte sDonphanAnims_11_5
+.4byte sDonphanAnims_11_6
+.4byte sDonphanAnims_11_7
+.4byte sDonphanAnims_11_8
+sDonphanAnimTable12:
+.4byte sDonphanAnims_12_1
+.4byte sDonphanAnims_12_2
+.4byte sDonphanAnims_12_3
+.4byte sDonphanAnims_12_4
+.4byte sDonphanAnims_12_5
+.4byte sDonphanAnims_12_6
+.4byte sDonphanAnims_12_7
+.4byte sDonphanAnims_12_8
+sDonphanAnimTable13:
+.4byte sDonphanAnims_13_1
+.4byte sDonphanAnims_13_2
+.4byte sDonphanAnims_13_3
+.4byte sDonphanAnims_13_4
+.4byte sDonphanAnims_13_5
+.4byte sDonphanAnims_13_6
+.4byte sDonphanAnims_13_7
+.4byte sDonphanAnims_13_8
+sAxAnimationsDonphan:
+.4byte sDonphanAnimTable1
+.4byte sDonphanAnimTable2
+.4byte sDonphanAnimTable3
+.4byte sDonphanAnimTable4
+.4byte sDonphanAnimTable5
+.4byte sDonphanAnimTable6
+.4byte sDonphanAnimTable7
+.4byte sDonphanAnimTable8
+.4byte sDonphanAnimTable9
+.4byte sDonphanAnimTable10
+.4byte sDonphanAnimTable11
+.4byte sDonphanAnimTable12
+.4byte sDonphanAnimTable13
+sAxSpritesDonphan:
+.4byte sDonphanSprites1
+.4byte sDonphanSprites2
+.4byte sDonphanSprites3
+.4byte sDonphanSprites4
+.4byte sDonphanSprites5
+.4byte sDonphanSprites6
+.4byte sDonphanSprites7
+.4byte sDonphanSprites8
+.4byte sDonphanSprites9
+.4byte sDonphanSprites10
+.4byte sDonphanSprites11
+.4byte sDonphanSprites12
+.4byte sDonphanSprites13
+.4byte sDonphanSprites14
+.4byte sDonphanSprites15
+.4byte sDonphanSprites16
+.4byte sDonphanSprites17
+.4byte sDonphanSprites18
+.4byte sDonphanSprites19
+.4byte sDonphanSprites20
+.4byte sDonphanSprites21
+.4byte sDonphanSprites22
+.4byte sDonphanSprites23
+.4byte sDonphanSprites24
+.4byte sDonphanSprites25
+.4byte sDonphanSprites26
+.4byte sDonphanSprites27
+.4byte sDonphanSprites28
+.4byte sDonphanSprites29
+.4byte sDonphanSprites30
+.4byte sDonphanSprites31
+.4byte sDonphanSprites32
+.4byte sDonphanSprites33
+.4byte sDonphanSprites34
+.4byte sDonphanSprites35
+.4byte sDonphanSprites36
+.4byte sDonphanSprites37
+.4byte sDonphanSprites38
+.4byte sDonphanSprites39
+.4byte sDonphanSprites40
+sAxMainDonphan:
+ax_main sAxPosesDonphan, sAxAnimationsDonphan, 13, sAxSpritesDonphan, sAxPositionsDonphan

--- a/data/ax/dragonair.inc
+++ b/data/ax/dragonair.inc
@@ -1,0 +1,4203 @@
+.global gAxDragonair
+gAxDragonair:
+ax_siro sAxMainDragonair
+sDragonairPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose2:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose3:
+ax_pose 6, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose4:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose5:
+ax_pose 8, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose6:
+ax_pose 9, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose7:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose8:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose9:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose10:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose11:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose12:
+ax_pose 27, 0x81e3, 0x80fb, 0x9c00
+ax_pose 28, 0x01f3, 0x40eb, 0x9c08
+ax_pose 29, 0x4203, 0x00f9, 0x9c0c
+ax_pose 30, 0x01eb, 0x00f3, 0x9c0e
+ax_pose_terminator
+sDragonairPose13:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose14:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose15:
+ax_pose 37, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose16:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose17:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose18:
+ax_pose 45, 0x81e4, 0x80f5, 0x9c00
+ax_pose 46, 0x81f4, 0x0105, 0x9c08
+ax_pose 47, 0x0204, 0x00fe, 0x9c0a
+ax_pose_terminator
+sDragonairPose19:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose20:
+ax_pose 49, 0x81e5, 0x80ee, 0x9c00
+ax_pose 50, 0x01f5, 0x40fe, 0x9c08
+ax_pose 51, 0x01f5, 0x410e, 0x9c0c
+ax_pose_terminator
+sDragonairPose21:
+ax_pose 52, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose22:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose23:
+ax_pose 54, 0x01e6, 0x80f2, 0x9c00
+ax_pose_terminator
+sDragonairPose24:
+ax_pose 55, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose26:
+ax_pose 56, 0x01e2, 0x40f9, 0x9c00
+ax_pose 57, 0x41f2, 0x80f1, 0x9c04
+ax_pose 58, 0x01e2, 0x00f1, 0x9c0c
+ax_pose 59, 0x01da, 0x0101, 0x9c0d
+ax_pose 60, 0x01da, 0x00f5, 0x9c0e
+ax_pose 61, 0x01ea, 0x0109, 0x9c0f
+ax_pose_terminator
+sDragonairPose27:
+ax_pose 62, 0x81eb, 0x80f5, 0x9c00
+ax_pose 63, 0x81db, 0x00fc, 0x9c08
+ax_pose 64, 0x81fb, 0x0105, 0x9c0a
+ax_pose_terminator
+sDragonairPose28:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose29:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose30:
+ax_pose 65, 0x81e1, 0x90f3, 0x9c00
+ax_pose 66, 0x81e1, 0x50eb, 0x9c08
+ax_pose 67, 0x01d9, 0x10fb, 0x9c0c
+ax_pose 68, 0x01d9, 0x10f3, 0x9c0d
+ax_pose 69, 0x81f1, 0x1103, 0x9c0e
+ax_pose_terminator
+sDragonairPose31:
+ax_pose 70, 0x41ed, 0x50f3, 0x9c00
+ax_pose 71, 0x41f5, 0x90f3, 0x9c04
+ax_pose 72, 0x01e5, 0x10e6, 0x9c0c
+ax_pose 73, 0x41ed, 0x10e3, 0x9c0d
+ax_pose 74, 0x01f5, 0x10eb, 0x9c0f
+ax_pose_terminator
+sDragonairPose32:
+ax_pose 8, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose33:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose34:
+ax_pose 75, 0x81e4, 0x90fa, 0x9c00
+ax_pose 76, 0x01f4, 0x50ea, 0x9c08
+ax_pose 77, 0x01e4, 0x10f2, 0x9c0c
+ax_pose 78, 0x41dc, 0x10f8, 0x9c0d
+ax_pose_terminator
+sDragonairPose35:
+ax_pose 79, 0x41ee, 0x90fe, 0x9c00
+ax_pose 80, 0x41f7, 0x50de, 0x9c08
+ax_pose 81, 0x01e6, 0x1116, 0x9c0c
+ax_pose 82, 0x01ef, 0x10f6, 0x9c0d
+ax_pose_terminator
+sDragonairPose36:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose37:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose38:
+ax_pose 83, 0x81e4, 0x90fb, 0x9c00
+ax_pose 84, 0x81e4, 0x50f3, 0x9c08
+ax_pose 85, 0x01dc, 0x1100, 0x9c0c
+ax_pose 86, 0x01dc, 0x10f8, 0x9c0d
+ax_pose 87, 0x0204, 0x10fb, 0x9c0e
+ax_pose 88, 0x0204, 0x10f3, 0x9c0f
+ax_pose_terminator
+sDragonairPose39:
+ax_pose 89, 0x81dc, 0x9109, 0x9c00
+ax_pose 90, 0x01ec, 0x50f9, 0x9c08
+ax_pose 91, 0x41fb, 0x10f5, 0x9c0c
+ax_pose 92, 0x4203, 0x10ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose40:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose41:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose42:
+ax_pose 93, 0x81e5, 0x80f5, 0x9c00
+ax_pose 94, 0x81e5, 0x4105, 0x9c08
+ax_pose 95, 0x01dd, 0x00f5, 0x9c0c
+ax_pose 96, 0x01dd, 0x0102, 0x9c0d
+ax_pose_terminator
+sDragonairPose43:
+ax_pose 97, 0x81dc, 0x80f5, 0x9c00
+ax_pose 98, 0x81dc, 0x0105, 0x9c08
+ax_pose 99, 0x81fc, 0x40fd, 0x9c0a
+ax_pose_terminator
+sDragonairPose44:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose45:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose46:
+ax_pose 83, 0x81e4, 0x80f5, 0x9c00
+ax_pose 84, 0x81e4, 0x4105, 0x9c08
+ax_pose 85, 0x01dc, 0x00f8, 0x9c0c
+ax_pose 86, 0x01dc, 0x0100, 0x9c0d
+ax_pose 87, 0x0204, 0x00fd, 0x9c0e
+ax_pose 88, 0x0204, 0x0105, 0x9c0f
+ax_pose_terminator
+sDragonairPose47:
+ax_pose 89, 0x81dc, 0x80e7, 0x9c00
+ax_pose 90, 0x01ec, 0x40f7, 0x9c08
+ax_pose 91, 0x41fb, 0x00fb, 0x9c0c
+ax_pose 92, 0x4203, 0x0103, 0x9c0e
+ax_pose_terminator
+sDragonairPose48:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose49:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose50:
+ax_pose 75, 0x81e4, 0x80f8, 0x9c00
+ax_pose 76, 0x01f4, 0x4108, 0x9c08
+ax_pose 77, 0x01e4, 0x0108, 0x9c0c
+ax_pose 78, 0x41dc, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDragonairPose51:
+ax_pose 79, 0x41ee, 0x80e4, 0x9c00
+ax_pose 80, 0x41f7, 0x4104, 0x9c08
+ax_pose 81, 0x01e6, 0x00e4, 0x9c0c
+ax_pose 82, 0x01ef, 0x0104, 0x9c0d
+ax_pose_terminator
+sDragonairPose52:
+ax_pose 49, 0x81e5, 0x80ee, 0x9c00
+ax_pose 50, 0x01f5, 0x40fe, 0x9c08
+ax_pose 51, 0x01f5, 0x410e, 0x9c0c
+ax_pose_terminator
+sDragonairPose53:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose54:
+ax_pose 65, 0x81e1, 0x80fe, 0x9c00
+ax_pose 66, 0x81e1, 0x410e, 0x9c08
+ax_pose 67, 0x01d9, 0x00fe, 0x9c0c
+ax_pose 68, 0x01d9, 0x0106, 0x9c0d
+ax_pose 69, 0x81f1, 0x00f6, 0x9c0e
+ax_pose_terminator
+sDragonairPose55:
+ax_pose 70, 0x41ed, 0x40ee, 0x9c00
+ax_pose 71, 0x41f5, 0x80ee, 0x9c04
+ax_pose 72, 0x01e5, 0x0113, 0x9c0c
+ax_pose 73, 0x41ed, 0x010e, 0x9c0d
+ax_pose 74, 0x01f5, 0x010e, 0x9c0f
+ax_pose_terminator
+sDragonairPose56:
+ax_pose 54, 0x01e6, 0x80f2, 0x9c00
+ax_pose_terminator
+sDragonairPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose58:
+ax_pose 56, 0x01e2, 0x40f9, 0x9c00
+ax_pose 57, 0x41f2, 0x80f1, 0x9c04
+ax_pose 58, 0x01e2, 0x00f1, 0x9c0c
+ax_pose 59, 0x01da, 0x0101, 0x9c0d
+ax_pose 60, 0x01da, 0x00f5, 0x9c0e
+ax_pose 61, 0x01ea, 0x0109, 0x9c0f
+ax_pose_terminator
+sDragonairPose59:
+ax_pose 62, 0x81eb, 0x80f5, 0x9c00
+ax_pose 63, 0x81db, 0x00fc, 0x9c08
+ax_pose 64, 0x81fb, 0x0105, 0x9c0a
+ax_pose_terminator
+sDragonairPose60:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose61:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose62:
+ax_pose 65, 0x81e1, 0x90f3, 0x9c00
+ax_pose 66, 0x81e1, 0x50eb, 0x9c08
+ax_pose 67, 0x01d9, 0x10fb, 0x9c0c
+ax_pose 68, 0x01d9, 0x10f3, 0x9c0d
+ax_pose 69, 0x81f1, 0x1103, 0x9c0e
+ax_pose_terminator
+sDragonairPose63:
+ax_pose 70, 0x41ed, 0x50f3, 0x9c00
+ax_pose 71, 0x41f5, 0x90f3, 0x9c04
+ax_pose 72, 0x01e5, 0x10e6, 0x9c0c
+ax_pose 73, 0x41ed, 0x10e3, 0x9c0d
+ax_pose 74, 0x01f5, 0x10eb, 0x9c0f
+ax_pose_terminator
+sDragonairPose64:
+ax_pose 8, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose65:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose66:
+ax_pose 75, 0x81e4, 0x90fa, 0x9c00
+ax_pose 76, 0x01f4, 0x50ea, 0x9c08
+ax_pose 77, 0x01e4, 0x10f2, 0x9c0c
+ax_pose 78, 0x41dc, 0x10f8, 0x9c0d
+ax_pose_terminator
+sDragonairPose67:
+ax_pose 79, 0x41ee, 0x90fe, 0x9c00
+ax_pose 80, 0x41f7, 0x50de, 0x9c08
+ax_pose 81, 0x01e6, 0x1116, 0x9c0c
+ax_pose 82, 0x01ef, 0x10f6, 0x9c0d
+ax_pose_terminator
+sDragonairPose68:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose69:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose70:
+ax_pose 83, 0x81e4, 0x90fb, 0x9c00
+ax_pose 84, 0x81e4, 0x50f3, 0x9c08
+ax_pose 85, 0x01dc, 0x1100, 0x9c0c
+ax_pose 86, 0x01dc, 0x10f8, 0x9c0d
+ax_pose 87, 0x0204, 0x10fb, 0x9c0e
+ax_pose 88, 0x0204, 0x10f3, 0x9c0f
+ax_pose_terminator
+sDragonairPose71:
+ax_pose 89, 0x81dc, 0x9109, 0x9c00
+ax_pose 90, 0x01ec, 0x50f9, 0x9c08
+ax_pose 91, 0x41fb, 0x10f5, 0x9c0c
+ax_pose 92, 0x4203, 0x10ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose72:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose73:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose74:
+ax_pose 93, 0x81e5, 0x80f5, 0x9c00
+ax_pose 94, 0x81e5, 0x4105, 0x9c08
+ax_pose 95, 0x01dd, 0x00f5, 0x9c0c
+ax_pose 96, 0x01dd, 0x0102, 0x9c0d
+ax_pose_terminator
+sDragonairPose75:
+ax_pose 97, 0x81dc, 0x80f5, 0x9c00
+ax_pose 98, 0x81dc, 0x0105, 0x9c08
+ax_pose 99, 0x81fc, 0x40fd, 0x9c0a
+ax_pose_terminator
+sDragonairPose76:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose77:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose78:
+ax_pose 83, 0x81e4, 0x80f5, 0x9c00
+ax_pose 84, 0x81e4, 0x4105, 0x9c08
+ax_pose 85, 0x01dc, 0x00f8, 0x9c0c
+ax_pose 86, 0x01dc, 0x0100, 0x9c0d
+ax_pose 87, 0x0204, 0x00fd, 0x9c0e
+ax_pose 88, 0x0204, 0x0105, 0x9c0f
+ax_pose_terminator
+sDragonairPose79:
+ax_pose 89, 0x81dc, 0x80e7, 0x9c00
+ax_pose 90, 0x01ec, 0x40f7, 0x9c08
+ax_pose 91, 0x41fb, 0x00fb, 0x9c0c
+ax_pose 92, 0x4203, 0x0103, 0x9c0e
+ax_pose_terminator
+sDragonairPose80:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose81:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose82:
+ax_pose 75, 0x81e4, 0x80f8, 0x9c00
+ax_pose 76, 0x01f4, 0x4108, 0x9c08
+ax_pose 77, 0x01e4, 0x0108, 0x9c0c
+ax_pose 78, 0x41dc, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDragonairPose83:
+ax_pose 79, 0x41ee, 0x80e4, 0x9c00
+ax_pose 80, 0x41f7, 0x4104, 0x9c08
+ax_pose 81, 0x01e6, 0x00e4, 0x9c0c
+ax_pose 82, 0x01ef, 0x0104, 0x9c0d
+ax_pose_terminator
+sDragonairPose84:
+ax_pose 49, 0x81e5, 0x80ee, 0x9c00
+ax_pose 50, 0x01f5, 0x40fe, 0x9c08
+ax_pose 51, 0x01f5, 0x410e, 0x9c0c
+ax_pose_terminator
+sDragonairPose85:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose86:
+ax_pose 65, 0x81e1, 0x80fe, 0x9c00
+ax_pose 66, 0x81e1, 0x410e, 0x9c08
+ax_pose 67, 0x01d9, 0x00fe, 0x9c0c
+ax_pose 68, 0x01d9, 0x0106, 0x9c0d
+ax_pose 69, 0x81f1, 0x00f6, 0x9c0e
+ax_pose_terminator
+sDragonairPose87:
+ax_pose 70, 0x41ed, 0x40ee, 0x9c00
+ax_pose 71, 0x41f5, 0x80ee, 0x9c04
+ax_pose 72, 0x01e5, 0x0113, 0x9c0c
+ax_pose 73, 0x41ed, 0x010e, 0x9c0d
+ax_pose 74, 0x01f5, 0x010e, 0x9c0f
+ax_pose_terminator
+sDragonairPose88:
+ax_pose 54, 0x01e6, 0x80f2, 0x9c00
+ax_pose_terminator
+sDragonairPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose90:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose91:
+ax_pose 6, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose92:
+ax_pose 56, 0x01e2, 0x40f9, 0x9c00
+ax_pose 57, 0x41f2, 0x80f1, 0x9c04
+ax_pose 58, 0x01e2, 0x00f1, 0x9c0c
+ax_pose 59, 0x01da, 0x0101, 0x9c0d
+ax_pose 60, 0x01da, 0x00f5, 0x9c0e
+ax_pose 61, 0x01ea, 0x0109, 0x9c0f
+ax_pose_terminator
+sDragonairPose93:
+ax_pose 62, 0x81eb, 0x80f5, 0x9c00
+ax_pose 63, 0x81db, 0x00fc, 0x9c08
+ax_pose 64, 0x81fb, 0x0105, 0x9c0a
+ax_pose_terminator
+sDragonairPose94:
+ax_pose 100, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose95:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose96:
+ax_pose 8, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose97:
+ax_pose 9, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose98:
+ax_pose 65, 0x81e1, 0x90f3, 0x9c00
+ax_pose 66, 0x81e1, 0x50eb, 0x9c08
+ax_pose 67, 0x01d9, 0x10fb, 0x9c0c
+ax_pose 68, 0x01d9, 0x10f3, 0x9c0d
+ax_pose 69, 0x81f1, 0x1103, 0x9c0e
+ax_pose_terminator
+sDragonairPose99:
+ax_pose 70, 0x41ed, 0x50f3, 0x9c00
+ax_pose 71, 0x41f5, 0x90f3, 0x9c04
+ax_pose 72, 0x01e5, 0x10e6, 0x9c0c
+ax_pose 73, 0x41ed, 0x10e3, 0x9c0d
+ax_pose 74, 0x01f5, 0x10eb, 0x9c0f
+ax_pose_terminator
+sDragonairPose100:
+ax_pose 101, 0x41f5, 0x90f4, 0x9c00
+ax_pose 102, 0x41ed, 0x50f4, 0x9c08
+ax_pose 103, 0x01e5, 0x110c, 0x9c0c
+ax_pose 104, 0x41ed, 0x10e4, 0x9c0d
+ax_pose 105, 0x01f5, 0x10ec, 0x9c0f
+ax_pose_terminator
+sDragonairPose101:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose102:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose103:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose104:
+ax_pose 75, 0x81e4, 0x90fa, 0x9c00
+ax_pose 76, 0x01f4, 0x50ea, 0x9c08
+ax_pose 77, 0x01e4, 0x10f2, 0x9c0c
+ax_pose 78, 0x41dc, 0x10f8, 0x9c0d
+ax_pose_terminator
+sDragonairPose105:
+ax_pose 79, 0x41ee, 0x90fe, 0x9c00
+ax_pose 80, 0x41f7, 0x50de, 0x9c08
+ax_pose 81, 0x01e6, 0x1116, 0x9c0c
+ax_pose 82, 0x01ef, 0x10f6, 0x9c0d
+ax_pose_terminator
+sDragonairPose106:
+ax_pose 106, 0x01e5, 0x5106, 0x9c00
+ax_pose 107, 0x01f5, 0x50f6, 0x9c04
+ax_pose 108, 0x01f5, 0x50e6, 0x9c08
+ax_pose 109, 0x81f5, 0x1106, 0x9c0c
+ax_pose 110, 0x01dd, 0x1108, 0x9c0e
+ax_pose_terminator
+sDragonairPose107:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose108:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose109:
+ax_pose 27, 0x81e3, 0x80fb, 0x9c00
+ax_pose 28, 0x01f3, 0x40eb, 0x9c08
+ax_pose 29, 0x4203, 0x00f9, 0x9c0c
+ax_pose 30, 0x01eb, 0x00f3, 0x9c0e
+ax_pose_terminator
+sDragonairPose110:
+ax_pose 83, 0x81e4, 0x90fb, 0x9c00
+ax_pose 84, 0x81e4, 0x50f3, 0x9c08
+ax_pose 85, 0x01dc, 0x1100, 0x9c0c
+ax_pose 86, 0x01dc, 0x10f8, 0x9c0d
+ax_pose 87, 0x0204, 0x10fb, 0x9c0e
+ax_pose 88, 0x0204, 0x10f3, 0x9c0f
+ax_pose_terminator
+sDragonairPose111:
+ax_pose 89, 0x81dc, 0x9109, 0x9c00
+ax_pose 90, 0x01ec, 0x50f9, 0x9c08
+ax_pose 91, 0x41fb, 0x10f5, 0x9c0c
+ax_pose 92, 0x4203, 0x10ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose112:
+ax_pose 111, 0x81df, 0x9100, 0x9c00
+ax_pose 112, 0x41f7, 0x10f0, 0x9c08
+ax_pose 113, 0x41ff, 0x10f0, 0x9c0a
+ax_pose 114, 0x4207, 0x10f0, 0x9c0c
+ax_pose 115, 0x01ff, 0x1100, 0x9c0e
+ax_pose 116, 0x01ef, 0x10f8, 0x9c0f
+ax_pose_terminator
+sDragonairPose113:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose114:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose115:
+ax_pose 37, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose116:
+ax_pose 93, 0x81e5, 0x80f5, 0x9c00
+ax_pose 94, 0x81e5, 0x4105, 0x9c08
+ax_pose 95, 0x01dd, 0x00f5, 0x9c0c
+ax_pose 96, 0x01dd, 0x0102, 0x9c0d
+ax_pose_terminator
+sDragonairPose117:
+ax_pose 97, 0x81dc, 0x80f5, 0x9c00
+ax_pose 98, 0x81dc, 0x0105, 0x9c08
+ax_pose 99, 0x81fc, 0x40fd, 0x9c0a
+ax_pose_terminator
+sDragonairPose118:
+ax_pose 117, 0x81e0, 0x80f4, 0x9c00
+ax_pose 118, 0x81e0, 0x4104, 0x9c08
+ax_pose 119, 0x0200, 0x00f7, 0x9c0c
+ax_pose 120, 0x0200, 0x00ff, 0x9c0d
+ax_pose 121, 0x0200, 0x0107, 0x9c0e
+ax_pose 122, 0x0208, 0x00f7, 0x9c0f
+ax_pose_terminator
+sDragonairPose119:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose120:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose121:
+ax_pose 45, 0x81e4, 0x80f5, 0x9c00
+ax_pose 46, 0x81f4, 0x0105, 0x9c08
+ax_pose 47, 0x0204, 0x00fe, 0x9c0a
+ax_pose_terminator
+sDragonairPose122:
+ax_pose 83, 0x81e4, 0x80f5, 0x9c00
+ax_pose 84, 0x81e4, 0x4105, 0x9c08
+ax_pose 85, 0x01dc, 0x00f8, 0x9c0c
+ax_pose 86, 0x01dc, 0x0100, 0x9c0d
+ax_pose 87, 0x0204, 0x00fd, 0x9c0e
+ax_pose 88, 0x0204, 0x0105, 0x9c0f
+ax_pose_terminator
+sDragonairPose123:
+ax_pose 89, 0x81dc, 0x80e7, 0x9c00
+ax_pose 90, 0x01ec, 0x40f7, 0x9c08
+ax_pose 91, 0x41fb, 0x00fb, 0x9c0c
+ax_pose 92, 0x4203, 0x0103, 0x9c0e
+ax_pose_terminator
+sDragonairPose124:
+ax_pose 111, 0x81df, 0x80f0, 0x9c00
+ax_pose 112, 0x41f7, 0x0100, 0x9c08
+ax_pose 113, 0x41ff, 0x0100, 0x9c0a
+ax_pose 114, 0x4207, 0x0100, 0x9c0c
+ax_pose 115, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 116, 0x01ef, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose125:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose126:
+ax_pose 49, 0x81e5, 0x80ee, 0x9c00
+ax_pose 50, 0x01f5, 0x40fe, 0x9c08
+ax_pose 51, 0x01f5, 0x410e, 0x9c0c
+ax_pose_terminator
+sDragonairPose127:
+ax_pose 52, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose128:
+ax_pose 75, 0x81e4, 0x80f8, 0x9c00
+ax_pose 76, 0x01f4, 0x4108, 0x9c08
+ax_pose 77, 0x01e4, 0x0108, 0x9c0c
+ax_pose 78, 0x41dc, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDragonairPose129:
+ax_pose 79, 0x41ee, 0x80e4, 0x9c00
+ax_pose 80, 0x41f7, 0x4104, 0x9c08
+ax_pose 81, 0x01e6, 0x00e4, 0x9c0c
+ax_pose 82, 0x01ef, 0x0104, 0x9c0d
+ax_pose_terminator
+sDragonairPose130:
+ax_pose 106, 0x01e5, 0x40ec, 0x9c00
+ax_pose 107, 0x01f5, 0x40fc, 0x9c04
+ax_pose 108, 0x01f5, 0x410c, 0x9c08
+ax_pose 109, 0x81f5, 0x00f4, 0x9c0c
+ax_pose 110, 0x01dd, 0x00f2, 0x9c0e
+ax_pose_terminator
+sDragonairPose131:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose132:
+ax_pose 54, 0x01e6, 0x80f2, 0x9c00
+ax_pose_terminator
+sDragonairPose133:
+ax_pose 55, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose134:
+ax_pose 65, 0x81e1, 0x80fe, 0x9c00
+ax_pose 66, 0x81e1, 0x410e, 0x9c08
+ax_pose 67, 0x01d9, 0x00fe, 0x9c0c
+ax_pose 68, 0x01d9, 0x0106, 0x9c0d
+ax_pose 69, 0x81f1, 0x00f6, 0x9c0e
+ax_pose_terminator
+sDragonairPose135:
+ax_pose 70, 0x41ed, 0x40ee, 0x9c00
+ax_pose 71, 0x41f5, 0x80ee, 0x9c04
+ax_pose 72, 0x01e5, 0x0113, 0x9c0c
+ax_pose 73, 0x41ed, 0x010e, 0x9c0d
+ax_pose 74, 0x01f5, 0x010e, 0x9c0f
+ax_pose_terminator
+sDragonairPose136:
+ax_pose 101, 0x41f5, 0x80ed, 0x9c00
+ax_pose 102, 0x41ed, 0x40ed, 0x9c08
+ax_pose 103, 0x01e5, 0x00ed, 0x9c0c
+ax_pose 104, 0x41ed, 0x010d, 0x9c0d
+ax_pose 105, 0x01f5, 0x010d, 0x9c0f
+ax_pose_terminator
+sDragonairPose137:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose138:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose139:
+ax_pose 6, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose140:
+ax_pose 56, 0x01e2, 0x40f9, 0x9c00
+ax_pose 57, 0x41f2, 0x80f1, 0x9c04
+ax_pose 58, 0x01e2, 0x00f1, 0x9c0c
+ax_pose 59, 0x01da, 0x0101, 0x9c0d
+ax_pose 60, 0x01da, 0x00f5, 0x9c0e
+ax_pose 61, 0x01ea, 0x0109, 0x9c0f
+ax_pose_terminator
+sDragonairPose141:
+ax_pose 62, 0x81eb, 0x80f5, 0x9c00
+ax_pose 63, 0x81db, 0x00fc, 0x9c08
+ax_pose 64, 0x81fb, 0x0105, 0x9c0a
+ax_pose_terminator
+sDragonairPose142:
+ax_pose 100, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose143:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose144:
+ax_pose 8, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose145:
+ax_pose 9, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose146:
+ax_pose 65, 0x81e1, 0x90f3, 0x9c00
+ax_pose 66, 0x81e1, 0x50eb, 0x9c08
+ax_pose 67, 0x01d9, 0x10fb, 0x9c0c
+ax_pose 68, 0x01d9, 0x10f3, 0x9c0d
+ax_pose 69, 0x81f1, 0x1103, 0x9c0e
+ax_pose_terminator
+sDragonairPose147:
+ax_pose 70, 0x41ed, 0x50f3, 0x9c00
+ax_pose 71, 0x41f5, 0x90f3, 0x9c04
+ax_pose 72, 0x01e5, 0x10e6, 0x9c0c
+ax_pose 73, 0x41ed, 0x10e3, 0x9c0d
+ax_pose 74, 0x01f5, 0x10eb, 0x9c0f
+ax_pose_terminator
+sDragonairPose148:
+ax_pose 101, 0x41f5, 0x90f4, 0x9c00
+ax_pose 102, 0x41ed, 0x50f4, 0x9c08
+ax_pose 103, 0x01e5, 0x110c, 0x9c0c
+ax_pose 104, 0x41ed, 0x10e4, 0x9c0d
+ax_pose 105, 0x01f5, 0x10ec, 0x9c0f
+ax_pose_terminator
+sDragonairPose149:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose150:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose151:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose152:
+ax_pose 75, 0x81e4, 0x90fa, 0x9c00
+ax_pose 76, 0x01f4, 0x50ea, 0x9c08
+ax_pose 77, 0x01e4, 0x10f2, 0x9c0c
+ax_pose 78, 0x41dc, 0x10f8, 0x9c0d
+ax_pose_terminator
+sDragonairPose153:
+ax_pose 79, 0x41ee, 0x90fe, 0x9c00
+ax_pose 80, 0x41f7, 0x50de, 0x9c08
+ax_pose 81, 0x01e6, 0x1116, 0x9c0c
+ax_pose 82, 0x01ef, 0x10f6, 0x9c0d
+ax_pose_terminator
+sDragonairPose154:
+ax_pose 106, 0x01e5, 0x5106, 0x9c00
+ax_pose 107, 0x01f5, 0x50f6, 0x9c04
+ax_pose 108, 0x01f5, 0x50e6, 0x9c08
+ax_pose 109, 0x81f5, 0x1106, 0x9c0c
+ax_pose 110, 0x01dd, 0x1108, 0x9c0e
+ax_pose_terminator
+sDragonairPose155:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose156:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose157:
+ax_pose 27, 0x81e3, 0x80fb, 0x9c00
+ax_pose 28, 0x01f3, 0x40eb, 0x9c08
+ax_pose 29, 0x4203, 0x00f9, 0x9c0c
+ax_pose 30, 0x01eb, 0x00f3, 0x9c0e
+ax_pose_terminator
+sDragonairPose158:
+ax_pose 83, 0x81e4, 0x90fb, 0x9c00
+ax_pose 84, 0x81e4, 0x50f3, 0x9c08
+ax_pose 85, 0x01dc, 0x1100, 0x9c0c
+ax_pose 86, 0x01dc, 0x10f8, 0x9c0d
+ax_pose 87, 0x0204, 0x10fb, 0x9c0e
+ax_pose 88, 0x0204, 0x10f3, 0x9c0f
+ax_pose_terminator
+sDragonairPose159:
+ax_pose 89, 0x81dc, 0x9109, 0x9c00
+ax_pose 90, 0x01ec, 0x50f9, 0x9c08
+ax_pose 91, 0x41fb, 0x10f5, 0x9c0c
+ax_pose 92, 0x4203, 0x10ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose160:
+ax_pose 111, 0x81df, 0x9100, 0x9c00
+ax_pose 112, 0x41f7, 0x10f0, 0x9c08
+ax_pose 113, 0x41ff, 0x10f0, 0x9c0a
+ax_pose 114, 0x4207, 0x10f0, 0x9c0c
+ax_pose 115, 0x01ff, 0x1100, 0x9c0e
+ax_pose 116, 0x01ef, 0x10f8, 0x9c0f
+ax_pose_terminator
+sDragonairPose161:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose162:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose163:
+ax_pose 37, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose164:
+ax_pose 93, 0x81e5, 0x80f5, 0x9c00
+ax_pose 94, 0x81e5, 0x4105, 0x9c08
+ax_pose 95, 0x01dd, 0x00f5, 0x9c0c
+ax_pose 96, 0x01dd, 0x0102, 0x9c0d
+ax_pose_terminator
+sDragonairPose165:
+ax_pose 97, 0x81dc, 0x80f5, 0x9c00
+ax_pose 98, 0x81dc, 0x0105, 0x9c08
+ax_pose 99, 0x81fc, 0x40fd, 0x9c0a
+ax_pose_terminator
+sDragonairPose166:
+ax_pose 117, 0x81e0, 0x80f4, 0x9c00
+ax_pose 118, 0x81e0, 0x4104, 0x9c08
+ax_pose 119, 0x0200, 0x00f7, 0x9c0c
+ax_pose 120, 0x0200, 0x00ff, 0x9c0d
+ax_pose 121, 0x0200, 0x0107, 0x9c0e
+ax_pose 122, 0x0208, 0x00f7, 0x9c0f
+ax_pose_terminator
+sDragonairPose167:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose168:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose169:
+ax_pose 45, 0x81e4, 0x80f5, 0x9c00
+ax_pose 46, 0x81f4, 0x0105, 0x9c08
+ax_pose 47, 0x0204, 0x00fe, 0x9c0a
+ax_pose_terminator
+sDragonairPose170:
+ax_pose 83, 0x81e4, 0x80f5, 0x9c00
+ax_pose 84, 0x81e4, 0x4105, 0x9c08
+ax_pose 85, 0x01dc, 0x00f8, 0x9c0c
+ax_pose 86, 0x01dc, 0x0100, 0x9c0d
+ax_pose 87, 0x0204, 0x00fd, 0x9c0e
+ax_pose 88, 0x0204, 0x0105, 0x9c0f
+ax_pose_terminator
+sDragonairPose171:
+ax_pose 89, 0x81dc, 0x80e7, 0x9c00
+ax_pose 90, 0x01ec, 0x40f7, 0x9c08
+ax_pose 91, 0x41fb, 0x00fb, 0x9c0c
+ax_pose 92, 0x4203, 0x0103, 0x9c0e
+ax_pose_terminator
+sDragonairPose172:
+ax_pose 111, 0x81df, 0x80f0, 0x9c00
+ax_pose 112, 0x41f7, 0x0100, 0x9c08
+ax_pose 113, 0x41ff, 0x0100, 0x9c0a
+ax_pose 114, 0x4207, 0x0100, 0x9c0c
+ax_pose 115, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 116, 0x01ef, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose173:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose174:
+ax_pose 49, 0x81e5, 0x80ee, 0x9c00
+ax_pose 50, 0x01f5, 0x40fe, 0x9c08
+ax_pose 51, 0x01f5, 0x410e, 0x9c0c
+ax_pose_terminator
+sDragonairPose175:
+ax_pose 52, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose176:
+ax_pose 75, 0x81e4, 0x80f8, 0x9c00
+ax_pose 76, 0x01f4, 0x4108, 0x9c08
+ax_pose 77, 0x01e4, 0x0108, 0x9c0c
+ax_pose 78, 0x41dc, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDragonairPose177:
+ax_pose 79, 0x41ee, 0x80e4, 0x9c00
+ax_pose 80, 0x41f7, 0x4104, 0x9c08
+ax_pose 81, 0x01e6, 0x00e4, 0x9c0c
+ax_pose 82, 0x01ef, 0x0104, 0x9c0d
+ax_pose_terminator
+sDragonairPose178:
+ax_pose 106, 0x01e5, 0x40ec, 0x9c00
+ax_pose 107, 0x01f5, 0x40fc, 0x9c04
+ax_pose 108, 0x01f5, 0x410c, 0x9c08
+ax_pose 109, 0x81f5, 0x00f4, 0x9c0c
+ax_pose 110, 0x01dd, 0x00f2, 0x9c0e
+ax_pose_terminator
+sDragonairPose179:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose180:
+ax_pose 54, 0x01e6, 0x80f2, 0x9c00
+ax_pose_terminator
+sDragonairPose181:
+ax_pose 55, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose182:
+ax_pose 65, 0x81e1, 0x80fe, 0x9c00
+ax_pose 66, 0x81e1, 0x410e, 0x9c08
+ax_pose 67, 0x01d9, 0x00fe, 0x9c0c
+ax_pose 68, 0x01d9, 0x0106, 0x9c0d
+ax_pose 69, 0x81f1, 0x00f6, 0x9c0e
+ax_pose_terminator
+sDragonairPose183:
+ax_pose 70, 0x41ed, 0x40ee, 0x9c00
+ax_pose 71, 0x41f5, 0x80ee, 0x9c04
+ax_pose 72, 0x01e5, 0x0113, 0x9c0c
+ax_pose 73, 0x41ed, 0x010e, 0x9c0d
+ax_pose 74, 0x01f5, 0x010e, 0x9c0f
+ax_pose_terminator
+sDragonairPose184:
+ax_pose 101, 0x41f5, 0x80ed, 0x9c00
+ax_pose 102, 0x41ed, 0x40ed, 0x9c08
+ax_pose 103, 0x01e5, 0x00ed, 0x9c0c
+ax_pose 104, 0x41ed, 0x010d, 0x9c0d
+ax_pose 105, 0x01f5, 0x010d, 0x9c0f
+ax_pose_terminator
+sDragonairPose185:
+ax_pose 123, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose186:
+ax_pose 124, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose187:
+ax_pose 125, 0x81e4, 0x4107, 0x9c00
+ax_pose 126, 0x01dc, 0x0103, 0x9c04
+ax_pose 127, 0x01dc, 0x00f5, 0x9c05
+ax_pose 128, 0x81ec, 0x00ef, 0x9c06
+ax_pose 129, 0x81e4, 0x80f7, 0x9c08
+ax_pose_terminator
+sDragonairPose188:
+ax_pose 130, 0x01e3, 0x90eb, 0x9c00
+ax_pose_terminator
+sDragonairPose189:
+ax_pose 131, 0x01e3, 0x90ed, 0x9c00
+ax_pose_terminator
+sDragonairPose190:
+ax_pose 132, 0x01e5, 0x90ec, 0x9c00
+ax_pose_terminator
+sDragonairPose191:
+ax_pose 133, 0x41ee, 0x40f0, 0x9c00
+ax_pose 134, 0x01de, 0x0104, 0x9c04
+ax_pose 135, 0x01de, 0x00f5, 0x9c05
+ax_pose 136, 0x41e6, 0x00f8, 0x9c06
+ax_pose 137, 0x41f6, 0x80f0, 0x9c08
+ax_pose_terminator
+sDragonairPose192:
+ax_pose 132, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose193:
+ax_pose 131, 0x01e3, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose194:
+ax_pose 130, 0x01e3, 0x80f5, 0x9c00
+ax_pose_terminator
+sDragonairPose195:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose196:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose197:
+ax_pose 6, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose198:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose199:
+ax_pose 8, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose200:
+ax_pose 9, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose201:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose202:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose203:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose204:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose205:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose206:
+ax_pose 27, 0x81e3, 0x80fb, 0x9c00
+ax_pose 28, 0x01f3, 0x40eb, 0x9c08
+ax_pose 29, 0x4203, 0x00f9, 0x9c0c
+ax_pose 30, 0x01eb, 0x00f3, 0x9c0e
+ax_pose_terminator
+sDragonairPose207:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose208:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose209:
+ax_pose 37, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose210:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose211:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose212:
+ax_pose 45, 0x81e4, 0x80f5, 0x9c00
+ax_pose 46, 0x81f4, 0x0105, 0x9c08
+ax_pose 47, 0x0204, 0x00fe, 0x9c0a
+ax_pose_terminator
+sDragonairPose213:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose214:
+ax_pose 49, 0x81e5, 0x80ee, 0x9c00
+ax_pose 50, 0x01f5, 0x40fe, 0x9c08
+ax_pose 51, 0x01f5, 0x410e, 0x9c0c
+ax_pose_terminator
+sDragonairPose215:
+ax_pose 52, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose216:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose217:
+ax_pose 54, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose218:
+ax_pose 55, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose219:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose220:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose221:
+ax_pose 6, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose222:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose223:
+ax_pose 8, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose224:
+ax_pose 9, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose225:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose226:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose227:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose228:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose229:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose230:
+ax_pose 27, 0x81e3, 0x80fb, 0x9c00
+ax_pose 28, 0x01f3, 0x40eb, 0x9c08
+ax_pose 29, 0x4203, 0x00f9, 0x9c0c
+ax_pose 30, 0x01eb, 0x00f3, 0x9c0e
+ax_pose_terminator
+sDragonairPose231:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose232:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose233:
+ax_pose 37, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose234:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose235:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose236:
+ax_pose 45, 0x81e4, 0x80f5, 0x9c00
+ax_pose 46, 0x81f4, 0x0105, 0x9c08
+ax_pose 47, 0x0204, 0x00fe, 0x9c0a
+ax_pose_terminator
+sDragonairPose237:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose238:
+ax_pose 49, 0x81e5, 0x80ef, 0x9c00
+ax_pose 50, 0x01f5, 0x40ff, 0x9c08
+ax_pose 51, 0x01f5, 0x410f, 0x9c0c
+ax_pose_terminator
+sDragonairPose239:
+ax_pose 52, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose240:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose241:
+ax_pose 54, 0x01e6, 0x80f2, 0x9c00
+ax_pose_terminator
+sDragonairPose242:
+ax_pose 55, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose243:
+ax_pose 56, 0x01e2, 0x40f9, 0x9c00
+ax_pose 57, 0x41f2, 0x80f1, 0x9c04
+ax_pose 58, 0x01e2, 0x00f1, 0x9c0c
+ax_pose 59, 0x01da, 0x0101, 0x9c0d
+ax_pose 60, 0x01da, 0x00f5, 0x9c0e
+ax_pose 61, 0x01ea, 0x0109, 0x9c0f
+ax_pose_terminator
+sDragonairPose244:
+ax_pose 65, 0x81e1, 0x90f7, 0x9c00
+ax_pose 66, 0x81e1, 0x50ef, 0x9c08
+ax_pose 67, 0x01d9, 0x10ff, 0x9c0c
+ax_pose 68, 0x01d9, 0x10f7, 0x9c0d
+ax_pose 69, 0x81f1, 0x1107, 0x9c0e
+ax_pose_terminator
+sDragonairPose245:
+ax_pose 75, 0x81e4, 0x90fc, 0x9c00
+ax_pose 76, 0x01f4, 0x50ec, 0x9c08
+ax_pose 77, 0x01e4, 0x10f4, 0x9c0c
+ax_pose 78, 0x41dc, 0x10fa, 0x9c0d
+ax_pose_terminator
+sDragonairPose246:
+ax_pose 83, 0x81e4, 0x90fc, 0x9c00
+ax_pose 84, 0x81e4, 0x50f4, 0x9c08
+ax_pose 85, 0x01dc, 0x1101, 0x9c0c
+ax_pose 86, 0x01dc, 0x10f9, 0x9c0d
+ax_pose 87, 0x0204, 0x10fc, 0x9c0e
+ax_pose 88, 0x0204, 0x10f4, 0x9c0f
+ax_pose_terminator
+sDragonairPose247:
+ax_pose 93, 0x81e4, 0x80f5, 0x9c00
+ax_pose 94, 0x81e4, 0x4105, 0x9c08
+ax_pose 95, 0x01dc, 0x00f5, 0x9c0c
+ax_pose 96, 0x01dc, 0x0102, 0x9c0d
+ax_pose_terminator
+sDragonairPose248:
+ax_pose 83, 0x81e4, 0x80f5, 0x9c00
+ax_pose 84, 0x81e4, 0x4105, 0x9c08
+ax_pose 85, 0x01dc, 0x00f8, 0x9c0c
+ax_pose 86, 0x01dc, 0x0100, 0x9c0d
+ax_pose 87, 0x0204, 0x00fd, 0x9c0e
+ax_pose 88, 0x0204, 0x0105, 0x9c0f
+ax_pose_terminator
+sDragonairPose249:
+ax_pose 75, 0x81e4, 0x80f5, 0x9c00
+ax_pose 76, 0x01f4, 0x4105, 0x9c08
+ax_pose 77, 0x01e4, 0x0105, 0x9c0c
+ax_pose 78, 0x41dc, 0x00f7, 0x9c0d
+ax_pose_terminator
+sDragonairPose250:
+ax_pose 65, 0x81e1, 0x80f9, 0x9c00
+ax_pose 66, 0x81e1, 0x4109, 0x9c08
+ax_pose 67, 0x01d9, 0x00f9, 0x9c0c
+ax_pose 68, 0x01d9, 0x0101, 0x9c0d
+ax_pose 69, 0x81f1, 0x00f1, 0x9c0e
+ax_pose_terminator
+sDragonairPose251:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose252:
+ax_pose 1, 0x41e7, 0x80f0, 0x9c00
+ax_pose 2, 0x41f7, 0x40f0, 0x9c08
+ax_pose 3, 0x41ff, 0x0100, 0x9c0c
+ax_pose 4, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 5, 0x01df, 0x0100, 0x9c0f
+ax_pose_terminator
+sDragonairPose253:
+ax_pose 56, 0x01e2, 0x40f9, 0x9c00
+ax_pose 57, 0x41f2, 0x80f1, 0x9c04
+ax_pose 58, 0x01e2, 0x00f1, 0x9c0c
+ax_pose 59, 0x01da, 0x0101, 0x9c0d
+ax_pose 60, 0x01da, 0x00f5, 0x9c0e
+ax_pose 61, 0x01ea, 0x0109, 0x9c0f
+ax_pose_terminator
+sDragonairPose254:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose255:
+ax_pose 8, 0x01e5, 0x80ee, 0x9c00
+ax_pose_terminator
+sDragonairPose256:
+ax_pose 65, 0x81e1, 0x90f7, 0x9c00
+ax_pose 66, 0x81e1, 0x50ef, 0x9c08
+ax_pose 67, 0x01d9, 0x10ff, 0x9c0c
+ax_pose 68, 0x01d9, 0x10f7, 0x9c0d
+ax_pose 69, 0x81f1, 0x1107, 0x9c0e
+ax_pose_terminator
+sDragonairPose257:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose258:
+ax_pose 11, 0x81e5, 0x8100, 0x9c00
+ax_pose 12, 0x81e5, 0x0110, 0x9c08
+ax_pose 13, 0x01f5, 0x0110, 0x9c0a
+ax_pose 14, 0x01fd, 0x00f0, 0x9c0b
+ax_pose 15, 0x81f5, 0x00f8, 0x9c0c
+ax_pose 16, 0x81ed, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose259:
+ax_pose 75, 0x81e4, 0x90fb, 0x9c00
+ax_pose 76, 0x01f4, 0x50eb, 0x9c08
+ax_pose 77, 0x01e4, 0x10f3, 0x9c0c
+ax_pose 78, 0x41dc, 0x10f9, 0x9c0d
+ax_pose_terminator
+sDragonairPose260:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose261:
+ax_pose 22, 0x81e3, 0x8100, 0x9c00
+ax_pose 23, 0x81f3, 0x00f8, 0x9c08
+ax_pose 24, 0x4203, 0x00f5, 0x9c0a
+ax_pose 25, 0x81f3, 0x00ed, 0x9c0c
+ax_pose 26, 0x0203, 0x00ed, 0x9c0e
+ax_pose_terminator
+sDragonairPose262:
+ax_pose 83, 0x81e4, 0x90fb, 0x9c00
+ax_pose 84, 0x81e4, 0x50f3, 0x9c08
+ax_pose 85, 0x01dc, 0x1100, 0x9c0c
+ax_pose 86, 0x01dc, 0x10f8, 0x9c0d
+ax_pose 87, 0x0204, 0x10fb, 0x9c0e
+ax_pose 88, 0x0204, 0x10f3, 0x9c0f
+ax_pose_terminator
+sDragonairPose263:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose264:
+ax_pose 32, 0x81e2, 0x80f4, 0x9c00
+ax_pose 33, 0x81e2, 0x4104, 0x9c08
+ax_pose 34, 0x0202, 0x00f4, 0x9c0c
+ax_pose 35, 0x0202, 0x00fc, 0x9c0d
+ax_pose 36, 0x0202, 0x0104, 0x9c0e
+ax_pose_terminator
+sDragonairPose265:
+ax_pose 93, 0x81e5, 0x80f5, 0x9c00
+ax_pose 94, 0x81e5, 0x4105, 0x9c08
+ax_pose 95, 0x01dd, 0x00f5, 0x9c0c
+ax_pose 96, 0x01dd, 0x0102, 0x9c0d
+ax_pose_terminator
+sDragonairPose266:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose267:
+ax_pose 41, 0x81e4, 0x80f1, 0x9c00
+ax_pose 42, 0x01f4, 0x4101, 0x9c08
+ax_pose 43, 0x4204, 0x0101, 0x9c0c
+ax_pose 44, 0x01fc, 0x0111, 0x9c0e
+ax_pose_terminator
+sDragonairPose268:
+ax_pose 83, 0x81e4, 0x80f5, 0x9c00
+ax_pose 84, 0x81e4, 0x4105, 0x9c08
+ax_pose 85, 0x01dc, 0x00f8, 0x9c0c
+ax_pose 86, 0x01dc, 0x0100, 0x9c0d
+ax_pose 87, 0x0204, 0x00fd, 0x9c0e
+ax_pose 88, 0x0204, 0x0105, 0x9c0f
+ax_pose_terminator
+sDragonairPose269:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose270:
+ax_pose 49, 0x81e5, 0x80ee, 0x9c00
+ax_pose 50, 0x01f5, 0x40fe, 0x9c08
+ax_pose 51, 0x01f5, 0x410e, 0x9c0c
+ax_pose_terminator
+sDragonairPose271:
+ax_pose 75, 0x81e4, 0x80f8, 0x9c00
+ax_pose 76, 0x01f4, 0x4108, 0x9c08
+ax_pose 77, 0x01e4, 0x0108, 0x9c0c
+ax_pose 78, 0x41dc, 0x00fa, 0x9c0d
+ax_pose_terminator
+sDragonairPose272:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose273:
+ax_pose 54, 0x01e6, 0x80f2, 0x9c00
+ax_pose_terminator
+sDragonairPose274:
+ax_pose 65, 0x81e1, 0x80fe, 0x9c00
+ax_pose 66, 0x81e1, 0x410e, 0x9c08
+ax_pose 67, 0x01d9, 0x00fe, 0x9c0c
+ax_pose 68, 0x01d9, 0x0106, 0x9c0d
+ax_pose 69, 0x81f1, 0x00f6, 0x9c0e
+ax_pose_terminator
+sDragonairPose275:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose276:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose277:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose278:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose279:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose280:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose281:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose282:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose283:
+ax_pose 0, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose284:
+ax_pose 53, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sDragonairPose285:
+ax_pose 48, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sDragonairPose286:
+ax_pose 38, 0x81e4, 0x80f5, 0x9c00
+ax_pose 39, 0x01f4, 0x4105, 0x9c08
+ax_pose 40, 0x4204, 0x00fd, 0x9c0c
+ax_pose_terminator
+sDragonairPose287:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose288:
+ax_pose 18, 0x81e3, 0x80fd, 0x9c00
+ax_pose 19, 0x01f3, 0x40ed, 0x9c08
+ax_pose 20, 0x41eb, 0x00ed, 0x9c0c
+ax_pose 21, 0x4203, 0x00f5, 0x9c0e
+ax_pose_terminator
+sDragonairPose289:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sDragonairPose290:
+ax_pose 7, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+.align 2
+sDragonairAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 1, 0, 2, 0, 2,
+ax_anim 6, 0, 0, 0, 3, 0, 3,
+ax_anim 6, 0, 2, 0, 1, 0, 1,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 4, 2, 2, 2, 2,
+ax_anim 6, 0, 3, 3, 3, 3, 3,
+ax_anim 6, 0, 5, 2, 2, 2, 2,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 7, 2, 0, 2, 0,
+ax_anim 6, 0, 6, 3, 0, 3, 0,
+ax_anim 6, 0, 8, 2, 0, 2, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 10, 2, -2, 2, -2,
+ax_anim 6, 0, 9, 3, -3, 3, -3,
+ax_anim 6, 0, 11, 2, -2, 2, -2,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, -1,
+ax_anim 8, 0, 13, 0, -2, 0, -2,
+ax_anim 6, 0, 12, 0, -3, 0, -3,
+ax_anim 6, 0, 14, 0, -1, 0, -1,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 16, -2, -2, -2, -2,
+ax_anim 6, 0, 15, -3, -3, -3, -3,
+ax_anim 6, 0, 17, -2, -2, -2, -2,
+ax_anim 6, 0, 17, 0, 0, -1, -1,
+ax_anim_terminator
+sDragonairAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, 0, 0, 0,
+ax_anim 8, 0, 19, -2, 0, 0, 0,
+ax_anim 6, 0, 18, -3, 0, 0, 0,
+ax_anim 6, 0, 20, -2, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 22, -2, 2, -2, 2,
+ax_anim 6, 0, 21, -4, 3, -3, 3,
+ax_anim 6, 0, 23, -2, 2, -2, 2,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragonairAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 2, 27, 0, 2, 0, 2,
+ax_anim 1, 0, 26, 0, 8, 0, 8,
+ax_anim 2, 0, 26, 0, 14, 0, 14,
+ax_anim 2, 1, 26, 1, 14, 1, 14,
+ax_anim 2, 0, 26, 0, 14, 0, 14,
+ax_anim 2, 0, 26, 1, 14, 1, 14,
+ax_anim 2, 0, 27, 0, 6, 0, 6,
+ax_anim_terminator
+sDragonairAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, -4, -4, -4, -4,
+ax_anim 1, 2, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 8, 12, 8, 12,
+ax_anim 2, 0, 30, 14, 20, 14, 20,
+ax_anim 2, 1, 30, 15, 19, 15, 19,
+ax_anim 2, 0, 30, 14, 20, 14, 20,
+ax_anim 2, 0, 30, 15, 19, 15, 19,
+ax_anim 2, 0, 31, 6, 6, 6, 6,
+ax_anim_terminator
+sDragonairAnims_2_3:
+ax_anim 2, 0, 33, -3, 0, -3, 0,
+ax_anim 6, 0, 33, -4, 0, -4, 0,
+ax_anim 1, 0, 32, -6, 0, -6, 0,
+ax_anim 1, 2, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 6, 2, 6, 2,
+ax_anim 2, 0, 34, 8, 2, 8, 2,
+ax_anim 2, 1, 34, 8, 1, 8, 1,
+ax_anim 2, 0, 34, 8, 2, 8, 2,
+ax_anim 2, 0, 34, 8, 1, 8, 1,
+ax_anim 2, 0, 35, 4, 0, 4, 0,
+ax_anim_terminator
+sDragonairAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 2, 39, 2, -2, 2, -2,
+ax_anim 1, 0, 38, 6, -6, 6, -6,
+ax_anim 2, 0, 38, 8, -8, 8, -8,
+ax_anim 2, 1, 38, 9, -7, 9, -7,
+ax_anim 2, 0, 38, 8, -8, 8, -8,
+ax_anim 2, 0, 38, 9, -7, 9, -7,
+ax_anim 2, 0, 39, 5, -5, 5, -5,
+ax_anim_terminator
+sDragonairAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 3, 0, 3,
+ax_anim 1, 2, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, -4, 0, -4,
+ax_anim 2, 0, 42, 0, -8, 0, -8,
+ax_anim 2, 1, 42, 1, -8, 1, -8,
+ax_anim 2, 0, 42, 0, -8, 0, -8,
+ax_anim 2, 0, 42, 1, -8, 1, -8,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sDragonairAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 2, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -4, -4, -4, -4,
+ax_anim 2, 0, 46, -8, -8, -8, -8,
+ax_anim 2, 1, 46, -9, -7, -9, -7,
+ax_anim 2, 0, 46, -8, -8, -8, -8,
+ax_anim 2, 0, 46, -9, -7, -9, -7,
+ax_anim 2, 0, 47, -5, -5, -5, -5,
+ax_anim_terminator
+sDragonairAnims_2_7:
+ax_anim 2, 0, 49, 3, 0, 3, 0,
+ax_anim 6, 0, 49, 4, 0, 4, 0,
+ax_anim 1, 0, 48, 4, 0, 4, 0,
+ax_anim 1, 2, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 50, -6, 1, -6, 1,
+ax_anim 2, 0, 50, -8, 1, -8, 1,
+ax_anim 2, 1, 50, -8, 0, -8, 0,
+ax_anim 2, 0, 50, -8, 1, -8, 1,
+ax_anim 2, 0, 50, -8, 0, -8, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sDragonairAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 3, -3, 0, 0,
+ax_anim 1, 2, 55, 1, -1, -4, 6,
+ax_anim 1, 0, 54, -8, 12, -8, 12,
+ax_anim 2, 0, 54, -14, 20, -14, 20,
+ax_anim 2, 1, 54, -15, 19, -15, 19,
+ax_anim 2, 0, 54, -14, 20, -14, 20,
+ax_anim 2, 0, 54, -15, 19, -15, 19,
+ax_anim 2, 0, 55, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDragonairAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 6, 0, 57, 0, -4, 0, -2,
+ax_anim 1, 0, 56, 0, -4, 0, -2,
+ax_anim 1, 2, 58, 0, -4, 0, 2,
+ax_anim 1, 0, 58, 0, 8, 0, 8,
+ax_anim 2, 0, 58, 0, 14, 0, 14,
+ax_anim 2, 1, 58, 0, 17, 1, 14,
+ax_anim 2, 0, 58, 0, 14, 0, 14,
+ax_anim 2, 0, 58, 0, 17, 1, 14,
+ax_anim 2, 0, 58, 0, 14, 0, 14,
+ax_anim 2, 0, 58, 0, 17, 1, 14,
+ax_anim 2, 0, 59, 0, 6, 0, 6,
+ax_anim_terminator
+sDragonairAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 6, 0, 61, -4, -4, -4, -4,
+ax_anim 1, 0, 60, -4, -4, -4, -4,
+ax_anim 1, 2, 62, -4, -4, -4, -4,
+ax_anim 1, 0, 62, 8, 10, 8, 10,
+ax_anim 2, 0, 62, 14, 17, 14, 17,
+ax_anim 2, 1, 62, 17, 20, 17, 20,
+ax_anim 2, 0, 62, 14, 17, 14, 17,
+ax_anim 2, 0, 62, 17, 20, 17, 20,
+ax_anim 2, 0, 62, 14, 17, 14, 17,
+ax_anim 2, 0, 62, 17, 20, 17, 20,
+ax_anim 2, 0, 63, 6, 7, 6, 7,
+ax_anim_terminator
+sDragonairAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 6, 0, 65, -4, 0, -4, 0,
+ax_anim 1, 0, 64, -4, 0, -4, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 66, 3, 0, 3, 0,
+ax_anim 2, 0, 66, 7, 0, 7, 0,
+ax_anim 2, 1, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 66, 7, 0, 7, 0,
+ax_anim 2, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 66, 7, 0, 7, 0,
+ax_anim 2, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 4, 0, 4, 0,
+ax_anim_terminator
+sDragonairAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 6, 0, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 68, -4, 4, -4, 4,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, 4, -6, 4, -6,
+ax_anim 2, 0, 70, 6, -9, 6, -9,
+ax_anim 2, 1, 70, 9, -12, 9, -12,
+ax_anim 2, 0, 70, 6, -9, 6, -9,
+ax_anim 2, 0, 70, 9, -12, 9, -12,
+ax_anim 2, 0, 70, 6, -9, 6, -9,
+ax_anim 2, 0, 70, 9, -12, 9, -12,
+ax_anim 2, 0, 71, 4, -5, 4, -5,
+ax_anim_terminator
+sDragonairAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 6, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 0, 72, 0, 4, 0, 4,
+ax_anim 1, 2, 74, 0, 4, 0, 4,
+ax_anim 1, 0, 74, 0, -6, 0, -6,
+ax_anim 2, 0, 74, 0, -9, 0, -9,
+ax_anim 2, 1, 74, 0, -12, 0, -12,
+ax_anim 2, 0, 74, 0, -9, 0, -9,
+ax_anim 2, 0, 74, 0, -12, 0, -12,
+ax_anim 2, 0, 74, 0, -9, 0, -9,
+ax_anim 2, 0, 74, 0, -12, 0, -12,
+ax_anim 2, 0, 75, 0, -5, 0, -5,
+ax_anim_terminator
+sDragonairAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 6, 0, 77, 4, 4, 4, 4,
+ax_anim 1, 0, 76, 4, 4, 4, 4,
+ax_anim 1, 2, 78, 4, 4, 4, 4,
+ax_anim 1, 0, 78, -4, -6, -4, -6,
+ax_anim 2, 0, 78, -6, -9, -6, -9,
+ax_anim 2, 1, 78, -9, -12, -9, -12,
+ax_anim 2, 0, 78, -6, -9, -6, -9,
+ax_anim 2, 0, 78, -9, -12, -9, -12,
+ax_anim 2, 0, 78, -6, -9, -6, -9,
+ax_anim 2, 0, 78, -9, -12, -9, -12,
+ax_anim 2, 0, 79, -4, -5, -4, -5,
+ax_anim_terminator
+sDragonairAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 6, 0, 81, 4, 0, 4, 0,
+ax_anim 1, 0, 80, 4, 0, 4, 0,
+ax_anim 1, 2, 82, 4, 0, 4, 0,
+ax_anim 1, 0, 82, -3, 0, -3, 0,
+ax_anim 2, 0, 82, -7, 0, -7, 0,
+ax_anim 2, 1, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 82, -7, 0, -7, 0,
+ax_anim 2, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 82, -7, 0, -7, 0,
+ax_anim 2, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -4, 0, -4, 0,
+ax_anim_terminator
+sDragonairAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 6, 0, 85, 4, -4, 4, -4,
+ax_anim 1, 0, 84, 4, -4, 4, -4,
+ax_anim 1, 2, 86, 4, -4, 4, -4,
+ax_anim 1, 0, 86, -8, 10, -8, 10,
+ax_anim 2, 0, 86, -14, 17, -14, 17,
+ax_anim 2, 1, 86, -17, 20, -17, 20,
+ax_anim 2, 0, 86, -14, 17, -14, 17,
+ax_anim 2, 0, 86, -17, 20, -17, 20,
+ax_anim 2, 0, 86, -14, 17, -14, 17,
+ax_anim 2, 0, 86, -17, 20, -17, 20,
+ax_anim 2, 0, 87, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sDragonairAnims_4_1:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 6, 0, 91, 0, -5, 0, -5,
+ax_anim 1, 2, 91, 0, -3, 0, -3,
+ax_anim 1, 0, 93, 0, 1, 0, 1,
+ax_anim 2, 0, 93, 0, 5, 0, 5,
+ax_anim 2, 1, 93, 1, 5, 1, 5,
+ax_anim 2, 0, 93, 0, 5, 0, 5,
+ax_anim 2, 0, 93, 1, 5, 1, 5,
+ax_anim 2, 0, 93, 0, 5, 0, 5,
+ax_anim 2, 0, 93, 1, 5, 1, 5,
+ax_anim 2, 0, 93, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim_terminator
+sDragonairAnims_4_2:
+ax_anim 2, 0, 96, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -4, -4, -4, -4,
+ax_anim 6, 0, 97, -5, -5, -5, -5,
+ax_anim 1, 2, 97, -3, -3, -3, -3,
+ax_anim 1, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 5, 5, 5, 5,
+ax_anim 2, 1, 99, 6, 4, 6, 4,
+ax_anim 2, 0, 99, 5, 5, 5, 5,
+ax_anim 2, 0, 99, 6, 4, 6, 4,
+ax_anim 2, 0, 99, 5, 5, 5, 5,
+ax_anim 2, 0, 99, 6, 4, 6, 4,
+ax_anim 2, 0, 99, 5, 5, 5, 5,
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim_terminator
+sDragonairAnims_4_3:
+ax_anim 2, 0, 102, -2, 0, -2, 0,
+ax_anim 2, 0, 103, -4, 0, -4, 0,
+ax_anim 6, 0, 103, -5, 0, -5, 0,
+ax_anim 1, 2, 103, -3, 0, -3, 0,
+ax_anim 1, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 5, 0, 5, 0,
+ax_anim 2, 1, 105, 5, 1, 5, 1,
+ax_anim 2, 0, 105, 5, 0, 5, 0,
+ax_anim 2, 0, 105, 5, 1, 5, 1,
+ax_anim 2, 0, 105, 5, 0, 5, 0,
+ax_anim 2, 0, 105, 5, 1, 5, 1,
+ax_anim 2, 0, 105, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 2, 0, 2, 0,
+ax_anim_terminator
+sDragonairAnims_4_4:
+ax_anim 2, 0, 108, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 6, 0, 109, -5, 5, -5, 5,
+ax_anim 1, 2, 109, -3, 3, -3, 3,
+ax_anim 1, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim 2, 1, 111, 6, -4, 6, -4,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim 2, 0, 111, 6, -4, 6, -4,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim 2, 0, 111, 6, -4, 6, -4,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim_terminator
+sDragonairAnims_4_5:
+ax_anim 2, 0, 114, 0, 2, 0, 2,
+ax_anim 2, 0, 115, 0, 4, 0, 4,
+ax_anim 6, 0, 115, 0, 5, 0, 5,
+ax_anim 1, 2, 115, 0, 3, 0, 3,
+ax_anim 1, 0, 117, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, -5, 0, -5,
+ax_anim 2, 1, 117, -1, -5, -1, -5,
+ax_anim 2, 0, 117, 0, -5, 0, -5,
+ax_anim 2, 0, 117, -1, -5, -1, -5,
+ax_anim 2, 0, 117, 0, -5, 0, -5,
+ax_anim 2, 0, 117, -1, -5, -1, -5,
+ax_anim 2, 0, 117, 0, -5, 0, -5,
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim_terminator
+sDragonairAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 2, 0, 121, 4, 4, 4, 4,
+ax_anim 6, 0, 121, 5, 5, 5, 5,
+ax_anim 1, 2, 121, 3, 3, 3, 3,
+ax_anim 1, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, -5, -5, -5, -5,
+ax_anim 2, 1, 123, -6, -4, -6, -4,
+ax_anim 2, 0, 123, -5, -5, -5, -5,
+ax_anim 2, 0, 123, -6, -4, -6, -4,
+ax_anim 2, 0, 123, -5, -5, -5, -5,
+ax_anim 2, 0, 123, -6, -4, -6, -4,
+ax_anim 2, 0, 123, -5, -5, -5, -5,
+ax_anim 2, 0, 120, -2, -2, -2, -2,
+ax_anim_terminator
+sDragonairAnims_4_7:
+ax_anim 2, 0, 126, 2, 0, 2, 0,
+ax_anim 2, 0, 127, 4, 0, 4, 0,
+ax_anim 6, 0, 127, 5, 0, 5, 0,
+ax_anim 1, 2, 127, 3, 0, 3, 0,
+ax_anim 1, 0, 129, -1, 0, -1, 0,
+ax_anim 2, 0, 129, -5, 0, -5, 0,
+ax_anim 2, 1, 129, -5, 1, -5, 1,
+ax_anim 2, 0, 129, -5, 0, -5, 0,
+ax_anim 2, 0, 129, -5, 1, -5, 1,
+ax_anim 2, 0, 129, -5, 0, -5, 0,
+ax_anim 2, 0, 129, -5, 1, -5, 1,
+ax_anim 2, 0, 129, -5, 0, -5, 0,
+ax_anim 2, 0, 126, -2, 0, -2, 0,
+ax_anim_terminator
+sDragonairAnims_4_8:
+ax_anim 2, 0, 132, 2, -2, 2, -2,
+ax_anim 2, 0, 133, 4, -4, 4, -4,
+ax_anim 6, 0, 133, 5, -5, 5, -5,
+ax_anim 1, 2, 133, 3, -3, 3, -3,
+ax_anim 1, 0, 135, -1, 1, -1, 1,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 1, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sDragonairAnims_5_1:
+ax_anim 2, 0, 137, 0, 2, 0, 2,
+ax_anim 2, 0, 140, 0, 8, 0, 8,
+ax_anim 2, 0, 141, 0, 12, 0, 12,
+ax_anim 2, 2, 137, 0, 16, 0, 16,
+ax_anim 2, 0, 136, 0, 16, 0, 16,
+ax_anim 2, 0, 143, 1, 16, 1, 16,
+ax_anim 2, 0, 148, 2, 16, 2, 16,
+ax_anim 2, 0, 156, 1, 16, 1, 16,
+ax_anim 2, 0, 160, 0, 16, 0, 16,
+ax_anim 2, 1, 167, -1, 16, -1, 16,
+ax_anim 2, 0, 172, -2, 16, -2, 16,
+ax_anim 2, 0, 180, -1, 16, -1, 16,
+ax_anim 2, 0, 136, 0, 16, 0, 16,
+ax_anim 2, 0, 139, 0, 11, 0, 11,
+ax_anim 2, 0, 139, 0, 3, 0, 3,
+ax_anim_terminator
+sDragonairAnims_5_2:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 2, 0, 146, 8, 8, 8, 8,
+ax_anim 2, 0, 147, 12, 12, 12, 12,
+ax_anim 2, 2, 143, 16, 16, 16, 16,
+ax_anim 2, 0, 142, 16, 16, 16, 16,
+ax_anim 2, 0, 149, 17, 15, 17, 15,
+ax_anim 2, 0, 154, 18, 14, 18, 14,
+ax_anim 2, 0, 162, 17, 15, 17, 15,
+ax_anim 2, 0, 166, 16, 16, 16, 16,
+ax_anim 2, 1, 173, 15, 17, 15, 17,
+ax_anim 2, 0, 178, 14, 18, 14, 18,
+ax_anim 2, 0, 138, 15, 17, 15, 17,
+ax_anim 2, 0, 142, 16, 16, 16, 16,
+ax_anim 2, 0, 145, 11, 11, 11, 11,
+ax_anim 2, 0, 145, 3, 3, 3, 3,
+ax_anim_terminator
+sDragonairAnims_5_3:
+ax_anim 2, 0, 149, 2, 0, 2, 0,
+ax_anim 2, 0, 152, 8, 0, 8, 0,
+ax_anim 2, 0, 153, 12, 0, 12, 0,
+ax_anim 2, 2, 149, 16, 0, 16, 0,
+ax_anim 2, 0, 148, 16, 0, 16, 0,
+ax_anim 2, 0, 155, 16, 1, 16, 1,
+ax_anim 2, 0, 160, 16, 2, 16, 2,
+ax_anim 2, 0, 168, 16, 1, 16, 1,
+ax_anim 2, 0, 172, 16, 0, 16, 0,
+ax_anim 2, 1, 179, 16, -1, 16, -1,
+ax_anim 2, 0, 136, 16, -2, 16, -2,
+ax_anim 2, 0, 144, 16, -1, 16, -1,
+ax_anim 2, 0, 148, 16, 0, 16, 0,
+ax_anim 2, 0, 151, 11, 0, 11, 0,
+ax_anim 2, 0, 151, 3, 0, 3, 0,
+ax_anim_terminator
+sDragonairAnims_5_4:
+ax_anim 2, 0, 155, 2, -2, 2, -2,
+ax_anim 2, 0, 158, 4, -5, 4, -5,
+ax_anim 2, 0, 159, 12, -14, 12, -14,
+ax_anim 2, 2, 155, 16, -18, 16, -18,
+ax_anim 2, 0, 154, 19, -22, 19, -22,
+ax_anim 2, 0, 161, 20, -21, 20, -21,
+ax_anim 2, 0, 166, 21, -20, 21, -20,
+ax_anim 2, 0, 174, 20, -21, 20, -21,
+ax_anim 2, 0, 178, 19, -22, 19, -22,
+ax_anim 2, 1, 137, 18, -23, 18, -23,
+ax_anim 2, 0, 142, 17, -24, 17, -24,
+ax_anim 2, 0, 150, 18, -23, 18, -23,
+ax_anim 2, 0, 154, 19, -22, 19, -22,
+ax_anim 2, 0, 157, 11, -13, 11, -13,
+ax_anim 2, 0, 157, 3, -4, 3, -4,
+ax_anim_terminator
+sDragonairAnims_5_5:
+ax_anim 2, 0, 161, 0, -2, 0, -2,
+ax_anim 2, 0, 164, 0, -5, 0, -5,
+ax_anim 2, 0, 165, 0, -14, 0, -14,
+ax_anim 2, 2, 161, 0, -18, 0, -18,
+ax_anim 2, 0, 160, 0, -20, 0, -20,
+ax_anim 2, 0, 167, 1, -20, 1, -20,
+ax_anim 2, 0, 172, 2, -20, 2, -20,
+ax_anim 2, 0, 180, 1, -20, 1, -20,
+ax_anim 2, 0, 136, 0, -20, 0, -20,
+ax_anim 2, 1, 143, -1, -20, -1, -20,
+ax_anim 2, 0, 148, -2, -21, -2, -21,
+ax_anim 2, 0, 156, -1, -20, -1, -20,
+ax_anim 2, 0, 160, 0, -20, 0, -20,
+ax_anim 2, 0, 163, 0, -13, 0, -13,
+ax_anim 2, 0, 163, 0, -4, 0, -4,
+ax_anim_terminator
+sDragonairAnims_5_6:
+ax_anim 2, 0, 167, -2, -2, -2, -2,
+ax_anim 2, 0, 170, -4, -5, -4, -5,
+ax_anim 2, 0, 171, -12, -14, -12, -14,
+ax_anim 2, 2, 167, -16, -18, -16, -18,
+ax_anim 2, 0, 166, -19, -22, -19, -22,
+ax_anim 2, 0, 173, -20, -21, -20, -21,
+ax_anim 2, 0, 178, -21, -20, -21, -20,
+ax_anim 2, 0, 138, -20, -21, -20, -21,
+ax_anim 2, 0, 142, -19, -22, -19, -22,
+ax_anim 2, 1, 149, -18, -23, -18, -23,
+ax_anim 2, 0, 154, -17, -24, -17, -24,
+ax_anim 2, 0, 162, -18, -23, -18, -23,
+ax_anim 2, 0, 166, -19, -22, -19, -22,
+ax_anim 2, 0, 169, -11, -13, -11, -13,
+ax_anim 2, 0, 169, -3, -4, -3, -4,
+ax_anim_terminator
+sDragonairAnims_5_7:
+ax_anim 2, 0, 173, -2, 0, -2, 0,
+ax_anim 2, 0, 176, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -12, 0, -12, 0,
+ax_anim 2, 2, 173, -16, 0, -16, 0,
+ax_anim 2, 0, 172, -16, 0, -16, 0,
+ax_anim 2, 0, 179, -16, 1, -16, 1,
+ax_anim 2, 0, 136, -16, 2, -16, 2,
+ax_anim 2, 0, 144, -16, 1, -16, 1,
+ax_anim 2, 0, 148, -16, 0, -16, 0,
+ax_anim 2, 1, 155, -16, -1, -16, -1,
+ax_anim 2, 0, 160, -16, -2, -16, -2,
+ax_anim 2, 0, 168, -16, -1, -16, -1,
+ax_anim 2, 0, 172, -16, 0, -16, 0,
+ax_anim 2, 0, 175, -11, 0, -11, 0,
+ax_anim 2, 0, 175, -3, 0, -3, 0,
+ax_anim_terminator
+sDragonairAnims_5_8:
+ax_anim 2, 0, 179, -2, 2, -2, 2,
+ax_anim 2, 0, 182, -8, 8, -8, 8,
+ax_anim 2, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 2, 179, -16, 16, -16, 16,
+ax_anim 2, 0, 178, -16, 16, -16, 16,
+ax_anim 2, 0, 137, -17, 15, -17, 15,
+ax_anim 2, 0, 142, -18, 14, -18, 14,
+ax_anim 2, 0, 150, -17, 15, -17, 15,
+ax_anim 2, 0, 154, -16, 16, -16, 16,
+ax_anim 2, 1, 161, -15, 17, -15, 17,
+ax_anim 2, 0, 166, -14, 18, -14, 18,
+ax_anim 2, 0, 174, -15, 17, -15, 17,
+ax_anim 2, 0, 178, -16, 16, -16, 16,
+ax_anim 2, 0, 181, -11, 11, -11, 11,
+ax_anim 2, 0, 181, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDragonairAnims_6_1:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 35, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragonairAnims_7_1:
+ax_anim 2, 0, 186, 0, -2, 0, -2,
+ax_anim 8, 0, 186, 0, -3, 0, -3,
+ax_anim_terminator
+sDragonairAnims_7_2:
+ax_anim 2, 0, 187, -2, -2, -2, -2,
+ax_anim 8, 0, 187, -3, -3, -3, -3,
+ax_anim_terminator
+sDragonairAnims_7_3:
+ax_anim 2, 0, 188, -2, 0, -2, 0,
+ax_anim 8, 0, 188, -3, 0, -3, 0,
+ax_anim_terminator
+sDragonairAnims_7_4:
+ax_anim 2, 0, 189, -2, 2, -2, 2,
+ax_anim 8, 0, 189, -3, 3, -3, 3,
+ax_anim_terminator
+sDragonairAnims_7_5:
+ax_anim 2, 0, 190, 0, 2, 0, 2,
+ax_anim 8, 0, 190, 0, 3, 0, 3,
+ax_anim_terminator
+sDragonairAnims_7_6:
+ax_anim 2, 0, 191, 2, 2, 2, 2,
+ax_anim 8, 0, 191, 3, 3, 3, 3,
+ax_anim_terminator
+sDragonairAnims_7_7:
+ax_anim 2, 0, 192, 2, 0, 2, 0,
+ax_anim 8, 0, 192, 3, 0, 3, 0,
+ax_anim_terminator
+sDragonairAnims_7_8:
+ax_anim 2, 0, 193, 2, -2, 2, -2,
+ax_anim 8, 0, 193, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDragonairAnims_8_1:
+ax_anim 12, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 196, 0, 0, 0, 0,
+ax_anim 12, 0, 196, 0, -1, 0, -1,
+ax_anim 10, 0, 194, 0, -1, 0, -1,
+ax_anim_terminator
+sDragonairAnims_8_2:
+ax_anim 12, 0, 197, 0, 0, 0, 0,
+ax_anim 10, 0, 199, 0, 0, 0, 0,
+ax_anim 12, 0, 199, -1, -1, -1, -1,
+ax_anim 10, 0, 197, -1, -1, -1, -1,
+ax_anim_terminator
+sDragonairAnims_8_3:
+ax_anim 12, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 202, 1, 0, 1, 0,
+ax_anim 12, 0, 202, 0, 0, 0, 0,
+ax_anim 10, 0, 200, -1, 0, -1, 0,
+ax_anim_terminator
+sDragonairAnims_8_4:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 10, 0, 205, 1, -1, 1, -1,
+ax_anim 12, 0, 205, 0, 0, 0, 0,
+ax_anim 10, 0, 203, -1, 1, -1, 1,
+ax_anim_terminator
+sDragonairAnims_8_5:
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, -1, 0, -1,
+ax_anim 12, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 206, 0, 1, 0, 1,
+ax_anim_terminator
+sDragonairAnims_8_6:
+ax_anim 12, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 1, 1, 1, 1,
+ax_anim 10, 0, 209, 1, 1, 1, 1,
+ax_anim_terminator
+sDragonairAnims_8_7:
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 10, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 214, 1, 0, 1, 0,
+ax_anim 10, 0, 212, 1, 0, 1, 0,
+ax_anim_terminator
+sDragonairAnims_8_8:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 1, -1, 1, -1,
+ax_anim 10, 0, 215, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sDragonairAnims_9_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 6, 3, 6, 3,
+ax_anim 2, 0, 237, 8, 7, 8, 7,
+ax_anim 2, 0, 234, 7, 12, 7, 12,
+ax_anim 3, 0, 231, 0, 15, 0, 15,
+ax_anim 2, 3, 228, -7, 12, -7, 12,
+ax_anim 2, 0, 225, -8, 7, -8, 7,
+ax_anim 1, 0, 222, -6, 3, -6, 3,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_9_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 8, -2, 8, -2,
+ax_anim 2, 0, 240, 14, 2, 14, 2,
+ax_anim 2, 0, 237, 16, 8, 16, 8,
+ax_anim 3, 0, 234, 14, 14, 14, 14,
+ax_anim 2, 3, 231, 11, 15, 11, 15,
+ax_anim 2, 0, 228, 3, 12, 3, 12,
+ax_anim 1, 0, 225, 0, 5, 0, 5,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_9_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 2, -5, 2, -5,
+ax_anim 2, 0, 219, 9, -6, 9, -6,
+ax_anim 2, 0, 240, 13, -5, 13, -5,
+ax_anim 3, 0, 237, 15, -2, 15, -2,
+ax_anim 2, 3, 234, 13, 4, 13, 4,
+ax_anim 2, 0, 231, 10, 5, 10, 5,
+ax_anim 1, 0, 228, 3, 5, 3, 5,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_9_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 225, -1, -8, -1, -8,
+ax_anim 2, 0, 222, 4, -16, 4, -16,
+ax_anim 2, 0, 219, 12, -22, 12, -22,
+ax_anim 3, 0, 240, 18, -22, 18, -22,
+ax_anim 2, 3, 237, 20, -15, 20, -15,
+ax_anim 2, 0, 234, 17, -4, 17, -4,
+ax_anim 1, 0, 231, 7, -1, 7, -1,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_9_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 228, -8, -4, -8, -4,
+ax_anim 2, 0, 225, -9, -12, -9, -12,
+ax_anim 2, 0, 222, -7, -18, -7, -18,
+ax_anim 3, 0, 219, 0, -22, 0, -22,
+ax_anim 2, 3, 240, 7, -18, 7, -18,
+ax_anim 2, 0, 237, 9, -10, 9, -10,
+ax_anim 1, 0, 234, 8, -4, 8, -4,
+ax_anim 1, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_9_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 1, -6, 1, -6,
+ax_anim 2, 0, 240, -4, -16, -4, -16,
+ax_anim 2, 0, 219, -12, -22, -12, -22,
+ax_anim 3, 0, 222, -18, -22, -18, -22,
+ax_anim 2, 3, 225, -20, -15, -20, -15,
+ax_anim 2, 0, 228, -17, -4, -17, -4,
+ax_anim 1, 0, 231, -7, -1, -7, -1,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_9_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 240, -2, -5, -2, -5,
+ax_anim 2, 0, 219, -9, -6, -9, -6,
+ax_anim 2, 0, 222, -13, -5, -13, -5,
+ax_anim 3, 0, 225, -15, -2, -15, -2,
+ax_anim 2, 3, 228, -13, 4, -13, 4,
+ax_anim 2, 0, 231, -10, 5, -10, 5,
+ax_anim 1, 0, 234, -3, 5, -3, 5,
+ax_anim 1, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_9_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 219, -8, -2, -8, -2,
+ax_anim 2, 0, 222, -14, 2, -14, 2,
+ax_anim 2, 0, 225, -16, 8, -16, 8,
+ax_anim 3, 0, 228, -14, 14, -14, 14,
+ax_anim 2, 3, 231, -11, 15, -11, 15,
+ax_anim 2, 0, 234, -3, 12, -3, 12,
+ax_anim 1, 0, 237, 0, 5, 0, 5,
+ax_anim 1, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragonairAnims_10_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 3, 0, 242, 13, 0, 13, 0,
+ax_anim 3, 0, 242, -13, 0, -13, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_10_2:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 3, 0, 243, 13, -13, 13, -13,
+ax_anim 3, 0, 243, -13, 13, -13, 13,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_10_3:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 3, 0, 244, 0, -13, 0, -13,
+ax_anim 3, 0, 244, 0, 13, 0, 13,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_10_4:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 3, 0, 245, -13, -13, -13, -13,
+ax_anim 3, 0, 245, 13, 13, 13, 13,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_10_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 3, 0, 246, 13, 0, 13, 0,
+ax_anim 3, 0, 246, -13, 0, -13, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_10_6:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 3, 0, 247, 13, -13, 13, -13,
+ax_anim 3, 0, 247, -13, 13, -13, 13,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_10_7:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 3, 0, 248, 0, -13, 0, -13,
+ax_anim 3, 0, 248, 0, 13, 0, 13,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_10_8:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 3, 0, 249, -13, -13, -13, -13,
+ax_anim 3, 0, 249, 13, 13, 13, 13,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragonairAnims_11_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -10, 0, 0,
+ax_anim 2, 0, 252, 0, -15, 0, 0,
+ax_anim 3, 0, 252, 0, -17, 0, 0,
+ax_anim 4, 0, 252, 0, -18, 0, 0,
+ax_anim 4, 0, 250, 0, -23, 0, 0,
+ax_anim 3, 0, 251, 0, -22, 0, 0,
+ax_anim 2, 0, 251, 0, -18, 0, 0,
+ax_anim 1, 0, 251, 0, -12, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_11_2:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, -10, 0, 0,
+ax_anim 2, 0, 255, 0, -11, 0, 0,
+ax_anim 3, 0, 255, 0, -14, 0, 0,
+ax_anim 4, 0, 255, 0, -15, 0, 0,
+ax_anim 4, 0, 253, 0, -23, 0, 0,
+ax_anim 3, 0, 254, 0, -22, 0, 0,
+ax_anim 2, 0, 254, 0, -18, 0, 0,
+ax_anim 1, 0, 254, 0, -12, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_11_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -11, 0, 0,
+ax_anim 3, 0, 258, 0, -15, 0, 0,
+ax_anim 4, 0, 258, 0, -16, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 257, 0, -22, 0, 0,
+ax_anim 2, 0, 257, 0, -18, 0, 0,
+ax_anim 1, 0, 257, 0, -12, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_11_4:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 261, 0, -10, 0, 0,
+ax_anim 2, 0, 261, 0, -12, 0, 0,
+ax_anim 3, 0, 261, 0, -16, 0, 0,
+ax_anim 4, 0, 261, 0, -17, 0, 0,
+ax_anim 4, 0, 259, 0, -22, 0, 0,
+ax_anim 3, 0, 260, 0, -21, 0, 0,
+ax_anim 2, 0, 260, 0, -17, 0, 0,
+ax_anim 1, 0, 260, 0, -11, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_11_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 264, 0, -10, 0, 0,
+ax_anim 2, 0, 264, 0, -16, 0, 0,
+ax_anim 3, 0, 264, 0, -20, 0, 0,
+ax_anim 4, 0, 264, 0, -21, 0, 0,
+ax_anim 4, 0, 264, 0, -23, 0, 0,
+ax_anim 3, 0, 263, 0, -22, 0, 0,
+ax_anim 2, 0, 263, 0, -18, 0, 0,
+ax_anim 1, 0, 263, 0, -12, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_11_6:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 267, 0, -10, 0, 0,
+ax_anim 2, 0, 267, 0, -12, 0, 0,
+ax_anim 3, 0, 267, 0, -16, 0, 0,
+ax_anim 4, 0, 267, 0, -17, 0, 0,
+ax_anim 4, 0, 265, 0, -22, 0, 0,
+ax_anim 3, 0, 266, 0, -21, 0, 0,
+ax_anim 2, 0, 266, 0, -17, 0, 0,
+ax_anim 1, 0, 266, 0, -11, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_11_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 270, 0, -10, 0, 0,
+ax_anim 2, 0, 270, 0, -11, 0, 0,
+ax_anim 3, 0, 270, 0, -15, 0, 0,
+ax_anim 4, 0, 270, 0, -16, 0, 0,
+ax_anim 4, 0, 268, 0, -23, 0, 0,
+ax_anim 3, 0, 269, 0, -22, 0, 0,
+ax_anim 2, 0, 269, 0, -18, 0, 0,
+ax_anim 1, 0, 269, 0, -12, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_11_8:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 1, 0, 273, 0, -10, 0, 0,
+ax_anim 2, 0, 273, 0, -11, 0, 0,
+ax_anim 3, 0, 273, 0, -14, 0, 0,
+ax_anim 4, 0, 273, 0, -15, 0, 0,
+ax_anim 4, 0, 271, 0, -23, 0, 0,
+ax_anim 3, 0, 272, 0, -22, 0, 0,
+ax_anim 2, 0, 272, 0, -18, 0, 0,
+ax_anim 1, 0, 272, 0, -12, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragonairAnims_12_1:
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 1, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_12_2:
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 1, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_12_3:
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 1, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_12_4:
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 1, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_12_5:
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 1, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_12_6:
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 1, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_12_7:
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 1, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_12_8:
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 1, 275, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragonairAnims_13_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_13_2:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_13_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_13_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_13_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_13_6:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_13_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairAnims_13_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sDragonairGfx1:
+.incbin "baserom.gba", 0xB7821C, 0x200
+sDragonairSprites1:
+ax_sprite sDragonairGfx1, 0x200
+ax_sprite_terminator
+sDragonairGfx2:
+.incbin "baserom.gba", 0xB7842C, 0x100
+sDragonairSprites2:
+ax_sprite sDragonairGfx2, 0x100
+ax_sprite_terminator
+sDragonairGfx3:
+.incbin "baserom.gba", 0xB7853C, 0x80
+sDragonairSprites3:
+ax_sprite sDragonairGfx3, 0x80
+ax_sprite_terminator
+sDragonairGfx4:
+.incbin "baserom.gba", 0xB785CC, 0x40
+sDragonairSprites4:
+ax_sprite sDragonairGfx4, 0x40
+ax_sprite_terminator
+sDragonairGfx5:
+.incbin "baserom.gba", 0xB7861C, 0x20
+sDragonairSprites5:
+ax_sprite sDragonairGfx5, 0x20
+ax_sprite_terminator
+sDragonairGfx6:
+.incbin "baserom.gba", 0xB7864C, 0x20
+sDragonairSprites6:
+ax_sprite sDragonairGfx6, 0x20
+ax_sprite_terminator
+sDragonairGfx7:
+.incbin "baserom.gba", 0xB7867C, 0x200
+sDragonairSprites7:
+ax_sprite sDragonairGfx7, 0x200
+ax_sprite_terminator
+sDragonairGfx8:
+.incbin "baserom.gba", 0xB7888C, 0x200
+sDragonairSprites8:
+ax_sprite sDragonairGfx8, 0x200
+ax_sprite_terminator
+sDragonairGfx9:
+.incbin "baserom.gba", 0xB78A9C, 0x200
+sDragonairSprites9:
+ax_sprite sDragonairGfx9, 0x200
+ax_sprite_terminator
+sDragonairGfx10:
+.incbin "baserom.gba", 0xB78CAC, 0x200
+sDragonairSprites10:
+ax_sprite sDragonairGfx10, 0x200
+ax_sprite_terminator
+sDragonairGfx11:
+.incbin "baserom.gba", 0xB78EBC, 0x200
+sDragonairSprites11:
+ax_sprite sDragonairGfx11, 0x200
+ax_sprite_terminator
+sDragonairGfx12:
+.incbin "baserom.gba", 0xB790CC, 0x100
+sDragonairSprites12:
+ax_sprite sDragonairGfx12, 0x100
+ax_sprite_terminator
+sDragonairGfx13:
+.incbin "baserom.gba", 0xB791DC, 0x40
+sDragonairSprites13:
+ax_sprite sDragonairGfx13, 0x40
+ax_sprite_terminator
+sDragonairGfx14:
+.incbin "baserom.gba", 0xB7922C, 0x20
+sDragonairSprites14:
+ax_sprite sDragonairGfx14, 0x20
+ax_sprite_terminator
+sDragonairGfx15:
+.incbin "baserom.gba", 0xB7925C, 0x20
+sDragonairSprites15:
+ax_sprite sDragonairGfx15, 0x20
+ax_sprite_terminator
+sDragonairGfx16:
+.incbin "baserom.gba", 0xB7928C, 0x40
+sDragonairSprites16:
+ax_sprite sDragonairGfx16, 0x40
+ax_sprite_terminator
+sDragonairGfx17:
+.incbin "baserom.gba", 0xB792DC, 0x40
+sDragonairSprites17:
+ax_sprite sDragonairGfx17, 0x40
+ax_sprite_terminator
+sDragonairGfx18:
+.incbin "baserom.gba", 0xB7932C, 0x200
+sDragonairSprites18:
+ax_sprite sDragonairGfx18, 0x200
+ax_sprite_terminator
+sDragonairGfx19:
+.incbin "baserom.gba", 0xB7953C, 0x100
+sDragonairSprites19:
+ax_sprite sDragonairGfx19, 0x100
+ax_sprite_terminator
+sDragonairGfx20:
+.incbin "baserom.gba", 0xB7964C, 0x80
+sDragonairSprites20:
+ax_sprite sDragonairGfx20, 0x80
+ax_sprite_terminator
+sDragonairGfx21:
+.incbin "baserom.gba", 0xB796DC, 0x40
+sDragonairSprites21:
+ax_sprite sDragonairGfx21, 0x40
+ax_sprite_terminator
+sDragonairGfx22:
+.incbin "baserom.gba", 0xB7972C, 0x40
+sDragonairSprites22:
+ax_sprite sDragonairGfx22, 0x40
+ax_sprite_terminator
+sDragonairGfx23:
+.incbin "baserom.gba", 0xB7977C, 0x100
+sDragonairSprites23:
+ax_sprite sDragonairGfx23, 0x100
+ax_sprite_terminator
+sDragonairGfx24:
+.incbin "baserom.gba", 0xB7988C, 0x40
+sDragonairSprites24:
+ax_sprite sDragonairGfx24, 0x40
+ax_sprite_terminator
+sDragonairGfx25:
+.incbin "baserom.gba", 0xB798DC, 0x40
+sDragonairSprites25:
+ax_sprite sDragonairGfx25, 0x40
+ax_sprite_terminator
+sDragonairGfx26:
+.incbin "baserom.gba", 0xB7992C, 0x40
+sDragonairSprites26:
+ax_sprite sDragonairGfx26, 0x40
+ax_sprite_terminator
+sDragonairGfx27:
+.incbin "baserom.gba", 0xB7997C, 0x20
+sDragonairSprites27:
+ax_sprite sDragonairGfx27, 0x20
+ax_sprite_terminator
+sDragonairGfx28:
+.incbin "baserom.gba", 0xB799AC, 0x100
+sDragonairSprites28:
+ax_sprite sDragonairGfx28, 0x100
+ax_sprite_terminator
+sDragonairGfx29:
+.incbin "baserom.gba", 0xB79ABC, 0x80
+sDragonairSprites29:
+ax_sprite sDragonairGfx29, 0x80
+ax_sprite_terminator
+sDragonairGfx30:
+.incbin "baserom.gba", 0xB79B4C, 0x40
+sDragonairSprites30:
+ax_sprite sDragonairGfx30, 0x40
+ax_sprite_terminator
+sDragonairGfx31:
+.incbin "baserom.gba", 0xB79B9C, 0x20
+sDragonairSprites31:
+ax_sprite sDragonairGfx31, 0x20
+ax_sprite_terminator
+sDragonairGfx32:
+.incbin "baserom.gba", 0xB79BCC, 0x200
+sDragonairSprites32:
+ax_sprite sDragonairGfx32, 0x200
+ax_sprite_terminator
+sDragonairGfx33:
+.incbin "baserom.gba", 0xB79DDC, 0x100
+sDragonairSprites33:
+ax_sprite sDragonairGfx33, 0x100
+ax_sprite_terminator
+sDragonairGfx34:
+.incbin "baserom.gba", 0xB79EEC, 0x80
+sDragonairSprites34:
+ax_sprite sDragonairGfx34, 0x80
+ax_sprite_terminator
+sDragonairGfx35:
+.incbin "baserom.gba", 0xB79F7C, 0x20
+sDragonairSprites35:
+ax_sprite sDragonairGfx35, 0x20
+ax_sprite_terminator
+sDragonairGfx36:
+.incbin "baserom.gba", 0xB79FAC, 0x20
+sDragonairSprites36:
+ax_sprite sDragonairGfx36, 0x20
+ax_sprite_terminator
+sDragonairGfx37:
+.incbin "baserom.gba", 0xB79FDC, 0x20
+sDragonairSprites37:
+ax_sprite sDragonairGfx37, 0x20
+ax_sprite_terminator
+sDragonairGfx38:
+.incbin "baserom.gba", 0xB7A00C, 0x200
+sDragonairSprites38:
+ax_sprite sDragonairGfx38, 0x200
+ax_sprite_terminator
+sDragonairGfx39:
+.incbin "baserom.gba", 0xB7A21C, 0x100
+sDragonairSprites39:
+ax_sprite sDragonairGfx39, 0x100
+ax_sprite_terminator
+sDragonairGfx40:
+.incbin "baserom.gba", 0xB7A32C, 0x80
+sDragonairSprites40:
+ax_sprite sDragonairGfx40, 0x80
+ax_sprite_terminator
+sDragonairGfx41:
+.incbin "baserom.gba", 0xB7A3BC, 0x40
+sDragonairSprites41:
+ax_sprite sDragonairGfx41, 0x40
+ax_sprite_terminator
+sDragonairGfx42:
+.incbin "baserom.gba", 0xB7A40C, 0x100
+sDragonairSprites42:
+ax_sprite sDragonairGfx42, 0x100
+ax_sprite_terminator
+sDragonairGfx43:
+.incbin "baserom.gba", 0xB7A51C, 0x80
+sDragonairSprites43:
+ax_sprite sDragonairGfx43, 0x80
+ax_sprite_terminator
+sDragonairGfx44:
+.incbin "baserom.gba", 0xB7A5AC, 0x40
+sDragonairSprites44:
+ax_sprite sDragonairGfx44, 0x40
+ax_sprite_terminator
+sDragonairGfx45:
+.incbin "baserom.gba", 0xB7A5FC, 0x20
+sDragonairSprites45:
+ax_sprite sDragonairGfx45, 0x20
+ax_sprite_terminator
+sDragonairGfx46:
+.incbin "baserom.gba", 0xB7A62C, 0x100
+sDragonairSprites46:
+ax_sprite sDragonairGfx46, 0x100
+ax_sprite_terminator
+sDragonairGfx47:
+.incbin "baserom.gba", 0xB7A73C, 0x40
+sDragonairSprites47:
+ax_sprite sDragonairGfx47, 0x40
+ax_sprite_terminator
+sDragonairGfx48:
+.incbin "baserom.gba", 0xB7A78C, 0x20
+sDragonairSprites48:
+ax_sprite sDragonairGfx48, 0x20
+ax_sprite_terminator
+sDragonairGfx49:
+.incbin "baserom.gba", 0xB7A7BC, 0x200
+sDragonairSprites49:
+ax_sprite sDragonairGfx49, 0x200
+ax_sprite_terminator
+sDragonairGfx50:
+.incbin "baserom.gba", 0xB7A9CC, 0x100
+sDragonairSprites50:
+ax_sprite sDragonairGfx50, 0x100
+ax_sprite_terminator
+sDragonairGfx51:
+.incbin "baserom.gba", 0xB7AADC, 0x80
+sDragonairSprites51:
+ax_sprite sDragonairGfx51, 0x80
+ax_sprite_terminator
+sDragonairGfx52:
+.incbin "baserom.gba", 0xB7AB6C, 0x80
+sDragonairSprites52:
+ax_sprite sDragonairGfx52, 0x80
+ax_sprite_terminator
+sDragonairGfx53:
+.incbin "baserom.gba", 0xB7ABFC, 0x200
+sDragonairSprites53:
+ax_sprite sDragonairGfx53, 0x200
+ax_sprite_terminator
+sDragonairGfx54:
+.incbin "baserom.gba", 0xB7AE0C, 0x200
+sDragonairSprites54:
+ax_sprite sDragonairGfx54, 0x200
+ax_sprite_terminator
+sDragonairGfx55:
+.incbin "baserom.gba", 0xB7B01C, 0x200
+sDragonairSprites55:
+ax_sprite sDragonairGfx55, 0x200
+ax_sprite_terminator
+sDragonairGfx56:
+.incbin "baserom.gba", 0xB7B22C, 0x200
+sDragonairSprites56:
+ax_sprite sDragonairGfx56, 0x200
+ax_sprite_terminator
+sDragonairGfx57:
+.incbin "baserom.gba", 0xB7B43C, 0x80
+sDragonairSprites57:
+ax_sprite sDragonairGfx57, 0x80
+ax_sprite_terminator
+sDragonairGfx58:
+.incbin "baserom.gba", 0xB7B4CC, 0x100
+sDragonairSprites58:
+ax_sprite sDragonairGfx58, 0x100
+ax_sprite_terminator
+sDragonairGfx59:
+.incbin "baserom.gba", 0xB7B5DC, 0x20
+sDragonairSprites59:
+ax_sprite sDragonairGfx59, 0x20
+ax_sprite_terminator
+sDragonairGfx60:
+.incbin "baserom.gba", 0xB7B60C, 0x20
+sDragonairSprites60:
+ax_sprite sDragonairGfx60, 0x20
+ax_sprite_terminator
+sDragonairGfx61:
+.incbin "baserom.gba", 0xB7B63C, 0x20
+sDragonairSprites61:
+ax_sprite sDragonairGfx61, 0x20
+ax_sprite_terminator
+sDragonairGfx62:
+.incbin "baserom.gba", 0xB7B66C, 0x20
+sDragonairSprites62:
+ax_sprite sDragonairGfx62, 0x20
+ax_sprite_terminator
+sDragonairGfx63:
+.incbin "baserom.gba", 0xB7B69C, 0x100
+sDragonairSprites63:
+ax_sprite sDragonairGfx63, 0x100
+ax_sprite_terminator
+sDragonairGfx64:
+.incbin "baserom.gba", 0xB7B7AC, 0x40
+sDragonairSprites64:
+ax_sprite sDragonairGfx64, 0x40
+ax_sprite_terminator
+sDragonairGfx65:
+.incbin "baserom.gba", 0xB7B7FC, 0x40
+sDragonairSprites65:
+ax_sprite sDragonairGfx65, 0x40
+ax_sprite_terminator
+sDragonairGfx66:
+.incbin "baserom.gba", 0xB7B84C, 0x100
+sDragonairSprites66:
+ax_sprite sDragonairGfx66, 0x100
+ax_sprite_terminator
+sDragonairGfx67:
+.incbin "baserom.gba", 0xB7B95C, 0x60
+sDragonairSprites67:
+ax_sprite 0, 0x20
+ax_sprite sDragonairGfx67, 0x60
+ax_sprite_terminator
+sDragonairGfx68:
+.incbin "baserom.gba", 0xB7B9D4, 0x20
+sDragonairSprites68:
+ax_sprite sDragonairGfx68, 0x20
+ax_sprite_terminator
+sDragonairGfx69:
+.incbin "baserom.gba", 0xB7BA04, 0x20
+sDragonairSprites69:
+ax_sprite sDragonairGfx69, 0x20
+ax_sprite_terminator
+sDragonairGfx70:
+.incbin "baserom.gba", 0xB7BA34, 0x40
+sDragonairSprites70:
+ax_sprite sDragonairGfx70, 0x40
+ax_sprite_terminator
+sDragonairGfx71:
+.incbin "baserom.gba", 0xB7BA84, 0x40
+sDragonairGfx71_1:
+.incbin "baserom.gba", 0xB7BAC4, 0x20
+sDragonairSprites71:
+ax_sprite sDragonairGfx71, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDragonairGfx71_1, 0x20
+ax_sprite_terminator
+sDragonairGfx72:
+.incbin "baserom.gba", 0xB7BB04, 0x100
+sDragonairSprites72:
+ax_sprite sDragonairGfx72, 0x100
+ax_sprite_terminator
+sDragonairGfx73:
+.incbin "baserom.gba", 0xB7BC14, 0x20
+sDragonairSprites73:
+ax_sprite sDragonairGfx73, 0x20
+ax_sprite_terminator
+sDragonairGfx74:
+.incbin "baserom.gba", 0xB7BC44, 0x40
+sDragonairSprites74:
+ax_sprite sDragonairGfx74, 0x40
+ax_sprite_terminator
+sDragonairGfx75:
+.incbin "baserom.gba", 0xB7BC94, 0x20
+sDragonairSprites75:
+ax_sprite sDragonairGfx75, 0x20
+ax_sprite_terminator
+sDragonairGfx76:
+.incbin "baserom.gba", 0xB7BCC4, 0x100
+sDragonairSprites76:
+ax_sprite sDragonairGfx76, 0x100
+ax_sprite_terminator
+sDragonairGfx77:
+.incbin "baserom.gba", 0xB7BDD4, 0x80
+sDragonairSprites77:
+ax_sprite sDragonairGfx77, 0x80
+ax_sprite_terminator
+sDragonairGfx78:
+.incbin "baserom.gba", 0xB7BE64, 0x20
+sDragonairSprites78:
+ax_sprite sDragonairGfx78, 0x20
+ax_sprite_terminator
+sDragonairGfx79:
+.incbin "baserom.gba", 0xB7BE94, 0x40
+sDragonairSprites79:
+ax_sprite sDragonairGfx79, 0x40
+ax_sprite_terminator
+sDragonairGfx80:
+.incbin "baserom.gba", 0xB7BEE4, 0x100
+sDragonairSprites80:
+ax_sprite sDragonairGfx80, 0x100
+ax_sprite_terminator
+sDragonairGfx81:
+.incbin "baserom.gba", 0xB7BFF4, 0x80
+sDragonairSprites81:
+ax_sprite sDragonairGfx81, 0x80
+ax_sprite_terminator
+sDragonairGfx82:
+.incbin "baserom.gba", 0xB7C084, 0x20
+sDragonairSprites82:
+ax_sprite sDragonairGfx82, 0x20
+ax_sprite_terminator
+sDragonairGfx83:
+.incbin "baserom.gba", 0xB7C0B4, 0x20
+sDragonairSprites83:
+ax_sprite sDragonairGfx83, 0x20
+ax_sprite_terminator
+sDragonairGfx84:
+.incbin "baserom.gba", 0xB7C0E4, 0x100
+sDragonairSprites84:
+ax_sprite sDragonairGfx84, 0x100
+ax_sprite_terminator
+sDragonairGfx85:
+.incbin "baserom.gba", 0xB7C1F4, 0x20
+sDragonairGfx85_1:
+.incbin "baserom.gba", 0xB7C214, 0x40
+sDragonairSprites85:
+ax_sprite sDragonairGfx85, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDragonairGfx85_1, 0x40
+ax_sprite_terminator
+sDragonairGfx86:
+.incbin "baserom.gba", 0xB7C274, 0x20
+sDragonairSprites86:
+ax_sprite sDragonairGfx86, 0x20
+ax_sprite_terminator
+sDragonairGfx87:
+.incbin "baserom.gba", 0xB7C2A4, 0x20
+sDragonairSprites87:
+ax_sprite sDragonairGfx87, 0x20
+ax_sprite_terminator
+sDragonairGfx88:
+.incbin "baserom.gba", 0xB7C2D4, 0x20
+sDragonairSprites88:
+ax_sprite sDragonairGfx88, 0x20
+ax_sprite_terminator
+sDragonairGfx89:
+.incbin "baserom.gba", 0xB7C304, 0x20
+sDragonairSprites89:
+ax_sprite sDragonairGfx89, 0x20
+ax_sprite_terminator
+sDragonairGfx90:
+.incbin "baserom.gba", 0xB7C334, 0xC0
+sDragonairGfx90_1:
+.incbin "baserom.gba", 0xB7C3F4, 0x20
+sDragonairSprites90:
+ax_sprite sDragonairGfx90, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sDragonairGfx90_1, 0x20
+ax_sprite_terminator
+sDragonairGfx91:
+.incbin "baserom.gba", 0xB7C434, 0x20
+sDragonairGfx91_1:
+.incbin "baserom.gba", 0xB7C454, 0x40
+sDragonairSprites91:
+ax_sprite sDragonairGfx91, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDragonairGfx91_1, 0x40
+ax_sprite_terminator
+sDragonairGfx92:
+.incbin "baserom.gba", 0xB7C4B4, 0x40
+sDragonairSprites92:
+ax_sprite sDragonairGfx92, 0x40
+ax_sprite_terminator
+sDragonairGfx93:
+.incbin "baserom.gba", 0xB7C504, 0x40
+sDragonairSprites93:
+ax_sprite sDragonairGfx93, 0x40
+ax_sprite_terminator
+sDragonairGfx94:
+.incbin "baserom.gba", 0xB7C554, 0x100
+sDragonairSprites94:
+ax_sprite sDragonairGfx94, 0x100
+ax_sprite_terminator
+sDragonairGfx95:
+.incbin "baserom.gba", 0xB7C664, 0x20
+sDragonairGfx95_1:
+.incbin "baserom.gba", 0xB7C684, 0x40
+sDragonairSprites95:
+ax_sprite sDragonairGfx95, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDragonairGfx95_1, 0x40
+ax_sprite_terminator
+sDragonairGfx96:
+.incbin "baserom.gba", 0xB7C6E4, 0x20
+sDragonairSprites96:
+ax_sprite sDragonairGfx96, 0x20
+ax_sprite_terminator
+sDragonairGfx97:
+.incbin "baserom.gba", 0xB7C714, 0x20
+sDragonairSprites97:
+ax_sprite sDragonairGfx97, 0x20
+ax_sprite_terminator
+sDragonairGfx98:
+.incbin "baserom.gba", 0xB7C744, 0x100
+sDragonairSprites98:
+ax_sprite sDragonairGfx98, 0x100
+ax_sprite_terminator
+sDragonairGfx99:
+.incbin "baserom.gba", 0xB7C854, 0x40
+sDragonairSprites99:
+ax_sprite sDragonairGfx99, 0x40
+ax_sprite_terminator
+sDragonairGfx100:
+.incbin "baserom.gba", 0xB7C8A4, 0x60
+sDragonairSprites100:
+ax_sprite sDragonairGfx100, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDragonairGfx101:
+.incbin "baserom.gba", 0xB7C91C, 0x120
+sDragonairGfx101_1:
+.incbin "baserom.gba", 0xB7CA3C, 0x40
+sDragonairSprites101:
+ax_sprite 0, 0x40
+ax_sprite sDragonairGfx101, 0x120
+ax_sprite 0, 0x40
+ax_sprite sDragonairGfx101_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDragonairGfx102:
+.incbin "baserom.gba", 0xB7CAAC, 0x100
+sDragonairSprites102:
+ax_sprite sDragonairGfx102, 0x100
+ax_sprite_terminator
+sDragonairGfx103:
+.incbin "baserom.gba", 0xB7CBBC, 0x80
+sDragonairSprites103:
+ax_sprite sDragonairGfx103, 0x80
+ax_sprite_terminator
+sDragonairGfx104:
+.incbin "baserom.gba", 0xB7CC4C, 0x20
+sDragonairSprites104:
+ax_sprite sDragonairGfx104, 0x20
+ax_sprite_terminator
+sDragonairGfx105:
+.incbin "baserom.gba", 0xB7CC7C, 0x40
+sDragonairSprites105:
+ax_sprite sDragonairGfx105, 0x40
+ax_sprite_terminator
+sDragonairGfx106:
+.incbin "baserom.gba", 0xB7CCCC, 0x20
+sDragonairSprites106:
+ax_sprite sDragonairGfx106, 0x20
+ax_sprite_terminator
+sDragonairGfx107:
+.incbin "baserom.gba", 0xB7CCFC, 0x80
+sDragonairSprites107:
+ax_sprite sDragonairGfx107, 0x80
+ax_sprite_terminator
+sDragonairGfx108:
+.incbin "baserom.gba", 0xB7CD8C, 0x80
+sDragonairSprites108:
+ax_sprite sDragonairGfx108, 0x80
+ax_sprite_terminator
+sDragonairGfx109:
+.incbin "baserom.gba", 0xB7CE1C, 0x80
+sDragonairSprites109:
+ax_sprite sDragonairGfx109, 0x80
+ax_sprite_terminator
+sDragonairGfx110:
+.incbin "baserom.gba", 0xB7CEAC, 0x40
+sDragonairSprites110:
+ax_sprite sDragonairGfx110, 0x40
+ax_sprite_terminator
+sDragonairGfx111:
+.incbin "baserom.gba", 0xB7CEFC, 0x20
+sDragonairSprites111:
+ax_sprite sDragonairGfx111, 0x20
+ax_sprite_terminator
+sDragonairGfx112:
+.incbin "baserom.gba", 0xB7CF2C, 0x100
+sDragonairSprites112:
+ax_sprite sDragonairGfx112, 0x100
+ax_sprite_terminator
+sDragonairGfx113:
+.incbin "baserom.gba", 0xB7D03C, 0x40
+sDragonairSprites113:
+ax_sprite sDragonairGfx113, 0x40
+ax_sprite_terminator
+sDragonairGfx114:
+.incbin "baserom.gba", 0xB7D08C, 0x40
+sDragonairSprites114:
+ax_sprite sDragonairGfx114, 0x40
+ax_sprite_terminator
+sDragonairGfx115:
+.incbin "baserom.gba", 0xB7D0DC, 0x40
+sDragonairSprites115:
+ax_sprite sDragonairGfx115, 0x40
+ax_sprite_terminator
+sDragonairGfx116:
+.incbin "baserom.gba", 0xB7D12C, 0x20
+sDragonairSprites116:
+ax_sprite sDragonairGfx116, 0x20
+ax_sprite_terminator
+sDragonairGfx117:
+.incbin "baserom.gba", 0xB7D15C, 0x20
+sDragonairSprites117:
+ax_sprite sDragonairGfx117, 0x20
+ax_sprite_terminator
+sDragonairGfx118:
+.incbin "baserom.gba", 0xB7D18C, 0x100
+sDragonairSprites118:
+ax_sprite sDragonairGfx118, 0x100
+ax_sprite_terminator
+sDragonairGfx119:
+.incbin "baserom.gba", 0xB7D29C, 0x40
+sDragonairGfx119_1:
+.incbin "baserom.gba", 0xB7D2DC, 0x20
+sDragonairSprites119:
+ax_sprite sDragonairGfx119, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDragonairGfx119_1, 0x20
+ax_sprite_terminator
+sDragonairGfx120:
+.incbin "baserom.gba", 0xB7D31C, 0x20
+sDragonairSprites120:
+ax_sprite sDragonairGfx120, 0x20
+ax_sprite_terminator
+sDragonairGfx121:
+.incbin "baserom.gba", 0xB7D34C, 0x20
+sDragonairSprites121:
+ax_sprite sDragonairGfx121, 0x20
+ax_sprite_terminator
+sDragonairGfx122:
+.incbin "baserom.gba", 0xB7D37C, 0x20
+sDragonairSprites122:
+ax_sprite sDragonairGfx122, 0x20
+ax_sprite_terminator
+sDragonairGfx123:
+.incbin "baserom.gba", 0xB7D3AC, 0x20
+sDragonairSprites123:
+ax_sprite sDragonairGfx123, 0x20
+ax_sprite_terminator
+sDragonairGfx124:
+.incbin "baserom.gba", 0xB7D3DC, 0x200
+sDragonairSprites124:
+ax_sprite sDragonairGfx124, 0x200
+ax_sprite_terminator
+sDragonairGfx125:
+.incbin "baserom.gba", 0xB7D5EC, 0x200
+sDragonairSprites125:
+ax_sprite sDragonairGfx125, 0x200
+ax_sprite_terminator
+sDragonairGfx126:
+.incbin "baserom.gba", 0xB7D7FC, 0x80
+sDragonairSprites126:
+ax_sprite sDragonairGfx126, 0x80
+ax_sprite_terminator
+sDragonairGfx127:
+.incbin "baserom.gba", 0xB7D88C, 0x20
+sDragonairSprites127:
+ax_sprite sDragonairGfx127, 0x20
+ax_sprite_terminator
+sDragonairGfx128:
+.incbin "baserom.gba", 0xB7D8BC, 0x20
+sDragonairSprites128:
+ax_sprite sDragonairGfx128, 0x20
+ax_sprite_terminator
+sDragonairGfx129:
+.incbin "baserom.gba", 0xB7D8EC, 0x40
+sDragonairSprites129:
+ax_sprite sDragonairGfx129, 0x40
+ax_sprite_terminator
+sDragonairGfx130:
+.incbin "baserom.gba", 0xB7D93C, 0x100
+sDragonairSprites130:
+ax_sprite sDragonairGfx130, 0x100
+ax_sprite_terminator
+sDragonairGfx131:
+.incbin "baserom.gba", 0xB7DA4C, 0x200
+sDragonairSprites131:
+ax_sprite sDragonairGfx131, 0x200
+ax_sprite_terminator
+sDragonairGfx132:
+.incbin "baserom.gba", 0xB7DC5C, 0x200
+sDragonairSprites132:
+ax_sprite sDragonairGfx132, 0x200
+ax_sprite_terminator
+sDragonairGfx133:
+.incbin "baserom.gba", 0xB7DE6C, 0x200
+sDragonairSprites133:
+ax_sprite sDragonairGfx133, 0x200
+ax_sprite_terminator
+sDragonairGfx134:
+.incbin "baserom.gba", 0xB7E07C, 0x80
+sDragonairSprites134:
+ax_sprite sDragonairGfx134, 0x80
+ax_sprite_terminator
+sDragonairGfx135:
+.incbin "baserom.gba", 0xB7E10C, 0x20
+sDragonairSprites135:
+ax_sprite sDragonairGfx135, 0x20
+ax_sprite_terminator
+sDragonairGfx136:
+.incbin "baserom.gba", 0xB7E13C, 0x20
+sDragonairSprites136:
+ax_sprite sDragonairGfx136, 0x20
+ax_sprite_terminator
+sDragonairGfx137:
+.incbin "baserom.gba", 0xB7E16C, 0x40
+sDragonairSprites137:
+ax_sprite sDragonairGfx137, 0x40
+ax_sprite_terminator
+sDragonairGfx138:
+.incbin "baserom.gba", 0xB7E1BC, 0x100
+sDragonairSprites138:
+ax_sprite sDragonairGfx138, 0x100
+ax_sprite_terminator
+sAxPosesDragonair:
+.4byte sDragonairPose1
+.4byte sDragonairPose2
+.4byte sDragonairPose3
+.4byte sDragonairPose4
+.4byte sDragonairPose5
+.4byte sDragonairPose6
+.4byte sDragonairPose7
+.4byte sDragonairPose8
+.4byte sDragonairPose9
+.4byte sDragonairPose10
+.4byte sDragonairPose11
+.4byte sDragonairPose12
+.4byte sDragonairPose13
+.4byte sDragonairPose14
+.4byte sDragonairPose15
+.4byte sDragonairPose16
+.4byte sDragonairPose17
+.4byte sDragonairPose18
+.4byte sDragonairPose19
+.4byte sDragonairPose20
+.4byte sDragonairPose21
+.4byte sDragonairPose22
+.4byte sDragonairPose23
+.4byte sDragonairPose24
+.4byte sDragonairPose25
+.4byte sDragonairPose26
+.4byte sDragonairPose27
+.4byte sDragonairPose28
+.4byte sDragonairPose29
+.4byte sDragonairPose30
+.4byte sDragonairPose31
+.4byte sDragonairPose32
+.4byte sDragonairPose33
+.4byte sDragonairPose34
+.4byte sDragonairPose35
+.4byte sDragonairPose36
+.4byte sDragonairPose37
+.4byte sDragonairPose38
+.4byte sDragonairPose39
+.4byte sDragonairPose40
+.4byte sDragonairPose41
+.4byte sDragonairPose42
+.4byte sDragonairPose43
+.4byte sDragonairPose44
+.4byte sDragonairPose45
+.4byte sDragonairPose46
+.4byte sDragonairPose47
+.4byte sDragonairPose48
+.4byte sDragonairPose49
+.4byte sDragonairPose50
+.4byte sDragonairPose51
+.4byte sDragonairPose52
+.4byte sDragonairPose53
+.4byte sDragonairPose54
+.4byte sDragonairPose55
+.4byte sDragonairPose56
+.4byte sDragonairPose57
+.4byte sDragonairPose58
+.4byte sDragonairPose59
+.4byte sDragonairPose60
+.4byte sDragonairPose61
+.4byte sDragonairPose62
+.4byte sDragonairPose63
+.4byte sDragonairPose64
+.4byte sDragonairPose65
+.4byte sDragonairPose66
+.4byte sDragonairPose67
+.4byte sDragonairPose68
+.4byte sDragonairPose69
+.4byte sDragonairPose70
+.4byte sDragonairPose71
+.4byte sDragonairPose72
+.4byte sDragonairPose73
+.4byte sDragonairPose74
+.4byte sDragonairPose75
+.4byte sDragonairPose76
+.4byte sDragonairPose77
+.4byte sDragonairPose78
+.4byte sDragonairPose79
+.4byte sDragonairPose80
+.4byte sDragonairPose81
+.4byte sDragonairPose82
+.4byte sDragonairPose83
+.4byte sDragonairPose84
+.4byte sDragonairPose85
+.4byte sDragonairPose86
+.4byte sDragonairPose87
+.4byte sDragonairPose88
+.4byte sDragonairPose89
+.4byte sDragonairPose90
+.4byte sDragonairPose91
+.4byte sDragonairPose92
+.4byte sDragonairPose93
+.4byte sDragonairPose94
+.4byte sDragonairPose95
+.4byte sDragonairPose96
+.4byte sDragonairPose97
+.4byte sDragonairPose98
+.4byte sDragonairPose99
+.4byte sDragonairPose100
+.4byte sDragonairPose101
+.4byte sDragonairPose102
+.4byte sDragonairPose103
+.4byte sDragonairPose104
+.4byte sDragonairPose105
+.4byte sDragonairPose106
+.4byte sDragonairPose107
+.4byte sDragonairPose108
+.4byte sDragonairPose109
+.4byte sDragonairPose110
+.4byte sDragonairPose111
+.4byte sDragonairPose112
+.4byte sDragonairPose113
+.4byte sDragonairPose114
+.4byte sDragonairPose115
+.4byte sDragonairPose116
+.4byte sDragonairPose117
+.4byte sDragonairPose118
+.4byte sDragonairPose119
+.4byte sDragonairPose120
+.4byte sDragonairPose121
+.4byte sDragonairPose122
+.4byte sDragonairPose123
+.4byte sDragonairPose124
+.4byte sDragonairPose125
+.4byte sDragonairPose126
+.4byte sDragonairPose127
+.4byte sDragonairPose128
+.4byte sDragonairPose129
+.4byte sDragonairPose130
+.4byte sDragonairPose131
+.4byte sDragonairPose132
+.4byte sDragonairPose133
+.4byte sDragonairPose134
+.4byte sDragonairPose135
+.4byte sDragonairPose136
+.4byte sDragonairPose137
+.4byte sDragonairPose138
+.4byte sDragonairPose139
+.4byte sDragonairPose140
+.4byte sDragonairPose141
+.4byte sDragonairPose142
+.4byte sDragonairPose143
+.4byte sDragonairPose144
+.4byte sDragonairPose145
+.4byte sDragonairPose146
+.4byte sDragonairPose147
+.4byte sDragonairPose148
+.4byte sDragonairPose149
+.4byte sDragonairPose150
+.4byte sDragonairPose151
+.4byte sDragonairPose152
+.4byte sDragonairPose153
+.4byte sDragonairPose154
+.4byte sDragonairPose155
+.4byte sDragonairPose156
+.4byte sDragonairPose157
+.4byte sDragonairPose158
+.4byte sDragonairPose159
+.4byte sDragonairPose160
+.4byte sDragonairPose161
+.4byte sDragonairPose162
+.4byte sDragonairPose163
+.4byte sDragonairPose164
+.4byte sDragonairPose165
+.4byte sDragonairPose166
+.4byte sDragonairPose167
+.4byte sDragonairPose168
+.4byte sDragonairPose169
+.4byte sDragonairPose170
+.4byte sDragonairPose171
+.4byte sDragonairPose172
+.4byte sDragonairPose173
+.4byte sDragonairPose174
+.4byte sDragonairPose175
+.4byte sDragonairPose176
+.4byte sDragonairPose177
+.4byte sDragonairPose178
+.4byte sDragonairPose179
+.4byte sDragonairPose180
+.4byte sDragonairPose181
+.4byte sDragonairPose182
+.4byte sDragonairPose183
+.4byte sDragonairPose184
+.4byte sDragonairPose185
+.4byte sDragonairPose186
+.4byte sDragonairPose187
+.4byte sDragonairPose188
+.4byte sDragonairPose189
+.4byte sDragonairPose190
+.4byte sDragonairPose191
+.4byte sDragonairPose192
+.4byte sDragonairPose193
+.4byte sDragonairPose194
+.4byte sDragonairPose195
+.4byte sDragonairPose196
+.4byte sDragonairPose197
+.4byte sDragonairPose198
+.4byte sDragonairPose199
+.4byte sDragonairPose200
+.4byte sDragonairPose201
+.4byte sDragonairPose202
+.4byte sDragonairPose203
+.4byte sDragonairPose204
+.4byte sDragonairPose205
+.4byte sDragonairPose206
+.4byte sDragonairPose207
+.4byte sDragonairPose208
+.4byte sDragonairPose209
+.4byte sDragonairPose210
+.4byte sDragonairPose211
+.4byte sDragonairPose212
+.4byte sDragonairPose213
+.4byte sDragonairPose214
+.4byte sDragonairPose215
+.4byte sDragonairPose216
+.4byte sDragonairPose217
+.4byte sDragonairPose218
+.4byte sDragonairPose219
+.4byte sDragonairPose220
+.4byte sDragonairPose221
+.4byte sDragonairPose222
+.4byte sDragonairPose223
+.4byte sDragonairPose224
+.4byte sDragonairPose225
+.4byte sDragonairPose226
+.4byte sDragonairPose227
+.4byte sDragonairPose228
+.4byte sDragonairPose229
+.4byte sDragonairPose230
+.4byte sDragonairPose231
+.4byte sDragonairPose232
+.4byte sDragonairPose233
+.4byte sDragonairPose234
+.4byte sDragonairPose235
+.4byte sDragonairPose236
+.4byte sDragonairPose237
+.4byte sDragonairPose238
+.4byte sDragonairPose239
+.4byte sDragonairPose240
+.4byte sDragonairPose241
+.4byte sDragonairPose242
+.4byte sDragonairPose243
+.4byte sDragonairPose244
+.4byte sDragonairPose245
+.4byte sDragonairPose246
+.4byte sDragonairPose247
+.4byte sDragonairPose248
+.4byte sDragonairPose249
+.4byte sDragonairPose250
+.4byte sDragonairPose251
+.4byte sDragonairPose252
+.4byte sDragonairPose253
+.4byte sDragonairPose254
+.4byte sDragonairPose255
+.4byte sDragonairPose256
+.4byte sDragonairPose257
+.4byte sDragonairPose258
+.4byte sDragonairPose259
+.4byte sDragonairPose260
+.4byte sDragonairPose261
+.4byte sDragonairPose262
+.4byte sDragonairPose263
+.4byte sDragonairPose264
+.4byte sDragonairPose265
+.4byte sDragonairPose266
+.4byte sDragonairPose267
+.4byte sDragonairPose268
+.4byte sDragonairPose269
+.4byte sDragonairPose270
+.4byte sDragonairPose271
+.4byte sDragonairPose272
+.4byte sDragonairPose273
+.4byte sDragonairPose274
+.4byte sDragonairPose275
+.4byte sDragonairPose276
+.4byte sDragonairPose277
+.4byte sDragonairPose278
+.4byte sDragonairPose279
+.4byte sDragonairPose280
+.4byte sDragonairPose281
+.4byte sDragonairPose282
+.4byte sDragonairPose283
+.4byte sDragonairPose284
+.4byte sDragonairPose285
+.4byte sDragonairPose286
+.4byte sDragonairPose287
+.4byte sDragonairPose288
+.4byte sDragonairPose289
+.4byte sDragonairPose290
+sAxPositionsDragonair:
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte   -1,  -11, 	  -3,   -5, 	   1,   -5, 	  -1,   -5
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte   13,   -8, 	   5,   -3, 	   9,   -4, 	   0,   -6
+.2byte    7,  -12, 	   2,   -6, 	   6,   -7, 	   0,   -4
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    9,  -13, 	   8,   -4, 	   9,   -6, 	   1,   -5
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    8,  -14, 	   7,   -7, 	   4,   -8, 	   1,   -2
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte    0,  -17, 	   1,   -9, 	  -2,   -9, 	   0,   -5
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -7,  -14, 	  -1,  -11, 	  -5,  -10, 	  -4,   -4
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte  -16,  -11, 	 -12,   -7, 	 -10,   -4, 	   0,   -2
+.2byte   -8,  -13, 	  -8,   -8, 	  -7,   -6, 	  -1,   -2
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte  -12,   -8, 	  -8,   -5, 	  -5,   -3, 	   1,    0
+.2byte   -6,  -12, 	  -6,   -7, 	  -3,   -5, 	   2,   -1
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,  -19, 	  -2,  -12, 	   1,  -12, 	   0,   -6
+.2byte    0,    8, 	  -4,    4, 	   3,    5, 	   0,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -15, 	  -2,  -13, 	  -3,   -8
+.2byte   11,    1, 	   4,   -7, 	   1,   -3, 	  -5,   -6
+.2byte   13,   -8, 	   5,   -3, 	   9,   -4, 	   0,   -6
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte    6,  -22, 	   4,  -15, 	   4,  -13, 	   0,   -5
+.2byte   19,   -6, 	  11,  -12, 	  10,  -10, 	  -1,   -7
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte    6,  -22, 	   0,  -18, 	   3,  -17, 	   1,   -6
+.2byte   18,  -20, 	  11,  -21, 	  15,  -20, 	   6,  -12
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte   -1,  -20, 	   1,  -13, 	  -3,  -13, 	  -1,   -9
+.2byte    0,  -22, 	   1,  -21, 	  -2,  -21, 	   0,  -17
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte   -7,  -22, 	  -1,  -18, 	  -4,  -17, 	  -2,   -6
+.2byte  -19,  -20, 	 -12,  -21, 	 -16,  -20, 	  -7,  -12
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte   -5,  -22, 	  -3,  -15, 	  -3,  -13, 	   1,   -5
+.2byte  -18,   -6, 	 -10,  -12, 	  -9,  -10, 	   2,   -7
+.2byte  -16,  -11, 	 -12,   -7, 	 -10,   -4, 	   0,   -2
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte    0,  -21, 	  -1,  -15, 	   2,  -13, 	   3,   -8
+.2byte  -11,    1, 	  -4,   -7, 	  -1,   -3, 	   5,   -6
+.2byte  -12,   -8, 	  -8,   -5, 	  -5,   -3, 	   1,    0
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,  -19, 	  -2,  -12, 	   1,  -12, 	   0,   -6
+.2byte    0,    8, 	  -4,    4, 	   3,    5, 	   0,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -15, 	  -2,  -13, 	  -3,   -8
+.2byte   11,    1, 	   4,   -7, 	   1,   -3, 	  -5,   -6
+.2byte   13,   -8, 	   5,   -3, 	   9,   -4, 	   0,   -6
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte    6,  -22, 	   4,  -15, 	   4,  -13, 	   0,   -5
+.2byte   19,   -6, 	  11,  -12, 	  10,  -10, 	  -1,   -7
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte    6,  -22, 	   0,  -18, 	   3,  -17, 	   1,   -6
+.2byte   18,  -20, 	  11,  -21, 	  15,  -20, 	   6,  -12
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte   -1,  -20, 	   1,  -13, 	  -3,  -13, 	  -1,   -9
+.2byte    0,  -22, 	   1,  -21, 	  -2,  -21, 	   0,  -17
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte   -7,  -22, 	  -1,  -18, 	  -4,  -17, 	  -2,   -6
+.2byte  -19,  -20, 	 -12,  -21, 	 -16,  -20, 	  -7,  -12
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte   -5,  -22, 	  -3,  -15, 	  -3,  -13, 	   1,   -5
+.2byte  -18,   -6, 	 -10,  -12, 	  -9,  -10, 	   2,   -7
+.2byte  -16,  -11, 	 -12,   -7, 	 -10,   -4, 	   0,   -2
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte    0,  -21, 	  -1,  -15, 	   2,  -13, 	   3,   -8
+.2byte  -11,    1, 	  -4,   -7, 	  -1,   -3, 	   5,   -6
+.2byte  -12,   -8, 	  -8,   -5, 	  -5,   -3, 	   1,    0
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte   -1,  -11, 	  -3,   -5, 	   1,   -5, 	  -1,   -5
+.2byte   -1,  -19, 	  -2,  -12, 	   1,  -12, 	   0,   -6
+.2byte    0,    8, 	  -4,    4, 	   3,    5, 	   0,   -6
+.2byte   -1,   -1, 	  -4,   -4, 	   2,   -4, 	  -2,   -5
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte   13,   -8, 	   5,   -3, 	   9,   -4, 	   0,   -6
+.2byte    7,  -12, 	   2,   -6, 	   6,   -7, 	   0,   -4
+.2byte    0,  -21, 	   1,  -15, 	  -2,  -13, 	  -3,   -8
+.2byte   11,    1, 	   4,   -7, 	   1,   -3, 	  -5,   -6
+.2byte   17,   -5, 	   8,   -4, 	   7,   -1, 	   0,   -1
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    9,  -13, 	   8,   -4, 	   9,   -6, 	   1,   -5
+.2byte    6,  -22, 	   4,  -15, 	   4,  -13, 	   0,   -5
+.2byte   19,   -6, 	  11,  -12, 	  10,  -10, 	  -1,   -7
+.2byte   19,  -18, 	   9,  -13, 	  10,  -11, 	   2,   -4
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    8,  -14, 	   7,   -7, 	   4,   -8, 	   1,   -2
+.2byte    6,  -22, 	   0,  -18, 	   3,  -17, 	   1,   -6
+.2byte   18,  -20, 	  11,  -21, 	  15,  -20, 	   6,  -12
+.2byte   13,  -20, 	   4,  -17, 	   7,  -16, 	   1,   -7
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte    0,  -17, 	   1,   -9, 	  -2,   -9, 	   0,   -5
+.2byte   -1,  -20, 	   1,  -13, 	  -3,  -13, 	  -1,   -9
+.2byte    0,  -22, 	   1,  -21, 	  -2,  -21, 	   0,  -17
+.2byte    0,  -23, 	   1,  -16, 	  -2,  -16, 	   0,  -11
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -7,  -14, 	  -1,  -11, 	  -5,  -10, 	  -4,   -4
+.2byte   -7,  -22, 	  -1,  -18, 	  -4,  -17, 	  -2,   -6
+.2byte  -19,  -20, 	 -12,  -21, 	 -16,  -20, 	  -7,  -12
+.2byte  -14,  -20, 	  -5,  -17, 	  -8,  -16, 	  -2,   -7
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte  -16,  -11, 	 -12,   -7, 	 -10,   -4, 	   0,   -2
+.2byte   -8,  -13, 	  -8,   -8, 	  -7,   -6, 	  -1,   -2
+.2byte   -5,  -22, 	  -3,  -15, 	  -3,  -13, 	   1,   -5
+.2byte  -18,   -6, 	 -10,  -12, 	  -9,  -10, 	   2,   -7
+.2byte  -18,  -18, 	  -8,  -13, 	  -9,  -11, 	  -1,   -4
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte  -12,   -8, 	  -8,   -5, 	  -5,   -3, 	   1,    0
+.2byte   -6,  -12, 	  -6,   -7, 	  -3,   -5, 	   2,   -1
+.2byte    0,  -21, 	  -1,  -15, 	   2,  -13, 	   3,   -8
+.2byte  -11,    1, 	  -4,   -7, 	  -1,   -3, 	   5,   -6
+.2byte  -17,   -5, 	  -8,   -4, 	  -7,   -1, 	   0,   -1
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte   -1,  -11, 	  -3,   -5, 	   1,   -5, 	  -1,   -5
+.2byte   -1,  -19, 	  -2,  -12, 	   1,  -12, 	   0,   -6
+.2byte    0,    8, 	  -4,    4, 	   3,    5, 	   0,   -6
+.2byte   -1,   -1, 	  -4,   -4, 	   2,   -4, 	  -2,   -5
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte   13,   -8, 	   5,   -3, 	   9,   -4, 	   0,   -6
+.2byte    7,  -12, 	   2,   -6, 	   6,   -7, 	   0,   -4
+.2byte    0,  -21, 	   1,  -15, 	  -2,  -13, 	  -3,   -8
+.2byte   11,    1, 	   4,   -7, 	   1,   -3, 	  -5,   -6
+.2byte   17,   -5, 	   8,   -4, 	   7,   -1, 	   0,   -1
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    9,  -13, 	   8,   -4, 	   9,   -6, 	   1,   -5
+.2byte    6,  -22, 	   4,  -15, 	   4,  -13, 	   0,   -5
+.2byte   19,   -6, 	  11,  -12, 	  10,  -10, 	  -1,   -7
+.2byte   19,  -18, 	   9,  -13, 	  10,  -11, 	   2,   -4
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    8,  -14, 	   7,   -7, 	   4,   -8, 	   1,   -2
+.2byte    6,  -22, 	   0,  -18, 	   3,  -17, 	   1,   -6
+.2byte   18,  -20, 	  11,  -21, 	  15,  -20, 	   6,  -12
+.2byte   13,  -20, 	   4,  -17, 	   7,  -16, 	   1,   -7
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte    0,  -17, 	   1,   -9, 	  -2,   -9, 	   0,   -5
+.2byte   -1,  -20, 	   1,  -13, 	  -3,  -13, 	  -1,   -9
+.2byte    0,  -22, 	   1,  -21, 	  -2,  -21, 	   0,  -17
+.2byte    0,  -23, 	   1,  -16, 	  -2,  -16, 	   0,  -11
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -7,  -14, 	  -1,  -11, 	  -5,  -10, 	  -4,   -4
+.2byte   -7,  -22, 	  -1,  -18, 	  -4,  -17, 	  -2,   -6
+.2byte  -19,  -20, 	 -12,  -21, 	 -16,  -20, 	  -7,  -12
+.2byte  -14,  -20, 	  -5,  -17, 	  -8,  -16, 	  -2,   -7
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte  -16,  -11, 	 -12,   -7, 	 -10,   -4, 	   0,   -2
+.2byte   -8,  -13, 	  -8,   -8, 	  -7,   -6, 	  -1,   -2
+.2byte   -5,  -22, 	  -3,  -15, 	  -3,  -13, 	   1,   -5
+.2byte  -18,   -6, 	 -10,  -12, 	  -9,  -10, 	   2,   -7
+.2byte  -18,  -18, 	  -8,  -13, 	  -9,  -11, 	  -1,   -4
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte  -12,   -8, 	  -8,   -5, 	  -5,   -3, 	   1,    0
+.2byte   -6,  -12, 	  -6,   -7, 	  -3,   -5, 	   2,   -1
+.2byte    0,  -21, 	  -1,  -15, 	   2,  -13, 	   3,   -8
+.2byte  -11,    1, 	  -4,   -7, 	  -1,   -3, 	   5,   -6
+.2byte  -17,   -5, 	  -8,   -4, 	  -7,   -1, 	   0,   -1
+.2byte   -6,  -11, 	  -4,   -7, 	  -2,   -5, 	  -3,   -3
+.2byte   -6,  -10, 	  -4,   -7, 	  -1,   -5, 	  -4,   -2
+.2byte   -2,  -13, 	  -4,   -6, 	   0,   -6, 	  -2,   -7
+.2byte    4,  -13, 	   5,   -8, 	   2,   -6, 	   2,   -3
+.2byte    6,  -15, 	   8,  -10, 	   7,   -7, 	   2,   -6
+.2byte    5,  -15, 	   0,  -11, 	   3,  -11, 	   3,   -4
+.2byte    0,  -15, 	   2,  -10, 	  -2,  -10, 	   0,   -6
+.2byte   -6,  -15, 	  -1,  -11, 	  -4,  -11, 	  -4,   -4
+.2byte   -7,  -15, 	  -9,  -10, 	  -8,   -7, 	  -3,   -6
+.2byte   -5,  -13, 	  -6,   -8, 	  -3,   -6, 	  -3,   -3
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte   -1,  -11, 	  -3,   -5, 	   1,   -5, 	  -1,   -5
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte   13,   -8, 	   5,   -3, 	   9,   -4, 	   0,   -6
+.2byte    7,  -12, 	   2,   -6, 	   6,   -7, 	   0,   -4
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    9,  -13, 	   8,   -4, 	   9,   -6, 	   1,   -5
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    8,  -14, 	   7,   -7, 	   4,   -8, 	   1,   -2
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte    0,  -17, 	   1,   -9, 	  -2,   -9, 	   0,   -5
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -7,  -14, 	  -1,  -11, 	  -5,  -10, 	  -4,   -4
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte  -16,  -11, 	 -12,   -7, 	 -10,   -4, 	   0,   -2
+.2byte   -8,  -13, 	  -8,   -8, 	  -7,   -6, 	  -1,   -2
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte  -11,   -9, 	  -7,   -6, 	  -4,   -4, 	   2,   -1
+.2byte   -6,  -12, 	  -6,   -7, 	  -3,   -5, 	   2,   -1
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte   -1,  -11, 	  -3,   -5, 	   1,   -5, 	  -1,   -5
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte   13,   -8, 	   5,   -3, 	   9,   -4, 	   0,   -6
+.2byte    7,  -12, 	   2,   -6, 	   6,   -7, 	   0,   -4
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    9,  -13, 	   8,   -4, 	   9,   -6, 	   1,   -5
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    8,  -14, 	   7,   -7, 	   4,   -8, 	   1,   -2
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte    0,  -17, 	   1,   -9, 	  -2,   -9, 	   0,   -5
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -7,  -14, 	  -1,  -11, 	  -5,  -10, 	  -4,   -4
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte  -15,  -11, 	 -11,   -7, 	  -9,   -4, 	   1,   -2
+.2byte   -8,  -13, 	  -8,   -8, 	  -7,   -6, 	  -1,   -2
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte  -12,   -8, 	  -8,   -5, 	  -5,   -3, 	   1,    0
+.2byte   -6,  -12, 	  -6,   -7, 	  -3,   -5, 	   2,   -1
+.2byte   -1,  -19, 	  -2,  -12, 	   1,  -12, 	   0,   -6
+.2byte    4,  -21, 	   5,  -15, 	   2,  -13, 	   1,   -8
+.2byte    8,  -22, 	   6,  -15, 	   6,  -13, 	   2,   -5
+.2byte    7,  -22, 	   1,  -18, 	   4,  -17, 	   2,   -6
+.2byte   -1,  -21, 	   1,  -14, 	  -3,  -14, 	  -1,  -10
+.2byte   -7,  -22, 	  -1,  -18, 	  -4,  -17, 	  -2,   -6
+.2byte   -8,  -22, 	  -6,  -15, 	  -6,  -13, 	  -2,   -5
+.2byte   -5,  -21, 	  -6,  -15, 	  -3,  -13, 	  -2,   -8
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -3,   -3, 	   1,   -3, 	   0,   -6
+.2byte   -1,  -19, 	  -2,  -12, 	   1,  -12, 	   0,   -6
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte   11,   -8, 	   3,   -3, 	   7,   -4, 	  -2,   -6
+.2byte    4,  -21, 	   5,  -15, 	   2,  -13, 	   1,   -8
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte   18,  -12, 	   9,   -3, 	  11,   -7, 	   4,   -2
+.2byte    7,  -22, 	   5,  -15, 	   5,  -13, 	   1,   -5
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   13,  -14, 	   9,   -7, 	   6,   -9, 	   4,   -5
+.2byte    6,  -22, 	   0,  -18, 	   3,  -17, 	   1,   -6
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    0,  -21, 	   1,  -14, 	  -2,  -14, 	  -1,   -8
+.2byte   -1,  -20, 	   1,  -13, 	  -3,  -13, 	  -1,   -9
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte  -13,  -14, 	  -6,  -12, 	  -9,  -11, 	  -3,   -3
+.2byte   -7,  -22, 	  -1,  -18, 	  -4,  -17, 	  -2,   -6
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte  -16,  -11, 	 -12,   -7, 	 -10,   -4, 	   0,   -2
+.2byte   -5,  -22, 	  -3,  -15, 	  -3,  -13, 	   1,   -5
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte  -12,   -8, 	  -8,   -5, 	  -5,   -3, 	   1,    0
+.2byte    0,  -21, 	  -1,  -15, 	   2,  -13, 	   3,   -8
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+.2byte   -1,  -10, 	  -3,   -4, 	   0,   -4, 	  -1,   -6
+.2byte   -7,  -12, 	  -7,   -6, 	  -4,   -5, 	   2,   -2
+.2byte   -9,  -14, 	  -8,   -8, 	  -7,   -6, 	   0,   -1
+.2byte   -8,  -15, 	  -3,  -12, 	  -6,  -11, 	  -2,   -3
+.2byte    0,  -17, 	   1,  -12, 	  -2,  -12, 	  -1,   -5
+.2byte    9,  -15, 	   7,   -7, 	   4,   -9, 	   4,   -5
+.2byte   10,  -14, 	   8,   -3, 	   8,   -7, 	   2,   -4
+.2byte    8,  -12, 	   3,   -5, 	   7,   -6, 	  -1,   -5
+sDragonairAnimTable1:
+.4byte sDragonairAnims_1_1
+.4byte sDragonairAnims_1_2
+.4byte sDragonairAnims_1_3
+.4byte sDragonairAnims_1_4
+.4byte sDragonairAnims_1_5
+.4byte sDragonairAnims_1_6
+.4byte sDragonairAnims_1_7
+.4byte sDragonairAnims_1_8
+sDragonairAnimTable2:
+.4byte sDragonairAnims_2_1
+.4byte sDragonairAnims_2_2
+.4byte sDragonairAnims_2_3
+.4byte sDragonairAnims_2_4
+.4byte sDragonairAnims_2_5
+.4byte sDragonairAnims_2_6
+.4byte sDragonairAnims_2_7
+.4byte sDragonairAnims_2_8
+sDragonairAnimTable3:
+.4byte sDragonairAnims_3_1
+.4byte sDragonairAnims_3_2
+.4byte sDragonairAnims_3_3
+.4byte sDragonairAnims_3_4
+.4byte sDragonairAnims_3_5
+.4byte sDragonairAnims_3_6
+.4byte sDragonairAnims_3_7
+.4byte sDragonairAnims_3_8
+sDragonairAnimTable4:
+.4byte sDragonairAnims_4_1
+.4byte sDragonairAnims_4_2
+.4byte sDragonairAnims_4_3
+.4byte sDragonairAnims_4_4
+.4byte sDragonairAnims_4_5
+.4byte sDragonairAnims_4_6
+.4byte sDragonairAnims_4_7
+.4byte sDragonairAnims_4_8
+sDragonairAnimTable5:
+.4byte sDragonairAnims_5_1
+.4byte sDragonairAnims_5_2
+.4byte sDragonairAnims_5_3
+.4byte sDragonairAnims_5_4
+.4byte sDragonairAnims_5_5
+.4byte sDragonairAnims_5_6
+.4byte sDragonairAnims_5_7
+.4byte sDragonairAnims_5_8
+sDragonairAnimTable6:
+.4byte sDragonairAnims_6_1
+.4byte sDragonairAnims_6_1
+.4byte sDragonairAnims_6_1
+.4byte sDragonairAnims_6_1
+.4byte sDragonairAnims_6_1
+.4byte sDragonairAnims_6_1
+.4byte sDragonairAnims_6_1
+.4byte sDragonairAnims_6_1
+sDragonairAnimTable7:
+.4byte sDragonairAnims_7_1
+.4byte sDragonairAnims_7_2
+.4byte sDragonairAnims_7_3
+.4byte sDragonairAnims_7_4
+.4byte sDragonairAnims_7_5
+.4byte sDragonairAnims_7_6
+.4byte sDragonairAnims_7_7
+.4byte sDragonairAnims_7_8
+sDragonairAnimTable8:
+.4byte sDragonairAnims_8_1
+.4byte sDragonairAnims_8_2
+.4byte sDragonairAnims_8_3
+.4byte sDragonairAnims_8_4
+.4byte sDragonairAnims_8_5
+.4byte sDragonairAnims_8_6
+.4byte sDragonairAnims_8_7
+.4byte sDragonairAnims_8_8
+sDragonairAnimTable9:
+.4byte sDragonairAnims_9_1
+.4byte sDragonairAnims_9_2
+.4byte sDragonairAnims_9_3
+.4byte sDragonairAnims_9_4
+.4byte sDragonairAnims_9_5
+.4byte sDragonairAnims_9_6
+.4byte sDragonairAnims_9_7
+.4byte sDragonairAnims_9_8
+sDragonairAnimTable10:
+.4byte sDragonairAnims_10_1
+.4byte sDragonairAnims_10_2
+.4byte sDragonairAnims_10_3
+.4byte sDragonairAnims_10_4
+.4byte sDragonairAnims_10_5
+.4byte sDragonairAnims_10_6
+.4byte sDragonairAnims_10_7
+.4byte sDragonairAnims_10_8
+sDragonairAnimTable11:
+.4byte sDragonairAnims_11_1
+.4byte sDragonairAnims_11_2
+.4byte sDragonairAnims_11_3
+.4byte sDragonairAnims_11_4
+.4byte sDragonairAnims_11_5
+.4byte sDragonairAnims_11_6
+.4byte sDragonairAnims_11_7
+.4byte sDragonairAnims_11_8
+sDragonairAnimTable12:
+.4byte sDragonairAnims_12_1
+.4byte sDragonairAnims_12_2
+.4byte sDragonairAnims_12_3
+.4byte sDragonairAnims_12_4
+.4byte sDragonairAnims_12_5
+.4byte sDragonairAnims_12_6
+.4byte sDragonairAnims_12_7
+.4byte sDragonairAnims_12_8
+sDragonairAnimTable13:
+.4byte sDragonairAnims_13_1
+.4byte sDragonairAnims_13_2
+.4byte sDragonairAnims_13_3
+.4byte sDragonairAnims_13_4
+.4byte sDragonairAnims_13_5
+.4byte sDragonairAnims_13_6
+.4byte sDragonairAnims_13_7
+.4byte sDragonairAnims_13_8
+sAxAnimationsDragonair:
+.4byte sDragonairAnimTable1
+.4byte sDragonairAnimTable2
+.4byte sDragonairAnimTable3
+.4byte sDragonairAnimTable4
+.4byte sDragonairAnimTable5
+.4byte sDragonairAnimTable6
+.4byte sDragonairAnimTable7
+.4byte sDragonairAnimTable8
+.4byte sDragonairAnimTable9
+.4byte sDragonairAnimTable10
+.4byte sDragonairAnimTable11
+.4byte sDragonairAnimTable12
+.4byte sDragonairAnimTable13
+sAxSpritesDragonair:
+.4byte sDragonairSprites1
+.4byte sDragonairSprites2
+.4byte sDragonairSprites3
+.4byte sDragonairSprites4
+.4byte sDragonairSprites5
+.4byte sDragonairSprites6
+.4byte sDragonairSprites7
+.4byte sDragonairSprites8
+.4byte sDragonairSprites9
+.4byte sDragonairSprites10
+.4byte sDragonairSprites11
+.4byte sDragonairSprites12
+.4byte sDragonairSprites13
+.4byte sDragonairSprites14
+.4byte sDragonairSprites15
+.4byte sDragonairSprites16
+.4byte sDragonairSprites17
+.4byte sDragonairSprites18
+.4byte sDragonairSprites19
+.4byte sDragonairSprites20
+.4byte sDragonairSprites21
+.4byte sDragonairSprites22
+.4byte sDragonairSprites23
+.4byte sDragonairSprites24
+.4byte sDragonairSprites25
+.4byte sDragonairSprites26
+.4byte sDragonairSprites27
+.4byte sDragonairSprites28
+.4byte sDragonairSprites29
+.4byte sDragonairSprites30
+.4byte sDragonairSprites31
+.4byte sDragonairSprites32
+.4byte sDragonairSprites33
+.4byte sDragonairSprites34
+.4byte sDragonairSprites35
+.4byte sDragonairSprites36
+.4byte sDragonairSprites37
+.4byte sDragonairSprites38
+.4byte sDragonairSprites39
+.4byte sDragonairSprites40
+.4byte sDragonairSprites41
+.4byte sDragonairSprites42
+.4byte sDragonairSprites43
+.4byte sDragonairSprites44
+.4byte sDragonairSprites45
+.4byte sDragonairSprites46
+.4byte sDragonairSprites47
+.4byte sDragonairSprites48
+.4byte sDragonairSprites49
+.4byte sDragonairSprites50
+.4byte sDragonairSprites51
+.4byte sDragonairSprites52
+.4byte sDragonairSprites53
+.4byte sDragonairSprites54
+.4byte sDragonairSprites55
+.4byte sDragonairSprites56
+.4byte sDragonairSprites57
+.4byte sDragonairSprites58
+.4byte sDragonairSprites59
+.4byte sDragonairSprites60
+.4byte sDragonairSprites61
+.4byte sDragonairSprites62
+.4byte sDragonairSprites63
+.4byte sDragonairSprites64
+.4byte sDragonairSprites65
+.4byte sDragonairSprites66
+.4byte sDragonairSprites67
+.4byte sDragonairSprites68
+.4byte sDragonairSprites69
+.4byte sDragonairSprites70
+.4byte sDragonairSprites71
+.4byte sDragonairSprites72
+.4byte sDragonairSprites73
+.4byte sDragonairSprites74
+.4byte sDragonairSprites75
+.4byte sDragonairSprites76
+.4byte sDragonairSprites77
+.4byte sDragonairSprites78
+.4byte sDragonairSprites79
+.4byte sDragonairSprites80
+.4byte sDragonairSprites81
+.4byte sDragonairSprites82
+.4byte sDragonairSprites83
+.4byte sDragonairSprites84
+.4byte sDragonairSprites85
+.4byte sDragonairSprites86
+.4byte sDragonairSprites87
+.4byte sDragonairSprites88
+.4byte sDragonairSprites89
+.4byte sDragonairSprites90
+.4byte sDragonairSprites91
+.4byte sDragonairSprites92
+.4byte sDragonairSprites93
+.4byte sDragonairSprites94
+.4byte sDragonairSprites95
+.4byte sDragonairSprites96
+.4byte sDragonairSprites97
+.4byte sDragonairSprites98
+.4byte sDragonairSprites99
+.4byte sDragonairSprites100
+.4byte sDragonairSprites101
+.4byte sDragonairSprites102
+.4byte sDragonairSprites103
+.4byte sDragonairSprites104
+.4byte sDragonairSprites105
+.4byte sDragonairSprites106
+.4byte sDragonairSprites107
+.4byte sDragonairSprites108
+.4byte sDragonairSprites109
+.4byte sDragonairSprites110
+.4byte sDragonairSprites111
+.4byte sDragonairSprites112
+.4byte sDragonairSprites113
+.4byte sDragonairSprites114
+.4byte sDragonairSprites115
+.4byte sDragonairSprites116
+.4byte sDragonairSprites117
+.4byte sDragonairSprites118
+.4byte sDragonairSprites119
+.4byte sDragonairSprites120
+.4byte sDragonairSprites121
+.4byte sDragonairSprites122
+.4byte sDragonairSprites123
+.4byte sDragonairSprites124
+.4byte sDragonairSprites125
+.4byte sDragonairSprites126
+.4byte sDragonairSprites127
+.4byte sDragonairSprites128
+.4byte sDragonairSprites129
+.4byte sDragonairSprites130
+.4byte sDragonairSprites131
+.4byte sDragonairSprites132
+.4byte sDragonairSprites133
+.4byte sDragonairSprites134
+.4byte sDragonairSprites135
+.4byte sDragonairSprites136
+.4byte sDragonairSprites137
+.4byte sDragonairSprites138
+sAxMainDragonair:
+ax_main sAxPosesDragonair, sAxAnimationsDragonair, 13, sAxSpritesDragonair, sAxPositionsDragonair

--- a/data/ax/dragonite.inc
+++ b/data/ax/dragonite.inc
@@ -1,0 +1,3115 @@
+.global gAxDragonite
+gAxDragonite:
+ax_siro sAxMainDragonite
+sDragonitePose1:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose2:
+ax_pose 1, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose3:
+ax_pose 2, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose4:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose5:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose6:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose7:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose8:
+ax_pose 10, 0x01e0, 0x90ee, 0x8c00
+ax_pose 11, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose9:
+ax_pose 12, 0x01e0, 0x90ee, 0x8c00
+ax_pose 13, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose10:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose11:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose12:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose13:
+ax_pose 18, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose14:
+ax_pose 19, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose15:
+ax_pose 20, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose16:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose17:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose18:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose19:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose20:
+ax_pose 10, 0x01e0, 0x80f2, 0x8c00
+ax_pose 11, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose21:
+ax_pose 12, 0x01e0, 0x80f2, 0x8c00
+ax_pose 13, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose22:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose23:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose24:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose25:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose26:
+ax_pose 1, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose27:
+ax_pose 2, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose28:
+ax_pose 21, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose29:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose30:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose31:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose32:
+ax_pose 22, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sDragonitePose33:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose34:
+ax_pose 10, 0x01e0, 0x90ee, 0x8c00
+ax_pose 11, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose35:
+ax_pose 12, 0x01e0, 0x90ee, 0x8c00
+ax_pose 13, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose36:
+ax_pose 23, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose37:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose38:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose39:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose40:
+ax_pose 24, 0x01e2, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose41:
+ax_pose 18, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose42:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose43:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose44:
+ax_pose 25, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose45:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose46:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose47:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose48:
+ax_pose 24, 0x01e2, 0x80ef, 0x8c00
+ax_pose_terminator
+sDragonitePose49:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose50:
+ax_pose 10, 0x01e0, 0x80f2, 0x8c00
+ax_pose 11, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose51:
+ax_pose 12, 0x01e0, 0x80f2, 0x8c00
+ax_pose 13, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose52:
+ax_pose 23, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose53:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose54:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose55:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose56:
+ax_pose 22, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sDragonitePose57:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose58:
+ax_pose 1, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose59:
+ax_pose 2, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose60:
+ax_pose 21, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose61:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose62:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose63:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose64:
+ax_pose 22, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sDragonitePose65:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose66:
+ax_pose 10, 0x01e0, 0x90ee, 0x8c00
+ax_pose 11, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose67:
+ax_pose 12, 0x01e0, 0x90ee, 0x8c00
+ax_pose 13, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose68:
+ax_pose 23, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose69:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose70:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose71:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose72:
+ax_pose 24, 0x01e2, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose73:
+ax_pose 18, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose74:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose75:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose76:
+ax_pose 25, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose77:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose78:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose79:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose80:
+ax_pose 24, 0x01e2, 0x80ef, 0x8c00
+ax_pose_terminator
+sDragonitePose81:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose82:
+ax_pose 10, 0x01e0, 0x80f2, 0x8c00
+ax_pose 11, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose83:
+ax_pose 12, 0x01e0, 0x80f2, 0x8c00
+ax_pose 13, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose84:
+ax_pose 23, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose85:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose86:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose87:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose88:
+ax_pose 22, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sDragonitePose89:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose90:
+ax_pose 1, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose91:
+ax_pose 2, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose92:
+ax_pose 26, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose93:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose94:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose95:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose96:
+ax_pose 27, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose97:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose98:
+ax_pose 10, 0x01e0, 0x90ee, 0x8c00
+ax_pose 11, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose99:
+ax_pose 12, 0x01e0, 0x90ee, 0x8c00
+ax_pose 13, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose100:
+ax_pose 28, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose101:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose102:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose103:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose104:
+ax_pose 29, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose105:
+ax_pose 18, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose106:
+ax_pose 19, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose107:
+ax_pose 20, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose108:
+ax_pose 30, 0x01e1, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose109:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose110:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose111:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose112:
+ax_pose 29, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose113:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose114:
+ax_pose 10, 0x01e0, 0x80f2, 0x8c00
+ax_pose 11, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose115:
+ax_pose 12, 0x01e0, 0x80f2, 0x8c00
+ax_pose 13, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose116:
+ax_pose 28, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sDragonitePose117:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose118:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose119:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose120:
+ax_pose 27, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose121:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose122:
+ax_pose 1, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose123:
+ax_pose 2, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose124:
+ax_pose 26, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose125:
+ax_pose 21, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose126:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose127:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose128:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose129:
+ax_pose 27, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose130:
+ax_pose 22, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sDragonitePose131:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose132:
+ax_pose 10, 0x01e0, 0x90ee, 0x8c00
+ax_pose 11, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose133:
+ax_pose 12, 0x01e0, 0x90ee, 0x8c00
+ax_pose 13, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose134:
+ax_pose 28, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose135:
+ax_pose 23, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose136:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose137:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose138:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose139:
+ax_pose 29, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose140:
+ax_pose 24, 0x01e2, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose141:
+ax_pose 18, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose142:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose143:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose144:
+ax_pose 30, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose145:
+ax_pose 25, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose146:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose147:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose148:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose149:
+ax_pose 29, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose150:
+ax_pose 24, 0x01e2, 0x80ef, 0x8c00
+ax_pose_terminator
+sDragonitePose151:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose152:
+ax_pose 10, 0x01e0, 0x80f2, 0x8c00
+ax_pose 11, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose153:
+ax_pose 12, 0x01e0, 0x80f2, 0x8c00
+ax_pose 13, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose154:
+ax_pose 28, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sDragonitePose155:
+ax_pose 23, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose156:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose157:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose158:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose159:
+ax_pose 27, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose160:
+ax_pose 22, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sDragonitePose161:
+ax_pose 31, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose162:
+ax_pose 32, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose163:
+ax_pose 33, 0x0206, 0x00f9, 0x8c00
+ax_pose 34, 0x41fe, 0x40f1, 0x8c01
+ax_pose 35, 0x01de, 0x80f1, 0x8c05
+ax_pose_terminator
+sDragonitePose164:
+ax_pose 36, 0x01dc, 0x90ef, 0x8c00
+ax_pose 37, 0x41fc, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose165:
+ax_pose 38, 0x01dc, 0x90ef, 0x8c00
+ax_pose 39, 0x41fc, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose166:
+ax_pose 40, 0x01e0, 0x90ee, 0x8c00
+ax_pose_terminator
+sDragonitePose167:
+ax_pose 41, 0x01e0, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose168:
+ax_pose 40, 0x01e0, 0x80f2, 0x8c00
+ax_pose_terminator
+sDragonitePose169:
+ax_pose 38, 0x01dc, 0x80f1, 0x8c00
+ax_pose 39, 0x41fc, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose170:
+ax_pose 36, 0x01dc, 0x80f1, 0x8c00
+ax_pose 37, 0x41fc, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose171:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose172:
+ax_pose 1, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose173:
+ax_pose 2, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose174:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose175:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose176:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose177:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose178:
+ax_pose 10, 0x01e0, 0x90ee, 0x8c00
+ax_pose 11, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose179:
+ax_pose 12, 0x01e0, 0x90ee, 0x8c00
+ax_pose 13, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose180:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose181:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose182:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose183:
+ax_pose 18, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose184:
+ax_pose 19, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose185:
+ax_pose 20, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose186:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose187:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose188:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose189:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose190:
+ax_pose 10, 0x01e0, 0x80f2, 0x8c00
+ax_pose 11, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose191:
+ax_pose 12, 0x01e0, 0x80f2, 0x8c00
+ax_pose 13, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose192:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose193:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose194:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose195:
+ax_pose 26, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose196:
+ax_pose 27, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose197:
+ax_pose 28, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose198:
+ax_pose 29, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose199:
+ax_pose 30, 0x01e1, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose200:
+ax_pose 29, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose201:
+ax_pose 28, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose202:
+ax_pose 27, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose203:
+ax_pose 26, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose204:
+ax_pose 27, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose205:
+ax_pose 28, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose206:
+ax_pose 29, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose207:
+ax_pose 30, 0x01e1, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose208:
+ax_pose 29, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose209:
+ax_pose 28, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose210:
+ax_pose 27, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose211:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose212:
+ax_pose 1, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose213:
+ax_pose 2, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose214:
+ax_pose 26, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose215:
+ax_pose 21, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose216:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose217:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose218:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose219:
+ax_pose 27, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose220:
+ax_pose 22, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sDragonitePose221:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose222:
+ax_pose 10, 0x01e0, 0x90ed, 0x8c00
+ax_pose 11, 0x4200, 0x50ed, 0x8c10
+ax_pose_terminator
+sDragonitePose223:
+ax_pose 12, 0x01e0, 0x90ed, 0x8c00
+ax_pose 13, 0x4200, 0x50ed, 0x8c10
+ax_pose_terminator
+sDragonitePose224:
+ax_pose 28, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose225:
+ax_pose 23, 0x01e3, 0x90ed, 0x8c00
+ax_pose_terminator
+sDragonitePose226:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose227:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose228:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose229:
+ax_pose 29, 0x01e2, 0x90ed, 0x8c00
+ax_pose_terminator
+sDragonitePose230:
+ax_pose 24, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose231:
+ax_pose 18, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose232:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose233:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose234:
+ax_pose 30, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose235:
+ax_pose 25, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose236:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose237:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose238:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose239:
+ax_pose 29, 0x01e2, 0x80f3, 0x8c00
+ax_pose_terminator
+sDragonitePose240:
+ax_pose 24, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose241:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose242:
+ax_pose 10, 0x01e0, 0x80f3, 0x8c00
+ax_pose 11, 0x4200, 0x40f3, 0x8c10
+ax_pose_terminator
+sDragonitePose243:
+ax_pose 12, 0x01e0, 0x80f3, 0x8c00
+ax_pose 13, 0x4200, 0x40f3, 0x8c10
+ax_pose_terminator
+sDragonitePose244:
+ax_pose 28, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sDragonitePose245:
+ax_pose 23, 0x01e3, 0x80f3, 0x8c00
+ax_pose_terminator
+sDragonitePose246:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose247:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose248:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose249:
+ax_pose 27, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose250:
+ax_pose 22, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sDragonitePose251:
+ax_pose 21, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose252:
+ax_pose 22, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sDragonitePose253:
+ax_pose 23, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose254:
+ax_pose 24, 0x01e2, 0x80ef, 0x8c00
+ax_pose_terminator
+sDragonitePose255:
+ax_pose 25, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose256:
+ax_pose 24, 0x01e2, 0x90f1, 0x8c00
+ax_pose_terminator
+sDragonitePose257:
+ax_pose 23, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose258:
+ax_pose 22, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sDragonitePose259:
+ax_pose 0, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose260:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose261:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose262:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose263:
+ax_pose 18, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose264:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose265:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose266:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose267:
+ax_pose 3, 0x01e0, 0x90ef, 0x8c00
+ax_pose 4, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose268:
+ax_pose 5, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose269:
+ax_pose 6, 0x01e0, 0x90ef, 0x8c00
+ax_pose 7, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose270:
+ax_pose 8, 0x01e0, 0x90ee, 0x8c00
+ax_pose 9, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose271:
+ax_pose 10, 0x01e0, 0x90ee, 0x8c00
+ax_pose 11, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose272:
+ax_pose 12, 0x01e0, 0x90ee, 0x8c00
+ax_pose 13, 0x4200, 0x50ee, 0x8c10
+ax_pose_terminator
+sDragonitePose273:
+ax_pose 14, 0x01e0, 0x90ef, 0x8c00
+ax_pose 15, 0x4200, 0x50ef, 0x8c10
+ax_pose_terminator
+sDragonitePose274:
+ax_pose 16, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose275:
+ax_pose 17, 0x01e3, 0x90ef, 0x8c00
+ax_pose_terminator
+sDragonitePose276:
+ax_pose 18, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose277:
+ax_pose 19, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose278:
+ax_pose 20, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sDragonitePose279:
+ax_pose 14, 0x01e0, 0x80f1, 0x8c00
+ax_pose 15, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose280:
+ax_pose 16, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose281:
+ax_pose 17, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose282:
+ax_pose 8, 0x01e0, 0x80f2, 0x8c00
+ax_pose 9, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose283:
+ax_pose 10, 0x01e0, 0x80f2, 0x8c00
+ax_pose 11, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose284:
+ax_pose 12, 0x01e0, 0x80f2, 0x8c00
+ax_pose 13, 0x4200, 0x40f2, 0x8c10
+ax_pose_terminator
+sDragonitePose285:
+ax_pose 3, 0x01e0, 0x80f1, 0x8c00
+ax_pose 4, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+sDragonitePose286:
+ax_pose 5, 0x01e2, 0x80f1, 0x8c00
+ax_pose_terminator
+sDragonitePose287:
+ax_pose 6, 0x01e0, 0x80f1, 0x8c00
+ax_pose 7, 0x4200, 0x40f1, 0x8c10
+ax_pose_terminator
+.align 2
+sDragoniteAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 4, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim 2, 0, 24, 0, 3, 0, 3,
+ax_anim_terminator
+sDragoniteAnims_2_2:
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 4, 0, 29, -3, -3, -3, -3,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim 2, 0, 28, 3, 3, 3, 3,
+ax_anim_terminator
+sDragoniteAnims_2_3:
+ax_anim 2, 0, 33, -2, 0, -2, 0,
+ax_anim 4, 0, 33, -3, 0, -3, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim_terminator
+sDragoniteAnims_2_4:
+ax_anim 2, 0, 37, -2, 2, -2, 2,
+ax_anim 4, 0, 37, -3, 3, -3, 3,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 8, -11, 8, -11,
+ax_anim 2, 0, 39, 14, -19, 14, -19,
+ax_anim 2, 1, 39, 15, -18, 15, -18,
+ax_anim 2, 0, 39, 14, -19, 14, -19,
+ax_anim 2, 0, 39, 15, -18, 15, -18,
+ax_anim 2, 0, 39, 14, -19, 14, -19,
+ax_anim 2, 0, 39, 15, -18, 15, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim 2, 0, 36, 3, -3, 3, -3,
+ax_anim_terminator
+sDragoniteAnims_2_5:
+ax_anim 2, 0, 41, 0, 2, 0, 2,
+ax_anim 4, 0, 41, 0, 3, 0, 3,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 1, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim 2, 0, 40, 0, -3, 0, -3,
+ax_anim_terminator
+sDragoniteAnims_2_6:
+ax_anim 2, 0, 45, 2, 2, 2, 2,
+ax_anim 4, 0, 45, 3, 3, 3, 3,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -8, -11, -8, -11,
+ax_anim 2, 0, 47, -14, -19, -14, -19,
+ax_anim 2, 1, 47, -15, -18, -15, -18,
+ax_anim 2, 0, 47, -14, -19, -14, -19,
+ax_anim 2, 0, 47, -15, -18, -15, -18,
+ax_anim 2, 0, 47, -14, -19, -14, -19,
+ax_anim 2, 0, 47, -15, -18, -15, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim 2, 0, 44, -3, -3, -3, -3,
+ax_anim_terminator
+sDragoniteAnims_2_7:
+ax_anim 2, 0, 49, 2, 0, 2, 0,
+ax_anim 4, 0, 49, 3, 0, 3, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim 2, 0, 48, -3, 0, -3, 0,
+ax_anim_terminator
+sDragoniteAnims_2_8:
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 4, 0, 53, 3, -3, 3, -3,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 1, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim 2, 0, 52, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 4, 0, 57, 0, -3, 0, -3,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sDragoniteAnims_3_2:
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 4, 0, 61, -3, -3, -3, -3,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 1, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim 2, 0, 60, 3, 3, 3, 3,
+ax_anim_terminator
+sDragoniteAnims_3_3:
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 4, 0, 65, -3, 0, -3, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim 2, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sDragoniteAnims_3_4:
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 4, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 8, -11, 8, -11,
+ax_anim 2, 0, 71, 14, -19, 14, -19,
+ax_anim 2, 1, 71, 15, -18, 15, -18,
+ax_anim 2, 0, 71, 14, -19, 14, -19,
+ax_anim 2, 0, 71, 15, -18, 15, -18,
+ax_anim 2, 0, 71, 14, -19, 14, -19,
+ax_anim 2, 0, 71, 15, -18, 15, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim 2, 0, 68, 3, -3, 3, -3,
+ax_anim_terminator
+sDragoniteAnims_3_5:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 4, 0, 73, 0, 3, 0, 3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 1, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 0, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 0, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sDragoniteAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 4, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -8, -11, -8, -11,
+ax_anim 2, 0, 79, -14, -19, -14, -19,
+ax_anim 2, 1, 79, -15, -18, -15, -18,
+ax_anim 2, 0, 79, -14, -19, -14, -19,
+ax_anim 2, 0, 79, -15, -18, -15, -18,
+ax_anim 2, 0, 79, -14, -19, -14, -19,
+ax_anim 2, 0, 79, -15, -18, -15, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim 2, 0, 76, -3, -3, -3, -3,
+ax_anim_terminator
+sDragoniteAnims_3_7:
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 4, 0, 81, 3, 0, 3, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim 2, 0, 80, -3, 0, -3, 0,
+ax_anim_terminator
+sDragoniteAnims_3_8:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 4, 0, 85, 3, -3, 3, -3,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 1, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim 2, 0, 84, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 6, 0, 88, 0, -4, 0, -4,
+ax_anim 2, 2, 91, 0, 2, 0, 2,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 1, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sDragoniteAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 94, -3, -3, -3, -3,
+ax_anim 6, 0, 92, -4, -4, -4, -4,
+ax_anim 2, 2, 95, 2, 2, 2, 2,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 95, 6, 4, 6, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 1, 95, 6, 4, 6, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 95, 6, 4, 6, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sDragoniteAnims_4_3:
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 6, 0, 96, -4, 0, -4, 0,
+ax_anim 2, 2, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 99, 5, -1, 5, -1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 1, 99, 5, -1, 5, -1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 99, 5, -1, 5, -1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sDragoniteAnims_4_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim 6, 0, 100, -4, 4, -4, 4,
+ax_anim 2, 2, 103, 2, -2, 2, -2,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 6, -4, 6, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 1, 103, 6, -4, 6, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 6, -4, 6, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sDragoniteAnims_4_5:
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 6, 0, 104, 0, 4, 0, 4,
+ax_anim 2, 2, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 107, 1, -5, 1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 1, 107, 1, -5, 1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 107, 1, -5, 1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sDragoniteAnims_4_6:
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 110, 3, 3, 3, 3,
+ax_anim 6, 0, 108, 4, 4, 4, 4,
+ax_anim 2, 2, 111, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 111, -6, -4, -6, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 1, 111, -6, -4, -6, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 111, -6, -4, -6, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sDragoniteAnims_4_7:
+ax_anim 2, 0, 113, 2, 0, 2, 0,
+ax_anim 2, 0, 114, 3, 0, 3, 0,
+ax_anim 6, 0, 112, 4, 0, 4, 0,
+ax_anim 2, 2, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, -1, -5, -1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 1, 115, -5, -1, -5, -1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, -1, -5, -1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sDragoniteAnims_4_8:
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 2, 0, 118, 3, -3, 3, -3,
+ax_anim 6, 0, 116, 4, -4, 4, -4,
+ax_anim 2, 2, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 1, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_5_1:
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 4, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 2, 1, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_5_2:
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 4, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, -1, 0, 0,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_5_3:
+ax_anim 2, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 4, 0, 130, 0, -6, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 1, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_5_4:
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 4, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -1, 0, 0,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_5_5:
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 4, 0, 140, 0, -6, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, -1, 0, 0,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_5_6:
+ax_anim 2, 0, 145, 0, -3, 0, 0,
+ax_anim 2, 0, 145, 0, -5, 0, 0,
+ax_anim 4, 0, 145, 0, -6, 0, 0,
+ax_anim 2, 0, 145, 0, -5, 0, 0,
+ax_anim 2, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, -1, 0, 0,
+ax_anim 2, 1, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_5_7:
+ax_anim 2, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -5, 0, 0,
+ax_anim 4, 0, 150, 0, -6, 0, 0,
+ax_anim 2, 0, 150, 0, -5, 0, 0,
+ax_anim 2, 0, 153, 0, -3, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -1, 0, 0,
+ax_anim 2, 1, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_5_8:
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 155, 0, -5, 0, 0,
+ax_anim 4, 0, 155, 0, -6, 0, 0,
+ax_anim 2, 0, 155, 0, -5, 0, 0,
+ax_anim 2, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, 0,
+ax_anim 2, 1, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sDragoniteAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sDragoniteAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sDragoniteAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sDragoniteAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sDragoniteAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sDragoniteAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sDragoniteAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_8_1:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, -4, 0, 0,
+ax_anim 2, 0, 171, 0, -5, 0, 0,
+ax_anim 3, 0, 171, 0, -6, 0, 0,
+ax_anim 3, 0, 172, 0, -6, 0, 0,
+ax_anim 2, 0, 172, 0, -5, 0, 0,
+ax_anim 2, 0, 172, 0, -4, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_8_2:
+ax_anim 40, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, -4, 0, 0,
+ax_anim 2, 0, 174, 0, -5, 0, 0,
+ax_anim 3, 0, 174, 0, -6, 0, 0,
+ax_anim 3, 0, 175, 0, -6, 0, 0,
+ax_anim 2, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 0, -4, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_8_3:
+ax_anim 40, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, -4, 0, 0,
+ax_anim 2, 0, 177, 0, -5, 0, 0,
+ax_anim 3, 0, 177, 0, -6, 0, 0,
+ax_anim 3, 0, 178, 0, -6, 0, 0,
+ax_anim 2, 0, 178, 0, -5, 0, 0,
+ax_anim 2, 0, 178, 0, -4, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_8_4:
+ax_anim 40, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -4, 0, 0,
+ax_anim 2, 0, 180, 0, -5, 0, 0,
+ax_anim 3, 0, 180, 0, -6, 0, 0,
+ax_anim 3, 0, 181, 0, -6, 0, 0,
+ax_anim 2, 0, 181, 0, -5, 0, 0,
+ax_anim 2, 0, 181, 0, -4, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_8_5:
+ax_anim 40, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, -4, 0, 0,
+ax_anim 2, 0, 183, 0, -5, 0, 0,
+ax_anim 3, 0, 183, 0, -6, 0, 0,
+ax_anim 3, 0, 184, 0, -6, 0, 0,
+ax_anim 2, 0, 184, 0, -5, 0, 0,
+ax_anim 2, 0, 184, 0, -4, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_8_6:
+ax_anim 40, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -4, 0, 0,
+ax_anim 2, 0, 186, 0, -5, 0, 0,
+ax_anim 3, 0, 186, 0, -6, 0, 0,
+ax_anim 3, 0, 187, 0, -6, 0, 0,
+ax_anim 2, 0, 187, 0, -5, 0, 0,
+ax_anim 2, 0, 187, 0, -4, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_8_7:
+ax_anim 40, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -4, 0, 0,
+ax_anim 2, 0, 189, 0, -5, 0, 0,
+ax_anim 3, 0, 189, 0, -6, 0, 0,
+ax_anim 3, 0, 190, 0, -6, 0, 0,
+ax_anim 2, 0, 190, 0, -5, 0, 0,
+ax_anim 2, 0, 190, 0, -4, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_8_8:
+ax_anim 40, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -4, 0, 0,
+ax_anim 2, 0, 192, 0, -5, 0, 0,
+ax_anim 3, 0, 192, 0, -6, 0, 0,
+ax_anim 3, 0, 193, 0, -6, 0, 0,
+ax_anim 2, 0, 193, 0, -5, 0, 0,
+ax_anim 2, 0, 193, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 11, 8, 11,
+ax_anim 2, 0, 197, 7, 18, 7, 18,
+ax_anim 3, 0, 198, 0, 22, 0, 22,
+ax_anim 2, 3, 199, -7, 18, -7, 18,
+ax_anim 2, 0, 200, -8, 11, -8, 11,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 19, 12, 19, 12,
+ax_anim 3, 0, 197, 20, 21, 20, 21,
+ax_anim 2, 3, 198, 13, 23, 13, 23,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -5, 16, -5,
+ax_anim 3, 0, 196, 18, -2, 18, -2,
+ax_anim 2, 3, 197, 18, 4, 18, 4,
+ax_anim 2, 0, 198, 12, 5, 12, 5,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 12, -20, 12, -20,
+ax_anim 3, 0, 195, 18, -19, 18, -19,
+ax_anim 2, 3, 196, 20, -12, 20, -12,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -9, -10, -9, -10,
+ax_anim 2, 0, 201, -7, -16, -7, -16,
+ax_anim 3, 0, 194, 0, -19, 0, -19,
+ax_anim 2, 3, 195, 7, -16, 7, -16,
+ax_anim 2, 0, 196, 9, -10, 9, -10,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -12, -20, -12, -20,
+ax_anim 3, 0, 201, -18, -19, -18, -19,
+ax_anim 2, 3, 200, -20, -12, -20, -12,
+ax_anim 2, 0, 199, -17, -4, -17, -4,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -5, -16, -5,
+ax_anim 3, 0, 200, -18, -2, -18, -2,
+ax_anim 2, 3, 199, -18, 4, -18, 4,
+ax_anim 2, 0, 198, -12, 5, -12, 5,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -19, 12, -19, 12,
+ax_anim 3, 0, 199, -20, 21, -20, 21,
+ax_anim 2, 3, 198, -13, 23, -13, 23,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_11_2:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_11_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_11_4:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 228, 0, -11, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 3, 0, 232, 0, -21, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_11_6:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 236, 0, -16, 0, 0,
+ax_anim 3, 0, 236, 0, -20, 0, 0,
+ax_anim 4, 0, 236, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 3, 0, 237, 0, -21, 0, 0,
+ax_anim 2, 0, 237, 0, -17, 0, 0,
+ax_anim 1, 0, 238, 0, -11, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_11_7:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 3, 0, 242, 0, -21, 0, 0,
+ax_anim 2, 0, 242, 0, -18, 0, 0,
+ax_anim 1, 0, 243, 0, -12, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_11_8:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 246, 0, -20, 0, 0,
+ax_anim 4, 0, 246, 0, -21, 0, 0,
+ax_anim 4, 0, 245, 0, -21, 0, 0,
+ax_anim 3, 0, 247, 0, -21, 0, 0,
+ax_anim 2, 0, 247, 0, -18, 0, 0,
+ax_anim 1, 0, 248, 0, -12, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_12_1:
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_12_2:
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 1, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_12_3:
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 1, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_12_4:
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 1, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_12_5:
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 1, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_12_6:
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 1, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_12_7:
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 1, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_12_8:
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 1, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDragoniteAnims_13_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_13_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_13_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_13_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_13_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_13_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_13_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteAnims_13_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sDragoniteGfx1:
+.incbin "baserom.gba", 0xB847FC, 0x200
+sDragoniteSprites1:
+ax_sprite sDragoniteGfx1, 0x200
+ax_sprite_terminator
+sDragoniteGfx2:
+.incbin "baserom.gba", 0xB84A0C, 0x200
+sDragoniteSprites2:
+ax_sprite sDragoniteGfx2, 0x200
+ax_sprite_terminator
+sDragoniteGfx3:
+.incbin "baserom.gba", 0xB84C1C, 0x200
+sDragoniteSprites3:
+ax_sprite sDragoniteGfx3, 0x200
+ax_sprite_terminator
+sDragoniteGfx4:
+.incbin "baserom.gba", 0xB84E2C, 0x200
+sDragoniteSprites4:
+ax_sprite sDragoniteGfx4, 0x200
+ax_sprite_terminator
+sDragoniteGfx5:
+.incbin "baserom.gba", 0xB8503C, 0x80
+sDragoniteSprites5:
+ax_sprite sDragoniteGfx5, 0x80
+ax_sprite_terminator
+sDragoniteGfx6:
+.incbin "baserom.gba", 0xB850CC, 0x200
+sDragoniteSprites6:
+ax_sprite sDragoniteGfx6, 0x200
+ax_sprite_terminator
+sDragoniteGfx7:
+.incbin "baserom.gba", 0xB852DC, 0x200
+sDragoniteSprites7:
+ax_sprite sDragoniteGfx7, 0x200
+ax_sprite_terminator
+sDragoniteGfx8:
+.incbin "baserom.gba", 0xB854EC, 0x80
+sDragoniteSprites8:
+ax_sprite sDragoniteGfx8, 0x80
+ax_sprite_terminator
+sDragoniteGfx9:
+.incbin "baserom.gba", 0xB8557C, 0x200
+sDragoniteSprites9:
+ax_sprite sDragoniteGfx9, 0x200
+ax_sprite_terminator
+sDragoniteGfx10:
+.incbin "baserom.gba", 0xB8578C, 0x80
+sDragoniteSprites10:
+ax_sprite sDragoniteGfx10, 0x80
+ax_sprite_terminator
+sDragoniteGfx11:
+.incbin "baserom.gba", 0xB8581C, 0x200
+sDragoniteSprites11:
+ax_sprite sDragoniteGfx11, 0x200
+ax_sprite_terminator
+sDragoniteGfx12:
+.incbin "baserom.gba", 0xB85A2C, 0x80
+sDragoniteSprites12:
+ax_sprite sDragoniteGfx12, 0x80
+ax_sprite_terminator
+sDragoniteGfx13:
+.incbin "baserom.gba", 0xB85ABC, 0x200
+sDragoniteSprites13:
+ax_sprite sDragoniteGfx13, 0x200
+ax_sprite_terminator
+sDragoniteGfx14:
+.incbin "baserom.gba", 0xB85CCC, 0x80
+sDragoniteSprites14:
+ax_sprite sDragoniteGfx14, 0x80
+ax_sprite_terminator
+sDragoniteGfx15:
+.incbin "baserom.gba", 0xB85D5C, 0x200
+sDragoniteSprites15:
+ax_sprite sDragoniteGfx15, 0x200
+ax_sprite_terminator
+sDragoniteGfx16:
+.incbin "baserom.gba", 0xB85F6C, 0x80
+sDragoniteSprites16:
+ax_sprite sDragoniteGfx16, 0x80
+ax_sprite_terminator
+sDragoniteGfx17:
+.incbin "baserom.gba", 0xB85FFC, 0x200
+sDragoniteSprites17:
+ax_sprite sDragoniteGfx17, 0x200
+ax_sprite_terminator
+sDragoniteGfx18:
+.incbin "baserom.gba", 0xB8620C, 0x200
+sDragoniteSprites18:
+ax_sprite sDragoniteGfx18, 0x200
+ax_sprite_terminator
+sDragoniteGfx19:
+.incbin "baserom.gba", 0xB8641C, 0x200
+sDragoniteSprites19:
+ax_sprite sDragoniteGfx19, 0x200
+ax_sprite_terminator
+sDragoniteGfx20:
+.incbin "baserom.gba", 0xB8662C, 0x200
+sDragoniteSprites20:
+ax_sprite sDragoniteGfx20, 0x200
+ax_sprite_terminator
+sDragoniteGfx21:
+.incbin "baserom.gba", 0xB8683C, 0x200
+sDragoniteSprites21:
+ax_sprite sDragoniteGfx21, 0x200
+ax_sprite_terminator
+sDragoniteGfx22:
+.incbin "baserom.gba", 0xB86A4C, 0x60
+sDragoniteGfx22_1:
+.incbin "baserom.gba", 0xB86AAC, 0x180
+sDragoniteSprites22:
+ax_sprite sDragoniteGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx22_1, 0x180
+ax_sprite_terminator
+sDragoniteGfx23:
+.incbin "baserom.gba", 0xB86C4C, 0x40
+sDragoniteGfx23_1:
+.incbin "baserom.gba", 0xB86C8C, 0x180
+sDragoniteSprites23:
+ax_sprite sDragoniteGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx23_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDragoniteGfx24:
+.incbin "baserom.gba", 0xB86E34, 0x60
+sDragoniteGfx24_1:
+.incbin "baserom.gba", 0xB86E94, 0x100
+sDragoniteGfx24_2:
+.incbin "baserom.gba", 0xB86F94, 0x60
+sDragoniteSprites24:
+ax_sprite sDragoniteGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx24_2, 0x60
+ax_sprite_terminator
+sDragoniteGfx25:
+.incbin "baserom.gba", 0xB87024, 0x40
+sDragoniteGfx25_1:
+.incbin "baserom.gba", 0xB87064, 0x100
+sDragoniteGfx25_2:
+.incbin "baserom.gba", 0xB87164, 0x60
+sDragoniteSprites25:
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx25_2, 0x60
+ax_sprite_terminator
+sDragoniteGfx26:
+.incbin "baserom.gba", 0xB871FC, 0x60
+sDragoniteGfx26_1:
+.incbin "baserom.gba", 0xB8725C, 0x180
+sDragoniteSprites26:
+ax_sprite sDragoniteGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx26_1, 0x180
+ax_sprite_terminator
+sDragoniteGfx27:
+.incbin "baserom.gba", 0xB873FC, 0x40
+sDragoniteGfx27_1:
+.incbin "baserom.gba", 0xB8743C, 0x180
+sDragoniteSprites27:
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx27_1, 0x180
+ax_sprite_terminator
+sDragoniteGfx28:
+.incbin "baserom.gba", 0xB875E4, 0x180
+sDragoniteGfx28_1:
+.incbin "baserom.gba", 0xB87764, 0x40
+sDragoniteSprites28:
+ax_sprite sDragoniteGfx28, 0x180
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDragoniteGfx29:
+.incbin "baserom.gba", 0xB877CC, 0x180
+sDragoniteGfx29_1:
+.incbin "baserom.gba", 0xB8794C, 0x60
+sDragoniteSprites29:
+ax_sprite sDragoniteGfx29, 0x180
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx29_1, 0x60
+ax_sprite_terminator
+sDragoniteGfx30:
+.incbin "baserom.gba", 0xB879CC, 0x60
+sDragoniteGfx30_1:
+.incbin "baserom.gba", 0xB87A2C, 0x180
+sDragoniteSprites30:
+ax_sprite sDragoniteGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx30_1, 0x180
+ax_sprite_terminator
+sDragoniteGfx31:
+.incbin "baserom.gba", 0xB87BCC, 0x60
+sDragoniteGfx31_1:
+.incbin "baserom.gba", 0xB87C2C, 0x180
+sDragoniteSprites31:
+ax_sprite sDragoniteGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDragoniteGfx31_1, 0x180
+ax_sprite_terminator
+sDragoniteGfx32:
+.incbin "baserom.gba", 0xB87DCC, 0x200
+sDragoniteSprites32:
+ax_sprite sDragoniteGfx32, 0x200
+ax_sprite_terminator
+sDragoniteGfx33:
+.incbin "baserom.gba", 0xB87FDC, 0x200
+sDragoniteSprites33:
+ax_sprite sDragoniteGfx33, 0x200
+ax_sprite_terminator
+sDragoniteGfx34:
+.incbin "baserom.gba", 0xB881EC, 0x20
+sDragoniteSprites34:
+ax_sprite sDragoniteGfx34, 0x20
+ax_sprite_terminator
+sDragoniteGfx35:
+.incbin "baserom.gba", 0xB8821C, 0x80
+sDragoniteSprites35:
+ax_sprite sDragoniteGfx35, 0x80
+ax_sprite_terminator
+sDragoniteGfx36:
+.incbin "baserom.gba", 0xB882AC, 0x200
+sDragoniteSprites36:
+ax_sprite sDragoniteGfx36, 0x200
+ax_sprite_terminator
+sDragoniteGfx37:
+.incbin "baserom.gba", 0xB884BC, 0x200
+sDragoniteSprites37:
+ax_sprite sDragoniteGfx37, 0x200
+ax_sprite_terminator
+sDragoniteGfx38:
+.incbin "baserom.gba", 0xB886CC, 0x80
+sDragoniteSprites38:
+ax_sprite sDragoniteGfx38, 0x80
+ax_sprite_terminator
+sDragoniteGfx39:
+.incbin "baserom.gba", 0xB8875C, 0x200
+sDragoniteSprites39:
+ax_sprite sDragoniteGfx39, 0x200
+ax_sprite_terminator
+sDragoniteGfx40:
+.incbin "baserom.gba", 0xB8896C, 0x80
+sDragoniteSprites40:
+ax_sprite sDragoniteGfx40, 0x80
+ax_sprite_terminator
+sDragoniteGfx41:
+.incbin "baserom.gba", 0xB889FC, 0x200
+sDragoniteSprites41:
+ax_sprite sDragoniteGfx41, 0x200
+ax_sprite_terminator
+sDragoniteGfx42:
+.incbin "baserom.gba", 0xB88C0C, 0x200
+sDragoniteSprites42:
+ax_sprite sDragoniteGfx42, 0x200
+ax_sprite_terminator
+sAxPosesDragonite:
+.4byte sDragonitePose1
+.4byte sDragonitePose2
+.4byte sDragonitePose3
+.4byte sDragonitePose4
+.4byte sDragonitePose5
+.4byte sDragonitePose6
+.4byte sDragonitePose7
+.4byte sDragonitePose8
+.4byte sDragonitePose9
+.4byte sDragonitePose10
+.4byte sDragonitePose11
+.4byte sDragonitePose12
+.4byte sDragonitePose13
+.4byte sDragonitePose14
+.4byte sDragonitePose15
+.4byte sDragonitePose16
+.4byte sDragonitePose17
+.4byte sDragonitePose18
+.4byte sDragonitePose19
+.4byte sDragonitePose20
+.4byte sDragonitePose21
+.4byte sDragonitePose22
+.4byte sDragonitePose23
+.4byte sDragonitePose24
+.4byte sDragonitePose25
+.4byte sDragonitePose26
+.4byte sDragonitePose27
+.4byte sDragonitePose28
+.4byte sDragonitePose29
+.4byte sDragonitePose30
+.4byte sDragonitePose31
+.4byte sDragonitePose32
+.4byte sDragonitePose33
+.4byte sDragonitePose34
+.4byte sDragonitePose35
+.4byte sDragonitePose36
+.4byte sDragonitePose37
+.4byte sDragonitePose38
+.4byte sDragonitePose39
+.4byte sDragonitePose40
+.4byte sDragonitePose41
+.4byte sDragonitePose42
+.4byte sDragonitePose43
+.4byte sDragonitePose44
+.4byte sDragonitePose45
+.4byte sDragonitePose46
+.4byte sDragonitePose47
+.4byte sDragonitePose48
+.4byte sDragonitePose49
+.4byte sDragonitePose50
+.4byte sDragonitePose51
+.4byte sDragonitePose52
+.4byte sDragonitePose53
+.4byte sDragonitePose54
+.4byte sDragonitePose55
+.4byte sDragonitePose56
+.4byte sDragonitePose57
+.4byte sDragonitePose58
+.4byte sDragonitePose59
+.4byte sDragonitePose60
+.4byte sDragonitePose61
+.4byte sDragonitePose62
+.4byte sDragonitePose63
+.4byte sDragonitePose64
+.4byte sDragonitePose65
+.4byte sDragonitePose66
+.4byte sDragonitePose67
+.4byte sDragonitePose68
+.4byte sDragonitePose69
+.4byte sDragonitePose70
+.4byte sDragonitePose71
+.4byte sDragonitePose72
+.4byte sDragonitePose73
+.4byte sDragonitePose74
+.4byte sDragonitePose75
+.4byte sDragonitePose76
+.4byte sDragonitePose77
+.4byte sDragonitePose78
+.4byte sDragonitePose79
+.4byte sDragonitePose80
+.4byte sDragonitePose81
+.4byte sDragonitePose82
+.4byte sDragonitePose83
+.4byte sDragonitePose84
+.4byte sDragonitePose85
+.4byte sDragonitePose86
+.4byte sDragonitePose87
+.4byte sDragonitePose88
+.4byte sDragonitePose89
+.4byte sDragonitePose90
+.4byte sDragonitePose91
+.4byte sDragonitePose92
+.4byte sDragonitePose93
+.4byte sDragonitePose94
+.4byte sDragonitePose95
+.4byte sDragonitePose96
+.4byte sDragonitePose97
+.4byte sDragonitePose98
+.4byte sDragonitePose99
+.4byte sDragonitePose100
+.4byte sDragonitePose101
+.4byte sDragonitePose102
+.4byte sDragonitePose103
+.4byte sDragonitePose104
+.4byte sDragonitePose105
+.4byte sDragonitePose106
+.4byte sDragonitePose107
+.4byte sDragonitePose108
+.4byte sDragonitePose109
+.4byte sDragonitePose110
+.4byte sDragonitePose111
+.4byte sDragonitePose112
+.4byte sDragonitePose113
+.4byte sDragonitePose114
+.4byte sDragonitePose115
+.4byte sDragonitePose116
+.4byte sDragonitePose117
+.4byte sDragonitePose118
+.4byte sDragonitePose119
+.4byte sDragonitePose120
+.4byte sDragonitePose121
+.4byte sDragonitePose122
+.4byte sDragonitePose123
+.4byte sDragonitePose124
+.4byte sDragonitePose125
+.4byte sDragonitePose126
+.4byte sDragonitePose127
+.4byte sDragonitePose128
+.4byte sDragonitePose129
+.4byte sDragonitePose130
+.4byte sDragonitePose131
+.4byte sDragonitePose132
+.4byte sDragonitePose133
+.4byte sDragonitePose134
+.4byte sDragonitePose135
+.4byte sDragonitePose136
+.4byte sDragonitePose137
+.4byte sDragonitePose138
+.4byte sDragonitePose139
+.4byte sDragonitePose140
+.4byte sDragonitePose141
+.4byte sDragonitePose142
+.4byte sDragonitePose143
+.4byte sDragonitePose144
+.4byte sDragonitePose145
+.4byte sDragonitePose146
+.4byte sDragonitePose147
+.4byte sDragonitePose148
+.4byte sDragonitePose149
+.4byte sDragonitePose150
+.4byte sDragonitePose151
+.4byte sDragonitePose152
+.4byte sDragonitePose153
+.4byte sDragonitePose154
+.4byte sDragonitePose155
+.4byte sDragonitePose156
+.4byte sDragonitePose157
+.4byte sDragonitePose158
+.4byte sDragonitePose159
+.4byte sDragonitePose160
+.4byte sDragonitePose161
+.4byte sDragonitePose162
+.4byte sDragonitePose163
+.4byte sDragonitePose164
+.4byte sDragonitePose165
+.4byte sDragonitePose166
+.4byte sDragonitePose167
+.4byte sDragonitePose168
+.4byte sDragonitePose169
+.4byte sDragonitePose170
+.4byte sDragonitePose171
+.4byte sDragonitePose172
+.4byte sDragonitePose173
+.4byte sDragonitePose174
+.4byte sDragonitePose175
+.4byte sDragonitePose176
+.4byte sDragonitePose177
+.4byte sDragonitePose178
+.4byte sDragonitePose179
+.4byte sDragonitePose180
+.4byte sDragonitePose181
+.4byte sDragonitePose182
+.4byte sDragonitePose183
+.4byte sDragonitePose184
+.4byte sDragonitePose185
+.4byte sDragonitePose186
+.4byte sDragonitePose187
+.4byte sDragonitePose188
+.4byte sDragonitePose189
+.4byte sDragonitePose190
+.4byte sDragonitePose191
+.4byte sDragonitePose192
+.4byte sDragonitePose193
+.4byte sDragonitePose194
+.4byte sDragonitePose195
+.4byte sDragonitePose196
+.4byte sDragonitePose197
+.4byte sDragonitePose198
+.4byte sDragonitePose199
+.4byte sDragonitePose200
+.4byte sDragonitePose201
+.4byte sDragonitePose202
+.4byte sDragonitePose203
+.4byte sDragonitePose204
+.4byte sDragonitePose205
+.4byte sDragonitePose206
+.4byte sDragonitePose207
+.4byte sDragonitePose208
+.4byte sDragonitePose209
+.4byte sDragonitePose210
+.4byte sDragonitePose211
+.4byte sDragonitePose212
+.4byte sDragonitePose213
+.4byte sDragonitePose214
+.4byte sDragonitePose215
+.4byte sDragonitePose216
+.4byte sDragonitePose217
+.4byte sDragonitePose218
+.4byte sDragonitePose219
+.4byte sDragonitePose220
+.4byte sDragonitePose221
+.4byte sDragonitePose222
+.4byte sDragonitePose223
+.4byte sDragonitePose224
+.4byte sDragonitePose225
+.4byte sDragonitePose226
+.4byte sDragonitePose227
+.4byte sDragonitePose228
+.4byte sDragonitePose229
+.4byte sDragonitePose230
+.4byte sDragonitePose231
+.4byte sDragonitePose232
+.4byte sDragonitePose233
+.4byte sDragonitePose234
+.4byte sDragonitePose235
+.4byte sDragonitePose236
+.4byte sDragonitePose237
+.4byte sDragonitePose238
+.4byte sDragonitePose239
+.4byte sDragonitePose240
+.4byte sDragonitePose241
+.4byte sDragonitePose242
+.4byte sDragonitePose243
+.4byte sDragonitePose244
+.4byte sDragonitePose245
+.4byte sDragonitePose246
+.4byte sDragonitePose247
+.4byte sDragonitePose248
+.4byte sDragonitePose249
+.4byte sDragonitePose250
+.4byte sDragonitePose251
+.4byte sDragonitePose252
+.4byte sDragonitePose253
+.4byte sDragonitePose254
+.4byte sDragonitePose255
+.4byte sDragonitePose256
+.4byte sDragonitePose257
+.4byte sDragonitePose258
+.4byte sDragonitePose259
+.4byte sDragonitePose260
+.4byte sDragonitePose261
+.4byte sDragonitePose262
+.4byte sDragonitePose263
+.4byte sDragonitePose264
+.4byte sDragonitePose265
+.4byte sDragonitePose266
+.4byte sDragonitePose267
+.4byte sDragonitePose268
+.4byte sDragonitePose269
+.4byte sDragonitePose270
+.4byte sDragonitePose271
+.4byte sDragonitePose272
+.4byte sDragonitePose273
+.4byte sDragonitePose274
+.4byte sDragonitePose275
+.4byte sDragonitePose276
+.4byte sDragonitePose277
+.4byte sDragonitePose278
+.4byte sDragonitePose279
+.4byte sDragonitePose280
+.4byte sDragonitePose281
+.4byte sDragonitePose282
+.4byte sDragonitePose283
+.4byte sDragonitePose284
+.4byte sDragonitePose285
+.4byte sDragonitePose286
+.4byte sDragonitePose287
+sAxPositionsDragonite:
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -9,  -12, 	   6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	  -8,  -11, 	   7,  -12, 	  -1,  -11
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    7,  -17, 	  -5,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    7,  -17, 	   5,  -10, 	  -5,   -8, 	   0,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte   -1,  -21, 	   7,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte   -2,  -20, 	   6,   -8, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -20, 	   5,  -10, 	  -8,   -8, 	   0,   -9
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -8,  -17, 	   4,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,  -17, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -9,  -12, 	   6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	  -8,  -11, 	   7,  -12, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,  -10, 	   4,  -10, 	  -1,   -8
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte    3,   -8, 	   5,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    7,  -17, 	  -5,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    7,  -17, 	   5,  -10, 	  -5,   -8, 	   0,   -8
+.2byte    6,  -10, 	   5,   -9, 	   3,   -9, 	  -1,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte    7,  -11, 	   3,  -14, 	   8,  -11, 	  -1,  -10
+.2byte   -1,  -20, 	   7,   -9, 	  -9,   -9, 	  -1,  -10
+.2byte   -2,  -19, 	   6,   -7, 	  -7,  -12, 	  -1,   -8
+.2byte    0,  -19, 	   5,   -9, 	  -8,   -7, 	   0,   -8
+.2byte   -1,  -15, 	   2,  -16, 	  -4,  -16, 	  -1,  -10
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte   -8,  -11, 	  -4,  -14, 	  -9,  -11, 	   0,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -8,  -17, 	   4,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,  -17, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte   -7,  -10, 	  -6,   -9, 	  -4,   -9, 	   0,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+.2byte   -4,   -8, 	  -6,   -7, 	   1,   -6, 	   0,   -7
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -9,  -12, 	   6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	  -8,  -11, 	   7,  -12, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,  -10, 	   4,  -10, 	  -1,   -8
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte    3,   -8, 	   5,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    7,  -17, 	  -5,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    7,  -17, 	   5,  -10, 	  -5,   -8, 	   0,   -8
+.2byte    6,  -10, 	   5,   -9, 	   3,   -9, 	  -1,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte    7,  -11, 	   3,  -14, 	   8,  -11, 	  -1,  -10
+.2byte   -1,  -20, 	   7,   -9, 	  -9,   -9, 	  -1,  -10
+.2byte   -2,  -19, 	   6,   -7, 	  -7,  -12, 	  -1,   -8
+.2byte    0,  -19, 	   5,   -9, 	  -8,   -7, 	   0,   -8
+.2byte   -1,  -15, 	   2,  -16, 	  -4,  -16, 	  -1,  -10
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte   -8,  -11, 	  -4,  -14, 	  -9,  -11, 	   0,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -8,  -17, 	   4,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,  -17, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte   -7,  -10, 	  -6,   -9, 	  -4,   -9, 	   0,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+.2byte   -4,   -8, 	  -6,   -7, 	   1,   -6, 	   0,   -7
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -9,  -12, 	   6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	  -8,  -11, 	   7,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	 -10,   -9, 	   9,   -9, 	  -1,   -7
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte   10,  -10, 	   3,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    7,  -17, 	  -5,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    7,  -17, 	   5,  -10, 	  -5,   -8, 	   0,   -8
+.2byte   10,  -12, 	  -2,  -12, 	  -2,  -10, 	   2,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte    9,  -17, 	  -5,  -14, 	   1,   -9, 	  -1,  -11
+.2byte   -1,  -21, 	   7,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte   -2,  -20, 	   6,   -8, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -20, 	   5,  -10, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -22, 	   8,  -13, 	 -10,  -13, 	  -1,  -11
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte  -10,  -17, 	   4,  -14, 	  -2,   -9, 	   0,  -11
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -8,  -17, 	   4,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,  -17, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte  -11,  -12, 	   1,  -12, 	   1,  -10, 	  -3,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+.2byte  -11,  -10, 	  -4,  -10, 	   3,   -8, 	  -2,   -8
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -9,  -12, 	   6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	  -8,  -11, 	   7,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	 -10,   -9, 	   9,   -9, 	  -1,   -7
+.2byte   -1,  -10, 	  -7,  -10, 	   4,  -10, 	  -1,   -8
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte   10,  -10, 	   3,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    3,   -8, 	   5,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    7,  -17, 	  -5,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    7,  -17, 	   5,  -10, 	  -5,   -8, 	   0,   -8
+.2byte   10,  -12, 	  -2,  -12, 	  -2,  -10, 	   2,   -8
+.2byte    6,  -10, 	   5,   -9, 	   3,   -9, 	  -1,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte    9,  -17, 	  -5,  -14, 	   1,   -9, 	  -1,  -11
+.2byte    7,  -11, 	   3,  -14, 	   8,  -11, 	  -1,  -10
+.2byte   -1,  -20, 	   7,   -9, 	  -9,   -9, 	  -1,  -10
+.2byte   -2,  -19, 	   6,   -7, 	  -7,  -12, 	  -1,   -8
+.2byte    0,  -19, 	   5,   -9, 	  -8,   -7, 	   0,   -8
+.2byte   -1,  -21, 	   8,  -12, 	 -10,  -12, 	  -1,  -10
+.2byte   -1,  -15, 	   2,  -16, 	  -4,  -16, 	  -1,  -10
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte  -10,  -17, 	   4,  -14, 	  -2,   -9, 	   0,  -11
+.2byte   -8,  -11, 	  -4,  -14, 	  -9,  -11, 	   0,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -8,  -17, 	   4,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,  -17, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte  -11,  -12, 	   1,  -12, 	   1,  -10, 	  -3,   -8
+.2byte   -7,  -10, 	  -6,   -9, 	  -4,   -9, 	   0,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+.2byte  -11,  -10, 	  -4,  -10, 	   3,   -8, 	  -2,   -8
+.2byte   -4,   -8, 	  -6,   -7, 	   1,   -6, 	   0,   -7
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte    0,  -19, 	  -7,  -17, 	  10,  -14, 	   0,  -14
+.2byte    3,  -20, 	   7,  -19, 	  -9,  -13, 	  -1,  -14
+.2byte    3,  -20, 	   8,  -20, 	  -6,  -12, 	   0,  -14
+.2byte    1,  -20, 	   1,  -19, 	  -2,   -9, 	   0,  -13
+.2byte    0,  -21, 	   5,  -15, 	  -7,   -9, 	   0,  -12
+.2byte   -2,  -20, 	  -2,  -19, 	   1,   -9, 	  -1,  -13
+.2byte   -4,  -20, 	  -9,  -20, 	   5,  -12, 	  -1,  -14
+.2byte   -4,  -20, 	  -8,  -19, 	   8,  -13, 	   0,  -14
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -9,  -12, 	   6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	  -8,  -11, 	   7,  -12, 	  -1,  -11
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    7,  -17, 	  -5,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    7,  -17, 	   5,  -10, 	  -5,   -8, 	   0,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte   -1,  -21, 	   7,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte   -2,  -20, 	   6,   -8, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -20, 	   5,  -10, 	  -8,   -8, 	   0,   -9
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -8,  -17, 	   4,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,  -17, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+.2byte   -1,   -8, 	 -10,   -9, 	   9,   -9, 	  -1,   -7
+.2byte  -11,  -10, 	  -4,  -10, 	   3,   -8, 	  -2,   -8
+.2byte  -10,  -12, 	   2,  -12, 	   2,  -10, 	  -2,   -8
+.2byte  -10,  -17, 	   4,  -14, 	  -2,   -9, 	   0,  -11
+.2byte   -1,  -22, 	   8,  -13, 	 -10,  -13, 	  -1,  -11
+.2byte    9,  -17, 	  -5,  -14, 	   1,   -9, 	  -1,  -11
+.2byte   10,  -12, 	  -2,  -12, 	  -2,  -10, 	   2,   -8
+.2byte   10,  -10, 	   3,  -10, 	  -4,   -8, 	   1,   -8
+.2byte   -1,   -8, 	 -10,   -9, 	   9,   -9, 	  -1,   -7
+.2byte   10,  -10, 	   3,  -10, 	  -4,   -8, 	   1,   -8
+.2byte   10,  -12, 	  -2,  -12, 	  -2,  -10, 	   2,   -8
+.2byte    9,  -17, 	  -5,  -14, 	   1,   -9, 	  -1,  -11
+.2byte   -1,  -22, 	   8,  -13, 	 -10,  -13, 	  -1,  -11
+.2byte  -10,  -17, 	   4,  -14, 	  -2,   -9, 	   0,  -11
+.2byte  -10,  -12, 	   2,  -12, 	   2,  -10, 	  -2,   -8
+.2byte  -11,  -10, 	  -4,  -10, 	   3,   -8, 	  -2,   -8
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -15, 	  -9,  -12, 	   6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	  -8,  -11, 	   7,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	 -10,   -9, 	   9,   -9, 	  -1,   -7
+.2byte   -1,  -10, 	  -7,  -10, 	   4,  -10, 	  -1,   -8
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte   10,  -10, 	   3,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    3,   -8, 	   5,   -7, 	  -2,   -6, 	  -1,   -7
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    6,  -17, 	  -6,  -10, 	   3,   -8, 	  -2,  -10
+.2byte    6,  -17, 	   4,  -10, 	  -6,   -8, 	  -1,   -8
+.2byte    8,  -12, 	  -4,  -12, 	  -4,  -10, 	   0,   -8
+.2byte    4,  -10, 	   3,   -9, 	   1,   -9, 	  -3,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte    7,  -17, 	  -7,  -14, 	  -1,   -9, 	  -3,  -11
+.2byte    5,  -11, 	   1,  -14, 	   6,  -11, 	  -3,  -10
+.2byte   -1,  -20, 	   7,   -9, 	  -9,   -9, 	  -1,  -10
+.2byte   -2,  -19, 	   6,   -7, 	  -7,  -12, 	  -1,   -8
+.2byte    0,  -19, 	   5,   -9, 	  -8,   -7, 	   0,   -8
+.2byte   -1,  -21, 	   8,  -12, 	 -10,  -12, 	  -1,  -10
+.2byte   -1,  -15, 	   2,  -16, 	  -4,  -16, 	  -1,  -10
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte   -8,  -17, 	   6,  -14, 	   0,   -9, 	   2,  -11
+.2byte   -6,  -11, 	  -2,  -14, 	  -7,  -11, 	   2,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -7,  -17, 	   5,  -10, 	  -4,   -8, 	   1,  -10
+.2byte   -7,  -17, 	  -5,  -10, 	   5,   -8, 	   0,   -8
+.2byte   -8,  -12, 	   4,  -12, 	   4,  -10, 	   0,   -8
+.2byte   -5,  -10, 	  -4,   -9, 	  -2,   -9, 	   2,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+.2byte  -11,  -10, 	  -4,  -10, 	   3,   -8, 	  -2,   -8
+.2byte   -4,   -8, 	  -6,   -7, 	   1,   -6, 	   0,   -7
+.2byte   -1,  -10, 	  -7,  -10, 	   4,  -10, 	  -1,   -8
+.2byte   -5,   -8, 	  -7,   -7, 	   0,   -6, 	  -1,   -7
+.2byte   -7,  -10, 	  -6,   -9, 	  -4,   -9, 	   0,   -8
+.2byte   -8,  -11, 	  -4,  -14, 	  -9,  -11, 	   0,  -10
+.2byte   -1,  -15, 	   2,  -16, 	  -4,  -16, 	  -1,  -10
+.2byte    7,  -11, 	   3,  -14, 	   8,  -11, 	  -1,  -10
+.2byte    6,  -10, 	   5,   -9, 	   3,   -9, 	  -1,   -8
+.2byte    4,   -8, 	   6,   -7, 	  -1,   -6, 	   0,   -7
+.2byte   -1,  -17, 	 -10,  -10, 	   8,  -10, 	  -1,  -12
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -1,  -21, 	   7,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -17, 	   7,  -11, 	  -6,   -7, 	   1,  -10
+.2byte    3,  -15, 	   0,  -12, 	  -1,   -7, 	   0,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -8,   -9, 	   0,  -10
+.2byte    6,  -19, 	   0,  -10, 	  -1,   -7, 	  -1,  -11
+.2byte    7,  -17, 	  -5,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    7,  -17, 	   5,  -10, 	  -5,   -8, 	   0,   -8
+.2byte    3,  -20, 	  -7,  -12, 	   3,   -8, 	  -2,  -11
+.2byte    4,  -18, 	  -9,   -9, 	   7,  -11, 	  -1,  -10
+.2byte    4,  -18, 	   1,  -13, 	   1,   -7, 	  -2,  -10
+.2byte   -1,  -21, 	   7,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte   -2,  -20, 	   6,   -8, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -20, 	   5,  -10, 	  -8,   -8, 	   0,   -9
+.2byte   -4,  -20, 	   6,  -12, 	  -4,   -8, 	   1,  -11
+.2byte   -5,  -18, 	   8,   -9, 	  -8,  -11, 	   0,  -10
+.2byte   -5,  -18, 	  -2,  -13, 	  -2,   -7, 	   1,  -10
+.2byte   -7,  -19, 	  -1,  -10, 	   0,   -7, 	   0,  -11
+.2byte   -8,  -17, 	   4,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,  -17, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte   -4,  -17, 	  -8,  -11, 	   5,   -7, 	  -2,  -10
+.2byte   -4,  -15, 	  -1,  -12, 	   0,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   7,   -9, 	  -1,  -10
+sDragoniteAnimTable1:
+.4byte sDragoniteAnims_1_1
+.4byte sDragoniteAnims_1_2
+.4byte sDragoniteAnims_1_3
+.4byte sDragoniteAnims_1_4
+.4byte sDragoniteAnims_1_5
+.4byte sDragoniteAnims_1_6
+.4byte sDragoniteAnims_1_7
+.4byte sDragoniteAnims_1_8
+sDragoniteAnimTable2:
+.4byte sDragoniteAnims_2_1
+.4byte sDragoniteAnims_2_2
+.4byte sDragoniteAnims_2_3
+.4byte sDragoniteAnims_2_4
+.4byte sDragoniteAnims_2_5
+.4byte sDragoniteAnims_2_6
+.4byte sDragoniteAnims_2_7
+.4byte sDragoniteAnims_2_8
+sDragoniteAnimTable3:
+.4byte sDragoniteAnims_3_1
+.4byte sDragoniteAnims_3_2
+.4byte sDragoniteAnims_3_3
+.4byte sDragoniteAnims_3_4
+.4byte sDragoniteAnims_3_5
+.4byte sDragoniteAnims_3_6
+.4byte sDragoniteAnims_3_7
+.4byte sDragoniteAnims_3_8
+sDragoniteAnimTable4:
+.4byte sDragoniteAnims_4_1
+.4byte sDragoniteAnims_4_2
+.4byte sDragoniteAnims_4_3
+.4byte sDragoniteAnims_4_4
+.4byte sDragoniteAnims_4_5
+.4byte sDragoniteAnims_4_6
+.4byte sDragoniteAnims_4_7
+.4byte sDragoniteAnims_4_8
+sDragoniteAnimTable5:
+.4byte sDragoniteAnims_5_1
+.4byte sDragoniteAnims_5_2
+.4byte sDragoniteAnims_5_3
+.4byte sDragoniteAnims_5_4
+.4byte sDragoniteAnims_5_5
+.4byte sDragoniteAnims_5_6
+.4byte sDragoniteAnims_5_7
+.4byte sDragoniteAnims_5_8
+sDragoniteAnimTable6:
+.4byte sDragoniteAnims_6_1
+.4byte sDragoniteAnims_6_1
+.4byte sDragoniteAnims_6_1
+.4byte sDragoniteAnims_6_1
+.4byte sDragoniteAnims_6_1
+.4byte sDragoniteAnims_6_1
+.4byte sDragoniteAnims_6_1
+.4byte sDragoniteAnims_6_1
+sDragoniteAnimTable7:
+.4byte sDragoniteAnims_7_1
+.4byte sDragoniteAnims_7_2
+.4byte sDragoniteAnims_7_3
+.4byte sDragoniteAnims_7_4
+.4byte sDragoniteAnims_7_5
+.4byte sDragoniteAnims_7_6
+.4byte sDragoniteAnims_7_7
+.4byte sDragoniteAnims_7_8
+sDragoniteAnimTable8:
+.4byte sDragoniteAnims_8_1
+.4byte sDragoniteAnims_8_2
+.4byte sDragoniteAnims_8_3
+.4byte sDragoniteAnims_8_4
+.4byte sDragoniteAnims_8_5
+.4byte sDragoniteAnims_8_6
+.4byte sDragoniteAnims_8_7
+.4byte sDragoniteAnims_8_8
+sDragoniteAnimTable9:
+.4byte sDragoniteAnims_9_1
+.4byte sDragoniteAnims_9_2
+.4byte sDragoniteAnims_9_3
+.4byte sDragoniteAnims_9_4
+.4byte sDragoniteAnims_9_5
+.4byte sDragoniteAnims_9_6
+.4byte sDragoniteAnims_9_7
+.4byte sDragoniteAnims_9_8
+sDragoniteAnimTable10:
+.4byte sDragoniteAnims_10_1
+.4byte sDragoniteAnims_10_2
+.4byte sDragoniteAnims_10_3
+.4byte sDragoniteAnims_10_4
+.4byte sDragoniteAnims_10_5
+.4byte sDragoniteAnims_10_6
+.4byte sDragoniteAnims_10_7
+.4byte sDragoniteAnims_10_8
+sDragoniteAnimTable11:
+.4byte sDragoniteAnims_11_1
+.4byte sDragoniteAnims_11_2
+.4byte sDragoniteAnims_11_3
+.4byte sDragoniteAnims_11_4
+.4byte sDragoniteAnims_11_5
+.4byte sDragoniteAnims_11_6
+.4byte sDragoniteAnims_11_7
+.4byte sDragoniteAnims_11_8
+sDragoniteAnimTable12:
+.4byte sDragoniteAnims_12_1
+.4byte sDragoniteAnims_12_2
+.4byte sDragoniteAnims_12_3
+.4byte sDragoniteAnims_12_4
+.4byte sDragoniteAnims_12_5
+.4byte sDragoniteAnims_12_6
+.4byte sDragoniteAnims_12_7
+.4byte sDragoniteAnims_12_8
+sDragoniteAnimTable13:
+.4byte sDragoniteAnims_13_1
+.4byte sDragoniteAnims_13_2
+.4byte sDragoniteAnims_13_3
+.4byte sDragoniteAnims_13_4
+.4byte sDragoniteAnims_13_5
+.4byte sDragoniteAnims_13_6
+.4byte sDragoniteAnims_13_7
+.4byte sDragoniteAnims_13_8
+sAxAnimationsDragonite:
+.4byte sDragoniteAnimTable1
+.4byte sDragoniteAnimTable2
+.4byte sDragoniteAnimTable3
+.4byte sDragoniteAnimTable4
+.4byte sDragoniteAnimTable5
+.4byte sDragoniteAnimTable6
+.4byte sDragoniteAnimTable7
+.4byte sDragoniteAnimTable8
+.4byte sDragoniteAnimTable9
+.4byte sDragoniteAnimTable10
+.4byte sDragoniteAnimTable11
+.4byte sDragoniteAnimTable12
+.4byte sDragoniteAnimTable13
+sAxSpritesDragonite:
+.4byte sDragoniteSprites1
+.4byte sDragoniteSprites2
+.4byte sDragoniteSprites3
+.4byte sDragoniteSprites4
+.4byte sDragoniteSprites5
+.4byte sDragoniteSprites6
+.4byte sDragoniteSprites7
+.4byte sDragoniteSprites8
+.4byte sDragoniteSprites9
+.4byte sDragoniteSprites10
+.4byte sDragoniteSprites11
+.4byte sDragoniteSprites12
+.4byte sDragoniteSprites13
+.4byte sDragoniteSprites14
+.4byte sDragoniteSprites15
+.4byte sDragoniteSprites16
+.4byte sDragoniteSprites17
+.4byte sDragoniteSprites18
+.4byte sDragoniteSprites19
+.4byte sDragoniteSprites20
+.4byte sDragoniteSprites21
+.4byte sDragoniteSprites22
+.4byte sDragoniteSprites23
+.4byte sDragoniteSprites24
+.4byte sDragoniteSprites25
+.4byte sDragoniteSprites26
+.4byte sDragoniteSprites27
+.4byte sDragoniteSprites28
+.4byte sDragoniteSprites29
+.4byte sDragoniteSprites30
+.4byte sDragoniteSprites31
+.4byte sDragoniteSprites32
+.4byte sDragoniteSprites33
+.4byte sDragoniteSprites34
+.4byte sDragoniteSprites35
+.4byte sDragoniteSprites36
+.4byte sDragoniteSprites37
+.4byte sDragoniteSprites38
+.4byte sDragoniteSprites39
+.4byte sDragoniteSprites40
+.4byte sDragoniteSprites41
+.4byte sDragoniteSprites42
+sAxMainDragonite:
+ax_main sAxPosesDragonite, sAxAnimationsDragonite, 13, sAxSpritesDragonite, sAxPositionsDragonite

--- a/data/ax/dratini.inc
+++ b/data/ax/dratini.inc
@@ -1,0 +1,2956 @@
+.global gAxDratini
+gAxDratini:
+ax_siro sAxMainDratini
+sDratiniPose1:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose2:
+ax_pose 1, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose3:
+ax_pose 2, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose4:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose5:
+ax_pose 4, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose6:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose7:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose8:
+ax_pose 7, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose9:
+ax_pose 8, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose10:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose11:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose12:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose13:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose14:
+ax_pose 13, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose15:
+ax_pose 14, 0x01ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose16:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose17:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose18:
+ax_pose 17, 0x01ed, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose19:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose20:
+ax_pose 19, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose21:
+ax_pose 20, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose22:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose23:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose24:
+ax_pose 23, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose25:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose26:
+ax_pose 1, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose27:
+ax_pose 2, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose28:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose29:
+ax_pose 4, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose30:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose31:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose32:
+ax_pose 7, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose33:
+ax_pose 8, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose34:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose35:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose36:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose37:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose38:
+ax_pose 13, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose39:
+ax_pose 14, 0x01ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose40:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose41:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose42:
+ax_pose 17, 0x01ed, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose43:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose44:
+ax_pose 19, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose45:
+ax_pose 20, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose46:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose47:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose48:
+ax_pose 23, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose49:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose50:
+ax_pose 1, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose51:
+ax_pose 2, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose52:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose53:
+ax_pose 4, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose54:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose55:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose56:
+ax_pose 7, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose57:
+ax_pose 8, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose58:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose59:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose60:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose61:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose62:
+ax_pose 13, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose63:
+ax_pose 14, 0x01ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose64:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose65:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose66:
+ax_pose 17, 0x01ed, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose67:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose68:
+ax_pose 19, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose69:
+ax_pose 20, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose70:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose71:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose72:
+ax_pose 23, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose73:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose74:
+ax_pose 1, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose75:
+ax_pose 2, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose76:
+ax_pose 24, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose77:
+ax_pose 25, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose78:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose79:
+ax_pose 4, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose80:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose81:
+ax_pose 26, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sDratiniPose82:
+ax_pose 27, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDratiniPose83:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose84:
+ax_pose 7, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose85:
+ax_pose 8, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose86:
+ax_pose 28, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sDratiniPose87:
+ax_pose 29, 0x01e8, 0x90ea, 0x5c00
+ax_pose_terminator
+sDratiniPose88:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose89:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose90:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose91:
+ax_pose 30, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sDratiniPose92:
+ax_pose 31, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sDratiniPose93:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose94:
+ax_pose 13, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose95:
+ax_pose 14, 0x01ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose96:
+ax_pose 32, 0x01e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose97:
+ax_pose 33, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose98:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose99:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose100:
+ax_pose 17, 0x01ed, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose101:
+ax_pose 30, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose102:
+ax_pose 31, 0x01e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sDratiniPose103:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose104:
+ax_pose 19, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose105:
+ax_pose 20, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose106:
+ax_pose 28, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose107:
+ax_pose 29, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sDratiniPose108:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose109:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose110:
+ax_pose 23, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose111:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose112:
+ax_pose 27, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose113:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose114:
+ax_pose 1, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose115:
+ax_pose 2, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose116:
+ax_pose 24, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose117:
+ax_pose 25, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose118:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose119:
+ax_pose 4, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose120:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose121:
+ax_pose 26, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sDratiniPose122:
+ax_pose 27, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDratiniPose123:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose124:
+ax_pose 7, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose125:
+ax_pose 8, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose126:
+ax_pose 28, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sDratiniPose127:
+ax_pose 29, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sDratiniPose128:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose129:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose130:
+ax_pose 11, 0x01e9, 0x80f5, 0x5c00
+ax_pose_terminator
+sDratiniPose131:
+ax_pose 30, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sDratiniPose132:
+ax_pose 31, 0x01e9, 0x90e9, 0x5c00
+ax_pose_terminator
+sDratiniPose133:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose134:
+ax_pose 13, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose135:
+ax_pose 14, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose136:
+ax_pose 32, 0x01e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose137:
+ax_pose 33, 0x01e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose138:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose139:
+ax_pose 16, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose140:
+ax_pose 17, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose141:
+ax_pose 30, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose142:
+ax_pose 31, 0x01e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sDratiniPose143:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose144:
+ax_pose 19, 0x01ec, 0x80ee, 0x5c00
+ax_pose_terminator
+sDratiniPose145:
+ax_pose 20, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose146:
+ax_pose 28, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose147:
+ax_pose 29, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sDratiniPose148:
+ax_pose 21, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose149:
+ax_pose 22, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose150:
+ax_pose 23, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose151:
+ax_pose 26, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose152:
+ax_pose 27, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose153:
+ax_pose 34, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose154:
+ax_pose 35, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose155:
+ax_pose 36, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose156:
+ax_pose 37, 0x01e2, 0x90ed, 0x5c00
+ax_pose_terminator
+sDratiniPose157:
+ax_pose 38, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDratiniPose158:
+ax_pose 39, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sDratiniPose159:
+ax_pose 40, 0x0202, 0x00fc, 0x5c00
+ax_pose 41, 0x81e2, 0x4104, 0x5c01
+ax_pose 42, 0x81e2, 0x80f4, 0x5c05
+ax_pose_terminator
+sDratiniPose160:
+ax_pose 39, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose161:
+ax_pose 38, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose162:
+ax_pose 37, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose163:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose164:
+ax_pose 1, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose165:
+ax_pose 2, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose166:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose167:
+ax_pose 4, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose168:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose169:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose170:
+ax_pose 7, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose171:
+ax_pose 8, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose172:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose173:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose174:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose175:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose176:
+ax_pose 13, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose177:
+ax_pose 14, 0x01ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose178:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose179:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose180:
+ax_pose 17, 0x01ed, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose181:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose182:
+ax_pose 19, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose183:
+ax_pose 20, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose184:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose185:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose186:
+ax_pose 23, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose187:
+ax_pose 24, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose188:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose189:
+ax_pose 28, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDratiniPose190:
+ax_pose 30, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose191:
+ax_pose 32, 0x01e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose192:
+ax_pose 30, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sDratiniPose193:
+ax_pose 28, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sDratiniPose194:
+ax_pose 26, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sDratiniPose195:
+ax_pose 25, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose196:
+ax_pose 27, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sDratiniPose197:
+ax_pose 29, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sDratiniPose198:
+ax_pose 31, 0x01e8, 0x90e9, 0x5c00
+ax_pose_terminator
+sDratiniPose199:
+ax_pose 33, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose200:
+ax_pose 31, 0x01e8, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose201:
+ax_pose 29, 0x01e9, 0x80f5, 0x5c00
+ax_pose_terminator
+sDratiniPose202:
+ax_pose 27, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose203:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose204:
+ax_pose 25, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose205:
+ax_pose 1, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose206:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose207:
+ax_pose 27, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sDratiniPose208:
+ax_pose 4, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose209:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose210:
+ax_pose 29, 0x01e8, 0x90ea, 0x5c00
+ax_pose_terminator
+sDratiniPose211:
+ax_pose 7, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose212:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose213:
+ax_pose 31, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sDratiniPose214:
+ax_pose 10, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose215:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose216:
+ax_pose 33, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose217:
+ax_pose 13, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose218:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose219:
+ax_pose 31, 0x01e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sDratiniPose220:
+ax_pose 16, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose221:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose222:
+ax_pose 29, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sDratiniPose223:
+ax_pose 19, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose224:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose225:
+ax_pose 27, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sDratiniPose226:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose227:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose228:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose229:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose230:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose231:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose232:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose233:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose234:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose235:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose236:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose237:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose238:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose239:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose240:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose241:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose242:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose243:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose244:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose245:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose246:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose247:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose248:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose249:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose250:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose251:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose252:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose253:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose254:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose255:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose256:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose257:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose258:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose259:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose260:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose261:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose262:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose263:
+ax_pose 0, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sDratiniPose264:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose265:
+ax_pose 18, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose266:
+ax_pose 15, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sDratiniPose267:
+ax_pose 12, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sDratiniPose268:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sDratiniPose269:
+ax_pose 6, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDratiniPose270:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+.align 2
+sDratiniAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 2, 0, 2,
+ax_anim 8, 0, 0, 0, 2, 0, 2,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 3, 1, 1, 1, 1,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 6, 2, 0, 2, 0,
+ax_anim 8, 0, 8, 1, 0, 1, 0,
+ax_anim_terminator
+sDratiniAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 9, 1, -1, 1, -1,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, -2,
+ax_anim 8, 0, 12, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 15, -1, -1, -1, -1,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 19, -1, 0, -1, 0,
+ax_anim 8, 0, 18, -2, 0, -2, 0,
+ax_anim 8, 0, 20, -1, 0, -1, 0,
+ax_anim_terminator
+sDratiniAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 21, -1, 1, -1, 1,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDratiniAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sDratiniAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sDratiniAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 4, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 34, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 16, -21, 16, -21,
+ax_anim 2, 1, 34, 17, -20, 17, -20,
+ax_anim 2, 0, 34, 16, -21, 16, -21,
+ax_anim 2, 0, 34, 17, -20, 17, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sDratiniAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 4, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -18, 0, -21,
+ax_anim 2, 1, 37, 1, -18, 1, -21,
+ax_anim 2, 0, 37, 0, -18, 0, -21,
+ax_anim 2, 0, 37, 1, -18, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sDratiniAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 4, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 40, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -16, -21, -18, -23,
+ax_anim 2, 1, 40, -17, -20, -19, -22,
+ax_anim 2, 0, 40, -16, -21, -18, -23,
+ax_anim 2, 0, 40, -17, -20, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sDratiniAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 4, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sDratiniAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -18, 19, -18, 19,
+ax_anim 2, 1, 46, -19, 18, -19, 18,
+ax_anim 2, 0, 46, -18, 19, -18, 19,
+ax_anim 2, 0, 46, -19, 18, -19, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDratiniAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 4, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sDratiniAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 4, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sDratiniAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 4, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sDratiniAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 4, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 58, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 16, -21, 16, -21,
+ax_anim 2, 1, 58, 17, -20, 17, -20,
+ax_anim 2, 0, 58, 16, -21, 16, -21,
+ax_anim 2, 0, 58, 17, -20, 17, -20,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sDratiniAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 4, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -18, 0, -21,
+ax_anim 2, 1, 61, 1, -18, 1, -21,
+ax_anim 2, 0, 61, 0, -18, 0, -21,
+ax_anim 2, 0, 61, 1, -18, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sDratiniAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 4, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 64, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -16, -21, -18, -23,
+ax_anim 2, 1, 64, -17, -20, -19, -22,
+ax_anim 2, 0, 64, -16, -21, -18, -23,
+ax_anim 2, 0, 64, -17, -20, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sDratiniAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 4, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sDratiniAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 4, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -18, 19, -18, 19,
+ax_anim 2, 1, 70, -19, 18, -19, 18,
+ax_anim 2, 0, 70, -18, 19, -18, 19,
+ax_anim 2, 0, 70, -19, 18, -19, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDratiniAnims_4_1:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 76, 0, -3, 0, -3,
+ax_anim 4, 2, 76, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -4, 0, -4,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 1, 75, 1, 4, 1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, 1, 4, 1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, 1, 4, 1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sDratiniAnims_4_2:
+ax_anim 2, 0, 79, -1, -1, -1, -1,
+ax_anim 2, 0, 81, -3, -3, -3, -3,
+ax_anim 4, 2, 81, -4, -4, -4, -4,
+ax_anim 1, 0, 80, -4, -4, -4, -4,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 4, 4, 4, 4,
+ax_anim 2, 1, 80, 5, 3, 5, 3,
+ax_anim 2, 0, 80, 4, 4, 4, 4,
+ax_anim 2, 0, 80, 5, 3, 5, 3,
+ax_anim 2, 0, 80, 4, 4, 4, 4,
+ax_anim 2, 0, 80, 5, 3, 5, 3,
+ax_anim 2, 0, 80, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim_terminator
+sDratiniAnims_4_3:
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 2, 0, 86, -3, 0, -3, 0,
+ax_anim 4, 2, 86, -4, 0, -4, 0,
+ax_anim 1, 0, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 1, 83, 4, 1, 4, 1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, 1, 4, 1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, 1, 4, 1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim_terminator
+sDratiniAnims_4_4:
+ax_anim 2, 0, 89, -1, 1, -1, 1,
+ax_anim 2, 0, 91, -3, 3, -3, 3,
+ax_anim 4, 2, 91, -4, 4, -4, 4,
+ax_anim 1, 0, 91, -4, 4, -4, 4,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 4, -4, 4, -4,
+ax_anim 2, 1, 90, 5, -3, 5, -3,
+ax_anim 2, 0, 90, 4, -4, 4, -4,
+ax_anim 2, 0, 90, 5, -3, 5, -3,
+ax_anim 2, 0, 90, 4, -4, 4, -4,
+ax_anim 2, 0, 90, 5, -3, 5, -3,
+ax_anim 2, 0, 90, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim_terminator
+sDratiniAnims_4_5:
+ax_anim 2, 0, 94, 0, 1, 0, 1,
+ax_anim 2, 0, 96, 0, 3, 0, 3,
+ax_anim 4, 2, 96, 0, 4, 0, 4,
+ax_anim 1, 0, 95, 0, 4, 0, 4,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, -4,
+ax_anim 2, 1, 95, -1, -4, -1, -4,
+ax_anim 2, 0, 95, 0, -4, 0, -4,
+ax_anim 2, 0, 95, -1, -4, -1, -4,
+ax_anim 2, 0, 95, 0, -4, 0, -4,
+ax_anim 2, 0, 95, -1, -4, -1, -4,
+ax_anim 2, 0, 95, 0, -4, 0, -4,
+ax_anim 2, 0, 92, 0, -2, 0, -2,
+ax_anim_terminator
+sDratiniAnims_4_6:
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 101, 3, 3, 3, 3,
+ax_anim 4, 2, 101, 4, 4, 4, 4,
+ax_anim 1, 0, 101, 4, 4, 4, 4,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -4, -4, -4, -4,
+ax_anim 2, 1, 100, -5, -3, -5, -3,
+ax_anim 2, 0, 100, -4, -4, -4, -4,
+ax_anim 2, 0, 100, -5, -3, -5, -3,
+ax_anim 2, 0, 100, -4, -4, -4, -4,
+ax_anim 2, 0, 100, -5, -3, -5, -3,
+ax_anim 2, 0, 100, -4, -4, -4, -4,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim_terminator
+sDratiniAnims_4_7:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 3, 0, 3, 0,
+ax_anim 4, 2, 106, 4, 0, 4, 0,
+ax_anim 1, 0, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -4, 0, -4, 0,
+ax_anim 2, 1, 103, -4, 1, -4, 1,
+ax_anim 2, 0, 103, -4, 0, -4, 0,
+ax_anim 2, 0, 103, -4, 1, -4, 1,
+ax_anim 2, 0, 103, -4, 0, -4, 0,
+ax_anim 2, 0, 103, -4, 1, -4, 1,
+ax_anim 2, 0, 103, -4, 0, -4, 0,
+ax_anim 2, 0, 102, -2, 0, -2, 0,
+ax_anim_terminator
+sDratiniAnims_4_8:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 3, -3, 3, -3,
+ax_anim 4, 2, 111, 4, -4, 4, -4,
+ax_anim 1, 0, 110, 4, -4, 4, -4,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -4, 4, -4, 4,
+ax_anim 2, 1, 110, -5, 3, -5, 3,
+ax_anim 2, 0, 110, -4, 4, -4, 4,
+ax_anim 2, 0, 110, -5, 3, -5, 3,
+ax_anim 2, 0, 110, -4, 4, -4, 4,
+ax_anim 2, 0, 110, -5, 3, -5, 3,
+ax_anim 2, 0, 110, -4, 4, -4, 4,
+ax_anim 2, 0, 107, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sDratiniAnims_5_1:
+ax_anim 6, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 2, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 1, 0, 114, 0, 1, 0, 1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_5_2:
+ax_anim 6, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 2, 118, -1, -1, -1, -1,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 1, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 1, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_5_3:
+ax_anim 6, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 2, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_5_4:
+ax_anim 6, 0, 129, 0, -1, 0, -1,
+ax_anim 2, 2, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim 1, 0, 130, 0, 1, 0, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 1, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_5_5:
+ax_anim 6, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 2, 134, -1, -1, -1, -1,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 1, 0, 132, 0, 0, 0, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 1, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_5_6:
+ax_anim 6, 0, 139, 0, -1, 0, -1,
+ax_anim 2, 2, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, -1, 0, -1,
+ax_anim 1, 0, 140, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, 0, 1, 0,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, 0, 1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, 0, 1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_5_7:
+ax_anim 6, 0, 143, 0, -1, 0, -1,
+ax_anim 2, 2, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, -1, 0, -1,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 1, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_5_8:
+ax_anim 6, 0, 148, 0, -1, 0, -1,
+ax_anim 2, 2, 148, 1, -1, 1, -1,
+ax_anim 2, 0, 148, 0, -1, 0, -1,
+ax_anim 1, 0, 150, 0, 1, 0, 1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, 0, 1, 0,
+ax_anim 2, 1, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, 0, 1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, 0, 1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sDratiniAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sDratiniAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sDratiniAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sDratiniAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sDratiniAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sDratiniAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sDratiniAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDratiniAnims_8_1:
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_8_2:
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_8_3:
+ax_anim 10, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_8_4:
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_8_5:
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_8_6:
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_8_7:
+ax_anim 10, 0, 180, 0, 0, 0, 0,
+ax_anim 20, 0, 181, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, 0, 0, 0,
+ax_anim 20, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_8_8:
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim 20, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim 20, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 3, 7, 3,
+ax_anim 2, 0, 188, 8, 13, 8, 13,
+ax_anim 2, 0, 189, 7, 15, 7, 15,
+ax_anim 3, 0, 190, 0, 17, 0, 17,
+ax_anim 2, 3, 191, -7, 15, -7, 15,
+ax_anim 2, 0, 192, -8, 13, -8, 13,
+ax_anim 1, 0, 193, -7, 3, -7, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 16, 3, 16, 3,
+ax_anim 2, 0, 188, 18, 15, 18, 15,
+ax_anim 3, 0, 189, 19, 21, 19, 21,
+ax_anim 2, 3, 190, 11, 21, 11, 21,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 1, 10, 1, 10,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -9, 3, -9,
+ax_anim 2, 0, 186, 11, -11, 11, -11,
+ax_anim 2, 0, 187, 16, -10, 16, -10,
+ax_anim 3, 0, 188, 18, -2, 18, -2,
+ax_anim 2, 3, 189, 18, 3, 18, 3,
+ax_anim 2, 0, 190, 10, 5, 10, 5,
+ax_anim 1, 0, 191, 2, 3, 2, 3,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 1, -6, 1, -6,
+ax_anim 2, 0, 193, 3, -18, 3, -18,
+ax_anim 2, 0, 186, 11, -21, 11, -21,
+ax_anim 3, 0, 187, 21, -20, 21, -20,
+ax_anim 2, 3, 188, 20, -8, 20, -8,
+ax_anim 2, 0, 189, 18, -4, 18, -4,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -9, -2, -9, -2,
+ax_anim 2, 0, 192, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -8, -17, -8, -17,
+ax_anim 3, 0, 186, 0, -20, 0, -20,
+ax_anim 2, 3, 187, 8, -17, 8, -17,
+ax_anim 2, 0, 188, 11, -6, 11, -6,
+ax_anim 1, 0, 189, 9, -2, 9, -2,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -6, 1, -6,
+ax_anim 2, 0, 187, -3, -18, -3, -18,
+ax_anim 2, 0, 186, -11, -21, -11, -21,
+ax_anim 3, 0, 193, -21, -20, -21, -20,
+ax_anim 2, 3, 192, -20, -8, -20, -8,
+ax_anim 2, 0, 191, -18, -4, -18, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -9, -3, -9,
+ax_anim 2, 0, 186, -11, -11, -11, -11,
+ax_anim 2, 0, 193, -16, -10, -16, -10,
+ax_anim 3, 0, 192, -18, -2, -18, -2,
+ax_anim 2, 3, 191, -18, 3, -18, 3,
+ax_anim 2, 0, 190, -10, 5, -10, 5,
+ax_anim 1, 0, 189, -2, 3, -2, 3,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -16, 3, -16, 3,
+ax_anim 2, 0, 192, -18, 15, -18, 15,
+ax_anim 3, 0, 191, -19, 21, -19, 21,
+ax_anim 2, 3, 190, -11, 21, -11, 21,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, -1, 10, -1, 10,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -28, 0, 0,
+ax_anim 3, 0, 204, 0, -25, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -26, 0, 0,
+ax_anim 3, 0, 207, 0, -24, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -26, 0, 0,
+ax_anim 3, 0, 210, 0, -24, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -27, 0, 0,
+ax_anim 3, 0, 219, 0, -25, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -24, 0, 0,
+ax_anim 3, 0, 222, 0, -23, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -26, 0, 0,
+ax_anim 3, 0, 225, 0, -24, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDratiniAnims_13_1:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_13_2:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_13_3:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_13_4:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_13_5:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_13_6:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_13_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniAnims_13_8:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sDratiniGfx1:
+.incbin "baserom.gba", 0xB6BCB8, 0x200
+sDratiniSprites1:
+ax_sprite sDratiniGfx1, 0x200
+ax_sprite_terminator
+sDratiniGfx2:
+.incbin "baserom.gba", 0xB6BEC8, 0x200
+sDratiniSprites2:
+ax_sprite sDratiniGfx2, 0x200
+ax_sprite_terminator
+sDratiniGfx3:
+.incbin "baserom.gba", 0xB6C0D8, 0x200
+sDratiniSprites3:
+ax_sprite sDratiniGfx3, 0x200
+ax_sprite_terminator
+sDratiniGfx4:
+.incbin "baserom.gba", 0xB6C2E8, 0x200
+sDratiniSprites4:
+ax_sprite sDratiniGfx4, 0x200
+ax_sprite_terminator
+sDratiniGfx5:
+.incbin "baserom.gba", 0xB6C4F8, 0x200
+sDratiniSprites5:
+ax_sprite sDratiniGfx5, 0x200
+ax_sprite_terminator
+sDratiniGfx6:
+.incbin "baserom.gba", 0xB6C708, 0x200
+sDratiniSprites6:
+ax_sprite sDratiniGfx6, 0x200
+ax_sprite_terminator
+sDratiniGfx7:
+.incbin "baserom.gba", 0xB6C918, 0x200
+sDratiniSprites7:
+ax_sprite sDratiniGfx7, 0x200
+ax_sprite_terminator
+sDratiniGfx8:
+.incbin "baserom.gba", 0xB6CB28, 0x200
+sDratiniSprites8:
+ax_sprite sDratiniGfx8, 0x200
+ax_sprite_terminator
+sDratiniGfx9:
+.incbin "baserom.gba", 0xB6CD38, 0x200
+sDratiniSprites9:
+ax_sprite sDratiniGfx9, 0x200
+ax_sprite_terminator
+sDratiniGfx10:
+.incbin "baserom.gba", 0xB6CF48, 0x200
+sDratiniSprites10:
+ax_sprite sDratiniGfx10, 0x200
+ax_sprite_terminator
+sDratiniGfx11:
+.incbin "baserom.gba", 0xB6D158, 0x200
+sDratiniSprites11:
+ax_sprite sDratiniGfx11, 0x200
+ax_sprite_terminator
+sDratiniGfx12:
+.incbin "baserom.gba", 0xB6D368, 0x200
+sDratiniSprites12:
+ax_sprite sDratiniGfx12, 0x200
+ax_sprite_terminator
+sDratiniGfx13:
+.incbin "baserom.gba", 0xB6D578, 0x200
+sDratiniSprites13:
+ax_sprite sDratiniGfx13, 0x200
+ax_sprite_terminator
+sDratiniGfx14:
+.incbin "baserom.gba", 0xB6D788, 0x200
+sDratiniSprites14:
+ax_sprite sDratiniGfx14, 0x200
+ax_sprite_terminator
+sDratiniGfx15:
+.incbin "baserom.gba", 0xB6D998, 0x200
+sDratiniSprites15:
+ax_sprite sDratiniGfx15, 0x200
+ax_sprite_terminator
+sDratiniGfx16:
+.incbin "baserom.gba", 0xB6DBA8, 0x200
+sDratiniSprites16:
+ax_sprite sDratiniGfx16, 0x200
+ax_sprite_terminator
+sDratiniGfx17:
+.incbin "baserom.gba", 0xB6DDB8, 0x200
+sDratiniSprites17:
+ax_sprite sDratiniGfx17, 0x200
+ax_sprite_terminator
+sDratiniGfx18:
+.incbin "baserom.gba", 0xB6DFC8, 0x200
+sDratiniSprites18:
+ax_sprite sDratiniGfx18, 0x200
+ax_sprite_terminator
+sDratiniGfx19:
+.incbin "baserom.gba", 0xB6E1D8, 0x200
+sDratiniSprites19:
+ax_sprite sDratiniGfx19, 0x200
+ax_sprite_terminator
+sDratiniGfx20:
+.incbin "baserom.gba", 0xB6E3E8, 0x200
+sDratiniSprites20:
+ax_sprite sDratiniGfx20, 0x200
+ax_sprite_terminator
+sDratiniGfx21:
+.incbin "baserom.gba", 0xB6E5F8, 0x200
+sDratiniSprites21:
+ax_sprite sDratiniGfx21, 0x200
+ax_sprite_terminator
+sDratiniGfx22:
+.incbin "baserom.gba", 0xB6E808, 0x200
+sDratiniSprites22:
+ax_sprite sDratiniGfx22, 0x200
+ax_sprite_terminator
+sDratiniGfx23:
+.incbin "baserom.gba", 0xB6EA18, 0x200
+sDratiniSprites23:
+ax_sprite sDratiniGfx23, 0x200
+ax_sprite_terminator
+sDratiniGfx24:
+.incbin "baserom.gba", 0xB6EC28, 0x200
+sDratiniSprites24:
+ax_sprite sDratiniGfx24, 0x200
+ax_sprite_terminator
+sDratiniGfx25:
+.incbin "baserom.gba", 0xB6EE38, 0x20
+sDratiniGfx25_1:
+.incbin "baserom.gba", 0xB6EE58, 0x40
+sDratiniGfx25_2:
+.incbin "baserom.gba", 0xB6EE98, 0x60
+sDratiniGfx25_3:
+.incbin "baserom.gba", 0xB6EEF8, 0x40
+sDratiniSprites25:
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx25, 0x20
+ax_sprite 0, 0x60
+ax_sprite sDratiniGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDratiniGfx26:
+.incbin "baserom.gba", 0xB6EF88, 0x60
+sDratiniGfx26_1:
+.incbin "baserom.gba", 0xB6EFE8, 0x60
+sDratiniGfx26_2:
+.incbin "baserom.gba", 0xB6F048, 0x40
+sDratiniSprites26:
+ax_sprite sDratiniGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx26_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDratiniGfx27:
+.incbin "baserom.gba", 0xB6F0C0, 0x60
+sDratiniGfx27_1:
+.incbin "baserom.gba", 0xB6F120, 0x60
+sDratiniGfx27_2:
+.incbin "baserom.gba", 0xB6F180, 0x60
+sDratiniSprites27:
+ax_sprite sDratiniGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDratiniGfx28:
+.incbin "baserom.gba", 0xB6F218, 0x40
+sDratiniGfx28_1:
+.incbin "baserom.gba", 0xB6F258, 0x60
+sDratiniGfx28_2:
+.incbin "baserom.gba", 0xB6F2B8, 0x60
+sDratiniSprites28:
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx28_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDratiniGfx29:
+.incbin "baserom.gba", 0xB6F358, 0x40
+sDratiniGfx29_1:
+.incbin "baserom.gba", 0xB6F398, 0x40
+sDratiniGfx29_2:
+.incbin "baserom.gba", 0xB6F3D8, 0xA0
+sDratiniGfx29_3:
+.incbin "baserom.gba", 0xB6F478, 0x60
+sDratiniSprites29:
+ax_sprite sDratiniGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx29_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx29_3, 0x60
+ax_sprite_terminator
+sDratiniGfx30:
+.incbin "baserom.gba", 0xB6F518, 0x40
+sDratiniGfx30_1:
+.incbin "baserom.gba", 0xB6F558, 0x40
+sDratiniGfx30_2:
+.incbin "baserom.gba", 0xB6F598, 0x60
+sDratiniGfx30_3:
+.incbin "baserom.gba", 0xB6F5F8, 0x60
+sDratiniSprites30:
+ax_sprite sDratiniGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDratiniGfx31:
+.incbin "baserom.gba", 0xB6F6A0, 0x40
+sDratiniGfx31_1:
+.incbin "baserom.gba", 0xB6F6E0, 0x40
+sDratiniGfx31_2:
+.incbin "baserom.gba", 0xB6F720, 0x80
+sDratiniGfx31_3:
+.incbin "baserom.gba", 0xB6F7A0, 0x60
+sDratiniSprites31:
+ax_sprite sDratiniGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx31_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx31_3, 0x60
+ax_sprite_terminator
+sDratiniGfx32:
+.incbin "baserom.gba", 0xB6F840, 0x60
+sDratiniGfx32_1:
+.incbin "baserom.gba", 0xB6F8A0, 0x40
+sDratiniGfx32_2:
+.incbin "baserom.gba", 0xB6F8E0, 0x60
+sDratiniGfx32_3:
+.incbin "baserom.gba", 0xB6F940, 0x60
+sDratiniSprites32:
+ax_sprite sDratiniGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDratiniGfx33:
+.incbin "baserom.gba", 0xB6F9E8, 0x60
+sDratiniGfx33_1:
+.incbin "baserom.gba", 0xB6FA48, 0x60
+sDratiniGfx33_2:
+.incbin "baserom.gba", 0xB6FAA8, 0x60
+sDratiniGfx33_3:
+.incbin "baserom.gba", 0xB6FB08, 0x60
+sDratiniSprites33:
+ax_sprite sDratiniGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx33_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDratiniGfx34:
+.incbin "baserom.gba", 0xB6FBB0, 0x60
+sDratiniGfx34_1:
+.incbin "baserom.gba", 0xB6FC10, 0x60
+sDratiniGfx34_2:
+.incbin "baserom.gba", 0xB6FC70, 0x40
+sDratiniGfx34_3:
+.incbin "baserom.gba", 0xB6FCB0, 0x40
+sDratiniSprites34:
+ax_sprite sDratiniGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDratiniGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDratiniGfx34_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDratiniGfx35:
+.incbin "baserom.gba", 0xB6FD38, 0x200
+sDratiniSprites35:
+ax_sprite sDratiniGfx35, 0x200
+ax_sprite_terminator
+sDratiniGfx36:
+.incbin "baserom.gba", 0xB6FF48, 0x200
+sDratiniSprites36:
+ax_sprite sDratiniGfx36, 0x200
+ax_sprite_terminator
+sDratiniGfx37:
+.incbin "baserom.gba", 0xB70158, 0x200
+sDratiniSprites37:
+ax_sprite sDratiniGfx37, 0x200
+ax_sprite_terminator
+sDratiniGfx38:
+.incbin "baserom.gba", 0xB70368, 0x200
+sDratiniSprites38:
+ax_sprite sDratiniGfx38, 0x200
+ax_sprite_terminator
+sDratiniGfx39:
+.incbin "baserom.gba", 0xB70578, 0x200
+sDratiniSprites39:
+ax_sprite sDratiniGfx39, 0x200
+ax_sprite_terminator
+sDratiniGfx40:
+.incbin "baserom.gba", 0xB70788, 0x200
+sDratiniSprites40:
+ax_sprite sDratiniGfx40, 0x200
+ax_sprite_terminator
+sDratiniGfx41:
+.incbin "baserom.gba", 0xB70998, 0x20
+sDratiniSprites41:
+ax_sprite sDratiniGfx41, 0x20
+ax_sprite_terminator
+sDratiniGfx42:
+.incbin "baserom.gba", 0xB709C8, 0x80
+sDratiniSprites42:
+ax_sprite sDratiniGfx42, 0x80
+ax_sprite_terminator
+sDratiniGfx43:
+.incbin "baserom.gba", 0xB70A58, 0x100
+sDratiniSprites43:
+ax_sprite sDratiniGfx43, 0x100
+ax_sprite_terminator
+sAxPosesDratini:
+.4byte sDratiniPose1
+.4byte sDratiniPose2
+.4byte sDratiniPose3
+.4byte sDratiniPose4
+.4byte sDratiniPose5
+.4byte sDratiniPose6
+.4byte sDratiniPose7
+.4byte sDratiniPose8
+.4byte sDratiniPose9
+.4byte sDratiniPose10
+.4byte sDratiniPose11
+.4byte sDratiniPose12
+.4byte sDratiniPose13
+.4byte sDratiniPose14
+.4byte sDratiniPose15
+.4byte sDratiniPose16
+.4byte sDratiniPose17
+.4byte sDratiniPose18
+.4byte sDratiniPose19
+.4byte sDratiniPose20
+.4byte sDratiniPose21
+.4byte sDratiniPose22
+.4byte sDratiniPose23
+.4byte sDratiniPose24
+.4byte sDratiniPose25
+.4byte sDratiniPose26
+.4byte sDratiniPose27
+.4byte sDratiniPose28
+.4byte sDratiniPose29
+.4byte sDratiniPose30
+.4byte sDratiniPose31
+.4byte sDratiniPose32
+.4byte sDratiniPose33
+.4byte sDratiniPose34
+.4byte sDratiniPose35
+.4byte sDratiniPose36
+.4byte sDratiniPose37
+.4byte sDratiniPose38
+.4byte sDratiniPose39
+.4byte sDratiniPose40
+.4byte sDratiniPose41
+.4byte sDratiniPose42
+.4byte sDratiniPose43
+.4byte sDratiniPose44
+.4byte sDratiniPose45
+.4byte sDratiniPose46
+.4byte sDratiniPose47
+.4byte sDratiniPose48
+.4byte sDratiniPose49
+.4byte sDratiniPose50
+.4byte sDratiniPose51
+.4byte sDratiniPose52
+.4byte sDratiniPose53
+.4byte sDratiniPose54
+.4byte sDratiniPose55
+.4byte sDratiniPose56
+.4byte sDratiniPose57
+.4byte sDratiniPose58
+.4byte sDratiniPose59
+.4byte sDratiniPose60
+.4byte sDratiniPose61
+.4byte sDratiniPose62
+.4byte sDratiniPose63
+.4byte sDratiniPose64
+.4byte sDratiniPose65
+.4byte sDratiniPose66
+.4byte sDratiniPose67
+.4byte sDratiniPose68
+.4byte sDratiniPose69
+.4byte sDratiniPose70
+.4byte sDratiniPose71
+.4byte sDratiniPose72
+.4byte sDratiniPose73
+.4byte sDratiniPose74
+.4byte sDratiniPose75
+.4byte sDratiniPose76
+.4byte sDratiniPose77
+.4byte sDratiniPose78
+.4byte sDratiniPose79
+.4byte sDratiniPose80
+.4byte sDratiniPose81
+.4byte sDratiniPose82
+.4byte sDratiniPose83
+.4byte sDratiniPose84
+.4byte sDratiniPose85
+.4byte sDratiniPose86
+.4byte sDratiniPose87
+.4byte sDratiniPose88
+.4byte sDratiniPose89
+.4byte sDratiniPose90
+.4byte sDratiniPose91
+.4byte sDratiniPose92
+.4byte sDratiniPose93
+.4byte sDratiniPose94
+.4byte sDratiniPose95
+.4byte sDratiniPose96
+.4byte sDratiniPose97
+.4byte sDratiniPose98
+.4byte sDratiniPose99
+.4byte sDratiniPose100
+.4byte sDratiniPose101
+.4byte sDratiniPose102
+.4byte sDratiniPose103
+.4byte sDratiniPose104
+.4byte sDratiniPose105
+.4byte sDratiniPose106
+.4byte sDratiniPose107
+.4byte sDratiniPose108
+.4byte sDratiniPose109
+.4byte sDratiniPose110
+.4byte sDratiniPose111
+.4byte sDratiniPose112
+.4byte sDratiniPose113
+.4byte sDratiniPose114
+.4byte sDratiniPose115
+.4byte sDratiniPose116
+.4byte sDratiniPose117
+.4byte sDratiniPose118
+.4byte sDratiniPose119
+.4byte sDratiniPose120
+.4byte sDratiniPose121
+.4byte sDratiniPose122
+.4byte sDratiniPose123
+.4byte sDratiniPose124
+.4byte sDratiniPose125
+.4byte sDratiniPose126
+.4byte sDratiniPose127
+.4byte sDratiniPose128
+.4byte sDratiniPose129
+.4byte sDratiniPose130
+.4byte sDratiniPose131
+.4byte sDratiniPose132
+.4byte sDratiniPose133
+.4byte sDratiniPose134
+.4byte sDratiniPose135
+.4byte sDratiniPose136
+.4byte sDratiniPose137
+.4byte sDratiniPose138
+.4byte sDratiniPose139
+.4byte sDratiniPose140
+.4byte sDratiniPose141
+.4byte sDratiniPose142
+.4byte sDratiniPose143
+.4byte sDratiniPose144
+.4byte sDratiniPose145
+.4byte sDratiniPose146
+.4byte sDratiniPose147
+.4byte sDratiniPose148
+.4byte sDratiniPose149
+.4byte sDratiniPose150
+.4byte sDratiniPose151
+.4byte sDratiniPose152
+.4byte sDratiniPose153
+.4byte sDratiniPose154
+.4byte sDratiniPose155
+.4byte sDratiniPose156
+.4byte sDratiniPose157
+.4byte sDratiniPose158
+.4byte sDratiniPose159
+.4byte sDratiniPose160
+.4byte sDratiniPose161
+.4byte sDratiniPose162
+.4byte sDratiniPose163
+.4byte sDratiniPose164
+.4byte sDratiniPose165
+.4byte sDratiniPose166
+.4byte sDratiniPose167
+.4byte sDratiniPose168
+.4byte sDratiniPose169
+.4byte sDratiniPose170
+.4byte sDratiniPose171
+.4byte sDratiniPose172
+.4byte sDratiniPose173
+.4byte sDratiniPose174
+.4byte sDratiniPose175
+.4byte sDratiniPose176
+.4byte sDratiniPose177
+.4byte sDratiniPose178
+.4byte sDratiniPose179
+.4byte sDratiniPose180
+.4byte sDratiniPose181
+.4byte sDratiniPose182
+.4byte sDratiniPose183
+.4byte sDratiniPose184
+.4byte sDratiniPose185
+.4byte sDratiniPose186
+.4byte sDratiniPose187
+.4byte sDratiniPose188
+.4byte sDratiniPose189
+.4byte sDratiniPose190
+.4byte sDratiniPose191
+.4byte sDratiniPose192
+.4byte sDratiniPose193
+.4byte sDratiniPose194
+.4byte sDratiniPose195
+.4byte sDratiniPose196
+.4byte sDratiniPose197
+.4byte sDratiniPose198
+.4byte sDratiniPose199
+.4byte sDratiniPose200
+.4byte sDratiniPose201
+.4byte sDratiniPose202
+.4byte sDratiniPose203
+.4byte sDratiniPose204
+.4byte sDratiniPose205
+.4byte sDratiniPose206
+.4byte sDratiniPose207
+.4byte sDratiniPose208
+.4byte sDratiniPose209
+.4byte sDratiniPose210
+.4byte sDratiniPose211
+.4byte sDratiniPose212
+.4byte sDratiniPose213
+.4byte sDratiniPose214
+.4byte sDratiniPose215
+.4byte sDratiniPose216
+.4byte sDratiniPose217
+.4byte sDratiniPose218
+.4byte sDratiniPose219
+.4byte sDratiniPose220
+.4byte sDratiniPose221
+.4byte sDratiniPose222
+.4byte sDratiniPose223
+.4byte sDratiniPose224
+.4byte sDratiniPose225
+.4byte sDratiniPose226
+.4byte sDratiniPose227
+.4byte sDratiniPose228
+.4byte sDratiniPose229
+.4byte sDratiniPose230
+.4byte sDratiniPose231
+.4byte sDratiniPose232
+.4byte sDratiniPose233
+.4byte sDratiniPose234
+.4byte sDratiniPose235
+.4byte sDratiniPose236
+.4byte sDratiniPose237
+.4byte sDratiniPose238
+.4byte sDratiniPose239
+.4byte sDratiniPose240
+.4byte sDratiniPose241
+.4byte sDratiniPose242
+.4byte sDratiniPose243
+.4byte sDratiniPose244
+.4byte sDratiniPose245
+.4byte sDratiniPose246
+.4byte sDratiniPose247
+.4byte sDratiniPose248
+.4byte sDratiniPose249
+.4byte sDratiniPose250
+.4byte sDratiniPose251
+.4byte sDratiniPose252
+.4byte sDratiniPose253
+.4byte sDratiniPose254
+.4byte sDratiniPose255
+.4byte sDratiniPose256
+.4byte sDratiniPose257
+.4byte sDratiniPose258
+.4byte sDratiniPose259
+.4byte sDratiniPose260
+.4byte sDratiniPose261
+.4byte sDratiniPose262
+.4byte sDratiniPose263
+.4byte sDratiniPose264
+.4byte sDratiniPose265
+.4byte sDratiniPose266
+.4byte sDratiniPose267
+.4byte sDratiniPose268
+.4byte sDratiniPose269
+.4byte sDratiniPose270
+sAxPositionsDratini:
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte    0,   -1, 	  -4,   -1, 	   3,   -1, 	   0,   -3
+.2byte    0,   -8, 	  -4,   -5, 	   3,   -5, 	   0,   -9
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    8,   -3, 	   1,    0, 	   5,   -2, 	  -1,   -2
+.2byte    1,   -8, 	  -2,   -3, 	   0,   -6, 	  -3,   -4
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte   10,   -6, 	   1,   -1, 	   1,   -5, 	  -1,   -2
+.2byte    2,   -7, 	  -1,   -2, 	  -2,   -5, 	  -2,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte   10,  -11, 	   3,   -4, 	   0,   -6, 	   0,   -3
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -4, 	  -1,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    0,  -15, 	   2,   -8, 	  -3,   -8, 	   0,   -3
+.2byte    0,   -9, 	   3,   -2, 	  -4,   -2, 	   0,    0
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte   -9,   -8, 	  -1,   -7, 	  -5,   -4, 	   1,   -1
+.2byte   -2,   -7, 	   4,   -5, 	  -1,   -3, 	   2,    0
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte  -11,   -6, 	  -6,   -4, 	  -4,   -2, 	   0,   -2
+.2byte   -2,   -8, 	   2,   -7, 	   2,   -3, 	   2,   -4
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -9,   -3, 	  -4,   -2, 	   0,   -1, 	   0,   -3
+.2byte   -1,   -9, 	   0,   -7, 	   3,   -4, 	   2,   -5
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte    0,   -1, 	  -4,   -1, 	   3,   -1, 	   0,   -3
+.2byte    0,   -8, 	  -4,   -5, 	   3,   -5, 	   0,   -9
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    8,   -3, 	   1,    0, 	   5,   -2, 	  -1,   -2
+.2byte    1,   -8, 	  -2,   -3, 	   0,   -6, 	  -3,   -4
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte   10,   -6, 	   1,   -1, 	   1,   -5, 	  -1,   -2
+.2byte    2,   -7, 	  -1,   -2, 	  -2,   -5, 	  -2,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte   10,  -11, 	   3,   -4, 	   0,   -6, 	   0,   -3
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -4, 	  -1,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    0,  -15, 	   2,   -8, 	  -3,   -8, 	   0,   -3
+.2byte    0,   -9, 	   3,   -2, 	  -4,   -2, 	   0,    0
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte   -9,   -8, 	  -1,   -7, 	  -5,   -4, 	   1,   -1
+.2byte   -2,   -7, 	   4,   -5, 	  -1,   -3, 	   2,    0
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte  -11,   -6, 	  -6,   -4, 	  -4,   -2, 	   0,   -2
+.2byte   -2,   -8, 	   2,   -7, 	   2,   -3, 	   2,   -4
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -9,   -3, 	  -4,   -2, 	   0,   -1, 	   0,   -3
+.2byte   -1,   -9, 	   0,   -7, 	   3,   -4, 	   2,   -5
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte    0,   -1, 	  -4,   -1, 	   3,   -1, 	   0,   -3
+.2byte    0,   -8, 	  -4,   -5, 	   3,   -5, 	   0,   -9
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    8,   -3, 	   1,    0, 	   5,   -2, 	  -1,   -2
+.2byte    1,   -8, 	  -2,   -3, 	   0,   -6, 	  -3,   -4
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte   10,   -6, 	   1,   -1, 	   1,   -5, 	  -1,   -2
+.2byte    2,   -7, 	  -1,   -2, 	  -2,   -5, 	  -2,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte   10,  -11, 	   3,   -4, 	   0,   -6, 	   0,   -3
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -4, 	  -1,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    0,  -15, 	   2,   -8, 	  -3,   -8, 	   0,   -3
+.2byte    0,   -9, 	   3,   -2, 	  -4,   -2, 	   0,    0
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte   -9,   -8, 	  -1,   -7, 	  -5,   -4, 	   1,   -1
+.2byte   -2,   -7, 	   4,   -5, 	  -1,   -3, 	   2,    0
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte  -11,   -6, 	  -6,   -4, 	  -4,   -2, 	   0,   -2
+.2byte   -2,   -8, 	   2,   -7, 	   2,   -3, 	   2,   -4
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -9,   -3, 	  -4,   -2, 	   0,   -1, 	   0,   -3
+.2byte   -1,   -9, 	   0,   -7, 	   3,   -4, 	   2,   -5
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte    0,   -1, 	  -4,   -1, 	   3,   -1, 	   0,   -3
+.2byte    0,   -8, 	  -4,   -5, 	   3,   -5, 	   0,   -9
+.2byte    0,   -2, 	  -4,   -3, 	   3,   -3, 	   0,   -4
+.2byte    0,  -14, 	  -3,  -10, 	   3,  -10, 	   0,   -7
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    8,   -3, 	   1,    0, 	   5,   -2, 	  -1,   -2
+.2byte    1,   -8, 	  -2,   -3, 	   0,   -6, 	  -3,   -4
+.2byte   10,   -3, 	   3,   -4, 	   0,   -2, 	   1,   -2
+.2byte    4,  -14, 	   2,   -9, 	  -1,   -7, 	   0,   -5
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte   10,   -6, 	   1,   -1, 	   1,   -5, 	  -1,   -2
+.2byte    2,   -7, 	  -1,   -2, 	  -2,   -5, 	  -2,   -2
+.2byte   10,  -11, 	   3,   -9, 	   3,   -6, 	   1,   -3
+.2byte    6,  -21, 	   1,   -9, 	   1,   -6, 	  -1,   -4
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte   10,  -11, 	   3,   -4, 	   0,   -6, 	   0,   -3
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -4, 	  -1,   -1
+.2byte   10,  -11, 	   1,  -10, 	   4,   -8, 	  -1,   -3
+.2byte    4,  -19, 	  -2,   -8, 	   3,   -8, 	  -2,   -3
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    0,  -15, 	   2,   -8, 	  -3,   -8, 	   0,   -3
+.2byte    0,   -9, 	   3,   -2, 	  -4,   -2, 	   0,    0
+.2byte    0,  -17, 	   3,   -8, 	  -3,   -8, 	   0,   -6
+.2byte    0,  -18, 	   3,   -7, 	  -3,   -7, 	   0,   -5
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte   -9,   -8, 	  -1,   -7, 	  -5,   -4, 	   1,   -1
+.2byte   -2,   -7, 	   4,   -5, 	  -1,   -3, 	   2,    0
+.2byte  -10,  -12, 	  -1,  -11, 	  -4,   -9, 	   1,   -4
+.2byte   -4,  -20, 	   2,   -9, 	  -3,   -9, 	   2,   -4
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte  -11,   -6, 	  -6,   -4, 	  -4,   -2, 	   0,   -2
+.2byte   -2,   -8, 	   2,   -7, 	   2,   -3, 	   2,   -4
+.2byte  -10,  -12, 	  -3,  -10, 	  -3,   -7, 	  -1,   -4
+.2byte   -8,  -22, 	  -3,  -10, 	  -3,   -7, 	  -1,   -5
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -9,   -3, 	  -4,   -2, 	   0,   -1, 	   0,   -3
+.2byte   -1,   -9, 	   0,   -7, 	   3,   -4, 	   2,   -5
+.2byte  -10,   -3, 	  -3,   -4, 	   0,   -2, 	  -1,   -2
+.2byte   -4,  -14, 	  -2,   -9, 	   1,   -7, 	   0,   -5
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte    0,   -1, 	  -4,   -1, 	   3,   -1, 	   0,   -3
+.2byte    0,   -8, 	  -4,   -5, 	   3,   -5, 	   0,   -9
+.2byte    0,   -2, 	  -4,   -3, 	   3,   -3, 	   0,   -4
+.2byte    0,  -14, 	  -3,  -10, 	   3,  -10, 	   0,   -7
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    8,   -3, 	   1,    0, 	   5,   -2, 	  -1,   -2
+.2byte    1,   -8, 	  -2,   -3, 	   0,   -6, 	  -3,   -4
+.2byte   10,   -3, 	   3,   -4, 	   0,   -2, 	   1,   -2
+.2byte    4,  -14, 	   2,   -9, 	  -1,   -7, 	   0,   -5
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte   10,   -6, 	   1,   -1, 	   1,   -5, 	  -1,   -2
+.2byte    2,   -7, 	  -1,   -2, 	  -2,   -5, 	  -2,   -2
+.2byte   10,  -12, 	   3,  -10, 	   3,   -7, 	   1,   -4
+.2byte    7,  -22, 	   2,  -10, 	   2,   -7, 	   0,   -5
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte   10,  -11, 	   3,   -4, 	   0,   -6, 	   0,   -3
+.2byte    4,   -8, 	   2,   -3, 	  -2,   -5, 	   0,   -2
+.2byte   11,  -12, 	   2,  -11, 	   5,   -9, 	   0,   -4
+.2byte    5,  -20, 	  -1,   -9, 	   4,   -9, 	  -1,   -4
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    0,  -15, 	   2,   -8, 	  -3,   -8, 	   0,   -3
+.2byte    0,  -11, 	   3,   -4, 	  -4,   -4, 	   0,   -2
+.2byte    0,  -17, 	   3,   -8, 	  -3,   -8, 	   0,   -6
+.2byte    0,  -20, 	   3,   -9, 	  -3,   -9, 	   0,   -7
+.2byte   -7,   -9, 	   0,   -8, 	  -4,   -5, 	   0,   -2
+.2byte   -9,   -9, 	  -1,   -8, 	  -5,   -5, 	   1,   -2
+.2byte   -5,   -9, 	   1,   -7, 	  -4,   -5, 	  -1,   -2
+.2byte  -11,  -13, 	  -2,  -12, 	  -5,  -10, 	   0,   -5
+.2byte   -5,  -21, 	   1,  -10, 	  -4,  -10, 	   1,   -5
+.2byte   -7,   -7, 	  -3,   -5, 	  -2,   -1, 	  -2,   -2
+.2byte  -13,   -6, 	  -8,   -4, 	  -6,   -2, 	  -2,   -2
+.2byte   -5,   -8, 	  -1,   -7, 	  -1,   -3, 	  -1,   -4
+.2byte  -12,  -12, 	  -5,  -10, 	  -5,   -7, 	  -3,   -4
+.2byte   -8,  -22, 	  -3,  -10, 	  -3,   -7, 	  -1,   -5
+.2byte   -5,   -7, 	  -3,   -5, 	   0,   -3, 	  -1,   -6
+.2byte  -11,   -3, 	  -6,   -2, 	  -2,   -1, 	  -2,   -3
+.2byte   -3,   -8, 	  -2,   -6, 	   1,   -3, 	   0,   -4
+.2byte  -11,   -3, 	  -4,   -4, 	  -1,   -2, 	  -2,   -2
+.2byte   -5,  -14, 	  -3,   -9, 	   0,   -7, 	  -1,   -5
+.2byte   -3,   -4, 	  -5,   -4, 	  -1,   -2, 	  -1,    0
+.2byte   -5,   -3, 	  -6,   -4, 	  -1,   -1, 	   0,    0
+.2byte    0,  -10, 	  -3,   -5, 	   3,   -5, 	   0,   -8
+.2byte    3,  -13, 	   2,  -11, 	  -1,   -9, 	   2,   -5
+.2byte    4,  -17, 	   1,  -13, 	   1,   -9, 	   3,   -7
+.2byte    4,  -17, 	  -2,  -13, 	   3,  -12, 	   2,   -8
+.2byte    0,  -18, 	   3,   -8, 	  -3,   -8, 	   0,   -6
+.2byte   -5,  -17, 	   1,  -13, 	  -4,  -12, 	  -3,   -8
+.2byte   -5,  -17, 	  -2,  -13, 	  -2,   -9, 	  -4,   -7
+.2byte   -4,  -13, 	  -3,  -11, 	   0,   -9, 	  -3,   -5
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte    0,   -1, 	  -4,   -1, 	   3,   -1, 	   0,   -3
+.2byte    0,   -8, 	  -4,   -5, 	   3,   -5, 	   0,   -9
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    8,   -3, 	   1,    0, 	   5,   -2, 	  -1,   -2
+.2byte    1,   -8, 	  -2,   -3, 	   0,   -6, 	  -3,   -4
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte   10,   -6, 	   1,   -1, 	   1,   -5, 	  -1,   -2
+.2byte    2,   -7, 	  -1,   -2, 	  -2,   -5, 	  -2,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte   10,  -11, 	   3,   -4, 	   0,   -6, 	   0,   -3
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -4, 	  -1,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    0,  -15, 	   2,   -8, 	  -3,   -8, 	   0,   -3
+.2byte    0,   -9, 	   3,   -2, 	  -4,   -2, 	   0,    0
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte   -9,   -8, 	  -1,   -7, 	  -5,   -4, 	   1,   -1
+.2byte   -2,   -7, 	   4,   -5, 	  -1,   -3, 	   2,    0
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte  -11,   -6, 	  -6,   -4, 	  -4,   -2, 	   0,   -2
+.2byte   -2,   -8, 	   2,   -7, 	   2,   -3, 	   2,   -4
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -9,   -3, 	  -4,   -2, 	   0,   -1, 	   0,   -3
+.2byte   -1,   -9, 	   0,   -7, 	   3,   -4, 	   2,   -5
+.2byte    0,   -2, 	  -4,   -3, 	   3,   -3, 	   0,   -4
+.2byte  -10,   -3, 	  -3,   -4, 	   0,   -2, 	  -1,   -2
+.2byte  -10,  -12, 	  -3,  -10, 	  -3,   -7, 	  -1,   -4
+.2byte  -11,  -13, 	  -2,  -12, 	  -5,  -10, 	   0,   -5
+.2byte    0,  -17, 	   3,   -8, 	  -3,   -8, 	   0,   -6
+.2byte   10,  -12, 	   1,  -11, 	   4,   -9, 	  -1,   -4
+.2byte   10,  -11, 	   3,   -9, 	   3,   -6, 	   1,   -3
+.2byte   10,   -3, 	   3,   -4, 	   0,   -2, 	   1,   -2
+.2byte    0,  -14, 	  -3,  -10, 	   3,  -10, 	   0,   -7
+.2byte    5,  -14, 	   3,   -9, 	   0,   -7, 	   1,   -5
+.2byte    7,  -21, 	   2,   -9, 	   2,   -6, 	   0,   -4
+.2byte    5,  -21, 	  -1,  -10, 	   4,  -10, 	  -1,   -5
+.2byte    0,  -21, 	   3,  -10, 	  -3,  -10, 	   0,   -8
+.2byte   -7,  -21, 	  -1,  -10, 	  -6,  -10, 	  -1,   -5
+.2byte   -8,  -20, 	  -3,   -8, 	  -3,   -5, 	  -1,   -3
+.2byte   -6,  -14, 	  -4,   -9, 	  -1,   -7, 	  -2,   -5
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte    0,  -14, 	  -3,  -10, 	   3,  -10, 	   0,   -7
+.2byte    0,   -1, 	  -4,   -1, 	   3,   -1, 	   0,   -3
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    4,  -14, 	   2,   -9, 	  -1,   -7, 	   0,   -5
+.2byte    8,   -3, 	   1,    0, 	   5,   -2, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    6,  -21, 	   1,   -9, 	   1,   -6, 	  -1,   -4
+.2byte   10,   -6, 	   1,   -1, 	   1,   -5, 	  -1,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    4,  -19, 	  -2,   -8, 	   3,   -8, 	  -2,   -3
+.2byte    8,  -11, 	   1,   -4, 	  -2,   -6, 	  -2,   -3
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    0,  -18, 	   3,   -7, 	  -3,   -7, 	   0,   -5
+.2byte    0,  -15, 	   2,   -8, 	  -3,   -8, 	   0,   -3
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte   -4,  -20, 	   2,   -9, 	  -3,   -9, 	   2,   -4
+.2byte   -9,   -8, 	  -1,   -7, 	  -5,   -4, 	   1,   -1
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte   -8,  -22, 	  -3,  -10, 	  -3,   -7, 	  -1,   -5
+.2byte  -11,   -6, 	  -6,   -4, 	  -4,   -2, 	   0,   -2
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -4,  -14, 	  -2,   -9, 	   1,   -7, 	   0,   -5
+.2byte   -9,   -3, 	  -4,   -2, 	   0,   -1, 	   0,   -3
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -5
+.2byte   -4,   -7, 	  -2,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -5, 	   0,   -1, 	   0,   -2
+.2byte   -5,   -8, 	   2,   -7, 	  -2,   -4, 	   2,   -1
+.2byte    0,  -12, 	   2,   -5, 	  -3,   -5, 	   0,   -2
+.2byte    6,   -9, 	   2,   -3, 	  -2,   -5, 	  -1,   -2
+.2byte    5,   -7, 	   1,   -2, 	   1,   -5, 	  -1,   -2
+.2byte    4,   -7, 	  -2,   -2, 	   4,   -4, 	  -1,   -3
+sDratiniAnimTable1:
+.4byte sDratiniAnims_1_1
+.4byte sDratiniAnims_1_2
+.4byte sDratiniAnims_1_3
+.4byte sDratiniAnims_1_4
+.4byte sDratiniAnims_1_5
+.4byte sDratiniAnims_1_6
+.4byte sDratiniAnims_1_7
+.4byte sDratiniAnims_1_8
+sDratiniAnimTable2:
+.4byte sDratiniAnims_2_1
+.4byte sDratiniAnims_2_2
+.4byte sDratiniAnims_2_3
+.4byte sDratiniAnims_2_4
+.4byte sDratiniAnims_2_5
+.4byte sDratiniAnims_2_6
+.4byte sDratiniAnims_2_7
+.4byte sDratiniAnims_2_8
+sDratiniAnimTable3:
+.4byte sDratiniAnims_3_1
+.4byte sDratiniAnims_3_2
+.4byte sDratiniAnims_3_3
+.4byte sDratiniAnims_3_4
+.4byte sDratiniAnims_3_5
+.4byte sDratiniAnims_3_6
+.4byte sDratiniAnims_3_7
+.4byte sDratiniAnims_3_8
+sDratiniAnimTable4:
+.4byte sDratiniAnims_4_1
+.4byte sDratiniAnims_4_2
+.4byte sDratiniAnims_4_3
+.4byte sDratiniAnims_4_4
+.4byte sDratiniAnims_4_5
+.4byte sDratiniAnims_4_6
+.4byte sDratiniAnims_4_7
+.4byte sDratiniAnims_4_8
+sDratiniAnimTable5:
+.4byte sDratiniAnims_5_1
+.4byte sDratiniAnims_5_2
+.4byte sDratiniAnims_5_3
+.4byte sDratiniAnims_5_4
+.4byte sDratiniAnims_5_5
+.4byte sDratiniAnims_5_6
+.4byte sDratiniAnims_5_7
+.4byte sDratiniAnims_5_8
+sDratiniAnimTable6:
+.4byte sDratiniAnims_6_1
+.4byte sDratiniAnims_6_1
+.4byte sDratiniAnims_6_1
+.4byte sDratiniAnims_6_1
+.4byte sDratiniAnims_6_1
+.4byte sDratiniAnims_6_1
+.4byte sDratiniAnims_6_1
+.4byte sDratiniAnims_6_1
+sDratiniAnimTable7:
+.4byte sDratiniAnims_7_1
+.4byte sDratiniAnims_7_2
+.4byte sDratiniAnims_7_3
+.4byte sDratiniAnims_7_4
+.4byte sDratiniAnims_7_5
+.4byte sDratiniAnims_7_6
+.4byte sDratiniAnims_7_7
+.4byte sDratiniAnims_7_8
+sDratiniAnimTable8:
+.4byte sDratiniAnims_8_1
+.4byte sDratiniAnims_8_2
+.4byte sDratiniAnims_8_3
+.4byte sDratiniAnims_8_4
+.4byte sDratiniAnims_8_5
+.4byte sDratiniAnims_8_6
+.4byte sDratiniAnims_8_7
+.4byte sDratiniAnims_8_8
+sDratiniAnimTable9:
+.4byte sDratiniAnims_9_1
+.4byte sDratiniAnims_9_2
+.4byte sDratiniAnims_9_3
+.4byte sDratiniAnims_9_4
+.4byte sDratiniAnims_9_5
+.4byte sDratiniAnims_9_6
+.4byte sDratiniAnims_9_7
+.4byte sDratiniAnims_9_8
+sDratiniAnimTable10:
+.4byte sDratiniAnims_10_1
+.4byte sDratiniAnims_10_2
+.4byte sDratiniAnims_10_3
+.4byte sDratiniAnims_10_4
+.4byte sDratiniAnims_10_5
+.4byte sDratiniAnims_10_6
+.4byte sDratiniAnims_10_7
+.4byte sDratiniAnims_10_8
+sDratiniAnimTable11:
+.4byte sDratiniAnims_11_1
+.4byte sDratiniAnims_11_2
+.4byte sDratiniAnims_11_3
+.4byte sDratiniAnims_11_4
+.4byte sDratiniAnims_11_5
+.4byte sDratiniAnims_11_6
+.4byte sDratiniAnims_11_7
+.4byte sDratiniAnims_11_8
+sDratiniAnimTable12:
+.4byte sDratiniAnims_12_1
+.4byte sDratiniAnims_12_2
+.4byte sDratiniAnims_12_3
+.4byte sDratiniAnims_12_4
+.4byte sDratiniAnims_12_5
+.4byte sDratiniAnims_12_6
+.4byte sDratiniAnims_12_7
+.4byte sDratiniAnims_12_8
+sDratiniAnimTable13:
+.4byte sDratiniAnims_13_1
+.4byte sDratiniAnims_13_2
+.4byte sDratiniAnims_13_3
+.4byte sDratiniAnims_13_4
+.4byte sDratiniAnims_13_5
+.4byte sDratiniAnims_13_6
+.4byte sDratiniAnims_13_7
+.4byte sDratiniAnims_13_8
+sAxAnimationsDratini:
+.4byte sDratiniAnimTable1
+.4byte sDratiniAnimTable2
+.4byte sDratiniAnimTable3
+.4byte sDratiniAnimTable4
+.4byte sDratiniAnimTable5
+.4byte sDratiniAnimTable6
+.4byte sDratiniAnimTable7
+.4byte sDratiniAnimTable8
+.4byte sDratiniAnimTable9
+.4byte sDratiniAnimTable10
+.4byte sDratiniAnimTable11
+.4byte sDratiniAnimTable12
+.4byte sDratiniAnimTable13
+sAxSpritesDratini:
+.4byte sDratiniSprites1
+.4byte sDratiniSprites2
+.4byte sDratiniSprites3
+.4byte sDratiniSprites4
+.4byte sDratiniSprites5
+.4byte sDratiniSprites6
+.4byte sDratiniSprites7
+.4byte sDratiniSprites8
+.4byte sDratiniSprites9
+.4byte sDratiniSprites10
+.4byte sDratiniSprites11
+.4byte sDratiniSprites12
+.4byte sDratiniSprites13
+.4byte sDratiniSprites14
+.4byte sDratiniSprites15
+.4byte sDratiniSprites16
+.4byte sDratiniSprites17
+.4byte sDratiniSprites18
+.4byte sDratiniSprites19
+.4byte sDratiniSprites20
+.4byte sDratiniSprites21
+.4byte sDratiniSprites22
+.4byte sDratiniSprites23
+.4byte sDratiniSprites24
+.4byte sDratiniSprites25
+.4byte sDratiniSprites26
+.4byte sDratiniSprites27
+.4byte sDratiniSprites28
+.4byte sDratiniSprites29
+.4byte sDratiniSprites30
+.4byte sDratiniSprites31
+.4byte sDratiniSprites32
+.4byte sDratiniSprites33
+.4byte sDratiniSprites34
+.4byte sDratiniSprites35
+.4byte sDratiniSprites36
+.4byte sDratiniSprites37
+.4byte sDratiniSprites38
+.4byte sDratiniSprites39
+.4byte sDratiniSprites40
+.4byte sDratiniSprites41
+.4byte sDratiniSprites42
+.4byte sDratiniSprites43
+sAxMainDratini:
+ax_main sAxPosesDratini, sAxAnimationsDratini, 13, sAxSpritesDratini, sAxPositionsDratini

--- a/data/ax/drowzee.inc
+++ b/data/ax/drowzee.inc
@@ -1,0 +1,2803 @@
+.global gAxDrowzee
+gAxDrowzee:
+ax_siro sAxMainDrowzee
+sDrowzeePose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose4:
+ax_pose 3, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose5:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose6:
+ax_pose 5, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose8:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose22:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose23:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose24:
+ax_pose 5, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose25:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose26:
+ax_pose 16, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose27:
+ax_pose 17, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose28:
+ax_pose 18, 0x01e9, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose29:
+ax_pose 19, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDrowzeePose30:
+ax_pose 20, 0x01ed, 0x90ef, 0x4c00
+ax_pose_terminator
+sDrowzeePose31:
+ax_pose 21, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose32:
+ax_pose 22, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sDrowzeePose33:
+ax_pose 23, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sDrowzeePose34:
+ax_pose 24, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose35:
+ax_pose 25, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose36:
+ax_pose 26, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose37:
+ax_pose 27, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose38:
+ax_pose 28, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose39:
+ax_pose 29, 0x01ea, 0x80ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose40:
+ax_pose 24, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose41:
+ax_pose 25, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose42:
+ax_pose 26, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose43:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose44:
+ax_pose 22, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose45:
+ax_pose 23, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose46:
+ax_pose 18, 0x01e9, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose47:
+ax_pose 19, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose48:
+ax_pose 20, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose49:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose52:
+ax_pose 15, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose53:
+ax_pose 30, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose54:
+ax_pose 3, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose55:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose56:
+ax_pose 5, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose57:
+ax_pose 18, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose58:
+ax_pose 31, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose59:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose60:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose61:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose62:
+ax_pose 21, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sDrowzeePose63:
+ax_pose 32, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose64:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose65:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose66:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose67:
+ax_pose 24, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose68:
+ax_pose 33, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose69:
+ax_pose 12, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose70:
+ax_pose 13, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose71:
+ax_pose 14, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose72:
+ax_pose 27, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose73:
+ax_pose 34, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose74:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose75:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose76:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose77:
+ax_pose 24, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose78:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose79:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose80:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose81:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose82:
+ax_pose 21, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose83:
+ax_pose 32, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose84:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose85:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose86:
+ax_pose 5, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose87:
+ax_pose 18, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose88:
+ax_pose 31, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose89:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose90:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose91:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose92:
+ax_pose 35, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose93:
+ax_pose 18, 0x01e9, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose94:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose95:
+ax_pose 5, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose96:
+ax_pose 36, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sDrowzeePose97:
+ax_pose 21, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose98:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose99:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose100:
+ax_pose 37, 0x01eb, 0x90f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose101:
+ax_pose 24, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sDrowzeePose102:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose103:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose104:
+ax_pose 38, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose105:
+ax_pose 27, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose106:
+ax_pose 13, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose107:
+ax_pose 14, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose108:
+ax_pose 39, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose109:
+ax_pose 24, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose110:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose111:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose112:
+ax_pose 38, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose113:
+ax_pose 21, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose114:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose115:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose116:
+ax_pose 37, 0x01eb, 0x80ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose117:
+ax_pose 18, 0x01e9, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose118:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose119:
+ax_pose 5, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose120:
+ax_pose 36, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose121:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose122:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose123:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose124:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose125:
+ax_pose 12, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose126:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose127:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose128:
+ax_pose 3, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose129:
+ax_pose 40, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose130:
+ax_pose 41, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose131:
+ax_pose 42, 0x01e0, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose132:
+ax_pose 43, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sDrowzeePose133:
+ax_pose 44, 0x01e2, 0x90ea, 0x4c00
+ax_pose_terminator
+sDrowzeePose134:
+ax_pose 45, 0x01e2, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose135:
+ax_pose 46, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose136:
+ax_pose 45, 0x01e2, 0x80f5, 0x4c00
+ax_pose_terminator
+sDrowzeePose137:
+ax_pose 44, 0x01e2, 0x80f5, 0x4c00
+ax_pose_terminator
+sDrowzeePose138:
+ax_pose 43, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose139:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose140:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose141:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose142:
+ax_pose 3, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose143:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose144:
+ax_pose 5, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose145:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose146:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose147:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose148:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose149:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose150:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose151:
+ax_pose 12, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose152:
+ax_pose 13, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose153:
+ax_pose 14, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose154:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose155:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose156:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose157:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose158:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose159:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose160:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose161:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose162:
+ax_pose 5, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose163:
+ax_pose 16, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose164:
+ax_pose 19, 0x01ed, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose165:
+ax_pose 22, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose166:
+ax_pose 25, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose167:
+ax_pose 28, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose168:
+ax_pose 25, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose169:
+ax_pose 22, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sDrowzeePose170:
+ax_pose 19, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose171:
+ax_pose 15, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose172:
+ax_pose 18, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sDrowzeePose173:
+ax_pose 21, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sDrowzeePose174:
+ax_pose 24, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose175:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose176:
+ax_pose 24, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose177:
+ax_pose 21, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose178:
+ax_pose 18, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose179:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose180:
+ax_pose 15, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose181:
+ax_pose 30, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose182:
+ax_pose 3, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose183:
+ax_pose 18, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sDrowzeePose184:
+ax_pose 31, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose185:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose186:
+ax_pose 21, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose187:
+ax_pose 32, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose188:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose189:
+ax_pose 24, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose190:
+ax_pose 33, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose191:
+ax_pose 12, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose192:
+ax_pose 27, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose193:
+ax_pose 34, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose194:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose195:
+ax_pose 24, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose196:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose197:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose198:
+ax_pose 21, 0x01e8, 0x80ef, 0x4c00
+ax_pose_terminator
+sDrowzeePose199:
+ax_pose 32, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose200:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose201:
+ax_pose 18, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose202:
+ax_pose 31, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sDrowzeePose203:
+ax_pose 35, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose204:
+ax_pose 36, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose205:
+ax_pose 37, 0x01eb, 0x80ec, 0x4c00
+ax_pose_terminator
+sDrowzeePose206:
+ax_pose 38, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sDrowzeePose207:
+ax_pose 39, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose208:
+ax_pose 38, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose209:
+ax_pose 37, 0x01eb, 0x90f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose210:
+ax_pose 36, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sDrowzeePose211:
+ax_pose 0, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose212:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sDrowzeePose213:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose214:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sDrowzeePose215:
+ax_pose 12, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sDrowzeePose216:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose217:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sDrowzeePose218:
+ax_pose 3, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+.align 2
+sDrowzeeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_2_1:
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 6, 0, 24, 0, -3, 0, -3,
+ax_anim 1, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 2, 25, 0, 8, 0, 8,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 24, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 5, 0, 5,
+ax_anim_terminator
+sDrowzeeAnims_2_2:
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 6, 0, 27, -3, -3, -3, -3,
+ax_anim 1, 0, 29, -3, -3, -3, -3,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 2, 29, 9, 8, 9, 8,
+ax_anim 2, 0, 28, 20, 18, 20, 18,
+ax_anim 2, 1, 28, 21, 17, 21, 17,
+ax_anim 2, 0, 28, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 21, 17, 21, 17,
+ax_anim 2, 0, 28, 20, 18, 20, 18,
+ax_anim 2, 0, 27, 12, 11, 12, 11,
+ax_anim 2, 0, 27, 5, 5, 5, 5,
+ax_anim_terminator
+sDrowzeeAnims_2_3:
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 6, 0, 30, -3, 0, -3, 0,
+ax_anim 1, 0, 31, -1, 0, -1, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 31, 9, 0, 9, 0,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 1, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 30, 12, 0, 12, 0,
+ax_anim 2, 0, 30, 5, 0, 5, 0,
+ax_anim_terminator
+sDrowzeeAnims_2_4:
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 6, 0, 33, -3, 3, -3, 3,
+ax_anim 1, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 8, -8, 8, -8,
+ax_anim 2, 0, 35, 19, -17, 19, -17,
+ax_anim 2, 1, 35, 20, -16, 20, -16,
+ax_anim 2, 0, 35, 19, -17, 19, -17,
+ax_anim 2, 0, 35, 20, -16, 20, -16,
+ax_anim 2, 0, 35, 19, -17, 19, -17,
+ax_anim 2, 0, 33, 11, -11, 11, -11,
+ax_anim 2, 0, 33, 5, -5, 5, -5,
+ax_anim_terminator
+sDrowzeeAnims_2_5:
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 6, 0, 36, 0, 3, 0, 3,
+ax_anim 1, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 38, 0, -3, 0, -3,
+ax_anim 2, 2, 37, 0, -8, 0, -8,
+ax_anim 2, 0, 38, 0, -17, 0, -17,
+ax_anim 2, 1, 38, -1, -17, -1, -17,
+ax_anim 2, 0, 38, 0, -17, 0, -17,
+ax_anim 2, 0, 38, -1, -17, -1, -17,
+ax_anim 2, 0, 38, 0, -17, 0, -17,
+ax_anim 2, 0, 36, 0, -12, 0, -12,
+ax_anim 2, 0, 36, 0, -5, 0, -5,
+ax_anim_terminator
+sDrowzeeAnims_2_6:
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 6, 0, 39, 3, 3, 3, 3,
+ax_anim 1, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 2, 40, -8, -8, -8, -8,
+ax_anim 2, 0, 41, -19, -17, -19, -17,
+ax_anim 2, 1, 41, -20, -16, -20, -16,
+ax_anim 2, 0, 41, -19, -17, -19, -17,
+ax_anim 2, 0, 41, -20, -16, -20, -16,
+ax_anim 2, 0, 41, -19, -17, -19, -17,
+ax_anim 2, 0, 39, -11, -11, -11, -11,
+ax_anim 2, 0, 39, -5, -5, -5, -5,
+ax_anim_terminator
+sDrowzeeAnims_2_7:
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 6, 0, 42, 3, 0, 3, 0,
+ax_anim 1, 0, 43, 1, 0, 1, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 2, 43, -9, 0, -9, 0,
+ax_anim 2, 0, 44, -19, 0, -19, 0,
+ax_anim 2, 1, 44, -19, 1, -19, 1,
+ax_anim 2, 0, 44, -19, 0, -19, 0,
+ax_anim 2, 0, 44, -19, 1, -19, 1,
+ax_anim 2, 0, 44, -19, 0, -19, 0,
+ax_anim 2, 0, 42, -12, 0, -12, 0,
+ax_anim 2, 0, 42, -5, 0, -5, 0,
+ax_anim_terminator
+sDrowzeeAnims_2_8:
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 6, 0, 45, 3, -3, 3, -3,
+ax_anim 1, 0, 47, 3, -3, 3, -3,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 2, 47, -9, 8, -9, 8,
+ax_anim 2, 0, 46, -20, 18, -20, 18,
+ax_anim 2, 1, 46, -21, 17, -21, 17,
+ax_anim 2, 0, 46, -20, 18, -20, 18,
+ax_anim 2, 0, 46, -21, 17, -21, 17,
+ax_anim 2, 0, 46, -20, 18, -20, 18,
+ax_anim 2, 0, 45, -12, 11, -12, 11,
+ax_anim 2, 0, 45, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, -4, 0, -4,
+ax_anim 2, 0, 48, 0, -5, 0, -5,
+ax_anim 4, 0, 51, 0, -5, 0, -5,
+ax_anim 1, 2, 51, 0, -2, 0, -2,
+ax_anim 2, 2, 51, 0, 6, 0, 6,
+ax_anim 2, 0, 52, 0, 16, 0, 16,
+ax_anim 2, 1, 52, -1, 16, -1, 16,
+ax_anim 2, 0, 52, 0, 16, 0, 16,
+ax_anim 2, 0, 52, -1, 16, -1, 16,
+ax_anim 2, 0, 52, 0, 16, 0, 16,
+ax_anim 2, 0, 48, 0, 11, 0, 11,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sDrowzeeAnims_3_2:
+ax_anim 2, 0, 54, -2, -2, -2, -2,
+ax_anim 2, 0, 55, -4, -4, -4, -4,
+ax_anim 2, 0, 53, -5, -5, -5, -5,
+ax_anim 4, 0, 56, -5, -5, -5, -5,
+ax_anim 1, 0, 56, 2, 2, 2, 2,
+ax_anim 2, 2, 56, 6, 6, 6, 6,
+ax_anim 2, 0, 57, 20, 16, 20, 16,
+ax_anim 2, 1, 57, 19, 17, 19, 17,
+ax_anim 2, 0, 57, 20, 16, 20, 16,
+ax_anim 2, 0, 57, 19, 17, 19, 17,
+ax_anim 2, 0, 57, 20, 16, 20, 16,
+ax_anim 2, 0, 53, 12, 10, 12, 10,
+ax_anim 2, 0, 53, 3, 3, 3, 3,
+ax_anim_terminator
+sDrowzeeAnims_3_3:
+ax_anim 2, 0, 59, -2, 0, -2, 0,
+ax_anim 2, 0, 60, -4, 0, -4, 0,
+ax_anim 2, 0, 58, -5, 0, -5, 0,
+ax_anim 4, 0, 61, -8, 0, -8, 0,
+ax_anim 1, 2, 61, -3, 0, -3, 0,
+ax_anim 2, 2, 61, 6, 0, 6, 0,
+ax_anim 2, 0, 62, 18, 0, 18, 0,
+ax_anim 2, 1, 62, 18, 1, 18, 1,
+ax_anim 2, 0, 62, 18, 0, 18, 0,
+ax_anim 2, 0, 62, 18, 1, 18, 1,
+ax_anim 2, 0, 62, 18, 0, 18, 0,
+ax_anim 2, 0, 58, 12, 0, 12, 0,
+ax_anim 2, 0, 58, 3, 0, 3, 0,
+ax_anim_terminator
+sDrowzeeAnims_3_4:
+ax_anim 2, 0, 64, -2, 2, -2, 2,
+ax_anim 2, 0, 65, -4, 4, -4, 4,
+ax_anim 2, 0, 63, -5, 5, -5, 5,
+ax_anim 4, 0, 66, -8, 6, -6, 6,
+ax_anim 1, 2, 66, 0, 0, 0, 0,
+ax_anim 2, 2, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 67, 21, -19, 21, -19,
+ax_anim 2, 1, 67, 20, -20, 20, -20,
+ax_anim 2, 0, 67, 21, -19, 21, -19,
+ax_anim 2, 0, 67, 20, -20, 20, -20,
+ax_anim 2, 0, 67, 21, -19, 21, -19,
+ax_anim 2, 0, 63, 11, -10, 11, -10,
+ax_anim 2, 0, 63, 3, -3, 3, -3,
+ax_anim_terminator
+sDrowzeeAnims_3_5:
+ax_anim 2, 0, 69, 0, 2, 0, 2,
+ax_anim 2, 0, 70, 0, 4, 0, 4,
+ax_anim 2, 0, 68, 0, 5, 0, 5,
+ax_anim 4, 0, 71, 0, 5, 0, 5,
+ax_anim 1, 2, 71, 0, 2, 0, 2,
+ax_anim 2, 2, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 72, 0, -17, 0, -17,
+ax_anim 2, 1, 72, -1, -17, -1, -17,
+ax_anim 2, 0, 72, 0, -17, 0, -17,
+ax_anim 2, 0, 72, -1, -17, -1, -17,
+ax_anim 2, 0, 72, 0, -17, 0, -17,
+ax_anim 2, 0, 68, 0, -11, 0, -11,
+ax_anim 2, 0, 68, 0, -3, 0, -3,
+ax_anim_terminator
+sDrowzeeAnims_3_6:
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 73, 5, 5, 5, 5,
+ax_anim 4, 0, 76, 8, 6, 6, 6,
+ax_anim 1, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 2, 76, -6, -6, -6, -6,
+ax_anim 2, 0, 77, -21, -19, -21, -19,
+ax_anim 2, 1, 77, -20, -20, -20, -20,
+ax_anim 2, 0, 77, -21, -19, -21, -19,
+ax_anim 2, 0, 77, -20, -20, -20, -20,
+ax_anim 2, 0, 77, -21, -19, -21, -19,
+ax_anim 2, 0, 73, -11, -10, -11, -10,
+ax_anim 2, 0, 73, -3, -3, -3, -3,
+ax_anim_terminator
+sDrowzeeAnims_3_7:
+ax_anim 2, 0, 79, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 5, 0, 5, 0,
+ax_anim 4, 0, 81, 8, 0, 8, 0,
+ax_anim 1, 2, 81, 3, 0, 3, 0,
+ax_anim 2, 2, 81, -6, 0, -6, 0,
+ax_anim 2, 0, 82, -18, 0, -18, 0,
+ax_anim 2, 1, 82, -18, 1, -18, 1,
+ax_anim 2, 0, 82, -18, 0, -18, 0,
+ax_anim 2, 0, 82, -18, 1, -18, 1,
+ax_anim 2, 0, 82, -18, 0, -18, 0,
+ax_anim 2, 0, 78, -12, 0, -12, 0,
+ax_anim 2, 0, 78, -3, 0, -3, 0,
+ax_anim_terminator
+sDrowzeeAnims_3_8:
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim 2, 0, 85, 4, -4, 4, -4,
+ax_anim 2, 0, 83, 5, -5, 5, -5,
+ax_anim 4, 0, 86, 5, -5, 5, -5,
+ax_anim 1, 2, 86, -2, 2, -2, 2,
+ax_anim 2, 2, 86, -6, 6, -6, 6,
+ax_anim 2, 0, 87, -20, 16, -20, 16,
+ax_anim 2, 1, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -20, 16, -20, 16,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -20, 16, -20, 16,
+ax_anim 2, 0, 83, -12, 10, -12, 10,
+ax_anim 2, 0, 83, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim 6, 2, 88, 0, -4, 0, -4,
+ax_anim 1, 0, 88, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 91, 0, 6, 0, 6,
+ax_anim 2, 1, 91, 1, 6, 1, 6,
+ax_anim 2, 0, 91, 0, 6, 0, 6,
+ax_anim 2, 0, 91, 1, 6, 1, 6,
+ax_anim 2, 0, 91, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim_terminator
+sDrowzeeAnims_4_2:
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim 6, 2, 92, -4, -4, -4, -4,
+ax_anim 1, 0, 94, -3, -3, -3, -3,
+ax_anim 1, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 95, 6, 6, 6, 6,
+ax_anim 2, 1, 95, 7, 5, 7, 5,
+ax_anim 2, 0, 95, 6, 6, 6, 6,
+ax_anim 2, 0, 95, 7, 5, 7, 5,
+ax_anim 2, 0, 95, 6, 6, 6, 6,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim_terminator
+sDrowzeeAnims_4_3:
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, -3, 0, -3, 0,
+ax_anim 6, 2, 96, -4, 0, -4, 0,
+ax_anim 1, 0, 98, -3, 0, -3, 0,
+ax_anim 1, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 99, 6, 0, 6, 0,
+ax_anim 2, 1, 99, 6, 1, 6, 1,
+ax_anim 2, 0, 99, 6, 0, 6, 0,
+ax_anim 2, 0, 99, 6, 1, 6, 1,
+ax_anim 2, 0, 99, 6, 0, 6, 0,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim_terminator
+sDrowzeeAnims_4_4:
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 0, 100, -3, 3, -3, 3,
+ax_anim 6, 2, 100, -4, 4, -4, 4,
+ax_anim 1, 0, 102, -3, 3, -3, 3,
+ax_anim 1, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 1, 103, 7, -5, 7, -5,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 103, 7, -5, 7, -5,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim_terminator
+sDrowzeeAnims_4_5:
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim 6, 2, 104, 0, 4, 0, 4,
+ax_anim 1, 0, 106, 0, 3, 0, 3,
+ax_anim 1, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -6, 0, -6,
+ax_anim 2, 1, 107, 1, -6, 1, -6,
+ax_anim 2, 0, 107, 0, -6, 0, -6,
+ax_anim 2, 0, 107, 1, -6, 1, -6,
+ax_anim 2, 0, 107, 0, -6, 0, -6,
+ax_anim 2, 0, 104, 0, -3, 0, -3,
+ax_anim_terminator
+sDrowzeeAnims_4_6:
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 0, 108, 3, 3, 3, 3,
+ax_anim 6, 2, 108, 4, 4, 4, 4,
+ax_anim 1, 0, 110, 3, 3, 3, 3,
+ax_anim 1, 0, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -6, -6, -6, -6,
+ax_anim 2, 1, 111, -7, -5, -7, -5,
+ax_anim 2, 0, 111, -6, -6, -6, -6,
+ax_anim 2, 0, 111, -7, -5, -7, -5,
+ax_anim 2, 0, 111, -6, -6, -6, -6,
+ax_anim 2, 0, 108, -3, -3, -3, -3,
+ax_anim_terminator
+sDrowzeeAnims_4_7:
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 6, 2, 112, 4, 0, 4, 0,
+ax_anim 1, 0, 114, 3, 0, 3, 0,
+ax_anim 1, 0, 113, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -6, 0, -6, 0,
+ax_anim 2, 1, 115, -6, 1, -6, 1,
+ax_anim 2, 0, 115, -6, 0, -6, 0,
+ax_anim 2, 0, 115, -6, 1, -6, 1,
+ax_anim 2, 0, 115, -6, 0, -6, 0,
+ax_anim 2, 0, 112, -3, 0, -3, 0,
+ax_anim_terminator
+sDrowzeeAnims_4_8:
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim 2, 0, 116, 3, -3, 3, -3,
+ax_anim 6, 2, 116, 4, -4, 4, -4,
+ax_anim 1, 0, 118, 3, -3, 3, -3,
+ax_anim 1, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 1, 119, -7, 5, -7, 5,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, -7, 5, -7, 5,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 116, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_6_1:
+ax_anim 35, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sDrowzeeAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sDrowzeeAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sDrowzeeAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sDrowzeeAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sDrowzeeAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sDrowzeeAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sDrowzeeAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_8_2:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_8_4:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_8_5:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_8_6:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_8_8:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 15, 7, 15,
+ax_anim 3, 0, 166, 0, 19, 0, 19,
+ax_anim 2, 3, 167, -7, 15, -7, 15,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 10, 22, 10,
+ax_anim 3, 0, 165, 21, 19, 21, 19,
+ax_anim 2, 3, 166, 12, 18, 12, 18,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 18, -5, 18, -5,
+ax_anim 3, 0, 164, 21, -2, 21, -2,
+ax_anim 2, 3, 165, 17, 3, 17, 3,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 4, 4, 4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -8, 0, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 10, -20, 10, -20,
+ax_anim 3, 0, 163, 20, -22, 20, -22,
+ax_anim 2, 3, 164, 21, -13, 21, -13,
+ax_anim 2, 0, 165, 16, -6, 16, -6,
+ax_anim 1, 0, 166, 10, -1, 10, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -8, 0, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -10, -20, -10, -20,
+ax_anim 3, 0, 169, -20, -22, -20, -22,
+ax_anim 2, 3, 168, -21, -13, -21, -13,
+ax_anim 2, 0, 167, -16, -6, -16, -6,
+ax_anim 1, 0, 166, -10, -1, -10, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -18, -5, -18, -5,
+ax_anim 3, 0, 168, -21, -2, -21, -2,
+ax_anim 2, 3, 167, -17, 3, -17, 3,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 10, -22, 10,
+ax_anim 3, 0, 167, -21, 19, -21, 19,
+ax_anim 2, 3, 166, -12, 18, -12, 18,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, -1, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, -1, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, -1, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 2, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, -1, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDrowzeeAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sDrowzeeGfx1:
+.incbin "baserom.gba", 0x916D4C, 0x200
+sDrowzeeSprites1:
+ax_sprite sDrowzeeGfx1, 0x200
+ax_sprite_terminator
+sDrowzeeGfx2:
+.incbin "baserom.gba", 0x916F5C, 0x200
+sDrowzeeSprites2:
+ax_sprite sDrowzeeGfx2, 0x200
+ax_sprite_terminator
+sDrowzeeGfx3:
+.incbin "baserom.gba", 0x91716C, 0x200
+sDrowzeeSprites3:
+ax_sprite sDrowzeeGfx3, 0x200
+ax_sprite_terminator
+sDrowzeeGfx4:
+.incbin "baserom.gba", 0x91737C, 0x200
+sDrowzeeSprites4:
+ax_sprite sDrowzeeGfx4, 0x200
+ax_sprite_terminator
+sDrowzeeGfx5:
+.incbin "baserom.gba", 0x91758C, 0x200
+sDrowzeeSprites5:
+ax_sprite sDrowzeeGfx5, 0x200
+ax_sprite_terminator
+sDrowzeeGfx6:
+.incbin "baserom.gba", 0x91779C, 0x200
+sDrowzeeSprites6:
+ax_sprite sDrowzeeGfx6, 0x200
+ax_sprite_terminator
+sDrowzeeGfx7:
+.incbin "baserom.gba", 0x9179AC, 0x200
+sDrowzeeSprites7:
+ax_sprite sDrowzeeGfx7, 0x200
+ax_sprite_terminator
+sDrowzeeGfx8:
+.incbin "baserom.gba", 0x917BBC, 0x200
+sDrowzeeSprites8:
+ax_sprite sDrowzeeGfx8, 0x200
+ax_sprite_terminator
+sDrowzeeGfx9:
+.incbin "baserom.gba", 0x917DCC, 0x200
+sDrowzeeSprites9:
+ax_sprite sDrowzeeGfx9, 0x200
+ax_sprite_terminator
+sDrowzeeGfx10:
+.incbin "baserom.gba", 0x917FDC, 0x200
+sDrowzeeSprites10:
+ax_sprite sDrowzeeGfx10, 0x200
+ax_sprite_terminator
+sDrowzeeGfx11:
+.incbin "baserom.gba", 0x9181EC, 0x200
+sDrowzeeSprites11:
+ax_sprite sDrowzeeGfx11, 0x200
+ax_sprite_terminator
+sDrowzeeGfx12:
+.incbin "baserom.gba", 0x9183FC, 0x200
+sDrowzeeSprites12:
+ax_sprite sDrowzeeGfx12, 0x200
+ax_sprite_terminator
+sDrowzeeGfx13:
+.incbin "baserom.gba", 0x91860C, 0x200
+sDrowzeeSprites13:
+ax_sprite sDrowzeeGfx13, 0x200
+ax_sprite_terminator
+sDrowzeeGfx14:
+.incbin "baserom.gba", 0x91881C, 0x200
+sDrowzeeSprites14:
+ax_sprite sDrowzeeGfx14, 0x200
+ax_sprite_terminator
+sDrowzeeGfx15:
+.incbin "baserom.gba", 0x918A2C, 0x200
+sDrowzeeSprites15:
+ax_sprite sDrowzeeGfx15, 0x200
+ax_sprite_terminator
+sDrowzeeGfx16:
+.incbin "baserom.gba", 0x918C3C, 0x160
+sDrowzeeGfx16_1:
+.incbin "baserom.gba", 0x918D9C, 0x40
+sDrowzeeSprites16:
+ax_sprite sDrowzeeGfx16, 0x160
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDrowzeeGfx17:
+.incbin "baserom.gba", 0x918E04, 0x140
+sDrowzeeSprites17:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx17, 0x140
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx18:
+.incbin "baserom.gba", 0x918F64, 0x60
+sDrowzeeGfx18_1:
+.incbin "baserom.gba", 0x918FC4, 0x80
+sDrowzeeGfx18_2:
+.incbin "baserom.gba", 0x919044, 0x60
+sDrowzeeSprites18:
+ax_sprite sDrowzeeGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx18_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDrowzeeGfx19:
+.incbin "baserom.gba", 0x9190DC, 0x60
+sDrowzeeGfx19_1:
+.incbin "baserom.gba", 0x91913C, 0x60
+sDrowzeeGfx19_2:
+.incbin "baserom.gba", 0x91919C, 0x60
+sDrowzeeGfx19_3:
+.incbin "baserom.gba", 0x9191FC, 0x40
+sDrowzeeSprites19:
+ax_sprite sDrowzeeGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDrowzeeGfx20:
+.incbin "baserom.gba", 0x919284, 0x60
+sDrowzeeGfx20_1:
+.incbin "baserom.gba", 0x9192E4, 0x60
+sDrowzeeGfx20_2:
+.incbin "baserom.gba", 0x919344, 0x60
+sDrowzeeSprites20:
+ax_sprite sDrowzeeGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx21:
+.incbin "baserom.gba", 0x9193DC, 0x60
+sDrowzeeGfx21_1:
+.incbin "baserom.gba", 0x91943C, 0x60
+sDrowzeeGfx21_2:
+.incbin "baserom.gba", 0x91949C, 0x60
+sDrowzeeSprites21:
+ax_sprite sDrowzeeGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx22:
+.incbin "baserom.gba", 0x919534, 0x60
+sDrowzeeGfx22_1:
+.incbin "baserom.gba", 0x919594, 0x60
+sDrowzeeGfx22_2:
+.incbin "baserom.gba", 0x9195F4, 0x40
+sDrowzeeGfx22_3:
+.incbin "baserom.gba", 0x919634, 0x40
+sDrowzeeSprites22:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx22_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDrowzeeGfx23:
+.incbin "baserom.gba", 0x9196C4, 0x60
+sDrowzeeGfx23_1:
+.incbin "baserom.gba", 0x919724, 0x60
+sDrowzeeGfx23_2:
+.incbin "baserom.gba", 0x919784, 0x60
+sDrowzeeSprites23:
+ax_sprite sDrowzeeGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx24:
+.incbin "baserom.gba", 0x91981C, 0x40
+sDrowzeeGfx24_1:
+.incbin "baserom.gba", 0x91985C, 0x60
+sDrowzeeGfx24_2:
+.incbin "baserom.gba", 0x9198BC, 0x60
+sDrowzeeSprites24:
+ax_sprite sDrowzeeGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx25:
+.incbin "baserom.gba", 0x919954, 0x140
+sDrowzeeSprites25:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx25, 0x140
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx26:
+.incbin "baserom.gba", 0x919AB4, 0x60
+sDrowzeeGfx26_1:
+.incbin "baserom.gba", 0x919B14, 0x60
+sDrowzeeGfx26_2:
+.incbin "baserom.gba", 0x919B74, 0x60
+sDrowzeeGfx26_3:
+.incbin "baserom.gba", 0x919BD4, 0x20
+sDrowzeeSprites26:
+ax_sprite sDrowzeeGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDrowzeeGfx27:
+.incbin "baserom.gba", 0x919C3C, 0x60
+sDrowzeeGfx27_1:
+.incbin "baserom.gba", 0x919C9C, 0x60
+sDrowzeeGfx27_2:
+.incbin "baserom.gba", 0x919CFC, 0x60
+sDrowzeeSprites27:
+ax_sprite sDrowzeeGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx28:
+.incbin "baserom.gba", 0x919D94, 0x160
+sDrowzeeSprites28:
+ax_sprite sDrowzeeGfx28, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx29:
+.incbin "baserom.gba", 0x919F0C, 0x60
+sDrowzeeGfx29_1:
+.incbin "baserom.gba", 0x919F6C, 0x60
+sDrowzeeGfx29_2:
+.incbin "baserom.gba", 0x919FCC, 0x60
+sDrowzeeSprites29:
+ax_sprite sDrowzeeGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx30:
+.incbin "baserom.gba", 0x91A064, 0x60
+sDrowzeeGfx30_1:
+.incbin "baserom.gba", 0x91A0C4, 0x60
+sDrowzeeGfx30_2:
+.incbin "baserom.gba", 0x91A124, 0x60
+sDrowzeeSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx30_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDrowzeeGfx31:
+.incbin "baserom.gba", 0x91A1C4, 0x40
+sDrowzeeGfx31_1:
+.incbin "baserom.gba", 0x91A204, 0x80
+sDrowzeeGfx31_2:
+.incbin "baserom.gba", 0x91A284, 0x40
+sDrowzeeSprites31:
+ax_sprite 0, 0xa0
+ax_sprite sDrowzeeGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx31_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDrowzeeGfx32:
+.incbin "baserom.gba", 0x91A304, 0x60
+sDrowzeeGfx32_1:
+.incbin "baserom.gba", 0x91A364, 0x60
+sDrowzeeGfx32_2:
+.incbin "baserom.gba", 0x91A3C4, 0x60
+sDrowzeeSprites32:
+ax_sprite 0, 0x80
+ax_sprite sDrowzeeGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDrowzeeGfx33:
+.incbin "baserom.gba", 0x91A464, 0x40
+sDrowzeeGfx33_1:
+.incbin "baserom.gba", 0x91A4A4, 0x60
+sDrowzeeGfx33_2:
+.incbin "baserom.gba", 0x91A504, 0x60
+sDrowzeeSprites33:
+ax_sprite sDrowzeeGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx34:
+.incbin "baserom.gba", 0x91A59C, 0x60
+sDrowzeeGfx34_1:
+.incbin "baserom.gba", 0x91A5FC, 0x60
+sDrowzeeGfx34_2:
+.incbin "baserom.gba", 0x91A65C, 0x60
+sDrowzeeSprites34:
+ax_sprite sDrowzeeGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx35:
+.incbin "baserom.gba", 0x91A6F4, 0x40
+sDrowzeeGfx35_1:
+.incbin "baserom.gba", 0x91A734, 0xE0
+sDrowzeeSprites35:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx35_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx36:
+.incbin "baserom.gba", 0x91A844, 0x40
+sDrowzeeGfx36_1:
+.incbin "baserom.gba", 0x91A884, 0x100
+sDrowzeeSprites36:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx36_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDrowzeeGfx37:
+.incbin "baserom.gba", 0x91A9B4, 0x60
+sDrowzeeGfx37_1:
+.incbin "baserom.gba", 0x91AA14, 0x60
+sDrowzeeGfx37_2:
+.incbin "baserom.gba", 0x91AA74, 0x60
+sDrowzeeSprites37:
+ax_sprite sDrowzeeGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDrowzeeGfx38:
+.incbin "baserom.gba", 0x91AB0C, 0xE0
+sDrowzeeGfx38_1:
+.incbin "baserom.gba", 0x91ABEC, 0x60
+sDrowzeeSprites38:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx38, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx38_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDrowzeeGfx39:
+.incbin "baserom.gba", 0x91AC7C, 0x60
+sDrowzeeGfx39_1:
+.incbin "baserom.gba", 0x91ACDC, 0x60
+sDrowzeeGfx39_2:
+.incbin "baserom.gba", 0x91AD3C, 0x60
+sDrowzeeGfx39_3:
+.incbin "baserom.gba", 0x91AD9C, 0x20
+sDrowzeeSprites39:
+ax_sprite sDrowzeeGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx39_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx39_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDrowzeeGfx40:
+.incbin "baserom.gba", 0x91AE04, 0x40
+sDrowzeeGfx40_1:
+.incbin "baserom.gba", 0x91AE44, 0xE0
+sDrowzeeGfx40_2:
+.incbin "baserom.gba", 0x91AF24, 0x40
+sDrowzeeSprites40:
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDrowzeeGfx40_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sDrowzeeGfx40_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDrowzeeGfx41:
+.incbin "baserom.gba", 0x91AFA4, 0x200
+sDrowzeeSprites41:
+ax_sprite sDrowzeeGfx41, 0x200
+ax_sprite_terminator
+sDrowzeeGfx42:
+.incbin "baserom.gba", 0x91B1B4, 0x200
+sDrowzeeSprites42:
+ax_sprite sDrowzeeGfx42, 0x200
+ax_sprite_terminator
+sDrowzeeGfx43:
+.incbin "baserom.gba", 0x91B3C4, 0x200
+sDrowzeeSprites43:
+ax_sprite sDrowzeeGfx43, 0x200
+ax_sprite_terminator
+sDrowzeeGfx44:
+.incbin "baserom.gba", 0x91B5D4, 0x200
+sDrowzeeSprites44:
+ax_sprite sDrowzeeGfx44, 0x200
+ax_sprite_terminator
+sDrowzeeGfx45:
+.incbin "baserom.gba", 0x91B7E4, 0x200
+sDrowzeeSprites45:
+ax_sprite sDrowzeeGfx45, 0x200
+ax_sprite_terminator
+sDrowzeeGfx46:
+.incbin "baserom.gba", 0x91B9F4, 0x200
+sDrowzeeSprites46:
+ax_sprite sDrowzeeGfx46, 0x200
+ax_sprite_terminator
+sDrowzeeGfx47:
+.incbin "baserom.gba", 0x91BC04, 0x200
+sDrowzeeSprites47:
+ax_sprite sDrowzeeGfx47, 0x200
+ax_sprite_terminator
+sAxPosesDrowzee:
+.4byte sDrowzeePose1
+.4byte sDrowzeePose2
+.4byte sDrowzeePose3
+.4byte sDrowzeePose4
+.4byte sDrowzeePose5
+.4byte sDrowzeePose6
+.4byte sDrowzeePose7
+.4byte sDrowzeePose8
+.4byte sDrowzeePose9
+.4byte sDrowzeePose10
+.4byte sDrowzeePose11
+.4byte sDrowzeePose12
+.4byte sDrowzeePose13
+.4byte sDrowzeePose14
+.4byte sDrowzeePose15
+.4byte sDrowzeePose16
+.4byte sDrowzeePose17
+.4byte sDrowzeePose18
+.4byte sDrowzeePose19
+.4byte sDrowzeePose20
+.4byte sDrowzeePose21
+.4byte sDrowzeePose22
+.4byte sDrowzeePose23
+.4byte sDrowzeePose24
+.4byte sDrowzeePose25
+.4byte sDrowzeePose26
+.4byte sDrowzeePose27
+.4byte sDrowzeePose28
+.4byte sDrowzeePose29
+.4byte sDrowzeePose30
+.4byte sDrowzeePose31
+.4byte sDrowzeePose32
+.4byte sDrowzeePose33
+.4byte sDrowzeePose34
+.4byte sDrowzeePose35
+.4byte sDrowzeePose36
+.4byte sDrowzeePose37
+.4byte sDrowzeePose38
+.4byte sDrowzeePose39
+.4byte sDrowzeePose40
+.4byte sDrowzeePose41
+.4byte sDrowzeePose42
+.4byte sDrowzeePose43
+.4byte sDrowzeePose44
+.4byte sDrowzeePose45
+.4byte sDrowzeePose46
+.4byte sDrowzeePose47
+.4byte sDrowzeePose48
+.4byte sDrowzeePose49
+.4byte sDrowzeePose50
+.4byte sDrowzeePose51
+.4byte sDrowzeePose52
+.4byte sDrowzeePose53
+.4byte sDrowzeePose54
+.4byte sDrowzeePose55
+.4byte sDrowzeePose56
+.4byte sDrowzeePose57
+.4byte sDrowzeePose58
+.4byte sDrowzeePose59
+.4byte sDrowzeePose60
+.4byte sDrowzeePose61
+.4byte sDrowzeePose62
+.4byte sDrowzeePose63
+.4byte sDrowzeePose64
+.4byte sDrowzeePose65
+.4byte sDrowzeePose66
+.4byte sDrowzeePose67
+.4byte sDrowzeePose68
+.4byte sDrowzeePose69
+.4byte sDrowzeePose70
+.4byte sDrowzeePose71
+.4byte sDrowzeePose72
+.4byte sDrowzeePose73
+.4byte sDrowzeePose74
+.4byte sDrowzeePose75
+.4byte sDrowzeePose76
+.4byte sDrowzeePose77
+.4byte sDrowzeePose78
+.4byte sDrowzeePose79
+.4byte sDrowzeePose80
+.4byte sDrowzeePose81
+.4byte sDrowzeePose82
+.4byte sDrowzeePose83
+.4byte sDrowzeePose84
+.4byte sDrowzeePose85
+.4byte sDrowzeePose86
+.4byte sDrowzeePose87
+.4byte sDrowzeePose88
+.4byte sDrowzeePose89
+.4byte sDrowzeePose90
+.4byte sDrowzeePose91
+.4byte sDrowzeePose92
+.4byte sDrowzeePose93
+.4byte sDrowzeePose94
+.4byte sDrowzeePose95
+.4byte sDrowzeePose96
+.4byte sDrowzeePose97
+.4byte sDrowzeePose98
+.4byte sDrowzeePose99
+.4byte sDrowzeePose100
+.4byte sDrowzeePose101
+.4byte sDrowzeePose102
+.4byte sDrowzeePose103
+.4byte sDrowzeePose104
+.4byte sDrowzeePose105
+.4byte sDrowzeePose106
+.4byte sDrowzeePose107
+.4byte sDrowzeePose108
+.4byte sDrowzeePose109
+.4byte sDrowzeePose110
+.4byte sDrowzeePose111
+.4byte sDrowzeePose112
+.4byte sDrowzeePose113
+.4byte sDrowzeePose114
+.4byte sDrowzeePose115
+.4byte sDrowzeePose116
+.4byte sDrowzeePose117
+.4byte sDrowzeePose118
+.4byte sDrowzeePose119
+.4byte sDrowzeePose120
+.4byte sDrowzeePose121
+.4byte sDrowzeePose122
+.4byte sDrowzeePose123
+.4byte sDrowzeePose124
+.4byte sDrowzeePose125
+.4byte sDrowzeePose126
+.4byte sDrowzeePose127
+.4byte sDrowzeePose128
+.4byte sDrowzeePose129
+.4byte sDrowzeePose130
+.4byte sDrowzeePose131
+.4byte sDrowzeePose132
+.4byte sDrowzeePose133
+.4byte sDrowzeePose134
+.4byte sDrowzeePose135
+.4byte sDrowzeePose136
+.4byte sDrowzeePose137
+.4byte sDrowzeePose138
+.4byte sDrowzeePose139
+.4byte sDrowzeePose140
+.4byte sDrowzeePose141
+.4byte sDrowzeePose142
+.4byte sDrowzeePose143
+.4byte sDrowzeePose144
+.4byte sDrowzeePose145
+.4byte sDrowzeePose146
+.4byte sDrowzeePose147
+.4byte sDrowzeePose148
+.4byte sDrowzeePose149
+.4byte sDrowzeePose150
+.4byte sDrowzeePose151
+.4byte sDrowzeePose152
+.4byte sDrowzeePose153
+.4byte sDrowzeePose154
+.4byte sDrowzeePose155
+.4byte sDrowzeePose156
+.4byte sDrowzeePose157
+.4byte sDrowzeePose158
+.4byte sDrowzeePose159
+.4byte sDrowzeePose160
+.4byte sDrowzeePose161
+.4byte sDrowzeePose162
+.4byte sDrowzeePose163
+.4byte sDrowzeePose164
+.4byte sDrowzeePose165
+.4byte sDrowzeePose166
+.4byte sDrowzeePose167
+.4byte sDrowzeePose168
+.4byte sDrowzeePose169
+.4byte sDrowzeePose170
+.4byte sDrowzeePose171
+.4byte sDrowzeePose172
+.4byte sDrowzeePose173
+.4byte sDrowzeePose174
+.4byte sDrowzeePose175
+.4byte sDrowzeePose176
+.4byte sDrowzeePose177
+.4byte sDrowzeePose178
+.4byte sDrowzeePose179
+.4byte sDrowzeePose180
+.4byte sDrowzeePose181
+.4byte sDrowzeePose182
+.4byte sDrowzeePose183
+.4byte sDrowzeePose184
+.4byte sDrowzeePose185
+.4byte sDrowzeePose186
+.4byte sDrowzeePose187
+.4byte sDrowzeePose188
+.4byte sDrowzeePose189
+.4byte sDrowzeePose190
+.4byte sDrowzeePose191
+.4byte sDrowzeePose192
+.4byte sDrowzeePose193
+.4byte sDrowzeePose194
+.4byte sDrowzeePose195
+.4byte sDrowzeePose196
+.4byte sDrowzeePose197
+.4byte sDrowzeePose198
+.4byte sDrowzeePose199
+.4byte sDrowzeePose200
+.4byte sDrowzeePose201
+.4byte sDrowzeePose202
+.4byte sDrowzeePose203
+.4byte sDrowzeePose204
+.4byte sDrowzeePose205
+.4byte sDrowzeePose206
+.4byte sDrowzeePose207
+.4byte sDrowzeePose208
+.4byte sDrowzeePose209
+.4byte sDrowzeePose210
+.4byte sDrowzeePose211
+.4byte sDrowzeePose212
+.4byte sDrowzeePose213
+.4byte sDrowzeePose214
+.4byte sDrowzeePose215
+.4byte sDrowzeePose216
+.4byte sDrowzeePose217
+.4byte sDrowzeePose218
+sAxPositionsDrowzee:
+.2byte   -1,   -7, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    0,   -7, 	 -11,   -9, 	   7,   -7, 	  -1,   -9
+.2byte   -1,   -7, 	  -8,   -7, 	   9,   -9, 	  -1,   -9
+.2byte    2,   -9, 	   8,  -11, 	  -5,   -5, 	  -2,   -8
+.2byte    1,   -8, 	  -2,  -10, 	  -3,   -5, 	  -2,   -7
+.2byte    3,   -8, 	   8,   -9, 	  -7,   -4, 	  -1,   -7
+.2byte    3,   -9, 	   4,   -9, 	   2,   -5, 	  -3,   -8
+.2byte    2,   -8, 	  -8,   -9, 	   2,   -6, 	  -4,   -7
+.2byte    3,   -7, 	   5,  -10, 	   0,   -4, 	  -5,   -6
+.2byte    5,  -11, 	  -4,  -14, 	   7,   -8, 	  -3,   -9
+.2byte    5,  -10, 	  -8,   -9, 	   7,   -8, 	  -2,   -9
+.2byte    4,  -11, 	  -3,  -12, 	   6,   -6, 	  -3,   -8
+.2byte   -1,  -16, 	   8,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -9, 	  -9,  -11, 	  -1,   -9
+.2byte    0,  -15, 	   6,  -12, 	 -10,   -9, 	   0,   -9
+.2byte   -7,  -11, 	   2,  -14, 	  -9,   -8, 	   1,   -9
+.2byte   -7,  -10, 	   6,   -9, 	  -9,   -8, 	   0,   -9
+.2byte   -6,  -11, 	   1,  -12, 	  -8,   -6, 	   1,   -8
+.2byte   -5,   -9, 	  -6,   -9, 	  -4,   -5, 	   1,   -8
+.2byte   -4,   -8, 	   6,   -9, 	  -4,   -6, 	   2,   -7
+.2byte   -5,   -7, 	  -7,  -10, 	  -2,   -4, 	   3,   -6
+.2byte   -4,   -9, 	 -10,  -11, 	   3,   -5, 	   0,   -8
+.2byte   -3,   -8, 	   0,  -10, 	   1,   -5, 	   0,   -7
+.2byte   -5,   -8, 	 -10,   -9, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -16, 	  -9,  -14, 	   7,  -14, 	  -1,   -9
+.2byte    0,   -5, 	  -6,   -5, 	   5,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,   -6, 	   5,   -5, 	   0,   -8
+.2byte   -1,  -16, 	   4,  -16, 	  -8,  -10, 	   0,   -9
+.2byte    4,   -3, 	  12,   -6, 	  -2,   -3, 	   1,   -7
+.2byte    5,   -4, 	   8,   -6, 	   3,   -5, 	   0,   -6
+.2byte   -2,  -16, 	  -7,  -14, 	  -5,   -9, 	   0,   -8
+.2byte    5,   -4, 	  11,  -11, 	   1,   -4, 	  -2,   -7
+.2byte    8,   -5, 	   7,   -8, 	   8,   -8, 	  -1,   -7
+.2byte   -1,  -16, 	 -12,  -14, 	   2,  -10, 	  -3,   -7
+.2byte    5,   -9, 	   2,  -17, 	   4,   -6, 	  -2,  -10
+.2byte    2,  -15, 	  -2,  -16, 	   7,  -17, 	  -2,  -10
+.2byte   -1,  -19, 	   7,  -14, 	  -9,  -13, 	  -1,   -7
+.2byte   -2,  -15, 	   4,  -20, 	  -7,   -8, 	   1,  -10
+.2byte    0,  -17, 	   6,   -8, 	  -5,  -20, 	  -1,  -11
+.2byte    0,  -16, 	  11,  -14, 	  -3,  -10, 	   2,   -7
+.2byte   -7,   -9, 	  -4,  -17, 	  -6,   -6, 	   0,  -10
+.2byte   -4,  -15, 	   0,  -16, 	  -9,  -17, 	   0,  -10
+.2byte    1,  -16, 	   6,  -14, 	   4,   -9, 	  -1,   -8
+.2byte   -7,   -4, 	 -13,  -11, 	  -3,   -4, 	   0,   -7
+.2byte  -10,   -5, 	  -9,   -8, 	 -10,   -8, 	  -1,   -7
+.2byte    0,  -16, 	  -5,  -16, 	   7,  -10, 	  -1,   -9
+.2byte   -6,   -3, 	 -14,   -6, 	   0,   -3, 	  -3,   -7
+.2byte   -7,   -4, 	 -10,   -6, 	  -5,   -5, 	  -2,   -6
+.2byte   -1,   -7, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    0,   -7, 	 -11,   -9, 	   7,   -7, 	  -1,   -9
+.2byte   -1,   -7, 	  -8,   -7, 	   9,   -9, 	  -1,   -9
+.2byte   -1,  -17, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    1,    1, 	 -10,   -3, 	   7,   -4, 	   0,   -4
+.2byte    2,   -9, 	   8,  -11, 	  -5,   -5, 	  -2,   -8
+.2byte    1,   -8, 	  -2,  -10, 	  -3,   -5, 	  -2,   -7
+.2byte    3,   -8, 	   8,   -9, 	  -7,   -4, 	  -1,   -7
+.2byte   -3,  -17, 	   2,  -17, 	 -10,  -11, 	  -2,  -10
+.2byte    1,    1, 	   8,   -3, 	  -5,   -2, 	   0,   -5
+.2byte    3,   -9, 	   4,   -9, 	   2,   -5, 	  -3,   -8
+.2byte    2,   -8, 	  -8,   -9, 	   2,   -6, 	  -4,   -7
+.2byte    3,   -7, 	   5,  -10, 	   0,   -4, 	  -5,   -6
+.2byte   -3,  -17, 	  -8,  -15, 	  -6,  -10, 	  -1,   -9
+.2byte    2,   -2, 	   6,   -8, 	  -2,   -4, 	  -1,   -8
+.2byte    5,  -11, 	  -4,  -14, 	   7,   -8, 	  -3,   -9
+.2byte    5,  -10, 	  -8,   -9, 	   7,   -8, 	  -2,   -9
+.2byte    4,  -11, 	  -3,  -12, 	   6,   -6, 	  -3,   -8
+.2byte   -1,  -16, 	 -12,  -14, 	   2,  -10, 	  -3,   -7
+.2byte    5,   -8, 	  -6,  -14, 	   5,   -6, 	  -2,  -10
+.2byte   -1,  -16, 	   8,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -9, 	  -9,  -11, 	  -1,   -9
+.2byte    0,  -15, 	   6,  -12, 	 -10,   -9, 	   0,   -9
+.2byte   -1,  -19, 	   7,  -14, 	  -9,  -13, 	  -1,   -7
+.2byte   -2,  -16, 	   7,  -10, 	  -9,  -11, 	   0,  -12
+.2byte   -7,  -11, 	   2,  -14, 	  -9,   -8, 	   1,   -9
+.2byte   -7,  -10, 	   6,   -9, 	  -9,   -8, 	   0,   -9
+.2byte   -6,  -11, 	   1,  -12, 	  -8,   -6, 	   1,   -8
+.2byte   -1,  -16, 	  10,  -14, 	  -4,  -10, 	   1,   -7
+.2byte   -7,   -8, 	   4,  -14, 	  -7,   -6, 	   0,  -10
+.2byte   -5,   -9, 	  -6,   -9, 	  -4,   -5, 	   1,   -8
+.2byte   -4,   -8, 	   6,   -9, 	  -4,   -6, 	   2,   -7
+.2byte   -5,   -7, 	  -7,  -10, 	  -2,   -4, 	   3,   -6
+.2byte    1,  -17, 	   6,  -15, 	   4,  -10, 	  -1,   -9
+.2byte   -4,   -2, 	  -8,   -8, 	   0,   -4, 	  -1,   -8
+.2byte   -4,   -9, 	 -10,  -11, 	   3,   -5, 	   0,   -8
+.2byte   -3,   -8, 	   0,  -10, 	   1,   -5, 	   0,   -7
+.2byte   -5,   -8, 	 -10,   -9, 	   5,   -4, 	  -1,   -7
+.2byte    1,  -17, 	  -4,  -17, 	   8,  -11, 	   0,  -10
+.2byte   -3,    1, 	 -10,   -3, 	   3,   -2, 	  -2,   -5
+.2byte   -1,  -16, 	  -9,  -14, 	   7,  -14, 	  -1,   -9
+.2byte    0,   -7, 	 -11,   -9, 	   7,   -7, 	  -1,   -9
+.2byte   -1,   -7, 	  -8,   -7, 	   9,   -9, 	  -1,   -9
+.2byte   -1,   -4, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,  -16, 	   4,  -16, 	  -8,  -10, 	   0,   -9
+.2byte    1,   -8, 	  -2,  -10, 	  -3,   -5, 	  -2,   -7
+.2byte    3,   -8, 	   8,   -9, 	  -7,   -4, 	  -1,   -7
+.2byte    5,   -8, 	   9,   -9, 	  -2,   -5, 	   0,   -8
+.2byte   -2,  -16, 	  -7,  -14, 	  -5,   -9, 	   0,   -8
+.2byte    2,   -8, 	  -8,   -9, 	   2,   -6, 	  -4,   -7
+.2byte    3,   -7, 	   5,  -10, 	   0,   -4, 	  -5,   -6
+.2byte   10,  -10, 	   7,  -12, 	   4,   -6, 	  -2,   -8
+.2byte    0,  -16, 	 -11,  -14, 	   3,  -10, 	  -2,   -7
+.2byte    5,  -10, 	  -8,   -9, 	   7,   -8, 	  -2,   -9
+.2byte    4,  -11, 	  -3,  -12, 	   6,   -6, 	  -3,   -8
+.2byte    8,  -17, 	   0,  -16, 	   9,  -10, 	  -2,  -10
+.2byte   -1,  -19, 	   7,  -14, 	  -9,  -13, 	  -1,   -7
+.2byte   -1,  -15, 	   9,   -9, 	  -9,  -11, 	  -1,   -9
+.2byte    0,  -15, 	   6,  -12, 	 -10,   -9, 	   0,   -9
+.2byte   -1,  -19, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte    0,  -16, 	  11,  -14, 	  -3,  -10, 	   2,   -7
+.2byte   -7,  -10, 	   6,   -9, 	  -9,   -8, 	   0,   -9
+.2byte   -6,  -11, 	   1,  -12, 	  -8,   -6, 	   1,   -8
+.2byte  -10,  -17, 	  -2,  -16, 	 -11,  -10, 	   0,  -10
+.2byte    2,  -16, 	   7,  -14, 	   5,   -9, 	   0,   -8
+.2byte   -4,   -8, 	   6,   -9, 	  -4,   -6, 	   2,   -7
+.2byte   -5,   -7, 	  -7,  -10, 	  -2,   -4, 	   3,   -6
+.2byte  -12,  -10, 	  -9,  -12, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -16, 	  -5,  -16, 	   7,  -10, 	  -1,   -9
+.2byte   -3,   -8, 	   0,  -10, 	   1,   -5, 	   0,   -7
+.2byte   -5,   -8, 	 -10,   -9, 	   5,   -4, 	  -1,   -7
+.2byte   -7,   -8, 	 -11,   -9, 	   0,   -5, 	  -2,   -8
+.2byte   -1,   -7, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte   -4,   -9, 	 -10,  -11, 	   3,   -5, 	   0,   -8
+.2byte   -5,   -9, 	  -6,   -9, 	  -4,   -5, 	   1,   -8
+.2byte   -7,  -11, 	   2,  -14, 	  -9,   -8, 	   1,   -9
+.2byte   -1,  -16, 	   8,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte    5,  -11, 	  -4,  -14, 	   7,   -8, 	  -3,   -9
+.2byte    3,   -9, 	   4,   -9, 	   2,   -5, 	  -3,   -8
+.2byte    2,   -9, 	   8,  -11, 	  -5,   -5, 	  -2,   -8
+.2byte    4,   -7, 	   1,   -3, 	   7,   -8, 	   1,   -6
+.2byte    4,   -6, 	   1,   -3, 	   7,   -7, 	   0,   -6
+.2byte    0,  -16, 	 -10,  -10, 	  10,  -10, 	   0,  -10
+.2byte    1,  -16, 	   5,  -19, 	  -9,   -7, 	  -1,  -10
+.2byte    2,  -17, 	  -1,   -9, 	  -9,   -7, 	  -1,   -7
+.2byte    3,  -17, 	 -10,  -10, 	   1,   -6, 	  -1,   -8
+.2byte    0,  -19, 	  10,   -6, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -17, 	   9,  -10, 	  -2,   -6, 	   0,   -8
+.2byte   -4,  -17, 	  -1,   -9, 	   7,   -7, 	  -1,   -7
+.2byte   -2,  -16, 	  -6,  -19, 	   8,   -7, 	   0,  -10
+.2byte   -1,   -7, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    0,   -7, 	 -11,   -9, 	   7,   -7, 	  -1,   -9
+.2byte   -1,   -7, 	  -8,   -7, 	   9,   -9, 	  -1,   -9
+.2byte    2,   -9, 	   8,  -11, 	  -5,   -5, 	  -2,   -8
+.2byte    1,   -8, 	  -2,  -10, 	  -3,   -5, 	  -2,   -7
+.2byte    3,   -8, 	   8,   -9, 	  -7,   -4, 	  -1,   -7
+.2byte    3,   -9, 	   4,   -9, 	   2,   -5, 	  -3,   -8
+.2byte    2,   -8, 	  -8,   -9, 	   2,   -6, 	  -4,   -7
+.2byte    3,   -7, 	   5,  -10, 	   0,   -4, 	  -5,   -6
+.2byte    5,  -11, 	  -4,  -14, 	   7,   -8, 	  -3,   -9
+.2byte    5,  -10, 	  -8,   -9, 	   7,   -8, 	  -2,   -9
+.2byte    4,  -11, 	  -3,  -12, 	   6,   -6, 	  -3,   -8
+.2byte   -1,  -16, 	   8,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -9, 	  -9,  -11, 	  -1,   -9
+.2byte    0,  -15, 	   6,  -12, 	 -10,   -9, 	   0,   -9
+.2byte   -7,  -11, 	   2,  -14, 	  -9,   -8, 	   1,   -9
+.2byte   -7,  -10, 	   6,   -9, 	  -9,   -8, 	   0,   -9
+.2byte   -6,  -11, 	   1,  -12, 	  -8,   -6, 	   1,   -8
+.2byte   -5,   -9, 	  -6,   -9, 	  -4,   -5, 	   1,   -8
+.2byte   -4,   -8, 	   6,   -9, 	  -4,   -6, 	   2,   -7
+.2byte   -5,   -7, 	  -7,  -10, 	  -2,   -4, 	   3,   -6
+.2byte   -4,   -9, 	 -10,  -11, 	   3,   -5, 	   0,   -8
+.2byte   -3,   -8, 	   0,  -10, 	   1,   -5, 	   0,   -7
+.2byte   -5,   -8, 	 -10,   -9, 	   5,   -4, 	  -1,   -7
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -5, 	  -1,   -6
+.2byte   -4,   -3, 	 -12,   -6, 	   2,   -3, 	  -1,   -7
+.2byte   -7,   -4, 	 -13,  -11, 	  -3,   -4, 	   0,   -7
+.2byte   -6,   -7, 	  -3,  -15, 	  -5,   -4, 	   1,   -8
+.2byte   -2,  -13, 	   4,  -18, 	  -7,   -6, 	   1,   -8
+.2byte    5,   -7, 	   2,  -15, 	   4,   -4, 	  -2,   -8
+.2byte    5,   -4, 	  11,  -11, 	   1,   -4, 	  -2,   -7
+.2byte    3,   -3, 	  11,   -6, 	  -3,   -3, 	   0,   -7
+.2byte   -1,  -17, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte   -2,  -17, 	   3,  -17, 	  -9,  -11, 	  -1,  -10
+.2byte   -3,  -17, 	  -8,  -15, 	  -6,  -10, 	  -1,   -9
+.2byte   -1,  -16, 	 -12,  -14, 	   2,  -10, 	  -3,   -7
+.2byte   -1,  -20, 	   7,  -15, 	  -9,  -14, 	  -1,   -8
+.2byte    0,  -16, 	  11,  -14, 	  -3,  -10, 	   2,   -7
+.2byte    1,  -17, 	   6,  -15, 	   4,  -10, 	  -1,   -9
+.2byte    0,  -17, 	  -5,  -17, 	   7,  -11, 	  -1,  -10
+.2byte   -1,   -7, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte   -1,  -17, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    1,    1, 	 -10,   -3, 	   7,   -4, 	   0,   -4
+.2byte    2,   -9, 	   8,  -11, 	  -5,   -5, 	  -2,   -8
+.2byte   -2,  -17, 	   3,  -17, 	  -9,  -11, 	  -1,  -10
+.2byte    1,    1, 	   8,   -3, 	  -5,   -2, 	   0,   -5
+.2byte    3,   -9, 	   4,   -9, 	   2,   -5, 	  -3,   -8
+.2byte   -2,  -17, 	  -7,  -15, 	  -5,  -10, 	   0,   -9
+.2byte    2,   -2, 	   6,   -8, 	  -2,   -4, 	  -1,   -8
+.2byte    5,  -11, 	  -4,  -14, 	   7,   -8, 	  -3,   -9
+.2byte   -1,  -16, 	 -12,  -14, 	   2,  -10, 	  -3,   -7
+.2byte    5,   -8, 	  -6,  -14, 	   5,   -6, 	  -2,  -10
+.2byte   -1,  -16, 	   8,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -1,  -19, 	   7,  -14, 	  -9,  -13, 	  -1,   -7
+.2byte   -2,  -16, 	   7,  -10, 	  -9,  -11, 	   0,  -12
+.2byte   -7,  -11, 	   2,  -14, 	  -9,   -8, 	   1,   -9
+.2byte   -1,  -16, 	  10,  -14, 	  -4,  -10, 	   1,   -7
+.2byte   -7,   -8, 	   4,  -14, 	  -7,   -6, 	   0,  -10
+.2byte   -5,   -9, 	  -6,   -9, 	  -4,   -5, 	   1,   -8
+.2byte    0,  -17, 	   5,  -15, 	   3,  -10, 	  -2,   -9
+.2byte   -4,   -2, 	  -8,   -8, 	   0,   -4, 	  -1,   -8
+.2byte   -4,   -9, 	 -10,  -11, 	   3,   -5, 	   0,   -8
+.2byte    0,  -17, 	  -5,  -17, 	   7,  -11, 	  -1,  -10
+.2byte   -3,    1, 	 -10,   -3, 	   3,   -2, 	  -2,   -5
+.2byte   -1,   -4, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -7,   -8, 	 -11,   -9, 	   0,   -5, 	  -2,   -8
+.2byte  -12,  -10, 	  -9,  -12, 	  -6,   -6, 	   0,   -8
+.2byte   -9,  -17, 	  -1,  -16, 	 -10,  -10, 	   1,  -10
+.2byte   -1,  -19, 	   6,  -15, 	  -8,  -15, 	  -1,  -10
+.2byte    8,  -17, 	   0,  -16, 	   9,  -10, 	  -2,  -10
+.2byte   10,  -10, 	   7,  -12, 	   4,   -6, 	  -2,   -8
+.2byte    6,   -8, 	  10,   -9, 	  -1,   -5, 	   1,   -8
+.2byte   -1,   -7, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte   -4,   -9, 	 -10,  -11, 	   3,   -5, 	   0,   -8
+.2byte   -5,   -9, 	  -6,   -9, 	  -4,   -5, 	   1,   -8
+.2byte   -7,  -11, 	   2,  -14, 	  -9,   -8, 	   1,   -9
+.2byte   -1,  -16, 	   8,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte    5,  -11, 	  -4,  -14, 	   7,   -8, 	  -3,   -9
+.2byte    3,   -9, 	   4,   -9, 	   2,   -5, 	  -3,   -8
+.2byte    2,   -9, 	   8,  -11, 	  -5,   -5, 	  -2,   -8
+sDrowzeeAnimTable1:
+.4byte sDrowzeeAnims_1_1
+.4byte sDrowzeeAnims_1_2
+.4byte sDrowzeeAnims_1_3
+.4byte sDrowzeeAnims_1_4
+.4byte sDrowzeeAnims_1_5
+.4byte sDrowzeeAnims_1_6
+.4byte sDrowzeeAnims_1_7
+.4byte sDrowzeeAnims_1_8
+sDrowzeeAnimTable2:
+.4byte sDrowzeeAnims_2_1
+.4byte sDrowzeeAnims_2_2
+.4byte sDrowzeeAnims_2_3
+.4byte sDrowzeeAnims_2_4
+.4byte sDrowzeeAnims_2_5
+.4byte sDrowzeeAnims_2_6
+.4byte sDrowzeeAnims_2_7
+.4byte sDrowzeeAnims_2_8
+sDrowzeeAnimTable3:
+.4byte sDrowzeeAnims_3_1
+.4byte sDrowzeeAnims_3_2
+.4byte sDrowzeeAnims_3_3
+.4byte sDrowzeeAnims_3_4
+.4byte sDrowzeeAnims_3_5
+.4byte sDrowzeeAnims_3_6
+.4byte sDrowzeeAnims_3_7
+.4byte sDrowzeeAnims_3_8
+sDrowzeeAnimTable4:
+.4byte sDrowzeeAnims_4_1
+.4byte sDrowzeeAnims_4_2
+.4byte sDrowzeeAnims_4_3
+.4byte sDrowzeeAnims_4_4
+.4byte sDrowzeeAnims_4_5
+.4byte sDrowzeeAnims_4_6
+.4byte sDrowzeeAnims_4_7
+.4byte sDrowzeeAnims_4_8
+sDrowzeeAnimTable5:
+.4byte sDrowzeeAnims_5_1
+.4byte sDrowzeeAnims_5_2
+.4byte sDrowzeeAnims_5_3
+.4byte sDrowzeeAnims_5_4
+.4byte sDrowzeeAnims_5_5
+.4byte sDrowzeeAnims_5_6
+.4byte sDrowzeeAnims_5_7
+.4byte sDrowzeeAnims_5_8
+sDrowzeeAnimTable6:
+.4byte sDrowzeeAnims_6_1
+.4byte sDrowzeeAnims_6_1
+.4byte sDrowzeeAnims_6_1
+.4byte sDrowzeeAnims_6_1
+.4byte sDrowzeeAnims_6_1
+.4byte sDrowzeeAnims_6_1
+.4byte sDrowzeeAnims_6_1
+.4byte sDrowzeeAnims_6_1
+sDrowzeeAnimTable7:
+.4byte sDrowzeeAnims_7_1
+.4byte sDrowzeeAnims_7_2
+.4byte sDrowzeeAnims_7_3
+.4byte sDrowzeeAnims_7_4
+.4byte sDrowzeeAnims_7_5
+.4byte sDrowzeeAnims_7_6
+.4byte sDrowzeeAnims_7_7
+.4byte sDrowzeeAnims_7_8
+sDrowzeeAnimTable8:
+.4byte sDrowzeeAnims_8_1
+.4byte sDrowzeeAnims_8_2
+.4byte sDrowzeeAnims_8_3
+.4byte sDrowzeeAnims_8_4
+.4byte sDrowzeeAnims_8_5
+.4byte sDrowzeeAnims_8_6
+.4byte sDrowzeeAnims_8_7
+.4byte sDrowzeeAnims_8_8
+sDrowzeeAnimTable9:
+.4byte sDrowzeeAnims_9_1
+.4byte sDrowzeeAnims_9_2
+.4byte sDrowzeeAnims_9_3
+.4byte sDrowzeeAnims_9_4
+.4byte sDrowzeeAnims_9_5
+.4byte sDrowzeeAnims_9_6
+.4byte sDrowzeeAnims_9_7
+.4byte sDrowzeeAnims_9_8
+sDrowzeeAnimTable10:
+.4byte sDrowzeeAnims_10_1
+.4byte sDrowzeeAnims_10_2
+.4byte sDrowzeeAnims_10_3
+.4byte sDrowzeeAnims_10_4
+.4byte sDrowzeeAnims_10_5
+.4byte sDrowzeeAnims_10_6
+.4byte sDrowzeeAnims_10_7
+.4byte sDrowzeeAnims_10_8
+sDrowzeeAnimTable11:
+.4byte sDrowzeeAnims_11_1
+.4byte sDrowzeeAnims_11_2
+.4byte sDrowzeeAnims_11_3
+.4byte sDrowzeeAnims_11_4
+.4byte sDrowzeeAnims_11_5
+.4byte sDrowzeeAnims_11_6
+.4byte sDrowzeeAnims_11_7
+.4byte sDrowzeeAnims_11_8
+sDrowzeeAnimTable12:
+.4byte sDrowzeeAnims_12_1
+.4byte sDrowzeeAnims_12_2
+.4byte sDrowzeeAnims_12_3
+.4byte sDrowzeeAnims_12_4
+.4byte sDrowzeeAnims_12_5
+.4byte sDrowzeeAnims_12_6
+.4byte sDrowzeeAnims_12_7
+.4byte sDrowzeeAnims_12_8
+sDrowzeeAnimTable13:
+.4byte sDrowzeeAnims_13_1
+.4byte sDrowzeeAnims_13_2
+.4byte sDrowzeeAnims_13_3
+.4byte sDrowzeeAnims_13_4
+.4byte sDrowzeeAnims_13_5
+.4byte sDrowzeeAnims_13_6
+.4byte sDrowzeeAnims_13_7
+.4byte sDrowzeeAnims_13_8
+sAxAnimationsDrowzee:
+.4byte sDrowzeeAnimTable1
+.4byte sDrowzeeAnimTable2
+.4byte sDrowzeeAnimTable3
+.4byte sDrowzeeAnimTable4
+.4byte sDrowzeeAnimTable5
+.4byte sDrowzeeAnimTable6
+.4byte sDrowzeeAnimTable7
+.4byte sDrowzeeAnimTable8
+.4byte sDrowzeeAnimTable9
+.4byte sDrowzeeAnimTable10
+.4byte sDrowzeeAnimTable11
+.4byte sDrowzeeAnimTable12
+.4byte sDrowzeeAnimTable13
+sAxSpritesDrowzee:
+.4byte sDrowzeeSprites1
+.4byte sDrowzeeSprites2
+.4byte sDrowzeeSprites3
+.4byte sDrowzeeSprites4
+.4byte sDrowzeeSprites5
+.4byte sDrowzeeSprites6
+.4byte sDrowzeeSprites7
+.4byte sDrowzeeSprites8
+.4byte sDrowzeeSprites9
+.4byte sDrowzeeSprites10
+.4byte sDrowzeeSprites11
+.4byte sDrowzeeSprites12
+.4byte sDrowzeeSprites13
+.4byte sDrowzeeSprites14
+.4byte sDrowzeeSprites15
+.4byte sDrowzeeSprites16
+.4byte sDrowzeeSprites17
+.4byte sDrowzeeSprites18
+.4byte sDrowzeeSprites19
+.4byte sDrowzeeSprites20
+.4byte sDrowzeeSprites21
+.4byte sDrowzeeSprites22
+.4byte sDrowzeeSprites23
+.4byte sDrowzeeSprites24
+.4byte sDrowzeeSprites25
+.4byte sDrowzeeSprites26
+.4byte sDrowzeeSprites27
+.4byte sDrowzeeSprites28
+.4byte sDrowzeeSprites29
+.4byte sDrowzeeSprites30
+.4byte sDrowzeeSprites31
+.4byte sDrowzeeSprites32
+.4byte sDrowzeeSprites33
+.4byte sDrowzeeSprites34
+.4byte sDrowzeeSprites35
+.4byte sDrowzeeSprites36
+.4byte sDrowzeeSprites37
+.4byte sDrowzeeSprites38
+.4byte sDrowzeeSprites39
+.4byte sDrowzeeSprites40
+.4byte sDrowzeeSprites41
+.4byte sDrowzeeSprites42
+.4byte sDrowzeeSprites43
+.4byte sDrowzeeSprites44
+.4byte sDrowzeeSprites45
+.4byte sDrowzeeSprites46
+.4byte sDrowzeeSprites47
+sAxMainDrowzee:
+ax_main sAxPosesDrowzee, sAxAnimationsDrowzee, 13, sAxSpritesDrowzee, sAxPositionsDrowzee

--- a/data/ax/dugtrio.inc
+++ b/data/ax/dugtrio.inc
@@ -1,0 +1,6328 @@
+.global gAxDugtrio
+gAxDugtrio:
+ax_siro sAxMainDugtrio
+sDugtrioPose1:
+ax_pose 0, 0x0201, 0x00fc, 0x4c00
+ax_pose 1, 0x41fc, 0x40f0, 0x4c01
+ax_pose 2, 0x41f5, 0x00f8, 0x4c05
+ax_pose -1, 0x01f1, 0x00fc, 0x4c00
+ax_pose -1, 0x01fa, 0x00f4, 0x4c00
+ax_pose -1, 0x41f5, 0x40e8, 0x4c01
+ax_pose -1, 0x41ee, 0x00f0, 0x4c05
+ax_pose -1, 0x01ea, 0x00f4, 0x4c00
+ax_pose -1, 0x01f6, 0x0102, 0x4c00
+ax_pose -1, 0x41f1, 0x40f6, 0x4c01
+ax_pose -1, 0x41ea, 0x00fe, 0x4c05
+ax_pose -1, 0x01e6, 0x0102, 0x4c00
+ax_pose_terminator
+sDugtrioPose2:
+ax_pose 3, 0x4200, 0x00f8, 0x4c00
+ax_pose 4, 0x41f9, 0x40f0, 0x4c02
+ax_pose -1, 0x41f4, 0x00f8, 0x4c00
+ax_pose 5, 0x01ef, 0x00fc, 0x4c06
+ax_pose -1, 0x41f9, 0x00f0, 0x4c00
+ax_pose -1, 0x41f2, 0x40e8, 0x4c02
+ax_pose -1, 0x41ed, 0x00f0, 0x4c00
+ax_pose -1, 0x01e8, 0x00f4, 0x4c06
+ax_pose -1, 0x41f5, 0x00fe, 0x4c00
+ax_pose -1, 0x41ee, 0x40f6, 0x4c02
+ax_pose -1, 0x41e9, 0x00fe, 0x4c00
+ax_pose -1, 0x01e4, 0x0102, 0x4c06
+ax_pose_terminator
+sDugtrioPose3:
+ax_pose 4, 0x41fe, 0x40f0, 0x4c00
+ax_pose 6, 0x41f8, 0x40f0, 0x4c04
+ax_pose 7, 0x41f3, 0x00f8, 0x4c08
+ax_pose 8, 0x01ee, 0x00fc, 0x4c0a
+ax_pose -1, 0x41f7, 0x40e8, 0x4c00
+ax_pose -1, 0x41f1, 0x40e8, 0x4c04
+ax_pose -1, 0x41ec, 0x00f0, 0x4c08
+ax_pose -1, 0x01e7, 0x00f4, 0x4c0a
+ax_pose -1, 0x41f3, 0x40f6, 0x4c00
+ax_pose -1, 0x41ed, 0x40f6, 0x4c04
+ax_pose -1, 0x41e8, 0x00fe, 0x4c08
+ax_pose -1, 0x01e3, 0x0102, 0x4c0a
+ax_pose_terminator
+sDugtrioPose4:
+ax_pose 0, 0x01fe, 0x00f7, 0x4c00
+ax_pose 1, 0x41f9, 0x40e5, 0x4c01
+ax_pose 2, 0x41f2, 0x00e7, 0x4c05
+ax_pose -1, 0x01ee, 0x00e6, 0x4c00
+ax_pose -1, 0x0200, 0x0102, 0x4c00
+ax_pose -1, 0x41fb, 0x40f0, 0x4c01
+ax_pose -1, 0x41f4, 0x00f2, 0x4c05
+ax_pose -1, 0x01f0, 0x00f1, 0x4c00
+ax_pose -1, 0x01f6, 0x0101, 0x4c00
+ax_pose -1, 0x41f1, 0x40ef, 0x4c01
+ax_pose -1, 0x41ea, 0x00f1, 0x4c05
+ax_pose -1, 0x01e6, 0x00f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose5:
+ax_pose 3, 0x41fd, 0x00f0, 0x4c00
+ax_pose 4, 0x41f7, 0x40e3, 0x4c02
+ax_pose -1, 0x41f2, 0x00e5, 0x4c00
+ax_pose 5, 0x01ed, 0x00e4, 0x4c06
+ax_pose -1, 0x41ff, 0x00fb, 0x4c00
+ax_pose -1, 0x41f9, 0x40ee, 0x4c02
+ax_pose -1, 0x41f4, 0x00f0, 0x4c00
+ax_pose -1, 0x01ef, 0x00ef, 0x4c06
+ax_pose -1, 0x41f5, 0x00fa, 0x4c00
+ax_pose -1, 0x41ef, 0x40ed, 0x4c02
+ax_pose -1, 0x41ea, 0x00ef, 0x4c00
+ax_pose -1, 0x01e5, 0x00ee, 0x4c06
+ax_pose_terminator
+sDugtrioPose6:
+ax_pose 4, 0x41fb, 0x40e7, 0x4c00
+ax_pose 6, 0x41f6, 0x40e2, 0x4c04
+ax_pose 7, 0x41f1, 0x00e4, 0x4c08
+ax_pose 8, 0x01ec, 0x00e3, 0x4c0a
+ax_pose -1, 0x41fd, 0x40f2, 0x4c00
+ax_pose -1, 0x41f8, 0x40ed, 0x4c04
+ax_pose -1, 0x41f3, 0x00ef, 0x4c08
+ax_pose -1, 0x01ee, 0x00ee, 0x4c0a
+ax_pose -1, 0x41f3, 0x40f1, 0x4c00
+ax_pose -1, 0x41ee, 0x40ec, 0x4c04
+ax_pose -1, 0x41e9, 0x00ee, 0x4c08
+ax_pose -1, 0x01e4, 0x00ed, 0x4c0a
+ax_pose_terminator
+sDugtrioPose7:
+ax_pose 0, 0x01fc, 0x0104, 0x4c00
+ax_pose 1, 0x41fb, 0x40f1, 0x4c01
+ax_pose 2, 0x41fc, 0x00f2, 0x4c05
+ax_pose -1, 0x01fb, 0x00ef, 0x4c00
+ax_pose -1, 0x01f8, 0x0109, 0x4c00
+ax_pose -1, 0x41f7, 0x40f6, 0x4c01
+ax_pose -1, 0x41f8, 0x00f7, 0x4c05
+ax_pose -1, 0x01f7, 0x00f4, 0x4c00
+ax_pose -1, 0x01f5, 0x00fc, 0x4c00
+ax_pose -1, 0x41f4, 0x40e9, 0x4c01
+ax_pose -1, 0x41f5, 0x00ea, 0x4c05
+ax_pose -1, 0x01f4, 0x00e7, 0x4c00
+ax_pose_terminator
+sDugtrioPose8:
+ax_pose 3, 0x41fc, 0x00fd, 0x4c00
+ax_pose 4, 0x41fb, 0x40ee, 0x4c02
+ax_pose -1, 0x41fc, 0x00f0, 0x4c00
+ax_pose 5, 0x01fc, 0x00ed, 0x4c06
+ax_pose -1, 0x41f8, 0x0102, 0x4c00
+ax_pose -1, 0x41f7, 0x40f3, 0x4c02
+ax_pose -1, 0x41f8, 0x00f5, 0x4c00
+ax_pose -1, 0x01f8, 0x00f2, 0x4c06
+ax_pose -1, 0x41f5, 0x00f5, 0x4c00
+ax_pose -1, 0x41f4, 0x40e6, 0x4c02
+ax_pose -1, 0x41f5, 0x00e8, 0x4c00
+ax_pose -1, 0x01f5, 0x00e5, 0x4c06
+ax_pose_terminator
+sDugtrioPose9:
+ax_pose 4, 0x41fb, 0x40f3, 0x4c00
+ax_pose 6, 0x41fc, 0x40ec, 0x4c04
+ax_pose 7, 0x41fb, 0x00ed, 0x4c08
+ax_pose 8, 0x01fc, 0x00ec, 0x4c0a
+ax_pose -1, 0x41f7, 0x40f8, 0x4c00
+ax_pose -1, 0x41f8, 0x40f1, 0x4c04
+ax_pose -1, 0x41f7, 0x00f2, 0x4c08
+ax_pose -1, 0x01f8, 0x00f1, 0x4c0a
+ax_pose -1, 0x41f4, 0x40eb, 0x4c00
+ax_pose -1, 0x41f5, 0x40e4, 0x4c04
+ax_pose -1, 0x41f4, 0x00e5, 0x4c08
+ax_pose -1, 0x01f5, 0x00e4, 0x4c0a
+ax_pose_terminator
+sDugtrioPose10:
+ax_pose 0, 0x0205, 0x00f3, 0x4c00
+ax_pose 2, 0x4200, 0x00f5, 0x4c01
+ax_pose 1, 0x41fc, 0x40f4, 0x4c03
+ax_pose -1, 0x01f7, 0x0105, 0x4c00
+ax_pose -1, 0x0204, 0x00ea, 0x4c00
+ax_pose -1, 0x41ff, 0x00ec, 0x4c01
+ax_pose -1, 0x41fb, 0x40eb, 0x4c03
+ax_pose -1, 0x01f6, 0x00fc, 0x4c00
+ax_pose -1, 0x01fd, 0x00ed, 0x4c00
+ax_pose -1, 0x41f8, 0x00ef, 0x4c01
+ax_pose -1, 0x41f4, 0x40ee, 0x4c03
+ax_pose -1, 0x01ef, 0x00ff, 0x4c00
+ax_pose_terminator
+sDugtrioPose11:
+ax_pose 5, 0x0207, 0x00f1, 0x4c00
+ax_pose 3, 0x4203, 0x00f3, 0x4c01
+ax_pose 4, 0x41fd, 0x40f2, 0x4c03
+ax_pose -1, 0x41f8, 0x0101, 0x4c01
+ax_pose -1, 0x0206, 0x00e8, 0x4c00
+ax_pose -1, 0x4202, 0x00ea, 0x4c01
+ax_pose -1, 0x41fc, 0x40e9, 0x4c03
+ax_pose -1, 0x41f7, 0x00f8, 0x4c01
+ax_pose -1, 0x01ff, 0x00eb, 0x4c00
+ax_pose -1, 0x41fb, 0x00ed, 0x4c01
+ax_pose -1, 0x41f5, 0x40ec, 0x4c03
+ax_pose -1, 0x41f0, 0x00fb, 0x4c01
+ax_pose_terminator
+sDugtrioPose12:
+ax_pose 8, 0x0209, 0x00ef, 0x4c00
+ax_pose 7, 0x4205, 0x00f1, 0x4c01
+ax_pose 6, 0x41ff, 0x40f0, 0x4c03
+ax_pose 4, 0x41f9, 0x40f7, 0x4c07
+ax_pose -1, 0x0208, 0x00e6, 0x4c00
+ax_pose -1, 0x4204, 0x00e8, 0x4c01
+ax_pose -1, 0x41fe, 0x40e7, 0x4c03
+ax_pose -1, 0x41f8, 0x40ee, 0x4c07
+ax_pose -1, 0x0201, 0x00e9, 0x4c00
+ax_pose -1, 0x41fd, 0x00eb, 0x4c01
+ax_pose -1, 0x41f7, 0x40ea, 0x4c03
+ax_pose -1, 0x41f1, 0x40f1, 0x4c07
+ax_pose_terminator
+sDugtrioPose13:
+ax_pose 0, 0x0209, 0x00fa, 0x4c00
+ax_pose 2, 0x4203, 0x00f6, 0x4c01
+ax_pose 1, 0x41fe, 0x40ee, 0x4c03
+ax_pose -1, 0x01f9, 0x00fa, 0x4c00
+ax_pose -1, 0x0203, 0x0103, 0x4c00
+ax_pose -1, 0x41fd, 0x00ff, 0x4c01
+ax_pose -1, 0x41f8, 0x40f7, 0x4c03
+ax_pose -1, 0x01f3, 0x0103, 0x4c00
+ax_pose -1, 0x01ff, 0x00f7, 0x4c00
+ax_pose -1, 0x41f9, 0x00f3, 0x4c01
+ax_pose -1, 0x41f4, 0x40eb, 0x4c03
+ax_pose -1, 0x01ef, 0x00f7, 0x4c00
+ax_pose_terminator
+sDugtrioPose14:
+ax_pose 5, 0x020b, 0x00fa, 0x4c00
+ax_pose 3, 0x4206, 0x00f6, 0x4c01
+ax_pose 4, 0x4200, 0x40ee, 0x4c03
+ax_pose -1, 0x41fb, 0x00f6, 0x4c01
+ax_pose -1, 0x0205, 0x0103, 0x4c00
+ax_pose -1, 0x4200, 0x00ff, 0x4c01
+ax_pose -1, 0x41fa, 0x40f7, 0x4c03
+ax_pose -1, 0x41f5, 0x00ff, 0x4c01
+ax_pose -1, 0x0201, 0x00f7, 0x4c00
+ax_pose -1, 0x41fc, 0x00f3, 0x4c01
+ax_pose -1, 0x41f6, 0x40eb, 0x4c03
+ax_pose -1, 0x41f1, 0x00f3, 0x4c01
+ax_pose_terminator
+sDugtrioPose15:
+ax_pose 8, 0x020c, 0x00fa, 0x4c00
+ax_pose 7, 0x4208, 0x00f6, 0x4c01
+ax_pose 6, 0x4202, 0x40ee, 0x4c03
+ax_pose 4, 0x41fc, 0x40ee, 0x4c07
+ax_pose -1, 0x0206, 0x0103, 0x4c00
+ax_pose -1, 0x4202, 0x00ff, 0x4c01
+ax_pose -1, 0x41fc, 0x40f7, 0x4c03
+ax_pose -1, 0x41f6, 0x40f7, 0x4c07
+ax_pose -1, 0x0202, 0x00f7, 0x4c00
+ax_pose -1, 0x41fe, 0x00f3, 0x4c01
+ax_pose -1, 0x41f8, 0x40eb, 0x4c03
+ax_pose -1, 0x41f2, 0x40eb, 0x4c07
+ax_pose_terminator
+sDugtrioPose16:
+ax_pose 0, 0x0206, 0x1109, 0x4c00
+ax_pose 2, 0x4201, 0x10ff, 0x4c01
+ax_pose 1, 0x41fd, 0x50f0, 0x4c03
+ax_pose -1, 0x01f8, 0x10f7, 0x4c00
+ax_pose -1, 0x01fd, 0x1103, 0x4c00
+ax_pose -1, 0x41f8, 0x10f9, 0x4c01
+ax_pose -1, 0x41f4, 0x50ea, 0x4c03
+ax_pose -1, 0x01ef, 0x10f1, 0x4c00
+ax_pose -1, 0x01fe, 0x110e, 0x4c00
+ax_pose -1, 0x41f9, 0x1104, 0x4c01
+ax_pose -1, 0x41f5, 0x50f5, 0x4c03
+ax_pose -1, 0x01f0, 0x10fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose17:
+ax_pose 5, 0x0208, 0x110b, 0x4c00
+ax_pose 3, 0x4204, 0x1101, 0x4c01
+ax_pose 4, 0x41fe, 0x50f2, 0x4c03
+ax_pose -1, 0x41f9, 0x10f3, 0x4c01
+ax_pose -1, 0x01ff, 0x1105, 0x4c00
+ax_pose -1, 0x41fb, 0x10fb, 0x4c01
+ax_pose -1, 0x41f5, 0x50ec, 0x4c03
+ax_pose -1, 0x41f0, 0x10ed, 0x4c01
+ax_pose -1, 0x0200, 0x1110, 0x4c00
+ax_pose -1, 0x41fc, 0x1106, 0x4c01
+ax_pose -1, 0x41f6, 0x50f7, 0x4c03
+ax_pose -1, 0x41f1, 0x10f8, 0x4c01
+ax_pose_terminator
+sDugtrioPose18:
+ax_pose 8, 0x020a, 0x110d, 0x4c00
+ax_pose 7, 0x4206, 0x1103, 0x4c01
+ax_pose 6, 0x4200, 0x50f4, 0x4c03
+ax_pose 4, 0x41f9, 0x50ef, 0x4c07
+ax_pose -1, 0x0201, 0x1107, 0x4c00
+ax_pose -1, 0x41fd, 0x10fd, 0x4c01
+ax_pose -1, 0x41f7, 0x50ee, 0x4c03
+ax_pose -1, 0x41f1, 0x50e7, 0x4c07
+ax_pose -1, 0x0202, 0x1112, 0x4c00
+ax_pose -1, 0x41fe, 0x1108, 0x4c01
+ax_pose -1, 0x41f8, 0x50f9, 0x4c03
+ax_pose -1, 0x41f2, 0x50f2, 0x4c07
+ax_pose_terminator
+sDugtrioPose19:
+ax_pose 0, 0x01fe, 0x10f9, 0x4c00
+ax_pose 1, 0x41fd, 0x50f4, 0x4c01
+ax_pose 2, 0x41fe, 0x1103, 0x4c05
+ax_pose -1, 0x01fd, 0x110e, 0x4c00
+ax_pose -1, 0x01fa, 0x10f1, 0x4c00
+ax_pose -1, 0x41f9, 0x50ec, 0x4c01
+ax_pose -1, 0x41fa, 0x10fb, 0x4c05
+ax_pose -1, 0x01f9, 0x1106, 0x4c00
+ax_pose -1, 0x01f5, 0x10f6, 0x4c00
+ax_pose -1, 0x41f4, 0x50f1, 0x4c01
+ax_pose -1, 0x41f5, 0x1100, 0x4c05
+ax_pose -1, 0x01f4, 0x110b, 0x4c00
+ax_pose_terminator
+sDugtrioPose20:
+ax_pose 3, 0x41fe, 0x10f8, 0x4c00
+ax_pose 4, 0x41fd, 0x50f7, 0x4c02
+ax_pose -1, 0x41fe, 0x1105, 0x4c00
+ax_pose 5, 0x01fe, 0x1110, 0x4c06
+ax_pose -1, 0x41fa, 0x10f0, 0x4c00
+ax_pose -1, 0x41f9, 0x50ef, 0x4c02
+ax_pose -1, 0x41fa, 0x10fd, 0x4c00
+ax_pose -1, 0x01fa, 0x1108, 0x4c06
+ax_pose -1, 0x41f5, 0x10f5, 0x4c00
+ax_pose -1, 0x41f4, 0x50f4, 0x4c02
+ax_pose -1, 0x41f5, 0x1102, 0x4c00
+ax_pose -1, 0x01f5, 0x110d, 0x4c06
+ax_pose_terminator
+sDugtrioPose21:
+ax_pose 4, 0x41fd, 0x50f2, 0x4c00
+ax_pose 6, 0x41fe, 0x50f9, 0x4c04
+ax_pose 7, 0x41fd, 0x1108, 0x4c08
+ax_pose 8, 0x01fe, 0x1111, 0x4c0a
+ax_pose -1, 0x41f9, 0x50ea, 0x4c00
+ax_pose -1, 0x41fa, 0x50f1, 0x4c04
+ax_pose -1, 0x41f9, 0x1100, 0x4c08
+ax_pose -1, 0x01fa, 0x1109, 0x4c0a
+ax_pose -1, 0x41f4, 0x50ef, 0x4c00
+ax_pose -1, 0x41f5, 0x50f6, 0x4c04
+ax_pose -1, 0x41f4, 0x1105, 0x4c08
+ax_pose -1, 0x01f5, 0x110e, 0x4c0a
+ax_pose_terminator
+sDugtrioPose22:
+ax_pose 0, 0x0201, 0x10f7, 0x4c00
+ax_pose 1, 0x41fc, 0x50f1, 0x4c01
+ax_pose 2, 0x41f5, 0x10ff, 0x4c05
+ax_pose -1, 0x01f1, 0x1108, 0x4c00
+ax_pose -1, 0x01f9, 0x10f9, 0x4c00
+ax_pose -1, 0x41f4, 0x50f3, 0x4c01
+ax_pose -1, 0x41ed, 0x1101, 0x4c05
+ax_pose -1, 0x01e9, 0x110a, 0x4c00
+ax_pose -1, 0x01fa, 0x10ef, 0x4c00
+ax_pose -1, 0x41f5, 0x50e9, 0x4c01
+ax_pose -1, 0x41ee, 0x10f7, 0x4c05
+ax_pose -1, 0x01ea, 0x1100, 0x4c00
+ax_pose_terminator
+sDugtrioPose23:
+ax_pose 3, 0x4200, 0x10f6, 0x4c00
+ax_pose 4, 0x41fa, 0x50f3, 0x4c02
+ax_pose -1, 0x41f5, 0x1101, 0x4c00
+ax_pose 5, 0x01f0, 0x110a, 0x4c06
+ax_pose -1, 0x41f8, 0x10f8, 0x4c00
+ax_pose -1, 0x41f2, 0x50f5, 0x4c02
+ax_pose -1, 0x41ed, 0x1103, 0x4c00
+ax_pose -1, 0x01e8, 0x110c, 0x4c06
+ax_pose -1, 0x41f9, 0x10ee, 0x4c00
+ax_pose -1, 0x41f3, 0x50eb, 0x4c02
+ax_pose -1, 0x41ee, 0x10f9, 0x4c00
+ax_pose -1, 0x01e9, 0x1102, 0x4c06
+ax_pose_terminator
+sDugtrioPose24:
+ax_pose 4, 0x41fe, 0x50ef, 0x4c00
+ax_pose 6, 0x41f9, 0x50f4, 0x4c04
+ax_pose 7, 0x41f4, 0x1102, 0x4c08
+ax_pose 8, 0x01ef, 0x110b, 0x4c0a
+ax_pose -1, 0x41f6, 0x50f1, 0x4c00
+ax_pose -1, 0x41f1, 0x50f6, 0x4c04
+ax_pose -1, 0x41ec, 0x1104, 0x4c08
+ax_pose -1, 0x01e7, 0x110d, 0x4c0a
+ax_pose -1, 0x41f7, 0x50e7, 0x4c00
+ax_pose -1, 0x41f2, 0x50ec, 0x4c04
+ax_pose -1, 0x41ed, 0x10fa, 0x4c08
+ax_pose -1, 0x01e8, 0x1103, 0x4c0a
+ax_pose_terminator
+sDugtrioPose25:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01f7, 0x00fc, 0x4c10
+ax_pose 1, 0x41f2, 0x40f0, 0x4c11
+ax_pose 2, 0x41eb, 0x00f8, 0x4c15
+ax_pose -1, 0x01e7, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose26:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41f6, 0x00f8, 0x4c10
+ax_pose 4, 0x41ef, 0x40f0, 0x4c12
+ax_pose -1, 0x41ea, 0x00f8, 0x4c10
+ax_pose 5, 0x01e5, 0x00fc, 0x4c16
+ax_pose_terminator
+sDugtrioPose27:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41f4, 0x40f0, 0x4c10
+ax_pose 6, 0x41ee, 0x40f0, 0x4c14
+ax_pose 7, 0x41e9, 0x00f8, 0x4c18
+ax_pose 8, 0x01e4, 0x00fc, 0x4c1a
+ax_pose_terminator
+sDugtrioPose28:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose29:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose30:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose31:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x020c, 0x00fc, 0x4c10
+ax_pose 2, 0x4206, 0x00f8, 0x4c11
+ax_pose 1, 0x4201, 0x40f0, 0x4c13
+ax_pose -1, 0x01fc, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose32:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fe, 0x00fd, 0x4c10
+ax_pose 1, 0x41f9, 0x40eb, 0x4c11
+ax_pose 2, 0x41f2, 0x00ed, 0x4c15
+ax_pose -1, 0x01ee, 0x00ec, 0x4c10
+ax_pose_terminator
+sDugtrioPose33:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fd, 0x00f6, 0x4c10
+ax_pose 4, 0x41f7, 0x40e9, 0x4c12
+ax_pose -1, 0x41f2, 0x00eb, 0x4c10
+ax_pose 5, 0x01ed, 0x00ea, 0x4c16
+ax_pose_terminator
+sDugtrioPose34:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x40ed, 0x4c10
+ax_pose 6, 0x41f6, 0x40e8, 0x4c14
+ax_pose 7, 0x41f1, 0x00ea, 0x4c18
+ax_pose 8, 0x01ec, 0x00e9, 0x4c1a
+ax_pose_terminator
+sDugtrioPose35:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose36:
+ax_pose 14, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose37:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose38:
+ax_pose 14, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0206, 0x110d, 0x4c10
+ax_pose 2, 0x4201, 0x1103, 0x4c11
+ax_pose 1, 0x41fd, 0x50f4, 0x4c13
+ax_pose -1, 0x01f8, 0x10fb, 0x4c10
+ax_pose_terminator
+sDugtrioPose39:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x00f5, 0x4c10
+ax_pose 1, 0x41fb, 0x40e2, 0x4c11
+ax_pose 2, 0x41fc, 0x00e3, 0x4c15
+ax_pose -1, 0x01fb, 0x00e0, 0x4c10
+ax_pose_terminator
+sDugtrioPose40:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fc, 0x00ee, 0x4c10
+ax_pose 4, 0x41fb, 0x40df, 0x4c12
+ax_pose -1, 0x41fc, 0x00e1, 0x4c10
+ax_pose 5, 0x01fc, 0x00de, 0x4c16
+ax_pose_terminator
+sDugtrioPose41:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x40e4, 0x4c10
+ax_pose 6, 0x41fc, 0x40dd, 0x4c14
+ax_pose 7, 0x41fb, 0x00de, 0x4c18
+ax_pose 8, 0x01fc, 0x00dd, 0x4c1a
+ax_pose_terminator
+sDugtrioPose42:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose43:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose44:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose45:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x1103, 0x4c10
+ax_pose 1, 0x41fb, 0x50fe, 0x4c11
+ax_pose 2, 0x41fc, 0x110d, 0x4c15
+ax_pose -1, 0x01fb, 0x1118, 0x4c10
+ax_pose_terminator
+sDugtrioPose46:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0209, 0x00ea, 0x4c10
+ax_pose 2, 0x4204, 0x00ec, 0x4c11
+ax_pose 1, 0x4200, 0x40eb, 0x4c13
+ax_pose -1, 0x01fb, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose47:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose 5, 0x020b, 0x00e8, 0x4c10
+ax_pose 3, 0x4207, 0x00ea, 0x4c11
+ax_pose 4, 0x4201, 0x40e9, 0x4c13
+ax_pose -1, 0x41fc, 0x00f8, 0x4c11
+ax_pose_terminator
+sDugtrioPose48:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose 8, 0x020d, 0x00e6, 0x4c10
+ax_pose 7, 0x4209, 0x00e8, 0x4c11
+ax_pose 6, 0x4203, 0x40e7, 0x4c13
+ax_pose 4, 0x41fd, 0x40ee, 0x4c17
+ax_pose_terminator
+sDugtrioPose49:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose50:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose51:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose52:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fe, 0x10fd, 0x4c10
+ax_pose 1, 0x41f9, 0x50f7, 0x4c11
+ax_pose 2, 0x41f2, 0x1105, 0x4c15
+ax_pose -1, 0x01ee, 0x110e, 0x4c10
+ax_pose_terminator
+sDugtrioPose53:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x020e, 0x00fc, 0x4c10
+ax_pose 2, 0x4208, 0x00f8, 0x4c11
+ax_pose 1, 0x4203, 0x40f0, 0x4c13
+ax_pose -1, 0x01fe, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose54:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose 5, 0x0210, 0x00fc, 0x4c10
+ax_pose 3, 0x420b, 0x00f8, 0x4c11
+ax_pose 4, 0x4205, 0x40f0, 0x4c13
+ax_pose -1, 0x4200, 0x00f8, 0x4c11
+ax_pose_terminator
+sDugtrioPose55:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose 8, 0x0211, 0x00fc, 0x4c10
+ax_pose 7, 0x420d, 0x00f8, 0x4c11
+ax_pose 6, 0x4207, 0x40f0, 0x4c13
+ax_pose 4, 0x4201, 0x40f0, 0x4c17
+ax_pose_terminator
+sDugtrioPose56:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose57:
+ax_pose 23, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose58:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose59:
+ax_pose 23, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01f7, 0x00fc, 0x4c10
+ax_pose 1, 0x41f2, 0x40f0, 0x4c11
+ax_pose 2, 0x41eb, 0x00f8, 0x4c15
+ax_pose -1, 0x01e7, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose60:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0209, 0x110e, 0x4c10
+ax_pose 2, 0x4204, 0x1104, 0x4c11
+ax_pose 1, 0x4200, 0x50f5, 0x4c13
+ax_pose -1, 0x01fb, 0x10fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose61:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose 5, 0x020b, 0x1110, 0x4c10
+ax_pose 3, 0x4207, 0x1106, 0x4c11
+ax_pose 4, 0x4201, 0x50f7, 0x4c13
+ax_pose -1, 0x41fc, 0x10f8, 0x4c11
+ax_pose_terminator
+sDugtrioPose62:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose 8, 0x020d, 0x1112, 0x4c10
+ax_pose 7, 0x4209, 0x1108, 0x4c11
+ax_pose 6, 0x4203, 0x50f9, 0x4c13
+ax_pose 4, 0x41fd, 0x50f2, 0x4c17
+ax_pose_terminator
+sDugtrioPose63:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose64:
+ax_pose 26, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose65:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose66:
+ax_pose 26, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fd, 0x00fb, 0x4c10
+ax_pose 1, 0x41f8, 0x40e9, 0x4c11
+ax_pose 2, 0x41f1, 0x00eb, 0x4c15
+ax_pose -1, 0x01ed, 0x00ea, 0x4c10
+ax_pose_terminator
+sDugtrioPose67:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x1103, 0x4c10
+ax_pose 1, 0x41fb, 0x50fe, 0x4c11
+ax_pose 2, 0x41fc, 0x110d, 0x4c15
+ax_pose -1, 0x01fb, 0x1118, 0x4c10
+ax_pose_terminator
+sDugtrioPose68:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fc, 0x1102, 0x4c10
+ax_pose 4, 0x41fb, 0x5101, 0x4c12
+ax_pose -1, 0x41fc, 0x110f, 0x4c10
+ax_pose 5, 0x01fc, 0x111a, 0x4c16
+ax_pose_terminator
+sDugtrioPose69:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x50fc, 0x4c10
+ax_pose 6, 0x41fc, 0x5103, 0x4c14
+ax_pose 7, 0x41fb, 0x1112, 0x4c18
+ax_pose 8, 0x01fc, 0x111b, 0x4c1a
+ax_pose_terminator
+sDugtrioPose70:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose71:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose72:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose73:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x00f5, 0x4c10
+ax_pose 1, 0x41fb, 0x40e2, 0x4c11
+ax_pose 2, 0x41fc, 0x00e3, 0x4c15
+ax_pose -1, 0x01fb, 0x00e0, 0x4c10
+ax_pose_terminator
+sDugtrioPose74:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fe, 0x10fb, 0x4c10
+ax_pose 1, 0x41f9, 0x50f5, 0x4c11
+ax_pose 2, 0x41f2, 0x1103, 0x4c15
+ax_pose -1, 0x01ee, 0x110c, 0x4c10
+ax_pose_terminator
+sDugtrioPose75:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fd, 0x10fa, 0x4c10
+ax_pose 4, 0x41f7, 0x50f7, 0x4c12
+ax_pose -1, 0x41f2, 0x1105, 0x4c10
+ax_pose 5, 0x01ed, 0x110e, 0x4c16
+ax_pose_terminator
+sDugtrioPose76:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x50f3, 0x4c10
+ax_pose 6, 0x41f6, 0x50f8, 0x4c14
+ax_pose 7, 0x41f1, 0x1106, 0x4c18
+ax_pose 8, 0x01ec, 0x110f, 0x4c1a
+ax_pose_terminator
+sDugtrioPose77:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose78:
+ax_pose 32, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose79:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose80:
+ax_pose 32, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0205, 0x00ea, 0x4c10
+ax_pose 2, 0x4200, 0x00ec, 0x4c11
+ax_pose 1, 0x41fc, 0x40eb, 0x4c13
+ax_pose -1, 0x01f7, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose81:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01f7, 0x00fc, 0x4c10
+ax_pose 1, 0x41f2, 0x40f0, 0x4c11
+ax_pose 2, 0x41eb, 0x00f8, 0x4c15
+ax_pose -1, 0x01e7, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose82:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41f6, 0x00f8, 0x4c10
+ax_pose 4, 0x41ef, 0x40f0, 0x4c12
+ax_pose -1, 0x41ea, 0x00f8, 0x4c10
+ax_pose 5, 0x01e5, 0x00fc, 0x4c16
+ax_pose_terminator
+sDugtrioPose83:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41f4, 0x40f0, 0x4c10
+ax_pose 6, 0x41ee, 0x40f0, 0x4c14
+ax_pose 7, 0x41e9, 0x00f8, 0x4c18
+ax_pose 8, 0x01e4, 0x00fc, 0x4c1a
+ax_pose_terminator
+sDugtrioPose84:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose85:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose86:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose87:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x020c, 0x00fc, 0x4c10
+ax_pose 2, 0x4206, 0x00f8, 0x4c11
+ax_pose 1, 0x4201, 0x40f0, 0x4c13
+ax_pose -1, 0x01fc, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose88:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fe, 0x00fd, 0x4c10
+ax_pose 1, 0x41f9, 0x40eb, 0x4c11
+ax_pose 2, 0x41f2, 0x00ed, 0x4c15
+ax_pose -1, 0x01ee, 0x00ec, 0x4c10
+ax_pose_terminator
+sDugtrioPose89:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fd, 0x00f6, 0x4c10
+ax_pose 4, 0x41f7, 0x40e9, 0x4c12
+ax_pose -1, 0x41f2, 0x00eb, 0x4c10
+ax_pose 5, 0x01ed, 0x00ea, 0x4c16
+ax_pose_terminator
+sDugtrioPose90:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x40ed, 0x4c10
+ax_pose 6, 0x41f6, 0x40e8, 0x4c14
+ax_pose 7, 0x41f1, 0x00ea, 0x4c18
+ax_pose 8, 0x01ec, 0x00e9, 0x4c1a
+ax_pose_terminator
+sDugtrioPose91:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose92:
+ax_pose 14, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose93:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose94:
+ax_pose 14, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0206, 0x110d, 0x4c10
+ax_pose 2, 0x4201, 0x1103, 0x4c11
+ax_pose 1, 0x41fd, 0x50f4, 0x4c13
+ax_pose -1, 0x01f8, 0x10fb, 0x4c10
+ax_pose_terminator
+sDugtrioPose95:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x00f5, 0x4c10
+ax_pose 1, 0x41fb, 0x40e2, 0x4c11
+ax_pose 2, 0x41fc, 0x00e3, 0x4c15
+ax_pose -1, 0x01fb, 0x00e0, 0x4c10
+ax_pose_terminator
+sDugtrioPose96:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fc, 0x00ee, 0x4c10
+ax_pose 4, 0x41fb, 0x40df, 0x4c12
+ax_pose -1, 0x41fc, 0x00e1, 0x4c10
+ax_pose 5, 0x01fc, 0x00de, 0x4c16
+ax_pose_terminator
+sDugtrioPose97:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x40e4, 0x4c10
+ax_pose 6, 0x41fc, 0x40dd, 0x4c14
+ax_pose 7, 0x41fb, 0x00de, 0x4c18
+ax_pose 8, 0x01fc, 0x00dd, 0x4c1a
+ax_pose_terminator
+sDugtrioPose98:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose99:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose100:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose101:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x1103, 0x4c10
+ax_pose 1, 0x41fb, 0x50fe, 0x4c11
+ax_pose 2, 0x41fc, 0x110d, 0x4c15
+ax_pose -1, 0x01fb, 0x1118, 0x4c10
+ax_pose_terminator
+sDugtrioPose102:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0209, 0x00ea, 0x4c10
+ax_pose 2, 0x4204, 0x00ec, 0x4c11
+ax_pose 1, 0x4200, 0x40eb, 0x4c13
+ax_pose -1, 0x01fb, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose103:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose 5, 0x020b, 0x00e8, 0x4c10
+ax_pose 3, 0x4207, 0x00ea, 0x4c11
+ax_pose 4, 0x4201, 0x40e9, 0x4c13
+ax_pose -1, 0x41fc, 0x00f8, 0x4c11
+ax_pose_terminator
+sDugtrioPose104:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose 8, 0x020d, 0x00e6, 0x4c10
+ax_pose 7, 0x4209, 0x00e8, 0x4c11
+ax_pose 6, 0x4203, 0x40e7, 0x4c13
+ax_pose 4, 0x41fd, 0x40ee, 0x4c17
+ax_pose_terminator
+sDugtrioPose105:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose106:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose107:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose108:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fe, 0x10fd, 0x4c10
+ax_pose 1, 0x41f9, 0x50f7, 0x4c11
+ax_pose 2, 0x41f2, 0x1105, 0x4c15
+ax_pose -1, 0x01ee, 0x110e, 0x4c10
+ax_pose_terminator
+sDugtrioPose109:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x020e, 0x00fc, 0x4c10
+ax_pose 2, 0x4208, 0x00f8, 0x4c11
+ax_pose 1, 0x4203, 0x40f0, 0x4c13
+ax_pose -1, 0x01fe, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose110:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose 5, 0x0210, 0x00fc, 0x4c10
+ax_pose 3, 0x420b, 0x00f8, 0x4c11
+ax_pose 4, 0x4205, 0x40f0, 0x4c13
+ax_pose -1, 0x4200, 0x00f8, 0x4c11
+ax_pose_terminator
+sDugtrioPose111:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose 8, 0x0211, 0x00fc, 0x4c10
+ax_pose 7, 0x420d, 0x00f8, 0x4c11
+ax_pose 6, 0x4207, 0x40f0, 0x4c13
+ax_pose 4, 0x4201, 0x40f0, 0x4c17
+ax_pose_terminator
+sDugtrioPose112:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose113:
+ax_pose 23, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose114:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose115:
+ax_pose 23, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01f7, 0x00fc, 0x4c10
+ax_pose 1, 0x41f2, 0x40f0, 0x4c11
+ax_pose 2, 0x41eb, 0x00f8, 0x4c15
+ax_pose -1, 0x01e7, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose116:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0209, 0x110e, 0x4c10
+ax_pose 2, 0x4204, 0x1104, 0x4c11
+ax_pose 1, 0x4200, 0x50f5, 0x4c13
+ax_pose -1, 0x01fb, 0x10fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose117:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose 5, 0x020b, 0x1110, 0x4c10
+ax_pose 3, 0x4207, 0x1106, 0x4c11
+ax_pose 4, 0x4201, 0x50f7, 0x4c13
+ax_pose -1, 0x41fc, 0x10f8, 0x4c11
+ax_pose_terminator
+sDugtrioPose118:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose 8, 0x020d, 0x1112, 0x4c10
+ax_pose 7, 0x4209, 0x1108, 0x4c11
+ax_pose 6, 0x4203, 0x50f9, 0x4c13
+ax_pose 4, 0x41fd, 0x50f2, 0x4c17
+ax_pose_terminator
+sDugtrioPose119:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose120:
+ax_pose 26, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose121:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose122:
+ax_pose 26, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fd, 0x00fb, 0x4c10
+ax_pose 1, 0x41f8, 0x40e9, 0x4c11
+ax_pose 2, 0x41f1, 0x00eb, 0x4c15
+ax_pose -1, 0x01ed, 0x00ea, 0x4c10
+ax_pose_terminator
+sDugtrioPose123:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x1103, 0x4c10
+ax_pose 1, 0x41fb, 0x50fe, 0x4c11
+ax_pose 2, 0x41fc, 0x110d, 0x4c15
+ax_pose -1, 0x01fb, 0x1118, 0x4c10
+ax_pose_terminator
+sDugtrioPose124:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fc, 0x1102, 0x4c10
+ax_pose 4, 0x41fb, 0x5101, 0x4c12
+ax_pose -1, 0x41fc, 0x110f, 0x4c10
+ax_pose 5, 0x01fc, 0x111a, 0x4c16
+ax_pose_terminator
+sDugtrioPose125:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x50fc, 0x4c10
+ax_pose 6, 0x41fc, 0x5103, 0x4c14
+ax_pose 7, 0x41fb, 0x1112, 0x4c18
+ax_pose 8, 0x01fc, 0x111b, 0x4c1a
+ax_pose_terminator
+sDugtrioPose126:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose127:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose128:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose129:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fc, 0x00f5, 0x4c10
+ax_pose 1, 0x41fb, 0x40e2, 0x4c11
+ax_pose 2, 0x41fc, 0x00e3, 0x4c15
+ax_pose -1, 0x01fb, 0x00e0, 0x4c10
+ax_pose_terminator
+sDugtrioPose130:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x01fe, 0x10fb, 0x4c10
+ax_pose 1, 0x41f9, 0x50f5, 0x4c11
+ax_pose 2, 0x41f2, 0x1103, 0x4c15
+ax_pose -1, 0x01ee, 0x110c, 0x4c10
+ax_pose_terminator
+sDugtrioPose131:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose 3, 0x41fd, 0x10fa, 0x4c10
+ax_pose 4, 0x41f7, 0x50f7, 0x4c12
+ax_pose -1, 0x41f2, 0x1105, 0x4c10
+ax_pose 5, 0x01ed, 0x110e, 0x4c16
+ax_pose_terminator
+sDugtrioPose132:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose 4, 0x41fb, 0x50f3, 0x4c10
+ax_pose 6, 0x41f6, 0x50f8, 0x4c14
+ax_pose 7, 0x41f1, 0x1106, 0x4c18
+ax_pose 8, 0x01ec, 0x110f, 0x4c1a
+ax_pose_terminator
+sDugtrioPose133:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose134:
+ax_pose 32, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose135:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose136:
+ax_pose 32, 0x01e9, 0x80f0, 0x4c00
+ax_pose 0, 0x0205, 0x00ea, 0x4c10
+ax_pose 2, 0x4200, 0x00ec, 0x4c11
+ax_pose 1, 0x41fc, 0x40eb, 0x4c13
+ax_pose -1, 0x01f7, 0x00fc, 0x4c10
+ax_pose_terminator
+sDugtrioPose137:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose138:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose139:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose140:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose141:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose142:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose143:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose144:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose145:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose146:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose147:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose148:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose149:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose150:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose151:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose152:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose153:
+ax_pose 33, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose154:
+ax_pose 34, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose155:
+ax_pose 35, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose156:
+ax_pose 36, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose157:
+ax_pose 37, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose158:
+ax_pose 38, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose159:
+ax_pose 39, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose160:
+ax_pose 38, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose161:
+ax_pose 37, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose162:
+ax_pose 36, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose163:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose164:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose165:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose166:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose167:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose168:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose169:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose170:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose171:
+ax_pose 40, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose172:
+ax_pose 41, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose173:
+ax_pose 42, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose174:
+ax_pose 43, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose175:
+ax_pose 44, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose176:
+ax_pose 45, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose177:
+ax_pose 46, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose178:
+ax_pose 47, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose179:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose180:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose181:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose182:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose183:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose184:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose185:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose186:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose187:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose188:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose189:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose190:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose191:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose192:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose193:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose194:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose195:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose196:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose197:
+ax_pose 9, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose198:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose199:
+ax_pose 14, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose200:
+ax_pose 12, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose201:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose202:
+ax_pose 17, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose203:
+ax_pose 15, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose204:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose205:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose206:
+ax_pose 18, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose207:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose208:
+ax_pose 23, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose209:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose210:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose211:
+ax_pose 26, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose212:
+ax_pose 24, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose213:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose214:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose215:
+ax_pose 27, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose216:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose217:
+ax_pose 32, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose218:
+ax_pose 30, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose219:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose220:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose221:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose222:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose223:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose224:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose225:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose226:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose227:
+ax_pose 10, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose228:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose229:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose230:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose231:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose232:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose233:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose234:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose235:
+ax_pose 8, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f6, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose236:
+ax_pose 5, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f6, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose237:
+ax_pose 0, 0x01fd, 0x00ff, 0x4c00
+ax_pose 8, 0x01fa, 0x00f7, 0x4c01
+ax_pose -1, 0x01f5, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose238:
+ax_pose 7, 0x41fe, 0x00fb, 0x4c00
+ax_pose 5, 0x01fa, 0x00f7, 0x4c02
+ax_pose -1, 0x41f6, 0x00f9, 0x4c00
+ax_pose_terminator
+sDugtrioPose239:
+ax_pose 3, 0x41fe, 0x00fb, 0x4c00
+ax_pose 0, 0x01f9, 0x00f7, 0x4c02
+ax_pose -1, 0x41f6, 0x00f9, 0x4c00
+ax_pose_terminator
+sDugtrioPose240:
+ax_pose 2, 0x41fd, 0x00fb, 0x4c00
+ax_pose 7, 0x41fa, 0x00f3, 0x4c02
+ax_pose -1, 0x41f5, 0x00f9, 0x4c00
+ax_pose_terminator
+sDugtrioPose241:
+ax_pose 6, 0x41fd, 0x40f3, 0x4c00
+ax_pose 3, 0x41fa, 0x00f3, 0x4c04
+ax_pose -1, 0x41f5, 0x40f1, 0x4c00
+ax_pose_terminator
+sDugtrioPose242:
+ax_pose 4, 0x41fd, 0x40f3, 0x4c00
+ax_pose 2, 0x41f9, 0x00f3, 0x4c04
+ax_pose -1, 0x41f5, 0x40f1, 0x4c00
+ax_pose_terminator
+sDugtrioPose243:
+ax_pose 1, 0x41fd, 0x40f3, 0x4c00
+ax_pose 6, 0x41f9, 0x40eb, 0x4c04
+ax_pose -1, 0x41f5, 0x40f1, 0x4c00
+ax_pose_terminator
+sDugtrioPose244:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41f9, 0x40eb, 0x4c03
+ax_pose_terminator
+sDugtrioPose245:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41f9, 0x40eb, 0x4c03
+ax_pose 10, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose246:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose247:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose248:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose249:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose250:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose251:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose252:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose253:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose254:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 10, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose255:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 10, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose256:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 10, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose257:
+ax_pose 8, 0x01fc, 0x0103, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose258:
+ax_pose 5, 0x01fc, 0x0103, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose259:
+ax_pose 0, 0x01fb, 0x0103, 0x4c00
+ax_pose 8, 0x01fd, 0x00f7, 0x4c01
+ax_pose -1, 0x01f5, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose260:
+ax_pose 7, 0x41fc, 0x00ff, 0x4c00
+ax_pose 5, 0x01fd, 0x00f7, 0x4c02
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose261:
+ax_pose 3, 0x41fc, 0x00ff, 0x4c00
+ax_pose 0, 0x01fc, 0x00f7, 0x4c02
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose262:
+ax_pose 2, 0x41fb, 0x00ff, 0x4c00
+ax_pose 7, 0x41fd, 0x00f3, 0x4c02
+ax_pose -1, 0x41f5, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose263:
+ax_pose 6, 0x41fb, 0x40f7, 0x4c00
+ax_pose 3, 0x41fd, 0x00f3, 0x4c04
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose264:
+ax_pose 4, 0x41fb, 0x40f7, 0x4c00
+ax_pose 2, 0x41fc, 0x00f3, 0x4c04
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose265:
+ax_pose 1, 0x41fb, 0x40f7, 0x4c00
+ax_pose 6, 0x41fc, 0x40eb, 0x4c04
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose266:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41fc, 0x40eb, 0x4c03
+ax_pose_terminator
+sDugtrioPose267:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41fc, 0x40eb, 0x4c03
+ax_pose 13, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose268:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose269:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose270:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose271:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose272:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose273:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose274:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose275:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 13, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose276:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 13, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose277:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 13, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose278:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 13, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose279:
+ax_pose 8, 0x01ff, 0x00fb, 0x4c00
+ax_pose -1, 0x01f8, 0x0101, 0x4c00
+ax_pose_terminator
+sDugtrioPose280:
+ax_pose 5, 0x01ff, 0x00fb, 0x4c00
+ax_pose -1, 0x01f8, 0x0101, 0x4c00
+ax_pose_terminator
+sDugtrioPose281:
+ax_pose 0, 0x01fe, 0x00fb, 0x4c00
+ax_pose 8, 0x01f8, 0x00f5, 0x4c01
+ax_pose -1, 0x01f7, 0x0101, 0x4c00
+ax_pose_terminator
+sDugtrioPose282:
+ax_pose 7, 0x41ff, 0x00f7, 0x4c00
+ax_pose 5, 0x01f8, 0x00f5, 0x4c02
+ax_pose -1, 0x41f8, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose283:
+ax_pose 3, 0x41ff, 0x00f7, 0x4c00
+ax_pose 0, 0x01f7, 0x00f5, 0x4c02
+ax_pose -1, 0x41f8, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose284:
+ax_pose 2, 0x41fe, 0x00f7, 0x4c00
+ax_pose 7, 0x41f8, 0x00f1, 0x4c02
+ax_pose -1, 0x41f7, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose285:
+ax_pose 6, 0x41fe, 0x40ef, 0x4c00
+ax_pose 3, 0x41f8, 0x00f1, 0x4c04
+ax_pose -1, 0x41f7, 0x40f5, 0x4c00
+ax_pose_terminator
+sDugtrioPose286:
+ax_pose 4, 0x41fe, 0x40ef, 0x4c00
+ax_pose 2, 0x41f7, 0x00f1, 0x4c04
+ax_pose -1, 0x41f7, 0x40f5, 0x4c00
+ax_pose_terminator
+sDugtrioPose287:
+ax_pose 1, 0x41fe, 0x40ef, 0x4c00
+ax_pose 6, 0x41f7, 0x40e9, 0x4c04
+ax_pose -1, 0x41f7, 0x40f5, 0x4c00
+ax_pose_terminator
+sDugtrioPose288:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41f7, 0x40e9, 0x4c03
+ax_pose_terminator
+sDugtrioPose289:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41f7, 0x40e9, 0x4c03
+ax_pose 16, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose290:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose291:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose292:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose293:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose294:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose295:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose296:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose297:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 16, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose298:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 16, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose299:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 16, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose300:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 16, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose301:
+ax_pose 8, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f8, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose302:
+ax_pose 5, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f8, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose303:
+ax_pose 0, 0x01fd, 0x00ff, 0x4c00
+ax_pose 8, 0x01fd, 0x00f6, 0x4c01
+ax_pose -1, 0x01f7, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose304:
+ax_pose 7, 0x41fe, 0x00fb, 0x4c00
+ax_pose 5, 0x01fd, 0x00f6, 0x4c02
+ax_pose -1, 0x41f8, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose305:
+ax_pose 3, 0x41fe, 0x00fb, 0x4c00
+ax_pose 0, 0x01fc, 0x00f6, 0x4c02
+ax_pose -1, 0x41f8, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose306:
+ax_pose 2, 0x41fd, 0x00fb, 0x4c00
+ax_pose 7, 0x41fd, 0x00f2, 0x4c02
+ax_pose -1, 0x41f7, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose307:
+ax_pose 6, 0x41fd, 0x40f3, 0x4c00
+ax_pose 3, 0x41fd, 0x00f2, 0x4c04
+ax_pose -1, 0x41f7, 0x40f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose308:
+ax_pose 4, 0x41fd, 0x40f3, 0x4c00
+ax_pose 2, 0x41fc, 0x00f2, 0x4c04
+ax_pose -1, 0x41f7, 0x40f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose309:
+ax_pose 1, 0x41fd, 0x40f3, 0x4c00
+ax_pose 6, 0x41fc, 0x40ea, 0x4c04
+ax_pose -1, 0x41f7, 0x40f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose310:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41fc, 0x40ea, 0x4c03
+ax_pose_terminator
+sDugtrioPose311:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41fc, 0x40ea, 0x4c03
+ax_pose 19, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose312:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose313:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose314:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose315:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose316:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose317:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose318:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose319:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 19, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose320:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 19, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose321:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 19, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose322:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 19, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose323:
+ax_pose 8, 0x01fa, 0x0101, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose324:
+ax_pose 5, 0x01fa, 0x0101, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose325:
+ax_pose 0, 0x01f9, 0x0101, 0x4c00
+ax_pose 8, 0x01ff, 0x00f9, 0x4c01
+ax_pose -1, 0x01f5, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose326:
+ax_pose 7, 0x41fa, 0x00fd, 0x4c00
+ax_pose 5, 0x01ff, 0x00f9, 0x4c02
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose327:
+ax_pose 3, 0x41fa, 0x00fd, 0x4c00
+ax_pose 0, 0x01fe, 0x00f9, 0x4c02
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose328:
+ax_pose 2, 0x41f9, 0x00fd, 0x4c00
+ax_pose 7, 0x41ff, 0x00f5, 0x4c02
+ax_pose -1, 0x41f5, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose329:
+ax_pose 3, 0x41ff, 0x00f5, 0x4c00
+ax_pose 6, 0x41f9, 0x40f5, 0x4c02
+ax_pose -1, 0x41f5, 0x40ec, 0x4c02
+ax_pose_terminator
+sDugtrioPose330:
+ax_pose 2, 0x41fe, 0x00f5, 0x4c00
+ax_pose 4, 0x41f9, 0x40f5, 0x4c02
+ax_pose -1, 0x41f5, 0x40ec, 0x4c02
+ax_pose_terminator
+sDugtrioPose331:
+ax_pose 6, 0x41fe, 0x40ed, 0x4c00
+ax_pose 1, 0x41f9, 0x40f5, 0x4c04
+ax_pose -1, 0x41f5, 0x40ec, 0x4c04
+ax_pose_terminator
+sDugtrioPose332:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41fe, 0x40ed, 0x4c03
+ax_pose_terminator
+sDugtrioPose333:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41fe, 0x40ed, 0x4c03
+ax_pose 22, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose334:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose335:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose336:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose337:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose338:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose339:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose340:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose341:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 22, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose342:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 22, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose343:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 22, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose344:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 22, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose345:
+ax_pose 8, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f7, 0x00ff, 0x4c00
+ax_pose_terminator
+sDugtrioPose346:
+ax_pose 5, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f7, 0x00ff, 0x4c00
+ax_pose_terminator
+sDugtrioPose347:
+ax_pose 0, 0x01fd, 0x00ff, 0x4c00
+ax_pose 8, 0x01fa, 0x00f6, 0x4c01
+ax_pose -1, 0x01f6, 0x00ff, 0x4c00
+ax_pose_terminator
+sDugtrioPose348:
+ax_pose 7, 0x41fe, 0x00fb, 0x4c00
+ax_pose 5, 0x01fa, 0x00f6, 0x4c02
+ax_pose -1, 0x41f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose349:
+ax_pose 3, 0x41fe, 0x00fb, 0x4c00
+ax_pose 0, 0x01f9, 0x00f6, 0x4c02
+ax_pose -1, 0x41f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose350:
+ax_pose 2, 0x41fd, 0x00fb, 0x4c00
+ax_pose 7, 0x41fa, 0x00f2, 0x4c02
+ax_pose -1, 0x41f6, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose351:
+ax_pose 6, 0x41fd, 0x40f3, 0x4c00
+ax_pose 3, 0x41fa, 0x00f2, 0x4c04
+ax_pose -1, 0x41f6, 0x40f3, 0x4c00
+ax_pose_terminator
+sDugtrioPose352:
+ax_pose 4, 0x41fd, 0x40f3, 0x4c00
+ax_pose 2, 0x41f9, 0x00f2, 0x4c04
+ax_pose -1, 0x41f6, 0x40f3, 0x4c00
+ax_pose_terminator
+sDugtrioPose353:
+ax_pose 1, 0x41fd, 0x40f3, 0x4c00
+ax_pose 6, 0x41f9, 0x40ea, 0x4c04
+ax_pose -1, 0x41f6, 0x40f3, 0x4c00
+ax_pose_terminator
+sDugtrioPose354:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41f9, 0x40ea, 0x4c03
+ax_pose_terminator
+sDugtrioPose355:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41f9, 0x40ea, 0x4c03
+ax_pose 25, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose356:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose357:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose358:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose359:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose360:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose361:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose362:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose363:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 25, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose364:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 25, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose365:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 25, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose366:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 25, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose367:
+ax_pose 8, 0x01fc, 0x0102, 0x4c00
+ax_pose -1, 0x01f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose368:
+ax_pose 5, 0x01fc, 0x0102, 0x4c00
+ax_pose -1, 0x01f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose369:
+ax_pose 0, 0x01fb, 0x0102, 0x4c00
+ax_pose 8, 0x01fd, 0x00f5, 0x4c01
+ax_pose -1, 0x01f6, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose370:
+ax_pose 7, 0x41fc, 0x00fe, 0x4c00
+ax_pose 5, 0x01fd, 0x00f5, 0x4c02
+ax_pose -1, 0x41f7, 0x00f7, 0x4c00
+ax_pose_terminator
+sDugtrioPose371:
+ax_pose 3, 0x41fc, 0x00fe, 0x4c00
+ax_pose 0, 0x01fc, 0x00f5, 0x4c02
+ax_pose -1, 0x41f7, 0x00f7, 0x4c00
+ax_pose_terminator
+sDugtrioPose372:
+ax_pose 2, 0x41fb, 0x00fe, 0x4c00
+ax_pose 7, 0x41fd, 0x00f1, 0x4c02
+ax_pose -1, 0x41f6, 0x00f7, 0x4c00
+ax_pose_terminator
+sDugtrioPose373:
+ax_pose 6, 0x41fb, 0x40f6, 0x4c00
+ax_pose 3, 0x41fd, 0x00f1, 0x4c04
+ax_pose -1, 0x41f6, 0x40ef, 0x4c00
+ax_pose_terminator
+sDugtrioPose374:
+ax_pose 4, 0x41fb, 0x40f6, 0x4c00
+ax_pose 2, 0x41fc, 0x00f1, 0x4c04
+ax_pose -1, 0x41f6, 0x40ef, 0x4c00
+ax_pose_terminator
+sDugtrioPose375:
+ax_pose 1, 0x41fb, 0x40f6, 0x4c00
+ax_pose 6, 0x41fc, 0x40e9, 0x4c04
+ax_pose -1, 0x41f6, 0x40ef, 0x4c00
+ax_pose_terminator
+sDugtrioPose376:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41fc, 0x40e9, 0x4c03
+ax_pose_terminator
+sDugtrioPose377:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41fc, 0x40e9, 0x4c03
+ax_pose 28, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose378:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose379:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose380:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose381:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose382:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose383:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose384:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose385:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 28, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose386:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 28, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose387:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 28, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose388:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 28, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose389:
+ax_pose 8, 0x01fe, 0x00f9, 0x4c00
+ax_pose -1, 0x01f7, 0x0100, 0x4c00
+ax_pose_terminator
+sDugtrioPose390:
+ax_pose 5, 0x01fe, 0x00f9, 0x4c00
+ax_pose -1, 0x01f7, 0x0100, 0x4c00
+ax_pose_terminator
+sDugtrioPose391:
+ax_pose 0, 0x01fd, 0x00f9, 0x4c00
+ax_pose 8, 0x01f8, 0x00f4, 0x4c01
+ax_pose -1, 0x01f6, 0x0100, 0x4c00
+ax_pose_terminator
+sDugtrioPose392:
+ax_pose 7, 0x41fe, 0x00f5, 0x4c00
+ax_pose 5, 0x01f8, 0x00f4, 0x4c02
+ax_pose -1, 0x41f7, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose393:
+ax_pose 3, 0x41fe, 0x00f5, 0x4c00
+ax_pose 0, 0x01f7, 0x00f4, 0x4c02
+ax_pose -1, 0x41f7, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose394:
+ax_pose 2, 0x41fd, 0x00f5, 0x4c00
+ax_pose 7, 0x41f8, 0x00f0, 0x4c02
+ax_pose -1, 0x41f6, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose395:
+ax_pose 6, 0x41fd, 0x40ed, 0x4c00
+ax_pose 3, 0x41f8, 0x00f0, 0x4c04
+ax_pose -1, 0x41f6, 0x40f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose396:
+ax_pose 4, 0x41fd, 0x40ed, 0x4c00
+ax_pose 2, 0x41f7, 0x00f0, 0x4c04
+ax_pose -1, 0x41f6, 0x40f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose397:
+ax_pose 1, 0x41fd, 0x40ed, 0x4c00
+ax_pose 6, 0x41f7, 0x40e8, 0x4c04
+ax_pose -1, 0x41f6, 0x40f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose398:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41f7, 0x40e8, 0x4c03
+ax_pose_terminator
+sDugtrioPose399:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41f7, 0x40e8, 0x4c03
+ax_pose 31, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose400:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose401:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose402:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose403:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose404:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose405:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose406:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose407:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 31, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose408:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 31, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose409:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 31, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose410:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 31, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose411:
+ax_pose 8, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f6, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose412:
+ax_pose 5, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01f6, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose413:
+ax_pose 0, 0x01fd, 0x00ff, 0x4c00
+ax_pose 8, 0x01fa, 0x00f7, 0x4c01
+ax_pose -1, 0x01f5, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose414:
+ax_pose 7, 0x41fe, 0x00fb, 0x4c00
+ax_pose 5, 0x01fa, 0x00f7, 0x4c02
+ax_pose -1, 0x41f6, 0x00f9, 0x4c00
+ax_pose_terminator
+sDugtrioPose415:
+ax_pose 3, 0x41fe, 0x00fb, 0x4c00
+ax_pose 0, 0x01f9, 0x00f7, 0x4c02
+ax_pose -1, 0x41f6, 0x00f9, 0x4c00
+ax_pose_terminator
+sDugtrioPose416:
+ax_pose 2, 0x41fd, 0x00fb, 0x4c00
+ax_pose 7, 0x41fa, 0x00f3, 0x4c02
+ax_pose -1, 0x41f5, 0x00f9, 0x4c00
+ax_pose_terminator
+sDugtrioPose417:
+ax_pose 6, 0x41fd, 0x40f3, 0x4c00
+ax_pose 3, 0x41fa, 0x00f3, 0x4c04
+ax_pose -1, 0x41f5, 0x40f1, 0x4c00
+ax_pose_terminator
+sDugtrioPose418:
+ax_pose 4, 0x41fd, 0x40f3, 0x4c00
+ax_pose 2, 0x41f9, 0x00f3, 0x4c04
+ax_pose -1, 0x41f5, 0x40f1, 0x4c00
+ax_pose_terminator
+sDugtrioPose419:
+ax_pose 1, 0x41fd, 0x40f3, 0x4c00
+ax_pose 6, 0x41f9, 0x40eb, 0x4c04
+ax_pose -1, 0x41f5, 0x40f1, 0x4c00
+ax_pose_terminator
+sDugtrioPose420:
+ax_pose 48, 0x01fb, 0x04fd, 0x6c00
+ax_pose 49, 0x01ff, 0x0503, 0x6c01
+ax_pose -1, 0x01f9, 0x0501, 0x6c00
+ax_pose -1, 0x01ff, 0x04fe, 0x6c01
+ax_pose 50, 0x01f7, 0x04fd, 0x6c02
+ax_pose -1, 0x01fc, 0x0505, 0x6c02
+ax_pose -1, 0x01fc, 0x04f9, 0x6c02
+ax_pose 4, 0x41f9, 0x40eb, 0x4c03
+ax_pose_terminator
+sDugtrioPose421:
+ax_pose 48, 0x01f7, 0x14f9, 0x6c00
+ax_pose 49, 0x0201, 0x2507, 0x6c01
+ax_pose -1, 0x01f5, 0x2503, 0x6c00
+ax_pose -1, 0x0201, 0x14fa, 0x6c01
+ax_pose 50, 0x01ef, 0x14fa, 0x6c02
+ax_pose -1, 0x01f9, 0x1507, 0x6c02
+ax_pose -1, 0x01fb, 0x24f5, 0x6c02
+ax_pose 1, 0x41f9, 0x40eb, 0x4c03
+ax_pose 10, 0x01e9, 0x80f0, 0x4c07
+ax_pose_terminator
+sDugtrioPose422:
+ax_pose 48, 0x01f3, 0x34f5, 0x6c00
+ax_pose 49, 0x0203, 0x350b, 0x6c01
+ax_pose -1, 0x01f1, 0x3505, 0x6c00
+ax_pose -1, 0x0203, 0x24f6, 0x6c01
+ax_pose 50, 0x01e9, 0x34f6, 0x6c02
+ax_pose -1, 0x01f7, 0x350d, 0x6c02
+ax_pose -1, 0x01fc, 0x34f1, 0x6c02
+ax_pose -1, 0x01f7, 0x04f5, 0x6c00
+ax_pose -1, 0x01fb, 0x04fb, 0x6c01
+ax_pose -1, 0x01f5, 0x04f9, 0x6c00
+ax_pose -1, 0x01fb, 0x04f6, 0x6c01
+ax_pose -1, 0x01f3, 0x04f5, 0x6c02
+ax_pose -1, 0x01f8, 0x04fd, 0x6c02
+ax_pose -1, 0x01f8, 0x04f1, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose423:
+ax_pose 48, 0x01f0, 0x24f2, 0x6c00
+ax_pose 49, 0x0206, 0x150e, 0x6c01
+ax_pose -1, 0x01ee, 0x1508, 0x6c00
+ax_pose -1, 0x0204, 0x34f3, 0x6c01
+ax_pose 50, 0x01e5, 0x24f3, 0x6c02
+ax_pose -1, 0x01f6, 0x2511, 0x6c02
+ax_pose -1, 0x01fe, 0x14ed, 0x6c02
+ax_pose -1, 0x01f3, 0x14f1, 0x6c00
+ax_pose -1, 0x01fd, 0x24ff, 0x6c01
+ax_pose -1, 0x01f1, 0x24fb, 0x6c00
+ax_pose -1, 0x01fd, 0x14f2, 0x6c01
+ax_pose -1, 0x01eb, 0x14f2, 0x6c02
+ax_pose -1, 0x01f5, 0x14ff, 0x6c02
+ax_pose -1, 0x01f7, 0x24ed, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose424:
+ax_pose 48, 0x01ee, 0x04ee, 0x6c00
+ax_pose 49, 0x0207, 0x050f, 0x6c01
+ax_pose -1, 0x01ec, 0x050b, 0x6c00
+ax_pose -1, 0x0206, 0x14f1, 0x6c01
+ax_pose 50, 0x01e2, 0x04f0, 0x6c02
+ax_pose -1, 0x01f6, 0x0514, 0x6c02
+ax_pose -1, 0x0201, 0x04ea, 0x6c02
+ax_pose -1, 0x01ef, 0x34ed, 0x6c00
+ax_pose -1, 0x01ff, 0x3503, 0x6c01
+ax_pose -1, 0x01ed, 0x34fd, 0x6c00
+ax_pose -1, 0x01ff, 0x24ee, 0x6c01
+ax_pose -1, 0x01e5, 0x34ee, 0x6c02
+ax_pose -1, 0x01f3, 0x3505, 0x6c02
+ax_pose -1, 0x01f8, 0x34e9, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose425:
+ax_pose 48, 0x01ed, 0x14ea, 0x6c00
+ax_pose 49, 0x0209, 0x2510, 0x6c01
+ax_pose -1, 0x01ea, 0x250d, 0x6c00
+ax_pose -1, 0x0208, 0x04f0, 0x6c01
+ax_pose 50, 0x01e0, 0x14ed, 0x6c02
+ax_pose -1, 0x01f7, 0x1517, 0x6c02
+ax_pose -1, 0x0204, 0x24e7, 0x6c02
+ax_pose -1, 0x01ec, 0x24ea, 0x6c00
+ax_pose -1, 0x0202, 0x1506, 0x6c01
+ax_pose -1, 0x01ea, 0x1500, 0x6c00
+ax_pose -1, 0x0200, 0x34eb, 0x6c01
+ax_pose -1, 0x01e1, 0x24eb, 0x6c02
+ax_pose -1, 0x01f2, 0x2509, 0x6c02
+ax_pose -1, 0x01fa, 0x14e5, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose426:
+ax_pose 48, 0x01ed, 0x34e7, 0x6c00
+ax_pose -1, 0x01e9, 0x350f, 0x6c00
+ax_pose 49, 0x020b, 0x24ef, 0x6c01
+ax_pose 50, 0x01df, 0x34eb, 0x6c02
+ax_pose -1, 0x01f9, 0x351a, 0x6c02
+ax_pose -1, 0x0208, 0x34e5, 0x6c02
+ax_pose -1, 0x01ea, 0x04e6, 0x6c00
+ax_pose -1, 0x0203, 0x0507, 0x6c01
+ax_pose -1, 0x01e8, 0x0503, 0x6c00
+ax_pose -1, 0x0202, 0x14e9, 0x6c01
+ax_pose -1, 0x01de, 0x04e8, 0x6c02
+ax_pose -1, 0x01f2, 0x050c, 0x6c02
+ax_pose -1, 0x01fd, 0x04e2, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose427:
+ax_pose 48, 0x01ee, 0x24e5, 0x6c00
+ax_pose 49, 0x020b, 0x1512, 0x6c01
+ax_pose -1, 0x01e9, 0x1511, 0x6c00
+ax_pose -1, 0x020f, 0x34ee, 0x6c01
+ax_pose 50, 0x01df, 0x24e9, 0x6c02
+ax_pose -1, 0x01fc, 0x251d, 0x6c02
+ax_pose -1, 0x01e9, 0x14e2, 0x6c00
+ax_pose -1, 0x0205, 0x2508, 0x6c01
+ax_pose -1, 0x01e6, 0x2505, 0x6c00
+ax_pose -1, 0x0204, 0x04e8, 0x6c01
+ax_pose -1, 0x01dc, 0x14e5, 0x6c02
+ax_pose -1, 0x01f3, 0x150f, 0x6c02
+ax_pose -1, 0x0200, 0x24df, 0x6c02
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose428:
+ax_pose 48, 0x01f1, 0x04e2, 0x6c00
+ax_pose -1, 0x01ea, 0x0515, 0x6c00
+ax_pose 50, 0x01e1, 0x04e6, 0x6c01
+ax_pose -1, 0x0200, 0x051f, 0x6c01
+ax_pose -1, 0x0212, 0x04e3, 0x6c01
+ax_pose -1, 0x0204, 0x1520, 0x6c01
+ax_pose -1, 0x01e9, 0x34df, 0x6c00
+ax_pose -1, 0x01e5, 0x3507, 0x6c00
+ax_pose 49, 0x0207, 0x24e7, 0x6c02
+ax_pose -1, 0x01db, 0x34e3, 0x6c01
+ax_pose -1, 0x01f5, 0x3512, 0x6c01
+ax_pose -1, 0x0204, 0x34dd, 0x6c01
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose429:
+ax_pose 48, 0x01f4, 0x14e0, 0x6c00
+ax_pose -1, 0x01ec, 0x2518, 0x6c00
+ax_pose 50, 0x01e4, 0x14e4, 0x6c01
+ax_pose -1, 0x01ea, 0x24dd, 0x6c00
+ax_pose 49, 0x0207, 0x150a, 0x6c02
+ax_pose -1, 0x01e5, 0x1509, 0x6c00
+ax_pose -1, 0x020b, 0x34e6, 0x6c02
+ax_pose -1, 0x01db, 0x24e1, 0x6c01
+ax_pose -1, 0x01f8, 0x2515, 0x6c01
+ax_pose 10, 0x01e9, 0x80f0, 0x4c03
+ax_pose_terminator
+sDugtrioPose430:
+ax_pose 50, 0x0209, 0x3521, 0x6c00
+ax_pose 48, 0x01ed, 0x04da, 0x6c01
+ax_pose -1, 0x01e6, 0x050d, 0x6c01
+ax_pose -1, 0x01dd, 0x04de, 0x6c00
+ax_pose -1, 0x01fc, 0x0517, 0x6c00
+ax_pose -1, 0x020e, 0x04db, 0x6c00
+ax_pose -1, 0x0200, 0x1518, 0x6c00
+ax_pose 10, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose431:
+ax_pose 48, 0x01f0, 0x14d8, 0x6c00
+ax_pose -1, 0x01e8, 0x2510, 0x6c00
+ax_pose 50, 0x01e0, 0x14dc, 0x6c01
+ax_pose 10, 0x01e9, 0x80f0, 0x4c02
+ax_pose_terminator
+sDugtrioPose432:
+ax_pose 50, 0x0205, 0x3519, 0x6c00
+ax_pose 10, 0x01e9, 0x80f0, 0x4c01
+ax_pose_terminator
+sDugtrioPose433:
+ax_pose 8, 0x01fc, 0x0103, 0x4c00
+ax_pose -1, 0x01fd, 0x00f7, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose434:
+ax_pose 5, 0x01fc, 0x0103, 0x4c00
+ax_pose -1, 0x01fd, 0x00f7, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose435:
+ax_pose 0, 0x01fb, 0x0103, 0x4c00
+ax_pose -1, 0x01fc, 0x00f7, 0x4c00
+ax_pose -1, 0x01f5, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose436:
+ax_pose 7, 0x41fc, 0x00ff, 0x4c00
+ax_pose -1, 0x41fd, 0x00f3, 0x4c00
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose437:
+ax_pose 3, 0x41fc, 0x00ff, 0x4c00
+ax_pose -1, 0x41fd, 0x00f3, 0x4c00
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose438:
+ax_pose 2, 0x41fb, 0x00ff, 0x4c00
+ax_pose -1, 0x41fc, 0x00f3, 0x4c00
+ax_pose -1, 0x41f5, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose439:
+ax_pose 6, 0x41fb, 0x40f7, 0x4c00
+ax_pose -1, 0x41fc, 0x40eb, 0x4c00
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose440:
+ax_pose 4, 0x41fb, 0x40f7, 0x4c00
+ax_pose -1, 0x41fc, 0x40eb, 0x4c00
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose441:
+ax_pose 1, 0x41fb, 0x40f7, 0x4c00
+ax_pose -1, 0x41fc, 0x40eb, 0x4c00
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose442:
+ax_pose 13, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose443:
+ax_pose 8, 0x01ff, 0x00fb, 0x4c00
+ax_pose -1, 0x01f8, 0x00f5, 0x4c00
+ax_pose -1, 0x01f8, 0x0101, 0x4c00
+ax_pose_terminator
+sDugtrioPose444:
+ax_pose 5, 0x01ff, 0x00fb, 0x4c00
+ax_pose -1, 0x01f8, 0x00f5, 0x4c00
+ax_pose -1, 0x01f8, 0x0101, 0x4c00
+ax_pose_terminator
+sDugtrioPose445:
+ax_pose 0, 0x01fe, 0x00fb, 0x4c00
+ax_pose -1, 0x01f7, 0x00f5, 0x4c00
+ax_pose -1, 0x01f7, 0x0101, 0x4c00
+ax_pose_terminator
+sDugtrioPose446:
+ax_pose 7, 0x41f8, 0x00f1, 0x4c00
+ax_pose -1, 0x41ff, 0x00f7, 0x4c00
+ax_pose -1, 0x41f8, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose447:
+ax_pose 3, 0x41ff, 0x00f7, 0x4c00
+ax_pose -1, 0x41f8, 0x00f1, 0x4c00
+ax_pose -1, 0x41f8, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose448:
+ax_pose 2, 0x41fe, 0x00f7, 0x4c00
+ax_pose -1, 0x41f7, 0x00f1, 0x4c00
+ax_pose -1, 0x41f7, 0x00fd, 0x4c00
+ax_pose_terminator
+sDugtrioPose449:
+ax_pose 6, 0x41fe, 0x40ef, 0x4c00
+ax_pose -1, 0x41f7, 0x40e9, 0x4c00
+ax_pose -1, 0x41f7, 0x40f5, 0x4c00
+ax_pose_terminator
+sDugtrioPose450:
+ax_pose 4, 0x41fe, 0x40ef, 0x4c00
+ax_pose -1, 0x41f7, 0x40e9, 0x4c00
+ax_pose -1, 0x41f7, 0x40f5, 0x4c00
+ax_pose_terminator
+sDugtrioPose451:
+ax_pose 1, 0x41fe, 0x40ef, 0x4c00
+ax_pose -1, 0x41f7, 0x40e9, 0x4c00
+ax_pose -1, 0x41f7, 0x40f5, 0x4c00
+ax_pose_terminator
+sDugtrioPose452:
+ax_pose 16, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose453:
+ax_pose 8, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01fd, 0x00f6, 0x4c00
+ax_pose -1, 0x01f8, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose454:
+ax_pose 5, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01fd, 0x00f6, 0x4c00
+ax_pose -1, 0x01f8, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose455:
+ax_pose 0, 0x01fd, 0x00ff, 0x4c00
+ax_pose -1, 0x01fc, 0x00f6, 0x4c00
+ax_pose -1, 0x01f7, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose456:
+ax_pose 7, 0x41fe, 0x00fb, 0x4c00
+ax_pose -1, 0x41fd, 0x00f2, 0x4c00
+ax_pose -1, 0x41f8, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose457:
+ax_pose 3, 0x41fe, 0x00fb, 0x4c00
+ax_pose -1, 0x41fd, 0x00f2, 0x4c00
+ax_pose -1, 0x41f8, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose458:
+ax_pose 2, 0x41fd, 0x00fb, 0x4c00
+ax_pose -1, 0x41fc, 0x00f2, 0x4c00
+ax_pose -1, 0x41f7, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose459:
+ax_pose 6, 0x41fd, 0x40f3, 0x4c00
+ax_pose -1, 0x41fc, 0x40ea, 0x4c00
+ax_pose -1, 0x41f7, 0x40f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose460:
+ax_pose 4, 0x41fd, 0x40f3, 0x4c00
+ax_pose -1, 0x41fc, 0x40ea, 0x4c00
+ax_pose -1, 0x41f7, 0x40f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose461:
+ax_pose 1, 0x41fd, 0x40f3, 0x4c00
+ax_pose -1, 0x41fc, 0x40ea, 0x4c00
+ax_pose -1, 0x41f7, 0x40f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose462:
+ax_pose 19, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose463:
+ax_pose 8, 0x01fa, 0x0101, 0x4c00
+ax_pose -1, 0x01ff, 0x00f9, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose464:
+ax_pose 5, 0x01fa, 0x0101, 0x4c00
+ax_pose -1, 0x01ff, 0x00f9, 0x4c00
+ax_pose -1, 0x01f6, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose465:
+ax_pose 0, 0x01f9, 0x0101, 0x4c00
+ax_pose -1, 0x01fe, 0x00f9, 0x4c00
+ax_pose -1, 0x01f5, 0x00f8, 0x4c00
+ax_pose_terminator
+sDugtrioPose466:
+ax_pose 7, 0x41fa, 0x00fd, 0x4c00
+ax_pose -1, 0x41ff, 0x00f5, 0x4c00
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose467:
+ax_pose 3, 0x41ff, 0x00f5, 0x4c00
+ax_pose -1, 0x41fa, 0x00fd, 0x4c00
+ax_pose -1, 0x41f6, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose468:
+ax_pose 2, 0x41fe, 0x00f5, 0x4c00
+ax_pose -1, 0x41f9, 0x00fd, 0x4c00
+ax_pose -1, 0x41f5, 0x00f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose469:
+ax_pose 6, 0x41fe, 0x40ed, 0x4c00
+ax_pose -1, 0x41f9, 0x40f5, 0x4c00
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose470:
+ax_pose 4, 0x41fe, 0x40ed, 0x4c00
+ax_pose -1, 0x41f9, 0x40f5, 0x4c00
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose471:
+ax_pose 1, 0x41fe, 0x40ed, 0x4c00
+ax_pose -1, 0x41f9, 0x40f5, 0x4c00
+ax_pose -1, 0x41f5, 0x40ec, 0x4c00
+ax_pose_terminator
+sDugtrioPose472:
+ax_pose 22, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose473:
+ax_pose 8, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01fa, 0x00f6, 0x4c00
+ax_pose -1, 0x01f7, 0x00ff, 0x4c00
+ax_pose_terminator
+sDugtrioPose474:
+ax_pose 5, 0x01fe, 0x00ff, 0x4c00
+ax_pose -1, 0x01fa, 0x00f6, 0x4c00
+ax_pose -1, 0x01f7, 0x00ff, 0x4c00
+ax_pose_terminator
+sDugtrioPose475:
+ax_pose 0, 0x01fd, 0x00ff, 0x4c00
+ax_pose -1, 0x01f9, 0x00f6, 0x4c00
+ax_pose -1, 0x01f6, 0x00ff, 0x4c00
+ax_pose_terminator
+sDugtrioPose476:
+ax_pose 7, 0x41fe, 0x00fb, 0x4c00
+ax_pose -1, 0x41fa, 0x00f2, 0x4c00
+ax_pose -1, 0x41f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose477:
+ax_pose 3, 0x41fe, 0x00fb, 0x4c00
+ax_pose -1, 0x41fa, 0x00f2, 0x4c00
+ax_pose -1, 0x41f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose478:
+ax_pose 2, 0x41fd, 0x00fb, 0x4c00
+ax_pose -1, 0x41f9, 0x00f2, 0x4c00
+ax_pose -1, 0x41f6, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose479:
+ax_pose 6, 0x41fd, 0x40f3, 0x4c00
+ax_pose -1, 0x41f9, 0x40ea, 0x4c00
+ax_pose -1, 0x41f6, 0x40f3, 0x4c00
+ax_pose_terminator
+sDugtrioPose480:
+ax_pose 4, 0x41fd, 0x40f3, 0x4c00
+ax_pose -1, 0x41f9, 0x40ea, 0x4c00
+ax_pose -1, 0x41f6, 0x40f3, 0x4c00
+ax_pose_terminator
+sDugtrioPose481:
+ax_pose 1, 0x41fd, 0x40f3, 0x4c00
+ax_pose -1, 0x41f9, 0x40ea, 0x4c00
+ax_pose -1, 0x41f6, 0x40f3, 0x4c00
+ax_pose_terminator
+sDugtrioPose482:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose483:
+ax_pose 8, 0x01fc, 0x0102, 0x4c00
+ax_pose -1, 0x01fd, 0x00f5, 0x4c00
+ax_pose -1, 0x01f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose484:
+ax_pose 5, 0x01fc, 0x0102, 0x4c00
+ax_pose -1, 0x01fd, 0x00f5, 0x4c00
+ax_pose -1, 0x01f7, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose485:
+ax_pose 0, 0x01fb, 0x0102, 0x4c00
+ax_pose -1, 0x01fc, 0x00f5, 0x4c00
+ax_pose -1, 0x01f6, 0x00fb, 0x4c00
+ax_pose_terminator
+sDugtrioPose486:
+ax_pose 7, 0x41fc, 0x00fe, 0x4c00
+ax_pose -1, 0x41fd, 0x00f1, 0x4c00
+ax_pose -1, 0x41f7, 0x00f7, 0x4c00
+ax_pose_terminator
+sDugtrioPose487:
+ax_pose 3, 0x41fc, 0x00fe, 0x4c00
+ax_pose -1, 0x41fd, 0x00f1, 0x4c00
+ax_pose -1, 0x41f7, 0x00f7, 0x4c00
+ax_pose_terminator
+sDugtrioPose488:
+ax_pose 2, 0x41fb, 0x00fe, 0x4c00
+ax_pose -1, 0x41fc, 0x00f1, 0x4c00
+ax_pose -1, 0x41f6, 0x00f7, 0x4c00
+ax_pose_terminator
+sDugtrioPose489:
+ax_pose 6, 0x41fb, 0x40f6, 0x4c00
+ax_pose -1, 0x41fc, 0x40e9, 0x4c00
+ax_pose -1, 0x41f6, 0x40ef, 0x4c00
+ax_pose_terminator
+sDugtrioPose490:
+ax_pose 4, 0x41fb, 0x40f6, 0x4c00
+ax_pose -1, 0x41fc, 0x40e9, 0x4c00
+ax_pose -1, 0x41f6, 0x40ef, 0x4c00
+ax_pose_terminator
+sDugtrioPose491:
+ax_pose 1, 0x41fb, 0x40f6, 0x4c00
+ax_pose -1, 0x41fc, 0x40e9, 0x4c00
+ax_pose -1, 0x41f6, 0x40ef, 0x4c00
+ax_pose_terminator
+sDugtrioPose492:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sDugtrioPose493:
+ax_pose 8, 0x01fe, 0x00f9, 0x4c00
+ax_pose -1, 0x01f8, 0x00f4, 0x4c00
+ax_pose -1, 0x01f7, 0x0100, 0x4c00
+ax_pose_terminator
+sDugtrioPose494:
+ax_pose 5, 0x01fe, 0x00f9, 0x4c00
+ax_pose -1, 0x01f8, 0x00f4, 0x4c00
+ax_pose -1, 0x01f7, 0x0100, 0x4c00
+ax_pose_terminator
+sDugtrioPose495:
+ax_pose 0, 0x01fd, 0x00f9, 0x4c00
+ax_pose -1, 0x01f7, 0x00f4, 0x4c00
+ax_pose -1, 0x01f6, 0x0100, 0x4c00
+ax_pose_terminator
+sDugtrioPose496:
+ax_pose 7, 0x41fe, 0x00f5, 0x4c00
+ax_pose -1, 0x41f8, 0x00f0, 0x4c00
+ax_pose -1, 0x41f7, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose497:
+ax_pose 3, 0x41fe, 0x00f5, 0x4c00
+ax_pose -1, 0x41f8, 0x00f0, 0x4c00
+ax_pose -1, 0x41f7, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose498:
+ax_pose 2, 0x41fd, 0x00f5, 0x4c00
+ax_pose -1, 0x41f7, 0x00f0, 0x4c00
+ax_pose -1, 0x41f6, 0x00fc, 0x4c00
+ax_pose_terminator
+sDugtrioPose499:
+ax_pose 6, 0x41fd, 0x40ed, 0x4c00
+ax_pose -1, 0x41f7, 0x40e8, 0x4c00
+ax_pose -1, 0x41f6, 0x40f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose500:
+ax_pose 4, 0x41fd, 0x40ed, 0x4c00
+ax_pose -1, 0x41f7, 0x40e8, 0x4c00
+ax_pose -1, 0x41f6, 0x40f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose501:
+ax_pose 1, 0x41fd, 0x40ed, 0x4c00
+ax_pose -1, 0x41f7, 0x40e8, 0x4c00
+ax_pose -1, 0x41f6, 0x40f4, 0x4c00
+ax_pose_terminator
+sDugtrioPose502:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+.align 2
+sDugtrioAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_2_1:
+ax_anim 2, 0, 28, 0, -2, 0, -2,
+ax_anim 6, 0, 28, 0, -3, 0, -3,
+ax_anim 2, 2, 25, 0, 9, 0, 9,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 30, 0, 6, 0, 6,
+ax_anim 2, 0, 30, 0, 3, 0, 3,
+ax_anim_terminator
+sDugtrioAnims_2_2:
+ax_anim 2, 0, 35, -2, -2, -2, -2,
+ax_anim 6, 0, 35, -3, -3, -3, -3,
+ax_anim 2, 2, 32, 9, 9, 9, 9,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 32, 17, 19, 17, 19,
+ax_anim 2, 0, 33, 18, 18, 18, 18,
+ax_anim 2, 0, 33, 17, 19, 17, 19,
+ax_anim 2, 0, 37, 6, 6, 6, 6,
+ax_anim 2, 0, 37, 3, 3, 3, 3,
+ax_anim_terminator
+sDugtrioAnims_2_3:
+ax_anim 2, 0, 42, -2, 0, -2, 0,
+ax_anim 6, 0, 42, -3, 0, -3, 0,
+ax_anim 2, 2, 40, 8, 0, 8, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 39, 18, -1, 18, -1,
+ax_anim 2, 0, 40, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, -1, 18, -1,
+ax_anim 2, 0, 44, 6, 0, 6, 0,
+ax_anim 2, 0, 44, 3, 0, 3, 0,
+ax_anim_terminator
+sDugtrioAnims_2_4:
+ax_anim 2, 0, 49, -2, 2, -2, 2,
+ax_anim 6, 0, 49, -3, 3, -3, 3,
+ax_anim 2, 2, 47, 9, -9, 9, -9,
+ax_anim 2, 0, 45, 18, -18, 18, -18,
+ax_anim 2, 1, 46, 17, -19, 17, -19,
+ax_anim 2, 0, 47, 18, -18, 18, -18,
+ax_anim 2, 0, 45, 17, -19, 17, -19,
+ax_anim 2, 0, 51, 6, -6, 6, -6,
+ax_anim 2, 0, 51, 3, -3, 3, -3,
+ax_anim_terminator
+sDugtrioAnims_2_5:
+ax_anim 2, 0, 56, 0, 2, 0, 2,
+ax_anim 6, 0, 56, 0, 3, 0, 3,
+ax_anim 2, 2, 54, 0, -10, 0, -10,
+ax_anim 2, 0, 52, 0, -18, 0, -18,
+ax_anim 2, 1, 53, 1, -18, 1, -18,
+ax_anim 2, 0, 54, 0, -18, 0, -18,
+ax_anim 2, 0, 52, 1, -18, 1, -18,
+ax_anim 2, 0, 58, 0, -6, 0, -6,
+ax_anim 2, 0, 58, 0, -3, 0, -3,
+ax_anim_terminator
+sDugtrioAnims_2_6:
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 6, 0, 63, 3, 3, 3, 3,
+ax_anim 2, 2, 61, -9, -9, -9, -9,
+ax_anim 2, 0, 59, -18, -18, -18, -18,
+ax_anim 2, 1, 60, -17, -19, -17, -19,
+ax_anim 2, 0, 61, -18, -18, -18, -18,
+ax_anim 2, 0, 59, -17, -19, -17, -19,
+ax_anim 2, 0, 65, -6, -6, -6, -6,
+ax_anim 2, 0, 65, -3, -3, -3, -3,
+ax_anim_terminator
+sDugtrioAnims_2_7:
+ax_anim 2, 0, 42, -2, 0, -2, 0,
+ax_anim 6, 0, 70, 3, 0, 3, 0,
+ax_anim 2, 2, 68, -8, 0, -8, 0,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, -1, -18, -1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -18, -1, -18, -1,
+ax_anim 2, 0, 72, -6, 0, -6, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sDugtrioAnims_2_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 2, 74, -9, 9, -9, 9,
+ax_anim 2, 0, 73, -18, 18, -18, 18,
+ax_anim 2, 1, 74, -17, 19, -17, 19,
+ax_anim 2, 0, 75, -18, 18, -18, 18,
+ax_anim 2, 0, 75, -17, 19, -17, 19,
+ax_anim 2, 0, 79, -6, 6, -6, 6,
+ax_anim 2, 0, 79, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_3_1:
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim 6, 0, 84, 0, -3, 0, -3,
+ax_anim 2, 2, 81, 0, 9, 0, 9,
+ax_anim 2, 0, 80, 0, 18, 0, 18,
+ax_anim 2, 1, 81, 1, 18, 1, 18,
+ax_anim 2, 0, 82, 0, 18, 0, 18,
+ax_anim 2, 0, 80, 1, 18, 1, 18,
+ax_anim 2, 0, 86, 0, 6, 0, 6,
+ax_anim 2, 0, 86, 0, 3, 0, 3,
+ax_anim_terminator
+sDugtrioAnims_3_2:
+ax_anim 2, 0, 91, -2, -2, -2, -2,
+ax_anim 6, 0, 91, -3, -3, -3, -3,
+ax_anim 2, 2, 88, 9, 9, 9, 9,
+ax_anim 2, 0, 87, 18, 18, 18, 18,
+ax_anim 2, 1, 88, 17, 19, 17, 19,
+ax_anim 2, 0, 89, 18, 18, 18, 18,
+ax_anim 2, 0, 89, 17, 19, 17, 19,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim_terminator
+sDugtrioAnims_3_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 6, 0, 98, -3, 0, -3, 0,
+ax_anim 2, 2, 96, 8, 0, 8, 0,
+ax_anim 2, 0, 94, 18, 0, 18, 0,
+ax_anim 2, 1, 95, 18, -1, 18, -1,
+ax_anim 2, 0, 96, 18, 0, 18, 0,
+ax_anim 2, 0, 94, 18, -1, 18, -1,
+ax_anim 2, 0, 100, 6, 0, 6, 0,
+ax_anim 2, 0, 100, 3, 0, 3, 0,
+ax_anim_terminator
+sDugtrioAnims_3_4:
+ax_anim 2, 0, 105, -2, 2, -2, 2,
+ax_anim 6, 0, 105, -3, 3, -3, 3,
+ax_anim 2, 2, 103, 9, -9, 9, -9,
+ax_anim 2, 0, 101, 18, -18, 18, -18,
+ax_anim 2, 1, 102, 17, -19, 17, -19,
+ax_anim 2, 0, 103, 18, -18, 18, -18,
+ax_anim 2, 0, 101, 17, -19, 17, -19,
+ax_anim 2, 0, 107, 6, -6, 6, -6,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim_terminator
+sDugtrioAnims_3_5:
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim 6, 0, 112, 0, 3, 0, 3,
+ax_anim 2, 2, 110, 0, -10, 0, -10,
+ax_anim 2, 0, 108, 0, -18, 0, -18,
+ax_anim 2, 1, 109, 1, -18, 1, -18,
+ax_anim 2, 0, 110, 0, -18, 0, -18,
+ax_anim 2, 0, 108, 1, -18, 1, -18,
+ax_anim 2, 0, 114, 0, -6, 0, -6,
+ax_anim 2, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sDugtrioAnims_3_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 6, 0, 119, 3, 3, 3, 3,
+ax_anim 2, 2, 117, -9, -9, -9, -9,
+ax_anim 2, 0, 115, -18, -18, -18, -18,
+ax_anim 2, 1, 116, -17, -19, -17, -19,
+ax_anim 2, 0, 117, -18, -18, -18, -18,
+ax_anim 2, 0, 115, -17, -19, -17, -19,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim_terminator
+sDugtrioAnims_3_7:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 6, 0, 126, 3, 0, 3, 0,
+ax_anim 2, 2, 124, -8, 0, -8, 0,
+ax_anim 2, 0, 122, -18, 0, -18, 0,
+ax_anim 2, 1, 123, -18, -1, -18, -1,
+ax_anim 2, 0, 124, -18, 0, -18, 0,
+ax_anim 2, 0, 122, -18, -1, -18, -1,
+ax_anim 2, 0, 128, -6, 0, -6, 0,
+ax_anim 2, 0, 128, -3, 0, -3, 0,
+ax_anim_terminator
+sDugtrioAnims_3_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 6, 0, 133, 3, -3, 3, -3,
+ax_anim 2, 2, 130, -9, 9, -9, 9,
+ax_anim 2, 0, 129, -18, 18, -18, 18,
+ax_anim 2, 1, 130, -17, 19, -17, 19,
+ax_anim 2, 0, 131, -18, 18, -18, 18,
+ax_anim 2, 0, 131, -17, 19, -17, 19,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_4_1:
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 1, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_4_2:
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, 0,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_4_3:
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_4_4:
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_4_5:
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 1, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_4_6:
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_4_7:
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_4_8:
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 1, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_5_1:
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_5_2:
+ax_anim 2, 0, 151, 1, -1, 1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, -1, 1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, -1, 1, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, -1, 1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, -1, 1, 0,
+ax_anim 2, 1, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_5_3:
+ax_anim 2, 0, 150, 0, -1, 0, -1,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -1, 0, -1,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -1, 0, -1,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -1, 0, -1,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -1, 0, -1,
+ax_anim 2, 1, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_5_4:
+ax_anim 2, 0, 149, -1, -1, -1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, -1, -1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, -1, -1, -1,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, -1, -1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, -1, -1, -1,
+ax_anim 2, 1, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_5_5:
+ax_anim 2, 0, 148, 1, 0, 1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 1, 0, 1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 1, 0, 1, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 1, 0, 1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 1, 0, 1, 0,
+ax_anim 2, 1, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_5_6:
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim 2, 1, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_5_7:
+ax_anim 2, 0, 146, 0, -1, 0, -1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, -1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, -1,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, -1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, -1,
+ax_anim 2, 1, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_5_8:
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 1, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sDugtrioAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sDugtrioAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sDugtrioAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sDugtrioAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sDugtrioAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sDugtrioAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sDugtrioAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_8_1:
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_8_2:
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim 16, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_8_3:
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_8_4:
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_8_5:
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim 16, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_8_6:
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 16, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_8_7:
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_8_8:
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim 16, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 7, 8, 7,
+ax_anim 2, 0, 181, 7, 13, 7, 13,
+ax_anim 3, 0, 182, 0, 16, 0, 16,
+ax_anim 2, 3, 183, -7, 13, -7, 13,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 19, 8, 19, 8,
+ax_anim 3, 0, 181, 17, 15, 17, 15,
+ax_anim 2, 3, 182, 9, 16, 9, 16,
+ax_anim 2, 0, 183, 2, 12, 2, 12,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 18, 1, 18, 1,
+ax_anim 2, 3, 181, 15, 5, 15, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 9, -20, 9, -20,
+ax_anim 3, 0, 179, 16, -22, 16, -22,
+ax_anim 2, 3, 180, 18, -15, 18, -15,
+ax_anim 2, 0, 181, 16, -6, 16, -6,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -8, -10, -8, -10,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 8, -8, 8, -8,
+ax_anim 1, 0, 181, 6, -4, 6, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -8, -20, -8, -20,
+ax_anim 3, 0, 185, -16, -22, -16, -22,
+ax_anim 2, 3, 184, -18, -15, -18, -15,
+ax_anim 2, 0, 183, -16, -6, -16, -6,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -4, -17, -4,
+ax_anim 3, 0, 184, -18, 1, -18, 1,
+ax_anim 2, 3, 183, -15, 5, -15, 5,
+ax_anim 2, 0, 182, -10, 7, -10, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -19, 8, -19, 8,
+ax_anim 3, 0, 183, -17, 15, -17, 15,
+ax_anim 2, 3, 182, -9, 16, -9, 16,
+ax_anim 2, 0, 181, -2, 12, -2, 12,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, 0, -1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, 0, -1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 10, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, -1, 1, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, -1, 1, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, -1, 0, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, -1, 0, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 10, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 10, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, -1, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, -1, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_14_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_14_2:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_14_3:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_14_4:
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_14_5:
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_14_6:
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 346, 0, 0, 0, 0,
+ax_anim 2, 0, 347, 0, 0, 0, 0,
+ax_anim 2, 0, 348, 0, 0, 0, 0,
+ax_anim 2, 0, 349, 0, 0, 0, 0,
+ax_anim 2, 0, 350, 0, 0, 0, 0,
+ax_anim 2, 0, 351, 0, 0, 0, 0,
+ax_anim 2, 0, 352, 0, 0, 0, 0,
+ax_anim 2, 0, 353, 0, 0, 0, 0,
+ax_anim 2, 0, 354, 0, 0, 0, 0,
+ax_anim 2, 0, 355, 0, 0, 0, 0,
+ax_anim 2, 0, 356, 0, 0, 0, 0,
+ax_anim 2, 0, 357, 0, 0, 0, 0,
+ax_anim 2, 0, 358, 0, 0, 0, 0,
+ax_anim 2, 0, 359, 0, 0, 0, 0,
+ax_anim 2, 0, 360, 0, 0, 0, 0,
+ax_anim 2, 0, 361, 0, 0, 0, 0,
+ax_anim 2, 0, 362, 0, 0, 0, 0,
+ax_anim 2, 0, 363, 0, 0, 0, 0,
+ax_anim 2, 0, 364, 0, 0, 0, 0,
+ax_anim 2, 0, 365, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_14_7:
+ax_anim 2, 0, 366, 0, 0, 0, 0,
+ax_anim 2, 0, 367, 0, 0, 0, 0,
+ax_anim 2, 0, 368, 0, 0, 0, 0,
+ax_anim 2, 0, 369, 0, 0, 0, 0,
+ax_anim 2, 0, 370, 0, 0, 0, 0,
+ax_anim 2, 0, 371, 0, 0, 0, 0,
+ax_anim 2, 0, 372, 0, 0, 0, 0,
+ax_anim 2, 0, 373, 0, 0, 0, 0,
+ax_anim 2, 0, 374, 0, 0, 0, 0,
+ax_anim 2, 0, 375, 0, 0, 0, 0,
+ax_anim 2, 0, 376, 0, 0, 0, 0,
+ax_anim 2, 0, 377, 0, 0, 0, 0,
+ax_anim 2, 0, 378, 0, 0, 0, 0,
+ax_anim 2, 0, 379, 0, 0, 0, 0,
+ax_anim 2, 0, 380, 0, 0, 0, 0,
+ax_anim 2, 0, 381, 0, 0, 0, 0,
+ax_anim 2, 0, 382, 0, 0, 0, 0,
+ax_anim 2, 0, 383, 0, 0, 0, 0,
+ax_anim 2, 0, 384, 0, 0, 0, 0,
+ax_anim 2, 0, 385, 0, 0, 0, 0,
+ax_anim 2, 0, 386, 0, 0, 0, 0,
+ax_anim 2, 0, 387, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_14_8:
+ax_anim 2, 0, 388, 0, 0, 0, 0,
+ax_anim 2, 0, 389, 0, 0, 0, 0,
+ax_anim 2, 0, 390, 0, 0, 0, 0,
+ax_anim 2, 0, 391, 0, 0, 0, 0,
+ax_anim 2, 0, 392, 0, 0, 0, 0,
+ax_anim 2, 0, 393, 0, 0, 0, 0,
+ax_anim 2, 0, 394, 0, 0, 0, 0,
+ax_anim 2, 0, 395, 0, 0, 0, 0,
+ax_anim 2, 0, 396, 0, 0, 0, 0,
+ax_anim 2, 0, 397, 0, 0, 0, 0,
+ax_anim 2, 0, 398, 0, 0, 0, 0,
+ax_anim 2, 0, 399, 0, 0, 0, 0,
+ax_anim 2, 0, 400, 0, 0, 0, 0,
+ax_anim 2, 0, 401, 0, 0, 0, 0,
+ax_anim 2, 0, 402, 0, 0, 0, 0,
+ax_anim 2, 0, 403, 0, 0, 0, 0,
+ax_anim 2, 0, 404, 0, 0, 0, 0,
+ax_anim 2, 0, 405, 0, 0, 0, 0,
+ax_anim 2, 0, 406, 0, 0, 0, 0,
+ax_anim 2, 0, 407, 0, 0, 0, 0,
+ax_anim 2, 0, 408, 0, 0, 0, 0,
+ax_anim 2, 0, 409, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDugtrioAnims_15_1:
+ax_anim 2, 0, 419, 0, 0, 0, 0,
+ax_anim 2, 0, 419, 1, 0, 0, 0,
+ax_anim 2, 0, 419, 0, 0, 0, 0,
+ax_anim 2, 0, 419, 1, 0, 0, 0,
+ax_anim 2, 0, 419, 0, 0, 0, 0,
+ax_anim 2, 0, 418, 0, 0, 0, 0,
+ax_anim 2, 0, 417, 0, 0, 0, 0,
+ax_anim 2, 0, 416, 0, 0, 0, 0,
+ax_anim 2, 0, 415, 0, 0, 0, 0,
+ax_anim 2, 0, 414, 0, 0, 0, 0,
+ax_anim 2, 0, 413, 0, 0, 0, 0,
+ax_anim 2, 0, 412, 0, 0, 0, 0,
+ax_anim 2, 0, 411, 0, 0, 0, 0,
+ax_anim 2, 0, 410, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_15_2:
+ax_anim 2, 0, 441, 0, 0, 0, 0,
+ax_anim 2, 0, 441, 1, 0, 0, 0,
+ax_anim 2, 0, 441, 0, 0, 0, 0,
+ax_anim 2, 0, 441, 1, 0, 0, 0,
+ax_anim 2, 0, 441, 0, 0, 0, 0,
+ax_anim 2, 0, 440, 0, 0, 0, 0,
+ax_anim 2, 0, 439, 0, 0, 0, 0,
+ax_anim 2, 0, 438, 0, 0, 0, 0,
+ax_anim 2, 0, 437, 0, 0, 0, 0,
+ax_anim 2, 0, 436, 0, 0, 0, 0,
+ax_anim 2, 0, 435, 0, 0, 0, 0,
+ax_anim 2, 0, 434, 0, 0, 0, 0,
+ax_anim 2, 0, 433, 0, 0, 0, 0,
+ax_anim 2, 0, 432, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_15_3:
+ax_anim 2, 0, 451, 0, 0, 0, 0,
+ax_anim 2, 0, 451, 1, 0, 0, 0,
+ax_anim 2, 0, 451, 0, 0, 0, 0,
+ax_anim 2, 0, 451, 1, 0, 0, 0,
+ax_anim 2, 0, 451, 0, 0, 0, 0,
+ax_anim 2, 0, 450, 0, 0, 0, 0,
+ax_anim 2, 0, 449, 0, 0, 0, 0,
+ax_anim 2, 0, 448, 0, 0, 0, 0,
+ax_anim 2, 0, 447, 0, 0, 0, 0,
+ax_anim 2, 0, 446, 0, 0, 0, 0,
+ax_anim 2, 0, 445, 0, 0, 0, 0,
+ax_anim 2, 0, 444, 0, 0, 0, 0,
+ax_anim 2, 0, 443, 0, 0, 0, 0,
+ax_anim 2, 0, 442, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_15_4:
+ax_anim 2, 0, 461, 0, 0, 0, 0,
+ax_anim 2, 0, 461, 1, 0, 0, 0,
+ax_anim 2, 0, 461, 0, 0, 0, 0,
+ax_anim 2, 0, 461, 1, 0, 0, 0,
+ax_anim 2, 0, 461, 0, 0, 0, 0,
+ax_anim 2, 0, 460, 0, 0, 0, 0,
+ax_anim 2, 0, 459, 0, 0, 0, 0,
+ax_anim 2, 0, 458, 0, 0, 0, 0,
+ax_anim 2, 0, 457, 0, 0, 0, 0,
+ax_anim 2, 0, 456, 0, 0, 0, 0,
+ax_anim 2, 0, 455, 0, 0, 0, 0,
+ax_anim 2, 0, 454, 0, 0, 0, 0,
+ax_anim 2, 0, 453, 0, 0, 0, 0,
+ax_anim 2, 0, 452, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_15_5:
+ax_anim 2, 0, 471, 0, 0, 0, 0,
+ax_anim 2, 0, 471, 1, 0, 0, 0,
+ax_anim 2, 0, 471, 0, 0, 0, 0,
+ax_anim 2, 0, 471, 1, 0, 0, 0,
+ax_anim 2, 0, 471, 0, 0, 0, 0,
+ax_anim 2, 0, 470, 0, 0, 0, 0,
+ax_anim 2, 0, 469, 0, 0, 0, 0,
+ax_anim 2, 0, 468, 0, 0, 0, 0,
+ax_anim 2, 0, 467, 0, 0, 0, 0,
+ax_anim 2, 0, 466, 0, 0, 0, 0,
+ax_anim 2, 0, 465, 0, 0, 0, 0,
+ax_anim 2, 0, 464, 0, 0, 0, 0,
+ax_anim 2, 0, 463, 0, 0, 0, 0,
+ax_anim 2, 0, 462, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_15_6:
+ax_anim 2, 0, 481, 0, 0, 0, 0,
+ax_anim 2, 0, 481, 1, 0, 0, 0,
+ax_anim 2, 0, 481, 0, 0, 0, 0,
+ax_anim 2, 0, 481, 1, 0, 0, 0,
+ax_anim 2, 0, 481, 0, 0, 0, 0,
+ax_anim 2, 0, 480, 0, 0, 0, 0,
+ax_anim 2, 0, 479, 0, 0, 0, 0,
+ax_anim 2, 0, 478, 0, 0, 0, 0,
+ax_anim 2, 0, 477, 0, 0, 0, 0,
+ax_anim 2, 0, 476, 0, 0, 0, 0,
+ax_anim 2, 0, 475, 0, 0, 0, 0,
+ax_anim 2, 0, 474, 0, 0, 0, 0,
+ax_anim 2, 0, 473, 0, 0, 0, 0,
+ax_anim 2, 0, 472, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_15_7:
+ax_anim 2, 0, 491, 0, 0, 0, 0,
+ax_anim 2, 0, 491, 1, 0, 0, 0,
+ax_anim 2, 0, 491, 0, 0, 0, 0,
+ax_anim 2, 0, 491, 1, 0, 0, 0,
+ax_anim 2, 0, 491, 0, 0, 0, 0,
+ax_anim 2, 0, 490, 0, 0, 0, 0,
+ax_anim 2, 0, 489, 0, 0, 0, 0,
+ax_anim 2, 0, 488, 0, 0, 0, 0,
+ax_anim 2, 0, 487, 0, 0, 0, 0,
+ax_anim 2, 0, 486, 0, 0, 0, 0,
+ax_anim 2, 0, 485, 0, 0, 0, 0,
+ax_anim 2, 0, 484, 0, 0, 0, 0,
+ax_anim 2, 0, 483, 0, 0, 0, 0,
+ax_anim 2, 0, 482, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioAnims_15_8:
+ax_anim 2, 0, 501, 0, 0, 0, 0,
+ax_anim 2, 0, 501, 1, 0, 0, 0,
+ax_anim 2, 0, 501, 0, 0, 0, 0,
+ax_anim 2, 0, 501, 1, 0, 0, 0,
+ax_anim 2, 0, 501, 0, 0, 0, 0,
+ax_anim 2, 0, 500, 0, 0, 0, 0,
+ax_anim 2, 0, 499, 0, 0, 0, 0,
+ax_anim 2, 0, 498, 0, 0, 0, 0,
+ax_anim 2, 0, 497, 0, 0, 0, 0,
+ax_anim 2, 0, 496, 0, 0, 0, 0,
+ax_anim 2, 0, 495, 0, 0, 0, 0,
+ax_anim 2, 0, 494, 0, 0, 0, 0,
+ax_anim 2, 0, 493, 0, 0, 0, 0,
+ax_anim 2, 0, 492, 0, 0, 0, 0,
+ax_anim_terminator
+sDugtrioGfx1:
+.incbin "baserom.gba", 0x72CE68, 0x20
+sDugtrioSprites1:
+ax_sprite sDugtrioGfx1, 0x20
+ax_sprite_terminator
+sDugtrioGfx2:
+.incbin "baserom.gba", 0x72CE98, 0x80
+sDugtrioSprites2:
+ax_sprite sDugtrioGfx2, 0x80
+ax_sprite_terminator
+sDugtrioGfx3:
+.incbin "baserom.gba", 0x72CF28, 0x40
+sDugtrioSprites3:
+ax_sprite sDugtrioGfx3, 0x40
+ax_sprite_terminator
+sDugtrioGfx4:
+.incbin "baserom.gba", 0x72CF78, 0x40
+sDugtrioSprites4:
+ax_sprite sDugtrioGfx4, 0x40
+ax_sprite_terminator
+sDugtrioGfx5:
+.incbin "baserom.gba", 0x72CFC8, 0x80
+sDugtrioSprites5:
+ax_sprite sDugtrioGfx5, 0x80
+ax_sprite_terminator
+sDugtrioGfx6:
+.incbin "baserom.gba", 0x72D058, 0x20
+sDugtrioSprites6:
+ax_sprite sDugtrioGfx6, 0x20
+ax_sprite_terminator
+sDugtrioGfx7:
+.incbin "baserom.gba", 0x72D088, 0x80
+sDugtrioSprites7:
+ax_sprite sDugtrioGfx7, 0x80
+ax_sprite_terminator
+sDugtrioGfx8:
+.incbin "baserom.gba", 0x72D118, 0x40
+sDugtrioSprites8:
+ax_sprite sDugtrioGfx8, 0x40
+ax_sprite_terminator
+sDugtrioGfx9:
+.incbin "baserom.gba", 0x72D168, 0x20
+sDugtrioSprites9:
+ax_sprite sDugtrioGfx9, 0x20
+ax_sprite_terminator
+sDugtrioGfx10:
+.incbin "baserom.gba", 0x72D198, 0x40
+sDugtrioGfx10_1:
+.incbin "baserom.gba", 0x72D1D8, 0x180
+sDugtrioSprites10:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx10, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx10_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx11:
+.incbin "baserom.gba", 0x72D380, 0x40
+sDugtrioGfx11_1:
+.incbin "baserom.gba", 0x72D3C0, 0x180
+sDugtrioSprites11:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx11, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx11_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx12:
+.incbin "baserom.gba", 0x72D568, 0x40
+sDugtrioGfx12_1:
+.incbin "baserom.gba", 0x72D5A8, 0x180
+sDugtrioSprites12:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx12, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx12_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx13:
+.incbin "baserom.gba", 0x72D750, 0x40
+sDugtrioGfx13_1:
+.incbin "baserom.gba", 0x72D790, 0x180
+sDugtrioSprites13:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx13, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx13_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx14:
+.incbin "baserom.gba", 0x72D938, 0x40
+sDugtrioGfx14_1:
+.incbin "baserom.gba", 0x72D978, 0x180
+sDugtrioSprites14:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx14, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx14_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx15:
+.incbin "baserom.gba", 0x72DB20, 0x60
+sDugtrioGfx15_1:
+.incbin "baserom.gba", 0x72DB80, 0x180
+sDugtrioSprites15:
+ax_sprite sDugtrioGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx15_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx16:
+.incbin "baserom.gba", 0x72DD20, 0x1C0
+sDugtrioSprites16:
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx16, 0x1c0
+ax_sprite_terminator
+sDugtrioGfx17:
+.incbin "baserom.gba", 0x72DEF8, 0x20
+sDugtrioGfx17_1:
+.incbin "baserom.gba", 0x72DF18, 0x180
+sDugtrioSprites17:
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx17_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx18:
+.incbin "baserom.gba", 0x72E0C0, 0x20
+sDugtrioGfx18_1:
+.incbin "baserom.gba", 0x72E0E0, 0x180
+sDugtrioSprites18:
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx18_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx19:
+.incbin "baserom.gba", 0x72E288, 0x40
+sDugtrioGfx19_1:
+.incbin "baserom.gba", 0x72E2C8, 0x180
+sDugtrioSprites19:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx19_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx20:
+.incbin "baserom.gba", 0x72E470, 0x40
+sDugtrioGfx20_1:
+.incbin "baserom.gba", 0x72E4B0, 0x180
+sDugtrioSprites20:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx20_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx21:
+.incbin "baserom.gba", 0x72E658, 0x40
+sDugtrioGfx21_1:
+.incbin "baserom.gba", 0x72E698, 0x60
+sDugtrioGfx21_2:
+.incbin "baserom.gba", 0x72E6F8, 0x100
+sDugtrioSprites21:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx21_2, 0x100
+ax_sprite_terminator
+sDugtrioGfx22:
+.incbin "baserom.gba", 0x72E830, 0x20
+sDugtrioGfx22_1:
+.incbin "baserom.gba", 0x72E850, 0x180
+sDugtrioSprites22:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx22_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx23:
+.incbin "baserom.gba", 0x72E9F8, 0x40
+sDugtrioGfx23_1:
+.incbin "baserom.gba", 0x72EA38, 0x180
+sDugtrioSprites23:
+ax_sprite sDugtrioGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx23_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx24:
+.incbin "baserom.gba", 0x72EBD8, 0x40
+sDugtrioGfx24_1:
+.incbin "baserom.gba", 0x72EC18, 0x180
+sDugtrioSprites24:
+ax_sprite sDugtrioGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx24_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx25:
+.incbin "baserom.gba", 0x72EDB8, 0x40
+sDugtrioGfx25_1:
+.incbin "baserom.gba", 0x72EDF8, 0x180
+sDugtrioSprites25:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx25_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx26:
+.incbin "baserom.gba", 0x72EFA0, 0x20
+sDugtrioGfx26_1:
+.incbin "baserom.gba", 0x72EFC0, 0x180
+sDugtrioSprites26:
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx26, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx26_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx27:
+.incbin "baserom.gba", 0x72F168, 0x1C0
+sDugtrioSprites27:
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx27, 0x1c0
+ax_sprite_terminator
+sDugtrioGfx28:
+.incbin "baserom.gba", 0x72F340, 0x40
+sDugtrioGfx28_1:
+.incbin "baserom.gba", 0x72F380, 0x180
+sDugtrioSprites28:
+ax_sprite sDugtrioGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDugtrioGfx28_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx29:
+.incbin "baserom.gba", 0x72F520, 0x40
+sDugtrioGfx29_1:
+.incbin "baserom.gba", 0x72F560, 0x180
+sDugtrioSprites29:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx29_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx30:
+.incbin "baserom.gba", 0x72F708, 0x40
+sDugtrioGfx30_1:
+.incbin "baserom.gba", 0x72F748, 0x180
+sDugtrioSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx30_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx31:
+.incbin "baserom.gba", 0x72F8F0, 0x60
+sDugtrioGfx31_1:
+.incbin "baserom.gba", 0x72F950, 0x180
+sDugtrioSprites31:
+ax_sprite sDugtrioGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx31_1, 0x180
+ax_sprite_terminator
+sDugtrioGfx32:
+.incbin "baserom.gba", 0x72FAF0, 0x1E0
+sDugtrioSprites32:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx32, 0x1e0
+ax_sprite_terminator
+sDugtrioGfx33:
+.incbin "baserom.gba", 0x72FCE8, 0x1E0
+sDugtrioSprites33:
+ax_sprite 0, 0x20
+ax_sprite sDugtrioGfx33, 0x1e0
+ax_sprite_terminator
+sDugtrioGfx34:
+.incbin "baserom.gba", 0x72FEE0, 0x200
+sDugtrioSprites34:
+ax_sprite sDugtrioGfx34, 0x200
+ax_sprite_terminator
+sDugtrioGfx35:
+.incbin "baserom.gba", 0x7300F0, 0x200
+sDugtrioSprites35:
+ax_sprite sDugtrioGfx35, 0x200
+ax_sprite_terminator
+sDugtrioGfx36:
+.incbin "baserom.gba", 0x730300, 0x200
+sDugtrioSprites36:
+ax_sprite sDugtrioGfx36, 0x200
+ax_sprite_terminator
+sDugtrioGfx37:
+.incbin "baserom.gba", 0x730510, 0x200
+sDugtrioSprites37:
+ax_sprite sDugtrioGfx37, 0x200
+ax_sprite_terminator
+sDugtrioGfx38:
+.incbin "baserom.gba", 0x730720, 0x200
+sDugtrioSprites38:
+ax_sprite sDugtrioGfx38, 0x200
+ax_sprite_terminator
+sDugtrioGfx39:
+.incbin "baserom.gba", 0x730930, 0x200
+sDugtrioSprites39:
+ax_sprite sDugtrioGfx39, 0x200
+ax_sprite_terminator
+sDugtrioGfx40:
+.incbin "baserom.gba", 0x730B40, 0x200
+sDugtrioSprites40:
+ax_sprite sDugtrioGfx40, 0x200
+ax_sprite_terminator
+sDugtrioGfx41:
+.incbin "baserom.gba", 0x730D50, 0x200
+sDugtrioSprites41:
+ax_sprite sDugtrioGfx41, 0x200
+ax_sprite_terminator
+sDugtrioGfx42:
+.incbin "baserom.gba", 0x730F60, 0x200
+sDugtrioSprites42:
+ax_sprite sDugtrioGfx42, 0x200
+ax_sprite_terminator
+sDugtrioGfx43:
+.incbin "baserom.gba", 0x731170, 0x200
+sDugtrioSprites43:
+ax_sprite sDugtrioGfx43, 0x200
+ax_sprite_terminator
+sDugtrioGfx44:
+.incbin "baserom.gba", 0x731380, 0x200
+sDugtrioSprites44:
+ax_sprite sDugtrioGfx44, 0x200
+ax_sprite_terminator
+sDugtrioGfx45:
+.incbin "baserom.gba", 0x731590, 0x200
+sDugtrioSprites45:
+ax_sprite sDugtrioGfx45, 0x200
+ax_sprite_terminator
+sDugtrioGfx46:
+.incbin "baserom.gba", 0x7317A0, 0x200
+sDugtrioSprites46:
+ax_sprite sDugtrioGfx46, 0x200
+ax_sprite_terminator
+sDugtrioGfx47:
+.incbin "baserom.gba", 0x7319B0, 0x200
+sDugtrioSprites47:
+ax_sprite sDugtrioGfx47, 0x200
+ax_sprite_terminator
+sDugtrioGfx48:
+.incbin "baserom.gba", 0x731BC0, 0x200
+sDugtrioSprites48:
+ax_sprite sDugtrioGfx48, 0x200
+ax_sprite_terminator
+sDugtrioGfx49:
+.incbin "baserom.gba", 0x731DD0, 0x20
+sDugtrioSprites49:
+ax_sprite sDugtrioGfx49, 0x20
+ax_sprite_terminator
+sDugtrioGfx50:
+.incbin "baserom.gba", 0x731E00, 0x20
+sDugtrioSprites50:
+ax_sprite sDugtrioGfx50, 0x20
+ax_sprite_terminator
+sDugtrioGfx51:
+.incbin "baserom.gba", 0x731E30, 0x20
+sDugtrioSprites51:
+ax_sprite sDugtrioGfx51, 0x20
+ax_sprite_terminator
+sAxPosesDugtrio:
+.4byte sDugtrioPose1
+.4byte sDugtrioPose2
+.4byte sDugtrioPose3
+.4byte sDugtrioPose4
+.4byte sDugtrioPose5
+.4byte sDugtrioPose6
+.4byte sDugtrioPose7
+.4byte sDugtrioPose8
+.4byte sDugtrioPose9
+.4byte sDugtrioPose10
+.4byte sDugtrioPose11
+.4byte sDugtrioPose12
+.4byte sDugtrioPose13
+.4byte sDugtrioPose14
+.4byte sDugtrioPose15
+.4byte sDugtrioPose16
+.4byte sDugtrioPose17
+.4byte sDugtrioPose18
+.4byte sDugtrioPose19
+.4byte sDugtrioPose20
+.4byte sDugtrioPose21
+.4byte sDugtrioPose22
+.4byte sDugtrioPose23
+.4byte sDugtrioPose24
+.4byte sDugtrioPose25
+.4byte sDugtrioPose26
+.4byte sDugtrioPose27
+.4byte sDugtrioPose28
+.4byte sDugtrioPose29
+.4byte sDugtrioPose30
+.4byte sDugtrioPose31
+.4byte sDugtrioPose32
+.4byte sDugtrioPose33
+.4byte sDugtrioPose34
+.4byte sDugtrioPose35
+.4byte sDugtrioPose36
+.4byte sDugtrioPose37
+.4byte sDugtrioPose38
+.4byte sDugtrioPose39
+.4byte sDugtrioPose40
+.4byte sDugtrioPose41
+.4byte sDugtrioPose42
+.4byte sDugtrioPose43
+.4byte sDugtrioPose44
+.4byte sDugtrioPose45
+.4byte sDugtrioPose46
+.4byte sDugtrioPose47
+.4byte sDugtrioPose48
+.4byte sDugtrioPose49
+.4byte sDugtrioPose50
+.4byte sDugtrioPose51
+.4byte sDugtrioPose52
+.4byte sDugtrioPose53
+.4byte sDugtrioPose54
+.4byte sDugtrioPose55
+.4byte sDugtrioPose56
+.4byte sDugtrioPose57
+.4byte sDugtrioPose58
+.4byte sDugtrioPose59
+.4byte sDugtrioPose60
+.4byte sDugtrioPose61
+.4byte sDugtrioPose62
+.4byte sDugtrioPose63
+.4byte sDugtrioPose64
+.4byte sDugtrioPose65
+.4byte sDugtrioPose66
+.4byte sDugtrioPose67
+.4byte sDugtrioPose68
+.4byte sDugtrioPose69
+.4byte sDugtrioPose70
+.4byte sDugtrioPose71
+.4byte sDugtrioPose72
+.4byte sDugtrioPose73
+.4byte sDugtrioPose74
+.4byte sDugtrioPose75
+.4byte sDugtrioPose76
+.4byte sDugtrioPose77
+.4byte sDugtrioPose78
+.4byte sDugtrioPose79
+.4byte sDugtrioPose80
+.4byte sDugtrioPose81
+.4byte sDugtrioPose82
+.4byte sDugtrioPose83
+.4byte sDugtrioPose84
+.4byte sDugtrioPose85
+.4byte sDugtrioPose86
+.4byte sDugtrioPose87
+.4byte sDugtrioPose88
+.4byte sDugtrioPose89
+.4byte sDugtrioPose90
+.4byte sDugtrioPose91
+.4byte sDugtrioPose92
+.4byte sDugtrioPose93
+.4byte sDugtrioPose94
+.4byte sDugtrioPose95
+.4byte sDugtrioPose96
+.4byte sDugtrioPose97
+.4byte sDugtrioPose98
+.4byte sDugtrioPose99
+.4byte sDugtrioPose100
+.4byte sDugtrioPose101
+.4byte sDugtrioPose102
+.4byte sDugtrioPose103
+.4byte sDugtrioPose104
+.4byte sDugtrioPose105
+.4byte sDugtrioPose106
+.4byte sDugtrioPose107
+.4byte sDugtrioPose108
+.4byte sDugtrioPose109
+.4byte sDugtrioPose110
+.4byte sDugtrioPose111
+.4byte sDugtrioPose112
+.4byte sDugtrioPose113
+.4byte sDugtrioPose114
+.4byte sDugtrioPose115
+.4byte sDugtrioPose116
+.4byte sDugtrioPose117
+.4byte sDugtrioPose118
+.4byte sDugtrioPose119
+.4byte sDugtrioPose120
+.4byte sDugtrioPose121
+.4byte sDugtrioPose122
+.4byte sDugtrioPose123
+.4byte sDugtrioPose124
+.4byte sDugtrioPose125
+.4byte sDugtrioPose126
+.4byte sDugtrioPose127
+.4byte sDugtrioPose128
+.4byte sDugtrioPose129
+.4byte sDugtrioPose130
+.4byte sDugtrioPose131
+.4byte sDugtrioPose132
+.4byte sDugtrioPose133
+.4byte sDugtrioPose134
+.4byte sDugtrioPose135
+.4byte sDugtrioPose136
+.4byte sDugtrioPose137
+.4byte sDugtrioPose138
+.4byte sDugtrioPose139
+.4byte sDugtrioPose140
+.4byte sDugtrioPose141
+.4byte sDugtrioPose142
+.4byte sDugtrioPose143
+.4byte sDugtrioPose144
+.4byte sDugtrioPose145
+.4byte sDugtrioPose146
+.4byte sDugtrioPose147
+.4byte sDugtrioPose148
+.4byte sDugtrioPose149
+.4byte sDugtrioPose150
+.4byte sDugtrioPose151
+.4byte sDugtrioPose152
+.4byte sDugtrioPose153
+.4byte sDugtrioPose154
+.4byte sDugtrioPose155
+.4byte sDugtrioPose156
+.4byte sDugtrioPose157
+.4byte sDugtrioPose158
+.4byte sDugtrioPose159
+.4byte sDugtrioPose160
+.4byte sDugtrioPose161
+.4byte sDugtrioPose162
+.4byte sDugtrioPose163
+.4byte sDugtrioPose164
+.4byte sDugtrioPose165
+.4byte sDugtrioPose166
+.4byte sDugtrioPose167
+.4byte sDugtrioPose168
+.4byte sDugtrioPose169
+.4byte sDugtrioPose170
+.4byte sDugtrioPose171
+.4byte sDugtrioPose172
+.4byte sDugtrioPose173
+.4byte sDugtrioPose174
+.4byte sDugtrioPose175
+.4byte sDugtrioPose176
+.4byte sDugtrioPose177
+.4byte sDugtrioPose178
+.4byte sDugtrioPose179
+.4byte sDugtrioPose180
+.4byte sDugtrioPose181
+.4byte sDugtrioPose182
+.4byte sDugtrioPose183
+.4byte sDugtrioPose184
+.4byte sDugtrioPose185
+.4byte sDugtrioPose186
+.4byte sDugtrioPose187
+.4byte sDugtrioPose188
+.4byte sDugtrioPose189
+.4byte sDugtrioPose190
+.4byte sDugtrioPose191
+.4byte sDugtrioPose192
+.4byte sDugtrioPose193
+.4byte sDugtrioPose194
+.4byte sDugtrioPose195
+.4byte sDugtrioPose196
+.4byte sDugtrioPose197
+.4byte sDugtrioPose198
+.4byte sDugtrioPose199
+.4byte sDugtrioPose200
+.4byte sDugtrioPose201
+.4byte sDugtrioPose202
+.4byte sDugtrioPose203
+.4byte sDugtrioPose204
+.4byte sDugtrioPose205
+.4byte sDugtrioPose206
+.4byte sDugtrioPose207
+.4byte sDugtrioPose208
+.4byte sDugtrioPose209
+.4byte sDugtrioPose210
+.4byte sDugtrioPose211
+.4byte sDugtrioPose212
+.4byte sDugtrioPose213
+.4byte sDugtrioPose214
+.4byte sDugtrioPose215
+.4byte sDugtrioPose216
+.4byte sDugtrioPose217
+.4byte sDugtrioPose218
+.4byte sDugtrioPose219
+.4byte sDugtrioPose220
+.4byte sDugtrioPose221
+.4byte sDugtrioPose222
+.4byte sDugtrioPose223
+.4byte sDugtrioPose224
+.4byte sDugtrioPose225
+.4byte sDugtrioPose226
+.4byte sDugtrioPose227
+.4byte sDugtrioPose228
+.4byte sDugtrioPose229
+.4byte sDugtrioPose230
+.4byte sDugtrioPose231
+.4byte sDugtrioPose232
+.4byte sDugtrioPose233
+.4byte sDugtrioPose234
+.4byte sDugtrioPose235
+.4byte sDugtrioPose236
+.4byte sDugtrioPose237
+.4byte sDugtrioPose238
+.4byte sDugtrioPose239
+.4byte sDugtrioPose240
+.4byte sDugtrioPose241
+.4byte sDugtrioPose242
+.4byte sDugtrioPose243
+.4byte sDugtrioPose244
+.4byte sDugtrioPose245
+.4byte sDugtrioPose246
+.4byte sDugtrioPose247
+.4byte sDugtrioPose248
+.4byte sDugtrioPose249
+.4byte sDugtrioPose250
+.4byte sDugtrioPose251
+.4byte sDugtrioPose252
+.4byte sDugtrioPose253
+.4byte sDugtrioPose254
+.4byte sDugtrioPose255
+.4byte sDugtrioPose256
+.4byte sDugtrioPose257
+.4byte sDugtrioPose258
+.4byte sDugtrioPose259
+.4byte sDugtrioPose260
+.4byte sDugtrioPose261
+.4byte sDugtrioPose262
+.4byte sDugtrioPose263
+.4byte sDugtrioPose264
+.4byte sDugtrioPose265
+.4byte sDugtrioPose266
+.4byte sDugtrioPose267
+.4byte sDugtrioPose268
+.4byte sDugtrioPose269
+.4byte sDugtrioPose270
+.4byte sDugtrioPose271
+.4byte sDugtrioPose272
+.4byte sDugtrioPose273
+.4byte sDugtrioPose274
+.4byte sDugtrioPose275
+.4byte sDugtrioPose276
+.4byte sDugtrioPose277
+.4byte sDugtrioPose278
+.4byte sDugtrioPose279
+.4byte sDugtrioPose280
+.4byte sDugtrioPose281
+.4byte sDugtrioPose282
+.4byte sDugtrioPose283
+.4byte sDugtrioPose284
+.4byte sDugtrioPose285
+.4byte sDugtrioPose286
+.4byte sDugtrioPose287
+.4byte sDugtrioPose288
+.4byte sDugtrioPose289
+.4byte sDugtrioPose290
+.4byte sDugtrioPose291
+.4byte sDugtrioPose292
+.4byte sDugtrioPose293
+.4byte sDugtrioPose294
+.4byte sDugtrioPose295
+.4byte sDugtrioPose296
+.4byte sDugtrioPose297
+.4byte sDugtrioPose298
+.4byte sDugtrioPose299
+.4byte sDugtrioPose300
+.4byte sDugtrioPose301
+.4byte sDugtrioPose302
+.4byte sDugtrioPose303
+.4byte sDugtrioPose304
+.4byte sDugtrioPose305
+.4byte sDugtrioPose306
+.4byte sDugtrioPose307
+.4byte sDugtrioPose308
+.4byte sDugtrioPose309
+.4byte sDugtrioPose310
+.4byte sDugtrioPose311
+.4byte sDugtrioPose312
+.4byte sDugtrioPose313
+.4byte sDugtrioPose314
+.4byte sDugtrioPose315
+.4byte sDugtrioPose316
+.4byte sDugtrioPose317
+.4byte sDugtrioPose318
+.4byte sDugtrioPose319
+.4byte sDugtrioPose320
+.4byte sDugtrioPose321
+.4byte sDugtrioPose322
+.4byte sDugtrioPose323
+.4byte sDugtrioPose324
+.4byte sDugtrioPose325
+.4byte sDugtrioPose326
+.4byte sDugtrioPose327
+.4byte sDugtrioPose328
+.4byte sDugtrioPose329
+.4byte sDugtrioPose330
+.4byte sDugtrioPose331
+.4byte sDugtrioPose332
+.4byte sDugtrioPose333
+.4byte sDugtrioPose334
+.4byte sDugtrioPose335
+.4byte sDugtrioPose336
+.4byte sDugtrioPose337
+.4byte sDugtrioPose338
+.4byte sDugtrioPose339
+.4byte sDugtrioPose340
+.4byte sDugtrioPose341
+.4byte sDugtrioPose342
+.4byte sDugtrioPose343
+.4byte sDugtrioPose344
+.4byte sDugtrioPose345
+.4byte sDugtrioPose346
+.4byte sDugtrioPose347
+.4byte sDugtrioPose348
+.4byte sDugtrioPose349
+.4byte sDugtrioPose350
+.4byte sDugtrioPose351
+.4byte sDugtrioPose352
+.4byte sDugtrioPose353
+.4byte sDugtrioPose354
+.4byte sDugtrioPose355
+.4byte sDugtrioPose356
+.4byte sDugtrioPose357
+.4byte sDugtrioPose358
+.4byte sDugtrioPose359
+.4byte sDugtrioPose360
+.4byte sDugtrioPose361
+.4byte sDugtrioPose362
+.4byte sDugtrioPose363
+.4byte sDugtrioPose364
+.4byte sDugtrioPose365
+.4byte sDugtrioPose366
+.4byte sDugtrioPose367
+.4byte sDugtrioPose368
+.4byte sDugtrioPose369
+.4byte sDugtrioPose370
+.4byte sDugtrioPose371
+.4byte sDugtrioPose372
+.4byte sDugtrioPose373
+.4byte sDugtrioPose374
+.4byte sDugtrioPose375
+.4byte sDugtrioPose376
+.4byte sDugtrioPose377
+.4byte sDugtrioPose378
+.4byte sDugtrioPose379
+.4byte sDugtrioPose380
+.4byte sDugtrioPose381
+.4byte sDugtrioPose382
+.4byte sDugtrioPose383
+.4byte sDugtrioPose384
+.4byte sDugtrioPose385
+.4byte sDugtrioPose386
+.4byte sDugtrioPose387
+.4byte sDugtrioPose388
+.4byte sDugtrioPose389
+.4byte sDugtrioPose390
+.4byte sDugtrioPose391
+.4byte sDugtrioPose392
+.4byte sDugtrioPose393
+.4byte sDugtrioPose394
+.4byte sDugtrioPose395
+.4byte sDugtrioPose396
+.4byte sDugtrioPose397
+.4byte sDugtrioPose398
+.4byte sDugtrioPose399
+.4byte sDugtrioPose400
+.4byte sDugtrioPose401
+.4byte sDugtrioPose402
+.4byte sDugtrioPose403
+.4byte sDugtrioPose404
+.4byte sDugtrioPose405
+.4byte sDugtrioPose406
+.4byte sDugtrioPose407
+.4byte sDugtrioPose408
+.4byte sDugtrioPose409
+.4byte sDugtrioPose410
+.4byte sDugtrioPose411
+.4byte sDugtrioPose412
+.4byte sDugtrioPose413
+.4byte sDugtrioPose414
+.4byte sDugtrioPose415
+.4byte sDugtrioPose416
+.4byte sDugtrioPose417
+.4byte sDugtrioPose418
+.4byte sDugtrioPose419
+.4byte sDugtrioPose420
+.4byte sDugtrioPose421
+.4byte sDugtrioPose422
+.4byte sDugtrioPose423
+.4byte sDugtrioPose424
+.4byte sDugtrioPose425
+.4byte sDugtrioPose426
+.4byte sDugtrioPose427
+.4byte sDugtrioPose428
+.4byte sDugtrioPose429
+.4byte sDugtrioPose430
+.4byte sDugtrioPose431
+.4byte sDugtrioPose432
+.4byte sDugtrioPose433
+.4byte sDugtrioPose434
+.4byte sDugtrioPose435
+.4byte sDugtrioPose436
+.4byte sDugtrioPose437
+.4byte sDugtrioPose438
+.4byte sDugtrioPose439
+.4byte sDugtrioPose440
+.4byte sDugtrioPose441
+.4byte sDugtrioPose442
+.4byte sDugtrioPose443
+.4byte sDugtrioPose444
+.4byte sDugtrioPose445
+.4byte sDugtrioPose446
+.4byte sDugtrioPose447
+.4byte sDugtrioPose448
+.4byte sDugtrioPose449
+.4byte sDugtrioPose450
+.4byte sDugtrioPose451
+.4byte sDugtrioPose452
+.4byte sDugtrioPose453
+.4byte sDugtrioPose454
+.4byte sDugtrioPose455
+.4byte sDugtrioPose456
+.4byte sDugtrioPose457
+.4byte sDugtrioPose458
+.4byte sDugtrioPose459
+.4byte sDugtrioPose460
+.4byte sDugtrioPose461
+.4byte sDugtrioPose462
+.4byte sDugtrioPose463
+.4byte sDugtrioPose464
+.4byte sDugtrioPose465
+.4byte sDugtrioPose466
+.4byte sDugtrioPose467
+.4byte sDugtrioPose468
+.4byte sDugtrioPose469
+.4byte sDugtrioPose470
+.4byte sDugtrioPose471
+.4byte sDugtrioPose472
+.4byte sDugtrioPose473
+.4byte sDugtrioPose474
+.4byte sDugtrioPose475
+.4byte sDugtrioPose476
+.4byte sDugtrioPose477
+.4byte sDugtrioPose478
+.4byte sDugtrioPose479
+.4byte sDugtrioPose480
+.4byte sDugtrioPose481
+.4byte sDugtrioPose482
+.4byte sDugtrioPose483
+.4byte sDugtrioPose484
+.4byte sDugtrioPose485
+.4byte sDugtrioPose486
+.4byte sDugtrioPose487
+.4byte sDugtrioPose488
+.4byte sDugtrioPose489
+.4byte sDugtrioPose490
+.4byte sDugtrioPose491
+.4byte sDugtrioPose492
+.4byte sDugtrioPose493
+.4byte sDugtrioPose494
+.4byte sDugtrioPose495
+.4byte sDugtrioPose496
+.4byte sDugtrioPose497
+.4byte sDugtrioPose498
+.4byte sDugtrioPose499
+.4byte sDugtrioPose500
+.4byte sDugtrioPose501
+.4byte sDugtrioPose502
+sAxPositionsDugtrio:
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -1,   -9, 	 -10,   -8, 	   7,   -4, 	   0,  -11
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -1,   -9, 	 -10,   -8, 	   7,   -4, 	   0,  -11
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -1,  -11, 	 -10,   -3, 	   3,  -11, 	  -4,   -8
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte   -1,  -11, 	 -10,   -3, 	   3,  -11, 	  -4,   -8
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    4,   -8, 	  -2,   -1, 	  -1,  -11, 	  -4,   -6
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    4,   -8, 	  -2,   -1, 	  -1,  -11, 	  -4,   -6
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -12, 	   3,   -2, 	  -4,  -10, 	  -3,   -5
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    3,  -12, 	   3,   -2, 	  -4,  -10, 	  -3,   -5
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,  -10, 	   8,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte    0,  -10, 	   8,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    1,  -11, 	   8,  -10, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte    1,  -11, 	   8,  -10, 	  -6,   -4, 	   0,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -4,  -13, 	   0,  -11, 	   0,   -2, 	   2,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte   -4,  -13, 	   0,  -11, 	   0,   -2, 	   2,   -7
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	  -7,  -14, 	   2,   -1, 	   0,  -10
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	  -7,  -14, 	   2,   -1, 	   0,  -10
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -1,   -9, 	 -10,   -8, 	   7,   -4, 	   0,  -11
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte   -1,   -9, 	 -10,   -8, 	   7,   -4, 	   0,  -11
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -1,  -11, 	 -10,   -3, 	   3,  -11, 	  -4,   -8
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte   -1,  -11, 	 -10,   -3, 	   3,  -11, 	  -4,   -8
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    4,   -8, 	  -2,   -1, 	  -1,  -11, 	  -4,   -6
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    4,   -8, 	  -2,   -1, 	  -1,  -11, 	  -4,   -6
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -12, 	   3,   -2, 	  -4,  -10, 	  -3,   -5
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    3,  -12, 	   3,   -2, 	  -4,  -10, 	  -3,   -5
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,  -10, 	   8,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte    0,  -10, 	   8,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    1,  -11, 	   8,  -10, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte    1,  -11, 	   8,  -10, 	  -6,   -4, 	   0,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -4,  -13, 	   0,  -11, 	   0,   -2, 	   2,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte   -4,  -13, 	   0,  -11, 	   0,   -2, 	   2,   -7
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	  -7,  -14, 	   2,   -1, 	   0,  -10
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	  -7,  -14, 	   2,   -1, 	   0,  -10
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -2,   -4, 	 -10,   -5, 	   7,   -5, 	   0,   -6
+.2byte   -2,   -3, 	 -10,   -5, 	   7,   -5, 	   1,   -5
+.2byte   -1,   -8, 	 -11,   -6, 	   8,   -6, 	   1,   -8
+.2byte    4,   -6, 	   8,  -11, 	  -8,   -7, 	  -1,   -8
+.2byte    5,  -11, 	   0,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    0,  -11, 	  -9,  -12, 	   9,   -8, 	  -1,   -7
+.2byte   -1,  -10, 	  10,   -8, 	 -10,  -10, 	  -1,   -6
+.2byte   -1,  -11, 	   8,  -12, 	 -10,   -8, 	   0,   -7
+.2byte   -6,  -11, 	  -1,  -14, 	  -4,   -3, 	   0,   -9
+.2byte   -5,   -6, 	  -9,  -11, 	   7,   -7, 	   0,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -2,   -2, 	 -10,   -3, 	   8,   -3, 	   0,   -7
+.2byte   -7,   -3, 	  -7,  -11, 	   3,    0, 	  -1,   -7
+.2byte   -6,  -11, 	   1,  -11, 	   4,   -2, 	  -1,   -6
+.2byte   -2,   -9, 	   7,  -11, 	  -8,   -4, 	   0,   -7
+.2byte    0,   -9, 	   9,   -7, 	  -9,   -7, 	  -1,   -5
+.2byte    4,   -7, 	   2,   -2, 	  -3,  -12, 	  -1,   -6
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	  -1,   -5
+.2byte    3,   -3, 	  -8,   -4, 	   6,   -8, 	  -1,   -7
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -1,   -9, 	 -10,   -8, 	   7,   -4, 	   0,  -11
+.2byte   -2,    3, 	 -10,   -6, 	   7,    0, 	  -1,   -5
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -1,  -11, 	 -10,   -3, 	   3,  -11, 	  -4,   -8
+.2byte    2,    0, 	  -8,   -3, 	   8,   -6, 	   0,   -6
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    4,   -8, 	  -2,   -1, 	  -1,  -11, 	  -4,   -6
+.2byte    7,   -3, 	   1,    1, 	   4,  -10, 	   0,   -5
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -12, 	   3,   -2, 	  -4,  -10, 	  -3,   -5
+.2byte    6,   -6, 	   9,   -1, 	  -1,   -9, 	   1,   -4
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,  -10, 	   8,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte   -1,   -6, 	   9,   -5, 	  -9,   -5, 	  -1,   -3
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    1,  -11, 	   8,  -10, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -9, 	   7,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -4,  -13, 	   0,  -11, 	   0,   -2, 	   2,   -7
+.2byte  -10,   -7, 	  -8,  -12, 	  -1,   -1, 	  -2,   -7
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	  -7,  -14, 	   2,   -1, 	   0,  -10
+.2byte   -8,    2, 	  -3,  -11, 	   1,   -1, 	  -1,   -7
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte   -2,   -2, 	 -11,   -2, 	   8,   -2, 	  -1,   -8
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    3,   -3, 	  -8,   -2, 	   4,   -8, 	  -2,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    6,   -5, 	  -3,   -1, 	   3,   -9, 	   0,   -4
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    3,  -10, 	   2,   -2, 	  -3,  -11, 	  -1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -9, 	   9,   -6, 	  -9,   -6, 	  -2,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -1,   -9, 	   7,  -10, 	  -8,   -4, 	   1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -8,  -10, 	   1,  -10, 	   4,   -2, 	  -1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -7,   -4, 	  -7,  -10, 	   3,   -2, 	  -1,   -6
+sDugtrioAnimTable1:
+.4byte sDugtrioAnims_1_1
+.4byte sDugtrioAnims_1_2
+.4byte sDugtrioAnims_1_3
+.4byte sDugtrioAnims_1_4
+.4byte sDugtrioAnims_1_5
+.4byte sDugtrioAnims_1_6
+.4byte sDugtrioAnims_1_7
+.4byte sDugtrioAnims_1_8
+sDugtrioAnimTable2:
+.4byte sDugtrioAnims_2_1
+.4byte sDugtrioAnims_2_2
+.4byte sDugtrioAnims_2_3
+.4byte sDugtrioAnims_2_4
+.4byte sDugtrioAnims_2_5
+.4byte sDugtrioAnims_2_6
+.4byte sDugtrioAnims_2_7
+.4byte sDugtrioAnims_2_8
+sDugtrioAnimTable3:
+.4byte sDugtrioAnims_3_1
+.4byte sDugtrioAnims_3_2
+.4byte sDugtrioAnims_3_3
+.4byte sDugtrioAnims_3_4
+.4byte sDugtrioAnims_3_5
+.4byte sDugtrioAnims_3_6
+.4byte sDugtrioAnims_3_7
+.4byte sDugtrioAnims_3_8
+sDugtrioAnimTable4:
+.4byte sDugtrioAnims_4_1
+.4byte sDugtrioAnims_4_2
+.4byte sDugtrioAnims_4_3
+.4byte sDugtrioAnims_4_4
+.4byte sDugtrioAnims_4_5
+.4byte sDugtrioAnims_4_6
+.4byte sDugtrioAnims_4_7
+.4byte sDugtrioAnims_4_8
+sDugtrioAnimTable5:
+.4byte sDugtrioAnims_5_1
+.4byte sDugtrioAnims_5_2
+.4byte sDugtrioAnims_5_3
+.4byte sDugtrioAnims_5_4
+.4byte sDugtrioAnims_5_5
+.4byte sDugtrioAnims_5_6
+.4byte sDugtrioAnims_5_7
+.4byte sDugtrioAnims_5_8
+sDugtrioAnimTable6:
+.4byte sDugtrioAnims_6_1
+.4byte sDugtrioAnims_6_1
+.4byte sDugtrioAnims_6_1
+.4byte sDugtrioAnims_6_1
+.4byte sDugtrioAnims_6_1
+.4byte sDugtrioAnims_6_1
+.4byte sDugtrioAnims_6_1
+.4byte sDugtrioAnims_6_1
+sDugtrioAnimTable7:
+.4byte sDugtrioAnims_7_1
+.4byte sDugtrioAnims_7_2
+.4byte sDugtrioAnims_7_3
+.4byte sDugtrioAnims_7_4
+.4byte sDugtrioAnims_7_5
+.4byte sDugtrioAnims_7_6
+.4byte sDugtrioAnims_7_7
+.4byte sDugtrioAnims_7_8
+sDugtrioAnimTable8:
+.4byte sDugtrioAnims_8_1
+.4byte sDugtrioAnims_8_2
+.4byte sDugtrioAnims_8_3
+.4byte sDugtrioAnims_8_4
+.4byte sDugtrioAnims_8_5
+.4byte sDugtrioAnims_8_6
+.4byte sDugtrioAnims_8_7
+.4byte sDugtrioAnims_8_8
+sDugtrioAnimTable9:
+.4byte sDugtrioAnims_9_1
+.4byte sDugtrioAnims_9_2
+.4byte sDugtrioAnims_9_3
+.4byte sDugtrioAnims_9_4
+.4byte sDugtrioAnims_9_5
+.4byte sDugtrioAnims_9_6
+.4byte sDugtrioAnims_9_7
+.4byte sDugtrioAnims_9_8
+sDugtrioAnimTable10:
+.4byte sDugtrioAnims_10_1
+.4byte sDugtrioAnims_10_2
+.4byte sDugtrioAnims_10_3
+.4byte sDugtrioAnims_10_4
+.4byte sDugtrioAnims_10_5
+.4byte sDugtrioAnims_10_6
+.4byte sDugtrioAnims_10_7
+.4byte sDugtrioAnims_10_8
+sDugtrioAnimTable11:
+.4byte sDugtrioAnims_11_1
+.4byte sDugtrioAnims_11_2
+.4byte sDugtrioAnims_11_3
+.4byte sDugtrioAnims_11_4
+.4byte sDugtrioAnims_11_5
+.4byte sDugtrioAnims_11_6
+.4byte sDugtrioAnims_11_7
+.4byte sDugtrioAnims_11_8
+sDugtrioAnimTable12:
+.4byte sDugtrioAnims_12_1
+.4byte sDugtrioAnims_12_2
+.4byte sDugtrioAnims_12_3
+.4byte sDugtrioAnims_12_4
+.4byte sDugtrioAnims_12_5
+.4byte sDugtrioAnims_12_6
+.4byte sDugtrioAnims_12_7
+.4byte sDugtrioAnims_12_8
+sDugtrioAnimTable13:
+.4byte sDugtrioAnims_13_1
+.4byte sDugtrioAnims_13_2
+.4byte sDugtrioAnims_13_3
+.4byte sDugtrioAnims_13_4
+.4byte sDugtrioAnims_13_5
+.4byte sDugtrioAnims_13_6
+.4byte sDugtrioAnims_13_7
+.4byte sDugtrioAnims_13_8
+sDugtrioAnimTable14:
+.4byte sDugtrioAnims_14_1
+.4byte sDugtrioAnims_14_2
+.4byte sDugtrioAnims_14_3
+.4byte sDugtrioAnims_14_4
+.4byte sDugtrioAnims_14_5
+.4byte sDugtrioAnims_14_6
+.4byte sDugtrioAnims_14_7
+.4byte sDugtrioAnims_14_8
+sDugtrioAnimTable15:
+.4byte sDugtrioAnims_15_1
+.4byte sDugtrioAnims_15_2
+.4byte sDugtrioAnims_15_3
+.4byte sDugtrioAnims_15_4
+.4byte sDugtrioAnims_15_5
+.4byte sDugtrioAnims_15_6
+.4byte sDugtrioAnims_15_7
+.4byte sDugtrioAnims_15_8
+sAxAnimationsDugtrio:
+.4byte sDugtrioAnimTable1
+.4byte sDugtrioAnimTable2
+.4byte sDugtrioAnimTable3
+.4byte sDugtrioAnimTable4
+.4byte sDugtrioAnimTable5
+.4byte sDugtrioAnimTable6
+.4byte sDugtrioAnimTable7
+.4byte sDugtrioAnimTable8
+.4byte sDugtrioAnimTable9
+.4byte sDugtrioAnimTable10
+.4byte sDugtrioAnimTable11
+.4byte sDugtrioAnimTable12
+.4byte sDugtrioAnimTable13
+.4byte sDugtrioAnimTable14
+.4byte sDugtrioAnimTable15
+sAxSpritesDugtrio:
+.4byte sDugtrioSprites1
+.4byte sDugtrioSprites2
+.4byte sDugtrioSprites3
+.4byte sDugtrioSprites4
+.4byte sDugtrioSprites5
+.4byte sDugtrioSprites6
+.4byte sDugtrioSprites7
+.4byte sDugtrioSprites8
+.4byte sDugtrioSprites9
+.4byte sDugtrioSprites10
+.4byte sDugtrioSprites11
+.4byte sDugtrioSprites12
+.4byte sDugtrioSprites13
+.4byte sDugtrioSprites14
+.4byte sDugtrioSprites15
+.4byte sDugtrioSprites16
+.4byte sDugtrioSprites17
+.4byte sDugtrioSprites18
+.4byte sDugtrioSprites19
+.4byte sDugtrioSprites20
+.4byte sDugtrioSprites21
+.4byte sDugtrioSprites22
+.4byte sDugtrioSprites23
+.4byte sDugtrioSprites24
+.4byte sDugtrioSprites25
+.4byte sDugtrioSprites26
+.4byte sDugtrioSprites27
+.4byte sDugtrioSprites28
+.4byte sDugtrioSprites29
+.4byte sDugtrioSprites30
+.4byte sDugtrioSprites31
+.4byte sDugtrioSprites32
+.4byte sDugtrioSprites33
+.4byte sDugtrioSprites34
+.4byte sDugtrioSprites35
+.4byte sDugtrioSprites36
+.4byte sDugtrioSprites37
+.4byte sDugtrioSprites38
+.4byte sDugtrioSprites39
+.4byte sDugtrioSprites40
+.4byte sDugtrioSprites41
+.4byte sDugtrioSprites42
+.4byte sDugtrioSprites43
+.4byte sDugtrioSprites44
+.4byte sDugtrioSprites45
+.4byte sDugtrioSprites46
+.4byte sDugtrioSprites47
+.4byte sDugtrioSprites48
+.4byte sDugtrioSprites49
+.4byte sDugtrioSprites50
+.4byte sDugtrioSprites51
+sAxMainDugtrio:
+ax_main sAxPosesDugtrio, sAxAnimationsDugtrio, 15, sAxSpritesDugtrio, sAxPositionsDugtrio

--- a/data/ax/dunsparce.inc
+++ b/data/ax/dunsparce.inc
@@ -1,0 +1,2689 @@
+.global gAxDunsparce
+gAxDunsparce:
+ax_siro sAxMainDunsparce
+sDunsparcePose1:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose2:
+ax_pose 1, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose3:
+ax_pose 2, 0x01eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose4:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose5:
+ax_pose 4, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose6:
+ax_pose 5, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose7:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose8:
+ax_pose 7, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose9:
+ax_pose 8, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose10:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose11:
+ax_pose 10, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose12:
+ax_pose 11, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose13:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose14:
+ax_pose 13, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose15:
+ax_pose 14, 0x41f7, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose16:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose17:
+ax_pose 10, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose18:
+ax_pose 11, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose19:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose20:
+ax_pose 7, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose22:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose23:
+ax_pose 4, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose24:
+ax_pose 5, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose25:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose26:
+ax_pose 1, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose27:
+ax_pose 2, 0x01eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose28:
+ax_pose 15, 0x81eb, 0x80f7, 0x0c00
+ax_pose_terminator
+sDunsparcePose29:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose30:
+ax_pose 4, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose31:
+ax_pose 5, 0x01ec, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose32:
+ax_pose 16, 0x81ea, 0x90f6, 0x0c00
+ax_pose 17, 0x01fa, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose33:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose34:
+ax_pose 7, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose35:
+ax_pose 8, 0x01ed, 0x90f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose36:
+ax_pose 18, 0x81ec, 0x90f6, 0x0c00
+ax_pose 19, 0x01fc, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose37:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose38:
+ax_pose 10, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose39:
+ax_pose 11, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose40:
+ax_pose 20, 0x81eb, 0x90f6, 0x0c00
+ax_pose 21, 0x01f3, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose41:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose42:
+ax_pose 13, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose43:
+ax_pose 14, 0x41f4, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose44:
+ax_pose 22, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose45:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose46:
+ax_pose 10, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose47:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sDunsparcePose48:
+ax_pose 20, 0x81eb, 0x80fa, 0x0c00
+ax_pose 21, 0x01f3, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose49:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose50:
+ax_pose 7, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose51:
+ax_pose 8, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose52:
+ax_pose 18, 0x81ec, 0x80fa, 0x0c00
+ax_pose 19, 0x01fc, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose53:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose54:
+ax_pose 4, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose55:
+ax_pose 5, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose56:
+ax_pose 16, 0x81ea, 0x80fa, 0x0c00
+ax_pose 17, 0x01fa, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose57:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose58:
+ax_pose 1, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose59:
+ax_pose 2, 0x01eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose60:
+ax_pose 15, 0x81eb, 0x80f7, 0x0c00
+ax_pose_terminator
+sDunsparcePose61:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose62:
+ax_pose 4, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose63:
+ax_pose 5, 0x01ec, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose64:
+ax_pose 16, 0x81ea, 0x90f6, 0x0c00
+ax_pose 17, 0x01fa, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose65:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose66:
+ax_pose 7, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose67:
+ax_pose 8, 0x01ed, 0x90f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose68:
+ax_pose 18, 0x81ec, 0x90f6, 0x0c00
+ax_pose 19, 0x01fc, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose69:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose70:
+ax_pose 10, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose71:
+ax_pose 11, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose72:
+ax_pose 20, 0x81eb, 0x90f6, 0x0c00
+ax_pose 21, 0x01f3, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose73:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose74:
+ax_pose 13, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose75:
+ax_pose 14, 0x41f4, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose76:
+ax_pose 22, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose77:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose78:
+ax_pose 10, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose79:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sDunsparcePose80:
+ax_pose 20, 0x81eb, 0x80fa, 0x0c00
+ax_pose 21, 0x01f3, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose81:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose82:
+ax_pose 7, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose83:
+ax_pose 8, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose84:
+ax_pose 18, 0x81ec, 0x80fa, 0x0c00
+ax_pose 19, 0x01fc, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose85:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose86:
+ax_pose 4, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose87:
+ax_pose 5, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose88:
+ax_pose 16, 0x81ea, 0x80fa, 0x0c00
+ax_pose 17, 0x01fa, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose89:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose90:
+ax_pose 1, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose91:
+ax_pose 2, 0x01eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose92:
+ax_pose 15, 0x81eb, 0x80f7, 0x0c00
+ax_pose_terminator
+sDunsparcePose93:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose94:
+ax_pose 4, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose95:
+ax_pose 5, 0x01ec, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose96:
+ax_pose 16, 0x81ea, 0x90f6, 0x0c00
+ax_pose 17, 0x01fa, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose97:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose98:
+ax_pose 7, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose99:
+ax_pose 8, 0x01ed, 0x90f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose100:
+ax_pose 18, 0x81ec, 0x90f6, 0x0c00
+ax_pose 19, 0x01fc, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose101:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose102:
+ax_pose 10, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose103:
+ax_pose 11, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose104:
+ax_pose 20, 0x81eb, 0x90f6, 0x0c00
+ax_pose 21, 0x01f3, 0x10ee, 0x0c08
+ax_pose_terminator
+sDunsparcePose105:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose106:
+ax_pose 13, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose107:
+ax_pose 14, 0x41f4, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose108:
+ax_pose 22, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose109:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose110:
+ax_pose 10, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose111:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sDunsparcePose112:
+ax_pose 20, 0x81eb, 0x80fa, 0x0c00
+ax_pose 21, 0x01f3, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose113:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose114:
+ax_pose 7, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose115:
+ax_pose 8, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose116:
+ax_pose 18, 0x81ec, 0x80fa, 0x0c00
+ax_pose 19, 0x01fc, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose117:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose118:
+ax_pose 4, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose119:
+ax_pose 5, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose120:
+ax_pose 16, 0x81ea, 0x80fa, 0x0c00
+ax_pose 17, 0x01fa, 0x010a, 0x0c08
+ax_pose_terminator
+sDunsparcePose121:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose122:
+ax_pose 23, 0x01f6, 0x40f7, 0x0c00
+ax_pose 24, 0x81f6, 0x0107, 0x0c04
+ax_pose_terminator
+sDunsparcePose123:
+ax_pose 25, 0x81f0, 0x80f9, 0x0c00
+ax_pose_terminator
+sDunsparcePose124:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose125:
+ax_pose 26, 0x81f3, 0x9100, 0x0c00
+ax_pose 27, 0x81f3, 0x10f8, 0x0c08
+ax_pose_terminator
+sDunsparcePose126:
+ax_pose 28, 0x41f7, 0x90ef, 0x0c00
+ax_pose 29, 0x01ef, 0x10ff, 0x0c08
+ax_pose_terminator
+sDunsparcePose127:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose128:
+ax_pose 30, 0x01f3, 0x50fd, 0x0c00
+ax_pose 31, 0x81f3, 0x10f5, 0x0c04
+ax_pose_terminator
+sDunsparcePose129:
+ax_pose 32, 0x41f6, 0x90f1, 0x0c00
+ax_pose 33, 0x01ee, 0x10f9, 0x0c08
+ax_pose_terminator
+sDunsparcePose130:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose131:
+ax_pose 34, 0x81ef, 0x90fb, 0x0c00
+ax_pose 35, 0x81f7, 0x10f3, 0x0c08
+ax_pose_terminator
+sDunsparcePose132:
+ax_pose 36, 0x01f5, 0x5100, 0x0c00
+ax_pose 37, 0x81f5, 0x50f8, 0x0c04
+ax_pose_terminator
+sDunsparcePose133:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose134:
+ax_pose 38, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose135:
+ax_pose 39, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose136:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose137:
+ax_pose 34, 0x81ef, 0x80f6, 0x0c00
+ax_pose 35, 0x81f7, 0x0106, 0x0c08
+ax_pose_terminator
+sDunsparcePose138:
+ax_pose 36, 0x01f5, 0x40f1, 0x0c00
+ax_pose 37, 0x81f5, 0x4101, 0x0c04
+ax_pose_terminator
+sDunsparcePose139:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose140:
+ax_pose 30, 0x01f3, 0x40f4, 0x0c00
+ax_pose 31, 0x81f3, 0x0104, 0x0c04
+ax_pose_terminator
+sDunsparcePose141:
+ax_pose 32, 0x41f6, 0x80f0, 0x0c00
+ax_pose 33, 0x01ee, 0x0100, 0x0c08
+ax_pose_terminator
+sDunsparcePose142:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose143:
+ax_pose 26, 0x81f3, 0x80f1, 0x0c00
+ax_pose 27, 0x81f3, 0x0101, 0x0c08
+ax_pose_terminator
+sDunsparcePose144:
+ax_pose 28, 0x41f7, 0x80f2, 0x0c00
+ax_pose 29, 0x01ef, 0x00fa, 0x0c08
+ax_pose_terminator
+sDunsparcePose145:
+ax_pose 40, 0x41f6, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose146:
+ax_pose 41, 0x41f6, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose147:
+ax_pose 42, 0x01e1, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose148:
+ax_pose 43, 0x01e1, 0x90ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose149:
+ax_pose 44, 0x01e1, 0x90ed, 0x0c00
+ax_pose_terminator
+sDunsparcePose150:
+ax_pose 45, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sDunsparcePose151:
+ax_pose 46, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose152:
+ax_pose 45, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sDunsparcePose153:
+ax_pose 44, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sDunsparcePose154:
+ax_pose 43, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose155:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose156:
+ax_pose 23, 0x01f6, 0x40f7, 0x0c00
+ax_pose 24, 0x81f6, 0x0107, 0x0c04
+ax_pose_terminator
+sDunsparcePose157:
+ax_pose 25, 0x81f0, 0x80f9, 0x0c00
+ax_pose_terminator
+sDunsparcePose158:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose159:
+ax_pose 26, 0x81f3, 0x9100, 0x0c00
+ax_pose 27, 0x81f3, 0x10f8, 0x0c08
+ax_pose_terminator
+sDunsparcePose160:
+ax_pose 28, 0x41f7, 0x90ef, 0x0c00
+ax_pose 29, 0x01ef, 0x10ff, 0x0c08
+ax_pose_terminator
+sDunsparcePose161:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose162:
+ax_pose 30, 0x01f3, 0x50fd, 0x0c00
+ax_pose 31, 0x81f3, 0x10f5, 0x0c04
+ax_pose_terminator
+sDunsparcePose163:
+ax_pose 32, 0x41f6, 0x90f1, 0x0c00
+ax_pose 33, 0x01ee, 0x10f9, 0x0c08
+ax_pose_terminator
+sDunsparcePose164:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose165:
+ax_pose 34, 0x81ef, 0x90fb, 0x0c00
+ax_pose 35, 0x81f7, 0x10f3, 0x0c08
+ax_pose_terminator
+sDunsparcePose166:
+ax_pose 36, 0x01f5, 0x5100, 0x0c00
+ax_pose 37, 0x81f5, 0x50f8, 0x0c04
+ax_pose_terminator
+sDunsparcePose167:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose168:
+ax_pose 38, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose169:
+ax_pose 39, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose170:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose171:
+ax_pose 34, 0x81ef, 0x80f6, 0x0c00
+ax_pose 35, 0x81f7, 0x0106, 0x0c08
+ax_pose_terminator
+sDunsparcePose172:
+ax_pose 36, 0x01f5, 0x40f1, 0x0c00
+ax_pose 37, 0x81f5, 0x4101, 0x0c04
+ax_pose_terminator
+sDunsparcePose173:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose174:
+ax_pose 30, 0x01f3, 0x40f4, 0x0c00
+ax_pose 31, 0x81f3, 0x0104, 0x0c04
+ax_pose_terminator
+sDunsparcePose175:
+ax_pose 32, 0x41f6, 0x80f0, 0x0c00
+ax_pose 33, 0x01ee, 0x0100, 0x0c08
+ax_pose_terminator
+sDunsparcePose176:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose177:
+ax_pose 26, 0x81f3, 0x80f1, 0x0c00
+ax_pose 27, 0x81f3, 0x0101, 0x0c08
+ax_pose_terminator
+sDunsparcePose178:
+ax_pose 28, 0x41f7, 0x80f2, 0x0c00
+ax_pose 29, 0x01ef, 0x00fa, 0x0c08
+ax_pose_terminator
+sDunsparcePose179:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose180:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose181:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose182:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose183:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose184:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose185:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose186:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose187:
+ax_pose 15, 0x81eb, 0x80f7, 0x0c00
+ax_pose_terminator
+sDunsparcePose188:
+ax_pose 16, 0x81ea, 0x90f7, 0x0c00
+ax_pose 17, 0x01fa, 0x10ef, 0x0c08
+ax_pose_terminator
+sDunsparcePose189:
+ax_pose 18, 0x81eb, 0x90f8, 0x0c00
+ax_pose 19, 0x01fb, 0x10f0, 0x0c08
+ax_pose_terminator
+sDunsparcePose190:
+ax_pose 20, 0x81e9, 0x90f8, 0x0c00
+ax_pose 21, 0x01f1, 0x10f0, 0x0c08
+ax_pose_terminator
+sDunsparcePose191:
+ax_pose 22, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose192:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose 21, 0x01f1, 0x0108, 0x0c08
+ax_pose_terminator
+sDunsparcePose193:
+ax_pose 18, 0x81eb, 0x80f8, 0x0c00
+ax_pose 19, 0x01fb, 0x0108, 0x0c08
+ax_pose_terminator
+sDunsparcePose194:
+ax_pose 16, 0x81ea, 0x80f9, 0x0c00
+ax_pose 17, 0x01fa, 0x0109, 0x0c08
+ax_pose_terminator
+sDunsparcePose195:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose196:
+ax_pose 1, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose197:
+ax_pose 2, 0x01eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose198:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose199:
+ax_pose 4, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose200:
+ax_pose 5, 0x01ec, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose201:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose202:
+ax_pose 7, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose203:
+ax_pose 8, 0x01ed, 0x90f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose204:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose205:
+ax_pose 10, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose206:
+ax_pose 11, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose207:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose208:
+ax_pose 13, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose209:
+ax_pose 14, 0x41f4, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose210:
+ax_pose 9, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose211:
+ax_pose 10, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose212:
+ax_pose 11, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose213:
+ax_pose 6, 0x41f3, 0x80ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose214:
+ax_pose 7, 0x41f3, 0x80ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose215:
+ax_pose 8, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose216:
+ax_pose 3, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose217:
+ax_pose 4, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose218:
+ax_pose 5, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sDunsparcePose219:
+ax_pose 25, 0x81f0, 0x80f9, 0x0c00
+ax_pose_terminator
+sDunsparcePose220:
+ax_pose 28, 0x41f7, 0x80f2, 0x0c00
+ax_pose 29, 0x01ef, 0x00fa, 0x0c08
+ax_pose_terminator
+sDunsparcePose221:
+ax_pose 32, 0x41f6, 0x80f0, 0x0c00
+ax_pose 33, 0x01ee, 0x0100, 0x0c08
+ax_pose_terminator
+sDunsparcePose222:
+ax_pose 36, 0x01f5, 0x40f1, 0x0c00
+ax_pose 37, 0x81f5, 0x4101, 0x0c04
+ax_pose_terminator
+sDunsparcePose223:
+ax_pose 39, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose224:
+ax_pose 36, 0x01f5, 0x5100, 0x0c00
+ax_pose 37, 0x81f5, 0x50f8, 0x0c04
+ax_pose_terminator
+sDunsparcePose225:
+ax_pose 32, 0x41f6, 0x90f1, 0x0c00
+ax_pose 33, 0x01ee, 0x10f9, 0x0c08
+ax_pose_terminator
+sDunsparcePose226:
+ax_pose 28, 0x41f7, 0x90ef, 0x0c00
+ax_pose 29, 0x01ef, 0x10ff, 0x0c08
+ax_pose_terminator
+sDunsparcePose227:
+ax_pose 0, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose228:
+ax_pose 3, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose229:
+ax_pose 6, 0x41f3, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose230:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sDunsparcePose231:
+ax_pose 12, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sDunsparcePose232:
+ax_pose 9, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose233:
+ax_pose 6, 0x41f3, 0x90f1, 0x0c00
+ax_pose_terminator
+sDunsparcePose234:
+ax_pose 3, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+.align 2
+sDunsparceAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -4, 0, 0,
+ax_anim 6, 0, 2, 0, -4, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -4, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -6, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -6, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -8, 0, 0,
+ax_anim 6, 0, 14, 0, -7, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -6, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -6, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -4, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_2_1:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, -3, 0, 2,
+ax_anim 2, 2, 25, 0, 3, 0, 7,
+ax_anim 2, 0, 26, 0, 9, 0, 10,
+ax_anim 2, 1, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 26, -1, 12, -1, 12,
+ax_anim 2, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 26, -1, 12, -1, 12,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDunsparceAnims_2_2:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 4, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 4, -1, 4, 2,
+ax_anim 2, 2, 29, 10, 3, 10, 8,
+ax_anim 2, 0, 30, 15, 7, 15, 13,
+ax_anim 2, 1, 30, 18, 16, 18, 16,
+ax_anim 2, 0, 30, 19, 15, 19, 15,
+ax_anim 2, 0, 30, 18, 16, 18, 16,
+ax_anim 2, 0, 30, 19, 15, 19, 15,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sDunsparceAnims_2_3:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 4, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 2, -3, 2, 0,
+ax_anim 2, 2, 33, 7, -5, 7, 0,
+ax_anim 2, 0, 34, 13, -5, 13, 0,
+ax_anim 2, 1, 34, 18, -1, 18, -1,
+ax_anim 2, 0, 34, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 18, -1, 18, -1,
+ax_anim 2, 0, 34, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sDunsparceAnims_2_4:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -6, 0, -1,
+ax_anim 2, 2, 37, 6, -15, 6, -9,
+ax_anim 2, 0, 38, 12, -22, 12, -17,
+ax_anim 2, 1, 38, 18, -25, 18, -25,
+ax_anim 2, 0, 38, 17, -26, 17, -26,
+ax_anim 2, 0, 38, 18, -25, 18, -25,
+ax_anim 2, 0, 38, 17, -26, 17, -26,
+ax_anim 2, 0, 36, 6, -9, 6, -9,
+ax_anim_terminator
+sDunsparceAnims_2_5:
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 4, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, -4, 0, -2,
+ax_anim 2, 2, 41, 0, -12, 0, -9,
+ax_anim 2, 0, 42, 0, -19, 0, -17,
+ax_anim 2, 1, 42, 0, -23, 0, -23,
+ax_anim 2, 0, 42, -1, -23, -1, -23,
+ax_anim 2, 0, 42, 0, -23, 0, -23,
+ax_anim 2, 0, 42, -1, -23, -1, -23,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sDunsparceAnims_2_6:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 4, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -6, 0, -1,
+ax_anim 2, 2, 45, -6, -15, -6, -9,
+ax_anim 2, 0, 46, -12, -22, -12, -17,
+ax_anim 2, 1, 46, -18, -25, -18, -25,
+ax_anim 2, 0, 46, -17, -26, -17, -26,
+ax_anim 2, 0, 46, -18, -25, -18, -25,
+ax_anim 2, 0, 46, -17, -26, -17, -26,
+ax_anim 2, 0, 44, -6, -9, -6, -9,
+ax_anim_terminator
+sDunsparceAnims_2_7:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 4, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 49, -2, -3, -2, 0,
+ax_anim 2, 2, 49, -7, -5, -7, 0,
+ax_anim 2, 0, 50, -13, -5, -13, 0,
+ax_anim 2, 1, 50, -17, -1, -17, -1,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 0, 50, -17, -1, -17, -1,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sDunsparceAnims_2_8:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 4, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 0, 53, -4, -1, -4, 2,
+ax_anim 2, 2, 53, -10, 3, -10, 8,
+ax_anim 2, 0, 54, -15, 7, -15, 13,
+ax_anim 2, 1, 54, -18, 16, -18, 16,
+ax_anim 2, 0, 54, -19, 15, -19, 15,
+ax_anim 2, 0, 54, -18, 16, -18, 16,
+ax_anim 2, 0, 54, -19, 15, -19, 15,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_3_1:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 4, 0, 59, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, -3, 0, 2,
+ax_anim 2, 2, 57, 0, 3, 0, 7,
+ax_anim 2, 0, 58, 0, 9, 0, 10,
+ax_anim 2, 1, 58, 0, 12, 0, 12,
+ax_anim 2, 0, 58, -1, 12, -1, 12,
+ax_anim 2, 0, 58, 0, 12, 0, 12,
+ax_anim 2, 0, 58, -1, 12, -1, 12,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sDunsparceAnims_3_2:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, -1, -1, -1, -1,
+ax_anim 4, 0, 63, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 4, -1, 4, 2,
+ax_anim 2, 2, 61, 10, 3, 10, 8,
+ax_anim 2, 0, 62, 15, 7, 15, 13,
+ax_anim 2, 1, 62, 18, 16, 18, 16,
+ax_anim 2, 0, 62, 19, 15, 19, 15,
+ax_anim 2, 0, 62, 18, 16, 18, 16,
+ax_anim 2, 0, 62, 19, 15, 19, 15,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sDunsparceAnims_3_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -1, 0, -1, 0,
+ax_anim 4, 0, 67, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 2, -3, 2, 0,
+ax_anim 2, 2, 65, 7, -5, 7, 0,
+ax_anim 2, 0, 66, 13, -5, 13, 0,
+ax_anim 2, 1, 66, 18, -1, 18, -1,
+ax_anim 2, 0, 66, 18, 0, 18, 0,
+ax_anim 2, 0, 66, 18, -1, 18, -1,
+ax_anim 2, 0, 66, 18, 0, 18, 0,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sDunsparceAnims_3_4:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, -1, 1, -1, 1,
+ax_anim 4, 0, 71, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -6, 0, -1,
+ax_anim 2, 2, 69, 6, -15, 6, -9,
+ax_anim 2, 0, 70, 12, -22, 12, -17,
+ax_anim 2, 1, 70, 18, -25, 18, -25,
+ax_anim 2, 0, 70, 17, -26, 17, -26,
+ax_anim 2, 0, 70, 18, -25, 18, -25,
+ax_anim 2, 0, 70, 17, -26, 17, -26,
+ax_anim 2, 0, 68, 6, -9, 6, -9,
+ax_anim_terminator
+sDunsparceAnims_3_5:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 4, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, -4, 0, -2,
+ax_anim 2, 2, 73, 0, -12, 0, -9,
+ax_anim 2, 0, 74, 0, -19, 0, -17,
+ax_anim 2, 1, 74, 0, -23, 0, -23,
+ax_anim 2, 0, 74, -1, -23, -1, -23,
+ax_anim 2, 0, 74, 0, -23, 0, -23,
+ax_anim 2, 0, 74, -1, -23, -1, -23,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sDunsparceAnims_3_6:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 4, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 2, 77, -6, -15, -6, -9,
+ax_anim 2, 0, 78, -12, -22, -12, -17,
+ax_anim 2, 1, 78, -18, -25, -18, -25,
+ax_anim 2, 0, 78, -17, -26, -17, -26,
+ax_anim 2, 0, 78, -18, -25, -18, -25,
+ax_anim 2, 0, 78, -17, -26, -17, -26,
+ax_anim 2, 0, 76, -6, -9, -6, -9,
+ax_anim_terminator
+sDunsparceAnims_3_7:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 4, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 0, 81, -2, -3, -2, 0,
+ax_anim 2, 2, 81, -7, -5, -7, 0,
+ax_anim 2, 0, 82, -13, -5, -13, 0,
+ax_anim 2, 1, 82, -17, -1, -17, -1,
+ax_anim 2, 0, 82, -17, 0, -17, 0,
+ax_anim 2, 0, 82, -17, -1, -17, -1,
+ax_anim 2, 0, 82, -17, 0, -17, 0,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sDunsparceAnims_3_8:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 4, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 0, 85, -4, -1, -4, 2,
+ax_anim 2, 2, 85, -10, 3, -10, 8,
+ax_anim 2, 0, 86, -15, 7, -15, 13,
+ax_anim 2, 1, 86, -18, 16, -18, 16,
+ax_anim 2, 0, 86, -19, 15, -19, 15,
+ax_anim 2, 0, 86, -18, 16, -18, 16,
+ax_anim 2, 0, 86, -19, 15, -19, 15,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_4_1:
+ax_anim 2, 0, 91, 0, -2, 0, -2,
+ax_anim 6, 2, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sDunsparceAnims_4_2:
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 6, 2, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 1, 94, 2, 2, 1, 1,
+ax_anim 2, 0, 94, 3, 1, 2, 0,
+ax_anim 2, 0, 94, 2, 2, 1, 1,
+ax_anim 2, 0, 94, 3, 1, 2, 0,
+ax_anim 2, 0, 94, 2, 2, 1, 1,
+ax_anim 2, 0, 94, 3, 1, 2, 0,
+ax_anim 2, 0, 94, 2, 2, 1, 1,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sDunsparceAnims_4_3:
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 6, 2, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 1, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 1, 2, 1,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 1, 2, 1,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 1, 2, 1,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sDunsparceAnims_4_4:
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 6, 2, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 1, 102, 2, -2, 1, -1,
+ax_anim 2, 0, 102, 3, -1, 2, 0,
+ax_anim 2, 0, 102, 2, -2, 1, -1,
+ax_anim 2, 0, 102, 3, -1, 2, 0,
+ax_anim 2, 0, 102, 2, -2, 1, -1,
+ax_anim 2, 0, 102, 3, -1, 2, 0,
+ax_anim 2, 0, 102, 2, -2, 1, -1,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim_terminator
+sDunsparceAnims_4_5:
+ax_anim 2, 0, 107, 0, 2, 0, 2,
+ax_anim 6, 2, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 1, 106, 0, -3, 0, -2,
+ax_anim 2, 0, 106, 1, -3, 1, -2,
+ax_anim 2, 0, 106, 0, -3, 0, -2,
+ax_anim 2, 0, 106, 1, -3, 1, -2,
+ax_anim 2, 0, 106, 0, -3, 0, -2,
+ax_anim 2, 0, 106, 1, -3, 1, -2,
+ax_anim 2, 0, 106, 0, -3, 0, -2,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim_terminator
+sDunsparceAnims_4_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 6, 2, 111, 3, 3, 3, 3,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 1, 110, -2, -2, -1, -1,
+ax_anim 2, 0, 110, -3, -1, -2, 0,
+ax_anim 2, 0, 110, -2, -2, -1, -1,
+ax_anim 2, 0, 110, -3, -1, -2, 0,
+ax_anim 2, 0, 110, -2, -2, -1, -1,
+ax_anim 2, 0, 110, -3, -1, -2, 0,
+ax_anim 2, 0, 110, -2, -2, -1, -1,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim_terminator
+sDunsparceAnims_4_7:
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 6, 2, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim_terminator
+sDunsparceAnims_4_8:
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim 6, 2, 119, 3, -3, 3, -3,
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim 2, 1, 118, -2, 2, -1, 1,
+ax_anim 2, 0, 118, -3, 1, -2, 0,
+ax_anim 2, 0, 118, -2, 2, -1, 1,
+ax_anim 2, 0, 118, -3, 1, -2, 0,
+ax_anim 2, 0, 118, -2, 2, -1, 1,
+ax_anim 2, 0, 118, -3, 1, -2, 0,
+ax_anim 2, 0, 118, -2, 2, -1, 1,
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_5_1:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 2, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_5_2:
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_5_3:
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_5_4:
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_5_5:
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_5_6:
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_5_7:
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_5_8:
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sDunsparceAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sDunsparceAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sDunsparceAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sDunsparceAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sDunsparceAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sDunsparceAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sDunsparceAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_8_1:
+ax_anim 36, 0, 154, 0, 0, 0, 0,
+ax_anim 19, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_8_2:
+ax_anim 36, 0, 157, 0, 0, 0, 0,
+ax_anim 19, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_8_3:
+ax_anim 36, 0, 160, 0, 0, 0, 0,
+ax_anim 19, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_8_4:
+ax_anim 36, 0, 163, 0, 0, 0, 0,
+ax_anim 19, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_8_5:
+ax_anim 36, 0, 166, 0, 0, 0, 0,
+ax_anim 19, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_8_6:
+ax_anim 36, 0, 169, 0, 0, 0, 0,
+ax_anim 19, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_8_7:
+ax_anim 36, 0, 172, 0, 0, 0, 0,
+ax_anim 19, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_8_8:
+ax_anim 36, 0, 175, 0, 0, 0, 0,
+ax_anim 19, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 7, 8, 7,
+ax_anim 2, 0, 181, 7, 14, 7, 14,
+ax_anim 3, 0, 182, 0, 17, 0, 17,
+ax_anim 2, 3, 183, -7, 14, -7, 14,
+ax_anim 2, 0, 184, -8, 7, -8, 7,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, -1, 8, -1,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 21, 10, 21, 10,
+ax_anim 3, 0, 181, 20, 18, 20, 18,
+ax_anim 2, 3, 182, 11, 20, 11, 20,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 2, -5, 2, -5,
+ax_anim 2, 0, 178, 11, -8, 11, -8,
+ax_anim 2, 0, 179, 17, -6, 17, -6,
+ax_anim 3, 0, 180, 19, -2, 19, -2,
+ax_anim 2, 3, 181, 17, 6, 17, 6,
+ax_anim 2, 0, 182, 12, 9, 12, 9,
+ax_anim 1, 0, 183, 5, 7, 5, 7,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -2, -8, -2, -8,
+ax_anim 2, 0, 185, 1, -16, 1, -16,
+ax_anim 2, 0, 178, 10, -24, 10, -24,
+ax_anim 3, 0, 179, 18, -25, 18, -25,
+ax_anim 2, 3, 180, 22, -16, 22, -16,
+ax_anim 2, 0, 181, 18, -4, 18, -4,
+ax_anim 1, 0, 182, 8, 1, 8, 1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -10, -12, -10, -12,
+ax_anim 2, 0, 185, -7, -21, -7, -21,
+ax_anim 3, 0, 178, 0, -25, 0, -25,
+ax_anim 2, 3, 179, 7, -21, 7, -21,
+ax_anim 2, 0, 180, 10, -12, 10, -12,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 2, -8, 2, -8,
+ax_anim 2, 0, 179, -1, -16, -1, -16,
+ax_anim 2, 0, 178, -10, -24, -10, -24,
+ax_anim 3, 0, 185, -18, -25, -18, -25,
+ax_anim 2, 3, 184, -22, -16, -22, -16,
+ax_anim 2, 0, 183, -18, -4, -18, -4,
+ax_anim 1, 0, 182, -8, -1, -8, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -2, -5, -2, -5,
+ax_anim 2, 0, 178, -11, -8, -11, -8,
+ax_anim 2, 0, 185, -17, -6, -17, -6,
+ax_anim 3, 0, 184, -19, -2, -19, -2,
+ax_anim 2, 3, 183, -17, 6, -17, 6,
+ax_anim 2, 0, 182, -12, 9, -12, 9,
+ax_anim 1, 0, 181, -5, 7, -5, 7,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, -1, -8, -1,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -21, 10, -21, 10,
+ax_anim 3, 0, 183, -20, 18, -20, 18,
+ax_anim 2, 3, 182, -11, 20, -11, 20,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -24, 0, 0,
+ax_anim 3, 0, 199, 0, -18, 0, 0,
+ax_anim 2, 0, 199, 0, -12, 0, 0,
+ax_anim 1, 0, 199, 0, -8, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -18, 0, 0,
+ax_anim 2, 0, 202, 0, -14, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -19, 0, 0,
+ax_anim 4, 0, 204, 0, -22, 0, 0,
+ax_anim 4, 0, 203, 0, -24, 0, 0,
+ax_anim 3, 0, 205, 0, -19, 0, 0,
+ax_anim 2, 0, 205, 0, -13, 0, 0,
+ax_anim 1, 0, 205, 0, -9, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -19, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 4, 0, 209, 0, -24, 0, 0,
+ax_anim 3, 0, 211, 0, -19, 0, 0,
+ax_anim 2, 0, 211, 0, -13, 0, 0,
+ax_anim 1, 0, 211, 0, -9, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -18, 0, 0,
+ax_anim 2, 0, 214, 0, -14, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -24, 0, 0,
+ax_anim 3, 0, 217, 0, -18, 0, 0,
+ax_anim 2, 0, 217, 0, -12, 0, 0,
+ax_anim 1, 0, 217, 0, -8, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDunsparceAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sDunsparceGfx1:
+.incbin "baserom.gba", 0xE4F704, 0x100
+sDunsparceSprites1:
+ax_sprite sDunsparceGfx1, 0x100
+ax_sprite_terminator
+sDunsparceGfx2:
+.incbin "baserom.gba", 0xE4F814, 0x100
+sDunsparceSprites2:
+ax_sprite sDunsparceGfx2, 0x100
+ax_sprite_terminator
+sDunsparceGfx3:
+.incbin "baserom.gba", 0xE4F924, 0x200
+sDunsparceSprites3:
+ax_sprite sDunsparceGfx3, 0x200
+ax_sprite_terminator
+sDunsparceGfx4:
+.incbin "baserom.gba", 0xE4FB34, 0x200
+sDunsparceSprites4:
+ax_sprite sDunsparceGfx4, 0x200
+ax_sprite_terminator
+sDunsparceGfx5:
+.incbin "baserom.gba", 0xE4FD44, 0x200
+sDunsparceSprites5:
+ax_sprite sDunsparceGfx5, 0x200
+ax_sprite_terminator
+sDunsparceGfx6:
+.incbin "baserom.gba", 0xE4FF54, 0x200
+sDunsparceSprites6:
+ax_sprite sDunsparceGfx6, 0x200
+ax_sprite_terminator
+sDunsparceGfx7:
+.incbin "baserom.gba", 0xE50164, 0x100
+sDunsparceSprites7:
+ax_sprite sDunsparceGfx7, 0x100
+ax_sprite_terminator
+sDunsparceGfx8:
+.incbin "baserom.gba", 0xE50274, 0x100
+sDunsparceSprites8:
+ax_sprite sDunsparceGfx8, 0x100
+ax_sprite_terminator
+sDunsparceGfx9:
+.incbin "baserom.gba", 0xE50384, 0x200
+sDunsparceSprites9:
+ax_sprite sDunsparceGfx9, 0x200
+ax_sprite_terminator
+sDunsparceGfx10:
+.incbin "baserom.gba", 0xE50594, 0x200
+sDunsparceSprites10:
+ax_sprite sDunsparceGfx10, 0x200
+ax_sprite_terminator
+sDunsparceGfx11:
+.incbin "baserom.gba", 0xE507A4, 0x200
+sDunsparceSprites11:
+ax_sprite sDunsparceGfx11, 0x200
+ax_sprite_terminator
+sDunsparceGfx12:
+.incbin "baserom.gba", 0xE509B4, 0x200
+sDunsparceSprites12:
+ax_sprite sDunsparceGfx12, 0x200
+ax_sprite_terminator
+sDunsparceGfx13:
+.incbin "baserom.gba", 0xE50BC4, 0x100
+sDunsparceSprites13:
+ax_sprite sDunsparceGfx13, 0x100
+ax_sprite_terminator
+sDunsparceGfx14:
+.incbin "baserom.gba", 0xE50CD4, 0x100
+sDunsparceSprites14:
+ax_sprite sDunsparceGfx14, 0x100
+ax_sprite_terminator
+sDunsparceGfx15:
+.incbin "baserom.gba", 0xE50DE4, 0x100
+sDunsparceSprites15:
+ax_sprite sDunsparceGfx15, 0x100
+ax_sprite_terminator
+sDunsparceGfx16:
+.incbin "baserom.gba", 0xE50EF4, 0xC0
+sDunsparceSprites16:
+ax_sprite sDunsparceGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx17:
+.incbin "baserom.gba", 0xE50FCC, 0xC0
+sDunsparceSprites17:
+ax_sprite sDunsparceGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx18:
+.incbin "baserom.gba", 0xE510A4, 0x20
+sDunsparceSprites18:
+ax_sprite sDunsparceGfx18, 0x20
+ax_sprite_terminator
+sDunsparceGfx19:
+.incbin "baserom.gba", 0xE510D4, 0xC0
+sDunsparceSprites19:
+ax_sprite sDunsparceGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx20:
+.incbin "baserom.gba", 0xE511AC, 0x20
+sDunsparceSprites20:
+ax_sprite sDunsparceGfx20, 0x20
+ax_sprite_terminator
+sDunsparceGfx21:
+.incbin "baserom.gba", 0xE511DC, 0x100
+sDunsparceSprites21:
+ax_sprite sDunsparceGfx21, 0x100
+ax_sprite_terminator
+sDunsparceGfx22:
+.incbin "baserom.gba", 0xE512EC, 0x20
+sDunsparceSprites22:
+ax_sprite sDunsparceGfx22, 0x20
+ax_sprite_terminator
+sDunsparceGfx23:
+.incbin "baserom.gba", 0xE5131C, 0x100
+sDunsparceSprites23:
+ax_sprite sDunsparceGfx23, 0x100
+ax_sprite_terminator
+sDunsparceGfx24:
+.incbin "baserom.gba", 0xE5142C, 0x80
+sDunsparceSprites24:
+ax_sprite sDunsparceGfx24, 0x80
+ax_sprite_terminator
+sDunsparceGfx25:
+.incbin "baserom.gba", 0xE514BC, 0x40
+sDunsparceSprites25:
+ax_sprite sDunsparceGfx25, 0x40
+ax_sprite_terminator
+sDunsparceGfx26:
+.incbin "baserom.gba", 0xE5150C, 0xC0
+sDunsparceSprites26:
+ax_sprite sDunsparceGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx27:
+.incbin "baserom.gba", 0xE515E4, 0xC0
+sDunsparceSprites27:
+ax_sprite sDunsparceGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx28:
+.incbin "baserom.gba", 0xE516BC, 0x40
+sDunsparceSprites28:
+ax_sprite sDunsparceGfx28, 0x40
+ax_sprite_terminator
+sDunsparceGfx29:
+.incbin "baserom.gba", 0xE5170C, 0x100
+sDunsparceSprites29:
+ax_sprite sDunsparceGfx29, 0x100
+ax_sprite_terminator
+sDunsparceGfx30:
+.incbin "baserom.gba", 0xE5181C, 0x20
+sDunsparceSprites30:
+ax_sprite sDunsparceGfx30, 0x20
+ax_sprite_terminator
+sDunsparceGfx31:
+.incbin "baserom.gba", 0xE5184C, 0x80
+sDunsparceSprites31:
+ax_sprite sDunsparceGfx31, 0x80
+ax_sprite_terminator
+sDunsparceGfx32:
+.incbin "baserom.gba", 0xE518DC, 0x40
+sDunsparceSprites32:
+ax_sprite sDunsparceGfx32, 0x40
+ax_sprite_terminator
+sDunsparceGfx33:
+.incbin "baserom.gba", 0xE5192C, 0x100
+sDunsparceSprites33:
+ax_sprite sDunsparceGfx33, 0x100
+ax_sprite_terminator
+sDunsparceGfx34:
+.incbin "baserom.gba", 0xE51A3C, 0x20
+sDunsparceSprites34:
+ax_sprite sDunsparceGfx34, 0x20
+ax_sprite_terminator
+sDunsparceGfx35:
+.incbin "baserom.gba", 0xE51A6C, 0xC0
+sDunsparceSprites35:
+ax_sprite sDunsparceGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx36:
+.incbin "baserom.gba", 0xE51B44, 0x40
+sDunsparceSprites36:
+ax_sprite sDunsparceGfx36, 0x40
+ax_sprite_terminator
+sDunsparceGfx37:
+.incbin "baserom.gba", 0xE51B94, 0x80
+sDunsparceSprites37:
+ax_sprite sDunsparceGfx37, 0x80
+ax_sprite_terminator
+sDunsparceGfx38:
+.incbin "baserom.gba", 0xE51C24, 0x60
+sDunsparceSprites38:
+ax_sprite sDunsparceGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDunsparceGfx39:
+.incbin "baserom.gba", 0xE51C9C, 0xC0
+sDunsparceSprites39:
+ax_sprite sDunsparceGfx39, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx40:
+.incbin "baserom.gba", 0xE51D74, 0xC0
+sDunsparceSprites40:
+ax_sprite sDunsparceGfx40, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sDunsparceGfx41:
+.incbin "baserom.gba", 0xE51E4C, 0x100
+sDunsparceSprites41:
+ax_sprite sDunsparceGfx41, 0x100
+ax_sprite_terminator
+sDunsparceGfx42:
+.incbin "baserom.gba", 0xE51F5C, 0x100
+sDunsparceSprites42:
+ax_sprite sDunsparceGfx42, 0x100
+ax_sprite_terminator
+sDunsparceGfx43:
+.incbin "baserom.gba", 0xE5206C, 0x200
+sDunsparceSprites43:
+ax_sprite sDunsparceGfx43, 0x200
+ax_sprite_terminator
+sDunsparceGfx44:
+.incbin "baserom.gba", 0xE5227C, 0x200
+sDunsparceSprites44:
+ax_sprite sDunsparceGfx44, 0x200
+ax_sprite_terminator
+sDunsparceGfx45:
+.incbin "baserom.gba", 0xE5248C, 0x200
+sDunsparceSprites45:
+ax_sprite sDunsparceGfx45, 0x200
+ax_sprite_terminator
+sDunsparceGfx46:
+.incbin "baserom.gba", 0xE5269C, 0x200
+sDunsparceSprites46:
+ax_sprite sDunsparceGfx46, 0x200
+ax_sprite_terminator
+sDunsparceGfx47:
+.incbin "baserom.gba", 0xE528AC, 0x200
+sDunsparceSprites47:
+ax_sprite sDunsparceGfx47, 0x200
+ax_sprite_terminator
+sAxPosesDunsparce:
+.4byte sDunsparcePose1
+.4byte sDunsparcePose2
+.4byte sDunsparcePose3
+.4byte sDunsparcePose4
+.4byte sDunsparcePose5
+.4byte sDunsparcePose6
+.4byte sDunsparcePose7
+.4byte sDunsparcePose8
+.4byte sDunsparcePose9
+.4byte sDunsparcePose10
+.4byte sDunsparcePose11
+.4byte sDunsparcePose12
+.4byte sDunsparcePose13
+.4byte sDunsparcePose14
+.4byte sDunsparcePose15
+.4byte sDunsparcePose16
+.4byte sDunsparcePose17
+.4byte sDunsparcePose18
+.4byte sDunsparcePose19
+.4byte sDunsparcePose20
+.4byte sDunsparcePose21
+.4byte sDunsparcePose22
+.4byte sDunsparcePose23
+.4byte sDunsparcePose24
+.4byte sDunsparcePose25
+.4byte sDunsparcePose26
+.4byte sDunsparcePose27
+.4byte sDunsparcePose28
+.4byte sDunsparcePose29
+.4byte sDunsparcePose30
+.4byte sDunsparcePose31
+.4byte sDunsparcePose32
+.4byte sDunsparcePose33
+.4byte sDunsparcePose34
+.4byte sDunsparcePose35
+.4byte sDunsparcePose36
+.4byte sDunsparcePose37
+.4byte sDunsparcePose38
+.4byte sDunsparcePose39
+.4byte sDunsparcePose40
+.4byte sDunsparcePose41
+.4byte sDunsparcePose42
+.4byte sDunsparcePose43
+.4byte sDunsparcePose44
+.4byte sDunsparcePose45
+.4byte sDunsparcePose46
+.4byte sDunsparcePose47
+.4byte sDunsparcePose48
+.4byte sDunsparcePose49
+.4byte sDunsparcePose50
+.4byte sDunsparcePose51
+.4byte sDunsparcePose52
+.4byte sDunsparcePose53
+.4byte sDunsparcePose54
+.4byte sDunsparcePose55
+.4byte sDunsparcePose56
+.4byte sDunsparcePose57
+.4byte sDunsparcePose58
+.4byte sDunsparcePose59
+.4byte sDunsparcePose60
+.4byte sDunsparcePose61
+.4byte sDunsparcePose62
+.4byte sDunsparcePose63
+.4byte sDunsparcePose64
+.4byte sDunsparcePose65
+.4byte sDunsparcePose66
+.4byte sDunsparcePose67
+.4byte sDunsparcePose68
+.4byte sDunsparcePose69
+.4byte sDunsparcePose70
+.4byte sDunsparcePose71
+.4byte sDunsparcePose72
+.4byte sDunsparcePose73
+.4byte sDunsparcePose74
+.4byte sDunsparcePose75
+.4byte sDunsparcePose76
+.4byte sDunsparcePose77
+.4byte sDunsparcePose78
+.4byte sDunsparcePose79
+.4byte sDunsparcePose80
+.4byte sDunsparcePose81
+.4byte sDunsparcePose82
+.4byte sDunsparcePose83
+.4byte sDunsparcePose84
+.4byte sDunsparcePose85
+.4byte sDunsparcePose86
+.4byte sDunsparcePose87
+.4byte sDunsparcePose88
+.4byte sDunsparcePose89
+.4byte sDunsparcePose90
+.4byte sDunsparcePose91
+.4byte sDunsparcePose92
+.4byte sDunsparcePose93
+.4byte sDunsparcePose94
+.4byte sDunsparcePose95
+.4byte sDunsparcePose96
+.4byte sDunsparcePose97
+.4byte sDunsparcePose98
+.4byte sDunsparcePose99
+.4byte sDunsparcePose100
+.4byte sDunsparcePose101
+.4byte sDunsparcePose102
+.4byte sDunsparcePose103
+.4byte sDunsparcePose104
+.4byte sDunsparcePose105
+.4byte sDunsparcePose106
+.4byte sDunsparcePose107
+.4byte sDunsparcePose108
+.4byte sDunsparcePose109
+.4byte sDunsparcePose110
+.4byte sDunsparcePose111
+.4byte sDunsparcePose112
+.4byte sDunsparcePose113
+.4byte sDunsparcePose114
+.4byte sDunsparcePose115
+.4byte sDunsparcePose116
+.4byte sDunsparcePose117
+.4byte sDunsparcePose118
+.4byte sDunsparcePose119
+.4byte sDunsparcePose120
+.4byte sDunsparcePose121
+.4byte sDunsparcePose122
+.4byte sDunsparcePose123
+.4byte sDunsparcePose124
+.4byte sDunsparcePose125
+.4byte sDunsparcePose126
+.4byte sDunsparcePose127
+.4byte sDunsparcePose128
+.4byte sDunsparcePose129
+.4byte sDunsparcePose130
+.4byte sDunsparcePose131
+.4byte sDunsparcePose132
+.4byte sDunsparcePose133
+.4byte sDunsparcePose134
+.4byte sDunsparcePose135
+.4byte sDunsparcePose136
+.4byte sDunsparcePose137
+.4byte sDunsparcePose138
+.4byte sDunsparcePose139
+.4byte sDunsparcePose140
+.4byte sDunsparcePose141
+.4byte sDunsparcePose142
+.4byte sDunsparcePose143
+.4byte sDunsparcePose144
+.4byte sDunsparcePose145
+.4byte sDunsparcePose146
+.4byte sDunsparcePose147
+.4byte sDunsparcePose148
+.4byte sDunsparcePose149
+.4byte sDunsparcePose150
+.4byte sDunsparcePose151
+.4byte sDunsparcePose152
+.4byte sDunsparcePose153
+.4byte sDunsparcePose154
+.4byte sDunsparcePose155
+.4byte sDunsparcePose156
+.4byte sDunsparcePose157
+.4byte sDunsparcePose158
+.4byte sDunsparcePose159
+.4byte sDunsparcePose160
+.4byte sDunsparcePose161
+.4byte sDunsparcePose162
+.4byte sDunsparcePose163
+.4byte sDunsparcePose164
+.4byte sDunsparcePose165
+.4byte sDunsparcePose166
+.4byte sDunsparcePose167
+.4byte sDunsparcePose168
+.4byte sDunsparcePose169
+.4byte sDunsparcePose170
+.4byte sDunsparcePose171
+.4byte sDunsparcePose172
+.4byte sDunsparcePose173
+.4byte sDunsparcePose174
+.4byte sDunsparcePose175
+.4byte sDunsparcePose176
+.4byte sDunsparcePose177
+.4byte sDunsparcePose178
+.4byte sDunsparcePose179
+.4byte sDunsparcePose180
+.4byte sDunsparcePose181
+.4byte sDunsparcePose182
+.4byte sDunsparcePose183
+.4byte sDunsparcePose184
+.4byte sDunsparcePose185
+.4byte sDunsparcePose186
+.4byte sDunsparcePose187
+.4byte sDunsparcePose188
+.4byte sDunsparcePose189
+.4byte sDunsparcePose190
+.4byte sDunsparcePose191
+.4byte sDunsparcePose192
+.4byte sDunsparcePose193
+.4byte sDunsparcePose194
+.4byte sDunsparcePose195
+.4byte sDunsparcePose196
+.4byte sDunsparcePose197
+.4byte sDunsparcePose198
+.4byte sDunsparcePose199
+.4byte sDunsparcePose200
+.4byte sDunsparcePose201
+.4byte sDunsparcePose202
+.4byte sDunsparcePose203
+.4byte sDunsparcePose204
+.4byte sDunsparcePose205
+.4byte sDunsparcePose206
+.4byte sDunsparcePose207
+.4byte sDunsparcePose208
+.4byte sDunsparcePose209
+.4byte sDunsparcePose210
+.4byte sDunsparcePose211
+.4byte sDunsparcePose212
+.4byte sDunsparcePose213
+.4byte sDunsparcePose214
+.4byte sDunsparcePose215
+.4byte sDunsparcePose216
+.4byte sDunsparcePose217
+.4byte sDunsparcePose218
+.4byte sDunsparcePose219
+.4byte sDunsparcePose220
+.4byte sDunsparcePose221
+.4byte sDunsparcePose222
+.4byte sDunsparcePose223
+.4byte sDunsparcePose224
+.4byte sDunsparcePose225
+.4byte sDunsparcePose226
+.4byte sDunsparcePose227
+.4byte sDunsparcePose228
+.4byte sDunsparcePose229
+.4byte sDunsparcePose230
+.4byte sDunsparcePose231
+.4byte sDunsparcePose232
+.4byte sDunsparcePose233
+.4byte sDunsparcePose234
+sAxPositionsDunsparce:
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte    0,    0, 	  -4,  -11, 	   4,  -11, 	   0,   -4
+.2byte    0,    6, 	  -7,   -6, 	   7,   -6, 	   0,   -1
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    8,   -5, 	  -2,  -12, 	  -7,   -7, 	  -1,   -5
+.2byte    9,    1, 	   5,  -10, 	  -5,   -3, 	   1,   -4
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte    9,   -8, 	  -5,   -7, 	  -4,   -3, 	   0,   -5
+.2byte   12,   -2, 	   1,  -13, 	  -2,   -8, 	   3,   -6
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte    8,  -11, 	  -4,   -9, 	   1,   -5, 	  -1,   -7
+.2byte    9,   -6, 	  -3,  -11, 	   4,   -4, 	   2,   -7
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    0,  -12, 	   4,   -2, 	  -4,   -2, 	   0,   -4
+.2byte    0,   -4, 	   6,   -1, 	  -6,   -1, 	   0,   -2
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte   -8,  -11, 	   4,   -9, 	  -1,   -5, 	   1,   -7
+.2byte   -9,   -6, 	   3,  -11, 	  -4,   -4, 	  -2,   -7
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte   -9,   -8, 	   5,   -7, 	   4,   -3, 	   0,   -5
+.2byte  -12,   -2, 	  -1,  -13, 	   2,   -8, 	  -3,   -6
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte   -8,   -5, 	   2,  -12, 	   7,   -7, 	   1,   -5
+.2byte   -9,    1, 	  -5,  -10, 	   5,   -3, 	  -1,   -4
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte    0,    0, 	  -4,  -11, 	   4,  -11, 	   0,   -4
+.2byte    0,    6, 	  -7,   -6, 	   7,   -6, 	   0,   -1
+.2byte    0,  -12, 	  -4,  -16, 	   4,  -16, 	   0,   -7
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    8,   -5, 	  -2,  -12, 	  -7,   -7, 	  -1,   -5
+.2byte    9,    2, 	   5,   -9, 	  -5,   -2, 	   1,   -3
+.2byte    1,  -15, 	  -2,  -10, 	  -8,   -7, 	   0,   -8
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte    9,   -8, 	  -5,   -7, 	  -4,   -3, 	   0,   -5
+.2byte   11,    0, 	   0,  -11, 	  -3,   -6, 	   2,   -4
+.2byte    3,  -16, 	  -7,   -9, 	  -5,   -3, 	  -1,   -7
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte    8,   -8, 	  -4,   -6, 	   1,   -2, 	  -1,   -4
+.2byte    7,   -3, 	  -5,   -8, 	   2,   -1, 	   0,   -4
+.2byte    1,  -15, 	  -9,   -9, 	  -1,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    0,  -14, 	   4,   -4, 	  -4,   -4, 	   0,   -6
+.2byte    0,   -7, 	   6,   -4, 	  -6,   -4, 	   0,   -5
+.2byte    0,  -15, 	   5,   -7, 	  -5,   -7, 	   0,   -6
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte   -8,   -8, 	   4,   -6, 	  -1,   -2, 	   1,   -4
+.2byte   -7,   -3, 	   5,   -8, 	  -2,   -1, 	   0,   -4
+.2byte   -2,  -15, 	   8,   -9, 	   0,   -7, 	   1,   -6
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte   -9,   -8, 	   5,   -7, 	   4,   -3, 	   0,   -5
+.2byte  -11,    0, 	   0,  -11, 	   3,   -6, 	  -2,   -4
+.2byte   -4,  -16, 	   6,   -9, 	   4,   -3, 	   0,   -7
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte   -8,   -5, 	   2,  -12, 	   7,   -7, 	   1,   -5
+.2byte   -9,    2, 	  -5,   -9, 	   5,   -2, 	  -1,   -3
+.2byte   -2,  -15, 	   1,  -10, 	   7,   -7, 	  -1,   -8
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte    0,    0, 	  -4,  -11, 	   4,  -11, 	   0,   -4
+.2byte    0,    6, 	  -7,   -6, 	   7,   -6, 	   0,   -1
+.2byte    0,  -12, 	  -4,  -16, 	   4,  -16, 	   0,   -7
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    8,   -5, 	  -2,  -12, 	  -7,   -7, 	  -1,   -5
+.2byte    9,    2, 	   5,   -9, 	  -5,   -2, 	   1,   -3
+.2byte    1,  -15, 	  -2,  -10, 	  -8,   -7, 	   0,   -8
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte    9,   -8, 	  -5,   -7, 	  -4,   -3, 	   0,   -5
+.2byte   11,    0, 	   0,  -11, 	  -3,   -6, 	   2,   -4
+.2byte    3,  -16, 	  -7,   -9, 	  -5,   -3, 	  -1,   -7
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte    8,   -8, 	  -4,   -6, 	   1,   -2, 	  -1,   -4
+.2byte    7,   -3, 	  -5,   -8, 	   2,   -1, 	   0,   -4
+.2byte    1,  -15, 	  -9,   -9, 	  -1,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    0,  -14, 	   4,   -4, 	  -4,   -4, 	   0,   -6
+.2byte    0,   -7, 	   6,   -4, 	  -6,   -4, 	   0,   -5
+.2byte    0,  -15, 	   5,   -7, 	  -5,   -7, 	   0,   -6
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte   -8,   -8, 	   4,   -6, 	  -1,   -2, 	   1,   -4
+.2byte   -7,   -3, 	   5,   -8, 	  -2,   -1, 	   0,   -4
+.2byte   -2,  -15, 	   8,   -9, 	   0,   -7, 	   1,   -6
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte   -9,   -8, 	   5,   -7, 	   4,   -3, 	   0,   -5
+.2byte  -11,    0, 	   0,  -11, 	   3,   -6, 	  -2,   -4
+.2byte   -4,  -16, 	   6,   -9, 	   4,   -3, 	   0,   -7
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte   -8,   -5, 	   2,  -12, 	   7,   -7, 	   1,   -5
+.2byte   -9,    2, 	  -5,   -9, 	   5,   -2, 	  -1,   -3
+.2byte   -2,  -15, 	   1,  -10, 	   7,   -7, 	  -1,   -8
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte    0,    0, 	  -4,  -11, 	   4,  -11, 	   0,   -4
+.2byte    0,    6, 	  -7,   -6, 	   7,   -6, 	   0,   -1
+.2byte    0,  -12, 	  -4,  -16, 	   4,  -16, 	   0,   -7
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    8,   -5, 	  -2,  -12, 	  -7,   -7, 	  -1,   -5
+.2byte    9,    2, 	   5,   -9, 	  -5,   -2, 	   1,   -3
+.2byte    1,  -15, 	  -2,  -10, 	  -8,   -7, 	   0,   -8
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte    9,   -8, 	  -5,   -7, 	  -4,   -3, 	   0,   -5
+.2byte   11,    0, 	   0,  -11, 	  -3,   -6, 	   2,   -4
+.2byte    3,  -16, 	  -7,   -9, 	  -5,   -3, 	  -1,   -7
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte    8,   -8, 	  -4,   -6, 	   1,   -2, 	  -1,   -4
+.2byte    7,   -3, 	  -5,   -8, 	   2,   -1, 	   0,   -4
+.2byte    1,  -15, 	  -9,   -9, 	  -1,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    0,  -14, 	   4,   -4, 	  -4,   -4, 	   0,   -6
+.2byte    0,   -7, 	   6,   -4, 	  -6,   -4, 	   0,   -5
+.2byte    0,  -15, 	   5,   -7, 	  -5,   -7, 	   0,   -6
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte   -8,   -8, 	   4,   -6, 	  -1,   -2, 	   1,   -4
+.2byte   -7,   -3, 	   5,   -8, 	  -2,   -1, 	   0,   -4
+.2byte   -2,  -15, 	   8,   -9, 	   0,   -7, 	   1,   -6
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte   -9,   -8, 	   5,   -7, 	   4,   -3, 	   0,   -5
+.2byte  -11,    0, 	   0,  -11, 	   3,   -6, 	  -2,   -4
+.2byte   -4,  -16, 	   6,   -9, 	   4,   -3, 	   0,   -7
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte   -8,   -5, 	   2,  -12, 	   7,   -7, 	   1,   -5
+.2byte   -9,    2, 	  -5,   -9, 	   5,   -2, 	  -1,   -3
+.2byte   -2,  -15, 	   1,  -10, 	   7,   -7, 	  -1,   -8
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte    0,    3, 	  -8,   -3, 	   7,   -3, 	   0,   -2
+.2byte    0,    5, 	  -5,   -7, 	   5,   -7, 	   0,   -2
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    8,    1, 	   4,   -9, 	  -5,    0, 	   1,   -3
+.2byte    8,    3, 	   1,   -9, 	  -4,   -5, 	  -1,   -2
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte   10,   -4, 	  -2,   -8, 	  -3,    0, 	   1,   -4
+.2byte   10,    1, 	  -1,  -10, 	  -1,   -5, 	   1,   -2
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte    6,  -10, 	  -5,   -6, 	   2,   -1, 	  -1,   -4
+.2byte    9,   -5, 	  -4,   -9, 	   2,   -3, 	   1,   -4
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    0,  -12, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -9, 	   5,   -7, 	  -5,   -7, 	   0,   -4
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte   -6,  -10, 	   5,   -6, 	  -2,   -1, 	   1,   -4
+.2byte   -9,   -5, 	   4,   -9, 	  -2,   -3, 	  -1,   -4
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte  -10,   -4, 	   2,   -8, 	   3,    0, 	  -1,   -4
+.2byte  -10,    1, 	   1,  -10, 	   1,   -5, 	  -1,   -2
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte   -8,    1, 	  -4,   -9, 	   5,    0, 	  -1,   -3
+.2byte   -8,    3, 	  -1,   -9, 	   4,   -5, 	   1,   -2
+.2byte   -9,    2, 	  -4,   -7, 	   6,    0, 	   0,   -3
+.2byte   -9,    1, 	  -4,   -7, 	   5,    0, 	   0,   -4
+.2byte    0,  -11, 	  -7,  -11, 	   7,  -11, 	   0,  -10
+.2byte    8,  -16, 	   3,  -18, 	  -3,  -14, 	   1,  -13
+.2byte    9,  -19, 	  -6,  -16, 	  -3,  -12, 	   1,  -12
+.2byte    8,  -19, 	  -4,  -14, 	   2,  -11, 	   1,  -11
+.2byte    0,  -21, 	   5,  -11, 	  -5,  -11, 	   0,  -13
+.2byte   -9,  -19, 	   3,  -14, 	  -3,  -11, 	  -2,  -11
+.2byte  -10,  -17, 	   5,  -14, 	   2,  -10, 	  -2,  -10
+.2byte   -9,  -14, 	  -4,  -16, 	   2,  -12, 	  -2,  -11
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte    0,    3, 	  -8,   -3, 	   7,   -3, 	   0,   -2
+.2byte    0,    5, 	  -5,   -7, 	   5,   -7, 	   0,   -2
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    8,    1, 	   4,   -9, 	  -5,    0, 	   1,   -3
+.2byte    8,    3, 	   1,   -9, 	  -4,   -5, 	  -1,   -2
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte   10,   -4, 	  -2,   -8, 	  -3,    0, 	   1,   -4
+.2byte   10,    1, 	  -1,  -10, 	  -1,   -5, 	   1,   -2
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte    6,  -10, 	  -5,   -6, 	   2,   -1, 	  -1,   -4
+.2byte    9,   -5, 	  -4,   -9, 	   2,   -3, 	   1,   -4
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    0,  -12, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -9, 	   5,   -7, 	  -5,   -7, 	   0,   -4
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte   -6,  -10, 	   5,   -6, 	  -2,   -1, 	   1,   -4
+.2byte   -9,   -5, 	   4,   -9, 	  -2,   -3, 	  -1,   -4
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte  -10,   -4, 	   2,   -8, 	   3,    0, 	  -1,   -4
+.2byte  -10,    1, 	   1,  -10, 	   1,   -5, 	  -1,   -2
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte   -8,    1, 	  -4,   -9, 	   5,    0, 	  -1,   -3
+.2byte   -8,    3, 	  -1,   -9, 	   4,   -5, 	   1,   -2
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    0,  -12, 	  -4,  -16, 	   4,  -16, 	   0,   -7
+.2byte    2,  -15, 	  -1,  -10, 	  -7,   -7, 	   1,   -8
+.2byte    5,  -17, 	  -5,  -10, 	  -3,   -4, 	   1,   -8
+.2byte    3,  -17, 	  -7,  -11, 	   1,   -9, 	   0,   -8
+.2byte    0,  -17, 	   5,   -9, 	  -5,   -9, 	   0,   -8
+.2byte   -4,  -17, 	   6,  -11, 	  -2,   -9, 	  -1,   -8
+.2byte   -6,  -17, 	   4,  -10, 	   2,   -4, 	  -2,   -8
+.2byte   -3,  -15, 	   0,  -10, 	   6,   -7, 	  -2,   -8
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte    0,    0, 	  -4,  -11, 	   4,  -11, 	   0,   -4
+.2byte    0,    6, 	  -7,   -6, 	   7,   -6, 	   0,   -1
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+.2byte    8,   -5, 	  -2,  -12, 	  -7,   -7, 	  -1,   -5
+.2byte    9,    2, 	   5,   -9, 	  -5,   -2, 	   1,   -3
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte    9,   -8, 	  -5,   -7, 	  -4,   -3, 	   0,   -5
+.2byte   11,    0, 	   0,  -11, 	  -3,   -6, 	   2,   -4
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte    8,   -8, 	  -4,   -6, 	   1,   -2, 	  -1,   -4
+.2byte    8,   -3, 	  -4,   -8, 	   3,   -1, 	   1,   -4
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    0,  -14, 	   4,   -4, 	  -4,   -4, 	   0,   -6
+.2byte    0,   -7, 	   6,   -4, 	  -6,   -4, 	   0,   -5
+.2byte   -9,   -7, 	   4,   -7, 	  -2,   -1, 	  -1,   -4
+.2byte   -9,   -8, 	   3,   -6, 	  -2,   -2, 	   0,   -4
+.2byte   -9,   -3, 	   3,   -8, 	  -4,   -1, 	  -2,   -4
+.2byte  -11,   -1, 	   2,   -9, 	   2,   -1, 	  -2,   -3
+.2byte  -10,   -8, 	   4,   -7, 	   3,   -3, 	  -1,   -5
+.2byte  -12,    0, 	  -1,  -11, 	   2,   -6, 	  -3,   -4
+.2byte   -9,    2, 	  -3,   -9, 	   4,   -3, 	  -1,   -2
+.2byte   -9,   -5, 	   1,  -12, 	   6,   -7, 	   0,   -5
+.2byte  -10,    2, 	  -6,   -9, 	   4,   -2, 	  -2,   -3
+.2byte    0,    5, 	  -5,   -7, 	   5,   -7, 	   0,   -2
+.2byte   -8,    3, 	  -1,   -9, 	   4,   -5, 	   1,   -2
+.2byte  -10,    1, 	   1,  -10, 	   1,   -5, 	  -1,   -2
+.2byte   -9,   -5, 	   4,   -9, 	  -2,   -3, 	  -1,   -4
+.2byte    0,   -9, 	   5,   -7, 	  -5,   -7, 	   0,   -4
+.2byte    9,   -5, 	  -4,   -9, 	   2,   -3, 	   1,   -4
+.2byte   10,    1, 	  -1,  -10, 	  -1,   -5, 	   1,   -2
+.2byte    8,    3, 	   1,   -9, 	  -4,   -5, 	  -1,   -2
+.2byte    0,    4, 	  -6,   -7, 	   6,   -7, 	   0,   -3
+.2byte   -8,    2, 	  -2,   -9, 	   5,   -3, 	   0,   -2
+.2byte  -10,   -1, 	   3,   -9, 	   3,   -1, 	  -1,   -3
+.2byte   -8,   -7, 	   5,   -7, 	  -1,   -1, 	   0,   -4
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -6
+.2byte    8,   -7, 	  -5,   -7, 	   1,   -1, 	   0,   -4
+.2byte   10,   -1, 	  -3,   -9, 	  -3,   -1, 	   1,   -3
+.2byte    8,    2, 	   2,   -9, 	  -5,   -3, 	   0,   -2
+sDunsparceAnimTable1:
+.4byte sDunsparceAnims_1_1
+.4byte sDunsparceAnims_1_2
+.4byte sDunsparceAnims_1_3
+.4byte sDunsparceAnims_1_4
+.4byte sDunsparceAnims_1_5
+.4byte sDunsparceAnims_1_6
+.4byte sDunsparceAnims_1_7
+.4byte sDunsparceAnims_1_8
+sDunsparceAnimTable2:
+.4byte sDunsparceAnims_2_1
+.4byte sDunsparceAnims_2_2
+.4byte sDunsparceAnims_2_3
+.4byte sDunsparceAnims_2_4
+.4byte sDunsparceAnims_2_5
+.4byte sDunsparceAnims_2_6
+.4byte sDunsparceAnims_2_7
+.4byte sDunsparceAnims_2_8
+sDunsparceAnimTable3:
+.4byte sDunsparceAnims_3_1
+.4byte sDunsparceAnims_3_2
+.4byte sDunsparceAnims_3_3
+.4byte sDunsparceAnims_3_4
+.4byte sDunsparceAnims_3_5
+.4byte sDunsparceAnims_3_6
+.4byte sDunsparceAnims_3_7
+.4byte sDunsparceAnims_3_8
+sDunsparceAnimTable4:
+.4byte sDunsparceAnims_4_1
+.4byte sDunsparceAnims_4_2
+.4byte sDunsparceAnims_4_3
+.4byte sDunsparceAnims_4_4
+.4byte sDunsparceAnims_4_5
+.4byte sDunsparceAnims_4_6
+.4byte sDunsparceAnims_4_7
+.4byte sDunsparceAnims_4_8
+sDunsparceAnimTable5:
+.4byte sDunsparceAnims_5_1
+.4byte sDunsparceAnims_5_2
+.4byte sDunsparceAnims_5_3
+.4byte sDunsparceAnims_5_4
+.4byte sDunsparceAnims_5_5
+.4byte sDunsparceAnims_5_6
+.4byte sDunsparceAnims_5_7
+.4byte sDunsparceAnims_5_8
+sDunsparceAnimTable6:
+.4byte sDunsparceAnims_6_1
+.4byte sDunsparceAnims_6_1
+.4byte sDunsparceAnims_6_1
+.4byte sDunsparceAnims_6_1
+.4byte sDunsparceAnims_6_1
+.4byte sDunsparceAnims_6_1
+.4byte sDunsparceAnims_6_1
+.4byte sDunsparceAnims_6_1
+sDunsparceAnimTable7:
+.4byte sDunsparceAnims_7_1
+.4byte sDunsparceAnims_7_2
+.4byte sDunsparceAnims_7_3
+.4byte sDunsparceAnims_7_4
+.4byte sDunsparceAnims_7_5
+.4byte sDunsparceAnims_7_6
+.4byte sDunsparceAnims_7_7
+.4byte sDunsparceAnims_7_8
+sDunsparceAnimTable8:
+.4byte sDunsparceAnims_8_1
+.4byte sDunsparceAnims_8_2
+.4byte sDunsparceAnims_8_3
+.4byte sDunsparceAnims_8_4
+.4byte sDunsparceAnims_8_5
+.4byte sDunsparceAnims_8_6
+.4byte sDunsparceAnims_8_7
+.4byte sDunsparceAnims_8_8
+sDunsparceAnimTable9:
+.4byte sDunsparceAnims_9_1
+.4byte sDunsparceAnims_9_2
+.4byte sDunsparceAnims_9_3
+.4byte sDunsparceAnims_9_4
+.4byte sDunsparceAnims_9_5
+.4byte sDunsparceAnims_9_6
+.4byte sDunsparceAnims_9_7
+.4byte sDunsparceAnims_9_8
+sDunsparceAnimTable10:
+.4byte sDunsparceAnims_10_1
+.4byte sDunsparceAnims_10_2
+.4byte sDunsparceAnims_10_3
+.4byte sDunsparceAnims_10_4
+.4byte sDunsparceAnims_10_5
+.4byte sDunsparceAnims_10_6
+.4byte sDunsparceAnims_10_7
+.4byte sDunsparceAnims_10_8
+sDunsparceAnimTable11:
+.4byte sDunsparceAnims_11_1
+.4byte sDunsparceAnims_11_2
+.4byte sDunsparceAnims_11_3
+.4byte sDunsparceAnims_11_4
+.4byte sDunsparceAnims_11_5
+.4byte sDunsparceAnims_11_6
+.4byte sDunsparceAnims_11_7
+.4byte sDunsparceAnims_11_8
+sDunsparceAnimTable12:
+.4byte sDunsparceAnims_12_1
+.4byte sDunsparceAnims_12_2
+.4byte sDunsparceAnims_12_3
+.4byte sDunsparceAnims_12_4
+.4byte sDunsparceAnims_12_5
+.4byte sDunsparceAnims_12_6
+.4byte sDunsparceAnims_12_7
+.4byte sDunsparceAnims_12_8
+sDunsparceAnimTable13:
+.4byte sDunsparceAnims_13_1
+.4byte sDunsparceAnims_13_2
+.4byte sDunsparceAnims_13_3
+.4byte sDunsparceAnims_13_4
+.4byte sDunsparceAnims_13_5
+.4byte sDunsparceAnims_13_6
+.4byte sDunsparceAnims_13_7
+.4byte sDunsparceAnims_13_8
+sAxAnimationsDunsparce:
+.4byte sDunsparceAnimTable1
+.4byte sDunsparceAnimTable2
+.4byte sDunsparceAnimTable3
+.4byte sDunsparceAnimTable4
+.4byte sDunsparceAnimTable5
+.4byte sDunsparceAnimTable6
+.4byte sDunsparceAnimTable7
+.4byte sDunsparceAnimTable8
+.4byte sDunsparceAnimTable9
+.4byte sDunsparceAnimTable10
+.4byte sDunsparceAnimTable11
+.4byte sDunsparceAnimTable12
+.4byte sDunsparceAnimTable13
+sAxSpritesDunsparce:
+.4byte sDunsparceSprites1
+.4byte sDunsparceSprites2
+.4byte sDunsparceSprites3
+.4byte sDunsparceSprites4
+.4byte sDunsparceSprites5
+.4byte sDunsparceSprites6
+.4byte sDunsparceSprites7
+.4byte sDunsparceSprites8
+.4byte sDunsparceSprites9
+.4byte sDunsparceSprites10
+.4byte sDunsparceSprites11
+.4byte sDunsparceSprites12
+.4byte sDunsparceSprites13
+.4byte sDunsparceSprites14
+.4byte sDunsparceSprites15
+.4byte sDunsparceSprites16
+.4byte sDunsparceSprites17
+.4byte sDunsparceSprites18
+.4byte sDunsparceSprites19
+.4byte sDunsparceSprites20
+.4byte sDunsparceSprites21
+.4byte sDunsparceSprites22
+.4byte sDunsparceSprites23
+.4byte sDunsparceSprites24
+.4byte sDunsparceSprites25
+.4byte sDunsparceSprites26
+.4byte sDunsparceSprites27
+.4byte sDunsparceSprites28
+.4byte sDunsparceSprites29
+.4byte sDunsparceSprites30
+.4byte sDunsparceSprites31
+.4byte sDunsparceSprites32
+.4byte sDunsparceSprites33
+.4byte sDunsparceSprites34
+.4byte sDunsparceSprites35
+.4byte sDunsparceSprites36
+.4byte sDunsparceSprites37
+.4byte sDunsparceSprites38
+.4byte sDunsparceSprites39
+.4byte sDunsparceSprites40
+.4byte sDunsparceSprites41
+.4byte sDunsparceSprites42
+.4byte sDunsparceSprites43
+.4byte sDunsparceSprites44
+.4byte sDunsparceSprites45
+.4byte sDunsparceSprites46
+.4byte sDunsparceSprites47
+sAxMainDunsparce:
+ax_main sAxPosesDunsparce, sAxAnimationsDunsparce, 13, sAxSpritesDunsparce, sAxPositionsDunsparce

--- a/data/ax/dusclops.inc
+++ b/data/ax/dusclops.inc
@@ -1,0 +1,3592 @@
+.global gAxDusclops
+gAxDusclops:
+ax_siro sAxMainDusclops
+sDusclopsPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose5:
+ax_pose 4, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose7:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose8:
+ax_pose 7, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose9:
+ax_pose 8, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose10:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose11:
+ax_pose 10, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose12:
+ax_pose 11, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose16:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose17:
+ax_pose 10, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose18:
+ax_pose 11, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose28:
+ax_pose 15, 0x81e3, 0x80f4, 0x5c00
+ax_pose 16, 0x81e3, 0x4104, 0x5c08
+ax_pose 17, 0x01eb, 0x010c, 0x5c0c
+ax_pose 18, 0x01eb, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose29:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose30:
+ax_pose 4, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose31:
+ax_pose 5, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose32:
+ax_pose 19, 0x81e3, 0x9100, 0x5c00
+ax_pose 20, 0x81e3, 0x50f8, 0x5c08
+ax_pose 21, 0x01f0, 0x10e8, 0x5c0c
+ax_pose 22, 0x81eb, 0x10f0, 0x5c0d
+ax_pose_terminator
+sDusclopsPose33:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose34:
+ax_pose 7, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose35:
+ax_pose 8, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose36:
+ax_pose 23, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose37:
+ax_pose 24, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose38:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose39:
+ax_pose 10, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose40:
+ax_pose 11, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose41:
+ax_pose 25, 0x41f4, 0x90f1, 0x5c00
+ax_pose 26, 0x41ec, 0x50f1, 0x5c08
+ax_pose 27, 0x41e4, 0x10f9, 0x5c0c
+ax_pose 28, 0x01ec, 0x10e9, 0x5c0e
+ax_pose_terminator
+sDusclopsPose42:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose43:
+ax_pose 13, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose44:
+ax_pose 14, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose45:
+ax_pose 29, 0x81e4, 0x80fc, 0x5c00
+ax_pose 30, 0x81e4, 0x40f4, 0x5c08
+ax_pose 31, 0x01ee, 0x010c, 0x5c0c
+ax_pose 32, 0x81ec, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose46:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose47:
+ax_pose 10, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose48:
+ax_pose 11, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose49:
+ax_pose 25, 0x41f4, 0x80ef, 0x5c00
+ax_pose 26, 0x41ec, 0x40ef, 0x5c08
+ax_pose 27, 0x41e4, 0x00f7, 0x5c0c
+ax_pose 28, 0x01ec, 0x010f, 0x5c0e
+ax_pose_terminator
+sDusclopsPose50:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose51:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose52:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose53:
+ax_pose 23, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose54:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose55:
+ax_pose 4, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose56:
+ax_pose 5, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose57:
+ax_pose 19, 0x81e3, 0x80f0, 0x5c00
+ax_pose 20, 0x81e3, 0x4100, 0x5c08
+ax_pose 21, 0x01f0, 0x0110, 0x5c0c
+ax_pose 22, 0x81eb, 0x0108, 0x5c0d
+ax_pose_terminator
+sDusclopsPose58:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose59:
+ax_pose 33, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose60:
+ax_pose 34, 0x01e8, 0x80f7, 0x5c00
+ax_pose 35, 0x81e4, 0x80f1, 0x5c10
+ax_pose 36, 0x81e4, 0x4101, 0x5c18
+ax_pose 37, 0x81ec, 0x0109, 0x5c1c
+ax_pose 38, 0x01fc, 0x0109, 0x5c1e
+ax_pose 39, 0x01ec, 0x0111, 0x5c1f
+ax_pose_terminator
+sDusclopsPose61:
+ax_pose 35, 0x81e4, 0x80f1, 0x5c00
+ax_pose 36, 0x81e4, 0x4101, 0x5c08
+ax_pose 37, 0x81ec, 0x0109, 0x5c0c
+ax_pose 38, 0x01fc, 0x0109, 0x5c0e
+ax_pose 39, 0x01ec, 0x0111, 0x5c0f
+ax_pose_terminator
+sDusclopsPose62:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose63:
+ax_pose 40, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose64:
+ax_pose 41, 0x41f4, 0x90ed, 0x5c00
+ax_pose 42, 0x01e4, 0x90ee, 0x5c08
+ax_pose_terminator
+sDusclopsPose65:
+ax_pose 42, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sDusclopsPose66:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose67:
+ax_pose 43, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose68:
+ax_pose 44, 0x41f1, 0x90f7, 0x5c00
+ax_pose 45, 0x81e2, 0x9100, 0x5c08
+ax_pose 46, 0x81e2, 0x50f8, 0x5c10
+ax_pose 47, 0x01f2, 0x10e8, 0x5c14
+ax_pose 48, 0x81ef, 0x10f0, 0x5c15
+ax_pose_terminator
+sDusclopsPose69:
+ax_pose 45, 0x81e2, 0x9100, 0x5c00
+ax_pose 46, 0x81e2, 0x50f8, 0x5c08
+ax_pose 47, 0x01f2, 0x10e8, 0x5c0c
+ax_pose 48, 0x81ef, 0x10f0, 0x5c0d
+ax_pose_terminator
+sDusclopsPose70:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose71:
+ax_pose 49, 0x01e4, 0x90f2, 0x5c00
+ax_pose_terminator
+sDusclopsPose72:
+ax_pose 50, 0x81e4, 0x9109, 0x5c00
+ax_pose 51, 0x81e4, 0x90f2, 0x5c08
+ax_pose 52, 0x81e4, 0x5102, 0x5c10
+ax_pose 53, 0x01f2, 0x10eb, 0x5c14
+ax_pose 54, 0x01ec, 0x110a, 0x5c15
+ax_pose 55, 0x81f4, 0x110a, 0x5c16
+ax_pose_terminator
+sDusclopsPose73:
+ax_pose 51, 0x81e4, 0x90f2, 0x5c00
+ax_pose 52, 0x81e4, 0x5102, 0x5c08
+ax_pose 53, 0x01f2, 0x10eb, 0x5c0c
+ax_pose 54, 0x01ec, 0x110a, 0x5c0d
+ax_pose 55, 0x81f4, 0x110a, 0x5c0e
+ax_pose_terminator
+sDusclopsPose74:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose75:
+ax_pose 56, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sDusclopsPose76:
+ax_pose 57, 0x81e4, 0x80f0, 0x5c00
+ax_pose 58, 0x81e4, 0x8102, 0x5c08
+ax_pose 59, 0x81e4, 0x40fa, 0x5c10
+ax_pose 60, 0x01f3, 0x00ea, 0x5c14
+ax_pose 61, 0x01ec, 0x00f2, 0x5c15
+ax_pose 62, 0x81f4, 0x00f2, 0x5c16
+ax_pose_terminator
+sDusclopsPose77:
+ax_pose 58, 0x81e4, 0x8102, 0x5c00
+ax_pose 59, 0x81e4, 0x40fa, 0x5c08
+ax_pose 60, 0x01f3, 0x00ea, 0x5c0c
+ax_pose 61, 0x01ec, 0x00f2, 0x5c0d
+ax_pose 62, 0x81f4, 0x00f2, 0x5c0e
+ax_pose_terminator
+sDusclopsPose78:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose79:
+ax_pose 49, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sDusclopsPose80:
+ax_pose 50, 0x81e4, 0x80e7, 0x5c00
+ax_pose 51, 0x81e4, 0x80fe, 0x5c08
+ax_pose 52, 0x81e4, 0x40f6, 0x5c10
+ax_pose 53, 0x01f2, 0x010e, 0x5c14
+ax_pose 54, 0x01ec, 0x00ee, 0x5c15
+ax_pose 55, 0x81f4, 0x00ee, 0x5c16
+ax_pose_terminator
+sDusclopsPose81:
+ax_pose 51, 0x81e4, 0x80fe, 0x5c00
+ax_pose 52, 0x81e4, 0x40f6, 0x5c08
+ax_pose 53, 0x01f2, 0x010e, 0x5c0c
+ax_pose 54, 0x01ec, 0x00ee, 0x5c0d
+ax_pose 55, 0x81f4, 0x00ee, 0x5c0e
+ax_pose_terminator
+sDusclopsPose82:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose83:
+ax_pose 43, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose84:
+ax_pose 44, 0x41f1, 0x80e9, 0x5c00
+ax_pose 45, 0x81e2, 0x80f0, 0x5c08
+ax_pose 46, 0x81e2, 0x4100, 0x5c10
+ax_pose 47, 0x01f2, 0x0110, 0x5c14
+ax_pose 48, 0x81ef, 0x0108, 0x5c15
+ax_pose_terminator
+sDusclopsPose85:
+ax_pose 45, 0x81e2, 0x80f0, 0x5c00
+ax_pose 46, 0x81e2, 0x4100, 0x5c08
+ax_pose 47, 0x01f2, 0x0110, 0x5c0c
+ax_pose 48, 0x81ef, 0x0108, 0x5c0d
+ax_pose_terminator
+sDusclopsPose86:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose87:
+ax_pose 40, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose88:
+ax_pose 41, 0x41f4, 0x80f3, 0x5c00
+ax_pose 42, 0x01e4, 0x80f2, 0x5c08
+ax_pose_terminator
+sDusclopsPose89:
+ax_pose 42, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sDusclopsPose90:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose91:
+ax_pose 15, 0x81e3, 0x80f4, 0x5c00
+ax_pose 16, 0x81e3, 0x4104, 0x5c08
+ax_pose 17, 0x01eb, 0x010c, 0x5c0c
+ax_pose 18, 0x01eb, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose92:
+ax_pose 63, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose93:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose94:
+ax_pose 19, 0x81e3, 0x9100, 0x5c00
+ax_pose 20, 0x81e3, 0x50f8, 0x5c08
+ax_pose 21, 0x01f0, 0x10e8, 0x5c0c
+ax_pose 22, 0x81eb, 0x10f0, 0x5c0d
+ax_pose_terminator
+sDusclopsPose95:
+ax_pose 64, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose96:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose97:
+ax_pose 23, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose98:
+ax_pose 24, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose99:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose100:
+ax_pose 25, 0x41f4, 0x90f1, 0x5c00
+ax_pose 26, 0x41ec, 0x50f1, 0x5c08
+ax_pose 27, 0x41e4, 0x10f9, 0x5c0c
+ax_pose 28, 0x01ec, 0x10e9, 0x5c0e
+ax_pose_terminator
+sDusclopsPose101:
+ax_pose 65, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose102:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose103:
+ax_pose 29, 0x81e4, 0x80fc, 0x5c00
+ax_pose 30, 0x81e4, 0x40f4, 0x5c08
+ax_pose 31, 0x01ee, 0x010c, 0x5c0c
+ax_pose 32, 0x81ec, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose104:
+ax_pose 66, 0x81e9, 0x80fc, 0x5c00
+ax_pose 67, 0x81e9, 0x40f4, 0x5c08
+ax_pose 68, 0x81e9, 0x00ec, 0x5c0c
+ax_pose 69, 0x81e9, 0x010c, 0x5c0e
+ax_pose_terminator
+sDusclopsPose105:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose106:
+ax_pose 25, 0x41f4, 0x80ef, 0x5c00
+ax_pose 26, 0x41ec, 0x40ef, 0x5c08
+ax_pose 27, 0x41e4, 0x00f7, 0x5c0c
+ax_pose 28, 0x01ec, 0x010f, 0x5c0e
+ax_pose_terminator
+sDusclopsPose107:
+ax_pose 65, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose108:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose109:
+ax_pose 23, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose110:
+ax_pose 24, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose111:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose112:
+ax_pose 19, 0x81e3, 0x80f0, 0x5c00
+ax_pose 20, 0x81e3, 0x4100, 0x5c08
+ax_pose 21, 0x01f0, 0x0110, 0x5c0c
+ax_pose 22, 0x81eb, 0x0108, 0x5c0d
+ax_pose_terminator
+sDusclopsPose113:
+ax_pose 64, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose114:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose115:
+ax_pose 15, 0x81e3, 0x80f4, 0x5c00
+ax_pose 16, 0x81e3, 0x4104, 0x5c08
+ax_pose 17, 0x01eb, 0x010c, 0x5c0c
+ax_pose 18, 0x01eb, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose116:
+ax_pose 63, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose117:
+ax_pose 70, 0x81e2, 0x80fd, 0x5c00
+ax_pose 71, 0x81e2, 0x40f5, 0x5c08
+ax_pose 72, 0x01f3, 0x010d, 0x5c0c
+ax_pose 73, 0x01fa, 0x00ed, 0x5c0d
+ax_pose 74, 0x01f2, 0x00ed, 0x5c0e
+ax_pose 75, 0x01da, 0x00fd, 0x5c0f
+ax_pose_terminator
+sDusclopsPose118:
+ax_pose 76, 0x01e9, 0x44f8, 0x2c00
+ax_pose 70, 0x81e2, 0x80fd, 0x5c04
+ax_pose 71, 0x81e2, 0x40f5, 0x5c0c
+ax_pose 72, 0x01f3, 0x010d, 0x5c10
+ax_pose 73, 0x01fa, 0x00ed, 0x5c11
+ax_pose 74, 0x01f2, 0x00ed, 0x5c12
+ax_pose 75, 0x01da, 0x00fd, 0x5c13
+ax_pose_terminator
+sDusclopsPose119:
+ax_pose 77, 0x01e9, 0x44f8, 0x2c00
+ax_pose 70, 0x81e2, 0x80fd, 0x5c04
+ax_pose 71, 0x81e2, 0x40f5, 0x5c0c
+ax_pose 72, 0x01f3, 0x010d, 0x5c10
+ax_pose 73, 0x01fa, 0x00ed, 0x5c11
+ax_pose 74, 0x01f2, 0x00ed, 0x5c12
+ax_pose 75, 0x01da, 0x00fd, 0x5c13
+ax_pose_terminator
+sDusclopsPose120:
+ax_pose 78, 0x01e9, 0x44f8, 0x2c00
+ax_pose 70, 0x81e2, 0x80fd, 0x5c04
+ax_pose 71, 0x81e2, 0x40f5, 0x5c0c
+ax_pose 72, 0x01f3, 0x010d, 0x5c10
+ax_pose 73, 0x01fa, 0x00ed, 0x5c11
+ax_pose 74, 0x01f2, 0x00ed, 0x5c12
+ax_pose 75, 0x01da, 0x00fd, 0x5c13
+ax_pose_terminator
+sDusclopsPose121:
+ax_pose 79, 0x01e9, 0x44f8, 0x2c00
+ax_pose 70, 0x81e2, 0x80fd, 0x5c04
+ax_pose 71, 0x81e2, 0x40f5, 0x5c0c
+ax_pose 72, 0x01f3, 0x010d, 0x5c10
+ax_pose 73, 0x01fa, 0x00ed, 0x5c11
+ax_pose 74, 0x01f2, 0x00ed, 0x5c12
+ax_pose 75, 0x01da, 0x00fd, 0x5c13
+ax_pose_terminator
+sDusclopsPose122:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose123:
+ax_pose 19, 0x81e3, 0x9100, 0x5c00
+ax_pose 20, 0x81e3, 0x50f8, 0x5c08
+ax_pose 21, 0x01f0, 0x10e8, 0x5c0c
+ax_pose 22, 0x81eb, 0x10f0, 0x5c0d
+ax_pose_terminator
+sDusclopsPose124:
+ax_pose 64, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose125:
+ax_pose 80, 0x41f4, 0x90f3, 0x5c00
+ax_pose 81, 0x41ec, 0x50f3, 0x5c08
+ax_pose 82, 0x41e4, 0x10fb, 0x5c0c
+ax_pose 83, 0x01dc, 0x10fb, 0x5c0e
+ax_pose 84, 0x01f7, 0x10eb, 0x5c0f
+ax_pose_terminator
+sDusclopsPose126:
+ax_pose 76, 0x01e9, 0x44fc, 0x2c00
+ax_pose 80, 0x41f4, 0x90f3, 0x5c04
+ax_pose 81, 0x41ec, 0x50f3, 0x5c0c
+ax_pose 82, 0x41e4, 0x10fb, 0x5c10
+ax_pose 83, 0x01dc, 0x10fb, 0x5c12
+ax_pose 84, 0x01f7, 0x10eb, 0x5c13
+ax_pose_terminator
+sDusclopsPose127:
+ax_pose 77, 0x01e9, 0x44fc, 0x2c00
+ax_pose 80, 0x41f4, 0x90f3, 0x5c04
+ax_pose 81, 0x41ec, 0x50f3, 0x5c0c
+ax_pose 82, 0x41e4, 0x10fb, 0x5c10
+ax_pose 83, 0x01dc, 0x10fb, 0x5c12
+ax_pose 84, 0x01f7, 0x10eb, 0x5c13
+ax_pose_terminator
+sDusclopsPose128:
+ax_pose 78, 0x01e9, 0x44fc, 0x2c00
+ax_pose 80, 0x41f4, 0x90f3, 0x5c04
+ax_pose 81, 0x41ec, 0x50f3, 0x5c0c
+ax_pose 82, 0x41e4, 0x10fb, 0x5c10
+ax_pose 83, 0x01dc, 0x10fb, 0x5c12
+ax_pose 84, 0x01f7, 0x10eb, 0x5c13
+ax_pose_terminator
+sDusclopsPose129:
+ax_pose 79, 0x01e9, 0x44fc, 0x2c00
+ax_pose 80, 0x41f4, 0x90f3, 0x5c04
+ax_pose 81, 0x41ec, 0x50f3, 0x5c0c
+ax_pose 82, 0x41e4, 0x10fb, 0x5c10
+ax_pose 83, 0x01dc, 0x10fb, 0x5c12
+ax_pose 84, 0x01f7, 0x10eb, 0x5c13
+ax_pose_terminator
+sDusclopsPose130:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose131:
+ax_pose 23, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose132:
+ax_pose 24, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose133:
+ax_pose 85, 0x41f2, 0x90f1, 0x5c00
+ax_pose 86, 0x41ea, 0x50f1, 0x5c08
+ax_pose 87, 0x41e2, 0x10f9, 0x5c0c
+ax_pose 88, 0x01da, 0x10f9, 0x5c0e
+ax_pose 89, 0x01fa, 0x10e9, 0x5c0f
+ax_pose_terminator
+sDusclopsPose134:
+ax_pose 76, 0x01e5, 0x44ff, 0x2c00
+ax_pose 85, 0x41f2, 0x90f1, 0x5c04
+ax_pose 86, 0x41ea, 0x50f1, 0x5c0c
+ax_pose 87, 0x41e2, 0x10f9, 0x5c10
+ax_pose 88, 0x01da, 0x10f9, 0x5c12
+ax_pose 89, 0x01fa, 0x10e9, 0x5c13
+ax_pose_terminator
+sDusclopsPose135:
+ax_pose 77, 0x01e5, 0x44ff, 0x2c00
+ax_pose 85, 0x41f2, 0x90f1, 0x5c04
+ax_pose 86, 0x41ea, 0x50f1, 0x5c0c
+ax_pose 87, 0x41e2, 0x10f9, 0x5c10
+ax_pose 88, 0x01da, 0x10f9, 0x5c12
+ax_pose 89, 0x01fa, 0x10e9, 0x5c13
+ax_pose_terminator
+sDusclopsPose136:
+ax_pose 78, 0x01e5, 0x44ff, 0x2c00
+ax_pose 85, 0x41f2, 0x90f1, 0x5c04
+ax_pose 86, 0x41ea, 0x50f1, 0x5c0c
+ax_pose 87, 0x41e2, 0x10f9, 0x5c10
+ax_pose 88, 0x01da, 0x10f9, 0x5c12
+ax_pose 89, 0x01fa, 0x10e9, 0x5c13
+ax_pose_terminator
+sDusclopsPose137:
+ax_pose 79, 0x01e5, 0x44ff, 0x2c00
+ax_pose 85, 0x41f2, 0x90f1, 0x5c04
+ax_pose 86, 0x41ea, 0x50f1, 0x5c0c
+ax_pose 87, 0x41e2, 0x10f9, 0x5c10
+ax_pose 88, 0x01da, 0x10f9, 0x5c12
+ax_pose 89, 0x01fa, 0x10e9, 0x5c13
+ax_pose_terminator
+sDusclopsPose138:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose139:
+ax_pose 25, 0x41f4, 0x90f1, 0x5c00
+ax_pose 26, 0x41ec, 0x50f1, 0x5c08
+ax_pose 27, 0x41e4, 0x10f9, 0x5c0c
+ax_pose 28, 0x01ec, 0x10e9, 0x5c0e
+ax_pose_terminator
+sDusclopsPose140:
+ax_pose 65, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose141:
+ax_pose 90, 0x81e3, 0x90f4, 0x5c00
+ax_pose 91, 0x81e3, 0x5104, 0x5c08
+ax_pose 92, 0x01db, 0x10fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x110c, 0x5c0d
+ax_pose 94, 0x01ef, 0x10ec, 0x5c0f
+ax_pose_terminator
+sDusclopsPose142:
+ax_pose 90, 0x81e3, 0x90f4, 0x5c00
+ax_pose 91, 0x81e3, 0x5104, 0x5c08
+ax_pose 92, 0x01db, 0x10fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x110c, 0x5c0d
+ax_pose 94, 0x01ef, 0x10ec, 0x5c0f
+ax_pose 76, 0x01e3, 0x4500, 0x2c10
+ax_pose_terminator
+sDusclopsPose143:
+ax_pose 90, 0x81e3, 0x90f4, 0x5c00
+ax_pose 91, 0x81e3, 0x5104, 0x5c08
+ax_pose 92, 0x01db, 0x10fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x110c, 0x5c0d
+ax_pose 94, 0x01ef, 0x10ec, 0x5c0f
+ax_pose 77, 0x01e3, 0x4500, 0x2c10
+ax_pose_terminator
+sDusclopsPose144:
+ax_pose 90, 0x81e3, 0x90f4, 0x5c00
+ax_pose 91, 0x81e3, 0x5104, 0x5c08
+ax_pose 92, 0x01db, 0x10fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x110c, 0x5c0d
+ax_pose 94, 0x01ef, 0x10ec, 0x5c0f
+ax_pose 78, 0x01e3, 0x4500, 0x2c10
+ax_pose_terminator
+sDusclopsPose145:
+ax_pose 90, 0x81e3, 0x90f4, 0x5c00
+ax_pose 91, 0x81e3, 0x5104, 0x5c08
+ax_pose 92, 0x01db, 0x10fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x110c, 0x5c0d
+ax_pose 94, 0x01ef, 0x10ec, 0x5c0f
+ax_pose 79, 0x01e3, 0x4500, 0x2c10
+ax_pose_terminator
+sDusclopsPose146:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose147:
+ax_pose 29, 0x81e4, 0x80fc, 0x5c00
+ax_pose 30, 0x81e4, 0x40f4, 0x5c08
+ax_pose 31, 0x01ee, 0x010c, 0x5c0c
+ax_pose 32, 0x81ec, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose148:
+ax_pose 66, 0x81e9, 0x80fc, 0x5c00
+ax_pose 67, 0x81e9, 0x40f4, 0x5c08
+ax_pose 68, 0x81e9, 0x00ec, 0x5c0c
+ax_pose 69, 0x81e9, 0x010c, 0x5c0e
+ax_pose_terminator
+sDusclopsPose149:
+ax_pose 95, 0x01e2, 0x80f5, 0x5c00
+ax_pose 96, 0x01da, 0x00fd, 0x5c10
+ax_pose 97, 0x01ec, 0x00ed, 0x5c11
+ax_pose 98, 0x81f4, 0x00ed, 0x5c12
+ax_pose_terminator
+sDusclopsPose150:
+ax_pose 95, 0x01e2, 0x80f5, 0x5c00
+ax_pose 96, 0x01da, 0x00fd, 0x5c10
+ax_pose 97, 0x01ec, 0x00ed, 0x5c11
+ax_pose 98, 0x81f4, 0x00ed, 0x5c12
+ax_pose 76, 0x01dd, 0x44f8, 0x2c14
+ax_pose_terminator
+sDusclopsPose151:
+ax_pose 95, 0x01e2, 0x80f5, 0x5c00
+ax_pose 96, 0x01da, 0x00fd, 0x5c10
+ax_pose 97, 0x01ec, 0x00ed, 0x5c11
+ax_pose 98, 0x81f4, 0x00ed, 0x5c12
+ax_pose 77, 0x01dd, 0x44f8, 0x2c14
+ax_pose_terminator
+sDusclopsPose152:
+ax_pose 95, 0x01e2, 0x80f5, 0x5c00
+ax_pose 96, 0x01da, 0x00fd, 0x5c10
+ax_pose 97, 0x01ec, 0x00ed, 0x5c11
+ax_pose 98, 0x81f4, 0x00ed, 0x5c12
+ax_pose 78, 0x01dd, 0x44f8, 0x2c14
+ax_pose_terminator
+sDusclopsPose153:
+ax_pose 95, 0x01e2, 0x80f5, 0x5c00
+ax_pose 96, 0x01da, 0x00fd, 0x5c10
+ax_pose 97, 0x01ec, 0x00ed, 0x5c11
+ax_pose 98, 0x81f4, 0x00ed, 0x5c12
+ax_pose 79, 0x01dd, 0x44f8, 0x2c14
+ax_pose_terminator
+sDusclopsPose154:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose155:
+ax_pose 25, 0x41f4, 0x80ef, 0x5c00
+ax_pose 26, 0x41ec, 0x40ef, 0x5c08
+ax_pose 27, 0x41e4, 0x00f7, 0x5c0c
+ax_pose 28, 0x01ec, 0x010f, 0x5c0e
+ax_pose_terminator
+sDusclopsPose156:
+ax_pose 65, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose157:
+ax_pose 90, 0x81e3, 0x80fc, 0x5c00
+ax_pose 91, 0x81e3, 0x40f4, 0x5c08
+ax_pose 92, 0x01db, 0x00fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x00ec, 0x5c0d
+ax_pose 94, 0x01ef, 0x010c, 0x5c0f
+ax_pose_terminator
+sDusclopsPose158:
+ax_pose 90, 0x81e3, 0x80fc, 0x5c00
+ax_pose 91, 0x81e3, 0x40f4, 0x5c08
+ax_pose 92, 0x01db, 0x00fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x00ec, 0x5c0d
+ax_pose 94, 0x01ef, 0x010c, 0x5c0f
+ax_pose 76, 0x01e3, 0x44f0, 0x2c10
+ax_pose_terminator
+sDusclopsPose159:
+ax_pose 90, 0x81e3, 0x80fc, 0x5c00
+ax_pose 91, 0x81e3, 0x40f4, 0x5c08
+ax_pose 92, 0x01db, 0x00fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x00ec, 0x5c0d
+ax_pose 94, 0x01ef, 0x010c, 0x5c0f
+ax_pose 77, 0x01e3, 0x44f0, 0x2c10
+ax_pose_terminator
+sDusclopsPose160:
+ax_pose 90, 0x81e3, 0x80fc, 0x5c00
+ax_pose 91, 0x81e3, 0x40f4, 0x5c08
+ax_pose 92, 0x01db, 0x00fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x00ec, 0x5c0d
+ax_pose 94, 0x01ef, 0x010c, 0x5c0f
+ax_pose 78, 0x01e3, 0x44f0, 0x2c10
+ax_pose_terminator
+sDusclopsPose161:
+ax_pose 90, 0x81e3, 0x80fc, 0x5c00
+ax_pose 91, 0x81e3, 0x40f4, 0x5c08
+ax_pose 92, 0x01db, 0x00fc, 0x5c0c
+ax_pose 93, 0x81eb, 0x00ec, 0x5c0d
+ax_pose 94, 0x01ef, 0x010c, 0x5c0f
+ax_pose 79, 0x01e3, 0x44f0, 0x2c10
+ax_pose_terminator
+sDusclopsPose162:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose163:
+ax_pose 23, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose164:
+ax_pose 24, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose165:
+ax_pose 85, 0x41f2, 0x80ef, 0x5c00
+ax_pose 86, 0x41ea, 0x40ef, 0x5c08
+ax_pose 87, 0x41e2, 0x00f7, 0x5c0c
+ax_pose 88, 0x01da, 0x00ff, 0x5c0e
+ax_pose 89, 0x01fa, 0x010f, 0x5c0f
+ax_pose_terminator
+sDusclopsPose166:
+ax_pose 76, 0x01e5, 0x44f0, 0x2c00
+ax_pose 85, 0x41f2, 0x80ef, 0x5c04
+ax_pose 86, 0x41ea, 0x40ef, 0x5c0c
+ax_pose 87, 0x41e2, 0x00f7, 0x5c10
+ax_pose 88, 0x01da, 0x00ff, 0x5c12
+ax_pose 89, 0x01fa, 0x010f, 0x5c13
+ax_pose_terminator
+sDusclopsPose167:
+ax_pose 77, 0x01e5, 0x44f0, 0x2c00
+ax_pose 85, 0x41f2, 0x80ef, 0x5c04
+ax_pose 86, 0x41ea, 0x40ef, 0x5c0c
+ax_pose 87, 0x41e2, 0x00f7, 0x5c10
+ax_pose 88, 0x01da, 0x00ff, 0x5c12
+ax_pose 89, 0x01fa, 0x010f, 0x5c13
+ax_pose_terminator
+sDusclopsPose168:
+ax_pose 78, 0x01e5, 0x44f0, 0x2c00
+ax_pose 85, 0x41f2, 0x80ef, 0x5c04
+ax_pose 86, 0x41ea, 0x40ef, 0x5c0c
+ax_pose 87, 0x41e2, 0x00f7, 0x5c10
+ax_pose 88, 0x01da, 0x00ff, 0x5c12
+ax_pose 89, 0x01fa, 0x010f, 0x5c13
+ax_pose_terminator
+sDusclopsPose169:
+ax_pose 79, 0x01e5, 0x44f0, 0x2c00
+ax_pose 85, 0x41f2, 0x80ef, 0x5c04
+ax_pose 86, 0x41ea, 0x40ef, 0x5c0c
+ax_pose 87, 0x41e2, 0x00f7, 0x5c10
+ax_pose 88, 0x01da, 0x00ff, 0x5c12
+ax_pose 89, 0x01fa, 0x010f, 0x5c13
+ax_pose_terminator
+sDusclopsPose170:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose171:
+ax_pose 19, 0x81e3, 0x80f0, 0x5c00
+ax_pose 20, 0x81e3, 0x4100, 0x5c08
+ax_pose 21, 0x01f0, 0x0110, 0x5c0c
+ax_pose 22, 0x81eb, 0x0108, 0x5c0d
+ax_pose_terminator
+sDusclopsPose172:
+ax_pose 64, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose173:
+ax_pose 80, 0x41f4, 0x80ed, 0x5c00
+ax_pose 81, 0x41ec, 0x40ed, 0x5c08
+ax_pose 82, 0x41e4, 0x00f5, 0x5c0c
+ax_pose 83, 0x01dc, 0x00fd, 0x5c0e
+ax_pose 84, 0x01f7, 0x010d, 0x5c0f
+ax_pose_terminator
+sDusclopsPose174:
+ax_pose 76, 0x01e9, 0x44f3, 0x2c00
+ax_pose 80, 0x41f4, 0x80ed, 0x5c04
+ax_pose 81, 0x41ec, 0x40ed, 0x5c0c
+ax_pose 82, 0x41e4, 0x00f5, 0x5c10
+ax_pose 83, 0x01dc, 0x00fd, 0x5c12
+ax_pose 84, 0x01f7, 0x010d, 0x5c13
+ax_pose_terminator
+sDusclopsPose175:
+ax_pose 77, 0x01e9, 0x44f3, 0x2c00
+ax_pose 80, 0x41f4, 0x80ed, 0x5c04
+ax_pose 81, 0x41ec, 0x40ed, 0x5c0c
+ax_pose 82, 0x41e4, 0x00f5, 0x5c10
+ax_pose 83, 0x01dc, 0x00fd, 0x5c12
+ax_pose 84, 0x01f7, 0x010d, 0x5c13
+ax_pose_terminator
+sDusclopsPose176:
+ax_pose 78, 0x01e9, 0x44f3, 0x2c00
+ax_pose 80, 0x41f4, 0x80ed, 0x5c04
+ax_pose 81, 0x41ec, 0x40ed, 0x5c0c
+ax_pose 82, 0x41e4, 0x00f5, 0x5c10
+ax_pose 83, 0x01dc, 0x00fd, 0x5c12
+ax_pose 84, 0x01f7, 0x010d, 0x5c13
+ax_pose_terminator
+sDusclopsPose177:
+ax_pose 79, 0x01e9, 0x44f3, 0x2c00
+ax_pose 80, 0x41f4, 0x80ed, 0x5c04
+ax_pose 81, 0x41ec, 0x40ed, 0x5c0c
+ax_pose 82, 0x41e4, 0x00f5, 0x5c10
+ax_pose 83, 0x01dc, 0x00fd, 0x5c12
+ax_pose 84, 0x01f7, 0x010d, 0x5c13
+ax_pose_terminator
+sDusclopsPose178:
+ax_pose 99, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sDusclopsPose179:
+ax_pose 100, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sDusclopsPose180:
+ax_pose 101, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose181:
+ax_pose 102, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose182:
+ax_pose 103, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sDusclopsPose183:
+ax_pose 104, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose184:
+ax_pose 105, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose185:
+ax_pose 104, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose186:
+ax_pose 103, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sDusclopsPose187:
+ax_pose 102, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose188:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose189:
+ax_pose 63, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose190:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose191:
+ax_pose 64, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose192:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose193:
+ax_pose 24, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose194:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose195:
+ax_pose 65, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose196:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose197:
+ax_pose 66, 0x81e9, 0x80fc, 0x5c00
+ax_pose 67, 0x81e9, 0x40f4, 0x5c08
+ax_pose 68, 0x81e9, 0x00ec, 0x5c0c
+ax_pose 69, 0x81e9, 0x010c, 0x5c0e
+ax_pose_terminator
+sDusclopsPose198:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose199:
+ax_pose 65, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose200:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose201:
+ax_pose 24, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose202:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose203:
+ax_pose 64, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose204:
+ax_pose 15, 0x81e3, 0x80f4, 0x5c00
+ax_pose 16, 0x81e3, 0x4104, 0x5c08
+ax_pose 17, 0x01eb, 0x010c, 0x5c0c
+ax_pose 18, 0x01eb, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose205:
+ax_pose 19, 0x81e3, 0x80f1, 0x5c00
+ax_pose 20, 0x81e3, 0x4101, 0x5c08
+ax_pose 21, 0x01f0, 0x0111, 0x5c0c
+ax_pose 22, 0x81eb, 0x0109, 0x5c0d
+ax_pose_terminator
+sDusclopsPose206:
+ax_pose 23, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose207:
+ax_pose 25, 0x41f4, 0x80f0, 0x5c00
+ax_pose 26, 0x41ec, 0x40f0, 0x5c08
+ax_pose 27, 0x41e4, 0x00f8, 0x5c0c
+ax_pose 28, 0x01ec, 0x0110, 0x5c0e
+ax_pose_terminator
+sDusclopsPose208:
+ax_pose 29, 0x81e4, 0x80fd, 0x5c00
+ax_pose 30, 0x81e4, 0x40f5, 0x5c08
+ax_pose 31, 0x01ee, 0x010d, 0x5c0c
+ax_pose 32, 0x81ec, 0x00ed, 0x5c0d
+ax_pose_terminator
+sDusclopsPose209:
+ax_pose 25, 0x41f4, 0x90f2, 0x5c00
+ax_pose 26, 0x41ec, 0x50f2, 0x5c08
+ax_pose 27, 0x41e4, 0x10fa, 0x5c0c
+ax_pose 28, 0x01ec, 0x10ea, 0x5c0e
+ax_pose_terminator
+sDusclopsPose210:
+ax_pose 23, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose211:
+ax_pose 19, 0x81e3, 0x9101, 0x5c00
+ax_pose 20, 0x81e3, 0x50f9, 0x5c08
+ax_pose 21, 0x01f0, 0x10e9, 0x5c0c
+ax_pose 22, 0x81eb, 0x10f1, 0x5c0d
+ax_pose_terminator
+sDusclopsPose212:
+ax_pose 15, 0x81e3, 0x80f4, 0x5c00
+ax_pose 16, 0x81e3, 0x4104, 0x5c08
+ax_pose 17, 0x01eb, 0x010c, 0x5c0c
+ax_pose 18, 0x01eb, 0x00ec, 0x5c0d
+ax_pose_terminator
+sDusclopsPose213:
+ax_pose 19, 0x81e3, 0x9100, 0x5c00
+ax_pose 20, 0x81e3, 0x50f8, 0x5c08
+ax_pose 21, 0x01f0, 0x10e8, 0x5c0c
+ax_pose 22, 0x81eb, 0x10f0, 0x5c0d
+ax_pose_terminator
+sDusclopsPose214:
+ax_pose 23, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose215:
+ax_pose 25, 0x41f4, 0x90f1, 0x5c00
+ax_pose 26, 0x41ec, 0x50f1, 0x5c08
+ax_pose 27, 0x41e4, 0x10f9, 0x5c0c
+ax_pose 28, 0x01ec, 0x10e9, 0x5c0e
+ax_pose_terminator
+sDusclopsPose216:
+ax_pose 29, 0x81e4, 0x80fd, 0x5c00
+ax_pose 30, 0x81e4, 0x40f5, 0x5c08
+ax_pose 31, 0x01ee, 0x010d, 0x5c0c
+ax_pose 32, 0x81ec, 0x00ed, 0x5c0d
+ax_pose_terminator
+sDusclopsPose217:
+ax_pose 25, 0x41f4, 0x80f0, 0x5c00
+ax_pose 26, 0x41ec, 0x40f0, 0x5c08
+ax_pose 27, 0x41e4, 0x00f8, 0x5c0c
+ax_pose 28, 0x01ec, 0x0110, 0x5c0e
+ax_pose_terminator
+sDusclopsPose218:
+ax_pose 23, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose219:
+ax_pose 19, 0x81e3, 0x80f1, 0x5c00
+ax_pose 20, 0x81e3, 0x4101, 0x5c08
+ax_pose 21, 0x01f0, 0x0111, 0x5c0c
+ax_pose 22, 0x81eb, 0x0109, 0x5c0d
+ax_pose_terminator
+sDusclopsPose220:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose221:
+ax_pose 1, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose222:
+ax_pose 2, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose223:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose224:
+ax_pose 4, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose225:
+ax_pose 5, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose226:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose227:
+ax_pose 7, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose228:
+ax_pose 8, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose229:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose230:
+ax_pose 10, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose231:
+ax_pose 11, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose232:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose233:
+ax_pose 13, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose234:
+ax_pose 14, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose235:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose236:
+ax_pose 10, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose237:
+ax_pose 11, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose238:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose239:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose240:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose241:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose242:
+ax_pose 4, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose243:
+ax_pose 5, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose244:
+ax_pose 63, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose245:
+ax_pose 64, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose246:
+ax_pose 24, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose247:
+ax_pose 65, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose248:
+ax_pose 66, 0x81e8, 0x80fc, 0x5c00
+ax_pose 67, 0x81e8, 0x40f4, 0x5c08
+ax_pose 68, 0x81e8, 0x00ec, 0x5c0c
+ax_pose 69, 0x81e8, 0x010c, 0x5c0e
+ax_pose_terminator
+sDusclopsPose249:
+ax_pose 65, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose250:
+ax_pose 24, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose251:
+ax_pose 64, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose252:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose253:
+ax_pose 3, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose254:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose255:
+ax_pose 9, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDusclopsPose256:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose257:
+ax_pose 9, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sDusclopsPose258:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDusclopsPose259:
+ax_pose 3, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sDusclopsAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDusclopsAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 1, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sDusclopsAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sDusclopsAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 1, -2, 0, -1,
+ax_anim 1, 2, 38, 6, -8, 6, -8,
+ax_anim 1, 0, 39, 9, -12, 9, -12,
+ax_anim 2, 0, 40, 16, -18, 16, -18,
+ax_anim 2, 1, 40, 17, -17, 17, -17,
+ax_anim 2, 0, 40, 16, -18, 16, -18,
+ax_anim 2, 0, 40, 17, -17, 17, -17,
+ax_anim 2, 0, 37, 6, -6, 6, -6,
+ax_anim_terminator
+sDusclopsAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -10, 0, -10,
+ax_anim 2, 0, 44, 0, -17, 0, -17,
+ax_anim 2, 1, 44, 1, -17, 1, -17,
+ax_anim 2, 0, 44, 0, -17, 0, -17,
+ax_anim 2, 0, 44, 1, -17, 1, -17,
+ax_anim 2, 0, 41, 0, -6, 0, -6,
+ax_anim_terminator
+sDusclopsAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 47, -1, -2, 0, -1,
+ax_anim 1, 2, 46, -6, -8, -6, -8,
+ax_anim 1, 0, 47, -9, -12, -9, -12,
+ax_anim 2, 0, 48, -16, -18, -16, -18,
+ax_anim 2, 1, 48, -17, -17, -17, -17,
+ax_anim 2, 0, 48, -16, -18, -16, -18,
+ax_anim 2, 0, 48, -17, -17, -17, -17,
+ax_anim 2, 0, 45, -6, -6, -6, -6,
+ax_anim_terminator
+sDusclopsAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 52, -20, 0, -20, 0,
+ax_anim 2, 1, 52, -20, 1, -20, 1,
+ax_anim 2, 0, 52, -20, 0, -20, 0,
+ax_anim 2, 0, 52, -20, 1, -20, 1,
+ax_anim 2, 0, 49, -6, 0, -6, 0,
+ax_anim_terminator
+sDusclopsAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 56, -18, 19, -18, 19,
+ax_anim 2, 1, 56, -19, 18, -19, 18,
+ax_anim 2, 0, 56, -18, 19, -18, 19,
+ax_anim 2, 0, 56, -19, 18, -19, 18,
+ax_anim 2, 0, 53, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, -4, 0, -4,
+ax_anim 8, 0, 58, 0, -5, 0, -5,
+ax_anim 1, 2, 58, 0, -1, 0, -1,
+ax_anim 1, 0, 58, 0, 4, 0, 4,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 1, 88, -1, 19, -1, 19,
+ax_anim 2, 0, 88, 0, 19, 0, 19,
+ax_anim 2, 0, 88, -1, 19, -1, 19,
+ax_anim 2, 0, 88, 0, 19, 0, 19,
+ax_anim 2, 0, 88, -1, 19, -1, 19,
+ax_anim 2, 0, 57, 0, 11, 0, 11,
+ax_anim 2, 0, 57, 0, 3, 0, 3,
+ax_anim_terminator
+sDusclopsAnims_3_2:
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 2, 0, 62, -4, -4, -4, -4,
+ax_anim 8, 0, 62, -5, -5, -5, -5,
+ax_anim 1, 2, 62, 1, 1, 1, 1,
+ax_anim 1, 0, 62, 8, 8, 8, 8,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 1, 68, 16, 20, 16, 20,
+ax_anim 2, 0, 68, 17, 19, 17, 19,
+ax_anim 2, 0, 68, 16, 20, 16, 20,
+ax_anim 2, 0, 68, 17, 19, 17, 19,
+ax_anim 2, 0, 68, 16, 20, 16, 20,
+ax_anim 2, 0, 61, 10, 11, 10, 11,
+ax_anim 2, 0, 61, 3, 3, 3, 3,
+ax_anim_terminator
+sDusclopsAnims_3_3:
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 2, 0, 66, -4, 0, -4, 0,
+ax_anim 8, 0, 66, -5, 0, -5, 0,
+ax_anim 1, 2, 66, -1, 0, -1, 0,
+ax_anim 1, 0, 66, 4, 0, 4, 0,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 1, 72, 15, 1, 15, 1,
+ax_anim 2, 0, 72, 15, 0, 15, 0,
+ax_anim 2, 0, 72, 15, 1, 15, 1,
+ax_anim 2, 0, 72, 15, 0, 15, 0,
+ax_anim 2, 0, 72, 15, 1, 15, 1,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, 3, 0, 3, 0,
+ax_anim_terminator
+sDusclopsAnims_3_4:
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 2, 0, 70, -4, 4, -4, 4,
+ax_anim 8, 0, 70, -5, 5, -5, 5,
+ax_anim 1, 2, 70, -1, 1, -1, 1,
+ax_anim 1, 0, 70, 6, -8, 6, -8,
+ax_anim 2, 0, 71, 12, -16, 12, -16,
+ax_anim 2, 1, 76, 13, -18, 13, -18,
+ax_anim 2, 0, 76, 14, -17, 14, -17,
+ax_anim 2, 0, 76, 13, -18, 13, -18,
+ax_anim 2, 0, 76, 14, -17, 14, -17,
+ax_anim 2, 0, 76, 13, -18, 13, -18,
+ax_anim 2, 0, 69, 4, -6, 4, -6,
+ax_anim 2, 0, 69, 2, -3, 2, -3,
+ax_anim_terminator
+sDusclopsAnims_3_5:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 8, 0, 74, 0, 5, 0, 5,
+ax_anim 1, 2, 74, 0, 1, 0, 1,
+ax_anim 1, 0, 74, 0, -4, 0, -4,
+ax_anim 2, 0, 75, 0, -13, 0, -13,
+ax_anim 2, 1, 72, 1, -15, 1, -15,
+ax_anim 2, 0, 72, 0, -15, 0, -15,
+ax_anim 2, 0, 72, 1, -15, 1, -15,
+ax_anim 2, 0, 72, 0, -15, 0, -15,
+ax_anim 2, 0, 72, 1, -15, 1, -15,
+ax_anim 2, 0, 73, 0, -6, 0, -6,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim_terminator
+sDusclopsAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 4, 4, 4, 4,
+ax_anim 8, 0, 78, 5, 5, 5, 5,
+ax_anim 1, 2, 78, 1, 1, 1, 1,
+ax_anim 1, 0, 78, -6, -8, -6, -8,
+ax_anim 2, 0, 79, -12, -16, -12, -16,
+ax_anim 2, 1, 76, -13, -18, -13, -18,
+ax_anim 2, 0, 76, -14, -17, -14, -17,
+ax_anim 2, 0, 76, -13, -18, -13, -18,
+ax_anim 2, 0, 76, -14, -17, -14, -17,
+ax_anim 2, 0, 76, -13, -18, -13, -18,
+ax_anim 2, 0, 77, -4, -6, -4, -6,
+ax_anim 2, 0, 77, -2, -3, -2, -3,
+ax_anim_terminator
+sDusclopsAnims_3_7:
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 8, 0, 82, 5, 0, 5, 0,
+ax_anim 1, 2, 82, 1, 0, 1, 0,
+ax_anim 1, 0, 82, -4, 0, -4, 0,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 1, 80, -15, 1, -15, 1,
+ax_anim 2, 0, 80, -15, 0, -15, 0,
+ax_anim 2, 0, 80, -15, 1, -15, 1,
+ax_anim 2, 0, 80, -15, 0, -15, 0,
+ax_anim 2, 0, 80, -15, 1, -15, 1,
+ax_anim 2, 0, 81, -6, 0, -6, 0,
+ax_anim 2, 0, 81, -3, 0, -3, 0,
+ax_anim_terminator
+sDusclopsAnims_3_8:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 2, 0, 86, 4, -4, 4, -4,
+ax_anim 8, 0, 86, 5, -5, 5, -5,
+ax_anim 1, 2, 86, -1, 1, -1, 1,
+ax_anim 1, 0, 86, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 1, 84, -16, 20, -16, 20,
+ax_anim 2, 0, 84, -17, 19, -17, 19,
+ax_anim 2, 0, 84, -16, 20, -16, 20,
+ax_anim 2, 0, 84, -17, 19, -17, 19,
+ax_anim 2, 0, 84, -16, 20, -16, 20,
+ax_anim 2, 0, 85, -10, 11, -10, 11,
+ax_anim 2, 0, 85, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_4_1:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 6, 2, 90, 0, -2, 0, -2,
+ax_anim 1, 0, 89, 0, -1, 0, -1,
+ax_anim 1, 0, 89, 0, 2, 0, 3,
+ax_anim 4, 1, 91, 0, 4, 0, 3,
+ax_anim 4, 0, 90, 0, 4, 0, 3,
+ax_anim 2, 0, 91, 0, 4, 0, 3,
+ax_anim 4, 0, 90, 0, 4, 0, 3,
+ax_anim 2, 0, 91, 0, 4, 0, 3,
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim_terminator
+sDusclopsAnims_4_2:
+ax_anim 2, 0, 93, -2, -1, -2, -1,
+ax_anim 6, 2, 93, -3, -2, -3, -2,
+ax_anim 1, 0, 92, 0, 1, 0, 1,
+ax_anim 1, 0, 92, 1, 2, 1, 2,
+ax_anim 4, 1, 94, 2, 4, 2, 4,
+ax_anim 4, 0, 93, 2, 4, 2, 4,
+ax_anim 2, 0, 94, 2, 4, 2, 4,
+ax_anim 4, 0, 93, 2, 4, 2, 4,
+ax_anim 2, 0, 94, 2, 4, 2, 4,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sDusclopsAnims_4_3:
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 6, 2, 96, -2, 0, -2, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 2, 0, 2, 0,
+ax_anim 4, 1, 97, 3, 0, 3, 0,
+ax_anim 4, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 4, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim_terminator
+sDusclopsAnims_4_4:
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 6, 2, 99, -2, 2, -2, 2,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 1, -1, 1, -1,
+ax_anim 4, 1, 100, 2, -2, 2, -2,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim_terminator
+sDusclopsAnims_4_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 6, 2, 102, 0, 3, 0, 3,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, -2,
+ax_anim 4, 1, 103, 0, -3, 0, -3,
+ax_anim 4, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 4, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim_terminator
+sDusclopsAnims_4_6:
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 6, 2, 105, 2, 2, 2, 2,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 104, -1, -1, -1, -1,
+ax_anim 4, 1, 106, -2, -2, -2, -2,
+ax_anim 4, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim 4, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim 2, 0, 104, -1, -1, -1, -1,
+ax_anim_terminator
+sDusclopsAnims_4_7:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 6, 2, 108, 2, 0, 2, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, -2, 0, -2, 0,
+ax_anim 4, 1, 109, -3, 0, -3, 0,
+ax_anim 4, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 109, -3, 0, -3, 0,
+ax_anim 4, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 109, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -1, 0, -1, 0,
+ax_anim_terminator
+sDusclopsAnims_4_8:
+ax_anim 2, 0, 111, 2, -1, 2, -1,
+ax_anim 6, 2, 111, 3, -2, 3, -2,
+ax_anim 1, 0, 110, 0, 1, 0, 1,
+ax_anim 1, 0, 110, -1, 2, -1, 2,
+ax_anim 4, 1, 112, -2, 4, -2, 4,
+ax_anim 4, 0, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 112, -2, 4, -2, 4,
+ax_anim 4, 0, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 112, -2, 4, -2, 4,
+ax_anim 2, 0, 110, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_5_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 4, 0, 114, 0, -3, 0, -3,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_5_2:
+ax_anim 2, 0, 122, -2, -2, -2, -2,
+ax_anim 4, 0, 122, -3, -3, -3, -3,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 2, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 1, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_5_3:
+ax_anim 2, 0, 130, -2, 0, -2, 0,
+ax_anim 4, 0, 130, -3, 0, -3, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 1, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_5_4:
+ax_anim 2, 0, 138, -2, 2, -2, 2,
+ax_anim 4, 0, 138, -3, 3, -3, 3,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 6, 2, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_5_5:
+ax_anim 2, 0, 146, 0, 2, 0, 2,
+ax_anim 4, 0, 146, 0, 3, 0, 3,
+ax_anim 2, 0, 147, 0, 1, 0, 1,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 2, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 1, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_5_6:
+ax_anim 2, 0, 154, 2, 2, 2, 2,
+ax_anim 4, 0, 154, 3, 3, 3, 3,
+ax_anim 2, 0, 155, 1, 1, 1, 1,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 2, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 1, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_5_7:
+ax_anim 2, 0, 162, 2, 0, 2, 0,
+ax_anim 4, 0, 162, 3, 0, 3, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 2, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_5_8:
+ax_anim 2, 0, 170, 2, -2, 2, -2,
+ax_anim 4, 0, 170, 3, -3, 3, -3,
+ax_anim 2, 0, 171, 1, -1, 1, -1,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 6, 2, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_6_1:
+ax_anim 30, 0, 177, 0, 0, 0, 0,
+ax_anim 35, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_7_1:
+ax_anim 2, 0, 179, 0, -2, 0, -2,
+ax_anim 8, 0, 179, 0, -3, 0, -3,
+ax_anim_terminator
+sDusclopsAnims_7_2:
+ax_anim 2, 0, 180, -2, -2, -2, -2,
+ax_anim 8, 0, 180, -3, -3, -3, -3,
+ax_anim_terminator
+sDusclopsAnims_7_3:
+ax_anim 2, 0, 181, -3, 0, -3, 0,
+ax_anim 8, 0, 181, -4, 0, -4, 0,
+ax_anim_terminator
+sDusclopsAnims_7_4:
+ax_anim 2, 0, 182, -2, 2, -2, 2,
+ax_anim 8, 0, 182, -3, 3, -3, 3,
+ax_anim_terminator
+sDusclopsAnims_7_5:
+ax_anim 2, 0, 183, 0, 2, 0, 2,
+ax_anim 8, 0, 183, 0, 3, 0, 3,
+ax_anim_terminator
+sDusclopsAnims_7_6:
+ax_anim 2, 0, 184, 2, 2, 2, 2,
+ax_anim 8, 0, 184, 3, 3, 3, 3,
+ax_anim_terminator
+sDusclopsAnims_7_7:
+ax_anim 2, 0, 185, 3, 0, 3, 0,
+ax_anim 8, 0, 185, 4, 0, 4, 0,
+ax_anim_terminator
+sDusclopsAnims_7_8:
+ax_anim 2, 0, 186, 2, -2, 2, -2,
+ax_anim 8, 0, 186, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_8_1:
+ax_anim 40, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 188, 0, 0, 0, 0,
+ax_anim 12, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_8_2:
+ax_anim 40, 0, 189, 0, 0, 0, 0,
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim 12, 0, 189, 0, 0, 0, 0,
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_8_3:
+ax_anim 40, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim 12, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_8_4:
+ax_anim 40, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim 12, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_8_5:
+ax_anim 40, 0, 195, 0, 0, 0, 0,
+ax_anim 8, 0, 196, 0, 0, 0, 0,
+ax_anim 12, 0, 195, 0, 0, 0, 0,
+ax_anim 8, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_8_6:
+ax_anim 40, 0, 197, 0, 0, 0, 0,
+ax_anim 8, 0, 198, 0, 0, 0, 0,
+ax_anim 12, 0, 197, 0, 0, 0, 0,
+ax_anim 8, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_8_7:
+ax_anim 40, 0, 199, 0, 0, 0, 0,
+ax_anim 8, 0, 200, 0, 0, 0, 0,
+ax_anim 12, 0, 199, 0, 0, 0, 0,
+ax_anim 8, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_8_8:
+ax_anim 40, 0, 201, 0, 0, 0, 0,
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim 12, 0, 201, 0, 0, 0, 0,
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_9_1:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 7, 4, 7, 4,
+ax_anim 2, 0, 205, 12, 11, 12, 11,
+ax_anim 2, 0, 206, 11, 17, 11, 17,
+ax_anim 3, 0, 207, 0, 21, 0, 21,
+ax_anim 2, 3, 208, -11, 17, -11, 17,
+ax_anim 2, 0, 209, -12, 11, -12, 11,
+ax_anim 1, 0, 210, -7, 4, -7, 4,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_9_2:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 10, 1, 10, 1,
+ax_anim 2, 0, 204, 16, 6, 16, 6,
+ax_anim 2, 0, 205, 21, 13, 21, 13,
+ax_anim 3, 0, 206, 21, 20, 21, 20,
+ax_anim 2, 3, 207, 11, 21, 11, 21,
+ax_anim 2, 0, 208, 2, 17, 2, 17,
+ax_anim 1, 0, 209, -1, 9, -1, 9,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_9_3:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 4, -5, 4, -5,
+ax_anim 2, 0, 203, 11, -7, 11, -7,
+ax_anim 2, 0, 204, 17, -5, 17, -5,
+ax_anim 3, 0, 205, 21, 1, 21, 1,
+ax_anim 2, 3, 206, 18, 5, 18, 5,
+ax_anim 2, 0, 207, 10, 7, 10, 7,
+ax_anim 1, 0, 208, 3, 4, 3, 4,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_9_4:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -8, 0, -8,
+ax_anim 2, 0, 210, 5, -14, 5, -14,
+ax_anim 2, 0, 203, 12, -18, 12, -18,
+ax_anim 3, 0, 204, 20, -17, 20, -17,
+ax_anim 2, 3, 205, 22, -11, 22, -11,
+ax_anim 2, 0, 206, 19, -6, 19, -6,
+ax_anim 1, 0, 207, 11, -1, 11, -1,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_9_5:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -10, -3, -10, -3,
+ax_anim 2, 0, 209, -12, -9, -12, -9,
+ax_anim 2, 0, 210, -7, -14, -7, -14,
+ax_anim 3, 0, 203, 0, -18, 0, -18,
+ax_anim 2, 3, 204, 7, -14, 7, -14,
+ax_anim 2, 0, 205, 12, -9, 12, -9,
+ax_anim 1, 0, 206, 10, -3, 10, -3,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_9_6:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -8, 0, -8,
+ax_anim 2, 0, 204, -5, -14, -5, -14,
+ax_anim 2, 0, 203, -12, -18, -12, -18,
+ax_anim 3, 0, 210, -20, -17, -20, -17,
+ax_anim 2, 3, 209, -22, -11, -22, -11,
+ax_anim 2, 0, 208, -19, -6, -19, -6,
+ax_anim 1, 0, 207, -11, -1, -11, -1,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_9_7:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, -4, -5, -4, -5,
+ax_anim 2, 0, 203, -11, -7, -11, -7,
+ax_anim 2, 0, 210, -17, -5, -17, -5,
+ax_anim 3, 0, 209, -21, 1, -21, 1,
+ax_anim 2, 3, 208, -18, 5, -18, 5,
+ax_anim 2, 0, 207, -10, 7, -10, 7,
+ax_anim 1, 0, 206, -3, 4, -3, 4,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_9_8:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -10, 1, -10, 1,
+ax_anim 2, 0, 210, -16, 6, -16, 6,
+ax_anim 2, 0, 209, -21, 13, -21, 13,
+ax_anim 3, 0, 208, -21, 20, -21, 20,
+ax_anim 2, 3, 207, -11, 21, -11, 21,
+ax_anim 2, 0, 206, -2, 17, -2, 17,
+ax_anim 1, 0, 205, 1, 9, 1, 9,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_10_1:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, 0, 6, 0,
+ax_anim 2, 0, 211, -6, 0, -6, 0,
+ax_anim 2, 0, 211, 10, 0, 10, 0,
+ax_anim 2, 0, 211, -10, 0, -10, 0,
+ax_anim 2, 0, 211, 12, 0, 12, 0,
+ax_anim 3, 0, 211, -12, 0, -12, 0,
+ax_anim 3, 0, 211, 13, 0, 13, 0,
+ax_anim 3, 0, 211, -13, 0, -13, 0,
+ax_anim 2, 0, 211, 12, 0, 12, 0,
+ax_anim 3, 0, 211, -12, 0, -12, 0,
+ax_anim 2, 0, 211, 10, 0, 10, 0,
+ax_anim 2, 0, 211, -10, 0, -10, 0,
+ax_anim 2, 0, 211, 6, 0, 6, 0,
+ax_anim 2, 0, 211, -6, 0, -6, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_10_2:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 6, -6, 6, -6,
+ax_anim 2, 0, 212, -6, 6, -6, 6,
+ax_anim 2, 0, 212, 10, -10, 10, -10,
+ax_anim 2, 0, 212, -10, 10, -10, 10,
+ax_anim 2, 0, 212, 12, -12, 12, -12,
+ax_anim 3, 0, 212, -12, 12, -12, 12,
+ax_anim 3, 0, 212, 13, -13, 13, -13,
+ax_anim 3, 0, 212, -13, 13, -13, 13,
+ax_anim 2, 0, 212, 12, -12, 12, -12,
+ax_anim 3, 0, 212, -12, 12, -12, 12,
+ax_anim 2, 0, 212, 10, -10, 10, -10,
+ax_anim 2, 0, 212, -10, 10, -10, 10,
+ax_anim 2, 0, 212, 6, -6, 6, -6,
+ax_anim 2, 0, 212, -6, 6, -6, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_10_3:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -6, 0, -6,
+ax_anim 2, 0, 213, 0, 6, 0, 6,
+ax_anim 2, 0, 213, 0, -10, 0, -10,
+ax_anim 2, 0, 213, 0, 10, 0, 10,
+ax_anim 2, 0, 213, 0, -12, 0, -12,
+ax_anim 3, 0, 213, 0, 12, 0, 12,
+ax_anim 3, 0, 213, 0, -13, 0, -13,
+ax_anim 3, 0, 213, 0, 13, 0, 13,
+ax_anim 2, 0, 213, 0, -12, 0, -12,
+ax_anim 3, 0, 213, 0, 12, 0, 12,
+ax_anim 2, 0, 213, 0, -10, 0, -10,
+ax_anim 2, 0, 213, 0, 10, 0, 10,
+ax_anim 2, 0, 213, 0, -6, 0, -6,
+ax_anim 2, 0, 213, 0, 6, 0, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_10_4:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -6, -6, -6, -6,
+ax_anim 2, 0, 214, 6, 6, 6, 6,
+ax_anim 2, 0, 214, -10, -10, -10, -10,
+ax_anim 2, 0, 214, 10, 10, 10, 10,
+ax_anim 2, 0, 214, -12, -12, -12, -12,
+ax_anim 3, 0, 214, 12, 12, 12, 12,
+ax_anim 3, 0, 214, -13, -13, -13, -13,
+ax_anim 3, 0, 214, 13, 13, 13, 13,
+ax_anim 2, 0, 214, -12, -12, -12, -12,
+ax_anim 3, 0, 214, 12, 12, 12, 12,
+ax_anim 2, 0, 214, -10, -10, -10, -10,
+ax_anim 2, 0, 214, 10, 10, 10, 10,
+ax_anim 2, 0, 214, -6, -6, -6, -6,
+ax_anim 2, 0, 214, 6, 6, 6, 6,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_10_5:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, 0, 6, 0,
+ax_anim 2, 0, 215, -6, 0, -6, 0,
+ax_anim 2, 0, 215, 10, 0, 10, 0,
+ax_anim 2, 0, 215, -10, 0, -10, 0,
+ax_anim 2, 0, 215, 12, 0, 12, 0,
+ax_anim 3, 0, 215, -12, 0, -12, 0,
+ax_anim 3, 0, 215, 13, 0, 13, 0,
+ax_anim 3, 0, 215, -13, 0, -13, 0,
+ax_anim 2, 0, 215, 12, 0, 12, 0,
+ax_anim 3, 0, 215, -12, 0, -12, 0,
+ax_anim 2, 0, 215, 10, 0, 10, 0,
+ax_anim 2, 0, 215, -10, 0, -10, 0,
+ax_anim 2, 0, 215, 6, 0, 6, 0,
+ax_anim 2, 0, 215, -6, 0, -6, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_10_6:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 6, -6, 6, -6,
+ax_anim 2, 0, 216, -6, 6, -6, 6,
+ax_anim 2, 0, 216, 10, -10, 10, -10,
+ax_anim 2, 0, 216, -10, 10, -10, 10,
+ax_anim 2, 0, 216, 12, -12, 12, -12,
+ax_anim 3, 0, 216, -12, 12, -12, 12,
+ax_anim 3, 0, 216, 13, -13, 13, -13,
+ax_anim 3, 0, 216, -13, 13, -13, 13,
+ax_anim 2, 0, 216, 12, -12, 12, -12,
+ax_anim 3, 0, 216, -12, 12, -12, 12,
+ax_anim 2, 0, 216, 10, -10, 10, -10,
+ax_anim 2, 0, 216, -10, 10, -10, 10,
+ax_anim 2, 0, 216, 6, -6, 6, -6,
+ax_anim 2, 0, 216, -6, 6, -6, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_10_7:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, -6, 0, -6,
+ax_anim 2, 0, 217, 0, 6, 0, 6,
+ax_anim 2, 0, 217, 0, -10, 0, -10,
+ax_anim 2, 0, 217, 0, 10, 0, 10,
+ax_anim 2, 0, 217, 0, -12, 0, -12,
+ax_anim 3, 0, 217, 0, 12, 0, 12,
+ax_anim 3, 0, 217, 0, -13, 0, -13,
+ax_anim 3, 0, 217, 0, 13, 0, 13,
+ax_anim 2, 0, 217, 0, -12, 0, -12,
+ax_anim 3, 0, 217, 0, 12, 0, 12,
+ax_anim 2, 0, 217, 0, -10, 0, -10,
+ax_anim 2, 0, 217, 0, 10, 0, 10,
+ax_anim 2, 0, 217, 0, -6, 0, -6,
+ax_anim 2, 0, 217, 0, 6, 0, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_10_8:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, -6, -6, -6, -6,
+ax_anim 2, 0, 218, 6, 6, 6, 6,
+ax_anim 2, 0, 218, -10, -10, -10, -10,
+ax_anim 2, 0, 218, 10, 10, 10, 10,
+ax_anim 2, 0, 218, -12, -12, -12, -12,
+ax_anim 3, 0, 218, 12, 12, 12, 12,
+ax_anim 3, 0, 218, -13, -13, -13, -13,
+ax_anim 3, 0, 218, 13, 13, 13, 13,
+ax_anim 2, 0, 218, -12, -12, -12, -12,
+ax_anim 3, 0, 218, 12, 12, 12, 12,
+ax_anim 2, 0, 218, -10, -10, -10, -10,
+ax_anim 2, 0, 218, 10, 10, 10, 10,
+ax_anim 2, 0, 218, -6, -6, -6, -6,
+ax_anim 2, 0, 218, 6, 6, 6, 6,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_11_1:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 2, 0, 221, 0, -18, 0, 0,
+ax_anim 1, 0, 221, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_11_2:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_11_3:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -18, 0, 0,
+ax_anim 1, 0, 227, 0, -12, 0, 0,
+ax_anim 2, 2, 227, 0, 1, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_11_4:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -17, 0, 0,
+ax_anim 1, 0, 230, 0, -11, 0, 0,
+ax_anim 2, 2, 230, 0, 1, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_11_5:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 3, 0, 233, 0, -21, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 1, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_11_6:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 3, 0, 236, 0, -21, 0, 0,
+ax_anim 2, 0, 236, 0, -17, 0, 0,
+ax_anim 1, 0, 236, 0, -11, 0, 0,
+ax_anim 2, 2, 236, 0, 1, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_11_7:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 0, -10, 0, 0,
+ax_anim 2, 0, 238, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 4, 0, 238, 0, -21, 0, 0,
+ax_anim 4, 0, 237, 0, -22, 0, 0,
+ax_anim 3, 0, 239, 0, -21, 0, 0,
+ax_anim 2, 0, 239, 0, -18, 0, 0,
+ax_anim 1, 0, 239, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 1, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_11_8:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 3, 0, 242, 0, -21, 0, 0,
+ax_anim 2, 0, 242, 0, -18, 0, 0,
+ax_anim 1, 0, 242, 0, -12, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_12_1:
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_12_2:
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_12_3:
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_12_4:
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_12_5:
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_12_6:
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_12_7:
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_12_8:
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDusclopsAnims_13_1:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_13_2:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_13_3:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_13_4:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_13_5:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_13_6:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_13_7:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsAnims_13_8:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sDusclopsGfx1:
+.incbin "baserom.gba", 0x14B397C, 0x200
+sDusclopsSprites1:
+ax_sprite sDusclopsGfx1, 0x200
+ax_sprite_terminator
+sDusclopsGfx2:
+.incbin "baserom.gba", 0x14B3B8C, 0x200
+sDusclopsSprites2:
+ax_sprite sDusclopsGfx2, 0x200
+ax_sprite_terminator
+sDusclopsGfx3:
+.incbin "baserom.gba", 0x14B3D9C, 0x200
+sDusclopsSprites3:
+ax_sprite sDusclopsGfx3, 0x200
+ax_sprite_terminator
+sDusclopsGfx4:
+.incbin "baserom.gba", 0x14B3FAC, 0x200
+sDusclopsSprites4:
+ax_sprite sDusclopsGfx4, 0x200
+ax_sprite_terminator
+sDusclopsGfx5:
+.incbin "baserom.gba", 0x14B41BC, 0x200
+sDusclopsSprites5:
+ax_sprite sDusclopsGfx5, 0x200
+ax_sprite_terminator
+sDusclopsGfx6:
+.incbin "baserom.gba", 0x14B43CC, 0x200
+sDusclopsSprites6:
+ax_sprite sDusclopsGfx6, 0x200
+ax_sprite_terminator
+sDusclopsGfx7:
+.incbin "baserom.gba", 0x14B45DC, 0x200
+sDusclopsSprites7:
+ax_sprite sDusclopsGfx7, 0x200
+ax_sprite_terminator
+sDusclopsGfx8:
+.incbin "baserom.gba", 0x14B47EC, 0x200
+sDusclopsSprites8:
+ax_sprite sDusclopsGfx8, 0x200
+ax_sprite_terminator
+sDusclopsGfx9:
+.incbin "baserom.gba", 0x14B49FC, 0x200
+sDusclopsSprites9:
+ax_sprite sDusclopsGfx9, 0x200
+ax_sprite_terminator
+sDusclopsGfx10:
+.incbin "baserom.gba", 0x14B4C0C, 0x200
+sDusclopsSprites10:
+ax_sprite sDusclopsGfx10, 0x200
+ax_sprite_terminator
+sDusclopsGfx11:
+.incbin "baserom.gba", 0x14B4E1C, 0x200
+sDusclopsSprites11:
+ax_sprite sDusclopsGfx11, 0x200
+ax_sprite_terminator
+sDusclopsGfx12:
+.incbin "baserom.gba", 0x14B502C, 0x200
+sDusclopsSprites12:
+ax_sprite sDusclopsGfx12, 0x200
+ax_sprite_terminator
+sDusclopsGfx13:
+.incbin "baserom.gba", 0x14B523C, 0x200
+sDusclopsSprites13:
+ax_sprite sDusclopsGfx13, 0x200
+ax_sprite_terminator
+sDusclopsGfx14:
+.incbin "baserom.gba", 0x14B544C, 0x200
+sDusclopsSprites14:
+ax_sprite sDusclopsGfx14, 0x200
+ax_sprite_terminator
+sDusclopsGfx15:
+.incbin "baserom.gba", 0x14B565C, 0x200
+sDusclopsSprites15:
+ax_sprite sDusclopsGfx15, 0x200
+ax_sprite_terminator
+sDusclopsGfx16:
+.incbin "baserom.gba", 0x14B586C, 0xE0
+sDusclopsSprites16:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx16, 0xe0
+ax_sprite_terminator
+sDusclopsGfx17:
+.incbin "baserom.gba", 0x14B5964, 0x60
+sDusclopsSprites17:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx17, 0x60
+ax_sprite_terminator
+sDusclopsGfx18:
+.incbin "baserom.gba", 0x14B59DC, 0x20
+sDusclopsSprites18:
+ax_sprite sDusclopsGfx18, 0x20
+ax_sprite_terminator
+sDusclopsGfx19:
+.incbin "baserom.gba", 0x14B5A0C, 0x20
+sDusclopsSprites19:
+ax_sprite sDusclopsGfx19, 0x20
+ax_sprite_terminator
+sDusclopsGfx20:
+.incbin "baserom.gba", 0x14B5A3C, 0x100
+sDusclopsSprites20:
+ax_sprite sDusclopsGfx20, 0x100
+ax_sprite_terminator
+sDusclopsGfx21:
+.incbin "baserom.gba", 0x14B5B4C, 0x80
+sDusclopsSprites21:
+ax_sprite sDusclopsGfx21, 0x80
+ax_sprite_terminator
+sDusclopsGfx22:
+.incbin "baserom.gba", 0x14B5BDC, 0x20
+sDusclopsSprites22:
+ax_sprite sDusclopsGfx22, 0x20
+ax_sprite_terminator
+sDusclopsGfx23:
+.incbin "baserom.gba", 0x14B5C0C, 0x40
+sDusclopsSprites23:
+ax_sprite sDusclopsGfx23, 0x40
+ax_sprite_terminator
+sDusclopsGfx24:
+.incbin "baserom.gba", 0x14B5C5C, 0x40
+sDusclopsGfx24_1:
+.incbin "baserom.gba", 0x14B5C9C, 0x180
+sDusclopsSprites24:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx24_1, 0x180
+ax_sprite_terminator
+sDusclopsGfx25:
+.incbin "baserom.gba", 0x14B5E44, 0x40
+sDusclopsGfx25_1:
+.incbin "baserom.gba", 0x14B5E84, 0x160
+sDusclopsSprites25:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx25_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx26:
+.incbin "baserom.gba", 0x14B6014, 0x100
+sDusclopsSprites26:
+ax_sprite sDusclopsGfx26, 0x100
+ax_sprite_terminator
+sDusclopsGfx27:
+.incbin "baserom.gba", 0x14B6124, 0x80
+sDusclopsSprites27:
+ax_sprite sDusclopsGfx27, 0x80
+ax_sprite_terminator
+sDusclopsGfx28:
+.incbin "baserom.gba", 0x14B61B4, 0x40
+sDusclopsSprites28:
+ax_sprite sDusclopsGfx28, 0x40
+ax_sprite_terminator
+sDusclopsGfx29:
+.incbin "baserom.gba", 0x14B6204, 0x20
+sDusclopsSprites29:
+ax_sprite sDusclopsGfx29, 0x20
+ax_sprite_terminator
+sDusclopsGfx30:
+.incbin "baserom.gba", 0x14B6234, 0x100
+sDusclopsSprites30:
+ax_sprite sDusclopsGfx30, 0x100
+ax_sprite_terminator
+sDusclopsGfx31:
+.incbin "baserom.gba", 0x14B6344, 0x80
+sDusclopsSprites31:
+ax_sprite sDusclopsGfx31, 0x80
+ax_sprite_terminator
+sDusclopsGfx32:
+.incbin "baserom.gba", 0x14B63D4, 0x20
+sDusclopsSprites32:
+ax_sprite sDusclopsGfx32, 0x20
+ax_sprite_terminator
+sDusclopsGfx33:
+.incbin "baserom.gba", 0x14B6404, 0x40
+sDusclopsSprites33:
+ax_sprite sDusclopsGfx33, 0x40
+ax_sprite_terminator
+sDusclopsGfx34:
+.incbin "baserom.gba", 0x14B6454, 0x40
+sDusclopsGfx34_1:
+.incbin "baserom.gba", 0x14B6494, 0x180
+sDusclopsSprites34:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx34_1, 0x180
+ax_sprite_terminator
+sDusclopsGfx35:
+.incbin "baserom.gba", 0x14B663C, 0x20
+sDusclopsGfx35_1:
+.incbin "baserom.gba", 0x14B665C, 0xA0
+sDusclopsGfx35_2:
+.incbin "baserom.gba", 0x14B66FC, 0x60
+sDusclopsSprites35:
+ax_sprite 0, 0x40
+ax_sprite sDusclopsGfx35, 0x20
+ax_sprite 0, 0x60
+ax_sprite sDusclopsGfx35_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx36:
+.incbin "baserom.gba", 0x14B679C, 0x100
+sDusclopsSprites36:
+ax_sprite sDusclopsGfx36, 0x100
+ax_sprite_terminator
+sDusclopsGfx37:
+.incbin "baserom.gba", 0x14B68AC, 0x80
+sDusclopsSprites37:
+ax_sprite sDusclopsGfx37, 0x80
+ax_sprite_terminator
+sDusclopsGfx38:
+.incbin "baserom.gba", 0x14B693C, 0x40
+sDusclopsSprites38:
+ax_sprite sDusclopsGfx38, 0x40
+ax_sprite_terminator
+sDusclopsGfx39:
+.incbin "baserom.gba", 0x14B698C, 0x20
+sDusclopsSprites39:
+ax_sprite sDusclopsGfx39, 0x20
+ax_sprite_terminator
+sDusclopsGfx40:
+.incbin "baserom.gba", 0x14B69BC, 0x20
+sDusclopsSprites40:
+ax_sprite sDusclopsGfx40, 0x20
+ax_sprite_terminator
+sDusclopsGfx41:
+.incbin "baserom.gba", 0x14B69EC, 0x40
+sDusclopsGfx41_1:
+.incbin "baserom.gba", 0x14B6A2C, 0x180
+sDusclopsSprites41:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx41_1, 0x180
+ax_sprite_terminator
+sDusclopsGfx42:
+.incbin "baserom.gba", 0x14B6BD4, 0xE0
+sDusclopsSprites42:
+ax_sprite sDusclopsGfx42, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx43:
+.incbin "baserom.gba", 0x14B6CCC, 0x40
+sDusclopsGfx43_1:
+.incbin "baserom.gba", 0x14B6D0C, 0x160
+sDusclopsSprites43:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx43_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx44:
+.incbin "baserom.gba", 0x14B6E9C, 0x40
+sDusclopsGfx44_1:
+.incbin "baserom.gba", 0x14B6EDC, 0x40
+sDusclopsGfx44_2:
+.incbin "baserom.gba", 0x14B6F1C, 0x100
+sDusclopsSprites44:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDusclopsGfx44_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx44_2, 0x100
+ax_sprite_terminator
+sDusclopsGfx45:
+.incbin "baserom.gba", 0x14B7054, 0x40
+sDusclopsGfx45_1:
+.incbin "baserom.gba", 0x14B7094, 0x80
+sDusclopsSprites45:
+ax_sprite sDusclopsGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDusclopsGfx45_1, 0x80
+ax_sprite_terminator
+sDusclopsGfx46:
+.incbin "baserom.gba", 0x14B7134, 0xE0
+sDusclopsSprites46:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx46, 0xe0
+ax_sprite_terminator
+sDusclopsGfx47:
+.incbin "baserom.gba", 0x14B722C, 0x80
+sDusclopsSprites47:
+ax_sprite sDusclopsGfx47, 0x80
+ax_sprite_terminator
+sDusclopsGfx48:
+.incbin "baserom.gba", 0x14B72BC, 0x20
+sDusclopsSprites48:
+ax_sprite sDusclopsGfx48, 0x20
+ax_sprite_terminator
+sDusclopsGfx49:
+.incbin "baserom.gba", 0x14B72EC, 0x40
+sDusclopsSprites49:
+ax_sprite sDusclopsGfx49, 0x40
+ax_sprite_terminator
+sDusclopsGfx50:
+.incbin "baserom.gba", 0x14B733C, 0x40
+sDusclopsGfx50_1:
+.incbin "baserom.gba", 0x14B737C, 0x180
+sDusclopsSprites50:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx50_1, 0x180
+ax_sprite_terminator
+sDusclopsGfx51:
+.incbin "baserom.gba", 0x14B7524, 0x80
+sDusclopsGfx51_1:
+.incbin "baserom.gba", 0x14B75A4, 0x20
+sDusclopsSprites51:
+ax_sprite 0, 0x40
+ax_sprite sDusclopsGfx51, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx51_1, 0x20
+ax_sprite_terminator
+sDusclopsGfx52:
+.incbin "baserom.gba", 0x14B75EC, 0x20
+sDusclopsGfx52_1:
+.incbin "baserom.gba", 0x14B760C, 0xC0
+sDusclopsSprites52:
+ax_sprite sDusclopsGfx52, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx52_1, 0xc0
+ax_sprite_terminator
+sDusclopsGfx53:
+.incbin "baserom.gba", 0x14B76EC, 0x80
+sDusclopsSprites53:
+ax_sprite sDusclopsGfx53, 0x80
+ax_sprite_terminator
+sDusclopsGfx54:
+.incbin "baserom.gba", 0x14B777C, 0x20
+sDusclopsSprites54:
+ax_sprite sDusclopsGfx54, 0x20
+ax_sprite_terminator
+sDusclopsGfx55:
+.incbin "baserom.gba", 0x14B77AC, 0x20
+sDusclopsSprites55:
+ax_sprite sDusclopsGfx55, 0x20
+ax_sprite_terminator
+sDusclopsGfx56:
+.incbin "baserom.gba", 0x14B77DC, 0x40
+sDusclopsSprites56:
+ax_sprite sDusclopsGfx56, 0x40
+ax_sprite_terminator
+sDusclopsGfx57:
+.incbin "baserom.gba", 0x14B782C, 0x40
+sDusclopsGfx57_1:
+.incbin "baserom.gba", 0x14B786C, 0x160
+sDusclopsSprites57:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx57, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx57_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx58:
+.incbin "baserom.gba", 0x14B79FC, 0xA0
+sDusclopsGfx58_1:
+.incbin "baserom.gba", 0x14B7A9C, 0x20
+sDusclopsSprites58:
+ax_sprite sDusclopsGfx58, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx58_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx59:
+.incbin "baserom.gba", 0x14B7AE4, 0x20
+sDusclopsGfx59_1:
+.incbin "baserom.gba", 0x14B7B04, 0xC0
+sDusclopsSprites59:
+ax_sprite sDusclopsGfx59, 0x20
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx59_1, 0xc0
+ax_sprite_terminator
+sDusclopsGfx60:
+.incbin "baserom.gba", 0x14B7BE4, 0x80
+sDusclopsSprites60:
+ax_sprite sDusclopsGfx60, 0x80
+ax_sprite_terminator
+sDusclopsGfx61:
+.incbin "baserom.gba", 0x14B7C74, 0x20
+sDusclopsSprites61:
+ax_sprite sDusclopsGfx61, 0x20
+ax_sprite_terminator
+sDusclopsGfx62:
+.incbin "baserom.gba", 0x14B7CA4, 0x20
+sDusclopsSprites62:
+ax_sprite sDusclopsGfx62, 0x20
+ax_sprite_terminator
+sDusclopsGfx63:
+.incbin "baserom.gba", 0x14B7CD4, 0x40
+sDusclopsSprites63:
+ax_sprite sDusclopsGfx63, 0x40
+ax_sprite_terminator
+sDusclopsGfx64:
+.incbin "baserom.gba", 0x14B7D24, 0x40
+sDusclopsGfx64_1:
+.incbin "baserom.gba", 0x14B7D64, 0x180
+sDusclopsSprites64:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx64, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx64_1, 0x180
+ax_sprite_terminator
+sDusclopsGfx65:
+.incbin "baserom.gba", 0x14B7F0C, 0x60
+sDusclopsGfx65_1:
+.incbin "baserom.gba", 0x14B7F6C, 0x160
+sDusclopsSprites65:
+ax_sprite sDusclopsGfx65, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx65_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx66:
+.incbin "baserom.gba", 0x14B80F4, 0x1E0
+sDusclopsSprites66:
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx66, 0x1e0
+ax_sprite_terminator
+sDusclopsGfx67:
+.incbin "baserom.gba", 0x14B82EC, 0xC0
+sDusclopsGfx67_1:
+.incbin "baserom.gba", 0x14B83AC, 0x20
+sDusclopsSprites67:
+ax_sprite sDusclopsGfx67, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx67_1, 0x20
+ax_sprite_terminator
+sDusclopsGfx68:
+.incbin "baserom.gba", 0x14B83EC, 0x80
+sDusclopsSprites68:
+ax_sprite sDusclopsGfx68, 0x80
+ax_sprite_terminator
+sDusclopsGfx69:
+.incbin "baserom.gba", 0x14B847C, 0x40
+sDusclopsSprites69:
+ax_sprite sDusclopsGfx69, 0x40
+ax_sprite_terminator
+sDusclopsGfx70:
+.incbin "baserom.gba", 0x14B84CC, 0x40
+sDusclopsSprites70:
+ax_sprite sDusclopsGfx70, 0x40
+ax_sprite_terminator
+sDusclopsGfx71:
+.incbin "baserom.gba", 0x14B851C, 0x100
+sDusclopsSprites71:
+ax_sprite sDusclopsGfx71, 0x100
+ax_sprite_terminator
+sDusclopsGfx72:
+.incbin "baserom.gba", 0x14B862C, 0x80
+sDusclopsSprites72:
+ax_sprite sDusclopsGfx72, 0x80
+ax_sprite_terminator
+sDusclopsGfx73:
+.incbin "baserom.gba", 0x14B86BC, 0x20
+sDusclopsSprites73:
+ax_sprite sDusclopsGfx73, 0x20
+ax_sprite_terminator
+sDusclopsGfx74:
+.incbin "baserom.gba", 0x14B86EC, 0x20
+sDusclopsSprites74:
+ax_sprite sDusclopsGfx74, 0x20
+ax_sprite_terminator
+sDusclopsGfx75:
+.incbin "baserom.gba", 0x14B871C, 0x20
+sDusclopsSprites75:
+ax_sprite sDusclopsGfx75, 0x20
+ax_sprite_terminator
+sDusclopsGfx76:
+.incbin "baserom.gba", 0x14B874C, 0x20
+sDusclopsSprites76:
+ax_sprite sDusclopsGfx76, 0x20
+ax_sprite_terminator
+sDusclopsGfx77:
+.incbin "baserom.gba", 0x14B877C, 0x80
+sDusclopsSprites77:
+ax_sprite sDusclopsGfx77, 0x80
+ax_sprite_terminator
+sDusclopsGfx78:
+.incbin "baserom.gba", 0x14B880C, 0x80
+sDusclopsSprites78:
+ax_sprite sDusclopsGfx78, 0x80
+ax_sprite_terminator
+sDusclopsGfx79:
+.incbin "baserom.gba", 0x14B889C, 0x80
+sDusclopsSprites79:
+ax_sprite sDusclopsGfx79, 0x80
+ax_sprite_terminator
+sDusclopsGfx80:
+.incbin "baserom.gba", 0x14B892C, 0x80
+sDusclopsSprites80:
+ax_sprite sDusclopsGfx80, 0x80
+ax_sprite_terminator
+sDusclopsGfx81:
+.incbin "baserom.gba", 0x14B89BC, 0x100
+sDusclopsSprites81:
+ax_sprite sDusclopsGfx81, 0x100
+ax_sprite_terminator
+sDusclopsGfx82:
+.incbin "baserom.gba", 0x14B8ACC, 0x80
+sDusclopsSprites82:
+ax_sprite sDusclopsGfx82, 0x80
+ax_sprite_terminator
+sDusclopsGfx83:
+.incbin "baserom.gba", 0x14B8B5C, 0x40
+sDusclopsSprites83:
+ax_sprite sDusclopsGfx83, 0x40
+ax_sprite_terminator
+sDusclopsGfx84:
+.incbin "baserom.gba", 0x14B8BAC, 0x20
+sDusclopsSprites84:
+ax_sprite sDusclopsGfx84, 0x20
+ax_sprite_terminator
+sDusclopsGfx85:
+.incbin "baserom.gba", 0x14B8BDC, 0x20
+sDusclopsSprites85:
+ax_sprite sDusclopsGfx85, 0x20
+ax_sprite_terminator
+sDusclopsGfx86:
+.incbin "baserom.gba", 0x14B8C0C, 0x100
+sDusclopsSprites86:
+ax_sprite sDusclopsGfx86, 0x100
+ax_sprite_terminator
+sDusclopsGfx87:
+.incbin "baserom.gba", 0x14B8D1C, 0x80
+sDusclopsSprites87:
+ax_sprite sDusclopsGfx87, 0x80
+ax_sprite_terminator
+sDusclopsGfx88:
+.incbin "baserom.gba", 0x14B8DAC, 0x40
+sDusclopsSprites88:
+ax_sprite sDusclopsGfx88, 0x40
+ax_sprite_terminator
+sDusclopsGfx89:
+.incbin "baserom.gba", 0x14B8DFC, 0x20
+sDusclopsSprites89:
+ax_sprite sDusclopsGfx89, 0x20
+ax_sprite_terminator
+sDusclopsGfx90:
+.incbin "baserom.gba", 0x14B8E2C, 0x20
+sDusclopsSprites90:
+ax_sprite sDusclopsGfx90, 0x20
+ax_sprite_terminator
+sDusclopsGfx91:
+.incbin "baserom.gba", 0x14B8E5C, 0x100
+sDusclopsSprites91:
+ax_sprite sDusclopsGfx91, 0x100
+ax_sprite_terminator
+sDusclopsGfx92:
+.incbin "baserom.gba", 0x14B8F6C, 0x80
+sDusclopsSprites92:
+ax_sprite sDusclopsGfx92, 0x80
+ax_sprite_terminator
+sDusclopsGfx93:
+.incbin "baserom.gba", 0x14B8FFC, 0x20
+sDusclopsSprites93:
+ax_sprite sDusclopsGfx93, 0x20
+ax_sprite_terminator
+sDusclopsGfx94:
+.incbin "baserom.gba", 0x14B902C, 0x40
+sDusclopsSprites94:
+ax_sprite sDusclopsGfx94, 0x40
+ax_sprite_terminator
+sDusclopsGfx95:
+.incbin "baserom.gba", 0x14B907C, 0x20
+sDusclopsSprites95:
+ax_sprite sDusclopsGfx95, 0x20
+ax_sprite_terminator
+sDusclopsGfx96:
+.incbin "baserom.gba", 0x14B90AC, 0x60
+sDusclopsGfx96_1:
+.incbin "baserom.gba", 0x14B910C, 0x180
+sDusclopsSprites96:
+ax_sprite sDusclopsGfx96, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDusclopsGfx96_1, 0x180
+ax_sprite_terminator
+sDusclopsGfx97:
+.incbin "baserom.gba", 0x14B92AC, 0x20
+sDusclopsSprites97:
+ax_sprite sDusclopsGfx97, 0x20
+ax_sprite_terminator
+sDusclopsGfx98:
+.incbin "baserom.gba", 0x14B92DC, 0x20
+sDusclopsSprites98:
+ax_sprite sDusclopsGfx98, 0x20
+ax_sprite_terminator
+sDusclopsGfx99:
+.incbin "baserom.gba", 0x14B930C, 0x20
+sDusclopsSprites99:
+ax_sprite sDusclopsGfx99, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDusclopsGfx100:
+.incbin "baserom.gba", 0x14B9344, 0x200
+sDusclopsSprites100:
+ax_sprite sDusclopsGfx100, 0x200
+ax_sprite_terminator
+sDusclopsGfx101:
+.incbin "baserom.gba", 0x14B9554, 0x200
+sDusclopsSprites101:
+ax_sprite sDusclopsGfx101, 0x200
+ax_sprite_terminator
+sDusclopsGfx102:
+.incbin "baserom.gba", 0x14B9764, 0x200
+sDusclopsSprites102:
+ax_sprite sDusclopsGfx102, 0x200
+ax_sprite_terminator
+sDusclopsGfx103:
+.incbin "baserom.gba", 0x14B9974, 0x200
+sDusclopsSprites103:
+ax_sprite sDusclopsGfx103, 0x200
+ax_sprite_terminator
+sDusclopsGfx104:
+.incbin "baserom.gba", 0x14B9B84, 0x200
+sDusclopsSprites104:
+ax_sprite sDusclopsGfx104, 0x200
+ax_sprite_terminator
+sDusclopsGfx105:
+.incbin "baserom.gba", 0x14B9D94, 0x200
+sDusclopsSprites105:
+ax_sprite sDusclopsGfx105, 0x200
+ax_sprite_terminator
+sDusclopsGfx106:
+.incbin "baserom.gba", 0x14B9FA4, 0x200
+sDusclopsSprites106:
+ax_sprite sDusclopsGfx106, 0x200
+ax_sprite_terminator
+sAxPosesDusclops:
+.4byte sDusclopsPose1
+.4byte sDusclopsPose2
+.4byte sDusclopsPose3
+.4byte sDusclopsPose4
+.4byte sDusclopsPose5
+.4byte sDusclopsPose6
+.4byte sDusclopsPose7
+.4byte sDusclopsPose8
+.4byte sDusclopsPose9
+.4byte sDusclopsPose10
+.4byte sDusclopsPose11
+.4byte sDusclopsPose12
+.4byte sDusclopsPose13
+.4byte sDusclopsPose14
+.4byte sDusclopsPose15
+.4byte sDusclopsPose16
+.4byte sDusclopsPose17
+.4byte sDusclopsPose18
+.4byte sDusclopsPose19
+.4byte sDusclopsPose20
+.4byte sDusclopsPose21
+.4byte sDusclopsPose22
+.4byte sDusclopsPose23
+.4byte sDusclopsPose24
+.4byte sDusclopsPose25
+.4byte sDusclopsPose26
+.4byte sDusclopsPose27
+.4byte sDusclopsPose28
+.4byte sDusclopsPose29
+.4byte sDusclopsPose30
+.4byte sDusclopsPose31
+.4byte sDusclopsPose32
+.4byte sDusclopsPose33
+.4byte sDusclopsPose34
+.4byte sDusclopsPose35
+.4byte sDusclopsPose36
+.4byte sDusclopsPose37
+.4byte sDusclopsPose38
+.4byte sDusclopsPose39
+.4byte sDusclopsPose40
+.4byte sDusclopsPose41
+.4byte sDusclopsPose42
+.4byte sDusclopsPose43
+.4byte sDusclopsPose44
+.4byte sDusclopsPose45
+.4byte sDusclopsPose46
+.4byte sDusclopsPose47
+.4byte sDusclopsPose48
+.4byte sDusclopsPose49
+.4byte sDusclopsPose50
+.4byte sDusclopsPose51
+.4byte sDusclopsPose52
+.4byte sDusclopsPose53
+.4byte sDusclopsPose54
+.4byte sDusclopsPose55
+.4byte sDusclopsPose56
+.4byte sDusclopsPose57
+.4byte sDusclopsPose58
+.4byte sDusclopsPose59
+.4byte sDusclopsPose60
+.4byte sDusclopsPose61
+.4byte sDusclopsPose62
+.4byte sDusclopsPose63
+.4byte sDusclopsPose64
+.4byte sDusclopsPose65
+.4byte sDusclopsPose66
+.4byte sDusclopsPose67
+.4byte sDusclopsPose68
+.4byte sDusclopsPose69
+.4byte sDusclopsPose70
+.4byte sDusclopsPose71
+.4byte sDusclopsPose72
+.4byte sDusclopsPose73
+.4byte sDusclopsPose74
+.4byte sDusclopsPose75
+.4byte sDusclopsPose76
+.4byte sDusclopsPose77
+.4byte sDusclopsPose78
+.4byte sDusclopsPose79
+.4byte sDusclopsPose80
+.4byte sDusclopsPose81
+.4byte sDusclopsPose82
+.4byte sDusclopsPose83
+.4byte sDusclopsPose84
+.4byte sDusclopsPose85
+.4byte sDusclopsPose86
+.4byte sDusclopsPose87
+.4byte sDusclopsPose88
+.4byte sDusclopsPose89
+.4byte sDusclopsPose90
+.4byte sDusclopsPose91
+.4byte sDusclopsPose92
+.4byte sDusclopsPose93
+.4byte sDusclopsPose94
+.4byte sDusclopsPose95
+.4byte sDusclopsPose96
+.4byte sDusclopsPose97
+.4byte sDusclopsPose98
+.4byte sDusclopsPose99
+.4byte sDusclopsPose100
+.4byte sDusclopsPose101
+.4byte sDusclopsPose102
+.4byte sDusclopsPose103
+.4byte sDusclopsPose104
+.4byte sDusclopsPose105
+.4byte sDusclopsPose106
+.4byte sDusclopsPose107
+.4byte sDusclopsPose108
+.4byte sDusclopsPose109
+.4byte sDusclopsPose110
+.4byte sDusclopsPose111
+.4byte sDusclopsPose112
+.4byte sDusclopsPose113
+.4byte sDusclopsPose114
+.4byte sDusclopsPose115
+.4byte sDusclopsPose116
+.4byte sDusclopsPose117
+.4byte sDusclopsPose118
+.4byte sDusclopsPose119
+.4byte sDusclopsPose120
+.4byte sDusclopsPose121
+.4byte sDusclopsPose122
+.4byte sDusclopsPose123
+.4byte sDusclopsPose124
+.4byte sDusclopsPose125
+.4byte sDusclopsPose126
+.4byte sDusclopsPose127
+.4byte sDusclopsPose128
+.4byte sDusclopsPose129
+.4byte sDusclopsPose130
+.4byte sDusclopsPose131
+.4byte sDusclopsPose132
+.4byte sDusclopsPose133
+.4byte sDusclopsPose134
+.4byte sDusclopsPose135
+.4byte sDusclopsPose136
+.4byte sDusclopsPose137
+.4byte sDusclopsPose138
+.4byte sDusclopsPose139
+.4byte sDusclopsPose140
+.4byte sDusclopsPose141
+.4byte sDusclopsPose142
+.4byte sDusclopsPose143
+.4byte sDusclopsPose144
+.4byte sDusclopsPose145
+.4byte sDusclopsPose146
+.4byte sDusclopsPose147
+.4byte sDusclopsPose148
+.4byte sDusclopsPose149
+.4byte sDusclopsPose150
+.4byte sDusclopsPose151
+.4byte sDusclopsPose152
+.4byte sDusclopsPose153
+.4byte sDusclopsPose154
+.4byte sDusclopsPose155
+.4byte sDusclopsPose156
+.4byte sDusclopsPose157
+.4byte sDusclopsPose158
+.4byte sDusclopsPose159
+.4byte sDusclopsPose160
+.4byte sDusclopsPose161
+.4byte sDusclopsPose162
+.4byte sDusclopsPose163
+.4byte sDusclopsPose164
+.4byte sDusclopsPose165
+.4byte sDusclopsPose166
+.4byte sDusclopsPose167
+.4byte sDusclopsPose168
+.4byte sDusclopsPose169
+.4byte sDusclopsPose170
+.4byte sDusclopsPose171
+.4byte sDusclopsPose172
+.4byte sDusclopsPose173
+.4byte sDusclopsPose174
+.4byte sDusclopsPose175
+.4byte sDusclopsPose176
+.4byte sDusclopsPose177
+.4byte sDusclopsPose178
+.4byte sDusclopsPose179
+.4byte sDusclopsPose180
+.4byte sDusclopsPose181
+.4byte sDusclopsPose182
+.4byte sDusclopsPose183
+.4byte sDusclopsPose184
+.4byte sDusclopsPose185
+.4byte sDusclopsPose186
+.4byte sDusclopsPose187
+.4byte sDusclopsPose188
+.4byte sDusclopsPose189
+.4byte sDusclopsPose190
+.4byte sDusclopsPose191
+.4byte sDusclopsPose192
+.4byte sDusclopsPose193
+.4byte sDusclopsPose194
+.4byte sDusclopsPose195
+.4byte sDusclopsPose196
+.4byte sDusclopsPose197
+.4byte sDusclopsPose198
+.4byte sDusclopsPose199
+.4byte sDusclopsPose200
+.4byte sDusclopsPose201
+.4byte sDusclopsPose202
+.4byte sDusclopsPose203
+.4byte sDusclopsPose204
+.4byte sDusclopsPose205
+.4byte sDusclopsPose206
+.4byte sDusclopsPose207
+.4byte sDusclopsPose208
+.4byte sDusclopsPose209
+.4byte sDusclopsPose210
+.4byte sDusclopsPose211
+.4byte sDusclopsPose212
+.4byte sDusclopsPose213
+.4byte sDusclopsPose214
+.4byte sDusclopsPose215
+.4byte sDusclopsPose216
+.4byte sDusclopsPose217
+.4byte sDusclopsPose218
+.4byte sDusclopsPose219
+.4byte sDusclopsPose220
+.4byte sDusclopsPose221
+.4byte sDusclopsPose222
+.4byte sDusclopsPose223
+.4byte sDusclopsPose224
+.4byte sDusclopsPose225
+.4byte sDusclopsPose226
+.4byte sDusclopsPose227
+.4byte sDusclopsPose228
+.4byte sDusclopsPose229
+.4byte sDusclopsPose230
+.4byte sDusclopsPose231
+.4byte sDusclopsPose232
+.4byte sDusclopsPose233
+.4byte sDusclopsPose234
+.4byte sDusclopsPose235
+.4byte sDusclopsPose236
+.4byte sDusclopsPose237
+.4byte sDusclopsPose238
+.4byte sDusclopsPose239
+.4byte sDusclopsPose240
+.4byte sDusclopsPose241
+.4byte sDusclopsPose242
+.4byte sDusclopsPose243
+.4byte sDusclopsPose244
+.4byte sDusclopsPose245
+.4byte sDusclopsPose246
+.4byte sDusclopsPose247
+.4byte sDusclopsPose248
+.4byte sDusclopsPose249
+.4byte sDusclopsPose250
+.4byte sDusclopsPose251
+.4byte sDusclopsPose252
+.4byte sDusclopsPose253
+.4byte sDusclopsPose254
+.4byte sDusclopsPose255
+.4byte sDusclopsPose256
+.4byte sDusclopsPose257
+.4byte sDusclopsPose258
+.4byte sDusclopsPose259
+sAxPositionsDusclops:
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte   -2,   -7, 	  -7,   -5, 	   8,   -6, 	   0,   -7
+.2byte    1,   -7, 	  -8,   -6, 	   5,   -5, 	  -1,   -6
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+.2byte    6,   -8, 	  10,   -9, 	   0,   -4, 	  -1,   -8
+.2byte    3,   -8, 	  11,  -11, 	  -3,   -3, 	   0,   -9
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    7,  -11, 	  11,  -14, 	   6,   -4, 	  -1,   -8
+.2byte    7,  -12, 	   7,  -11, 	  10,   -7, 	   0,   -9
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    3,  -13, 	  -1,  -14, 	   8,   -8, 	  -2,  -10
+.2byte    3,  -14, 	  -3,  -15, 	  11,  -13, 	  -2,  -10
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    0,  -13, 	   7,  -12, 	  -9,  -16, 	   0,   -9
+.2byte    0,  -13, 	   8,  -17, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte   -4,  -13, 	   0,  -14, 	  -9,   -8, 	   1,  -10
+.2byte   -4,  -14, 	   2,  -15, 	 -12,  -13, 	   1,  -10
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -8,  -11, 	 -12,  -14, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -12, 	  -8,  -11, 	 -11,   -7, 	  -1,   -9
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -7,   -8, 	 -11,   -9, 	  -1,   -4, 	   0,   -8
+.2byte   -4,   -8, 	 -12,  -11, 	   2,   -3, 	  -1,   -9
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte   -2,   -7, 	  -7,   -5, 	   8,   -6, 	   0,   -7
+.2byte    1,   -7, 	  -8,   -6, 	   5,   -5, 	  -1,   -6
+.2byte    0,   -9, 	  -8,   -3, 	   7,   -3, 	   0,   -7
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+.2byte    6,   -8, 	  10,   -9, 	   0,   -4, 	  -1,   -8
+.2byte    3,   -8, 	  11,  -11, 	  -3,   -3, 	   0,   -9
+.2byte    5,  -10, 	  10,   -7, 	   0,   -2, 	  -1,   -9
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    7,  -11, 	  11,  -14, 	   6,   -4, 	  -1,   -8
+.2byte    7,  -12, 	   7,  -11, 	  10,   -7, 	   0,   -9
+.2byte    7,  -13, 	  10,  -10, 	   8,   -4, 	  -1,   -9
+.2byte    7,  -10, 	  10,  -12, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    3,  -13, 	  -1,  -14, 	   8,   -8, 	  -2,  -10
+.2byte    3,  -14, 	  -3,  -15, 	  11,  -13, 	  -2,  -10
+.2byte    5,  -15, 	   1,  -14, 	  10,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    0,  -13, 	   7,  -12, 	  -9,  -16, 	   0,   -9
+.2byte    0,  -13, 	   8,  -17, 	  -8,  -12, 	   0,   -9
+.2byte    0,  -15, 	   9,  -12, 	  -9,  -12, 	   0,  -10
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte   -4,  -13, 	   0,  -14, 	  -9,   -8, 	   1,  -10
+.2byte   -4,  -14, 	   2,  -15, 	 -12,  -13, 	   1,  -10
+.2byte   -6,  -15, 	  -2,  -14, 	 -11,   -7, 	   0,  -10
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -8,  -11, 	 -12,  -14, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -12, 	  -8,  -11, 	 -11,   -7, 	  -1,   -9
+.2byte   -8,  -13, 	 -11,  -10, 	  -9,   -4, 	   0,   -9
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -7,   -8, 	 -11,   -9, 	  -1,   -4, 	   0,   -8
+.2byte   -4,   -8, 	 -12,  -11, 	   2,   -3, 	  -1,   -9
+.2byte   -6,  -10, 	 -11,   -7, 	  -1,   -2, 	   0,   -9
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte    1,   -8, 	  -2,   -3, 	  11,   -6, 	   1,   -7
+.2byte   -2,   -6, 	 -10,   -6, 	   2,   -1, 	   0,   -6
+.2byte   -2,   -6, 	 -10,   -6, 	   2,   -1, 	   0,   -6
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+.2byte    4,   -9, 	   7,   -6, 	  -6,   -4, 	   1,   -9
+.2byte    5,   -8, 	   8,  -14, 	   4,   -3, 	   0,   -8
+.2byte    5,   -8, 	   8,  -14, 	   4,   -3, 	   0,   -8
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    6,  -12, 	  10,  -10, 	   2,   -5, 	  -1,  -10
+.2byte    8,  -12, 	   1,  -13, 	  11,   -8, 	   0,   -9
+.2byte    8,  -12, 	   1,  -13, 	  11,   -8, 	   0,   -9
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    5,  -13, 	   8,  -14, 	   9,   -6, 	  -1,   -9
+.2byte    5,  -16, 	  -2,  -15, 	  12,  -16, 	  -1,  -10
+.2byte    5,  -16, 	  -2,  -15, 	  12,  -16, 	  -1,  -10
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    0,  -14, 	   2,  -16, 	 -10,  -11, 	   0,  -10
+.2byte    0,  -15, 	   9,  -11, 	  -6,  -18, 	   0,   -9
+.2byte    0,  -15, 	   9,  -11, 	  -6,  -18, 	   0,   -9
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte   -6,  -13, 	  -9,  -14, 	 -10,   -6, 	   0,   -9
+.2byte   -6,  -16, 	   1,  -15, 	 -13,  -16, 	   0,  -10
+.2byte   -6,  -16, 	   1,  -15, 	 -13,  -16, 	   0,  -10
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -7,  -12, 	 -11,  -10, 	  -3,   -5, 	   0,  -10
+.2byte   -9,  -12, 	  -2,  -13, 	 -12,   -8, 	  -1,   -9
+.2byte   -9,  -12, 	  -2,  -13, 	 -12,   -8, 	  -1,   -9
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -5,   -9, 	  -8,   -6, 	   5,   -4, 	  -2,   -9
+.2byte   -6,   -8, 	  -9,  -14, 	  -5,   -3, 	  -1,   -8
+.2byte   -6,   -8, 	  -9,  -14, 	  -5,   -3, 	  -1,   -8
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte    0,   -9, 	  -8,   -3, 	   7,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -4, 	   7,   -4, 	  -1,   -7
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+.2byte    5,  -10, 	  10,   -7, 	   0,   -2, 	  -1,   -9
+.2byte    5,   -8, 	  10,   -8, 	  -2,   -4, 	  -1,   -8
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    7,  -13, 	  10,  -10, 	   8,   -4, 	  -1,   -9
+.2byte    7,  -10, 	  10,  -12, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    5,  -15, 	   1,  -14, 	  10,   -7, 	  -1,  -10
+.2byte    4,  -13, 	   1,  -12, 	  10,   -8, 	  -2,   -8
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    0,  -15, 	   9,  -12, 	  -9,  -12, 	   0,  -10
+.2byte    0,  -12, 	   8,  -15, 	  -9,  -15, 	   0,   -7
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte   -6,  -15, 	  -2,  -14, 	 -11,   -7, 	   0,  -10
+.2byte   -5,  -13, 	  -2,  -12, 	 -11,   -8, 	   1,   -8
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -8,  -13, 	 -11,  -10, 	  -9,   -4, 	   0,   -9
+.2byte   -8,  -10, 	 -11,  -12, 	  -7,   -5, 	   0,   -8
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -6,  -10, 	 -11,   -7, 	  -1,   -2, 	   0,   -9
+.2byte   -6,   -8, 	 -11,   -8, 	   1,   -4, 	   0,   -8
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte    0,   -9, 	  -8,   -3, 	   7,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -4, 	   7,   -4, 	  -1,   -7
+.2byte    0,  -10, 	  -8,   -7, 	   8,   -7, 	   0,  -11
+.2byte    0,  -10, 	  -8,   -7, 	   8,   -7, 	   0,  -11
+.2byte    0,  -10, 	  -8,   -7, 	   8,   -7, 	   0,  -11
+.2byte    0,  -10, 	  -8,   -7, 	   8,   -7, 	   0,  -11
+.2byte    0,  -10, 	  -8,   -7, 	   8,   -7, 	   0,  -11
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+.2byte    5,  -10, 	  10,   -7, 	   0,   -2, 	  -1,   -9
+.2byte    5,   -8, 	  10,   -8, 	  -2,   -4, 	  -1,   -8
+.2byte    7,  -10, 	  13,  -11, 	   0,   -4, 	   1,  -11
+.2byte    7,  -10, 	  13,  -11, 	   0,   -4, 	   1,  -11
+.2byte    7,  -10, 	  13,  -11, 	   0,   -4, 	   1,  -11
+.2byte    7,  -10, 	  13,  -11, 	   0,   -4, 	   1,  -11
+.2byte    7,  -10, 	  13,  -11, 	   0,   -4, 	   1,  -11
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    7,  -13, 	  10,  -10, 	   8,   -4, 	  -1,   -9
+.2byte    7,  -10, 	  10,  -12, 	   6,   -5, 	  -1,   -8
+.2byte    9,  -15, 	  12,  -15, 	  10,   -6, 	   0,  -11
+.2byte    9,  -15, 	  12,  -15, 	  10,   -6, 	   0,  -11
+.2byte    9,  -15, 	  12,  -15, 	  10,   -6, 	   0,  -11
+.2byte    9,  -15, 	  12,  -15, 	  10,   -6, 	   0,  -11
+.2byte    9,  -15, 	  12,  -15, 	  10,   -6, 	   0,  -11
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    5,  -15, 	   1,  -14, 	  10,   -7, 	  -1,  -10
+.2byte    4,  -13, 	   1,  -12, 	  10,   -8, 	  -2,   -8
+.2byte    5,  -17, 	  -2,  -17, 	  12,  -12, 	  -1,  -12
+.2byte    5,  -17, 	  -2,  -17, 	  12,  -12, 	  -1,  -12
+.2byte    5,  -17, 	  -2,  -17, 	  12,  -12, 	  -1,  -12
+.2byte    5,  -17, 	  -2,  -17, 	  12,  -12, 	  -1,  -12
+.2byte    5,  -17, 	  -2,  -17, 	  12,  -12, 	  -1,  -12
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    0,  -15, 	   9,  -12, 	  -9,  -12, 	   0,  -10
+.2byte    0,  -12, 	   8,  -15, 	  -9,  -15, 	   0,   -7
+.2byte    0,  -16, 	   9,  -16, 	 -10,  -17, 	   0,  -10
+.2byte    0,  -16, 	   9,  -16, 	 -10,  -17, 	   0,  -10
+.2byte    0,  -16, 	   9,  -16, 	 -10,  -17, 	   0,  -10
+.2byte    0,  -16, 	   9,  -16, 	 -10,  -17, 	   0,  -10
+.2byte    0,  -16, 	   9,  -16, 	 -10,  -17, 	   0,  -10
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte   -6,  -15, 	  -2,  -14, 	 -11,   -7, 	   0,  -10
+.2byte   -5,  -13, 	  -2,  -12, 	 -11,   -8, 	   1,   -8
+.2byte   -6,  -17, 	   1,  -17, 	 -13,  -12, 	   0,  -12
+.2byte   -6,  -17, 	   1,  -17, 	 -13,  -12, 	   0,  -12
+.2byte   -6,  -17, 	   1,  -17, 	 -13,  -12, 	   0,  -12
+.2byte   -6,  -17, 	   1,  -17, 	 -13,  -12, 	   0,  -12
+.2byte   -6,  -17, 	   1,  -17, 	 -13,  -12, 	   0,  -12
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -8,  -13, 	 -11,  -10, 	  -9,   -4, 	   0,   -9
+.2byte   -8,  -10, 	 -11,  -12, 	  -7,   -5, 	   0,   -8
+.2byte  -10,  -15, 	 -13,  -15, 	 -11,   -6, 	  -1,  -11
+.2byte  -10,  -15, 	 -13,  -15, 	 -11,   -6, 	  -1,  -11
+.2byte  -10,  -15, 	 -13,  -15, 	 -11,   -6, 	  -1,  -11
+.2byte  -10,  -15, 	 -13,  -15, 	 -11,   -6, 	  -1,  -11
+.2byte  -10,  -15, 	 -13,  -15, 	 -11,   -6, 	  -1,  -11
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -6,  -10, 	 -11,   -7, 	  -1,   -2, 	   0,   -9
+.2byte   -6,   -8, 	 -11,   -8, 	   1,   -4, 	   0,   -8
+.2byte   -8,  -10, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -8,  -10, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -8,  -10, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -8,  -10, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte   -8,  -10, 	 -14,  -11, 	  -1,   -4, 	  -2,  -11
+.2byte    0,   -7, 	  -7,   -3, 	   6,   -3, 	  -1,   -5
+.2byte    0,   -6, 	  -7,   -3, 	   6,   -3, 	  -1,   -4
+.2byte    0,  -10, 	  -8,   -9, 	   7,   -9, 	  -1,  -10
+.2byte    4,  -11, 	  11,  -13, 	  -3,   -7, 	  -1,  -10
+.2byte    5,  -12, 	   9,  -13, 	   5,   -8, 	  -1,  -10
+.2byte    2,  -13, 	  -2,  -16, 	   8,  -12, 	  -2,   -8
+.2byte   -1,  -12, 	   8,  -14, 	  -9,  -14, 	   0,   -6
+.2byte   -3,  -13, 	   1,  -16, 	  -9,  -12, 	   1,   -8
+.2byte   -6,  -12, 	 -10,  -13, 	  -6,   -8, 	   0,  -10
+.2byte   -5,  -11, 	 -12,  -13, 	   2,   -7, 	   0,  -10
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte    0,   -6, 	  -7,   -4, 	   7,   -4, 	  -1,   -7
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+.2byte    5,   -8, 	  10,   -8, 	  -2,   -4, 	  -1,   -8
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    7,  -10, 	  10,  -12, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    4,  -13, 	   1,  -12, 	  10,   -8, 	  -2,   -8
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    0,  -12, 	   8,  -15, 	  -9,  -15, 	   0,   -7
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte   -5,  -13, 	  -2,  -12, 	 -11,   -8, 	   1,   -8
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -8,  -10, 	 -11,  -12, 	  -7,   -5, 	   0,   -8
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -6,   -8, 	 -11,   -8, 	   1,   -4, 	   0,   -8
+.2byte    0,   -9, 	  -8,   -3, 	   7,   -3, 	   0,   -7
+.2byte   -5,  -10, 	 -10,   -7, 	   0,   -2, 	   1,   -9
+.2byte   -7,  -13, 	 -10,  -10, 	  -8,   -4, 	   1,   -9
+.2byte   -5,  -15, 	  -1,  -14, 	 -10,   -7, 	   1,  -10
+.2byte    1,  -15, 	  10,  -12, 	  -8,  -12, 	   1,  -10
+.2byte    6,  -15, 	   2,  -14, 	  11,   -7, 	   0,  -10
+.2byte    8,  -13, 	  11,  -10, 	   9,   -4, 	   0,   -9
+.2byte    6,  -10, 	  11,   -7, 	   1,   -2, 	   0,   -9
+.2byte    0,   -9, 	  -8,   -3, 	   7,   -3, 	   0,   -7
+.2byte    5,  -10, 	  10,   -7, 	   0,   -2, 	  -1,   -9
+.2byte    7,  -13, 	  10,  -10, 	   8,   -4, 	  -1,   -9
+.2byte    5,  -15, 	   1,  -14, 	  10,   -7, 	  -1,  -10
+.2byte    1,  -15, 	  10,  -12, 	  -8,  -12, 	   1,  -10
+.2byte   -5,  -15, 	  -1,  -14, 	 -10,   -7, 	   1,  -10
+.2byte   -7,  -13, 	 -10,  -10, 	  -8,   -4, 	   1,   -9
+.2byte   -5,  -10, 	 -10,   -7, 	   0,   -2, 	   1,   -9
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte   -2,   -7, 	  -7,   -5, 	   8,   -6, 	   0,   -7
+.2byte    1,   -7, 	  -8,   -6, 	   5,   -5, 	  -1,   -6
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+.2byte    6,   -8, 	  10,   -9, 	   0,   -4, 	  -1,   -8
+.2byte    3,   -8, 	  11,  -11, 	  -3,   -3, 	   0,   -9
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    7,  -11, 	  11,  -14, 	   6,   -4, 	  -1,   -8
+.2byte    7,  -12, 	   7,  -11, 	  10,   -7, 	   0,   -9
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    3,  -13, 	  -1,  -14, 	   8,   -8, 	  -2,  -10
+.2byte    3,  -14, 	  -3,  -15, 	  11,  -13, 	  -2,  -10
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    0,  -13, 	   7,  -12, 	  -9,  -16, 	   0,   -9
+.2byte    0,  -13, 	   8,  -17, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte   -4,  -13, 	   0,  -14, 	  -9,   -8, 	   1,  -10
+.2byte   -4,  -14, 	   2,  -15, 	 -12,  -13, 	   1,  -10
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -8,  -11, 	 -12,  -14, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -12, 	  -8,  -11, 	 -11,   -7, 	  -1,   -9
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -7,   -8, 	 -11,   -9, 	  -1,   -4, 	   0,   -8
+.2byte   -4,   -8, 	 -12,  -11, 	   2,   -3, 	  -1,   -9
+.2byte    0,   -6, 	  -7,   -4, 	   7,   -4, 	  -1,   -7
+.2byte   -6,   -8, 	 -11,   -8, 	   1,   -4, 	   0,   -8
+.2byte   -8,  -10, 	 -11,  -12, 	  -7,   -5, 	   0,   -8
+.2byte   -5,  -13, 	  -2,  -12, 	 -11,   -8, 	   1,   -8
+.2byte    0,  -13, 	   8,  -16, 	  -9,  -16, 	   0,   -8
+.2byte    4,  -13, 	   1,  -12, 	  10,   -8, 	  -2,   -8
+.2byte    7,  -10, 	  10,  -12, 	   6,   -5, 	  -1,   -8
+.2byte    5,   -8, 	  10,   -8, 	  -2,   -4, 	  -1,   -8
+.2byte    0,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,   -7
+.2byte   -5,   -9, 	 -12,  -10, 	   0,   -3, 	  -1,   -9
+.2byte   -8,  -12, 	 -11,  -13, 	  -8,   -6, 	  -1,   -9
+.2byte   -5,  -13, 	   0,  -14, 	 -11,  -10, 	   1,  -10
+.2byte    0,  -14, 	   9,  -14, 	  -9,  -14, 	   0,   -9
+.2byte    4,  -13, 	  -1,  -14, 	  10,  -10, 	  -2,  -10
+.2byte    7,  -12, 	  10,  -13, 	   7,   -6, 	   0,   -9
+.2byte    4,   -9, 	  11,  -10, 	  -1,   -3, 	   0,   -9
+sDusclopsAnimTable1:
+.4byte sDusclopsAnims_1_1
+.4byte sDusclopsAnims_1_2
+.4byte sDusclopsAnims_1_3
+.4byte sDusclopsAnims_1_4
+.4byte sDusclopsAnims_1_5
+.4byte sDusclopsAnims_1_6
+.4byte sDusclopsAnims_1_7
+.4byte sDusclopsAnims_1_8
+sDusclopsAnimTable2:
+.4byte sDusclopsAnims_2_1
+.4byte sDusclopsAnims_2_2
+.4byte sDusclopsAnims_2_3
+.4byte sDusclopsAnims_2_4
+.4byte sDusclopsAnims_2_5
+.4byte sDusclopsAnims_2_6
+.4byte sDusclopsAnims_2_7
+.4byte sDusclopsAnims_2_8
+sDusclopsAnimTable3:
+.4byte sDusclopsAnims_3_1
+.4byte sDusclopsAnims_3_2
+.4byte sDusclopsAnims_3_3
+.4byte sDusclopsAnims_3_4
+.4byte sDusclopsAnims_3_5
+.4byte sDusclopsAnims_3_6
+.4byte sDusclopsAnims_3_7
+.4byte sDusclopsAnims_3_8
+sDusclopsAnimTable4:
+.4byte sDusclopsAnims_4_1
+.4byte sDusclopsAnims_4_2
+.4byte sDusclopsAnims_4_3
+.4byte sDusclopsAnims_4_4
+.4byte sDusclopsAnims_4_5
+.4byte sDusclopsAnims_4_6
+.4byte sDusclopsAnims_4_7
+.4byte sDusclopsAnims_4_8
+sDusclopsAnimTable5:
+.4byte sDusclopsAnims_5_1
+.4byte sDusclopsAnims_5_2
+.4byte sDusclopsAnims_5_3
+.4byte sDusclopsAnims_5_4
+.4byte sDusclopsAnims_5_5
+.4byte sDusclopsAnims_5_6
+.4byte sDusclopsAnims_5_7
+.4byte sDusclopsAnims_5_8
+sDusclopsAnimTable6:
+.4byte sDusclopsAnims_6_1
+.4byte sDusclopsAnims_6_1
+.4byte sDusclopsAnims_6_1
+.4byte sDusclopsAnims_6_1
+.4byte sDusclopsAnims_6_1
+.4byte sDusclopsAnims_6_1
+.4byte sDusclopsAnims_6_1
+.4byte sDusclopsAnims_6_1
+sDusclopsAnimTable7:
+.4byte sDusclopsAnims_7_1
+.4byte sDusclopsAnims_7_2
+.4byte sDusclopsAnims_7_3
+.4byte sDusclopsAnims_7_4
+.4byte sDusclopsAnims_7_5
+.4byte sDusclopsAnims_7_6
+.4byte sDusclopsAnims_7_7
+.4byte sDusclopsAnims_7_8
+sDusclopsAnimTable8:
+.4byte sDusclopsAnims_8_1
+.4byte sDusclopsAnims_8_2
+.4byte sDusclopsAnims_8_3
+.4byte sDusclopsAnims_8_4
+.4byte sDusclopsAnims_8_5
+.4byte sDusclopsAnims_8_6
+.4byte sDusclopsAnims_8_7
+.4byte sDusclopsAnims_8_8
+sDusclopsAnimTable9:
+.4byte sDusclopsAnims_9_1
+.4byte sDusclopsAnims_9_2
+.4byte sDusclopsAnims_9_3
+.4byte sDusclopsAnims_9_4
+.4byte sDusclopsAnims_9_5
+.4byte sDusclopsAnims_9_6
+.4byte sDusclopsAnims_9_7
+.4byte sDusclopsAnims_9_8
+sDusclopsAnimTable10:
+.4byte sDusclopsAnims_10_1
+.4byte sDusclopsAnims_10_2
+.4byte sDusclopsAnims_10_3
+.4byte sDusclopsAnims_10_4
+.4byte sDusclopsAnims_10_5
+.4byte sDusclopsAnims_10_6
+.4byte sDusclopsAnims_10_7
+.4byte sDusclopsAnims_10_8
+sDusclopsAnimTable11:
+.4byte sDusclopsAnims_11_1
+.4byte sDusclopsAnims_11_2
+.4byte sDusclopsAnims_11_3
+.4byte sDusclopsAnims_11_4
+.4byte sDusclopsAnims_11_5
+.4byte sDusclopsAnims_11_6
+.4byte sDusclopsAnims_11_7
+.4byte sDusclopsAnims_11_8
+sDusclopsAnimTable12:
+.4byte sDusclopsAnims_12_1
+.4byte sDusclopsAnims_12_2
+.4byte sDusclopsAnims_12_3
+.4byte sDusclopsAnims_12_4
+.4byte sDusclopsAnims_12_5
+.4byte sDusclopsAnims_12_6
+.4byte sDusclopsAnims_12_7
+.4byte sDusclopsAnims_12_8
+sDusclopsAnimTable13:
+.4byte sDusclopsAnims_13_1
+.4byte sDusclopsAnims_13_2
+.4byte sDusclopsAnims_13_3
+.4byte sDusclopsAnims_13_4
+.4byte sDusclopsAnims_13_5
+.4byte sDusclopsAnims_13_6
+.4byte sDusclopsAnims_13_7
+.4byte sDusclopsAnims_13_8
+sAxAnimationsDusclops:
+.4byte sDusclopsAnimTable1
+.4byte sDusclopsAnimTable2
+.4byte sDusclopsAnimTable3
+.4byte sDusclopsAnimTable4
+.4byte sDusclopsAnimTable5
+.4byte sDusclopsAnimTable6
+.4byte sDusclopsAnimTable7
+.4byte sDusclopsAnimTable8
+.4byte sDusclopsAnimTable9
+.4byte sDusclopsAnimTable10
+.4byte sDusclopsAnimTable11
+.4byte sDusclopsAnimTable12
+.4byte sDusclopsAnimTable13
+sAxSpritesDusclops:
+.4byte sDusclopsSprites1
+.4byte sDusclopsSprites2
+.4byte sDusclopsSprites3
+.4byte sDusclopsSprites4
+.4byte sDusclopsSprites5
+.4byte sDusclopsSprites6
+.4byte sDusclopsSprites7
+.4byte sDusclopsSprites8
+.4byte sDusclopsSprites9
+.4byte sDusclopsSprites10
+.4byte sDusclopsSprites11
+.4byte sDusclopsSprites12
+.4byte sDusclopsSprites13
+.4byte sDusclopsSprites14
+.4byte sDusclopsSprites15
+.4byte sDusclopsSprites16
+.4byte sDusclopsSprites17
+.4byte sDusclopsSprites18
+.4byte sDusclopsSprites19
+.4byte sDusclopsSprites20
+.4byte sDusclopsSprites21
+.4byte sDusclopsSprites22
+.4byte sDusclopsSprites23
+.4byte sDusclopsSprites24
+.4byte sDusclopsSprites25
+.4byte sDusclopsSprites26
+.4byte sDusclopsSprites27
+.4byte sDusclopsSprites28
+.4byte sDusclopsSprites29
+.4byte sDusclopsSprites30
+.4byte sDusclopsSprites31
+.4byte sDusclopsSprites32
+.4byte sDusclopsSprites33
+.4byte sDusclopsSprites34
+.4byte sDusclopsSprites35
+.4byte sDusclopsSprites36
+.4byte sDusclopsSprites37
+.4byte sDusclopsSprites38
+.4byte sDusclopsSprites39
+.4byte sDusclopsSprites40
+.4byte sDusclopsSprites41
+.4byte sDusclopsSprites42
+.4byte sDusclopsSprites43
+.4byte sDusclopsSprites44
+.4byte sDusclopsSprites45
+.4byte sDusclopsSprites46
+.4byte sDusclopsSprites47
+.4byte sDusclopsSprites48
+.4byte sDusclopsSprites49
+.4byte sDusclopsSprites50
+.4byte sDusclopsSprites51
+.4byte sDusclopsSprites52
+.4byte sDusclopsSprites53
+.4byte sDusclopsSprites54
+.4byte sDusclopsSprites55
+.4byte sDusclopsSprites56
+.4byte sDusclopsSprites57
+.4byte sDusclopsSprites58
+.4byte sDusclopsSprites59
+.4byte sDusclopsSprites60
+.4byte sDusclopsSprites61
+.4byte sDusclopsSprites62
+.4byte sDusclopsSprites63
+.4byte sDusclopsSprites64
+.4byte sDusclopsSprites65
+.4byte sDusclopsSprites66
+.4byte sDusclopsSprites67
+.4byte sDusclopsSprites68
+.4byte sDusclopsSprites69
+.4byte sDusclopsSprites70
+.4byte sDusclopsSprites71
+.4byte sDusclopsSprites72
+.4byte sDusclopsSprites73
+.4byte sDusclopsSprites74
+.4byte sDusclopsSprites75
+.4byte sDusclopsSprites76
+.4byte sDusclopsSprites77
+.4byte sDusclopsSprites78
+.4byte sDusclopsSprites79
+.4byte sDusclopsSprites80
+.4byte sDusclopsSprites81
+.4byte sDusclopsSprites82
+.4byte sDusclopsSprites83
+.4byte sDusclopsSprites84
+.4byte sDusclopsSprites85
+.4byte sDusclopsSprites86
+.4byte sDusclopsSprites87
+.4byte sDusclopsSprites88
+.4byte sDusclopsSprites89
+.4byte sDusclopsSprites90
+.4byte sDusclopsSprites91
+.4byte sDusclopsSprites92
+.4byte sDusclopsSprites93
+.4byte sDusclopsSprites94
+.4byte sDusclopsSprites95
+.4byte sDusclopsSprites96
+.4byte sDusclopsSprites97
+.4byte sDusclopsSprites98
+.4byte sDusclopsSprites99
+.4byte sDusclopsSprites100
+.4byte sDusclopsSprites101
+.4byte sDusclopsSprites102
+.4byte sDusclopsSprites103
+.4byte sDusclopsSprites104
+.4byte sDusclopsSprites105
+.4byte sDusclopsSprites106
+sAxMainDusclops:
+ax_main sAxPosesDusclops, sAxAnimationsDusclops, 13, sAxSpritesDusclops, sAxPositionsDusclops

--- a/data/ax/duskull.inc
+++ b/data/ax/duskull.inc
@@ -1,0 +1,3083 @@
+.global gAxDuskull
+gAxDuskull:
+ax_siro sAxMainDuskull
+sDuskullPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose2:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose3:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose4:
+ax_pose 3, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose5:
+ax_pose 4, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose6:
+ax_pose 5, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose7:
+ax_pose 6, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose8:
+ax_pose 7, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose9:
+ax_pose 8, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose10:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose11:
+ax_pose 10, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose12:
+ax_pose 11, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose13:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose14:
+ax_pose 13, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose15:
+ax_pose 14, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose16:
+ax_pose 9, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose17:
+ax_pose 10, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose18:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose19:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose20:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose21:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose22:
+ax_pose 3, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose23:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose24:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose25:
+ax_pose 15, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose26:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose27:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose28:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose29:
+ax_pose 16, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose30:
+ax_pose 3, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose31:
+ax_pose 4, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose32:
+ax_pose 5, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose33:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose34:
+ax_pose 6, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose35:
+ax_pose 7, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose36:
+ax_pose 8, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose37:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose38:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose39:
+ax_pose 10, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose40:
+ax_pose 11, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose41:
+ax_pose 19, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose42:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose43:
+ax_pose 13, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose44:
+ax_pose 14, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose45:
+ax_pose 18, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose46:
+ax_pose 9, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose47:
+ax_pose 10, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose48:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose49:
+ax_pose 17, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose50:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose51:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose52:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose53:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose54:
+ax_pose 3, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose55:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose56:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose57:
+ax_pose 15, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose59:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose60:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose61:
+ax_pose 16, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose62:
+ax_pose 3, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose63:
+ax_pose 4, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose64:
+ax_pose 5, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose65:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose66:
+ax_pose 6, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose67:
+ax_pose 7, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose68:
+ax_pose 8, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose69:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose70:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose71:
+ax_pose 10, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose72:
+ax_pose 11, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose73:
+ax_pose 19, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose74:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose75:
+ax_pose 13, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose76:
+ax_pose 14, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose77:
+ax_pose 18, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose78:
+ax_pose 9, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose79:
+ax_pose 10, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose80:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose81:
+ax_pose 17, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose82:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose83:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose84:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose85:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose86:
+ax_pose 3, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose87:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose88:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose89:
+ax_pose 15, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose91:
+ax_pose 1, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose92:
+ax_pose 2, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose93:
+ax_pose 20, 0x41eb, 0x80ee, 0x5c00
+ax_pose 21, 0x41fb, 0x00f6, 0x5c08
+ax_pose 22, 0x01f3, 0x010e, 0x5c0a
+ax_pose_terminator
+sDuskullPose94:
+ax_pose 16, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose95:
+ax_pose 3, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose96:
+ax_pose 4, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose97:
+ax_pose 5, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose98:
+ax_pose 23, 0x01e3, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose99:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose100:
+ax_pose 6, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose101:
+ax_pose 7, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose102:
+ax_pose 8, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose103:
+ax_pose 24, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose104:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose105:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose106:
+ax_pose 10, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose107:
+ax_pose 11, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose108:
+ax_pose 25, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sDuskullPose109:
+ax_pose 19, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose110:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose111:
+ax_pose 13, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose112:
+ax_pose 14, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose113:
+ax_pose 26, 0x41e7, 0x80ee, 0x5c00
+ax_pose 27, 0x41f7, 0x40ee, 0x5c08
+ax_pose 28, 0x01ef, 0x010e, 0x5c0c
+ax_pose_terminator
+sDuskullPose114:
+ax_pose 18, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose115:
+ax_pose 9, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose116:
+ax_pose 10, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose117:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose118:
+ax_pose 25, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sDuskullPose119:
+ax_pose 17, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose120:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose121:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose122:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose123:
+ax_pose 24, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose124:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose125:
+ax_pose 3, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose126:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose127:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose128:
+ax_pose 23, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose129:
+ax_pose 15, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose130:
+ax_pose 29, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sDuskullPose131:
+ax_pose 30, 0x01f2, 0x04f8, 0x2c00
+ax_pose -1, 0x01f2, 0x04fd, 0x2c00
+ax_pose 29, 0x01e2, 0x80ef, 0x5c01
+ax_pose_terminator
+sDuskullPose132:
+ax_pose 31, 0x01f2, 0x04f8, 0x2c00
+ax_pose -1, 0x01f2, 0x04fd, 0x2c00
+ax_pose 29, 0x01e2, 0x80ef, 0x5c01
+ax_pose_terminator
+sDuskullPose133:
+ax_pose 32, 0x01ee, 0x44f4, 0x2c00
+ax_pose -1, 0x01ee, 0x44f9, 0x2c00
+ax_pose 29, 0x01e2, 0x80ef, 0x5c04
+ax_pose_terminator
+sDuskullPose134:
+ax_pose 33, 0x01ee, 0x44f4, 0x2c00
+ax_pose -1, 0x01ee, 0x44f9, 0x2c00
+ax_pose 29, 0x01e2, 0x80ef, 0x5c04
+ax_pose_terminator
+sDuskullPose135:
+ax_pose 34, 0x01ee, 0x44f4, 0x2c00
+ax_pose -1, 0x01ee, 0x44f9, 0x2c00
+ax_pose 29, 0x01e2, 0x80ef, 0x5c04
+ax_pose_terminator
+sDuskullPose136:
+ax_pose 35, 0x01ee, 0x44f4, 0x2c00
+ax_pose -1, 0x01ee, 0x44f9, 0x2c00
+ax_pose 29, 0x01e2, 0x80ef, 0x5c04
+ax_pose_terminator
+sDuskullPose137:
+ax_pose 16, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose138:
+ax_pose 36, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sDuskullPose139:
+ax_pose 30, 0x01f2, 0x04ff, 0x2c00
+ax_pose -1, 0x01f0, 0x0504, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x5c01
+ax_pose_terminator
+sDuskullPose140:
+ax_pose 31, 0x01f2, 0x04ff, 0x2c00
+ax_pose -1, 0x01f0, 0x0504, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x5c01
+ax_pose_terminator
+sDuskullPose141:
+ax_pose 32, 0x01ee, 0x44fb, 0x2c00
+ax_pose -1, 0x01ec, 0x4500, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x5c04
+ax_pose_terminator
+sDuskullPose142:
+ax_pose 33, 0x01ee, 0x44fb, 0x2c00
+ax_pose -1, 0x01ec, 0x4500, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x5c04
+ax_pose_terminator
+sDuskullPose143:
+ax_pose 34, 0x01ee, 0x44fb, 0x2c00
+ax_pose -1, 0x01ec, 0x4500, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x5c04
+ax_pose_terminator
+sDuskullPose144:
+ax_pose 35, 0x01ee, 0x44fb, 0x2c00
+ax_pose -1, 0x01ec, 0x4500, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x5c04
+ax_pose_terminator
+sDuskullPose145:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose146:
+ax_pose 37, 0x01e1, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose147:
+ax_pose 30, 0x01ef, 0x0502, 0x2c00
+ax_pose 37, 0x01e1, 0x90ed, 0x5c01
+ax_pose -1, 0x01ee, 0x0506, 0x2c00
+ax_pose_terminator
+sDuskullPose148:
+ax_pose 31, 0x01ef, 0x0502, 0x2c00
+ax_pose 37, 0x01e1, 0x90ed, 0x5c01
+ax_pose -1, 0x01ee, 0x0506, 0x2c00
+ax_pose_terminator
+sDuskullPose149:
+ax_pose 32, 0x01eb, 0x44fe, 0x2c00
+ax_pose 37, 0x01e1, 0x90ed, 0x5c04
+ax_pose -1, 0x01ea, 0x4502, 0x2c00
+ax_pose_terminator
+sDuskullPose150:
+ax_pose 33, 0x01eb, 0x44fe, 0x2c00
+ax_pose 37, 0x01e1, 0x90ed, 0x5c04
+ax_pose -1, 0x01ea, 0x4502, 0x2c00
+ax_pose_terminator
+sDuskullPose151:
+ax_pose 34, 0x01eb, 0x44fe, 0x2c00
+ax_pose 37, 0x01e1, 0x90ed, 0x5c04
+ax_pose -1, 0x01ea, 0x4502, 0x2c00
+ax_pose_terminator
+sDuskullPose152:
+ax_pose 35, 0x01eb, 0x44fe, 0x2c00
+ax_pose 37, 0x01e1, 0x90ed, 0x5c04
+ax_pose -1, 0x01ea, 0x4502, 0x2c00
+ax_pose_terminator
+sDuskullPose153:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose154:
+ax_pose 38, 0x01e2, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose155:
+ax_pose 38, 0x01e2, 0x90ed, 0x5c00
+ax_pose 30, 0x01ed, 0x0505, 0x2c10
+ax_pose -1, 0x01ea, 0x0500, 0x2c10
+ax_pose_terminator
+sDuskullPose156:
+ax_pose 38, 0x01e2, 0x90ed, 0x5c00
+ax_pose 31, 0x01ed, 0x0505, 0x2c10
+ax_pose -1, 0x01ea, 0x0500, 0x2c10
+ax_pose_terminator
+sDuskullPose157:
+ax_pose 38, 0x01e2, 0x90ed, 0x5c00
+ax_pose 32, 0x01e9, 0x4501, 0x2c10
+ax_pose -1, 0x01e6, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose158:
+ax_pose 38, 0x01e2, 0x90ed, 0x5c00
+ax_pose 33, 0x01e9, 0x4501, 0x2c10
+ax_pose -1, 0x01e6, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose159:
+ax_pose 38, 0x01e2, 0x90ed, 0x5c00
+ax_pose 34, 0x01e9, 0x4501, 0x2c10
+ax_pose -1, 0x01e6, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose160:
+ax_pose 38, 0x01e2, 0x90ed, 0x5c00
+ax_pose 35, 0x01e9, 0x4501, 0x2c10
+ax_pose -1, 0x01e6, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose161:
+ax_pose 19, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose162:
+ax_pose 39, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose163:
+ax_pose 39, 0x01e1, 0x80f0, 0x5c00
+ax_pose 30, 0x01e8, 0x04f7, 0x2c10
+ax_pose -1, 0x01e8, 0x0500, 0x2c10
+ax_pose_terminator
+sDuskullPose164:
+ax_pose 39, 0x01e1, 0x80f0, 0x5c00
+ax_pose 31, 0x01e8, 0x04f7, 0x2c10
+ax_pose -1, 0x01e8, 0x0500, 0x2c10
+ax_pose_terminator
+sDuskullPose165:
+ax_pose 39, 0x01e1, 0x80f0, 0x5c00
+ax_pose 32, 0x01e4, 0x44f3, 0x2c10
+ax_pose -1, 0x01e4, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose166:
+ax_pose 39, 0x01e1, 0x80f0, 0x5c00
+ax_pose 33, 0x01e4, 0x44f3, 0x2c10
+ax_pose -1, 0x01e4, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose167:
+ax_pose 39, 0x01e1, 0x80f0, 0x5c00
+ax_pose 34, 0x01e4, 0x44f3, 0x2c10
+ax_pose -1, 0x01e4, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose168:
+ax_pose 39, 0x01e1, 0x80f0, 0x5c00
+ax_pose 35, 0x01e4, 0x44f3, 0x2c10
+ax_pose -1, 0x01e4, 0x44fc, 0x2c10
+ax_pose_terminator
+sDuskullPose169:
+ax_pose 18, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose170:
+ax_pose 38, 0x01e2, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose171:
+ax_pose 38, 0x01e2, 0x80f2, 0x5c00
+ax_pose 30, 0x01ed, 0x04f2, 0x2c10
+ax_pose -1, 0x01ea, 0x04f6, 0x2c10
+ax_pose_terminator
+sDuskullPose172:
+ax_pose 38, 0x01e2, 0x80f2, 0x5c00
+ax_pose 31, 0x01ed, 0x04f2, 0x2c10
+ax_pose -1, 0x01ea, 0x04f6, 0x2c10
+ax_pose_terminator
+sDuskullPose173:
+ax_pose 38, 0x01e2, 0x80f2, 0x5c00
+ax_pose 32, 0x01e9, 0x44ee, 0x2c10
+ax_pose -1, 0x01e6, 0x44f2, 0x2c10
+ax_pose_terminator
+sDuskullPose174:
+ax_pose 38, 0x01e2, 0x80f2, 0x5c00
+ax_pose 33, 0x01e9, 0x44ee, 0x2c10
+ax_pose -1, 0x01e6, 0x44f2, 0x2c10
+ax_pose_terminator
+sDuskullPose175:
+ax_pose 38, 0x01e2, 0x80f2, 0x5c00
+ax_pose 34, 0x01e9, 0x44ee, 0x2c10
+ax_pose -1, 0x01e6, 0x44f2, 0x2c10
+ax_pose_terminator
+sDuskullPose176:
+ax_pose 38, 0x01e2, 0x80f2, 0x5c00
+ax_pose 35, 0x01e9, 0x44ee, 0x2c10
+ax_pose -1, 0x01e6, 0x44f2, 0x2c10
+ax_pose_terminator
+sDuskullPose177:
+ax_pose 17, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose178:
+ax_pose 37, 0x01e1, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose179:
+ax_pose 30, 0x01ef, 0x04f4, 0x2c00
+ax_pose 37, 0x01e1, 0x80f2, 0x5c01
+ax_pose -1, 0x01ee, 0x04f0, 0x2c00
+ax_pose_terminator
+sDuskullPose180:
+ax_pose 31, 0x01ef, 0x04f4, 0x2c00
+ax_pose 37, 0x01e1, 0x80f2, 0x5c01
+ax_pose -1, 0x01ee, 0x04f0, 0x2c00
+ax_pose_terminator
+sDuskullPose181:
+ax_pose 32, 0x01eb, 0x44f0, 0x2c00
+ax_pose 37, 0x01e1, 0x80f2, 0x5c04
+ax_pose -1, 0x01ea, 0x44ec, 0x2c00
+ax_pose_terminator
+sDuskullPose182:
+ax_pose 33, 0x01eb, 0x44f0, 0x2c00
+ax_pose 37, 0x01e1, 0x80f2, 0x5c04
+ax_pose -1, 0x01ea, 0x44ec, 0x2c00
+ax_pose_terminator
+sDuskullPose183:
+ax_pose 34, 0x01eb, 0x44f0, 0x2c00
+ax_pose 37, 0x01e1, 0x80f2, 0x5c04
+ax_pose -1, 0x01ea, 0x44ec, 0x2c00
+ax_pose_terminator
+sDuskullPose184:
+ax_pose 35, 0x01eb, 0x44f0, 0x2c00
+ax_pose 37, 0x01e1, 0x80f2, 0x5c04
+ax_pose -1, 0x01ea, 0x44ec, 0x2c00
+ax_pose_terminator
+sDuskullPose185:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose186:
+ax_pose 36, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose187:
+ax_pose 30, 0x01f2, 0x04f7, 0x2c00
+ax_pose -1, 0x01f0, 0x04f3, 0x2c00
+ax_pose 36, 0x01e2, 0x80f0, 0x5c01
+ax_pose_terminator
+sDuskullPose188:
+ax_pose 31, 0x01f2, 0x04f7, 0x2c00
+ax_pose -1, 0x01f0, 0x04f3, 0x2c00
+ax_pose 36, 0x01e2, 0x80f0, 0x5c01
+ax_pose_terminator
+sDuskullPose189:
+ax_pose 32, 0x01ee, 0x44f3, 0x2c00
+ax_pose -1, 0x01ec, 0x44ef, 0x2c00
+ax_pose 36, 0x01e2, 0x80f0, 0x5c04
+ax_pose_terminator
+sDuskullPose190:
+ax_pose 33, 0x01ee, 0x44f3, 0x2c00
+ax_pose -1, 0x01ec, 0x44ef, 0x2c00
+ax_pose 36, 0x01e2, 0x80f0, 0x5c04
+ax_pose_terminator
+sDuskullPose191:
+ax_pose 34, 0x01ee, 0x44f3, 0x2c00
+ax_pose -1, 0x01ec, 0x44ef, 0x2c00
+ax_pose 36, 0x01e2, 0x80f0, 0x5c04
+ax_pose_terminator
+sDuskullPose192:
+ax_pose 35, 0x01ee, 0x44f3, 0x2c00
+ax_pose -1, 0x01ec, 0x44ef, 0x2c00
+ax_pose 36, 0x01e2, 0x80f0, 0x5c04
+ax_pose_terminator
+sDuskullPose193:
+ax_pose 40, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose194:
+ax_pose 41, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose195:
+ax_pose 42, 0x01de, 0x80f1, 0x5c00
+ax_pose_terminator
+sDuskullPose196:
+ax_pose 43, 0x01df, 0x90ee, 0x5c00
+ax_pose_terminator
+sDuskullPose197:
+ax_pose 44, 0x01e1, 0x90ee, 0x5c00
+ax_pose_terminator
+sDuskullPose198:
+ax_pose 45, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose199:
+ax_pose 46, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sDuskullPose200:
+ax_pose 45, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sDuskullPose201:
+ax_pose 44, 0x01e1, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose202:
+ax_pose 43, 0x01df, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose203:
+ax_pose 15, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose204:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose205:
+ax_pose 17, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose206:
+ax_pose 18, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose207:
+ax_pose 19, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose208:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose209:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose210:
+ax_pose 16, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose211:
+ax_pose 20, 0x41eb, 0x80ef, 0x5c00
+ax_pose 21, 0x41fb, 0x00f7, 0x5c08
+ax_pose 22, 0x01f3, 0x010f, 0x5c0a
+ax_pose_terminator
+sDuskullPose212:
+ax_pose 23, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose213:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose214:
+ax_pose 25, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose215:
+ax_pose 26, 0x41ea, 0x80ef, 0x5c00
+ax_pose 27, 0x41fa, 0x40ef, 0x5c08
+ax_pose 28, 0x01f2, 0x010f, 0x5c0c
+ax_pose_terminator
+sDuskullPose216:
+ax_pose 25, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sDuskullPose217:
+ax_pose 24, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose218:
+ax_pose 23, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sDuskullPose219:
+ax_pose 20, 0x41eb, 0x80ef, 0x5c00
+ax_pose 21, 0x41fb, 0x00f7, 0x5c08
+ax_pose 22, 0x01f3, 0x010f, 0x5c0a
+ax_pose_terminator
+sDuskullPose220:
+ax_pose 23, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sDuskullPose221:
+ax_pose 24, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose222:
+ax_pose 25, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sDuskullPose223:
+ax_pose 26, 0x41ea, 0x80ef, 0x5c00
+ax_pose 27, 0x41fa, 0x40ef, 0x5c08
+ax_pose 28, 0x01f2, 0x010f, 0x5c0c
+ax_pose_terminator
+sDuskullPose224:
+ax_pose 25, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose225:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose226:
+ax_pose 23, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose227:
+ax_pose 15, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose228:
+ax_pose 20, 0x41ea, 0x80ee, 0x5c00
+ax_pose 21, 0x41fa, 0x00f6, 0x5c08
+ax_pose 22, 0x01f2, 0x010e, 0x5c0a
+ax_pose_terminator
+sDuskullPose229:
+ax_pose 16, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose230:
+ax_pose 23, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sDuskullPose231:
+ax_pose 17, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sDuskullPose232:
+ax_pose 24, 0x01ea, 0x90ef, 0x5c00
+ax_pose_terminator
+sDuskullPose233:
+ax_pose 18, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sDuskullPose234:
+ax_pose 25, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sDuskullPose235:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose236:
+ax_pose 26, 0x41ea, 0x80ee, 0x5c00
+ax_pose 27, 0x41fa, 0x40ee, 0x5c08
+ax_pose 28, 0x01f2, 0x010e, 0x5c0c
+ax_pose_terminator
+sDuskullPose237:
+ax_pose 18, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sDuskullPose238:
+ax_pose 25, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sDuskullPose239:
+ax_pose 17, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sDuskullPose240:
+ax_pose 24, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sDuskullPose241:
+ax_pose 16, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose242:
+ax_pose 23, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sDuskullPose243:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sDuskullPose244:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose245:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose246:
+ax_pose 9, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose247:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose248:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sDuskullPose249:
+ax_pose 6, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose250:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose251:
+ax_pose 15, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose252:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose253:
+ax_pose 17, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose254:
+ax_pose 18, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sDuskullPose255:
+ax_pose 19, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sDuskullPose256:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose257:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sDuskullPose258:
+ax_pose 16, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+.align 2
+sDuskullAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 1, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 1, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 1, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 1, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 17, 0, 1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 1, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 1, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 23, 0, 22,
+ax_anim 2, 1, 24, 1, 23, 1, 22,
+ax_anim 2, 0, 24, 0, 23, 0, 22,
+ax_anim 2, 0, 24, 1, 23, 1, 22,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sDuskullAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 11, 10, 11,
+ax_anim 2, 0, 28, 20, 23, 20, 23,
+ax_anim 2, 1, 28, 21, 22, 21, 22,
+ax_anim 2, 0, 28, 20, 23, 20, 23,
+ax_anim 2, 0, 28, 21, 22, 21, 22,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sDuskullAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 6, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 1, 32, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 20, 1, 20, 1,
+ax_anim 2, 0, 33, 6, 0, 6, 0,
+ax_anim_terminator
+sDuskullAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 38, 6, -5, 6, -5,
+ax_anim 1, 0, 38, 15, -11, 15, -12,
+ax_anim 2, 0, 36, 21, -16, 21, -18,
+ax_anim 2, 1, 36, 22, -15, 22, -17,
+ax_anim 2, 0, 36, 21, -16, 21, -18,
+ax_anim 2, 0, 36, 22, -15, 22, -17,
+ax_anim 2, 0, 37, 7, -6, 7, -6,
+ax_anim_terminator
+sDuskullAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -14, 0, -16,
+ax_anim 2, 1, 40, 1, -14, 1, -16,
+ax_anim 2, 0, 40, 0, -14, 0, -16,
+ax_anim 2, 0, 40, 1, -14, 1, -16,
+ax_anim 2, 0, 41, 0, -6, 0, -6,
+ax_anim_terminator
+sDuskullAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 46, -6, -5, -6, -5,
+ax_anim 1, 0, 46, -15, -11, -15, -12,
+ax_anim 2, 0, 44, -21, -16, -21, -18,
+ax_anim 2, 1, 44, -22, -15, -22, -17,
+ax_anim 2, 0, 44, -21, -16, -21, -18,
+ax_anim 2, 0, 44, -22, -15, -22, -17,
+ax_anim 2, 0, 45, -7, -6, -7, -6,
+ax_anim_terminator
+sDuskullAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -20, 0, -20, 0,
+ax_anim 2, 1, 48, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -20, 0, -20, 0,
+ax_anim 2, 0, 48, -20, 1, -20, 1,
+ax_anim 2, 0, 49, -6, 0, -6, 0,
+ax_anim_terminator
+sDuskullAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 11, -10, 11,
+ax_anim 2, 0, 52, -20, 23, -20, 23,
+ax_anim 2, 1, 52, -21, 22, -21, 22,
+ax_anim 2, 0, 52, -20, 23, -20, 23,
+ax_anim 2, 0, 52, -21, 22, -21, 22,
+ax_anim 2, 0, 53, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDuskullAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 6, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 23, 0, 22,
+ax_anim 2, 1, 56, 1, 23, 1, 22,
+ax_anim 2, 0, 56, 0, 23, 0, 22,
+ax_anim 2, 0, 56, 1, 23, 1, 22,
+ax_anim 2, 0, 57, 0, 6, 0, 6,
+ax_anim_terminator
+sDuskullAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 6, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 11, 10, 11,
+ax_anim 2, 0, 60, 20, 23, 20, 23,
+ax_anim 2, 1, 60, 21, 22, 21, 22,
+ax_anim 2, 0, 60, 20, 23, 20, 23,
+ax_anim 2, 0, 60, 21, 22, 21, 22,
+ax_anim 2, 0, 61, 6, 6, 6, 6,
+ax_anim_terminator
+sDuskullAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 6, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 20, 0, 20, 0,
+ax_anim 2, 1, 64, 20, 1, 20, 1,
+ax_anim 2, 0, 64, 20, 0, 20, 0,
+ax_anim 2, 0, 64, 20, 1, 20, 1,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim_terminator
+sDuskullAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 6, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 70, 6, -5, 6, -5,
+ax_anim 1, 0, 70, 15, -11, 15, -12,
+ax_anim 2, 0, 68, 21, -16, 21, -18,
+ax_anim 2, 1, 68, 22, -15, 22, -17,
+ax_anim 2, 0, 68, 21, -16, 21, -18,
+ax_anim 2, 0, 68, 22, -15, 22, -17,
+ax_anim 2, 0, 69, 7, -6, 7, -6,
+ax_anim_terminator
+sDuskullAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 6, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 72, 0, -14, 0, -16,
+ax_anim 2, 1, 72, 1, -14, 1, -16,
+ax_anim 2, 0, 72, 0, -14, 0, -16,
+ax_anim 2, 0, 72, 1, -14, 1, -16,
+ax_anim 2, 0, 73, 0, -6, 0, -6,
+ax_anim_terminator
+sDuskullAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 6, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 78, -6, -5, -6, -5,
+ax_anim 1, 0, 78, -15, -11, -15, -12,
+ax_anim 2, 0, 76, -21, -16, -21, -18,
+ax_anim 2, 1, 76, -22, -15, -22, -17,
+ax_anim 2, 0, 76, -21, -16, -21, -18,
+ax_anim 2, 0, 76, -22, -15, -22, -17,
+ax_anim 2, 0, 77, -7, -6, -7, -6,
+ax_anim_terminator
+sDuskullAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 6, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -20, 0, -20, 0,
+ax_anim 2, 1, 80, -20, 1, -20, 1,
+ax_anim 2, 0, 80, -20, 0, -20, 0,
+ax_anim 2, 0, 80, -20, 1, -20, 1,
+ax_anim 2, 0, 81, -6, 0, -6, 0,
+ax_anim_terminator
+sDuskullAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 6, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 86, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 11, -10, 11,
+ax_anim 2, 0, 84, -20, 23, -20, 23,
+ax_anim 2, 1, 84, -21, 22, -21, 22,
+ax_anim 2, 0, 84, -20, 23, -20, 23,
+ax_anim 2, 0, 84, -21, 22, -21, 22,
+ax_anim 2, 0, 85, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sDuskullAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sDuskullAnims_4_2:
+ax_anim 2, 0, 94, -2, -2, -2, -2,
+ax_anim 6, 2, 94, -3, -3, -3, -3,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 1, 97, 2, 2, 2, 2,
+ax_anim 2, 0, 97, 3, 1, 3, 1,
+ax_anim 2, 0, 97, 2, 2, 2, 2,
+ax_anim 2, 0, 97, 3, 1, 3, 1,
+ax_anim 2, 0, 97, 2, 2, 2, 2,
+ax_anim 2, 0, 97, 3, 1, 3, 1,
+ax_anim 2, 0, 97, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim_terminator
+sDuskullAnims_4_3:
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 6, 2, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 1, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim_terminator
+sDuskullAnims_4_4:
+ax_anim 2, 0, 104, -2, 2, -2, 2,
+ax_anim 6, 2, 104, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 1, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim_terminator
+sDuskullAnims_4_5:
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim 6, 2, 109, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 1, 0, 1,
+ax_anim 2, 1, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sDuskullAnims_4_6:
+ax_anim 2, 0, 114, 2, 2, 2, 2,
+ax_anim 6, 2, 114, 3, 3, 3, 3,
+ax_anim 2, 0, 113, 1, 1, 1, 1,
+ax_anim 2, 1, 117, -2, -2, -2, -2,
+ax_anim 2, 0, 117, -3, -1, -3, -1,
+ax_anim 2, 0, 117, -2, -2, -2, -2,
+ax_anim 2, 0, 117, -3, -1, -3, -1,
+ax_anim 2, 0, 117, -2, -2, -2, -2,
+ax_anim 2, 0, 117, -3, -1, -3, -1,
+ax_anim 2, 0, 117, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim_terminator
+sDuskullAnims_4_7:
+ax_anim 2, 0, 119, 2, 0, 2, 0,
+ax_anim 6, 2, 119, 3, 0, 3, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 1, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim_terminator
+sDuskullAnims_4_8:
+ax_anim 2, 0, 124, 2, -2, 2, -2,
+ax_anim 6, 2, 124, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sDuskullAnims_5_1:
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 1, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_5_2:
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 2, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 1, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_5_3:
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 2, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_5_4:
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 1, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_5_5:
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 2, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_5_6:
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 2, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_5_7:
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 2, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_5_8:
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 2, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_6_1:
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, -1, 0, 0,
+ax_anim 16, 0, 192, 0, -2, 0, 0,
+ax_anim 8, 0, 193, 0, -3, 0, 0,
+ax_anim 8, 0, 193, 0, -2, 0, 0,
+ax_anim 8, 0, 193, 0, -1, 0, 0,
+ax_anim 16, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_7_1:
+ax_anim 2, 0, 194, 0, -2, 0, -2,
+ax_anim 8, 0, 194, 0, -3, 0, -3,
+ax_anim_terminator
+sDuskullAnims_7_2:
+ax_anim 2, 0, 195, -2, -2, -2, -2,
+ax_anim 8, 0, 195, -3, -3, -3, -3,
+ax_anim_terminator
+sDuskullAnims_7_3:
+ax_anim 2, 0, 196, -2, 0, -2, 0,
+ax_anim 8, 0, 196, -3, 0, -3, 0,
+ax_anim_terminator
+sDuskullAnims_7_4:
+ax_anim 2, 0, 197, -2, 2, -2, 2,
+ax_anim 8, 0, 197, -3, 3, -3, 3,
+ax_anim_terminator
+sDuskullAnims_7_5:
+ax_anim 2, 0, 198, 0, 2, 0, 2,
+ax_anim 8, 0, 198, 0, 3, 0, 3,
+ax_anim_terminator
+sDuskullAnims_7_6:
+ax_anim 2, 0, 199, 2, 2, 2, 2,
+ax_anim 8, 0, 199, 3, 3, 3, 3,
+ax_anim_terminator
+sDuskullAnims_7_7:
+ax_anim 2, 0, 200, 2, 0, 2, 0,
+ax_anim 8, 0, 200, 3, 0, 3, 0,
+ax_anim_terminator
+sDuskullAnims_7_8:
+ax_anim 2, 0, 201, 2, -2, 2, -2,
+ax_anim 8, 0, 201, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sDuskullAnims_8_1:
+ax_anim 24, 0, 202, 0, 0, 0, 0,
+ax_anim 8, 0, 202, 0, -1, 0, 0,
+ax_anim 8, 0, 202, 0, -2, 0, 0,
+ax_anim 24, 0, 202, 0, -3, 0, 0,
+ax_anim 8, 0, 202, 0, -2, 0, 0,
+ax_anim 8, 0, 202, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_8_2:
+ax_anim 24, 0, 209, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, -1, 0, 0,
+ax_anim 8, 0, 209, 0, -2, 0, 0,
+ax_anim 24, 0, 209, 0, -3, 0, 0,
+ax_anim 8, 0, 209, 0, -2, 0, 0,
+ax_anim 8, 0, 209, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_8_3:
+ax_anim 24, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 208, 0, -1, 0, 0,
+ax_anim 8, 0, 208, 0, -2, 0, 0,
+ax_anim 24, 0, 208, 0, -3, 0, 0,
+ax_anim 8, 0, 208, 0, -2, 0, 0,
+ax_anim 8, 0, 208, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_8_4:
+ax_anim 24, 0, 207, 0, 0, 0, 0,
+ax_anim 8, 0, 207, 0, -1, 0, 0,
+ax_anim 8, 0, 207, 0, -2, 0, 0,
+ax_anim 24, 0, 207, 0, -3, 0, 0,
+ax_anim 8, 0, 207, 0, -2, 0, 0,
+ax_anim 8, 0, 207, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_8_5:
+ax_anim 24, 0, 206, 0, 0, 0, 0,
+ax_anim 8, 0, 206, 0, -1, 0, 0,
+ax_anim 8, 0, 206, 0, -2, 0, 0,
+ax_anim 24, 0, 206, 0, -3, 0, 0,
+ax_anim 8, 0, 206, 0, -2, 0, 0,
+ax_anim 8, 0, 206, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_8_6:
+ax_anim 24, 0, 205, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, -1, 0, 0,
+ax_anim 8, 0, 205, 0, -2, 0, 0,
+ax_anim 24, 0, 205, 0, -3, 0, 0,
+ax_anim 8, 0, 205, 0, -2, 0, 0,
+ax_anim 8, 0, 205, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_8_7:
+ax_anim 24, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 204, 0, -1, 0, 0,
+ax_anim 8, 0, 204, 0, -2, 0, 0,
+ax_anim 24, 0, 204, 0, -3, 0, 0,
+ax_anim 8, 0, 204, 0, -2, 0, 0,
+ax_anim 8, 0, 204, 0, -1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_8_8:
+ax_anim 24, 0, 203, 0, 0, 0, 0,
+ax_anim 8, 0, 203, 0, -1, 0, 0,
+ax_anim 8, 0, 203, 0, -2, 0, 0,
+ax_anim 24, 0, 203, 0, -3, 0, 0,
+ax_anim 8, 0, 203, 0, -2, 0, 0,
+ax_anim 8, 0, 203, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 9, 5, 9, 5,
+ax_anim 2, 0, 212, 12, 12, 12, 12,
+ax_anim 2, 0, 213, 9, 18, 9, 18,
+ax_anim 3, 0, 214, 0, 21, 0, 21,
+ax_anim 2, 3, 215, -9, 18, -9, 18,
+ax_anim 2, 0, 216, -12, 12, -12, 12,
+ax_anim 1, 0, 217, -9, 5, -9, 5,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 211, 19, 5, 19, 5,
+ax_anim 2, 0, 212, 24, 13, 24, 13,
+ax_anim 3, 0, 213, 22, 20, 22, 20,
+ax_anim 2, 3, 214, 10, 20, 10, 20,
+ax_anim 2, 0, 215, 3, 15, 3, 15,
+ax_anim 1, 0, 216, 0, 7, 0, 7,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 5, -5, 5, -5,
+ax_anim 2, 0, 210, 12, -7, 12, -7,
+ax_anim 2, 0, 211, 19, -5, 19, -5,
+ax_anim 3, 0, 212, 23, 0, 23, 0,
+ax_anim 2, 3, 213, 21, 4, 21, 4,
+ax_anim 2, 0, 214, 13, 7, 13, 7,
+ax_anim 1, 0, 215, 5, 5, 5, 5,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, -1, -8, -1, -8,
+ax_anim 2, 0, 217, 4, -15, 4, -15,
+ax_anim 2, 0, 210, 10, -20, 10, -20,
+ax_anim 3, 0, 211, 22, -20, 22, -20,
+ax_anim 2, 3, 212, 22, -13, 22, -13,
+ax_anim 2, 0, 213, 18, -7, 18, -7,
+ax_anim 1, 0, 214, 12, -1, 12, -1,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -9, -5, -9, -5,
+ax_anim 2, 0, 216, -11, -11, -11, -11,
+ax_anim 2, 0, 217, -8, -18, -8, -18,
+ax_anim 3, 0, 210, 0, -23, 0, -23,
+ax_anim 2, 3, 211, 8, -18, 8, -18,
+ax_anim 2, 0, 212, 11, -11, 11, -11,
+ax_anim 1, 0, 213, 9, -5, 9, -5,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 1, -8, 1, -8,
+ax_anim 2, 0, 211, -4, -15, -4, -15,
+ax_anim 2, 0, 210, -10, -20, -10, -20,
+ax_anim 3, 0, 217, -22, -20, -22, -20,
+ax_anim 2, 3, 216, -22, -13, -22, -13,
+ax_anim 2, 0, 215, -18, -7, -18, -7,
+ax_anim 1, 0, 214, -12, -1, -12, -1,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, -5, -5, -5, -5,
+ax_anim 2, 0, 210, -12, -7, -12, -7,
+ax_anim 2, 0, 217, -19, -5, -19, -5,
+ax_anim 3, 0, 216, -23, 0, -23, 0,
+ax_anim 2, 3, 215, -21, 4, -21, 4,
+ax_anim 2, 0, 214, -13, 7, -13, 7,
+ax_anim 1, 0, 213, -5, 5, -5, 5,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 217, -19, 5, -19, 5,
+ax_anim 2, 0, 216, -24, 13, -24, 13,
+ax_anim 3, 0, 215, -22, 20, -22, 20,
+ax_anim 2, 3, 214, -10, 20, -10, 20,
+ax_anim 2, 0, 213, -3, 15, -3, 15,
+ax_anim 1, 0, 212, 0, 7, 0, 7,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -22, 0, 0,
+ax_anim 3, 0, 226, 0, -21, 0, 0,
+ax_anim 2, 0, 226, 0, -17, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_11_2:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -22, 0, 0,
+ax_anim 3, 0, 228, 0, -21, 0, 0,
+ax_anim 2, 0, 228, 0, -17, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 2, 228, 0, 1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_11_3:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -17, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 2, 230, 0, 1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_11_4:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -22, 0, 0,
+ax_anim 3, 0, 232, 0, -21, 0, 0,
+ax_anim 2, 0, 232, 0, -17, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_11_5:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -20, 0, 0,
+ax_anim 3, 0, 234, 0, -19, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_11_6:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -22, 0, 0,
+ax_anim 3, 0, 236, 0, -21, 0, 0,
+ax_anim 2, 0, 236, 0, -17, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_11_7:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 239, 0, -16, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -22, 0, 0,
+ax_anim 3, 0, 238, 0, -21, 0, 0,
+ax_anim 2, 0, 238, 0, -17, 0, 0,
+ax_anim 1, 0, 238, 0, -10, 0, 0,
+ax_anim 2, 2, 238, 0, 1, 0, 0,
+ax_anim_terminator
+sDuskullAnims_11_8:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -22, 0, 0,
+ax_anim 3, 0, 240, 0, -21, 0, 0,
+ax_anim 2, 0, 240, 0, -17, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 2, 240, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDuskullAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sDuskullGfx1:
+.incbin "baserom.gba", 0x14A8BE4, 0x200
+sDuskullSprites1:
+ax_sprite sDuskullGfx1, 0x200
+ax_sprite_terminator
+sDuskullGfx2:
+.incbin "baserom.gba", 0x14A8DF4, 0x200
+sDuskullSprites2:
+ax_sprite sDuskullGfx2, 0x200
+ax_sprite_terminator
+sDuskullGfx3:
+.incbin "baserom.gba", 0x14A9004, 0x200
+sDuskullSprites3:
+ax_sprite sDuskullGfx3, 0x200
+ax_sprite_terminator
+sDuskullGfx4:
+.incbin "baserom.gba", 0x14A9214, 0x200
+sDuskullSprites4:
+ax_sprite sDuskullGfx4, 0x200
+ax_sprite_terminator
+sDuskullGfx5:
+.incbin "baserom.gba", 0x14A9424, 0x200
+sDuskullSprites5:
+ax_sprite sDuskullGfx5, 0x200
+ax_sprite_terminator
+sDuskullGfx6:
+.incbin "baserom.gba", 0x14A9634, 0x200
+sDuskullSprites6:
+ax_sprite sDuskullGfx6, 0x200
+ax_sprite_terminator
+sDuskullGfx7:
+.incbin "baserom.gba", 0x14A9844, 0x200
+sDuskullSprites7:
+ax_sprite sDuskullGfx7, 0x200
+ax_sprite_terminator
+sDuskullGfx8:
+.incbin "baserom.gba", 0x14A9A54, 0x200
+sDuskullSprites8:
+ax_sprite sDuskullGfx8, 0x200
+ax_sprite_terminator
+sDuskullGfx9:
+.incbin "baserom.gba", 0x14A9C64, 0x200
+sDuskullSprites9:
+ax_sprite sDuskullGfx9, 0x200
+ax_sprite_terminator
+sDuskullGfx10:
+.incbin "baserom.gba", 0x14A9E74, 0x200
+sDuskullSprites10:
+ax_sprite sDuskullGfx10, 0x200
+ax_sprite_terminator
+sDuskullGfx11:
+.incbin "baserom.gba", 0x14AA084, 0x200
+sDuskullSprites11:
+ax_sprite sDuskullGfx11, 0x200
+ax_sprite_terminator
+sDuskullGfx12:
+.incbin "baserom.gba", 0x14AA294, 0x200
+sDuskullSprites12:
+ax_sprite sDuskullGfx12, 0x200
+ax_sprite_terminator
+sDuskullGfx13:
+.incbin "baserom.gba", 0x14AA4A4, 0x200
+sDuskullSprites13:
+ax_sprite sDuskullGfx13, 0x200
+ax_sprite_terminator
+sDuskullGfx14:
+.incbin "baserom.gba", 0x14AA6B4, 0x200
+sDuskullSprites14:
+ax_sprite sDuskullGfx14, 0x200
+ax_sprite_terminator
+sDuskullGfx15:
+.incbin "baserom.gba", 0x14AA8C4, 0x200
+sDuskullSprites15:
+ax_sprite sDuskullGfx15, 0x200
+ax_sprite_terminator
+sDuskullGfx16:
+.incbin "baserom.gba", 0x14AAAD4, 0x160
+sDuskullSprites16:
+ax_sprite sDuskullGfx16, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDuskullGfx17:
+.incbin "baserom.gba", 0x14AAC4C, 0x40
+sDuskullGfx17_1:
+.incbin "baserom.gba", 0x14AAC8C, 0x60
+sDuskullGfx17_2:
+.incbin "baserom.gba", 0x14AACEC, 0x60
+sDuskullSprites17:
+ax_sprite sDuskullGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDuskullGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDuskullGfx18:
+.incbin "baserom.gba", 0x14AAD84, 0x60
+sDuskullGfx18_1:
+.incbin "baserom.gba", 0x14AADE4, 0x60
+sDuskullGfx18_2:
+.incbin "baserom.gba", 0x14AAE44, 0x60
+sDuskullSprites18:
+ax_sprite sDuskullGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDuskullGfx19:
+.incbin "baserom.gba", 0x14AAEDC, 0x20
+sDuskullGfx19_1:
+.incbin "baserom.gba", 0x14AAEFC, 0x60
+sDuskullGfx19_2:
+.incbin "baserom.gba", 0x14AAF5C, 0x60
+sDuskullGfx19_3:
+.incbin "baserom.gba", 0x14AAFBC, 0x60
+sDuskullSprites19:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sDuskullGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDuskullGfx20:
+.incbin "baserom.gba", 0x14AB06C, 0x40
+sDuskullGfx20_1:
+.incbin "baserom.gba", 0x14AB0AC, 0x100
+sDuskullGfx20_2:
+.incbin "baserom.gba", 0x14AB1AC, 0x40
+sDuskullSprites20:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDuskullGfx21:
+.incbin "baserom.gba", 0x14AB22C, 0xE0
+sDuskullSprites21:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx21, 0xe0
+ax_sprite_terminator
+sDuskullGfx22:
+.incbin "baserom.gba", 0x14AB324, 0x40
+sDuskullSprites22:
+ax_sprite sDuskullGfx22, 0x40
+ax_sprite_terminator
+sDuskullGfx23:
+.incbin "baserom.gba", 0x14AB374, 0x20
+sDuskullSprites23:
+ax_sprite sDuskullGfx23, 0x20
+ax_sprite_terminator
+sDuskullGfx24:
+.incbin "baserom.gba", 0x14AB3A4, 0x60
+sDuskullGfx24_1:
+.incbin "baserom.gba", 0x14AB404, 0x60
+sDuskullGfx24_2:
+.incbin "baserom.gba", 0x14AB464, 0x80
+sDuskullGfx24_3:
+.incbin "baserom.gba", 0x14AB4E4, 0x60
+sDuskullSprites24:
+ax_sprite sDuskullGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx24_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx24_3, 0x60
+ax_sprite_terminator
+sDuskullGfx25:
+.incbin "baserom.gba", 0x14AB584, 0x60
+sDuskullGfx25_1:
+.incbin "baserom.gba", 0x14AB5E4, 0x60
+sDuskullGfx25_2:
+.incbin "baserom.gba", 0x14AB644, 0x40
+sDuskullSprites25:
+ax_sprite sDuskullGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDuskullGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDuskullGfx26:
+.incbin "baserom.gba", 0x14AB6BC, 0x160
+sDuskullGfx26_1:
+.incbin "baserom.gba", 0x14AB81C, 0x40
+sDuskullSprites26:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx26, 0x160
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDuskullGfx27:
+.incbin "baserom.gba", 0x14AB88C, 0x40
+sDuskullGfx27_1:
+.incbin "baserom.gba", 0x14AB8CC, 0x80
+sDuskullSprites27:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx27_1, 0x80
+ax_sprite_terminator
+sDuskullGfx28:
+.incbin "baserom.gba", 0x14AB974, 0x60
+sDuskullSprites28:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx28, 0x60
+ax_sprite_terminator
+sDuskullGfx29:
+.incbin "baserom.gba", 0x14AB9EC, 0x20
+sDuskullSprites29:
+ax_sprite sDuskullGfx29, 0x20
+ax_sprite_terminator
+sDuskullGfx30:
+.incbin "baserom.gba", 0x14ABA1C, 0x40
+sDuskullGfx30_1:
+.incbin "baserom.gba", 0x14ABA5C, 0x100
+sDuskullGfx30_2:
+.incbin "baserom.gba", 0x14ABB5C, 0x40
+sDuskullSprites30:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDuskullGfx31:
+.incbin "baserom.gba", 0x14ABBDC, 0x20
+sDuskullSprites31:
+ax_sprite sDuskullGfx31, 0x20
+ax_sprite_terminator
+sDuskullGfx32:
+.incbin "baserom.gba", 0x14ABC0C, 0x20
+sDuskullSprites32:
+ax_sprite sDuskullGfx32, 0x20
+ax_sprite_terminator
+sDuskullGfx33:
+.incbin "baserom.gba", 0x14ABC3C, 0x80
+sDuskullSprites33:
+ax_sprite sDuskullGfx33, 0x80
+ax_sprite_terminator
+sDuskullGfx34:
+.incbin "baserom.gba", 0x14ABCCC, 0x80
+sDuskullSprites34:
+ax_sprite sDuskullGfx34, 0x80
+ax_sprite_terminator
+sDuskullGfx35:
+.incbin "baserom.gba", 0x14ABD5C, 0x80
+sDuskullSprites35:
+ax_sprite sDuskullGfx35, 0x80
+ax_sprite_terminator
+sDuskullGfx36:
+.incbin "baserom.gba", 0x14ABDEC, 0x80
+sDuskullSprites36:
+ax_sprite sDuskullGfx36, 0x80
+ax_sprite_terminator
+sDuskullGfx37:
+.incbin "baserom.gba", 0x14ABE7C, 0x20
+sDuskullGfx37_1:
+.incbin "baserom.gba", 0x14ABE9C, 0x160
+sDuskullSprites37:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx37, 0x20
+ax_sprite 0, 0x40
+ax_sprite sDuskullGfx37_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDuskullGfx38:
+.incbin "baserom.gba", 0x14AC02C, 0x40
+sDuskullGfx38_1:
+.incbin "baserom.gba", 0x14AC06C, 0x60
+sDuskullGfx38_2:
+.incbin "baserom.gba", 0x14AC0CC, 0xE0
+sDuskullSprites38:
+ax_sprite sDuskullGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDuskullGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx38_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDuskullGfx39:
+.incbin "baserom.gba", 0x14AC1E4, 0x20
+sDuskullGfx39_1:
+.incbin "baserom.gba", 0x14AC204, 0x160
+sDuskullSprites39:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx39, 0x20
+ax_sprite 0, 0x40
+ax_sprite sDuskullGfx39_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDuskullGfx40:
+.incbin "baserom.gba", 0x14AC394, 0x40
+sDuskullGfx40_1:
+.incbin "baserom.gba", 0x14AC3D4, 0x40
+sDuskullGfx40_2:
+.incbin "baserom.gba", 0x14AC414, 0x100
+sDuskullSprites40:
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDuskullGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDuskullGfx40_2, 0x100
+ax_sprite_terminator
+sDuskullGfx41:
+.incbin "baserom.gba", 0x14AC54C, 0x200
+sDuskullSprites41:
+ax_sprite sDuskullGfx41, 0x200
+ax_sprite_terminator
+sDuskullGfx42:
+.incbin "baserom.gba", 0x14AC75C, 0x200
+sDuskullSprites42:
+ax_sprite sDuskullGfx42, 0x200
+ax_sprite_terminator
+sDuskullGfx43:
+.incbin "baserom.gba", 0x14AC96C, 0x200
+sDuskullSprites43:
+ax_sprite sDuskullGfx43, 0x200
+ax_sprite_terminator
+sDuskullGfx44:
+.incbin "baserom.gba", 0x14ACB7C, 0x200
+sDuskullSprites44:
+ax_sprite sDuskullGfx44, 0x200
+ax_sprite_terminator
+sDuskullGfx45:
+.incbin "baserom.gba", 0x14ACD8C, 0x200
+sDuskullSprites45:
+ax_sprite sDuskullGfx45, 0x200
+ax_sprite_terminator
+sDuskullGfx46:
+.incbin "baserom.gba", 0x14ACF9C, 0x200
+sDuskullSprites46:
+ax_sprite sDuskullGfx46, 0x200
+ax_sprite_terminator
+sDuskullGfx47:
+.incbin "baserom.gba", 0x14AD1AC, 0x200
+sDuskullSprites47:
+ax_sprite sDuskullGfx47, 0x200
+ax_sprite_terminator
+sAxPosesDuskull:
+.4byte sDuskullPose1
+.4byte sDuskullPose2
+.4byte sDuskullPose3
+.4byte sDuskullPose4
+.4byte sDuskullPose5
+.4byte sDuskullPose6
+.4byte sDuskullPose7
+.4byte sDuskullPose8
+.4byte sDuskullPose9
+.4byte sDuskullPose10
+.4byte sDuskullPose11
+.4byte sDuskullPose12
+.4byte sDuskullPose13
+.4byte sDuskullPose14
+.4byte sDuskullPose15
+.4byte sDuskullPose16
+.4byte sDuskullPose17
+.4byte sDuskullPose18
+.4byte sDuskullPose19
+.4byte sDuskullPose20
+.4byte sDuskullPose21
+.4byte sDuskullPose22
+.4byte sDuskullPose23
+.4byte sDuskullPose24
+.4byte sDuskullPose25
+.4byte sDuskullPose26
+.4byte sDuskullPose27
+.4byte sDuskullPose28
+.4byte sDuskullPose29
+.4byte sDuskullPose30
+.4byte sDuskullPose31
+.4byte sDuskullPose32
+.4byte sDuskullPose33
+.4byte sDuskullPose34
+.4byte sDuskullPose35
+.4byte sDuskullPose36
+.4byte sDuskullPose37
+.4byte sDuskullPose38
+.4byte sDuskullPose39
+.4byte sDuskullPose40
+.4byte sDuskullPose41
+.4byte sDuskullPose42
+.4byte sDuskullPose43
+.4byte sDuskullPose44
+.4byte sDuskullPose45
+.4byte sDuskullPose46
+.4byte sDuskullPose47
+.4byte sDuskullPose48
+.4byte sDuskullPose49
+.4byte sDuskullPose50
+.4byte sDuskullPose51
+.4byte sDuskullPose52
+.4byte sDuskullPose53
+.4byte sDuskullPose54
+.4byte sDuskullPose55
+.4byte sDuskullPose56
+.4byte sDuskullPose57
+.4byte sDuskullPose58
+.4byte sDuskullPose59
+.4byte sDuskullPose60
+.4byte sDuskullPose61
+.4byte sDuskullPose62
+.4byte sDuskullPose63
+.4byte sDuskullPose64
+.4byte sDuskullPose65
+.4byte sDuskullPose66
+.4byte sDuskullPose67
+.4byte sDuskullPose68
+.4byte sDuskullPose69
+.4byte sDuskullPose70
+.4byte sDuskullPose71
+.4byte sDuskullPose72
+.4byte sDuskullPose73
+.4byte sDuskullPose74
+.4byte sDuskullPose75
+.4byte sDuskullPose76
+.4byte sDuskullPose77
+.4byte sDuskullPose78
+.4byte sDuskullPose79
+.4byte sDuskullPose80
+.4byte sDuskullPose81
+.4byte sDuskullPose82
+.4byte sDuskullPose83
+.4byte sDuskullPose84
+.4byte sDuskullPose85
+.4byte sDuskullPose86
+.4byte sDuskullPose87
+.4byte sDuskullPose88
+.4byte sDuskullPose89
+.4byte sDuskullPose90
+.4byte sDuskullPose91
+.4byte sDuskullPose92
+.4byte sDuskullPose93
+.4byte sDuskullPose94
+.4byte sDuskullPose95
+.4byte sDuskullPose96
+.4byte sDuskullPose97
+.4byte sDuskullPose98
+.4byte sDuskullPose99
+.4byte sDuskullPose100
+.4byte sDuskullPose101
+.4byte sDuskullPose102
+.4byte sDuskullPose103
+.4byte sDuskullPose104
+.4byte sDuskullPose105
+.4byte sDuskullPose106
+.4byte sDuskullPose107
+.4byte sDuskullPose108
+.4byte sDuskullPose109
+.4byte sDuskullPose110
+.4byte sDuskullPose111
+.4byte sDuskullPose112
+.4byte sDuskullPose113
+.4byte sDuskullPose114
+.4byte sDuskullPose115
+.4byte sDuskullPose116
+.4byte sDuskullPose117
+.4byte sDuskullPose118
+.4byte sDuskullPose119
+.4byte sDuskullPose120
+.4byte sDuskullPose121
+.4byte sDuskullPose122
+.4byte sDuskullPose123
+.4byte sDuskullPose124
+.4byte sDuskullPose125
+.4byte sDuskullPose126
+.4byte sDuskullPose127
+.4byte sDuskullPose128
+.4byte sDuskullPose129
+.4byte sDuskullPose130
+.4byte sDuskullPose131
+.4byte sDuskullPose132
+.4byte sDuskullPose133
+.4byte sDuskullPose134
+.4byte sDuskullPose135
+.4byte sDuskullPose136
+.4byte sDuskullPose137
+.4byte sDuskullPose138
+.4byte sDuskullPose139
+.4byte sDuskullPose140
+.4byte sDuskullPose141
+.4byte sDuskullPose142
+.4byte sDuskullPose143
+.4byte sDuskullPose144
+.4byte sDuskullPose145
+.4byte sDuskullPose146
+.4byte sDuskullPose147
+.4byte sDuskullPose148
+.4byte sDuskullPose149
+.4byte sDuskullPose150
+.4byte sDuskullPose151
+.4byte sDuskullPose152
+.4byte sDuskullPose153
+.4byte sDuskullPose154
+.4byte sDuskullPose155
+.4byte sDuskullPose156
+.4byte sDuskullPose157
+.4byte sDuskullPose158
+.4byte sDuskullPose159
+.4byte sDuskullPose160
+.4byte sDuskullPose161
+.4byte sDuskullPose162
+.4byte sDuskullPose163
+.4byte sDuskullPose164
+.4byte sDuskullPose165
+.4byte sDuskullPose166
+.4byte sDuskullPose167
+.4byte sDuskullPose168
+.4byte sDuskullPose169
+.4byte sDuskullPose170
+.4byte sDuskullPose171
+.4byte sDuskullPose172
+.4byte sDuskullPose173
+.4byte sDuskullPose174
+.4byte sDuskullPose175
+.4byte sDuskullPose176
+.4byte sDuskullPose177
+.4byte sDuskullPose178
+.4byte sDuskullPose179
+.4byte sDuskullPose180
+.4byte sDuskullPose181
+.4byte sDuskullPose182
+.4byte sDuskullPose183
+.4byte sDuskullPose184
+.4byte sDuskullPose185
+.4byte sDuskullPose186
+.4byte sDuskullPose187
+.4byte sDuskullPose188
+.4byte sDuskullPose189
+.4byte sDuskullPose190
+.4byte sDuskullPose191
+.4byte sDuskullPose192
+.4byte sDuskullPose193
+.4byte sDuskullPose194
+.4byte sDuskullPose195
+.4byte sDuskullPose196
+.4byte sDuskullPose197
+.4byte sDuskullPose198
+.4byte sDuskullPose199
+.4byte sDuskullPose200
+.4byte sDuskullPose201
+.4byte sDuskullPose202
+.4byte sDuskullPose203
+.4byte sDuskullPose204
+.4byte sDuskullPose205
+.4byte sDuskullPose206
+.4byte sDuskullPose207
+.4byte sDuskullPose208
+.4byte sDuskullPose209
+.4byte sDuskullPose210
+.4byte sDuskullPose211
+.4byte sDuskullPose212
+.4byte sDuskullPose213
+.4byte sDuskullPose214
+.4byte sDuskullPose215
+.4byte sDuskullPose216
+.4byte sDuskullPose217
+.4byte sDuskullPose218
+.4byte sDuskullPose219
+.4byte sDuskullPose220
+.4byte sDuskullPose221
+.4byte sDuskullPose222
+.4byte sDuskullPose223
+.4byte sDuskullPose224
+.4byte sDuskullPose225
+.4byte sDuskullPose226
+.4byte sDuskullPose227
+.4byte sDuskullPose228
+.4byte sDuskullPose229
+.4byte sDuskullPose230
+.4byte sDuskullPose231
+.4byte sDuskullPose232
+.4byte sDuskullPose233
+.4byte sDuskullPose234
+.4byte sDuskullPose235
+.4byte sDuskullPose236
+.4byte sDuskullPose237
+.4byte sDuskullPose238
+.4byte sDuskullPose239
+.4byte sDuskullPose240
+.4byte sDuskullPose241
+.4byte sDuskullPose242
+.4byte sDuskullPose243
+.4byte sDuskullPose244
+.4byte sDuskullPose245
+.4byte sDuskullPose246
+.4byte sDuskullPose247
+.4byte sDuskullPose248
+.4byte sDuskullPose249
+.4byte sDuskullPose250
+.4byte sDuskullPose251
+.4byte sDuskullPose252
+.4byte sDuskullPose253
+.4byte sDuskullPose254
+.4byte sDuskullPose255
+.4byte sDuskullPose256
+.4byte sDuskullPose257
+.4byte sDuskullPose258
+sAxPositionsDuskull:
+.2byte   -1,   -2, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte   -1,   -3, 	  -9,  -15, 	   7,  -15, 	  -1,   -8
+.2byte   -1,   -4, 	 -10,  -13, 	   7,  -13, 	  -1,  -10
+.2byte    4,   -3, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte    5,   -4, 	   6,  -16, 	  -8,  -11, 	   1,  -10
+.2byte    5,   -5, 	   7,  -15, 	  -8,  -10, 	   1,  -10
+.2byte    6,   -5, 	  -7,  -16, 	  -7,  -11, 	  -3,  -10
+.2byte    7,   -7, 	  -8,  -15, 	  -8,  -10, 	  -4,  -11
+.2byte    7,   -9, 	  -7,  -14, 	  -7,   -9, 	  -3,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   1,   -7, 	  -4,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   0,   -6, 	  -4,  -10
+.2byte    5,  -12, 	 -10,  -11, 	   0,   -5, 	  -4,   -9
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,   -8
+.2byte   -7,  -11, 	   8,  -13, 	  -3,   -7, 	   2,  -11
+.2byte   -7,  -11, 	   8,  -13, 	  -2,   -6, 	   2,  -10
+.2byte   -7,  -12, 	   8,  -11, 	  -2,   -5, 	   2,   -9
+.2byte   -8,   -5, 	   5,  -16, 	   5,  -11, 	   1,  -10
+.2byte   -9,   -7, 	   6,  -15, 	   6,  -10, 	   2,  -11
+.2byte   -9,   -9, 	   5,  -14, 	   5,   -9, 	   1,  -11
+.2byte   -5,   -4, 	  -7,  -16, 	   7,  -12, 	  -1,  -11
+.2byte   -6,   -4, 	  -7,  -16, 	   7,  -11, 	  -2,  -10
+.2byte   -6,   -5, 	  -8,  -15, 	   7,  -10, 	  -2,  -10
+.2byte   -1,   -4, 	 -11,  -15, 	   9,  -15, 	  -1,  -10
+.2byte   -1,   -2, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte   -1,   -3, 	  -9,  -15, 	   7,  -15, 	  -1,   -8
+.2byte   -1,   -4, 	 -10,  -13, 	   7,  -13, 	  -1,  -10
+.2byte    5,   -5, 	   7,  -15, 	 -10,  -10, 	   1,  -10
+.2byte    4,   -3, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte    5,   -4, 	   6,  -16, 	  -8,  -11, 	   1,  -10
+.2byte    5,   -5, 	   7,  -15, 	  -8,  -10, 	   1,  -10
+.2byte    8,   -8, 	  -6,  -16, 	  -8,   -9, 	  -2,  -11
+.2byte    6,   -5, 	  -7,  -16, 	  -7,  -11, 	  -3,  -10
+.2byte    7,   -7, 	  -8,  -15, 	  -8,  -10, 	  -4,  -11
+.2byte    7,   -9, 	  -7,  -14, 	  -7,   -9, 	  -3,  -11
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -6, 	  -1,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   1,   -7, 	  -4,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   0,   -6, 	  -4,  -10
+.2byte    5,  -12, 	 -10,  -11, 	   0,   -5, 	  -4,   -9
+.2byte   -1,  -13, 	   9,  -10, 	 -11,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,   -8
+.2byte   -7,  -12, 	   7,  -14, 	  -5,   -6, 	  -1,  -11
+.2byte   -7,  -11, 	   8,  -13, 	  -3,   -7, 	   2,  -11
+.2byte   -7,  -11, 	   8,  -13, 	  -2,   -6, 	   2,  -10
+.2byte   -7,  -12, 	   8,  -11, 	  -2,   -5, 	   2,   -9
+.2byte  -10,   -8, 	   4,  -16, 	   6,   -9, 	   0,  -11
+.2byte   -8,   -5, 	   5,  -16, 	   5,  -11, 	   1,  -10
+.2byte   -9,   -7, 	   6,  -15, 	   6,  -10, 	   2,  -11
+.2byte   -9,   -9, 	   5,  -14, 	   5,   -9, 	   1,  -11
+.2byte   -7,   -5, 	  -9,  -15, 	   8,  -10, 	  -3,  -10
+.2byte   -5,   -4, 	  -7,  -16, 	   7,  -12, 	  -1,  -11
+.2byte   -6,   -4, 	  -7,  -16, 	   7,  -11, 	  -2,  -10
+.2byte   -6,   -5, 	  -8,  -15, 	   7,  -10, 	  -2,  -10
+.2byte   -1,   -4, 	 -11,  -15, 	   9,  -15, 	  -1,  -10
+.2byte   -1,   -2, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte   -1,   -3, 	  -9,  -15, 	   7,  -15, 	  -1,   -8
+.2byte   -1,   -4, 	 -10,  -13, 	   7,  -13, 	  -1,  -10
+.2byte    5,   -5, 	   7,  -15, 	 -10,  -10, 	   1,  -10
+.2byte    4,   -3, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte    5,   -4, 	   6,  -16, 	  -8,  -11, 	   1,  -10
+.2byte    5,   -5, 	   7,  -15, 	  -8,  -10, 	   1,  -10
+.2byte    8,   -8, 	  -6,  -16, 	  -8,   -9, 	  -2,  -11
+.2byte    6,   -5, 	  -7,  -16, 	  -7,  -11, 	  -3,  -10
+.2byte    7,   -7, 	  -8,  -15, 	  -8,  -10, 	  -4,  -11
+.2byte    7,   -9, 	  -7,  -14, 	  -7,   -9, 	  -3,  -11
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -6, 	  -1,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   1,   -7, 	  -4,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   0,   -6, 	  -4,  -10
+.2byte    5,  -12, 	 -10,  -11, 	   0,   -5, 	  -4,   -9
+.2byte   -1,  -13, 	   9,  -10, 	 -11,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,   -8
+.2byte   -7,  -12, 	   7,  -14, 	  -5,   -6, 	  -1,  -11
+.2byte   -7,  -11, 	   8,  -13, 	  -3,   -7, 	   2,  -11
+.2byte   -7,  -11, 	   8,  -13, 	  -2,   -6, 	   2,  -10
+.2byte   -7,  -12, 	   8,  -11, 	  -2,   -5, 	   2,   -9
+.2byte  -10,   -8, 	   4,  -16, 	   6,   -9, 	   0,  -11
+.2byte   -8,   -5, 	   5,  -16, 	   5,  -11, 	   1,  -10
+.2byte   -9,   -7, 	   6,  -15, 	   6,  -10, 	   2,  -11
+.2byte   -9,   -9, 	   5,  -14, 	   5,   -9, 	   1,  -11
+.2byte   -7,   -5, 	  -9,  -15, 	   8,  -10, 	  -3,  -10
+.2byte   -5,   -4, 	  -7,  -16, 	   7,  -12, 	  -1,  -11
+.2byte   -6,   -4, 	  -7,  -16, 	   7,  -11, 	  -2,  -10
+.2byte   -6,   -5, 	  -8,  -15, 	   7,  -10, 	  -2,  -10
+.2byte   -1,   -4, 	 -11,  -15, 	   9,  -15, 	  -1,  -10
+.2byte   -1,   -2, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte   -1,   -3, 	  -9,  -15, 	   7,  -15, 	  -1,   -8
+.2byte   -1,   -4, 	 -10,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -7, 	 -14,  -12, 	  12,  -12, 	  -1,   -8
+.2byte    5,   -5, 	   7,  -15, 	 -10,  -10, 	   1,  -10
+.2byte    4,   -3, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte    5,   -4, 	   6,  -16, 	  -8,  -11, 	   1,  -10
+.2byte    5,   -5, 	   7,  -15, 	  -8,  -10, 	   1,  -10
+.2byte    5,  -11, 	  10,  -19, 	 -12,   -5, 	  -2,   -9
+.2byte    8,   -8, 	  -6,  -16, 	  -8,   -9, 	  -2,  -11
+.2byte    6,   -5, 	  -7,  -16, 	  -7,  -11, 	  -3,  -10
+.2byte    7,   -7, 	  -8,  -15, 	  -8,  -10, 	  -4,  -11
+.2byte    7,   -9, 	  -7,  -14, 	  -7,   -9, 	  -3,  -11
+.2byte    7,  -13, 	  -2,  -15, 	  -4,   -9, 	  -3,   -9
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -6, 	  -1,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   1,   -7, 	  -4,  -11
+.2byte    5,  -11, 	 -10,  -13, 	   0,   -6, 	  -4,  -10
+.2byte    5,  -12, 	 -10,  -11, 	   0,   -5, 	  -4,   -9
+.2byte    5,  -16, 	  -9,  -18, 	   9,   -8, 	  -2,  -11
+.2byte   -1,  -13, 	   9,  -10, 	 -11,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	  12,  -15, 	 -13,  -15, 	  -1,  -10
+.2byte   -7,  -12, 	   7,  -14, 	  -5,   -6, 	  -1,  -11
+.2byte   -7,  -11, 	   8,  -13, 	  -3,   -7, 	   2,  -11
+.2byte   -7,  -11, 	   8,  -13, 	  -2,   -6, 	   2,  -10
+.2byte   -7,  -12, 	   8,  -11, 	  -2,   -5, 	   2,   -9
+.2byte   -7,  -16, 	   7,  -18, 	 -11,   -8, 	   0,  -11
+.2byte  -10,   -8, 	   4,  -16, 	   6,   -9, 	   0,  -11
+.2byte   -8,   -5, 	   5,  -16, 	   5,  -11, 	   1,  -10
+.2byte   -9,   -7, 	   6,  -15, 	   6,  -10, 	   2,  -11
+.2byte   -9,   -9, 	   5,  -14, 	   5,   -9, 	   1,  -11
+.2byte   -9,  -13, 	   0,  -15, 	   2,   -9, 	   1,   -9
+.2byte   -7,   -5, 	  -9,  -15, 	   8,  -10, 	  -3,  -10
+.2byte   -5,   -4, 	  -7,  -16, 	   7,  -12, 	  -1,  -11
+.2byte   -6,   -4, 	  -7,  -16, 	   7,  -11, 	  -2,  -10
+.2byte   -6,   -5, 	  -8,  -15, 	   7,  -10, 	  -2,  -10
+.2byte   -7,  -11, 	 -12,  -19, 	  10,   -5, 	   0,   -9
+.2byte   -1,   -4, 	 -11,  -15, 	   9,  -15, 	  -1,  -10
+.2byte   -1,   -5, 	 -13,  -16, 	  10,  -16, 	  -1,  -11
+.2byte   -1,   -5, 	 -13,  -16, 	  10,  -16, 	  -1,  -11
+.2byte   -1,   -5, 	 -13,  -16, 	  10,  -16, 	  -1,  -11
+.2byte   -1,   -5, 	 -13,  -16, 	  10,  -16, 	  -1,  -11
+.2byte   -1,   -5, 	 -13,  -16, 	  10,  -16, 	  -1,  -11
+.2byte   -1,   -5, 	 -13,  -16, 	  10,  -16, 	  -1,  -11
+.2byte   -1,   -5, 	 -13,  -16, 	  10,  -16, 	  -1,  -11
+.2byte    5,   -5, 	   7,  -15, 	 -10,  -10, 	   1,  -10
+.2byte    7,   -6, 	   8,  -17, 	 -11,  -12, 	   1,  -11
+.2byte    7,   -6, 	   8,  -17, 	 -11,  -12, 	   1,  -11
+.2byte    7,   -6, 	   8,  -17, 	 -11,  -12, 	   1,  -11
+.2byte    7,   -6, 	   8,  -17, 	 -11,  -12, 	   1,  -11
+.2byte    7,   -6, 	   8,  -17, 	 -11,  -12, 	   1,  -11
+.2byte    7,   -6, 	   8,  -17, 	 -11,  -12, 	   1,  -11
+.2byte    7,   -6, 	   8,  -17, 	 -11,  -12, 	   1,  -11
+.2byte    8,   -8, 	  -6,  -16, 	  -8,   -9, 	  -2,  -11
+.2byte    8,   -9, 	  -7,  -18, 	  -9,   -9, 	  -3,  -11
+.2byte    8,   -9, 	  -7,  -18, 	  -9,   -9, 	  -3,  -11
+.2byte    8,   -9, 	  -7,  -18, 	  -9,   -9, 	  -3,  -11
+.2byte    8,   -9, 	  -7,  -18, 	  -9,   -9, 	  -3,  -11
+.2byte    8,   -9, 	  -7,  -18, 	  -9,   -9, 	  -3,  -11
+.2byte    8,   -9, 	  -7,  -18, 	  -9,   -9, 	  -3,  -11
+.2byte    8,   -9, 	  -7,  -18, 	  -9,   -9, 	  -3,  -11
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -6, 	  -1,  -11
+.2byte    7,  -14, 	 -10,  -15, 	   2,   -6, 	  -2,  -11
+.2byte    7,  -14, 	 -10,  -15, 	   2,   -6, 	  -2,  -11
+.2byte    7,  -14, 	 -10,  -15, 	   2,   -6, 	  -2,  -11
+.2byte    7,  -14, 	 -10,  -15, 	   2,   -6, 	  -2,  -11
+.2byte    7,  -14, 	 -10,  -15, 	   2,   -6, 	  -2,  -11
+.2byte    7,  -14, 	 -10,  -15, 	   2,   -6, 	  -2,  -11
+.2byte    7,  -14, 	 -10,  -15, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -13, 	   9,  -10, 	 -11,  -10, 	  -1,  -11
+.2byte   -1,  -15, 	  12,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	  12,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	  12,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	  12,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	  12,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	  12,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	  12,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -7,  -12, 	   7,  -14, 	  -5,   -6, 	  -1,  -11
+.2byte   -9,  -14, 	   8,  -15, 	  -4,   -6, 	   0,  -11
+.2byte   -9,  -14, 	   8,  -15, 	  -4,   -6, 	   0,  -11
+.2byte   -9,  -14, 	   8,  -15, 	  -4,   -6, 	   0,  -11
+.2byte   -9,  -14, 	   8,  -15, 	  -4,   -6, 	   0,  -11
+.2byte   -9,  -14, 	   8,  -15, 	  -4,   -6, 	   0,  -11
+.2byte   -9,  -14, 	   8,  -15, 	  -4,   -6, 	   0,  -11
+.2byte   -9,  -14, 	   8,  -15, 	  -4,   -6, 	   0,  -11
+.2byte  -10,   -8, 	   4,  -16, 	   6,   -9, 	   0,  -11
+.2byte  -10,   -9, 	   5,  -18, 	   7,   -9, 	   1,  -11
+.2byte  -10,   -9, 	   5,  -18, 	   7,   -9, 	   1,  -11
+.2byte  -10,   -9, 	   5,  -18, 	   7,   -9, 	   1,  -11
+.2byte  -10,   -9, 	   5,  -18, 	   7,   -9, 	   1,  -11
+.2byte  -10,   -9, 	   5,  -18, 	   7,   -9, 	   1,  -11
+.2byte  -10,   -9, 	   5,  -18, 	   7,   -9, 	   1,  -11
+.2byte  -10,   -9, 	   5,  -18, 	   7,   -9, 	   1,  -11
+.2byte   -7,   -5, 	  -9,  -15, 	   8,  -10, 	  -3,  -10
+.2byte   -9,   -6, 	 -10,  -17, 	   9,  -12, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,  -17, 	   9,  -12, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,  -17, 	   9,  -12, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,  -17, 	   9,  -12, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,  -17, 	   9,  -12, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,  -17, 	   9,  -12, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,  -17, 	   9,  -12, 	  -3,  -11
+.2byte   -7,   -4, 	  -8,  -16, 	   7,  -12, 	  -1,  -12
+.2byte   -7,   -3, 	  -7,  -17, 	   7,  -12, 	  -1,  -11
+.2byte    0,   -9, 	 -10,  -13, 	  10,  -13, 	   0,  -15
+.2byte    4,   -7, 	   8,  -16, 	  -7,   -7, 	  -2,  -14
+.2byte    7,  -10, 	   1,  -11, 	  -1,   -7, 	  -3,  -12
+.2byte    3,  -16, 	  -1,  -16, 	   7,  -12, 	  -4,  -10
+.2byte    0,  -15, 	  10,  -15, 	  -9,  -14, 	   0,   -9
+.2byte   -4,  -16, 	   0,  -16, 	  -8,  -12, 	   3,  -10
+.2byte   -8,  -10, 	  -2,  -11, 	   0,   -7, 	   2,  -12
+.2byte   -5,   -7, 	  -9,  -16, 	   6,   -7, 	   1,  -14
+.2byte   -1,   -4, 	 -11,  -15, 	   9,  -15, 	  -1,  -10
+.2byte   -7,   -5, 	  -9,  -15, 	   8,  -10, 	  -3,  -10
+.2byte  -10,   -8, 	   4,  -16, 	   6,   -9, 	   0,  -11
+.2byte   -7,  -12, 	   7,  -14, 	  -5,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	   9,  -10, 	 -11,  -10, 	  -1,  -11
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -6, 	  -1,  -11
+.2byte    8,   -8, 	  -6,  -16, 	  -8,   -9, 	  -2,  -11
+.2byte    5,   -5, 	   7,  -15, 	 -10,  -10, 	   1,  -10
+.2byte    0,   -7, 	 -13,  -12, 	  13,  -12, 	   0,   -8
+.2byte   -7,  -10, 	 -12,  -18, 	  10,   -4, 	   0,   -8
+.2byte   -9,  -11, 	   0,  -13, 	   2,   -7, 	   1,   -7
+.2byte   -6,  -14, 	   8,  -16, 	 -10,   -6, 	   1,   -9
+.2byte    0,  -11, 	  13,  -12, 	 -12,  -12, 	   0,   -7
+.2byte    5,  -14, 	  -9,  -16, 	   9,   -6, 	  -2,   -9
+.2byte    8,  -11, 	  -1,  -13, 	  -3,   -7, 	  -2,   -7
+.2byte    6,  -10, 	  11,  -18, 	 -11,   -4, 	  -1,   -8
+.2byte    0,   -7, 	 -13,  -12, 	  13,  -12, 	   0,   -8
+.2byte    6,  -10, 	  11,  -18, 	 -11,   -4, 	  -1,   -8
+.2byte    8,  -11, 	  -1,  -13, 	  -3,   -7, 	  -2,   -7
+.2byte    5,  -14, 	  -9,  -16, 	   9,   -6, 	  -2,   -9
+.2byte    0,  -11, 	  13,  -12, 	 -12,  -12, 	   0,   -7
+.2byte   -6,  -14, 	   8,  -16, 	 -10,   -6, 	   1,   -9
+.2byte   -9,  -11, 	   0,  -13, 	   2,   -7, 	   1,   -7
+.2byte   -7,  -10, 	 -12,  -18, 	  10,   -4, 	   0,   -8
+.2byte   -1,   -2, 	 -11,  -13, 	   9,  -13, 	  -1,   -8
+.2byte   -1,   -8, 	 -14,  -13, 	  12,  -13, 	  -1,   -9
+.2byte    6,   -3, 	   8,  -13, 	  -9,   -8, 	   2,   -8
+.2byte    7,  -10, 	  12,  -18, 	 -10,   -4, 	   0,   -8
+.2byte   11,   -6, 	  -3,  -14, 	  -5,   -7, 	   1,   -9
+.2byte   10,  -11, 	   1,  -13, 	  -1,   -7, 	   0,   -7
+.2byte    7,  -10, 	  -7,  -12, 	   5,   -4, 	   1,   -9
+.2byte    7,  -14, 	  -7,  -16, 	  11,   -6, 	   0,   -9
+.2byte   -1,  -11, 	   9,   -8, 	 -11,   -8, 	  -1,   -9
+.2byte   -1,  -11, 	  12,  -12, 	 -13,  -12, 	  -1,   -7
+.2byte   -8,  -10, 	   6,  -12, 	  -6,   -4, 	  -2,   -9
+.2byte   -8,  -14, 	   6,  -16, 	 -12,   -6, 	  -1,   -9
+.2byte  -12,   -6, 	   2,  -14, 	   4,   -7, 	  -2,   -9
+.2byte  -11,  -11, 	  -2,  -13, 	   0,   -7, 	  -1,   -7
+.2byte   -7,   -3, 	  -9,  -13, 	   8,   -8, 	  -3,   -8
+.2byte   -8,  -10, 	 -13,  -18, 	   9,   -4, 	  -1,   -8
+.2byte    0,   -2, 	  -8,  -15, 	   8,  -15, 	   0,  -10
+.2byte   -5,   -3, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte   -8,   -5, 	   5,  -16, 	   5,  -11, 	   1,  -10
+.2byte   -7,  -11, 	   8,  -13, 	  -3,   -7, 	   2,  -11
+.2byte   -1,  -13, 	   6,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte    6,  -11, 	  -9,  -13, 	   2,   -7, 	  -3,  -11
+.2byte    6,   -5, 	  -7,  -16, 	  -7,  -11, 	  -3,  -10
+.2byte    3,   -3, 	   5,  -15, 	  -9,  -11, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,  -15, 	   9,  -15, 	  -1,  -10
+.2byte   -7,   -5, 	  -9,  -15, 	   8,  -10, 	  -3,  -10
+.2byte  -10,   -8, 	   4,  -16, 	   6,   -9, 	   0,  -11
+.2byte   -7,  -12, 	   7,  -14, 	  -5,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	   9,  -10, 	 -11,  -10, 	  -1,  -11
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -6, 	  -1,  -11
+.2byte    8,   -8, 	  -6,  -16, 	  -8,   -9, 	  -2,  -11
+.2byte    5,   -5, 	   7,  -15, 	 -10,  -10, 	   1,  -10
+sDuskullAnimTable1:
+.4byte sDuskullAnims_1_1
+.4byte sDuskullAnims_1_2
+.4byte sDuskullAnims_1_3
+.4byte sDuskullAnims_1_4
+.4byte sDuskullAnims_1_5
+.4byte sDuskullAnims_1_6
+.4byte sDuskullAnims_1_7
+.4byte sDuskullAnims_1_8
+sDuskullAnimTable2:
+.4byte sDuskullAnims_2_1
+.4byte sDuskullAnims_2_2
+.4byte sDuskullAnims_2_3
+.4byte sDuskullAnims_2_4
+.4byte sDuskullAnims_2_5
+.4byte sDuskullAnims_2_6
+.4byte sDuskullAnims_2_7
+.4byte sDuskullAnims_2_8
+sDuskullAnimTable3:
+.4byte sDuskullAnims_3_1
+.4byte sDuskullAnims_3_2
+.4byte sDuskullAnims_3_3
+.4byte sDuskullAnims_3_4
+.4byte sDuskullAnims_3_5
+.4byte sDuskullAnims_3_6
+.4byte sDuskullAnims_3_7
+.4byte sDuskullAnims_3_8
+sDuskullAnimTable4:
+.4byte sDuskullAnims_4_1
+.4byte sDuskullAnims_4_2
+.4byte sDuskullAnims_4_3
+.4byte sDuskullAnims_4_4
+.4byte sDuskullAnims_4_5
+.4byte sDuskullAnims_4_6
+.4byte sDuskullAnims_4_7
+.4byte sDuskullAnims_4_8
+sDuskullAnimTable5:
+.4byte sDuskullAnims_5_1
+.4byte sDuskullAnims_5_2
+.4byte sDuskullAnims_5_3
+.4byte sDuskullAnims_5_4
+.4byte sDuskullAnims_5_5
+.4byte sDuskullAnims_5_6
+.4byte sDuskullAnims_5_7
+.4byte sDuskullAnims_5_8
+sDuskullAnimTable6:
+.4byte sDuskullAnims_6_1
+.4byte sDuskullAnims_6_1
+.4byte sDuskullAnims_6_1
+.4byte sDuskullAnims_6_1
+.4byte sDuskullAnims_6_1
+.4byte sDuskullAnims_6_1
+.4byte sDuskullAnims_6_1
+.4byte sDuskullAnims_6_1
+sDuskullAnimTable7:
+.4byte sDuskullAnims_7_1
+.4byte sDuskullAnims_7_2
+.4byte sDuskullAnims_7_3
+.4byte sDuskullAnims_7_4
+.4byte sDuskullAnims_7_5
+.4byte sDuskullAnims_7_6
+.4byte sDuskullAnims_7_7
+.4byte sDuskullAnims_7_8
+sDuskullAnimTable8:
+.4byte sDuskullAnims_8_1
+.4byte sDuskullAnims_8_2
+.4byte sDuskullAnims_8_3
+.4byte sDuskullAnims_8_4
+.4byte sDuskullAnims_8_5
+.4byte sDuskullAnims_8_6
+.4byte sDuskullAnims_8_7
+.4byte sDuskullAnims_8_8
+sDuskullAnimTable9:
+.4byte sDuskullAnims_9_1
+.4byte sDuskullAnims_9_2
+.4byte sDuskullAnims_9_3
+.4byte sDuskullAnims_9_4
+.4byte sDuskullAnims_9_5
+.4byte sDuskullAnims_9_6
+.4byte sDuskullAnims_9_7
+.4byte sDuskullAnims_9_8
+sDuskullAnimTable10:
+.4byte sDuskullAnims_10_1
+.4byte sDuskullAnims_10_2
+.4byte sDuskullAnims_10_3
+.4byte sDuskullAnims_10_4
+.4byte sDuskullAnims_10_5
+.4byte sDuskullAnims_10_6
+.4byte sDuskullAnims_10_7
+.4byte sDuskullAnims_10_8
+sDuskullAnimTable11:
+.4byte sDuskullAnims_11_1
+.4byte sDuskullAnims_11_2
+.4byte sDuskullAnims_11_3
+.4byte sDuskullAnims_11_4
+.4byte sDuskullAnims_11_5
+.4byte sDuskullAnims_11_6
+.4byte sDuskullAnims_11_7
+.4byte sDuskullAnims_11_8
+sDuskullAnimTable12:
+.4byte sDuskullAnims_12_1
+.4byte sDuskullAnims_12_2
+.4byte sDuskullAnims_12_3
+.4byte sDuskullAnims_12_4
+.4byte sDuskullAnims_12_5
+.4byte sDuskullAnims_12_6
+.4byte sDuskullAnims_12_7
+.4byte sDuskullAnims_12_8
+sDuskullAnimTable13:
+.4byte sDuskullAnims_13_1
+.4byte sDuskullAnims_13_2
+.4byte sDuskullAnims_13_3
+.4byte sDuskullAnims_13_4
+.4byte sDuskullAnims_13_5
+.4byte sDuskullAnims_13_6
+.4byte sDuskullAnims_13_7
+.4byte sDuskullAnims_13_8
+sAxAnimationsDuskull:
+.4byte sDuskullAnimTable1
+.4byte sDuskullAnimTable2
+.4byte sDuskullAnimTable3
+.4byte sDuskullAnimTable4
+.4byte sDuskullAnimTable5
+.4byte sDuskullAnimTable6
+.4byte sDuskullAnimTable7
+.4byte sDuskullAnimTable8
+.4byte sDuskullAnimTable9
+.4byte sDuskullAnimTable10
+.4byte sDuskullAnimTable11
+.4byte sDuskullAnimTable12
+.4byte sDuskullAnimTable13
+sAxSpritesDuskull:
+.4byte sDuskullSprites1
+.4byte sDuskullSprites2
+.4byte sDuskullSprites3
+.4byte sDuskullSprites4
+.4byte sDuskullSprites5
+.4byte sDuskullSprites6
+.4byte sDuskullSprites7
+.4byte sDuskullSprites8
+.4byte sDuskullSprites9
+.4byte sDuskullSprites10
+.4byte sDuskullSprites11
+.4byte sDuskullSprites12
+.4byte sDuskullSprites13
+.4byte sDuskullSprites14
+.4byte sDuskullSprites15
+.4byte sDuskullSprites16
+.4byte sDuskullSprites17
+.4byte sDuskullSprites18
+.4byte sDuskullSprites19
+.4byte sDuskullSprites20
+.4byte sDuskullSprites21
+.4byte sDuskullSprites22
+.4byte sDuskullSprites23
+.4byte sDuskullSprites24
+.4byte sDuskullSprites25
+.4byte sDuskullSprites26
+.4byte sDuskullSprites27
+.4byte sDuskullSprites28
+.4byte sDuskullSprites29
+.4byte sDuskullSprites30
+.4byte sDuskullSprites31
+.4byte sDuskullSprites32
+.4byte sDuskullSprites33
+.4byte sDuskullSprites34
+.4byte sDuskullSprites35
+.4byte sDuskullSprites36
+.4byte sDuskullSprites37
+.4byte sDuskullSprites38
+.4byte sDuskullSprites39
+.4byte sDuskullSprites40
+.4byte sDuskullSprites41
+.4byte sDuskullSprites42
+.4byte sDuskullSprites43
+.4byte sDuskullSprites44
+.4byte sDuskullSprites45
+.4byte sDuskullSprites46
+.4byte sDuskullSprites47
+sAxMainDuskull:
+ax_main sAxPosesDuskull, sAxAnimationsDuskull, 13, sAxSpritesDuskull, sAxPositionsDuskull

--- a/data/ax/dustox.inc
+++ b/data/ax/dustox.inc
@@ -1,0 +1,2876 @@
+.global gAxDustox
+gAxDustox:
+ax_siro sAxMainDustox
+sDustoxPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose5:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose7:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose8:
+ax_pose 7, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose9:
+ax_pose 8, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose10:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose11:
+ax_pose 10, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose12:
+ax_pose 11, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose16:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose17:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose18:
+ax_pose 11, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose19:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose20:
+ax_pose 7, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose21:
+ax_pose 8, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose28:
+ax_pose 15, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose29:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose30:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose31:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose32:
+ax_pose 16, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose33:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose34:
+ax_pose 7, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose35:
+ax_pose 8, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose36:
+ax_pose 17, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sDustoxPose37:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose38:
+ax_pose 10, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose39:
+ax_pose 11, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose40:
+ax_pose 18, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose41:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose42:
+ax_pose 13, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose43:
+ax_pose 14, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose44:
+ax_pose 19, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose45:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose47:
+ax_pose 11, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose48:
+ax_pose 18, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose49:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose50:
+ax_pose 7, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose51:
+ax_pose 8, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose52:
+ax_pose 17, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sDustoxPose53:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose54:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose55:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose56:
+ax_pose 16, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose58:
+ax_pose 1, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose59:
+ax_pose 2, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose60:
+ax_pose 15, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose61:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose62:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose63:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose64:
+ax_pose 16, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose65:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose66:
+ax_pose 7, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose67:
+ax_pose 8, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose68:
+ax_pose 17, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sDustoxPose69:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose70:
+ax_pose 10, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose71:
+ax_pose 11, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose72:
+ax_pose 18, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose73:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose74:
+ax_pose 13, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose75:
+ax_pose 14, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose76:
+ax_pose 19, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose77:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose78:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose79:
+ax_pose 11, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose80:
+ax_pose 18, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose81:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose82:
+ax_pose 7, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose83:
+ax_pose 8, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose84:
+ax_pose 17, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sDustoxPose85:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose86:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose87:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose88:
+ax_pose 16, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose90:
+ax_pose 1, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose91:
+ax_pose 2, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose92:
+ax_pose 20, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose93:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose94:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose95:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose96:
+ax_pose 21, 0x01e5, 0x90ef, 0xac00
+ax_pose_terminator
+sDustoxPose97:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose98:
+ax_pose 7, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose99:
+ax_pose 8, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose100:
+ax_pose 22, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose101:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose102:
+ax_pose 10, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose103:
+ax_pose 11, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose104:
+ax_pose 23, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose105:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose106:
+ax_pose 13, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose107:
+ax_pose 14, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose108:
+ax_pose 24, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose109:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose110:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose111:
+ax_pose 11, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose112:
+ax_pose 23, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose113:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose114:
+ax_pose 7, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose115:
+ax_pose 8, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose116:
+ax_pose 22, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose117:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose118:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose119:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose120:
+ax_pose 21, 0x01e5, 0x80f1, 0xac00
+ax_pose_terminator
+sDustoxPose121:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose122:
+ax_pose 1, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose123:
+ax_pose 2, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose124:
+ax_pose 20, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose125:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose126:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose127:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose128:
+ax_pose 21, 0x01e5, 0x90ef, 0xac00
+ax_pose_terminator
+sDustoxPose129:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose130:
+ax_pose 7, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose131:
+ax_pose 8, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose132:
+ax_pose 22, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose133:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose134:
+ax_pose 10, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose135:
+ax_pose 11, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose136:
+ax_pose 23, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose137:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose138:
+ax_pose 13, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose139:
+ax_pose 14, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose140:
+ax_pose 24, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose141:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose142:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose143:
+ax_pose 11, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose144:
+ax_pose 23, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose145:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose146:
+ax_pose 7, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose147:
+ax_pose 8, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose148:
+ax_pose 22, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose149:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose150:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose151:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose152:
+ax_pose 21, 0x01e5, 0x80f1, 0xac00
+ax_pose_terminator
+sDustoxPose153:
+ax_pose 25, 0x01ec, 0x80f1, 0xac00
+ax_pose_terminator
+sDustoxPose154:
+ax_pose 26, 0x01ec, 0x80f1, 0xac00
+ax_pose_terminator
+sDustoxPose155:
+ax_pose 27, 0x01df, 0x80f1, 0xac00
+ax_pose_terminator
+sDustoxPose156:
+ax_pose 28, 0x01e3, 0x90eb, 0xac00
+ax_pose_terminator
+sDustoxPose157:
+ax_pose 29, 0x01e3, 0x90eb, 0xac00
+ax_pose_terminator
+sDustoxPose158:
+ax_pose 30, 0x01e6, 0x90eb, 0xac00
+ax_pose_terminator
+sDustoxPose159:
+ax_pose 31, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose160:
+ax_pose 30, 0x01e6, 0x80f5, 0xac00
+ax_pose_terminator
+sDustoxPose161:
+ax_pose 29, 0x01e3, 0x80f5, 0xac00
+ax_pose_terminator
+sDustoxPose162:
+ax_pose 28, 0x01e3, 0x80f5, 0xac00
+ax_pose_terminator
+sDustoxPose163:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose164:
+ax_pose 1, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose165:
+ax_pose 2, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose166:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose167:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose168:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose169:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose170:
+ax_pose 7, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose171:
+ax_pose 8, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose172:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose173:
+ax_pose 10, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose174:
+ax_pose 11, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose175:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose176:
+ax_pose 13, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose177:
+ax_pose 14, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose178:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose179:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose180:
+ax_pose 11, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose181:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose182:
+ax_pose 7, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose183:
+ax_pose 8, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose184:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose185:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose186:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose187:
+ax_pose 15, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose188:
+ax_pose 16, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose189:
+ax_pose 17, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sDustoxPose190:
+ax_pose 18, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose191:
+ax_pose 19, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose192:
+ax_pose 18, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose193:
+ax_pose 17, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sDustoxPose194:
+ax_pose 16, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose195:
+ax_pose 2, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose196:
+ax_pose 5, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose197:
+ax_pose 8, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose198:
+ax_pose 11, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose199:
+ax_pose 14, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose200:
+ax_pose 11, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose201:
+ax_pose 8, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose202:
+ax_pose 5, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose203:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose204:
+ax_pose 1, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose205:
+ax_pose 15, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose206:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose207:
+ax_pose 4, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose208:
+ax_pose 16, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sDustoxPose209:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose210:
+ax_pose 7, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose211:
+ax_pose 17, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sDustoxPose212:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose213:
+ax_pose 10, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose214:
+ax_pose 18, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose215:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose216:
+ax_pose 13, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose217:
+ax_pose 19, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose218:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose219:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose220:
+ax_pose 18, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose221:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose222:
+ax_pose 7, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose223:
+ax_pose 17, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sDustoxPose224:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose225:
+ax_pose 4, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose226:
+ax_pose 16, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose227:
+ax_pose 20, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose228:
+ax_pose 21, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose229:
+ax_pose 22, 0x01e4, 0x80f5, 0xac00
+ax_pose_terminator
+sDustoxPose230:
+ax_pose 23, 0x01e6, 0x80f5, 0xac00
+ax_pose_terminator
+sDustoxPose231:
+ax_pose 24, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose232:
+ax_pose 23, 0x01e6, 0x90eb, 0xac00
+ax_pose_terminator
+sDustoxPose233:
+ax_pose 22, 0x01e4, 0x90eb, 0xac00
+ax_pose_terminator
+sDustoxPose234:
+ax_pose 21, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose235:
+ax_pose 0, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose236:
+ax_pose 3, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose237:
+ax_pose 6, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sDustoxPose238:
+ax_pose 9, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sDustoxPose239:
+ax_pose 12, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sDustoxPose240:
+ax_pose 9, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sDustoxPose241:
+ax_pose 6, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sDustoxPose242:
+ax_pose 3, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+.align 2
+sDustoxAnims_1_1:
+ax_anim 2, 0, 0, 0, 0, 0, 0,
+ax_anim 2, 0, 1, 0, 0, 0, 0,
+ax_anim 2, 0, 0, 0, -1, 0, 0,
+ax_anim 2, 0, 2, 0, -1, 0, 0,
+ax_anim 2, 0, 0, 0, -2, 0, 0,
+ax_anim 2, 0, 1, 0, -2, 0, 0,
+ax_anim 2, 0, 0, 0, -2, 0, 0,
+ax_anim 2, 0, 2, 0, -2, 0, 0,
+ax_anim 2, 0, 0, 0, -1, 0, 0,
+ax_anim 2, 0, 1, 0, -1, 0, 0,
+ax_anim 2, 0, 0, 0, 0, 0, 0,
+ax_anim 2, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_1_2:
+ax_anim 2, 0, 3, 0, 0, 0, 0,
+ax_anim 2, 0, 4, 0, 0, 0, 0,
+ax_anim 2, 0, 3, 0, -1, 0, 0,
+ax_anim 2, 0, 5, 0, -1, 0, 0,
+ax_anim 2, 0, 3, 0, -2, 0, 0,
+ax_anim 2, 0, 4, 0, -2, 0, 0,
+ax_anim 2, 0, 3, 0, -2, 0, 0,
+ax_anim 2, 0, 5, 0, -2, 0, 0,
+ax_anim 2, 0, 3, 0, -1, 0, 0,
+ax_anim 2, 0, 4, 0, -1, 0, 0,
+ax_anim 2, 0, 3, 0, 0, 0, 0,
+ax_anim 2, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_1_3:
+ax_anim 2, 0, 6, 0, 0, 0, 0,
+ax_anim 2, 0, 7, 0, 0, 0, 0,
+ax_anim 2, 0, 6, 0, -1, 0, 0,
+ax_anim 2, 0, 8, 0, -1, 0, 0,
+ax_anim 2, 0, 6, 0, -2, 0, 0,
+ax_anim 2, 0, 7, 0, -2, 0, 0,
+ax_anim 2, 0, 6, 0, -2, 0, 0,
+ax_anim 2, 0, 8, 0, -2, 0, 0,
+ax_anim 2, 0, 6, 0, -1, 0, 0,
+ax_anim 2, 0, 7, 0, -1, 0, 0,
+ax_anim 2, 0, 6, 0, 0, 0, 0,
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_1_4:
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 9, 0, -1, 0, 0,
+ax_anim 2, 0, 11, 0, -1, 0, 0,
+ax_anim 2, 0, 9, 0, -2, 0, 0,
+ax_anim 2, 0, 10, 0, -2, 0, 0,
+ax_anim 2, 0, 9, 0, -2, 0, 0,
+ax_anim 2, 0, 11, 0, -2, 0, 0,
+ax_anim 2, 0, 9, 0, -1, 0, 0,
+ax_anim 2, 0, 10, 0, -1, 0, 0,
+ax_anim 2, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_1_5:
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 12, 0, -1, 0, 0,
+ax_anim 2, 0, 14, 0, -1, 0, 0,
+ax_anim 2, 0, 12, 0, -2, 0, 0,
+ax_anim 2, 0, 13, 0, -2, 0, 0,
+ax_anim 2, 0, 12, 0, -2, 0, 0,
+ax_anim 2, 0, 14, 0, -2, 0, 0,
+ax_anim 2, 0, 12, 0, -1, 0, 0,
+ax_anim 2, 0, 13, 0, -1, 0, 0,
+ax_anim 2, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_1_6:
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 15, 0, -1, 0, 0,
+ax_anim 2, 0, 17, 0, -1, 0, 0,
+ax_anim 2, 0, 15, 0, -2, 0, 0,
+ax_anim 2, 0, 16, 0, -2, 0, 0,
+ax_anim 2, 0, 15, 0, -2, 0, 0,
+ax_anim 2, 0, 17, 0, -2, 0, 0,
+ax_anim 2, 0, 15, 0, -1, 0, 0,
+ax_anim 2, 0, 16, 0, -1, 0, 0,
+ax_anim 2, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_1_7:
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, -1, 0, 0,
+ax_anim 2, 0, 20, 0, -1, 0, 0,
+ax_anim 2, 0, 18, 0, -2, 0, 0,
+ax_anim 2, 0, 19, 0, -2, 0, 0,
+ax_anim 2, 0, 18, 0, -2, 0, 0,
+ax_anim 2, 0, 20, 0, -2, 0, 0,
+ax_anim 2, 0, 18, 0, -1, 0, 0,
+ax_anim 2, 0, 19, 0, -1, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_1_8:
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 21, 0, -1, 0, 0,
+ax_anim 2, 0, 23, 0, -1, 0, 0,
+ax_anim 2, 0, 21, 0, -2, 0, 0,
+ax_anim 2, 0, 22, 0, -2, 0, 0,
+ax_anim 2, 0, 21, 0, -2, 0, 0,
+ax_anim 2, 0, 23, 0, -2, 0, 0,
+ax_anim 2, 0, 21, 0, -1, 0, 0,
+ax_anim 2, 0, 22, 0, -1, 0, 0,
+ax_anim 2, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -3, 0, -3,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 26, 0, -4, 0, -4,
+ax_anim 1, 2, 27, 0, 2, 0, 2,
+ax_anim 2, 0, 27, 0, 16, 0, 15,
+ax_anim 2, 0, 27, 0, 25, 0, 22,
+ax_anim 2, 1, 27, -1, 25, -1, 22,
+ax_anim 2, 0, 27, 0, 25, 0, 22,
+ax_anim 2, 0, 27, -1, 25, -1, 22,
+ax_anim 2, 0, 27, 0, 25, 0, 22,
+ax_anim 2, 0, 27, -1, 25, -1, 22,
+ax_anim 2, 0, 24, 0, 15, 0, 14,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sDustoxAnims_2_2:
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 29, -4, -4, -4, -4,
+ax_anim 2, 0, 30, -4, -4, -4, -4,
+ax_anim 1, 2, 31, 2, 2, 2, 2,
+ax_anim 2, 0, 31, 15, 21, 15, 19,
+ax_anim 2, 0, 31, 19, 26, 19, 23,
+ax_anim 2, 1, 31, 18, 27, 18, 24,
+ax_anim 2, 0, 31, 19, 26, 19, 23,
+ax_anim 2, 0, 31, 18, 27, 18, 24,
+ax_anim 2, 0, 31, 19, 26, 19, 23,
+ax_anim 2, 0, 31, 18, 27, 18, 24,
+ax_anim 2, 0, 28, 13, 19, 13, 17,
+ax_anim 2, 0, 28, 5, 8, 5, 7,
+ax_anim_terminator
+sDustoxAnims_2_3:
+ax_anim 2, 0, 33, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 2, 0, 33, -4, 0, -4, 0,
+ax_anim 2, 0, 34, -4, 0, -4, 0,
+ax_anim 1, 2, 35, 2, 2, 2, 0,
+ax_anim 2, 0, 35, 13, 3, 13, 0,
+ax_anim 2, 0, 35, 19, 4, 19, 0,
+ax_anim 2, 1, 35, 19, 5, 19, 1,
+ax_anim 2, 0, 35, 19, 4, 19, 0,
+ax_anim 2, 0, 35, 19, 5, 19, 1,
+ax_anim 2, 0, 35, 19, 4, 19, 0,
+ax_anim 2, 0, 35, 19, 5, 19, 1,
+ax_anim 2, 0, 32, 13, 2, 13, 0,
+ax_anim 2, 0, 32, 5, 1, 5, 0,
+ax_anim_terminator
+sDustoxAnims_2_4:
+ax_anim 2, 0, 37, -2, 2, -2, 2,
+ax_anim 2, 0, 38, -3, 3, -3, 3,
+ax_anim 2, 0, 37, -4, 4, -4, 4,
+ax_anim 2, 0, 38, -4, 4, -4, 4,
+ax_anim 1, 2, 39, 2, -2, 2, -3,
+ax_anim 2, 0, 39, 15, -15, 15, -17,
+ax_anim 2, 0, 39, 18, -16, 18, -19,
+ax_anim 2, 1, 39, 17, -17, 17, -20,
+ax_anim 2, 0, 39, 18, -16, 18, -19,
+ax_anim 2, 0, 39, 17, -17, 17, -20,
+ax_anim 2, 0, 39, 18, -16, 18, -19,
+ax_anim 2, 0, 39, 17, -17, 17, -20,
+ax_anim 2, 0, 36, 13, -13, 13, -14,
+ax_anim 2, 0, 36, 5, -5, 5, -6,
+ax_anim_terminator
+sDustoxAnims_2_5:
+ax_anim 2, 0, 41, 0, 2, 0, 2,
+ax_anim 2, 0, 42, 0, 3, 0, 3,
+ax_anim 2, 0, 41, 0, 4, 0, 4,
+ax_anim 2, 0, 42, 0, 4, 0, 4,
+ax_anim 1, 2, 43, 0, -2, 0, -4,
+ax_anim 2, 0, 43, 0, -11, 0, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -22,
+ax_anim 2, 1, 43, -1, -15, -1, -22,
+ax_anim 2, 0, 43, 0, -15, 0, -22,
+ax_anim 2, 0, 43, -1, -15, -1, -22,
+ax_anim 2, 0, 43, 0, -15, 0, -22,
+ax_anim 2, 0, 43, -1, -15, -1, -22,
+ax_anim 2, 0, 40, 0, -10, 0, -10,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sDustoxAnims_2_6:
+ax_anim 2, 0, 45, 2, 2, 2, 2,
+ax_anim 2, 0, 46, 3, 3, 3, 3,
+ax_anim 2, 0, 45, 4, 4, 4, 4,
+ax_anim 2, 0, 46, 4, 4, 4, 4,
+ax_anim 1, 2, 47, -2, -2, -2, -3,
+ax_anim 2, 0, 47, -15, -15, -15, -17,
+ax_anim 2, 0, 47, -18, -16, -18, -19,
+ax_anim 2, 1, 47, -17, -17, -17, -20,
+ax_anim 2, 0, 47, -18, -16, -18, -19,
+ax_anim 2, 0, 47, -17, -17, -17, -20,
+ax_anim 2, 0, 47, -18, -16, -18, -19,
+ax_anim 2, 0, 47, -17, -17, -17, -20,
+ax_anim 2, 0, 44, -13, -13, -13, -14,
+ax_anim 2, 0, 44, -5, -5, -5, -6,
+ax_anim_terminator
+sDustoxAnims_2_7:
+ax_anim 2, 0, 49, 2, 0, 2, 0,
+ax_anim 2, 0, 50, 3, 0, 3, 0,
+ax_anim 2, 0, 49, 4, 0, 4, 0,
+ax_anim 2, 0, 50, 4, 0, 4, 0,
+ax_anim 1, 2, 51, -2, 2, -2, 0,
+ax_anim 2, 0, 51, -13, 3, -13, 0,
+ax_anim 2, 0, 51, -19, 4, -19, 0,
+ax_anim 2, 1, 51, -19, 5, -19, 1,
+ax_anim 2, 0, 51, -19, 4, -19, 0,
+ax_anim 2, 0, 51, -19, 5, -19, 1,
+ax_anim 2, 0, 51, -19, 4, -19, 0,
+ax_anim 2, 0, 51, -19, 5, -19, 1,
+ax_anim 2, 0, 48, -13, 2, -13, 0,
+ax_anim 2, 0, 48, -5, 1, -5, 0,
+ax_anim_terminator
+sDustoxAnims_2_8:
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 0, 54, 3, -3, 3, -3,
+ax_anim 2, 0, 53, 4, -4, 4, -4,
+ax_anim 2, 0, 54, 4, -4, 4, -4,
+ax_anim 1, 2, 55, -2, 2, -2, 2,
+ax_anim 2, 0, 55, -15, 21, -15, 19,
+ax_anim 2, 0, 55, -19, 26, -19, 23,
+ax_anim 2, 1, 55, -18, 27, -18, 24,
+ax_anim 2, 0, 55, -19, 26, -19, 23,
+ax_anim 2, 0, 55, -18, 27, -18, 24,
+ax_anim 2, 0, 55, -19, 26, -19, 23,
+ax_anim 2, 0, 55, -18, 27, -18, 24,
+ax_anim 2, 0, 52, -13, 19, -13, 17,
+ax_anim 2, 0, 52, -5, 8, -5, 7,
+ax_anim_terminator
+.align 2
+sDustoxAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, -3, 0, -3,
+ax_anim 2, 0, 57, 0, -4, 0, -4,
+ax_anim 2, 0, 58, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, 2, 0, 2,
+ax_anim 2, 0, 59, 0, 16, 0, 15,
+ax_anim 2, 0, 59, 0, 25, 0, 22,
+ax_anim 2, 1, 59, -1, 25, -1, 22,
+ax_anim 2, 0, 59, 0, 25, 0, 22,
+ax_anim 2, 0, 59, -1, 25, -1, 22,
+ax_anim 2, 0, 59, 0, 25, 0, 22,
+ax_anim 2, 0, 59, -1, 25, -1, 22,
+ax_anim 2, 0, 56, 0, 15, 0, 14,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sDustoxAnims_3_2:
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 2, 0, 62, -3, -3, -3, -3,
+ax_anim 2, 0, 61, -4, -4, -4, -4,
+ax_anim 2, 0, 62, -4, -4, -4, -4,
+ax_anim 1, 2, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 63, 15, 21, 15, 19,
+ax_anim 2, 0, 63, 19, 26, 19, 23,
+ax_anim 2, 1, 63, 18, 27, 18, 24,
+ax_anim 2, 0, 63, 19, 26, 19, 23,
+ax_anim 2, 0, 63, 18, 27, 18, 24,
+ax_anim 2, 0, 63, 19, 26, 19, 23,
+ax_anim 2, 0, 63, 18, 27, 18, 24,
+ax_anim 2, 0, 60, 13, 19, 13, 17,
+ax_anim 2, 0, 60, 5, 8, 5, 7,
+ax_anim_terminator
+sDustoxAnims_3_3:
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 2, 0, 66, -3, 0, -3, 0,
+ax_anim 2, 0, 65, -4, 0, -4, 0,
+ax_anim 2, 0, 66, -4, 0, -4, 0,
+ax_anim 1, 2, 67, 2, 2, 2, 0,
+ax_anim 2, 0, 67, 13, 3, 13, 0,
+ax_anim 2, 0, 67, 19, 4, 19, 0,
+ax_anim 2, 1, 67, 19, 5, 19, 1,
+ax_anim 2, 0, 67, 19, 4, 19, 0,
+ax_anim 2, 0, 67, 19, 5, 19, 1,
+ax_anim 2, 0, 67, 19, 4, 19, 0,
+ax_anim 2, 0, 67, 19, 5, 19, 1,
+ax_anim 2, 0, 64, 13, 2, 13, 0,
+ax_anim 2, 0, 64, 5, 1, 5, 0,
+ax_anim_terminator
+sDustoxAnims_3_4:
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 2, 0, 70, -3, 3, -3, 3,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim 2, 0, 70, -4, 4, -4, 4,
+ax_anim 1, 2, 71, 2, -2, 2, -3,
+ax_anim 2, 0, 71, 15, -15, 15, -17,
+ax_anim 2, 0, 71, 18, -16, 18, -19,
+ax_anim 2, 1, 71, 17, -17, 17, -20,
+ax_anim 2, 0, 71, 18, -16, 18, -19,
+ax_anim 2, 0, 71, 17, -17, 17, -20,
+ax_anim 2, 0, 71, 18, -16, 18, -19,
+ax_anim 2, 0, 71, 17, -17, 17, -20,
+ax_anim 2, 0, 68, 13, -13, 13, -14,
+ax_anim 2, 0, 68, 5, -5, 5, -6,
+ax_anim_terminator
+sDustoxAnims_3_5:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 1, 2, 75, 0, -2, 0, -4,
+ax_anim 2, 0, 75, 0, -11, 0, -15,
+ax_anim 2, 0, 75, 0, -15, 0, -22,
+ax_anim 2, 1, 75, -1, -15, -1, -22,
+ax_anim 2, 0, 75, 0, -15, 0, -22,
+ax_anim 2, 0, 75, -1, -15, -1, -22,
+ax_anim 2, 0, 75, 0, -15, 0, -22,
+ax_anim 2, 0, 75, -1, -15, -1, -22,
+ax_anim 2, 0, 72, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sDustoxAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 78, 4, 4, 4, 4,
+ax_anim 1, 2, 79, -2, -2, -2, -3,
+ax_anim 2, 0, 79, -15, -15, -15, -17,
+ax_anim 2, 0, 79, -18, -16, -18, -19,
+ax_anim 2, 1, 79, -17, -17, -17, -20,
+ax_anim 2, 0, 79, -18, -16, -18, -19,
+ax_anim 2, 0, 79, -17, -17, -17, -20,
+ax_anim 2, 0, 79, -18, -16, -18, -19,
+ax_anim 2, 0, 79, -17, -17, -17, -20,
+ax_anim 2, 0, 76, -13, -13, -13, -14,
+ax_anim 2, 0, 76, -5, -5, -5, -6,
+ax_anim_terminator
+sDustoxAnims_3_7:
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 2, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 81, 4, 0, 4, 0,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 1, 2, 83, -2, 2, -2, 0,
+ax_anim 2, 0, 83, -13, 3, -13, 0,
+ax_anim 2, 0, 83, -19, 4, -19, 0,
+ax_anim 2, 1, 83, -19, 5, -19, 1,
+ax_anim 2, 0, 83, -19, 4, -19, 0,
+ax_anim 2, 0, 83, -19, 5, -19, 1,
+ax_anim 2, 0, 83, -19, 4, -19, 0,
+ax_anim 2, 0, 83, -19, 5, -19, 1,
+ax_anim 2, 0, 80, -13, 2, -13, 0,
+ax_anim 2, 0, 80, -5, 1, -5, 0,
+ax_anim_terminator
+sDustoxAnims_3_8:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 2, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 85, 4, -4, 4, -4,
+ax_anim 2, 0, 86, 4, -4, 4, -4,
+ax_anim 1, 2, 87, -2, 2, -2, 2,
+ax_anim 2, 0, 87, -15, 21, -15, 19,
+ax_anim 2, 0, 87, -19, 26, -19, 23,
+ax_anim 2, 1, 87, -18, 27, -18, 24,
+ax_anim 2, 0, 87, -19, 26, -19, 23,
+ax_anim 2, 0, 87, -18, 27, -18, 24,
+ax_anim 2, 0, 87, -19, 26, -19, 23,
+ax_anim 2, 0, 87, -18, 27, -18, 24,
+ax_anim 2, 0, 84, -13, 19, -13, 17,
+ax_anim 2, 0, 84, -5, 8, -5, 7,
+ax_anim_terminator
+.align 2
+sDustoxAnims_4_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 2, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 1, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_4_2:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 2, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 1, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_4_3:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 2, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 1, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_4_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 2, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 1, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_4_5:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 2, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 1, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_4_6:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 2, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 1, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_4_7:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 2, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 1, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_4_8:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 2, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 1, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_5_1:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_5_2:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_5_3:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 1, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_5_5:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_5_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_5_7:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 1, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_5_8:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 1, 151, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sDustoxAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sDustoxAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sDustoxAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sDustoxAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sDustoxAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sDustoxAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sDustoxAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sDustoxAnims_8_1:
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 163, 0, -1, 0, 0,
+ax_anim 6, 0, 162, 0, -1, 0, 0,
+ax_anim 4, 0, 164, 0, -1, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_8_2:
+ax_anim 6, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, -1, 0, 0,
+ax_anim 6, 0, 165, 0, -1, 0, 0,
+ax_anim 4, 0, 167, 0, -1, 0, 0,
+ax_anim 4, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_8_3:
+ax_anim 6, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, -1, 0, 0,
+ax_anim 6, 0, 168, 0, -1, 0, 0,
+ax_anim 4, 0, 170, 0, -1, 0, 0,
+ax_anim 4, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_8_4:
+ax_anim 6, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, -1, 0, 0,
+ax_anim 6, 0, 171, 0, -1, 0, 0,
+ax_anim 4, 0, 173, 0, -1, 0, 0,
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_8_5:
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, -1, 0, 0,
+ax_anim 6, 0, 174, 0, -1, 0, 0,
+ax_anim 4, 0, 176, 0, -1, 0, 0,
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_8_6:
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, -1, 0, 0,
+ax_anim 6, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 179, 0, -1, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_8_7:
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, -1, 0, 0,
+ax_anim 6, 0, 180, 0, -1, 0, 0,
+ax_anim 4, 0, 182, 0, -1, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_8_8:
+ax_anim 6, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, -1, 0, 0,
+ax_anim 6, 0, 183, 0, -1, 0, 0,
+ax_anim 4, 0, 185, 0, -1, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 12, 8, 12,
+ax_anim 2, 0, 189, 7, 22, 7, 20,
+ax_anim 3, 0, 190, 0, 27, 0, 23,
+ax_anim 2, 3, 191, -7, 22, -7, 20,
+ax_anim 2, 0, 192, -8, 12, -8, 12,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 6, 17, 6,
+ax_anim 2, 0, 188, 21, 16, 21, 14,
+ax_anim 3, 0, 189, 20, 26, 20, 23,
+ax_anim 2, 3, 190, 11, 27, 11, 24,
+ax_anim 2, 0, 191, 4, 18, 4, 18,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -3, 3, -3,
+ax_anim 2, 0, 186, 11, -2, 11, -3,
+ax_anim 2, 0, 187, 16, -1, 16, -2,
+ax_anim 3, 0, 188, 20, 6, 20, 1,
+ax_anim 2, 3, 189, 16, 9, 16, 6,
+ax_anim 2, 0, 190, 12, 9, 12, 7,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 14, -20, 14, -22,
+ax_anim 3, 0, 187, 20, -18, 20, -23,
+ax_anim 2, 3, 188, 21, -12, 21, -14,
+ax_anim 2, 0, 189, 17, -4, 17, -4,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -11, -9, -13,
+ax_anim 2, 0, 193, -7, -16, -7, -19,
+ax_anim 3, 0, 186, 0, -19, 0, -21,
+ax_anim 2, 3, 187, 7, -16, 7, -19,
+ax_anim 2, 0, 188, 9, -11, 9, -13,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -14, -20, -14, -22,
+ax_anim 3, 0, 193, -20, -18, -20, -23,
+ax_anim 2, 3, 192, -21, -12, -21, -14,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -3, -3, -3,
+ax_anim 2, 0, 186, -11, -2, -11, -3,
+ax_anim 2, 0, 193, -16, -1, -16, -2,
+ax_anim 3, 0, 192, -20, 6, -20, 1,
+ax_anim 2, 3, 191, -16, 9, -16, 6,
+ax_anim 2, 0, 190, -12, 9, -12, 7,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 6, -17, 6,
+ax_anim 2, 0, 192, -21, 16, -21, 14,
+ax_anim 3, 0, 191, -20, 26, -20, 23,
+ax_anim 2, 3, 190, -11, 27, -11, 24,
+ax_anim 2, 0, 189, -4, 18, -4, 18,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -8, 0, 0,
+ax_anim 2, 2, 204, 0, 6, 0, 0,
+ax_anim_terminator
+sDustoxAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -8, 0, 0,
+ax_anim 2, 2, 207, 0, 7, 0, 0,
+ax_anim_terminator
+sDustoxAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -8, 0, 0,
+ax_anim 2, 2, 210, 0, 8, 0, 0,
+ax_anim_terminator
+sDustoxAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -7, 0, 0,
+ax_anim 2, 2, 213, 0, 7, 0, 0,
+ax_anim_terminator
+sDustoxAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -8, 0, 0,
+ax_anim 2, 2, 216, 0, 9, 0, 0,
+ax_anim_terminator
+sDustoxAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -7, 0, 0,
+ax_anim 2, 2, 219, 0, 7, 0, 0,
+ax_anim_terminator
+sDustoxAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -8, 0, 0,
+ax_anim 2, 2, 222, 0, 8, 0, 0,
+ax_anim_terminator
+sDustoxAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -8, 0, 0,
+ax_anim 2, 2, 225, 0, 7, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sDustoxAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sDustoxGfx1:
+.incbin "baserom.gba", 0x1101734, 0x200
+sDustoxSprites1:
+ax_sprite sDustoxGfx1, 0x200
+ax_sprite_terminator
+sDustoxGfx2:
+.incbin "baserom.gba", 0x1101944, 0x200
+sDustoxSprites2:
+ax_sprite sDustoxGfx2, 0x200
+ax_sprite_terminator
+sDustoxGfx3:
+.incbin "baserom.gba", 0x1101B54, 0x200
+sDustoxSprites3:
+ax_sprite sDustoxGfx3, 0x200
+ax_sprite_terminator
+sDustoxGfx4:
+.incbin "baserom.gba", 0x1101D64, 0x200
+sDustoxSprites4:
+ax_sprite sDustoxGfx4, 0x200
+ax_sprite_terminator
+sDustoxGfx5:
+.incbin "baserom.gba", 0x1101F74, 0x200
+sDustoxSprites5:
+ax_sprite sDustoxGfx5, 0x200
+ax_sprite_terminator
+sDustoxGfx6:
+.incbin "baserom.gba", 0x1102184, 0x200
+sDustoxSprites6:
+ax_sprite sDustoxGfx6, 0x200
+ax_sprite_terminator
+sDustoxGfx7:
+.incbin "baserom.gba", 0x1102394, 0x200
+sDustoxSprites7:
+ax_sprite sDustoxGfx7, 0x200
+ax_sprite_terminator
+sDustoxGfx8:
+.incbin "baserom.gba", 0x11025A4, 0x200
+sDustoxSprites8:
+ax_sprite sDustoxGfx8, 0x200
+ax_sprite_terminator
+sDustoxGfx9:
+.incbin "baserom.gba", 0x11027B4, 0x200
+sDustoxSprites9:
+ax_sprite sDustoxGfx9, 0x200
+ax_sprite_terminator
+sDustoxGfx10:
+.incbin "baserom.gba", 0x11029C4, 0x200
+sDustoxSprites10:
+ax_sprite sDustoxGfx10, 0x200
+ax_sprite_terminator
+sDustoxGfx11:
+.incbin "baserom.gba", 0x1102BD4, 0x200
+sDustoxSprites11:
+ax_sprite sDustoxGfx11, 0x200
+ax_sprite_terminator
+sDustoxGfx12:
+.incbin "baserom.gba", 0x1102DE4, 0x200
+sDustoxSprites12:
+ax_sprite sDustoxGfx12, 0x200
+ax_sprite_terminator
+sDustoxGfx13:
+.incbin "baserom.gba", 0x1102FF4, 0x200
+sDustoxSprites13:
+ax_sprite sDustoxGfx13, 0x200
+ax_sprite_terminator
+sDustoxGfx14:
+.incbin "baserom.gba", 0x1103204, 0x200
+sDustoxSprites14:
+ax_sprite sDustoxGfx14, 0x200
+ax_sprite_terminator
+sDustoxGfx15:
+.incbin "baserom.gba", 0x1103414, 0x200
+sDustoxSprites15:
+ax_sprite sDustoxGfx15, 0x200
+ax_sprite_terminator
+sDustoxGfx16:
+.incbin "baserom.gba", 0x1103624, 0x40
+sDustoxGfx16_1:
+.incbin "baserom.gba", 0x1103664, 0x80
+sDustoxGfx16_2:
+.incbin "baserom.gba", 0x11036E4, 0x40
+sDustoxSprites16:
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx16_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDustoxGfx17:
+.incbin "baserom.gba", 0x1103764, 0x100
+sDustoxSprites17:
+ax_sprite 0, 0x80
+ax_sprite sDustoxGfx17, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDustoxGfx18:
+.incbin "baserom.gba", 0x1103884, 0x20
+sDustoxGfx18_1:
+.incbin "baserom.gba", 0x11038A4, 0x100
+sDustoxSprites18:
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sDustoxGfx18_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDustoxGfx19:
+.incbin "baserom.gba", 0x11039D4, 0x60
+sDustoxGfx19_1:
+.incbin "baserom.gba", 0x1103A34, 0x100
+sDustoxSprites19:
+ax_sprite sDustoxGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx19_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDustoxGfx20:
+.incbin "baserom.gba", 0x1103B5C, 0x180
+sDustoxSprites20:
+ax_sprite sDustoxGfx20, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDustoxGfx21:
+.incbin "baserom.gba", 0x1103CF4, 0x40
+sDustoxGfx21_1:
+.incbin "baserom.gba", 0x1103D34, 0x100
+sDustoxSprites21:
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sDustoxGfx22:
+.incbin "baserom.gba", 0x1103E64, 0x60
+sDustoxGfx22_1:
+.incbin "baserom.gba", 0x1103EC4, 0x60
+sDustoxGfx22_2:
+.incbin "baserom.gba", 0x1103F24, 0x60
+sDustoxGfx22_3:
+.incbin "baserom.gba", 0x1103F84, 0x20
+sDustoxSprites22:
+ax_sprite sDustoxGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx22_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sDustoxGfx22_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDustoxGfx23:
+.incbin "baserom.gba", 0x1103FEC, 0x40
+sDustoxGfx23_1:
+.incbin "baserom.gba", 0x110402C, 0x60
+sDustoxGfx23_2:
+.incbin "baserom.gba", 0x110408C, 0x60
+sDustoxGfx23_3:
+.incbin "baserom.gba", 0x11040EC, 0x40
+sDustoxSprites23:
+ax_sprite sDustoxGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sDustoxGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sDustoxGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sDustoxGfx24:
+.incbin "baserom.gba", 0x1104174, 0x60
+sDustoxGfx24_1:
+.incbin "baserom.gba", 0x11041D4, 0x60
+sDustoxGfx24_2:
+.incbin "baserom.gba", 0x1104234, 0x60
+sDustoxSprites24:
+ax_sprite sDustoxGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDustoxGfx25:
+.incbin "baserom.gba", 0x11042CC, 0x100
+sDustoxGfx25_1:
+.incbin "baserom.gba", 0x11043CC, 0x40
+sDustoxSprites25:
+ax_sprite sDustoxGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sDustoxGfx25_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sDustoxGfx26:
+.incbin "baserom.gba", 0x1104434, 0x200
+sDustoxSprites26:
+ax_sprite sDustoxGfx26, 0x200
+ax_sprite_terminator
+sDustoxGfx27:
+.incbin "baserom.gba", 0x1104644, 0x200
+sDustoxSprites27:
+ax_sprite sDustoxGfx27, 0x200
+ax_sprite_terminator
+sDustoxGfx28:
+.incbin "baserom.gba", 0x1104854, 0x200
+sDustoxSprites28:
+ax_sprite sDustoxGfx28, 0x200
+ax_sprite_terminator
+sDustoxGfx29:
+.incbin "baserom.gba", 0x1104A64, 0x200
+sDustoxSprites29:
+ax_sprite sDustoxGfx29, 0x200
+ax_sprite_terminator
+sDustoxGfx30:
+.incbin "baserom.gba", 0x1104C74, 0x200
+sDustoxSprites30:
+ax_sprite sDustoxGfx30, 0x200
+ax_sprite_terminator
+sDustoxGfx31:
+.incbin "baserom.gba", 0x1104E84, 0x200
+sDustoxSprites31:
+ax_sprite sDustoxGfx31, 0x200
+ax_sprite_terminator
+sDustoxGfx32:
+.incbin "baserom.gba", 0x1105094, 0x200
+sDustoxSprites32:
+ax_sprite sDustoxGfx32, 0x200
+ax_sprite_terminator
+sAxPosesDustox:
+.4byte sDustoxPose1
+.4byte sDustoxPose2
+.4byte sDustoxPose3
+.4byte sDustoxPose4
+.4byte sDustoxPose5
+.4byte sDustoxPose6
+.4byte sDustoxPose7
+.4byte sDustoxPose8
+.4byte sDustoxPose9
+.4byte sDustoxPose10
+.4byte sDustoxPose11
+.4byte sDustoxPose12
+.4byte sDustoxPose13
+.4byte sDustoxPose14
+.4byte sDustoxPose15
+.4byte sDustoxPose16
+.4byte sDustoxPose17
+.4byte sDustoxPose18
+.4byte sDustoxPose19
+.4byte sDustoxPose20
+.4byte sDustoxPose21
+.4byte sDustoxPose22
+.4byte sDustoxPose23
+.4byte sDustoxPose24
+.4byte sDustoxPose25
+.4byte sDustoxPose26
+.4byte sDustoxPose27
+.4byte sDustoxPose28
+.4byte sDustoxPose29
+.4byte sDustoxPose30
+.4byte sDustoxPose31
+.4byte sDustoxPose32
+.4byte sDustoxPose33
+.4byte sDustoxPose34
+.4byte sDustoxPose35
+.4byte sDustoxPose36
+.4byte sDustoxPose37
+.4byte sDustoxPose38
+.4byte sDustoxPose39
+.4byte sDustoxPose40
+.4byte sDustoxPose41
+.4byte sDustoxPose42
+.4byte sDustoxPose43
+.4byte sDustoxPose44
+.4byte sDustoxPose45
+.4byte sDustoxPose46
+.4byte sDustoxPose47
+.4byte sDustoxPose48
+.4byte sDustoxPose49
+.4byte sDustoxPose50
+.4byte sDustoxPose51
+.4byte sDustoxPose52
+.4byte sDustoxPose53
+.4byte sDustoxPose54
+.4byte sDustoxPose55
+.4byte sDustoxPose56
+.4byte sDustoxPose57
+.4byte sDustoxPose58
+.4byte sDustoxPose59
+.4byte sDustoxPose60
+.4byte sDustoxPose61
+.4byte sDustoxPose62
+.4byte sDustoxPose63
+.4byte sDustoxPose64
+.4byte sDustoxPose65
+.4byte sDustoxPose66
+.4byte sDustoxPose67
+.4byte sDustoxPose68
+.4byte sDustoxPose69
+.4byte sDustoxPose70
+.4byte sDustoxPose71
+.4byte sDustoxPose72
+.4byte sDustoxPose73
+.4byte sDustoxPose74
+.4byte sDustoxPose75
+.4byte sDustoxPose76
+.4byte sDustoxPose77
+.4byte sDustoxPose78
+.4byte sDustoxPose79
+.4byte sDustoxPose80
+.4byte sDustoxPose81
+.4byte sDustoxPose82
+.4byte sDustoxPose83
+.4byte sDustoxPose84
+.4byte sDustoxPose85
+.4byte sDustoxPose86
+.4byte sDustoxPose87
+.4byte sDustoxPose88
+.4byte sDustoxPose89
+.4byte sDustoxPose90
+.4byte sDustoxPose91
+.4byte sDustoxPose92
+.4byte sDustoxPose93
+.4byte sDustoxPose94
+.4byte sDustoxPose95
+.4byte sDustoxPose96
+.4byte sDustoxPose97
+.4byte sDustoxPose98
+.4byte sDustoxPose99
+.4byte sDustoxPose100
+.4byte sDustoxPose101
+.4byte sDustoxPose102
+.4byte sDustoxPose103
+.4byte sDustoxPose104
+.4byte sDustoxPose105
+.4byte sDustoxPose106
+.4byte sDustoxPose107
+.4byte sDustoxPose108
+.4byte sDustoxPose109
+.4byte sDustoxPose110
+.4byte sDustoxPose111
+.4byte sDustoxPose112
+.4byte sDustoxPose113
+.4byte sDustoxPose114
+.4byte sDustoxPose115
+.4byte sDustoxPose116
+.4byte sDustoxPose117
+.4byte sDustoxPose118
+.4byte sDustoxPose119
+.4byte sDustoxPose120
+.4byte sDustoxPose121
+.4byte sDustoxPose122
+.4byte sDustoxPose123
+.4byte sDustoxPose124
+.4byte sDustoxPose125
+.4byte sDustoxPose126
+.4byte sDustoxPose127
+.4byte sDustoxPose128
+.4byte sDustoxPose129
+.4byte sDustoxPose130
+.4byte sDustoxPose131
+.4byte sDustoxPose132
+.4byte sDustoxPose133
+.4byte sDustoxPose134
+.4byte sDustoxPose135
+.4byte sDustoxPose136
+.4byte sDustoxPose137
+.4byte sDustoxPose138
+.4byte sDustoxPose139
+.4byte sDustoxPose140
+.4byte sDustoxPose141
+.4byte sDustoxPose142
+.4byte sDustoxPose143
+.4byte sDustoxPose144
+.4byte sDustoxPose145
+.4byte sDustoxPose146
+.4byte sDustoxPose147
+.4byte sDustoxPose148
+.4byte sDustoxPose149
+.4byte sDustoxPose150
+.4byte sDustoxPose151
+.4byte sDustoxPose152
+.4byte sDustoxPose153
+.4byte sDustoxPose154
+.4byte sDustoxPose155
+.4byte sDustoxPose156
+.4byte sDustoxPose157
+.4byte sDustoxPose158
+.4byte sDustoxPose159
+.4byte sDustoxPose160
+.4byte sDustoxPose161
+.4byte sDustoxPose162
+.4byte sDustoxPose163
+.4byte sDustoxPose164
+.4byte sDustoxPose165
+.4byte sDustoxPose166
+.4byte sDustoxPose167
+.4byte sDustoxPose168
+.4byte sDustoxPose169
+.4byte sDustoxPose170
+.4byte sDustoxPose171
+.4byte sDustoxPose172
+.4byte sDustoxPose173
+.4byte sDustoxPose174
+.4byte sDustoxPose175
+.4byte sDustoxPose176
+.4byte sDustoxPose177
+.4byte sDustoxPose178
+.4byte sDustoxPose179
+.4byte sDustoxPose180
+.4byte sDustoxPose181
+.4byte sDustoxPose182
+.4byte sDustoxPose183
+.4byte sDustoxPose184
+.4byte sDustoxPose185
+.4byte sDustoxPose186
+.4byte sDustoxPose187
+.4byte sDustoxPose188
+.4byte sDustoxPose189
+.4byte sDustoxPose190
+.4byte sDustoxPose191
+.4byte sDustoxPose192
+.4byte sDustoxPose193
+.4byte sDustoxPose194
+.4byte sDustoxPose195
+.4byte sDustoxPose196
+.4byte sDustoxPose197
+.4byte sDustoxPose198
+.4byte sDustoxPose199
+.4byte sDustoxPose200
+.4byte sDustoxPose201
+.4byte sDustoxPose202
+.4byte sDustoxPose203
+.4byte sDustoxPose204
+.4byte sDustoxPose205
+.4byte sDustoxPose206
+.4byte sDustoxPose207
+.4byte sDustoxPose208
+.4byte sDustoxPose209
+.4byte sDustoxPose210
+.4byte sDustoxPose211
+.4byte sDustoxPose212
+.4byte sDustoxPose213
+.4byte sDustoxPose214
+.4byte sDustoxPose215
+.4byte sDustoxPose216
+.4byte sDustoxPose217
+.4byte sDustoxPose218
+.4byte sDustoxPose219
+.4byte sDustoxPose220
+.4byte sDustoxPose221
+.4byte sDustoxPose222
+.4byte sDustoxPose223
+.4byte sDustoxPose224
+.4byte sDustoxPose225
+.4byte sDustoxPose226
+.4byte sDustoxPose227
+.4byte sDustoxPose228
+.4byte sDustoxPose229
+.4byte sDustoxPose230
+.4byte sDustoxPose231
+.4byte sDustoxPose232
+.4byte sDustoxPose233
+.4byte sDustoxPose234
+.4byte sDustoxPose235
+.4byte sDustoxPose236
+.4byte sDustoxPose237
+.4byte sDustoxPose238
+.4byte sDustoxPose239
+.4byte sDustoxPose240
+.4byte sDustoxPose241
+.4byte sDustoxPose242
+sAxPositionsDustox:
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    3,  -11, 	   2,  -13, 	   3,   -8, 	   0,  -12
+.2byte    4,  -11, 	   3,  -13, 	   4,   -9, 	   1,  -12
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -13, 	   0,  -15
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -13, 	  -1,  -15
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -11, 	  -3,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -4,  -13, 	  -5,   -9, 	  -2,  -12
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -3,   -7, 	   2,   -7, 	  -1,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,   -8, 	   7,   -9, 	   0,   -9, 	   0,  -15
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    3,  -11, 	   2,  -13, 	   3,   -8, 	   0,  -12
+.2byte    4,  -11, 	   3,  -13, 	   4,   -9, 	   1,  -12
+.2byte    2,   -9, 	   1,  -15, 	   0,   -9, 	   0,  -15
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -13, 	   0,  -15
+.2byte    3,  -14, 	  -1,  -14, 	   4,  -11, 	  -1,  -15
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -15, 	  -4,  -15, 	  -1,  -15
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -13, 	  -1,  -15
+.2byte   -4,  -14, 	   0,  -14, 	  -5,  -11, 	   0,  -15
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -11, 	  -3,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -4,  -13, 	  -5,   -9, 	  -2,  -12
+.2byte   -3,   -9, 	  -2,  -15, 	  -1,   -9, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,   -8, 	  -8,   -9, 	  -1,   -9, 	  -1,  -15
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -3,   -7, 	   2,   -7, 	  -1,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,   -8, 	   7,   -9, 	   0,   -9, 	   0,  -15
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    3,  -11, 	   2,  -13, 	   3,   -8, 	   0,  -12
+.2byte    4,  -11, 	   3,  -13, 	   4,   -9, 	   1,  -12
+.2byte    2,   -9, 	   1,  -15, 	   0,   -9, 	   0,  -15
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -13, 	   0,  -15
+.2byte    3,  -14, 	  -1,  -14, 	   4,  -11, 	  -1,  -15
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -15, 	  -4,  -15, 	  -1,  -15
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -13, 	  -1,  -15
+.2byte   -4,  -14, 	   0,  -14, 	  -5,  -11, 	   0,  -15
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -11, 	  -3,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -4,  -13, 	  -5,   -9, 	  -2,  -12
+.2byte   -3,   -9, 	  -2,  -15, 	  -1,   -9, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,   -8, 	  -8,   -9, 	  -1,   -9, 	  -1,  -15
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    3,  -11, 	   2,  -13, 	   3,   -8, 	   0,  -12
+.2byte    4,  -11, 	   3,  -13, 	   4,   -9, 	   1,  -12
+.2byte    4,  -11, 	   2,  -12, 	   3,   -9, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -13, 	   0,  -15
+.2byte    2,  -16, 	   0,  -16, 	   5,  -14, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -17, 	   3,  -14, 	  -4,  -14, 	  -1,  -15
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -13, 	  -1,  -15
+.2byte   -3,  -16, 	  -1,  -16, 	  -6,  -14, 	   0,  -14
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -11, 	  -3,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -4,  -13, 	  -5,   -9, 	  -2,  -12
+.2byte   -5,  -11, 	  -3,  -12, 	  -4,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    3,  -11, 	   2,  -13, 	   3,   -8, 	   0,  -12
+.2byte    4,  -11, 	   3,  -13, 	   4,   -9, 	   1,  -12
+.2byte    4,  -11, 	   2,  -12, 	   3,   -9, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -13, 	   0,  -15
+.2byte    2,  -16, 	   0,  -16, 	   5,  -14, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -17, 	   3,  -14, 	  -4,  -14, 	  -1,  -15
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -13, 	  -1,  -15
+.2byte   -3,  -16, 	  -1,  -16, 	  -6,  -14, 	   0,  -14
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -11, 	  -3,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -4,  -13, 	  -5,   -9, 	  -2,  -12
+.2byte   -5,  -11, 	  -3,  -12, 	  -4,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -5,   -5, 	  -5,   -4, 	   0,   -3, 	   1,   -5
+.2byte   -6,   -4, 	  -5,   -3, 	  -1,   -2, 	   0,   -5
+.2byte    0,  -15, 	  -4,  -13, 	   5,  -13, 	   0,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -2,  -10, 	   0,   -9
+.2byte    2,  -14, 	   4,  -15, 	   3,  -13, 	  -1,   -8
+.2byte    3,  -11, 	   0,  -13, 	   5,  -11, 	  -1,   -9
+.2byte   -2,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,   -8
+.2byte   -4,  -11, 	  -1,  -13, 	  -6,  -11, 	   0,   -9
+.2byte   -3,  -14, 	  -5,  -15, 	  -4,  -13, 	   0,   -8
+.2byte   -1,  -12, 	  -5,  -14, 	   1,  -10, 	  -1,   -9
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    3,  -11, 	   2,  -13, 	   3,   -8, 	   0,  -12
+.2byte    4,  -11, 	   3,  -13, 	   4,   -9, 	   1,  -12
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -13, 	   0,  -15
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -13, 	  -1,  -15
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -11, 	  -3,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -5,  -11, 	  -4,  -13, 	  -5,   -9, 	  -2,  -12
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -1,   -8, 	  -3,   -7, 	   2,   -7, 	  -1,  -11
+.2byte   -6,   -8, 	  -8,   -9, 	  -1,   -9, 	  -1,  -15
+.2byte   -3,   -9, 	  -2,  -15, 	  -1,   -9, 	  -1,  -15
+.2byte   -4,  -14, 	   0,  -14, 	  -5,  -11, 	   0,  -15
+.2byte   -1,  -14, 	   3,  -13, 	  -4,  -13, 	  -1,  -13
+.2byte    3,  -14, 	  -1,  -14, 	   4,  -11, 	  -1,  -15
+.2byte    2,   -9, 	   1,  -15, 	   0,   -9, 	   0,  -15
+.2byte    5,   -8, 	   7,   -9, 	   0,   -9, 	   0,  -15
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    4,  -11, 	   3,  -13, 	   4,   -9, 	   1,  -12
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -13, 	   0,  -15
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -13, 	  -1,  -15
+.2byte   -5,  -11, 	  -4,  -13, 	  -5,   -9, 	  -2,  -12
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -3,   -7, 	   2,   -7, 	  -1,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+.2byte    5,   -8, 	   7,   -9, 	   0,   -9, 	   0,  -15
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    3,  -11, 	   2,  -13, 	   3,   -8, 	   0,  -12
+.2byte    2,   -9, 	   1,  -15, 	   0,   -9, 	   0,  -15
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    3,  -14, 	  -1,  -14, 	   4,  -11, 	  -1,  -15
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -15, 	  -4,  -15, 	  -1,  -15
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -4,  -14, 	   0,  -14, 	  -5,  -11, 	   0,  -15
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -11, 	  -3,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -3,   -9, 	  -2,  -15, 	  -1,   -9, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -6,   -8, 	  -8,   -9, 	  -1,   -9, 	  -1,  -15
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -3,  -11, 	  -3,   -9, 	   2,   -8, 	   2,  -11
+.2byte   -4,  -11, 	  -2,  -12, 	  -3,   -9, 	   1,  -12
+.2byte   -1,  -14, 	   1,  -14, 	  -4,  -12, 	   2,  -12
+.2byte   -1,  -15, 	   3,  -12, 	  -4,  -12, 	  -1,  -13
+.2byte    0,  -14, 	  -2,  -14, 	   3,  -12, 	  -3,  -12
+.2byte    3,  -11, 	   1,  -12, 	   2,   -9, 	  -2,  -12
+.2byte    2,  -11, 	   2,   -9, 	  -3,   -8, 	  -3,  -11
+.2byte   -1,  -11, 	  -4,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -6,  -11, 	  -6,   -9, 	  -1,   -8, 	  -1,  -11
+.2byte   -5,  -11, 	  -4,  -13, 	  -4,   -8, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -16, 	  -4,  -12, 	  -1,  -14
+.2byte   -1,  -16, 	   3,  -13, 	  -4,  -13, 	  -1,  -14
+.2byte    3,  -16, 	  -2,  -16, 	   3,  -12, 	   0,  -14
+.2byte    4,  -11, 	   3,  -13, 	   3,   -8, 	   0,  -12
+.2byte    5,  -11, 	   5,   -9, 	   0,   -8, 	   0,  -11
+sDustoxAnimTable1:
+.4byte sDustoxAnims_1_1
+.4byte sDustoxAnims_1_2
+.4byte sDustoxAnims_1_3
+.4byte sDustoxAnims_1_4
+.4byte sDustoxAnims_1_5
+.4byte sDustoxAnims_1_6
+.4byte sDustoxAnims_1_7
+.4byte sDustoxAnims_1_8
+sDustoxAnimTable2:
+.4byte sDustoxAnims_2_1
+.4byte sDustoxAnims_2_2
+.4byte sDustoxAnims_2_3
+.4byte sDustoxAnims_2_4
+.4byte sDustoxAnims_2_5
+.4byte sDustoxAnims_2_6
+.4byte sDustoxAnims_2_7
+.4byte sDustoxAnims_2_8
+sDustoxAnimTable3:
+.4byte sDustoxAnims_3_1
+.4byte sDustoxAnims_3_2
+.4byte sDustoxAnims_3_3
+.4byte sDustoxAnims_3_4
+.4byte sDustoxAnims_3_5
+.4byte sDustoxAnims_3_6
+.4byte sDustoxAnims_3_7
+.4byte sDustoxAnims_3_8
+sDustoxAnimTable4:
+.4byte sDustoxAnims_4_1
+.4byte sDustoxAnims_4_2
+.4byte sDustoxAnims_4_3
+.4byte sDustoxAnims_4_4
+.4byte sDustoxAnims_4_5
+.4byte sDustoxAnims_4_6
+.4byte sDustoxAnims_4_7
+.4byte sDustoxAnims_4_8
+sDustoxAnimTable5:
+.4byte sDustoxAnims_5_1
+.4byte sDustoxAnims_5_2
+.4byte sDustoxAnims_5_3
+.4byte sDustoxAnims_5_4
+.4byte sDustoxAnims_5_5
+.4byte sDustoxAnims_5_6
+.4byte sDustoxAnims_5_7
+.4byte sDustoxAnims_5_8
+sDustoxAnimTable6:
+.4byte sDustoxAnims_6_1
+.4byte sDustoxAnims_6_1
+.4byte sDustoxAnims_6_1
+.4byte sDustoxAnims_6_1
+.4byte sDustoxAnims_6_1
+.4byte sDustoxAnims_6_1
+.4byte sDustoxAnims_6_1
+.4byte sDustoxAnims_6_1
+sDustoxAnimTable7:
+.4byte sDustoxAnims_7_1
+.4byte sDustoxAnims_7_2
+.4byte sDustoxAnims_7_3
+.4byte sDustoxAnims_7_4
+.4byte sDustoxAnims_7_5
+.4byte sDustoxAnims_7_6
+.4byte sDustoxAnims_7_7
+.4byte sDustoxAnims_7_8
+sDustoxAnimTable8:
+.4byte sDustoxAnims_8_1
+.4byte sDustoxAnims_8_2
+.4byte sDustoxAnims_8_3
+.4byte sDustoxAnims_8_4
+.4byte sDustoxAnims_8_5
+.4byte sDustoxAnims_8_6
+.4byte sDustoxAnims_8_7
+.4byte sDustoxAnims_8_8
+sDustoxAnimTable9:
+.4byte sDustoxAnims_9_1
+.4byte sDustoxAnims_9_2
+.4byte sDustoxAnims_9_3
+.4byte sDustoxAnims_9_4
+.4byte sDustoxAnims_9_5
+.4byte sDustoxAnims_9_6
+.4byte sDustoxAnims_9_7
+.4byte sDustoxAnims_9_8
+sDustoxAnimTable10:
+.4byte sDustoxAnims_10_1
+.4byte sDustoxAnims_10_2
+.4byte sDustoxAnims_10_3
+.4byte sDustoxAnims_10_4
+.4byte sDustoxAnims_10_5
+.4byte sDustoxAnims_10_6
+.4byte sDustoxAnims_10_7
+.4byte sDustoxAnims_10_8
+sDustoxAnimTable11:
+.4byte sDustoxAnims_11_1
+.4byte sDustoxAnims_11_2
+.4byte sDustoxAnims_11_3
+.4byte sDustoxAnims_11_4
+.4byte sDustoxAnims_11_5
+.4byte sDustoxAnims_11_6
+.4byte sDustoxAnims_11_7
+.4byte sDustoxAnims_11_8
+sDustoxAnimTable12:
+.4byte sDustoxAnims_12_1
+.4byte sDustoxAnims_12_2
+.4byte sDustoxAnims_12_3
+.4byte sDustoxAnims_12_4
+.4byte sDustoxAnims_12_5
+.4byte sDustoxAnims_12_6
+.4byte sDustoxAnims_12_7
+.4byte sDustoxAnims_12_8
+sDustoxAnimTable13:
+.4byte sDustoxAnims_13_1
+.4byte sDustoxAnims_13_2
+.4byte sDustoxAnims_13_3
+.4byte sDustoxAnims_13_4
+.4byte sDustoxAnims_13_5
+.4byte sDustoxAnims_13_6
+.4byte sDustoxAnims_13_7
+.4byte sDustoxAnims_13_8
+sAxAnimationsDustox:
+.4byte sDustoxAnimTable1
+.4byte sDustoxAnimTable2
+.4byte sDustoxAnimTable3
+.4byte sDustoxAnimTable4
+.4byte sDustoxAnimTable5
+.4byte sDustoxAnimTable6
+.4byte sDustoxAnimTable7
+.4byte sDustoxAnimTable8
+.4byte sDustoxAnimTable9
+.4byte sDustoxAnimTable10
+.4byte sDustoxAnimTable11
+.4byte sDustoxAnimTable12
+.4byte sDustoxAnimTable13
+sAxSpritesDustox:
+.4byte sDustoxSprites1
+.4byte sDustoxSprites2
+.4byte sDustoxSprites3
+.4byte sDustoxSprites4
+.4byte sDustoxSprites5
+.4byte sDustoxSprites6
+.4byte sDustoxSprites7
+.4byte sDustoxSprites8
+.4byte sDustoxSprites9
+.4byte sDustoxSprites10
+.4byte sDustoxSprites11
+.4byte sDustoxSprites12
+.4byte sDustoxSprites13
+.4byte sDustoxSprites14
+.4byte sDustoxSprites15
+.4byte sDustoxSprites16
+.4byte sDustoxSprites17
+.4byte sDustoxSprites18
+.4byte sDustoxSprites19
+.4byte sDustoxSprites20
+.4byte sDustoxSprites21
+.4byte sDustoxSprites22
+.4byte sDustoxSprites23
+.4byte sDustoxSprites24
+.4byte sDustoxSprites25
+.4byte sDustoxSprites26
+.4byte sDustoxSprites27
+.4byte sDustoxSprites28
+.4byte sDustoxSprites29
+.4byte sDustoxSprites30
+.4byte sDustoxSprites31
+.4byte sDustoxSprites32
+sAxMainDustox:
+ax_main sAxPosesDustox, sAxAnimationsDustox, 13, sAxSpritesDustox, sAxPositionsDustox

--- a/data/ax/eevee.inc
+++ b/data/ax/eevee.inc
@@ -1,0 +1,4028 @@
+.global gAxEevee
+gAxEevee:
+ax_siro sAxMainEevee
+sEeveePose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose4:
+ax_pose 3, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sEeveePose5:
+ax_pose 4, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose6:
+ax_pose 5, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose7:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose8:
+ax_pose 7, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose9:
+ax_pose 8, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose10:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose11:
+ax_pose 10, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose12:
+ax_pose 11, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sEeveePose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose16:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose17:
+ax_pose 10, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose18:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sEeveePose19:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose20:
+ax_pose 7, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose21:
+ax_pose 8, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose22:
+ax_pose 3, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sEeveePose23:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose24:
+ax_pose 5, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose25:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose26:
+ax_pose 1, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose27:
+ax_pose 2, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose28:
+ax_pose 3, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sEeveePose29:
+ax_pose 4, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose30:
+ax_pose 5, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose31:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose32:
+ax_pose 7, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose33:
+ax_pose 8, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose34:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose35:
+ax_pose 10, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose36:
+ax_pose 11, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose37:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose38:
+ax_pose 13, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose39:
+ax_pose 14, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose40:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose41:
+ax_pose 10, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose42:
+ax_pose 11, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose43:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose44:
+ax_pose 7, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose45:
+ax_pose 8, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose46:
+ax_pose 3, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sEeveePose47:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose48:
+ax_pose 5, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose49:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose50:
+ax_pose 1, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose51:
+ax_pose 2, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose52:
+ax_pose 3, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sEeveePose53:
+ax_pose 4, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose54:
+ax_pose 5, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose55:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose56:
+ax_pose 7, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose57:
+ax_pose 8, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose58:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose59:
+ax_pose 10, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose60:
+ax_pose 11, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose61:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose62:
+ax_pose 13, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose63:
+ax_pose 14, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose64:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose65:
+ax_pose 10, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose66:
+ax_pose 11, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose67:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose68:
+ax_pose 7, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose69:
+ax_pose 8, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose70:
+ax_pose 3, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sEeveePose71:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose72:
+ax_pose 5, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose73:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose74:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose75:
+ax_pose 2, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose76:
+ax_pose 17, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose77:
+ax_pose 18, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose78:
+ax_pose 5, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose79:
+ax_pose 19, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose80:
+ax_pose 20, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose81:
+ax_pose 6, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose82:
+ax_pose 21, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose83:
+ax_pose 22, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose84:
+ax_pose 10, 0x01f0, 0x90ea, 0x4c00
+ax_pose_terminator
+sEeveePose85:
+ax_pose 23, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose86:
+ax_pose 24, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose87:
+ax_pose 13, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose88:
+ax_pose 21, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose89:
+ax_pose 22, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose90:
+ax_pose 10, 0x01f0, 0x80f6, 0x4c00
+ax_pose_terminator
+sEeveePose91:
+ax_pose 19, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose92:
+ax_pose 20, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose93:
+ax_pose 6, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sEeveePose94:
+ax_pose 17, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose95:
+ax_pose 18, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose96:
+ax_pose 5, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose97:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose98:
+ax_pose 25, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose99:
+ax_pose 26, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose100:
+ax_pose 3, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose101:
+ax_pose 27, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose102:
+ax_pose 28, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose103:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose104:
+ax_pose 29, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose105:
+ax_pose 30, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose106:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose107:
+ax_pose 31, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose108:
+ax_pose 32, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose109:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose110:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose111:
+ax_pose 34, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose112:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose113:
+ax_pose 31, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose114:
+ax_pose 32, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose115:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose116:
+ax_pose 29, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose117:
+ax_pose 30, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose118:
+ax_pose 3, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose119:
+ax_pose 27, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose120:
+ax_pose 28, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose121:
+ax_pose 35, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose122:
+ax_pose 36, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose123:
+ax_pose 37, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose124:
+ax_pose 38, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sEeveePose125:
+ax_pose 39, 0x01e9, 0x90ee, 0x4c00
+ax_pose_terminator
+sEeveePose126:
+ax_pose 40, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sEeveePose127:
+ax_pose 41, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose128:
+ax_pose 40, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sEeveePose129:
+ax_pose 39, 0x01e9, 0x80f2, 0x4c00
+ax_pose_terminator
+sEeveePose130:
+ax_pose 38, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sEeveePose131:
+ax_pose 25, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose132:
+ax_pose 26, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose133:
+ax_pose 27, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose134:
+ax_pose 28, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose135:
+ax_pose 29, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose136:
+ax_pose 30, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose137:
+ax_pose 31, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose138:
+ax_pose 32, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose139:
+ax_pose 33, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose140:
+ax_pose 34, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose141:
+ax_pose 31, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose142:
+ax_pose 32, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose143:
+ax_pose 29, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose144:
+ax_pose 30, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose145:
+ax_pose 27, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose146:
+ax_pose 28, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose147:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose148:
+ax_pose 3, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose149:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose150:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose151:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose152:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose153:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose154:
+ax_pose 3, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose155:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose156:
+ax_pose 3, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose157:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose158:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose159:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose160:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose161:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose162:
+ax_pose 3, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose163:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose164:
+ax_pose 1, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose165:
+ax_pose 2, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose166:
+ax_pose 3, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sEeveePose167:
+ax_pose 4, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose168:
+ax_pose 5, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose169:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose170:
+ax_pose 7, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose171:
+ax_pose 8, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose172:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose173:
+ax_pose 10, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose174:
+ax_pose 11, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose175:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose176:
+ax_pose 13, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose177:
+ax_pose 14, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose178:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose179:
+ax_pose 10, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose180:
+ax_pose 11, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose181:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose182:
+ax_pose 7, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose183:
+ax_pose 8, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose184:
+ax_pose 3, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sEeveePose185:
+ax_pose 4, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose186:
+ax_pose 5, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose187:
+ax_pose 15, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose188:
+ax_pose 16, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose189:
+ax_pose 17, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose190:
+ax_pose 18, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose191:
+ax_pose 19, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose192:
+ax_pose 20, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose193:
+ax_pose 21, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose194:
+ax_pose 22, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose195:
+ax_pose 23, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose196:
+ax_pose 24, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose197:
+ax_pose 21, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose198:
+ax_pose 22, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose199:
+ax_pose 19, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose200:
+ax_pose 20, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose201:
+ax_pose 17, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose202:
+ax_pose 18, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose203:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose204:
+ax_pose 3, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose205:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose206:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose207:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose208:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose209:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose210:
+ax_pose 3, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sEeveePose211:
+ax_pose 42, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose212:
+ax_pose 43, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose213:
+ax_pose 42, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sEeveePose214:
+ax_pose 43, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sEeveePose215:
+ax_pose 42, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose216:
+ax_pose 44, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose217:
+ax_pose 45, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose218:
+ax_pose 46, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose219:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose220:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose221:
+ax_pose 47, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose222:
+ax_pose 48, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose223:
+ax_pose 49, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose224:
+ax_pose 50, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose225:
+ax_pose 49, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose226:
+ax_pose 50, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose227:
+ax_pose 51, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose228:
+ax_pose 52, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose229:
+ax_pose 53, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sEeveePose230:
+ax_pose 54, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose231:
+ax_pose 55, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose232:
+ax_pose 56, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose233:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose234:
+ax_pose 57, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose235:
+ax_pose 58, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose236:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose237:
+ax_pose 59, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose238:
+ax_pose 60, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose239:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose240:
+ax_pose 61, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose241:
+ax_pose 62, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose242:
+ax_pose 6, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose243:
+ax_pose 63, 0x01e9, 0x80ee, 0x4c00
+ax_pose_terminator
+sEeveePose244:
+ax_pose 6, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sEeveePose245:
+ax_pose 63, 0x01e9, 0x90f2, 0x4c00
+ax_pose_terminator
+sEeveePose246:
+ax_pose 12, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose247:
+ax_pose 64, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sEeveePose248:
+ax_pose 65, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sEeveePose249:
+ax_pose 66, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sEeveePose250:
+ax_pose 67, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sEeveePose251:
+ax_pose 68, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sEeveePose252:
+ax_pose 69, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sEeveePose253:
+ax_pose 65, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sEeveePose254:
+ax_pose 66, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sEeveePose255:
+ax_pose 67, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sEeveePose256:
+ax_pose 68, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sEeveePose257:
+ax_pose 69, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sEeveePose258:
+ax_pose 70, 0x81eb, 0x90f9, 0x4c00
+ax_pose_terminator
+sEeveePose259:
+ax_pose 42, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose260:
+ax_pose 43, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose261:
+ax_pose 42, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sEeveePose262:
+ax_pose 43, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sEeveePose263:
+ax_pose 42, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose264:
+ax_pose 43, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sEeveePose265:
+ax_pose 42, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sEeveePose266:
+ax_pose 43, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+.align 2
+sEeveeAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 1,
+ax_anim 4, 0, 1, 0, 2, 0, 2,
+ax_anim 4, 0, 2, 0, -4, 0, 3,
+ax_anim 6, 0, 2, 0, -1, 0, 4,
+ax_anim 2, 0, 0, 0, 5, 0, 5,
+ax_anim 2, 0, 0, 0, 2, 0, 1,
+ax_anim_terminator
+sEeveeAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 2, 2, 2, 2,
+ax_anim 4, 0, 4, 3, 1, 3, 3,
+ax_anim 4, 0, 5, 5, 0, 4, 4,
+ax_anim 6, 0, 5, 5, 3, 4, 4,
+ax_anim 2, 0, 3, 4, 4, 3, 3,
+ax_anim 2, 0, 3, 2, 2, 1, 1,
+ax_anim_terminator
+sEeveeAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 1, 1, 1, 0,
+ax_anim 4, 0, 7, 2, -1, 2, 0,
+ax_anim 4, 0, 8, 2, -5, 2, 0,
+ax_anim 6, 0, 8, 3, -3, 3, 0,
+ax_anim 2, 0, 6, 4, 0, 4, 0,
+ax_anim 2, 0, 6, 2, 0, 2, 0,
+ax_anim_terminator
+sEeveeAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, -1, -1, 1, -1,
+ax_anim 4, 0, 10, 0, -3, 3, -3,
+ax_anim 4, 0, 11, 0, -6, 4, -4,
+ax_anim 6, 0, 11, 1, -5, 5, -5,
+ax_anim 2, 0, 9, 5, -5, 6, -6,
+ax_anim 2, 0, 9, 2, -2, 3, -3,
+ax_anim_terminator
+sEeveeAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 2, 0, -2,
+ax_anim 4, 0, 13, 0, -1, 0, -4,
+ax_anim 4, 0, 14, 0, -8, 0, -6,
+ax_anim 6, 0, 14, 0, -5, 0, -5,
+ax_anim 2, 0, 12, 0, -2, 0, -3,
+ax_anim 2, 0, 12, 0, -1, 0, -1,
+ax_anim_terminator
+sEeveeAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 1, -1, -1, -1,
+ax_anim 4, 0, 16, 0, -3, -3, -3,
+ax_anim 4, 0, 17, 0, -6, -4, -4,
+ax_anim 6, 0, 17, -1, -5, -5, -5,
+ax_anim 2, 0, 15, -5, -5, -6, -6,
+ax_anim 2, 0, 15, -2, -2, -3, -3,
+ax_anim_terminator
+sEeveeAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -1, 1, -1, 0,
+ax_anim 4, 0, 19, -2, -1, -2, 0,
+ax_anim 4, 0, 20, -2, -5, -2, 0,
+ax_anim 6, 0, 20, -3, -3, -3, 0,
+ax_anim 2, 0, 18, -4, 0, -4, 0,
+ax_anim 2, 0, 18, -2, 0, -2, 0,
+ax_anim_terminator
+sEeveeAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -2, 2, -2, 2,
+ax_anim 4, 0, 22, -3, 1, -3, 3,
+ax_anim 4, 0, 23, -5, 0, -4, 4,
+ax_anim 6, 0, 23, -5, 3, -4, 4,
+ax_anim 2, 0, 21, -4, 4, -3, 3,
+ax_anim 2, 0, 21, -2, 2, -1, 1,
+ax_anim_terminator
+.align 2
+sEeveeAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 1, 0, 1,
+ax_anim 2, 0, 25, 0, 3, 0, 3,
+ax_anim 2, 2, 26, 0, 5, 0, 5,
+ax_anim 2, 0, 26, 0, 16, 0, 12,
+ax_anim 2, 1, 26, -1, 16, -1, 12,
+ax_anim 2, 0, 26, 0, 16, 0, 12,
+ax_anim 2, 0, 26, -1, 16, -1, 12,
+ax_anim 4, 0, 25, 0, 6, 0, 6,
+ax_anim 4, 0, 25, 0, -2, 0, 0,
+ax_anim 4, 0, 25, 0, -1, 0, 0,
+ax_anim_terminator
+sEeveeAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 2, 0, 2, 2,
+ax_anim 2, 0, 28, 4, 0, 4, 4,
+ax_anim 2, 2, 29, 6, 3, 6, 6,
+ax_anim 2, 0, 29, 16, 18, 16, 16,
+ax_anim 2, 1, 29, 15, 19, 15, 17,
+ax_anim 2, 0, 29, 16, 18, 16, 16,
+ax_anim 2, 0, 29, 15, 19, 15, 17,
+ax_anim 4, 0, 28, 10, 6, 10, 10,
+ax_anim 4, 0, 28, 3, -2, 3, 3,
+ax_anim 4, 0, 28, 1, -1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 2, 1, 2, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 6, -3, 6, 0,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 1, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 16, 1, 16, 1,
+ax_anim 4, 0, 31, 10, -1, 10, 0,
+ax_anim 4, 0, 31, 3, 0, 3, 0,
+ax_anim 4, 0, 31, 1, 1, 1, 0,
+ax_anim_terminator
+sEeveeAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 2, -4, 2, -2,
+ax_anim 2, 0, 34, 4, -9, 4, -4,
+ax_anim 2, 2, 35, 7, -16, 7, -7,
+ax_anim 2, 0, 35, 14, -17, 16, -16,
+ax_anim 2, 1, 35, 15, -16, 17, -15,
+ax_anim 2, 0, 35, 14, -17, 16, -16,
+ax_anim 2, 0, 35, 15, -16, 17, -15,
+ax_anim 4, 0, 34, 7, -9, 7, -7,
+ax_anim 4, 0, 34, 0, -2, 1, -1,
+ax_anim 4, 0, 34, -1, 1, 0, 0,
+ax_anim_terminator
+sEeveeAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, -1,
+ax_anim 2, 0, 37, 0, -3, 0, -3,
+ax_anim 2, 2, 38, 0, -16, 0, -10,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 1, 38, -1, -22, -1, -22,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 0, 38, -1, -22, -1, -22,
+ax_anim 4, 0, 37, 0, -6, 0, -6,
+ax_anim 4, 0, 37, 0, 3, 0, 0,
+ax_anim 4, 0, 37, 0, 4, 0, 0,
+ax_anim_terminator
+sEeveeAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, -2, -4, -2, -2,
+ax_anim 2, 0, 40, -4, -9, -4, -4,
+ax_anim 2, 2, 41, -7, -16, -7, -7,
+ax_anim 2, 0, 41, -14, -17, -16, -16,
+ax_anim 2, 1, 41, -15, -16, -17, -15,
+ax_anim 2, 0, 41, -14, -17, -16, -16,
+ax_anim 2, 0, 41, -15, -16, -17, -15,
+ax_anim 4, 0, 40, -7, -9, -7, -7,
+ax_anim 4, 0, 40, 0, -2, -1, -1,
+ax_anim 4, 0, 40, 1, 1, 0, 0,
+ax_anim_terminator
+sEeveeAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -2, 1, -2, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -6, -3, -6, 0,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 1, 44, -16, 1, -16, 1,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 0, 44, -16, 1, -16, 1,
+ax_anim 4, 0, 43, -10, -1, -10, 0,
+ax_anim 4, 0, 43, -3, 0, -3, 0,
+ax_anim 4, 0, 43, -1, 1, -1, 0,
+ax_anim_terminator
+sEeveeAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, -2, 0, -2, 2,
+ax_anim 2, 0, 46, -4, 0, -4, 4,
+ax_anim 2, 2, 47, -6, 3, -6, 6,
+ax_anim 2, 0, 47, -16, 18, -16, 16,
+ax_anim 2, 1, 47, -15, 19, -15, 17,
+ax_anim 2, 0, 47, -16, 18, -16, 16,
+ax_anim 2, 0, 47, -15, 19, -15, 17,
+ax_anim 4, 0, 46, -10, 6, -10, 10,
+ax_anim 4, 0, 46, -3, -2, -3, 3,
+ax_anim 4, 0, 46, -1, -1, -1, 1,
+ax_anim_terminator
+.align 2
+sEeveeAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 1, 0, 1,
+ax_anim 2, 0, 49, 0, 3, 0, 3,
+ax_anim 2, 2, 50, 0, 5, 0, 5,
+ax_anim 2, 0, 50, 0, 16, 0, 12,
+ax_anim 2, 1, 50, -1, 16, -1, 12,
+ax_anim 2, 0, 50, 0, 16, 0, 12,
+ax_anim 2, 0, 50, -1, 16, -1, 12,
+ax_anim 4, 0, 49, 0, 6, 0, 6,
+ax_anim 4, 0, 49, 0, -2, 0, 0,
+ax_anim 4, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sEeveeAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 2, 0, 2, 2,
+ax_anim 2, 0, 52, 4, 0, 4, 4,
+ax_anim 2, 2, 53, 6, 3, 6, 6,
+ax_anim 2, 0, 53, 16, 18, 16, 16,
+ax_anim 2, 1, 53, 15, 19, 15, 17,
+ax_anim 2, 0, 53, 16, 18, 16, 16,
+ax_anim 2, 0, 53, 15, 19, 15, 17,
+ax_anim 4, 0, 52, 10, 6, 10, 10,
+ax_anim 4, 0, 52, 3, -2, 3, 3,
+ax_anim 4, 0, 52, 1, -1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 2, 1, 2, 0,
+ax_anim 2, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 6, -3, 6, 0,
+ax_anim 2, 0, 56, 16, 0, 16, 0,
+ax_anim 2, 1, 56, 16, 1, 16, 1,
+ax_anim 2, 0, 56, 16, 0, 16, 0,
+ax_anim 2, 0, 56, 16, 1, 16, 1,
+ax_anim 4, 0, 55, 10, -1, 10, 0,
+ax_anim 4, 0, 55, 3, 0, 3, 0,
+ax_anim 4, 0, 55, 1, 1, 1, 0,
+ax_anim_terminator
+sEeveeAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 2, -4, 2, -2,
+ax_anim 2, 0, 58, 4, -9, 4, -4,
+ax_anim 2, 2, 59, 7, -16, 7, -7,
+ax_anim 2, 0, 59, 14, -17, 16, -16,
+ax_anim 2, 1, 59, 15, -16, 17, -15,
+ax_anim 2, 0, 59, 14, -17, 16, -16,
+ax_anim 2, 0, 59, 15, -16, 17, -15,
+ax_anim 4, 0, 58, 7, -9, 7, -7,
+ax_anim 4, 0, 58, 0, -2, 1, -1,
+ax_anim 4, 0, 58, -1, 1, 0, 0,
+ax_anim_terminator
+sEeveeAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, -1,
+ax_anim 2, 0, 61, 0, -3, 0, -3,
+ax_anim 2, 2, 62, 0, -16, 0, -10,
+ax_anim 2, 0, 62, 0, -22, 0, -22,
+ax_anim 2, 1, 62, -1, -22, -1, -22,
+ax_anim 2, 0, 62, 0, -22, 0, -22,
+ax_anim 2, 0, 62, -1, -22, -1, -22,
+ax_anim 4, 0, 61, 0, -6, 0, -6,
+ax_anim 4, 0, 61, 0, 3, 0, 0,
+ax_anim 4, 0, 61, 0, 4, 0, 0,
+ax_anim_terminator
+sEeveeAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -2, -4, -2, -2,
+ax_anim 2, 0, 64, -4, -9, -4, -4,
+ax_anim 2, 2, 65, -7, -16, -7, -7,
+ax_anim 2, 0, 65, -14, -17, -16, -16,
+ax_anim 2, 1, 65, -15, -16, -17, -15,
+ax_anim 2, 0, 65, -14, -17, -16, -16,
+ax_anim 2, 0, 65, -15, -16, -17, -15,
+ax_anim 4, 0, 64, -7, -9, -7, -7,
+ax_anim 4, 0, 64, 0, -2, -1, -1,
+ax_anim 4, 0, 64, 1, 1, 0, 0,
+ax_anim_terminator
+sEeveeAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -2, 1, -2, 0,
+ax_anim 2, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -6, -3, -6, 0,
+ax_anim 2, 0, 68, -16, 0, -16, 0,
+ax_anim 2, 1, 68, -16, 1, -16, 1,
+ax_anim 2, 0, 68, -16, 0, -16, 0,
+ax_anim 2, 0, 68, -16, 1, -16, 1,
+ax_anim 4, 0, 67, -10, -1, -10, 0,
+ax_anim 4, 0, 67, -3, 0, -3, 0,
+ax_anim 4, 0, 67, -1, 1, -1, 0,
+ax_anim_terminator
+sEeveeAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, -2, 0, -2, 2,
+ax_anim 2, 0, 70, -4, 0, -4, 4,
+ax_anim 2, 2, 71, -6, 3, -6, 6,
+ax_anim 2, 0, 71, -16, 18, -16, 16,
+ax_anim 2, 1, 71, -15, 19, -15, 17,
+ax_anim 2, 0, 71, -16, 18, -16, 16,
+ax_anim 2, 0, 71, -15, 19, -15, 17,
+ax_anim 4, 0, 70, -10, 6, -10, 10,
+ax_anim 4, 0, 70, -3, -2, -3, 3,
+ax_anim 4, 0, 70, -1, -1, -1, 1,
+ax_anim_terminator
+.align 2
+sEeveeAnims_4_1:
+ax_anim 4, 0, 74, 0, -1, 0, -1,
+ax_anim 6, 0, 74, 0, -2, 0, -2,
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 0, 1, 0, 0,
+ax_anim 4, 0, 72, 0, 1, 0, 0,
+ax_anim 4, 1, 73, 0, 1, 0, 0,
+ax_anim 4, 0, 72, 0, 1, 0, 0,
+ax_anim 4, 0, 73, 0, 1, 0, 0,
+ax_anim_terminator
+sEeveeAnims_4_2:
+ax_anim 4, 0, 77, -1, -1, -1, -1,
+ax_anim 6, 0, 77, -2, -2, -2, -2,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 75, 1, 1, 1, 1,
+ax_anim 4, 1, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 75, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_4_3:
+ax_anim 4, 0, 80, -1, 0, -1, 0,
+ax_anim 6, 0, 80, -2, 0, -2, 0,
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 79, 1, 0, 1, 0,
+ax_anim 4, 0, 78, 1, 0, 1, 0,
+ax_anim 4, 1, 79, 1, 0, 1, 0,
+ax_anim 4, 0, 78, 1, 0, 1, 0,
+ax_anim 4, 0, 79, 1, 0, 1, 0,
+ax_anim_terminator
+sEeveeAnims_4_4:
+ax_anim 4, 0, 83, -1, 1, -1, 1,
+ax_anim 6, 0, 83, -2, 2, -2, 2,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 82, 1, -1, 1, -1,
+ax_anim 4, 0, 81, 1, -1, 1, -1,
+ax_anim 4, 1, 82, 1, -1, 1, -1,
+ax_anim 4, 0, 81, 1, -1, 1, -1,
+ax_anim 4, 0, 82, 1, -1, 1, -1,
+ax_anim_terminator
+sEeveeAnims_4_5:
+ax_anim 4, 0, 86, 0, 1, 0, 0,
+ax_anim 6, 0, 86, 0, 2, 0, 1,
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 85, 0, -1, 0, -1,
+ax_anim 4, 0, 84, 0, -1, 0, -1,
+ax_anim 4, 1, 85, 0, -1, 0, -1,
+ax_anim 4, 0, 84, 0, -1, 0, -1,
+ax_anim 4, 0, 85, 0, -1, 0, -1,
+ax_anim_terminator
+sEeveeAnims_4_6:
+ax_anim 4, 0, 89, 1, 1, 1, 1,
+ax_anim 6, 0, 89, 2, 2, 2, 2,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 88, -1, -1, -1, -1,
+ax_anim 4, 0, 87, -1, -1, -1, -1,
+ax_anim 4, 1, 88, -1, -1, -1, -1,
+ax_anim 4, 0, 87, -1, -1, -1, -1,
+ax_anim 4, 0, 88, -1, -1, -1, -1,
+ax_anim_terminator
+sEeveeAnims_4_7:
+ax_anim 4, 0, 92, 1, 0, 1, 0,
+ax_anim 6, 0, 92, 2, 0, 2, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, -1, 0, -1, 0,
+ax_anim 4, 0, 90, -1, 0, -1, 0,
+ax_anim 4, 1, 91, -1, 0, -1, 0,
+ax_anim 4, 0, 90, -1, 0, -1, 0,
+ax_anim 4, 0, 91, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_4_8:
+ax_anim 4, 0, 95, 1, -1, 1, -1,
+ax_anim 6, 0, 95, 2, -2, 2, -2,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, -1, 1, -1, 1,
+ax_anim 4, 0, 93, -1, 1, -1, 1,
+ax_anim 4, 1, 94, -1, 1, -1, 1,
+ax_anim 4, 0, 93, -1, 1, -1, 1,
+ax_anim 4, 0, 94, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sEeveeAnims_5_1:
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 2, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_5_2:
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 2, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_5_3:
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 2, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_5_4:
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 2, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_5_5:
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 6, 2, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_5_6:
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 2, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_5_7:
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 2, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_5_8:
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 2, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_7_1:
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 8, 0, 122, 0, -4, 0, -4,
+ax_anim_terminator
+sEeveeAnims_7_2:
+ax_anim 2, 0, 123, -3, -3, -3, -3,
+ax_anim 8, 0, 123, -4, -4, -4, -4,
+ax_anim_terminator
+sEeveeAnims_7_3:
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 8, 0, 124, -4, 0, -4, 0,
+ax_anim_terminator
+sEeveeAnims_7_4:
+ax_anim 2, 0, 125, -3, 3, -3, 3,
+ax_anim 8, 0, 125, -4, 4, -4, 4,
+ax_anim_terminator
+sEeveeAnims_7_5:
+ax_anim 2, 0, 126, 0, 3, 0, 3,
+ax_anim 8, 0, 126, 0, 4, 0, 4,
+ax_anim_terminator
+sEeveeAnims_7_6:
+ax_anim 2, 0, 127, 3, 3, 3, 3,
+ax_anim 8, 0, 127, 4, 4, 4, 4,
+ax_anim_terminator
+sEeveeAnims_7_7:
+ax_anim 2, 0, 128, 3, 0, 3, 0,
+ax_anim 8, 0, 128, 4, 0, 4, 0,
+ax_anim_terminator
+sEeveeAnims_7_8:
+ax_anim 2, 0, 129, 3, -3, 3, -3,
+ax_anim 8, 0, 129, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sEeveeAnims_8_1:
+ax_anim 16, 0, 130, 0, 0, 0, 0,
+ax_anim 16, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_8_2:
+ax_anim 16, 0, 132, 0, 0, 0, 0,
+ax_anim 16, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_8_3:
+ax_anim 16, 0, 134, 0, 0, 0, 0,
+ax_anim 16, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_8_4:
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 16, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_8_5:
+ax_anim 16, 0, 138, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_8_6:
+ax_anim 16, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_8_7:
+ax_anim 16, 0, 142, 0, 0, 0, 0,
+ax_anim 16, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_8_8:
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 9, 11, 9, 11,
+ax_anim 2, 0, 149, 8, 18, 8, 18,
+ax_anim 3, 0, 150, 1, 21, 1, 21,
+ax_anim 2, 3, 151, -5, 19, -5, 19,
+ax_anim 2, 0, 152, -6, 10, -6, 10,
+ax_anim 1, 0, 153, -4, 4, -4, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 26, 9, 26, 9,
+ax_anim 3, 0, 149, 27, 20, 27, 20,
+ax_anim 2, 3, 150, 14, 22, 14, 22,
+ax_anim 2, 0, 151, 4, 12, 4, 12,
+ax_anim 1, 0, 152, 1, 7, 1, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 19, -4, 19, -4,
+ax_anim 3, 0, 148, 23, 1, 23, 1,
+ax_anim 2, 3, 149, 19, 5, 19, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 1, -6, 1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -20, 11, -20,
+ax_anim 3, 0, 147, 20, -20, 20, -20,
+ax_anim 2, 3, 148, 18, -12, 18, -12,
+ax_anim 2, 0, 149, 14, -6, 14, -6,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -9, -8, -9,
+ax_anim 2, 0, 153, -7, -15, -7, -15,
+ax_anim 3, 0, 146, -1, -20, -1, -20,
+ax_anim 2, 3, 147, 4, -16, 4, -16,
+ax_anim 2, 0, 148, 5, -8, 5, -8,
+ax_anim 1, 0, 149, 4, -4, 4, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, -1, -6, -1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -11, -20, -11, -20,
+ax_anim 3, 0, 153, -20, -20, -20, -20,
+ax_anim 2, 3, 152, -18, -12, -18, -12,
+ax_anim 2, 0, 151, -14, -6, -14, -6,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -19, -4, -19, -4,
+ax_anim 3, 0, 152, -23, 1, -23, 1,
+ax_anim 2, 3, 151, -19, 5, -19, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -26, 9, -26, 9,
+ax_anim 3, 0, 151, -27, 20, -27, 20,
+ax_anim 2, 3, 150, -14, 22, -14, 22,
+ax_anim 2, 0, 149, -4, 12, -4, 12,
+ax_anim 1, 0, 148, -1, 7, -1, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_12_1:
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_12_2:
+ax_anim 2, 0, 189, 1, -1, 1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, 0,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_12_3:
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_12_4:
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_12_5:
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_12_7:
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_12_8:
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_14_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_14_2:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_14_3:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_14_4:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_14_5:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_14_6:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_14_7:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_14_8:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_15_1:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_15_2:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_15_3:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_15_4:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_15_5:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_15_6:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_15_7:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_15_8:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 14, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_16_1:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_16_2:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_16_3:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_16_4:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_16_5:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_16_6:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_16_7:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_16_8:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_17_1:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_17_2:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_17_3:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_17_4:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_17_5:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_17_6:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_17_7:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sEeveeAnims_17_8:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_18_1:
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_18_2:
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_18_3:
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_18_4:
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_18_5:
+ax_anim 12, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_18_6:
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_18_7:
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_18_8:
+ax_anim 12, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_19_1:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_19_2:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_19_3:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_19_4:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_19_5:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_19_6:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_19_7:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_19_8:
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_20_1:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -1, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 1, 0, 0,
+ax_anim 2, 0, 234, 1, 1, 1, 0,
+ax_anim 2, 0, 234, 0, 1, 0, 0,
+ax_anim 2, 0, 234, 1, 1, 1, 0,
+ax_anim 2, 0, 234, 0, 1, 0, 0,
+ax_anim 2, 0, 234, 1, 1, 1, 0,
+ax_anim_terminator
+sEeveeAnims_20_2:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim_terminator
+sEeveeAnims_20_3:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim_terminator
+sEeveeAnims_20_4:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim_terminator
+sEeveeAnims_20_5:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim_terminator
+sEeveeAnims_20_6:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim_terminator
+sEeveeAnims_20_7:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim_terminator
+sEeveeAnims_20_8:
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 1, 0, 233, 0, -4, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_21_1:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_21_2:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_21_3:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_21_4:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_21_5:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_21_6:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_21_7:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_21_8:
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_22_1:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_22_2:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_22_3:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_22_4:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_22_5:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_22_6:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_22_7:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_22_8:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 34, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_23_1:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_23_2:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_23_3:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_23_4:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_23_5:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_23_6:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_23_7:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_23_8:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_24_1:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_24_2:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_24_3:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_24_4:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_24_5:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_24_6:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_24_7:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_24_8:
+ax_anim 4, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_25_1:
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_25_2:
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_25_3:
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_25_4:
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_25_5:
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_25_6:
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_25_7:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_25_8:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim 8, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_26_1:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_26_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_26_3:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_26_4:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_26_5:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_26_6:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_26_7:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+sEeveeAnims_26_8:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sEeveeAnims_27_1:
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim 16, 0, 258, -1, 0, 0, 0,
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim 12, 0, 258, 1, 0, 0, 0,
+ax_anim 16, 0, 258, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEeveeAnims_28_1:
+ax_anim 12, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_28_2:
+ax_anim 12, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_28_3:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_28_4:
+ax_anim 12, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_28_5:
+ax_anim 12, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_28_6:
+ax_anim 12, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_28_7:
+ax_anim 12, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeAnims_28_8:
+ax_anim 12, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sEeveeGfx1:
+.incbin "baserom.gba", 0xAC1E10, 0x200
+sEeveeSprites1:
+ax_sprite sEeveeGfx1, 0x200
+ax_sprite_terminator
+sEeveeGfx2:
+.incbin "baserom.gba", 0xAC2020, 0x200
+sEeveeSprites2:
+ax_sprite sEeveeGfx2, 0x200
+ax_sprite_terminator
+sEeveeGfx3:
+.incbin "baserom.gba", 0xAC2230, 0x200
+sEeveeSprites3:
+ax_sprite sEeveeGfx3, 0x200
+ax_sprite_terminator
+sEeveeGfx4:
+.incbin "baserom.gba", 0xAC2440, 0x200
+sEeveeSprites4:
+ax_sprite sEeveeGfx4, 0x200
+ax_sprite_terminator
+sEeveeGfx5:
+.incbin "baserom.gba", 0xAC2650, 0x200
+sEeveeSprites5:
+ax_sprite sEeveeGfx5, 0x200
+ax_sprite_terminator
+sEeveeGfx6:
+.incbin "baserom.gba", 0xAC2860, 0x200
+sEeveeSprites6:
+ax_sprite sEeveeGfx6, 0x200
+ax_sprite_terminator
+sEeveeGfx7:
+.incbin "baserom.gba", 0xAC2A70, 0x200
+sEeveeSprites7:
+ax_sprite sEeveeGfx7, 0x200
+ax_sprite_terminator
+sEeveeGfx8:
+.incbin "baserom.gba", 0xAC2C80, 0x200
+sEeveeSprites8:
+ax_sprite sEeveeGfx8, 0x200
+ax_sprite_terminator
+sEeveeGfx9:
+.incbin "baserom.gba", 0xAC2E90, 0x200
+sEeveeSprites9:
+ax_sprite sEeveeGfx9, 0x200
+ax_sprite_terminator
+sEeveeGfx10:
+.incbin "baserom.gba", 0xAC30A0, 0x200
+sEeveeSprites10:
+ax_sprite sEeveeGfx10, 0x200
+ax_sprite_terminator
+sEeveeGfx11:
+.incbin "baserom.gba", 0xAC32B0, 0x200
+sEeveeSprites11:
+ax_sprite sEeveeGfx11, 0x200
+ax_sprite_terminator
+sEeveeGfx12:
+.incbin "baserom.gba", 0xAC34C0, 0x200
+sEeveeSprites12:
+ax_sprite sEeveeGfx12, 0x200
+ax_sprite_terminator
+sEeveeGfx13:
+.incbin "baserom.gba", 0xAC36D0, 0x200
+sEeveeSprites13:
+ax_sprite sEeveeGfx13, 0x200
+ax_sprite_terminator
+sEeveeGfx14:
+.incbin "baserom.gba", 0xAC38E0, 0x200
+sEeveeSprites14:
+ax_sprite sEeveeGfx14, 0x200
+ax_sprite_terminator
+sEeveeGfx15:
+.incbin "baserom.gba", 0xAC3AF0, 0x200
+sEeveeSprites15:
+ax_sprite sEeveeGfx15, 0x200
+ax_sprite_terminator
+sEeveeGfx16:
+.incbin "baserom.gba", 0xAC3D00, 0x60
+sEeveeGfx16_1:
+.incbin "baserom.gba", 0xAC3D60, 0x60
+sEeveeGfx16_2:
+.incbin "baserom.gba", 0xAC3DC0, 0x60
+sEeveeSprites16:
+ax_sprite sEeveeGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx17:
+.incbin "baserom.gba", 0xAC3E58, 0x60
+sEeveeGfx17_1:
+.incbin "baserom.gba", 0xAC3EB8, 0x60
+sEeveeGfx17_2:
+.incbin "baserom.gba", 0xAC3F18, 0x60
+sEeveeSprites17:
+ax_sprite sEeveeGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx18:
+.incbin "baserom.gba", 0xAC3FB0, 0x40
+sEeveeGfx18_1:
+.incbin "baserom.gba", 0xAC3FF0, 0x60
+sEeveeGfx18_2:
+.incbin "baserom.gba", 0xAC4050, 0x60
+sEeveeSprites18:
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx19:
+.incbin "baserom.gba", 0xAC40F0, 0x60
+sEeveeGfx19_1:
+.incbin "baserom.gba", 0xAC4150, 0x60
+sEeveeGfx19_2:
+.incbin "baserom.gba", 0xAC41B0, 0x60
+sEeveeSprites19:
+ax_sprite sEeveeGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx20:
+.incbin "baserom.gba", 0xAC4248, 0x60
+sEeveeGfx20_1:
+.incbin "baserom.gba", 0xAC42A8, 0x60
+sEeveeGfx20_2:
+.incbin "baserom.gba", 0xAC4308, 0x60
+sEeveeSprites20:
+ax_sprite sEeveeGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx21:
+.incbin "baserom.gba", 0xAC43A0, 0x60
+sEeveeGfx21_1:
+.incbin "baserom.gba", 0xAC4400, 0x60
+sEeveeGfx21_2:
+.incbin "baserom.gba", 0xAC4460, 0x60
+sEeveeSprites21:
+ax_sprite sEeveeGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx22:
+.incbin "baserom.gba", 0xAC44F8, 0x60
+sEeveeGfx22_1:
+.incbin "baserom.gba", 0xAC4558, 0x60
+sEeveeGfx22_2:
+.incbin "baserom.gba", 0xAC45B8, 0x60
+sEeveeSprites22:
+ax_sprite sEeveeGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx23:
+.incbin "baserom.gba", 0xAC4650, 0x60
+sEeveeGfx23_1:
+.incbin "baserom.gba", 0xAC46B0, 0x60
+sEeveeGfx23_2:
+.incbin "baserom.gba", 0xAC4710, 0x60
+sEeveeSprites23:
+ax_sprite sEeveeGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx24:
+.incbin "baserom.gba", 0xAC47A8, 0x60
+sEeveeGfx24_1:
+.incbin "baserom.gba", 0xAC4808, 0x60
+sEeveeGfx24_2:
+.incbin "baserom.gba", 0xAC4868, 0x60
+sEeveeSprites24:
+ax_sprite sEeveeGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx25:
+.incbin "baserom.gba", 0xAC4900, 0x60
+sEeveeGfx25_1:
+.incbin "baserom.gba", 0xAC4960, 0x60
+sEeveeGfx25_2:
+.incbin "baserom.gba", 0xAC49C0, 0x60
+sEeveeSprites25:
+ax_sprite sEeveeGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx26:
+.incbin "baserom.gba", 0xAC4A58, 0x60
+sEeveeGfx26_1:
+.incbin "baserom.gba", 0xAC4AB8, 0x60
+sEeveeGfx26_2:
+.incbin "baserom.gba", 0xAC4B18, 0x60
+sEeveeSprites26:
+ax_sprite sEeveeGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx27:
+.incbin "baserom.gba", 0xAC4BB0, 0x60
+sEeveeGfx27_1:
+.incbin "baserom.gba", 0xAC4C10, 0x60
+sEeveeGfx27_2:
+.incbin "baserom.gba", 0xAC4C70, 0x60
+sEeveeSprites27:
+ax_sprite sEeveeGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx28:
+.incbin "baserom.gba", 0xAC4D08, 0x60
+sEeveeGfx28_1:
+.incbin "baserom.gba", 0xAC4D68, 0x60
+sEeveeGfx28_2:
+.incbin "baserom.gba", 0xAC4DC8, 0x60
+sEeveeSprites28:
+ax_sprite sEeveeGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx29:
+.incbin "baserom.gba", 0xAC4E60, 0x60
+sEeveeGfx29_1:
+.incbin "baserom.gba", 0xAC4EC0, 0x60
+sEeveeGfx29_2:
+.incbin "baserom.gba", 0xAC4F20, 0x60
+sEeveeSprites29:
+ax_sprite sEeveeGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx30:
+.incbin "baserom.gba", 0xAC4FB8, 0x20
+sEeveeGfx30_1:
+.incbin "baserom.gba", 0xAC4FD8, 0x60
+sEeveeGfx30_2:
+.incbin "baserom.gba", 0xAC5038, 0x60
+sEeveeSprites30:
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sEeveeGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx31:
+.incbin "baserom.gba", 0xAC50D8, 0x20
+sEeveeGfx31_1:
+.incbin "baserom.gba", 0xAC50F8, 0x60
+sEeveeGfx31_2:
+.incbin "baserom.gba", 0xAC5158, 0x60
+sEeveeSprites31:
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx31, 0x20
+ax_sprite 0, 0x40
+ax_sprite sEeveeGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx32:
+.incbin "baserom.gba", 0xAC51F8, 0x60
+sEeveeGfx32_1:
+.incbin "baserom.gba", 0xAC5258, 0x60
+sEeveeGfx32_2:
+.incbin "baserom.gba", 0xAC52B8, 0x60
+sEeveeSprites32:
+ax_sprite sEeveeGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx33:
+.incbin "baserom.gba", 0xAC5350, 0x60
+sEeveeGfx33_1:
+.incbin "baserom.gba", 0xAC53B0, 0x60
+sEeveeGfx33_2:
+.incbin "baserom.gba", 0xAC5410, 0x60
+sEeveeSprites33:
+ax_sprite sEeveeGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx34:
+.incbin "baserom.gba", 0xAC54A8, 0x60
+sEeveeGfx34_1:
+.incbin "baserom.gba", 0xAC5508, 0x60
+sEeveeGfx34_2:
+.incbin "baserom.gba", 0xAC5568, 0x60
+sEeveeSprites34:
+ax_sprite sEeveeGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx35:
+.incbin "baserom.gba", 0xAC5600, 0x60
+sEeveeGfx35_1:
+.incbin "baserom.gba", 0xAC5660, 0x60
+sEeveeGfx35_2:
+.incbin "baserom.gba", 0xAC56C0, 0x60
+sEeveeSprites35:
+ax_sprite sEeveeGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEeveeGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEeveeGfx36:
+.incbin "baserom.gba", 0xAC5758, 0x200
+sEeveeSprites36:
+ax_sprite sEeveeGfx36, 0x200
+ax_sprite_terminator
+sEeveeGfx37:
+.incbin "baserom.gba", 0xAC5968, 0x200
+sEeveeSprites37:
+ax_sprite sEeveeGfx37, 0x200
+ax_sprite_terminator
+sEeveeGfx38:
+.incbin "baserom.gba", 0xAC5B78, 0x200
+sEeveeSprites38:
+ax_sprite sEeveeGfx38, 0x200
+ax_sprite_terminator
+sEeveeGfx39:
+.incbin "baserom.gba", 0xAC5D88, 0x200
+sEeveeSprites39:
+ax_sprite sEeveeGfx39, 0x200
+ax_sprite_terminator
+sEeveeGfx40:
+.incbin "baserom.gba", 0xAC5F98, 0x200
+sEeveeSprites40:
+ax_sprite sEeveeGfx40, 0x200
+ax_sprite_terminator
+sEeveeGfx41:
+.incbin "baserom.gba", 0xAC61A8, 0x200
+sEeveeSprites41:
+ax_sprite sEeveeGfx41, 0x200
+ax_sprite_terminator
+sEeveeGfx42:
+.incbin "baserom.gba", 0xAC63B8, 0x200
+sEeveeSprites42:
+ax_sprite sEeveeGfx42, 0x200
+ax_sprite_terminator
+sEeveeGfx43:
+.incbin "baserom.gba", 0xAC65C8, 0x200
+sEeveeSprites43:
+ax_sprite sEeveeGfx43, 0x200
+ax_sprite_terminator
+sEeveeGfx44:
+.incbin "baserom.gba", 0xAC67D8, 0x200
+sEeveeSprites44:
+ax_sprite sEeveeGfx44, 0x200
+ax_sprite_terminator
+sEeveeGfx45:
+.incbin "baserom.gba", 0xAC69E8, 0x200
+sEeveeSprites45:
+ax_sprite sEeveeGfx45, 0x200
+ax_sprite_terminator
+sEeveeGfx46:
+.incbin "baserom.gba", 0xAC6BF8, 0x200
+sEeveeSprites46:
+ax_sprite sEeveeGfx46, 0x200
+ax_sprite_terminator
+sEeveeGfx47:
+.incbin "baserom.gba", 0xAC6E08, 0x200
+sEeveeSprites47:
+ax_sprite sEeveeGfx47, 0x200
+ax_sprite_terminator
+sEeveeGfx48:
+.incbin "baserom.gba", 0xAC7018, 0x200
+sEeveeSprites48:
+ax_sprite sEeveeGfx48, 0x200
+ax_sprite_terminator
+sEeveeGfx49:
+.incbin "baserom.gba", 0xAC7228, 0x200
+sEeveeSprites49:
+ax_sprite sEeveeGfx49, 0x200
+ax_sprite_terminator
+sEeveeGfx50:
+.incbin "baserom.gba", 0xAC7438, 0x200
+sEeveeSprites50:
+ax_sprite sEeveeGfx50, 0x200
+ax_sprite_terminator
+sEeveeGfx51:
+.incbin "baserom.gba", 0xAC7648, 0x200
+sEeveeSprites51:
+ax_sprite sEeveeGfx51, 0x200
+ax_sprite_terminator
+sEeveeGfx52:
+.incbin "baserom.gba", 0xAC7858, 0x200
+sEeveeSprites52:
+ax_sprite sEeveeGfx52, 0x200
+ax_sprite_terminator
+sEeveeGfx53:
+.incbin "baserom.gba", 0xAC7A68, 0x200
+sEeveeSprites53:
+ax_sprite sEeveeGfx53, 0x200
+ax_sprite_terminator
+sEeveeGfx54:
+.incbin "baserom.gba", 0xAC7C78, 0x200
+sEeveeSprites54:
+ax_sprite sEeveeGfx54, 0x200
+ax_sprite_terminator
+sEeveeGfx55:
+.incbin "baserom.gba", 0xAC7E88, 0x200
+sEeveeSprites55:
+ax_sprite sEeveeGfx55, 0x200
+ax_sprite_terminator
+sEeveeGfx56:
+.incbin "baserom.gba", 0xAC8098, 0x200
+sEeveeSprites56:
+ax_sprite sEeveeGfx56, 0x200
+ax_sprite_terminator
+sEeveeGfx57:
+.incbin "baserom.gba", 0xAC82A8, 0x200
+sEeveeSprites57:
+ax_sprite sEeveeGfx57, 0x200
+ax_sprite_terminator
+sEeveeGfx58:
+.incbin "baserom.gba", 0xAC84B8, 0x200
+sEeveeSprites58:
+ax_sprite sEeveeGfx58, 0x200
+ax_sprite_terminator
+sEeveeGfx59:
+.incbin "baserom.gba", 0xAC86C8, 0x200
+sEeveeSprites59:
+ax_sprite sEeveeGfx59, 0x200
+ax_sprite_terminator
+sEeveeGfx60:
+.incbin "baserom.gba", 0xAC88D8, 0x200
+sEeveeSprites60:
+ax_sprite sEeveeGfx60, 0x200
+ax_sprite_terminator
+sEeveeGfx61:
+.incbin "baserom.gba", 0xAC8AE8, 0x200
+sEeveeSprites61:
+ax_sprite sEeveeGfx61, 0x200
+ax_sprite_terminator
+sEeveeGfx62:
+.incbin "baserom.gba", 0xAC8CF8, 0x200
+sEeveeSprites62:
+ax_sprite sEeveeGfx62, 0x200
+ax_sprite_terminator
+sEeveeGfx63:
+.incbin "baserom.gba", 0xAC8F08, 0x200
+sEeveeSprites63:
+ax_sprite sEeveeGfx63, 0x200
+ax_sprite_terminator
+sEeveeGfx64:
+.incbin "baserom.gba", 0xAC9118, 0x200
+sEeveeSprites64:
+ax_sprite sEeveeGfx64, 0x200
+ax_sprite_terminator
+sEeveeGfx65:
+.incbin "baserom.gba", 0xAC9328, 0x200
+sEeveeSprites65:
+ax_sprite sEeveeGfx65, 0x200
+ax_sprite_terminator
+sEeveeGfx66:
+.incbin "baserom.gba", 0xAC9538, 0x200
+sEeveeSprites66:
+ax_sprite sEeveeGfx66, 0x200
+ax_sprite_terminator
+sEeveeGfx67:
+.incbin "baserom.gba", 0xAC9748, 0x200
+sEeveeSprites67:
+ax_sprite sEeveeGfx67, 0x200
+ax_sprite_terminator
+sEeveeGfx68:
+.incbin "baserom.gba", 0xAC9958, 0x200
+sEeveeSprites68:
+ax_sprite sEeveeGfx68, 0x200
+ax_sprite_terminator
+sEeveeGfx69:
+.incbin "baserom.gba", 0xAC9B68, 0x200
+sEeveeSprites69:
+ax_sprite sEeveeGfx69, 0x200
+ax_sprite_terminator
+sEeveeGfx70:
+.incbin "baserom.gba", 0xAC9D78, 0x200
+sEeveeSprites70:
+ax_sprite sEeveeGfx70, 0x200
+ax_sprite_terminator
+sEeveeGfx71:
+.incbin "baserom.gba", 0xAC9F88, 0x100
+sEeveeSprites71:
+ax_sprite sEeveeGfx71, 0x100
+ax_sprite_terminator
+sAxPosesEevee:
+.4byte sEeveePose1
+.4byte sEeveePose2
+.4byte sEeveePose3
+.4byte sEeveePose4
+.4byte sEeveePose5
+.4byte sEeveePose6
+.4byte sEeveePose7
+.4byte sEeveePose8
+.4byte sEeveePose9
+.4byte sEeveePose10
+.4byte sEeveePose11
+.4byte sEeveePose12
+.4byte sEeveePose13
+.4byte sEeveePose14
+.4byte sEeveePose15
+.4byte sEeveePose16
+.4byte sEeveePose17
+.4byte sEeveePose18
+.4byte sEeveePose19
+.4byte sEeveePose20
+.4byte sEeveePose21
+.4byte sEeveePose22
+.4byte sEeveePose23
+.4byte sEeveePose24
+.4byte sEeveePose25
+.4byte sEeveePose26
+.4byte sEeveePose27
+.4byte sEeveePose28
+.4byte sEeveePose29
+.4byte sEeveePose30
+.4byte sEeveePose31
+.4byte sEeveePose32
+.4byte sEeveePose33
+.4byte sEeveePose34
+.4byte sEeveePose35
+.4byte sEeveePose36
+.4byte sEeveePose37
+.4byte sEeveePose38
+.4byte sEeveePose39
+.4byte sEeveePose40
+.4byte sEeveePose41
+.4byte sEeveePose42
+.4byte sEeveePose43
+.4byte sEeveePose44
+.4byte sEeveePose45
+.4byte sEeveePose46
+.4byte sEeveePose47
+.4byte sEeveePose48
+.4byte sEeveePose49
+.4byte sEeveePose50
+.4byte sEeveePose51
+.4byte sEeveePose52
+.4byte sEeveePose53
+.4byte sEeveePose54
+.4byte sEeveePose55
+.4byte sEeveePose56
+.4byte sEeveePose57
+.4byte sEeveePose58
+.4byte sEeveePose59
+.4byte sEeveePose60
+.4byte sEeveePose61
+.4byte sEeveePose62
+.4byte sEeveePose63
+.4byte sEeveePose64
+.4byte sEeveePose65
+.4byte sEeveePose66
+.4byte sEeveePose67
+.4byte sEeveePose68
+.4byte sEeveePose69
+.4byte sEeveePose70
+.4byte sEeveePose71
+.4byte sEeveePose72
+.4byte sEeveePose73
+.4byte sEeveePose74
+.4byte sEeveePose75
+.4byte sEeveePose76
+.4byte sEeveePose77
+.4byte sEeveePose78
+.4byte sEeveePose79
+.4byte sEeveePose80
+.4byte sEeveePose81
+.4byte sEeveePose82
+.4byte sEeveePose83
+.4byte sEeveePose84
+.4byte sEeveePose85
+.4byte sEeveePose86
+.4byte sEeveePose87
+.4byte sEeveePose88
+.4byte sEeveePose89
+.4byte sEeveePose90
+.4byte sEeveePose91
+.4byte sEeveePose92
+.4byte sEeveePose93
+.4byte sEeveePose94
+.4byte sEeveePose95
+.4byte sEeveePose96
+.4byte sEeveePose97
+.4byte sEeveePose98
+.4byte sEeveePose99
+.4byte sEeveePose100
+.4byte sEeveePose101
+.4byte sEeveePose102
+.4byte sEeveePose103
+.4byte sEeveePose104
+.4byte sEeveePose105
+.4byte sEeveePose106
+.4byte sEeveePose107
+.4byte sEeveePose108
+.4byte sEeveePose109
+.4byte sEeveePose110
+.4byte sEeveePose111
+.4byte sEeveePose112
+.4byte sEeveePose113
+.4byte sEeveePose114
+.4byte sEeveePose115
+.4byte sEeveePose116
+.4byte sEeveePose117
+.4byte sEeveePose118
+.4byte sEeveePose119
+.4byte sEeveePose120
+.4byte sEeveePose121
+.4byte sEeveePose122
+.4byte sEeveePose123
+.4byte sEeveePose124
+.4byte sEeveePose125
+.4byte sEeveePose126
+.4byte sEeveePose127
+.4byte sEeveePose128
+.4byte sEeveePose129
+.4byte sEeveePose130
+.4byte sEeveePose131
+.4byte sEeveePose132
+.4byte sEeveePose133
+.4byte sEeveePose134
+.4byte sEeveePose135
+.4byte sEeveePose136
+.4byte sEeveePose137
+.4byte sEeveePose138
+.4byte sEeveePose139
+.4byte sEeveePose140
+.4byte sEeveePose141
+.4byte sEeveePose142
+.4byte sEeveePose143
+.4byte sEeveePose144
+.4byte sEeveePose145
+.4byte sEeveePose146
+.4byte sEeveePose147
+.4byte sEeveePose148
+.4byte sEeveePose149
+.4byte sEeveePose150
+.4byte sEeveePose151
+.4byte sEeveePose152
+.4byte sEeveePose153
+.4byte sEeveePose154
+.4byte sEeveePose155
+.4byte sEeveePose156
+.4byte sEeveePose157
+.4byte sEeveePose158
+.4byte sEeveePose159
+.4byte sEeveePose160
+.4byte sEeveePose161
+.4byte sEeveePose162
+.4byte sEeveePose163
+.4byte sEeveePose164
+.4byte sEeveePose165
+.4byte sEeveePose166
+.4byte sEeveePose167
+.4byte sEeveePose168
+.4byte sEeveePose169
+.4byte sEeveePose170
+.4byte sEeveePose171
+.4byte sEeveePose172
+.4byte sEeveePose173
+.4byte sEeveePose174
+.4byte sEeveePose175
+.4byte sEeveePose176
+.4byte sEeveePose177
+.4byte sEeveePose178
+.4byte sEeveePose179
+.4byte sEeveePose180
+.4byte sEeveePose181
+.4byte sEeveePose182
+.4byte sEeveePose183
+.4byte sEeveePose184
+.4byte sEeveePose185
+.4byte sEeveePose186
+.4byte sEeveePose187
+.4byte sEeveePose188
+.4byte sEeveePose189
+.4byte sEeveePose190
+.4byte sEeveePose191
+.4byte sEeveePose192
+.4byte sEeveePose193
+.4byte sEeveePose194
+.4byte sEeveePose195
+.4byte sEeveePose196
+.4byte sEeveePose197
+.4byte sEeveePose198
+.4byte sEeveePose199
+.4byte sEeveePose200
+.4byte sEeveePose201
+.4byte sEeveePose202
+.4byte sEeveePose203
+.4byte sEeveePose204
+.4byte sEeveePose205
+.4byte sEeveePose206
+.4byte sEeveePose207
+.4byte sEeveePose208
+.4byte sEeveePose209
+.4byte sEeveePose210
+.4byte sEeveePose211
+.4byte sEeveePose212
+.4byte sEeveePose213
+.4byte sEeveePose214
+.4byte sEeveePose215
+.4byte sEeveePose216
+.4byte sEeveePose217
+.4byte sEeveePose218
+.4byte sEeveePose219
+.4byte sEeveePose220
+.4byte sEeveePose221
+.4byte sEeveePose222
+.4byte sEeveePose223
+.4byte sEeveePose224
+.4byte sEeveePose225
+.4byte sEeveePose226
+.4byte sEeveePose227
+.4byte sEeveePose228
+.4byte sEeveePose229
+.4byte sEeveePose230
+.4byte sEeveePose231
+.4byte sEeveePose232
+.4byte sEeveePose233
+.4byte sEeveePose234
+.4byte sEeveePose235
+.4byte sEeveePose236
+.4byte sEeveePose237
+.4byte sEeveePose238
+.4byte sEeveePose239
+.4byte sEeveePose240
+.4byte sEeveePose241
+.4byte sEeveePose242
+.4byte sEeveePose243
+.4byte sEeveePose244
+.4byte sEeveePose245
+.4byte sEeveePose246
+.4byte sEeveePose247
+.4byte sEeveePose248
+.4byte sEeveePose249
+.4byte sEeveePose250
+.4byte sEeveePose251
+.4byte sEeveePose252
+.4byte sEeveePose253
+.4byte sEeveePose254
+.4byte sEeveePose255
+.4byte sEeveePose256
+.4byte sEeveePose257
+.4byte sEeveePose258
+.4byte sEeveePose259
+.4byte sEeveePose260
+.4byte sEeveePose261
+.4byte sEeveePose262
+.4byte sEeveePose263
+.4byte sEeveePose264
+.4byte sEeveePose265
+.4byte sEeveePose266
+sAxPositionsEevee:
+.2byte    0,   -7, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte    0,  -12, 	  -2,   -5, 	   2,   -5, 	   0,  -10
+.2byte    0,    0, 	  -3,    3, 	   3,    3, 	   0,   -3
+.2byte    6,   -8, 	   4,   -1, 	   2,    0, 	   0,   -7
+.2byte    5,  -11, 	   7,   -9, 	   2,   -8, 	  -2,  -10
+.2byte    6,   -5, 	   5,   -1, 	   2,    0, 	   0,   -6
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    7,  -13, 	   8,  -12, 	   5,   -9, 	  -3,  -10
+.2byte    8,   -6, 	   6,   -3, 	   3,   -1, 	   1,   -7
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    6,  -15, 	   3,  -13, 	   8,  -11, 	   0,  -10
+.2byte    8,   -9, 	   3,   -4, 	   6,   -2, 	   4,   -9
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -17, 	   3,  -13, 	  -3,  -13, 	   0,   -9
+.2byte    0,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -8
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte   -7,  -15, 	  -4,  -13, 	  -9,  -11, 	  -1,  -10
+.2byte   -9,   -9, 	  -4,   -4, 	  -7,   -2, 	  -5,   -9
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -8,  -13, 	  -9,  -12, 	  -6,   -9, 	   2,  -10
+.2byte   -9,   -6, 	  -7,   -3, 	  -4,   -1, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -1, 	  -3,    0, 	  -1,   -7
+.2byte   -6,  -11, 	  -8,   -9, 	  -3,   -8, 	   1,  -10
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  -3,    0, 	   1,    0, 	  -1,   -6
+.2byte   -1,  -11, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -9
+.2byte    6,   -8, 	   4,   -1, 	   2,    0, 	   0,   -7
+.2byte    5,  -11, 	   7,   -9, 	   2,   -8, 	  -2,  -10
+.2byte    6,   -8, 	   5,   -4, 	   2,   -3, 	   0,   -9
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    7,  -13, 	   8,  -12, 	   5,   -9, 	  -3,  -10
+.2byte    8,   -6, 	   6,   -3, 	   3,   -1, 	   1,   -7
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    6,  -15, 	   3,  -13, 	   8,  -11, 	   0,  -10
+.2byte    5,   -9, 	   0,   -4, 	   3,   -2, 	   1,   -9
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -17, 	   3,  -13, 	  -3,  -13, 	   0,   -9
+.2byte    0,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -8
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte   -7,  -15, 	  -4,  -13, 	  -9,  -11, 	  -1,  -10
+.2byte   -6,   -9, 	  -1,   -4, 	  -4,   -2, 	  -2,   -9
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -8,  -13, 	  -9,  -12, 	  -6,   -9, 	   2,  -10
+.2byte   -9,   -6, 	  -7,   -3, 	  -4,   -1, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -1, 	  -3,    0, 	  -1,   -7
+.2byte   -6,  -11, 	  -8,   -9, 	  -3,   -8, 	   1,  -10
+.2byte   -7,   -8, 	  -6,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	  -3,    0, 	   1,    0, 	  -1,   -6
+.2byte   -1,  -11, 	  -3,   -4, 	   1,   -4, 	  -1,   -9
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -9
+.2byte    6,   -8, 	   4,   -1, 	   2,    0, 	   0,   -7
+.2byte    5,  -11, 	   7,   -9, 	   2,   -8, 	  -2,  -10
+.2byte    6,   -8, 	   5,   -4, 	   2,   -3, 	   0,   -9
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    7,  -13, 	   8,  -12, 	   5,   -9, 	  -3,  -10
+.2byte    8,   -6, 	   6,   -3, 	   3,   -1, 	   1,   -7
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    6,  -15, 	   3,  -13, 	   8,  -11, 	   0,  -10
+.2byte    5,   -9, 	   0,   -4, 	   3,   -2, 	   1,   -9
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -17, 	   3,  -13, 	  -3,  -13, 	   0,   -9
+.2byte    0,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -8
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte   -7,  -15, 	  -4,  -13, 	  -9,  -11, 	  -1,  -10
+.2byte   -6,   -9, 	  -1,   -4, 	  -4,   -2, 	  -2,   -9
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -8,  -13, 	  -9,  -12, 	  -6,   -9, 	   2,  -10
+.2byte   -9,   -6, 	  -7,   -3, 	  -4,   -1, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -1, 	  -3,    0, 	  -1,   -7
+.2byte   -6,  -11, 	  -8,   -9, 	  -3,   -8, 	   1,  -10
+.2byte   -7,   -8, 	  -6,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	  -5,    1, 	   2,   -1, 	  -1,   -5
+.2byte   -1,   -9, 	  -5,    1, 	   2,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -4,    0, 	   2,    0, 	  -1,   -6
+.2byte    5,  -10, 	   5,    0, 	  -2,   -1, 	  -2,   -7
+.2byte    5,   -9, 	   5,    0, 	  -2,   -1, 	  -2,   -7
+.2byte    6,   -3, 	   5,    1, 	   2,    2, 	   0,   -4
+.2byte    8,  -11, 	   7,   -2, 	   2,    0, 	  -1,   -6
+.2byte    8,  -10, 	   7,   -2, 	   2,    0, 	  -1,   -6
+.2byte    7,   -9, 	   4,   -2, 	   2,   -1, 	  -1,   -6
+.2byte    6,  -12, 	  -1,   -4, 	   2,   -2, 	  -2,   -8
+.2byte    6,  -11, 	  -1,   -4, 	   2,   -2, 	  -2,   -7
+.2byte    3,   -9, 	   0,   -7, 	   5,   -5, 	  -3,   -4
+.2byte    0,  -13, 	   3,   -7, 	  -2,   -8, 	   0,   -7
+.2byte    0,  -12, 	   3,   -7, 	  -3,   -8, 	   1,   -7
+.2byte    0,  -12, 	   3,   -8, 	  -3,   -8, 	   0,   -4
+.2byte   -7,  -12, 	   0,   -4, 	  -3,   -2, 	   1,   -8
+.2byte   -7,  -11, 	   0,   -4, 	  -3,   -2, 	   1,   -7
+.2byte   -4,   -9, 	  -1,   -7, 	  -6,   -5, 	   2,   -4
+.2byte   -9,  -11, 	  -8,   -2, 	  -3,    0, 	   0,   -6
+.2byte   -9,  -10, 	  -8,   -2, 	  -3,    0, 	   0,   -6
+.2byte   -8,   -9, 	  -5,   -2, 	  -3,   -1, 	   0,   -6
+.2byte   -6,  -10, 	  -6,    0, 	   1,   -1, 	   1,   -7
+.2byte   -6,   -9, 	  -6,    0, 	   1,   -1, 	   1,   -7
+.2byte   -7,   -3, 	  -6,    1, 	  -3,    2, 	  -1,   -4
+.2byte    0,   -7, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte    0,   -6, 	  -2,    0, 	   2,    0, 	   0,   -4
+.2byte    0,   -6, 	  -2,    0, 	   2,    0, 	   0,   -4
+.2byte    5,   -8, 	   3,   -1, 	   1,    0, 	  -1,   -7
+.2byte    5,   -7, 	   3,   -1, 	   0,    0, 	  -1,   -6
+.2byte    5,   -7, 	   4,   -1, 	   0,    0, 	  -1,   -6
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    8,   -8, 	   5,   -3, 	   3,   -1, 	  -1,   -5
+.2byte    8,   -8, 	   5,   -3, 	   3,   -1, 	  -1,   -4
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    7,  -10, 	   1,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    7,  -10, 	   1,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -11, 	   3,   -6, 	  -2,   -7, 	   0,   -6
+.2byte    0,  -11, 	   2,   -7, 	  -2,   -7, 	   1,   -5
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte   -8,  -10, 	  -2,   -4, 	  -5,   -2, 	   0,   -6
+.2byte   -8,  -10, 	  -2,   -4, 	  -5,   -2, 	   0,   -6
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -9,   -8, 	  -6,   -3, 	  -4,   -1, 	   0,   -5
+.2byte   -9,   -8, 	  -6,   -3, 	  -4,   -1, 	   0,   -4
+.2byte   -6,   -8, 	  -4,   -1, 	  -2,    0, 	   0,   -7
+.2byte   -6,   -7, 	  -4,   -1, 	  -1,    0, 	   0,   -6
+.2byte   -6,   -7, 	  -5,   -1, 	  -1,    0, 	   0,   -6
+.2byte   -6,   -7, 	  -7,   -1, 	  -5,    0, 	   0,   -5
+.2byte   -6,   -6, 	  -7,   -1, 	  -5,    0, 	   1,   -4
+.2byte    0,   -4, 	  -4,    1, 	   4,    1, 	   0,   -8
+.2byte    4,   -4, 	   8,   -1, 	   3,    0, 	  -1,   -6
+.2byte    8,   -5, 	   9,   -3, 	   9,    0, 	   1,   -4
+.2byte    6,   -8, 	   4,   -5, 	   8,   -3, 	   0,   -6
+.2byte    0,  -10, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte   -7,   -8, 	  -5,   -5, 	  -9,   -3, 	  -1,   -6
+.2byte   -9,   -5, 	 -10,   -3, 	 -10,    0, 	  -2,   -4
+.2byte   -5,   -4, 	  -9,   -1, 	  -4,    0, 	   0,   -6
+.2byte    0,   -6, 	  -2,    0, 	   2,    0, 	   0,   -4
+.2byte    0,   -6, 	  -2,    0, 	   2,    0, 	   0,   -4
+.2byte    5,   -7, 	   3,   -1, 	   0,    0, 	  -1,   -6
+.2byte    5,   -7, 	   4,   -1, 	   0,    0, 	  -1,   -6
+.2byte    8,   -8, 	   5,   -3, 	   3,   -1, 	  -1,   -5
+.2byte    8,   -8, 	   5,   -3, 	   3,   -1, 	  -1,   -4
+.2byte    7,  -10, 	   1,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    7,  -10, 	   1,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    0,  -11, 	   3,   -6, 	  -2,   -7, 	   0,   -6
+.2byte    0,  -11, 	   2,   -7, 	  -2,   -7, 	   1,   -5
+.2byte   -8,  -10, 	  -2,   -4, 	  -5,   -2, 	   0,   -6
+.2byte   -8,  -10, 	  -2,   -4, 	  -5,   -2, 	   0,   -6
+.2byte   -9,   -8, 	  -6,   -3, 	  -4,   -1, 	   0,   -5
+.2byte   -9,   -8, 	  -6,   -3, 	  -4,   -1, 	   0,   -4
+.2byte   -6,   -7, 	  -4,   -1, 	  -1,    0, 	   0,   -6
+.2byte   -6,   -7, 	  -5,   -1, 	  -1,    0, 	   0,   -6
+.2byte    0,   -7, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte   -6,   -8, 	  -4,   -1, 	  -2,    0, 	   0,   -7
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    5,   -8, 	   3,   -1, 	   1,    0, 	  -1,   -7
+.2byte    0,   -7, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte    5,   -8, 	   3,   -1, 	   1,    0, 	  -1,   -7
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -6,   -8, 	  -4,   -1, 	  -2,    0, 	   0,   -7
+.2byte    0,   -7, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte    0,  -12, 	  -2,   -5, 	   2,   -5, 	   0,  -10
+.2byte    0,    0, 	  -3,    3, 	   3,    3, 	   0,   -3
+.2byte    6,   -8, 	   4,   -1, 	   2,    0, 	   0,   -7
+.2byte    5,  -11, 	   7,   -9, 	   2,   -8, 	  -2,  -10
+.2byte    6,   -5, 	   5,   -1, 	   2,    0, 	   0,   -6
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    7,  -13, 	   8,  -12, 	   5,   -9, 	  -3,  -10
+.2byte    8,   -6, 	   6,   -3, 	   3,   -1, 	   1,   -7
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    6,  -15, 	   3,  -13, 	   8,  -11, 	   0,  -10
+.2byte    5,   -9, 	   0,   -4, 	   3,   -2, 	   1,   -9
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -17, 	   3,  -13, 	  -3,  -13, 	   0,   -9
+.2byte    0,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -8
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte   -7,  -15, 	  -4,  -13, 	  -9,  -11, 	  -1,  -10
+.2byte   -6,   -9, 	  -1,   -4, 	  -4,   -2, 	  -2,   -9
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -8,  -13, 	  -9,  -12, 	  -6,   -9, 	   2,  -10
+.2byte   -9,   -6, 	  -7,   -3, 	  -4,   -1, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -1, 	  -3,    0, 	  -1,   -7
+.2byte   -6,  -11, 	  -8,   -9, 	  -3,   -8, 	   1,  -10
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    0, 	  -1,   -6
+.2byte    0,  -10, 	  -4,    1, 	   3,   -1, 	   0,   -5
+.2byte    0,   -9, 	  -4,    1, 	   3,   -1, 	   0,   -5
+.2byte    5,  -10, 	   5,    0, 	  -2,   -1, 	  -2,   -7
+.2byte    5,   -9, 	   5,    0, 	  -2,   -1, 	  -2,   -7
+.2byte    8,  -11, 	   7,   -2, 	   2,    0, 	  -1,   -6
+.2byte    8,  -10, 	   7,   -2, 	   2,    0, 	  -1,   -6
+.2byte    6,  -12, 	  -1,   -4, 	   2,   -2, 	  -2,   -8
+.2byte    6,  -11, 	  -1,   -4, 	   2,   -2, 	  -2,   -7
+.2byte    0,  -13, 	   3,   -7, 	  -2,   -8, 	   0,   -7
+.2byte    0,  -12, 	   3,   -7, 	  -3,   -8, 	   1,   -7
+.2byte   -7,  -12, 	   0,   -4, 	  -3,   -2, 	   1,   -8
+.2byte   -7,  -11, 	   0,   -4, 	  -3,   -2, 	   1,   -7
+.2byte   -9,  -11, 	  -8,   -2, 	  -3,    0, 	   0,   -6
+.2byte   -9,  -10, 	  -8,   -2, 	  -3,    0, 	   0,   -6
+.2byte   -6,  -10, 	  -6,    0, 	   1,   -1, 	   1,   -7
+.2byte   -6,   -9, 	  -6,    0, 	   1,   -1, 	   1,   -7
+.2byte    0,   -7, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte   -6,   -8, 	  -4,   -1, 	  -2,    0, 	   0,   -7
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -7,  -11, 	  -2,   -5, 	  -5,   -2, 	   1,   -6
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    6,  -11, 	   1,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    5,   -8, 	   3,   -1, 	   1,    0, 	  -1,   -7
+.2byte    7,   -6, 	   5,   -2, 	   4,   -1, 	  -1,   -5
+.2byte    7,   -7, 	   5,   -2, 	   4,   -1, 	  -1,   -5
+.2byte   -8,   -6, 	  -6,   -2, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -7, 	  -6,   -2, 	  -5,   -1, 	   0,   -5
+.2byte    7,   -6, 	   5,   -2, 	   4,   -1, 	  -1,   -5
+.2byte    6,   -8, 	   5,   -3, 	   5,   -1, 	  -1,   -6
+.2byte    5,  -10, 	   4,   -3, 	   4,   -1, 	  -2,   -6
+.2byte    7,   -7, 	   4,   -3, 	   2,   -1, 	  -1,   -6
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -10, 	   4,   -3, 	  -4,   -3, 	   0,   -8
+.2byte    0,   -9, 	   5,   -3, 	  -5,   -3, 	   0,   -8
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -3
+.2byte    0,  -11, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -3
+.2byte    0,  -11, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -4, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte   -1,   -5, 	   2,   -1, 	  -4,   -1, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -2, 	  -8,   -7, 	  -1,   -6
+.2byte    0,   -7, 	  -4,    0, 	   4,    0, 	   0,   -6
+.2byte    0,   -6, 	  -4,    1, 	   3,    0, 	   0,   -5
+.2byte    0,   -6, 	  -3,    0, 	   4,    1, 	   0,   -5
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -9,   -7, 	  -7,   -1, 	  -2,   -3, 	   0,   -6
+.2byte   -8,   -6, 	  -9,    0, 	  -1,   -5, 	  -2,   -5
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -10, 	   5,   -5, 	  -5,   -5, 	   0,   -8
+.2byte    0,   -9, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -7, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte    0,  -10, 	  -2,    0, 	   2,    0, 	   0,   -6
+.2byte    0,   -5, 	  -2,    0, 	   2,    0, 	   0,   -8
+.2byte   -9,   -9, 	  -6,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte   -6,   -5, 	  -5,   -2, 	  -4,   -1, 	  -1,   -6
+.2byte    8,   -9, 	   5,   -2, 	   3,   -1, 	   0,   -6
+.2byte    5,   -5, 	   4,   -2, 	   3,   -1, 	   0,   -6
+.2byte    0,  -13, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte    0,  -10, 	   6,   -7, 	  -6,   -7, 	   0,   -3
+.2byte   -9,   -7, 	  -6,   -2, 	  -4,   -1, 	  -2,   -7
+.2byte   -8,   -8, 	 -12,   -6, 	  -3,   -1, 	  -2,   -7
+.2byte   -9,   -6, 	 -12,   -2, 	  -3,    0, 	  -2,   -6
+.2byte  -10,   -9, 	 -10,   -5, 	  -4,   -2, 	  -3,   -7
+.2byte  -11,   -8, 	  -4,   -2, 	 -10,   -1, 	  -3,   -6
+.2byte    8,   -7, 	   5,   -2, 	   3,   -1, 	   1,   -7
+.2byte    7,   -8, 	  11,   -6, 	   2,   -1, 	   1,   -7
+.2byte    8,   -6, 	  11,   -2, 	   2,    0, 	   1,   -6
+.2byte    9,   -9, 	   9,   -5, 	   3,   -2, 	   2,   -7
+.2byte   10,   -8, 	   3,   -2, 	   9,   -1, 	   2,   -6
+.2byte    1,   -9, 	   0,  -13, 	   6,   -8, 	  -2,   -7
+.2byte    7,   -6, 	   5,   -2, 	   4,   -1, 	  -1,   -5
+.2byte    7,   -7, 	   5,   -2, 	   4,   -1, 	  -1,   -5
+.2byte   -8,   -6, 	  -6,   -2, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -7, 	  -6,   -2, 	  -5,   -1, 	   0,   -5
+.2byte    7,   -6, 	   5,   -2, 	   4,   -1, 	  -1,   -5
+.2byte    7,   -7, 	   5,   -2, 	   4,   -1, 	  -1,   -5
+.2byte   -8,   -6, 	  -6,   -2, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -7, 	  -6,   -2, 	  -5,   -1, 	   0,   -5
+sEeveeAnimTable1:
+.4byte sEeveeAnims_1_1
+.4byte sEeveeAnims_1_2
+.4byte sEeveeAnims_1_3
+.4byte sEeveeAnims_1_4
+.4byte sEeveeAnims_1_5
+.4byte sEeveeAnims_1_6
+.4byte sEeveeAnims_1_7
+.4byte sEeveeAnims_1_8
+sEeveeAnimTable2:
+.4byte sEeveeAnims_2_1
+.4byte sEeveeAnims_2_2
+.4byte sEeveeAnims_2_3
+.4byte sEeveeAnims_2_4
+.4byte sEeveeAnims_2_5
+.4byte sEeveeAnims_2_6
+.4byte sEeveeAnims_2_7
+.4byte sEeveeAnims_2_8
+sEeveeAnimTable3:
+.4byte sEeveeAnims_3_1
+.4byte sEeveeAnims_3_2
+.4byte sEeveeAnims_3_3
+.4byte sEeveeAnims_3_4
+.4byte sEeveeAnims_3_5
+.4byte sEeveeAnims_3_6
+.4byte sEeveeAnims_3_7
+.4byte sEeveeAnims_3_8
+sEeveeAnimTable4:
+.4byte sEeveeAnims_4_1
+.4byte sEeveeAnims_4_2
+.4byte sEeveeAnims_4_3
+.4byte sEeveeAnims_4_4
+.4byte sEeveeAnims_4_5
+.4byte sEeveeAnims_4_6
+.4byte sEeveeAnims_4_7
+.4byte sEeveeAnims_4_8
+sEeveeAnimTable5:
+.4byte sEeveeAnims_5_1
+.4byte sEeveeAnims_5_2
+.4byte sEeveeAnims_5_3
+.4byte sEeveeAnims_5_4
+.4byte sEeveeAnims_5_5
+.4byte sEeveeAnims_5_6
+.4byte sEeveeAnims_5_7
+.4byte sEeveeAnims_5_8
+sEeveeAnimTable6:
+.4byte sEeveeAnims_6_1
+.4byte sEeveeAnims_6_1
+.4byte sEeveeAnims_6_1
+.4byte sEeveeAnims_6_1
+.4byte sEeveeAnims_6_1
+.4byte sEeveeAnims_6_1
+.4byte sEeveeAnims_6_1
+.4byte sEeveeAnims_6_1
+sEeveeAnimTable7:
+.4byte sEeveeAnims_7_1
+.4byte sEeveeAnims_7_2
+.4byte sEeveeAnims_7_3
+.4byte sEeveeAnims_7_4
+.4byte sEeveeAnims_7_5
+.4byte sEeveeAnims_7_6
+.4byte sEeveeAnims_7_7
+.4byte sEeveeAnims_7_8
+sEeveeAnimTable8:
+.4byte sEeveeAnims_8_1
+.4byte sEeveeAnims_8_2
+.4byte sEeveeAnims_8_3
+.4byte sEeveeAnims_8_4
+.4byte sEeveeAnims_8_5
+.4byte sEeveeAnims_8_6
+.4byte sEeveeAnims_8_7
+.4byte sEeveeAnims_8_8
+sEeveeAnimTable9:
+.4byte sEeveeAnims_9_1
+.4byte sEeveeAnims_9_2
+.4byte sEeveeAnims_9_3
+.4byte sEeveeAnims_9_4
+.4byte sEeveeAnims_9_5
+.4byte sEeveeAnims_9_6
+.4byte sEeveeAnims_9_7
+.4byte sEeveeAnims_9_8
+sEeveeAnimTable10:
+.4byte sEeveeAnims_10_1
+.4byte sEeveeAnims_10_2
+.4byte sEeveeAnims_10_3
+.4byte sEeveeAnims_10_4
+.4byte sEeveeAnims_10_5
+.4byte sEeveeAnims_10_6
+.4byte sEeveeAnims_10_7
+.4byte sEeveeAnims_10_8
+sEeveeAnimTable11:
+.4byte sEeveeAnims_11_1
+.4byte sEeveeAnims_11_2
+.4byte sEeveeAnims_11_3
+.4byte sEeveeAnims_11_4
+.4byte sEeveeAnims_11_5
+.4byte sEeveeAnims_11_6
+.4byte sEeveeAnims_11_7
+.4byte sEeveeAnims_11_8
+sEeveeAnimTable12:
+.4byte sEeveeAnims_12_1
+.4byte sEeveeAnims_12_2
+.4byte sEeveeAnims_12_3
+.4byte sEeveeAnims_12_4
+.4byte sEeveeAnims_12_5
+.4byte sEeveeAnims_12_6
+.4byte sEeveeAnims_12_7
+.4byte sEeveeAnims_12_8
+sEeveeAnimTable13:
+.4byte sEeveeAnims_13_1
+.4byte sEeveeAnims_13_2
+.4byte sEeveeAnims_13_3
+.4byte sEeveeAnims_13_4
+.4byte sEeveeAnims_13_5
+.4byte sEeveeAnims_13_6
+.4byte sEeveeAnims_13_7
+.4byte sEeveeAnims_13_8
+sEeveeAnimTable14:
+.4byte sEeveeAnims_14_1
+.4byte sEeveeAnims_14_2
+.4byte sEeveeAnims_14_3
+.4byte sEeveeAnims_14_4
+.4byte sEeveeAnims_14_5
+.4byte sEeveeAnims_14_6
+.4byte sEeveeAnims_14_7
+.4byte sEeveeAnims_14_8
+sEeveeAnimTable15:
+.4byte sEeveeAnims_15_1
+.4byte sEeveeAnims_15_2
+.4byte sEeveeAnims_15_3
+.4byte sEeveeAnims_15_4
+.4byte sEeveeAnims_15_5
+.4byte sEeveeAnims_15_6
+.4byte sEeveeAnims_15_7
+.4byte sEeveeAnims_15_8
+sEeveeAnimTable16:
+.4byte sEeveeAnims_16_1
+.4byte sEeveeAnims_16_2
+.4byte sEeveeAnims_16_3
+.4byte sEeveeAnims_16_4
+.4byte sEeveeAnims_16_5
+.4byte sEeveeAnims_16_6
+.4byte sEeveeAnims_16_7
+.4byte sEeveeAnims_16_8
+sEeveeAnimTable17:
+.4byte sEeveeAnims_17_1
+.4byte sEeveeAnims_17_2
+.4byte sEeveeAnims_17_3
+.4byte sEeveeAnims_17_4
+.4byte sEeveeAnims_17_5
+.4byte sEeveeAnims_17_6
+.4byte sEeveeAnims_17_7
+.4byte sEeveeAnims_17_8
+sEeveeAnimTable18:
+.4byte sEeveeAnims_18_1
+.4byte sEeveeAnims_18_2
+.4byte sEeveeAnims_18_3
+.4byte sEeveeAnims_18_4
+.4byte sEeveeAnims_18_5
+.4byte sEeveeAnims_18_6
+.4byte sEeveeAnims_18_7
+.4byte sEeveeAnims_18_8
+sEeveeAnimTable19:
+.4byte sEeveeAnims_19_1
+.4byte sEeveeAnims_19_2
+.4byte sEeveeAnims_19_3
+.4byte sEeveeAnims_19_4
+.4byte sEeveeAnims_19_5
+.4byte sEeveeAnims_19_6
+.4byte sEeveeAnims_19_7
+.4byte sEeveeAnims_19_8
+sEeveeAnimTable20:
+.4byte sEeveeAnims_20_1
+.4byte sEeveeAnims_20_2
+.4byte sEeveeAnims_20_3
+.4byte sEeveeAnims_20_4
+.4byte sEeveeAnims_20_5
+.4byte sEeveeAnims_20_6
+.4byte sEeveeAnims_20_7
+.4byte sEeveeAnims_20_8
+sEeveeAnimTable21:
+.4byte sEeveeAnims_21_1
+.4byte sEeveeAnims_21_2
+.4byte sEeveeAnims_21_3
+.4byte sEeveeAnims_21_4
+.4byte sEeveeAnims_21_5
+.4byte sEeveeAnims_21_6
+.4byte sEeveeAnims_21_7
+.4byte sEeveeAnims_21_8
+sEeveeAnimTable22:
+.4byte sEeveeAnims_22_1
+.4byte sEeveeAnims_22_2
+.4byte sEeveeAnims_22_3
+.4byte sEeveeAnims_22_4
+.4byte sEeveeAnims_22_5
+.4byte sEeveeAnims_22_6
+.4byte sEeveeAnims_22_7
+.4byte sEeveeAnims_22_8
+sEeveeAnimTable23:
+.4byte sEeveeAnims_23_1
+.4byte sEeveeAnims_23_2
+.4byte sEeveeAnims_23_3
+.4byte sEeveeAnims_23_4
+.4byte sEeveeAnims_23_5
+.4byte sEeveeAnims_23_6
+.4byte sEeveeAnims_23_7
+.4byte sEeveeAnims_23_8
+sEeveeAnimTable24:
+.4byte sEeveeAnims_24_1
+.4byte sEeveeAnims_24_2
+.4byte sEeveeAnims_24_3
+.4byte sEeveeAnims_24_4
+.4byte sEeveeAnims_24_5
+.4byte sEeveeAnims_24_6
+.4byte sEeveeAnims_24_7
+.4byte sEeveeAnims_24_8
+sEeveeAnimTable25:
+.4byte sEeveeAnims_25_1
+.4byte sEeveeAnims_25_2
+.4byte sEeveeAnims_25_3
+.4byte sEeveeAnims_25_4
+.4byte sEeveeAnims_25_5
+.4byte sEeveeAnims_25_6
+.4byte sEeveeAnims_25_7
+.4byte sEeveeAnims_25_8
+sEeveeAnimTable26:
+.4byte sEeveeAnims_26_1
+.4byte sEeveeAnims_26_2
+.4byte sEeveeAnims_26_3
+.4byte sEeveeAnims_26_4
+.4byte sEeveeAnims_26_5
+.4byte sEeveeAnims_26_6
+.4byte sEeveeAnims_26_7
+.4byte sEeveeAnims_26_8
+sEeveeAnimTable27:
+.4byte sEeveeAnims_27_1
+.4byte sEeveeAnims_27_1
+.4byte sEeveeAnims_27_1
+.4byte sEeveeAnims_27_1
+.4byte sEeveeAnims_27_1
+.4byte sEeveeAnims_27_1
+.4byte sEeveeAnims_27_1
+.4byte sEeveeAnims_27_1
+sEeveeAnimTable28:
+.4byte sEeveeAnims_28_1
+.4byte sEeveeAnims_28_2
+.4byte sEeveeAnims_28_3
+.4byte sEeveeAnims_28_4
+.4byte sEeveeAnims_28_5
+.4byte sEeveeAnims_28_6
+.4byte sEeveeAnims_28_7
+.4byte sEeveeAnims_28_8
+sAxAnimationsEevee:
+.4byte sEeveeAnimTable1
+.4byte sEeveeAnimTable2
+.4byte sEeveeAnimTable3
+.4byte sEeveeAnimTable4
+.4byte sEeveeAnimTable5
+.4byte sEeveeAnimTable6
+.4byte sEeveeAnimTable7
+.4byte sEeveeAnimTable8
+.4byte sEeveeAnimTable9
+.4byte sEeveeAnimTable10
+.4byte sEeveeAnimTable11
+.4byte sEeveeAnimTable12
+.4byte sEeveeAnimTable13
+.4byte sEeveeAnimTable14
+.4byte sEeveeAnimTable15
+.4byte sEeveeAnimTable16
+.4byte sEeveeAnimTable17
+.4byte sEeveeAnimTable18
+.4byte sEeveeAnimTable19
+.4byte sEeveeAnimTable20
+.4byte sEeveeAnimTable21
+.4byte sEeveeAnimTable22
+.4byte sEeveeAnimTable23
+.4byte sEeveeAnimTable24
+.4byte sEeveeAnimTable25
+.4byte sEeveeAnimTable26
+.4byte sEeveeAnimTable27
+.4byte sEeveeAnimTable28
+sAxSpritesEevee:
+.4byte sEeveeSprites1
+.4byte sEeveeSprites2
+.4byte sEeveeSprites3
+.4byte sEeveeSprites4
+.4byte sEeveeSprites5
+.4byte sEeveeSprites6
+.4byte sEeveeSprites7
+.4byte sEeveeSprites8
+.4byte sEeveeSprites9
+.4byte sEeveeSprites10
+.4byte sEeveeSprites11
+.4byte sEeveeSprites12
+.4byte sEeveeSprites13
+.4byte sEeveeSprites14
+.4byte sEeveeSprites15
+.4byte sEeveeSprites16
+.4byte sEeveeSprites17
+.4byte sEeveeSprites18
+.4byte sEeveeSprites19
+.4byte sEeveeSprites20
+.4byte sEeveeSprites21
+.4byte sEeveeSprites22
+.4byte sEeveeSprites23
+.4byte sEeveeSprites24
+.4byte sEeveeSprites25
+.4byte sEeveeSprites26
+.4byte sEeveeSprites27
+.4byte sEeveeSprites28
+.4byte sEeveeSprites29
+.4byte sEeveeSprites30
+.4byte sEeveeSprites31
+.4byte sEeveeSprites32
+.4byte sEeveeSprites33
+.4byte sEeveeSprites34
+.4byte sEeveeSprites35
+.4byte sEeveeSprites36
+.4byte sEeveeSprites37
+.4byte sEeveeSprites38
+.4byte sEeveeSprites39
+.4byte sEeveeSprites40
+.4byte sEeveeSprites41
+.4byte sEeveeSprites42
+.4byte sEeveeSprites43
+.4byte sEeveeSprites44
+.4byte sEeveeSprites45
+.4byte sEeveeSprites46
+.4byte sEeveeSprites47
+.4byte sEeveeSprites48
+.4byte sEeveeSprites49
+.4byte sEeveeSprites50
+.4byte sEeveeSprites51
+.4byte sEeveeSprites52
+.4byte sEeveeSprites53
+.4byte sEeveeSprites54
+.4byte sEeveeSprites55
+.4byte sEeveeSprites56
+.4byte sEeveeSprites57
+.4byte sEeveeSprites58
+.4byte sEeveeSprites59
+.4byte sEeveeSprites60
+.4byte sEeveeSprites61
+.4byte sEeveeSprites62
+.4byte sEeveeSprites63
+.4byte sEeveeSprites64
+.4byte sEeveeSprites65
+.4byte sEeveeSprites66
+.4byte sEeveeSprites67
+.4byte sEeveeSprites68
+.4byte sEeveeSprites69
+.4byte sEeveeSprites70
+.4byte sEeveeSprites71
+sAxMainEevee:
+ax_main sAxPosesEevee, sAxAnimationsEevee, 28, sAxSpritesEevee, sAxPositionsEevee

--- a/data/ax/ekans.inc
+++ b/data/ax/ekans.inc
@@ -1,0 +1,3080 @@
+.global gAxEkans
+gAxEkans:
+ax_siro sAxMainEkans
+sEkansPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose4:
+ax_pose 3, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose5:
+ax_pose 4, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose6:
+ax_pose 5, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose7:
+ax_pose 6, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose8:
+ax_pose 7, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose9:
+ax_pose 8, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose10:
+ax_pose 9, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose11:
+ax_pose 10, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose12:
+ax_pose 11, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose16:
+ax_pose 15, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose17:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose18:
+ax_pose 17, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose19:
+ax_pose 18, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose20:
+ax_pose 19, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose21:
+ax_pose 20, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose22:
+ax_pose 21, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose23:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose24:
+ax_pose 23, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose26:
+ax_pose 24, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose27:
+ax_pose 25, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose28:
+ax_pose 3, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose29:
+ax_pose 26, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose30:
+ax_pose 27, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose31:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose32:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose33:
+ax_pose 29, 0x81e4, 0x8101, 0x2c00
+ax_pose 30, 0x01f4, 0x40f1, 0x2c08
+ax_pose 31, 0x01ec, 0x0111, 0x2c0c
+ax_pose 32, 0x01ec, 0x00f1, 0x2c0d
+ax_pose_terminator
+sEkansPose34:
+ax_pose 9, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose35:
+ax_pose 33, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose36:
+ax_pose 34, 0x81e7, 0x80ff, 0x2c00
+ax_pose 35, 0x01f7, 0x40ef, 0x2c08
+ax_pose 36, 0x01f7, 0x00e7, 0x2c0c
+ax_pose_terminator
+sEkansPose37:
+ax_pose 12, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose38:
+ax_pose 37, 0x81eb, 0x80f7, 0x2c00
+ax_pose 38, 0x41e3, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose39:
+ax_pose 39, 0x81ec, 0x80f7, 0x2c00
+ax_pose 40, 0x41e4, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose40:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose41:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose42:
+ax_pose 42, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sEkansPose43:
+ax_pose 18, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose44:
+ax_pose 43, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sEkansPose45:
+ax_pose 44, 0x81e4, 0x80eb, 0x2c00
+ax_pose 45, 0x01f4, 0x40fb, 0x2c08
+ax_pose 46, 0x81f2, 0x010b, 0x2c0c
+ax_pose_terminator
+sEkansPose46:
+ax_pose 21, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose47:
+ax_pose 47, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose48:
+ax_pose 48, 0x01e9, 0x80ed, 0x2c00
+ax_pose_terminator
+sEkansPose49:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose50:
+ax_pose 24, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose51:
+ax_pose 25, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose52:
+ax_pose 3, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose53:
+ax_pose 26, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose54:
+ax_pose 27, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose55:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose56:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose57:
+ax_pose 29, 0x81e4, 0x8101, 0x2c00
+ax_pose 30, 0x01f4, 0x40f1, 0x2c08
+ax_pose 31, 0x01ec, 0x0111, 0x2c0c
+ax_pose 32, 0x01ec, 0x00f1, 0x2c0d
+ax_pose_terminator
+sEkansPose58:
+ax_pose 9, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose59:
+ax_pose 33, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose60:
+ax_pose 34, 0x81e7, 0x80ff, 0x2c00
+ax_pose 35, 0x01f7, 0x40ef, 0x2c08
+ax_pose 36, 0x01f7, 0x00e7, 0x2c0c
+ax_pose_terminator
+sEkansPose61:
+ax_pose 12, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose62:
+ax_pose 37, 0x81eb, 0x80f7, 0x2c00
+ax_pose 38, 0x41e3, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose63:
+ax_pose 39, 0x81ec, 0x80f7, 0x2c00
+ax_pose 40, 0x41e4, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose64:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose65:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose66:
+ax_pose 42, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sEkansPose67:
+ax_pose 18, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose68:
+ax_pose 43, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sEkansPose69:
+ax_pose 44, 0x81e4, 0x80eb, 0x2c00
+ax_pose 45, 0x01f4, 0x40fb, 0x2c08
+ax_pose 46, 0x81f2, 0x010b, 0x2c0c
+ax_pose_terminator
+sEkansPose70:
+ax_pose 21, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose71:
+ax_pose 47, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose72:
+ax_pose 48, 0x01e9, 0x80ed, 0x2c00
+ax_pose_terminator
+sEkansPose73:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose74:
+ax_pose 24, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose75:
+ax_pose 25, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose76:
+ax_pose 49, 0x81eb, 0x80fc, 0x2c00
+ax_pose 50, 0x81fb, 0x00f4, 0x2c08
+ax_pose 51, 0x020b, 0x00fa, 0x2c0a
+ax_pose_terminator
+sEkansPose77:
+ax_pose 3, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose78:
+ax_pose 26, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose79:
+ax_pose 27, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose80:
+ax_pose 52, 0x81e5, 0x80f1, 0x2c00
+ax_pose 53, 0x01f5, 0x4101, 0x2c08
+ax_pose 54, 0x81f5, 0x0111, 0x2c0c
+ax_pose_terminator
+sEkansPose81:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose82:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose83:
+ax_pose 29, 0x81e4, 0x8101, 0x2c00
+ax_pose 30, 0x01f4, 0x40f1, 0x2c08
+ax_pose 31, 0x01ec, 0x0111, 0x2c0c
+ax_pose 32, 0x01ec, 0x00f1, 0x2c0d
+ax_pose_terminator
+sEkansPose84:
+ax_pose 55, 0x41f3, 0x80ed, 0x2c00
+ax_pose 56, 0x01ee, 0x410d, 0x2c08
+ax_pose 57, 0x81f3, 0x00e5, 0x2c0c
+ax_pose_terminator
+sEkansPose85:
+ax_pose 9, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose86:
+ax_pose 33, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose87:
+ax_pose 34, 0x81e6, 0x8100, 0x2c00
+ax_pose 35, 0x01f6, 0x40f0, 0x2c08
+ax_pose 36, 0x01f6, 0x00e8, 0x2c0c
+ax_pose_terminator
+sEkansPose88:
+ax_pose 58, 0x81e4, 0x8103, 0x2c00
+ax_pose 59, 0x01f4, 0x40f3, 0x2c08
+ax_pose 60, 0x81f4, 0x00eb, 0x2c0c
+ax_pose_terminator
+sEkansPose89:
+ax_pose 12, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose90:
+ax_pose 37, 0x81e8, 0x80f7, 0x2c00
+ax_pose 38, 0x41e0, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose91:
+ax_pose 39, 0x81e7, 0x80f7, 0x2c00
+ax_pose 40, 0x41df, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose92:
+ax_pose 61, 0x81ea, 0x80f8, 0x2c00
+ax_pose 62, 0x01da, 0x40f8, 0x2c08
+ax_pose_terminator
+sEkansPose93:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose94:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose95:
+ax_pose 42, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sEkansPose96:
+ax_pose 63, 0x81e6, 0x80eb, 0x2c00
+ax_pose 64, 0x01f6, 0x40fb, 0x2c08
+ax_pose 65, 0x81f6, 0x010b, 0x2c0c
+ax_pose_terminator
+sEkansPose97:
+ax_pose 18, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose98:
+ax_pose 43, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sEkansPose99:
+ax_pose 44, 0x81e4, 0x80eb, 0x2c00
+ax_pose 45, 0x01f4, 0x40fb, 0x2c08
+ax_pose 46, 0x81f2, 0x010b, 0x2c0c
+ax_pose_terminator
+sEkansPose100:
+ax_pose 66, 0x41f4, 0x80e5, 0x2c00
+ax_pose 67, 0x01f4, 0x4105, 0x2c08
+ax_pose 68, 0x41ec, 0x00e5, 0x2c0c
+ax_pose 69, 0x01f6, 0x0115, 0x2c0e
+ax_pose_terminator
+sEkansPose101:
+ax_pose 21, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose102:
+ax_pose 47, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose103:
+ax_pose 48, 0x01e9, 0x80ed, 0x2c00
+ax_pose_terminator
+sEkansPose104:
+ax_pose 70, 0x41f5, 0x80e8, 0x2c00
+ax_pose 71, 0x81ec, 0x0108, 0x2c08
+ax_pose_terminator
+sEkansPose105:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose106:
+ax_pose 24, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose107:
+ax_pose 25, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose108:
+ax_pose 49, 0x81eb, 0x80fc, 0x2c00
+ax_pose 50, 0x81fb, 0x00f4, 0x2c08
+ax_pose 51, 0x020b, 0x00fa, 0x2c0a
+ax_pose_terminator
+sEkansPose109:
+ax_pose 3, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose110:
+ax_pose 26, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose111:
+ax_pose 27, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose112:
+ax_pose 52, 0x81e5, 0x80f1, 0x2c00
+ax_pose 53, 0x01f5, 0x4101, 0x2c08
+ax_pose 54, 0x81f5, 0x0111, 0x2c0c
+ax_pose_terminator
+sEkansPose113:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose114:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose115:
+ax_pose 29, 0x81e4, 0x8101, 0x2c00
+ax_pose 30, 0x01f4, 0x40f1, 0x2c08
+ax_pose 31, 0x01ec, 0x0111, 0x2c0c
+ax_pose 32, 0x01ec, 0x00f1, 0x2c0d
+ax_pose_terminator
+sEkansPose116:
+ax_pose 55, 0x41f3, 0x80ed, 0x2c00
+ax_pose 56, 0x01ee, 0x410d, 0x2c08
+ax_pose 57, 0x81f3, 0x00e5, 0x2c0c
+ax_pose_terminator
+sEkansPose117:
+ax_pose 9, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose118:
+ax_pose 33, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose119:
+ax_pose 34, 0x81e6, 0x8100, 0x2c00
+ax_pose 35, 0x01f6, 0x40f0, 0x2c08
+ax_pose 36, 0x01f6, 0x00e8, 0x2c0c
+ax_pose_terminator
+sEkansPose120:
+ax_pose 58, 0x81e4, 0x8103, 0x2c00
+ax_pose 59, 0x01f4, 0x40f3, 0x2c08
+ax_pose 60, 0x81f4, 0x00eb, 0x2c0c
+ax_pose_terminator
+sEkansPose121:
+ax_pose 12, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose122:
+ax_pose 37, 0x81e8, 0x80f7, 0x2c00
+ax_pose 38, 0x41e0, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose123:
+ax_pose 39, 0x81e7, 0x80f7, 0x2c00
+ax_pose 40, 0x41df, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose124:
+ax_pose 61, 0x81ea, 0x80f8, 0x2c00
+ax_pose 62, 0x01da, 0x40f8, 0x2c08
+ax_pose_terminator
+sEkansPose125:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose126:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose127:
+ax_pose 42, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sEkansPose128:
+ax_pose 63, 0x81e6, 0x80eb, 0x2c00
+ax_pose 64, 0x01f6, 0x40fb, 0x2c08
+ax_pose 65, 0x81f6, 0x010b, 0x2c0c
+ax_pose_terminator
+sEkansPose129:
+ax_pose 18, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose130:
+ax_pose 43, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sEkansPose131:
+ax_pose 44, 0x81e4, 0x80eb, 0x2c00
+ax_pose 45, 0x01f4, 0x40fb, 0x2c08
+ax_pose 46, 0x81f2, 0x010b, 0x2c0c
+ax_pose_terminator
+sEkansPose132:
+ax_pose 66, 0x41f4, 0x80e5, 0x2c00
+ax_pose 67, 0x01f4, 0x4105, 0x2c08
+ax_pose 68, 0x41ec, 0x00e5, 0x2c0c
+ax_pose 69, 0x01f6, 0x0115, 0x2c0e
+ax_pose_terminator
+sEkansPose133:
+ax_pose 21, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose134:
+ax_pose 47, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose135:
+ax_pose 48, 0x01e9, 0x80ed, 0x2c00
+ax_pose_terminator
+sEkansPose136:
+ax_pose 70, 0x41f5, 0x80e8, 0x2c00
+ax_pose 71, 0x81ec, 0x0108, 0x2c08
+ax_pose_terminator
+sEkansPose137:
+ax_pose 72, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose138:
+ax_pose 73, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose139:
+ax_pose 74, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose140:
+ax_pose 75, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sEkansPose141:
+ax_pose 76, 0x01e5, 0x90f4, 0x2c00
+ax_pose_terminator
+sEkansPose142:
+ax_pose 77, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sEkansPose143:
+ax_pose 78, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose144:
+ax_pose 77, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose145:
+ax_pose 76, 0x01e5, 0x80ec, 0x2c00
+ax_pose_terminator
+sEkansPose146:
+ax_pose 75, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose147:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose148:
+ax_pose 1, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose149:
+ax_pose 2, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose150:
+ax_pose 3, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose151:
+ax_pose 4, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose152:
+ax_pose 5, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose153:
+ax_pose 6, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose154:
+ax_pose 7, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose155:
+ax_pose 8, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose156:
+ax_pose 9, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose157:
+ax_pose 10, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose158:
+ax_pose 11, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose159:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose160:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose161:
+ax_pose 14, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose162:
+ax_pose 15, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose163:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose164:
+ax_pose 17, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose165:
+ax_pose 18, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose166:
+ax_pose 19, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose167:
+ax_pose 20, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose168:
+ax_pose 21, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose169:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose170:
+ax_pose 23, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose171:
+ax_pose 1, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose172:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose173:
+ax_pose 19, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose174:
+ax_pose 16, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose175:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose176:
+ax_pose 10, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose177:
+ax_pose 7, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose178:
+ax_pose 4, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose179:
+ax_pose 24, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose180:
+ax_pose 26, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose181:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose182:
+ax_pose 33, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose183:
+ax_pose 37, 0x81ea, 0x80f8, 0x2c00
+ax_pose 38, 0x41e2, 0x00f8, 0x2c08
+ax_pose_terminator
+sEkansPose184:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose185:
+ax_pose 43, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sEkansPose186:
+ax_pose 47, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose187:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose188:
+ax_pose 24, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose189:
+ax_pose 25, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose190:
+ax_pose 3, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose191:
+ax_pose 26, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose192:
+ax_pose 27, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose193:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose194:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose195:
+ax_pose 29, 0x81e4, 0x80ff, 0x2c00
+ax_pose 30, 0x01f4, 0x40ef, 0x2c08
+ax_pose 31, 0x01ec, 0x010f, 0x2c0c
+ax_pose 32, 0x01ec, 0x00ef, 0x2c0d
+ax_pose_terminator
+sEkansPose196:
+ax_pose 9, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose197:
+ax_pose 33, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEkansPose198:
+ax_pose 34, 0x81e6, 0x80fe, 0x2c00
+ax_pose 35, 0x01f6, 0x40ee, 0x2c08
+ax_pose 36, 0x01f6, 0x00e6, 0x2c0c
+ax_pose_terminator
+sEkansPose199:
+ax_pose 12, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose200:
+ax_pose 37, 0x81e8, 0x80f7, 0x2c00
+ax_pose 38, 0x41e0, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose201:
+ax_pose 39, 0x81e7, 0x80f7, 0x2c00
+ax_pose 40, 0x41df, 0x00f7, 0x2c08
+ax_pose_terminator
+sEkansPose202:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose203:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose204:
+ax_pose 42, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sEkansPose205:
+ax_pose 18, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose206:
+ax_pose 43, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sEkansPose207:
+ax_pose 44, 0x81e4, 0x80ed, 0x2c00
+ax_pose 45, 0x01f4, 0x40fd, 0x2c08
+ax_pose 46, 0x81f2, 0x010d, 0x2c0c
+ax_pose_terminator
+sEkansPose208:
+ax_pose 21, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose209:
+ax_pose 47, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose210:
+ax_pose 48, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sEkansPose211:
+ax_pose 24, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose212:
+ax_pose 47, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose213:
+ax_pose 43, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sEkansPose214:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose215:
+ax_pose 37, 0x81ea, 0x80f8, 0x2c00
+ax_pose 38, 0x41e2, 0x00f8, 0x2c08
+ax_pose_terminator
+sEkansPose216:
+ax_pose 33, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEkansPose217:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose218:
+ax_pose 26, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose219:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose220:
+ax_pose 21, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sEkansPose221:
+ax_pose 18, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sEkansPose222:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose223:
+ax_pose 12, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sEkansPose224:
+ax_pose 9, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sEkansPose225:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sEkansPose226:
+ax_pose 3, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+.align 2
+sEkansAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 3, 0, 3,
+ax_anim 6, 0, 1, 0, 4, 0, 4,
+ax_anim 6, 0, 0, 0, 3, 0, 3,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, -1,
+ax_anim_terminator
+sEkansAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 3, 3, 3, 3,
+ax_anim 6, 0, 4, 4, 4, 4, 4,
+ax_anim 6, 0, 3, 4, 4, 4, 4,
+ax_anim 6, 0, 5, 2, 2, 2, 2,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 3, 0, 3, 0,
+ax_anim 6, 0, 7, 4, 0, 4, 0,
+ax_anim 6, 0, 6, 5, 0, 5, 0,
+ax_anim 6, 0, 8, 4, 0, 4, 0,
+ax_anim 6, 0, 8, 1, 0, 2, 0,
+ax_anim_terminator
+sEkansAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 2, -2, 2, -2,
+ax_anim 6, 0, 10, 3, -3, 3, -3,
+ax_anim 6, 0, 9, 3, -3, 3, -3,
+ax_anim 6, 0, 11, 2, -2, 2, -2,
+ax_anim 6, 0, 11, 1, -1, 1, -1,
+ax_anim_terminator
+sEkansAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, -3,
+ax_anim 6, 0, 13, 0, -4, 0, -4,
+ax_anim 6, 0, 12, 0, -3, 0, -3,
+ax_anim 6, 0, 14, 0, -2, 0, -2,
+ax_anim 6, 0, 14, 0, -1, 0, -1,
+ax_anim_terminator
+sEkansAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -2, -2, -2, -2,
+ax_anim 6, 0, 16, -3, -3, -3, -3,
+ax_anim 6, 0, 15, -3, -3, -3, -3,
+ax_anim 6, 0, 17, -2, -2, -2, -2,
+ax_anim 6, 0, 17, -1, -1, -1, -1,
+ax_anim_terminator
+sEkansAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -3, 0, -3, 0,
+ax_anim 6, 0, 19, -4, 0, -4, 0,
+ax_anim 6, 0, 18, -5, 0, -5, 0,
+ax_anim 6, 0, 20, -4, 0, -4, 0,
+ax_anim 6, 0, 20, -1, 0, -1, 0,
+ax_anim_terminator
+sEkansAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -2, 2, -2, 2,
+ax_anim 6, 0, 22, -3, 3, -3, 3,
+ax_anim 6, 0, 21, -5, 4, -5, 4,
+ax_anim 6, 0, 23, -4, 3, -4, 3,
+ax_anim 6, 0, 23, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sEkansAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 6, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, -1, 18, -1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, -1, 18, -1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sEkansAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 6, 0, 28, -1, -1, 0, 0,
+ax_anim 2, 0, 28, 3, 2, 4, 4,
+ax_anim 2, 2, 28, 9, 9, 9, 9,
+ax_anim 2, 0, 29, 14, 14, 14, 14,
+ax_anim 2, 1, 29, 13, 15, 13, 15,
+ax_anim 2, 0, 29, 14, 14, 14, 14,
+ax_anim 2, 0, 29, 13, 15, 13, 15,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sEkansAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 6, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 31, 8, 0, 10, 0,
+ax_anim 2, 0, 32, 14, 0, 18, 0,
+ax_anim 2, 1, 32, 14, 1, 18, 0,
+ax_anim 2, 0, 32, 14, 0, 18, 0,
+ax_anim 2, 0, 32, 14, 1, 18, 0,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sEkansAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 6, 0, 34, -1, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim 2, 2, 34, 6, -6, 7, -7,
+ax_anim 2, 0, 35, 10, -10, 12, -12,
+ax_anim 2, 1, 35, 11, -9, 13, -11,
+ax_anim 2, 0, 35, 10, -10, 12, -12,
+ax_anim 2, 0, 35, 11, -9, 13, -11,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sEkansAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 6, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -3, 0, -3,
+ax_anim 2, 2, 37, 0, -5, 0, -6,
+ax_anim 2, 0, 38, 0, -10, 0, -10,
+ax_anim 2, 1, 38, 1, -10, 1, -10,
+ax_anim 2, 0, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 38, 1, -10, 1, -10,
+ax_anim 4, 0, 36, 0, -3, 0, -5,
+ax_anim_terminator
+sEkansAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 6, 0, 40, 0, 0, 0, -1,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim 2, 2, 40, -6, -6, -7, -7,
+ax_anim 2, 0, 41, -10, -10, -12, -12,
+ax_anim 2, 1, 41, -11, -9, -13, -11,
+ax_anim 2, 0, 41, -10, -10, -12, -12,
+ax_anim 2, 0, 41, -11, -9, -13, -11,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sEkansAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 6, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 43, -8, 0, -10, 0,
+ax_anim 2, 0, 44, -14, 0, -18, 0,
+ax_anim 2, 1, 44, -14, 1, -18, 0,
+ax_anim 2, 0, 44, -14, 0, -18, 0,
+ax_anim 2, 0, 44, -14, 1, -18, 0,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sEkansAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 6, 0, 46, 1, -1, 0, 0,
+ax_anim 2, 0, 46, -3, 2, -4, 4,
+ax_anim 2, 2, 46, -9, 9, -9, 9,
+ax_anim 2, 0, 47, -14, 14, -14, 14,
+ax_anim 2, 1, 47, -13, 15, -13, 15,
+ax_anim 2, 0, 47, -14, 14, -14, 14,
+ax_anim 2, 0, 47, -13, 15, -13, 15,
+ax_anim 4, 0, 45, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sEkansAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, -1, 18, -1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, -1, 18, -1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sEkansAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 6, 0, 52, -1, -1, 0, 0,
+ax_anim 2, 0, 52, 3, 2, 4, 4,
+ax_anim 2, 2, 52, 9, 9, 9, 9,
+ax_anim 2, 0, 53, 14, 14, 14, 14,
+ax_anim 2, 1, 53, 13, 15, 13, 15,
+ax_anim 2, 0, 53, 14, 14, 14, 14,
+ax_anim 2, 0, 53, 13, 15, 13, 15,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sEkansAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 6, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 2, 55, 8, 0, 10, 0,
+ax_anim 2, 0, 56, 14, 0, 18, 0,
+ax_anim 2, 1, 56, 14, 1, 18, 0,
+ax_anim 2, 0, 56, 14, 0, 18, 0,
+ax_anim 2, 0, 56, 14, 1, 18, 0,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sEkansAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 6, 0, 58, -1, -1, 0, -1,
+ax_anim 2, 0, 58, 4, -4, 4, -4,
+ax_anim 2, 2, 58, 6, -6, 7, -7,
+ax_anim 2, 0, 59, 10, -10, 12, -12,
+ax_anim 2, 1, 59, 11, -9, 13, -11,
+ax_anim 2, 0, 59, 10, -10, 12, -12,
+ax_anim 2, 0, 59, 11, -9, 13, -11,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sEkansAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 6, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -3, 0, -3,
+ax_anim 2, 2, 61, 0, -5, 0, -6,
+ax_anim 2, 0, 62, 0, -10, 0, -10,
+ax_anim 2, 1, 62, 1, -10, 1, -10,
+ax_anim 2, 0, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 62, 1, -10, 1, -10,
+ax_anim 4, 0, 60, 0, -3, 0, -5,
+ax_anim_terminator
+sEkansAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 6, 0, 64, 0, 0, 0, -1,
+ax_anim 2, 0, 64, -4, -4, -4, -4,
+ax_anim 2, 2, 64, -6, -6, -7, -7,
+ax_anim 2, 0, 65, -10, -10, -12, -12,
+ax_anim 2, 1, 65, -11, -9, -13, -11,
+ax_anim 2, 0, 65, -10, -10, -12, -12,
+ax_anim 2, 0, 65, -11, -9, -13, -11,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sEkansAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 6, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 67, -8, 0, -10, 0,
+ax_anim 2, 0, 68, -14, 0, -18, 0,
+ax_anim 2, 1, 68, -14, 1, -18, 0,
+ax_anim 2, 0, 68, -14, 0, -18, 0,
+ax_anim 2, 0, 68, -14, 1, -18, 0,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sEkansAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 6, 0, 70, 1, -1, 0, 0,
+ax_anim 2, 0, 70, -3, 2, -4, 4,
+ax_anim 2, 2, 70, -9, 9, -9, 9,
+ax_anim 2, 0, 71, -14, 14, -14, 14,
+ax_anim 2, 1, 71, -13, 15, -13, 15,
+ax_anim 2, 0, 71, -14, 14, -14, 14,
+ax_anim 2, 0, 71, -13, 15, -13, 15,
+ax_anim 4, 0, 69, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sEkansAnims_4_1:
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 6, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 1,
+ax_anim 2, 0, 75, 0, 1, 0, 3,
+ax_anim 2, 2, 75, -1, 1, -1, 3,
+ax_anim 2, 0, 75, 0, 1, 0, 3,
+ax_anim 2, 0, 75, -1, 1, -1, 3,
+ax_anim 2, 0, 75, 0, 1, 0, 3,
+ax_anim 2, 1, 75, -1, 1, -1, 3,
+ax_anim 2, 0, 75, 0, 1, 0, 3,
+ax_anim 2, 0, 75, -1, 1, -1, 3,
+ax_anim 4, 0, 74, 0, 1, 0, 0,
+ax_anim_terminator
+sEkansAnims_4_2:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 6, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 2, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 3, 1, 3, 1,
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 3, 1, 3, 1,
+ax_anim 2, 1, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 3, 1, 3, 1,
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 4, 0, 78, 1, 1, 1, 1,
+ax_anim_terminator
+sEkansAnims_4_3:
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 6, 0, 81, -2, 0, -2, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 2, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 1, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 4, 0, 82, 1, 0, 1, 0,
+ax_anim_terminator
+sEkansAnims_4_4:
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 6, 0, 85, -2, 2, -2, 2,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 2, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 1, -3, 1, -3,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 1, -3, 1, -3,
+ax_anim 2, 1, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 1, -3, 1, -3,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 4, 0, 86, 1, -1, 1, -1,
+ax_anim_terminator
+sEkansAnims_4_5:
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim 6, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 2, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 1, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 4, 0, 90, 0, -1, 0, -1,
+ax_anim_terminator
+sEkansAnims_4_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 6, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 2, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -3, -1, -3,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -3, -1, -3,
+ax_anim 2, 1, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -3, -1, -3,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 4, 0, 94, -1, -1, -1, -1,
+ax_anim_terminator
+sEkansAnims_4_7:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 6, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 2, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 1, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 4, 0, 98, -1, 0, -1, 0,
+ax_anim_terminator
+sEkansAnims_4_8:
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 6, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 2, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 1, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 4, 0, 102, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sEkansAnims_5_1:
+ax_anim 2, 0, 105, 0, -1, 0, -1,
+ax_anim 6, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 1,
+ax_anim 2, 0, 107, 0, 1, 0, 3,
+ax_anim 2, 2, 107, -1, 1, -1, 3,
+ax_anim 2, 0, 107, 0, 1, 0, 3,
+ax_anim 2, 0, 107, -1, 1, -1, 3,
+ax_anim 2, 0, 107, 0, 1, 0, 3,
+ax_anim 2, 1, 107, -1, 1, -1, 3,
+ax_anim 2, 0, 107, 0, 1, 0, 3,
+ax_anim 2, 0, 107, -1, 1, -1, 3,
+ax_anim 4, 0, 106, 0, 1, 0, 0,
+ax_anim_terminator
+sEkansAnims_5_2:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 6, 0, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 2, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 111, 3, 1, 3, 1,
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 111, 3, 1, 3, 1,
+ax_anim 2, 1, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 111, 3, 1, 3, 1,
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 4, 0, 110, 1, 1, 1, 1,
+ax_anim_terminator
+sEkansAnims_5_3:
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim 6, 0, 113, -2, 0, -2, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 2, 115, 2, 0, 2, 0,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 1, 115, 2, 0, 2, 0,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 4, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sEkansAnims_5_4:
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 6, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 2, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 1, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim 4, 0, 118, 1, -1, 1, -1,
+ax_anim_terminator
+sEkansAnims_5_5:
+ax_anim 2, 0, 121, 0, 1, 0, 1,
+ax_anim 6, 0, 121, 0, 2, 0, 2,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 2, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 1, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 4, 0, 122, 0, -1, 0, -1,
+ax_anim_terminator
+sEkansAnims_5_6:
+ax_anim 2, 0, 125, 1, 1, 1, 1,
+ax_anim 6, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 2, 127, -2, -2, -2, -2,
+ax_anim 2, 0, 127, -1, -3, -1, -3,
+ax_anim 2, 0, 127, -2, -2, -2, -2,
+ax_anim 2, 0, 127, -1, -3, -1, -3,
+ax_anim 2, 1, 127, -2, -2, -2, -2,
+ax_anim 2, 0, 127, -1, -3, -1, -3,
+ax_anim 2, 0, 127, -2, -2, -2, -2,
+ax_anim 4, 0, 126, -1, -1, -1, -1,
+ax_anim_terminator
+sEkansAnims_5_7:
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 6, 0, 129, 2, 0, 2, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 2, 131, -2, 0, -2, 0,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 131, -2, 0, -2, 0,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 1, 131, -2, 0, -2, 0,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 131, -2, 0, -2, 0,
+ax_anim 4, 0, 130, -1, 0, -1, 0,
+ax_anim_terminator
+sEkansAnims_5_8:
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 6, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 1, -1, 1,
+ax_anim 2, 2, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 1, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 4, 0, 134, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sEkansAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEkansAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sEkansAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sEkansAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sEkansAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sEkansAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sEkansAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sEkansAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sEkansAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sEkansAnims_8_1:
+ax_anim 16, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 148, 0, -1, 0, -1,
+ax_anim_terminator
+sEkansAnims_8_2:
+ax_anim 16, 0, 149, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_8_3:
+ax_anim 16, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_8_4:
+ax_anim 16, 0, 155, 0, 0, 0, 0,
+ax_anim 16, 0, 157, -1, 1, -1, 1,
+ax_anim_terminator
+sEkansAnims_8_5:
+ax_anim 16, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 160, 0, 1, 0, 1,
+ax_anim_terminator
+sEkansAnims_8_6:
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_8_7:
+ax_anim 16, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_8_8:
+ax_anim 16, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 169, 0, -1, 0, -1,
+ax_anim_terminator
+.align 2
+sEkansAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 10, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 19,
+ax_anim 3, 0, 174, 0, 19, 0, 24,
+ax_anim 2, 3, 175, -7, 17, -7, 19,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 22, 9, 22, 9,
+ax_anim 3, 0, 173, 16, 19, 16, 19,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 3, 16, 3, 16,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 15, -4, 15, -4,
+ax_anim 3, 0, 172, 16, 1, 16, 1,
+ax_anim 2, 3, 173, 14, 5, 14, 5,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -20, 11, -20,
+ax_anim 3, 0, 171, 16, -20, 16, -20,
+ax_anim 2, 3, 172, 18, -12, 18, -12,
+ax_anim 2, 0, 173, 16, -6, 16, -6,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -10, -10, -10, -10,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -19, 0, -19,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 10, -8, 10, -8,
+ax_anim 1, 0, 173, 5, -4, 5, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -20, -11, -20,
+ax_anim 3, 0, 177, -16, -20, -16, -20,
+ax_anim 2, 3, 176, -18, -12, -18, -12,
+ax_anim 2, 0, 175, -16, -6, -16, -6,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -8, -6, -8, -6,
+ax_anim 2, 0, 177, -15, -4, -15, -4,
+ax_anim 3, 0, 176, -16, 1, -16, 1,
+ax_anim 2, 3, 175, -14, 5, -14, 5,
+ax_anim 2, 0, 174, -9, 7, -9, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 2, -19, 2,
+ax_anim 2, 0, 176, -22, 9, -22, 9,
+ax_anim 3, 0, 175, -16, 19, -16, 19,
+ax_anim 2, 3, 174, -9, 19, -9, 19,
+ax_anim 2, 0, 173, -3, 16, -3, 16,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEkansAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEkansAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEkansAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEkansAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sEkansGfx1:
+.incbin "baserom.gba", 0x600E68, 0x200
+sEkansSprites1:
+ax_sprite sEkansGfx1, 0x200
+ax_sprite_terminator
+sEkansGfx2:
+.incbin "baserom.gba", 0x601078, 0x200
+sEkansSprites2:
+ax_sprite sEkansGfx2, 0x200
+ax_sprite_terminator
+sEkansGfx3:
+.incbin "baserom.gba", 0x601288, 0x200
+sEkansSprites3:
+ax_sprite sEkansGfx3, 0x200
+ax_sprite_terminator
+sEkansGfx4:
+.incbin "baserom.gba", 0x601498, 0x200
+sEkansSprites4:
+ax_sprite sEkansGfx4, 0x200
+ax_sprite_terminator
+sEkansGfx5:
+.incbin "baserom.gba", 0x6016A8, 0x200
+sEkansSprites5:
+ax_sprite sEkansGfx5, 0x200
+ax_sprite_terminator
+sEkansGfx6:
+.incbin "baserom.gba", 0x6018B8, 0x200
+sEkansSprites6:
+ax_sprite sEkansGfx6, 0x200
+ax_sprite_terminator
+sEkansGfx7:
+.incbin "baserom.gba", 0x601AC8, 0x200
+sEkansSprites7:
+ax_sprite sEkansGfx7, 0x200
+ax_sprite_terminator
+sEkansGfx8:
+.incbin "baserom.gba", 0x601CD8, 0x200
+sEkansSprites8:
+ax_sprite sEkansGfx8, 0x200
+ax_sprite_terminator
+sEkansGfx9:
+.incbin "baserom.gba", 0x601EE8, 0x200
+sEkansSprites9:
+ax_sprite sEkansGfx9, 0x200
+ax_sprite_terminator
+sEkansGfx10:
+.incbin "baserom.gba", 0x6020F8, 0x200
+sEkansSprites10:
+ax_sprite sEkansGfx10, 0x200
+ax_sprite_terminator
+sEkansGfx11:
+.incbin "baserom.gba", 0x602308, 0x200
+sEkansSprites11:
+ax_sprite sEkansGfx11, 0x200
+ax_sprite_terminator
+sEkansGfx12:
+.incbin "baserom.gba", 0x602518, 0x200
+sEkansSprites12:
+ax_sprite sEkansGfx12, 0x200
+ax_sprite_terminator
+sEkansGfx13:
+.incbin "baserom.gba", 0x602728, 0x200
+sEkansSprites13:
+ax_sprite sEkansGfx13, 0x200
+ax_sprite_terminator
+sEkansGfx14:
+.incbin "baserom.gba", 0x602938, 0x200
+sEkansSprites14:
+ax_sprite sEkansGfx14, 0x200
+ax_sprite_terminator
+sEkansGfx15:
+.incbin "baserom.gba", 0x602B48, 0x200
+sEkansSprites15:
+ax_sprite sEkansGfx15, 0x200
+ax_sprite_terminator
+sEkansGfx16:
+.incbin "baserom.gba", 0x602D58, 0x200
+sEkansSprites16:
+ax_sprite sEkansGfx16, 0x200
+ax_sprite_terminator
+sEkansGfx17:
+.incbin "baserom.gba", 0x602F68, 0x200
+sEkansSprites17:
+ax_sprite sEkansGfx17, 0x200
+ax_sprite_terminator
+sEkansGfx18:
+.incbin "baserom.gba", 0x603178, 0x200
+sEkansSprites18:
+ax_sprite sEkansGfx18, 0x200
+ax_sprite_terminator
+sEkansGfx19:
+.incbin "baserom.gba", 0x603388, 0x200
+sEkansSprites19:
+ax_sprite sEkansGfx19, 0x200
+ax_sprite_terminator
+sEkansGfx20:
+.incbin "baserom.gba", 0x603598, 0x200
+sEkansSprites20:
+ax_sprite sEkansGfx20, 0x200
+ax_sprite_terminator
+sEkansGfx21:
+.incbin "baserom.gba", 0x6037A8, 0x200
+sEkansSprites21:
+ax_sprite sEkansGfx21, 0x200
+ax_sprite_terminator
+sEkansGfx22:
+.incbin "baserom.gba", 0x6039B8, 0x200
+sEkansSprites22:
+ax_sprite sEkansGfx22, 0x200
+ax_sprite_terminator
+sEkansGfx23:
+.incbin "baserom.gba", 0x603BC8, 0x200
+sEkansSprites23:
+ax_sprite sEkansGfx23, 0x200
+ax_sprite_terminator
+sEkansGfx24:
+.incbin "baserom.gba", 0x603DD8, 0x200
+sEkansSprites24:
+ax_sprite sEkansGfx24, 0x200
+ax_sprite_terminator
+sEkansGfx25:
+.incbin "baserom.gba", 0x603FE8, 0x60
+sEkansGfx25_1:
+.incbin "baserom.gba", 0x604048, 0x60
+sEkansGfx25_2:
+.incbin "baserom.gba", 0x6040A8, 0x60
+sEkansGfx25_3:
+.incbin "baserom.gba", 0x604108, 0x60
+sEkansSprites25:
+ax_sprite sEkansGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx26:
+.incbin "baserom.gba", 0x6041B0, 0x20
+sEkansGfx26_1:
+.incbin "baserom.gba", 0x6041D0, 0x60
+sEkansGfx26_2:
+.incbin "baserom.gba", 0x604230, 0x60
+sEkansGfx26_3:
+.incbin "baserom.gba", 0x604290, 0x60
+sEkansSprites26:
+ax_sprite 0, 0x40
+ax_sprite sEkansGfx26, 0x20
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx27:
+.incbin "baserom.gba", 0x604340, 0x40
+sEkansGfx27_1:
+.incbin "baserom.gba", 0x604380, 0x60
+sEkansGfx27_2:
+.incbin "baserom.gba", 0x6043E0, 0x60
+sEkansGfx27_3:
+.incbin "baserom.gba", 0x604440, 0x60
+sEkansSprites27:
+ax_sprite sEkansGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sEkansGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx28:
+.incbin "baserom.gba", 0x6044E8, 0x20
+sEkansGfx28_1:
+.incbin "baserom.gba", 0x604508, 0x20
+sEkansGfx28_2:
+.incbin "baserom.gba", 0x604528, 0x100
+sEkansGfx28_3:
+.incbin "baserom.gba", 0x604628, 0x40
+sEkansSprites28:
+ax_sprite sEkansGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx28_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx28_2, 0x100
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx29:
+.incbin "baserom.gba", 0x6046B0, 0x60
+sEkansGfx29_1:
+.incbin "baserom.gba", 0x604710, 0x60
+sEkansGfx29_2:
+.incbin "baserom.gba", 0x604770, 0x60
+sEkansGfx29_3:
+.incbin "baserom.gba", 0x6047D0, 0x60
+sEkansSprites29:
+ax_sprite sEkansGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx30:
+.incbin "baserom.gba", 0x604878, 0x100
+sEkansSprites30:
+ax_sprite sEkansGfx30, 0x100
+ax_sprite_terminator
+sEkansGfx31:
+.incbin "baserom.gba", 0x604988, 0x80
+sEkansSprites31:
+ax_sprite sEkansGfx31, 0x80
+ax_sprite_terminator
+sEkansGfx32:
+.incbin "baserom.gba", 0x604A18, 0x20
+sEkansSprites32:
+ax_sprite sEkansGfx32, 0x20
+ax_sprite_terminator
+sEkansGfx33:
+.incbin "baserom.gba", 0x604A48, 0x20
+sEkansSprites33:
+ax_sprite sEkansGfx33, 0x20
+ax_sprite_terminator
+sEkansGfx34:
+.incbin "baserom.gba", 0x604A78, 0x60
+sEkansGfx34_1:
+.incbin "baserom.gba", 0x604AD8, 0x60
+sEkansGfx34_2:
+.incbin "baserom.gba", 0x604B38, 0x60
+sEkansGfx34_3:
+.incbin "baserom.gba", 0x604B98, 0x60
+sEkansSprites34:
+ax_sprite sEkansGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx35:
+.incbin "baserom.gba", 0x604C40, 0xE0
+sEkansSprites35:
+ax_sprite sEkansGfx35, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx36:
+.incbin "baserom.gba", 0x604D38, 0x80
+sEkansSprites36:
+ax_sprite sEkansGfx36, 0x80
+ax_sprite_terminator
+sEkansGfx37:
+.incbin "baserom.gba", 0x604DC8, 0x20
+sEkansSprites37:
+ax_sprite sEkansGfx37, 0x20
+ax_sprite_terminator
+sEkansGfx38:
+.incbin "baserom.gba", 0x604DF8, 0x100
+sEkansSprites38:
+ax_sprite sEkansGfx38, 0x100
+ax_sprite_terminator
+sEkansGfx39:
+.incbin "baserom.gba", 0x604F08, 0x40
+sEkansSprites39:
+ax_sprite sEkansGfx39, 0x40
+ax_sprite_terminator
+sEkansGfx40:
+.incbin "baserom.gba", 0x604F58, 0x100
+sEkansSprites40:
+ax_sprite sEkansGfx40, 0x100
+ax_sprite_terminator
+sEkansGfx41:
+.incbin "baserom.gba", 0x605068, 0x40
+sEkansSprites41:
+ax_sprite sEkansGfx41, 0x40
+ax_sprite_terminator
+sEkansGfx42:
+.incbin "baserom.gba", 0x6050B8, 0x60
+sEkansGfx42_1:
+.incbin "baserom.gba", 0x605118, 0x60
+sEkansGfx42_2:
+.incbin "baserom.gba", 0x605178, 0x60
+sEkansGfx42_3:
+.incbin "baserom.gba", 0x6051D8, 0x60
+sEkansSprites42:
+ax_sprite sEkansGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx42_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx43:
+.incbin "baserom.gba", 0x605280, 0x40
+sEkansGfx43_1:
+.incbin "baserom.gba", 0x6052C0, 0x40
+sEkansGfx43_2:
+.incbin "baserom.gba", 0x605300, 0x80
+sEkansGfx43_3:
+.incbin "baserom.gba", 0x605380, 0x60
+sEkansSprites43:
+ax_sprite sEkansGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sEkansGfx43_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sEkansGfx43_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx43_3, 0x60
+ax_sprite_terminator
+sEkansGfx44:
+.incbin "baserom.gba", 0x605420, 0x60
+sEkansGfx44_1:
+.incbin "baserom.gba", 0x605480, 0x60
+sEkansGfx44_2:
+.incbin "baserom.gba", 0x6054E0, 0x60
+sEkansGfx44_3:
+.incbin "baserom.gba", 0x605540, 0x60
+sEkansSprites44:
+ax_sprite sEkansGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx44_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx45:
+.incbin "baserom.gba", 0x6055E8, 0x80
+sEkansGfx45_1:
+.incbin "baserom.gba", 0x605668, 0x20
+sEkansSprites45:
+ax_sprite 0, 0x40
+ax_sprite sEkansGfx45, 0x80
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx45_1, 0x20
+ax_sprite_terminator
+sEkansGfx46:
+.incbin "baserom.gba", 0x6056B0, 0x80
+sEkansSprites46:
+ax_sprite sEkansGfx46, 0x80
+ax_sprite_terminator
+sEkansGfx47:
+.incbin "baserom.gba", 0x605740, 0x40
+sEkansSprites47:
+ax_sprite sEkansGfx47, 0x40
+ax_sprite_terminator
+sEkansGfx48:
+.incbin "baserom.gba", 0x605790, 0x60
+sEkansGfx48_1:
+.incbin "baserom.gba", 0x6057F0, 0x60
+sEkansGfx48_2:
+.incbin "baserom.gba", 0x605850, 0x60
+sEkansGfx48_3:
+.incbin "baserom.gba", 0x6058B0, 0x60
+sEkansSprites48:
+ax_sprite sEkansGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx48_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx49:
+.incbin "baserom.gba", 0x605958, 0x120
+sEkansGfx49_1:
+.incbin "baserom.gba", 0x605A78, 0x40
+sEkansSprites49:
+ax_sprite 0, 0x60
+ax_sprite sEkansGfx49, 0x120
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx49_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx50:
+.incbin "baserom.gba", 0x605AE8, 0x100
+sEkansSprites50:
+ax_sprite sEkansGfx50, 0x100
+ax_sprite_terminator
+sEkansGfx51:
+.incbin "baserom.gba", 0x605BF8, 0x40
+sEkansSprites51:
+ax_sprite sEkansGfx51, 0x40
+ax_sprite_terminator
+sEkansGfx52:
+.incbin "baserom.gba", 0x605C48, 0x20
+sEkansSprites52:
+ax_sprite sEkansGfx52, 0x20
+ax_sprite_terminator
+sEkansGfx53:
+.incbin "baserom.gba", 0x605C78, 0x20
+sEkansGfx53_1:
+.incbin "baserom.gba", 0x605C98, 0x80
+sEkansGfx53_2:
+.incbin "baserom.gba", 0x605D18, 0x20
+sEkansSprites53:
+ax_sprite sEkansGfx53, 0x20
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx53_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx53_2, 0x20
+ax_sprite_terminator
+sEkansGfx54:
+.incbin "baserom.gba", 0x605D68, 0x80
+sEkansSprites54:
+ax_sprite sEkansGfx54, 0x80
+ax_sprite_terminator
+sEkansGfx55:
+.incbin "baserom.gba", 0x605DF8, 0x40
+sEkansSprites55:
+ax_sprite sEkansGfx55, 0x40
+ax_sprite_terminator
+sEkansGfx56:
+.incbin "baserom.gba", 0x605E48, 0x100
+sEkansSprites56:
+ax_sprite sEkansGfx56, 0x100
+ax_sprite_terminator
+sEkansGfx57:
+.incbin "baserom.gba", 0x605F58, 0x80
+sEkansSprites57:
+ax_sprite sEkansGfx57, 0x80
+ax_sprite_terminator
+sEkansGfx58:
+.incbin "baserom.gba", 0x605FE8, 0x40
+sEkansSprites58:
+ax_sprite sEkansGfx58, 0x40
+ax_sprite_terminator
+sEkansGfx59:
+.incbin "baserom.gba", 0x606038, 0xE0
+sEkansSprites59:
+ax_sprite sEkansGfx59, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEkansGfx60:
+.incbin "baserom.gba", 0x606130, 0x80
+sEkansSprites60:
+ax_sprite sEkansGfx60, 0x80
+ax_sprite_terminator
+sEkansGfx61:
+.incbin "baserom.gba", 0x6061C0, 0x40
+sEkansSprites61:
+ax_sprite sEkansGfx61, 0x40
+ax_sprite_terminator
+sEkansGfx62:
+.incbin "baserom.gba", 0x606210, 0x100
+sEkansSprites62:
+ax_sprite sEkansGfx62, 0x100
+ax_sprite_terminator
+sEkansGfx63:
+.incbin "baserom.gba", 0x606320, 0x80
+sEkansSprites63:
+ax_sprite sEkansGfx63, 0x80
+ax_sprite_terminator
+sEkansGfx64:
+.incbin "baserom.gba", 0x6063B0, 0xC0
+sEkansGfx64_1:
+.incbin "baserom.gba", 0x606470, 0x20
+sEkansSprites64:
+ax_sprite sEkansGfx64, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sEkansGfx64_1, 0x20
+ax_sprite_terminator
+sEkansGfx65:
+.incbin "baserom.gba", 0x6064B0, 0x80
+sEkansSprites65:
+ax_sprite sEkansGfx65, 0x80
+ax_sprite_terminator
+sEkansGfx66:
+.incbin "baserom.gba", 0x606540, 0x40
+sEkansSprites66:
+ax_sprite sEkansGfx66, 0x40
+ax_sprite_terminator
+sEkansGfx67:
+.incbin "baserom.gba", 0x606590, 0x100
+sEkansSprites67:
+ax_sprite sEkansGfx67, 0x100
+ax_sprite_terminator
+sEkansGfx68:
+.incbin "baserom.gba", 0x6066A0, 0x80
+sEkansSprites68:
+ax_sprite sEkansGfx68, 0x80
+ax_sprite_terminator
+sEkansGfx69:
+.incbin "baserom.gba", 0x606730, 0x40
+sEkansSprites69:
+ax_sprite sEkansGfx69, 0x40
+ax_sprite_terminator
+sEkansGfx70:
+.incbin "baserom.gba", 0x606780, 0x20
+sEkansSprites70:
+ax_sprite sEkansGfx70, 0x20
+ax_sprite_terminator
+sEkansGfx71:
+.incbin "baserom.gba", 0x6067B0, 0x100
+sEkansSprites71:
+ax_sprite sEkansGfx71, 0x100
+ax_sprite_terminator
+sEkansGfx72:
+.incbin "baserom.gba", 0x6068C0, 0x40
+sEkansSprites72:
+ax_sprite sEkansGfx72, 0x40
+ax_sprite_terminator
+sEkansGfx73:
+.incbin "baserom.gba", 0x606910, 0x200
+sEkansSprites73:
+ax_sprite sEkansGfx73, 0x200
+ax_sprite_terminator
+sEkansGfx74:
+.incbin "baserom.gba", 0x606B20, 0x200
+sEkansSprites74:
+ax_sprite sEkansGfx74, 0x200
+ax_sprite_terminator
+sEkansGfx75:
+.incbin "baserom.gba", 0x606D30, 0x200
+sEkansSprites75:
+ax_sprite sEkansGfx75, 0x200
+ax_sprite_terminator
+sEkansGfx76:
+.incbin "baserom.gba", 0x606F40, 0x200
+sEkansSprites76:
+ax_sprite sEkansGfx76, 0x200
+ax_sprite_terminator
+sEkansGfx77:
+.incbin "baserom.gba", 0x607150, 0x200
+sEkansSprites77:
+ax_sprite sEkansGfx77, 0x200
+ax_sprite_terminator
+sEkansGfx78:
+.incbin "baserom.gba", 0x607360, 0x200
+sEkansSprites78:
+ax_sprite sEkansGfx78, 0x200
+ax_sprite_terminator
+sEkansGfx79:
+.incbin "baserom.gba", 0x607570, 0x200
+sEkansSprites79:
+ax_sprite sEkansGfx79, 0x200
+ax_sprite_terminator
+sAxPosesEkans:
+.4byte sEkansPose1
+.4byte sEkansPose2
+.4byte sEkansPose3
+.4byte sEkansPose4
+.4byte sEkansPose5
+.4byte sEkansPose6
+.4byte sEkansPose7
+.4byte sEkansPose8
+.4byte sEkansPose9
+.4byte sEkansPose10
+.4byte sEkansPose11
+.4byte sEkansPose12
+.4byte sEkansPose13
+.4byte sEkansPose14
+.4byte sEkansPose15
+.4byte sEkansPose16
+.4byte sEkansPose17
+.4byte sEkansPose18
+.4byte sEkansPose19
+.4byte sEkansPose20
+.4byte sEkansPose21
+.4byte sEkansPose22
+.4byte sEkansPose23
+.4byte sEkansPose24
+.4byte sEkansPose25
+.4byte sEkansPose26
+.4byte sEkansPose27
+.4byte sEkansPose28
+.4byte sEkansPose29
+.4byte sEkansPose30
+.4byte sEkansPose31
+.4byte sEkansPose32
+.4byte sEkansPose33
+.4byte sEkansPose34
+.4byte sEkansPose35
+.4byte sEkansPose36
+.4byte sEkansPose37
+.4byte sEkansPose38
+.4byte sEkansPose39
+.4byte sEkansPose40
+.4byte sEkansPose41
+.4byte sEkansPose42
+.4byte sEkansPose43
+.4byte sEkansPose44
+.4byte sEkansPose45
+.4byte sEkansPose46
+.4byte sEkansPose47
+.4byte sEkansPose48
+.4byte sEkansPose49
+.4byte sEkansPose50
+.4byte sEkansPose51
+.4byte sEkansPose52
+.4byte sEkansPose53
+.4byte sEkansPose54
+.4byte sEkansPose55
+.4byte sEkansPose56
+.4byte sEkansPose57
+.4byte sEkansPose58
+.4byte sEkansPose59
+.4byte sEkansPose60
+.4byte sEkansPose61
+.4byte sEkansPose62
+.4byte sEkansPose63
+.4byte sEkansPose64
+.4byte sEkansPose65
+.4byte sEkansPose66
+.4byte sEkansPose67
+.4byte sEkansPose68
+.4byte sEkansPose69
+.4byte sEkansPose70
+.4byte sEkansPose71
+.4byte sEkansPose72
+.4byte sEkansPose73
+.4byte sEkansPose74
+.4byte sEkansPose75
+.4byte sEkansPose76
+.4byte sEkansPose77
+.4byte sEkansPose78
+.4byte sEkansPose79
+.4byte sEkansPose80
+.4byte sEkansPose81
+.4byte sEkansPose82
+.4byte sEkansPose83
+.4byte sEkansPose84
+.4byte sEkansPose85
+.4byte sEkansPose86
+.4byte sEkansPose87
+.4byte sEkansPose88
+.4byte sEkansPose89
+.4byte sEkansPose90
+.4byte sEkansPose91
+.4byte sEkansPose92
+.4byte sEkansPose93
+.4byte sEkansPose94
+.4byte sEkansPose95
+.4byte sEkansPose96
+.4byte sEkansPose97
+.4byte sEkansPose98
+.4byte sEkansPose99
+.4byte sEkansPose100
+.4byte sEkansPose101
+.4byte sEkansPose102
+.4byte sEkansPose103
+.4byte sEkansPose104
+.4byte sEkansPose105
+.4byte sEkansPose106
+.4byte sEkansPose107
+.4byte sEkansPose108
+.4byte sEkansPose109
+.4byte sEkansPose110
+.4byte sEkansPose111
+.4byte sEkansPose112
+.4byte sEkansPose113
+.4byte sEkansPose114
+.4byte sEkansPose115
+.4byte sEkansPose116
+.4byte sEkansPose117
+.4byte sEkansPose118
+.4byte sEkansPose119
+.4byte sEkansPose120
+.4byte sEkansPose121
+.4byte sEkansPose122
+.4byte sEkansPose123
+.4byte sEkansPose124
+.4byte sEkansPose125
+.4byte sEkansPose126
+.4byte sEkansPose127
+.4byte sEkansPose128
+.4byte sEkansPose129
+.4byte sEkansPose130
+.4byte sEkansPose131
+.4byte sEkansPose132
+.4byte sEkansPose133
+.4byte sEkansPose134
+.4byte sEkansPose135
+.4byte sEkansPose136
+.4byte sEkansPose137
+.4byte sEkansPose138
+.4byte sEkansPose139
+.4byte sEkansPose140
+.4byte sEkansPose141
+.4byte sEkansPose142
+.4byte sEkansPose143
+.4byte sEkansPose144
+.4byte sEkansPose145
+.4byte sEkansPose146
+.4byte sEkansPose147
+.4byte sEkansPose148
+.4byte sEkansPose149
+.4byte sEkansPose150
+.4byte sEkansPose151
+.4byte sEkansPose152
+.4byte sEkansPose153
+.4byte sEkansPose154
+.4byte sEkansPose155
+.4byte sEkansPose156
+.4byte sEkansPose157
+.4byte sEkansPose158
+.4byte sEkansPose159
+.4byte sEkansPose160
+.4byte sEkansPose161
+.4byte sEkansPose162
+.4byte sEkansPose163
+.4byte sEkansPose164
+.4byte sEkansPose165
+.4byte sEkansPose166
+.4byte sEkansPose167
+.4byte sEkansPose168
+.4byte sEkansPose169
+.4byte sEkansPose170
+.4byte sEkansPose171
+.4byte sEkansPose172
+.4byte sEkansPose173
+.4byte sEkansPose174
+.4byte sEkansPose175
+.4byte sEkansPose176
+.4byte sEkansPose177
+.4byte sEkansPose178
+.4byte sEkansPose179
+.4byte sEkansPose180
+.4byte sEkansPose181
+.4byte sEkansPose182
+.4byte sEkansPose183
+.4byte sEkansPose184
+.4byte sEkansPose185
+.4byte sEkansPose186
+.4byte sEkansPose187
+.4byte sEkansPose188
+.4byte sEkansPose189
+.4byte sEkansPose190
+.4byte sEkansPose191
+.4byte sEkansPose192
+.4byte sEkansPose193
+.4byte sEkansPose194
+.4byte sEkansPose195
+.4byte sEkansPose196
+.4byte sEkansPose197
+.4byte sEkansPose198
+.4byte sEkansPose199
+.4byte sEkansPose200
+.4byte sEkansPose201
+.4byte sEkansPose202
+.4byte sEkansPose203
+.4byte sEkansPose204
+.4byte sEkansPose205
+.4byte sEkansPose206
+.4byte sEkansPose207
+.4byte sEkansPose208
+.4byte sEkansPose209
+.4byte sEkansPose210
+.4byte sEkansPose211
+.4byte sEkansPose212
+.4byte sEkansPose213
+.4byte sEkansPose214
+.4byte sEkansPose215
+.4byte sEkansPose216
+.4byte sEkansPose217
+.4byte sEkansPose218
+.4byte sEkansPose219
+.4byte sEkansPose220
+.4byte sEkansPose221
+.4byte sEkansPose222
+.4byte sEkansPose223
+.4byte sEkansPose224
+.4byte sEkansPose225
+.4byte sEkansPose226
+sAxPositionsEkans:
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -3,   -6, 	  -6,   -6, 	   0,   -5, 	  -1,   -4
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -1,   -5
+.2byte    5,  -11, 	  -1,   -6, 	   3,   -9, 	   0,   -9
+.2byte   10,   -8, 	   0,   -6, 	   4,   -7, 	   3,   -6
+.2byte    4,  -12, 	  -3,   -7, 	   2,   -9, 	   0,   -9
+.2byte    9,  -14, 	   2,   -7, 	   5,   -9, 	  -1,   -8
+.2byte   13,  -13, 	   5,   -7, 	   8,   -9, 	   0,   -7
+.2byte    7,  -14, 	   2,   -7, 	   4,   -9, 	  -2,   -8
+.2byte    8,  -16, 	   4,   -9, 	  -1,  -10, 	   0,   -7
+.2byte   11,  -15, 	   6,   -9, 	  -1,   -9, 	   2,   -7
+.2byte    7,  -15, 	   5,  -10, 	  -2,  -10, 	   0,   -7
+.2byte   -1,  -19, 	   1,   -9, 	  -5,  -10, 	  -1,   -8
+.2byte   -1,  -16, 	   2,   -9, 	  -5,   -9, 	  -2,   -6
+.2byte   -1,  -18, 	   1,   -8, 	  -6,  -10, 	  -1,   -8
+.2byte   -9,  -18, 	   0,  -10, 	  -6,   -9, 	  -2,   -8
+.2byte  -14,  -18, 	  -2,  -11, 	  -7,   -8, 	  -3,   -8
+.2byte   -8,  -17, 	   0,   -8, 	  -6,   -9, 	   1,   -6
+.2byte   -9,  -14, 	  -6,   -9, 	  -5,   -7, 	  -1,   -7
+.2byte  -13,  -13, 	  -8,   -8, 	  -6,   -6, 	  -4,   -5
+.2byte   -6,  -13, 	  -4,   -9, 	  -3,   -7, 	   1,   -7
+.2byte   -6,  -11, 	  -7,   -9, 	  -2,   -7, 	   0,   -9
+.2byte  -10,   -8, 	  -9,   -5, 	  -2,   -6, 	   0,   -6
+.2byte   -5,  -12, 	  -6,   -9, 	  -1,   -7, 	   1,   -6
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -3,  -13, 	  -6,   -8, 	   0,   -8, 	  -1,   -7
+.2byte   -2,    3, 	  -5,    1, 	   2,    0, 	   3,   -3
+.2byte    4,  -11, 	  -2,   -6, 	   2,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -5,  -10, 	   0,  -12, 	   0,   -8
+.2byte   13,   -6, 	   3,   -4, 	  10,   -3, 	   1,   -5
+.2byte    8,  -12, 	   1,   -5, 	   4,   -7, 	  -2,   -6
+.2byte    5,  -15, 	   0,   -8, 	   2,  -10, 	  -1,   -9
+.2byte   17,  -14, 	   6,   -7, 	  10,   -8, 	   7,   -6
+.2byte    7,  -14, 	   3,   -7, 	  -2,   -8, 	  -1,   -5
+.2byte    5,  -18, 	   2,  -10, 	  -2,  -12, 	  -1,   -8
+.2byte   13,  -18, 	   6,   -7, 	   2,  -12, 	   2,   -7
+.2byte   -1,  -18, 	   1,   -8, 	  -5,   -9, 	  -1,   -7
+.2byte    0,  -18, 	   2,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    0,  -19, 	   2,  -11, 	  -3,  -12, 	  -1,   -9
+.2byte   -9,  -17, 	   0,   -9, 	  -6,   -8, 	  -2,   -7
+.2byte   -6,  -17, 	   4,   -9, 	  -2,   -9, 	   2,   -7
+.2byte  -15,  -17, 	  -3,  -11, 	  -9,   -8, 	  -3,   -6
+.2byte   -9,  -13, 	  -6,   -8, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,  -16, 	  -1,  -11, 	   0,  -10, 	   3,  -10
+.2byte  -19,  -10, 	  -9,   -6, 	  -7,   -6, 	  -5,   -5
+.2byte   -6,  -10, 	  -7,   -8, 	  -2,   -6, 	   0,   -8
+.2byte   -3,  -13, 	  -6,   -9, 	   0,   -8, 	   1,  -10
+.2byte  -15,   -4, 	 -10,   -2, 	  -5,   -2, 	   0,   -3
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -3,  -13, 	  -6,   -8, 	   0,   -8, 	  -1,   -7
+.2byte   -2,    3, 	  -5,    1, 	   2,    0, 	   3,   -3
+.2byte    4,  -11, 	  -2,   -6, 	   2,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -5,  -10, 	   0,  -12, 	   0,   -8
+.2byte   13,   -6, 	   3,   -4, 	  10,   -3, 	   1,   -5
+.2byte    8,  -12, 	   1,   -5, 	   4,   -7, 	  -2,   -6
+.2byte    5,  -15, 	   0,   -8, 	   2,  -10, 	  -1,   -9
+.2byte   17,  -14, 	   6,   -7, 	  10,   -8, 	   7,   -6
+.2byte    7,  -14, 	   3,   -7, 	  -2,   -8, 	  -1,   -5
+.2byte    5,  -18, 	   2,  -10, 	  -2,  -12, 	  -1,   -8
+.2byte   13,  -18, 	   6,   -7, 	   2,  -12, 	   2,   -7
+.2byte   -1,  -18, 	   1,   -8, 	  -5,   -9, 	  -1,   -7
+.2byte    0,  -18, 	   2,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    0,  -19, 	   2,  -11, 	  -3,  -12, 	  -1,   -9
+.2byte   -9,  -17, 	   0,   -9, 	  -6,   -8, 	  -2,   -7
+.2byte   -6,  -17, 	   4,   -9, 	  -2,   -9, 	   2,   -7
+.2byte  -15,  -17, 	  -3,  -11, 	  -9,   -8, 	  -3,   -6
+.2byte   -9,  -13, 	  -6,   -8, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,  -16, 	  -1,  -11, 	   0,  -10, 	   3,  -10
+.2byte  -19,  -10, 	  -9,   -6, 	  -7,   -6, 	  -5,   -5
+.2byte   -6,  -10, 	  -7,   -8, 	  -2,   -6, 	   0,   -8
+.2byte   -3,  -13, 	  -6,   -9, 	   0,   -8, 	   1,  -10
+.2byte  -15,   -4, 	 -10,   -2, 	  -5,   -2, 	   0,   -3
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -3,  -12, 	  -6,   -7, 	   0,   -7, 	  -1,   -6
+.2byte   -2,    3, 	  -5,    1, 	   2,    0, 	   3,   -3
+.2byte   -2,   12, 	  -3,    3, 	   4,    7, 	   4,   -1
+.2byte    4,  -11, 	  -2,   -6, 	   2,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -5,  -10, 	   0,  -12, 	   0,   -8
+.2byte   13,   -6, 	   3,   -4, 	  10,   -3, 	   1,   -5
+.2byte   17,    3, 	   6,   -2, 	  12,    1, 	   9,   -2
+.2byte    8,  -12, 	   1,   -5, 	   4,   -7, 	  -2,   -6
+.2byte    5,  -15, 	   0,   -8, 	   2,  -10, 	  -1,   -9
+.2byte   17,  -14, 	   6,   -7, 	  10,   -8, 	   7,   -6
+.2byte   21,   -6, 	   9,   -5, 	  12,   -6, 	   9,   -6
+.2byte    7,  -14, 	   3,   -7, 	  -2,   -8, 	  -1,   -5
+.2byte    4,  -18, 	   1,  -10, 	  -3,  -12, 	  -2,   -8
+.2byte   14,  -19, 	   7,   -8, 	   3,  -13, 	   3,   -8
+.2byte   16,  -18, 	   8,   -9, 	   6,  -15, 	   3,   -9
+.2byte   -1,  -18, 	   1,   -8, 	  -5,   -9, 	  -1,   -7
+.2byte    0,  -21, 	   2,  -12, 	  -3,  -12, 	   0,  -11
+.2byte    0,  -24, 	   2,  -16, 	  -3,  -17, 	  -1,  -14
+.2byte    0,  -25, 	   2,  -17, 	  -3,  -18, 	  -1,  -15
+.2byte   -9,  -17, 	   0,   -9, 	  -6,   -8, 	  -2,   -7
+.2byte   -6,  -17, 	   4,   -9, 	  -2,   -9, 	   2,   -7
+.2byte  -17,  -18, 	  -5,  -12, 	 -11,   -9, 	  -5,   -7
+.2byte  -19,  -16, 	  -8,  -11, 	 -12,  -10, 	  -3,   -6
+.2byte   -9,  -13, 	  -6,   -8, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,  -16, 	  -1,  -11, 	   0,  -10, 	   3,  -10
+.2byte  -19,  -10, 	  -9,   -6, 	  -7,   -6, 	  -5,   -5
+.2byte  -21,   -5, 	 -10,   -3, 	  -8,   -4, 	  -3,   -3
+.2byte   -6,  -10, 	  -7,   -8, 	  -2,   -6, 	   0,   -8
+.2byte   -3,  -13, 	  -6,   -9, 	   0,   -8, 	   1,  -10
+.2byte  -15,   -4, 	 -10,   -2, 	  -5,   -2, 	   0,   -3
+.2byte  -17,    3, 	  -8,    2, 	  -6,   -1, 	   0,   -4
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -3,  -12, 	  -6,   -7, 	   0,   -7, 	  -1,   -6
+.2byte   -2,    3, 	  -5,    1, 	   2,    0, 	   3,   -3
+.2byte   -2,   12, 	  -3,    3, 	   4,    7, 	   4,   -1
+.2byte    4,  -11, 	  -2,   -6, 	   2,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -5,  -10, 	   0,  -12, 	   0,   -8
+.2byte   13,   -6, 	   3,   -4, 	  10,   -3, 	   1,   -5
+.2byte   17,    3, 	   6,   -2, 	  12,    1, 	   9,   -2
+.2byte    8,  -12, 	   1,   -5, 	   4,   -7, 	  -2,   -6
+.2byte    5,  -15, 	   0,   -8, 	   2,  -10, 	  -1,   -9
+.2byte   17,  -14, 	   6,   -7, 	  10,   -8, 	   7,   -6
+.2byte   21,   -6, 	   9,   -5, 	  12,   -6, 	   9,   -6
+.2byte    7,  -14, 	   3,   -7, 	  -2,   -8, 	  -1,   -5
+.2byte    4,  -18, 	   1,  -10, 	  -3,  -12, 	  -2,   -8
+.2byte   14,  -19, 	   7,   -8, 	   3,  -13, 	   3,   -8
+.2byte   16,  -18, 	   8,   -9, 	   6,  -15, 	   3,   -9
+.2byte   -1,  -18, 	   1,   -8, 	  -5,   -9, 	  -1,   -7
+.2byte    0,  -21, 	   2,  -12, 	  -3,  -12, 	   0,  -11
+.2byte    0,  -24, 	   2,  -16, 	  -3,  -17, 	  -1,  -14
+.2byte    0,  -25, 	   2,  -17, 	  -3,  -18, 	  -1,  -15
+.2byte   -9,  -17, 	   0,   -9, 	  -6,   -8, 	  -2,   -7
+.2byte   -6,  -17, 	   4,   -9, 	  -2,   -9, 	   2,   -7
+.2byte  -17,  -18, 	  -5,  -12, 	 -11,   -9, 	  -5,   -7
+.2byte  -19,  -16, 	  -8,  -11, 	 -12,  -10, 	  -3,   -6
+.2byte   -9,  -13, 	  -6,   -8, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,  -16, 	  -1,  -11, 	   0,  -10, 	   3,  -10
+.2byte  -19,  -10, 	  -9,   -6, 	  -7,   -6, 	  -5,   -5
+.2byte  -21,   -5, 	 -10,   -3, 	  -8,   -4, 	  -3,   -3
+.2byte   -6,  -10, 	  -7,   -8, 	  -2,   -6, 	   0,   -8
+.2byte   -3,  -13, 	  -6,   -9, 	   0,   -8, 	   1,  -10
+.2byte  -15,   -4, 	 -10,   -2, 	  -5,   -2, 	   0,   -3
+.2byte  -17,    3, 	  -8,    2, 	  -6,   -1, 	   0,   -4
+.2byte   -7,    5, 	   0,   -2, 	   5,    1, 	   2,   -5
+.2byte   -7,    5, 	   1,   -1, 	   7,    1, 	   2,   -6
+.2byte   -3,    6, 	  -4,   -3, 	   1,   -3, 	   0,   -7
+.2byte    8,    4, 	  -1,   -2, 	  -3,    1, 	  -4,   -2
+.2byte   17,   -3, 	   4,   -3, 	   3,   -1, 	   0,   -3
+.2byte   12,  -15, 	   0,  -10, 	   4,   -8, 	   1,   -5
+.2byte   -1,  -18, 	   1,   -9, 	  -5,   -9, 	  -2,   -4
+.2byte  -13,  -15, 	  -1,  -10, 	  -5,   -8, 	  -2,   -5
+.2byte  -18,   -3, 	  -5,   -3, 	  -4,   -1, 	  -1,   -3
+.2byte   -9,    4, 	   0,   -2, 	   2,    1, 	   3,   -2
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -3,   -6, 	  -6,   -6, 	   0,   -5, 	  -1,   -4
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -1,   -5
+.2byte    5,  -11, 	  -1,   -6, 	   3,   -9, 	   0,   -9
+.2byte   10,   -8, 	   0,   -6, 	   4,   -7, 	   3,   -6
+.2byte    4,  -12, 	  -3,   -7, 	   2,   -9, 	   0,   -9
+.2byte    9,  -14, 	   2,   -7, 	   5,   -9, 	  -1,   -8
+.2byte   13,  -13, 	   5,   -7, 	   8,   -9, 	   0,   -7
+.2byte    7,  -14, 	   2,   -7, 	   4,   -9, 	  -2,   -8
+.2byte    8,  -16, 	   4,   -9, 	  -1,  -10, 	   0,   -7
+.2byte   11,  -15, 	   6,   -9, 	  -1,   -9, 	   2,   -7
+.2byte    7,  -15, 	   5,  -10, 	  -2,  -10, 	   0,   -7
+.2byte   -1,  -19, 	   1,   -9, 	  -5,  -10, 	  -1,   -8
+.2byte   -1,  -16, 	   2,   -9, 	  -5,   -9, 	  -2,   -6
+.2byte   -1,  -18, 	   1,   -8, 	  -6,  -10, 	  -1,   -8
+.2byte   -9,  -18, 	   0,  -10, 	  -6,   -9, 	  -2,   -8
+.2byte  -14,  -18, 	  -2,  -11, 	  -7,   -8, 	  -3,   -8
+.2byte   -8,  -17, 	   0,   -8, 	  -6,   -9, 	   1,   -6
+.2byte   -9,  -14, 	  -6,   -9, 	  -5,   -7, 	  -1,   -7
+.2byte  -13,  -13, 	  -8,   -8, 	  -6,   -6, 	  -4,   -5
+.2byte   -6,  -13, 	  -4,   -9, 	  -3,   -7, 	   1,   -7
+.2byte   -6,  -11, 	  -7,   -9, 	  -2,   -7, 	   0,   -9
+.2byte  -10,   -8, 	  -9,   -5, 	  -2,   -6, 	   0,   -6
+.2byte   -5,  -12, 	  -6,   -9, 	  -1,   -7, 	   1,   -6
+.2byte   -3,   -6, 	  -6,   -6, 	   0,   -5, 	  -1,   -4
+.2byte  -10,   -8, 	  -9,   -5, 	  -2,   -6, 	   0,   -6
+.2byte  -13,  -13, 	  -8,   -8, 	  -6,   -6, 	  -4,   -5
+.2byte  -12,  -18, 	   0,  -11, 	  -5,   -8, 	  -1,   -8
+.2byte   -1,  -16, 	   2,   -9, 	  -5,   -9, 	  -2,   -6
+.2byte   11,  -15, 	   6,   -9, 	  -1,   -9, 	   2,   -7
+.2byte   13,  -13, 	   5,   -7, 	   8,   -9, 	   0,   -7
+.2byte   10,   -8, 	   0,   -6, 	   4,   -7, 	   3,   -6
+.2byte   -3,  -12, 	  -6,   -7, 	   0,   -7, 	  -1,   -6
+.2byte    0,  -15, 	  -5,  -10, 	   0,  -12, 	   0,   -8
+.2byte    5,  -15, 	   0,   -8, 	   2,  -10, 	  -1,   -9
+.2byte    6,  -18, 	   3,  -10, 	  -1,  -12, 	   0,   -8
+.2byte    1,  -19, 	   3,  -10, 	  -2,  -10, 	   1,   -9
+.2byte   -6,  -17, 	   4,   -9, 	  -2,   -9, 	   2,   -7
+.2byte   -4,  -16, 	  -1,  -11, 	   0,  -10, 	   3,  -10
+.2byte   -3,  -13, 	  -6,   -9, 	   0,   -8, 	   1,  -10
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -3,  -12, 	  -6,   -7, 	   0,   -7, 	  -1,   -6
+.2byte   -2,    3, 	  -5,    1, 	   2,    0, 	   3,   -3
+.2byte    4,  -11, 	  -2,   -6, 	   2,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -5,  -10, 	   0,  -12, 	   0,   -8
+.2byte   11,   -6, 	   1,   -4, 	   8,   -3, 	  -1,   -5
+.2byte    8,  -12, 	   1,   -5, 	   4,   -7, 	  -2,   -6
+.2byte    5,  -15, 	   0,   -8, 	   2,  -10, 	  -1,   -9
+.2byte   15,  -14, 	   4,   -7, 	   8,   -8, 	   5,   -6
+.2byte    7,  -14, 	   3,   -7, 	  -2,   -8, 	  -1,   -5
+.2byte    4,  -18, 	   1,  -10, 	  -3,  -12, 	  -2,   -8
+.2byte   12,  -19, 	   5,   -8, 	   1,  -13, 	   1,   -8
+.2byte   -1,  -18, 	   1,   -8, 	  -5,   -9, 	  -1,   -7
+.2byte    0,  -21, 	   2,  -12, 	  -3,  -12, 	   0,  -11
+.2byte    0,  -24, 	   2,  -16, 	  -3,  -17, 	  -1,  -14
+.2byte   -9,  -17, 	   0,   -9, 	  -6,   -8, 	  -2,   -7
+.2byte   -6,  -17, 	   4,   -9, 	  -2,   -9, 	   2,   -7
+.2byte  -15,  -18, 	  -3,  -12, 	  -9,   -9, 	  -3,   -7
+.2byte   -9,  -13, 	  -6,   -8, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,  -16, 	  -1,  -11, 	   0,  -10, 	   3,  -10
+.2byte  -17,  -10, 	  -7,   -6, 	  -5,   -6, 	  -3,   -5
+.2byte   -6,  -10, 	  -7,   -8, 	  -2,   -6, 	   0,   -8
+.2byte   -3,  -13, 	  -6,   -9, 	   0,   -8, 	   1,  -10
+.2byte  -13,   -4, 	  -8,   -2, 	  -3,   -2, 	   2,   -3
+.2byte   -3,  -12, 	  -6,   -7, 	   0,   -7, 	  -1,   -6
+.2byte   -3,  -13, 	  -6,   -9, 	   0,   -8, 	   1,  -10
+.2byte   -4,  -16, 	  -1,  -11, 	   0,  -10, 	   3,  -10
+.2byte   -6,  -17, 	   4,   -9, 	  -2,   -9, 	   2,   -7
+.2byte    1,  -19, 	   3,  -10, 	  -2,  -10, 	   1,   -9
+.2byte    6,  -18, 	   3,  -10, 	  -1,  -12, 	   0,   -8
+.2byte    5,  -15, 	   0,   -8, 	   2,  -10, 	  -1,   -9
+.2byte    0,  -15, 	  -5,  -10, 	   0,  -12, 	   0,   -8
+.2byte   -3,   -8, 	  -6,   -6, 	   0,   -6, 	  -2,   -5
+.2byte   -6,  -10, 	  -7,   -8, 	  -2,   -6, 	   0,   -8
+.2byte   -9,  -13, 	  -6,   -8, 	  -5,   -6, 	  -1,   -6
+.2byte   -9,  -17, 	   0,   -9, 	  -6,   -8, 	  -2,   -7
+.2byte   -1,  -18, 	   1,   -8, 	  -5,   -9, 	  -1,   -7
+.2byte    7,  -14, 	   3,   -7, 	  -2,   -8, 	  -1,   -5
+.2byte    8,  -12, 	   1,   -5, 	   4,   -7, 	  -2,   -6
+.2byte    4,  -11, 	  -2,   -6, 	   2,   -9, 	  -1,   -9
+sEkansAnimTable1:
+.4byte sEkansAnims_1_1
+.4byte sEkansAnims_1_2
+.4byte sEkansAnims_1_3
+.4byte sEkansAnims_1_4
+.4byte sEkansAnims_1_5
+.4byte sEkansAnims_1_6
+.4byte sEkansAnims_1_7
+.4byte sEkansAnims_1_8
+sEkansAnimTable2:
+.4byte sEkansAnims_2_1
+.4byte sEkansAnims_2_2
+.4byte sEkansAnims_2_3
+.4byte sEkansAnims_2_4
+.4byte sEkansAnims_2_5
+.4byte sEkansAnims_2_6
+.4byte sEkansAnims_2_7
+.4byte sEkansAnims_2_8
+sEkansAnimTable3:
+.4byte sEkansAnims_3_1
+.4byte sEkansAnims_3_2
+.4byte sEkansAnims_3_3
+.4byte sEkansAnims_3_4
+.4byte sEkansAnims_3_5
+.4byte sEkansAnims_3_6
+.4byte sEkansAnims_3_7
+.4byte sEkansAnims_3_8
+sEkansAnimTable4:
+.4byte sEkansAnims_4_1
+.4byte sEkansAnims_4_2
+.4byte sEkansAnims_4_3
+.4byte sEkansAnims_4_4
+.4byte sEkansAnims_4_5
+.4byte sEkansAnims_4_6
+.4byte sEkansAnims_4_7
+.4byte sEkansAnims_4_8
+sEkansAnimTable5:
+.4byte sEkansAnims_5_1
+.4byte sEkansAnims_5_2
+.4byte sEkansAnims_5_3
+.4byte sEkansAnims_5_4
+.4byte sEkansAnims_5_5
+.4byte sEkansAnims_5_6
+.4byte sEkansAnims_5_7
+.4byte sEkansAnims_5_8
+sEkansAnimTable6:
+.4byte sEkansAnims_6_1
+.4byte sEkansAnims_6_1
+.4byte sEkansAnims_6_1
+.4byte sEkansAnims_6_1
+.4byte sEkansAnims_6_1
+.4byte sEkansAnims_6_1
+.4byte sEkansAnims_6_1
+.4byte sEkansAnims_6_1
+sEkansAnimTable7:
+.4byte sEkansAnims_7_1
+.4byte sEkansAnims_7_2
+.4byte sEkansAnims_7_3
+.4byte sEkansAnims_7_4
+.4byte sEkansAnims_7_5
+.4byte sEkansAnims_7_6
+.4byte sEkansAnims_7_7
+.4byte sEkansAnims_7_8
+sEkansAnimTable8:
+.4byte sEkansAnims_8_1
+.4byte sEkansAnims_8_2
+.4byte sEkansAnims_8_3
+.4byte sEkansAnims_8_4
+.4byte sEkansAnims_8_5
+.4byte sEkansAnims_8_6
+.4byte sEkansAnims_8_7
+.4byte sEkansAnims_8_8
+sEkansAnimTable9:
+.4byte sEkansAnims_9_1
+.4byte sEkansAnims_9_2
+.4byte sEkansAnims_9_3
+.4byte sEkansAnims_9_4
+.4byte sEkansAnims_9_5
+.4byte sEkansAnims_9_6
+.4byte sEkansAnims_9_7
+.4byte sEkansAnims_9_8
+sEkansAnimTable10:
+.4byte sEkansAnims_10_1
+.4byte sEkansAnims_10_2
+.4byte sEkansAnims_10_3
+.4byte sEkansAnims_10_4
+.4byte sEkansAnims_10_5
+.4byte sEkansAnims_10_6
+.4byte sEkansAnims_10_7
+.4byte sEkansAnims_10_8
+sEkansAnimTable11:
+.4byte sEkansAnims_11_1
+.4byte sEkansAnims_11_2
+.4byte sEkansAnims_11_3
+.4byte sEkansAnims_11_4
+.4byte sEkansAnims_11_5
+.4byte sEkansAnims_11_6
+.4byte sEkansAnims_11_7
+.4byte sEkansAnims_11_8
+sEkansAnimTable12:
+.4byte sEkansAnims_12_1
+.4byte sEkansAnims_12_2
+.4byte sEkansAnims_12_3
+.4byte sEkansAnims_12_4
+.4byte sEkansAnims_12_5
+.4byte sEkansAnims_12_6
+.4byte sEkansAnims_12_7
+.4byte sEkansAnims_12_8
+sEkansAnimTable13:
+.4byte sEkansAnims_13_1
+.4byte sEkansAnims_13_2
+.4byte sEkansAnims_13_3
+.4byte sEkansAnims_13_4
+.4byte sEkansAnims_13_5
+.4byte sEkansAnims_13_6
+.4byte sEkansAnims_13_7
+.4byte sEkansAnims_13_8
+sAxAnimationsEkans:
+.4byte sEkansAnimTable1
+.4byte sEkansAnimTable2
+.4byte sEkansAnimTable3
+.4byte sEkansAnimTable4
+.4byte sEkansAnimTable5
+.4byte sEkansAnimTable6
+.4byte sEkansAnimTable7
+.4byte sEkansAnimTable8
+.4byte sEkansAnimTable9
+.4byte sEkansAnimTable10
+.4byte sEkansAnimTable11
+.4byte sEkansAnimTable12
+.4byte sEkansAnimTable13
+sAxSpritesEkans:
+.4byte sEkansSprites1
+.4byte sEkansSprites2
+.4byte sEkansSprites3
+.4byte sEkansSprites4
+.4byte sEkansSprites5
+.4byte sEkansSprites6
+.4byte sEkansSprites7
+.4byte sEkansSprites8
+.4byte sEkansSprites9
+.4byte sEkansSprites10
+.4byte sEkansSprites11
+.4byte sEkansSprites12
+.4byte sEkansSprites13
+.4byte sEkansSprites14
+.4byte sEkansSprites15
+.4byte sEkansSprites16
+.4byte sEkansSprites17
+.4byte sEkansSprites18
+.4byte sEkansSprites19
+.4byte sEkansSprites20
+.4byte sEkansSprites21
+.4byte sEkansSprites22
+.4byte sEkansSprites23
+.4byte sEkansSprites24
+.4byte sEkansSprites25
+.4byte sEkansSprites26
+.4byte sEkansSprites27
+.4byte sEkansSprites28
+.4byte sEkansSprites29
+.4byte sEkansSprites30
+.4byte sEkansSprites31
+.4byte sEkansSprites32
+.4byte sEkansSprites33
+.4byte sEkansSprites34
+.4byte sEkansSprites35
+.4byte sEkansSprites36
+.4byte sEkansSprites37
+.4byte sEkansSprites38
+.4byte sEkansSprites39
+.4byte sEkansSprites40
+.4byte sEkansSprites41
+.4byte sEkansSprites42
+.4byte sEkansSprites43
+.4byte sEkansSprites44
+.4byte sEkansSprites45
+.4byte sEkansSprites46
+.4byte sEkansSprites47
+.4byte sEkansSprites48
+.4byte sEkansSprites49
+.4byte sEkansSprites50
+.4byte sEkansSprites51
+.4byte sEkansSprites52
+.4byte sEkansSprites53
+.4byte sEkansSprites54
+.4byte sEkansSprites55
+.4byte sEkansSprites56
+.4byte sEkansSprites57
+.4byte sEkansSprites58
+.4byte sEkansSprites59
+.4byte sEkansSprites60
+.4byte sEkansSprites61
+.4byte sEkansSprites62
+.4byte sEkansSprites63
+.4byte sEkansSprites64
+.4byte sEkansSprites65
+.4byte sEkansSprites66
+.4byte sEkansSprites67
+.4byte sEkansSprites68
+.4byte sEkansSprites69
+.4byte sEkansSprites70
+.4byte sEkansSprites71
+.4byte sEkansSprites72
+.4byte sEkansSprites73
+.4byte sEkansSprites74
+.4byte sEkansSprites75
+.4byte sEkansSprites76
+.4byte sEkansSprites77
+.4byte sEkansSprites78
+.4byte sEkansSprites79
+sAxMainEkans:
+ax_main sAxPosesEkans, sAxAnimationsEkans, 13, sAxSpritesEkans, sAxPositionsEkans

--- a/data/ax/electabuzz.inc
+++ b/data/ax/electabuzz.inc
@@ -1,0 +1,2961 @@
+.global gAxElectabuzz
+gAxElectabuzz:
+ax_siro sAxMainElectabuzz
+sElectabuzzPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose4:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose5:
+ax_pose 4, 0x01e2, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose6:
+ax_pose 5, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose7:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose8:
+ax_pose 7, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose9:
+ax_pose 8, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose10:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose11:
+ax_pose 10, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose12:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose16:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose17:
+ax_pose 16, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose18:
+ax_pose 17, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose19:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose20:
+ax_pose 7, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose21:
+ax_pose 8, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose22:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose23:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose24:
+ax_pose 20, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose28:
+ax_pose 21, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose29:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose30:
+ax_pose 4, 0x01e2, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose31:
+ax_pose 5, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose32:
+ax_pose 22, 0x01e8, 0x90f2, 0x4c00
+ax_pose_terminator
+sElectabuzzPose33:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose34:
+ax_pose 7, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose35:
+ax_pose 8, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose36:
+ax_pose 23, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose37:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose38:
+ax_pose 10, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose39:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose40:
+ax_pose 24, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose41:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose42:
+ax_pose 13, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose43:
+ax_pose 14, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose44:
+ax_pose 25, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sElectabuzzPose45:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose46:
+ax_pose 16, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose47:
+ax_pose 17, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose48:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose49:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose50:
+ax_pose 7, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose51:
+ax_pose 8, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose52:
+ax_pose 23, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose53:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose54:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose55:
+ax_pose 20, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose56:
+ax_pose 22, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose57:
+ax_pose 26, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose58:
+ax_pose 27, 0x01ea, 0x80eb, 0x4c00
+ax_pose 21, 0x01e4, 0x80f0, 0x4c10
+ax_pose_terminator
+sElectabuzzPose59:
+ax_pose 21, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose60:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose61:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose62:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose63:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose64:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose65:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose66:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose67:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose68:
+ax_pose 28, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose69:
+ax_pose 29, 0x01e8, 0x90f8, 0x4c00
+ax_pose 22, 0x01e4, 0x90f0, 0x4c10
+ax_pose_terminator
+sElectabuzzPose70:
+ax_pose 22, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose71:
+ax_pose 30, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose72:
+ax_pose 31, 0x01e4, 0x90fc, 0x4c00
+ax_pose 23, 0x01e4, 0x90ef, 0x4c10
+ax_pose_terminator
+sElectabuzzPose73:
+ax_pose 23, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose74:
+ax_pose 32, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose75:
+ax_pose 33, 0x01e2, 0x90f7, 0x4c00
+ax_pose 24, 0x01e4, 0x90f0, 0x4c10
+ax_pose_terminator
+sElectabuzzPose76:
+ax_pose 24, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose77:
+ax_pose 34, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose78:
+ax_pose 35, 0x01e1, 0x80ef, 0x4c00
+ax_pose 25, 0x01e4, 0x80f0, 0x4c10
+ax_pose_terminator
+sElectabuzzPose79:
+ax_pose 25, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose80:
+ax_pose 36, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose81:
+ax_pose 33, 0x01e3, 0x80e8, 0x4c00
+ax_pose 24, 0x01e4, 0x80f0, 0x4c10
+ax_pose_terminator
+sElectabuzzPose82:
+ax_pose 24, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose83:
+ax_pose 37, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose84:
+ax_pose 31, 0x01e4, 0x80e4, 0x4c00
+ax_pose 23, 0x01e4, 0x80f1, 0x4c10
+ax_pose_terminator
+sElectabuzzPose85:
+ax_pose 23, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose86:
+ax_pose 38, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose87:
+ax_pose 29, 0x01e8, 0x80e8, 0x4c00
+ax_pose 22, 0x01e4, 0x80f0, 0x4c10
+ax_pose_terminator
+sElectabuzzPose88:
+ax_pose 22, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose89:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose90:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose91:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose92:
+ax_pose 39, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose93:
+ax_pose 40, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose94:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose95:
+ax_pose 4, 0x01e2, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose96:
+ax_pose 5, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose97:
+ax_pose 41, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose98:
+ax_pose 42, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose99:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose100:
+ax_pose 7, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose101:
+ax_pose 8, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose102:
+ax_pose 43, 0x01e4, 0x90f3, 0x4c00
+ax_pose_terminator
+sElectabuzzPose103:
+ax_pose 44, 0x01e4, 0x90f3, 0x4c00
+ax_pose_terminator
+sElectabuzzPose104:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose105:
+ax_pose 10, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose106:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose107:
+ax_pose 45, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sElectabuzzPose108:
+ax_pose 46, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sElectabuzzPose109:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose110:
+ax_pose 13, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose111:
+ax_pose 14, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose112:
+ax_pose 47, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose113:
+ax_pose 48, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose114:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose115:
+ax_pose 16, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose116:
+ax_pose 17, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose117:
+ax_pose 49, 0x01e4, 0x80ee, 0x4c00
+ax_pose_terminator
+sElectabuzzPose118:
+ax_pose 50, 0x01e4, 0x80ee, 0x4c00
+ax_pose_terminator
+sElectabuzzPose119:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose120:
+ax_pose 7, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose121:
+ax_pose 8, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose122:
+ax_pose 43, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sElectabuzzPose123:
+ax_pose 44, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sElectabuzzPose124:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose125:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose126:
+ax_pose 20, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose127:
+ax_pose 41, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose128:
+ax_pose 42, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose129:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose130:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose131:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose132:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose133:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose134:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose135:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose136:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose137:
+ax_pose 51, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose138:
+ax_pose 52, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose139:
+ax_pose 53, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose140:
+ax_pose 54, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sElectabuzzPose141:
+ax_pose 55, 0x01e4, 0x80ec, 0x4c00
+ax_pose_terminator
+sElectabuzzPose142:
+ax_pose 56, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sElectabuzzPose143:
+ax_pose 57, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose144:
+ax_pose 58, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sElectabuzzPose145:
+ax_pose 59, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sElectabuzzPose146:
+ax_pose 60, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sElectabuzzPose147:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose148:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose149:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose150:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose151:
+ax_pose 4, 0x01e2, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose152:
+ax_pose 5, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose153:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose154:
+ax_pose 7, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose155:
+ax_pose 8, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose156:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose157:
+ax_pose 10, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose158:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose159:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose160:
+ax_pose 13, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose161:
+ax_pose 14, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose162:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose163:
+ax_pose 16, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose164:
+ax_pose 17, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose165:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose166:
+ax_pose 7, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose167:
+ax_pose 8, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose168:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose169:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose170:
+ax_pose 20, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose171:
+ax_pose 39, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose172:
+ax_pose 41, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sElectabuzzPose173:
+ax_pose 43, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose174:
+ax_pose 49, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose175:
+ax_pose 47, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose176:
+ax_pose 45, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose177:
+ax_pose 43, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose178:
+ax_pose 41, 0x01e3, 0x90ee, 0x4c00
+ax_pose_terminator
+sElectabuzzPose179:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose180:
+ax_pose 4, 0x01e2, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose181:
+ax_pose 7, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose182:
+ax_pose 10, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose183:
+ax_pose 13, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose184:
+ax_pose 16, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose185:
+ax_pose 7, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose186:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose187:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose188:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose189:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose190:
+ax_pose 39, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose191:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose192:
+ax_pose 4, 0x01e2, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose193:
+ax_pose 5, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose194:
+ax_pose 41, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose195:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose196:
+ax_pose 7, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose197:
+ax_pose 8, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose198:
+ax_pose 43, 0x01e4, 0x90f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose199:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose200:
+ax_pose 10, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose201:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose202:
+ax_pose 45, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose203:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose204:
+ax_pose 13, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose205:
+ax_pose 14, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose206:
+ax_pose 47, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose207:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose208:
+ax_pose 16, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose209:
+ax_pose 17, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose210:
+ax_pose 49, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose211:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose212:
+ax_pose 7, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose213:
+ax_pose 8, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose214:
+ax_pose 43, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose215:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose216:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose217:
+ax_pose 20, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose218:
+ax_pose 41, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose219:
+ax_pose 39, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose220:
+ax_pose 41, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sElectabuzzPose221:
+ax_pose 43, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose222:
+ax_pose 49, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose223:
+ax_pose 47, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose224:
+ax_pose 45, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose225:
+ax_pose 43, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose226:
+ax_pose 41, 0x01e3, 0x90ee, 0x4c00
+ax_pose_terminator
+sElectabuzzPose227:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose228:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose229:
+ax_pose 6, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElectabuzzPose230:
+ax_pose 15, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose231:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose232:
+ax_pose 9, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElectabuzzPose233:
+ax_pose 6, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElectabuzzPose234:
+ax_pose 3, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+.align 2
+sElectabuzzAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_2_1:
+ax_anim 2, 0, 52, 0, -1, 0, -1,
+ax_anim 6, 0, 52, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sElectabuzzAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 6, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 34, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sElectabuzzAnims_2_3:
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 6, 0, 36, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sElectabuzzAnims_2_4:
+ax_anim 2, 0, 44, -1, 1, -1, 1,
+ax_anim 6, 0, 44, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 7, -6, 7, -6,
+ax_anim 1, 0, 38, 13, -12, 13, -12,
+ax_anim 2, 0, 39, 18, -15, 18, -15,
+ax_anim 2, 1, 39, 19, -14, 19, -14,
+ax_anim 2, 0, 39, 18, -15, 18, -15,
+ax_anim 2, 0, 39, 19, -14, 19, -14,
+ax_anim 2, 0, 37, 6, -6, 6, -6,
+ax_anim_terminator
+sElectabuzzAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 42, 0, -6, 0, -6,
+ax_anim_terminator
+sElectabuzzAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -7, -6, -7, -6,
+ax_anim 1, 0, 46, -13, -12, -13, -12,
+ax_anim 2, 0, 47, -18, -15, -18, -15,
+ax_anim 2, 1, 47, -19, -14, -19, -14,
+ax_anim 2, 0, 47, -18, -15, -18, -15,
+ax_anim 2, 0, 47, -19, -14, -19, -14,
+ax_anim 2, 0, 45, -6, -6, -6, -6,
+ax_anim_terminator
+sElectabuzzAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 49, -6, 0, -6, 0,
+ax_anim_terminator
+sElectabuzzAnims_2_8:
+ax_anim 2, 0, 24, 1, -1, 1, -1,
+ax_anim 6, 0, 24, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 26, -10, 10, -10, 10,
+ax_anim 2, 0, 31, -19, 19, -19, 19,
+ax_anim 2, 1, 31, -20, 18, -20, 18,
+ax_anim 2, 0, 31, -19, 19, -19, 19,
+ax_anim 2, 0, 31, -20, 18, -20, 18,
+ax_anim 2, 0, 54, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_3_1:
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 2, 0, 56, 0, -4, 0, -4,
+ax_anim 6, 0, 56, 0, -5, 0, -5,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 2, 56, 0, 9, 0, 9,
+ax_anim 2, 0, 57, 0, 16, 0, 16,
+ax_anim 2, 1, 78, 0, 16, 0, 16,
+ax_anim 2, 0, 62, 0, 16, 0, 16,
+ax_anim 2, 0, 61, 0, 16, 0, 16,
+ax_anim 2, 0, 60, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 0, 11, 0, 11,
+ax_anim 2, 0, 59, 0, 4, 0, 4,
+ax_anim_terminator
+sElectabuzzAnims_3_2:
+ax_anim 2, 0, 66, -2, -2, -2, -2,
+ax_anim 2, 0, 67, -4, -4, -4, -4,
+ax_anim 6, 0, 67, -5, -5, -5, -5,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 2, 67, 9, 9, 9, 9,
+ax_anim 2, 0, 68, 16, 16, 16, 16,
+ax_anim 2, 1, 81, 18, 18, 16, 16,
+ax_anim 2, 0, 63, 16, 16, 16, 16,
+ax_anim 2, 0, 64, 16, 16, 16, 16,
+ax_anim 2, 0, 65, 16, 16, 16, 16,
+ax_anim 2, 0, 66, 16, 16, 16, 16,
+ax_anim 2, 0, 66, 11, 11, 11, 11,
+ax_anim 2, 0, 66, 4, 4, 4, 4,
+ax_anim_terminator
+sElectabuzzAnims_3_3:
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 2, 0, 70, -4, 0, -4, 0,
+ax_anim 6, 0, 70, -5, 0, -5, 0,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 2, 70, 6, 0, 6, 0,
+ax_anim 2, 0, 71, 11, 0, 11, 0,
+ax_anim 2, 1, 69, 15, 0, 13, 0,
+ax_anim 2, 0, 62, 11, 0, 11, 0,
+ax_anim 2, 0, 63, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 11, 0, 11, 0,
+ax_anim 2, 0, 65, 11, 0, 11, 0,
+ax_anim 2, 0, 65, 7, 0, 7, 0,
+ax_anim 2, 0, 65, 3, 0, 3, 0,
+ax_anim_terminator
+sElectabuzzAnims_3_4:
+ax_anim 2, 0, 73, -2, 2, -2, 2,
+ax_anim 2, 0, 73, -4, 4, -4, 4,
+ax_anim 6, 0, 73, -5, 5, -5, 5,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 6, -6, 6, -6,
+ax_anim 2, 0, 74, 12, -13, 12, -13,
+ax_anim 2, 1, 69, 16, -13, 12, -13,
+ax_anim 2, 0, 61, 12, -13, 12, -13,
+ax_anim 2, 0, 62, 12, -13, 12, -13,
+ax_anim 2, 0, 63, 12, -13, 12, -13,
+ax_anim 2, 0, 64, 12, -13, 12, -13,
+ax_anim 2, 0, 64, 9, -10, 9, -10,
+ax_anim 2, 0, 64, 4, -4, 4, -4,
+ax_anim_terminator
+sElectabuzzAnims_3_5:
+ax_anim 2, 0, 63, 0, 2, 0, 2,
+ax_anim 2, 0, 76, 0, 4, 0, 4,
+ax_anim 6, 0, 76, 0, 5, 0, 5,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 2, 76, 0, -7, 0, -7,
+ax_anim 2, 0, 77, 0, -12, 0, -12,
+ax_anim 2, 1, 84, 0, -12, 0, -12,
+ax_anim 2, 0, 87, 0, -12, 0, -12,
+ax_anim 2, 0, 65, 0, -12, 0, -12,
+ax_anim 2, 0, 64, 0, -12, 0, -12,
+ax_anim 2, 0, 63, 0, -12, 0, -12,
+ax_anim 2, 0, 63, 0, -9, 0, -9,
+ax_anim 2, 0, 63, 0, -4, 0, -4,
+ax_anim_terminator
+sElectabuzzAnims_3_6:
+ax_anim 2, 0, 62, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 6, 0, 79, 5, 5, 5, 5,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 2, 79, -6, -6, -6, -6,
+ax_anim 2, 0, 80, -12, -13, -12, -13,
+ax_anim 2, 1, 69, -14, -13, -12, -13,
+ax_anim 2, 0, 65, -12, -13, -12, -13,
+ax_anim 2, 0, 64, -12, -13, -12, -13,
+ax_anim 2, 0, 63, -12, -13, -12, -13,
+ax_anim 2, 0, 62, -12, -13, -12, -13,
+ax_anim 2, 0, 62, -9, -10, -9, -10,
+ax_anim 2, 0, 62, -4, -4, -4, -4,
+ax_anim_terminator
+sElectabuzzAnims_3_7:
+ax_anim 2, 0, 61, 2, 0, 2, 0,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 6, 0, 82, 5, 0, 5, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 82, -6, 0, -6, 0,
+ax_anim 2, 0, 83, -11, 0, -11, 0,
+ax_anim 2, 1, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 64, -11, 0, -11, 0,
+ax_anim 2, 0, 63, -11, 0, -11, 0,
+ax_anim 2, 0, 62, -11, 0, -11, 0,
+ax_anim 2, 0, 61, -11, 0, -11, 0,
+ax_anim 2, 0, 61, -7, 0, -7, 0,
+ax_anim 2, 0, 61, -3, 0, -3, 0,
+ax_anim_terminator
+sElectabuzzAnims_3_8:
+ax_anim 2, 0, 60, 2, -2, 2, -2,
+ax_anim 2, 0, 85, 4, -4, 4, -4,
+ax_anim 6, 0, 85, 5, -5, 5, -5,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 85, -9, 9, -9, 9,
+ax_anim 2, 0, 86, -16, 16, -16, 16,
+ax_anim 2, 1, 58, -16, 16, -16, 16,
+ax_anim 2, 0, 63, -16, 16, -16, 16,
+ax_anim 2, 0, 62, -16, 16, -16, 16,
+ax_anim 2, 0, 61, -16, 16, -16, 16,
+ax_anim 2, 0, 60, -16, 16, -16, 16,
+ax_anim 2, 0, 60, -11, 11, -11, 11,
+ax_anim 2, 0, 60, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim 6, 2, 88, 0, -4, 0, -4,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 3, 1, 92, 0, 4, 0, 4,
+ax_anim 3, 0, 91, 0, 4, 0, 4,
+ax_anim 3, 0, 92, 0, 4, 0, 4,
+ax_anim 3, 0, 91, 0, 4, 0, 4,
+ax_anim 3, 0, 92, 0, 4, 0, 4,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sElectabuzzAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 93, -3, -3, -3, -3,
+ax_anim 6, 2, 93, -4, -4, -4, -4,
+ax_anim 1, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 96, 4, 4, 4, 4,
+ax_anim 3, 1, 97, 4, 4, 4, 4,
+ax_anim 3, 0, 96, 4, 4, 4, 4,
+ax_anim 3, 0, 97, 4, 4, 4, 4,
+ax_anim 3, 0, 96, 4, 4, 4, 4,
+ax_anim 3, 0, 97, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sElectabuzzAnims_4_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 6, 2, 98, -4, 0, -4, 0,
+ax_anim 1, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 101, 4, 0, 4, 0,
+ax_anim 3, 1, 102, 4, 0, 4, 0,
+ax_anim 3, 0, 101, 4, 0, 4, 0,
+ax_anim 3, 0, 102, 4, 0, 4, 0,
+ax_anim 3, 0, 101, 4, 0, 4, 0,
+ax_anim 3, 0, 102, 4, 0, 4, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sElectabuzzAnims_4_4:
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 6, 2, 103, -4, 4, -4, 4,
+ax_anim 1, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 106, 4, -4, 4, -4,
+ax_anim 3, 1, 107, 4, -4, 4, -4,
+ax_anim 3, 0, 106, 4, -4, 4, -4,
+ax_anim 3, 0, 107, 4, -4, 4, -4,
+ax_anim 3, 0, 106, 4, -4, 4, -4,
+ax_anim 3, 0, 107, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sElectabuzzAnims_4_5:
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 6, 2, 108, 0, 4, 0, 4,
+ax_anim 1, 0, 110, 0, 1, 0, 1,
+ax_anim 2, 0, 111, 0, -4, 0, -4,
+ax_anim 3, 1, 112, 0, -4, 0, -4,
+ax_anim 3, 0, 111, 0, -4, 0, -4,
+ax_anim 3, 0, 112, 0, -4, 0, -4,
+ax_anim 3, 0, 111, 0, -4, 0, -4,
+ax_anim 3, 0, 112, 0, -4, 0, -4,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim_terminator
+sElectabuzzAnims_4_6:
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 6, 2, 113, 4, 4, 4, 4,
+ax_anim 1, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 116, -4, -4, -4, -4,
+ax_anim 3, 1, 117, -4, -4, -4, -4,
+ax_anim 3, 0, 116, -4, -4, -4, -4,
+ax_anim 3, 0, 117, -4, -4, -4, -4,
+ax_anim 3, 0, 116, -4, -4, -4, -4,
+ax_anim 3, 0, 117, -4, -4, -4, -4,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sElectabuzzAnims_4_7:
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 6, 2, 118, 4, 0, 4, 0,
+ax_anim 1, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 121, -4, 0, -4, 0,
+ax_anim 3, 1, 122, -4, 0, -4, 0,
+ax_anim 3, 0, 121, -4, 0, -4, 0,
+ax_anim 3, 0, 122, -4, 0, -4, 0,
+ax_anim 3, 0, 121, -4, 0, -4, 0,
+ax_anim 3, 0, 122, -4, 0, -4, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sElectabuzzAnims_4_8:
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 6, 2, 123, 4, -4, 4, -4,
+ax_anim 1, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 126, -4, 4, -4, 4,
+ax_anim 3, 1, 127, -4, 4, -4, 4,
+ax_anim 3, 0, 126, -4, 4, -4, 4,
+ax_anim 3, 0, 127, -4, 4, -4, 4,
+ax_anim 3, 0, 126, -4, 4, -4, 4,
+ax_anim 3, 0, 127, -4, 4, -4, 4,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sElectabuzzAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sElectabuzzAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sElectabuzzAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sElectabuzzAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sElectabuzzAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sElectabuzzAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sElectabuzzAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_8_1:
+ax_anim 28, 0, 146, 0, 0, 0, 0,
+ax_anim 18, 0, 147, 0, 0, 0, 0,
+ax_anim 28, 0, 146, 0, 0, 0, 0,
+ax_anim 18, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_8_2:
+ax_anim 28, 0, 149, 0, 0, 0, 0,
+ax_anim 18, 0, 150, 0, 0, 0, 0,
+ax_anim 28, 0, 149, 0, 0, 0, 0,
+ax_anim 18, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_8_3:
+ax_anim 28, 0, 152, 0, 0, 0, 0,
+ax_anim 18, 0, 153, 0, 0, 0, 0,
+ax_anim 28, 0, 152, 0, 0, 0, 0,
+ax_anim 18, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_8_4:
+ax_anim 28, 0, 155, 0, 0, 0, 0,
+ax_anim 18, 0, 156, 0, 0, 0, 0,
+ax_anim 28, 0, 155, 0, 0, 0, 0,
+ax_anim 18, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_8_5:
+ax_anim 28, 0, 158, 0, 0, 0, 0,
+ax_anim 18, 0, 159, 0, 0, 0, 0,
+ax_anim 28, 0, 158, 0, 0, 0, 0,
+ax_anim 18, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_8_6:
+ax_anim 28, 0, 161, 0, 0, 0, 0,
+ax_anim 18, 0, 162, 0, 0, 0, 0,
+ax_anim 28, 0, 161, 0, 0, 0, 0,
+ax_anim 18, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_8_7:
+ax_anim 28, 0, 164, 0, 0, 0, 0,
+ax_anim 18, 0, 165, 0, 0, 0, 0,
+ax_anim 28, 0, 164, 0, 0, 0, 0,
+ax_anim 18, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_8_8:
+ax_anim 28, 0, 167, 0, 0, 0, 0,
+ax_anim 18, 0, 168, 0, 0, 0, 0,
+ax_anim 28, 0, 167, 0, 0, 0, 0,
+ax_anim 18, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 17, 7, 17,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -7, 17, -7, 17,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 19, 11, 19, 11,
+ax_anim 3, 0, 173, 19, 21, 19, 21,
+ax_anim 2, 3, 174, 11, 20, 11, 20,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 20, -2, 20, -2,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 3, -16, 3, -16,
+ax_anim 2, 0, 170, 12, -21, 12, -21,
+ax_anim 3, 0, 171, 21, -19, 21, -19,
+ax_anim 2, 3, 172, 20, -13, 20, -13,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -17, -7, -17,
+ax_anim 3, 0, 170, 0, -20, 0, -20,
+ax_anim 2, 3, 171, 7, -17, 7, -17,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -3, -16, -3, -16,
+ax_anim 2, 0, 170, -12, -21, -12, -21,
+ax_anim 3, 0, 177, -21, -19, -21, -19,
+ax_anim 2, 3, 176, -20, -13, -20, -13,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -20, -2, -20, -2,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -19, 11, -19, 11,
+ax_anim 3, 0, 175, -19, 21, -19, 21,
+ax_anim 2, 3, 174, -11, 20, -11, 20,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_11_2:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_11_3:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -22, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_11_4:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -17, 0, 0,
+ax_anim 1, 0, 201, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_11_5:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 2, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_11_6:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -17, 0, 0,
+ax_anim 1, 0, 209, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_11_7:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_11_8:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectabuzzAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sElectabuzzGfx1:
+.incbin "baserom.gba", 0xA5F8E0, 0x200
+sElectabuzzSprites1:
+ax_sprite sElectabuzzGfx1, 0x200
+ax_sprite_terminator
+sElectabuzzGfx2:
+.incbin "baserom.gba", 0xA5FAF0, 0x200
+sElectabuzzSprites2:
+ax_sprite sElectabuzzGfx2, 0x200
+ax_sprite_terminator
+sElectabuzzGfx3:
+.incbin "baserom.gba", 0xA5FD00, 0x200
+sElectabuzzSprites3:
+ax_sprite sElectabuzzGfx3, 0x200
+ax_sprite_terminator
+sElectabuzzGfx4:
+.incbin "baserom.gba", 0xA5FF10, 0x200
+sElectabuzzSprites4:
+ax_sprite sElectabuzzGfx4, 0x200
+ax_sprite_terminator
+sElectabuzzGfx5:
+.incbin "baserom.gba", 0xA60120, 0x200
+sElectabuzzSprites5:
+ax_sprite sElectabuzzGfx5, 0x200
+ax_sprite_terminator
+sElectabuzzGfx6:
+.incbin "baserom.gba", 0xA60330, 0x200
+sElectabuzzSprites6:
+ax_sprite sElectabuzzGfx6, 0x200
+ax_sprite_terminator
+sElectabuzzGfx7:
+.incbin "baserom.gba", 0xA60540, 0x200
+sElectabuzzSprites7:
+ax_sprite sElectabuzzGfx7, 0x200
+ax_sprite_terminator
+sElectabuzzGfx8:
+.incbin "baserom.gba", 0xA60750, 0x200
+sElectabuzzSprites8:
+ax_sprite sElectabuzzGfx8, 0x200
+ax_sprite_terminator
+sElectabuzzGfx9:
+.incbin "baserom.gba", 0xA60960, 0x200
+sElectabuzzSprites9:
+ax_sprite sElectabuzzGfx9, 0x200
+ax_sprite_terminator
+sElectabuzzGfx10:
+.incbin "baserom.gba", 0xA60B70, 0x200
+sElectabuzzSprites10:
+ax_sprite sElectabuzzGfx10, 0x200
+ax_sprite_terminator
+sElectabuzzGfx11:
+.incbin "baserom.gba", 0xA60D80, 0x200
+sElectabuzzSprites11:
+ax_sprite sElectabuzzGfx11, 0x200
+ax_sprite_terminator
+sElectabuzzGfx12:
+.incbin "baserom.gba", 0xA60F90, 0x200
+sElectabuzzSprites12:
+ax_sprite sElectabuzzGfx12, 0x200
+ax_sprite_terminator
+sElectabuzzGfx13:
+.incbin "baserom.gba", 0xA611A0, 0x200
+sElectabuzzSprites13:
+ax_sprite sElectabuzzGfx13, 0x200
+ax_sprite_terminator
+sElectabuzzGfx14:
+.incbin "baserom.gba", 0xA613B0, 0x200
+sElectabuzzSprites14:
+ax_sprite sElectabuzzGfx14, 0x200
+ax_sprite_terminator
+sElectabuzzGfx15:
+.incbin "baserom.gba", 0xA615C0, 0x200
+sElectabuzzSprites15:
+ax_sprite sElectabuzzGfx15, 0x200
+ax_sprite_terminator
+sElectabuzzGfx16:
+.incbin "baserom.gba", 0xA617D0, 0x200
+sElectabuzzSprites16:
+ax_sprite sElectabuzzGfx16, 0x200
+ax_sprite_terminator
+sElectabuzzGfx17:
+.incbin "baserom.gba", 0xA619E0, 0x200
+sElectabuzzSprites17:
+ax_sprite sElectabuzzGfx17, 0x200
+ax_sprite_terminator
+sElectabuzzGfx18:
+.incbin "baserom.gba", 0xA61BF0, 0x200
+sElectabuzzSprites18:
+ax_sprite sElectabuzzGfx18, 0x200
+ax_sprite_terminator
+sElectabuzzGfx19:
+.incbin "baserom.gba", 0xA61E00, 0x200
+sElectabuzzSprites19:
+ax_sprite sElectabuzzGfx19, 0x200
+ax_sprite_terminator
+sElectabuzzGfx20:
+.incbin "baserom.gba", 0xA62010, 0x200
+sElectabuzzSprites20:
+ax_sprite sElectabuzzGfx20, 0x200
+ax_sprite_terminator
+sElectabuzzGfx21:
+.incbin "baserom.gba", 0xA62220, 0x200
+sElectabuzzSprites21:
+ax_sprite sElectabuzzGfx21, 0x200
+ax_sprite_terminator
+sElectabuzzGfx22:
+.incbin "baserom.gba", 0xA62430, 0x40
+sElectabuzzGfx22_1:
+.incbin "baserom.gba", 0xA62470, 0x100
+sElectabuzzGfx22_2:
+.incbin "baserom.gba", 0xA62570, 0x60
+sElectabuzzSprites22:
+ax_sprite sElectabuzzGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx22_2, 0x60
+ax_sprite_terminator
+sElectabuzzGfx23:
+.incbin "baserom.gba", 0xA62600, 0x60
+sElectabuzzGfx23_1:
+.incbin "baserom.gba", 0xA62660, 0x60
+sElectabuzzGfx23_2:
+.incbin "baserom.gba", 0xA626C0, 0xC0
+sElectabuzzSprites23:
+ax_sprite sElectabuzzGfx23, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx23_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx24:
+.incbin "baserom.gba", 0xA627B8, 0x200
+sElectabuzzSprites24:
+ax_sprite sElectabuzzGfx24, 0x200
+ax_sprite_terminator
+sElectabuzzGfx25:
+.incbin "baserom.gba", 0xA629C8, 0x40
+sElectabuzzGfx25_1:
+.incbin "baserom.gba", 0xA62A08, 0x160
+sElectabuzzSprites25:
+ax_sprite sElectabuzzGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx25_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx26:
+.incbin "baserom.gba", 0xA62B90, 0x40
+sElectabuzzGfx26_1:
+.incbin "baserom.gba", 0xA62BD0, 0x60
+sElectabuzzGfx26_2:
+.incbin "baserom.gba", 0xA62C30, 0x100
+sElectabuzzSprites26:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx26_2, 0x100
+ax_sprite_terminator
+sElectabuzzGfx27:
+.incbin "baserom.gba", 0xA62D68, 0x40
+sElectabuzzGfx27_1:
+.incbin "baserom.gba", 0xA62DA8, 0x160
+sElectabuzzSprites27:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx28:
+.incbin "baserom.gba", 0xA62F38, 0x20
+sElectabuzzGfx28_1:
+.incbin "baserom.gba", 0xA62F58, 0x20
+sElectabuzzGfx28_2:
+.incbin "baserom.gba", 0xA62F78, 0x100
+sElectabuzzSprites28:
+ax_sprite sElectabuzzGfx28, 0x20
+ax_sprite 0, 0x60
+ax_sprite sElectabuzzGfx28_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sElectabuzzGfx28_2, 0x100
+ax_sprite_terminator
+sElectabuzzGfx29:
+.incbin "baserom.gba", 0xA630A8, 0x60
+sElectabuzzGfx29_1:
+.incbin "baserom.gba", 0xA63108, 0x60
+sElectabuzzGfx29_2:
+.incbin "baserom.gba", 0xA63168, 0xE0
+sElectabuzzSprites29:
+ax_sprite sElectabuzzGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx29_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx30:
+.incbin "baserom.gba", 0xA63280, 0x60
+sElectabuzzGfx30_1:
+.incbin "baserom.gba", 0xA632E0, 0x40
+sElectabuzzGfx30_2:
+.incbin "baserom.gba", 0xA63320, 0x100
+sElectabuzzSprites30:
+ax_sprite sElectabuzzGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx30_2, 0x100
+ax_sprite_terminator
+sElectabuzzGfx31:
+.incbin "baserom.gba", 0xA63450, 0x60
+sElectabuzzGfx31_1:
+.incbin "baserom.gba", 0xA634B0, 0x180
+sElectabuzzSprites31:
+ax_sprite sElectabuzzGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx31_1, 0x180
+ax_sprite_terminator
+sElectabuzzGfx32:
+.incbin "baserom.gba", 0xA63650, 0xC0
+sElectabuzzGfx32_1:
+.incbin "baserom.gba", 0xA63710, 0x40
+sElectabuzzGfx32_2:
+.incbin "baserom.gba", 0xA63750, 0x80
+sElectabuzzSprites32:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx32, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx32_2, 0x80
+ax_sprite_terminator
+sElectabuzzGfx33:
+.incbin "baserom.gba", 0xA63808, 0x60
+sElectabuzzGfx33_1:
+.incbin "baserom.gba", 0xA63868, 0x60
+sElectabuzzGfx33_2:
+.incbin "baserom.gba", 0xA638C8, 0x60
+sElectabuzzGfx33_3:
+.incbin "baserom.gba", 0xA63928, 0x60
+sElectabuzzSprites33:
+ax_sprite sElectabuzzGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx33_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx34:
+.incbin "baserom.gba", 0xA639D0, 0xC0
+sElectabuzzGfx34_1:
+.incbin "baserom.gba", 0xA63A90, 0x40
+sElectabuzzGfx34_2:
+.incbin "baserom.gba", 0xA63AD0, 0x40
+sElectabuzzSprites34:
+ax_sprite sElectabuzzGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sElectabuzzGfx35:
+.incbin "baserom.gba", 0xA63B48, 0x40
+sElectabuzzGfx35_1:
+.incbin "baserom.gba", 0xA63B88, 0xC0
+sElectabuzzGfx35_2:
+.incbin "baserom.gba", 0xA63C48, 0x60
+sElectabuzzSprites35:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx35_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx36:
+.incbin "baserom.gba", 0xA63CE8, 0xC0
+sElectabuzzGfx36_1:
+.incbin "baserom.gba", 0xA63DA8, 0x60
+sElectabuzzGfx36_2:
+.incbin "baserom.gba", 0xA63E08, 0x20
+sElectabuzzSprites36:
+ax_sprite sElectabuzzGfx36, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx36_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sElectabuzzGfx37:
+.incbin "baserom.gba", 0xA63E60, 0x60
+sElectabuzzGfx37_1:
+.incbin "baserom.gba", 0xA63EC0, 0x60
+sElectabuzzGfx37_2:
+.incbin "baserom.gba", 0xA63F20, 0x60
+sElectabuzzGfx37_3:
+.incbin "baserom.gba", 0xA63F80, 0x60
+sElectabuzzSprites37:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx37_3, 0x60
+ax_sprite_terminator
+sElectabuzzGfx38:
+.incbin "baserom.gba", 0xA64028, 0x1E0
+sElectabuzzSprites38:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx38, 0x1e0
+ax_sprite_terminator
+sElectabuzzGfx39:
+.incbin "baserom.gba", 0xA64220, 0x60
+sElectabuzzGfx39_1:
+.incbin "baserom.gba", 0xA64280, 0xE0
+sElectabuzzGfx39_2:
+.incbin "baserom.gba", 0xA64360, 0x60
+sElectabuzzSprites39:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx39_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx39_2, 0x60
+ax_sprite_terminator
+sElectabuzzGfx40:
+.incbin "baserom.gba", 0xA643F8, 0x40
+sElectabuzzGfx40_1:
+.incbin "baserom.gba", 0xA64438, 0x180
+sElectabuzzSprites40:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx40_1, 0x180
+ax_sprite_terminator
+sElectabuzzGfx41:
+.incbin "baserom.gba", 0xA645E0, 0x40
+sElectabuzzGfx41_1:
+.incbin "baserom.gba", 0xA64620, 0x180
+sElectabuzzSprites41:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx41_1, 0x180
+ax_sprite_terminator
+sElectabuzzGfx42:
+.incbin "baserom.gba", 0xA647C8, 0x140
+sElectabuzzGfx42_1:
+.incbin "baserom.gba", 0xA64908, 0x60
+sElectabuzzSprites42:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx42, 0x140
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx43:
+.incbin "baserom.gba", 0xA64998, 0x120
+sElectabuzzGfx43_1:
+.incbin "baserom.gba", 0xA64AB8, 0x60
+sElectabuzzSprites43:
+ax_sprite 0, 0x40
+ax_sprite sElectabuzzGfx43, 0x120
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx44:
+.incbin "baserom.gba", 0xA64B48, 0x160
+sElectabuzzGfx44_1:
+.incbin "baserom.gba", 0xA64CA8, 0x40
+sElectabuzzSprites44:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx44, 0x160
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx44_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx45:
+.incbin "baserom.gba", 0xA64D18, 0x40
+sElectabuzzGfx45_1:
+.incbin "baserom.gba", 0xA64D58, 0x160
+sElectabuzzSprites45:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx45_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx46:
+.incbin "baserom.gba", 0xA64EE8, 0x40
+sElectabuzzGfx46_1:
+.incbin "baserom.gba", 0xA64F28, 0x100
+sElectabuzzGfx46_2:
+.incbin "baserom.gba", 0xA65028, 0x40
+sElectabuzzSprites46:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx46_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx46_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx47:
+.incbin "baserom.gba", 0xA650A8, 0x40
+sElectabuzzGfx47_1:
+.incbin "baserom.gba", 0xA650E8, 0x100
+sElectabuzzGfx47_2:
+.incbin "baserom.gba", 0xA651E8, 0x60
+sElectabuzzSprites47:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx47, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx47_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx47_2, 0x60
+ax_sprite_terminator
+sElectabuzzGfx48:
+.incbin "baserom.gba", 0xA65280, 0x60
+sElectabuzzGfx48_1:
+.incbin "baserom.gba", 0xA652E0, 0x180
+sElectabuzzSprites48:
+ax_sprite sElectabuzzGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx48_1, 0x180
+ax_sprite_terminator
+sElectabuzzGfx49:
+.incbin "baserom.gba", 0xA65480, 0x1E0
+sElectabuzzSprites49:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx49, 0x1e0
+ax_sprite_terminator
+sElectabuzzGfx50:
+.incbin "baserom.gba", 0xA65678, 0x40
+sElectabuzzGfx50_1:
+.incbin "baserom.gba", 0xA656B8, 0x100
+sElectabuzzGfx50_2:
+.incbin "baserom.gba", 0xA657B8, 0x40
+sElectabuzzSprites50:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx50_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx50_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx51:
+.incbin "baserom.gba", 0xA65838, 0x40
+sElectabuzzGfx51_1:
+.incbin "baserom.gba", 0xA65878, 0x160
+sElectabuzzSprites51:
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx51, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectabuzzGfx51_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectabuzzGfx52:
+.incbin "baserom.gba", 0xA65A08, 0x200
+sElectabuzzSprites52:
+ax_sprite sElectabuzzGfx52, 0x200
+ax_sprite_terminator
+sElectabuzzGfx53:
+.incbin "baserom.gba", 0xA65C18, 0x200
+sElectabuzzSprites53:
+ax_sprite sElectabuzzGfx53, 0x200
+ax_sprite_terminator
+sElectabuzzGfx54:
+.incbin "baserom.gba", 0xA65E28, 0x200
+sElectabuzzSprites54:
+ax_sprite sElectabuzzGfx54, 0x200
+ax_sprite_terminator
+sElectabuzzGfx55:
+.incbin "baserom.gba", 0xA66038, 0x200
+sElectabuzzSprites55:
+ax_sprite sElectabuzzGfx55, 0x200
+ax_sprite_terminator
+sElectabuzzGfx56:
+.incbin "baserom.gba", 0xA66248, 0x200
+sElectabuzzSprites56:
+ax_sprite sElectabuzzGfx56, 0x200
+ax_sprite_terminator
+sElectabuzzGfx57:
+.incbin "baserom.gba", 0xA66458, 0x200
+sElectabuzzSprites57:
+ax_sprite sElectabuzzGfx57, 0x200
+ax_sprite_terminator
+sElectabuzzGfx58:
+.incbin "baserom.gba", 0xA66668, 0x200
+sElectabuzzSprites58:
+ax_sprite sElectabuzzGfx58, 0x200
+ax_sprite_terminator
+sElectabuzzGfx59:
+.incbin "baserom.gba", 0xA66878, 0x200
+sElectabuzzSprites59:
+ax_sprite sElectabuzzGfx59, 0x200
+ax_sprite_terminator
+sElectabuzzGfx60:
+.incbin "baserom.gba", 0xA66A88, 0x200
+sElectabuzzSprites60:
+ax_sprite sElectabuzzGfx60, 0x200
+ax_sprite_terminator
+sElectabuzzGfx61:
+.incbin "baserom.gba", 0xA66C98, 0x200
+sElectabuzzSprites61:
+ax_sprite sElectabuzzGfx61, 0x200
+ax_sprite_terminator
+sAxPosesElectabuzz:
+.4byte sElectabuzzPose1
+.4byte sElectabuzzPose2
+.4byte sElectabuzzPose3
+.4byte sElectabuzzPose4
+.4byte sElectabuzzPose5
+.4byte sElectabuzzPose6
+.4byte sElectabuzzPose7
+.4byte sElectabuzzPose8
+.4byte sElectabuzzPose9
+.4byte sElectabuzzPose10
+.4byte sElectabuzzPose11
+.4byte sElectabuzzPose12
+.4byte sElectabuzzPose13
+.4byte sElectabuzzPose14
+.4byte sElectabuzzPose15
+.4byte sElectabuzzPose16
+.4byte sElectabuzzPose17
+.4byte sElectabuzzPose18
+.4byte sElectabuzzPose19
+.4byte sElectabuzzPose20
+.4byte sElectabuzzPose21
+.4byte sElectabuzzPose22
+.4byte sElectabuzzPose23
+.4byte sElectabuzzPose24
+.4byte sElectabuzzPose25
+.4byte sElectabuzzPose26
+.4byte sElectabuzzPose27
+.4byte sElectabuzzPose28
+.4byte sElectabuzzPose29
+.4byte sElectabuzzPose30
+.4byte sElectabuzzPose31
+.4byte sElectabuzzPose32
+.4byte sElectabuzzPose33
+.4byte sElectabuzzPose34
+.4byte sElectabuzzPose35
+.4byte sElectabuzzPose36
+.4byte sElectabuzzPose37
+.4byte sElectabuzzPose38
+.4byte sElectabuzzPose39
+.4byte sElectabuzzPose40
+.4byte sElectabuzzPose41
+.4byte sElectabuzzPose42
+.4byte sElectabuzzPose43
+.4byte sElectabuzzPose44
+.4byte sElectabuzzPose45
+.4byte sElectabuzzPose46
+.4byte sElectabuzzPose47
+.4byte sElectabuzzPose48
+.4byte sElectabuzzPose49
+.4byte sElectabuzzPose50
+.4byte sElectabuzzPose51
+.4byte sElectabuzzPose52
+.4byte sElectabuzzPose53
+.4byte sElectabuzzPose54
+.4byte sElectabuzzPose55
+.4byte sElectabuzzPose56
+.4byte sElectabuzzPose57
+.4byte sElectabuzzPose58
+.4byte sElectabuzzPose59
+.4byte sElectabuzzPose60
+.4byte sElectabuzzPose61
+.4byte sElectabuzzPose62
+.4byte sElectabuzzPose63
+.4byte sElectabuzzPose64
+.4byte sElectabuzzPose65
+.4byte sElectabuzzPose66
+.4byte sElectabuzzPose67
+.4byte sElectabuzzPose68
+.4byte sElectabuzzPose69
+.4byte sElectabuzzPose70
+.4byte sElectabuzzPose71
+.4byte sElectabuzzPose72
+.4byte sElectabuzzPose73
+.4byte sElectabuzzPose74
+.4byte sElectabuzzPose75
+.4byte sElectabuzzPose76
+.4byte sElectabuzzPose77
+.4byte sElectabuzzPose78
+.4byte sElectabuzzPose79
+.4byte sElectabuzzPose80
+.4byte sElectabuzzPose81
+.4byte sElectabuzzPose82
+.4byte sElectabuzzPose83
+.4byte sElectabuzzPose84
+.4byte sElectabuzzPose85
+.4byte sElectabuzzPose86
+.4byte sElectabuzzPose87
+.4byte sElectabuzzPose88
+.4byte sElectabuzzPose89
+.4byte sElectabuzzPose90
+.4byte sElectabuzzPose91
+.4byte sElectabuzzPose92
+.4byte sElectabuzzPose93
+.4byte sElectabuzzPose94
+.4byte sElectabuzzPose95
+.4byte sElectabuzzPose96
+.4byte sElectabuzzPose97
+.4byte sElectabuzzPose98
+.4byte sElectabuzzPose99
+.4byte sElectabuzzPose100
+.4byte sElectabuzzPose101
+.4byte sElectabuzzPose102
+.4byte sElectabuzzPose103
+.4byte sElectabuzzPose104
+.4byte sElectabuzzPose105
+.4byte sElectabuzzPose106
+.4byte sElectabuzzPose107
+.4byte sElectabuzzPose108
+.4byte sElectabuzzPose109
+.4byte sElectabuzzPose110
+.4byte sElectabuzzPose111
+.4byte sElectabuzzPose112
+.4byte sElectabuzzPose113
+.4byte sElectabuzzPose114
+.4byte sElectabuzzPose115
+.4byte sElectabuzzPose116
+.4byte sElectabuzzPose117
+.4byte sElectabuzzPose118
+.4byte sElectabuzzPose119
+.4byte sElectabuzzPose120
+.4byte sElectabuzzPose121
+.4byte sElectabuzzPose122
+.4byte sElectabuzzPose123
+.4byte sElectabuzzPose124
+.4byte sElectabuzzPose125
+.4byte sElectabuzzPose126
+.4byte sElectabuzzPose127
+.4byte sElectabuzzPose128
+.4byte sElectabuzzPose129
+.4byte sElectabuzzPose130
+.4byte sElectabuzzPose131
+.4byte sElectabuzzPose132
+.4byte sElectabuzzPose133
+.4byte sElectabuzzPose134
+.4byte sElectabuzzPose135
+.4byte sElectabuzzPose136
+.4byte sElectabuzzPose137
+.4byte sElectabuzzPose138
+.4byte sElectabuzzPose139
+.4byte sElectabuzzPose140
+.4byte sElectabuzzPose141
+.4byte sElectabuzzPose142
+.4byte sElectabuzzPose143
+.4byte sElectabuzzPose144
+.4byte sElectabuzzPose145
+.4byte sElectabuzzPose146
+.4byte sElectabuzzPose147
+.4byte sElectabuzzPose148
+.4byte sElectabuzzPose149
+.4byte sElectabuzzPose150
+.4byte sElectabuzzPose151
+.4byte sElectabuzzPose152
+.4byte sElectabuzzPose153
+.4byte sElectabuzzPose154
+.4byte sElectabuzzPose155
+.4byte sElectabuzzPose156
+.4byte sElectabuzzPose157
+.4byte sElectabuzzPose158
+.4byte sElectabuzzPose159
+.4byte sElectabuzzPose160
+.4byte sElectabuzzPose161
+.4byte sElectabuzzPose162
+.4byte sElectabuzzPose163
+.4byte sElectabuzzPose164
+.4byte sElectabuzzPose165
+.4byte sElectabuzzPose166
+.4byte sElectabuzzPose167
+.4byte sElectabuzzPose168
+.4byte sElectabuzzPose169
+.4byte sElectabuzzPose170
+.4byte sElectabuzzPose171
+.4byte sElectabuzzPose172
+.4byte sElectabuzzPose173
+.4byte sElectabuzzPose174
+.4byte sElectabuzzPose175
+.4byte sElectabuzzPose176
+.4byte sElectabuzzPose177
+.4byte sElectabuzzPose178
+.4byte sElectabuzzPose179
+.4byte sElectabuzzPose180
+.4byte sElectabuzzPose181
+.4byte sElectabuzzPose182
+.4byte sElectabuzzPose183
+.4byte sElectabuzzPose184
+.4byte sElectabuzzPose185
+.4byte sElectabuzzPose186
+.4byte sElectabuzzPose187
+.4byte sElectabuzzPose188
+.4byte sElectabuzzPose189
+.4byte sElectabuzzPose190
+.4byte sElectabuzzPose191
+.4byte sElectabuzzPose192
+.4byte sElectabuzzPose193
+.4byte sElectabuzzPose194
+.4byte sElectabuzzPose195
+.4byte sElectabuzzPose196
+.4byte sElectabuzzPose197
+.4byte sElectabuzzPose198
+.4byte sElectabuzzPose199
+.4byte sElectabuzzPose200
+.4byte sElectabuzzPose201
+.4byte sElectabuzzPose202
+.4byte sElectabuzzPose203
+.4byte sElectabuzzPose204
+.4byte sElectabuzzPose205
+.4byte sElectabuzzPose206
+.4byte sElectabuzzPose207
+.4byte sElectabuzzPose208
+.4byte sElectabuzzPose209
+.4byte sElectabuzzPose210
+.4byte sElectabuzzPose211
+.4byte sElectabuzzPose212
+.4byte sElectabuzzPose213
+.4byte sElectabuzzPose214
+.4byte sElectabuzzPose215
+.4byte sElectabuzzPose216
+.4byte sElectabuzzPose217
+.4byte sElectabuzzPose218
+.4byte sElectabuzzPose219
+.4byte sElectabuzzPose220
+.4byte sElectabuzzPose221
+.4byte sElectabuzzPose222
+.4byte sElectabuzzPose223
+.4byte sElectabuzzPose224
+.4byte sElectabuzzPose225
+.4byte sElectabuzzPose226
+.4byte sElectabuzzPose227
+.4byte sElectabuzzPose228
+.4byte sElectabuzzPose229
+.4byte sElectabuzzPose230
+.4byte sElectabuzzPose231
+.4byte sElectabuzzPose232
+.4byte sElectabuzzPose233
+.4byte sElectabuzzPose234
+sAxPositionsElectabuzz:
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte    0,   -8, 	  -3,  -23, 	   6,  -20, 	   0,  -10
+.2byte   -2,   -8, 	  -7,  -20, 	   2,  -24, 	  -2,  -10
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+.2byte    0,   -8, 	 -10,  -19, 	   0,  -27, 	  -2,   -9
+.2byte    4,   -9, 	  -9,  -22, 	   4,  -24, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    5,   -8, 	  -6,  -26, 	  -7,  -15, 	  -1,   -8
+.2byte    8,  -10, 	   0,  -23, 	  -7,  -19, 	   0,   -9
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    3,  -14, 	   3,  -17, 	  -7,  -25, 	  -1,  -10
+.2byte    2,  -12, 	  -2,  -19, 	  -7,  -21, 	  -2,  -10
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	   5,  -17, 	  -9,  -21, 	  -1,  -10
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -5,  -12, 	   7,  -25, 	  -5,  -17, 	   0,  -10
+.2byte   -3,  -11, 	   5,  -21, 	   2,  -20, 	   0,   -9
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -6,   -8, 	   5,  -26, 	   6,  -15, 	   0,   -8
+.2byte   -9,  -10, 	  -1,  -23, 	   6,  -19, 	  -1,   -9
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -2,   -6, 	  -2,  -24, 	   7,  -17, 	   1,   -7
+.2byte   -5,   -8, 	  -5,  -24, 	   7,  -21, 	   1,   -8
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte    0,   -8, 	  -3,  -23, 	   6,  -20, 	   0,  -10
+.2byte   -2,   -8, 	  -7,  -20, 	   2,  -24, 	  -2,  -10
+.2byte    2,   -5, 	  10,    0, 	  -7,  -21, 	   0,  -11
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+.2byte    0,   -8, 	 -10,  -19, 	   0,  -27, 	  -2,   -9
+.2byte    4,   -9, 	  -9,  -22, 	   4,  -24, 	   0,   -8
+.2byte   -5,   -5, 	  -4,    5, 	  -2,  -20, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    5,   -8, 	  -6,  -26, 	  -7,  -15, 	  -1,   -8
+.2byte    8,  -10, 	   0,  -23, 	  -7,  -19, 	   0,   -9
+.2byte    3,   -5, 	   3,    4, 	  -9,  -18, 	   0,   -8
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    3,  -14, 	   3,  -17, 	  -7,  -25, 	  -1,  -10
+.2byte    2,  -12, 	  -2,  -19, 	  -7,  -21, 	  -2,  -10
+.2byte    6,   -9, 	  10,    1, 	 -10,   -9, 	   0,   -9
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	   5,  -17, 	  -9,  -21, 	  -1,  -10
+.2byte   -2,  -14, 	 -11,   -9, 	  -4,   -3, 	   1,   -9
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -5,  -12, 	   7,  -25, 	  -5,  -17, 	   0,  -10
+.2byte   -3,  -11, 	   5,  -21, 	   2,  -20, 	   0,   -9
+.2byte   -7,   -9, 	 -11,    1, 	   9,   -9, 	  -1,   -9
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -6,   -8, 	   5,  -26, 	   6,  -15, 	   0,   -8
+.2byte   -9,  -10, 	  -1,  -23, 	   6,  -19, 	  -1,   -9
+.2byte   -4,   -5, 	  -4,    4, 	   8,  -18, 	  -1,   -8
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -2,   -6, 	  -2,  -24, 	   7,  -17, 	   1,   -7
+.2byte   -5,   -8, 	  -5,  -24, 	   7,  -21, 	   1,   -8
+.2byte    6,   -5, 	   5,    5, 	   3,  -20, 	   1,   -8
+.2byte   -7,  -14, 	   2,  -24, 	  -9,   -5, 	   0,  -10
+.2byte    1,   -5, 	   9,    0, 	  -8,  -21, 	  -1,  -11
+.2byte    1,   -5, 	   9,    0, 	  -8,  -21, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+.2byte    3,  -12, 	  12,   -9, 	  -8,  -21, 	  -1,  -10
+.2byte   -7,   -9, 	  -6,    1, 	  -4,  -24, 	  -2,  -12
+.2byte   -7,   -9, 	  -6,    1, 	  -4,  -24, 	  -2,  -12
+.2byte    0,  -13, 	   9,  -14, 	 -13,  -15, 	  -4,   -9
+.2byte    3,   -8, 	   3,    1, 	  -9,  -21, 	   0,  -11
+.2byte    3,   -8, 	   3,    1, 	  -9,  -21, 	   0,  -11
+.2byte   -5,  -16, 	   1,  -20, 	 -12,  -12, 	  -4,   -9
+.2byte    6,  -12, 	  10,   -2, 	 -10,  -12, 	   0,  -12
+.2byte    6,  -12, 	  10,   -2, 	 -10,  -12, 	   0,  -12
+.2byte    5,  -11, 	  -1,   -8, 	   8,  -17, 	   1,  -10
+.2byte   -4,  -15, 	 -13,  -10, 	  -6,   -4, 	  -1,  -10
+.2byte   -4,  -15, 	 -13,  -10, 	  -6,   -4, 	  -1,  -10
+.2byte    7,  -15, 	  12,  -13, 	  -3,  -19, 	   2,  -10
+.2byte   -7,  -12, 	 -11,   -2, 	   9,  -12, 	  -1,  -12
+.2byte   -7,  -12, 	 -11,   -2, 	   9,  -12, 	  -1,  -12
+.2byte    2,  -15, 	  12,  -15, 	 -10,  -15, 	   4,   -9
+.2byte   -4,   -8, 	  -4,    1, 	   8,  -21, 	  -1,  -11
+.2byte   -4,   -8, 	  -4,    1, 	   8,  -21, 	  -1,  -11
+.2byte   -2,  -16, 	   6,  -21, 	 -13,   -9, 	   1,  -10
+.2byte    6,   -9, 	   5,    1, 	   3,  -24, 	   1,  -12
+.2byte    6,   -9, 	   5,    1, 	   3,  -24, 	   1,  -12
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte    0,   -8, 	  -3,  -23, 	   6,  -20, 	   0,  -10
+.2byte   -2,   -8, 	  -7,  -20, 	   2,  -24, 	  -2,  -10
+.2byte   -1,   -6, 	  -8,   -1, 	   8,   -6, 	  -1,  -10
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -2, 	  -1,   -9
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+.2byte    0,   -8, 	 -10,  -19, 	   0,  -27, 	  -2,   -9
+.2byte    4,   -9, 	  -9,  -22, 	   4,  -24, 	   0,   -8
+.2byte    5,   -7, 	  12,   -2, 	   2,   -3, 	   2,   -8
+.2byte    4,   -6, 	  12,   -6, 	   1,    0, 	   2,   -7
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    5,   -8, 	  -6,  -26, 	  -7,  -15, 	  -1,   -8
+.2byte    8,  -10, 	   0,  -23, 	  -7,  -19, 	   0,   -9
+.2byte   11,  -10, 	  13,   -7, 	  15,  -10, 	   4,   -9
+.2byte   13,   -9, 	  16,  -13, 	  14,   -5, 	   5,   -8
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    3,  -14, 	   3,  -17, 	  -7,  -25, 	  -1,  -10
+.2byte    2,  -12, 	  -2,  -19, 	  -7,  -21, 	  -2,  -10
+.2byte    7,  -11, 	  15,  -15, 	   5,  -17, 	   1,  -11
+.2byte    8,  -10, 	  15,  -10, 	   3,  -16, 	   3,  -10
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	   5,  -17, 	  -9,  -21, 	  -1,  -10
+.2byte   -2,  -15, 	   8,  -17, 	 -10,  -22, 	  -1,  -11
+.2byte   -1,  -13, 	   8,  -19, 	  -9,  -17, 	  -1,  -11
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -5,  -12, 	   7,  -25, 	  -5,  -17, 	   0,  -10
+.2byte   -3,  -11, 	   5,  -21, 	   2,  -20, 	   0,   -9
+.2byte   -7,  -12, 	 -10,  -12, 	 -15,  -14, 	  -2,  -11
+.2byte   -9,  -11, 	 -10,  -14, 	 -15,  -10, 	  -3,  -11
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -6,   -8, 	   5,  -26, 	   6,  -15, 	   0,   -8
+.2byte   -9,  -10, 	  -1,  -23, 	   6,  -19, 	  -1,   -9
+.2byte  -12,  -10, 	 -14,   -7, 	 -16,  -10, 	  -5,   -9
+.2byte  -14,   -9, 	 -17,  -13, 	 -15,   -5, 	  -6,   -8
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -2,   -6, 	  -2,  -24, 	   7,  -17, 	   1,   -7
+.2byte   -5,   -8, 	  -5,  -24, 	   7,  -21, 	   1,   -8
+.2byte   -6,   -7, 	 -13,   -2, 	  -3,   -3, 	  -3,   -8
+.2byte   -5,   -6, 	 -13,   -6, 	  -2,    0, 	  -3,   -7
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+.2byte   -1,   -6, 	 -10,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -1, 	  -1,   -6
+.2byte    0,  -16, 	 -13,  -10, 	  13,  -11, 	   0,  -12
+.2byte    0,  -15, 	 -12,   -4, 	   8,  -18, 	  -2,  -12
+.2byte    3,  -16, 	  -3,   -4, 	  -3,  -10, 	  -1,  -11
+.2byte    2,  -20, 	   9,   -7, 	  -9,  -12, 	  -1,  -11
+.2byte    0,  -16, 	  11,  -10, 	 -11,  -10, 	   0,  -10
+.2byte   -3,  -19, 	   8,  -11, 	 -11,   -6, 	   1,  -10
+.2byte   -5,  -17, 	  -2,  -10, 	   1,   -5, 	   0,  -11
+.2byte   -2,  -15, 	 -10,  -17, 	  10,   -4, 	   1,  -11
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte    0,   -8, 	  -3,  -23, 	   6,  -20, 	   0,  -10
+.2byte   -2,   -8, 	  -7,  -20, 	   2,  -24, 	  -2,  -10
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+.2byte    0,   -8, 	 -10,  -19, 	   0,  -27, 	  -2,   -9
+.2byte    4,   -9, 	  -9,  -22, 	   4,  -24, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    5,   -8, 	  -6,  -26, 	  -7,  -15, 	  -1,   -8
+.2byte    8,  -10, 	   0,  -23, 	  -7,  -19, 	   0,   -9
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    3,  -14, 	   3,  -17, 	  -7,  -25, 	  -1,  -10
+.2byte    2,  -12, 	  -2,  -19, 	  -7,  -21, 	  -2,  -10
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	   5,  -17, 	  -9,  -21, 	  -1,  -10
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -5,  -12, 	   7,  -25, 	  -5,  -17, 	   0,  -10
+.2byte   -3,  -11, 	   5,  -21, 	   2,  -20, 	   0,   -9
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -6,   -8, 	   5,  -26, 	   6,  -15, 	   0,   -8
+.2byte   -9,  -10, 	  -1,  -23, 	   6,  -19, 	  -1,   -9
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -2,   -6, 	  -2,  -24, 	   7,  -17, 	   1,   -7
+.2byte   -5,   -8, 	  -5,  -24, 	   7,  -21, 	   1,   -8
+.2byte   -1,   -6, 	  -8,   -1, 	   8,   -6, 	  -1,  -10
+.2byte   -4,   -8, 	 -11,   -3, 	  -1,   -4, 	  -1,   -9
+.2byte   -8,  -10, 	 -10,   -7, 	 -12,  -10, 	  -1,   -9
+.2byte   -4,  -12, 	  -7,  -12, 	 -12,  -14, 	   1,  -11
+.2byte   -2,  -14, 	   8,  -16, 	 -10,  -21, 	  -1,  -10
+.2byte    4,  -11, 	  12,  -15, 	   2,  -17, 	  -2,  -11
+.2byte    7,  -10, 	   9,   -7, 	  11,  -10, 	   0,   -9
+.2byte    3,   -8, 	  10,   -3, 	   0,   -4, 	   0,   -9
+.2byte    0,   -8, 	  -3,  -23, 	   6,  -20, 	   0,  -10
+.2byte    0,   -8, 	 -10,  -19, 	   0,  -27, 	  -2,   -9
+.2byte    5,   -8, 	  -6,  -26, 	  -7,  -15, 	  -1,   -8
+.2byte    3,  -14, 	   3,  -17, 	  -7,  -25, 	  -1,  -10
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -17, 	  -1,  -10
+.2byte   -5,  -12, 	   7,  -25, 	  -5,  -17, 	   0,  -10
+.2byte   -6,   -8, 	   5,  -26, 	   6,  -15, 	   0,   -8
+.2byte   -2,   -6, 	  -2,  -24, 	   7,  -17, 	   1,   -7
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte    0,   -8, 	  -3,  -23, 	   6,  -20, 	   0,  -10
+.2byte   -2,   -8, 	  -7,  -20, 	   2,  -24, 	  -2,  -10
+.2byte   -1,   -6, 	  -8,   -1, 	   8,   -6, 	  -1,  -10
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+.2byte    0,   -8, 	 -10,  -19, 	   0,  -27, 	  -2,   -9
+.2byte    4,   -9, 	  -9,  -22, 	   4,  -24, 	   0,   -8
+.2byte    4,   -7, 	  11,   -2, 	   1,   -3, 	   1,   -8
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    5,   -8, 	  -6,  -26, 	  -7,  -15, 	  -1,   -8
+.2byte    8,  -10, 	   0,  -23, 	  -7,  -19, 	   0,   -9
+.2byte    9,  -10, 	  11,   -7, 	  13,  -10, 	   2,   -9
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    3,  -14, 	   3,  -17, 	  -7,  -25, 	  -1,  -10
+.2byte    2,  -12, 	  -2,  -19, 	  -7,  -21, 	  -2,  -10
+.2byte    5,  -11, 	  13,  -15, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	   5,  -17, 	  -9,  -21, 	  -1,  -10
+.2byte   -2,  -15, 	   8,  -17, 	 -10,  -22, 	  -1,  -11
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -5,  -12, 	   7,  -25, 	  -5,  -17, 	   0,  -10
+.2byte   -3,  -11, 	   5,  -21, 	   2,  -20, 	   0,   -9
+.2byte   -5,  -12, 	  -8,  -12, 	 -13,  -14, 	   0,  -11
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -6,   -8, 	   5,  -26, 	   6,  -15, 	   0,   -8
+.2byte   -9,  -10, 	  -1,  -23, 	   6,  -19, 	  -1,   -9
+.2byte  -10,  -10, 	 -12,   -7, 	 -14,  -10, 	  -3,   -9
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -2,   -6, 	  -2,  -24, 	   7,  -17, 	   1,   -7
+.2byte   -5,   -8, 	  -5,  -24, 	   7,  -21, 	   1,   -8
+.2byte   -5,   -7, 	 -12,   -2, 	  -2,   -3, 	  -2,   -8
+.2byte   -1,   -6, 	  -8,   -1, 	   8,   -6, 	  -1,  -10
+.2byte   -4,   -8, 	 -11,   -3, 	  -1,   -4, 	  -1,   -9
+.2byte   -8,   -9, 	 -10,   -6, 	 -12,   -9, 	  -1,   -8
+.2byte   -4,  -11, 	  -7,  -11, 	 -12,  -13, 	   1,  -10
+.2byte   -2,  -14, 	   8,  -16, 	 -10,  -21, 	  -1,  -10
+.2byte    4,  -10, 	  12,  -14, 	   2,  -16, 	  -2,  -10
+.2byte    7,   -9, 	   9,   -6, 	  11,   -9, 	   0,   -8
+.2byte    3,   -8, 	  10,   -3, 	   0,   -4, 	   0,   -9
+.2byte   -1,   -9, 	  -7,  -23, 	   4,  -23, 	  -1,  -12
+.2byte   -3,   -9, 	  -1,  -25, 	   8,  -20, 	   1,   -9
+.2byte   -8,  -11, 	   5,  -25, 	   7,  -18, 	   0,  -10
+.2byte   -5,  -13, 	   7,  -23, 	  -1,  -17, 	   0,  -11
+.2byte   -1,  -13, 	   6,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    3,  -12, 	   0,  -16, 	  -7,  -23, 	  -1,  -10
+.2byte    7,  -11, 	  -6,  -25, 	  -8,  -18, 	  -1,  -10
+.2byte    2,   -9, 	  -9,  -20, 	   0,  -25, 	   0,   -9
+sElectabuzzAnimTable1:
+.4byte sElectabuzzAnims_1_1
+.4byte sElectabuzzAnims_1_2
+.4byte sElectabuzzAnims_1_3
+.4byte sElectabuzzAnims_1_4
+.4byte sElectabuzzAnims_1_5
+.4byte sElectabuzzAnims_1_6
+.4byte sElectabuzzAnims_1_7
+.4byte sElectabuzzAnims_1_8
+sElectabuzzAnimTable2:
+.4byte sElectabuzzAnims_2_1
+.4byte sElectabuzzAnims_2_2
+.4byte sElectabuzzAnims_2_3
+.4byte sElectabuzzAnims_2_4
+.4byte sElectabuzzAnims_2_5
+.4byte sElectabuzzAnims_2_6
+.4byte sElectabuzzAnims_2_7
+.4byte sElectabuzzAnims_2_8
+sElectabuzzAnimTable3:
+.4byte sElectabuzzAnims_3_1
+.4byte sElectabuzzAnims_3_2
+.4byte sElectabuzzAnims_3_3
+.4byte sElectabuzzAnims_3_4
+.4byte sElectabuzzAnims_3_5
+.4byte sElectabuzzAnims_3_6
+.4byte sElectabuzzAnims_3_7
+.4byte sElectabuzzAnims_3_8
+sElectabuzzAnimTable4:
+.4byte sElectabuzzAnims_4_1
+.4byte sElectabuzzAnims_4_2
+.4byte sElectabuzzAnims_4_3
+.4byte sElectabuzzAnims_4_4
+.4byte sElectabuzzAnims_4_5
+.4byte sElectabuzzAnims_4_6
+.4byte sElectabuzzAnims_4_7
+.4byte sElectabuzzAnims_4_8
+sElectabuzzAnimTable5:
+.4byte sElectabuzzAnims_5_1
+.4byte sElectabuzzAnims_5_2
+.4byte sElectabuzzAnims_5_3
+.4byte sElectabuzzAnims_5_4
+.4byte sElectabuzzAnims_5_5
+.4byte sElectabuzzAnims_5_6
+.4byte sElectabuzzAnims_5_7
+.4byte sElectabuzzAnims_5_8
+sElectabuzzAnimTable6:
+.4byte sElectabuzzAnims_6_1
+.4byte sElectabuzzAnims_6_1
+.4byte sElectabuzzAnims_6_1
+.4byte sElectabuzzAnims_6_1
+.4byte sElectabuzzAnims_6_1
+.4byte sElectabuzzAnims_6_1
+.4byte sElectabuzzAnims_6_1
+.4byte sElectabuzzAnims_6_1
+sElectabuzzAnimTable7:
+.4byte sElectabuzzAnims_7_1
+.4byte sElectabuzzAnims_7_2
+.4byte sElectabuzzAnims_7_3
+.4byte sElectabuzzAnims_7_4
+.4byte sElectabuzzAnims_7_5
+.4byte sElectabuzzAnims_7_6
+.4byte sElectabuzzAnims_7_7
+.4byte sElectabuzzAnims_7_8
+sElectabuzzAnimTable8:
+.4byte sElectabuzzAnims_8_1
+.4byte sElectabuzzAnims_8_2
+.4byte sElectabuzzAnims_8_3
+.4byte sElectabuzzAnims_8_4
+.4byte sElectabuzzAnims_8_5
+.4byte sElectabuzzAnims_8_6
+.4byte sElectabuzzAnims_8_7
+.4byte sElectabuzzAnims_8_8
+sElectabuzzAnimTable9:
+.4byte sElectabuzzAnims_9_1
+.4byte sElectabuzzAnims_9_2
+.4byte sElectabuzzAnims_9_3
+.4byte sElectabuzzAnims_9_4
+.4byte sElectabuzzAnims_9_5
+.4byte sElectabuzzAnims_9_6
+.4byte sElectabuzzAnims_9_7
+.4byte sElectabuzzAnims_9_8
+sElectabuzzAnimTable10:
+.4byte sElectabuzzAnims_10_1
+.4byte sElectabuzzAnims_10_2
+.4byte sElectabuzzAnims_10_3
+.4byte sElectabuzzAnims_10_4
+.4byte sElectabuzzAnims_10_5
+.4byte sElectabuzzAnims_10_6
+.4byte sElectabuzzAnims_10_7
+.4byte sElectabuzzAnims_10_8
+sElectabuzzAnimTable11:
+.4byte sElectabuzzAnims_11_1
+.4byte sElectabuzzAnims_11_2
+.4byte sElectabuzzAnims_11_3
+.4byte sElectabuzzAnims_11_4
+.4byte sElectabuzzAnims_11_5
+.4byte sElectabuzzAnims_11_6
+.4byte sElectabuzzAnims_11_7
+.4byte sElectabuzzAnims_11_8
+sElectabuzzAnimTable12:
+.4byte sElectabuzzAnims_12_1
+.4byte sElectabuzzAnims_12_2
+.4byte sElectabuzzAnims_12_3
+.4byte sElectabuzzAnims_12_4
+.4byte sElectabuzzAnims_12_5
+.4byte sElectabuzzAnims_12_6
+.4byte sElectabuzzAnims_12_7
+.4byte sElectabuzzAnims_12_8
+sElectabuzzAnimTable13:
+.4byte sElectabuzzAnims_13_1
+.4byte sElectabuzzAnims_13_2
+.4byte sElectabuzzAnims_13_3
+.4byte sElectabuzzAnims_13_4
+.4byte sElectabuzzAnims_13_5
+.4byte sElectabuzzAnims_13_6
+.4byte sElectabuzzAnims_13_7
+.4byte sElectabuzzAnims_13_8
+sAxAnimationsElectabuzz:
+.4byte sElectabuzzAnimTable1
+.4byte sElectabuzzAnimTable2
+.4byte sElectabuzzAnimTable3
+.4byte sElectabuzzAnimTable4
+.4byte sElectabuzzAnimTable5
+.4byte sElectabuzzAnimTable6
+.4byte sElectabuzzAnimTable7
+.4byte sElectabuzzAnimTable8
+.4byte sElectabuzzAnimTable9
+.4byte sElectabuzzAnimTable10
+.4byte sElectabuzzAnimTable11
+.4byte sElectabuzzAnimTable12
+.4byte sElectabuzzAnimTable13
+sAxSpritesElectabuzz:
+.4byte sElectabuzzSprites1
+.4byte sElectabuzzSprites2
+.4byte sElectabuzzSprites3
+.4byte sElectabuzzSprites4
+.4byte sElectabuzzSprites5
+.4byte sElectabuzzSprites6
+.4byte sElectabuzzSprites7
+.4byte sElectabuzzSprites8
+.4byte sElectabuzzSprites9
+.4byte sElectabuzzSprites10
+.4byte sElectabuzzSprites11
+.4byte sElectabuzzSprites12
+.4byte sElectabuzzSprites13
+.4byte sElectabuzzSprites14
+.4byte sElectabuzzSprites15
+.4byte sElectabuzzSprites16
+.4byte sElectabuzzSprites17
+.4byte sElectabuzzSprites18
+.4byte sElectabuzzSprites19
+.4byte sElectabuzzSprites20
+.4byte sElectabuzzSprites21
+.4byte sElectabuzzSprites22
+.4byte sElectabuzzSprites23
+.4byte sElectabuzzSprites24
+.4byte sElectabuzzSprites25
+.4byte sElectabuzzSprites26
+.4byte sElectabuzzSprites27
+.4byte sElectabuzzSprites28
+.4byte sElectabuzzSprites29
+.4byte sElectabuzzSprites30
+.4byte sElectabuzzSprites31
+.4byte sElectabuzzSprites32
+.4byte sElectabuzzSprites33
+.4byte sElectabuzzSprites34
+.4byte sElectabuzzSprites35
+.4byte sElectabuzzSprites36
+.4byte sElectabuzzSprites37
+.4byte sElectabuzzSprites38
+.4byte sElectabuzzSprites39
+.4byte sElectabuzzSprites40
+.4byte sElectabuzzSprites41
+.4byte sElectabuzzSprites42
+.4byte sElectabuzzSprites43
+.4byte sElectabuzzSprites44
+.4byte sElectabuzzSprites45
+.4byte sElectabuzzSprites46
+.4byte sElectabuzzSprites47
+.4byte sElectabuzzSprites48
+.4byte sElectabuzzSprites49
+.4byte sElectabuzzSprites50
+.4byte sElectabuzzSprites51
+.4byte sElectabuzzSprites52
+.4byte sElectabuzzSprites53
+.4byte sElectabuzzSprites54
+.4byte sElectabuzzSprites55
+.4byte sElectabuzzSprites56
+.4byte sElectabuzzSprites57
+.4byte sElectabuzzSprites58
+.4byte sElectabuzzSprites59
+.4byte sElectabuzzSprites60
+.4byte sElectabuzzSprites61
+sAxMainElectabuzz:
+ax_main sAxPosesElectabuzz, sAxAnimationsElectabuzz, 13, sAxSpritesElectabuzz, sAxPositionsElectabuzz

--- a/data/ax/electrike.inc
+++ b/data/ax/electrike.inc
@@ -1,0 +1,3558 @@
+.global gAxElectrike
+gAxElectrike:
+ax_siro sAxMainElectrike
+sElectrikePose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose4:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose5:
+ax_pose 4, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose6:
+ax_pose 5, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose7:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose8:
+ax_pose 7, 0x01ec, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose9:
+ax_pose 8, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose10:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose11:
+ax_pose 10, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose12:
+ax_pose 11, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose14:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose15:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose16:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose17:
+ax_pose 10, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose18:
+ax_pose 11, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose23:
+ax_pose 4, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose28:
+ax_pose 15, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose29:
+ax_pose 16, 0x01e4, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose30:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose31:
+ax_pose 4, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose32:
+ax_pose 5, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose33:
+ax_pose 17, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose34:
+ax_pose 18, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose35:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose36:
+ax_pose 7, 0x01ec, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose37:
+ax_pose 8, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose38:
+ax_pose 19, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose39:
+ax_pose 20, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose40:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose41:
+ax_pose 10, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose42:
+ax_pose 11, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose43:
+ax_pose 21, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose44:
+ax_pose 22, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose45:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose46:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose47:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose48:
+ax_pose 23, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose49:
+ax_pose 24, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose50:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose51:
+ax_pose 10, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose52:
+ax_pose 11, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose53:
+ax_pose 21, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sElectrikePose54:
+ax_pose 22, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose55:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose56:
+ax_pose 7, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose57:
+ax_pose 8, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose58:
+ax_pose 19, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose59:
+ax_pose 20, 0x01e8, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose60:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose61:
+ax_pose 4, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose62:
+ax_pose 5, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose63:
+ax_pose 17, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose64:
+ax_pose 18, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose65:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose66:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose67:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose68:
+ax_pose 15, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose69:
+ax_pose 16, 0x01e4, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose70:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose71:
+ax_pose 4, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose72:
+ax_pose 5, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose73:
+ax_pose 17, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose74:
+ax_pose 18, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose75:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose76:
+ax_pose 7, 0x01ec, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose77:
+ax_pose 8, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose78:
+ax_pose 19, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose79:
+ax_pose 20, 0x01e8, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose80:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose81:
+ax_pose 10, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose82:
+ax_pose 11, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose83:
+ax_pose 21, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose84:
+ax_pose 22, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose85:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose86:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose87:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose88:
+ax_pose 23, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose89:
+ax_pose 24, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose90:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose91:
+ax_pose 10, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose92:
+ax_pose 11, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose93:
+ax_pose 21, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sElectrikePose94:
+ax_pose 22, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose95:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose96:
+ax_pose 7, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose97:
+ax_pose 8, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose98:
+ax_pose 19, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose99:
+ax_pose 20, 0x01e8, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose100:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose101:
+ax_pose 4, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose102:
+ax_pose 5, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose103:
+ax_pose 17, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose104:
+ax_pose 18, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose105:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose106:
+ax_pose 25, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose107:
+ax_pose 26, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose108:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose109:
+ax_pose 27, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose110:
+ax_pose 28, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose111:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose112:
+ax_pose 29, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose113:
+ax_pose 30, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose114:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose115:
+ax_pose 31, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose116:
+ax_pose 32, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose117:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose118:
+ax_pose 33, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose119:
+ax_pose 34, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose120:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose121:
+ax_pose 31, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose122:
+ax_pose 32, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose123:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose124:
+ax_pose 29, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose125:
+ax_pose 30, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose126:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose127:
+ax_pose 27, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose128:
+ax_pose 28, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose129:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose130:
+ax_pose 26, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose131:
+ax_pose 35, 0x81e4, 0x40ec, 0x3c00
+ax_pose 36, 0x41e4, 0x40f4, 0x3c04
+ax_pose 37, 0x01ec, 0x4104, 0x3c08
+ax_pose 38, 0x01ec, 0x00f4, 0x3c0c
+ax_pose 39, 0x41fc, 0x0104, 0x3c0d
+ax_pose 40, 0x01e7, 0x80f1, 0x3c0f
+ax_pose_terminator
+sElectrikePose132:
+ax_pose 41, 0x81dc, 0x80e9, 0x3c00
+ax_pose 42, 0x41fc, 0x00e9, 0x3c08
+ax_pose 43, 0x41dc, 0x80f9, 0x3c0a
+ax_pose 44, 0x41ec, 0x0101, 0x3c12
+ax_pose 45, 0x01f4, 0x4109, 0x3c14
+ax_pose 46, 0x01ec, 0x0111, 0x3c18
+ax_pose 47, 0x01e7, 0x80f1, 0x3c19
+ax_pose_terminator
+sElectrikePose133:
+ax_pose 40, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose134:
+ax_pose 47, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose135:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose136:
+ax_pose 28, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose137:
+ax_pose 48, 0x81e4, 0x510b, 0x3c00
+ax_pose 49, 0x41e4, 0x90eb, 0x3c04
+ax_pose 50, 0x01f4, 0x50eb, 0x3c0c
+ax_pose 51, 0x0204, 0x10f3, 0x3c10
+ax_pose 52, 0x01e9, 0x90ef, 0x3c11
+ax_pose_terminator
+sElectrikePose138:
+ax_pose 53, 0x41dc, 0x90f3, 0x3c00
+ax_pose 54, 0x81e4, 0x1113, 0x3c08
+ax_pose 55, 0x01f4, 0x1113, 0x3c0a
+ax_pose 56, 0x41ec, 0x50f3, 0x3c0b
+ax_pose 57, 0x81f4, 0x110b, 0x3c0f
+ax_pose 58, 0x81ec, 0x50eb, 0x3c11
+ax_pose 59, 0x81f4, 0x10f3, 0x3c15
+ax_pose 60, 0x0204, 0x10f3, 0x3c17
+ax_pose 61, 0x01e9, 0x90ef, 0x3c18
+ax_pose_terminator
+sElectrikePose139:
+ax_pose 52, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose140:
+ax_pose 61, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose141:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose142:
+ax_pose 30, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose143:
+ax_pose 35, 0x81e4, 0x40ed, 0x3c00
+ax_pose 36, 0x41e4, 0x40f5, 0x3c04
+ax_pose 37, 0x01ec, 0x4105, 0x3c08
+ax_pose 38, 0x01ec, 0x00f5, 0x3c0c
+ax_pose 39, 0x41fc, 0x0105, 0x3c0d
+ax_pose 62, 0x01e7, 0x90f2, 0x3c0f
+ax_pose_terminator
+sElectrikePose144:
+ax_pose 41, 0x81dc, 0x80ea, 0x3c00
+ax_pose 42, 0x41fc, 0x00ea, 0x3c08
+ax_pose 43, 0x41dc, 0x80fa, 0x3c0a
+ax_pose 44, 0x41ec, 0x0102, 0x3c12
+ax_pose 45, 0x01f4, 0x410a, 0x3c14
+ax_pose 46, 0x01ec, 0x0112, 0x3c18
+ax_pose 63, 0x01e7, 0x90f2, 0x3c19
+ax_pose_terminator
+sElectrikePose145:
+ax_pose 62, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose146:
+ax_pose 63, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose147:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose148:
+ax_pose 32, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose149:
+ax_pose 48, 0x81e2, 0x40ee, 0x3c00
+ax_pose 49, 0x41e2, 0x80f6, 0x3c04
+ax_pose 50, 0x01f2, 0x4106, 0x3c0c
+ax_pose 51, 0x0202, 0x0106, 0x3c10
+ax_pose 64, 0x01ea, 0x90ee, 0x3c11
+ax_pose_terminator
+sElectrikePose150:
+ax_pose 53, 0x41da, 0x80ee, 0x3c00
+ax_pose 54, 0x81e2, 0x00e6, 0x3c08
+ax_pose 55, 0x01f2, 0x00e6, 0x3c0a
+ax_pose 56, 0x41ea, 0x40ee, 0x3c0b
+ax_pose 57, 0x81f2, 0x00ee, 0x3c0f
+ax_pose 58, 0x81ea, 0x410e, 0x3c11
+ax_pose 59, 0x81f2, 0x0106, 0x3c15
+ax_pose 60, 0x0202, 0x0106, 0x3c17
+ax_pose 65, 0x01ea, 0x90ee, 0x3c18
+ax_pose_terminator
+sElectrikePose151:
+ax_pose 64, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose152:
+ax_pose 65, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose153:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose154:
+ax_pose 34, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose155:
+ax_pose 35, 0x81e3, 0x40ec, 0x3c00
+ax_pose 36, 0x41e3, 0x40f4, 0x3c04
+ax_pose 37, 0x01eb, 0x4104, 0x3c08
+ax_pose 38, 0x01eb, 0x00f4, 0x3c0c
+ax_pose 39, 0x41fb, 0x0104, 0x3c0d
+ax_pose 66, 0x01e7, 0x80f1, 0x3c0f
+ax_pose_terminator
+sElectrikePose156:
+ax_pose 41, 0x81db, 0x80e9, 0x3c00
+ax_pose 42, 0x41fb, 0x00e9, 0x3c08
+ax_pose 43, 0x41db, 0x80f9, 0x3c0a
+ax_pose 44, 0x41eb, 0x0101, 0x3c12
+ax_pose 45, 0x01f3, 0x4109, 0x3c14
+ax_pose 46, 0x01eb, 0x0111, 0x3c18
+ax_pose 67, 0x01e7, 0x80f1, 0x3c19
+ax_pose_terminator
+sElectrikePose157:
+ax_pose 66, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose158:
+ax_pose 67, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose159:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose160:
+ax_pose 32, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose161:
+ax_pose 48, 0x81e2, 0x5109, 0x3c00
+ax_pose 49, 0x41e2, 0x90e9, 0x3c04
+ax_pose 50, 0x01f2, 0x50e9, 0x3c0c
+ax_pose 51, 0x0202, 0x10f1, 0x3c10
+ax_pose 64, 0x01ea, 0x80f1, 0x3c11
+ax_pose_terminator
+sElectrikePose162:
+ax_pose 53, 0x41da, 0x90f1, 0x3c00
+ax_pose 54, 0x81e2, 0x1111, 0x3c08
+ax_pose 55, 0x01f2, 0x1111, 0x3c0a
+ax_pose 56, 0x41ea, 0x50f1, 0x3c0b
+ax_pose 57, 0x81f2, 0x1109, 0x3c0f
+ax_pose 58, 0x81ea, 0x50e9, 0x3c11
+ax_pose 59, 0x81f2, 0x10f1, 0x3c15
+ax_pose 60, 0x0202, 0x10f1, 0x3c17
+ax_pose 65, 0x01ea, 0x80f1, 0x3c18
+ax_pose_terminator
+sElectrikePose163:
+ax_pose 64, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose164:
+ax_pose 65, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose165:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose166:
+ax_pose 30, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose167:
+ax_pose 35, 0x81e4, 0x40ec, 0x3c00
+ax_pose 36, 0x41e4, 0x40f4, 0x3c04
+ax_pose 37, 0x01ec, 0x4104, 0x3c08
+ax_pose 38, 0x01ec, 0x00f4, 0x3c0c
+ax_pose 39, 0x41fc, 0x0104, 0x3c0d
+ax_pose 62, 0x01e7, 0x80ee, 0x3c0f
+ax_pose_terminator
+sElectrikePose168:
+ax_pose 41, 0x81dc, 0x80e9, 0x3c00
+ax_pose 42, 0x41fc, 0x00e9, 0x3c08
+ax_pose 43, 0x41dc, 0x80f9, 0x3c0a
+ax_pose 44, 0x41ec, 0x0101, 0x3c12
+ax_pose 45, 0x01f4, 0x4109, 0x3c14
+ax_pose 46, 0x01ec, 0x0111, 0x3c18
+ax_pose 63, 0x01e7, 0x80ee, 0x3c19
+ax_pose_terminator
+sElectrikePose169:
+ax_pose 62, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose170:
+ax_pose 63, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose171:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose172:
+ax_pose 28, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose173:
+ax_pose 48, 0x81e4, 0x40ed, 0x3c00
+ax_pose 49, 0x41e4, 0x80f5, 0x3c04
+ax_pose 50, 0x01f4, 0x4105, 0x3c0c
+ax_pose 51, 0x0204, 0x0105, 0x3c10
+ax_pose 52, 0x01e9, 0x80f1, 0x3c11
+ax_pose_terminator
+sElectrikePose174:
+ax_pose 53, 0x41dc, 0x80ed, 0x3c00
+ax_pose 54, 0x81e4, 0x00e5, 0x3c08
+ax_pose 55, 0x01f4, 0x00e5, 0x3c0a
+ax_pose 56, 0x41ec, 0x40ed, 0x3c0b
+ax_pose 57, 0x81f4, 0x00ed, 0x3c0f
+ax_pose 58, 0x81ec, 0x410d, 0x3c11
+ax_pose 59, 0x81f4, 0x0105, 0x3c15
+ax_pose 60, 0x0204, 0x0105, 0x3c17
+ax_pose 61, 0x01e9, 0x80f1, 0x3c18
+ax_pose_terminator
+sElectrikePose175:
+ax_pose 52, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose176:
+ax_pose 61, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose177:
+ax_pose 68, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose178:
+ax_pose 69, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose179:
+ax_pose 70, 0x01e4, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose180:
+ax_pose 71, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose181:
+ax_pose 72, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose182:
+ax_pose 73, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose183:
+ax_pose 74, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose184:
+ax_pose 73, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose185:
+ax_pose 72, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose186:
+ax_pose 71, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose187:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose188:
+ax_pose 25, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose189:
+ax_pose 40, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose190:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose191:
+ax_pose 27, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose192:
+ax_pose 52, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose193:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose194:
+ax_pose 29, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose195:
+ax_pose 62, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose196:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose197:
+ax_pose 31, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose198:
+ax_pose 64, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose199:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose200:
+ax_pose 33, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose201:
+ax_pose 66, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose202:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose203:
+ax_pose 31, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose204:
+ax_pose 64, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose205:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose206:
+ax_pose 29, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose207:
+ax_pose 62, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose208:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose209:
+ax_pose 27, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose210:
+ax_pose 52, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose211:
+ax_pose 15, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose212:
+ax_pose 17, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sElectrikePose213:
+ax_pose 19, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sElectrikePose214:
+ax_pose 21, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose215:
+ax_pose 23, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose216:
+ax_pose 21, 0x01ea, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose217:
+ax_pose 19, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose218:
+ax_pose 17, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sElectrikePose219:
+ax_pose 25, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose220:
+ax_pose 27, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose221:
+ax_pose 29, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose222:
+ax_pose 31, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose223:
+ax_pose 33, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose224:
+ax_pose 31, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose225:
+ax_pose 29, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose226:
+ax_pose 27, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose227:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose228:
+ax_pose 25, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose229:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose230:
+ax_pose 27, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sElectrikePose231:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose232:
+ax_pose 29, 0x01e7, 0x90f2, 0x3c00
+ax_pose_terminator
+sElectrikePose233:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose234:
+ax_pose 31, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sElectrikePose235:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose236:
+ax_pose 33, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose237:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose238:
+ax_pose 31, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose239:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose240:
+ax_pose 29, 0x01e7, 0x80ee, 0x3c00
+ax_pose_terminator
+sElectrikePose241:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose242:
+ax_pose 27, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sElectrikePose243:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose244:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose245:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose246:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose247:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose248:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose249:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose250:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sElectrikePose251:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose252:
+ax_pose 3, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose253:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sElectrikePose254:
+ax_pose 9, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose255:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sElectrikePose256:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sElectrikePose257:
+ax_pose 6, 0x01eb, 0x90f0, 0x3c00
+ax_pose_terminator
+sElectrikePose258:
+ax_pose 3, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+.align 2
+sElectrikeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_2_1:
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, -6, 0, -6,
+ax_anim 6, 0, 24, 0, -8, 0, -8,
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 2, 0, 28, 0, 7, 0, 7,
+ax_anim 2, 2, 27, 0, 9, 0, 9,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, -1, 20, -1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, -1, 20, -1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 0, 11, 0, 11,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sElectrikeAnims_2_2:
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim 6, 0, 29, -8, -8, -8, -8,
+ax_anim 2, 0, 32, -2, -2, -2, -2,
+ax_anim 2, 0, 33, 5, 5, 5, 5,
+ax_anim 2, 2, 32, 11, 12, 11, 12,
+ax_anim 2, 0, 33, 18, 21, 18, 21,
+ax_anim 2, 1, 33, 17, 22, 17, 22,
+ax_anim 2, 0, 33, 18, 21, 18, 21,
+ax_anim 2, 0, 33, 17, 22, 17, 22,
+ax_anim 2, 0, 33, 18, 21, 18, 21,
+ax_anim 2, 0, 30, 11, 12, 11, 12,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sElectrikeAnims_2_3:
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 2, 0, 36, -6, 0, -6, 0,
+ax_anim 6, 0, 34, -8, 0, -8, 0,
+ax_anim 2, 0, 37, -2, 0, -2, 0,
+ax_anim 2, 0, 38, 5, 0, 5, 0,
+ax_anim 2, 2, 37, 11, 0, 11, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sElectrikeAnims_2_4:
+ax_anim 2, 0, 40, -3, 3, -3, 3,
+ax_anim 2, 0, 41, -6, 6, -6, 6,
+ax_anim 6, 0, 39, -8, 8, -8, 8,
+ax_anim 2, 0, 42, -2, 2, -2, 2,
+ax_anim 2, 0, 43, 6, -7, 6, -7,
+ax_anim 2, 2, 42, 13, -14, 13, -14,
+ax_anim 2, 0, 43, 20, -21, 20, -21,
+ax_anim 2, 1, 43, 19, -22, 19, -22,
+ax_anim 2, 0, 43, 20, -21, 20, -21,
+ax_anim 2, 0, 43, 19, -22, 19, -22,
+ax_anim 2, 0, 43, 20, -21, 20, -21,
+ax_anim 2, 0, 40, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 4, -5, 4, -5,
+ax_anim_terminator
+sElectrikeAnims_2_5:
+ax_anim 2, 0, 45, 0, 3, 0, 3,
+ax_anim 2, 0, 46, 0, 6, 0, 6,
+ax_anim 6, 0, 44, 0, 8, 0, 8,
+ax_anim 2, 0, 47, 0, 2, 0, 2,
+ax_anim 2, 0, 48, 0, -7, 0, -7,
+ax_anim 2, 2, 47, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -22, 0, -22,
+ax_anim 2, 1, 48, -1, -22, -1, -22,
+ax_anim 2, 0, 48, 0, -22, 0, -22,
+ax_anim 2, 0, 48, -1, -22, -1, -22,
+ax_anim 2, 0, 48, 0, -22, 0, -22,
+ax_anim 2, 0, 45, 0, -11, 0, -11,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sElectrikeAnims_2_6:
+ax_anim 2, 0, 50, 3, 3, 3, 3,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim 6, 0, 49, 8, 8, 8, 8,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim 2, 0, 53, -6, -7, -6, -7,
+ax_anim 2, 2, 52, -13, -14, -13, -14,
+ax_anim 2, 0, 53, -20, -21, -20, -21,
+ax_anim 2, 1, 53, -19, -22, -19, -22,
+ax_anim 2, 0, 53, -20, -21, -20, -21,
+ax_anim 2, 0, 53, -19, -22, -19, -22,
+ax_anim 2, 0, 53, -20, -21, -20, -21,
+ax_anim 2, 0, 50, -11, -13, -11, -13,
+ax_anim 2, 0, 49, -4, -5, -4, -5,
+ax_anim_terminator
+sElectrikeAnims_2_7:
+ax_anim 2, 0, 55, 3, 0, 3, 0,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim 6, 0, 54, 8, 0, 8, 0,
+ax_anim 2, 0, 57, 2, 0, 2, 0,
+ax_anim 2, 0, 58, -5, 0, -5, 0,
+ax_anim 2, 2, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 55, -11, 0, -11, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sElectrikeAnims_2_8:
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim 2, 0, 61, 6, -6, 6, -6,
+ax_anim 6, 0, 59, 8, -8, 8, -8,
+ax_anim 2, 0, 62, 2, -2, 2, -2,
+ax_anim 2, 0, 63, -5, 5, -5, 5,
+ax_anim 2, 2, 62, -11, 12, -11, 12,
+ax_anim 2, 0, 63, -18, 21, -18, 21,
+ax_anim 2, 1, 63, -17, 22, -17, 22,
+ax_anim 2, 0, 63, -18, 21, -18, 21,
+ax_anim 2, 0, 63, -17, 22, -17, 22,
+ax_anim 2, 0, 63, -18, 21, -18, 21,
+ax_anim 2, 0, 60, -11, 12, -11, 12,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_3_1:
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 66, 0, -6, 0, -6,
+ax_anim 6, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 67, 0, -2, 0, -2,
+ax_anim 2, 0, 68, 0, 15, 0, 15,
+ax_anim 2, 2, 67, 0, 25, 0, 25,
+ax_anim 2, 0, 68, 0, 44, 0, 44,
+ax_anim 2, 1, 68, -1, 44, -1, 44,
+ax_anim 2, 0, 68, 0, 44, 0, 44,
+ax_anim 2, 0, 68, -1, 44, -1, 44,
+ax_anim 2, 0, 68, 0, 44, 0, 44,
+ax_anim 2, 0, 65, 0, 11, 0, 11,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sElectrikeAnims_3_2:
+ax_anim 2, 0, 70, -3, -3, -3, -3,
+ax_anim 2, 0, 71, -6, -6, -6, -6,
+ax_anim 6, 0, 69, -8, -8, -8, -8,
+ax_anim 2, 0, 72, -2, -2, -2, -2,
+ax_anim 2, 0, 73, 13, 13, 13, 13,
+ax_anim 2, 2, 72, 27, 28, 27, 28,
+ax_anim 2, 0, 73, 42, 45, 42, 45,
+ax_anim 2, 1, 73, 41, 46, 41, 46,
+ax_anim 2, 0, 73, 42, 45, 42, 45,
+ax_anim 2, 0, 73, 41, 46, 41, 46,
+ax_anim 2, 0, 73, 42, 45, 42, 45,
+ax_anim 2, 0, 70, 11, 12, 11, 12,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sElectrikeAnims_3_3:
+ax_anim 2, 0, 75, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -6, 0, -6, 0,
+ax_anim 6, 0, 74, -8, 0, -8, 0,
+ax_anim 2, 0, 77, -2, 0, -2, 0,
+ax_anim 2, 0, 78, 13, 0, 13, 0,
+ax_anim 2, 2, 77, 27, 0, 27, 0,
+ax_anim 2, 0, 78, 42, 0, 42, 0,
+ax_anim 2, 1, 78, 42, 1, 42, 1,
+ax_anim 2, 0, 78, 42, 0, 42, 0,
+ax_anim 2, 0, 78, 42, 1, 42, 1,
+ax_anim 2, 0, 78, 42, 0, 42, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sElectrikeAnims_3_4:
+ax_anim 2, 0, 80, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -6, 6, -6, 6,
+ax_anim 6, 0, 79, -8, 8, -8, 8,
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 2, 0, 83, 14, -15, 14, -15,
+ax_anim 2, 2, 82, 29, -30, 29, -30,
+ax_anim 2, 0, 83, 44, -45, 44, -45,
+ax_anim 2, 1, 83, 43, -46, 43, -46,
+ax_anim 2, 0, 83, 44, -45, 44, -45,
+ax_anim 2, 0, 83, 43, -46, 43, -46,
+ax_anim 2, 0, 83, 44, -45, 44, -45,
+ax_anim 2, 0, 80, 11, -13, 11, -13,
+ax_anim 2, 0, 79, 4, -5, 4, -5,
+ax_anim_terminator
+sElectrikeAnims_3_5:
+ax_anim 2, 0, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 86, 0, 6, 0, 6,
+ax_anim 6, 0, 84, 0, 8, 0, 8,
+ax_anim 2, 0, 87, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, -15, 0, -15,
+ax_anim 2, 2, 87, 0, -27, 0, -27,
+ax_anim 2, 0, 88, 0, -46, 0, -46,
+ax_anim 2, 1, 88, -1, -46, -1, -46,
+ax_anim 2, 0, 88, 0, -46, 0, -46,
+ax_anim 2, 0, 88, -1, -46, -1, -46,
+ax_anim 2, 0, 88, 0, -46, 0, -46,
+ax_anim 2, 0, 85, 0, -11, 0, -11,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sElectrikeAnims_3_6:
+ax_anim 2, 0, 90, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 6, 6, 6, 6,
+ax_anim 6, 0, 89, 8, 8, 8, 8,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 0, 93, -14, -15, -14, -15,
+ax_anim 2, 2, 92, -29, -30, -29, -30,
+ax_anim 2, 0, 93, -44, -45, -44, -45,
+ax_anim 2, 1, 93, -43, -46, -43, -46,
+ax_anim 2, 0, 93, -44, -45, -44, -45,
+ax_anim 2, 0, 93, -43, -46, -43, -46,
+ax_anim 2, 0, 93, -44, -45, -44, -45,
+ax_anim 2, 0, 90, -11, -13, -11, -13,
+ax_anim 2, 0, 89, -4, -5, -4, -5,
+ax_anim_terminator
+sElectrikeAnims_3_7:
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 6, 0, 94, 8, 0, 8, 0,
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 98, -13, 0, -13, 0,
+ax_anim 2, 2, 97, -27, 0, -27, 0,
+ax_anim 2, 0, 98, -42, 0, -42, 0,
+ax_anim 2, 1, 98, -42, 1, -42, 1,
+ax_anim 2, 0, 98, -42, 0, -42, 0,
+ax_anim 2, 0, 98, -42, 1, -42, 1,
+ax_anim 2, 0, 98, -42, 0, -42, 0,
+ax_anim 2, 0, 95, -11, 0, -11, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sElectrikeAnims_3_8:
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 6, -6, 6, -6,
+ax_anim 6, 0, 99, 8, -8, 8, -8,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 103, -13, 13, -13, 13,
+ax_anim 2, 2, 102, -27, 28, -27, 28,
+ax_anim 2, 0, 103, -42, 45, -42, 45,
+ax_anim 2, 1, 103, -41, 46, -41, 46,
+ax_anim 2, 0, 103, -42, 45, -42, 45,
+ax_anim 2, 0, 103, -41, 46, -41, 46,
+ax_anim 2, 0, 103, -42, 45, -42, 45,
+ax_anim 2, 0, 100, -11, 12, -11, 12,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sElectrikeAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sElectrikeAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sElectrikeAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sElectrikeAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sElectrikeAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sElectrikeAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sElectrikeAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_5_1:
+ax_anim 5, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -5, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -1, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 1, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_5_2:
+ax_anim 5, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 1, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 138, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 1, 0, 138, 0, -1, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 2, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 1, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_5_3:
+ax_anim 5, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -2, 0, 0,
+ax_anim 1, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 144, 0, -5, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 1, 0, 144, 0, -1, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 2, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 1, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_5_4:
+ax_anim 5, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -2, 0, 0,
+ax_anim 1, 0, 150, 0, -4, 0, 0,
+ax_anim 4, 0, 150, 0, -5, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 0,
+ax_anim 1, 0, 150, 0, -1, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 2, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 1, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_5_5:
+ax_anim 5, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -2, 0, 0,
+ax_anim 1, 0, 156, 0, -4, 0, 0,
+ax_anim 4, 0, 156, 0, -5, 0, 0,
+ax_anim 2, 0, 156, 0, -4, 0, 0,
+ax_anim 1, 0, 156, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 1, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_5_6:
+ax_anim 5, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -2, 0, 0,
+ax_anim 1, 0, 162, 0, -4, 0, 0,
+ax_anim 4, 0, 162, 0, -5, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 1, 0, 162, 0, -1, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 2, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 1, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_5_7:
+ax_anim 5, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -2, 0, 0,
+ax_anim 1, 0, 168, 0, -4, 0, 0,
+ax_anim 4, 0, 168, 0, -5, 0, 0,
+ax_anim 2, 0, 168, 0, -4, 0, 0,
+ax_anim 1, 0, 168, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 2, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 1, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_5_8:
+ax_anim 5, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -2, 0, 0,
+ax_anim 1, 0, 174, 0, -4, 0, 0,
+ax_anim 4, 0, 174, 0, -5, 0, 0,
+ax_anim 2, 0, 174, 0, -4, 0, 0,
+ax_anim 1, 0, 174, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 2, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 1, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sElectrikeAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sElectrikeAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sElectrikeAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sElectrikeAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sElectrikeAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sElectrikeAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sElectrikeAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_8_1:
+ax_anim 60, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_8_2:
+ax_anim 60, 0, 189, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_8_3:
+ax_anim 60, 0, 192, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_8_4:
+ax_anim 60, 0, 195, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_8_5:
+ax_anim 60, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_8_6:
+ax_anim 60, 0, 201, 0, 0, 0, 0,
+ax_anim 10, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 10, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_8_7:
+ax_anim 60, 0, 204, 0, 0, 0, 0,
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_8_8:
+ax_anim 60, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 7, 3, 7, 3,
+ax_anim 2, 0, 212, 12, 9, 12, 9,
+ax_anim 2, 0, 213, 9, 17, 9, 17,
+ax_anim 3, 0, 214, 0, 20, 0, 20,
+ax_anim 2, 3, 215, -9, 17, -9, 17,
+ax_anim 2, 0, 216, -12, 9, -12, 9,
+ax_anim 1, 0, 217, -7, 3, -7, 3,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 10, 1, 10, 1,
+ax_anim 2, 0, 211, 20, 5, 20, 5,
+ax_anim 2, 0, 212, 23, 10, 23, 10,
+ax_anim 3, 0, 213, 19, 19, 19, 19,
+ax_anim 2, 3, 214, 11, 19, 11, 19,
+ax_anim 2, 0, 215, 4, 14, 4, 14,
+ax_anim 1, 0, 216, 0, 5, 0, 5,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 4, -4, 4, -4,
+ax_anim 2, 0, 210, 11, -5, 11, -5,
+ax_anim 2, 0, 211, 17, -4, 17, -4,
+ax_anim 3, 0, 212, 18, 0, 18, 0,
+ax_anim 2, 3, 213, 15, 6, 15, 6,
+ax_anim 2, 0, 214, 10, 8, 10, 8,
+ax_anim 1, 0, 215, 3, 5, 3, 5,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, -2, -8, -2, -8,
+ax_anim 2, 0, 217, 3, -17, 3, -17,
+ax_anim 2, 0, 210, 12, -20, 12, -20,
+ax_anim 3, 0, 211, 21, -18, 21, -18,
+ax_anim 2, 3, 212, 24, -12, 24, -12,
+ax_anim 2, 0, 213, 21, -3, 21, -3,
+ax_anim 1, 0, 214, 10, 1, 10, 1,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -10, -4, -10, -4,
+ax_anim 2, 0, 216, -13, -12, -13, -12,
+ax_anim 2, 0, 217, -9, -18, -9, -18,
+ax_anim 3, 0, 210, 0, -20, 0, -20,
+ax_anim 2, 3, 211, 9, -18, 9, -18,
+ax_anim 2, 0, 212, 13, -12, 13, -12,
+ax_anim 1, 0, 213, 10, -4, 10, -4,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 2, -8, 2, -8,
+ax_anim 2, 0, 211, -3, -17, -3, -17,
+ax_anim 2, 0, 210, -12, -20, -12, -20,
+ax_anim 3, 0, 217, -21, -18, -21, -18,
+ax_anim 2, 3, 216, -24, -12, -24, -12,
+ax_anim 2, 0, 215, -21, -3, -21, -3,
+ax_anim 1, 0, 214, -10, 1, -10, 1,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, -4, -4, -4, -4,
+ax_anim 2, 0, 210, -11, -5, -11, -5,
+ax_anim 2, 0, 217, -17, -4, -17, -4,
+ax_anim 3, 0, 216, -18, 0, -18, 0,
+ax_anim 2, 3, 215, -15, 6, -15, 6,
+ax_anim 2, 0, 214, -10, 8, -10, 8,
+ax_anim 1, 0, 213, -3, 5, -3, 5,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -10, 1, -10, 1,
+ax_anim 2, 0, 217, -20, 5, -20, 5,
+ax_anim 2, 0, 216, -23, 10, -23, 10,
+ax_anim 3, 0, 215, -19, 19, -19, 19,
+ax_anim 2, 3, 214, -11, 19, -11, 19,
+ax_anim 2, 0, 213, -4, 14, -4, 14,
+ax_anim 1, 0, 212, 0, 5, 0, 5,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_11_2:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 228, 0, -22, 0, 0,
+ax_anim 2, 0, 228, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_11_3:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_11_4:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -22, 0, 0,
+ax_anim 3, 0, 232, 0, -21, 0, 0,
+ax_anim 2, 0, 232, 0, -17, 0, 0,
+ax_anim 1, 0, 232, 0, -11, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_11_5:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -23, 0, 0,
+ax_anim 3, 0, 234, 0, -22, 0, 0,
+ax_anim 2, 0, 234, 0, -18, 0, 0,
+ax_anim 1, 0, 234, 0, -12, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_11_6:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -22, 0, 0,
+ax_anim 3, 0, 236, 0, -21, 0, 0,
+ax_anim 2, 0, 236, 0, -17, 0, 0,
+ax_anim 1, 0, 236, 0, -11, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_11_7:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 239, 0, -16, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_11_8:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -23, 0, 0,
+ax_anim 3, 0, 240, 0, -22, 0, 0,
+ax_anim 2, 0, 240, 0, -18, 0, 0,
+ax_anim 1, 0, 240, 0, -12, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrikeAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrikeGfx1:
+.incbin "baserom.gba", 0x1291E08, 0x200
+sElectrikeSprites1:
+ax_sprite sElectrikeGfx1, 0x200
+ax_sprite_terminator
+sElectrikeGfx2:
+.incbin "baserom.gba", 0x1292018, 0x200
+sElectrikeSprites2:
+ax_sprite sElectrikeGfx2, 0x200
+ax_sprite_terminator
+sElectrikeGfx3:
+.incbin "baserom.gba", 0x1292228, 0x200
+sElectrikeSprites3:
+ax_sprite sElectrikeGfx3, 0x200
+ax_sprite_terminator
+sElectrikeGfx4:
+.incbin "baserom.gba", 0x1292438, 0x200
+sElectrikeSprites4:
+ax_sprite sElectrikeGfx4, 0x200
+ax_sprite_terminator
+sElectrikeGfx5:
+.incbin "baserom.gba", 0x1292648, 0x200
+sElectrikeSprites5:
+ax_sprite sElectrikeGfx5, 0x200
+ax_sprite_terminator
+sElectrikeGfx6:
+.incbin "baserom.gba", 0x1292858, 0x200
+sElectrikeSprites6:
+ax_sprite sElectrikeGfx6, 0x200
+ax_sprite_terminator
+sElectrikeGfx7:
+.incbin "baserom.gba", 0x1292A68, 0x200
+sElectrikeSprites7:
+ax_sprite sElectrikeGfx7, 0x200
+ax_sprite_terminator
+sElectrikeGfx8:
+.incbin "baserom.gba", 0x1292C78, 0x200
+sElectrikeSprites8:
+ax_sprite sElectrikeGfx8, 0x200
+ax_sprite_terminator
+sElectrikeGfx9:
+.incbin "baserom.gba", 0x1292E88, 0x200
+sElectrikeSprites9:
+ax_sprite sElectrikeGfx9, 0x200
+ax_sprite_terminator
+sElectrikeGfx10:
+.incbin "baserom.gba", 0x1293098, 0x200
+sElectrikeSprites10:
+ax_sprite sElectrikeGfx10, 0x200
+ax_sprite_terminator
+sElectrikeGfx11:
+.incbin "baserom.gba", 0x12932A8, 0x200
+sElectrikeSprites11:
+ax_sprite sElectrikeGfx11, 0x200
+ax_sprite_terminator
+sElectrikeGfx12:
+.incbin "baserom.gba", 0x12934B8, 0x200
+sElectrikeSprites12:
+ax_sprite sElectrikeGfx12, 0x200
+ax_sprite_terminator
+sElectrikeGfx13:
+.incbin "baserom.gba", 0x12936C8, 0x200
+sElectrikeSprites13:
+ax_sprite sElectrikeGfx13, 0x200
+ax_sprite_terminator
+sElectrikeGfx14:
+.incbin "baserom.gba", 0x12938D8, 0x200
+sElectrikeSprites14:
+ax_sprite sElectrikeGfx14, 0x200
+ax_sprite_terminator
+sElectrikeGfx15:
+.incbin "baserom.gba", 0x1293AE8, 0x200
+sElectrikeSprites15:
+ax_sprite sElectrikeGfx15, 0x200
+ax_sprite_terminator
+sElectrikeGfx16:
+.incbin "baserom.gba", 0x1293CF8, 0x60
+sElectrikeGfx16_1:
+.incbin "baserom.gba", 0x1293D58, 0x60
+sElectrikeGfx16_2:
+.incbin "baserom.gba", 0x1293DB8, 0x40
+sElectrikeSprites16:
+ax_sprite 0, 0x80
+ax_sprite sElectrikeGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx17:
+.incbin "baserom.gba", 0x1293E38, 0x40
+sElectrikeGfx17_1:
+.incbin "baserom.gba", 0x1293E78, 0x40
+sElectrikeGfx17_2:
+.incbin "baserom.gba", 0x1293EB8, 0x60
+sElectrikeGfx17_3:
+.incbin "baserom.gba", 0x1293F18, 0x60
+sElectrikeSprites17:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx18:
+.incbin "baserom.gba", 0x1293FC8, 0x60
+sElectrikeGfx18_1:
+.incbin "baserom.gba", 0x1294028, 0x60
+sElectrikeGfx18_2:
+.incbin "baserom.gba", 0x1294088, 0x40
+sElectrikeSprites18:
+ax_sprite 0, 0x80
+ax_sprite sElectrikeGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx18_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sElectrikeGfx19:
+.incbin "baserom.gba", 0x1294108, 0x20
+sElectrikeGfx19_1:
+.incbin "baserom.gba", 0x1294128, 0x60
+sElectrikeGfx19_2:
+.incbin "baserom.gba", 0x1294188, 0x60
+sElectrikeGfx19_3:
+.incbin "baserom.gba", 0x12941E8, 0x60
+sElectrikeSprites19:
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx20:
+.incbin "baserom.gba", 0x1294298, 0x180
+sElectrikeSprites20:
+ax_sprite 0, 0x80
+ax_sprite sElectrikeGfx20, 0x180
+ax_sprite_terminator
+sElectrikeGfx21:
+.incbin "baserom.gba", 0x1294430, 0x100
+sElectrikeGfx21_1:
+.incbin "baserom.gba", 0x1294530, 0x40
+sElectrikeSprites21:
+ax_sprite 0, 0x80
+ax_sprite sElectrikeGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx21_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx22:
+.incbin "baserom.gba", 0x12945A0, 0x60
+sElectrikeGfx22_1:
+.incbin "baserom.gba", 0x1294600, 0x60
+sElectrikeGfx22_2:
+.incbin "baserom.gba", 0x1294660, 0x60
+sElectrikeGfx22_3:
+.incbin "baserom.gba", 0x12946C0, 0x20
+sElectrikeSprites22:
+ax_sprite sElectrikeGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx22_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sElectrikeGfx22_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx23:
+.incbin "baserom.gba", 0x1294728, 0x60
+sElectrikeGfx23_1:
+.incbin "baserom.gba", 0x1294788, 0x60
+sElectrikeGfx23_2:
+.incbin "baserom.gba", 0x12947E8, 0x60
+sElectrikeGfx23_3:
+.incbin "baserom.gba", 0x1294848, 0x20
+sElectrikeSprites23:
+ax_sprite sElectrikeGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sElectrikeGfx24:
+.incbin "baserom.gba", 0x12948B0, 0x60
+sElectrikeGfx24_1:
+.incbin "baserom.gba", 0x1294910, 0x60
+sElectrikeGfx24_2:
+.incbin "baserom.gba", 0x1294970, 0x40
+sElectrikeGfx24_3:
+.incbin "baserom.gba", 0x12949B0, 0x40
+sElectrikeSprites24:
+ax_sprite sElectrikeGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx25:
+.incbin "baserom.gba", 0x1294A38, 0x40
+sElectrikeGfx25_1:
+.incbin "baserom.gba", 0x1294A78, 0x60
+sElectrikeGfx25_2:
+.incbin "baserom.gba", 0x1294AD8, 0x60
+sElectrikeGfx25_3:
+.incbin "baserom.gba", 0x1294B38, 0x40
+sElectrikeSprites25:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx26:
+.incbin "baserom.gba", 0x1294BC8, 0x40
+sElectrikeGfx26_1:
+.incbin "baserom.gba", 0x1294C08, 0x60
+sElectrikeGfx26_2:
+.incbin "baserom.gba", 0x1294C68, 0x60
+sElectrikeGfx26_3:
+.incbin "baserom.gba", 0x1294CC8, 0x60
+sElectrikeSprites26:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx27:
+.incbin "baserom.gba", 0x1294D78, 0x20
+sElectrikeGfx27_1:
+.incbin "baserom.gba", 0x1294D98, 0x60
+sElectrikeGfx27_2:
+.incbin "baserom.gba", 0x1294DF8, 0x60
+sElectrikeGfx27_3:
+.incbin "baserom.gba", 0x1294E58, 0x60
+sElectrikeSprites27:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx28:
+.incbin "baserom.gba", 0x1294F08, 0x60
+sElectrikeGfx28_1:
+.incbin "baserom.gba", 0x1294F68, 0xE0
+sElectrikeGfx28_2:
+.incbin "baserom.gba", 0x1295048, 0x40
+sElectrikeSprites28:
+ax_sprite sElectrikeGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx28_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx29:
+.incbin "baserom.gba", 0x12950C0, 0x20
+sElectrikeGfx29_1:
+.incbin "baserom.gba", 0x12950E0, 0x60
+sElectrikeGfx29_2:
+.incbin "baserom.gba", 0x1295140, 0x60
+sElectrikeGfx29_3:
+.incbin "baserom.gba", 0x12951A0, 0x60
+sElectrikeSprites29:
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx29, 0x20
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx30:
+.incbin "baserom.gba", 0x1295250, 0x60
+sElectrikeGfx30_1:
+.incbin "baserom.gba", 0x12952B0, 0x80
+sElectrikeGfx30_2:
+.incbin "baserom.gba", 0x1295330, 0x60
+sElectrikeGfx30_3:
+.incbin "baserom.gba", 0x1295390, 0x60
+sElectrikeSprites30:
+ax_sprite sElectrikeGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx30_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx30_3, 0x60
+ax_sprite_terminator
+sElectrikeGfx31:
+.incbin "baserom.gba", 0x1295430, 0x180
+sElectrikeSprites31:
+ax_sprite 0, 0x80
+ax_sprite sElectrikeGfx31, 0x180
+ax_sprite_terminator
+sElectrikeGfx32:
+.incbin "baserom.gba", 0x12955C8, 0x60
+sElectrikeGfx32_1:
+.incbin "baserom.gba", 0x1295628, 0x100
+sElectrikeGfx32_2:
+.incbin "baserom.gba", 0x1295728, 0x40
+sElectrikeSprites32:
+ax_sprite sElectrikeGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx33:
+.incbin "baserom.gba", 0x12957A0, 0x60
+sElectrikeGfx33_1:
+.incbin "baserom.gba", 0x1295800, 0xE0
+sElectrikeGfx33_2:
+.incbin "baserom.gba", 0x12958E0, 0x40
+sElectrikeSprites33:
+ax_sprite sElectrikeGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx33_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx34:
+.incbin "baserom.gba", 0x1295958, 0x40
+sElectrikeGfx34_1:
+.incbin "baserom.gba", 0x1295998, 0x60
+sElectrikeGfx34_2:
+.incbin "baserom.gba", 0x12959F8, 0x60
+sElectrikeGfx34_3:
+.incbin "baserom.gba", 0x1295A58, 0x60
+sElectrikeSprites34:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx35:
+.incbin "baserom.gba", 0x1295B08, 0x60
+sElectrikeGfx35_1:
+.incbin "baserom.gba", 0x1295B68, 0x60
+sElectrikeGfx35_2:
+.incbin "baserom.gba", 0x1295BC8, 0x60
+sElectrikeSprites35:
+ax_sprite 0, 0x80
+ax_sprite sElectrikeGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx36:
+.incbin "baserom.gba", 0x1295C68, 0x80
+sElectrikeSprites36:
+ax_sprite sElectrikeGfx36, 0x80
+ax_sprite_terminator
+sElectrikeGfx37:
+.incbin "baserom.gba", 0x1295CF8, 0x80
+sElectrikeSprites37:
+ax_sprite sElectrikeGfx37, 0x80
+ax_sprite_terminator
+sElectrikeGfx38:
+.incbin "baserom.gba", 0x1295D88, 0x40
+sElectrikeGfx38_1:
+.incbin "baserom.gba", 0x1295DC8, 0x20
+sElectrikeSprites38:
+ax_sprite sElectrikeGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx38_1, 0x20
+ax_sprite_terminator
+sElectrikeGfx39:
+.incbin "baserom.gba", 0x1295E08, 0x20
+sElectrikeSprites39:
+ax_sprite sElectrikeGfx39, 0x20
+ax_sprite_terminator
+sElectrikeGfx40:
+.incbin "baserom.gba", 0x1295E38, 0x40
+sElectrikeSprites40:
+ax_sprite sElectrikeGfx40, 0x40
+ax_sprite_terminator
+sElectrikeGfx41:
+.incbin "baserom.gba", 0x1295E88, 0x40
+sElectrikeGfx41_1:
+.incbin "baserom.gba", 0x1295EC8, 0x60
+sElectrikeGfx41_2:
+.incbin "baserom.gba", 0x1295F28, 0x60
+sElectrikeGfx41_3:
+.incbin "baserom.gba", 0x1295F88, 0x60
+sElectrikeSprites41:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx41_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx42:
+.incbin "baserom.gba", 0x1296038, 0x20
+sElectrikeGfx42_1:
+.incbin "baserom.gba", 0x1296058, 0xC0
+sElectrikeSprites42:
+ax_sprite sElectrikeGfx42, 0x20
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx42_1, 0xc0
+ax_sprite_terminator
+sElectrikeGfx43:
+.incbin "baserom.gba", 0x1296138, 0x40
+sElectrikeSprites43:
+ax_sprite sElectrikeGfx43, 0x40
+ax_sprite_terminator
+sElectrikeGfx44:
+.incbin "baserom.gba", 0x1296188, 0x60
+sElectrikeGfx44_1:
+.incbin "baserom.gba", 0x12961E8, 0x80
+sElectrikeSprites44:
+ax_sprite sElectrikeGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx44_1, 0x80
+ax_sprite_terminator
+sElectrikeGfx45:
+.incbin "baserom.gba", 0x1296288, 0x40
+sElectrikeSprites45:
+ax_sprite sElectrikeGfx45, 0x40
+ax_sprite_terminator
+sElectrikeGfx46:
+.incbin "baserom.gba", 0x12962D8, 0x80
+sElectrikeSprites46:
+ax_sprite sElectrikeGfx46, 0x80
+ax_sprite_terminator
+sElectrikeGfx47:
+.incbin "baserom.gba", 0x1296368, 0x20
+sElectrikeSprites47:
+ax_sprite sElectrikeGfx47, 0x20
+ax_sprite_terminator
+sElectrikeGfx48:
+.incbin "baserom.gba", 0x1296398, 0x40
+sElectrikeGfx48_1:
+.incbin "baserom.gba", 0x12963D8, 0x60
+sElectrikeGfx48_2:
+.incbin "baserom.gba", 0x1296438, 0x60
+sElectrikeGfx48_3:
+.incbin "baserom.gba", 0x1296498, 0x60
+sElectrikeSprites48:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx48_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx49:
+.incbin "baserom.gba", 0x1296548, 0x80
+sElectrikeSprites49:
+ax_sprite sElectrikeGfx49, 0x80
+ax_sprite_terminator
+sElectrikeGfx50:
+.incbin "baserom.gba", 0x12965D8, 0x60
+sElectrikeGfx50_1:
+.incbin "baserom.gba", 0x1296638, 0x80
+sElectrikeSprites50:
+ax_sprite sElectrikeGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx50_1, 0x80
+ax_sprite_terminator
+sElectrikeGfx51:
+.incbin "baserom.gba", 0x12966D8, 0x80
+sElectrikeSprites51:
+ax_sprite sElectrikeGfx51, 0x80
+ax_sprite_terminator
+sElectrikeGfx52:
+.incbin "baserom.gba", 0x1296768, 0x20
+sElectrikeSprites52:
+ax_sprite sElectrikeGfx52, 0x20
+ax_sprite_terminator
+sElectrikeGfx53:
+.incbin "baserom.gba", 0x1296798, 0x60
+sElectrikeGfx53_1:
+.incbin "baserom.gba", 0x12967F8, 0xE0
+sElectrikeGfx53_2:
+.incbin "baserom.gba", 0x12968D8, 0x40
+sElectrikeSprites53:
+ax_sprite sElectrikeGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx53_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx53_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx54:
+.incbin "baserom.gba", 0x1296950, 0x100
+sElectrikeSprites54:
+ax_sprite sElectrikeGfx54, 0x100
+ax_sprite_terminator
+sElectrikeGfx55:
+.incbin "baserom.gba", 0x1296A60, 0x40
+sElectrikeSprites55:
+ax_sprite sElectrikeGfx55, 0x40
+ax_sprite_terminator
+sElectrikeGfx56:
+.incbin "baserom.gba", 0x1296AB0, 0x20
+sElectrikeSprites56:
+ax_sprite sElectrikeGfx56, 0x20
+ax_sprite_terminator
+sElectrikeGfx57:
+.incbin "baserom.gba", 0x1296AE0, 0x80
+sElectrikeSprites57:
+ax_sprite sElectrikeGfx57, 0x80
+ax_sprite_terminator
+sElectrikeGfx58:
+.incbin "baserom.gba", 0x1296B70, 0x40
+sElectrikeSprites58:
+ax_sprite sElectrikeGfx58, 0x40
+ax_sprite_terminator
+sElectrikeGfx59:
+.incbin "baserom.gba", 0x1296BC0, 0x80
+sElectrikeSprites59:
+ax_sprite sElectrikeGfx59, 0x80
+ax_sprite_terminator
+sElectrikeGfx60:
+.incbin "baserom.gba", 0x1296C50, 0x40
+sElectrikeSprites60:
+ax_sprite sElectrikeGfx60, 0x40
+ax_sprite_terminator
+sElectrikeGfx61:
+.incbin "baserom.gba", 0x1296CA0, 0x20
+sElectrikeSprites61:
+ax_sprite sElectrikeGfx61, 0x20
+ax_sprite_terminator
+sElectrikeGfx62:
+.incbin "baserom.gba", 0x1296CD0, 0x60
+sElectrikeGfx62_1:
+.incbin "baserom.gba", 0x1296D30, 0xE0
+sElectrikeGfx62_2:
+.incbin "baserom.gba", 0x1296E10, 0x40
+sElectrikeSprites62:
+ax_sprite sElectrikeGfx62, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx62_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sElectrikeGfx62_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx63:
+.incbin "baserom.gba", 0x1296E88, 0x60
+sElectrikeGfx63_1:
+.incbin "baserom.gba", 0x1296EE8, 0x100
+sElectrikeGfx63_2:
+.incbin "baserom.gba", 0x1296FE8, 0x60
+sElectrikeSprites63:
+ax_sprite sElectrikeGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx63_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx63_2, 0x60
+ax_sprite_terminator
+sElectrikeGfx64:
+.incbin "baserom.gba", 0x1297078, 0x60
+sElectrikeGfx64_1:
+.incbin "baserom.gba", 0x12970D8, 0x100
+sElectrikeGfx64_2:
+.incbin "baserom.gba", 0x12971D8, 0x60
+sElectrikeSprites64:
+ax_sprite sElectrikeGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx64_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx64_2, 0x60
+ax_sprite_terminator
+sElectrikeGfx65:
+.incbin "baserom.gba", 0x1297268, 0x60
+sElectrikeGfx65_1:
+.incbin "baserom.gba", 0x12972C8, 0x100
+sElectrikeGfx65_2:
+.incbin "baserom.gba", 0x12973C8, 0x40
+sElectrikeSprites65:
+ax_sprite sElectrikeGfx65, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx65_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx65_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx66:
+.incbin "baserom.gba", 0x1297440, 0x60
+sElectrikeGfx66_1:
+.incbin "baserom.gba", 0x12974A0, 0x100
+sElectrikeGfx66_2:
+.incbin "baserom.gba", 0x12975A0, 0x40
+sElectrikeSprites66:
+ax_sprite sElectrikeGfx66, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx66_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx66_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx67:
+.incbin "baserom.gba", 0x1297618, 0x40
+sElectrikeGfx67_1:
+.incbin "baserom.gba", 0x1297658, 0x60
+sElectrikeGfx67_2:
+.incbin "baserom.gba", 0x12976B8, 0x60
+sElectrikeGfx67_3:
+.incbin "baserom.gba", 0x1297718, 0x60
+sElectrikeSprites67:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx67, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx67_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx67_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx67_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx68:
+.incbin "baserom.gba", 0x12977C8, 0x40
+sElectrikeGfx68_1:
+.incbin "baserom.gba", 0x1297808, 0x60
+sElectrikeGfx68_2:
+.incbin "baserom.gba", 0x1297868, 0x60
+sElectrikeGfx68_3:
+.incbin "baserom.gba", 0x12978C8, 0x60
+sElectrikeSprites68:
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx68, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx68_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx68_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElectrikeGfx68_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElectrikeGfx69:
+.incbin "baserom.gba", 0x1297978, 0x200
+sElectrikeSprites69:
+ax_sprite sElectrikeGfx69, 0x200
+ax_sprite_terminator
+sElectrikeGfx70:
+.incbin "baserom.gba", 0x1297B88, 0x200
+sElectrikeSprites70:
+ax_sprite sElectrikeGfx70, 0x200
+ax_sprite_terminator
+sElectrikeGfx71:
+.incbin "baserom.gba", 0x1297D98, 0x200
+sElectrikeSprites71:
+ax_sprite sElectrikeGfx71, 0x200
+ax_sprite_terminator
+sElectrikeGfx72:
+.incbin "baserom.gba", 0x1297FA8, 0x200
+sElectrikeSprites72:
+ax_sprite sElectrikeGfx72, 0x200
+ax_sprite_terminator
+sElectrikeGfx73:
+.incbin "baserom.gba", 0x12981B8, 0x200
+sElectrikeSprites73:
+ax_sprite sElectrikeGfx73, 0x200
+ax_sprite_terminator
+sElectrikeGfx74:
+.incbin "baserom.gba", 0x12983C8, 0x200
+sElectrikeSprites74:
+ax_sprite sElectrikeGfx74, 0x200
+ax_sprite_terminator
+sElectrikeGfx75:
+.incbin "baserom.gba", 0x12985D8, 0x200
+sElectrikeSprites75:
+ax_sprite sElectrikeGfx75, 0x200
+ax_sprite_terminator
+sAxPosesElectrike:
+.4byte sElectrikePose1
+.4byte sElectrikePose2
+.4byte sElectrikePose3
+.4byte sElectrikePose4
+.4byte sElectrikePose5
+.4byte sElectrikePose6
+.4byte sElectrikePose7
+.4byte sElectrikePose8
+.4byte sElectrikePose9
+.4byte sElectrikePose10
+.4byte sElectrikePose11
+.4byte sElectrikePose12
+.4byte sElectrikePose13
+.4byte sElectrikePose14
+.4byte sElectrikePose15
+.4byte sElectrikePose16
+.4byte sElectrikePose17
+.4byte sElectrikePose18
+.4byte sElectrikePose19
+.4byte sElectrikePose20
+.4byte sElectrikePose21
+.4byte sElectrikePose22
+.4byte sElectrikePose23
+.4byte sElectrikePose24
+.4byte sElectrikePose25
+.4byte sElectrikePose26
+.4byte sElectrikePose27
+.4byte sElectrikePose28
+.4byte sElectrikePose29
+.4byte sElectrikePose30
+.4byte sElectrikePose31
+.4byte sElectrikePose32
+.4byte sElectrikePose33
+.4byte sElectrikePose34
+.4byte sElectrikePose35
+.4byte sElectrikePose36
+.4byte sElectrikePose37
+.4byte sElectrikePose38
+.4byte sElectrikePose39
+.4byte sElectrikePose40
+.4byte sElectrikePose41
+.4byte sElectrikePose42
+.4byte sElectrikePose43
+.4byte sElectrikePose44
+.4byte sElectrikePose45
+.4byte sElectrikePose46
+.4byte sElectrikePose47
+.4byte sElectrikePose48
+.4byte sElectrikePose49
+.4byte sElectrikePose50
+.4byte sElectrikePose51
+.4byte sElectrikePose52
+.4byte sElectrikePose53
+.4byte sElectrikePose54
+.4byte sElectrikePose55
+.4byte sElectrikePose56
+.4byte sElectrikePose57
+.4byte sElectrikePose58
+.4byte sElectrikePose59
+.4byte sElectrikePose60
+.4byte sElectrikePose61
+.4byte sElectrikePose62
+.4byte sElectrikePose63
+.4byte sElectrikePose64
+.4byte sElectrikePose65
+.4byte sElectrikePose66
+.4byte sElectrikePose67
+.4byte sElectrikePose68
+.4byte sElectrikePose69
+.4byte sElectrikePose70
+.4byte sElectrikePose71
+.4byte sElectrikePose72
+.4byte sElectrikePose73
+.4byte sElectrikePose74
+.4byte sElectrikePose75
+.4byte sElectrikePose76
+.4byte sElectrikePose77
+.4byte sElectrikePose78
+.4byte sElectrikePose79
+.4byte sElectrikePose80
+.4byte sElectrikePose81
+.4byte sElectrikePose82
+.4byte sElectrikePose83
+.4byte sElectrikePose84
+.4byte sElectrikePose85
+.4byte sElectrikePose86
+.4byte sElectrikePose87
+.4byte sElectrikePose88
+.4byte sElectrikePose89
+.4byte sElectrikePose90
+.4byte sElectrikePose91
+.4byte sElectrikePose92
+.4byte sElectrikePose93
+.4byte sElectrikePose94
+.4byte sElectrikePose95
+.4byte sElectrikePose96
+.4byte sElectrikePose97
+.4byte sElectrikePose98
+.4byte sElectrikePose99
+.4byte sElectrikePose100
+.4byte sElectrikePose101
+.4byte sElectrikePose102
+.4byte sElectrikePose103
+.4byte sElectrikePose104
+.4byte sElectrikePose105
+.4byte sElectrikePose106
+.4byte sElectrikePose107
+.4byte sElectrikePose108
+.4byte sElectrikePose109
+.4byte sElectrikePose110
+.4byte sElectrikePose111
+.4byte sElectrikePose112
+.4byte sElectrikePose113
+.4byte sElectrikePose114
+.4byte sElectrikePose115
+.4byte sElectrikePose116
+.4byte sElectrikePose117
+.4byte sElectrikePose118
+.4byte sElectrikePose119
+.4byte sElectrikePose120
+.4byte sElectrikePose121
+.4byte sElectrikePose122
+.4byte sElectrikePose123
+.4byte sElectrikePose124
+.4byte sElectrikePose125
+.4byte sElectrikePose126
+.4byte sElectrikePose127
+.4byte sElectrikePose128
+.4byte sElectrikePose129
+.4byte sElectrikePose130
+.4byte sElectrikePose131
+.4byte sElectrikePose132
+.4byte sElectrikePose133
+.4byte sElectrikePose134
+.4byte sElectrikePose135
+.4byte sElectrikePose136
+.4byte sElectrikePose137
+.4byte sElectrikePose138
+.4byte sElectrikePose139
+.4byte sElectrikePose140
+.4byte sElectrikePose141
+.4byte sElectrikePose142
+.4byte sElectrikePose143
+.4byte sElectrikePose144
+.4byte sElectrikePose145
+.4byte sElectrikePose146
+.4byte sElectrikePose147
+.4byte sElectrikePose148
+.4byte sElectrikePose149
+.4byte sElectrikePose150
+.4byte sElectrikePose151
+.4byte sElectrikePose152
+.4byte sElectrikePose153
+.4byte sElectrikePose154
+.4byte sElectrikePose155
+.4byte sElectrikePose156
+.4byte sElectrikePose157
+.4byte sElectrikePose158
+.4byte sElectrikePose159
+.4byte sElectrikePose160
+.4byte sElectrikePose161
+.4byte sElectrikePose162
+.4byte sElectrikePose163
+.4byte sElectrikePose164
+.4byte sElectrikePose165
+.4byte sElectrikePose166
+.4byte sElectrikePose167
+.4byte sElectrikePose168
+.4byte sElectrikePose169
+.4byte sElectrikePose170
+.4byte sElectrikePose171
+.4byte sElectrikePose172
+.4byte sElectrikePose173
+.4byte sElectrikePose174
+.4byte sElectrikePose175
+.4byte sElectrikePose176
+.4byte sElectrikePose177
+.4byte sElectrikePose178
+.4byte sElectrikePose179
+.4byte sElectrikePose180
+.4byte sElectrikePose181
+.4byte sElectrikePose182
+.4byte sElectrikePose183
+.4byte sElectrikePose184
+.4byte sElectrikePose185
+.4byte sElectrikePose186
+.4byte sElectrikePose187
+.4byte sElectrikePose188
+.4byte sElectrikePose189
+.4byte sElectrikePose190
+.4byte sElectrikePose191
+.4byte sElectrikePose192
+.4byte sElectrikePose193
+.4byte sElectrikePose194
+.4byte sElectrikePose195
+.4byte sElectrikePose196
+.4byte sElectrikePose197
+.4byte sElectrikePose198
+.4byte sElectrikePose199
+.4byte sElectrikePose200
+.4byte sElectrikePose201
+.4byte sElectrikePose202
+.4byte sElectrikePose203
+.4byte sElectrikePose204
+.4byte sElectrikePose205
+.4byte sElectrikePose206
+.4byte sElectrikePose207
+.4byte sElectrikePose208
+.4byte sElectrikePose209
+.4byte sElectrikePose210
+.4byte sElectrikePose211
+.4byte sElectrikePose212
+.4byte sElectrikePose213
+.4byte sElectrikePose214
+.4byte sElectrikePose215
+.4byte sElectrikePose216
+.4byte sElectrikePose217
+.4byte sElectrikePose218
+.4byte sElectrikePose219
+.4byte sElectrikePose220
+.4byte sElectrikePose221
+.4byte sElectrikePose222
+.4byte sElectrikePose223
+.4byte sElectrikePose224
+.4byte sElectrikePose225
+.4byte sElectrikePose226
+.4byte sElectrikePose227
+.4byte sElectrikePose228
+.4byte sElectrikePose229
+.4byte sElectrikePose230
+.4byte sElectrikePose231
+.4byte sElectrikePose232
+.4byte sElectrikePose233
+.4byte sElectrikePose234
+.4byte sElectrikePose235
+.4byte sElectrikePose236
+.4byte sElectrikePose237
+.4byte sElectrikePose238
+.4byte sElectrikePose239
+.4byte sElectrikePose240
+.4byte sElectrikePose241
+.4byte sElectrikePose242
+.4byte sElectrikePose243
+.4byte sElectrikePose244
+.4byte sElectrikePose245
+.4byte sElectrikePose246
+.4byte sElectrikePose247
+.4byte sElectrikePose248
+.4byte sElectrikePose249
+.4byte sElectrikePose250
+.4byte sElectrikePose251
+.4byte sElectrikePose252
+.4byte sElectrikePose253
+.4byte sElectrikePose254
+.4byte sElectrikePose255
+.4byte sElectrikePose256
+.4byte sElectrikePose257
+.4byte sElectrikePose258
+sAxPositionsElectrike:
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte    0,    0, 	  -5,    3, 	   4,    0, 	   0,   -8
+.2byte   -2,    0, 	  -6,    0, 	   3,    3, 	  -2,   -8
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte    5,    0, 	   3,   -3, 	   1,    3, 	  -2,   -7
+.2byte    3,    0, 	   8,    1, 	  -2,    0, 	  -4,   -8
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte    9,   -4, 	   2,   -3, 	   8,    1, 	  -1,   -5
+.2byte    9,   -4, 	   9,   -2, 	   3,    1, 	   0,   -4
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    6,   -9, 	  -3,   -4, 	   7,   -3, 	  -2,   -5
+.2byte    4,   -9, 	  -2,   -7, 	   3,   -1, 	  -3,   -4
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -3,   -7, 	   2,   -5, 	  -6,   -3, 	  -2,   -4
+.2byte    1,   -7, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -8,   -9, 	   1,   -4, 	  -9,   -3, 	   0,   -5
+.2byte   -6,   -9, 	   0,   -7, 	  -5,   -1, 	   1,   -4
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte  -10,   -4, 	  -3,   -3, 	  -9,    1, 	   0,   -5
+.2byte  -10,   -4, 	 -10,   -2, 	  -4,    1, 	  -1,   -4
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte   -6,    0, 	  -4,   -3, 	  -2,    3, 	   1,   -7
+.2byte   -4,    0, 	  -9,    1, 	   1,    0, 	   3,   -8
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte    0,    0, 	  -5,    3, 	   4,    0, 	   0,   -8
+.2byte   -2,    0, 	  -6,    0, 	   3,    3, 	  -2,   -8
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -9
+.2byte   -1,    2, 	  -6,   -1, 	   4,   -1, 	  -1,   -8
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte    5,    0, 	   3,   -3, 	   1,    3, 	  -2,   -7
+.2byte    3,    0, 	   8,    1, 	  -2,    0, 	  -4,   -8
+.2byte    6,   -3, 	   9,   -1, 	   5,    0, 	   0,  -10
+.2byte    6,   -1, 	   4,   -1, 	  -1,    0, 	  -1,   -9
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte    9,   -4, 	   2,   -3, 	   8,    1, 	  -1,   -5
+.2byte    9,   -4, 	   9,   -2, 	   3,    1, 	   0,   -4
+.2byte    8,   -6, 	   8,   -5, 	   8,   -3, 	  -1,   -7
+.2byte    9,   -4, 	   1,    1, 	  -1,    2, 	  -2,   -4
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    6,   -9, 	  -3,   -4, 	   7,   -3, 	  -2,   -5
+.2byte    4,   -9, 	  -2,   -7, 	   3,   -1, 	  -3,   -4
+.2byte    7,  -13, 	   2,  -13, 	   9,   -9, 	  -1,   -9
+.2byte    4,   -9, 	  -5,   -1, 	  -3,    1, 	  -3,   -6
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -3,   -7, 	   2,   -5, 	  -6,   -3, 	  -2,   -4
+.2byte    1,   -7, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte   -1,  -14, 	   4,  -13, 	  -6,  -13, 	  -1,   -9
+.2byte   -1,   -7, 	   2,   -1, 	  -4,   -1, 	  -1,   -5
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -8,   -9, 	   1,   -4, 	  -9,   -3, 	   0,   -5
+.2byte   -6,   -9, 	   0,   -7, 	  -5,   -1, 	   1,   -4
+.2byte   -9,  -14, 	  -4,  -14, 	 -11,  -10, 	  -1,  -10
+.2byte   -6,   -9, 	   3,   -1, 	   1,    1, 	   1,   -6
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte  -10,   -4, 	  -3,   -3, 	  -9,    1, 	   0,   -5
+.2byte  -10,   -4, 	 -10,   -2, 	  -4,    1, 	  -1,   -4
+.2byte   -9,   -6, 	  -9,   -5, 	  -9,   -3, 	   0,   -7
+.2byte  -10,   -4, 	  -2,    1, 	   0,    2, 	   1,   -4
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte   -6,    0, 	  -4,   -3, 	  -2,    3, 	   1,   -7
+.2byte   -4,    0, 	  -9,    1, 	   1,    0, 	   3,   -8
+.2byte   -7,   -3, 	 -10,   -1, 	  -6,    0, 	  -1,  -10
+.2byte   -7,   -1, 	  -5,   -1, 	   0,    0, 	   0,   -9
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte    0,    0, 	  -5,    3, 	   4,    0, 	   0,   -8
+.2byte   -2,    0, 	  -6,    0, 	   3,    3, 	  -2,   -8
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -9
+.2byte   -1,    2, 	  -6,   -1, 	   4,   -1, 	  -1,   -8
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte    5,    0, 	   3,   -3, 	   1,    3, 	  -2,   -7
+.2byte    3,    0, 	   8,    1, 	  -2,    0, 	  -4,   -8
+.2byte    6,   -3, 	   9,   -1, 	   5,    0, 	   0,  -10
+.2byte    6,   -1, 	   4,   -1, 	  -1,    0, 	  -1,   -9
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte    9,   -4, 	   2,   -3, 	   8,    1, 	  -1,   -5
+.2byte    9,   -4, 	   9,   -2, 	   3,    1, 	   0,   -4
+.2byte    8,   -6, 	   8,   -5, 	   8,   -3, 	  -1,   -7
+.2byte    9,   -4, 	   1,    1, 	  -1,    2, 	  -2,   -4
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    6,   -9, 	  -3,   -4, 	   7,   -3, 	  -2,   -5
+.2byte    4,   -9, 	  -2,   -7, 	   3,   -1, 	  -3,   -4
+.2byte    7,  -13, 	   2,  -13, 	   9,   -9, 	  -1,   -9
+.2byte    4,   -9, 	  -5,   -1, 	  -3,    1, 	  -3,   -6
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -3,   -7, 	   2,   -5, 	  -6,   -3, 	  -2,   -4
+.2byte    1,   -7, 	   4,   -3, 	  -4,   -5, 	   1,   -5
+.2byte   -1,  -14, 	   4,  -13, 	  -6,  -13, 	  -1,   -9
+.2byte   -1,   -7, 	   2,   -1, 	  -4,   -1, 	  -1,   -5
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -8,   -9, 	   1,   -4, 	  -9,   -3, 	   0,   -5
+.2byte   -6,   -9, 	   0,   -7, 	  -5,   -1, 	   1,   -4
+.2byte   -9,  -14, 	  -4,  -14, 	 -11,  -10, 	  -1,  -10
+.2byte   -6,   -9, 	   3,   -1, 	   1,    1, 	   1,   -6
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte  -10,   -4, 	  -3,   -3, 	  -9,    1, 	   0,   -5
+.2byte  -10,   -4, 	 -10,   -2, 	  -4,    1, 	  -1,   -4
+.2byte   -9,   -6, 	  -9,   -5, 	  -9,   -3, 	   0,   -7
+.2byte  -10,   -4, 	  -2,    1, 	   0,    2, 	   1,   -4
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte   -6,    0, 	  -4,   -3, 	  -2,    3, 	   1,   -7
+.2byte   -4,    0, 	  -9,    1, 	   1,    0, 	   3,   -8
+.2byte   -7,   -3, 	 -10,   -1, 	  -6,    0, 	  -1,  -10
+.2byte   -7,   -1, 	  -5,   -1, 	   0,    0, 	   0,   -9
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte   -1,  -14, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,    3, 	  -6,    1, 	   4,    1, 	  -1,   -5
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte    9,  -14, 	   7,   -2, 	  -1,    1, 	  -1,   -7
+.2byte    7,    3, 	   7,   -1, 	  -1,    1, 	  -1,   -7
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte   10,  -16, 	   6,   -3, 	   5,    1, 	  -1,   -7
+.2byte   12,   -3, 	   6,   -3, 	   5,    1, 	   2,   -5
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    3,  -17, 	  -3,   -5, 	   5,   -2, 	  -3,   -7
+.2byte    9,  -12, 	  -1,   -4, 	   5,   -2, 	  -1,   -7
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,  -19, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -5,  -17, 	   1,   -5, 	  -7,   -2, 	   1,   -7
+.2byte  -11,  -12, 	  -1,   -4, 	  -7,   -2, 	  -1,   -7
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte  -11,  -16, 	  -7,   -3, 	  -6,    1, 	   0,   -7
+.2byte  -13,   -3, 	  -7,   -3, 	  -6,    1, 	  -3,   -5
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte  -10,  -14, 	  -8,   -2, 	   0,    1, 	   0,   -7
+.2byte   -8,    3, 	  -8,   -1, 	   0,    1, 	   0,   -7
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte   -1,    3, 	  -6,    1, 	   4,    1, 	  -1,   -5
+.2byte   -1,  -13, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte   -1,  -13, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte   -1,  -13, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte   -1,  -13, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte    7,    3, 	   7,   -1, 	  -1,    1, 	  -1,   -7
+.2byte    7,  -11, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    7,  -11, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    7,  -11, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    7,  -11, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte   12,   -3, 	   6,   -3, 	   5,    1, 	   2,   -5
+.2byte    9,  -13, 	   6,   -3, 	   5,    1, 	  -1,   -8
+.2byte    9,  -13, 	   6,   -3, 	   5,    1, 	  -1,   -8
+.2byte    9,  -13, 	   6,   -3, 	   5,    1, 	  -1,   -8
+.2byte    9,  -13, 	   6,   -3, 	   5,    1, 	  -1,   -8
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    9,  -12, 	  -1,   -4, 	   5,   -2, 	  -1,   -7
+.2byte    4,  -17, 	  -3,   -6, 	   5,   -2, 	  -3,   -7
+.2byte    4,  -17, 	  -3,   -6, 	   5,   -2, 	  -3,   -7
+.2byte    4,  -17, 	  -3,   -6, 	   5,   -2, 	  -3,   -7
+.2byte    4,  -17, 	  -3,   -6, 	   5,   -2, 	  -3,   -7
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte   -1,  -18, 	   4,   -3, 	  -6,   -3, 	  -1,   -8
+.2byte   -1,  -18, 	   4,   -3, 	  -6,   -3, 	  -1,   -8
+.2byte   -1,  -18, 	   4,   -3, 	  -6,   -3, 	  -1,   -8
+.2byte   -1,  -18, 	   4,   -3, 	  -6,   -3, 	  -1,   -8
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte  -11,  -12, 	  -1,   -4, 	  -7,   -2, 	  -1,   -7
+.2byte   -6,  -17, 	   1,   -6, 	  -7,   -2, 	   1,   -7
+.2byte   -6,  -17, 	   1,   -6, 	  -7,   -2, 	   1,   -7
+.2byte   -6,  -17, 	   1,   -6, 	  -7,   -2, 	   1,   -7
+.2byte   -6,  -17, 	   1,   -6, 	  -7,   -2, 	   1,   -7
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte  -13,   -3, 	  -7,   -3, 	  -6,    1, 	  -3,   -5
+.2byte  -10,  -13, 	  -7,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -10,  -13, 	  -7,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -10,  -13, 	  -7,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -10,  -13, 	  -7,   -3, 	  -6,    1, 	   0,   -8
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte   -8,    3, 	  -8,   -1, 	   0,    1, 	   0,   -7
+.2byte   -8,  -11, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -8,  -11, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -8,  -11, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -8,  -11, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -5,   -1, 	  -9,   -1, 	  -5,    1, 	   1,   -7
+.2byte   -4,    0, 	  -9,   -1, 	  -4,    1, 	   2,   -6
+.2byte    0,   -1, 	  -7,    2, 	   6,    2, 	   0,   -8
+.2byte    5,    2, 	  11,    0, 	   0,    4, 	  -1,   -5
+.2byte    6,   -4, 	  12,   -3, 	   8,    0, 	  -1,   -5
+.2byte    5,   -6, 	   3,   -9, 	  10,   -4, 	  -2,   -7
+.2byte   -1,   -6, 	   7,   -5, 	  -9,   -5, 	  -1,   -5
+.2byte   -6,   -6, 	  -4,   -9, 	 -11,   -4, 	   1,   -7
+.2byte   -7,   -4, 	 -13,   -3, 	  -9,    0, 	   0,   -5
+.2byte   -6,    2, 	 -12,    0, 	  -1,    4, 	   0,   -5
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte   -1,  -14, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,  -13, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte    9,  -14, 	   7,   -2, 	  -1,    1, 	  -1,   -7
+.2byte    7,  -11, 	   7,   -1, 	  -1,    1, 	  -1,   -8
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte   10,  -16, 	   6,   -3, 	   5,    1, 	  -1,   -7
+.2byte    9,  -13, 	   6,   -3, 	   5,    1, 	  -1,   -8
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    3,  -17, 	  -3,   -5, 	   5,   -2, 	  -3,   -7
+.2byte    4,  -17, 	  -3,   -6, 	   5,   -2, 	  -3,   -7
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,  -19, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,  -18, 	   4,   -3, 	  -6,   -3, 	  -1,   -8
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -5,  -17, 	   1,   -5, 	  -7,   -2, 	   1,   -7
+.2byte   -6,  -17, 	   1,   -6, 	  -7,   -2, 	   1,   -7
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte  -11,  -16, 	  -7,   -3, 	  -6,    1, 	   0,   -7
+.2byte  -10,  -13, 	  -7,   -3, 	  -6,    1, 	   0,   -8
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte  -10,  -14, 	  -8,   -2, 	   0,    1, 	   0,   -7
+.2byte   -8,  -11, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -9
+.2byte   -6,   -3, 	  -9,   -1, 	  -5,    0, 	   0,  -10
+.2byte   -9,   -6, 	  -9,   -5, 	  -9,   -3, 	   0,   -7
+.2byte   -8,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -1,  -14, 	   4,  -13, 	  -6,  -13, 	  -1,   -9
+.2byte    6,  -12, 	   1,  -12, 	   8,   -8, 	  -2,   -8
+.2byte    8,   -6, 	   8,   -5, 	   8,   -3, 	  -1,   -7
+.2byte    5,   -3, 	   8,   -1, 	   4,    0, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte    9,  -14, 	   7,   -2, 	  -1,    1, 	  -1,   -7
+.2byte   10,  -16, 	   6,   -3, 	   5,    1, 	  -1,   -7
+.2byte    3,  -17, 	  -3,   -5, 	   5,   -2, 	  -3,   -7
+.2byte   -1,  -19, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -5,  -17, 	   1,   -5, 	  -7,   -2, 	   1,   -7
+.2byte  -11,  -16, 	  -7,   -3, 	  -6,    1, 	   0,   -7
+.2byte  -10,  -14, 	  -8,   -2, 	   0,    1, 	   0,   -7
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte   -1,  -14, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte    9,  -14, 	   7,   -2, 	  -1,    1, 	  -1,   -7
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte   10,  -16, 	   6,   -3, 	   5,    1, 	  -1,   -7
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    3,  -17, 	  -3,   -5, 	   5,   -2, 	  -3,   -7
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,  -19, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -5,  -17, 	   1,   -5, 	  -7,   -2, 	   1,   -7
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte  -11,  -16, 	  -7,   -3, 	  -6,    1, 	   0,   -7
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte  -10,  -14, 	  -8,   -2, 	   0,    1, 	   0,   -7
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	  -1,   -9
+.2byte   -5,   -1, 	  -8,   -1, 	   0,    1, 	   2,   -7
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    1, 	   0,   -5
+.2byte   -8,  -10, 	   1,   -5, 	  -7,   -2, 	   0,   -6
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte    6,  -10, 	  -3,   -5, 	   5,   -2, 	  -2,   -6
+.2byte    8,   -5, 	   6,   -3, 	   5,    1, 	  -1,   -5
+.2byte    4,   -1, 	   7,   -1, 	  -1,    1, 	  -3,   -7
+sElectrikeAnimTable1:
+.4byte sElectrikeAnims_1_1
+.4byte sElectrikeAnims_1_2
+.4byte sElectrikeAnims_1_3
+.4byte sElectrikeAnims_1_4
+.4byte sElectrikeAnims_1_5
+.4byte sElectrikeAnims_1_6
+.4byte sElectrikeAnims_1_7
+.4byte sElectrikeAnims_1_8
+sElectrikeAnimTable2:
+.4byte sElectrikeAnims_2_1
+.4byte sElectrikeAnims_2_2
+.4byte sElectrikeAnims_2_3
+.4byte sElectrikeAnims_2_4
+.4byte sElectrikeAnims_2_5
+.4byte sElectrikeAnims_2_6
+.4byte sElectrikeAnims_2_7
+.4byte sElectrikeAnims_2_8
+sElectrikeAnimTable3:
+.4byte sElectrikeAnims_3_1
+.4byte sElectrikeAnims_3_2
+.4byte sElectrikeAnims_3_3
+.4byte sElectrikeAnims_3_4
+.4byte sElectrikeAnims_3_5
+.4byte sElectrikeAnims_3_6
+.4byte sElectrikeAnims_3_7
+.4byte sElectrikeAnims_3_8
+sElectrikeAnimTable4:
+.4byte sElectrikeAnims_4_1
+.4byte sElectrikeAnims_4_2
+.4byte sElectrikeAnims_4_3
+.4byte sElectrikeAnims_4_4
+.4byte sElectrikeAnims_4_5
+.4byte sElectrikeAnims_4_6
+.4byte sElectrikeAnims_4_7
+.4byte sElectrikeAnims_4_8
+sElectrikeAnimTable5:
+.4byte sElectrikeAnims_5_1
+.4byte sElectrikeAnims_5_2
+.4byte sElectrikeAnims_5_3
+.4byte sElectrikeAnims_5_4
+.4byte sElectrikeAnims_5_5
+.4byte sElectrikeAnims_5_6
+.4byte sElectrikeAnims_5_7
+.4byte sElectrikeAnims_5_8
+sElectrikeAnimTable6:
+.4byte sElectrikeAnims_6_1
+.4byte sElectrikeAnims_6_1
+.4byte sElectrikeAnims_6_1
+.4byte sElectrikeAnims_6_1
+.4byte sElectrikeAnims_6_1
+.4byte sElectrikeAnims_6_1
+.4byte sElectrikeAnims_6_1
+.4byte sElectrikeAnims_6_1
+sElectrikeAnimTable7:
+.4byte sElectrikeAnims_7_1
+.4byte sElectrikeAnims_7_2
+.4byte sElectrikeAnims_7_3
+.4byte sElectrikeAnims_7_4
+.4byte sElectrikeAnims_7_5
+.4byte sElectrikeAnims_7_6
+.4byte sElectrikeAnims_7_7
+.4byte sElectrikeAnims_7_8
+sElectrikeAnimTable8:
+.4byte sElectrikeAnims_8_1
+.4byte sElectrikeAnims_8_2
+.4byte sElectrikeAnims_8_3
+.4byte sElectrikeAnims_8_4
+.4byte sElectrikeAnims_8_5
+.4byte sElectrikeAnims_8_6
+.4byte sElectrikeAnims_8_7
+.4byte sElectrikeAnims_8_8
+sElectrikeAnimTable9:
+.4byte sElectrikeAnims_9_1
+.4byte sElectrikeAnims_9_2
+.4byte sElectrikeAnims_9_3
+.4byte sElectrikeAnims_9_4
+.4byte sElectrikeAnims_9_5
+.4byte sElectrikeAnims_9_6
+.4byte sElectrikeAnims_9_7
+.4byte sElectrikeAnims_9_8
+sElectrikeAnimTable10:
+.4byte sElectrikeAnims_10_1
+.4byte sElectrikeAnims_10_2
+.4byte sElectrikeAnims_10_3
+.4byte sElectrikeAnims_10_4
+.4byte sElectrikeAnims_10_5
+.4byte sElectrikeAnims_10_6
+.4byte sElectrikeAnims_10_7
+.4byte sElectrikeAnims_10_8
+sElectrikeAnimTable11:
+.4byte sElectrikeAnims_11_1
+.4byte sElectrikeAnims_11_2
+.4byte sElectrikeAnims_11_3
+.4byte sElectrikeAnims_11_4
+.4byte sElectrikeAnims_11_5
+.4byte sElectrikeAnims_11_6
+.4byte sElectrikeAnims_11_7
+.4byte sElectrikeAnims_11_8
+sElectrikeAnimTable12:
+.4byte sElectrikeAnims_12_1
+.4byte sElectrikeAnims_12_2
+.4byte sElectrikeAnims_12_3
+.4byte sElectrikeAnims_12_4
+.4byte sElectrikeAnims_12_5
+.4byte sElectrikeAnims_12_6
+.4byte sElectrikeAnims_12_7
+.4byte sElectrikeAnims_12_8
+sElectrikeAnimTable13:
+.4byte sElectrikeAnims_13_1
+.4byte sElectrikeAnims_13_2
+.4byte sElectrikeAnims_13_3
+.4byte sElectrikeAnims_13_4
+.4byte sElectrikeAnims_13_5
+.4byte sElectrikeAnims_13_6
+.4byte sElectrikeAnims_13_7
+.4byte sElectrikeAnims_13_8
+sAxAnimationsElectrike:
+.4byte sElectrikeAnimTable1
+.4byte sElectrikeAnimTable2
+.4byte sElectrikeAnimTable3
+.4byte sElectrikeAnimTable4
+.4byte sElectrikeAnimTable5
+.4byte sElectrikeAnimTable6
+.4byte sElectrikeAnimTable7
+.4byte sElectrikeAnimTable8
+.4byte sElectrikeAnimTable9
+.4byte sElectrikeAnimTable10
+.4byte sElectrikeAnimTable11
+.4byte sElectrikeAnimTable12
+.4byte sElectrikeAnimTable13
+sAxSpritesElectrike:
+.4byte sElectrikeSprites1
+.4byte sElectrikeSprites2
+.4byte sElectrikeSprites3
+.4byte sElectrikeSprites4
+.4byte sElectrikeSprites5
+.4byte sElectrikeSprites6
+.4byte sElectrikeSprites7
+.4byte sElectrikeSprites8
+.4byte sElectrikeSprites9
+.4byte sElectrikeSprites10
+.4byte sElectrikeSprites11
+.4byte sElectrikeSprites12
+.4byte sElectrikeSprites13
+.4byte sElectrikeSprites14
+.4byte sElectrikeSprites15
+.4byte sElectrikeSprites16
+.4byte sElectrikeSprites17
+.4byte sElectrikeSprites18
+.4byte sElectrikeSprites19
+.4byte sElectrikeSprites20
+.4byte sElectrikeSprites21
+.4byte sElectrikeSprites22
+.4byte sElectrikeSprites23
+.4byte sElectrikeSprites24
+.4byte sElectrikeSprites25
+.4byte sElectrikeSprites26
+.4byte sElectrikeSprites27
+.4byte sElectrikeSprites28
+.4byte sElectrikeSprites29
+.4byte sElectrikeSprites30
+.4byte sElectrikeSprites31
+.4byte sElectrikeSprites32
+.4byte sElectrikeSprites33
+.4byte sElectrikeSprites34
+.4byte sElectrikeSprites35
+.4byte sElectrikeSprites36
+.4byte sElectrikeSprites37
+.4byte sElectrikeSprites38
+.4byte sElectrikeSprites39
+.4byte sElectrikeSprites40
+.4byte sElectrikeSprites41
+.4byte sElectrikeSprites42
+.4byte sElectrikeSprites43
+.4byte sElectrikeSprites44
+.4byte sElectrikeSprites45
+.4byte sElectrikeSprites46
+.4byte sElectrikeSprites47
+.4byte sElectrikeSprites48
+.4byte sElectrikeSprites49
+.4byte sElectrikeSprites50
+.4byte sElectrikeSprites51
+.4byte sElectrikeSprites52
+.4byte sElectrikeSprites53
+.4byte sElectrikeSprites54
+.4byte sElectrikeSprites55
+.4byte sElectrikeSprites56
+.4byte sElectrikeSprites57
+.4byte sElectrikeSprites58
+.4byte sElectrikeSprites59
+.4byte sElectrikeSprites60
+.4byte sElectrikeSprites61
+.4byte sElectrikeSprites62
+.4byte sElectrikeSprites63
+.4byte sElectrikeSprites64
+.4byte sElectrikeSprites65
+.4byte sElectrikeSprites66
+.4byte sElectrikeSprites67
+.4byte sElectrikeSprites68
+.4byte sElectrikeSprites69
+.4byte sElectrikeSprites70
+.4byte sElectrikeSprites71
+.4byte sElectrikeSprites72
+.4byte sElectrikeSprites73
+.4byte sElectrikeSprites74
+.4byte sElectrikeSprites75
+sAxMainElectrike:
+ax_main sAxPosesElectrike, sAxAnimationsElectrike, 13, sAxSpritesElectrike, sAxPositionsElectrike

--- a/data/ax/electrode.inc
+++ b/data/ax/electrode.inc
@@ -1,0 +1,2592 @@
+.global gAxElectrode
+gAxElectrode:
+ax_siro sAxMainElectrode
+sElectrodePose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose4:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose5:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose6:
+ax_pose 5, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose7:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose8:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose9:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose10:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose11:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose12:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose16:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose17:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose18:
+ax_pose 17, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose19:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose20:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose21:
+ax_pose 20, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose22:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose23:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose24:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose26:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose27:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose28:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose29:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose30:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose31:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose32:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose33:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose34:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose35:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose36:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose37:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose38:
+ax_pose 5, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose39:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose40:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose41:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose42:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose43:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose44:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose45:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose46:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose47:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose48:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose49:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose50:
+ax_pose 17, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose51:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose52:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose53:
+ax_pose 20, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose54:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose55:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose56:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose57:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose58:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose59:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose60:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose61:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose62:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose63:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose64:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose65:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose66:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose67:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose68:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose69:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose70:
+ax_pose 5, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose71:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose72:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose73:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose74:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose75:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose76:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose77:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose78:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose79:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose80:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose81:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose82:
+ax_pose 17, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose83:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose84:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose85:
+ax_pose 20, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose86:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose87:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose88:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose89:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose90:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose91:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose92:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose93:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose94:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose95:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose96:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose97:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose98:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose99:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose100:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose101:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose102:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose103:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose104:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose105:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose106:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose107:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose108:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose109:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose110:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose111:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose112:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose113:
+ax_pose 24, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sElectrodePose114:
+ax_pose 25, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sElectrodePose115:
+ax_pose 26, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sElectrodePose116:
+ax_pose 27, 0x01e2, 0x90eb, 0x5c00
+ax_pose_terminator
+sElectrodePose117:
+ax_pose 28, 0x01e3, 0x90e9, 0x5c00
+ax_pose_terminator
+sElectrodePose118:
+ax_pose 29, 0x01e4, 0x90e8, 0x5c00
+ax_pose_terminator
+sElectrodePose119:
+ax_pose 30, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sElectrodePose120:
+ax_pose 29, 0x01e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sElectrodePose121:
+ax_pose 28, 0x01e3, 0x80f7, 0x5c00
+ax_pose_terminator
+sElectrodePose122:
+ax_pose 27, 0x01e2, 0x80f5, 0x5c00
+ax_pose_terminator
+sElectrodePose123:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose124:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose125:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose126:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose127:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose128:
+ax_pose 5, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose129:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose130:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose131:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose132:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose133:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose134:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose135:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose136:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose137:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose138:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose139:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose140:
+ax_pose 17, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose141:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose142:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose143:
+ax_pose 20, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose144:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose145:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose146:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose147:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose148:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose149:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose150:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose151:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose152:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose153:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose154:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose155:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose156:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose157:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose158:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose159:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose160:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose161:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose162:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose163:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose164:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose165:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose166:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose167:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose168:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose169:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose170:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose171:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose172:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose173:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose174:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose175:
+ax_pose 5, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose176:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose177:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose178:
+ax_pose 8, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose179:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose180:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose181:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose182:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose183:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose184:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose185:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose186:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose187:
+ax_pose 17, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose188:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose189:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose190:
+ax_pose 20, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose191:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose192:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose193:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose194:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose195:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose196:
+ax_pose 22, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose197:
+ax_pose 19, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose198:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose199:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose200:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose201:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose202:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose203:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose204:
+ax_pose 21, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose205:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose206:
+ax_pose 15, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose207:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose208:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose209:
+ax_pose 6, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sElectrodePose210:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+.align 2
+sElectrodeAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 3, 0, 3,
+ax_anim 6, 0, 1, 0, 4, 0, 4,
+ax_anim 8, 0, 1, 0, 5, 0, 5,
+ax_anim 6, 0, 0, 0, 5, 0, 5,
+ax_anim 4, 0, 2, 0, 2, 0, 2,
+ax_anim 10, 0, 2, 0, -1, 0, -1,
+ax_anim_terminator
+sElectrodeAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 2, 2, 2, 2,
+ax_anim 6, 0, 4, 3, 3, 3, 3,
+ax_anim 8, 0, 4, 4, 4, 4, 4,
+ax_anim 6, 0, 3, 4, 4, 4, 4,
+ax_anim 4, 0, 5, 2, 2, 2, 2,
+ax_anim 10, 0, 5, -1, -1, -1, -1,
+ax_anim_terminator
+sElectrodeAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 1, 0, 1, 0,
+ax_anim 6, 0, 7, 3, 0, 3, 0,
+ax_anim 8, 0, 7, 4, 0, 4, 0,
+ax_anim 6, 0, 6, 4, 0, 4, 0,
+ax_anim 4, 0, 8, 2, 0, 2, 0,
+ax_anim 10, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sElectrodeAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 2, -2, 2, -2,
+ax_anim 6, 0, 10, 3, -3, 3, -3,
+ax_anim 8, 0, 10, 4, -4, 4, -4,
+ax_anim 6, 0, 9, 4, -4, 4, -4,
+ax_anim 4, 0, 11, 2, -2, 2, -2,
+ax_anim 10, 0, 11, -1, 1, -1, 1,
+ax_anim_terminator
+sElectrodeAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, -3,
+ax_anim 6, 0, 13, 0, -4, 0, -4,
+ax_anim 8, 0, 13, 0, -5, 0, -5,
+ax_anim 6, 0, 12, 0, -5, 0, -5,
+ax_anim 4, 0, 14, 0, -2, 0, -2,
+ax_anim 10, 0, 14, 0, 1, 0, 1,
+ax_anim_terminator
+sElectrodeAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -2, -2, -2, -2,
+ax_anim 6, 0, 16, -3, -3, -3, -3,
+ax_anim 8, 0, 16, -4, -4, -4, -4,
+ax_anim 6, 0, 15, -4, -4, -4, -4,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 10, 0, 17, 1, 1, 1, 1,
+ax_anim_terminator
+sElectrodeAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -1, 0, -1, 0,
+ax_anim 6, 0, 19, -3, 0, -3, 0,
+ax_anim 8, 0, 19, -4, 0, -4, 0,
+ax_anim 6, 0, 18, -4, 0, -4, 0,
+ax_anim 4, 0, 20, -2, 0, -2, 0,
+ax_anim 10, 0, 20, 1, 0, 1, 0,
+ax_anim_terminator
+sElectrodeAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -2, 2, -2, 2,
+ax_anim 6, 0, 22, -3, 3, -3, 3,
+ax_anim 8, 0, 22, -4, 4, -4, 4,
+ax_anim 6, 0, 21, -4, 4, -4, 4,
+ax_anim 4, 0, 23, -2, 2, -2, 2,
+ax_anim 10, 0, 23, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_2_1:
+ax_anim 2, 0, 34, 0, -2, 0, -2,
+ax_anim 2, 0, 34, 0, -3, 0, -3,
+ax_anim 6, 0, 34, 0, -4, 0, -4,
+ax_anim 1, 2, 33, 0, -1, 0, -1,
+ax_anim 2, 0, 33, 0, 15, 0, 15,
+ax_anim 2, 0, 33, 0, 20, 0, 20,
+ax_anim 2, 1, 33, -1, 20, -1, 20,
+ax_anim 2, 0, 33, 0, 20, 0, 20,
+ax_anim 2, 0, 33, -1, 20, -1, 20,
+ax_anim 2, 0, 33, 0, 20, 0, 20,
+ax_anim 2, 0, 33, -1, 20, -1, 20,
+ax_anim 2, 0, 34, 0, 7, 0, 15,
+ax_anim 2, 0, 34, 0, 1, 0, 9,
+ax_anim_terminator
+sElectrodeAnims_2_2:
+ax_anim 2, 0, 37, -2, -2, -2, -2,
+ax_anim 2, 0, 37, -3, -3, -3, -3,
+ax_anim 6, 0, 37, -4, -4, -4, -4,
+ax_anim 1, 2, 36, -1, -1, -1, -1,
+ax_anim 2, 0, 36, 15, 15, 15, 15,
+ax_anim 2, 0, 36, 20, 20, 20, 20,
+ax_anim 2, 1, 36, 19, 21, 19, 21,
+ax_anim 2, 0, 36, 20, 20, 20, 20,
+ax_anim 2, 0, 36, 19, 21, 19, 21,
+ax_anim 2, 0, 36, 20, 20, 20, 20,
+ax_anim 2, 0, 36, 19, 21, 19, 21,
+ax_anim 2, 0, 37, 16, 9, 16, 16,
+ax_anim 2, 0, 37, 6, 0, 6, 6,
+ax_anim_terminator
+sElectrodeAnims_2_3:
+ax_anim 2, 0, 40, -2, 0, -2, 0,
+ax_anim 2, 0, 40, -3, 0, -3, 0,
+ax_anim 6, 0, 40, -4, 0, -4, 0,
+ax_anim 1, 2, 39, -1, 0, -1, 0,
+ax_anim 2, 0, 39, 15, 0, 15, 0,
+ax_anim 2, 0, 39, 20, 0, 20, 0,
+ax_anim 2, 1, 39, 20, 1, 20, 1,
+ax_anim 2, 0, 39, 20, 0, 20, 0,
+ax_anim 2, 0, 39, 20, 1, 20, 1,
+ax_anim 2, 0, 39, 20, 0, 20, 0,
+ax_anim 2, 0, 39, 20, 1, 20, 1,
+ax_anim 2, 0, 40, 14, -5, 14, 0,
+ax_anim 2, 0, 40, 6, -5, 6, 0,
+ax_anim_terminator
+sElectrodeAnims_2_4:
+ax_anim 2, 0, 43, -2, 2, -2, 2,
+ax_anim 2, 0, 43, -3, 3, -3, 3,
+ax_anim 6, 0, 43, -4, 4, -4, 4,
+ax_anim 1, 2, 42, -1, 1, -1, 1,
+ax_anim 2, 0, 42, 15, -15, 15, -15,
+ax_anim 2, 0, 42, 20, -20, 20, -20,
+ax_anim 2, 1, 42, 19, -21, 19, -21,
+ax_anim 2, 0, 42, 20, -20, 20, -20,
+ax_anim 2, 0, 42, 19, -21, 19, -21,
+ax_anim 2, 0, 42, 20, -20, 20, -20,
+ax_anim 2, 0, 42, 19, -21, 19, -21,
+ax_anim 2, 0, 43, 6, -16, 6, -6,
+ax_anim 2, 0, 43, 1, -5, 1, -1,
+ax_anim_terminator
+sElectrodeAnims_2_5:
+ax_anim 2, 0, 46, 0, 2, 0, 2,
+ax_anim 2, 0, 46, 0, 3, 0, 3,
+ax_anim 6, 0, 46, 0, 4, 0, 4,
+ax_anim 1, 2, 45, 0, 1, 0, 1,
+ax_anim 2, 0, 45, 0, -15, 0, -15,
+ax_anim 2, 0, 45, 0, -20, 0, -20,
+ax_anim 2, 1, 45, -1, -20, -1, -20,
+ax_anim 2, 0, 45, 0, -20, 0, -20,
+ax_anim 2, 0, 45, -1, -20, -1, -20,
+ax_anim 2, 0, 45, 0, -20, 0, -20,
+ax_anim 2, 0, 45, -1, -20, -1, -20,
+ax_anim 2, 0, 46, 0, -17, 0, -14,
+ax_anim 2, 0, 46, 0, -8, 0, -4,
+ax_anim_terminator
+sElectrodeAnims_2_6:
+ax_anim 2, 0, 49, 2, 2, 2, 2,
+ax_anim 2, 0, 49, 3, 3, 3, 3,
+ax_anim 6, 0, 49, 4, 4, 4, 4,
+ax_anim 1, 2, 48, 1, 1, 1, 1,
+ax_anim 2, 0, 48, -15, -15, -15, -15,
+ax_anim 2, 0, 48, -20, -20, -20, -20,
+ax_anim 2, 1, 48, -19, -21, -19, -21,
+ax_anim 2, 0, 48, -20, -20, -20, -20,
+ax_anim 2, 0, 48, -19, -21, -19, -21,
+ax_anim 2, 0, 48, -20, -20, -20, -20,
+ax_anim 2, 0, 48, -19, -21, -19, -21,
+ax_anim 2, 0, 49, -6, -16, -6, -6,
+ax_anim 2, 0, 49, -1, -5, -1, -1,
+ax_anim_terminator
+sElectrodeAnims_2_7:
+ax_anim 2, 0, 52, 2, 0, 2, 0,
+ax_anim 2, 0, 52, 3, 0, 3, 0,
+ax_anim 6, 0, 52, 4, 0, 4, 0,
+ax_anim 1, 2, 51, 1, 0, 1, 0,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 52, -14, -5, -14, 0,
+ax_anim 2, 0, 52, -6, -5, -6, 0,
+ax_anim_terminator
+sElectrodeAnims_2_8:
+ax_anim 2, 0, 55, 2, -2, 2, -2,
+ax_anim 2, 0, 55, 3, -3, 3, -3,
+ax_anim 6, 0, 55, 4, -4, 4, -4,
+ax_anim 1, 2, 54, 1, -1, 1, -1,
+ax_anim 2, 0, 54, -15, 15, -15, 15,
+ax_anim 2, 0, 54, -20, 20, -20, 20,
+ax_anim 2, 1, 54, -19, 21, -19, 21,
+ax_anim 2, 0, 54, -20, 20, -20, 20,
+ax_anim 2, 0, 54, -19, 21, -19, 21,
+ax_anim 2, 0, 54, -20, 20, -20, 20,
+ax_anim 2, 0, 54, -19, 21, -19, 21,
+ax_anim 2, 0, 55, -16, 9, -16, 16,
+ax_anim 2, 0, 55, -6, 0, -6, 6,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_3_1:
+ax_anim 2, 0, 66, 0, -2, 0, -2,
+ax_anim 2, 0, 66, 0, -3, 0, -3,
+ax_anim 6, 0, 66, 0, -4, 0, -4,
+ax_anim 1, 2, 65, 0, -1, 0, -1,
+ax_anim 2, 0, 65, 0, 15, 0, 15,
+ax_anim 2, 0, 65, 0, 20, 0, 20,
+ax_anim 2, 1, 65, -1, 20, -1, 20,
+ax_anim 2, 0, 65, 0, 20, 0, 20,
+ax_anim 2, 0, 65, -1, 20, -1, 20,
+ax_anim 2, 0, 65, 0, 20, 0, 20,
+ax_anim 2, 0, 65, -1, 20, -1, 20,
+ax_anim 2, 0, 66, 0, 7, 0, 15,
+ax_anim 2, 0, 66, 0, 1, 0, 9,
+ax_anim_terminator
+sElectrodeAnims_3_2:
+ax_anim 2, 0, 69, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -3, -3, -3, -3,
+ax_anim 6, 0, 69, -4, -4, -4, -4,
+ax_anim 1, 2, 68, -1, -1, -1, -1,
+ax_anim 2, 0, 68, 15, 15, 15, 15,
+ax_anim 2, 0, 68, 20, 20, 20, 20,
+ax_anim 2, 1, 68, 19, 21, 19, 21,
+ax_anim 2, 0, 68, 20, 20, 20, 20,
+ax_anim 2, 0, 68, 19, 21, 19, 21,
+ax_anim 2, 0, 68, 20, 20, 20, 20,
+ax_anim 2, 0, 68, 19, 21, 19, 21,
+ax_anim 2, 0, 69, 16, 9, 16, 16,
+ax_anim 2, 0, 69, 6, 0, 6, 6,
+ax_anim_terminator
+sElectrodeAnims_3_3:
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim 6, 0, 72, -4, 0, -4, 0,
+ax_anim 1, 2, 71, -1, 0, -1, 0,
+ax_anim 2, 0, 71, 15, 0, 15, 0,
+ax_anim 2, 0, 71, 20, 0, 20, 0,
+ax_anim 2, 1, 71, 20, 1, 20, 1,
+ax_anim 2, 0, 71, 20, 0, 20, 0,
+ax_anim 2, 0, 71, 20, 1, 20, 1,
+ax_anim 2, 0, 71, 20, 0, 20, 0,
+ax_anim 2, 0, 71, 20, 1, 20, 1,
+ax_anim 2, 0, 72, 14, -5, 14, 0,
+ax_anim 2, 0, 72, 6, -5, 6, 0,
+ax_anim_terminator
+sElectrodeAnims_3_4:
+ax_anim 2, 0, 75, -2, 2, -2, 2,
+ax_anim 2, 0, 75, -3, 3, -3, 3,
+ax_anim 6, 0, 75, -4, 4, -4, 4,
+ax_anim 1, 2, 74, -1, 1, -1, 1,
+ax_anim 2, 0, 74, 15, -15, 15, -15,
+ax_anim 2, 0, 74, 20, -20, 20, -20,
+ax_anim 2, 1, 74, 19, -21, 19, -21,
+ax_anim 2, 0, 74, 20, -20, 20, -20,
+ax_anim 2, 0, 74, 19, -21, 19, -21,
+ax_anim 2, 0, 74, 20, -20, 20, -20,
+ax_anim 2, 0, 74, 19, -21, 19, -21,
+ax_anim 2, 0, 75, 6, -16, 6, -6,
+ax_anim 2, 0, 75, 1, -5, 1, -1,
+ax_anim_terminator
+sElectrodeAnims_3_5:
+ax_anim 2, 0, 78, 0, 2, 0, 2,
+ax_anim 2, 0, 78, 0, 3, 0, 3,
+ax_anim 6, 0, 78, 0, 4, 0, 4,
+ax_anim 1, 2, 77, 0, 1, 0, 1,
+ax_anim 2, 0, 77, 0, -15, 0, -15,
+ax_anim 2, 0, 77, 0, -20, 0, -20,
+ax_anim 2, 1, 77, -1, -20, -1, -20,
+ax_anim 2, 0, 77, 0, -20, 0, -20,
+ax_anim 2, 0, 77, -1, -20, -1, -20,
+ax_anim 2, 0, 77, 0, -20, 0, -20,
+ax_anim 2, 0, 77, -1, -20, -1, -20,
+ax_anim 2, 0, 78, 0, -17, 0, -14,
+ax_anim 2, 0, 78, 0, -8, 0, -4,
+ax_anim_terminator
+sElectrodeAnims_3_6:
+ax_anim 2, 0, 81, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 6, 0, 81, 4, 4, 4, 4,
+ax_anim 1, 2, 80, 1, 1, 1, 1,
+ax_anim 2, 0, 80, -15, -15, -15, -15,
+ax_anim 2, 0, 80, -20, -20, -20, -20,
+ax_anim 2, 1, 80, -19, -21, -19, -21,
+ax_anim 2, 0, 80, -20, -20, -20, -20,
+ax_anim 2, 0, 80, -19, -21, -19, -21,
+ax_anim 2, 0, 80, -20, -20, -20, -20,
+ax_anim 2, 0, 80, -19, -21, -19, -21,
+ax_anim 2, 0, 81, -6, -16, -6, -6,
+ax_anim 2, 0, 81, -1, -5, -1, -1,
+ax_anim_terminator
+sElectrodeAnims_3_7:
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 2, 0, 84, 3, 0, 3, 0,
+ax_anim 6, 0, 84, 4, 0, 4, 0,
+ax_anim 1, 2, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 1, 83, -20, 1, -20, 1,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 0, 83, -20, 1, -20, 1,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 0, 83, -20, 1, -20, 1,
+ax_anim 2, 0, 84, -14, -5, -14, 0,
+ax_anim 2, 0, 84, -6, -5, -6, 0,
+ax_anim_terminator
+sElectrodeAnims_3_8:
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 6, 0, 87, 4, -4, 4, -4,
+ax_anim 1, 2, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, -15, 15, -15, 15,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 1, 86, -19, 21, -19, 21,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 86, -19, 21, -19, 21,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 86, -19, 21, -19, 21,
+ax_anim 2, 0, 87, -16, 9, -16, 16,
+ax_anim 2, 0, 87, -6, 0, -6, 6,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_4_1:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_4_2:
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_4_3:
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 1, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_4_4:
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_4_5:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 1, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_4_6:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_4_7:
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_4_8:
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 1, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_5_1:
+ax_anim 1, 0, 111, 5, 0, 5, 0,
+ax_anim 1, 0, 110, 4, -2, 4, -2,
+ax_anim 1, 0, 109, 2, -4, 2, -3,
+ax_anim 1, 0, 108, 0, -4, 0, -3,
+ax_anim 1, 0, 107, -2, -5, -2, -3,
+ax_anim 1, 0, 106, -4, -4, -4, -2,
+ax_anim 1, 0, 105, -5, -3, -5, 0,
+ax_anim 1, 0, 104, -4, -1, -4, 2,
+ax_anim 1, 0, 111, -2, -1, -2, 3,
+ax_anim 1, 0, 110, 0, -1, 0, 3,
+ax_anim 1, 0, 109, 2, -2, 2, 3,
+ax_anim 1, 0, 108, 4, -3, 4, 2,
+ax_anim 1, 0, 107, 5, -6, 5, 0,
+ax_anim 1, 0, 106, 4, -8, 4, -2,
+ax_anim 1, 0, 105, 2, -10, 2, -3,
+ax_anim 6, 2, 104, 0, -10, 0, -3,
+ax_anim 1, 0, 104, 0, -8, 0, -3,
+ax_anim 1, 0, 104, 0, -4, 0, -2,
+ax_anim 3, 1, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_5_2:
+ax_anim 1, 0, 110, 5, 0, 5, 0,
+ax_anim 1, 0, 109, 4, -2, 4, -2,
+ax_anim 1, 0, 108, 2, -4, 2, -3,
+ax_anim 1, 0, 107, 0, -4, 0, -3,
+ax_anim 1, 0, 106, -2, -5, -2, -3,
+ax_anim 1, 0, 105, -4, -4, -4, -2,
+ax_anim 1, 0, 104, -5, -3, -5, 0,
+ax_anim 1, 0, 111, -4, -1, -4, 2,
+ax_anim 1, 0, 110, -2, -1, -2, 3,
+ax_anim 1, 0, 109, 0, -1, 0, 3,
+ax_anim 1, 0, 108, 2, -2, 2, 3,
+ax_anim 1, 0, 107, 4, -3, 4, 2,
+ax_anim 1, 0, 106, 5, -6, 5, 0,
+ax_anim 1, 0, 105, 4, -8, 4, -2,
+ax_anim 1, 0, 104, 2, -10, 2, -3,
+ax_anim 6, 2, 111, 0, -10, 0, -3,
+ax_anim 1, 0, 111, 0, -8, 0, -3,
+ax_anim 1, 0, 111, 0, -4, 0, -2,
+ax_anim 3, 1, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 1, 0, 111, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_5_3:
+ax_anim 1, 0, 109, 5, 0, 5, 0,
+ax_anim 1, 0, 108, 4, -2, 4, -2,
+ax_anim 1, 0, 107, 2, -4, 2, -3,
+ax_anim 1, 0, 106, 0, -4, 0, -3,
+ax_anim 1, 0, 105, -2, -5, -2, -3,
+ax_anim 1, 0, 104, -4, -4, -4, -2,
+ax_anim 1, 0, 111, -5, -3, -5, 0,
+ax_anim 1, 0, 110, -4, -1, -4, 2,
+ax_anim 1, 0, 109, -2, -1, -2, 3,
+ax_anim 1, 0, 108, 0, -1, 0, 3,
+ax_anim 1, 0, 107, 2, -2, 2, 3,
+ax_anim 1, 0, 106, 4, -3, 4, 2,
+ax_anim 1, 0, 105, 5, -6, 5, 0,
+ax_anim 1, 0, 104, 4, -8, 4, -2,
+ax_anim 1, 0, 111, 2, -10, 2, -3,
+ax_anim 6, 2, 110, 0, -10, 0, -3,
+ax_anim 1, 0, 110, 0, -8, 0, -3,
+ax_anim 1, 0, 110, 0, -4, 0, -2,
+ax_anim 3, 1, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_5_4:
+ax_anim 1, 0, 108, 5, 0, 5, 0,
+ax_anim 1, 0, 107, 4, -2, 4, -2,
+ax_anim 1, 0, 106, 2, -4, 2, -3,
+ax_anim 1, 0, 105, 0, -4, 0, -3,
+ax_anim 1, 0, 104, -2, -5, -2, -3,
+ax_anim 1, 0, 111, -4, -4, -4, -2,
+ax_anim 1, 0, 110, -5, -3, -5, 0,
+ax_anim 1, 0, 109, -4, -1, -4, 2,
+ax_anim 1, 0, 108, -2, -1, -2, 3,
+ax_anim 1, 0, 107, 0, -1, 0, 3,
+ax_anim 1, 0, 106, 2, -2, 2, 3,
+ax_anim 1, 0, 105, 4, -3, 4, 2,
+ax_anim 1, 0, 104, 5, -6, 5, 0,
+ax_anim 1, 0, 111, 4, -8, 4, -2,
+ax_anim 1, 0, 110, 2, -10, 2, -3,
+ax_anim 6, 2, 109, 0, -10, 0, -3,
+ax_anim 1, 0, 109, 0, -8, 0, -3,
+ax_anim 1, 0, 109, 0, -4, 0, -2,
+ax_anim 3, 1, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 1, 0, 109, 0, -3, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_5_5:
+ax_anim 1, 0, 107, 5, 0, 5, 0,
+ax_anim 1, 0, 106, 4, -2, 4, -2,
+ax_anim 1, 0, 105, 2, -4, 2, -3,
+ax_anim 1, 0, 104, 0, -4, 0, -3,
+ax_anim 1, 0, 111, -2, -5, -2, -3,
+ax_anim 1, 0, 110, -4, -4, -4, -2,
+ax_anim 1, 0, 109, -5, -3, -5, 0,
+ax_anim 1, 0, 108, -4, -1, -4, 2,
+ax_anim 1, 0, 107, -2, -1, -2, 3,
+ax_anim 1, 0, 106, 0, -1, 0, 3,
+ax_anim 1, 0, 105, 2, -2, 2, 3,
+ax_anim 1, 0, 104, 4, -3, 4, 2,
+ax_anim 1, 0, 111, 5, -6, 5, 0,
+ax_anim 1, 0, 110, 4, -8, 4, -2,
+ax_anim 1, 0, 109, 2, -10, 2, -3,
+ax_anim 6, 2, 108, 0, -10, 0, -3,
+ax_anim 1, 0, 108, 0, -8, 0, -3,
+ax_anim 1, 0, 108, 0, -4, 0, -2,
+ax_anim 3, 1, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 1, 0, 108, 0, -3, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_5_6:
+ax_anim 1, 0, 106, 5, 0, 5, 0,
+ax_anim 1, 0, 105, 4, -2, 4, -2,
+ax_anim 1, 0, 104, 2, -4, 2, -3,
+ax_anim 1, 0, 111, 0, -4, 0, -3,
+ax_anim 1, 0, 110, -2, -5, -2, -3,
+ax_anim 1, 0, 109, -4, -4, -4, -2,
+ax_anim 1, 0, 108, -5, -3, -5, 0,
+ax_anim 1, 0, 107, -4, -1, -4, 2,
+ax_anim 1, 0, 106, -2, -1, -2, 3,
+ax_anim 1, 0, 105, 0, -1, 0, 3,
+ax_anim 1, 0, 104, 2, -2, 2, 3,
+ax_anim 1, 0, 111, 4, -3, 4, 2,
+ax_anim 1, 0, 110, 5, -6, 5, 0,
+ax_anim 1, 0, 109, 4, -8, 4, -2,
+ax_anim 1, 0, 108, 2, -10, 2, -3,
+ax_anim 6, 2, 107, 0, -10, 0, -3,
+ax_anim 1, 0, 107, 0, -8, 0, -3,
+ax_anim 1, 0, 107, 0, -4, 0, -2,
+ax_anim 3, 1, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_5_7:
+ax_anim 1, 0, 105, 5, 0, 5, 0,
+ax_anim 1, 0, 104, 4, -2, 4, -2,
+ax_anim 1, 0, 111, 2, -4, 2, -3,
+ax_anim 1, 0, 110, 0, -4, 0, -3,
+ax_anim 1, 0, 109, -2, -5, -2, -3,
+ax_anim 1, 0, 108, -4, -4, -4, -2,
+ax_anim 1, 0, 107, -5, -3, -5, 0,
+ax_anim 1, 0, 106, -4, -1, -4, 2,
+ax_anim 1, 0, 105, -2, -1, -2, 3,
+ax_anim 1, 0, 104, 0, -1, 0, 3,
+ax_anim 1, 0, 111, 2, -2, 2, 3,
+ax_anim 1, 0, 110, 4, -3, 4, 2,
+ax_anim 1, 0, 109, 5, -6, 5, 0,
+ax_anim 1, 0, 108, 4, -8, 4, -2,
+ax_anim 1, 0, 107, 2, -10, 2, -3,
+ax_anim 6, 2, 106, 0, -10, 0, -3,
+ax_anim 1, 0, 106, 0, -8, 0, -3,
+ax_anim 1, 0, 106, 0, -4, 0, -2,
+ax_anim 3, 1, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 1, 0, 106, 0, -3, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_5_8:
+ax_anim 1, 0, 104, 5, 0, 5, 0,
+ax_anim 1, 0, 111, 4, -2, 4, -2,
+ax_anim 1, 0, 110, 2, -4, 2, -3,
+ax_anim 1, 0, 109, 0, -4, 0, -3,
+ax_anim 1, 0, 108, -2, -5, -2, -3,
+ax_anim 1, 0, 107, -4, -4, -4, -2,
+ax_anim 1, 0, 106, -5, -3, -5, 0,
+ax_anim 1, 0, 105, -4, -1, -4, 2,
+ax_anim 1, 0, 104, -2, -1, -2, 3,
+ax_anim 1, 0, 111, 0, -1, 0, 3,
+ax_anim 1, 0, 110, 2, -2, 2, 3,
+ax_anim 1, 0, 109, 4, -3, 4, 2,
+ax_anim 1, 0, 108, 5, -6, 5, 0,
+ax_anim 1, 0, 107, 4, -8, 4, -2,
+ax_anim 1, 0, 106, 2, -10, 2, -3,
+ax_anim 6, 2, 105, 0, -10, 0, -3,
+ax_anim 1, 0, 105, 0, -8, 0, -3,
+ax_anim 1, 0, 105, 0, -4, 0, -2,
+ax_anim 3, 1, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 1, 0, 105, 0, -3, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sElectrodeAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sElectrodeAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sElectrodeAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sElectrodeAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sElectrodeAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sElectrodeAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sElectrodeAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_8_1:
+ax_anim 10, 0, 122, 0, 0, 0, 0,
+ax_anim 18, 0, 123, 0, 1, 0, 1,
+ax_anim 10, 0, 122, 0, 0, 0, 0,
+ax_anim 18, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sElectrodeAnims_8_2:
+ax_anim 10, 0, 125, 0, 0, 0, 0,
+ax_anim 18, 0, 126, 1, 1, 1, 1,
+ax_anim 10, 0, 125, 0, 0, 0, 0,
+ax_anim 18, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+sElectrodeAnims_8_3:
+ax_anim 10, 0, 128, 0, 0, 0, 0,
+ax_anim 18, 0, 129, 1, 0, 1, 0,
+ax_anim 10, 0, 128, 0, 0, 0, 0,
+ax_anim 18, 0, 130, -1, 0, -1, 0,
+ax_anim_terminator
+sElectrodeAnims_8_4:
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 18, 0, 132, 1, -1, 1, -1,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 18, 0, 133, -1, 1, -1, 1,
+ax_anim_terminator
+sElectrodeAnims_8_5:
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 18, 0, 135, 0, -1, 0, -1,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 18, 0, 136, 0, 1, 0, 1,
+ax_anim_terminator
+sElectrodeAnims_8_6:
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 18, 0, 138, -1, -1, -1, -1,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 18, 0, 139, 1, 1, 1, 1,
+ax_anim_terminator
+sElectrodeAnims_8_7:
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 18, 0, 141, -1, 0, -1, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 18, 0, 142, 1, 0, 1, 0,
+ax_anim_terminator
+sElectrodeAnims_8_8:
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 18, 0, 144, -1, 1, -1, 1,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 18, 0, 145, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 16, 7, 16,
+ax_anim 3, 0, 158, 0, 20, 0, 20,
+ax_anim 2, 3, 159, -7, 16, -7, 16,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 20, 12, 20, 12,
+ax_anim 3, 0, 157, 20, 20, 20, 20,
+ax_anim 2, 3, 158, 11, 21, 11, 21,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 18, -5, 18, -5,
+ax_anim 3, 0, 156, 21, -2, 21, -2,
+ax_anim 2, 3, 157, 18, 4, 18, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 3, -17, 3, -17,
+ax_anim 2, 0, 154, 12, -22, 12, -22,
+ax_anim 3, 0, 155, 20, -22, 20, -22,
+ax_anim 2, 3, 156, 21, -13, 21, -13,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -3, -17, -3, -17,
+ax_anim 2, 0, 154, -12, -22, -12, -22,
+ax_anim 3, 0, 161, -20, -22, -20, -22,
+ax_anim 2, 3, 160, -21, -13, -21, -13,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -18, -5, -18, -5,
+ax_anim 3, 0, 160, -21, -2, -21, -2,
+ax_anim 2, 3, 159, -18, 4, -18, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -20, 12, -20, 12,
+ax_anim 3, 0, 159, -20, 20, -20, 20,
+ax_anim 2, 3, 158, -11, 21, -11, 21,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElectrodeAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sElectrodeGfx1:
+.incbin "baserom.gba", 0x94F8E4, 0x200
+sElectrodeSprites1:
+ax_sprite sElectrodeGfx1, 0x200
+ax_sprite_terminator
+sElectrodeGfx2:
+.incbin "baserom.gba", 0x94FAF4, 0x200
+sElectrodeSprites2:
+ax_sprite sElectrodeGfx2, 0x200
+ax_sprite_terminator
+sElectrodeGfx3:
+.incbin "baserom.gba", 0x94FD04, 0x200
+sElectrodeSprites3:
+ax_sprite sElectrodeGfx3, 0x200
+ax_sprite_terminator
+sElectrodeGfx4:
+.incbin "baserom.gba", 0x94FF14, 0x200
+sElectrodeSprites4:
+ax_sprite sElectrodeGfx4, 0x200
+ax_sprite_terminator
+sElectrodeGfx5:
+.incbin "baserom.gba", 0x950124, 0x200
+sElectrodeSprites5:
+ax_sprite sElectrodeGfx5, 0x200
+ax_sprite_terminator
+sElectrodeGfx6:
+.incbin "baserom.gba", 0x950334, 0x200
+sElectrodeSprites6:
+ax_sprite sElectrodeGfx6, 0x200
+ax_sprite_terminator
+sElectrodeGfx7:
+.incbin "baserom.gba", 0x950544, 0x200
+sElectrodeSprites7:
+ax_sprite sElectrodeGfx7, 0x200
+ax_sprite_terminator
+sElectrodeGfx8:
+.incbin "baserom.gba", 0x950754, 0x200
+sElectrodeSprites8:
+ax_sprite sElectrodeGfx8, 0x200
+ax_sprite_terminator
+sElectrodeGfx9:
+.incbin "baserom.gba", 0x950964, 0x200
+sElectrodeSprites9:
+ax_sprite sElectrodeGfx9, 0x200
+ax_sprite_terminator
+sElectrodeGfx10:
+.incbin "baserom.gba", 0x950B74, 0x200
+sElectrodeSprites10:
+ax_sprite sElectrodeGfx10, 0x200
+ax_sprite_terminator
+sElectrodeGfx11:
+.incbin "baserom.gba", 0x950D84, 0x200
+sElectrodeSprites11:
+ax_sprite sElectrodeGfx11, 0x200
+ax_sprite_terminator
+sElectrodeGfx12:
+.incbin "baserom.gba", 0x950F94, 0x200
+sElectrodeSprites12:
+ax_sprite sElectrodeGfx12, 0x200
+ax_sprite_terminator
+sElectrodeGfx13:
+.incbin "baserom.gba", 0x9511A4, 0x200
+sElectrodeSprites13:
+ax_sprite sElectrodeGfx13, 0x200
+ax_sprite_terminator
+sElectrodeGfx14:
+.incbin "baserom.gba", 0x9513B4, 0x200
+sElectrodeSprites14:
+ax_sprite sElectrodeGfx14, 0x200
+ax_sprite_terminator
+sElectrodeGfx15:
+.incbin "baserom.gba", 0x9515C4, 0x200
+sElectrodeSprites15:
+ax_sprite sElectrodeGfx15, 0x200
+ax_sprite_terminator
+sElectrodeGfx16:
+.incbin "baserom.gba", 0x9517D4, 0x200
+sElectrodeSprites16:
+ax_sprite sElectrodeGfx16, 0x200
+ax_sprite_terminator
+sElectrodeGfx17:
+.incbin "baserom.gba", 0x9519E4, 0x200
+sElectrodeSprites17:
+ax_sprite sElectrodeGfx17, 0x200
+ax_sprite_terminator
+sElectrodeGfx18:
+.incbin "baserom.gba", 0x951BF4, 0x200
+sElectrodeSprites18:
+ax_sprite sElectrodeGfx18, 0x200
+ax_sprite_terminator
+sElectrodeGfx19:
+.incbin "baserom.gba", 0x951E04, 0x200
+sElectrodeSprites19:
+ax_sprite sElectrodeGfx19, 0x200
+ax_sprite_terminator
+sElectrodeGfx20:
+.incbin "baserom.gba", 0x952014, 0x200
+sElectrodeSprites20:
+ax_sprite sElectrodeGfx20, 0x200
+ax_sprite_terminator
+sElectrodeGfx21:
+.incbin "baserom.gba", 0x952224, 0x200
+sElectrodeSprites21:
+ax_sprite sElectrodeGfx21, 0x200
+ax_sprite_terminator
+sElectrodeGfx22:
+.incbin "baserom.gba", 0x952434, 0x200
+sElectrodeSprites22:
+ax_sprite sElectrodeGfx22, 0x200
+ax_sprite_terminator
+sElectrodeGfx23:
+.incbin "baserom.gba", 0x952644, 0x200
+sElectrodeSprites23:
+ax_sprite sElectrodeGfx23, 0x200
+ax_sprite_terminator
+sElectrodeGfx24:
+.incbin "baserom.gba", 0x952854, 0x200
+sElectrodeSprites24:
+ax_sprite sElectrodeGfx24, 0x200
+ax_sprite_terminator
+sElectrodeGfx25:
+.incbin "baserom.gba", 0x952A64, 0x200
+sElectrodeSprites25:
+ax_sprite sElectrodeGfx25, 0x200
+ax_sprite_terminator
+sElectrodeGfx26:
+.incbin "baserom.gba", 0x952C74, 0x200
+sElectrodeSprites26:
+ax_sprite sElectrodeGfx26, 0x200
+ax_sprite_terminator
+sElectrodeGfx27:
+.incbin "baserom.gba", 0x952E84, 0x200
+sElectrodeSprites27:
+ax_sprite sElectrodeGfx27, 0x200
+ax_sprite_terminator
+sElectrodeGfx28:
+.incbin "baserom.gba", 0x953094, 0x200
+sElectrodeSprites28:
+ax_sprite sElectrodeGfx28, 0x200
+ax_sprite_terminator
+sElectrodeGfx29:
+.incbin "baserom.gba", 0x9532A4, 0x200
+sElectrodeSprites29:
+ax_sprite sElectrodeGfx29, 0x200
+ax_sprite_terminator
+sElectrodeGfx30:
+.incbin "baserom.gba", 0x9534B4, 0x200
+sElectrodeSprites30:
+ax_sprite sElectrodeGfx30, 0x200
+ax_sprite_terminator
+sElectrodeGfx31:
+.incbin "baserom.gba", 0x9536C4, 0x200
+sElectrodeSprites31:
+ax_sprite sElectrodeGfx31, 0x200
+ax_sprite_terminator
+sAxPosesElectrode:
+.4byte sElectrodePose1
+.4byte sElectrodePose2
+.4byte sElectrodePose3
+.4byte sElectrodePose4
+.4byte sElectrodePose5
+.4byte sElectrodePose6
+.4byte sElectrodePose7
+.4byte sElectrodePose8
+.4byte sElectrodePose9
+.4byte sElectrodePose10
+.4byte sElectrodePose11
+.4byte sElectrodePose12
+.4byte sElectrodePose13
+.4byte sElectrodePose14
+.4byte sElectrodePose15
+.4byte sElectrodePose16
+.4byte sElectrodePose17
+.4byte sElectrodePose18
+.4byte sElectrodePose19
+.4byte sElectrodePose20
+.4byte sElectrodePose21
+.4byte sElectrodePose22
+.4byte sElectrodePose23
+.4byte sElectrodePose24
+.4byte sElectrodePose25
+.4byte sElectrodePose26
+.4byte sElectrodePose27
+.4byte sElectrodePose28
+.4byte sElectrodePose29
+.4byte sElectrodePose30
+.4byte sElectrodePose31
+.4byte sElectrodePose32
+.4byte sElectrodePose33
+.4byte sElectrodePose34
+.4byte sElectrodePose35
+.4byte sElectrodePose36
+.4byte sElectrodePose37
+.4byte sElectrodePose38
+.4byte sElectrodePose39
+.4byte sElectrodePose40
+.4byte sElectrodePose41
+.4byte sElectrodePose42
+.4byte sElectrodePose43
+.4byte sElectrodePose44
+.4byte sElectrodePose45
+.4byte sElectrodePose46
+.4byte sElectrodePose47
+.4byte sElectrodePose48
+.4byte sElectrodePose49
+.4byte sElectrodePose50
+.4byte sElectrodePose51
+.4byte sElectrodePose52
+.4byte sElectrodePose53
+.4byte sElectrodePose54
+.4byte sElectrodePose55
+.4byte sElectrodePose56
+.4byte sElectrodePose57
+.4byte sElectrodePose58
+.4byte sElectrodePose59
+.4byte sElectrodePose60
+.4byte sElectrodePose61
+.4byte sElectrodePose62
+.4byte sElectrodePose63
+.4byte sElectrodePose64
+.4byte sElectrodePose65
+.4byte sElectrodePose66
+.4byte sElectrodePose67
+.4byte sElectrodePose68
+.4byte sElectrodePose69
+.4byte sElectrodePose70
+.4byte sElectrodePose71
+.4byte sElectrodePose72
+.4byte sElectrodePose73
+.4byte sElectrodePose74
+.4byte sElectrodePose75
+.4byte sElectrodePose76
+.4byte sElectrodePose77
+.4byte sElectrodePose78
+.4byte sElectrodePose79
+.4byte sElectrodePose80
+.4byte sElectrodePose81
+.4byte sElectrodePose82
+.4byte sElectrodePose83
+.4byte sElectrodePose84
+.4byte sElectrodePose85
+.4byte sElectrodePose86
+.4byte sElectrodePose87
+.4byte sElectrodePose88
+.4byte sElectrodePose89
+.4byte sElectrodePose90
+.4byte sElectrodePose91
+.4byte sElectrodePose92
+.4byte sElectrodePose93
+.4byte sElectrodePose94
+.4byte sElectrodePose95
+.4byte sElectrodePose96
+.4byte sElectrodePose97
+.4byte sElectrodePose98
+.4byte sElectrodePose99
+.4byte sElectrodePose100
+.4byte sElectrodePose101
+.4byte sElectrodePose102
+.4byte sElectrodePose103
+.4byte sElectrodePose104
+.4byte sElectrodePose105
+.4byte sElectrodePose106
+.4byte sElectrodePose107
+.4byte sElectrodePose108
+.4byte sElectrodePose109
+.4byte sElectrodePose110
+.4byte sElectrodePose111
+.4byte sElectrodePose112
+.4byte sElectrodePose113
+.4byte sElectrodePose114
+.4byte sElectrodePose115
+.4byte sElectrodePose116
+.4byte sElectrodePose117
+.4byte sElectrodePose118
+.4byte sElectrodePose119
+.4byte sElectrodePose120
+.4byte sElectrodePose121
+.4byte sElectrodePose122
+.4byte sElectrodePose123
+.4byte sElectrodePose124
+.4byte sElectrodePose125
+.4byte sElectrodePose126
+.4byte sElectrodePose127
+.4byte sElectrodePose128
+.4byte sElectrodePose129
+.4byte sElectrodePose130
+.4byte sElectrodePose131
+.4byte sElectrodePose132
+.4byte sElectrodePose133
+.4byte sElectrodePose134
+.4byte sElectrodePose135
+.4byte sElectrodePose136
+.4byte sElectrodePose137
+.4byte sElectrodePose138
+.4byte sElectrodePose139
+.4byte sElectrodePose140
+.4byte sElectrodePose141
+.4byte sElectrodePose142
+.4byte sElectrodePose143
+.4byte sElectrodePose144
+.4byte sElectrodePose145
+.4byte sElectrodePose146
+.4byte sElectrodePose147
+.4byte sElectrodePose148
+.4byte sElectrodePose149
+.4byte sElectrodePose150
+.4byte sElectrodePose151
+.4byte sElectrodePose152
+.4byte sElectrodePose153
+.4byte sElectrodePose154
+.4byte sElectrodePose155
+.4byte sElectrodePose156
+.4byte sElectrodePose157
+.4byte sElectrodePose158
+.4byte sElectrodePose159
+.4byte sElectrodePose160
+.4byte sElectrodePose161
+.4byte sElectrodePose162
+.4byte sElectrodePose163
+.4byte sElectrodePose164
+.4byte sElectrodePose165
+.4byte sElectrodePose166
+.4byte sElectrodePose167
+.4byte sElectrodePose168
+.4byte sElectrodePose169
+.4byte sElectrodePose170
+.4byte sElectrodePose171
+.4byte sElectrodePose172
+.4byte sElectrodePose173
+.4byte sElectrodePose174
+.4byte sElectrodePose175
+.4byte sElectrodePose176
+.4byte sElectrodePose177
+.4byte sElectrodePose178
+.4byte sElectrodePose179
+.4byte sElectrodePose180
+.4byte sElectrodePose181
+.4byte sElectrodePose182
+.4byte sElectrodePose183
+.4byte sElectrodePose184
+.4byte sElectrodePose185
+.4byte sElectrodePose186
+.4byte sElectrodePose187
+.4byte sElectrodePose188
+.4byte sElectrodePose189
+.4byte sElectrodePose190
+.4byte sElectrodePose191
+.4byte sElectrodePose192
+.4byte sElectrodePose193
+.4byte sElectrodePose194
+.4byte sElectrodePose195
+.4byte sElectrodePose196
+.4byte sElectrodePose197
+.4byte sElectrodePose198
+.4byte sElectrodePose199
+.4byte sElectrodePose200
+.4byte sElectrodePose201
+.4byte sElectrodePose202
+.4byte sElectrodePose203
+.4byte sElectrodePose204
+.4byte sElectrodePose205
+.4byte sElectrodePose206
+.4byte sElectrodePose207
+.4byte sElectrodePose208
+.4byte sElectrodePose209
+.4byte sElectrodePose210
+sAxPositionsElectrode:
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte    0,   -3, 	  -8,   -9, 	   8,   -9, 	   0,  -10
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    5,   -4, 	  -4,   -5, 	   3,  -12, 	   0,   -7
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    6,   -4, 	  -1,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    7,  -11, 	   4,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    0,  -16, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,  -12, 	   4,  -13, 	  -5,   -8, 	   0,   -9
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -7,   -5, 	  -4,  -13, 	  -2,   -3, 	   1,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte   -4,   -4, 	  -6,  -12, 	   2,   -5, 	   0,   -9
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte    0,   -3, 	  -8,   -9, 	   8,   -9, 	   0,  -10
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    5,   -4, 	  -4,   -5, 	   3,  -12, 	   0,   -7
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    6,   -4, 	  -1,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    7,  -11, 	   4,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    0,  -16, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,  -12, 	   4,  -13, 	  -5,   -8, 	   0,   -9
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -7,   -5, 	  -4,  -13, 	  -2,   -3, 	   1,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte   -4,   -4, 	  -6,  -12, 	   2,   -5, 	   0,   -9
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte    0,   -3, 	  -8,   -9, 	   8,   -9, 	   0,  -10
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    5,   -4, 	  -4,   -5, 	   3,  -12, 	   0,   -7
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    6,   -4, 	  -1,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    7,  -11, 	   4,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    0,  -16, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,  -12, 	   4,  -13, 	  -5,   -8, 	   0,   -9
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -7,   -5, 	  -4,  -13, 	  -2,   -3, 	   1,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte   -4,   -4, 	  -6,  -12, 	   2,   -5, 	   0,   -9
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    0,   -2, 	  -8,   -8, 	   8,   -8, 	   0,   -6
+.2byte    1,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -7
+.2byte    0,  -10, 	  -8,  -10, 	   8,  -10, 	   0,  -11
+.2byte   -1,  -11, 	   1,  -12, 	  -8,   -6, 	  -3,   -9
+.2byte    1,   -9, 	  -2,  -11, 	  -3,   -7, 	  -4,   -7
+.2byte    1,  -12, 	  -9,  -11, 	   1,   -6, 	  -4,   -5
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   1,   -6
+.2byte   -2,  -12, 	   8,  -11, 	  -2,   -6, 	   3,   -5
+.2byte   -2,   -9, 	   1,  -11, 	   2,   -7, 	   3,   -7
+.2byte    0,  -11, 	  -2,  -12, 	   7,   -6, 	   2,   -9
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte    0,   -3, 	  -8,   -9, 	   8,   -9, 	   0,  -10
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    5,   -4, 	  -4,   -5, 	   3,  -12, 	   0,   -7
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    6,   -4, 	  -1,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    7,  -11, 	   4,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    0,  -16, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,  -12, 	   4,  -13, 	  -5,   -8, 	   0,   -9
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -7,   -5, 	  -4,  -13, 	  -2,   -3, 	   1,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte   -4,   -4, 	  -6,  -12, 	   2,   -5, 	   0,   -9
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,   -3, 	  -8,   -9, 	   8,   -9, 	   0,  -10
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+.2byte    5,   -4, 	  -4,   -5, 	   3,  -12, 	   0,   -7
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    6,   -4, 	  -1,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    7,  -11, 	   4,   -4, 	  -2,  -13, 	   0,   -8
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -16, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -7,  -12, 	   4,  -13, 	  -5,   -8, 	   0,   -9
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -7,   -5, 	  -4,  -13, 	  -2,   -3, 	   1,   -8
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -4, 	  -6,  -12, 	   2,   -5, 	   0,   -9
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte    0,    0, 	  -8,   -7, 	   8,   -7, 	   0,   -9
+.2byte   -4,   -1, 	  -8,   -9, 	   3,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,  -10, 	  -1,   -2, 	   0,   -9
+.2byte   -7,   -8, 	   0,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    7,   -9, 	   4,   -6, 	  -1,  -15, 	   0,   -8
+.2byte    4,   -1, 	   1,   -5, 	   1,  -14, 	   0,   -8
+.2byte    3,   -1, 	  -3,   -6, 	   6,  -12, 	   0,   -8
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte   -5,   -2, 	  -8,  -10, 	   4,   -4, 	   0,   -8
+.2byte   -6,   -3, 	  -6,  -12, 	  -2,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   2,  -14, 	  -6,   -6, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    6,  -11, 	   4,   -5, 	  -1,  -13, 	  -1,   -9
+.2byte    5,   -2, 	   1,   -4, 	   1,  -13, 	   0,   -8
+.2byte    4,   -1, 	  -3,   -6, 	   4,  -14, 	   0,   -7
+sElectrodeAnimTable1:
+.4byte sElectrodeAnims_1_1
+.4byte sElectrodeAnims_1_2
+.4byte sElectrodeAnims_1_3
+.4byte sElectrodeAnims_1_4
+.4byte sElectrodeAnims_1_5
+.4byte sElectrodeAnims_1_6
+.4byte sElectrodeAnims_1_7
+.4byte sElectrodeAnims_1_8
+sElectrodeAnimTable2:
+.4byte sElectrodeAnims_2_1
+.4byte sElectrodeAnims_2_2
+.4byte sElectrodeAnims_2_3
+.4byte sElectrodeAnims_2_4
+.4byte sElectrodeAnims_2_5
+.4byte sElectrodeAnims_2_6
+.4byte sElectrodeAnims_2_7
+.4byte sElectrodeAnims_2_8
+sElectrodeAnimTable3:
+.4byte sElectrodeAnims_3_1
+.4byte sElectrodeAnims_3_2
+.4byte sElectrodeAnims_3_3
+.4byte sElectrodeAnims_3_4
+.4byte sElectrodeAnims_3_5
+.4byte sElectrodeAnims_3_6
+.4byte sElectrodeAnims_3_7
+.4byte sElectrodeAnims_3_8
+sElectrodeAnimTable4:
+.4byte sElectrodeAnims_4_1
+.4byte sElectrodeAnims_4_2
+.4byte sElectrodeAnims_4_3
+.4byte sElectrodeAnims_4_4
+.4byte sElectrodeAnims_4_5
+.4byte sElectrodeAnims_4_6
+.4byte sElectrodeAnims_4_7
+.4byte sElectrodeAnims_4_8
+sElectrodeAnimTable5:
+.4byte sElectrodeAnims_5_1
+.4byte sElectrodeAnims_5_2
+.4byte sElectrodeAnims_5_3
+.4byte sElectrodeAnims_5_4
+.4byte sElectrodeAnims_5_5
+.4byte sElectrodeAnims_5_6
+.4byte sElectrodeAnims_5_7
+.4byte sElectrodeAnims_5_8
+sElectrodeAnimTable6:
+.4byte sElectrodeAnims_6_1
+.4byte sElectrodeAnims_6_1
+.4byte sElectrodeAnims_6_1
+.4byte sElectrodeAnims_6_1
+.4byte sElectrodeAnims_6_1
+.4byte sElectrodeAnims_6_1
+.4byte sElectrodeAnims_6_1
+.4byte sElectrodeAnims_6_1
+sElectrodeAnimTable7:
+.4byte sElectrodeAnims_7_1
+.4byte sElectrodeAnims_7_2
+.4byte sElectrodeAnims_7_3
+.4byte sElectrodeAnims_7_4
+.4byte sElectrodeAnims_7_5
+.4byte sElectrodeAnims_7_6
+.4byte sElectrodeAnims_7_7
+.4byte sElectrodeAnims_7_8
+sElectrodeAnimTable8:
+.4byte sElectrodeAnims_8_1
+.4byte sElectrodeAnims_8_2
+.4byte sElectrodeAnims_8_3
+.4byte sElectrodeAnims_8_4
+.4byte sElectrodeAnims_8_5
+.4byte sElectrodeAnims_8_6
+.4byte sElectrodeAnims_8_7
+.4byte sElectrodeAnims_8_8
+sElectrodeAnimTable9:
+.4byte sElectrodeAnims_9_1
+.4byte sElectrodeAnims_9_2
+.4byte sElectrodeAnims_9_3
+.4byte sElectrodeAnims_9_4
+.4byte sElectrodeAnims_9_5
+.4byte sElectrodeAnims_9_6
+.4byte sElectrodeAnims_9_7
+.4byte sElectrodeAnims_9_8
+sElectrodeAnimTable10:
+.4byte sElectrodeAnims_10_1
+.4byte sElectrodeAnims_10_2
+.4byte sElectrodeAnims_10_3
+.4byte sElectrodeAnims_10_4
+.4byte sElectrodeAnims_10_5
+.4byte sElectrodeAnims_10_6
+.4byte sElectrodeAnims_10_7
+.4byte sElectrodeAnims_10_8
+sElectrodeAnimTable11:
+.4byte sElectrodeAnims_11_1
+.4byte sElectrodeAnims_11_2
+.4byte sElectrodeAnims_11_3
+.4byte sElectrodeAnims_11_4
+.4byte sElectrodeAnims_11_5
+.4byte sElectrodeAnims_11_6
+.4byte sElectrodeAnims_11_7
+.4byte sElectrodeAnims_11_8
+sElectrodeAnimTable12:
+.4byte sElectrodeAnims_12_1
+.4byte sElectrodeAnims_12_2
+.4byte sElectrodeAnims_12_3
+.4byte sElectrodeAnims_12_4
+.4byte sElectrodeAnims_12_5
+.4byte sElectrodeAnims_12_6
+.4byte sElectrodeAnims_12_7
+.4byte sElectrodeAnims_12_8
+sElectrodeAnimTable13:
+.4byte sElectrodeAnims_13_1
+.4byte sElectrodeAnims_13_2
+.4byte sElectrodeAnims_13_3
+.4byte sElectrodeAnims_13_4
+.4byte sElectrodeAnims_13_5
+.4byte sElectrodeAnims_13_6
+.4byte sElectrodeAnims_13_7
+.4byte sElectrodeAnims_13_8
+sAxAnimationsElectrode:
+.4byte sElectrodeAnimTable1
+.4byte sElectrodeAnimTable2
+.4byte sElectrodeAnimTable3
+.4byte sElectrodeAnimTable4
+.4byte sElectrodeAnimTable5
+.4byte sElectrodeAnimTable6
+.4byte sElectrodeAnimTable7
+.4byte sElectrodeAnimTable8
+.4byte sElectrodeAnimTable9
+.4byte sElectrodeAnimTable10
+.4byte sElectrodeAnimTable11
+.4byte sElectrodeAnimTable12
+.4byte sElectrodeAnimTable13
+sAxSpritesElectrode:
+.4byte sElectrodeSprites1
+.4byte sElectrodeSprites2
+.4byte sElectrodeSprites3
+.4byte sElectrodeSprites4
+.4byte sElectrodeSprites5
+.4byte sElectrodeSprites6
+.4byte sElectrodeSprites7
+.4byte sElectrodeSprites8
+.4byte sElectrodeSprites9
+.4byte sElectrodeSprites10
+.4byte sElectrodeSprites11
+.4byte sElectrodeSprites12
+.4byte sElectrodeSprites13
+.4byte sElectrodeSprites14
+.4byte sElectrodeSprites15
+.4byte sElectrodeSprites16
+.4byte sElectrodeSprites17
+.4byte sElectrodeSprites18
+.4byte sElectrodeSprites19
+.4byte sElectrodeSprites20
+.4byte sElectrodeSprites21
+.4byte sElectrodeSprites22
+.4byte sElectrodeSprites23
+.4byte sElectrodeSprites24
+.4byte sElectrodeSprites25
+.4byte sElectrodeSprites26
+.4byte sElectrodeSprites27
+.4byte sElectrodeSprites28
+.4byte sElectrodeSprites29
+.4byte sElectrodeSprites30
+.4byte sElectrodeSprites31
+sAxMainElectrode:
+ax_main sAxPosesElectrode, sAxAnimationsElectrode, 13, sAxSpritesElectrode, sAxPositionsElectrode

--- a/data/ax/elekid.inc
+++ b/data/ax/elekid.inc
@@ -1,0 +1,3268 @@
+.global gAxElekid
+gAxElekid:
+ax_siro sAxMainElekid
+sElekidPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose3:
+ax_pose 0, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose4:
+ax_pose 1, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose5:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose6:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose7:
+ax_pose 4, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sElekidPose8:
+ax_pose 5, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose9:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose10:
+ax_pose 7, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose11:
+ax_pose 8, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose12:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose13:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose14:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose15:
+ax_pose 12, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose16:
+ax_pose 13, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose17:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose18:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose19:
+ax_pose 14, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose20:
+ax_pose 15, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose21:
+ax_pose 12, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose22:
+ax_pose 13, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose23:
+ax_pose 10, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose24:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose25:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose26:
+ax_pose 9, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose27:
+ax_pose 6, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose28:
+ax_pose 7, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose29:
+ax_pose 2, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose30:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose31:
+ax_pose 4, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sElekidPose32:
+ax_pose 5, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose33:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose34:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose35:
+ax_pose 16, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose36:
+ax_pose 1, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose37:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose38:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose39:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose40:
+ax_pose 18, 0x01e2, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose41:
+ax_pose 5, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose42:
+ax_pose 19, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose43:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose44:
+ax_pose 7, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose45:
+ax_pose 20, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose46:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose47:
+ax_pose 21, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose48:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose49:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose50:
+ax_pose 22, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose51:
+ax_pose 13, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose52:
+ax_pose 23, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose53:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose54:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose55:
+ax_pose 24, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose56:
+ax_pose 15, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose57:
+ax_pose 25, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose58:
+ax_pose 12, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose59:
+ax_pose 13, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose60:
+ax_pose 22, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose61:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose62:
+ax_pose 23, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose63:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose64:
+ax_pose 9, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose65:
+ax_pose 20, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose66:
+ax_pose 7, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose67:
+ax_pose 21, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose68:
+ax_pose 2, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose69:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose70:
+ax_pose 18, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose71:
+ax_pose 5, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose72:
+ax_pose 19, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose73:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose74:
+ax_pose 26, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose75:
+ax_pose 27, 0x01e6, 0x80f0, 0x4c00
+ax_pose 28, 0x01e5, 0x80f0, 0x4c10
+ax_pose_terminator
+sElekidPose76:
+ax_pose 28, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose77:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose78:
+ax_pose 29, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose79:
+ax_pose 30, 0x01e7, 0x90ec, 0x4c00
+ax_pose 31, 0x01e5, 0x90ec, 0x4c10
+ax_pose_terminator
+sElekidPose80:
+ax_pose 31, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose81:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose82:
+ax_pose 32, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose83:
+ax_pose 33, 0x01e7, 0x90f0, 0x4c00
+ax_pose 34, 0x01e5, 0x90f0, 0x4c10
+ax_pose_terminator
+sElekidPose84:
+ax_pose 34, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose85:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose86:
+ax_pose 35, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose87:
+ax_pose 36, 0x01e6, 0x90f4, 0x4c00
+ax_pose 37, 0x01e5, 0x90f0, 0x4c10
+ax_pose_terminator
+sElekidPose88:
+ax_pose 37, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose89:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose90:
+ax_pose 38, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose91:
+ax_pose 39, 0x01e5, 0x80f0, 0x4c00
+ax_pose 40, 0x01e5, 0x80f0, 0x4c10
+ax_pose_terminator
+sElekidPose92:
+ax_pose 40, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose93:
+ax_pose 12, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose94:
+ax_pose 35, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose95:
+ax_pose 36, 0x01e6, 0x80ec, 0x4c00
+ax_pose 37, 0x01e5, 0x80f0, 0x4c10
+ax_pose_terminator
+sElekidPose96:
+ax_pose 37, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose97:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose98:
+ax_pose 32, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose99:
+ax_pose 33, 0x01e7, 0x80f0, 0x4c00
+ax_pose 34, 0x01e5, 0x80f0, 0x4c10
+ax_pose_terminator
+sElekidPose100:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose101:
+ax_pose 2, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose102:
+ax_pose 29, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose103:
+ax_pose 30, 0x01e7, 0x80f4, 0x4c00
+ax_pose 31, 0x01e5, 0x80f4, 0x4c10
+ax_pose_terminator
+sElekidPose104:
+ax_pose 31, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose105:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose106:
+ax_pose 19, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose107:
+ax_pose 21, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sElekidPose108:
+ax_pose 23, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sElekidPose109:
+ax_pose 25, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose110:
+ax_pose 23, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sElekidPose111:
+ax_pose 21, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sElekidPose112:
+ax_pose 19, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose113:
+ax_pose 16, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose114:
+ax_pose 18, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose115:
+ax_pose 20, 0x01e3, 0x80f3, 0x4c00
+ax_pose_terminator
+sElekidPose116:
+ax_pose 22, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose117:
+ax_pose 24, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose118:
+ax_pose 22, 0x01e3, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose119:
+ax_pose 20, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sElekidPose120:
+ax_pose 18, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose121:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose122:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose123:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose124:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 16, 0x01e5, 0x80f0, 0x4c23
+ax_pose_terminator
+sElekidPose125:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 16, 0x01e5, 0x80f0, 0x4c23
+ax_pose_terminator
+sElekidPose126:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose127:
+ax_pose 19, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose128:
+ax_pose 18, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose129:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 18, 0x01e5, 0x90f0, 0x4c23
+ax_pose_terminator
+sElekidPose130:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 18, 0x01e5, 0x90f0, 0x4c23
+ax_pose_terminator
+sElekidPose131:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose132:
+ax_pose 21, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose133:
+ax_pose 20, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose134:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 20, 0x01e5, 0x90ee, 0x4c23
+ax_pose_terminator
+sElekidPose135:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 20, 0x01e5, 0x90ee, 0x4c23
+ax_pose_terminator
+sElekidPose136:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose137:
+ax_pose 23, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose138:
+ax_pose 22, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose139:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 22, 0x01e5, 0x90ee, 0x4c23
+ax_pose_terminator
+sElekidPose140:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 22, 0x01e5, 0x90ee, 0x4c23
+ax_pose_terminator
+sElekidPose141:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose142:
+ax_pose 25, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose143:
+ax_pose 24, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose144:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 24, 0x01e5, 0x80f0, 0x4c23
+ax_pose_terminator
+sElekidPose145:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 24, 0x01e5, 0x80f0, 0x4c23
+ax_pose_terminator
+sElekidPose146:
+ax_pose 12, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose147:
+ax_pose 23, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose148:
+ax_pose 22, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose149:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 22, 0x01e5, 0x80f2, 0x4c23
+ax_pose_terminator
+sElekidPose150:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 22, 0x01e5, 0x80f2, 0x4c23
+ax_pose_terminator
+sElekidPose151:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose152:
+ax_pose 21, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose153:
+ax_pose 20, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose154:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 20, 0x01e5, 0x80f2, 0x4c23
+ax_pose_terminator
+sElekidPose155:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 20, 0x01e5, 0x80f2, 0x4c23
+ax_pose_terminator
+sElekidPose156:
+ax_pose 2, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose157:
+ax_pose 19, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose158:
+ax_pose 18, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose159:
+ax_pose 41, 0x01dd, 0x80f1, 0x4c00
+ax_pose 42, 0x01d5, 0x00f1, 0x4c10
+ax_pose 43, 0x01d5, 0x0101, 0x4c11
+ax_pose 44, 0x01dd, 0x00e9, 0x4c12
+ax_pose 45, 0x41e9, 0x0111, 0x4c13
+ax_pose 46, 0x01f5, 0x00e1, 0x4c15
+ax_pose 47, 0x81f5, 0x00e9, 0x4c16
+ax_pose 48, 0x41fd, 0x40f1, 0x4c18
+ax_pose 49, 0x41fd, 0x0111, 0x4c1c
+ax_pose 50, 0x4205, 0x00f1, 0x4c1e
+ax_pose 51, 0x8205, 0x0101, 0x4c20
+ax_pose 52, 0x020d, 0x00f1, 0x4c22
+ax_pose 18, 0x01e5, 0x80f0, 0x4c23
+ax_pose_terminator
+sElekidPose160:
+ax_pose 41, 0x01dd, 0x90ef, 0x4c00
+ax_pose 42, 0x01d5, 0x1107, 0x4c10
+ax_pose 43, 0x01d5, 0x10f7, 0x4c11
+ax_pose 44, 0x01dd, 0x110f, 0x4c12
+ax_pose 45, 0x41e9, 0x10df, 0x4c13
+ax_pose 46, 0x01f5, 0x1117, 0x4c15
+ax_pose 47, 0x81f5, 0x110f, 0x4c16
+ax_pose 48, 0x41fd, 0x50ef, 0x4c18
+ax_pose 49, 0x41fd, 0x10df, 0x4c1c
+ax_pose 50, 0x4205, 0x10ff, 0x4c1e
+ax_pose 51, 0x8205, 0x10f7, 0x4c20
+ax_pose 52, 0x020d, 0x1107, 0x4c22
+ax_pose 18, 0x01e5, 0x80f0, 0x4c23
+ax_pose_terminator
+sElekidPose161:
+ax_pose 53, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose162:
+ax_pose 54, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose163:
+ax_pose 55, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose164:
+ax_pose 56, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose165:
+ax_pose 57, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose166:
+ax_pose 58, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose167:
+ax_pose 59, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose168:
+ax_pose 58, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose169:
+ax_pose 57, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose170:
+ax_pose 56, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose171:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose172:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose173:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose174:
+ax_pose 18, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose175:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose176:
+ax_pose 20, 0x01e3, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose177:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose178:
+ax_pose 22, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose179:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose180:
+ax_pose 24, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose181:
+ax_pose 12, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose182:
+ax_pose 22, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose183:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose184:
+ax_pose 20, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose185:
+ax_pose 2, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose186:
+ax_pose 18, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose187:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose188:
+ax_pose 19, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose189:
+ax_pose 21, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sElekidPose190:
+ax_pose 23, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sElekidPose191:
+ax_pose 25, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose192:
+ax_pose 23, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sElekidPose193:
+ax_pose 21, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sElekidPose194:
+ax_pose 19, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose195:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose196:
+ax_pose 18, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose197:
+ax_pose 20, 0x01e3, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose198:
+ax_pose 22, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose199:
+ax_pose 24, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose200:
+ax_pose 22, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose201:
+ax_pose 20, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose202:
+ax_pose 18, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose203:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose204:
+ax_pose 16, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose205:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose206:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose207:
+ax_pose 18, 0x01e2, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose208:
+ax_pose 19, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose209:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose210:
+ax_pose 20, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sElekidPose211:
+ax_pose 21, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sElekidPose212:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose213:
+ax_pose 22, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sElekidPose214:
+ax_pose 23, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sElekidPose215:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose216:
+ax_pose 24, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose217:
+ax_pose 25, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose218:
+ax_pose 12, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose219:
+ax_pose 22, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sElekidPose220:
+ax_pose 23, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose221:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose222:
+ax_pose 20, 0x01e3, 0x80f3, 0x4c00
+ax_pose_terminator
+sElekidPose223:
+ax_pose 21, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sElekidPose224:
+ax_pose 2, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sElekidPose225:
+ax_pose 18, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose226:
+ax_pose 19, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose227:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose228:
+ax_pose 19, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose229:
+ax_pose 21, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sElekidPose230:
+ax_pose 23, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sElekidPose231:
+ax_pose 25, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose232:
+ax_pose 23, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sElekidPose233:
+ax_pose 21, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sElekidPose234:
+ax_pose 19, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sElekidPose235:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose236:
+ax_pose 4, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sElekidPose237:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose238:
+ax_pose 12, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose239:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sElekidPose240:
+ax_pose 10, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sElekidPose241:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sElekidPose242:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+.align 2
+sElekidAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_1_2:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_1_3:
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_1_4:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_1_5:
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_1_6:
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_1_7:
+ax_anim 6, 0, 24, 0, 0, 0, 0,
+ax_anim 10, 0, 25, 0, 0, 0, 0,
+ax_anim 6, 0, 26, 0, 0, 0, 0,
+ax_anim 10, 0, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_1_8:
+ax_anim 6, 0, 28, 0, 0, 0, 0,
+ax_anim 10, 0, 29, 0, 0, 0, 0,
+ax_anim 6, 0, 30, 0, 0, 0, 0,
+ax_anim 10, 0, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 6, 0, 34, 0, -2, 0, -2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, 4, 0, 4,
+ax_anim 1, 0, 35, 0, 10, 0, 10,
+ax_anim 2, 0, 36, 0, 21, 0, 21,
+ax_anim 2, 1, 36, 1, 21, 1, 21,
+ax_anim 2, 0, 36, 0, 21, 0, 21,
+ax_anim 2, 0, 36, 1, 21, 1, 21,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sElekidAnims_2_2:
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 6, 0, 39, -2, -2, -2, -2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, 4, 4, 4,
+ax_anim 1, 0, 40, 10, 10, 10, 10,
+ax_anim 2, 0, 41, 20, 21, 20, 21,
+ax_anim 2, 1, 41, 21, 20, 21, 20,
+ax_anim 2, 0, 41, 20, 21, 20, 21,
+ax_anim 2, 0, 41, 21, 20, 21, 20,
+ax_anim 2, 0, 37, 6, 6, 6, 6,
+ax_anim_terminator
+sElekidAnims_2_3:
+ax_anim 2, 0, 42, -1, 0, -1, 0,
+ax_anim 6, 0, 44, -2, 0, -2, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 4, 0, 4, 0,
+ax_anim 1, 0, 45, 10, 0, 10, 0,
+ax_anim 2, 0, 46, 17, 0, 17, 0,
+ax_anim 2, 1, 46, 17, 1, 17, 1,
+ax_anim 2, 0, 46, 17, 0, 17, 0,
+ax_anim 2, 0, 46, 17, 1, 17, 1,
+ax_anim 2, 0, 42, 6, 0, 6, 0,
+ax_anim_terminator
+sElekidAnims_2_4:
+ax_anim 2, 0, 47, -1, 1, -1, 1,
+ax_anim 6, 0, 49, -2, 2, -2, 2,
+ax_anim 1, 0, 50, 0, -1, 0, -1,
+ax_anim 1, 2, 48, 6, -6, 6, -6,
+ax_anim 1, 0, 50, 12, -13, 12, -13,
+ax_anim 2, 0, 51, 18, -19, 18, -19,
+ax_anim 2, 1, 51, 19, -18, 19, -18,
+ax_anim 2, 0, 51, 18, -19, 18, -19,
+ax_anim 2, 0, 51, 19, -18, 19, -18,
+ax_anim 2, 0, 47, 6, -6, 6, -6,
+ax_anim_terminator
+sElekidAnims_2_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 6, 0, 54, 0, 2, 0, 2,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 0, -4, 0, -4,
+ax_anim 1, 0, 55, 0, -11, 0, -11,
+ax_anim 2, 0, 56, 0, -19, 0, -19,
+ax_anim 2, 1, 56, 1, -19, 1, -19,
+ax_anim 2, 0, 56, 0, -19, 0, -19,
+ax_anim 2, 0, 56, 1, -19, 1, -19,
+ax_anim 2, 0, 52, 0, -6, 0, -6,
+ax_anim_terminator
+sElekidAnims_2_6:
+ax_anim 2, 0, 57, 1, 1, 1, 1,
+ax_anim 6, 0, 59, 2, 2, 2, 2,
+ax_anim 1, 0, 60, 0, -1, 0, -1,
+ax_anim 1, 2, 58, -6, -6, -6, -6,
+ax_anim 1, 0, 60, -12, -13, -12, -13,
+ax_anim 2, 0, 61, -18, -19, -18, -19,
+ax_anim 2, 1, 61, -19, -18, -19, -18,
+ax_anim 2, 0, 61, -18, -19, -18, -19,
+ax_anim 2, 0, 61, -19, -18, -19, -18,
+ax_anim 2, 0, 57, -6, -6, -6, -6,
+ax_anim_terminator
+sElekidAnims_2_7:
+ax_anim 2, 0, 62, 1, 0, 1, 0,
+ax_anim 6, 0, 64, 2, 0, 2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 63, -4, 0, -4, 0,
+ax_anim 1, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -17, 0, -17, 0,
+ax_anim 2, 1, 66, -17, 1, -17, 1,
+ax_anim 2, 0, 66, -17, 0, -17, 0,
+ax_anim 2, 0, 66, -17, 1, -17, 1,
+ax_anim 2, 0, 62, -6, 0, -6, 0,
+ax_anim_terminator
+sElekidAnims_2_8:
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 6, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -20, 21, -20, 21,
+ax_anim 2, 1, 71, -21, 20, -21, 20,
+ax_anim 2, 0, 71, -20, 21, -20, 21,
+ax_anim 2, 0, 71, -21, 20, -21, 20,
+ax_anim 2, 0, 67, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sElekidAnims_3_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, -4, 0, -4,
+ax_anim 4, 0, 73, 0, -5, 0, -5,
+ax_anim 1, 2, 73, 0, 1, 0, 1,
+ax_anim 1, 0, 73, 0, 9, 0, 9,
+ax_anim 2, 0, 74, 0, 16, 0, 16,
+ax_anim 2, 1, 75, -1, 16, -1, 16,
+ax_anim 2, 0, 75, 0, 16, 0, 16,
+ax_anim 2, 0, 75, -1, 16, -1, 16,
+ax_anim 2, 0, 75, 0, 16, 0, 16,
+ax_anim 2, 0, 75, -1, 16, -1, 16,
+ax_anim 2, 0, 72, 0, 10, 0, 10,
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim_terminator
+sElekidAnims_3_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 2, 0, 77, -4, -4, -4, -4,
+ax_anim 4, 0, 77, -5, -5, -5, -5,
+ax_anim 1, 2, 77, 1, 1, 1, 1,
+ax_anim 1, 0, 77, 9, 9, 9, 9,
+ax_anim 2, 0, 78, 18, 16, 18, 16,
+ax_anim 2, 1, 79, 17, 15, 17, 15,
+ax_anim 2, 0, 79, 18, 16, 18, 16,
+ax_anim 2, 0, 79, 17, 15, 17, 15,
+ax_anim 2, 0, 79, 18, 16, 18, 16,
+ax_anim 2, 0, 79, 17, 15, 17, 15,
+ax_anim 2, 0, 76, 10, 10, 10, 10,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim_terminator
+sElekidAnims_3_3:
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim 2, 0, 81, -4, 0, -4, 0,
+ax_anim 4, 0, 81, -5, 0, -5, 0,
+ax_anim 1, 2, 81, 1, 0, 1, 0,
+ax_anim 1, 0, 81, 6, 0, 6, 0,
+ax_anim 2, 0, 82, 14, 0, 14, 0,
+ax_anim 2, 1, 83, 14, -1, 14, -1,
+ax_anim 2, 0, 83, 14, 0, 14, 0,
+ax_anim 2, 0, 83, 14, -1, 14, -1,
+ax_anim 2, 0, 83, 14, 0, 14, 0,
+ax_anim 2, 0, 83, 14, -1, 14, -1,
+ax_anim 2, 0, 80, 8, 0, 8, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim_terminator
+sElekidAnims_3_4:
+ax_anim 2, 0, 84, -2, 2, -2, 2,
+ax_anim 2, 0, 85, -4, 4, -4, 4,
+ax_anim 4, 0, 85, -5, 5, -5, 5,
+ax_anim 1, 2, 85, 1, -1, 1, -1,
+ax_anim 1, 0, 85, 8, -9, 8, -9,
+ax_anim 2, 0, 86, 13, -16, 13, -16,
+ax_anim 2, 1, 87, 12, -15, 12, -15,
+ax_anim 2, 0, 87, 13, -16, 13, -16,
+ax_anim 2, 0, 87, 12, -15, 12, -15,
+ax_anim 2, 0, 87, 13, -16, 13, -16,
+ax_anim 2, 0, 87, 12, -15, 12, -15,
+ax_anim 2, 0, 84, 8, -10, 8, -10,
+ax_anim 2, 0, 84, 4, -4, 4, -4,
+ax_anim_terminator
+sElekidAnims_3_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 0, 4, 0, 4,
+ax_anim 4, 0, 89, 0, 5, 0, 5,
+ax_anim 1, 2, 89, 0, -1, 0, -1,
+ax_anim 1, 0, 89, 0, -7, 0, -7,
+ax_anim 2, 0, 90, 0, -13, 0, -13,
+ax_anim 2, 1, 91, -1, -13, -1, -13,
+ax_anim 2, 0, 91, 0, -13, 0, -13,
+ax_anim 2, 0, 91, -1, -13, -1, -13,
+ax_anim 2, 0, 91, 0, -13, 0, -13,
+ax_anim 2, 0, 91, -1, -13, -1, -13,
+ax_anim 2, 0, 88, 0, -8, 0, -8,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim_terminator
+sElekidAnims_3_6:
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 4, 0, 93, 5, 5, 5, 5,
+ax_anim 1, 2, 93, -1, -1, -1, -1,
+ax_anim 1, 0, 93, -8, -9, -8, -9,
+ax_anim 2, 0, 94, -13, -16, -13, -16,
+ax_anim 2, 1, 95, -12, -15, -12, -15,
+ax_anim 2, 0, 95, -13, -16, -13, -16,
+ax_anim 2, 0, 95, -12, -15, -12, -15,
+ax_anim 2, 0, 95, -13, -16, -13, -16,
+ax_anim 2, 0, 95, -12, -15, -12, -15,
+ax_anim 2, 0, 92, -8, -10, -8, -10,
+ax_anim 2, 0, 92, -4, -4, -4, -4,
+ax_anim_terminator
+sElekidAnims_3_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 97, 4, 0, 4, 0,
+ax_anim 4, 0, 97, 5, 0, 5, 0,
+ax_anim 1, 2, 97, -1, 0, -1, 0,
+ax_anim 1, 0, 97, -6, 0, -6, 0,
+ax_anim 2, 0, 98, -14, 0, -14, 0,
+ax_anim 2, 1, 99, -14, -1, -14, -1,
+ax_anim 2, 0, 99, -14, 0, -14, 0,
+ax_anim 2, 0, 99, -14, -1, -14, -1,
+ax_anim 2, 0, 99, -14, 0, -14, 0,
+ax_anim 2, 0, 99, -14, -1, -14, -1,
+ax_anim 2, 0, 96, -8, 0, -8, 0,
+ax_anim 2, 0, 96, -4, 0, -4, 0,
+ax_anim_terminator
+sElekidAnims_3_8:
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 101, 4, -4, 4, -4,
+ax_anim 4, 0, 101, 5, -5, 5, -5,
+ax_anim 1, 2, 101, -1, 1, -1, 1,
+ax_anim 1, 0, 101, -9, 9, -9, 9,
+ax_anim 2, 0, 102, -18, 16, -18, 16,
+ax_anim 2, 1, 103, -17, 15, -17, 15,
+ax_anim 2, 0, 103, -18, 16, -18, 16,
+ax_anim 2, 0, 103, -17, 15, -17, 15,
+ax_anim 2, 0, 103, -18, 16, -18, 16,
+ax_anim 2, 0, 103, -17, 15, -17, 15,
+ax_anim 2, 0, 100, -10, 10, -10, 10,
+ax_anim 2, 0, 100, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sElekidAnims_4_1:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_4_2:
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_4_3:
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_4_4:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_4_5:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_4_6:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_4_7:
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_4_8:
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_5_1:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -8, 0, 0,
+ax_anim 2, 0, 123, 0, -9, 0, 0,
+ax_anim 1, 2, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 2, 0, 122, 0, -8, 0, 0,
+ax_anim 1, 1, 122, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_5_2:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -8, 0, 0,
+ax_anim 2, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 2, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 2, 0, 127, 0, -8, 0, 0,
+ax_anim 1, 1, 127, 0, -4, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_5_3:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 133, 0, -9, 0, 0,
+ax_anim 1, 2, 132, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -9, 0, 0,
+ax_anim 1, 0, 132, 0, -9, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 1, 1, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_5_4:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 1, 1, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 1, 1, 1,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 138, 0, -9, 0, 0,
+ax_anim 1, 2, 137, 0, -9, 0, 0,
+ax_anim 1, 0, 139, 0, -9, 0, 0,
+ax_anim 1, 0, 139, 0, -9, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 1, 1, 137, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_5_5:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, 0, 1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, 0, 1, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 143, 0, -9, 0, 0,
+ax_anim 1, 2, 142, 0, -9, 0, 0,
+ax_anim 1, 0, 144, 0, -9, 0, 0,
+ax_anim 1, 0, 144, 0, -9, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 1, 1, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_5_6:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 1, -1, 1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 1, -1, 1,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 148, 0, -9, 0, 0,
+ax_anim 1, 2, 147, 0, -9, 0, 0,
+ax_anim 1, 0, 149, 0, -9, 0, 0,
+ax_anim 1, 0, 149, 0, -9, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 1, 1, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_5_7:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, -1, 0, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, -1, 0, -1,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -4, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 153, 0, -9, 0, 0,
+ax_anim 1, 2, 152, 0, -9, 0, 0,
+ax_anim 1, 0, 154, 0, -9, 0, 0,
+ax_anim 1, 0, 152, 0, -9, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 1, 1, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_5_8:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, -1, -1, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, -1, -1, -1,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 158, 0, -9, 0, 0,
+ax_anim 1, 2, 157, 0, -9, 0, 0,
+ax_anim 1, 0, 159, 0, -9, 0, 0,
+ax_anim 1, 0, 159, 0, -9, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 1, 1, 157, 0, -4, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sElekidAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sElekidAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sElekidAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sElekidAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sElekidAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sElekidAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sElekidAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sElekidAnims_8_1:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, -2, 0, 0,
+ax_anim 6, 0, 171, 0, -3, 0, 0,
+ax_anim 4, 0, 171, 0, -2, 0, 0,
+ax_anim_terminator
+sElekidAnims_8_2:
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -2, 0, 0,
+ax_anim 6, 0, 173, 0, -3, 0, 0,
+ax_anim 4, 0, 173, 0, -2, 0, 0,
+ax_anim_terminator
+sElekidAnims_8_3:
+ax_anim 30, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, -2, 0, 0,
+ax_anim 6, 0, 175, 0, -3, 0, 0,
+ax_anim 4, 0, 175, 0, -2, 0, 0,
+ax_anim_terminator
+sElekidAnims_8_4:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim 6, 0, 177, 0, -3, 0, 0,
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim_terminator
+sElekidAnims_8_5:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 0, -2, 0, 0,
+ax_anim 6, 0, 179, 0, -3, 0, 0,
+ax_anim 4, 0, 179, 0, -2, 0, 0,
+ax_anim_terminator
+sElekidAnims_8_6:
+ax_anim 30, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, -2, 0, 0,
+ax_anim 6, 0, 181, 0, -3, 0, 0,
+ax_anim 4, 0, 181, 0, -2, 0, 0,
+ax_anim_terminator
+sElekidAnims_8_7:
+ax_anim 30, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, -2, 0, 0,
+ax_anim 6, 0, 183, 0, -3, 0, 0,
+ax_anim 4, 0, 183, 0, -2, 0, 0,
+ax_anim_terminator
+sElekidAnims_8_8:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, -2, 0, 0,
+ax_anim 6, 0, 185, 0, -3, 0, 0,
+ax_anim 4, 0, 185, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 4, 6, 4,
+ax_anim 2, 0, 188, 10, 10, 10, 10,
+ax_anim 2, 0, 189, 9, 17, 9, 17,
+ax_anim 3, 0, 190, 0, 22, 0, 22,
+ax_anim 2, 3, 191, -9, 17, -9, 17,
+ax_anim 2, 0, 192, -10, 10, -10, 10,
+ax_anim 1, 0, 193, -6, 4, -6, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 21, 11, 21, 11,
+ax_anim 3, 0, 189, 21, 20, 21, 20,
+ax_anim 2, 3, 190, 11, 22, 11, 22,
+ax_anim 2, 0, 191, 3, 17, 3, 17,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -7, 11, -7,
+ax_anim 2, 0, 187, 19, -5, 19, -5,
+ax_anim 3, 0, 188, 20, 0, 21, 0,
+ax_anim 2, 3, 189, 19, 5, 19, 6,
+ax_anim 2, 0, 190, 12, 8, 12, 8,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 3, -16, 3, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 21, -22, 21, -22,
+ax_anim 2, 3, 188, 23, -15, 23, -15,
+ax_anim 2, 0, 189, 21, -5, 21, -5,
+ax_anim 1, 0, 190, 11, 0, 11, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -22, 0, -22,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 9, -12, 9, -12,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, -1, -8, 1, -8,
+ax_anim 2, 0, 187, -3, -16, -9, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -21, -22, -21, -22,
+ax_anim 2, 3, 192, -23, -15, -23, -15,
+ax_anim 2, 0, 191, -21, -5, -21, -5,
+ax_anim 1, 0, 190, -11, 0, -11, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -7, -11, -7,
+ax_anim 2, 0, 193, -19, -5, -19, -5,
+ax_anim 3, 0, 192, -20, 0, -20, 0,
+ax_anim 2, 3, 191, -19, 5, -19, 5,
+ax_anim 2, 0, 190, -12, 8, -12, 8,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -21, 11, -21, 11,
+ax_anim 3, 0, 191, -21, 20, -21, 20,
+ax_anim 2, 3, 190, -11, 21, -11, 21,
+ax_anim 2, 0, 189, -3, 17, -3, 17,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -25, 0, 0,
+ax_anim 3, 0, 204, 0, -24, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -26, 0, 0,
+ax_anim 3, 0, 207, 0, -25, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -26, 0, 0,
+ax_anim 3, 0, 210, 0, -25, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -24, 0, 0,
+ax_anim 3, 0, 213, 0, -23, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -22, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -24, 0, 0,
+ax_anim 3, 0, 219, 0, -23, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -26, 0, 0,
+ax_anim 3, 0, 222, 0, -25, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sElekidAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sElekidGfx1:
+.incbin "baserom.gba", 0xFAFC6C, 0x200
+sElekidSprites1:
+ax_sprite sElekidGfx1, 0x200
+ax_sprite_terminator
+sElekidGfx2:
+.incbin "baserom.gba", 0xFAFE7C, 0x200
+sElekidSprites2:
+ax_sprite sElekidGfx2, 0x200
+ax_sprite_terminator
+sElekidGfx3:
+.incbin "baserom.gba", 0xFB008C, 0x200
+sElekidSprites3:
+ax_sprite sElekidGfx3, 0x200
+ax_sprite_terminator
+sElekidGfx4:
+.incbin "baserom.gba", 0xFB029C, 0x200
+sElekidSprites4:
+ax_sprite sElekidGfx4, 0x200
+ax_sprite_terminator
+sElekidGfx5:
+.incbin "baserom.gba", 0xFB04AC, 0x200
+sElekidSprites5:
+ax_sprite sElekidGfx5, 0x200
+ax_sprite_terminator
+sElekidGfx6:
+.incbin "baserom.gba", 0xFB06BC, 0x200
+sElekidSprites6:
+ax_sprite sElekidGfx6, 0x200
+ax_sprite_terminator
+sElekidGfx7:
+.incbin "baserom.gba", 0xFB08CC, 0x200
+sElekidSprites7:
+ax_sprite sElekidGfx7, 0x200
+ax_sprite_terminator
+sElekidGfx8:
+.incbin "baserom.gba", 0xFB0ADC, 0x200
+sElekidSprites8:
+ax_sprite sElekidGfx8, 0x200
+ax_sprite_terminator
+sElekidGfx9:
+.incbin "baserom.gba", 0xFB0CEC, 0x200
+sElekidSprites9:
+ax_sprite sElekidGfx9, 0x200
+ax_sprite_terminator
+sElekidGfx10:
+.incbin "baserom.gba", 0xFB0EFC, 0x200
+sElekidSprites10:
+ax_sprite sElekidGfx10, 0x200
+ax_sprite_terminator
+sElekidGfx11:
+.incbin "baserom.gba", 0xFB110C, 0x200
+sElekidSprites11:
+ax_sprite sElekidGfx11, 0x200
+ax_sprite_terminator
+sElekidGfx12:
+.incbin "baserom.gba", 0xFB131C, 0x200
+sElekidSprites12:
+ax_sprite sElekidGfx12, 0x200
+ax_sprite_terminator
+sElekidGfx13:
+.incbin "baserom.gba", 0xFB152C, 0x200
+sElekidSprites13:
+ax_sprite sElekidGfx13, 0x200
+ax_sprite_terminator
+sElekidGfx14:
+.incbin "baserom.gba", 0xFB173C, 0x200
+sElekidSprites14:
+ax_sprite sElekidGfx14, 0x200
+ax_sprite_terminator
+sElekidGfx15:
+.incbin "baserom.gba", 0xFB194C, 0x200
+sElekidSprites15:
+ax_sprite sElekidGfx15, 0x200
+ax_sprite_terminator
+sElekidGfx16:
+.incbin "baserom.gba", 0xFB1B5C, 0x200
+sElekidSprites16:
+ax_sprite sElekidGfx16, 0x200
+ax_sprite_terminator
+sElekidGfx17:
+.incbin "baserom.gba", 0xFB1D6C, 0x180
+sElekidGfx17_1:
+.incbin "baserom.gba", 0xFB1EEC, 0x40
+sElekidSprites17:
+ax_sprite sElekidGfx17, 0x180
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx18:
+.incbin "baserom.gba", 0xFB1F54, 0x40
+sElekidGfx18_1:
+.incbin "baserom.gba", 0xFB1F94, 0x40
+sElekidGfx18_2:
+.incbin "baserom.gba", 0xFB1FD4, 0x80
+sElekidGfx18_3:
+.incbin "baserom.gba", 0xFB2054, 0x40
+sElekidSprites18:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx18_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx19:
+.incbin "baserom.gba", 0xFB20E4, 0x60
+sElekidGfx19_1:
+.incbin "baserom.gba", 0xFB2144, 0x80
+sElekidGfx19_2:
+.incbin "baserom.gba", 0xFB21C4, 0x60
+sElekidGfx19_3:
+.incbin "baserom.gba", 0xFB2224, 0x40
+sElekidSprites19:
+ax_sprite sElekidGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx20:
+.incbin "baserom.gba", 0xFB22AC, 0x40
+sElekidGfx20_1:
+.incbin "baserom.gba", 0xFB22EC, 0x60
+sElekidGfx20_2:
+.incbin "baserom.gba", 0xFB234C, 0x60
+sElekidGfx20_3:
+.incbin "baserom.gba", 0xFB23AC, 0x40
+sElekidSprites20:
+ax_sprite sElekidGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx21:
+.incbin "baserom.gba", 0xFB2434, 0x60
+sElekidGfx21_1:
+.incbin "baserom.gba", 0xFB2494, 0x60
+sElekidGfx21_2:
+.incbin "baserom.gba", 0xFB24F4, 0x60
+sElekidGfx21_3:
+.incbin "baserom.gba", 0xFB2554, 0x40
+sElekidSprites21:
+ax_sprite sElekidGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx22:
+.incbin "baserom.gba", 0xFB25DC, 0x40
+sElekidGfx22_1:
+.incbin "baserom.gba", 0xFB261C, 0x60
+sElekidGfx22_2:
+.incbin "baserom.gba", 0xFB267C, 0x60
+sElekidGfx22_3:
+.incbin "baserom.gba", 0xFB26DC, 0x60
+sElekidSprites22:
+ax_sprite sElekidGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx23:
+.incbin "baserom.gba", 0xFB2784, 0x140
+sElekidGfx23_1:
+.incbin "baserom.gba", 0xFB28C4, 0x40
+sElekidSprites23:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx23, 0x140
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx24:
+.incbin "baserom.gba", 0xFB2934, 0x40
+sElekidGfx24_1:
+.incbin "baserom.gba", 0xFB2974, 0x60
+sElekidGfx24_2:
+.incbin "baserom.gba", 0xFB29D4, 0x60
+sElekidGfx24_3:
+.incbin "baserom.gba", 0xFB2A34, 0x60
+sElekidSprites24:
+ax_sprite sElekidGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx25:
+.incbin "baserom.gba", 0xFB2ADC, 0x180
+sElekidGfx25_1:
+.incbin "baserom.gba", 0xFB2C5C, 0x40
+sElekidSprites25:
+ax_sprite sElekidGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx26:
+.incbin "baserom.gba", 0xFB2CC4, 0x40
+sElekidGfx26_1:
+.incbin "baserom.gba", 0xFB2D04, 0x100
+sElekidGfx26_2:
+.incbin "baserom.gba", 0xFB2E04, 0x40
+sElekidSprites26:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx27:
+.incbin "baserom.gba", 0xFB2E84, 0x40
+sElekidGfx27_1:
+.incbin "baserom.gba", 0xFB2EC4, 0x60
+sElekidGfx27_2:
+.incbin "baserom.gba", 0xFB2F24, 0x60
+sElekidGfx27_3:
+.incbin "baserom.gba", 0xFB2F84, 0x40
+sElekidSprites27:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx28:
+.incbin "baserom.gba", 0xFB3014, 0x20
+sElekidGfx28_1:
+.incbin "baserom.gba", 0xFB3034, 0x20
+sElekidGfx28_2:
+.incbin "baserom.gba", 0xFB3054, 0x60
+sElekidGfx28_3:
+.incbin "baserom.gba", 0xFB30B4, 0x60
+sElekidSprites28:
+ax_sprite 0, 0x60
+ax_sprite sElekidGfx28, 0x20
+ax_sprite 0, 0x60
+ax_sprite sElekidGfx28_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx28_3, 0x60
+ax_sprite_terminator
+sElekidGfx29:
+.incbin "baserom.gba", 0xFB315C, 0x20
+sElekidGfx29_1:
+.incbin "baserom.gba", 0xFB317C, 0x60
+sElekidGfx29_2:
+.incbin "baserom.gba", 0xFB31DC, 0x60
+sElekidGfx29_3:
+.incbin "baserom.gba", 0xFB323C, 0x40
+sElekidSprites29:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx30:
+.incbin "baserom.gba", 0xFB32CC, 0x40
+sElekidGfx30_1:
+.incbin "baserom.gba", 0xFB330C, 0x160
+sElekidSprites30:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx30_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx31:
+.incbin "baserom.gba", 0xFB349C, 0x100
+sElekidSprites31:
+ax_sprite 0, 0xe0
+ax_sprite sElekidGfx31, 0x100
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx32:
+.incbin "baserom.gba", 0xFB35BC, 0x40
+sElekidGfx32_1:
+.incbin "baserom.gba", 0xFB35FC, 0x60
+sElekidGfx32_2:
+.incbin "baserom.gba", 0xFB365C, 0x60
+sElekidGfx32_3:
+.incbin "baserom.gba", 0xFB36BC, 0x60
+sElekidSprites32:
+ax_sprite sElekidGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx33:
+.incbin "baserom.gba", 0xFB3764, 0x40
+sElekidGfx33_1:
+.incbin "baserom.gba", 0xFB37A4, 0x60
+sElekidGfx33_2:
+.incbin "baserom.gba", 0xFB3804, 0xE0
+sElekidSprites33:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx33_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx34:
+.incbin "baserom.gba", 0xFB3924, 0x40
+sElekidGfx34_1:
+.incbin "baserom.gba", 0xFB3964, 0x100
+sElekidSprites34:
+ax_sprite 0, 0x80
+ax_sprite sElekidGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx34_1, 0x100
+ax_sprite_terminator
+sElekidGfx35:
+.incbin "baserom.gba", 0xFB3A8C, 0x40
+sElekidGfx35_1:
+.incbin "baserom.gba", 0xFB3ACC, 0x160
+sElekidSprites35:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx35_1, 0x160
+ax_sprite_terminator
+sElekidGfx36:
+.incbin "baserom.gba", 0xFB3C54, 0x60
+sElekidGfx36_1:
+.incbin "baserom.gba", 0xFB3CB4, 0x60
+sElekidGfx36_2:
+.incbin "baserom.gba", 0xFB3D14, 0x60
+sElekidGfx36_3:
+.incbin "baserom.gba", 0xFB3D74, 0x40
+sElekidSprites36:
+ax_sprite sElekidGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx37:
+.incbin "baserom.gba", 0xFB3DFC, 0x40
+sElekidGfx37_1:
+.incbin "baserom.gba", 0xFB3E3C, 0x60
+sElekidGfx37_2:
+.incbin "baserom.gba", 0xFB3E9C, 0x40
+sElekidGfx37_3:
+.incbin "baserom.gba", 0xFB3EDC, 0x40
+sElekidSprites37:
+ax_sprite sElekidGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx37_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sElekidGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx38:
+.incbin "baserom.gba", 0xFB3F64, 0x40
+sElekidGfx38_1:
+.incbin "baserom.gba", 0xFB3FA4, 0x60
+sElekidGfx38_2:
+.incbin "baserom.gba", 0xFB4004, 0x100
+sElekidSprites38:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx38_2, 0x100
+ax_sprite_terminator
+sElekidGfx39:
+.incbin "baserom.gba", 0xFB413C, 0x40
+sElekidGfx39_1:
+.incbin "baserom.gba", 0xFB417C, 0x60
+sElekidGfx39_2:
+.incbin "baserom.gba", 0xFB41DC, 0x60
+sElekidGfx39_3:
+.incbin "baserom.gba", 0xFB423C, 0x60
+sElekidSprites39:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sElekidGfx40:
+.incbin "baserom.gba", 0xFB42EC, 0x40
+sElekidGfx40_1:
+.incbin "baserom.gba", 0xFB432C, 0x40
+sElekidGfx40_2:
+.incbin "baserom.gba", 0xFB436C, 0x40
+sElekidGfx40_3:
+.incbin "baserom.gba", 0xFB43AC, 0x40
+sElekidSprites40:
+ax_sprite sElekidGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx40_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx40_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx40_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sElekidGfx41:
+.incbin "baserom.gba", 0xFB4434, 0x40
+sElekidGfx41_1:
+.incbin "baserom.gba", 0xFB4474, 0x40
+sElekidGfx41_2:
+.incbin "baserom.gba", 0xFB44B4, 0x60
+sElekidGfx41_3:
+.incbin "baserom.gba", 0xFB4514, 0x60
+sElekidSprites41:
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx41_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sElekidGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sElekidGfx41_3, 0x60
+ax_sprite_terminator
+sElekidGfx42:
+.incbin "baserom.gba", 0xFB45BC, 0x200
+sElekidSprites42:
+ax_sprite sElekidGfx42, 0x200
+ax_sprite_terminator
+sElekidGfx43:
+.incbin "baserom.gba", 0xFB47CC, 0x20
+sElekidSprites43:
+ax_sprite sElekidGfx43, 0x20
+ax_sprite_terminator
+sElekidGfx44:
+.incbin "baserom.gba", 0xFB47FC, 0x20
+sElekidSprites44:
+ax_sprite sElekidGfx44, 0x20
+ax_sprite_terminator
+sElekidGfx45:
+.incbin "baserom.gba", 0xFB482C, 0x20
+sElekidSprites45:
+ax_sprite sElekidGfx45, 0x20
+ax_sprite_terminator
+sElekidGfx46:
+.incbin "baserom.gba", 0xFB485C, 0x40
+sElekidSprites46:
+ax_sprite sElekidGfx46, 0x40
+ax_sprite_terminator
+sElekidGfx47:
+.incbin "baserom.gba", 0xFB48AC, 0x20
+sElekidSprites47:
+ax_sprite sElekidGfx47, 0x20
+ax_sprite_terminator
+sElekidGfx48:
+.incbin "baserom.gba", 0xFB48DC, 0x40
+sElekidSprites48:
+ax_sprite sElekidGfx48, 0x40
+ax_sprite_terminator
+sElekidGfx49:
+.incbin "baserom.gba", 0xFB492C, 0x80
+sElekidSprites49:
+ax_sprite sElekidGfx49, 0x80
+ax_sprite_terminator
+sElekidGfx50:
+.incbin "baserom.gba", 0xFB49BC, 0x40
+sElekidSprites50:
+ax_sprite sElekidGfx50, 0x40
+ax_sprite_terminator
+sElekidGfx51:
+.incbin "baserom.gba", 0xFB4A0C, 0x40
+sElekidSprites51:
+ax_sprite sElekidGfx51, 0x40
+ax_sprite_terminator
+sElekidGfx52:
+.incbin "baserom.gba", 0xFB4A5C, 0x40
+sElekidSprites52:
+ax_sprite sElekidGfx52, 0x40
+ax_sprite_terminator
+sElekidGfx53:
+.incbin "baserom.gba", 0xFB4AAC, 0x20
+sElekidSprites53:
+ax_sprite sElekidGfx53, 0x20
+ax_sprite_terminator
+sElekidGfx54:
+.incbin "baserom.gba", 0xFB4ADC, 0x200
+sElekidSprites54:
+ax_sprite sElekidGfx54, 0x200
+ax_sprite_terminator
+sElekidGfx55:
+.incbin "baserom.gba", 0xFB4CEC, 0x200
+sElekidSprites55:
+ax_sprite sElekidGfx55, 0x200
+ax_sprite_terminator
+sElekidGfx56:
+.incbin "baserom.gba", 0xFB4EFC, 0x200
+sElekidSprites56:
+ax_sprite sElekidGfx56, 0x200
+ax_sprite_terminator
+sElekidGfx57:
+.incbin "baserom.gba", 0xFB510C, 0x200
+sElekidSprites57:
+ax_sprite sElekidGfx57, 0x200
+ax_sprite_terminator
+sElekidGfx58:
+.incbin "baserom.gba", 0xFB531C, 0x200
+sElekidSprites58:
+ax_sprite sElekidGfx58, 0x200
+ax_sprite_terminator
+sElekidGfx59:
+.incbin "baserom.gba", 0xFB552C, 0x200
+sElekidSprites59:
+ax_sprite sElekidGfx59, 0x200
+ax_sprite_terminator
+sElekidGfx60:
+.incbin "baserom.gba", 0xFB573C, 0x200
+sElekidSprites60:
+ax_sprite sElekidGfx60, 0x200
+ax_sprite_terminator
+sAxPosesElekid:
+.4byte sElekidPose1
+.4byte sElekidPose2
+.4byte sElekidPose3
+.4byte sElekidPose4
+.4byte sElekidPose5
+.4byte sElekidPose6
+.4byte sElekidPose7
+.4byte sElekidPose8
+.4byte sElekidPose9
+.4byte sElekidPose10
+.4byte sElekidPose11
+.4byte sElekidPose12
+.4byte sElekidPose13
+.4byte sElekidPose14
+.4byte sElekidPose15
+.4byte sElekidPose16
+.4byte sElekidPose17
+.4byte sElekidPose18
+.4byte sElekidPose19
+.4byte sElekidPose20
+.4byte sElekidPose21
+.4byte sElekidPose22
+.4byte sElekidPose23
+.4byte sElekidPose24
+.4byte sElekidPose25
+.4byte sElekidPose26
+.4byte sElekidPose27
+.4byte sElekidPose28
+.4byte sElekidPose29
+.4byte sElekidPose30
+.4byte sElekidPose31
+.4byte sElekidPose32
+.4byte sElekidPose33
+.4byte sElekidPose34
+.4byte sElekidPose35
+.4byte sElekidPose36
+.4byte sElekidPose37
+.4byte sElekidPose38
+.4byte sElekidPose39
+.4byte sElekidPose40
+.4byte sElekidPose41
+.4byte sElekidPose42
+.4byte sElekidPose43
+.4byte sElekidPose44
+.4byte sElekidPose45
+.4byte sElekidPose46
+.4byte sElekidPose47
+.4byte sElekidPose48
+.4byte sElekidPose49
+.4byte sElekidPose50
+.4byte sElekidPose51
+.4byte sElekidPose52
+.4byte sElekidPose53
+.4byte sElekidPose54
+.4byte sElekidPose55
+.4byte sElekidPose56
+.4byte sElekidPose57
+.4byte sElekidPose58
+.4byte sElekidPose59
+.4byte sElekidPose60
+.4byte sElekidPose61
+.4byte sElekidPose62
+.4byte sElekidPose63
+.4byte sElekidPose64
+.4byte sElekidPose65
+.4byte sElekidPose66
+.4byte sElekidPose67
+.4byte sElekidPose68
+.4byte sElekidPose69
+.4byte sElekidPose70
+.4byte sElekidPose71
+.4byte sElekidPose72
+.4byte sElekidPose73
+.4byte sElekidPose74
+.4byte sElekidPose75
+.4byte sElekidPose76
+.4byte sElekidPose77
+.4byte sElekidPose78
+.4byte sElekidPose79
+.4byte sElekidPose80
+.4byte sElekidPose81
+.4byte sElekidPose82
+.4byte sElekidPose83
+.4byte sElekidPose84
+.4byte sElekidPose85
+.4byte sElekidPose86
+.4byte sElekidPose87
+.4byte sElekidPose88
+.4byte sElekidPose89
+.4byte sElekidPose90
+.4byte sElekidPose91
+.4byte sElekidPose92
+.4byte sElekidPose93
+.4byte sElekidPose94
+.4byte sElekidPose95
+.4byte sElekidPose96
+.4byte sElekidPose97
+.4byte sElekidPose98
+.4byte sElekidPose99
+.4byte sElekidPose100
+.4byte sElekidPose101
+.4byte sElekidPose102
+.4byte sElekidPose103
+.4byte sElekidPose104
+.4byte sElekidPose105
+.4byte sElekidPose106
+.4byte sElekidPose107
+.4byte sElekidPose108
+.4byte sElekidPose109
+.4byte sElekidPose110
+.4byte sElekidPose111
+.4byte sElekidPose112
+.4byte sElekidPose113
+.4byte sElekidPose114
+.4byte sElekidPose115
+.4byte sElekidPose116
+.4byte sElekidPose117
+.4byte sElekidPose118
+.4byte sElekidPose119
+.4byte sElekidPose120
+.4byte sElekidPose121
+.4byte sElekidPose122
+.4byte sElekidPose123
+.4byte sElekidPose124
+.4byte sElekidPose125
+.4byte sElekidPose126
+.4byte sElekidPose127
+.4byte sElekidPose128
+.4byte sElekidPose129
+.4byte sElekidPose130
+.4byte sElekidPose131
+.4byte sElekidPose132
+.4byte sElekidPose133
+.4byte sElekidPose134
+.4byte sElekidPose135
+.4byte sElekidPose136
+.4byte sElekidPose137
+.4byte sElekidPose138
+.4byte sElekidPose139
+.4byte sElekidPose140
+.4byte sElekidPose141
+.4byte sElekidPose142
+.4byte sElekidPose143
+.4byte sElekidPose144
+.4byte sElekidPose145
+.4byte sElekidPose146
+.4byte sElekidPose147
+.4byte sElekidPose148
+.4byte sElekidPose149
+.4byte sElekidPose150
+.4byte sElekidPose151
+.4byte sElekidPose152
+.4byte sElekidPose153
+.4byte sElekidPose154
+.4byte sElekidPose155
+.4byte sElekidPose156
+.4byte sElekidPose157
+.4byte sElekidPose158
+.4byte sElekidPose159
+.4byte sElekidPose160
+.4byte sElekidPose161
+.4byte sElekidPose162
+.4byte sElekidPose163
+.4byte sElekidPose164
+.4byte sElekidPose165
+.4byte sElekidPose166
+.4byte sElekidPose167
+.4byte sElekidPose168
+.4byte sElekidPose169
+.4byte sElekidPose170
+.4byte sElekidPose171
+.4byte sElekidPose172
+.4byte sElekidPose173
+.4byte sElekidPose174
+.4byte sElekidPose175
+.4byte sElekidPose176
+.4byte sElekidPose177
+.4byte sElekidPose178
+.4byte sElekidPose179
+.4byte sElekidPose180
+.4byte sElekidPose181
+.4byte sElekidPose182
+.4byte sElekidPose183
+.4byte sElekidPose184
+.4byte sElekidPose185
+.4byte sElekidPose186
+.4byte sElekidPose187
+.4byte sElekidPose188
+.4byte sElekidPose189
+.4byte sElekidPose190
+.4byte sElekidPose191
+.4byte sElekidPose192
+.4byte sElekidPose193
+.4byte sElekidPose194
+.4byte sElekidPose195
+.4byte sElekidPose196
+.4byte sElekidPose197
+.4byte sElekidPose198
+.4byte sElekidPose199
+.4byte sElekidPose200
+.4byte sElekidPose201
+.4byte sElekidPose202
+.4byte sElekidPose203
+.4byte sElekidPose204
+.4byte sElekidPose205
+.4byte sElekidPose206
+.4byte sElekidPose207
+.4byte sElekidPose208
+.4byte sElekidPose209
+.4byte sElekidPose210
+.4byte sElekidPose211
+.4byte sElekidPose212
+.4byte sElekidPose213
+.4byte sElekidPose214
+.4byte sElekidPose215
+.4byte sElekidPose216
+.4byte sElekidPose217
+.4byte sElekidPose218
+.4byte sElekidPose219
+.4byte sElekidPose220
+.4byte sElekidPose221
+.4byte sElekidPose222
+.4byte sElekidPose223
+.4byte sElekidPose224
+.4byte sElekidPose225
+.4byte sElekidPose226
+.4byte sElekidPose227
+.4byte sElekidPose228
+.4byte sElekidPose229
+.4byte sElekidPose230
+.4byte sElekidPose231
+.4byte sElekidPose232
+.4byte sElekidPose233
+.4byte sElekidPose234
+.4byte sElekidPose235
+.4byte sElekidPose236
+.4byte sElekidPose237
+.4byte sElekidPose238
+.4byte sElekidPose239
+.4byte sElekidPose240
+.4byte sElekidPose241
+.4byte sElekidPose242
+sAxPositionsElekid:
+.2byte   -1,  -10, 	  -9,  -17, 	   8,   -4, 	  -1,   -9
+.2byte    0,  -11, 	  -8,  -20, 	   7,   -5, 	   0,  -10
+.2byte    0,  -10, 	   8,  -17, 	  -9,   -4, 	   0,   -9
+.2byte   -1,  -11, 	   7,  -20, 	  -8,   -5, 	  -1,  -10
+.2byte    4,  -10, 	  -5,  -12, 	  12,   -7, 	   0,   -9
+.2byte    5,  -11, 	  -5,  -17, 	   5,   -7, 	   0,  -10
+.2byte    4,  -10, 	   9,  -20, 	  -3,   -1, 	   1,   -9
+.2byte    3,  -11, 	   7,  -23, 	  -8,   -3, 	   0,  -10
+.2byte    6,  -10, 	   7,  -14, 	  -2,   -5, 	  -1,  -10
+.2byte    6,  -10, 	   1,  -18, 	  -1,   -6, 	  -2,  -11
+.2byte    6,  -10, 	   7,  -20, 	   4,   -3, 	   0,  -10
+.2byte    6,  -11, 	   5,  -24, 	  -5,   -1, 	  -1,  -11
+.2byte    5,  -11, 	   9,  -14, 	  -8,   -7, 	  -1,  -10
+.2byte    5,  -12, 	   7,  -18, 	 -10,   -3, 	  -1,  -11
+.2byte    4,  -11, 	  -6,  -21, 	  10,   -7, 	  -1,   -8
+.2byte    5,  -12, 	  -7,  -23, 	   3,    0, 	  -2,  -10
+.2byte   -1,  -10, 	   9,  -19, 	 -12,   -5, 	  -1,   -9
+.2byte   -1,  -11, 	   7,  -23, 	  -9,   -2, 	  -1,  -10
+.2byte    0,  -10, 	 -10,  -19, 	  11,   -5, 	   0,   -9
+.2byte    0,  -11, 	  -8,  -23, 	   8,   -2, 	   0,  -10
+.2byte   -5,  -11, 	   5,  -21, 	 -11,   -7, 	   0,   -8
+.2byte   -6,  -12, 	   6,  -23, 	  -4,    0, 	   1,  -10
+.2byte   -6,  -11, 	 -10,  -14, 	   7,   -7, 	   0,  -10
+.2byte   -6,  -12, 	  -8,  -18, 	   9,   -3, 	   0,  -11
+.2byte   -7,  -10, 	  -8,  -20, 	  -5,   -3, 	  -1,  -10
+.2byte   -7,  -11, 	  -6,  -24, 	   4,   -1, 	   0,  -11
+.2byte   -7,  -10, 	  -8,  -14, 	   1,   -5, 	   0,  -10
+.2byte   -7,  -10, 	  -2,  -18, 	   0,   -6, 	   1,  -11
+.2byte   -5,  -10, 	   4,  -12, 	 -13,   -7, 	  -1,   -9
+.2byte   -6,  -11, 	   4,  -17, 	  -6,   -7, 	  -1,  -10
+.2byte   -5,  -10, 	 -10,  -20, 	   2,   -1, 	  -2,   -9
+.2byte   -4,  -11, 	  -8,  -23, 	   7,   -3, 	  -1,  -10
+.2byte   -1,  -10, 	  -9,  -17, 	   8,   -4, 	  -1,   -9
+.2byte    0,  -11, 	  -8,  -20, 	   7,   -5, 	   0,  -10
+.2byte   -1,  -14, 	 -15,  -20, 	  14,  -20, 	  -1,  -12
+.2byte   -1,  -11, 	   7,  -20, 	  -8,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -8
+.2byte    4,  -10, 	  -5,  -12, 	  12,   -7, 	   0,   -9
+.2byte    5,  -11, 	  -5,  -17, 	   5,   -7, 	   0,  -10
+.2byte    3,  -15, 	  13,  -24, 	 -11,  -18, 	  -1,  -13
+.2byte    3,  -11, 	   7,  -23, 	  -8,   -3, 	   0,  -10
+.2byte    5,   -8, 	  11,   -9, 	   0,   -7, 	   0,   -8
+.2byte    6,  -10, 	   7,  -14, 	  -2,   -5, 	  -1,  -10
+.2byte    6,  -10, 	   1,  -18, 	  -1,   -6, 	  -2,  -11
+.2byte    4,  -15, 	   5,  -26, 	   3,  -14, 	  -4,  -12
+.2byte    6,  -11, 	   5,  -24, 	  -5,   -1, 	  -1,  -11
+.2byte    9,   -8, 	  12,  -12, 	  10,   -4, 	   2,   -8
+.2byte    5,  -11, 	   9,  -14, 	  -8,   -7, 	  -1,  -10
+.2byte    5,  -12, 	   7,  -18, 	 -10,   -3, 	  -1,  -11
+.2byte    5,  -16, 	  -8,  -26, 	  13,  -17, 	  -1,  -11
+.2byte    5,  -12, 	  -7,  -23, 	   3,    0, 	  -2,  -10
+.2byte    5,  -11, 	   1,  -14, 	  10,  -12, 	  -1,   -9
+.2byte   -1,  -10, 	   9,  -19, 	 -12,   -5, 	  -1,   -9
+.2byte   -1,  -11, 	   7,  -23, 	  -9,   -2, 	  -1,  -10
+.2byte    0,  -16, 	 -15,  -19, 	  13,  -20, 	  -1,  -11
+.2byte    0,  -11, 	  -8,  -23, 	   8,   -2, 	   0,  -10
+.2byte   -1,  -14, 	   6,  -16, 	  -7,  -16, 	   0,  -11
+.2byte   -5,  -11, 	   5,  -21, 	 -11,   -7, 	   0,   -8
+.2byte   -6,  -12, 	   6,  -23, 	  -4,    0, 	   1,  -10
+.2byte   -6,  -16, 	   7,  -26, 	 -14,  -17, 	   0,  -11
+.2byte   -6,  -12, 	  -8,  -18, 	   9,   -3, 	   0,  -11
+.2byte   -6,  -11, 	  -2,  -14, 	 -11,  -12, 	   0,   -9
+.2byte   -7,  -10, 	  -8,  -20, 	  -5,   -3, 	  -1,  -10
+.2byte   -7,  -11, 	  -6,  -24, 	   4,   -1, 	   0,  -11
+.2byte   -5,  -15, 	  -6,  -26, 	  -4,  -14, 	   3,  -12
+.2byte   -7,  -10, 	  -2,  -18, 	   0,   -6, 	   1,  -11
+.2byte  -10,   -8, 	 -13,  -12, 	 -11,   -4, 	  -3,   -8
+.2byte   -5,  -10, 	   4,  -12, 	 -13,   -7, 	  -1,   -9
+.2byte   -6,  -11, 	   4,  -17, 	  -6,   -7, 	  -1,  -10
+.2byte   -4,  -15, 	 -14,  -24, 	  10,  -18, 	   0,  -13
+.2byte   -4,  -11, 	  -8,  -23, 	   7,   -3, 	  -1,  -10
+.2byte   -6,   -8, 	 -12,   -9, 	  -1,   -7, 	  -1,   -8
+.2byte   -1,  -10, 	  -9,  -17, 	   8,   -4, 	  -1,   -9
+.2byte    6,  -12, 	   0,  -15, 	  10,  -16, 	   2,  -11
+.2byte   -6,   -7, 	  -8,  -12, 	  -3,    2, 	   0,   -7
+.2byte   -6,   -7, 	  -8,  -12, 	  -3,    2, 	   0,   -7
+.2byte    4,  -10, 	  -5,  -12, 	  12,   -7, 	   0,   -9
+.2byte   -7,  -11, 	   3,  -16, 	 -19,  -13, 	  -4,  -11
+.2byte    4,   -6, 	  -5,  -17, 	   9,    0, 	  -3,   -8
+.2byte    4,   -6, 	  -5,  -17, 	   9,    0, 	  -3,   -8
+.2byte    6,  -10, 	   7,  -14, 	  -2,   -5, 	  -1,  -10
+.2byte    0,   -9, 	  14,  -15, 	 -14,   -6, 	   0,   -8
+.2byte    0,   -8, 	 -14,  -15, 	  14,   -5, 	  -2,   -8
+.2byte    0,   -8, 	 -14,  -15, 	  14,   -5, 	  -2,   -8
+.2byte    5,  -11, 	   9,  -14, 	  -8,   -7, 	  -1,  -10
+.2byte    4,   -8, 	  11,  -20, 	  -3,    2, 	   0,   -7
+.2byte    2,   -8, 	 -13,   -6, 	  12,  -17, 	   4,   -8
+.2byte    2,   -8, 	 -13,   -6, 	  12,  -17, 	   4,   -8
+.2byte   -1,  -10, 	   9,  -19, 	 -12,   -5, 	  -1,   -9
+.2byte   -8,   -7, 	  -8,  -19, 	  -9,   -1, 	  -1,   -8
+.2byte    5,  -10, 	   8,   -3, 	  -5,  -20, 	  -2,  -10
+.2byte    5,  -10, 	   8,   -3, 	  -5,  -20, 	  -2,  -10
+.2byte   -5,  -11, 	   5,  -21, 	 -11,   -7, 	   0,   -8
+.2byte   -5,   -8, 	 -12,  -20, 	   2,    2, 	  -1,   -7
+.2byte   -3,   -8, 	  12,   -6, 	 -13,  -17, 	  -5,   -8
+.2byte   -3,   -8, 	  12,   -6, 	 -13,  -17, 	  -5,   -8
+.2byte   -7,  -10, 	  -8,  -20, 	  -5,   -3, 	  -1,  -10
+.2byte   -1,   -9, 	 -15,  -15, 	  13,   -6, 	  -1,   -8
+.2byte   -1,   -8, 	  13,  -15, 	 -15,   -5, 	   1,   -8
+.2byte   -1,   -8, 	  13,  -15, 	 -15,   -5, 	   1,   -8
+.2byte   -5,  -10, 	   4,  -12, 	 -13,   -7, 	  -1,   -9
+.2byte    6,  -11, 	  -4,  -16, 	  18,  -13, 	   3,  -11
+.2byte   -5,   -6, 	   4,  -17, 	 -10,    0, 	   2,   -8
+.2byte   -5,   -6, 	   4,  -17, 	 -10,    0, 	   2,   -8
+.2byte   -1,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -5,   -8, 	 -11,   -9, 	   0,   -7, 	   0,   -8
+.2byte   -6,   -8, 	  -9,  -12, 	  -7,   -4, 	   1,   -8
+.2byte   -5,  -11, 	  -1,  -14, 	 -10,  -12, 	   1,   -9
+.2byte   -1,  -14, 	   6,  -16, 	  -7,  -16, 	   0,  -11
+.2byte    4,  -11, 	   0,  -14, 	   9,  -12, 	  -2,   -9
+.2byte    5,   -8, 	   8,  -12, 	   6,   -4, 	  -2,   -8
+.2byte    4,   -8, 	  10,   -9, 	  -1,   -7, 	  -1,   -8
+.2byte   -1,  -14, 	 -15,  -20, 	  14,  -20, 	  -1,  -12
+.2byte   -5,  -14, 	 -15,  -23, 	   9,  -17, 	  -1,  -12
+.2byte   -6,  -15, 	  -7,  -26, 	  -5,  -14, 	   2,  -12
+.2byte   -5,  -16, 	   8,  -26, 	 -13,  -17, 	   1,  -11
+.2byte   -1,  -18, 	  14,  -21, 	 -14,  -22, 	   0,  -13
+.2byte    4,  -16, 	  -9,  -26, 	  12,  -17, 	  -2,  -11
+.2byte    5,  -15, 	   6,  -26, 	   4,  -14, 	  -3,  -12
+.2byte    4,  -13, 	  14,  -22, 	 -10,  -16, 	   0,  -11
+.2byte   -1,  -10, 	  -9,  -17, 	   8,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	 -15,  -18, 	  14,  -18, 	  -1,  -10
+.2byte   -1,  -12, 	 -15,  -18, 	  14,  -18, 	  -1,  -10
+.2byte   -1,  -12, 	 -15,  -18, 	  14,  -18, 	  -1,  -10
+.2byte    4,  -10, 	  -5,  -12, 	  12,   -7, 	   0,   -9
+.2byte    5,   -8, 	  11,   -9, 	   0,   -7, 	   0,   -8
+.2byte    4,  -12, 	  14,  -21, 	 -10,  -15, 	   0,  -10
+.2byte    4,  -12, 	  14,  -21, 	 -10,  -15, 	   0,  -10
+.2byte    4,  -12, 	  14,  -21, 	 -10,  -15, 	   0,  -10
+.2byte    6,  -10, 	   7,  -14, 	  -2,   -5, 	  -1,  -10
+.2byte    9,   -8, 	  12,  -12, 	  10,   -4, 	   2,   -8
+.2byte    6,  -13, 	   7,  -24, 	   5,  -12, 	  -2,  -10
+.2byte    6,  -13, 	   7,  -24, 	   5,  -12, 	  -2,  -10
+.2byte    6,  -13, 	   7,  -24, 	   5,  -12, 	  -2,  -10
+.2byte    5,  -11, 	   9,  -14, 	  -8,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   1,  -14, 	  10,  -12, 	  -1,   -9
+.2byte    4,  -14, 	  -9,  -24, 	  12,  -15, 	  -2,   -9
+.2byte    4,  -14, 	  -9,  -24, 	  12,  -15, 	  -2,   -9
+.2byte    4,  -14, 	  -9,  -24, 	  12,  -15, 	  -2,   -9
+.2byte   -1,  -10, 	   9,  -19, 	 -12,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   6,  -16, 	  -7,  -16, 	   0,  -11
+.2byte   -1,  -16, 	  14,  -19, 	 -14,  -20, 	   0,  -11
+.2byte   -1,  -16, 	  14,  -19, 	 -14,  -20, 	   0,  -11
+.2byte   -1,  -16, 	  14,  -19, 	 -14,  -20, 	   0,  -11
+.2byte   -5,  -11, 	   5,  -21, 	 -11,   -7, 	   0,   -8
+.2byte   -6,  -11, 	  -2,  -14, 	 -11,  -12, 	   0,   -9
+.2byte   -5,  -14, 	   8,  -24, 	 -13,  -15, 	   1,   -9
+.2byte   -5,  -14, 	   8,  -24, 	 -13,  -15, 	   1,   -9
+.2byte   -5,  -14, 	   8,  -24, 	 -13,  -15, 	   1,   -9
+.2byte   -7,  -10, 	  -8,  -20, 	  -5,   -3, 	  -1,  -10
+.2byte  -10,   -8, 	 -13,  -12, 	 -11,   -4, 	  -3,   -8
+.2byte   -7,  -13, 	  -8,  -24, 	  -6,  -12, 	   1,  -10
+.2byte   -7,  -13, 	  -8,  -24, 	  -6,  -12, 	   1,  -10
+.2byte   -7,  -13, 	  -8,  -24, 	  -6,  -12, 	   1,  -10
+.2byte   -5,  -10, 	   4,  -12, 	 -13,   -7, 	  -1,   -9
+.2byte   -6,   -8, 	 -12,   -9, 	  -1,   -7, 	  -1,   -8
+.2byte   -5,  -12, 	 -15,  -21, 	   9,  -15, 	  -1,  -10
+.2byte   -5,  -12, 	 -15,  -21, 	   9,  -15, 	  -1,  -10
+.2byte   -5,  -12, 	 -15,  -21, 	   9,  -15, 	  -1,  -10
+.2byte   -1,   -8, 	 -12,   -2, 	  10,   -1, 	  -1,   -9
+.2byte   -1,   -7, 	 -12,   -1, 	  10,    0, 	  -1,   -8
+.2byte   -1,   -9, 	  -9,  -17, 	   8,  -17, 	  -1,   -8
+.2byte    2,  -10, 	   0,  -20, 	 -13,  -14, 	  -1,   -8
+.2byte    6,   -9, 	  -2,  -17, 	  -7,  -13, 	   0,   -7
+.2byte    4,  -12, 	 -11,  -12, 	  -3,  -15, 	  -1,   -7
+.2byte   -1,  -12, 	   9,  -18, 	 -11,  -18, 	  -1,   -7
+.2byte   -5,  -12, 	  10,  -12, 	   2,  -15, 	   0,   -7
+.2byte   -7,   -9, 	   1,  -17, 	   6,  -13, 	  -1,   -7
+.2byte   -3,  -10, 	  -1,  -20, 	  12,  -14, 	   0,   -8
+.2byte   -1,  -10, 	  -9,  -17, 	   8,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	 -15,  -18, 	  14,  -18, 	  -1,  -10
+.2byte    4,  -10, 	  -5,  -12, 	  12,   -7, 	   0,   -9
+.2byte    4,  -14, 	  14,  -23, 	 -10,  -17, 	   0,  -12
+.2byte    6,  -10, 	   7,  -14, 	  -2,   -5, 	  -1,  -10
+.2byte    6,  -15, 	   7,  -26, 	   5,  -14, 	  -2,  -12
+.2byte    5,  -11, 	   9,  -14, 	  -8,   -7, 	  -1,  -10
+.2byte    4,  -15, 	  -9,  -25, 	  12,  -16, 	  -2,  -10
+.2byte   -1,  -10, 	   9,  -19, 	 -12,   -5, 	  -1,   -9
+.2byte   -1,  -16, 	  14,  -19, 	 -14,  -20, 	   0,  -11
+.2byte   -5,  -11, 	   5,  -21, 	 -11,   -7, 	   0,   -8
+.2byte   -5,  -15, 	   8,  -25, 	 -13,  -16, 	   1,  -10
+.2byte   -7,  -10, 	  -8,  -20, 	  -5,   -3, 	  -1,  -10
+.2byte   -7,  -15, 	  -8,  -26, 	  -6,  -14, 	   1,  -12
+.2byte   -5,  -10, 	   4,  -12, 	 -13,   -7, 	  -1,   -9
+.2byte   -5,  -14, 	 -15,  -23, 	   9,  -17, 	  -1,  -12
+.2byte   -1,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -5,   -8, 	 -11,   -9, 	   0,   -7, 	   0,   -8
+.2byte   -6,   -8, 	  -9,  -12, 	  -7,   -4, 	   1,   -8
+.2byte   -5,  -11, 	  -1,  -14, 	 -10,  -12, 	   1,   -9
+.2byte   -1,  -14, 	   6,  -16, 	  -7,  -16, 	   0,  -11
+.2byte    4,  -11, 	   0,  -14, 	   9,  -12, 	  -2,   -9
+.2byte    5,   -8, 	   8,  -12, 	   6,   -4, 	  -2,   -8
+.2byte    4,   -8, 	  10,   -9, 	  -1,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	 -15,  -18, 	  14,  -18, 	  -1,  -10
+.2byte    4,  -13, 	  14,  -22, 	 -10,  -16, 	   0,  -11
+.2byte    6,  -15, 	   7,  -26, 	   5,  -14, 	  -2,  -12
+.2byte    5,  -16, 	  -8,  -26, 	  13,  -17, 	  -1,  -11
+.2byte   -1,  -16, 	  14,  -19, 	 -14,  -20, 	   0,  -11
+.2byte   -6,  -16, 	   7,  -26, 	 -14,  -17, 	   0,  -11
+.2byte   -7,  -15, 	  -8,  -26, 	  -6,  -14, 	   1,  -12
+.2byte   -5,  -13, 	 -15,  -22, 	   9,  -16, 	  -1,  -11
+.2byte   -1,  -10, 	  -9,  -17, 	   8,   -4, 	  -1,   -9
+.2byte   -1,  -14, 	 -15,  -20, 	  14,  -20, 	  -1,  -12
+.2byte   -1,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -8
+.2byte    4,  -10, 	  -5,  -12, 	  12,   -7, 	   0,   -9
+.2byte    3,  -15, 	  13,  -24, 	 -11,  -18, 	  -1,  -13
+.2byte    4,   -8, 	  10,   -9, 	  -1,   -7, 	  -1,   -8
+.2byte    6,  -10, 	   7,  -14, 	  -2,   -5, 	  -1,  -10
+.2byte    5,  -15, 	   6,  -26, 	   4,  -14, 	  -3,  -12
+.2byte    6,   -8, 	   9,  -12, 	   7,   -4, 	  -1,   -8
+.2byte    5,  -11, 	   9,  -14, 	  -8,   -7, 	  -1,  -10
+.2byte    4,  -15, 	  -9,  -25, 	  12,  -16, 	  -2,  -10
+.2byte    3,  -11, 	  -1,  -14, 	   8,  -12, 	  -3,   -9
+.2byte   -1,  -10, 	   9,  -19, 	 -12,   -5, 	  -1,   -9
+.2byte    0,  -15, 	 -15,  -18, 	  13,  -19, 	  -1,  -10
+.2byte   -1,  -14, 	   6,  -16, 	  -7,  -16, 	   0,  -11
+.2byte   -5,  -11, 	   5,  -21, 	 -11,   -7, 	   0,   -8
+.2byte   -5,  -15, 	   8,  -25, 	 -13,  -16, 	   1,  -10
+.2byte   -4,  -11, 	   0,  -14, 	  -9,  -12, 	   2,   -9
+.2byte   -7,  -10, 	  -8,  -20, 	  -5,   -3, 	  -1,  -10
+.2byte   -6,  -15, 	  -7,  -26, 	  -5,  -14, 	   2,  -12
+.2byte   -7,   -8, 	 -10,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -5,  -10, 	   4,  -12, 	 -13,   -7, 	  -1,   -9
+.2byte   -4,  -15, 	 -14,  -24, 	  10,  -18, 	   0,  -13
+.2byte   -5,   -8, 	 -11,   -9, 	   0,   -7, 	   0,   -8
+.2byte   -1,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -5,   -8, 	 -11,   -9, 	   0,   -7, 	   0,   -8
+.2byte   -6,   -8, 	  -9,  -12, 	  -7,   -4, 	   1,   -8
+.2byte   -5,  -11, 	  -1,  -14, 	 -10,  -12, 	   1,   -9
+.2byte   -1,  -14, 	   6,  -16, 	  -7,  -16, 	   0,  -11
+.2byte    4,  -11, 	   0,  -14, 	   9,  -12, 	  -2,   -9
+.2byte    5,   -8, 	   8,  -12, 	   6,   -4, 	  -2,   -8
+.2byte    4,   -8, 	  10,   -9, 	  -1,   -7, 	  -1,   -8
+.2byte   -1,  -10, 	  -9,  -17, 	   8,   -4, 	  -1,   -9
+.2byte   -5,  -10, 	 -10,  -20, 	   2,   -1, 	  -2,   -9
+.2byte   -7,  -10, 	  -8,  -20, 	  -5,   -3, 	  -1,  -10
+.2byte   -5,  -11, 	   5,  -21, 	 -11,   -7, 	   0,   -8
+.2byte   -1,  -10, 	   9,  -19, 	 -12,   -5, 	  -1,   -9
+.2byte    6,  -11, 	  10,  -14, 	  -7,   -7, 	   0,  -10
+.2byte    6,  -10, 	   7,  -14, 	  -2,   -5, 	  -1,  -10
+.2byte    4,  -10, 	  -5,  -12, 	  12,   -7, 	   0,   -9
+sElekidAnimTable1:
+.4byte sElekidAnims_1_1
+.4byte sElekidAnims_1_2
+.4byte sElekidAnims_1_3
+.4byte sElekidAnims_1_4
+.4byte sElekidAnims_1_5
+.4byte sElekidAnims_1_6
+.4byte sElekidAnims_1_7
+.4byte sElekidAnims_1_8
+sElekidAnimTable2:
+.4byte sElekidAnims_2_1
+.4byte sElekidAnims_2_2
+.4byte sElekidAnims_2_3
+.4byte sElekidAnims_2_4
+.4byte sElekidAnims_2_5
+.4byte sElekidAnims_2_6
+.4byte sElekidAnims_2_7
+.4byte sElekidAnims_2_8
+sElekidAnimTable3:
+.4byte sElekidAnims_3_1
+.4byte sElekidAnims_3_2
+.4byte sElekidAnims_3_3
+.4byte sElekidAnims_3_4
+.4byte sElekidAnims_3_5
+.4byte sElekidAnims_3_6
+.4byte sElekidAnims_3_7
+.4byte sElekidAnims_3_8
+sElekidAnimTable4:
+.4byte sElekidAnims_4_1
+.4byte sElekidAnims_4_2
+.4byte sElekidAnims_4_3
+.4byte sElekidAnims_4_4
+.4byte sElekidAnims_4_5
+.4byte sElekidAnims_4_6
+.4byte sElekidAnims_4_7
+.4byte sElekidAnims_4_8
+sElekidAnimTable5:
+.4byte sElekidAnims_5_1
+.4byte sElekidAnims_5_2
+.4byte sElekidAnims_5_3
+.4byte sElekidAnims_5_4
+.4byte sElekidAnims_5_5
+.4byte sElekidAnims_5_6
+.4byte sElekidAnims_5_7
+.4byte sElekidAnims_5_8
+sElekidAnimTable6:
+.4byte sElekidAnims_6_1
+.4byte sElekidAnims_6_1
+.4byte sElekidAnims_6_1
+.4byte sElekidAnims_6_1
+.4byte sElekidAnims_6_1
+.4byte sElekidAnims_6_1
+.4byte sElekidAnims_6_1
+.4byte sElekidAnims_6_1
+sElekidAnimTable7:
+.4byte sElekidAnims_7_1
+.4byte sElekidAnims_7_2
+.4byte sElekidAnims_7_3
+.4byte sElekidAnims_7_4
+.4byte sElekidAnims_7_5
+.4byte sElekidAnims_7_6
+.4byte sElekidAnims_7_7
+.4byte sElekidAnims_7_8
+sElekidAnimTable8:
+.4byte sElekidAnims_8_1
+.4byte sElekidAnims_8_2
+.4byte sElekidAnims_8_3
+.4byte sElekidAnims_8_4
+.4byte sElekidAnims_8_5
+.4byte sElekidAnims_8_6
+.4byte sElekidAnims_8_7
+.4byte sElekidAnims_8_8
+sElekidAnimTable9:
+.4byte sElekidAnims_9_1
+.4byte sElekidAnims_9_2
+.4byte sElekidAnims_9_3
+.4byte sElekidAnims_9_4
+.4byte sElekidAnims_9_5
+.4byte sElekidAnims_9_6
+.4byte sElekidAnims_9_7
+.4byte sElekidAnims_9_8
+sElekidAnimTable10:
+.4byte sElekidAnims_10_1
+.4byte sElekidAnims_10_2
+.4byte sElekidAnims_10_3
+.4byte sElekidAnims_10_4
+.4byte sElekidAnims_10_5
+.4byte sElekidAnims_10_6
+.4byte sElekidAnims_10_7
+.4byte sElekidAnims_10_8
+sElekidAnimTable11:
+.4byte sElekidAnims_11_1
+.4byte sElekidAnims_11_2
+.4byte sElekidAnims_11_3
+.4byte sElekidAnims_11_4
+.4byte sElekidAnims_11_5
+.4byte sElekidAnims_11_6
+.4byte sElekidAnims_11_7
+.4byte sElekidAnims_11_8
+sElekidAnimTable12:
+.4byte sElekidAnims_12_1
+.4byte sElekidAnims_12_2
+.4byte sElekidAnims_12_3
+.4byte sElekidAnims_12_4
+.4byte sElekidAnims_12_5
+.4byte sElekidAnims_12_6
+.4byte sElekidAnims_12_7
+.4byte sElekidAnims_12_8
+sElekidAnimTable13:
+.4byte sElekidAnims_13_1
+.4byte sElekidAnims_13_2
+.4byte sElekidAnims_13_3
+.4byte sElekidAnims_13_4
+.4byte sElekidAnims_13_5
+.4byte sElekidAnims_13_6
+.4byte sElekidAnims_13_7
+.4byte sElekidAnims_13_8
+sAxAnimationsElekid:
+.4byte sElekidAnimTable1
+.4byte sElekidAnimTable2
+.4byte sElekidAnimTable3
+.4byte sElekidAnimTable4
+.4byte sElekidAnimTable5
+.4byte sElekidAnimTable6
+.4byte sElekidAnimTable7
+.4byte sElekidAnimTable8
+.4byte sElekidAnimTable9
+.4byte sElekidAnimTable10
+.4byte sElekidAnimTable11
+.4byte sElekidAnimTable12
+.4byte sElekidAnimTable13
+sAxSpritesElekid:
+.4byte sElekidSprites1
+.4byte sElekidSprites2
+.4byte sElekidSprites3
+.4byte sElekidSprites4
+.4byte sElekidSprites5
+.4byte sElekidSprites6
+.4byte sElekidSprites7
+.4byte sElekidSprites8
+.4byte sElekidSprites9
+.4byte sElekidSprites10
+.4byte sElekidSprites11
+.4byte sElekidSprites12
+.4byte sElekidSprites13
+.4byte sElekidSprites14
+.4byte sElekidSprites15
+.4byte sElekidSprites16
+.4byte sElekidSprites17
+.4byte sElekidSprites18
+.4byte sElekidSprites19
+.4byte sElekidSprites20
+.4byte sElekidSprites21
+.4byte sElekidSprites22
+.4byte sElekidSprites23
+.4byte sElekidSprites24
+.4byte sElekidSprites25
+.4byte sElekidSprites26
+.4byte sElekidSprites27
+.4byte sElekidSprites28
+.4byte sElekidSprites29
+.4byte sElekidSprites30
+.4byte sElekidSprites31
+.4byte sElekidSprites32
+.4byte sElekidSprites33
+.4byte sElekidSprites34
+.4byte sElekidSprites35
+.4byte sElekidSprites36
+.4byte sElekidSprites37
+.4byte sElekidSprites38
+.4byte sElekidSprites39
+.4byte sElekidSprites40
+.4byte sElekidSprites41
+.4byte sElekidSprites42
+.4byte sElekidSprites43
+.4byte sElekidSprites44
+.4byte sElekidSprites45
+.4byte sElekidSprites46
+.4byte sElekidSprites47
+.4byte sElekidSprites48
+.4byte sElekidSprites49
+.4byte sElekidSprites50
+.4byte sElekidSprites51
+.4byte sElekidSprites52
+.4byte sElekidSprites53
+.4byte sElekidSprites54
+.4byte sElekidSprites55
+.4byte sElekidSprites56
+.4byte sElekidSprites57
+.4byte sElekidSprites58
+.4byte sElekidSprites59
+.4byte sElekidSprites60
+sAxMainElekid:
+ax_main sAxPosesElekid, sAxAnimationsElekid, 13, sAxSpritesElekid, sAxPositionsElekid

--- a/data/ax/entei.inc
+++ b/data/ax/entei.inc
@@ -1,0 +1,3475 @@
+.global gAxEntei
+gAxEntei:
+ax_siro sAxMainEntei
+sEnteiPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose4:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose5:
+ax_pose 4, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose6:
+ax_pose 5, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose7:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose8:
+ax_pose 7, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose9:
+ax_pose 8, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose10:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose11:
+ax_pose 10, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose12:
+ax_pose 11, 0x81e3, 0x9100, 0xcc00
+ax_pose 12, 0x81e3, 0x50f8, 0xcc08
+ax_pose 13, 0x81eb, 0x10f0, 0xcc0c
+ax_pose 14, 0x01fb, 0x10f0, 0xcc0e
+ax_pose 15, 0x0203, 0x10f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose13:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose14:
+ax_pose 17, 0x81e3, 0x80f0, 0xcc00
+ax_pose 18, 0x81e3, 0x4100, 0xcc08
+ax_pose 19, 0x0203, 0x0100, 0xcc0c
+ax_pose 20, 0x01eb, 0x0108, 0xcc0d
+ax_pose 21, 0x81f3, 0x0108, 0xcc0e
+ax_pose_terminator
+sEnteiPose15:
+ax_pose 22, 0x81e3, 0x80f0, 0xcc00
+ax_pose 23, 0x81e3, 0x4100, 0xcc08
+ax_pose 24, 0x81eb, 0x0108, 0xcc0c
+ax_pose 25, 0x01fb, 0x0108, 0xcc0e
+ax_pose 26, 0x0203, 0x00f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose18:
+ax_pose 11, 0x81e3, 0x80f1, 0xcc00
+ax_pose 12, 0x81e3, 0x4101, 0xcc08
+ax_pose 15, 0x0203, 0x0101, 0xcc0c
+ax_pose 13, 0x81eb, 0x0109, 0xcc0d
+ax_pose 14, 0x01fb, 0x0109, 0xcc0f
+ax_pose_terminator
+sEnteiPose19:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose20:
+ax_pose 7, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose21:
+ax_pose 8, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose22:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose28:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose29:
+ax_pose 4, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose30:
+ax_pose 5, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose31:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose32:
+ax_pose 7, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose33:
+ax_pose 8, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose34:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose35:
+ax_pose 10, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose36:
+ax_pose 11, 0x81e3, 0x9100, 0xcc00
+ax_pose 12, 0x81e3, 0x50f8, 0xcc08
+ax_pose 13, 0x81eb, 0x10f0, 0xcc0c
+ax_pose 14, 0x01fb, 0x10f0, 0xcc0e
+ax_pose 15, 0x0203, 0x10f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose37:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose38:
+ax_pose 17, 0x81e3, 0x80f0, 0xcc00
+ax_pose 18, 0x81e3, 0x4100, 0xcc08
+ax_pose 19, 0x0203, 0x0100, 0xcc0c
+ax_pose 20, 0x01eb, 0x0108, 0xcc0d
+ax_pose 21, 0x81f3, 0x0108, 0xcc0e
+ax_pose_terminator
+sEnteiPose39:
+ax_pose 22, 0x81e3, 0x80f0, 0xcc00
+ax_pose 23, 0x81e3, 0x4100, 0xcc08
+ax_pose 24, 0x81eb, 0x0108, 0xcc0c
+ax_pose 25, 0x01fb, 0x0108, 0xcc0e
+ax_pose 26, 0x0203, 0x00f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose40:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose41:
+ax_pose 10, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose42:
+ax_pose 11, 0x81e3, 0x80f1, 0xcc00
+ax_pose 12, 0x81e3, 0x4101, 0xcc08
+ax_pose 15, 0x0203, 0x0101, 0xcc0c
+ax_pose 13, 0x81eb, 0x0109, 0xcc0d
+ax_pose 14, 0x01fb, 0x0109, 0xcc0f
+ax_pose_terminator
+sEnteiPose43:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose44:
+ax_pose 7, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose45:
+ax_pose 8, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose46:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose47:
+ax_pose 4, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose48:
+ax_pose 5, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose49:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose50:
+ax_pose 1, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose51:
+ax_pose 2, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose52:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose53:
+ax_pose 4, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose54:
+ax_pose 5, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose55:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose56:
+ax_pose 7, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose57:
+ax_pose 8, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose58:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose59:
+ax_pose 10, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose60:
+ax_pose 11, 0x81e3, 0x9100, 0xcc00
+ax_pose 12, 0x81e3, 0x50f8, 0xcc08
+ax_pose 13, 0x81eb, 0x10f0, 0xcc0c
+ax_pose 14, 0x01fb, 0x10f0, 0xcc0e
+ax_pose 15, 0x0203, 0x10f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose61:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose62:
+ax_pose 17, 0x81e3, 0x80f0, 0xcc00
+ax_pose 18, 0x81e3, 0x4100, 0xcc08
+ax_pose 19, 0x0203, 0x0100, 0xcc0c
+ax_pose 20, 0x01eb, 0x0108, 0xcc0d
+ax_pose 21, 0x81f3, 0x0108, 0xcc0e
+ax_pose_terminator
+sEnteiPose63:
+ax_pose 22, 0x81e3, 0x80f0, 0xcc00
+ax_pose 23, 0x81e3, 0x4100, 0xcc08
+ax_pose 24, 0x81eb, 0x0108, 0xcc0c
+ax_pose 25, 0x01fb, 0x0108, 0xcc0e
+ax_pose 26, 0x0203, 0x00f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose64:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose65:
+ax_pose 10, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose66:
+ax_pose 11, 0x81e3, 0x80f1, 0xcc00
+ax_pose 12, 0x81e3, 0x4101, 0xcc08
+ax_pose 15, 0x0203, 0x0101, 0xcc0c
+ax_pose 13, 0x81eb, 0x0109, 0xcc0d
+ax_pose 14, 0x01fb, 0x0109, 0xcc0f
+ax_pose_terminator
+sEnteiPose67:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose68:
+ax_pose 7, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose69:
+ax_pose 8, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose70:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose71:
+ax_pose 4, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose72:
+ax_pose 5, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose73:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose74:
+ax_pose 27, 0x81e4, 0x80ff, 0xcc00
+ax_pose 28, 0x81e4, 0x40f7, 0xcc08
+ax_pose 29, 0x81e4, 0x00ef, 0xcc0c
+ax_pose 30, 0x01f4, 0x00ef, 0xcc0e
+ax_pose 31, 0x01dc, 0x00fc, 0xcc0f
+ax_pose_terminator
+sEnteiPose75:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose76:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose77:
+ax_pose 33, 0x81e4, 0x90fc, 0xcc00
+ax_pose 34, 0x81e4, 0x50f4, 0xcc08
+ax_pose 35, 0x01ec, 0x10ec, 0xcc0c
+ax_pose 36, 0x01dc, 0x1104, 0xcc0d
+ax_pose 37, 0x01dc, 0x10fc, 0xcc0e
+ax_pose_terminator
+sEnteiPose78:
+ax_pose 38, 0x01e4, 0x90f3, 0xcc00
+ax_pose_terminator
+sEnteiPose79:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose80:
+ax_pose 39, 0x01e3, 0x50fd, 0xcc00
+ax_pose 40, 0x81e3, 0x10f5, 0xcc04
+ax_pose 41, 0x01db, 0x1105, 0xcc06
+ax_pose 42, 0x01db, 0x10fd, 0xcc07
+ax_pose 43, 0x41f3, 0x50ed, 0xcc08
+ax_pose 44, 0x41fb, 0x10fb, 0xcc0c
+ax_pose 45, 0x01fb, 0x10f3, 0xcc0e
+ax_pose_terminator
+sEnteiPose81:
+ax_pose 46, 0x01e3, 0x5104, 0xcc00
+ax_pose 47, 0x81e3, 0x50fc, 0xcc04
+ax_pose 48, 0x01eb, 0x1114, 0xcc08
+ax_pose 49, 0x01eb, 0x10f4, 0xcc09
+ax_pose 50, 0x81f3, 0x10f4, 0xcc0a
+ax_pose 51, 0x01f3, 0x1114, 0xcc0c
+ax_pose 52, 0x41f3, 0x1104, 0xcc0d
+ax_pose 53, 0x01fb, 0x1104, 0xcc0f
+ax_pose_terminator
+sEnteiPose82:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose83:
+ax_pose 54, 0x81e4, 0x90f3, 0xcc00
+ax_pose 55, 0x81e4, 0x5103, 0xcc08
+ax_pose 56, 0x01dc, 0x1103, 0xcc0c
+ax_pose 57, 0x01dc, 0x10fb, 0xcc0d
+ax_pose 58, 0x01fc, 0x110b, 0xcc0e
+ax_pose_terminator
+sEnteiPose84:
+ax_pose 59, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose85:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose86:
+ax_pose 60, 0x81e3, 0x80ff, 0xcc00
+ax_pose 61, 0x81e3, 0x40f7, 0xcc08
+ax_pose 62, 0x01eb, 0x00ef, 0xcc0c
+ax_pose 63, 0x01f3, 0x00ef, 0xcc0d
+ax_pose 64, 0x01db, 0x00ff, 0xcc0e
+ax_pose 65, 0x01db, 0x00f7, 0xcc0f
+ax_pose_terminator
+sEnteiPose87:
+ax_pose 66, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose88:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose89:
+ax_pose 54, 0x81e4, 0x80fe, 0xcc00
+ax_pose 55, 0x81e4, 0x40f6, 0xcc08
+ax_pose 56, 0x01dc, 0x00f6, 0xcc0c
+ax_pose 57, 0x01dc, 0x00fe, 0xcc0d
+ax_pose 58, 0x01fc, 0x00ee, 0xcc0e
+ax_pose_terminator
+sEnteiPose90:
+ax_pose 59, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose91:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose92:
+ax_pose 39, 0x01e3, 0x40f4, 0xcc00
+ax_pose 40, 0x81e3, 0x0104, 0xcc04
+ax_pose 41, 0x01db, 0x00f4, 0xcc06
+ax_pose 42, 0x01db, 0x00fc, 0xcc07
+ax_pose 43, 0x41f3, 0x40f4, 0xcc08
+ax_pose 44, 0x41fb, 0x00f6, 0xcc0c
+ax_pose 45, 0x01fb, 0x0106, 0xcc0e
+ax_pose_terminator
+sEnteiPose93:
+ax_pose 46, 0x01e3, 0x40ed, 0xcc00
+ax_pose 47, 0x81e3, 0x40fd, 0xcc04
+ax_pose 48, 0x01eb, 0x00e5, 0xcc08
+ax_pose 49, 0x01eb, 0x0105, 0xcc09
+ax_pose 50, 0x81f3, 0x0105, 0xcc0a
+ax_pose 51, 0x01f3, 0x00e5, 0xcc0c
+ax_pose 52, 0x41f3, 0x00ed, 0xcc0d
+ax_pose 53, 0x01fb, 0x00f5, 0xcc0f
+ax_pose_terminator
+sEnteiPose94:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose95:
+ax_pose 33, 0x81e4, 0x80f5, 0xcc00
+ax_pose 34, 0x81e4, 0x4105, 0xcc08
+ax_pose 35, 0x01ec, 0x010d, 0xcc0c
+ax_pose 36, 0x01dc, 0x00f5, 0xcc0d
+ax_pose 37, 0x01dc, 0x00fd, 0xcc0e
+ax_pose_terminator
+sEnteiPose96:
+ax_pose 38, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sEnteiPose97:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose98:
+ax_pose 27, 0x81e4, 0x80ff, 0xcc00
+ax_pose 28, 0x81e4, 0x40f7, 0xcc08
+ax_pose 29, 0x81e4, 0x00ef, 0xcc0c
+ax_pose 30, 0x01f4, 0x00ef, 0xcc0e
+ax_pose 31, 0x01dc, 0x00fc, 0xcc0f
+ax_pose_terminator
+sEnteiPose99:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose100:
+ax_pose 67, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose101:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose102:
+ax_pose 33, 0x81e4, 0x90fc, 0xcc00
+ax_pose 34, 0x81e4, 0x50f4, 0xcc08
+ax_pose 35, 0x01ec, 0x10ec, 0xcc0c
+ax_pose 36, 0x01dc, 0x1104, 0xcc0d
+ax_pose 37, 0x01dc, 0x10fc, 0xcc0e
+ax_pose_terminator
+sEnteiPose103:
+ax_pose 38, 0x01e4, 0x90f3, 0xcc00
+ax_pose_terminator
+sEnteiPose104:
+ax_pose 68, 0x01e9, 0x90f4, 0xcc00
+ax_pose_terminator
+sEnteiPose105:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose106:
+ax_pose 39, 0x01e3, 0x50fd, 0xcc00
+ax_pose 40, 0x81e3, 0x10f5, 0xcc04
+ax_pose 41, 0x01db, 0x1105, 0xcc06
+ax_pose 42, 0x01db, 0x10fd, 0xcc07
+ax_pose 43, 0x41f3, 0x50ed, 0xcc08
+ax_pose 44, 0x41fb, 0x10fb, 0xcc0c
+ax_pose 45, 0x01fb, 0x10f3, 0xcc0e
+ax_pose_terminator
+sEnteiPose107:
+ax_pose 46, 0x01e3, 0x5104, 0xcc00
+ax_pose 47, 0x81e3, 0x50fc, 0xcc04
+ax_pose 48, 0x01eb, 0x1114, 0xcc08
+ax_pose 49, 0x01eb, 0x10f4, 0xcc09
+ax_pose 50, 0x81f3, 0x10f4, 0xcc0a
+ax_pose 51, 0x01f3, 0x1114, 0xcc0c
+ax_pose 52, 0x41f3, 0x1104, 0xcc0d
+ax_pose 53, 0x01fb, 0x1104, 0xcc0f
+ax_pose_terminator
+sEnteiPose108:
+ax_pose 69, 0x01f4, 0x5101, 0xcc00
+ax_pose 70, 0x01ec, 0x1111, 0xcc04
+ax_pose 71, 0x01e4, 0x1101, 0xcc05
+ax_pose 72, 0x41ec, 0x1101, 0xcc06
+ax_pose 73, 0x81e4, 0x50f9, 0xcc08
+ax_pose 74, 0x01f4, 0x1111, 0xcc0c
+ax_pose 75, 0x01ec, 0x10f1, 0xcc0d
+ax_pose 76, 0x81f4, 0x10f1, 0xcc0e
+ax_pose_terminator
+sEnteiPose109:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose110:
+ax_pose 54, 0x81e4, 0x90f3, 0xcc00
+ax_pose 55, 0x81e4, 0x5103, 0xcc08
+ax_pose 56, 0x01dc, 0x1103, 0xcc0c
+ax_pose 57, 0x01dc, 0x10fb, 0xcc0d
+ax_pose 58, 0x01fc, 0x110b, 0xcc0e
+ax_pose_terminator
+sEnteiPose111:
+ax_pose 59, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose112:
+ax_pose 77, 0x01e9, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose113:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose114:
+ax_pose 60, 0x81e3, 0x80ff, 0xcc00
+ax_pose 61, 0x81e3, 0x40f7, 0xcc08
+ax_pose 62, 0x01eb, 0x00ef, 0xcc0c
+ax_pose 63, 0x01f3, 0x00ef, 0xcc0d
+ax_pose 64, 0x01db, 0x00ff, 0xcc0e
+ax_pose 65, 0x01db, 0x00f7, 0xcc0f
+ax_pose_terminator
+sEnteiPose115:
+ax_pose 66, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose116:
+ax_pose 78, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose117:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose118:
+ax_pose 54, 0x81e4, 0x80fe, 0xcc00
+ax_pose 55, 0x81e4, 0x40f6, 0xcc08
+ax_pose 56, 0x01dc, 0x00f6, 0xcc0c
+ax_pose 57, 0x01dc, 0x00fe, 0xcc0d
+ax_pose 58, 0x01fc, 0x00ee, 0xcc0e
+ax_pose_terminator
+sEnteiPose119:
+ax_pose 59, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose120:
+ax_pose 77, 0x01e9, 0x80f1, 0xcc00
+ax_pose_terminator
+sEnteiPose121:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose122:
+ax_pose 39, 0x01e3, 0x40f4, 0xcc00
+ax_pose 40, 0x81e3, 0x0104, 0xcc04
+ax_pose 41, 0x01db, 0x00f4, 0xcc06
+ax_pose 42, 0x01db, 0x00fc, 0xcc07
+ax_pose 43, 0x41f3, 0x40f4, 0xcc08
+ax_pose 44, 0x41fb, 0x00f6, 0xcc0c
+ax_pose 45, 0x01fb, 0x0106, 0xcc0e
+ax_pose_terminator
+sEnteiPose123:
+ax_pose 46, 0x01e3, 0x40ed, 0xcc00
+ax_pose 47, 0x81e3, 0x40fd, 0xcc04
+ax_pose 48, 0x01eb, 0x00e5, 0xcc08
+ax_pose 49, 0x01eb, 0x0105, 0xcc09
+ax_pose 50, 0x81f3, 0x0105, 0xcc0a
+ax_pose 51, 0x01f3, 0x00e5, 0xcc0c
+ax_pose 52, 0x41f3, 0x00ed, 0xcc0d
+ax_pose 53, 0x01fb, 0x00f5, 0xcc0f
+ax_pose_terminator
+sEnteiPose124:
+ax_pose 69, 0x01f4, 0x40ef, 0xcc00
+ax_pose 70, 0x01ec, 0x00e7, 0xcc04
+ax_pose 71, 0x01e4, 0x00f7, 0xcc05
+ax_pose 72, 0x41ec, 0x00ef, 0xcc06
+ax_pose 73, 0x81e4, 0x40ff, 0xcc08
+ax_pose 74, 0x01f4, 0x00e7, 0xcc0c
+ax_pose 75, 0x01ec, 0x0107, 0xcc0d
+ax_pose 76, 0x81f4, 0x0107, 0xcc0e
+ax_pose_terminator
+sEnteiPose125:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose126:
+ax_pose 33, 0x81e4, 0x80f5, 0xcc00
+ax_pose 34, 0x81e4, 0x4105, 0xcc08
+ax_pose 35, 0x01ec, 0x010d, 0xcc0c
+ax_pose 36, 0x01dc, 0x00f5, 0xcc0d
+ax_pose 37, 0x01dc, 0x00fd, 0xcc0e
+ax_pose_terminator
+sEnteiPose127:
+ax_pose 38, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sEnteiPose128:
+ax_pose 68, 0x01e9, 0x80ed, 0xcc00
+ax_pose_terminator
+sEnteiPose129:
+ax_pose 79, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose130:
+ax_pose 80, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose131:
+ax_pose 81, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose132:
+ax_pose 82, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sEnteiPose133:
+ax_pose 83, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose134:
+ax_pose 84, 0x01e6, 0x90f0, 0xcc00
+ax_pose_terminator
+sEnteiPose135:
+ax_pose 85, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose136:
+ax_pose 84, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose137:
+ax_pose 83, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose138:
+ax_pose 82, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose139:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose140:
+ax_pose 27, 0x81e4, 0x80ff, 0xcc00
+ax_pose 28, 0x81e4, 0x40f7, 0xcc08
+ax_pose 29, 0x81e4, 0x00ef, 0xcc0c
+ax_pose 30, 0x01f4, 0x00ef, 0xcc0e
+ax_pose 31, 0x01dc, 0x00fc, 0xcc0f
+ax_pose_terminator
+sEnteiPose141:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose142:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose143:
+ax_pose 33, 0x81e4, 0x90fc, 0xcc00
+ax_pose 34, 0x81e4, 0x50f4, 0xcc08
+ax_pose 35, 0x01ec, 0x10ec, 0xcc0c
+ax_pose 36, 0x01dc, 0x1104, 0xcc0d
+ax_pose 37, 0x01dc, 0x10fc, 0xcc0e
+ax_pose_terminator
+sEnteiPose144:
+ax_pose 38, 0x01e4, 0x90f3, 0xcc00
+ax_pose_terminator
+sEnteiPose145:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose146:
+ax_pose 39, 0x01e3, 0x50fd, 0xcc00
+ax_pose 40, 0x81e3, 0x10f5, 0xcc04
+ax_pose 41, 0x01db, 0x1105, 0xcc06
+ax_pose 42, 0x01db, 0x10fd, 0xcc07
+ax_pose 43, 0x41f3, 0x50ed, 0xcc08
+ax_pose 44, 0x41fb, 0x10fb, 0xcc0c
+ax_pose 45, 0x01fb, 0x10f3, 0xcc0e
+ax_pose_terminator
+sEnteiPose147:
+ax_pose 46, 0x01e3, 0x5104, 0xcc00
+ax_pose 47, 0x81e3, 0x50fc, 0xcc04
+ax_pose 48, 0x01eb, 0x1114, 0xcc08
+ax_pose 49, 0x01eb, 0x10f4, 0xcc09
+ax_pose 50, 0x81f3, 0x10f4, 0xcc0a
+ax_pose 51, 0x01f3, 0x1114, 0xcc0c
+ax_pose 52, 0x41f3, 0x1104, 0xcc0d
+ax_pose 53, 0x01fb, 0x1104, 0xcc0f
+ax_pose_terminator
+sEnteiPose148:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose149:
+ax_pose 54, 0x81e4, 0x90f3, 0xcc00
+ax_pose 55, 0x81e4, 0x5103, 0xcc08
+ax_pose 56, 0x01dc, 0x1103, 0xcc0c
+ax_pose 57, 0x01dc, 0x10fb, 0xcc0d
+ax_pose 58, 0x01fc, 0x110b, 0xcc0e
+ax_pose_terminator
+sEnteiPose150:
+ax_pose 59, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose151:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose152:
+ax_pose 60, 0x81e3, 0x80ff, 0xcc00
+ax_pose 61, 0x81e3, 0x40f7, 0xcc08
+ax_pose 62, 0x01eb, 0x00ef, 0xcc0c
+ax_pose 63, 0x01f3, 0x00ef, 0xcc0d
+ax_pose 64, 0x01db, 0x00ff, 0xcc0e
+ax_pose 65, 0x01db, 0x00f7, 0xcc0f
+ax_pose_terminator
+sEnteiPose153:
+ax_pose 66, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose154:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose155:
+ax_pose 54, 0x81e4, 0x80fe, 0xcc00
+ax_pose 55, 0x81e4, 0x40f6, 0xcc08
+ax_pose 56, 0x01dc, 0x00f6, 0xcc0c
+ax_pose 57, 0x01dc, 0x00fe, 0xcc0d
+ax_pose 58, 0x01fc, 0x00ee, 0xcc0e
+ax_pose_terminator
+sEnteiPose156:
+ax_pose 59, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose157:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose158:
+ax_pose 39, 0x01e3, 0x40f4, 0xcc00
+ax_pose 40, 0x81e3, 0x0104, 0xcc04
+ax_pose 41, 0x01db, 0x00f4, 0xcc06
+ax_pose 42, 0x01db, 0x00fc, 0xcc07
+ax_pose 43, 0x41f3, 0x40f4, 0xcc08
+ax_pose 44, 0x41fb, 0x00f6, 0xcc0c
+ax_pose 45, 0x01fb, 0x0106, 0xcc0e
+ax_pose_terminator
+sEnteiPose159:
+ax_pose 46, 0x01e3, 0x40ed, 0xcc00
+ax_pose 47, 0x81e3, 0x40fd, 0xcc04
+ax_pose 48, 0x01eb, 0x00e5, 0xcc08
+ax_pose 49, 0x01eb, 0x0105, 0xcc09
+ax_pose 50, 0x81f3, 0x0105, 0xcc0a
+ax_pose 51, 0x01f3, 0x00e5, 0xcc0c
+ax_pose 52, 0x41f3, 0x00ed, 0xcc0d
+ax_pose 53, 0x01fb, 0x00f5, 0xcc0f
+ax_pose_terminator
+sEnteiPose160:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose161:
+ax_pose 33, 0x81e4, 0x80f5, 0xcc00
+ax_pose 34, 0x81e4, 0x4105, 0xcc08
+ax_pose 35, 0x01ec, 0x010d, 0xcc0c
+ax_pose 36, 0x01dc, 0x00f5, 0xcc0d
+ax_pose 37, 0x01dc, 0x00fd, 0xcc0e
+ax_pose_terminator
+sEnteiPose162:
+ax_pose 38, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sEnteiPose163:
+ax_pose 2, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose164:
+ax_pose 5, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose165:
+ax_pose 8, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose166:
+ax_pose 11, 0x81e3, 0x80f1, 0xcc00
+ax_pose 12, 0x81e3, 0x4101, 0xcc08
+ax_pose 15, 0x0203, 0x0101, 0xcc0c
+ax_pose 13, 0x81eb, 0x0109, 0xcc0d
+ax_pose 14, 0x01fb, 0x0109, 0xcc0f
+ax_pose_terminator
+sEnteiPose167:
+ax_pose 22, 0x81e3, 0x80f0, 0xcc00
+ax_pose 23, 0x81e3, 0x4100, 0xcc08
+ax_pose 24, 0x81eb, 0x0108, 0xcc0c
+ax_pose 25, 0x01fb, 0x0108, 0xcc0e
+ax_pose 26, 0x0203, 0x00f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose168:
+ax_pose 11, 0x81e3, 0x9100, 0xcc00
+ax_pose 12, 0x81e3, 0x50f8, 0xcc08
+ax_pose 13, 0x81eb, 0x10f0, 0xcc0c
+ax_pose 14, 0x01fb, 0x10f0, 0xcc0e
+ax_pose 15, 0x0203, 0x10f8, 0xcc0f
+ax_pose_terminator
+sEnteiPose169:
+ax_pose 8, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose170:
+ax_pose 5, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose171:
+ax_pose 67, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose172:
+ax_pose 68, 0x01e8, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose173:
+ax_pose 69, 0x01f4, 0x5101, 0xcc00
+ax_pose 70, 0x01ec, 0x1111, 0xcc04
+ax_pose 71, 0x01e4, 0x1101, 0xcc05
+ax_pose 72, 0x41ec, 0x1101, 0xcc06
+ax_pose 73, 0x81e4, 0x50f9, 0xcc08
+ax_pose 74, 0x01f4, 0x1111, 0xcc0c
+ax_pose 75, 0x01ec, 0x10f1, 0xcc0d
+ax_pose 76, 0x81f4, 0x10f1, 0xcc0e
+ax_pose_terminator
+sEnteiPose174:
+ax_pose 77, 0x01e8, 0x90f0, 0xcc00
+ax_pose_terminator
+sEnteiPose175:
+ax_pose 78, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose176:
+ax_pose 77, 0x01e8, 0x80f1, 0xcc00
+ax_pose_terminator
+sEnteiPose177:
+ax_pose 69, 0x01f4, 0x40ef, 0xcc00
+ax_pose 70, 0x01ec, 0x00e7, 0xcc04
+ax_pose 71, 0x01e4, 0x00f7, 0xcc05
+ax_pose 72, 0x41ec, 0x00ef, 0xcc06
+ax_pose 73, 0x81e4, 0x40ff, 0xcc08
+ax_pose 74, 0x01f4, 0x00e7, 0xcc0c
+ax_pose 75, 0x01ec, 0x0107, 0xcc0d
+ax_pose 76, 0x81f4, 0x0107, 0xcc0e
+ax_pose_terminator
+sEnteiPose178:
+ax_pose 68, 0x01e8, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose179:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose180:
+ax_pose 27, 0x81e4, 0x80ff, 0xcc00
+ax_pose 28, 0x81e4, 0x40f7, 0xcc08
+ax_pose 29, 0x81e4, 0x00ef, 0xcc0c
+ax_pose 30, 0x01f4, 0x00ef, 0xcc0e
+ax_pose 31, 0x01dc, 0x00fc, 0xcc0f
+ax_pose_terminator
+sEnteiPose181:
+ax_pose 67, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose182:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose183:
+ax_pose 33, 0x81e4, 0x90fc, 0xcc00
+ax_pose 34, 0x81e4, 0x50f4, 0xcc08
+ax_pose 35, 0x01ec, 0x10ec, 0xcc0c
+ax_pose 36, 0x01dc, 0x1104, 0xcc0d
+ax_pose 37, 0x01dc, 0x10fc, 0xcc0e
+ax_pose_terminator
+sEnteiPose184:
+ax_pose 68, 0x01e8, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose185:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose186:
+ax_pose 39, 0x01e3, 0x50fd, 0xcc00
+ax_pose 40, 0x81e3, 0x10f5, 0xcc04
+ax_pose 41, 0x01db, 0x1105, 0xcc06
+ax_pose 42, 0x01db, 0x10fd, 0xcc07
+ax_pose 43, 0x41f3, 0x50ed, 0xcc08
+ax_pose 44, 0x41fb, 0x10fb, 0xcc0c
+ax_pose 45, 0x01fb, 0x10f3, 0xcc0e
+ax_pose_terminator
+sEnteiPose187:
+ax_pose 69, 0x01f4, 0x5100, 0xcc00
+ax_pose 70, 0x01ec, 0x1110, 0xcc04
+ax_pose 71, 0x01e4, 0x1100, 0xcc05
+ax_pose 72, 0x41ec, 0x1100, 0xcc06
+ax_pose 73, 0x81e4, 0x50f8, 0xcc08
+ax_pose 74, 0x01f4, 0x1110, 0xcc0c
+ax_pose 75, 0x01ec, 0x10f0, 0xcc0d
+ax_pose 76, 0x81f4, 0x10f0, 0xcc0e
+ax_pose_terminator
+sEnteiPose188:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose189:
+ax_pose 54, 0x81e4, 0x90f3, 0xcc00
+ax_pose 55, 0x81e4, 0x5103, 0xcc08
+ax_pose 56, 0x01dc, 0x1103, 0xcc0c
+ax_pose 57, 0x01dc, 0x10fb, 0xcc0d
+ax_pose 58, 0x01fc, 0x110b, 0xcc0e
+ax_pose_terminator
+sEnteiPose190:
+ax_pose 77, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose191:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose192:
+ax_pose 60, 0x81e3, 0x80ff, 0xcc00
+ax_pose 61, 0x81e3, 0x40f7, 0xcc08
+ax_pose 62, 0x01eb, 0x00ef, 0xcc0c
+ax_pose 63, 0x01f3, 0x00ef, 0xcc0d
+ax_pose 64, 0x01db, 0x00ff, 0xcc0e
+ax_pose 65, 0x01db, 0x00f7, 0xcc0f
+ax_pose_terminator
+sEnteiPose193:
+ax_pose 78, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose194:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose195:
+ax_pose 54, 0x81e4, 0x80fe, 0xcc00
+ax_pose 55, 0x81e4, 0x40f6, 0xcc08
+ax_pose 56, 0x01dc, 0x00f6, 0xcc0c
+ax_pose 57, 0x01dc, 0x00fe, 0xcc0d
+ax_pose 58, 0x01fc, 0x00ee, 0xcc0e
+ax_pose_terminator
+sEnteiPose196:
+ax_pose 77, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose197:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose198:
+ax_pose 39, 0x01e3, 0x40f4, 0xcc00
+ax_pose 40, 0x81e3, 0x0104, 0xcc04
+ax_pose 41, 0x01db, 0x00f4, 0xcc06
+ax_pose 42, 0x01db, 0x00fc, 0xcc07
+ax_pose 43, 0x41f3, 0x40f4, 0xcc08
+ax_pose 44, 0x41fb, 0x00f6, 0xcc0c
+ax_pose 45, 0x01fb, 0x0106, 0xcc0e
+ax_pose_terminator
+sEnteiPose199:
+ax_pose 69, 0x01f4, 0x40f1, 0xcc00
+ax_pose 70, 0x01ec, 0x00e9, 0xcc04
+ax_pose 71, 0x01e4, 0x00f9, 0xcc05
+ax_pose 72, 0x41ec, 0x00f1, 0xcc06
+ax_pose 73, 0x81e4, 0x4101, 0xcc08
+ax_pose 74, 0x01f4, 0x00e9, 0xcc0c
+ax_pose 75, 0x01ec, 0x0109, 0xcc0d
+ax_pose 76, 0x81f4, 0x0109, 0xcc0e
+ax_pose_terminator
+sEnteiPose200:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose201:
+ax_pose 33, 0x81e4, 0x80f5, 0xcc00
+ax_pose 34, 0x81e4, 0x4105, 0xcc08
+ax_pose 35, 0x01ec, 0x010d, 0xcc0c
+ax_pose 36, 0x01dc, 0x00f5, 0xcc0d
+ax_pose 37, 0x01dc, 0x00fd, 0xcc0e
+ax_pose_terminator
+sEnteiPose202:
+ax_pose 68, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose203:
+ax_pose 27, 0x81e4, 0x80ff, 0xcc00
+ax_pose 28, 0x81e4, 0x40f7, 0xcc08
+ax_pose 29, 0x81e4, 0x00ef, 0xcc0c
+ax_pose 30, 0x01f4, 0x00ef, 0xcc0e
+ax_pose 31, 0x01dc, 0x00fc, 0xcc0f
+ax_pose_terminator
+sEnteiPose204:
+ax_pose 33, 0x81e4, 0x80f5, 0xcc00
+ax_pose 34, 0x81e4, 0x4105, 0xcc08
+ax_pose 35, 0x01ec, 0x010d, 0xcc0c
+ax_pose 36, 0x01dc, 0x00f5, 0xcc0d
+ax_pose 37, 0x01dc, 0x00fd, 0xcc0e
+ax_pose_terminator
+sEnteiPose205:
+ax_pose 39, 0x01e3, 0x40f4, 0xcc00
+ax_pose 40, 0x81e3, 0x0104, 0xcc04
+ax_pose 41, 0x01db, 0x00f4, 0xcc06
+ax_pose 42, 0x01db, 0x00fc, 0xcc07
+ax_pose 43, 0x41f3, 0x40f4, 0xcc08
+ax_pose 44, 0x41fb, 0x00f6, 0xcc0c
+ax_pose 45, 0x01fb, 0x0106, 0xcc0e
+ax_pose_terminator
+sEnteiPose206:
+ax_pose 54, 0x81e4, 0x80fe, 0xcc00
+ax_pose 55, 0x81e4, 0x40f6, 0xcc08
+ax_pose 56, 0x01dc, 0x00f6, 0xcc0c
+ax_pose 57, 0x01dc, 0x00fe, 0xcc0d
+ax_pose 58, 0x01fc, 0x00ee, 0xcc0e
+ax_pose_terminator
+sEnteiPose207:
+ax_pose 60, 0x81e3, 0x80ff, 0xcc00
+ax_pose 61, 0x81e3, 0x40f7, 0xcc08
+ax_pose 62, 0x01eb, 0x00ef, 0xcc0c
+ax_pose 63, 0x01f3, 0x00ef, 0xcc0d
+ax_pose 64, 0x01db, 0x00ff, 0xcc0e
+ax_pose 65, 0x01db, 0x00f7, 0xcc0f
+ax_pose_terminator
+sEnteiPose208:
+ax_pose 54, 0x81e4, 0x90f3, 0xcc00
+ax_pose 55, 0x81e4, 0x5103, 0xcc08
+ax_pose 56, 0x01dc, 0x1103, 0xcc0c
+ax_pose 57, 0x01dc, 0x10fb, 0xcc0d
+ax_pose 58, 0x01fc, 0x110b, 0xcc0e
+ax_pose_terminator
+sEnteiPose209:
+ax_pose 39, 0x01e3, 0x50fd, 0xcc00
+ax_pose 40, 0x81e3, 0x10f5, 0xcc04
+ax_pose 41, 0x01db, 0x1105, 0xcc06
+ax_pose 42, 0x01db, 0x10fd, 0xcc07
+ax_pose 43, 0x41f3, 0x50ed, 0xcc08
+ax_pose 44, 0x41fb, 0x10fb, 0xcc0c
+ax_pose 45, 0x01fb, 0x10f3, 0xcc0e
+ax_pose_terminator
+sEnteiPose210:
+ax_pose 33, 0x81e4, 0x90fc, 0xcc00
+ax_pose 34, 0x81e4, 0x50f4, 0xcc08
+ax_pose 35, 0x01ec, 0x10ec, 0xcc0c
+ax_pose 36, 0x01dc, 0x1104, 0xcc0d
+ax_pose 37, 0x01dc, 0x10fc, 0xcc0e
+ax_pose_terminator
+sEnteiPose211:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose212:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose213:
+ax_pose 6, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sEnteiPose214:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose215:
+ax_pose 16, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose216:
+ax_pose 9, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose217:
+ax_pose 6, 0x01e4, 0x90f2, 0xcc00
+ax_pose_terminator
+sEnteiPose218:
+ax_pose 3, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sEnteiPose219:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose220:
+ax_pose 27, 0x81e4, 0x80ff, 0xcc00
+ax_pose 28, 0x81e4, 0x40f7, 0xcc08
+ax_pose 29, 0x81e4, 0x00ef, 0xcc0c
+ax_pose 30, 0x01f4, 0x00ef, 0xcc0e
+ax_pose 31, 0x01dc, 0x00fc, 0xcc0f
+ax_pose_terminator
+sEnteiPose221:
+ax_pose 86, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sEnteiPose222:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+.align 2
+sEnteiAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 3, 0, 25, 0, -3, 0, -3,
+ax_anim 6, 0, 25, 0, -6, 0, -6,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 1, 16, 0, 16,
+ax_anim 2, 1, 28, 0, 16, -1, 16,
+ax_anim 2, 0, 28, 1, 16, 0, 16,
+ax_anim 2, 0, 28, 0, 16, -1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sEnteiAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 3, 0, 28, -3, -3, -3, -3,
+ax_anim 6, 0, 28, -6, -6, -6, -6,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 11, 10, 11, 10,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 31, 17, 19, 17, 19,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 17, 19, 17, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sEnteiAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 3, 0, 31, -3, 0, -3, 0,
+ax_anim 6, 0, 31, -6, 0, -6, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 16, 0, 16, 0,
+ax_anim 2, 1, 34, 16, 1, 16, 1,
+ax_anim 2, 0, 34, 16, 0, 16, 0,
+ax_anim 2, 0, 34, 16, 1, 16, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sEnteiAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 3, 0, 34, -3, 3, -3, 3,
+ax_anim 6, 0, 34, -6, 6, -6, 6,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 11, -10, 11, -10,
+ax_anim 2, 0, 38, 16, -14, 16, -14,
+ax_anim 2, 1, 38, 15, -15, 15, -15,
+ax_anim 2, 0, 38, 16, -14, 16, -14,
+ax_anim 2, 0, 38, 15, -15, 15, -15,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sEnteiAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 3, 0, 37, 0, 3, 0, 3,
+ax_anim 6, 0, 37, 0, 6, 0, 6,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 41, 0, -15, 0, -15,
+ax_anim 2, 1, 41, -1, -15, -1, -15,
+ax_anim 2, 0, 41, 0, -15, 0, -15,
+ax_anim 2, 0, 41, -1, -15, -1, -15,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sEnteiAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 3, 0, 40, 3, 3, 3, 3,
+ax_anim 6, 0, 40, 6, 6, 6, 6,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -11, -10, -11, -10,
+ax_anim 2, 0, 44, -16, -18, -16, -18,
+ax_anim 2, 1, 44, -15, -19, -15, -19,
+ax_anim 2, 0, 44, -16, -18, -16, -18,
+ax_anim 2, 0, 44, -15, -19, -15, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sEnteiAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 3, 0, 43, 3, 0, 3, 0,
+ax_anim 6, 0, 43, 6, 0, 6, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -8, 0, -8, 0,
+ax_anim 2, 0, 47, -18, -1, -18, -1,
+ax_anim 2, 1, 47, -18, 0, -18, 0,
+ax_anim 2, 0, 47, -18, -1, -18, -1,
+ax_anim 2, 0, 47, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sEnteiAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 3, 0, 46, 3, -3, 3, -3,
+ax_anim 6, 0, 46, 6, -6, 6, -6,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -11, 10, -11, 10,
+ax_anim 2, 0, 26, -20, 18, -20, 18,
+ax_anim 2, 1, 26, -19, 19, -19, 19,
+ax_anim 2, 0, 26, -20, 18, -20, 18,
+ax_anim 2, 0, 26, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sEnteiAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 3, 0, 49, 0, -3, 0, -3,
+ax_anim 6, 0, 49, 0, -6, 0, -6,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 52, 1, 16, 0, 16,
+ax_anim 2, 1, 52, 0, 16, -1, 16,
+ax_anim 2, 0, 52, 1, 16, 0, 16,
+ax_anim 2, 0, 52, 0, 16, -1, 16,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sEnteiAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 3, 0, 52, -3, -3, -3, -3,
+ax_anim 6, 0, 52, -6, -6, -6, -6,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 11, 10, 11, 10,
+ax_anim 2, 0, 55, 18, 18, 18, 18,
+ax_anim 2, 1, 55, 17, 19, 17, 19,
+ax_anim 2, 0, 55, 18, 18, 18, 18,
+ax_anim 2, 0, 55, 17, 19, 17, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sEnteiAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 3, 0, 55, -3, 0, -3, 0,
+ax_anim 6, 0, 55, -6, 0, -6, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 58, 16, 0, 16, 0,
+ax_anim 2, 1, 58, 16, 1, 16, 1,
+ax_anim 2, 0, 58, 16, 0, 16, 0,
+ax_anim 2, 0, 58, 16, 1, 16, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sEnteiAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 3, 0, 58, -3, 3, -3, 3,
+ax_anim 6, 0, 58, -6, 6, -6, 6,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 4, -4, 4, -4,
+ax_anim 1, 0, 59, 11, -10, 11, -10,
+ax_anim 2, 0, 62, 16, -14, 16, -14,
+ax_anim 2, 1, 62, 15, -15, 15, -15,
+ax_anim 2, 0, 62, 16, -14, 16, -14,
+ax_anim 2, 0, 62, 15, -15, 15, -15,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sEnteiAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 3, 0, 61, 0, 3, 0, 3,
+ax_anim 6, 0, 61, 0, 6, 0, 6,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 65, 0, -15, 0, -15,
+ax_anim 2, 1, 65, -1, -15, -1, -15,
+ax_anim 2, 0, 65, 0, -15, 0, -15,
+ax_anim 2, 0, 65, -1, -15, -1, -15,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sEnteiAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 3, 0, 64, 3, 3, 3, 3,
+ax_anim 6, 0, 64, 6, 6, 6, 6,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 65, -4, -4, -4, -4,
+ax_anim 1, 0, 65, -11, -10, -11, -10,
+ax_anim 2, 0, 68, -16, -18, -16, -18,
+ax_anim 2, 1, 68, -15, -19, -15, -19,
+ax_anim 2, 0, 68, -16, -18, -16, -18,
+ax_anim 2, 0, 68, -15, -19, -15, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sEnteiAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 3, 0, 67, 3, 0, 3, 0,
+ax_anim 6, 0, 67, 6, 0, 6, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -8, 0, -8, 0,
+ax_anim 2, 0, 71, -18, -1, -18, -1,
+ax_anim 2, 1, 71, -18, 0, -18, 0,
+ax_anim 2, 0, 71, -18, -1, -18, -1,
+ax_anim 2, 0, 71, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sEnteiAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 3, 0, 70, 3, -3, 3, -3,
+ax_anim 6, 0, 70, 6, -6, 6, -6,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -11, 10, -11, 10,
+ax_anim 2, 0, 50, -20, 18, -20, 18,
+ax_anim 2, 1, 50, -19, 19, -19, 19,
+ax_anim 2, 0, 50, -20, 18, -20, 18,
+ax_anim 2, 0, 50, -19, 19, -19, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sEnteiAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, -3, 0, -3,
+ax_anim 6, 0, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -2, 0, -2,
+ax_anim 2, 2, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 74, -1, 2, -1, 2,
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 74, -1, 2, -1, 2,
+ax_anim 2, 1, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 74, -1, 2, -1, 2,
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 74, -1, 2, -1, 2,
+ax_anim 4, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sEnteiAnims_4_2:
+ax_anim 2, 0, 75, -2, -2, -2, -2,
+ax_anim 2, 0, 76, -3, -3, -3, -3,
+ax_anim 6, 0, 76, -4, -4, -4, -4,
+ax_anim 1, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 2, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 1, 3, 1, 3,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 1, 3, 1, 3,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 1, 3, 1, 3,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 1, 3, 1, 3,
+ax_anim 4, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sEnteiAnims_4_3:
+ax_anim 2, 0, 78, -2, 0, -2, 0,
+ax_anim 2, 0, 79, -3, 0, -3, 0,
+ax_anim 6, 0, 79, -4, 0, -4, 0,
+ax_anim 1, 0, 80, -2, 0, -2, 0,
+ax_anim 2, 2, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, -1, 2, -1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, -1, 2, -1,
+ax_anim 2, 1, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, -1, 2, -1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, -1, 2, -1,
+ax_anim 4, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sEnteiAnims_4_4:
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim 2, 0, 82, -3, 3, -3, 3,
+ax_anim 6, 0, 82, -4, 4, -4, 4,
+ax_anim 1, 0, 83, -2, 2, -2, 2,
+ax_anim 2, 2, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 1, -3, 1, -3,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 1, -3, 1, -3,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 1, -3, 1, -3,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 1, -3, 1, -3,
+ax_anim 4, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sEnteiAnims_4_5:
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 2, 0, 85, 0, 3, 0, 3,
+ax_anim 6, 0, 85, 0, 4, 0, 4,
+ax_anim 1, 0, 86, 0, 2, 0, 2,
+ax_anim 2, 2, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 86, -1, -3, -1, -2,
+ax_anim 2, 0, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 86, -1, -3, -1, -2,
+ax_anim 2, 1, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 86, -1, -3, -1, -2,
+ax_anim 2, 0, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 86, -1, -3, -1, -2,
+ax_anim 4, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sEnteiAnims_4_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 88, 3, 3, 3, 3,
+ax_anim 6, 0, 88, 4, 4, 4, 4,
+ax_anim 1, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 2, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -1, -3, -1, -3,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -1, -3, -1, -3,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -1, -3, -1, -3,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -1, -3, -1, -3,
+ax_anim 4, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sEnteiAnims_4_7:
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim 2, 0, 91, 3, 0, 3, 0,
+ax_anim 6, 0, 91, 4, 0, 4, 0,
+ax_anim 1, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 2, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, -1, -2, -1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, -1, -2, -1,
+ax_anim 2, 1, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, -1, -2, -1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, -1, -2, -1,
+ax_anim 4, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sEnteiAnims_4_8:
+ax_anim 2, 0, 93, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 3, -3, 3, -3,
+ax_anim 6, 0, 94, 4, -4, 4, -4,
+ax_anim 1, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 2, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -1, 3, -1, 3,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -1, 3, -1, 3,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -1, 3, -1, 3,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -1, 3, -1, 3,
+ax_anim 4, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sEnteiAnims_5_1:
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 2, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 2, 0, 2,
+ax_anim 2, 0, 99, -1, 2, -1, 2,
+ax_anim 2, 0, 99, 0, 2, 0, 2,
+ax_anim 2, 0, 99, -1, 2, -1, 2,
+ax_anim 2, 1, 99, 0, 2, 0, 2,
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_5_2:
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 2, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 2, 0, 103, 1, 3, 1, 3,
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 2, 0, 103, 1, 3, 1, 3,
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 2, 1, 103, 1, 3, 1, 3,
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_5_3:
+ax_anim 2, 0, 104, -2, 0, -2, 0,
+ax_anim 2, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 2, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -3, 0, -3, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 4, 0, 4, 0,
+ax_anim 2, 0, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 1, 107, 1, 0, 1, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_5_4:
+ax_anim 2, 0, 108, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -3, 3, -3, 3,
+ax_anim 2, 0, 109, -2, 4, -2, 4,
+ax_anim 2, 2, 109, -3, 3, -3, 3,
+ax_anim 2, 0, 109, -2, 4, -2, 4,
+ax_anim 2, 0, 109, -3, 3, -3, 3,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 2, -2, 2, -2,
+ax_anim 2, 0, 111, 1, -3, 1, -3,
+ax_anim 2, 0, 111, 2, -2, 2, -2,
+ax_anim 2, 0, 111, 1, -3, 1, -3,
+ax_anim 2, 0, 111, 2, -2, 2, -2,
+ax_anim 2, 1, 111, 1, -3, 1, -3,
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_5_5:
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim 2, 0, 113, 0, 3, 0, 3,
+ax_anim 2, 0, 113, -1, 3, -1, 3,
+ax_anim 2, 2, 113, 0, 3, 0, 3,
+ax_anim 2, 0, 113, -1, 3, -1, 3,
+ax_anim 2, 0, 113, 0, 3, 0, 3,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, -3,
+ax_anim 2, 0, 115, -1, -3, -1, -3,
+ax_anim 2, 0, 115, 0, -3, 0, -3,
+ax_anim 2, 0, 115, -1, -3, -1, -3,
+ax_anim 2, 0, 115, 0, -3, 0, -3,
+ax_anim 2, 1, 115, -1, -3, -1, -3,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_5_6:
+ax_anim 2, 0, 116, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 3, 3, 3, 3,
+ax_anim 2, 0, 117, 2, 4, 2, 4,
+ax_anim 2, 2, 117, 3, 3, 3, 3,
+ax_anim 2, 0, 117, 2, 4, 2, 4,
+ax_anim 2, 0, 117, 3, 3, 3, 3,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -3, -1, -3,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -3, -1, -3,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim 2, 1, 119, -1, -3, -1, -3,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_5_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 121, 3, 0, 3, 0,
+ax_anim 2, 0, 121, 3, -1, 3, -1,
+ax_anim 2, 2, 121, 3, 0, 3, 0,
+ax_anim 2, 0, 121, 3, -1, 3, -1,
+ax_anim 2, 0, 121, 3, 0, 3, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -4, 0, -4, 0,
+ax_anim 2, 0, 123, -3, 0, -3, 0,
+ax_anim 2, 0, 123, -3, -1, -3, -1,
+ax_anim 2, 0, 123, -3, 0, -3, 0,
+ax_anim 2, 0, 123, -3, -1, -3, -1,
+ax_anim 2, 1, 123, -1, 0, -1, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_5_8:
+ax_anim 2, 0, 124, 2, -2, 2, -2,
+ax_anim 2, 0, 125, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 2, -4, 2, -4,
+ax_anim 2, 2, 125, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 2, -4, 2, -4,
+ax_anim 2, 0, 125, 3, -3, 3, -3,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -1, 3, -1, 3,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -1, 3, -1, 3,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 1, 127, -1, 3, -1, 3,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sEnteiAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sEnteiAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sEnteiAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sEnteiAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sEnteiAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sEnteiAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sEnteiAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sEnteiAnims_8_1:
+ax_anim 60, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_8_2:
+ax_anim 60, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_8_3:
+ax_anim 60, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_8_4:
+ax_anim 60, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_8_5:
+ax_anim 60, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -1, 0, -1, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_8_6:
+ax_anim 60, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_8_7:
+ax_anim 60, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_8_8:
+ax_anim 60, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 10, 9, 10, 9,
+ax_anim 2, 0, 165, 7, 19, 7, 19,
+ax_anim 3, 0, 166, 0, 22, 0, 22,
+ax_anim 2, 3, 167, -7, 19, -7, 19,
+ax_anim 2, 0, 168, -10, 9, -10, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 24, 9, 24, 9,
+ax_anim 3, 0, 165, 21, 18, 21, 18,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 12, 2, 12,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 20, 1, 20, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -3, -6, -3, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 10, -20, 10, -20,
+ax_anim 3, 0, 163, 16, -20, 16, -20,
+ax_anim 2, 3, 164, 20, -12, 20, -12,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -10, -10, -10, -10,
+ax_anim 2, 0, 169, -8, -16, -8, -16,
+ax_anim 3, 0, 162, 0, -17, 0, -17,
+ax_anim 2, 3, 163, 8, -16, 8, -16,
+ax_anim 2, 0, 164, 10, -10, 10, -10,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 3, -6, 3, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -10, -20, -10, -20,
+ax_anim 3, 0, 169, -16, -20, -16, -20,
+ax_anim 2, 3, 168, -20, -12, -20, -12,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -20, 1, -20, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -24, 9, -24, 9,
+ax_anim 3, 0, 167, -21, 18, -21, 18,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -2, 12, -2, 12,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -19, 0, 0,
+ax_anim 2, 0, 178, 0, -15, 0, 0,
+ax_anim 1, 0, 178, 0, -9, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEnteiAnims_14_1:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_14_2:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_14_3:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_14_4:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_14_5:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_14_6:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_14_7:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiAnims_14_8:
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 14, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 1, 0, 1,
+ax_anim 14, 0, 221, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sEnteiGfx1:
+.incbin "baserom.gba", 0xFEBC30, 0x200
+sEnteiSprites1:
+ax_sprite sEnteiGfx1, 0x200
+ax_sprite_terminator
+sEnteiGfx2:
+.incbin "baserom.gba", 0xFEBE40, 0x200
+sEnteiSprites2:
+ax_sprite sEnteiGfx2, 0x200
+ax_sprite_terminator
+sEnteiGfx3:
+.incbin "baserom.gba", 0xFEC050, 0x200
+sEnteiSprites3:
+ax_sprite sEnteiGfx3, 0x200
+ax_sprite_terminator
+sEnteiGfx4:
+.incbin "baserom.gba", 0xFEC260, 0x200
+sEnteiSprites4:
+ax_sprite sEnteiGfx4, 0x200
+ax_sprite_terminator
+sEnteiGfx5:
+.incbin "baserom.gba", 0xFEC470, 0x200
+sEnteiSprites5:
+ax_sprite sEnteiGfx5, 0x200
+ax_sprite_terminator
+sEnteiGfx6:
+.incbin "baserom.gba", 0xFEC680, 0x200
+sEnteiSprites6:
+ax_sprite sEnteiGfx6, 0x200
+ax_sprite_terminator
+sEnteiGfx7:
+.incbin "baserom.gba", 0xFEC890, 0x200
+sEnteiSprites7:
+ax_sprite sEnteiGfx7, 0x200
+ax_sprite_terminator
+sEnteiGfx8:
+.incbin "baserom.gba", 0xFECAA0, 0x200
+sEnteiSprites8:
+ax_sprite sEnteiGfx8, 0x200
+ax_sprite_terminator
+sEnteiGfx9:
+.incbin "baserom.gba", 0xFECCB0, 0x200
+sEnteiSprites9:
+ax_sprite sEnteiGfx9, 0x200
+ax_sprite_terminator
+sEnteiGfx10:
+.incbin "baserom.gba", 0xFECEC0, 0x200
+sEnteiSprites10:
+ax_sprite sEnteiGfx10, 0x200
+ax_sprite_terminator
+sEnteiGfx11:
+.incbin "baserom.gba", 0xFED0D0, 0x200
+sEnteiSprites11:
+ax_sprite sEnteiGfx11, 0x200
+ax_sprite_terminator
+sEnteiGfx12:
+.incbin "baserom.gba", 0xFED2E0, 0x100
+sEnteiSprites12:
+ax_sprite sEnteiGfx12, 0x100
+ax_sprite_terminator
+sEnteiGfx13:
+.incbin "baserom.gba", 0xFED3F0, 0x80
+sEnteiSprites13:
+ax_sprite sEnteiGfx13, 0x80
+ax_sprite_terminator
+sEnteiGfx14:
+.incbin "baserom.gba", 0xFED480, 0x40
+sEnteiSprites14:
+ax_sprite sEnteiGfx14, 0x40
+ax_sprite_terminator
+sEnteiGfx15:
+.incbin "baserom.gba", 0xFED4D0, 0x20
+sEnteiSprites15:
+ax_sprite sEnteiGfx15, 0x20
+ax_sprite_terminator
+sEnteiGfx16:
+.incbin "baserom.gba", 0xFED500, 0x20
+sEnteiSprites16:
+ax_sprite sEnteiGfx16, 0x20
+ax_sprite_terminator
+sEnteiGfx17:
+.incbin "baserom.gba", 0xFED530, 0x200
+sEnteiSprites17:
+ax_sprite sEnteiGfx17, 0x200
+ax_sprite_terminator
+sEnteiGfx18:
+.incbin "baserom.gba", 0xFED740, 0x100
+sEnteiSprites18:
+ax_sprite sEnteiGfx18, 0x100
+ax_sprite_terminator
+sEnteiGfx19:
+.incbin "baserom.gba", 0xFED850, 0x80
+sEnteiSprites19:
+ax_sprite sEnteiGfx19, 0x80
+ax_sprite_terminator
+sEnteiGfx20:
+.incbin "baserom.gba", 0xFED8E0, 0x20
+sEnteiSprites20:
+ax_sprite sEnteiGfx20, 0x20
+ax_sprite_terminator
+sEnteiGfx21:
+.incbin "baserom.gba", 0xFED910, 0x20
+sEnteiSprites21:
+ax_sprite sEnteiGfx21, 0x20
+ax_sprite_terminator
+sEnteiGfx22:
+.incbin "baserom.gba", 0xFED940, 0x40
+sEnteiSprites22:
+ax_sprite sEnteiGfx22, 0x40
+ax_sprite_terminator
+sEnteiGfx23:
+.incbin "baserom.gba", 0xFED990, 0x100
+sEnteiSprites23:
+ax_sprite sEnteiGfx23, 0x100
+ax_sprite_terminator
+sEnteiGfx24:
+.incbin "baserom.gba", 0xFEDAA0, 0x80
+sEnteiSprites24:
+ax_sprite sEnteiGfx24, 0x80
+ax_sprite_terminator
+sEnteiGfx25:
+.incbin "baserom.gba", 0xFEDB30, 0x40
+sEnteiSprites25:
+ax_sprite sEnteiGfx25, 0x40
+ax_sprite_terminator
+sEnteiGfx26:
+.incbin "baserom.gba", 0xFEDB80, 0x20
+sEnteiSprites26:
+ax_sprite sEnteiGfx26, 0x20
+ax_sprite_terminator
+sEnteiGfx27:
+.incbin "baserom.gba", 0xFEDBB0, 0x20
+sEnteiSprites27:
+ax_sprite sEnteiGfx27, 0x20
+ax_sprite_terminator
+sEnteiGfx28:
+.incbin "baserom.gba", 0xFEDBE0, 0x100
+sEnteiSprites28:
+ax_sprite sEnteiGfx28, 0x100
+ax_sprite_terminator
+sEnteiGfx29:
+.incbin "baserom.gba", 0xFEDCF0, 0x80
+sEnteiSprites29:
+ax_sprite sEnteiGfx29, 0x80
+ax_sprite_terminator
+sEnteiGfx30:
+.incbin "baserom.gba", 0xFEDD80, 0x40
+sEnteiSprites30:
+ax_sprite sEnteiGfx30, 0x40
+ax_sprite_terminator
+sEnteiGfx31:
+.incbin "baserom.gba", 0xFEDDD0, 0x20
+sEnteiSprites31:
+ax_sprite sEnteiGfx31, 0x20
+ax_sprite_terminator
+sEnteiGfx32:
+.incbin "baserom.gba", 0xFEDE00, 0x20
+sEnteiSprites32:
+ax_sprite sEnteiGfx32, 0x20
+ax_sprite_terminator
+sEnteiGfx33:
+.incbin "baserom.gba", 0xFEDE30, 0x40
+sEnteiGfx33_1:
+.incbin "baserom.gba", 0xFEDE70, 0x180
+sEnteiSprites33:
+ax_sprite 0, 0x20
+ax_sprite sEnteiGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sEnteiGfx33_1, 0x180
+ax_sprite_terminator
+sEnteiGfx34:
+.incbin "baserom.gba", 0xFEE018, 0x100
+sEnteiSprites34:
+ax_sprite sEnteiGfx34, 0x100
+ax_sprite_terminator
+sEnteiGfx35:
+.incbin "baserom.gba", 0xFEE128, 0x80
+sEnteiSprites35:
+ax_sprite sEnteiGfx35, 0x80
+ax_sprite_terminator
+sEnteiGfx36:
+.incbin "baserom.gba", 0xFEE1B8, 0x20
+sEnteiSprites36:
+ax_sprite sEnteiGfx36, 0x20
+ax_sprite_terminator
+sEnteiGfx37:
+.incbin "baserom.gba", 0xFEE1E8, 0x20
+sEnteiSprites37:
+ax_sprite sEnteiGfx37, 0x20
+ax_sprite_terminator
+sEnteiGfx38:
+.incbin "baserom.gba", 0xFEE218, 0x20
+sEnteiSprites38:
+ax_sprite sEnteiGfx38, 0x20
+ax_sprite_terminator
+sEnteiGfx39:
+.incbin "baserom.gba", 0xFEE248, 0x60
+sEnteiGfx39_1:
+.incbin "baserom.gba", 0xFEE2A8, 0x180
+sEnteiSprites39:
+ax_sprite sEnteiGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEnteiGfx39_1, 0x180
+ax_sprite_terminator
+sEnteiGfx40:
+.incbin "baserom.gba", 0xFEE448, 0x80
+sEnteiSprites40:
+ax_sprite sEnteiGfx40, 0x80
+ax_sprite_terminator
+sEnteiGfx41:
+.incbin "baserom.gba", 0xFEE4D8, 0x40
+sEnteiSprites41:
+ax_sprite sEnteiGfx41, 0x40
+ax_sprite_terminator
+sEnteiGfx42:
+.incbin "baserom.gba", 0xFEE528, 0x20
+sEnteiSprites42:
+ax_sprite sEnteiGfx42, 0x20
+ax_sprite_terminator
+sEnteiGfx43:
+.incbin "baserom.gba", 0xFEE558, 0x20
+sEnteiSprites43:
+ax_sprite sEnteiGfx43, 0x20
+ax_sprite_terminator
+sEnteiGfx44:
+.incbin "baserom.gba", 0xFEE588, 0x80
+sEnteiSprites44:
+ax_sprite sEnteiGfx44, 0x80
+ax_sprite_terminator
+sEnteiGfx45:
+.incbin "baserom.gba", 0xFEE618, 0x40
+sEnteiSprites45:
+ax_sprite sEnteiGfx45, 0x40
+ax_sprite_terminator
+sEnteiGfx46:
+.incbin "baserom.gba", 0xFEE668, 0x20
+sEnteiSprites46:
+ax_sprite sEnteiGfx46, 0x20
+ax_sprite_terminator
+sEnteiGfx47:
+.incbin "baserom.gba", 0xFEE698, 0x80
+sEnteiSprites47:
+ax_sprite sEnteiGfx47, 0x80
+ax_sprite_terminator
+sEnteiGfx48:
+.incbin "baserom.gba", 0xFEE728, 0x80
+sEnteiSprites48:
+ax_sprite sEnteiGfx48, 0x80
+ax_sprite_terminator
+sEnteiGfx49:
+.incbin "baserom.gba", 0xFEE7B8, 0x20
+sEnteiSprites49:
+ax_sprite sEnteiGfx49, 0x20
+ax_sprite_terminator
+sEnteiGfx50:
+.incbin "baserom.gba", 0xFEE7E8, 0x20
+sEnteiSprites50:
+ax_sprite sEnteiGfx50, 0x20
+ax_sprite_terminator
+sEnteiGfx51:
+.incbin "baserom.gba", 0xFEE818, 0x40
+sEnteiSprites51:
+ax_sprite sEnteiGfx51, 0x40
+ax_sprite_terminator
+sEnteiGfx52:
+.incbin "baserom.gba", 0xFEE868, 0x20
+sEnteiSprites52:
+ax_sprite sEnteiGfx52, 0x20
+ax_sprite_terminator
+sEnteiGfx53:
+.incbin "baserom.gba", 0xFEE898, 0x40
+sEnteiSprites53:
+ax_sprite sEnteiGfx53, 0x40
+ax_sprite_terminator
+sEnteiGfx54:
+.incbin "baserom.gba", 0xFEE8E8, 0x20
+sEnteiSprites54:
+ax_sprite sEnteiGfx54, 0x20
+ax_sprite_terminator
+sEnteiGfx55:
+.incbin "baserom.gba", 0xFEE918, 0x100
+sEnteiSprites55:
+ax_sprite sEnteiGfx55, 0x100
+ax_sprite_terminator
+sEnteiGfx56:
+.incbin "baserom.gba", 0xFEEA28, 0x80
+sEnteiSprites56:
+ax_sprite sEnteiGfx56, 0x80
+ax_sprite_terminator
+sEnteiGfx57:
+.incbin "baserom.gba", 0xFEEAB8, 0x20
+sEnteiSprites57:
+ax_sprite sEnteiGfx57, 0x20
+ax_sprite_terminator
+sEnteiGfx58:
+.incbin "baserom.gba", 0xFEEAE8, 0x20
+sEnteiSprites58:
+ax_sprite sEnteiGfx58, 0x20
+ax_sprite_terminator
+sEnteiGfx59:
+.incbin "baserom.gba", 0xFEEB18, 0x20
+sEnteiSprites59:
+ax_sprite sEnteiGfx59, 0x20
+ax_sprite_terminator
+sEnteiGfx60:
+.incbin "baserom.gba", 0xFEEB48, 0x200
+sEnteiSprites60:
+ax_sprite sEnteiGfx60, 0x200
+ax_sprite_terminator
+sEnteiGfx61:
+.incbin "baserom.gba", 0xFEED58, 0x100
+sEnteiSprites61:
+ax_sprite sEnteiGfx61, 0x100
+ax_sprite_terminator
+sEnteiGfx62:
+.incbin "baserom.gba", 0xFEEE68, 0x80
+sEnteiSprites62:
+ax_sprite sEnteiGfx62, 0x80
+ax_sprite_terminator
+sEnteiGfx63:
+.incbin "baserom.gba", 0xFEEEF8, 0x20
+sEnteiSprites63:
+ax_sprite sEnteiGfx63, 0x20
+ax_sprite_terminator
+sEnteiGfx64:
+.incbin "baserom.gba", 0xFEEF28, 0x20
+sEnteiSprites64:
+ax_sprite sEnteiGfx64, 0x20
+ax_sprite_terminator
+sEnteiGfx65:
+.incbin "baserom.gba", 0xFEEF58, 0x20
+sEnteiSprites65:
+ax_sprite sEnteiGfx65, 0x20
+ax_sprite_terminator
+sEnteiGfx66:
+.incbin "baserom.gba", 0xFEEF88, 0x20
+sEnteiSprites66:
+ax_sprite sEnteiGfx66, 0x20
+ax_sprite_terminator
+sEnteiGfx67:
+.incbin "baserom.gba", 0xFEEFB8, 0x100
+sEnteiGfx67_1:
+.incbin "baserom.gba", 0xFEF0B8, 0xE0
+sEnteiSprites67:
+ax_sprite sEnteiGfx67, 0x100
+ax_sprite 0, 0x20
+ax_sprite sEnteiGfx67_1, 0xe0
+ax_sprite_terminator
+sEnteiGfx68:
+.incbin "baserom.gba", 0xFEF1B8, 0x200
+sEnteiSprites68:
+ax_sprite sEnteiGfx68, 0x200
+ax_sprite_terminator
+sEnteiGfx69:
+.incbin "baserom.gba", 0xFEF3C8, 0x1E0
+sEnteiSprites69:
+ax_sprite sEnteiGfx69, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEnteiGfx70:
+.incbin "baserom.gba", 0xFEF5C0, 0x80
+sEnteiSprites70:
+ax_sprite sEnteiGfx70, 0x80
+ax_sprite_terminator
+sEnteiGfx71:
+.incbin "baserom.gba", 0xFEF650, 0x20
+sEnteiSprites71:
+ax_sprite sEnteiGfx71, 0x20
+ax_sprite_terminator
+sEnteiGfx72:
+.incbin "baserom.gba", 0xFEF680, 0x20
+sEnteiSprites72:
+ax_sprite sEnteiGfx72, 0x20
+ax_sprite_terminator
+sEnteiGfx73:
+.incbin "baserom.gba", 0xFEF6B0, 0x40
+sEnteiSprites73:
+ax_sprite sEnteiGfx73, 0x40
+ax_sprite_terminator
+sEnteiGfx74:
+.incbin "baserom.gba", 0xFEF700, 0x80
+sEnteiSprites74:
+ax_sprite sEnteiGfx74, 0x80
+ax_sprite_terminator
+sEnteiGfx75:
+.incbin "baserom.gba", 0xFEF790, 0x20
+sEnteiSprites75:
+ax_sprite sEnteiGfx75, 0x20
+ax_sprite_terminator
+sEnteiGfx76:
+.incbin "baserom.gba", 0xFEF7C0, 0x20
+sEnteiSprites76:
+ax_sprite sEnteiGfx76, 0x20
+ax_sprite_terminator
+sEnteiGfx77:
+.incbin "baserom.gba", 0xFEF7F0, 0x40
+sEnteiSprites77:
+ax_sprite sEnteiGfx77, 0x40
+ax_sprite_terminator
+sEnteiGfx78:
+.incbin "baserom.gba", 0xFEF840, 0x180
+sEnteiGfx78_1:
+.incbin "baserom.gba", 0xFEF9C0, 0x40
+sEnteiSprites78:
+ax_sprite sEnteiGfx78, 0x180
+ax_sprite 0, 0x40
+ax_sprite sEnteiGfx78_1, 0x40
+ax_sprite_terminator
+sEnteiGfx79:
+.incbin "baserom.gba", 0xFEFA20, 0x40
+sEnteiGfx79_1:
+.incbin "baserom.gba", 0xFEFA60, 0x180
+sEnteiSprites79:
+ax_sprite 0, 0x20
+ax_sprite sEnteiGfx79, 0x40
+ax_sprite 0, 0x20
+ax_sprite sEnteiGfx79_1, 0x180
+ax_sprite_terminator
+sEnteiGfx80:
+.incbin "baserom.gba", 0xFEFC08, 0x200
+sEnteiSprites80:
+ax_sprite sEnteiGfx80, 0x200
+ax_sprite_terminator
+sEnteiGfx81:
+.incbin "baserom.gba", 0xFEFE18, 0x200
+sEnteiSprites81:
+ax_sprite sEnteiGfx81, 0x200
+ax_sprite_terminator
+sEnteiGfx82:
+.incbin "baserom.gba", 0xFF0028, 0x200
+sEnteiSprites82:
+ax_sprite sEnteiGfx82, 0x200
+ax_sprite_terminator
+sEnteiGfx83:
+.incbin "baserom.gba", 0xFF0238, 0x200
+sEnteiSprites83:
+ax_sprite sEnteiGfx83, 0x200
+ax_sprite_terminator
+sEnteiGfx84:
+.incbin "baserom.gba", 0xFF0448, 0x200
+sEnteiSprites84:
+ax_sprite sEnteiGfx84, 0x200
+ax_sprite_terminator
+sEnteiGfx85:
+.incbin "baserom.gba", 0xFF0658, 0x200
+sEnteiSprites85:
+ax_sprite sEnteiGfx85, 0x200
+ax_sprite_terminator
+sEnteiGfx86:
+.incbin "baserom.gba", 0xFF0868, 0x200
+sEnteiSprites86:
+ax_sprite sEnteiGfx86, 0x200
+ax_sprite_terminator
+sEnteiGfx87:
+.incbin "baserom.gba", 0xFF0A78, 0x200
+sEnteiSprites87:
+ax_sprite sEnteiGfx87, 0x200
+ax_sprite_terminator
+sAxPosesEntei:
+.4byte sEnteiPose1
+.4byte sEnteiPose2
+.4byte sEnteiPose3
+.4byte sEnteiPose4
+.4byte sEnteiPose5
+.4byte sEnteiPose6
+.4byte sEnteiPose7
+.4byte sEnteiPose8
+.4byte sEnteiPose9
+.4byte sEnteiPose10
+.4byte sEnteiPose11
+.4byte sEnteiPose12
+.4byte sEnteiPose13
+.4byte sEnteiPose14
+.4byte sEnteiPose15
+.4byte sEnteiPose16
+.4byte sEnteiPose17
+.4byte sEnteiPose18
+.4byte sEnteiPose19
+.4byte sEnteiPose20
+.4byte sEnteiPose21
+.4byte sEnteiPose22
+.4byte sEnteiPose23
+.4byte sEnteiPose24
+.4byte sEnteiPose25
+.4byte sEnteiPose26
+.4byte sEnteiPose27
+.4byte sEnteiPose28
+.4byte sEnteiPose29
+.4byte sEnteiPose30
+.4byte sEnteiPose31
+.4byte sEnteiPose32
+.4byte sEnteiPose33
+.4byte sEnteiPose34
+.4byte sEnteiPose35
+.4byte sEnteiPose36
+.4byte sEnteiPose37
+.4byte sEnteiPose38
+.4byte sEnteiPose39
+.4byte sEnteiPose40
+.4byte sEnteiPose41
+.4byte sEnteiPose42
+.4byte sEnteiPose43
+.4byte sEnteiPose44
+.4byte sEnteiPose45
+.4byte sEnteiPose46
+.4byte sEnteiPose47
+.4byte sEnteiPose48
+.4byte sEnteiPose49
+.4byte sEnteiPose50
+.4byte sEnteiPose51
+.4byte sEnteiPose52
+.4byte sEnteiPose53
+.4byte sEnteiPose54
+.4byte sEnteiPose55
+.4byte sEnteiPose56
+.4byte sEnteiPose57
+.4byte sEnteiPose58
+.4byte sEnteiPose59
+.4byte sEnteiPose60
+.4byte sEnteiPose61
+.4byte sEnteiPose62
+.4byte sEnteiPose63
+.4byte sEnteiPose64
+.4byte sEnteiPose65
+.4byte sEnteiPose66
+.4byte sEnteiPose67
+.4byte sEnteiPose68
+.4byte sEnteiPose69
+.4byte sEnteiPose70
+.4byte sEnteiPose71
+.4byte sEnteiPose72
+.4byte sEnteiPose73
+.4byte sEnteiPose74
+.4byte sEnteiPose75
+.4byte sEnteiPose76
+.4byte sEnteiPose77
+.4byte sEnteiPose78
+.4byte sEnteiPose79
+.4byte sEnteiPose80
+.4byte sEnteiPose81
+.4byte sEnteiPose82
+.4byte sEnteiPose83
+.4byte sEnteiPose84
+.4byte sEnteiPose85
+.4byte sEnteiPose86
+.4byte sEnteiPose87
+.4byte sEnteiPose88
+.4byte sEnteiPose89
+.4byte sEnteiPose90
+.4byte sEnteiPose91
+.4byte sEnteiPose92
+.4byte sEnteiPose93
+.4byte sEnteiPose94
+.4byte sEnteiPose95
+.4byte sEnteiPose96
+.4byte sEnteiPose97
+.4byte sEnteiPose98
+.4byte sEnteiPose99
+.4byte sEnteiPose100
+.4byte sEnteiPose101
+.4byte sEnteiPose102
+.4byte sEnteiPose103
+.4byte sEnteiPose104
+.4byte sEnteiPose105
+.4byte sEnteiPose106
+.4byte sEnteiPose107
+.4byte sEnteiPose108
+.4byte sEnteiPose109
+.4byte sEnteiPose110
+.4byte sEnteiPose111
+.4byte sEnteiPose112
+.4byte sEnteiPose113
+.4byte sEnteiPose114
+.4byte sEnteiPose115
+.4byte sEnteiPose116
+.4byte sEnteiPose117
+.4byte sEnteiPose118
+.4byte sEnteiPose119
+.4byte sEnteiPose120
+.4byte sEnteiPose121
+.4byte sEnteiPose122
+.4byte sEnteiPose123
+.4byte sEnteiPose124
+.4byte sEnteiPose125
+.4byte sEnteiPose126
+.4byte sEnteiPose127
+.4byte sEnteiPose128
+.4byte sEnteiPose129
+.4byte sEnteiPose130
+.4byte sEnteiPose131
+.4byte sEnteiPose132
+.4byte sEnteiPose133
+.4byte sEnteiPose134
+.4byte sEnteiPose135
+.4byte sEnteiPose136
+.4byte sEnteiPose137
+.4byte sEnteiPose138
+.4byte sEnteiPose139
+.4byte sEnteiPose140
+.4byte sEnteiPose141
+.4byte sEnteiPose142
+.4byte sEnteiPose143
+.4byte sEnteiPose144
+.4byte sEnteiPose145
+.4byte sEnteiPose146
+.4byte sEnteiPose147
+.4byte sEnteiPose148
+.4byte sEnteiPose149
+.4byte sEnteiPose150
+.4byte sEnteiPose151
+.4byte sEnteiPose152
+.4byte sEnteiPose153
+.4byte sEnteiPose154
+.4byte sEnteiPose155
+.4byte sEnteiPose156
+.4byte sEnteiPose157
+.4byte sEnteiPose158
+.4byte sEnteiPose159
+.4byte sEnteiPose160
+.4byte sEnteiPose161
+.4byte sEnteiPose162
+.4byte sEnteiPose163
+.4byte sEnteiPose164
+.4byte sEnteiPose165
+.4byte sEnteiPose166
+.4byte sEnteiPose167
+.4byte sEnteiPose168
+.4byte sEnteiPose169
+.4byte sEnteiPose170
+.4byte sEnteiPose171
+.4byte sEnteiPose172
+.4byte sEnteiPose173
+.4byte sEnteiPose174
+.4byte sEnteiPose175
+.4byte sEnteiPose176
+.4byte sEnteiPose177
+.4byte sEnteiPose178
+.4byte sEnteiPose179
+.4byte sEnteiPose180
+.4byte sEnteiPose181
+.4byte sEnteiPose182
+.4byte sEnteiPose183
+.4byte sEnteiPose184
+.4byte sEnteiPose185
+.4byte sEnteiPose186
+.4byte sEnteiPose187
+.4byte sEnteiPose188
+.4byte sEnteiPose189
+.4byte sEnteiPose190
+.4byte sEnteiPose191
+.4byte sEnteiPose192
+.4byte sEnteiPose193
+.4byte sEnteiPose194
+.4byte sEnteiPose195
+.4byte sEnteiPose196
+.4byte sEnteiPose197
+.4byte sEnteiPose198
+.4byte sEnteiPose199
+.4byte sEnteiPose200
+.4byte sEnteiPose201
+.4byte sEnteiPose202
+.4byte sEnteiPose203
+.4byte sEnteiPose204
+.4byte sEnteiPose205
+.4byte sEnteiPose206
+.4byte sEnteiPose207
+.4byte sEnteiPose208
+.4byte sEnteiPose209
+.4byte sEnteiPose210
+.4byte sEnteiPose211
+.4byte sEnteiPose212
+.4byte sEnteiPose213
+.4byte sEnteiPose214
+.4byte sEnteiPose215
+.4byte sEnteiPose216
+.4byte sEnteiPose217
+.4byte sEnteiPose218
+.4byte sEnteiPose219
+.4byte sEnteiPose220
+.4byte sEnteiPose221
+.4byte sEnteiPose222
+sAxPositionsEntei:
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -10, 	  -7,    4, 	   6,    2, 	   0,   -8
+.2byte    0,  -10, 	  -6,    2, 	   7,    4, 	   0,   -8
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    9,  -11, 	  11,    2, 	  -2,    1, 	   0,  -11
+.2byte    9,  -11, 	   8,    0, 	   1,    4, 	  -1,  -12
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte   15,  -14, 	  13,   -2, 	   5,    1, 	   3,  -12
+.2byte   15,  -14, 	   3,   -1, 	  12,    1, 	   1,  -12
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte   10,  -19, 	   6,   -8, 	   8,   -2, 	   1,  -13
+.2byte   10,  -19, 	   0,   -4, 	  11,   -4, 	   1,  -12
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte    0,  -23, 	   4,   -5, 	  -5,   -7, 	   0,  -15
+.2byte    0,  -21, 	   5,   -6, 	  -4,   -3, 	   1,  -14
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte  -10,  -19, 	  -6,   -8, 	  -8,   -2, 	  -1,  -13
+.2byte  -10,  -19, 	   0,   -4, 	 -11,   -4, 	  -1,  -12
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -15,  -14, 	 -13,   -2, 	  -5,    1, 	  -3,  -12
+.2byte  -15,  -14, 	  -3,   -1, 	 -12,    1, 	  -1,  -12
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte   -9,  -11, 	 -11,    2, 	   2,    1, 	   0,  -11
+.2byte   -9,  -11, 	  -8,    0, 	  -1,    4, 	   1,  -12
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -10, 	  -7,    4, 	   6,    2, 	   0,   -8
+.2byte    0,  -10, 	  -6,    2, 	   7,    4, 	   0,   -8
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    9,  -11, 	  11,    2, 	  -2,    1, 	   0,  -11
+.2byte    9,  -11, 	   8,    0, 	   1,    4, 	  -1,  -12
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte   15,  -14, 	  13,   -2, 	   5,    1, 	   3,  -12
+.2byte   15,  -14, 	   3,   -1, 	  12,    1, 	   1,  -12
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte   10,  -19, 	   6,   -8, 	   8,   -2, 	   1,  -13
+.2byte   10,  -19, 	   0,   -4, 	  11,   -4, 	   1,  -12
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte    0,  -23, 	   4,   -5, 	  -5,   -7, 	   0,  -15
+.2byte    0,  -21, 	   5,   -6, 	  -4,   -3, 	   1,  -14
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte  -10,  -19, 	  -6,   -8, 	  -8,   -2, 	  -1,  -13
+.2byte  -10,  -19, 	   0,   -4, 	 -11,   -4, 	  -1,  -12
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -15,  -14, 	 -13,   -2, 	  -5,    1, 	  -3,  -12
+.2byte  -15,  -14, 	  -3,   -1, 	 -12,    1, 	  -1,  -12
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte   -9,  -11, 	 -11,    2, 	   2,    1, 	   0,  -11
+.2byte   -9,  -11, 	  -8,    0, 	  -1,    4, 	   1,  -12
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -10, 	  -7,    4, 	   6,    2, 	   0,   -8
+.2byte    0,  -10, 	  -6,    2, 	   7,    4, 	   0,   -8
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    9,  -11, 	  11,    2, 	  -2,    1, 	   0,  -11
+.2byte    9,  -11, 	   8,    0, 	   1,    4, 	  -1,  -12
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte   15,  -14, 	  13,   -2, 	   5,    1, 	   3,  -12
+.2byte   15,  -14, 	   3,   -1, 	  12,    1, 	   1,  -12
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte   10,  -19, 	   6,   -8, 	   8,   -2, 	   1,  -13
+.2byte   10,  -19, 	   0,   -4, 	  11,   -4, 	   1,  -12
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte    0,  -23, 	   4,   -5, 	  -5,   -7, 	   0,  -15
+.2byte    0,  -21, 	   5,   -6, 	  -4,   -3, 	   1,  -14
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte  -10,  -19, 	  -6,   -8, 	  -8,   -2, 	  -1,  -13
+.2byte  -10,  -19, 	   0,   -4, 	 -11,   -4, 	  -1,  -12
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -15,  -14, 	 -13,   -2, 	  -5,    1, 	  -3,  -12
+.2byte  -15,  -14, 	  -3,   -1, 	 -12,    1, 	  -1,  -12
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte   -9,  -11, 	 -11,    2, 	   2,    1, 	   0,  -11
+.2byte   -9,  -11, 	  -8,    0, 	  -1,    4, 	   1,  -12
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -22, 	  -7,    2, 	   7,    2, 	   0,  -13
+.2byte    0,   -7, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    7,  -21, 	   9,    0, 	   0,    2, 	   0,  -14
+.2byte   13,   -9, 	   9,    0, 	   0,    2, 	   2,  -11
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte   11,  -24, 	   7,   -1, 	   8,    1, 	   2,  -17
+.2byte   19,  -10, 	   6,   -1, 	   8,    1, 	   5,  -11
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte    8,  -24, 	   1,   -5, 	  10,   -4, 	   0,  -16
+.2byte   13,  -17, 	   6,   -7, 	  10,   -4, 	   3,  -15
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte    0,  -25, 	   5,   -3, 	  -5,   -3, 	   0,  -15
+.2byte    0,  -21, 	   5,   -4, 	  -5,   -4, 	   0,  -16
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte   -8,  -24, 	  -1,   -5, 	 -10,   -4, 	   0,  -16
+.2byte  -13,  -17, 	  -6,   -7, 	 -10,   -4, 	  -3,  -15
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -11,  -24, 	  -7,   -1, 	  -8,    1, 	  -2,  -17
+.2byte  -19,  -10, 	  -6,   -1, 	  -8,    1, 	  -5,  -11
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte   -7,  -21, 	  -9,    0, 	   0,    2, 	   0,  -14
+.2byte  -13,   -9, 	  -9,    0, 	   0,    2, 	  -2,  -11
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -22, 	  -7,    2, 	   7,    2, 	   0,  -13
+.2byte    0,   -7, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,   -4, 	  -7,    3, 	   7,    6, 	   0,   -6
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    7,  -21, 	   9,    0, 	   0,    2, 	   0,  -14
+.2byte   13,   -9, 	   9,    0, 	   0,    2, 	   2,  -11
+.2byte   13,   -4, 	  11,    1, 	   7,    6, 	   2,   -9
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte   11,  -24, 	   7,   -1, 	   8,    1, 	   2,  -17
+.2byte   19,  -10, 	   6,   -1, 	   8,    1, 	   5,  -11
+.2byte   17,   -7, 	   6,   -1, 	  15,    1, 	   1,  -10
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte    8,  -24, 	   1,   -5, 	  10,   -4, 	   0,  -16
+.2byte   13,  -17, 	   6,   -7, 	  10,   -4, 	   3,  -15
+.2byte   12,  -12, 	   9,  -10, 	  15,   -6, 	   2,  -11
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte    0,  -25, 	   5,   -3, 	  -5,   -3, 	   0,  -15
+.2byte    0,  -21, 	   5,   -4, 	  -5,   -4, 	   0,  -16
+.2byte    0,  -18, 	   5,  -10, 	  -5,   -4, 	   0,  -13
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte   -8,  -24, 	  -1,   -5, 	 -10,   -4, 	   0,  -16
+.2byte  -13,  -17, 	  -6,   -7, 	 -10,   -4, 	  -3,  -15
+.2byte  -10,  -12, 	  -7,  -10, 	 -13,   -6, 	   0,  -11
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -11,  -24, 	  -7,   -1, 	  -8,    1, 	  -2,  -17
+.2byte  -19,  -10, 	  -6,   -1, 	  -8,    1, 	  -5,  -11
+.2byte  -18,   -7, 	  -7,   -1, 	 -16,    1, 	  -2,  -10
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte   -7,  -21, 	  -9,    0, 	   0,    2, 	   0,  -14
+.2byte  -13,   -9, 	  -9,    0, 	   0,    2, 	  -2,  -11
+.2byte  -13,   -4, 	 -11,    1, 	  -7,    6, 	  -2,   -9
+.2byte   -9,   -5, 	 -14,   -1, 	  -4,    2, 	   1,  -10
+.2byte   -9,   -5, 	 -14,   -1, 	  -4,    2, 	   1,   -9
+.2byte    0,   -7, 	 -11,    2, 	  11,    2, 	   0,  -10
+.2byte    8,   -6, 	  13,   -1, 	  -8,    1, 	  -3,  -10
+.2byte   13,   -9, 	  12,   -3, 	   6,    2, 	  -1,  -10
+.2byte   11,  -15, 	   2,  -14, 	  14,   -3, 	   1,  -12
+.2byte    0,  -20, 	   7,   -2, 	  -7,   -2, 	   0,  -13
+.2byte  -12,  -15, 	  -3,  -14, 	 -15,   -3, 	  -2,  -12
+.2byte  -14,   -9, 	 -13,   -3, 	  -7,    2, 	   0,  -10
+.2byte   -9,   -6, 	 -14,   -1, 	   7,    1, 	   2,  -10
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -22, 	  -7,    2, 	   7,    2, 	   0,  -13
+.2byte    0,   -7, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    7,  -21, 	   9,    0, 	   0,    2, 	   0,  -14
+.2byte   13,   -9, 	   9,    0, 	   0,    2, 	   2,  -11
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte   11,  -24, 	   7,   -1, 	   8,    1, 	   2,  -17
+.2byte   19,  -10, 	   6,   -1, 	   8,    1, 	   5,  -11
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte    8,  -24, 	   1,   -5, 	  10,   -4, 	   0,  -16
+.2byte   13,  -17, 	   6,   -7, 	  10,   -4, 	   3,  -15
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte    0,  -25, 	   5,   -3, 	  -5,   -3, 	   0,  -15
+.2byte    0,  -21, 	   5,   -4, 	  -5,   -4, 	   0,  -16
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte   -8,  -24, 	  -1,   -5, 	 -10,   -4, 	   0,  -16
+.2byte  -13,  -17, 	  -6,   -7, 	 -10,   -4, 	  -3,  -15
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -11,  -24, 	  -7,   -1, 	  -8,    1, 	  -2,  -17
+.2byte  -19,  -10, 	  -6,   -1, 	  -8,    1, 	  -5,  -11
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte   -7,  -21, 	  -9,    0, 	   0,    2, 	   0,  -14
+.2byte  -13,   -9, 	  -9,    0, 	   0,    2, 	  -2,  -11
+.2byte    0,  -10, 	  -6,    2, 	   7,    4, 	   0,   -8
+.2byte   -9,  -11, 	  -8,    0, 	  -1,    4, 	   1,  -12
+.2byte  -15,  -14, 	  -3,   -1, 	 -12,    1, 	  -1,  -12
+.2byte  -10,  -19, 	   0,   -4, 	 -11,   -4, 	  -1,  -12
+.2byte    0,  -21, 	   5,   -6, 	  -4,   -3, 	   1,  -14
+.2byte   10,  -19, 	   0,   -4, 	  11,   -4, 	   1,  -12
+.2byte   15,  -14, 	   3,   -1, 	  12,    1, 	   1,  -12
+.2byte    9,  -11, 	   8,    0, 	   1,    4, 	  -1,  -12
+.2byte    0,   -4, 	  -7,    3, 	   7,    6, 	   0,   -6
+.2byte   11,   -5, 	   9,    0, 	   5,    5, 	   0,  -10
+.2byte   17,   -7, 	   6,   -1, 	  15,    1, 	   1,  -10
+.2byte   10,  -13, 	   7,  -11, 	  13,   -7, 	   0,  -12
+.2byte    0,  -16, 	   5,   -8, 	  -5,   -2, 	   0,  -11
+.2byte  -10,  -13, 	  -7,  -11, 	 -13,   -7, 	   0,  -12
+.2byte  -18,   -7, 	  -7,   -1, 	 -16,    1, 	  -2,  -10
+.2byte  -11,   -5, 	  -9,    0, 	  -5,    5, 	   0,  -10
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -22, 	  -7,    2, 	   7,    2, 	   0,  -13
+.2byte    0,   -4, 	  -7,    3, 	   7,    6, 	   0,   -6
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    7,  -21, 	   9,    0, 	   0,    2, 	   0,  -14
+.2byte   10,   -5, 	   8,    0, 	   4,    5, 	  -1,  -10
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte   11,  -24, 	   7,   -1, 	   8,    1, 	   2,  -17
+.2byte   16,   -7, 	   5,   -1, 	  14,    1, 	   0,  -10
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte    8,  -24, 	   1,   -5, 	  10,   -4, 	   0,  -16
+.2byte   11,  -15, 	   8,  -13, 	  14,   -9, 	   1,  -14
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte    0,  -25, 	   5,   -3, 	  -5,   -3, 	   0,  -15
+.2byte    0,  -16, 	   5,   -8, 	  -5,   -2, 	   0,  -11
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte   -8,  -24, 	  -1,   -5, 	 -10,   -4, 	   0,  -16
+.2byte  -11,  -15, 	  -8,  -13, 	 -14,   -9, 	  -1,  -14
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -11,  -24, 	  -7,   -1, 	  -8,    1, 	  -2,  -17
+.2byte  -16,   -7, 	  -5,   -1, 	 -14,    1, 	   0,  -10
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte   -7,  -21, 	  -9,    0, 	   0,    2, 	   0,  -14
+.2byte  -10,   -5, 	  -8,    0, 	  -4,    5, 	   1,  -10
+.2byte    0,  -22, 	  -7,    2, 	   7,    2, 	   0,  -13
+.2byte   -7,  -21, 	  -9,    0, 	   0,    2, 	   0,  -14
+.2byte  -11,  -24, 	  -7,   -1, 	  -8,    1, 	  -2,  -17
+.2byte   -8,  -24, 	  -1,   -5, 	 -10,   -4, 	   0,  -16
+.2byte    0,  -25, 	   5,   -3, 	  -5,   -3, 	   0,  -15
+.2byte    8,  -24, 	   1,   -5, 	  10,   -4, 	   0,  -16
+.2byte   11,  -24, 	   7,   -1, 	   8,    1, 	   2,  -17
+.2byte    7,  -21, 	   9,    0, 	   0,    2, 	   0,  -14
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte   -9,  -12, 	  -9,    0, 	   0,    2, 	  -1,  -12
+.2byte  -15,  -15, 	  -8,   -3, 	  -8,    1, 	  -3,  -13
+.2byte  -10,  -20, 	  -1,   -7, 	 -10,   -4, 	  -1,  -13
+.2byte    0,  -24, 	   5,   -6, 	  -5,   -6, 	   0,  -16
+.2byte   10,  -20, 	   1,   -7, 	  10,   -4, 	   1,  -13
+.2byte   15,  -15, 	   8,   -3, 	   8,    1, 	   3,  -13
+.2byte    9,  -12, 	   9,    0, 	   0,    2, 	   1,  -12
+.2byte    0,  -11, 	  -7,    2, 	   7,    2, 	   0,   -9
+.2byte    0,  -22, 	  -7,    2, 	   7,    2, 	   0,  -13
+.2byte    0,  -16, 	  -7,    2, 	   7,    2, 	   0,  -11
+.2byte    0,   -7, 	  -7,    2, 	   7,    2, 	   0,   -9
+sEnteiAnimTable1:
+.4byte sEnteiAnims_1_1
+.4byte sEnteiAnims_1_2
+.4byte sEnteiAnims_1_3
+.4byte sEnteiAnims_1_4
+.4byte sEnteiAnims_1_5
+.4byte sEnteiAnims_1_6
+.4byte sEnteiAnims_1_7
+.4byte sEnteiAnims_1_8
+sEnteiAnimTable2:
+.4byte sEnteiAnims_2_1
+.4byte sEnteiAnims_2_2
+.4byte sEnteiAnims_2_3
+.4byte sEnteiAnims_2_4
+.4byte sEnteiAnims_2_5
+.4byte sEnteiAnims_2_6
+.4byte sEnteiAnims_2_7
+.4byte sEnteiAnims_2_8
+sEnteiAnimTable3:
+.4byte sEnteiAnims_3_1
+.4byte sEnteiAnims_3_2
+.4byte sEnteiAnims_3_3
+.4byte sEnteiAnims_3_4
+.4byte sEnteiAnims_3_5
+.4byte sEnteiAnims_3_6
+.4byte sEnteiAnims_3_7
+.4byte sEnteiAnims_3_8
+sEnteiAnimTable4:
+.4byte sEnteiAnims_4_1
+.4byte sEnteiAnims_4_2
+.4byte sEnteiAnims_4_3
+.4byte sEnteiAnims_4_4
+.4byte sEnteiAnims_4_5
+.4byte sEnteiAnims_4_6
+.4byte sEnteiAnims_4_7
+.4byte sEnteiAnims_4_8
+sEnteiAnimTable5:
+.4byte sEnteiAnims_5_1
+.4byte sEnteiAnims_5_2
+.4byte sEnteiAnims_5_3
+.4byte sEnteiAnims_5_4
+.4byte sEnteiAnims_5_5
+.4byte sEnteiAnims_5_6
+.4byte sEnteiAnims_5_7
+.4byte sEnteiAnims_5_8
+sEnteiAnimTable6:
+.4byte sEnteiAnims_6_1
+.4byte sEnteiAnims_6_1
+.4byte sEnteiAnims_6_1
+.4byte sEnteiAnims_6_1
+.4byte sEnteiAnims_6_1
+.4byte sEnteiAnims_6_1
+.4byte sEnteiAnims_6_1
+.4byte sEnteiAnims_6_1
+sEnteiAnimTable7:
+.4byte sEnteiAnims_7_1
+.4byte sEnteiAnims_7_2
+.4byte sEnteiAnims_7_3
+.4byte sEnteiAnims_7_4
+.4byte sEnteiAnims_7_5
+.4byte sEnteiAnims_7_6
+.4byte sEnteiAnims_7_7
+.4byte sEnteiAnims_7_8
+sEnteiAnimTable8:
+.4byte sEnteiAnims_8_1
+.4byte sEnteiAnims_8_2
+.4byte sEnteiAnims_8_3
+.4byte sEnteiAnims_8_4
+.4byte sEnteiAnims_8_5
+.4byte sEnteiAnims_8_6
+.4byte sEnteiAnims_8_7
+.4byte sEnteiAnims_8_8
+sEnteiAnimTable9:
+.4byte sEnteiAnims_9_1
+.4byte sEnteiAnims_9_2
+.4byte sEnteiAnims_9_3
+.4byte sEnteiAnims_9_4
+.4byte sEnteiAnims_9_5
+.4byte sEnteiAnims_9_6
+.4byte sEnteiAnims_9_7
+.4byte sEnteiAnims_9_8
+sEnteiAnimTable10:
+.4byte sEnteiAnims_10_1
+.4byte sEnteiAnims_10_2
+.4byte sEnteiAnims_10_3
+.4byte sEnteiAnims_10_4
+.4byte sEnteiAnims_10_5
+.4byte sEnteiAnims_10_6
+.4byte sEnteiAnims_10_7
+.4byte sEnteiAnims_10_8
+sEnteiAnimTable11:
+.4byte sEnteiAnims_11_1
+.4byte sEnteiAnims_11_2
+.4byte sEnteiAnims_11_3
+.4byte sEnteiAnims_11_4
+.4byte sEnteiAnims_11_5
+.4byte sEnteiAnims_11_6
+.4byte sEnteiAnims_11_7
+.4byte sEnteiAnims_11_8
+sEnteiAnimTable12:
+.4byte sEnteiAnims_12_1
+.4byte sEnteiAnims_12_2
+.4byte sEnteiAnims_12_3
+.4byte sEnteiAnims_12_4
+.4byte sEnteiAnims_12_5
+.4byte sEnteiAnims_12_6
+.4byte sEnteiAnims_12_7
+.4byte sEnteiAnims_12_8
+sEnteiAnimTable13:
+.4byte sEnteiAnims_13_1
+.4byte sEnteiAnims_13_2
+.4byte sEnteiAnims_13_3
+.4byte sEnteiAnims_13_4
+.4byte sEnteiAnims_13_5
+.4byte sEnteiAnims_13_6
+.4byte sEnteiAnims_13_7
+.4byte sEnteiAnims_13_8
+sEnteiAnimTable14:
+.4byte sEnteiAnims_14_1
+.4byte sEnteiAnims_14_2
+.4byte sEnteiAnims_14_3
+.4byte sEnteiAnims_14_4
+.4byte sEnteiAnims_14_5
+.4byte sEnteiAnims_14_6
+.4byte sEnteiAnims_14_7
+.4byte sEnteiAnims_14_8
+sAxAnimationsEntei:
+.4byte sEnteiAnimTable1
+.4byte sEnteiAnimTable2
+.4byte sEnteiAnimTable3
+.4byte sEnteiAnimTable4
+.4byte sEnteiAnimTable5
+.4byte sEnteiAnimTable6
+.4byte sEnteiAnimTable7
+.4byte sEnteiAnimTable8
+.4byte sEnteiAnimTable9
+.4byte sEnteiAnimTable10
+.4byte sEnteiAnimTable11
+.4byte sEnteiAnimTable12
+.4byte sEnteiAnimTable13
+.4byte sEnteiAnimTable14
+sAxSpritesEntei:
+.4byte sEnteiSprites1
+.4byte sEnteiSprites2
+.4byte sEnteiSprites3
+.4byte sEnteiSprites4
+.4byte sEnteiSprites5
+.4byte sEnteiSprites6
+.4byte sEnteiSprites7
+.4byte sEnteiSprites8
+.4byte sEnteiSprites9
+.4byte sEnteiSprites10
+.4byte sEnteiSprites11
+.4byte sEnteiSprites12
+.4byte sEnteiSprites13
+.4byte sEnteiSprites14
+.4byte sEnteiSprites15
+.4byte sEnteiSprites16
+.4byte sEnteiSprites17
+.4byte sEnteiSprites18
+.4byte sEnteiSprites19
+.4byte sEnteiSprites20
+.4byte sEnteiSprites21
+.4byte sEnteiSprites22
+.4byte sEnteiSprites23
+.4byte sEnteiSprites24
+.4byte sEnteiSprites25
+.4byte sEnteiSprites26
+.4byte sEnteiSprites27
+.4byte sEnteiSprites28
+.4byte sEnteiSprites29
+.4byte sEnteiSprites30
+.4byte sEnteiSprites31
+.4byte sEnteiSprites32
+.4byte sEnteiSprites33
+.4byte sEnteiSprites34
+.4byte sEnteiSprites35
+.4byte sEnteiSprites36
+.4byte sEnteiSprites37
+.4byte sEnteiSprites38
+.4byte sEnteiSprites39
+.4byte sEnteiSprites40
+.4byte sEnteiSprites41
+.4byte sEnteiSprites42
+.4byte sEnteiSprites43
+.4byte sEnteiSprites44
+.4byte sEnteiSprites45
+.4byte sEnteiSprites46
+.4byte sEnteiSprites47
+.4byte sEnteiSprites48
+.4byte sEnteiSprites49
+.4byte sEnteiSprites50
+.4byte sEnteiSprites51
+.4byte sEnteiSprites52
+.4byte sEnteiSprites53
+.4byte sEnteiSprites54
+.4byte sEnteiSprites55
+.4byte sEnteiSprites56
+.4byte sEnteiSprites57
+.4byte sEnteiSprites58
+.4byte sEnteiSprites59
+.4byte sEnteiSprites60
+.4byte sEnteiSprites61
+.4byte sEnteiSprites62
+.4byte sEnteiSprites63
+.4byte sEnteiSprites64
+.4byte sEnteiSprites65
+.4byte sEnteiSprites66
+.4byte sEnteiSprites67
+.4byte sEnteiSprites68
+.4byte sEnteiSprites69
+.4byte sEnteiSprites70
+.4byte sEnteiSprites71
+.4byte sEnteiSprites72
+.4byte sEnteiSprites73
+.4byte sEnteiSprites74
+.4byte sEnteiSprites75
+.4byte sEnteiSprites76
+.4byte sEnteiSprites77
+.4byte sEnteiSprites78
+.4byte sEnteiSprites79
+.4byte sEnteiSprites80
+.4byte sEnteiSprites81
+.4byte sEnteiSprites82
+.4byte sEnteiSprites83
+.4byte sEnteiSprites84
+.4byte sEnteiSprites85
+.4byte sEnteiSprites86
+.4byte sEnteiSprites87
+sAxMainEntei:
+ax_main sAxPosesEntei, sAxAnimationsEntei, 14, sAxSpritesEntei, sAxPositionsEntei

--- a/data/ax/espeon.inc
+++ b/data/ax/espeon.inc
@@ -1,0 +1,2551 @@
+.global gAxEspeon
+gAxEspeon:
+ax_siro sAxMainEspeon
+sEspeonPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose4:
+ax_pose 3, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose5:
+ax_pose 4, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose6:
+ax_pose 5, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose7:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose8:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose9:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose10:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose11:
+ax_pose 10, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose12:
+ax_pose 11, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose16:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose17:
+ax_pose 10, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose18:
+ax_pose 11, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose19:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose22:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose23:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose24:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose28:
+ax_pose 3, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose29:
+ax_pose 4, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose30:
+ax_pose 5, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose31:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose32:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose33:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose34:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose35:
+ax_pose 10, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose36:
+ax_pose 11, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose37:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose39:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose40:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose41:
+ax_pose 10, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose42:
+ax_pose 11, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose43:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose44:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose45:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose46:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose47:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose48:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose49:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose50:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose51:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose52:
+ax_pose 3, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose53:
+ax_pose 4, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose54:
+ax_pose 5, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose55:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose56:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose57:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose58:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose59:
+ax_pose 10, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose60:
+ax_pose 11, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose61:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose62:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose63:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose64:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose65:
+ax_pose 10, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose66:
+ax_pose 11, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose67:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose68:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose69:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose70:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose71:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose72:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose73:
+ax_pose 15, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sEspeonPose74:
+ax_pose 16, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose75:
+ax_pose 17, 0x01e7, 0x40f8, 0x2c00
+ax_pose 18, 0x01f5, 0x0103, 0x2c04
+ax_pose 16, 0x01e6, 0x80f5, 0x2c05
+ax_pose_terminator
+sEspeonPose76:
+ax_pose 19, 0x01eb, 0x00fc, 0x2c00
+ax_pose -1, 0x01f5, 0x0103, 0x2c00
+ax_pose 16, 0x01e6, 0x80f5, 0x2c01
+ax_pose_terminator
+sEspeonPose77:
+ax_pose 18, 0x01eb, 0x00fc, 0x2c00
+ax_pose 17, 0x01f1, 0x40ff, 0x2c01
+ax_pose 16, 0x01e6, 0x80f5, 0x2c05
+ax_pose_terminator
+sEspeonPose78:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose79:
+ax_pose 20, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose80:
+ax_pose 21, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose81:
+ax_pose 17, 0x01ea, 0x40fd, 0x2c00
+ax_pose 18, 0x01f4, 0x010a, 0x2c04
+ax_pose 21, 0x01eb, 0x90ed, 0x2c05
+ax_pose_terminator
+sEspeonPose82:
+ax_pose 19, 0x01ee, 0x0101, 0x2c00
+ax_pose -1, 0x01f4, 0x010a, 0x2c00
+ax_pose 21, 0x01eb, 0x90ed, 0x2c01
+ax_pose_terminator
+sEspeonPose83:
+ax_pose 18, 0x01ee, 0x0101, 0x2c00
+ax_pose 17, 0x01f0, 0x4106, 0x2c01
+ax_pose 21, 0x01eb, 0x90ed, 0x2c05
+ax_pose_terminator
+sEspeonPose84:
+ax_pose 3, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose85:
+ax_pose 22, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose86:
+ax_pose 23, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose87:
+ax_pose 17, 0x01e8, 0x4100, 0x2c00
+ax_pose 18, 0x01f2, 0x010c, 0x2c04
+ax_pose 23, 0x01ea, 0x90f0, 0x2c05
+ax_pose_terminator
+sEspeonPose88:
+ax_pose 19, 0x01ec, 0x0104, 0x2c00
+ax_pose -1, 0x01f2, 0x010c, 0x2c00
+ax_pose 23, 0x01ea, 0x90f0, 0x2c01
+ax_pose_terminator
+sEspeonPose89:
+ax_pose 18, 0x01ec, 0x0104, 0x2c00
+ax_pose 17, 0x01ee, 0x4108, 0x2c01
+ax_pose 23, 0x01ea, 0x90f0, 0x2c05
+ax_pose_terminator
+sEspeonPose90:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose91:
+ax_pose 24, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose92:
+ax_pose 25, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose93:
+ax_pose 25, 0x01e6, 0x90ec, 0x2c00
+ax_pose 17, 0x01e4, 0x4103, 0x2c10
+ax_pose 18, 0x01eb, 0x00fe, 0x2c14
+ax_pose_terminator
+sEspeonPose94:
+ax_pose 25, 0x01e6, 0x90ec, 0x2c00
+ax_pose 19, 0x01e8, 0x0107, 0x2c10
+ax_pose -1, 0x01eb, 0x00fe, 0x2c10
+ax_pose_terminator
+sEspeonPose95:
+ax_pose 25, 0x01e6, 0x90ec, 0x2c00
+ax_pose 18, 0x01e8, 0x0107, 0x2c10
+ax_pose 17, 0x01e7, 0x40fa, 0x2c11
+ax_pose_terminator
+sEspeonPose96:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose97:
+ax_pose 26, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose98:
+ax_pose 27, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose99:
+ax_pose 27, 0x01ec, 0x80f5, 0x2c00
+ax_pose 17, 0x01e6, 0x40f5, 0x2c10
+ax_pose 18, 0x01f1, 0x0106, 0x2c14
+ax_pose_terminator
+sEspeonPose100:
+ax_pose 27, 0x01ec, 0x80f5, 0x2c00
+ax_pose 19, 0x01ea, 0x00f9, 0x2c10
+ax_pose -1, 0x01f1, 0x0106, 0x2c10
+ax_pose_terminator
+sEspeonPose101:
+ax_pose 27, 0x01ec, 0x80f5, 0x2c00
+ax_pose 18, 0x01ea, 0x00f9, 0x2c10
+ax_pose 17, 0x01ed, 0x4102, 0x2c11
+ax_pose_terminator
+sEspeonPose102:
+ax_pose 12, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sEspeonPose103:
+ax_pose 24, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose104:
+ax_pose 25, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose105:
+ax_pose 25, 0x01e6, 0x80f5, 0x2c00
+ax_pose 17, 0x01e6, 0x40ed, 0x2c10
+ax_pose 18, 0x01ec, 0x00fd, 0x2c14
+ax_pose_terminator
+sEspeonPose106:
+ax_pose 25, 0x01e6, 0x80f5, 0x2c00
+ax_pose 19, 0x01ea, 0x00f1, 0x2c10
+ax_pose -1, 0x01ec, 0x00fd, 0x2c10
+ax_pose_terminator
+sEspeonPose107:
+ax_pose 25, 0x01e6, 0x80f5, 0x2c00
+ax_pose 18, 0x01ea, 0x00f1, 0x2c10
+ax_pose 17, 0x01e8, 0x40f9, 0x2c11
+ax_pose_terminator
+sEspeonPose108:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose109:
+ax_pose 22, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sEspeonPose110:
+ax_pose 23, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose111:
+ax_pose 17, 0x01e5, 0x40ef, 0x2c00
+ax_pose 18, 0x01f1, 0x00ee, 0x2c04
+ax_pose 23, 0x01ea, 0x80f0, 0x2c05
+ax_pose_terminator
+sEspeonPose112:
+ax_pose 19, 0x01e9, 0x00f3, 0x2c00
+ax_pose -1, 0x01f1, 0x00ee, 0x2c00
+ax_pose 23, 0x01ea, 0x80f0, 0x2c01
+ax_pose_terminator
+sEspeonPose113:
+ax_pose 18, 0x01e9, 0x00f3, 0x2c00
+ax_pose 17, 0x01ed, 0x40ea, 0x2c01
+ax_pose 23, 0x01ea, 0x80f0, 0x2c05
+ax_pose_terminator
+sEspeonPose114:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose115:
+ax_pose 20, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose116:
+ax_pose 21, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose117:
+ax_pose 17, 0x01e9, 0x40ee, 0x2c00
+ax_pose 18, 0x01f6, 0x00f7, 0x2c04
+ax_pose 21, 0x01eb, 0x80f3, 0x2c05
+ax_pose_terminator
+sEspeonPose118:
+ax_pose 19, 0x01ed, 0x00f2, 0x2c00
+ax_pose -1, 0x01f6, 0x00f7, 0x2c00
+ax_pose 21, 0x01eb, 0x80f3, 0x2c01
+ax_pose_terminator
+sEspeonPose119:
+ax_pose 18, 0x01ed, 0x00f2, 0x2c00
+ax_pose 17, 0x01f2, 0x40f3, 0x2c01
+ax_pose 21, 0x01eb, 0x80f3, 0x2c05
+ax_pose_terminator
+sEspeonPose120:
+ax_pose 3, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose121:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose122:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose123:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose124:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose125:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose126:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose127:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose128:
+ax_pose 3, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose129:
+ax_pose 28, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose130:
+ax_pose 29, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose131:
+ax_pose 30, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose132:
+ax_pose 31, 0x01e1, 0x90ef, 0x2c00
+ax_pose_terminator
+sEspeonPose133:
+ax_pose 32, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sEspeonPose134:
+ax_pose 33, 0x01e2, 0x90ea, 0x2c00
+ax_pose_terminator
+sEspeonPose135:
+ax_pose 34, 0x01e2, 0x80ef, 0x2c00
+ax_pose_terminator
+sEspeonPose136:
+ax_pose 33, 0x01e2, 0x80f6, 0x2c00
+ax_pose_terminator
+sEspeonPose137:
+ax_pose 32, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose138:
+ax_pose 31, 0x01e1, 0x80f1, 0x2c00
+ax_pose_terminator
+sEspeonPose139:
+ax_pose 16, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose140:
+ax_pose 21, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose141:
+ax_pose 23, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose142:
+ax_pose 25, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose143:
+ax_pose 27, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose144:
+ax_pose 25, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose145:
+ax_pose 23, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose146:
+ax_pose 21, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose147:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose148:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose149:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose150:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose151:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose152:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose153:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose154:
+ax_pose 3, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose155:
+ax_pose 16, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose156:
+ax_pose 21, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose157:
+ax_pose 23, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose158:
+ax_pose 25, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose159:
+ax_pose 27, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose160:
+ax_pose 25, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose161:
+ax_pose 23, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose162:
+ax_pose 21, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose163:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose164:
+ax_pose 15, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sEspeonPose165:
+ax_pose 16, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose166:
+ax_pose 3, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose167:
+ax_pose 20, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose168:
+ax_pose 21, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sEspeonPose169:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose170:
+ax_pose 22, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose171:
+ax_pose 23, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose172:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose173:
+ax_pose 24, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose174:
+ax_pose 25, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose175:
+ax_pose 12, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sEspeonPose176:
+ax_pose 26, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose177:
+ax_pose 27, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose178:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose179:
+ax_pose 24, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose180:
+ax_pose 25, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose181:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose182:
+ax_pose 22, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sEspeonPose183:
+ax_pose 23, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose184:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose185:
+ax_pose 20, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose186:
+ax_pose 21, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose187:
+ax_pose 16, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sEspeonPose188:
+ax_pose 21, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sEspeonPose189:
+ax_pose 23, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose190:
+ax_pose 25, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sEspeonPose191:
+ax_pose 27, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sEspeonPose192:
+ax_pose 25, 0x01e5, 0x90eb, 0x2c00
+ax_pose_terminator
+sEspeonPose193:
+ax_pose 23, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose194:
+ax_pose 21, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sEspeonPose195:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose196:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose197:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose198:
+ax_pose 9, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sEspeonPose199:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sEspeonPose200:
+ax_pose 9, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sEspeonPose201:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sEspeonPose202:
+ax_pose 3, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sEspeonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sEspeonAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sEspeonAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sEspeonAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 35, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim 2, 2, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 1, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sEspeonAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sEspeonAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 0, 0, 0, -1,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim 2, 2, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 1, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sEspeonAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sEspeonAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sEspeonAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sEspeonAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 4, 4, 4, 4,
+ax_anim 2, 2, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sEspeonAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sEspeonAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 4, -4, 4, -4,
+ax_anim 2, 2, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 1, 58, 19, -17, 19, -17,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 0, 58, 19, -17, 19, -17,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sEspeonAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, -4,
+ax_anim 2, 2, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 1, 61, 1, -18, 1, -18,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 0, 61, 1, -18, 1, -18,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sEspeonAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 65, 0, 0, 0, -1,
+ax_anim 2, 0, 64, -4, -4, -4, -4,
+ax_anim 2, 2, 65, -10, -10, -10, -10,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 1, 64, -19, -17, -19, -17,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 0, 64, -19, -17, -19, -17,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sEspeonAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sEspeonAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, -4, 4, -4, 4,
+ax_anim 2, 2, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sEspeonAnims_4_1:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 72, 0, -1, 0, -1,
+ax_anim 6, 0, 72, 0, -2, 0, -2,
+ax_anim 4, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 1, 2, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_4_2:
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 78, -1, -1, -1, -1,
+ax_anim 6, 0, 78, -2, -2, -2, -2,
+ax_anim 4, 0, 79, -2, -2, -2, -2,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 1, 2, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_4_3:
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 84, -1, 0, -1, 0,
+ax_anim 6, 0, 84, -2, 0, -2, 0,
+ax_anim 4, 0, 85, -2, 0, -2, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 1, 2, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_4_4:
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 4, 0, 90, -1, 1, -1, 1,
+ax_anim 6, 0, 90, -2, 2, -2, 2,
+ax_anim 4, 0, 91, -2, 2, -2, 2,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 1, 2, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_4_5:
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 1, 0, 1,
+ax_anim 6, 0, 96, 0, 2, 0, 2,
+ax_anim 4, 0, 97, 0, 2, 0, 2,
+ax_anim 2, 0, 97, 0, -1, 0, -1,
+ax_anim 1, 2, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_4_6:
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 1, 1, 1, 1,
+ax_anim 6, 0, 102, 2, 2, 2, 2,
+ax_anim 4, 0, 103, 2, 2, 2, 2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 1, 2, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_4_7:
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 1, 0, 1, 0,
+ax_anim 6, 0, 108, 2, 0, 2, 0,
+ax_anim 4, 0, 109, 2, 0, 2, 0,
+ax_anim 2, 0, 109, -1, 0, -1, 0,
+ax_anim 1, 2, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_4_8:
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 1, -1, 1, -1,
+ax_anim 6, 0, 114, 2, -2, 2, -2,
+ax_anim 4, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, -1, 1, -1, 1,
+ax_anim 1, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sEspeonAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sEspeonAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sEspeonAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sEspeonAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sEspeonAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sEspeonAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sEspeonAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sEspeonAnims_8_1:
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_8_2:
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_8_3:
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_8_4:
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_8_5:
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_8_6:
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_8_7:
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_8_8:
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 10, 9, 10, 9,
+ax_anim 2, 0, 149, 7, 13, 7, 13,
+ax_anim 3, 0, 150, -1, 16, -1, 16,
+ax_anim 2, 3, 151, -7, 13, -7, 13,
+ax_anim 2, 0, 152, -10, 9, -10, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 24, 9, 24, 9,
+ax_anim 3, 0, 149, 23, 16, 23, 16,
+ax_anim 2, 3, 150, 11, 16, 11, 16,
+ax_anim 2, 0, 151, 4, 12, 4, 12,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 17, -4, 17, -4,
+ax_anim 3, 0, 148, 20, 1, 20, 1,
+ax_anim 2, 3, 149, 17, 5, 17, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -9, -1, -9,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -20, 11, -20,
+ax_anim 3, 0, 147, 16, -20, 16, -20,
+ax_anim 2, 3, 148, 19, -13, 19, -13,
+ax_anim 2, 0, 149, 16, -4, 16, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -9, -8, -9,
+ax_anim 2, 0, 153, -7, -15, -7, -15,
+ax_anim 3, 0, 146, -1, -19, -1, -19,
+ax_anim 2, 3, 147, 6, -16, 6, -16,
+ax_anim 2, 0, 148, 9, -8, 9, -8,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 2, -9, 2, -9,
+ax_anim 2, 0, 147, -4, -17, -4, -17,
+ax_anim 2, 0, 146, -11, -20, -11, -20,
+ax_anim 3, 0, 153, -16, -20, -16, -20,
+ax_anim 2, 3, 152, -18, -13, -18, -13,
+ax_anim 2, 0, 151, -15, -4, -15, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -17, -4, -17, -4,
+ax_anim 3, 0, 152, -20, 1, -20, 1,
+ax_anim 2, 3, 151, -17, 5, -17, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -24, 9, -24, 9,
+ax_anim 3, 0, 151, -23, 16, -23, 16,
+ax_anim 2, 3, 150, -11, 16, -11, 16,
+ax_anim 2, 0, 149, -4, 12, -4, 12,
+ax_anim 1, 0, 148, 1, 7, 1, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sEspeonAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sEspeonGfx1:
+.incbin "baserom.gba", 0xD66CCC, 0x200
+sEspeonSprites1:
+ax_sprite sEspeonGfx1, 0x200
+ax_sprite_terminator
+sEspeonGfx2:
+.incbin "baserom.gba", 0xD66EDC, 0x200
+sEspeonSprites2:
+ax_sprite sEspeonGfx2, 0x200
+ax_sprite_terminator
+sEspeonGfx3:
+.incbin "baserom.gba", 0xD670EC, 0x200
+sEspeonSprites3:
+ax_sprite sEspeonGfx3, 0x200
+ax_sprite_terminator
+sEspeonGfx4:
+.incbin "baserom.gba", 0xD672FC, 0x200
+sEspeonSprites4:
+ax_sprite sEspeonGfx4, 0x200
+ax_sprite_terminator
+sEspeonGfx5:
+.incbin "baserom.gba", 0xD6750C, 0x200
+sEspeonSprites5:
+ax_sprite sEspeonGfx5, 0x200
+ax_sprite_terminator
+sEspeonGfx6:
+.incbin "baserom.gba", 0xD6771C, 0x200
+sEspeonSprites6:
+ax_sprite sEspeonGfx6, 0x200
+ax_sprite_terminator
+sEspeonGfx7:
+.incbin "baserom.gba", 0xD6792C, 0x200
+sEspeonSprites7:
+ax_sprite sEspeonGfx7, 0x200
+ax_sprite_terminator
+sEspeonGfx8:
+.incbin "baserom.gba", 0xD67B3C, 0x200
+sEspeonSprites8:
+ax_sprite sEspeonGfx8, 0x200
+ax_sprite_terminator
+sEspeonGfx9:
+.incbin "baserom.gba", 0xD67D4C, 0x200
+sEspeonSprites9:
+ax_sprite sEspeonGfx9, 0x200
+ax_sprite_terminator
+sEspeonGfx10:
+.incbin "baserom.gba", 0xD67F5C, 0x200
+sEspeonSprites10:
+ax_sprite sEspeonGfx10, 0x200
+ax_sprite_terminator
+sEspeonGfx11:
+.incbin "baserom.gba", 0xD6816C, 0x200
+sEspeonSprites11:
+ax_sprite sEspeonGfx11, 0x200
+ax_sprite_terminator
+sEspeonGfx12:
+.incbin "baserom.gba", 0xD6837C, 0x200
+sEspeonSprites12:
+ax_sprite sEspeonGfx12, 0x200
+ax_sprite_terminator
+sEspeonGfx13:
+.incbin "baserom.gba", 0xD6858C, 0x200
+sEspeonSprites13:
+ax_sprite sEspeonGfx13, 0x200
+ax_sprite_terminator
+sEspeonGfx14:
+.incbin "baserom.gba", 0xD6879C, 0x200
+sEspeonSprites14:
+ax_sprite sEspeonGfx14, 0x200
+ax_sprite_terminator
+sEspeonGfx15:
+.incbin "baserom.gba", 0xD689AC, 0x200
+sEspeonSprites15:
+ax_sprite sEspeonGfx15, 0x200
+ax_sprite_terminator
+sEspeonGfx16:
+.incbin "baserom.gba", 0xD68BBC, 0x60
+sEspeonGfx16_1:
+.incbin "baserom.gba", 0xD68C1C, 0x60
+sEspeonGfx16_2:
+.incbin "baserom.gba", 0xD68C7C, 0x60
+sEspeonSprites16:
+ax_sprite sEspeonGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEspeonGfx17:
+.incbin "baserom.gba", 0xD68D14, 0x60
+sEspeonGfx17_1:
+.incbin "baserom.gba", 0xD68D74, 0x60
+sEspeonGfx17_2:
+.incbin "baserom.gba", 0xD68DD4, 0x60
+sEspeonGfx17_3:
+.incbin "baserom.gba", 0xD68E34, 0x60
+sEspeonSprites17:
+ax_sprite sEspeonGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEspeonGfx18:
+.incbin "baserom.gba", 0xD68EDC, 0x80
+sEspeonSprites18:
+ax_sprite sEspeonGfx18, 0x80
+ax_sprite_terminator
+sEspeonGfx19:
+.incbin "baserom.gba", 0xD68F6C, 0x20
+sEspeonSprites19:
+ax_sprite sEspeonGfx19, 0x20
+ax_sprite_terminator
+sEspeonGfx20:
+.incbin "baserom.gba", 0xD68F9C, 0x20
+sEspeonSprites20:
+ax_sprite sEspeonGfx20, 0x20
+ax_sprite_terminator
+sEspeonGfx21:
+.incbin "baserom.gba", 0xD68FCC, 0x60
+sEspeonGfx21_1:
+.incbin "baserom.gba", 0xD6902C, 0x60
+sEspeonGfx21_2:
+.incbin "baserom.gba", 0xD6908C, 0x60
+sEspeonSprites21:
+ax_sprite sEspeonGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEspeonGfx22:
+.incbin "baserom.gba", 0xD69124, 0x60
+sEspeonGfx22_1:
+.incbin "baserom.gba", 0xD69184, 0x60
+sEspeonGfx22_2:
+.incbin "baserom.gba", 0xD691E4, 0x60
+sEspeonGfx22_3:
+.incbin "baserom.gba", 0xD69244, 0x40
+sEspeonSprites22:
+ax_sprite sEspeonGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx22_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sEspeonGfx23:
+.incbin "baserom.gba", 0xD692CC, 0x60
+sEspeonGfx23_1:
+.incbin "baserom.gba", 0xD6932C, 0x60
+sEspeonGfx23_2:
+.incbin "baserom.gba", 0xD6938C, 0x40
+sEspeonSprites23:
+ax_sprite sEspeonGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sEspeonGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEspeonGfx24:
+.incbin "baserom.gba", 0xD69404, 0x180
+sEspeonSprites24:
+ax_sprite sEspeonGfx24, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sEspeonGfx25:
+.incbin "baserom.gba", 0xD6959C, 0x40
+sEspeonGfx25_1:
+.incbin "baserom.gba", 0xD695DC, 0x60
+sEspeonGfx25_2:
+.incbin "baserom.gba", 0xD6963C, 0x60
+sEspeonGfx25_3:
+.incbin "baserom.gba", 0xD6969C, 0x60
+sEspeonSprites25:
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEspeonGfx26:
+.incbin "baserom.gba", 0xD6974C, 0x40
+sEspeonGfx26_1:
+.incbin "baserom.gba", 0xD6978C, 0x60
+sEspeonGfx26_2:
+.incbin "baserom.gba", 0xD697EC, 0x60
+sEspeonGfx26_3:
+.incbin "baserom.gba", 0xD6984C, 0x60
+sEspeonSprites26:
+ax_sprite sEspeonGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sEspeonGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEspeonGfx27:
+.incbin "baserom.gba", 0xD698F4, 0x60
+sEspeonGfx27_1:
+.incbin "baserom.gba", 0xD69954, 0x60
+sEspeonGfx27_2:
+.incbin "baserom.gba", 0xD699B4, 0x60
+sEspeonSprites27:
+ax_sprite sEspeonGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sEspeonGfx28:
+.incbin "baserom.gba", 0xD69A4C, 0x60
+sEspeonGfx28_1:
+.incbin "baserom.gba", 0xD69AAC, 0x60
+sEspeonGfx28_2:
+.incbin "baserom.gba", 0xD69B0C, 0x60
+sEspeonGfx28_3:
+.incbin "baserom.gba", 0xD69B6C, 0x60
+sEspeonSprites28:
+ax_sprite sEspeonGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sEspeonGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sEspeonGfx29:
+.incbin "baserom.gba", 0xD69C14, 0x200
+sEspeonSprites29:
+ax_sprite sEspeonGfx29, 0x200
+ax_sprite_terminator
+sEspeonGfx30:
+.incbin "baserom.gba", 0xD69E24, 0x200
+sEspeonSprites30:
+ax_sprite sEspeonGfx30, 0x200
+ax_sprite_terminator
+sEspeonGfx31:
+.incbin "baserom.gba", 0xD6A034, 0x200
+sEspeonSprites31:
+ax_sprite sEspeonGfx31, 0x200
+ax_sprite_terminator
+sEspeonGfx32:
+.incbin "baserom.gba", 0xD6A244, 0x200
+sEspeonSprites32:
+ax_sprite sEspeonGfx32, 0x200
+ax_sprite_terminator
+sEspeonGfx33:
+.incbin "baserom.gba", 0xD6A454, 0x200
+sEspeonSprites33:
+ax_sprite sEspeonGfx33, 0x200
+ax_sprite_terminator
+sEspeonGfx34:
+.incbin "baserom.gba", 0xD6A664, 0x200
+sEspeonSprites34:
+ax_sprite sEspeonGfx34, 0x200
+ax_sprite_terminator
+sEspeonGfx35:
+.incbin "baserom.gba", 0xD6A874, 0x200
+sEspeonSprites35:
+ax_sprite sEspeonGfx35, 0x200
+ax_sprite_terminator
+sAxPosesEspeon:
+.4byte sEspeonPose1
+.4byte sEspeonPose2
+.4byte sEspeonPose3
+.4byte sEspeonPose4
+.4byte sEspeonPose5
+.4byte sEspeonPose6
+.4byte sEspeonPose7
+.4byte sEspeonPose8
+.4byte sEspeonPose9
+.4byte sEspeonPose10
+.4byte sEspeonPose11
+.4byte sEspeonPose12
+.4byte sEspeonPose13
+.4byte sEspeonPose14
+.4byte sEspeonPose15
+.4byte sEspeonPose16
+.4byte sEspeonPose17
+.4byte sEspeonPose18
+.4byte sEspeonPose19
+.4byte sEspeonPose20
+.4byte sEspeonPose21
+.4byte sEspeonPose22
+.4byte sEspeonPose23
+.4byte sEspeonPose24
+.4byte sEspeonPose25
+.4byte sEspeonPose26
+.4byte sEspeonPose27
+.4byte sEspeonPose28
+.4byte sEspeonPose29
+.4byte sEspeonPose30
+.4byte sEspeonPose31
+.4byte sEspeonPose32
+.4byte sEspeonPose33
+.4byte sEspeonPose34
+.4byte sEspeonPose35
+.4byte sEspeonPose36
+.4byte sEspeonPose37
+.4byte sEspeonPose38
+.4byte sEspeonPose39
+.4byte sEspeonPose40
+.4byte sEspeonPose41
+.4byte sEspeonPose42
+.4byte sEspeonPose43
+.4byte sEspeonPose44
+.4byte sEspeonPose45
+.4byte sEspeonPose46
+.4byte sEspeonPose47
+.4byte sEspeonPose48
+.4byte sEspeonPose49
+.4byte sEspeonPose50
+.4byte sEspeonPose51
+.4byte sEspeonPose52
+.4byte sEspeonPose53
+.4byte sEspeonPose54
+.4byte sEspeonPose55
+.4byte sEspeonPose56
+.4byte sEspeonPose57
+.4byte sEspeonPose58
+.4byte sEspeonPose59
+.4byte sEspeonPose60
+.4byte sEspeonPose61
+.4byte sEspeonPose62
+.4byte sEspeonPose63
+.4byte sEspeonPose64
+.4byte sEspeonPose65
+.4byte sEspeonPose66
+.4byte sEspeonPose67
+.4byte sEspeonPose68
+.4byte sEspeonPose69
+.4byte sEspeonPose70
+.4byte sEspeonPose71
+.4byte sEspeonPose72
+.4byte sEspeonPose73
+.4byte sEspeonPose74
+.4byte sEspeonPose75
+.4byte sEspeonPose76
+.4byte sEspeonPose77
+.4byte sEspeonPose78
+.4byte sEspeonPose79
+.4byte sEspeonPose80
+.4byte sEspeonPose81
+.4byte sEspeonPose82
+.4byte sEspeonPose83
+.4byte sEspeonPose84
+.4byte sEspeonPose85
+.4byte sEspeonPose86
+.4byte sEspeonPose87
+.4byte sEspeonPose88
+.4byte sEspeonPose89
+.4byte sEspeonPose90
+.4byte sEspeonPose91
+.4byte sEspeonPose92
+.4byte sEspeonPose93
+.4byte sEspeonPose94
+.4byte sEspeonPose95
+.4byte sEspeonPose96
+.4byte sEspeonPose97
+.4byte sEspeonPose98
+.4byte sEspeonPose99
+.4byte sEspeonPose100
+.4byte sEspeonPose101
+.4byte sEspeonPose102
+.4byte sEspeonPose103
+.4byte sEspeonPose104
+.4byte sEspeonPose105
+.4byte sEspeonPose106
+.4byte sEspeonPose107
+.4byte sEspeonPose108
+.4byte sEspeonPose109
+.4byte sEspeonPose110
+.4byte sEspeonPose111
+.4byte sEspeonPose112
+.4byte sEspeonPose113
+.4byte sEspeonPose114
+.4byte sEspeonPose115
+.4byte sEspeonPose116
+.4byte sEspeonPose117
+.4byte sEspeonPose118
+.4byte sEspeonPose119
+.4byte sEspeonPose120
+.4byte sEspeonPose121
+.4byte sEspeonPose122
+.4byte sEspeonPose123
+.4byte sEspeonPose124
+.4byte sEspeonPose125
+.4byte sEspeonPose126
+.4byte sEspeonPose127
+.4byte sEspeonPose128
+.4byte sEspeonPose129
+.4byte sEspeonPose130
+.4byte sEspeonPose131
+.4byte sEspeonPose132
+.4byte sEspeonPose133
+.4byte sEspeonPose134
+.4byte sEspeonPose135
+.4byte sEspeonPose136
+.4byte sEspeonPose137
+.4byte sEspeonPose138
+.4byte sEspeonPose139
+.4byte sEspeonPose140
+.4byte sEspeonPose141
+.4byte sEspeonPose142
+.4byte sEspeonPose143
+.4byte sEspeonPose144
+.4byte sEspeonPose145
+.4byte sEspeonPose146
+.4byte sEspeonPose147
+.4byte sEspeonPose148
+.4byte sEspeonPose149
+.4byte sEspeonPose150
+.4byte sEspeonPose151
+.4byte sEspeonPose152
+.4byte sEspeonPose153
+.4byte sEspeonPose154
+.4byte sEspeonPose155
+.4byte sEspeonPose156
+.4byte sEspeonPose157
+.4byte sEspeonPose158
+.4byte sEspeonPose159
+.4byte sEspeonPose160
+.4byte sEspeonPose161
+.4byte sEspeonPose162
+.4byte sEspeonPose163
+.4byte sEspeonPose164
+.4byte sEspeonPose165
+.4byte sEspeonPose166
+.4byte sEspeonPose167
+.4byte sEspeonPose168
+.4byte sEspeonPose169
+.4byte sEspeonPose170
+.4byte sEspeonPose171
+.4byte sEspeonPose172
+.4byte sEspeonPose173
+.4byte sEspeonPose174
+.4byte sEspeonPose175
+.4byte sEspeonPose176
+.4byte sEspeonPose177
+.4byte sEspeonPose178
+.4byte sEspeonPose179
+.4byte sEspeonPose180
+.4byte sEspeonPose181
+.4byte sEspeonPose182
+.4byte sEspeonPose183
+.4byte sEspeonPose184
+.4byte sEspeonPose185
+.4byte sEspeonPose186
+.4byte sEspeonPose187
+.4byte sEspeonPose188
+.4byte sEspeonPose189
+.4byte sEspeonPose190
+.4byte sEspeonPose191
+.4byte sEspeonPose192
+.4byte sEspeonPose193
+.4byte sEspeonPose194
+.4byte sEspeonPose195
+.4byte sEspeonPose196
+.4byte sEspeonPose197
+.4byte sEspeonPose198
+.4byte sEspeonPose199
+.4byte sEspeonPose200
+.4byte sEspeonPose201
+.4byte sEspeonPose202
+sAxPositionsEspeon:
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte    0,   -7, 	  -1,    3, 	   2,   -1, 	   0,   -6
+.2byte    0,   -7, 	  -2,   -1, 	   0,    3, 	   0,   -6
+.2byte    8,   -9, 	   4,    0, 	   1,    1, 	   1,   -7
+.2byte    8,   -8, 	   1,   -2, 	   5,    2, 	   1,   -6
+.2byte    8,   -8, 	   8,    1, 	  -2,    0, 	   1,   -5
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte   11,   -9, 	  10,    0, 	   2,    1, 	   2,   -6
+.2byte   11,   -9, 	   1,    0, 	   9,    0, 	   2,   -6
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte    5,  -11, 	   1,   -2, 	   9,   -4, 	   1,   -6
+.2byte    5,  -11, 	   3,   -5, 	   4,    0, 	   1,   -7
+.2byte    1,  -13, 	   4,   -3, 	  -1,   -3, 	   1,   -8
+.2byte    0,  -12, 	   4,   -3, 	  -1,   -4, 	   1,   -8
+.2byte    1,  -12, 	   3,   -6, 	  -2,   -2, 	   1,   -8
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte   -5,  -11, 	  -1,   -2, 	  -9,   -4, 	  -1,   -6
+.2byte   -5,  -11, 	  -3,   -5, 	  -4,    0, 	  -1,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte  -12,   -9, 	 -11,    0, 	  -3,    1, 	  -3,   -6
+.2byte  -12,   -9, 	  -2,    0, 	 -10,    0, 	  -3,   -6
+.2byte   -9,   -9, 	  -5,    0, 	  -2,    1, 	  -2,   -7
+.2byte   -9,   -8, 	  -2,   -2, 	  -6,    2, 	  -2,   -6
+.2byte   -9,   -8, 	  -9,    1, 	   1,    0, 	  -2,   -5
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte    0,   -7, 	  -1,    3, 	   2,   -1, 	   0,   -6
+.2byte    0,   -7, 	  -2,   -1, 	   0,    3, 	   0,   -6
+.2byte    8,   -9, 	   4,    0, 	   1,    1, 	   1,   -7
+.2byte    8,   -8, 	   1,   -2, 	   5,    2, 	   1,   -6
+.2byte    8,   -8, 	   8,    1, 	  -2,    0, 	   1,   -5
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte   11,   -9, 	  10,    0, 	   2,    1, 	   2,   -6
+.2byte   11,   -9, 	   1,    0, 	   9,    0, 	   2,   -6
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte    5,  -11, 	   1,   -2, 	   9,   -4, 	   1,   -6
+.2byte    5,  -11, 	   3,   -5, 	   4,    0, 	   1,   -7
+.2byte    1,  -13, 	   4,   -3, 	  -1,   -3, 	   1,   -8
+.2byte    0,  -12, 	   4,   -3, 	  -1,   -4, 	   1,   -8
+.2byte    1,  -12, 	   3,   -6, 	  -2,   -2, 	   1,   -8
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte   -5,  -11, 	  -1,   -2, 	  -9,   -4, 	  -1,   -6
+.2byte   -5,  -11, 	  -3,   -5, 	  -4,    0, 	  -1,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte  -12,   -9, 	 -11,    0, 	  -3,    1, 	  -3,   -6
+.2byte  -12,   -9, 	  -2,    0, 	 -10,    0, 	  -3,   -6
+.2byte   -9,   -9, 	  -5,    0, 	  -2,    1, 	  -2,   -7
+.2byte   -9,   -8, 	  -2,   -2, 	  -6,    2, 	  -2,   -6
+.2byte   -9,   -8, 	  -9,    1, 	   1,    0, 	  -2,   -5
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte    0,   -7, 	  -1,    3, 	   2,   -1, 	   0,   -6
+.2byte    0,   -7, 	  -2,   -1, 	   0,    3, 	   0,   -6
+.2byte    8,   -9, 	   4,    0, 	   1,    1, 	   1,   -7
+.2byte    8,   -8, 	   1,   -2, 	   5,    2, 	   1,   -6
+.2byte    8,   -8, 	   8,    1, 	  -2,    0, 	   1,   -5
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte   11,   -9, 	  10,    0, 	   2,    1, 	   2,   -6
+.2byte   11,   -9, 	   1,    0, 	   9,    0, 	   2,   -6
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte    5,  -11, 	   1,   -2, 	   9,   -4, 	   1,   -6
+.2byte    5,  -11, 	   3,   -5, 	   4,    0, 	   1,   -7
+.2byte    1,  -13, 	   4,   -3, 	  -1,   -3, 	   1,   -8
+.2byte    0,  -12, 	   4,   -3, 	  -1,   -4, 	   1,   -8
+.2byte    1,  -12, 	   3,   -6, 	  -2,   -2, 	   1,   -8
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte   -5,  -11, 	  -1,   -2, 	  -9,   -4, 	  -1,   -6
+.2byte   -5,  -11, 	  -3,   -5, 	  -4,    0, 	  -1,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte  -12,   -9, 	 -11,    0, 	  -3,    1, 	  -3,   -6
+.2byte  -12,   -9, 	  -2,    0, 	 -10,    0, 	  -3,   -6
+.2byte   -9,   -9, 	  -5,    0, 	  -2,    1, 	  -2,   -7
+.2byte   -9,   -8, 	  -2,   -2, 	  -6,    2, 	  -2,   -6
+.2byte   -9,   -8, 	  -9,    1, 	   1,    0, 	  -2,   -5
+.2byte    6,  -19, 	   5,   -4, 	   6,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -3,    2, 	   4,    1, 	   1,   -6
+.2byte    1,   -5, 	  -3,    2, 	   4,    1, 	   1,   -6
+.2byte    1,   -5, 	  -3,    2, 	   4,    1, 	   1,   -6
+.2byte    1,   -5, 	  -3,    2, 	   4,    1, 	   1,   -6
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte   -5,  -16, 	  -1,   -1, 	  -3,   -1, 	  -2,   -7
+.2byte    9,   -5, 	   7,    1, 	   2,    1, 	   0,   -5
+.2byte    9,   -5, 	   7,    1, 	   2,    1, 	   0,   -5
+.2byte    9,   -5, 	   7,    1, 	   2,    1, 	   0,   -5
+.2byte    9,   -5, 	   7,    1, 	   2,    1, 	   0,   -5
+.2byte    8,   -7, 	   4,    2, 	   1,    3, 	   1,   -5
+.2byte    0,  -14, 	   2,   -4, 	   0,   -2, 	  -1,   -8
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte    5,  -12, 	   5,   -5, 	   3,   -2, 	  -1,   -6
+.2byte    6,   -9, 	   6,   -3, 	   4,    0, 	   1,   -6
+.2byte    6,   -9, 	   6,   -3, 	   4,    0, 	   1,   -6
+.2byte    6,   -9, 	   6,   -3, 	   4,    0, 	   1,   -6
+.2byte    6,   -9, 	   6,   -3, 	   4,    0, 	   1,   -6
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte   -4,  -14, 	   0,   -5, 	  -4,   -3, 	   0,   -4
+.2byte    0,   -8, 	   5,   -5, 	  -5,   -4, 	   0,   -4
+.2byte    0,   -8, 	   5,   -5, 	  -5,   -4, 	   0,   -4
+.2byte    0,   -8, 	   5,   -5, 	  -5,   -4, 	   0,   -4
+.2byte    0,   -8, 	   5,   -5, 	  -5,   -4, 	   0,   -4
+.2byte    0,  -13, 	   3,   -3, 	  -2,   -3, 	   0,   -8
+.2byte   -5,  -12, 	  -5,   -5, 	  -3,   -2, 	   1,   -6
+.2byte   -6,   -9, 	  -6,   -3, 	  -4,    0, 	  -1,   -6
+.2byte   -6,   -9, 	  -6,   -3, 	  -4,    0, 	  -1,   -6
+.2byte   -6,   -9, 	  -6,   -3, 	  -4,    0, 	  -1,   -6
+.2byte   -6,   -9, 	  -6,   -3, 	  -4,    0, 	  -1,   -6
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte   -1,  -14, 	  -3,   -4, 	  -1,   -2, 	   0,   -8
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte    4,  -16, 	   0,   -1, 	   2,   -1, 	   1,   -7
+.2byte  -10,   -5, 	  -8,    1, 	  -3,    1, 	  -1,   -5
+.2byte  -10,   -5, 	  -8,    1, 	  -3,    1, 	  -1,   -5
+.2byte  -10,   -5, 	  -8,    1, 	  -3,    1, 	  -1,   -5
+.2byte  -10,   -5, 	  -8,    1, 	  -3,    1, 	  -1,   -5
+.2byte   -9,   -7, 	  -5,    2, 	  -2,    3, 	  -2,   -5
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte   -9,   -9, 	  -5,    0, 	  -2,    1, 	  -2,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte    1,  -13, 	   4,   -3, 	  -1,   -3, 	   1,   -8
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte    8,   -9, 	   4,    0, 	   1,    1, 	   1,   -7
+.2byte   -9,   -4, 	  -8,   -1, 	  -7,    0, 	  -3,   -3
+.2byte   -9,   -3, 	  -8,   -1, 	  -7,    0, 	  -3,   -4
+.2byte    0,   -8, 	  -4,  -11, 	   4,  -11, 	   0,   -7
+.2byte    2,  -10, 	   5,  -13, 	  -2,  -11, 	  -4,   -7
+.2byte    4,  -11, 	   4,  -15, 	   1,  -12, 	  -3,   -9
+.2byte    1,  -12, 	   0,  -15, 	   5,  -13, 	  -2,   -7
+.2byte   -1,  -12, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte   -2,  -12, 	  -1,  -15, 	  -6,  -13, 	   1,   -7
+.2byte   -5,  -11, 	  -5,  -15, 	  -2,  -12, 	   2,   -9
+.2byte   -3,  -10, 	  -6,  -13, 	   1,  -11, 	   3,   -7
+.2byte    1,   -5, 	  -3,    2, 	   4,    1, 	   1,   -6
+.2byte  -10,   -5, 	  -8,    1, 	  -3,    1, 	  -1,   -5
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte   -6,  -10, 	  -6,   -4, 	  -4,   -1, 	  -1,   -7
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -5, 	   0,   -5
+.2byte    6,  -10, 	   6,   -4, 	   4,   -1, 	   1,   -7
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte    9,   -5, 	   7,    1, 	   2,    1, 	   0,   -5
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte   -9,   -9, 	  -5,    0, 	  -2,    1, 	  -2,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte    1,  -13, 	   4,   -3, 	  -1,   -3, 	   1,   -8
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte    8,   -9, 	   4,    0, 	   1,    1, 	   1,   -7
+.2byte    1,   -5, 	  -3,    2, 	   4,    1, 	   1,   -6
+.2byte    9,   -5, 	   7,    1, 	   2,    1, 	   0,   -5
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte    6,  -10, 	   6,   -4, 	   4,   -1, 	   1,   -7
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -5, 	   0,   -5
+.2byte   -6,  -10, 	  -6,   -4, 	  -4,   -1, 	  -1,   -7
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte  -10,   -5, 	  -8,    1, 	  -3,    1, 	  -1,   -5
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte    6,  -19, 	   5,   -4, 	   6,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -3,    2, 	   4,    1, 	   1,   -6
+.2byte    8,   -9, 	   4,    0, 	   1,    1, 	   1,   -7
+.2byte   -5,  -18, 	  -1,   -3, 	  -3,   -3, 	  -2,   -9
+.2byte    9,   -7, 	   7,   -1, 	   2,   -1, 	   0,   -7
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte    0,  -14, 	   2,   -4, 	   0,   -2, 	  -1,   -8
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte    5,  -12, 	   5,   -5, 	   3,   -2, 	  -1,   -6
+.2byte    6,   -9, 	   6,   -3, 	   4,    0, 	   1,   -6
+.2byte    0,  -13, 	   3,   -3, 	  -2,   -3, 	   0,   -8
+.2byte   -4,  -14, 	   0,   -5, 	  -4,   -3, 	   0,   -4
+.2byte    0,   -8, 	   5,   -5, 	  -5,   -4, 	   0,   -4
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte   -5,  -12, 	  -5,   -5, 	  -3,   -2, 	   1,   -6
+.2byte   -6,   -9, 	  -6,   -3, 	  -4,    0, 	  -1,   -6
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte   -1,  -14, 	  -3,   -4, 	  -1,   -2, 	   0,   -8
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte   -9,   -9, 	  -5,    0, 	  -2,    1, 	  -2,   -7
+.2byte    4,  -18, 	   0,   -3, 	   2,   -3, 	   1,   -9
+.2byte  -10,   -7, 	  -8,   -1, 	  -3,   -1, 	  -1,   -7
+.2byte    0,   -4, 	  -4,    3, 	   3,    2, 	   0,   -5
+.2byte   -9,   -6, 	  -7,    0, 	  -2,    0, 	   0,   -6
+.2byte  -12,   -7, 	  -8,   -2, 	  -4,    0, 	  -2,   -6
+.2byte   -6,  -10, 	  -6,   -4, 	  -4,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -7, 	  -1,   -7
+.2byte    5,  -10, 	   5,   -4, 	   3,   -1, 	   0,   -7
+.2byte   11,   -7, 	   7,   -2, 	   3,    0, 	   1,   -6
+.2byte    8,   -6, 	   6,    0, 	   1,    0, 	  -1,   -6
+.2byte    0,   -8, 	  -2,    1, 	   2,    1, 	   0,   -7
+.2byte   -9,   -9, 	  -5,    0, 	  -2,    1, 	  -2,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -5,    0, 	  -2,   -7
+.2byte   -5,  -13, 	  -1,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte    1,  -13, 	   4,   -3, 	  -1,   -3, 	   1,   -8
+.2byte    5,  -13, 	   1,   -3, 	   5,   -1, 	   1,   -8
+.2byte   11,  -10, 	   6,   -2, 	   4,    0, 	   1,   -7
+.2byte    8,   -9, 	   4,    0, 	   1,    1, 	   1,   -7
+sEspeonAnimTable1:
+.4byte sEspeonAnims_1_1
+.4byte sEspeonAnims_1_2
+.4byte sEspeonAnims_1_3
+.4byte sEspeonAnims_1_4
+.4byte sEspeonAnims_1_5
+.4byte sEspeonAnims_1_6
+.4byte sEspeonAnims_1_7
+.4byte sEspeonAnims_1_8
+sEspeonAnimTable2:
+.4byte sEspeonAnims_2_1
+.4byte sEspeonAnims_2_2
+.4byte sEspeonAnims_2_3
+.4byte sEspeonAnims_2_4
+.4byte sEspeonAnims_2_5
+.4byte sEspeonAnims_2_6
+.4byte sEspeonAnims_2_7
+.4byte sEspeonAnims_2_8
+sEspeonAnimTable3:
+.4byte sEspeonAnims_3_1
+.4byte sEspeonAnims_3_2
+.4byte sEspeonAnims_3_3
+.4byte sEspeonAnims_3_4
+.4byte sEspeonAnims_3_5
+.4byte sEspeonAnims_3_6
+.4byte sEspeonAnims_3_7
+.4byte sEspeonAnims_3_8
+sEspeonAnimTable4:
+.4byte sEspeonAnims_4_1
+.4byte sEspeonAnims_4_2
+.4byte sEspeonAnims_4_3
+.4byte sEspeonAnims_4_4
+.4byte sEspeonAnims_4_5
+.4byte sEspeonAnims_4_6
+.4byte sEspeonAnims_4_7
+.4byte sEspeonAnims_4_8
+sEspeonAnimTable5:
+.4byte sEspeonAnims_5_1
+.4byte sEspeonAnims_5_2
+.4byte sEspeonAnims_5_3
+.4byte sEspeonAnims_5_4
+.4byte sEspeonAnims_5_5
+.4byte sEspeonAnims_5_6
+.4byte sEspeonAnims_5_7
+.4byte sEspeonAnims_5_8
+sEspeonAnimTable6:
+.4byte sEspeonAnims_6_1
+.4byte sEspeonAnims_6_1
+.4byte sEspeonAnims_6_1
+.4byte sEspeonAnims_6_1
+.4byte sEspeonAnims_6_1
+.4byte sEspeonAnims_6_1
+.4byte sEspeonAnims_6_1
+.4byte sEspeonAnims_6_1
+sEspeonAnimTable7:
+.4byte sEspeonAnims_7_1
+.4byte sEspeonAnims_7_2
+.4byte sEspeonAnims_7_3
+.4byte sEspeonAnims_7_4
+.4byte sEspeonAnims_7_5
+.4byte sEspeonAnims_7_6
+.4byte sEspeonAnims_7_7
+.4byte sEspeonAnims_7_8
+sEspeonAnimTable8:
+.4byte sEspeonAnims_8_1
+.4byte sEspeonAnims_8_2
+.4byte sEspeonAnims_8_3
+.4byte sEspeonAnims_8_4
+.4byte sEspeonAnims_8_5
+.4byte sEspeonAnims_8_6
+.4byte sEspeonAnims_8_7
+.4byte sEspeonAnims_8_8
+sEspeonAnimTable9:
+.4byte sEspeonAnims_9_1
+.4byte sEspeonAnims_9_2
+.4byte sEspeonAnims_9_3
+.4byte sEspeonAnims_9_4
+.4byte sEspeonAnims_9_5
+.4byte sEspeonAnims_9_6
+.4byte sEspeonAnims_9_7
+.4byte sEspeonAnims_9_8
+sEspeonAnimTable10:
+.4byte sEspeonAnims_10_1
+.4byte sEspeonAnims_10_2
+.4byte sEspeonAnims_10_3
+.4byte sEspeonAnims_10_4
+.4byte sEspeonAnims_10_5
+.4byte sEspeonAnims_10_6
+.4byte sEspeonAnims_10_7
+.4byte sEspeonAnims_10_8
+sEspeonAnimTable11:
+.4byte sEspeonAnims_11_1
+.4byte sEspeonAnims_11_2
+.4byte sEspeonAnims_11_3
+.4byte sEspeonAnims_11_4
+.4byte sEspeonAnims_11_5
+.4byte sEspeonAnims_11_6
+.4byte sEspeonAnims_11_7
+.4byte sEspeonAnims_11_8
+sEspeonAnimTable12:
+.4byte sEspeonAnims_12_1
+.4byte sEspeonAnims_12_2
+.4byte sEspeonAnims_12_3
+.4byte sEspeonAnims_12_4
+.4byte sEspeonAnims_12_5
+.4byte sEspeonAnims_12_6
+.4byte sEspeonAnims_12_7
+.4byte sEspeonAnims_12_8
+sEspeonAnimTable13:
+.4byte sEspeonAnims_13_1
+.4byte sEspeonAnims_13_2
+.4byte sEspeonAnims_13_3
+.4byte sEspeonAnims_13_4
+.4byte sEspeonAnims_13_5
+.4byte sEspeonAnims_13_6
+.4byte sEspeonAnims_13_7
+.4byte sEspeonAnims_13_8
+sAxAnimationsEspeon:
+.4byte sEspeonAnimTable1
+.4byte sEspeonAnimTable2
+.4byte sEspeonAnimTable3
+.4byte sEspeonAnimTable4
+.4byte sEspeonAnimTable5
+.4byte sEspeonAnimTable6
+.4byte sEspeonAnimTable7
+.4byte sEspeonAnimTable8
+.4byte sEspeonAnimTable9
+.4byte sEspeonAnimTable10
+.4byte sEspeonAnimTable11
+.4byte sEspeonAnimTable12
+.4byte sEspeonAnimTable13
+sAxSpritesEspeon:
+.4byte sEspeonSprites1
+.4byte sEspeonSprites2
+.4byte sEspeonSprites3
+.4byte sEspeonSprites4
+.4byte sEspeonSprites5
+.4byte sEspeonSprites6
+.4byte sEspeonSprites7
+.4byte sEspeonSprites8
+.4byte sEspeonSprites9
+.4byte sEspeonSprites10
+.4byte sEspeonSprites11
+.4byte sEspeonSprites12
+.4byte sEspeonSprites13
+.4byte sEspeonSprites14
+.4byte sEspeonSprites15
+.4byte sEspeonSprites16
+.4byte sEspeonSprites17
+.4byte sEspeonSprites18
+.4byte sEspeonSprites19
+.4byte sEspeonSprites20
+.4byte sEspeonSprites21
+.4byte sEspeonSprites22
+.4byte sEspeonSprites23
+.4byte sEspeonSprites24
+.4byte sEspeonSprites25
+.4byte sEspeonSprites26
+.4byte sEspeonSprites27
+.4byte sEspeonSprites28
+.4byte sEspeonSprites29
+.4byte sEspeonSprites30
+.4byte sEspeonSprites31
+.4byte sEspeonSprites32
+.4byte sEspeonSprites33
+.4byte sEspeonSprites34
+.4byte sEspeonSprites35
+sAxMainEspeon:
+ax_main sAxPosesEspeon, sAxAnimationsEspeon, 13, sAxSpritesEspeon, sAxPositionsEspeon

--- a/data/ax/exeggcute.inc
+++ b/data/ax/exeggcute.inc
@@ -1,0 +1,2829 @@
+.global gAxExeggcute
+gAxExeggcute:
+ax_siro sAxMainExeggcute
+sExeggcutePose1:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose2:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose3:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose4:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose5:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose6:
+ax_pose 5, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose7:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose8:
+ax_pose 7, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose9:
+ax_pose 8, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose10:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose11:
+ax_pose 10, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose12:
+ax_pose 11, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose13:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose14:
+ax_pose 13, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose15:
+ax_pose 14, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose16:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose17:
+ax_pose 16, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose18:
+ax_pose 17, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose19:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose20:
+ax_pose 19, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose21:
+ax_pose 20, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose22:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose23:
+ax_pose 22, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose24:
+ax_pose 23, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose25:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose26:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose27:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose28:
+ax_pose 24, 0x01fa, 0x40f8, 0xac00
+ax_pose 25, 0x01f7, 0x40fc, 0xac04
+ax_pose 26, 0x01f7, 0x40f5, 0xac08
+ax_pose 27, 0x01f2, 0x40f8, 0xac0c
+ax_pose -1, 0x01f2, 0x4100, 0xac0c
+ax_pose 28, 0x01f0, 0x40f2, 0xac10
+ax_pose_terminator
+sExeggcutePose29:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose30:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose31:
+ax_pose 5, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose32:
+ax_pose 29, 0x01fa, 0x50ff, 0xac00
+ax_pose 30, 0x01f8, 0x50f7, 0xac04
+ax_pose 31, 0x01f4, 0x50fe, 0xac08
+ax_pose 32, 0x01f7, 0x50ef, 0xac0c
+ax_pose 33, 0x01f2, 0x50f7, 0xac10
+ax_pose -1, 0x01ee, 0x50fc, 0xac10
+ax_pose_terminator
+sExeggcutePose33:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose34:
+ax_pose 7, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose35:
+ax_pose 8, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose36:
+ax_pose 34, 0x01fa, 0x50f4, 0xac00
+ax_pose 35, 0x01f7, 0x50fa, 0xac04
+ax_pose 36, 0x01f3, 0x5100, 0xac08
+ax_pose 37, 0x01f3, 0x50f5, 0xac0c
+ax_pose 38, 0x01ef, 0x50fb, 0xac10
+ax_pose -1, 0x01ed, 0x50f4, 0xac0c
+ax_pose_terminator
+sExeggcutePose37:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose38:
+ax_pose 10, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose39:
+ax_pose 11, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose40:
+ax_pose 39, 0x01f8, 0x50fd, 0xac00
+ax_pose 40, 0x01f3, 0x50f7, 0xac04
+ax_pose 41, 0x01f2, 0x50ff, 0xac08
+ax_pose -1, 0x01ee, 0x50f0, 0xac04
+ax_pose 42, 0x01ed, 0x50f8, 0xac0c
+ax_pose 43, 0x01ec, 0x5100, 0xac10
+ax_pose_terminator
+sExeggcutePose41:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose42:
+ax_pose 13, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose43:
+ax_pose 14, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose44:
+ax_pose 44, 0x01f4, 0x4102, 0xac00
+ax_pose 45, 0x01f6, 0x40f0, 0xac04
+ax_pose -1, 0x01f6, 0x40f8, 0xac04
+ax_pose 46, 0x01f0, 0x40fc, 0xac08
+ax_pose 47, 0x01f0, 0x40f5, 0xac0c
+ax_pose 48, 0x01eb, 0x40f8, 0xac10
+ax_pose_terminator
+sExeggcutePose45:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose46:
+ax_pose 16, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose47:
+ax_pose 17, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose48:
+ax_pose 40, 0x01f8, 0x40f2, 0xac00
+ax_pose -1, 0x01f3, 0x40f9, 0xac00
+ax_pose 42, 0x01f2, 0x40f1, 0xac04
+ax_pose 39, 0x01ee, 0x4100, 0xac08
+ax_pose 41, 0x01ed, 0x40f8, 0xac0c
+ax_pose 43, 0x01ec, 0x40f0, 0xac10
+ax_pose_terminator
+sExeggcutePose49:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose50:
+ax_pose 19, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose51:
+ax_pose 20, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose52:
+ax_pose 37, 0x01fa, 0x40fc, 0xac00
+ax_pose 38, 0x01f7, 0x40f6, 0xac04
+ax_pose 36, 0x01f3, 0x40f0, 0xac08
+ax_pose -1, 0x01f3, 0x40fb, 0xac00
+ax_pose 35, 0x01ef, 0x40f5, 0xac0c
+ax_pose 34, 0x01ec, 0x40fc, 0xac10
+ax_pose_terminator
+sExeggcutePose53:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose54:
+ax_pose 22, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose55:
+ax_pose 23, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose56:
+ax_pose 29, 0x01fa, 0x40f1, 0xac00
+ax_pose 31, 0x01f8, 0x40f9, 0xac04
+ax_pose 30, 0x01f4, 0x40f2, 0xac08
+ax_pose 33, 0x01f6, 0x4100, 0xac0c
+ax_pose -1, 0x01f2, 0x40f9, 0xac0c
+ax_pose 32, 0x01ee, 0x40f4, 0xac10
+ax_pose_terminator
+sExeggcutePose57:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose58:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose59:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose60:
+ax_pose 24, 0x01fa, 0x40f8, 0xac00
+ax_pose 25, 0x01f7, 0x40fc, 0xac04
+ax_pose 26, 0x01f7, 0x40f5, 0xac08
+ax_pose 27, 0x01f2, 0x40f8, 0xac0c
+ax_pose -1, 0x01f2, 0x4100, 0xac0c
+ax_pose 28, 0x01f0, 0x40f2, 0xac10
+ax_pose_terminator
+sExeggcutePose61:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose62:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose63:
+ax_pose 5, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose64:
+ax_pose 29, 0x01fa, 0x50ff, 0xac00
+ax_pose 30, 0x01f8, 0x50f7, 0xac04
+ax_pose 31, 0x01f4, 0x50fe, 0xac08
+ax_pose 32, 0x01f7, 0x50ef, 0xac0c
+ax_pose 33, 0x01f2, 0x50f7, 0xac10
+ax_pose -1, 0x01ee, 0x50fc, 0xac10
+ax_pose_terminator
+sExeggcutePose65:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose66:
+ax_pose 7, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose67:
+ax_pose 8, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose68:
+ax_pose 34, 0x01fa, 0x50f4, 0xac00
+ax_pose 35, 0x01f7, 0x50fa, 0xac04
+ax_pose 36, 0x01f3, 0x5100, 0xac08
+ax_pose 37, 0x01f3, 0x50f5, 0xac0c
+ax_pose 38, 0x01ef, 0x50fb, 0xac10
+ax_pose -1, 0x01ed, 0x50f4, 0xac0c
+ax_pose_terminator
+sExeggcutePose69:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose70:
+ax_pose 10, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose71:
+ax_pose 11, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose72:
+ax_pose 39, 0x01f8, 0x50fd, 0xac00
+ax_pose 40, 0x01f3, 0x50f7, 0xac04
+ax_pose 41, 0x01f2, 0x50ff, 0xac08
+ax_pose -1, 0x01ee, 0x50f0, 0xac04
+ax_pose 42, 0x01ed, 0x50f8, 0xac0c
+ax_pose 43, 0x01ec, 0x5100, 0xac10
+ax_pose_terminator
+sExeggcutePose73:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose74:
+ax_pose 13, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose75:
+ax_pose 14, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose76:
+ax_pose 44, 0x01f4, 0x4102, 0xac00
+ax_pose 45, 0x01f6, 0x40f0, 0xac04
+ax_pose -1, 0x01f6, 0x40f8, 0xac04
+ax_pose 46, 0x01f0, 0x40fc, 0xac08
+ax_pose 47, 0x01f0, 0x40f5, 0xac0c
+ax_pose 48, 0x01eb, 0x40f8, 0xac10
+ax_pose_terminator
+sExeggcutePose77:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose78:
+ax_pose 16, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose79:
+ax_pose 17, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose80:
+ax_pose 40, 0x01f8, 0x40f2, 0xac00
+ax_pose -1, 0x01f3, 0x40f9, 0xac00
+ax_pose 42, 0x01f2, 0x40f1, 0xac04
+ax_pose 39, 0x01ee, 0x4100, 0xac08
+ax_pose 41, 0x01ed, 0x40f8, 0xac0c
+ax_pose 43, 0x01ec, 0x40f0, 0xac10
+ax_pose_terminator
+sExeggcutePose81:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose82:
+ax_pose 19, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose83:
+ax_pose 20, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose84:
+ax_pose 37, 0x01fa, 0x40fc, 0xac00
+ax_pose 38, 0x01f7, 0x40f6, 0xac04
+ax_pose 36, 0x01f3, 0x40f0, 0xac08
+ax_pose -1, 0x01f3, 0x40fb, 0xac00
+ax_pose 35, 0x01ef, 0x40f5, 0xac0c
+ax_pose 34, 0x01ec, 0x40fc, 0xac10
+ax_pose_terminator
+sExeggcutePose85:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose86:
+ax_pose 22, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose87:
+ax_pose 23, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose88:
+ax_pose 29, 0x01fa, 0x40f1, 0xac00
+ax_pose 31, 0x01f8, 0x40f9, 0xac04
+ax_pose 30, 0x01f4, 0x40f2, 0xac08
+ax_pose 33, 0x01f6, 0x4100, 0xac0c
+ax_pose -1, 0x01f2, 0x40f9, 0xac0c
+ax_pose 32, 0x01ee, 0x40f4, 0xac10
+ax_pose_terminator
+sExeggcutePose89:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose90:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose91:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose92:
+ax_pose 49, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose93:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose94:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose95:
+ax_pose 5, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose96:
+ax_pose 50, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sExeggcutePose97:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose98:
+ax_pose 7, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose99:
+ax_pose 8, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose100:
+ax_pose 51, 0x01e9, 0x90f0, 0xac00
+ax_pose_terminator
+sExeggcutePose101:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose102:
+ax_pose 10, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose103:
+ax_pose 11, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose104:
+ax_pose 52, 0x01e9, 0x90f0, 0xac00
+ax_pose_terminator
+sExeggcutePose105:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose106:
+ax_pose 13, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose107:
+ax_pose 14, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose108:
+ax_pose 53, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose109:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose110:
+ax_pose 16, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose111:
+ax_pose 17, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose112:
+ax_pose 52, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose113:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose114:
+ax_pose 19, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose115:
+ax_pose 20, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose116:
+ax_pose 51, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose117:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose118:
+ax_pose 22, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose119:
+ax_pose 23, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose120:
+ax_pose 50, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sExeggcutePose121:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose122:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose123:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose124:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose125:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose126:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose127:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose128:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose129:
+ax_pose 54, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose130:
+ax_pose 55, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose131:
+ax_pose 56, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose132:
+ax_pose 57, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sExeggcutePose133:
+ax_pose 58, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sExeggcutePose134:
+ax_pose 59, 0x01ec, 0x90f0, 0xac00
+ax_pose_terminator
+sExeggcutePose135:
+ax_pose 60, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose136:
+ax_pose 59, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose137:
+ax_pose 58, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sExeggcutePose138:
+ax_pose 57, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sExeggcutePose139:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose140:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose141:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose142:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose143:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose144:
+ax_pose 5, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose145:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose146:
+ax_pose 7, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose147:
+ax_pose 8, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose148:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose149:
+ax_pose 10, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose150:
+ax_pose 11, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose151:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose152:
+ax_pose 13, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose153:
+ax_pose 14, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose154:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose155:
+ax_pose 16, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose156:
+ax_pose 17, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose157:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose158:
+ax_pose 19, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose159:
+ax_pose 20, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose160:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose161:
+ax_pose 22, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose162:
+ax_pose 23, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose163:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose164:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose165:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose166:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose167:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose168:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose169:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose170:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose171:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose172:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose173:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose174:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose175:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose176:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose177:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose178:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose179:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose180:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose181:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose182:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose183:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose184:
+ax_pose 5, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose185:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose186:
+ax_pose 7, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose187:
+ax_pose 8, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose188:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose189:
+ax_pose 10, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose190:
+ax_pose 11, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose191:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose192:
+ax_pose 13, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose193:
+ax_pose 14, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose194:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose195:
+ax_pose 16, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose196:
+ax_pose 17, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose197:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose198:
+ax_pose 19, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose199:
+ax_pose 20, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose200:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose201:
+ax_pose 22, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose202:
+ax_pose 23, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose203:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose204:
+ax_pose 21, 0x01f0, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose205:
+ax_pose 18, 0x01f1, 0x80f6, 0xac00
+ax_pose_terminator
+sExeggcutePose206:
+ax_pose 15, 0x01f1, 0x80f4, 0xac00
+ax_pose_terminator
+sExeggcutePose207:
+ax_pose 12, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose208:
+ax_pose 9, 0x01f1, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose209:
+ax_pose 6, 0x01ef, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose210:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose211:
+ax_pose 0, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose212:
+ax_pose 21, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose213:
+ax_pose 18, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose214:
+ax_pose 15, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose215:
+ax_pose 12, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose216:
+ax_pose 9, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose217:
+ax_pose 6, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sExeggcutePose218:
+ax_pose 3, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+.align 2
+sExeggcuteAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 1, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sExeggcuteAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 30, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 16, 18, 16,
+ax_anim 2, 1, 31, 19, 15, 19, 15,
+ax_anim 2, 0, 31, 18, 16, 18, 16,
+ax_anim 2, 0, 31, 19, 15, 19, 15,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sExeggcuteAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 1, 35, 17, 1, 17, 1,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 35, 17, 1, 17, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sExeggcuteAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 4, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 16, -20, 16, -20,
+ax_anim 2, 1, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 39, 16, -20, 16, -20,
+ax_anim 2, 0, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sExeggcuteAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 4, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sExeggcuteAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 4, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 47, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -16, -20, -16, -20,
+ax_anim 2, 1, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 47, -16, -20, -16, -20,
+ax_anim 2, 0, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sExeggcuteAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 4, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 1, 51, -17, 1, -17, 1,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 51, -17, 1, -17, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sExeggcuteAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 16, -18, 16,
+ax_anim 2, 1, 55, -19, 15, -19, 15,
+ax_anim 2, 0, 55, -18, 16, -18, 16,
+ax_anim 2, 0, 55, -19, 15, -19, 15,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 4, 0, 58, 0, -2, 0, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 1, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sExeggcuteAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 4, 0, 62, -2, -2, -2, -2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 18, 16, 18, 16,
+ax_anim 2, 1, 63, 19, 15, 19, 15,
+ax_anim 2, 0, 63, 18, 16, 18, 16,
+ax_anim 2, 0, 63, 19, 15, 19, 15,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sExeggcuteAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 4, 0, 66, -2, 0, -2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 1, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sExeggcuteAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 4, 0, 70, -2, 2, -2, 2,
+ax_anim 1, 0, 71, 0, -1, 0, -1,
+ax_anim 1, 2, 71, 4, -6, 4, -6,
+ax_anim 1, 0, 71, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 16, -20, 16, -20,
+ax_anim 2, 1, 71, 17, -19, 17, -19,
+ax_anim 2, 0, 71, 16, -20, 16, -20,
+ax_anim 2, 0, 71, 17, -19, 17, -19,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sExeggcuteAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 4, 0, 74, 0, 2, 0, 2,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sExeggcuteAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 4, 0, 78, 2, 2, 2, 2,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 1, 2, 79, -4, -6, -4, -6,
+ax_anim 1, 0, 79, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -16, -20, -16, -20,
+ax_anim 2, 1, 79, -17, -19, -17, -19,
+ax_anim 2, 0, 79, -16, -20, -16, -20,
+ax_anim 2, 0, 79, -17, -19, -17, -19,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sExeggcuteAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 4, 0, 82, 2, 0, 2, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 1, 83, -17, 1, -17, 1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, 1, -17, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sExeggcuteAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 4, 0, 86, 2, -2, 2, -2,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 16, -18, 16,
+ax_anim 2, 1, 87, -19, 15, -19, 15,
+ax_anim 2, 0, 87, -18, 16, -18, 16,
+ax_anim 2, 0, 87, -19, 15, -19, 15,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_4_1:
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 1, 0, 90, 0, 3, 0, 3,
+ax_anim 1, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 2, 91, 0, 5, 0, 5,
+ax_anim 6, 0, 91, 0, 6, 0, 6,
+ax_anim 1, 1, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 6, 0, 91, 0, -6, 0, -6,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim_terminator
+sExeggcuteAnims_4_2:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 1, 0, 94, 3, 3, 3, 3,
+ax_anim 1, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 2, 95, 5, 5, 5, 5,
+ax_anim 6, 0, 95, 6, 6, 6, 6,
+ax_anim 1, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 6, 0, 95, -6, -6, -6, -6,
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim_terminator
+sExeggcuteAnims_4_3:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 1, 0, 98, 3, 0, 3, 0,
+ax_anim 1, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 2, 99, 5, 0, 5, 0,
+ax_anim 6, 0, 99, 6, 0, 6, 0,
+ax_anim 1, 1, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 6, 0, 99, -6, 0, -6, 0,
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim_terminator
+sExeggcuteAnims_4_4:
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 1, 0, 102, 3, -3, 3, -3,
+ax_anim 1, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 2, 103, 5, -5, 5, -5,
+ax_anim 6, 0, 103, 6, -6, 6, -6,
+ax_anim 1, 1, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 6, 0, 103, -6, 6, -6, 6,
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim_terminator
+sExeggcuteAnims_4_5:
+ax_anim 2, 0, 105, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 1, 0, 106, 0, -3, 0, -3,
+ax_anim 1, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 2, 107, 0, -5, 0, -5,
+ax_anim 6, 0, 107, 0, -6, 0, -6,
+ax_anim 1, 1, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 6, 0, 107, 0, 6, 0, 6,
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim 2, 0, 105, 0, 1, 0, 1,
+ax_anim_terminator
+sExeggcuteAnims_4_6:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 1, 0, 110, -3, -3, -3, -3,
+ax_anim 1, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 2, 111, -5, -5, -5, -5,
+ax_anim 6, 0, 111, -6, -6, -6, -6,
+ax_anim 1, 1, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 6, 0, 111, 6, 6, 6, 6,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim_terminator
+sExeggcuteAnims_4_7:
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 113, -2, 0, -2, 0,
+ax_anim 1, 0, 114, -3, 0, -3, 0,
+ax_anim 1, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 2, 115, -5, 0, -5, 0,
+ax_anim 6, 0, 115, -6, 0, -6, 0,
+ax_anim 1, 1, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 6, 0, 115, 6, 0, 6, 0,
+ax_anim 2, 0, 113, 2, 0, 2, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim_terminator
+sExeggcuteAnims_4_8:
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 1, 0, 118, -3, 3, -3, 3,
+ax_anim 1, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 2, 119, -5, 5, -5, 5,
+ax_anim 6, 0, 119, -6, 6, -6, 6,
+ax_anim 1, 1, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 6, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_5_1:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -5, 0, 0,
+ax_anim 1, 0, 125, 0, -6, 0, 0,
+ax_anim 1, 2, 124, 0, -7, 0, 0,
+ax_anim 1, 0, 123, 0, -8, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 121, 0, -10, 0, 0,
+ax_anim 1, 0, 120, 0, -10, 0, 0,
+ax_anim 1, 0, 127, 0, -10, 0, 0,
+ax_anim 1, 0, 126, 0, -9, 0, 0,
+ax_anim 1, 0, 125, 0, -8, 0, 0,
+ax_anim 1, 0, 124, 0, -7, 0, 0,
+ax_anim 1, 0, 123, 0, -6, 0, 0,
+ax_anim 1, 1, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_5_2:
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 1, 0, 125, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -6, 0, 0,
+ax_anim 1, 2, 123, 0, -7, 0, 0,
+ax_anim 1, 0, 122, 0, -8, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 1, 0, 120, 0, -10, 0, 0,
+ax_anim 1, 0, 127, 0, -10, 0, 0,
+ax_anim 1, 0, 126, 0, -10, 0, 0,
+ax_anim 1, 0, 125, 0, -9, 0, 0,
+ax_anim 1, 0, 124, 0, -8, 0, 0,
+ax_anim 1, 0, 123, 0, -7, 0, 0,
+ax_anim 1, 0, 122, 0, -6, 0, 0,
+ax_anim 1, 1, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_5_3:
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -2, 0, 0,
+ax_anim 1, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 123, 0, -6, 0, 0,
+ax_anim 1, 2, 122, 0, -7, 0, 0,
+ax_anim 1, 0, 121, 0, -8, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 1, 0, 127, 0, -10, 0, 0,
+ax_anim 1, 0, 126, 0, -10, 0, 0,
+ax_anim 1, 0, 125, 0, -10, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 1, 0, 123, 0, -8, 0, 0,
+ax_anim 1, 0, 122, 0, -7, 0, 0,
+ax_anim 1, 0, 121, 0, -6, 0, 0,
+ax_anim 1, 1, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -2, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_5_4:
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 1, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -5, 0, 0,
+ax_anim 1, 0, 122, 0, -6, 0, 0,
+ax_anim 1, 2, 121, 0, -7, 0, 0,
+ax_anim 1, 0, 120, 0, -8, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 126, 0, -10, 0, 0,
+ax_anim 1, 0, 125, 0, -10, 0, 0,
+ax_anim 1, 0, 124, 0, -10, 0, 0,
+ax_anim 1, 0, 123, 0, -9, 0, 0,
+ax_anim 1, 0, 122, 0, -8, 0, 0,
+ax_anim 1, 0, 121, 0, -7, 0, 0,
+ax_anim 1, 0, 120, 0, -6, 0, 0,
+ax_anim 1, 1, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_5_5:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 1, 0, 123, 0, -4, 0, 0,
+ax_anim 1, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -6, 0, 0,
+ax_anim 1, 2, 120, 0, -7, 0, 0,
+ax_anim 1, 0, 127, 0, -8, 0, 0,
+ax_anim 1, 0, 126, 0, -9, 0, 0,
+ax_anim 1, 0, 125, 0, -10, 0, 0,
+ax_anim 1, 0, 124, 0, -10, 0, 0,
+ax_anim 1, 0, 123, 0, -10, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 121, 0, -8, 0, 0,
+ax_anim 1, 0, 120, 0, -7, 0, 0,
+ax_anim 1, 0, 127, 0, -6, 0, 0,
+ax_anim 1, 1, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_5_6:
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -2, 0, 0,
+ax_anim 1, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -5, 0, 0,
+ax_anim 1, 0, 120, 0, -6, 0, 0,
+ax_anim 1, 2, 127, 0, -7, 0, 0,
+ax_anim 1, 0, 126, 0, -8, 0, 0,
+ax_anim 1, 0, 125, 0, -9, 0, 0,
+ax_anim 1, 0, 124, 0, -10, 0, 0,
+ax_anim 1, 0, 123, 0, -10, 0, 0,
+ax_anim 1, 0, 122, 0, -10, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 1, 0, 120, 0, -8, 0, 0,
+ax_anim 1, 0, 127, 0, -7, 0, 0,
+ax_anim 1, 0, 126, 0, -6, 0, 0,
+ax_anim 1, 1, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -2, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_5_7:
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 1, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -6, 0, 0,
+ax_anim 1, 2, 126, 0, -7, 0, 0,
+ax_anim 1, 0, 125, 0, -8, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 1, 0, 123, 0, -10, 0, 0,
+ax_anim 1, 0, 122, 0, -10, 0, 0,
+ax_anim 1, 0, 121, 0, -10, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 1, 0, 127, 0, -8, 0, 0,
+ax_anim 1, 0, 126, 0, -7, 0, 0,
+ax_anim 1, 0, 125, 0, -6, 0, 0,
+ax_anim 1, 1, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_5_8:
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 1, 0, 120, 0, -4, 0, 0,
+ax_anim 1, 0, 127, 0, -5, 0, 0,
+ax_anim 1, 0, 126, 0, -6, 0, 0,
+ax_anim 1, 2, 125, 0, -7, 0, 0,
+ax_anim 1, 0, 124, 0, -8, 0, 0,
+ax_anim 1, 0, 123, 0, -9, 0, 0,
+ax_anim 1, 0, 122, 0, -10, 0, 0,
+ax_anim 1, 0, 121, 0, -10, 0, 0,
+ax_anim 1, 0, 120, 0, -10, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 126, 0, -8, 0, 0,
+ax_anim 1, 0, 125, 0, -7, 0, 0,
+ax_anim 1, 0, 124, 0, -6, 0, 0,
+ax_anim 1, 1, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sExeggcuteAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sExeggcuteAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sExeggcuteAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sExeggcuteAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sExeggcuteAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sExeggcuteAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sExeggcuteAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -1, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim 2, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 13, 7, 13,
+ax_anim 3, 0, 166, 0, 15, 0, 15,
+ax_anim 2, 3, 167, -7, 13, -7, 13,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 18, 16, 18, 16,
+ax_anim 2, 3, 166, 11, 17, 11, 17,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 18, -2, 18, -2,
+ax_anim 2, 3, 165, 16, 4, 16, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 18, -22, 18, -22,
+ax_anim 2, 3, 164, 20, -15, 20, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -18, -22, -18, -22,
+ax_anim 2, 3, 168, -20, -15, -20, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -18, -2, -18, -2,
+ax_anim 2, 3, 167, -16, 4, -16, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -18, 16, -18, 16,
+ax_anim 2, 3, 166, -11, 17, -11, 17,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggcuteAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggcuteGfx1:
+.incbin "baserom.gba", 0x958F9C, 0x200
+sExeggcuteSprites1:
+ax_sprite sExeggcuteGfx1, 0x200
+ax_sprite_terminator
+sExeggcuteGfx2:
+.incbin "baserom.gba", 0x9591AC, 0x200
+sExeggcuteSprites2:
+ax_sprite sExeggcuteGfx2, 0x200
+ax_sprite_terminator
+sExeggcuteGfx3:
+.incbin "baserom.gba", 0x9593BC, 0x200
+sExeggcuteSprites3:
+ax_sprite sExeggcuteGfx3, 0x200
+ax_sprite_terminator
+sExeggcuteGfx4:
+.incbin "baserom.gba", 0x9595CC, 0x200
+sExeggcuteSprites4:
+ax_sprite sExeggcuteGfx4, 0x200
+ax_sprite_terminator
+sExeggcuteGfx5:
+.incbin "baserom.gba", 0x9597DC, 0x200
+sExeggcuteSprites5:
+ax_sprite sExeggcuteGfx5, 0x200
+ax_sprite_terminator
+sExeggcuteGfx6:
+.incbin "baserom.gba", 0x9599EC, 0x200
+sExeggcuteSprites6:
+ax_sprite sExeggcuteGfx6, 0x200
+ax_sprite_terminator
+sExeggcuteGfx7:
+.incbin "baserom.gba", 0x959BFC, 0x200
+sExeggcuteSprites7:
+ax_sprite sExeggcuteGfx7, 0x200
+ax_sprite_terminator
+sExeggcuteGfx8:
+.incbin "baserom.gba", 0x959E0C, 0x200
+sExeggcuteSprites8:
+ax_sprite sExeggcuteGfx8, 0x200
+ax_sprite_terminator
+sExeggcuteGfx9:
+.incbin "baserom.gba", 0x95A01C, 0x200
+sExeggcuteSprites9:
+ax_sprite sExeggcuteGfx9, 0x200
+ax_sprite_terminator
+sExeggcuteGfx10:
+.incbin "baserom.gba", 0x95A22C, 0x200
+sExeggcuteSprites10:
+ax_sprite sExeggcuteGfx10, 0x200
+ax_sprite_terminator
+sExeggcuteGfx11:
+.incbin "baserom.gba", 0x95A43C, 0x200
+sExeggcuteSprites11:
+ax_sprite sExeggcuteGfx11, 0x200
+ax_sprite_terminator
+sExeggcuteGfx12:
+.incbin "baserom.gba", 0x95A64C, 0x200
+sExeggcuteSprites12:
+ax_sprite sExeggcuteGfx12, 0x200
+ax_sprite_terminator
+sExeggcuteGfx13:
+.incbin "baserom.gba", 0x95A85C, 0x200
+sExeggcuteSprites13:
+ax_sprite sExeggcuteGfx13, 0x200
+ax_sprite_terminator
+sExeggcuteGfx14:
+.incbin "baserom.gba", 0x95AA6C, 0x200
+sExeggcuteSprites14:
+ax_sprite sExeggcuteGfx14, 0x200
+ax_sprite_terminator
+sExeggcuteGfx15:
+.incbin "baserom.gba", 0x95AC7C, 0x200
+sExeggcuteSprites15:
+ax_sprite sExeggcuteGfx15, 0x200
+ax_sprite_terminator
+sExeggcuteGfx16:
+.incbin "baserom.gba", 0x95AE8C, 0x200
+sExeggcuteSprites16:
+ax_sprite sExeggcuteGfx16, 0x200
+ax_sprite_terminator
+sExeggcuteGfx17:
+.incbin "baserom.gba", 0x95B09C, 0x200
+sExeggcuteSprites17:
+ax_sprite sExeggcuteGfx17, 0x200
+ax_sprite_terminator
+sExeggcuteGfx18:
+.incbin "baserom.gba", 0x95B2AC, 0x200
+sExeggcuteSprites18:
+ax_sprite sExeggcuteGfx18, 0x200
+ax_sprite_terminator
+sExeggcuteGfx19:
+.incbin "baserom.gba", 0x95B4BC, 0x200
+sExeggcuteSprites19:
+ax_sprite sExeggcuteGfx19, 0x200
+ax_sprite_terminator
+sExeggcuteGfx20:
+.incbin "baserom.gba", 0x95B6CC, 0x200
+sExeggcuteSprites20:
+ax_sprite sExeggcuteGfx20, 0x200
+ax_sprite_terminator
+sExeggcuteGfx21:
+.incbin "baserom.gba", 0x95B8DC, 0x200
+sExeggcuteSprites21:
+ax_sprite sExeggcuteGfx21, 0x200
+ax_sprite_terminator
+sExeggcuteGfx22:
+.incbin "baserom.gba", 0x95BAEC, 0x200
+sExeggcuteSprites22:
+ax_sprite sExeggcuteGfx22, 0x200
+ax_sprite_terminator
+sExeggcuteGfx23:
+.incbin "baserom.gba", 0x95BCFC, 0x200
+sExeggcuteSprites23:
+ax_sprite sExeggcuteGfx23, 0x200
+ax_sprite_terminator
+sExeggcuteGfx24:
+.incbin "baserom.gba", 0x95BF0C, 0x200
+sExeggcuteSprites24:
+ax_sprite sExeggcuteGfx24, 0x200
+ax_sprite_terminator
+sExeggcuteGfx25:
+.incbin "baserom.gba", 0x95C11C, 0x80
+sExeggcuteSprites25:
+ax_sprite sExeggcuteGfx25, 0x80
+ax_sprite_terminator
+sExeggcuteGfx26:
+.incbin "baserom.gba", 0x95C1AC, 0x80
+sExeggcuteSprites26:
+ax_sprite sExeggcuteGfx26, 0x80
+ax_sprite_terminator
+sExeggcuteGfx27:
+.incbin "baserom.gba", 0x95C23C, 0x80
+sExeggcuteSprites27:
+ax_sprite sExeggcuteGfx27, 0x80
+ax_sprite_terminator
+sExeggcuteGfx28:
+.incbin "baserom.gba", 0x95C2CC, 0x80
+sExeggcuteSprites28:
+ax_sprite sExeggcuteGfx28, 0x80
+ax_sprite_terminator
+sExeggcuteGfx29:
+.incbin "baserom.gba", 0x95C35C, 0x80
+sExeggcuteSprites29:
+ax_sprite sExeggcuteGfx29, 0x80
+ax_sprite_terminator
+sExeggcuteGfx30:
+.incbin "baserom.gba", 0x95C3EC, 0x80
+sExeggcuteSprites30:
+ax_sprite sExeggcuteGfx30, 0x80
+ax_sprite_terminator
+sExeggcuteGfx31:
+.incbin "baserom.gba", 0x95C47C, 0x80
+sExeggcuteSprites31:
+ax_sprite sExeggcuteGfx31, 0x80
+ax_sprite_terminator
+sExeggcuteGfx32:
+.incbin "baserom.gba", 0x95C50C, 0x80
+sExeggcuteSprites32:
+ax_sprite sExeggcuteGfx32, 0x80
+ax_sprite_terminator
+sExeggcuteGfx33:
+.incbin "baserom.gba", 0x95C59C, 0x80
+sExeggcuteSprites33:
+ax_sprite sExeggcuteGfx33, 0x80
+ax_sprite_terminator
+sExeggcuteGfx34:
+.incbin "baserom.gba", 0x95C62C, 0x80
+sExeggcuteSprites34:
+ax_sprite sExeggcuteGfx34, 0x80
+ax_sprite_terminator
+sExeggcuteGfx35:
+.incbin "baserom.gba", 0x95C6BC, 0x80
+sExeggcuteSprites35:
+ax_sprite sExeggcuteGfx35, 0x80
+ax_sprite_terminator
+sExeggcuteGfx36:
+.incbin "baserom.gba", 0x95C74C, 0x80
+sExeggcuteSprites36:
+ax_sprite sExeggcuteGfx36, 0x80
+ax_sprite_terminator
+sExeggcuteGfx37:
+.incbin "baserom.gba", 0x95C7DC, 0x80
+sExeggcuteSprites37:
+ax_sprite sExeggcuteGfx37, 0x80
+ax_sprite_terminator
+sExeggcuteGfx38:
+.incbin "baserom.gba", 0x95C86C, 0x80
+sExeggcuteSprites38:
+ax_sprite sExeggcuteGfx38, 0x80
+ax_sprite_terminator
+sExeggcuteGfx39:
+.incbin "baserom.gba", 0x95C8FC, 0x80
+sExeggcuteSprites39:
+ax_sprite sExeggcuteGfx39, 0x80
+ax_sprite_terminator
+sExeggcuteGfx40:
+.incbin "baserom.gba", 0x95C98C, 0x80
+sExeggcuteSprites40:
+ax_sprite sExeggcuteGfx40, 0x80
+ax_sprite_terminator
+sExeggcuteGfx41:
+.incbin "baserom.gba", 0x95CA1C, 0x80
+sExeggcuteSprites41:
+ax_sprite sExeggcuteGfx41, 0x80
+ax_sprite_terminator
+sExeggcuteGfx42:
+.incbin "baserom.gba", 0x95CAAC, 0x80
+sExeggcuteSprites42:
+ax_sprite sExeggcuteGfx42, 0x80
+ax_sprite_terminator
+sExeggcuteGfx43:
+.incbin "baserom.gba", 0x95CB3C, 0x80
+sExeggcuteSprites43:
+ax_sprite sExeggcuteGfx43, 0x80
+ax_sprite_terminator
+sExeggcuteGfx44:
+.incbin "baserom.gba", 0x95CBCC, 0x80
+sExeggcuteSprites44:
+ax_sprite sExeggcuteGfx44, 0x80
+ax_sprite_terminator
+sExeggcuteGfx45:
+.incbin "baserom.gba", 0x95CC5C, 0x80
+sExeggcuteSprites45:
+ax_sprite sExeggcuteGfx45, 0x80
+ax_sprite_terminator
+sExeggcuteGfx46:
+.incbin "baserom.gba", 0x95CCEC, 0x80
+sExeggcuteSprites46:
+ax_sprite sExeggcuteGfx46, 0x80
+ax_sprite_terminator
+sExeggcuteGfx47:
+.incbin "baserom.gba", 0x95CD7C, 0x80
+sExeggcuteSprites47:
+ax_sprite sExeggcuteGfx47, 0x80
+ax_sprite_terminator
+sExeggcuteGfx48:
+.incbin "baserom.gba", 0x95CE0C, 0x80
+sExeggcuteSprites48:
+ax_sprite sExeggcuteGfx48, 0x80
+ax_sprite_terminator
+sExeggcuteGfx49:
+.incbin "baserom.gba", 0x95CE9C, 0x80
+sExeggcuteSprites49:
+ax_sprite sExeggcuteGfx49, 0x80
+ax_sprite_terminator
+sExeggcuteGfx50:
+.incbin "baserom.gba", 0x95CF2C, 0x200
+sExeggcuteSprites50:
+ax_sprite sExeggcuteGfx50, 0x200
+ax_sprite_terminator
+sExeggcuteGfx51:
+.incbin "baserom.gba", 0x95D13C, 0x60
+sExeggcuteGfx51_1:
+.incbin "baserom.gba", 0x95D19C, 0x160
+sExeggcuteSprites51:
+ax_sprite sExeggcuteGfx51, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggcuteGfx51_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggcuteGfx52:
+.incbin "baserom.gba", 0x95D324, 0x40
+sExeggcuteGfx52_1:
+.incbin "baserom.gba", 0x95D364, 0x60
+sExeggcuteGfx52_2:
+.incbin "baserom.gba", 0x95D3C4, 0x60
+sExeggcuteGfx52_3:
+.incbin "baserom.gba", 0x95D424, 0x40
+sExeggcuteSprites52:
+ax_sprite 0, 0x20
+ax_sprite sExeggcuteGfx52, 0x40
+ax_sprite 0, 0x40
+ax_sprite sExeggcuteGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggcuteGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggcuteGfx52_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggcuteGfx53:
+.incbin "baserom.gba", 0x95D4B4, 0x160
+sExeggcuteGfx53_1:
+.incbin "baserom.gba", 0x95D614, 0x40
+sExeggcuteSprites53:
+ax_sprite 0, 0x20
+ax_sprite sExeggcuteGfx53, 0x160
+ax_sprite 0, 0x20
+ax_sprite sExeggcuteGfx53_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggcuteGfx54:
+.incbin "baserom.gba", 0x95D684, 0x200
+sExeggcuteSprites54:
+ax_sprite sExeggcuteGfx54, 0x200
+ax_sprite_terminator
+sExeggcuteGfx55:
+.incbin "baserom.gba", 0x95D894, 0x200
+sExeggcuteSprites55:
+ax_sprite sExeggcuteGfx55, 0x200
+ax_sprite_terminator
+sExeggcuteGfx56:
+.incbin "baserom.gba", 0x95DAA4, 0x200
+sExeggcuteSprites56:
+ax_sprite sExeggcuteGfx56, 0x200
+ax_sprite_terminator
+sExeggcuteGfx57:
+.incbin "baserom.gba", 0x95DCB4, 0x200
+sExeggcuteSprites57:
+ax_sprite sExeggcuteGfx57, 0x200
+ax_sprite_terminator
+sExeggcuteGfx58:
+.incbin "baserom.gba", 0x95DEC4, 0x200
+sExeggcuteSprites58:
+ax_sprite sExeggcuteGfx58, 0x200
+ax_sprite_terminator
+sExeggcuteGfx59:
+.incbin "baserom.gba", 0x95E0D4, 0x200
+sExeggcuteSprites59:
+ax_sprite sExeggcuteGfx59, 0x200
+ax_sprite_terminator
+sExeggcuteGfx60:
+.incbin "baserom.gba", 0x95E2E4, 0x200
+sExeggcuteSprites60:
+ax_sprite sExeggcuteGfx60, 0x200
+ax_sprite_terminator
+sExeggcuteGfx61:
+.incbin "baserom.gba", 0x95E4F4, 0x200
+sExeggcuteSprites61:
+ax_sprite sExeggcuteGfx61, 0x200
+ax_sprite_terminator
+sAxPosesExeggcute:
+.4byte sExeggcutePose1
+.4byte sExeggcutePose2
+.4byte sExeggcutePose3
+.4byte sExeggcutePose4
+.4byte sExeggcutePose5
+.4byte sExeggcutePose6
+.4byte sExeggcutePose7
+.4byte sExeggcutePose8
+.4byte sExeggcutePose9
+.4byte sExeggcutePose10
+.4byte sExeggcutePose11
+.4byte sExeggcutePose12
+.4byte sExeggcutePose13
+.4byte sExeggcutePose14
+.4byte sExeggcutePose15
+.4byte sExeggcutePose16
+.4byte sExeggcutePose17
+.4byte sExeggcutePose18
+.4byte sExeggcutePose19
+.4byte sExeggcutePose20
+.4byte sExeggcutePose21
+.4byte sExeggcutePose22
+.4byte sExeggcutePose23
+.4byte sExeggcutePose24
+.4byte sExeggcutePose25
+.4byte sExeggcutePose26
+.4byte sExeggcutePose27
+.4byte sExeggcutePose28
+.4byte sExeggcutePose29
+.4byte sExeggcutePose30
+.4byte sExeggcutePose31
+.4byte sExeggcutePose32
+.4byte sExeggcutePose33
+.4byte sExeggcutePose34
+.4byte sExeggcutePose35
+.4byte sExeggcutePose36
+.4byte sExeggcutePose37
+.4byte sExeggcutePose38
+.4byte sExeggcutePose39
+.4byte sExeggcutePose40
+.4byte sExeggcutePose41
+.4byte sExeggcutePose42
+.4byte sExeggcutePose43
+.4byte sExeggcutePose44
+.4byte sExeggcutePose45
+.4byte sExeggcutePose46
+.4byte sExeggcutePose47
+.4byte sExeggcutePose48
+.4byte sExeggcutePose49
+.4byte sExeggcutePose50
+.4byte sExeggcutePose51
+.4byte sExeggcutePose52
+.4byte sExeggcutePose53
+.4byte sExeggcutePose54
+.4byte sExeggcutePose55
+.4byte sExeggcutePose56
+.4byte sExeggcutePose57
+.4byte sExeggcutePose58
+.4byte sExeggcutePose59
+.4byte sExeggcutePose60
+.4byte sExeggcutePose61
+.4byte sExeggcutePose62
+.4byte sExeggcutePose63
+.4byte sExeggcutePose64
+.4byte sExeggcutePose65
+.4byte sExeggcutePose66
+.4byte sExeggcutePose67
+.4byte sExeggcutePose68
+.4byte sExeggcutePose69
+.4byte sExeggcutePose70
+.4byte sExeggcutePose71
+.4byte sExeggcutePose72
+.4byte sExeggcutePose73
+.4byte sExeggcutePose74
+.4byte sExeggcutePose75
+.4byte sExeggcutePose76
+.4byte sExeggcutePose77
+.4byte sExeggcutePose78
+.4byte sExeggcutePose79
+.4byte sExeggcutePose80
+.4byte sExeggcutePose81
+.4byte sExeggcutePose82
+.4byte sExeggcutePose83
+.4byte sExeggcutePose84
+.4byte sExeggcutePose85
+.4byte sExeggcutePose86
+.4byte sExeggcutePose87
+.4byte sExeggcutePose88
+.4byte sExeggcutePose89
+.4byte sExeggcutePose90
+.4byte sExeggcutePose91
+.4byte sExeggcutePose92
+.4byte sExeggcutePose93
+.4byte sExeggcutePose94
+.4byte sExeggcutePose95
+.4byte sExeggcutePose96
+.4byte sExeggcutePose97
+.4byte sExeggcutePose98
+.4byte sExeggcutePose99
+.4byte sExeggcutePose100
+.4byte sExeggcutePose101
+.4byte sExeggcutePose102
+.4byte sExeggcutePose103
+.4byte sExeggcutePose104
+.4byte sExeggcutePose105
+.4byte sExeggcutePose106
+.4byte sExeggcutePose107
+.4byte sExeggcutePose108
+.4byte sExeggcutePose109
+.4byte sExeggcutePose110
+.4byte sExeggcutePose111
+.4byte sExeggcutePose112
+.4byte sExeggcutePose113
+.4byte sExeggcutePose114
+.4byte sExeggcutePose115
+.4byte sExeggcutePose116
+.4byte sExeggcutePose117
+.4byte sExeggcutePose118
+.4byte sExeggcutePose119
+.4byte sExeggcutePose120
+.4byte sExeggcutePose121
+.4byte sExeggcutePose122
+.4byte sExeggcutePose123
+.4byte sExeggcutePose124
+.4byte sExeggcutePose125
+.4byte sExeggcutePose126
+.4byte sExeggcutePose127
+.4byte sExeggcutePose128
+.4byte sExeggcutePose129
+.4byte sExeggcutePose130
+.4byte sExeggcutePose131
+.4byte sExeggcutePose132
+.4byte sExeggcutePose133
+.4byte sExeggcutePose134
+.4byte sExeggcutePose135
+.4byte sExeggcutePose136
+.4byte sExeggcutePose137
+.4byte sExeggcutePose138
+.4byte sExeggcutePose139
+.4byte sExeggcutePose140
+.4byte sExeggcutePose141
+.4byte sExeggcutePose142
+.4byte sExeggcutePose143
+.4byte sExeggcutePose144
+.4byte sExeggcutePose145
+.4byte sExeggcutePose146
+.4byte sExeggcutePose147
+.4byte sExeggcutePose148
+.4byte sExeggcutePose149
+.4byte sExeggcutePose150
+.4byte sExeggcutePose151
+.4byte sExeggcutePose152
+.4byte sExeggcutePose153
+.4byte sExeggcutePose154
+.4byte sExeggcutePose155
+.4byte sExeggcutePose156
+.4byte sExeggcutePose157
+.4byte sExeggcutePose158
+.4byte sExeggcutePose159
+.4byte sExeggcutePose160
+.4byte sExeggcutePose161
+.4byte sExeggcutePose162
+.4byte sExeggcutePose163
+.4byte sExeggcutePose164
+.4byte sExeggcutePose165
+.4byte sExeggcutePose166
+.4byte sExeggcutePose167
+.4byte sExeggcutePose168
+.4byte sExeggcutePose169
+.4byte sExeggcutePose170
+.4byte sExeggcutePose171
+.4byte sExeggcutePose172
+.4byte sExeggcutePose173
+.4byte sExeggcutePose174
+.4byte sExeggcutePose175
+.4byte sExeggcutePose176
+.4byte sExeggcutePose177
+.4byte sExeggcutePose178
+.4byte sExeggcutePose179
+.4byte sExeggcutePose180
+.4byte sExeggcutePose181
+.4byte sExeggcutePose182
+.4byte sExeggcutePose183
+.4byte sExeggcutePose184
+.4byte sExeggcutePose185
+.4byte sExeggcutePose186
+.4byte sExeggcutePose187
+.4byte sExeggcutePose188
+.4byte sExeggcutePose189
+.4byte sExeggcutePose190
+.4byte sExeggcutePose191
+.4byte sExeggcutePose192
+.4byte sExeggcutePose193
+.4byte sExeggcutePose194
+.4byte sExeggcutePose195
+.4byte sExeggcutePose196
+.4byte sExeggcutePose197
+.4byte sExeggcutePose198
+.4byte sExeggcutePose199
+.4byte sExeggcutePose200
+.4byte sExeggcutePose201
+.4byte sExeggcutePose202
+.4byte sExeggcutePose203
+.4byte sExeggcutePose204
+.4byte sExeggcutePose205
+.4byte sExeggcutePose206
+.4byte sExeggcutePose207
+.4byte sExeggcutePose208
+.4byte sExeggcutePose209
+.4byte sExeggcutePose210
+.4byte sExeggcutePose211
+.4byte sExeggcutePose212
+.4byte sExeggcutePose213
+.4byte sExeggcutePose214
+.4byte sExeggcutePose215
+.4byte sExeggcutePose216
+.4byte sExeggcutePose217
+.4byte sExeggcutePose218
+sAxPositionsExeggcute:
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -3, 	   9,    0, 	  -1,   -7
+.2byte    0,   -5, 	  -8,    0, 	   9,   -6, 	   0,   -8
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    3,   -4, 	  -3,   -2, 	  12,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  -2,    3, 	  11,  -10, 	  -1,   -8
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -4, 	   4,   -2, 	   8,  -11, 	  -1,   -6
+.2byte    1,   -6, 	   4,    1, 	   7,  -16, 	  -3,   -7
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -7, 	   7,   -7, 	   1,  -12, 	  -1,   -4
+.2byte    2,   -8, 	   7,   -5, 	   0,  -16, 	  -1,   -7
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,  -13, 	  -8,  -11, 	   0,   -4
+.2byte    0,  -11, 	   7,   -9, 	  -7,  -16, 	   1,   -7
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte   -2,   -7, 	   0,  -15, 	 -10,   -6, 	   1,   -5
+.2byte   -1,   -8, 	   1,  -12, 	  -9,  -11, 	   0,   -5
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -3,   -3, 	  -6,  -14, 	  -8,    0, 	   3,   -6
+.2byte   -3,   -9, 	  -6,  -10, 	  -7,   -5, 	   2,   -5
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -2, 	 -10,   -8, 	   3,    3, 	   1,   -6
+.2byte   -2,   -6, 	 -12,   -4, 	   3,   -4, 	   1,   -7
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -3, 	   9,    0, 	  -1,   -7
+.2byte    0,   -5, 	  -8,    0, 	   9,   -6, 	   0,   -8
+.2byte   -1,    1, 	  -3,   -1, 	   4,   -1, 	  -1,    3
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    3,   -4, 	  -3,   -2, 	  12,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  -2,    3, 	  11,  -10, 	  -1,   -8
+.2byte    7,    1, 	  -2,    0, 	   6,   -4, 	   6,    3
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -4, 	   4,   -2, 	   8,  -11, 	  -1,   -6
+.2byte    1,   -6, 	   4,    1, 	   7,  -16, 	  -3,   -7
+.2byte    8,   -6, 	   1,   -2, 	   2,   -9, 	   6,   -4
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -7, 	   7,   -7, 	   1,  -12, 	  -1,   -4
+.2byte    2,   -8, 	   7,   -5, 	   0,  -16, 	  -1,   -7
+.2byte    8,  -13, 	   6,   -6, 	  -1,  -11, 	   7,  -11
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,  -13, 	  -8,  -11, 	   0,   -4
+.2byte    0,  -11, 	   7,   -9, 	  -7,  -16, 	   1,   -7
+.2byte    0,  -14, 	   3,   -9, 	  -3,   -8, 	   0,  -12
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte   -2,   -7, 	   0,  -15, 	 -10,   -6, 	   1,   -5
+.2byte   -1,   -8, 	   1,  -12, 	  -9,  -11, 	   0,   -5
+.2byte   -9,  -13, 	   0,  -11, 	  -7,   -6, 	  -8,  -11
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -3,   -3, 	  -6,  -14, 	  -8,    0, 	   3,   -6
+.2byte   -3,   -9, 	  -6,  -10, 	  -7,   -5, 	   2,   -5
+.2byte   -9,   -6, 	  -3,  -10, 	  -2,   -1, 	  -7,   -4
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -2, 	 -10,   -8, 	   3,    3, 	   1,   -6
+.2byte   -2,   -6, 	 -12,   -4, 	   3,   -4, 	   1,   -7
+.2byte   -8,    1, 	  -6,   -4, 	   0,    0, 	  -7,    3
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -3, 	   9,    0, 	  -1,   -7
+.2byte    0,   -5, 	  -8,    0, 	   9,   -6, 	   0,   -8
+.2byte   -1,    1, 	  -3,   -1, 	   4,   -1, 	  -1,    3
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    3,   -4, 	  -3,   -2, 	  12,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  -2,    3, 	  11,  -10, 	  -1,   -8
+.2byte    7,    1, 	  -2,    0, 	   6,   -4, 	   6,    3
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -4, 	   4,   -2, 	   8,  -11, 	  -1,   -6
+.2byte    1,   -6, 	   4,    1, 	   7,  -16, 	  -3,   -7
+.2byte    8,   -6, 	   1,   -2, 	   2,   -9, 	   6,   -4
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -7, 	   7,   -7, 	   1,  -12, 	  -1,   -4
+.2byte    2,   -8, 	   7,   -5, 	   0,  -16, 	  -1,   -7
+.2byte    8,  -13, 	   6,   -6, 	  -1,  -11, 	   7,  -11
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,  -13, 	  -8,  -11, 	   0,   -4
+.2byte    0,  -11, 	   7,   -9, 	  -7,  -16, 	   1,   -7
+.2byte    0,  -14, 	   3,   -9, 	  -3,   -8, 	   0,  -12
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte   -2,   -7, 	   0,  -15, 	 -10,   -6, 	   1,   -5
+.2byte   -1,   -8, 	   1,  -12, 	  -9,  -11, 	   0,   -5
+.2byte   -9,  -13, 	   0,  -11, 	  -7,   -6, 	  -8,  -11
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -3,   -3, 	  -6,  -14, 	  -8,    0, 	   3,   -6
+.2byte   -3,   -9, 	  -6,  -10, 	  -7,   -5, 	   2,   -5
+.2byte   -9,   -6, 	  -3,  -10, 	  -2,   -1, 	  -7,   -4
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -2, 	 -10,   -8, 	   3,    3, 	   1,   -6
+.2byte   -2,   -6, 	 -12,   -4, 	   3,   -4, 	   1,   -7
+.2byte   -8,    1, 	  -6,   -4, 	   0,    0, 	  -7,    3
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -3, 	   9,    0, 	  -1,   -7
+.2byte    0,   -5, 	  -8,    0, 	   9,   -6, 	   0,   -8
+.2byte    0,   -4, 	 -12,  -12, 	  11,  -13, 	   0,   -7
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    3,   -4, 	  -3,   -2, 	  12,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  -2,    3, 	  11,  -10, 	  -1,   -8
+.2byte    1,   -5, 	  10,  -12, 	 -13,   -7, 	  -1,   -7
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -4, 	   4,   -2, 	   8,  -11, 	  -1,   -6
+.2byte    1,   -6, 	   4,    1, 	   7,  -16, 	  -3,   -7
+.2byte    2,   -7, 	   4,  -14, 	  -6,   -6, 	  -1,   -7
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -7, 	   7,   -7, 	   1,  -12, 	  -1,   -4
+.2byte    2,   -8, 	   7,   -5, 	   0,  -16, 	  -1,   -7
+.2byte    0,   -8, 	 -10,  -13, 	  10,   -6, 	  -1,   -8
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,  -13, 	  -8,  -11, 	   0,   -4
+.2byte    0,  -11, 	   7,   -9, 	  -7,  -16, 	   1,   -7
+.2byte    0,   -8, 	  10,  -12, 	 -10,  -13, 	  -1,   -8
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte   -2,   -7, 	   0,  -15, 	 -10,   -6, 	   1,   -5
+.2byte   -1,   -8, 	   1,  -12, 	  -9,  -11, 	   0,   -5
+.2byte   -1,   -8, 	   9,  -13, 	 -11,   -6, 	   0,   -8
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -3,   -3, 	  -6,  -14, 	  -8,    0, 	   3,   -6
+.2byte   -3,   -9, 	  -6,  -10, 	  -7,   -5, 	   2,   -5
+.2byte   -3,   -7, 	  -5,  -14, 	   5,   -6, 	   0,   -7
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -2, 	 -10,   -8, 	   3,    3, 	   1,   -6
+.2byte   -2,   -6, 	 -12,   -4, 	   3,   -4, 	   1,   -7
+.2byte   -2,   -5, 	 -11,  -12, 	  12,   -7, 	   0,   -7
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    0,   -4, 	  -8,    0, 	   8,    0, 	   0,   -5
+.2byte    0,   -3, 	  -8,    0, 	  10,    1, 	  -1,   -6
+.2byte   -2,   -7, 	  -8,   -1, 	  11,    2, 	  -1,  -10
+.2byte    3,  -14, 	  10,   -4, 	  -6,    3, 	  -2,  -10
+.2byte    5,  -15, 	   8,  -15, 	   5,   -1, 	  -2,   -9
+.2byte    0,  -11, 	   1,  -15, 	  13,   -4, 	  -1,   -8
+.2byte    2,  -17, 	   9,  -15, 	 -13,  -17, 	   0,  -12
+.2byte   -1,  -11, 	  -2,  -15, 	 -14,   -4, 	   0,   -8
+.2byte   -6,  -15, 	  -9,  -15, 	  -6,   -1, 	   1,   -9
+.2byte   -4,  -14, 	 -11,   -4, 	   5,    3, 	   1,  -10
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -3, 	   9,    0, 	  -1,   -7
+.2byte    0,   -5, 	  -8,    0, 	   9,   -6, 	   0,   -8
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    3,   -4, 	  -3,   -2, 	  12,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  -2,    3, 	  11,  -10, 	  -1,   -8
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -4, 	   4,   -2, 	   8,  -11, 	  -1,   -6
+.2byte    1,   -6, 	   4,    1, 	   7,  -16, 	  -3,   -7
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -7, 	   7,   -7, 	   1,  -12, 	  -1,   -4
+.2byte    2,   -8, 	   7,   -5, 	   0,  -16, 	  -1,   -7
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,  -13, 	  -8,  -11, 	   0,   -4
+.2byte    0,  -11, 	   7,   -9, 	  -7,  -16, 	   1,   -7
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte   -2,   -7, 	   0,  -15, 	 -10,   -6, 	   1,   -5
+.2byte   -1,   -8, 	   1,  -12, 	  -9,  -11, 	   0,   -5
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -3,   -3, 	  -6,  -14, 	  -8,    0, 	   3,   -6
+.2byte   -3,   -9, 	  -6,  -10, 	  -7,   -5, 	   2,   -5
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -2, 	 -10,   -8, 	   3,    3, 	   1,   -6
+.2byte   -2,   -6, 	 -12,   -4, 	   3,   -4, 	   1,   -7
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -3, 	   9,    0, 	  -1,   -7
+.2byte    0,   -5, 	  -8,    0, 	   9,   -6, 	   0,   -8
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    3,   -4, 	  -3,   -2, 	  12,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  -2,    3, 	  11,  -10, 	  -1,   -8
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -4, 	   4,   -2, 	   8,  -11, 	  -1,   -6
+.2byte    1,   -6, 	   4,    1, 	   7,  -16, 	  -3,   -7
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -7, 	   7,   -7, 	   1,  -12, 	  -1,   -4
+.2byte    2,   -8, 	   7,   -5, 	   0,  -16, 	  -1,   -7
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,  -13, 	  -8,  -11, 	   0,   -4
+.2byte    0,  -11, 	   7,   -9, 	  -7,  -16, 	   1,   -7
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte   -2,   -7, 	   0,  -15, 	 -10,   -6, 	   1,   -5
+.2byte   -1,   -8, 	   1,  -12, 	  -9,  -11, 	   0,   -5
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -3,   -3, 	  -6,  -14, 	  -8,    0, 	   3,   -6
+.2byte   -3,   -9, 	  -6,  -10, 	  -7,   -5, 	   2,   -5
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -2, 	 -10,   -8, 	   3,    3, 	   1,   -6
+.2byte   -2,   -6, 	 -12,   -4, 	   3,   -4, 	   1,   -7
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte   -2,   -2, 	 -10,   -4, 	   3,    1, 	   1,   -6
+.2byte   -2,   -3, 	  -6,  -10, 	  -7,    1, 	   2,   -4
+.2byte   -2,   -6, 	   0,  -11, 	 -10,   -5, 	   1,   -4
+.2byte    0,   -8, 	   6,  -10, 	  -8,  -11, 	   0,   -3
+.2byte    0,   -7, 	   6,   -2, 	   0,  -12, 	   0,   -3
+.2byte    1,   -3, 	   4,    1, 	   7,  -10, 	   0,   -4
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+.2byte    0,   -2, 	  -6,    1, 	   8,   -1, 	   0,   -6
+.2byte   -2,   -9, 	 -10,  -11, 	   3,   -6, 	   1,  -13
+.2byte   -8,  -11, 	 -12,  -18, 	 -13,   -7, 	  -4,  -12
+.2byte   -6,  -14, 	  -4,  -19, 	 -14,  -13, 	  -3,  -12
+.2byte    0,  -16, 	   6,  -18, 	  -8,  -19, 	   0,  -11
+.2byte    0,  -15, 	   6,  -10, 	   0,  -20, 	   0,  -11
+.2byte    1,   -9, 	   4,   -5, 	   7,  -16, 	   0,  -10
+.2byte    2,   -2, 	  -3,    1, 	  11,   -5, 	  -1,   -4
+sExeggcuteAnimTable1:
+.4byte sExeggcuteAnims_1_1
+.4byte sExeggcuteAnims_1_2
+.4byte sExeggcuteAnims_1_3
+.4byte sExeggcuteAnims_1_4
+.4byte sExeggcuteAnims_1_5
+.4byte sExeggcuteAnims_1_6
+.4byte sExeggcuteAnims_1_7
+.4byte sExeggcuteAnims_1_8
+sExeggcuteAnimTable2:
+.4byte sExeggcuteAnims_2_1
+.4byte sExeggcuteAnims_2_2
+.4byte sExeggcuteAnims_2_3
+.4byte sExeggcuteAnims_2_4
+.4byte sExeggcuteAnims_2_5
+.4byte sExeggcuteAnims_2_6
+.4byte sExeggcuteAnims_2_7
+.4byte sExeggcuteAnims_2_8
+sExeggcuteAnimTable3:
+.4byte sExeggcuteAnims_3_1
+.4byte sExeggcuteAnims_3_2
+.4byte sExeggcuteAnims_3_3
+.4byte sExeggcuteAnims_3_4
+.4byte sExeggcuteAnims_3_5
+.4byte sExeggcuteAnims_3_6
+.4byte sExeggcuteAnims_3_7
+.4byte sExeggcuteAnims_3_8
+sExeggcuteAnimTable4:
+.4byte sExeggcuteAnims_4_1
+.4byte sExeggcuteAnims_4_2
+.4byte sExeggcuteAnims_4_3
+.4byte sExeggcuteAnims_4_4
+.4byte sExeggcuteAnims_4_5
+.4byte sExeggcuteAnims_4_6
+.4byte sExeggcuteAnims_4_7
+.4byte sExeggcuteAnims_4_8
+sExeggcuteAnimTable5:
+.4byte sExeggcuteAnims_5_1
+.4byte sExeggcuteAnims_5_2
+.4byte sExeggcuteAnims_5_3
+.4byte sExeggcuteAnims_5_4
+.4byte sExeggcuteAnims_5_5
+.4byte sExeggcuteAnims_5_6
+.4byte sExeggcuteAnims_5_7
+.4byte sExeggcuteAnims_5_8
+sExeggcuteAnimTable6:
+.4byte sExeggcuteAnims_6_1
+.4byte sExeggcuteAnims_6_1
+.4byte sExeggcuteAnims_6_1
+.4byte sExeggcuteAnims_6_1
+.4byte sExeggcuteAnims_6_1
+.4byte sExeggcuteAnims_6_1
+.4byte sExeggcuteAnims_6_1
+.4byte sExeggcuteAnims_6_1
+sExeggcuteAnimTable7:
+.4byte sExeggcuteAnims_7_1
+.4byte sExeggcuteAnims_7_2
+.4byte sExeggcuteAnims_7_3
+.4byte sExeggcuteAnims_7_4
+.4byte sExeggcuteAnims_7_5
+.4byte sExeggcuteAnims_7_6
+.4byte sExeggcuteAnims_7_7
+.4byte sExeggcuteAnims_7_8
+sExeggcuteAnimTable8:
+.4byte sExeggcuteAnims_8_1
+.4byte sExeggcuteAnims_8_2
+.4byte sExeggcuteAnims_8_3
+.4byte sExeggcuteAnims_8_4
+.4byte sExeggcuteAnims_8_5
+.4byte sExeggcuteAnims_8_6
+.4byte sExeggcuteAnims_8_7
+.4byte sExeggcuteAnims_8_8
+sExeggcuteAnimTable9:
+.4byte sExeggcuteAnims_9_1
+.4byte sExeggcuteAnims_9_2
+.4byte sExeggcuteAnims_9_3
+.4byte sExeggcuteAnims_9_4
+.4byte sExeggcuteAnims_9_5
+.4byte sExeggcuteAnims_9_6
+.4byte sExeggcuteAnims_9_7
+.4byte sExeggcuteAnims_9_8
+sExeggcuteAnimTable10:
+.4byte sExeggcuteAnims_10_1
+.4byte sExeggcuteAnims_10_2
+.4byte sExeggcuteAnims_10_3
+.4byte sExeggcuteAnims_10_4
+.4byte sExeggcuteAnims_10_5
+.4byte sExeggcuteAnims_10_6
+.4byte sExeggcuteAnims_10_7
+.4byte sExeggcuteAnims_10_8
+sExeggcuteAnimTable11:
+.4byte sExeggcuteAnims_11_1
+.4byte sExeggcuteAnims_11_2
+.4byte sExeggcuteAnims_11_3
+.4byte sExeggcuteAnims_11_4
+.4byte sExeggcuteAnims_11_5
+.4byte sExeggcuteAnims_11_6
+.4byte sExeggcuteAnims_11_7
+.4byte sExeggcuteAnims_11_8
+sExeggcuteAnimTable12:
+.4byte sExeggcuteAnims_12_1
+.4byte sExeggcuteAnims_12_2
+.4byte sExeggcuteAnims_12_3
+.4byte sExeggcuteAnims_12_4
+.4byte sExeggcuteAnims_12_5
+.4byte sExeggcuteAnims_12_6
+.4byte sExeggcuteAnims_12_7
+.4byte sExeggcuteAnims_12_8
+sExeggcuteAnimTable13:
+.4byte sExeggcuteAnims_13_1
+.4byte sExeggcuteAnims_13_2
+.4byte sExeggcuteAnims_13_3
+.4byte sExeggcuteAnims_13_4
+.4byte sExeggcuteAnims_13_5
+.4byte sExeggcuteAnims_13_6
+.4byte sExeggcuteAnims_13_7
+.4byte sExeggcuteAnims_13_8
+sAxAnimationsExeggcute:
+.4byte sExeggcuteAnimTable1
+.4byte sExeggcuteAnimTable2
+.4byte sExeggcuteAnimTable3
+.4byte sExeggcuteAnimTable4
+.4byte sExeggcuteAnimTable5
+.4byte sExeggcuteAnimTable6
+.4byte sExeggcuteAnimTable7
+.4byte sExeggcuteAnimTable8
+.4byte sExeggcuteAnimTable9
+.4byte sExeggcuteAnimTable10
+.4byte sExeggcuteAnimTable11
+.4byte sExeggcuteAnimTable12
+.4byte sExeggcuteAnimTable13
+sAxSpritesExeggcute:
+.4byte sExeggcuteSprites1
+.4byte sExeggcuteSprites2
+.4byte sExeggcuteSprites3
+.4byte sExeggcuteSprites4
+.4byte sExeggcuteSprites5
+.4byte sExeggcuteSprites6
+.4byte sExeggcuteSprites7
+.4byte sExeggcuteSprites8
+.4byte sExeggcuteSprites9
+.4byte sExeggcuteSprites10
+.4byte sExeggcuteSprites11
+.4byte sExeggcuteSprites12
+.4byte sExeggcuteSprites13
+.4byte sExeggcuteSprites14
+.4byte sExeggcuteSprites15
+.4byte sExeggcuteSprites16
+.4byte sExeggcuteSprites17
+.4byte sExeggcuteSprites18
+.4byte sExeggcuteSprites19
+.4byte sExeggcuteSprites20
+.4byte sExeggcuteSprites21
+.4byte sExeggcuteSprites22
+.4byte sExeggcuteSprites23
+.4byte sExeggcuteSprites24
+.4byte sExeggcuteSprites25
+.4byte sExeggcuteSprites26
+.4byte sExeggcuteSprites27
+.4byte sExeggcuteSprites28
+.4byte sExeggcuteSprites29
+.4byte sExeggcuteSprites30
+.4byte sExeggcuteSprites31
+.4byte sExeggcuteSprites32
+.4byte sExeggcuteSprites33
+.4byte sExeggcuteSprites34
+.4byte sExeggcuteSprites35
+.4byte sExeggcuteSprites36
+.4byte sExeggcuteSprites37
+.4byte sExeggcuteSprites38
+.4byte sExeggcuteSprites39
+.4byte sExeggcuteSprites40
+.4byte sExeggcuteSprites41
+.4byte sExeggcuteSprites42
+.4byte sExeggcuteSprites43
+.4byte sExeggcuteSprites44
+.4byte sExeggcuteSprites45
+.4byte sExeggcuteSprites46
+.4byte sExeggcuteSprites47
+.4byte sExeggcuteSprites48
+.4byte sExeggcuteSprites49
+.4byte sExeggcuteSprites50
+.4byte sExeggcuteSprites51
+.4byte sExeggcuteSprites52
+.4byte sExeggcuteSprites53
+.4byte sExeggcuteSprites54
+.4byte sExeggcuteSprites55
+.4byte sExeggcuteSprites56
+.4byte sExeggcuteSprites57
+.4byte sExeggcuteSprites58
+.4byte sExeggcuteSprites59
+.4byte sExeggcuteSprites60
+.4byte sExeggcuteSprites61
+sAxMainExeggcute:
+ax_main sAxPosesExeggcute, sAxAnimationsExeggcute, 13, sAxSpritesExeggcute, sAxPositionsExeggcute

--- a/data/ax/exeggutor.inc
+++ b/data/ax/exeggutor.inc
@@ -1,0 +1,2890 @@
+.global gAxExeggutor
+gAxExeggutor:
+ax_siro sAxMainExeggutor
+sExeggutorPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose9:
+ax_pose 8, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose10:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose11:
+ax_pose 10, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose12:
+ax_pose 11, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose26:
+ax_pose 15, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose27:
+ax_pose 16, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose28:
+ax_pose 17, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose29:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose30:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose31:
+ax_pose 19, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose32:
+ax_pose 20, 0x01e5, 0x90f2, 0x8c00
+ax_pose_terminator
+sExeggutorPose33:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose34:
+ax_pose 21, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose35:
+ax_pose 22, 0x01e5, 0x90ea, 0x8c00
+ax_pose_terminator
+sExeggutorPose36:
+ax_pose 23, 0x01e5, 0x90f7, 0x8c00
+ax_pose_terminator
+sExeggutorPose37:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose38:
+ax_pose 24, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose39:
+ax_pose 25, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sExeggutorPose40:
+ax_pose 26, 0x01e5, 0x90f4, 0x8c00
+ax_pose_terminator
+sExeggutorPose41:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose42:
+ax_pose 27, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose43:
+ax_pose 28, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose44:
+ax_pose 29, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose45:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose46:
+ax_pose 24, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose47:
+ax_pose 25, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sExeggutorPose48:
+ax_pose 26, 0x01e5, 0x80eb, 0x8c00
+ax_pose_terminator
+sExeggutorPose49:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose50:
+ax_pose 21, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose51:
+ax_pose 22, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sExeggutorPose52:
+ax_pose 23, 0x01e5, 0x80e8, 0x8c00
+ax_pose_terminator
+sExeggutorPose53:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose54:
+ax_pose 18, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose55:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose56:
+ax_pose 20, 0x01e5, 0x80ed, 0x8c00
+ax_pose_terminator
+sExeggutorPose57:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose58:
+ax_pose 15, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose59:
+ax_pose 16, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose60:
+ax_pose 17, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose61:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose62:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose63:
+ax_pose 19, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose64:
+ax_pose 20, 0x01e5, 0x90f2, 0x8c00
+ax_pose_terminator
+sExeggutorPose65:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose66:
+ax_pose 21, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose67:
+ax_pose 22, 0x01e5, 0x90ea, 0x8c00
+ax_pose_terminator
+sExeggutorPose68:
+ax_pose 23, 0x01e5, 0x90f7, 0x8c00
+ax_pose_terminator
+sExeggutorPose69:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose70:
+ax_pose 24, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose71:
+ax_pose 25, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sExeggutorPose72:
+ax_pose 26, 0x01e5, 0x90f4, 0x8c00
+ax_pose_terminator
+sExeggutorPose73:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose74:
+ax_pose 27, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose75:
+ax_pose 28, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose76:
+ax_pose 29, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose77:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose78:
+ax_pose 24, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose79:
+ax_pose 25, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sExeggutorPose80:
+ax_pose 26, 0x01e5, 0x80eb, 0x8c00
+ax_pose_terminator
+sExeggutorPose81:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose82:
+ax_pose 21, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose83:
+ax_pose 22, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sExeggutorPose84:
+ax_pose 23, 0x01e5, 0x80e8, 0x8c00
+ax_pose_terminator
+sExeggutorPose85:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose86:
+ax_pose 18, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose87:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose88:
+ax_pose 20, 0x01e5, 0x80ed, 0x8c00
+ax_pose_terminator
+sExeggutorPose89:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose90:
+ax_pose 15, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose91:
+ax_pose 16, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose92:
+ax_pose 17, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose93:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose94:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose95:
+ax_pose 19, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose96:
+ax_pose 20, 0x01e5, 0x90f2, 0x8c00
+ax_pose_terminator
+sExeggutorPose97:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose98:
+ax_pose 21, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose99:
+ax_pose 22, 0x01e5, 0x90ea, 0x8c00
+ax_pose_terminator
+sExeggutorPose100:
+ax_pose 23, 0x01e5, 0x90f7, 0x8c00
+ax_pose_terminator
+sExeggutorPose101:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose102:
+ax_pose 24, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose103:
+ax_pose 25, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sExeggutorPose104:
+ax_pose 26, 0x01e5, 0x90f4, 0x8c00
+ax_pose_terminator
+sExeggutorPose105:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose106:
+ax_pose 27, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose107:
+ax_pose 28, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose108:
+ax_pose 29, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose109:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose110:
+ax_pose 24, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose111:
+ax_pose 25, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sExeggutorPose112:
+ax_pose 26, 0x01e5, 0x80eb, 0x8c00
+ax_pose_terminator
+sExeggutorPose113:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose114:
+ax_pose 21, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose115:
+ax_pose 22, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sExeggutorPose116:
+ax_pose 23, 0x01e5, 0x80e8, 0x8c00
+ax_pose_terminator
+sExeggutorPose117:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose118:
+ax_pose 18, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose119:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose120:
+ax_pose 20, 0x01e5, 0x80ed, 0x8c00
+ax_pose_terminator
+sExeggutorPose121:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose122:
+ax_pose 30, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose123:
+ax_pose 31, 0x01e3, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose124:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose125:
+ax_pose 32, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose126:
+ax_pose 33, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose127:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose128:
+ax_pose 34, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose129:
+ax_pose 35, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose130:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose131:
+ax_pose 36, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose132:
+ax_pose 37, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose133:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose134:
+ax_pose 38, 0x01e3, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose135:
+ax_pose 39, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose136:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose137:
+ax_pose 36, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose138:
+ax_pose 37, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose139:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose140:
+ax_pose 34, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose141:
+ax_pose 35, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose142:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose143:
+ax_pose 32, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose144:
+ax_pose 33, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose145:
+ax_pose 40, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose146:
+ax_pose 41, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose147:
+ax_pose 42, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose148:
+ax_pose 43, 0x01e3, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose149:
+ax_pose 44, 0x01e3, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose150:
+ax_pose 45, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose151:
+ax_pose 46, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose152:
+ax_pose 45, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose153:
+ax_pose 44, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose154:
+ax_pose 43, 0x01e3, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose155:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose156:
+ax_pose 30, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose157:
+ax_pose 31, 0x01e3, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose158:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose159:
+ax_pose 32, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose160:
+ax_pose 33, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose161:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose162:
+ax_pose 34, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose163:
+ax_pose 35, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose164:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose165:
+ax_pose 36, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose166:
+ax_pose 37, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose167:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose168:
+ax_pose 38, 0x01e3, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose169:
+ax_pose 39, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose170:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose171:
+ax_pose 36, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose172:
+ax_pose 37, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose173:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose174:
+ax_pose 34, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose175:
+ax_pose 35, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose176:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose177:
+ax_pose 32, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose178:
+ax_pose 33, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose179:
+ax_pose 15, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose180:
+ax_pose 18, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose181:
+ax_pose 21, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose182:
+ax_pose 24, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose183:
+ax_pose 27, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose184:
+ax_pose 24, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose185:
+ax_pose 21, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose186:
+ax_pose 18, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose187:
+ax_pose 16, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose188:
+ax_pose 19, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose189:
+ax_pose 22, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sExeggutorPose190:
+ax_pose 25, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose191:
+ax_pose 28, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose192:
+ax_pose 25, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose193:
+ax_pose 22, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sExeggutorPose194:
+ax_pose 19, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose195:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose196:
+ax_pose 16, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose197:
+ax_pose 15, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose198:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose199:
+ax_pose 19, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose200:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose201:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose202:
+ax_pose 22, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sExeggutorPose203:
+ax_pose 21, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose204:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose205:
+ax_pose 25, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose206:
+ax_pose 24, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose207:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose208:
+ax_pose 28, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose209:
+ax_pose 27, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose210:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose211:
+ax_pose 25, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose212:
+ax_pose 24, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose213:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose214:
+ax_pose 22, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sExeggutorPose215:
+ax_pose 21, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose216:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose217:
+ax_pose 19, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose218:
+ax_pose 18, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose219:
+ax_pose 17, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose220:
+ax_pose 20, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose221:
+ax_pose 23, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sExeggutorPose222:
+ax_pose 26, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sExeggutorPose223:
+ax_pose 29, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose224:
+ax_pose 26, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sExeggutorPose225:
+ax_pose 23, 0x01e5, 0x90f3, 0x8c00
+ax_pose_terminator
+sExeggutorPose226:
+ax_pose 20, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose227:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose228:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose229:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose230:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose231:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sExeggutorPose232:
+ax_pose 9, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose233:
+ax_pose 6, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sExeggutorPose234:
+ax_pose 3, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+.align 2
+sExeggutorAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sExeggutorAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 6, 0, 30, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 2, -3, 2, 2,
+ax_anim 1, 2, 29, 8, 1, 8, 7,
+ax_anim 1, 0, 29, 16, 9, 16, 15,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 1, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 28, 8, 7, 8, 7,
+ax_anim_terminator
+sExeggutorAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 6, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 3, -3, 3, 0,
+ax_anim 1, 2, 33, 8, -5, 8, 0,
+ax_anim 1, 0, 33, 12, -5, 12, 0,
+ax_anim 2, 0, 35, 17, -1, 17, -1,
+ax_anim 2, 1, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 35, 17, -1, 17, -1,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sExeggutorAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 6, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -5, 0, -1,
+ax_anim 1, 2, 37, 4, -12, 4, -5,
+ax_anim 1, 0, 37, 10, -17, 10, -11,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 1, 39, 19, -17, 19, -17,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 39, 19, -17, 19, -17,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sExeggutorAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 6, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, -3, 0, -1,
+ax_anim 1, 2, 41, 0, -9, 0, -6,
+ax_anim 1, 0, 41, 0, -14, 0, -10,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sExeggutorAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 1, 1, 1, 1,
+ax_anim 6, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -5, 0, -1,
+ax_anim 1, 2, 45, -4, -12, -4, -5,
+ax_anim 1, 0, 45, -10, -17, -10, -11,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 1, 47, -19, -17, -19, -17,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 47, -19, -17, -19, -17,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sExeggutorAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 6, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 49, -3, -3, -3, 0,
+ax_anim 1, 2, 49, -8, -5, -8, 0,
+ax_anim 1, 0, 49, -12, -5, -12, 0,
+ax_anim 2, 0, 51, -17, -1, -17, -1,
+ax_anim 2, 1, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 51, -17, -1, -17, -1,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sExeggutorAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 6, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 53, -2, -3, -2, 2,
+ax_anim 1, 2, 53, -8, 1, -8, 7,
+ax_anim 1, 0, 53, -16, 9, -16, 15,
+ax_anim 2, 0, 55, -19, 18, -19, 18,
+ax_anim 2, 1, 55, -20, 17, -20, 17,
+ax_anim 2, 0, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 55, -20, 17, -20, 17,
+ax_anim 2, 0, 52, -8, 7, -8, 7,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 6, 0, 58, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sExeggutorAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 6, 0, 62, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 2, -3, 2, 2,
+ax_anim 1, 2, 61, 8, 1, 8, 7,
+ax_anim 1, 0, 61, 16, 9, 16, 15,
+ax_anim 2, 0, 63, 19, 18, 19, 18,
+ax_anim 2, 1, 63, 20, 17, 20, 17,
+ax_anim 2, 0, 63, 19, 18, 19, 18,
+ax_anim 2, 0, 63, 20, 17, 20, 17,
+ax_anim 2, 0, 60, 8, 7, 8, 7,
+ax_anim_terminator
+sExeggutorAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 66, -1, 0, -1, 0,
+ax_anim 6, 0, 66, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 3, -3, 3, 0,
+ax_anim 1, 2, 65, 8, -5, 8, 0,
+ax_anim 1, 0, 65, 12, -5, 12, 0,
+ax_anim 2, 0, 67, 17, -1, 17, -1,
+ax_anim 2, 1, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, -1, 17, -1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sExeggutorAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim 6, 0, 70, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -5, 0, -1,
+ax_anim 1, 2, 69, 4, -12, 4, -5,
+ax_anim 1, 0, 69, 10, -17, 10, -11,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 2, 1, 71, 19, -17, 19, -17,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 2, 0, 71, 19, -17, 19, -17,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sExeggutorAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 1, 0, 1,
+ax_anim 6, 0, 74, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, -3, 0, -1,
+ax_anim 1, 2, 73, 0, -9, 0, -6,
+ax_anim 1, 0, 73, 0, -14, 0, -10,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sExeggutorAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim 6, 0, 78, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -5, 0, -1,
+ax_anim 1, 2, 77, -4, -12, -4, -5,
+ax_anim 1, 0, 77, -10, -17, -10, -11,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 1, 79, -19, -17, -19, -17,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 0, 79, -19, -17, -19, -17,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sExeggutorAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 6, 0, 82, 2, 0, 2, 0,
+ax_anim 1, 0, 81, -3, -3, -3, 0,
+ax_anim 1, 2, 81, -8, -5, -8, 0,
+ax_anim 1, 0, 81, -12, -5, -12, 0,
+ax_anim 2, 0, 83, -17, -1, -17, -1,
+ax_anim 2, 1, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, -1, -17, -1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sExeggutorAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 6, 0, 86, 2, -2, 2, -2,
+ax_anim 1, 0, 85, -2, -3, -2, 2,
+ax_anim 1, 2, 85, -8, 1, -8, 7,
+ax_anim 1, 0, 85, -16, 9, -16, 15,
+ax_anim 2, 0, 87, -19, 18, -19, 18,
+ax_anim 2, 1, 87, -20, 17, -20, 17,
+ax_anim 2, 0, 87, -19, 18, -19, 18,
+ax_anim 2, 0, 87, -20, 17, -20, 17,
+ax_anim 2, 0, 84, -8, 7, -8, 7,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 6, 2, 90, 0, -4, 0, -4,
+ax_anim 1, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 1, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sExeggutorAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 2, 0, 94, -3, -3, -3, -3,
+ax_anim 6, 2, 94, -4, -4, -4, -4,
+ax_anim 1, 0, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 1, 95, 6, 4, 6, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 95, 6, 4, 6, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 95, 6, 4, 6, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sExeggutorAnims_4_3:
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 6, 2, 98, -4, 0, -4, 0,
+ax_anim 1, 0, 97, -2, 0, -2, 0,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 1, 99, 5, 1, 5, 1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 99, 5, 1, 5, 1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 99, 5, 1, 5, 1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sExeggutorAnims_4_4:
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim 6, 2, 102, -4, 4, -4, 4,
+ax_anim 1, 0, 101, -2, 2, -2, 2,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 1, 103, 6, -4, 6, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 6, -4, 6, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 6, -4, 6, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sExeggutorAnims_4_5:
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 6, 2, 106, 0, 4, 0, 4,
+ax_anim 1, 0, 105, 0, 2, 0, 2,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 1, 107, 1, -5, 1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 107, 1, -5, 1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 107, 1, -5, 1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sExeggutorAnims_4_6:
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim 2, 0, 110, 3, 3, 3, 3,
+ax_anim 6, 2, 110, 4, 4, 4, 4,
+ax_anim 1, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 1, 111, -6, -4, -6, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 111, -6, -4, -6, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 111, -6, -4, -6, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sExeggutorAnims_4_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 114, 3, 0, 3, 0,
+ax_anim 6, 2, 114, 4, 0, 4, 0,
+ax_anim 1, 0, 113, 2, 0, 2, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 1, 115, -5, 1, -5, 1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, 1, -5, 1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, 1, -5, 1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sExeggutorAnims_4_8:
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim 2, 0, 118, 3, -3, 3, -3,
+ax_anim 6, 2, 118, 4, -4, 4, -4,
+ax_anim 1, 0, 117, 2, -2, 2, -2,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 1, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_5_1:
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 2, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_5_2:
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_5_3:
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_5_4:
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_5_5:
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_5_6:
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_5_7:
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_5_8:
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sExeggutorAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sExeggutorAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sExeggutorAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sExeggutorAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sExeggutorAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sExeggutorAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sExeggutorAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim 12, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 12, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 17, 7, 17,
+ax_anim 3, 0, 182, 0, 21, 0, 21,
+ax_anim 2, 3, 183, -7, 17, -7, 17,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 17, 5, 17, 5,
+ax_anim 2, 0, 180, 21, 12, 21, 12,
+ax_anim 3, 0, 181, 22, 20, 22, 20,
+ax_anim 2, 3, 182, 13, 21, 13, 21,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 18, -5, 18, -5,
+ax_anim 3, 0, 180, 22, -2, 22, -2,
+ax_anim 2, 3, 181, 20, 3, 20, 3,
+ax_anim 2, 0, 182, 12, 5, 12, 5,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -8, -1, -8,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 22, -21, 22, -21,
+ax_anim 2, 3, 180, 22, -14, 22, -14,
+ax_anim 2, 0, 181, 17, -6, 17, -6,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -12, -9, -12,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -8, 1, -8,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -22, -21, -22, -21,
+ax_anim 2, 3, 184, -22, -14, -22, -14,
+ax_anim 2, 0, 183, -17, -6, -17, -6,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -18, -5, -18, -5,
+ax_anim 3, 0, 184, -22, -2, -22, -2,
+ax_anim 2, 3, 183, -20, 3, -20, 3,
+ax_anim 2, 0, 182, -12, 5, -12, 5,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -17, 5, -17, 5,
+ax_anim 2, 0, 184, -21, 12, -21, 12,
+ax_anim 3, 0, 183, -22, 20, -22, 20,
+ax_anim 2, 3, 182, -13, 21, -13, 21,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExeggutorAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sExeggutorGfx1:
+.incbin "baserom.gba", 0x963A64, 0x200
+sExeggutorSprites1:
+ax_sprite sExeggutorGfx1, 0x200
+ax_sprite_terminator
+sExeggutorGfx2:
+.incbin "baserom.gba", 0x963C74, 0x200
+sExeggutorSprites2:
+ax_sprite sExeggutorGfx2, 0x200
+ax_sprite_terminator
+sExeggutorGfx3:
+.incbin "baserom.gba", 0x963E84, 0x200
+sExeggutorSprites3:
+ax_sprite sExeggutorGfx3, 0x200
+ax_sprite_terminator
+sExeggutorGfx4:
+.incbin "baserom.gba", 0x964094, 0x200
+sExeggutorSprites4:
+ax_sprite sExeggutorGfx4, 0x200
+ax_sprite_terminator
+sExeggutorGfx5:
+.incbin "baserom.gba", 0x9642A4, 0x200
+sExeggutorSprites5:
+ax_sprite sExeggutorGfx5, 0x200
+ax_sprite_terminator
+sExeggutorGfx6:
+.incbin "baserom.gba", 0x9644B4, 0x200
+sExeggutorSprites6:
+ax_sprite sExeggutorGfx6, 0x200
+ax_sprite_terminator
+sExeggutorGfx7:
+.incbin "baserom.gba", 0x9646C4, 0x200
+sExeggutorSprites7:
+ax_sprite sExeggutorGfx7, 0x200
+ax_sprite_terminator
+sExeggutorGfx8:
+.incbin "baserom.gba", 0x9648D4, 0x200
+sExeggutorSprites8:
+ax_sprite sExeggutorGfx8, 0x200
+ax_sprite_terminator
+sExeggutorGfx9:
+.incbin "baserom.gba", 0x964AE4, 0x200
+sExeggutorSprites9:
+ax_sprite sExeggutorGfx9, 0x200
+ax_sprite_terminator
+sExeggutorGfx10:
+.incbin "baserom.gba", 0x964CF4, 0x200
+sExeggutorSprites10:
+ax_sprite sExeggutorGfx10, 0x200
+ax_sprite_terminator
+sExeggutorGfx11:
+.incbin "baserom.gba", 0x964F04, 0x200
+sExeggutorSprites11:
+ax_sprite sExeggutorGfx11, 0x200
+ax_sprite_terminator
+sExeggutorGfx12:
+.incbin "baserom.gba", 0x965114, 0x200
+sExeggutorSprites12:
+ax_sprite sExeggutorGfx12, 0x200
+ax_sprite_terminator
+sExeggutorGfx13:
+.incbin "baserom.gba", 0x965324, 0x200
+sExeggutorSprites13:
+ax_sprite sExeggutorGfx13, 0x200
+ax_sprite_terminator
+sExeggutorGfx14:
+.incbin "baserom.gba", 0x965534, 0x200
+sExeggutorSprites14:
+ax_sprite sExeggutorGfx14, 0x200
+ax_sprite_terminator
+sExeggutorGfx15:
+.incbin "baserom.gba", 0x965744, 0x200
+sExeggutorSprites15:
+ax_sprite sExeggutorGfx15, 0x200
+ax_sprite_terminator
+sExeggutorGfx16:
+.incbin "baserom.gba", 0x965954, 0x100
+sExeggutorGfx16_1:
+.incbin "baserom.gba", 0x965A54, 0x60
+sExeggutorGfx16_2:
+.incbin "baserom.gba", 0x965AB4, 0x40
+sExeggutorSprites16:
+ax_sprite sExeggutorGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx17:
+.incbin "baserom.gba", 0x965B2C, 0x160
+sExeggutorGfx17_1:
+.incbin "baserom.gba", 0x965C8C, 0x40
+sExeggutorSprites17:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx17, 0x160
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx18:
+.incbin "baserom.gba", 0x965CFC, 0x1E0
+sExeggutorSprites18:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx18, 0x1e0
+ax_sprite_terminator
+sExeggutorGfx19:
+.incbin "baserom.gba", 0x965EF4, 0x60
+sExeggutorGfx19_1:
+.incbin "baserom.gba", 0x965F54, 0x80
+sExeggutorGfx19_2:
+.incbin "baserom.gba", 0x965FD4, 0x40
+sExeggutorGfx19_3:
+.incbin "baserom.gba", 0x966014, 0x40
+sExeggutorSprites19:
+ax_sprite sExeggutorGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx19_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx20:
+.incbin "baserom.gba", 0x96609C, 0x60
+sExeggutorGfx20_1:
+.incbin "baserom.gba", 0x9660FC, 0x60
+sExeggutorGfx20_2:
+.incbin "baserom.gba", 0x96615C, 0x60
+sExeggutorGfx20_3:
+.incbin "baserom.gba", 0x9661BC, 0x40
+sExeggutorSprites20:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx21:
+.incbin "baserom.gba", 0x96624C, 0x40
+sExeggutorGfx21_1:
+.incbin "baserom.gba", 0x96628C, 0x60
+sExeggutorGfx21_2:
+.incbin "baserom.gba", 0x9662EC, 0x60
+sExeggutorGfx21_3:
+.incbin "baserom.gba", 0x96634C, 0x60
+sExeggutorSprites21:
+ax_sprite sExeggutorGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx22:
+.incbin "baserom.gba", 0x9663F4, 0x60
+sExeggutorGfx22_1:
+.incbin "baserom.gba", 0x966454, 0xE0
+sExeggutorGfx22_2:
+.incbin "baserom.gba", 0x966534, 0x40
+sExeggutorSprites22:
+ax_sprite sExeggutorGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx22_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx23:
+.incbin "baserom.gba", 0x9665AC, 0x60
+sExeggutorGfx23_1:
+.incbin "baserom.gba", 0x96660C, 0x120
+sExeggutorGfx23_2:
+.incbin "baserom.gba", 0x96672C, 0x20
+sExeggutorSprites23:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx23_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx23_2, 0x20
+ax_sprite_terminator
+sExeggutorGfx24:
+.incbin "baserom.gba", 0x966784, 0x40
+sExeggutorGfx24_1:
+.incbin "baserom.gba", 0x9667C4, 0x60
+sExeggutorGfx24_2:
+.incbin "baserom.gba", 0x966824, 0x100
+sExeggutorSprites24:
+ax_sprite sExeggutorGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx24_2, 0x100
+ax_sprite_terminator
+sExeggutorGfx25:
+.incbin "baserom.gba", 0x966954, 0x60
+sExeggutorGfx25_1:
+.incbin "baserom.gba", 0x9669B4, 0x60
+sExeggutorGfx25_2:
+.incbin "baserom.gba", 0x966A14, 0x60
+sExeggutorGfx25_3:
+.incbin "baserom.gba", 0x966A74, 0x40
+sExeggutorSprites25:
+ax_sprite sExeggutorGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx26:
+.incbin "baserom.gba", 0x966AFC, 0x60
+sExeggutorGfx26_1:
+.incbin "baserom.gba", 0x966B5C, 0x60
+sExeggutorGfx26_2:
+.incbin "baserom.gba", 0x966BBC, 0xE0
+sExeggutorSprites26:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx26_2, 0xe0
+ax_sprite_terminator
+sExeggutorGfx27:
+.incbin "baserom.gba", 0x966CD4, 0x60
+sExeggutorGfx27_1:
+.incbin "baserom.gba", 0x966D34, 0x60
+sExeggutorGfx27_2:
+.incbin "baserom.gba", 0x966D94, 0x80
+sExeggutorGfx27_3:
+.incbin "baserom.gba", 0x966E14, 0x60
+sExeggutorSprites27:
+ax_sprite sExeggutorGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx27_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx27_3, 0x60
+ax_sprite_terminator
+sExeggutorGfx28:
+.incbin "baserom.gba", 0x966EB4, 0x180
+sExeggutorGfx28_1:
+.incbin "baserom.gba", 0x967034, 0x40
+sExeggutorSprites28:
+ax_sprite sExeggutorGfx28, 0x180
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx29:
+.incbin "baserom.gba", 0x96709C, 0x40
+sExeggutorGfx29_1:
+.incbin "baserom.gba", 0x9670DC, 0x180
+sExeggutorSprites29:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx29_1, 0x180
+ax_sprite_terminator
+sExeggutorGfx30:
+.incbin "baserom.gba", 0x967284, 0x200
+sExeggutorSprites30:
+ax_sprite sExeggutorGfx30, 0x200
+ax_sprite_terminator
+sExeggutorGfx31:
+.incbin "baserom.gba", 0x967494, 0x60
+sExeggutorGfx31_1:
+.incbin "baserom.gba", 0x9674F4, 0x60
+sExeggutorGfx31_2:
+.incbin "baserom.gba", 0x967554, 0xC0
+sExeggutorSprites31:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx31_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx32:
+.incbin "baserom.gba", 0x967654, 0xE0
+sExeggutorGfx32_1:
+.incbin "baserom.gba", 0x967734, 0x80
+sExeggutorGfx32_2:
+.incbin "baserom.gba", 0x9677B4, 0x60
+sExeggutorSprites32:
+ax_sprite sExeggutorGfx32, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx32_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx32_2, 0x60
+ax_sprite_terminator
+sExeggutorGfx33:
+.incbin "baserom.gba", 0x967844, 0x60
+sExeggutorGfx33_1:
+.incbin "baserom.gba", 0x9678A4, 0x60
+sExeggutorGfx33_2:
+.incbin "baserom.gba", 0x967904, 0x60
+sExeggutorGfx33_3:
+.incbin "baserom.gba", 0x967964, 0x40
+sExeggutorSprites33:
+ax_sprite sExeggutorGfx33, 0x60
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx34:
+.incbin "baserom.gba", 0x9679EC, 0xE0
+sExeggutorGfx34_1:
+.incbin "baserom.gba", 0x967ACC, 0x60
+sExeggutorGfx34_2:
+.incbin "baserom.gba", 0x967B2C, 0x40
+sExeggutorSprites34:
+ax_sprite sExeggutorGfx34, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx35:
+.incbin "baserom.gba", 0x967BA4, 0x100
+sExeggutorGfx35_1:
+.incbin "baserom.gba", 0x967CA4, 0x60
+sExeggutorGfx35_2:
+.incbin "baserom.gba", 0x967D04, 0x40
+sExeggutorSprites35:
+ax_sprite sExeggutorGfx35, 0x100
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx36:
+.incbin "baserom.gba", 0x967D7C, 0xC0
+sExeggutorGfx36_1:
+.incbin "baserom.gba", 0x967E3C, 0x60
+sExeggutorGfx36_2:
+.incbin "baserom.gba", 0x967E9C, 0x40
+sExeggutorSprites36:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx36, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx36_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx37:
+.incbin "baserom.gba", 0x967F1C, 0xE0
+sExeggutorGfx37_1:
+.incbin "baserom.gba", 0x967FFC, 0x60
+sExeggutorGfx37_2:
+.incbin "baserom.gba", 0x96805C, 0x40
+sExeggutorSprites37:
+ax_sprite sExeggutorGfx37, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx37_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sExeggutorGfx37_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx38:
+.incbin "baserom.gba", 0x9680D4, 0x100
+sExeggutorGfx38_1:
+.incbin "baserom.gba", 0x9681D4, 0x60
+sExeggutorGfx38_2:
+.incbin "baserom.gba", 0x968234, 0x40
+sExeggutorSprites38:
+ax_sprite sExeggutorGfx38, 0x100
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx39:
+.incbin "baserom.gba", 0x9682AC, 0x40
+sExeggutorGfx39_1:
+.incbin "baserom.gba", 0x9682EC, 0x60
+sExeggutorGfx39_2:
+.incbin "baserom.gba", 0x96834C, 0x80
+sExeggutorGfx39_3:
+.incbin "baserom.gba", 0x9683CC, 0x60
+sExeggutorSprites39:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx39_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx39_3, 0x60
+ax_sprite_terminator
+sExeggutorGfx40:
+.incbin "baserom.gba", 0x968474, 0x60
+sExeggutorGfx40_1:
+.incbin "baserom.gba", 0x9684D4, 0x60
+sExeggutorGfx40_2:
+.incbin "baserom.gba", 0x968534, 0xC0
+sExeggutorSprites40:
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sExeggutorGfx40_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExeggutorGfx41:
+.incbin "baserom.gba", 0x968634, 0x200
+sExeggutorSprites41:
+ax_sprite sExeggutorGfx41, 0x200
+ax_sprite_terminator
+sExeggutorGfx42:
+.incbin "baserom.gba", 0x968844, 0x200
+sExeggutorSprites42:
+ax_sprite sExeggutorGfx42, 0x200
+ax_sprite_terminator
+sExeggutorGfx43:
+.incbin "baserom.gba", 0x968A54, 0x200
+sExeggutorSprites43:
+ax_sprite sExeggutorGfx43, 0x200
+ax_sprite_terminator
+sExeggutorGfx44:
+.incbin "baserom.gba", 0x968C64, 0x200
+sExeggutorSprites44:
+ax_sprite sExeggutorGfx44, 0x200
+ax_sprite_terminator
+sExeggutorGfx45:
+.incbin "baserom.gba", 0x968E74, 0x200
+sExeggutorSprites45:
+ax_sprite sExeggutorGfx45, 0x200
+ax_sprite_terminator
+sExeggutorGfx46:
+.incbin "baserom.gba", 0x969084, 0x200
+sExeggutorSprites46:
+ax_sprite sExeggutorGfx46, 0x200
+ax_sprite_terminator
+sExeggutorGfx47:
+.incbin "baserom.gba", 0x969294, 0x200
+sExeggutorSprites47:
+ax_sprite sExeggutorGfx47, 0x200
+ax_sprite_terminator
+sAxPosesExeggutor:
+.4byte sExeggutorPose1
+.4byte sExeggutorPose2
+.4byte sExeggutorPose3
+.4byte sExeggutorPose4
+.4byte sExeggutorPose5
+.4byte sExeggutorPose6
+.4byte sExeggutorPose7
+.4byte sExeggutorPose8
+.4byte sExeggutorPose9
+.4byte sExeggutorPose10
+.4byte sExeggutorPose11
+.4byte sExeggutorPose12
+.4byte sExeggutorPose13
+.4byte sExeggutorPose14
+.4byte sExeggutorPose15
+.4byte sExeggutorPose16
+.4byte sExeggutorPose17
+.4byte sExeggutorPose18
+.4byte sExeggutorPose19
+.4byte sExeggutorPose20
+.4byte sExeggutorPose21
+.4byte sExeggutorPose22
+.4byte sExeggutorPose23
+.4byte sExeggutorPose24
+.4byte sExeggutorPose25
+.4byte sExeggutorPose26
+.4byte sExeggutorPose27
+.4byte sExeggutorPose28
+.4byte sExeggutorPose29
+.4byte sExeggutorPose30
+.4byte sExeggutorPose31
+.4byte sExeggutorPose32
+.4byte sExeggutorPose33
+.4byte sExeggutorPose34
+.4byte sExeggutorPose35
+.4byte sExeggutorPose36
+.4byte sExeggutorPose37
+.4byte sExeggutorPose38
+.4byte sExeggutorPose39
+.4byte sExeggutorPose40
+.4byte sExeggutorPose41
+.4byte sExeggutorPose42
+.4byte sExeggutorPose43
+.4byte sExeggutorPose44
+.4byte sExeggutorPose45
+.4byte sExeggutorPose46
+.4byte sExeggutorPose47
+.4byte sExeggutorPose48
+.4byte sExeggutorPose49
+.4byte sExeggutorPose50
+.4byte sExeggutorPose51
+.4byte sExeggutorPose52
+.4byte sExeggutorPose53
+.4byte sExeggutorPose54
+.4byte sExeggutorPose55
+.4byte sExeggutorPose56
+.4byte sExeggutorPose57
+.4byte sExeggutorPose58
+.4byte sExeggutorPose59
+.4byte sExeggutorPose60
+.4byte sExeggutorPose61
+.4byte sExeggutorPose62
+.4byte sExeggutorPose63
+.4byte sExeggutorPose64
+.4byte sExeggutorPose65
+.4byte sExeggutorPose66
+.4byte sExeggutorPose67
+.4byte sExeggutorPose68
+.4byte sExeggutorPose69
+.4byte sExeggutorPose70
+.4byte sExeggutorPose71
+.4byte sExeggutorPose72
+.4byte sExeggutorPose73
+.4byte sExeggutorPose74
+.4byte sExeggutorPose75
+.4byte sExeggutorPose76
+.4byte sExeggutorPose77
+.4byte sExeggutorPose78
+.4byte sExeggutorPose79
+.4byte sExeggutorPose80
+.4byte sExeggutorPose81
+.4byte sExeggutorPose82
+.4byte sExeggutorPose83
+.4byte sExeggutorPose84
+.4byte sExeggutorPose85
+.4byte sExeggutorPose86
+.4byte sExeggutorPose87
+.4byte sExeggutorPose88
+.4byte sExeggutorPose89
+.4byte sExeggutorPose90
+.4byte sExeggutorPose91
+.4byte sExeggutorPose92
+.4byte sExeggutorPose93
+.4byte sExeggutorPose94
+.4byte sExeggutorPose95
+.4byte sExeggutorPose96
+.4byte sExeggutorPose97
+.4byte sExeggutorPose98
+.4byte sExeggutorPose99
+.4byte sExeggutorPose100
+.4byte sExeggutorPose101
+.4byte sExeggutorPose102
+.4byte sExeggutorPose103
+.4byte sExeggutorPose104
+.4byte sExeggutorPose105
+.4byte sExeggutorPose106
+.4byte sExeggutorPose107
+.4byte sExeggutorPose108
+.4byte sExeggutorPose109
+.4byte sExeggutorPose110
+.4byte sExeggutorPose111
+.4byte sExeggutorPose112
+.4byte sExeggutorPose113
+.4byte sExeggutorPose114
+.4byte sExeggutorPose115
+.4byte sExeggutorPose116
+.4byte sExeggutorPose117
+.4byte sExeggutorPose118
+.4byte sExeggutorPose119
+.4byte sExeggutorPose120
+.4byte sExeggutorPose121
+.4byte sExeggutorPose122
+.4byte sExeggutorPose123
+.4byte sExeggutorPose124
+.4byte sExeggutorPose125
+.4byte sExeggutorPose126
+.4byte sExeggutorPose127
+.4byte sExeggutorPose128
+.4byte sExeggutorPose129
+.4byte sExeggutorPose130
+.4byte sExeggutorPose131
+.4byte sExeggutorPose132
+.4byte sExeggutorPose133
+.4byte sExeggutorPose134
+.4byte sExeggutorPose135
+.4byte sExeggutorPose136
+.4byte sExeggutorPose137
+.4byte sExeggutorPose138
+.4byte sExeggutorPose139
+.4byte sExeggutorPose140
+.4byte sExeggutorPose141
+.4byte sExeggutorPose142
+.4byte sExeggutorPose143
+.4byte sExeggutorPose144
+.4byte sExeggutorPose145
+.4byte sExeggutorPose146
+.4byte sExeggutorPose147
+.4byte sExeggutorPose148
+.4byte sExeggutorPose149
+.4byte sExeggutorPose150
+.4byte sExeggutorPose151
+.4byte sExeggutorPose152
+.4byte sExeggutorPose153
+.4byte sExeggutorPose154
+.4byte sExeggutorPose155
+.4byte sExeggutorPose156
+.4byte sExeggutorPose157
+.4byte sExeggutorPose158
+.4byte sExeggutorPose159
+.4byte sExeggutorPose160
+.4byte sExeggutorPose161
+.4byte sExeggutorPose162
+.4byte sExeggutorPose163
+.4byte sExeggutorPose164
+.4byte sExeggutorPose165
+.4byte sExeggutorPose166
+.4byte sExeggutorPose167
+.4byte sExeggutorPose168
+.4byte sExeggutorPose169
+.4byte sExeggutorPose170
+.4byte sExeggutorPose171
+.4byte sExeggutorPose172
+.4byte sExeggutorPose173
+.4byte sExeggutorPose174
+.4byte sExeggutorPose175
+.4byte sExeggutorPose176
+.4byte sExeggutorPose177
+.4byte sExeggutorPose178
+.4byte sExeggutorPose179
+.4byte sExeggutorPose180
+.4byte sExeggutorPose181
+.4byte sExeggutorPose182
+.4byte sExeggutorPose183
+.4byte sExeggutorPose184
+.4byte sExeggutorPose185
+.4byte sExeggutorPose186
+.4byte sExeggutorPose187
+.4byte sExeggutorPose188
+.4byte sExeggutorPose189
+.4byte sExeggutorPose190
+.4byte sExeggutorPose191
+.4byte sExeggutorPose192
+.4byte sExeggutorPose193
+.4byte sExeggutorPose194
+.4byte sExeggutorPose195
+.4byte sExeggutorPose196
+.4byte sExeggutorPose197
+.4byte sExeggutorPose198
+.4byte sExeggutorPose199
+.4byte sExeggutorPose200
+.4byte sExeggutorPose201
+.4byte sExeggutorPose202
+.4byte sExeggutorPose203
+.4byte sExeggutorPose204
+.4byte sExeggutorPose205
+.4byte sExeggutorPose206
+.4byte sExeggutorPose207
+.4byte sExeggutorPose208
+.4byte sExeggutorPose209
+.4byte sExeggutorPose210
+.4byte sExeggutorPose211
+.4byte sExeggutorPose212
+.4byte sExeggutorPose213
+.4byte sExeggutorPose214
+.4byte sExeggutorPose215
+.4byte sExeggutorPose216
+.4byte sExeggutorPose217
+.4byte sExeggutorPose218
+.4byte sExeggutorPose219
+.4byte sExeggutorPose220
+.4byte sExeggutorPose221
+.4byte sExeggutorPose222
+.4byte sExeggutorPose223
+.4byte sExeggutorPose224
+.4byte sExeggutorPose225
+.4byte sExeggutorPose226
+.4byte sExeggutorPose227
+.4byte sExeggutorPose228
+.4byte sExeggutorPose229
+.4byte sExeggutorPose230
+.4byte sExeggutorPose231
+.4byte sExeggutorPose232
+.4byte sExeggutorPose233
+.4byte sExeggutorPose234
+sAxPositionsExeggutor:
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte    1,  -12, 	  -5,  -15, 	   8,  -13, 	  -1,  -10
+.2byte   -3,  -12, 	 -10,  -13, 	   3,  -15, 	  -1,  -10
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	   0,  -18, 	  -8,  -10, 	  -3,  -10
+.2byte    6,  -11, 	   6,  -18, 	  -2,  -15, 	   0,  -11
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    6,  -12, 	   3,  -19, 	   1,   -8, 	  -2,  -10
+.2byte    3,  -14, 	   1,  -23, 	  -1,  -12, 	  -2,  -11
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte    3,  -17, 	  -2,  -21, 	   6,  -11, 	  -1,  -10
+.2byte   -2,  -19, 	  -8,  -21, 	   2,  -13, 	  -3,  -10
+.2byte   -1,  -21, 	   5,  -17, 	  -8,  -14, 	  -1,  -11
+.2byte   -3,  -20, 	   3,  -17, 	  -9,  -13, 	   0,  -10
+.2byte    2,  -19, 	   8,  -14, 	  -5,  -14, 	   0,   -9
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte   -5,  -17, 	   0,  -21, 	  -8,  -11, 	  -1,  -10
+.2byte    0,  -19, 	   6,  -21, 	  -4,  -13, 	   1,  -10
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -8,  -12, 	  -5,  -19, 	  -3,   -8, 	   0,  -10
+.2byte   -5,  -14, 	  -3,  -23, 	  -1,  -12, 	   0,  -11
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	  -2,  -18, 	   6,  -10, 	   1,  -10
+.2byte   -8,  -11, 	  -8,  -18, 	   0,  -15, 	  -2,  -11
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,   -9, 	   6,   -9, 	  -1,   -8
+.2byte   -1,  -17, 	  -9,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -3, 	  -6,   -7, 	   4,   -6, 	  -1,   -9
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+.2byte    5,   -8, 	   4,  -15, 	  -3,   -8, 	  -2,   -8
+.2byte   -2,  -16, 	  -5,  -19, 	  -9,  -12, 	  -3,  -10
+.2byte    8,   -5, 	  11,  -10, 	   3,   -4, 	   4,   -8
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    7,   -6, 	   3,  -14, 	   0,  -10, 	  -1,   -8
+.2byte   -1,  -17, 	  -8,  -15, 	  -6,  -11, 	  -5,   -9
+.2byte   10,   -5, 	   8,  -11, 	   3,   -9, 	   4,   -8
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte    4,  -14, 	   0,  -14, 	   5,   -9, 	  -2,   -8
+.2byte   -7,  -18, 	 -11,  -17, 	  -4,  -14, 	  -6,   -9
+.2byte    6,  -12, 	   4,  -15, 	   8,   -9, 	   1,   -9
+.2byte   -1,  -20, 	   5,  -16, 	  -8,  -13, 	  -1,  -10
+.2byte   -1,  -14, 	   7,  -13, 	  -8,  -13, 	  -1,   -9
+.2byte   -1,  -16, 	   5,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,  -13, 	   5,  -14, 	  -9,  -14, 	  -1,  -11
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte   -6,  -14, 	  -2,  -14, 	  -7,   -9, 	   0,   -8
+.2byte    5,  -18, 	   9,  -17, 	   2,  -14, 	   4,   -9
+.2byte   -8,  -12, 	  -6,  -15, 	 -10,   -9, 	  -3,   -9
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -8,   -6, 	  -4,  -14, 	  -1,  -10, 	   0,   -8
+.2byte   -1,  -17, 	   6,  -15, 	   4,  -11, 	   3,   -9
+.2byte  -12,   -5, 	 -10,  -11, 	  -5,   -9, 	  -6,   -8
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -7,   -8, 	  -6,  -15, 	   1,   -8, 	   0,   -8
+.2byte    0,  -16, 	   3,  -19, 	   7,  -12, 	   1,  -10
+.2byte  -10,   -5, 	 -13,  -10, 	  -5,   -4, 	  -6,   -8
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,   -9, 	   6,   -9, 	  -1,   -8
+.2byte   -1,  -17, 	  -9,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -3, 	  -6,   -7, 	   4,   -6, 	  -1,   -9
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+.2byte    5,   -8, 	   4,  -15, 	  -3,   -8, 	  -2,   -8
+.2byte   -2,  -16, 	  -5,  -19, 	  -9,  -12, 	  -3,  -10
+.2byte    8,   -5, 	  11,  -10, 	   3,   -4, 	   4,   -8
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    7,   -6, 	   3,  -14, 	   0,  -10, 	  -1,   -8
+.2byte   -1,  -17, 	  -8,  -15, 	  -6,  -11, 	  -5,   -9
+.2byte   10,   -5, 	   8,  -11, 	   3,   -9, 	   4,   -8
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte    4,  -14, 	   0,  -14, 	   5,   -9, 	  -2,   -8
+.2byte   -7,  -18, 	 -11,  -17, 	  -4,  -14, 	  -6,   -9
+.2byte    6,  -12, 	   4,  -15, 	   8,   -9, 	   1,   -9
+.2byte   -1,  -20, 	   5,  -16, 	  -8,  -13, 	  -1,  -10
+.2byte   -1,  -14, 	   7,  -13, 	  -8,  -13, 	  -1,   -9
+.2byte   -1,  -16, 	   5,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,  -13, 	   5,  -14, 	  -9,  -14, 	  -1,  -11
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte   -6,  -14, 	  -2,  -14, 	  -7,   -9, 	   0,   -8
+.2byte    5,  -18, 	   9,  -17, 	   2,  -14, 	   4,   -9
+.2byte   -8,  -12, 	  -6,  -15, 	 -10,   -9, 	  -3,   -9
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -8,   -6, 	  -4,  -14, 	  -1,  -10, 	   0,   -8
+.2byte   -1,  -17, 	   6,  -15, 	   4,  -11, 	   3,   -9
+.2byte  -12,   -5, 	 -10,  -11, 	  -5,   -9, 	  -6,   -8
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -7,   -8, 	  -6,  -15, 	   1,   -8, 	   0,   -8
+.2byte    0,  -16, 	   3,  -19, 	   7,  -12, 	   1,  -10
+.2byte  -10,   -5, 	 -13,  -10, 	  -5,   -4, 	  -6,   -8
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,   -9, 	   6,   -9, 	  -1,   -8
+.2byte   -1,  -17, 	  -9,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -3, 	  -6,   -7, 	   4,   -6, 	  -1,   -9
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+.2byte    5,   -8, 	   4,  -15, 	  -3,   -8, 	  -2,   -8
+.2byte   -2,  -16, 	  -5,  -19, 	  -9,  -12, 	  -3,  -10
+.2byte    8,   -5, 	  11,  -10, 	   3,   -4, 	   4,   -8
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    7,   -6, 	   3,  -14, 	   0,  -10, 	  -1,   -8
+.2byte   -1,  -17, 	  -8,  -15, 	  -6,  -11, 	  -5,   -9
+.2byte   10,   -5, 	   8,  -11, 	   3,   -9, 	   4,   -8
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte    4,  -14, 	   0,  -14, 	   5,   -9, 	  -2,   -8
+.2byte   -7,  -18, 	 -11,  -17, 	  -4,  -14, 	  -6,   -9
+.2byte    6,  -12, 	   4,  -15, 	   8,   -9, 	   1,   -9
+.2byte   -1,  -20, 	   5,  -16, 	  -8,  -13, 	  -1,  -10
+.2byte   -1,  -14, 	   7,  -13, 	  -8,  -13, 	  -1,   -9
+.2byte   -1,  -16, 	   5,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,  -13, 	   5,  -14, 	  -9,  -14, 	  -1,  -11
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte   -6,  -14, 	  -2,  -14, 	  -7,   -9, 	   0,   -8
+.2byte    5,  -18, 	   9,  -17, 	   2,  -14, 	   4,   -9
+.2byte   -8,  -12, 	  -6,  -15, 	 -10,   -9, 	  -3,   -9
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -8,   -6, 	  -4,  -14, 	  -1,  -10, 	   0,   -8
+.2byte   -1,  -17, 	   6,  -15, 	   4,  -11, 	   3,   -9
+.2byte  -12,   -5, 	 -10,  -11, 	  -5,   -9, 	  -6,   -8
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -7,   -8, 	  -6,  -15, 	   1,   -8, 	   0,   -8
+.2byte    0,  -16, 	   3,  -19, 	   7,  -12, 	   1,  -10
+.2byte  -10,   -5, 	 -13,  -10, 	  -5,   -4, 	  -6,   -8
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte    3,  -12, 	  -3,  -19, 	   9,  -12, 	   1,  -10
+.2byte   -5,  -12, 	 -11,  -12, 	   2,  -19, 	  -3,   -9
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+.2byte    0,  -12, 	   1,  -18, 	  -8,   -9, 	  -4,   -9
+.2byte    5,  -13, 	   8,  -14, 	  -4,  -16, 	   0,  -12
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    6,  -15, 	   1,  -18, 	   2,  -10, 	  -2,  -11
+.2byte    4,  -12, 	   5,  -16, 	  -3,  -15, 	   0,  -12
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte    4,  -18, 	   0,  -21, 	   7,  -11, 	   1,   -9
+.2byte   -2,  -21, 	  -7,  -20, 	   2,  -16, 	  -4,  -10
+.2byte   -1,  -20, 	   5,  -16, 	  -8,  -13, 	  -1,  -10
+.2byte   -8,  -18, 	  -2,  -22, 	 -10,  -11, 	  -3,  -11
+.2byte    6,  -19, 	   9,  -15, 	  -5,  -19, 	   2,  -11
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte   -6,  -18, 	  -2,  -21, 	  -9,  -11, 	  -3,   -9
+.2byte    0,  -21, 	   5,  -20, 	  -4,  -16, 	   2,  -10
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -8,  -15, 	  -3,  -18, 	  -4,  -10, 	   0,  -11
+.2byte   -6,  -12, 	  -7,  -16, 	   1,  -15, 	  -2,  -12
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -2,  -12, 	  -3,  -18, 	   6,   -9, 	   2,   -9
+.2byte   -7,  -13, 	 -10,  -14, 	   2,  -16, 	  -2,  -12
+.2byte   -1,   -7, 	  -8,  -11, 	   6,  -11, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,  -10, 	   6,  -10, 	  -1,   -4
+.2byte    0,    0, 	  -6,   -2, 	   7,   -3, 	   0,  -11
+.2byte    5,    0, 	   8,   -9, 	  -2,   -4, 	   0,  -10
+.2byte   11,   -3, 	   8,  -10, 	   5,   -1, 	   0,   -8
+.2byte    7,  -11, 	   3,  -14, 	  10,   -5, 	   0,   -8
+.2byte   -1,  -12, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte   -8,  -11, 	  -4,  -14, 	 -11,   -5, 	  -1,   -8
+.2byte  -12,   -3, 	  -9,  -10, 	  -6,   -1, 	  -1,   -8
+.2byte   -6,    0, 	  -9,   -9, 	   1,   -4, 	  -1,  -10
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte    3,  -12, 	  -3,  -19, 	   9,  -12, 	   1,  -10
+.2byte   -5,  -12, 	 -11,  -12, 	   2,  -19, 	  -3,   -9
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+.2byte    0,  -12, 	   1,  -18, 	  -8,   -9, 	  -4,   -9
+.2byte    5,  -13, 	   8,  -14, 	  -4,  -16, 	   0,  -12
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    6,  -15, 	   1,  -18, 	   2,  -10, 	  -2,  -11
+.2byte    4,  -12, 	   5,  -16, 	  -3,  -15, 	   0,  -12
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte    4,  -18, 	   0,  -21, 	   7,  -11, 	   1,   -9
+.2byte   -2,  -21, 	  -7,  -20, 	   2,  -16, 	  -4,  -10
+.2byte   -1,  -20, 	   5,  -16, 	  -8,  -13, 	  -1,  -10
+.2byte   -8,  -18, 	  -2,  -22, 	 -10,  -11, 	  -3,  -11
+.2byte    6,  -19, 	   9,  -15, 	  -5,  -19, 	   2,  -11
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte   -6,  -18, 	  -2,  -21, 	  -9,  -11, 	  -3,   -9
+.2byte    0,  -21, 	   5,  -20, 	  -4,  -16, 	   2,  -10
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -8,  -15, 	  -3,  -18, 	  -4,  -10, 	   0,  -11
+.2byte   -6,  -12, 	  -7,  -16, 	   1,  -15, 	  -2,  -12
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -2,  -12, 	  -3,  -18, 	   6,   -9, 	   2,   -9
+.2byte   -7,  -13, 	 -10,  -14, 	   2,  -16, 	  -2,  -12
+.2byte   -1,   -5, 	  -8,   -9, 	   6,   -9, 	  -1,   -8
+.2byte   -7,   -8, 	  -6,  -15, 	   1,   -8, 	   0,   -8
+.2byte   -9,   -6, 	  -5,  -14, 	  -2,  -10, 	  -1,   -8
+.2byte   -6,  -14, 	  -2,  -14, 	  -7,   -9, 	   0,   -8
+.2byte   -1,  -14, 	   7,  -13, 	  -8,  -13, 	  -1,   -9
+.2byte    5,  -14, 	   1,  -14, 	   6,   -9, 	  -1,   -8
+.2byte    8,   -6, 	   4,  -14, 	   1,  -10, 	   0,   -8
+.2byte    6,   -8, 	   5,  -15, 	  -2,   -8, 	  -1,   -8
+.2byte   -1,  -17, 	  -9,  -13, 	   7,  -13, 	  -1,  -10
+.2byte    0,  -16, 	  -3,  -19, 	  -7,  -12, 	  -1,  -10
+.2byte    2,  -17, 	  -5,  -15, 	  -3,  -11, 	  -2,   -9
+.2byte   -5,  -18, 	  -9,  -17, 	  -2,  -14, 	  -4,   -9
+.2byte   -1,  -16, 	   5,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte    3,  -18, 	   7,  -17, 	   0,  -14, 	   2,   -9
+.2byte   -3,  -17, 	   4,  -15, 	   2,  -11, 	   1,   -9
+.2byte   -1,  -16, 	   2,  -19, 	   6,  -12, 	   0,  -10
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -1,  -17, 	  -9,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -5, 	  -8,   -9, 	   6,   -9, 	  -1,   -8
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+.2byte    0,  -16, 	  -3,  -19, 	  -7,  -12, 	  -1,  -10
+.2byte    5,   -8, 	   4,  -15, 	  -3,   -8, 	  -2,   -8
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    1,  -17, 	  -6,  -15, 	  -4,  -11, 	  -3,   -9
+.2byte    7,   -6, 	   3,  -14, 	   0,  -10, 	  -1,   -8
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte   -5,  -18, 	  -9,  -17, 	  -2,  -14, 	  -4,   -9
+.2byte    4,  -14, 	   0,  -14, 	   5,   -9, 	  -2,   -8
+.2byte   -1,  -20, 	   5,  -16, 	  -8,  -13, 	  -1,  -10
+.2byte   -1,  -16, 	   5,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,  -14, 	   7,  -13, 	  -8,  -13, 	  -1,   -9
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte    3,  -18, 	   7,  -17, 	   0,  -14, 	   2,   -9
+.2byte   -6,  -14, 	  -2,  -14, 	  -7,   -9, 	   0,   -8
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -3,  -17, 	   4,  -15, 	   2,  -11, 	   1,   -9
+.2byte   -8,   -6, 	  -4,  -14, 	  -1,  -10, 	   0,   -8
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -2,  -16, 	   1,  -19, 	   5,  -12, 	  -1,  -10
+.2byte   -7,   -8, 	  -6,  -15, 	   1,   -8, 	   0,   -8
+.2byte   -1,   -3, 	  -6,   -7, 	   4,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -9,  -11, 	  -1,   -5, 	  -2,   -9
+.2byte   -8,   -5, 	  -6,  -11, 	  -1,   -9, 	  -2,   -8
+.2byte   -5,  -11, 	  -3,  -14, 	  -7,   -8, 	   0,   -8
+.2byte   -1,  -12, 	   5,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte    3,  -11, 	   1,  -14, 	   5,   -8, 	  -2,   -8
+.2byte    6,   -5, 	   4,  -11, 	  -1,   -9, 	   0,   -8
+.2byte    5,   -6, 	   8,  -11, 	   0,   -5, 	   1,   -9
+.2byte   -1,  -10, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -5,  -10, 	  -6,  -17, 	   3,  -11, 	  -1,   -8
+.2byte   -7,  -12, 	  -4,  -19, 	  -3,  -10, 	   0,   -9
+.2byte   -4,  -17, 	   3,  -21, 	  -7,  -12, 	   0,   -9
+.2byte   -1,  -20, 	   5,  -16, 	  -8,  -13, 	  -1,  -10
+.2byte    2,  -17, 	  -5,  -21, 	   5,  -12, 	  -2,   -9
+.2byte    5,  -12, 	   2,  -19, 	   1,  -10, 	  -2,   -9
+.2byte    3,  -10, 	   4,  -17, 	  -5,  -11, 	  -1,   -8
+sExeggutorAnimTable1:
+.4byte sExeggutorAnims_1_1
+.4byte sExeggutorAnims_1_2
+.4byte sExeggutorAnims_1_3
+.4byte sExeggutorAnims_1_4
+.4byte sExeggutorAnims_1_5
+.4byte sExeggutorAnims_1_6
+.4byte sExeggutorAnims_1_7
+.4byte sExeggutorAnims_1_8
+sExeggutorAnimTable2:
+.4byte sExeggutorAnims_2_1
+.4byte sExeggutorAnims_2_2
+.4byte sExeggutorAnims_2_3
+.4byte sExeggutorAnims_2_4
+.4byte sExeggutorAnims_2_5
+.4byte sExeggutorAnims_2_6
+.4byte sExeggutorAnims_2_7
+.4byte sExeggutorAnims_2_8
+sExeggutorAnimTable3:
+.4byte sExeggutorAnims_3_1
+.4byte sExeggutorAnims_3_2
+.4byte sExeggutorAnims_3_3
+.4byte sExeggutorAnims_3_4
+.4byte sExeggutorAnims_3_5
+.4byte sExeggutorAnims_3_6
+.4byte sExeggutorAnims_3_7
+.4byte sExeggutorAnims_3_8
+sExeggutorAnimTable4:
+.4byte sExeggutorAnims_4_1
+.4byte sExeggutorAnims_4_2
+.4byte sExeggutorAnims_4_3
+.4byte sExeggutorAnims_4_4
+.4byte sExeggutorAnims_4_5
+.4byte sExeggutorAnims_4_6
+.4byte sExeggutorAnims_4_7
+.4byte sExeggutorAnims_4_8
+sExeggutorAnimTable5:
+.4byte sExeggutorAnims_5_1
+.4byte sExeggutorAnims_5_2
+.4byte sExeggutorAnims_5_3
+.4byte sExeggutorAnims_5_4
+.4byte sExeggutorAnims_5_5
+.4byte sExeggutorAnims_5_6
+.4byte sExeggutorAnims_5_7
+.4byte sExeggutorAnims_5_8
+sExeggutorAnimTable6:
+.4byte sExeggutorAnims_6_1
+.4byte sExeggutorAnims_6_1
+.4byte sExeggutorAnims_6_1
+.4byte sExeggutorAnims_6_1
+.4byte sExeggutorAnims_6_1
+.4byte sExeggutorAnims_6_1
+.4byte sExeggutorAnims_6_1
+.4byte sExeggutorAnims_6_1
+sExeggutorAnimTable7:
+.4byte sExeggutorAnims_7_1
+.4byte sExeggutorAnims_7_2
+.4byte sExeggutorAnims_7_3
+.4byte sExeggutorAnims_7_4
+.4byte sExeggutorAnims_7_5
+.4byte sExeggutorAnims_7_6
+.4byte sExeggutorAnims_7_7
+.4byte sExeggutorAnims_7_8
+sExeggutorAnimTable8:
+.4byte sExeggutorAnims_8_1
+.4byte sExeggutorAnims_8_2
+.4byte sExeggutorAnims_8_3
+.4byte sExeggutorAnims_8_4
+.4byte sExeggutorAnims_8_5
+.4byte sExeggutorAnims_8_6
+.4byte sExeggutorAnims_8_7
+.4byte sExeggutorAnims_8_8
+sExeggutorAnimTable9:
+.4byte sExeggutorAnims_9_1
+.4byte sExeggutorAnims_9_2
+.4byte sExeggutorAnims_9_3
+.4byte sExeggutorAnims_9_4
+.4byte sExeggutorAnims_9_5
+.4byte sExeggutorAnims_9_6
+.4byte sExeggutorAnims_9_7
+.4byte sExeggutorAnims_9_8
+sExeggutorAnimTable10:
+.4byte sExeggutorAnims_10_1
+.4byte sExeggutorAnims_10_2
+.4byte sExeggutorAnims_10_3
+.4byte sExeggutorAnims_10_4
+.4byte sExeggutorAnims_10_5
+.4byte sExeggutorAnims_10_6
+.4byte sExeggutorAnims_10_7
+.4byte sExeggutorAnims_10_8
+sExeggutorAnimTable11:
+.4byte sExeggutorAnims_11_1
+.4byte sExeggutorAnims_11_2
+.4byte sExeggutorAnims_11_3
+.4byte sExeggutorAnims_11_4
+.4byte sExeggutorAnims_11_5
+.4byte sExeggutorAnims_11_6
+.4byte sExeggutorAnims_11_7
+.4byte sExeggutorAnims_11_8
+sExeggutorAnimTable12:
+.4byte sExeggutorAnims_12_1
+.4byte sExeggutorAnims_12_2
+.4byte sExeggutorAnims_12_3
+.4byte sExeggutorAnims_12_4
+.4byte sExeggutorAnims_12_5
+.4byte sExeggutorAnims_12_6
+.4byte sExeggutorAnims_12_7
+.4byte sExeggutorAnims_12_8
+sExeggutorAnimTable13:
+.4byte sExeggutorAnims_13_1
+.4byte sExeggutorAnims_13_2
+.4byte sExeggutorAnims_13_3
+.4byte sExeggutorAnims_13_4
+.4byte sExeggutorAnims_13_5
+.4byte sExeggutorAnims_13_6
+.4byte sExeggutorAnims_13_7
+.4byte sExeggutorAnims_13_8
+sAxAnimationsExeggutor:
+.4byte sExeggutorAnimTable1
+.4byte sExeggutorAnimTable2
+.4byte sExeggutorAnimTable3
+.4byte sExeggutorAnimTable4
+.4byte sExeggutorAnimTable5
+.4byte sExeggutorAnimTable6
+.4byte sExeggutorAnimTable7
+.4byte sExeggutorAnimTable8
+.4byte sExeggutorAnimTable9
+.4byte sExeggutorAnimTable10
+.4byte sExeggutorAnimTable11
+.4byte sExeggutorAnimTable12
+.4byte sExeggutorAnimTable13
+sAxSpritesExeggutor:
+.4byte sExeggutorSprites1
+.4byte sExeggutorSprites2
+.4byte sExeggutorSprites3
+.4byte sExeggutorSprites4
+.4byte sExeggutorSprites5
+.4byte sExeggutorSprites6
+.4byte sExeggutorSprites7
+.4byte sExeggutorSprites8
+.4byte sExeggutorSprites9
+.4byte sExeggutorSprites10
+.4byte sExeggutorSprites11
+.4byte sExeggutorSprites12
+.4byte sExeggutorSprites13
+.4byte sExeggutorSprites14
+.4byte sExeggutorSprites15
+.4byte sExeggutorSprites16
+.4byte sExeggutorSprites17
+.4byte sExeggutorSprites18
+.4byte sExeggutorSprites19
+.4byte sExeggutorSprites20
+.4byte sExeggutorSprites21
+.4byte sExeggutorSprites22
+.4byte sExeggutorSprites23
+.4byte sExeggutorSprites24
+.4byte sExeggutorSprites25
+.4byte sExeggutorSprites26
+.4byte sExeggutorSprites27
+.4byte sExeggutorSprites28
+.4byte sExeggutorSprites29
+.4byte sExeggutorSprites30
+.4byte sExeggutorSprites31
+.4byte sExeggutorSprites32
+.4byte sExeggutorSprites33
+.4byte sExeggutorSprites34
+.4byte sExeggutorSprites35
+.4byte sExeggutorSprites36
+.4byte sExeggutorSprites37
+.4byte sExeggutorSprites38
+.4byte sExeggutorSprites39
+.4byte sExeggutorSprites40
+.4byte sExeggutorSprites41
+.4byte sExeggutorSprites42
+.4byte sExeggutorSprites43
+.4byte sExeggutorSprites44
+.4byte sExeggutorSprites45
+.4byte sExeggutorSprites46
+.4byte sExeggutorSprites47
+sAxMainExeggutor:
+ax_main sAxPosesExeggutor, sAxAnimationsExeggutor, 13, sAxSpritesExeggutor, sAxPositionsExeggutor

--- a/data/ax/exploud.inc
+++ b/data/ax/exploud.inc
@@ -1,0 +1,2527 @@
+.global gAxExploud
+gAxExploud:
+ax_siro sAxMainExploud
+sExploudPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose4:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose5:
+ax_pose 4, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose6:
+ax_pose 5, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose8:
+ax_pose 7, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose9:
+ax_pose 8, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose10:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose12:
+ax_pose 11, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose13:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose22:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose23:
+ax_pose 4, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose24:
+ax_pose 5, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose28:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose29:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose30:
+ax_pose 4, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose31:
+ax_pose 5, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose32:
+ax_pose 16, 0x41eb, 0x90ed, 0x3c00
+ax_pose 17, 0x41fb, 0x50ed, 0x3c08
+ax_pose 18, 0x01e3, 0x10fd, 0x3c0c
+ax_pose_terminator
+sExploudPose33:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose34:
+ax_pose 7, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose35:
+ax_pose 8, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose36:
+ax_pose 19, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose37:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose38:
+ax_pose 10, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose39:
+ax_pose 11, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose40:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose41:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose42:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose43:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose44:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose45:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose46:
+ax_pose 10, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose47:
+ax_pose 11, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose48:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose49:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose50:
+ax_pose 7, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose51:
+ax_pose 8, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose52:
+ax_pose 19, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose53:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose54:
+ax_pose 4, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose55:
+ax_pose 5, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose56:
+ax_pose 16, 0x41eb, 0x80f2, 0x3c00
+ax_pose 17, 0x41fb, 0x40f2, 0x3c08
+ax_pose 18, 0x01e3, 0x00fa, 0x3c0c
+ax_pose_terminator
+sExploudPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose58:
+ax_pose 1, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose59:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose60:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose61:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose62:
+ax_pose 4, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose63:
+ax_pose 5, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose64:
+ax_pose 16, 0x41eb, 0x90ed, 0x3c00
+ax_pose 17, 0x41fb, 0x50ed, 0x3c08
+ax_pose 18, 0x01e3, 0x10fd, 0x3c0c
+ax_pose_terminator
+sExploudPose65:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose66:
+ax_pose 7, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose67:
+ax_pose 8, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose68:
+ax_pose 19, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose69:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose70:
+ax_pose 10, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose71:
+ax_pose 11, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose72:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose73:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose74:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose75:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose76:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose77:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose78:
+ax_pose 10, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose79:
+ax_pose 11, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose80:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose81:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose82:
+ax_pose 7, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose83:
+ax_pose 8, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose84:
+ax_pose 19, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose85:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose86:
+ax_pose 4, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose87:
+ax_pose 5, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose88:
+ax_pose 16, 0x41eb, 0x80f2, 0x3c00
+ax_pose 17, 0x41fb, 0x40f2, 0x3c08
+ax_pose 18, 0x01e3, 0x00fa, 0x3c0c
+ax_pose_terminator
+sExploudPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose90:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose91:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose92:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose93:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose94:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose95:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose96:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose97:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose98:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose99:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose100:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose101:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose102:
+ax_pose 19, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose103:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose104:
+ax_pose 16, 0x41eb, 0x80f1, 0x3c00
+ax_pose 17, 0x41fb, 0x40f1, 0x3c08
+ax_pose 18, 0x01e3, 0x00f9, 0x3c0c
+ax_pose_terminator
+sExploudPose105:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose106:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose107:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose108:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose109:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose110:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose111:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose112:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose113:
+ax_pose 23, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose114:
+ax_pose 24, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose115:
+ax_pose 25, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose116:
+ax_pose 26, 0x01e6, 0x90ed, 0x3c00
+ax_pose_terminator
+sExploudPose117:
+ax_pose 27, 0x01e8, 0x90eb, 0x3c00
+ax_pose_terminator
+sExploudPose118:
+ax_pose 28, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose119:
+ax_pose 29, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose120:
+ax_pose 28, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sExploudPose121:
+ax_pose 27, 0x01e8, 0x80f5, 0x3c00
+ax_pose_terminator
+sExploudPose122:
+ax_pose 26, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose123:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose124:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose125:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose126:
+ax_pose 16, 0x41eb, 0x90ed, 0x3c00
+ax_pose 17, 0x41fb, 0x50ed, 0x3c08
+ax_pose 18, 0x01e3, 0x10fd, 0x3c0c
+ax_pose_terminator
+sExploudPose127:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose128:
+ax_pose 19, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose129:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose130:
+ax_pose 20, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sExploudPose131:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose132:
+ax_pose 21, 0x41eb, 0x80f0, 0x3c00
+ax_pose 22, 0x41fb, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose133:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose134:
+ax_pose 20, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sExploudPose135:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose136:
+ax_pose 19, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose137:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose138:
+ax_pose 16, 0x41eb, 0x80f2, 0x3c00
+ax_pose 17, 0x41fb, 0x40f2, 0x3c08
+ax_pose 18, 0x01e3, 0x00fa, 0x3c0c
+ax_pose_terminator
+sExploudPose139:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose140:
+ax_pose 16, 0x41eb, 0x80f3, 0x3c00
+ax_pose 17, 0x41fb, 0x40f3, 0x3c08
+ax_pose 18, 0x01e3, 0x00fb, 0x3c0c
+ax_pose_terminator
+sExploudPose141:
+ax_pose 19, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose142:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose143:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose144:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose145:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose146:
+ax_pose 16, 0x41eb, 0x90ed, 0x3c00
+ax_pose 17, 0x41fb, 0x50ed, 0x3c08
+ax_pose 18, 0x01e3, 0x10fd, 0x3c0c
+ax_pose_terminator
+sExploudPose147:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose148:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose149:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose150:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose151:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose152:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose153:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose154:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose155:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose156:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose157:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose158:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose159:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose160:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose161:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose162:
+ax_pose 19, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose163:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose164:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose165:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose166:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose167:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose168:
+ax_pose 16, 0x41eb, 0x80f1, 0x3c00
+ax_pose 17, 0x41fb, 0x40f1, 0x3c08
+ax_pose 18, 0x01e3, 0x00f9, 0x3c0c
+ax_pose_terminator
+sExploudPose169:
+ax_pose 19, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sExploudPose170:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose171:
+ax_pose 21, 0x41e9, 0x80f0, 0x3c00
+ax_pose 22, 0x41f9, 0x40f0, 0x3c08
+ax_pose_terminator
+sExploudPose172:
+ax_pose 20, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose173:
+ax_pose 19, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sExploudPose174:
+ax_pose 16, 0x41eb, 0x90ee, 0x3c00
+ax_pose 17, 0x41fb, 0x50ee, 0x3c08
+ax_pose 18, 0x01e3, 0x10fe, 0x3c0c
+ax_pose_terminator
+sExploudPose175:
+ax_pose 1, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose176:
+ax_pose 5, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose177:
+ax_pose 8, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose178:
+ax_pose 11, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose179:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose180:
+ax_pose 10, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose181:
+ax_pose 8, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose182:
+ax_pose 5, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose183:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose184:
+ax_pose 1, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose185:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose186:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose187:
+ax_pose 4, 0x01ec, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose188:
+ax_pose 5, 0x01ed, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose189:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose190:
+ax_pose 7, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sExploudPose191:
+ax_pose 8, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sExploudPose192:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose193:
+ax_pose 10, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose194:
+ax_pose 11, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose195:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose196:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose197:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose198:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose199:
+ax_pose 10, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose200:
+ax_pose 11, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose201:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose202:
+ax_pose 7, 0x01ec, 0x80f1, 0x3c00
+ax_pose_terminator
+sExploudPose203:
+ax_pose 8, 0x01ec, 0x80f1, 0x3c00
+ax_pose_terminator
+sExploudPose204:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose205:
+ax_pose 4, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose206:
+ax_pose 5, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose207:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose208:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose209:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose210:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose211:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose212:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose213:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose214:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose215:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose216:
+ax_pose 3, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose217:
+ax_pose 6, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose218:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose219:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sExploudPose220:
+ax_pose 9, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose221:
+ax_pose 6, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+sExploudPose222:
+ax_pose 3, 0x01eb, 0x90ef, 0x3c00
+ax_pose_terminator
+.align 2
+sExploudAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sExploudAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 17, 18, 17, 18,
+ax_anim 2, 1, 31, 18, 17, 18, 17,
+ax_anim 2, 0, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 31, 18, 17, 18, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sExploudAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sExploudAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -6, 6, -6,
+ax_anim 1, 0, 38, 13, -12, 13, -12,
+ax_anim 2, 0, 39, 20, -18, 20, -18,
+ax_anim 2, 1, 39, 21, -17, 21, -17,
+ax_anim 2, 0, 39, 20, -18, 20, -18,
+ax_anim 2, 0, 39, 21, -17, 21, -17,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sExploudAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sExploudAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -6, -6, -6,
+ax_anim 1, 0, 46, -13, -12, -13, -12,
+ax_anim 2, 0, 47, -20, -18, -20, -18,
+ax_anim 2, 1, 47, -21, -17, -21, -17,
+ax_anim 2, 0, 47, -20, -18, -20, -18,
+ax_anim 2, 0, 47, -21, -17, -21, -17,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sExploudAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sExploudAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -17, 18, -17, 18,
+ax_anim 2, 1, 55, -18, 17, -18, 17,
+ax_anim 2, 0, 55, -17, 18, -17, 18,
+ax_anim 2, 0, 55, -18, 17, -18, 17,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sExploudAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sExploudAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 17, 18, 17, 18,
+ax_anim 2, 1, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sExploudAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 1, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 0, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sExploudAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 6, -6, 6, -6,
+ax_anim 1, 0, 70, 13, -12, 13, -12,
+ax_anim 2, 0, 71, 20, -18, 20, -18,
+ax_anim 2, 1, 71, 21, -17, 21, -17,
+ax_anim 2, 0, 71, 20, -18, 20, -18,
+ax_anim 2, 0, 71, 21, -17, 21, -17,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sExploudAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sExploudAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -6, -6, -6, -6,
+ax_anim 1, 0, 78, -13, -12, -13, -12,
+ax_anim 2, 0, 79, -20, -18, -20, -18,
+ax_anim 2, 1, 79, -21, -17, -21, -17,
+ax_anim 2, 0, 79, -20, -18, -20, -18,
+ax_anim 2, 0, 79, -21, -17, -21, -17,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sExploudAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 1, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 0, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sExploudAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -17, 18, -17, 18,
+ax_anim 2, 1, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -17, 18, -17, 18,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sExploudAnims_4_1:
+ax_anim 1, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 4, 2, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 4, 1, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_4_2:
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 4, 2, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 4, 1, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_4_3:
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 2, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 1, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_4_4:
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 4, 2, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 4, 1, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_4_5:
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 4, 2, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 4, 1, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_4_6:
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 4, 2, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 4, 1, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_4_7:
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 4, 2, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 4, 1, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_4_8:
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 4, 2, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 4, 1, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_5_1:
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 3, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 8, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 3, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 1, 111, 0, -3, 0, 0,
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_5_2:
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 3, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 8, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 3, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 1, 110, 0, -3, 0, 0,
+ax_anim 8, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_5_3:
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 3, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 8, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 3, 0, 108, 0, -6, 0, 0,
+ax_anim 2, 1, 109, 0, -3, 0, 0,
+ax_anim 8, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_5_4:
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 3, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 8, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 3, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 1, 108, 0, -3, 0, 0,
+ax_anim 8, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_5_5:
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 3, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 8, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 3, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 1, 107, 0, -3, 0, 0,
+ax_anim 8, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_5_6:
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 3, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 8, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 3, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 1, 106, 0, -3, 0, 0,
+ax_anim 8, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_5_7:
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 3, 0, 108, 0, -6, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 8, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 3, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 1, 105, 0, -3, 0, 0,
+ax_anim 8, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_5_8:
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 3, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 8, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 3, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 1, 104, 0, -3, 0, 0,
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sExploudAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sExploudAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sExploudAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sExploudAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sExploudAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sExploudAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sExploudAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sExploudAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_8_2:
+ax_anim 40, 0, 124, 0, 0, 0, 0,
+ax_anim 10, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 10, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_8_3:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_8_4:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 10, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 10, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_8_5:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_8_6:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_8_7:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_8_8:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 11, 9, 11, 9,
+ax_anim 2, 0, 141, 10, 16, 10, 16,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -10, 16, -10, 16,
+ax_anim 2, 0, 144, -11, 9, -11, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 24, 11, 24, 11,
+ax_anim 3, 0, 141, 22, 21, 22, 21,
+ax_anim 2, 3, 142, 12, 23, 12, 23,
+ax_anim 2, 0, 143, 3, 16, 3, 16,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 10, -7, 10, -7,
+ax_anim 2, 0, 139, 19, -6, 19, -6,
+ax_anim 3, 0, 140, 21, 0, 21, 0,
+ax_anim 2, 3, 141, 17, 7, 17, 7,
+ax_anim 2, 0, 142, 10, 8, 10, 8,
+ax_anim 1, 0, 143, 4, 4, 4, 4,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 13, -22, 13, -22,
+ax_anim 3, 0, 139, 20, -21, 20, -21,
+ax_anim 2, 3, 140, 22, -13, 22, -13,
+ax_anim 2, 0, 141, 19, -6, 19, -6,
+ax_anim 1, 0, 142, 8, -1, 8, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -8, -19, -8, -19,
+ax_anim 3, 0, 138, 0, -22, 0, -22,
+ax_anim 2, 3, 139, 8, -19, 8, -19,
+ax_anim 2, 0, 140, 9, -10, 9, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -13, -22, -13, -22,
+ax_anim 3, 0, 145, -20, -21, -20, -21,
+ax_anim 2, 3, 144, -22, -13, -22, -13,
+ax_anim 2, 0, 143, -19, -6, -19, -6,
+ax_anim 1, 0, 142, -8, -1, -8, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -10, -7, -10, -7,
+ax_anim 2, 0, 145, -19, -6, -19, -6,
+ax_anim 3, 0, 144, -21, 0, -21, 0,
+ax_anim 2, 3, 143, -17, 7, -17, 7,
+ax_anim 2, 0, 142, -10, 8, -10, 8,
+ax_anim 1, 0, 141, -4, 4, -4, 4,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -24, 11, -24, 11,
+ax_anim 3, 0, 143, -22, 21, -22, 21,
+ax_anim 2, 3, 142, -12, 23, -12, 23,
+ax_anim 2, 0, 141, -3, 16, -3, 16,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_10_1:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_10_2:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_10_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_10_4:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_10_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_10_6:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_10_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_10_8:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_11_1:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_11_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -20, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_11_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -20, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_11_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_11_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -17, 0, 0,
+ax_anim 1, 0, 199, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_11_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -20, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_11_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -20, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_12_1:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_12_2:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_12_3:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_12_4:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_12_5:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_12_6:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_12_7:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_12_8:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sExploudAnims_13_1:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_13_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_13_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_13_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_13_5:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_13_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_13_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudAnims_13_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sExploudGfx1:
+.incbin "baserom.gba", 0x11FFC04, 0x200
+sExploudSprites1:
+ax_sprite sExploudGfx1, 0x200
+ax_sprite_terminator
+sExploudGfx2:
+.incbin "baserom.gba", 0x11FFE14, 0x200
+sExploudSprites2:
+ax_sprite sExploudGfx2, 0x200
+ax_sprite_terminator
+sExploudGfx3:
+.incbin "baserom.gba", 0x1200024, 0x200
+sExploudSprites3:
+ax_sprite sExploudGfx3, 0x200
+ax_sprite_terminator
+sExploudGfx4:
+.incbin "baserom.gba", 0x1200234, 0x200
+sExploudSprites4:
+ax_sprite sExploudGfx4, 0x200
+ax_sprite_terminator
+sExploudGfx5:
+.incbin "baserom.gba", 0x1200444, 0x200
+sExploudSprites5:
+ax_sprite sExploudGfx5, 0x200
+ax_sprite_terminator
+sExploudGfx6:
+.incbin "baserom.gba", 0x1200654, 0x200
+sExploudSprites6:
+ax_sprite sExploudGfx6, 0x200
+ax_sprite_terminator
+sExploudGfx7:
+.incbin "baserom.gba", 0x1200864, 0x200
+sExploudSprites7:
+ax_sprite sExploudGfx7, 0x200
+ax_sprite_terminator
+sExploudGfx8:
+.incbin "baserom.gba", 0x1200A74, 0x200
+sExploudSprites8:
+ax_sprite sExploudGfx8, 0x200
+ax_sprite_terminator
+sExploudGfx9:
+.incbin "baserom.gba", 0x1200C84, 0x200
+sExploudSprites9:
+ax_sprite sExploudGfx9, 0x200
+ax_sprite_terminator
+sExploudGfx10:
+.incbin "baserom.gba", 0x1200E94, 0x200
+sExploudSprites10:
+ax_sprite sExploudGfx10, 0x200
+ax_sprite_terminator
+sExploudGfx11:
+.incbin "baserom.gba", 0x12010A4, 0x200
+sExploudSprites11:
+ax_sprite sExploudGfx11, 0x200
+ax_sprite_terminator
+sExploudGfx12:
+.incbin "baserom.gba", 0x12012B4, 0x200
+sExploudSprites12:
+ax_sprite sExploudGfx12, 0x200
+ax_sprite_terminator
+sExploudGfx13:
+.incbin "baserom.gba", 0x12014C4, 0x200
+sExploudSprites13:
+ax_sprite sExploudGfx13, 0x200
+ax_sprite_terminator
+sExploudGfx14:
+.incbin "baserom.gba", 0x12016D4, 0x200
+sExploudSprites14:
+ax_sprite sExploudGfx14, 0x200
+ax_sprite_terminator
+sExploudGfx15:
+.incbin "baserom.gba", 0x12018E4, 0x200
+sExploudSprites15:
+ax_sprite sExploudGfx15, 0x200
+ax_sprite_terminator
+sExploudGfx16:
+.incbin "baserom.gba", 0x1201AF4, 0x200
+sExploudSprites16:
+ax_sprite sExploudGfx16, 0x200
+ax_sprite_terminator
+sExploudGfx17:
+.incbin "baserom.gba", 0x1201D04, 0x100
+sExploudSprites17:
+ax_sprite sExploudGfx17, 0x100
+ax_sprite_terminator
+sExploudGfx18:
+.incbin "baserom.gba", 0x1201E14, 0x60
+sExploudSprites18:
+ax_sprite sExploudGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExploudGfx19:
+.incbin "baserom.gba", 0x1201E8C, 0x20
+sExploudSprites19:
+ax_sprite sExploudGfx19, 0x20
+ax_sprite_terminator
+sExploudGfx20:
+.incbin "baserom.gba", 0x1201EBC, 0x40
+sExploudGfx20_1:
+.incbin "baserom.gba", 0x1201EFC, 0x180
+sExploudSprites20:
+ax_sprite sExploudGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sExploudGfx20_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExploudGfx21:
+.incbin "baserom.gba", 0x12020A4, 0x40
+sExploudGfx21_1:
+.incbin "baserom.gba", 0x12020E4, 0x160
+sExploudSprites21:
+ax_sprite 0, 0x20
+ax_sprite sExploudGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sExploudGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sExploudGfx22:
+.incbin "baserom.gba", 0x1202274, 0x100
+sExploudSprites22:
+ax_sprite sExploudGfx22, 0x100
+ax_sprite_terminator
+sExploudGfx23:
+.incbin "baserom.gba", 0x1202384, 0x80
+sExploudSprites23:
+ax_sprite sExploudGfx23, 0x80
+ax_sprite_terminator
+sExploudGfx24:
+.incbin "baserom.gba", 0x1202414, 0x200
+sExploudSprites24:
+ax_sprite sExploudGfx24, 0x200
+ax_sprite_terminator
+sExploudGfx25:
+.incbin "baserom.gba", 0x1202624, 0x200
+sExploudSprites25:
+ax_sprite sExploudGfx25, 0x200
+ax_sprite_terminator
+sExploudGfx26:
+.incbin "baserom.gba", 0x1202834, 0x200
+sExploudSprites26:
+ax_sprite sExploudGfx26, 0x200
+ax_sprite_terminator
+sExploudGfx27:
+.incbin "baserom.gba", 0x1202A44, 0x200
+sExploudSprites27:
+ax_sprite sExploudGfx27, 0x200
+ax_sprite_terminator
+sExploudGfx28:
+.incbin "baserom.gba", 0x1202C54, 0x200
+sExploudSprites28:
+ax_sprite sExploudGfx28, 0x200
+ax_sprite_terminator
+sExploudGfx29:
+.incbin "baserom.gba", 0x1202E64, 0x200
+sExploudSprites29:
+ax_sprite sExploudGfx29, 0x200
+ax_sprite_terminator
+sExploudGfx30:
+.incbin "baserom.gba", 0x1203074, 0x200
+sExploudSprites30:
+ax_sprite sExploudGfx30, 0x200
+ax_sprite_terminator
+sAxPosesExploud:
+.4byte sExploudPose1
+.4byte sExploudPose2
+.4byte sExploudPose3
+.4byte sExploudPose4
+.4byte sExploudPose5
+.4byte sExploudPose6
+.4byte sExploudPose7
+.4byte sExploudPose8
+.4byte sExploudPose9
+.4byte sExploudPose10
+.4byte sExploudPose11
+.4byte sExploudPose12
+.4byte sExploudPose13
+.4byte sExploudPose14
+.4byte sExploudPose15
+.4byte sExploudPose16
+.4byte sExploudPose17
+.4byte sExploudPose18
+.4byte sExploudPose19
+.4byte sExploudPose20
+.4byte sExploudPose21
+.4byte sExploudPose22
+.4byte sExploudPose23
+.4byte sExploudPose24
+.4byte sExploudPose25
+.4byte sExploudPose26
+.4byte sExploudPose27
+.4byte sExploudPose28
+.4byte sExploudPose29
+.4byte sExploudPose30
+.4byte sExploudPose31
+.4byte sExploudPose32
+.4byte sExploudPose33
+.4byte sExploudPose34
+.4byte sExploudPose35
+.4byte sExploudPose36
+.4byte sExploudPose37
+.4byte sExploudPose38
+.4byte sExploudPose39
+.4byte sExploudPose40
+.4byte sExploudPose41
+.4byte sExploudPose42
+.4byte sExploudPose43
+.4byte sExploudPose44
+.4byte sExploudPose45
+.4byte sExploudPose46
+.4byte sExploudPose47
+.4byte sExploudPose48
+.4byte sExploudPose49
+.4byte sExploudPose50
+.4byte sExploudPose51
+.4byte sExploudPose52
+.4byte sExploudPose53
+.4byte sExploudPose54
+.4byte sExploudPose55
+.4byte sExploudPose56
+.4byte sExploudPose57
+.4byte sExploudPose58
+.4byte sExploudPose59
+.4byte sExploudPose60
+.4byte sExploudPose61
+.4byte sExploudPose62
+.4byte sExploudPose63
+.4byte sExploudPose64
+.4byte sExploudPose65
+.4byte sExploudPose66
+.4byte sExploudPose67
+.4byte sExploudPose68
+.4byte sExploudPose69
+.4byte sExploudPose70
+.4byte sExploudPose71
+.4byte sExploudPose72
+.4byte sExploudPose73
+.4byte sExploudPose74
+.4byte sExploudPose75
+.4byte sExploudPose76
+.4byte sExploudPose77
+.4byte sExploudPose78
+.4byte sExploudPose79
+.4byte sExploudPose80
+.4byte sExploudPose81
+.4byte sExploudPose82
+.4byte sExploudPose83
+.4byte sExploudPose84
+.4byte sExploudPose85
+.4byte sExploudPose86
+.4byte sExploudPose87
+.4byte sExploudPose88
+.4byte sExploudPose89
+.4byte sExploudPose90
+.4byte sExploudPose91
+.4byte sExploudPose92
+.4byte sExploudPose93
+.4byte sExploudPose94
+.4byte sExploudPose95
+.4byte sExploudPose96
+.4byte sExploudPose97
+.4byte sExploudPose98
+.4byte sExploudPose99
+.4byte sExploudPose100
+.4byte sExploudPose101
+.4byte sExploudPose102
+.4byte sExploudPose103
+.4byte sExploudPose104
+.4byte sExploudPose105
+.4byte sExploudPose106
+.4byte sExploudPose107
+.4byte sExploudPose108
+.4byte sExploudPose109
+.4byte sExploudPose110
+.4byte sExploudPose111
+.4byte sExploudPose112
+.4byte sExploudPose113
+.4byte sExploudPose114
+.4byte sExploudPose115
+.4byte sExploudPose116
+.4byte sExploudPose117
+.4byte sExploudPose118
+.4byte sExploudPose119
+.4byte sExploudPose120
+.4byte sExploudPose121
+.4byte sExploudPose122
+.4byte sExploudPose123
+.4byte sExploudPose124
+.4byte sExploudPose125
+.4byte sExploudPose126
+.4byte sExploudPose127
+.4byte sExploudPose128
+.4byte sExploudPose129
+.4byte sExploudPose130
+.4byte sExploudPose131
+.4byte sExploudPose132
+.4byte sExploudPose133
+.4byte sExploudPose134
+.4byte sExploudPose135
+.4byte sExploudPose136
+.4byte sExploudPose137
+.4byte sExploudPose138
+.4byte sExploudPose139
+.4byte sExploudPose140
+.4byte sExploudPose141
+.4byte sExploudPose142
+.4byte sExploudPose143
+.4byte sExploudPose144
+.4byte sExploudPose145
+.4byte sExploudPose146
+.4byte sExploudPose147
+.4byte sExploudPose148
+.4byte sExploudPose149
+.4byte sExploudPose150
+.4byte sExploudPose151
+.4byte sExploudPose152
+.4byte sExploudPose153
+.4byte sExploudPose154
+.4byte sExploudPose155
+.4byte sExploudPose156
+.4byte sExploudPose157
+.4byte sExploudPose158
+.4byte sExploudPose159
+.4byte sExploudPose160
+.4byte sExploudPose161
+.4byte sExploudPose162
+.4byte sExploudPose163
+.4byte sExploudPose164
+.4byte sExploudPose165
+.4byte sExploudPose166
+.4byte sExploudPose167
+.4byte sExploudPose168
+.4byte sExploudPose169
+.4byte sExploudPose170
+.4byte sExploudPose171
+.4byte sExploudPose172
+.4byte sExploudPose173
+.4byte sExploudPose174
+.4byte sExploudPose175
+.4byte sExploudPose176
+.4byte sExploudPose177
+.4byte sExploudPose178
+.4byte sExploudPose179
+.4byte sExploudPose180
+.4byte sExploudPose181
+.4byte sExploudPose182
+.4byte sExploudPose183
+.4byte sExploudPose184
+.4byte sExploudPose185
+.4byte sExploudPose186
+.4byte sExploudPose187
+.4byte sExploudPose188
+.4byte sExploudPose189
+.4byte sExploudPose190
+.4byte sExploudPose191
+.4byte sExploudPose192
+.4byte sExploudPose193
+.4byte sExploudPose194
+.4byte sExploudPose195
+.4byte sExploudPose196
+.4byte sExploudPose197
+.4byte sExploudPose198
+.4byte sExploudPose199
+.4byte sExploudPose200
+.4byte sExploudPose201
+.4byte sExploudPose202
+.4byte sExploudPose203
+.4byte sExploudPose204
+.4byte sExploudPose205
+.4byte sExploudPose206
+.4byte sExploudPose207
+.4byte sExploudPose208
+.4byte sExploudPose209
+.4byte sExploudPose210
+.4byte sExploudPose211
+.4byte sExploudPose212
+.4byte sExploudPose213
+.4byte sExploudPose214
+.4byte sExploudPose215
+.4byte sExploudPose216
+.4byte sExploudPose217
+.4byte sExploudPose218
+.4byte sExploudPose219
+.4byte sExploudPose220
+.4byte sExploudPose221
+.4byte sExploudPose222
+sAxPositionsExploud:
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte    0,   -2, 	 -12,   -7, 	  10,   -3, 	   0,   -4
+.2byte   -2,   -2, 	 -12,   -3, 	  10,   -7, 	  -2,   -4
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte    3,   -3, 	   3,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte    5,   -3, 	  10,   -3, 	 -10,   -4, 	   1,   -5
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    7,   -3, 	  -4,   -4, 	   3,    0, 	  -1,   -7
+.2byte    7,   -4, 	   3,   -4, 	  -3,   -2, 	   1,   -7
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    3,   -8, 	  -7,   -8, 	  11,   -4, 	   0,  -10
+.2byte    2,  -10, 	   1,   -9, 	   5,   -2, 	  -1,  -10
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte   -2,   -8, 	   9,   -8, 	 -11,   -5, 	  -1,   -9
+.2byte    0,   -8, 	   9,   -5, 	 -11,   -8, 	  -1,   -9
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -5,   -8, 	   5,   -8, 	 -13,   -4, 	  -2,  -10
+.2byte   -4,  -10, 	  -3,   -9, 	  -7,   -2, 	  -1,  -10
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -9,   -3, 	   2,   -4, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -4, 	  -5,   -4, 	   1,   -2, 	  -3,   -7
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -5,   -3, 	  -5,   -6, 	   5,   -1, 	  -1,   -5
+.2byte   -7,   -3, 	 -12,   -3, 	   8,   -4, 	  -3,   -5
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte    0,   -2, 	 -12,   -7, 	  10,   -3, 	   0,   -4
+.2byte   -2,   -2, 	 -12,   -3, 	  10,   -7, 	  -2,   -4
+.2byte   -1,   -4, 	 -14,   -6, 	  12,   -6, 	  -1,   -9
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte    3,   -3, 	   3,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte    5,   -3, 	  10,   -3, 	 -10,   -4, 	   1,   -5
+.2byte    4,   -5, 	  10,   -9, 	 -10,   -6, 	  -1,   -7
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    7,   -3, 	  -4,   -4, 	   3,    0, 	  -1,   -7
+.2byte    7,   -4, 	   3,   -4, 	  -3,   -2, 	   1,   -7
+.2byte    4,   -5, 	  -3,   -7, 	  -3,   -2, 	  -2,   -8
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    3,   -8, 	  -7,   -8, 	  11,   -4, 	   0,  -10
+.2byte    2,  -10, 	   1,   -9, 	   5,   -2, 	  -1,  -10
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte   -2,   -8, 	   9,   -8, 	 -11,   -5, 	  -1,   -9
+.2byte    0,   -8, 	   9,   -5, 	 -11,   -8, 	  -1,   -9
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -5,   -8, 	   5,   -8, 	 -13,   -4, 	  -2,  -10
+.2byte   -4,  -10, 	  -3,   -9, 	  -7,   -2, 	  -1,  -10
+.2byte   -2,  -10, 	   6,   -8, 	 -10,   -5, 	   0,  -12
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -9,   -3, 	   2,   -4, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -4, 	  -5,   -4, 	   1,   -2, 	  -3,   -7
+.2byte   -6,   -5, 	   1,   -7, 	   1,   -2, 	   0,   -8
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -5,   -3, 	  -5,   -6, 	   5,   -1, 	  -1,   -5
+.2byte   -7,   -3, 	 -12,   -3, 	   8,   -4, 	  -3,   -5
+.2byte   -6,   -5, 	 -12,   -9, 	   8,   -6, 	  -1,   -7
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte    0,   -2, 	 -12,   -7, 	  10,   -3, 	   0,   -4
+.2byte   -2,   -2, 	 -12,   -3, 	  10,   -7, 	  -2,   -4
+.2byte   -1,   -4, 	 -14,   -6, 	  12,   -6, 	  -1,   -9
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte    3,   -3, 	   3,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte    5,   -3, 	  10,   -3, 	 -10,   -4, 	   1,   -5
+.2byte    4,   -5, 	  10,   -9, 	 -10,   -6, 	  -1,   -7
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    7,   -3, 	  -4,   -4, 	   3,    0, 	  -1,   -7
+.2byte    7,   -4, 	   3,   -4, 	  -3,   -2, 	   1,   -7
+.2byte    4,   -5, 	  -3,   -7, 	  -3,   -2, 	  -2,   -8
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    3,   -8, 	  -7,   -8, 	  11,   -4, 	   0,  -10
+.2byte    2,  -10, 	   1,   -9, 	   5,   -2, 	  -1,  -10
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte   -2,   -8, 	   9,   -8, 	 -11,   -5, 	  -1,   -9
+.2byte    0,   -8, 	   9,   -5, 	 -11,   -8, 	  -1,   -9
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -5,   -8, 	   5,   -8, 	 -13,   -4, 	  -2,  -10
+.2byte   -4,  -10, 	  -3,   -9, 	  -7,   -2, 	  -1,  -10
+.2byte   -2,  -10, 	   6,   -8, 	 -10,   -5, 	   0,  -12
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -9,   -3, 	   2,   -4, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -4, 	  -5,   -4, 	   1,   -2, 	  -3,   -7
+.2byte   -6,   -5, 	   1,   -7, 	   1,   -2, 	   0,   -8
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -5,   -3, 	  -5,   -6, 	   5,   -1, 	  -1,   -5
+.2byte   -7,   -3, 	 -12,   -3, 	   8,   -4, 	  -3,   -5
+.2byte   -6,   -5, 	 -12,   -9, 	   8,   -6, 	  -1,   -7
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte   -1,   -4, 	 -14,   -6, 	  12,   -6, 	  -1,   -9
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -2,  -10, 	   6,   -8, 	 -10,   -5, 	   0,  -12
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -6,   -6, 	   1,   -8, 	   1,   -3, 	   0,   -9
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -7,   -5, 	 -13,   -9, 	   7,   -6, 	  -2,   -7
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte    0,   -8, 	  -5,   -1, 	   1,    0, 	   3,   -7
+.2byte    0,   -8, 	  -5,   -1, 	   1,    0, 	   3,   -8
+.2byte   -1,    1, 	 -13,    2, 	  11,    2, 	  -1,   -6
+.2byte    2,    2, 	  10,   -2, 	 -10,    3, 	  -3,   -5
+.2byte    7,    0, 	   8,   -1, 	   3,    5, 	  -5,   -5
+.2byte    3,   -4, 	  -5,   -6, 	   9,    1, 	  -2,   -3
+.2byte   -1,    0, 	  10,   -3, 	 -12,   -3, 	  -1,   -3
+.2byte   -4,   -4, 	   4,   -6, 	 -10,    1, 	   1,   -3
+.2byte   -8,    0, 	  -9,   -1, 	  -4,    5, 	   4,   -5
+.2byte   -3,    2, 	 -11,   -2, 	   9,    3, 	   2,   -5
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte   -1,   -4, 	 -14,   -6, 	  12,   -6, 	  -1,   -9
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte    4,   -5, 	  10,   -9, 	 -10,   -6, 	  -1,   -7
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    4,   -5, 	  -3,   -7, 	  -3,   -2, 	  -2,   -8
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte   -1,  -10, 	  -9,   -8, 	   7,   -5, 	  -3,  -12
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte   -1,   -6, 	  11,   -6, 	 -13,   -6, 	  -1,   -9
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -1,  -10, 	   7,   -8, 	  -9,   -5, 	   1,  -12
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -6,   -5, 	   1,   -7, 	   1,   -2, 	   0,   -8
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -6,   -5, 	 -12,   -9, 	   8,   -6, 	  -1,   -7
+.2byte   -1,   -4, 	 -14,   -6, 	  12,   -6, 	  -1,   -9
+.2byte   -5,   -5, 	 -11,   -9, 	   9,   -6, 	   0,   -7
+.2byte   -6,   -6, 	   1,   -8, 	   1,   -3, 	   0,   -9
+.2byte   -2,  -10, 	   6,   -8, 	 -10,   -5, 	   0,  -12
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    4,   -5, 	  10,   -9, 	 -10,   -6, 	  -1,   -7
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte   -2,  -10, 	   6,   -8, 	 -10,   -5, 	   0,  -12
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte   -6,   -6, 	   1,   -8, 	   1,   -3, 	   0,   -9
+.2byte   -2,  -10, 	   6,   -8, 	 -10,   -5, 	   0,  -12
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte   -7,   -5, 	 -13,   -9, 	   7,   -6, 	  -2,   -7
+.2byte   -6,   -6, 	   1,   -8, 	   1,   -3, 	   0,   -9
+.2byte   -2,  -10, 	   6,   -8, 	 -10,   -5, 	   0,  -12
+.2byte   -1,   -8, 	  11,   -8, 	 -13,   -8, 	  -1,  -11
+.2byte    0,  -10, 	  -8,   -8, 	   8,   -5, 	  -2,  -12
+.2byte    4,   -6, 	  -3,   -8, 	  -3,   -3, 	  -2,   -9
+.2byte    5,   -5, 	  11,   -9, 	  -9,   -6, 	   0,   -7
+.2byte    0,   -2, 	 -12,   -7, 	  10,   -3, 	   0,   -4
+.2byte    5,   -3, 	  10,   -3, 	 -10,   -4, 	   1,   -5
+.2byte    7,   -4, 	   3,   -4, 	  -3,   -2, 	   1,   -7
+.2byte    2,  -10, 	   1,   -9, 	   5,   -2, 	  -1,  -10
+.2byte   -2,   -8, 	   9,   -8, 	 -11,   -5, 	  -1,   -9
+.2byte   -5,   -8, 	   5,   -8, 	 -13,   -4, 	  -2,  -10
+.2byte   -9,   -4, 	  -5,   -4, 	   1,   -2, 	  -3,   -7
+.2byte   -7,   -3, 	 -12,   -3, 	   8,   -4, 	  -3,   -5
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte    0,   -2, 	 -12,   -7, 	  10,   -3, 	   0,   -4
+.2byte   -2,   -2, 	 -12,   -3, 	  10,   -7, 	  -2,   -4
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte    3,   -3, 	   3,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte    5,   -3, 	  10,   -3, 	 -10,   -4, 	   1,   -5
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    6,   -3, 	  -5,   -4, 	   2,    0, 	  -2,   -7
+.2byte    6,   -4, 	   2,   -4, 	  -4,   -2, 	   0,   -7
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    3,   -8, 	  -7,   -8, 	  11,   -4, 	   0,  -10
+.2byte    2,  -10, 	   1,   -9, 	   5,   -2, 	  -1,  -10
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte   -2,   -8, 	   9,   -8, 	 -11,   -5, 	  -1,   -9
+.2byte    0,   -8, 	   9,   -5, 	 -11,   -8, 	  -1,   -9
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -5,   -8, 	   5,   -8, 	 -13,   -4, 	  -2,  -10
+.2byte   -4,  -10, 	  -3,   -9, 	  -7,   -2, 	  -1,  -10
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -8,   -3, 	   3,   -4, 	  -4,    0, 	   0,   -7
+.2byte   -8,   -4, 	  -4,   -4, 	   2,   -2, 	  -2,   -7
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -5,   -3, 	  -5,   -6, 	   5,   -1, 	  -1,   -5
+.2byte   -7,   -3, 	 -12,   -3, 	   8,   -4, 	  -3,   -5
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+.2byte   -1,   -3, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte   -5,   -3, 	 -10,   -6, 	   7,   -3, 	  -2,   -6
+.2byte   -8,   -5, 	  -2,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte   -5,   -9, 	   4,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -1,   -8, 	  10,   -7, 	 -12,   -7, 	  -1,  -10
+.2byte    3,   -9, 	  -6,   -8, 	   8,   -2, 	  -1,  -11
+.2byte    6,   -5, 	   0,   -5, 	  -1,   -1, 	  -1,   -8
+.2byte    3,   -3, 	   8,   -6, 	  -9,   -3, 	   0,   -6
+sExploudAnimTable1:
+.4byte sExploudAnims_1_1
+.4byte sExploudAnims_1_2
+.4byte sExploudAnims_1_3
+.4byte sExploudAnims_1_4
+.4byte sExploudAnims_1_5
+.4byte sExploudAnims_1_6
+.4byte sExploudAnims_1_7
+.4byte sExploudAnims_1_8
+sExploudAnimTable2:
+.4byte sExploudAnims_2_1
+.4byte sExploudAnims_2_2
+.4byte sExploudAnims_2_3
+.4byte sExploudAnims_2_4
+.4byte sExploudAnims_2_5
+.4byte sExploudAnims_2_6
+.4byte sExploudAnims_2_7
+.4byte sExploudAnims_2_8
+sExploudAnimTable3:
+.4byte sExploudAnims_3_1
+.4byte sExploudAnims_3_2
+.4byte sExploudAnims_3_3
+.4byte sExploudAnims_3_4
+.4byte sExploudAnims_3_5
+.4byte sExploudAnims_3_6
+.4byte sExploudAnims_3_7
+.4byte sExploudAnims_3_8
+sExploudAnimTable4:
+.4byte sExploudAnims_4_1
+.4byte sExploudAnims_4_2
+.4byte sExploudAnims_4_3
+.4byte sExploudAnims_4_4
+.4byte sExploudAnims_4_5
+.4byte sExploudAnims_4_6
+.4byte sExploudAnims_4_7
+.4byte sExploudAnims_4_8
+sExploudAnimTable5:
+.4byte sExploudAnims_5_1
+.4byte sExploudAnims_5_2
+.4byte sExploudAnims_5_3
+.4byte sExploudAnims_5_4
+.4byte sExploudAnims_5_5
+.4byte sExploudAnims_5_6
+.4byte sExploudAnims_5_7
+.4byte sExploudAnims_5_8
+sExploudAnimTable6:
+.4byte sExploudAnims_6_1
+.4byte sExploudAnims_6_1
+.4byte sExploudAnims_6_1
+.4byte sExploudAnims_6_1
+.4byte sExploudAnims_6_1
+.4byte sExploudAnims_6_1
+.4byte sExploudAnims_6_1
+.4byte sExploudAnims_6_1
+sExploudAnimTable7:
+.4byte sExploudAnims_7_1
+.4byte sExploudAnims_7_2
+.4byte sExploudAnims_7_3
+.4byte sExploudAnims_7_4
+.4byte sExploudAnims_7_5
+.4byte sExploudAnims_7_6
+.4byte sExploudAnims_7_7
+.4byte sExploudAnims_7_8
+sExploudAnimTable8:
+.4byte sExploudAnims_8_1
+.4byte sExploudAnims_8_2
+.4byte sExploudAnims_8_3
+.4byte sExploudAnims_8_4
+.4byte sExploudAnims_8_5
+.4byte sExploudAnims_8_6
+.4byte sExploudAnims_8_7
+.4byte sExploudAnims_8_8
+sExploudAnimTable9:
+.4byte sExploudAnims_9_1
+.4byte sExploudAnims_9_2
+.4byte sExploudAnims_9_3
+.4byte sExploudAnims_9_4
+.4byte sExploudAnims_9_5
+.4byte sExploudAnims_9_6
+.4byte sExploudAnims_9_7
+.4byte sExploudAnims_9_8
+sExploudAnimTable10:
+.4byte sExploudAnims_10_1
+.4byte sExploudAnims_10_2
+.4byte sExploudAnims_10_3
+.4byte sExploudAnims_10_4
+.4byte sExploudAnims_10_5
+.4byte sExploudAnims_10_6
+.4byte sExploudAnims_10_7
+.4byte sExploudAnims_10_8
+sExploudAnimTable11:
+.4byte sExploudAnims_11_1
+.4byte sExploudAnims_11_2
+.4byte sExploudAnims_11_3
+.4byte sExploudAnims_11_4
+.4byte sExploudAnims_11_5
+.4byte sExploudAnims_11_6
+.4byte sExploudAnims_11_7
+.4byte sExploudAnims_11_8
+sExploudAnimTable12:
+.4byte sExploudAnims_12_1
+.4byte sExploudAnims_12_2
+.4byte sExploudAnims_12_3
+.4byte sExploudAnims_12_4
+.4byte sExploudAnims_12_5
+.4byte sExploudAnims_12_6
+.4byte sExploudAnims_12_7
+.4byte sExploudAnims_12_8
+sExploudAnimTable13:
+.4byte sExploudAnims_13_1
+.4byte sExploudAnims_13_2
+.4byte sExploudAnims_13_3
+.4byte sExploudAnims_13_4
+.4byte sExploudAnims_13_5
+.4byte sExploudAnims_13_6
+.4byte sExploudAnims_13_7
+.4byte sExploudAnims_13_8
+sAxAnimationsExploud:
+.4byte sExploudAnimTable1
+.4byte sExploudAnimTable2
+.4byte sExploudAnimTable3
+.4byte sExploudAnimTable4
+.4byte sExploudAnimTable5
+.4byte sExploudAnimTable6
+.4byte sExploudAnimTable7
+.4byte sExploudAnimTable8
+.4byte sExploudAnimTable9
+.4byte sExploudAnimTable10
+.4byte sExploudAnimTable11
+.4byte sExploudAnimTable12
+.4byte sExploudAnimTable13
+sAxSpritesExploud:
+.4byte sExploudSprites1
+.4byte sExploudSprites2
+.4byte sExploudSprites3
+.4byte sExploudSprites4
+.4byte sExploudSprites5
+.4byte sExploudSprites6
+.4byte sExploudSprites7
+.4byte sExploudSprites8
+.4byte sExploudSprites9
+.4byte sExploudSprites10
+.4byte sExploudSprites11
+.4byte sExploudSprites12
+.4byte sExploudSprites13
+.4byte sExploudSprites14
+.4byte sExploudSprites15
+.4byte sExploudSprites16
+.4byte sExploudSprites17
+.4byte sExploudSprites18
+.4byte sExploudSprites19
+.4byte sExploudSprites20
+.4byte sExploudSprites21
+.4byte sExploudSprites22
+.4byte sExploudSprites23
+.4byte sExploudSprites24
+.4byte sExploudSprites25
+.4byte sExploudSprites26
+.4byte sExploudSprites27
+.4byte sExploudSprites28
+.4byte sExploudSprites29
+.4byte sExploudSprites30
+sAxMainExploud:
+ax_main sAxPosesExploud, sAxAnimationsExploud, 13, sAxSpritesExploud, sAxPositionsExploud

--- a/data/ax/farfetchd.inc
+++ b/data/ax/farfetchd.inc
@@ -1,0 +1,2999 @@
+.global gAxFarfetchd
+gAxFarfetchd:
+ax_siro sAxMainFarfetchd
+sFarfetchdPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose4:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose5:
+ax_pose 4, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose6:
+ax_pose 5, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose7:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose8:
+ax_pose 7, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose9:
+ax_pose 8, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose10:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose11:
+ax_pose 10, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose12:
+ax_pose 11, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose16:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose17:
+ax_pose 16, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose18:
+ax_pose 17, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose19:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose20:
+ax_pose 19, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose21:
+ax_pose 20, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose22:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose23:
+ax_pose 22, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose24:
+ax_pose 23, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose28:
+ax_pose 24, 0x41ee, 0x80f4, 0x8c00
+ax_pose 25, 0x81fe, 0x00fc, 0x8c08
+ax_pose 26, 0x01e6, 0x00fc, 0x8c0a
+ax_pose_terminator
+sFarfetchdPose29:
+ax_pose 27, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose30:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose31:
+ax_pose 4, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose32:
+ax_pose 5, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose33:
+ax_pose 28, 0x41ec, 0x90f2, 0x8c00
+ax_pose 29, 0x41fc, 0x50f2, 0x8c08
+ax_pose 30, 0x0204, 0x110a, 0x8c0c
+ax_pose 31, 0x0204, 0x1112, 0x8c0d
+ax_pose_terminator
+sFarfetchdPose34:
+ax_pose 32, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose35:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose36:
+ax_pose 7, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose37:
+ax_pose 8, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose38:
+ax_pose 33, 0x41ec, 0x90f3, 0x8c00
+ax_pose 34, 0x41fc, 0x50f3, 0x8c08
+ax_pose 35, 0x01f8, 0x1113, 0x8c0c
+ax_pose_terminator
+sFarfetchdPose39:
+ax_pose 36, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose40:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose41:
+ax_pose 10, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose42:
+ax_pose 11, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose43:
+ax_pose 37, 0x01e5, 0x90f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose44:
+ax_pose 38, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose45:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose46:
+ax_pose 13, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose47:
+ax_pose 14, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose48:
+ax_pose 39, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose49:
+ax_pose 40, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose50:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose51:
+ax_pose 16, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose52:
+ax_pose 17, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose53:
+ax_pose 37, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sFarfetchdPose54:
+ax_pose 41, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose55:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose56:
+ax_pose 19, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose57:
+ax_pose 20, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose58:
+ax_pose 33, 0x41ec, 0x80ed, 0x8c00
+ax_pose 34, 0x41fc, 0x40ed, 0x8c08
+ax_pose 35, 0x01f8, 0x00e5, 0x8c0c
+ax_pose_terminator
+sFarfetchdPose59:
+ax_pose 42, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose60:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose61:
+ax_pose 22, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose62:
+ax_pose 23, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose63:
+ax_pose 28, 0x41ec, 0x80ef, 0x8c00
+ax_pose 29, 0x41fc, 0x40ef, 0x8c08
+ax_pose 30, 0x0204, 0x00ef, 0x8c0c
+ax_pose 31, 0x0204, 0x00e7, 0x8c0d
+ax_pose_terminator
+sFarfetchdPose64:
+ax_pose 43, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose65:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose66:
+ax_pose 1, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose67:
+ax_pose 2, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose68:
+ax_pose 27, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose69:
+ax_pose 44, 0x01e9, 0x80f4, 0x8c00
+ax_pose 45, 0x01e9, 0x80f4, 0x8c10
+ax_pose_terminator
+sFarfetchdPose70:
+ax_pose 45, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose71:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose72:
+ax_pose 4, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose73:
+ax_pose 5, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose74:
+ax_pose 32, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose75:
+ax_pose 46, 0x01ed, 0x80f2, 0x8c00
+ax_pose 47, 0x01eb, 0x80f0, 0x8c10
+ax_pose_terminator
+sFarfetchdPose76:
+ax_pose 47, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose77:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose78:
+ax_pose 7, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose79:
+ax_pose 8, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose80:
+ax_pose 36, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose81:
+ax_pose 48, 0x01e8, 0x80f6, 0x8c00
+ax_pose 49, 0x01ec, 0x80f3, 0x8c10
+ax_pose_terminator
+sFarfetchdPose82:
+ax_pose 49, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose83:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose84:
+ax_pose 10, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose85:
+ax_pose 11, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose86:
+ax_pose 38, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose87:
+ax_pose 50, 0x01e8, 0x80f0, 0x8c00
+ax_pose 51, 0x01ea, 0x80f0, 0x8c10
+ax_pose_terminator
+sFarfetchdPose88:
+ax_pose 51, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose89:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose90:
+ax_pose 13, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose91:
+ax_pose 14, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose92:
+ax_pose 40, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose93:
+ax_pose 52, 0x01e8, 0x80f1, 0x8c00
+ax_pose 53, 0x01e8, 0x80f1, 0x8c10
+ax_pose_terminator
+sFarfetchdPose94:
+ax_pose 52, 0x01e8, 0x80f1, 0x8c00
+ax_pose_terminator
+sFarfetchdPose95:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose96:
+ax_pose 16, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose97:
+ax_pose 17, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose98:
+ax_pose 41, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose99:
+ax_pose 54, 0x01e6, 0x80ec, 0x8c00
+ax_pose 55, 0x01eb, 0x80f0, 0x8c10
+ax_pose_terminator
+sFarfetchdPose100:
+ax_pose 55, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose101:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose102:
+ax_pose 19, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose103:
+ax_pose 20, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose104:
+ax_pose 42, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose105:
+ax_pose 56, 0x41ec, 0x80e9, 0x8c00
+ax_pose 57, 0x01eb, 0x80f0, 0x8c08
+ax_pose_terminator
+sFarfetchdPose106:
+ax_pose 57, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose107:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose108:
+ax_pose 22, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose109:
+ax_pose 23, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose110:
+ax_pose 43, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose111:
+ax_pose 58, 0x01ed, 0x80f1, 0x8c00
+ax_pose 59, 0x01ea, 0x80f0, 0x8c10
+ax_pose_terminator
+sFarfetchdPose112:
+ax_pose 59, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose113:
+ax_pose 27, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose114:
+ax_pose 43, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose115:
+ax_pose 42, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose116:
+ax_pose 41, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose117:
+ax_pose 40, 0x01e7, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose118:
+ax_pose 38, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose119:
+ax_pose 36, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose120:
+ax_pose 32, 0x01eb, 0x80f2, 0x8c00
+ax_pose_terminator
+sFarfetchdPose121:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose122:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose123:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose124:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose125:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose126:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose127:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose128:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose129:
+ax_pose 60, 0x01ed, 0x80f2, 0x8c00
+ax_pose_terminator
+sFarfetchdPose130:
+ax_pose 61, 0x01ed, 0x80f2, 0x8c00
+ax_pose_terminator
+sFarfetchdPose131:
+ax_pose 62, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sFarfetchdPose132:
+ax_pose 63, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sFarfetchdPose133:
+ax_pose 64, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose134:
+ax_pose 65, 0x01e8, 0x90ee, 0x8c00
+ax_pose_terminator
+sFarfetchdPose135:
+ax_pose 66, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sFarfetchdPose136:
+ax_pose 65, 0x01e8, 0x80f2, 0x8c00
+ax_pose_terminator
+sFarfetchdPose137:
+ax_pose 64, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sFarfetchdPose138:
+ax_pose 63, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sFarfetchdPose139:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose140:
+ax_pose 1, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose141:
+ax_pose 2, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose142:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose143:
+ax_pose 4, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose144:
+ax_pose 5, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose145:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose146:
+ax_pose 7, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose147:
+ax_pose 8, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose148:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose149:
+ax_pose 10, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose150:
+ax_pose 11, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose151:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose152:
+ax_pose 13, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose153:
+ax_pose 14, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose154:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose155:
+ax_pose 16, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose156:
+ax_pose 17, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose157:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose158:
+ax_pose 19, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose159:
+ax_pose 20, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose160:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose161:
+ax_pose 22, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose162:
+ax_pose 23, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose163:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose164:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose165:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose166:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose167:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose168:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose169:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose170:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose171:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose172:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose173:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose174:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose175:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose176:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose177:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose178:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose179:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose180:
+ax_pose 1, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose181:
+ax_pose 2, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose182:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose183:
+ax_pose 4, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose184:
+ax_pose 5, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose185:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose186:
+ax_pose 7, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose187:
+ax_pose 8, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose188:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose189:
+ax_pose 10, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose190:
+ax_pose 11, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose191:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose192:
+ax_pose 13, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose193:
+ax_pose 14, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose194:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose195:
+ax_pose 16, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose196:
+ax_pose 17, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose197:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose198:
+ax_pose 19, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose199:
+ax_pose 20, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose200:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose201:
+ax_pose 22, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose202:
+ax_pose 23, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose203:
+ax_pose 27, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose204:
+ax_pose 43, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose205:
+ax_pose 42, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose206:
+ax_pose 41, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose207:
+ax_pose 40, 0x01e7, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose208:
+ax_pose 38, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sFarfetchdPose209:
+ax_pose 36, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose210:
+ax_pose 32, 0x01eb, 0x80f2, 0x8c00
+ax_pose_terminator
+sFarfetchdPose211:
+ax_pose 0, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose212:
+ax_pose 21, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose213:
+ax_pose 18, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose214:
+ax_pose 15, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sFarfetchdPose215:
+ax_pose 12, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose216:
+ax_pose 9, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sFarfetchdPose217:
+ax_pose 6, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sFarfetchdPose218:
+ax_pose 3, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+.align 2
+sFarfetchdAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_2_1:
+ax_anim 2, 0, 28, 0, -2, 0, 0,
+ax_anim 6, 0, 28, 0, -4, 0, 0,
+ax_anim 1, 0, 27, 0, -4, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 4, 0, 6,
+ax_anim_terminator
+sFarfetchdAnims_2_2:
+ax_anim 2, 0, 33, 0, -2, 0, 0,
+ax_anim 6, 0, 33, 0, -4, 0, 0,
+ax_anim 1, 0, 32, 0, -4, 0, 0,
+ax_anim 1, 2, 32, 4, 1, 4, 4,
+ax_anim 1, 0, 32, 10, 8, 10, 10,
+ax_anim 2, 0, 32, 18, 18, 18, 18,
+ax_anim 2, 1, 32, 19, 17, 19, 17,
+ax_anim 2, 0, 32, 18, 18, 18, 18,
+ax_anim 2, 0, 32, 19, 17, 19, 17,
+ax_anim 2, 0, 33, 6, 4, 6, 6,
+ax_anim_terminator
+sFarfetchdAnims_2_3:
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 6, 0, 38, 0, -5, 0, 0,
+ax_anim 1, 0, 37, 0, -7, 0, 0,
+ax_anim 1, 2, 37, 4, -6, 4, 0,
+ax_anim 1, 0, 37, 10, -3, 10, 0,
+ax_anim 2, 0, 37, 17, 0, 17, 0,
+ax_anim 2, 1, 37, 17, -1, 17, -1,
+ax_anim 2, 0, 37, 17, 0, 17, 0,
+ax_anim 2, 0, 37, 17, -1, 17, -1,
+ax_anim 2, 0, 38, 6, -4, 6, 0,
+ax_anim_terminator
+sFarfetchdAnims_2_4:
+ax_anim 2, 0, 43, 0, -2, 0, 0,
+ax_anim 6, 0, 43, 0, -4, 0, 0,
+ax_anim 1, 0, 42, 0, -4, 0, 0,
+ax_anim 1, 2, 42, 4, -8, 4, -4,
+ax_anim 1, 0, 42, 10, -12, 10, -9,
+ax_anim 2, 0, 42, 16, -17, 16, -17,
+ax_anim 2, 1, 42, 17, -16, 17, -16,
+ax_anim 2, 0, 42, 16, -17, 16, -17,
+ax_anim 2, 0, 42, 17, -16, 17, -16,
+ax_anim 2, 0, 43, 6, -6, 6, -6,
+ax_anim_terminator
+sFarfetchdAnims_2_5:
+ax_anim 2, 0, 48, 0, -2, 0, 0,
+ax_anim 6, 0, 48, 0, -4, 0, 0,
+ax_anim 1, 0, 47, 0, -4, 0, 0,
+ax_anim 1, 2, 47, 0, -6, 0, -3,
+ax_anim 1, 0, 47, 0, -10, 0, -7,
+ax_anim 2, 0, 47, 0, -18, 0, -17,
+ax_anim 2, 1, 47, 1, -18, 1, -17,
+ax_anim 2, 0, 47, 0, -18, 0, -18,
+ax_anim 2, 0, 47, 1, -18, 1, -18,
+ax_anim 2, 0, 48, 0, -7, 0, -4,
+ax_anim_terminator
+sFarfetchdAnims_2_6:
+ax_anim 2, 0, 53, 0, -2, 0, 0,
+ax_anim 6, 0, 53, 0, -4, 0, 0,
+ax_anim 1, 0, 52, 0, -4, 0, 0,
+ax_anim 1, 2, 52, -4, -8, -4, -4,
+ax_anim 1, 0, 52, -10, -12, -10, -9,
+ax_anim 2, 0, 52, -16, -17, -16, -17,
+ax_anim 2, 1, 52, -17, -16, -17, -16,
+ax_anim 2, 0, 52, -16, -17, -16, -17,
+ax_anim 2, 0, 52, -17, -16, -17, -16,
+ax_anim 2, 0, 53, -6, -6, -6, -6,
+ax_anim_terminator
+sFarfetchdAnims_2_7:
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 6, 0, 58, 0, -5, 0, 0,
+ax_anim 1, 0, 57, 0, -7, 0, 0,
+ax_anim 1, 2, 57, -4, -6, -4, 0,
+ax_anim 1, 0, 57, -10, -3, -10, 0,
+ax_anim 2, 0, 57, -17, 0, -17, 0,
+ax_anim 2, 1, 57, -17, -1, -17, -1,
+ax_anim 2, 0, 57, -17, 0, -17, 0,
+ax_anim 2, 0, 57, -17, -1, -17, -1,
+ax_anim 2, 0, 58, -6, -4, -6, 0,
+ax_anim_terminator
+sFarfetchdAnims_2_8:
+ax_anim 2, 0, 63, 0, -2, 0, 0,
+ax_anim 6, 0, 63, 0, -4, 0, 0,
+ax_anim 1, 0, 62, 0, -4, 0, 0,
+ax_anim 1, 2, 62, -4, 1, -4, 4,
+ax_anim 1, 0, 62, -10, 8, -10, 10,
+ax_anim 2, 0, 62, -18, 18, -18, 18,
+ax_anim 2, 1, 62, -19, 17, -19, 17,
+ax_anim 2, 0, 62, -18, 18, -18, 18,
+ax_anim 2, 0, 62, -19, 17, -19, 17,
+ax_anim 2, 0, 63, -6, 4, -6, 6,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 2, 0, 67, 0, -3, 0, -3,
+ax_anim 4, 0, 67, 0, -4, 0, -4,
+ax_anim 1, 2, 67, 0, 1, 0, 1,
+ax_anim 1, 0, 67, 0, 9, 0, 9,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 1, 69, -1, 16, -1, 16,
+ax_anim 2, 0, 69, 0, 16, 0, 16,
+ax_anim 2, 0, 69, -1, 16, -1, 16,
+ax_anim 2, 0, 69, 0, 16, 0, 16,
+ax_anim 2, 0, 69, -1, 16, -1, 16,
+ax_anim 2, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 3, 0, 3,
+ax_anim_terminator
+sFarfetchdAnims_3_2:
+ax_anim 2, 0, 70, -1, -1, -1, -1,
+ax_anim 2, 0, 73, -3, -3, -3, -3,
+ax_anim 4, 0, 73, -4, -4, -4, -4,
+ax_anim 1, 2, 73, 1, 1, 1, 1,
+ax_anim 1, 0, 73, 12, 8, 12, 8,
+ax_anim 2, 0, 74, 20, 13, 20, 13,
+ax_anim 2, 1, 75, 19, 14, 19, 14,
+ax_anim 2, 0, 75, 20, 13, 20, 13,
+ax_anim 2, 0, 75, 19, 14, 19, 14,
+ax_anim 2, 0, 75, 20, 13, 20, 13,
+ax_anim 2, 0, 75, 19, 14, 19, 14,
+ax_anim 2, 0, 70, 12, 9, 12, 9,
+ax_anim 2, 0, 70, 3, 3, 3, 3,
+ax_anim_terminator
+sFarfetchdAnims_3_3:
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 2, 0, 79, -3, 0, -3, 0,
+ax_anim 4, 0, 79, -4, 0, -4, 0,
+ax_anim 1, 2, 79, 1, 0, 1, 0,
+ax_anim 1, 0, 79, 7, 0, 7, 0,
+ax_anim 2, 0, 80, 14, 0, 14, 0,
+ax_anim 2, 1, 81, 14, 1, 14, 1,
+ax_anim 2, 0, 81, 14, 0, 14, 0,
+ax_anim 2, 0, 81, 14, 1, 14, 1,
+ax_anim 2, 0, 81, 14, 0, 14, 0,
+ax_anim 2, 0, 81, 14, 1, 14, 1,
+ax_anim 2, 0, 76, 8, 0, 8, 0,
+ax_anim 2, 0, 76, 2, 0, 2, 0,
+ax_anim_terminator
+sFarfetchdAnims_3_4:
+ax_anim 2, 0, 82, -1, 1, -1, 1,
+ax_anim 2, 0, 85, -3, 3, -3, 3,
+ax_anim 4, 0, 85, -4, 4, -4, 4,
+ax_anim 1, 2, 85, 1, -1, 1, -1,
+ax_anim 1, 0, 85, 8, -8, 8, -8,
+ax_anim 2, 0, 86, 16, -17, 16, -17,
+ax_anim 2, 1, 87, 17, -16, 17, -16,
+ax_anim 2, 0, 87, 16, -17, 16, -17,
+ax_anim 2, 0, 87, 17, -16, 17, -16,
+ax_anim 2, 0, 87, 16, -17, 16, -17,
+ax_anim 2, 0, 87, 17, -16, 17, -16,
+ax_anim 2, 0, 82, 9, -9, 9, -9,
+ax_anim 2, 0, 82, 3, -3, 3, -3,
+ax_anim_terminator
+sFarfetchdAnims_3_5:
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 4, 0, 91, 0, 4, 0, 4,
+ax_anim 1, 2, 91, 0, -1, 0, -1,
+ax_anim 1, 0, 91, 0, -7, 0, -7,
+ax_anim 2, 0, 92, 0, -14, 0, -14,
+ax_anim 2, 1, 93, -1, -14, -1, -14,
+ax_anim 2, 0, 93, 0, -14, 0, -14,
+ax_anim 2, 0, 93, -1, -14, -1, -14,
+ax_anim 2, 0, 93, 0, -14, 0, -14,
+ax_anim 2, 0, 93, -1, -14, -1, -14,
+ax_anim 2, 0, 88, 0, -8, 0, -8,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim_terminator
+sFarfetchdAnims_3_6:
+ax_anim 2, 0, 94, 1, 1, 1, 1,
+ax_anim 2, 0, 97, 3, 3, 3, 3,
+ax_anim 4, 0, 97, 4, 4, 4, 4,
+ax_anim 1, 2, 97, -1, -1, -1, -1,
+ax_anim 1, 0, 97, -7, -8, -7, -8,
+ax_anim 2, 0, 98, -14, -17, -14, -17,
+ax_anim 2, 1, 99, -15, -16, -15, -16,
+ax_anim 2, 0, 99, -14, -17, -14, -17,
+ax_anim 2, 0, 99, -15, -16, -15, -16,
+ax_anim 2, 0, 99, -14, -17, -14, -17,
+ax_anim 2, 0, 99, -15, -16, -15, -16,
+ax_anim 2, 0, 94, -8, -9, -8, -9,
+ax_anim 2, 0, 94, -3, -3, -3, -3,
+ax_anim_terminator
+sFarfetchdAnims_3_7:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 103, 3, 0, 3, 0,
+ax_anim 4, 0, 103, 4, 0, 4, 0,
+ax_anim 1, 2, 103, -1, 0, -1, 0,
+ax_anim 1, 0, 103, -7, 0, -7, 0,
+ax_anim 2, 0, 104, -15, 0, -15, 0,
+ax_anim 2, 1, 105, -15, 1, -15, 1,
+ax_anim 2, 0, 105, -15, 0, -15, 0,
+ax_anim 2, 0, 105, -15, 1, -15, 1,
+ax_anim 2, 0, 105, -15, 0, -15, 0,
+ax_anim 2, 0, 105, -15, 1, -15, 1,
+ax_anim 2, 0, 100, -8, 0, -8, 0,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim_terminator
+sFarfetchdAnims_3_8:
+ax_anim 2, 0, 106, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 3, -3, 3, -3,
+ax_anim 4, 0, 109, 4, -4, 4, -4,
+ax_anim 1, 2, 109, -1, 1, -1, 1,
+ax_anim 1, 0, 109, -8, 8, -8, 8,
+ax_anim 2, 0, 110, -16, 17, -16, 17,
+ax_anim 2, 1, 111, -17, 16, -15, 17,
+ax_anim 2, 0, 111, -16, 17, -16, 17,
+ax_anim 2, 0, 111, -17, 16, -15, 17,
+ax_anim 2, 0, 111, -16, 17, -16, 17,
+ax_anim 2, 0, 111, -17, 16, -19, 14,
+ax_anim 2, 0, 106, -10, 10, -10, 10,
+ax_anim 2, 0, 106, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_4_1:
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_4_2:
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_4_3:
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_4_4:
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_4_5:
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_4_6:
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_4_7:
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_4_8:
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sFarfetchdAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sFarfetchdAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sFarfetchdAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sFarfetchdAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sFarfetchdAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sFarfetchdAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sFarfetchdAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 139, 0, 0, 0, 0,
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 5, 17, 5,
+ax_anim 2, 0, 164, 21, 13, 21, 13,
+ax_anim 3, 0, 165, 22, 20, 22, 20,
+ax_anim 2, 3, 166, 13, 21, 13, 21,
+ax_anim 2, 0, 167, 3, 17, 3, 17,
+ax_anim 1, 0, 168, -1, 9, -1, 9,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 18, -5, 18, -5,
+ax_anim 3, 0, 164, 22, -2, 22, -2,
+ax_anim 2, 3, 165, 18, 4, 18, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 4, 4, 4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -23, 12, -23,
+ax_anim 3, 0, 163, 21, -23, 21, -23,
+ax_anim 2, 3, 164, 22, -15, 22, -15,
+ax_anim 2, 0, 165, 18, -6, 18, -6,
+ax_anim 1, 0, 166, 10, 0, 10, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -20, -7, -20,
+ax_anim 3, 0, 162, 0, -24, 0, -24,
+ax_anim 2, 3, 163, 7, -20, 7, -20,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -23, -12, -23,
+ax_anim 3, 0, 169, -21, -23, -21, -23,
+ax_anim 2, 3, 168, -22, -15, -22, -15,
+ax_anim 2, 0, 167, -18, -6, -18, -6,
+ax_anim 1, 0, 166, -10, 0, -10, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -18, -5, -18, -5,
+ax_anim 3, 0, 168, -22, -2, -22, -2,
+ax_anim 2, 3, 167, -18, 4, -18, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 5, -17, 5,
+ax_anim 2, 0, 168, -21, 13, -21, 13,
+ax_anim 3, 0, 167, -22, 20, -22, 20,
+ax_anim 2, 3, 166, -13, 21, -13, 21,
+ax_anim 2, 0, 165, -3, 17, -3, 17,
+ax_anim 1, 0, 164, 1, 9, 1, 9,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFarfetchdAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sFarfetchdGfx1:
+.incbin "baserom.gba", 0x88E324, 0x200
+sFarfetchdSprites1:
+ax_sprite sFarfetchdGfx1, 0x200
+ax_sprite_terminator
+sFarfetchdGfx2:
+.incbin "baserom.gba", 0x88E534, 0x200
+sFarfetchdSprites2:
+ax_sprite sFarfetchdGfx2, 0x200
+ax_sprite_terminator
+sFarfetchdGfx3:
+.incbin "baserom.gba", 0x88E744, 0x200
+sFarfetchdSprites3:
+ax_sprite sFarfetchdGfx3, 0x200
+ax_sprite_terminator
+sFarfetchdGfx4:
+.incbin "baserom.gba", 0x88E954, 0x200
+sFarfetchdSprites4:
+ax_sprite sFarfetchdGfx4, 0x200
+ax_sprite_terminator
+sFarfetchdGfx5:
+.incbin "baserom.gba", 0x88EB64, 0x200
+sFarfetchdSprites5:
+ax_sprite sFarfetchdGfx5, 0x200
+ax_sprite_terminator
+sFarfetchdGfx6:
+.incbin "baserom.gba", 0x88ED74, 0x200
+sFarfetchdSprites6:
+ax_sprite sFarfetchdGfx6, 0x200
+ax_sprite_terminator
+sFarfetchdGfx7:
+.incbin "baserom.gba", 0x88EF84, 0x200
+sFarfetchdSprites7:
+ax_sprite sFarfetchdGfx7, 0x200
+ax_sprite_terminator
+sFarfetchdGfx8:
+.incbin "baserom.gba", 0x88F194, 0x200
+sFarfetchdSprites8:
+ax_sprite sFarfetchdGfx8, 0x200
+ax_sprite_terminator
+sFarfetchdGfx9:
+.incbin "baserom.gba", 0x88F3A4, 0x200
+sFarfetchdSprites9:
+ax_sprite sFarfetchdGfx9, 0x200
+ax_sprite_terminator
+sFarfetchdGfx10:
+.incbin "baserom.gba", 0x88F5B4, 0x200
+sFarfetchdSprites10:
+ax_sprite sFarfetchdGfx10, 0x200
+ax_sprite_terminator
+sFarfetchdGfx11:
+.incbin "baserom.gba", 0x88F7C4, 0x200
+sFarfetchdSprites11:
+ax_sprite sFarfetchdGfx11, 0x200
+ax_sprite_terminator
+sFarfetchdGfx12:
+.incbin "baserom.gba", 0x88F9D4, 0x200
+sFarfetchdSprites12:
+ax_sprite sFarfetchdGfx12, 0x200
+ax_sprite_terminator
+sFarfetchdGfx13:
+.incbin "baserom.gba", 0x88FBE4, 0x200
+sFarfetchdSprites13:
+ax_sprite sFarfetchdGfx13, 0x200
+ax_sprite_terminator
+sFarfetchdGfx14:
+.incbin "baserom.gba", 0x88FDF4, 0x200
+sFarfetchdSprites14:
+ax_sprite sFarfetchdGfx14, 0x200
+ax_sprite_terminator
+sFarfetchdGfx15:
+.incbin "baserom.gba", 0x890004, 0x200
+sFarfetchdSprites15:
+ax_sprite sFarfetchdGfx15, 0x200
+ax_sprite_terminator
+sFarfetchdGfx16:
+.incbin "baserom.gba", 0x890214, 0x200
+sFarfetchdSprites16:
+ax_sprite sFarfetchdGfx16, 0x200
+ax_sprite_terminator
+sFarfetchdGfx17:
+.incbin "baserom.gba", 0x890424, 0x200
+sFarfetchdSprites17:
+ax_sprite sFarfetchdGfx17, 0x200
+ax_sprite_terminator
+sFarfetchdGfx18:
+.incbin "baserom.gba", 0x890634, 0x200
+sFarfetchdSprites18:
+ax_sprite sFarfetchdGfx18, 0x200
+ax_sprite_terminator
+sFarfetchdGfx19:
+.incbin "baserom.gba", 0x890844, 0x200
+sFarfetchdSprites19:
+ax_sprite sFarfetchdGfx19, 0x200
+ax_sprite_terminator
+sFarfetchdGfx20:
+.incbin "baserom.gba", 0x890A54, 0x200
+sFarfetchdSprites20:
+ax_sprite sFarfetchdGfx20, 0x200
+ax_sprite_terminator
+sFarfetchdGfx21:
+.incbin "baserom.gba", 0x890C64, 0x200
+sFarfetchdSprites21:
+ax_sprite sFarfetchdGfx21, 0x200
+ax_sprite_terminator
+sFarfetchdGfx22:
+.incbin "baserom.gba", 0x890E74, 0x200
+sFarfetchdSprites22:
+ax_sprite sFarfetchdGfx22, 0x200
+ax_sprite_terminator
+sFarfetchdGfx23:
+.incbin "baserom.gba", 0x891084, 0x200
+sFarfetchdSprites23:
+ax_sprite sFarfetchdGfx23, 0x200
+ax_sprite_terminator
+sFarfetchdGfx24:
+.incbin "baserom.gba", 0x891294, 0x200
+sFarfetchdSprites24:
+ax_sprite sFarfetchdGfx24, 0x200
+ax_sprite_terminator
+sFarfetchdGfx25:
+.incbin "baserom.gba", 0x8914A4, 0x60
+sFarfetchdGfx25_1:
+.incbin "baserom.gba", 0x891504, 0x60
+sFarfetchdSprites25:
+ax_sprite sFarfetchdGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx26:
+.incbin "baserom.gba", 0x89158C, 0x40
+sFarfetchdSprites26:
+ax_sprite sFarfetchdGfx26, 0x40
+ax_sprite_terminator
+sFarfetchdGfx27:
+.incbin "baserom.gba", 0x8915DC, 0x20
+sFarfetchdSprites27:
+ax_sprite sFarfetchdGfx27, 0x20
+ax_sprite_terminator
+sFarfetchdGfx28:
+.incbin "baserom.gba", 0x89160C, 0x40
+sFarfetchdGfx28_1:
+.incbin "baserom.gba", 0x89164C, 0x60
+sFarfetchdGfx28_2:
+.incbin "baserom.gba", 0x8916AC, 0x60
+sFarfetchdGfx28_3:
+.incbin "baserom.gba", 0x89170C, 0x40
+sFarfetchdSprites28:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx29:
+.incbin "baserom.gba", 0x89179C, 0x60
+sFarfetchdGfx29_1:
+.incbin "baserom.gba", 0x8917FC, 0x60
+sFarfetchdSprites29:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx29_1, 0x60
+ax_sprite_terminator
+sFarfetchdGfx30:
+.incbin "baserom.gba", 0x891884, 0x80
+sFarfetchdSprites30:
+ax_sprite sFarfetchdGfx30, 0x80
+ax_sprite_terminator
+sFarfetchdGfx31:
+.incbin "baserom.gba", 0x891914, 0x20
+sFarfetchdSprites31:
+ax_sprite sFarfetchdGfx31, 0x20
+ax_sprite_terminator
+sFarfetchdGfx32:
+.incbin "baserom.gba", 0x891944, 0x20
+sFarfetchdSprites32:
+ax_sprite sFarfetchdGfx32, 0x20
+ax_sprite_terminator
+sFarfetchdGfx33:
+.incbin "baserom.gba", 0x891974, 0x40
+sFarfetchdGfx33_1:
+.incbin "baserom.gba", 0x8919B4, 0x60
+sFarfetchdGfx33_2:
+.incbin "baserom.gba", 0x891A14, 0x60
+sFarfetchdSprites33:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFarfetchdGfx34:
+.incbin "baserom.gba", 0x891AB4, 0xE0
+sFarfetchdSprites34:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx34, 0xe0
+ax_sprite_terminator
+sFarfetchdGfx35:
+.incbin "baserom.gba", 0x891BAC, 0x80
+sFarfetchdSprites35:
+ax_sprite sFarfetchdGfx35, 0x80
+ax_sprite_terminator
+sFarfetchdGfx36:
+.incbin "baserom.gba", 0x891C3C, 0x20
+sFarfetchdSprites36:
+ax_sprite sFarfetchdGfx36, 0x20
+ax_sprite_terminator
+sFarfetchdGfx37:
+.incbin "baserom.gba", 0x891C6C, 0x60
+sFarfetchdGfx37_1:
+.incbin "baserom.gba", 0x891CCC, 0x60
+sFarfetchdGfx37_2:
+.incbin "baserom.gba", 0x891D2C, 0x60
+sFarfetchdSprites37:
+ax_sprite sFarfetchdGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFarfetchdGfx38:
+.incbin "baserom.gba", 0x891DC4, 0x20
+sFarfetchdGfx38_1:
+.incbin "baserom.gba", 0x891DE4, 0x80
+sFarfetchdGfx38_2:
+.incbin "baserom.gba", 0x891E64, 0x60
+sFarfetchdGfx38_3:
+.incbin "baserom.gba", 0x891EC4, 0x60
+sFarfetchdSprites38:
+ax_sprite sFarfetchdGfx38, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFarfetchdGfx38_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx38_3, 0x60
+ax_sprite_terminator
+sFarfetchdGfx39:
+.incbin "baserom.gba", 0x891F64, 0x40
+sFarfetchdGfx39_1:
+.incbin "baserom.gba", 0x891FA4, 0x80
+sFarfetchdGfx39_2:
+.incbin "baserom.gba", 0x892024, 0x60
+sFarfetchdSprites39:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx39_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx39_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFarfetchdGfx40:
+.incbin "baserom.gba", 0x8920C4, 0x40
+sFarfetchdGfx40_1:
+.incbin "baserom.gba", 0x892104, 0x40
+sFarfetchdGfx40_2:
+.incbin "baserom.gba", 0x892144, 0x100
+sFarfetchdSprites40:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx40_2, 0x100
+ax_sprite_terminator
+sFarfetchdGfx41:
+.incbin "baserom.gba", 0x89227C, 0x40
+sFarfetchdGfx41_1:
+.incbin "baserom.gba", 0x8922BC, 0x40
+sFarfetchdGfx41_2:
+.incbin "baserom.gba", 0x8922FC, 0x40
+sFarfetchdGfx41_3:
+.incbin "baserom.gba", 0x89233C, 0x40
+sFarfetchdSprites41:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx41_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx41_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx41_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx42:
+.incbin "baserom.gba", 0x8923CC, 0x60
+sFarfetchdGfx42_1:
+.incbin "baserom.gba", 0x89242C, 0x60
+sFarfetchdGfx42_2:
+.incbin "baserom.gba", 0x89248C, 0x60
+sFarfetchdSprites42:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx42_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFarfetchdGfx43:
+.incbin "baserom.gba", 0x89252C, 0x60
+sFarfetchdGfx43_1:
+.incbin "baserom.gba", 0x89258C, 0x60
+sFarfetchdGfx43_2:
+.incbin "baserom.gba", 0x8925EC, 0x40
+sFarfetchdSprites43:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx43_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFarfetchdGfx44:
+.incbin "baserom.gba", 0x89266C, 0x40
+sFarfetchdGfx44_1:
+.incbin "baserom.gba", 0x8926AC, 0x60
+sFarfetchdGfx44_2:
+.incbin "baserom.gba", 0x89270C, 0x40
+sFarfetchdGfx44_3:
+.incbin "baserom.gba", 0x89274C, 0x20
+sFarfetchdSprites44:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx44_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sFarfetchdGfx44_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx45:
+.incbin "baserom.gba", 0x8927BC, 0x20
+sFarfetchdGfx45_1:
+.incbin "baserom.gba", 0x8927DC, 0x20
+sFarfetchdGfx45_2:
+.incbin "baserom.gba", 0x8927FC, 0x60
+sFarfetchdGfx45_3:
+.incbin "baserom.gba", 0x89285C, 0x60
+sFarfetchdSprites45:
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx45, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFarfetchdGfx45_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx45_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx46:
+.incbin "baserom.gba", 0x89290C, 0x20
+sFarfetchdGfx46_1:
+.incbin "baserom.gba", 0x89292C, 0x60
+sFarfetchdGfx46_2:
+.incbin "baserom.gba", 0x89298C, 0x60
+sFarfetchdGfx46_3:
+.incbin "baserom.gba", 0x8929EC, 0x40
+sFarfetchdSprites46:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx46, 0x20
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx46_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFarfetchdGfx47:
+.incbin "baserom.gba", 0x892A7C, 0x20
+sFarfetchdGfx47_1:
+.incbin "baserom.gba", 0x892A9C, 0x40
+sFarfetchdGfx47_2:
+.incbin "baserom.gba", 0x892ADC, 0x60
+sFarfetchdGfx47_3:
+.incbin "baserom.gba", 0x892B3C, 0x60
+sFarfetchdSprites47:
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx47, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFarfetchdGfx47_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx47_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx47_3, 0x60
+ax_sprite_terminator
+sFarfetchdGfx48:
+.incbin "baserom.gba", 0x892BE4, 0x40
+sFarfetchdGfx48_1:
+.incbin "baserom.gba", 0x892C24, 0x60
+sFarfetchdGfx48_2:
+.incbin "baserom.gba", 0x892C84, 0x60
+sFarfetchdGfx48_3:
+.incbin "baserom.gba", 0x892CE4, 0x40
+sFarfetchdSprites48:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx48_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx48_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx49:
+.incbin "baserom.gba", 0x892D74, 0x60
+sFarfetchdGfx49_1:
+.incbin "baserom.gba", 0x892DD4, 0x20
+sFarfetchdGfx49_2:
+.incbin "baserom.gba", 0x892DF4, 0x40
+sFarfetchdGfx49_3:
+.incbin "baserom.gba", 0x892E34, 0x40
+sFarfetchdSprites49:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx49, 0x60
+ax_sprite 0, 0x60
+ax_sprite sFarfetchdGfx49_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx49_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx49_3, 0x40
+ax_sprite_terminator
+sFarfetchdGfx50:
+.incbin "baserom.gba", 0x892EBC, 0x60
+sFarfetchdGfx50_1:
+.incbin "baserom.gba", 0x892F1C, 0x60
+sFarfetchdGfx50_2:
+.incbin "baserom.gba", 0x892F7C, 0x80
+sFarfetchdGfx50_3:
+.incbin "baserom.gba", 0x892FFC, 0x40
+sFarfetchdSprites50:
+ax_sprite sFarfetchdGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx50_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx50_3, 0x40
+ax_sprite_terminator
+sFarfetchdGfx51:
+.incbin "baserom.gba", 0x89307C, 0xA0
+sFarfetchdGfx51_1:
+.incbin "baserom.gba", 0x89311C, 0x20
+sFarfetchdGfx51_2:
+.incbin "baserom.gba", 0x89313C, 0x20
+sFarfetchdSprites51:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx51, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx51_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFarfetchdGfx51_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFarfetchdGfx52:
+.incbin "baserom.gba", 0x89319C, 0x40
+sFarfetchdGfx52_1:
+.incbin "baserom.gba", 0x8931DC, 0x60
+sFarfetchdGfx52_2:
+.incbin "baserom.gba", 0x89323C, 0x60
+sFarfetchdSprites52:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx52, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx52_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFarfetchdGfx53:
+.incbin "baserom.gba", 0x8932DC, 0x40
+sFarfetchdGfx53_1:
+.incbin "baserom.gba", 0x89331C, 0x60
+sFarfetchdGfx53_2:
+.incbin "baserom.gba", 0x89337C, 0x60
+sFarfetchdGfx53_3:
+.incbin "baserom.gba", 0x8933DC, 0x40
+sFarfetchdSprites53:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx53, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx53_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx53_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx53_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx54:
+.incbin "baserom.gba", 0x89346C, 0x60
+sFarfetchdGfx54_1:
+.incbin "baserom.gba", 0x8934CC, 0xA0
+sFarfetchdGfx54_2:
+.incbin "baserom.gba", 0x89356C, 0x20
+sFarfetchdSprites54:
+ax_sprite sFarfetchdGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx54_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx54_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFarfetchdGfx55:
+.incbin "baserom.gba", 0x8935C4, 0x60
+sFarfetchdGfx55_1:
+.incbin "baserom.gba", 0x893624, 0xC0
+sFarfetchdSprites55:
+ax_sprite sFarfetchdGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx55_1, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sFarfetchdGfx56:
+.incbin "baserom.gba", 0x89370C, 0x40
+sFarfetchdGfx56_1:
+.incbin "baserom.gba", 0x89374C, 0x60
+sFarfetchdGfx56_2:
+.incbin "baserom.gba", 0x8937AC, 0x40
+sFarfetchdSprites56:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx56_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx56_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFarfetchdGfx57:
+.incbin "baserom.gba", 0x89382C, 0xC0
+sFarfetchdSprites57:
+ax_sprite sFarfetchdGfx57, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFarfetchdGfx58:
+.incbin "baserom.gba", 0x893904, 0x40
+sFarfetchdGfx58_1:
+.incbin "baserom.gba", 0x893944, 0x60
+sFarfetchdGfx58_2:
+.incbin "baserom.gba", 0x8939A4, 0x60
+sFarfetchdSprites58:
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx58, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx58_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx58_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFarfetchdGfx59:
+.incbin "baserom.gba", 0x893A44, 0xA0
+sFarfetchdGfx59_1:
+.incbin "baserom.gba", 0x893AE4, 0x40
+sFarfetchdSprites59:
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx59, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx59_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sFarfetchdGfx60:
+.incbin "baserom.gba", 0x893B54, 0x40
+sFarfetchdGfx60_1:
+.incbin "baserom.gba", 0x893B94, 0x60
+sFarfetchdGfx60_2:
+.incbin "baserom.gba", 0x893BF4, 0x60
+sFarfetchdGfx60_3:
+.incbin "baserom.gba", 0x893C54, 0x40
+sFarfetchdSprites60:
+ax_sprite sFarfetchdGfx60, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFarfetchdGfx60_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFarfetchdGfx60_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFarfetchdGfx61:
+.incbin "baserom.gba", 0x893CDC, 0x200
+sFarfetchdSprites61:
+ax_sprite sFarfetchdGfx61, 0x200
+ax_sprite_terminator
+sFarfetchdGfx62:
+.incbin "baserom.gba", 0x893EEC, 0x200
+sFarfetchdSprites62:
+ax_sprite sFarfetchdGfx62, 0x200
+ax_sprite_terminator
+sFarfetchdGfx63:
+.incbin "baserom.gba", 0x8940FC, 0x200
+sFarfetchdSprites63:
+ax_sprite sFarfetchdGfx63, 0x200
+ax_sprite_terminator
+sFarfetchdGfx64:
+.incbin "baserom.gba", 0x89430C, 0x200
+sFarfetchdSprites64:
+ax_sprite sFarfetchdGfx64, 0x200
+ax_sprite_terminator
+sFarfetchdGfx65:
+.incbin "baserom.gba", 0x89451C, 0x200
+sFarfetchdSprites65:
+ax_sprite sFarfetchdGfx65, 0x200
+ax_sprite_terminator
+sFarfetchdGfx66:
+.incbin "baserom.gba", 0x89472C, 0x200
+sFarfetchdSprites66:
+ax_sprite sFarfetchdGfx66, 0x200
+ax_sprite_terminator
+sFarfetchdGfx67:
+.incbin "baserom.gba", 0x89493C, 0x200
+sFarfetchdSprites67:
+ax_sprite sFarfetchdGfx67, 0x200
+ax_sprite_terminator
+sAxPosesFarfetchd:
+.4byte sFarfetchdPose1
+.4byte sFarfetchdPose2
+.4byte sFarfetchdPose3
+.4byte sFarfetchdPose4
+.4byte sFarfetchdPose5
+.4byte sFarfetchdPose6
+.4byte sFarfetchdPose7
+.4byte sFarfetchdPose8
+.4byte sFarfetchdPose9
+.4byte sFarfetchdPose10
+.4byte sFarfetchdPose11
+.4byte sFarfetchdPose12
+.4byte sFarfetchdPose13
+.4byte sFarfetchdPose14
+.4byte sFarfetchdPose15
+.4byte sFarfetchdPose16
+.4byte sFarfetchdPose17
+.4byte sFarfetchdPose18
+.4byte sFarfetchdPose19
+.4byte sFarfetchdPose20
+.4byte sFarfetchdPose21
+.4byte sFarfetchdPose22
+.4byte sFarfetchdPose23
+.4byte sFarfetchdPose24
+.4byte sFarfetchdPose25
+.4byte sFarfetchdPose26
+.4byte sFarfetchdPose27
+.4byte sFarfetchdPose28
+.4byte sFarfetchdPose29
+.4byte sFarfetchdPose30
+.4byte sFarfetchdPose31
+.4byte sFarfetchdPose32
+.4byte sFarfetchdPose33
+.4byte sFarfetchdPose34
+.4byte sFarfetchdPose35
+.4byte sFarfetchdPose36
+.4byte sFarfetchdPose37
+.4byte sFarfetchdPose38
+.4byte sFarfetchdPose39
+.4byte sFarfetchdPose40
+.4byte sFarfetchdPose41
+.4byte sFarfetchdPose42
+.4byte sFarfetchdPose43
+.4byte sFarfetchdPose44
+.4byte sFarfetchdPose45
+.4byte sFarfetchdPose46
+.4byte sFarfetchdPose47
+.4byte sFarfetchdPose48
+.4byte sFarfetchdPose49
+.4byte sFarfetchdPose50
+.4byte sFarfetchdPose51
+.4byte sFarfetchdPose52
+.4byte sFarfetchdPose53
+.4byte sFarfetchdPose54
+.4byte sFarfetchdPose55
+.4byte sFarfetchdPose56
+.4byte sFarfetchdPose57
+.4byte sFarfetchdPose58
+.4byte sFarfetchdPose59
+.4byte sFarfetchdPose60
+.4byte sFarfetchdPose61
+.4byte sFarfetchdPose62
+.4byte sFarfetchdPose63
+.4byte sFarfetchdPose64
+.4byte sFarfetchdPose65
+.4byte sFarfetchdPose66
+.4byte sFarfetchdPose67
+.4byte sFarfetchdPose68
+.4byte sFarfetchdPose69
+.4byte sFarfetchdPose70
+.4byte sFarfetchdPose71
+.4byte sFarfetchdPose72
+.4byte sFarfetchdPose73
+.4byte sFarfetchdPose74
+.4byte sFarfetchdPose75
+.4byte sFarfetchdPose76
+.4byte sFarfetchdPose77
+.4byte sFarfetchdPose78
+.4byte sFarfetchdPose79
+.4byte sFarfetchdPose80
+.4byte sFarfetchdPose81
+.4byte sFarfetchdPose82
+.4byte sFarfetchdPose83
+.4byte sFarfetchdPose84
+.4byte sFarfetchdPose85
+.4byte sFarfetchdPose86
+.4byte sFarfetchdPose87
+.4byte sFarfetchdPose88
+.4byte sFarfetchdPose89
+.4byte sFarfetchdPose90
+.4byte sFarfetchdPose91
+.4byte sFarfetchdPose92
+.4byte sFarfetchdPose93
+.4byte sFarfetchdPose94
+.4byte sFarfetchdPose95
+.4byte sFarfetchdPose96
+.4byte sFarfetchdPose97
+.4byte sFarfetchdPose98
+.4byte sFarfetchdPose99
+.4byte sFarfetchdPose100
+.4byte sFarfetchdPose101
+.4byte sFarfetchdPose102
+.4byte sFarfetchdPose103
+.4byte sFarfetchdPose104
+.4byte sFarfetchdPose105
+.4byte sFarfetchdPose106
+.4byte sFarfetchdPose107
+.4byte sFarfetchdPose108
+.4byte sFarfetchdPose109
+.4byte sFarfetchdPose110
+.4byte sFarfetchdPose111
+.4byte sFarfetchdPose112
+.4byte sFarfetchdPose113
+.4byte sFarfetchdPose114
+.4byte sFarfetchdPose115
+.4byte sFarfetchdPose116
+.4byte sFarfetchdPose117
+.4byte sFarfetchdPose118
+.4byte sFarfetchdPose119
+.4byte sFarfetchdPose120
+.4byte sFarfetchdPose121
+.4byte sFarfetchdPose122
+.4byte sFarfetchdPose123
+.4byte sFarfetchdPose124
+.4byte sFarfetchdPose125
+.4byte sFarfetchdPose126
+.4byte sFarfetchdPose127
+.4byte sFarfetchdPose128
+.4byte sFarfetchdPose129
+.4byte sFarfetchdPose130
+.4byte sFarfetchdPose131
+.4byte sFarfetchdPose132
+.4byte sFarfetchdPose133
+.4byte sFarfetchdPose134
+.4byte sFarfetchdPose135
+.4byte sFarfetchdPose136
+.4byte sFarfetchdPose137
+.4byte sFarfetchdPose138
+.4byte sFarfetchdPose139
+.4byte sFarfetchdPose140
+.4byte sFarfetchdPose141
+.4byte sFarfetchdPose142
+.4byte sFarfetchdPose143
+.4byte sFarfetchdPose144
+.4byte sFarfetchdPose145
+.4byte sFarfetchdPose146
+.4byte sFarfetchdPose147
+.4byte sFarfetchdPose148
+.4byte sFarfetchdPose149
+.4byte sFarfetchdPose150
+.4byte sFarfetchdPose151
+.4byte sFarfetchdPose152
+.4byte sFarfetchdPose153
+.4byte sFarfetchdPose154
+.4byte sFarfetchdPose155
+.4byte sFarfetchdPose156
+.4byte sFarfetchdPose157
+.4byte sFarfetchdPose158
+.4byte sFarfetchdPose159
+.4byte sFarfetchdPose160
+.4byte sFarfetchdPose161
+.4byte sFarfetchdPose162
+.4byte sFarfetchdPose163
+.4byte sFarfetchdPose164
+.4byte sFarfetchdPose165
+.4byte sFarfetchdPose166
+.4byte sFarfetchdPose167
+.4byte sFarfetchdPose168
+.4byte sFarfetchdPose169
+.4byte sFarfetchdPose170
+.4byte sFarfetchdPose171
+.4byte sFarfetchdPose172
+.4byte sFarfetchdPose173
+.4byte sFarfetchdPose174
+.4byte sFarfetchdPose175
+.4byte sFarfetchdPose176
+.4byte sFarfetchdPose177
+.4byte sFarfetchdPose178
+.4byte sFarfetchdPose179
+.4byte sFarfetchdPose180
+.4byte sFarfetchdPose181
+.4byte sFarfetchdPose182
+.4byte sFarfetchdPose183
+.4byte sFarfetchdPose184
+.4byte sFarfetchdPose185
+.4byte sFarfetchdPose186
+.4byte sFarfetchdPose187
+.4byte sFarfetchdPose188
+.4byte sFarfetchdPose189
+.4byte sFarfetchdPose190
+.4byte sFarfetchdPose191
+.4byte sFarfetchdPose192
+.4byte sFarfetchdPose193
+.4byte sFarfetchdPose194
+.4byte sFarfetchdPose195
+.4byte sFarfetchdPose196
+.4byte sFarfetchdPose197
+.4byte sFarfetchdPose198
+.4byte sFarfetchdPose199
+.4byte sFarfetchdPose200
+.4byte sFarfetchdPose201
+.4byte sFarfetchdPose202
+.4byte sFarfetchdPose203
+.4byte sFarfetchdPose204
+.4byte sFarfetchdPose205
+.4byte sFarfetchdPose206
+.4byte sFarfetchdPose207
+.4byte sFarfetchdPose208
+.4byte sFarfetchdPose209
+.4byte sFarfetchdPose210
+.4byte sFarfetchdPose211
+.4byte sFarfetchdPose212
+.4byte sFarfetchdPose213
+.4byte sFarfetchdPose214
+.4byte sFarfetchdPose215
+.4byte sFarfetchdPose216
+.4byte sFarfetchdPose217
+.4byte sFarfetchdPose218
+sAxPositionsFarfetchd:
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -3, 	   4,   -5, 	  -1,   -4
+.2byte   -1,   -6, 	  -6,   -4, 	   3,   -4, 	  -1,   -4
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte    4,   -7, 	  -7,   -3, 	   3,   -6, 	  -1,   -4
+.2byte    4,   -7, 	  -8,   -4, 	   4,   -6, 	  -2,   -4
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    7,   -9, 	  -3,   -1, 	  -4,   -9, 	  -1,   -5
+.2byte    7,   -9, 	  -6,   -2, 	   4,   -6, 	   0,   -5
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    6,  -12, 	   2,   -2, 	  -3,   -8, 	   0,   -6
+.2byte    6,  -12, 	   1,   -2, 	  -4,   -9, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   4,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -1,  -14, 	   3,   -3, 	  -6,   -8, 	  -1,   -6
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   0,   -8, 	  -5,   -5, 	   0,   -6
+.2byte   -7,  -12, 	   0,   -8, 	  -7,   -6, 	   0,   -6
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -6,   -8, 	  -5,   -4, 	  -1,   -2, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -4, 	  -3,   -2, 	   0,   -5
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -5,   -7, 	  -6,   -4, 	   2,   -4, 	  -1,   -5
+.2byte   -5,   -7, 	  -5,   -4, 	   0,   -3, 	   0,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -3, 	   4,   -5, 	  -1,   -4
+.2byte   -1,   -6, 	  -6,   -4, 	   3,   -4, 	  -1,   -4
+.2byte    0,    0, 	  -9,  -16, 	   9,  -16, 	   0,  -13
+.2byte    3,  -10, 	  -3,   -9, 	   6,  -14, 	   0,   -6
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte    4,   -7, 	  -7,   -3, 	   3,   -6, 	  -1,   -4
+.2byte    4,   -7, 	  -8,   -4, 	   4,   -6, 	  -2,   -4
+.2byte   11,    0, 	  -2,  -17, 	 -11,   -5, 	  -1,   -9
+.2byte    4,  -10, 	  -1,   -7, 	  -3,  -14, 	  -2,   -6
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    7,   -9, 	  -3,   -1, 	  -4,   -9, 	  -1,   -5
+.2byte    7,   -9, 	  -6,   -2, 	   4,   -6, 	   0,   -5
+.2byte   11,   -5, 	  -5,  -16, 	 -10,   -3, 	  -3,  -10
+.2byte    7,  -12, 	   5,   -9, 	  -5,  -12, 	  -1,   -8
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    6,  -12, 	   2,   -2, 	  -3,   -8, 	   0,   -6
+.2byte    6,  -12, 	   1,   -2, 	  -4,   -9, 	   0,   -7
+.2byte   11,  -18, 	 -10,  -13, 	   5,    1, 	   1,  -10
+.2byte    4,  -15, 	   5,  -11, 	  -7,  -12, 	  -1,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   4,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -1,  -14, 	   3,   -3, 	  -6,   -8, 	  -1,   -6
+.2byte   -1,  -18, 	  11,   -5, 	 -13,   -5, 	  -1,   -8
+.2byte    0,  -14, 	   3,  -10, 	  -8,  -10, 	   0,   -6
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   0,   -8, 	  -5,   -5, 	   0,   -6
+.2byte   -7,  -12, 	   0,   -8, 	  -7,   -6, 	   0,   -6
+.2byte  -12,  -18, 	   9,  -13, 	  -6,    1, 	  -2,  -10
+.2byte   -7,  -12, 	  -6,  -10, 	  -2,  -12, 	  -1,   -8
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -6,   -8, 	  -5,   -4, 	  -1,   -2, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -4, 	  -3,   -2, 	   0,   -5
+.2byte  -12,   -5, 	   4,  -16, 	   9,   -3, 	   2,  -10
+.2byte   -6,  -11, 	  -6,   -9, 	   3,  -11, 	  -1,   -7
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -5,   -7, 	  -6,   -4, 	   2,   -4, 	  -1,   -5
+.2byte   -5,   -7, 	  -5,   -4, 	   0,   -3, 	   0,   -5
+.2byte  -11,    0, 	   2,  -17, 	  11,   -5, 	   1,   -9
+.2byte   -4,   -9, 	  -6,   -9, 	   5,  -14, 	  -1,   -7
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -3, 	   4,   -5, 	  -1,   -4
+.2byte   -1,   -6, 	  -6,   -4, 	   3,   -4, 	  -1,   -4
+.2byte    3,  -10, 	  -3,   -9, 	   6,  -14, 	   0,   -6
+.2byte   -4,   -6, 	  -9,  -13, 	  -1,   -1, 	   0,   -4
+.2byte   -4,   -6, 	  -9,  -13, 	  -1,   -1, 	   0,   -4
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte    4,   -7, 	  -7,   -3, 	   3,   -6, 	  -1,   -4
+.2byte    4,   -7, 	  -8,   -4, 	   4,   -6, 	  -2,   -4
+.2byte    4,  -10, 	  -1,   -7, 	  -3,  -14, 	  -2,   -6
+.2byte    3,   -5, 	  -9,  -10, 	   2,    1, 	   0,   -2
+.2byte    3,   -5, 	  -9,  -10, 	   2,    1, 	   0,   -2
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    7,   -9, 	  -3,   -1, 	  -4,   -9, 	  -1,   -5
+.2byte    7,   -9, 	  -6,   -2, 	   4,   -6, 	   0,   -5
+.2byte    7,  -12, 	   5,   -9, 	  -5,  -12, 	  -1,   -8
+.2byte    9,   -7, 	  -6,  -11, 	   8,   -2, 	   2,   -5
+.2byte    9,   -7, 	  -6,  -11, 	   8,   -2, 	   2,   -5
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    6,  -12, 	   2,   -2, 	  -3,   -8, 	   0,   -6
+.2byte    6,  -12, 	   1,   -2, 	  -4,   -9, 	   0,   -7
+.2byte    4,  -15, 	   5,  -11, 	  -7,  -12, 	  -1,   -7
+.2byte    7,  -11, 	   3,  -11, 	   5,   -6, 	   1,   -7
+.2byte    7,  -11, 	   3,  -11, 	   5,   -6, 	   1,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   4,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -1,  -14, 	   3,   -3, 	  -6,   -8, 	  -1,   -6
+.2byte    0,  -14, 	   3,  -10, 	  -8,  -10, 	   0,   -6
+.2byte    0,  -14, 	   7,  -14, 	   2,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   7,  -14, 	   2,   -7, 	  -1,   -7
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   0,   -8, 	  -5,   -5, 	   0,   -6
+.2byte   -7,  -12, 	   0,   -8, 	  -7,   -6, 	   0,   -6
+.2byte   -7,  -12, 	  -6,  -10, 	  -2,  -12, 	  -1,   -8
+.2byte   -8,  -12, 	   5,  -17, 	  -7,   -6, 	  -2,   -6
+.2byte   -8,  -12, 	   5,  -17, 	  -7,   -6, 	  -2,   -6
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -6,   -8, 	  -5,   -4, 	  -1,   -2, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -4, 	  -3,   -2, 	   0,   -5
+.2byte   -6,  -11, 	  -6,   -9, 	   3,  -11, 	  -1,   -7
+.2byte   -9,   -8, 	   2,  -16, 	  -8,   -3, 	  -1,   -6
+.2byte   -9,   -8, 	   2,  -16, 	  -8,   -3, 	  -1,   -6
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -5,   -7, 	  -6,   -4, 	   2,   -4, 	  -1,   -5
+.2byte   -5,   -7, 	  -5,   -4, 	   0,   -3, 	   0,   -5
+.2byte   -4,   -9, 	  -6,   -9, 	   5,  -14, 	  -1,   -7
+.2byte   -8,   -6, 	  -8,  -14, 	  -8,   -1, 	  -3,   -4
+.2byte   -8,   -6, 	  -8,  -14, 	  -8,   -1, 	  -3,   -4
+.2byte    3,  -10, 	  -3,   -9, 	   6,  -14, 	   0,   -6
+.2byte   -4,   -9, 	  -6,   -9, 	   5,  -14, 	  -1,   -7
+.2byte   -6,  -11, 	  -6,   -9, 	   3,  -11, 	  -1,   -7
+.2byte   -7,  -12, 	  -6,  -10, 	  -2,  -12, 	  -1,   -8
+.2byte    0,  -15, 	   3,  -11, 	  -8,  -11, 	   0,   -7
+.2byte    4,  -15, 	   5,  -11, 	  -7,  -12, 	  -1,   -7
+.2byte    7,  -12, 	   5,   -9, 	  -5,  -12, 	  -1,   -8
+.2byte    6,  -10, 	   1,   -7, 	  -1,  -14, 	   0,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte    4,   -5, 	  -8,   -2, 	   4,   -3, 	  -1,   -3
+.2byte    4,   -3, 	  -8,   -2, 	   5,   -4, 	  -2,   -3
+.2byte    0,  -16, 	  -5,  -16, 	   5,  -16, 	   0,   -8
+.2byte   -1,  -15, 	   0,  -17, 	  -4,  -15, 	   0,   -7
+.2byte   -1,  -17, 	   1,  -16, 	  -1,  -13, 	  -1,   -6
+.2byte    0,  -15, 	  -4,  -17, 	   3,  -13, 	   0,   -5
+.2byte    0,  -15, 	   5,  -16, 	  -5,  -16, 	   0,   -5
+.2byte   -1,  -15, 	   3,  -17, 	  -4,  -13, 	  -1,   -5
+.2byte    0,  -17, 	  -2,  -16, 	   0,  -13, 	   0,   -6
+.2byte    0,  -15, 	  -1,  -17, 	   3,  -15, 	  -1,   -7
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -3, 	   4,   -5, 	  -1,   -4
+.2byte   -1,   -6, 	  -6,   -4, 	   3,   -4, 	  -1,   -4
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte    4,   -7, 	  -7,   -3, 	   3,   -6, 	  -1,   -4
+.2byte    4,   -7, 	  -8,   -4, 	   4,   -6, 	  -2,   -4
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    7,   -9, 	  -3,   -1, 	  -4,   -9, 	  -1,   -5
+.2byte    7,   -9, 	  -6,   -2, 	   4,   -6, 	   0,   -5
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    6,  -12, 	   2,   -2, 	  -3,   -8, 	   0,   -6
+.2byte    6,  -12, 	   1,   -2, 	  -4,   -9, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   4,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -1,  -14, 	   3,   -3, 	  -6,   -8, 	  -1,   -6
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   0,   -8, 	  -5,   -5, 	   0,   -6
+.2byte   -7,  -12, 	   0,   -8, 	  -7,   -6, 	   0,   -6
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -6,   -8, 	  -5,   -4, 	  -1,   -2, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -4, 	  -3,   -2, 	   0,   -5
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -5,   -7, 	  -6,   -4, 	   2,   -4, 	  -1,   -5
+.2byte   -5,   -7, 	  -5,   -4, 	   0,   -3, 	   0,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -3, 	   4,   -5, 	  -1,   -4
+.2byte   -1,   -6, 	  -6,   -4, 	   3,   -4, 	  -1,   -4
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+.2byte    4,   -7, 	  -7,   -3, 	   3,   -6, 	  -1,   -4
+.2byte    4,   -7, 	  -8,   -4, 	   4,   -6, 	  -2,   -4
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    7,   -9, 	  -3,   -1, 	  -4,   -9, 	  -1,   -5
+.2byte    7,   -9, 	  -6,   -2, 	   4,   -6, 	   0,   -5
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    6,  -12, 	   2,   -2, 	  -3,   -8, 	   0,   -6
+.2byte    6,  -12, 	   1,   -2, 	  -4,   -9, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   4,   -5, 	  -8,   -5, 	  -1,   -6
+.2byte   -1,  -14, 	   3,   -3, 	  -6,   -8, 	  -1,   -6
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   0,   -8, 	  -5,   -5, 	   0,   -6
+.2byte   -7,  -12, 	   0,   -8, 	  -7,   -6, 	   0,   -6
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -6,   -8, 	  -5,   -4, 	  -1,   -2, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -4, 	  -3,   -2, 	   0,   -5
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -5,   -7, 	  -6,   -4, 	   2,   -4, 	  -1,   -5
+.2byte   -5,   -7, 	  -5,   -4, 	   0,   -3, 	   0,   -5
+.2byte    3,  -10, 	  -3,   -9, 	   6,  -14, 	   0,   -6
+.2byte   -4,   -9, 	  -6,   -9, 	   5,  -14, 	  -1,   -7
+.2byte   -6,  -11, 	  -6,   -9, 	   3,  -11, 	  -1,   -7
+.2byte   -7,  -12, 	  -6,  -10, 	  -2,  -12, 	  -1,   -8
+.2byte    0,  -15, 	   3,  -11, 	  -8,  -11, 	   0,   -7
+.2byte    4,  -15, 	   5,  -11, 	  -7,  -12, 	  -1,   -7
+.2byte    7,  -12, 	   5,   -9, 	  -5,  -12, 	  -1,   -8
+.2byte    6,  -10, 	   1,   -7, 	  -1,  -14, 	   0,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -5, 	  -1,   -5
+.2byte   -5,   -8, 	  -4,   -5, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -9, 	  -4,   -5, 	  -2,   -3, 	   0,   -6
+.2byte   -7,  -13, 	   3,   -9, 	  -6,   -6, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -5, 	  -8,   -7, 	  -1,   -7
+.2byte    6,  -13, 	   1,   -3, 	  -3,   -7, 	   0,   -7
+.2byte    7,  -10, 	  -5,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    4,   -8, 	  -9,   -5, 	   4,   -6, 	  -2,   -5
+sFarfetchdAnimTable1:
+.4byte sFarfetchdAnims_1_1
+.4byte sFarfetchdAnims_1_2
+.4byte sFarfetchdAnims_1_3
+.4byte sFarfetchdAnims_1_4
+.4byte sFarfetchdAnims_1_5
+.4byte sFarfetchdAnims_1_6
+.4byte sFarfetchdAnims_1_7
+.4byte sFarfetchdAnims_1_8
+sFarfetchdAnimTable2:
+.4byte sFarfetchdAnims_2_1
+.4byte sFarfetchdAnims_2_2
+.4byte sFarfetchdAnims_2_3
+.4byte sFarfetchdAnims_2_4
+.4byte sFarfetchdAnims_2_5
+.4byte sFarfetchdAnims_2_6
+.4byte sFarfetchdAnims_2_7
+.4byte sFarfetchdAnims_2_8
+sFarfetchdAnimTable3:
+.4byte sFarfetchdAnims_3_1
+.4byte sFarfetchdAnims_3_2
+.4byte sFarfetchdAnims_3_3
+.4byte sFarfetchdAnims_3_4
+.4byte sFarfetchdAnims_3_5
+.4byte sFarfetchdAnims_3_6
+.4byte sFarfetchdAnims_3_7
+.4byte sFarfetchdAnims_3_8
+sFarfetchdAnimTable4:
+.4byte sFarfetchdAnims_4_1
+.4byte sFarfetchdAnims_4_2
+.4byte sFarfetchdAnims_4_3
+.4byte sFarfetchdAnims_4_4
+.4byte sFarfetchdAnims_4_5
+.4byte sFarfetchdAnims_4_6
+.4byte sFarfetchdAnims_4_7
+.4byte sFarfetchdAnims_4_8
+sFarfetchdAnimTable5:
+.4byte sFarfetchdAnims_5_1
+.4byte sFarfetchdAnims_5_2
+.4byte sFarfetchdAnims_5_3
+.4byte sFarfetchdAnims_5_4
+.4byte sFarfetchdAnims_5_5
+.4byte sFarfetchdAnims_5_6
+.4byte sFarfetchdAnims_5_7
+.4byte sFarfetchdAnims_5_8
+sFarfetchdAnimTable6:
+.4byte sFarfetchdAnims_6_1
+.4byte sFarfetchdAnims_6_1
+.4byte sFarfetchdAnims_6_1
+.4byte sFarfetchdAnims_6_1
+.4byte sFarfetchdAnims_6_1
+.4byte sFarfetchdAnims_6_1
+.4byte sFarfetchdAnims_6_1
+.4byte sFarfetchdAnims_6_1
+sFarfetchdAnimTable7:
+.4byte sFarfetchdAnims_7_1
+.4byte sFarfetchdAnims_7_2
+.4byte sFarfetchdAnims_7_3
+.4byte sFarfetchdAnims_7_4
+.4byte sFarfetchdAnims_7_5
+.4byte sFarfetchdAnims_7_6
+.4byte sFarfetchdAnims_7_7
+.4byte sFarfetchdAnims_7_8
+sFarfetchdAnimTable8:
+.4byte sFarfetchdAnims_8_1
+.4byte sFarfetchdAnims_8_2
+.4byte sFarfetchdAnims_8_3
+.4byte sFarfetchdAnims_8_4
+.4byte sFarfetchdAnims_8_5
+.4byte sFarfetchdAnims_8_6
+.4byte sFarfetchdAnims_8_7
+.4byte sFarfetchdAnims_8_8
+sFarfetchdAnimTable9:
+.4byte sFarfetchdAnims_9_1
+.4byte sFarfetchdAnims_9_2
+.4byte sFarfetchdAnims_9_3
+.4byte sFarfetchdAnims_9_4
+.4byte sFarfetchdAnims_9_5
+.4byte sFarfetchdAnims_9_6
+.4byte sFarfetchdAnims_9_7
+.4byte sFarfetchdAnims_9_8
+sFarfetchdAnimTable10:
+.4byte sFarfetchdAnims_10_1
+.4byte sFarfetchdAnims_10_2
+.4byte sFarfetchdAnims_10_3
+.4byte sFarfetchdAnims_10_4
+.4byte sFarfetchdAnims_10_5
+.4byte sFarfetchdAnims_10_6
+.4byte sFarfetchdAnims_10_7
+.4byte sFarfetchdAnims_10_8
+sFarfetchdAnimTable11:
+.4byte sFarfetchdAnims_11_1
+.4byte sFarfetchdAnims_11_2
+.4byte sFarfetchdAnims_11_3
+.4byte sFarfetchdAnims_11_4
+.4byte sFarfetchdAnims_11_5
+.4byte sFarfetchdAnims_11_6
+.4byte sFarfetchdAnims_11_7
+.4byte sFarfetchdAnims_11_8
+sFarfetchdAnimTable12:
+.4byte sFarfetchdAnims_12_1
+.4byte sFarfetchdAnims_12_2
+.4byte sFarfetchdAnims_12_3
+.4byte sFarfetchdAnims_12_4
+.4byte sFarfetchdAnims_12_5
+.4byte sFarfetchdAnims_12_6
+.4byte sFarfetchdAnims_12_7
+.4byte sFarfetchdAnims_12_8
+sFarfetchdAnimTable13:
+.4byte sFarfetchdAnims_13_1
+.4byte sFarfetchdAnims_13_2
+.4byte sFarfetchdAnims_13_3
+.4byte sFarfetchdAnims_13_4
+.4byte sFarfetchdAnims_13_5
+.4byte sFarfetchdAnims_13_6
+.4byte sFarfetchdAnims_13_7
+.4byte sFarfetchdAnims_13_8
+sAxAnimationsFarfetchd:
+.4byte sFarfetchdAnimTable1
+.4byte sFarfetchdAnimTable2
+.4byte sFarfetchdAnimTable3
+.4byte sFarfetchdAnimTable4
+.4byte sFarfetchdAnimTable5
+.4byte sFarfetchdAnimTable6
+.4byte sFarfetchdAnimTable7
+.4byte sFarfetchdAnimTable8
+.4byte sFarfetchdAnimTable9
+.4byte sFarfetchdAnimTable10
+.4byte sFarfetchdAnimTable11
+.4byte sFarfetchdAnimTable12
+.4byte sFarfetchdAnimTable13
+sAxSpritesFarfetchd:
+.4byte sFarfetchdSprites1
+.4byte sFarfetchdSprites2
+.4byte sFarfetchdSprites3
+.4byte sFarfetchdSprites4
+.4byte sFarfetchdSprites5
+.4byte sFarfetchdSprites6
+.4byte sFarfetchdSprites7
+.4byte sFarfetchdSprites8
+.4byte sFarfetchdSprites9
+.4byte sFarfetchdSprites10
+.4byte sFarfetchdSprites11
+.4byte sFarfetchdSprites12
+.4byte sFarfetchdSprites13
+.4byte sFarfetchdSprites14
+.4byte sFarfetchdSprites15
+.4byte sFarfetchdSprites16
+.4byte sFarfetchdSprites17
+.4byte sFarfetchdSprites18
+.4byte sFarfetchdSprites19
+.4byte sFarfetchdSprites20
+.4byte sFarfetchdSprites21
+.4byte sFarfetchdSprites22
+.4byte sFarfetchdSprites23
+.4byte sFarfetchdSprites24
+.4byte sFarfetchdSprites25
+.4byte sFarfetchdSprites26
+.4byte sFarfetchdSprites27
+.4byte sFarfetchdSprites28
+.4byte sFarfetchdSprites29
+.4byte sFarfetchdSprites30
+.4byte sFarfetchdSprites31
+.4byte sFarfetchdSprites32
+.4byte sFarfetchdSprites33
+.4byte sFarfetchdSprites34
+.4byte sFarfetchdSprites35
+.4byte sFarfetchdSprites36
+.4byte sFarfetchdSprites37
+.4byte sFarfetchdSprites38
+.4byte sFarfetchdSprites39
+.4byte sFarfetchdSprites40
+.4byte sFarfetchdSprites41
+.4byte sFarfetchdSprites42
+.4byte sFarfetchdSprites43
+.4byte sFarfetchdSprites44
+.4byte sFarfetchdSprites45
+.4byte sFarfetchdSprites46
+.4byte sFarfetchdSprites47
+.4byte sFarfetchdSprites48
+.4byte sFarfetchdSprites49
+.4byte sFarfetchdSprites50
+.4byte sFarfetchdSprites51
+.4byte sFarfetchdSprites52
+.4byte sFarfetchdSprites53
+.4byte sFarfetchdSprites54
+.4byte sFarfetchdSprites55
+.4byte sFarfetchdSprites56
+.4byte sFarfetchdSprites57
+.4byte sFarfetchdSprites58
+.4byte sFarfetchdSprites59
+.4byte sFarfetchdSprites60
+.4byte sFarfetchdSprites61
+.4byte sFarfetchdSprites62
+.4byte sFarfetchdSprites63
+.4byte sFarfetchdSprites64
+.4byte sFarfetchdSprites65
+.4byte sFarfetchdSprites66
+.4byte sFarfetchdSprites67
+sAxMainFarfetchd:
+ax_main sAxPosesFarfetchd, sAxAnimationsFarfetchd, 13, sAxSpritesFarfetchd, sAxPositionsFarfetchd

--- a/data/ax/fearow.inc
+++ b/data/ax/fearow.inc
@@ -1,0 +1,2937 @@
+.global gAxFearow
+gAxFearow:
+ax_siro sAxMainFearow
+sFearowPose1:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose2:
+ax_pose 1, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose3:
+ax_pose 2, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose4:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose5:
+ax_pose 4, 0x01de, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose6:
+ax_pose 5, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose7:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose8:
+ax_pose 7, 0x01df, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose9:
+ax_pose 8, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose10:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose11:
+ax_pose 10, 0x01de, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose12:
+ax_pose 11, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose13:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose14:
+ax_pose 13, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose15:
+ax_pose 14, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose16:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose17:
+ax_pose 10, 0x01de, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose18:
+ax_pose 11, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose19:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose20:
+ax_pose 7, 0x01df, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose21:
+ax_pose 8, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose22:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose23:
+ax_pose 4, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose24:
+ax_pose 5, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose25:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose26:
+ax_pose 1, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose27:
+ax_pose 2, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose28:
+ax_pose 15, 0x41e9, 0x80ee, 0x4c00
+ax_pose 16, 0x01f9, 0x40f6, 0x4c08
+ax_pose 17, 0x81e9, 0x010e, 0x4c0c
+ax_pose_terminator
+sFearowPose29:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose30:
+ax_pose 4, 0x01de, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose31:
+ax_pose 5, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose32:
+ax_pose 18, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sFearowPose33:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose34:
+ax_pose 7, 0x01df, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose35:
+ax_pose 8, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose36:
+ax_pose 19, 0x81db, 0x90f5, 0x4c00
+ax_pose 20, 0x01eb, 0x5105, 0x4c08
+ax_pose 21, 0x81eb, 0x10ed, 0x4c0c
+ax_pose_terminator
+sFearowPose37:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose38:
+ax_pose 10, 0x01de, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose39:
+ax_pose 11, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose40:
+ax_pose 22, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose41:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose42:
+ax_pose 13, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose43:
+ax_pose 14, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose44:
+ax_pose 23, 0x81df, 0x80fe, 0x4c00
+ax_pose 24, 0x81df, 0x40f6, 0x4c08
+ax_pose 25, 0x81ef, 0x00ee, 0x4c0c
+ax_pose 26, 0x81ef, 0x010e, 0x4c0e
+ax_pose_terminator
+sFearowPose45:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose46:
+ax_pose 10, 0x01de, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose47:
+ax_pose 11, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose48:
+ax_pose 22, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose49:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose50:
+ax_pose 7, 0x01df, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose51:
+ax_pose 8, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose52:
+ax_pose 19, 0x81db, 0x80fc, 0x4c00
+ax_pose 20, 0x01eb, 0x40ec, 0x4c08
+ax_pose 21, 0x81eb, 0x010c, 0x4c0c
+ax_pose_terminator
+sFearowPose53:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose54:
+ax_pose 4, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose55:
+ax_pose 5, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose56:
+ax_pose 18, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sFearowPose57:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose58:
+ax_pose 1, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose59:
+ax_pose 2, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose60:
+ax_pose 15, 0x41e9, 0x80ee, 0x4c00
+ax_pose 16, 0x01f9, 0x40f6, 0x4c08
+ax_pose 17, 0x81e9, 0x010e, 0x4c0c
+ax_pose_terminator
+sFearowPose61:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose62:
+ax_pose 4, 0x01de, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose63:
+ax_pose 5, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose64:
+ax_pose 18, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sFearowPose65:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose66:
+ax_pose 7, 0x01df, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose67:
+ax_pose 8, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose68:
+ax_pose 19, 0x81db, 0x90f5, 0x4c00
+ax_pose 20, 0x01eb, 0x5105, 0x4c08
+ax_pose 21, 0x81eb, 0x10ed, 0x4c0c
+ax_pose_terminator
+sFearowPose69:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose70:
+ax_pose 10, 0x01de, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose71:
+ax_pose 11, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose72:
+ax_pose 22, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose73:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose74:
+ax_pose 13, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose75:
+ax_pose 14, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose76:
+ax_pose 23, 0x81df, 0x80fe, 0x4c00
+ax_pose 24, 0x81df, 0x40f6, 0x4c08
+ax_pose 25, 0x81ef, 0x00ee, 0x4c0c
+ax_pose 26, 0x81ef, 0x010e, 0x4c0e
+ax_pose_terminator
+sFearowPose77:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose78:
+ax_pose 10, 0x01de, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose79:
+ax_pose 11, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose80:
+ax_pose 22, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose81:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose82:
+ax_pose 7, 0x01df, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose83:
+ax_pose 8, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose84:
+ax_pose 19, 0x81db, 0x80fc, 0x4c00
+ax_pose 20, 0x01eb, 0x40ec, 0x4c08
+ax_pose 21, 0x81eb, 0x010c, 0x4c0c
+ax_pose_terminator
+sFearowPose85:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose86:
+ax_pose 4, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose87:
+ax_pose 5, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose88:
+ax_pose 18, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sFearowPose89:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose90:
+ax_pose 1, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose91:
+ax_pose 2, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose92:
+ax_pose 27, 0x41e8, 0x80ed, 0x4c00
+ax_pose 28, 0x41f8, 0x00f5, 0x4c08
+ax_pose 29, 0x01f8, 0x0105, 0x4c0a
+ax_pose 30, 0x81e8, 0x010d, 0x4c0b
+ax_pose_terminator
+sFearowPose93:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose94:
+ax_pose 4, 0x01de, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose95:
+ax_pose 5, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose96:
+ax_pose 31, 0x41e6, 0x90f1, 0x4c00
+ax_pose 32, 0x41f6, 0x10f9, 0x4c08
+ax_pose 33, 0x81e6, 0x10e9, 0x4c0a
+ax_pose_terminator
+sFearowPose97:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose98:
+ax_pose 7, 0x01df, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose99:
+ax_pose 8, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose100:
+ax_pose 34, 0x01df, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose101:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose102:
+ax_pose 10, 0x01de, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose103:
+ax_pose 11, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose104:
+ax_pose 35, 0x01e0, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose105:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose106:
+ax_pose 13, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose107:
+ax_pose 14, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose108:
+ax_pose 36, 0x41e1, 0x80ef, 0x4c00
+ax_pose 37, 0x41f1, 0x40ef, 0x4c08
+ax_pose 38, 0x41f9, 0x00f7, 0x4c0c
+ax_pose 39, 0x01e4, 0x010f, 0x4c0e
+ax_pose 40, 0x01ec, 0x010f, 0x4c0f
+ax_pose_terminator
+sFearowPose109:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose110:
+ax_pose 10, 0x01de, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose111:
+ax_pose 11, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose112:
+ax_pose 35, 0x01e0, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose113:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose114:
+ax_pose 7, 0x01df, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose115:
+ax_pose 8, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose116:
+ax_pose 34, 0x01df, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose117:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose118:
+ax_pose 4, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose119:
+ax_pose 5, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose120:
+ax_pose 31, 0x41e6, 0x80ee, 0x4c00
+ax_pose 32, 0x41f6, 0x00f6, 0x4c08
+ax_pose 33, 0x81e6, 0x010e, 0x4c0a
+ax_pose_terminator
+sFearowPose121:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose122:
+ax_pose 1, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose123:
+ax_pose 2, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose124:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose125:
+ax_pose 4, 0x01de, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose126:
+ax_pose 5, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose127:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose128:
+ax_pose 7, 0x01df, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose129:
+ax_pose 8, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose130:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose131:
+ax_pose 10, 0x01de, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose132:
+ax_pose 11, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose133:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose134:
+ax_pose 13, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose135:
+ax_pose 14, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose136:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose137:
+ax_pose 10, 0x01de, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose138:
+ax_pose 11, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose139:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose140:
+ax_pose 7, 0x01df, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose141:
+ax_pose 8, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose142:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose143:
+ax_pose 4, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose144:
+ax_pose 5, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose145:
+ax_pose 41, 0x01f1, 0x80f3, 0x4c00
+ax_pose_terminator
+sFearowPose146:
+ax_pose 42, 0x01f1, 0x80f3, 0x4c00
+ax_pose_terminator
+sFearowPose147:
+ax_pose 43, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose148:
+ax_pose 44, 0x01df, 0x90ee, 0x4c00
+ax_pose_terminator
+sFearowPose149:
+ax_pose 45, 0x01de, 0x90f0, 0x4c00
+ax_pose_terminator
+sFearowPose150:
+ax_pose 46, 0x01dd, 0x90f4, 0x4c00
+ax_pose_terminator
+sFearowPose151:
+ax_pose 47, 0x01df, 0x80f1, 0x4c00
+ax_pose_terminator
+sFearowPose152:
+ax_pose 46, 0x01dd, 0x80ec, 0x4c00
+ax_pose_terminator
+sFearowPose153:
+ax_pose 45, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose154:
+ax_pose 44, 0x01df, 0x80f2, 0x4c00
+ax_pose_terminator
+sFearowPose155:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose156:
+ax_pose 1, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose157:
+ax_pose 2, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose158:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose159:
+ax_pose 4, 0x01de, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose160:
+ax_pose 5, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose161:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose162:
+ax_pose 7, 0x01df, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose163:
+ax_pose 8, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose164:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose165:
+ax_pose 10, 0x01de, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose166:
+ax_pose 11, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose167:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose168:
+ax_pose 13, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose169:
+ax_pose 14, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose170:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose171:
+ax_pose 10, 0x01de, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose172:
+ax_pose 11, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose173:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose174:
+ax_pose 7, 0x01df, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose175:
+ax_pose 8, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose176:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose177:
+ax_pose 4, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose178:
+ax_pose 5, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose179:
+ax_pose 27, 0x41e8, 0x80ed, 0x4c00
+ax_pose 28, 0x41f8, 0x00f5, 0x4c08
+ax_pose 29, 0x01f8, 0x0105, 0x4c0a
+ax_pose 30, 0x81e8, 0x010d, 0x4c0b
+ax_pose_terminator
+sFearowPose180:
+ax_pose 31, 0x41e6, 0x80ee, 0x4c00
+ax_pose 32, 0x41f6, 0x00f6, 0x4c08
+ax_pose 33, 0x81e6, 0x010e, 0x4c0a
+ax_pose_terminator
+sFearowPose181:
+ax_pose 34, 0x01df, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose182:
+ax_pose 35, 0x01e0, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose183:
+ax_pose 36, 0x41e1, 0x80ef, 0x4c00
+ax_pose 37, 0x41f1, 0x40ef, 0x4c08
+ax_pose 38, 0x41f9, 0x00f7, 0x4c0c
+ax_pose 39, 0x01e4, 0x010f, 0x4c0e
+ax_pose 40, 0x01ec, 0x010f, 0x4c0f
+ax_pose_terminator
+sFearowPose184:
+ax_pose 35, 0x01e0, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose185:
+ax_pose 34, 0x01df, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose186:
+ax_pose 31, 0x41e6, 0x90f1, 0x4c00
+ax_pose 32, 0x41f6, 0x10f9, 0x4c08
+ax_pose 33, 0x81e6, 0x10e9, 0x4c0a
+ax_pose_terminator
+sFearowPose187:
+ax_pose 27, 0x41e8, 0x80ed, 0x4c00
+ax_pose 28, 0x41f8, 0x00f5, 0x4c08
+ax_pose 29, 0x01f8, 0x0105, 0x4c0a
+ax_pose 30, 0x81e8, 0x010d, 0x4c0b
+ax_pose_terminator
+sFearowPose188:
+ax_pose 31, 0x41e6, 0x90f1, 0x4c00
+ax_pose 32, 0x41f6, 0x10f9, 0x4c08
+ax_pose 33, 0x81e6, 0x10e9, 0x4c0a
+ax_pose_terminator
+sFearowPose189:
+ax_pose 34, 0x01df, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose190:
+ax_pose 35, 0x01e0, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose191:
+ax_pose 36, 0x41e1, 0x80ef, 0x4c00
+ax_pose 37, 0x41f1, 0x40ef, 0x4c08
+ax_pose 38, 0x41f9, 0x00f7, 0x4c0c
+ax_pose 39, 0x01e4, 0x010f, 0x4c0e
+ax_pose 40, 0x01ec, 0x010f, 0x4c0f
+ax_pose_terminator
+sFearowPose192:
+ax_pose 35, 0x01e0, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose193:
+ax_pose 34, 0x01df, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose194:
+ax_pose 31, 0x41e6, 0x80ee, 0x4c00
+ax_pose 32, 0x41f6, 0x00f6, 0x4c08
+ax_pose 33, 0x81e6, 0x010e, 0x4c0a
+ax_pose_terminator
+sFearowPose195:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose196:
+ax_pose 2, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose197:
+ax_pose 27, 0x41e8, 0x80ed, 0x4c00
+ax_pose 28, 0x41f8, 0x00f5, 0x4c08
+ax_pose 29, 0x01f8, 0x0105, 0x4c0a
+ax_pose 30, 0x81e8, 0x010d, 0x4c0b
+ax_pose_terminator
+sFearowPose198:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose199:
+ax_pose 5, 0x01e1, 0x90ef, 0x4c00
+ax_pose_terminator
+sFearowPose200:
+ax_pose 31, 0x41e7, 0x90f2, 0x4c00
+ax_pose 32, 0x41f7, 0x10fa, 0x4c08
+ax_pose 33, 0x81e7, 0x10ea, 0x4c0a
+ax_pose_terminator
+sFearowPose201:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose202:
+ax_pose 8, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose203:
+ax_pose 34, 0x01df, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose204:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose205:
+ax_pose 11, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose206:
+ax_pose 35, 0x01e0, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose207:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose208:
+ax_pose 14, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose209:
+ax_pose 36, 0x41e1, 0x80ef, 0x4c00
+ax_pose 37, 0x41f1, 0x40ef, 0x4c08
+ax_pose 38, 0x41f9, 0x00f7, 0x4c0c
+ax_pose 39, 0x01e4, 0x010f, 0x4c0e
+ax_pose 40, 0x01ec, 0x010f, 0x4c0f
+ax_pose_terminator
+sFearowPose210:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose211:
+ax_pose 11, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose212:
+ax_pose 35, 0x01e0, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose213:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose214:
+ax_pose 8, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose215:
+ax_pose 34, 0x01df, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose216:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose217:
+ax_pose 5, 0x01e1, 0x80f2, 0x4c00
+ax_pose_terminator
+sFearowPose218:
+ax_pose 31, 0x41e7, 0x80ed, 0x4c00
+ax_pose 32, 0x41f7, 0x00f5, 0x4c08
+ax_pose 33, 0x81e7, 0x010d, 0x4c0a
+ax_pose_terminator
+sFearowPose219:
+ax_pose 1, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose220:
+ax_pose 4, 0x01de, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose221:
+ax_pose 7, 0x01df, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose222:
+ax_pose 10, 0x01de, 0x80ee, 0x4c00
+ax_pose_terminator
+sFearowPose223:
+ax_pose 13, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose224:
+ax_pose 10, 0x01de, 0x90f3, 0x4c00
+ax_pose_terminator
+sFearowPose225:
+ax_pose 7, 0x01df, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose226:
+ax_pose 4, 0x01de, 0x90f1, 0x4c00
+ax_pose_terminator
+sFearowPose227:
+ax_pose 0, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose228:
+ax_pose 3, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose229:
+ax_pose 6, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose230:
+ax_pose 9, 0x01e1, 0x80ef, 0x4c00
+ax_pose_terminator
+sFearowPose231:
+ax_pose 12, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sFearowPose232:
+ax_pose 9, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose233:
+ax_pose 6, 0x01e1, 0x90f2, 0x4c00
+ax_pose_terminator
+sFearowPose234:
+ax_pose 3, 0x01e1, 0x90f1, 0x4c00
+ax_pose_terminator
+.align 2
+sFearowAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 5, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 5, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sFearowAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 5, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 5, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sFearowAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 5, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 5, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sFearowAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 5, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 5, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sFearowAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 5, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 5, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sFearowAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 5, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 5, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sFearowAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 5, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 5, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sFearowAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 5, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 5, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -3, 0, -3,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 4, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 2, 27, 0, 2, 0, 2,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, -1, 19, -1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, -1, 19, -1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim_terminator
+sFearowAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 4, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 2, 31, 2, 2, 2, 2,
+ax_anim 1, 0, 31, 10, 11, 10, 11,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 1, 31, 15, 20, 15, 20,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 0, 31, 15, 20, 15, 20,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sFearowAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 2, 0, 32, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 2, 0, 32, -4, 0, -4, 0,
+ax_anim 4, 0, 33, -4, 0, -4, 0,
+ax_anim 1, 2, 35, 2, 2, 2, 0,
+ax_anim 1, 0, 35, 8, 5, 8, 0,
+ax_anim 2, 0, 35, 11, 6, 11, 1,
+ax_anim 2, 1, 35, 11, 5, 11, 0,
+ax_anim 2, 0, 35, 11, 6, 11, 1,
+ax_anim 2, 0, 35, 11, 5, 11, 0,
+ax_anim 2, 0, 35, 11, 6, 11, 1,
+ax_anim 2, 0, 33, 10, 3, 10, 0,
+ax_anim 2, 0, 33, 4, 1, 4, 0,
+ax_anim_terminator
+sFearowAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 2, 0, 36, -2, 2, -2, 2,
+ax_anim 2, 0, 38, -3, 3, -3, 3,
+ax_anim 2, 0, 36, -4, 4, -4, 4,
+ax_anim 4, 0, 37, -4, 4, -4, 4,
+ax_anim 1, 2, 39, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 7, -6, 7, -6,
+ax_anim 2, 0, 39, 13, -11, 13, -11,
+ax_anim 2, 1, 39, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 13, -11, 13, -11,
+ax_anim 2, 0, 39, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 13, -11, 13, -11,
+ax_anim 2, 0, 37, 7, -6, 7, -6,
+ax_anim 2, 0, 37, 4, -4, 4, -4,
+ax_anim_terminator
+sFearowAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 2, 0, 40, 0, 4, 0, 2,
+ax_anim 2, 0, 42, 0, 7, 0, 3,
+ax_anim 2, 0, 40, 0, 6, 0, 4,
+ax_anim 4, 0, 41, 0, 4, 0, 4,
+ax_anim 1, 2, 43, 0, -2, 0, -2,
+ax_anim 1, 0, 43, 0, -6, 0, -6,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 1, 43, -1, -11, -1, -11,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, -1, -11, -1, -11,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 41, 0, -6, 0, -6,
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim_terminator
+sFearowAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 2, 0, 44, 2, 2, 2, 2,
+ax_anim 2, 0, 46, 3, 3, 3, 3,
+ax_anim 2, 0, 44, 4, 4, 4, 4,
+ax_anim 4, 0, 45, 4, 4, 4, 4,
+ax_anim 1, 2, 47, -2, -2, -2, -2,
+ax_anim 1, 0, 47, -7, -6, -7, -6,
+ax_anim 2, 0, 47, -13, -11, -13, -11,
+ax_anim 2, 1, 47, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -13, -11, -13, -11,
+ax_anim 2, 0, 47, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -13, -11, -13, -11,
+ax_anim 2, 0, 45, -7, -6, -7, -6,
+ax_anim 2, 0, 45, -4, -4, -4, -4,
+ax_anim_terminator
+sFearowAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 2, 0, 48, 2, 0, 2, 0,
+ax_anim 2, 0, 50, 3, 0, 3, 0,
+ax_anim 2, 0, 48, 4, 0, 4, 0,
+ax_anim 4, 0, 49, 4, 0, 4, 0,
+ax_anim 1, 2, 51, -2, 2, -2, 0,
+ax_anim 1, 0, 51, -8, 5, -8, 0,
+ax_anim 2, 0, 51, -11, 6, -11, 1,
+ax_anim 2, 1, 51, -11, 5, -11, 0,
+ax_anim 2, 0, 51, -11, 6, -11, 1,
+ax_anim 2, 0, 51, -11, 5, -11, 0,
+ax_anim 2, 0, 51, -11, 6, -11, 1,
+ax_anim 2, 0, 49, -10, 3, -10, 0,
+ax_anim 2, 0, 49, -4, 1, -4, 0,
+ax_anim_terminator
+sFearowAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 0, 52, 2, -2, 2, -2,
+ax_anim 2, 0, 54, 3, -3, 3, -3,
+ax_anim 2, 0, 52, 4, -4, 4, -4,
+ax_anim 4, 0, 53, 4, -4, 4, -4,
+ax_anim 1, 2, 55, -2, 2, -2, 2,
+ax_anim 1, 0, 55, -10, 11, -10, 11,
+ax_anim 2, 0, 55, -16, 19, -16, 19,
+ax_anim 2, 1, 55, -15, 20, -15, 20,
+ax_anim 2, 0, 55, -16, 19, -16, 19,
+ax_anim 2, 0, 55, -15, 20, -15, 20,
+ax_anim 2, 0, 55, -16, 19, -16, 19,
+ax_anim 2, 0, 53, -10, 10, -10, 10,
+ax_anim 2, 0, 53, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sFearowAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, -3, 0, -3,
+ax_anim 2, 0, 56, 0, -4, 0, -4,
+ax_anim 4, 0, 57, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, 2, 0, 2,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 59, -1, 19, -1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, -1, 19, -1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 57, 0, 4, 0, 4,
+ax_anim_terminator
+sFearowAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 62, -3, -3, -3, -3,
+ax_anim 2, 0, 60, -4, -4, -4, -4,
+ax_anim 4, 0, 61, -4, -4, -4, -4,
+ax_anim 1, 2, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 10, 11, 10, 11,
+ax_anim 2, 0, 63, 16, 19, 16, 19,
+ax_anim 2, 1, 63, 15, 20, 15, 20,
+ax_anim 2, 0, 63, 16, 19, 16, 19,
+ax_anim 2, 0, 63, 15, 20, 15, 20,
+ax_anim 2, 0, 63, 16, 19, 16, 19,
+ax_anim 2, 0, 61, 10, 10, 10, 10,
+ax_anim 2, 0, 61, 4, 4, 4, 4,
+ax_anim_terminator
+sFearowAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 2, 0, 64, -2, 0, -2, 0,
+ax_anim 2, 0, 66, -3, 0, -3, 0,
+ax_anim 2, 0, 64, -4, 0, -4, 0,
+ax_anim 4, 0, 65, -4, 0, -4, 0,
+ax_anim 1, 2, 67, 2, 2, 2, 0,
+ax_anim 1, 0, 67, 8, 5, 8, 0,
+ax_anim 2, 0, 67, 11, 6, 11, 1,
+ax_anim 2, 1, 67, 11, 5, 11, 0,
+ax_anim 2, 0, 67, 11, 6, 11, 1,
+ax_anim 2, 0, 67, 11, 5, 11, 0,
+ax_anim 2, 0, 67, 11, 6, 11, 1,
+ax_anim 2, 0, 65, 10, 3, 10, 0,
+ax_anim 2, 0, 65, 4, 1, 4, 0,
+ax_anim_terminator
+sFearowAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 2, 0, 68, -2, 2, -2, 2,
+ax_anim 2, 0, 70, -3, 3, -3, 3,
+ax_anim 2, 0, 68, -4, 4, -4, 4,
+ax_anim 4, 0, 69, -4, 4, -4, 4,
+ax_anim 1, 2, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 7, -6, 7, -6,
+ax_anim 2, 0, 71, 13, -11, 13, -11,
+ax_anim 2, 1, 71, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 13, -11, 13, -11,
+ax_anim 2, 0, 71, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 13, -11, 13, -11,
+ax_anim 2, 0, 69, 7, -6, 7, -6,
+ax_anim 2, 0, 69, 4, -4, 4, -4,
+ax_anim_terminator
+sFearowAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 72, 0, 4, 0, 2,
+ax_anim 2, 0, 74, 0, 7, 0, 3,
+ax_anim 2, 0, 72, 0, 6, 0, 4,
+ax_anim 4, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 2, 75, 0, -2, 0, -2,
+ax_anim 1, 0, 75, 0, -6, 0, -6,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 1, 75, -1, -11, -1, -11,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, -1, -11, -1, -11,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 73, 0, -6, 0, -6,
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim_terminator
+sFearowAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 4, 0, 77, 4, 4, 4, 4,
+ax_anim 1, 2, 79, -2, -2, -2, -2,
+ax_anim 1, 0, 79, -7, -6, -7, -6,
+ax_anim 2, 0, 79, -13, -11, -13, -11,
+ax_anim 2, 1, 79, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -13, -11, -13, -11,
+ax_anim 2, 0, 79, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -13, -11, -13, -11,
+ax_anim 2, 0, 77, -7, -6, -7, -6,
+ax_anim 2, 0, 77, -4, -4, -4, -4,
+ax_anim_terminator
+sFearowAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 4, 0, 81, 4, 0, 4, 0,
+ax_anim 1, 2, 83, -2, 2, -2, 0,
+ax_anim 1, 0, 83, -8, 5, -8, 0,
+ax_anim 2, 0, 83, -11, 6, -11, 1,
+ax_anim 2, 1, 83, -11, 5, -11, 0,
+ax_anim 2, 0, 83, -11, 6, -11, 1,
+ax_anim 2, 0, 83, -11, 5, -11, 0,
+ax_anim 2, 0, 83, -11, 6, -11, 1,
+ax_anim 2, 0, 81, -10, 3, -10, 0,
+ax_anim 2, 0, 81, -4, 1, -4, 0,
+ax_anim_terminator
+sFearowAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim 2, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 84, 4, -4, 4, -4,
+ax_anim 4, 0, 85, 4, -4, 4, -4,
+ax_anim 1, 2, 87, -2, 2, -2, 2,
+ax_anim 1, 0, 87, -10, 11, -10, 11,
+ax_anim 2, 0, 87, -16, 19, -16, 19,
+ax_anim 2, 1, 87, -15, 20, -15, 20,
+ax_anim 2, 0, 87, -16, 19, -16, 19,
+ax_anim 2, 0, 87, -15, 20, -15, 20,
+ax_anim 2, 0, 87, -16, 19, -16, 19,
+ax_anim 2, 0, 85, -10, 10, -10, 10,
+ax_anim 2, 0, 85, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sFearowAnims_4_1:
+ax_anim 3, 0, 88, 0, -1, 0, 0,
+ax_anim 3, 0, 90, 0, -1, 0, 0,
+ax_anim 3, 0, 88, 0, -2, 0, 0,
+ax_anim 3, 2, 89, 0, -2, 0, 0,
+ax_anim 1, 0, 91, 0, 1, 0, 1,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 1, 4, 1, 4,
+ax_anim 2, 1, 91, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 1, 4, 1, 4,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 1, 4, 1, 4,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 1, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sFearowAnims_4_2:
+ax_anim 3, 0, 92, 0, -1, 0, 0,
+ax_anim 3, 0, 94, 0, -1, 0, 0,
+ax_anim 3, 0, 92, 0, -2, 0, 0,
+ax_anim 3, 2, 93, 0, -2, 0, 0,
+ax_anim 1, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 0, 95, 4, 4, 4, 4,
+ax_anim 2, 0, 95, 5, 3, 5, 3,
+ax_anim 2, 1, 95, 4, 4, 4, 4,
+ax_anim 2, 0, 95, 5, 3, 5, 3,
+ax_anim 2, 0, 95, 4, 4, 4, 4,
+ax_anim 2, 0, 95, 5, 3, 5, 3,
+ax_anim 2, 0, 95, 4, 4, 4, 4,
+ax_anim 1, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sFearowAnims_4_3:
+ax_anim 3, 0, 96, 0, -1, 0, 0,
+ax_anim 3, 0, 98, 0, -1, 0, 0,
+ax_anim 3, 0, 96, 0, -2, 0, 0,
+ax_anim 3, 2, 97, 0, -2, 0, 0,
+ax_anim 1, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 99, 5, 1, 5, 1,
+ax_anim 2, 1, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 99, 5, 1, 5, 1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 99, 5, 1, 5, 1,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 1, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sFearowAnims_4_4:
+ax_anim 3, 0, 100, 0, -1, 0, 0,
+ax_anim 3, 0, 102, 0, -1, 0, 0,
+ax_anim 3, 0, 100, 0, -2, 0, 0,
+ax_anim 3, 2, 101, 0, -2, 0, 0,
+ax_anim 1, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -3, 5, -3,
+ax_anim 2, 1, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -3, 5, -3,
+ax_anim 2, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -3, 5, -3,
+ax_anim 2, 0, 103, 4, -4, 4, -4,
+ax_anim 1, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sFearowAnims_4_5:
+ax_anim 3, 0, 104, 0, -1, 0, 0,
+ax_anim 3, 0, 106, 0, -1, 0, 0,
+ax_anim 3, 0, 104, 0, -2, 0, 0,
+ax_anim 3, 2, 105, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 107, -1, -5, -1, -5,
+ax_anim 2, 1, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 107, -1, -5, -1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 107, -1, -5, -1, -5,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 1, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sFearowAnims_4_6:
+ax_anim 3, 0, 108, 0, -1, 0, 0,
+ax_anim 3, 0, 110, 0, -1, 0, 0,
+ax_anim 3, 0, 108, 0, -2, 0, 0,
+ax_anim 3, 2, 109, 0, -2, 0, 0,
+ax_anim 1, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, -4, -4, -4, -4,
+ax_anim 2, 0, 111, -5, -3, -5, -3,
+ax_anim 2, 1, 111, -4, -4, -4, -4,
+ax_anim 2, 0, 111, -5, -3, -5, -3,
+ax_anim 2, 0, 111, -4, -4, -4, -4,
+ax_anim 2, 0, 111, -5, -3, -5, -3,
+ax_anim 2, 0, 111, -4, -4, -4, -4,
+ax_anim 1, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sFearowAnims_4_7:
+ax_anim 3, 0, 112, 0, -1, 0, 0,
+ax_anim 3, 0, 114, 0, -1, 0, 0,
+ax_anim 3, 0, 112, 0, -2, 0, 0,
+ax_anim 3, 2, 113, 0, -2, 0, 0,
+ax_anim 1, 0, 115, -1, 0, -1, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, 1, -5, 1,
+ax_anim 2, 1, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, 1, -5, 1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, 1, -5, 1,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 1, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sFearowAnims_4_8:
+ax_anim 3, 0, 116, 0, -1, 0, 0,
+ax_anim 3, 0, 118, 0, -1, 0, 0,
+ax_anim 3, 0, 116, 0, -2, 0, 0,
+ax_anim 3, 2, 117, 0, -2, 0, 0,
+ax_anim 1, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -5, 3, -5, 3,
+ax_anim 2, 1, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -5, 3, -5, 3,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -5, 3, -5, 3,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 1, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sFearowAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 1, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, -1, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 2, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim_terminator
+sFearowAnims_5_2:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 2, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim_terminator
+sFearowAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 1, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 126, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 2, 2, 126, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim_terminator
+sFearowAnims_5_4:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 1, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 2, 2, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim_terminator
+sFearowAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 2, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim_terminator
+sFearowAnims_5_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 2, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim_terminator
+sFearowAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 1, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, -4, 0, 0,
+ax_anim 2, 2, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, -4, 0, 0,
+ax_anim_terminator
+sFearowAnims_5_8:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 1, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -4, 0, 0,
+ax_anim 2, 2, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sFearowAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sFearowAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sFearowAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sFearowAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sFearowAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sFearowAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sFearowAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sFearowAnims_8_1:
+ax_anim 40, 0, 154, 0, 5, 0, 0,
+ax_anim 20, 0, 155, 0, 4, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 2, 0, 0,
+ax_anim_terminator
+sFearowAnims_8_2:
+ax_anim 40, 0, 157, 0, 5, 0, 0,
+ax_anim 20, 0, 158, 0, 4, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, 2, 0, 0,
+ax_anim_terminator
+sFearowAnims_8_3:
+ax_anim 40, 0, 160, 0, 8, 0, 0,
+ax_anim 20, 0, 161, 0, 7, 0, 0,
+ax_anim 4, 0, 160, 0, 3, 0, 0,
+ax_anim 4, 0, 162, 0, 2, 0, 0,
+ax_anim 4, 0, 162, 0, 1, 0, 0,
+ax_anim 4, 0, 160, 0, 1, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 3, 0, 0,
+ax_anim 4, 0, 161, 0, 5, 0, 0,
+ax_anim_terminator
+sFearowAnims_8_4:
+ax_anim 40, 0, 163, 0, 9, 0, 0,
+ax_anim 20, 0, 164, 0, 8, 0, 0,
+ax_anim 4, 0, 163, 0, 4, 0, 0,
+ax_anim 4, 0, 165, 0, 3, 0, 0,
+ax_anim 4, 0, 165, 0, 2, 0, 0,
+ax_anim 4, 0, 163, 0, 2, 0, 0,
+ax_anim 4, 0, 164, 0, 1, 0, 0,
+ax_anim 4, 0, 164, 0, 1, 0, 0,
+ax_anim 4, 0, 164, 0, 4, 0, 0,
+ax_anim 4, 0, 164, 0, 6, 0, 0,
+ax_anim_terminator
+sFearowAnims_8_5:
+ax_anim 40, 0, 166, 0, 10, 0, 0,
+ax_anim 20, 0, 167, 0, 9, 0, 0,
+ax_anim 4, 0, 166, 0, 5, 0, 0,
+ax_anim 4, 0, 168, 0, 4, 0, 0,
+ax_anim 4, 0, 168, 0, 3, 0, 0,
+ax_anim 4, 0, 166, 0, 3, 0, 0,
+ax_anim 4, 0, 167, 0, 2, 0, 0,
+ax_anim 4, 0, 167, 0, 2, 0, 0,
+ax_anim 4, 0, 167, 0, 5, 0, 0,
+ax_anim 4, 0, 167, 0, 7, 0, 0,
+ax_anim_terminator
+sFearowAnims_8_6:
+ax_anim 40, 0, 169, 0, 9, 0, 0,
+ax_anim 20, 0, 170, 0, 8, 0, 0,
+ax_anim 4, 0, 169, 0, 4, 0, 0,
+ax_anim 4, 0, 171, 0, 3, 0, 0,
+ax_anim 4, 0, 171, 0, 2, 0, 0,
+ax_anim 4, 0, 169, 0, 2, 0, 0,
+ax_anim 4, 0, 170, 0, 1, 0, 0,
+ax_anim 4, 0, 170, 0, 1, 0, 0,
+ax_anim 4, 0, 170, 0, 4, 0, 0,
+ax_anim 4, 0, 170, 0, 6, 0, 0,
+ax_anim_terminator
+sFearowAnims_8_7:
+ax_anim 40, 0, 172, 0, 8, 0, 0,
+ax_anim 20, 0, 173, 0, 7, 0, 0,
+ax_anim 4, 0, 172, 0, 3, 0, 0,
+ax_anim 4, 0, 174, 0, 2, 0, 0,
+ax_anim 4, 0, 174, 0, 1, 0, 0,
+ax_anim 4, 0, 172, 0, 1, 0, 0,
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, 3, 0, 0,
+ax_anim 4, 0, 173, 0, 5, 0, 0,
+ax_anim_terminator
+sFearowAnims_8_8:
+ax_anim 40, 0, 175, 0, 5, 0, 0,
+ax_anim 20, 0, 176, 0, 4, 0, 0,
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim 4, 0, 175, 0, -2, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 14, 8, 14,
+ax_anim 2, 0, 181, 7, 21, 7, 21,
+ax_anim 3, 0, 182, 0, 26, 0, 26,
+ax_anim 2, 3, 183, -7, 21, -7, 21,
+ax_anim 2, 0, 184, -8, 13, -8, 13,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 1, 8, 1,
+ax_anim 2, 0, 179, 18, 6, 18, 6,
+ax_anim 2, 0, 180, 24, 17, 24, 17,
+ax_anim 3, 0, 181, 20, 26, 20, 26,
+ax_anim 2, 3, 182, 11, 26, 11, 26,
+ax_anim 2, 0, 183, 3, 22, 3, 22,
+ax_anim 1, 0, 184, 0, 13, 0, 13,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 6, -4, 6, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 22, 4, 22, 4,
+ax_anim 2, 3, 181, 17, 6, 17, 6,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 4, 4, 4,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 11, -20, 11, -20,
+ax_anim 3, 0, 179, 19, -17, 19, -17,
+ax_anim 2, 3, 180, 20, -7, 20, -7,
+ax_anim 2, 0, 181, 16, -4, 16, -4,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -10, -8, -10, -8,
+ax_anim 2, 0, 185, -5, -14, -5, -14,
+ax_anim 3, 0, 178, 0, -18, 0, -18,
+ax_anim 2, 3, 179, 5, -14, 5, -14,
+ax_anim 2, 0, 180, 10, -6, 10, -6,
+ax_anim 1, 0, 181, 6, -4, 6, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -11, -20, -11, -20,
+ax_anim 3, 0, 185, -19, -17, -19, -17,
+ax_anim 2, 3, 184, -20, -7, -20, -7,
+ax_anim 2, 0, 183, -16, -4, -16, -4,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -6, -4, -6, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -4, -17, -4,
+ax_anim 3, 0, 184, -22, 4, -22, 4,
+ax_anim 2, 3, 183, -17, 6, -17, 6,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 4, -4, 4,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -18, 6, -18, 6,
+ax_anim 2, 0, 184, -24, 17, -24, 17,
+ax_anim 3, 0, 183, -20, 26, -20, 26,
+ax_anim 2, 3, 182, -11, 26, -11, 26,
+ax_anim 2, 0, 181, -3, 22, -3, 22,
+ax_anim 1, 0, 180, 0, 13, 0, 13,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -26, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 4, 0, 0,
+ax_anim_terminator
+sFearowAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 3, 0, 0,
+ax_anim_terminator
+sFearowAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 8, 0, 0,
+ax_anim_terminator
+sFearowAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -24, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 7, 0, 0,
+ax_anim_terminator
+sFearowAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 7, 0, 0,
+ax_anim_terminator
+sFearowAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -24, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 7, 0, 0,
+ax_anim_terminator
+sFearowAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 8, 0, 0,
+ax_anim_terminator
+sFearowAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFearowAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sFearowGfx1:
+.incbin "baserom.gba", 0x5F7610, 0x200
+sFearowSprites1:
+ax_sprite sFearowGfx1, 0x200
+ax_sprite_terminator
+sFearowGfx2:
+.incbin "baserom.gba", 0x5F7820, 0x200
+sFearowSprites2:
+ax_sprite sFearowGfx2, 0x200
+ax_sprite_terminator
+sFearowGfx3:
+.incbin "baserom.gba", 0x5F7A30, 0x200
+sFearowSprites3:
+ax_sprite sFearowGfx3, 0x200
+ax_sprite_terminator
+sFearowGfx4:
+.incbin "baserom.gba", 0x5F7C40, 0x200
+sFearowSprites4:
+ax_sprite sFearowGfx4, 0x200
+ax_sprite_terminator
+sFearowGfx5:
+.incbin "baserom.gba", 0x5F7E50, 0x200
+sFearowSprites5:
+ax_sprite sFearowGfx5, 0x200
+ax_sprite_terminator
+sFearowGfx6:
+.incbin "baserom.gba", 0x5F8060, 0x200
+sFearowSprites6:
+ax_sprite sFearowGfx6, 0x200
+ax_sprite_terminator
+sFearowGfx7:
+.incbin "baserom.gba", 0x5F8270, 0x200
+sFearowSprites7:
+ax_sprite sFearowGfx7, 0x200
+ax_sprite_terminator
+sFearowGfx8:
+.incbin "baserom.gba", 0x5F8480, 0x200
+sFearowSprites8:
+ax_sprite sFearowGfx8, 0x200
+ax_sprite_terminator
+sFearowGfx9:
+.incbin "baserom.gba", 0x5F8690, 0x200
+sFearowSprites9:
+ax_sprite sFearowGfx9, 0x200
+ax_sprite_terminator
+sFearowGfx10:
+.incbin "baserom.gba", 0x5F88A0, 0x200
+sFearowSprites10:
+ax_sprite sFearowGfx10, 0x200
+ax_sprite_terminator
+sFearowGfx11:
+.incbin "baserom.gba", 0x5F8AB0, 0x200
+sFearowSprites11:
+ax_sprite sFearowGfx11, 0x200
+ax_sprite_terminator
+sFearowGfx12:
+.incbin "baserom.gba", 0x5F8CC0, 0x200
+sFearowSprites12:
+ax_sprite sFearowGfx12, 0x200
+ax_sprite_terminator
+sFearowGfx13:
+.incbin "baserom.gba", 0x5F8ED0, 0x200
+sFearowSprites13:
+ax_sprite sFearowGfx13, 0x200
+ax_sprite_terminator
+sFearowGfx14:
+.incbin "baserom.gba", 0x5F90E0, 0x200
+sFearowSprites14:
+ax_sprite sFearowGfx14, 0x200
+ax_sprite_terminator
+sFearowGfx15:
+.incbin "baserom.gba", 0x5F92F0, 0x200
+sFearowSprites15:
+ax_sprite sFearowGfx15, 0x200
+ax_sprite_terminator
+sFearowGfx16:
+.incbin "baserom.gba", 0x5F9500, 0x100
+sFearowSprites16:
+ax_sprite sFearowGfx16, 0x100
+ax_sprite_terminator
+sFearowGfx17:
+.incbin "baserom.gba", 0x5F9610, 0x40
+sFearowGfx17_1:
+.incbin "baserom.gba", 0x5F9650, 0x20
+sFearowSprites17:
+ax_sprite sFearowGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFearowGfx17_1, 0x20
+ax_sprite_terminator
+sFearowGfx18:
+.incbin "baserom.gba", 0x5F9690, 0x40
+sFearowSprites18:
+ax_sprite sFearowGfx18, 0x40
+ax_sprite_terminator
+sFearowGfx19:
+.incbin "baserom.gba", 0x5F96E0, 0x40
+sFearowGfx19_1:
+.incbin "baserom.gba", 0x5F9720, 0x140
+sFearowSprites19:
+ax_sprite sFearowGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFearowGfx19_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFearowGfx20:
+.incbin "baserom.gba", 0x5F9888, 0xC0
+sFearowSprites20:
+ax_sprite 0, 0x40
+ax_sprite sFearowGfx20, 0xc0
+ax_sprite_terminator
+sFearowGfx21:
+.incbin "baserom.gba", 0x5F9960, 0x80
+sFearowSprites21:
+ax_sprite sFearowGfx21, 0x80
+ax_sprite_terminator
+sFearowGfx22:
+.incbin "baserom.gba", 0x5F99F0, 0x40
+sFearowSprites22:
+ax_sprite sFearowGfx22, 0x40
+ax_sprite_terminator
+sFearowGfx23:
+.incbin "baserom.gba", 0x5F9A40, 0x40
+sFearowGfx23_1:
+.incbin "baserom.gba", 0x5F9A80, 0x160
+sFearowSprites23:
+ax_sprite sFearowGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFearowGfx23_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFearowGfx24:
+.incbin "baserom.gba", 0x5F9C08, 0x20
+sFearowGfx24_1:
+.incbin "baserom.gba", 0x5F9C28, 0xC0
+sFearowSprites24:
+ax_sprite sFearowGfx24, 0x20
+ax_sprite 0, 0x20
+ax_sprite sFearowGfx24_1, 0xc0
+ax_sprite_terminator
+sFearowGfx25:
+.incbin "baserom.gba", 0x5F9D08, 0x60
+sFearowSprites25:
+ax_sprite 0, 0x20
+ax_sprite sFearowGfx25, 0x60
+ax_sprite_terminator
+sFearowGfx26:
+.incbin "baserom.gba", 0x5F9D80, 0x40
+sFearowSprites26:
+ax_sprite sFearowGfx26, 0x40
+ax_sprite_terminator
+sFearowGfx27:
+.incbin "baserom.gba", 0x5F9DD0, 0x40
+sFearowSprites27:
+ax_sprite sFearowGfx27, 0x40
+ax_sprite_terminator
+sFearowGfx28:
+.incbin "baserom.gba", 0x5F9E20, 0x100
+sFearowSprites28:
+ax_sprite sFearowGfx28, 0x100
+ax_sprite_terminator
+sFearowGfx29:
+.incbin "baserom.gba", 0x5F9F30, 0x40
+sFearowSprites29:
+ax_sprite sFearowGfx29, 0x40
+ax_sprite_terminator
+sFearowGfx30:
+.incbin "baserom.gba", 0x5F9F80, 0x20
+sFearowSprites30:
+ax_sprite sFearowGfx30, 0x20
+ax_sprite_terminator
+sFearowGfx31:
+.incbin "baserom.gba", 0x5F9FB0, 0x40
+sFearowSprites31:
+ax_sprite sFearowGfx31, 0x40
+ax_sprite_terminator
+sFearowGfx32:
+.incbin "baserom.gba", 0x5FA000, 0x100
+sFearowSprites32:
+ax_sprite sFearowGfx32, 0x100
+ax_sprite_terminator
+sFearowGfx33:
+.incbin "baserom.gba", 0x5FA110, 0x40
+sFearowSprites33:
+ax_sprite sFearowGfx33, 0x40
+ax_sprite_terminator
+sFearowGfx34:
+.incbin "baserom.gba", 0x5FA160, 0x40
+sFearowSprites34:
+ax_sprite sFearowGfx34, 0x40
+ax_sprite_terminator
+sFearowGfx35:
+.incbin "baserom.gba", 0x5FA1B0, 0x40
+sFearowGfx35_1:
+.incbin "baserom.gba", 0x5FA1F0, 0x60
+sFearowGfx35_2:
+.incbin "baserom.gba", 0x5FA250, 0x80
+sFearowGfx35_3:
+.incbin "baserom.gba", 0x5FA2D0, 0x40
+sFearowSprites35:
+ax_sprite sFearowGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFearowGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFearowGfx35_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sFearowGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFearowGfx36:
+.incbin "baserom.gba", 0x5FA358, 0x180
+sFearowGfx36_1:
+.incbin "baserom.gba", 0x5FA4D8, 0x60
+sFearowSprites36:
+ax_sprite sFearowGfx36, 0x180
+ax_sprite 0, 0x20
+ax_sprite sFearowGfx36_1, 0x60
+ax_sprite_terminator
+sFearowGfx37:
+.incbin "baserom.gba", 0x5FA558, 0x100
+sFearowSprites37:
+ax_sprite sFearowGfx37, 0x100
+ax_sprite_terminator
+sFearowGfx38:
+.incbin "baserom.gba", 0x5FA668, 0x80
+sFearowSprites38:
+ax_sprite sFearowGfx38, 0x80
+ax_sprite_terminator
+sFearowGfx39:
+.incbin "baserom.gba", 0x5FA6F8, 0x40
+sFearowSprites39:
+ax_sprite sFearowGfx39, 0x40
+ax_sprite_terminator
+sFearowGfx40:
+.incbin "baserom.gba", 0x5FA748, 0x20
+sFearowSprites40:
+ax_sprite sFearowGfx40, 0x20
+ax_sprite_terminator
+sFearowGfx41:
+.incbin "baserom.gba", 0x5FA778, 0x20
+sFearowSprites41:
+ax_sprite sFearowGfx41, 0x20
+ax_sprite_terminator
+sFearowGfx42:
+.incbin "baserom.gba", 0x5FA7A8, 0x200
+sFearowSprites42:
+ax_sprite sFearowGfx42, 0x200
+ax_sprite_terminator
+sFearowGfx43:
+.incbin "baserom.gba", 0x5FA9B8, 0x200
+sFearowSprites43:
+ax_sprite sFearowGfx43, 0x200
+ax_sprite_terminator
+sFearowGfx44:
+.incbin "baserom.gba", 0x5FABC8, 0x200
+sFearowSprites44:
+ax_sprite sFearowGfx44, 0x200
+ax_sprite_terminator
+sFearowGfx45:
+.incbin "baserom.gba", 0x5FADD8, 0x200
+sFearowSprites45:
+ax_sprite sFearowGfx45, 0x200
+ax_sprite_terminator
+sFearowGfx46:
+.incbin "baserom.gba", 0x5FAFE8, 0x200
+sFearowSprites46:
+ax_sprite sFearowGfx46, 0x200
+ax_sprite_terminator
+sFearowGfx47:
+.incbin "baserom.gba", 0x5FB1F8, 0x200
+sFearowSprites47:
+ax_sprite sFearowGfx47, 0x200
+ax_sprite_terminator
+sFearowGfx48:
+.incbin "baserom.gba", 0x5FB408, 0x200
+sFearowSprites48:
+ax_sprite sFearowGfx48, 0x200
+ax_sprite_terminator
+sAxPosesFearow:
+.4byte sFearowPose1
+.4byte sFearowPose2
+.4byte sFearowPose3
+.4byte sFearowPose4
+.4byte sFearowPose5
+.4byte sFearowPose6
+.4byte sFearowPose7
+.4byte sFearowPose8
+.4byte sFearowPose9
+.4byte sFearowPose10
+.4byte sFearowPose11
+.4byte sFearowPose12
+.4byte sFearowPose13
+.4byte sFearowPose14
+.4byte sFearowPose15
+.4byte sFearowPose16
+.4byte sFearowPose17
+.4byte sFearowPose18
+.4byte sFearowPose19
+.4byte sFearowPose20
+.4byte sFearowPose21
+.4byte sFearowPose22
+.4byte sFearowPose23
+.4byte sFearowPose24
+.4byte sFearowPose25
+.4byte sFearowPose26
+.4byte sFearowPose27
+.4byte sFearowPose28
+.4byte sFearowPose29
+.4byte sFearowPose30
+.4byte sFearowPose31
+.4byte sFearowPose32
+.4byte sFearowPose33
+.4byte sFearowPose34
+.4byte sFearowPose35
+.4byte sFearowPose36
+.4byte sFearowPose37
+.4byte sFearowPose38
+.4byte sFearowPose39
+.4byte sFearowPose40
+.4byte sFearowPose41
+.4byte sFearowPose42
+.4byte sFearowPose43
+.4byte sFearowPose44
+.4byte sFearowPose45
+.4byte sFearowPose46
+.4byte sFearowPose47
+.4byte sFearowPose48
+.4byte sFearowPose49
+.4byte sFearowPose50
+.4byte sFearowPose51
+.4byte sFearowPose52
+.4byte sFearowPose53
+.4byte sFearowPose54
+.4byte sFearowPose55
+.4byte sFearowPose56
+.4byte sFearowPose57
+.4byte sFearowPose58
+.4byte sFearowPose59
+.4byte sFearowPose60
+.4byte sFearowPose61
+.4byte sFearowPose62
+.4byte sFearowPose63
+.4byte sFearowPose64
+.4byte sFearowPose65
+.4byte sFearowPose66
+.4byte sFearowPose67
+.4byte sFearowPose68
+.4byte sFearowPose69
+.4byte sFearowPose70
+.4byte sFearowPose71
+.4byte sFearowPose72
+.4byte sFearowPose73
+.4byte sFearowPose74
+.4byte sFearowPose75
+.4byte sFearowPose76
+.4byte sFearowPose77
+.4byte sFearowPose78
+.4byte sFearowPose79
+.4byte sFearowPose80
+.4byte sFearowPose81
+.4byte sFearowPose82
+.4byte sFearowPose83
+.4byte sFearowPose84
+.4byte sFearowPose85
+.4byte sFearowPose86
+.4byte sFearowPose87
+.4byte sFearowPose88
+.4byte sFearowPose89
+.4byte sFearowPose90
+.4byte sFearowPose91
+.4byte sFearowPose92
+.4byte sFearowPose93
+.4byte sFearowPose94
+.4byte sFearowPose95
+.4byte sFearowPose96
+.4byte sFearowPose97
+.4byte sFearowPose98
+.4byte sFearowPose99
+.4byte sFearowPose100
+.4byte sFearowPose101
+.4byte sFearowPose102
+.4byte sFearowPose103
+.4byte sFearowPose104
+.4byte sFearowPose105
+.4byte sFearowPose106
+.4byte sFearowPose107
+.4byte sFearowPose108
+.4byte sFearowPose109
+.4byte sFearowPose110
+.4byte sFearowPose111
+.4byte sFearowPose112
+.4byte sFearowPose113
+.4byte sFearowPose114
+.4byte sFearowPose115
+.4byte sFearowPose116
+.4byte sFearowPose117
+.4byte sFearowPose118
+.4byte sFearowPose119
+.4byte sFearowPose120
+.4byte sFearowPose121
+.4byte sFearowPose122
+.4byte sFearowPose123
+.4byte sFearowPose124
+.4byte sFearowPose125
+.4byte sFearowPose126
+.4byte sFearowPose127
+.4byte sFearowPose128
+.4byte sFearowPose129
+.4byte sFearowPose130
+.4byte sFearowPose131
+.4byte sFearowPose132
+.4byte sFearowPose133
+.4byte sFearowPose134
+.4byte sFearowPose135
+.4byte sFearowPose136
+.4byte sFearowPose137
+.4byte sFearowPose138
+.4byte sFearowPose139
+.4byte sFearowPose140
+.4byte sFearowPose141
+.4byte sFearowPose142
+.4byte sFearowPose143
+.4byte sFearowPose144
+.4byte sFearowPose145
+.4byte sFearowPose146
+.4byte sFearowPose147
+.4byte sFearowPose148
+.4byte sFearowPose149
+.4byte sFearowPose150
+.4byte sFearowPose151
+.4byte sFearowPose152
+.4byte sFearowPose153
+.4byte sFearowPose154
+.4byte sFearowPose155
+.4byte sFearowPose156
+.4byte sFearowPose157
+.4byte sFearowPose158
+.4byte sFearowPose159
+.4byte sFearowPose160
+.4byte sFearowPose161
+.4byte sFearowPose162
+.4byte sFearowPose163
+.4byte sFearowPose164
+.4byte sFearowPose165
+.4byte sFearowPose166
+.4byte sFearowPose167
+.4byte sFearowPose168
+.4byte sFearowPose169
+.4byte sFearowPose170
+.4byte sFearowPose171
+.4byte sFearowPose172
+.4byte sFearowPose173
+.4byte sFearowPose174
+.4byte sFearowPose175
+.4byte sFearowPose176
+.4byte sFearowPose177
+.4byte sFearowPose178
+.4byte sFearowPose179
+.4byte sFearowPose180
+.4byte sFearowPose181
+.4byte sFearowPose182
+.4byte sFearowPose183
+.4byte sFearowPose184
+.4byte sFearowPose185
+.4byte sFearowPose186
+.4byte sFearowPose187
+.4byte sFearowPose188
+.4byte sFearowPose189
+.4byte sFearowPose190
+.4byte sFearowPose191
+.4byte sFearowPose192
+.4byte sFearowPose193
+.4byte sFearowPose194
+.4byte sFearowPose195
+.4byte sFearowPose196
+.4byte sFearowPose197
+.4byte sFearowPose198
+.4byte sFearowPose199
+.4byte sFearowPose200
+.4byte sFearowPose201
+.4byte sFearowPose202
+.4byte sFearowPose203
+.4byte sFearowPose204
+.4byte sFearowPose205
+.4byte sFearowPose206
+.4byte sFearowPose207
+.4byte sFearowPose208
+.4byte sFearowPose209
+.4byte sFearowPose210
+.4byte sFearowPose211
+.4byte sFearowPose212
+.4byte sFearowPose213
+.4byte sFearowPose214
+.4byte sFearowPose215
+.4byte sFearowPose216
+.4byte sFearowPose217
+.4byte sFearowPose218
+.4byte sFearowPose219
+.4byte sFearowPose220
+.4byte sFearowPose221
+.4byte sFearowPose222
+.4byte sFearowPose223
+.4byte sFearowPose224
+.4byte sFearowPose225
+.4byte sFearowPose226
+.4byte sFearowPose227
+.4byte sFearowPose228
+.4byte sFearowPose229
+.4byte sFearowPose230
+.4byte sFearowPose231
+.4byte sFearowPose232
+.4byte sFearowPose233
+.4byte sFearowPose234
+sAxPositionsFearow:
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte    0,   -2, 	 -11,  -29, 	  10,  -29, 	   0,  -14
+.2byte    0,   -6, 	  -3,   -1, 	   2,   -1, 	   0,  -14
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+.2byte   11,   -4, 	   7,  -32, 	  -8,  -27, 	   1,  -13
+.2byte   10,   -8, 	  13,   -5, 	   8,   -2, 	   2,  -15
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   16,  -10, 	   2,  -31, 	  -3,  -29, 	   2,  -15
+.2byte   16,  -14, 	  13,   -5, 	  11,   -3, 	   1,  -17
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   11,  -20, 	  -4,  -32, 	  16,  -22, 	   1,  -16
+.2byte   11,  -24, 	   8,  -21, 	  11,  -19, 	   1,  -18
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte    0,  -22, 	  11,  -30, 	 -11,  -30, 	   0,  -15
+.2byte    0,  -27, 	   3,  -24, 	  -3,  -24, 	   0,  -18
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte  -11,  -20, 	   4,  -32, 	 -16,  -22, 	  -1,  -16
+.2byte  -11,  -24, 	  -8,  -21, 	 -11,  -19, 	  -1,  -18
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -16,  -10, 	  -2,  -31, 	   3,  -29, 	  -2,  -15
+.2byte  -16,  -14, 	 -13,   -5, 	 -11,   -3, 	  -1,  -17
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte  -11,   -4, 	  -7,  -32, 	   8,  -27, 	  -1,  -13
+.2byte  -10,   -8, 	 -13,   -5, 	  -8,   -2, 	  -2,  -15
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte    0,   -2, 	 -11,  -29, 	  10,  -29, 	   0,  -14
+.2byte    0,   -6, 	  -3,   -1, 	   2,   -1, 	   0,  -14
+.2byte    0,    5, 	 -16,  -16, 	  15,  -16, 	   0,   -9
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+.2byte   11,   -4, 	   7,  -32, 	  -8,  -27, 	   1,  -13
+.2byte   10,   -8, 	  13,   -5, 	   8,   -2, 	   2,  -15
+.2byte   10,    1, 	  10,  -21, 	 -17,  -13, 	   0,  -12
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   16,  -10, 	   2,  -31, 	  -3,  -29, 	   2,  -15
+.2byte   16,  -14, 	  13,   -5, 	  11,   -3, 	   1,  -17
+.2byte   19,  -14, 	  -8,  -24, 	 -11,   -9, 	   2,  -15
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   11,  -20, 	  -4,  -32, 	  16,  -22, 	   1,  -16
+.2byte   11,  -24, 	   8,  -21, 	  11,  -19, 	   1,  -18
+.2byte   15,  -25, 	 -11,  -22, 	  11,   -2, 	   2,  -17
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte    0,  -22, 	  11,  -30, 	 -11,  -30, 	   0,  -15
+.2byte    0,  -27, 	   3,  -24, 	  -3,  -24, 	   0,  -18
+.2byte    0,  -26, 	  16,  -14, 	 -16,  -14, 	   0,  -15
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte  -11,  -20, 	   4,  -32, 	 -16,  -22, 	  -1,  -16
+.2byte  -11,  -24, 	  -8,  -21, 	 -11,  -19, 	  -1,  -18
+.2byte  -15,  -25, 	  11,  -22, 	 -11,   -2, 	  -2,  -17
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -16,  -10, 	  -2,  -31, 	   3,  -29, 	  -2,  -15
+.2byte  -16,  -14, 	 -13,   -5, 	 -11,   -3, 	  -1,  -17
+.2byte  -19,  -14, 	   8,  -24, 	  11,   -9, 	  -2,  -15
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte  -11,   -4, 	  -7,  -32, 	   8,  -27, 	  -1,  -13
+.2byte  -10,   -8, 	 -13,   -5, 	  -8,   -2, 	  -2,  -15
+.2byte  -12,    1, 	 -12,  -21, 	  15,  -13, 	  -2,  -12
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte    0,   -2, 	 -11,  -29, 	  10,  -29, 	   0,  -14
+.2byte    0,   -6, 	  -3,   -1, 	   2,   -1, 	   0,  -14
+.2byte    0,    5, 	 -16,  -16, 	  15,  -16, 	   0,   -9
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+.2byte   11,   -4, 	   7,  -32, 	  -8,  -27, 	   1,  -13
+.2byte   10,   -8, 	  13,   -5, 	   8,   -2, 	   2,  -15
+.2byte   10,    1, 	  10,  -21, 	 -17,  -13, 	   0,  -12
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   16,  -10, 	   2,  -31, 	  -3,  -29, 	   2,  -15
+.2byte   16,  -14, 	  13,   -5, 	  11,   -3, 	   1,  -17
+.2byte   19,  -14, 	  -8,  -24, 	 -11,   -9, 	   2,  -15
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   11,  -20, 	  -4,  -32, 	  16,  -22, 	   1,  -16
+.2byte   11,  -24, 	   8,  -21, 	  11,  -19, 	   1,  -18
+.2byte   15,  -25, 	 -11,  -22, 	  11,   -2, 	   2,  -17
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte    0,  -22, 	  11,  -30, 	 -11,  -30, 	   0,  -15
+.2byte    0,  -27, 	   3,  -24, 	  -3,  -24, 	   0,  -18
+.2byte    0,  -26, 	  16,  -14, 	 -16,  -14, 	   0,  -15
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte  -11,  -20, 	   4,  -32, 	 -16,  -22, 	  -1,  -16
+.2byte  -11,  -24, 	  -8,  -21, 	 -11,  -19, 	  -1,  -18
+.2byte  -15,  -25, 	  11,  -22, 	 -11,   -2, 	  -2,  -17
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -16,  -10, 	  -2,  -31, 	   3,  -29, 	  -2,  -15
+.2byte  -16,  -14, 	 -13,   -5, 	 -11,   -3, 	  -1,  -17
+.2byte  -19,  -14, 	   8,  -24, 	  11,   -9, 	  -2,  -15
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte  -11,   -4, 	  -7,  -32, 	   8,  -27, 	  -1,  -13
+.2byte  -10,   -8, 	 -13,   -5, 	  -8,   -2, 	  -2,  -15
+.2byte  -12,    1, 	 -12,  -21, 	  15,  -13, 	  -2,  -12
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte    0,   -2, 	 -11,  -29, 	  10,  -29, 	   0,  -14
+.2byte    0,   -6, 	  -3,   -1, 	   2,   -1, 	   0,  -14
+.2byte    0,   -9, 	 -15,  -21, 	  14,  -21, 	   0,  -12
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+.2byte   11,   -4, 	   7,  -32, 	  -8,  -27, 	   1,  -13
+.2byte   10,   -8, 	  13,   -5, 	   8,   -2, 	   2,  -15
+.2byte    4,  -11, 	  13,  -24, 	 -18,  -19, 	  -3,  -13
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   16,  -10, 	   2,  -31, 	  -3,  -29, 	   2,  -15
+.2byte   16,  -14, 	  13,   -5, 	  11,   -3, 	   1,  -17
+.2byte   11,  -19, 	   9,  -31, 	   7,  -20, 	   2,  -16
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   11,  -20, 	  -4,  -32, 	  16,  -22, 	   1,  -16
+.2byte   11,  -24, 	   8,  -21, 	  11,  -19, 	   1,  -18
+.2byte    8,  -23, 	  -1,  -31, 	  14,  -25, 	  -1,  -16
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte    0,  -22, 	  11,  -30, 	 -11,  -30, 	   0,  -15
+.2byte    0,  -27, 	   3,  -24, 	  -3,  -24, 	   0,  -18
+.2byte    0,  -28, 	  14,  -24, 	 -14,  -24, 	   0,  -15
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte  -11,  -20, 	   4,  -32, 	 -16,  -22, 	  -1,  -16
+.2byte  -11,  -24, 	  -8,  -21, 	 -11,  -19, 	  -1,  -18
+.2byte   -8,  -23, 	   1,  -31, 	 -14,  -25, 	   1,  -16
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -16,  -10, 	  -2,  -31, 	   3,  -29, 	  -2,  -15
+.2byte  -16,  -14, 	 -13,   -5, 	 -11,   -3, 	  -1,  -17
+.2byte  -11,  -19, 	  -9,  -31, 	  -7,  -20, 	  -2,  -16
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte  -11,   -4, 	  -7,  -32, 	   8,  -27, 	  -1,  -13
+.2byte  -10,   -8, 	 -13,   -5, 	  -8,   -2, 	  -2,  -15
+.2byte   -6,  -11, 	 -15,  -24, 	  16,  -19, 	   1,  -13
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte    0,   -2, 	 -11,  -29, 	  10,  -29, 	   0,  -14
+.2byte    0,   -6, 	  -3,   -1, 	   2,   -1, 	   0,  -14
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+.2byte   11,   -4, 	   7,  -32, 	  -8,  -27, 	   1,  -13
+.2byte   10,   -8, 	  13,   -5, 	   8,   -2, 	   2,  -15
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   16,  -10, 	   2,  -31, 	  -3,  -29, 	   2,  -15
+.2byte   16,  -14, 	  13,   -5, 	  11,   -3, 	   1,  -17
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   11,  -20, 	  -4,  -32, 	  16,  -22, 	   1,  -16
+.2byte   11,  -24, 	   8,  -21, 	  11,  -19, 	   1,  -18
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte    0,  -22, 	  11,  -30, 	 -11,  -30, 	   0,  -15
+.2byte    0,  -27, 	   3,  -24, 	  -3,  -24, 	   0,  -18
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte  -11,  -20, 	   4,  -32, 	 -16,  -22, 	  -1,  -16
+.2byte  -11,  -24, 	  -8,  -21, 	 -11,  -19, 	  -1,  -18
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -16,  -10, 	  -2,  -31, 	   3,  -29, 	  -2,  -15
+.2byte  -16,  -14, 	 -13,   -5, 	 -11,   -3, 	  -1,  -17
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte  -11,   -4, 	  -7,  -32, 	   8,  -27, 	  -1,  -13
+.2byte  -10,   -8, 	 -13,   -5, 	  -8,   -2, 	  -2,  -15
+.2byte  -10,    4, 	   1,  -11, 	   7,   -9, 	  -1,   -5
+.2byte  -10,    5, 	   1,  -11, 	   7,   -9, 	  -1,   -5
+.2byte    1,  -28, 	 -13,  -29, 	  12,  -28, 	  -1,  -16
+.2byte    1,  -28, 	  11,  -29, 	 -15,  -28, 	  -1,  -15
+.2byte    0,  -30, 	   5,  -27, 	   7,  -20, 	  -2,  -15
+.2byte   -1,  -28, 	  -6,  -29, 	  14,  -25, 	  -1,  -15
+.2byte    1,  -28, 	  13,  -24, 	 -13,  -25, 	   1,  -16
+.2byte    0,  -28, 	   5,  -29, 	 -15,  -25, 	   0,  -15
+.2byte   -1,  -30, 	  -6,  -27, 	  -8,  -20, 	   1,  -15
+.2byte   -2,  -28, 	 -12,  -29, 	  14,  -28, 	   0,  -15
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte    0,   -2, 	 -11,  -29, 	  10,  -29, 	   0,  -14
+.2byte    0,   -6, 	  -3,   -1, 	   2,   -1, 	   0,  -14
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+.2byte   11,   -4, 	   7,  -32, 	  -8,  -27, 	   1,  -13
+.2byte   10,   -8, 	  13,   -5, 	   8,   -2, 	   2,  -15
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   16,  -10, 	   2,  -31, 	  -3,  -29, 	   2,  -15
+.2byte   16,  -14, 	  13,   -5, 	  11,   -3, 	   1,  -17
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   11,  -20, 	  -4,  -32, 	  16,  -22, 	   1,  -16
+.2byte   11,  -24, 	   8,  -21, 	  11,  -19, 	   1,  -18
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte    0,  -22, 	  11,  -30, 	 -11,  -30, 	   0,  -15
+.2byte    0,  -27, 	   3,  -24, 	  -3,  -24, 	   0,  -18
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte  -11,  -20, 	   4,  -32, 	 -16,  -22, 	  -1,  -16
+.2byte  -11,  -24, 	  -8,  -21, 	 -11,  -19, 	  -1,  -18
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -16,  -10, 	  -2,  -31, 	   3,  -29, 	  -2,  -15
+.2byte  -16,  -14, 	 -13,   -5, 	 -11,   -3, 	  -1,  -17
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte  -11,   -4, 	  -7,  -32, 	   8,  -27, 	  -1,  -13
+.2byte  -10,   -8, 	 -13,   -5, 	  -8,   -2, 	  -2,  -15
+.2byte    0,   -9, 	 -15,  -21, 	  14,  -21, 	   0,  -12
+.2byte   -6,  -11, 	 -15,  -24, 	  16,  -19, 	   1,  -13
+.2byte  -11,  -19, 	  -9,  -31, 	  -7,  -20, 	  -2,  -16
+.2byte   -8,  -23, 	   1,  -31, 	 -14,  -25, 	   1,  -16
+.2byte    0,  -28, 	  14,  -24, 	 -14,  -24, 	   0,  -15
+.2byte    8,  -23, 	  -1,  -31, 	  14,  -25, 	  -1,  -16
+.2byte   11,  -19, 	   9,  -31, 	   7,  -20, 	   2,  -16
+.2byte    4,  -11, 	  13,  -24, 	 -18,  -19, 	  -3,  -13
+.2byte    0,   -9, 	 -15,  -21, 	  14,  -21, 	   0,  -12
+.2byte    4,  -11, 	  13,  -24, 	 -18,  -19, 	  -3,  -13
+.2byte   11,  -19, 	   9,  -31, 	   7,  -20, 	   2,  -16
+.2byte    8,  -23, 	  -1,  -31, 	  14,  -25, 	  -1,  -16
+.2byte    0,  -28, 	  14,  -24, 	 -14,  -24, 	   0,  -15
+.2byte   -8,  -23, 	   1,  -31, 	 -14,  -25, 	   1,  -16
+.2byte  -11,  -19, 	  -9,  -31, 	  -7,  -20, 	  -2,  -16
+.2byte   -6,  -11, 	 -15,  -24, 	  16,  -19, 	   1,  -13
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte    0,   -6, 	  -3,   -1, 	   2,   -1, 	   0,  -14
+.2byte    0,   -9, 	 -15,  -21, 	  14,  -21, 	   0,  -12
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+.2byte    8,   -8, 	  11,   -5, 	   6,   -2, 	   0,  -15
+.2byte    5,  -10, 	  14,  -23, 	 -17,  -18, 	  -2,  -12
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   16,  -14, 	  13,   -5, 	  11,   -3, 	   1,  -17
+.2byte   11,  -19, 	   9,  -31, 	   7,  -20, 	   2,  -16
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   10,  -24, 	   7,  -21, 	  10,  -19, 	   0,  -18
+.2byte    8,  -23, 	  -1,  -31, 	  14,  -25, 	  -1,  -16
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte    0,  -27, 	   3,  -24, 	  -3,  -24, 	   0,  -18
+.2byte    0,  -28, 	  14,  -24, 	 -14,  -24, 	   0,  -15
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte  -10,  -24, 	  -7,  -21, 	 -10,  -19, 	   0,  -18
+.2byte   -8,  -23, 	   1,  -31, 	 -14,  -25, 	   1,  -16
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -16,  -14, 	 -13,   -5, 	 -11,   -3, 	  -1,  -17
+.2byte  -11,  -19, 	  -9,  -31, 	  -7,  -20, 	  -2,  -16
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte   -8,   -8, 	 -11,   -5, 	  -6,   -2, 	   0,  -15
+.2byte   -7,  -10, 	 -16,  -23, 	  15,  -18, 	   0,  -12
+.2byte    0,   -2, 	 -11,  -29, 	  10,  -29, 	   0,  -14
+.2byte  -11,   -4, 	  -7,  -32, 	   8,  -27, 	  -1,  -13
+.2byte  -16,  -10, 	  -2,  -31, 	   3,  -29, 	  -2,  -15
+.2byte  -11,  -20, 	   4,  -32, 	 -16,  -22, 	  -1,  -16
+.2byte    0,  -22, 	  11,  -30, 	 -11,  -30, 	   0,  -15
+.2byte   11,  -20, 	  -4,  -32, 	  16,  -22, 	   1,  -16
+.2byte   16,  -10, 	   2,  -31, 	  -3,  -29, 	   2,  -15
+.2byte   11,   -4, 	   7,  -32, 	  -8,  -27, 	   1,  -13
+.2byte    0,   -4, 	 -11,   -7, 	  10,   -7, 	   0,  -15
+.2byte  -10,   -6, 	 -13,  -14, 	   2,   -3, 	   0,  -13
+.2byte  -16,  -12, 	 -12,  -19, 	  -9,   -4, 	  -1,  -16
+.2byte  -11,  -22, 	   3,  -25, 	 -15,  -13, 	   0,  -16
+.2byte    0,  -25, 	  12,  -24, 	 -12,  -24, 	   0,  -16
+.2byte   11,  -22, 	  -3,  -25, 	  15,  -13, 	   0,  -16
+.2byte   16,  -12, 	  12,  -19, 	   9,   -4, 	   1,  -16
+.2byte   10,   -6, 	  13,  -14, 	  -2,   -3, 	   0,  -13
+sFearowAnimTable1:
+.4byte sFearowAnims_1_1
+.4byte sFearowAnims_1_2
+.4byte sFearowAnims_1_3
+.4byte sFearowAnims_1_4
+.4byte sFearowAnims_1_5
+.4byte sFearowAnims_1_6
+.4byte sFearowAnims_1_7
+.4byte sFearowAnims_1_8
+sFearowAnimTable2:
+.4byte sFearowAnims_2_1
+.4byte sFearowAnims_2_2
+.4byte sFearowAnims_2_3
+.4byte sFearowAnims_2_4
+.4byte sFearowAnims_2_5
+.4byte sFearowAnims_2_6
+.4byte sFearowAnims_2_7
+.4byte sFearowAnims_2_8
+sFearowAnimTable3:
+.4byte sFearowAnims_3_1
+.4byte sFearowAnims_3_2
+.4byte sFearowAnims_3_3
+.4byte sFearowAnims_3_4
+.4byte sFearowAnims_3_5
+.4byte sFearowAnims_3_6
+.4byte sFearowAnims_3_7
+.4byte sFearowAnims_3_8
+sFearowAnimTable4:
+.4byte sFearowAnims_4_1
+.4byte sFearowAnims_4_2
+.4byte sFearowAnims_4_3
+.4byte sFearowAnims_4_4
+.4byte sFearowAnims_4_5
+.4byte sFearowAnims_4_6
+.4byte sFearowAnims_4_7
+.4byte sFearowAnims_4_8
+sFearowAnimTable5:
+.4byte sFearowAnims_5_1
+.4byte sFearowAnims_5_2
+.4byte sFearowAnims_5_3
+.4byte sFearowAnims_5_4
+.4byte sFearowAnims_5_5
+.4byte sFearowAnims_5_6
+.4byte sFearowAnims_5_7
+.4byte sFearowAnims_5_8
+sFearowAnimTable6:
+.4byte sFearowAnims_6_1
+.4byte sFearowAnims_6_1
+.4byte sFearowAnims_6_1
+.4byte sFearowAnims_6_1
+.4byte sFearowAnims_6_1
+.4byte sFearowAnims_6_1
+.4byte sFearowAnims_6_1
+.4byte sFearowAnims_6_1
+sFearowAnimTable7:
+.4byte sFearowAnims_7_1
+.4byte sFearowAnims_7_2
+.4byte sFearowAnims_7_3
+.4byte sFearowAnims_7_4
+.4byte sFearowAnims_7_5
+.4byte sFearowAnims_7_6
+.4byte sFearowAnims_7_7
+.4byte sFearowAnims_7_8
+sFearowAnimTable8:
+.4byte sFearowAnims_8_1
+.4byte sFearowAnims_8_2
+.4byte sFearowAnims_8_3
+.4byte sFearowAnims_8_4
+.4byte sFearowAnims_8_5
+.4byte sFearowAnims_8_6
+.4byte sFearowAnims_8_7
+.4byte sFearowAnims_8_8
+sFearowAnimTable9:
+.4byte sFearowAnims_9_1
+.4byte sFearowAnims_9_2
+.4byte sFearowAnims_9_3
+.4byte sFearowAnims_9_4
+.4byte sFearowAnims_9_5
+.4byte sFearowAnims_9_6
+.4byte sFearowAnims_9_7
+.4byte sFearowAnims_9_8
+sFearowAnimTable10:
+.4byte sFearowAnims_10_1
+.4byte sFearowAnims_10_2
+.4byte sFearowAnims_10_3
+.4byte sFearowAnims_10_4
+.4byte sFearowAnims_10_5
+.4byte sFearowAnims_10_6
+.4byte sFearowAnims_10_7
+.4byte sFearowAnims_10_8
+sFearowAnimTable11:
+.4byte sFearowAnims_11_1
+.4byte sFearowAnims_11_2
+.4byte sFearowAnims_11_3
+.4byte sFearowAnims_11_4
+.4byte sFearowAnims_11_5
+.4byte sFearowAnims_11_6
+.4byte sFearowAnims_11_7
+.4byte sFearowAnims_11_8
+sFearowAnimTable12:
+.4byte sFearowAnims_12_1
+.4byte sFearowAnims_12_2
+.4byte sFearowAnims_12_3
+.4byte sFearowAnims_12_4
+.4byte sFearowAnims_12_5
+.4byte sFearowAnims_12_6
+.4byte sFearowAnims_12_7
+.4byte sFearowAnims_12_8
+sFearowAnimTable13:
+.4byte sFearowAnims_13_1
+.4byte sFearowAnims_13_2
+.4byte sFearowAnims_13_3
+.4byte sFearowAnims_13_4
+.4byte sFearowAnims_13_5
+.4byte sFearowAnims_13_6
+.4byte sFearowAnims_13_7
+.4byte sFearowAnims_13_8
+sAxAnimationsFearow:
+.4byte sFearowAnimTable1
+.4byte sFearowAnimTable2
+.4byte sFearowAnimTable3
+.4byte sFearowAnimTable4
+.4byte sFearowAnimTable5
+.4byte sFearowAnimTable6
+.4byte sFearowAnimTable7
+.4byte sFearowAnimTable8
+.4byte sFearowAnimTable9
+.4byte sFearowAnimTable10
+.4byte sFearowAnimTable11
+.4byte sFearowAnimTable12
+.4byte sFearowAnimTable13
+sAxSpritesFearow:
+.4byte sFearowSprites1
+.4byte sFearowSprites2
+.4byte sFearowSprites3
+.4byte sFearowSprites4
+.4byte sFearowSprites5
+.4byte sFearowSprites6
+.4byte sFearowSprites7
+.4byte sFearowSprites8
+.4byte sFearowSprites9
+.4byte sFearowSprites10
+.4byte sFearowSprites11
+.4byte sFearowSprites12
+.4byte sFearowSprites13
+.4byte sFearowSprites14
+.4byte sFearowSprites15
+.4byte sFearowSprites16
+.4byte sFearowSprites17
+.4byte sFearowSprites18
+.4byte sFearowSprites19
+.4byte sFearowSprites20
+.4byte sFearowSprites21
+.4byte sFearowSprites22
+.4byte sFearowSprites23
+.4byte sFearowSprites24
+.4byte sFearowSprites25
+.4byte sFearowSprites26
+.4byte sFearowSprites27
+.4byte sFearowSprites28
+.4byte sFearowSprites29
+.4byte sFearowSprites30
+.4byte sFearowSprites31
+.4byte sFearowSprites32
+.4byte sFearowSprites33
+.4byte sFearowSprites34
+.4byte sFearowSprites35
+.4byte sFearowSprites36
+.4byte sFearowSprites37
+.4byte sFearowSprites38
+.4byte sFearowSprites39
+.4byte sFearowSprites40
+.4byte sFearowSprites41
+.4byte sFearowSprites42
+.4byte sFearowSprites43
+.4byte sFearowSprites44
+.4byte sFearowSprites45
+.4byte sFearowSprites46
+.4byte sFearowSprites47
+.4byte sFearowSprites48
+sAxMainFearow:
+ax_main sAxPosesFearow, sAxAnimationsFearow, 13, sAxSpritesFearow, sAxPositionsFearow

--- a/data/ax/feebas.inc
+++ b/data/ax/feebas.inc
@@ -1,0 +1,2654 @@
+.global gAxFeebas
+gAxFeebas:
+ax_siro sAxMainFeebas
+sFeebasPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose4:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose5:
+ax_pose 4, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose6:
+ax_pose 5, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose7:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose8:
+ax_pose 7, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose9:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose10:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose11:
+ax_pose 10, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose12:
+ax_pose 11, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose16:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose17:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose18:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose19:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose20:
+ax_pose 7, 0x01e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sFeebasPose21:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose22:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose23:
+ax_pose 4, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose24:
+ax_pose 5, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose26:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose27:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose28:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose29:
+ax_pose 4, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose30:
+ax_pose 5, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose31:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose32:
+ax_pose 7, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose33:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose34:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose35:
+ax_pose 10, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose36:
+ax_pose 11, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose37:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose38:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose39:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose40:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose41:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose42:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose43:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose44:
+ax_pose 7, 0x01e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sFeebasPose45:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose46:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose47:
+ax_pose 4, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose48:
+ax_pose 5, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose49:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose50:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose51:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose52:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose53:
+ax_pose 4, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose54:
+ax_pose 5, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose55:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose56:
+ax_pose 7, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose57:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose58:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose59:
+ax_pose 10, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose60:
+ax_pose 11, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose61:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose62:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose63:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose64:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose65:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose66:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose67:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose68:
+ax_pose 7, 0x01e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sFeebasPose69:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose70:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose71:
+ax_pose 4, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose72:
+ax_pose 5, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose73:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose74:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose75:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose76:
+ax_pose 15, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose77:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose78:
+ax_pose 4, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose79:
+ax_pose 5, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose80:
+ax_pose 16, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose81:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose82:
+ax_pose 7, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose83:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose84:
+ax_pose 17, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose85:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose86:
+ax_pose 10, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose87:
+ax_pose 11, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose88:
+ax_pose 18, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose89:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose90:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose91:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose92:
+ax_pose 19, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose93:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose94:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose95:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose96:
+ax_pose 18, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose97:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose98:
+ax_pose 7, 0x01e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sFeebasPose99:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose100:
+ax_pose 17, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose101:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose102:
+ax_pose 4, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose103:
+ax_pose 5, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose104:
+ax_pose 16, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose105:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose106:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose107:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose108:
+ax_pose 15, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose109:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose110:
+ax_pose 5, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose111:
+ax_pose 4, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose112:
+ax_pose 16, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose113:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose114:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose115:
+ax_pose 7, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose116:
+ax_pose 17, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose117:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose118:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose119:
+ax_pose 10, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose120:
+ax_pose 18, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose121:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose122:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose123:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose124:
+ax_pose 19, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose125:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose126:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose127:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose128:
+ax_pose 18, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose129:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose130:
+ax_pose 7, 0x01e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sFeebasPose131:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose132:
+ax_pose 17, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose133:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose134:
+ax_pose 4, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose135:
+ax_pose 5, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose136:
+ax_pose 16, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose137:
+ax_pose 20, 0x01e8, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose138:
+ax_pose 21, 0x01e8, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose139:
+ax_pose 22, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sFeebasPose140:
+ax_pose 23, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose141:
+ax_pose 24, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose142:
+ax_pose 25, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose143:
+ax_pose 26, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose144:
+ax_pose 25, 0x01e6, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose145:
+ax_pose 24, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sFeebasPose146:
+ax_pose 23, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose147:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose148:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose149:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose150:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose151:
+ax_pose 4, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose152:
+ax_pose 5, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose153:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose154:
+ax_pose 7, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose155:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose156:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose157:
+ax_pose 10, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose158:
+ax_pose 11, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose159:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose160:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose161:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose162:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose163:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose164:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose165:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose166:
+ax_pose 7, 0x01e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sFeebasPose167:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose168:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose169:
+ax_pose 4, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose170:
+ax_pose 5, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose171:
+ax_pose 15, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose172:
+ax_pose 16, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose173:
+ax_pose 17, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose174:
+ax_pose 18, 0x01e7, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose175:
+ax_pose 19, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose176:
+ax_pose 18, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose177:
+ax_pose 17, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose178:
+ax_pose 16, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose179:
+ax_pose 15, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose180:
+ax_pose 16, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose181:
+ax_pose 17, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose182:
+ax_pose 18, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose183:
+ax_pose 19, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose184:
+ax_pose 18, 0x01e7, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose185:
+ax_pose 17, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose186:
+ax_pose 16, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose187:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose188:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose189:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose190:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose191:
+ax_pose 4, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose192:
+ax_pose 5, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose193:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose194:
+ax_pose 7, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sFeebasPose195:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose196:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose197:
+ax_pose 10, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose198:
+ax_pose 11, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose199:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose200:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose201:
+ax_pose 14, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose202:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose203:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose204:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose205:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose206:
+ax_pose 7, 0x01e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sFeebasPose207:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose208:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose209:
+ax_pose 4, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose210:
+ax_pose 5, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose211:
+ax_pose 15, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose212:
+ax_pose 16, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose213:
+ax_pose 17, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose214:
+ax_pose 18, 0x01e7, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose215:
+ax_pose 19, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose216:
+ax_pose 18, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose217:
+ax_pose 17, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose218:
+ax_pose 16, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sFeebasPose219:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose220:
+ax_pose 3, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sFeebasPose221:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeebasPose222:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFeebasPose223:
+ax_pose 12, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFeebasPose224:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sFeebasPose225:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sFeebasPose226:
+ax_pose 3, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+.align 2
+sFeebasAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 10, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 10, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 10, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 10, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 10, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 10, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 10, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -3, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 10, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -1, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -3, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 10, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -1, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 22, 0, 22,
+ax_anim 2, 1, 24, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 22, 0, 22,
+ax_anim 2, 0, 24, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sFeebasAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 20, 22, 20, 22,
+ax_anim 2, 1, 27, 21, 21, 21, 21,
+ax_anim 2, 0, 27, 20, 22, 20, 22,
+ax_anim 2, 0, 27, 21, 21, 21, 21,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sFeebasAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 2, 0, 32, -2, 0, -2, 0,
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 2, 0, 32, -2, 0, -2, 0,
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sFeebasAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 2, 0, 35, -2, 2, -2, 2,
+ax_anim 2, 0, 34, -2, 2, -2, 2,
+ax_anim 2, 0, 35, -2, 2, -2, 2,
+ax_anim 2, 0, 34, -2, 2, -2, 2,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 4, -6, 4, -6,
+ax_anim 1, 0, 33, 11, -13, 11, -13,
+ax_anim 2, 0, 33, 18, -20, 18, -20,
+ax_anim 2, 1, 33, 19, -19, 19, -19,
+ax_anim 2, 0, 33, 18, -20, 18, -20,
+ax_anim 2, 0, 33, 19, -19, 19, -19,
+ax_anim 2, 0, 33, 5, -7, 5, -7,
+ax_anim_terminator
+sFeebasAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -9, 0, -9,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 1, 36, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 0, 36, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sFeebasAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 2, 0, 41, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 2, 2, 2, 2,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -4, -6, -4, -6,
+ax_anim 1, 0, 39, -11, -13, -11, -13,
+ax_anim 2, 0, 39, -18, -20, -18, -20,
+ax_anim 2, 1, 39, -19, -19, -19, -19,
+ax_anim 2, 0, 39, -18, -20, -18, -20,
+ax_anim 2, 0, 39, -19, -19, -19, -19,
+ax_anim 2, 0, 39, -5, -7, -5, -7,
+ax_anim_terminator
+sFeebasAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 2, 0, 44, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 2, 0, 2, 0,
+ax_anim 2, 0, 44, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 2, 0, 2, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sFeebasAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 2, 0, 47, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 2, -2, 2, -2,
+ax_anim 2, 0, 47, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 2, -2, 2, -2,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -20, 22, -20, 22,
+ax_anim 2, 1, 45, -21, 21, -21, 21,
+ax_anim 2, 0, 45, -20, 22, -20, 22,
+ax_anim 2, 0, 45, -21, 21, -21, 21,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sFeebasAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 22, 0, 22,
+ax_anim 2, 1, 48, 1, 22, 1, 22,
+ax_anim 2, 0, 48, 0, 22, 0, 22,
+ax_anim 2, 0, 48, 1, 22, 1, 22,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sFeebasAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 2, 0, 52, -2, -2, -2, -2,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 2, 0, 52, -2, -2, -2, -2,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 20, 22, 20, 22,
+ax_anim 2, 1, 51, 21, 21, 21, 21,
+ax_anim 2, 0, 51, 20, 22, 20, 22,
+ax_anim 2, 0, 51, 21, 21, 21, 21,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sFeebasAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 2, 0, 56, -2, 0, -2, 0,
+ax_anim 2, 0, 55, -2, 0, -2, 0,
+ax_anim 2, 0, 56, -2, 0, -2, 0,
+ax_anim 2, 0, 55, -2, 0, -2, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 1, 54, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 0, 54, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sFeebasAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 2, 0, 59, -2, 2, -2, 2,
+ax_anim 2, 0, 58, -2, 2, -2, 2,
+ax_anim 2, 0, 59, -2, 2, -2, 2,
+ax_anim 2, 0, 58, -2, 2, -2, 2,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 4, -6, 4, -6,
+ax_anim 1, 0, 57, 11, -13, 11, -13,
+ax_anim 2, 0, 57, 18, -20, 18, -20,
+ax_anim 2, 1, 57, 19, -19, 19, -19,
+ax_anim 2, 0, 57, 18, -20, 18, -20,
+ax_anim 2, 0, 57, 19, -19, 19, -19,
+ax_anim 2, 0, 57, 5, -7, 5, -7,
+ax_anim_terminator
+sFeebasAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 2, 0, 2,
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 2, 0, 2,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -9, 0, -9,
+ax_anim 2, 0, 60, 0, -19, 0, -19,
+ax_anim 2, 1, 60, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -19, 0, -19,
+ax_anim 2, 0, 60, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sFeebasAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 2, 0, 65, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 2, 2, 2, 2,
+ax_anim 2, 0, 65, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 2, 2, 2, 2,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -4, -6, -4, -6,
+ax_anim 1, 0, 63, -11, -13, -11, -13,
+ax_anim 2, 0, 63, -18, -20, -18, -20,
+ax_anim 2, 1, 63, -19, -19, -19, -19,
+ax_anim 2, 0, 63, -18, -20, -18, -20,
+ax_anim 2, 0, 63, -19, -19, -19, -19,
+ax_anim 2, 0, 63, -5, -7, -5, -7,
+ax_anim_terminator
+sFeebasAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 2, 0, 68, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 2, 0, 2, 0,
+ax_anim 2, 0, 68, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 2, 0, 2, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 1, 66, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sFeebasAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 2, -2, 2, -2,
+ax_anim 2, 0, 71, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 2, -2, 2, -2,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -20, 22, -20, 22,
+ax_anim 2, 1, 69, -21, 21, -21, 21,
+ax_anim 2, 0, 69, -20, 22, -20, 22,
+ax_anim 2, 0, 69, -21, 21, -21, 21,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sFeebasAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 74, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sFeebasAnims_4_2:
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 6, 2, 78, -3, -3, -3, -3,
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim 2, 1, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim_terminator
+sFeebasAnims_4_3:
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 6, 2, 82, -3, 0, -3, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 1, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim_terminator
+sFeebasAnims_4_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 6, 2, 86, -3, 3, -3, 3,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 1, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim_terminator
+sFeebasAnims_4_5:
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 6, 2, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 2, 1, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -2,
+ax_anim 2, 0, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -2,
+ax_anim 2, 0, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -2,
+ax_anim 2, 0, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim_terminator
+sFeebasAnims_4_6:
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 6, 2, 94, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 2, 1, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim_terminator
+sFeebasAnims_4_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 6, 2, 98, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 1, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sFeebasAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 6, 2, 102, 3, -3, 3, -3,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sFeebasAnims_5_1:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 1, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_5_2:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_5_3:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_5_5:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_5_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_5_7:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_5_8:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 1, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_6_1:
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, -1, 0, 0,
+ax_anim 16, 0, 136, 0, -2, 0, 0,
+ax_anim 16, 0, 137, 0, -2, 0, 0,
+ax_anim 12, 0, 137, 0, -1, 0, 0,
+ax_anim 16, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sFeebasAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sFeebasAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sFeebasAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sFeebasAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sFeebasAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sFeebasAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sFeebasAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sFeebasAnims_8_1:
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 147, 0, 0, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_8_2:
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_8_3:
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 153, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_8_4:
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 14, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 14, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_8_5:
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 14, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 14, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_8_6:
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 14, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 14, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_8_7:
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 14, 0, 165, 0, 0, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 14, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_8_8:
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 14, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 14, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 15, 7, 15,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -7, 15, -7, 15,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 19, 10, 19, 10,
+ax_anim 3, 0, 173, 17, 19, 17, 19,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -3, 17, -3,
+ax_anim 3, 0, 172, 18, 1, 18, 1,
+ax_anim 2, 3, 173, 17, 7, 17, 7,
+ax_anim 2, 0, 174, 12, 8, 12, 8,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -21, 12, -21,
+ax_anim 3, 0, 171, 18, -19, 18, -19,
+ax_anim 2, 3, 172, 20, -13, 20, -13,
+ax_anim 2, 0, 173, 16, -5, 16, -5,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -20, 0, -20,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -12, 9, -12,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -21, -12, -21,
+ax_anim 3, 0, 177, -18, -19, -18, -19,
+ax_anim 2, 3, 176, -20, -13, -20, -13,
+ax_anim 2, 0, 175, -16, -5, -16, -5,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -3, -17, -3,
+ax_anim 3, 0, 176, -18, -1, -18, -1,
+ax_anim 2, 3, 175, -17, 7, -17, 7,
+ax_anim 2, 0, 174, -12, 8, -12, 8,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -19, 10, -19, 10,
+ax_anim 3, 0, 175, -17, 19, -17, 19,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 3, 0, 0,
+ax_anim_terminator
+sFeebasAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 3, 0, 0,
+ax_anim_terminator
+sFeebasAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 4, 0, 0,
+ax_anim_terminator
+sFeebasAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 4, 0, 0,
+ax_anim_terminator
+sFeebasAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 4, 0, 0,
+ax_anim_terminator
+sFeebasAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 4, 0, 0,
+ax_anim_terminator
+sFeebasAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -22, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 4, 0, 0,
+ax_anim_terminator
+sFeebasAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeebasAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sFeebasGfx1:
+.incbin "baserom.gba", 0x143E068, 0x200
+sFeebasSprites1:
+ax_sprite sFeebasGfx1, 0x200
+ax_sprite_terminator
+sFeebasGfx2:
+.incbin "baserom.gba", 0x143E278, 0x200
+sFeebasSprites2:
+ax_sprite sFeebasGfx2, 0x200
+ax_sprite_terminator
+sFeebasGfx3:
+.incbin "baserom.gba", 0x143E488, 0x200
+sFeebasSprites3:
+ax_sprite sFeebasGfx3, 0x200
+ax_sprite_terminator
+sFeebasGfx4:
+.incbin "baserom.gba", 0x143E698, 0x200
+sFeebasSprites4:
+ax_sprite sFeebasGfx4, 0x200
+ax_sprite_terminator
+sFeebasGfx5:
+.incbin "baserom.gba", 0x143E8A8, 0x200
+sFeebasSprites5:
+ax_sprite sFeebasGfx5, 0x200
+ax_sprite_terminator
+sFeebasGfx6:
+.incbin "baserom.gba", 0x143EAB8, 0x200
+sFeebasSprites6:
+ax_sprite sFeebasGfx6, 0x200
+ax_sprite_terminator
+sFeebasGfx7:
+.incbin "baserom.gba", 0x143ECC8, 0x200
+sFeebasSprites7:
+ax_sprite sFeebasGfx7, 0x200
+ax_sprite_terminator
+sFeebasGfx8:
+.incbin "baserom.gba", 0x143EED8, 0x200
+sFeebasSprites8:
+ax_sprite sFeebasGfx8, 0x200
+ax_sprite_terminator
+sFeebasGfx9:
+.incbin "baserom.gba", 0x143F0E8, 0x200
+sFeebasSprites9:
+ax_sprite sFeebasGfx9, 0x200
+ax_sprite_terminator
+sFeebasGfx10:
+.incbin "baserom.gba", 0x143F2F8, 0x200
+sFeebasSprites10:
+ax_sprite sFeebasGfx10, 0x200
+ax_sprite_terminator
+sFeebasGfx11:
+.incbin "baserom.gba", 0x143F508, 0x200
+sFeebasSprites11:
+ax_sprite sFeebasGfx11, 0x200
+ax_sprite_terminator
+sFeebasGfx12:
+.incbin "baserom.gba", 0x143F718, 0x200
+sFeebasSprites12:
+ax_sprite sFeebasGfx12, 0x200
+ax_sprite_terminator
+sFeebasGfx13:
+.incbin "baserom.gba", 0x143F928, 0x200
+sFeebasSprites13:
+ax_sprite sFeebasGfx13, 0x200
+ax_sprite_terminator
+sFeebasGfx14:
+.incbin "baserom.gba", 0x143FB38, 0x200
+sFeebasSprites14:
+ax_sprite sFeebasGfx14, 0x200
+ax_sprite_terminator
+sFeebasGfx15:
+.incbin "baserom.gba", 0x143FD48, 0x200
+sFeebasSprites15:
+ax_sprite sFeebasGfx15, 0x200
+ax_sprite_terminator
+sFeebasGfx16:
+.incbin "baserom.gba", 0x143FF58, 0x40
+sFeebasGfx16_1:
+.incbin "baserom.gba", 0x143FF98, 0x60
+sFeebasGfx16_2:
+.incbin "baserom.gba", 0x143FFF8, 0x60
+sFeebasGfx16_3:
+.incbin "baserom.gba", 0x1440058, 0x20
+sFeebasSprites16:
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFeebasGfx16_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFeebasGfx17:
+.incbin "baserom.gba", 0x14400C8, 0x40
+sFeebasGfx17_1:
+.incbin "baserom.gba", 0x1440108, 0x60
+sFeebasGfx17_2:
+.incbin "baserom.gba", 0x1440168, 0x60
+sFeebasSprites17:
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFeebasGfx18:
+.incbin "baserom.gba", 0x1440208, 0x160
+sFeebasSprites18:
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx18, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFeebasGfx19:
+.incbin "baserom.gba", 0x1440388, 0x20
+sFeebasGfx19_1:
+.incbin "baserom.gba", 0x14403A8, 0x60
+sFeebasGfx19_2:
+.incbin "baserom.gba", 0x1440408, 0x60
+sFeebasGfx19_3:
+.incbin "baserom.gba", 0x1440468, 0x20
+sFeebasGfx19_4:
+.incbin "baserom.gba", 0x1440488, 0x20
+sFeebasSprites19:
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sFeebasGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx19_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx19_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFeebasGfx20:
+.incbin "baserom.gba", 0x1440508, 0x20
+sFeebasGfx20_1:
+.incbin "baserom.gba", 0x1440528, 0x60
+sFeebasGfx20_2:
+.incbin "baserom.gba", 0x1440588, 0x60
+sFeebasGfx20_3:
+.incbin "baserom.gba", 0x14405E8, 0x20
+sFeebasSprites20:
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sFeebasGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeebasGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFeebasGfx20_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFeebasGfx21:
+.incbin "baserom.gba", 0x1440658, 0x200
+sFeebasSprites21:
+ax_sprite sFeebasGfx21, 0x200
+ax_sprite_terminator
+sFeebasGfx22:
+.incbin "baserom.gba", 0x1440868, 0x200
+sFeebasSprites22:
+ax_sprite sFeebasGfx22, 0x200
+ax_sprite_terminator
+sFeebasGfx23:
+.incbin "baserom.gba", 0x1440A78, 0x200
+sFeebasSprites23:
+ax_sprite sFeebasGfx23, 0x200
+ax_sprite_terminator
+sFeebasGfx24:
+.incbin "baserom.gba", 0x1440C88, 0x200
+sFeebasSprites24:
+ax_sprite sFeebasGfx24, 0x200
+ax_sprite_terminator
+sFeebasGfx25:
+.incbin "baserom.gba", 0x1440E98, 0x200
+sFeebasSprites25:
+ax_sprite sFeebasGfx25, 0x200
+ax_sprite_terminator
+sFeebasGfx26:
+.incbin "baserom.gba", 0x14410A8, 0x200
+sFeebasSprites26:
+ax_sprite sFeebasGfx26, 0x200
+ax_sprite_terminator
+sFeebasGfx27:
+.incbin "baserom.gba", 0x14412B8, 0x200
+sFeebasSprites27:
+ax_sprite sFeebasGfx27, 0x200
+ax_sprite_terminator
+sAxPosesFeebas:
+.4byte sFeebasPose1
+.4byte sFeebasPose2
+.4byte sFeebasPose3
+.4byte sFeebasPose4
+.4byte sFeebasPose5
+.4byte sFeebasPose6
+.4byte sFeebasPose7
+.4byte sFeebasPose8
+.4byte sFeebasPose9
+.4byte sFeebasPose10
+.4byte sFeebasPose11
+.4byte sFeebasPose12
+.4byte sFeebasPose13
+.4byte sFeebasPose14
+.4byte sFeebasPose15
+.4byte sFeebasPose16
+.4byte sFeebasPose17
+.4byte sFeebasPose18
+.4byte sFeebasPose19
+.4byte sFeebasPose20
+.4byte sFeebasPose21
+.4byte sFeebasPose22
+.4byte sFeebasPose23
+.4byte sFeebasPose24
+.4byte sFeebasPose25
+.4byte sFeebasPose26
+.4byte sFeebasPose27
+.4byte sFeebasPose28
+.4byte sFeebasPose29
+.4byte sFeebasPose30
+.4byte sFeebasPose31
+.4byte sFeebasPose32
+.4byte sFeebasPose33
+.4byte sFeebasPose34
+.4byte sFeebasPose35
+.4byte sFeebasPose36
+.4byte sFeebasPose37
+.4byte sFeebasPose38
+.4byte sFeebasPose39
+.4byte sFeebasPose40
+.4byte sFeebasPose41
+.4byte sFeebasPose42
+.4byte sFeebasPose43
+.4byte sFeebasPose44
+.4byte sFeebasPose45
+.4byte sFeebasPose46
+.4byte sFeebasPose47
+.4byte sFeebasPose48
+.4byte sFeebasPose49
+.4byte sFeebasPose50
+.4byte sFeebasPose51
+.4byte sFeebasPose52
+.4byte sFeebasPose53
+.4byte sFeebasPose54
+.4byte sFeebasPose55
+.4byte sFeebasPose56
+.4byte sFeebasPose57
+.4byte sFeebasPose58
+.4byte sFeebasPose59
+.4byte sFeebasPose60
+.4byte sFeebasPose61
+.4byte sFeebasPose62
+.4byte sFeebasPose63
+.4byte sFeebasPose64
+.4byte sFeebasPose65
+.4byte sFeebasPose66
+.4byte sFeebasPose67
+.4byte sFeebasPose68
+.4byte sFeebasPose69
+.4byte sFeebasPose70
+.4byte sFeebasPose71
+.4byte sFeebasPose72
+.4byte sFeebasPose73
+.4byte sFeebasPose74
+.4byte sFeebasPose75
+.4byte sFeebasPose76
+.4byte sFeebasPose77
+.4byte sFeebasPose78
+.4byte sFeebasPose79
+.4byte sFeebasPose80
+.4byte sFeebasPose81
+.4byte sFeebasPose82
+.4byte sFeebasPose83
+.4byte sFeebasPose84
+.4byte sFeebasPose85
+.4byte sFeebasPose86
+.4byte sFeebasPose87
+.4byte sFeebasPose88
+.4byte sFeebasPose89
+.4byte sFeebasPose90
+.4byte sFeebasPose91
+.4byte sFeebasPose92
+.4byte sFeebasPose93
+.4byte sFeebasPose94
+.4byte sFeebasPose95
+.4byte sFeebasPose96
+.4byte sFeebasPose97
+.4byte sFeebasPose98
+.4byte sFeebasPose99
+.4byte sFeebasPose100
+.4byte sFeebasPose101
+.4byte sFeebasPose102
+.4byte sFeebasPose103
+.4byte sFeebasPose104
+.4byte sFeebasPose105
+.4byte sFeebasPose106
+.4byte sFeebasPose107
+.4byte sFeebasPose108
+.4byte sFeebasPose109
+.4byte sFeebasPose110
+.4byte sFeebasPose111
+.4byte sFeebasPose112
+.4byte sFeebasPose113
+.4byte sFeebasPose114
+.4byte sFeebasPose115
+.4byte sFeebasPose116
+.4byte sFeebasPose117
+.4byte sFeebasPose118
+.4byte sFeebasPose119
+.4byte sFeebasPose120
+.4byte sFeebasPose121
+.4byte sFeebasPose122
+.4byte sFeebasPose123
+.4byte sFeebasPose124
+.4byte sFeebasPose125
+.4byte sFeebasPose126
+.4byte sFeebasPose127
+.4byte sFeebasPose128
+.4byte sFeebasPose129
+.4byte sFeebasPose130
+.4byte sFeebasPose131
+.4byte sFeebasPose132
+.4byte sFeebasPose133
+.4byte sFeebasPose134
+.4byte sFeebasPose135
+.4byte sFeebasPose136
+.4byte sFeebasPose137
+.4byte sFeebasPose138
+.4byte sFeebasPose139
+.4byte sFeebasPose140
+.4byte sFeebasPose141
+.4byte sFeebasPose142
+.4byte sFeebasPose143
+.4byte sFeebasPose144
+.4byte sFeebasPose145
+.4byte sFeebasPose146
+.4byte sFeebasPose147
+.4byte sFeebasPose148
+.4byte sFeebasPose149
+.4byte sFeebasPose150
+.4byte sFeebasPose151
+.4byte sFeebasPose152
+.4byte sFeebasPose153
+.4byte sFeebasPose154
+.4byte sFeebasPose155
+.4byte sFeebasPose156
+.4byte sFeebasPose157
+.4byte sFeebasPose158
+.4byte sFeebasPose159
+.4byte sFeebasPose160
+.4byte sFeebasPose161
+.4byte sFeebasPose162
+.4byte sFeebasPose163
+.4byte sFeebasPose164
+.4byte sFeebasPose165
+.4byte sFeebasPose166
+.4byte sFeebasPose167
+.4byte sFeebasPose168
+.4byte sFeebasPose169
+.4byte sFeebasPose170
+.4byte sFeebasPose171
+.4byte sFeebasPose172
+.4byte sFeebasPose173
+.4byte sFeebasPose174
+.4byte sFeebasPose175
+.4byte sFeebasPose176
+.4byte sFeebasPose177
+.4byte sFeebasPose178
+.4byte sFeebasPose179
+.4byte sFeebasPose180
+.4byte sFeebasPose181
+.4byte sFeebasPose182
+.4byte sFeebasPose183
+.4byte sFeebasPose184
+.4byte sFeebasPose185
+.4byte sFeebasPose186
+.4byte sFeebasPose187
+.4byte sFeebasPose188
+.4byte sFeebasPose189
+.4byte sFeebasPose190
+.4byte sFeebasPose191
+.4byte sFeebasPose192
+.4byte sFeebasPose193
+.4byte sFeebasPose194
+.4byte sFeebasPose195
+.4byte sFeebasPose196
+.4byte sFeebasPose197
+.4byte sFeebasPose198
+.4byte sFeebasPose199
+.4byte sFeebasPose200
+.4byte sFeebasPose201
+.4byte sFeebasPose202
+.4byte sFeebasPose203
+.4byte sFeebasPose204
+.4byte sFeebasPose205
+.4byte sFeebasPose206
+.4byte sFeebasPose207
+.4byte sFeebasPose208
+.4byte sFeebasPose209
+.4byte sFeebasPose210
+.4byte sFeebasPose211
+.4byte sFeebasPose212
+.4byte sFeebasPose213
+.4byte sFeebasPose214
+.4byte sFeebasPose215
+.4byte sFeebasPose216
+.4byte sFeebasPose217
+.4byte sFeebasPose218
+.4byte sFeebasPose219
+.4byte sFeebasPose220
+.4byte sFeebasPose221
+.4byte sFeebasPose222
+.4byte sFeebasPose223
+.4byte sFeebasPose224
+.4byte sFeebasPose225
+.4byte sFeebasPose226
+sAxPositionsFeebas:
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    1,   -2, 	  -6,   -6, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -2, 	  -6,   -4, 	   6,   -4, 	   0,   -9
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    4,   -3, 	   3,   -8, 	  -5,   -4, 	  -2,   -9
+.2byte    5,   -3, 	   4,   -6, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    8,   -5, 	  -1,   -8, 	  -2,   -3, 	   0,   -9
+.2byte    9,   -6, 	   0,   -8, 	   1,   -3, 	   0,   -9
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -7, 	   5,   -4, 	   2,  -10
+.2byte    9,  -10, 	  -1,   -8, 	   7,   -4, 	   2,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    0,  -13, 	   7,   -5, 	  -6,   -6, 	   0,  -11
+.2byte    1,  -13, 	   7,   -7, 	  -7,   -7, 	   1,  -11
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -7, 	  -5,   -4, 	  -2,  -10
+.2byte   -9,  -10, 	   1,   -8, 	  -7,   -4, 	  -2,  -10
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,   -5, 	   1,   -8, 	   2,   -3, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -8, 	  -1,   -3, 	   0,   -9
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -4,   -3, 	  -3,   -8, 	   5,   -4, 	   2,   -9
+.2byte   -5,   -3, 	  -4,   -6, 	   4,   -3, 	   1,   -9
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    1,   -2, 	  -6,   -6, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -2, 	  -6,   -4, 	   6,   -4, 	   0,   -9
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    4,   -3, 	   3,   -8, 	  -5,   -4, 	  -2,   -9
+.2byte    5,   -3, 	   4,   -6, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    8,   -5, 	  -1,   -8, 	  -2,   -3, 	   0,   -9
+.2byte    9,   -6, 	   0,   -8, 	   1,   -3, 	   0,   -9
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -7, 	   5,   -4, 	   2,  -10
+.2byte    9,  -10, 	  -1,   -8, 	   7,   -4, 	   2,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    0,  -13, 	   7,   -5, 	  -6,   -6, 	   0,  -11
+.2byte    1,  -13, 	   7,   -7, 	  -7,   -7, 	   1,  -11
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -7, 	  -5,   -4, 	  -2,  -10
+.2byte   -9,  -10, 	   1,   -8, 	  -7,   -4, 	  -2,  -10
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,   -5, 	   1,   -8, 	   2,   -3, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -8, 	  -1,   -3, 	   0,   -9
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -4,   -3, 	  -3,   -8, 	   5,   -4, 	   2,   -9
+.2byte   -5,   -3, 	  -4,   -6, 	   4,   -3, 	   1,   -9
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    1,   -2, 	  -6,   -6, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -2, 	  -6,   -4, 	   6,   -4, 	   0,   -9
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    4,   -3, 	   3,   -8, 	  -5,   -4, 	  -2,   -9
+.2byte    5,   -3, 	   4,   -6, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    8,   -5, 	  -1,   -8, 	  -2,   -3, 	   0,   -9
+.2byte    9,   -6, 	   0,   -8, 	   1,   -3, 	   0,   -9
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -7, 	   5,   -4, 	   2,  -10
+.2byte    9,  -10, 	  -1,   -8, 	   7,   -4, 	   2,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    0,  -13, 	   7,   -5, 	  -6,   -6, 	   0,  -11
+.2byte    1,  -13, 	   7,   -7, 	  -7,   -7, 	   1,  -11
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -7, 	  -5,   -4, 	  -2,  -10
+.2byte   -9,  -10, 	   1,   -8, 	  -7,   -4, 	  -2,  -10
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,   -5, 	   1,   -8, 	   2,   -3, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -8, 	  -1,   -3, 	   0,   -9
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -4,   -3, 	  -3,   -8, 	   5,   -4, 	   2,   -9
+.2byte   -5,   -3, 	  -4,   -6, 	   4,   -3, 	   1,   -9
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    1,   -2, 	  -6,   -6, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -2, 	  -6,   -4, 	   6,   -4, 	   0,   -9
+.2byte    0,   -3, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    4,   -3, 	   3,   -8, 	  -5,   -4, 	  -2,   -9
+.2byte    5,   -3, 	   4,   -6, 	  -4,   -3, 	  -1,   -9
+.2byte    5,   -4, 	   3,   -7, 	  -5,   -4, 	   0,   -9
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    8,   -5, 	  -1,   -8, 	  -2,   -3, 	   0,   -9
+.2byte    9,   -6, 	   0,   -8, 	   1,   -3, 	   0,   -9
+.2byte    8,   -6, 	  -2,   -8, 	  -2,   -3, 	   0,  -10
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -7, 	   5,   -4, 	   2,  -10
+.2byte    9,  -10, 	  -1,   -8, 	   7,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -8, 	   5,   -4, 	   1,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    0,  -13, 	   7,   -5, 	  -6,   -6, 	   0,  -11
+.2byte    1,  -13, 	   7,   -7, 	  -7,   -7, 	   1,  -11
+.2byte    0,  -13, 	   6,   -6, 	  -6,   -6, 	   0,  -10
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -7, 	  -5,   -4, 	  -2,  -10
+.2byte   -9,  -10, 	   1,   -8, 	  -7,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -8, 	  -5,   -4, 	  -1,  -10
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,   -5, 	   1,   -8, 	   2,   -3, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -8, 	  -1,   -3, 	   0,   -9
+.2byte   -8,   -6, 	   2,   -8, 	   2,   -3, 	   0,  -10
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -4,   -3, 	  -3,   -8, 	   5,   -4, 	   2,   -9
+.2byte   -5,   -3, 	  -4,   -6, 	   4,   -3, 	   1,   -9
+.2byte   -5,   -4, 	  -3,   -7, 	   5,   -4, 	   0,   -9
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    1,   -2, 	  -6,   -6, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -2, 	  -6,   -4, 	   6,   -4, 	   0,   -9
+.2byte    0,   -3, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    5,   -3, 	   4,   -6, 	  -4,   -3, 	  -1,   -9
+.2byte    4,   -3, 	   3,   -8, 	  -5,   -4, 	  -2,   -9
+.2byte    5,   -4, 	   3,   -7, 	  -5,   -4, 	   0,   -9
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    9,   -6, 	   0,   -8, 	   1,   -3, 	   0,   -9
+.2byte    8,   -5, 	  -1,   -8, 	  -2,   -3, 	   0,   -9
+.2byte    8,   -6, 	  -2,   -8, 	  -2,   -3, 	   0,  -10
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    8,  -10, 	  -2,   -8, 	   6,   -4, 	   1,  -10
+.2byte    8,   -9, 	  -2,   -7, 	   5,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -8, 	   5,   -4, 	   1,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    0,  -13, 	   7,   -5, 	  -6,   -6, 	   0,  -11
+.2byte    1,  -13, 	   7,   -7, 	  -7,   -7, 	   1,  -11
+.2byte    0,  -13, 	   6,   -6, 	  -6,   -6, 	   0,  -10
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -7, 	  -5,   -4, 	  -2,  -10
+.2byte   -9,  -10, 	   1,   -8, 	  -7,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -8, 	  -5,   -4, 	  -1,  -10
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,   -5, 	   1,   -8, 	   2,   -3, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -8, 	  -1,   -3, 	   0,   -9
+.2byte   -8,   -6, 	   2,   -8, 	   2,   -3, 	   0,  -10
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -4,   -3, 	  -3,   -8, 	   5,   -4, 	   2,   -9
+.2byte   -5,   -3, 	  -4,   -6, 	   4,   -3, 	   1,   -9
+.2byte   -5,   -4, 	  -3,   -7, 	   5,   -4, 	   0,   -9
+.2byte   -5,   -4, 	  -2,  -10, 	   5,   -6, 	   1,  -10
+.2byte   -5,   -3, 	  -2,   -9, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -1, 	  -5,   -5, 	   6,   -4, 	   0,   -9
+.2byte    3,   -2, 	   2,   -8, 	  -7,   -7, 	  -1,   -8
+.2byte    8,   -3, 	   0,   -9, 	  -2,   -4, 	   0,   -7
+.2byte    7,   -5, 	  -3,   -7, 	   3,   -3, 	   0,   -8
+.2byte   -1,   -8, 	   7,   -9, 	  -7,   -6, 	   0,   -8
+.2byte   -8,   -5, 	   2,   -7, 	  -4,   -3, 	  -1,   -8
+.2byte   -9,   -3, 	  -1,   -9, 	   1,   -4, 	  -1,   -7
+.2byte   -4,   -2, 	  -3,   -8, 	   6,   -7, 	   0,   -8
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    1,   -2, 	  -6,   -6, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -2, 	  -6,   -4, 	   6,   -4, 	   0,   -9
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    4,   -3, 	   3,   -8, 	  -5,   -4, 	  -2,   -9
+.2byte    5,   -3, 	   4,   -6, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    8,   -5, 	  -1,   -8, 	  -2,   -3, 	   0,   -9
+.2byte    9,   -6, 	   0,   -8, 	   1,   -3, 	   0,   -9
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -7, 	   5,   -4, 	   2,  -10
+.2byte    9,  -10, 	  -1,   -8, 	   7,   -4, 	   2,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    0,  -13, 	   7,   -5, 	  -6,   -6, 	   0,  -11
+.2byte    1,  -13, 	   7,   -7, 	  -7,   -7, 	   1,  -11
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -7, 	  -5,   -4, 	  -2,  -10
+.2byte   -9,  -10, 	   1,   -8, 	  -7,   -4, 	  -2,  -10
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,   -5, 	   1,   -8, 	   2,   -3, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -8, 	  -1,   -3, 	   0,   -9
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -4,   -3, 	  -3,   -8, 	   5,   -4, 	   2,   -9
+.2byte   -5,   -3, 	  -4,   -6, 	   4,   -3, 	   1,   -9
+.2byte    0,   -3, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte   -5,   -4, 	  -3,   -7, 	   5,   -4, 	   0,   -9
+.2byte   -8,   -6, 	   2,   -8, 	   2,   -3, 	   0,  -10
+.2byte   -7,   -9, 	   3,   -8, 	  -4,   -4, 	   0,  -10
+.2byte    0,  -13, 	   6,   -6, 	  -6,   -6, 	   0,  -10
+.2byte    7,   -9, 	  -3,   -8, 	   4,   -4, 	   0,  -10
+.2byte    8,   -6, 	  -2,   -8, 	  -2,   -3, 	   0,  -10
+.2byte    5,   -4, 	   3,   -7, 	  -5,   -4, 	   0,   -9
+.2byte    0,   -3, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    5,   -4, 	   3,   -7, 	  -5,   -4, 	   0,   -9
+.2byte    8,   -6, 	  -2,   -8, 	  -2,   -3, 	   0,  -10
+.2byte    7,   -9, 	  -3,   -8, 	   4,   -4, 	   0,  -10
+.2byte    0,  -13, 	   6,   -6, 	  -6,   -6, 	   0,  -10
+.2byte   -7,   -9, 	   3,   -8, 	  -4,   -4, 	   0,  -10
+.2byte   -8,   -6, 	   2,   -8, 	   2,   -3, 	   0,  -10
+.2byte   -5,   -4, 	  -3,   -7, 	   5,   -4, 	   0,   -9
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    1,   -2, 	  -6,   -6, 	   6,   -6, 	   1,   -9
+.2byte   -1,   -2, 	  -6,   -4, 	   6,   -4, 	   0,   -9
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    4,   -3, 	   3,   -8, 	  -5,   -4, 	  -2,   -9
+.2byte    5,   -3, 	   4,   -6, 	  -4,   -3, 	  -1,   -9
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    8,   -5, 	  -1,   -8, 	  -2,   -3, 	   0,   -9
+.2byte    9,   -6, 	   0,   -8, 	   1,   -3, 	   0,   -9
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    8,   -9, 	  -2,   -7, 	   5,   -4, 	   2,  -10
+.2byte    9,  -10, 	  -1,   -8, 	   7,   -4, 	   2,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    0,  -13, 	   7,   -5, 	  -6,   -6, 	   0,  -11
+.2byte    1,  -13, 	   7,   -7, 	  -7,   -7, 	   1,  -11
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte   -8,   -9, 	   2,   -7, 	  -5,   -4, 	  -2,  -10
+.2byte   -9,  -10, 	   1,   -8, 	  -7,   -4, 	  -2,  -10
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,   -5, 	   1,   -8, 	   2,   -3, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -8, 	  -1,   -3, 	   0,   -9
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -4,   -3, 	  -3,   -8, 	   5,   -4, 	   2,   -9
+.2byte   -5,   -3, 	  -4,   -6, 	   4,   -3, 	   1,   -9
+.2byte    0,   -3, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte   -5,   -4, 	  -3,   -7, 	   5,   -4, 	   0,   -9
+.2byte   -8,   -6, 	   2,   -8, 	   2,   -3, 	   0,  -10
+.2byte   -7,   -9, 	   3,   -8, 	  -4,   -4, 	   0,  -10
+.2byte    0,  -13, 	   6,   -6, 	  -6,   -6, 	   0,  -10
+.2byte    7,   -9, 	  -3,   -8, 	   4,   -4, 	   0,  -10
+.2byte    8,   -6, 	  -2,   -8, 	  -2,   -3, 	   0,  -10
+.2byte    5,   -4, 	   3,   -7, 	  -5,   -4, 	   0,   -9
+.2byte    0,   -2, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte   -5,   -3, 	  -3,   -7, 	   5,   -4, 	   1,   -9
+.2byte   -9,   -6, 	   1,   -8, 	   1,   -3, 	   0,  -10
+.2byte   -8,  -10, 	   2,   -5, 	  -6,   -4, 	  -2,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -6,   -6, 	   0,  -11
+.2byte    8,  -10, 	  -2,   -5, 	   6,   -4, 	   2,  -10
+.2byte    9,   -6, 	  -1,   -8, 	  -1,   -3, 	   0,  -10
+.2byte    5,   -3, 	   3,   -7, 	  -5,   -4, 	  -1,   -9
+sFeebasAnimTable1:
+.4byte sFeebasAnims_1_1
+.4byte sFeebasAnims_1_2
+.4byte sFeebasAnims_1_3
+.4byte sFeebasAnims_1_4
+.4byte sFeebasAnims_1_5
+.4byte sFeebasAnims_1_6
+.4byte sFeebasAnims_1_7
+.4byte sFeebasAnims_1_8
+sFeebasAnimTable2:
+.4byte sFeebasAnims_2_1
+.4byte sFeebasAnims_2_2
+.4byte sFeebasAnims_2_3
+.4byte sFeebasAnims_2_4
+.4byte sFeebasAnims_2_5
+.4byte sFeebasAnims_2_6
+.4byte sFeebasAnims_2_7
+.4byte sFeebasAnims_2_8
+sFeebasAnimTable3:
+.4byte sFeebasAnims_3_1
+.4byte sFeebasAnims_3_2
+.4byte sFeebasAnims_3_3
+.4byte sFeebasAnims_3_4
+.4byte sFeebasAnims_3_5
+.4byte sFeebasAnims_3_6
+.4byte sFeebasAnims_3_7
+.4byte sFeebasAnims_3_8
+sFeebasAnimTable4:
+.4byte sFeebasAnims_4_1
+.4byte sFeebasAnims_4_2
+.4byte sFeebasAnims_4_3
+.4byte sFeebasAnims_4_4
+.4byte sFeebasAnims_4_5
+.4byte sFeebasAnims_4_6
+.4byte sFeebasAnims_4_7
+.4byte sFeebasAnims_4_8
+sFeebasAnimTable5:
+.4byte sFeebasAnims_5_1
+.4byte sFeebasAnims_5_2
+.4byte sFeebasAnims_5_3
+.4byte sFeebasAnims_5_4
+.4byte sFeebasAnims_5_5
+.4byte sFeebasAnims_5_6
+.4byte sFeebasAnims_5_7
+.4byte sFeebasAnims_5_8
+sFeebasAnimTable6:
+.4byte sFeebasAnims_6_1
+.4byte sFeebasAnims_6_1
+.4byte sFeebasAnims_6_1
+.4byte sFeebasAnims_6_1
+.4byte sFeebasAnims_6_1
+.4byte sFeebasAnims_6_1
+.4byte sFeebasAnims_6_1
+.4byte sFeebasAnims_6_1
+sFeebasAnimTable7:
+.4byte sFeebasAnims_7_1
+.4byte sFeebasAnims_7_2
+.4byte sFeebasAnims_7_3
+.4byte sFeebasAnims_7_4
+.4byte sFeebasAnims_7_5
+.4byte sFeebasAnims_7_6
+.4byte sFeebasAnims_7_7
+.4byte sFeebasAnims_7_8
+sFeebasAnimTable8:
+.4byte sFeebasAnims_8_1
+.4byte sFeebasAnims_8_2
+.4byte sFeebasAnims_8_3
+.4byte sFeebasAnims_8_4
+.4byte sFeebasAnims_8_5
+.4byte sFeebasAnims_8_6
+.4byte sFeebasAnims_8_7
+.4byte sFeebasAnims_8_8
+sFeebasAnimTable9:
+.4byte sFeebasAnims_9_1
+.4byte sFeebasAnims_9_2
+.4byte sFeebasAnims_9_3
+.4byte sFeebasAnims_9_4
+.4byte sFeebasAnims_9_5
+.4byte sFeebasAnims_9_6
+.4byte sFeebasAnims_9_7
+.4byte sFeebasAnims_9_8
+sFeebasAnimTable10:
+.4byte sFeebasAnims_10_1
+.4byte sFeebasAnims_10_2
+.4byte sFeebasAnims_10_3
+.4byte sFeebasAnims_10_4
+.4byte sFeebasAnims_10_5
+.4byte sFeebasAnims_10_6
+.4byte sFeebasAnims_10_7
+.4byte sFeebasAnims_10_8
+sFeebasAnimTable11:
+.4byte sFeebasAnims_11_1
+.4byte sFeebasAnims_11_2
+.4byte sFeebasAnims_11_3
+.4byte sFeebasAnims_11_4
+.4byte sFeebasAnims_11_5
+.4byte sFeebasAnims_11_6
+.4byte sFeebasAnims_11_7
+.4byte sFeebasAnims_11_8
+sFeebasAnimTable12:
+.4byte sFeebasAnims_12_1
+.4byte sFeebasAnims_12_2
+.4byte sFeebasAnims_12_3
+.4byte sFeebasAnims_12_4
+.4byte sFeebasAnims_12_5
+.4byte sFeebasAnims_12_6
+.4byte sFeebasAnims_12_7
+.4byte sFeebasAnims_12_8
+sFeebasAnimTable13:
+.4byte sFeebasAnims_13_1
+.4byte sFeebasAnims_13_2
+.4byte sFeebasAnims_13_3
+.4byte sFeebasAnims_13_4
+.4byte sFeebasAnims_13_5
+.4byte sFeebasAnims_13_6
+.4byte sFeebasAnims_13_7
+.4byte sFeebasAnims_13_8
+sAxAnimationsFeebas:
+.4byte sFeebasAnimTable1
+.4byte sFeebasAnimTable2
+.4byte sFeebasAnimTable3
+.4byte sFeebasAnimTable4
+.4byte sFeebasAnimTable5
+.4byte sFeebasAnimTable6
+.4byte sFeebasAnimTable7
+.4byte sFeebasAnimTable8
+.4byte sFeebasAnimTable9
+.4byte sFeebasAnimTable10
+.4byte sFeebasAnimTable11
+.4byte sFeebasAnimTable12
+.4byte sFeebasAnimTable13
+sAxSpritesFeebas:
+.4byte sFeebasSprites1
+.4byte sFeebasSprites2
+.4byte sFeebasSprites3
+.4byte sFeebasSprites4
+.4byte sFeebasSprites5
+.4byte sFeebasSprites6
+.4byte sFeebasSprites7
+.4byte sFeebasSprites8
+.4byte sFeebasSprites9
+.4byte sFeebasSprites10
+.4byte sFeebasSprites11
+.4byte sFeebasSprites12
+.4byte sFeebasSprites13
+.4byte sFeebasSprites14
+.4byte sFeebasSprites15
+.4byte sFeebasSprites16
+.4byte sFeebasSprites17
+.4byte sFeebasSprites18
+.4byte sFeebasSprites19
+.4byte sFeebasSprites20
+.4byte sFeebasSprites21
+.4byte sFeebasSprites22
+.4byte sFeebasSprites23
+.4byte sFeebasSprites24
+.4byte sFeebasSprites25
+.4byte sFeebasSprites26
+.4byte sFeebasSprites27
+sAxMainFeebas:
+ax_main sAxPosesFeebas, sAxAnimationsFeebas, 13, sAxSpritesFeebas, sAxPositionsFeebas

--- a/data/ax/feraligatr.inc
+++ b/data/ax/feraligatr.inc
@@ -1,0 +1,3190 @@
+.global gAxFeraligatr
+gAxFeraligatr:
+ax_siro sAxMainFeraligatr
+sFeraligatrPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose4:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose5:
+ax_pose 4, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose6:
+ax_pose 5, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose8:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose10:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose11:
+ax_pose 10, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose12:
+ax_pose 11, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose27:
+ax_pose 15, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose28:
+ax_pose 16, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose29:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose30:
+ax_pose 4, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose31:
+ax_pose 17, 0x81e0, 0x9101, 0x0c00
+ax_pose 18, 0x81e0, 0x50f9, 0x0c08
+ax_pose 19, 0x01e8, 0x10f1, 0x0c0c
+ax_pose 20, 0x81f0, 0x10f1, 0x0c0d
+ax_pose 21, 0x0200, 0x10f6, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose32:
+ax_pose 22, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sFeraligatrPose33:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose34:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose35:
+ax_pose 23, 0x81dd, 0x90fd, 0x0c00
+ax_pose 24, 0x01e5, 0x10f5, 0x0c08
+ax_pose 25, 0x01ed, 0x50ed, 0x0c09
+ax_pose 26, 0x41fd, 0x10f5, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose36:
+ax_pose 27, 0x81e5, 0x9103, 0x0c00
+ax_pose 28, 0x81e5, 0x50fb, 0x0c08
+ax_pose 29, 0x81ed, 0x10f3, 0x0c0c
+ax_pose 30, 0x01fd, 0x10f3, 0x0c0e
+ax_pose 31, 0x01f2, 0x10eb, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose37:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose38:
+ax_pose 10, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose39:
+ax_pose 32, 0x81e2, 0x90fd, 0x0c00
+ax_pose 33, 0x81e2, 0x50f5, 0x0c08
+ax_pose 34, 0x01fa, 0x10ed, 0x0c0c
+ax_pose 35, 0x01da, 0x10fd, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose40:
+ax_pose 36, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose41:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose42:
+ax_pose 13, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose43:
+ax_pose 37, 0x41e7, 0x80f0, 0x0c00
+ax_pose 38, 0x41f7, 0x40f0, 0x0c08
+ax_pose 39, 0x41ff, 0x00f8, 0x0c0c
+ax_pose 40, 0x01df, 0x00fc, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose44:
+ax_pose 41, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sFeraligatrPose45:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose46:
+ax_pose 10, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose47:
+ax_pose 32, 0x81e2, 0x80f3, 0x0c00
+ax_pose 33, 0x81e2, 0x4103, 0x0c08
+ax_pose 34, 0x01fa, 0x010b, 0x0c0c
+ax_pose 35, 0x01da, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose48:
+ax_pose 36, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose49:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose50:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose51:
+ax_pose 23, 0x81dd, 0x80f3, 0x0c00
+ax_pose 24, 0x01e5, 0x0103, 0x0c08
+ax_pose 25, 0x01ed, 0x4103, 0x0c09
+ax_pose 26, 0x41fd, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose52:
+ax_pose 27, 0x81e5, 0x80ed, 0x0c00
+ax_pose 28, 0x81e5, 0x40fd, 0x0c08
+ax_pose 29, 0x81ed, 0x0105, 0x0c0c
+ax_pose 30, 0x01fd, 0x0105, 0x0c0e
+ax_pose 31, 0x01f2, 0x010d, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose53:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose54:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose55:
+ax_pose 17, 0x81e0, 0x80ef, 0x0c00
+ax_pose 18, 0x81e0, 0x40ff, 0x0c08
+ax_pose 19, 0x01e8, 0x0107, 0x0c0c
+ax_pose 20, 0x81f0, 0x0107, 0x0c0d
+ax_pose 21, 0x0200, 0x0102, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose56:
+ax_pose 22, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sFeraligatrPose57:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose58:
+ax_pose 1, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose59:
+ax_pose 2, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose60:
+ax_pose 42, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose61:
+ax_pose 43, 0x01e9, 0x80e6, 0x0c00
+ax_pose 16, 0x01e7, 0x80f1, 0x0c10
+ax_pose_terminator
+sFeraligatrPose62:
+ax_pose 16, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sFeraligatrPose63:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose64:
+ax_pose 4, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose65:
+ax_pose 5, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose66:
+ax_pose 44, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose67:
+ax_pose 22, 0x01e5, 0x90f2, 0x0c00
+ax_pose 45, 0x81e6, 0x9105, 0x0c10
+ax_pose_terminator
+sFeraligatrPose68:
+ax_pose 22, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sFeraligatrPose69:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose70:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose71:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose72:
+ax_pose 46, 0x41e5, 0x90f0, 0x0c00
+ax_pose 47, 0x41f5, 0x50f0, 0x0c08
+ax_pose 48, 0x41fd, 0x10f8, 0x0c0c
+ax_pose 49, 0x01f5, 0x10e8, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose73:
+ax_pose 27, 0x81e5, 0x9103, 0x0c00
+ax_pose 28, 0x81e5, 0x50fb, 0x0c08
+ax_pose 29, 0x81ed, 0x10f3, 0x0c0c
+ax_pose 30, 0x01fd, 0x10f3, 0x0c0e
+ax_pose 31, 0x01f2, 0x10eb, 0x0c0f
+ax_pose 50, 0x01e5, 0x90fa, 0x0c10
+ax_pose_terminator
+sFeraligatrPose74:
+ax_pose 27, 0x81e5, 0x9103, 0x0c00
+ax_pose 28, 0x81e5, 0x50fb, 0x0c08
+ax_pose 29, 0x81ed, 0x10f3, 0x0c0c
+ax_pose 30, 0x01fd, 0x10f3, 0x0c0e
+ax_pose 31, 0x01f2, 0x10eb, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose75:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose76:
+ax_pose 10, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose77:
+ax_pose 11, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose78:
+ax_pose 51, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose79:
+ax_pose 36, 0x01e4, 0x90f0, 0x0c00
+ax_pose 52, 0x01e1, 0x90f5, 0x0c10
+ax_pose_terminator
+sFeraligatrPose80:
+ax_pose 36, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose81:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose82:
+ax_pose 13, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose83:
+ax_pose 14, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose84:
+ax_pose 53, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sFeraligatrPose85:
+ax_pose 41, 0x01e4, 0x80ef, 0x0c00
+ax_pose 54, 0x01dc, 0x80f4, 0x0c10
+ax_pose_terminator
+sFeraligatrPose86:
+ax_pose 41, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sFeraligatrPose87:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose88:
+ax_pose 10, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose89:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose90:
+ax_pose 51, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose91:
+ax_pose 36, 0x01e4, 0x80f0, 0x0c00
+ax_pose 52, 0x01e2, 0x80ec, 0x0c10
+ax_pose_terminator
+sFeraligatrPose92:
+ax_pose 36, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose93:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose94:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose95:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose96:
+ax_pose 46, 0x41e5, 0x80f0, 0x0c00
+ax_pose 47, 0x41f5, 0x40f0, 0x0c08
+ax_pose 48, 0x41fd, 0x00f8, 0x0c0c
+ax_pose 49, 0x01f5, 0x0110, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose97:
+ax_pose 27, 0x81e5, 0x80ed, 0x0c00
+ax_pose 28, 0x81e5, 0x40fd, 0x0c08
+ax_pose 29, 0x81ed, 0x0105, 0x0c0c
+ax_pose 30, 0x01fd, 0x0105, 0x0c0e
+ax_pose 31, 0x01f2, 0x010d, 0x0c0f
+ax_pose 50, 0x01e5, 0x80e6, 0x0c10
+ax_pose_terminator
+sFeraligatrPose98:
+ax_pose 27, 0x81e5, 0x80ed, 0x0c00
+ax_pose 28, 0x81e5, 0x40fd, 0x0c08
+ax_pose 29, 0x81ed, 0x0105, 0x0c0c
+ax_pose 30, 0x01fd, 0x0105, 0x0c0e
+ax_pose 31, 0x01f2, 0x010d, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose99:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose100:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose101:
+ax_pose 5, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose102:
+ax_pose 44, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose103:
+ax_pose 22, 0x01e5, 0x80ee, 0x0c00
+ax_pose 45, 0x81e6, 0x80eb, 0x0c10
+ax_pose_terminator
+sFeraligatrPose104:
+ax_pose 22, 0x01e5, 0x80ee, 0x0c00
+ax_pose_terminator
+sFeraligatrPose105:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose106:
+ax_pose 15, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose107:
+ax_pose 55, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose108:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose109:
+ax_pose 17, 0x81e0, 0x9101, 0x0c00
+ax_pose 18, 0x81e0, 0x50f9, 0x0c08
+ax_pose 19, 0x01e8, 0x10f1, 0x0c0c
+ax_pose 20, 0x81f0, 0x10f1, 0x0c0d
+ax_pose 21, 0x0200, 0x10f6, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose110:
+ax_pose 56, 0x41e6, 0x90f1, 0x0c00
+ax_pose 57, 0x41f6, 0x50f1, 0x0c08
+ax_pose 58, 0x41fe, 0x10f1, 0x0c0c
+ax_pose 59, 0x01ee, 0x1111, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose111:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose112:
+ax_pose 23, 0x81dd, 0x90fd, 0x0c00
+ax_pose 24, 0x01e5, 0x10f5, 0x0c08
+ax_pose 25, 0x01ed, 0x50ed, 0x0c09
+ax_pose 26, 0x41fd, 0x10f5, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose113:
+ax_pose 60, 0x41e4, 0x90f6, 0x0c00
+ax_pose 61, 0x41f4, 0x50f6, 0x0c08
+ax_pose 62, 0x41fc, 0x10f6, 0x0c0c
+ax_pose 63, 0x01f4, 0x10ee, 0x0c0e
+ax_pose 64, 0x01ec, 0x10ee, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose114:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose115:
+ax_pose 32, 0x81e2, 0x90fd, 0x0c00
+ax_pose 33, 0x81e2, 0x50f5, 0x0c08
+ax_pose 34, 0x01fa, 0x10ed, 0x0c0c
+ax_pose 35, 0x01da, 0x10fd, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose116:
+ax_pose 65, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose117:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose118:
+ax_pose 37, 0x41e7, 0x80f0, 0x0c00
+ax_pose 38, 0x41f7, 0x40f0, 0x0c08
+ax_pose 39, 0x41ff, 0x00f8, 0x0c0c
+ax_pose 40, 0x01df, 0x00fc, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose119:
+ax_pose 66, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose120:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose121:
+ax_pose 32, 0x81e2, 0x80f3, 0x0c00
+ax_pose 33, 0x81e2, 0x4103, 0x0c08
+ax_pose 34, 0x01fa, 0x010b, 0x0c0c
+ax_pose 35, 0x01da, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose122:
+ax_pose 65, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose123:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose124:
+ax_pose 23, 0x81dd, 0x80f3, 0x0c00
+ax_pose 24, 0x01e5, 0x0103, 0x0c08
+ax_pose 25, 0x01ed, 0x4103, 0x0c09
+ax_pose 26, 0x41fd, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose125:
+ax_pose 60, 0x41e4, 0x80ea, 0x0c00
+ax_pose 61, 0x41f4, 0x40ea, 0x0c08
+ax_pose 62, 0x41fc, 0x00fa, 0x0c0c
+ax_pose 63, 0x01f4, 0x010a, 0x0c0e
+ax_pose 64, 0x01ec, 0x010a, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose126:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose127:
+ax_pose 17, 0x81e0, 0x80ef, 0x0c00
+ax_pose 18, 0x81e0, 0x40ff, 0x0c08
+ax_pose 19, 0x01e8, 0x0107, 0x0c0c
+ax_pose 20, 0x81f0, 0x0107, 0x0c0d
+ax_pose 21, 0x0200, 0x0102, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose128:
+ax_pose 56, 0x41e6, 0x80ef, 0x0c00
+ax_pose 57, 0x41f6, 0x40ef, 0x0c08
+ax_pose 58, 0x41fe, 0x00ff, 0x0c0c
+ax_pose 59, 0x01ee, 0x00e7, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose129:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose130:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose131:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose132:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose133:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose134:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose135:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose136:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose137:
+ax_pose 67, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose138:
+ax_pose 68, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose139:
+ax_pose 69, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose140:
+ax_pose 70, 0x81de, 0x50ff, 0x0c00
+ax_pose 71, 0x81ee, 0x1107, 0x0c04
+ax_pose 72, 0x01fe, 0x10fb, 0x0c06
+ax_pose 73, 0x01e6, 0x1107, 0x0c07
+ax_pose 74, 0x81de, 0x90ef, 0x0c08
+ax_pose_terminator
+sFeraligatrPose141:
+ax_pose 75, 0x81e0, 0x5101, 0x0c00
+ax_pose 76, 0x81e0, 0x10e9, 0x0c04
+ax_pose 77, 0x81f0, 0x1109, 0x0c06
+ax_pose 78, 0x81e0, 0x90f1, 0x0c08
+ax_pose_terminator
+sFeraligatrPose142:
+ax_pose 79, 0x81e3, 0x50f6, 0x0c00
+ax_pose 80, 0x01f3, 0x10ee, 0x0c04
+ax_pose 81, 0x81e3, 0x10ee, 0x0c05
+ax_pose 82, 0x01db, 0x10fc, 0x0c07
+ax_pose 83, 0x81e3, 0x90fe, 0x0c08
+ax_pose_terminator
+sFeraligatrPose143:
+ax_pose 84, 0x41f5, 0x40f0, 0x0c00
+ax_pose 85, 0x41dd, 0x00f8, 0x0c04
+ax_pose 86, 0x41fd, 0x00f8, 0x0c06
+ax_pose 87, 0x41e5, 0x80f0, 0x0c08
+ax_pose_terminator
+sFeraligatrPose144:
+ax_pose 79, 0x81e3, 0x4102, 0x0c00
+ax_pose 80, 0x01f3, 0x010a, 0x0c04
+ax_pose 81, 0x81e3, 0x010a, 0x0c05
+ax_pose 82, 0x01db, 0x00fc, 0x0c07
+ax_pose 83, 0x81e3, 0x80f2, 0x0c08
+ax_pose_terminator
+sFeraligatrPose145:
+ax_pose 75, 0x81e0, 0x40f7, 0x0c00
+ax_pose 76, 0x81e0, 0x010f, 0x0c04
+ax_pose 77, 0x81f0, 0x00ef, 0x0c06
+ax_pose 78, 0x81e0, 0x80ff, 0x0c08
+ax_pose_terminator
+sFeraligatrPose146:
+ax_pose 70, 0x81de, 0x40f9, 0x0c00
+ax_pose 71, 0x81ee, 0x00f1, 0x0c04
+ax_pose 72, 0x01fe, 0x00fd, 0x0c06
+ax_pose 73, 0x01e6, 0x00f1, 0x0c07
+ax_pose 74, 0x81de, 0x8101, 0x0c08
+ax_pose_terminator
+sFeraligatrPose147:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose148:
+ax_pose 55, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose149:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose150:
+ax_pose 56, 0x41e7, 0x90f0, 0x0c00
+ax_pose 57, 0x41f7, 0x50f0, 0x0c08
+ax_pose 58, 0x41ff, 0x10f0, 0x0c0c
+ax_pose 59, 0x01ef, 0x1110, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose151:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose152:
+ax_pose 60, 0x41e5, 0x90f5, 0x0c00
+ax_pose 61, 0x41f5, 0x50f5, 0x0c08
+ax_pose 62, 0x41fd, 0x10f5, 0x0c0c
+ax_pose 63, 0x01f5, 0x10ed, 0x0c0e
+ax_pose 64, 0x01ed, 0x10ed, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose153:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose154:
+ax_pose 65, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose155:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose156:
+ax_pose 66, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose157:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose158:
+ax_pose 65, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose159:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose160:
+ax_pose 60, 0x41e5, 0x80eb, 0x0c00
+ax_pose 61, 0x41f5, 0x40eb, 0x0c08
+ax_pose 62, 0x41fd, 0x00fb, 0x0c0c
+ax_pose 63, 0x01f5, 0x010b, 0x0c0e
+ax_pose 64, 0x01ed, 0x010b, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose161:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose162:
+ax_pose 56, 0x41e7, 0x80f0, 0x0c00
+ax_pose 57, 0x41f7, 0x40f0, 0x0c08
+ax_pose 58, 0x41ff, 0x0100, 0x0c0c
+ax_pose 59, 0x01ef, 0x00e8, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose163:
+ax_pose 55, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose164:
+ax_pose 56, 0x41e7, 0x80ef, 0x0c00
+ax_pose 57, 0x41f7, 0x40ef, 0x0c08
+ax_pose 58, 0x41ff, 0x00ff, 0x0c0c
+ax_pose 59, 0x01ef, 0x00e7, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose165:
+ax_pose 60, 0x41e5, 0x80ea, 0x0c00
+ax_pose 61, 0x41f5, 0x40ea, 0x0c08
+ax_pose 62, 0x41fd, 0x00fa, 0x0c0c
+ax_pose 63, 0x01f5, 0x010a, 0x0c0e
+ax_pose 64, 0x01ed, 0x010a, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose166:
+ax_pose 65, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose167:
+ax_pose 66, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose168:
+ax_pose 65, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose169:
+ax_pose 60, 0x41e5, 0x90f6, 0x0c00
+ax_pose 61, 0x41f5, 0x50f6, 0x0c08
+ax_pose 62, 0x41fd, 0x10f6, 0x0c0c
+ax_pose 63, 0x01f5, 0x10ee, 0x0c0e
+ax_pose 64, 0x01ed, 0x10ee, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose170:
+ax_pose 56, 0x41e7, 0x90f1, 0x0c00
+ax_pose 57, 0x41f7, 0x50f1, 0x0c08
+ax_pose 58, 0x41ff, 0x10f1, 0x0c0c
+ax_pose 59, 0x01ef, 0x1111, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose171:
+ax_pose 15, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose172:
+ax_pose 17, 0x81e1, 0x9100, 0x0c00
+ax_pose 18, 0x81e1, 0x50f8, 0x0c08
+ax_pose 19, 0x01e9, 0x10f0, 0x0c0c
+ax_pose 20, 0x81f1, 0x10f0, 0x0c0d
+ax_pose 21, 0x0201, 0x10f5, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose173:
+ax_pose 23, 0x81de, 0x90fd, 0x0c00
+ax_pose 24, 0x01e6, 0x10f5, 0x0c08
+ax_pose 25, 0x01ee, 0x50ed, 0x0c09
+ax_pose 26, 0x41fe, 0x10f5, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose174:
+ax_pose 32, 0x81e3, 0x90fd, 0x0c00
+ax_pose 33, 0x81e3, 0x50f5, 0x0c08
+ax_pose 34, 0x01fb, 0x10ed, 0x0c0c
+ax_pose 35, 0x01db, 0x10fd, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose175:
+ax_pose 37, 0x41e8, 0x80f0, 0x0c00
+ax_pose 38, 0x41f8, 0x40f0, 0x0c08
+ax_pose 39, 0x4200, 0x00f8, 0x0c0c
+ax_pose 40, 0x01e0, 0x00fc, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose176:
+ax_pose 32, 0x81e3, 0x80f3, 0x0c00
+ax_pose 33, 0x81e3, 0x4103, 0x0c08
+ax_pose 34, 0x01fb, 0x010b, 0x0c0c
+ax_pose 35, 0x01db, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose177:
+ax_pose 23, 0x81de, 0x80f3, 0x0c00
+ax_pose 24, 0x01e6, 0x0103, 0x0c08
+ax_pose 25, 0x01ee, 0x4103, 0x0c09
+ax_pose 26, 0x41fe, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose178:
+ax_pose 17, 0x81e1, 0x80ef, 0x0c00
+ax_pose 18, 0x81e1, 0x40ff, 0x0c08
+ax_pose 19, 0x01e9, 0x0107, 0x0c0c
+ax_pose 20, 0x81f1, 0x0107, 0x0c0d
+ax_pose 21, 0x0201, 0x0102, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose179:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose180:
+ax_pose 15, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose181:
+ax_pose 55, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose182:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose183:
+ax_pose 17, 0x81e0, 0x9101, 0x0c00
+ax_pose 18, 0x81e0, 0x50f9, 0x0c08
+ax_pose 19, 0x01e8, 0x10f1, 0x0c0c
+ax_pose 20, 0x81f0, 0x10f1, 0x0c0d
+ax_pose 21, 0x0200, 0x10f6, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose184:
+ax_pose 56, 0x41e6, 0x90f0, 0x0c00
+ax_pose 57, 0x41f6, 0x50f0, 0x0c08
+ax_pose 58, 0x41fe, 0x10f0, 0x0c0c
+ax_pose 59, 0x01ee, 0x1110, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose185:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose186:
+ax_pose 23, 0x81dd, 0x90fd, 0x0c00
+ax_pose 24, 0x01e5, 0x10f5, 0x0c08
+ax_pose 25, 0x01ed, 0x50ed, 0x0c09
+ax_pose 26, 0x41fd, 0x10f5, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose187:
+ax_pose 60, 0x41e4, 0x90f4, 0x0c00
+ax_pose 61, 0x41f4, 0x50f4, 0x0c08
+ax_pose 62, 0x41fc, 0x10f4, 0x0c0c
+ax_pose 63, 0x01f4, 0x10ec, 0x0c0e
+ax_pose 64, 0x01ec, 0x10ec, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose188:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose189:
+ax_pose 32, 0x81e2, 0x90fd, 0x0c00
+ax_pose 33, 0x81e2, 0x50f5, 0x0c08
+ax_pose 34, 0x01fa, 0x10ed, 0x0c0c
+ax_pose 35, 0x01da, 0x10fd, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose190:
+ax_pose 65, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sFeraligatrPose191:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose192:
+ax_pose 37, 0x41e7, 0x80f0, 0x0c00
+ax_pose 38, 0x41f7, 0x40f0, 0x0c08
+ax_pose 39, 0x41ff, 0x00f8, 0x0c0c
+ax_pose 40, 0x01df, 0x00fc, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose193:
+ax_pose 66, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose194:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose195:
+ax_pose 32, 0x81e2, 0x80f3, 0x0c00
+ax_pose 33, 0x81e2, 0x4103, 0x0c08
+ax_pose 34, 0x01fa, 0x010b, 0x0c0c
+ax_pose 35, 0x01da, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose196:
+ax_pose 65, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sFeraligatrPose197:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose198:
+ax_pose 23, 0x81dd, 0x80f3, 0x0c00
+ax_pose 24, 0x01e5, 0x0103, 0x0c08
+ax_pose 25, 0x01ed, 0x4103, 0x0c09
+ax_pose 26, 0x41fd, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose199:
+ax_pose 60, 0x41e4, 0x80ec, 0x0c00
+ax_pose 61, 0x41f4, 0x40ec, 0x0c08
+ax_pose 62, 0x41fc, 0x00fc, 0x0c0c
+ax_pose 63, 0x01f4, 0x010c, 0x0c0e
+ax_pose 64, 0x01ec, 0x010c, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose200:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose201:
+ax_pose 17, 0x81e0, 0x80ef, 0x0c00
+ax_pose 18, 0x81e0, 0x40ff, 0x0c08
+ax_pose 19, 0x01e8, 0x0107, 0x0c0c
+ax_pose 20, 0x81f0, 0x0107, 0x0c0d
+ax_pose 21, 0x0200, 0x0102, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose202:
+ax_pose 56, 0x41e6, 0x80f0, 0x0c00
+ax_pose 57, 0x41f6, 0x40f0, 0x0c08
+ax_pose 58, 0x41fe, 0x0100, 0x0c0c
+ax_pose 59, 0x01ee, 0x00e8, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose203:
+ax_pose 15, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose204:
+ax_pose 17, 0x81e1, 0x80ef, 0x0c00
+ax_pose 18, 0x81e1, 0x40ff, 0x0c08
+ax_pose 19, 0x01e9, 0x0107, 0x0c0c
+ax_pose 20, 0x81f1, 0x0107, 0x0c0d
+ax_pose 21, 0x0201, 0x0102, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose205:
+ax_pose 23, 0x81de, 0x80f3, 0x0c00
+ax_pose 24, 0x01e6, 0x0103, 0x0c08
+ax_pose 25, 0x01ee, 0x4103, 0x0c09
+ax_pose 26, 0x41fe, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose206:
+ax_pose 32, 0x81e3, 0x80f3, 0x0c00
+ax_pose 33, 0x81e3, 0x4103, 0x0c08
+ax_pose 34, 0x01fb, 0x010b, 0x0c0c
+ax_pose 35, 0x01db, 0x00fb, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose207:
+ax_pose 37, 0x41e8, 0x80f0, 0x0c00
+ax_pose 38, 0x41f8, 0x40f0, 0x0c08
+ax_pose 39, 0x4200, 0x00f8, 0x0c0c
+ax_pose 40, 0x01e0, 0x00fc, 0x0c0e
+ax_pose_terminator
+sFeraligatrPose208:
+ax_pose 32, 0x81e3, 0x90fd, 0x0c00
+ax_pose 33, 0x81e3, 0x50f5, 0x0c08
+ax_pose 34, 0x01fb, 0x10ed, 0x0c0c
+ax_pose 35, 0x01db, 0x10fd, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose209:
+ax_pose 23, 0x81de, 0x90fd, 0x0c00
+ax_pose 24, 0x01e6, 0x10f5, 0x0c08
+ax_pose 25, 0x01ee, 0x50ed, 0x0c09
+ax_pose 26, 0x41fe, 0x10f5, 0x0c0d
+ax_pose_terminator
+sFeraligatrPose210:
+ax_pose 17, 0x81e1, 0x9100, 0x0c00
+ax_pose 18, 0x81e1, 0x50f8, 0x0c08
+ax_pose 19, 0x01e9, 0x10f0, 0x0c0c
+ax_pose 20, 0x81f1, 0x10f0, 0x0c0d
+ax_pose 21, 0x0201, 0x10f5, 0x0c0f
+ax_pose_terminator
+sFeraligatrPose211:
+ax_pose 0, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose212:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose213:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose214:
+ax_pose 9, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose215:
+ax_pose 12, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose216:
+ax_pose 9, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose217:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sFeraligatrPose218:
+ax_pose 3, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+.align 2
+sFeraligatrAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sFeraligatrAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 30, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sFeraligatrAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 8, 0, 8, 0,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 1, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 0, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 0, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sFeraligatrAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 36, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 15, -16, 15, -16,
+ax_anim 2, 1, 39, 16, -15, 16, -15,
+ax_anim 2, 0, 39, 15, -16, 15, -16,
+ax_anim 2, 0, 39, 16, -15, 16, -15,
+ax_anim 2, 0, 39, 15, -16, 15, -16,
+ax_anim 2, 0, 39, 16, -15, 16, -15,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sFeraligatrAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sFeraligatrAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 44, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -15, -16, -15, -16,
+ax_anim 2, 1, 47, -16, -15, -16, -15,
+ax_anim 2, 0, 47, -15, -16, -15, -16,
+ax_anim 2, 0, 47, -16, -15, -16, -15,
+ax_anim 2, 0, 47, -15, -16, -15, -16,
+ax_anim 2, 0, 47, -16, -15, -16, -15,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sFeraligatrAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 48, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -8, 0, -8, 0,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 1, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sFeraligatrAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 52, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 1, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_3_1:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 6, 0, 101, 2, -3, 2, -3,
+ax_anim 1, 2, 59, 0, 2, 0, 2,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 2, 0, 60, 0, 14, 0, 14,
+ax_anim 2, 1, 61, 1, 14, 1, 14,
+ax_anim 2, 0, 61, 0, 14, 0, 14,
+ax_anim 2, 0, 61, 1, 14, 1, 14,
+ax_anim 2, 0, 61, 0, 14, 0, 14,
+ax_anim 2, 0, 61, 1, 14, 1, 14,
+ax_anim 2, 0, 61, 0, 14, 0, 14,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sFeraligatrAnims_3_2:
+ax_anim 2, 0, 71, -2, -2, -2, -2,
+ax_anim 6, 0, 71, -3, -3, -3, -3,
+ax_anim 1, 2, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 6, 8, 6, 8,
+ax_anim 2, 0, 66, 13, 17, 13, 17,
+ax_anim 2, 1, 67, 14, 16, 14, 16,
+ax_anim 2, 0, 67, 13, 17, 13, 17,
+ax_anim 2, 0, 67, 14, 16, 14, 16,
+ax_anim 2, 0, 67, 13, 17, 13, 17,
+ax_anim 2, 0, 67, 14, 16, 14, 16,
+ax_anim 2, 0, 67, 13, 17, 13, 17,
+ax_anim 2, 0, 62, 9, 11, 9, 11,
+ax_anim 2, 0, 62, 3, 5, 3, 5,
+ax_anim_terminator
+sFeraligatrAnims_3_3:
+ax_anim 2, 0, 77, -2, 0, -2, 0,
+ax_anim 6, 0, 77, -3, 0, -3, 0,
+ax_anim 1, 2, 71, 2, 0, 2, 0,
+ax_anim 1, 0, 71, 6, 0, 6, 0,
+ax_anim 2, 0, 72, 9, 0, 9, 0,
+ax_anim 2, 1, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 73, 10, 1, 10, 1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 73, 10, 1, 10, 1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 73, 10, 1, 10, 1,
+ax_anim 2, 0, 68, 7, 0, 7, 0,
+ax_anim 2, 0, 68, 3, 0, 3, 0,
+ax_anim_terminator
+sFeraligatrAnims_3_4:
+ax_anim 2, 0, 83, -2, 2, -2, 2,
+ax_anim 6, 0, 83, -3, 3, -3, 3,
+ax_anim 1, 2, 77, 2, -2, 2, -2,
+ax_anim 1, 0, 77, 8, -7, 8, -7,
+ax_anim 2, 0, 78, 13, -11, 13, -11,
+ax_anim 2, 1, 79, 14, -10, 14, -10,
+ax_anim 2, 0, 79, 13, -11, 13, -11,
+ax_anim 2, 0, 79, 14, -10, 14, -10,
+ax_anim 2, 0, 79, 13, -11, 13, -11,
+ax_anim 2, 0, 79, 14, -10, 14, -10,
+ax_anim 2, 0, 79, 13, -11, 13, -11,
+ax_anim 2, 0, 74, 11, -10, 11, -10,
+ax_anim 2, 0, 74, 4, -4, 4, -4,
+ax_anim_terminator
+sFeraligatrAnims_3_5:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 6, 0, 77, 2, 3, 2, 3,
+ax_anim 1, 2, 83, 0, -2, 0, -2,
+ax_anim 1, 0, 83, 0, -7, 0, -7,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 1, 85, 1, -10, 1, -10,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 85, 1, -10, 1, -10,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 85, 1, -10, 1, -10,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -6, 0, -6,
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim_terminator
+sFeraligatrAnims_3_6:
+ax_anim 2, 0, 83, 4, 0, 2, 2,
+ax_anim 6, 0, 83, 5, 1, 3, 3,
+ax_anim 1, 2, 89, -2, -2, -2, -2,
+ax_anim 1, 0, 89, -8, -7, -8, -7,
+ax_anim 2, 0, 90, -13, -11, -13, -11,
+ax_anim 2, 1, 91, -14, -10, -14, -10,
+ax_anim 2, 0, 91, -13, -11, -13, -11,
+ax_anim 2, 0, 91, -14, -10, -14, -10,
+ax_anim 2, 0, 91, -13, -11, -13, -11,
+ax_anim 2, 0, 91, -14, -10, -14, -10,
+ax_anim 2, 0, 91, -13, -11, -13, -11,
+ax_anim 2, 0, 86, -11, -10, -11, -10,
+ax_anim 2, 0, 86, -4, -4, -4, -4,
+ax_anim_terminator
+sFeraligatrAnims_3_7:
+ax_anim 2, 0, 89, 2, 0, 2, 0,
+ax_anim 6, 0, 89, 3, 0, 3, 0,
+ax_anim 1, 2, 95, -2, 0, -2, 0,
+ax_anim 1, 0, 95, -6, 0, -6, 0,
+ax_anim 2, 0, 96, -9, 0, -9, 0,
+ax_anim 2, 1, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -10, 1, -10, 1,
+ax_anim 2, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -10, 1, -10, 1,
+ax_anim 2, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -10, 1, -10, 1,
+ax_anim 2, 0, 92, -7, 0, -7, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim_terminator
+sFeraligatrAnims_3_8:
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 6, 0, 95, 3, -3, 3, -3,
+ax_anim 1, 2, 101, -2, 2, -2, 2,
+ax_anim 1, 0, 101, -6, 8, -6, 8,
+ax_anim 2, 0, 102, -13, 17, -13, 17,
+ax_anim 2, 1, 103, -14, 16, -14, 16,
+ax_anim 2, 0, 103, -13, 17, -13, 17,
+ax_anim 2, 0, 103, -14, 16, -14, 16,
+ax_anim 2, 0, 103, -13, 17, -13, 17,
+ax_anim 2, 0, 103, -14, 16, -14, 16,
+ax_anim 2, 0, 103, -13, 17, -13, 17,
+ax_anim 2, 0, 98, -9, 11, -9, 11,
+ax_anim 2, 0, 98, -3, 5, -3, 5,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 105, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 1, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 104, 0, 3, 0, 2,
+ax_anim_terminator
+sFeraligatrAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 1, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 107, 2, 2, 1, 1,
+ax_anim_terminator
+sFeraligatrAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 1, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 1, 0, 2, 0,
+ax_anim_terminator
+sFeraligatrAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 114, -1, 1, -1, 1,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 1, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 113, 2, -2, 1, -1,
+ax_anim_terminator
+sFeraligatrAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 1, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim_terminator
+sFeraligatrAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 120, 1, 1, 1, 1,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 1, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 119, -2, -2, -1, -1,
+ax_anim_terminator
+sFeraligatrAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 1, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sFeraligatrAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 1, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 125, -2, 2, -1, 1,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sFeraligatrAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sFeraligatrAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sFeraligatrAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sFeraligatrAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sFeraligatrAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sFeraligatrAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sFeraligatrAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_8_1:
+ax_anim 36, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_8_2:
+ax_anim 36, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 16, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_8_3:
+ax_anim 36, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 4, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_8_4:
+ax_anim 36, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_8_5:
+ax_anim 36, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 2, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 16, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_8_6:
+ax_anim 36, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 0, 156, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 16, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_8_7:
+ax_anim 36, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_8_8:
+ax_anim 36, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 2, 0, 160, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 16, 7, 16,
+ax_anim 3, 0, 166, 0, 19, 0, 19,
+ax_anim 2, 3, 167, -7, 16, -7, 16,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 17, 19, 17, 19,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 18, -2, 18, -2,
+ax_anim 2, 3, 165, 16, 3, 16, 3,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 4, 4, 4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -20, 12, -20,
+ax_anim 3, 0, 163, 18, -19, 18, -19,
+ax_anim 2, 3, 164, 20, -13, 20, -13,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 8, 1, 8, 1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -21, 0, -21,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -20, -12, -20,
+ax_anim 3, 0, 169, -18, -19, -18, -19,
+ax_anim 2, 3, 168, -20, -13, -20, -13,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -8, 1, -8, 1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -18, -2, -18, -2,
+ax_anim 2, 3, 167, -16, 3, -16, 3,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -17, 19, -17, 19,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -14, 0, 0,
+ax_anim 3, 0, 179, 0, -16, 0, 0,
+ax_anim 4, 0, 179, 0, -17, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -15, 0, 0,
+ax_anim 3, 0, 182, 0, -19, 0, 0,
+ax_anim 4, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -15, 0, 0,
+ax_anim 3, 0, 185, 0, -19, 0, 0,
+ax_anim 4, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -15, 0, 0,
+ax_anim 3, 0, 188, 0, -19, 0, 0,
+ax_anim 4, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -15, 0, 0,
+ax_anim 3, 0, 191, 0, -19, 0, 0,
+ax_anim 4, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -15, 0, 0,
+ax_anim 3, 0, 194, 0, -19, 0, 0,
+ax_anim 4, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -15, 0, 0,
+ax_anim 3, 0, 197, 0, -19, 0, 0,
+ax_anim 4, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -15, 0, 0,
+ax_anim 3, 0, 200, 0, -19, 0, 0,
+ax_anim 4, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFeraligatrAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sFeraligatrGfx1:
+.incbin "baserom.gba", 0xC0A1B0, 0x200
+sFeraligatrSprites1:
+ax_sprite sFeraligatrGfx1, 0x200
+ax_sprite_terminator
+sFeraligatrGfx2:
+.incbin "baserom.gba", 0xC0A3C0, 0x200
+sFeraligatrSprites2:
+ax_sprite sFeraligatrGfx2, 0x200
+ax_sprite_terminator
+sFeraligatrGfx3:
+.incbin "baserom.gba", 0xC0A5D0, 0x200
+sFeraligatrSprites3:
+ax_sprite sFeraligatrGfx3, 0x200
+ax_sprite_terminator
+sFeraligatrGfx4:
+.incbin "baserom.gba", 0xC0A7E0, 0x200
+sFeraligatrSprites4:
+ax_sprite sFeraligatrGfx4, 0x200
+ax_sprite_terminator
+sFeraligatrGfx5:
+.incbin "baserom.gba", 0xC0A9F0, 0x200
+sFeraligatrSprites5:
+ax_sprite sFeraligatrGfx5, 0x200
+ax_sprite_terminator
+sFeraligatrGfx6:
+.incbin "baserom.gba", 0xC0AC00, 0x200
+sFeraligatrSprites6:
+ax_sprite sFeraligatrGfx6, 0x200
+ax_sprite_terminator
+sFeraligatrGfx7:
+.incbin "baserom.gba", 0xC0AE10, 0x200
+sFeraligatrSprites7:
+ax_sprite sFeraligatrGfx7, 0x200
+ax_sprite_terminator
+sFeraligatrGfx8:
+.incbin "baserom.gba", 0xC0B020, 0x200
+sFeraligatrSprites8:
+ax_sprite sFeraligatrGfx8, 0x200
+ax_sprite_terminator
+sFeraligatrGfx9:
+.incbin "baserom.gba", 0xC0B230, 0x200
+sFeraligatrSprites9:
+ax_sprite sFeraligatrGfx9, 0x200
+ax_sprite_terminator
+sFeraligatrGfx10:
+.incbin "baserom.gba", 0xC0B440, 0x200
+sFeraligatrSprites10:
+ax_sprite sFeraligatrGfx10, 0x200
+ax_sprite_terminator
+sFeraligatrGfx11:
+.incbin "baserom.gba", 0xC0B650, 0x200
+sFeraligatrSprites11:
+ax_sprite sFeraligatrGfx11, 0x200
+ax_sprite_terminator
+sFeraligatrGfx12:
+.incbin "baserom.gba", 0xC0B860, 0x200
+sFeraligatrSprites12:
+ax_sprite sFeraligatrGfx12, 0x200
+ax_sprite_terminator
+sFeraligatrGfx13:
+.incbin "baserom.gba", 0xC0BA70, 0x200
+sFeraligatrSprites13:
+ax_sprite sFeraligatrGfx13, 0x200
+ax_sprite_terminator
+sFeraligatrGfx14:
+.incbin "baserom.gba", 0xC0BC80, 0x200
+sFeraligatrSprites14:
+ax_sprite sFeraligatrGfx14, 0x200
+ax_sprite_terminator
+sFeraligatrGfx15:
+.incbin "baserom.gba", 0xC0BE90, 0x200
+sFeraligatrSprites15:
+ax_sprite sFeraligatrGfx15, 0x200
+ax_sprite_terminator
+sFeraligatrGfx16:
+.incbin "baserom.gba", 0xC0C0A0, 0x200
+sFeraligatrSprites16:
+ax_sprite sFeraligatrGfx16, 0x200
+ax_sprite_terminator
+sFeraligatrGfx17:
+.incbin "baserom.gba", 0xC0C2B0, 0x180
+sFeraligatrSprites17:
+ax_sprite 0, 0x80
+ax_sprite sFeraligatrGfx17, 0x180
+ax_sprite_terminator
+sFeraligatrGfx18:
+.incbin "baserom.gba", 0xC0C448, 0x100
+sFeraligatrSprites18:
+ax_sprite sFeraligatrGfx18, 0x100
+ax_sprite_terminator
+sFeraligatrGfx19:
+.incbin "baserom.gba", 0xC0C558, 0x80
+sFeraligatrSprites19:
+ax_sprite sFeraligatrGfx19, 0x80
+ax_sprite_terminator
+sFeraligatrGfx20:
+.incbin "baserom.gba", 0xC0C5E8, 0x20
+sFeraligatrSprites20:
+ax_sprite sFeraligatrGfx20, 0x20
+ax_sprite_terminator
+sFeraligatrGfx21:
+.incbin "baserom.gba", 0xC0C618, 0x40
+sFeraligatrSprites21:
+ax_sprite sFeraligatrGfx21, 0x40
+ax_sprite_terminator
+sFeraligatrGfx22:
+.incbin "baserom.gba", 0xC0C668, 0x20
+sFeraligatrSprites22:
+ax_sprite sFeraligatrGfx22, 0x20
+ax_sprite_terminator
+sFeraligatrGfx23:
+.incbin "baserom.gba", 0xC0C698, 0x40
+sFeraligatrGfx23_1:
+.incbin "baserom.gba", 0xC0C6D8, 0x180
+sFeraligatrSprites23:
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx23_1, 0x180
+ax_sprite_terminator
+sFeraligatrGfx24:
+.incbin "baserom.gba", 0xC0C880, 0x100
+sFeraligatrSprites24:
+ax_sprite sFeraligatrGfx24, 0x100
+ax_sprite_terminator
+sFeraligatrGfx25:
+.incbin "baserom.gba", 0xC0C990, 0x20
+sFeraligatrSprites25:
+ax_sprite sFeraligatrGfx25, 0x20
+ax_sprite_terminator
+sFeraligatrGfx26:
+.incbin "baserom.gba", 0xC0C9C0, 0x80
+sFeraligatrSprites26:
+ax_sprite sFeraligatrGfx26, 0x80
+ax_sprite_terminator
+sFeraligatrGfx27:
+.incbin "baserom.gba", 0xC0CA50, 0x40
+sFeraligatrSprites27:
+ax_sprite sFeraligatrGfx27, 0x40
+ax_sprite_terminator
+sFeraligatrGfx28:
+.incbin "baserom.gba", 0xC0CAA0, 0xC0
+sFeraligatrGfx28_1:
+.incbin "baserom.gba", 0xC0CB60, 0x20
+sFeraligatrSprites28:
+ax_sprite sFeraligatrGfx28, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx28_1, 0x20
+ax_sprite_terminator
+sFeraligatrGfx29:
+.incbin "baserom.gba", 0xC0CBA0, 0x80
+sFeraligatrSprites29:
+ax_sprite sFeraligatrGfx29, 0x80
+ax_sprite_terminator
+sFeraligatrGfx30:
+.incbin "baserom.gba", 0xC0CC30, 0x40
+sFeraligatrSprites30:
+ax_sprite sFeraligatrGfx30, 0x40
+ax_sprite_terminator
+sFeraligatrGfx31:
+.incbin "baserom.gba", 0xC0CC80, 0x20
+sFeraligatrSprites31:
+ax_sprite sFeraligatrGfx31, 0x20
+ax_sprite_terminator
+sFeraligatrGfx32:
+.incbin "baserom.gba", 0xC0CCB0, 0x20
+sFeraligatrSprites32:
+ax_sprite sFeraligatrGfx32, 0x20
+ax_sprite_terminator
+sFeraligatrGfx33:
+.incbin "baserom.gba", 0xC0CCE0, 0x100
+sFeraligatrSprites33:
+ax_sprite sFeraligatrGfx33, 0x100
+ax_sprite_terminator
+sFeraligatrGfx34:
+.incbin "baserom.gba", 0xC0CDF0, 0x80
+sFeraligatrSprites34:
+ax_sprite sFeraligatrGfx34, 0x80
+ax_sprite_terminator
+sFeraligatrGfx35:
+.incbin "baserom.gba", 0xC0CE80, 0x20
+sFeraligatrSprites35:
+ax_sprite sFeraligatrGfx35, 0x20
+ax_sprite_terminator
+sFeraligatrGfx36:
+.incbin "baserom.gba", 0xC0CEB0, 0x20
+sFeraligatrSprites36:
+ax_sprite sFeraligatrGfx36, 0x20
+ax_sprite_terminator
+sFeraligatrGfx37:
+.incbin "baserom.gba", 0xC0CEE0, 0x60
+sFeraligatrGfx37_1:
+.incbin "baserom.gba", 0xC0CF40, 0x60
+sFeraligatrGfx37_2:
+.incbin "baserom.gba", 0xC0CFA0, 0x100
+sFeraligatrSprites37:
+ax_sprite sFeraligatrGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx37_2, 0x100
+ax_sprite_terminator
+sFeraligatrGfx38:
+.incbin "baserom.gba", 0xC0D0D0, 0x100
+sFeraligatrSprites38:
+ax_sprite sFeraligatrGfx38, 0x100
+ax_sprite_terminator
+sFeraligatrGfx39:
+.incbin "baserom.gba", 0xC0D1E0, 0x80
+sFeraligatrSprites39:
+ax_sprite sFeraligatrGfx39, 0x80
+ax_sprite_terminator
+sFeraligatrGfx40:
+.incbin "baserom.gba", 0xC0D270, 0x40
+sFeraligatrSprites40:
+ax_sprite sFeraligatrGfx40, 0x40
+ax_sprite_terminator
+sFeraligatrGfx41:
+.incbin "baserom.gba", 0xC0D2C0, 0x20
+sFeraligatrSprites41:
+ax_sprite sFeraligatrGfx41, 0x20
+ax_sprite_terminator
+sFeraligatrGfx42:
+.incbin "baserom.gba", 0xC0D2F0, 0x40
+sFeraligatrGfx42_1:
+.incbin "baserom.gba", 0xC0D330, 0x60
+sFeraligatrGfx42_2:
+.incbin "baserom.gba", 0xC0D390, 0x100
+sFeraligatrSprites42:
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx42_2, 0x100
+ax_sprite_terminator
+sFeraligatrGfx43:
+.incbin "baserom.gba", 0xC0D4C8, 0x60
+sFeraligatrGfx43_1:
+.incbin "baserom.gba", 0xC0D528, 0x180
+sFeraligatrSprites43:
+ax_sprite sFeraligatrGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx43_1, 0x180
+ax_sprite_terminator
+sFeraligatrGfx44:
+.incbin "baserom.gba", 0xC0D6C8, 0x20
+sFeraligatrGfx44_1:
+.incbin "baserom.gba", 0xC0D6E8, 0x20
+sFeraligatrGfx44_2:
+.incbin "baserom.gba", 0xC0D708, 0x40
+sFeraligatrGfx44_3:
+.incbin "baserom.gba", 0xC0D748, 0x60
+sFeraligatrSprites44:
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx44, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFeraligatrGfx44_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFeraligatrGfx44_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFeraligatrGfx44_3, 0x60
+ax_sprite_terminator
+sFeraligatrGfx45:
+.incbin "baserom.gba", 0xC0D7F0, 0x60
+sFeraligatrGfx45_1:
+.incbin "baserom.gba", 0xC0D850, 0x100
+sFeraligatrGfx45_2:
+.incbin "baserom.gba", 0xC0D950, 0x60
+sFeraligatrSprites45:
+ax_sprite sFeraligatrGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx45_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx45_2, 0x60
+ax_sprite_terminator
+sFeraligatrGfx46:
+.incbin "baserom.gba", 0xC0D9E0, 0x60
+sFeraligatrGfx46_1:
+.incbin "baserom.gba", 0xC0DA40, 0x80
+sFeraligatrSprites46:
+ax_sprite sFeraligatrGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx46_1, 0x80
+ax_sprite_terminator
+sFeraligatrGfx47:
+.incbin "baserom.gba", 0xC0DAE0, 0x60
+sFeraligatrGfx47_1:
+.incbin "baserom.gba", 0xC0DB40, 0x80
+sFeraligatrSprites47:
+ax_sprite sFeraligatrGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx47_1, 0x80
+ax_sprite_terminator
+sFeraligatrGfx48:
+.incbin "baserom.gba", 0xC0DBE0, 0x80
+sFeraligatrSprites48:
+ax_sprite sFeraligatrGfx48, 0x80
+ax_sprite_terminator
+sFeraligatrGfx49:
+.incbin "baserom.gba", 0xC0DC70, 0x40
+sFeraligatrSprites49:
+ax_sprite sFeraligatrGfx49, 0x40
+ax_sprite_terminator
+sFeraligatrGfx50:
+.incbin "baserom.gba", 0xC0DCC0, 0x20
+sFeraligatrSprites50:
+ax_sprite sFeraligatrGfx50, 0x20
+ax_sprite_terminator
+sFeraligatrGfx51:
+.incbin "baserom.gba", 0xC0DCF0, 0xA0
+sFeraligatrGfx51_1:
+.incbin "baserom.gba", 0xC0DD90, 0x40
+sFeraligatrGfx51_2:
+.incbin "baserom.gba", 0xC0DDD0, 0x40
+sFeraligatrSprites51:
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx51, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sFeraligatrGfx51_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFeraligatrGfx51_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFeraligatrGfx52:
+.incbin "baserom.gba", 0xC0DE50, 0x200
+sFeraligatrSprites52:
+ax_sprite sFeraligatrGfx52, 0x200
+ax_sprite_terminator
+sFeraligatrGfx53:
+.incbin "baserom.gba", 0xC0E060, 0xC0
+sFeraligatrGfx53_1:
+.incbin "baserom.gba", 0xC0E120, 0x60
+sFeraligatrGfx53_2:
+.incbin "baserom.gba", 0xC0E180, 0x40
+sFeraligatrSprites53:
+ax_sprite sFeraligatrGfx53, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx53_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFeraligatrGfx53_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFeraligatrGfx54:
+.incbin "baserom.gba", 0xC0E1F8, 0x200
+sFeraligatrSprites54:
+ax_sprite sFeraligatrGfx54, 0x200
+ax_sprite_terminator
+sFeraligatrGfx55:
+.incbin "baserom.gba", 0xC0E408, 0x140
+sFeraligatrGfx55_1:
+.incbin "baserom.gba", 0xC0E548, 0x20
+sFeraligatrGfx55_2:
+.incbin "baserom.gba", 0xC0E568, 0x20
+sFeraligatrSprites55:
+ax_sprite sFeraligatrGfx55, 0x140
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx55_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sFeraligatrGfx55_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFeraligatrGfx56:
+.incbin "baserom.gba", 0xC0E5C0, 0x40
+sFeraligatrGfx56_1:
+.incbin "baserom.gba", 0xC0E600, 0x180
+sFeraligatrSprites56:
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx56_1, 0x180
+ax_sprite_terminator
+sFeraligatrGfx57:
+.incbin "baserom.gba", 0xC0E7A8, 0x100
+sFeraligatrSprites57:
+ax_sprite sFeraligatrGfx57, 0x100
+ax_sprite_terminator
+sFeraligatrGfx58:
+.incbin "baserom.gba", 0xC0E8B8, 0x80
+sFeraligatrSprites58:
+ax_sprite sFeraligatrGfx58, 0x80
+ax_sprite_terminator
+sFeraligatrGfx59:
+.incbin "baserom.gba", 0xC0E948, 0x40
+sFeraligatrSprites59:
+ax_sprite sFeraligatrGfx59, 0x40
+ax_sprite_terminator
+sFeraligatrGfx60:
+.incbin "baserom.gba", 0xC0E998, 0x20
+sFeraligatrSprites60:
+ax_sprite sFeraligatrGfx60, 0x20
+ax_sprite_terminator
+sFeraligatrGfx61:
+.incbin "baserom.gba", 0xC0E9C8, 0x100
+sFeraligatrSprites61:
+ax_sprite sFeraligatrGfx61, 0x100
+ax_sprite_terminator
+sFeraligatrGfx62:
+.incbin "baserom.gba", 0xC0EAD8, 0x80
+sFeraligatrSprites62:
+ax_sprite sFeraligatrGfx62, 0x80
+ax_sprite_terminator
+sFeraligatrGfx63:
+.incbin "baserom.gba", 0xC0EB68, 0x40
+sFeraligatrSprites63:
+ax_sprite sFeraligatrGfx63, 0x40
+ax_sprite_terminator
+sFeraligatrGfx64:
+.incbin "baserom.gba", 0xC0EBB8, 0x20
+sFeraligatrSprites64:
+ax_sprite sFeraligatrGfx64, 0x20
+ax_sprite_terminator
+sFeraligatrGfx65:
+.incbin "baserom.gba", 0xC0EBE8, 0x20
+sFeraligatrSprites65:
+ax_sprite sFeraligatrGfx65, 0x20
+ax_sprite_terminator
+sFeraligatrGfx66:
+.incbin "baserom.gba", 0xC0EC18, 0x60
+sFeraligatrGfx66_1:
+.incbin "baserom.gba", 0xC0EC78, 0x180
+sFeraligatrSprites66:
+ax_sprite sFeraligatrGfx66, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx66_1, 0x180
+ax_sprite_terminator
+sFeraligatrGfx67:
+.incbin "baserom.gba", 0xC0EE18, 0x40
+sFeraligatrGfx67_1:
+.incbin "baserom.gba", 0xC0EE58, 0x180
+sFeraligatrSprites67:
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx67, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFeraligatrGfx67_1, 0x180
+ax_sprite_terminator
+sFeraligatrGfx68:
+.incbin "baserom.gba", 0xC0F000, 0x200
+sFeraligatrSprites68:
+ax_sprite sFeraligatrGfx68, 0x200
+ax_sprite_terminator
+sFeraligatrGfx69:
+.incbin "baserom.gba", 0xC0F210, 0x200
+sFeraligatrSprites69:
+ax_sprite sFeraligatrGfx69, 0x200
+ax_sprite_terminator
+sFeraligatrGfx70:
+.incbin "baserom.gba", 0xC0F420, 0x200
+sFeraligatrSprites70:
+ax_sprite sFeraligatrGfx70, 0x200
+ax_sprite_terminator
+sFeraligatrGfx71:
+.incbin "baserom.gba", 0xC0F630, 0x80
+sFeraligatrSprites71:
+ax_sprite sFeraligatrGfx71, 0x80
+ax_sprite_terminator
+sFeraligatrGfx72:
+.incbin "baserom.gba", 0xC0F6C0, 0x40
+sFeraligatrSprites72:
+ax_sprite sFeraligatrGfx72, 0x40
+ax_sprite_terminator
+sFeraligatrGfx73:
+.incbin "baserom.gba", 0xC0F710, 0x20
+sFeraligatrSprites73:
+ax_sprite sFeraligatrGfx73, 0x20
+ax_sprite_terminator
+sFeraligatrGfx74:
+.incbin "baserom.gba", 0xC0F740, 0x20
+sFeraligatrSprites74:
+ax_sprite sFeraligatrGfx74, 0x20
+ax_sprite_terminator
+sFeraligatrGfx75:
+.incbin "baserom.gba", 0xC0F770, 0x100
+sFeraligatrSprites75:
+ax_sprite sFeraligatrGfx75, 0x100
+ax_sprite_terminator
+sFeraligatrGfx76:
+.incbin "baserom.gba", 0xC0F880, 0x80
+sFeraligatrSprites76:
+ax_sprite sFeraligatrGfx76, 0x80
+ax_sprite_terminator
+sFeraligatrGfx77:
+.incbin "baserom.gba", 0xC0F910, 0x40
+sFeraligatrSprites77:
+ax_sprite sFeraligatrGfx77, 0x40
+ax_sprite_terminator
+sFeraligatrGfx78:
+.incbin "baserom.gba", 0xC0F960, 0x40
+sFeraligatrSprites78:
+ax_sprite sFeraligatrGfx78, 0x40
+ax_sprite_terminator
+sFeraligatrGfx79:
+.incbin "baserom.gba", 0xC0F9B0, 0x100
+sFeraligatrSprites79:
+ax_sprite sFeraligatrGfx79, 0x100
+ax_sprite_terminator
+sFeraligatrGfx80:
+.incbin "baserom.gba", 0xC0FAC0, 0x80
+sFeraligatrSprites80:
+ax_sprite sFeraligatrGfx80, 0x80
+ax_sprite_terminator
+sFeraligatrGfx81:
+.incbin "baserom.gba", 0xC0FB50, 0x20
+sFeraligatrSprites81:
+ax_sprite sFeraligatrGfx81, 0x20
+ax_sprite_terminator
+sFeraligatrGfx82:
+.incbin "baserom.gba", 0xC0FB80, 0x40
+sFeraligatrSprites82:
+ax_sprite sFeraligatrGfx82, 0x40
+ax_sprite_terminator
+sFeraligatrGfx83:
+.incbin "baserom.gba", 0xC0FBD0, 0x20
+sFeraligatrSprites83:
+ax_sprite sFeraligatrGfx83, 0x20
+ax_sprite_terminator
+sFeraligatrGfx84:
+.incbin "baserom.gba", 0xC0FC00, 0x100
+sFeraligatrSprites84:
+ax_sprite sFeraligatrGfx84, 0x100
+ax_sprite_terminator
+sFeraligatrGfx85:
+.incbin "baserom.gba", 0xC0FD10, 0x80
+sFeraligatrSprites85:
+ax_sprite sFeraligatrGfx85, 0x80
+ax_sprite_terminator
+sFeraligatrGfx86:
+.incbin "baserom.gba", 0xC0FDA0, 0x40
+sFeraligatrSprites86:
+ax_sprite sFeraligatrGfx86, 0x40
+ax_sprite_terminator
+sFeraligatrGfx87:
+.incbin "baserom.gba", 0xC0FDF0, 0x40
+sFeraligatrSprites87:
+ax_sprite sFeraligatrGfx87, 0x40
+ax_sprite_terminator
+sFeraligatrGfx88:
+.incbin "baserom.gba", 0xC0FE40, 0x100
+sFeraligatrSprites88:
+ax_sprite sFeraligatrGfx88, 0x100
+ax_sprite_terminator
+sAxPosesFeraligatr:
+.4byte sFeraligatrPose1
+.4byte sFeraligatrPose2
+.4byte sFeraligatrPose3
+.4byte sFeraligatrPose4
+.4byte sFeraligatrPose5
+.4byte sFeraligatrPose6
+.4byte sFeraligatrPose7
+.4byte sFeraligatrPose8
+.4byte sFeraligatrPose9
+.4byte sFeraligatrPose10
+.4byte sFeraligatrPose11
+.4byte sFeraligatrPose12
+.4byte sFeraligatrPose13
+.4byte sFeraligatrPose14
+.4byte sFeraligatrPose15
+.4byte sFeraligatrPose16
+.4byte sFeraligatrPose17
+.4byte sFeraligatrPose18
+.4byte sFeraligatrPose19
+.4byte sFeraligatrPose20
+.4byte sFeraligatrPose21
+.4byte sFeraligatrPose22
+.4byte sFeraligatrPose23
+.4byte sFeraligatrPose24
+.4byte sFeraligatrPose25
+.4byte sFeraligatrPose26
+.4byte sFeraligatrPose27
+.4byte sFeraligatrPose28
+.4byte sFeraligatrPose29
+.4byte sFeraligatrPose30
+.4byte sFeraligatrPose31
+.4byte sFeraligatrPose32
+.4byte sFeraligatrPose33
+.4byte sFeraligatrPose34
+.4byte sFeraligatrPose35
+.4byte sFeraligatrPose36
+.4byte sFeraligatrPose37
+.4byte sFeraligatrPose38
+.4byte sFeraligatrPose39
+.4byte sFeraligatrPose40
+.4byte sFeraligatrPose41
+.4byte sFeraligatrPose42
+.4byte sFeraligatrPose43
+.4byte sFeraligatrPose44
+.4byte sFeraligatrPose45
+.4byte sFeraligatrPose46
+.4byte sFeraligatrPose47
+.4byte sFeraligatrPose48
+.4byte sFeraligatrPose49
+.4byte sFeraligatrPose50
+.4byte sFeraligatrPose51
+.4byte sFeraligatrPose52
+.4byte sFeraligatrPose53
+.4byte sFeraligatrPose54
+.4byte sFeraligatrPose55
+.4byte sFeraligatrPose56
+.4byte sFeraligatrPose57
+.4byte sFeraligatrPose58
+.4byte sFeraligatrPose59
+.4byte sFeraligatrPose60
+.4byte sFeraligatrPose61
+.4byte sFeraligatrPose62
+.4byte sFeraligatrPose63
+.4byte sFeraligatrPose64
+.4byte sFeraligatrPose65
+.4byte sFeraligatrPose66
+.4byte sFeraligatrPose67
+.4byte sFeraligatrPose68
+.4byte sFeraligatrPose69
+.4byte sFeraligatrPose70
+.4byte sFeraligatrPose71
+.4byte sFeraligatrPose72
+.4byte sFeraligatrPose73
+.4byte sFeraligatrPose74
+.4byte sFeraligatrPose75
+.4byte sFeraligatrPose76
+.4byte sFeraligatrPose77
+.4byte sFeraligatrPose78
+.4byte sFeraligatrPose79
+.4byte sFeraligatrPose80
+.4byte sFeraligatrPose81
+.4byte sFeraligatrPose82
+.4byte sFeraligatrPose83
+.4byte sFeraligatrPose84
+.4byte sFeraligatrPose85
+.4byte sFeraligatrPose86
+.4byte sFeraligatrPose87
+.4byte sFeraligatrPose88
+.4byte sFeraligatrPose89
+.4byte sFeraligatrPose90
+.4byte sFeraligatrPose91
+.4byte sFeraligatrPose92
+.4byte sFeraligatrPose93
+.4byte sFeraligatrPose94
+.4byte sFeraligatrPose95
+.4byte sFeraligatrPose96
+.4byte sFeraligatrPose97
+.4byte sFeraligatrPose98
+.4byte sFeraligatrPose99
+.4byte sFeraligatrPose100
+.4byte sFeraligatrPose101
+.4byte sFeraligatrPose102
+.4byte sFeraligatrPose103
+.4byte sFeraligatrPose104
+.4byte sFeraligatrPose105
+.4byte sFeraligatrPose106
+.4byte sFeraligatrPose107
+.4byte sFeraligatrPose108
+.4byte sFeraligatrPose109
+.4byte sFeraligatrPose110
+.4byte sFeraligatrPose111
+.4byte sFeraligatrPose112
+.4byte sFeraligatrPose113
+.4byte sFeraligatrPose114
+.4byte sFeraligatrPose115
+.4byte sFeraligatrPose116
+.4byte sFeraligatrPose117
+.4byte sFeraligatrPose118
+.4byte sFeraligatrPose119
+.4byte sFeraligatrPose120
+.4byte sFeraligatrPose121
+.4byte sFeraligatrPose122
+.4byte sFeraligatrPose123
+.4byte sFeraligatrPose124
+.4byte sFeraligatrPose125
+.4byte sFeraligatrPose126
+.4byte sFeraligatrPose127
+.4byte sFeraligatrPose128
+.4byte sFeraligatrPose129
+.4byte sFeraligatrPose130
+.4byte sFeraligatrPose131
+.4byte sFeraligatrPose132
+.4byte sFeraligatrPose133
+.4byte sFeraligatrPose134
+.4byte sFeraligatrPose135
+.4byte sFeraligatrPose136
+.4byte sFeraligatrPose137
+.4byte sFeraligatrPose138
+.4byte sFeraligatrPose139
+.4byte sFeraligatrPose140
+.4byte sFeraligatrPose141
+.4byte sFeraligatrPose142
+.4byte sFeraligatrPose143
+.4byte sFeraligatrPose144
+.4byte sFeraligatrPose145
+.4byte sFeraligatrPose146
+.4byte sFeraligatrPose147
+.4byte sFeraligatrPose148
+.4byte sFeraligatrPose149
+.4byte sFeraligatrPose150
+.4byte sFeraligatrPose151
+.4byte sFeraligatrPose152
+.4byte sFeraligatrPose153
+.4byte sFeraligatrPose154
+.4byte sFeraligatrPose155
+.4byte sFeraligatrPose156
+.4byte sFeraligatrPose157
+.4byte sFeraligatrPose158
+.4byte sFeraligatrPose159
+.4byte sFeraligatrPose160
+.4byte sFeraligatrPose161
+.4byte sFeraligatrPose162
+.4byte sFeraligatrPose163
+.4byte sFeraligatrPose164
+.4byte sFeraligatrPose165
+.4byte sFeraligatrPose166
+.4byte sFeraligatrPose167
+.4byte sFeraligatrPose168
+.4byte sFeraligatrPose169
+.4byte sFeraligatrPose170
+.4byte sFeraligatrPose171
+.4byte sFeraligatrPose172
+.4byte sFeraligatrPose173
+.4byte sFeraligatrPose174
+.4byte sFeraligatrPose175
+.4byte sFeraligatrPose176
+.4byte sFeraligatrPose177
+.4byte sFeraligatrPose178
+.4byte sFeraligatrPose179
+.4byte sFeraligatrPose180
+.4byte sFeraligatrPose181
+.4byte sFeraligatrPose182
+.4byte sFeraligatrPose183
+.4byte sFeraligatrPose184
+.4byte sFeraligatrPose185
+.4byte sFeraligatrPose186
+.4byte sFeraligatrPose187
+.4byte sFeraligatrPose188
+.4byte sFeraligatrPose189
+.4byte sFeraligatrPose190
+.4byte sFeraligatrPose191
+.4byte sFeraligatrPose192
+.4byte sFeraligatrPose193
+.4byte sFeraligatrPose194
+.4byte sFeraligatrPose195
+.4byte sFeraligatrPose196
+.4byte sFeraligatrPose197
+.4byte sFeraligatrPose198
+.4byte sFeraligatrPose199
+.4byte sFeraligatrPose200
+.4byte sFeraligatrPose201
+.4byte sFeraligatrPose202
+.4byte sFeraligatrPose203
+.4byte sFeraligatrPose204
+.4byte sFeraligatrPose205
+.4byte sFeraligatrPose206
+.4byte sFeraligatrPose207
+.4byte sFeraligatrPose208
+.4byte sFeraligatrPose209
+.4byte sFeraligatrPose210
+.4byte sFeraligatrPose211
+.4byte sFeraligatrPose212
+.4byte sFeraligatrPose213
+.4byte sFeraligatrPose214
+.4byte sFeraligatrPose215
+.4byte sFeraligatrPose216
+.4byte sFeraligatrPose217
+.4byte sFeraligatrPose218
+sAxPositionsFeraligatr:
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte    0,  -12, 	 -12,  -10, 	  10,  -14, 	   0,   -9
+.2byte   -1,  -12, 	 -11,  -14, 	  11,  -11, 	   0,   -9
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+.2byte    9,  -12, 	  13,  -13, 	  -9,  -10, 	  -2,  -10
+.2byte   11,  -12, 	  10,  -10, 	  -3,   -7, 	   1,  -10
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   13,  -14, 	   8,  -12, 	   4,   -8, 	  -2,  -10
+.2byte   13,  -14, 	   8,  -16, 	   9,   -8, 	   0,  -10
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte   10,  -19, 	  -4,  -21, 	   8,   -9, 	  -2,  -11
+.2byte    9,  -20, 	  -7,  -17, 	  11,  -12, 	  -2,  -10
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte   -2,  -22, 	  10,  -17, 	 -12,  -11, 	   1,  -10
+.2byte    2,  -22, 	  11,  -11, 	 -11,  -17, 	   0,  -10
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte  -11,  -19, 	   3,  -21, 	  -9,   -9, 	   1,  -11
+.2byte  -10,  -20, 	   6,  -17, 	 -12,  -12, 	   1,  -10
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -14,  -14, 	  -9,  -12, 	  -5,   -8, 	   1,  -10
+.2byte  -14,  -14, 	  -9,  -16, 	 -10,   -8, 	  -1,  -10
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -10,  -12, 	 -14,  -13, 	   8,  -10, 	   1,  -10
+.2byte  -12,  -12, 	 -11,  -10, 	   2,   -7, 	  -2,  -10
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte    0,  -12, 	 -12,  -10, 	  10,  -14, 	   0,   -9
+.2byte    0,  -21, 	 -13,  -20, 	  12,  -20, 	   0,  -12
+.2byte    3,    1, 	   1,    1, 	  10,  -16, 	  -1,   -7
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+.2byte    9,  -12, 	  13,  -13, 	  -9,  -10, 	  -2,  -10
+.2byte   11,  -24, 	  14,  -22, 	  -4,  -17, 	   1,  -13
+.2byte   11,   -3, 	   5,   -3, 	 -12,  -14, 	  -1,  -10
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   13,  -14, 	   8,  -12, 	   4,   -8, 	  -2,  -10
+.2byte   11,  -25, 	   3,  -25, 	   4,  -16, 	  -2,  -12
+.2byte   13,   -7, 	   8,   -5, 	  -6,  -12, 	   1,  -11
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte   10,  -19, 	  -4,  -21, 	   8,   -9, 	  -2,  -11
+.2byte    7,  -28, 	  -6,  -23, 	   9,  -18, 	  -3,  -12
+.2byte   10,  -12, 	   8,   -6, 	   8,   -8, 	   0,  -11
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte   -2,  -22, 	  10,  -17, 	 -12,  -11, 	   1,  -10
+.2byte    0,  -28, 	  11,  -22, 	 -12,  -22, 	   0,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	 -13,  -14, 	   1,  -11
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte  -11,  -19, 	   3,  -21, 	  -9,   -9, 	   1,  -11
+.2byte   -8,  -28, 	   5,  -23, 	 -10,  -18, 	   2,  -12
+.2byte  -11,  -12, 	  -9,   -6, 	  -9,   -8, 	  -1,  -11
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -14,  -14, 	  -9,  -12, 	  -5,   -8, 	   1,  -10
+.2byte  -12,  -25, 	  -4,  -25, 	  -5,  -16, 	   1,  -12
+.2byte  -14,   -7, 	  -9,   -5, 	   5,  -12, 	  -2,  -11
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -10,  -12, 	 -14,  -13, 	   8,  -10, 	   1,  -10
+.2byte  -12,  -24, 	 -15,  -22, 	   3,  -17, 	  -2,  -13
+.2byte  -12,   -3, 	  -6,   -3, 	  11,  -14, 	   0,  -10
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte    0,  -12, 	 -12,  -10, 	  10,  -14, 	   0,   -9
+.2byte   -1,  -12, 	 -11,  -14, 	  11,  -11, 	   0,   -9
+.2byte    1,  -10, 	 -13,  -20, 	   9,  -10, 	   1,   -8
+.2byte    4,    2, 	   2,    2, 	  11,  -15, 	   0,   -6
+.2byte    4,    2, 	   2,    2, 	  11,  -15, 	   0,   -6
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+.2byte    9,  -12, 	  13,  -13, 	  -9,  -10, 	  -2,  -10
+.2byte   11,  -12, 	  10,  -10, 	  -3,   -7, 	   1,  -10
+.2byte   13,  -10, 	   8,  -24, 	   5,   -7, 	  -2,  -11
+.2byte   11,   -3, 	   5,   -3, 	 -12,  -14, 	  -1,  -10
+.2byte   11,   -3, 	   5,   -3, 	 -12,  -14, 	  -1,  -10
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   13,  -14, 	   8,  -12, 	   4,   -8, 	  -2,  -10
+.2byte   13,  -14, 	   8,  -16, 	   9,   -8, 	   0,  -10
+.2byte   13,  -14, 	  -4,  -25, 	  11,  -10, 	  -2,  -12
+.2byte   13,   -7, 	   8,   -5, 	  -6,  -12, 	   1,  -11
+.2byte   13,   -7, 	   8,   -5, 	  -6,  -12, 	   1,  -11
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte   10,  -19, 	  -4,  -21, 	   8,   -9, 	  -2,  -11
+.2byte    9,  -20, 	  -7,  -17, 	  11,  -12, 	  -2,  -10
+.2byte    8,  -24, 	 -13,  -23, 	  12,  -16, 	  -4,  -12
+.2byte   10,  -12, 	   8,   -6, 	   8,   -8, 	   0,  -11
+.2byte   10,  -12, 	   8,   -6, 	   8,   -8, 	   0,  -11
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte   -2,  -22, 	  10,  -17, 	 -12,  -11, 	   1,  -10
+.2byte    2,  -22, 	  11,  -11, 	 -11,  -17, 	   0,  -10
+.2byte    0,  -19, 	  13,  -21, 	  -9,  -20, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	 -13,  -14, 	   1,  -11
+.2byte   -2,  -14, 	  -1,   -6, 	 -13,  -14, 	   1,  -11
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte  -11,  -19, 	   3,  -21, 	  -9,   -9, 	   1,  -11
+.2byte  -10,  -20, 	   6,  -17, 	 -12,  -12, 	   1,  -10
+.2byte   -9,  -24, 	  12,  -23, 	 -13,  -16, 	   3,  -12
+.2byte  -11,  -12, 	  -9,   -6, 	  -9,   -8, 	  -1,  -11
+.2byte  -11,  -12, 	  -9,   -6, 	  -9,   -8, 	  -1,  -11
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -14,  -14, 	  -9,  -12, 	  -5,   -8, 	   1,  -10
+.2byte  -14,  -14, 	  -9,  -16, 	 -10,   -8, 	  -1,  -10
+.2byte  -14,  -14, 	   3,  -25, 	 -12,  -10, 	   1,  -12
+.2byte  -14,   -7, 	  -9,   -5, 	   5,  -12, 	  -2,  -11
+.2byte  -14,   -7, 	  -9,   -5, 	   5,  -12, 	  -2,  -11
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -10,  -12, 	 -14,  -13, 	   8,  -10, 	   1,  -10
+.2byte  -12,  -12, 	 -11,  -10, 	   2,   -7, 	  -2,  -10
+.2byte  -14,  -10, 	  -9,  -24, 	  -6,   -7, 	   1,  -11
+.2byte  -12,   -3, 	  -6,   -3, 	  11,  -14, 	   0,  -10
+.2byte  -12,   -3, 	  -6,   -3, 	  11,  -14, 	   0,  -10
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte    0,  -21, 	 -13,  -20, 	  12,  -20, 	   0,  -12
+.2byte   -1,   -9, 	 -12,  -10, 	  11,  -11, 	   0,   -9
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+.2byte   11,  -24, 	  14,  -22, 	  -4,  -17, 	   1,  -13
+.2byte   11,  -11, 	  12,  -11, 	  -5,   -8, 	   2,  -11
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   11,  -25, 	   3,  -25, 	   4,  -16, 	  -2,  -12
+.2byte   13,  -16, 	   8,  -15, 	   5,   -9, 	  -1,  -12
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte    7,  -28, 	  -6,  -23, 	   9,  -18, 	  -3,  -12
+.2byte    8,  -22, 	  -5,  -18, 	   9,  -10, 	  -2,  -15
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte    0,  -28, 	  11,  -22, 	 -12,  -22, 	   0,  -12
+.2byte    0,  -20, 	  10,  -13, 	 -11,  -13, 	   0,  -10
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte   -8,  -28, 	   5,  -23, 	 -10,  -18, 	   2,  -12
+.2byte   -9,  -22, 	   4,  -18, 	 -10,  -10, 	   1,  -15
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -12,  -25, 	  -4,  -25, 	  -5,  -16, 	   1,  -12
+.2byte  -14,  -16, 	  -9,  -15, 	  -6,   -9, 	   0,  -12
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -12,  -24, 	 -15,  -22, 	   3,  -17, 	  -2,  -13
+.2byte  -12,  -11, 	 -13,  -11, 	   4,   -8, 	  -3,  -11
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+.2byte    4,   -8, 	  -3,  -11, 	  10,  -10, 	  -1,   -5
+.2byte    4,   -7, 	  -3,  -10, 	  11,  -10, 	  -1,   -4
+.2byte   -1,  -27, 	 -12,  -22, 	  11,  -22, 	   0,  -12
+.2byte   -2,  -27, 	   6,  -23, 	 -15,  -16, 	  -2,  -10
+.2byte   -2,  -29, 	  -4,  -28, 	  -9,  -21, 	  -2,  -11
+.2byte    0,  -29, 	 -11,  -22, 	   6,  -19, 	  -3,  -11
+.2byte    0,  -26, 	  11,  -19, 	 -12,  -19, 	   0,   -8
+.2byte   -1,  -29, 	  10,  -22, 	  -7,  -19, 	   2,  -11
+.2byte    1,  -29, 	   3,  -28, 	   8,  -21, 	   1,  -11
+.2byte    1,  -27, 	  -7,  -23, 	  14,  -16, 	   1,  -10
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte   -1,   -9, 	 -12,  -10, 	  11,  -11, 	   0,   -9
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+.2byte   10,  -10, 	  11,  -10, 	  -6,   -7, 	   1,  -10
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   12,  -15, 	   7,  -14, 	   4,   -8, 	  -2,  -11
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte    8,  -21, 	  -5,  -17, 	   9,   -9, 	  -2,  -14
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte    0,  -20, 	  10,  -13, 	 -11,  -13, 	   0,  -10
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte   -9,  -21, 	   4,  -17, 	 -10,   -9, 	   1,  -14
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -13,  -15, 	  -8,  -14, 	  -5,   -8, 	   1,  -11
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -11,  -10, 	 -12,  -10, 	   5,   -7, 	  -2,  -10
+.2byte   -1,   -9, 	 -12,  -10, 	  11,  -11, 	   0,   -9
+.2byte  -12,  -10, 	 -13,  -10, 	   4,   -7, 	  -3,  -10
+.2byte  -14,  -15, 	  -9,  -14, 	  -6,   -8, 	   0,  -11
+.2byte   -9,  -20, 	   4,  -16, 	 -10,   -8, 	   1,  -13
+.2byte    0,  -19, 	  10,  -12, 	 -11,  -12, 	   0,   -9
+.2byte    8,  -20, 	  -5,  -16, 	   9,   -8, 	  -2,  -13
+.2byte   13,  -15, 	   8,  -14, 	   5,   -8, 	  -1,  -11
+.2byte   11,  -10, 	  12,  -10, 	  -5,   -7, 	   2,  -10
+.2byte    0,  -21, 	 -13,  -20, 	  12,  -20, 	   0,  -12
+.2byte   10,  -23, 	  13,  -21, 	  -5,  -16, 	   0,  -12
+.2byte   11,  -24, 	   3,  -24, 	   4,  -15, 	  -2,  -11
+.2byte    7,  -27, 	  -6,  -22, 	   9,  -17, 	  -3,  -11
+.2byte    0,  -27, 	  11,  -21, 	 -12,  -21, 	   0,  -11
+.2byte   -8,  -27, 	   5,  -22, 	 -10,  -17, 	   2,  -11
+.2byte  -12,  -24, 	  -4,  -24, 	  -5,  -15, 	   1,  -11
+.2byte  -12,  -23, 	 -15,  -21, 	   3,  -16, 	  -2,  -12
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte    0,  -21, 	 -13,  -20, 	  12,  -20, 	   0,  -12
+.2byte   -1,   -9, 	 -12,  -10, 	  11,  -11, 	   0,   -9
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+.2byte   11,  -24, 	  14,  -22, 	  -4,  -17, 	   1,  -13
+.2byte   10,  -11, 	  11,  -11, 	  -6,   -8, 	   1,  -11
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   11,  -25, 	   3,  -25, 	   4,  -16, 	  -2,  -12
+.2byte   11,  -16, 	   6,  -15, 	   3,   -9, 	  -3,  -12
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte    7,  -28, 	  -6,  -23, 	   9,  -18, 	  -3,  -12
+.2byte    7,  -22, 	  -6,  -18, 	   8,  -10, 	  -3,  -15
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte    0,  -28, 	  11,  -22, 	 -12,  -22, 	   0,  -12
+.2byte    0,  -20, 	  10,  -13, 	 -11,  -13, 	   0,  -10
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte   -8,  -28, 	   5,  -23, 	 -10,  -18, 	   2,  -12
+.2byte   -8,  -22, 	   5,  -18, 	  -9,  -10, 	   2,  -15
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -12,  -25, 	  -4,  -25, 	  -5,  -16, 	   1,  -12
+.2byte  -12,  -16, 	  -7,  -15, 	  -4,   -9, 	   2,  -12
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -12,  -24, 	 -15,  -22, 	   3,  -17, 	  -2,  -13
+.2byte  -11,  -11, 	 -12,  -11, 	   5,   -8, 	  -2,  -11
+.2byte    0,  -21, 	 -13,  -20, 	  12,  -20, 	   0,  -12
+.2byte  -12,  -23, 	 -15,  -21, 	   3,  -16, 	  -2,  -12
+.2byte  -12,  -24, 	  -4,  -24, 	  -5,  -15, 	   1,  -11
+.2byte   -8,  -27, 	   5,  -22, 	 -10,  -17, 	   2,  -11
+.2byte    0,  -27, 	  11,  -21, 	 -12,  -21, 	   0,  -11
+.2byte    7,  -27, 	  -6,  -22, 	   9,  -17, 	  -3,  -11
+.2byte   11,  -24, 	   3,  -24, 	   4,  -15, 	  -2,  -11
+.2byte   10,  -23, 	  13,  -21, 	  -5,  -16, 	   0,  -12
+.2byte   -1,  -13, 	 -12,  -13, 	  11,  -13, 	  -1,   -9
+.2byte  -11,  -13, 	 -12,  -16, 	   6,   -9, 	  -1,  -11
+.2byte  -14,  -15, 	  -9,  -17, 	  -7,   -9, 	   1,  -11
+.2byte  -10,  -20, 	   4,  -18, 	 -10,  -11, 	   2,  -11
+.2byte    0,  -23, 	  11,  -14, 	 -12,  -15, 	   0,  -11
+.2byte    9,  -20, 	  -5,  -18, 	   9,  -11, 	  -3,  -11
+.2byte   13,  -15, 	   8,  -17, 	   6,   -9, 	  -2,  -11
+.2byte   10,  -13, 	  11,  -16, 	  -7,   -9, 	   0,  -11
+sFeraligatrAnimTable1:
+.4byte sFeraligatrAnims_1_1
+.4byte sFeraligatrAnims_1_2
+.4byte sFeraligatrAnims_1_3
+.4byte sFeraligatrAnims_1_4
+.4byte sFeraligatrAnims_1_5
+.4byte sFeraligatrAnims_1_6
+.4byte sFeraligatrAnims_1_7
+.4byte sFeraligatrAnims_1_8
+sFeraligatrAnimTable2:
+.4byte sFeraligatrAnims_2_1
+.4byte sFeraligatrAnims_2_2
+.4byte sFeraligatrAnims_2_3
+.4byte sFeraligatrAnims_2_4
+.4byte sFeraligatrAnims_2_5
+.4byte sFeraligatrAnims_2_6
+.4byte sFeraligatrAnims_2_7
+.4byte sFeraligatrAnims_2_8
+sFeraligatrAnimTable3:
+.4byte sFeraligatrAnims_3_1
+.4byte sFeraligatrAnims_3_2
+.4byte sFeraligatrAnims_3_3
+.4byte sFeraligatrAnims_3_4
+.4byte sFeraligatrAnims_3_5
+.4byte sFeraligatrAnims_3_6
+.4byte sFeraligatrAnims_3_7
+.4byte sFeraligatrAnims_3_8
+sFeraligatrAnimTable4:
+.4byte sFeraligatrAnims_4_1
+.4byte sFeraligatrAnims_4_2
+.4byte sFeraligatrAnims_4_3
+.4byte sFeraligatrAnims_4_4
+.4byte sFeraligatrAnims_4_5
+.4byte sFeraligatrAnims_4_6
+.4byte sFeraligatrAnims_4_7
+.4byte sFeraligatrAnims_4_8
+sFeraligatrAnimTable5:
+.4byte sFeraligatrAnims_5_1
+.4byte sFeraligatrAnims_5_2
+.4byte sFeraligatrAnims_5_3
+.4byte sFeraligatrAnims_5_4
+.4byte sFeraligatrAnims_5_5
+.4byte sFeraligatrAnims_5_6
+.4byte sFeraligatrAnims_5_7
+.4byte sFeraligatrAnims_5_8
+sFeraligatrAnimTable6:
+.4byte sFeraligatrAnims_6_1
+.4byte sFeraligatrAnims_6_1
+.4byte sFeraligatrAnims_6_1
+.4byte sFeraligatrAnims_6_1
+.4byte sFeraligatrAnims_6_1
+.4byte sFeraligatrAnims_6_1
+.4byte sFeraligatrAnims_6_1
+.4byte sFeraligatrAnims_6_1
+sFeraligatrAnimTable7:
+.4byte sFeraligatrAnims_7_1
+.4byte sFeraligatrAnims_7_2
+.4byte sFeraligatrAnims_7_3
+.4byte sFeraligatrAnims_7_4
+.4byte sFeraligatrAnims_7_5
+.4byte sFeraligatrAnims_7_6
+.4byte sFeraligatrAnims_7_7
+.4byte sFeraligatrAnims_7_8
+sFeraligatrAnimTable8:
+.4byte sFeraligatrAnims_8_1
+.4byte sFeraligatrAnims_8_2
+.4byte sFeraligatrAnims_8_3
+.4byte sFeraligatrAnims_8_4
+.4byte sFeraligatrAnims_8_5
+.4byte sFeraligatrAnims_8_6
+.4byte sFeraligatrAnims_8_7
+.4byte sFeraligatrAnims_8_8
+sFeraligatrAnimTable9:
+.4byte sFeraligatrAnims_9_1
+.4byte sFeraligatrAnims_9_2
+.4byte sFeraligatrAnims_9_3
+.4byte sFeraligatrAnims_9_4
+.4byte sFeraligatrAnims_9_5
+.4byte sFeraligatrAnims_9_6
+.4byte sFeraligatrAnims_9_7
+.4byte sFeraligatrAnims_9_8
+sFeraligatrAnimTable10:
+.4byte sFeraligatrAnims_10_1
+.4byte sFeraligatrAnims_10_2
+.4byte sFeraligatrAnims_10_3
+.4byte sFeraligatrAnims_10_4
+.4byte sFeraligatrAnims_10_5
+.4byte sFeraligatrAnims_10_6
+.4byte sFeraligatrAnims_10_7
+.4byte sFeraligatrAnims_10_8
+sFeraligatrAnimTable11:
+.4byte sFeraligatrAnims_11_1
+.4byte sFeraligatrAnims_11_2
+.4byte sFeraligatrAnims_11_3
+.4byte sFeraligatrAnims_11_4
+.4byte sFeraligatrAnims_11_5
+.4byte sFeraligatrAnims_11_6
+.4byte sFeraligatrAnims_11_7
+.4byte sFeraligatrAnims_11_8
+sFeraligatrAnimTable12:
+.4byte sFeraligatrAnims_12_1
+.4byte sFeraligatrAnims_12_2
+.4byte sFeraligatrAnims_12_3
+.4byte sFeraligatrAnims_12_4
+.4byte sFeraligatrAnims_12_5
+.4byte sFeraligatrAnims_12_6
+.4byte sFeraligatrAnims_12_7
+.4byte sFeraligatrAnims_12_8
+sFeraligatrAnimTable13:
+.4byte sFeraligatrAnims_13_1
+.4byte sFeraligatrAnims_13_2
+.4byte sFeraligatrAnims_13_3
+.4byte sFeraligatrAnims_13_4
+.4byte sFeraligatrAnims_13_5
+.4byte sFeraligatrAnims_13_6
+.4byte sFeraligatrAnims_13_7
+.4byte sFeraligatrAnims_13_8
+sAxAnimationsFeraligatr:
+.4byte sFeraligatrAnimTable1
+.4byte sFeraligatrAnimTable2
+.4byte sFeraligatrAnimTable3
+.4byte sFeraligatrAnimTable4
+.4byte sFeraligatrAnimTable5
+.4byte sFeraligatrAnimTable6
+.4byte sFeraligatrAnimTable7
+.4byte sFeraligatrAnimTable8
+.4byte sFeraligatrAnimTable9
+.4byte sFeraligatrAnimTable10
+.4byte sFeraligatrAnimTable11
+.4byte sFeraligatrAnimTable12
+.4byte sFeraligatrAnimTable13
+sAxSpritesFeraligatr:
+.4byte sFeraligatrSprites1
+.4byte sFeraligatrSprites2
+.4byte sFeraligatrSprites3
+.4byte sFeraligatrSprites4
+.4byte sFeraligatrSprites5
+.4byte sFeraligatrSprites6
+.4byte sFeraligatrSprites7
+.4byte sFeraligatrSprites8
+.4byte sFeraligatrSprites9
+.4byte sFeraligatrSprites10
+.4byte sFeraligatrSprites11
+.4byte sFeraligatrSprites12
+.4byte sFeraligatrSprites13
+.4byte sFeraligatrSprites14
+.4byte sFeraligatrSprites15
+.4byte sFeraligatrSprites16
+.4byte sFeraligatrSprites17
+.4byte sFeraligatrSprites18
+.4byte sFeraligatrSprites19
+.4byte sFeraligatrSprites20
+.4byte sFeraligatrSprites21
+.4byte sFeraligatrSprites22
+.4byte sFeraligatrSprites23
+.4byte sFeraligatrSprites24
+.4byte sFeraligatrSprites25
+.4byte sFeraligatrSprites26
+.4byte sFeraligatrSprites27
+.4byte sFeraligatrSprites28
+.4byte sFeraligatrSprites29
+.4byte sFeraligatrSprites30
+.4byte sFeraligatrSprites31
+.4byte sFeraligatrSprites32
+.4byte sFeraligatrSprites33
+.4byte sFeraligatrSprites34
+.4byte sFeraligatrSprites35
+.4byte sFeraligatrSprites36
+.4byte sFeraligatrSprites37
+.4byte sFeraligatrSprites38
+.4byte sFeraligatrSprites39
+.4byte sFeraligatrSprites40
+.4byte sFeraligatrSprites41
+.4byte sFeraligatrSprites42
+.4byte sFeraligatrSprites43
+.4byte sFeraligatrSprites44
+.4byte sFeraligatrSprites45
+.4byte sFeraligatrSprites46
+.4byte sFeraligatrSprites47
+.4byte sFeraligatrSprites48
+.4byte sFeraligatrSprites49
+.4byte sFeraligatrSprites50
+.4byte sFeraligatrSprites51
+.4byte sFeraligatrSprites52
+.4byte sFeraligatrSprites53
+.4byte sFeraligatrSprites54
+.4byte sFeraligatrSprites55
+.4byte sFeraligatrSprites56
+.4byte sFeraligatrSprites57
+.4byte sFeraligatrSprites58
+.4byte sFeraligatrSprites59
+.4byte sFeraligatrSprites60
+.4byte sFeraligatrSprites61
+.4byte sFeraligatrSprites62
+.4byte sFeraligatrSprites63
+.4byte sFeraligatrSprites64
+.4byte sFeraligatrSprites65
+.4byte sFeraligatrSprites66
+.4byte sFeraligatrSprites67
+.4byte sFeraligatrSprites68
+.4byte sFeraligatrSprites69
+.4byte sFeraligatrSprites70
+.4byte sFeraligatrSprites71
+.4byte sFeraligatrSprites72
+.4byte sFeraligatrSprites73
+.4byte sFeraligatrSprites74
+.4byte sFeraligatrSprites75
+.4byte sFeraligatrSprites76
+.4byte sFeraligatrSprites77
+.4byte sFeraligatrSprites78
+.4byte sFeraligatrSprites79
+.4byte sFeraligatrSprites80
+.4byte sFeraligatrSprites81
+.4byte sFeraligatrSprites82
+.4byte sFeraligatrSprites83
+.4byte sFeraligatrSprites84
+.4byte sFeraligatrSprites85
+.4byte sFeraligatrSprites86
+.4byte sFeraligatrSprites87
+.4byte sFeraligatrSprites88
+sAxMainFeraligatr:
+ax_main sAxPosesFeraligatr, sAxAnimationsFeraligatr, 13, sAxSpritesFeraligatr, sAxPositionsFeraligatr

--- a/data/ax/flaaffy.inc
+++ b/data/ax/flaaffy.inc
@@ -1,0 +1,2817 @@
+.global gAxFlaaffy
+gAxFlaaffy:
+ax_siro sAxMainFlaaffy
+sFlaaffyPose1:
+ax_pose 0, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose2:
+ax_pose 1, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose3:
+ax_pose 2, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose4:
+ax_pose 3, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose5:
+ax_pose 4, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose6:
+ax_pose 5, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose7:
+ax_pose 6, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose8:
+ax_pose 7, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose9:
+ax_pose 8, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose11:
+ax_pose 10, 0x81eb, 0x90f7, 0xbc00
+ax_pose_terminator
+sFlaaffyPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose13:
+ax_pose 12, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose14:
+ax_pose 13, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose15:
+ax_pose 14, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose17:
+ax_pose 10, 0x81eb, 0x80f8, 0xbc00
+ax_pose_terminator
+sFlaaffyPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose19:
+ax_pose 6, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose20:
+ax_pose 7, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose21:
+ax_pose 8, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose22:
+ax_pose 3, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose23:
+ax_pose 4, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose24:
+ax_pose 5, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose25:
+ax_pose 0, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose26:
+ax_pose 1, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose27:
+ax_pose 2, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose28:
+ax_pose 15, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose29:
+ax_pose 3, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose30:
+ax_pose 4, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose31:
+ax_pose 5, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose32:
+ax_pose 16, 0x01eb, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose33:
+ax_pose 6, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose34:
+ax_pose 7, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose35:
+ax_pose 8, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose36:
+ax_pose 17, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose37:
+ax_pose 9, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose38:
+ax_pose 10, 0x81eb, 0x90f7, 0xbc00
+ax_pose_terminator
+sFlaaffyPose39:
+ax_pose 11, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose40:
+ax_pose 18, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose41:
+ax_pose 12, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose42:
+ax_pose 13, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose43:
+ax_pose 14, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose44:
+ax_pose 19, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose45:
+ax_pose 9, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose46:
+ax_pose 10, 0x81eb, 0x80f8, 0xbc00
+ax_pose_terminator
+sFlaaffyPose47:
+ax_pose 11, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose48:
+ax_pose 18, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose49:
+ax_pose 6, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose50:
+ax_pose 7, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose51:
+ax_pose 8, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose52:
+ax_pose 17, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose53:
+ax_pose 3, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose54:
+ax_pose 4, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose55:
+ax_pose 5, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose56:
+ax_pose 16, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose57:
+ax_pose 0, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose58:
+ax_pose 1, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose59:
+ax_pose 2, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose60:
+ax_pose 15, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose61:
+ax_pose 3, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose62:
+ax_pose 4, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose63:
+ax_pose 5, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose64:
+ax_pose 16, 0x01eb, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose65:
+ax_pose 6, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose66:
+ax_pose 7, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose67:
+ax_pose 8, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose68:
+ax_pose 17, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose69:
+ax_pose 9, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose70:
+ax_pose 10, 0x81eb, 0x90f7, 0xbc00
+ax_pose_terminator
+sFlaaffyPose71:
+ax_pose 11, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose72:
+ax_pose 18, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose73:
+ax_pose 12, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose74:
+ax_pose 13, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose75:
+ax_pose 14, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose76:
+ax_pose 19, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose77:
+ax_pose 9, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose78:
+ax_pose 10, 0x81eb, 0x80f8, 0xbc00
+ax_pose_terminator
+sFlaaffyPose79:
+ax_pose 11, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose80:
+ax_pose 18, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose81:
+ax_pose 6, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose82:
+ax_pose 7, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose83:
+ax_pose 8, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose84:
+ax_pose 17, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose85:
+ax_pose 3, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose86:
+ax_pose 4, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose87:
+ax_pose 5, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose88:
+ax_pose 16, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose89:
+ax_pose 0, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose90:
+ax_pose 20, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose91:
+ax_pose 15, 0x01ea, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose92:
+ax_pose 3, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose93:
+ax_pose 21, 0x01e9, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose94:
+ax_pose 16, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose95:
+ax_pose 6, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose96:
+ax_pose 22, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose97:
+ax_pose 17, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose98:
+ax_pose 9, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose99:
+ax_pose 23, 0x01ea, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose100:
+ax_pose 18, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose101:
+ax_pose 12, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose102:
+ax_pose 24, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose103:
+ax_pose 19, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose104:
+ax_pose 9, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose105:
+ax_pose 23, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose106:
+ax_pose 18, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose107:
+ax_pose 6, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose108:
+ax_pose 22, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose109:
+ax_pose 17, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose110:
+ax_pose 3, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose111:
+ax_pose 21, 0x01e9, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose112:
+ax_pose 16, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose113:
+ax_pose 25, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose114:
+ax_pose 26, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose115:
+ax_pose 27, 0x01ea, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose116:
+ax_pose 28, 0x01ea, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose117:
+ax_pose 29, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose118:
+ax_pose 30, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose119:
+ax_pose 31, 0x01eb, 0x90ec, 0xbc00
+ax_pose_terminator
+sFlaaffyPose120:
+ax_pose 32, 0x01eb, 0x90ec, 0xbc00
+ax_pose_terminator
+sFlaaffyPose121:
+ax_pose 33, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose122:
+ax_pose 34, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose123:
+ax_pose 31, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose124:
+ax_pose 32, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose125:
+ax_pose 29, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose126:
+ax_pose 30, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose127:
+ax_pose 27, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose128:
+ax_pose 28, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose129:
+ax_pose 35, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose130:
+ax_pose 36, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose131:
+ax_pose 37, 0x01e3, 0x80f1, 0xbc00
+ax_pose_terminator
+sFlaaffyPose132:
+ax_pose 38, 0x01e4, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose133:
+ax_pose 39, 0x01e3, 0x90e9, 0xbc00
+ax_pose_terminator
+sFlaaffyPose134:
+ax_pose 40, 0x01e3, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose135:
+ax_pose 41, 0x01e3, 0x80f1, 0xbc00
+ax_pose_terminator
+sFlaaffyPose136:
+ax_pose 40, 0x01e3, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose137:
+ax_pose 39, 0x01e3, 0x80f7, 0xbc00
+ax_pose_terminator
+sFlaaffyPose138:
+ax_pose 38, 0x01e4, 0x80f6, 0xbc00
+ax_pose_terminator
+sFlaaffyPose139:
+ax_pose 0, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose140:
+ax_pose 1, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose141:
+ax_pose 2, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose142:
+ax_pose 3, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose143:
+ax_pose 4, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose144:
+ax_pose 5, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose145:
+ax_pose 6, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose146:
+ax_pose 7, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose147:
+ax_pose 8, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose148:
+ax_pose 9, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose149:
+ax_pose 10, 0x81eb, 0x90f7, 0xbc00
+ax_pose_terminator
+sFlaaffyPose150:
+ax_pose 11, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose151:
+ax_pose 12, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose152:
+ax_pose 13, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose153:
+ax_pose 14, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose154:
+ax_pose 9, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose155:
+ax_pose 10, 0x81eb, 0x80f8, 0xbc00
+ax_pose_terminator
+sFlaaffyPose156:
+ax_pose 11, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose157:
+ax_pose 6, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose158:
+ax_pose 7, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose159:
+ax_pose 8, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose160:
+ax_pose 3, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose161:
+ax_pose 4, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose162:
+ax_pose 5, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose163:
+ax_pose 15, 0x01ea, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose164:
+ax_pose 16, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose165:
+ax_pose 17, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose166:
+ax_pose 18, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose167:
+ax_pose 19, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose168:
+ax_pose 18, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose169:
+ax_pose 17, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose170:
+ax_pose 16, 0x01eb, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose171:
+ax_pose 20, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose172:
+ax_pose 21, 0x01e9, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose173:
+ax_pose 22, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose174:
+ax_pose 23, 0x01ea, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose175:
+ax_pose 24, 0x01ea, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose176:
+ax_pose 23, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose177:
+ax_pose 22, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose178:
+ax_pose 21, 0x01e9, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose179:
+ax_pose 0, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose180:
+ax_pose 20, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose181:
+ax_pose 15, 0x01ea, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose182:
+ax_pose 3, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose183:
+ax_pose 21, 0x01e9, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose184:
+ax_pose 16, 0x01ea, 0x90e9, 0xbc00
+ax_pose_terminator
+sFlaaffyPose185:
+ax_pose 6, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose186:
+ax_pose 22, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose187:
+ax_pose 17, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose188:
+ax_pose 9, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose189:
+ax_pose 23, 0x01ea, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose190:
+ax_pose 18, 0x01eb, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose191:
+ax_pose 12, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose192:
+ax_pose 24, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose193:
+ax_pose 19, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose194:
+ax_pose 9, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose195:
+ax_pose 23, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose196:
+ax_pose 18, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose197:
+ax_pose 6, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose198:
+ax_pose 22, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose199:
+ax_pose 17, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose200:
+ax_pose 3, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose201:
+ax_pose 21, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose202:
+ax_pose 16, 0x01ea, 0x80f6, 0xbc00
+ax_pose_terminator
+sFlaaffyPose203:
+ax_pose 15, 0x01ea, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose204:
+ax_pose 16, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose205:
+ax_pose 17, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose206:
+ax_pose 18, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose207:
+ax_pose 19, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose208:
+ax_pose 18, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose209:
+ax_pose 17, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose210:
+ax_pose 16, 0x01eb, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose211:
+ax_pose 0, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose212:
+ax_pose 3, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose213:
+ax_pose 6, 0x01ea, 0x80f5, 0xbc00
+ax_pose_terminator
+sFlaaffyPose214:
+ax_pose 9, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sFlaaffyPose215:
+ax_pose 12, 0x01eb, 0x80f2, 0xbc00
+ax_pose_terminator
+sFlaaffyPose216:
+ax_pose 9, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sFlaaffyPose217:
+ax_pose 6, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+sFlaaffyPose218:
+ax_pose 3, 0x01ea, 0x90ea, 0xbc00
+ax_pose_terminator
+.align 2
+sFlaaffyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 52, 0, -2, 0, -2,
+ax_anim 1, 0, 26, -1, 0, -1, 0,
+ax_anim 1, 2, 25, -2, 4, -2, 4,
+ax_anim 1, 0, 26, -3, 10, -3, 10,
+ax_anim 2, 0, 31, 0, 21, 0, 21,
+ax_anim 2, 1, 31, 1, 21, 1, 21,
+ax_anim 2, 0, 31, 0, 21, 0, 21,
+ax_anim 2, 0, 31, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sFlaaffyAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 24, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 3, 4, 3, 4,
+ax_anim 1, 0, 30, 8, 10, 8, 10,
+ax_anim 2, 0, 35, 22, 21, 22, 21,
+ax_anim 2, 1, 35, 23, 20, 23, 20,
+ax_anim 2, 0, 35, 22, 21, 22, 21,
+ax_anim 2, 0, 35, 23, 20, 23, 20,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sFlaaffyAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 28, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 2, 4, 2,
+ax_anim 1, 0, 34, 12, 3, 12, 3,
+ax_anim 2, 0, 39, 21, 0, 21, 0,
+ax_anim 2, 1, 39, 21, 1, 21, 1,
+ax_anim 2, 0, 39, 21, 0, 21, 0,
+ax_anim 2, 0, 39, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sFlaaffyAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 32, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 9, -6, 9, -6,
+ax_anim 1, 0, 38, 18, -16, 18, -16,
+ax_anim 2, 0, 43, 21, -20, 21, -20,
+ax_anim 2, 1, 43, 22, -19, 22, -19,
+ax_anim 2, 0, 43, 21, -20, 21, -20,
+ax_anim 2, 0, 43, 22, -19, 22, -19,
+ax_anim 2, 0, 36, 6, -7, 6, -7,
+ax_anim_terminator
+sFlaaffyAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 2, -1, 2, -1,
+ax_anim 1, 2, 42, 3, -4, 3, -4,
+ax_anim 1, 0, 42, 3, -11, 3, -11,
+ax_anim 2, 0, 47, 0, -19, 0, -19,
+ax_anim 2, 1, 47, 1, -19, 1, -19,
+ax_anim 2, 0, 47, 0, -19, 0, -19,
+ax_anim 2, 0, 47, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sFlaaffyAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 1, -2, 1, -2,
+ax_anim 1, 2, 45, -4, -7, -4, -7,
+ax_anim 1, 0, 46, -12, -15, -12, -15,
+ax_anim 2, 0, 51, -20, -20, -20, -20,
+ax_anim 2, 1, 51, -21, -19, -21, -19,
+ax_anim 2, 0, 51, -20, -20, -20, -20,
+ax_anim 2, 0, 51, -21, -19, -21, -19,
+ax_anim 2, 0, 44, -6, -7, -6, -7,
+ax_anim_terminator
+sFlaaffyAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, -1, 0, -1,
+ax_anim 1, 2, 49, -4, -2, -4, -2,
+ax_anim 1, 0, 50, -10, -3, -10, -3,
+ax_anim 2, 0, 55, -20, 0, -20, 0,
+ax_anim 2, 1, 55, -20, 1, -20, 1,
+ax_anim 2, 0, 55, -20, 0, -20, 0,
+ax_anim 2, 0, 55, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sFlaaffyAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 48, 2, -2, 2, -2,
+ax_anim 1, 0, 54, -2, 0, 0, 0,
+ax_anim 1, 2, 53, -7, 4, -4, 4,
+ax_anim 1, 0, 54, -13, 10, -10, 10,
+ax_anim 2, 0, 27, -20, 20, -20, 20,
+ax_anim 2, 1, 27, -21, 19, -21, 19,
+ax_anim 2, 0, 27, -20, 20, -20, 20,
+ax_anim 2, 0, 27, -21, 19, -21, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 84, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 63, 0, 21, 0, 21,
+ax_anim 2, 1, 63, 1, 21, 1, 21,
+ax_anim 2, 0, 63, 0, 21, 0, 21,
+ax_anim 2, 0, 63, 1, 21, 1, 21,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sFlaaffyAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 56, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 67, 22, 21, 22, 21,
+ax_anim 2, 1, 67, 23, 20, 23, 20,
+ax_anim 2, 0, 67, 22, 21, 22, 21,
+ax_anim 2, 0, 67, 23, 20, 23, 20,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sFlaaffyAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 60, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 71, 21, 0, 21, 0,
+ax_anim 2, 1, 71, 21, 1, 21, 1,
+ax_anim 2, 0, 71, 21, 0, 21, 0,
+ax_anim 2, 0, 71, 21, 1, 21, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sFlaaffyAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 64, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 5, -6, 5, -6,
+ax_anim 1, 0, 70, 12, -13, 12, -13,
+ax_anim 2, 0, 75, 21, -20, 21, -20,
+ax_anim 2, 1, 75, 22, -19, 22, -19,
+ax_anim 2, 0, 75, 21, -20, 21, -20,
+ax_anim 2, 0, 75, 22, -19, 22, -19,
+ax_anim 2, 0, 68, 6, -7, 6, -7,
+ax_anim_terminator
+sFlaaffyAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 68, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 79, 0, -19, 0, -19,
+ax_anim 2, 1, 79, 1, -19, 1, -19,
+ax_anim 2, 0, 79, 0, -19, 0, -19,
+ax_anim 2, 0, 79, 1, -19, 1, -19,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sFlaaffyAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 72, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -5, -6, -5, -6,
+ax_anim 1, 0, 78, -12, -13, -12, -13,
+ax_anim 2, 0, 83, -20, -20, -20, -20,
+ax_anim 2, 1, 83, -21, -19, -21, -19,
+ax_anim 2, 0, 83, -20, -20, -20, -20,
+ax_anim 2, 0, 83, -21, -19, -21, -19,
+ax_anim 2, 0, 76, -6, -7, -6, -7,
+ax_anim_terminator
+sFlaaffyAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 76, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 87, -20, 0, -20, 0,
+ax_anim 2, 1, 87, -20, 1, -20, 1,
+ax_anim 2, 0, 87, -20, 0, -20, 0,
+ax_anim 2, 0, 87, -20, 1, -20, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sFlaaffyAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 80, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 59, -21, 20, -18, 18,
+ax_anim 2, 1, 59, -22, 19, -19, 17,
+ax_anim 2, 0, 59, -21, 20, -18, 18,
+ax_anim 2, 0, 59, -22, 19, -19, 17,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 2, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 1, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 1, 4, 1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 1, 4, 1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 1, 4, 1, 4,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sFlaaffyAnims_4_2:
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 1, 2, 93, -1, -1, -1, -1,
+ax_anim 1, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 1, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim_terminator
+sFlaaffyAnims_4_3:
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 1, 2, 96, -1, 0, -1, 0,
+ax_anim 1, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 1, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim_terminator
+sFlaaffyAnims_4_4:
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 1, 0, 99, -1, 1, -1, 1,
+ax_anim 1, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 1, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim_terminator
+sFlaaffyAnims_4_5:
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 1, 2, 102, 0, 1, 0, 1,
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 1, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sFlaaffyAnims_4_6:
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 1, 2, 105, 1, 1, 1, 1,
+ax_anim 1, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 1, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim_terminator
+sFlaaffyAnims_4_7:
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 2, 108, 1, 0, 1, 0,
+ax_anim 1, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 1, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim_terminator
+sFlaaffyAnims_4_8:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 2, 111, 1, -1, 1, -1,
+ax_anim 1, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 1, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_5_1:
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_5_2:
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_5_3:
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_5_4:
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_5_5:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_5_6:
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_5_7:
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_5_8:
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sFlaaffyAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sFlaaffyAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sFlaaffyAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sFlaaffyAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sFlaaffyAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sFlaaffyAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sFlaaffyAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 3, 0, 139, 0, -4, 0, 0,
+ax_anim 3, 0, 138, 0, -4, 0, 0,
+ax_anim 3, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 3, 0, 142, 0, -4, 0, 0,
+ax_anim 3, 0, 141, 0, -4, 0, 0,
+ax_anim 3, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 3, 0, 145, 0, -4, 0, 0,
+ax_anim 3, 0, 144, 0, -4, 0, 0,
+ax_anim 3, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -3, 0, 0,
+ax_anim 3, 0, 148, 0, -4, 0, 0,
+ax_anim 3, 0, 147, 0, -4, 0, 0,
+ax_anim 3, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -3, 0, 0,
+ax_anim 3, 0, 151, 0, -4, 0, 0,
+ax_anim 3, 0, 150, 0, -4, 0, 0,
+ax_anim 3, 0, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 3, 0, 154, 0, -4, 0, 0,
+ax_anim 3, 0, 153, 0, -4, 0, 0,
+ax_anim 3, 0, 155, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 3, 0, 157, 0, -4, 0, 0,
+ax_anim 3, 0, 156, 0, -4, 0, 0,
+ax_anim 3, 0, 158, 0, -4, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -4, 0, 0,
+ax_anim 3, 0, 159, 0, -4, 0, 0,
+ax_anim 3, 0, 161, 0, -4, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 9, 11, 9, 11,
+ax_anim 2, 0, 165, 7, 19, 7, 19,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 19, -7, 19,
+ax_anim 2, 0, 168, -9, 11, -9, 11,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, 1, 9, 1,
+ax_anim 2, 0, 163, 21, 8, 21, 8,
+ax_anim 2, 0, 164, 25, 16, 25, 16,
+ax_anim 3, 0, 165, 22, 21, 22, 21,
+ax_anim 2, 3, 166, 14, 19, 14, 19,
+ax_anim 2, 0, 167, 6, 15, 6, 15,
+ax_anim 1, 0, 168, 1, 7, 1, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 12, -6, 12, -6,
+ax_anim 2, 0, 163, 19, -4, 19, -4,
+ax_anim 3, 0, 164, 22, 0, 22, 0,
+ax_anim 2, 3, 165, 20, 5, 20, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 4, 4, 4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -8, 0, -8,
+ax_anim 2, 0, 169, 4, -17, 4, -17,
+ax_anim 2, 0, 162, 12, -24, 12, -24,
+ax_anim 3, 0, 163, 22, -22, 22, -22,
+ax_anim 2, 3, 164, 23, -14, 23, -14,
+ax_anim 2, 0, 165, 19, -4, 19, -4,
+ax_anim 1, 0, 166, 9, -1, 9, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -10, -12, -10, -12,
+ax_anim 2, 0, 169, -7, -20, -7, -20,
+ax_anim 3, 0, 162, 0, -24, 0, -24,
+ax_anim 2, 3, 163, 7, -20, 7, -20,
+ax_anim 2, 0, 164, 10, -12, 10, -12,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -8, 0, -8,
+ax_anim 2, 0, 163, -4, -17, -4, -17,
+ax_anim 2, 0, 162, -12, -24, -12, -24,
+ax_anim 3, 0, 169, -22, -22, -22, -22,
+ax_anim 2, 3, 168, -23, -14, -23, -14,
+ax_anim 2, 0, 167, -19, -4, -19, -4,
+ax_anim 1, 0, 166, -9, -1, -9, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -12, -6, -12, -6,
+ax_anim 2, 0, 169, -19, -4, -19, -4,
+ax_anim 3, 0, 168, -22, 0, -22, 0,
+ax_anim 2, 3, 167, -20, 5, -20, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, 1, -9, 1,
+ax_anim 2, 0, 169, -21, 8, -21, 8,
+ax_anim 2, 0, 168, -25, 16, -25, 16,
+ax_anim 3, 0, 167, -22, 21, -22, 21,
+ax_anim 2, 3, 166, -14, 19, -14, 19,
+ax_anim 2, 0, 165, -6, 15, -6, 15,
+ax_anim 1, 0, 164, -1, 7, -1, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -9, 0, 0,
+ax_anim 2, 0, 179, 0, -15, 0, 0,
+ax_anim 3, 0, 179, 0, -19, 0, 0,
+ax_anim 4, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -24, 0, 0,
+ax_anim 2, 0, 180, 0, -21, 0, 0,
+ax_anim 1, 0, 180, 0, -13, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -17, 0, 0,
+ax_anim 1, 0, 183, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -17, 0, 0,
+ax_anim 1, 0, 186, 0, -11, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -8, 0, 0,
+ax_anim 2, 0, 188, 0, -14, 0, 0,
+ax_anim 3, 0, 188, 0, -18, 0, 0,
+ax_anim 4, 0, 188, 0, -19, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -9, 0, 0,
+ax_anim 2, 0, 191, 0, -15, 0, 0,
+ax_anim 3, 0, 191, 0, -19, 0, 0,
+ax_anim 4, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -17, 0, 0,
+ax_anim 1, 0, 192, 0, -11, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -8, 0, 0,
+ax_anim 2, 0, 194, 0, -14, 0, 0,
+ax_anim 3, 0, 194, 0, -18, 0, 0,
+ax_anim 4, 0, 194, 0, -19, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -17, 0, 0,
+ax_anim 1, 0, 198, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -17, 0, 0,
+ax_anim 1, 0, 201, 0, -11, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlaaffyAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sFlaaffyGfx1:
+.incbin "baserom.gba", 0xCCBDF4, 0x200
+sFlaaffySprites1:
+ax_sprite sFlaaffyGfx1, 0x200
+ax_sprite_terminator
+sFlaaffyGfx2:
+.incbin "baserom.gba", 0xCCC004, 0x200
+sFlaaffySprites2:
+ax_sprite sFlaaffyGfx2, 0x200
+ax_sprite_terminator
+sFlaaffyGfx3:
+.incbin "baserom.gba", 0xCCC214, 0x200
+sFlaaffySprites3:
+ax_sprite sFlaaffyGfx3, 0x200
+ax_sprite_terminator
+sFlaaffyGfx4:
+.incbin "baserom.gba", 0xCCC424, 0x200
+sFlaaffySprites4:
+ax_sprite sFlaaffyGfx4, 0x200
+ax_sprite_terminator
+sFlaaffyGfx5:
+.incbin "baserom.gba", 0xCCC634, 0x200
+sFlaaffySprites5:
+ax_sprite sFlaaffyGfx5, 0x200
+ax_sprite_terminator
+sFlaaffyGfx6:
+.incbin "baserom.gba", 0xCCC844, 0x200
+sFlaaffySprites6:
+ax_sprite sFlaaffyGfx6, 0x200
+ax_sprite_terminator
+sFlaaffyGfx7:
+.incbin "baserom.gba", 0xCCCA54, 0x200
+sFlaaffySprites7:
+ax_sprite sFlaaffyGfx7, 0x200
+ax_sprite_terminator
+sFlaaffyGfx8:
+.incbin "baserom.gba", 0xCCCC64, 0x200
+sFlaaffySprites8:
+ax_sprite sFlaaffyGfx8, 0x200
+ax_sprite_terminator
+sFlaaffyGfx9:
+.incbin "baserom.gba", 0xCCCE74, 0x200
+sFlaaffySprites9:
+ax_sprite sFlaaffyGfx9, 0x200
+ax_sprite_terminator
+sFlaaffyGfx10:
+.incbin "baserom.gba", 0xCCD084, 0x200
+sFlaaffySprites10:
+ax_sprite sFlaaffyGfx10, 0x200
+ax_sprite_terminator
+sFlaaffyGfx11:
+.incbin "baserom.gba", 0xCCD294, 0x100
+sFlaaffySprites11:
+ax_sprite sFlaaffyGfx11, 0x100
+ax_sprite_terminator
+sFlaaffyGfx12:
+.incbin "baserom.gba", 0xCCD3A4, 0x200
+sFlaaffySprites12:
+ax_sprite sFlaaffyGfx12, 0x200
+ax_sprite_terminator
+sFlaaffyGfx13:
+.incbin "baserom.gba", 0xCCD5B4, 0x200
+sFlaaffySprites13:
+ax_sprite sFlaaffyGfx13, 0x200
+ax_sprite_terminator
+sFlaaffyGfx14:
+.incbin "baserom.gba", 0xCCD7C4, 0x200
+sFlaaffySprites14:
+ax_sprite sFlaaffyGfx14, 0x200
+ax_sprite_terminator
+sFlaaffyGfx15:
+.incbin "baserom.gba", 0xCCD9D4, 0x200
+sFlaaffySprites15:
+ax_sprite sFlaaffyGfx15, 0x200
+ax_sprite_terminator
+sFlaaffyGfx16:
+.incbin "baserom.gba", 0xCCDBE4, 0x40
+sFlaaffyGfx16_1:
+.incbin "baserom.gba", 0xCCDC24, 0x60
+sFlaaffyGfx16_2:
+.incbin "baserom.gba", 0xCCDC84, 0x60
+sFlaaffySprites16:
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx17:
+.incbin "baserom.gba", 0xCCDD24, 0x60
+sFlaaffyGfx17_1:
+.incbin "baserom.gba", 0xCCDD84, 0x60
+sFlaaffyGfx17_2:
+.incbin "baserom.gba", 0xCCDDE4, 0x60
+sFlaaffySprites17:
+ax_sprite sFlaaffyGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx18:
+.incbin "baserom.gba", 0xCCDE7C, 0x60
+sFlaaffyGfx18_1:
+.incbin "baserom.gba", 0xCCDEDC, 0x60
+sFlaaffyGfx18_2:
+.incbin "baserom.gba", 0xCCDF3C, 0x60
+sFlaaffySprites18:
+ax_sprite sFlaaffyGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx19:
+.incbin "baserom.gba", 0xCCDFD4, 0x60
+sFlaaffyGfx19_1:
+.incbin "baserom.gba", 0xCCE034, 0x60
+sFlaaffyGfx19_2:
+.incbin "baserom.gba", 0xCCE094, 0x60
+sFlaaffySprites19:
+ax_sprite sFlaaffyGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx20:
+.incbin "baserom.gba", 0xCCE12C, 0x60
+sFlaaffyGfx20_1:
+.incbin "baserom.gba", 0xCCE18C, 0x60
+sFlaaffyGfx20_2:
+.incbin "baserom.gba", 0xCCE1EC, 0x60
+sFlaaffySprites20:
+ax_sprite sFlaaffyGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx21:
+.incbin "baserom.gba", 0xCCE284, 0x60
+sFlaaffyGfx21_1:
+.incbin "baserom.gba", 0xCCE2E4, 0x60
+sFlaaffyGfx21_2:
+.incbin "baserom.gba", 0xCCE344, 0x60
+sFlaaffySprites21:
+ax_sprite sFlaaffyGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx22:
+.incbin "baserom.gba", 0xCCE3DC, 0x60
+sFlaaffyGfx22_1:
+.incbin "baserom.gba", 0xCCE43C, 0x60
+sFlaaffyGfx22_2:
+.incbin "baserom.gba", 0xCCE49C, 0x60
+sFlaaffyGfx22_3:
+.incbin "baserom.gba", 0xCCE4FC, 0x20
+sFlaaffySprites22:
+ax_sprite sFlaaffyGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFlaaffyGfx22_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFlaaffyGfx23:
+.incbin "baserom.gba", 0xCCE564, 0x60
+sFlaaffyGfx23_1:
+.incbin "baserom.gba", 0xCCE5C4, 0x60
+sFlaaffyGfx23_2:
+.incbin "baserom.gba", 0xCCE624, 0x60
+sFlaaffySprites23:
+ax_sprite sFlaaffyGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx24:
+.incbin "baserom.gba", 0xCCE6BC, 0x60
+sFlaaffyGfx24_1:
+.incbin "baserom.gba", 0xCCE71C, 0x60
+sFlaaffyGfx24_2:
+.incbin "baserom.gba", 0xCCE77C, 0x60
+sFlaaffySprites24:
+ax_sprite sFlaaffyGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx25:
+.incbin "baserom.gba", 0xCCE814, 0x60
+sFlaaffyGfx25_1:
+.incbin "baserom.gba", 0xCCE874, 0x60
+sFlaaffyGfx25_2:
+.incbin "baserom.gba", 0xCCE8D4, 0x60
+sFlaaffySprites25:
+ax_sprite sFlaaffyGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx26:
+.incbin "baserom.gba", 0xCCE96C, 0x40
+sFlaaffyGfx26_1:
+.incbin "baserom.gba", 0xCCE9AC, 0x60
+sFlaaffyGfx26_2:
+.incbin "baserom.gba", 0xCCEA0C, 0x60
+sFlaaffyGfx26_3:
+.incbin "baserom.gba", 0xCCEA6C, 0x60
+sFlaaffySprites26:
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlaaffyGfx27:
+.incbin "baserom.gba", 0xCCEB1C, 0x40
+sFlaaffyGfx27_1:
+.incbin "baserom.gba", 0xCCEB5C, 0x60
+sFlaaffyGfx27_2:
+.incbin "baserom.gba", 0xCCEBBC, 0x60
+sFlaaffyGfx27_3:
+.incbin "baserom.gba", 0xCCEC1C, 0x60
+sFlaaffySprites27:
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlaaffyGfx28:
+.incbin "baserom.gba", 0xCCECCC, 0x60
+sFlaaffyGfx28_1:
+.incbin "baserom.gba", 0xCCED2C, 0x60
+sFlaaffyGfx28_2:
+.incbin "baserom.gba", 0xCCED8C, 0x60
+sFlaaffyGfx28_3:
+.incbin "baserom.gba", 0xCCEDEC, 0x20
+sFlaaffySprites28:
+ax_sprite sFlaaffyGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFlaaffyGfx28_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFlaaffyGfx29:
+.incbin "baserom.gba", 0xCCEE54, 0x60
+sFlaaffyGfx29_1:
+.incbin "baserom.gba", 0xCCEEB4, 0x60
+sFlaaffyGfx29_2:
+.incbin "baserom.gba", 0xCCEF14, 0x60
+sFlaaffyGfx29_3:
+.incbin "baserom.gba", 0xCCEF74, 0x20
+sFlaaffySprites29:
+ax_sprite sFlaaffyGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFlaaffyGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFlaaffyGfx30:
+.incbin "baserom.gba", 0xCCEFDC, 0x40
+sFlaaffyGfx30_1:
+.incbin "baserom.gba", 0xCCF01C, 0x60
+sFlaaffyGfx30_2:
+.incbin "baserom.gba", 0xCCF07C, 0x60
+sFlaaffySprites30:
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx31:
+.incbin "baserom.gba", 0xCCF11C, 0x40
+sFlaaffyGfx31_1:
+.incbin "baserom.gba", 0xCCF15C, 0x60
+sFlaaffyGfx31_2:
+.incbin "baserom.gba", 0xCCF1BC, 0x60
+sFlaaffySprites31:
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx32:
+.incbin "baserom.gba", 0xCCF25C, 0x40
+sFlaaffyGfx32_1:
+.incbin "baserom.gba", 0xCCF29C, 0x60
+sFlaaffyGfx32_2:
+.incbin "baserom.gba", 0xCCF2FC, 0x60
+sFlaaffySprites32:
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx33:
+.incbin "baserom.gba", 0xCCF39C, 0x40
+sFlaaffyGfx33_1:
+.incbin "baserom.gba", 0xCCF3DC, 0x60
+sFlaaffyGfx33_2:
+.incbin "baserom.gba", 0xCCF43C, 0x60
+sFlaaffySprites33:
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlaaffyGfx34:
+.incbin "baserom.gba", 0xCCF4DC, 0x60
+sFlaaffyGfx34_1:
+.incbin "baserom.gba", 0xCCF53C, 0x60
+sFlaaffyGfx34_2:
+.incbin "baserom.gba", 0xCCF59C, 0x60
+sFlaaffyGfx34_3:
+.incbin "baserom.gba", 0xCCF5FC, 0x20
+sFlaaffySprites34:
+ax_sprite sFlaaffyGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFlaaffyGfx34_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFlaaffyGfx35:
+.incbin "baserom.gba", 0xCCF664, 0x60
+sFlaaffyGfx35_1:
+.incbin "baserom.gba", 0xCCF6C4, 0x60
+sFlaaffyGfx35_2:
+.incbin "baserom.gba", 0xCCF724, 0x60
+sFlaaffyGfx35_3:
+.incbin "baserom.gba", 0xCCF784, 0x40
+sFlaaffySprites35:
+ax_sprite sFlaaffyGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlaaffyGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFlaaffyGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlaaffyGfx36:
+.incbin "baserom.gba", 0xCCF80C, 0x200
+sFlaaffySprites36:
+ax_sprite sFlaaffyGfx36, 0x200
+ax_sprite_terminator
+sFlaaffyGfx37:
+.incbin "baserom.gba", 0xCCFA1C, 0x200
+sFlaaffySprites37:
+ax_sprite sFlaaffyGfx37, 0x200
+ax_sprite_terminator
+sFlaaffyGfx38:
+.incbin "baserom.gba", 0xCCFC2C, 0x200
+sFlaaffySprites38:
+ax_sprite sFlaaffyGfx38, 0x200
+ax_sprite_terminator
+sFlaaffyGfx39:
+.incbin "baserom.gba", 0xCCFE3C, 0x200
+sFlaaffySprites39:
+ax_sprite sFlaaffyGfx39, 0x200
+ax_sprite_terminator
+sFlaaffyGfx40:
+.incbin "baserom.gba", 0xCD004C, 0x200
+sFlaaffySprites40:
+ax_sprite sFlaaffyGfx40, 0x200
+ax_sprite_terminator
+sFlaaffyGfx41:
+.incbin "baserom.gba", 0xCD025C, 0x200
+sFlaaffySprites41:
+ax_sprite sFlaaffyGfx41, 0x200
+ax_sprite_terminator
+sFlaaffyGfx42:
+.incbin "baserom.gba", 0xCD046C, 0x200
+sFlaaffySprites42:
+ax_sprite sFlaaffyGfx42, 0x200
+ax_sprite_terminator
+sAxPosesFlaaffy:
+.4byte sFlaaffyPose1
+.4byte sFlaaffyPose2
+.4byte sFlaaffyPose3
+.4byte sFlaaffyPose4
+.4byte sFlaaffyPose5
+.4byte sFlaaffyPose6
+.4byte sFlaaffyPose7
+.4byte sFlaaffyPose8
+.4byte sFlaaffyPose9
+.4byte sFlaaffyPose10
+.4byte sFlaaffyPose11
+.4byte sFlaaffyPose12
+.4byte sFlaaffyPose13
+.4byte sFlaaffyPose14
+.4byte sFlaaffyPose15
+.4byte sFlaaffyPose16
+.4byte sFlaaffyPose17
+.4byte sFlaaffyPose18
+.4byte sFlaaffyPose19
+.4byte sFlaaffyPose20
+.4byte sFlaaffyPose21
+.4byte sFlaaffyPose22
+.4byte sFlaaffyPose23
+.4byte sFlaaffyPose24
+.4byte sFlaaffyPose25
+.4byte sFlaaffyPose26
+.4byte sFlaaffyPose27
+.4byte sFlaaffyPose28
+.4byte sFlaaffyPose29
+.4byte sFlaaffyPose30
+.4byte sFlaaffyPose31
+.4byte sFlaaffyPose32
+.4byte sFlaaffyPose33
+.4byte sFlaaffyPose34
+.4byte sFlaaffyPose35
+.4byte sFlaaffyPose36
+.4byte sFlaaffyPose37
+.4byte sFlaaffyPose38
+.4byte sFlaaffyPose39
+.4byte sFlaaffyPose40
+.4byte sFlaaffyPose41
+.4byte sFlaaffyPose42
+.4byte sFlaaffyPose43
+.4byte sFlaaffyPose44
+.4byte sFlaaffyPose45
+.4byte sFlaaffyPose46
+.4byte sFlaaffyPose47
+.4byte sFlaaffyPose48
+.4byte sFlaaffyPose49
+.4byte sFlaaffyPose50
+.4byte sFlaaffyPose51
+.4byte sFlaaffyPose52
+.4byte sFlaaffyPose53
+.4byte sFlaaffyPose54
+.4byte sFlaaffyPose55
+.4byte sFlaaffyPose56
+.4byte sFlaaffyPose57
+.4byte sFlaaffyPose58
+.4byte sFlaaffyPose59
+.4byte sFlaaffyPose60
+.4byte sFlaaffyPose61
+.4byte sFlaaffyPose62
+.4byte sFlaaffyPose63
+.4byte sFlaaffyPose64
+.4byte sFlaaffyPose65
+.4byte sFlaaffyPose66
+.4byte sFlaaffyPose67
+.4byte sFlaaffyPose68
+.4byte sFlaaffyPose69
+.4byte sFlaaffyPose70
+.4byte sFlaaffyPose71
+.4byte sFlaaffyPose72
+.4byte sFlaaffyPose73
+.4byte sFlaaffyPose74
+.4byte sFlaaffyPose75
+.4byte sFlaaffyPose76
+.4byte sFlaaffyPose77
+.4byte sFlaaffyPose78
+.4byte sFlaaffyPose79
+.4byte sFlaaffyPose80
+.4byte sFlaaffyPose81
+.4byte sFlaaffyPose82
+.4byte sFlaaffyPose83
+.4byte sFlaaffyPose84
+.4byte sFlaaffyPose85
+.4byte sFlaaffyPose86
+.4byte sFlaaffyPose87
+.4byte sFlaaffyPose88
+.4byte sFlaaffyPose89
+.4byte sFlaaffyPose90
+.4byte sFlaaffyPose91
+.4byte sFlaaffyPose92
+.4byte sFlaaffyPose93
+.4byte sFlaaffyPose94
+.4byte sFlaaffyPose95
+.4byte sFlaaffyPose96
+.4byte sFlaaffyPose97
+.4byte sFlaaffyPose98
+.4byte sFlaaffyPose99
+.4byte sFlaaffyPose100
+.4byte sFlaaffyPose101
+.4byte sFlaaffyPose102
+.4byte sFlaaffyPose103
+.4byte sFlaaffyPose104
+.4byte sFlaaffyPose105
+.4byte sFlaaffyPose106
+.4byte sFlaaffyPose107
+.4byte sFlaaffyPose108
+.4byte sFlaaffyPose109
+.4byte sFlaaffyPose110
+.4byte sFlaaffyPose111
+.4byte sFlaaffyPose112
+.4byte sFlaaffyPose113
+.4byte sFlaaffyPose114
+.4byte sFlaaffyPose115
+.4byte sFlaaffyPose116
+.4byte sFlaaffyPose117
+.4byte sFlaaffyPose118
+.4byte sFlaaffyPose119
+.4byte sFlaaffyPose120
+.4byte sFlaaffyPose121
+.4byte sFlaaffyPose122
+.4byte sFlaaffyPose123
+.4byte sFlaaffyPose124
+.4byte sFlaaffyPose125
+.4byte sFlaaffyPose126
+.4byte sFlaaffyPose127
+.4byte sFlaaffyPose128
+.4byte sFlaaffyPose129
+.4byte sFlaaffyPose130
+.4byte sFlaaffyPose131
+.4byte sFlaaffyPose132
+.4byte sFlaaffyPose133
+.4byte sFlaaffyPose134
+.4byte sFlaaffyPose135
+.4byte sFlaaffyPose136
+.4byte sFlaaffyPose137
+.4byte sFlaaffyPose138
+.4byte sFlaaffyPose139
+.4byte sFlaaffyPose140
+.4byte sFlaaffyPose141
+.4byte sFlaaffyPose142
+.4byte sFlaaffyPose143
+.4byte sFlaaffyPose144
+.4byte sFlaaffyPose145
+.4byte sFlaaffyPose146
+.4byte sFlaaffyPose147
+.4byte sFlaaffyPose148
+.4byte sFlaaffyPose149
+.4byte sFlaaffyPose150
+.4byte sFlaaffyPose151
+.4byte sFlaaffyPose152
+.4byte sFlaaffyPose153
+.4byte sFlaaffyPose154
+.4byte sFlaaffyPose155
+.4byte sFlaaffyPose156
+.4byte sFlaaffyPose157
+.4byte sFlaaffyPose158
+.4byte sFlaaffyPose159
+.4byte sFlaaffyPose160
+.4byte sFlaaffyPose161
+.4byte sFlaaffyPose162
+.4byte sFlaaffyPose163
+.4byte sFlaaffyPose164
+.4byte sFlaaffyPose165
+.4byte sFlaaffyPose166
+.4byte sFlaaffyPose167
+.4byte sFlaaffyPose168
+.4byte sFlaaffyPose169
+.4byte sFlaaffyPose170
+.4byte sFlaaffyPose171
+.4byte sFlaaffyPose172
+.4byte sFlaaffyPose173
+.4byte sFlaaffyPose174
+.4byte sFlaaffyPose175
+.4byte sFlaaffyPose176
+.4byte sFlaaffyPose177
+.4byte sFlaaffyPose178
+.4byte sFlaaffyPose179
+.4byte sFlaaffyPose180
+.4byte sFlaaffyPose181
+.4byte sFlaaffyPose182
+.4byte sFlaaffyPose183
+.4byte sFlaaffyPose184
+.4byte sFlaaffyPose185
+.4byte sFlaaffyPose186
+.4byte sFlaaffyPose187
+.4byte sFlaaffyPose188
+.4byte sFlaaffyPose189
+.4byte sFlaaffyPose190
+.4byte sFlaaffyPose191
+.4byte sFlaaffyPose192
+.4byte sFlaaffyPose193
+.4byte sFlaaffyPose194
+.4byte sFlaaffyPose195
+.4byte sFlaaffyPose196
+.4byte sFlaaffyPose197
+.4byte sFlaaffyPose198
+.4byte sFlaaffyPose199
+.4byte sFlaaffyPose200
+.4byte sFlaaffyPose201
+.4byte sFlaaffyPose202
+.4byte sFlaaffyPose203
+.4byte sFlaaffyPose204
+.4byte sFlaaffyPose205
+.4byte sFlaaffyPose206
+.4byte sFlaaffyPose207
+.4byte sFlaaffyPose208
+.4byte sFlaaffyPose209
+.4byte sFlaaffyPose210
+.4byte sFlaaffyPose211
+.4byte sFlaaffyPose212
+.4byte sFlaaffyPose213
+.4byte sFlaaffyPose214
+.4byte sFlaaffyPose215
+.4byte sFlaaffyPose216
+.4byte sFlaaffyPose217
+.4byte sFlaaffyPose218
+sAxPositionsFlaaffy:
+.2byte   -1,  -10, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -9, 	  -2,   -4, 	   5,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -7,   -6, 	   0,   -4, 	  -1,   -7
+.2byte    3,  -10, 	   3,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    4,   -9, 	   2,   -4, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -9, 	   6,   -7, 	   1,   -4, 	  -1,   -8
+.2byte    4,  -10, 	   4,   -6, 	   3,   -4, 	  -1,   -8
+.2byte    5,   -9, 	   3,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   3,   -8, 	   5,   -5, 	  -1,   -8
+.2byte    1,  -11, 	  -4,   -9, 	   0,   -6, 	  -2,   -9
+.2byte    1,  -11, 	  -1,   -5, 	   3,   -4, 	  -2,   -9
+.2byte    3,  -10, 	  -4,   -8, 	   0,   -5, 	  -1,   -8
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte    0,  -11, 	   0,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -1,  -11, 	  -2,   -6, 	   5,   -6, 	   0,   -9
+.2byte   -3,  -11, 	   2,   -9, 	  -2,   -6, 	   0,   -9
+.2byte   -3,  -11, 	  -1,   -5, 	  -5,   -4, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -8, 	  -2,   -5, 	  -1,   -8
+.2byte   -6,  -10, 	  -6,   -6, 	  -5,   -4, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -5,   -8, 	  -7,   -5, 	  -1,   -8
+.2byte   -5,  -10, 	  -5,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -6,   -9, 	  -4,   -4, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -9, 	  -8,   -7, 	  -3,   -4, 	  -1,   -8
+.2byte   -1,  -10, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -9, 	  -2,   -4, 	   5,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -7,   -6, 	   0,   -4, 	  -1,   -7
+.2byte   -1,   -5, 	  -3,   -1, 	   1,   -1, 	  -1,   -6
+.2byte    3,  -10, 	   3,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    4,   -9, 	   2,   -4, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -9, 	   6,   -7, 	   1,   -4, 	  -1,   -8
+.2byte    6,   -8, 	   4,   -4, 	   0,   -3, 	   0,   -9
+.2byte    4,  -10, 	   4,   -6, 	   3,   -4, 	  -1,   -8
+.2byte    5,   -9, 	   3,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   3,   -8, 	   5,   -5, 	  -1,   -8
+.2byte    7,  -10, 	   4,   -6, 	   4,   -5, 	  -1,   -9
+.2byte    1,  -11, 	  -4,   -9, 	   0,   -6, 	  -2,   -9
+.2byte    1,  -11, 	  -1,   -5, 	   3,   -4, 	  -2,   -9
+.2byte    3,  -10, 	  -4,   -8, 	   0,   -5, 	  -1,   -8
+.2byte    6,  -11, 	   0,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte    0,  -11, 	   0,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -1,  -11, 	  -2,   -6, 	   5,   -6, 	   0,   -9
+.2byte   -1,  -15, 	   1,   -6, 	  -3,   -6, 	  -1,  -10
+.2byte   -3,  -11, 	   2,   -9, 	  -2,   -6, 	   0,   -9
+.2byte   -3,  -11, 	  -1,   -5, 	  -5,   -4, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -8, 	  -2,   -5, 	  -1,   -8
+.2byte   -8,  -11, 	  -2,   -7, 	  -7,   -5, 	  -2,   -8
+.2byte   -6,  -10, 	  -6,   -6, 	  -5,   -4, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -5,   -8, 	  -7,   -5, 	  -1,   -8
+.2byte   -9,  -10, 	  -6,   -6, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,  -10, 	  -5,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -6,   -9, 	  -4,   -4, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -9, 	  -8,   -7, 	  -3,   -4, 	  -1,   -8
+.2byte   -8,   -8, 	  -6,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte   -1,  -10, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -9, 	  -2,   -4, 	   5,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -7,   -6, 	   0,   -4, 	  -1,   -7
+.2byte   -1,   -5, 	  -3,   -1, 	   1,   -1, 	  -1,   -6
+.2byte    3,  -10, 	   3,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    4,   -9, 	   2,   -4, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -9, 	   6,   -7, 	   1,   -4, 	  -1,   -8
+.2byte    6,   -8, 	   4,   -4, 	   0,   -3, 	   0,   -9
+.2byte    4,  -10, 	   4,   -6, 	   3,   -4, 	  -1,   -8
+.2byte    5,   -9, 	   3,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   3,   -8, 	   5,   -5, 	  -1,   -8
+.2byte    7,  -10, 	   4,   -6, 	   4,   -5, 	  -1,   -9
+.2byte    1,  -11, 	  -4,   -9, 	   0,   -6, 	  -2,   -9
+.2byte    1,  -11, 	  -1,   -5, 	   3,   -4, 	  -2,   -9
+.2byte    3,  -10, 	  -4,   -8, 	   0,   -5, 	  -1,   -8
+.2byte    6,  -11, 	   0,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte    0,  -11, 	   0,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -1,  -11, 	  -2,   -6, 	   5,   -6, 	   0,   -9
+.2byte   -1,  -15, 	   1,   -6, 	  -3,   -6, 	  -1,  -10
+.2byte   -3,  -11, 	   2,   -9, 	  -2,   -6, 	   0,   -9
+.2byte   -3,  -11, 	  -1,   -5, 	  -5,   -4, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -8, 	  -2,   -5, 	  -1,   -8
+.2byte   -8,  -11, 	  -2,   -7, 	  -7,   -5, 	  -2,   -8
+.2byte   -6,  -10, 	  -6,   -6, 	  -5,   -4, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -5,   -8, 	  -7,   -5, 	  -1,   -8
+.2byte   -9,  -10, 	  -6,   -6, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,  -10, 	  -5,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -6,   -9, 	  -4,   -4, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -9, 	  -8,   -7, 	  -3,   -4, 	  -1,   -8
+.2byte   -8,   -8, 	  -6,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte   -1,  -10, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	  -4,   -9, 	   2,   -9, 	  -1,   -9
+.2byte   -1,   -6, 	  -3,   -2, 	   1,   -2, 	  -1,   -7
+.2byte    3,  -10, 	   3,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    1,  -12, 	   3,  -10, 	  -2,   -9, 	  -1,   -8
+.2byte    6,   -9, 	   4,   -5, 	   0,   -4, 	   0,  -10
+.2byte    4,  -10, 	   4,   -6, 	   3,   -4, 	  -1,   -8
+.2byte    3,  -14, 	   2,  -11, 	   2,   -9, 	  -1,   -9
+.2byte    7,  -10, 	   4,   -6, 	   4,   -5, 	  -1,   -9
+.2byte    1,  -11, 	  -4,   -9, 	   0,   -6, 	  -2,   -9
+.2byte    4,  -14, 	  -3,  -12, 	   3,   -8, 	  -2,   -8
+.2byte    6,  -11, 	   0,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -15, 	   2,  -12, 	  -4,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte   -3,  -11, 	   2,   -9, 	  -2,   -6, 	   0,   -9
+.2byte   -6,  -14, 	   1,  -12, 	  -5,   -8, 	   0,   -8
+.2byte   -8,  -11, 	  -2,   -7, 	  -7,   -5, 	  -2,   -8
+.2byte   -6,  -10, 	  -6,   -6, 	  -5,   -4, 	  -1,   -8
+.2byte   -5,  -14, 	  -4,  -11, 	  -4,   -9, 	  -1,   -9
+.2byte   -9,  -10, 	  -6,   -6, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,  -10, 	  -5,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -3,  -12, 	  -5,  -10, 	   0,   -9, 	  -1,   -8
+.2byte   -8,   -9, 	  -6,   -5, 	  -2,   -4, 	  -2,  -10
+.2byte   -1,  -11, 	  -4,   -7, 	   2,   -7, 	  -1,   -7
+.2byte   -1,  -11, 	  -5,   -7, 	   3,   -7, 	  -1,   -6
+.2byte    1,  -10, 	   3,   -8, 	  -2,   -7, 	  -2,   -6
+.2byte    1,  -11, 	   4,   -8, 	  -4,   -6, 	  -1,   -7
+.2byte    0,  -12, 	   3,  -12, 	   2,   -9, 	  -1,   -7
+.2byte    0,  -12, 	   3,  -11, 	   3,   -6, 	  -2,   -8
+.2byte   -1,  -12, 	  -3,  -12, 	   3,   -9, 	  -2,   -7
+.2byte    0,  -12, 	  -2,  -10, 	   4,   -9, 	  -2,   -7
+.2byte   -1,  -13, 	   2,  -10, 	  -4,  -10, 	  -1,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -9, 	   1,   -7
+.2byte   -1,  -12, 	   1,  -10, 	  -5,   -9, 	   1,   -7
+.2byte   -2,  -12, 	  -5,  -12, 	  -4,   -9, 	  -1,   -7
+.2byte   -2,  -12, 	  -5,  -11, 	  -5,   -6, 	   0,   -8
+.2byte   -2,  -10, 	  -4,   -8, 	   1,   -7, 	   1,   -6
+.2byte   -2,  -11, 	  -5,   -8, 	   3,   -6, 	   0,   -7
+.2byte   -4,   -8, 	  -4,   -4, 	   0,   -3, 	   0,   -8
+.2byte   -5,   -6, 	  -4,   -4, 	   0,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -7,   -5, 	   7,   -5, 	   0,   -5
+.2byte    0,   -8, 	   4,   -7, 	  -6,   -4, 	  -3,   -7
+.2byte    2,   -9, 	   1,  -10, 	   0,   -6, 	  -2,   -8
+.2byte    1,  -11, 	  -2,   -9, 	   5,   -8, 	  -1,   -8
+.2byte    0,  -10, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte   -2,  -11, 	   1,   -9, 	  -6,   -8, 	   0,   -8
+.2byte   -3,   -9, 	  -2,  -10, 	  -1,   -6, 	   1,   -8
+.2byte   -1,   -8, 	  -5,   -7, 	   5,   -4, 	   2,   -7
+.2byte   -1,  -10, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -9, 	  -2,   -4, 	   5,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -7,   -6, 	   0,   -4, 	  -1,   -7
+.2byte    3,  -10, 	   3,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    4,   -9, 	   2,   -4, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -9, 	   6,   -7, 	   1,   -4, 	  -1,   -8
+.2byte    4,  -10, 	   4,   -6, 	   3,   -4, 	  -1,   -8
+.2byte    5,   -9, 	   3,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   3,   -8, 	   5,   -5, 	  -1,   -8
+.2byte    1,  -11, 	  -4,   -9, 	   0,   -6, 	  -2,   -9
+.2byte    1,  -11, 	  -1,   -5, 	   3,   -4, 	  -2,   -9
+.2byte    3,  -10, 	  -4,   -8, 	   0,   -5, 	  -1,   -8
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte    0,  -11, 	   0,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -1,  -11, 	  -2,   -6, 	   5,   -6, 	   0,   -9
+.2byte   -3,  -11, 	   2,   -9, 	  -2,   -6, 	   0,   -9
+.2byte   -3,  -11, 	  -1,   -5, 	  -5,   -4, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -8, 	  -2,   -5, 	  -1,   -8
+.2byte   -6,  -10, 	  -6,   -6, 	  -5,   -4, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -4, 	  -1,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -5,   -8, 	  -7,   -5, 	  -1,   -8
+.2byte   -5,  -10, 	  -5,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -6,   -9, 	  -4,   -4, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -9, 	  -8,   -7, 	  -3,   -4, 	  -1,   -8
+.2byte   -1,   -6, 	  -3,   -2, 	   1,   -2, 	  -1,   -7
+.2byte   -8,   -8, 	  -6,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte  -10,   -9, 	  -7,   -5, 	  -7,   -4, 	  -2,   -8
+.2byte   -8,  -11, 	  -2,   -7, 	  -7,   -5, 	  -2,   -8
+.2byte   -1,  -13, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte    6,  -11, 	   0,   -7, 	   5,   -5, 	   0,   -8
+.2byte    8,   -9, 	   5,   -5, 	   5,   -4, 	   0,   -8
+.2byte    6,   -8, 	   4,   -4, 	   0,   -3, 	   0,   -9
+.2byte   -1,  -12, 	  -4,   -9, 	   2,   -9, 	  -1,   -9
+.2byte    1,  -12, 	   3,  -10, 	  -2,   -9, 	  -1,   -8
+.2byte    3,  -14, 	   2,  -11, 	   2,   -9, 	  -1,   -9
+.2byte    4,  -14, 	  -3,  -12, 	   3,   -8, 	  -2,   -8
+.2byte   -1,  -14, 	   2,  -11, 	  -4,  -11, 	  -1,   -9
+.2byte   -6,  -14, 	   1,  -12, 	  -5,   -8, 	   0,   -8
+.2byte   -5,  -14, 	  -4,  -11, 	  -4,   -9, 	  -1,   -9
+.2byte   -3,  -12, 	  -5,  -10, 	   0,   -9, 	  -1,   -8
+.2byte   -1,  -10, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	  -4,   -9, 	   2,   -9, 	  -1,   -9
+.2byte   -1,   -6, 	  -3,   -2, 	   1,   -2, 	  -1,   -7
+.2byte    3,  -10, 	   3,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    2,  -12, 	   4,  -10, 	  -1,   -9, 	   0,   -8
+.2byte    5,   -9, 	   3,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte    4,  -10, 	   4,   -6, 	   3,   -4, 	  -1,   -8
+.2byte    3,  -14, 	   2,  -11, 	   2,   -9, 	  -1,   -9
+.2byte    7,  -10, 	   4,   -6, 	   4,   -5, 	  -1,   -9
+.2byte    1,  -11, 	  -4,   -9, 	   0,   -6, 	  -2,   -9
+.2byte    4,  -14, 	  -3,  -12, 	   3,   -8, 	  -2,   -8
+.2byte    5,  -11, 	  -1,   -7, 	   4,   -5, 	  -1,   -8
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -15, 	   2,  -12, 	  -4,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte   -3,  -11, 	   2,   -9, 	  -2,   -6, 	   0,   -9
+.2byte   -6,  -14, 	   1,  -12, 	  -5,   -8, 	   0,   -8
+.2byte   -7,  -11, 	  -1,   -7, 	  -6,   -5, 	  -1,   -8
+.2byte   -6,  -10, 	  -6,   -6, 	  -5,   -4, 	  -1,   -8
+.2byte   -5,  -14, 	  -4,  -11, 	  -4,   -9, 	  -1,   -9
+.2byte   -9,  -10, 	  -6,   -6, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,  -10, 	  -5,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -6,  -10, 	  -1,   -9, 	  -2,   -8
+.2byte   -7,   -9, 	  -5,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -1,   -6, 	  -3,   -2, 	   1,   -2, 	  -1,   -7
+.2byte   -8,   -8, 	  -6,   -4, 	  -2,   -3, 	  -2,   -9
+.2byte  -10,   -9, 	  -7,   -5, 	  -7,   -4, 	  -2,   -8
+.2byte   -8,  -11, 	  -2,   -7, 	  -7,   -5, 	  -2,   -8
+.2byte   -1,  -13, 	   1,   -4, 	  -3,   -4, 	  -1,   -8
+.2byte    6,  -11, 	   0,   -7, 	   5,   -5, 	   0,   -8
+.2byte    8,   -9, 	   5,   -5, 	   5,   -4, 	   0,   -8
+.2byte    6,   -8, 	   4,   -4, 	   0,   -3, 	   0,   -9
+.2byte   -1,  -10, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -5,  -10, 	  -5,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte   -6,  -10, 	  -6,   -6, 	  -5,   -4, 	  -1,   -8
+.2byte   -3,  -11, 	   2,   -9, 	  -2,   -6, 	   0,   -9
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte    1,  -11, 	  -4,   -9, 	   0,   -6, 	  -2,   -9
+.2byte    4,  -10, 	   4,   -6, 	   3,   -4, 	  -1,   -8
+.2byte    3,  -10, 	   3,   -6, 	  -1,   -5, 	  -1,   -9
+sFlaaffyAnimTable1:
+.4byte sFlaaffyAnims_1_1
+.4byte sFlaaffyAnims_1_2
+.4byte sFlaaffyAnims_1_3
+.4byte sFlaaffyAnims_1_4
+.4byte sFlaaffyAnims_1_5
+.4byte sFlaaffyAnims_1_6
+.4byte sFlaaffyAnims_1_7
+.4byte sFlaaffyAnims_1_8
+sFlaaffyAnimTable2:
+.4byte sFlaaffyAnims_2_1
+.4byte sFlaaffyAnims_2_2
+.4byte sFlaaffyAnims_2_3
+.4byte sFlaaffyAnims_2_4
+.4byte sFlaaffyAnims_2_5
+.4byte sFlaaffyAnims_2_6
+.4byte sFlaaffyAnims_2_7
+.4byte sFlaaffyAnims_2_8
+sFlaaffyAnimTable3:
+.4byte sFlaaffyAnims_3_1
+.4byte sFlaaffyAnims_3_2
+.4byte sFlaaffyAnims_3_3
+.4byte sFlaaffyAnims_3_4
+.4byte sFlaaffyAnims_3_5
+.4byte sFlaaffyAnims_3_6
+.4byte sFlaaffyAnims_3_7
+.4byte sFlaaffyAnims_3_8
+sFlaaffyAnimTable4:
+.4byte sFlaaffyAnims_4_1
+.4byte sFlaaffyAnims_4_2
+.4byte sFlaaffyAnims_4_3
+.4byte sFlaaffyAnims_4_4
+.4byte sFlaaffyAnims_4_5
+.4byte sFlaaffyAnims_4_6
+.4byte sFlaaffyAnims_4_7
+.4byte sFlaaffyAnims_4_8
+sFlaaffyAnimTable5:
+.4byte sFlaaffyAnims_5_1
+.4byte sFlaaffyAnims_5_2
+.4byte sFlaaffyAnims_5_3
+.4byte sFlaaffyAnims_5_4
+.4byte sFlaaffyAnims_5_5
+.4byte sFlaaffyAnims_5_6
+.4byte sFlaaffyAnims_5_7
+.4byte sFlaaffyAnims_5_8
+sFlaaffyAnimTable6:
+.4byte sFlaaffyAnims_6_1
+.4byte sFlaaffyAnims_6_1
+.4byte sFlaaffyAnims_6_1
+.4byte sFlaaffyAnims_6_1
+.4byte sFlaaffyAnims_6_1
+.4byte sFlaaffyAnims_6_1
+.4byte sFlaaffyAnims_6_1
+.4byte sFlaaffyAnims_6_1
+sFlaaffyAnimTable7:
+.4byte sFlaaffyAnims_7_1
+.4byte sFlaaffyAnims_7_2
+.4byte sFlaaffyAnims_7_3
+.4byte sFlaaffyAnims_7_4
+.4byte sFlaaffyAnims_7_5
+.4byte sFlaaffyAnims_7_6
+.4byte sFlaaffyAnims_7_7
+.4byte sFlaaffyAnims_7_8
+sFlaaffyAnimTable8:
+.4byte sFlaaffyAnims_8_1
+.4byte sFlaaffyAnims_8_2
+.4byte sFlaaffyAnims_8_3
+.4byte sFlaaffyAnims_8_4
+.4byte sFlaaffyAnims_8_5
+.4byte sFlaaffyAnims_8_6
+.4byte sFlaaffyAnims_8_7
+.4byte sFlaaffyAnims_8_8
+sFlaaffyAnimTable9:
+.4byte sFlaaffyAnims_9_1
+.4byte sFlaaffyAnims_9_2
+.4byte sFlaaffyAnims_9_3
+.4byte sFlaaffyAnims_9_4
+.4byte sFlaaffyAnims_9_5
+.4byte sFlaaffyAnims_9_6
+.4byte sFlaaffyAnims_9_7
+.4byte sFlaaffyAnims_9_8
+sFlaaffyAnimTable10:
+.4byte sFlaaffyAnims_10_1
+.4byte sFlaaffyAnims_10_2
+.4byte sFlaaffyAnims_10_3
+.4byte sFlaaffyAnims_10_4
+.4byte sFlaaffyAnims_10_5
+.4byte sFlaaffyAnims_10_6
+.4byte sFlaaffyAnims_10_7
+.4byte sFlaaffyAnims_10_8
+sFlaaffyAnimTable11:
+.4byte sFlaaffyAnims_11_1
+.4byte sFlaaffyAnims_11_2
+.4byte sFlaaffyAnims_11_3
+.4byte sFlaaffyAnims_11_4
+.4byte sFlaaffyAnims_11_5
+.4byte sFlaaffyAnims_11_6
+.4byte sFlaaffyAnims_11_7
+.4byte sFlaaffyAnims_11_8
+sFlaaffyAnimTable12:
+.4byte sFlaaffyAnims_12_1
+.4byte sFlaaffyAnims_12_2
+.4byte sFlaaffyAnims_12_3
+.4byte sFlaaffyAnims_12_4
+.4byte sFlaaffyAnims_12_5
+.4byte sFlaaffyAnims_12_6
+.4byte sFlaaffyAnims_12_7
+.4byte sFlaaffyAnims_12_8
+sFlaaffyAnimTable13:
+.4byte sFlaaffyAnims_13_1
+.4byte sFlaaffyAnims_13_2
+.4byte sFlaaffyAnims_13_3
+.4byte sFlaaffyAnims_13_4
+.4byte sFlaaffyAnims_13_5
+.4byte sFlaaffyAnims_13_6
+.4byte sFlaaffyAnims_13_7
+.4byte sFlaaffyAnims_13_8
+sAxAnimationsFlaaffy:
+.4byte sFlaaffyAnimTable1
+.4byte sFlaaffyAnimTable2
+.4byte sFlaaffyAnimTable3
+.4byte sFlaaffyAnimTable4
+.4byte sFlaaffyAnimTable5
+.4byte sFlaaffyAnimTable6
+.4byte sFlaaffyAnimTable7
+.4byte sFlaaffyAnimTable8
+.4byte sFlaaffyAnimTable9
+.4byte sFlaaffyAnimTable10
+.4byte sFlaaffyAnimTable11
+.4byte sFlaaffyAnimTable12
+.4byte sFlaaffyAnimTable13
+sAxSpritesFlaaffy:
+.4byte sFlaaffySprites1
+.4byte sFlaaffySprites2
+.4byte sFlaaffySprites3
+.4byte sFlaaffySprites4
+.4byte sFlaaffySprites5
+.4byte sFlaaffySprites6
+.4byte sFlaaffySprites7
+.4byte sFlaaffySprites8
+.4byte sFlaaffySprites9
+.4byte sFlaaffySprites10
+.4byte sFlaaffySprites11
+.4byte sFlaaffySprites12
+.4byte sFlaaffySprites13
+.4byte sFlaaffySprites14
+.4byte sFlaaffySprites15
+.4byte sFlaaffySprites16
+.4byte sFlaaffySprites17
+.4byte sFlaaffySprites18
+.4byte sFlaaffySprites19
+.4byte sFlaaffySprites20
+.4byte sFlaaffySprites21
+.4byte sFlaaffySprites22
+.4byte sFlaaffySprites23
+.4byte sFlaaffySprites24
+.4byte sFlaaffySprites25
+.4byte sFlaaffySprites26
+.4byte sFlaaffySprites27
+.4byte sFlaaffySprites28
+.4byte sFlaaffySprites29
+.4byte sFlaaffySprites30
+.4byte sFlaaffySprites31
+.4byte sFlaaffySprites32
+.4byte sFlaaffySprites33
+.4byte sFlaaffySprites34
+.4byte sFlaaffySprites35
+.4byte sFlaaffySprites36
+.4byte sFlaaffySprites37
+.4byte sFlaaffySprites38
+.4byte sFlaaffySprites39
+.4byte sFlaaffySprites40
+.4byte sFlaaffySprites41
+.4byte sFlaaffySprites42
+sAxMainFlaaffy:
+ax_main sAxPosesFlaaffy, sAxAnimationsFlaaffy, 13, sAxSpritesFlaaffy, sAxPositionsFlaaffy

--- a/data/ax/flareon.inc
+++ b/data/ax/flareon.inc
@@ -1,0 +1,2535 @@
+.global gAxFlareon
+gAxFlareon:
+ax_siro sAxMainFlareon
+sFlareonPose1:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose6:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose7:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose8:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose9:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose10:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose11:
+ax_pose 10, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose12:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose13:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose14:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose15:
+ax_pose 14, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose16:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose17:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose18:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose19:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose20:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose21:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose25:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose26:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose27:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose28:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose29:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose30:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose31:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose32:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose33:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose34:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose35:
+ax_pose 10, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose36:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose37:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose38:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose39:
+ax_pose 14, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose40:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose41:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose42:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose43:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose44:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose45:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose47:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose48:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose49:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose50:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose51:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose52:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose53:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose54:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose55:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose56:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose57:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose58:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose59:
+ax_pose 10, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose60:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose61:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose62:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose63:
+ax_pose 14, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose64:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose65:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose66:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose67:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose68:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose69:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose71:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose72:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose73:
+ax_pose 2, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose74:
+ax_pose 15, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose75:
+ax_pose 5, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose76:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sFlareonPose77:
+ax_pose 8, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sFlareonPose78:
+ax_pose 17, 0x01ea, 0x90f4, 0x0c00
+ax_pose_terminator
+sFlareonPose79:
+ax_pose 11, 0x01e7, 0x90ea, 0x0c00
+ax_pose_terminator
+sFlareonPose80:
+ax_pose 18, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sFlareonPose81:
+ax_pose 14, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose82:
+ax_pose 19, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sFlareonPose83:
+ax_pose 11, 0x01e7, 0x80f6, 0x0c00
+ax_pose_terminator
+sFlareonPose84:
+ax_pose 18, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose85:
+ax_pose 8, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sFlareonPose86:
+ax_pose 17, 0x01ea, 0x80ec, 0x0c00
+ax_pose_terminator
+sFlareonPose87:
+ax_pose 5, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose88:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sFlareonPose89:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose90:
+ax_pose 20, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose91:
+ax_pose 21, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose92:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose93:
+ax_pose 22, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose94:
+ax_pose 23, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose95:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose96:
+ax_pose 24, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose97:
+ax_pose 25, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose98:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose99:
+ax_pose 26, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose100:
+ax_pose 27, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose101:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose102:
+ax_pose 28, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose103:
+ax_pose 29, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose104:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose105:
+ax_pose 26, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose106:
+ax_pose 27, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose107:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose108:
+ax_pose 24, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose109:
+ax_pose 25, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose110:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose111:
+ax_pose 22, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose112:
+ax_pose 23, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose113:
+ax_pose 30, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sFlareonPose114:
+ax_pose 31, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sFlareonPose115:
+ax_pose 32, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sFlareonPose116:
+ax_pose 33, 0x01e3, 0x90ee, 0x0c00
+ax_pose_terminator
+sFlareonPose117:
+ax_pose 34, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sFlareonPose118:
+ax_pose 35, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sFlareonPose119:
+ax_pose 36, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose120:
+ax_pose 35, 0x01e4, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose121:
+ax_pose 34, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose122:
+ax_pose 33, 0x01e3, 0x80f2, 0x0c00
+ax_pose_terminator
+sFlareonPose123:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose124:
+ax_pose 20, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose125:
+ax_pose 21, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose126:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose127:
+ax_pose 22, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose128:
+ax_pose 23, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose129:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose130:
+ax_pose 24, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose131:
+ax_pose 25, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose132:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose133:
+ax_pose 26, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose134:
+ax_pose 27, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose135:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose136:
+ax_pose 28, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose137:
+ax_pose 29, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose138:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose139:
+ax_pose 26, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose140:
+ax_pose 27, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose141:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose142:
+ax_pose 24, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose143:
+ax_pose 25, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose144:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose145:
+ax_pose 22, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose146:
+ax_pose 23, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose147:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose148:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose149:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose150:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose151:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose152:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose153:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose154:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose155:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose156:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose157:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose158:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose159:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose160:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose161:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose162:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose163:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose164:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose165:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose166:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose167:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose168:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sFlareonPose169:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose170:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose171:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose172:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose173:
+ax_pose 10, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose174:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose175:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose176:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose177:
+ax_pose 14, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose178:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose179:
+ax_pose 10, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose180:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose181:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose182:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose183:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose184:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose185:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose186:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose187:
+ax_pose 15, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sFlareonPose188:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sFlareonPose189:
+ax_pose 17, 0x01ea, 0x90f4, 0x0c00
+ax_pose_terminator
+sFlareonPose190:
+ax_pose 18, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sFlareonPose191:
+ax_pose 19, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sFlareonPose192:
+ax_pose 18, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose193:
+ax_pose 17, 0x01ea, 0x80ec, 0x0c00
+ax_pose_terminator
+sFlareonPose194:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sFlareonPose195:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose196:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sFlareonPose197:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sFlareonPose198:
+ax_pose 9, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sFlareonPose199:
+ax_pose 12, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sFlareonPose200:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sFlareonPose201:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sFlareonPose202:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+.align 2
+sFlareonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sFlareonAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sFlareonAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sFlareonAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 35, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim 2, 2, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 1, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sFlareonAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sFlareonAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 0, 0, 0, -1,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim 2, 2, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 1, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sFlareonAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sFlareonAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sFlareonAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sFlareonAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 4, 4, 4, 4,
+ax_anim 2, 2, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sFlareonAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sFlareonAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 4, -4, 4, -4,
+ax_anim 2, 2, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 1, 58, 19, -17, 19, -17,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 0, 58, 19, -17, 19, -17,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sFlareonAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, -4,
+ax_anim 2, 2, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 1, 61, 1, -18, 1, -18,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 0, 61, 1, -18, 1, -18,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sFlareonAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 65, 0, 0, 0, -1,
+ax_anim 2, 0, 64, -4, -4, -4, -4,
+ax_anim 2, 2, 65, -10, -10, -10, -10,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 1, 64, -19, -17, -19, -17,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 0, 64, -19, -17, -19, -17,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sFlareonAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sFlareonAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, -4, 4, -4, 4,
+ax_anim 2, 2, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sFlareonAnims_4_1:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 6, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 2, 73, -1, 2, -1, 2,
+ax_anim 3, 0, 73, 0, 2, 0, 2,
+ax_anim 3, 0, 73, -1, 2, -1, 2,
+ax_anim 3, 1, 73, 0, 2, 0, 2,
+ax_anim 3, 0, 73, -1, 2, -1, 2,
+ax_anim_terminator
+sFlareonAnims_4_2:
+ax_anim 4, 0, 74, -1, -1, -1, -1,
+ax_anim 6, 0, 74, -2, -2, -2, -2,
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 2, 75, 2, 2, 2, 2,
+ax_anim 3, 0, 75, 0, 2, 0, 2,
+ax_anim 3, 0, 75, 2, 2, 2, 2,
+ax_anim 3, 1, 75, 0, 2, 0, 2,
+ax_anim 3, 0, 75, 2, 2, 2, 2,
+ax_anim_terminator
+sFlareonAnims_4_3:
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 6, 0, 76, -1, 0, -1, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 77, 1, 0, 1, 0,
+ax_anim 3, 0, 77, 0, 0, 0, 0,
+ax_anim 3, 0, 77, 1, 0, 1, 0,
+ax_anim 3, 1, 77, 0, 0, 0, 0,
+ax_anim 3, 0, 77, 1, 0, 1, 0,
+ax_anim_terminator
+sFlareonAnims_4_4:
+ax_anim 4, 0, 78, -1, 1, -1, 1,
+ax_anim 6, 0, 78, -2, 2, -2, 2,
+ax_anim 2, 0, 79, 0, -2, 0, -2,
+ax_anim 2, 2, 79, 2, -2, 2, -2,
+ax_anim 3, 0, 79, 0, -2, 0, -2,
+ax_anim 3, 0, 79, 2, -2, 2, -2,
+ax_anim 3, 1, 79, 0, -2, 0, -2,
+ax_anim 3, 0, 79, 2, -2, 2, -2,
+ax_anim_terminator
+sFlareonAnims_4_5:
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 6, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 2, 2, 81, -1, -2, -1, -2,
+ax_anim 3, 0, 81, 0, -2, 0, -2,
+ax_anim 3, 0, 81, -1, -2, -1, -2,
+ax_anim 3, 1, 81, 0, -2, 0, -2,
+ax_anim 3, 0, 81, -1, -2, -1, -2,
+ax_anim_terminator
+sFlareonAnims_4_6:
+ax_anim 4, 0, 82, 1, 1, 1, 1,
+ax_anim 6, 0, 82, 2, 2, 2, 2,
+ax_anim 2, 0, 83, 0, -2, 0, -2,
+ax_anim 2, 2, 83, -2, -2, -2, -2,
+ax_anim 3, 0, 83, 0, -2, 0, -2,
+ax_anim 3, 0, 83, -2, -2, -2, -2,
+ax_anim 3, 1, 83, 0, -2, 0, -2,
+ax_anim 3, 0, 83, -2, -2, -2, -2,
+ax_anim_terminator
+sFlareonAnims_4_7:
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 6, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 85, -1, 0, -1, 0,
+ax_anim 3, 0, 85, 0, 0, 0, 0,
+ax_anim 3, 0, 85, -1, 0, -1, 0,
+ax_anim 3, 1, 85, 0, 0, 0, 0,
+ax_anim 3, 0, 85, -1, 0, -1, 0,
+ax_anim_terminator
+sFlareonAnims_4_8:
+ax_anim 4, 0, 86, 1, -1, 1, -1,
+ax_anim 6, 0, 86, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 0, 2, 0, 2,
+ax_anim 2, 2, 87, -2, 2, -2, 2,
+ax_anim 3, 0, 87, 0, 2, 0, 2,
+ax_anim 3, 0, 87, -2, 2, -2, 2,
+ax_anim 3, 1, 87, 0, 2, 0, 2,
+ax_anim 3, 0, 87, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sFlareonAnims_5_1:
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 4, 2, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_5_2:
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 4, 2, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_5_3:
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 2, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_5_4:
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 2, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_5_5:
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 2, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_5_6:
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 2, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_5_7:
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 2, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_5_8:
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 2, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sFlareonAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sFlareonAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sFlareonAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sFlareonAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sFlareonAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sFlareonAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sFlareonAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sFlareonAnims_8_1:
+ax_anim 12, 0, 122, 0, 0, 0, 0,
+ax_anim 16, 0, 123, 0, 0, 0, 0,
+ax_anim 12, 0, 122, 0, 0, 0, 0,
+ax_anim 16, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_8_2:
+ax_anim 12, 0, 125, 0, 0, 0, 0,
+ax_anim 16, 0, 126, 0, 0, 0, 0,
+ax_anim 12, 0, 125, 0, 0, 0, 0,
+ax_anim 16, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_8_3:
+ax_anim 12, 0, 128, 0, 0, 0, 0,
+ax_anim 16, 0, 129, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, 0, 0, 0,
+ax_anim 16, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_8_4:
+ax_anim 12, 0, 131, 0, 0, 0, 0,
+ax_anim 16, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 131, 0, 0, 0, 0,
+ax_anim 16, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_8_5:
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim 16, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_8_6:
+ax_anim 12, 0, 137, 0, 0, 0, 0,
+ax_anim 16, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 137, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_8_7:
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_8_8:
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 9, 11, 9, 11,
+ax_anim 2, 0, 149, 8, 18, 8, 18,
+ax_anim 3, 0, 150, 1, 21, 1, 21,
+ax_anim 2, 3, 151, -5, 19, -5, 19,
+ax_anim 2, 0, 152, -6, 10, -6, 10,
+ax_anim 1, 0, 153, -4, 4, -4, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 26, 9, 26, 9,
+ax_anim 3, 0, 149, 27, 20, 27, 20,
+ax_anim 2, 3, 150, 14, 22, 14, 22,
+ax_anim 2, 0, 151, 4, 12, 4, 12,
+ax_anim 1, 0, 152, 1, 7, 1, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 19, -4, 19, -4,
+ax_anim 3, 0, 148, 23, 1, 23, 1,
+ax_anim 2, 3, 149, 19, 5, 19, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 1, -6, 1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -20, 11, -20,
+ax_anim 3, 0, 147, 20, -20, 20, -20,
+ax_anim 2, 3, 148, 18, -12, 18, -12,
+ax_anim 2, 0, 149, 14, -6, 14, -6,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -9, -8, -9,
+ax_anim 2, 0, 153, -7, -15, -7, -15,
+ax_anim 3, 0, 146, -1, -20, -1, -20,
+ax_anim 2, 3, 147, 4, -16, 4, -16,
+ax_anim 2, 0, 148, 5, -8, 5, -8,
+ax_anim 1, 0, 149, 4, -4, 4, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, -1, -6, -1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -11, -20, -11, -20,
+ax_anim 3, 0, 153, -20, -20, -20, -20,
+ax_anim 2, 3, 152, -18, -12, -18, -12,
+ax_anim 2, 0, 151, -14, -6, -14, -6,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -19, -4, -19, -4,
+ax_anim 3, 0, 152, -23, 1, -23, 1,
+ax_anim 2, 3, 151, -19, 5, -19, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -26, 9, -26, 9,
+ax_anim 3, 0, 151, -27, 20, -27, 20,
+ax_anim 2, 3, 150, -14, 22, -14, 22,
+ax_anim 2, 0, 149, -4, 12, -4, 12,
+ax_anim 1, 0, 148, -1, 7, -1, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_12_2:
+ax_anim 2, 0, 187, 1, -1, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, -1, 1, 0,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_12_3:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_12_4:
+ax_anim 2, 0, 189, -1, -1, -1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, -1, -1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, -1, -1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, -1, -1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, -1, -1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_12_6:
+ax_anim 2, 0, 191, 1, -1, 1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, -1, 1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, -1, 1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, -1, 1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, -1, 1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_12_7:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_12_8:
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlareonAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sFlareonGfx1:
+.incbin "baserom.gba", 0xAE3E68, 0x200
+sFlareonSprites1:
+ax_sprite sFlareonGfx1, 0x200
+ax_sprite_terminator
+sFlareonGfx2:
+.incbin "baserom.gba", 0xAE4078, 0x200
+sFlareonSprites2:
+ax_sprite sFlareonGfx2, 0x200
+ax_sprite_terminator
+sFlareonGfx3:
+.incbin "baserom.gba", 0xAE4288, 0x200
+sFlareonSprites3:
+ax_sprite sFlareonGfx3, 0x200
+ax_sprite_terminator
+sFlareonGfx4:
+.incbin "baserom.gba", 0xAE4498, 0x200
+sFlareonSprites4:
+ax_sprite sFlareonGfx4, 0x200
+ax_sprite_terminator
+sFlareonGfx5:
+.incbin "baserom.gba", 0xAE46A8, 0x200
+sFlareonSprites5:
+ax_sprite sFlareonGfx5, 0x200
+ax_sprite_terminator
+sFlareonGfx6:
+.incbin "baserom.gba", 0xAE48B8, 0x200
+sFlareonSprites6:
+ax_sprite sFlareonGfx6, 0x200
+ax_sprite_terminator
+sFlareonGfx7:
+.incbin "baserom.gba", 0xAE4AC8, 0x200
+sFlareonSprites7:
+ax_sprite sFlareonGfx7, 0x200
+ax_sprite_terminator
+sFlareonGfx8:
+.incbin "baserom.gba", 0xAE4CD8, 0x200
+sFlareonSprites8:
+ax_sprite sFlareonGfx8, 0x200
+ax_sprite_terminator
+sFlareonGfx9:
+.incbin "baserom.gba", 0xAE4EE8, 0x200
+sFlareonSprites9:
+ax_sprite sFlareonGfx9, 0x200
+ax_sprite_terminator
+sFlareonGfx10:
+.incbin "baserom.gba", 0xAE50F8, 0x200
+sFlareonSprites10:
+ax_sprite sFlareonGfx10, 0x200
+ax_sprite_terminator
+sFlareonGfx11:
+.incbin "baserom.gba", 0xAE5308, 0x200
+sFlareonSprites11:
+ax_sprite sFlareonGfx11, 0x200
+ax_sprite_terminator
+sFlareonGfx12:
+.incbin "baserom.gba", 0xAE5518, 0x200
+sFlareonSprites12:
+ax_sprite sFlareonGfx12, 0x200
+ax_sprite_terminator
+sFlareonGfx13:
+.incbin "baserom.gba", 0xAE5728, 0x200
+sFlareonSprites13:
+ax_sprite sFlareonGfx13, 0x200
+ax_sprite_terminator
+sFlareonGfx14:
+.incbin "baserom.gba", 0xAE5938, 0x200
+sFlareonSprites14:
+ax_sprite sFlareonGfx14, 0x200
+ax_sprite_terminator
+sFlareonGfx15:
+.incbin "baserom.gba", 0xAE5B48, 0x200
+sFlareonSprites15:
+ax_sprite sFlareonGfx15, 0x200
+ax_sprite_terminator
+sFlareonGfx16:
+.incbin "baserom.gba", 0xAE5D58, 0x60
+sFlareonGfx16_1:
+.incbin "baserom.gba", 0xAE5DB8, 0x60
+sFlareonGfx16_2:
+.incbin "baserom.gba", 0xAE5E18, 0x60
+sFlareonSprites16:
+ax_sprite sFlareonGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx17:
+.incbin "baserom.gba", 0xAE5EB0, 0x60
+sFlareonGfx17_1:
+.incbin "baserom.gba", 0xAE5F10, 0x60
+sFlareonGfx17_2:
+.incbin "baserom.gba", 0xAE5F70, 0x60
+sFlareonSprites17:
+ax_sprite sFlareonGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx18:
+.incbin "baserom.gba", 0xAE6008, 0x180
+sFlareonSprites18:
+ax_sprite sFlareonGfx18, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFlareonGfx19:
+.incbin "baserom.gba", 0xAE61A0, 0x40
+sFlareonGfx19_1:
+.incbin "baserom.gba", 0xAE61E0, 0x60
+sFlareonGfx19_2:
+.incbin "baserom.gba", 0xAE6240, 0x60
+sFlareonGfx19_3:
+.incbin "baserom.gba", 0xAE62A0, 0x40
+sFlareonSprites19:
+ax_sprite sFlareonGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFlareonGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFlareonGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlareonGfx20:
+.incbin "baserom.gba", 0xAE6328, 0x60
+sFlareonGfx20_1:
+.incbin "baserom.gba", 0xAE6388, 0x60
+sFlareonGfx20_2:
+.incbin "baserom.gba", 0xAE63E8, 0x60
+sFlareonSprites20:
+ax_sprite sFlareonGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx21:
+.incbin "baserom.gba", 0xAE6480, 0x60
+sFlareonGfx21_1:
+.incbin "baserom.gba", 0xAE64E0, 0x60
+sFlareonGfx21_2:
+.incbin "baserom.gba", 0xAE6540, 0x60
+sFlareonSprites21:
+ax_sprite sFlareonGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx22:
+.incbin "baserom.gba", 0xAE65D8, 0x60
+sFlareonGfx22_1:
+.incbin "baserom.gba", 0xAE6638, 0x60
+sFlareonGfx22_2:
+.incbin "baserom.gba", 0xAE6698, 0x60
+sFlareonSprites22:
+ax_sprite sFlareonGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx23:
+.incbin "baserom.gba", 0xAE6730, 0x60
+sFlareonGfx23_1:
+.incbin "baserom.gba", 0xAE6790, 0x60
+sFlareonGfx23_2:
+.incbin "baserom.gba", 0xAE67F0, 0x60
+sFlareonSprites23:
+ax_sprite sFlareonGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx24:
+.incbin "baserom.gba", 0xAE6888, 0x60
+sFlareonGfx24_1:
+.incbin "baserom.gba", 0xAE68E8, 0x60
+sFlareonGfx24_2:
+.incbin "baserom.gba", 0xAE6948, 0x60
+sFlareonSprites24:
+ax_sprite sFlareonGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx25:
+.incbin "baserom.gba", 0xAE69E0, 0x60
+sFlareonGfx25_1:
+.incbin "baserom.gba", 0xAE6A40, 0x100
+sFlareonSprites25:
+ax_sprite sFlareonGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx25_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFlareonGfx26:
+.incbin "baserom.gba", 0xAE6B68, 0x60
+sFlareonGfx26_1:
+.incbin "baserom.gba", 0xAE6BC8, 0x100
+sFlareonSprites26:
+ax_sprite sFlareonGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx26_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sFlareonGfx27:
+.incbin "baserom.gba", 0xAE6CF0, 0x40
+sFlareonGfx27_1:
+.incbin "baserom.gba", 0xAE6D30, 0x60
+sFlareonGfx27_2:
+.incbin "baserom.gba", 0xAE6D90, 0x60
+sFlareonSprites27:
+ax_sprite sFlareonGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFlareonGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx28:
+.incbin "baserom.gba", 0xAE6E28, 0x60
+sFlareonGfx28_1:
+.incbin "baserom.gba", 0xAE6E88, 0x60
+sFlareonGfx28_2:
+.incbin "baserom.gba", 0xAE6EE8, 0x60
+sFlareonSprites28:
+ax_sprite sFlareonGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx29:
+.incbin "baserom.gba", 0xAE6F80, 0x60
+sFlareonGfx29_1:
+.incbin "baserom.gba", 0xAE6FE0, 0x60
+sFlareonGfx29_2:
+.incbin "baserom.gba", 0xAE7040, 0x60
+sFlareonSprites29:
+ax_sprite sFlareonGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx30:
+.incbin "baserom.gba", 0xAE70D8, 0x60
+sFlareonGfx30_1:
+.incbin "baserom.gba", 0xAE7138, 0x60
+sFlareonGfx30_2:
+.incbin "baserom.gba", 0xAE7198, 0x60
+sFlareonSprites30:
+ax_sprite sFlareonGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFlareonGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFlareonGfx31:
+.incbin "baserom.gba", 0xAE7230, 0x200
+sFlareonSprites31:
+ax_sprite sFlareonGfx31, 0x200
+ax_sprite_terminator
+sFlareonGfx32:
+.incbin "baserom.gba", 0xAE7440, 0x200
+sFlareonSprites32:
+ax_sprite sFlareonGfx32, 0x200
+ax_sprite_terminator
+sFlareonGfx33:
+.incbin "baserom.gba", 0xAE7650, 0x200
+sFlareonSprites33:
+ax_sprite sFlareonGfx33, 0x200
+ax_sprite_terminator
+sFlareonGfx34:
+.incbin "baserom.gba", 0xAE7860, 0x200
+sFlareonSprites34:
+ax_sprite sFlareonGfx34, 0x200
+ax_sprite_terminator
+sFlareonGfx35:
+.incbin "baserom.gba", 0xAE7A70, 0x200
+sFlareonSprites35:
+ax_sprite sFlareonGfx35, 0x200
+ax_sprite_terminator
+sFlareonGfx36:
+.incbin "baserom.gba", 0xAE7C80, 0x200
+sFlareonSprites36:
+ax_sprite sFlareonGfx36, 0x200
+ax_sprite_terminator
+sFlareonGfx37:
+.incbin "baserom.gba", 0xAE7E90, 0x200
+sFlareonSprites37:
+ax_sprite sFlareonGfx37, 0x200
+ax_sprite_terminator
+sAxPosesFlareon:
+.4byte sFlareonPose1
+.4byte sFlareonPose2
+.4byte sFlareonPose3
+.4byte sFlareonPose4
+.4byte sFlareonPose5
+.4byte sFlareonPose6
+.4byte sFlareonPose7
+.4byte sFlareonPose8
+.4byte sFlareonPose9
+.4byte sFlareonPose10
+.4byte sFlareonPose11
+.4byte sFlareonPose12
+.4byte sFlareonPose13
+.4byte sFlareonPose14
+.4byte sFlareonPose15
+.4byte sFlareonPose16
+.4byte sFlareonPose17
+.4byte sFlareonPose18
+.4byte sFlareonPose19
+.4byte sFlareonPose20
+.4byte sFlareonPose21
+.4byte sFlareonPose22
+.4byte sFlareonPose23
+.4byte sFlareonPose24
+.4byte sFlareonPose25
+.4byte sFlareonPose26
+.4byte sFlareonPose27
+.4byte sFlareonPose28
+.4byte sFlareonPose29
+.4byte sFlareonPose30
+.4byte sFlareonPose31
+.4byte sFlareonPose32
+.4byte sFlareonPose33
+.4byte sFlareonPose34
+.4byte sFlareonPose35
+.4byte sFlareonPose36
+.4byte sFlareonPose37
+.4byte sFlareonPose38
+.4byte sFlareonPose39
+.4byte sFlareonPose40
+.4byte sFlareonPose41
+.4byte sFlareonPose42
+.4byte sFlareonPose43
+.4byte sFlareonPose44
+.4byte sFlareonPose45
+.4byte sFlareonPose46
+.4byte sFlareonPose47
+.4byte sFlareonPose48
+.4byte sFlareonPose49
+.4byte sFlareonPose50
+.4byte sFlareonPose51
+.4byte sFlareonPose52
+.4byte sFlareonPose53
+.4byte sFlareonPose54
+.4byte sFlareonPose55
+.4byte sFlareonPose56
+.4byte sFlareonPose57
+.4byte sFlareonPose58
+.4byte sFlareonPose59
+.4byte sFlareonPose60
+.4byte sFlareonPose61
+.4byte sFlareonPose62
+.4byte sFlareonPose63
+.4byte sFlareonPose64
+.4byte sFlareonPose65
+.4byte sFlareonPose66
+.4byte sFlareonPose67
+.4byte sFlareonPose68
+.4byte sFlareonPose69
+.4byte sFlareonPose70
+.4byte sFlareonPose71
+.4byte sFlareonPose72
+.4byte sFlareonPose73
+.4byte sFlareonPose74
+.4byte sFlareonPose75
+.4byte sFlareonPose76
+.4byte sFlareonPose77
+.4byte sFlareonPose78
+.4byte sFlareonPose79
+.4byte sFlareonPose80
+.4byte sFlareonPose81
+.4byte sFlareonPose82
+.4byte sFlareonPose83
+.4byte sFlareonPose84
+.4byte sFlareonPose85
+.4byte sFlareonPose86
+.4byte sFlareonPose87
+.4byte sFlareonPose88
+.4byte sFlareonPose89
+.4byte sFlareonPose90
+.4byte sFlareonPose91
+.4byte sFlareonPose92
+.4byte sFlareonPose93
+.4byte sFlareonPose94
+.4byte sFlareonPose95
+.4byte sFlareonPose96
+.4byte sFlareonPose97
+.4byte sFlareonPose98
+.4byte sFlareonPose99
+.4byte sFlareonPose100
+.4byte sFlareonPose101
+.4byte sFlareonPose102
+.4byte sFlareonPose103
+.4byte sFlareonPose104
+.4byte sFlareonPose105
+.4byte sFlareonPose106
+.4byte sFlareonPose107
+.4byte sFlareonPose108
+.4byte sFlareonPose109
+.4byte sFlareonPose110
+.4byte sFlareonPose111
+.4byte sFlareonPose112
+.4byte sFlareonPose113
+.4byte sFlareonPose114
+.4byte sFlareonPose115
+.4byte sFlareonPose116
+.4byte sFlareonPose117
+.4byte sFlareonPose118
+.4byte sFlareonPose119
+.4byte sFlareonPose120
+.4byte sFlareonPose121
+.4byte sFlareonPose122
+.4byte sFlareonPose123
+.4byte sFlareonPose124
+.4byte sFlareonPose125
+.4byte sFlareonPose126
+.4byte sFlareonPose127
+.4byte sFlareonPose128
+.4byte sFlareonPose129
+.4byte sFlareonPose130
+.4byte sFlareonPose131
+.4byte sFlareonPose132
+.4byte sFlareonPose133
+.4byte sFlareonPose134
+.4byte sFlareonPose135
+.4byte sFlareonPose136
+.4byte sFlareonPose137
+.4byte sFlareonPose138
+.4byte sFlareonPose139
+.4byte sFlareonPose140
+.4byte sFlareonPose141
+.4byte sFlareonPose142
+.4byte sFlareonPose143
+.4byte sFlareonPose144
+.4byte sFlareonPose145
+.4byte sFlareonPose146
+.4byte sFlareonPose147
+.4byte sFlareonPose148
+.4byte sFlareonPose149
+.4byte sFlareonPose150
+.4byte sFlareonPose151
+.4byte sFlareonPose152
+.4byte sFlareonPose153
+.4byte sFlareonPose154
+.4byte sFlareonPose155
+.4byte sFlareonPose156
+.4byte sFlareonPose157
+.4byte sFlareonPose158
+.4byte sFlareonPose159
+.4byte sFlareonPose160
+.4byte sFlareonPose161
+.4byte sFlareonPose162
+.4byte sFlareonPose163
+.4byte sFlareonPose164
+.4byte sFlareonPose165
+.4byte sFlareonPose166
+.4byte sFlareonPose167
+.4byte sFlareonPose168
+.4byte sFlareonPose169
+.4byte sFlareonPose170
+.4byte sFlareonPose171
+.4byte sFlareonPose172
+.4byte sFlareonPose173
+.4byte sFlareonPose174
+.4byte sFlareonPose175
+.4byte sFlareonPose176
+.4byte sFlareonPose177
+.4byte sFlareonPose178
+.4byte sFlareonPose179
+.4byte sFlareonPose180
+.4byte sFlareonPose181
+.4byte sFlareonPose182
+.4byte sFlareonPose183
+.4byte sFlareonPose184
+.4byte sFlareonPose185
+.4byte sFlareonPose186
+.4byte sFlareonPose187
+.4byte sFlareonPose188
+.4byte sFlareonPose189
+.4byte sFlareonPose190
+.4byte sFlareonPose191
+.4byte sFlareonPose192
+.4byte sFlareonPose193
+.4byte sFlareonPose194
+.4byte sFlareonPose195
+.4byte sFlareonPose196
+.4byte sFlareonPose197
+.4byte sFlareonPose198
+.4byte sFlareonPose199
+.4byte sFlareonPose200
+.4byte sFlareonPose201
+.4byte sFlareonPose202
+sAxPositionsFlareon:
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    3, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    1, 	   2,    3, 	  -1,  -10
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   7,   -1, 	   4,    2, 	   0,   -6
+.2byte    8,   -6, 	   9,    1, 	   0,    1, 	   1,   -5
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   2,   -1, 	   8,    0, 	  -1,   -5
+.2byte   10,   -7, 	   7,   -1, 	   2,    0, 	  -1,   -4
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    8,   -9, 	  -3,   -4, 	   5,   -2, 	  -1,   -8
+.2byte    8,   -9, 	   1,   -7, 	   2,    0, 	  -1,   -7
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -4, 	  -1,   -7
+.2byte   -2,  -10, 	   4,   -4, 	  -6,   -8, 	  -1,   -7
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -9,   -9, 	   2,   -4, 	  -6,   -2, 	   0,   -8
+.2byte   -9,   -9, 	  -2,   -7, 	  -3,    0, 	   0,   -7
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -3,   -1, 	  -9,    0, 	   0,   -5
+.2byte  -11,   -7, 	  -8,   -1, 	  -3,    0, 	   0,   -4
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -8,   -1, 	  -5,    2, 	  -1,   -6
+.2byte   -9,   -6, 	 -10,    1, 	  -1,    1, 	  -2,   -5
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    3, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    1, 	   2,    3, 	  -1,  -10
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   7,   -1, 	   4,    2, 	   0,   -6
+.2byte    8,   -6, 	   9,    1, 	   0,    1, 	   1,   -5
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   2,   -1, 	   8,    0, 	  -1,   -5
+.2byte   10,   -7, 	   7,   -1, 	   2,    0, 	  -1,   -4
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    8,   -9, 	  -3,   -4, 	   5,   -2, 	  -1,   -8
+.2byte    8,   -9, 	   1,   -7, 	   2,    0, 	  -1,   -7
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -4, 	  -1,   -7
+.2byte   -2,  -10, 	   4,   -4, 	  -6,   -8, 	  -1,   -7
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -9,   -9, 	   2,   -4, 	  -6,   -2, 	   0,   -8
+.2byte   -9,   -9, 	  -2,   -7, 	  -3,    0, 	   0,   -7
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -3,   -1, 	  -9,    0, 	   0,   -5
+.2byte  -11,   -7, 	  -8,   -1, 	  -3,    0, 	   0,   -4
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -8,   -1, 	  -5,    2, 	  -1,   -6
+.2byte   -9,   -6, 	 -10,    1, 	  -1,    1, 	  -2,   -5
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    3, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    1, 	   2,    3, 	  -1,  -10
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   7,   -1, 	   4,    2, 	   0,   -6
+.2byte    8,   -6, 	   9,    1, 	   0,    1, 	   1,   -5
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   2,   -1, 	   8,    0, 	  -1,   -5
+.2byte   10,   -7, 	   7,   -1, 	   2,    0, 	  -1,   -4
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    8,   -9, 	  -3,   -4, 	   5,   -2, 	  -1,   -8
+.2byte    8,   -9, 	   1,   -7, 	   2,    0, 	  -1,   -7
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -4, 	  -1,   -7
+.2byte   -2,  -10, 	   4,   -4, 	  -6,   -8, 	  -1,   -7
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -9,   -9, 	   2,   -4, 	  -6,   -2, 	   0,   -8
+.2byte   -9,   -9, 	  -2,   -7, 	  -3,    0, 	   0,   -7
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -3,   -1, 	  -9,    0, 	   0,   -5
+.2byte  -11,   -7, 	  -8,   -1, 	  -3,    0, 	   0,   -4
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -8,   -1, 	  -5,    2, 	  -1,   -6
+.2byte   -9,   -6, 	 -10,    1, 	  -1,    1, 	  -2,   -5
+.2byte    0,   -7, 	  -3,   -1, 	   3,    1, 	   0,  -12
+.2byte    0,   -5, 	  -4,    1, 	   4,    1, 	   0,   -8
+.2byte    7,   -6, 	   8,    1, 	  -1,    1, 	   0,   -5
+.2byte   11,   -8, 	   4,    0, 	   0,    1, 	   2,   -7
+.2byte    9,   -7, 	   6,   -1, 	   1,    0, 	  -2,   -4
+.2byte   14,   -9, 	   5,   -1, 	   4,    0, 	   2,   -6
+.2byte    7,   -9, 	   0,   -7, 	   1,    0, 	  -2,   -7
+.2byte    9,  -13, 	  -2,   -4, 	   3,   -1, 	   1,   -9
+.2byte   -2,  -10, 	   4,   -4, 	  -6,   -8, 	  -1,   -7
+.2byte   -1,  -17, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -8,   -9, 	  -1,   -7, 	  -2,    0, 	   1,   -7
+.2byte  -10,  -13, 	   1,   -4, 	  -4,   -1, 	  -2,   -9
+.2byte  -10,   -7, 	  -7,   -1, 	  -2,    0, 	   1,   -4
+.2byte  -15,   -9, 	  -6,   -1, 	  -5,    0, 	  -3,   -6
+.2byte   -8,   -6, 	  -9,    1, 	   0,    1, 	  -1,   -5
+.2byte  -12,   -8, 	  -5,    0, 	  -1,    1, 	  -3,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    1, 	   2,    1, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,    1, 	   2,    1, 	  -1,   -7
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   6,    0, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   6,    0, 	   2,    1, 	  -1,   -7
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   6,   -1, 	   4,    0, 	  -1,   -6
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    7,  -10, 	  -2,   -3, 	   3,   -1, 	   0,   -7
+.2byte    7,  -10, 	  -2,   -4, 	   3,   -1, 	   0,   -8
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -2,  -13, 	   4,   -3, 	  -8,   -3, 	  -2,   -7
+.2byte   -1,  -13, 	   6,   -3, 	  -6,   -3, 	   0,   -7
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -8,  -10, 	   1,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -8,  -10, 	   1,   -4, 	  -4,   -1, 	  -1,   -8
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -7,   -1, 	  -5,    0, 	   0,   -6
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -7,    0, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -7,    0, 	  -3,    1, 	   0,   -7
+.2byte   -9,   -4, 	  -8,    1, 	  -6,    2, 	   0,   -3
+.2byte   -9,   -3, 	  -8,    1, 	  -6,    2, 	   0,   -2
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    7,   -3, 	   8,   -2, 	  -2,    0, 	  -3,   -6
+.2byte   10,   -4, 	   1,   -2, 	   0,    0, 	  -1,   -5
+.2byte    7,   -7, 	  -2,   -3, 	   3,    0, 	   0,   -7
+.2byte    0,   -9, 	   5,   -2, 	  -5,   -2, 	   0,   -8
+.2byte   -8,   -7, 	   1,   -3, 	  -4,    0, 	  -1,   -7
+.2byte  -11,   -4, 	  -2,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -8,   -3, 	  -9,   -2, 	   1,    0, 	   2,   -6
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    1, 	   2,    1, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,    1, 	   2,    1, 	  -1,   -7
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   6,    0, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   6,    0, 	   2,    1, 	  -1,   -7
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   6,   -1, 	   4,    0, 	  -1,   -6
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    7,  -10, 	  -2,   -3, 	   3,   -1, 	   0,   -7
+.2byte    7,  -10, 	  -2,   -4, 	   3,   -1, 	   0,   -8
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -2,  -13, 	   4,   -3, 	  -8,   -3, 	  -2,   -7
+.2byte   -1,  -13, 	   6,   -3, 	  -6,   -3, 	   0,   -7
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -8,  -10, 	   1,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -8,  -10, 	   1,   -4, 	  -4,   -1, 	  -1,   -8
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -7,   -1, 	  -5,    0, 	   0,   -6
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -7,    0, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -7,    0, 	  -3,    1, 	   0,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    3, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    1, 	   2,    3, 	  -1,  -10
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+.2byte    8,   -6, 	   7,   -1, 	   4,    2, 	   0,   -6
+.2byte    8,   -6, 	   9,    1, 	   0,    1, 	   1,   -5
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte   10,   -7, 	   2,   -1, 	   8,    0, 	  -1,   -5
+.2byte   10,   -7, 	   7,   -1, 	   2,    0, 	  -1,   -4
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte    8,   -9, 	  -3,   -4, 	   5,   -2, 	  -1,   -8
+.2byte    8,   -9, 	   1,   -7, 	   2,    0, 	  -1,   -7
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -4, 	  -1,   -7
+.2byte   -2,  -10, 	   4,   -4, 	  -6,   -8, 	  -1,   -7
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -9,   -9, 	   2,   -4, 	  -6,   -2, 	   0,   -8
+.2byte   -9,   -9, 	  -2,   -7, 	  -3,    0, 	   0,   -7
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -3,   -1, 	  -9,    0, 	   0,   -5
+.2byte  -11,   -7, 	  -8,   -1, 	  -3,    0, 	   0,   -4
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -9,   -6, 	  -8,   -1, 	  -5,    2, 	  -1,   -6
+.2byte   -9,   -6, 	 -10,    1, 	  -1,    1, 	  -2,   -5
+.2byte   -1,   -5, 	  -5,    1, 	   3,    1, 	  -1,   -8
+.2byte   11,   -8, 	   4,    0, 	   0,    1, 	   2,   -7
+.2byte   14,   -9, 	   5,   -1, 	   4,    0, 	   2,   -6
+.2byte    9,  -13, 	  -2,   -4, 	   3,   -1, 	   1,   -9
+.2byte   -1,  -17, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte  -10,  -13, 	   1,   -4, 	  -4,   -1, 	  -2,   -9
+.2byte  -15,   -9, 	  -6,   -1, 	  -5,    0, 	  -3,   -6
+.2byte  -12,   -8, 	  -5,    0, 	  -1,    1, 	  -3,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   2,    1, 	  -1,  -10
+.2byte   -9,   -7, 	  -8,   -1, 	  -3,    1, 	  -1,   -7
+.2byte  -11,   -8, 	  -6,   -1, 	  -5,    0, 	   0,   -6
+.2byte   -9,  -10, 	   1,   -4, 	  -4,   -1, 	   0,   -9
+.2byte   -2,  -11, 	   3,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte    8,  -10, 	  -2,   -4, 	   3,   -1, 	  -1,   -9
+.2byte   10,   -8, 	   5,   -1, 	   4,    0, 	  -1,   -6
+.2byte    8,   -7, 	   7,   -1, 	   2,    1, 	   0,   -7
+sFlareonAnimTable1:
+.4byte sFlareonAnims_1_1
+.4byte sFlareonAnims_1_2
+.4byte sFlareonAnims_1_3
+.4byte sFlareonAnims_1_4
+.4byte sFlareonAnims_1_5
+.4byte sFlareonAnims_1_6
+.4byte sFlareonAnims_1_7
+.4byte sFlareonAnims_1_8
+sFlareonAnimTable2:
+.4byte sFlareonAnims_2_1
+.4byte sFlareonAnims_2_2
+.4byte sFlareonAnims_2_3
+.4byte sFlareonAnims_2_4
+.4byte sFlareonAnims_2_5
+.4byte sFlareonAnims_2_6
+.4byte sFlareonAnims_2_7
+.4byte sFlareonAnims_2_8
+sFlareonAnimTable3:
+.4byte sFlareonAnims_3_1
+.4byte sFlareonAnims_3_2
+.4byte sFlareonAnims_3_3
+.4byte sFlareonAnims_3_4
+.4byte sFlareonAnims_3_5
+.4byte sFlareonAnims_3_6
+.4byte sFlareonAnims_3_7
+.4byte sFlareonAnims_3_8
+sFlareonAnimTable4:
+.4byte sFlareonAnims_4_1
+.4byte sFlareonAnims_4_2
+.4byte sFlareonAnims_4_3
+.4byte sFlareonAnims_4_4
+.4byte sFlareonAnims_4_5
+.4byte sFlareonAnims_4_6
+.4byte sFlareonAnims_4_7
+.4byte sFlareonAnims_4_8
+sFlareonAnimTable5:
+.4byte sFlareonAnims_5_1
+.4byte sFlareonAnims_5_2
+.4byte sFlareonAnims_5_3
+.4byte sFlareonAnims_5_4
+.4byte sFlareonAnims_5_5
+.4byte sFlareonAnims_5_6
+.4byte sFlareonAnims_5_7
+.4byte sFlareonAnims_5_8
+sFlareonAnimTable6:
+.4byte sFlareonAnims_6_1
+.4byte sFlareonAnims_6_1
+.4byte sFlareonAnims_6_1
+.4byte sFlareonAnims_6_1
+.4byte sFlareonAnims_6_1
+.4byte sFlareonAnims_6_1
+.4byte sFlareonAnims_6_1
+.4byte sFlareonAnims_6_1
+sFlareonAnimTable7:
+.4byte sFlareonAnims_7_1
+.4byte sFlareonAnims_7_2
+.4byte sFlareonAnims_7_3
+.4byte sFlareonAnims_7_4
+.4byte sFlareonAnims_7_5
+.4byte sFlareonAnims_7_6
+.4byte sFlareonAnims_7_7
+.4byte sFlareonAnims_7_8
+sFlareonAnimTable8:
+.4byte sFlareonAnims_8_1
+.4byte sFlareonAnims_8_2
+.4byte sFlareonAnims_8_3
+.4byte sFlareonAnims_8_4
+.4byte sFlareonAnims_8_5
+.4byte sFlareonAnims_8_6
+.4byte sFlareonAnims_8_7
+.4byte sFlareonAnims_8_8
+sFlareonAnimTable9:
+.4byte sFlareonAnims_9_1
+.4byte sFlareonAnims_9_2
+.4byte sFlareonAnims_9_3
+.4byte sFlareonAnims_9_4
+.4byte sFlareonAnims_9_5
+.4byte sFlareonAnims_9_6
+.4byte sFlareonAnims_9_7
+.4byte sFlareonAnims_9_8
+sFlareonAnimTable10:
+.4byte sFlareonAnims_10_1
+.4byte sFlareonAnims_10_2
+.4byte sFlareonAnims_10_3
+.4byte sFlareonAnims_10_4
+.4byte sFlareonAnims_10_5
+.4byte sFlareonAnims_10_6
+.4byte sFlareonAnims_10_7
+.4byte sFlareonAnims_10_8
+sFlareonAnimTable11:
+.4byte sFlareonAnims_11_1
+.4byte sFlareonAnims_11_2
+.4byte sFlareonAnims_11_3
+.4byte sFlareonAnims_11_4
+.4byte sFlareonAnims_11_5
+.4byte sFlareonAnims_11_6
+.4byte sFlareonAnims_11_7
+.4byte sFlareonAnims_11_8
+sFlareonAnimTable12:
+.4byte sFlareonAnims_12_1
+.4byte sFlareonAnims_12_2
+.4byte sFlareonAnims_12_3
+.4byte sFlareonAnims_12_4
+.4byte sFlareonAnims_12_5
+.4byte sFlareonAnims_12_6
+.4byte sFlareonAnims_12_7
+.4byte sFlareonAnims_12_8
+sFlareonAnimTable13:
+.4byte sFlareonAnims_13_1
+.4byte sFlareonAnims_13_2
+.4byte sFlareonAnims_13_3
+.4byte sFlareonAnims_13_4
+.4byte sFlareonAnims_13_5
+.4byte sFlareonAnims_13_6
+.4byte sFlareonAnims_13_7
+.4byte sFlareonAnims_13_8
+sAxAnimationsFlareon:
+.4byte sFlareonAnimTable1
+.4byte sFlareonAnimTable2
+.4byte sFlareonAnimTable3
+.4byte sFlareonAnimTable4
+.4byte sFlareonAnimTable5
+.4byte sFlareonAnimTable6
+.4byte sFlareonAnimTable7
+.4byte sFlareonAnimTable8
+.4byte sFlareonAnimTable9
+.4byte sFlareonAnimTable10
+.4byte sFlareonAnimTable11
+.4byte sFlareonAnimTable12
+.4byte sFlareonAnimTable13
+sAxSpritesFlareon:
+.4byte sFlareonSprites1
+.4byte sFlareonSprites2
+.4byte sFlareonSprites3
+.4byte sFlareonSprites4
+.4byte sFlareonSprites5
+.4byte sFlareonSprites6
+.4byte sFlareonSprites7
+.4byte sFlareonSprites8
+.4byte sFlareonSprites9
+.4byte sFlareonSprites10
+.4byte sFlareonSprites11
+.4byte sFlareonSprites12
+.4byte sFlareonSprites13
+.4byte sFlareonSprites14
+.4byte sFlareonSprites15
+.4byte sFlareonSprites16
+.4byte sFlareonSprites17
+.4byte sFlareonSprites18
+.4byte sFlareonSprites19
+.4byte sFlareonSprites20
+.4byte sFlareonSprites21
+.4byte sFlareonSprites22
+.4byte sFlareonSprites23
+.4byte sFlareonSprites24
+.4byte sFlareonSprites25
+.4byte sFlareonSprites26
+.4byte sFlareonSprites27
+.4byte sFlareonSprites28
+.4byte sFlareonSprites29
+.4byte sFlareonSprites30
+.4byte sFlareonSprites31
+.4byte sFlareonSprites32
+.4byte sFlareonSprites33
+.4byte sFlareonSprites34
+.4byte sFlareonSprites35
+.4byte sFlareonSprites36
+.4byte sFlareonSprites37
+sAxMainFlareon:
+ax_main sAxPosesFlareon, sAxAnimationsFlareon, 13, sAxSpritesFlareon, sAxPositionsFlareon

--- a/data/ax/flygon.inc
+++ b/data/ax/flygon.inc
@@ -1,0 +1,3193 @@
+.global gAxFlygon
+gAxFlygon:
+ax_siro sAxMainFlygon
+sFlygonPose1:
+ax_pose 0, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose2:
+ax_pose 1, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose3:
+ax_pose 2, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose4:
+ax_pose 3, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose5:
+ax_pose 4, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose6:
+ax_pose 5, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose7:
+ax_pose 6, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose8:
+ax_pose 7, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose9:
+ax_pose 8, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose10:
+ax_pose 9, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose11:
+ax_pose 10, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose12:
+ax_pose 11, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose13:
+ax_pose 12, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose14:
+ax_pose 13, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose15:
+ax_pose 14, 0x81de, 0x80f0, 0x3c00
+ax_pose 15, 0x81de, 0x4100, 0x3c08
+ax_pose 16, 0x81ee, 0x0108, 0x3c0c
+ax_pose 17, 0x01fe, 0x00f8, 0x3c0e
+ax_pose_terminator
+sFlygonPose16:
+ax_pose 9, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose17:
+ax_pose 10, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose18:
+ax_pose 11, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose19:
+ax_pose 6, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose20:
+ax_pose 7, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose21:
+ax_pose 8, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose22:
+ax_pose 3, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose23:
+ax_pose 4, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose24:
+ax_pose 5, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose25:
+ax_pose 0, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose26:
+ax_pose 1, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose27:
+ax_pose 2, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose28:
+ax_pose 18, 0x81df, 0x8100, 0x3c00
+ax_pose 19, 0x81df, 0x40f8, 0x3c08
+ax_pose 20, 0x81e7, 0x00f0, 0x3c0c
+ax_pose 21, 0x01d7, 0x00fc, 0x3c0e
+ax_pose_terminator
+sFlygonPose29:
+ax_pose 22, 0x81e0, 0x8100, 0x3c00
+ax_pose 23, 0x81e0, 0x40f8, 0x3c08
+ax_pose 24, 0x81e8, 0x00f0, 0x3c0c
+ax_pose 25, 0x01d8, 0x00fc, 0x3c0e
+ax_pose_terminator
+sFlygonPose30:
+ax_pose 3, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose31:
+ax_pose 4, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose32:
+ax_pose 5, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose33:
+ax_pose 26, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose34:
+ax_pose 27, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose35:
+ax_pose 6, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose36:
+ax_pose 7, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose37:
+ax_pose 8, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose38:
+ax_pose 28, 0x41e7, 0x90f0, 0x3c00
+ax_pose 29, 0x41f7, 0x50f0, 0x3c08
+ax_pose 30, 0x41f3, 0x10e0, 0x3c0c
+ax_pose 31, 0x01fb, 0x10e0, 0x3c0e
+ax_pose_terminator
+sFlygonPose39:
+ax_pose 32, 0x41e7, 0x90f0, 0x3c00
+ax_pose 33, 0x41f7, 0x50f0, 0x3c08
+ax_pose 34, 0x41f3, 0x10e0, 0x3c0c
+ax_pose 35, 0x01fb, 0x10e0, 0x3c0e
+ax_pose_terminator
+sFlygonPose40:
+ax_pose 9, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose41:
+ax_pose 10, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose42:
+ax_pose 11, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose43:
+ax_pose 36, 0x81df, 0x9100, 0x3c00
+ax_pose 37, 0x01e7, 0x50f0, 0x3c08
+ax_pose 38, 0x41f7, 0x10f0, 0x3c0c
+ax_pose 39, 0x01ff, 0x10f0, 0x3c0e
+ax_pose 40, 0x01fe, 0x10e8, 0x3c0f
+ax_pose_terminator
+sFlygonPose44:
+ax_pose 41, 0x81df, 0x9100, 0x3c00
+ax_pose 42, 0x01e7, 0x50f0, 0x3c08
+ax_pose 43, 0x41f7, 0x10f0, 0x3c0c
+ax_pose 44, 0x01ff, 0x10f0, 0x3c0e
+ax_pose 45, 0x01fe, 0x10e8, 0x3c0f
+ax_pose_terminator
+sFlygonPose45:
+ax_pose 12, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose46:
+ax_pose 13, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose47:
+ax_pose 14, 0x81df, 0x80f0, 0x3c00
+ax_pose 15, 0x81df, 0x4100, 0x3c08
+ax_pose 16, 0x81ef, 0x0108, 0x3c0c
+ax_pose 17, 0x01ff, 0x00f8, 0x3c0e
+ax_pose_terminator
+sFlygonPose48:
+ax_pose 46, 0x81e3, 0x80f8, 0x3c00
+ax_pose 47, 0x81eb, 0x00f0, 0x3c08
+ax_pose 48, 0x81eb, 0x0108, 0x3c0a
+ax_pose 49, 0x0203, 0x00f8, 0x3c0c
+ax_pose 50, 0x0203, 0x0100, 0x3c0d
+ax_pose 51, 0x020b, 0x00fe, 0x3c0e
+ax_pose_terminator
+sFlygonPose49:
+ax_pose 52, 0x81e3, 0x80f8, 0x3c00
+ax_pose 53, 0x81eb, 0x00f0, 0x3c08
+ax_pose 54, 0x81eb, 0x0108, 0x3c0a
+ax_pose 55, 0x0203, 0x00f8, 0x3c0c
+ax_pose 56, 0x0203, 0x0100, 0x3c0d
+ax_pose 57, 0x020b, 0x00fe, 0x3c0e
+ax_pose_terminator
+sFlygonPose50:
+ax_pose 9, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose51:
+ax_pose 10, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose52:
+ax_pose 11, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose53:
+ax_pose 36, 0x81df, 0x80f0, 0x3c00
+ax_pose 37, 0x01e7, 0x4100, 0x3c08
+ax_pose 38, 0x41f7, 0x0100, 0x3c0c
+ax_pose 39, 0x01ff, 0x0108, 0x3c0e
+ax_pose 40, 0x01fe, 0x0110, 0x3c0f
+ax_pose_terminator
+sFlygonPose54:
+ax_pose 41, 0x81df, 0x80f0, 0x3c00
+ax_pose 42, 0x01e7, 0x4100, 0x3c08
+ax_pose 43, 0x41f7, 0x0100, 0x3c0c
+ax_pose 44, 0x01ff, 0x0108, 0x3c0e
+ax_pose 45, 0x01fe, 0x0110, 0x3c0f
+ax_pose_terminator
+sFlygonPose55:
+ax_pose 6, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose56:
+ax_pose 7, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose57:
+ax_pose 8, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose58:
+ax_pose 28, 0x41e7, 0x80f0, 0x3c00
+ax_pose 29, 0x41f7, 0x40f0, 0x3c08
+ax_pose 30, 0x41f3, 0x0110, 0x3c0c
+ax_pose 31, 0x01fb, 0x0118, 0x3c0e
+ax_pose_terminator
+sFlygonPose59:
+ax_pose 32, 0x41e7, 0x80f0, 0x3c00
+ax_pose 33, 0x41f7, 0x40f0, 0x3c08
+ax_pose 34, 0x41f3, 0x0110, 0x3c0c
+ax_pose 35, 0x01fb, 0x0118, 0x3c0e
+ax_pose_terminator
+sFlygonPose60:
+ax_pose 3, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose61:
+ax_pose 4, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose62:
+ax_pose 5, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose63:
+ax_pose 26, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose64:
+ax_pose 27, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose65:
+ax_pose 0, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose66:
+ax_pose 1, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose67:
+ax_pose 2, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose68:
+ax_pose 18, 0x81df, 0x8100, 0x3c00
+ax_pose 19, 0x81df, 0x40f8, 0x3c08
+ax_pose 20, 0x81e7, 0x00f0, 0x3c0c
+ax_pose 21, 0x01d7, 0x00fc, 0x3c0e
+ax_pose_terminator
+sFlygonPose69:
+ax_pose 22, 0x81e0, 0x8100, 0x3c00
+ax_pose 23, 0x81e0, 0x40f8, 0x3c08
+ax_pose 24, 0x81e8, 0x00f0, 0x3c0c
+ax_pose 25, 0x01d8, 0x00fc, 0x3c0e
+ax_pose_terminator
+sFlygonPose70:
+ax_pose 3, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose71:
+ax_pose 4, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose72:
+ax_pose 5, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose73:
+ax_pose 26, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose74:
+ax_pose 27, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose75:
+ax_pose 6, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose76:
+ax_pose 7, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose77:
+ax_pose 8, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose78:
+ax_pose 28, 0x41e7, 0x90f0, 0x3c00
+ax_pose 29, 0x41f7, 0x50f0, 0x3c08
+ax_pose 30, 0x41f3, 0x10e0, 0x3c0c
+ax_pose 31, 0x01fb, 0x10e0, 0x3c0e
+ax_pose_terminator
+sFlygonPose79:
+ax_pose 32, 0x41e7, 0x90f0, 0x3c00
+ax_pose 33, 0x41f7, 0x50f0, 0x3c08
+ax_pose 34, 0x41f3, 0x10e0, 0x3c0c
+ax_pose 35, 0x01fb, 0x10e0, 0x3c0e
+ax_pose_terminator
+sFlygonPose80:
+ax_pose 9, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose81:
+ax_pose 10, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose82:
+ax_pose 11, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose83:
+ax_pose 36, 0x81df, 0x9100, 0x3c00
+ax_pose 37, 0x01e7, 0x50f0, 0x3c08
+ax_pose 38, 0x41f7, 0x10f0, 0x3c0c
+ax_pose 39, 0x01ff, 0x10f0, 0x3c0e
+ax_pose 40, 0x01fe, 0x10e8, 0x3c0f
+ax_pose_terminator
+sFlygonPose84:
+ax_pose 41, 0x81df, 0x9100, 0x3c00
+ax_pose 42, 0x01e7, 0x50f0, 0x3c08
+ax_pose 43, 0x41f7, 0x10f0, 0x3c0c
+ax_pose 44, 0x01ff, 0x10f0, 0x3c0e
+ax_pose 45, 0x01fe, 0x10e8, 0x3c0f
+ax_pose_terminator
+sFlygonPose85:
+ax_pose 12, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose86:
+ax_pose 13, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose87:
+ax_pose 14, 0x81df, 0x80f0, 0x3c00
+ax_pose 15, 0x81df, 0x4100, 0x3c08
+ax_pose 16, 0x81ef, 0x0108, 0x3c0c
+ax_pose 17, 0x01ff, 0x00f8, 0x3c0e
+ax_pose_terminator
+sFlygonPose88:
+ax_pose 46, 0x81e3, 0x80f8, 0x3c00
+ax_pose 47, 0x81eb, 0x00f0, 0x3c08
+ax_pose 48, 0x81eb, 0x0108, 0x3c0a
+ax_pose 49, 0x0203, 0x00f8, 0x3c0c
+ax_pose 50, 0x0203, 0x0100, 0x3c0d
+ax_pose 51, 0x020b, 0x00fe, 0x3c0e
+ax_pose_terminator
+sFlygonPose89:
+ax_pose 52, 0x81e3, 0x80f8, 0x3c00
+ax_pose 53, 0x81eb, 0x00f0, 0x3c08
+ax_pose 54, 0x81eb, 0x0108, 0x3c0a
+ax_pose 55, 0x0203, 0x00f8, 0x3c0c
+ax_pose 56, 0x0203, 0x0100, 0x3c0d
+ax_pose 57, 0x020b, 0x00fe, 0x3c0e
+ax_pose_terminator
+sFlygonPose90:
+ax_pose 9, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose91:
+ax_pose 10, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose92:
+ax_pose 11, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose93:
+ax_pose 36, 0x81df, 0x80f0, 0x3c00
+ax_pose 37, 0x01e7, 0x4100, 0x3c08
+ax_pose 38, 0x41f7, 0x0100, 0x3c0c
+ax_pose 39, 0x01ff, 0x0108, 0x3c0e
+ax_pose 40, 0x01fe, 0x0110, 0x3c0f
+ax_pose_terminator
+sFlygonPose94:
+ax_pose 41, 0x81df, 0x80f0, 0x3c00
+ax_pose 42, 0x01e7, 0x4100, 0x3c08
+ax_pose 43, 0x41f7, 0x0100, 0x3c0c
+ax_pose 44, 0x01ff, 0x0108, 0x3c0e
+ax_pose 45, 0x01fe, 0x0110, 0x3c0f
+ax_pose_terminator
+sFlygonPose95:
+ax_pose 6, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose96:
+ax_pose 7, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose97:
+ax_pose 8, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose98:
+ax_pose 28, 0x41e7, 0x80f0, 0x3c00
+ax_pose 29, 0x41f7, 0x40f0, 0x3c08
+ax_pose 30, 0x41f3, 0x0110, 0x3c0c
+ax_pose 31, 0x01fb, 0x0118, 0x3c0e
+ax_pose_terminator
+sFlygonPose99:
+ax_pose 32, 0x41e7, 0x80f0, 0x3c00
+ax_pose 33, 0x41f7, 0x40f0, 0x3c08
+ax_pose 34, 0x41f3, 0x0110, 0x3c0c
+ax_pose 35, 0x01fb, 0x0118, 0x3c0e
+ax_pose_terminator
+sFlygonPose100:
+ax_pose 3, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose101:
+ax_pose 4, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose102:
+ax_pose 5, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose103:
+ax_pose 26, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose104:
+ax_pose 27, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose105:
+ax_pose 0, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose106:
+ax_pose 1, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose107:
+ax_pose 2, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose108:
+ax_pose 58, 0x01dd, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose109:
+ax_pose 59, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose110:
+ax_pose 3, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose111:
+ax_pose 4, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose112:
+ax_pose 5, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose113:
+ax_pose 60, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose114:
+ax_pose 61, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose115:
+ax_pose 6, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose116:
+ax_pose 7, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose117:
+ax_pose 8, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose118:
+ax_pose 62, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose119:
+ax_pose 63, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose120:
+ax_pose 9, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose121:
+ax_pose 10, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose122:
+ax_pose 11, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose123:
+ax_pose 64, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose124:
+ax_pose 65, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose125:
+ax_pose 12, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose126:
+ax_pose 13, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose127:
+ax_pose 14, 0x81de, 0x80f0, 0x3c00
+ax_pose 15, 0x81de, 0x4100, 0x3c08
+ax_pose 16, 0x81ee, 0x0108, 0x3c0c
+ax_pose 17, 0x01fe, 0x00f8, 0x3c0e
+ax_pose_terminator
+sFlygonPose128:
+ax_pose 66, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose129:
+ax_pose 67, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose130:
+ax_pose 9, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose131:
+ax_pose 10, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose132:
+ax_pose 11, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose133:
+ax_pose 64, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose134:
+ax_pose 65, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose135:
+ax_pose 6, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose136:
+ax_pose 7, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose137:
+ax_pose 8, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose138:
+ax_pose 62, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose139:
+ax_pose 63, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose140:
+ax_pose 3, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose141:
+ax_pose 4, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose142:
+ax_pose 5, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose143:
+ax_pose 60, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose144:
+ax_pose 61, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose145:
+ax_pose 58, 0x01dd, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose146:
+ax_pose 59, 0x01dd, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose147:
+ax_pose 60, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose148:
+ax_pose 61, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose149:
+ax_pose 62, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose150:
+ax_pose 63, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose151:
+ax_pose 64, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose152:
+ax_pose 65, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose153:
+ax_pose 66, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose154:
+ax_pose 67, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose155:
+ax_pose 64, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose156:
+ax_pose 65, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose157:
+ax_pose 62, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose158:
+ax_pose 63, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose159:
+ax_pose 60, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose160:
+ax_pose 61, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose161:
+ax_pose 68, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose162:
+ax_pose 69, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose163:
+ax_pose 70, 0x01dd, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose164:
+ax_pose 71, 0x01dd, 0x90ee, 0x3c00
+ax_pose_terminator
+sFlygonPose165:
+ax_pose 72, 0x01de, 0x90ec, 0x3c00
+ax_pose_terminator
+sFlygonPose166:
+ax_pose 73, 0x01dd, 0x90eb, 0x3c00
+ax_pose_terminator
+sFlygonPose167:
+ax_pose 74, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose168:
+ax_pose 73, 0x01dd, 0x80f5, 0x3c00
+ax_pose_terminator
+sFlygonPose169:
+ax_pose 72, 0x01de, 0x80f4, 0x3c00
+ax_pose_terminator
+sFlygonPose170:
+ax_pose 71, 0x01dd, 0x80f2, 0x3c00
+ax_pose_terminator
+sFlygonPose171:
+ax_pose 0, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose172:
+ax_pose 1, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose173:
+ax_pose 2, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose174:
+ax_pose 3, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose175:
+ax_pose 4, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose176:
+ax_pose 5, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose177:
+ax_pose 6, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose178:
+ax_pose 7, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose179:
+ax_pose 8, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose180:
+ax_pose 9, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose181:
+ax_pose 10, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose182:
+ax_pose 11, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose183:
+ax_pose 12, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose184:
+ax_pose 13, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose185:
+ax_pose 14, 0x81de, 0x80f0, 0x3c00
+ax_pose 15, 0x81de, 0x4100, 0x3c08
+ax_pose 16, 0x81ee, 0x0108, 0x3c0c
+ax_pose 17, 0x01fe, 0x00f8, 0x3c0e
+ax_pose_terminator
+sFlygonPose186:
+ax_pose 9, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose187:
+ax_pose 10, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose188:
+ax_pose 11, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose189:
+ax_pose 6, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose190:
+ax_pose 7, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose191:
+ax_pose 8, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose192:
+ax_pose 3, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose193:
+ax_pose 4, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose194:
+ax_pose 5, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose195:
+ax_pose 58, 0x01dd, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose196:
+ax_pose 60, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose197:
+ax_pose 62, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose198:
+ax_pose 64, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose199:
+ax_pose 66, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose200:
+ax_pose 64, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose201:
+ax_pose 62, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose202:
+ax_pose 60, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose203:
+ax_pose 58, 0x01dd, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose204:
+ax_pose 60, 0x01df, 0x90ee, 0x3c00
+ax_pose_terminator
+sFlygonPose205:
+ax_pose 62, 0x01df, 0x90ef, 0x3c00
+ax_pose_terminator
+sFlygonPose206:
+ax_pose 64, 0x01df, 0x90ed, 0x3c00
+ax_pose_terminator
+sFlygonPose207:
+ax_pose 66, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose208:
+ax_pose 64, 0x01df, 0x80f3, 0x3c00
+ax_pose_terminator
+sFlygonPose209:
+ax_pose 62, 0x01df, 0x80f1, 0x3c00
+ax_pose_terminator
+sFlygonPose210:
+ax_pose 60, 0x01df, 0x80f2, 0x3c00
+ax_pose_terminator
+sFlygonPose211:
+ax_pose 0, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose212:
+ax_pose 2, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose213:
+ax_pose 1, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose214:
+ax_pose 3, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose215:
+ax_pose 5, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose216:
+ax_pose 4, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose217:
+ax_pose 6, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose218:
+ax_pose 8, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose219:
+ax_pose 7, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose220:
+ax_pose 9, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose221:
+ax_pose 11, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose222:
+ax_pose 10, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose223:
+ax_pose 12, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose224:
+ax_pose 14, 0x81df, 0x80f0, 0x3c00
+ax_pose 15, 0x81df, 0x4100, 0x3c08
+ax_pose 16, 0x81ef, 0x0108, 0x3c0c
+ax_pose 17, 0x01ff, 0x00f8, 0x3c0e
+ax_pose_terminator
+sFlygonPose225:
+ax_pose 13, 0x01de, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose226:
+ax_pose 9, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose227:
+ax_pose 11, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose228:
+ax_pose 10, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose229:
+ax_pose 6, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose230:
+ax_pose 8, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose231:
+ax_pose 7, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose232:
+ax_pose 3, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose233:
+ax_pose 5, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose234:
+ax_pose 4, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose235:
+ax_pose 1, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose236:
+ax_pose 4, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose237:
+ax_pose 7, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose238:
+ax_pose 10, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose239:
+ax_pose 13, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose240:
+ax_pose 10, 0x01e2, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose241:
+ax_pose 7, 0x01e2, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose242:
+ax_pose 4, 0x01e2, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose243:
+ax_pose 0, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose244:
+ax_pose 3, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose245:
+ax_pose 6, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose246:
+ax_pose 9, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose247:
+ax_pose 12, 0x01df, 0x80f0, 0x3c00
+ax_pose_terminator
+sFlygonPose248:
+ax_pose 9, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose249:
+ax_pose 6, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+sFlygonPose250:
+ax_pose 3, 0x01df, 0x90f0, 0x3c00
+ax_pose_terminator
+.align 2
+sFlygonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -3, 0, -3,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 6, 0, 24, 0, -5, 0, -5,
+ax_anim 1, 2, 27, 0, 5, 0, 5,
+ax_anim 2, 0, 27, 0, 11, 0, 11,
+ax_anim 2, 1, 28, 0, 22, 0, 22,
+ax_anim 2, 0, 28, 1, 22, 1, 22,
+ax_anim 2, 0, 28, 0, 22, 0, 22,
+ax_anim 2, 0, 28, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 13, 0, 13,
+ax_anim_terminator
+sFlygonAnims_2_2:
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 2, 0, 31, -3, -3, -3, -3,
+ax_anim 2, 0, 30, -4, -4, -4, -4,
+ax_anim 6, 0, 29, -5, -5, -5, -5,
+ax_anim 1, 2, 32, 5, 8, 5, 8,
+ax_anim 2, 0, 32, 11, 16, 11, 16,
+ax_anim 2, 1, 33, 15, 23, 15, 21,
+ax_anim 2, 0, 33, 16, 22, 16, 20,
+ax_anim 2, 0, 33, 15, 23, 15, 21,
+ax_anim 2, 0, 33, 16, 22, 16, 20,
+ax_anim 2, 0, 29, 9, 13, 9, 13,
+ax_anim_terminator
+sFlygonAnims_2_3:
+ax_anim 2, 0, 35, -2, 0, -2, 0,
+ax_anim 2, 0, 36, -3, 0, -3, 0,
+ax_anim 2, 0, 35, -4, 0, -4, 0,
+ax_anim 6, 0, 34, -5, 0, -5, 0,
+ax_anim 1, 2, 37, 5, 0, 5, 0,
+ax_anim 2, 0, 37, 11, 1, 11, 0,
+ax_anim 2, 1, 38, 16, 2, 16, 0,
+ax_anim 2, 0, 38, 16, 3, 16, 1,
+ax_anim 2, 0, 38, 16, 2, 16, 0,
+ax_anim 2, 0, 38, 16, 3, 16, 1,
+ax_anim 2, 0, 34, 9, 0, 9, 0,
+ax_anim_terminator
+sFlygonAnims_2_4:
+ax_anim 2, 0, 40, -2, 2, -2, 2,
+ax_anim 2, 0, 41, -3, 3, -3, 3,
+ax_anim 2, 0, 40, -4, 4, -4, 4,
+ax_anim 6, 0, 39, -5, 5, -5, 5,
+ax_anim 1, 2, 42, 5, -4, 7, -7,
+ax_anim 2, 0, 42, 11, -8, 13, -13,
+ax_anim 2, 1, 43, 15, -11, 18, -18,
+ax_anim 2, 0, 43, 16, -10, 19, -17,
+ax_anim 2, 0, 43, 15, -11, 18, -18,
+ax_anim 2, 0, 43, 16, -10, 19, -17,
+ax_anim 2, 0, 39, 9, -6, 9, -6,
+ax_anim_terminator
+sFlygonAnims_2_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 2, 0, 46, 0, 3, 0, 3,
+ax_anim 2, 0, 45, 0, 4, 0, 4,
+ax_anim 6, 0, 44, 0, 5, 0, 5,
+ax_anim 1, 2, 47, 0, -2, 0, -2,
+ax_anim 2, 0, 47, 0, -8, 0, -11,
+ax_anim 2, 1, 48, 0, -13, 0, -20,
+ax_anim 2, 0, 48, 1, -13, 1, -20,
+ax_anim 2, 0, 48, 0, -13, 0, -20,
+ax_anim 2, 0, 48, 1, -13, 1, -20,
+ax_anim 2, 0, 44, 0, -6, 0, -10,
+ax_anim_terminator
+sFlygonAnims_2_6:
+ax_anim 2, 0, 50, 2, 2, 2, 2,
+ax_anim 2, 0, 51, 3, 3, 3, 3,
+ax_anim 2, 0, 50, 4, 4, 4, 4,
+ax_anim 6, 0, 49, 5, 5, 5, 5,
+ax_anim 1, 2, 52, -5, -4, -7, -7,
+ax_anim 2, 0, 52, -11, -8, -13, -13,
+ax_anim 2, 1, 53, -15, -11, -18, -18,
+ax_anim 2, 0, 53, -16, -10, -19, -17,
+ax_anim 2, 0, 53, -15, -11, -18, -18,
+ax_anim 2, 0, 53, -16, -10, -19, -17,
+ax_anim 2, 0, 49, -9, -6, -9, -6,
+ax_anim_terminator
+sFlygonAnims_2_7:
+ax_anim 2, 0, 55, 2, 0, 2, 0,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim 2, 0, 55, 4, 0, 4, 0,
+ax_anim 6, 0, 54, 5, 0, 5, 0,
+ax_anim 1, 2, 57, -5, 0, -5, 0,
+ax_anim 2, 0, 57, -11, 1, -11, 0,
+ax_anim 2, 1, 58, -16, 2, -16, 0,
+ax_anim 2, 0, 58, -16, 3, -16, 1,
+ax_anim 2, 0, 58, -16, 2, -16, 0,
+ax_anim 2, 0, 58, -16, 3, -16, 1,
+ax_anim 2, 0, 54, -9, 0, -9, 0,
+ax_anim_terminator
+sFlygonAnims_2_8:
+ax_anim 2, 0, 60, 2, -2, 2, -2,
+ax_anim 2, 0, 61, 3, -3, 3, -3,
+ax_anim 2, 0, 60, 4, -4, 4, -4,
+ax_anim 6, 0, 59, 5, -5, 5, -5,
+ax_anim 1, 2, 62, -5, 8, -5, 8,
+ax_anim 2, 0, 62, -11, 16, -11, 16,
+ax_anim 2, 1, 63, -15, 23, -15, 21,
+ax_anim 2, 0, 63, -16, 22, -16, 20,
+ax_anim 2, 0, 63, -15, 23, -15, 21,
+ax_anim 2, 0, 63, -16, 22, -16, 20,
+ax_anim 2, 0, 59, -9, 13, -9, 13,
+ax_anim_terminator
+.align 2
+sFlygonAnims_3_1:
+ax_anim 2, 0, 65, 0, -2, 0, -2,
+ax_anim 2, 0, 66, 0, -3, 0, -3,
+ax_anim 2, 0, 65, 0, -4, 0, -4,
+ax_anim 6, 0, 64, 0, -5, 0, -5,
+ax_anim 1, 2, 67, 0, 5, 0, 5,
+ax_anim 2, 0, 67, 0, 11, 0, 11,
+ax_anim 2, 1, 68, 0, 22, 0, 22,
+ax_anim 2, 0, 68, 1, 22, 1, 22,
+ax_anim 2, 0, 68, 0, 22, 0, 22,
+ax_anim 2, 0, 68, 1, 22, 1, 22,
+ax_anim 2, 0, 64, 0, 13, 0, 13,
+ax_anim_terminator
+sFlygonAnims_3_2:
+ax_anim 2, 0, 70, -2, -2, -2, -2,
+ax_anim 2, 0, 71, -3, -3, -3, -3,
+ax_anim 2, 0, 70, -4, -4, -4, -4,
+ax_anim 6, 0, 69, -5, -5, -5, -5,
+ax_anim 1, 2, 72, 5, 8, 5, 8,
+ax_anim 2, 0, 72, 11, 16, 11, 16,
+ax_anim 2, 1, 73, 15, 23, 15, 21,
+ax_anim 2, 0, 73, 16, 22, 16, 20,
+ax_anim 2, 0, 73, 15, 23, 15, 21,
+ax_anim 2, 0, 73, 16, 22, 16, 20,
+ax_anim 2, 0, 69, 9, 13, 9, 13,
+ax_anim_terminator
+sFlygonAnims_3_3:
+ax_anim 2, 0, 75, -2, 0, -2, 0,
+ax_anim 2, 0, 76, -3, 0, -3, 0,
+ax_anim 2, 0, 75, -4, 0, -4, 0,
+ax_anim 6, 0, 74, -5, 0, -5, 0,
+ax_anim 1, 2, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 11, 1, 11, 0,
+ax_anim 2, 1, 78, 16, 2, 16, 0,
+ax_anim 2, 0, 78, 16, 3, 16, 1,
+ax_anim 2, 0, 78, 16, 2, 16, 0,
+ax_anim 2, 0, 78, 16, 3, 16, 1,
+ax_anim 2, 0, 74, 9, 0, 9, 0,
+ax_anim_terminator
+sFlygonAnims_3_4:
+ax_anim 2, 0, 80, -2, 2, -2, 2,
+ax_anim 2, 0, 81, -3, 3, -3, 3,
+ax_anim 2, 0, 80, -4, 4, -4, 4,
+ax_anim 6, 0, 79, -5, 5, -5, 5,
+ax_anim 1, 2, 82, 5, -4, 7, -7,
+ax_anim 2, 0, 82, 11, -8, 13, -13,
+ax_anim 2, 1, 83, 15, -11, 18, -18,
+ax_anim 2, 0, 83, 16, -10, 19, -17,
+ax_anim 2, 0, 83, 15, -11, 18, -18,
+ax_anim 2, 0, 83, 16, -10, 19, -17,
+ax_anim 2, 0, 79, 9, -6, 9, -6,
+ax_anim_terminator
+sFlygonAnims_3_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 2, 0, 86, 0, 3, 0, 3,
+ax_anim 2, 0, 85, 0, 4, 0, 4,
+ax_anim 6, 0, 84, 0, 5, 0, 5,
+ax_anim 1, 2, 87, 0, -2, 0, -2,
+ax_anim 2, 0, 87, 0, -8, 0, -11,
+ax_anim 2, 1, 88, 0, -13, 0, -20,
+ax_anim 2, 0, 88, 1, -13, 1, -20,
+ax_anim 2, 0, 88, 0, -13, 0, -20,
+ax_anim 2, 0, 88, 1, -13, 1, -20,
+ax_anim 2, 0, 84, 0, -6, 0, -10,
+ax_anim_terminator
+sFlygonAnims_3_6:
+ax_anim 2, 0, 90, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 0, 90, 4, 4, 4, 4,
+ax_anim 6, 0, 89, 5, 5, 5, 5,
+ax_anim 1, 2, 92, -5, -4, -7, -7,
+ax_anim 2, 0, 92, -11, -8, -13, -13,
+ax_anim 2, 1, 93, -15, -11, -18, -18,
+ax_anim 2, 0, 93, -16, -10, -19, -17,
+ax_anim 2, 0, 93, -15, -11, -18, -18,
+ax_anim 2, 0, 93, -16, -10, -19, -17,
+ax_anim 2, 0, 89, -9, -6, -9, -6,
+ax_anim_terminator
+sFlygonAnims_3_7:
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 4, 0, 4, 0,
+ax_anim 6, 0, 94, 5, 0, 5, 0,
+ax_anim 1, 2, 97, -5, 0, -5, 0,
+ax_anim 2, 0, 97, -11, 1, -11, 0,
+ax_anim 2, 1, 98, -16, 2, -16, 0,
+ax_anim 2, 0, 98, -16, 3, -16, 1,
+ax_anim 2, 0, 98, -16, 2, -16, 0,
+ax_anim 2, 0, 98, -16, 3, -16, 1,
+ax_anim 2, 0, 94, -9, 0, -9, 0,
+ax_anim_terminator
+sFlygonAnims_3_8:
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 101, 3, -3, 3, -3,
+ax_anim 2, 0, 100, 4, -4, 4, -4,
+ax_anim 6, 0, 99, 5, -5, 5, -5,
+ax_anim 1, 2, 102, -5, 8, -5, 8,
+ax_anim 2, 0, 102, -11, 16, -11, 16,
+ax_anim 2, 1, 103, -15, 23, -15, 21,
+ax_anim 2, 0, 103, -16, 22, -16, 20,
+ax_anim 2, 0, 103, -15, 23, -15, 21,
+ax_anim 2, 0, 103, -16, 22, -16, 20,
+ax_anim 2, 0, 99, -9, 13, -9, 13,
+ax_anim_terminator
+.align 2
+sFlygonAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 0, 104, 0, -5, 0, -5,
+ax_anim 2, 2, 105, 0, -5, 0, -5,
+ax_anim 4, 0, 104, 0, -5, 0, -5,
+ax_anim 1, 0, 108, 0, -2, 0, -2,
+ax_anim 1, 0, 107, 0, 2, 0, 2,
+ax_anim 2, 1, 107, 0, 6, 0, 6,
+ax_anim 2, 0, 107, 1, 6, 1, 6,
+ax_anim 2, 0, 107, 0, 6, 0, 6,
+ax_anim 2, 0, 107, 1, 6, 1, 6,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim_terminator
+sFlygonAnims_4_2:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 110, -2, -2, -2, -2,
+ax_anim 2, 0, 109, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -4, -4, -4,
+ax_anim 2, 0, 109, -5, -5, -5, -5,
+ax_anim 2, 2, 110, -5, -5, -5, -5,
+ax_anim 4, 0, 109, -5, -5, -5, -5,
+ax_anim 1, 0, 113, -2, -2, -2, -2,
+ax_anim 1, 0, 112, 2, 2, 2, 2,
+ax_anim 2, 1, 112, 6, 6, 6, 6,
+ax_anim 2, 0, 112, 7, 5, 7, 5,
+ax_anim 2, 0, 112, 6, 6, 6, 6,
+ax_anim 2, 0, 112, 7, 5, 7, 5,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim_terminator
+sFlygonAnims_4_3:
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -3, 0, -3, 0,
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 2, 0, 114, -5, 0, -5, 0,
+ax_anim 2, 2, 115, -5, 0, -5, 0,
+ax_anim 4, 0, 114, -5, 0, -5, 0,
+ax_anim 1, 0, 118, -2, 0, -2, 0,
+ax_anim 1, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 1, 117, 6, 0, 6, 0,
+ax_anim 2, 0, 117, 6, 1, 6, 1,
+ax_anim 2, 0, 117, 6, 0, 6, 0,
+ax_anim 2, 0, 117, 6, 1, 6, 1,
+ax_anim 2, 0, 114, 3, 0, 3, 0,
+ax_anim_terminator
+sFlygonAnims_4_4:
+ax_anim 2, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 0, 120, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 121, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 2, 120, -5, 5, -5, 5,
+ax_anim 4, 0, 119, -5, 5, -5, 5,
+ax_anim 1, 0, 123, -2, 2, -2, 2,
+ax_anim 1, 0, 122, 2, -2, 2, -2,
+ax_anim 2, 1, 122, 6, -6, 6, -6,
+ax_anim 2, 0, 122, 7, -5, 7, -5,
+ax_anim 2, 0, 122, 6, -6, 6, -6,
+ax_anim 2, 0, 122, 7, -5, 7, -5,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim_terminator
+sFlygonAnims_4_5:
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 2, 0, 2,
+ax_anim 2, 0, 124, 0, 3, 0, 3,
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 2, 0, 124, 0, 5, 0, 5,
+ax_anim 2, 2, 125, 0, 5, 0, 5,
+ax_anim 4, 0, 124, 0, 5, 0, 5,
+ax_anim 1, 0, 128, 0, 2, 0, 2,
+ax_anim 1, 0, 127, 0, -2, 0, -2,
+ax_anim 2, 1, 127, 0, -6, 0, -6,
+ax_anim 2, 0, 127, 1, -6, 1, -6,
+ax_anim 2, 0, 127, 0, -6, 0, -6,
+ax_anim 2, 0, 127, 1, -6, 1, -6,
+ax_anim 2, 0, 124, 0, -3, 0, -3,
+ax_anim_terminator
+sFlygonAnims_4_6:
+ax_anim 2, 0, 129, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 2, 2, 2, 2,
+ax_anim 2, 0, 129, 3, 3, 3, 3,
+ax_anim 2, 0, 131, 4, 4, 4, 4,
+ax_anim 2, 0, 129, 5, 5, 5, 5,
+ax_anim 2, 2, 130, 5, 5, 5, 5,
+ax_anim 4, 0, 129, 5, 5, 5, 5,
+ax_anim 1, 0, 133, 2, 2, 2, 2,
+ax_anim 1, 0, 132, -2, -2, -2, -2,
+ax_anim 2, 1, 132, -6, -6, -6, -6,
+ax_anim 2, 0, 132, -7, -5, -7, -5,
+ax_anim 2, 0, 132, -6, -6, -6, -6,
+ax_anim 2, 0, 132, -7, -5, -7, -5,
+ax_anim 2, 0, 129, -3, -3, -3, -3,
+ax_anim_terminator
+sFlygonAnims_4_7:
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim 2, 0, 134, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 2, 0, 134, 5, 0, 5, 0,
+ax_anim 2, 2, 135, 5, 0, 5, 0,
+ax_anim 4, 0, 134, 5, 0, 5, 0,
+ax_anim 1, 0, 138, 2, 0, 2, 0,
+ax_anim 1, 0, 137, -2, 0, -2, 0,
+ax_anim 2, 1, 137, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -6, 1, -6, 1,
+ax_anim 2, 0, 137, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -6, 1, -6, 1,
+ax_anim 2, 0, 134, -3, 0, -3, 0,
+ax_anim_terminator
+sFlygonAnims_4_8:
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 140, 2, -2, 2, -2,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 2, 0, 141, 4, -4, 4, -4,
+ax_anim 2, 0, 139, 5, -5, 5, -5,
+ax_anim 2, 2, 140, 5, -5, 5, -5,
+ax_anim 4, 0, 139, 5, -5, 5, -5,
+ax_anim 1, 0, 143, 2, -2, 2, -2,
+ax_anim 1, 0, 142, -2, 2, -2, 2,
+ax_anim 2, 1, 142, -6, 6, -6, 6,
+ax_anim 2, 0, 142, -7, 5, -7, 5,
+ax_anim 2, 0, 142, -6, 6, -6, 6,
+ax_anim 2, 0, 142, -7, 5, -7, 5,
+ax_anim 2, 0, 139, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sFlygonAnims_5_1:
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 1, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_5_2:
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 1, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_5_3:
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 1, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_5_4:
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 1, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_5_5:
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 1, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_5_6:
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 1, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_5_7:
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 1, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_5_8:
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 1, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_6_1:
+ax_anim 16, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, -1, 0, 0,
+ax_anim 16, 0, 160, 0, -2, 0, 0,
+ax_anim 16, 0, 161, 0, -2, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sFlygonAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sFlygonAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sFlygonAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sFlygonAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sFlygonAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sFlygonAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sFlygonAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sFlygonAnims_8_1:
+ax_anim 8, 0, 171, 0, -2, 0, 0,
+ax_anim 9, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, -1, 0, 0,
+ax_anim 11, 0, 172, 0, -2, 0, 0,
+ax_anim 8, 0, 170, 0, -4, 0, 0,
+ax_anim 8, 0, 171, 0, -4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_8_2:
+ax_anim 8, 0, 174, 0, -2, 0, 0,
+ax_anim 9, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, -1, 0, 0,
+ax_anim 11, 0, 175, 0, -2, 0, 0,
+ax_anim 8, 0, 173, 0, -4, 0, 0,
+ax_anim 8, 0, 174, 0, -4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_8_3:
+ax_anim 8, 0, 177, 0, -2, 0, 0,
+ax_anim 9, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 178, 0, -1, 0, 0,
+ax_anim 11, 0, 178, 0, -2, 0, 0,
+ax_anim 8, 0, 176, 0, -4, 0, 0,
+ax_anim 8, 0, 177, 0, -4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_8_4:
+ax_anim 8, 0, 180, 0, -2, 0, 0,
+ax_anim 9, 0, 179, 0, 0, 0, 0,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 181, 0, -1, 0, 0,
+ax_anim 11, 0, 181, 0, -2, 0, 0,
+ax_anim 8, 0, 179, 0, -4, 0, 0,
+ax_anim 8, 0, 180, 0, -4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_8_5:
+ax_anim 8, 0, 183, 0, -2, 0, 0,
+ax_anim 9, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, -1, 0, 0,
+ax_anim 11, 0, 184, 0, -2, 0, 0,
+ax_anim 8, 0, 182, 0, -4, 0, 0,
+ax_anim 8, 0, 183, 0, -4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_8_6:
+ax_anim 8, 0, 186, 0, -2, 0, 0,
+ax_anim 9, 0, 185, 0, 0, 0, 0,
+ax_anim 8, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 187, 0, -1, 0, 0,
+ax_anim 11, 0, 187, 0, -2, 0, 0,
+ax_anim 8, 0, 185, 0, -4, 0, 0,
+ax_anim 8, 0, 186, 0, -4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_8_7:
+ax_anim 8, 0, 189, 0, -2, 0, 0,
+ax_anim 9, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim 8, 0, 190, 0, -1, 0, 0,
+ax_anim 11, 0, 190, 0, -2, 0, 0,
+ax_anim 8, 0, 188, 0, -4, 0, 0,
+ax_anim 8, 0, 189, 0, -4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_8_8:
+ax_anim 8, 0, 192, 0, -2, 0, 0,
+ax_anim 9, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 193, 0, -1, 0, 0,
+ax_anim 11, 0, 193, 0, -2, 0, 0,
+ax_anim 8, 0, 191, 0, -4, 0, 0,
+ax_anim 8, 0, 192, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 9, 13, 9, 13,
+ax_anim 2, 0, 197, 7, 23, 7, 21,
+ax_anim 3, 0, 198, 0, 25, 0, 22,
+ax_anim 2, 3, 199, -7, 23, -7, 21,
+ax_anim 2, 0, 200, -9, 13, -9, 13,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 2, 8, 2,
+ax_anim 2, 0, 195, 19, 10, 19, 10,
+ax_anim 2, 0, 196, 20, 20, 20, 18,
+ax_anim 3, 0, 197, 17, 26, 17, 23,
+ax_anim 2, 3, 198, 10, 25, 10, 23,
+ax_anim 2, 0, 199, 4, 18, 4, 18,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 4, -3, 4, -3,
+ax_anim 2, 0, 194, 11, -3, 11, -3,
+ax_anim 2, 0, 195, 15, -1, 15, -2,
+ax_anim 3, 0, 196, 17, 3, 17, 0,
+ax_anim 2, 3, 197, 15, 8, 15, 7,
+ax_anim 2, 0, 198, 9, 10, 9, 10,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 1, -8, 1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 12, -20, 12, -22,
+ax_anim 3, 0, 195, 18, -18, 18, -21,
+ax_anim 2, 3, 196, 20, -12, 20, -14,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -7, -4, -7, -4,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -18, -7, -20,
+ax_anim 3, 0, 194, 0, -19, 0, -23,
+ax_anim 2, 3, 195, 7, -18, 7, -20,
+ax_anim 2, 0, 196, 9, -12, 9, -12,
+ax_anim 1, 0, 197, 7, -4, 7, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -12, -20, -12, -22,
+ax_anim 3, 0, 201, -18, -18, -18, -21,
+ax_anim 2, 3, 200, -20, -12, -20, -14,
+ax_anim 2, 0, 199, -17, -4, -17, -4,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -4, -3, -4, -3,
+ax_anim 2, 0, 194, -11, -3, -11, -3,
+ax_anim 2, 0, 201, -15, -1, -15, -2,
+ax_anim 3, 0, 200, -17, 3, -17, 0,
+ax_anim 2, 3, 199, -15, 8, -15, 7,
+ax_anim 2, 0, 198, -9, 10, -9, 10,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 2, -8, 2,
+ax_anim 2, 0, 201, -19, 10, -19, 10,
+ax_anim 2, 0, 200, -20, 20, -20, 18,
+ax_anim 3, 0, 199, -17, 26, -17, 23,
+ax_anim 2, 3, 198, -10, 25, -10, 23,
+ax_anim 2, 0, 197, -4, 18, -4, 18,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -19, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 3, 0, 0,
+ax_anim_terminator
+sFlygonAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 3, 0, 0,
+ax_anim_terminator
+sFlygonAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 3, 0, 0,
+ax_anim_terminator
+sFlygonAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 3, 0, 0,
+ax_anim_terminator
+sFlygonAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 4, 0, 0,
+ax_anim_terminator
+sFlygonAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 3, 0, 0,
+ax_anim_terminator
+sFlygonAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 3, 0, 0,
+ax_anim_terminator
+sFlygonAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFlygonAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sFlygonGfx1:
+.incbin "baserom.gba", 0x1377534, 0x200
+sFlygonSprites1:
+ax_sprite sFlygonGfx1, 0x200
+ax_sprite_terminator
+sFlygonGfx2:
+.incbin "baserom.gba", 0x1377744, 0x200
+sFlygonSprites2:
+ax_sprite sFlygonGfx2, 0x200
+ax_sprite_terminator
+sFlygonGfx3:
+.incbin "baserom.gba", 0x1377954, 0x200
+sFlygonSprites3:
+ax_sprite sFlygonGfx3, 0x200
+ax_sprite_terminator
+sFlygonGfx4:
+.incbin "baserom.gba", 0x1377B64, 0x200
+sFlygonSprites4:
+ax_sprite sFlygonGfx4, 0x200
+ax_sprite_terminator
+sFlygonGfx5:
+.incbin "baserom.gba", 0x1377D74, 0x200
+sFlygonSprites5:
+ax_sprite sFlygonGfx5, 0x200
+ax_sprite_terminator
+sFlygonGfx6:
+.incbin "baserom.gba", 0x1377F84, 0x200
+sFlygonSprites6:
+ax_sprite sFlygonGfx6, 0x200
+ax_sprite_terminator
+sFlygonGfx7:
+.incbin "baserom.gba", 0x1378194, 0x200
+sFlygonSprites7:
+ax_sprite sFlygonGfx7, 0x200
+ax_sprite_terminator
+sFlygonGfx8:
+.incbin "baserom.gba", 0x13783A4, 0x200
+sFlygonSprites8:
+ax_sprite sFlygonGfx8, 0x200
+ax_sprite_terminator
+sFlygonGfx9:
+.incbin "baserom.gba", 0x13785B4, 0x200
+sFlygonSprites9:
+ax_sprite sFlygonGfx9, 0x200
+ax_sprite_terminator
+sFlygonGfx10:
+.incbin "baserom.gba", 0x13787C4, 0x200
+sFlygonSprites10:
+ax_sprite sFlygonGfx10, 0x200
+ax_sprite_terminator
+sFlygonGfx11:
+.incbin "baserom.gba", 0x13789D4, 0x200
+sFlygonSprites11:
+ax_sprite sFlygonGfx11, 0x200
+ax_sprite_terminator
+sFlygonGfx12:
+.incbin "baserom.gba", 0x1378BE4, 0x200
+sFlygonSprites12:
+ax_sprite sFlygonGfx12, 0x200
+ax_sprite_terminator
+sFlygonGfx13:
+.incbin "baserom.gba", 0x1378DF4, 0x200
+sFlygonSprites13:
+ax_sprite sFlygonGfx13, 0x200
+ax_sprite_terminator
+sFlygonGfx14:
+.incbin "baserom.gba", 0x1379004, 0x200
+sFlygonSprites14:
+ax_sprite sFlygonGfx14, 0x200
+ax_sprite_terminator
+sFlygonGfx15:
+.incbin "baserom.gba", 0x1379214, 0x100
+sFlygonSprites15:
+ax_sprite sFlygonGfx15, 0x100
+ax_sprite_terminator
+sFlygonGfx16:
+.incbin "baserom.gba", 0x1379324, 0x80
+sFlygonSprites16:
+ax_sprite sFlygonGfx16, 0x80
+ax_sprite_terminator
+sFlygonGfx17:
+.incbin "baserom.gba", 0x13793B4, 0x40
+sFlygonSprites17:
+ax_sprite sFlygonGfx17, 0x40
+ax_sprite_terminator
+sFlygonGfx18:
+.incbin "baserom.gba", 0x1379404, 0x20
+sFlygonSprites18:
+ax_sprite sFlygonGfx18, 0x20
+ax_sprite_terminator
+sFlygonGfx19:
+.incbin "baserom.gba", 0x1379434, 0x20
+sFlygonGfx19_1:
+.incbin "baserom.gba", 0x1379454, 0xA0
+sFlygonSprites19:
+ax_sprite sFlygonGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx19_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlygonGfx20:
+.incbin "baserom.gba", 0x137951C, 0x80
+sFlygonSprites20:
+ax_sprite sFlygonGfx20, 0x80
+ax_sprite_terminator
+sFlygonGfx21:
+.incbin "baserom.gba", 0x13795AC, 0x40
+sFlygonSprites21:
+ax_sprite sFlygonGfx21, 0x40
+ax_sprite_terminator
+sFlygonGfx22:
+.incbin "baserom.gba", 0x13795FC, 0x20
+sFlygonSprites22:
+ax_sprite sFlygonGfx22, 0x20
+ax_sprite_terminator
+sFlygonGfx23:
+.incbin "baserom.gba", 0x137962C, 0x20
+sFlygonGfx23_1:
+.incbin "baserom.gba", 0x137964C, 0xA0
+sFlygonSprites23:
+ax_sprite sFlygonGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx23_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlygonGfx24:
+.incbin "baserom.gba", 0x1379714, 0x80
+sFlygonSprites24:
+ax_sprite sFlygonGfx24, 0x80
+ax_sprite_terminator
+sFlygonGfx25:
+.incbin "baserom.gba", 0x13797A4, 0x40
+sFlygonSprites25:
+ax_sprite sFlygonGfx25, 0x40
+ax_sprite_terminator
+sFlygonGfx26:
+.incbin "baserom.gba", 0x13797F4, 0x20
+sFlygonSprites26:
+ax_sprite sFlygonGfx26, 0x20
+ax_sprite_terminator
+sFlygonGfx27:
+.incbin "baserom.gba", 0x1379824, 0x160
+sFlygonSprites27:
+ax_sprite 0, 0x80
+ax_sprite sFlygonGfx27, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlygonGfx28:
+.incbin "baserom.gba", 0x13799A4, 0x160
+sFlygonSprites28:
+ax_sprite 0, 0x80
+ax_sprite sFlygonGfx28, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlygonGfx29:
+.incbin "baserom.gba", 0x1379B24, 0x100
+sFlygonSprites29:
+ax_sprite sFlygonGfx29, 0x100
+ax_sprite_terminator
+sFlygonGfx30:
+.incbin "baserom.gba", 0x1379C34, 0x60
+sFlygonSprites30:
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx30, 0x60
+ax_sprite_terminator
+sFlygonGfx31:
+.incbin "baserom.gba", 0x1379CAC, 0x40
+sFlygonSprites31:
+ax_sprite sFlygonGfx31, 0x40
+ax_sprite_terminator
+sFlygonGfx32:
+.incbin "baserom.gba", 0x1379CFC, 0x20
+sFlygonSprites32:
+ax_sprite sFlygonGfx32, 0x20
+ax_sprite_terminator
+sFlygonGfx33:
+.incbin "baserom.gba", 0x1379D2C, 0x100
+sFlygonSprites33:
+ax_sprite sFlygonGfx33, 0x100
+ax_sprite_terminator
+sFlygonGfx34:
+.incbin "baserom.gba", 0x1379E3C, 0x60
+sFlygonSprites34:
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx34, 0x60
+ax_sprite_terminator
+sFlygonGfx35:
+.incbin "baserom.gba", 0x1379EB4, 0x40
+sFlygonSprites35:
+ax_sprite sFlygonGfx35, 0x40
+ax_sprite_terminator
+sFlygonGfx36:
+.incbin "baserom.gba", 0x1379F04, 0x20
+sFlygonSprites36:
+ax_sprite sFlygonGfx36, 0x20
+ax_sprite_terminator
+sFlygonGfx37:
+.incbin "baserom.gba", 0x1379F34, 0x100
+sFlygonSprites37:
+ax_sprite sFlygonGfx37, 0x100
+ax_sprite_terminator
+sFlygonGfx38:
+.incbin "baserom.gba", 0x137A044, 0x60
+sFlygonSprites38:
+ax_sprite sFlygonGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlygonGfx39:
+.incbin "baserom.gba", 0x137A0BC, 0x40
+sFlygonSprites39:
+ax_sprite sFlygonGfx39, 0x40
+ax_sprite_terminator
+sFlygonGfx40:
+.incbin "baserom.gba", 0x137A10C, 0x20
+sFlygonSprites40:
+ax_sprite sFlygonGfx40, 0x20
+ax_sprite_terminator
+sFlygonGfx41:
+.incbin "baserom.gba", 0x137A13C, 0x20
+sFlygonSprites41:
+ax_sprite sFlygonGfx41, 0x20
+ax_sprite_terminator
+sFlygonGfx42:
+.incbin "baserom.gba", 0x137A16C, 0x100
+sFlygonSprites42:
+ax_sprite sFlygonGfx42, 0x100
+ax_sprite_terminator
+sFlygonGfx43:
+.incbin "baserom.gba", 0x137A27C, 0x60
+sFlygonSprites43:
+ax_sprite sFlygonGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlygonGfx44:
+.incbin "baserom.gba", 0x137A2F4, 0x40
+sFlygonSprites44:
+ax_sprite sFlygonGfx44, 0x40
+ax_sprite_terminator
+sFlygonGfx45:
+.incbin "baserom.gba", 0x137A344, 0x20
+sFlygonSprites45:
+ax_sprite sFlygonGfx45, 0x20
+ax_sprite_terminator
+sFlygonGfx46:
+.incbin "baserom.gba", 0x137A374, 0x20
+sFlygonSprites46:
+ax_sprite sFlygonGfx46, 0x20
+ax_sprite_terminator
+sFlygonGfx47:
+.incbin "baserom.gba", 0x137A3A4, 0x100
+sFlygonSprites47:
+ax_sprite sFlygonGfx47, 0x100
+ax_sprite_terminator
+sFlygonGfx48:
+.incbin "baserom.gba", 0x137A4B4, 0x40
+sFlygonSprites48:
+ax_sprite sFlygonGfx48, 0x40
+ax_sprite_terminator
+sFlygonGfx49:
+.incbin "baserom.gba", 0x137A504, 0x40
+sFlygonSprites49:
+ax_sprite sFlygonGfx49, 0x40
+ax_sprite_terminator
+sFlygonGfx50:
+.incbin "baserom.gba", 0x137A554, 0x20
+sFlygonSprites50:
+ax_sprite sFlygonGfx50, 0x20
+ax_sprite_terminator
+sFlygonGfx51:
+.incbin "baserom.gba", 0x137A584, 0x20
+sFlygonSprites51:
+ax_sprite sFlygonGfx51, 0x20
+ax_sprite_terminator
+sFlygonGfx52:
+.incbin "baserom.gba", 0x137A5B4, 0x20
+sFlygonSprites52:
+ax_sprite sFlygonGfx52, 0x20
+ax_sprite_terminator
+sFlygonGfx53:
+.incbin "baserom.gba", 0x137A5E4, 0x100
+sFlygonSprites53:
+ax_sprite sFlygonGfx53, 0x100
+ax_sprite_terminator
+sFlygonGfx54:
+.incbin "baserom.gba", 0x137A6F4, 0x40
+sFlygonSprites54:
+ax_sprite sFlygonGfx54, 0x40
+ax_sprite_terminator
+sFlygonGfx55:
+.incbin "baserom.gba", 0x137A744, 0x40
+sFlygonSprites55:
+ax_sprite sFlygonGfx55, 0x40
+ax_sprite_terminator
+sFlygonGfx56:
+.incbin "baserom.gba", 0x137A794, 0x20
+sFlygonSprites56:
+ax_sprite sFlygonGfx56, 0x20
+ax_sprite_terminator
+sFlygonGfx57:
+.incbin "baserom.gba", 0x137A7C4, 0x20
+sFlygonSprites57:
+ax_sprite sFlygonGfx57, 0x20
+ax_sprite_terminator
+sFlygonGfx58:
+.incbin "baserom.gba", 0x137A7F4, 0x20
+sFlygonSprites58:
+ax_sprite sFlygonGfx58, 0x20
+ax_sprite_terminator
+sFlygonGfx59:
+.incbin "baserom.gba", 0x137A824, 0x140
+sFlygonGfx59_1:
+.incbin "baserom.gba", 0x137A964, 0x60
+sFlygonSprites59:
+ax_sprite 0, 0x40
+ax_sprite sFlygonGfx59, 0x140
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx59_1, 0x60
+ax_sprite_terminator
+sFlygonGfx60:
+.incbin "baserom.gba", 0x137A9EC, 0x40
+sFlygonGfx60_1:
+.incbin "baserom.gba", 0x137AA2C, 0x160
+sFlygonSprites60:
+ax_sprite 0, 0x40
+ax_sprite sFlygonGfx60, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx60_1, 0x160
+ax_sprite_terminator
+sFlygonGfx61:
+.incbin "baserom.gba", 0x137ABB4, 0x180
+sFlygonGfx61_1:
+.incbin "baserom.gba", 0x137AD34, 0x60
+sFlygonSprites61:
+ax_sprite sFlygonGfx61, 0x180
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx61_1, 0x60
+ax_sprite_terminator
+sFlygonGfx62:
+.incbin "baserom.gba", 0x137ADB4, 0x1E0
+sFlygonSprites62:
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx62, 0x1e0
+ax_sprite_terminator
+sFlygonGfx63:
+.incbin "baserom.gba", 0x137AFAC, 0x1C0
+sFlygonSprites63:
+ax_sprite 0, 0x40
+ax_sprite sFlygonGfx63, 0x1c0
+ax_sprite_terminator
+sFlygonGfx64:
+.incbin "baserom.gba", 0x137B184, 0x1E0
+sFlygonSprites64:
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx64, 0x1e0
+ax_sprite_terminator
+sFlygonGfx65:
+.incbin "baserom.gba", 0x137B37C, 0x160
+sFlygonGfx65_1:
+.incbin "baserom.gba", 0x137B4DC, 0x60
+sFlygonSprites65:
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx65, 0x160
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx65_1, 0x60
+ax_sprite_terminator
+sFlygonGfx66:
+.incbin "baserom.gba", 0x137B564, 0x200
+sFlygonSprites66:
+ax_sprite sFlygonGfx66, 0x200
+ax_sprite_terminator
+sFlygonGfx67:
+.incbin "baserom.gba", 0x137B774, 0x40
+sFlygonGfx67_1:
+.incbin "baserom.gba", 0x137B7B4, 0x100
+sFlygonGfx67_2:
+.incbin "baserom.gba", 0x137B8B4, 0x40
+sFlygonSprites67:
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx67, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx67_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx67_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFlygonGfx68:
+.incbin "baserom.gba", 0x137B934, 0x40
+sFlygonGfx68_1:
+.incbin "baserom.gba", 0x137B974, 0x40
+sFlygonGfx68_2:
+.incbin "baserom.gba", 0x137B9B4, 0x100
+sFlygonSprites68:
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx68, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFlygonGfx68_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFlygonGfx68_2, 0x100
+ax_sprite_terminator
+sFlygonGfx69:
+.incbin "baserom.gba", 0x137BAEC, 0x200
+sFlygonSprites69:
+ax_sprite sFlygonGfx69, 0x200
+ax_sprite_terminator
+sFlygonGfx70:
+.incbin "baserom.gba", 0x137BCFC, 0x200
+sFlygonSprites70:
+ax_sprite sFlygonGfx70, 0x200
+ax_sprite_terminator
+sFlygonGfx71:
+.incbin "baserom.gba", 0x137BF0C, 0x200
+sFlygonSprites71:
+ax_sprite sFlygonGfx71, 0x200
+ax_sprite_terminator
+sFlygonGfx72:
+.incbin "baserom.gba", 0x137C11C, 0x200
+sFlygonSprites72:
+ax_sprite sFlygonGfx72, 0x200
+ax_sprite_terminator
+sFlygonGfx73:
+.incbin "baserom.gba", 0x137C32C, 0x200
+sFlygonSprites73:
+ax_sprite sFlygonGfx73, 0x200
+ax_sprite_terminator
+sFlygonGfx74:
+.incbin "baserom.gba", 0x137C53C, 0x200
+sFlygonSprites74:
+ax_sprite sFlygonGfx74, 0x200
+ax_sprite_terminator
+sFlygonGfx75:
+.incbin "baserom.gba", 0x137C74C, 0x200
+sFlygonSprites75:
+ax_sprite sFlygonGfx75, 0x200
+ax_sprite_terminator
+sAxPosesFlygon:
+.4byte sFlygonPose1
+.4byte sFlygonPose2
+.4byte sFlygonPose3
+.4byte sFlygonPose4
+.4byte sFlygonPose5
+.4byte sFlygonPose6
+.4byte sFlygonPose7
+.4byte sFlygonPose8
+.4byte sFlygonPose9
+.4byte sFlygonPose10
+.4byte sFlygonPose11
+.4byte sFlygonPose12
+.4byte sFlygonPose13
+.4byte sFlygonPose14
+.4byte sFlygonPose15
+.4byte sFlygonPose16
+.4byte sFlygonPose17
+.4byte sFlygonPose18
+.4byte sFlygonPose19
+.4byte sFlygonPose20
+.4byte sFlygonPose21
+.4byte sFlygonPose22
+.4byte sFlygonPose23
+.4byte sFlygonPose24
+.4byte sFlygonPose25
+.4byte sFlygonPose26
+.4byte sFlygonPose27
+.4byte sFlygonPose28
+.4byte sFlygonPose29
+.4byte sFlygonPose30
+.4byte sFlygonPose31
+.4byte sFlygonPose32
+.4byte sFlygonPose33
+.4byte sFlygonPose34
+.4byte sFlygonPose35
+.4byte sFlygonPose36
+.4byte sFlygonPose37
+.4byte sFlygonPose38
+.4byte sFlygonPose39
+.4byte sFlygonPose40
+.4byte sFlygonPose41
+.4byte sFlygonPose42
+.4byte sFlygonPose43
+.4byte sFlygonPose44
+.4byte sFlygonPose45
+.4byte sFlygonPose46
+.4byte sFlygonPose47
+.4byte sFlygonPose48
+.4byte sFlygonPose49
+.4byte sFlygonPose50
+.4byte sFlygonPose51
+.4byte sFlygonPose52
+.4byte sFlygonPose53
+.4byte sFlygonPose54
+.4byte sFlygonPose55
+.4byte sFlygonPose56
+.4byte sFlygonPose57
+.4byte sFlygonPose58
+.4byte sFlygonPose59
+.4byte sFlygonPose60
+.4byte sFlygonPose61
+.4byte sFlygonPose62
+.4byte sFlygonPose63
+.4byte sFlygonPose64
+.4byte sFlygonPose65
+.4byte sFlygonPose66
+.4byte sFlygonPose67
+.4byte sFlygonPose68
+.4byte sFlygonPose69
+.4byte sFlygonPose70
+.4byte sFlygonPose71
+.4byte sFlygonPose72
+.4byte sFlygonPose73
+.4byte sFlygonPose74
+.4byte sFlygonPose75
+.4byte sFlygonPose76
+.4byte sFlygonPose77
+.4byte sFlygonPose78
+.4byte sFlygonPose79
+.4byte sFlygonPose80
+.4byte sFlygonPose81
+.4byte sFlygonPose82
+.4byte sFlygonPose83
+.4byte sFlygonPose84
+.4byte sFlygonPose85
+.4byte sFlygonPose86
+.4byte sFlygonPose87
+.4byte sFlygonPose88
+.4byte sFlygonPose89
+.4byte sFlygonPose90
+.4byte sFlygonPose91
+.4byte sFlygonPose92
+.4byte sFlygonPose93
+.4byte sFlygonPose94
+.4byte sFlygonPose95
+.4byte sFlygonPose96
+.4byte sFlygonPose97
+.4byte sFlygonPose98
+.4byte sFlygonPose99
+.4byte sFlygonPose100
+.4byte sFlygonPose101
+.4byte sFlygonPose102
+.4byte sFlygonPose103
+.4byte sFlygonPose104
+.4byte sFlygonPose105
+.4byte sFlygonPose106
+.4byte sFlygonPose107
+.4byte sFlygonPose108
+.4byte sFlygonPose109
+.4byte sFlygonPose110
+.4byte sFlygonPose111
+.4byte sFlygonPose112
+.4byte sFlygonPose113
+.4byte sFlygonPose114
+.4byte sFlygonPose115
+.4byte sFlygonPose116
+.4byte sFlygonPose117
+.4byte sFlygonPose118
+.4byte sFlygonPose119
+.4byte sFlygonPose120
+.4byte sFlygonPose121
+.4byte sFlygonPose122
+.4byte sFlygonPose123
+.4byte sFlygonPose124
+.4byte sFlygonPose125
+.4byte sFlygonPose126
+.4byte sFlygonPose127
+.4byte sFlygonPose128
+.4byte sFlygonPose129
+.4byte sFlygonPose130
+.4byte sFlygonPose131
+.4byte sFlygonPose132
+.4byte sFlygonPose133
+.4byte sFlygonPose134
+.4byte sFlygonPose135
+.4byte sFlygonPose136
+.4byte sFlygonPose137
+.4byte sFlygonPose138
+.4byte sFlygonPose139
+.4byte sFlygonPose140
+.4byte sFlygonPose141
+.4byte sFlygonPose142
+.4byte sFlygonPose143
+.4byte sFlygonPose144
+.4byte sFlygonPose145
+.4byte sFlygonPose146
+.4byte sFlygonPose147
+.4byte sFlygonPose148
+.4byte sFlygonPose149
+.4byte sFlygonPose150
+.4byte sFlygonPose151
+.4byte sFlygonPose152
+.4byte sFlygonPose153
+.4byte sFlygonPose154
+.4byte sFlygonPose155
+.4byte sFlygonPose156
+.4byte sFlygonPose157
+.4byte sFlygonPose158
+.4byte sFlygonPose159
+.4byte sFlygonPose160
+.4byte sFlygonPose161
+.4byte sFlygonPose162
+.4byte sFlygonPose163
+.4byte sFlygonPose164
+.4byte sFlygonPose165
+.4byte sFlygonPose166
+.4byte sFlygonPose167
+.4byte sFlygonPose168
+.4byte sFlygonPose169
+.4byte sFlygonPose170
+.4byte sFlygonPose171
+.4byte sFlygonPose172
+.4byte sFlygonPose173
+.4byte sFlygonPose174
+.4byte sFlygonPose175
+.4byte sFlygonPose176
+.4byte sFlygonPose177
+.4byte sFlygonPose178
+.4byte sFlygonPose179
+.4byte sFlygonPose180
+.4byte sFlygonPose181
+.4byte sFlygonPose182
+.4byte sFlygonPose183
+.4byte sFlygonPose184
+.4byte sFlygonPose185
+.4byte sFlygonPose186
+.4byte sFlygonPose187
+.4byte sFlygonPose188
+.4byte sFlygonPose189
+.4byte sFlygonPose190
+.4byte sFlygonPose191
+.4byte sFlygonPose192
+.4byte sFlygonPose193
+.4byte sFlygonPose194
+.4byte sFlygonPose195
+.4byte sFlygonPose196
+.4byte sFlygonPose197
+.4byte sFlygonPose198
+.4byte sFlygonPose199
+.4byte sFlygonPose200
+.4byte sFlygonPose201
+.4byte sFlygonPose202
+.4byte sFlygonPose203
+.4byte sFlygonPose204
+.4byte sFlygonPose205
+.4byte sFlygonPose206
+.4byte sFlygonPose207
+.4byte sFlygonPose208
+.4byte sFlygonPose209
+.4byte sFlygonPose210
+.4byte sFlygonPose211
+.4byte sFlygonPose212
+.4byte sFlygonPose213
+.4byte sFlygonPose214
+.4byte sFlygonPose215
+.4byte sFlygonPose216
+.4byte sFlygonPose217
+.4byte sFlygonPose218
+.4byte sFlygonPose219
+.4byte sFlygonPose220
+.4byte sFlygonPose221
+.4byte sFlygonPose222
+.4byte sFlygonPose223
+.4byte sFlygonPose224
+.4byte sFlygonPose225
+.4byte sFlygonPose226
+.4byte sFlygonPose227
+.4byte sFlygonPose228
+.4byte sFlygonPose229
+.4byte sFlygonPose230
+.4byte sFlygonPose231
+.4byte sFlygonPose232
+.4byte sFlygonPose233
+.4byte sFlygonPose234
+.4byte sFlygonPose235
+.4byte sFlygonPose236
+.4byte sFlygonPose237
+.4byte sFlygonPose238
+.4byte sFlygonPose239
+.4byte sFlygonPose240
+.4byte sFlygonPose241
+.4byte sFlygonPose242
+.4byte sFlygonPose243
+.4byte sFlygonPose244
+.4byte sFlygonPose245
+.4byte sFlygonPose246
+.4byte sFlygonPose247
+.4byte sFlygonPose248
+.4byte sFlygonPose249
+.4byte sFlygonPose250
+sAxPositionsFlygon:
+.2byte   -1,  -17, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -15, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,  -19, 	  -4,  -12, 	   2,  -12, 	  -1,  -14
+.2byte    7,  -19, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    8,  -17, 	   7,  -12, 	   4,  -10, 	   0,  -12
+.2byte    6,  -21, 	   7,  -14, 	   4,  -12, 	   1,  -14
+.2byte   10,  -20, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   11,  -18, 	   8,  -13, 	   7,  -11, 	   1,  -14
+.2byte    9,  -22, 	   8,  -15, 	   7,  -13, 	   1,  -15
+.2byte    6,  -22, 	   2,  -18, 	  10,  -15, 	   1,  -15
+.2byte    7,  -19, 	   3,  -16, 	   9,  -14, 	   1,  -14
+.2byte    5,  -24, 	   1,  -17, 	   6,  -15, 	   1,  -14
+.2byte    0,  -24, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -23, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -26, 	   2,  -17, 	  -3,  -17, 	  -1,  -16
+.2byte   -7,  -22, 	  -3,  -18, 	 -11,  -15, 	  -2,  -15
+.2byte   -8,  -19, 	  -4,  -16, 	 -10,  -14, 	  -2,  -14
+.2byte   -6,  -24, 	  -2,  -17, 	  -7,  -15, 	  -2,  -14
+.2byte  -11,  -20, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -12,  -18, 	  -9,  -13, 	  -8,  -11, 	  -2,  -14
+.2byte  -10,  -22, 	  -9,  -15, 	  -8,  -13, 	  -2,  -15
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -9,  -17, 	  -8,  -12, 	  -5,  -10, 	  -1,  -12
+.2byte   -7,  -21, 	  -8,  -14, 	  -5,  -12, 	  -2,  -14
+.2byte   -1,  -17, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -16, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -18, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   3,  -10, 	  -1,  -15
+.2byte   -1,   -2, 	  -6,  -10, 	   3,  -10, 	  -1,  -14
+.2byte    7,  -19, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    8,  -18, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    6,  -20, 	   7,  -13, 	   4,  -11, 	   1,  -13
+.2byte   12,   -6, 	   7,  -10, 	   2,   -6, 	   3,  -13
+.2byte   12,   -4, 	   8,   -9, 	   2,   -6, 	   4,  -12
+.2byte   10,  -20, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   11,  -19, 	   8,  -14, 	   7,  -12, 	   1,  -15
+.2byte    9,  -21, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   13,  -12, 	   4,   -7, 	   1,   -6, 	  -1,  -12
+.2byte   13,  -11, 	   4,   -7, 	   1,   -6, 	   0,  -13
+.2byte    6,  -22, 	   2,  -18, 	  10,  -15, 	   1,  -15
+.2byte    7,  -20, 	   3,  -17, 	   9,  -15, 	   1,  -15
+.2byte    5,  -23, 	   1,  -16, 	   6,  -14, 	   1,  -13
+.2byte   11,  -24, 	   2,  -20, 	   7,  -17, 	   2,  -17
+.2byte   11,  -23, 	   1,  -20, 	   6,  -17, 	   2,  -17
+.2byte    0,  -24, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -24, 	   2,  -17, 	  -2,  -17, 	  -1,  -15
+.2byte   -1,  -25, 	   2,  -16, 	  -3,  -16, 	  -1,  -15
+.2byte   -1,  -23, 	   3,  -17, 	  -4,  -17, 	  -1,  -14
+.2byte   -1,  -23, 	   3,  -17, 	  -4,  -17, 	  -1,  -14
+.2byte   -7,  -22, 	  -3,  -18, 	 -11,  -15, 	  -2,  -15
+.2byte   -8,  -20, 	  -4,  -17, 	 -10,  -15, 	  -2,  -15
+.2byte   -6,  -23, 	  -2,  -16, 	  -7,  -14, 	  -2,  -13
+.2byte  -12,  -24, 	  -3,  -20, 	  -8,  -17, 	  -3,  -17
+.2byte  -12,  -23, 	  -2,  -20, 	  -7,  -17, 	  -3,  -17
+.2byte  -11,  -20, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -12,  -19, 	  -9,  -14, 	  -8,  -12, 	  -2,  -15
+.2byte  -10,  -21, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -14,  -12, 	  -5,   -7, 	  -2,   -6, 	   0,  -12
+.2byte  -14,  -11, 	  -5,   -7, 	  -2,   -6, 	  -1,  -13
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -9,  -18, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -7,  -20, 	  -8,  -13, 	  -5,  -11, 	  -2,  -13
+.2byte  -13,   -6, 	  -8,  -10, 	  -3,   -6, 	  -4,  -13
+.2byte  -13,   -4, 	  -9,   -9, 	  -3,   -6, 	  -5,  -12
+.2byte   -1,  -17, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -16, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -18, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,   -3, 	  -6,  -10, 	   3,  -10, 	  -1,  -15
+.2byte   -1,   -2, 	  -6,  -10, 	   3,  -10, 	  -1,  -14
+.2byte    7,  -19, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    8,  -18, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    6,  -20, 	   7,  -13, 	   4,  -11, 	   1,  -13
+.2byte   12,   -6, 	   7,  -10, 	   2,   -6, 	   3,  -13
+.2byte   12,   -4, 	   8,   -9, 	   2,   -6, 	   4,  -12
+.2byte   10,  -20, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   11,  -19, 	   8,  -14, 	   7,  -12, 	   1,  -15
+.2byte    9,  -21, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   13,  -12, 	   4,   -7, 	   1,   -6, 	  -1,  -12
+.2byte   13,  -11, 	   4,   -7, 	   1,   -6, 	   0,  -13
+.2byte    6,  -22, 	   2,  -18, 	  10,  -15, 	   1,  -15
+.2byte    7,  -20, 	   3,  -17, 	   9,  -15, 	   1,  -15
+.2byte    5,  -23, 	   1,  -16, 	   6,  -14, 	   1,  -13
+.2byte   11,  -24, 	   2,  -20, 	   7,  -17, 	   2,  -17
+.2byte   11,  -23, 	   1,  -20, 	   6,  -17, 	   2,  -17
+.2byte    0,  -24, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -24, 	   2,  -17, 	  -2,  -17, 	  -1,  -15
+.2byte   -1,  -25, 	   2,  -16, 	  -3,  -16, 	  -1,  -15
+.2byte   -1,  -23, 	   3,  -17, 	  -4,  -17, 	  -1,  -14
+.2byte   -1,  -23, 	   3,  -17, 	  -4,  -17, 	  -1,  -14
+.2byte   -7,  -22, 	  -3,  -18, 	 -11,  -15, 	  -2,  -15
+.2byte   -8,  -20, 	  -4,  -17, 	 -10,  -15, 	  -2,  -15
+.2byte   -6,  -23, 	  -2,  -16, 	  -7,  -14, 	  -2,  -13
+.2byte  -12,  -24, 	  -3,  -20, 	  -8,  -17, 	  -3,  -17
+.2byte  -12,  -23, 	  -2,  -20, 	  -7,  -17, 	  -3,  -17
+.2byte  -11,  -20, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -12,  -19, 	  -9,  -14, 	  -8,  -12, 	  -2,  -15
+.2byte  -10,  -21, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -14,  -12, 	  -5,   -7, 	  -2,   -6, 	   0,  -12
+.2byte  -14,  -11, 	  -5,   -7, 	  -2,   -6, 	  -1,  -13
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -9,  -18, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -7,  -20, 	  -8,  -13, 	  -5,  -11, 	  -2,  -13
+.2byte  -13,   -6, 	  -8,  -10, 	  -3,   -6, 	  -4,  -13
+.2byte  -13,   -4, 	  -9,   -9, 	  -3,   -6, 	  -5,  -12
+.2byte   -1,  -17, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -15, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,  -19, 	  -4,  -12, 	   2,  -12, 	  -1,  -14
+.2byte   -1,  -12, 	  -5,   -9, 	   3,   -9, 	  -1,  -10
+.2byte   -1,  -13, 	  -5,   -9, 	   3,   -9, 	  -1,  -10
+.2byte    7,  -19, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    8,  -17, 	   7,  -12, 	   4,  -10, 	   0,  -12
+.2byte    6,  -21, 	   7,  -14, 	   4,  -12, 	   1,  -14
+.2byte   10,  -13, 	   9,  -11, 	   2,   -9, 	   1,  -11
+.2byte    9,  -14, 	  10,  -11, 	   2,   -9, 	   2,  -11
+.2byte   10,  -20, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   11,  -18, 	   8,  -13, 	   7,  -11, 	   1,  -14
+.2byte    9,  -22, 	   8,  -15, 	   7,  -13, 	   1,  -15
+.2byte   13,  -14, 	   9,  -12, 	   7,   -9, 	   1,  -13
+.2byte   12,  -15, 	   9,  -12, 	   7,   -9, 	   1,  -12
+.2byte    6,  -22, 	   2,  -18, 	  10,  -15, 	   1,  -15
+.2byte    7,  -19, 	   3,  -16, 	   9,  -14, 	   1,  -14
+.2byte    5,  -24, 	   1,  -17, 	   6,  -15, 	   1,  -14
+.2byte   10,  -16, 	   6,  -16, 	  11,  -12, 	   2,  -14
+.2byte    9,  -16, 	   5,  -16, 	  11,  -12, 	   2,  -13
+.2byte    0,  -24, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -23, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -26, 	   2,  -17, 	  -3,  -17, 	  -1,  -16
+.2byte   -1,  -22, 	   3,  -17, 	  -4,  -17, 	   0,  -13
+.2byte   -1,  -21, 	   2,  -14, 	  -4,  -14, 	  -1,  -12
+.2byte   -7,  -22, 	  -3,  -18, 	 -11,  -15, 	  -2,  -15
+.2byte   -8,  -19, 	  -4,  -16, 	 -10,  -14, 	  -2,  -14
+.2byte   -6,  -24, 	  -2,  -17, 	  -7,  -15, 	  -2,  -14
+.2byte  -11,  -16, 	  -7,  -16, 	 -12,  -12, 	  -3,  -14
+.2byte  -10,  -16, 	  -6,  -16, 	 -12,  -12, 	  -3,  -13
+.2byte  -11,  -20, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -12,  -18, 	  -9,  -13, 	  -8,  -11, 	  -2,  -14
+.2byte  -10,  -22, 	  -9,  -15, 	  -8,  -13, 	  -2,  -15
+.2byte  -14,  -14, 	 -10,  -12, 	  -8,   -9, 	  -2,  -13
+.2byte  -13,  -15, 	 -10,  -12, 	  -8,   -9, 	  -2,  -12
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -9,  -17, 	  -8,  -12, 	  -5,  -10, 	  -1,  -12
+.2byte   -7,  -21, 	  -8,  -14, 	  -5,  -12, 	  -2,  -14
+.2byte  -11,  -13, 	 -10,  -11, 	  -3,   -9, 	  -2,  -11
+.2byte  -10,  -14, 	 -11,  -11, 	  -3,   -9, 	  -3,  -11
+.2byte   -1,  -12, 	  -5,   -9, 	   3,   -9, 	  -1,  -10
+.2byte   -1,  -14, 	  -5,  -10, 	   3,  -10, 	  -1,  -11
+.2byte   10,  -13, 	   9,  -11, 	   2,   -9, 	   1,  -11
+.2byte    9,  -15, 	  10,  -12, 	   2,  -10, 	   2,  -12
+.2byte   13,  -14, 	   9,  -12, 	   7,   -9, 	   1,  -13
+.2byte   12,  -16, 	   9,  -13, 	   7,  -10, 	   1,  -13
+.2byte   10,  -16, 	   6,  -16, 	  11,  -12, 	   2,  -14
+.2byte    9,  -17, 	   5,  -17, 	  11,  -13, 	   2,  -14
+.2byte   -1,  -22, 	   3,  -17, 	  -4,  -17, 	   0,  -13
+.2byte   -1,  -22, 	   2,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte  -11,  -16, 	  -7,  -16, 	 -12,  -12, 	  -3,  -14
+.2byte  -10,  -17, 	  -6,  -17, 	 -12,  -13, 	  -3,  -14
+.2byte  -14,  -14, 	 -10,  -12, 	  -8,   -9, 	  -2,  -13
+.2byte  -13,  -16, 	 -10,  -13, 	  -8,  -10, 	  -2,  -13
+.2byte  -11,  -13, 	 -10,  -11, 	  -3,   -9, 	  -2,  -11
+.2byte  -10,  -15, 	 -11,  -12, 	  -3,  -10, 	  -3,  -12
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -9,  -19, 	  -8,  -12, 	  -5,  -10, 	  -1,  -14
+.2byte   -1,  -22, 	  -5,  -21, 	   3,  -20, 	  -1,  -15
+.2byte    3,  -25, 	   7,  -23, 	   1,  -20, 	   2,  -14
+.2byte    5,  -24, 	   7,  -22, 	   4,  -19, 	   1,  -15
+.2byte    6,  -26, 	   3,  -23, 	   7,  -22, 	   0,  -17
+.2byte   -1,  -27, 	   6,  -23, 	  -7,  -23, 	  -1,  -15
+.2byte   -7,  -26, 	  -4,  -23, 	  -8,  -22, 	  -1,  -17
+.2byte   -6,  -24, 	  -8,  -22, 	  -5,  -19, 	  -2,  -15
+.2byte   -4,  -25, 	  -8,  -23, 	  -2,  -20, 	  -3,  -14
+.2byte   -1,  -17, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -15, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,  -19, 	  -4,  -12, 	   2,  -12, 	  -1,  -14
+.2byte    7,  -19, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    8,  -17, 	   7,  -12, 	   4,  -10, 	   0,  -12
+.2byte    6,  -21, 	   7,  -14, 	   4,  -12, 	   1,  -14
+.2byte   10,  -20, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   11,  -18, 	   8,  -13, 	   7,  -11, 	   1,  -14
+.2byte    9,  -22, 	   8,  -15, 	   7,  -13, 	   1,  -15
+.2byte    6,  -22, 	   2,  -18, 	  10,  -15, 	   1,  -15
+.2byte    7,  -19, 	   3,  -16, 	   9,  -14, 	   1,  -14
+.2byte    5,  -24, 	   1,  -17, 	   6,  -15, 	   1,  -14
+.2byte    0,  -24, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -23, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -26, 	   2,  -17, 	  -3,  -17, 	  -1,  -16
+.2byte   -7,  -22, 	  -3,  -18, 	 -11,  -15, 	  -2,  -15
+.2byte   -8,  -19, 	  -4,  -16, 	 -10,  -14, 	  -2,  -14
+.2byte   -6,  -24, 	  -2,  -17, 	  -7,  -15, 	  -2,  -14
+.2byte  -11,  -20, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -12,  -18, 	  -9,  -13, 	  -8,  -11, 	  -2,  -14
+.2byte  -10,  -22, 	  -9,  -15, 	  -8,  -13, 	  -2,  -15
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -9,  -17, 	  -8,  -12, 	  -5,  -10, 	  -1,  -12
+.2byte   -7,  -21, 	  -8,  -14, 	  -5,  -12, 	  -2,  -14
+.2byte   -1,  -12, 	  -5,   -9, 	   3,   -9, 	  -1,  -10
+.2byte  -11,  -13, 	 -10,  -11, 	  -3,   -9, 	  -2,  -11
+.2byte  -14,  -14, 	 -10,  -12, 	  -8,   -9, 	  -2,  -13
+.2byte  -11,  -16, 	  -7,  -16, 	 -12,  -12, 	  -3,  -14
+.2byte   -1,  -22, 	   3,  -17, 	  -4,  -17, 	   0,  -13
+.2byte   10,  -16, 	   6,  -16, 	  11,  -12, 	   2,  -14
+.2byte   13,  -14, 	   9,  -12, 	   7,   -9, 	   1,  -13
+.2byte   10,  -13, 	   9,  -11, 	   2,   -9, 	   1,  -11
+.2byte   -1,  -12, 	  -5,   -9, 	   3,   -9, 	  -1,  -10
+.2byte    8,  -13, 	   7,  -11, 	   0,   -9, 	  -1,  -11
+.2byte   12,  -14, 	   8,  -12, 	   6,   -9, 	   0,  -13
+.2byte    7,  -16, 	   3,  -16, 	   8,  -12, 	  -1,  -14
+.2byte   -1,  -22, 	   3,  -17, 	  -4,  -17, 	   0,  -13
+.2byte   -8,  -16, 	  -4,  -16, 	  -9,  -12, 	   0,  -14
+.2byte  -13,  -14, 	  -9,  -12, 	  -7,   -9, 	  -1,  -13
+.2byte   -9,  -13, 	  -8,  -11, 	  -1,   -9, 	   0,  -11
+.2byte   -1,  -17, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -18, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -1,  -16, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte    7,  -19, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte    6,  -20, 	   7,  -13, 	   4,  -11, 	   1,  -13
+.2byte    8,  -18, 	   7,  -13, 	   4,  -11, 	   0,  -13
+.2byte   10,  -20, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte    9,  -21, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte   11,  -19, 	   8,  -14, 	   7,  -12, 	   1,  -15
+.2byte    6,  -22, 	   2,  -18, 	  10,  -15, 	   1,  -15
+.2byte    5,  -23, 	   1,  -16, 	   6,  -14, 	   1,  -13
+.2byte    7,  -20, 	   3,  -17, 	   9,  -15, 	   1,  -15
+.2byte    0,  -24, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte   -1,  -25, 	   2,  -16, 	  -3,  -16, 	  -1,  -15
+.2byte   -1,  -24, 	   2,  -17, 	  -2,  -17, 	  -1,  -15
+.2byte   -7,  -22, 	  -3,  -18, 	 -11,  -15, 	  -2,  -15
+.2byte   -6,  -23, 	  -2,  -16, 	  -7,  -14, 	  -2,  -13
+.2byte   -8,  -20, 	  -4,  -17, 	 -10,  -15, 	  -2,  -15
+.2byte  -11,  -20, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -10,  -21, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte  -12,  -19, 	  -9,  -14, 	  -8,  -12, 	  -2,  -15
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -7,  -20, 	  -8,  -13, 	  -5,  -11, 	  -2,  -13
+.2byte   -9,  -18, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte   -1,  -14, 	  -4,   -9, 	   2,   -9, 	  -1,  -11
+.2byte   -9,  -15, 	  -8,  -10, 	  -5,   -8, 	  -1,  -10
+.2byte  -12,  -16, 	  -9,  -11, 	  -8,   -9, 	  -2,  -12
+.2byte   -8,  -17, 	  -4,  -14, 	 -10,  -12, 	  -2,  -12
+.2byte   -1,  -19, 	   2,  -12, 	  -2,  -12, 	  -1,  -10
+.2byte    7,  -17, 	   3,  -14, 	   9,  -12, 	   1,  -12
+.2byte   11,  -16, 	   8,  -11, 	   7,   -9, 	   1,  -12
+.2byte    8,  -15, 	   7,  -10, 	   4,   -8, 	   0,  -10
+.2byte   -1,  -17, 	  -4,  -11, 	   2,  -11, 	  -1,  -13
+.2byte   -8,  -19, 	  -8,  -13, 	  -5,  -11, 	  -1,  -13
+.2byte  -11,  -20, 	  -9,  -14, 	  -8,  -12, 	  -2,  -14
+.2byte   -7,  -22, 	  -3,  -18, 	 -11,  -15, 	  -2,  -15
+.2byte    0,  -24, 	   2,  -16, 	  -2,  -16, 	  -1,  -14
+.2byte    6,  -22, 	   2,  -18, 	  10,  -15, 	   1,  -15
+.2byte   10,  -20, 	   8,  -14, 	   7,  -12, 	   1,  -14
+.2byte    7,  -19, 	   7,  -13, 	   4,  -11, 	   0,  -13
+sFlygonAnimTable1:
+.4byte sFlygonAnims_1_1
+.4byte sFlygonAnims_1_2
+.4byte sFlygonAnims_1_3
+.4byte sFlygonAnims_1_4
+.4byte sFlygonAnims_1_5
+.4byte sFlygonAnims_1_6
+.4byte sFlygonAnims_1_7
+.4byte sFlygonAnims_1_8
+sFlygonAnimTable2:
+.4byte sFlygonAnims_2_1
+.4byte sFlygonAnims_2_2
+.4byte sFlygonAnims_2_3
+.4byte sFlygonAnims_2_4
+.4byte sFlygonAnims_2_5
+.4byte sFlygonAnims_2_6
+.4byte sFlygonAnims_2_7
+.4byte sFlygonAnims_2_8
+sFlygonAnimTable3:
+.4byte sFlygonAnims_3_1
+.4byte sFlygonAnims_3_2
+.4byte sFlygonAnims_3_3
+.4byte sFlygonAnims_3_4
+.4byte sFlygonAnims_3_5
+.4byte sFlygonAnims_3_6
+.4byte sFlygonAnims_3_7
+.4byte sFlygonAnims_3_8
+sFlygonAnimTable4:
+.4byte sFlygonAnims_4_1
+.4byte sFlygonAnims_4_2
+.4byte sFlygonAnims_4_3
+.4byte sFlygonAnims_4_4
+.4byte sFlygonAnims_4_5
+.4byte sFlygonAnims_4_6
+.4byte sFlygonAnims_4_7
+.4byte sFlygonAnims_4_8
+sFlygonAnimTable5:
+.4byte sFlygonAnims_5_1
+.4byte sFlygonAnims_5_2
+.4byte sFlygonAnims_5_3
+.4byte sFlygonAnims_5_4
+.4byte sFlygonAnims_5_5
+.4byte sFlygonAnims_5_6
+.4byte sFlygonAnims_5_7
+.4byte sFlygonAnims_5_8
+sFlygonAnimTable6:
+.4byte sFlygonAnims_6_1
+.4byte sFlygonAnims_6_1
+.4byte sFlygonAnims_6_1
+.4byte sFlygonAnims_6_1
+.4byte sFlygonAnims_6_1
+.4byte sFlygonAnims_6_1
+.4byte sFlygonAnims_6_1
+.4byte sFlygonAnims_6_1
+sFlygonAnimTable7:
+.4byte sFlygonAnims_7_1
+.4byte sFlygonAnims_7_2
+.4byte sFlygonAnims_7_3
+.4byte sFlygonAnims_7_4
+.4byte sFlygonAnims_7_5
+.4byte sFlygonAnims_7_6
+.4byte sFlygonAnims_7_7
+.4byte sFlygonAnims_7_8
+sFlygonAnimTable8:
+.4byte sFlygonAnims_8_1
+.4byte sFlygonAnims_8_2
+.4byte sFlygonAnims_8_3
+.4byte sFlygonAnims_8_4
+.4byte sFlygonAnims_8_5
+.4byte sFlygonAnims_8_6
+.4byte sFlygonAnims_8_7
+.4byte sFlygonAnims_8_8
+sFlygonAnimTable9:
+.4byte sFlygonAnims_9_1
+.4byte sFlygonAnims_9_2
+.4byte sFlygonAnims_9_3
+.4byte sFlygonAnims_9_4
+.4byte sFlygonAnims_9_5
+.4byte sFlygonAnims_9_6
+.4byte sFlygonAnims_9_7
+.4byte sFlygonAnims_9_8
+sFlygonAnimTable10:
+.4byte sFlygonAnims_10_1
+.4byte sFlygonAnims_10_2
+.4byte sFlygonAnims_10_3
+.4byte sFlygonAnims_10_4
+.4byte sFlygonAnims_10_5
+.4byte sFlygonAnims_10_6
+.4byte sFlygonAnims_10_7
+.4byte sFlygonAnims_10_8
+sFlygonAnimTable11:
+.4byte sFlygonAnims_11_1
+.4byte sFlygonAnims_11_2
+.4byte sFlygonAnims_11_3
+.4byte sFlygonAnims_11_4
+.4byte sFlygonAnims_11_5
+.4byte sFlygonAnims_11_6
+.4byte sFlygonAnims_11_7
+.4byte sFlygonAnims_11_8
+sFlygonAnimTable12:
+.4byte sFlygonAnims_12_1
+.4byte sFlygonAnims_12_2
+.4byte sFlygonAnims_12_3
+.4byte sFlygonAnims_12_4
+.4byte sFlygonAnims_12_5
+.4byte sFlygonAnims_12_6
+.4byte sFlygonAnims_12_7
+.4byte sFlygonAnims_12_8
+sFlygonAnimTable13:
+.4byte sFlygonAnims_13_1
+.4byte sFlygonAnims_13_2
+.4byte sFlygonAnims_13_3
+.4byte sFlygonAnims_13_4
+.4byte sFlygonAnims_13_5
+.4byte sFlygonAnims_13_6
+.4byte sFlygonAnims_13_7
+.4byte sFlygonAnims_13_8
+sAxAnimationsFlygon:
+.4byte sFlygonAnimTable1
+.4byte sFlygonAnimTable2
+.4byte sFlygonAnimTable3
+.4byte sFlygonAnimTable4
+.4byte sFlygonAnimTable5
+.4byte sFlygonAnimTable6
+.4byte sFlygonAnimTable7
+.4byte sFlygonAnimTable8
+.4byte sFlygonAnimTable9
+.4byte sFlygonAnimTable10
+.4byte sFlygonAnimTable11
+.4byte sFlygonAnimTable12
+.4byte sFlygonAnimTable13
+sAxSpritesFlygon:
+.4byte sFlygonSprites1
+.4byte sFlygonSprites2
+.4byte sFlygonSprites3
+.4byte sFlygonSprites4
+.4byte sFlygonSprites5
+.4byte sFlygonSprites6
+.4byte sFlygonSprites7
+.4byte sFlygonSprites8
+.4byte sFlygonSprites9
+.4byte sFlygonSprites10
+.4byte sFlygonSprites11
+.4byte sFlygonSprites12
+.4byte sFlygonSprites13
+.4byte sFlygonSprites14
+.4byte sFlygonSprites15
+.4byte sFlygonSprites16
+.4byte sFlygonSprites17
+.4byte sFlygonSprites18
+.4byte sFlygonSprites19
+.4byte sFlygonSprites20
+.4byte sFlygonSprites21
+.4byte sFlygonSprites22
+.4byte sFlygonSprites23
+.4byte sFlygonSprites24
+.4byte sFlygonSprites25
+.4byte sFlygonSprites26
+.4byte sFlygonSprites27
+.4byte sFlygonSprites28
+.4byte sFlygonSprites29
+.4byte sFlygonSprites30
+.4byte sFlygonSprites31
+.4byte sFlygonSprites32
+.4byte sFlygonSprites33
+.4byte sFlygonSprites34
+.4byte sFlygonSprites35
+.4byte sFlygonSprites36
+.4byte sFlygonSprites37
+.4byte sFlygonSprites38
+.4byte sFlygonSprites39
+.4byte sFlygonSprites40
+.4byte sFlygonSprites41
+.4byte sFlygonSprites42
+.4byte sFlygonSprites43
+.4byte sFlygonSprites44
+.4byte sFlygonSprites45
+.4byte sFlygonSprites46
+.4byte sFlygonSprites47
+.4byte sFlygonSprites48
+.4byte sFlygonSprites49
+.4byte sFlygonSprites50
+.4byte sFlygonSprites51
+.4byte sFlygonSprites52
+.4byte sFlygonSprites53
+.4byte sFlygonSprites54
+.4byte sFlygonSprites55
+.4byte sFlygonSprites56
+.4byte sFlygonSprites57
+.4byte sFlygonSprites58
+.4byte sFlygonSprites59
+.4byte sFlygonSprites60
+.4byte sFlygonSprites61
+.4byte sFlygonSprites62
+.4byte sFlygonSprites63
+.4byte sFlygonSprites64
+.4byte sFlygonSprites65
+.4byte sFlygonSprites66
+.4byte sFlygonSprites67
+.4byte sFlygonSprites68
+.4byte sFlygonSprites69
+.4byte sFlygonSprites70
+.4byte sFlygonSprites71
+.4byte sFlygonSprites72
+.4byte sFlygonSprites73
+.4byte sFlygonSprites74
+.4byte sFlygonSprites75
+sAxMainFlygon:
+ax_main sAxPosesFlygon, sAxAnimationsFlygon, 13, sAxSpritesFlygon, sAxPositionsFlygon

--- a/data/ax/forretress.inc
+++ b/data/ax/forretress.inc
@@ -1,0 +1,2101 @@
+.global gAxForretress
+gAxForretress:
+ax_siro sAxMainForretress
+sForretressPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose2:
+ax_pose 1, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose6:
+ax_pose 3, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose7:
+ax_pose 2, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose8:
+ax_pose 1, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose9:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose10:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose11:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose12:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose13:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose14:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose15:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose16:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose17:
+ax_pose 0, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose18:
+ax_pose 1, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose22:
+ax_pose 3, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose23:
+ax_pose 2, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose24:
+ax_pose 1, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose25:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose26:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose27:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose28:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose29:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose30:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose31:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose32:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose33:
+ax_pose 0, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose34:
+ax_pose 1, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose38:
+ax_pose 3, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose39:
+ax_pose 2, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose40:
+ax_pose 1, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose41:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose42:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose43:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose44:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose45:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose46:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose47:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose48:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose49:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose50:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose51:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose52:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose53:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose54:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose55:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose56:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose57:
+ax_pose 10, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose58:
+ax_pose 11, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose59:
+ax_pose 12, 0x01e1, 0x80f1, 0x6c00
+ax_pose_terminator
+sForretressPose60:
+ax_pose 13, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose61:
+ax_pose 14, 0x01e3, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose62:
+ax_pose 15, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sForretressPose63:
+ax_pose 16, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sForretressPose64:
+ax_pose 15, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sForretressPose65:
+ax_pose 14, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose66:
+ax_pose 13, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose67:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose68:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose69:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose70:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose71:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose72:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose73:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose74:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose75:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose76:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose77:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose78:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose79:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose80:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose81:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose82:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose83:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose84:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose85:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose86:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose87:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose88:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose89:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose90:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose91:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose92:
+ax_pose 0, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose93:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose94:
+ax_pose 1, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose95:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose96:
+ax_pose 2, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose97:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose98:
+ax_pose 3, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose99:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose100:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose101:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose102:
+ax_pose 3, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose103:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose104:
+ax_pose 2, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose105:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose106:
+ax_pose 1, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose107:
+ax_pose 0, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose108:
+ax_pose 1, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose109:
+ax_pose 2, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose110:
+ax_pose 3, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose111:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose112:
+ax_pose 3, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose113:
+ax_pose 2, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose114:
+ax_pose 1, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose115:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose116:
+ax_pose 6, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose117:
+ax_pose 7, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose118:
+ax_pose 8, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sForretressPose119:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sForretressPose120:
+ax_pose 8, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sForretressPose121:
+ax_pose 7, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sForretressPose122:
+ax_pose 6, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+.align 2
+sForretressAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_1_2:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_1_4:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_1_6:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_1_7:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_1_8:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 2, 0, 8, 0, -2, 0, -2,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 6, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 12, 0, 12,
+ax_anim 2, 0, 16, 0, 24, 0, 22,
+ax_anim 2, 1, 16, 1, 24, 1, 22,
+ax_anim 2, 0, 16, 0, 24, 0, 22,
+ax_anim 2, 0, 16, 1, 24, 1, 22,
+ax_anim 2, 0, 8, 0, 8, 0, 8,
+ax_anim_terminator
+sForretressAnims_2_2:
+ax_anim 2, 0, 15, -1, -1, -1, -1,
+ax_anim 2, 0, 15, -2, -2, -2, -2,
+ax_anim 4, 0, 23, -2, -2, -2, -2,
+ax_anim 6, 0, 23, -2, -2, -2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, 4, 5, 4, 5,
+ax_anim 1, 0, 23, 12, 14, 12, 13,
+ax_anim 2, 0, 23, 20, 24, 20, 22,
+ax_anim 2, 1, 23, 21, 23, 21, 21,
+ax_anim 2, 0, 23, 20, 24, 20, 22,
+ax_anim 2, 0, 23, 21, 23, 21, 21,
+ax_anim 2, 0, 15, 8, 9, 8, 9,
+ax_anim_terminator
+sForretressAnims_2_3:
+ax_anim 2, 0, 14, -1, 0, -1, 0,
+ax_anim 2, 0, 14, -2, 0, -2, 0,
+ax_anim 4, 0, 22, -2, 0, -2, 0,
+ax_anim 6, 0, 22, -2, 0, -2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, 4, 0, 4, 0,
+ax_anim 1, 0, 22, 12, 1, 12, 0,
+ax_anim 2, 0, 22, 21, 2, 21, 2,
+ax_anim 2, 1, 22, 21, 3, 21, 3,
+ax_anim 2, 0, 22, 21, 2, 21, 2,
+ax_anim 2, 0, 22, 21, 3, 21, 3,
+ax_anim 2, 0, 14, 8, 1, 8, 0,
+ax_anim_terminator
+sForretressAnims_2_4:
+ax_anim 2, 0, 13, -1, 1, -1, 1,
+ax_anim 2, 0, 13, -2, 2, -2, 2,
+ax_anim 4, 0, 21, -2, 2, -2, 2,
+ax_anim 6, 0, 21, -2, 2, -2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, 5, -4, 5, -4,
+ax_anim 1, 0, 21, 13, -12, 13, -13,
+ax_anim 2, 0, 21, 20, -17, 20, -20,
+ax_anim 2, 1, 21, 21, -16, 21, -19,
+ax_anim 2, 0, 21, 20, -17, 20, -20,
+ax_anim 2, 0, 21, 21, -16, 21, -19,
+ax_anim 2, 0, 13, 9, -8, 9, -8,
+ax_anim_terminator
+sForretressAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 2, 0, 12, 0, 2, 0, 2,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 6, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -12, 0, -12,
+ax_anim 2, 0, 20, 0, -18, 0, -18,
+ax_anim 2, 1, 20, 1, -18, 1, -18,
+ax_anim 2, 0, 20, 0, -18, 0, -18,
+ax_anim 2, 0, 20, 1, -18, 1, -18,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sForretressAnims_2_6:
+ax_anim 2, 0, 11, 1, 1, 1, 1,
+ax_anim 2, 0, 11, 2, 2, 2, 2,
+ax_anim 4, 0, 19, 2, 2, 2, 2,
+ax_anim 6, 0, 19, 2, 2, 2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, -5, -4, -5, -4,
+ax_anim 1, 0, 19, -13, -12, -13, -13,
+ax_anim 2, 0, 19, -20, -17, -20, -20,
+ax_anim 2, 1, 19, -21, -16, -21, -19,
+ax_anim 2, 0, 19, -20, -17, -20, -20,
+ax_anim 2, 0, 19, -21, -16, -21, -19,
+ax_anim 2, 0, 11, -9, -8, -9, -8,
+ax_anim_terminator
+sForretressAnims_2_7:
+ax_anim 2, 0, 10, 1, 0, 1, 0,
+ax_anim 2, 0, 10, 2, 0, 2, 0,
+ax_anim 4, 0, 18, 2, 0, 2, 0,
+ax_anim 6, 0, 18, 2, 0, 2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, -4, 0, -4, 0,
+ax_anim 1, 0, 18, -12, 1, -12, 0,
+ax_anim 2, 0, 18, -21, 2, -21, 2,
+ax_anim 2, 1, 18, -21, 3, -21, 3,
+ax_anim 2, 0, 18, -21, 2, -21, 2,
+ax_anim 2, 0, 18, -21, 3, -21, 3,
+ax_anim 2, 0, 10, -8, 1, -8, 0,
+ax_anim_terminator
+sForretressAnims_2_8:
+ax_anim 2, 0, 9, 1, -1, 1, -1,
+ax_anim 2, 0, 9, 2, -2, 2, -2,
+ax_anim 4, 0, 17, 2, -2, 2, -2,
+ax_anim 6, 0, 17, 2, -2, 2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, -4, 5, -4, 5,
+ax_anim 1, 0, 17, -12, 14, -12, 13,
+ax_anim 2, 0, 17, -20, 24, -20, 22,
+ax_anim 2, 1, 17, -21, 23, -21, 21,
+ax_anim 2, 0, 17, -20, 24, -20, 22,
+ax_anim 2, 0, 17, -21, 23, -21, 21,
+ax_anim 2, 0, 9, -8, 9, -8, 9,
+ax_anim_terminator
+.align 2
+sForretressAnims_3_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 4, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 4, 0, 4,
+ax_anim 2, 0, 32, 0, 12, 0, 12,
+ax_anim 1, 1, 39, 0, 24, 0, 22,
+ax_anim 1, 0, 38, 0, 24, 0, 22,
+ax_anim 1, 0, 37, 0, 24, 0, 22,
+ax_anim 1, 0, 36, 0, 24, 0, 22,
+ax_anim 1, 0, 35, 0, 24, 0, 22,
+ax_anim 1, 0, 34, 0, 24, 0, 22,
+ax_anim 1, 0, 33, 0, 24, 0, 22,
+ax_anim 2, 0, 32, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sForretressAnims_3_2:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 4, 5, 4, 4,
+ax_anim 2, 0, 39, 12, 14, 12, 12,
+ax_anim 1, 1, 38, 20, 24, 20, 22,
+ax_anim 1, 0, 37, 20, 24, 20, 22,
+ax_anim 1, 0, 36, 20, 24, 20, 22,
+ax_anim 1, 0, 35, 20, 24, 20, 22,
+ax_anim 1, 0, 34, 20, 24, 20, 22,
+ax_anim 1, 0, 33, 20, 24, 20, 22,
+ax_anim 1, 0, 32, 20, 24, 20, 22,
+ax_anim 2, 0, 39, 12, 14, 12, 12,
+ax_anim 2, 0, 31, 4, 5, 4, 4,
+ax_anim_terminator
+sForretressAnims_3_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 4, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 4, 0, 4, 0,
+ax_anim 2, 0, 38, 12, 1, 12, 0,
+ax_anim 1, 1, 37, 20, 2, 20, 0,
+ax_anim 1, 0, 36, 20, 2, 20, 0,
+ax_anim 1, 0, 35, 20, 2, 20, 0,
+ax_anim 1, 0, 34, 20, 2, 20, 0,
+ax_anim 1, 0, 33, 20, 2, 20, 0,
+ax_anim 1, 0, 32, 20, 2, 20, 0,
+ax_anim 1, 0, 39, 20, 2, 20, 0,
+ax_anim 2, 0, 38, 12, 1, 12, 0,
+ax_anim 2, 0, 30, 4, 0, 4, 0,
+ax_anim_terminator
+sForretressAnims_3_4:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 4, -3, 4, -4,
+ax_anim 2, 0, 37, 12, -9, 12, -11,
+ax_anim 1, 1, 36, 20, -15, 20, -18,
+ax_anim 1, 0, 35, 20, -15, 20, -18,
+ax_anim 1, 0, 34, 20, -15, 20, -18,
+ax_anim 1, 0, 33, 20, -15, 20, -18,
+ax_anim 1, 0, 32, 20, -15, 20, -18,
+ax_anim 1, 0, 39, 20, -15, 20, -18,
+ax_anim 1, 0, 38, 20, -15, 20, -18,
+ax_anim 2, 0, 37, 12, -9, 12, -11,
+ax_anim 2, 0, 29, 4, -3, 4, -4,
+ax_anim_terminator
+sForretressAnims_3_5:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 4, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, -3, 0, -3,
+ax_anim 2, 0, 36, 0, -9, 0, -10,
+ax_anim 1, 1, 35, 0, -15, 0, -18,
+ax_anim 1, 0, 34, 0, -15, 0, -18,
+ax_anim 1, 0, 33, 0, -15, 0, -18,
+ax_anim 1, 0, 32, 0, -15, 0, -18,
+ax_anim 1, 0, 39, 0, -15, 0, -18,
+ax_anim 1, 0, 38, 0, -15, 0, -18,
+ax_anim 1, 0, 37, 0, -15, 0, -18,
+ax_anim 2, 0, 36, 0, -9, 0, -10,
+ax_anim 2, 0, 28, 0, -3, 0, -3,
+ax_anim_terminator
+sForretressAnims_3_6:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 4, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 36, -4, -3, -4, -4,
+ax_anim 2, 0, 35, -12, -9, -12, -11,
+ax_anim 1, 1, 34, -20, -15, -20, -18,
+ax_anim 1, 0, 33, -20, -15, -20, -18,
+ax_anim 1, 0, 32, -20, -15, -20, -18,
+ax_anim 1, 0, 39, -20, -15, -20, -18,
+ax_anim 1, 0, 38, -20, -15, -20, -18,
+ax_anim 1, 0, 37, -20, -15, -20, -18,
+ax_anim 1, 0, 36, -20, -15, -20, -18,
+ax_anim 2, 0, 35, -12, -9, -12, -11,
+ax_anim 2, 0, 27, -4, -3, -4, -4,
+ax_anim_terminator
+sForretressAnims_3_7:
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 35, -4, 0, -4, 0,
+ax_anim 2, 0, 34, -12, 1, -12, 0,
+ax_anim 1, 1, 33, -20, 2, -20, 0,
+ax_anim 1, 0, 32, -20, 2, -20, 0,
+ax_anim 1, 0, 39, -20, 2, -20, 0,
+ax_anim 1, 0, 38, -20, 2, -20, 0,
+ax_anim 1, 0, 37, -20, 2, -20, 0,
+ax_anim 1, 0, 36, -20, 2, -20, 0,
+ax_anim 1, 0, 35, -20, 2, -20, 0,
+ax_anim 2, 0, 34, -12, 1, -12, 0,
+ax_anim 2, 0, 26, -4, 0, -4, 0,
+ax_anim_terminator
+sForretressAnims_3_8:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 4, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 34, -4, 5, -4, 4,
+ax_anim 2, 0, 33, -12, 14, -12, 12,
+ax_anim 1, 1, 32, -20, 24, -20, 22,
+ax_anim 1, 0, 39, -20, 24, -20, 22,
+ax_anim 1, 0, 38, -20, 24, -20, 22,
+ax_anim 1, 0, 37, -20, 24, -20, 22,
+ax_anim 1, 0, 36, -20, 24, -20, 22,
+ax_anim 1, 0, 35, -20, 24, -20, 22,
+ax_anim 1, 0, 34, -20, 24, -20, 22,
+ax_anim 2, 0, 33, -12, 14, -12, 12,
+ax_anim 2, 0, 25, -4, 5, -4, 4,
+ax_anim_terminator
+.align 2
+sForretressAnims_4_1:
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, -1, 0, 0,
+ax_anim 1, 0, 43, 0, -2, 0, 0,
+ax_anim 1, 0, 44, 0, -3, 0, 0,
+ax_anim 1, 0, 45, 0, -4, 0, 0,
+ax_anim 1, 0, 46, 0, -4, 0, 0,
+ax_anim 1, 0, 47, 0, -4, 0, 0,
+ax_anim 1, 2, 40, 0, -4, 0, 0,
+ax_anim 1, 0, 41, 0, -3, 0, 0,
+ax_anim 1, 0, 42, 0, -2, 0, 0,
+ax_anim 1, 0, 43, 0, -1, 0, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 4, 1, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim_terminator
+sForretressAnims_4_2:
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 41, 0, -1, 0, 0,
+ax_anim 1, 0, 42, 0, -2, 0, 0,
+ax_anim 1, 0, 43, 0, -3, 0, 0,
+ax_anim 1, 0, 44, 0, -4, 0, 0,
+ax_anim 1, 0, 45, 0, -4, 0, 0,
+ax_anim 1, 0, 46, 0, -4, 0, 0,
+ax_anim 1, 2, 47, 0, -4, 0, 0,
+ax_anim 1, 0, 40, 0, -3, 0, 0,
+ax_anim 1, 0, 41, 0, -2, 0, 0,
+ax_anim 1, 0, 42, 0, -1, 0, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 4, 1, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, 1, -1, 1,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, 1, -1, 1,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, 1, -1, 1,
+ax_anim_terminator
+sForretressAnims_4_3:
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 40, 0, -1, 0, 0,
+ax_anim 1, 0, 41, 0, -2, 0, 0,
+ax_anim 1, 0, 42, 0, -3, 0, 0,
+ax_anim 1, 0, 43, 0, -4, 0, 0,
+ax_anim 1, 0, 44, 0, -4, 0, 0,
+ax_anim 1, 0, 45, 0, -4, 0, 0,
+ax_anim 1, 2, 46, 0, -4, 0, 0,
+ax_anim 1, 0, 47, 0, -3, 0, 0,
+ax_anim 1, 0, 40, 0, -2, 0, 0,
+ax_anim 1, 0, 41, 0, -1, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 4, 1, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 1, 0, 1,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 1, 0, 1,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 1, 0, 1,
+ax_anim_terminator
+sForretressAnims_4_4:
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, -1, 0, 0,
+ax_anim 1, 0, 40, 0, -2, 0, 0,
+ax_anim 1, 0, 41, 0, -3, 0, 0,
+ax_anim 1, 0, 42, 0, -4, 0, 0,
+ax_anim 1, 0, 43, 0, -4, 0, 0,
+ax_anim 1, 0, 44, 0, -4, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, 0,
+ax_anim 1, 0, 46, 0, -3, 0, 0,
+ax_anim 1, 0, 47, 0, -2, 0, 0,
+ax_anim 1, 0, 40, 0, -1, 0, 0,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 4, 1, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim_terminator
+sForretressAnims_4_5:
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 46, 0, -1, 0, 0,
+ax_anim 1, 0, 47, 0, -2, 0, 0,
+ax_anim 1, 0, 40, 0, -3, 0, 0,
+ax_anim 1, 0, 41, 0, -4, 0, 0,
+ax_anim 1, 0, 42, 0, -4, 0, 0,
+ax_anim 1, 0, 43, 0, -4, 0, 0,
+ax_anim 1, 2, 44, 0, -4, 0, 0,
+ax_anim 1, 0, 45, 0, -3, 0, 0,
+ax_anim 1, 0, 46, 0, -2, 0, 0,
+ax_anim 1, 0, 47, 0, -1, 0, 0,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 4, 1, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, -1, 0, -1, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, -1, 0, -1, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, -1, 0, -1, 0,
+ax_anim_terminator
+sForretressAnims_4_6:
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 0, -1, 0, 0,
+ax_anim 1, 0, 46, 0, -2, 0, 0,
+ax_anim 1, 0, 47, 0, -3, 0, 0,
+ax_anim 1, 0, 40, 0, -4, 0, 0,
+ax_anim 1, 0, 41, 0, -4, 0, 0,
+ax_anim 1, 0, 42, 0, -4, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, 0,
+ax_anim 1, 0, 44, 0, -3, 0, 0,
+ax_anim 1, 0, 45, 0, -2, 0, 0,
+ax_anim 1, 0, 46, 0, -1, 0, 0,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 4, 1, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim_terminator
+sForretressAnims_4_7:
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, -1, 0, 0,
+ax_anim 1, 0, 45, 0, -2, 0, 0,
+ax_anim 1, 0, 46, 0, -3, 0, 0,
+ax_anim 1, 0, 47, 0, -4, 0, 0,
+ax_anim 1, 0, 40, 0, -4, 0, 0,
+ax_anim 1, 0, 41, 0, -4, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, 0,
+ax_anim 1, 0, 43, 0, -3, 0, 0,
+ax_anim 1, 0, 44, 0, -2, 0, 0,
+ax_anim 1, 0, 45, 0, -1, 0, 0,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 4, 1, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim_terminator
+sForretressAnims_4_8:
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, -1, 0, 0,
+ax_anim 1, 0, 44, 0, -2, 0, 0,
+ax_anim 1, 0, 45, 0, -3, 0, 0,
+ax_anim 1, 0, 46, 0, -4, 0, 0,
+ax_anim 1, 0, 47, 0, -4, 0, 0,
+ax_anim 1, 0, 40, 0, -4, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, 0,
+ax_anim 1, 0, 42, 0, -3, 0, 0,
+ax_anim 1, 0, 43, 0, -2, 0, 0,
+ax_anim 1, 0, 44, 0, -1, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 1, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sForretressAnims_5_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 2, 48, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_5_2:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 2, 55, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_5_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 2, 54, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_5_4:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 2, 53, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_5_5:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 2, 52, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_5_6:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 2, 51, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_5_7:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 50, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_5_8:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 2, 49, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_6_1:
+ax_anim 8, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 26, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 57, 0, -2, 0, 0,
+ax_anim 8, 0, 57, 0, -1, 0, 0,
+ax_anim 26, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_7_1:
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 8, 0, 58, 0, -3, 0, -3,
+ax_anim_terminator
+sForretressAnims_7_2:
+ax_anim 2, 0, 59, -2, -2, -2, -2,
+ax_anim 8, 0, 59, -3, -3, -3, -3,
+ax_anim_terminator
+sForretressAnims_7_3:
+ax_anim 2, 0, 60, -2, 0, -2, 0,
+ax_anim 8, 0, 60, -3, 0, -3, 0,
+ax_anim_terminator
+sForretressAnims_7_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 8, 0, 61, -3, 3, -3, 3,
+ax_anim_terminator
+sForretressAnims_7_5:
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 8, 0, 62, 0, 3, 0, 3,
+ax_anim_terminator
+sForretressAnims_7_6:
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 8, 0, 63, 3, 3, 3, 3,
+ax_anim_terminator
+sForretressAnims_7_7:
+ax_anim 2, 0, 64, 2, 0, 2, 0,
+ax_anim 8, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sForretressAnims_7_8:
+ax_anim 2, 0, 65, 2, -2, 2, -2,
+ax_anim 8, 0, 65, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sForretressAnims_8_1:
+ax_anim 40, 0, 66, 0, 0, 0, 0,
+ax_anim 8, 0, 66, 0, -1, 0, 0,
+ax_anim 20, 0, 66, 0, -2, 0, 0,
+ax_anim 8, 0, 66, 0, -1, 0, 0,
+ax_anim_terminator
+sForretressAnims_8_2:
+ax_anim 40, 0, 73, 0, 0, 0, 0,
+ax_anim 8, 0, 73, 0, -1, 0, 0,
+ax_anim 20, 0, 73, 0, -2, 0, 0,
+ax_anim 8, 0, 73, 0, -1, 0, 0,
+ax_anim_terminator
+sForretressAnims_8_3:
+ax_anim 40, 0, 72, 0, 0, 0, 0,
+ax_anim 8, 0, 72, 0, -1, 0, 0,
+ax_anim 20, 0, 72, 0, -2, 0, 0,
+ax_anim 8, 0, 72, 0, -1, 0, 0,
+ax_anim_terminator
+sForretressAnims_8_4:
+ax_anim 40, 0, 71, 0, 0, 0, 0,
+ax_anim 8, 0, 71, 0, -1, 0, 0,
+ax_anim 20, 0, 71, 0, -2, 0, 0,
+ax_anim 8, 0, 71, 0, -1, 0, 0,
+ax_anim_terminator
+sForretressAnims_8_5:
+ax_anim 40, 0, 70, 0, 0, 0, 0,
+ax_anim 8, 0, 70, 0, -1, 0, 0,
+ax_anim 20, 0, 70, 0, -2, 0, 0,
+ax_anim 8, 0, 70, 0, -1, 0, 0,
+ax_anim_terminator
+sForretressAnims_8_6:
+ax_anim 40, 0, 69, 0, 0, 0, 0,
+ax_anim 8, 0, 69, 0, -1, 0, 0,
+ax_anim 20, 0, 69, 0, -2, 0, 0,
+ax_anim 8, 0, 69, 0, -1, 0, 0,
+ax_anim_terminator
+sForretressAnims_8_7:
+ax_anim 40, 0, 68, 0, 0, 0, 0,
+ax_anim 8, 0, 68, 0, -1, 0, 0,
+ax_anim 20, 0, 68, 0, -2, 0, 0,
+ax_anim 8, 0, 68, 0, -1, 0, 0,
+ax_anim_terminator
+sForretressAnims_8_8:
+ax_anim 40, 0, 67, 0, 0, 0, 0,
+ax_anim 8, 0, 67, 0, -1, 0, 0,
+ax_anim 20, 0, 67, 0, -2, 0, 0,
+ax_anim 8, 0, 67, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_9_1:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 7, 4, 7, 4,
+ax_anim 2, 0, 76, 9, 11, 9, 11,
+ax_anim 2, 0, 77, 6, 21, 6, 20,
+ax_anim 3, 0, 78, 0, 23, 0, 21,
+ax_anim 2, 3, 79, -6, 21, -6, 20,
+ax_anim 2, 0, 80, -9, 11, -11, 11,
+ax_anim 1, 0, 81, -7, 4, -7, 4,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_9_2:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 8, 0, 8, 0,
+ax_anim 2, 0, 75, 20, 4, 20, 4,
+ax_anim 2, 0, 76, 26, 14, 26, 13,
+ax_anim 3, 0, 77, 20, 23, 20, 21,
+ax_anim 2, 3, 78, 10, 22, 10, 19,
+ax_anim 2, 0, 79, 3, 16, 3, 15,
+ax_anim 1, 0, 80, 1, 8, 1, 8,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_9_3:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 3, -4, 3, -4,
+ax_anim 2, 0, 74, 11, -6, 11, -6,
+ax_anim 2, 0, 75, 16, -4, 16, -4,
+ax_anim 3, 0, 76, 20, 2, 20, 0,
+ax_anim 2, 3, 77, 18, 7, 18, 5,
+ax_anim 2, 0, 78, 12, 9, 12, 9,
+ax_anim 1, 0, 79, 5, 8, 5, 7,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_9_4:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 80, -1, -6, -1, -6,
+ax_anim 2, 0, 81, 1, -12, 1, -12,
+ax_anim 2, 0, 74, 8, -17, 8, -17,
+ax_anim 3, 0, 75, 19, -18, 19, -20,
+ax_anim 2, 3, 76, 22, -10, 22, -11,
+ax_anim 2, 0, 77, 15, -2, 15, -2,
+ax_anim 1, 0, 78, 7, 0, 7, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_9_5:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 79, -6, -2, -6, -2,
+ax_anim 2, 0, 80, -9, -10, -9, -10,
+ax_anim 2, 0, 81, -7, -14, -7, -16,
+ax_anim 3, 0, 74, 0, -18, 0, -20,
+ax_anim 2, 3, 75, 7, -14, 7, -16,
+ax_anim 2, 0, 76, 9, -8, 9, -8,
+ax_anim 1, 0, 77, 6, -2, 6, -2,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_9_6:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 1, -6, 1, -6,
+ax_anim 2, 0, 75, -1, -12, -1, -12,
+ax_anim 2, 0, 74, -8, -17, -8, -17,
+ax_anim 3, 0, 81, -19, -18, -19, -20,
+ax_anim 2, 3, 80, -22, -10, -22, -11,
+ax_anim 2, 0, 79, -15, -2, -15, -2,
+ax_anim 1, 0, 78, -7, 0, -7, 0,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_9_7:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 75, -3, -4, -3, -4,
+ax_anim 2, 0, 74, -11, -6, -11, -6,
+ax_anim 2, 0, 81, -16, -4, -16, -4,
+ax_anim 3, 0, 80, -20, 2, -20, 0,
+ax_anim 2, 3, 79, -18, 7, -18, 5,
+ax_anim 2, 0, 78, -12, 9, -12, 9,
+ax_anim 1, 0, 77, -5, 8, -5, 7,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_9_8:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 74, -8, 0, -8, 0,
+ax_anim 2, 0, 81, -20, 4, -20, 4,
+ax_anim 2, 0, 80, -26, 14, -26, 13,
+ax_anim 3, 0, 79, -20, 23, -20, 21,
+ax_anim 2, 3, 78, -10, 22, -10, 19,
+ax_anim 2, 0, 77, -3, 16, -3, 15,
+ax_anim 1, 0, 76, -1, 8, -1, 8,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_10_1:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 6, 0, 6, 0,
+ax_anim 2, 0, 82, -6, 0, -6, 0,
+ax_anim 2, 0, 82, 10, 0, 10, 0,
+ax_anim 2, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 82, 12, 0, 12, 0,
+ax_anim 3, 0, 82, -12, 0, -12, 0,
+ax_anim 3, 0, 82, 13, 0, 13, 0,
+ax_anim 3, 0, 82, -13, 0, -13, 0,
+ax_anim 2, 0, 82, 12, 0, 12, 0,
+ax_anim 3, 0, 82, -12, 0, -12, 0,
+ax_anim 2, 0, 82, 10, 0, 10, 0,
+ax_anim 2, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 82, 6, 0, 6, 0,
+ax_anim 2, 0, 82, -6, 0, -6, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_10_2:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 83, -6, 6, -6, 6,
+ax_anim 2, 0, 83, 10, -10, 10, -10,
+ax_anim 2, 0, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, 12, -12, 12, -12,
+ax_anim 3, 0, 83, -12, 12, -12, 12,
+ax_anim 3, 0, 83, 13, -13, 13, -13,
+ax_anim 3, 0, 83, -13, 13, -13, 13,
+ax_anim 2, 0, 83, 12, -12, 12, -12,
+ax_anim 3, 0, 83, -12, 12, -12, 12,
+ax_anim 2, 0, 83, 10, -10, 10, -10,
+ax_anim 2, 0, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 83, -6, 6, -6, 6,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_10_3:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim 2, 0, 84, 0, 6, 0, 6,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, 10, 0, 10,
+ax_anim 2, 0, 84, 0, -12, 0, -12,
+ax_anim 3, 0, 84, 0, 12, 0, 12,
+ax_anim 3, 0, 84, 0, -13, 0, -13,
+ax_anim 3, 0, 84, 0, 13, 0, 13,
+ax_anim 2, 0, 84, 0, -12, 0, -12,
+ax_anim 3, 0, 84, 0, 12, 0, 12,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, 10, 0, 10,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim 2, 0, 84, 0, 6, 0, 6,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_10_4:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -6, -6, -6, -6,
+ax_anim 2, 0, 85, 6, 6, 6, 6,
+ax_anim 2, 0, 85, -10, -10, -10, -10,
+ax_anim 2, 0, 85, 10, 10, 10, 10,
+ax_anim 2, 0, 85, -12, -12, -12, -12,
+ax_anim 3, 0, 85, 12, 12, 12, 12,
+ax_anim 3, 0, 85, -13, -13, -13, -13,
+ax_anim 3, 0, 85, 13, 13, 13, 13,
+ax_anim 2, 0, 85, -12, -12, -12, -12,
+ax_anim 3, 0, 85, 12, 12, 12, 12,
+ax_anim 2, 0, 85, -10, -10, -10, -10,
+ax_anim 2, 0, 85, 10, 10, 10, 10,
+ax_anim 2, 0, 85, -6, -6, -6, -6,
+ax_anim 2, 0, 85, 6, 6, 6, 6,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_10_5:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 6, 0, 6, 0,
+ax_anim 2, 0, 86, -6, 0, -6, 0,
+ax_anim 2, 0, 86, 10, 0, 10, 0,
+ax_anim 2, 0, 86, -10, 0, -10, 0,
+ax_anim 2, 0, 86, 12, 0, 12, 0,
+ax_anim 3, 0, 86, -12, 0, -12, 0,
+ax_anim 3, 0, 86, 13, 0, 13, 0,
+ax_anim 3, 0, 86, -13, 0, -13, 0,
+ax_anim 2, 0, 86, 12, 0, 12, 0,
+ax_anim 3, 0, 86, -12, 0, -12, 0,
+ax_anim 2, 0, 86, 10, 0, 10, 0,
+ax_anim 2, 0, 86, -10, 0, -10, 0,
+ax_anim 2, 0, 86, 6, 0, 6, 0,
+ax_anim 2, 0, 86, -6, 0, -6, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_10_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 6, -6, 6, -6,
+ax_anim 2, 0, 87, -6, 6, -6, 6,
+ax_anim 2, 0, 87, 10, -10, 10, -10,
+ax_anim 2, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, 12, -12, 12, -12,
+ax_anim 3, 0, 87, -12, 12, -12, 12,
+ax_anim 3, 0, 87, 13, -13, 13, -13,
+ax_anim 3, 0, 87, -13, 13, -13, 13,
+ax_anim 2, 0, 87, 12, -12, 12, -12,
+ax_anim 3, 0, 87, -12, 12, -12, 12,
+ax_anim 2, 0, 87, 10, -10, 10, -10,
+ax_anim 2, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, 6, -6, 6, -6,
+ax_anim 2, 0, 87, -6, 6, -6, 6,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_10_7:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 88, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 0, 10, 0, 10,
+ax_anim 2, 0, 88, 0, -12, 0, -12,
+ax_anim 3, 0, 88, 0, 12, 0, 12,
+ax_anim 3, 0, 88, 0, -13, 0, -13,
+ax_anim 3, 0, 88, 0, 13, 0, 13,
+ax_anim 2, 0, 88, 0, -12, 0, -12,
+ax_anim 3, 0, 88, 0, 12, 0, 12,
+ax_anim 2, 0, 88, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 0, 10, 0, 10,
+ax_anim 2, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 88, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_10_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 89, 6, 6, 6, 6,
+ax_anim 2, 0, 89, -10, -10, -10, -10,
+ax_anim 2, 0, 89, 10, 10, 10, 10,
+ax_anim 2, 0, 89, -12, -12, -12, -12,
+ax_anim 3, 0, 89, 12, 12, 12, 12,
+ax_anim 3, 0, 89, -13, -13, -13, -13,
+ax_anim 3, 0, 89, 13, 13, 13, 13,
+ax_anim 2, 0, 89, -12, -12, -12, -12,
+ax_anim 3, 0, 89, 12, 12, 12, 12,
+ax_anim 2, 0, 89, -10, -10, -10, -10,
+ax_anim 2, 0, 89, 10, 10, 10, 10,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 89, 6, 6, 6, 6,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_11_1:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -10, 0, 0,
+ax_anim 2, 0, 90, 0, -16, 0, 0,
+ax_anim 3, 0, 90, 0, -20, 0, 0,
+ax_anim 4, 0, 90, 0, -21, 0, 0,
+ax_anim 4, 0, 91, 0, -23, 0, 0,
+ax_anim 3, 0, 91, 0, -22, 0, 0,
+ax_anim 2, 0, 91, 0, -18, 0, 0,
+ax_anim 1, 0, 91, 0, -12, 0, 0,
+ax_anim 2, 2, 91, 0, 3, 0, 0,
+ax_anim_terminator
+sForretressAnims_11_2:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -10, 0, 0,
+ax_anim 2, 0, 92, 0, -16, 0, 0,
+ax_anim 3, 0, 92, 0, -20, 0, 0,
+ax_anim 4, 0, 92, 0, -21, 0, 0,
+ax_anim 4, 0, 93, 0, -23, 0, 0,
+ax_anim 3, 0, 93, 0, -22, 0, 0,
+ax_anim 2, 0, 93, 0, -18, 0, 0,
+ax_anim 1, 0, 93, 0, -12, 0, 0,
+ax_anim 2, 2, 93, 0, 3, 0, 0,
+ax_anim_terminator
+sForretressAnims_11_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -10, 0, 0,
+ax_anim 2, 0, 94, 0, -16, 0, 0,
+ax_anim 3, 0, 94, 0, -20, 0, 0,
+ax_anim 4, 0, 94, 0, -21, 0, 0,
+ax_anim 4, 0, 95, 0, -23, 0, 0,
+ax_anim 3, 0, 95, 0, -22, 0, 0,
+ax_anim 2, 0, 95, 0, -18, 0, 0,
+ax_anim 1, 0, 95, 0, -12, 0, 0,
+ax_anim 2, 2, 95, 0, 3, 0, 0,
+ax_anim_terminator
+sForretressAnims_11_4:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -10, 0, 0,
+ax_anim 2, 0, 96, 0, -16, 0, 0,
+ax_anim 3, 0, 96, 0, -20, 0, 0,
+ax_anim 4, 0, 96, 0, -21, 0, 0,
+ax_anim 4, 0, 97, 0, -22, 0, 0,
+ax_anim 3, 0, 97, 0, -21, 0, 0,
+ax_anim 2, 0, 97, 0, -17, 0, 0,
+ax_anim 1, 0, 97, 0, -11, 0, 0,
+ax_anim 2, 2, 97, 0, 3, 0, 0,
+ax_anim_terminator
+sForretressAnims_11_5:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -10, 0, 0,
+ax_anim 2, 0, 98, 0, -16, 0, 0,
+ax_anim 3, 0, 98, 0, -20, 0, 0,
+ax_anim 4, 0, 98, 0, -21, 0, 0,
+ax_anim 4, 0, 99, 0, -23, 0, 0,
+ax_anim 3, 0, 99, 0, -22, 0, 0,
+ax_anim 2, 0, 99, 0, -18, 0, 0,
+ax_anim 1, 0, 99, 0, -12, 0, 0,
+ax_anim 2, 2, 99, 0, 3, 0, 0,
+ax_anim_terminator
+sForretressAnims_11_6:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, -10, 0, 0,
+ax_anim 2, 0, 100, 0, -16, 0, 0,
+ax_anim 3, 0, 100, 0, -20, 0, 0,
+ax_anim 4, 0, 100, 0, -21, 0, 0,
+ax_anim 4, 0, 101, 0, -22, 0, 0,
+ax_anim 3, 0, 101, 0, -21, 0, 0,
+ax_anim 2, 0, 101, 0, -17, 0, 0,
+ax_anim 1, 0, 101, 0, -11, 0, 0,
+ax_anim 2, 2, 101, 0, 3, 0, 0,
+ax_anim_terminator
+sForretressAnims_11_7:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -10, 0, 0,
+ax_anim 2, 0, 102, 0, -16, 0, 0,
+ax_anim 3, 0, 102, 0, -20, 0, 0,
+ax_anim 4, 0, 102, 0, -21, 0, 0,
+ax_anim 4, 0, 103, 0, -23, 0, 0,
+ax_anim 3, 0, 103, 0, -22, 0, 0,
+ax_anim 2, 0, 103, 0, -18, 0, 0,
+ax_anim 1, 0, 103, 0, -12, 0, 0,
+ax_anim 2, 2, 103, 0, 3, 0, 0,
+ax_anim_terminator
+sForretressAnims_11_8:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -10, 0, 0,
+ax_anim 2, 0, 104, 0, -16, 0, 0,
+ax_anim 3, 0, 104, 0, -20, 0, 0,
+ax_anim 4, 0, 104, 0, -21, 0, 0,
+ax_anim 4, 0, 105, 0, -23, 0, 0,
+ax_anim 3, 0, 105, 0, -22, 0, 0,
+ax_anim 2, 0, 105, 0, -18, 0, 0,
+ax_anim 1, 0, 105, 0, -12, 0, 0,
+ax_anim 2, 2, 105, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_12_1:
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_12_2:
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_12_3:
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_12_4:
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_12_5:
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_12_6:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_12_7:
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_12_8:
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sForretressAnims_13_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_13_2:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_13_3:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_13_4:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_13_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_13_6:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_13_7:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressAnims_13_8:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sForretressGfx1:
+.incbin "baserom.gba", 0xE48BE4, 0x200
+sForretressSprites1:
+ax_sprite sForretressGfx1, 0x200
+ax_sprite_terminator
+sForretressGfx2:
+.incbin "baserom.gba", 0xE48DF4, 0x200
+sForretressSprites2:
+ax_sprite sForretressGfx2, 0x200
+ax_sprite_terminator
+sForretressGfx3:
+.incbin "baserom.gba", 0xE49004, 0x200
+sForretressSprites3:
+ax_sprite sForretressGfx3, 0x200
+ax_sprite_terminator
+sForretressGfx4:
+.incbin "baserom.gba", 0xE49214, 0x200
+sForretressSprites4:
+ax_sprite sForretressGfx4, 0x200
+ax_sprite_terminator
+sForretressGfx5:
+.incbin "baserom.gba", 0xE49424, 0x200
+sForretressSprites5:
+ax_sprite sForretressGfx5, 0x200
+ax_sprite_terminator
+sForretressGfx6:
+.incbin "baserom.gba", 0xE49634, 0x60
+sForretressGfx6_1:
+.incbin "baserom.gba", 0xE49694, 0x60
+sForretressGfx6_2:
+.incbin "baserom.gba", 0xE496F4, 0x60
+sForretressSprites6:
+ax_sprite sForretressGfx6, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx6_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx6_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sForretressGfx7:
+.incbin "baserom.gba", 0xE4978C, 0x60
+sForretressGfx7_1:
+.incbin "baserom.gba", 0xE497EC, 0xE0
+sForretressSprites7:
+ax_sprite sForretressGfx7, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx7_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sForretressGfx8:
+.incbin "baserom.gba", 0xE498F4, 0x60
+sForretressGfx8_1:
+.incbin "baserom.gba", 0xE49954, 0x60
+sForretressGfx8_2:
+.incbin "baserom.gba", 0xE499B4, 0x60
+sForretressSprites8:
+ax_sprite sForretressGfx8, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx8_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx8_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sForretressGfx9:
+.incbin "baserom.gba", 0xE49A4C, 0x60
+sForretressGfx9_1:
+.incbin "baserom.gba", 0xE49AAC, 0xE0
+sForretressSprites9:
+ax_sprite sForretressGfx9, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx9_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sForretressGfx10:
+.incbin "baserom.gba", 0xE49BB4, 0x60
+sForretressGfx10_1:
+.incbin "baserom.gba", 0xE49C14, 0x60
+sForretressGfx10_2:
+.incbin "baserom.gba", 0xE49C74, 0x60
+sForretressSprites10:
+ax_sprite sForretressGfx10, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx10_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sForretressGfx10_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sForretressGfx11:
+.incbin "baserom.gba", 0xE49D0C, 0x200
+sForretressSprites11:
+ax_sprite sForretressGfx11, 0x200
+ax_sprite_terminator
+sForretressGfx12:
+.incbin "baserom.gba", 0xE49F1C, 0x200
+sForretressSprites12:
+ax_sprite sForretressGfx12, 0x200
+ax_sprite_terminator
+sForretressGfx13:
+.incbin "baserom.gba", 0xE4A12C, 0x200
+sForretressSprites13:
+ax_sprite sForretressGfx13, 0x200
+ax_sprite_terminator
+sForretressGfx14:
+.incbin "baserom.gba", 0xE4A33C, 0x200
+sForretressSprites14:
+ax_sprite sForretressGfx14, 0x200
+ax_sprite_terminator
+sForretressGfx15:
+.incbin "baserom.gba", 0xE4A54C, 0x200
+sForretressSprites15:
+ax_sprite sForretressGfx15, 0x200
+ax_sprite_terminator
+sForretressGfx16:
+.incbin "baserom.gba", 0xE4A75C, 0x200
+sForretressSprites16:
+ax_sprite sForretressGfx16, 0x200
+ax_sprite_terminator
+sForretressGfx17:
+.incbin "baserom.gba", 0xE4A96C, 0x200
+sForretressSprites17:
+ax_sprite sForretressGfx17, 0x200
+ax_sprite_terminator
+sAxPosesForretress:
+.4byte sForretressPose1
+.4byte sForretressPose2
+.4byte sForretressPose3
+.4byte sForretressPose4
+.4byte sForretressPose5
+.4byte sForretressPose6
+.4byte sForretressPose7
+.4byte sForretressPose8
+.4byte sForretressPose9
+.4byte sForretressPose10
+.4byte sForretressPose11
+.4byte sForretressPose12
+.4byte sForretressPose13
+.4byte sForretressPose14
+.4byte sForretressPose15
+.4byte sForretressPose16
+.4byte sForretressPose17
+.4byte sForretressPose18
+.4byte sForretressPose19
+.4byte sForretressPose20
+.4byte sForretressPose21
+.4byte sForretressPose22
+.4byte sForretressPose23
+.4byte sForretressPose24
+.4byte sForretressPose25
+.4byte sForretressPose26
+.4byte sForretressPose27
+.4byte sForretressPose28
+.4byte sForretressPose29
+.4byte sForretressPose30
+.4byte sForretressPose31
+.4byte sForretressPose32
+.4byte sForretressPose33
+.4byte sForretressPose34
+.4byte sForretressPose35
+.4byte sForretressPose36
+.4byte sForretressPose37
+.4byte sForretressPose38
+.4byte sForretressPose39
+.4byte sForretressPose40
+.4byte sForretressPose41
+.4byte sForretressPose42
+.4byte sForretressPose43
+.4byte sForretressPose44
+.4byte sForretressPose45
+.4byte sForretressPose46
+.4byte sForretressPose47
+.4byte sForretressPose48
+.4byte sForretressPose49
+.4byte sForretressPose50
+.4byte sForretressPose51
+.4byte sForretressPose52
+.4byte sForretressPose53
+.4byte sForretressPose54
+.4byte sForretressPose55
+.4byte sForretressPose56
+.4byte sForretressPose57
+.4byte sForretressPose58
+.4byte sForretressPose59
+.4byte sForretressPose60
+.4byte sForretressPose61
+.4byte sForretressPose62
+.4byte sForretressPose63
+.4byte sForretressPose64
+.4byte sForretressPose65
+.4byte sForretressPose66
+.4byte sForretressPose67
+.4byte sForretressPose68
+.4byte sForretressPose69
+.4byte sForretressPose70
+.4byte sForretressPose71
+.4byte sForretressPose72
+.4byte sForretressPose73
+.4byte sForretressPose74
+.4byte sForretressPose75
+.4byte sForretressPose76
+.4byte sForretressPose77
+.4byte sForretressPose78
+.4byte sForretressPose79
+.4byte sForretressPose80
+.4byte sForretressPose81
+.4byte sForretressPose82
+.4byte sForretressPose83
+.4byte sForretressPose84
+.4byte sForretressPose85
+.4byte sForretressPose86
+.4byte sForretressPose87
+.4byte sForretressPose88
+.4byte sForretressPose89
+.4byte sForretressPose90
+.4byte sForretressPose91
+.4byte sForretressPose92
+.4byte sForretressPose93
+.4byte sForretressPose94
+.4byte sForretressPose95
+.4byte sForretressPose96
+.4byte sForretressPose97
+.4byte sForretressPose98
+.4byte sForretressPose99
+.4byte sForretressPose100
+.4byte sForretressPose101
+.4byte sForretressPose102
+.4byte sForretressPose103
+.4byte sForretressPose104
+.4byte sForretressPose105
+.4byte sForretressPose106
+.4byte sForretressPose107
+.4byte sForretressPose108
+.4byte sForretressPose109
+.4byte sForretressPose110
+.4byte sForretressPose111
+.4byte sForretressPose112
+.4byte sForretressPose113
+.4byte sForretressPose114
+.4byte sForretressPose115
+.4byte sForretressPose116
+.4byte sForretressPose117
+.4byte sForretressPose118
+.4byte sForretressPose119
+.4byte sForretressPose120
+.4byte sForretressPose121
+.4byte sForretressPose122
+sAxPositionsForretress:
+.2byte   -1,   -8, 	  -6,  -10, 	   5,  -10, 	   0,  -12
+.2byte   -5,   -9, 	  -8,  -13, 	   1,   -8, 	   0,  -12
+.2byte   -7,  -12, 	  -5,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -3,  -16, 	   1,  -17, 	  -6,  -13, 	   0,  -12
+.2byte   -1,  -17, 	   4,  -16, 	  -5,  -16, 	   0,  -11
+.2byte    2,  -16, 	  -2,  -17, 	   5,  -13, 	  -1,  -12
+.2byte    6,  -12, 	   4,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    4,   -9, 	   7,  -13, 	  -2,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte   -1,   -8, 	  -6,  -10, 	   5,  -10, 	   0,  -12
+.2byte   -5,   -9, 	  -8,  -13, 	   1,   -8, 	   0,  -12
+.2byte   -7,  -12, 	  -5,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -3,  -16, 	   1,  -17, 	  -6,  -13, 	   0,  -12
+.2byte   -1,  -17, 	   4,  -16, 	  -5,  -16, 	   0,  -11
+.2byte    2,  -16, 	  -2,  -17, 	   5,  -13, 	  -1,  -12
+.2byte    6,  -12, 	   4,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    4,   -9, 	   7,  -13, 	  -2,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte   -1,   -8, 	  -6,  -10, 	   5,  -10, 	   0,  -12
+.2byte   -5,   -9, 	  -8,  -13, 	   1,   -8, 	   0,  -12
+.2byte   -7,  -12, 	  -5,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -3,  -16, 	   1,  -17, 	  -6,  -13, 	   0,  -12
+.2byte   -1,  -17, 	   4,  -16, 	  -5,  -16, 	   0,  -11
+.2byte    2,  -16, 	  -2,  -17, 	   5,  -13, 	  -1,  -12
+.2byte    6,  -12, 	   4,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    4,   -9, 	   7,  -13, 	  -2,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte   -4,   -7, 	  -7,  -11, 	   2,   -8, 	  -1,  -11
+.2byte   -4,   -8, 	  -7,  -12, 	   1,   -8, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,  -14, 	   5,  -14, 	   0,  -11
+.2byte    1,  -17, 	   6,  -15, 	  -3,  -14, 	   0,  -12
+.2byte    5,  -15, 	   3,  -17, 	   3,  -14, 	  -1,  -10
+.2byte    4,  -15, 	   0,  -15, 	   6,  -12, 	   1,  -11
+.2byte   -1,  -15, 	   4,  -14, 	  -5,  -14, 	  -1,  -10
+.2byte   -5,  -15, 	  -1,  -15, 	  -7,  -12, 	  -2,  -11
+.2byte   -6,  -15, 	  -4,  -17, 	  -4,  -14, 	   0,  -10
+.2byte   -2,  -17, 	  -7,  -15, 	   2,  -14, 	  -1,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	  -6,  -10, 	   5,  -10, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+.2byte    4,   -9, 	   7,  -13, 	  -2,   -8, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    6,  -12, 	   4,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    2,  -16, 	  -2,  -17, 	   5,  -13, 	  -1,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte   -1,  -17, 	   4,  -16, 	  -5,  -16, 	   0,  -11
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte   -3,  -16, 	   1,  -17, 	  -6,  -13, 	   0,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -7,  -12, 	  -5,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -5,   -9, 	  -8,  -13, 	   1,   -8, 	   0,  -12
+.2byte   -1,   -8, 	  -6,  -10, 	   5,  -10, 	   0,  -12
+.2byte   -5,   -9, 	  -8,  -13, 	   1,   -8, 	   0,  -12
+.2byte   -7,  -12, 	  -5,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -3,  -16, 	   1,  -17, 	  -6,  -13, 	   0,  -12
+.2byte   -1,  -17, 	   4,  -16, 	  -5,  -16, 	   0,  -11
+.2byte    2,  -16, 	  -2,  -17, 	   5,  -13, 	  -1,  -12
+.2byte    6,  -12, 	   4,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    4,   -9, 	   7,  -13, 	  -2,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	 -10,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -4,   -8, 	 -11,  -14, 	   2,   -7, 	  -1,  -12
+.2byte   -8,  -13, 	  -9,  -18, 	  -9,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	   1,  -17, 	 -11,  -13, 	   0,  -12
+.2byte    0,  -17, 	   9,  -18, 	 -10,  -18, 	  -1,  -12
+.2byte    3,  -16, 	  -2,  -17, 	  10,  -13, 	  -1,  -12
+.2byte    7,  -13, 	   8,  -18, 	   8,   -9, 	   0,  -12
+.2byte    3,   -8, 	  10,  -14, 	  -3,   -7, 	   0,  -12
+sForretressAnimTable1:
+.4byte sForretressAnims_1_1
+.4byte sForretressAnims_1_2
+.4byte sForretressAnims_1_3
+.4byte sForretressAnims_1_4
+.4byte sForretressAnims_1_5
+.4byte sForretressAnims_1_6
+.4byte sForretressAnims_1_7
+.4byte sForretressAnims_1_8
+sForretressAnimTable2:
+.4byte sForretressAnims_2_1
+.4byte sForretressAnims_2_2
+.4byte sForretressAnims_2_3
+.4byte sForretressAnims_2_4
+.4byte sForretressAnims_2_5
+.4byte sForretressAnims_2_6
+.4byte sForretressAnims_2_7
+.4byte sForretressAnims_2_8
+sForretressAnimTable3:
+.4byte sForretressAnims_3_1
+.4byte sForretressAnims_3_2
+.4byte sForretressAnims_3_3
+.4byte sForretressAnims_3_4
+.4byte sForretressAnims_3_5
+.4byte sForretressAnims_3_6
+.4byte sForretressAnims_3_7
+.4byte sForretressAnims_3_8
+sForretressAnimTable4:
+.4byte sForretressAnims_4_1
+.4byte sForretressAnims_4_2
+.4byte sForretressAnims_4_3
+.4byte sForretressAnims_4_4
+.4byte sForretressAnims_4_5
+.4byte sForretressAnims_4_6
+.4byte sForretressAnims_4_7
+.4byte sForretressAnims_4_8
+sForretressAnimTable5:
+.4byte sForretressAnims_5_1
+.4byte sForretressAnims_5_2
+.4byte sForretressAnims_5_3
+.4byte sForretressAnims_5_4
+.4byte sForretressAnims_5_5
+.4byte sForretressAnims_5_6
+.4byte sForretressAnims_5_7
+.4byte sForretressAnims_5_8
+sForretressAnimTable6:
+.4byte sForretressAnims_6_1
+.4byte sForretressAnims_6_1
+.4byte sForretressAnims_6_1
+.4byte sForretressAnims_6_1
+.4byte sForretressAnims_6_1
+.4byte sForretressAnims_6_1
+.4byte sForretressAnims_6_1
+.4byte sForretressAnims_6_1
+sForretressAnimTable7:
+.4byte sForretressAnims_7_1
+.4byte sForretressAnims_7_2
+.4byte sForretressAnims_7_3
+.4byte sForretressAnims_7_4
+.4byte sForretressAnims_7_5
+.4byte sForretressAnims_7_6
+.4byte sForretressAnims_7_7
+.4byte sForretressAnims_7_8
+sForretressAnimTable8:
+.4byte sForretressAnims_8_1
+.4byte sForretressAnims_8_2
+.4byte sForretressAnims_8_3
+.4byte sForretressAnims_8_4
+.4byte sForretressAnims_8_5
+.4byte sForretressAnims_8_6
+.4byte sForretressAnims_8_7
+.4byte sForretressAnims_8_8
+sForretressAnimTable9:
+.4byte sForretressAnims_9_1
+.4byte sForretressAnims_9_2
+.4byte sForretressAnims_9_3
+.4byte sForretressAnims_9_4
+.4byte sForretressAnims_9_5
+.4byte sForretressAnims_9_6
+.4byte sForretressAnims_9_7
+.4byte sForretressAnims_9_8
+sForretressAnimTable10:
+.4byte sForretressAnims_10_1
+.4byte sForretressAnims_10_2
+.4byte sForretressAnims_10_3
+.4byte sForretressAnims_10_4
+.4byte sForretressAnims_10_5
+.4byte sForretressAnims_10_6
+.4byte sForretressAnims_10_7
+.4byte sForretressAnims_10_8
+sForretressAnimTable11:
+.4byte sForretressAnims_11_1
+.4byte sForretressAnims_11_2
+.4byte sForretressAnims_11_3
+.4byte sForretressAnims_11_4
+.4byte sForretressAnims_11_5
+.4byte sForretressAnims_11_6
+.4byte sForretressAnims_11_7
+.4byte sForretressAnims_11_8
+sForretressAnimTable12:
+.4byte sForretressAnims_12_1
+.4byte sForretressAnims_12_2
+.4byte sForretressAnims_12_3
+.4byte sForretressAnims_12_4
+.4byte sForretressAnims_12_5
+.4byte sForretressAnims_12_6
+.4byte sForretressAnims_12_7
+.4byte sForretressAnims_12_8
+sForretressAnimTable13:
+.4byte sForretressAnims_13_1
+.4byte sForretressAnims_13_2
+.4byte sForretressAnims_13_3
+.4byte sForretressAnims_13_4
+.4byte sForretressAnims_13_5
+.4byte sForretressAnims_13_6
+.4byte sForretressAnims_13_7
+.4byte sForretressAnims_13_8
+sAxAnimationsForretress:
+.4byte sForretressAnimTable1
+.4byte sForretressAnimTable2
+.4byte sForretressAnimTable3
+.4byte sForretressAnimTable4
+.4byte sForretressAnimTable5
+.4byte sForretressAnimTable6
+.4byte sForretressAnimTable7
+.4byte sForretressAnimTable8
+.4byte sForretressAnimTable9
+.4byte sForretressAnimTable10
+.4byte sForretressAnimTable11
+.4byte sForretressAnimTable12
+.4byte sForretressAnimTable13
+sAxSpritesForretress:
+.4byte sForretressSprites1
+.4byte sForretressSprites2
+.4byte sForretressSprites3
+.4byte sForretressSprites4
+.4byte sForretressSprites5
+.4byte sForretressSprites6
+.4byte sForretressSprites7
+.4byte sForretressSprites8
+.4byte sForretressSprites9
+.4byte sForretressSprites10
+.4byte sForretressSprites11
+.4byte sForretressSprites12
+.4byte sForretressSprites13
+.4byte sForretressSprites14
+.4byte sForretressSprites15
+.4byte sForretressSprites16
+.4byte sForretressSprites17
+sAxMainForretress:
+ax_main sAxPosesForretress, sAxAnimationsForretress, 13, sAxSpritesForretress, sAxPositionsForretress

--- a/data/ax/furret.inc
+++ b/data/ax/furret.inc
@@ -1,0 +1,3545 @@
+.global gAxFurret
+gAxFurret:
+ax_siro sAxMainFurret
+sFurretPose1:
+ax_pose 0, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose2:
+ax_pose 1, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose3:
+ax_pose 2, 0x01de, 0x00fc, 0x4c00
+ax_pose 3, 0x81e6, 0x80f8, 0x4c01
+ax_pose_terminator
+sFurretPose4:
+ax_pose 4, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose5:
+ax_pose 5, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose6:
+ax_pose 6, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose7:
+ax_pose 7, 0x81ee, 0x110e, 0x4c00
+ax_pose 8, 0x81e6, 0x90fe, 0x4c02
+ax_pose 9, 0x81e6, 0x50f6, 0x4c0a
+ax_pose 10, 0x81ee, 0x10ee, 0x4c0e
+ax_pose_terminator
+sFurretPose8:
+ax_pose 11, 0x81f6, 0x10e8, 0x4c00
+ax_pose 12, 0x81e6, 0x9100, 0x4c02
+ax_pose 13, 0x81e6, 0x50f8, 0x4c0a
+ax_pose 14, 0x81f6, 0x10f0, 0x4c0e
+ax_pose_terminator
+sFurretPose9:
+ax_pose 15, 0x81e6, 0x10ef, 0x4c00
+ax_pose 16, 0x81e6, 0x9107, 0x4c02
+ax_pose 17, 0x81e6, 0x50ff, 0x4c0a
+ax_pose 18, 0x81e6, 0x10f7, 0x4c0e
+ax_pose_terminator
+sFurretPose10:
+ax_pose 19, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose11:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose12:
+ax_pose 21, 0x81ee, 0x110f, 0x4c00
+ax_pose 22, 0x81e6, 0x90ff, 0x4c02
+ax_pose 23, 0x81e6, 0x50f7, 0x4c0a
+ax_pose 24, 0x81ee, 0x10ef, 0x4c0e
+ax_pose_terminator
+sFurretPose13:
+ax_pose 25, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose14:
+ax_pose 26, 0x01f6, 0x40f8, 0x4c00
+ax_pose 27, 0x41e6, 0x80f0, 0x4c04
+ax_pose 28, 0x0206, 0x00fc, 0x4c0c
+ax_pose_terminator
+sFurretPose15:
+ax_pose 29, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose16:
+ax_pose 19, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose17:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose18:
+ax_pose 21, 0x81ee, 0x00e9, 0x4c00
+ax_pose 22, 0x81e6, 0x80f1, 0x4c02
+ax_pose 23, 0x81e6, 0x4101, 0x4c0a
+ax_pose 24, 0x81ee, 0x0109, 0x4c0e
+ax_pose_terminator
+sFurretPose19:
+ax_pose 7, 0x81ee, 0x00ea, 0x4c00
+ax_pose 8, 0x81e6, 0x80f2, 0x4c02
+ax_pose 9, 0x81e6, 0x4102, 0x4c0a
+ax_pose 10, 0x81ee, 0x010a, 0x4c0e
+ax_pose_terminator
+sFurretPose20:
+ax_pose 11, 0x81f6, 0x0110, 0x4c00
+ax_pose 12, 0x81e6, 0x80f0, 0x4c02
+ax_pose 13, 0x81e6, 0x4100, 0x4c0a
+ax_pose 14, 0x81f6, 0x0108, 0x4c0e
+ax_pose_terminator
+sFurretPose21:
+ax_pose 30, 0x01ed, 0x0109, 0x4c00
+ax_pose 16, 0x81e6, 0x80e9, 0x4c01
+ax_pose 17, 0x81e6, 0x40f9, 0x4c09
+ax_pose 18, 0x81e6, 0x0101, 0x4c0d
+ax_pose_terminator
+sFurretPose22:
+ax_pose 4, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose23:
+ax_pose 5, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose24:
+ax_pose 6, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sFurretPose25:
+ax_pose 0, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose26:
+ax_pose 1, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose27:
+ax_pose 2, 0x01de, 0x00fc, 0x4c00
+ax_pose 3, 0x81e6, 0x80f8, 0x4c01
+ax_pose_terminator
+sFurretPose28:
+ax_pose 31, 0x01e5, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose29:
+ax_pose 4, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose30:
+ax_pose 5, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose31:
+ax_pose 6, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose32:
+ax_pose 32, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose33:
+ax_pose 7, 0x81ee, 0x110c, 0x4c00
+ax_pose 8, 0x81e6, 0x90fc, 0x4c02
+ax_pose 9, 0x81e6, 0x50f4, 0x4c0a
+ax_pose 10, 0x81ee, 0x10ec, 0x4c0e
+ax_pose_terminator
+sFurretPose34:
+ax_pose 11, 0x81f6, 0x10e6, 0x4c00
+ax_pose 12, 0x81e6, 0x90fe, 0x4c02
+ax_pose 13, 0x81e6, 0x50f6, 0x4c0a
+ax_pose 14, 0x81f6, 0x10ee, 0x4c0e
+ax_pose_terminator
+sFurretPose35:
+ax_pose 15, 0x81e7, 0x10ed, 0x4c00
+ax_pose 16, 0x81e7, 0x9105, 0x4c02
+ax_pose 17, 0x81e7, 0x50fd, 0x4c0a
+ax_pose 18, 0x81e7, 0x10f5, 0x4c0e
+ax_pose_terminator
+sFurretPose36:
+ax_pose 33, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose37:
+ax_pose 19, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose38:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose39:
+ax_pose 21, 0x81ee, 0x110b, 0x4c00
+ax_pose 22, 0x81e6, 0x90fb, 0x4c02
+ax_pose 23, 0x81e6, 0x50f3, 0x4c0a
+ax_pose 24, 0x81ee, 0x10eb, 0x4c0e
+ax_pose_terminator
+sFurretPose40:
+ax_pose 34, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose41:
+ax_pose 25, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose42:
+ax_pose 26, 0x01f6, 0x40f8, 0x4c00
+ax_pose 27, 0x41e6, 0x80f0, 0x4c04
+ax_pose 28, 0x0206, 0x00fc, 0x4c0c
+ax_pose_terminator
+sFurretPose43:
+ax_pose 29, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose44:
+ax_pose 35, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose45:
+ax_pose 19, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose46:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose47:
+ax_pose 21, 0x81ee, 0x00ed, 0x4c00
+ax_pose 22, 0x81e6, 0x80f5, 0x4c02
+ax_pose 23, 0x81e6, 0x4105, 0x4c0a
+ax_pose 24, 0x81ee, 0x010d, 0x4c0e
+ax_pose_terminator
+sFurretPose48:
+ax_pose 34, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose49:
+ax_pose 7, 0x81ee, 0x00ec, 0x4c00
+ax_pose 8, 0x81e6, 0x80f4, 0x4c02
+ax_pose 9, 0x81e6, 0x4104, 0x4c0a
+ax_pose 10, 0x81ee, 0x010c, 0x4c0e
+ax_pose_terminator
+sFurretPose50:
+ax_pose 11, 0x81f6, 0x0112, 0x4c00
+ax_pose 12, 0x81e6, 0x80f2, 0x4c02
+ax_pose 13, 0x81e6, 0x4102, 0x4c0a
+ax_pose 14, 0x81f6, 0x010a, 0x4c0e
+ax_pose_terminator
+sFurretPose51:
+ax_pose 15, 0x81e7, 0x010b, 0x4c00
+ax_pose 16, 0x81e7, 0x80eb, 0x4c02
+ax_pose 17, 0x81e7, 0x40fb, 0x4c0a
+ax_pose 18, 0x81e7, 0x0103, 0x4c0e
+ax_pose_terminator
+sFurretPose52:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose53:
+ax_pose 4, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose54:
+ax_pose 5, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose55:
+ax_pose 6, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose56:
+ax_pose 32, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose57:
+ax_pose 0, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose58:
+ax_pose 36, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose59:
+ax_pose 37, 0x81ea, 0x8105, 0x4c00
+ax_pose 38, 0x01fa, 0x40f5, 0x4c08
+ax_pose 39, 0x01da, 0x4105, 0x4c0c
+ax_pose 40, 0x01eb, 0x80f4, 0x4c10
+ax_pose_terminator
+sFurretPose60:
+ax_pose 40, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose61:
+ax_pose 4, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose62:
+ax_pose 41, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose63:
+ax_pose 42, 0x01e4, 0x90ee, 0x4c00
+ax_pose 43, 0x41f7, 0x90ef, 0x4c10
+ax_pose 44, 0x81ef, 0x10e7, 0x4c18
+ax_pose_terminator
+sFurretPose64:
+ax_pose 42, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose65:
+ax_pose 7, 0x81ee, 0x110e, 0x4c00
+ax_pose 8, 0x81e6, 0x90fe, 0x4c02
+ax_pose 9, 0x81e6, 0x50f6, 0x4c0a
+ax_pose 10, 0x81ee, 0x10ee, 0x4c0e
+ax_pose_terminator
+sFurretPose66:
+ax_pose 45, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose67:
+ax_pose 46, 0x01f6, 0x50f9, 0x4c00
+ax_pose 47, 0x01f6, 0x50e9, 0x4c04
+ax_pose 48, 0x01e2, 0x90f2, 0x4c08
+ax_pose 49, 0x01f6, 0x5109, 0x4c18
+ax_pose_terminator
+sFurretPose68:
+ax_pose 48, 0x01e2, 0x90f2, 0x4c00
+ax_pose_terminator
+sFurretPose69:
+ax_pose 19, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose70:
+ax_pose 50, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sFurretPose71:
+ax_pose 51, 0x01f4, 0x50f2, 0x4c00
+ax_pose 52, 0x01fc, 0x10ea, 0x4c04
+ax_pose 53, 0x01fc, 0x1102, 0x4c05
+ax_pose 54, 0x01e8, 0x90ec, 0x4c06
+ax_pose 55, 0x81f4, 0x110a, 0x4c16
+ax_pose_terminator
+sFurretPose72:
+ax_pose 54, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sFurretPose73:
+ax_pose 25, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose74:
+ax_pose 56, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose75:
+ax_pose 57, 0x01e7, 0x80ec, 0x4c00
+ax_pose 58, 0x01e8, 0x80f1, 0x4c10
+ax_pose_terminator
+sFurretPose76:
+ax_pose 58, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose77:
+ax_pose 19, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose78:
+ax_pose 50, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sFurretPose79:
+ax_pose 51, 0x01f4, 0x40fe, 0x4c00
+ax_pose 52, 0x01fc, 0x010e, 0x4c04
+ax_pose 53, 0x01fc, 0x00f6, 0x4c05
+ax_pose 54, 0x01e8, 0x80f4, 0x4c06
+ax_pose 55, 0x81f4, 0x00ee, 0x4c16
+ax_pose_terminator
+sFurretPose80:
+ax_pose 54, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose81:
+ax_pose 7, 0x81ee, 0x00ea, 0x4c00
+ax_pose 8, 0x81e6, 0x80f2, 0x4c02
+ax_pose 9, 0x81e6, 0x4102, 0x4c0a
+ax_pose 10, 0x81ee, 0x010a, 0x4c0e
+ax_pose_terminator
+sFurretPose82:
+ax_pose 45, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose83:
+ax_pose 46, 0x01f9, 0x40f9, 0x4c00
+ax_pose 48, 0x01e2, 0x80ee, 0x4c04
+ax_pose 47, 0x01f9, 0x4109, 0x4c14
+ax_pose 49, 0x01f9, 0x40e9, 0x4c18
+ax_pose_terminator
+sFurretPose84:
+ax_pose 48, 0x01e2, 0x80ee, 0x4c00
+ax_pose_terminator
+sFurretPose85:
+ax_pose 4, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose86:
+ax_pose 41, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose87:
+ax_pose 42, 0x01e4, 0x80f2, 0x4c00
+ax_pose 43, 0x41f7, 0x80f1, 0x4c10
+ax_pose 44, 0x81ef, 0x0111, 0x4c18
+ax_pose_terminator
+sFurretPose88:
+ax_pose 42, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose89:
+ax_pose 0, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose90:
+ax_pose 1, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose91:
+ax_pose 2, 0x01de, 0x00fc, 0x4c00
+ax_pose 3, 0x81e6, 0x80f8, 0x4c01
+ax_pose_terminator
+sFurretPose92:
+ax_pose 59, 0x81e3, 0x80f9, 0x4c00
+ax_pose 60, 0x01db, 0x00f9, 0x4c08
+ax_pose_terminator
+sFurretPose93:
+ax_pose 61, 0x81e3, 0x80f8, 0x4c00
+ax_pose 60, 0x01db, 0x00f9, 0x4c08
+ax_pose_terminator
+sFurretPose94:
+ax_pose 31, 0x01e5, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose95:
+ax_pose 62, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose96:
+ax_pose 4, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose97:
+ax_pose 5, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose98:
+ax_pose 6, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose99:
+ax_pose 63, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose100:
+ax_pose 64, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose101:
+ax_pose 32, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose102:
+ax_pose 65, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sFurretPose103:
+ax_pose 7, 0x81ee, 0x110e, 0x4c00
+ax_pose 8, 0x81e6, 0x90fe, 0x4c02
+ax_pose 9, 0x81e6, 0x50f6, 0x4c0a
+ax_pose 10, 0x81ee, 0x10ee, 0x4c0e
+ax_pose_terminator
+sFurretPose104:
+ax_pose 11, 0x81f6, 0x10e8, 0x4c00
+ax_pose 12, 0x81e6, 0x9100, 0x4c02
+ax_pose 13, 0x81e6, 0x50f8, 0x4c0a
+ax_pose 14, 0x81f6, 0x10f0, 0x4c0e
+ax_pose_terminator
+sFurretPose105:
+ax_pose 15, 0x81e6, 0x10ef, 0x4c00
+ax_pose 16, 0x81e6, 0x9107, 0x4c02
+ax_pose 17, 0x81e6, 0x50ff, 0x4c0a
+ax_pose 18, 0x81e6, 0x10f7, 0x4c0e
+ax_pose_terminator
+sFurretPose106:
+ax_pose 66, 0x41f2, 0x90f3, 0x4c00
+ax_pose 67, 0x01e2, 0x50f3, 0x4c08
+ax_pose 68, 0x01ea, 0x10eb, 0x4c0c
+ax_pose_terminator
+sFurretPose107:
+ax_pose 69, 0x01e6, 0x90f3, 0x4c00
+ax_pose 68, 0x01ea, 0x10eb, 0x4c10
+ax_pose_terminator
+sFurretPose108:
+ax_pose 33, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose109:
+ax_pose 70, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose110:
+ax_pose 19, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose111:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose112:
+ax_pose 21, 0x81ee, 0x110f, 0x4c00
+ax_pose 22, 0x81e6, 0x90ff, 0x4c02
+ax_pose 23, 0x81e6, 0x50f7, 0x4c0a
+ax_pose 24, 0x81ee, 0x10ef, 0x4c0e
+ax_pose_terminator
+sFurretPose113:
+ax_pose 71, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose114:
+ax_pose 72, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose115:
+ax_pose 34, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose116:
+ax_pose 73, 0x01e6, 0x90e8, 0x4c00
+ax_pose_terminator
+sFurretPose117:
+ax_pose 25, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose118:
+ax_pose 26, 0x01f6, 0x40f8, 0x4c00
+ax_pose 27, 0x41e6, 0x80f0, 0x4c04
+ax_pose 28, 0x0206, 0x00fc, 0x4c0c
+ax_pose_terminator
+sFurretPose119:
+ax_pose 29, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose120:
+ax_pose 74, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose121:
+ax_pose 75, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose122:
+ax_pose 35, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose123:
+ax_pose 76, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose124:
+ax_pose 19, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose125:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose126:
+ax_pose 21, 0x81ee, 0x00e9, 0x4c00
+ax_pose 22, 0x81e6, 0x80f1, 0x4c02
+ax_pose 23, 0x81e6, 0x4101, 0x4c0a
+ax_pose 24, 0x81ee, 0x0109, 0x4c0e
+ax_pose_terminator
+sFurretPose127:
+ax_pose 71, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose128:
+ax_pose 72, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose129:
+ax_pose 34, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose130:
+ax_pose 73, 0x01e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose131:
+ax_pose 7, 0x81ee, 0x00ea, 0x4c00
+ax_pose 8, 0x81e6, 0x80f2, 0x4c02
+ax_pose 9, 0x81e6, 0x4102, 0x4c0a
+ax_pose 10, 0x81ee, 0x010a, 0x4c0e
+ax_pose_terminator
+sFurretPose132:
+ax_pose 11, 0x81f6, 0x0110, 0x4c00
+ax_pose 12, 0x81e6, 0x80f0, 0x4c02
+ax_pose 13, 0x81e6, 0x4100, 0x4c0a
+ax_pose 14, 0x81f6, 0x0108, 0x4c0e
+ax_pose_terminator
+sFurretPose133:
+ax_pose 30, 0x01ed, 0x0109, 0x4c00
+ax_pose 16, 0x81e6, 0x80e9, 0x4c01
+ax_pose 17, 0x81e6, 0x40f9, 0x4c09
+ax_pose 18, 0x81e6, 0x0101, 0x4c0d
+ax_pose_terminator
+sFurretPose134:
+ax_pose 66, 0x41f2, 0x80ed, 0x4c00
+ax_pose 67, 0x01e2, 0x40fd, 0x4c08
+ax_pose 68, 0x01ea, 0x010d, 0x4c0c
+ax_pose_terminator
+sFurretPose135:
+ax_pose 69, 0x01e6, 0x80ed, 0x4c00
+ax_pose 68, 0x01ea, 0x010d, 0x4c10
+ax_pose_terminator
+sFurretPose136:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose137:
+ax_pose 70, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose138:
+ax_pose 4, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose139:
+ax_pose 5, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose140:
+ax_pose 6, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sFurretPose141:
+ax_pose 63, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose142:
+ax_pose 64, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose143:
+ax_pose 32, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose144:
+ax_pose 65, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose145:
+ax_pose 0, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose146:
+ax_pose 1, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose147:
+ax_pose 2, 0x01de, 0x00fc, 0x4c00
+ax_pose 3, 0x81e6, 0x80f8, 0x4c01
+ax_pose_terminator
+sFurretPose148:
+ax_pose 59, 0x81e3, 0x80f9, 0x4c00
+ax_pose 60, 0x01db, 0x00f9, 0x4c08
+ax_pose_terminator
+sFurretPose149:
+ax_pose 61, 0x81e3, 0x80f8, 0x4c00
+ax_pose 60, 0x01db, 0x00f9, 0x4c08
+ax_pose_terminator
+sFurretPose150:
+ax_pose 31, 0x01e8, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose151:
+ax_pose 62, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose152:
+ax_pose 4, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose153:
+ax_pose 5, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose154:
+ax_pose 6, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sFurretPose155:
+ax_pose 63, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose156:
+ax_pose 64, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose157:
+ax_pose 32, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose158:
+ax_pose 65, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sFurretPose159:
+ax_pose 7, 0x81ee, 0x110e, 0x4c00
+ax_pose 8, 0x81e6, 0x90fe, 0x4c02
+ax_pose 9, 0x81e6, 0x50f6, 0x4c0a
+ax_pose 10, 0x81ee, 0x10ee, 0x4c0e
+ax_pose_terminator
+sFurretPose160:
+ax_pose 11, 0x81f6, 0x10e8, 0x4c00
+ax_pose 12, 0x81e6, 0x9100, 0x4c02
+ax_pose 13, 0x81e6, 0x50f8, 0x4c0a
+ax_pose 14, 0x81f6, 0x10f0, 0x4c0e
+ax_pose_terminator
+sFurretPose161:
+ax_pose 15, 0x81e6, 0x10ef, 0x4c00
+ax_pose 16, 0x81e6, 0x9107, 0x4c02
+ax_pose 17, 0x81e6, 0x50ff, 0x4c0a
+ax_pose 18, 0x81e6, 0x10f7, 0x4c0e
+ax_pose_terminator
+sFurretPose162:
+ax_pose 66, 0x41f2, 0x90f3, 0x4c00
+ax_pose 67, 0x01e2, 0x50f3, 0x4c08
+ax_pose 68, 0x01ea, 0x10eb, 0x4c0c
+ax_pose_terminator
+sFurretPose163:
+ax_pose 69, 0x01e6, 0x90f3, 0x4c00
+ax_pose 68, 0x01ea, 0x10eb, 0x4c10
+ax_pose_terminator
+sFurretPose164:
+ax_pose 33, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose165:
+ax_pose 70, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose166:
+ax_pose 19, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose167:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose168:
+ax_pose 21, 0x81ee, 0x110f, 0x4c00
+ax_pose 22, 0x81e6, 0x90ff, 0x4c02
+ax_pose 23, 0x81e6, 0x50f7, 0x4c0a
+ax_pose 24, 0x81ee, 0x10ef, 0x4c0e
+ax_pose_terminator
+sFurretPose169:
+ax_pose 71, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose170:
+ax_pose 72, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose171:
+ax_pose 34, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sFurretPose172:
+ax_pose 73, 0x01e6, 0x90e8, 0x4c00
+ax_pose_terminator
+sFurretPose173:
+ax_pose 25, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose174:
+ax_pose 26, 0x01f6, 0x40f8, 0x4c00
+ax_pose 27, 0x41e6, 0x80f0, 0x4c04
+ax_pose 28, 0x0206, 0x00fc, 0x4c0c
+ax_pose_terminator
+sFurretPose175:
+ax_pose 29, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose176:
+ax_pose 74, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose177:
+ax_pose 75, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose178:
+ax_pose 35, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose179:
+ax_pose 76, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose180:
+ax_pose 19, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose181:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose182:
+ax_pose 21, 0x81ee, 0x00e9, 0x4c00
+ax_pose 22, 0x81e6, 0x80f1, 0x4c02
+ax_pose 23, 0x81e6, 0x4101, 0x4c0a
+ax_pose 24, 0x81ee, 0x0109, 0x4c0e
+ax_pose_terminator
+sFurretPose183:
+ax_pose 71, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose184:
+ax_pose 72, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose185:
+ax_pose 34, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose186:
+ax_pose 73, 0x01e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose187:
+ax_pose 7, 0x81ee, 0x00ea, 0x4c00
+ax_pose 8, 0x81e6, 0x80f2, 0x4c02
+ax_pose 9, 0x81e6, 0x4102, 0x4c0a
+ax_pose 10, 0x81ee, 0x010a, 0x4c0e
+ax_pose_terminator
+sFurretPose188:
+ax_pose 11, 0x81f6, 0x0110, 0x4c00
+ax_pose 12, 0x81e6, 0x80f0, 0x4c02
+ax_pose 13, 0x81e6, 0x4100, 0x4c0a
+ax_pose 14, 0x81f6, 0x0108, 0x4c0e
+ax_pose_terminator
+sFurretPose189:
+ax_pose 30, 0x01ed, 0x0109, 0x4c00
+ax_pose 16, 0x81e6, 0x80e9, 0x4c01
+ax_pose 17, 0x81e6, 0x40f9, 0x4c09
+ax_pose 18, 0x81e6, 0x0101, 0x4c0d
+ax_pose_terminator
+sFurretPose190:
+ax_pose 66, 0x41f2, 0x80ed, 0x4c00
+ax_pose 67, 0x01e2, 0x40fd, 0x4c08
+ax_pose 68, 0x01ea, 0x010d, 0x4c0c
+ax_pose_terminator
+sFurretPose191:
+ax_pose 69, 0x01e6, 0x80ed, 0x4c00
+ax_pose 68, 0x01ea, 0x010d, 0x4c10
+ax_pose_terminator
+sFurretPose192:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose193:
+ax_pose 70, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose194:
+ax_pose 4, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose195:
+ax_pose 5, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose196:
+ax_pose 6, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sFurretPose197:
+ax_pose 63, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose198:
+ax_pose 64, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose199:
+ax_pose 32, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose200:
+ax_pose 65, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose201:
+ax_pose 77, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose202:
+ax_pose 78, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sFurretPose203:
+ax_pose 79, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose204:
+ax_pose 80, 0x01e2, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose205:
+ax_pose 81, 0x01e3, 0x90f2, 0x4c00
+ax_pose_terminator
+sFurretPose206:
+ax_pose 82, 0x01e4, 0x90f2, 0x4c00
+ax_pose_terminator
+sFurretPose207:
+ax_pose 83, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose208:
+ax_pose 82, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose209:
+ax_pose 81, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose210:
+ax_pose 80, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose211:
+ax_pose 62, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose212:
+ax_pose 65, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose213:
+ax_pose 70, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose214:
+ax_pose 73, 0x01e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose215:
+ax_pose 76, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose216:
+ax_pose 73, 0x01e6, 0x90e8, 0x4c00
+ax_pose_terminator
+sFurretPose217:
+ax_pose 70, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose218:
+ax_pose 65, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sFurretPose219:
+ax_pose 62, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose220:
+ax_pose 65, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose221:
+ax_pose 70, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose222:
+ax_pose 73, 0x01e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose223:
+ax_pose 76, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose224:
+ax_pose 73, 0x01e6, 0x90e8, 0x4c00
+ax_pose_terminator
+sFurretPose225:
+ax_pose 70, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose226:
+ax_pose 65, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sFurretPose227:
+ax_pose 31, 0x01e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose228:
+ax_pose 32, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose229:
+ax_pose 33, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose230:
+ax_pose 34, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sFurretPose231:
+ax_pose 35, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose232:
+ax_pose 34, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sFurretPose233:
+ax_pose 33, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sFurretPose234:
+ax_pose 32, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose235:
+ax_pose 62, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose236:
+ax_pose 31, 0x01e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose237:
+ax_pose 59, 0x81e3, 0x80f9, 0x4c00
+ax_pose 60, 0x01db, 0x00f9, 0x4c08
+ax_pose_terminator
+sFurretPose238:
+ax_pose 65, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sFurretPose239:
+ax_pose 32, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose240:
+ax_pose 63, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose241:
+ax_pose 70, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose242:
+ax_pose 33, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose243:
+ax_pose 66, 0x41f2, 0x90ee, 0x4c00
+ax_pose 67, 0x01e2, 0x50ee, 0x4c08
+ax_pose 68, 0x01ea, 0x10e6, 0x4c0c
+ax_pose_terminator
+sFurretPose244:
+ax_pose 73, 0x01e6, 0x90e8, 0x4c00
+ax_pose_terminator
+sFurretPose245:
+ax_pose 34, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose246:
+ax_pose 71, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sFurretPose247:
+ax_pose 76, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose248:
+ax_pose 35, 0x81e6, 0x80f9, 0x4c00
+ax_pose_terminator
+sFurretPose249:
+ax_pose 74, 0x01e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose250:
+ax_pose 73, 0x01e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose251:
+ax_pose 34, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose252:
+ax_pose 71, 0x01e7, 0x80f6, 0x4c00
+ax_pose_terminator
+sFurretPose253:
+ax_pose 70, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose254:
+ax_pose 33, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose255:
+ax_pose 66, 0x41f2, 0x80f2, 0x4c00
+ax_pose 67, 0x01e2, 0x4102, 0x4c08
+ax_pose 68, 0x01ea, 0x0112, 0x4c0c
+ax_pose_terminator
+sFurretPose256:
+ax_pose 65, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sFurretPose257:
+ax_pose 32, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose258:
+ax_pose 63, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose259:
+ax_pose 0, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sFurretPose260:
+ax_pose 4, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose261:
+ax_pose 7, 0x81ee, 0x00ec, 0x4c00
+ax_pose 8, 0x81e6, 0x80f4, 0x4c02
+ax_pose 9, 0x81e6, 0x4104, 0x4c0a
+ax_pose 10, 0x81ee, 0x010c, 0x4c0e
+ax_pose_terminator
+sFurretPose262:
+ax_pose 19, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sFurretPose263:
+ax_pose 25, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sFurretPose264:
+ax_pose 19, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose265:
+ax_pose 7, 0x81ee, 0x110c, 0x4c00
+ax_pose 8, 0x81e6, 0x90fc, 0x4c02
+ax_pose 9, 0x81e6, 0x50f4, 0x4c0a
+ax_pose 10, 0x81ee, 0x10ec, 0x4c0e
+ax_pose_terminator
+sFurretPose266:
+ax_pose 4, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sFurretPose267:
+ax_pose 62, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose268:
+ax_pose 65, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose269:
+ax_pose 70, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose270:
+ax_pose 73, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sFurretPose271:
+ax_pose 76, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sFurretPose272:
+ax_pose 73, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose273:
+ax_pose 70, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sFurretPose274:
+ax_pose 65, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+.align 2
+sFurretAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 1,
+ax_anim 4, 0, 1, 0, -1, 0, 2,
+ax_anim 4, 0, 2, 0, -6, 0, 3,
+ax_anim 4, 0, 2, 0, 0, 0, 4,
+ax_anim 4, 0, 2, 0, 1, 0, 4,
+ax_anim 6, 0, 0, 0, 2, 0, 2,
+ax_anim_terminator
+sFurretAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 1, -1, 1, 1,
+ax_anim 4, 0, 4, 2, -1, 2, 2,
+ax_anim 4, 0, 5, 4, -1, 3, 3,
+ax_anim 4, 0, 5, 5, 3, 4, 4,
+ax_anim 4, 0, 5, 6, 6, 5, 5,
+ax_anim 6, 0, 3, 4, 4, 4, 4,
+ax_anim_terminator
+sFurretAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 4, 0, 7, 1, 0, 1, 0,
+ax_anim 4, 0, 7, 2, -1, 2, 0,
+ax_anim 4, 0, 8, 2, -1, 3, 0,
+ax_anim 4, 0, 8, 3, 0, 4, 0,
+ax_anim 4, 0, 8, 4, 1, 5, 0,
+ax_anim 6, 0, 6, 3, 0, 3, 0,
+ax_anim_terminator
+sFurretAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, -1, 2, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 1, -1,
+ax_anim 4, 0, 10, 1, -3, 2, -2,
+ax_anim 4, 0, 11, 2, -6, 3, -3,
+ax_anim 4, 0, 11, 4, -4, 4, -4,
+ax_anim 4, 0, 11, 5, -3, 5, -5,
+ax_anim 6, 0, 9, 3, -3, 3, -3,
+ax_anim_terminator
+sFurretAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, -1,
+ax_anim 4, 0, 13, 0, 0, 0, -2,
+ax_anim 4, 0, 13, 0, -1, 0, -3,
+ax_anim 4, 0, 14, 0, -4, 0, -4,
+ax_anim 4, 0, 14, 0, -3, 0, -5,
+ax_anim 4, 0, 14, 0, -1, 0, -6,
+ax_anim 6, 0, 12, 0, -2, 0, -2,
+ax_anim_terminator
+sFurretAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 1, 2, 0, 0,
+ax_anim 4, 0, 16, 0, 0, -1, -1,
+ax_anim 4, 0, 16, -1, -3, -2, -2,
+ax_anim 4, 0, 17, -2, -6, -3, -3,
+ax_anim 4, 0, 17, -4, -4, -4, -4,
+ax_anim 4, 0, 17, -5, -3, -5, -5,
+ax_anim 6, 0, 15, -3, -3, -3, -3,
+ax_anim_terminator
+sFurretAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 4, 0, 19, -1, 0, -1, 0,
+ax_anim 4, 0, 19, -2, -1, -2, 0,
+ax_anim 4, 0, 20, -2, -1, -3, 0,
+ax_anim 4, 0, 20, -3, 0, -4, 0,
+ax_anim 4, 0, 20, -4, 1, -5, 0,
+ax_anim 6, 0, 18, -3, 0, -3, 0,
+ax_anim_terminator
+sFurretAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -1, -1, -1, 1,
+ax_anim 4, 0, 22, -2, -1, -2, 2,
+ax_anim 4, 0, 23, -4, -1, -3, 3,
+ax_anim 4, 0, 23, -5, 3, -4, 4,
+ax_anim 4, 0, 23, -6, 6, -5, 5,
+ax_anim 6, 0, 21, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sFurretAnims_2_1:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, -5, 0, 3,
+ax_anim 2, 2, 24, 0, 2, 0, 10,
+ax_anim 2, 0, 24, 0, 10, 0, 13,
+ax_anim 2, 0, 26, 0, 15, 0, 15,
+ax_anim 2, 1, 26, 1, 15, 1, 15,
+ax_anim 2, 0, 26, 0, 15, 0, 15,
+ax_anim 2, 0, 26, 1, 15, 1, 15,
+ax_anim 2, 0, 25, 0, 3, 0, 6,
+ax_anim_terminator
+sFurretAnims_2_2:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 4, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 2, 29, 6, 2, 6, 6,
+ax_anim 2, 0, 28, 10, 3, 10, 10,
+ax_anim 2, 0, 30, 15, 22, 15, 15,
+ax_anim 2, 1, 30, 14, 23, 14, 16,
+ax_anim 2, 0, 30, 15, 22, 15, 15,
+ax_anim 2, 0, 30, 14, 23, 14, 16,
+ax_anim 2, 0, 29, 6, 3, 6, 6,
+ax_anim_terminator
+sFurretAnims_2_3:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 4, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, -2, 0, 0,
+ax_anim 2, 2, 33, 4, -5, 4, 0,
+ax_anim 2, 0, 32, 8, -9, 8, 0,
+ax_anim 2, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 1, 34, 10, -1, 10, -1,
+ax_anim 2, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 10, -1, 10, -1,
+ax_anim 2, 0, 33, 4, -2, 4, 0,
+ax_anim_terminator
+sFurretAnims_2_4:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -4, 0, 0,
+ax_anim 2, 2, 37, 4, -10, 4, -4,
+ax_anim 2, 0, 36, 12, -23, 12, -12,
+ax_anim 2, 0, 38, 17, -17, 17, -17,
+ax_anim 2, 1, 38, 18, -16, 18, -16,
+ax_anim 2, 0, 38, 17, -17, 17, -17,
+ax_anim 2, 0, 38, 18, -16, 18, -16,
+ax_anim 2, 0, 37, 6, -9, 6, -6,
+ax_anim_terminator
+sFurretAnims_2_5:
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 4, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, -3, 0, 0,
+ax_anim 2, 2, 41, 0, -8, 0, -6,
+ax_anim 2, 0, 40, 0, -18, 0, -10,
+ax_anim 2, 0, 42, 0, -19, 0, -19,
+ax_anim 2, 1, 42, 1, -19, 1, -19,
+ax_anim 2, 0, 42, 0, -19, 0, -19,
+ax_anim 2, 0, 42, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -6, 0, -6,
+ax_anim_terminator
+sFurretAnims_2_6:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 4, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -4, 0, 0,
+ax_anim 2, 2, 45, -4, -10, -4, -4,
+ax_anim 2, 0, 44, -12, -23, -12, -12,
+ax_anim 2, 0, 46, -17, -17, -17, -17,
+ax_anim 2, 1, 46, -18, -16, -18, -16,
+ax_anim 2, 0, 46, -17, -17, -17, -17,
+ax_anim 2, 0, 46, -18, -16, -18, -16,
+ax_anim 2, 0, 45, -6, -9, -6, -6,
+ax_anim_terminator
+sFurretAnims_2_7:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 4, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 2, 49, -4, -5, -4, 0,
+ax_anim 2, 0, 48, -8, -9, -8, 0,
+ax_anim 2, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 1, 50, -10, -1, -10, -1,
+ax_anim 2, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 50, -10, -1, -10, -1,
+ax_anim 2, 0, 49, -4, -2, -4, 0,
+ax_anim_terminator
+sFurretAnims_2_8:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 4, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 2, 53, -6, 2, -6, 6,
+ax_anim 2, 0, 52, -10, 3, -10, 10,
+ax_anim 2, 0, 54, -15, 22, -15, 15,
+ax_anim 2, 1, 54, -14, 23, -14, 16,
+ax_anim 2, 0, 54, -15, 22, -15, 15,
+ax_anim 2, 0, 54, -14, 23, -14, 16,
+ax_anim 2, 0, 53, -6, 3, -6, 6,
+ax_anim_terminator
+.align 2
+sFurretAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 6, 0, 57, 0, -3, 0, -3,
+ax_anim 1, 2, 85, 0, 5, 0, 5,
+ax_anim 1, 0, 81, 0, 9, 0, 9,
+ax_anim 2, 0, 58, 0, 14, 0, 11,
+ax_anim 2, 1, 87, -1, 14, -1, 11,
+ax_anim 2, 0, 87, 0, 14, 0, 11,
+ax_anim 2, 0, 87, -1, 14, -1, 11,
+ax_anim 2, 0, 87, 0, 14, 0, 11,
+ax_anim 2, 0, 87, -1, 14, -1, 11,
+ax_anim 2, 0, 87, 0, 14, 0, 11,
+ax_anim 2, 0, 56, 0, 8, 0, 8,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sFurretAnims_3_2:
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 6, 0, 61, -3, -3, -3, -3,
+ax_anim 1, 2, 65, 5, 5, 5, 5,
+ax_anim 1, 0, 65, 12, 12, 9, 8,
+ax_anim 2, 0, 62, 15, 16, 15, 16,
+ax_anim 2, 1, 67, 14, 16, 14, 16,
+ax_anim 2, 0, 67, 15, 16, 15, 16,
+ax_anim 2, 0, 67, 14, 16, 14, 16,
+ax_anim 2, 0, 67, 15, 16, 15, 16,
+ax_anim 2, 0, 67, 14, 16, 14, 16,
+ax_anim 2, 0, 67, 15, 16, 15, 16,
+ax_anim 2, 0, 60, 8, 7, 8, 7,
+ax_anim 2, 0, 60, 3, 3, 3, 3,
+ax_anim_terminator
+sFurretAnims_3_3:
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 6, 0, 65, -3, 0, -3, 0,
+ax_anim 1, 2, 69, 1, 0, 1, 0,
+ax_anim 1, 0, 69, 5, 0, 5, 0,
+ax_anim 2, 0, 66, 9, 0, 9, 0,
+ax_anim 2, 1, 71, 9, 1, 9, 1,
+ax_anim 2, 0, 71, 9, 0, 9, 0,
+ax_anim 2, 0, 71, 9, 1, 9, 1,
+ax_anim 2, 0, 71, 9, 0, 9, 0,
+ax_anim 2, 0, 71, 9, 1, 9, 1,
+ax_anim 2, 0, 71, 9, 0, 9, 0,
+ax_anim 2, 0, 64, 5, 0, 5, 0,
+ax_anim 2, 0, 64, 2, 0, 2, 0,
+ax_anim_terminator
+sFurretAnims_3_4:
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 6, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 2, 81, 5, -5, 5, -5,
+ax_anim 1, 0, 81, 12, -13, 8, -9,
+ax_anim 2, 0, 70, 17, -23, 13, -15,
+ax_anim 2, 1, 75, 16, -21, 12, -15,
+ax_anim 2, 0, 75, 17, -21, 13, -15,
+ax_anim 2, 0, 75, 16, -21, 12, -15,
+ax_anim 2, 0, 75, 17, -21, 13, -15,
+ax_anim 2, 0, 75, 16, -21, 12, -15,
+ax_anim 2, 0, 75, 17, -21, 13, -15,
+ax_anim 2, 0, 68, 7, -8, 7, -8,
+ax_anim 2, 0, 68, 3, -3, 3, -3,
+ax_anim_terminator
+sFurretAnims_3_5:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 6, 0, 73, 0, 3, 0, 3,
+ax_anim 1, 2, 73, 0, -5, 0, -5,
+ax_anim 1, 0, 73, 0, -9, 0, -9,
+ax_anim 2, 0, 74, 0, -13, 0, -11,
+ax_anim 2, 1, 71, 1, -13, 1, -11,
+ax_anim 2, 0, 71, 0, -13, 0, -11,
+ax_anim 2, 0, 71, 1, -13, 1, -11,
+ax_anim 2, 0, 71, 0, -13, 0, -11,
+ax_anim 2, 0, 71, 1, -13, 1, -11,
+ax_anim 2, 0, 71, 0, -13, 0, -11,
+ax_anim 2, 0, 72, 0, -8, 0, -8,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sFurretAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 6, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 2, 65, -5, -5, -5, -5,
+ax_anim 1, 0, 65, -12, -13, -8, -9,
+ax_anim 2, 0, 78, -17, -23, -13, -15,
+ax_anim 2, 1, 75, -16, -21, -12, -15,
+ax_anim 2, 0, 75, -17, -21, -13, -15,
+ax_anim 2, 0, 75, -16, -21, -12, -15,
+ax_anim 2, 0, 75, -17, -21, -13, -15,
+ax_anim 2, 0, 75, -16, -21, -12, -15,
+ax_anim 2, 0, 75, -17, -21, -13, -15,
+ax_anim 2, 0, 76, -7, -8, -7, -8,
+ax_anim 2, 0, 76, -3, -3, -3, -3,
+ax_anim_terminator
+sFurretAnims_3_7:
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 6, 0, 81, 3, 0, 3, 0,
+ax_anim 1, 2, 69, -1, 0, -1, 0,
+ax_anim 1, 0, 69, -5, 0, -5, 0,
+ax_anim 2, 0, 82, -9, 0, -9, 0,
+ax_anim 2, 1, 79, -9, 1, -9, 1,
+ax_anim 2, 0, 79, -9, 0, -9, 0,
+ax_anim 2, 0, 79, -9, 1, -9, 1,
+ax_anim 2, 0, 79, -9, 0, -9, 0,
+ax_anim 2, 0, 79, -9, 1, -9, 1,
+ax_anim 2, 0, 79, -9, 0, -9, 0,
+ax_anim 2, 0, 80, -5, 0, -5, 0,
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim_terminator
+sFurretAnims_3_8:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 6, 0, 85, 3, -3, 3, -3,
+ax_anim 1, 2, 81, -5, 5, -5, 5,
+ax_anim 1, 0, 81, -12, 12, -9, 8,
+ax_anim 2, 0, 86, -15, 16, -15, 16,
+ax_anim 2, 1, 83, -14, 16, -14, 16,
+ax_anim 2, 0, 83, -15, 16, -15, 16,
+ax_anim 2, 0, 83, -14, 16, -14, 16,
+ax_anim 2, 0, 83, -15, 16, -15, 16,
+ax_anim 2, 0, 83, -14, 16, -14, 16,
+ax_anim 2, 0, 83, -15, 16, -15, 16,
+ax_anim 2, 0, 84, -8, 7, -8, 7,
+ax_anim 2, 0, 84, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sFurretAnims_4_1:
+ax_anim 2, 0, 94, 0, -2, 0, -2,
+ax_anim 6, 2, 94, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, -3, 0, -3,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 0, 4, 0, 4,
+ax_anim 2, 0, 92, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 2, 0, 92, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 2, 0, 92, 0, 4, 0, 4,
+ax_anim 2, 0, 94, 0, 2, 0, 2,
+ax_anim_terminator
+sFurretAnims_4_2:
+ax_anim 2, 0, 101, -2, -2, -2, -2,
+ax_anim 6, 2, 101, -3, -3, -3, -3,
+ax_anim 1, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 98, 4, 4, 4, 4,
+ax_anim 2, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 0, 98, 4, 4, 4, 4,
+ax_anim 2, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 0, 98, 4, 4, 4, 4,
+ax_anim 2, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim_terminator
+sFurretAnims_4_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 6, 2, 108, -3, 0, -3, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 2, 0, 2, 0,
+ax_anim 2, 1, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 106, 4, 0, 4, 0,
+ax_anim 2, 0, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 106, 4, 0, 4, 0,
+ax_anim 2, 0, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 106, 4, 0, 4, 0,
+ax_anim 2, 0, 108, 2, 0, 2, 0,
+ax_anim_terminator
+sFurretAnims_4_4:
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim 6, 2, 115, -3, 3, -3, 3,
+ax_anim 1, 0, 109, -2, 2, -2, 2,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 4, -4, 4, -4,
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 2, 0, 112, 4, -4, 4, -4,
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 2, 0, 112, 4, -4, 4, -4,
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim_terminator
+sFurretAnims_4_5:
+ax_anim 2, 0, 122, 0, 2, 0, 2,
+ax_anim 6, 2, 122, 0, 3, 0, 3,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, -2,
+ax_anim 2, 1, 119, 0, -4, 0, -4,
+ax_anim 2, 0, 120, 0, -4, 0, -4,
+ax_anim 2, 0, 119, 0, -4, 0, -4,
+ax_anim 2, 0, 120, 0, -4, 0, -4,
+ax_anim 2, 0, 119, 0, -4, 0, -4,
+ax_anim 2, 0, 120, 0, -4, 0, -4,
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim_terminator
+sFurretAnims_4_6:
+ax_anim 2, 0, 129, 2, 2, 2, 2,
+ax_anim 6, 2, 129, 3, 3, 3, 3,
+ax_anim 1, 0, 123, 2, 2, 2, 2,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 126, -4, -4, -4, -4,
+ax_anim 2, 0, 127, -4, -4, -4, -4,
+ax_anim 2, 0, 126, -4, -4, -4, -4,
+ax_anim 2, 0, 127, -4, -4, -4, -4,
+ax_anim 2, 0, 126, -4, -4, -4, -4,
+ax_anim 2, 0, 127, -4, -4, -4, -4,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim_terminator
+sFurretAnims_4_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 6, 2, 136, 3, 0, 3, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -2, 0, -2, 0,
+ax_anim 2, 1, 133, -4, 0, -4, 0,
+ax_anim 2, 0, 134, -4, 0, -4, 0,
+ax_anim 2, 0, 133, -4, 0, -4, 0,
+ax_anim 2, 0, 134, -4, 0, -4, 0,
+ax_anim 2, 0, 133, -4, 0, -4, 0,
+ax_anim 2, 0, 134, -4, 0, -4, 0,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim_terminator
+sFurretAnims_4_8:
+ax_anim 2, 0, 143, 2, -2, 2, -2,
+ax_anim 6, 2, 143, 3, -3, 3, -3,
+ax_anim 1, 0, 137, 3, -3, 3, -3,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 1, 140, -4, 4, -4, 4,
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 2, 0, 140, -4, 4, -4, 4,
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 2, 0, 140, -4, 4, -4, 4,
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sFurretAnims_5_1:
+ax_anim 2, 0, 144, 0, 3, 0, 3,
+ax_anim 8, 0, 147, 0, 4, 0, 4,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, 0, 1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, 0, 1, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, 0, 1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_5_2:
+ax_anim 2, 0, 151, 3, 3, 3, 3,
+ax_anim 8, 0, 154, 4, 4, 4, 4,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 1, -1, 1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 1, -1, 1,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 1, -1, 1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_5_3:
+ax_anim 2, 0, 158, 3, 0, 3, 0,
+ax_anim 8, 0, 161, 5, 0, 5, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_5_4:
+ax_anim 2, 0, 165, 5, -2, 5, -2,
+ax_anim 8, 0, 168, 6, -3, 6, -3,
+ax_anim 6, 0, 170, 2, -2, 2, -2,
+ax_anim 2, 0, 170, 1, -3, 1, -3,
+ax_anim 2, 0, 170, 2, -2, 2, -2,
+ax_anim 2, 0, 170, 1, -3, 1, -3,
+ax_anim 2, 2, 170, 2, -2, 2, -2,
+ax_anim 2, 0, 170, 1, -3, 1, -3,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_5_5:
+ax_anim 2, 0, 172, 0, -3, 0, -3,
+ax_anim 8, 0, 175, 0, -3, 0, -3,
+ax_anim 6, 0, 177, 0, -3, 0, -3,
+ax_anim 2, 0, 177, 1, -3, 1, -3,
+ax_anim 2, 0, 177, 0, -3, 0, -3,
+ax_anim 2, 0, 177, 1, -3, 1, -3,
+ax_anim 2, 2, 177, 0, -3, 0, -3,
+ax_anim 2, 0, 177, 1, -3, 1, -3,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_5_6:
+ax_anim 2, 0, 179, -5, -2, -5, -2,
+ax_anim 8, 0, 182, -6, -3, -6, -3,
+ax_anim 6, 0, 184, -2, -2, -2, -2,
+ax_anim 2, 0, 184, -1, -3, -1, -3,
+ax_anim 2, 0, 184, -2, -2, -2, -2,
+ax_anim 2, 0, 184, -1, -3, -1, -3,
+ax_anim 2, 2, 184, -2, -2, -2, -2,
+ax_anim 2, 0, 184, -1, -3, -1, -3,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_5_7:
+ax_anim 2, 0, 186, -3, 0, -3, 0,
+ax_anim 8, 0, 189, -5, 0, -5, 0,
+ax_anim 6, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_5_8:
+ax_anim 2, 0, 193, -3, 3, -3, 3,
+ax_anim 8, 0, 196, -4, 4, -4, 4,
+ax_anim 6, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 1, 1, 1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 1, 1, 1,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 1, 1, 1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFurretAnims_6_1:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 35, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFurretAnims_7_1:
+ax_anim 2, 0, 202, 0, -2, 0, -2,
+ax_anim 8, 0, 202, 0, -3, 0, -3,
+ax_anim_terminator
+sFurretAnims_7_2:
+ax_anim 2, 0, 203, -2, -2, -2, -2,
+ax_anim 8, 0, 203, -3, -3, -3, -3,
+ax_anim_terminator
+sFurretAnims_7_3:
+ax_anim 2, 0, 204, -2, 0, -2, 0,
+ax_anim 8, 0, 204, -3, 0, -3, 0,
+ax_anim_terminator
+sFurretAnims_7_4:
+ax_anim 2, 0, 205, -2, 2, -2, 2,
+ax_anim 8, 0, 205, -3, 3, -3, 3,
+ax_anim_terminator
+sFurretAnims_7_5:
+ax_anim 2, 0, 206, 0, 2, 0, 2,
+ax_anim 8, 0, 206, 0, 3, 0, 3,
+ax_anim_terminator
+sFurretAnims_7_6:
+ax_anim 2, 0, 207, 2, 2, 2, 2,
+ax_anim 8, 0, 207, 3, 3, 3, 3,
+ax_anim_terminator
+sFurretAnims_7_7:
+ax_anim 2, 0, 208, 2, 0, 2, 0,
+ax_anim 8, 0, 208, 3, 0, 3, 0,
+ax_anim_terminator
+sFurretAnims_7_8:
+ax_anim 2, 0, 209, 2, -2, 2, -2,
+ax_anim 8, 0, 209, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sFurretAnims_8_1:
+ax_anim 40, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_8_2:
+ax_anim 40, 0, 217, 0, 0, 0, 0,
+ax_anim 12, 0, 210, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 12, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_8_3:
+ax_anim 40, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_8_4:
+ax_anim 40, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_8_5:
+ax_anim 40, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_8_6:
+ax_anim 40, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_8_7:
+ax_anim 40, 0, 212, 0, 0, 0, 0,
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 212, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim 4, 0, 212, 0, 0, 0, 0,
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_8_8:
+ax_anim 40, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 210, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFurretAnims_9_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 13, 3, 13, 3,
+ax_anim 2, 0, 220, 15, 9, 15, 9,
+ax_anim 2, 0, 221, 10, 17, 10, 17,
+ax_anim 3, 0, 222, 0, 19, 0, 19,
+ax_anim 2, 3, 223, -10, 17, -10, 17,
+ax_anim 2, 0, 224, -15, 9, -15, 9,
+ax_anim 1, 0, 225, -13, 3, -13, 3,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_9_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 15, 0, 15, 0,
+ax_anim 2, 0, 219, 24, 6, 24, 6,
+ax_anim 2, 0, 220, 24, 13, 24, 13,
+ax_anim 3, 0, 221, 19, 21, 19, 21,
+ax_anim 2, 3, 222, 7, 21, 7, 21,
+ax_anim 2, 0, 223, 2, 16, 2, 16,
+ax_anim 1, 0, 224, -3, 7, -3, 7,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_9_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 2, -4, 2, -4,
+ax_anim 2, 0, 218, 10, -8, 10, -8,
+ax_anim 2, 0, 219, 20, -4, 20, -4,
+ax_anim 3, 0, 220, 21, 0, 21, 0,
+ax_anim 2, 3, 221, 16, 5, 16, 5,
+ax_anim 2, 0, 222, 12, 7, 12, 7,
+ax_anim 1, 0, 223, 4, 5, 4, 5,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_9_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, -4, -8, -4, -8,
+ax_anim 2, 0, 225, -2, -16, -2, -16,
+ax_anim 2, 0, 218, 10, -21, 10, -21,
+ax_anim 3, 0, 219, 22, -19, 22, -19,
+ax_anim 2, 3, 220, 24, -13, 24, -13,
+ax_anim 2, 0, 221, 20, -2, 20, -2,
+ax_anim 1, 0, 222, 9, 0, 9, 0,
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_9_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, -13, -3, -13, -3,
+ax_anim 2, 0, 224, -17, -11, -17, -11,
+ax_anim 2, 0, 225, -13, -16, -13, -16,
+ax_anim 3, 0, 218, 0, -20, 0, -20,
+ax_anim 2, 3, 219, 12, -16, 12, -16,
+ax_anim 2, 0, 220, 16, -11, 16, -11,
+ax_anim 1, 0, 221, 12, -3, 12, -3,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_9_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 4, -8, 4, -8,
+ax_anim 2, 0, 219, 2, -16, 2, -16,
+ax_anim 2, 0, 218, -10, -21, -10, -21,
+ax_anim 3, 0, 225, -22, -19, -22, -19,
+ax_anim 2, 3, 224, -24, -13, -24, -13,
+ax_anim 2, 0, 223, -20, -2, -20, -2,
+ax_anim 1, 0, 222, -9, 0, -9, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_9_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 219, -2, -4, -2, -4,
+ax_anim 2, 0, 218, -10, -8, -10, -8,
+ax_anim 2, 0, 225, -20, -4, -20, -4,
+ax_anim 3, 0, 224, -21, 0, -21, 0,
+ax_anim 2, 3, 223, -16, 5, -16, 5,
+ax_anim 2, 0, 222, -12, 7, -12, 7,
+ax_anim 1, 0, 221, -4, 5, -4, 5,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_9_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 218, -15, 0, -15, 0,
+ax_anim 2, 0, 225, -24, 6, -24, 6,
+ax_anim 2, 0, 224, -24, 13, -24, 13,
+ax_anim 3, 0, 223, -19, 21, -19, 21,
+ax_anim 2, 3, 222, -7, 21, -7, 21,
+ax_anim 2, 0, 221, -2, 16, -2, 16,
+ax_anim 1, 0, 220, 3, 7, 3, 7,
+ax_anim 1, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFurretAnims_10_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 3, 0, 226, 13, 0, 13, 0,
+ax_anim 3, 0, 226, -13, 0, -13, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_10_2:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 3, 0, 227, 13, -13, 13, -13,
+ax_anim 3, 0, 227, -13, 13, -13, 13,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_10_3:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 3, 0, 228, 0, -13, 0, -13,
+ax_anim 3, 0, 228, 0, 13, 0, 13,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_10_4:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 3, 0, 229, -13, -13, -13, -13,
+ax_anim 3, 0, 229, 13, 13, 13, 13,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_10_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 3, 0, 230, 13, 0, 13, 0,
+ax_anim 3, 0, 230, -13, 0, -13, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_10_6:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 3, 0, 231, 13, -13, 13, -13,
+ax_anim 3, 0, 231, -13, 13, -13, 13,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_10_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 3, 0, 232, 0, -13, 0, -13,
+ax_anim 3, 0, 232, 0, 13, 0, 13,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_10_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 3, 0, 233, -13, -13, -13, -13,
+ax_anim 3, 0, 233, 13, 13, 13, 13,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFurretAnims_11_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -23, 0, 0,
+ax_anim 3, 0, 236, 0, -22, 0, 0,
+ax_anim 2, 0, 236, 0, -18, 0, 0,
+ax_anim 1, 0, 236, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_11_2:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 0, -10, 0, 0,
+ax_anim 2, 0, 238, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 4, 0, 238, 0, -21, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 239, 0, -22, 0, 0,
+ax_anim 2, 0, 239, 0, -18, 0, 0,
+ax_anim 1, 0, 239, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_11_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 242, 0, -23, 0, 0,
+ax_anim 3, 0, 242, 0, -22, 0, 0,
+ax_anim 2, 0, 242, 0, -18, 0, 0,
+ax_anim 1, 0, 242, 0, -12, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_11_4:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 244, 0, -10, 0, 0,
+ax_anim 2, 0, 244, 0, -16, 0, 0,
+ax_anim 3, 0, 244, 0, -20, 0, 0,
+ax_anim 4, 0, 244, 0, -21, 0, 0,
+ax_anim 4, 0, 245, 0, -22, 0, 0,
+ax_anim 3, 0, 245, 0, -21, 0, 0,
+ax_anim 2, 0, 245, 0, -17, 0, 0,
+ax_anim 1, 0, 245, 0, -11, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_11_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 247, 0, -10, 0, 0,
+ax_anim 2, 0, 247, 0, -16, 0, 0,
+ax_anim 3, 0, 247, 0, -20, 0, 0,
+ax_anim 4, 0, 247, 0, -21, 0, 0,
+ax_anim 4, 0, 248, 0, -22, 0, 0,
+ax_anim 3, 0, 248, 0, -21, 0, 0,
+ax_anim 2, 0, 248, 0, -18, 0, 0,
+ax_anim 1, 0, 248, 0, -12, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_11_6:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 250, 0, -10, 0, 0,
+ax_anim 2, 0, 250, 0, -16, 0, 0,
+ax_anim 3, 0, 250, 0, -20, 0, 0,
+ax_anim 4, 0, 250, 0, -21, 0, 0,
+ax_anim 4, 0, 251, 0, -22, 0, 0,
+ax_anim 3, 0, 251, 0, -21, 0, 0,
+ax_anim 2, 0, 251, 0, -17, 0, 0,
+ax_anim 1, 0, 251, 0, -11, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_11_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 253, 0, -10, 0, 0,
+ax_anim 2, 0, 253, 0, -16, 0, 0,
+ax_anim 3, 0, 253, 0, -20, 0, 0,
+ax_anim 4, 0, 253, 0, -21, 0, 0,
+ax_anim 4, 0, 254, 0, -23, 0, 0,
+ax_anim 3, 0, 254, 0, -22, 0, 0,
+ax_anim 2, 0, 254, 0, -18, 0, 0,
+ax_anim 1, 0, 254, 0, -12, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_11_8:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 1, 0, 256, 0, -10, 0, 0,
+ax_anim 2, 0, 256, 0, -16, 0, 0,
+ax_anim 3, 0, 256, 0, -20, 0, 0,
+ax_anim 4, 0, 256, 0, -21, 0, 0,
+ax_anim 4, 0, 257, 0, -23, 0, 0,
+ax_anim 3, 0, 257, 0, -22, 0, 0,
+ax_anim 2, 0, 257, 0, -18, 0, 0,
+ax_anim 1, 0, 257, 0, -12, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFurretAnims_12_1:
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 1, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_12_2:
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 1, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_12_3:
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 1, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_12_4:
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 1, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_12_5:
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 1, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_12_6:
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 1, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_12_7:
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 1, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_12_8:
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 1, 259, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sFurretAnims_13_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_13_2:
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_13_3:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_13_4:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_13_5:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_13_6:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_13_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretAnims_13_8:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sFurretGfx1:
+.incbin "baserom.gba", 0xC216A4, 0x100
+sFurretSprites1:
+ax_sprite sFurretGfx1, 0x100
+ax_sprite_terminator
+sFurretGfx2:
+.incbin "baserom.gba", 0xC217B4, 0x100
+sFurretSprites2:
+ax_sprite sFurretGfx2, 0x100
+ax_sprite_terminator
+sFurretGfx3:
+.incbin "baserom.gba", 0xC218C4, 0x20
+sFurretSprites3:
+ax_sprite sFurretGfx3, 0x20
+ax_sprite_terminator
+sFurretGfx4:
+.incbin "baserom.gba", 0xC218F4, 0x100
+sFurretSprites4:
+ax_sprite sFurretGfx4, 0x100
+ax_sprite_terminator
+sFurretGfx5:
+.incbin "baserom.gba", 0xC21A04, 0x200
+sFurretSprites5:
+ax_sprite sFurretGfx5, 0x200
+ax_sprite_terminator
+sFurretGfx6:
+.incbin "baserom.gba", 0xC21C14, 0x200
+sFurretSprites6:
+ax_sprite sFurretGfx6, 0x200
+ax_sprite_terminator
+sFurretGfx7:
+.incbin "baserom.gba", 0xC21E24, 0x200
+sFurretSprites7:
+ax_sprite sFurretGfx7, 0x200
+ax_sprite_terminator
+sFurretGfx8:
+.incbin "baserom.gba", 0xC22034, 0x40
+sFurretSprites8:
+ax_sprite sFurretGfx8, 0x40
+ax_sprite_terminator
+sFurretGfx9:
+.incbin "baserom.gba", 0xC22084, 0x100
+sFurretSprites9:
+ax_sprite sFurretGfx9, 0x100
+ax_sprite_terminator
+sFurretGfx10:
+.incbin "baserom.gba", 0xC22194, 0x80
+sFurretSprites10:
+ax_sprite sFurretGfx10, 0x80
+ax_sprite_terminator
+sFurretGfx11:
+.incbin "baserom.gba", 0xC22224, 0x40
+sFurretSprites11:
+ax_sprite sFurretGfx11, 0x40
+ax_sprite_terminator
+sFurretGfx12:
+.incbin "baserom.gba", 0xC22274, 0x40
+sFurretSprites12:
+ax_sprite sFurretGfx12, 0x40
+ax_sprite_terminator
+sFurretGfx13:
+.incbin "baserom.gba", 0xC222C4, 0x100
+sFurretSprites13:
+ax_sprite sFurretGfx13, 0x100
+ax_sprite_terminator
+sFurretGfx14:
+.incbin "baserom.gba", 0xC223D4, 0x80
+sFurretSprites14:
+ax_sprite sFurretGfx14, 0x80
+ax_sprite_terminator
+sFurretGfx15:
+.incbin "baserom.gba", 0xC22464, 0x40
+sFurretSprites15:
+ax_sprite sFurretGfx15, 0x40
+ax_sprite_terminator
+sFurretGfx16:
+.incbin "baserom.gba", 0xC224B4, 0x40
+sFurretSprites16:
+ax_sprite sFurretGfx16, 0x40
+ax_sprite_terminator
+sFurretGfx17:
+.incbin "baserom.gba", 0xC22504, 0x100
+sFurretSprites17:
+ax_sprite sFurretGfx17, 0x100
+ax_sprite_terminator
+sFurretGfx18:
+.incbin "baserom.gba", 0xC22614, 0x80
+sFurretSprites18:
+ax_sprite sFurretGfx18, 0x80
+ax_sprite_terminator
+sFurretGfx19:
+.incbin "baserom.gba", 0xC226A4, 0x40
+sFurretSprites19:
+ax_sprite sFurretGfx19, 0x40
+ax_sprite_terminator
+sFurretGfx20:
+.incbin "baserom.gba", 0xC226F4, 0x200
+sFurretSprites20:
+ax_sprite sFurretGfx20, 0x200
+ax_sprite_terminator
+sFurretGfx21:
+.incbin "baserom.gba", 0xC22904, 0x200
+sFurretSprites21:
+ax_sprite sFurretGfx21, 0x200
+ax_sprite_terminator
+sFurretGfx22:
+.incbin "baserom.gba", 0xC22B14, 0x40
+sFurretSprites22:
+ax_sprite sFurretGfx22, 0x40
+ax_sprite_terminator
+sFurretGfx23:
+.incbin "baserom.gba", 0xC22B64, 0x100
+sFurretSprites23:
+ax_sprite sFurretGfx23, 0x100
+ax_sprite_terminator
+sFurretGfx24:
+.incbin "baserom.gba", 0xC22C74, 0x80
+sFurretSprites24:
+ax_sprite sFurretGfx24, 0x80
+ax_sprite_terminator
+sFurretGfx25:
+.incbin "baserom.gba", 0xC22D04, 0x40
+sFurretSprites25:
+ax_sprite sFurretGfx25, 0x40
+ax_sprite_terminator
+sFurretGfx26:
+.incbin "baserom.gba", 0xC22D54, 0x200
+sFurretSprites26:
+ax_sprite sFurretGfx26, 0x200
+ax_sprite_terminator
+sFurretGfx27:
+.incbin "baserom.gba", 0xC22F64, 0x80
+sFurretSprites27:
+ax_sprite sFurretGfx27, 0x80
+ax_sprite_terminator
+sFurretGfx28:
+.incbin "baserom.gba", 0xC22FF4, 0x100
+sFurretSprites28:
+ax_sprite sFurretGfx28, 0x100
+ax_sprite_terminator
+sFurretGfx29:
+.incbin "baserom.gba", 0xC23104, 0x20
+sFurretSprites29:
+ax_sprite sFurretGfx29, 0x20
+ax_sprite_terminator
+sFurretGfx30:
+.incbin "baserom.gba", 0xC23134, 0x100
+sFurretSprites30:
+ax_sprite sFurretGfx30, 0x100
+ax_sprite_terminator
+sFurretGfx31:
+.incbin "baserom.gba", 0xC23244, 0x20
+sFurretSprites31:
+ax_sprite sFurretGfx31, 0x20
+ax_sprite_terminator
+sFurretGfx32:
+.incbin "baserom.gba", 0xC23274, 0x40
+sFurretGfx32_1:
+.incbin "baserom.gba", 0xC232B4, 0x60
+sFurretGfx32_2:
+.incbin "baserom.gba", 0xC23314, 0x40
+sFurretGfx32_3:
+.incbin "baserom.gba", 0xC23354, 0x40
+sFurretSprites32:
+ax_sprite sFurretGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx32_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx32_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFurretGfx33:
+.incbin "baserom.gba", 0xC233DC, 0x160
+sFurretGfx33_1:
+.incbin "baserom.gba", 0xC2353C, 0x20
+sFurretSprites33:
+ax_sprite sFurretGfx33, 0x160
+ax_sprite 0, 0x60
+ax_sprite sFurretGfx33_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx34:
+.incbin "baserom.gba", 0xC23584, 0x180
+sFurretGfx34_1:
+.incbin "baserom.gba", 0xC23704, 0x40
+sFurretSprites34:
+ax_sprite sFurretGfx34, 0x180
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx35:
+.incbin "baserom.gba", 0xC2376C, 0x60
+sFurretGfx35_1:
+.incbin "baserom.gba", 0xC237CC, 0x60
+sFurretGfx35_2:
+.incbin "baserom.gba", 0xC2382C, 0x60
+sFurretGfx35_3:
+.incbin "baserom.gba", 0xC2388C, 0x40
+sFurretSprites35:
+ax_sprite sFurretGfx35, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx36:
+.incbin "baserom.gba", 0xC23914, 0x100
+sFurretSprites36:
+ax_sprite sFurretGfx36, 0x100
+ax_sprite_terminator
+sFurretGfx37:
+.incbin "baserom.gba", 0xC23A24, 0x160
+sFurretSprites37:
+ax_sprite sFurretGfx37, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFurretGfx38:
+.incbin "baserom.gba", 0xC23B9C, 0x40
+sFurretGfx38_1:
+.incbin "baserom.gba", 0xC23BDC, 0x20
+sFurretGfx38_2:
+.incbin "baserom.gba", 0xC23BFC, 0x60
+sFurretSprites38:
+ax_sprite sFurretGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx38_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx38_2, 0x60
+ax_sprite_terminator
+sFurretGfx39:
+.incbin "baserom.gba", 0xC23C8C, 0x40
+sFurretSprites39:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx39, 0x40
+ax_sprite_terminator
+sFurretGfx40:
+.incbin "baserom.gba", 0xC23CE4, 0x20
+sFurretSprites40:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx40, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx41:
+.incbin "baserom.gba", 0xC23D24, 0xE0
+sFurretGfx41_1:
+.incbin "baserom.gba", 0xC23E04, 0x60
+sFurretSprites41:
+ax_sprite 0, 0x80
+ax_sprite sFurretGfx41, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx42:
+.incbin "baserom.gba", 0xC23E94, 0x160
+sFurretGfx42_1:
+.incbin "baserom.gba", 0xC23FF4, 0x40
+sFurretSprites42:
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx42, 0x160
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx42_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx43:
+.incbin "baserom.gba", 0xC24064, 0x40
+sFurretGfx43_1:
+.incbin "baserom.gba", 0xC240A4, 0xE0
+sFurretSprites43:
+ax_sprite 0, 0xa0
+ax_sprite sFurretGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx43_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx44:
+.incbin "baserom.gba", 0xC241B4, 0x20
+sFurretGfx44_1:
+.incbin "baserom.gba", 0xC241D4, 0xA0
+sFurretSprites44:
+ax_sprite sFurretGfx44, 0x20
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx44_1, 0xa0
+ax_sprite_terminator
+sFurretGfx45:
+.incbin "baserom.gba", 0xC24294, 0x40
+sFurretSprites45:
+ax_sprite sFurretGfx45, 0x40
+ax_sprite_terminator
+sFurretGfx46:
+.incbin "baserom.gba", 0xC242E4, 0x1C0
+sFurretSprites46:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx46, 0x1c0
+ax_sprite_terminator
+sFurretGfx47:
+.incbin "baserom.gba", 0xC244BC, 0x40
+sFurretSprites47:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx47, 0x40
+ax_sprite_terminator
+sFurretGfx48:
+.incbin "baserom.gba", 0xC24514, 0x60
+sFurretSprites48:
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx48, 0x60
+ax_sprite_terminator
+sFurretGfx49:
+.incbin "baserom.gba", 0xC2458C, 0x40
+sFurretGfx49_1:
+.incbin "baserom.gba", 0xC245CC, 0x100
+sFurretSprites49:
+ax_sprite 0, 0x80
+ax_sprite sFurretGfx49, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx49_1, 0x100
+ax_sprite_terminator
+sFurretGfx50:
+.incbin "baserom.gba", 0xC246F4, 0x80
+sFurretSprites50:
+ax_sprite sFurretGfx50, 0x80
+ax_sprite_terminator
+sFurretGfx51:
+.incbin "baserom.gba", 0xC24784, 0x40
+sFurretGfx51_1:
+.incbin "baserom.gba", 0xC247C4, 0xE0
+sFurretGfx51_2:
+.incbin "baserom.gba", 0xC248A4, 0x40
+sFurretSprites51:
+ax_sprite sFurretGfx51, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx51_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx51_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx52:
+.incbin "baserom.gba", 0xC2491C, 0x40
+sFurretSprites52:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx52, 0x40
+ax_sprite_terminator
+sFurretGfx53:
+.incbin "baserom.gba", 0xC24974, 0x20
+sFurretSprites53:
+ax_sprite sFurretGfx53, 0x20
+ax_sprite_terminator
+sFurretGfx54:
+.incbin "baserom.gba", 0xC249A4, 0x20
+sFurretSprites54:
+ax_sprite sFurretGfx54, 0x20
+ax_sprite_terminator
+sFurretGfx55:
+.incbin "baserom.gba", 0xC249D4, 0x40
+sFurretGfx55_1:
+.incbin "baserom.gba", 0xC24A14, 0x60
+sFurretGfx55_2:
+.incbin "baserom.gba", 0xC24A74, 0x80
+sFurretGfx55_3:
+.incbin "baserom.gba", 0xC24AF4, 0x60
+sFurretSprites55:
+ax_sprite sFurretGfx55, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx55_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx55_3, 0x60
+ax_sprite_terminator
+sFurretGfx56:
+.incbin "baserom.gba", 0xC24B94, 0x40
+sFurretSprites56:
+ax_sprite sFurretGfx56, 0x40
+ax_sprite_terminator
+sFurretGfx57:
+.incbin "baserom.gba", 0xC24BE4, 0x40
+sFurretGfx57_1:
+.incbin "baserom.gba", 0xC24C24, 0x100
+sFurretGfx57_2:
+.incbin "baserom.gba", 0xC24D24, 0x40
+sFurretSprites57:
+ax_sprite sFurretGfx57, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx57_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx57_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx58:
+.incbin "baserom.gba", 0xC24D9C, 0x60
+sFurretGfx58_1:
+.incbin "baserom.gba", 0xC24DFC, 0x20
+sFurretGfx58_2:
+.incbin "baserom.gba", 0xC24E1C, 0x20
+sFurretGfx58_3:
+.incbin "baserom.gba", 0xC24E3C, 0x40
+sFurretSprites58:
+ax_sprite sFurretGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx58_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFurretGfx58_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sFurretGfx58_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFurretGfx59:
+.incbin "baserom.gba", 0xC24EC4, 0x60
+sFurretGfx59_1:
+.incbin "baserom.gba", 0xC24F24, 0x40
+sFurretGfx59_2:
+.incbin "baserom.gba", 0xC24F64, 0x60
+sFurretGfx59_3:
+.incbin "baserom.gba", 0xC24FC4, 0x60
+sFurretSprites59:
+ax_sprite sFurretGfx59, 0x60
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx59_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx59_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx59_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx60:
+.incbin "baserom.gba", 0xC2506C, 0x100
+sFurretSprites60:
+ax_sprite sFurretGfx60, 0x100
+ax_sprite_terminator
+sFurretGfx61:
+.incbin "baserom.gba", 0xC2517C, 0x20
+sFurretSprites61:
+ax_sprite sFurretGfx61, 0x20
+ax_sprite_terminator
+sFurretGfx62:
+.incbin "baserom.gba", 0xC251AC, 0x100
+sFurretSprites62:
+ax_sprite sFurretGfx62, 0x100
+ax_sprite_terminator
+sFurretGfx63:
+.incbin "baserom.gba", 0xC252BC, 0x60
+sFurretGfx63_1:
+.incbin "baserom.gba", 0xC2531C, 0x60
+sFurretGfx63_2:
+.incbin "baserom.gba", 0xC2537C, 0x60
+sFurretSprites63:
+ax_sprite sFurretGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx63_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx63_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sFurretGfx64:
+.incbin "baserom.gba", 0xC25414, 0x60
+sFurretGfx64_1:
+.incbin "baserom.gba", 0xC25474, 0x120
+sFurretSprites64:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx64_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx65:
+.incbin "baserom.gba", 0xC255C4, 0x60
+sFurretGfx65_1:
+.incbin "baserom.gba", 0xC25624, 0x120
+sFurretSprites65:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx65, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx65_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx66:
+.incbin "baserom.gba", 0xC25774, 0x40
+sFurretGfx66_1:
+.incbin "baserom.gba", 0xC257B4, 0x60
+sFurretGfx66_2:
+.incbin "baserom.gba", 0xC25814, 0x60
+sFurretGfx66_3:
+.incbin "baserom.gba", 0xC25874, 0x40
+sFurretSprites66:
+ax_sprite sFurretGfx66, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx66_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx66_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx66_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFurretGfx67:
+.incbin "baserom.gba", 0xC258FC, 0x100
+sFurretSprites67:
+ax_sprite sFurretGfx67, 0x100
+ax_sprite_terminator
+sFurretGfx68:
+.incbin "baserom.gba", 0xC25A0C, 0x20
+sFurretGfx68_1:
+.incbin "baserom.gba", 0xC25A2C, 0x20
+sFurretSprites68:
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx68, 0x20
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx68_1, 0x20
+ax_sprite_terminator
+sFurretGfx69:
+.incbin "baserom.gba", 0xC25A74, 0x20
+sFurretSprites69:
+ax_sprite sFurretGfx69, 0x20
+ax_sprite_terminator
+sFurretGfx70:
+.incbin "baserom.gba", 0xC25AA4, 0x180
+sFurretSprites70:
+ax_sprite 0, 0x60
+ax_sprite sFurretGfx70, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx71:
+.incbin "baserom.gba", 0xC25C44, 0x40
+sFurretGfx71_1:
+.incbin "baserom.gba", 0xC25C84, 0x80
+sFurretGfx71_2:
+.incbin "baserom.gba", 0xC25D04, 0x60
+sFurretGfx71_3:
+.incbin "baserom.gba", 0xC25D64, 0x40
+sFurretSprites71:
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx71, 0x40
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx71_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx71_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx71_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx72:
+.incbin "baserom.gba", 0xC25DF4, 0x120
+sFurretGfx72_1:
+.incbin "baserom.gba", 0xC25F14, 0x60
+sFurretSprites72:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx72, 0x120
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx72_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx73:
+.incbin "baserom.gba", 0xC25FA4, 0x120
+sFurretGfx73_1:
+.incbin "baserom.gba", 0xC260C4, 0x60
+sFurretSprites73:
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx73, 0x120
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx73_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx74:
+.incbin "baserom.gba", 0xC26154, 0x40
+sFurretGfx74_1:
+.incbin "baserom.gba", 0xC26194, 0x40
+sFurretGfx74_2:
+.incbin "baserom.gba", 0xC261D4, 0x60
+sFurretGfx74_3:
+.incbin "baserom.gba", 0xC26234, 0x60
+sFurretSprites74:
+ax_sprite sFurretGfx74, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx74_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx74_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx74_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx75:
+.incbin "baserom.gba", 0xC262DC, 0x60
+sFurretGfx75_1:
+.incbin "baserom.gba", 0xC2633C, 0x40
+sFurretGfx75_2:
+.incbin "baserom.gba", 0xC2637C, 0x40
+sFurretSprites75:
+ax_sprite 0, 0x80
+ax_sprite sFurretGfx75, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx75_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx75_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFurretGfx76:
+.incbin "baserom.gba", 0xC263FC, 0x60
+sFurretGfx76_1:
+.incbin "baserom.gba", 0xC2645C, 0x40
+sFurretGfx76_2:
+.incbin "baserom.gba", 0xC2649C, 0x40
+sFurretSprites76:
+ax_sprite 0, 0x80
+ax_sprite sFurretGfx76, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx76_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sFurretGfx76_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sFurretGfx77:
+.incbin "baserom.gba", 0xC2651C, 0x60
+sFurretGfx77_1:
+.incbin "baserom.gba", 0xC2657C, 0x60
+sFurretGfx77_2:
+.incbin "baserom.gba", 0xC265DC, 0x60
+sFurretGfx77_3:
+.incbin "baserom.gba", 0xC2663C, 0x60
+sFurretSprites77:
+ax_sprite sFurretGfx77, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx77_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx77_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sFurretGfx77_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sFurretGfx78:
+.incbin "baserom.gba", 0xC266E4, 0x200
+sFurretSprites78:
+ax_sprite sFurretGfx78, 0x200
+ax_sprite_terminator
+sFurretGfx79:
+.incbin "baserom.gba", 0xC268F4, 0x200
+sFurretSprites79:
+ax_sprite sFurretGfx79, 0x200
+ax_sprite_terminator
+sFurretGfx80:
+.incbin "baserom.gba", 0xC26B04, 0x200
+sFurretSprites80:
+ax_sprite sFurretGfx80, 0x200
+ax_sprite_terminator
+sFurretGfx81:
+.incbin "baserom.gba", 0xC26D14, 0x200
+sFurretSprites81:
+ax_sprite sFurretGfx81, 0x200
+ax_sprite_terminator
+sFurretGfx82:
+.incbin "baserom.gba", 0xC26F24, 0x200
+sFurretSprites82:
+ax_sprite sFurretGfx82, 0x200
+ax_sprite_terminator
+sFurretGfx83:
+.incbin "baserom.gba", 0xC27134, 0x200
+sFurretSprites83:
+ax_sprite sFurretGfx83, 0x200
+ax_sprite_terminator
+sFurretGfx84:
+.incbin "baserom.gba", 0xC27344, 0x200
+sFurretSprites84:
+ax_sprite sFurretGfx84, 0x200
+ax_sprite_terminator
+sAxPosesFurret:
+.4byte sFurretPose1
+.4byte sFurretPose2
+.4byte sFurretPose3
+.4byte sFurretPose4
+.4byte sFurretPose5
+.4byte sFurretPose6
+.4byte sFurretPose7
+.4byte sFurretPose8
+.4byte sFurretPose9
+.4byte sFurretPose10
+.4byte sFurretPose11
+.4byte sFurretPose12
+.4byte sFurretPose13
+.4byte sFurretPose14
+.4byte sFurretPose15
+.4byte sFurretPose16
+.4byte sFurretPose17
+.4byte sFurretPose18
+.4byte sFurretPose19
+.4byte sFurretPose20
+.4byte sFurretPose21
+.4byte sFurretPose22
+.4byte sFurretPose23
+.4byte sFurretPose24
+.4byte sFurretPose25
+.4byte sFurretPose26
+.4byte sFurretPose27
+.4byte sFurretPose28
+.4byte sFurretPose29
+.4byte sFurretPose30
+.4byte sFurretPose31
+.4byte sFurretPose32
+.4byte sFurretPose33
+.4byte sFurretPose34
+.4byte sFurretPose35
+.4byte sFurretPose36
+.4byte sFurretPose37
+.4byte sFurretPose38
+.4byte sFurretPose39
+.4byte sFurretPose40
+.4byte sFurretPose41
+.4byte sFurretPose42
+.4byte sFurretPose43
+.4byte sFurretPose44
+.4byte sFurretPose45
+.4byte sFurretPose46
+.4byte sFurretPose47
+.4byte sFurretPose48
+.4byte sFurretPose49
+.4byte sFurretPose50
+.4byte sFurretPose51
+.4byte sFurretPose52
+.4byte sFurretPose53
+.4byte sFurretPose54
+.4byte sFurretPose55
+.4byte sFurretPose56
+.4byte sFurretPose57
+.4byte sFurretPose58
+.4byte sFurretPose59
+.4byte sFurretPose60
+.4byte sFurretPose61
+.4byte sFurretPose62
+.4byte sFurretPose63
+.4byte sFurretPose64
+.4byte sFurretPose65
+.4byte sFurretPose66
+.4byte sFurretPose67
+.4byte sFurretPose68
+.4byte sFurretPose69
+.4byte sFurretPose70
+.4byte sFurretPose71
+.4byte sFurretPose72
+.4byte sFurretPose73
+.4byte sFurretPose74
+.4byte sFurretPose75
+.4byte sFurretPose76
+.4byte sFurretPose77
+.4byte sFurretPose78
+.4byte sFurretPose79
+.4byte sFurretPose80
+.4byte sFurretPose81
+.4byte sFurretPose82
+.4byte sFurretPose83
+.4byte sFurretPose84
+.4byte sFurretPose85
+.4byte sFurretPose86
+.4byte sFurretPose87
+.4byte sFurretPose88
+.4byte sFurretPose89
+.4byte sFurretPose90
+.4byte sFurretPose91
+.4byte sFurretPose92
+.4byte sFurretPose93
+.4byte sFurretPose94
+.4byte sFurretPose95
+.4byte sFurretPose96
+.4byte sFurretPose97
+.4byte sFurretPose98
+.4byte sFurretPose99
+.4byte sFurretPose100
+.4byte sFurretPose101
+.4byte sFurretPose102
+.4byte sFurretPose103
+.4byte sFurretPose104
+.4byte sFurretPose105
+.4byte sFurretPose106
+.4byte sFurretPose107
+.4byte sFurretPose108
+.4byte sFurretPose109
+.4byte sFurretPose110
+.4byte sFurretPose111
+.4byte sFurretPose112
+.4byte sFurretPose113
+.4byte sFurretPose114
+.4byte sFurretPose115
+.4byte sFurretPose116
+.4byte sFurretPose117
+.4byte sFurretPose118
+.4byte sFurretPose119
+.4byte sFurretPose120
+.4byte sFurretPose121
+.4byte sFurretPose122
+.4byte sFurretPose123
+.4byte sFurretPose124
+.4byte sFurretPose125
+.4byte sFurretPose126
+.4byte sFurretPose127
+.4byte sFurretPose128
+.4byte sFurretPose129
+.4byte sFurretPose130
+.4byte sFurretPose131
+.4byte sFurretPose132
+.4byte sFurretPose133
+.4byte sFurretPose134
+.4byte sFurretPose135
+.4byte sFurretPose136
+.4byte sFurretPose137
+.4byte sFurretPose138
+.4byte sFurretPose139
+.4byte sFurretPose140
+.4byte sFurretPose141
+.4byte sFurretPose142
+.4byte sFurretPose143
+.4byte sFurretPose144
+.4byte sFurretPose145
+.4byte sFurretPose146
+.4byte sFurretPose147
+.4byte sFurretPose148
+.4byte sFurretPose149
+.4byte sFurretPose150
+.4byte sFurretPose151
+.4byte sFurretPose152
+.4byte sFurretPose153
+.4byte sFurretPose154
+.4byte sFurretPose155
+.4byte sFurretPose156
+.4byte sFurretPose157
+.4byte sFurretPose158
+.4byte sFurretPose159
+.4byte sFurretPose160
+.4byte sFurretPose161
+.4byte sFurretPose162
+.4byte sFurretPose163
+.4byte sFurretPose164
+.4byte sFurretPose165
+.4byte sFurretPose166
+.4byte sFurretPose167
+.4byte sFurretPose168
+.4byte sFurretPose169
+.4byte sFurretPose170
+.4byte sFurretPose171
+.4byte sFurretPose172
+.4byte sFurretPose173
+.4byte sFurretPose174
+.4byte sFurretPose175
+.4byte sFurretPose176
+.4byte sFurretPose177
+.4byte sFurretPose178
+.4byte sFurretPose179
+.4byte sFurretPose180
+.4byte sFurretPose181
+.4byte sFurretPose182
+.4byte sFurretPose183
+.4byte sFurretPose184
+.4byte sFurretPose185
+.4byte sFurretPose186
+.4byte sFurretPose187
+.4byte sFurretPose188
+.4byte sFurretPose189
+.4byte sFurretPose190
+.4byte sFurretPose191
+.4byte sFurretPose192
+.4byte sFurretPose193
+.4byte sFurretPose194
+.4byte sFurretPose195
+.4byte sFurretPose196
+.4byte sFurretPose197
+.4byte sFurretPose198
+.4byte sFurretPose199
+.4byte sFurretPose200
+.4byte sFurretPose201
+.4byte sFurretPose202
+.4byte sFurretPose203
+.4byte sFurretPose204
+.4byte sFurretPose205
+.4byte sFurretPose206
+.4byte sFurretPose207
+.4byte sFurretPose208
+.4byte sFurretPose209
+.4byte sFurretPose210
+.4byte sFurretPose211
+.4byte sFurretPose212
+.4byte sFurretPose213
+.4byte sFurretPose214
+.4byte sFurretPose215
+.4byte sFurretPose216
+.4byte sFurretPose217
+.4byte sFurretPose218
+.4byte sFurretPose219
+.4byte sFurretPose220
+.4byte sFurretPose221
+.4byte sFurretPose222
+.4byte sFurretPose223
+.4byte sFurretPose224
+.4byte sFurretPose225
+.4byte sFurretPose226
+.4byte sFurretPose227
+.4byte sFurretPose228
+.4byte sFurretPose229
+.4byte sFurretPose230
+.4byte sFurretPose231
+.4byte sFurretPose232
+.4byte sFurretPose233
+.4byte sFurretPose234
+.4byte sFurretPose235
+.4byte sFurretPose236
+.4byte sFurretPose237
+.4byte sFurretPose238
+.4byte sFurretPose239
+.4byte sFurretPose240
+.4byte sFurretPose241
+.4byte sFurretPose242
+.4byte sFurretPose243
+.4byte sFurretPose244
+.4byte sFurretPose245
+.4byte sFurretPose246
+.4byte sFurretPose247
+.4byte sFurretPose248
+.4byte sFurretPose249
+.4byte sFurretPose250
+.4byte sFurretPose251
+.4byte sFurretPose252
+.4byte sFurretPose253
+.4byte sFurretPose254
+.4byte sFurretPose255
+.4byte sFurretPose256
+.4byte sFurretPose257
+.4byte sFurretPose258
+.4byte sFurretPose259
+.4byte sFurretPose260
+.4byte sFurretPose261
+.4byte sFurretPose262
+.4byte sFurretPose263
+.4byte sFurretPose264
+.4byte sFurretPose265
+.4byte sFurretPose266
+.4byte sFurretPose267
+.4byte sFurretPose268
+.4byte sFurretPose269
+.4byte sFurretPose270
+.4byte sFurretPose271
+.4byte sFurretPose272
+.4byte sFurretPose273
+.4byte sFurretPose274
+sAxPositionsFurret:
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -1,    2, 	  -4,    4, 	   2,    4, 	  -1,   -6
+.2byte   10,   -5, 	   7,   -1, 	   2,    1, 	  -1,   -7
+.2byte    8,  -15, 	   9,  -11, 	   3,   -9, 	  -1,  -12
+.2byte    8,   -3, 	   7,   -2, 	   2,   -1, 	   1,  -13
+.2byte   16,   -7, 	   9,   -2, 	   8,    0, 	   5,   -4
+.2byte   14,  -16, 	   7,   -9, 	   7,   -7, 	   3,  -11
+.2byte   20,   -4, 	  15,   -2, 	  14,   -1, 	   9,   -9
+.2byte    9,  -10, 	   1,   -6, 	   6,   -3, 	   0,   -6
+.2byte    9,  -20, 	   3,  -15, 	   8,  -11, 	   0,  -11
+.2byte   13,   -8, 	   7,   -8, 	  11,   -4, 	   3,  -14
+.2byte   -1,  -11, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -20, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte  -10,  -10, 	  -2,   -6, 	  -7,   -3, 	  -1,   -6
+.2byte  -10,  -20, 	  -4,  -15, 	  -9,  -11, 	  -1,  -11
+.2byte  -14,   -8, 	  -8,   -8, 	 -12,   -4, 	  -4,  -14
+.2byte  -17,   -7, 	 -10,   -2, 	  -9,    0, 	  -6,   -4
+.2byte  -15,  -16, 	  -8,   -9, 	  -8,   -7, 	  -4,  -11
+.2byte  -21,   -4, 	 -16,   -2, 	 -15,   -1, 	 -10,   -9
+.2byte  -11,   -5, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -9,  -15, 	 -10,  -11, 	  -4,   -9, 	   0,  -12
+.2byte  -13,   -4, 	 -12,   -3, 	  -7,   -2, 	  -6,  -14
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -1,    2, 	  -4,    4, 	   2,    4, 	  -1,   -6
+.2byte   -1,  -20, 	  -5,   -9, 	   3,   -9, 	  -1,  -11
+.2byte   10,   -5, 	   7,   -1, 	   2,    1, 	  -1,   -7
+.2byte    8,  -15, 	   9,  -11, 	   3,   -9, 	  -1,  -12
+.2byte    8,   -4, 	   7,   -3, 	   2,   -2, 	   1,  -14
+.2byte    5,  -20, 	   6,   -9, 	   2,   -6, 	   0,  -11
+.2byte   14,   -7, 	   7,   -2, 	   6,    0, 	   3,   -4
+.2byte   12,  -16, 	   5,   -9, 	   5,   -7, 	   1,  -11
+.2byte   18,   -3, 	  13,   -1, 	  12,    0, 	   7,   -8
+.2byte    8,  -22, 	   7,   -8, 	   7,   -6, 	   1,   -9
+.2byte    9,  -10, 	   1,   -6, 	   6,   -3, 	   0,   -6
+.2byte    9,  -20, 	   3,  -15, 	   8,  -11, 	   0,  -11
+.2byte    9,   -8, 	   3,   -8, 	   7,   -4, 	  -1,  -14
+.2byte    6,  -24, 	   0,  -11, 	   6,   -8, 	   0,  -10
+.2byte   -1,  -11, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -20, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,  -21, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte  -10,  -10, 	  -2,   -6, 	  -7,   -3, 	  -1,   -6
+.2byte  -10,  -20, 	  -4,  -15, 	  -9,  -11, 	  -1,  -11
+.2byte  -10,   -8, 	  -4,   -8, 	  -8,   -4, 	   0,  -14
+.2byte   -7,  -24, 	  -1,  -11, 	  -7,   -8, 	  -1,  -10
+.2byte  -15,   -7, 	  -8,   -2, 	  -7,    0, 	  -4,   -4
+.2byte  -13,  -16, 	  -6,   -9, 	  -6,   -7, 	  -2,  -11
+.2byte  -19,   -3, 	 -14,   -1, 	 -13,    0, 	  -8,   -8
+.2byte   -9,  -22, 	  -8,   -8, 	  -8,   -6, 	  -2,   -9
+.2byte  -11,   -5, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -9,  -15, 	 -10,  -11, 	  -4,   -9, 	   0,  -12
+.2byte   -9,   -4, 	  -8,   -3, 	  -3,   -2, 	  -2,  -14
+.2byte   -6,  -20, 	  -7,   -9, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   12,  -15, 	   9,   -7, 	   7,  -10, 	   3,   -7
+.2byte   -1,    5, 	  -5,    6, 	   3,    6, 	   0,   -6
+.2byte   -1,    2, 	  -5,    3, 	   3,    3, 	   0,   -9
+.2byte   10,   -5, 	   7,   -1, 	   2,    1, 	  -1,   -7
+.2byte  -14,  -13, 	  -9,   -6, 	 -12,   -7, 	  -5,   -9
+.2byte    8,    2, 	   6,   -1, 	  -2,    1, 	   0,   -7
+.2byte    8,    2, 	   6,   -1, 	  -2,    1, 	   0,   -7
+.2byte   16,   -7, 	   9,   -2, 	   8,    0, 	   5,   -4
+.2byte  -13,  -12, 	  -8,   -3, 	 -11,   -4, 	  -4,   -7
+.2byte   15,   -2, 	   7,   -2, 	   6,    0, 	   3,   -7
+.2byte   15,   -2, 	   7,   -2, 	   6,    0, 	   3,   -7
+.2byte    9,  -10, 	   1,   -6, 	   6,   -3, 	   0,   -6
+.2byte    1,  -10, 	   2,   -4, 	  -5,   -5, 	  -2,   -5
+.2byte    9,   -6, 	  -2,   -4, 	   2,   -1, 	  -1,   -8
+.2byte    9,   -6, 	  -2,   -4, 	   2,   -1, 	  -1,   -8
+.2byte   -1,  -11, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -9,  -10, 	 -10,   -5, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,  -11, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,  -11, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte  -10,  -10, 	  -2,   -6, 	  -7,   -3, 	  -1,   -6
+.2byte   -2,  -10, 	  -3,   -4, 	   4,   -5, 	   1,   -5
+.2byte  -10,   -6, 	   1,   -4, 	  -3,   -1, 	   0,   -8
+.2byte  -10,   -6, 	   1,   -4, 	  -3,   -1, 	   0,   -8
+.2byte  -17,   -7, 	 -10,   -2, 	  -9,    0, 	  -6,   -4
+.2byte   12,  -12, 	   7,   -3, 	  10,   -4, 	   3,   -7
+.2byte  -16,   -2, 	  -8,   -2, 	  -7,    0, 	  -4,   -7
+.2byte  -16,   -2, 	  -8,   -2, 	  -7,    0, 	  -4,   -7
+.2byte  -11,   -5, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte   13,  -13, 	   8,   -6, 	  11,   -7, 	   4,   -9
+.2byte   -9,    2, 	  -7,   -1, 	   1,    1, 	  -1,   -7
+.2byte   -9,    2, 	  -7,   -1, 	   1,    1, 	  -1,   -7
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -1,    2, 	  -4,    4, 	   2,    4, 	  -1,   -6
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,  -11
+.2byte   -1,   -1, 	  -5,    1, 	   3,    1, 	  -1,  -12
+.2byte   -1,  -20, 	  -5,   -9, 	   3,   -9, 	  -1,  -11
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   10,   -5, 	   7,   -1, 	   2,    1, 	  -1,   -7
+.2byte    8,  -15, 	   9,  -11, 	   3,   -9, 	  -1,  -12
+.2byte    8,   -3, 	   7,   -2, 	   2,   -1, 	   1,  -13
+.2byte   12,   -2, 	   8,    0, 	   2,    1, 	   0,   -7
+.2byte   12,   -3, 	   8,   -1, 	   2,    1, 	   0,   -7
+.2byte    5,  -20, 	   6,   -9, 	   2,   -6, 	   0,  -11
+.2byte    4,  -13, 	   5,   -7, 	  -2,   -6, 	  -1,   -5
+.2byte   16,   -7, 	   9,   -2, 	   8,    0, 	   5,   -4
+.2byte   14,  -16, 	   7,   -9, 	   7,   -7, 	   3,  -11
+.2byte   20,   -4, 	  15,   -2, 	  14,   -1, 	   9,   -9
+.2byte   16,   -2, 	   7,   -2, 	   6,    0, 	   2,   -5
+.2byte   16,   -3, 	   7,   -2, 	   6,    0, 	   2,   -5
+.2byte    8,  -22, 	   7,   -8, 	   7,   -6, 	   1,   -9
+.2byte    6,  -13, 	   1,   -8, 	   1,   -6, 	   0,   -6
+.2byte    9,  -10, 	   1,   -6, 	   6,   -3, 	   0,   -6
+.2byte    9,  -20, 	   3,  -15, 	   8,  -11, 	   0,  -11
+.2byte   13,   -8, 	   7,   -8, 	  11,   -4, 	   3,  -14
+.2byte   11,   -8, 	   2,   -5, 	   6,   -2, 	   2,   -7
+.2byte   11,   -9, 	   2,   -5, 	   6,   -2, 	   1,   -7
+.2byte    4,  -24, 	  -2,  -11, 	   4,   -8, 	  -2,  -10
+.2byte    5,  -16, 	  -1,  -10, 	   5,   -6, 	   0,   -6
+.2byte   -1,  -11, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -20, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	   3,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -1,   -6, 	   3,   -2, 	  -4,   -2, 	  -1,   -5
+.2byte   -1,  -21, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte   -1,  -17, 	   3,   -8, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,  -10, 	  -2,   -6, 	  -7,   -3, 	  -1,   -6
+.2byte  -10,  -20, 	  -4,  -15, 	  -9,  -11, 	  -1,  -11
+.2byte  -14,   -8, 	  -8,   -8, 	 -12,   -4, 	  -4,  -14
+.2byte  -12,   -8, 	  -3,   -5, 	  -7,   -2, 	  -3,   -7
+.2byte  -12,   -9, 	  -3,   -5, 	  -7,   -2, 	  -2,   -7
+.2byte   -5,  -24, 	   1,  -11, 	  -5,   -8, 	   1,  -10
+.2byte   -6,  -16, 	   0,  -10, 	  -6,   -6, 	  -1,   -6
+.2byte  -17,   -7, 	 -10,   -2, 	  -9,    0, 	  -6,   -4
+.2byte  -15,  -16, 	  -8,   -9, 	  -8,   -7, 	  -4,  -11
+.2byte  -21,   -4, 	 -16,   -2, 	 -15,   -1, 	 -10,   -9
+.2byte  -17,   -2, 	  -8,   -2, 	  -7,    0, 	  -3,   -5
+.2byte  -17,   -3, 	  -8,   -2, 	  -7,    0, 	  -3,   -5
+.2byte   -9,  -22, 	  -8,   -8, 	  -8,   -6, 	  -2,   -9
+.2byte   -7,  -13, 	  -2,   -8, 	  -2,   -6, 	  -1,   -6
+.2byte  -11,   -5, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -9,  -15, 	 -10,  -11, 	  -4,   -9, 	   0,  -12
+.2byte  -13,   -4, 	 -12,   -3, 	  -7,   -2, 	  -6,  -14
+.2byte  -13,   -2, 	  -9,    0, 	  -3,    1, 	  -1,   -7
+.2byte  -13,   -3, 	  -9,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -6,  -20, 	  -7,   -9, 	  -3,   -6, 	  -1,  -11
+.2byte   -5,  -13, 	  -6,   -7, 	   1,   -6, 	   0,   -5
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -1,    2, 	  -4,    4, 	   2,    4, 	  -1,   -6
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,  -11
+.2byte   -1,   -1, 	  -5,    1, 	   3,    1, 	  -1,  -12
+.2byte   -1,  -17, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   10,   -5, 	   7,   -1, 	   2,    1, 	  -1,   -7
+.2byte    8,  -15, 	   9,  -11, 	   3,   -9, 	  -1,  -12
+.2byte    8,   -3, 	   7,   -2, 	   2,   -1, 	   1,  -13
+.2byte   12,   -2, 	   8,    0, 	   2,    1, 	   0,   -7
+.2byte   12,   -3, 	   8,   -1, 	   2,    1, 	   0,   -7
+.2byte    7,  -18, 	   8,   -7, 	   4,   -4, 	   2,   -9
+.2byte    4,  -13, 	   5,   -7, 	  -2,   -6, 	  -1,   -5
+.2byte   16,   -7, 	   9,   -2, 	   8,    0, 	   5,   -4
+.2byte   14,  -16, 	   7,   -9, 	   7,   -7, 	   3,  -11
+.2byte   20,   -4, 	  15,   -2, 	  14,   -1, 	   9,   -9
+.2byte   16,   -2, 	   7,   -2, 	   6,    0, 	   2,   -5
+.2byte   16,   -3, 	   7,   -2, 	   6,    0, 	   2,   -5
+.2byte    8,  -22, 	   7,   -8, 	   7,   -6, 	   1,   -9
+.2byte    6,  -13, 	   1,   -8, 	   1,   -6, 	   0,   -6
+.2byte    9,  -10, 	   1,   -6, 	   6,   -3, 	   0,   -6
+.2byte    9,  -20, 	   3,  -15, 	   8,  -11, 	   0,  -11
+.2byte   13,   -8, 	   7,   -8, 	  11,   -4, 	   3,  -14
+.2byte   11,   -8, 	   2,   -5, 	   6,   -2, 	   2,   -7
+.2byte   11,   -9, 	   2,   -5, 	   6,   -2, 	   1,   -7
+.2byte    7,  -23, 	   1,  -10, 	   7,   -7, 	   1,   -9
+.2byte    5,  -16, 	  -1,  -10, 	   5,   -6, 	   0,   -6
+.2byte   -1,  -11, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -20, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	   3,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -1,   -6, 	   3,   -2, 	  -4,   -2, 	  -1,   -5
+.2byte   -1,  -21, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte   -1,  -17, 	   3,   -8, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,  -10, 	  -2,   -6, 	  -7,   -3, 	  -1,   -6
+.2byte  -10,  -20, 	  -4,  -15, 	  -9,  -11, 	  -1,  -11
+.2byte  -14,   -8, 	  -8,   -8, 	 -12,   -4, 	  -4,  -14
+.2byte  -12,   -8, 	  -3,   -5, 	  -7,   -2, 	  -3,   -7
+.2byte  -12,   -9, 	  -3,   -5, 	  -7,   -2, 	  -2,   -7
+.2byte   -5,  -22, 	   1,   -9, 	  -5,   -6, 	   1,   -8
+.2byte   -6,  -16, 	   0,  -10, 	  -6,   -6, 	  -1,   -6
+.2byte  -17,   -7, 	 -10,   -2, 	  -9,    0, 	  -6,   -4
+.2byte  -15,  -16, 	  -8,   -9, 	  -8,   -7, 	  -4,  -11
+.2byte  -21,   -4, 	 -16,   -2, 	 -15,   -1, 	 -10,   -9
+.2byte  -17,   -2, 	  -8,   -2, 	  -7,    0, 	  -3,   -5
+.2byte  -17,   -3, 	  -8,   -2, 	  -7,    0, 	  -3,   -5
+.2byte   -9,  -22, 	  -8,   -8, 	  -8,   -6, 	  -2,   -9
+.2byte   -7,  -13, 	  -2,   -8, 	  -2,   -6, 	  -1,   -6
+.2byte  -11,   -5, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -9,  -15, 	 -10,  -11, 	  -4,   -9, 	   0,  -12
+.2byte  -13,   -4, 	 -12,   -3, 	  -7,   -2, 	  -6,  -14
+.2byte  -13,   -2, 	  -9,    0, 	  -3,    1, 	  -1,   -7
+.2byte  -13,   -3, 	  -9,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -8,  -18, 	  -9,   -7, 	  -5,   -4, 	  -3,   -9
+.2byte   -5,  -13, 	  -6,   -7, 	   1,   -6, 	   0,   -5
+.2byte   -4,   -5, 	  -7,    1, 	  -2,    2, 	   5,   -3
+.2byte   -4,   -4, 	  -7,    1, 	  -2,    2, 	   5,   -3
+.2byte   -1,   -3, 	  -4,   -7, 	   3,   -7, 	  -1,  -12
+.2byte    7,   -2, 	   4,  -11, 	  -3,   -9, 	   0,  -15
+.2byte    9,   -1, 	   1,   -8, 	  -1,   -6, 	   1,  -13
+.2byte    8,   -4, 	  -2,  -11, 	   0,   -7, 	  -5,  -15
+.2byte    2,   -4, 	  -2,   -8, 	   3,   -8, 	   0,  -16
+.2byte   -5,   -4, 	   5,  -11, 	   3,   -7, 	   8,  -15
+.2byte   -6,   -1, 	   2,   -8, 	   4,   -6, 	   2,  -13
+.2byte   -8,   -2, 	  -5,  -11, 	   2,   -9, 	  -1,  -15
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -5,  -13, 	  -6,   -7, 	   1,   -6, 	   0,   -5
+.2byte   -7,  -13, 	  -2,   -8, 	  -2,   -6, 	  -1,   -6
+.2byte   -6,  -16, 	   0,  -10, 	  -6,   -6, 	  -1,   -6
+.2byte   -1,  -17, 	   3,   -8, 	  -5,   -8, 	  -1,   -8
+.2byte    5,  -16, 	  -1,  -10, 	   5,   -6, 	   0,   -6
+.2byte    6,  -13, 	   1,   -8, 	   1,   -6, 	   0,   -6
+.2byte    4,  -13, 	   5,   -7, 	  -2,   -6, 	  -1,   -5
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -5,  -13, 	  -6,   -7, 	   1,   -6, 	   0,   -5
+.2byte   -7,  -13, 	  -2,   -8, 	  -2,   -6, 	  -1,   -6
+.2byte   -6,  -16, 	   0,  -10, 	  -6,   -6, 	  -1,   -6
+.2byte   -1,  -17, 	   3,   -8, 	  -5,   -8, 	  -1,   -8
+.2byte    5,  -16, 	  -1,  -10, 	   5,   -6, 	   0,   -6
+.2byte    6,  -13, 	   1,   -8, 	   1,   -6, 	   0,   -6
+.2byte    4,  -13, 	   5,   -7, 	  -2,   -6, 	  -1,   -5
+.2byte    0,  -17, 	  -4,   -6, 	   4,   -6, 	   0,   -8
+.2byte    7,  -16, 	   8,   -5, 	   4,   -2, 	   2,   -7
+.2byte    8,  -20, 	   7,   -6, 	   7,   -4, 	   1,   -7
+.2byte    6,  -22, 	   0,   -9, 	   6,   -6, 	   0,   -8
+.2byte   -1,  -22, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -8,  -23, 	  -2,  -10, 	  -8,   -7, 	  -2,   -9
+.2byte  -10,  -21, 	  -9,   -7, 	  -9,   -5, 	  -3,   -8
+.2byte   -8,  -16, 	  -9,   -5, 	  -5,   -2, 	  -3,   -7
+.2byte   -1,  -13, 	  -5,   -6, 	   3,   -6, 	  -1,   -7
+.2byte   -1,  -18, 	  -5,   -7, 	   3,   -7, 	  -1,   -9
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,  -11
+.2byte    4,  -13, 	   5,   -7, 	  -2,   -6, 	  -1,   -5
+.2byte    6,  -17, 	   7,   -6, 	   3,   -3, 	   1,   -8
+.2byte   10,   -2, 	   6,    0, 	   0,    1, 	  -2,   -7
+.2byte    6,  -13, 	   1,   -8, 	   1,   -6, 	   0,   -6
+.2byte    7,  -22, 	   6,   -8, 	   6,   -6, 	   0,   -9
+.2byte   11,   -2, 	   2,   -2, 	   1,    0, 	  -3,   -5
+.2byte    5,  -16, 	  -1,  -10, 	   5,   -6, 	   0,   -6
+.2byte    4,  -24, 	  -2,  -11, 	   4,   -8, 	  -2,  -10
+.2byte    7,   -8, 	  -2,   -5, 	   2,   -2, 	  -2,   -7
+.2byte   -1,  -17, 	   3,   -8, 	  -5,   -8, 	  -1,   -8
+.2byte    0,  -21, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,   -7, 	   4,   -2, 	  -4,   -2, 	   0,   -5
+.2byte   -6,  -16, 	   0,  -10, 	  -6,   -6, 	  -1,   -6
+.2byte   -5,  -24, 	   1,  -11, 	  -5,   -8, 	   1,  -10
+.2byte   -8,   -8, 	   1,   -5, 	  -3,   -2, 	   1,   -7
+.2byte   -7,  -13, 	  -2,   -8, 	  -2,   -6, 	  -1,   -6
+.2byte   -8,  -22, 	  -7,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte  -12,   -2, 	  -3,   -2, 	  -2,    0, 	   2,   -5
+.2byte   -5,  -13, 	  -6,   -7, 	   1,   -6, 	   0,   -5
+.2byte   -7,  -17, 	  -8,   -6, 	  -4,   -3, 	  -2,   -8
+.2byte  -11,   -2, 	  -7,    0, 	  -1,    1, 	   1,   -7
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte  -11,   -4, 	  -8,    0, 	  -3,    2, 	   0,   -6
+.2byte  -15,   -7, 	  -8,   -2, 	  -7,    0, 	  -4,   -4
+.2byte  -10,   -9, 	  -2,   -5, 	  -7,   -2, 	  -1,   -5
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte    9,   -9, 	   1,   -5, 	   6,   -2, 	   0,   -5
+.2byte   14,   -7, 	   7,   -2, 	   6,    0, 	   3,   -4
+.2byte   10,   -4, 	   7,    0, 	   2,    2, 	  -1,   -6
+.2byte   -5,  -16, 	  -9,   -9, 	  -1,   -9, 	  -5,  -10
+.2byte  -11,  -13, 	 -12,   -7, 	  -5,   -6, 	  -6,   -5
+.2byte   -7,  -13, 	  -2,   -8, 	  -2,   -6, 	  -1,   -6
+.2byte  -13,  -16, 	  -7,  -10, 	 -13,   -6, 	  -8,   -6
+.2byte   -5,  -17, 	  -1,   -8, 	  -9,   -8, 	  -5,   -8
+.2byte   12,  -16, 	   6,  -10, 	  12,   -6, 	   7,   -6
+.2byte    6,  -13, 	   1,   -8, 	   1,   -6, 	   0,   -6
+.2byte   10,  -13, 	  11,   -7, 	   4,   -6, 	   5,   -5
+sFurretAnimTable1:
+.4byte sFurretAnims_1_1
+.4byte sFurretAnims_1_2
+.4byte sFurretAnims_1_3
+.4byte sFurretAnims_1_4
+.4byte sFurretAnims_1_5
+.4byte sFurretAnims_1_6
+.4byte sFurretAnims_1_7
+.4byte sFurretAnims_1_8
+sFurretAnimTable2:
+.4byte sFurretAnims_2_1
+.4byte sFurretAnims_2_2
+.4byte sFurretAnims_2_3
+.4byte sFurretAnims_2_4
+.4byte sFurretAnims_2_5
+.4byte sFurretAnims_2_6
+.4byte sFurretAnims_2_7
+.4byte sFurretAnims_2_8
+sFurretAnimTable3:
+.4byte sFurretAnims_3_1
+.4byte sFurretAnims_3_2
+.4byte sFurretAnims_3_3
+.4byte sFurretAnims_3_4
+.4byte sFurretAnims_3_5
+.4byte sFurretAnims_3_6
+.4byte sFurretAnims_3_7
+.4byte sFurretAnims_3_8
+sFurretAnimTable4:
+.4byte sFurretAnims_4_1
+.4byte sFurretAnims_4_2
+.4byte sFurretAnims_4_3
+.4byte sFurretAnims_4_4
+.4byte sFurretAnims_4_5
+.4byte sFurretAnims_4_6
+.4byte sFurretAnims_4_7
+.4byte sFurretAnims_4_8
+sFurretAnimTable5:
+.4byte sFurretAnims_5_1
+.4byte sFurretAnims_5_2
+.4byte sFurretAnims_5_3
+.4byte sFurretAnims_5_4
+.4byte sFurretAnims_5_5
+.4byte sFurretAnims_5_6
+.4byte sFurretAnims_5_7
+.4byte sFurretAnims_5_8
+sFurretAnimTable6:
+.4byte sFurretAnims_6_1
+.4byte sFurretAnims_6_1
+.4byte sFurretAnims_6_1
+.4byte sFurretAnims_6_1
+.4byte sFurretAnims_6_1
+.4byte sFurretAnims_6_1
+.4byte sFurretAnims_6_1
+.4byte sFurretAnims_6_1
+sFurretAnimTable7:
+.4byte sFurretAnims_7_1
+.4byte sFurretAnims_7_2
+.4byte sFurretAnims_7_3
+.4byte sFurretAnims_7_4
+.4byte sFurretAnims_7_5
+.4byte sFurretAnims_7_6
+.4byte sFurretAnims_7_7
+.4byte sFurretAnims_7_8
+sFurretAnimTable8:
+.4byte sFurretAnims_8_1
+.4byte sFurretAnims_8_2
+.4byte sFurretAnims_8_3
+.4byte sFurretAnims_8_4
+.4byte sFurretAnims_8_5
+.4byte sFurretAnims_8_6
+.4byte sFurretAnims_8_7
+.4byte sFurretAnims_8_8
+sFurretAnimTable9:
+.4byte sFurretAnims_9_1
+.4byte sFurretAnims_9_2
+.4byte sFurretAnims_9_3
+.4byte sFurretAnims_9_4
+.4byte sFurretAnims_9_5
+.4byte sFurretAnims_9_6
+.4byte sFurretAnims_9_7
+.4byte sFurretAnims_9_8
+sFurretAnimTable10:
+.4byte sFurretAnims_10_1
+.4byte sFurretAnims_10_2
+.4byte sFurretAnims_10_3
+.4byte sFurretAnims_10_4
+.4byte sFurretAnims_10_5
+.4byte sFurretAnims_10_6
+.4byte sFurretAnims_10_7
+.4byte sFurretAnims_10_8
+sFurretAnimTable11:
+.4byte sFurretAnims_11_1
+.4byte sFurretAnims_11_2
+.4byte sFurretAnims_11_3
+.4byte sFurretAnims_11_4
+.4byte sFurretAnims_11_5
+.4byte sFurretAnims_11_6
+.4byte sFurretAnims_11_7
+.4byte sFurretAnims_11_8
+sFurretAnimTable12:
+.4byte sFurretAnims_12_1
+.4byte sFurretAnims_12_2
+.4byte sFurretAnims_12_3
+.4byte sFurretAnims_12_4
+.4byte sFurretAnims_12_5
+.4byte sFurretAnims_12_6
+.4byte sFurretAnims_12_7
+.4byte sFurretAnims_12_8
+sFurretAnimTable13:
+.4byte sFurretAnims_13_1
+.4byte sFurretAnims_13_2
+.4byte sFurretAnims_13_3
+.4byte sFurretAnims_13_4
+.4byte sFurretAnims_13_5
+.4byte sFurretAnims_13_6
+.4byte sFurretAnims_13_7
+.4byte sFurretAnims_13_8
+sAxAnimationsFurret:
+.4byte sFurretAnimTable1
+.4byte sFurretAnimTable2
+.4byte sFurretAnimTable3
+.4byte sFurretAnimTable4
+.4byte sFurretAnimTable5
+.4byte sFurretAnimTable6
+.4byte sFurretAnimTable7
+.4byte sFurretAnimTable8
+.4byte sFurretAnimTable9
+.4byte sFurretAnimTable10
+.4byte sFurretAnimTable11
+.4byte sFurretAnimTable12
+.4byte sFurretAnimTable13
+sAxSpritesFurret:
+.4byte sFurretSprites1
+.4byte sFurretSprites2
+.4byte sFurretSprites3
+.4byte sFurretSprites4
+.4byte sFurretSprites5
+.4byte sFurretSprites6
+.4byte sFurretSprites7
+.4byte sFurretSprites8
+.4byte sFurretSprites9
+.4byte sFurretSprites10
+.4byte sFurretSprites11
+.4byte sFurretSprites12
+.4byte sFurretSprites13
+.4byte sFurretSprites14
+.4byte sFurretSprites15
+.4byte sFurretSprites16
+.4byte sFurretSprites17
+.4byte sFurretSprites18
+.4byte sFurretSprites19
+.4byte sFurretSprites20
+.4byte sFurretSprites21
+.4byte sFurretSprites22
+.4byte sFurretSprites23
+.4byte sFurretSprites24
+.4byte sFurretSprites25
+.4byte sFurretSprites26
+.4byte sFurretSprites27
+.4byte sFurretSprites28
+.4byte sFurretSprites29
+.4byte sFurretSprites30
+.4byte sFurretSprites31
+.4byte sFurretSprites32
+.4byte sFurretSprites33
+.4byte sFurretSprites34
+.4byte sFurretSprites35
+.4byte sFurretSprites36
+.4byte sFurretSprites37
+.4byte sFurretSprites38
+.4byte sFurretSprites39
+.4byte sFurretSprites40
+.4byte sFurretSprites41
+.4byte sFurretSprites42
+.4byte sFurretSprites43
+.4byte sFurretSprites44
+.4byte sFurretSprites45
+.4byte sFurretSprites46
+.4byte sFurretSprites47
+.4byte sFurretSprites48
+.4byte sFurretSprites49
+.4byte sFurretSprites50
+.4byte sFurretSprites51
+.4byte sFurretSprites52
+.4byte sFurretSprites53
+.4byte sFurretSprites54
+.4byte sFurretSprites55
+.4byte sFurretSprites56
+.4byte sFurretSprites57
+.4byte sFurretSprites58
+.4byte sFurretSprites59
+.4byte sFurretSprites60
+.4byte sFurretSprites61
+.4byte sFurretSprites62
+.4byte sFurretSprites63
+.4byte sFurretSprites64
+.4byte sFurretSprites65
+.4byte sFurretSprites66
+.4byte sFurretSprites67
+.4byte sFurretSprites68
+.4byte sFurretSprites69
+.4byte sFurretSprites70
+.4byte sFurretSprites71
+.4byte sFurretSprites72
+.4byte sFurretSprites73
+.4byte sFurretSprites74
+.4byte sFurretSprites75
+.4byte sFurretSprites76
+.4byte sFurretSprites77
+.4byte sFurretSprites78
+.4byte sFurretSprites79
+.4byte sFurretSprites80
+.4byte sFurretSprites81
+.4byte sFurretSprites82
+.4byte sFurretSprites83
+.4byte sFurretSprites84
+sAxMainFurret:
+ax_main sAxPosesFurret, sAxAnimationsFurret, 13, sAxSpritesFurret, sAxPositionsFurret

--- a/data/ax/gardevoir.inc
+++ b/data/ax/gardevoir.inc
@@ -1,0 +1,3082 @@
+.global gAxGardevoir
+gAxGardevoir:
+ax_siro sAxMainGardevoir
+sGardevoirPose1:
+ax_pose 0, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose3:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose4:
+ax_pose 3, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose5:
+ax_pose 4, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose6:
+ax_pose 5, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose7:
+ax_pose 6, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose8:
+ax_pose 7, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose9:
+ax_pose 8, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose10:
+ax_pose 9, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose11:
+ax_pose 10, 0x01e9, 0x90e7, 0xac00
+ax_pose_terminator
+sGardevoirPose12:
+ax_pose 11, 0x01e4, 0x90e9, 0xac00
+ax_pose_terminator
+sGardevoirPose13:
+ax_pose 12, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose14:
+ax_pose 13, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose15:
+ax_pose 14, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose16:
+ax_pose 9, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose17:
+ax_pose 10, 0x01e9, 0x80f8, 0xac00
+ax_pose_terminator
+sGardevoirPose18:
+ax_pose 11, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose19:
+ax_pose 6, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose20:
+ax_pose 7, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose21:
+ax_pose 8, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose22:
+ax_pose 3, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose23:
+ax_pose 4, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose24:
+ax_pose 5, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose25:
+ax_pose 0, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose27:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose28:
+ax_pose 15, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose29:
+ax_pose 3, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose30:
+ax_pose 4, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose31:
+ax_pose 5, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose32:
+ax_pose 16, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose33:
+ax_pose 6, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose34:
+ax_pose 7, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose35:
+ax_pose 8, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose36:
+ax_pose 17, 0x01e9, 0x90ee, 0xac00
+ax_pose_terminator
+sGardevoirPose37:
+ax_pose 9, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose38:
+ax_pose 10, 0x01e9, 0x90e7, 0xac00
+ax_pose_terminator
+sGardevoirPose39:
+ax_pose 11, 0x01e4, 0x90e9, 0xac00
+ax_pose_terminator
+sGardevoirPose40:
+ax_pose 18, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose41:
+ax_pose 12, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose42:
+ax_pose 13, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose43:
+ax_pose 14, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose44:
+ax_pose 19, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose45:
+ax_pose 9, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose46:
+ax_pose 10, 0x01e9, 0x80f8, 0xac00
+ax_pose_terminator
+sGardevoirPose47:
+ax_pose 11, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose48:
+ax_pose 18, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose49:
+ax_pose 6, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose50:
+ax_pose 7, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose51:
+ax_pose 8, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose52:
+ax_pose 17, 0x01e9, 0x80f3, 0xac00
+ax_pose_terminator
+sGardevoirPose53:
+ax_pose 3, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose54:
+ax_pose 4, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose55:
+ax_pose 5, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose56:
+ax_pose 16, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose57:
+ax_pose 0, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose58:
+ax_pose 1, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose59:
+ax_pose 2, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose60:
+ax_pose 15, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose61:
+ax_pose 3, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose62:
+ax_pose 4, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose63:
+ax_pose 5, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose64:
+ax_pose 16, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose65:
+ax_pose 6, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose66:
+ax_pose 7, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose67:
+ax_pose 8, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose68:
+ax_pose 17, 0x01e9, 0x90ee, 0xac00
+ax_pose_terminator
+sGardevoirPose69:
+ax_pose 9, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose70:
+ax_pose 10, 0x01e9, 0x90e7, 0xac00
+ax_pose_terminator
+sGardevoirPose71:
+ax_pose 11, 0x01e4, 0x90e9, 0xac00
+ax_pose_terminator
+sGardevoirPose72:
+ax_pose 18, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose73:
+ax_pose 12, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose74:
+ax_pose 13, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose75:
+ax_pose 14, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose76:
+ax_pose 19, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose77:
+ax_pose 9, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose78:
+ax_pose 10, 0x01e9, 0x80f8, 0xac00
+ax_pose_terminator
+sGardevoirPose79:
+ax_pose 11, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose80:
+ax_pose 18, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose81:
+ax_pose 6, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose82:
+ax_pose 7, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose83:
+ax_pose 8, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose84:
+ax_pose 17, 0x01e9, 0x80f3, 0xac00
+ax_pose_terminator
+sGardevoirPose85:
+ax_pose 3, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose86:
+ax_pose 4, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose87:
+ax_pose 5, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose88:
+ax_pose 16, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose89:
+ax_pose 15, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose90:
+ax_pose 16, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose91:
+ax_pose 17, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sGardevoirPose92:
+ax_pose 18, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose93:
+ax_pose 19, 0x01e8, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose94:
+ax_pose 18, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGardevoirPose95:
+ax_pose 17, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose96:
+ax_pose 16, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGardevoirPose97:
+ax_pose 20, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose98:
+ax_pose 21, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose99:
+ax_pose 22, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose100:
+ax_pose 23, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose101:
+ax_pose 24, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose102:
+ax_pose 25, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose103:
+ax_pose 26, 0x01e9, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose104:
+ax_pose 27, 0x01e9, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose105:
+ax_pose 28, 0x01e8, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose106:
+ax_pose 29, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose107:
+ax_pose 30, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose108:
+ax_pose 31, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose109:
+ax_pose 32, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose110:
+ax_pose 33, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose111:
+ax_pose 34, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose112:
+ax_pose 29, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose113:
+ax_pose 30, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose114:
+ax_pose 31, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose115:
+ax_pose 26, 0x01e9, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose116:
+ax_pose 27, 0x01e9, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose117:
+ax_pose 28, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose118:
+ax_pose 23, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose119:
+ax_pose 24, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose120:
+ax_pose 25, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose121:
+ax_pose 35, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose122:
+ax_pose 36, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose123:
+ax_pose 37, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose124:
+ax_pose 38, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose125:
+ax_pose 39, 0x01e5, 0x90ee, 0xac00
+ax_pose_terminator
+sGardevoirPose126:
+ax_pose 40, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose127:
+ax_pose 41, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose128:
+ax_pose 40, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sGardevoirPose129:
+ax_pose 39, 0x01e5, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose130:
+ax_pose 38, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose131:
+ax_pose 0, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose132:
+ax_pose 42, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose133:
+ax_pose 43, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose134:
+ax_pose 3, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose135:
+ax_pose 44, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose136:
+ax_pose 45, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose137:
+ax_pose 6, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose138:
+ax_pose 46, 0x01e8, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose139:
+ax_pose 47, 0x01e8, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose140:
+ax_pose 9, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose141:
+ax_pose 48, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose142:
+ax_pose 49, 0x01e9, 0x90ea, 0xac00
+ax_pose_terminator
+sGardevoirPose143:
+ax_pose 12, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose144:
+ax_pose 50, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose145:
+ax_pose 51, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose146:
+ax_pose 9, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose147:
+ax_pose 48, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose148:
+ax_pose 49, 0x01e9, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose149:
+ax_pose 6, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose150:
+ax_pose 46, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose151:
+ax_pose 47, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose152:
+ax_pose 3, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose153:
+ax_pose 44, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose154:
+ax_pose 45, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose155:
+ax_pose 15, 0x01e8, 0x80f1, 0xac00
+ax_pose_terminator
+sGardevoirPose156:
+ax_pose 16, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose157:
+ax_pose 17, 0x01e9, 0x80f3, 0xac00
+ax_pose_terminator
+sGardevoirPose158:
+ax_pose 18, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose159:
+ax_pose 19, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose160:
+ax_pose 18, 0x01e8, 0x90ec, 0xac00
+ax_pose_terminator
+sGardevoirPose161:
+ax_pose 17, 0x01e9, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose162:
+ax_pose 16, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose163:
+ax_pose 21, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose164:
+ax_pose 24, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose165:
+ax_pose 27, 0x01e9, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose166:
+ax_pose 30, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose167:
+ax_pose 33, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose168:
+ax_pose 30, 0x01e8, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose169:
+ax_pose 27, 0x01e9, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose170:
+ax_pose 24, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose171:
+ax_pose 0, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose172:
+ax_pose 22, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose173:
+ax_pose 15, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose174:
+ax_pose 3, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGardevoirPose175:
+ax_pose 25, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGardevoirPose176:
+ax_pose 16, 0x01e9, 0x90ea, 0xac00
+ax_pose_terminator
+sGardevoirPose177:
+ax_pose 6, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose178:
+ax_pose 28, 0x01e8, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose179:
+ax_pose 17, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose180:
+ax_pose 9, 0x01e9, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose181:
+ax_pose 31, 0x01e8, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose182:
+ax_pose 18, 0x01ea, 0x90ea, 0xac00
+ax_pose_terminator
+sGardevoirPose183:
+ax_pose 12, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose184:
+ax_pose 34, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose185:
+ax_pose 19, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose186:
+ax_pose 9, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose187:
+ax_pose 31, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose188:
+ax_pose 18, 0x01ea, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose189:
+ax_pose 6, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose190:
+ax_pose 28, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sGardevoirPose191:
+ax_pose 17, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose192:
+ax_pose 3, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose193:
+ax_pose 25, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose194:
+ax_pose 16, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose195:
+ax_pose 15, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose196:
+ax_pose 16, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose197:
+ax_pose 17, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sGardevoirPose198:
+ax_pose 18, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose199:
+ax_pose 19, 0x01e8, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose200:
+ax_pose 18, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGardevoirPose201:
+ax_pose 17, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sGardevoirPose202:
+ax_pose 16, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGardevoirPose203:
+ax_pose 0, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sGardevoirPose204:
+ax_pose 3, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose205:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose206:
+ax_pose 9, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sGardevoirPose207:
+ax_pose 12, 0x01eb, 0x80f6, 0xac00
+ax_pose_terminator
+sGardevoirPose208:
+ax_pose 9, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose209:
+ax_pose 6, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose210:
+ax_pose 3, 0x01ea, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose211:
+ax_pose 52, 0x41f6, 0x80ed, 0xac00
+ax_pose 53, 0x81f6, 0x010d, 0xac08
+ax_pose_terminator
+sGardevoirPose212:
+ax_pose 52, 0x41f6, 0x90f3, 0xac00
+ax_pose 53, 0x81f6, 0x10eb, 0xac08
+ax_pose_terminator
+sGardevoirPose213:
+ax_pose 54, 0x01ea, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose214:
+ax_pose 55, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose215:
+ax_pose 54, 0x01ea, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose216:
+ax_pose 55, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose217:
+ax_pose 56, 0x01fc, 0x00fc, 0xac00
+ax_pose_terminator
+sGardevoirPose218:
+ax_pose 54, 0x01ea, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose219:
+ax_pose 57, 0x01ea, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose220:
+ax_pose 54, 0x01ea, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose221:
+ax_pose 57, 0x01ea, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose222:
+ax_pose 55, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose223:
+ax_pose 58, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGardevoirPose224:
+ax_pose 55, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose225:
+ax_pose 58, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sGardevoirPose226:
+ax_pose 56, 0x01fc, 0x00fc, 0xac00
+ax_pose_terminator
+.align 2
+sGardevoirAnims_1_1:
+ax_anim 8, 0, 0, 0, 2, 0, 0,
+ax_anim 12, 0, 1, 0, 2, 0, 0,
+ax_anim 8, 0, 0, 0, 2, 0, 0,
+ax_anim 12, 0, 2, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_1_2:
+ax_anim 8, 0, 3, 0, 2, 0, 0,
+ax_anim 12, 0, 4, 0, 2, 0, 0,
+ax_anim 8, 0, 3, 0, 2, 0, 0,
+ax_anim 12, 0, 5, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_1_3:
+ax_anim 8, 0, 6, 0, 2, 0, 0,
+ax_anim 12, 0, 7, 0, 2, 0, 0,
+ax_anim 8, 0, 6, 0, 2, 0, 0,
+ax_anim 12, 0, 8, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_1_4:
+ax_anim 8, 0, 9, 0, 2, 0, 0,
+ax_anim 12, 0, 10, 0, 2, 0, 0,
+ax_anim 8, 0, 9, 0, 2, 0, 0,
+ax_anim 12, 0, 11, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_1_5:
+ax_anim 8, 0, 12, 0, 2, 0, 0,
+ax_anim 12, 0, 13, 0, 2, 0, 0,
+ax_anim 8, 0, 12, 0, 2, 0, 0,
+ax_anim 12, 0, 14, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_1_6:
+ax_anim 8, 0, 15, 0, 2, 0, 0,
+ax_anim 12, 0, 16, 0, 2, 0, 0,
+ax_anim 8, 0, 15, 0, 2, 0, 0,
+ax_anim 12, 0, 17, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_1_7:
+ax_anim 8, 0, 18, 0, 2, 0, 0,
+ax_anim 12, 0, 19, 0, 2, 0, 0,
+ax_anim 8, 0, 18, 0, 2, 0, 0,
+ax_anim 12, 0, 20, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_1_8:
+ax_anim 8, 0, 21, 0, 2, 0, 0,
+ax_anim 12, 0, 22, 0, 2, 0, 0,
+ax_anim 8, 0, 21, 0, 2, 0, 0,
+ax_anim 12, 0, 23, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_2_1:
+ax_anim 2, 0, 24, 0, 1, 0, -1,
+ax_anim 4, 0, 24, 0, 0, 0, -2,
+ax_anim 1, 0, 27, 0, 2, 0, 0,
+ax_anim 1, 2, 27, 0, 6, 0, 4,
+ax_anim 1, 0, 27, 0, 12, 0, 10,
+ax_anim 2, 0, 27, 0, 24, 0, 22,
+ax_anim 2, 1, 27, 1, 24, 1, 22,
+ax_anim 2, 0, 27, 0, 24, 0, 22,
+ax_anim 2, 0, 27, 1, 24, 1, 22,
+ax_anim 2, 0, 24, 0, 8, 0, 6,
+ax_anim_terminator
+sGardevoirAnims_2_2:
+ax_anim 2, 0, 28, -1, 1, -1, -1,
+ax_anim 4, 0, 28, -2, 0, -2, -2,
+ax_anim 1, 0, 31, 0, 2, 0, 0,
+ax_anim 1, 2, 31, 4, 6, 4, 4,
+ax_anim 1, 0, 31, 10, 12, 10, 10,
+ax_anim 2, 0, 31, 21, 24, 21, 22,
+ax_anim 2, 1, 31, 22, 23, 22, 21,
+ax_anim 2, 0, 31, 21, 24, 21, 22,
+ax_anim 2, 0, 31, 22, 23, 22, 21,
+ax_anim 2, 0, 28, 6, 8, 6, 6,
+ax_anim_terminator
+sGardevoirAnims_2_3:
+ax_anim 2, 0, 32, -1, 2, -1, 0,
+ax_anim 4, 0, 32, -2, 2, -2, 0,
+ax_anim 1, 0, 35, 0, 2, 0, 0,
+ax_anim 1, 2, 35, 4, 2, 4, 0,
+ax_anim 1, 0, 35, 10, 2, 10, 0,
+ax_anim 2, 0, 35, 21, 2, 21, 0,
+ax_anim 2, 1, 35, 21, 3, 21, 1,
+ax_anim 2, 0, 35, 21, 2, 21, 0,
+ax_anim 2, 0, 35, 21, 3, 21, 1,
+ax_anim 2, 0, 32, 6, 2, 6, 0,
+ax_anim_terminator
+sGardevoirAnims_2_4:
+ax_anim 2, 0, 36, -1, 3, -1, 1,
+ax_anim 4, 0, 36, -2, 4, -2, 2,
+ax_anim 1, 0, 39, 0, 1, 0, -1,
+ax_anim 1, 2, 39, 5, -4, 5, -6,
+ax_anim 1, 0, 39, 12, -10, 12, -12,
+ax_anim 2, 0, 39, 21, -16, 21, -18,
+ax_anim 2, 1, 39, 22, -15, 22, -17,
+ax_anim 2, 0, 39, 21, -16, 21, -18,
+ax_anim 2, 0, 39, 22, -15, 22, -17,
+ax_anim 2, 0, 36, 6, -4, 6, -6,
+ax_anim_terminator
+sGardevoirAnims_2_5:
+ax_anim 2, 0, 40, 0, 3, 0, 1,
+ax_anim 4, 0, 40, 0, 4, 0, 2,
+ax_anim 1, 0, 43, 0, 2, 0, 0,
+ax_anim 1, 2, 43, 0, -2, 0, -4,
+ax_anim 1, 0, 43, 0, -8, 0, -10,
+ax_anim 2, 0, 43, 0, -15, 0, -17,
+ax_anim 2, 1, 43, 1, -15, 1, -17,
+ax_anim 2, 0, 43, 0, -15, 0, -17,
+ax_anim 2, 0, 43, 1, -15, 1, -17,
+ax_anim 2, 0, 40, 0, -4, 0, -6,
+ax_anim_terminator
+sGardevoirAnims_2_6:
+ax_anim 2, 0, 44, 1, 3, 1, 1,
+ax_anim 4, 0, 44, 2, 4, 2, 2,
+ax_anim 1, 0, 47, 0, 1, 0, -1,
+ax_anim 1, 2, 47, -5, -4, -5, -6,
+ax_anim 1, 0, 47, -12, -10, -12, -12,
+ax_anim 2, 0, 47, -21, -16, -21, -18,
+ax_anim 2, 1, 47, -22, -15, -22, -17,
+ax_anim 2, 0, 47, -21, -16, -21, -18,
+ax_anim 2, 0, 47, -22, -15, -22, -17,
+ax_anim 2, 0, 44, -6, -4, -6, -6,
+ax_anim_terminator
+sGardevoirAnims_2_7:
+ax_anim 2, 0, 48, 1, 2, 1, 0,
+ax_anim 4, 0, 48, 2, 2, 2, 0,
+ax_anim 1, 0, 51, 0, 2, 0, 0,
+ax_anim 1, 2, 51, -4, 2, -4, 0,
+ax_anim 1, 0, 51, -10, 2, -10, 0,
+ax_anim 2, 0, 51, -21, 2, -21, 0,
+ax_anim 2, 1, 51, -21, 3, -21, 1,
+ax_anim 2, 0, 51, -21, 2, -21, 0,
+ax_anim 2, 0, 51, -21, 3, -21, 1,
+ax_anim 2, 0, 48, -6, 2, -6, 0,
+ax_anim_terminator
+sGardevoirAnims_2_8:
+ax_anim 2, 0, 52, 1, 1, 1, -1,
+ax_anim 4, 0, 52, 2, 0, 2, -2,
+ax_anim 1, 0, 55, 0, 2, 0, 0,
+ax_anim 1, 2, 55, -4, 6, -4, 4,
+ax_anim 1, 0, 55, -10, 12, -10, 10,
+ax_anim 2, 0, 55, -21, 24, -21, 22,
+ax_anim 2, 1, 55, -22, 23, -22, 21,
+ax_anim 2, 0, 55, -21, 24, -21, 22,
+ax_anim 2, 0, 55, -22, 23, -22, 21,
+ax_anim 2, 0, 52, -6, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_3_1:
+ax_anim 2, 0, 56, 0, 1, 0, -1,
+ax_anim 4, 0, 56, 0, 0, 0, -2,
+ax_anim 1, 0, 59, 0, 2, 0, 0,
+ax_anim 1, 2, 59, 0, 6, 0, 4,
+ax_anim 1, 0, 59, 0, 12, 0, 10,
+ax_anim 2, 0, 59, 0, 24, 0, 22,
+ax_anim 2, 1, 59, 1, 24, 1, 22,
+ax_anim 2, 0, 59, 0, 24, 0, 22,
+ax_anim 2, 0, 59, 1, 24, 1, 22,
+ax_anim 2, 0, 56, 0, 8, 0, 6,
+ax_anim_terminator
+sGardevoirAnims_3_2:
+ax_anim 2, 0, 60, -1, 1, -1, -1,
+ax_anim 4, 0, 60, -2, 0, -2, -2,
+ax_anim 1, 0, 63, 0, 2, 0, 0,
+ax_anim 1, 2, 63, 4, 6, 4, 4,
+ax_anim 1, 0, 63, 10, 12, 10, 10,
+ax_anim 2, 0, 63, 21, 24, 21, 22,
+ax_anim 2, 1, 63, 22, 23, 22, 21,
+ax_anim 2, 0, 63, 21, 24, 21, 22,
+ax_anim 2, 0, 63, 22, 23, 22, 21,
+ax_anim 2, 0, 60, 6, 8, 6, 6,
+ax_anim_terminator
+sGardevoirAnims_3_3:
+ax_anim 2, 0, 64, -1, 2, -1, 0,
+ax_anim 4, 0, 64, -2, 2, -2, 0,
+ax_anim 1, 0, 67, 0, 2, 0, 0,
+ax_anim 1, 2, 67, 4, 2, 4, 0,
+ax_anim 1, 0, 67, 10, 2, 10, 0,
+ax_anim 2, 0, 67, 21, 2, 21, 0,
+ax_anim 2, 1, 67, 21, 3, 21, 1,
+ax_anim 2, 0, 67, 21, 2, 21, 0,
+ax_anim 2, 0, 67, 21, 3, 21, 1,
+ax_anim 2, 0, 64, 6, 2, 6, 0,
+ax_anim_terminator
+sGardevoirAnims_3_4:
+ax_anim 2, 0, 68, -1, 3, -1, 1,
+ax_anim 4, 0, 68, -2, 4, -2, 2,
+ax_anim 1, 0, 71, 0, 1, 0, -1,
+ax_anim 1, 2, 71, 5, -4, 5, -6,
+ax_anim 1, 0, 71, 12, -10, 12, -12,
+ax_anim 2, 0, 71, 21, -16, 21, -18,
+ax_anim 2, 1, 71, 22, -15, 22, -17,
+ax_anim 2, 0, 71, 21, -16, 21, -18,
+ax_anim 2, 0, 71, 22, -15, 22, -17,
+ax_anim 2, 0, 68, 6, -4, 6, -6,
+ax_anim_terminator
+sGardevoirAnims_3_5:
+ax_anim 2, 0, 72, 0, 3, 0, 1,
+ax_anim 4, 0, 72, 0, 4, 0, 2,
+ax_anim 1, 0, 75, 0, 2, 0, 0,
+ax_anim 1, 2, 75, 0, -2, 0, -4,
+ax_anim 1, 0, 75, 0, -8, 0, -10,
+ax_anim 2, 0, 75, 0, -15, 0, -17,
+ax_anim 2, 1, 75, 1, -15, 1, -17,
+ax_anim 2, 0, 75, 0, -15, 0, -17,
+ax_anim 2, 0, 75, 1, -15, 1, -17,
+ax_anim 2, 0, 72, 0, -4, 0, -6,
+ax_anim_terminator
+sGardevoirAnims_3_6:
+ax_anim 2, 0, 76, 1, 3, 1, 1,
+ax_anim 4, 0, 76, 2, 4, 2, 2,
+ax_anim 1, 0, 79, 0, 1, 0, -1,
+ax_anim 1, 2, 79, -5, -4, -5, -6,
+ax_anim 1, 0, 79, -12, -10, -12, -12,
+ax_anim 2, 0, 79, -21, -16, -21, -18,
+ax_anim 2, 1, 79, -22, -15, -22, -17,
+ax_anim 2, 0, 79, -21, -16, -21, -18,
+ax_anim 2, 0, 79, -22, -15, -22, -17,
+ax_anim 2, 0, 76, -6, -4, -6, -6,
+ax_anim_terminator
+sGardevoirAnims_3_7:
+ax_anim 2, 0, 80, 1, 2, 1, 0,
+ax_anim 4, 0, 80, 2, 2, 2, 0,
+ax_anim 1, 0, 83, 0, 2, 0, 0,
+ax_anim 1, 2, 83, -4, 2, -4, 0,
+ax_anim 1, 0, 83, -10, 2, -10, 0,
+ax_anim 2, 0, 83, -21, 2, -21, 0,
+ax_anim 2, 1, 83, -21, 3, -21, 1,
+ax_anim 2, 0, 83, -21, 2, -21, 0,
+ax_anim 2, 0, 83, -21, 3, -21, 1,
+ax_anim 2, 0, 80, -6, 2, -6, 0,
+ax_anim_terminator
+sGardevoirAnims_3_8:
+ax_anim 2, 0, 84, 1, 1, 1, -1,
+ax_anim 4, 0, 84, 2, 0, 2, -2,
+ax_anim 1, 0, 87, 0, 2, 0, 0,
+ax_anim 1, 2, 87, -4, 6, -4, 4,
+ax_anim 1, 0, 87, -10, 12, -10, 10,
+ax_anim 2, 0, 87, -21, 24, -21, 22,
+ax_anim 2, 1, 87, -22, 23, -22, 21,
+ax_anim 2, 0, 87, -21, 24, -21, 22,
+ax_anim 2, 0, 87, -22, 23, -22, 21,
+ax_anim 2, 0, 84, -6, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_4_1:
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_4_2:
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_4_3:
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_4_4:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_4_5:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_4_6:
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_4_7:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_4_8:
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_5_1:
+ax_anim 1, 0, 98, 0, 1, 0, -1,
+ax_anim 6, 0, 98, 0, 0, 0, -2,
+ax_anim 1, 0, 98, 0, 1, 0, -1,
+ax_anim 4, 0, 96, 0, 2, 0, 0,
+ax_anim 5, 2, 97, 0, 2, 0, 0,
+ax_anim 4, 0, 96, 0, 2, 0, 0,
+ax_anim 5, 0, 97, 0, 2, 0, 0,
+ax_anim 4, 0, 96, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_5_2:
+ax_anim 1, 0, 101, -1, 1, -1, -1,
+ax_anim 6, 0, 101, -2, 0, -2, -2,
+ax_anim 1, 0, 101, -1, 1, -1, -1,
+ax_anim 4, 0, 99, 0, 2, 0, 0,
+ax_anim 5, 2, 100, 0, 2, 0, 0,
+ax_anim 4, 0, 99, 0, 2, 0, 0,
+ax_anim 5, 0, 100, 0, 2, 0, 0,
+ax_anim 4, 0, 99, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_5_3:
+ax_anim 1, 0, 104, -1, 2, -1, 0,
+ax_anim 6, 0, 104, -2, 2, -2, 0,
+ax_anim 1, 0, 104, -1, 2, -1, 0,
+ax_anim 4, 0, 102, 0, 2, 0, 0,
+ax_anim 5, 2, 103, 0, 2, 0, 0,
+ax_anim 4, 0, 102, 0, 2, 0, 0,
+ax_anim 5, 0, 103, 0, 2, 0, 0,
+ax_anim 4, 0, 102, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_5_4:
+ax_anim 1, 0, 107, -1, 3, -1, 1,
+ax_anim 6, 0, 107, -2, 4, -2, 2,
+ax_anim 1, 0, 107, -1, 3, -1, 1,
+ax_anim 4, 0, 105, 0, 2, 0, 0,
+ax_anim 5, 2, 106, 0, 2, 0, 0,
+ax_anim 4, 0, 105, 0, 2, 0, 0,
+ax_anim 5, 0, 106, 0, 2, 0, 0,
+ax_anim 4, 0, 105, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_5_5:
+ax_anim 1, 0, 110, 0, 4, 0, 2,
+ax_anim 6, 0, 110, 0, 5, 0, 3,
+ax_anim 1, 0, 110, 0, 4, 0, 2,
+ax_anim 4, 0, 108, 0, 2, 0, 0,
+ax_anim 5, 2, 109, 0, 2, 0, 0,
+ax_anim 4, 0, 108, 0, 2, 0, 0,
+ax_anim 5, 0, 109, 0, 2, 0, 0,
+ax_anim 4, 0, 108, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_5_6:
+ax_anim 1, 0, 113, 1, 3, 1, 1,
+ax_anim 6, 0, 113, 2, 4, 2, 2,
+ax_anim 1, 0, 113, 1, 3, 1, 1,
+ax_anim 4, 0, 111, 0, 2, 0, 0,
+ax_anim 5, 2, 112, 0, 2, 0, 0,
+ax_anim 4, 0, 111, 0, 2, 0, 0,
+ax_anim 5, 0, 112, 0, 2, 0, 0,
+ax_anim 4, 0, 111, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_5_7:
+ax_anim 1, 0, 116, 1, 2, 1, 0,
+ax_anim 6, 0, 116, 2, 2, 2, 0,
+ax_anim 1, 0, 116, 1, 2, 1, 0,
+ax_anim 4, 0, 114, 0, 2, 0, 0,
+ax_anim 5, 2, 115, 0, 2, 0, 0,
+ax_anim 4, 0, 114, 0, 2, 0, 0,
+ax_anim 5, 0, 115, 0, 2, 0, 0,
+ax_anim 4, 0, 114, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_5_8:
+ax_anim 1, 0, 119, 1, 1, 1, -1,
+ax_anim 6, 0, 119, 2, 0, 2, -2,
+ax_anim 1, 0, 119, 1, 1, 1, -1,
+ax_anim 4, 0, 117, 0, 2, 0, 0,
+ax_anim 5, 2, 118, 0, 2, 0, 0,
+ax_anim 4, 0, 117, 0, 2, 0, 0,
+ax_anim 5, 0, 118, 0, 2, 0, 0,
+ax_anim 4, 0, 117, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sGardevoirAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sGardevoirAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sGardevoirAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sGardevoirAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sGardevoirAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sGardevoirAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sGardevoirAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_8_1:
+ax_anim 6, 0, 130, 0, 2, 0, 0,
+ax_anim 12, 0, 131, 0, 2, 0, 0,
+ax_anim 6, 0, 130, 0, 2, 0, 0,
+ax_anim 12, 0, 132, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_8_2:
+ax_anim 6, 0, 133, 0, 2, 0, 0,
+ax_anim 12, 0, 134, 0, 2, 0, 0,
+ax_anim 6, 0, 133, 0, 2, 0, 0,
+ax_anim 12, 0, 135, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_8_3:
+ax_anim 6, 0, 136, 0, 2, 0, 0,
+ax_anim 12, 0, 137, 0, 2, 0, 0,
+ax_anim 6, 0, 136, 0, 2, 0, 0,
+ax_anim 12, 0, 138, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_8_4:
+ax_anim 6, 0, 139, 0, 2, 0, 0,
+ax_anim 12, 0, 140, 0, 2, 0, 0,
+ax_anim 6, 0, 139, 0, 2, 0, 0,
+ax_anim 12, 0, 141, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_8_5:
+ax_anim 6, 0, 142, 0, 2, 0, 0,
+ax_anim 12, 0, 143, 0, 2, 0, 0,
+ax_anim 6, 0, 142, 0, 2, 0, 0,
+ax_anim 12, 0, 144, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_8_6:
+ax_anim 6, 0, 145, 0, 2, 0, 0,
+ax_anim 12, 0, 146, 0, 2, 0, 0,
+ax_anim 6, 0, 145, 0, 2, 0, 0,
+ax_anim 12, 0, 147, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_8_7:
+ax_anim 6, 0, 148, 0, 2, 0, 0,
+ax_anim 12, 0, 149, 0, 2, 0, 0,
+ax_anim 6, 0, 148, 0, 2, 0, 0,
+ax_anim 12, 0, 150, 0, 2, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_8_8:
+ax_anim 6, 0, 151, 0, 2, 0, 0,
+ax_anim 12, 0, 152, 0, 2, 0, 0,
+ax_anim 6, 0, 151, 0, 2, 0, 0,
+ax_anim 12, 0, 153, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 4, 3, 4, 3,
+ax_anim 2, 0, 156, 7, 10, 7, 10,
+ax_anim 2, 0, 157, 7, 19, 7, 19,
+ax_anim 3, 0, 158, 0, 21, 0, 21,
+ax_anim 2, 3, 159, -7, 19, -7, 19,
+ax_anim 2, 0, 160, -7, 10, -7, 10,
+ax_anim 1, 0, 161, -4, 3, -4, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 9, 2, 9, 2,
+ax_anim 2, 0, 155, 17, 7, 17, 7,
+ax_anim 2, 0, 156, 22, 14, 22, 14,
+ax_anim 3, 0, 157, 22, 22, 22, 21,
+ax_anim 2, 3, 158, 13, 22, 13, 22,
+ax_anim 2, 0, 159, 4, 17, 4, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 5, -4, 5, -4,
+ax_anim 2, 0, 154, 10, -5, 10, -5,
+ax_anim 2, 0, 155, 18, -5, 18, -5,
+ax_anim 3, 0, 156, 21, 1, 21, 0,
+ax_anim 2, 3, 157, 17, 5, 17, 5,
+ax_anim 2, 0, 158, 12, 6, 12, 6,
+ax_anim 1, 0, 159, 5, 5, 5, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -7, 0, -7,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -19, 12, -19,
+ax_anim 3, 0, 155, 20, -20, 20, -21,
+ax_anim 2, 3, 156, 21, -12, 21, -12,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 9, 0, 9, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -11, -9, -11,
+ax_anim 2, 0, 161, -6, -18, -6, -18,
+ax_anim 3, 0, 154, 0, -20, 0, -22,
+ax_anim 2, 3, 155, 6, -18, 6, -18,
+ax_anim 2, 0, 156, 9, -11, 9, -11,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -7, 0, -7,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -19, -12, -19,
+ax_anim 3, 0, 161, -20, -20, -20, -21,
+ax_anim 2, 3, 160, -21, -12, -21, -12,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -9, 0, -9, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -5, -4, -5, -4,
+ax_anim 2, 0, 154, -10, -5, -10, -5,
+ax_anim 2, 0, 161, -18, -5, -18, -5,
+ax_anim 3, 0, 160, -21, 1, -21, 0,
+ax_anim 2, 3, 159, -17, 5, -17, 5,
+ax_anim 2, 0, 158, -12, 6, -12, 6,
+ax_anim 1, 0, 157, -5, 5, -5, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -9, 2, -9, 2,
+ax_anim 2, 0, 161, -17, 7, -17, 7,
+ax_anim 2, 0, 160, -22, 14, -22, 14,
+ax_anim 3, 0, 159, -22, 22, -22, 21,
+ax_anim 2, 3, 158, -13, 22, -13, 22,
+ax_anim 2, 0, 157, -4, 17, -4, 17,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 1, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -21, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 1, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 1, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 1, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_14_1:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_14_2:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_14_3:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_14_4:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_14_5:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_14_6:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_14_7:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_14_8:
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_15_1:
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_15_2:
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_15_3:
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_15_4:
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_15_5:
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_15_6:
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_15_7:
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_15_8:
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGardevoirAnims_16_1:
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 3, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 5, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 6, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 7, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 9, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_16_2:
+ax_anim 1, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 3, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 5, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 6, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 7, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 9, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_16_3:
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 3, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 5, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 6, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 7, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 9, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_16_4:
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_16_5:
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_16_6:
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_16_7:
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 3, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 5, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 7, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 9, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirAnims_16_8:
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 3, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 5, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 6, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 7, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 9, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGardevoirGfx1:
+.incbin "baserom.gba", 0x1181650, 0x200
+sGardevoirSprites1:
+ax_sprite sGardevoirGfx1, 0x200
+ax_sprite_terminator
+sGardevoirGfx2:
+.incbin "baserom.gba", 0x1181860, 0x200
+sGardevoirSprites2:
+ax_sprite sGardevoirGfx2, 0x200
+ax_sprite_terminator
+sGardevoirGfx3:
+.incbin "baserom.gba", 0x1181A70, 0x200
+sGardevoirSprites3:
+ax_sprite sGardevoirGfx3, 0x200
+ax_sprite_terminator
+sGardevoirGfx4:
+.incbin "baserom.gba", 0x1181C80, 0x200
+sGardevoirSprites4:
+ax_sprite sGardevoirGfx4, 0x200
+ax_sprite_terminator
+sGardevoirGfx5:
+.incbin "baserom.gba", 0x1181E90, 0x200
+sGardevoirSprites5:
+ax_sprite sGardevoirGfx5, 0x200
+ax_sprite_terminator
+sGardevoirGfx6:
+.incbin "baserom.gba", 0x11820A0, 0x200
+sGardevoirSprites6:
+ax_sprite sGardevoirGfx6, 0x200
+ax_sprite_terminator
+sGardevoirGfx7:
+.incbin "baserom.gba", 0x11822B0, 0x200
+sGardevoirSprites7:
+ax_sprite sGardevoirGfx7, 0x200
+ax_sprite_terminator
+sGardevoirGfx8:
+.incbin "baserom.gba", 0x11824C0, 0x200
+sGardevoirSprites8:
+ax_sprite sGardevoirGfx8, 0x200
+ax_sprite_terminator
+sGardevoirGfx9:
+.incbin "baserom.gba", 0x11826D0, 0x200
+sGardevoirSprites9:
+ax_sprite sGardevoirGfx9, 0x200
+ax_sprite_terminator
+sGardevoirGfx10:
+.incbin "baserom.gba", 0x11828E0, 0x200
+sGardevoirSprites10:
+ax_sprite sGardevoirGfx10, 0x200
+ax_sprite_terminator
+sGardevoirGfx11:
+.incbin "baserom.gba", 0x1182AF0, 0x200
+sGardevoirSprites11:
+ax_sprite sGardevoirGfx11, 0x200
+ax_sprite_terminator
+sGardevoirGfx12:
+.incbin "baserom.gba", 0x1182D00, 0x200
+sGardevoirSprites12:
+ax_sprite sGardevoirGfx12, 0x200
+ax_sprite_terminator
+sGardevoirGfx13:
+.incbin "baserom.gba", 0x1182F10, 0x200
+sGardevoirSprites13:
+ax_sprite sGardevoirGfx13, 0x200
+ax_sprite_terminator
+sGardevoirGfx14:
+.incbin "baserom.gba", 0x1183120, 0x200
+sGardevoirSprites14:
+ax_sprite sGardevoirGfx14, 0x200
+ax_sprite_terminator
+sGardevoirGfx15:
+.incbin "baserom.gba", 0x1183330, 0x200
+sGardevoirSprites15:
+ax_sprite sGardevoirGfx15, 0x200
+ax_sprite_terminator
+sGardevoirGfx16:
+.incbin "baserom.gba", 0x1183540, 0x40
+sGardevoirGfx16_1:
+.incbin "baserom.gba", 0x1183580, 0x100
+sGardevoirSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx16_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGardevoirGfx17:
+.incbin "baserom.gba", 0x11836B0, 0x40
+sGardevoirGfx17_1:
+.incbin "baserom.gba", 0x11836F0, 0x60
+sGardevoirGfx17_2:
+.incbin "baserom.gba", 0x1183750, 0x60
+sGardevoirSprites17:
+ax_sprite sGardevoirGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx18:
+.incbin "baserom.gba", 0x11837E8, 0x40
+sGardevoirGfx18_1:
+.incbin "baserom.gba", 0x1183828, 0x80
+sGardevoirGfx18_2:
+.incbin "baserom.gba", 0x11838A8, 0x40
+sGardevoirSprites18:
+ax_sprite sGardevoirGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx19:
+.incbin "baserom.gba", 0x1183920, 0x40
+sGardevoirGfx19_1:
+.incbin "baserom.gba", 0x1183960, 0x60
+sGardevoirGfx19_2:
+.incbin "baserom.gba", 0x11839C0, 0x60
+sGardevoirGfx19_3:
+.incbin "baserom.gba", 0x1183A20, 0x20
+sGardevoirSprites19:
+ax_sprite sGardevoirGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGardevoirGfx20:
+.incbin "baserom.gba", 0x1183A88, 0x40
+sGardevoirGfx20_1:
+.incbin "baserom.gba", 0x1183AC8, 0x40
+sGardevoirGfx20_2:
+.incbin "baserom.gba", 0x1183B08, 0x60
+sGardevoirGfx20_3:
+.incbin "baserom.gba", 0x1183B68, 0x40
+sGardevoirSprites20:
+ax_sprite sGardevoirGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx20_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGardevoirGfx21:
+.incbin "baserom.gba", 0x1183BF0, 0x40
+sGardevoirGfx21_1:
+.incbin "baserom.gba", 0x1183C30, 0x40
+sGardevoirGfx21_2:
+.incbin "baserom.gba", 0x1183C70, 0x60
+sGardevoirSprites21:
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx21_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGardevoirGfx22:
+.incbin "baserom.gba", 0x1183D10, 0x40
+sGardevoirGfx22_1:
+.incbin "baserom.gba", 0x1183D50, 0x60
+sGardevoirGfx22_2:
+.incbin "baserom.gba", 0x1183DB0, 0x60
+sGardevoirSprites22:
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx22_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGardevoirGfx23:
+.incbin "baserom.gba", 0x1183E50, 0x40
+sGardevoirGfx23_1:
+.incbin "baserom.gba", 0x1183E90, 0x40
+sGardevoirGfx23_2:
+.incbin "baserom.gba", 0x1183ED0, 0x60
+sGardevoirSprites23:
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx24:
+.incbin "baserom.gba", 0x1183F70, 0x60
+sGardevoirGfx24_1:
+.incbin "baserom.gba", 0x1183FD0, 0x60
+sGardevoirGfx24_2:
+.incbin "baserom.gba", 0x1184030, 0x60
+sGardevoirSprites24:
+ax_sprite sGardevoirGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx25:
+.incbin "baserom.gba", 0x11840C8, 0x60
+sGardevoirGfx25_1:
+.incbin "baserom.gba", 0x1184128, 0x60
+sGardevoirGfx25_2:
+.incbin "baserom.gba", 0x1184188, 0x60
+sGardevoirSprites25:
+ax_sprite sGardevoirGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx26:
+.incbin "baserom.gba", 0x1184220, 0x60
+sGardevoirGfx26_1:
+.incbin "baserom.gba", 0x1184280, 0x60
+sGardevoirGfx26_2:
+.incbin "baserom.gba", 0x11842E0, 0x60
+sGardevoirSprites26:
+ax_sprite sGardevoirGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx27:
+.incbin "baserom.gba", 0x1184378, 0x60
+sGardevoirGfx27_1:
+.incbin "baserom.gba", 0x11843D8, 0x80
+sGardevoirGfx27_2:
+.incbin "baserom.gba", 0x1184458, 0x40
+sGardevoirSprites27:
+ax_sprite sGardevoirGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx28:
+.incbin "baserom.gba", 0x11844D0, 0x60
+sGardevoirGfx28_1:
+.incbin "baserom.gba", 0x1184530, 0x60
+sGardevoirGfx28_2:
+.incbin "baserom.gba", 0x1184590, 0x40
+sGardevoirSprites28:
+ax_sprite sGardevoirGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx28_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx29:
+.incbin "baserom.gba", 0x1184608, 0x60
+sGardevoirGfx29_1:
+.incbin "baserom.gba", 0x1184668, 0x60
+sGardevoirGfx29_2:
+.incbin "baserom.gba", 0x11846C8, 0x60
+sGardevoirSprites29:
+ax_sprite sGardevoirGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx29_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGardevoirGfx30:
+.incbin "baserom.gba", 0x1184760, 0x60
+sGardevoirGfx30_1:
+.incbin "baserom.gba", 0x11847C0, 0x60
+sGardevoirGfx30_2:
+.incbin "baserom.gba", 0x1184820, 0x60
+sGardevoirSprites30:
+ax_sprite sGardevoirGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx31:
+.incbin "baserom.gba", 0x11848B8, 0x40
+sGardevoirGfx31_1:
+.incbin "baserom.gba", 0x11848F8, 0x60
+sGardevoirGfx31_2:
+.incbin "baserom.gba", 0x1184958, 0x60
+sGardevoirSprites31:
+ax_sprite sGardevoirGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGardevoirGfx32:
+.incbin "baserom.gba", 0x11849F0, 0x60
+sGardevoirGfx32_1:
+.incbin "baserom.gba", 0x1184A50, 0x60
+sGardevoirGfx32_2:
+.incbin "baserom.gba", 0x1184AB0, 0x60
+sGardevoirGfx32_3:
+.incbin "baserom.gba", 0x1184B10, 0x40
+sGardevoirSprites32:
+ax_sprite sGardevoirGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGardevoirGfx33:
+.incbin "baserom.gba", 0x1184B98, 0x60
+sGardevoirGfx33_1:
+.incbin "baserom.gba", 0x1184BF8, 0x60
+sGardevoirGfx33_2:
+.incbin "baserom.gba", 0x1184C58, 0x60
+sGardevoirGfx33_3:
+.incbin "baserom.gba", 0x1184CB8, 0x40
+sGardevoirSprites33:
+ax_sprite sGardevoirGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx33_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGardevoirGfx34:
+.incbin "baserom.gba", 0x1184D40, 0x60
+sGardevoirGfx34_1:
+.incbin "baserom.gba", 0x1184DA0, 0x60
+sGardevoirGfx34_2:
+.incbin "baserom.gba", 0x1184E00, 0x60
+sGardevoirGfx34_3:
+.incbin "baserom.gba", 0x1184E60, 0x60
+sGardevoirSprites34:
+ax_sprite sGardevoirGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGardevoirGfx35:
+.incbin "baserom.gba", 0x1184F08, 0x60
+sGardevoirGfx35_1:
+.incbin "baserom.gba", 0x1184F68, 0x60
+sGardevoirGfx35_2:
+.incbin "baserom.gba", 0x1184FC8, 0x40
+sGardevoirGfx35_3:
+.incbin "baserom.gba", 0x1185008, 0x40
+sGardevoirSprites35:
+ax_sprite sGardevoirGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGardevoirGfx35_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGardevoirGfx35_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGardevoirGfx36:
+.incbin "baserom.gba", 0x1185090, 0x200
+sGardevoirSprites36:
+ax_sprite sGardevoirGfx36, 0x200
+ax_sprite_terminator
+sGardevoirGfx37:
+.incbin "baserom.gba", 0x11852A0, 0x200
+sGardevoirSprites37:
+ax_sprite sGardevoirGfx37, 0x200
+ax_sprite_terminator
+sGardevoirGfx38:
+.incbin "baserom.gba", 0x11854B0, 0x200
+sGardevoirSprites38:
+ax_sprite sGardevoirGfx38, 0x200
+ax_sprite_terminator
+sGardevoirGfx39:
+.incbin "baserom.gba", 0x11856C0, 0x200
+sGardevoirSprites39:
+ax_sprite sGardevoirGfx39, 0x200
+ax_sprite_terminator
+sGardevoirGfx40:
+.incbin "baserom.gba", 0x11858D0, 0x200
+sGardevoirSprites40:
+ax_sprite sGardevoirGfx40, 0x200
+ax_sprite_terminator
+sGardevoirGfx41:
+.incbin "baserom.gba", 0x1185AE0, 0x200
+sGardevoirSprites41:
+ax_sprite sGardevoirGfx41, 0x200
+ax_sprite_terminator
+sGardevoirGfx42:
+.incbin "baserom.gba", 0x1185CF0, 0x200
+sGardevoirSprites42:
+ax_sprite sGardevoirGfx42, 0x200
+ax_sprite_terminator
+sGardevoirGfx43:
+.incbin "baserom.gba", 0x1185F00, 0x200
+sGardevoirSprites43:
+ax_sprite sGardevoirGfx43, 0x200
+ax_sprite_terminator
+sGardevoirGfx44:
+.incbin "baserom.gba", 0x1186110, 0x200
+sGardevoirSprites44:
+ax_sprite sGardevoirGfx44, 0x200
+ax_sprite_terminator
+sGardevoirGfx45:
+.incbin "baserom.gba", 0x1186320, 0x200
+sGardevoirSprites45:
+ax_sprite sGardevoirGfx45, 0x200
+ax_sprite_terminator
+sGardevoirGfx46:
+.incbin "baserom.gba", 0x1186530, 0x200
+sGardevoirSprites46:
+ax_sprite sGardevoirGfx46, 0x200
+ax_sprite_terminator
+sGardevoirGfx47:
+.incbin "baserom.gba", 0x1186740, 0x200
+sGardevoirSprites47:
+ax_sprite sGardevoirGfx47, 0x200
+ax_sprite_terminator
+sGardevoirGfx48:
+.incbin "baserom.gba", 0x1186950, 0x200
+sGardevoirSprites48:
+ax_sprite sGardevoirGfx48, 0x200
+ax_sprite_terminator
+sGardevoirGfx49:
+.incbin "baserom.gba", 0x1186B60, 0x200
+sGardevoirSprites49:
+ax_sprite sGardevoirGfx49, 0x200
+ax_sprite_terminator
+sGardevoirGfx50:
+.incbin "baserom.gba", 0x1186D70, 0x200
+sGardevoirSprites50:
+ax_sprite sGardevoirGfx50, 0x200
+ax_sprite_terminator
+sGardevoirGfx51:
+.incbin "baserom.gba", 0x1186F80, 0x200
+sGardevoirSprites51:
+ax_sprite sGardevoirGfx51, 0x200
+ax_sprite_terminator
+sGardevoirGfx52:
+.incbin "baserom.gba", 0x1187190, 0x200
+sGardevoirSprites52:
+ax_sprite sGardevoirGfx52, 0x200
+ax_sprite_terminator
+sGardevoirGfx53:
+.incbin "baserom.gba", 0x11873A0, 0x100
+sGardevoirSprites53:
+ax_sprite sGardevoirGfx53, 0x100
+ax_sprite_terminator
+sGardevoirGfx54:
+.incbin "baserom.gba", 0x11874B0, 0x40
+sGardevoirSprites54:
+ax_sprite sGardevoirGfx54, 0x40
+ax_sprite_terminator
+sGardevoirGfx55:
+.incbin "baserom.gba", 0x1187500, 0x200
+sGardevoirSprites55:
+ax_sprite sGardevoirGfx55, 0x200
+ax_sprite_terminator
+sGardevoirGfx56:
+.incbin "baserom.gba", 0x1187710, 0x200
+sGardevoirSprites56:
+ax_sprite sGardevoirGfx56, 0x200
+ax_sprite_terminator
+sGardevoirGfx57:
+.incbin "baserom.gba", 0x1187920, 0x20
+sGardevoirSprites57:
+ax_sprite sGardevoirGfx57, 0x20
+ax_sprite_terminator
+sGardevoirGfx58:
+.incbin "baserom.gba", 0x1187950, 0x200
+sGardevoirSprites58:
+ax_sprite sGardevoirGfx58, 0x200
+ax_sprite_terminator
+sGardevoirGfx59:
+.incbin "baserom.gba", 0x1187B60, 0x200
+sGardevoirSprites59:
+ax_sprite sGardevoirGfx59, 0x200
+ax_sprite_terminator
+sAxPosesGardevoir:
+.4byte sGardevoirPose1
+.4byte sGardevoirPose2
+.4byte sGardevoirPose3
+.4byte sGardevoirPose4
+.4byte sGardevoirPose5
+.4byte sGardevoirPose6
+.4byte sGardevoirPose7
+.4byte sGardevoirPose8
+.4byte sGardevoirPose9
+.4byte sGardevoirPose10
+.4byte sGardevoirPose11
+.4byte sGardevoirPose12
+.4byte sGardevoirPose13
+.4byte sGardevoirPose14
+.4byte sGardevoirPose15
+.4byte sGardevoirPose16
+.4byte sGardevoirPose17
+.4byte sGardevoirPose18
+.4byte sGardevoirPose19
+.4byte sGardevoirPose20
+.4byte sGardevoirPose21
+.4byte sGardevoirPose22
+.4byte sGardevoirPose23
+.4byte sGardevoirPose24
+.4byte sGardevoirPose25
+.4byte sGardevoirPose26
+.4byte sGardevoirPose27
+.4byte sGardevoirPose28
+.4byte sGardevoirPose29
+.4byte sGardevoirPose30
+.4byte sGardevoirPose31
+.4byte sGardevoirPose32
+.4byte sGardevoirPose33
+.4byte sGardevoirPose34
+.4byte sGardevoirPose35
+.4byte sGardevoirPose36
+.4byte sGardevoirPose37
+.4byte sGardevoirPose38
+.4byte sGardevoirPose39
+.4byte sGardevoirPose40
+.4byte sGardevoirPose41
+.4byte sGardevoirPose42
+.4byte sGardevoirPose43
+.4byte sGardevoirPose44
+.4byte sGardevoirPose45
+.4byte sGardevoirPose46
+.4byte sGardevoirPose47
+.4byte sGardevoirPose48
+.4byte sGardevoirPose49
+.4byte sGardevoirPose50
+.4byte sGardevoirPose51
+.4byte sGardevoirPose52
+.4byte sGardevoirPose53
+.4byte sGardevoirPose54
+.4byte sGardevoirPose55
+.4byte sGardevoirPose56
+.4byte sGardevoirPose57
+.4byte sGardevoirPose58
+.4byte sGardevoirPose59
+.4byte sGardevoirPose60
+.4byte sGardevoirPose61
+.4byte sGardevoirPose62
+.4byte sGardevoirPose63
+.4byte sGardevoirPose64
+.4byte sGardevoirPose65
+.4byte sGardevoirPose66
+.4byte sGardevoirPose67
+.4byte sGardevoirPose68
+.4byte sGardevoirPose69
+.4byte sGardevoirPose70
+.4byte sGardevoirPose71
+.4byte sGardevoirPose72
+.4byte sGardevoirPose73
+.4byte sGardevoirPose74
+.4byte sGardevoirPose75
+.4byte sGardevoirPose76
+.4byte sGardevoirPose77
+.4byte sGardevoirPose78
+.4byte sGardevoirPose79
+.4byte sGardevoirPose80
+.4byte sGardevoirPose81
+.4byte sGardevoirPose82
+.4byte sGardevoirPose83
+.4byte sGardevoirPose84
+.4byte sGardevoirPose85
+.4byte sGardevoirPose86
+.4byte sGardevoirPose87
+.4byte sGardevoirPose88
+.4byte sGardevoirPose89
+.4byte sGardevoirPose90
+.4byte sGardevoirPose91
+.4byte sGardevoirPose92
+.4byte sGardevoirPose93
+.4byte sGardevoirPose94
+.4byte sGardevoirPose95
+.4byte sGardevoirPose96
+.4byte sGardevoirPose97
+.4byte sGardevoirPose98
+.4byte sGardevoirPose99
+.4byte sGardevoirPose100
+.4byte sGardevoirPose101
+.4byte sGardevoirPose102
+.4byte sGardevoirPose103
+.4byte sGardevoirPose104
+.4byte sGardevoirPose105
+.4byte sGardevoirPose106
+.4byte sGardevoirPose107
+.4byte sGardevoirPose108
+.4byte sGardevoirPose109
+.4byte sGardevoirPose110
+.4byte sGardevoirPose111
+.4byte sGardevoirPose112
+.4byte sGardevoirPose113
+.4byte sGardevoirPose114
+.4byte sGardevoirPose115
+.4byte sGardevoirPose116
+.4byte sGardevoirPose117
+.4byte sGardevoirPose118
+.4byte sGardevoirPose119
+.4byte sGardevoirPose120
+.4byte sGardevoirPose121
+.4byte sGardevoirPose122
+.4byte sGardevoirPose123
+.4byte sGardevoirPose124
+.4byte sGardevoirPose125
+.4byte sGardevoirPose126
+.4byte sGardevoirPose127
+.4byte sGardevoirPose128
+.4byte sGardevoirPose129
+.4byte sGardevoirPose130
+.4byte sGardevoirPose131
+.4byte sGardevoirPose132
+.4byte sGardevoirPose133
+.4byte sGardevoirPose134
+.4byte sGardevoirPose135
+.4byte sGardevoirPose136
+.4byte sGardevoirPose137
+.4byte sGardevoirPose138
+.4byte sGardevoirPose139
+.4byte sGardevoirPose140
+.4byte sGardevoirPose141
+.4byte sGardevoirPose142
+.4byte sGardevoirPose143
+.4byte sGardevoirPose144
+.4byte sGardevoirPose145
+.4byte sGardevoirPose146
+.4byte sGardevoirPose147
+.4byte sGardevoirPose148
+.4byte sGardevoirPose149
+.4byte sGardevoirPose150
+.4byte sGardevoirPose151
+.4byte sGardevoirPose152
+.4byte sGardevoirPose153
+.4byte sGardevoirPose154
+.4byte sGardevoirPose155
+.4byte sGardevoirPose156
+.4byte sGardevoirPose157
+.4byte sGardevoirPose158
+.4byte sGardevoirPose159
+.4byte sGardevoirPose160
+.4byte sGardevoirPose161
+.4byte sGardevoirPose162
+.4byte sGardevoirPose163
+.4byte sGardevoirPose164
+.4byte sGardevoirPose165
+.4byte sGardevoirPose166
+.4byte sGardevoirPose167
+.4byte sGardevoirPose168
+.4byte sGardevoirPose169
+.4byte sGardevoirPose170
+.4byte sGardevoirPose171
+.4byte sGardevoirPose172
+.4byte sGardevoirPose173
+.4byte sGardevoirPose174
+.4byte sGardevoirPose175
+.4byte sGardevoirPose176
+.4byte sGardevoirPose177
+.4byte sGardevoirPose178
+.4byte sGardevoirPose179
+.4byte sGardevoirPose180
+.4byte sGardevoirPose181
+.4byte sGardevoirPose182
+.4byte sGardevoirPose183
+.4byte sGardevoirPose184
+.4byte sGardevoirPose185
+.4byte sGardevoirPose186
+.4byte sGardevoirPose187
+.4byte sGardevoirPose188
+.4byte sGardevoirPose189
+.4byte sGardevoirPose190
+.4byte sGardevoirPose191
+.4byte sGardevoirPose192
+.4byte sGardevoirPose193
+.4byte sGardevoirPose194
+.4byte sGardevoirPose195
+.4byte sGardevoirPose196
+.4byte sGardevoirPose197
+.4byte sGardevoirPose198
+.4byte sGardevoirPose199
+.4byte sGardevoirPose200
+.4byte sGardevoirPose201
+.4byte sGardevoirPose202
+.4byte sGardevoirPose203
+.4byte sGardevoirPose204
+.4byte sGardevoirPose205
+.4byte sGardevoirPose206
+.4byte sGardevoirPose207
+.4byte sGardevoirPose208
+.4byte sGardevoirPose209
+.4byte sGardevoirPose210
+.4byte sGardevoirPose211
+.4byte sGardevoirPose212
+.4byte sGardevoirPose213
+.4byte sGardevoirPose214
+.4byte sGardevoirPose215
+.4byte sGardevoirPose216
+.4byte sGardevoirPose217
+.4byte sGardevoirPose218
+.4byte sGardevoirPose219
+.4byte sGardevoirPose220
+.4byte sGardevoirPose221
+.4byte sGardevoirPose222
+.4byte sGardevoirPose223
+.4byte sGardevoirPose224
+.4byte sGardevoirPose225
+.4byte sGardevoirPose226
+sAxPositionsGardevoir:
+.2byte   -1,  -13, 	  -8,   -8, 	   6,   -8, 	  -1,  -12
+.2byte   -1,  -12, 	  -7,   -7, 	   6,   -9, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,   -9, 	   5,   -7, 	  -1,  -11
+.2byte    2,  -13, 	   4,   -9, 	  -6,   -8, 	   1,  -12
+.2byte    2,  -12, 	   6,   -9, 	  -7,   -8, 	   1,  -11
+.2byte    2,  -12, 	  -2,   -9, 	  -4,   -6, 	   1,  -11
+.2byte    3,  -14, 	  -1,  -11, 	   0,   -7, 	   1,  -12
+.2byte    3,  -13, 	   4,   -8, 	  -2,   -6, 	   1,  -11
+.2byte    3,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -11
+.2byte    2,  -14, 	  -7,  -10, 	   4,   -7, 	  -1,  -12
+.2byte    2,  -13, 	  -6,   -9, 	   3,   -6, 	  -1,  -11
+.2byte    2,  -13, 	  -8,   -8, 	   6,   -7, 	  -1,  -11
+.2byte   -1,  -15, 	   5,   -8, 	  -7,   -8, 	  -1,  -13
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	   5,   -7, 	  -6,   -8, 	  -1,  -12
+.2byte   -4,  -14, 	   5,  -10, 	  -6,   -7, 	  -1,  -12
+.2byte   -4,  -13, 	   4,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -4,  -13, 	   6,   -8, 	  -8,   -7, 	  -1,  -11
+.2byte   -5,  -14, 	  -1,  -11, 	  -2,   -7, 	  -3,  -12
+.2byte   -5,  -13, 	  -6,   -8, 	   0,   -6, 	  -3,  -11
+.2byte   -5,  -13, 	   1,   -8, 	  -4,   -6, 	  -3,  -11
+.2byte   -4,  -13, 	  -6,   -9, 	   4,   -8, 	  -3,  -12
+.2byte   -4,  -12, 	  -8,   -9, 	   5,   -8, 	  -3,  -11
+.2byte   -4,  -12, 	   0,   -9, 	   2,   -6, 	  -3,  -11
+.2byte   -1,  -13, 	  -8,   -8, 	   6,   -8, 	  -1,  -12
+.2byte   -1,  -12, 	  -7,   -7, 	   6,   -9, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,   -9, 	   5,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	 -10,  -10, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -13, 	   4,   -9, 	  -6,   -8, 	   1,  -12
+.2byte    2,  -12, 	   6,   -9, 	  -7,   -8, 	   1,  -11
+.2byte    2,  -12, 	  -2,   -9, 	  -4,   -6, 	   1,  -11
+.2byte    6,  -11, 	   8,  -10, 	  -4,   -8, 	   2,   -9
+.2byte    3,  -14, 	  -1,  -11, 	   0,   -7, 	   1,  -12
+.2byte    3,  -13, 	   4,   -8, 	  -2,   -6, 	   1,  -11
+.2byte    3,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -11
+.2byte    9,  -13, 	  -1,  -10, 	   0,   -7, 	   5,  -11
+.2byte    2,  -14, 	  -7,  -10, 	   4,   -7, 	  -1,  -12
+.2byte    2,  -13, 	  -6,   -9, 	   3,   -6, 	  -1,  -11
+.2byte    2,  -13, 	  -8,   -8, 	   6,   -7, 	  -1,  -11
+.2byte    5,  -14, 	  -6,  -10, 	   4,   -5, 	   1,  -12
+.2byte   -1,  -15, 	   5,   -8, 	  -7,   -8, 	  -1,  -13
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	   5,   -7, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	   5,   -9, 	  -7,   -9, 	  -1,  -13
+.2byte   -4,  -14, 	   5,  -10, 	  -6,   -7, 	  -1,  -12
+.2byte   -4,  -13, 	   4,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -4,  -13, 	   6,   -8, 	  -8,   -7, 	  -1,  -11
+.2byte   -7,  -14, 	   4,  -10, 	  -6,   -5, 	  -3,  -12
+.2byte   -5,  -14, 	  -1,  -11, 	  -2,   -7, 	  -3,  -12
+.2byte   -5,  -13, 	  -6,   -8, 	   0,   -6, 	  -3,  -11
+.2byte   -5,  -13, 	   1,   -8, 	  -4,   -6, 	  -3,  -11
+.2byte   -9,  -13, 	   1,  -10, 	   0,   -7, 	  -5,  -11
+.2byte   -4,  -13, 	  -6,   -9, 	   4,   -8, 	  -3,  -12
+.2byte   -4,  -12, 	  -8,   -9, 	   5,   -8, 	  -3,  -11
+.2byte   -4,  -12, 	   0,   -9, 	   2,   -6, 	  -3,  -11
+.2byte   -8,  -11, 	 -10,  -10, 	   2,   -8, 	  -4,   -9
+.2byte   -1,  -13, 	  -8,   -8, 	   6,   -8, 	  -1,  -12
+.2byte   -1,  -12, 	  -7,   -7, 	   6,   -9, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,   -9, 	   5,   -7, 	  -1,  -11
+.2byte   -1,  -10, 	 -10,  -10, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -13, 	   4,   -9, 	  -6,   -8, 	   1,  -12
+.2byte    2,  -12, 	   6,   -9, 	  -7,   -8, 	   1,  -11
+.2byte    2,  -12, 	  -2,   -9, 	  -4,   -6, 	   1,  -11
+.2byte    6,  -11, 	   8,  -10, 	  -4,   -8, 	   2,   -9
+.2byte    3,  -14, 	  -1,  -11, 	   0,   -7, 	   1,  -12
+.2byte    3,  -13, 	   4,   -8, 	  -2,   -6, 	   1,  -11
+.2byte    3,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -11
+.2byte    9,  -13, 	  -1,  -10, 	   0,   -7, 	   5,  -11
+.2byte    2,  -14, 	  -7,  -10, 	   4,   -7, 	  -1,  -12
+.2byte    2,  -13, 	  -6,   -9, 	   3,   -6, 	  -1,  -11
+.2byte    2,  -13, 	  -8,   -8, 	   6,   -7, 	  -1,  -11
+.2byte    5,  -14, 	  -6,  -10, 	   4,   -5, 	   1,  -12
+.2byte   -1,  -15, 	   5,   -8, 	  -7,   -8, 	  -1,  -13
+.2byte   -1,  -14, 	   4,   -8, 	  -7,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	   5,   -7, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	   5,   -9, 	  -7,   -9, 	  -1,  -13
+.2byte   -4,  -14, 	   5,  -10, 	  -6,   -7, 	  -1,  -12
+.2byte   -4,  -13, 	   4,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -4,  -13, 	   6,   -8, 	  -8,   -7, 	  -1,  -11
+.2byte   -7,  -14, 	   4,  -10, 	  -6,   -5, 	  -3,  -12
+.2byte   -5,  -14, 	  -1,  -11, 	  -2,   -7, 	  -3,  -12
+.2byte   -5,  -13, 	  -6,   -8, 	   0,   -6, 	  -3,  -11
+.2byte   -5,  -13, 	   1,   -8, 	  -4,   -6, 	  -3,  -11
+.2byte   -9,  -13, 	   1,  -10, 	   0,   -7, 	  -5,  -11
+.2byte   -4,  -13, 	  -6,   -9, 	   4,   -8, 	  -3,  -12
+.2byte   -4,  -12, 	  -8,   -9, 	   5,   -8, 	  -3,  -11
+.2byte   -4,  -12, 	   0,   -9, 	   2,   -6, 	  -3,  -11
+.2byte   -8,  -11, 	 -10,  -10, 	   2,   -8, 	  -4,   -9
+.2byte   -1,   -9, 	 -10,   -9, 	   8,   -9, 	  -1,   -8
+.2byte   -8,  -10, 	 -10,   -9, 	   2,   -7, 	  -4,   -8
+.2byte   -9,  -12, 	   1,   -9, 	   0,   -6, 	  -5,  -10
+.2byte   -7,  -14, 	   4,  -10, 	  -6,   -5, 	  -3,  -12
+.2byte   -1,  -14, 	   5,   -8, 	  -7,   -8, 	  -1,  -12
+.2byte    6,  -14, 	  -5,  -10, 	   5,   -5, 	   2,  -12
+.2byte    8,  -12, 	  -2,   -9, 	  -1,   -6, 	   4,  -10
+.2byte    7,  -10, 	   9,   -9, 	  -3,   -7, 	   3,   -8
+.2byte    0,  -14, 	  -3,  -10, 	  -2,  -12, 	  -1,  -12
+.2byte    0,  -13, 	  -3,  -10, 	  -2,  -11, 	  -1,  -11
+.2byte   -1,  -15, 	  -4,  -18, 	   2,  -19, 	  -1,  -13
+.2byte    1,  -14, 	   7,   -9, 	   3,  -12, 	   0,  -12
+.2byte    2,  -14, 	   8,  -10, 	   4,  -12, 	   1,  -12
+.2byte    1,  -16, 	   4,  -19, 	  -3,  -18, 	   0,  -13
+.2byte    3,  -14, 	  10,  -11, 	   5,  -13, 	   1,  -12
+.2byte    4,  -14, 	  10,  -12, 	   6,  -13, 	   2,  -12
+.2byte    3,  -15, 	   5,  -19, 	   2,  -18, 	   1,  -12
+.2byte    2,  -15, 	   6,  -17, 	   0,  -14, 	   0,  -12
+.2byte    3,  -15, 	   7,  -18, 	   1,  -14, 	   1,  -12
+.2byte    1,  -15, 	  -2,  -21, 	   4,  -19, 	  -1,  -11
+.2byte    0,  -14, 	   2,  -16, 	   1,  -13, 	   0,  -12
+.2byte    0,  -15, 	   2,  -17, 	   1,  -14, 	   0,  -14
+.2byte   -1,  -16, 	   2,  -18, 	  -4,  -18, 	  -1,  -12
+.2byte   -4,  -15, 	  -8,  -17, 	  -2,  -14, 	  -2,  -12
+.2byte   -5,  -15, 	  -9,  -18, 	  -3,  -14, 	  -3,  -12
+.2byte   -3,  -15, 	   0,  -21, 	  -6,  -19, 	  -1,  -11
+.2byte   -5,  -14, 	 -12,  -11, 	  -7,  -13, 	  -3,  -12
+.2byte   -6,  -14, 	 -12,  -12, 	  -8,  -13, 	  -4,  -12
+.2byte   -5,  -15, 	  -7,  -19, 	  -4,  -18, 	  -3,  -12
+.2byte   -3,  -14, 	  -9,   -9, 	  -5,  -12, 	  -2,  -12
+.2byte   -4,  -14, 	 -10,  -10, 	  -6,  -12, 	  -3,  -12
+.2byte   -3,  -16, 	  -6,  -19, 	   1,  -18, 	  -2,  -13
+.2byte   -4,  -10, 	  -6,   -5, 	   2,   -3, 	  -2,   -8
+.2byte   -5,   -9, 	  -6,   -5, 	   2,   -3, 	  -2,   -7
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte    1,  -11, 	   4,   -9, 	  -6,   -7, 	  -1,   -9
+.2byte    3,  -11, 	  -3,   -6, 	  -3,   -5, 	   1,   -8
+.2byte    2,  -11, 	  -6,   -9, 	   6,   -7, 	  -1,  -10
+.2byte   -1,  -11, 	   7,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -3,  -11, 	   5,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -4,  -11, 	   2,   -6, 	   2,   -5, 	  -2,   -8
+.2byte   -2,  -11, 	  -5,   -9, 	   5,   -7, 	   0,   -9
+.2byte   -1,  -13, 	  -8,   -8, 	   6,   -8, 	  -1,  -12
+.2byte   -2,  -13, 	  -9,   -8, 	   4,   -8, 	  -2,  -12
+.2byte    0,  -13, 	  -7,   -8, 	   6,   -8, 	   0,  -12
+.2byte    2,  -13, 	   4,   -9, 	  -6,   -8, 	   1,  -12
+.2byte    3,  -15, 	  -1,  -10, 	  -4,   -8, 	   1,  -13
+.2byte    1,  -14, 	   4,   -9, 	  -7,   -8, 	  -1,  -12
+.2byte    3,  -14, 	  -1,  -11, 	   0,   -7, 	   1,  -12
+.2byte    3,  -15, 	   2,  -10, 	   0,   -8, 	   1,  -12
+.2byte    3,  -13, 	  -2,   -9, 	  -2,   -6, 	   1,  -10
+.2byte    2,  -14, 	  -7,  -10, 	   4,   -7, 	  -1,  -12
+.2byte    1,  -14, 	  -9,  -10, 	   4,   -7, 	  -2,  -12
+.2byte    2,  -13, 	  -6,   -9, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -15, 	   5,   -8, 	  -7,   -8, 	  -1,  -13
+.2byte    0,  -15, 	   7,   -8, 	  -7,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   5,   -9, 	  -9,   -8, 	  -2,  -13
+.2byte   -4,  -14, 	   5,  -10, 	  -6,   -7, 	  -1,  -12
+.2byte   -3,  -14, 	   7,  -10, 	  -6,   -7, 	   0,  -12
+.2byte   -4,  -13, 	   4,   -9, 	  -5,   -5, 	  -1,  -11
+.2byte   -5,  -14, 	  -1,  -11, 	  -2,   -7, 	  -3,  -12
+.2byte   -5,  -15, 	  -4,  -10, 	  -2,   -8, 	  -3,  -12
+.2byte   -5,  -13, 	   0,   -9, 	   0,   -6, 	  -3,  -10
+.2byte   -4,  -13, 	  -6,   -9, 	   4,   -8, 	  -3,  -12
+.2byte   -5,  -15, 	  -1,  -10, 	   2,   -8, 	  -3,  -13
+.2byte   -3,  -14, 	  -6,   -9, 	   5,   -8, 	  -1,  -12
+.2byte    0,  -10, 	  -9,  -10, 	   9,  -10, 	   0,   -9
+.2byte   -8,  -11, 	 -10,  -10, 	   2,   -8, 	  -4,   -9
+.2byte   -9,  -13, 	   1,  -10, 	   0,   -7, 	  -5,  -11
+.2byte   -7,  -15, 	   4,  -11, 	  -6,   -6, 	  -3,  -13
+.2byte   -1,  -15, 	   5,   -9, 	  -7,   -9, 	  -1,  -13
+.2byte    6,  -15, 	  -5,  -11, 	   5,   -6, 	   2,  -13
+.2byte    8,  -13, 	  -2,  -10, 	  -1,   -7, 	   4,  -11
+.2byte    6,  -11, 	   8,  -10, 	  -4,   -8, 	   2,   -9
+.2byte    0,  -13, 	  -3,  -10, 	  -2,  -11, 	  -1,  -11
+.2byte    2,  -14, 	   8,  -10, 	   4,  -12, 	   1,  -12
+.2byte    4,  -14, 	  10,  -12, 	   6,  -13, 	   2,  -12
+.2byte    3,  -16, 	   7,  -19, 	   1,  -15, 	   1,  -13
+.2byte    0,  -15, 	   2,  -17, 	   1,  -14, 	   0,  -14
+.2byte   -4,  -16, 	  -8,  -19, 	  -2,  -15, 	  -2,  -13
+.2byte   -6,  -14, 	 -12,  -12, 	  -8,  -13, 	  -4,  -12
+.2byte   -4,  -14, 	 -10,  -10, 	  -6,  -12, 	  -3,  -12
+.2byte   -1,  -13, 	  -8,   -8, 	   6,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	  -4,  -18, 	   2,  -19, 	  -1,  -13
+.2byte   -1,  -10, 	 -10,  -10, 	   8,  -10, 	  -1,   -9
+.2byte    3,  -12, 	   5,   -8, 	  -5,   -7, 	   2,  -11
+.2byte    2,  -15, 	   5,  -18, 	  -2,  -17, 	   1,  -12
+.2byte    5,  -10, 	   7,   -9, 	  -5,   -7, 	   1,   -8
+.2byte    3,  -14, 	  -1,  -11, 	   0,   -7, 	   1,  -12
+.2byte    3,  -15, 	   5,  -19, 	   2,  -18, 	   1,  -12
+.2byte    6,  -13, 	  -4,  -10, 	  -3,   -7, 	   2,  -11
+.2byte    2,  -14, 	  -7,  -10, 	   4,   -7, 	  -1,  -12
+.2byte    1,  -15, 	  -2,  -21, 	   4,  -19, 	  -1,  -11
+.2byte    4,  -13, 	  -7,   -9, 	   3,   -4, 	   0,  -11
+.2byte   -1,  -15, 	   5,   -8, 	  -7,   -8, 	  -1,  -13
+.2byte   -1,  -16, 	   2,  -18, 	  -4,  -18, 	  -1,  -12
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -11
+.2byte   -4,  -14, 	   5,  -10, 	  -6,   -7, 	  -1,  -12
+.2byte   -3,  -15, 	   0,  -21, 	  -6,  -19, 	  -1,  -11
+.2byte   -6,  -13, 	   5,   -9, 	  -5,   -4, 	  -2,  -11
+.2byte   -5,  -14, 	  -1,  -11, 	  -2,   -7, 	  -3,  -12
+.2byte   -5,  -15, 	  -7,  -19, 	  -4,  -18, 	  -3,  -12
+.2byte   -8,  -13, 	   2,  -10, 	   1,   -7, 	  -4,  -11
+.2byte   -4,  -12, 	  -6,   -8, 	   4,   -7, 	  -3,  -11
+.2byte   -3,  -15, 	  -6,  -18, 	   1,  -17, 	  -2,  -12
+.2byte   -6,  -10, 	  -8,   -9, 	   4,   -7, 	  -2,   -8
+.2byte   -1,   -9, 	 -10,   -9, 	   8,   -9, 	  -1,   -8
+.2byte   -8,  -10, 	 -10,   -9, 	   2,   -7, 	  -4,   -8
+.2byte   -9,  -12, 	   1,   -9, 	   0,   -6, 	  -5,  -10
+.2byte   -7,  -14, 	   4,  -10, 	  -6,   -5, 	  -3,  -12
+.2byte   -1,  -14, 	   5,   -8, 	  -7,   -8, 	  -1,  -12
+.2byte    6,  -14, 	  -5,  -10, 	   5,   -5, 	   2,  -12
+.2byte    8,  -12, 	  -2,   -9, 	  -1,   -6, 	   4,  -10
+.2byte    7,  -10, 	   9,   -9, 	  -3,   -7, 	   3,   -8
+.2byte   -1,  -11, 	  -8,   -6, 	   6,   -6, 	  -1,  -10
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -6, 	  -3,  -10
+.2byte   -5,  -12, 	  -1,   -9, 	  -2,   -5, 	  -3,  -10
+.2byte   -4,  -12, 	   5,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	  -1,  -11
+.2byte    2,  -12, 	  -7,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   0,   -5, 	   1,  -10
+.2byte    2,  -11, 	   4,   -7, 	  -6,   -6, 	   1,  -10
+.2byte   -9,   -1, 	  -9,    1, 	  -8,    3, 	  -6,   -2
+.2byte    8,   -1, 	   8,    1, 	   7,    3, 	   5,   -2
+.2byte   -3,  -12, 	  -5,   -7, 	   4,   -6, 	   0,   -9
+.2byte   -4,  -12, 	   0,   -9, 	  -1,   -5, 	  -2,  -10
+.2byte    2,  -12, 	   4,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte    3,  -12, 	  -1,   -9, 	   0,   -5, 	   1,  -10
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -3,  -12, 	  -5,   -7, 	   4,   -6, 	   0,   -9
+.2byte   -3,  -12, 	  -5,   -7, 	   4,   -6, 	   0,   -9
+.2byte    2,  -12, 	   4,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte    2,  -12, 	   4,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte   -4,  -12, 	   0,   -9, 	  -1,   -5, 	  -2,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -1,   -5, 	  -2,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   0,   -5, 	   1,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   0,   -5, 	   1,  -10
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+sGardevoirAnimTable1:
+.4byte sGardevoirAnims_1_1
+.4byte sGardevoirAnims_1_2
+.4byte sGardevoirAnims_1_3
+.4byte sGardevoirAnims_1_4
+.4byte sGardevoirAnims_1_5
+.4byte sGardevoirAnims_1_6
+.4byte sGardevoirAnims_1_7
+.4byte sGardevoirAnims_1_8
+sGardevoirAnimTable2:
+.4byte sGardevoirAnims_2_1
+.4byte sGardevoirAnims_2_2
+.4byte sGardevoirAnims_2_3
+.4byte sGardevoirAnims_2_4
+.4byte sGardevoirAnims_2_5
+.4byte sGardevoirAnims_2_6
+.4byte sGardevoirAnims_2_7
+.4byte sGardevoirAnims_2_8
+sGardevoirAnimTable3:
+.4byte sGardevoirAnims_3_1
+.4byte sGardevoirAnims_3_2
+.4byte sGardevoirAnims_3_3
+.4byte sGardevoirAnims_3_4
+.4byte sGardevoirAnims_3_5
+.4byte sGardevoirAnims_3_6
+.4byte sGardevoirAnims_3_7
+.4byte sGardevoirAnims_3_8
+sGardevoirAnimTable4:
+.4byte sGardevoirAnims_4_1
+.4byte sGardevoirAnims_4_2
+.4byte sGardevoirAnims_4_3
+.4byte sGardevoirAnims_4_4
+.4byte sGardevoirAnims_4_5
+.4byte sGardevoirAnims_4_6
+.4byte sGardevoirAnims_4_7
+.4byte sGardevoirAnims_4_8
+sGardevoirAnimTable5:
+.4byte sGardevoirAnims_5_1
+.4byte sGardevoirAnims_5_2
+.4byte sGardevoirAnims_5_3
+.4byte sGardevoirAnims_5_4
+.4byte sGardevoirAnims_5_5
+.4byte sGardevoirAnims_5_6
+.4byte sGardevoirAnims_5_7
+.4byte sGardevoirAnims_5_8
+sGardevoirAnimTable6:
+.4byte sGardevoirAnims_6_1
+.4byte sGardevoirAnims_6_1
+.4byte sGardevoirAnims_6_1
+.4byte sGardevoirAnims_6_1
+.4byte sGardevoirAnims_6_1
+.4byte sGardevoirAnims_6_1
+.4byte sGardevoirAnims_6_1
+.4byte sGardevoirAnims_6_1
+sGardevoirAnimTable7:
+.4byte sGardevoirAnims_7_1
+.4byte sGardevoirAnims_7_2
+.4byte sGardevoirAnims_7_3
+.4byte sGardevoirAnims_7_4
+.4byte sGardevoirAnims_7_5
+.4byte sGardevoirAnims_7_6
+.4byte sGardevoirAnims_7_7
+.4byte sGardevoirAnims_7_8
+sGardevoirAnimTable8:
+.4byte sGardevoirAnims_8_1
+.4byte sGardevoirAnims_8_2
+.4byte sGardevoirAnims_8_3
+.4byte sGardevoirAnims_8_4
+.4byte sGardevoirAnims_8_5
+.4byte sGardevoirAnims_8_6
+.4byte sGardevoirAnims_8_7
+.4byte sGardevoirAnims_8_8
+sGardevoirAnimTable9:
+.4byte sGardevoirAnims_9_1
+.4byte sGardevoirAnims_9_2
+.4byte sGardevoirAnims_9_3
+.4byte sGardevoirAnims_9_4
+.4byte sGardevoirAnims_9_5
+.4byte sGardevoirAnims_9_6
+.4byte sGardevoirAnims_9_7
+.4byte sGardevoirAnims_9_8
+sGardevoirAnimTable10:
+.4byte sGardevoirAnims_10_1
+.4byte sGardevoirAnims_10_2
+.4byte sGardevoirAnims_10_3
+.4byte sGardevoirAnims_10_4
+.4byte sGardevoirAnims_10_5
+.4byte sGardevoirAnims_10_6
+.4byte sGardevoirAnims_10_7
+.4byte sGardevoirAnims_10_8
+sGardevoirAnimTable11:
+.4byte sGardevoirAnims_11_1
+.4byte sGardevoirAnims_11_2
+.4byte sGardevoirAnims_11_3
+.4byte sGardevoirAnims_11_4
+.4byte sGardevoirAnims_11_5
+.4byte sGardevoirAnims_11_6
+.4byte sGardevoirAnims_11_7
+.4byte sGardevoirAnims_11_8
+sGardevoirAnimTable12:
+.4byte sGardevoirAnims_12_1
+.4byte sGardevoirAnims_12_2
+.4byte sGardevoirAnims_12_3
+.4byte sGardevoirAnims_12_4
+.4byte sGardevoirAnims_12_5
+.4byte sGardevoirAnims_12_6
+.4byte sGardevoirAnims_12_7
+.4byte sGardevoirAnims_12_8
+sGardevoirAnimTable13:
+.4byte sGardevoirAnims_13_1
+.4byte sGardevoirAnims_13_2
+.4byte sGardevoirAnims_13_3
+.4byte sGardevoirAnims_13_4
+.4byte sGardevoirAnims_13_5
+.4byte sGardevoirAnims_13_6
+.4byte sGardevoirAnims_13_7
+.4byte sGardevoirAnims_13_8
+sGardevoirAnimTable14:
+.4byte sGardevoirAnims_14_1
+.4byte sGardevoirAnims_14_2
+.4byte sGardevoirAnims_14_3
+.4byte sGardevoirAnims_14_4
+.4byte sGardevoirAnims_14_5
+.4byte sGardevoirAnims_14_6
+.4byte sGardevoirAnims_14_7
+.4byte sGardevoirAnims_14_8
+sGardevoirAnimTable15:
+.4byte sGardevoirAnims_15_1
+.4byte sGardevoirAnims_15_2
+.4byte sGardevoirAnims_15_3
+.4byte sGardevoirAnims_15_4
+.4byte sGardevoirAnims_15_5
+.4byte sGardevoirAnims_15_6
+.4byte sGardevoirAnims_15_7
+.4byte sGardevoirAnims_15_8
+sGardevoirAnimTable16:
+.4byte sGardevoirAnims_16_1
+.4byte sGardevoirAnims_16_2
+.4byte sGardevoirAnims_16_3
+.4byte sGardevoirAnims_16_4
+.4byte sGardevoirAnims_16_5
+.4byte sGardevoirAnims_16_6
+.4byte sGardevoirAnims_16_7
+.4byte sGardevoirAnims_16_8
+sAxAnimationsGardevoir:
+.4byte sGardevoirAnimTable1
+.4byte sGardevoirAnimTable2
+.4byte sGardevoirAnimTable3
+.4byte sGardevoirAnimTable4
+.4byte sGardevoirAnimTable5
+.4byte sGardevoirAnimTable6
+.4byte sGardevoirAnimTable7
+.4byte sGardevoirAnimTable8
+.4byte sGardevoirAnimTable9
+.4byte sGardevoirAnimTable10
+.4byte sGardevoirAnimTable11
+.4byte sGardevoirAnimTable12
+.4byte sGardevoirAnimTable13
+.4byte sGardevoirAnimTable14
+.4byte sGardevoirAnimTable15
+.4byte sGardevoirAnimTable16
+sAxSpritesGardevoir:
+.4byte sGardevoirSprites1
+.4byte sGardevoirSprites2
+.4byte sGardevoirSprites3
+.4byte sGardevoirSprites4
+.4byte sGardevoirSprites5
+.4byte sGardevoirSprites6
+.4byte sGardevoirSprites7
+.4byte sGardevoirSprites8
+.4byte sGardevoirSprites9
+.4byte sGardevoirSprites10
+.4byte sGardevoirSprites11
+.4byte sGardevoirSprites12
+.4byte sGardevoirSprites13
+.4byte sGardevoirSprites14
+.4byte sGardevoirSprites15
+.4byte sGardevoirSprites16
+.4byte sGardevoirSprites17
+.4byte sGardevoirSprites18
+.4byte sGardevoirSprites19
+.4byte sGardevoirSprites20
+.4byte sGardevoirSprites21
+.4byte sGardevoirSprites22
+.4byte sGardevoirSprites23
+.4byte sGardevoirSprites24
+.4byte sGardevoirSprites25
+.4byte sGardevoirSprites26
+.4byte sGardevoirSprites27
+.4byte sGardevoirSprites28
+.4byte sGardevoirSprites29
+.4byte sGardevoirSprites30
+.4byte sGardevoirSprites31
+.4byte sGardevoirSprites32
+.4byte sGardevoirSprites33
+.4byte sGardevoirSprites34
+.4byte sGardevoirSprites35
+.4byte sGardevoirSprites36
+.4byte sGardevoirSprites37
+.4byte sGardevoirSprites38
+.4byte sGardevoirSprites39
+.4byte sGardevoirSprites40
+.4byte sGardevoirSprites41
+.4byte sGardevoirSprites42
+.4byte sGardevoirSprites43
+.4byte sGardevoirSprites44
+.4byte sGardevoirSprites45
+.4byte sGardevoirSprites46
+.4byte sGardevoirSprites47
+.4byte sGardevoirSprites48
+.4byte sGardevoirSprites49
+.4byte sGardevoirSprites50
+.4byte sGardevoirSprites51
+.4byte sGardevoirSprites52
+.4byte sGardevoirSprites53
+.4byte sGardevoirSprites54
+.4byte sGardevoirSprites55
+.4byte sGardevoirSprites56
+.4byte sGardevoirSprites57
+.4byte sGardevoirSprites58
+.4byte sGardevoirSprites59
+sAxMainGardevoir:
+ax_main sAxPosesGardevoir, sAxAnimationsGardevoir, 16, sAxSpritesGardevoir, sAxPositionsGardevoir

--- a/data/ax/gastly.inc
+++ b/data/ax/gastly.inc
@@ -1,0 +1,3003 @@
+.global gAxGastly
+gAxGastly:
+ax_siro sAxMainGastly
+sGastlyPose1:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose2:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose3:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose4:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose5:
+ax_pose 4, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose6:
+ax_pose 5, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose7:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose8:
+ax_pose 7, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose9:
+ax_pose 8, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose10:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose11:
+ax_pose 10, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose12:
+ax_pose 11, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose13:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose14:
+ax_pose 13, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose15:
+ax_pose 14, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose16:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose17:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose18:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose19:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose20:
+ax_pose 7, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose21:
+ax_pose 8, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose22:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose23:
+ax_pose 4, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose24:
+ax_pose 5, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose25:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose26:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose27:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose28:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose29:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose30:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose31:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose32:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose33:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose34:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose35:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose36:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose37:
+ax_pose 4, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose38:
+ax_pose 5, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose39:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose40:
+ax_pose 7, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose41:
+ax_pose 8, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose42:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose43:
+ax_pose 10, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose44:
+ax_pose 11, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose45:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose46:
+ax_pose 13, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose47:
+ax_pose 14, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose48:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose49:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose50:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose51:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose52:
+ax_pose 7, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose53:
+ax_pose 8, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose54:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose55:
+ax_pose 4, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose56:
+ax_pose 5, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose57:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose58:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose59:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose60:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose61:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose62:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose63:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose64:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose65:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose66:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose67:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose68:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose69:
+ax_pose 4, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose70:
+ax_pose 5, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose71:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose72:
+ax_pose 7, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose73:
+ax_pose 8, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose74:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose75:
+ax_pose 10, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose76:
+ax_pose 11, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose77:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose78:
+ax_pose 13, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose79:
+ax_pose 14, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose80:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose81:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose82:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose83:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose84:
+ax_pose 7, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose85:
+ax_pose 8, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose86:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose87:
+ax_pose 4, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose88:
+ax_pose 5, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose89:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose90:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose91:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose92:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose93:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose94:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose95:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose96:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose97:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose98:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose99:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose100:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose101:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose102:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose103:
+ax_pose 4, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose104:
+ax_pose 5, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose105:
+ax_pose 17, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose106:
+ax_pose 18, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose107:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose108:
+ax_pose 7, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose109:
+ax_pose 8, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose110:
+ax_pose 19, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose111:
+ax_pose 20, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose112:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose113:
+ax_pose 10, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose114:
+ax_pose 11, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose115:
+ax_pose 21, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose116:
+ax_pose 22, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose117:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose118:
+ax_pose 13, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose119:
+ax_pose 14, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose120:
+ax_pose 23, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose121:
+ax_pose 24, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose122:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose123:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose124:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose125:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose126:
+ax_pose 22, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose127:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose128:
+ax_pose 7, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose129:
+ax_pose 8, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose130:
+ax_pose 19, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose131:
+ax_pose 20, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose132:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose133:
+ax_pose 4, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose134:
+ax_pose 5, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose135:
+ax_pose 17, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose136:
+ax_pose 18, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose137:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose138:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose139:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose140:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose141:
+ax_pose 16, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose142:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose143:
+ax_pose 4, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose144:
+ax_pose 5, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose145:
+ax_pose 17, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose146:
+ax_pose 18, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose147:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose148:
+ax_pose 7, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose149:
+ax_pose 8, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose150:
+ax_pose 19, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose151:
+ax_pose 20, 0x01e1, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose152:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose153:
+ax_pose 10, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose154:
+ax_pose 11, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose155:
+ax_pose 21, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose156:
+ax_pose 22, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose157:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose158:
+ax_pose 13, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose159:
+ax_pose 14, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose160:
+ax_pose 23, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose161:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose162:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose163:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose164:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose165:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose166:
+ax_pose 22, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose167:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose168:
+ax_pose 7, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose169:
+ax_pose 8, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose170:
+ax_pose 19, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose171:
+ax_pose 20, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose172:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose173:
+ax_pose 4, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose174:
+ax_pose 5, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose175:
+ax_pose 17, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose176:
+ax_pose 18, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose177:
+ax_pose 25, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose178:
+ax_pose 26, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose179:
+ax_pose 27, 0x01de, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose180:
+ax_pose 28, 0x01de, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose181:
+ax_pose 29, 0x01df, 0x90e9, 0x2c00
+ax_pose_terminator
+sGastlyPose182:
+ax_pose 30, 0x01e4, 0x90e9, 0x2c00
+ax_pose_terminator
+sGastlyPose183:
+ax_pose 31, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose184:
+ax_pose 30, 0x01e4, 0x80f7, 0x2c00
+ax_pose_terminator
+sGastlyPose185:
+ax_pose 29, 0x01df, 0x80f7, 0x2c00
+ax_pose_terminator
+sGastlyPose186:
+ax_pose 28, 0x01de, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose187:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose188:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose189:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose190:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose191:
+ax_pose 4, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose192:
+ax_pose 5, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose193:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose194:
+ax_pose 7, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose195:
+ax_pose 8, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose196:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose197:
+ax_pose 10, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose198:
+ax_pose 11, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose199:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose200:
+ax_pose 13, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose201:
+ax_pose 14, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose202:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose203:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose204:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose205:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose206:
+ax_pose 7, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose207:
+ax_pose 8, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose208:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose209:
+ax_pose 4, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose210:
+ax_pose 5, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose211:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose212:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose213:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose214:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose215:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose216:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose217:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose218:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose219:
+ax_pose 0, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose220:
+ax_pose 3, 0x01df, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose221:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose222:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose223:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose224:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose225:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose226:
+ax_pose 3, 0x01df, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose227:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose228:
+ax_pose 18, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose229:
+ax_pose 20, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose230:
+ax_pose 22, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose231:
+ax_pose 24, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose232:
+ax_pose 22, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose233:
+ax_pose 20, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose234:
+ax_pose 18, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose235:
+ax_pose 0, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose236:
+ax_pose 1, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose237:
+ax_pose 2, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose238:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose239:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose240:
+ax_pose 3, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose241:
+ax_pose 4, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose242:
+ax_pose 5, 0x01e0, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose243:
+ax_pose 17, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose244:
+ax_pose 18, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose245:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose246:
+ax_pose 7, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose247:
+ax_pose 8, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose248:
+ax_pose 19, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose249:
+ax_pose 20, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose250:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose251:
+ax_pose 10, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose252:
+ax_pose 11, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose253:
+ax_pose 21, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose254:
+ax_pose 22, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose255:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose256:
+ax_pose 13, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose257:
+ax_pose 14, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose258:
+ax_pose 23, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose259:
+ax_pose 24, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose260:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose261:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose262:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose263:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose264:
+ax_pose 22, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose265:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose266:
+ax_pose 7, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose267:
+ax_pose 8, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose268:
+ax_pose 19, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose269:
+ax_pose 20, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose270:
+ax_pose 3, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose271:
+ax_pose 4, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose272:
+ax_pose 5, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose273:
+ax_pose 17, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose274:
+ax_pose 18, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose275:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose276:
+ax_pose 18, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sGastlyPose277:
+ax_pose 20, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose278:
+ax_pose 22, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose279:
+ax_pose 24, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose280:
+ax_pose 22, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sGastlyPose281:
+ax_pose 20, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose282:
+ax_pose 18, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sGastlyPose283:
+ax_pose 0, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose284:
+ax_pose 3, 0x01df, 0x80f3, 0x2c00
+ax_pose_terminator
+sGastlyPose285:
+ax_pose 6, 0x01e0, 0x80f6, 0x2c00
+ax_pose_terminator
+sGastlyPose286:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGastlyPose287:
+ax_pose 12, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGastlyPose288:
+ax_pose 9, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sGastlyPose289:
+ax_pose 6, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sGastlyPose290:
+ax_pose 3, 0x01df, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sGastlyAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 2, 0, 0,
+ax_anim 6, 0, 0, 0, 3, 0, 0,
+ax_anim 6, 0, 1, 0, 2, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sGastlyAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 2, 0, 0,
+ax_anim 6, 0, 3, 0, 3, 0, 0,
+ax_anim 6, 0, 4, 0, 2, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sGastlyAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 2, 0, 0,
+ax_anim 6, 0, 6, 0, 3, 0, 0,
+ax_anim 6, 0, 7, 0, 2, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sGastlyAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 2, 0, 0,
+ax_anim 6, 0, 9, 0, 3, 0, 0,
+ax_anim 6, 0, 10, 0, 2, 0, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 0,
+ax_anim_terminator
+sGastlyAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 2, 0, 0,
+ax_anim 6, 0, 12, 0, 3, 0, 0,
+ax_anim 6, 0, 13, 0, 2, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sGastlyAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 17, 0, 2, 0, 0,
+ax_anim 6, 0, 15, 0, 3, 0, 0,
+ax_anim 6, 0, 16, 0, 2, 0, 0,
+ax_anim 6, 0, 17, 0, 1, 0, 0,
+ax_anim_terminator
+sGastlyAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 2, 0, 0,
+ax_anim 6, 0, 18, 0, 3, 0, 0,
+ax_anim 6, 0, 19, 0, 2, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sGastlyAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 2, 0, 0,
+ax_anim 6, 0, 21, 0, 3, 0, 0,
+ax_anim 6, 0, 22, 0, 2, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sGastlyAnims_2_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 0, -3, 0, -3,
+ax_anim 2, 0, 32, 0, -3, 0, -3,
+ax_anim 2, 0, 33, 0, -3, 0, -3,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 4, 0, 4,
+ax_anim 1, 0, 33, 0, 11, 0, 11,
+ax_anim 1, 0, 34, 0, 23, 0, 23,
+ax_anim 2, 1, 32, 1, 23, 1, 23,
+ax_anim 2, 0, 33, 0, 23, 0, 23,
+ax_anim 2, 0, 34, 1, 23, 1, 23,
+ax_anim 3, 0, 32, 0, 8, 0, 8,
+ax_anim_terminator
+sGastlyAnims_2_2:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, -1, -1, -1,
+ax_anim 2, 0, 37, -3, -3, -3, -3,
+ax_anim 2, 0, 35, -3, -3, -3, -3,
+ax_anim 2, 0, 36, -3, -3, -3, -3,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 4, 4, 4, 4,
+ax_anim 1, 0, 36, 10, 12, 10, 12,
+ax_anim 1, 0, 37, 18, 22, 18, 22,
+ax_anim 2, 1, 35, 19, 22, 19, 22,
+ax_anim 2, 0, 36, 18, 22, 18, 22,
+ax_anim 2, 0, 37, 19, 22, 19, 22,
+ax_anim 3, 0, 35, 7, 9, 7, 9,
+ax_anim_terminator
+sGastlyAnims_2_3:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, -1, 0, -1, 0,
+ax_anim 2, 0, 40, -3, 0, -3, 0,
+ax_anim 2, 0, 38, -3, 0, -3, 0,
+ax_anim 2, 0, 39, -3, 0, -3, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 4, 0, 4, 0,
+ax_anim 1, 0, 39, 10, 1, 10, 0,
+ax_anim 1, 0, 40, 18, 2, 18, 0,
+ax_anim 2, 1, 38, 18, 1, 18, -1,
+ax_anim 2, 0, 39, 18, 2, 18, 0,
+ax_anim 2, 0, 40, 18, 1, 18, -1,
+ax_anim 3, 0, 38, 7, 1, 7, 0,
+ax_anim_terminator
+sGastlyAnims_2_4:
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 2, 0, 43, -3, 3, -3, 3,
+ax_anim 2, 0, 41, -3, 3, -3, 3,
+ax_anim 2, 0, 42, -3, 3, -3, 3,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 2, 41, 4, -4, 4, -4,
+ax_anim 1, 0, 42, 8, -8, 8, -8,
+ax_anim 1, 0, 43, 16, -16, 16, -16,
+ax_anim 2, 1, 41, 15, -17, 15, -17,
+ax_anim 2, 0, 42, 16, -16, 16, -16,
+ax_anim 2, 0, 43, 15, -17, 15, -17,
+ax_anim 3, 0, 41, 6, -6, 6, -6,
+ax_anim_terminator
+sGastlyAnims_2_5:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 1, 0, 1,
+ax_anim 2, 0, 46, 0, 3, 0, 3,
+ax_anim 2, 0, 44, 0, 3, 0, 3,
+ax_anim 2, 0, 45, 0, 3, 0, 3,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 2, 44, 0, -4, 0, -4,
+ax_anim 1, 0, 45, 0, -9, 0, -9,
+ax_anim 1, 0, 46, 0, -18, 0, -18,
+ax_anim 2, 1, 44, 1, -18, 1, -18,
+ax_anim 2, 0, 45, 0, -18, 0, -18,
+ax_anim 2, 0, 46, 1, -18, 1, -18,
+ax_anim 3, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sGastlyAnims_2_6:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 1, 1, 1,
+ax_anim 2, 0, 49, 3, 3, 3, 3,
+ax_anim 2, 0, 47, 3, 3, 3, 3,
+ax_anim 2, 0, 48, 3, 3, 3, 3,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 47, -4, -4, -4, -4,
+ax_anim 1, 0, 48, -8, -8, -8, -8,
+ax_anim 1, 0, 49, -16, -16, -16, -16,
+ax_anim 2, 1, 47, -15, -17, -15, -17,
+ax_anim 2, 0, 48, -16, -16, -16, -16,
+ax_anim 2, 0, 49, -15, -17, -15, -17,
+ax_anim 3, 0, 47, -6, -6, -6, -6,
+ax_anim_terminator
+sGastlyAnims_2_7:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 2, 0, 52, 3, 0, 3, 0,
+ax_anim 2, 0, 50, 3, 0, 3, 0,
+ax_anim 2, 0, 51, 3, 0, 3, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 1, -10, 0,
+ax_anim 1, 0, 52, -18, 2, -18, 0,
+ax_anim 2, 1, 50, -18, 1, -18, -1,
+ax_anim 2, 0, 51, -18, 2, -18, 0,
+ax_anim 2, 0, 52, -18, 1, -18, -1,
+ax_anim 3, 0, 50, -7, 1, -7, 0,
+ax_anim_terminator
+sGastlyAnims_2_8:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 2, 0, 55, 3, -3, 3, -3,
+ax_anim 2, 0, 53, 3, -3, 3, -3,
+ax_anim 2, 0, 54, 3, -3, 3, -3,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 12, -10, 12,
+ax_anim 1, 0, 55, -18, 22, -18, 22,
+ax_anim 2, 1, 53, -19, 22, -19, 22,
+ax_anim 2, 0, 54, -18, 22, -18, 22,
+ax_anim 2, 0, 55, -19, 22, -19, 22,
+ax_anim 3, 0, 53, -7, 9, -7, 9,
+ax_anim_terminator
+.align 2
+sGastlyAnims_3_1:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, -1, 0, -1,
+ax_anim 2, 0, 66, 0, -3, 0, -3,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 2, 64, 0, 4, 0, 4,
+ax_anim 1, 0, 65, 0, 11, 0, 11,
+ax_anim 1, 0, 66, 0, 23, 0, 23,
+ax_anim 2, 1, 64, 1, 23, 1, 23,
+ax_anim 2, 0, 65, 0, 23, 0, 23,
+ax_anim 2, 0, 66, 1, 23, 1, 23,
+ax_anim 3, 0, 64, 0, 8, 0, 8,
+ax_anim_terminator
+sGastlyAnims_3_2:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, -1, -1, -1,
+ax_anim 2, 0, 69, -3, -3, -3, -3,
+ax_anim 2, 0, 67, -3, -3, -3, -3,
+ax_anim 2, 0, 68, -3, -3, -3, -3,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 2, 67, 4, 4, 4, 4,
+ax_anim 1, 0, 68, 10, 12, 10, 12,
+ax_anim 1, 0, 69, 18, 22, 18, 22,
+ax_anim 2, 1, 67, 19, 22, 19, 22,
+ax_anim 2, 0, 68, 18, 22, 18, 22,
+ax_anim 2, 0, 69, 19, 22, 19, 22,
+ax_anim 3, 0, 67, 7, 9, 7, 9,
+ax_anim_terminator
+sGastlyAnims_3_3:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, -1, 0, -1, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim 2, 0, 70, -3, 0, -3, 0,
+ax_anim 2, 0, 71, -3, 0, -3, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 70, 4, 0, 4, 0,
+ax_anim 1, 0, 71, 10, 1, 10, 0,
+ax_anim 1, 0, 72, 18, 2, 18, 0,
+ax_anim 2, 1, 70, 18, 1, 18, -1,
+ax_anim 2, 0, 71, 18, 2, 18, 0,
+ax_anim 2, 0, 72, 18, 1, 18, -1,
+ax_anim 3, 0, 70, 7, 1, 7, 0,
+ax_anim_terminator
+sGastlyAnims_3_4:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 1, -1, 1,
+ax_anim 2, 0, 75, -3, 3, -3, 3,
+ax_anim 2, 0, 73, -3, 3, -3, 3,
+ax_anim 2, 0, 74, -3, 3, -3, 3,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 4, -4, 4, -4,
+ax_anim 1, 0, 74, 8, -8, 8, -8,
+ax_anim 1, 0, 75, 16, -16, 16, -16,
+ax_anim 2, 1, 73, 15, -17, 15, -17,
+ax_anim 2, 0, 74, 16, -16, 16, -16,
+ax_anim 2, 0, 75, 15, -17, 15, -17,
+ax_anim 3, 0, 73, 6, -6, 6, -6,
+ax_anim_terminator
+sGastlyAnims_3_5:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 1, 0, 1,
+ax_anim 2, 0, 78, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 76, 0, -4, 0, -4,
+ax_anim 1, 0, 77, 0, -9, 0, -9,
+ax_anim 1, 0, 78, 0, -18, 0, -18,
+ax_anim 2, 1, 76, 1, -18, 1, -18,
+ax_anim 2, 0, 77, 0, -18, 0, -18,
+ax_anim 2, 0, 78, 1, -18, 1, -18,
+ax_anim 3, 0, 76, 0, -6, 0, -6,
+ax_anim_terminator
+sGastlyAnims_3_6:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 1, 1, 1,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 80, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 79, -4, -4, -4, -4,
+ax_anim 1, 0, 80, -8, -8, -8, -8,
+ax_anim 1, 0, 81, -16, -16, -16, -16,
+ax_anim 2, 1, 79, -15, -17, -15, -17,
+ax_anim 2, 0, 80, -16, -16, -16, -16,
+ax_anim 2, 0, 81, -15, -17, -15, -17,
+ax_anim 3, 0, 79, -6, -6, -6, -6,
+ax_anim_terminator
+sGastlyAnims_3_7:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 3, 0, 3, 0,
+ax_anim 2, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 1, -10, 0,
+ax_anim 1, 0, 84, -18, 2, -18, 0,
+ax_anim 2, 1, 82, -18, 1, -18, -1,
+ax_anim 2, 0, 83, -18, 2, -18, 0,
+ax_anim 2, 0, 84, -18, 1, -18, -1,
+ax_anim 3, 0, 82, -7, 1, -7, 0,
+ax_anim_terminator
+sGastlyAnims_3_8:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 85, 3, -3, 3, -3,
+ax_anim 2, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 12, -10, 12,
+ax_anim 1, 0, 87, -18, 22, -18, 22,
+ax_anim 2, 1, 85, -19, 22, -19, 22,
+ax_anim 2, 0, 86, -18, 22, -18, 22,
+ax_anim 2, 0, 87, -19, 22, -19, 22,
+ax_anim 3, 0, 85, -7, 9, -7, 9,
+ax_anim_terminator
+.align 2
+sGastlyAnims_4_1:
+ax_anim 3, 0, 96, 0, 0, 0, -2,
+ax_anim 3, 0, 97, 0, -1, 0, -2,
+ax_anim 3, 0, 98, 0, -1, 0, -2,
+ax_anim 3, 0, 99, 0, 2, 0, 2,
+ax_anim 2, 2, 100, 0, 6, 0, 6,
+ax_anim 2, 0, 100, 1, 6, 1, 6,
+ax_anim 2, 0, 100, 0, 6, 0, 6,
+ax_anim 2, 0, 100, 1, 6, 1, 6,
+ax_anim 2, 1, 100, 0, 6, 0, 6,
+ax_anim 2, 0, 100, 1, 6, 1, 6,
+ax_anim 4, 0, 99, 0, 2, 0, 2,
+ax_anim_terminator
+sGastlyAnims_4_2:
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 3, 0, 102, -1, -1, -1, -1,
+ax_anim 3, 0, 103, -1, -1, -1, -1,
+ax_anim 3, 0, 104, 2, 2, 2, 2,
+ax_anim 2, 2, 105, 6, 6, 6, 6,
+ax_anim 2, 0, 105, 5, 7, 5, 7,
+ax_anim 2, 0, 105, 6, 6, 6, 6,
+ax_anim 2, 0, 105, 5, 7, 5, 7,
+ax_anim 2, 1, 105, 6, 6, 6, 6,
+ax_anim 2, 0, 105, 5, 7, 5, 7,
+ax_anim 4, 0, 104, 2, 2, 2, 2,
+ax_anim_terminator
+sGastlyAnims_4_3:
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 107, -1, 0, -1, 0,
+ax_anim 3, 0, 108, -1, 0, -1, 0,
+ax_anim 3, 0, 109, 2, 0, 2, 0,
+ax_anim 2, 2, 110, 6, 0, 6, 0,
+ax_anim 2, 0, 110, 6, 1, 6, 1,
+ax_anim 2, 0, 110, 6, 0, 6, 0,
+ax_anim 2, 0, 110, 6, 1, 6, 1,
+ax_anim 2, 1, 110, 6, 0, 6, 0,
+ax_anim 2, 0, 110, 6, 1, 6, 1,
+ax_anim 4, 0, 109, 2, 0, 2, 0,
+ax_anim_terminator
+sGastlyAnims_4_4:
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 112, -1, 1, -1, 1,
+ax_anim 3, 0, 113, -1, 1, -1, 1,
+ax_anim 3, 0, 114, 2, -2, 2, -2,
+ax_anim 2, 2, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, 5, -7, 5, -7,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, 5, -7, 5, -7,
+ax_anim 2, 1, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, 5, -7, 5, -7,
+ax_anim 4, 0, 114, 2, -2, 2, -2,
+ax_anim_terminator
+sGastlyAnims_4_5:
+ax_anim 3, 0, 116, 0, 0, 0, 2,
+ax_anim 3, 0, 117, 0, 1, 0, 2,
+ax_anim 3, 0, 118, 0, 1, 0, 2,
+ax_anim 3, 0, 119, 0, -2, 0, -2,
+ax_anim 2, 2, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 1, -6, 1, -6,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 1, -6, 1, -6,
+ax_anim 2, 1, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 1, -6, 1, -6,
+ax_anim 4, 0, 119, 0, -2, 0, -2,
+ax_anim_terminator
+sGastlyAnims_4_6:
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 1, 1, 1, 1,
+ax_anim 3, 0, 123, 1, 1, 1, 1,
+ax_anim 3, 0, 124, -2, -2, -2, -2,
+ax_anim 2, 2, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, -5, -7, -5, -7,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, -5, -7, -5, -7,
+ax_anim 2, 1, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, -5, -7, -5, -7,
+ax_anim 4, 0, 124, -2, -2, -2, -2,
+ax_anim_terminator
+sGastlyAnims_4_7:
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 1, 0, 1, 0,
+ax_anim 3, 0, 128, 1, 0, 1, 0,
+ax_anim 3, 0, 129, -2, 0, -2, 0,
+ax_anim 2, 2, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, -6, 1, -6, 1,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, -6, 1, -6, 1,
+ax_anim 2, 1, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, -6, 1, -6, 1,
+ax_anim 4, 0, 129, -2, 0, -2, 0,
+ax_anim_terminator
+sGastlyAnims_4_8:
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 1, -1, 1, -1,
+ax_anim 3, 0, 133, 1, -1, 1, -1,
+ax_anim 3, 0, 134, -2, 2, -2, 2,
+ax_anim 2, 2, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, -5, 7, -5, 7,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, -5, 7, -5, 7,
+ax_anim 2, 1, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, -5, 7, -5, 7,
+ax_anim 4, 0, 134, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGastlyAnims_5_1:
+ax_anim 2, 0, 136, 0, 2, 0, 2,
+ax_anim 2, 0, 137, 0, 8, 0, 8,
+ax_anim 2, 0, 138, 0, 16, 0, 16,
+ax_anim 4, 0, 136, 0, 16, 0, 16,
+ax_anim 5, 0, 137, 0, 16, 0, 16,
+ax_anim 6, 0, 138, 0, 16, 0, 16,
+ax_anim 2, 0, 139, 0, 16, 0, 16,
+ax_anim 2, 0, 140, 0, 16, 0, 16,
+ax_anim 2, 2, 139, 0, 16, 0, 16,
+ax_anim 2, 0, 140, 0, 16, 0, 16,
+ax_anim 2, 1, 139, 0, 16, 0, 16,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim_terminator
+sGastlyAnims_5_2:
+ax_anim 2, 0, 141, 2, 2, 2, 2,
+ax_anim 2, 0, 142, 8, 8, 8, 8,
+ax_anim 2, 0, 143, 16, 16, 16, 16,
+ax_anim 4, 0, 141, 16, 16, 16, 16,
+ax_anim 5, 0, 142, 16, 16, 16, 16,
+ax_anim 6, 0, 143, 16, 16, 16, 16,
+ax_anim 2, 0, 144, 16, 16, 16, 16,
+ax_anim 2, 0, 145, 16, 16, 16, 16,
+ax_anim 2, 2, 144, 16, 16, 16, 16,
+ax_anim 2, 0, 145, 16, 16, 16, 16,
+ax_anim 2, 1, 144, 16, 16, 16, 16,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim_terminator
+sGastlyAnims_5_3:
+ax_anim 2, 0, 146, 2, 0, 2, 0,
+ax_anim 2, 0, 147, 8, 0, 8, 0,
+ax_anim 2, 0, 148, 16, 0, 16, 0,
+ax_anim 4, 0, 146, 16, 0, 16, 0,
+ax_anim 5, 0, 147, 16, 0, 16, 0,
+ax_anim 6, 0, 148, 16, 0, 16, 0,
+ax_anim 2, 0, 149, 16, 0, 16, 0,
+ax_anim 2, 0, 150, 16, 0, 16, 0,
+ax_anim 2, 2, 149, 16, 0, 16, 0,
+ax_anim 2, 0, 150, 16, 0, 16, 0,
+ax_anim 2, 1, 149, 16, 0, 16, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim_terminator
+sGastlyAnims_5_4:
+ax_anim 2, 0, 151, 2, -2, 2, -2,
+ax_anim 2, 0, 152, 6, -6, 6, -6,
+ax_anim 2, 0, 153, 14, -14, 14, -14,
+ax_anim 4, 0, 151, 14, -14, 14, -14,
+ax_anim 5, 0, 152, 14, -14, 14, -14,
+ax_anim 6, 0, 153, 14, -14, 14, -14,
+ax_anim 2, 0, 154, 14, -14, 14, -14,
+ax_anim 2, 0, 155, 14, -14, 14, -14,
+ax_anim 2, 2, 154, 14, -14, 14, -14,
+ax_anim 2, 0, 155, 14, -14, 14, -14,
+ax_anim 2, 1, 154, 14, -14, 14, -14,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim_terminator
+sGastlyAnims_5_5:
+ax_anim 2, 0, 156, 0, -2, 0, -2,
+ax_anim 2, 0, 157, 0, -6, 0, -6,
+ax_anim 2, 0, 158, 0, -14, 0, -14,
+ax_anim 4, 0, 156, 0, -14, 0, -14,
+ax_anim 5, 0, 157, 0, -14, 0, -14,
+ax_anim 6, 0, 158, 0, -14, 0, -14,
+ax_anim 2, 0, 159, 0, -14, 0, -14,
+ax_anim 2, 0, 160, 0, -14, 0, -14,
+ax_anim 2, 2, 159, 0, -14, 0, -14,
+ax_anim 2, 0, 160, 0, -14, 0, -14,
+ax_anim 2, 1, 159, 0, -14, 0, -14,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim_terminator
+sGastlyAnims_5_6:
+ax_anim 2, 0, 161, -2, -2, -2, -2,
+ax_anim 2, 0, 162, -6, -6, -6, -6,
+ax_anim 2, 0, 163, -14, -14, -14, -14,
+ax_anim 4, 0, 161, -14, -14, -14, -14,
+ax_anim 5, 0, 162, -14, -14, -14, -14,
+ax_anim 6, 0, 163, -14, -14, -14, -14,
+ax_anim 2, 0, 164, -14, -14, -14, -14,
+ax_anim 2, 0, 165, -14, -14, -14, -14,
+ax_anim 2, 2, 164, -14, -14, -14, -14,
+ax_anim 2, 0, 165, -14, -14, -14, -14,
+ax_anim 2, 1, 164, -14, -14, -14, -14,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim_terminator
+sGastlyAnims_5_7:
+ax_anim 2, 0, 166, -2, 0, -2, 0,
+ax_anim 2, 0, 167, -8, 0, -8, 0,
+ax_anim 2, 0, 168, -16, 0, -16, 0,
+ax_anim 4, 0, 166, -16, 0, -16, 0,
+ax_anim 5, 0, 167, -16, 0, -16, 0,
+ax_anim 6, 0, 168, -16, 0, -16, 0,
+ax_anim 2, 0, 169, -16, 0, -16, 0,
+ax_anim 2, 0, 170, -16, 0, -16, 0,
+ax_anim 2, 2, 169, -16, 0, -16, 0,
+ax_anim 2, 0, 170, -16, 0, -16, 0,
+ax_anim 2, 1, 169, -16, 0, -16, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim_terminator
+sGastlyAnims_5_8:
+ax_anim 2, 0, 171, -2, 2, -2, 2,
+ax_anim 2, 0, 172, -8, 8, -8, 8,
+ax_anim 2, 0, 173, -16, 16, -16, 16,
+ax_anim 4, 0, 171, -16, 16, -16, 16,
+ax_anim 5, 0, 172, -16, 16, -16, 16,
+ax_anim 6, 0, 173, -16, 16, -16, 16,
+ax_anim 2, 0, 174, -16, 16, -16, 16,
+ax_anim 2, 0, 175, -16, 16, -16, 16,
+ax_anim 2, 2, 174, -16, 16, -16, 16,
+ax_anim 2, 0, 175, -16, 16, -16, 16,
+ax_anim 2, 1, 174, -16, 16, -16, 16,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGastlyAnims_6_1:
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 0, 176, 0, -1, 0, 0,
+ax_anim 6, 0, 176, 0, -2, 0, 0,
+ax_anim 16, 0, 177, 0, -3, 0, 0,
+ax_anim 6, 0, 177, 0, -2, 0, 0,
+ax_anim 6, 0, 177, 0, -1, 0, 0,
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 16, 0, 176, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sGastlyAnims_7_1:
+ax_anim 2, 0, 178, 0, -2, 0, -2,
+ax_anim 8, 0, 178, 0, -3, 0, -3,
+ax_anim_terminator
+sGastlyAnims_7_2:
+ax_anim 2, 0, 179, -2, -2, -2, -2,
+ax_anim 8, 0, 179, -3, -3, -3, -3,
+ax_anim_terminator
+sGastlyAnims_7_3:
+ax_anim 2, 0, 180, -2, 0, -2, 0,
+ax_anim 8, 0, 180, -3, 0, -3, 0,
+ax_anim_terminator
+sGastlyAnims_7_4:
+ax_anim 2, 0, 181, -2, 2, -2, 2,
+ax_anim 8, 0, 181, -3, 3, -3, 3,
+ax_anim_terminator
+sGastlyAnims_7_5:
+ax_anim 2, 0, 182, 0, 2, 0, 2,
+ax_anim 8, 0, 182, 0, 3, 0, 3,
+ax_anim_terminator
+sGastlyAnims_7_6:
+ax_anim 2, 0, 183, 2, 2, 2, 2,
+ax_anim 8, 0, 183, 3, 3, 3, 3,
+ax_anim_terminator
+sGastlyAnims_7_7:
+ax_anim 2, 0, 184, 2, 0, 2, 0,
+ax_anim 8, 0, 184, 3, 0, 3, 0,
+ax_anim_terminator
+sGastlyAnims_7_8:
+ax_anim 2, 0, 185, 2, -2, 2, -2,
+ax_anim 8, 0, 185, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGastlyAnims_8_1:
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 187, 1, 0, 1, 0,
+ax_anim 10, 0, 188, 1, 0, 1, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 187, -1, 0, -1, 0,
+ax_anim 10, 0, 188, -1, 0, -1, 0,
+ax_anim_terminator
+sGastlyAnims_8_2:
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim 10, 0, 190, 1, -1, 1, -1,
+ax_anim 10, 0, 191, 1, -1, 1, -1,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim 10, 0, 190, -1, 1, -1, 1,
+ax_anim 10, 0, 191, -1, 1, -1, 1,
+ax_anim_terminator
+sGastlyAnims_8_3:
+ax_anim 10, 0, 192, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, -1, 0, -1,
+ax_anim 10, 0, 194, 0, -1, 0, -1,
+ax_anim 10, 0, 192, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, 1, 0, 1,
+ax_anim 10, 0, 194, 0, 1, 0, 1,
+ax_anim_terminator
+sGastlyAnims_8_4:
+ax_anim 10, 0, 195, 0, 0, 0, 0,
+ax_anim 10, 0, 196, -1, -1, -1, -1,
+ax_anim 10, 0, 197, -1, -1, -1, -1,
+ax_anim 10, 0, 195, 0, 0, 0, 0,
+ax_anim 10, 0, 196, 1, 1, 1, 1,
+ax_anim 10, 0, 197, 1, 1, 1, 1,
+ax_anim_terminator
+sGastlyAnims_8_5:
+ax_anim 10, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 199, -1, 0, -1, 0,
+ax_anim 10, 0, 200, -1, 0, -1, 0,
+ax_anim 10, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 199, 1, 0, 1, 0,
+ax_anim 10, 0, 200, 1, 0, 1, 0,
+ax_anim_terminator
+sGastlyAnims_8_6:
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 10, 0, 202, 1, -1, 1, -1,
+ax_anim 10, 0, 203, 1, -1, 1, -1,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 10, 0, 202, -1, 1, -1, 1,
+ax_anim 10, 0, 203, -1, 1, -1, 1,
+ax_anim_terminator
+sGastlyAnims_8_7:
+ax_anim 10, 0, 204, 0, 0, 0, 0,
+ax_anim 10, 0, 205, 0, -1, 0, -1,
+ax_anim 10, 0, 206, 0, -1, 0, -1,
+ax_anim 10, 0, 204, 0, 0, 0, 0,
+ax_anim 10, 0, 205, 0, 1, 0, 1,
+ax_anim 10, 0, 206, 0, 1, 0, 1,
+ax_anim_terminator
+sGastlyAnims_8_8:
+ax_anim 10, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, -1, -1, -1, -1,
+ax_anim 10, 0, 209, -1, -1, -1, -1,
+ax_anim 10, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 1, 1, 1, 1,
+ax_anim 10, 0, 209, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sGastlyAnims_9_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 6, 4, 6, 4,
+ax_anim 2, 0, 220, 8, 9, 8, 9,
+ax_anim 2, 0, 221, 7, 19, 7, 19,
+ax_anim 3, 0, 222, 1, 24, 1, 24,
+ax_anim 2, 3, 223, -6, 19, -6, 19,
+ax_anim 2, 0, 224, -8, 9, -8, 9,
+ax_anim 1, 0, 225, -6, 4, -6, 4,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_9_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 219, 17, 3, 17, 3,
+ax_anim 2, 0, 220, 24, 9, 24, 9,
+ax_anim 3, 0, 221, 23, 21, 23, 21,
+ax_anim 2, 3, 222, 11, 21, 11, 21,
+ax_anim 2, 0, 223, 2, 12, 2, 12,
+ax_anim 1, 0, 224, 0, 7, 0, 7,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_9_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 3, -4, 3, -4,
+ax_anim 2, 0, 218, 11, -6, 11, -6,
+ax_anim 2, 0, 219, 17, -4, 17, -4,
+ax_anim 3, 0, 220, 20, 1, 20, 1,
+ax_anim 2, 3, 221, 17, 5, 17, 5,
+ax_anim 2, 0, 222, 12, 7, 12, 7,
+ax_anim 1, 0, 223, 4, 5, 4, 5,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_9_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, -1, -6, -1, -6,
+ax_anim 2, 0, 225, 4, -16, 4, -16,
+ax_anim 2, 0, 218, 11, -20, 11, -20,
+ax_anim 3, 0, 219, 19, -20, 19, -20,
+ax_anim 2, 3, 220, 18, -12, 18, -12,
+ax_anim 2, 0, 221, 16, -6, 16, -6,
+ax_anim 1, 0, 222, 7, -1, 7, -1,
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_9_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, -6, -4, -6, -4,
+ax_anim 2, 0, 224, -8, -10, -8, -10,
+ax_anim 2, 0, 225, -7, -18, -7, -18,
+ax_anim 3, 0, 218, -1, -24, -1, -24,
+ax_anim 2, 3, 219, 4, -19, 4, -19,
+ax_anim 2, 0, 220, 5, -9, 5, -9,
+ax_anim 1, 0, 221, 4, -4, 4, -4,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_9_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, -6, 1, -6,
+ax_anim 2, 0, 219, -4, -16, -4, -16,
+ax_anim 2, 0, 218, -11, -20, -11, -20,
+ax_anim 3, 0, 225, -19, -20, -19, -20,
+ax_anim 2, 3, 224, -18, -12, -18, -12,
+ax_anim 2, 0, 223, -16, -6, -16, -6,
+ax_anim 1, 0, 222, -7, -1, -7, -1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_9_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 219, -3, -4, -3, -4,
+ax_anim 2, 0, 218, -11, -6, -11, -6,
+ax_anim 2, 0, 225, -17, -4, -17, -4,
+ax_anim 3, 0, 224, -20, 1, -20, 1,
+ax_anim 2, 3, 223, -17, 5, -17, 5,
+ax_anim 2, 0, 222, -12, 7, -12, 7,
+ax_anim 1, 0, 221, -4, 5, -4, 5,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_9_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 225, -17, 3, -17, 3,
+ax_anim 2, 0, 224, -24, 9, -24, 9,
+ax_anim 3, 0, 223, -23, 21, -23, 21,
+ax_anim 2, 3, 222, -11, 21, -11, 21,
+ax_anim 2, 0, 221, -2, 12, -2, 12,
+ax_anim 1, 0, 220, 0, 7, 0, 7,
+ax_anim 1, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGastlyAnims_10_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 3, 0, 226, 13, 0, 13, 0,
+ax_anim 3, 0, 226, -13, 0, -13, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_10_2:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 3, 0, 227, 13, -13, 13, -13,
+ax_anim 3, 0, 227, -13, 13, -13, 13,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_10_3:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 3, 0, 228, 0, -13, 0, -13,
+ax_anim 3, 0, 228, 0, 13, 0, 13,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_10_4:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 3, 0, 229, -13, -13, -13, -13,
+ax_anim 3, 0, 229, 13, 13, 13, 13,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_10_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 3, 0, 230, 13, 0, 13, 0,
+ax_anim 3, 0, 230, -13, 0, -13, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_10_6:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 3, 0, 231, 13, -13, 13, -13,
+ax_anim 3, 0, 231, -13, 13, -13, 13,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_10_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 3, 0, 232, 0, -13, 0, -13,
+ax_anim 3, 0, 232, 0, 13, 0, 13,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_10_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 3, 0, 233, -13, -13, -13, -13,
+ax_anim 3, 0, 233, 13, 13, 13, 13,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGastlyAnims_11_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 238, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 4, 0, 238, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -23, 0, 0,
+ax_anim 3, 0, 234, 0, -22, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 1, 0, 236, 0, -8, 0, 0,
+ax_anim 2, 2, 234, 0, 4, 0, 0,
+ax_anim_terminator
+sGastlyAnims_11_2:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 243, 0, -20, 0, 0,
+ax_anim 4, 0, 243, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -23, 0, 0,
+ax_anim 3, 0, 239, 0, -22, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 1, 0, 241, 0, -8, 0, 0,
+ax_anim 2, 2, 239, 0, 4, 0, 0,
+ax_anim_terminator
+sGastlyAnims_11_3:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 247, 0, -10, 0, 0,
+ax_anim 2, 0, 248, 0, -16, 0, 0,
+ax_anim 3, 0, 248, 0, -20, 0, 0,
+ax_anim 4, 0, 248, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -23, 0, 0,
+ax_anim 3, 0, 244, 0, -22, 0, 0,
+ax_anim 2, 0, 245, 0, -16, 0, 0,
+ax_anim 1, 0, 246, 0, -8, 0, 0,
+ax_anim 2, 2, 244, 0, 4, 0, 0,
+ax_anim_terminator
+sGastlyAnims_11_4:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -10, 0, 0,
+ax_anim 2, 0, 253, 0, -16, 0, 0,
+ax_anim 3, 0, 253, 0, -20, 0, 0,
+ax_anim 4, 0, 253, 0, -21, 0, 0,
+ax_anim 4, 0, 251, 0, -22, 0, 0,
+ax_anim 3, 0, 249, 0, -21, 0, 0,
+ax_anim 2, 0, 250, 0, -15, 0, 0,
+ax_anim 1, 0, 251, 0, -7, 0, 0,
+ax_anim 2, 2, 249, 0, 4, 0, 0,
+ax_anim_terminator
+sGastlyAnims_11_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -16, 0, 0,
+ax_anim 3, 0, 258, 0, -20, 0, 0,
+ax_anim 4, 0, 258, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 254, 0, -22, 0, 0,
+ax_anim 2, 0, 255, 0, -16, 0, 0,
+ax_anim 1, 0, 256, 0, -8, 0, 0,
+ax_anim 2, 2, 254, 0, 4, 0, 0,
+ax_anim_terminator
+sGastlyAnims_11_6:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 262, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 261, 0, -22, 0, 0,
+ax_anim 3, 0, 259, 0, -21, 0, 0,
+ax_anim 2, 0, 260, 0, -15, 0, 0,
+ax_anim 1, 0, 261, 0, -7, 0, 0,
+ax_anim 2, 2, 259, 0, 4, 0, 0,
+ax_anim_terminator
+sGastlyAnims_11_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 1, 0, 267, 0, -10, 0, 0,
+ax_anim 2, 0, 268, 0, -16, 0, 0,
+ax_anim 3, 0, 268, 0, -20, 0, 0,
+ax_anim 4, 0, 268, 0, -21, 0, 0,
+ax_anim 4, 0, 266, 0, -23, 0, 0,
+ax_anim 3, 0, 264, 0, -22, 0, 0,
+ax_anim 2, 0, 265, 0, -16, 0, 0,
+ax_anim 1, 0, 266, 0, -8, 0, 0,
+ax_anim 2, 2, 264, 0, 4, 0, 0,
+ax_anim_terminator
+sGastlyAnims_11_8:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 273, 0, -16, 0, 0,
+ax_anim 3, 0, 273, 0, -20, 0, 0,
+ax_anim 4, 0, 273, 0, -21, 0, 0,
+ax_anim 4, 0, 271, 0, -23, 0, 0,
+ax_anim 3, 0, 269, 0, -22, 0, 0,
+ax_anim 2, 0, 270, 0, -16, 0, 0,
+ax_anim 1, 0, 271, 0, -8, 0, 0,
+ax_anim 2, 2, 269, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sGastlyAnims_12_1:
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 1, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_12_2:
+ax_anim 2, 0, 281, 1, -1, 1, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, 0,
+ax_anim 2, 1, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_12_3:
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 1, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_12_4:
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 1, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_12_5:
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 1, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_12_6:
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 1, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_12_7:
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 1, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_12_8:
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 1, 275, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGastlyAnims_13_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_13_2:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_13_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_13_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_13_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_13_6:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_13_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyAnims_13_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sGastlyGfx1:
+.incbin "baserom.gba", 0x8EB124, 0x200
+sGastlySprites1:
+ax_sprite sGastlyGfx1, 0x200
+ax_sprite_terminator
+sGastlyGfx2:
+.incbin "baserom.gba", 0x8EB334, 0x200
+sGastlySprites2:
+ax_sprite sGastlyGfx2, 0x200
+ax_sprite_terminator
+sGastlyGfx3:
+.incbin "baserom.gba", 0x8EB544, 0x200
+sGastlySprites3:
+ax_sprite sGastlyGfx3, 0x200
+ax_sprite_terminator
+sGastlyGfx4:
+.incbin "baserom.gba", 0x8EB754, 0x200
+sGastlySprites4:
+ax_sprite sGastlyGfx4, 0x200
+ax_sprite_terminator
+sGastlyGfx5:
+.incbin "baserom.gba", 0x8EB964, 0x200
+sGastlySprites5:
+ax_sprite sGastlyGfx5, 0x200
+ax_sprite_terminator
+sGastlyGfx6:
+.incbin "baserom.gba", 0x8EBB74, 0x200
+sGastlySprites6:
+ax_sprite sGastlyGfx6, 0x200
+ax_sprite_terminator
+sGastlyGfx7:
+.incbin "baserom.gba", 0x8EBD84, 0x200
+sGastlySprites7:
+ax_sprite sGastlyGfx7, 0x200
+ax_sprite_terminator
+sGastlyGfx8:
+.incbin "baserom.gba", 0x8EBF94, 0x200
+sGastlySprites8:
+ax_sprite sGastlyGfx8, 0x200
+ax_sprite_terminator
+sGastlyGfx9:
+.incbin "baserom.gba", 0x8EC1A4, 0x200
+sGastlySprites9:
+ax_sprite sGastlyGfx9, 0x200
+ax_sprite_terminator
+sGastlyGfx10:
+.incbin "baserom.gba", 0x8EC3B4, 0x200
+sGastlySprites10:
+ax_sprite sGastlyGfx10, 0x200
+ax_sprite_terminator
+sGastlyGfx11:
+.incbin "baserom.gba", 0x8EC5C4, 0x200
+sGastlySprites11:
+ax_sprite sGastlyGfx11, 0x200
+ax_sprite_terminator
+sGastlyGfx12:
+.incbin "baserom.gba", 0x8EC7D4, 0x200
+sGastlySprites12:
+ax_sprite sGastlyGfx12, 0x200
+ax_sprite_terminator
+sGastlyGfx13:
+.incbin "baserom.gba", 0x8EC9E4, 0x200
+sGastlySprites13:
+ax_sprite sGastlyGfx13, 0x200
+ax_sprite_terminator
+sGastlyGfx14:
+.incbin "baserom.gba", 0x8ECBF4, 0x200
+sGastlySprites14:
+ax_sprite sGastlyGfx14, 0x200
+ax_sprite_terminator
+sGastlyGfx15:
+.incbin "baserom.gba", 0x8ECE04, 0x200
+sGastlySprites15:
+ax_sprite sGastlyGfx15, 0x200
+ax_sprite_terminator
+sGastlyGfx16:
+.incbin "baserom.gba", 0x8ED014, 0x200
+sGastlySprites16:
+ax_sprite sGastlyGfx16, 0x200
+ax_sprite_terminator
+sGastlyGfx17:
+.incbin "baserom.gba", 0x8ED224, 0x200
+sGastlySprites17:
+ax_sprite sGastlyGfx17, 0x200
+ax_sprite_terminator
+sGastlyGfx18:
+.incbin "baserom.gba", 0x8ED434, 0x200
+sGastlySprites18:
+ax_sprite sGastlyGfx18, 0x200
+ax_sprite_terminator
+sGastlyGfx19:
+.incbin "baserom.gba", 0x8ED644, 0x1C0
+sGastlySprites19:
+ax_sprite 0, 0x20
+ax_sprite sGastlyGfx19, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGastlyGfx20:
+.incbin "baserom.gba", 0x8ED824, 0x60
+sGastlyGfx20_1:
+.incbin "baserom.gba", 0x8ED884, 0x180
+sGastlySprites20:
+ax_sprite sGastlyGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGastlyGfx20_1, 0x180
+ax_sprite_terminator
+sGastlyGfx21:
+.incbin "baserom.gba", 0x8EDA24, 0x40
+sGastlyGfx21_1:
+.incbin "baserom.gba", 0x8EDA64, 0x180
+sGastlySprites21:
+ax_sprite 0, 0x20
+ax_sprite sGastlyGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGastlyGfx21_1, 0x180
+ax_sprite_terminator
+sGastlyGfx22:
+.incbin "baserom.gba", 0x8EDC0C, 0x180
+sGastlyGfx22_1:
+.incbin "baserom.gba", 0x8EDD8C, 0x40
+sGastlySprites22:
+ax_sprite sGastlyGfx22, 0x180
+ax_sprite 0, 0x20
+ax_sprite sGastlyGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGastlyGfx23:
+.incbin "baserom.gba", 0x8EDDF4, 0x180
+sGastlySprites23:
+ax_sprite sGastlyGfx23, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGastlyGfx24:
+.incbin "baserom.gba", 0x8EDF8C, 0x180
+sGastlyGfx24_1:
+.incbin "baserom.gba", 0x8EE10C, 0x40
+sGastlySprites24:
+ax_sprite sGastlyGfx24, 0x180
+ax_sprite 0, 0x20
+ax_sprite sGastlyGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGastlyGfx25:
+.incbin "baserom.gba", 0x8EE174, 0x1E0
+sGastlySprites25:
+ax_sprite sGastlyGfx25, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGastlyGfx26:
+.incbin "baserom.gba", 0x8EE36C, 0x200
+sGastlySprites26:
+ax_sprite sGastlyGfx26, 0x200
+ax_sprite_terminator
+sGastlyGfx27:
+.incbin "baserom.gba", 0x8EE57C, 0x200
+sGastlySprites27:
+ax_sprite sGastlyGfx27, 0x200
+ax_sprite_terminator
+sGastlyGfx28:
+.incbin "baserom.gba", 0x8EE78C, 0x200
+sGastlySprites28:
+ax_sprite sGastlyGfx28, 0x200
+ax_sprite_terminator
+sGastlyGfx29:
+.incbin "baserom.gba", 0x8EE99C, 0x200
+sGastlySprites29:
+ax_sprite sGastlyGfx29, 0x200
+ax_sprite_terminator
+sGastlyGfx30:
+.incbin "baserom.gba", 0x8EEBAC, 0x200
+sGastlySprites30:
+ax_sprite sGastlyGfx30, 0x200
+ax_sprite_terminator
+sGastlyGfx31:
+.incbin "baserom.gba", 0x8EEDBC, 0x200
+sGastlySprites31:
+ax_sprite sGastlyGfx31, 0x200
+ax_sprite_terminator
+sGastlyGfx32:
+.incbin "baserom.gba", 0x8EEFCC, 0x200
+sGastlySprites32:
+ax_sprite sGastlyGfx32, 0x200
+ax_sprite_terminator
+sAxPosesGastly:
+.4byte sGastlyPose1
+.4byte sGastlyPose2
+.4byte sGastlyPose3
+.4byte sGastlyPose4
+.4byte sGastlyPose5
+.4byte sGastlyPose6
+.4byte sGastlyPose7
+.4byte sGastlyPose8
+.4byte sGastlyPose9
+.4byte sGastlyPose10
+.4byte sGastlyPose11
+.4byte sGastlyPose12
+.4byte sGastlyPose13
+.4byte sGastlyPose14
+.4byte sGastlyPose15
+.4byte sGastlyPose16
+.4byte sGastlyPose17
+.4byte sGastlyPose18
+.4byte sGastlyPose19
+.4byte sGastlyPose20
+.4byte sGastlyPose21
+.4byte sGastlyPose22
+.4byte sGastlyPose23
+.4byte sGastlyPose24
+.4byte sGastlyPose25
+.4byte sGastlyPose26
+.4byte sGastlyPose27
+.4byte sGastlyPose28
+.4byte sGastlyPose29
+.4byte sGastlyPose30
+.4byte sGastlyPose31
+.4byte sGastlyPose32
+.4byte sGastlyPose33
+.4byte sGastlyPose34
+.4byte sGastlyPose35
+.4byte sGastlyPose36
+.4byte sGastlyPose37
+.4byte sGastlyPose38
+.4byte sGastlyPose39
+.4byte sGastlyPose40
+.4byte sGastlyPose41
+.4byte sGastlyPose42
+.4byte sGastlyPose43
+.4byte sGastlyPose44
+.4byte sGastlyPose45
+.4byte sGastlyPose46
+.4byte sGastlyPose47
+.4byte sGastlyPose48
+.4byte sGastlyPose49
+.4byte sGastlyPose50
+.4byte sGastlyPose51
+.4byte sGastlyPose52
+.4byte sGastlyPose53
+.4byte sGastlyPose54
+.4byte sGastlyPose55
+.4byte sGastlyPose56
+.4byte sGastlyPose57
+.4byte sGastlyPose58
+.4byte sGastlyPose59
+.4byte sGastlyPose60
+.4byte sGastlyPose61
+.4byte sGastlyPose62
+.4byte sGastlyPose63
+.4byte sGastlyPose64
+.4byte sGastlyPose65
+.4byte sGastlyPose66
+.4byte sGastlyPose67
+.4byte sGastlyPose68
+.4byte sGastlyPose69
+.4byte sGastlyPose70
+.4byte sGastlyPose71
+.4byte sGastlyPose72
+.4byte sGastlyPose73
+.4byte sGastlyPose74
+.4byte sGastlyPose75
+.4byte sGastlyPose76
+.4byte sGastlyPose77
+.4byte sGastlyPose78
+.4byte sGastlyPose79
+.4byte sGastlyPose80
+.4byte sGastlyPose81
+.4byte sGastlyPose82
+.4byte sGastlyPose83
+.4byte sGastlyPose84
+.4byte sGastlyPose85
+.4byte sGastlyPose86
+.4byte sGastlyPose87
+.4byte sGastlyPose88
+.4byte sGastlyPose89
+.4byte sGastlyPose90
+.4byte sGastlyPose91
+.4byte sGastlyPose92
+.4byte sGastlyPose93
+.4byte sGastlyPose94
+.4byte sGastlyPose95
+.4byte sGastlyPose96
+.4byte sGastlyPose97
+.4byte sGastlyPose98
+.4byte sGastlyPose99
+.4byte sGastlyPose100
+.4byte sGastlyPose101
+.4byte sGastlyPose102
+.4byte sGastlyPose103
+.4byte sGastlyPose104
+.4byte sGastlyPose105
+.4byte sGastlyPose106
+.4byte sGastlyPose107
+.4byte sGastlyPose108
+.4byte sGastlyPose109
+.4byte sGastlyPose110
+.4byte sGastlyPose111
+.4byte sGastlyPose112
+.4byte sGastlyPose113
+.4byte sGastlyPose114
+.4byte sGastlyPose115
+.4byte sGastlyPose116
+.4byte sGastlyPose117
+.4byte sGastlyPose118
+.4byte sGastlyPose119
+.4byte sGastlyPose120
+.4byte sGastlyPose121
+.4byte sGastlyPose122
+.4byte sGastlyPose123
+.4byte sGastlyPose124
+.4byte sGastlyPose125
+.4byte sGastlyPose126
+.4byte sGastlyPose127
+.4byte sGastlyPose128
+.4byte sGastlyPose129
+.4byte sGastlyPose130
+.4byte sGastlyPose131
+.4byte sGastlyPose132
+.4byte sGastlyPose133
+.4byte sGastlyPose134
+.4byte sGastlyPose135
+.4byte sGastlyPose136
+.4byte sGastlyPose137
+.4byte sGastlyPose138
+.4byte sGastlyPose139
+.4byte sGastlyPose140
+.4byte sGastlyPose141
+.4byte sGastlyPose142
+.4byte sGastlyPose143
+.4byte sGastlyPose144
+.4byte sGastlyPose145
+.4byte sGastlyPose146
+.4byte sGastlyPose147
+.4byte sGastlyPose148
+.4byte sGastlyPose149
+.4byte sGastlyPose150
+.4byte sGastlyPose151
+.4byte sGastlyPose152
+.4byte sGastlyPose153
+.4byte sGastlyPose154
+.4byte sGastlyPose155
+.4byte sGastlyPose156
+.4byte sGastlyPose157
+.4byte sGastlyPose158
+.4byte sGastlyPose159
+.4byte sGastlyPose160
+.4byte sGastlyPose161
+.4byte sGastlyPose162
+.4byte sGastlyPose163
+.4byte sGastlyPose164
+.4byte sGastlyPose165
+.4byte sGastlyPose166
+.4byte sGastlyPose167
+.4byte sGastlyPose168
+.4byte sGastlyPose169
+.4byte sGastlyPose170
+.4byte sGastlyPose171
+.4byte sGastlyPose172
+.4byte sGastlyPose173
+.4byte sGastlyPose174
+.4byte sGastlyPose175
+.4byte sGastlyPose176
+.4byte sGastlyPose177
+.4byte sGastlyPose178
+.4byte sGastlyPose179
+.4byte sGastlyPose180
+.4byte sGastlyPose181
+.4byte sGastlyPose182
+.4byte sGastlyPose183
+.4byte sGastlyPose184
+.4byte sGastlyPose185
+.4byte sGastlyPose186
+.4byte sGastlyPose187
+.4byte sGastlyPose188
+.4byte sGastlyPose189
+.4byte sGastlyPose190
+.4byte sGastlyPose191
+.4byte sGastlyPose192
+.4byte sGastlyPose193
+.4byte sGastlyPose194
+.4byte sGastlyPose195
+.4byte sGastlyPose196
+.4byte sGastlyPose197
+.4byte sGastlyPose198
+.4byte sGastlyPose199
+.4byte sGastlyPose200
+.4byte sGastlyPose201
+.4byte sGastlyPose202
+.4byte sGastlyPose203
+.4byte sGastlyPose204
+.4byte sGastlyPose205
+.4byte sGastlyPose206
+.4byte sGastlyPose207
+.4byte sGastlyPose208
+.4byte sGastlyPose209
+.4byte sGastlyPose210
+.4byte sGastlyPose211
+.4byte sGastlyPose212
+.4byte sGastlyPose213
+.4byte sGastlyPose214
+.4byte sGastlyPose215
+.4byte sGastlyPose216
+.4byte sGastlyPose217
+.4byte sGastlyPose218
+.4byte sGastlyPose219
+.4byte sGastlyPose220
+.4byte sGastlyPose221
+.4byte sGastlyPose222
+.4byte sGastlyPose223
+.4byte sGastlyPose224
+.4byte sGastlyPose225
+.4byte sGastlyPose226
+.4byte sGastlyPose227
+.4byte sGastlyPose228
+.4byte sGastlyPose229
+.4byte sGastlyPose230
+.4byte sGastlyPose231
+.4byte sGastlyPose232
+.4byte sGastlyPose233
+.4byte sGastlyPose234
+.4byte sGastlyPose235
+.4byte sGastlyPose236
+.4byte sGastlyPose237
+.4byte sGastlyPose238
+.4byte sGastlyPose239
+.4byte sGastlyPose240
+.4byte sGastlyPose241
+.4byte sGastlyPose242
+.4byte sGastlyPose243
+.4byte sGastlyPose244
+.4byte sGastlyPose245
+.4byte sGastlyPose246
+.4byte sGastlyPose247
+.4byte sGastlyPose248
+.4byte sGastlyPose249
+.4byte sGastlyPose250
+.4byte sGastlyPose251
+.4byte sGastlyPose252
+.4byte sGastlyPose253
+.4byte sGastlyPose254
+.4byte sGastlyPose255
+.4byte sGastlyPose256
+.4byte sGastlyPose257
+.4byte sGastlyPose258
+.4byte sGastlyPose259
+.4byte sGastlyPose260
+.4byte sGastlyPose261
+.4byte sGastlyPose262
+.4byte sGastlyPose263
+.4byte sGastlyPose264
+.4byte sGastlyPose265
+.4byte sGastlyPose266
+.4byte sGastlyPose267
+.4byte sGastlyPose268
+.4byte sGastlyPose269
+.4byte sGastlyPose270
+.4byte sGastlyPose271
+.4byte sGastlyPose272
+.4byte sGastlyPose273
+.4byte sGastlyPose274
+.4byte sGastlyPose275
+.4byte sGastlyPose276
+.4byte sGastlyPose277
+.4byte sGastlyPose278
+.4byte sGastlyPose279
+.4byte sGastlyPose280
+.4byte sGastlyPose281
+.4byte sGastlyPose282
+.4byte sGastlyPose283
+.4byte sGastlyPose284
+.4byte sGastlyPose285
+.4byte sGastlyPose286
+.4byte sGastlyPose287
+.4byte sGastlyPose288
+.4byte sGastlyPose289
+.4byte sGastlyPose290
+sAxPositionsGastly:
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   0,   -5, 	   0,  -11
+.2byte    3,   -5, 	   4,  -16, 	   0,   -5, 	   0,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    4,   -9, 	  -2,  -17, 	   5,   -9, 	  -1,  -12
+.2byte    5,   -9, 	  -2,  -16, 	   4,   -9, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -5,   -9, 	   1,  -17, 	  -6,   -9, 	   0,  -12
+.2byte   -6,   -9, 	   1,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -1,   -5, 	  -1,  -11
+.2byte   -4,   -5, 	  -5,  -16, 	  -1,   -5, 	  -1,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   0,   -5, 	   0,  -11
+.2byte    3,   -5, 	   4,  -16, 	   0,   -5, 	   0,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    4,   -9, 	  -2,  -17, 	   5,   -9, 	  -1,  -12
+.2byte    5,   -9, 	  -2,  -16, 	   4,   -9, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -5,   -9, 	   1,  -17, 	  -6,   -9, 	   0,  -12
+.2byte   -6,   -9, 	   1,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -1,   -5, 	  -1,  -11
+.2byte   -4,   -5, 	  -5,  -16, 	  -1,   -5, 	  -1,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   0,   -5, 	   0,  -11
+.2byte    3,   -5, 	   4,  -16, 	   0,   -5, 	   0,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    4,   -9, 	  -2,  -17, 	   5,   -9, 	  -1,  -12
+.2byte    5,   -9, 	  -2,  -16, 	   4,   -9, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -5,   -9, 	   1,  -17, 	  -6,   -9, 	   0,  -12
+.2byte   -6,   -9, 	   1,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -1,   -5, 	  -1,  -11
+.2byte   -4,   -5, 	  -5,  -16, 	  -1,   -5, 	  -1,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -12, 	   6,  -12, 	   0,  -10
+.2byte   -1,   -5, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    3,   -6, 	   6,  -13, 	  -5,   -9, 	   1,  -11
+.2byte    4,   -5, 	   6,  -14, 	  -4,  -10, 	   1,  -11
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   0,   -5, 	   0,  -11
+.2byte    3,   -5, 	   4,  -16, 	   0,   -5, 	   0,  -12
+.2byte    5,   -7, 	   2,  -17, 	   0,   -7, 	   0,  -11
+.2byte    5,   -7, 	   2,  -18, 	   0,   -7, 	   0,  -11
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    4,   -9, 	  -2,  -17, 	   5,   -9, 	  -1,  -12
+.2byte    5,   -9, 	  -2,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    7,  -11, 	  -2,  -18, 	   4,   -9, 	   0,  -12
+.2byte    6,  -12, 	  -3,  -18, 	   4,   -9, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,  -13
+.2byte   -1,  -20, 	   5,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -5,   -9, 	   1,  -17, 	  -6,   -9, 	   0,  -12
+.2byte   -6,   -9, 	   1,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -8,  -11, 	   1,  -18, 	  -5,   -9, 	  -1,  -12
+.2byte   -7,  -12, 	   2,  -18, 	  -5,   -9, 	   0,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -1,   -5, 	  -1,  -11
+.2byte   -4,   -5, 	  -5,  -16, 	  -1,   -5, 	  -1,  -12
+.2byte   -6,   -7, 	  -3,  -17, 	  -1,   -7, 	  -1,  -11
+.2byte   -6,   -7, 	  -3,  -18, 	  -1,   -7, 	  -1,  -11
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -4,   -6, 	  -7,  -13, 	   4,   -9, 	  -2,  -11
+.2byte   -5,   -5, 	  -7,  -14, 	   3,  -10, 	  -2,  -11
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -12, 	   6,  -12, 	   0,  -10
+.2byte   -1,   -4, 	  -7,  -12, 	   6,  -12, 	   0,  -11
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    3,   -6, 	   6,  -13, 	  -5,   -9, 	   1,  -11
+.2byte    4,   -4, 	   6,  -13, 	  -4,   -9, 	   1,  -10
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   0,   -5, 	   0,  -11
+.2byte    3,   -5, 	   4,  -16, 	   0,   -5, 	   0,  -12
+.2byte    5,   -7, 	   2,  -17, 	   0,   -7, 	   0,  -11
+.2byte    5,   -6, 	   2,  -17, 	   0,   -6, 	   0,  -10
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    4,   -9, 	  -2,  -17, 	   5,   -9, 	  -1,  -12
+.2byte    5,   -9, 	  -2,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    7,  -11, 	  -2,  -18, 	   4,   -9, 	   0,  -12
+.2byte    6,  -11, 	  -3,  -17, 	   4,   -8, 	  -1,  -11
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,  -13
+.2byte   -1,  -21, 	   5,  -13, 	  -6,  -13, 	  -1,  -13
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -5,   -9, 	   1,  -17, 	  -6,   -9, 	   0,  -12
+.2byte   -6,   -9, 	   1,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -8,  -11, 	   1,  -18, 	  -5,   -9, 	  -1,  -12
+.2byte   -7,  -11, 	   2,  -17, 	  -5,   -8, 	   0,  -11
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -1,   -5, 	  -1,  -11
+.2byte   -4,   -5, 	  -5,  -16, 	  -1,   -5, 	  -1,  -12
+.2byte   -6,   -7, 	  -3,  -17, 	  -1,   -7, 	  -1,  -11
+.2byte   -6,   -6, 	  -3,  -17, 	  -1,   -6, 	  -1,  -10
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -4,   -6, 	  -7,  -13, 	   4,   -9, 	  -2,  -11
+.2byte   -5,   -4, 	  -7,  -13, 	   3,   -9, 	  -2,  -10
+.2byte    0,   -5, 	  -7,  -12, 	   6,  -12, 	  -1,  -12
+.2byte    0,   -5, 	  -7,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,   -9, 	  -6,  -12, 	   5,  -12, 	   0,  -14
+.2byte    0,  -10, 	   3,  -15, 	  -7,   -9, 	  -1,  -14
+.2byte    1,   -8, 	   1,  -18, 	  -3,   -8, 	  -3,  -13
+.2byte    4,  -12, 	  -5,  -17, 	   3,   -9, 	  -2,  -12
+.2byte    0,  -18, 	   6,  -12, 	  -6,  -12, 	   0,  -11
+.2byte   -5,  -12, 	   4,  -17, 	  -4,   -9, 	   1,  -12
+.2byte   -2,   -8, 	  -2,  -18, 	   2,   -8, 	   2,  -13
+.2byte   -1,  -10, 	  -4,  -15, 	   6,   -9, 	   0,  -14
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   0,   -5, 	   0,  -11
+.2byte    3,   -5, 	   4,  -16, 	   0,   -5, 	   0,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    4,   -9, 	  -2,  -17, 	   5,   -9, 	  -1,  -12
+.2byte    5,   -9, 	  -2,  -16, 	   4,   -9, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -5,   -9, 	   1,  -17, 	  -6,   -9, 	   0,  -12
+.2byte   -6,   -9, 	   1,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -1,   -5, 	  -1,  -11
+.2byte   -4,   -5, 	  -5,  -16, 	  -1,   -5, 	  -1,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    0,   -6, 	  -7,  -12, 	   6,  -12, 	   0,  -13
+.2byte   -4,   -6, 	  -7,  -13, 	   1,   -7, 	  -2,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -6, 	   6,  -13, 	  -2,   -7, 	   1,  -12
+.2byte   -1,   -5, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte    4,   -5, 	   6,  -14, 	  -4,  -10, 	   1,  -11
+.2byte    5,   -7, 	   2,  -18, 	   0,   -7, 	   0,  -11
+.2byte    6,  -12, 	  -3,  -18, 	   4,   -9, 	  -1,  -12
+.2byte   -1,  -20, 	   5,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -7,  -12, 	   2,  -18, 	  -5,   -9, 	   0,  -12
+.2byte   -6,   -7, 	  -3,  -18, 	  -1,   -7, 	  -1,  -11
+.2byte   -5,   -5, 	  -7,  -14, 	   3,  -10, 	  -2,  -11
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -12
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -11, 	   6,  -11, 	   0,  -13
+.2byte    0,   -5, 	  -7,  -12, 	   6,  -12, 	   0,  -10
+.2byte   -1,   -5, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte    3,   -5, 	   6,  -12, 	  -2,   -6, 	   1,  -11
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    1,   -4, 	   6,  -11, 	  -3,   -6, 	   1,  -12
+.2byte    3,   -6, 	   6,  -13, 	  -5,   -9, 	   1,  -11
+.2byte    4,   -5, 	   6,  -14, 	  -4,  -10, 	   1,  -11
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   0,   -5, 	   0,  -11
+.2byte    3,   -5, 	   4,  -16, 	   0,   -5, 	   0,  -12
+.2byte    5,   -7, 	   2,  -17, 	   0,   -7, 	   0,  -11
+.2byte    5,   -7, 	   2,  -18, 	   0,   -7, 	   0,  -11
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    4,   -9, 	  -2,  -17, 	   5,   -9, 	  -1,  -12
+.2byte    5,   -9, 	  -2,  -16, 	   4,   -9, 	  -1,  -12
+.2byte    7,  -11, 	  -2,  -18, 	   4,   -9, 	   0,  -12
+.2byte    6,  -12, 	  -3,  -18, 	   4,   -9, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte    0,  -16, 	   6,  -13, 	  -6,  -13, 	   0,  -12
+.2byte   -1,  -21, 	   5,  -13, 	  -7,  -13, 	  -1,  -13
+.2byte   -1,  -20, 	   5,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -5,   -9, 	   1,  -17, 	  -6,   -9, 	   0,  -12
+.2byte   -6,   -9, 	   1,  -16, 	  -5,   -9, 	   0,  -12
+.2byte   -8,  -11, 	   1,  -18, 	  -5,   -9, 	  -1,  -12
+.2byte   -7,  -12, 	   2,  -18, 	  -5,   -9, 	   0,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -1,   -5, 	  -1,  -11
+.2byte   -4,   -5, 	  -5,  -16, 	  -1,   -5, 	  -1,  -12
+.2byte   -6,   -7, 	  -3,  -17, 	  -1,   -7, 	  -1,  -11
+.2byte   -6,   -7, 	  -3,  -18, 	  -1,   -7, 	  -1,  -11
+.2byte   -4,   -5, 	  -7,  -12, 	   1,   -6, 	  -2,  -11
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -2,   -4, 	  -7,  -11, 	   2,   -6, 	  -2,  -12
+.2byte   -4,   -6, 	  -7,  -13, 	   4,   -9, 	  -2,  -11
+.2byte   -5,   -5, 	  -7,  -14, 	   3,  -10, 	  -2,  -11
+.2byte   -1,   -5, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte   -5,   -5, 	  -7,  -14, 	   3,  -10, 	  -2,  -11
+.2byte   -6,   -7, 	  -3,  -18, 	  -1,   -7, 	  -1,  -11
+.2byte   -7,  -12, 	   2,  -18, 	  -5,   -9, 	   0,  -12
+.2byte   -1,  -20, 	   5,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte    6,  -12, 	  -3,  -18, 	   4,   -9, 	  -1,  -12
+.2byte    5,   -7, 	   2,  -18, 	   0,   -7, 	   0,  -11
+.2byte    4,   -5, 	   6,  -14, 	  -4,  -10, 	   1,  -11
+.2byte    0,   -6, 	  -7,  -12, 	   6,  -12, 	   0,  -13
+.2byte   -4,   -6, 	  -7,  -13, 	   1,   -7, 	  -2,  -12
+.2byte   -4,   -5, 	  -5,  -15, 	  -2,   -6, 	  -1,  -12
+.2byte   -6,  -10, 	   1,  -17, 	  -6,   -8, 	  -1,  -12
+.2byte   -1,  -16, 	   5,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte    5,  -10, 	  -2,  -17, 	   5,   -8, 	   0,  -12
+.2byte    3,   -5, 	   4,  -15, 	   1,   -6, 	   0,  -12
+.2byte    3,   -6, 	   6,  -13, 	  -2,   -7, 	   1,  -12
+sGastlyAnimTable1:
+.4byte sGastlyAnims_1_1
+.4byte sGastlyAnims_1_2
+.4byte sGastlyAnims_1_3
+.4byte sGastlyAnims_1_4
+.4byte sGastlyAnims_1_5
+.4byte sGastlyAnims_1_6
+.4byte sGastlyAnims_1_7
+.4byte sGastlyAnims_1_8
+sGastlyAnimTable2:
+.4byte sGastlyAnims_2_1
+.4byte sGastlyAnims_2_2
+.4byte sGastlyAnims_2_3
+.4byte sGastlyAnims_2_4
+.4byte sGastlyAnims_2_5
+.4byte sGastlyAnims_2_6
+.4byte sGastlyAnims_2_7
+.4byte sGastlyAnims_2_8
+sGastlyAnimTable3:
+.4byte sGastlyAnims_3_1
+.4byte sGastlyAnims_3_2
+.4byte sGastlyAnims_3_3
+.4byte sGastlyAnims_3_4
+.4byte sGastlyAnims_3_5
+.4byte sGastlyAnims_3_6
+.4byte sGastlyAnims_3_7
+.4byte sGastlyAnims_3_8
+sGastlyAnimTable4:
+.4byte sGastlyAnims_4_1
+.4byte sGastlyAnims_4_2
+.4byte sGastlyAnims_4_3
+.4byte sGastlyAnims_4_4
+.4byte sGastlyAnims_4_5
+.4byte sGastlyAnims_4_6
+.4byte sGastlyAnims_4_7
+.4byte sGastlyAnims_4_8
+sGastlyAnimTable5:
+.4byte sGastlyAnims_5_1
+.4byte sGastlyAnims_5_2
+.4byte sGastlyAnims_5_3
+.4byte sGastlyAnims_5_4
+.4byte sGastlyAnims_5_5
+.4byte sGastlyAnims_5_6
+.4byte sGastlyAnims_5_7
+.4byte sGastlyAnims_5_8
+sGastlyAnimTable6:
+.4byte sGastlyAnims_6_1
+.4byte sGastlyAnims_6_1
+.4byte sGastlyAnims_6_1
+.4byte sGastlyAnims_6_1
+.4byte sGastlyAnims_6_1
+.4byte sGastlyAnims_6_1
+.4byte sGastlyAnims_6_1
+.4byte sGastlyAnims_6_1
+sGastlyAnimTable7:
+.4byte sGastlyAnims_7_1
+.4byte sGastlyAnims_7_2
+.4byte sGastlyAnims_7_3
+.4byte sGastlyAnims_7_4
+.4byte sGastlyAnims_7_5
+.4byte sGastlyAnims_7_6
+.4byte sGastlyAnims_7_7
+.4byte sGastlyAnims_7_8
+sGastlyAnimTable8:
+.4byte sGastlyAnims_8_1
+.4byte sGastlyAnims_8_2
+.4byte sGastlyAnims_8_3
+.4byte sGastlyAnims_8_4
+.4byte sGastlyAnims_8_5
+.4byte sGastlyAnims_8_6
+.4byte sGastlyAnims_8_7
+.4byte sGastlyAnims_8_8
+sGastlyAnimTable9:
+.4byte sGastlyAnims_9_1
+.4byte sGastlyAnims_9_2
+.4byte sGastlyAnims_9_3
+.4byte sGastlyAnims_9_4
+.4byte sGastlyAnims_9_5
+.4byte sGastlyAnims_9_6
+.4byte sGastlyAnims_9_7
+.4byte sGastlyAnims_9_8
+sGastlyAnimTable10:
+.4byte sGastlyAnims_10_1
+.4byte sGastlyAnims_10_2
+.4byte sGastlyAnims_10_3
+.4byte sGastlyAnims_10_4
+.4byte sGastlyAnims_10_5
+.4byte sGastlyAnims_10_6
+.4byte sGastlyAnims_10_7
+.4byte sGastlyAnims_10_8
+sGastlyAnimTable11:
+.4byte sGastlyAnims_11_1
+.4byte sGastlyAnims_11_2
+.4byte sGastlyAnims_11_3
+.4byte sGastlyAnims_11_4
+.4byte sGastlyAnims_11_5
+.4byte sGastlyAnims_11_6
+.4byte sGastlyAnims_11_7
+.4byte sGastlyAnims_11_8
+sGastlyAnimTable12:
+.4byte sGastlyAnims_12_1
+.4byte sGastlyAnims_12_2
+.4byte sGastlyAnims_12_3
+.4byte sGastlyAnims_12_4
+.4byte sGastlyAnims_12_5
+.4byte sGastlyAnims_12_6
+.4byte sGastlyAnims_12_7
+.4byte sGastlyAnims_12_8
+sGastlyAnimTable13:
+.4byte sGastlyAnims_13_1
+.4byte sGastlyAnims_13_2
+.4byte sGastlyAnims_13_3
+.4byte sGastlyAnims_13_4
+.4byte sGastlyAnims_13_5
+.4byte sGastlyAnims_13_6
+.4byte sGastlyAnims_13_7
+.4byte sGastlyAnims_13_8
+sAxAnimationsGastly:
+.4byte sGastlyAnimTable1
+.4byte sGastlyAnimTable2
+.4byte sGastlyAnimTable3
+.4byte sGastlyAnimTable4
+.4byte sGastlyAnimTable5
+.4byte sGastlyAnimTable6
+.4byte sGastlyAnimTable7
+.4byte sGastlyAnimTable8
+.4byte sGastlyAnimTable9
+.4byte sGastlyAnimTable10
+.4byte sGastlyAnimTable11
+.4byte sGastlyAnimTable12
+.4byte sGastlyAnimTable13
+sAxSpritesGastly:
+.4byte sGastlySprites1
+.4byte sGastlySprites2
+.4byte sGastlySprites3
+.4byte sGastlySprites4
+.4byte sGastlySprites5
+.4byte sGastlySprites6
+.4byte sGastlySprites7
+.4byte sGastlySprites8
+.4byte sGastlySprites9
+.4byte sGastlySprites10
+.4byte sGastlySprites11
+.4byte sGastlySprites12
+.4byte sGastlySprites13
+.4byte sGastlySprites14
+.4byte sGastlySprites15
+.4byte sGastlySprites16
+.4byte sGastlySprites17
+.4byte sGastlySprites18
+.4byte sGastlySprites19
+.4byte sGastlySprites20
+.4byte sGastlySprites21
+.4byte sGastlySprites22
+.4byte sGastlySprites23
+.4byte sGastlySprites24
+.4byte sGastlySprites25
+.4byte sGastlySprites26
+.4byte sGastlySprites27
+.4byte sGastlySprites28
+.4byte sGastlySprites29
+.4byte sGastlySprites30
+.4byte sGastlySprites31
+.4byte sGastlySprites32
+sAxMainGastly:
+ax_main sAxPosesGastly, sAxAnimationsGastly, 13, sAxSpritesGastly, sAxPositionsGastly

--- a/data/ax/gengar.inc
+++ b/data/ax/gengar.inc
@@ -1,0 +1,3003 @@
+.global gAxGengar
+gAxGengar:
+ax_siro sAxMainGengar
+sGengarPose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose3:
+ax_pose 2, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose4:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose5:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose6:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose7:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose8:
+ax_pose 7, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose9:
+ax_pose 8, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose10:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose12:
+ax_pose 11, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose14:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose15:
+ax_pose 14, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose25:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose26:
+ax_pose 1, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose27:
+ax_pose 2, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose28:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose29:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose30:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose31:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose32:
+ax_pose 7, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose33:
+ax_pose 8, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose34:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose35:
+ax_pose 10, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose36:
+ax_pose 11, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose37:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose38:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose39:
+ax_pose 14, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose40:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose41:
+ax_pose 10, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose42:
+ax_pose 11, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose43:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose44:
+ax_pose 7, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose45:
+ax_pose 8, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose46:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose47:
+ax_pose 4, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose48:
+ax_pose 5, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose49:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose50:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose51:
+ax_pose 16, 0x81eb, 0x80f5, 0x2c00
+ax_pose 17, 0x01eb, 0x80f6, 0x2c08
+ax_pose_terminator
+sGengarPose52:
+ax_pose 17, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sGengarPose53:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose54:
+ax_pose 18, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose55:
+ax_pose 19, 0x81e8, 0x9105, 0x2c00
+ax_pose 20, 0x01ee, 0x90f4, 0x2c08
+ax_pose_terminator
+sGengarPose56:
+ax_pose 20, 0x01ee, 0x90f4, 0x2c00
+ax_pose_terminator
+sGengarPose57:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose58:
+ax_pose 21, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sGengarPose59:
+ax_pose 22, 0x01e9, 0x90fa, 0x2c00
+ax_pose 23, 0x81e4, 0x90f5, 0x2c10
+ax_pose 24, 0x81e4, 0x5105, 0x2c18
+ax_pose 25, 0x01f4, 0x110d, 0x2c1c
+ax_pose 26, 0x01f4, 0x1115, 0x2c1d
+ax_pose_terminator
+sGengarPose60:
+ax_pose 23, 0x81e4, 0x90f5, 0x2c00
+ax_pose 24, 0x81e4, 0x5105, 0x2c08
+ax_pose 25, 0x01f4, 0x110d, 0x2c0c
+ax_pose 26, 0x01f4, 0x1115, 0x2c0d
+ax_pose_terminator
+sGengarPose61:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose62:
+ax_pose 27, 0x01e6, 0x90ea, 0x2c00
+ax_pose_terminator
+sGengarPose63:
+ax_pose 28, 0x41e4, 0x90f1, 0x2c00
+ax_pose 29, 0x01e5, 0x90f3, 0x2c08
+ax_pose_terminator
+sGengarPose64:
+ax_pose 29, 0x01e5, 0x90f3, 0x2c00
+ax_pose_terminator
+sGengarPose65:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose66:
+ax_pose 30, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose67:
+ax_pose 31, 0x81e3, 0x80fe, 0x2c00
+ax_pose 32, 0x01e4, 0x80f2, 0x2c08
+ax_pose_terminator
+sGengarPose68:
+ax_pose 32, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose69:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose70:
+ax_pose 27, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sGengarPose71:
+ax_pose 28, 0x41e4, 0x80ee, 0x2c00
+ax_pose 29, 0x01e5, 0x80ec, 0x2c08
+ax_pose_terminator
+sGengarPose72:
+ax_pose 29, 0x01e5, 0x80ec, 0x2c00
+ax_pose_terminator
+sGengarPose73:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose74:
+ax_pose 21, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sGengarPose75:
+ax_pose 22, 0x01e9, 0x80e5, 0x2c00
+ax_pose 23, 0x81e4, 0x80fa, 0x2c10
+ax_pose 24, 0x81e4, 0x40f2, 0x2c18
+ax_pose 25, 0x01f4, 0x00ea, 0x2c1c
+ax_pose 26, 0x01f4, 0x00e2, 0x2c1d
+ax_pose_terminator
+sGengarPose76:
+ax_pose 23, 0x81e4, 0x80fa, 0x2c00
+ax_pose 24, 0x81e4, 0x40f2, 0x2c08
+ax_pose 25, 0x01f4, 0x00ea, 0x2c0c
+ax_pose 26, 0x01f4, 0x00e2, 0x2c0d
+ax_pose_terminator
+sGengarPose77:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose78:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose79:
+ax_pose 19, 0x81e8, 0x80ec, 0x2c00
+ax_pose 20, 0x01ee, 0x80ed, 0x2c08
+ax_pose_terminator
+sGengarPose80:
+ax_pose 20, 0x01ee, 0x80ed, 0x2c00
+ax_pose_terminator
+sGengarPose81:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose82:
+ax_pose 33, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose83:
+ax_pose 34, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose84:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose85:
+ax_pose 35, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose86:
+ax_pose 36, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose87:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose88:
+ax_pose 37, 0x01eb, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose89:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose90:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose91:
+ax_pose 39, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose92:
+ax_pose 40, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose93:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose94:
+ax_pose 41, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose95:
+ax_pose 42, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose96:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose97:
+ax_pose 39, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose98:
+ax_pose 40, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose99:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose100:
+ax_pose 37, 0x01eb, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose101:
+ax_pose 38, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose102:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose103:
+ax_pose 35, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose104:
+ax_pose 36, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose105:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose106:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose107:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose108:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose109:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose110:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose111:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose112:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose113:
+ax_pose 43, 0x01e9, 0x80f5, 0x2c00
+ax_pose_terminator
+sGengarPose114:
+ax_pose 44, 0x01e9, 0x80f5, 0x2c00
+ax_pose_terminator
+sGengarPose115:
+ax_pose 45, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose116:
+ax_pose 46, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sGengarPose117:
+ax_pose 47, 0x01e6, 0x90e9, 0x2c00
+ax_pose_terminator
+sGengarPose118:
+ax_pose 48, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose119:
+ax_pose 49, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose120:
+ax_pose 48, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sGengarPose121:
+ax_pose 47, 0x01e6, 0x80f7, 0x2c00
+ax_pose_terminator
+sGengarPose122:
+ax_pose 46, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose123:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose124:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose125:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose126:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose127:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose128:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose129:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose130:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose131:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose132:
+ax_pose 33, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose133:
+ax_pose 34, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose134:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose135:
+ax_pose 35, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose136:
+ax_pose 36, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose137:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose138:
+ax_pose 37, 0x01eb, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose139:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose140:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose141:
+ax_pose 39, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose142:
+ax_pose 40, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose143:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose144:
+ax_pose 41, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose145:
+ax_pose 42, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose146:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose147:
+ax_pose 39, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose148:
+ax_pose 40, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose149:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose150:
+ax_pose 37, 0x01eb, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose151:
+ax_pose 38, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose152:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose153:
+ax_pose 35, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose154:
+ax_pose 36, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose155:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose156:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose157:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose158:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose159:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose160:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose161:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose162:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose163:
+ax_pose 34, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose164:
+ax_pose 36, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose165:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose166:
+ax_pose 40, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose167:
+ax_pose 42, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose168:
+ax_pose 40, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose169:
+ax_pose 38, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose170:
+ax_pose 36, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose171:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose172:
+ax_pose 33, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose173:
+ax_pose 34, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose174:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose175:
+ax_pose 35, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose176:
+ax_pose 36, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose177:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose178:
+ax_pose 37, 0x01eb, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose179:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose180:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose181:
+ax_pose 39, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose182:
+ax_pose 40, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose183:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose184:
+ax_pose 41, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose185:
+ax_pose 42, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose186:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose187:
+ax_pose 39, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose188:
+ax_pose 40, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose189:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose190:
+ax_pose 37, 0x01eb, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose191:
+ax_pose 38, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose192:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose193:
+ax_pose 35, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose194:
+ax_pose 36, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose195:
+ax_pose 34, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose196:
+ax_pose 36, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sGengarPose197:
+ax_pose 38, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sGengarPose198:
+ax_pose 40, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sGengarPose199:
+ax_pose 42, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose200:
+ax_pose 40, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sGengarPose201:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sGengarPose202:
+ax_pose 36, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sGengarPose203:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose204:
+ax_pose 3, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose205:
+ax_pose 6, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sGengarPose206:
+ax_pose 9, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose207:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose208:
+ax_pose 9, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose209:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose210:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sGengarPose211:
+ax_pose 50, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose212:
+ax_pose 51, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose213:
+ax_pose 52, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose214:
+ax_pose 6, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose215:
+ax_pose 7, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose216:
+ax_pose 8, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sGengarPose217:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose218:
+ax_pose 33, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sGengarPose219:
+ax_pose 34, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+.align 2
+sGengarAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGengarAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sGengarAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sGengarAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 19, -20, 19, -20,
+ax_anim 2, 1, 34, 20, -19, 20, -19,
+ax_anim 2, 0, 34, 19, -20, 19, -20,
+ax_anim 2, 0, 34, 20, -19, 20, -19,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sGengarAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 1, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 0, 37, 1, -19, 1, -19,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sGengarAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, 0, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -19, -20, -19, -20,
+ax_anim 2, 1, 40, -20, -19, -20, -19,
+ax_anim 2, 0, 40, -19, -20, -19, -20,
+ax_anim 2, 0, 40, -20, -19, -20, -19,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sGengarAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sGengarAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGengarAnims_3_1:
+ax_anim 2, 0, 76, 0, -1, 0, -1,
+ax_anim 2, 0, 48, 0, -3, 0, -3,
+ax_anim 4, 0, 49, 0, -4, 0, -4,
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 2, 2, 50, 0, 4, 0, 4,
+ax_anim 2, 0, 50, 0, 12, 0, 12,
+ax_anim 2, 1, 51, 1, 12, 1, 12,
+ax_anim 2, 0, 51, 0, 12, 0, 12,
+ax_anim 2, 0, 51, 1, 12, 1, 12,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sGengarAnims_3_2:
+ax_anim 2, 0, 56, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -3, -3, -3, -3,
+ax_anim 4, 0, 53, -4, -4, -4, -4,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 2, 2, 54, 4, 4, 4, 4,
+ax_anim 2, 0, 54, 12, 12, 12, 12,
+ax_anim 2, 1, 55, 11, 13, 11, 13,
+ax_anim 2, 0, 55, 12, 12, 12, 12,
+ax_anim 2, 0, 55, 11, 13, 11, 13,
+ax_anim 4, 0, 52, 6, 6, 6, 6,
+ax_anim_terminator
+sGengarAnims_3_3:
+ax_anim 2, 0, 60, -1, 0, -1, 0,
+ax_anim 2, 0, 57, -3, 0, -3, 0,
+ax_anim 4, 0, 57, -4, 0, -4, 0,
+ax_anim 2, 0, 57, -3, 0, -3, 0,
+ax_anim 2, 2, 58, 2, 0, 2, 0,
+ax_anim 2, 0, 58, 5, 0, 5, 0,
+ax_anim 2, 1, 59, 5, 1, 5, 1,
+ax_anim 2, 0, 59, 5, 0, 5, 0,
+ax_anim 2, 0, 59, 5, 1, 5, 1,
+ax_anim 4, 0, 56, 3, 0, 3, 0,
+ax_anim_terminator
+sGengarAnims_3_4:
+ax_anim 2, 0, 64, -1, 1, -1, 1,
+ax_anim 2, 0, 61, -3, 3, -3, 3,
+ax_anim 4, 0, 61, -4, 4, -4, 4,
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 2, 2, 62, 4, -4, 4, -4,
+ax_anim 2, 0, 62, 12, -12, 12, -12,
+ax_anim 2, 1, 63, 11, -13, 11, -13,
+ax_anim 2, 0, 63, 12, -12, 12, -12,
+ax_anim 2, 0, 63, 11, -13, 11, -13,
+ax_anim 4, 0, 60, 6, -6, 6, -6,
+ax_anim_terminator
+sGengarAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 4, 0, 65, 0, 4, 0, 4,
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 2, 2, 66, 0, -4, 0, -4,
+ax_anim 2, 0, 66, 0, -11, 0, -11,
+ax_anim 2, 1, 67, 1, -11, 1, -11,
+ax_anim 2, 0, 67, 0, -11, 0, -11,
+ax_anim 2, 0, 67, 1, -11, 1, -11,
+ax_anim 4, 0, 64, 0, -6, 0, -6,
+ax_anim_terminator
+sGengarAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 3, 3, 3, 3,
+ax_anim 4, 0, 69, 4, 4, 4, 4,
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 2, 2, 70, -4, -4, -4, -4,
+ax_anim 2, 0, 70, -12, -12, -12, -12,
+ax_anim 2, 1, 71, -11, -13, -11, -13,
+ax_anim 2, 0, 71, -12, -12, -12, -12,
+ax_anim 2, 0, 71, -11, -13, -11, -13,
+ax_anim 4, 0, 68, -6, -6, -6, -6,
+ax_anim_terminator
+sGengarAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 3, 0, 3, 0,
+ax_anim 4, 0, 73, 4, 0, 4, 0,
+ax_anim 2, 0, 73, 3, 0, 3, 0,
+ax_anim 2, 2, 74, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -5, 0, -5, 0,
+ax_anim 2, 1, 75, -5, 1, -5, 1,
+ax_anim 2, 0, 75, -5, 0, -5, 0,
+ax_anim 2, 0, 75, -5, 1, -5, 1,
+ax_anim 4, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sGengarAnims_3_8:
+ax_anim 2, 0, 72, 1, -1, 1, -1,
+ax_anim 2, 0, 77, 3, -3, 3, -3,
+ax_anim 4, 0, 77, 4, -4, 4, -4,
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 2, 2, 78, -4, 4, -4, 4,
+ax_anim 2, 0, 78, -12, 12, -12, 12,
+ax_anim 2, 1, 79, -11, 13, -11, 13,
+ax_anim 2, 0, 79, -12, 12, -12, 12,
+ax_anim 2, 0, 79, -11, 13, -11, 13,
+ax_anim 4, 0, 76, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGengarAnims_4_1:
+ax_anim 2, 0, 80, 0, -2, 0, -3,
+ax_anim 4, 0, 80, 0, -3, 0, -3,
+ax_anim 1, 0, 80, 0, 2, 0, 2,
+ax_anim 1, 0, 80, 0, 6, 0, 6,
+ax_anim 10, 0, 80, 0, 12, 0, 12,
+ax_anim 2, 0, 81, 0, 12, 0, 12,
+ax_anim 2, 2, 82, 1, 12, 1, 12,
+ax_anim 2, 0, 82, 0, 12, 0, 12,
+ax_anim 2, 0, 82, 1, 12, 1, 12,
+ax_anim 2, 0, 82, 0, 12, 0, 12,
+ax_anim 2, 1, 82, 1, 12, 1, 12,
+ax_anim 2, 0, 81, 0, 8, 0, 8,
+ax_anim_terminator
+sGengarAnims_4_2:
+ax_anim 2, 0, 83, -2, -2, -3, -3,
+ax_anim 4, 0, 83, -3, -3, -3, -3,
+ax_anim 1, 0, 83, 2, 2, 2, 2,
+ax_anim 1, 0, 83, 6, 6, 6, 6,
+ax_anim 10, 0, 83, 12, 12, 12, 12,
+ax_anim 2, 0, 84, 12, 12, 12, 12,
+ax_anim 2, 2, 85, 13, 11, 13, 11,
+ax_anim 2, 0, 85, 12, 12, 12, 12,
+ax_anim 2, 0, 85, 13, 11, 13, 11,
+ax_anim 2, 0, 85, 12, 12, 12, 12,
+ax_anim 2, 1, 85, 13, 11, 13, 11,
+ax_anim 2, 0, 84, 8, 8, 8, 8,
+ax_anim_terminator
+sGengarAnims_4_3:
+ax_anim 2, 0, 86, -2, 0, -3, 0,
+ax_anim 4, 0, 86, -3, 0, -3, 0,
+ax_anim 1, 0, 86, 2, 0, 2, 0,
+ax_anim 1, 0, 86, 6, 0, 6, 0,
+ax_anim 10, 0, 86, 12, 0, 12, 0,
+ax_anim 2, 0, 87, 12, 0, 12, 0,
+ax_anim 2, 2, 88, 13, 0, 13, 0,
+ax_anim 2, 0, 88, 12, 0, 12, 0,
+ax_anim 2, 0, 88, 13, 0, 13, 0,
+ax_anim 2, 0, 88, 12, 0, 12, 0,
+ax_anim 2, 1, 88, 13, 0, 13, 0,
+ax_anim 2, 0, 87, 8, 0, 8, 0,
+ax_anim_terminator
+sGengarAnims_4_4:
+ax_anim 2, 0, 89, -2, 2, -3, 3,
+ax_anim 4, 0, 89, -3, 3, -3, 3,
+ax_anim 1, 0, 89, 2, -2, 2, -2,
+ax_anim 1, 0, 89, 6, -6, 6, -6,
+ax_anim 10, 0, 89, 12, -12, 12, -12,
+ax_anim 2, 0, 90, 12, -12, 12, -12,
+ax_anim 2, 2, 91, 13, -11, 13, -11,
+ax_anim 2, 0, 91, 12, -12, 12, -12,
+ax_anim 2, 0, 91, 13, -11, 13, -11,
+ax_anim 2, 0, 91, 12, -12, 12, -12,
+ax_anim 2, 1, 91, 13, -11, 13, -11,
+ax_anim 2, 0, 90, 8, -8, 8, -8,
+ax_anim_terminator
+sGengarAnims_4_5:
+ax_anim 2, 0, 92, 0, 2, 0, 3,
+ax_anim 4, 0, 92, 0, 3, 0, 3,
+ax_anim 1, 0, 92, 0, -2, 0, -2,
+ax_anim 1, 0, 92, 0, -6, 0, -6,
+ax_anim 10, 0, 92, 0, -12, 0, -12,
+ax_anim 2, 0, 93, 0, -12, 0, -12,
+ax_anim 2, 2, 94, 1, -12, 1, -12,
+ax_anim 2, 0, 94, 0, -12, 0, -12,
+ax_anim 2, 0, 94, 1, -12, 1, -12,
+ax_anim 2, 0, 94, 0, -12, 0, -12,
+ax_anim 2, 1, 94, 1, -12, 1, -12,
+ax_anim 2, 0, 93, 0, -8, 0, -8,
+ax_anim_terminator
+sGengarAnims_4_6:
+ax_anim 2, 0, 95, 2, 2, 3, 3,
+ax_anim 4, 0, 95, 3, 3, 3, 3,
+ax_anim 1, 0, 95, -2, -2, -2, -2,
+ax_anim 1, 0, 95, -6, -6, -6, -6,
+ax_anim 10, 0, 95, -12, -12, -12, -12,
+ax_anim 2, 0, 96, -12, -12, -12, -12,
+ax_anim 2, 2, 97, -13, -11, -13, -11,
+ax_anim 2, 0, 97, -12, -12, -12, -12,
+ax_anim 2, 0, 97, -13, -11, -13, -11,
+ax_anim 2, 0, 97, -12, -12, -12, -12,
+ax_anim 2, 1, 97, -13, -11, -13, -11,
+ax_anim 2, 0, 96, -8, -8, -8, -8,
+ax_anim_terminator
+sGengarAnims_4_7:
+ax_anim 2, 0, 98, 2, 0, 3, 0,
+ax_anim 4, 0, 98, 3, 0, 3, 0,
+ax_anim 1, 0, 98, -2, 0, -2, 0,
+ax_anim 1, 0, 98, -6, 0, -6, 0,
+ax_anim 10, 0, 98, -12, 0, -12, 0,
+ax_anim 2, 0, 99, -12, 0, -12, 0,
+ax_anim 2, 2, 100, -13, 0, -13, 0,
+ax_anim 2, 0, 100, -12, 0, -12, 0,
+ax_anim 2, 0, 100, -13, 0, -13, 0,
+ax_anim 2, 0, 100, -12, 0, -12, 0,
+ax_anim 2, 1, 100, -13, 0, -13, 0,
+ax_anim 2, 0, 99, -8, 0, -8, 0,
+ax_anim_terminator
+sGengarAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 3, -3,
+ax_anim 4, 0, 101, 3, -3, 3, -3,
+ax_anim 1, 0, 101, -2, 2, -2, 2,
+ax_anim 1, 0, 101, -6, 6, -6, 6,
+ax_anim 10, 0, 101, -12, 12, -12, 12,
+ax_anim 2, 0, 102, -12, 12, -12, 12,
+ax_anim 2, 2, 103, -13, 11, -13, 11,
+ax_anim 2, 0, 103, -12, 12, -12, 12,
+ax_anim 2, 0, 103, -13, 11, -13, 11,
+ax_anim 2, 0, 103, -12, 12, -12, 12,
+ax_anim 2, 1, 103, -13, 11, -13, 11,
+ax_anim 2, 0, 102, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGengarAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sGengarAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sGengarAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sGengarAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sGengarAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sGengarAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sGengarAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sGengarAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGengarAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 1, 0, 1, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 1, 0, 1, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 1, -1, 1, -1,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 1, -1, 1, -1,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, -1, 0, -1,
+ax_anim 3, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, -1, 0, -1,
+ax_anim 3, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 141, -1, -1, -1, -1,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 141, -1, -1, -1, -1,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 144, -1, 0, -1, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 144, -1, 0, -1, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 1, -1, 1, -1,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 1, -1, 1, -1,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, -1, 0, -1,
+ax_anim 3, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, -1, 0, -1,
+ax_anim 3, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 153, -1, -1, -1, -1,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 153, -1, -1, -1, -1,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 17, 7, 19,
+ax_anim 3, 0, 158, 0, 20, 0, 24,
+ax_anim 2, 3, 159, -7, 17, -7, 19,
+ax_anim 2, 0, 160, -8, 8, -8, 9,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 22, 9, 22, 9,
+ax_anim 3, 0, 157, 21, 19, 21, 19,
+ax_anim 2, 3, 158, 11, 20, 11, 20,
+ax_anim 2, 0, 159, 2, 12, 2, 12,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -4, 17, -4,
+ax_anim 3, 0, 156, 20, 1, 20, 1,
+ax_anim 2, 3, 157, 17, 5, 17, 5,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 11, -22, 11, -22,
+ax_anim 3, 0, 155, 18, -22, 18, -22,
+ax_anim 2, 3, 156, 18, -12, 18, -12,
+ax_anim 2, 0, 157, 16, -6, 16, -6,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -8, -10, -8, -10,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 8, -8, 8, -8,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -11, -22, -11, -22,
+ax_anim 3, 0, 161, -18, -22, -18, -22,
+ax_anim 2, 3, 160, -18, -12, -18, -12,
+ax_anim 2, 0, 159, -16, -6, -16, -6,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -4, -17, -4,
+ax_anim 3, 0, 160, -20, 1, -20, 1,
+ax_anim 2, 3, 159, -17, 5, -17, 5,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -22, 9, -22, 9,
+ax_anim 3, 0, 159, -21, 21, -21, 21,
+ax_anim 2, 3, 158, -11, 20, -11, 20,
+ax_anim 2, 0, 157, -2, 12, -2, 12,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -17, 0, 0,
+ax_anim 1, 0, 180, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -17, 0, 0,
+ax_anim 1, 0, 186, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_14_1:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_14_2:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_14_3:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_14_4:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_14_5:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_14_6:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_14_7:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarAnims_14_8:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 15, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_15_1:
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 214, -1, 0, 0, 0,
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 1, 0, 0, 0,
+ax_anim 16, 0, 215, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGengarAnims_16_1:
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, -1, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, -1, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGengarGfx1:
+.incbin "baserom.gba", 0x9001EC, 0x200
+sGengarSprites1:
+ax_sprite sGengarGfx1, 0x200
+ax_sprite_terminator
+sGengarGfx2:
+.incbin "baserom.gba", 0x9003FC, 0x200
+sGengarSprites2:
+ax_sprite sGengarGfx2, 0x200
+ax_sprite_terminator
+sGengarGfx3:
+.incbin "baserom.gba", 0x90060C, 0x200
+sGengarSprites3:
+ax_sprite sGengarGfx3, 0x200
+ax_sprite_terminator
+sGengarGfx4:
+.incbin "baserom.gba", 0x90081C, 0x200
+sGengarSprites4:
+ax_sprite sGengarGfx4, 0x200
+ax_sprite_terminator
+sGengarGfx5:
+.incbin "baserom.gba", 0x900A2C, 0x200
+sGengarSprites5:
+ax_sprite sGengarGfx5, 0x200
+ax_sprite_terminator
+sGengarGfx6:
+.incbin "baserom.gba", 0x900C3C, 0x200
+sGengarSprites6:
+ax_sprite sGengarGfx6, 0x200
+ax_sprite_terminator
+sGengarGfx7:
+.incbin "baserom.gba", 0x900E4C, 0x200
+sGengarSprites7:
+ax_sprite sGengarGfx7, 0x200
+ax_sprite_terminator
+sGengarGfx8:
+.incbin "baserom.gba", 0x90105C, 0x200
+sGengarSprites8:
+ax_sprite sGengarGfx8, 0x200
+ax_sprite_terminator
+sGengarGfx9:
+.incbin "baserom.gba", 0x90126C, 0x200
+sGengarSprites9:
+ax_sprite sGengarGfx9, 0x200
+ax_sprite_terminator
+sGengarGfx10:
+.incbin "baserom.gba", 0x90147C, 0x200
+sGengarSprites10:
+ax_sprite sGengarGfx10, 0x200
+ax_sprite_terminator
+sGengarGfx11:
+.incbin "baserom.gba", 0x90168C, 0x200
+sGengarSprites11:
+ax_sprite sGengarGfx11, 0x200
+ax_sprite_terminator
+sGengarGfx12:
+.incbin "baserom.gba", 0x90189C, 0x200
+sGengarSprites12:
+ax_sprite sGengarGfx12, 0x200
+ax_sprite_terminator
+sGengarGfx13:
+.incbin "baserom.gba", 0x901AAC, 0x200
+sGengarSprites13:
+ax_sprite sGengarGfx13, 0x200
+ax_sprite_terminator
+sGengarGfx14:
+.incbin "baserom.gba", 0x901CBC, 0x200
+sGengarSprites14:
+ax_sprite sGengarGfx14, 0x200
+ax_sprite_terminator
+sGengarGfx15:
+.incbin "baserom.gba", 0x901ECC, 0x200
+sGengarSprites15:
+ax_sprite sGengarGfx15, 0x200
+ax_sprite_terminator
+sGengarGfx16:
+.incbin "baserom.gba", 0x9020DC, 0x60
+sGengarGfx16_1:
+.incbin "baserom.gba", 0x90213C, 0x60
+sGengarGfx16_2:
+.incbin "baserom.gba", 0x90219C, 0x60
+sGengarSprites16:
+ax_sprite sGengarGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGengarGfx17:
+.incbin "baserom.gba", 0x902234, 0x20
+sGengarGfx17_1:
+.incbin "baserom.gba", 0x902254, 0xC0
+sGengarSprites17:
+ax_sprite sGengarGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx17_1, 0xc0
+ax_sprite_terminator
+sGengarGfx18:
+.incbin "baserom.gba", 0x902334, 0x60
+sGengarGfx18_1:
+.incbin "baserom.gba", 0x902394, 0x60
+sGengarGfx18_2:
+.incbin "baserom.gba", 0x9023F4, 0x60
+sGengarGfx18_3:
+.incbin "baserom.gba", 0x902454, 0x40
+sGengarSprites18:
+ax_sprite sGengarGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx18_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGengarGfx19:
+.incbin "baserom.gba", 0x9024DC, 0x40
+sGengarGfx19_1:
+.incbin "baserom.gba", 0x90251C, 0x60
+sGengarGfx19_2:
+.incbin "baserom.gba", 0x90257C, 0x60
+sGengarGfx19_3:
+.incbin "baserom.gba", 0x9025DC, 0x40
+sGengarSprites19:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGengarGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGengarGfx20:
+.incbin "baserom.gba", 0x90266C, 0xE0
+sGengarSprites20:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx20, 0xe0
+ax_sprite_terminator
+sGengarGfx21:
+.incbin "baserom.gba", 0x902764, 0x160
+sGengarSprites21:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx21, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGengarGfx22:
+.incbin "baserom.gba", 0x9028E4, 0x20
+sGengarGfx22_1:
+.incbin "baserom.gba", 0x902904, 0x60
+sGengarGfx22_2:
+.incbin "baserom.gba", 0x902964, 0x60
+sGengarGfx22_3:
+.incbin "baserom.gba", 0x9029C4, 0x60
+sGengarSprites22:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGengarGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGengarGfx23:
+.incbin "baserom.gba", 0x902A74, 0xA0
+sGengarGfx23_1:
+.incbin "baserom.gba", 0x902B14, 0x40
+sGengarSprites23:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx23, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGengarGfx23_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sGengarGfx24:
+.incbin "baserom.gba", 0x902B84, 0xC0
+sGengarSprites24:
+ax_sprite 0, 0x40
+ax_sprite sGengarGfx24, 0xc0
+ax_sprite_terminator
+sGengarGfx25:
+.incbin "baserom.gba", 0x902C5C, 0x60
+sGengarSprites25:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx25, 0x60
+ax_sprite_terminator
+sGengarGfx26:
+.incbin "baserom.gba", 0x902CD4, 0x20
+sGengarSprites26:
+ax_sprite sGengarGfx26, 0x20
+ax_sprite_terminator
+sGengarGfx27:
+.incbin "baserom.gba", 0x902D04, 0x20
+sGengarSprites27:
+ax_sprite sGengarGfx27, 0x20
+ax_sprite_terminator
+sGengarGfx28:
+.incbin "baserom.gba", 0x902D34, 0x20
+sGengarGfx28_1:
+.incbin "baserom.gba", 0x902D54, 0x60
+sGengarGfx28_2:
+.incbin "baserom.gba", 0x902DB4, 0x60
+sGengarGfx28_3:
+.incbin "baserom.gba", 0x902E14, 0x60
+sGengarSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGengarGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGengarGfx29:
+.incbin "baserom.gba", 0x902EC4, 0xA0
+sGengarGfx29_1:
+.incbin "baserom.gba", 0x902F64, 0x40
+sGengarSprites29:
+ax_sprite sGengarGfx29, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx29_1, 0x40
+ax_sprite_terminator
+sGengarGfx30:
+.incbin "baserom.gba", 0x902FC4, 0x40
+sGengarGfx30_1:
+.incbin "baserom.gba", 0x903004, 0x80
+sGengarGfx30_2:
+.incbin "baserom.gba", 0x903084, 0x60
+sGengarGfx30_3:
+.incbin "baserom.gba", 0x9030E4, 0x60
+sGengarSprites30:
+ax_sprite sGengarGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGengarGfx30_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx30_3, 0x60
+ax_sprite_terminator
+sGengarGfx31:
+.incbin "baserom.gba", 0x903184, 0x40
+sGengarGfx31_1:
+.incbin "baserom.gba", 0x9031C4, 0x60
+sGengarGfx31_2:
+.incbin "baserom.gba", 0x903224, 0x60
+sGengarSprites31:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGengarGfx32:
+.incbin "baserom.gba", 0x9032C4, 0x80
+sGengarGfx32_1:
+.incbin "baserom.gba", 0x903344, 0x20
+sGengarGfx32_2:
+.incbin "baserom.gba", 0x903364, 0x20
+sGengarSprites32:
+ax_sprite sGengarGfx32, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx32_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx32_2, 0x20
+ax_sprite_terminator
+sGengarGfx33:
+.incbin "baserom.gba", 0x9033B4, 0x40
+sGengarGfx33_1:
+.incbin "baserom.gba", 0x9033F4, 0x60
+sGengarGfx33_2:
+.incbin "baserom.gba", 0x903454, 0x60
+sGengarGfx33_3:
+.incbin "baserom.gba", 0x9034B4, 0x60
+sGengarSprites33:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx33_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGengarGfx34:
+.incbin "baserom.gba", 0x903564, 0x160
+sGengarSprites34:
+ax_sprite sGengarGfx34, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGengarGfx35:
+.incbin "baserom.gba", 0x9036DC, 0x180
+sGengarGfx35_1:
+.incbin "baserom.gba", 0x90385C, 0x40
+sGengarSprites35:
+ax_sprite sGengarGfx35, 0x180
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGengarGfx36:
+.incbin "baserom.gba", 0x9038C4, 0x60
+sGengarGfx36_1:
+.incbin "baserom.gba", 0x903924, 0x60
+sGengarGfx36_2:
+.incbin "baserom.gba", 0x903984, 0x60
+sGengarSprites36:
+ax_sprite sGengarGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGengarGfx37:
+.incbin "baserom.gba", 0x903A1C, 0x40
+sGengarGfx37_1:
+.incbin "baserom.gba", 0x903A5C, 0x60
+sGengarGfx37_2:
+.incbin "baserom.gba", 0x903ABC, 0x60
+sGengarGfx37_3:
+.incbin "baserom.gba", 0x903B1C, 0x60
+sGengarSprites37:
+ax_sprite sGengarGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGengarGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGengarGfx38:
+.incbin "baserom.gba", 0x903BC4, 0x40
+sGengarGfx38_1:
+.incbin "baserom.gba", 0x903C04, 0x100
+sGengarSprites38:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx38_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGengarGfx39:
+.incbin "baserom.gba", 0x903D34, 0x40
+sGengarGfx39_1:
+.incbin "baserom.gba", 0x903D74, 0x180
+sGengarSprites39:
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx39_1, 0x180
+ax_sprite_terminator
+sGengarGfx40:
+.incbin "baserom.gba", 0x903F1C, 0x60
+sGengarGfx40_1:
+.incbin "baserom.gba", 0x903F7C, 0x60
+sGengarGfx40_2:
+.incbin "baserom.gba", 0x903FDC, 0x60
+sGengarSprites40:
+ax_sprite sGengarGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGengarGfx41:
+.incbin "baserom.gba", 0x904074, 0x60
+sGengarGfx41_1:
+.incbin "baserom.gba", 0x9040D4, 0x60
+sGengarGfx41_2:
+.incbin "baserom.gba", 0x904134, 0x60
+sGengarSprites41:
+ax_sprite sGengarGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGengarGfx41_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGengarGfx42:
+.incbin "baserom.gba", 0x9041CC, 0x180
+sGengarSprites42:
+ax_sprite sGengarGfx42, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGengarGfx43:
+.incbin "baserom.gba", 0x904364, 0x180
+sGengarSprites43:
+ax_sprite sGengarGfx43, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGengarGfx44:
+.incbin "baserom.gba", 0x9044FC, 0x200
+sGengarSprites44:
+ax_sprite sGengarGfx44, 0x200
+ax_sprite_terminator
+sGengarGfx45:
+.incbin "baserom.gba", 0x90470C, 0x200
+sGengarSprites45:
+ax_sprite sGengarGfx45, 0x200
+ax_sprite_terminator
+sGengarGfx46:
+.incbin "baserom.gba", 0x90491C, 0x200
+sGengarSprites46:
+ax_sprite sGengarGfx46, 0x200
+ax_sprite_terminator
+sGengarGfx47:
+.incbin "baserom.gba", 0x904B2C, 0x200
+sGengarSprites47:
+ax_sprite sGengarGfx47, 0x200
+ax_sprite_terminator
+sGengarGfx48:
+.incbin "baserom.gba", 0x904D3C, 0x200
+sGengarSprites48:
+ax_sprite sGengarGfx48, 0x200
+ax_sprite_terminator
+sGengarGfx49:
+.incbin "baserom.gba", 0x904F4C, 0x200
+sGengarSprites49:
+ax_sprite sGengarGfx49, 0x200
+ax_sprite_terminator
+sGengarGfx50:
+.incbin "baserom.gba", 0x90515C, 0x200
+sGengarSprites50:
+ax_sprite sGengarGfx50, 0x200
+ax_sprite_terminator
+sGengarGfx51:
+.incbin "baserom.gba", 0x90536C, 0x200
+sGengarSprites51:
+ax_sprite sGengarGfx51, 0x200
+ax_sprite_terminator
+sGengarGfx52:
+.incbin "baserom.gba", 0x90557C, 0x200
+sGengarSprites52:
+ax_sprite sGengarGfx52, 0x200
+ax_sprite_terminator
+sGengarGfx53:
+.incbin "baserom.gba", 0x90578C, 0x200
+sGengarSprites53:
+ax_sprite sGengarGfx53, 0x200
+ax_sprite_terminator
+sAxPosesGengar:
+.4byte sGengarPose1
+.4byte sGengarPose2
+.4byte sGengarPose3
+.4byte sGengarPose4
+.4byte sGengarPose5
+.4byte sGengarPose6
+.4byte sGengarPose7
+.4byte sGengarPose8
+.4byte sGengarPose9
+.4byte sGengarPose10
+.4byte sGengarPose11
+.4byte sGengarPose12
+.4byte sGengarPose13
+.4byte sGengarPose14
+.4byte sGengarPose15
+.4byte sGengarPose16
+.4byte sGengarPose17
+.4byte sGengarPose18
+.4byte sGengarPose19
+.4byte sGengarPose20
+.4byte sGengarPose21
+.4byte sGengarPose22
+.4byte sGengarPose23
+.4byte sGengarPose24
+.4byte sGengarPose25
+.4byte sGengarPose26
+.4byte sGengarPose27
+.4byte sGengarPose28
+.4byte sGengarPose29
+.4byte sGengarPose30
+.4byte sGengarPose31
+.4byte sGengarPose32
+.4byte sGengarPose33
+.4byte sGengarPose34
+.4byte sGengarPose35
+.4byte sGengarPose36
+.4byte sGengarPose37
+.4byte sGengarPose38
+.4byte sGengarPose39
+.4byte sGengarPose40
+.4byte sGengarPose41
+.4byte sGengarPose42
+.4byte sGengarPose43
+.4byte sGengarPose44
+.4byte sGengarPose45
+.4byte sGengarPose46
+.4byte sGengarPose47
+.4byte sGengarPose48
+.4byte sGengarPose49
+.4byte sGengarPose50
+.4byte sGengarPose51
+.4byte sGengarPose52
+.4byte sGengarPose53
+.4byte sGengarPose54
+.4byte sGengarPose55
+.4byte sGengarPose56
+.4byte sGengarPose57
+.4byte sGengarPose58
+.4byte sGengarPose59
+.4byte sGengarPose60
+.4byte sGengarPose61
+.4byte sGengarPose62
+.4byte sGengarPose63
+.4byte sGengarPose64
+.4byte sGengarPose65
+.4byte sGengarPose66
+.4byte sGengarPose67
+.4byte sGengarPose68
+.4byte sGengarPose69
+.4byte sGengarPose70
+.4byte sGengarPose71
+.4byte sGengarPose72
+.4byte sGengarPose73
+.4byte sGengarPose74
+.4byte sGengarPose75
+.4byte sGengarPose76
+.4byte sGengarPose77
+.4byte sGengarPose78
+.4byte sGengarPose79
+.4byte sGengarPose80
+.4byte sGengarPose81
+.4byte sGengarPose82
+.4byte sGengarPose83
+.4byte sGengarPose84
+.4byte sGengarPose85
+.4byte sGengarPose86
+.4byte sGengarPose87
+.4byte sGengarPose88
+.4byte sGengarPose89
+.4byte sGengarPose90
+.4byte sGengarPose91
+.4byte sGengarPose92
+.4byte sGengarPose93
+.4byte sGengarPose94
+.4byte sGengarPose95
+.4byte sGengarPose96
+.4byte sGengarPose97
+.4byte sGengarPose98
+.4byte sGengarPose99
+.4byte sGengarPose100
+.4byte sGengarPose101
+.4byte sGengarPose102
+.4byte sGengarPose103
+.4byte sGengarPose104
+.4byte sGengarPose105
+.4byte sGengarPose106
+.4byte sGengarPose107
+.4byte sGengarPose108
+.4byte sGengarPose109
+.4byte sGengarPose110
+.4byte sGengarPose111
+.4byte sGengarPose112
+.4byte sGengarPose113
+.4byte sGengarPose114
+.4byte sGengarPose115
+.4byte sGengarPose116
+.4byte sGengarPose117
+.4byte sGengarPose118
+.4byte sGengarPose119
+.4byte sGengarPose120
+.4byte sGengarPose121
+.4byte sGengarPose122
+.4byte sGengarPose123
+.4byte sGengarPose124
+.4byte sGengarPose125
+.4byte sGengarPose126
+.4byte sGengarPose127
+.4byte sGengarPose128
+.4byte sGengarPose129
+.4byte sGengarPose130
+.4byte sGengarPose131
+.4byte sGengarPose132
+.4byte sGengarPose133
+.4byte sGengarPose134
+.4byte sGengarPose135
+.4byte sGengarPose136
+.4byte sGengarPose137
+.4byte sGengarPose138
+.4byte sGengarPose139
+.4byte sGengarPose140
+.4byte sGengarPose141
+.4byte sGengarPose142
+.4byte sGengarPose143
+.4byte sGengarPose144
+.4byte sGengarPose145
+.4byte sGengarPose146
+.4byte sGengarPose147
+.4byte sGengarPose148
+.4byte sGengarPose149
+.4byte sGengarPose150
+.4byte sGengarPose151
+.4byte sGengarPose152
+.4byte sGengarPose153
+.4byte sGengarPose154
+.4byte sGengarPose155
+.4byte sGengarPose156
+.4byte sGengarPose157
+.4byte sGengarPose158
+.4byte sGengarPose159
+.4byte sGengarPose160
+.4byte sGengarPose161
+.4byte sGengarPose162
+.4byte sGengarPose163
+.4byte sGengarPose164
+.4byte sGengarPose165
+.4byte sGengarPose166
+.4byte sGengarPose167
+.4byte sGengarPose168
+.4byte sGengarPose169
+.4byte sGengarPose170
+.4byte sGengarPose171
+.4byte sGengarPose172
+.4byte sGengarPose173
+.4byte sGengarPose174
+.4byte sGengarPose175
+.4byte sGengarPose176
+.4byte sGengarPose177
+.4byte sGengarPose178
+.4byte sGengarPose179
+.4byte sGengarPose180
+.4byte sGengarPose181
+.4byte sGengarPose182
+.4byte sGengarPose183
+.4byte sGengarPose184
+.4byte sGengarPose185
+.4byte sGengarPose186
+.4byte sGengarPose187
+.4byte sGengarPose188
+.4byte sGengarPose189
+.4byte sGengarPose190
+.4byte sGengarPose191
+.4byte sGengarPose192
+.4byte sGengarPose193
+.4byte sGengarPose194
+.4byte sGengarPose195
+.4byte sGengarPose196
+.4byte sGengarPose197
+.4byte sGengarPose198
+.4byte sGengarPose199
+.4byte sGengarPose200
+.4byte sGengarPose201
+.4byte sGengarPose202
+.4byte sGengarPose203
+.4byte sGengarPose204
+.4byte sGengarPose205
+.4byte sGengarPose206
+.4byte sGengarPose207
+.4byte sGengarPose208
+.4byte sGengarPose209
+.4byte sGengarPose210
+.4byte sGengarPose211
+.4byte sGengarPose212
+.4byte sGengarPose213
+.4byte sGengarPose214
+.4byte sGengarPose215
+.4byte sGengarPose216
+.4byte sGengarPose217
+.4byte sGengarPose218
+.4byte sGengarPose219
+sAxPositionsGengar:
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -2,   -5, 	 -12,   -9, 	   8,   -5, 	  -1,   -6
+.2byte    0,   -5, 	 -10,   -5, 	  10,   -9, 	  -1,   -7
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte    4,   -6, 	   0,  -10, 	  -2,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  10,   -8, 	 -12,   -5, 	  -1,   -7
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    6,   -7, 	  -5,   -7, 	   3,   -3, 	  -2,   -7
+.2byte    5,   -5, 	   4,  -10, 	  -7,   -3, 	  -1,   -7
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    1,  -11, 	 -12,   -6, 	   9,   -7, 	  -2,   -7
+.2byte    3,   -9, 	  -2,   -8, 	   0,   -3, 	  -3,   -7
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte    0,  -11, 	  12,   -6, 	 -11,  -10, 	  -1,   -7
+.2byte   -2,  -12, 	   7,   -8, 	 -14,   -6, 	   0,   -8
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -3,  -11, 	  10,   -6, 	 -11,   -7, 	   0,   -7
+.2byte   -5,   -9, 	   0,   -8, 	  -2,   -3, 	   1,   -7
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -8,   -7, 	   3,   -7, 	  -5,   -3, 	   0,   -7
+.2byte   -7,   -5, 	  -6,  -10, 	   5,   -3, 	  -1,   -7
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -6,   -6, 	  -2,  -10, 	   0,   -4, 	   0,   -7
+.2byte   -4,   -5, 	 -12,   -8, 	  10,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -2,   -5, 	 -12,   -9, 	   8,   -5, 	  -1,   -6
+.2byte    0,   -5, 	 -10,   -5, 	  10,   -9, 	  -1,   -7
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte    4,   -6, 	   0,  -10, 	  -2,   -4, 	  -2,   -7
+.2byte    2,   -5, 	  10,   -8, 	 -12,   -5, 	  -1,   -7
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    6,   -7, 	  -5,   -7, 	   3,   -3, 	  -2,   -7
+.2byte    5,   -5, 	   4,  -10, 	  -7,   -3, 	  -1,   -7
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    1,  -11, 	 -12,   -6, 	   9,   -7, 	  -2,   -7
+.2byte    3,   -9, 	  -2,   -8, 	   0,   -3, 	  -3,   -7
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte    0,  -11, 	  12,   -6, 	 -11,  -10, 	  -1,   -7
+.2byte   -2,  -12, 	   7,   -8, 	 -14,   -6, 	   0,   -8
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -3,  -11, 	  10,   -6, 	 -11,   -7, 	   0,   -7
+.2byte   -5,   -9, 	   0,   -8, 	  -2,   -3, 	   1,   -7
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -8,   -7, 	   3,   -7, 	  -5,   -3, 	   0,   -7
+.2byte   -7,   -5, 	  -6,  -10, 	   5,   -3, 	  -1,   -7
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -6,   -6, 	  -2,  -10, 	   0,   -4, 	   0,   -7
+.2byte   -4,   -5, 	 -12,   -8, 	  10,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -8,   -8, 	  -7,   -6, 	  -5,  -11, 	  -2,   -9
+.2byte    1,   -3, 	  -2,    8, 	   7,  -14, 	   0,  -10
+.2byte    1,   -3, 	  -2,    8, 	   7,  -14, 	   0,  -10
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte    2,  -12, 	  -6,  -11, 	   7,  -17, 	  -2,  -10
+.2byte    1,   -2, 	  18,    2, 	 -10,   -6, 	   0,   -7
+.2byte    1,   -2, 	  18,    2, 	 -10,   -6, 	   0,   -7
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte   -5,  -12, 	 -14,   -5, 	   4,  -17, 	  -5,   -9
+.2byte    0,   -5, 	  21,   -8, 	 -10,   -7, 	   0,   -8
+.2byte    0,   -5, 	  21,   -8, 	 -10,   -7, 	   0,   -8
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte   -6,  -11, 	 -10,   -2, 	   0,  -13, 	  -4,   -7
+.2byte    6,   -6, 	  13,  -23, 	  -2,   -2, 	   0,  -10
+.2byte    6,   -6, 	  13,  -23, 	  -2,   -2, 	   0,  -10
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte    4,   -9, 	   2,    0, 	   4,  -18, 	  -2,   -8
+.2byte   -6,  -11, 	   2,  -26, 	  -8,   -3, 	   0,   -9
+.2byte   -6,  -11, 	   2,  -26, 	  -8,   -3, 	   0,   -9
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte    4,  -11, 	   8,   -2, 	  -2,  -13, 	   2,   -7
+.2byte   -8,   -6, 	 -15,  -23, 	   0,   -2, 	  -2,  -10
+.2byte   -8,   -6, 	 -15,  -23, 	   0,   -2, 	  -2,  -10
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte    3,  -12, 	  12,   -5, 	  -6,  -17, 	   3,   -9
+.2byte   -2,   -5, 	 -23,   -8, 	   8,   -7, 	  -2,   -8
+.2byte   -2,   -5, 	 -23,   -8, 	   8,   -7, 	  -2,   -8
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -4,  -12, 	   4,  -11, 	  -9,  -17, 	   0,  -10
+.2byte   -1,   -2, 	 -18,    2, 	  10,   -6, 	   0,   -7
+.2byte   -1,   -2, 	 -18,    2, 	  10,   -6, 	   0,   -7
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -1,   -3, 	 -11,   -7, 	  10,   -7, 	  -1,   -6
+.2byte   -1,   -4, 	 -12,   -8, 	  10,   -8, 	  -1,   -8
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte    4,   -3, 	   3,   -9, 	 -10,   -4, 	  -1,   -7
+.2byte    3,   -4, 	   3,  -11, 	 -10,   -5, 	  -1,   -8
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    6,   -4, 	  -2,  -10, 	  -4,   -3, 	   0,   -7
+.2byte    6,   -5, 	  -2,  -10, 	  -4,   -5, 	   1,   -8
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    5,   -7, 	  -7,  -10, 	   1,   -2, 	  -1,   -9
+.2byte    6,   -7, 	  -6,  -10, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	  11,   -4, 	 -13,   -4, 	  -1,   -8
+.2byte    0,  -13, 	  11,   -5, 	 -12,   -6, 	  -1,   -8
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -7,   -7, 	   5,  -10, 	  -3,   -2, 	  -1,   -9
+.2byte   -8,   -7, 	   4,  -10, 	  -3,   -4, 	  -1,   -9
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -8,   -4, 	   0,  -10, 	   2,   -3, 	  -2,   -7
+.2byte   -8,   -5, 	   0,  -10, 	   2,   -5, 	  -3,   -8
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -6,   -3, 	  -5,   -9, 	   8,   -4, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,  -11, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte   -2,   -5, 	  -8,   -6, 	   8,   -1, 	   2,   -7
+.2byte   -3,   -3, 	  -8,   -5, 	   7,    0, 	   2,   -5
+.2byte   -1,   -7, 	 -13,  -14, 	  12,  -14, 	  -1,   -8
+.2byte   -1,   -7, 	   5,  -17, 	 -16,  -11, 	  -5,   -9
+.2byte    1,   -7, 	  -9,  -15, 	 -11,  -11, 	  -7,   -7
+.2byte   -3,   -6, 	 -15,  -12, 	   1,   -9, 	  -7,   -3
+.2byte   -1,   -9, 	  12,  -10, 	 -13,  -10, 	  -1,   -6
+.2byte    2,   -6, 	  14,  -12, 	  -2,   -9, 	   6,   -3
+.2byte   -2,   -7, 	   8,  -15, 	  10,  -11, 	   6,   -7
+.2byte    0,   -7, 	  -6,  -17, 	  15,  -11, 	   4,   -9
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -1,   -3, 	 -11,   -7, 	  10,   -7, 	  -1,   -6
+.2byte   -1,   -4, 	 -12,   -8, 	  10,   -8, 	  -1,   -8
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte    4,   -3, 	   3,   -9, 	 -10,   -4, 	  -1,   -7
+.2byte    3,   -4, 	   3,  -11, 	 -10,   -5, 	  -1,   -8
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    6,   -4, 	  -2,  -10, 	  -4,   -3, 	   0,   -7
+.2byte    6,   -5, 	  -2,  -10, 	  -4,   -5, 	   1,   -8
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    5,   -7, 	  -7,  -10, 	   1,   -2, 	  -1,   -9
+.2byte    6,   -7, 	  -6,  -10, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	  11,   -4, 	 -13,   -4, 	  -1,   -8
+.2byte    0,  -13, 	  11,   -5, 	 -12,   -6, 	  -1,   -8
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -7,   -7, 	   5,  -10, 	  -3,   -2, 	  -1,   -9
+.2byte   -8,   -7, 	   4,  -10, 	  -3,   -4, 	  -1,   -9
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -8,   -4, 	   0,  -10, 	   2,   -3, 	  -2,   -7
+.2byte   -8,   -5, 	   0,  -10, 	   2,   -5, 	  -3,   -8
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -6,   -3, 	  -5,   -9, 	   8,   -4, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,  -11, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte   -1,   -4, 	 -12,   -8, 	  10,   -8, 	  -1,   -8
+.2byte    3,   -4, 	   3,  -11, 	 -10,   -5, 	  -1,   -8
+.2byte    6,   -5, 	  -2,  -10, 	  -4,   -5, 	   1,   -8
+.2byte    6,   -7, 	  -6,  -10, 	   1,   -4, 	  -1,   -9
+.2byte    0,  -13, 	  11,   -5, 	 -12,   -6, 	  -1,   -8
+.2byte   -8,   -7, 	   4,  -10, 	  -3,   -4, 	  -1,   -9
+.2byte   -8,   -5, 	   0,  -10, 	   2,   -5, 	  -3,   -8
+.2byte   -5,   -4, 	  -5,  -11, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -1,   -3, 	 -11,   -7, 	  10,   -7, 	  -1,   -6
+.2byte   -1,   -4, 	 -12,   -8, 	  10,   -8, 	  -1,   -8
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte    4,   -3, 	   3,   -9, 	 -10,   -4, 	  -1,   -7
+.2byte    3,   -4, 	   3,  -11, 	 -10,   -5, 	  -1,   -8
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    6,   -4, 	  -2,  -10, 	  -4,   -3, 	   0,   -7
+.2byte    6,   -5, 	  -2,  -10, 	  -4,   -5, 	   1,   -8
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    5,   -7, 	  -7,  -10, 	   1,   -2, 	  -1,   -9
+.2byte    6,   -7, 	  -6,  -10, 	   1,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	  11,   -4, 	 -13,   -4, 	  -1,   -8
+.2byte    0,  -13, 	  11,   -5, 	 -12,   -6, 	  -1,   -8
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -7,   -7, 	   5,  -10, 	  -3,   -2, 	  -1,   -9
+.2byte   -8,   -7, 	   4,  -10, 	  -3,   -4, 	  -1,   -9
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -8,   -4, 	   0,  -10, 	   2,   -3, 	  -2,   -7
+.2byte   -8,   -5, 	   0,  -10, 	   2,   -5, 	  -3,   -8
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -6,   -3, 	  -5,   -9, 	   8,   -4, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,  -11, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -4, 	 -12,   -8, 	  10,   -8, 	  -1,   -8
+.2byte   -5,   -4, 	  -5,  -11, 	   8,   -5, 	  -1,   -8
+.2byte   -8,   -5, 	   0,  -10, 	   2,   -5, 	  -3,   -8
+.2byte   -8,   -7, 	   4,  -10, 	  -3,   -4, 	  -1,   -9
+.2byte    0,  -13, 	  11,   -5, 	 -12,   -6, 	  -1,   -8
+.2byte    6,   -7, 	  -6,  -10, 	   1,   -4, 	  -1,   -9
+.2byte    6,   -5, 	  -2,  -10, 	  -4,   -5, 	   1,   -8
+.2byte    3,   -4, 	   3,  -11, 	 -10,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -5,   -6, 	 -11,   -8, 	   6,   -2, 	  -1,   -8
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -5,  -10, 	   5,   -8, 	  -7,   -2, 	   0,   -8
+.2byte   -1,  -12, 	   9,   -4, 	 -12,   -5, 	  -1,   -9
+.2byte    3,  -10, 	  -7,   -8, 	   5,   -2, 	  -2,   -8
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    3,   -6, 	   9,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte   -3,   -8, 	 -12,  -12, 	   5,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    1,   -8, 	  -7,   -7, 	  10,  -12, 	   0,  -10
+.2byte    6,   -7, 	  -1,   -8, 	  -3,   -2, 	  -2,   -7
+.2byte    6,   -7, 	  -5,   -7, 	   3,   -3, 	  -2,   -7
+.2byte    5,   -5, 	   4,  -10, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -1,   -3, 	 -11,   -7, 	  10,   -7, 	  -1,   -6
+.2byte   -1,   -4, 	 -12,   -8, 	  10,   -8, 	  -1,   -8
+sGengarAnimTable1:
+.4byte sGengarAnims_1_1
+.4byte sGengarAnims_1_2
+.4byte sGengarAnims_1_3
+.4byte sGengarAnims_1_4
+.4byte sGengarAnims_1_5
+.4byte sGengarAnims_1_6
+.4byte sGengarAnims_1_7
+.4byte sGengarAnims_1_8
+sGengarAnimTable2:
+.4byte sGengarAnims_2_1
+.4byte sGengarAnims_2_2
+.4byte sGengarAnims_2_3
+.4byte sGengarAnims_2_4
+.4byte sGengarAnims_2_5
+.4byte sGengarAnims_2_6
+.4byte sGengarAnims_2_7
+.4byte sGengarAnims_2_8
+sGengarAnimTable3:
+.4byte sGengarAnims_3_1
+.4byte sGengarAnims_3_2
+.4byte sGengarAnims_3_3
+.4byte sGengarAnims_3_4
+.4byte sGengarAnims_3_5
+.4byte sGengarAnims_3_6
+.4byte sGengarAnims_3_7
+.4byte sGengarAnims_3_8
+sGengarAnimTable4:
+.4byte sGengarAnims_4_1
+.4byte sGengarAnims_4_2
+.4byte sGengarAnims_4_3
+.4byte sGengarAnims_4_4
+.4byte sGengarAnims_4_5
+.4byte sGengarAnims_4_6
+.4byte sGengarAnims_4_7
+.4byte sGengarAnims_4_8
+sGengarAnimTable5:
+.4byte sGengarAnims_5_1
+.4byte sGengarAnims_5_2
+.4byte sGengarAnims_5_3
+.4byte sGengarAnims_5_4
+.4byte sGengarAnims_5_5
+.4byte sGengarAnims_5_6
+.4byte sGengarAnims_5_7
+.4byte sGengarAnims_5_8
+sGengarAnimTable6:
+.4byte sGengarAnims_6_1
+.4byte sGengarAnims_6_1
+.4byte sGengarAnims_6_1
+.4byte sGengarAnims_6_1
+.4byte sGengarAnims_6_1
+.4byte sGengarAnims_6_1
+.4byte sGengarAnims_6_1
+.4byte sGengarAnims_6_1
+sGengarAnimTable7:
+.4byte sGengarAnims_7_1
+.4byte sGengarAnims_7_2
+.4byte sGengarAnims_7_3
+.4byte sGengarAnims_7_4
+.4byte sGengarAnims_7_5
+.4byte sGengarAnims_7_6
+.4byte sGengarAnims_7_7
+.4byte sGengarAnims_7_8
+sGengarAnimTable8:
+.4byte sGengarAnims_8_1
+.4byte sGengarAnims_8_2
+.4byte sGengarAnims_8_3
+.4byte sGengarAnims_8_4
+.4byte sGengarAnims_8_5
+.4byte sGengarAnims_8_6
+.4byte sGengarAnims_8_7
+.4byte sGengarAnims_8_8
+sGengarAnimTable9:
+.4byte sGengarAnims_9_1
+.4byte sGengarAnims_9_2
+.4byte sGengarAnims_9_3
+.4byte sGengarAnims_9_4
+.4byte sGengarAnims_9_5
+.4byte sGengarAnims_9_6
+.4byte sGengarAnims_9_7
+.4byte sGengarAnims_9_8
+sGengarAnimTable10:
+.4byte sGengarAnims_10_1
+.4byte sGengarAnims_10_2
+.4byte sGengarAnims_10_3
+.4byte sGengarAnims_10_4
+.4byte sGengarAnims_10_5
+.4byte sGengarAnims_10_6
+.4byte sGengarAnims_10_7
+.4byte sGengarAnims_10_8
+sGengarAnimTable11:
+.4byte sGengarAnims_11_1
+.4byte sGengarAnims_11_2
+.4byte sGengarAnims_11_3
+.4byte sGengarAnims_11_4
+.4byte sGengarAnims_11_5
+.4byte sGengarAnims_11_6
+.4byte sGengarAnims_11_7
+.4byte sGengarAnims_11_8
+sGengarAnimTable12:
+.4byte sGengarAnims_12_1
+.4byte sGengarAnims_12_2
+.4byte sGengarAnims_12_3
+.4byte sGengarAnims_12_4
+.4byte sGengarAnims_12_5
+.4byte sGengarAnims_12_6
+.4byte sGengarAnims_12_7
+.4byte sGengarAnims_12_8
+sGengarAnimTable13:
+.4byte sGengarAnims_13_1
+.4byte sGengarAnims_13_2
+.4byte sGengarAnims_13_3
+.4byte sGengarAnims_13_4
+.4byte sGengarAnims_13_5
+.4byte sGengarAnims_13_6
+.4byte sGengarAnims_13_7
+.4byte sGengarAnims_13_8
+sGengarAnimTable14:
+.4byte sGengarAnims_14_1
+.4byte sGengarAnims_14_2
+.4byte sGengarAnims_14_3
+.4byte sGengarAnims_14_4
+.4byte sGengarAnims_14_5
+.4byte sGengarAnims_14_6
+.4byte sGengarAnims_14_7
+.4byte sGengarAnims_14_8
+sGengarAnimTable15:
+.4byte sGengarAnims_15_1
+.4byte sGengarAnims_15_1
+.4byte sGengarAnims_15_1
+.4byte sGengarAnims_15_1
+.4byte sGengarAnims_15_1
+.4byte sGengarAnims_15_1
+.4byte sGengarAnims_15_1
+.4byte sGengarAnims_15_1
+sGengarAnimTable16:
+.4byte sGengarAnims_16_1
+.4byte sGengarAnims_16_1
+.4byte sGengarAnims_16_1
+.4byte sGengarAnims_16_1
+.4byte sGengarAnims_16_1
+.4byte sGengarAnims_16_1
+.4byte sGengarAnims_16_1
+.4byte sGengarAnims_16_1
+sAxAnimationsGengar:
+.4byte sGengarAnimTable1
+.4byte sGengarAnimTable2
+.4byte sGengarAnimTable3
+.4byte sGengarAnimTable4
+.4byte sGengarAnimTable5
+.4byte sGengarAnimTable6
+.4byte sGengarAnimTable7
+.4byte sGengarAnimTable8
+.4byte sGengarAnimTable9
+.4byte sGengarAnimTable10
+.4byte sGengarAnimTable11
+.4byte sGengarAnimTable12
+.4byte sGengarAnimTable13
+.4byte sGengarAnimTable14
+.4byte sGengarAnimTable15
+.4byte sGengarAnimTable16
+sAxSpritesGengar:
+.4byte sGengarSprites1
+.4byte sGengarSprites2
+.4byte sGengarSprites3
+.4byte sGengarSprites4
+.4byte sGengarSprites5
+.4byte sGengarSprites6
+.4byte sGengarSprites7
+.4byte sGengarSprites8
+.4byte sGengarSprites9
+.4byte sGengarSprites10
+.4byte sGengarSprites11
+.4byte sGengarSprites12
+.4byte sGengarSprites13
+.4byte sGengarSprites14
+.4byte sGengarSprites15
+.4byte sGengarSprites16
+.4byte sGengarSprites17
+.4byte sGengarSprites18
+.4byte sGengarSprites19
+.4byte sGengarSprites20
+.4byte sGengarSprites21
+.4byte sGengarSprites22
+.4byte sGengarSprites23
+.4byte sGengarSprites24
+.4byte sGengarSprites25
+.4byte sGengarSprites26
+.4byte sGengarSprites27
+.4byte sGengarSprites28
+.4byte sGengarSprites29
+.4byte sGengarSprites30
+.4byte sGengarSprites31
+.4byte sGengarSprites32
+.4byte sGengarSprites33
+.4byte sGengarSprites34
+.4byte sGengarSprites35
+.4byte sGengarSprites36
+.4byte sGengarSprites37
+.4byte sGengarSprites38
+.4byte sGengarSprites39
+.4byte sGengarSprites40
+.4byte sGengarSprites41
+.4byte sGengarSprites42
+.4byte sGengarSprites43
+.4byte sGengarSprites44
+.4byte sGengarSprites45
+.4byte sGengarSprites46
+.4byte sGengarSprites47
+.4byte sGengarSprites48
+.4byte sGengarSprites49
+.4byte sGengarSprites50
+.4byte sGengarSprites51
+.4byte sGengarSprites52
+.4byte sGengarSprites53
+sAxMainGengar:
+ax_main sAxPosesGengar, sAxAnimationsGengar, 16, sAxSpritesGengar, sAxPositionsGengar

--- a/data/ax/geodude.inc
+++ b/data/ax/geodude.inc
@@ -1,0 +1,2844 @@
+.global gAxGeodude
+gAxGeodude:
+ax_siro sAxMainGeodude
+sGeodudePose1:
+ax_pose 0, 0x41f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose4:
+ax_pose 3, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose5:
+ax_pose 4, 0x41f1, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose6:
+ax_pose 5, 0x01ec, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose7:
+ax_pose 6, 0x81ea, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose8:
+ax_pose 7, 0x01ec, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose9:
+ax_pose 8, 0x81ec, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose10:
+ax_pose 9, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose11:
+ax_pose 10, 0x81ed, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose12:
+ax_pose 11, 0x01ef, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose13:
+ax_pose 12, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose16:
+ax_pose 9, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose17:
+ax_pose 10, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose18:
+ax_pose 11, 0x01ef, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose19:
+ax_pose 6, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose21:
+ax_pose 8, 0x81ec, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose22:
+ax_pose 3, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose23:
+ax_pose 15, 0x01f1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose24:
+ax_pose 5, 0x01ec, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose25:
+ax_pose 0, 0x41f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose28:
+ax_pose 3, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose29:
+ax_pose 4, 0x41f1, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose30:
+ax_pose 5, 0x01ec, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose31:
+ax_pose 6, 0x81ea, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose32:
+ax_pose 7, 0x01ec, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose33:
+ax_pose 8, 0x81ec, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose34:
+ax_pose 9, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose35:
+ax_pose 10, 0x81ed, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose36:
+ax_pose 11, 0x01ef, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose37:
+ax_pose 12, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose38:
+ax_pose 13, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose39:
+ax_pose 14, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose40:
+ax_pose 9, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose41:
+ax_pose 10, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose42:
+ax_pose 11, 0x01ef, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose43:
+ax_pose 6, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose44:
+ax_pose 7, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose45:
+ax_pose 8, 0x81ec, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose46:
+ax_pose 3, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose47:
+ax_pose 15, 0x01f1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose48:
+ax_pose 5, 0x01ec, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose49:
+ax_pose 16, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose50:
+ax_pose 17, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose51:
+ax_pose 18, 0x81ea, 0x80f0, 0x7c00
+ax_pose 19, 0x01ea, 0x80f0, 0x7c08
+ax_pose_terminator
+sGeodudePose52:
+ax_pose 19, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose53:
+ax_pose 20, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose54:
+ax_pose 21, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose55:
+ax_pose 22, 0x01ea, 0x90f0, 0x7c00
+ax_pose 23, 0x01ea, 0x90f0, 0x7c10
+ax_pose_terminator
+sGeodudePose56:
+ax_pose 23, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose57:
+ax_pose 24, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose58:
+ax_pose 25, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose59:
+ax_pose 26, 0x01ea, 0x90f4, 0x7c00
+ax_pose 27, 0x81ea, 0x90f0, 0x7c10
+ax_pose 28, 0x01f2, 0x5100, 0x7c18
+ax_pose 29, 0x01fa, 0x1110, 0x7c1c
+ax_pose_terminator
+sGeodudePose60:
+ax_pose 27, 0x81ea, 0x90f0, 0x7c00
+ax_pose 28, 0x01f2, 0x5100, 0x7c08
+ax_pose 29, 0x01fa, 0x1110, 0x7c0c
+ax_pose_terminator
+sGeodudePose61:
+ax_pose 30, 0x01ee, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose62:
+ax_pose 31, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose63:
+ax_pose 32, 0x01ea, 0x90f0, 0x7c00
+ax_pose 33, 0x01ea, 0x90f0, 0x7c10
+ax_pose_terminator
+sGeodudePose64:
+ax_pose 33, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose65:
+ax_pose 34, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose66:
+ax_pose 35, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose67:
+ax_pose 36, 0x81ea, 0x8100, 0x7c00
+ax_pose 37, 0x01ea, 0x80f0, 0x7c08
+ax_pose_terminator
+sGeodudePose68:
+ax_pose 37, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose69:
+ax_pose 30, 0x01ee, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose70:
+ax_pose 31, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose71:
+ax_pose 32, 0x01ea, 0x80f0, 0x7c00
+ax_pose 33, 0x01ea, 0x80f0, 0x7c10
+ax_pose_terminator
+sGeodudePose72:
+ax_pose 33, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose73:
+ax_pose 24, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose74:
+ax_pose 25, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose75:
+ax_pose 26, 0x01ea, 0x80ec, 0x7c00
+ax_pose 27, 0x81ea, 0x8100, 0x7c10
+ax_pose 28, 0x01f2, 0x40f0, 0x7c18
+ax_pose 29, 0x01fa, 0x00e8, 0x7c1c
+ax_pose_terminator
+sGeodudePose76:
+ax_pose 27, 0x81ea, 0x8100, 0x7c00
+ax_pose 28, 0x01f2, 0x40f0, 0x7c08
+ax_pose 29, 0x01fa, 0x00e8, 0x7c0c
+ax_pose_terminator
+sGeodudePose77:
+ax_pose 20, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose78:
+ax_pose 21, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose79:
+ax_pose 22, 0x01ea, 0x80f0, 0x7c00
+ax_pose 23, 0x01ea, 0x80f0, 0x7c10
+ax_pose_terminator
+sGeodudePose80:
+ax_pose 23, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose81:
+ax_pose 0, 0x41f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose82:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose83:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose84:
+ax_pose 38, 0x41f2, 0x80f0, 0x7c00
+ax_pose 39, 0x01fa, 0x00e8, 0x7c08
+ax_pose 40, 0x01fa, 0x0110, 0x7c09
+ax_pose_terminator
+sGeodudePose85:
+ax_pose 3, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose86:
+ax_pose 15, 0x01f1, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose87:
+ax_pose 5, 0x01ec, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose88:
+ax_pose 41, 0x41f2, 0x90f0, 0x7c00
+ax_pose 42, 0x01fc, 0x10e8, 0x7c08
+ax_pose 43, 0x0202, 0x10f0, 0x7c09
+ax_pose_terminator
+sGeodudePose89:
+ax_pose 6, 0x81ea, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose90:
+ax_pose 7, 0x01ec, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose91:
+ax_pose 8, 0x81ec, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose92:
+ax_pose 44, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose93:
+ax_pose 9, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose94:
+ax_pose 10, 0x81ed, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose95:
+ax_pose 11, 0x01ef, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose96:
+ax_pose 45, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose97:
+ax_pose 12, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose98:
+ax_pose 13, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose99:
+ax_pose 14, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose100:
+ax_pose 46, 0x41f2, 0x80f0, 0x7c00
+ax_pose 47, 0x01fa, 0x00e8, 0x7c08
+ax_pose 48, 0x01fa, 0x0110, 0x7c09
+ax_pose_terminator
+sGeodudePose101:
+ax_pose 9, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose102:
+ax_pose 10, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose103:
+ax_pose 11, 0x01ef, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose104:
+ax_pose 45, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose105:
+ax_pose 6, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose106:
+ax_pose 7, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose107:
+ax_pose 8, 0x81ec, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose108:
+ax_pose 44, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose109:
+ax_pose 3, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose110:
+ax_pose 15, 0x01f1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose111:
+ax_pose 5, 0x01ec, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose112:
+ax_pose 41, 0x41f2, 0x80f0, 0x7c00
+ax_pose 42, 0x01fc, 0x0110, 0x7c08
+ax_pose 43, 0x0202, 0x0108, 0x7c09
+ax_pose_terminator
+sGeodudePose113:
+ax_pose 16, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose114:
+ax_pose 20, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose115:
+ax_pose 24, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose116:
+ax_pose 30, 0x01ee, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose117:
+ax_pose 34, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose118:
+ax_pose 30, 0x01ee, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose119:
+ax_pose 24, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose120:
+ax_pose 20, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose121:
+ax_pose 49, 0x01ef, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose122:
+ax_pose 50, 0x01ef, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose123:
+ax_pose 51, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose124:
+ax_pose 52, 0x01eb, 0x90f1, 0x7c00
+ax_pose_terminator
+sGeodudePose125:
+ax_pose 53, 0x01ed, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose126:
+ax_pose 54, 0x01ed, 0x90ef, 0x7c00
+ax_pose_terminator
+sGeodudePose127:
+ax_pose 55, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose128:
+ax_pose 54, 0x01ed, 0x80f1, 0x7c00
+ax_pose_terminator
+sGeodudePose129:
+ax_pose 53, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose130:
+ax_pose 52, 0x01eb, 0x80ef, 0x7c00
+ax_pose_terminator
+sGeodudePose131:
+ax_pose 16, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose132:
+ax_pose 20, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose133:
+ax_pose 24, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose134:
+ax_pose 30, 0x01ee, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose135:
+ax_pose 34, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose136:
+ax_pose 30, 0x01ee, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose137:
+ax_pose 24, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose138:
+ax_pose 20, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose139:
+ax_pose 0, 0x41f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose140:
+ax_pose 3, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose141:
+ax_pose 6, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose142:
+ax_pose 9, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose143:
+ax_pose 12, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose144:
+ax_pose 9, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose145:
+ax_pose 6, 0x81ea, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose146:
+ax_pose 3, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose147:
+ax_pose 0, 0x41f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose148:
+ax_pose 16, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose149:
+ax_pose 3, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose150:
+ax_pose 20, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose151:
+ax_pose 6, 0x81ea, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose152:
+ax_pose 24, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose153:
+ax_pose 9, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose154:
+ax_pose 30, 0x01ee, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose155:
+ax_pose 12, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose156:
+ax_pose 34, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose157:
+ax_pose 9, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose158:
+ax_pose 30, 0x01ee, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose159:
+ax_pose 6, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose160:
+ax_pose 24, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose161:
+ax_pose 3, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose162:
+ax_pose 20, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose163:
+ax_pose 16, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose164:
+ax_pose 0, 0x41f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose165:
+ax_pose 20, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose166:
+ax_pose 3, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose167:
+ax_pose 24, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose168:
+ax_pose 6, 0x81ea, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose169:
+ax_pose 30, 0x01ee, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose170:
+ax_pose 9, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose171:
+ax_pose 34, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose172:
+ax_pose 12, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose173:
+ax_pose 30, 0x01ee, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose174:
+ax_pose 9, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose175:
+ax_pose 24, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose176:
+ax_pose 6, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose177:
+ax_pose 20, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose178:
+ax_pose 3, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose179:
+ax_pose 0, 0x41f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose180:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose181:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose182:
+ax_pose 3, 0x01ea, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose183:
+ax_pose 4, 0x41f1, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose184:
+ax_pose 5, 0x01ec, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose185:
+ax_pose 6, 0x81ea, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose186:
+ax_pose 7, 0x01ec, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose187:
+ax_pose 8, 0x81ec, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose188:
+ax_pose 9, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sGeodudePose189:
+ax_pose 10, 0x81ed, 0x90f8, 0x7c00
+ax_pose_terminator
+sGeodudePose190:
+ax_pose 56, 0x41f1, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose191:
+ax_pose 12, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose192:
+ax_pose 13, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose193:
+ax_pose 14, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose194:
+ax_pose 9, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose195:
+ax_pose 10, 0x81ed, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose196:
+ax_pose 56, 0x41f1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose197:
+ax_pose 6, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose198:
+ax_pose 7, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sGeodudePose199:
+ax_pose 8, 0x81ec, 0x80f8, 0x7c00
+ax_pose_terminator
+sGeodudePose200:
+ax_pose 3, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose201:
+ax_pose 15, 0x01f1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose202:
+ax_pose 5, 0x01ec, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose203:
+ax_pose 16, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose204:
+ax_pose 20, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose205:
+ax_pose 24, 0x01f0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose206:
+ax_pose 30, 0x01ee, 0x80f2, 0x7c00
+ax_pose_terminator
+sGeodudePose207:
+ax_pose 34, 0x41f2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGeodudePose208:
+ax_pose 30, 0x01ee, 0x90ee, 0x7c00
+ax_pose_terminator
+sGeodudePose209:
+ax_pose 24, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+sGeodudePose210:
+ax_pose 20, 0x01f0, 0x90f0, 0x7c00
+ax_pose_terminator
+.align 2
+sGeodudeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_2_1:
+ax_anim 3, 0, 24, 0, -1, 0, -1,
+ax_anim 3, 0, 45, 0, -2, 0, -2,
+ax_anim 2, 0, 47, 0, -5, 0, -5,
+ax_anim 2, 0, 47, 1, -5, 1, -5,
+ax_anim 2, 0, 47, 0, -5, 0, -5,
+ax_anim 2, 2, 47, 1, -5, 1, -5,
+ax_anim 1, 0, 45, 0, 2, 0, 2,
+ax_anim 1, 0, 26, 0, 9, 0, 9,
+ax_anim 1, 1, 29, 0, 21, 0, 21,
+ax_anim 1, 0, 29, -1, 21, -1, 21,
+ax_anim 1, 0, 29, 0, 21, 0, 21,
+ax_anim 1, 0, 29, -1, 21, -1, 21,
+ax_anim 2, 0, 27, 0, 9, 0, 9,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sGeodudeAnims_2_2:
+ax_anim 3, 0, 27, -1, -1, -1, -1,
+ax_anim 3, 0, 24, -2, -2, -2, -2,
+ax_anim 2, 0, 26, -5, -5, -5, -5,
+ax_anim 2, 0, 26, -4, -6, -4, -6,
+ax_anim 2, 0, 26, -5, -5, -5, -5,
+ax_anim 2, 2, 26, -4, -6, -4, -6,
+ax_anim 1, 0, 24, 2, 2, 2, 2,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 1, 1, 32, 21, 21, 21, 21,
+ax_anim 1, 0, 32, 22, 20, 22, 20,
+ax_anim 1, 0, 32, 21, 21, 21, 21,
+ax_anim 1, 0, 32, 22, 20, 22, 20,
+ax_anim 2, 0, 29, 15, 15, 15, 15,
+ax_anim 2, 0, 27, 7, 7, 7, 7,
+ax_anim_terminator
+sGeodudeAnims_2_3:
+ax_anim 3, 0, 30, -1, 0, -1, 0,
+ax_anim 3, 0, 27, -2, 0, -2, 0,
+ax_anim 2, 0, 28, -5, 0, -5, 0,
+ax_anim 2, 0, 28, -5, -1, -5, -1,
+ax_anim 2, 0, 28, -5, 0, -5, 0,
+ax_anim 2, 2, 28, -5, -1, -5, -1,
+ax_anim 1, 0, 31, 2, 0, 2, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 1, 1, 33, 21, 0, 21, 0,
+ax_anim 1, 0, 33, 21, -1, 21, -1,
+ax_anim 1, 0, 33, 21, 0, 21, 0,
+ax_anim 1, 0, 33, 21, -1, 21, -1,
+ax_anim 2, 0, 32, 17, -1, 17, -1,
+ax_anim 2, 0, 30, 5, 0, 5, 0,
+ax_anim_terminator
+sGeodudeAnims_2_4:
+ax_anim 3, 0, 33, -1, 1, -1, 1,
+ax_anim 3, 0, 30, -2, 2, -2, 2,
+ax_anim 2, 0, 31, -5, 5, -5, 5,
+ax_anim 2, 0, 31, -4, 6, -4, 6,
+ax_anim 2, 0, 31, -5, 5, -5, 5,
+ax_anim 2, 2, 31, -4, 6, -4, 6,
+ax_anim 1, 0, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 12, -12, 12, -12,
+ax_anim 1, 1, 37, 21, -22, 21, -22,
+ax_anim 1, 0, 37, 20, -23, 20, -23,
+ax_anim 1, 0, 37, 21, -22, 21, -22,
+ax_anim 1, 0, 37, 20, -23, 20, -23,
+ax_anim 2, 0, 36, 11, -11, 11, -11,
+ax_anim 2, 0, 33, 5, -5, 5, -5,
+ax_anim_terminator
+sGeodudeAnims_2_5:
+ax_anim 3, 0, 36, 0, 1, 0, 1,
+ax_anim 3, 0, 33, 0, 2, 0, 2,
+ax_anim 2, 0, 34, 0, 5, 0, 5,
+ax_anim 2, 0, 34, -1, 5, -1, 5,
+ax_anim 2, 0, 34, 0, 5, 0, 5,
+ax_anim 2, 2, 34, -1, 5, -1, 5,
+ax_anim 1, 0, 33, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -12, 0, -12,
+ax_anim 1, 1, 39, 0, -23, 0, -23,
+ax_anim 1, 0, 39, -1, -23, -1, -23,
+ax_anim 1, 0, 39, 0, -23, 0, -23,
+ax_anim 1, 0, 39, -1, -23, -1, -23,
+ax_anim 2, 0, 37, 0, -15, 0, -15,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sGeodudeAnims_2_6:
+ax_anim 3, 0, 39, 1, 1, 1, 1,
+ax_anim 3, 0, 37, 2, 2, 2, 2,
+ax_anim 2, 0, 36, 5, 5, 5, 5,
+ax_anim 2, 0, 36, 4, 6, 4, 6,
+ax_anim 2, 0, 36, 5, 5, 5, 5,
+ax_anim 2, 2, 36, 4, 6, 4, 6,
+ax_anim 1, 0, 37, -2, -2, -2, -2,
+ax_anim 1, 0, 40, -12, -12, -10, -12,
+ax_anim 1, 1, 42, -21, -22, -21, -22,
+ax_anim 1, 0, 42, -20, -23, -20, -23,
+ax_anim 1, 0, 42, -21, -22, -21, -22,
+ax_anim 1, 0, 42, -20, -23, -20, -23,
+ax_anim 2, 0, 44, -14, -14, -14, -14,
+ax_anim 2, 0, 39, -5, -5, -5, -5,
+ax_anim_terminator
+sGeodudeAnims_2_7:
+ax_anim 3, 0, 42, 1, 0, 1, 0,
+ax_anim 3, 0, 40, 4, -1, 4, 0,
+ax_anim 2, 0, 41, 6, -1, 5, 0,
+ax_anim 2, 0, 41, 6, -2, 5, -1,
+ax_anim 2, 0, 41, 6, -1, 5, 0,
+ax_anim 2, 2, 41, 6, -2, 5, -1,
+ax_anim 1, 0, 44, -2, -1, -2, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 1, 1, 46, -21, 0, -21, 0,
+ax_anim 1, 0, 46, -21, -1, -21, -1,
+ax_anim 1, 0, 46, -21, 0, -21, 0,
+ax_anim 1, 0, 46, -21, -1, -21, -1,
+ax_anim 2, 0, 47, -14, -1, -14, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sGeodudeAnims_2_8:
+ax_anim 3, 0, 45, 1, -1, 1, -1,
+ax_anim 3, 0, 42, 3, -3, 3, -3,
+ax_anim 2, 0, 44, 6, -6, 6, -6,
+ax_anim 2, 0, 44, 5, -7, 5, -7,
+ax_anim 2, 0, 44, 6, -6, 6, -6,
+ax_anim 2, 2, 44, 5, -7, 5, -7,
+ax_anim 1, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 1, 1, 25, -21, 21, -21, 21,
+ax_anim 1, 0, 25, -22, 20, -22, 20,
+ax_anim 1, 0, 25, -21, 21, -21, 21,
+ax_anim 1, 0, 25, -22, 20, -22, 20,
+ax_anim 2, 0, 24, -15, 15, -15, 15,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 2, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 3, 12, 3, 12,
+ax_anim 2, 1, 51, 4, 12, 4, 12,
+ax_anim 2, 0, 51, 3, 12, 3, 12,
+ax_anim 2, 0, 51, 4, 12, 4, 12,
+ax_anim 2, 0, 48, 3, 10, 3, 10,
+ax_anim 2, 0, 48, 1, 4, 1, 4,
+ax_anim_terminator
+sGeodudeAnims_3_2:
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 2, 2, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 12, 12, 12, 12,
+ax_anim 2, 1, 55, 11, 13, 11, 13,
+ax_anim 2, 0, 55, 12, 12, 12, 12,
+ax_anim 2, 0, 55, 11, 13, 11, 13,
+ax_anim 2, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 4, 4, 4, 4,
+ax_anim_terminator
+sGeodudeAnims_3_3:
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 6, 0, 57, -3, 0, -3, 0,
+ax_anim 2, 2, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 9, 0, 9, 0,
+ax_anim 2, 1, 59, 9, -1, 9, -1,
+ax_anim 2, 0, 59, 9, 0, 9, 0,
+ax_anim 2, 0, 59, 9, -1, 9, -1,
+ax_anim 2, 0, 56, 7, 0, 7, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim_terminator
+sGeodudeAnims_3_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 2, 2, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 15, -15, 15, -15,
+ax_anim 2, 1, 63, 14, -16, 14, -16,
+ax_anim 2, 0, 63, 15, -15, 15, -15,
+ax_anim 2, 0, 63, 14, -16, 14, -16,
+ax_anim 2, 0, 60, 10, -10, 10, -10,
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim_terminator
+sGeodudeAnims_3_5:
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 2, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, -2, -15, -2, -15,
+ax_anim 2, 1, 67, -1, -15, -1, -15,
+ax_anim 2, 0, 67, -2, -15, -2, -15,
+ax_anim 2, 0, 67, -1, -15, -1, -15,
+ax_anim 2, 0, 64, -1, -10, -1, -10,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sGeodudeAnims_3_6:
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 2, 2, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, -15, -15, -15, -15,
+ax_anim 2, 1, 71, -14, -16, -14, -16,
+ax_anim 2, 0, 71, -15, -15, -15, -15,
+ax_anim 2, 0, 71, -14, -16, -14, -16,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, -3, -3, -3, -3,
+ax_anim_terminator
+sGeodudeAnims_3_7:
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 6, 0, 73, 3, 0, 3, 0,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -9, 0, -9, 0,
+ax_anim 2, 1, 75, -9, -1, -9, -1,
+ax_anim 2, 0, 75, -9, 0, -9, 0,
+ax_anim 2, 0, 75, -9, -1, -9, -1,
+ax_anim 2, 0, 72, -7, 0, -7, 0,
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim_terminator
+sGeodudeAnims_3_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, -12, 12, -12, 12,
+ax_anim 2, 1, 79, -11, 13, -11, 13,
+ax_anim 2, 0, 79, -12, 12, -12, 12,
+ax_anim 2, 0, 79, -11, 13, -11, 13,
+ax_anim 2, 0, 76, -10, 10, -10, 10,
+ax_anim 2, 0, 76, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_4_1:
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim 4, 0, 82, 0, -5, 0, -5,
+ax_anim 1, 0, 82, 0, -3, 0, -3,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 1, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sGeodudeAnims_4_2:
+ax_anim 2, 0, 85, -2, -2, -2, -2,
+ax_anim 2, 0, 84, -3, -3, -3, -3,
+ax_anim 4, 0, 86, -5, -5, -5, -5,
+ax_anim 1, 0, 86, -3, -3, -3, -3,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 5, 3, 5, 3,
+ax_anim 2, 0, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 5, 3, 5, 3,
+ax_anim 2, 1, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 5, 3, 5, 3,
+ax_anim 2, 0, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 5, 3, 5, 3,
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim_terminator
+sGeodudeAnims_4_3:
+ax_anim 2, 0, 89, -2, 0, -2, 0,
+ax_anim 2, 0, 88, -3, 0, -3, 0,
+ax_anim 4, 0, 90, -5, 0, -5, 0,
+ax_anim 1, 0, 90, -3, 0, -3, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 91, 4, -1, 4, -1,
+ax_anim 2, 0, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 91, 4, -1, 4, -1,
+ax_anim 2, 1, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 91, 4, -1, 4, -1,
+ax_anim 2, 0, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 91, 4, -1, 4, -1,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim_terminator
+sGeodudeAnims_4_4:
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim 2, 0, 92, -3, 3, -3, 3,
+ax_anim 4, 0, 94, -5, 5, -5, 5,
+ax_anim 1, 0, 94, -3, 3, -3, 3,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 1, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 92, 2, -2, 2, -2,
+ax_anim_terminator
+sGeodudeAnims_4_5:
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 2, 0, 96, 0, 4, 0, 4,
+ax_anim 4, 0, 98, 0, 5, 0, 5,
+ax_anim 1, 0, 98, 0, 3, 0, 3,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 1, -4, 1, -4,
+ax_anim 2, 0, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 1, -4, 1, -4,
+ax_anim 2, 1, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 1, -4, 1, -4,
+ax_anim 2, 0, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 1, -4, 1, -4,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim_terminator
+sGeodudeAnims_4_6:
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 100, 3, 3, 3, 3,
+ax_anim 4, 0, 102, 5, 5, 5, 5,
+ax_anim 1, 0, 102, 3, 3, 3, 3,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -5, -3, -5, -3,
+ax_anim 2, 0, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -5, -3, -5, -3,
+ax_anim 2, 1, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -5, -3, -5, -3,
+ax_anim 2, 0, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -5, -3, -5, -3,
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim_terminator
+sGeodudeAnims_4_7:
+ax_anim 2, 0, 105, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 3, 0, 3, 0,
+ax_anim 4, 0, 106, 5, 0, 5, 0,
+ax_anim 1, 0, 106, 3, 0, 3, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -4, -1, -4, -1,
+ax_anim 2, 0, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -4, -1, -4, -1,
+ax_anim 2, 1, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -4, -1, -4, -1,
+ax_anim 2, 0, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -4, -1, -4, -1,
+ax_anim 2, 0, 104, -2, 0, -2, 0,
+ax_anim_terminator
+sGeodudeAnims_4_8:
+ax_anim 2, 0, 109, 2, -2, 2, -2,
+ax_anim 2, 0, 108, 3, -3, 3, -3,
+ax_anim 4, 0, 110, 5, -5, 5, -5,
+ax_anim 1, 0, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 1, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 108, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_6_1:
+ax_anim 9, 0, 120, 0, 0, 0, 0,
+ax_anim 8, 0, 120, 0, -1, 0, 0,
+ax_anim 20, 0, 120, 0, -2, 0, 0,
+ax_anim 9, 0, 121, 0, -2, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim 20, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sGeodudeAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sGeodudeAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sGeodudeAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sGeodudeAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sGeodudeAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sGeodudeAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sGeodudeAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_8_1:
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 0, -1, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 0, 1, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_8_2:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 137, 0, -1, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 137, 0, 1, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_8_3:
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, -1, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, 1, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_8_4:
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 135, 0, -1, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 135, 0, 1, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_8_5:
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 1, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_8_6:
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 133, 0, -1, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 133, 0, 1, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_8_7:
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 132, 0, -1, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 132, 0, 1, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_8_8:
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 131, 0, -1, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 131, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 17, 7, 17,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -7, 17, -7, 17,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 22, 10, 22, 10,
+ax_anim 3, 0, 141, 21, 20, 21, 20,
+ax_anim 2, 3, 142, 10, 21, 10, 21,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 16, -5, 16, -5,
+ax_anim 3, 0, 140, 23, -2, 23, -2,
+ax_anim 2, 3, 141, 18, 6, 18, 6,
+ax_anim 2, 0, 142, 12, 7, 12, 7,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -22, 12, -22,
+ax_anim 3, 0, 139, 22, -24, 22, -24,
+ax_anim 2, 3, 140, 25, -15, 25, -15,
+ax_anim 2, 0, 141, 20, -6, 20, -6,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -20, -7, -20,
+ax_anim 3, 0, 138, 0, -25, 0, -25,
+ax_anim 2, 3, 139, 7, -20, 7, -20,
+ax_anim 2, 0, 140, 9, -10, 9, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -22, -12, -22,
+ax_anim 3, 0, 145, -22, -24, -22, -24,
+ax_anim 2, 3, 144, -25, -15, -25, -15,
+ax_anim 2, 0, 143, -20, -6, -20, -6,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -16, -5, -16, -5,
+ax_anim 3, 0, 144, -23, -2, -23, -2,
+ax_anim 2, 3, 143, -18, 6, -18, 6,
+ax_anim 2, 0, 142, -12, 7, -12, 7,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -22, 10, -22, 10,
+ax_anim 3, 0, 143, -21, 20, -21, 20,
+ax_anim 2, 3, 142, -10, 21, -10, 21,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_10_2:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 6, -6, 6, -6,
+ax_anim 2, 0, 148, -6, 6, -6, 6,
+ax_anim 2, 0, 148, 10, -10, 10, -10,
+ax_anim 2, 0, 148, -10, 10, -10, 10,
+ax_anim 2, 0, 148, 12, -12, 12, -12,
+ax_anim 3, 0, 148, -12, 12, -12, 12,
+ax_anim 3, 0, 148, 13, -13, 13, -13,
+ax_anim 3, 0, 148, -13, 13, -13, 13,
+ax_anim 2, 0, 148, 12, -12, 12, -12,
+ax_anim 3, 0, 148, -12, 12, -12, 12,
+ax_anim 2, 0, 148, 10, -10, 10, -10,
+ax_anim 2, 0, 148, -10, 10, -10, 10,
+ax_anim 2, 0, 148, 6, -6, 6, -6,
+ax_anim 2, 0, 148, -6, 6, -6, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_10_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -6, 0, -6,
+ax_anim 2, 0, 150, 0, 6, 0, 6,
+ax_anim 2, 0, 150, 0, -10, 0, -10,
+ax_anim 2, 0, 150, 0, 10, 0, 10,
+ax_anim 2, 0, 150, 0, -12, 0, -12,
+ax_anim 3, 0, 150, 0, 12, 0, 12,
+ax_anim 3, 0, 150, 0, -13, 0, -13,
+ax_anim 3, 0, 150, 0, 13, 0, 13,
+ax_anim 2, 0, 150, 0, -12, 0, -12,
+ax_anim 3, 0, 150, 0, 12, 0, 12,
+ax_anim 2, 0, 150, 0, -10, 0, -10,
+ax_anim 2, 0, 150, 0, 10, 0, 10,
+ax_anim 2, 0, 150, 0, -6, 0, -6,
+ax_anim 2, 0, 150, 0, 6, 0, 6,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_10_4:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, -6, -6, -6, -6,
+ax_anim 2, 0, 152, 6, 6, 6, 6,
+ax_anim 2, 0, 152, -10, -10, -10, -10,
+ax_anim 2, 0, 152, 10, 10, 10, 10,
+ax_anim 2, 0, 152, -12, -12, -12, -12,
+ax_anim 3, 0, 152, 12, 12, 12, 12,
+ax_anim 3, 0, 152, -13, -13, -13, -13,
+ax_anim 3, 0, 152, 13, 13, 13, 13,
+ax_anim 2, 0, 152, -12, -12, -12, -12,
+ax_anim 3, 0, 152, 12, 12, 12, 12,
+ax_anim 2, 0, 152, -10, -10, -10, -10,
+ax_anim 2, 0, 152, 10, 10, 10, 10,
+ax_anim 2, 0, 152, -6, -6, -6, -6,
+ax_anim 2, 0, 152, 6, 6, 6, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_10_5:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_10_6:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 6, -6, 6, -6,
+ax_anim 2, 0, 156, -6, 6, -6, 6,
+ax_anim 2, 0, 156, 10, -10, 10, -10,
+ax_anim 2, 0, 156, -10, 10, -10, 10,
+ax_anim 2, 0, 156, 12, -12, 12, -12,
+ax_anim 3, 0, 156, -12, 12, -12, 12,
+ax_anim 3, 0, 156, 13, -13, 13, -13,
+ax_anim 3, 0, 156, -13, 13, -13, 13,
+ax_anim 2, 0, 156, 12, -12, 12, -12,
+ax_anim 3, 0, 156, -12, 12, -12, 12,
+ax_anim 2, 0, 156, 10, -10, 10, -10,
+ax_anim 2, 0, 156, -10, 10, -10, 10,
+ax_anim 2, 0, 156, 6, -6, 6, -6,
+ax_anim 2, 0, 156, -6, 6, -6, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_10_7:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -6, 0, -6,
+ax_anim 2, 0, 158, 0, 6, 0, 6,
+ax_anim 2, 0, 158, 0, -10, 0, -10,
+ax_anim 2, 0, 158, 0, 10, 0, 10,
+ax_anim 2, 0, 158, 0, -12, 0, -12,
+ax_anim 3, 0, 158, 0, 12, 0, 12,
+ax_anim 3, 0, 158, 0, -13, 0, -13,
+ax_anim 3, 0, 158, 0, 13, 0, 13,
+ax_anim 2, 0, 158, 0, -12, 0, -12,
+ax_anim 3, 0, 158, 0, 12, 0, 12,
+ax_anim 2, 0, 158, 0, -10, 0, -10,
+ax_anim 2, 0, 158, 0, 10, 0, 10,
+ax_anim 2, 0, 158, 0, -6, 0, -6,
+ax_anim 2, 0, 158, 0, 6, 0, 6,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_10_8:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, -6, -6, -6, -6,
+ax_anim 2, 0, 160, 6, 6, 6, 6,
+ax_anim 2, 0, 160, -10, -10, -10, -10,
+ax_anim 2, 0, 160, 10, 10, 10, 10,
+ax_anim 2, 0, 160, -12, -12, -12, -12,
+ax_anim 3, 0, 160, 12, 12, 12, 12,
+ax_anim 3, 0, 160, -13, -13, -13, -13,
+ax_anim 3, 0, 160, 13, 13, 13, 13,
+ax_anim 2, 0, 160, -12, -12, -12, -12,
+ax_anim 3, 0, 160, 12, 12, 12, 12,
+ax_anim 2, 0, 160, -10, -10, -10, -10,
+ax_anim 2, 0, 160, 10, 10, 10, 10,
+ax_anim 2, 0, 160, -6, -6, -6, -6,
+ax_anim 2, 0, 160, 6, 6, 6, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -23, 0, 0,
+ax_anim 3, 0, 163, 0, -22, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_11_2:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_11_3:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_11_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -17, 0, 0,
+ax_anim 1, 0, 169, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_11_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_11_6:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_11_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_11_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_12_2:
+ax_anim 2, 0, 181, 1, -1, 1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, 0,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_12_4:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_12_6:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_12_8:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGeodudeAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sGeodudeGfx1:
+.incbin "baserom.gba", 0x835F74, 0x100
+sGeodudeSprites1:
+ax_sprite sGeodudeGfx1, 0x100
+ax_sprite_terminator
+sGeodudeGfx2:
+.incbin "baserom.gba", 0x836084, 0x200
+sGeodudeSprites2:
+ax_sprite sGeodudeGfx2, 0x200
+ax_sprite_terminator
+sGeodudeGfx3:
+.incbin "baserom.gba", 0x836294, 0x200
+sGeodudeSprites3:
+ax_sprite sGeodudeGfx3, 0x200
+ax_sprite_terminator
+sGeodudeGfx4:
+.incbin "baserom.gba", 0x8364A4, 0x200
+sGeodudeSprites4:
+ax_sprite sGeodudeGfx4, 0x200
+ax_sprite_terminator
+sGeodudeGfx5:
+.incbin "baserom.gba", 0x8366B4, 0x100
+sGeodudeSprites5:
+ax_sprite sGeodudeGfx5, 0x100
+ax_sprite_terminator
+sGeodudeGfx6:
+.incbin "baserom.gba", 0x8367C4, 0x200
+sGeodudeSprites6:
+ax_sprite sGeodudeGfx6, 0x200
+ax_sprite_terminator
+sGeodudeGfx7:
+.incbin "baserom.gba", 0x8369D4, 0x100
+sGeodudeSprites7:
+ax_sprite sGeodudeGfx7, 0x100
+ax_sprite_terminator
+sGeodudeGfx8:
+.incbin "baserom.gba", 0x836AE4, 0x200
+sGeodudeSprites8:
+ax_sprite sGeodudeGfx8, 0x200
+ax_sprite_terminator
+sGeodudeGfx9:
+.incbin "baserom.gba", 0x836CF4, 0x100
+sGeodudeSprites9:
+ax_sprite sGeodudeGfx9, 0x100
+ax_sprite_terminator
+sGeodudeGfx10:
+.incbin "baserom.gba", 0x836E04, 0x200
+sGeodudeSprites10:
+ax_sprite sGeodudeGfx10, 0x200
+ax_sprite_terminator
+sGeodudeGfx11:
+.incbin "baserom.gba", 0x837014, 0x100
+sGeodudeSprites11:
+ax_sprite sGeodudeGfx11, 0x100
+ax_sprite_terminator
+sGeodudeGfx12:
+.incbin "baserom.gba", 0x837124, 0x200
+sGeodudeSprites12:
+ax_sprite sGeodudeGfx12, 0x200
+ax_sprite_terminator
+sGeodudeGfx13:
+.incbin "baserom.gba", 0x837334, 0x100
+sGeodudeSprites13:
+ax_sprite sGeodudeGfx13, 0x100
+ax_sprite_terminator
+sGeodudeGfx14:
+.incbin "baserom.gba", 0x837444, 0x200
+sGeodudeSprites14:
+ax_sprite sGeodudeGfx14, 0x200
+ax_sprite_terminator
+sGeodudeGfx15:
+.incbin "baserom.gba", 0x837654, 0x200
+sGeodudeSprites15:
+ax_sprite sGeodudeGfx15, 0x200
+ax_sprite_terminator
+sGeodudeGfx16:
+.incbin "baserom.gba", 0x837864, 0x200
+sGeodudeSprites16:
+ax_sprite sGeodudeGfx16, 0x200
+ax_sprite_terminator
+sGeodudeGfx17:
+.incbin "baserom.gba", 0x837A74, 0x180
+sGeodudeSprites17:
+ax_sprite sGeodudeGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGeodudeGfx18:
+.incbin "baserom.gba", 0x837C0C, 0x40
+sGeodudeGfx18_1:
+.incbin "baserom.gba", 0x837C4C, 0x40
+sGeodudeGfx18_2:
+.incbin "baserom.gba", 0x837C8C, 0x60
+sGeodudeGfx18_3:
+.incbin "baserom.gba", 0x837CEC, 0x20
+sGeodudeSprites18:
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGeodudeGfx19:
+.incbin "baserom.gba", 0x837D5C, 0x100
+sGeodudeSprites19:
+ax_sprite sGeodudeGfx19, 0x100
+ax_sprite_terminator
+sGeodudeGfx20:
+.incbin "baserom.gba", 0x837E6C, 0x40
+sGeodudeGfx20_1:
+.incbin "baserom.gba", 0x837EAC, 0x60
+sGeodudeGfx20_2:
+.incbin "baserom.gba", 0x837F0C, 0x40
+sGeodudeGfx20_3:
+.incbin "baserom.gba", 0x837F4C, 0x60
+sGeodudeSprites20:
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGeodudeGfx21:
+.incbin "baserom.gba", 0x837FFC, 0x60
+sGeodudeGfx21_1:
+.incbin "baserom.gba", 0x83805C, 0x80
+sGeodudeGfx21_2:
+.incbin "baserom.gba", 0x8380DC, 0x40
+sGeodudeSprites21:
+ax_sprite sGeodudeGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx21_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx21_2, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGeodudeGfx22:
+.incbin "baserom.gba", 0x838154, 0x20
+sGeodudeGfx22_1:
+.incbin "baserom.gba", 0x838174, 0x80
+sGeodudeGfx22_2:
+.incbin "baserom.gba", 0x8381F4, 0x60
+sGeodudeGfx22_3:
+.incbin "baserom.gba", 0x838254, 0x40
+sGeodudeSprites22:
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx22_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGeodudeGfx23:
+.incbin "baserom.gba", 0x8382E4, 0x40
+sGeodudeGfx23_1:
+.incbin "baserom.gba", 0x838324, 0x40
+sGeodudeGfx23_2:
+.incbin "baserom.gba", 0x838364, 0x40
+sGeodudeGfx23_3:
+.incbin "baserom.gba", 0x8383A4, 0x40
+sGeodudeSprites23:
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx23_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx23_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGeodudeGfx24:
+.incbin "baserom.gba", 0x838434, 0xC0
+sGeodudeGfx24_1:
+.incbin "baserom.gba", 0x8384F4, 0x40
+sGeodudeSprites24:
+ax_sprite 0, 0xa0
+ax_sprite sGeodudeGfx24, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGeodudeGfx25:
+.incbin "baserom.gba", 0x838564, 0x60
+sGeodudeGfx25_1:
+.incbin "baserom.gba", 0x8385C4, 0x60
+sGeodudeGfx25_2:
+.incbin "baserom.gba", 0x838624, 0x40
+sGeodudeSprites25:
+ax_sprite sGeodudeGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGeodudeGfx26:
+.incbin "baserom.gba", 0x83869C, 0x60
+sGeodudeGfx26_1:
+.incbin "baserom.gba", 0x8386FC, 0x40
+sGeodudeSprites26:
+ax_sprite 0, 0x80
+ax_sprite sGeodudeGfx26, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx26_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGeodudeGfx27:
+.incbin "baserom.gba", 0x83876C, 0xC0
+sGeodudeGfx27_1:
+.incbin "baserom.gba", 0x83882C, 0x40
+sGeodudeSprites27:
+ax_sprite sGeodudeGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx27_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sGeodudeGfx28:
+.incbin "baserom.gba", 0x838894, 0x20
+sGeodudeGfx28_1:
+.incbin "baserom.gba", 0x8388B4, 0x40
+sGeodudeSprites28:
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGeodudeGfx29:
+.incbin "baserom.gba", 0x838924, 0x80
+sGeodudeSprites29:
+ax_sprite sGeodudeGfx29, 0x80
+ax_sprite_terminator
+sGeodudeGfx30:
+.incbin "baserom.gba", 0x8389B4, 0x20
+sGeodudeSprites30:
+ax_sprite sGeodudeGfx30, 0x20
+ax_sprite_terminator
+sGeodudeGfx31:
+.incbin "baserom.gba", 0x8389E4, 0x40
+sGeodudeGfx31_1:
+.incbin "baserom.gba", 0x838A24, 0x60
+sGeodudeGfx31_2:
+.incbin "baserom.gba", 0x838A84, 0x60
+sGeodudeSprites31:
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGeodudeGfx32:
+.incbin "baserom.gba", 0x838B24, 0x40
+sGeodudeGfx32_1:
+.incbin "baserom.gba", 0x838B64, 0x60
+sGeodudeGfx32_2:
+.incbin "baserom.gba", 0x838BC4, 0x60
+sGeodudeGfx32_3:
+.incbin "baserom.gba", 0x838C24, 0x20
+sGeodudeSprites32:
+ax_sprite sGeodudeGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx32_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx32_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sGeodudeGfx32_3, 0x20
+ax_sprite_terminator
+sGeodudeGfx33:
+.incbin "baserom.gba", 0x838C84, 0x100
+sGeodudeGfx33_1:
+.incbin "baserom.gba", 0x838D84, 0x20
+sGeodudeGfx33_2:
+.incbin "baserom.gba", 0x838DA4, 0x20
+sGeodudeSprites33:
+ax_sprite sGeodudeGfx33, 0x100
+ax_sprite 0, 0x60
+ax_sprite sGeodudeGfx33_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGeodudeGfx33_2, 0x20
+ax_sprite_terminator
+sGeodudeGfx34:
+.incbin "baserom.gba", 0x838DF4, 0x60
+sGeodudeGfx34_1:
+.incbin "baserom.gba", 0x838E54, 0x40
+sGeodudeGfx34_2:
+.incbin "baserom.gba", 0x838E94, 0x40
+sGeodudeGfx34_3:
+.incbin "baserom.gba", 0x838ED4, 0x20
+sGeodudeSprites34:
+ax_sprite sGeodudeGfx34, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx34_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sGeodudeGfx34_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGeodudeGfx35:
+.incbin "baserom.gba", 0x838F3C, 0x100
+sGeodudeSprites35:
+ax_sprite sGeodudeGfx35, 0x100
+ax_sprite_terminator
+sGeodudeGfx36:
+.incbin "baserom.gba", 0x83904C, 0x40
+sGeodudeGfx36_1:
+.incbin "baserom.gba", 0x83908C, 0x60
+sGeodudeGfx36_2:
+.incbin "baserom.gba", 0x8390EC, 0x40
+sGeodudeGfx36_3:
+.incbin "baserom.gba", 0x83912C, 0x40
+sGeodudeSprites36:
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx36_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx36_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sGeodudeGfx36_3, 0x40
+ax_sprite_terminator
+sGeodudeGfx37:
+.incbin "baserom.gba", 0x8391B4, 0x80
+sGeodudeGfx37_1:
+.incbin "baserom.gba", 0x839234, 0x20
+sGeodudeGfx37_2:
+.incbin "baserom.gba", 0x839254, 0x20
+sGeodudeSprites37:
+ax_sprite sGeodudeGfx37, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx37_2, 0x20
+ax_sprite_terminator
+sGeodudeGfx38:
+.incbin "baserom.gba", 0x8392A4, 0x40
+sGeodudeGfx38_1:
+.incbin "baserom.gba", 0x8392E4, 0x40
+sGeodudeGfx38_2:
+.incbin "baserom.gba", 0x839324, 0x60
+sGeodudeGfx38_3:
+.incbin "baserom.gba", 0x839384, 0x40
+sGeodudeSprites38:
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx38_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx38_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGeodudeGfx39:
+.incbin "baserom.gba", 0x839414, 0x100
+sGeodudeSprites39:
+ax_sprite sGeodudeGfx39, 0x100
+ax_sprite_terminator
+sGeodudeGfx40:
+.incbin "baserom.gba", 0x839524, 0x20
+sGeodudeSprites40:
+ax_sprite sGeodudeGfx40, 0x20
+ax_sprite_terminator
+sGeodudeGfx41:
+.incbin "baserom.gba", 0x839554, 0x20
+sGeodudeSprites41:
+ax_sprite sGeodudeGfx41, 0x20
+ax_sprite_terminator
+sGeodudeGfx42:
+.incbin "baserom.gba", 0x839584, 0x60
+sGeodudeGfx42_1:
+.incbin "baserom.gba", 0x8395E4, 0x80
+sGeodudeSprites42:
+ax_sprite sGeodudeGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx42_1, 0x80
+ax_sprite_terminator
+sGeodudeGfx43:
+.incbin "baserom.gba", 0x839684, 0x20
+sGeodudeSprites43:
+ax_sprite sGeodudeGfx43, 0x20
+ax_sprite_terminator
+sGeodudeGfx44:
+.incbin "baserom.gba", 0x8396B4, 0x20
+sGeodudeSprites44:
+ax_sprite sGeodudeGfx44, 0x20
+ax_sprite_terminator
+sGeodudeGfx45:
+.incbin "baserom.gba", 0x8396E4, 0x40
+sGeodudeGfx45_1:
+.incbin "baserom.gba", 0x839724, 0x60
+sGeodudeGfx45_2:
+.incbin "baserom.gba", 0x839784, 0x60
+sGeodudeSprites45:
+ax_sprite 0, 0xa0
+ax_sprite sGeodudeGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGeodudeGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx45_2, 0x60
+ax_sprite_terminator
+sGeodudeGfx46:
+.incbin "baserom.gba", 0x83981C, 0x120
+sGeodudeSprites46:
+ax_sprite 0, 0xa0
+ax_sprite sGeodudeGfx46, 0x120
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGeodudeGfx47:
+.incbin "baserom.gba", 0x83995C, 0x40
+sGeodudeGfx47_1:
+.incbin "baserom.gba", 0x83999C, 0x80
+sGeodudeSprites47:
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx47, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGeodudeGfx47_1, 0x80
+ax_sprite_terminator
+sGeodudeGfx48:
+.incbin "baserom.gba", 0x839A44, 0x20
+sGeodudeSprites48:
+ax_sprite sGeodudeGfx48, 0x20
+ax_sprite_terminator
+sGeodudeGfx49:
+.incbin "baserom.gba", 0x839A74, 0x20
+sGeodudeSprites49:
+ax_sprite sGeodudeGfx49, 0x20
+ax_sprite_terminator
+sGeodudeGfx50:
+.incbin "baserom.gba", 0x839AA4, 0x200
+sGeodudeSprites50:
+ax_sprite sGeodudeGfx50, 0x200
+ax_sprite_terminator
+sGeodudeGfx51:
+.incbin "baserom.gba", 0x839CB4, 0x200
+sGeodudeSprites51:
+ax_sprite sGeodudeGfx51, 0x200
+ax_sprite_terminator
+sGeodudeGfx52:
+.incbin "baserom.gba", 0x839EC4, 0x200
+sGeodudeSprites52:
+ax_sprite sGeodudeGfx52, 0x200
+ax_sprite_terminator
+sGeodudeGfx53:
+.incbin "baserom.gba", 0x83A0D4, 0x200
+sGeodudeSprites53:
+ax_sprite sGeodudeGfx53, 0x200
+ax_sprite_terminator
+sGeodudeGfx54:
+.incbin "baserom.gba", 0x83A2E4, 0x200
+sGeodudeSprites54:
+ax_sprite sGeodudeGfx54, 0x200
+ax_sprite_terminator
+sGeodudeGfx55:
+.incbin "baserom.gba", 0x83A4F4, 0x200
+sGeodudeSprites55:
+ax_sprite sGeodudeGfx55, 0x200
+ax_sprite_terminator
+sGeodudeGfx56:
+.incbin "baserom.gba", 0x83A704, 0x200
+sGeodudeSprites56:
+ax_sprite sGeodudeGfx56, 0x200
+ax_sprite_terminator
+sGeodudeGfx57:
+.incbin "baserom.gba", 0x83A914, 0x100
+sGeodudeSprites57:
+ax_sprite sGeodudeGfx57, 0x100
+ax_sprite_terminator
+sAxPosesGeodude:
+.4byte sGeodudePose1
+.4byte sGeodudePose2
+.4byte sGeodudePose3
+.4byte sGeodudePose4
+.4byte sGeodudePose5
+.4byte sGeodudePose6
+.4byte sGeodudePose7
+.4byte sGeodudePose8
+.4byte sGeodudePose9
+.4byte sGeodudePose10
+.4byte sGeodudePose11
+.4byte sGeodudePose12
+.4byte sGeodudePose13
+.4byte sGeodudePose14
+.4byte sGeodudePose15
+.4byte sGeodudePose16
+.4byte sGeodudePose17
+.4byte sGeodudePose18
+.4byte sGeodudePose19
+.4byte sGeodudePose20
+.4byte sGeodudePose21
+.4byte sGeodudePose22
+.4byte sGeodudePose23
+.4byte sGeodudePose24
+.4byte sGeodudePose25
+.4byte sGeodudePose26
+.4byte sGeodudePose27
+.4byte sGeodudePose28
+.4byte sGeodudePose29
+.4byte sGeodudePose30
+.4byte sGeodudePose31
+.4byte sGeodudePose32
+.4byte sGeodudePose33
+.4byte sGeodudePose34
+.4byte sGeodudePose35
+.4byte sGeodudePose36
+.4byte sGeodudePose37
+.4byte sGeodudePose38
+.4byte sGeodudePose39
+.4byte sGeodudePose40
+.4byte sGeodudePose41
+.4byte sGeodudePose42
+.4byte sGeodudePose43
+.4byte sGeodudePose44
+.4byte sGeodudePose45
+.4byte sGeodudePose46
+.4byte sGeodudePose47
+.4byte sGeodudePose48
+.4byte sGeodudePose49
+.4byte sGeodudePose50
+.4byte sGeodudePose51
+.4byte sGeodudePose52
+.4byte sGeodudePose53
+.4byte sGeodudePose54
+.4byte sGeodudePose55
+.4byte sGeodudePose56
+.4byte sGeodudePose57
+.4byte sGeodudePose58
+.4byte sGeodudePose59
+.4byte sGeodudePose60
+.4byte sGeodudePose61
+.4byte sGeodudePose62
+.4byte sGeodudePose63
+.4byte sGeodudePose64
+.4byte sGeodudePose65
+.4byte sGeodudePose66
+.4byte sGeodudePose67
+.4byte sGeodudePose68
+.4byte sGeodudePose69
+.4byte sGeodudePose70
+.4byte sGeodudePose71
+.4byte sGeodudePose72
+.4byte sGeodudePose73
+.4byte sGeodudePose74
+.4byte sGeodudePose75
+.4byte sGeodudePose76
+.4byte sGeodudePose77
+.4byte sGeodudePose78
+.4byte sGeodudePose79
+.4byte sGeodudePose80
+.4byte sGeodudePose81
+.4byte sGeodudePose82
+.4byte sGeodudePose83
+.4byte sGeodudePose84
+.4byte sGeodudePose85
+.4byte sGeodudePose86
+.4byte sGeodudePose87
+.4byte sGeodudePose88
+.4byte sGeodudePose89
+.4byte sGeodudePose90
+.4byte sGeodudePose91
+.4byte sGeodudePose92
+.4byte sGeodudePose93
+.4byte sGeodudePose94
+.4byte sGeodudePose95
+.4byte sGeodudePose96
+.4byte sGeodudePose97
+.4byte sGeodudePose98
+.4byte sGeodudePose99
+.4byte sGeodudePose100
+.4byte sGeodudePose101
+.4byte sGeodudePose102
+.4byte sGeodudePose103
+.4byte sGeodudePose104
+.4byte sGeodudePose105
+.4byte sGeodudePose106
+.4byte sGeodudePose107
+.4byte sGeodudePose108
+.4byte sGeodudePose109
+.4byte sGeodudePose110
+.4byte sGeodudePose111
+.4byte sGeodudePose112
+.4byte sGeodudePose113
+.4byte sGeodudePose114
+.4byte sGeodudePose115
+.4byte sGeodudePose116
+.4byte sGeodudePose117
+.4byte sGeodudePose118
+.4byte sGeodudePose119
+.4byte sGeodudePose120
+.4byte sGeodudePose121
+.4byte sGeodudePose122
+.4byte sGeodudePose123
+.4byte sGeodudePose124
+.4byte sGeodudePose125
+.4byte sGeodudePose126
+.4byte sGeodudePose127
+.4byte sGeodudePose128
+.4byte sGeodudePose129
+.4byte sGeodudePose130
+.4byte sGeodudePose131
+.4byte sGeodudePose132
+.4byte sGeodudePose133
+.4byte sGeodudePose134
+.4byte sGeodudePose135
+.4byte sGeodudePose136
+.4byte sGeodudePose137
+.4byte sGeodudePose138
+.4byte sGeodudePose139
+.4byte sGeodudePose140
+.4byte sGeodudePose141
+.4byte sGeodudePose142
+.4byte sGeodudePose143
+.4byte sGeodudePose144
+.4byte sGeodudePose145
+.4byte sGeodudePose146
+.4byte sGeodudePose147
+.4byte sGeodudePose148
+.4byte sGeodudePose149
+.4byte sGeodudePose150
+.4byte sGeodudePose151
+.4byte sGeodudePose152
+.4byte sGeodudePose153
+.4byte sGeodudePose154
+.4byte sGeodudePose155
+.4byte sGeodudePose156
+.4byte sGeodudePose157
+.4byte sGeodudePose158
+.4byte sGeodudePose159
+.4byte sGeodudePose160
+.4byte sGeodudePose161
+.4byte sGeodudePose162
+.4byte sGeodudePose163
+.4byte sGeodudePose164
+.4byte sGeodudePose165
+.4byte sGeodudePose166
+.4byte sGeodudePose167
+.4byte sGeodudePose168
+.4byte sGeodudePose169
+.4byte sGeodudePose170
+.4byte sGeodudePose171
+.4byte sGeodudePose172
+.4byte sGeodudePose173
+.4byte sGeodudePose174
+.4byte sGeodudePose175
+.4byte sGeodudePose176
+.4byte sGeodudePose177
+.4byte sGeodudePose178
+.4byte sGeodudePose179
+.4byte sGeodudePose180
+.4byte sGeodudePose181
+.4byte sGeodudePose182
+.4byte sGeodudePose183
+.4byte sGeodudePose184
+.4byte sGeodudePose185
+.4byte sGeodudePose186
+.4byte sGeodudePose187
+.4byte sGeodudePose188
+.4byte sGeodudePose189
+.4byte sGeodudePose190
+.4byte sGeodudePose191
+.4byte sGeodudePose192
+.4byte sGeodudePose193
+.4byte sGeodudePose194
+.4byte sGeodudePose195
+.4byte sGeodudePose196
+.4byte sGeodudePose197
+.4byte sGeodudePose198
+.4byte sGeodudePose199
+.4byte sGeodudePose200
+.4byte sGeodudePose201
+.4byte sGeodudePose202
+.4byte sGeodudePose203
+.4byte sGeodudePose204
+.4byte sGeodudePose205
+.4byte sGeodudePose206
+.4byte sGeodudePose207
+.4byte sGeodudePose208
+.4byte sGeodudePose209
+.4byte sGeodudePose210
+sAxPositionsGeodude:
+.2byte    0,   -4, 	 -12,  -11, 	  11,  -13, 	   0,   -7
+.2byte    0,   -3, 	  -9,   -8, 	   7,  -15, 	   1,   -6
+.2byte   -1,   -3, 	  -9,  -15, 	   8,   -9, 	  -2,   -6
+.2byte    1,   -4, 	   9,  -16, 	 -10,  -10, 	  -1,   -7
+.2byte    0,   -3, 	  11,  -12, 	 -11,  -12, 	  -2,   -6
+.2byte    1,   -3, 	   6,  -16, 	  -5,   -7, 	   0,   -6
+.2byte    3,   -4, 	   2,  -18, 	  -5,   -9, 	  -1,   -7
+.2byte    3,   -4, 	   6,  -15, 	  -8,   -9, 	  -1,   -6
+.2byte    4,   -5, 	  -2,  -17, 	   3,   -8, 	   0,   -7
+.2byte    4,   -7, 	  -6,  -18, 	   6,  -10, 	   0,   -7
+.2byte    5,   -5, 	  -1,  -17, 	   2,   -8, 	   0,   -6
+.2byte    4,   -6, 	  -8,  -15, 	   9,  -10, 	   0,   -6
+.2byte   -1,   -8, 	   9,  -12, 	 -10,  -12, 	  -1,   -7
+.2byte   -1,   -7, 	   7,  -14, 	  -9,   -8, 	   0,   -6
+.2byte    1,   -7, 	   8,   -8, 	  -8,  -14, 	   0,   -6
+.2byte   -5,   -7, 	   5,  -18, 	  -7,  -10, 	  -1,   -7
+.2byte   -6,   -5, 	   0,  -17, 	  -3,   -8, 	  -1,   -6
+.2byte   -5,   -6, 	   7,  -15, 	 -10,  -10, 	  -1,   -6
+.2byte   -4,   -4, 	  -3,  -18, 	   4,   -9, 	   0,   -7
+.2byte   -4,   -4, 	  -7,  -15, 	   7,   -9, 	   0,   -6
+.2byte   -5,   -5, 	   1,  -17, 	  -4,   -8, 	  -1,   -7
+.2byte   -2,   -4, 	 -10,  -16, 	   9,  -10, 	   0,   -7
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -12, 	   1,   -6
+.2byte   -2,   -3, 	  -7,  -16, 	   4,   -7, 	  -1,   -6
+.2byte    0,   -4, 	 -12,  -11, 	  11,  -13, 	   0,   -7
+.2byte    0,   -3, 	  -9,   -8, 	   7,  -15, 	   1,   -6
+.2byte   -1,   -3, 	  -9,  -15, 	   8,   -9, 	  -2,   -6
+.2byte    1,   -4, 	   9,  -16, 	 -10,  -10, 	  -1,   -7
+.2byte    0,   -3, 	  11,  -12, 	 -11,  -12, 	  -2,   -6
+.2byte    1,   -3, 	   6,  -16, 	  -5,   -7, 	   0,   -6
+.2byte    3,   -4, 	   2,  -18, 	  -5,   -9, 	  -1,   -7
+.2byte    3,   -4, 	   6,  -15, 	  -8,   -9, 	  -1,   -6
+.2byte    4,   -5, 	  -2,  -17, 	   3,   -8, 	   0,   -7
+.2byte    4,   -7, 	  -6,  -18, 	   6,  -10, 	   0,   -7
+.2byte    5,   -5, 	  -1,  -17, 	   2,   -8, 	   0,   -6
+.2byte    4,   -6, 	  -8,  -15, 	   9,  -10, 	   0,   -6
+.2byte   -1,   -8, 	   9,  -12, 	 -10,  -12, 	  -1,   -7
+.2byte   -1,   -7, 	   7,  -14, 	  -9,   -8, 	   0,   -6
+.2byte    1,   -7, 	   8,   -8, 	  -8,  -14, 	   0,   -6
+.2byte   -5,   -7, 	   5,  -18, 	  -7,  -10, 	  -1,   -7
+.2byte   -6,   -5, 	   0,  -17, 	  -3,   -8, 	  -1,   -6
+.2byte   -5,   -6, 	   7,  -15, 	 -10,  -10, 	  -1,   -6
+.2byte   -4,   -4, 	  -3,  -18, 	   4,   -9, 	   0,   -7
+.2byte   -4,   -4, 	  -7,  -15, 	   7,   -9, 	   0,   -6
+.2byte   -5,   -5, 	   1,  -17, 	  -4,   -8, 	  -1,   -7
+.2byte   -2,   -4, 	 -10,  -16, 	   9,  -10, 	   0,   -7
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -12, 	   1,   -6
+.2byte   -2,   -3, 	  -7,  -16, 	   4,   -7, 	  -1,   -6
+.2byte    0,   -4, 	 -11,    0, 	  10,   -1, 	   0,   -7
+.2byte   -2,   -6, 	  -7,    0, 	  -2,  -18, 	   0,   -8
+.2byte    2,   -3, 	  -5,    7, 	   6,  -15, 	   0,   -7
+.2byte    2,   -3, 	  -5,    7, 	   6,  -15, 	   0,   -7
+.2byte    1,   -4, 	  12,   -6, 	  -6,    2, 	  -1,   -7
+.2byte    0,   -4, 	   0,    2, 	   5,  -14, 	  -2,   -6
+.2byte   -1,    0, 	  12,    5, 	 -12,  -11, 	   0,   -5
+.2byte   -1,    0, 	  12,    5, 	 -12,  -11, 	   0,   -5
+.2byte    3,   -4, 	   9,  -11, 	   4,    1, 	   0,   -7
+.2byte    3,   -5, 	  -3,   -1, 	   9,  -12, 	   1,   -7
+.2byte    0,   -1, 	  15,   -3, 	 -14,   -2, 	  -1,   -5
+.2byte    0,   -1, 	  15,   -3, 	 -14,   -2, 	  -1,   -5
+.2byte    5,   -7, 	  -4,  -12, 	  11,   -5, 	  -1,   -7
+.2byte    0,   -7, 	 -13,   -1, 	   5,  -16, 	  -2,   -7
+.2byte    2,   -3, 	   7,  -20, 	  -4,    6, 	  -1,   -7
+.2byte    2,   -3, 	   7,  -20, 	  -4,    6, 	  -1,   -7
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte    0,   -8, 	  11,    6, 	  -2,  -18, 	   0,   -5
+.2byte   -3,   -5, 	   2,  -18, 	  -7,    6, 	  -1,   -4
+.2byte   -3,   -5, 	   2,  -18, 	  -7,    6, 	  -1,   -4
+.2byte   -6,   -7, 	   3,  -12, 	 -12,   -5, 	   0,   -7
+.2byte   -1,   -7, 	  12,   -1, 	  -6,  -16, 	   1,   -7
+.2byte   -3,   -3, 	  -8,  -20, 	   3,    6, 	   0,   -7
+.2byte   -3,   -3, 	  -8,  -20, 	   3,    6, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -11, 	  -5,    1, 	  -1,   -7
+.2byte   -4,   -5, 	   2,   -1, 	 -10,  -12, 	  -2,   -7
+.2byte   -1,   -1, 	 -16,   -3, 	  13,   -2, 	   0,   -5
+.2byte   -1,   -1, 	 -16,   -3, 	  13,   -2, 	   0,   -5
+.2byte   -2,   -4, 	 -13,   -6, 	   5,    2, 	   0,   -7
+.2byte   -1,   -4, 	  -1,    2, 	  -6,  -14, 	   1,   -6
+.2byte    0,    0, 	 -13,    5, 	  11,  -11, 	  -1,   -5
+.2byte    0,    0, 	 -13,    5, 	  11,  -11, 	  -1,   -5
+.2byte    0,   -4, 	 -12,  -11, 	  11,  -13, 	   0,   -7
+.2byte    0,   -3, 	  -9,   -8, 	   7,  -15, 	   1,   -6
+.2byte   -1,   -3, 	  -9,  -15, 	   8,   -9, 	  -2,   -6
+.2byte    0,   -2, 	 -17,   -3, 	  16,   -3, 	   0,   -6
+.2byte    1,   -4, 	   9,  -16, 	 -10,  -10, 	  -1,   -7
+.2byte    0,   -3, 	  11,  -12, 	 -11,  -12, 	  -2,   -6
+.2byte    1,   -3, 	   6,  -16, 	  -5,   -7, 	   0,   -6
+.2byte    0,   -2, 	  12,   -5, 	 -16,    0, 	  -2,   -7
+.2byte    3,   -4, 	   2,  -18, 	  -5,   -9, 	  -1,   -7
+.2byte    3,   -4, 	   6,  -15, 	  -8,   -9, 	  -1,   -6
+.2byte    4,   -5, 	  -2,  -17, 	   3,   -8, 	   0,   -7
+.2byte    1,   -1, 	   5,   -2, 	  -9,    5, 	   0,   -6
+.2byte    4,   -7, 	  -6,  -18, 	   6,  -10, 	   0,   -7
+.2byte    5,   -5, 	  -1,  -17, 	   2,   -8, 	   0,   -6
+.2byte    4,   -6, 	  -8,  -15, 	   9,  -10, 	   0,   -6
+.2byte    2,   -4, 	  -6,   -8, 	  10,    2, 	  -1,   -7
+.2byte   -1,   -8, 	   9,  -12, 	 -10,  -12, 	  -1,   -7
+.2byte   -1,   -7, 	   7,  -14, 	  -9,   -8, 	   0,   -6
+.2byte    1,   -7, 	   8,   -8, 	  -8,  -14, 	   0,   -6
+.2byte    0,  -11, 	  15,   -1, 	 -16,   -1, 	   0,   -6
+.2byte   -5,   -7, 	   5,  -18, 	  -7,  -10, 	  -1,   -7
+.2byte   -6,   -5, 	   0,  -17, 	  -3,   -8, 	  -1,   -6
+.2byte   -5,   -6, 	   7,  -15, 	 -10,  -10, 	  -1,   -6
+.2byte   -3,   -4, 	   5,   -8, 	 -11,    2, 	   0,   -7
+.2byte   -4,   -4, 	  -3,  -18, 	   4,   -9, 	   0,   -7
+.2byte   -4,   -4, 	  -7,  -15, 	   7,   -9, 	   0,   -6
+.2byte   -5,   -5, 	   1,  -17, 	  -4,   -8, 	  -1,   -7
+.2byte   -2,   -1, 	  -6,   -2, 	   8,    5, 	  -1,   -6
+.2byte   -2,   -4, 	 -10,  -16, 	   9,  -10, 	   0,   -7
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -12, 	   1,   -6
+.2byte   -2,   -3, 	  -7,  -16, 	   4,   -7, 	  -1,   -6
+.2byte   -1,   -2, 	 -13,   -5, 	  15,    0, 	   1,   -7
+.2byte    0,   -4, 	 -11,    0, 	  10,   -1, 	   0,   -7
+.2byte   -2,   -4, 	 -13,   -6, 	   5,    2, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -11, 	  -5,    1, 	  -1,   -7
+.2byte   -6,   -7, 	   3,  -12, 	 -12,   -5, 	   0,   -7
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte    5,   -7, 	  -4,  -12, 	  11,   -5, 	  -1,   -7
+.2byte    3,   -4, 	   9,  -11, 	   4,    1, 	   0,   -7
+.2byte    1,   -4, 	  12,   -6, 	  -6,    2, 	  -1,   -7
+.2byte   -1,   -5, 	 -11,   -3, 	   9,    3, 	   0,   -8
+.2byte   -1,   -4, 	 -11,   -2, 	   9,    4, 	  -1,   -7
+.2byte    0,   -3, 	  -8,    1, 	   7,    1, 	   0,   -6
+.2byte   -1,   -3, 	   8,   -1, 	  -4,    3, 	  -1,   -6
+.2byte   -1,   -3, 	   8,   -7, 	   5,    0, 	  -1,   -6
+.2byte    3,   -4, 	  -1,  -10, 	   8,   -5, 	  -1,   -6
+.2byte    0,   -4, 	   7,   -8, 	  -8,   -8, 	   0,   -6
+.2byte   -4,   -4, 	   0,  -10, 	  -9,   -5, 	   0,   -6
+.2byte    0,   -3, 	  -9,   -7, 	  -6,    0, 	   0,   -6
+.2byte    0,   -3, 	  -9,   -1, 	   3,    3, 	   0,   -6
+.2byte    0,   -4, 	 -11,    0, 	  10,   -1, 	   0,   -7
+.2byte   -2,   -4, 	 -13,   -6, 	   5,    2, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -11, 	  -5,    1, 	  -1,   -7
+.2byte   -6,   -7, 	   3,  -12, 	 -12,   -5, 	   0,   -7
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte    5,   -7, 	  -4,  -12, 	  11,   -5, 	  -1,   -7
+.2byte    3,   -4, 	   9,  -11, 	   4,    1, 	   0,   -7
+.2byte    1,   -4, 	  12,   -6, 	  -6,    2, 	  -1,   -7
+.2byte    0,   -4, 	 -12,  -11, 	  11,  -13, 	   0,   -7
+.2byte   -2,   -4, 	 -10,  -16, 	   9,  -10, 	   0,   -7
+.2byte   -4,   -4, 	  -3,  -18, 	   4,   -9, 	   0,   -7
+.2byte   -5,   -7, 	   5,  -18, 	  -7,  -10, 	  -1,   -7
+.2byte   -1,   -8, 	   9,  -12, 	 -10,  -12, 	  -1,   -7
+.2byte    4,   -7, 	  -6,  -18, 	   6,  -10, 	   0,   -7
+.2byte    3,   -4, 	   2,  -18, 	  -5,   -9, 	  -1,   -7
+.2byte    1,   -4, 	   9,  -16, 	 -10,  -10, 	  -1,   -7
+.2byte    0,   -4, 	 -12,  -11, 	  11,  -13, 	   0,   -7
+.2byte    0,   -4, 	 -11,    0, 	  10,   -1, 	   0,   -7
+.2byte    1,   -4, 	   9,  -16, 	 -10,  -10, 	  -1,   -7
+.2byte    1,   -4, 	  12,   -6, 	  -6,    2, 	  -1,   -7
+.2byte    3,   -4, 	   2,  -18, 	  -5,   -9, 	  -1,   -7
+.2byte    3,   -4, 	   9,  -11, 	   4,    1, 	   0,   -7
+.2byte    4,   -7, 	  -6,  -18, 	   6,  -10, 	   0,   -7
+.2byte    5,   -7, 	  -4,  -12, 	  11,   -5, 	  -1,   -7
+.2byte   -1,   -8, 	   9,  -12, 	 -10,  -12, 	  -1,   -7
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte   -5,   -7, 	   5,  -18, 	  -7,  -10, 	  -1,   -7
+.2byte   -6,   -7, 	   3,  -12, 	 -12,   -5, 	   0,   -7
+.2byte   -4,   -4, 	  -3,  -18, 	   4,   -9, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -11, 	  -5,    1, 	  -1,   -7
+.2byte   -2,   -4, 	 -10,  -16, 	   9,  -10, 	   0,   -7
+.2byte   -2,   -4, 	 -13,   -6, 	   5,    2, 	   0,   -7
+.2byte    0,   -4, 	 -11,    0, 	  10,   -1, 	   0,   -7
+.2byte    0,   -4, 	 -12,  -11, 	  11,  -13, 	   0,   -7
+.2byte    1,   -4, 	  12,   -6, 	  -6,    2, 	  -1,   -7
+.2byte    1,   -4, 	   9,  -16, 	 -10,  -10, 	  -1,   -7
+.2byte    3,   -4, 	   9,  -11, 	   4,    1, 	   0,   -7
+.2byte    3,   -4, 	   2,  -18, 	  -5,   -9, 	  -1,   -7
+.2byte    5,   -7, 	  -4,  -12, 	  11,   -5, 	  -1,   -7
+.2byte    4,   -7, 	  -6,  -18, 	   6,  -10, 	   0,   -7
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte   -1,   -8, 	   9,  -12, 	 -10,  -12, 	  -1,   -7
+.2byte   -6,   -7, 	   3,  -12, 	 -12,   -5, 	   0,   -7
+.2byte   -5,   -7, 	   5,  -18, 	  -7,  -10, 	  -1,   -7
+.2byte   -4,   -4, 	 -10,  -11, 	  -5,    1, 	  -1,   -7
+.2byte   -4,   -4, 	  -3,  -18, 	   4,   -9, 	   0,   -7
+.2byte   -2,   -4, 	 -13,   -6, 	   5,    2, 	   0,   -7
+.2byte   -2,   -4, 	 -10,  -16, 	   9,  -10, 	   0,   -7
+.2byte    0,   -4, 	 -12,  -11, 	  11,  -13, 	   0,   -7
+.2byte    0,   -3, 	  -9,   -8, 	   7,  -15, 	   1,   -6
+.2byte   -1,   -3, 	  -9,  -15, 	   8,   -9, 	  -2,   -6
+.2byte    1,   -4, 	   9,  -16, 	 -10,  -10, 	  -1,   -7
+.2byte    0,   -3, 	  11,  -12, 	 -11,  -12, 	  -2,   -6
+.2byte    1,   -3, 	   6,  -16, 	  -5,   -7, 	   0,   -6
+.2byte    3,   -4, 	   2,  -18, 	  -5,   -9, 	  -1,   -7
+.2byte    3,   -4, 	   6,  -15, 	  -8,   -9, 	  -1,   -6
+.2byte    4,   -5, 	  -2,  -17, 	   3,   -8, 	   0,   -7
+.2byte    4,   -7, 	  -6,  -18, 	   6,  -10, 	   0,   -7
+.2byte    5,   -5, 	  -1,  -17, 	   2,   -8, 	   0,   -6
+.2byte    4,   -4, 	  -8,  -13, 	   9,   -8, 	   0,   -4
+.2byte   -1,   -8, 	   9,  -12, 	 -10,  -12, 	  -1,   -7
+.2byte   -1,   -7, 	   7,  -14, 	  -9,   -8, 	   0,   -6
+.2byte    1,   -7, 	   8,   -8, 	  -8,  -14, 	   0,   -6
+.2byte   -5,   -7, 	   5,  -18, 	  -7,  -10, 	  -1,   -7
+.2byte   -6,   -5, 	   0,  -17, 	  -3,   -8, 	  -1,   -6
+.2byte   -5,   -4, 	   7,  -13, 	 -10,   -8, 	  -1,   -4
+.2byte   -4,   -4, 	  -3,  -18, 	   4,   -9, 	   0,   -7
+.2byte   -4,   -4, 	  -7,  -15, 	   7,   -9, 	   0,   -6
+.2byte   -5,   -5, 	   1,  -17, 	  -4,   -8, 	  -1,   -7
+.2byte   -2,   -4, 	 -10,  -16, 	   9,  -10, 	   0,   -7
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -12, 	   1,   -6
+.2byte   -2,   -3, 	  -7,  -16, 	   4,   -7, 	  -1,   -6
+.2byte    0,   -4, 	 -11,    0, 	  10,   -1, 	   0,   -7
+.2byte   -2,   -4, 	 -13,   -6, 	   5,    2, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -11, 	  -5,    1, 	  -1,   -7
+.2byte   -6,   -7, 	   3,  -12, 	 -12,   -5, 	   0,   -7
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	  -1,   -7
+.2byte    5,   -7, 	  -4,  -12, 	  11,   -5, 	  -1,   -7
+.2byte    3,   -4, 	   9,  -11, 	   4,    1, 	   0,   -7
+.2byte    1,   -4, 	  12,   -6, 	  -6,    2, 	  -1,   -7
+sGeodudeAnimTable1:
+.4byte sGeodudeAnims_1_1
+.4byte sGeodudeAnims_1_2
+.4byte sGeodudeAnims_1_3
+.4byte sGeodudeAnims_1_4
+.4byte sGeodudeAnims_1_5
+.4byte sGeodudeAnims_1_6
+.4byte sGeodudeAnims_1_7
+.4byte sGeodudeAnims_1_8
+sGeodudeAnimTable2:
+.4byte sGeodudeAnims_2_1
+.4byte sGeodudeAnims_2_2
+.4byte sGeodudeAnims_2_3
+.4byte sGeodudeAnims_2_4
+.4byte sGeodudeAnims_2_5
+.4byte sGeodudeAnims_2_6
+.4byte sGeodudeAnims_2_7
+.4byte sGeodudeAnims_2_8
+sGeodudeAnimTable3:
+.4byte sGeodudeAnims_3_1
+.4byte sGeodudeAnims_3_2
+.4byte sGeodudeAnims_3_3
+.4byte sGeodudeAnims_3_4
+.4byte sGeodudeAnims_3_5
+.4byte sGeodudeAnims_3_6
+.4byte sGeodudeAnims_3_7
+.4byte sGeodudeAnims_3_8
+sGeodudeAnimTable4:
+.4byte sGeodudeAnims_4_1
+.4byte sGeodudeAnims_4_2
+.4byte sGeodudeAnims_4_3
+.4byte sGeodudeAnims_4_4
+.4byte sGeodudeAnims_4_5
+.4byte sGeodudeAnims_4_6
+.4byte sGeodudeAnims_4_7
+.4byte sGeodudeAnims_4_8
+sGeodudeAnimTable5:
+.4byte sGeodudeAnims_5_1
+.4byte sGeodudeAnims_5_2
+.4byte sGeodudeAnims_5_3
+.4byte sGeodudeAnims_5_4
+.4byte sGeodudeAnims_5_5
+.4byte sGeodudeAnims_5_6
+.4byte sGeodudeAnims_5_7
+.4byte sGeodudeAnims_5_8
+sGeodudeAnimTable6:
+.4byte sGeodudeAnims_6_1
+.4byte sGeodudeAnims_6_1
+.4byte sGeodudeAnims_6_1
+.4byte sGeodudeAnims_6_1
+.4byte sGeodudeAnims_6_1
+.4byte sGeodudeAnims_6_1
+.4byte sGeodudeAnims_6_1
+.4byte sGeodudeAnims_6_1
+sGeodudeAnimTable7:
+.4byte sGeodudeAnims_7_1
+.4byte sGeodudeAnims_7_2
+.4byte sGeodudeAnims_7_3
+.4byte sGeodudeAnims_7_4
+.4byte sGeodudeAnims_7_5
+.4byte sGeodudeAnims_7_6
+.4byte sGeodudeAnims_7_7
+.4byte sGeodudeAnims_7_8
+sGeodudeAnimTable8:
+.4byte sGeodudeAnims_8_1
+.4byte sGeodudeAnims_8_2
+.4byte sGeodudeAnims_8_3
+.4byte sGeodudeAnims_8_4
+.4byte sGeodudeAnims_8_5
+.4byte sGeodudeAnims_8_6
+.4byte sGeodudeAnims_8_7
+.4byte sGeodudeAnims_8_8
+sGeodudeAnimTable9:
+.4byte sGeodudeAnims_9_1
+.4byte sGeodudeAnims_9_2
+.4byte sGeodudeAnims_9_3
+.4byte sGeodudeAnims_9_4
+.4byte sGeodudeAnims_9_5
+.4byte sGeodudeAnims_9_6
+.4byte sGeodudeAnims_9_7
+.4byte sGeodudeAnims_9_8
+sGeodudeAnimTable10:
+.4byte sGeodudeAnims_10_1
+.4byte sGeodudeAnims_10_2
+.4byte sGeodudeAnims_10_3
+.4byte sGeodudeAnims_10_4
+.4byte sGeodudeAnims_10_5
+.4byte sGeodudeAnims_10_6
+.4byte sGeodudeAnims_10_7
+.4byte sGeodudeAnims_10_8
+sGeodudeAnimTable11:
+.4byte sGeodudeAnims_11_1
+.4byte sGeodudeAnims_11_2
+.4byte sGeodudeAnims_11_3
+.4byte sGeodudeAnims_11_4
+.4byte sGeodudeAnims_11_5
+.4byte sGeodudeAnims_11_6
+.4byte sGeodudeAnims_11_7
+.4byte sGeodudeAnims_11_8
+sGeodudeAnimTable12:
+.4byte sGeodudeAnims_12_1
+.4byte sGeodudeAnims_12_2
+.4byte sGeodudeAnims_12_3
+.4byte sGeodudeAnims_12_4
+.4byte sGeodudeAnims_12_5
+.4byte sGeodudeAnims_12_6
+.4byte sGeodudeAnims_12_7
+.4byte sGeodudeAnims_12_8
+sGeodudeAnimTable13:
+.4byte sGeodudeAnims_13_1
+.4byte sGeodudeAnims_13_2
+.4byte sGeodudeAnims_13_3
+.4byte sGeodudeAnims_13_4
+.4byte sGeodudeAnims_13_5
+.4byte sGeodudeAnims_13_6
+.4byte sGeodudeAnims_13_7
+.4byte sGeodudeAnims_13_8
+sAxAnimationsGeodude:
+.4byte sGeodudeAnimTable1
+.4byte sGeodudeAnimTable2
+.4byte sGeodudeAnimTable3
+.4byte sGeodudeAnimTable4
+.4byte sGeodudeAnimTable5
+.4byte sGeodudeAnimTable6
+.4byte sGeodudeAnimTable7
+.4byte sGeodudeAnimTable8
+.4byte sGeodudeAnimTable9
+.4byte sGeodudeAnimTable10
+.4byte sGeodudeAnimTable11
+.4byte sGeodudeAnimTable12
+.4byte sGeodudeAnimTable13
+sAxSpritesGeodude:
+.4byte sGeodudeSprites1
+.4byte sGeodudeSprites2
+.4byte sGeodudeSprites3
+.4byte sGeodudeSprites4
+.4byte sGeodudeSprites5
+.4byte sGeodudeSprites6
+.4byte sGeodudeSprites7
+.4byte sGeodudeSprites8
+.4byte sGeodudeSprites9
+.4byte sGeodudeSprites10
+.4byte sGeodudeSprites11
+.4byte sGeodudeSprites12
+.4byte sGeodudeSprites13
+.4byte sGeodudeSprites14
+.4byte sGeodudeSprites15
+.4byte sGeodudeSprites16
+.4byte sGeodudeSprites17
+.4byte sGeodudeSprites18
+.4byte sGeodudeSprites19
+.4byte sGeodudeSprites20
+.4byte sGeodudeSprites21
+.4byte sGeodudeSprites22
+.4byte sGeodudeSprites23
+.4byte sGeodudeSprites24
+.4byte sGeodudeSprites25
+.4byte sGeodudeSprites26
+.4byte sGeodudeSprites27
+.4byte sGeodudeSprites28
+.4byte sGeodudeSprites29
+.4byte sGeodudeSprites30
+.4byte sGeodudeSprites31
+.4byte sGeodudeSprites32
+.4byte sGeodudeSprites33
+.4byte sGeodudeSprites34
+.4byte sGeodudeSprites35
+.4byte sGeodudeSprites36
+.4byte sGeodudeSprites37
+.4byte sGeodudeSprites38
+.4byte sGeodudeSprites39
+.4byte sGeodudeSprites40
+.4byte sGeodudeSprites41
+.4byte sGeodudeSprites42
+.4byte sGeodudeSprites43
+.4byte sGeodudeSprites44
+.4byte sGeodudeSprites45
+.4byte sGeodudeSprites46
+.4byte sGeodudeSprites47
+.4byte sGeodudeSprites48
+.4byte sGeodudeSprites49
+.4byte sGeodudeSprites50
+.4byte sGeodudeSprites51
+.4byte sGeodudeSprites52
+.4byte sGeodudeSprites53
+.4byte sGeodudeSprites54
+.4byte sGeodudeSprites55
+.4byte sGeodudeSprites56
+.4byte sGeodudeSprites57
+sAxMainGeodude:
+ax_main sAxPosesGeodude, sAxAnimationsGeodude, 13, sAxSpritesGeodude, sAxPositionsGeodude

--- a/data/ax/girafarig.inc
+++ b/data/ax/girafarig.inc
@@ -1,0 +1,2895 @@
+.global gAxGirafarig
+gAxGirafarig:
+ax_siro sAxMainGirafarig
+sGirafarigPose1:
+ax_pose 0, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose2:
+ax_pose 1, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose3:
+ax_pose 2, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose4:
+ax_pose 3, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose5:
+ax_pose 4, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose8:
+ax_pose 7, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose10:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose11:
+ax_pose 10, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose12:
+ax_pose 11, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose13:
+ax_pose 12, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose14:
+ax_pose 13, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose15:
+ax_pose 14, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose16:
+ax_pose 9, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose17:
+ax_pose 10, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose18:
+ax_pose 11, 0x01e6, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose22:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose23:
+ax_pose 4, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose25:
+ax_pose 0, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose26:
+ax_pose 1, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose27:
+ax_pose 2, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose28:
+ax_pose 15, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose29:
+ax_pose 16, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose30:
+ax_pose 3, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose31:
+ax_pose 4, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose32:
+ax_pose 5, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose33:
+ax_pose 17, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sGirafarigPose34:
+ax_pose 18, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose35:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose36:
+ax_pose 7, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose37:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose38:
+ax_pose 19, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sGirafarigPose39:
+ax_pose 20, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose40:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose41:
+ax_pose 10, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose42:
+ax_pose 11, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose43:
+ax_pose 21, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sGirafarigPose44:
+ax_pose 22, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose45:
+ax_pose 12, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose46:
+ax_pose 13, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose47:
+ax_pose 14, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose48:
+ax_pose 23, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose49:
+ax_pose 24, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose50:
+ax_pose 9, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose51:
+ax_pose 10, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose52:
+ax_pose 11, 0x01e6, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose53:
+ax_pose 21, 0x01e6, 0x80f6, 0x4c00
+ax_pose_terminator
+sGirafarigPose54:
+ax_pose 22, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose55:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose56:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose57:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose58:
+ax_pose 19, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sGirafarigPose59:
+ax_pose 20, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose60:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose61:
+ax_pose 4, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose62:
+ax_pose 5, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose63:
+ax_pose 17, 0x01e7, 0x80f6, 0x4c00
+ax_pose_terminator
+sGirafarigPose64:
+ax_pose 18, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose65:
+ax_pose 0, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose66:
+ax_pose 1, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose67:
+ax_pose 2, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose68:
+ax_pose 25, 0x81e3, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose69:
+ax_pose 26, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose70:
+ax_pose 3, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose71:
+ax_pose 4, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose72:
+ax_pose 5, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose73:
+ax_pose 27, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose74:
+ax_pose 28, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose75:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose76:
+ax_pose 7, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose77:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose78:
+ax_pose 29, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose79:
+ax_pose 30, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose80:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose81:
+ax_pose 10, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose82:
+ax_pose 11, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose83:
+ax_pose 31, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose84:
+ax_pose 32, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sGirafarigPose85:
+ax_pose 12, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose86:
+ax_pose 13, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose87:
+ax_pose 14, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose88:
+ax_pose 33, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose89:
+ax_pose 34, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose90:
+ax_pose 9, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose91:
+ax_pose 10, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose92:
+ax_pose 11, 0x01e6, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose93:
+ax_pose 31, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose94:
+ax_pose 32, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose95:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose96:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose97:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose98:
+ax_pose 29, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose99:
+ax_pose 30, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose100:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose101:
+ax_pose 4, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose102:
+ax_pose 5, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose103:
+ax_pose 27, 0x01e3, 0x80f3, 0x4c00
+ax_pose_terminator
+sGirafarigPose104:
+ax_pose 28, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sGirafarigPose105:
+ax_pose 15, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose106:
+ax_pose 17, 0x01e7, 0x80f6, 0x4c00
+ax_pose_terminator
+sGirafarigPose107:
+ax_pose 19, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sGirafarigPose108:
+ax_pose 21, 0x01e6, 0x80f6, 0x4c00
+ax_pose_terminator
+sGirafarigPose109:
+ax_pose 23, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose110:
+ax_pose 21, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sGirafarigPose111:
+ax_pose 19, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sGirafarigPose112:
+ax_pose 17, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sGirafarigPose113:
+ax_pose 35, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose114:
+ax_pose 36, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose115:
+ax_pose 0, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose116:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose117:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose118:
+ax_pose 9, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose119:
+ax_pose 12, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose120:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose121:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose122:
+ax_pose 3, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose123:
+ax_pose 37, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose124:
+ax_pose 38, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose125:
+ax_pose 39, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose126:
+ax_pose 40, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose127:
+ax_pose 41, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose128:
+ax_pose 42, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose129:
+ax_pose 43, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose130:
+ax_pose 44, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose131:
+ax_pose 41, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose132:
+ax_pose 42, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose133:
+ax_pose 39, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose134:
+ax_pose 40, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose135:
+ax_pose 37, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose136:
+ax_pose 38, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose137:
+ax_pose 45, 0x01ed, 0x80f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose138:
+ax_pose 46, 0x01ed, 0x80f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose139:
+ax_pose 47, 0x01e0, 0x80f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose140:
+ax_pose 48, 0x01e2, 0x90ee, 0x4c00
+ax_pose_terminator
+sGirafarigPose141:
+ax_pose 49, 0x01e2, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose142:
+ax_pose 50, 0x01e4, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose143:
+ax_pose 51, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose144:
+ax_pose 50, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sGirafarigPose145:
+ax_pose 49, 0x01e2, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose146:
+ax_pose 48, 0x01e2, 0x80f2, 0x4c00
+ax_pose_terminator
+sGirafarigPose147:
+ax_pose 0, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose148:
+ax_pose 26, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose149:
+ax_pose 3, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose150:
+ax_pose 28, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose151:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose152:
+ax_pose 30, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose153:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose154:
+ax_pose 32, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sGirafarigPose155:
+ax_pose 12, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose156:
+ax_pose 34, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose157:
+ax_pose 9, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose158:
+ax_pose 32, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose159:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose160:
+ax_pose 30, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose161:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose162:
+ax_pose 28, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sGirafarigPose163:
+ax_pose 16, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose164:
+ax_pose 18, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose165:
+ax_pose 20, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose166:
+ax_pose 22, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose167:
+ax_pose 24, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose168:
+ax_pose 22, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose169:
+ax_pose 20, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose170:
+ax_pose 18, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose171:
+ax_pose 25, 0x81e3, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose172:
+ax_pose 27, 0x01e4, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose173:
+ax_pose 29, 0x01e4, 0x90f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose174:
+ax_pose 31, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose175:
+ax_pose 33, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose176:
+ax_pose 31, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose177:
+ax_pose 29, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose178:
+ax_pose 27, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sGirafarigPose179:
+ax_pose 0, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose180:
+ax_pose 25, 0x81e3, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose181:
+ax_pose 26, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose182:
+ax_pose 3, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose183:
+ax_pose 27, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose184:
+ax_pose 28, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose185:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose186:
+ax_pose 29, 0x01e4, 0x90f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose187:
+ax_pose 30, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose188:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose189:
+ax_pose 31, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sGirafarigPose190:
+ax_pose 32, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sGirafarigPose191:
+ax_pose 12, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose192:
+ax_pose 33, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose193:
+ax_pose 34, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose194:
+ax_pose 9, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose195:
+ax_pose 31, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose196:
+ax_pose 32, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose197:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose198:
+ax_pose 29, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sGirafarigPose199:
+ax_pose 30, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sGirafarigPose200:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose201:
+ax_pose 27, 0x01e3, 0x80f3, 0x4c00
+ax_pose_terminator
+sGirafarigPose202:
+ax_pose 28, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sGirafarigPose203:
+ax_pose 15, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose204:
+ax_pose 17, 0x01e7, 0x80f6, 0x4c00
+ax_pose_terminator
+sGirafarigPose205:
+ax_pose 19, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sGirafarigPose206:
+ax_pose 21, 0x01e6, 0x80f6, 0x4c00
+ax_pose_terminator
+sGirafarigPose207:
+ax_pose 23, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose208:
+ax_pose 21, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sGirafarigPose209:
+ax_pose 19, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sGirafarigPose210:
+ax_pose 17, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sGirafarigPose211:
+ax_pose 0, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose212:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sGirafarigPose213:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose214:
+ax_pose 9, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sGirafarigPose215:
+ax_pose 12, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sGirafarigPose216:
+ax_pose 9, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sGirafarigPose217:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sGirafarigPose218:
+ax_pose 3, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+.align 2
+sGirafarigAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_2_1:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 1, 0, 28, 0, -1, 0, 3,
+ax_anim 2, 0, 28, 0, -2, 0, 6,
+ax_anim 2, 0, 28, 0, 1, 0, 9,
+ax_anim 2, 0, 28, 0, 6, 0, 12,
+ax_anim 2, 2, 28, 0, 13, 0, 16,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 5, 0, 9,
+ax_anim 2, 0, 24, 0, 1, 0, 5,
+ax_anim_terminator
+sGirafarigAnims_2_2:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 1, -1, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 1, -1, 0,
+ax_anim 1, 0, 33, 3, 1, 3, 3,
+ax_anim 2, 0, 33, 6, 2, 6, 6,
+ax_anim 2, 0, 33, 9, 3, 9, 9,
+ax_anim 2, 0, 33, 12, 6, 12, 12,
+ax_anim 2, 2, 33, 16, 13, 16, 16,
+ax_anim 2, 0, 32, 20, 20, 20, 20,
+ax_anim 2, 1, 32, 21, 19, 21, 19,
+ax_anim 2, 0, 32, 20, 20, 20, 20,
+ax_anim 2, 0, 32, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 9, 4, 9, 9,
+ax_anim 2, 0, 29, 5, 1, 5, 5,
+ax_anim_terminator
+sGirafarigAnims_2_3:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -1, -1, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -1, -1, 0,
+ax_anim 1, 0, 38, 3, -2, 3, 0,
+ax_anim 2, 0, 38, 6, -5, 6, 0,
+ax_anim 2, 0, 38, 9, -5, 9, 0,
+ax_anim 2, 0, 38, 12, -4, 12, 0,
+ax_anim 2, 2, 38, 16, -2, 16, 0,
+ax_anim 2, 0, 37, 20, 0, 20, 0,
+ax_anim 2, 1, 37, 20, -1, 20, -1,
+ax_anim 2, 0, 37, 20, 0, 20, 0,
+ax_anim 2, 0, 37, 20, -1, 20, -1,
+ax_anim 2, 0, 34, 9, -5, 9, 0,
+ax_anim 2, 0, 34, 5, -2, 5, 0,
+ax_anim_terminator
+sGirafarigAnims_2_4:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, -1, -1, -1, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, -1, -1, -1, 0,
+ax_anim 1, 0, 43, 3, -7, 3, -3,
+ax_anim 2, 0, 43, 6, -11, 6, -6,
+ax_anim 2, 0, 43, 9, -16, 9, -9,
+ax_anim 2, 0, 43, 12, -19, 12, -12,
+ax_anim 2, 2, 43, 16, -21, 16, -16,
+ax_anim 2, 0, 42, 20, -20, 20, -20,
+ax_anim 2, 1, 42, 19, -21, 19, -21,
+ax_anim 2, 0, 42, 20, -20, 20, -20,
+ax_anim 2, 0, 42, 19, -21, 19, -21,
+ax_anim 2, 0, 39, 9, -12, 9, -9,
+ax_anim 2, 0, 39, 5, -6, 5, -5,
+ax_anim_terminator
+sGirafarigAnims_2_5:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, 0, -1, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, 0, -1, 0,
+ax_anim 1, 0, 48, 0, -7, 0, -3,
+ax_anim 2, 0, 48, 0, -11, 0, -6,
+ax_anim 2, 0, 48, 0, -16, 0, -9,
+ax_anim 2, 0, 48, 0, -19, 0, -12,
+ax_anim 2, 2, 48, 0, -21, 0, -16,
+ax_anim 2, 0, 47, 0, -20, 0, -20,
+ax_anim 2, 1, 47, -1, -20, -1, -20,
+ax_anim 2, 0, 47, 0, -20, 0, -20,
+ax_anim 2, 0, 47, -1, -20, -1, -20,
+ax_anim 2, 0, 44, 0, -12, 0, -9,
+ax_anim 2, 0, 44, 0, -6, 0, -5,
+ax_anim_terminator
+sGirafarigAnims_2_6:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, 0,
+ax_anim 1, 0, 53, -3, -7, -3, -3,
+ax_anim 2, 0, 53, -6, -11, -6, -6,
+ax_anim 2, 0, 53, -9, -16, -9, -9,
+ax_anim 2, 0, 53, -12, -19, -12, -12,
+ax_anim 2, 2, 53, -16, -21, -16, -16,
+ax_anim 2, 0, 52, -20, -20, -20, -20,
+ax_anim 2, 1, 52, -19, -21, -19, -21,
+ax_anim 2, 0, 52, -20, -20, -20, -20,
+ax_anim 2, 0, 52, -19, -21, -19, -21,
+ax_anim 2, 0, 49, -9, -12, -9, -9,
+ax_anim 2, 0, 49, -5, -6, -5, -5,
+ax_anim_terminator
+sGirafarigAnims_2_7:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, -1, 1, 0,
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, -1, 1, 0,
+ax_anim 1, 0, 58, -3, -2, -3, 0,
+ax_anim 2, 0, 58, -6, -5, -6, 0,
+ax_anim 2, 0, 58, -9, -5, -9, 0,
+ax_anim 2, 0, 58, -12, -4, -12, 0,
+ax_anim 2, 2, 58, -16, -2, -16, 0,
+ax_anim 2, 0, 57, -20, 0, -20, 0,
+ax_anim 2, 1, 57, -20, -1, -20, -1,
+ax_anim 2, 0, 57, -20, 0, -20, 0,
+ax_anim 2, 0, 57, -20, -1, -20, -1,
+ax_anim 2, 0, 54, -9, -5, -9, 0,
+ax_anim 2, 0, 54, -5, -2, -5, 0,
+ax_anim_terminator
+sGirafarigAnims_2_8:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 1, 1, 1, 0,
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 1, 1, 1, 0,
+ax_anim 1, 0, 63, -3, 1, -3, 3,
+ax_anim 2, 0, 63, -6, 2, -6, 6,
+ax_anim 2, 0, 63, -9, 3, -9, 9,
+ax_anim 2, 0, 63, -12, 6, -12, 12,
+ax_anim 2, 2, 63, -16, 13, -16, 16,
+ax_anim 2, 0, 62, -20, 20, -20, 20,
+ax_anim 2, 1, 62, -21, 19, -21, 19,
+ax_anim 2, 0, 62, -20, 20, -20, 20,
+ax_anim 2, 0, 62, -21, 19, -21, 19,
+ax_anim 2, 0, 59, -9, 4, -9, 9,
+ax_anim 2, 0, 59, -5, 1, -5, 5,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_3_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 66, 0, 3, 0, 3,
+ax_anim 2, 0, 65, 0, 10, 0, 10,
+ax_anim 6, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, 15, 0, 15,
+ax_anim 2, 1, 68, 1, 17, 1, 17,
+ax_anim 2, 0, 68, 0, 17, 0, 17,
+ax_anim 2, 0, 68, 1, 17, 1, 17,
+ax_anim 2, 0, 68, 0, 17, 0, 17,
+ax_anim 2, 0, 68, 1, 17, 1, 17,
+ax_anim 2, 0, 65, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sGirafarigAnims_3_2:
+ax_anim 2, 0, 70, 2, 2, 2, 2,
+ax_anim 2, 2, 71, 5, 5, 5, 5,
+ax_anim 2, 0, 70, 8, 8, 8, 8,
+ax_anim 6, 0, 72, 17, 15, 17, 15,
+ax_anim 2, 0, 72, 19, 17, 19, 17,
+ax_anim 2, 1, 73, 20, 18, 20, 16,
+ax_anim 2, 0, 73, 19, 19, 19, 17,
+ax_anim 2, 0, 73, 20, 18, 20, 16,
+ax_anim 2, 0, 73, 19, 19, 19, 17,
+ax_anim 2, 0, 73, 20, 18, 20, 16,
+ax_anim 2, 0, 70, 10, 9, 10, 9,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sGirafarigAnims_3_3:
+ax_anim 2, 0, 75, 3, 0, 3, 0,
+ax_anim 2, 2, 76, 6, 0, 6, 0,
+ax_anim 2, 0, 75, 8, 0, 8, 0,
+ax_anim 6, 0, 77, 14, 0, 14, 0,
+ax_anim 2, 0, 77, 16, 0, 16, 0,
+ax_anim 2, 1, 78, 16, -1, 16, -1,
+ax_anim 2, 0, 78, 16, 0, 16, 0,
+ax_anim 2, 0, 78, 16, -1, 16, -1,
+ax_anim 2, 0, 78, 16, 0, 16, 0,
+ax_anim 2, 0, 78, 16, -1, 16, -1,
+ax_anim 2, 0, 75, 10, 0, 10, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sGirafarigAnims_3_4:
+ax_anim 2, 0, 80, 5, -5, 5, -5,
+ax_anim 2, 2, 81, 8, -8, 8, -8,
+ax_anim 2, 0, 80, 14, -14, 14, -14,
+ax_anim 6, 0, 82, 16, -16, 16, -16,
+ax_anim 2, 0, 82, 19, -19, 19, -19,
+ax_anim 2, 1, 83, 20, -18, 20, -18,
+ax_anim 2, 0, 83, 19, -19, 19, -19,
+ax_anim 2, 0, 83, 20, -18, 20, -18,
+ax_anim 2, 0, 83, 19, -19, 19, -19,
+ax_anim 2, 0, 83, 20, -18, 20, -18,
+ax_anim 2, 0, 80, 10, -10, 10, -10,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sGirafarigAnims_3_5:
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim 2, 2, 86, 0, -8, 0, -8,
+ax_anim 2, 0, 85, 0, -13, 0, -13,
+ax_anim 6, 0, 87, 0, -16, 0, -16,
+ax_anim 2, 0, 87, 0, -18, 0, -18,
+ax_anim 2, 1, 88, 1, -18, 1, -18,
+ax_anim 2, 0, 88, 0, -18, 0, -18,
+ax_anim 2, 0, 88, 1, -18, 1, -18,
+ax_anim 2, 0, 88, 0, -18, 0, -18,
+ax_anim 2, 0, 88, 1, -18, 1, -18,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sGirafarigAnims_3_6:
+ax_anim 2, 0, 90, -5, -5, -5, -5,
+ax_anim 2, 2, 91, -8, -8, -8, -8,
+ax_anim 2, 0, 90, -14, -14, -14, -14,
+ax_anim 6, 0, 92, -16, -16, -16, -16,
+ax_anim 2, 0, 92, -19, -19, -19, -19,
+ax_anim 2, 1, 93, -20, -18, -20, -18,
+ax_anim 2, 0, 93, -19, -19, -19, -19,
+ax_anim 2, 0, 93, -20, -18, -20, -18,
+ax_anim 2, 0, 93, -19, -19, -19, -19,
+ax_anim 2, 0, 93, -20, -18, -20, -18,
+ax_anim 2, 0, 90, -10, -10, -10, -10,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sGirafarigAnims_3_7:
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 2, 96, -6, 0, -6, 0,
+ax_anim 2, 0, 95, -8, 0, -8, 0,
+ax_anim 6, 0, 97, -14, 0, -14, 0,
+ax_anim 2, 0, 97, -16, 0, -16, 0,
+ax_anim 2, 1, 98, -16, -1, -16, -1,
+ax_anim 2, 0, 98, -16, 0, -16, 0,
+ax_anim 2, 0, 98, -16, -1, -16, -1,
+ax_anim 2, 0, 98, -16, 0, -16, 0,
+ax_anim 2, 0, 98, -16, -1, -16, -1,
+ax_anim 2, 0, 95, -10, 0, -10, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sGirafarigAnims_3_8:
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim 2, 2, 101, -5, 5, -5, 5,
+ax_anim 2, 0, 100, -8, 8, -8, 8,
+ax_anim 6, 0, 102, -17, 15, -17, 15,
+ax_anim 2, 0, 102, -19, 17, -19, 17,
+ax_anim 2, 1, 103, -20, 18, -20, 18,
+ax_anim 2, 0, 103, -19, 19, -19, 19,
+ax_anim 2, 0, 103, -20, 18, -20, 18,
+ax_anim 2, 0, 103, -19, 19, -19, 19,
+ax_anim 2, 0, 103, -20, 18, -20, 18,
+ax_anim 2, 0, 100, -10, 9, -10, 9,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_4_1:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 1, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_4_2:
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_4_3:
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_4_4:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_4_5:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_4_6:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_4_7:
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_4_8:
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_5_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 3, 0, 118, 0, 1, 0, 1,
+ax_anim 3, 0, 112, 0, 2, 0, 2,
+ax_anim 3, 0, 113, 0, 2, 0, 2,
+ax_anim 3, 2, 112, 0, 2, 0, 2,
+ax_anim 3, 0, 113, 0, 2, 0, 2,
+ax_anim 3, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_5_2:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 1, 1, 1,
+ax_anim 3, 0, 117, 1, 1, 1, 1,
+ax_anim 3, 0, 122, 2, 2, 2, 2,
+ax_anim 3, 0, 123, 2, 2, 2, 2,
+ax_anim 3, 2, 122, 2, 2, 2, 2,
+ax_anim 3, 0, 123, 2, 2, 2, 2,
+ax_anim 3, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_5_3:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, 0, 1, 0,
+ax_anim 3, 0, 116, 1, 0, 1, 0,
+ax_anim 3, 0, 124, 2, 0, 2, 0,
+ax_anim 3, 0, 125, 2, 0, 2, 0,
+ax_anim 3, 2, 124, 2, 0, 2, 0,
+ax_anim 3, 0, 125, 2, 0, 2, 0,
+ax_anim 3, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_5_4:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 3, 0, 116, 1, -1, 1, -1,
+ax_anim 3, 0, 126, 2, -2, 2, -2,
+ax_anim 3, 0, 127, 2, -2, 2, -2,
+ax_anim 3, 2, 126, 2, -2, 2, -2,
+ax_anim 3, 0, 127, 2, -2, 2, -2,
+ax_anim 3, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_5_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, -1,
+ax_anim 3, 0, 115, 0, -1, 0, -1,
+ax_anim 3, 0, 128, 0, -2, 0, -2,
+ax_anim 3, 0, 129, 0, -2, 0, -2,
+ax_anim 3, 2, 128, 0, -2, 0, -2,
+ax_anim 3, 0, 129, 0, -2, 0, -2,
+ax_anim 3, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_5_6:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, -1, -1, -1,
+ax_anim 3, 0, 121, -1, -1, -1, -1,
+ax_anim 3, 0, 130, -2, -2, -2, -2,
+ax_anim 3, 0, 131, -2, -2, -2, -2,
+ax_anim 3, 2, 130, -2, -2, -2, -2,
+ax_anim 3, 0, 131, -2, -2, -2, -2,
+ax_anim 3, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_5_7:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, 0, -1, 0,
+ax_anim 3, 0, 120, -1, 0, -1, 0,
+ax_anim 3, 0, 132, -2, 0, -2, 0,
+ax_anim 3, 0, 133, -2, 0, -2, 0,
+ax_anim 3, 2, 132, -2, 0, -2, 0,
+ax_anim 3, 0, 133, -2, 0, -2, 0,
+ax_anim 3, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_5_8:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -1, 1, -1, 1,
+ax_anim 3, 0, 119, -1, 1, -1, 1,
+ax_anim 3, 0, 134, -2, 2, -2, 2,
+ax_anim 3, 0, 135, -2, 2, -2, 2,
+ax_anim 3, 2, 134, -2, 2, -2, 2,
+ax_anim 3, 0, 135, -2, 2, -2, 2,
+ax_anim 3, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sGirafarigAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sGirafarigAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sGirafarigAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sGirafarigAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sGirafarigAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sGirafarigAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sGirafarigAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 1, 0, 1, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 1, 0, 1, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 1, 0, 1, 0,
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_8_2:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 1, -1, 1, -1,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 1, -1, 1, -1,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 1, -1, 1, -1,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_8_3:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, -1,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, -1,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, -1,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_8_4:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 1, 1, 1, 1,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 1, 1, 1, 1,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 1, 1, 1, 1,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_8_5:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 1, 0, 1, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 1, 0, 1, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 1, 0, 1, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_8_6:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 157, -1, 1, -1, 1,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 157, -1, 1, -1, 1,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 157, -1, 1, -1, 1,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_8_7:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, -1,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, -1,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, -1,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_8_8:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, -1, -1, -1, -1,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, -1, -1, -1, -1,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, -1, -1, -1, -1,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 15, 7, 15,
+ax_anim 3, 0, 166, 0, 18, 0, 18,
+ax_anim 2, 3, 167, -7, 15, -7, 15,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 17, 19, 17, 19,
+ax_anim 2, 3, 166, 11, 19, 11, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 18, -2, 18, -2,
+ax_anim 2, 3, 165, 16, 4, 16, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 19, -20, 19, -20,
+ax_anim 2, 3, 164, 20, -15, 20, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -17, -7, -17,
+ax_anim 3, 0, 162, 0, -20, 0, -20,
+ax_anim 2, 3, 163, 7, -17, 7, -17,
+ax_anim 2, 0, 164, 9, -12, 9, -12,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -19, -20, -19, -20,
+ax_anim 2, 3, 168, -20, -15, -20, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -18, -2, -18, -2,
+ax_anim 2, 3, 167, -16, 4, -16, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -17, 19, -17, 19,
+ax_anim 2, 3, 166, -11, 19, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -24, 0, 0,
+ax_anim 3, 0, 183, 0, -23, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -24, 0, 0,
+ax_anim 3, 0, 186, 0, -23, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -24, 0, 0,
+ax_anim 3, 0, 198, 0, -23, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -24, 0, 0,
+ax_anim 3, 0, 201, 0, -23, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGirafarigAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGirafarigGfx1:
+.incbin "baserom.gba", 0xE36348, 0x100
+sGirafarigSprites1:
+ax_sprite sGirafarigGfx1, 0x100
+ax_sprite_terminator
+sGirafarigGfx2:
+.incbin "baserom.gba", 0xE36458, 0x100
+sGirafarigSprites2:
+ax_sprite sGirafarigGfx2, 0x100
+ax_sprite_terminator
+sGirafarigGfx3:
+.incbin "baserom.gba", 0xE36568, 0x100
+sGirafarigSprites3:
+ax_sprite sGirafarigGfx3, 0x100
+ax_sprite_terminator
+sGirafarigGfx4:
+.incbin "baserom.gba", 0xE36678, 0x200
+sGirafarigSprites4:
+ax_sprite sGirafarigGfx4, 0x200
+ax_sprite_terminator
+sGirafarigGfx5:
+.incbin "baserom.gba", 0xE36888, 0x200
+sGirafarigSprites5:
+ax_sprite sGirafarigGfx5, 0x200
+ax_sprite_terminator
+sGirafarigGfx6:
+.incbin "baserom.gba", 0xE36A98, 0x200
+sGirafarigSprites6:
+ax_sprite sGirafarigGfx6, 0x200
+ax_sprite_terminator
+sGirafarigGfx7:
+.incbin "baserom.gba", 0xE36CA8, 0x200
+sGirafarigSprites7:
+ax_sprite sGirafarigGfx7, 0x200
+ax_sprite_terminator
+sGirafarigGfx8:
+.incbin "baserom.gba", 0xE36EB8, 0x200
+sGirafarigSprites8:
+ax_sprite sGirafarigGfx8, 0x200
+ax_sprite_terminator
+sGirafarigGfx9:
+.incbin "baserom.gba", 0xE370C8, 0x200
+sGirafarigSprites9:
+ax_sprite sGirafarigGfx9, 0x200
+ax_sprite_terminator
+sGirafarigGfx10:
+.incbin "baserom.gba", 0xE372D8, 0x200
+sGirafarigSprites10:
+ax_sprite sGirafarigGfx10, 0x200
+ax_sprite_terminator
+sGirafarigGfx11:
+.incbin "baserom.gba", 0xE374E8, 0x200
+sGirafarigSprites11:
+ax_sprite sGirafarigGfx11, 0x200
+ax_sprite_terminator
+sGirafarigGfx12:
+.incbin "baserom.gba", 0xE376F8, 0x200
+sGirafarigSprites12:
+ax_sprite sGirafarigGfx12, 0x200
+ax_sprite_terminator
+sGirafarigGfx13:
+.incbin "baserom.gba", 0xE37908, 0x100
+sGirafarigSprites13:
+ax_sprite sGirafarigGfx13, 0x100
+ax_sprite_terminator
+sGirafarigGfx14:
+.incbin "baserom.gba", 0xE37A18, 0x100
+sGirafarigSprites14:
+ax_sprite sGirafarigGfx14, 0x100
+ax_sprite_terminator
+sGirafarigGfx15:
+.incbin "baserom.gba", 0xE37B28, 0x100
+sGirafarigSprites15:
+ax_sprite sGirafarigGfx15, 0x100
+ax_sprite_terminator
+sGirafarigGfx16:
+.incbin "baserom.gba", 0xE37C38, 0x100
+sGirafarigSprites16:
+ax_sprite sGirafarigGfx16, 0x100
+ax_sprite_terminator
+sGirafarigGfx17:
+.incbin "baserom.gba", 0xE37D48, 0x100
+sGirafarigSprites17:
+ax_sprite sGirafarigGfx17, 0x100
+ax_sprite_terminator
+sGirafarigGfx18:
+.incbin "baserom.gba", 0xE37E58, 0x60
+sGirafarigGfx18_1:
+.incbin "baserom.gba", 0xE37EB8, 0x60
+sGirafarigGfx18_2:
+.incbin "baserom.gba", 0xE37F18, 0x60
+sGirafarigGfx18_3:
+.incbin "baserom.gba", 0xE37F78, 0x60
+sGirafarigSprites18:
+ax_sprite sGirafarigGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx19:
+.incbin "baserom.gba", 0xE38020, 0x60
+sGirafarigGfx19_1:
+.incbin "baserom.gba", 0xE38080, 0x60
+sGirafarigGfx19_2:
+.incbin "baserom.gba", 0xE380E0, 0x60
+sGirafarigGfx19_3:
+.incbin "baserom.gba", 0xE38140, 0x20
+sGirafarigSprites19:
+ax_sprite sGirafarigGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx19_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sGirafarigGfx20:
+.incbin "baserom.gba", 0xE381A8, 0x40
+sGirafarigGfx20_1:
+.incbin "baserom.gba", 0xE381E8, 0xE0
+sGirafarigGfx20_2:
+.incbin "baserom.gba", 0xE382C8, 0x60
+sGirafarigSprites20:
+ax_sprite sGirafarigGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx20_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx21:
+.incbin "baserom.gba", 0xE38360, 0x40
+sGirafarigGfx21_1:
+.incbin "baserom.gba", 0xE383A0, 0x180
+sGirafarigSprites21:
+ax_sprite sGirafarigGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx21_1, 0x180
+ax_sprite_terminator
+sGirafarigGfx22:
+.incbin "baserom.gba", 0xE38540, 0x40
+sGirafarigGfx22_1:
+.incbin "baserom.gba", 0xE38580, 0x60
+sGirafarigGfx22_2:
+.incbin "baserom.gba", 0xE385E0, 0x60
+sGirafarigGfx22_3:
+.incbin "baserom.gba", 0xE38640, 0x60
+sGirafarigSprites22:
+ax_sprite sGirafarigGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx23:
+.incbin "baserom.gba", 0xE386E8, 0x40
+sGirafarigGfx23_1:
+.incbin "baserom.gba", 0xE38728, 0x60
+sGirafarigGfx23_2:
+.incbin "baserom.gba", 0xE38788, 0x60
+sGirafarigGfx23_3:
+.incbin "baserom.gba", 0xE387E8, 0x40
+sGirafarigSprites23:
+ax_sprite sGirafarigGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx24:
+.incbin "baserom.gba", 0xE38870, 0x100
+sGirafarigSprites24:
+ax_sprite sGirafarigGfx24, 0x100
+ax_sprite_terminator
+sGirafarigGfx25:
+.incbin "baserom.gba", 0xE38980, 0x100
+sGirafarigSprites25:
+ax_sprite sGirafarigGfx25, 0x100
+ax_sprite_terminator
+sGirafarigGfx26:
+.incbin "baserom.gba", 0xE38A90, 0x100
+sGirafarigSprites26:
+ax_sprite sGirafarigGfx26, 0x100
+ax_sprite_terminator
+sGirafarigGfx27:
+.incbin "baserom.gba", 0xE38BA0, 0x100
+sGirafarigSprites27:
+ax_sprite sGirafarigGfx27, 0x100
+ax_sprite_terminator
+sGirafarigGfx28:
+.incbin "baserom.gba", 0xE38CB0, 0x40
+sGirafarigGfx28_1:
+.incbin "baserom.gba", 0xE38CF0, 0xE0
+sGirafarigGfx28_2:
+.incbin "baserom.gba", 0xE38DD0, 0x40
+sGirafarigSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx28_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx29:
+.incbin "baserom.gba", 0xE38E50, 0x40
+sGirafarigGfx29_1:
+.incbin "baserom.gba", 0xE38E90, 0x60
+sGirafarigGfx29_2:
+.incbin "baserom.gba", 0xE38EF0, 0x60
+sGirafarigGfx29_3:
+.incbin "baserom.gba", 0xE38F50, 0x60
+sGirafarigSprites29:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx30:
+.incbin "baserom.gba", 0xE39000, 0x160
+sGirafarigGfx30_1:
+.incbin "baserom.gba", 0xE39160, 0x20
+sGirafarigSprites30:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx30, 0x160
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx30_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx31:
+.incbin "baserom.gba", 0xE391B0, 0x20
+sGirafarigGfx31_1:
+.incbin "baserom.gba", 0xE391D0, 0xE0
+sGirafarigGfx31_2:
+.incbin "baserom.gba", 0xE392B0, 0x60
+sGirafarigSprites31:
+ax_sprite sGirafarigGfx31, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGirafarigGfx31_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx32:
+.incbin "baserom.gba", 0xE39348, 0x40
+sGirafarigGfx32_1:
+.incbin "baserom.gba", 0xE39388, 0x60
+sGirafarigGfx32_2:
+.incbin "baserom.gba", 0xE393E8, 0x80
+sGirafarigGfx32_3:
+.incbin "baserom.gba", 0xE39468, 0x60
+sGirafarigSprites32:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx32_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx32_3, 0x60
+ax_sprite_terminator
+sGirafarigGfx33:
+.incbin "baserom.gba", 0xE39510, 0x40
+sGirafarigGfx33_1:
+.incbin "baserom.gba", 0xE39550, 0x60
+sGirafarigGfx33_2:
+.incbin "baserom.gba", 0xE395B0, 0x60
+sGirafarigGfx33_3:
+.incbin "baserom.gba", 0xE39610, 0x40
+sGirafarigSprites33:
+ax_sprite sGirafarigGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx34:
+.incbin "baserom.gba", 0xE39698, 0x100
+sGirafarigSprites34:
+ax_sprite sGirafarigGfx34, 0x100
+ax_sprite_terminator
+sGirafarigGfx35:
+.incbin "baserom.gba", 0xE397A8, 0x100
+sGirafarigSprites35:
+ax_sprite sGirafarigGfx35, 0x100
+ax_sprite_terminator
+sGirafarigGfx36:
+.incbin "baserom.gba", 0xE398B8, 0x60
+sGirafarigGfx36_1:
+.incbin "baserom.gba", 0xE39918, 0xC0
+sGirafarigGfx36_2:
+.incbin "baserom.gba", 0xE399D8, 0x60
+sGirafarigSprites36:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx36_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx37:
+.incbin "baserom.gba", 0xE39A78, 0x60
+sGirafarigGfx37_1:
+.incbin "baserom.gba", 0xE39AD8, 0xC0
+sGirafarigGfx37_2:
+.incbin "baserom.gba", 0xE39B98, 0x60
+sGirafarigSprites37:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx37_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx38:
+.incbin "baserom.gba", 0xE39C38, 0x1C0
+sGirafarigSprites38:
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx38, 0x1c0
+ax_sprite_terminator
+sGirafarigGfx39:
+.incbin "baserom.gba", 0xE39E10, 0x40
+sGirafarigGfx39_1:
+.incbin "baserom.gba", 0xE39E50, 0x160
+sGirafarigSprites39:
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx39_1, 0x160
+ax_sprite_terminator
+sGirafarigGfx40:
+.incbin "baserom.gba", 0xE39FD8, 0x160
+sGirafarigGfx40_1:
+.incbin "baserom.gba", 0xE3A138, 0x60
+sGirafarigSprites40:
+ax_sprite sGirafarigGfx40, 0x160
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx40_1, 0x60
+ax_sprite_terminator
+sGirafarigGfx41:
+.incbin "baserom.gba", 0xE3A1B8, 0x40
+sGirafarigGfx41_1:
+.incbin "baserom.gba", 0xE3A1F8, 0x60
+sGirafarigGfx41_2:
+.incbin "baserom.gba", 0xE3A258, 0x60
+sGirafarigGfx41_3:
+.incbin "baserom.gba", 0xE3A2B8, 0x60
+sGirafarigSprites41:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx41_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx41_3, 0x60
+ax_sprite_terminator
+sGirafarigGfx42:
+.incbin "baserom.gba", 0xE3A360, 0xC0
+sGirafarigGfx42_1:
+.incbin "baserom.gba", 0xE3A420, 0x60
+sGirafarigGfx42_2:
+.incbin "baserom.gba", 0xE3A480, 0x60
+sGirafarigSprites42:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx42, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx42_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx42_2, 0x60
+ax_sprite_terminator
+sGirafarigGfx43:
+.incbin "baserom.gba", 0xE3A518, 0xC0
+sGirafarigGfx43_1:
+.incbin "baserom.gba", 0xE3A5D8, 0x60
+sGirafarigGfx43_2:
+.incbin "baserom.gba", 0xE3A638, 0x60
+sGirafarigSprites43:
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx43, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx43_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx43_2, 0x60
+ax_sprite_terminator
+sGirafarigGfx44:
+.incbin "baserom.gba", 0xE3A6D0, 0x100
+sGirafarigGfx44_1:
+.incbin "baserom.gba", 0xE3A7D0, 0x40
+sGirafarigGfx44_2:
+.incbin "baserom.gba", 0xE3A810, 0x40
+sGirafarigSprites44:
+ax_sprite sGirafarigGfx44, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx44_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx44_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx45:
+.incbin "baserom.gba", 0xE3A888, 0x100
+sGirafarigGfx45_1:
+.incbin "baserom.gba", 0xE3A988, 0x40
+sGirafarigGfx45_2:
+.incbin "baserom.gba", 0xE3A9C8, 0x40
+sGirafarigSprites45:
+ax_sprite sGirafarigGfx45, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGirafarigGfx45_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGirafarigGfx45_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGirafarigGfx46:
+.incbin "baserom.gba", 0xE3AA40, 0x200
+sGirafarigSprites46:
+ax_sprite sGirafarigGfx46, 0x200
+ax_sprite_terminator
+sGirafarigGfx47:
+.incbin "baserom.gba", 0xE3AC50, 0x200
+sGirafarigSprites47:
+ax_sprite sGirafarigGfx47, 0x200
+ax_sprite_terminator
+sGirafarigGfx48:
+.incbin "baserom.gba", 0xE3AE60, 0x200
+sGirafarigSprites48:
+ax_sprite sGirafarigGfx48, 0x200
+ax_sprite_terminator
+sGirafarigGfx49:
+.incbin "baserom.gba", 0xE3B070, 0x200
+sGirafarigSprites49:
+ax_sprite sGirafarigGfx49, 0x200
+ax_sprite_terminator
+sGirafarigGfx50:
+.incbin "baserom.gba", 0xE3B280, 0x200
+sGirafarigSprites50:
+ax_sprite sGirafarigGfx50, 0x200
+ax_sprite_terminator
+sGirafarigGfx51:
+.incbin "baserom.gba", 0xE3B490, 0x200
+sGirafarigSprites51:
+ax_sprite sGirafarigGfx51, 0x200
+ax_sprite_terminator
+sGirafarigGfx52:
+.incbin "baserom.gba", 0xE3B6A0, 0x200
+sGirafarigSprites52:
+ax_sprite sGirafarigGfx52, 0x200
+ax_sprite_terminator
+sAxPosesGirafarig:
+.4byte sGirafarigPose1
+.4byte sGirafarigPose2
+.4byte sGirafarigPose3
+.4byte sGirafarigPose4
+.4byte sGirafarigPose5
+.4byte sGirafarigPose6
+.4byte sGirafarigPose7
+.4byte sGirafarigPose8
+.4byte sGirafarigPose9
+.4byte sGirafarigPose10
+.4byte sGirafarigPose11
+.4byte sGirafarigPose12
+.4byte sGirafarigPose13
+.4byte sGirafarigPose14
+.4byte sGirafarigPose15
+.4byte sGirafarigPose16
+.4byte sGirafarigPose17
+.4byte sGirafarigPose18
+.4byte sGirafarigPose19
+.4byte sGirafarigPose20
+.4byte sGirafarigPose21
+.4byte sGirafarigPose22
+.4byte sGirafarigPose23
+.4byte sGirafarigPose24
+.4byte sGirafarigPose25
+.4byte sGirafarigPose26
+.4byte sGirafarigPose27
+.4byte sGirafarigPose28
+.4byte sGirafarigPose29
+.4byte sGirafarigPose30
+.4byte sGirafarigPose31
+.4byte sGirafarigPose32
+.4byte sGirafarigPose33
+.4byte sGirafarigPose34
+.4byte sGirafarigPose35
+.4byte sGirafarigPose36
+.4byte sGirafarigPose37
+.4byte sGirafarigPose38
+.4byte sGirafarigPose39
+.4byte sGirafarigPose40
+.4byte sGirafarigPose41
+.4byte sGirafarigPose42
+.4byte sGirafarigPose43
+.4byte sGirafarigPose44
+.4byte sGirafarigPose45
+.4byte sGirafarigPose46
+.4byte sGirafarigPose47
+.4byte sGirafarigPose48
+.4byte sGirafarigPose49
+.4byte sGirafarigPose50
+.4byte sGirafarigPose51
+.4byte sGirafarigPose52
+.4byte sGirafarigPose53
+.4byte sGirafarigPose54
+.4byte sGirafarigPose55
+.4byte sGirafarigPose56
+.4byte sGirafarigPose57
+.4byte sGirafarigPose58
+.4byte sGirafarigPose59
+.4byte sGirafarigPose60
+.4byte sGirafarigPose61
+.4byte sGirafarigPose62
+.4byte sGirafarigPose63
+.4byte sGirafarigPose64
+.4byte sGirafarigPose65
+.4byte sGirafarigPose66
+.4byte sGirafarigPose67
+.4byte sGirafarigPose68
+.4byte sGirafarigPose69
+.4byte sGirafarigPose70
+.4byte sGirafarigPose71
+.4byte sGirafarigPose72
+.4byte sGirafarigPose73
+.4byte sGirafarigPose74
+.4byte sGirafarigPose75
+.4byte sGirafarigPose76
+.4byte sGirafarigPose77
+.4byte sGirafarigPose78
+.4byte sGirafarigPose79
+.4byte sGirafarigPose80
+.4byte sGirafarigPose81
+.4byte sGirafarigPose82
+.4byte sGirafarigPose83
+.4byte sGirafarigPose84
+.4byte sGirafarigPose85
+.4byte sGirafarigPose86
+.4byte sGirafarigPose87
+.4byte sGirafarigPose88
+.4byte sGirafarigPose89
+.4byte sGirafarigPose90
+.4byte sGirafarigPose91
+.4byte sGirafarigPose92
+.4byte sGirafarigPose93
+.4byte sGirafarigPose94
+.4byte sGirafarigPose95
+.4byte sGirafarigPose96
+.4byte sGirafarigPose97
+.4byte sGirafarigPose98
+.4byte sGirafarigPose99
+.4byte sGirafarigPose100
+.4byte sGirafarigPose101
+.4byte sGirafarigPose102
+.4byte sGirafarigPose103
+.4byte sGirafarigPose104
+.4byte sGirafarigPose105
+.4byte sGirafarigPose106
+.4byte sGirafarigPose107
+.4byte sGirafarigPose108
+.4byte sGirafarigPose109
+.4byte sGirafarigPose110
+.4byte sGirafarigPose111
+.4byte sGirafarigPose112
+.4byte sGirafarigPose113
+.4byte sGirafarigPose114
+.4byte sGirafarigPose115
+.4byte sGirafarigPose116
+.4byte sGirafarigPose117
+.4byte sGirafarigPose118
+.4byte sGirafarigPose119
+.4byte sGirafarigPose120
+.4byte sGirafarigPose121
+.4byte sGirafarigPose122
+.4byte sGirafarigPose123
+.4byte sGirafarigPose124
+.4byte sGirafarigPose125
+.4byte sGirafarigPose126
+.4byte sGirafarigPose127
+.4byte sGirafarigPose128
+.4byte sGirafarigPose129
+.4byte sGirafarigPose130
+.4byte sGirafarigPose131
+.4byte sGirafarigPose132
+.4byte sGirafarigPose133
+.4byte sGirafarigPose134
+.4byte sGirafarigPose135
+.4byte sGirafarigPose136
+.4byte sGirafarigPose137
+.4byte sGirafarigPose138
+.4byte sGirafarigPose139
+.4byte sGirafarigPose140
+.4byte sGirafarigPose141
+.4byte sGirafarigPose142
+.4byte sGirafarigPose143
+.4byte sGirafarigPose144
+.4byte sGirafarigPose145
+.4byte sGirafarigPose146
+.4byte sGirafarigPose147
+.4byte sGirafarigPose148
+.4byte sGirafarigPose149
+.4byte sGirafarigPose150
+.4byte sGirafarigPose151
+.4byte sGirafarigPose152
+.4byte sGirafarigPose153
+.4byte sGirafarigPose154
+.4byte sGirafarigPose155
+.4byte sGirafarigPose156
+.4byte sGirafarigPose157
+.4byte sGirafarigPose158
+.4byte sGirafarigPose159
+.4byte sGirafarigPose160
+.4byte sGirafarigPose161
+.4byte sGirafarigPose162
+.4byte sGirafarigPose163
+.4byte sGirafarigPose164
+.4byte sGirafarigPose165
+.4byte sGirafarigPose166
+.4byte sGirafarigPose167
+.4byte sGirafarigPose168
+.4byte sGirafarigPose169
+.4byte sGirafarigPose170
+.4byte sGirafarigPose171
+.4byte sGirafarigPose172
+.4byte sGirafarigPose173
+.4byte sGirafarigPose174
+.4byte sGirafarigPose175
+.4byte sGirafarigPose176
+.4byte sGirafarigPose177
+.4byte sGirafarigPose178
+.4byte sGirafarigPose179
+.4byte sGirafarigPose180
+.4byte sGirafarigPose181
+.4byte sGirafarigPose182
+.4byte sGirafarigPose183
+.4byte sGirafarigPose184
+.4byte sGirafarigPose185
+.4byte sGirafarigPose186
+.4byte sGirafarigPose187
+.4byte sGirafarigPose188
+.4byte sGirafarigPose189
+.4byte sGirafarigPose190
+.4byte sGirafarigPose191
+.4byte sGirafarigPose192
+.4byte sGirafarigPose193
+.4byte sGirafarigPose194
+.4byte sGirafarigPose195
+.4byte sGirafarigPose196
+.4byte sGirafarigPose197
+.4byte sGirafarigPose198
+.4byte sGirafarigPose199
+.4byte sGirafarigPose200
+.4byte sGirafarigPose201
+.4byte sGirafarigPose202
+.4byte sGirafarigPose203
+.4byte sGirafarigPose204
+.4byte sGirafarigPose205
+.4byte sGirafarigPose206
+.4byte sGirafarigPose207
+.4byte sGirafarigPose208
+.4byte sGirafarigPose209
+.4byte sGirafarigPose210
+.4byte sGirafarigPose211
+.4byte sGirafarigPose212
+.4byte sGirafarigPose213
+.4byte sGirafarigPose214
+.4byte sGirafarigPose215
+.4byte sGirafarigPose216
+.4byte sGirafarigPose217
+.4byte sGirafarigPose218
+sAxPositionsGirafarig:
+.2byte    0,  -10, 	  -4,    1, 	   3,    1, 	   0,   -9
+.2byte    0,   -8, 	  -4,    3, 	   2,    0, 	  -1,   -8
+.2byte    0,   -8, 	  -3,    0, 	   3,    3, 	  -1,   -8
+.2byte    6,  -13, 	   5,    0, 	   0,    2, 	   1,   -9
+.2byte    7,  -11, 	   7,    2, 	  -2,    2, 	   0,   -8
+.2byte    7,  -11, 	   4,   -1, 	   2,    4, 	   0,   -8
+.2byte   10,  -15, 	   5,   -2, 	   4,    1, 	   1,   -9
+.2byte   11,  -13, 	   9,   -2, 	   1,    1, 	   1,   -8
+.2byte   11,  -13, 	   2,   -2, 	   6,    1, 	   1,   -8
+.2byte    5,  -18, 	   0,   -4, 	   6,   -2, 	   1,  -10
+.2byte    6,  -17, 	   0,   -3, 	   4,    0, 	   1,   -8
+.2byte    6,  -17, 	   0,   -3, 	   6,   -2, 	   1,   -8
+.2byte    0,  -18, 	   2,   -6, 	  -3,   -6, 	   0,   -9
+.2byte    0,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -9
+.2byte    0,  -17, 	   3,   -2, 	  -3,   -5, 	  -1,   -8
+.2byte   -5,  -18, 	   0,   -4, 	  -6,   -2, 	  -1,  -10
+.2byte   -6,  -17, 	   0,   -3, 	  -4,    0, 	  -1,   -8
+.2byte   -6,  -17, 	   0,   -3, 	  -6,   -2, 	  -1,   -8
+.2byte  -11,  -15, 	  -6,   -2, 	  -5,    1, 	  -2,   -9
+.2byte  -12,  -13, 	 -10,   -2, 	  -2,    1, 	  -2,   -8
+.2byte  -12,  -13, 	  -3,   -2, 	  -7,    1, 	  -2,   -8
+.2byte   -7,  -13, 	  -6,    0, 	  -1,    2, 	  -2,   -9
+.2byte   -8,  -11, 	  -8,    2, 	   1,    2, 	  -1,   -8
+.2byte   -8,  -11, 	  -5,   -1, 	  -3,    4, 	  -1,   -8
+.2byte    0,  -10, 	  -4,    1, 	   3,    1, 	   0,   -9
+.2byte    0,   -8, 	  -4,    3, 	   2,    0, 	  -1,   -8
+.2byte    0,   -8, 	  -3,    0, 	   3,    3, 	  -1,   -8
+.2byte    0,   -8, 	  -2,    1, 	   1,    1, 	  -1,   -8
+.2byte    0,  -12, 	  -1,   -1, 	   1,   -3, 	   0,  -11
+.2byte    6,  -13, 	   5,    0, 	   0,    2, 	   1,   -9
+.2byte    7,  -11, 	   7,    2, 	  -2,    2, 	   0,   -8
+.2byte    7,  -11, 	   4,   -1, 	   2,    4, 	   0,   -8
+.2byte    5,  -10, 	   5,    2, 	   3,    3, 	  -1,   -7
+.2byte    9,  -14, 	   7,   -2, 	   2,   -4, 	   0,  -10
+.2byte   10,  -15, 	   5,   -2, 	   4,    1, 	   1,   -9
+.2byte   11,  -13, 	   9,   -2, 	   1,    1, 	   1,   -8
+.2byte   11,  -13, 	   2,   -2, 	   6,    1, 	   1,   -8
+.2byte   10,  -12, 	   6,    0, 	   5,    1, 	  -1,   -7
+.2byte   12,  -17, 	   9,   -2, 	   5,   -3, 	   0,   -9
+.2byte    5,  -18, 	   0,   -4, 	   6,   -2, 	   1,  -10
+.2byte    6,  -17, 	   0,   -3, 	   4,    0, 	   1,   -8
+.2byte    6,  -17, 	   0,   -3, 	   6,   -2, 	   1,   -8
+.2byte    5,  -15, 	   3,   -3, 	   6,   -3, 	   0,   -8
+.2byte    8,  -23, 	   2,   -8, 	   5,   -7, 	   1,  -10
+.2byte    0,  -18, 	   2,   -6, 	  -3,   -6, 	   0,   -9
+.2byte    0,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -9
+.2byte    0,  -17, 	   3,   -2, 	  -3,   -5, 	  -1,   -8
+.2byte    0,  -17, 	   2,   -5, 	  -3,   -5, 	  -1,   -7
+.2byte    0,  -20, 	   2,   -7, 	  -3,   -7, 	   0,   -9
+.2byte   -5,  -18, 	   0,   -4, 	  -6,   -2, 	  -1,  -10
+.2byte   -6,  -17, 	   0,   -3, 	  -4,    0, 	  -1,   -8
+.2byte   -6,  -17, 	   0,   -3, 	  -6,   -2, 	  -1,   -8
+.2byte   -5,  -15, 	  -3,   -3, 	  -6,   -3, 	   0,   -8
+.2byte   -8,  -23, 	  -2,   -8, 	  -5,   -7, 	  -1,  -10
+.2byte  -11,  -15, 	  -6,   -2, 	  -5,    1, 	  -2,   -9
+.2byte  -12,  -13, 	 -10,   -2, 	  -2,    1, 	  -2,   -8
+.2byte  -12,  -13, 	  -3,   -2, 	  -7,    1, 	  -2,   -8
+.2byte  -11,  -12, 	  -7,    0, 	  -6,    1, 	   0,   -7
+.2byte  -13,  -17, 	 -10,   -2, 	  -6,   -3, 	  -1,   -9
+.2byte   -7,  -13, 	  -6,    0, 	  -1,    2, 	  -2,   -9
+.2byte   -8,  -11, 	  -8,    2, 	   1,    2, 	  -1,   -8
+.2byte   -8,  -11, 	  -5,   -1, 	  -3,    4, 	  -1,   -8
+.2byte   -6,  -10, 	  -6,    2, 	  -4,    3, 	   0,   -7
+.2byte  -10,  -14, 	  -8,   -2, 	  -3,   -4, 	  -1,  -10
+.2byte    0,  -10, 	  -4,    1, 	   3,    1, 	   0,   -9
+.2byte    0,   -8, 	  -4,    3, 	   2,    0, 	  -1,   -8
+.2byte    0,   -8, 	  -3,    0, 	   3,    3, 	  -1,   -8
+.2byte    3,  -24, 	  -5,  -12, 	   5,  -11, 	  -1,  -14
+.2byte    0,   -6, 	  -6,    3, 	   5,    3, 	  -1,   -6
+.2byte    6,  -13, 	   5,    0, 	   0,    2, 	   1,   -9
+.2byte    7,  -11, 	   7,    2, 	  -2,    2, 	   0,   -8
+.2byte    7,  -11, 	   4,   -1, 	   2,    4, 	   0,   -8
+.2byte    0,  -26, 	  10,  -18, 	   5,  -11, 	   0,  -13
+.2byte    8,   -7, 	   8,    1, 	   1,    3, 	  -1,   -8
+.2byte   10,  -15, 	   5,   -2, 	   4,    1, 	   1,   -9
+.2byte   11,  -13, 	   9,   -2, 	   1,    1, 	   1,   -8
+.2byte   11,  -13, 	   2,   -2, 	   6,    1, 	   1,   -8
+.2byte    0,  -24, 	   9,  -17, 	   7,  -10, 	  -3,  -10
+.2byte   13,   -9, 	   9,   -2, 	   8,    2, 	   1,   -7
+.2byte    5,  -18, 	   0,   -4, 	   6,   -2, 	   1,  -10
+.2byte    6,  -17, 	   0,   -3, 	   4,    0, 	   1,   -8
+.2byte    6,  -17, 	   0,   -3, 	   6,   -2, 	   1,   -8
+.2byte    0,  -23, 	   4,  -17, 	   7,  -12, 	  -2,  -10
+.2byte    6,  -15, 	  -1,   -9, 	   9,   -5, 	   0,   -9
+.2byte    0,  -18, 	   2,   -6, 	  -3,   -6, 	   0,   -9
+.2byte    0,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -9
+.2byte    0,  -17, 	   3,   -2, 	  -3,   -5, 	  -1,   -8
+.2byte   -2,  -23, 	   3,  -17, 	  -7,  -15, 	   0,   -9
+.2byte    0,  -15, 	   3,   -5, 	  -4,   -5, 	   0,   -8
+.2byte   -5,  -18, 	   0,   -4, 	  -6,   -2, 	  -1,  -10
+.2byte   -6,  -17, 	   0,   -3, 	  -4,    0, 	  -1,   -8
+.2byte   -6,  -17, 	   0,   -3, 	  -6,   -2, 	  -1,   -8
+.2byte    0,  -23, 	  -4,  -17, 	  -7,  -12, 	   2,  -10
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -5, 	  -2,   -9
+.2byte  -11,  -15, 	  -6,   -2, 	  -5,    1, 	  -2,   -9
+.2byte  -12,  -13, 	 -10,   -2, 	  -2,    1, 	  -2,   -8
+.2byte  -12,  -13, 	  -3,   -2, 	  -7,    1, 	  -2,   -8
+.2byte   -1,  -24, 	 -10,  -17, 	  -8,  -10, 	   2,  -10
+.2byte  -14,   -9, 	 -10,   -2, 	  -9,    2, 	  -2,   -7
+.2byte   -7,  -13, 	  -6,    0, 	  -1,    2, 	  -2,   -9
+.2byte   -8,  -11, 	  -8,    2, 	   1,    2, 	  -1,   -8
+.2byte   -8,  -11, 	  -5,   -1, 	  -3,    4, 	  -1,   -8
+.2byte   -1,  -26, 	 -11,  -18, 	  -6,  -11, 	  -1,  -13
+.2byte   -9,   -7, 	  -9,    1, 	  -2,    3, 	   0,   -8
+.2byte    0,   -7, 	  -2,    2, 	   1,    2, 	  -1,   -7
+.2byte   -6,  -10, 	  -6,    2, 	  -4,    3, 	   0,   -7
+.2byte  -11,  -12, 	  -7,    0, 	  -6,    1, 	   0,   -7
+.2byte   -5,  -15, 	  -3,   -3, 	  -6,   -3, 	   0,   -8
+.2byte    0,  -17, 	   2,   -5, 	  -3,   -5, 	  -1,   -7
+.2byte    5,  -15, 	   3,   -3, 	   6,   -3, 	   0,   -8
+.2byte   10,  -12, 	   6,    0, 	   5,    1, 	  -1,   -7
+.2byte    5,  -10, 	   5,    2, 	   3,    3, 	  -1,   -7
+.2byte    5,  -16, 	   4,   -1, 	   1,   -4, 	   0,  -11
+.2byte    6,  -15, 	   3,   -1, 	   1,   -4, 	   1,  -10
+.2byte    0,  -10, 	  -4,    1, 	   3,    1, 	   0,   -9
+.2byte   -7,  -13, 	  -6,    0, 	  -1,    2, 	  -2,   -9
+.2byte  -11,  -15, 	  -6,   -2, 	  -5,    1, 	  -2,   -9
+.2byte   -5,  -18, 	   0,   -4, 	  -6,   -2, 	  -1,  -10
+.2byte    0,  -18, 	   2,   -6, 	  -3,   -6, 	   0,   -9
+.2byte    5,  -18, 	   0,   -4, 	   6,   -2, 	   1,  -10
+.2byte   10,  -15, 	   5,   -2, 	   4,    1, 	   1,   -9
+.2byte    6,  -13, 	   5,    0, 	   0,    2, 	   1,   -9
+.2byte   -4,  -17, 	  -4,    2, 	  -8,    0, 	  -2,   -9
+.2byte   -3,  -16, 	  -4,    2, 	  -8,    0, 	   0,  -10
+.2byte    0,  -18, 	   0,    1, 	  -7,    0, 	   0,   -9
+.2byte    1,  -17, 	   0,    1, 	  -7,    0, 	   0,   -8
+.2byte   -2,  -24, 	  -8,   -2, 	  -5,   -4, 	  -3,   -9
+.2byte   -1,  -23, 	  -8,   -2, 	  -4,   -4, 	  -1,   -9
+.2byte   -6,  -20, 	  -7,   -1, 	  -4,    2, 	  -2,   -9
+.2byte   -7,  -21, 	  -7,   -1, 	  -4,    2, 	  -3,  -10
+.2byte    1,  -24, 	   7,   -2, 	   4,   -4, 	   2,   -9
+.2byte    0,  -23, 	   7,   -2, 	   3,   -4, 	   0,   -9
+.2byte   -1,  -18, 	  -1,    1, 	   6,    0, 	  -1,   -9
+.2byte   -2,  -17, 	  -1,    1, 	   6,    0, 	  -1,   -8
+.2byte    3,  -18, 	   3,    1, 	   7,   -1, 	   1,  -10
+.2byte    2,  -17, 	   3,    1, 	   7,   -1, 	  -1,  -11
+.2byte   -8,   -6, 	  -5,    1, 	  -1,    2, 	  -1,   -3
+.2byte   -9,   -5, 	  -5,    0, 	  -1,    2, 	  -1,   -3
+.2byte    0,  -25, 	  -3,  -11, 	   2,  -11, 	   0,  -13
+.2byte    1,  -24, 	   7,   -9, 	   3,   -6, 	  -1,  -14
+.2byte    4,  -27, 	   5,  -12, 	   5,  -10, 	  -1,  -14
+.2byte    2,  -25, 	   0,  -12, 	   6,  -10, 	   0,  -11
+.2byte    0,  -19, 	   2,   -9, 	  -3,   -9, 	  -1,  -10
+.2byte   -3,  -25, 	  -1,  -12, 	  -7,  -10, 	  -1,  -11
+.2byte   -5,  -27, 	  -6,  -12, 	  -6,  -10, 	   0,  -14
+.2byte   -2,  -24, 	  -8,   -9, 	  -4,   -6, 	   0,  -14
+.2byte    0,  -10, 	  -4,    1, 	   3,    1, 	   0,   -9
+.2byte    0,   -6, 	  -6,    3, 	   5,    3, 	  -1,   -6
+.2byte    6,  -13, 	   5,    0, 	   0,    2, 	   1,   -9
+.2byte    8,   -7, 	   8,    1, 	   1,    3, 	  -1,   -8
+.2byte   10,  -15, 	   5,   -2, 	   4,    1, 	   1,   -9
+.2byte   11,   -9, 	   7,   -2, 	   6,    2, 	  -1,   -7
+.2byte    5,  -18, 	   0,   -4, 	   6,   -2, 	   1,  -10
+.2byte    6,  -13, 	  -1,   -7, 	   9,   -3, 	   0,   -7
+.2byte    0,  -18, 	   2,   -6, 	  -3,   -6, 	   0,   -9
+.2byte    0,  -14, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte   -5,  -18, 	   0,   -4, 	  -6,   -2, 	  -1,  -10
+.2byte   -7,  -13, 	   0,   -7, 	 -10,   -3, 	  -1,   -7
+.2byte  -11,  -15, 	  -6,   -2, 	  -5,    1, 	  -2,   -9
+.2byte  -12,   -9, 	  -8,   -2, 	  -7,    2, 	   0,   -7
+.2byte   -7,  -13, 	  -6,    0, 	  -1,    2, 	  -2,   -9
+.2byte   -9,   -7, 	  -9,    1, 	  -2,    3, 	   0,   -8
+.2byte    0,  -12, 	  -1,   -1, 	   1,   -3, 	   0,  -11
+.2byte  -10,  -14, 	  -8,   -2, 	  -3,   -4, 	  -1,  -10
+.2byte  -13,  -18, 	 -10,   -3, 	  -6,   -4, 	  -1,  -10
+.2byte   -8,  -23, 	  -2,   -8, 	  -5,   -7, 	  -1,  -10
+.2byte    0,  -21, 	   2,   -8, 	  -3,   -8, 	   0,  -10
+.2byte    8,  -23, 	   2,   -8, 	   5,   -7, 	   1,  -10
+.2byte   12,  -18, 	   9,   -3, 	   5,   -4, 	   0,  -10
+.2byte    9,  -14, 	   7,   -2, 	   2,   -4, 	   0,  -10
+.2byte    3,  -24, 	  -5,  -12, 	   5,  -11, 	  -1,  -14
+.2byte    0,  -25, 	  10,  -17, 	   5,  -10, 	   0,  -12
+.2byte    1,  -24, 	  10,  -17, 	   8,  -10, 	  -2,  -10
+.2byte    1,  -23, 	   5,  -17, 	   8,  -12, 	  -1,  -10
+.2byte   -2,  -23, 	   3,  -17, 	  -7,  -15, 	   0,   -9
+.2byte   -1,  -23, 	  -5,  -17, 	  -8,  -12, 	   1,  -10
+.2byte   -2,  -24, 	 -11,  -17, 	  -9,  -10, 	   1,  -10
+.2byte   -1,  -25, 	 -11,  -17, 	  -6,  -10, 	  -1,  -12
+.2byte    0,  -10, 	  -4,    1, 	   3,    1, 	   0,   -9
+.2byte    3,  -24, 	  -5,  -12, 	   5,  -11, 	  -1,  -14
+.2byte    0,   -6, 	  -6,    3, 	   5,    3, 	  -1,   -6
+.2byte    6,  -13, 	   5,    0, 	   0,    2, 	   1,   -9
+.2byte    0,  -26, 	  10,  -18, 	   5,  -11, 	   0,  -13
+.2byte    8,   -7, 	   8,    1, 	   1,    3, 	  -1,   -8
+.2byte   10,  -15, 	   5,   -2, 	   4,    1, 	   1,   -9
+.2byte    1,  -24, 	  10,  -17, 	   8,  -10, 	  -2,  -10
+.2byte   11,   -9, 	   7,   -2, 	   6,    2, 	  -1,   -7
+.2byte    5,  -18, 	   0,   -4, 	   6,   -2, 	   1,  -10
+.2byte    1,  -23, 	   5,  -17, 	   8,  -12, 	  -1,  -10
+.2byte    5,  -15, 	  -2,   -9, 	   8,   -5, 	  -1,   -9
+.2byte    0,  -18, 	   2,   -6, 	  -3,   -6, 	   0,   -9
+.2byte   -2,  -23, 	   3,  -17, 	  -7,  -15, 	   0,   -9
+.2byte    0,  -15, 	   3,   -5, 	  -4,   -5, 	   0,   -8
+.2byte   -5,  -18, 	   0,   -4, 	  -6,   -2, 	  -1,  -10
+.2byte   -1,  -23, 	  -5,  -17, 	  -8,  -12, 	   1,  -10
+.2byte   -7,  -15, 	   0,   -9, 	 -10,   -5, 	  -1,   -9
+.2byte  -11,  -15, 	  -6,   -2, 	  -5,    1, 	  -2,   -9
+.2byte   -2,  -24, 	 -11,  -17, 	  -9,  -10, 	   1,  -10
+.2byte  -12,   -9, 	  -8,   -2, 	  -7,    2, 	   0,   -7
+.2byte   -7,  -13, 	  -6,    0, 	  -1,    2, 	  -2,   -9
+.2byte   -1,  -26, 	 -11,  -18, 	  -6,  -11, 	  -1,  -13
+.2byte   -9,   -7, 	  -9,    1, 	  -2,    3, 	   0,   -8
+.2byte    0,   -7, 	  -2,    2, 	   1,    2, 	  -1,   -7
+.2byte   -6,  -10, 	  -6,    2, 	  -4,    3, 	   0,   -7
+.2byte  -11,  -12, 	  -7,    0, 	  -6,    1, 	   0,   -7
+.2byte   -5,  -15, 	  -3,   -3, 	  -6,   -3, 	   0,   -8
+.2byte    0,  -17, 	   2,   -5, 	  -3,   -5, 	  -1,   -7
+.2byte    5,  -15, 	   3,   -3, 	   6,   -3, 	   0,   -8
+.2byte   10,  -12, 	   6,    0, 	   5,    1, 	  -1,   -7
+.2byte    5,  -10, 	   5,    2, 	   3,    3, 	  -1,   -7
+.2byte    0,  -10, 	  -4,    1, 	   3,    1, 	   0,   -9
+.2byte   -7,  -13, 	  -6,    0, 	  -1,    2, 	  -2,   -9
+.2byte  -11,  -15, 	  -6,   -2, 	  -5,    1, 	  -2,   -9
+.2byte   -5,  -18, 	   0,   -4, 	  -6,   -2, 	  -1,  -10
+.2byte    0,  -18, 	   2,   -6, 	  -3,   -6, 	   0,   -9
+.2byte    5,  -18, 	   0,   -4, 	   6,   -2, 	   1,  -10
+.2byte   10,  -15, 	   5,   -2, 	   4,    1, 	   1,   -9
+.2byte    6,  -13, 	   5,    0, 	   0,    2, 	   1,   -9
+sGirafarigAnimTable1:
+.4byte sGirafarigAnims_1_1
+.4byte sGirafarigAnims_1_2
+.4byte sGirafarigAnims_1_3
+.4byte sGirafarigAnims_1_4
+.4byte sGirafarigAnims_1_5
+.4byte sGirafarigAnims_1_6
+.4byte sGirafarigAnims_1_7
+.4byte sGirafarigAnims_1_8
+sGirafarigAnimTable2:
+.4byte sGirafarigAnims_2_1
+.4byte sGirafarigAnims_2_2
+.4byte sGirafarigAnims_2_3
+.4byte sGirafarigAnims_2_4
+.4byte sGirafarigAnims_2_5
+.4byte sGirafarigAnims_2_6
+.4byte sGirafarigAnims_2_7
+.4byte sGirafarigAnims_2_8
+sGirafarigAnimTable3:
+.4byte sGirafarigAnims_3_1
+.4byte sGirafarigAnims_3_2
+.4byte sGirafarigAnims_3_3
+.4byte sGirafarigAnims_3_4
+.4byte sGirafarigAnims_3_5
+.4byte sGirafarigAnims_3_6
+.4byte sGirafarigAnims_3_7
+.4byte sGirafarigAnims_3_8
+sGirafarigAnimTable4:
+.4byte sGirafarigAnims_4_1
+.4byte sGirafarigAnims_4_2
+.4byte sGirafarigAnims_4_3
+.4byte sGirafarigAnims_4_4
+.4byte sGirafarigAnims_4_5
+.4byte sGirafarigAnims_4_6
+.4byte sGirafarigAnims_4_7
+.4byte sGirafarigAnims_4_8
+sGirafarigAnimTable5:
+.4byte sGirafarigAnims_5_1
+.4byte sGirafarigAnims_5_2
+.4byte sGirafarigAnims_5_3
+.4byte sGirafarigAnims_5_4
+.4byte sGirafarigAnims_5_5
+.4byte sGirafarigAnims_5_6
+.4byte sGirafarigAnims_5_7
+.4byte sGirafarigAnims_5_8
+sGirafarigAnimTable6:
+.4byte sGirafarigAnims_6_1
+.4byte sGirafarigAnims_6_1
+.4byte sGirafarigAnims_6_1
+.4byte sGirafarigAnims_6_1
+.4byte sGirafarigAnims_6_1
+.4byte sGirafarigAnims_6_1
+.4byte sGirafarigAnims_6_1
+.4byte sGirafarigAnims_6_1
+sGirafarigAnimTable7:
+.4byte sGirafarigAnims_7_1
+.4byte sGirafarigAnims_7_2
+.4byte sGirafarigAnims_7_3
+.4byte sGirafarigAnims_7_4
+.4byte sGirafarigAnims_7_5
+.4byte sGirafarigAnims_7_6
+.4byte sGirafarigAnims_7_7
+.4byte sGirafarigAnims_7_8
+sGirafarigAnimTable8:
+.4byte sGirafarigAnims_8_1
+.4byte sGirafarigAnims_8_2
+.4byte sGirafarigAnims_8_3
+.4byte sGirafarigAnims_8_4
+.4byte sGirafarigAnims_8_5
+.4byte sGirafarigAnims_8_6
+.4byte sGirafarigAnims_8_7
+.4byte sGirafarigAnims_8_8
+sGirafarigAnimTable9:
+.4byte sGirafarigAnims_9_1
+.4byte sGirafarigAnims_9_2
+.4byte sGirafarigAnims_9_3
+.4byte sGirafarigAnims_9_4
+.4byte sGirafarigAnims_9_5
+.4byte sGirafarigAnims_9_6
+.4byte sGirafarigAnims_9_7
+.4byte sGirafarigAnims_9_8
+sGirafarigAnimTable10:
+.4byte sGirafarigAnims_10_1
+.4byte sGirafarigAnims_10_2
+.4byte sGirafarigAnims_10_3
+.4byte sGirafarigAnims_10_4
+.4byte sGirafarigAnims_10_5
+.4byte sGirafarigAnims_10_6
+.4byte sGirafarigAnims_10_7
+.4byte sGirafarigAnims_10_8
+sGirafarigAnimTable11:
+.4byte sGirafarigAnims_11_1
+.4byte sGirafarigAnims_11_2
+.4byte sGirafarigAnims_11_3
+.4byte sGirafarigAnims_11_4
+.4byte sGirafarigAnims_11_5
+.4byte sGirafarigAnims_11_6
+.4byte sGirafarigAnims_11_7
+.4byte sGirafarigAnims_11_8
+sGirafarigAnimTable12:
+.4byte sGirafarigAnims_12_1
+.4byte sGirafarigAnims_12_2
+.4byte sGirafarigAnims_12_3
+.4byte sGirafarigAnims_12_4
+.4byte sGirafarigAnims_12_5
+.4byte sGirafarigAnims_12_6
+.4byte sGirafarigAnims_12_7
+.4byte sGirafarigAnims_12_8
+sGirafarigAnimTable13:
+.4byte sGirafarigAnims_13_1
+.4byte sGirafarigAnims_13_2
+.4byte sGirafarigAnims_13_3
+.4byte sGirafarigAnims_13_4
+.4byte sGirafarigAnims_13_5
+.4byte sGirafarigAnims_13_6
+.4byte sGirafarigAnims_13_7
+.4byte sGirafarigAnims_13_8
+sAxAnimationsGirafarig:
+.4byte sGirafarigAnimTable1
+.4byte sGirafarigAnimTable2
+.4byte sGirafarigAnimTable3
+.4byte sGirafarigAnimTable4
+.4byte sGirafarigAnimTable5
+.4byte sGirafarigAnimTable6
+.4byte sGirafarigAnimTable7
+.4byte sGirafarigAnimTable8
+.4byte sGirafarigAnimTable9
+.4byte sGirafarigAnimTable10
+.4byte sGirafarigAnimTable11
+.4byte sGirafarigAnimTable12
+.4byte sGirafarigAnimTable13
+sAxSpritesGirafarig:
+.4byte sGirafarigSprites1
+.4byte sGirafarigSprites2
+.4byte sGirafarigSprites3
+.4byte sGirafarigSprites4
+.4byte sGirafarigSprites5
+.4byte sGirafarigSprites6
+.4byte sGirafarigSprites7
+.4byte sGirafarigSprites8
+.4byte sGirafarigSprites9
+.4byte sGirafarigSprites10
+.4byte sGirafarigSprites11
+.4byte sGirafarigSprites12
+.4byte sGirafarigSprites13
+.4byte sGirafarigSprites14
+.4byte sGirafarigSprites15
+.4byte sGirafarigSprites16
+.4byte sGirafarigSprites17
+.4byte sGirafarigSprites18
+.4byte sGirafarigSprites19
+.4byte sGirafarigSprites20
+.4byte sGirafarigSprites21
+.4byte sGirafarigSprites22
+.4byte sGirafarigSprites23
+.4byte sGirafarigSprites24
+.4byte sGirafarigSprites25
+.4byte sGirafarigSprites26
+.4byte sGirafarigSprites27
+.4byte sGirafarigSprites28
+.4byte sGirafarigSprites29
+.4byte sGirafarigSprites30
+.4byte sGirafarigSprites31
+.4byte sGirafarigSprites32
+.4byte sGirafarigSprites33
+.4byte sGirafarigSprites34
+.4byte sGirafarigSprites35
+.4byte sGirafarigSprites36
+.4byte sGirafarigSprites37
+.4byte sGirafarigSprites38
+.4byte sGirafarigSprites39
+.4byte sGirafarigSprites40
+.4byte sGirafarigSprites41
+.4byte sGirafarigSprites42
+.4byte sGirafarigSprites43
+.4byte sGirafarigSprites44
+.4byte sGirafarigSprites45
+.4byte sGirafarigSprites46
+.4byte sGirafarigSprites47
+.4byte sGirafarigSprites48
+.4byte sGirafarigSprites49
+.4byte sGirafarigSprites50
+.4byte sGirafarigSprites51
+.4byte sGirafarigSprites52
+sAxMainGirafarig:
+ax_main sAxPosesGirafarig, sAxAnimationsGirafarig, 13, sAxSpritesGirafarig, sAxPositionsGirafarig

--- a/data/ax/glalie.inc
+++ b/data/ax/glalie.inc
@@ -1,0 +1,2550 @@
+.global gAxGlalie
+gAxGlalie:
+ax_siro sAxMainGlalie
+sGlaliePose1:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose2:
+ax_pose 1, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose3:
+ax_pose 2, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose4:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose5:
+ax_pose 4, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose6:
+ax_pose 5, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose7:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose8:
+ax_pose 7, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose9:
+ax_pose 7, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose10:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose11:
+ax_pose 9, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose12:
+ax_pose 10, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose13:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose14:
+ax_pose 12, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose15:
+ax_pose 13, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose16:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose17:
+ax_pose 9, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose18:
+ax_pose 10, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose19:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose20:
+ax_pose 14, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose21:
+ax_pose 7, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose22:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose23:
+ax_pose 4, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose24:
+ax_pose 5, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose25:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose26:
+ax_pose 15, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose27:
+ax_pose 16, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose28:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose29:
+ax_pose 17, 0x01e1, 0x90ed, 0x5c00
+ax_pose_terminator
+sGlaliePose30:
+ax_pose 18, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose31:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose32:
+ax_pose 19, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose33:
+ax_pose 20, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose34:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose35:
+ax_pose 21, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sGlaliePose36:
+ax_pose 22, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose37:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose38:
+ax_pose 23, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose39:
+ax_pose 24, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose40:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose41:
+ax_pose 21, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sGlaliePose42:
+ax_pose 22, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose43:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose44:
+ax_pose 19, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose45:
+ax_pose 20, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose46:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose47:
+ax_pose 17, 0x01e1, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose48:
+ax_pose 18, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose49:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose50:
+ax_pose 15, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose51:
+ax_pose 16, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose52:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose53:
+ax_pose 17, 0x01e1, 0x90ed, 0x5c00
+ax_pose_terminator
+sGlaliePose54:
+ax_pose 18, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose55:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose56:
+ax_pose 19, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose57:
+ax_pose 20, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose58:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose59:
+ax_pose 21, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sGlaliePose60:
+ax_pose 22, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose61:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose62:
+ax_pose 23, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose63:
+ax_pose 24, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose64:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose65:
+ax_pose 21, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sGlaliePose66:
+ax_pose 22, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose67:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose68:
+ax_pose 19, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose69:
+ax_pose 20, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose70:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose71:
+ax_pose 17, 0x01e1, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose72:
+ax_pose 18, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose73:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose74:
+ax_pose 16, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose75:
+ax_pose 25, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose76:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose77:
+ax_pose 18, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose78:
+ax_pose 26, 0x01e1, 0x90ed, 0x5c00
+ax_pose_terminator
+sGlaliePose79:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose80:
+ax_pose 20, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose81:
+ax_pose 27, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose82:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose83:
+ax_pose 22, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose84:
+ax_pose 21, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sGlaliePose85:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose86:
+ax_pose 24, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose87:
+ax_pose 23, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose88:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose89:
+ax_pose 22, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose90:
+ax_pose 21, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sGlaliePose91:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose92:
+ax_pose 20, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose93:
+ax_pose 27, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose94:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose95:
+ax_pose 18, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose96:
+ax_pose 26, 0x01e1, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose97:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose98:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose99:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose100:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose101:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose102:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose103:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose104:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose105:
+ax_pose 28, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose106:
+ax_pose 29, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose107:
+ax_pose 30, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose108:
+ax_pose 31, 0x01df, 0x90ed, 0x5c00
+ax_pose_terminator
+sGlaliePose109:
+ax_pose 32, 0x01df, 0x90ed, 0x5c00
+ax_pose_terminator
+sGlaliePose110:
+ax_pose 33, 0x01e0, 0x90ee, 0x5c00
+ax_pose_terminator
+sGlaliePose111:
+ax_pose 34, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose112:
+ax_pose 33, 0x01e0, 0x80f2, 0x5c00
+ax_pose_terminator
+sGlaliePose113:
+ax_pose 32, 0x01df, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose114:
+ax_pose 31, 0x01df, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose115:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose116:
+ax_pose 1, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose117:
+ax_pose 2, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose118:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose119:
+ax_pose 4, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose120:
+ax_pose 5, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose121:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose122:
+ax_pose 7, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose123:
+ax_pose 7, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose124:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose125:
+ax_pose 9, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose126:
+ax_pose 10, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose127:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose128:
+ax_pose 12, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose129:
+ax_pose 13, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose130:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose131:
+ax_pose 9, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose132:
+ax_pose 10, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose133:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose134:
+ax_pose 14, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose135:
+ax_pose 7, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose136:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose137:
+ax_pose 4, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose138:
+ax_pose 5, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose139:
+ax_pose 16, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose140:
+ax_pose 18, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose141:
+ax_pose 20, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose142:
+ax_pose 22, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose143:
+ax_pose 24, 0x01e1, 0x90f0, 0x5c00
+ax_pose_terminator
+sGlaliePose144:
+ax_pose 22, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose145:
+ax_pose 20, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose146:
+ax_pose 18, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose147:
+ax_pose 16, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose148:
+ax_pose 18, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose149:
+ax_pose 20, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose150:
+ax_pose 22, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose151:
+ax_pose 24, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose152:
+ax_pose 22, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose153:
+ax_pose 20, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose154:
+ax_pose 18, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose155:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose156:
+ax_pose 16, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose157:
+ax_pose 25, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose158:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose159:
+ax_pose 18, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose160:
+ax_pose 26, 0x01e1, 0x90ed, 0x5c00
+ax_pose_terminator
+sGlaliePose161:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose162:
+ax_pose 20, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose163:
+ax_pose 27, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose164:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose165:
+ax_pose 22, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose166:
+ax_pose 21, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sGlaliePose167:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose168:
+ax_pose 24, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose169:
+ax_pose 23, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose170:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose171:
+ax_pose 22, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose172:
+ax_pose 21, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sGlaliePose173:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose174:
+ax_pose 20, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose175:
+ax_pose 27, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose176:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose177:
+ax_pose 18, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose178:
+ax_pose 26, 0x01e1, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose179:
+ax_pose 15, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose180:
+ax_pose 17, 0x01e1, 0x80f3, 0x5c00
+ax_pose_terminator
+sGlaliePose181:
+ax_pose 19, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose182:
+ax_pose 21, 0x01e1, 0x80f1, 0x5c00
+ax_pose_terminator
+sGlaliePose183:
+ax_pose 23, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose184:
+ax_pose 21, 0x01e1, 0x90ef, 0x5c00
+ax_pose_terminator
+sGlaliePose185:
+ax_pose 19, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose186:
+ax_pose 17, 0x01e1, 0x90ed, 0x5c00
+ax_pose_terminator
+sGlaliePose187:
+ax_pose 0, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose188:
+ax_pose 3, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose189:
+ax_pose 6, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose190:
+ax_pose 8, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sGlaliePose191:
+ax_pose 11, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sGlaliePose192:
+ax_pose 8, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose193:
+ax_pose 6, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+sGlaliePose194:
+ax_pose 3, 0x01e1, 0x90ec, 0x5c00
+ax_pose_terminator
+.align 2
+sGlalieAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 1, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 0, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGlalieAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 11, 10, 11,
+ax_anim 2, 0, 28, 19, 23, 19, 23,
+ax_anim 2, 1, 28, 20, 22, 20, 22,
+ax_anim 2, 0, 28, 19, 23, 19, 23,
+ax_anim 2, 0, 28, 20, 22, 20, 22,
+ax_anim 2, 0, 27, 6, 7, 6, 7,
+ax_anim_terminator
+sGlalieAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 19, 0, 19, 0,
+ax_anim 2, 1, 31, 19, 1, 19, 1,
+ax_anim 2, 0, 31, 19, 0, 19, 0,
+ax_anim 2, 0, 31, 19, 1, 19, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sGlalieAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 34, 13, -13, 13, -13,
+ax_anim 2, 0, 34, 19, -19, 19, -19,
+ax_anim 2, 1, 34, 20, -18, 20, -18,
+ax_anim 2, 0, 34, 19, -19, 19, -19,
+ax_anim 2, 0, 34, 20, -18, 20, -18,
+ax_anim 2, 0, 33, 7, -6, 7, -6,
+ax_anim_terminator
+sGlalieAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -5, 0, -5,
+ax_anim 1, 0, 37, 0, -12, 0, -12,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sGlalieAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -6, -6, -6, -6,
+ax_anim 1, 0, 40, -13, -13, -13, -13,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 1, 40, -20, -18, -20, -18,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -20, -18, -20, -18,
+ax_anim 2, 0, 39, -7, -6, -7, -6,
+ax_anim_terminator
+sGlalieAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 1, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 0, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sGlalieAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 11, -10, 11,
+ax_anim 2, 0, 46, -19, 23, -19, 23,
+ax_anim 2, 1, 46, -20, 22, -20, 22,
+ax_anim 2, 0, 46, -19, 23, -19, 23,
+ax_anim 2, 0, 46, -20, 22, -20, 22,
+ax_anim 2, 0, 45, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sGlalieAnims_3_1:
+ax_anim 1, 0, 50, 0, 3, 0, 3,
+ax_anim 1, 0, 50, 0, 8, 0, 8,
+ax_anim 2, 0, 50, 0, 14, 0, 14,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 6, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 2, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 49, 1, 22, 1, 22,
+ax_anim 2, 1, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 49, 1, 22, 1, 22,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 49, 1, 22, 1, 22,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 48, 0, 12, 0, 12,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sGlalieAnims_3_2:
+ax_anim 1, 0, 53, 3, 3, 3, 3,
+ax_anim 1, 0, 53, 8, 9, 8, 9,
+ax_anim 2, 0, 53, 13, 15, 13, 15,
+ax_anim 2, 0, 53, 17, 20, 17, 20,
+ax_anim 6, 0, 53, 17, 20, 17, 20,
+ax_anim 2, 2, 52, 19, 22, 19, 22,
+ax_anim 2, 0, 52, 20, 21, 20, 21,
+ax_anim 2, 1, 52, 19, 22, 19, 22,
+ax_anim 2, 0, 52, 20, 21, 20, 21,
+ax_anim 2, 0, 52, 19, 22, 19, 22,
+ax_anim 2, 0, 52, 20, 21, 20, 21,
+ax_anim 2, 0, 52, 19, 22, 19, 22,
+ax_anim 2, 0, 51, 11, 13, 11, 13,
+ax_anim 2, 0, 51, 4, 4, 4, 4,
+ax_anim_terminator
+sGlalieAnims_3_3:
+ax_anim 1, 0, 56, 3, 0, 3, 0,
+ax_anim 1, 0, 56, 8, 0, 8, 0,
+ax_anim 2, 0, 56, 12, 0, 12, 0,
+ax_anim 2, 0, 56, 17, 0, 17, 0,
+ax_anim 6, 0, 56, 17, 0, 17, 0,
+ax_anim 2, 2, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 2, 1, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 54, 12, 0, 12, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim_terminator
+sGlalieAnims_3_4:
+ax_anim 1, 0, 59, 3, -3, 3, -3,
+ax_anim 1, 0, 59, 9, -7, 9, -7,
+ax_anim 2, 0, 59, 13, -10, 13, -10,
+ax_anim 2, 0, 59, 17, -13, 17, -13,
+ax_anim 6, 0, 59, 17, -13, 17, -13,
+ax_anim 2, 2, 58, 19, -15, 19, -15,
+ax_anim 2, 0, 58, 20, -14, 20, -14,
+ax_anim 2, 1, 58, 19, -15, 19, -15,
+ax_anim 2, 0, 58, 20, -14, 20, -14,
+ax_anim 2, 0, 58, 19, -15, 19, -15,
+ax_anim 2, 0, 58, 20, -14, 20, -14,
+ax_anim 2, 0, 58, 19, -15, 19, -15,
+ax_anim 2, 0, 57, 13, -10, 13, -10,
+ax_anim 2, 0, 57, 5, -4, 5, -4,
+ax_anim_terminator
+sGlalieAnims_3_5:
+ax_anim 1, 0, 62, 0, -3, 0, -3,
+ax_anim 1, 0, 62, 0, -6, 0, -6,
+ax_anim 2, 0, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 62, 0, -14, 0, -14,
+ax_anim 6, 0, 62, 0, -14, 0, -14,
+ax_anim 2, 2, 61, 0, -16, 0, -16,
+ax_anim 2, 0, 61, 1, -16, 1, -16,
+ax_anim 2, 1, 61, 0, -16, 0, -16,
+ax_anim 2, 0, 61, 1, -16, 1, -16,
+ax_anim 2, 0, 61, 0, -16, 0, -16,
+ax_anim 2, 0, 61, 1, -16, 1, -16,
+ax_anim 2, 0, 61, 0, -16, 0, -16,
+ax_anim 2, 0, 60, 0, -10, 0, -10,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sGlalieAnims_3_6:
+ax_anim 1, 0, 65, -3, -3, -3, -3,
+ax_anim 1, 0, 65, -9, -7, -9, -7,
+ax_anim 2, 0, 65, -13, -10, -13, -10,
+ax_anim 2, 0, 65, -17, -13, -17, -13,
+ax_anim 6, 0, 65, -17, -13, -17, -13,
+ax_anim 2, 2, 64, -19, -15, -19, -15,
+ax_anim 2, 0, 64, -20, -14, -20, -14,
+ax_anim 2, 1, 64, -19, -15, -19, -15,
+ax_anim 2, 0, 64, -20, -14, -20, -14,
+ax_anim 2, 0, 64, -19, -15, -19, -15,
+ax_anim 2, 0, 64, -20, -14, -20, -14,
+ax_anim 2, 0, 64, -19, -15, -19, -15,
+ax_anim 2, 0, 63, -13, -10, -13, -10,
+ax_anim 2, 0, 63, -5, -4, -5, -4,
+ax_anim_terminator
+sGlalieAnims_3_7:
+ax_anim 1, 0, 68, -3, 0, -3, 0,
+ax_anim 1, 0, 68, -8, 0, -8, 0,
+ax_anim 2, 0, 68, -12, 0, -12, 0,
+ax_anim 2, 0, 68, -17, 0, -17, 0,
+ax_anim 6, 0, 68, -17, 0, -17, 0,
+ax_anim 2, 2, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 67, -20, 1, -20, 1,
+ax_anim 2, 1, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 66, -12, 0, -12, 0,
+ax_anim 2, 0, 66, -4, 0, -4, 0,
+ax_anim_terminator
+sGlalieAnims_3_8:
+ax_anim 1, 0, 71, -3, 3, -3, 3,
+ax_anim 1, 0, 71, -8, 9, -8, 9,
+ax_anim 2, 0, 71, -13, 15, -13, 15,
+ax_anim 2, 0, 71, -17, 20, -17, 20,
+ax_anim 6, 0, 71, -17, 20, -17, 20,
+ax_anim 2, 2, 70, -19, 22, -19, 22,
+ax_anim 2, 0, 70, -20, 21, -20, 21,
+ax_anim 2, 1, 70, -19, 22, -19, 22,
+ax_anim 2, 0, 70, -20, 21, -20, 21,
+ax_anim 2, 0, 70, -19, 22, -19, 22,
+ax_anim 2, 0, 70, -20, 21, -20, 21,
+ax_anim 2, 0, 70, -19, 22, -19, 22,
+ax_anim 2, 0, 69, -11, 13, -11, 13,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGlalieAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sGlalieAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 5, 3, 5, 3,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 5, 3, 5, 3,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 5, 3, 5, 3,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim_terminator
+sGlalieAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 79, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sGlalieAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 82, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sGlalieAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 86, 1, -5, 1, -5,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 86, 1, -5, 1, -5,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 86, 1, -5, 1, -5,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim_terminator
+sGlalieAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 88, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sGlalieAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 91, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sGlalieAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -5, 3, -5, 3,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -5, 3, -5, 3,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -5, 3, -5, 3,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGlalieAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sGlalieAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sGlalieAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sGlalieAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sGlalieAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sGlalieAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sGlalieAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sGlalieAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sGlalieAnims_8_1:
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, -1, 0, 0,
+ax_anim 6, 0, 114, 0, -2, 0, 0,
+ax_anim 6, 0, 116, 0, -2, 0, 0,
+ax_anim 6, 0, 114, 0, -1, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_8_2:
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, -1, 0, 0,
+ax_anim 6, 0, 117, 0, -2, 0, 0,
+ax_anim 6, 0, 119, 0, -2, 0, 0,
+ax_anim 6, 0, 117, 0, -1, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_8_3:
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, -1, 0, 0,
+ax_anim 6, 0, 120, 0, -2, 0, 0,
+ax_anim 6, 0, 122, 0, -2, 0, 0,
+ax_anim 6, 0, 120, 0, -1, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_8_4:
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, -1, 0, 0,
+ax_anim 6, 0, 123, 0, -2, 0, 0,
+ax_anim 6, 0, 125, 0, -2, 0, 0,
+ax_anim 6, 0, 123, 0, -1, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_8_5:
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, -1, 0, 0,
+ax_anim 6, 0, 126, 0, -2, 0, 0,
+ax_anim 6, 0, 128, 0, -2, 0, 0,
+ax_anim 6, 0, 126, 0, -1, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_8_6:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 130, 0, -1, 0, 0,
+ax_anim 6, 0, 129, 0, -2, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 129, 0, -1, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_8_7:
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 133, 0, -1, 0, 0,
+ax_anim 6, 0, 132, 0, -2, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 132, 0, -1, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_8_8:
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 136, 0, -1, 0, 0,
+ax_anim 6, 0, 135, 0, -2, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 135, 0, -1, 0, 0,
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 10, 11, 10, 11,
+ax_anim 2, 0, 141, 7, 21, 7, 20,
+ax_anim 3, 0, 142, 0, 24, 0, 21,
+ax_anim 2, 3, 143, -7, 21, -7, 20,
+ax_anim 2, 0, 144, -10, 11, -10, 11,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 10, 1, 10, 1,
+ax_anim 2, 0, 139, 21, 7, 21, 7,
+ax_anim 2, 0, 140, 24, 15, 24, 15,
+ax_anim 3, 0, 141, 20, 23, 20, 21,
+ax_anim 2, 3, 142, 10, 23, 10, 20,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 8, 0, 8,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 4, -3, 4, -3,
+ax_anim 2, 0, 138, 11, -5, 11, -5,
+ax_anim 2, 0, 139, 17, -4, 17, -4,
+ax_anim 3, 0, 140, 21, 2, 21, 0,
+ax_anim 2, 3, 141, 16, 4, 16, 4,
+ax_anim 2, 0, 142, 12, 5, 12, 5,
+ax_anim 1, 0, 143, 6, 4, 6, 4,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 145, 3, -12, 3, -12,
+ax_anim 2, 0, 138, 10, -17, 10, -19,
+ax_anim 3, 0, 139, 19, -16, 19, -18,
+ax_anim 2, 3, 140, 20, -9, 20, -9,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 9, 1, 9, 1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -7, -3, -7, -3,
+ax_anim 2, 0, 144, -9, -9, -9, -9,
+ax_anim 2, 0, 145, -7, -15, -7, -16,
+ax_anim 3, 0, 138, 0, -17, 0, -19,
+ax_anim 2, 3, 139, 7, -15, 7, -16,
+ax_anim 2, 0, 140, 9, -9, 9, -9,
+ax_anim 1, 0, 141, 7, -3, 7, -3,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -6, 1, -6,
+ax_anim 2, 0, 139, -3, -12, -3, -12,
+ax_anim 2, 0, 138, -10, -17, -10, -19,
+ax_anim 3, 0, 145, -19, -16, -19, -18,
+ax_anim 2, 3, 144, -20, -9, -20, -9,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -9, -1, -9, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -5, -11, -5,
+ax_anim 2, 0, 145, -17, -4, -17, -4,
+ax_anim 3, 0, 144, -21, 2, -21, 0,
+ax_anim 2, 3, 143, -16, 4, -16, 4,
+ax_anim 2, 0, 142, -12, 5, -12, 5,
+ax_anim 1, 0, 141, -8, 5, -8, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -10, 1, -10, 1,
+ax_anim 2, 0, 145, -21, 7, -21, 7,
+ax_anim 2, 0, 144, -24, 15, -24, 15,
+ax_anim 3, 0, 143, -20, 23, -20, 21,
+ax_anim 2, 3, 142, -10, 23, -10, 20,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 8,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 3, 0, 0,
+ax_anim_terminator
+sGlalieAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 3, 0, 0,
+ax_anim_terminator
+sGlalieAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 3, 0, 0,
+ax_anim_terminator
+sGlalieAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 3, 0, 0,
+ax_anim_terminator
+sGlalieAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 3, 0, 0,
+ax_anim_terminator
+sGlalieAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 3, 0, 0,
+ax_anim_terminator
+sGlalieAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 3, 0, 0,
+ax_anim_terminator
+sGlalieAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGlalieAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sGlalieGfx1:
+.incbin "baserom.gba", 0x14F4A98, 0x200
+sGlalieSprites1:
+ax_sprite sGlalieGfx1, 0x200
+ax_sprite_terminator
+sGlalieGfx2:
+.incbin "baserom.gba", 0x14F4CA8, 0x200
+sGlalieSprites2:
+ax_sprite sGlalieGfx2, 0x200
+ax_sprite_terminator
+sGlalieGfx3:
+.incbin "baserom.gba", 0x14F4EB8, 0x200
+sGlalieSprites3:
+ax_sprite sGlalieGfx3, 0x200
+ax_sprite_terminator
+sGlalieGfx4:
+.incbin "baserom.gba", 0x14F50C8, 0x200
+sGlalieSprites4:
+ax_sprite sGlalieGfx4, 0x200
+ax_sprite_terminator
+sGlalieGfx5:
+.incbin "baserom.gba", 0x14F52D8, 0x200
+sGlalieSprites5:
+ax_sprite sGlalieGfx5, 0x200
+ax_sprite_terminator
+sGlalieGfx6:
+.incbin "baserom.gba", 0x14F54E8, 0x200
+sGlalieSprites6:
+ax_sprite sGlalieGfx6, 0x200
+ax_sprite_terminator
+sGlalieGfx7:
+.incbin "baserom.gba", 0x14F56F8, 0x200
+sGlalieSprites7:
+ax_sprite sGlalieGfx7, 0x200
+ax_sprite_terminator
+sGlalieGfx8:
+.incbin "baserom.gba", 0x14F5908, 0x200
+sGlalieSprites8:
+ax_sprite sGlalieGfx8, 0x200
+ax_sprite_terminator
+sGlalieGfx9:
+.incbin "baserom.gba", 0x14F5B18, 0x200
+sGlalieSprites9:
+ax_sprite sGlalieGfx9, 0x200
+ax_sprite_terminator
+sGlalieGfx10:
+.incbin "baserom.gba", 0x14F5D28, 0x200
+sGlalieSprites10:
+ax_sprite sGlalieGfx10, 0x200
+ax_sprite_terminator
+sGlalieGfx11:
+.incbin "baserom.gba", 0x14F5F38, 0x200
+sGlalieSprites11:
+ax_sprite sGlalieGfx11, 0x200
+ax_sprite_terminator
+sGlalieGfx12:
+.incbin "baserom.gba", 0x14F6148, 0x200
+sGlalieSprites12:
+ax_sprite sGlalieGfx12, 0x200
+ax_sprite_terminator
+sGlalieGfx13:
+.incbin "baserom.gba", 0x14F6358, 0x200
+sGlalieSprites13:
+ax_sprite sGlalieGfx13, 0x200
+ax_sprite_terminator
+sGlalieGfx14:
+.incbin "baserom.gba", 0x14F6568, 0x200
+sGlalieSprites14:
+ax_sprite sGlalieGfx14, 0x200
+ax_sprite_terminator
+sGlalieGfx15:
+.incbin "baserom.gba", 0x14F6778, 0x200
+sGlalieSprites15:
+ax_sprite sGlalieGfx15, 0x200
+ax_sprite_terminator
+sGlalieGfx16:
+.incbin "baserom.gba", 0x14F6988, 0x40
+sGlalieGfx16_1:
+.incbin "baserom.gba", 0x14F69C8, 0x180
+sGlalieSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx16_1, 0x180
+ax_sprite_terminator
+sGlalieGfx17:
+.incbin "baserom.gba", 0x14F6B70, 0x40
+sGlalieGfx17_1:
+.incbin "baserom.gba", 0x14F6BB0, 0x180
+sGlalieSprites17:
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx17_1, 0x180
+ax_sprite_terminator
+sGlalieGfx18:
+.incbin "baserom.gba", 0x14F6D58, 0x60
+sGlalieGfx18_1:
+.incbin "baserom.gba", 0x14F6DB8, 0x160
+sGlalieSprites18:
+ax_sprite sGlalieGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx18_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGlalieGfx19:
+.incbin "baserom.gba", 0x14F6F40, 0x40
+sGlalieGfx19_1:
+.incbin "baserom.gba", 0x14F6F80, 0xE0
+sGlalieGfx19_2:
+.incbin "baserom.gba", 0x14F7060, 0x60
+sGlalieSprites19:
+ax_sprite sGlalieGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGlalieGfx19_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGlalieGfx20:
+.incbin "baserom.gba", 0x14F70F8, 0x60
+sGlalieGfx20_1:
+.incbin "baserom.gba", 0x14F7158, 0x60
+sGlalieGfx20_2:
+.incbin "baserom.gba", 0x14F71B8, 0x60
+sGlalieGfx20_3:
+.incbin "baserom.gba", 0x14F7218, 0x60
+sGlalieSprites20:
+ax_sprite sGlalieGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGlalieGfx21:
+.incbin "baserom.gba", 0x14F72C0, 0x40
+sGlalieGfx21_1:
+.incbin "baserom.gba", 0x14F7300, 0x60
+sGlalieGfx21_2:
+.incbin "baserom.gba", 0x14F7360, 0x60
+sGlalieGfx21_3:
+.incbin "baserom.gba", 0x14F73C0, 0x60
+sGlalieSprites21:
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGlalieGfx22:
+.incbin "baserom.gba", 0x14F7470, 0x40
+sGlalieGfx22_1:
+.incbin "baserom.gba", 0x14F74B0, 0x180
+sGlalieSprites22:
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx22_1, 0x180
+ax_sprite_terminator
+sGlalieGfx23:
+.incbin "baserom.gba", 0x14F7658, 0x20
+sGlalieGfx23_1:
+.incbin "baserom.gba", 0x14F7678, 0x100
+sGlalieGfx23_2:
+.incbin "baserom.gba", 0x14F7778, 0x60
+sGlalieSprites23:
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGlalieGfx24:
+.incbin "baserom.gba", 0x14F7818, 0x200
+sGlalieSprites24:
+ax_sprite sGlalieGfx24, 0x200
+ax_sprite_terminator
+sGlalieGfx25:
+.incbin "baserom.gba", 0x14F7A28, 0x40
+sGlalieGfx25_1:
+.incbin "baserom.gba", 0x14F7A68, 0x180
+sGlalieSprites25:
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx25_1, 0x180
+ax_sprite_terminator
+sGlalieGfx26:
+.incbin "baserom.gba", 0x14F7C10, 0x40
+sGlalieGfx26_1:
+.incbin "baserom.gba", 0x14F7C50, 0x180
+sGlalieSprites26:
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx26_1, 0x180
+ax_sprite_terminator
+sGlalieGfx27:
+.incbin "baserom.gba", 0x14F7DF8, 0x60
+sGlalieGfx27_1:
+.incbin "baserom.gba", 0x14F7E58, 0x160
+sGlalieSprites27:
+ax_sprite sGlalieGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGlalieGfx28:
+.incbin "baserom.gba", 0x14F7FE0, 0x60
+sGlalieGfx28_1:
+.incbin "baserom.gba", 0x14F8040, 0x60
+sGlalieGfx28_2:
+.incbin "baserom.gba", 0x14F80A0, 0x60
+sGlalieGfx28_3:
+.incbin "baserom.gba", 0x14F8100, 0x60
+sGlalieSprites28:
+ax_sprite sGlalieGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGlalieGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGlalieGfx29:
+.incbin "baserom.gba", 0x14F81A8, 0x200
+sGlalieSprites29:
+ax_sprite sGlalieGfx29, 0x200
+ax_sprite_terminator
+sGlalieGfx30:
+.incbin "baserom.gba", 0x14F83B8, 0x200
+sGlalieSprites30:
+ax_sprite sGlalieGfx30, 0x200
+ax_sprite_terminator
+sGlalieGfx31:
+.incbin "baserom.gba", 0x14F85C8, 0x200
+sGlalieSprites31:
+ax_sprite sGlalieGfx31, 0x200
+ax_sprite_terminator
+sGlalieGfx32:
+.incbin "baserom.gba", 0x14F87D8, 0x200
+sGlalieSprites32:
+ax_sprite sGlalieGfx32, 0x200
+ax_sprite_terminator
+sGlalieGfx33:
+.incbin "baserom.gba", 0x14F89E8, 0x200
+sGlalieSprites33:
+ax_sprite sGlalieGfx33, 0x200
+ax_sprite_terminator
+sGlalieGfx34:
+.incbin "baserom.gba", 0x14F8BF8, 0x200
+sGlalieSprites34:
+ax_sprite sGlalieGfx34, 0x200
+ax_sprite_terminator
+sGlalieGfx35:
+.incbin "baserom.gba", 0x14F8E08, 0x200
+sGlalieSprites35:
+ax_sprite sGlalieGfx35, 0x200
+ax_sprite_terminator
+sAxPosesGlalie:
+.4byte sGlaliePose1
+.4byte sGlaliePose2
+.4byte sGlaliePose3
+.4byte sGlaliePose4
+.4byte sGlaliePose5
+.4byte sGlaliePose6
+.4byte sGlaliePose7
+.4byte sGlaliePose8
+.4byte sGlaliePose9
+.4byte sGlaliePose10
+.4byte sGlaliePose11
+.4byte sGlaliePose12
+.4byte sGlaliePose13
+.4byte sGlaliePose14
+.4byte sGlaliePose15
+.4byte sGlaliePose16
+.4byte sGlaliePose17
+.4byte sGlaliePose18
+.4byte sGlaliePose19
+.4byte sGlaliePose20
+.4byte sGlaliePose21
+.4byte sGlaliePose22
+.4byte sGlaliePose23
+.4byte sGlaliePose24
+.4byte sGlaliePose25
+.4byte sGlaliePose26
+.4byte sGlaliePose27
+.4byte sGlaliePose28
+.4byte sGlaliePose29
+.4byte sGlaliePose30
+.4byte sGlaliePose31
+.4byte sGlaliePose32
+.4byte sGlaliePose33
+.4byte sGlaliePose34
+.4byte sGlaliePose35
+.4byte sGlaliePose36
+.4byte sGlaliePose37
+.4byte sGlaliePose38
+.4byte sGlaliePose39
+.4byte sGlaliePose40
+.4byte sGlaliePose41
+.4byte sGlaliePose42
+.4byte sGlaliePose43
+.4byte sGlaliePose44
+.4byte sGlaliePose45
+.4byte sGlaliePose46
+.4byte sGlaliePose47
+.4byte sGlaliePose48
+.4byte sGlaliePose49
+.4byte sGlaliePose50
+.4byte sGlaliePose51
+.4byte sGlaliePose52
+.4byte sGlaliePose53
+.4byte sGlaliePose54
+.4byte sGlaliePose55
+.4byte sGlaliePose56
+.4byte sGlaliePose57
+.4byte sGlaliePose58
+.4byte sGlaliePose59
+.4byte sGlaliePose60
+.4byte sGlaliePose61
+.4byte sGlaliePose62
+.4byte sGlaliePose63
+.4byte sGlaliePose64
+.4byte sGlaliePose65
+.4byte sGlaliePose66
+.4byte sGlaliePose67
+.4byte sGlaliePose68
+.4byte sGlaliePose69
+.4byte sGlaliePose70
+.4byte sGlaliePose71
+.4byte sGlaliePose72
+.4byte sGlaliePose73
+.4byte sGlaliePose74
+.4byte sGlaliePose75
+.4byte sGlaliePose76
+.4byte sGlaliePose77
+.4byte sGlaliePose78
+.4byte sGlaliePose79
+.4byte sGlaliePose80
+.4byte sGlaliePose81
+.4byte sGlaliePose82
+.4byte sGlaliePose83
+.4byte sGlaliePose84
+.4byte sGlaliePose85
+.4byte sGlaliePose86
+.4byte sGlaliePose87
+.4byte sGlaliePose88
+.4byte sGlaliePose89
+.4byte sGlaliePose90
+.4byte sGlaliePose91
+.4byte sGlaliePose92
+.4byte sGlaliePose93
+.4byte sGlaliePose94
+.4byte sGlaliePose95
+.4byte sGlaliePose96
+.4byte sGlaliePose97
+.4byte sGlaliePose98
+.4byte sGlaliePose99
+.4byte sGlaliePose100
+.4byte sGlaliePose101
+.4byte sGlaliePose102
+.4byte sGlaliePose103
+.4byte sGlaliePose104
+.4byte sGlaliePose105
+.4byte sGlaliePose106
+.4byte sGlaliePose107
+.4byte sGlaliePose108
+.4byte sGlaliePose109
+.4byte sGlaliePose110
+.4byte sGlaliePose111
+.4byte sGlaliePose112
+.4byte sGlaliePose113
+.4byte sGlaliePose114
+.4byte sGlaliePose115
+.4byte sGlaliePose116
+.4byte sGlaliePose117
+.4byte sGlaliePose118
+.4byte sGlaliePose119
+.4byte sGlaliePose120
+.4byte sGlaliePose121
+.4byte sGlaliePose122
+.4byte sGlaliePose123
+.4byte sGlaliePose124
+.4byte sGlaliePose125
+.4byte sGlaliePose126
+.4byte sGlaliePose127
+.4byte sGlaliePose128
+.4byte sGlaliePose129
+.4byte sGlaliePose130
+.4byte sGlaliePose131
+.4byte sGlaliePose132
+.4byte sGlaliePose133
+.4byte sGlaliePose134
+.4byte sGlaliePose135
+.4byte sGlaliePose136
+.4byte sGlaliePose137
+.4byte sGlaliePose138
+.4byte sGlaliePose139
+.4byte sGlaliePose140
+.4byte sGlaliePose141
+.4byte sGlaliePose142
+.4byte sGlaliePose143
+.4byte sGlaliePose144
+.4byte sGlaliePose145
+.4byte sGlaliePose146
+.4byte sGlaliePose147
+.4byte sGlaliePose148
+.4byte sGlaliePose149
+.4byte sGlaliePose150
+.4byte sGlaliePose151
+.4byte sGlaliePose152
+.4byte sGlaliePose153
+.4byte sGlaliePose154
+.4byte sGlaliePose155
+.4byte sGlaliePose156
+.4byte sGlaliePose157
+.4byte sGlaliePose158
+.4byte sGlaliePose159
+.4byte sGlaliePose160
+.4byte sGlaliePose161
+.4byte sGlaliePose162
+.4byte sGlaliePose163
+.4byte sGlaliePose164
+.4byte sGlaliePose165
+.4byte sGlaliePose166
+.4byte sGlaliePose167
+.4byte sGlaliePose168
+.4byte sGlaliePose169
+.4byte sGlaliePose170
+.4byte sGlaliePose171
+.4byte sGlaliePose172
+.4byte sGlaliePose173
+.4byte sGlaliePose174
+.4byte sGlaliePose175
+.4byte sGlaliePose176
+.4byte sGlaliePose177
+.4byte sGlaliePose178
+.4byte sGlaliePose179
+.4byte sGlaliePose180
+.4byte sGlaliePose181
+.4byte sGlaliePose182
+.4byte sGlaliePose183
+.4byte sGlaliePose184
+.4byte sGlaliePose185
+.4byte sGlaliePose186
+.4byte sGlaliePose187
+.4byte sGlaliePose188
+.4byte sGlaliePose189
+.4byte sGlaliePose190
+.4byte sGlaliePose191
+.4byte sGlaliePose192
+.4byte sGlaliePose193
+.4byte sGlaliePose194
+sAxPositionsGlalie:
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte   -1,   -6, 	  -8,  -10, 	   8,  -10, 	   0,  -12
+.2byte   -1,   -6, 	  -8,  -10, 	   8,  -10, 	   0,  -12
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+.2byte    5,   -7, 	   9,  -11, 	  -5,   -7, 	  -1,  -11
+.2byte    5,   -7, 	   9,  -11, 	  -5,   -7, 	  -1,  -11
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    3,  -12, 	  -7,  -19, 	   7,  -10, 	  -2,  -11
+.2byte    3,  -12, 	  -7,  -20, 	   8,  -10, 	  -3,  -11
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte    0,   -8, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte   -4,  -12, 	   6,  -19, 	  -8,  -10, 	   1,  -11
+.2byte   -4,  -12, 	   6,  -20, 	  -9,  -10, 	   2,  -11
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte  -10,   -8, 	  -9,  -15, 	  -4,   -8, 	   1,  -12
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -7, 	 -10,  -11, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -7, 	 -10,  -11, 	   4,   -7, 	   0,  -11
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	  -1,  -13
+.2byte    0,  -11, 	  -9,  -15, 	   8,  -15, 	  -1,  -15
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+.2byte    5,   -5, 	   9,  -13, 	  -6,   -8, 	   1,  -13
+.2byte    4,  -12, 	   9,  -16, 	  -7,  -11, 	   2,  -14
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    6,   -5, 	   7,  -16, 	   0,   -6, 	   0,  -14
+.2byte   10,  -14, 	   1,  -21, 	   1,   -8, 	   0,  -13
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    1,  -14, 	  -9,  -19, 	   9,  -12, 	  -3,  -14
+.2byte    6,  -16, 	  -9,  -17, 	   5,  -12, 	  -2,  -14
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte   -1,  -10, 	  10,  -15, 	 -11,  -15, 	  -1,  -13
+.2byte   -1,  -15, 	  10,  -14, 	 -11,  -13, 	  -1,  -13
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte   -2,  -14, 	   8,  -19, 	 -10,  -12, 	   2,  -14
+.2byte   -7,  -16, 	   8,  -17, 	  -6,  -12, 	   1,  -14
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte   -7,   -5, 	  -8,  -16, 	  -1,   -6, 	  -1,  -14
+.2byte  -11,  -14, 	  -2,  -21, 	  -2,   -8, 	  -1,  -13
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -5, 	 -10,  -13, 	   5,   -8, 	  -2,  -13
+.2byte   -5,  -12, 	 -10,  -16, 	   6,  -11, 	  -3,  -14
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	  -1,  -13
+.2byte    0,  -11, 	  -9,  -15, 	   8,  -15, 	  -1,  -15
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+.2byte    5,   -5, 	   9,  -13, 	  -6,   -8, 	   1,  -13
+.2byte    4,  -12, 	   9,  -16, 	  -7,  -11, 	   2,  -14
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    6,   -5, 	   7,  -16, 	   0,   -6, 	   0,  -14
+.2byte   10,  -14, 	   1,  -21, 	   1,   -8, 	   0,  -13
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    1,  -14, 	  -9,  -19, 	   9,  -12, 	  -3,  -14
+.2byte    6,  -16, 	  -9,  -17, 	   5,  -12, 	  -2,  -14
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte   -1,  -10, 	  10,  -15, 	 -11,  -15, 	  -1,  -13
+.2byte   -1,  -15, 	  10,  -14, 	 -11,  -13, 	  -1,  -13
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte   -2,  -14, 	   8,  -19, 	 -10,  -12, 	   2,  -14
+.2byte   -7,  -16, 	   8,  -17, 	  -6,  -12, 	   1,  -14
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte   -7,   -5, 	  -8,  -16, 	  -1,   -6, 	  -1,  -14
+.2byte  -11,  -14, 	  -2,  -21, 	  -2,   -8, 	  -1,  -13
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -5, 	 -10,  -13, 	   5,   -8, 	  -2,  -13
+.2byte   -5,  -12, 	 -10,  -16, 	   6,  -11, 	  -3,  -14
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte    0,  -11, 	  -9,  -15, 	   8,  -15, 	  -1,  -15
+.2byte   -1,   -4, 	  -9,  -11, 	   8,  -11, 	  -1,  -13
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+.2byte    4,  -12, 	   9,  -16, 	  -7,  -11, 	   2,  -14
+.2byte    5,   -4, 	  10,  -13, 	  -6,   -7, 	   1,  -13
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte   10,  -14, 	   1,  -21, 	   1,   -8, 	   0,  -13
+.2byte    5,   -4, 	   7,  -15, 	  -1,   -6, 	   1,  -13
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    6,  -16, 	  -9,  -17, 	   5,  -12, 	  -2,  -14
+.2byte    1,  -14, 	  -9,  -19, 	   9,  -12, 	  -3,  -14
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte   -1,  -15, 	  10,  -14, 	 -11,  -13, 	  -1,  -13
+.2byte   -1,  -10, 	  10,  -15, 	 -11,  -15, 	  -1,  -13
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte   -7,  -16, 	   8,  -17, 	  -6,  -12, 	   1,  -14
+.2byte   -2,  -14, 	   8,  -19, 	 -10,  -12, 	   2,  -14
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte  -11,  -14, 	  -2,  -21, 	  -2,   -8, 	  -1,  -13
+.2byte   -6,   -4, 	  -8,  -15, 	   0,   -6, 	  -2,  -13
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte   -5,  -12, 	 -10,  -16, 	   6,  -11, 	  -3,  -14
+.2byte   -6,   -4, 	 -11,  -13, 	   5,   -7, 	  -2,  -13
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+.2byte   -6,   -5, 	  -8,  -12, 	   6,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -7,  -13, 	   6,   -6, 	   0,   -9
+.2byte   -1,   -8, 	  -8,  -12, 	   7,  -12, 	   0,  -13
+.2byte    4,   -9, 	   7,  -15, 	  -7,  -10, 	  -2,  -13
+.2byte    8,   -9, 	   7,  -18, 	   3,  -11, 	  -2,  -12
+.2byte    3,  -13, 	  -9,  -20, 	   8,  -12, 	  -2,  -11
+.2byte    0,  -12, 	   9,  -14, 	 -10,  -14, 	  -1,  -12
+.2byte   -4,  -13, 	   8,  -20, 	  -9,  -12, 	   1,  -11
+.2byte   -9,   -9, 	  -8,  -18, 	  -4,  -11, 	   1,  -12
+.2byte   -5,   -9, 	  -8,  -15, 	   6,  -10, 	   1,  -13
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte   -1,   -6, 	  -8,  -10, 	   8,  -10, 	   0,  -12
+.2byte   -1,   -6, 	  -8,  -10, 	   8,  -10, 	   0,  -12
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+.2byte    5,   -7, 	   9,  -11, 	  -5,   -7, 	  -1,  -11
+.2byte    5,   -7, 	   9,  -11, 	  -5,   -7, 	  -1,  -11
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    3,  -12, 	  -7,  -19, 	   7,  -10, 	  -2,  -11
+.2byte    3,  -12, 	  -7,  -20, 	   8,  -10, 	  -3,  -11
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte    0,   -8, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte   -4,  -12, 	   6,  -19, 	  -8,  -10, 	   1,  -11
+.2byte   -4,  -12, 	   6,  -20, 	  -9,  -10, 	   2,  -11
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte  -10,   -8, 	  -9,  -15, 	  -4,   -8, 	   1,  -12
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -7, 	 -10,  -11, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -7, 	 -10,  -11, 	   4,   -7, 	   0,  -11
+.2byte    0,  -11, 	  -9,  -15, 	   8,  -15, 	  -1,  -15
+.2byte   -5,  -12, 	 -10,  -16, 	   6,  -11, 	  -3,  -14
+.2byte  -11,  -14, 	  -2,  -21, 	  -2,   -8, 	  -1,  -13
+.2byte   -7,  -16, 	   8,  -17, 	  -6,  -12, 	   1,  -14
+.2byte    0,  -15, 	 -11,  -14, 	  10,  -13, 	   0,  -13
+.2byte    6,  -16, 	  -9,  -17, 	   5,  -12, 	  -2,  -14
+.2byte   10,  -14, 	   1,  -21, 	   1,   -8, 	   0,  -13
+.2byte    4,  -12, 	   9,  -16, 	  -7,  -11, 	   2,  -14
+.2byte    0,  -11, 	  -9,  -15, 	   8,  -15, 	  -1,  -15
+.2byte    4,  -12, 	   9,  -16, 	  -7,  -11, 	   2,  -14
+.2byte   10,  -14, 	   1,  -21, 	   1,   -8, 	   0,  -13
+.2byte    6,  -16, 	  -9,  -17, 	   5,  -12, 	  -2,  -14
+.2byte   -1,  -15, 	  10,  -14, 	 -11,  -13, 	  -1,  -13
+.2byte   -7,  -16, 	   8,  -17, 	  -6,  -12, 	   1,  -14
+.2byte  -11,  -14, 	  -2,  -21, 	  -2,   -8, 	  -1,  -13
+.2byte   -5,  -12, 	 -10,  -16, 	   6,  -11, 	  -3,  -14
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte    0,  -11, 	  -9,  -15, 	   8,  -15, 	  -1,  -15
+.2byte   -1,   -4, 	  -9,  -11, 	   8,  -11, 	  -1,  -13
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+.2byte    4,  -12, 	   9,  -16, 	  -7,  -11, 	   2,  -14
+.2byte    5,   -4, 	  10,  -13, 	  -6,   -7, 	   1,  -13
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte   10,  -14, 	   1,  -21, 	   1,   -8, 	   0,  -13
+.2byte    5,   -4, 	   7,  -15, 	  -1,   -6, 	   1,  -13
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    6,  -16, 	  -9,  -17, 	   5,  -12, 	  -2,  -14
+.2byte    1,  -14, 	  -9,  -19, 	   9,  -12, 	  -3,  -14
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte   -1,  -15, 	  10,  -14, 	 -11,  -13, 	  -1,  -13
+.2byte   -1,  -10, 	  10,  -15, 	 -11,  -15, 	  -1,  -13
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte   -7,  -16, 	   8,  -17, 	  -6,  -12, 	   1,  -14
+.2byte   -2,  -14, 	   8,  -19, 	 -10,  -12, 	   2,  -14
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte  -11,  -14, 	  -2,  -21, 	  -2,   -8, 	  -1,  -13
+.2byte   -6,   -4, 	  -8,  -15, 	   0,   -6, 	  -2,  -13
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte   -5,  -12, 	 -10,  -16, 	   6,  -11, 	  -3,  -14
+.2byte   -6,   -4, 	 -11,  -13, 	   5,   -7, 	  -2,  -13
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	  -1,  -13
+.2byte   -6,   -5, 	 -10,  -13, 	   5,   -8, 	  -2,  -13
+.2byte   -7,   -5, 	  -8,  -16, 	  -1,   -6, 	  -1,  -14
+.2byte   -2,  -14, 	   8,  -19, 	 -10,  -12, 	   2,  -14
+.2byte   -1,  -10, 	  10,  -15, 	 -11,  -15, 	  -1,  -13
+.2byte    1,  -14, 	  -9,  -19, 	   9,  -12, 	  -3,  -14
+.2byte    6,   -5, 	   7,  -16, 	   0,   -6, 	   0,  -14
+.2byte    5,   -5, 	   9,  -13, 	  -6,   -8, 	   1,  -13
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte   -6,   -7, 	 -10,  -12, 	   4,   -7, 	   0,  -11
+.2byte  -10,   -8, 	  -9,  -15, 	  -5,   -8, 	   1,  -12
+.2byte   -3,  -12, 	   6,  -19, 	  -9,  -11, 	   1,  -12
+.2byte    0,   -9, 	   9,  -14, 	 -10,  -14, 	   0,  -13
+.2byte    2,  -12, 	  -7,  -19, 	   8,  -11, 	  -2,  -12
+.2byte    9,   -8, 	   8,  -15, 	   4,   -8, 	  -2,  -12
+.2byte    5,   -7, 	   9,  -12, 	  -5,   -7, 	  -1,  -11
+sGlalieAnimTable1:
+.4byte sGlalieAnims_1_1
+.4byte sGlalieAnims_1_2
+.4byte sGlalieAnims_1_3
+.4byte sGlalieAnims_1_4
+.4byte sGlalieAnims_1_5
+.4byte sGlalieAnims_1_6
+.4byte sGlalieAnims_1_7
+.4byte sGlalieAnims_1_8
+sGlalieAnimTable2:
+.4byte sGlalieAnims_2_1
+.4byte sGlalieAnims_2_2
+.4byte sGlalieAnims_2_3
+.4byte sGlalieAnims_2_4
+.4byte sGlalieAnims_2_5
+.4byte sGlalieAnims_2_6
+.4byte sGlalieAnims_2_7
+.4byte sGlalieAnims_2_8
+sGlalieAnimTable3:
+.4byte sGlalieAnims_3_1
+.4byte sGlalieAnims_3_2
+.4byte sGlalieAnims_3_3
+.4byte sGlalieAnims_3_4
+.4byte sGlalieAnims_3_5
+.4byte sGlalieAnims_3_6
+.4byte sGlalieAnims_3_7
+.4byte sGlalieAnims_3_8
+sGlalieAnimTable4:
+.4byte sGlalieAnims_4_1
+.4byte sGlalieAnims_4_2
+.4byte sGlalieAnims_4_3
+.4byte sGlalieAnims_4_4
+.4byte sGlalieAnims_4_5
+.4byte sGlalieAnims_4_6
+.4byte sGlalieAnims_4_7
+.4byte sGlalieAnims_4_8
+sGlalieAnimTable5:
+.4byte sGlalieAnims_5_1
+.4byte sGlalieAnims_5_2
+.4byte sGlalieAnims_5_3
+.4byte sGlalieAnims_5_4
+.4byte sGlalieAnims_5_5
+.4byte sGlalieAnims_5_6
+.4byte sGlalieAnims_5_7
+.4byte sGlalieAnims_5_8
+sGlalieAnimTable6:
+.4byte sGlalieAnims_6_1
+.4byte sGlalieAnims_6_1
+.4byte sGlalieAnims_6_1
+.4byte sGlalieAnims_6_1
+.4byte sGlalieAnims_6_1
+.4byte sGlalieAnims_6_1
+.4byte sGlalieAnims_6_1
+.4byte sGlalieAnims_6_1
+sGlalieAnimTable7:
+.4byte sGlalieAnims_7_1
+.4byte sGlalieAnims_7_2
+.4byte sGlalieAnims_7_3
+.4byte sGlalieAnims_7_4
+.4byte sGlalieAnims_7_5
+.4byte sGlalieAnims_7_6
+.4byte sGlalieAnims_7_7
+.4byte sGlalieAnims_7_8
+sGlalieAnimTable8:
+.4byte sGlalieAnims_8_1
+.4byte sGlalieAnims_8_2
+.4byte sGlalieAnims_8_3
+.4byte sGlalieAnims_8_4
+.4byte sGlalieAnims_8_5
+.4byte sGlalieAnims_8_6
+.4byte sGlalieAnims_8_7
+.4byte sGlalieAnims_8_8
+sGlalieAnimTable9:
+.4byte sGlalieAnims_9_1
+.4byte sGlalieAnims_9_2
+.4byte sGlalieAnims_9_3
+.4byte sGlalieAnims_9_4
+.4byte sGlalieAnims_9_5
+.4byte sGlalieAnims_9_6
+.4byte sGlalieAnims_9_7
+.4byte sGlalieAnims_9_8
+sGlalieAnimTable10:
+.4byte sGlalieAnims_10_1
+.4byte sGlalieAnims_10_2
+.4byte sGlalieAnims_10_3
+.4byte sGlalieAnims_10_4
+.4byte sGlalieAnims_10_5
+.4byte sGlalieAnims_10_6
+.4byte sGlalieAnims_10_7
+.4byte sGlalieAnims_10_8
+sGlalieAnimTable11:
+.4byte sGlalieAnims_11_1
+.4byte sGlalieAnims_11_2
+.4byte sGlalieAnims_11_3
+.4byte sGlalieAnims_11_4
+.4byte sGlalieAnims_11_5
+.4byte sGlalieAnims_11_6
+.4byte sGlalieAnims_11_7
+.4byte sGlalieAnims_11_8
+sGlalieAnimTable12:
+.4byte sGlalieAnims_12_1
+.4byte sGlalieAnims_12_2
+.4byte sGlalieAnims_12_3
+.4byte sGlalieAnims_12_4
+.4byte sGlalieAnims_12_5
+.4byte sGlalieAnims_12_6
+.4byte sGlalieAnims_12_7
+.4byte sGlalieAnims_12_8
+sGlalieAnimTable13:
+.4byte sGlalieAnims_13_1
+.4byte sGlalieAnims_13_2
+.4byte sGlalieAnims_13_3
+.4byte sGlalieAnims_13_4
+.4byte sGlalieAnims_13_5
+.4byte sGlalieAnims_13_6
+.4byte sGlalieAnims_13_7
+.4byte sGlalieAnims_13_8
+sAxAnimationsGlalie:
+.4byte sGlalieAnimTable1
+.4byte sGlalieAnimTable2
+.4byte sGlalieAnimTable3
+.4byte sGlalieAnimTable4
+.4byte sGlalieAnimTable5
+.4byte sGlalieAnimTable6
+.4byte sGlalieAnimTable7
+.4byte sGlalieAnimTable8
+.4byte sGlalieAnimTable9
+.4byte sGlalieAnimTable10
+.4byte sGlalieAnimTable11
+.4byte sGlalieAnimTable12
+.4byte sGlalieAnimTable13
+sAxSpritesGlalie:
+.4byte sGlalieSprites1
+.4byte sGlalieSprites2
+.4byte sGlalieSprites3
+.4byte sGlalieSprites4
+.4byte sGlalieSprites5
+.4byte sGlalieSprites6
+.4byte sGlalieSprites7
+.4byte sGlalieSprites8
+.4byte sGlalieSprites9
+.4byte sGlalieSprites10
+.4byte sGlalieSprites11
+.4byte sGlalieSprites12
+.4byte sGlalieSprites13
+.4byte sGlalieSprites14
+.4byte sGlalieSprites15
+.4byte sGlalieSprites16
+.4byte sGlalieSprites17
+.4byte sGlalieSprites18
+.4byte sGlalieSprites19
+.4byte sGlalieSprites20
+.4byte sGlalieSprites21
+.4byte sGlalieSprites22
+.4byte sGlalieSprites23
+.4byte sGlalieSprites24
+.4byte sGlalieSprites25
+.4byte sGlalieSprites26
+.4byte sGlalieSprites27
+.4byte sGlalieSprites28
+.4byte sGlalieSprites29
+.4byte sGlalieSprites30
+.4byte sGlalieSprites31
+.4byte sGlalieSprites32
+.4byte sGlalieSprites33
+.4byte sGlalieSprites34
+.4byte sGlalieSprites35
+sAxMainGlalie:
+ax_main sAxPosesGlalie, sAxAnimationsGlalie, 13, sAxSpritesGlalie, sAxPositionsGlalie

--- a/data/ax/gligar.inc
+++ b/data/ax/gligar.inc
@@ -1,0 +1,3289 @@
+.global gAxGligar
+gAxGligar:
+ax_siro sAxMainGligar
+sGligarPose1:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose2:
+ax_pose 1, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose3:
+ax_pose 2, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose4:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose5:
+ax_pose 4, 0x01e0, 0x90ea, 0x7c00
+ax_pose_terminator
+sGligarPose6:
+ax_pose 5, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose7:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose8:
+ax_pose 7, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose9:
+ax_pose 8, 0x01e0, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose10:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose11:
+ax_pose 10, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose12:
+ax_pose 11, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sGligarPose13:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose14:
+ax_pose 13, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose15:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose16:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose17:
+ax_pose 10, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose18:
+ax_pose 11, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose19:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose20:
+ax_pose 7, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose21:
+ax_pose 8, 0x01e0, 0x80f5, 0x7c00
+ax_pose_terminator
+sGligarPose22:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose23:
+ax_pose 4, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose24:
+ax_pose 5, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose25:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose26:
+ax_pose 1, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose27:
+ax_pose 2, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose28:
+ax_pose 15, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose29:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose30:
+ax_pose 4, 0x01df, 0x90ea, 0x7c00
+ax_pose_terminator
+sGligarPose31:
+ax_pose 5, 0x01e1, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose32:
+ax_pose 16, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sGligarPose33:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose34:
+ax_pose 7, 0x01df, 0x90ed, 0x7c00
+ax_pose_terminator
+sGligarPose35:
+ax_pose 8, 0x01e1, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose36:
+ax_pose 17, 0x01e1, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose37:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose38:
+ax_pose 10, 0x01e2, 0x90ed, 0x7c00
+ax_pose_terminator
+sGligarPose39:
+ax_pose 11, 0x01e2, 0x90f1, 0x7c00
+ax_pose_terminator
+sGligarPose40:
+ax_pose 18, 0x41ea, 0x90f2, 0x7c00
+ax_pose 19, 0x41e2, 0x10fa, 0x7c08
+ax_pose 20, 0x41fa, 0x10fa, 0x7c0a
+ax_pose_terminator
+sGligarPose41:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose42:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose43:
+ax_pose 14, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose44:
+ax_pose 21, 0x41e7, 0x80f0, 0x7c00
+ax_pose 22, 0x41f7, 0x40f0, 0x7c08
+ax_pose_terminator
+sGligarPose45:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose46:
+ax_pose 10, 0x01e2, 0x80f3, 0x7c00
+ax_pose_terminator
+sGligarPose47:
+ax_pose 11, 0x01e2, 0x80ef, 0x7c00
+ax_pose_terminator
+sGligarPose48:
+ax_pose 18, 0x41e9, 0x80ef, 0x7c00
+ax_pose 19, 0x41e1, 0x00f7, 0x7c08
+ax_pose 20, 0x41f9, 0x00f7, 0x7c0a
+ax_pose_terminator
+sGligarPose49:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose50:
+ax_pose 7, 0x01df, 0x80f3, 0x7c00
+ax_pose_terminator
+sGligarPose51:
+ax_pose 8, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose52:
+ax_pose 17, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose53:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose54:
+ax_pose 4, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose55:
+ax_pose 5, 0x01e1, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose56:
+ax_pose 16, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose57:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose58:
+ax_pose 1, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose59:
+ax_pose 2, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose60:
+ax_pose 23, 0x01e1, 0x80f1, 0x7c00
+ax_pose 24, 0x01e2, 0x80f4, 0x7c10
+ax_pose_terminator
+sGligarPose61:
+ax_pose 24, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose62:
+ax_pose 23, 0x01e1, 0x90ef, 0x7c00
+ax_pose 24, 0x01e2, 0x90ec, 0x7c10
+ax_pose_terminator
+sGligarPose63:
+ax_pose 24, 0x01e2, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose64:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose65:
+ax_pose 4, 0x01e0, 0x90ea, 0x7c00
+ax_pose_terminator
+sGligarPose66:
+ax_pose 5, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose67:
+ax_pose 25, 0x01e1, 0x90ee, 0x7c00
+ax_pose 26, 0x81e2, 0x90fd, 0x7c10
+ax_pose 27, 0x81e2, 0x50f5, 0x7c18
+ax_pose 28, 0x01da, 0x10fd, 0x7c1c
+ax_pose_terminator
+sGligarPose68:
+ax_pose 26, 0x81e2, 0x90fd, 0x7c00
+ax_pose 27, 0x81e2, 0x50f5, 0x7c08
+ax_pose 28, 0x01da, 0x10fd, 0x7c0c
+ax_pose_terminator
+sGligarPose69:
+ax_pose 29, 0x01e3, 0x90f9, 0x7c00
+ax_pose 30, 0x01e3, 0x90ee, 0x7c10
+ax_pose_terminator
+sGligarPose70:
+ax_pose 30, 0x01e3, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose71:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose72:
+ax_pose 7, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose73:
+ax_pose 8, 0x01e0, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose74:
+ax_pose 31, 0x01e0, 0x90f7, 0x7c00
+ax_pose 32, 0x01e4, 0x90f2, 0x7c10
+ax_pose_terminator
+sGligarPose75:
+ax_pose 32, 0x01e4, 0x90f2, 0x7c00
+ax_pose_terminator
+sGligarPose76:
+ax_pose 33, 0x01e3, 0x90fb, 0x7c00
+ax_pose 34, 0x01e3, 0x90ee, 0x7c10
+ax_pose_terminator
+sGligarPose77:
+ax_pose 34, 0x01e3, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose78:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose79:
+ax_pose 10, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose80:
+ax_pose 11, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sGligarPose81:
+ax_pose 35, 0x01de, 0x90f7, 0x7c00
+ax_pose 36, 0x01e1, 0x90eb, 0x7c10
+ax_pose_terminator
+sGligarPose82:
+ax_pose 36, 0x01e1, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose83:
+ax_pose 37, 0x01e2, 0x90ef, 0x7c00
+ax_pose 38, 0x01de, 0x90ed, 0x7c10
+ax_pose_terminator
+sGligarPose84:
+ax_pose 37, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose85:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose86:
+ax_pose 13, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose87:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose88:
+ax_pose 39, 0x01e2, 0x80f2, 0x7c00
+ax_pose 40, 0x01da, 0x80ee, 0x7c10
+ax_pose_terminator
+sGligarPose89:
+ax_pose 41, 0x01e2, 0x80f3, 0x7c00
+ax_pose_terminator
+sGligarPose90:
+ax_pose 39, 0x01e2, 0x90ee, 0x7c00
+ax_pose 40, 0x01db, 0x90f1, 0x7c10
+ax_pose_terminator
+sGligarPose91:
+ax_pose 41, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose92:
+ax_pose 39, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose93:
+ax_pose 39, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose94:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose95:
+ax_pose 10, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose96:
+ax_pose 11, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose97:
+ax_pose 37, 0x01e2, 0x80f1, 0x7c00
+ax_pose 38, 0x01de, 0x80f0, 0x7c10
+ax_pose_terminator
+sGligarPose98:
+ax_pose 37, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose99:
+ax_pose 35, 0x01de, 0x80e9, 0x7c00
+ax_pose 36, 0x01e1, 0x80f5, 0x7c10
+ax_pose_terminator
+sGligarPose100:
+ax_pose 36, 0x01e1, 0x80f5, 0x7c00
+ax_pose_terminator
+sGligarPose101:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose102:
+ax_pose 7, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose103:
+ax_pose 8, 0x01e0, 0x80f5, 0x7c00
+ax_pose_terminator
+sGligarPose104:
+ax_pose 33, 0x01e2, 0x80e6, 0x7c00
+ax_pose 34, 0x01e3, 0x80f2, 0x7c10
+ax_pose_terminator
+sGligarPose105:
+ax_pose 34, 0x01e3, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose106:
+ax_pose 31, 0x01e0, 0x80ec, 0x7c00
+ax_pose 32, 0x01e4, 0x80ee, 0x7c10
+ax_pose_terminator
+sGligarPose107:
+ax_pose 32, 0x01e4, 0x80ee, 0x7c00
+ax_pose_terminator
+sGligarPose108:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose109:
+ax_pose 4, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose110:
+ax_pose 5, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose111:
+ax_pose 29, 0x01e3, 0x80e8, 0x7c00
+ax_pose 30, 0x01e3, 0x80f2, 0x7c10
+ax_pose_terminator
+sGligarPose112:
+ax_pose 30, 0x01e3, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose113:
+ax_pose 25, 0x01e1, 0x80f2, 0x7c00
+ax_pose 26, 0x81e2, 0x80f3, 0x7c10
+ax_pose 27, 0x81e2, 0x4103, 0x7c18
+ax_pose 28, 0x01da, 0x00fb, 0x7c1c
+ax_pose_terminator
+sGligarPose114:
+ax_pose 26, 0x81e2, 0x80f3, 0x7c00
+ax_pose 27, 0x81e2, 0x4103, 0x7c08
+ax_pose_terminator
+sGligarPose115:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose116:
+ax_pose 1, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose117:
+ax_pose 2, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose118:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose119:
+ax_pose 4, 0x01e0, 0x90ea, 0x7c00
+ax_pose_terminator
+sGligarPose120:
+ax_pose 5, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose121:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose122:
+ax_pose 7, 0x01e0, 0x90ed, 0x7c00
+ax_pose_terminator
+sGligarPose123:
+ax_pose 8, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose124:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose125:
+ax_pose 10, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose126:
+ax_pose 11, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sGligarPose127:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose128:
+ax_pose 13, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose129:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose130:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose131:
+ax_pose 10, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose132:
+ax_pose 11, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose133:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose134:
+ax_pose 7, 0x01e0, 0x80f3, 0x7c00
+ax_pose_terminator
+sGligarPose135:
+ax_pose 8, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose136:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose137:
+ax_pose 4, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose138:
+ax_pose 5, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose139:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose140:
+ax_pose 1, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose141:
+ax_pose 2, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose142:
+ax_pose 23, 0x01e1, 0x80f1, 0x7c00
+ax_pose 24, 0x01e2, 0x80f4, 0x7c10
+ax_pose_terminator
+sGligarPose143:
+ax_pose 24, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose144:
+ax_pose 23, 0x01e1, 0x90ef, 0x7c00
+ax_pose 24, 0x01e2, 0x90ec, 0x7c10
+ax_pose_terminator
+sGligarPose145:
+ax_pose 24, 0x01e2, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose146:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose147:
+ax_pose 4, 0x01e0, 0x90ea, 0x7c00
+ax_pose_terminator
+sGligarPose148:
+ax_pose 5, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose149:
+ax_pose 25, 0x01e1, 0x90ee, 0x7c00
+ax_pose 26, 0x81e2, 0x90fd, 0x7c10
+ax_pose 27, 0x81e2, 0x50f5, 0x7c18
+ax_pose 28, 0x01da, 0x10fd, 0x7c1c
+ax_pose_terminator
+sGligarPose150:
+ax_pose 26, 0x81e2, 0x90fd, 0x7c00
+ax_pose 27, 0x81e2, 0x50f5, 0x7c08
+ax_pose 28, 0x01da, 0x10fd, 0x7c0c
+ax_pose_terminator
+sGligarPose151:
+ax_pose 29, 0x01e3, 0x90f9, 0x7c00
+ax_pose 30, 0x01e3, 0x90ee, 0x7c10
+ax_pose_terminator
+sGligarPose152:
+ax_pose 30, 0x01e3, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose153:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose154:
+ax_pose 7, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose155:
+ax_pose 8, 0x01e0, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose156:
+ax_pose 31, 0x01e0, 0x90f7, 0x7c00
+ax_pose 32, 0x01e4, 0x90f2, 0x7c10
+ax_pose_terminator
+sGligarPose157:
+ax_pose 32, 0x01e4, 0x90f2, 0x7c00
+ax_pose_terminator
+sGligarPose158:
+ax_pose 33, 0x01e3, 0x90fb, 0x7c00
+ax_pose 34, 0x01e3, 0x90ee, 0x7c10
+ax_pose_terminator
+sGligarPose159:
+ax_pose 34, 0x01e3, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose160:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose161:
+ax_pose 10, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose162:
+ax_pose 11, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sGligarPose163:
+ax_pose 35, 0x01de, 0x90f7, 0x7c00
+ax_pose 36, 0x01e1, 0x90eb, 0x7c10
+ax_pose_terminator
+sGligarPose164:
+ax_pose 36, 0x01e1, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose165:
+ax_pose 37, 0x01e2, 0x90ef, 0x7c00
+ax_pose 38, 0x01de, 0x90ed, 0x7c10
+ax_pose_terminator
+sGligarPose166:
+ax_pose 37, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose167:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose168:
+ax_pose 13, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose169:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose170:
+ax_pose 39, 0x01e2, 0x80f2, 0x7c00
+ax_pose 40, 0x01da, 0x80ee, 0x7c10
+ax_pose_terminator
+sGligarPose171:
+ax_pose 41, 0x01e2, 0x80f3, 0x7c00
+ax_pose_terminator
+sGligarPose172:
+ax_pose 39, 0x01e2, 0x90ee, 0x7c00
+ax_pose 40, 0x01da, 0x90f2, 0x7c10
+ax_pose_terminator
+sGligarPose173:
+ax_pose 41, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose174:
+ax_pose 39, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose175:
+ax_pose 39, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose176:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose177:
+ax_pose 10, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose178:
+ax_pose 11, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose179:
+ax_pose 37, 0x01e2, 0x80f1, 0x7c00
+ax_pose 38, 0x01de, 0x80f0, 0x7c10
+ax_pose_terminator
+sGligarPose180:
+ax_pose 37, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose181:
+ax_pose 35, 0x01de, 0x80e9, 0x7c00
+ax_pose 36, 0x01e1, 0x80f5, 0x7c10
+ax_pose_terminator
+sGligarPose182:
+ax_pose 36, 0x01e1, 0x80f5, 0x7c00
+ax_pose_terminator
+sGligarPose183:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose184:
+ax_pose 7, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose185:
+ax_pose 8, 0x01e0, 0x80f5, 0x7c00
+ax_pose_terminator
+sGligarPose186:
+ax_pose 33, 0x01e2, 0x80e6, 0x7c00
+ax_pose 34, 0x01e3, 0x80f2, 0x7c10
+ax_pose_terminator
+sGligarPose187:
+ax_pose 34, 0x01e3, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose188:
+ax_pose 31, 0x01e0, 0x80ec, 0x7c00
+ax_pose 32, 0x01e4, 0x80ee, 0x7c10
+ax_pose_terminator
+sGligarPose189:
+ax_pose 32, 0x01e4, 0x80ee, 0x7c00
+ax_pose_terminator
+sGligarPose190:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose191:
+ax_pose 4, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose192:
+ax_pose 5, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose193:
+ax_pose 29, 0x01e3, 0x80e8, 0x7c00
+ax_pose 30, 0x01e3, 0x80f2, 0x7c10
+ax_pose_terminator
+sGligarPose194:
+ax_pose 30, 0x01e3, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose195:
+ax_pose 25, 0x01e1, 0x80f2, 0x7c00
+ax_pose 26, 0x81e2, 0x80f3, 0x7c10
+ax_pose 27, 0x81e2, 0x4103, 0x7c18
+ax_pose 28, 0x01da, 0x00fb, 0x7c1c
+ax_pose_terminator
+sGligarPose196:
+ax_pose 26, 0x81e2, 0x80f3, 0x7c00
+ax_pose 27, 0x81e2, 0x4103, 0x7c08
+ax_pose_terminator
+sGligarPose197:
+ax_pose 42, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose198:
+ax_pose 43, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose199:
+ax_pose 44, 0x01de, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose200:
+ax_pose 45, 0x01df, 0x90ed, 0x7c00
+ax_pose_terminator
+sGligarPose201:
+ax_pose 46, 0x01dc, 0x90ed, 0x7c00
+ax_pose_terminator
+sGligarPose202:
+ax_pose 47, 0x01e4, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose203:
+ax_pose 48, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose204:
+ax_pose 47, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose205:
+ax_pose 46, 0x01dc, 0x80f3, 0x7c00
+ax_pose_terminator
+sGligarPose206:
+ax_pose 45, 0x01df, 0x80f3, 0x7c00
+ax_pose_terminator
+sGligarPose207:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose208:
+ax_pose 1, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose209:
+ax_pose 2, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose210:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose211:
+ax_pose 4, 0x01e0, 0x90ea, 0x7c00
+ax_pose_terminator
+sGligarPose212:
+ax_pose 5, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose213:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose214:
+ax_pose 7, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose215:
+ax_pose 8, 0x01e0, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose216:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose217:
+ax_pose 10, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose218:
+ax_pose 11, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sGligarPose219:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose220:
+ax_pose 13, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose221:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose222:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose223:
+ax_pose 10, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose224:
+ax_pose 11, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose225:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose226:
+ax_pose 7, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose227:
+ax_pose 8, 0x01e0, 0x80f5, 0x7c00
+ax_pose_terminator
+sGligarPose228:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose229:
+ax_pose 4, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose230:
+ax_pose 5, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose231:
+ax_pose 15, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose232:
+ax_pose 16, 0x01e3, 0x80ef, 0x7c00
+ax_pose_terminator
+sGligarPose233:
+ax_pose 17, 0x01e3, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose234:
+ax_pose 18, 0x41e9, 0x80f0, 0x7c00
+ax_pose 19, 0x41e1, 0x00f8, 0x7c08
+ax_pose 20, 0x41f9, 0x00f8, 0x7c0a
+ax_pose_terminator
+sGligarPose235:
+ax_pose 21, 0x41e6, 0x80f0, 0x7c00
+ax_pose 22, 0x41f6, 0x40f0, 0x7c08
+ax_pose_terminator
+sGligarPose236:
+ax_pose 18, 0x41e9, 0x90f0, 0x7c00
+ax_pose 19, 0x41e1, 0x10f8, 0x7c08
+ax_pose 20, 0x41f9, 0x10f8, 0x7c0a
+ax_pose_terminator
+sGligarPose237:
+ax_pose 17, 0x01e3, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose238:
+ax_pose 16, 0x01e3, 0x90f1, 0x7c00
+ax_pose_terminator
+sGligarPose239:
+ax_pose 1, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose240:
+ax_pose 4, 0x01e0, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose241:
+ax_pose 7, 0x01e0, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose242:
+ax_pose 10, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose243:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose244:
+ax_pose 10, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose245:
+ax_pose 7, 0x01e0, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose246:
+ax_pose 4, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose247:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose248:
+ax_pose 1, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose249:
+ax_pose 2, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose250:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose251:
+ax_pose 4, 0x01df, 0x90ea, 0x7c00
+ax_pose_terminator
+sGligarPose252:
+ax_pose 5, 0x01e1, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose253:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose254:
+ax_pose 7, 0x01df, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose255:
+ax_pose 8, 0x01e1, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose256:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose257:
+ax_pose 10, 0x01e1, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose258:
+ax_pose 11, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sGligarPose259:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose260:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose261:
+ax_pose 14, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose262:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose263:
+ax_pose 10, 0x01e1, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose264:
+ax_pose 11, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose265:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose266:
+ax_pose 7, 0x01df, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose267:
+ax_pose 8, 0x01e1, 0x80f5, 0x7c00
+ax_pose_terminator
+sGligarPose268:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose269:
+ax_pose 4, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose270:
+ax_pose 5, 0x01e1, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose271:
+ax_pose 1, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose272:
+ax_pose 4, 0x01e0, 0x80f6, 0x7c00
+ax_pose_terminator
+sGligarPose273:
+ax_pose 7, 0x01e0, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose274:
+ax_pose 10, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sGligarPose275:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose276:
+ax_pose 10, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sGligarPose277:
+ax_pose 7, 0x01e0, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose278:
+ax_pose 4, 0x01e0, 0x90eb, 0x7c00
+ax_pose_terminator
+sGligarPose279:
+ax_pose 0, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose280:
+ax_pose 3, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose281:
+ax_pose 6, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sGligarPose282:
+ax_pose 9, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sGligarPose283:
+ax_pose 12, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sGligarPose284:
+ax_pose 9, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sGligarPose285:
+ax_pose 6, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+sGligarPose286:
+ax_pose 3, 0x01e0, 0x90ec, 0x7c00
+ax_pose_terminator
+.align 2
+sGligarAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sGligarAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sGligarAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sGligarAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sGligarAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sGligarAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, -1, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 4, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sGligarAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, -1, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 4, 0, 18, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 4, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sGligarAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 4, 0, 21, 0, -3, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 4, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, 0,
+ax_anim 2, 0, 26, 0, -2, 0, 0,
+ax_anim 2, 0, 25, 0, -4, 0, 0,
+ax_anim 2, 0, 24, 0, -5, 0, 0,
+ax_anim 6, 2, 25, 0, -4, 0, 0,
+ax_anim 2, 0, 27, 0, 11, 0, 11,
+ax_anim 2, 1, 27, 0, 24, 0, 21,
+ax_anim 2, 0, 27, 1, 24, 1, 21,
+ax_anim 2, 0, 27, 0, 24, 0, 21,
+ax_anim 2, 0, 27, 1, 24, 1, 21,
+ax_anim 2, 0, 24, 0, 13, 0, 13,
+ax_anim_terminator
+sGligarAnims_2_2:
+ax_anim 2, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 0, 30, 0, -2, 0, 0,
+ax_anim 2, 0, 29, 0, -4, 0, 0,
+ax_anim 2, 0, 28, 0, -5, 0, 0,
+ax_anim 6, 2, 29, 0, -4, 0, 0,
+ax_anim 2, 0, 31, 9, 13, 9, 12,
+ax_anim 2, 1, 31, 17, 24, 17, 21,
+ax_anim 2, 0, 31, 18, 23, 18, 20,
+ax_anim 2, 0, 31, 17, 24, 17, 21,
+ax_anim 2, 0, 31, 18, 23, 18, 20,
+ax_anim 2, 0, 28, 11, 15, 11, 15,
+ax_anim_terminator
+sGligarAnims_2_3:
+ax_anim 2, 0, 33, 0, -1, 0, 0,
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 33, 0, -4, 0, 0,
+ax_anim 2, 0, 32, 0, -5, 0, 0,
+ax_anim 6, 2, 33, 0, -4, 0, 0,
+ax_anim 2, 0, 35, 9, 2, 9, 0,
+ax_anim 2, 1, 35, 18, 5, 18, 0,
+ax_anim 2, 0, 35, 18, 4, 18, -1,
+ax_anim 2, 0, 35, 18, 5, 18, 0,
+ax_anim 2, 0, 35, 18, 4, 18, -1,
+ax_anim 2, 0, 32, 11, 2, 11, 0,
+ax_anim_terminator
+sGligarAnims_2_4:
+ax_anim 2, 0, 37, 0, -1, 0, 0,
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, 0,
+ax_anim 2, 0, 36, 0, -5, 0, 0,
+ax_anim 6, 2, 37, 0, -4, 0, 0,
+ax_anim 2, 0, 39, 10, -9, 10, -11,
+ax_anim 2, 1, 39, 16, -13, 16, -17,
+ax_anim 2, 0, 39, 17, -12, 17, -16,
+ax_anim 2, 0, 39, 16, -13, 16, -17,
+ax_anim 2, 0, 39, 17, -12, 17, -16,
+ax_anim 2, 0, 36, 11, -10, 11, -11,
+ax_anim_terminator
+sGligarAnims_2_5:
+ax_anim 2, 0, 41, 0, -1, 0, 0,
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 40, 0, -5, 0, 0,
+ax_anim 6, 2, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 43, 0, -11, 0, -9,
+ax_anim 2, 1, 43, 0, -14, 0, -14,
+ax_anim 2, 0, 43, 1, -14, 1, -14,
+ax_anim 2, 0, 43, 0, -14, 0, -14,
+ax_anim 2, 0, 43, 1, -14, 1, -14,
+ax_anim 2, 0, 40, 0, -13, 0, -13,
+ax_anim_terminator
+sGligarAnims_2_6:
+ax_anim 2, 0, 45, 0, -1, 0, 0,
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 45, 0, -4, 0, 0,
+ax_anim 2, 0, 44, 0, -5, 0, 0,
+ax_anim 6, 2, 45, 0, -4, 0, 0,
+ax_anim 2, 0, 47, -10, -9, -10, -11,
+ax_anim 2, 1, 47, -16, -13, -16, -17,
+ax_anim 2, 0, 47, -17, -12, -17, -16,
+ax_anim 2, 0, 47, -16, -13, -16, -17,
+ax_anim 2, 0, 47, -17, -12, -17, -16,
+ax_anim 2, 0, 44, -11, -10, -11, -11,
+ax_anim_terminator
+sGligarAnims_2_7:
+ax_anim 2, 0, 49, 0, -1, 0, 0,
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 6, 2, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 51, -9, 2, -9, 0,
+ax_anim 2, 1, 51, -18, 5, -18, 0,
+ax_anim 2, 0, 51, -18, 4, -18, -1,
+ax_anim 2, 0, 51, -18, 5, -18, 0,
+ax_anim 2, 0, 51, -18, 4, -18, -1,
+ax_anim 2, 0, 48, -11, 2, -11, 0,
+ax_anim_terminator
+sGligarAnims_2_8:
+ax_anim 2, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 2, 0, 53, 0, -4, 0, 0,
+ax_anim 2, 0, 52, 0, -5, 0, 0,
+ax_anim 6, 2, 53, 0, -4, 0, 0,
+ax_anim 2, 0, 55, -9, 13, -9, 12,
+ax_anim 2, 1, 55, -17, 24, -17, 21,
+ax_anim 2, 0, 55, -18, 23, -18, 20,
+ax_anim 2, 0, 55, -17, 24, -17, 21,
+ax_anim 2, 0, 55, -18, 23, -18, 20,
+ax_anim 2, 0, 52, -11, 15, -11, 15,
+ax_anim_terminator
+.align 2
+sGligarAnims_3_1:
+ax_anim 2, 0, 113, 0, -2, 0, -2,
+ax_anim 6, 0, 113, 0, -3, 0, -3,
+ax_anim 1, 2, 113, 0, -1, 0, -1,
+ax_anim 1, 0, 62, 0, 8, 0, 8,
+ax_anim 2, 0, 59, 2, 19, 2, 19,
+ax_anim 2, 1, 60, 3, 20, 3, 20,
+ax_anim 2, 0, 60, 4, 20, 4, 20,
+ax_anim 2, 0, 60, 3, 20, 3, 20,
+ax_anim 2, 0, 60, 4, 20, 4, 20,
+ax_anim 2, 0, 60, 3, 20, 3, 20,
+ax_anim 2, 0, 58, 0, 13, 0, 13,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sGligarAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 6, 0, 62, -3, -3, -3, -3,
+ax_anim 1, 2, 62, -1, -1, -1, -1,
+ax_anim 1, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 66, 15, 16, 15, 16,
+ax_anim 2, 1, 67, 16, 17, 16, 17,
+ax_anim 2, 0, 67, 15, 18, 15, 18,
+ax_anim 2, 0, 67, 16, 17, 16, 17,
+ax_anim 2, 0, 67, 15, 18, 15, 18,
+ax_anim 2, 0, 67, 16, 17, 16, 17,
+ax_anim 2, 0, 65, 13, 13, 13, 13,
+ax_anim 2, 0, 63, 4, 4, 4, 4,
+ax_anim_terminator
+sGligarAnims_3_3:
+ax_anim 2, 0, 69, -2, 0, -2, 0,
+ax_anim 6, 0, 69, -3, 0, -3, 0,
+ax_anim 1, 2, 69, -1, 0, -1, 0,
+ax_anim 1, 0, 76, 8, 0, 8, 0,
+ax_anim 2, 0, 73, 12, 0, 12, 0,
+ax_anim 2, 1, 74, 13, 0, 13, 0,
+ax_anim 2, 0, 74, 13, 1, 13, 1,
+ax_anim 2, 0, 74, 13, 0, 13, 0,
+ax_anim 2, 0, 74, 13, 1, 13, 1,
+ax_anim 2, 0, 74, 13, 0, 13, 0,
+ax_anim 2, 0, 72, 10, 0, 10, 0,
+ax_anim 2, 0, 70, 4, 0, 4, 0,
+ax_anim_terminator
+sGligarAnims_3_4:
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 6, 0, 76, -3, 3, -3, 3,
+ax_anim 1, 2, 76, -1, 1, -1, 1,
+ax_anim 1, 0, 83, 8, -8, 8, -8,
+ax_anim 2, 0, 80, 13, -8, 13, -8,
+ax_anim 2, 1, 81, 14, -9, 14, -9,
+ax_anim 2, 0, 81, 15, -8, 15, -8,
+ax_anim 2, 0, 81, 14, -9, 14, -9,
+ax_anim 2, 0, 81, 15, -8, 15, -8,
+ax_anim 2, 0, 81, 14, -9, 14, -9,
+ax_anim 2, 0, 79, 8, -7, 8, -7,
+ax_anim 2, 0, 77, 4, -4, 4, -4,
+ax_anim_terminator
+sGligarAnims_3_5:
+ax_anim 2, 0, 83, 0, 2, 0, 2,
+ax_anim 6, 0, 83, 0, 3, 0, 3,
+ax_anim 1, 2, 83, 0, 1, 0, 1,
+ax_anim 1, 0, 90, 0, -2, 0, -2,
+ax_anim 2, 0, 87, 0, -8, 0, -8,
+ax_anim 2, 1, 91, 0, -9, 0, -9,
+ax_anim 2, 0, 91, -1, -9, -1, -9,
+ax_anim 2, 0, 91, 0, -9, 0, -9,
+ax_anim 2, 0, 91, -1, -9, -1, -9,
+ax_anim 2, 0, 91, 0, -9, 0, -9,
+ax_anim 2, 0, 86, 0, -6, 0, -6,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim_terminator
+sGligarAnims_3_6:
+ax_anim 2, 0, 90, 2, 2, 2, 2,
+ax_anim 6, 0, 90, 3, 3, 3, 3,
+ax_anim 1, 2, 90, 1, 1, 1, 1,
+ax_anim 1, 0, 99, -8, -8, -8, -8,
+ax_anim 2, 0, 96, -12, -10, -12, -10,
+ax_anim 2, 1, 97, -14, -11, -14, -11,
+ax_anim 2, 0, 97, -15, -10, -15, -10,
+ax_anim 2, 0, 97, -14, -11, -14, -11,
+ax_anim 2, 0, 97, -15, -10, -15, -10,
+ax_anim 2, 0, 97, -14, -11, -14, -11,
+ax_anim 2, 0, 95, -8, -7, -8, -7,
+ax_anim 2, 0, 93, -4, -4, -4, -4,
+ax_anim_terminator
+sGligarAnims_3_7:
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 6, 0, 99, 3, 0, 3, 0,
+ax_anim 1, 2, 99, 1, 0, 1, 0,
+ax_anim 1, 0, 106, -8, 0, -8, 0,
+ax_anim 2, 0, 103, -12, 0, -12, 0,
+ax_anim 2, 1, 104, -13, 0, -13, 0,
+ax_anim 2, 0, 104, -13, 1, -13, 1,
+ax_anim 2, 0, 104, -13, 0, -13, 0,
+ax_anim 2, 0, 104, -13, 1, -13, 1,
+ax_anim 2, 0, 104, -13, 0, -13, 0,
+ax_anim 2, 0, 102, -10, 0, -10, 0,
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim_terminator
+sGligarAnims_3_8:
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 6, 0, 106, 3, -3, 3, -3,
+ax_anim 1, 2, 106, 1, -1, 1, -1,
+ax_anim 1, 0, 113, -8, 8, -8, 8,
+ax_anim 2, 0, 110, -15, 16, -15, 16,
+ax_anim 2, 1, 111, -15, 17, -15, 17,
+ax_anim 2, 0, 111, -14, 18, -14, 18,
+ax_anim 2, 0, 111, -15, 17, -15, 17,
+ax_anim 2, 0, 111, -14, 18, -14, 18,
+ax_anim 2, 0, 111, -15, 17, -15, 17,
+ax_anim 2, 0, 109, -12, 13, -12, 13,
+ax_anim 2, 0, 107, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGligarAnims_4_1:
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 1, 2, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 1, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_4_2:
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 1, 2, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 1, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_4_3:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 1, 0, 120, 0, -2, 0, 0,
+ax_anim 2, 0, 122, 0, -3, 0, 0,
+ax_anim 1, 2, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 1, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_4_4:
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 1, 0, 123, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 1, 2, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 1, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_4_5:
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 0, 0,
+ax_anim 1, 0, 126, 0, -3, 0, 0,
+ax_anim 2, 0, 128, 0, -5, 0, 0,
+ax_anim 1, 2, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 1, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 1, 0, 126, 0, -1, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_4_6:
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 1, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 2, 129, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 1, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_4_7:
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -3, 0, 0,
+ax_anim 1, 2, 132, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 1, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_4_8:
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 1, 2, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 1, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_5_1:
+ax_anim 2, 0, 195, 0, -2, 0, -2,
+ax_anim 2, 0, 195, 0, -4, 0, -4,
+ax_anim 4, 0, 195, 0, -6, 0, -6,
+ax_anim 1, 0, 195, 0, -3, 0, -3,
+ax_anim 1, 2, 144, 0, 3, 0, 3,
+ax_anim 2, 0, 141, 0, 19, 0, 19,
+ax_anim 2, 1, 149, 2, 20, 1, 20,
+ax_anim 2, 0, 149, 3, 17, 2, 17,
+ax_anim 4, 0, 149, 4, 14, 3, 14,
+ax_anim 2, 0, 143, 0, 19, 0, 19,
+ax_anim 2, 0, 195, -3, 19, -3, 19,
+ax_anim 2, 0, 144, -1, 16, -1, 16,
+ax_anim 2, 0, 139, 0, 11, 0, 11,
+ax_anim 2, 0, 138, 0, 3, 0, 3,
+ax_anim_terminator
+sGligarAnims_5_2:
+ax_anim 2, 0, 144, -2, -2, -2, -2,
+ax_anim 2, 0, 144, -4, -4, -4, -4,
+ax_anim 4, 0, 144, -6, -6, -6, -6,
+ax_anim 1, 0, 144, -3, -3, -3, -3,
+ax_anim 1, 2, 151, 6, 7, 6, 7,
+ax_anim 2, 0, 148, 19, 19, 19, 19,
+ax_anim 2, 1, 156, 21, 19, 21, 19,
+ax_anim 2, 0, 156, 19, 17, 19, 17,
+ax_anim 4, 0, 156, 17, 15, 17, 15,
+ax_anim 2, 0, 150, 17, 21, 17, 21,
+ax_anim 2, 0, 144, 16, 21, 16, 21,
+ax_anim 2, 0, 151, 14, 13, 14, 13,
+ax_anim 2, 0, 146, 10, 11, 10, 11,
+ax_anim 2, 0, 145, 2, 3, 2, 3,
+ax_anim_terminator
+sGligarAnims_5_3:
+ax_anim 2, 0, 151, -2, 0, -2, 0,
+ax_anim 2, 0, 151, -4, 0, -4, 0,
+ax_anim 4, 0, 151, -6, 0, -6, 0,
+ax_anim 1, 0, 151, -3, 0, -3, 0,
+ax_anim 1, 2, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 155, 14, 0, 14, 0,
+ax_anim 2, 1, 163, 15, 1, 15, 1,
+ax_anim 2, 0, 163, 13, 0, 13, 0,
+ax_anim 4, 0, 163, 12, 0, 12, 0,
+ax_anim 2, 0, 157, 16, 0, 16, 0,
+ax_anim 2, 0, 151, 15, 1, 15, 1,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 153, 6, -1, 6, -1,
+ax_anim 2, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sGligarAnims_5_4:
+ax_anim 2, 0, 158, -2, 2, -2, 2,
+ax_anim 2, 0, 158, -4, 4, -4, 4,
+ax_anim 4, 0, 158, -6, 6, -6, 6,
+ax_anim 1, 0, 158, -3, 3, -3, 3,
+ax_anim 1, 2, 165, 9, -6, 9, -6,
+ax_anim 2, 0, 162, 16, -11, 16, -11,
+ax_anim 2, 1, 170, 17, -11, 17, -11,
+ax_anim 2, 0, 170, 13, -8, 13, -8,
+ax_anim 4, 0, 170, 7, -5, 7, -5,
+ax_anim 2, 0, 164, 15, -12, 15, -12,
+ax_anim 2, 0, 158, 16, -14, 16, -14,
+ax_anim 2, 0, 165, 9, -8, 9, -8,
+ax_anim 2, 0, 160, 7, -6, 7, -6,
+ax_anim 2, 0, 159, 4, -3, 4, -3,
+ax_anim_terminator
+sGligarAnims_5_5:
+ax_anim 2, 0, 165, 0, 2, 0, 2,
+ax_anim 2, 0, 165, 0, 4, 0, 4,
+ax_anim 4, 0, 165, 0, 6, 0, 6,
+ax_anim 1, 0, 165, 0, 3, 0, 3,
+ax_anim 1, 2, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 169, 0, -9, 0, -9,
+ax_anim 2, 1, 179, -2, -9, -2, -9,
+ax_anim 2, 0, 179, -3, -7, -3, -7,
+ax_anim 4, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 171, 0, -9, 0, -9,
+ax_anim 2, 0, 165, 2, -9, 2, -9,
+ax_anim 2, 0, 172, 1, -5, 1, -5,
+ax_anim 2, 0, 167, 0, -2, 0, -2,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim_terminator
+sGligarAnims_5_6:
+ax_anim 2, 0, 172, 2, 2, 2, 2,
+ax_anim 2, 0, 172, 4, 4, 4, 4,
+ax_anim 4, 0, 172, 6, 6, 6, 6,
+ax_anim 1, 0, 172, 3, 3, 3, 3,
+ax_anim 1, 2, 181, -9, -6, -9, -6,
+ax_anim 2, 0, 178, -16, -11, -16, -11,
+ax_anim 2, 1, 186, -17, -11, -17, -11,
+ax_anim 2, 0, 186, -13, -8, -13, -8,
+ax_anim 4, 0, 186, -7, -5, -7, -5,
+ax_anim 2, 0, 180, -15, -12, -15, -12,
+ax_anim 2, 0, 172, -16, -14, -16, -14,
+ax_anim 2, 0, 181, -9, -8, -9, -8,
+ax_anim 2, 0, 176, -7, -6, -7, -6,
+ax_anim 2, 0, 175, -4, -3, -4, -3,
+ax_anim_terminator
+sGligarAnims_5_7:
+ax_anim 2, 0, 181, 2, 0, 2, 0,
+ax_anim 2, 0, 181, 4, 0, 4, 0,
+ax_anim 4, 0, 181, 6, 0, 6, 0,
+ax_anim 1, 0, 181, 3, 0, 3, 0,
+ax_anim 1, 2, 188, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -14, 0, -14, 0,
+ax_anim 2, 1, 193, -15, 1, -15, 1,
+ax_anim 2, 0, 193, -13, 0, -13, 0,
+ax_anim 4, 0, 193, -12, 0, -12, 0,
+ax_anim 2, 0, 187, -16, 0, -16, 0,
+ax_anim 2, 0, 181, -15, 1, -15, 1,
+ax_anim 2, 0, 188, -10, 0, -10, 0,
+ax_anim 2, 0, 183, -6, -1, -6, -1,
+ax_anim 2, 0, 182, -3, 0, -3, 0,
+ax_anim_terminator
+sGligarAnims_5_8:
+ax_anim 2, 0, 188, 2, -2, 2, -2,
+ax_anim 2, 0, 188, 4, -4, 4, -4,
+ax_anim 4, 0, 188, 6, -6, 6, -6,
+ax_anim 1, 0, 188, 3, -3, 3, -3,
+ax_anim 1, 2, 195, -6, 7, -6, 7,
+ax_anim 2, 0, 192, -19, 19, -19, 19,
+ax_anim 2, 1, 142, -21, 19, -21, 19,
+ax_anim 2, 0, 142, -19, 17, -19, 17,
+ax_anim 4, 0, 142, -17, 15, -17, 15,
+ax_anim 2, 0, 194, -17, 21, -17, 21,
+ax_anim 2, 0, 188, -16, 21, -16, 21,
+ax_anim 2, 0, 195, -14, 13, -14, 13,
+ax_anim 2, 0, 190, -10, 11, -10, 11,
+ax_anim 2, 0, 189, -2, 3, -2, 3,
+ax_anim_terminator
+.align 2
+sGligarAnims_6_1:
+ax_anim 30, 0, 196, 0, 0, 0, 0,
+ax_anim 35, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_7_1:
+ax_anim 2, 0, 198, 0, -4, 0, -4,
+ax_anim 8, 0, 198, 0, -5, 0, -5,
+ax_anim_terminator
+sGligarAnims_7_2:
+ax_anim 2, 0, 199, -4, -4, -4, -4,
+ax_anim 8, 0, 199, -5, -5, -5, -5,
+ax_anim_terminator
+sGligarAnims_7_3:
+ax_anim 2, 0, 200, -4, 0, -4, 0,
+ax_anim 8, 0, 200, -5, 0, -5, 0,
+ax_anim_terminator
+sGligarAnims_7_4:
+ax_anim 2, 0, 201, -4, 4, -4, 4,
+ax_anim 8, 0, 201, -5, 5, -5, 5,
+ax_anim_terminator
+sGligarAnims_7_5:
+ax_anim 2, 0, 202, 0, 4, 0, 4,
+ax_anim 8, 0, 202, 0, 5, 0, 5,
+ax_anim_terminator
+sGligarAnims_7_6:
+ax_anim 2, 0, 203, 4, 4, 4, 4,
+ax_anim 8, 0, 203, 5, 5, 5, 5,
+ax_anim_terminator
+sGligarAnims_7_7:
+ax_anim 2, 0, 204, 4, 0, 4, 0,
+ax_anim 8, 0, 204, 5, 0, 5, 0,
+ax_anim_terminator
+sGligarAnims_7_8:
+ax_anim 2, 0, 205, 4, -4, 4, -4,
+ax_anim 8, 0, 205, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sGligarAnims_8_1:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 207, 0, 0, 0, 0,
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_8_2:
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_8_3:
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 10, 0, 213, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 10, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_8_4:
+ax_anim 8, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_8_5:
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim 10, 0, 219, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim 10, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_8_6:
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_8_7:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_8_8:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_9_1:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 6, 3, 6, 3,
+ax_anim 2, 0, 232, 8, 12, 8, 12,
+ax_anim 2, 0, 233, 7, 19, 7, 17,
+ax_anim 3, 0, 234, 0, 23, 0, 21,
+ax_anim 2, 3, 235, -7, 19, -7, 17,
+ax_anim 2, 0, 236, -8, 12, -8, 12,
+ax_anim 1, 0, 237, -6, 3, -6, 3,
+ax_anim 1, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_9_2:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 8, 0, 8, 0,
+ax_anim 2, 0, 231, 17, 5, 17, 5,
+ax_anim 2, 0, 232, 19, 14, 19, 12,
+ax_anim 3, 0, 233, 15, 24, 15, 24,
+ax_anim 2, 3, 234, 8, 25, 8, 25,
+ax_anim 2, 0, 235, 3, 18, 3, 18,
+ax_anim 1, 0, 236, 0, 7, 0, 7,
+ax_anim 1, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_9_3:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 3, -5, 3, -5,
+ax_anim 2, 0, 230, 11, -7, 11, -7,
+ax_anim 2, 0, 231, 17, -5, 17, -5,
+ax_anim 3, 0, 232, 20, 2, 20, 2,
+ax_anim 2, 3, 233, 16, 8, 16, 8,
+ax_anim 2, 0, 234, 11, 11, 11, 11,
+ax_anim 1, 0, 235, 4, 7, 4, 7,
+ax_anim 1, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_9_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, -1, -8, -1, -8,
+ax_anim 2, 0, 237, 4, -16, 4, -16,
+ax_anim 2, 0, 230, 12, -19, 12, -21,
+ax_anim 3, 0, 231, 17, -15, 17, -19,
+ax_anim 2, 3, 232, 20, -10, 20, -12,
+ax_anim 2, 0, 233, 17, -4, 17, -4,
+ax_anim 1, 0, 234, 7, 1, 7, 1,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_9_5:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -8, -4, -8, -4,
+ax_anim 2, 0, 236, -9, -10, -9, -10,
+ax_anim 2, 0, 237, -7, -13, -7, -17,
+ax_anim 3, 0, 230, 0, -16, 0, -21,
+ax_anim 2, 3, 231, 7, -13, 7, -17,
+ax_anim 2, 0, 232, 10, -10, 10, -10,
+ax_anim 1, 0, 233, 8, -4, 8, -4,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_9_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 1, -8, 1, -8,
+ax_anim 2, 0, 231, -4, -16, -4, -16,
+ax_anim 2, 0, 230, -12, -19, -12, -21,
+ax_anim 3, 0, 237, -17, -15, -17, -19,
+ax_anim 2, 3, 236, -20, -10, -20, -12,
+ax_anim 2, 0, 235, -17, -4, -17, -4,
+ax_anim 1, 0, 234, -7, 1, -7, 1,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_9_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 231, -3, -5, -3, -5,
+ax_anim 2, 0, 230, -11, -7, -11, -7,
+ax_anim 2, 0, 237, -17, -5, -17, -5,
+ax_anim 3, 0, 236, -20, 2, -20, 2,
+ax_anim 2, 3, 235, -16, 8, -16, 8,
+ax_anim 2, 0, 234, -11, 11, -11, 11,
+ax_anim 1, 0, 233, -4, 7, -4, 7,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_9_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 230, -8, 0, -8, 0,
+ax_anim 2, 0, 237, -17, 5, -17, 5,
+ax_anim 2, 0, 236, -19, 14, -19, 12,
+ax_anim 3, 0, 235, -15, 24, -15, 24,
+ax_anim 2, 3, 234, -8, 25, -8, 25,
+ax_anim 2, 0, 233, -3, 18, -3, 18,
+ax_anim 1, 0, 232, 0, 7, 0, 7,
+ax_anim 1, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_10_1:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 3, 0, 238, 13, 0, 13, 0,
+ax_anim 3, 0, 238, -13, 0, -13, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_10_2:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 3, 0, 239, 13, -13, 13, -13,
+ax_anim 3, 0, 239, -13, 13, -13, 13,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_10_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 3, 0, 240, 0, -13, 0, -13,
+ax_anim 3, 0, 240, 0, 13, 0, 13,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_10_4:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 3, 0, 241, -13, -13, -13, -13,
+ax_anim 3, 0, 241, 13, 13, 13, 13,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_10_5:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 3, 0, 242, 13, 0, 13, 0,
+ax_anim 3, 0, 242, -13, 0, -13, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_10_6:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 3, 0, 243, 13, -13, 13, -13,
+ax_anim 3, 0, 243, -13, 13, -13, 13,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_10_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 3, 0, 244, 0, -13, 0, -13,
+ax_anim 3, 0, 244, 0, 13, 0, 13,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_10_8:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 3, 0, 245, -13, -13, -13, -13,
+ax_anim 3, 0, 245, 13, 13, 13, 13,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_11_1:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 247, 0, -10, 0, 0,
+ax_anim 2, 0, 247, 0, -16, 0, 0,
+ax_anim 3, 0, 247, 0, -20, 0, 0,
+ax_anim 4, 0, 247, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -22, 0, 0,
+ax_anim 3, 0, 248, 0, -21, 0, 0,
+ax_anim 2, 0, 248, 0, -17, 0, 0,
+ax_anim 1, 0, 248, 0, -8, 0, 0,
+ax_anim 2, 2, 246, 0, 7, 0, 0,
+ax_anim_terminator
+sGligarAnims_11_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 250, 0, -10, 0, 0,
+ax_anim 2, 0, 250, 0, -16, 0, 0,
+ax_anim 3, 0, 250, 0, -20, 0, 0,
+ax_anim 4, 0, 250, 0, -21, 0, 0,
+ax_anim 4, 0, 249, 0, -22, 0, 0,
+ax_anim 3, 0, 251, 0, -21, 0, 0,
+ax_anim 2, 0, 251, 0, -17, 0, 0,
+ax_anim 1, 0, 251, 0, -8, 0, 0,
+ax_anim 2, 2, 249, 0, 7, 0, 0,
+ax_anim_terminator
+sGligarAnims_11_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 253, 0, -10, 0, 0,
+ax_anim 2, 0, 253, 0, -16, 0, 0,
+ax_anim 3, 0, 253, 0, -20, 0, 0,
+ax_anim 4, 0, 253, 0, -21, 0, 0,
+ax_anim 4, 0, 252, 0, -22, 0, 0,
+ax_anim 3, 0, 254, 0, -21, 0, 0,
+ax_anim 2, 0, 254, 0, -17, 0, 0,
+ax_anim 1, 0, 254, 0, -8, 0, 0,
+ax_anim 2, 2, 252, 0, 7, 0, 0,
+ax_anim_terminator
+sGligarAnims_11_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 1, 0, 256, 0, -10, 0, 0,
+ax_anim 2, 0, 256, 0, -16, 0, 0,
+ax_anim 3, 0, 256, 0, -20, 0, 0,
+ax_anim 4, 0, 256, 0, -21, 0, 0,
+ax_anim 4, 0, 255, 0, -22, 0, 0,
+ax_anim 3, 0, 257, 0, -21, 0, 0,
+ax_anim 2, 0, 257, 0, -17, 0, 0,
+ax_anim 1, 0, 257, 0, -8, 0, 0,
+ax_anim 2, 2, 255, 0, 7, 0, 0,
+ax_anim_terminator
+sGligarAnims_11_5:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 1, 0, 259, 0, -10, 0, 0,
+ax_anim 2, 0, 259, 0, -16, 0, 0,
+ax_anim 3, 0, 259, 0, -20, 0, 0,
+ax_anim 4, 0, 259, 0, -21, 0, 0,
+ax_anim 4, 0, 258, 0, -22, 0, 0,
+ax_anim 3, 0, 260, 0, -21, 0, 0,
+ax_anim 2, 0, 260, 0, -17, 0, 0,
+ax_anim 1, 0, 260, 0, -8, 0, 0,
+ax_anim 2, 2, 258, 0, 7, 0, 0,
+ax_anim_terminator
+sGligarAnims_11_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 1, 0, 262, 0, -10, 0, 0,
+ax_anim 2, 0, 262, 0, -16, 0, 0,
+ax_anim 3, 0, 262, 0, -20, 0, 0,
+ax_anim 4, 0, 262, 0, -21, 0, 0,
+ax_anim 4, 0, 261, 0, -22, 0, 0,
+ax_anim 3, 0, 263, 0, -21, 0, 0,
+ax_anim 2, 0, 263, 0, -17, 0, 0,
+ax_anim 1, 0, 263, 0, -8, 0, 0,
+ax_anim 2, 2, 261, 0, 7, 0, 0,
+ax_anim_terminator
+sGligarAnims_11_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 1, 0, 265, 0, -10, 0, 0,
+ax_anim 2, 0, 265, 0, -16, 0, 0,
+ax_anim 3, 0, 265, 0, -20, 0, 0,
+ax_anim 4, 0, 265, 0, -21, 0, 0,
+ax_anim 4, 0, 264, 0, -22, 0, 0,
+ax_anim 3, 0, 266, 0, -21, 0, 0,
+ax_anim 2, 0, 266, 0, -17, 0, 0,
+ax_anim 1, 0, 266, 0, -8, 0, 0,
+ax_anim 2, 2, 264, 0, 7, 0, 0,
+ax_anim_terminator
+sGligarAnims_11_8:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 1, 0, 268, 0, -10, 0, 0,
+ax_anim 2, 0, 268, 0, -16, 0, 0,
+ax_anim 3, 0, 268, 0, -20, 0, 0,
+ax_anim 4, 0, 268, 0, -21, 0, 0,
+ax_anim 4, 0, 267, 0, -22, 0, 0,
+ax_anim 3, 0, 269, 0, -21, 0, 0,
+ax_anim 2, 0, 269, 0, -17, 0, 0,
+ax_anim 1, 0, 269, 0, -8, 0, 0,
+ax_anim 2, 2, 267, 0, 7, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_12_1:
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 1, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_12_2:
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 1, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_12_3:
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 1, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_12_4:
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 1, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_12_5:
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 1, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_12_6:
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 1, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_12_7:
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 1, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_12_8:
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 1, 271, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGligarAnims_13_1:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_13_2:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_13_3:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_13_4:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_13_5:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_13_6:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_13_7:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarAnims_13_8:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sGligarGfx1:
+.incbin "baserom.gba", 0xE58BC4, 0x200
+sGligarSprites1:
+ax_sprite sGligarGfx1, 0x200
+ax_sprite_terminator
+sGligarGfx2:
+.incbin "baserom.gba", 0xE58DD4, 0x200
+sGligarSprites2:
+ax_sprite sGligarGfx2, 0x200
+ax_sprite_terminator
+sGligarGfx3:
+.incbin "baserom.gba", 0xE58FE4, 0x200
+sGligarSprites3:
+ax_sprite sGligarGfx3, 0x200
+ax_sprite_terminator
+sGligarGfx4:
+.incbin "baserom.gba", 0xE591F4, 0x200
+sGligarSprites4:
+ax_sprite sGligarGfx4, 0x200
+ax_sprite_terminator
+sGligarGfx5:
+.incbin "baserom.gba", 0xE59404, 0x200
+sGligarSprites5:
+ax_sprite sGligarGfx5, 0x200
+ax_sprite_terminator
+sGligarGfx6:
+.incbin "baserom.gba", 0xE59614, 0x200
+sGligarSprites6:
+ax_sprite sGligarGfx6, 0x200
+ax_sprite_terminator
+sGligarGfx7:
+.incbin "baserom.gba", 0xE59824, 0x200
+sGligarSprites7:
+ax_sprite sGligarGfx7, 0x200
+ax_sprite_terminator
+sGligarGfx8:
+.incbin "baserom.gba", 0xE59A34, 0x200
+sGligarSprites8:
+ax_sprite sGligarGfx8, 0x200
+ax_sprite_terminator
+sGligarGfx9:
+.incbin "baserom.gba", 0xE59C44, 0x200
+sGligarSprites9:
+ax_sprite sGligarGfx9, 0x200
+ax_sprite_terminator
+sGligarGfx10:
+.incbin "baserom.gba", 0xE59E54, 0x200
+sGligarSprites10:
+ax_sprite sGligarGfx10, 0x200
+ax_sprite_terminator
+sGligarGfx11:
+.incbin "baserom.gba", 0xE5A064, 0x200
+sGligarSprites11:
+ax_sprite sGligarGfx11, 0x200
+ax_sprite_terminator
+sGligarGfx12:
+.incbin "baserom.gba", 0xE5A274, 0x200
+sGligarSprites12:
+ax_sprite sGligarGfx12, 0x200
+ax_sprite_terminator
+sGligarGfx13:
+.incbin "baserom.gba", 0xE5A484, 0x200
+sGligarSprites13:
+ax_sprite sGligarGfx13, 0x200
+ax_sprite_terminator
+sGligarGfx14:
+.incbin "baserom.gba", 0xE5A694, 0x200
+sGligarSprites14:
+ax_sprite sGligarGfx14, 0x200
+ax_sprite_terminator
+sGligarGfx15:
+.incbin "baserom.gba", 0xE5A8A4, 0x200
+sGligarSprites15:
+ax_sprite sGligarGfx15, 0x200
+ax_sprite_terminator
+sGligarGfx16:
+.incbin "baserom.gba", 0xE5AAB4, 0x40
+sGligarGfx16_1:
+.incbin "baserom.gba", 0xE5AAF4, 0x180
+sGligarSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx16_1, 0x180
+ax_sprite_terminator
+sGligarGfx17:
+.incbin "baserom.gba", 0xE5AC9C, 0x160
+sGligarGfx17_1:
+.incbin "baserom.gba", 0xE5ADFC, 0x40
+sGligarSprites17:
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx17, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx18:
+.incbin "baserom.gba", 0xE5AE6C, 0x200
+sGligarSprites18:
+ax_sprite sGligarGfx18, 0x200
+ax_sprite_terminator
+sGligarGfx19:
+.incbin "baserom.gba", 0xE5B07C, 0x100
+sGligarSprites19:
+ax_sprite sGligarGfx19, 0x100
+ax_sprite_terminator
+sGligarGfx20:
+.incbin "baserom.gba", 0xE5B18C, 0x40
+sGligarSprites20:
+ax_sprite sGligarGfx20, 0x40
+ax_sprite_terminator
+sGligarGfx21:
+.incbin "baserom.gba", 0xE5B1DC, 0x40
+sGligarSprites21:
+ax_sprite sGligarGfx21, 0x40
+ax_sprite_terminator
+sGligarGfx22:
+.incbin "baserom.gba", 0xE5B22C, 0x100
+sGligarSprites22:
+ax_sprite sGligarGfx22, 0x100
+ax_sprite_terminator
+sGligarGfx23:
+.incbin "baserom.gba", 0xE5B33C, 0x80
+sGligarSprites23:
+ax_sprite sGligarGfx23, 0x80
+ax_sprite_terminator
+sGligarGfx24:
+.incbin "baserom.gba", 0xE5B3CC, 0x20
+sGligarGfx24_1:
+.incbin "baserom.gba", 0xE5B3EC, 0x20
+sGligarGfx24_2:
+.incbin "baserom.gba", 0xE5B40C, 0x40
+sGligarGfx24_3:
+.incbin "baserom.gba", 0xE5B44C, 0x60
+sGligarSprites24:
+ax_sprite sGligarGfx24, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGligarGfx24_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGligarGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGligarGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx25:
+.incbin "baserom.gba", 0xE5B4F4, 0x60
+sGligarGfx25_1:
+.incbin "baserom.gba", 0xE5B554, 0x60
+sGligarGfx25_2:
+.incbin "baserom.gba", 0xE5B5B4, 0x60
+sGligarGfx25_3:
+.incbin "baserom.gba", 0xE5B614, 0x60
+sGligarSprites25:
+ax_sprite sGligarGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx26:
+.incbin "baserom.gba", 0xE5B6BC, 0x20
+sGligarGfx26_1:
+.incbin "baserom.gba", 0xE5B6DC, 0x20
+sGligarGfx26_2:
+.incbin "baserom.gba", 0xE5B6FC, 0xE0
+sGligarSprites26:
+ax_sprite 0, 0x60
+ax_sprite sGligarGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGligarGfx26_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx26_2, 0xe0
+ax_sprite_terminator
+sGligarGfx27:
+.incbin "baserom.gba", 0xE5B814, 0xE0
+sGligarSprites27:
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx27, 0xe0
+ax_sprite_terminator
+sGligarGfx28:
+.incbin "baserom.gba", 0xE5B90C, 0x80
+sGligarSprites28:
+ax_sprite sGligarGfx28, 0x80
+ax_sprite_terminator
+sGligarSprites29:
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx30:
+.incbin "baserom.gba", 0xE5B9AC, 0x60
+sGligarGfx30_1:
+.incbin "baserom.gba", 0xE5BA0C, 0x40
+sGligarGfx30_2:
+.incbin "baserom.gba", 0xE5BA4C, 0x60
+sGligarGfx30_3:
+.incbin "baserom.gba", 0xE5BAAC, 0x60
+sGligarSprites30:
+ax_sprite sGligarGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGligarGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx31:
+.incbin "baserom.gba", 0xE5BB54, 0x60
+sGligarGfx31_1:
+.incbin "baserom.gba", 0xE5BBB4, 0x140
+sGligarSprites31:
+ax_sprite sGligarGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx31_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGligarGfx32:
+.incbin "baserom.gba", 0xE5BD1C, 0xC0
+sGligarGfx32_1:
+.incbin "baserom.gba", 0xE5BDDC, 0x40
+sGligarGfx32_2:
+.incbin "baserom.gba", 0xE5BE1C, 0x40
+sGligarSprites32:
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx32, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGligarGfx32_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGligarGfx33:
+.incbin "baserom.gba", 0xE5BE9C, 0x40
+sGligarGfx33_1:
+.incbin "baserom.gba", 0xE5BEDC, 0x140
+sGligarSprites33:
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGligarGfx33_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx34:
+.incbin "baserom.gba", 0xE5C04C, 0xC0
+sGligarGfx34_1:
+.incbin "baserom.gba", 0xE5C10C, 0x60
+sGligarGfx34_2:
+.incbin "baserom.gba", 0xE5C16C, 0x60
+sGligarSprites34:
+ax_sprite sGligarGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGligarGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx35:
+.incbin "baserom.gba", 0xE5C204, 0x60
+sGligarGfx35_1:
+.incbin "baserom.gba", 0xE5C264, 0x160
+sGligarSprites35:
+ax_sprite sGligarGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx35_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx36:
+.incbin "baserom.gba", 0xE5C3EC, 0x60
+sGligarGfx36_1:
+.incbin "baserom.gba", 0xE5C44C, 0xC0
+sGligarGfx36_2:
+.incbin "baserom.gba", 0xE5C50C, 0x20
+sGligarSprites36:
+ax_sprite sGligarGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx36_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx36_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGligarGfx37:
+.incbin "baserom.gba", 0xE5C564, 0x60
+sGligarGfx37_1:
+.incbin "baserom.gba", 0xE5C5C4, 0x60
+sGligarGfx37_2:
+.incbin "baserom.gba", 0xE5C624, 0x60
+sGligarGfx37_3:
+.incbin "baserom.gba", 0xE5C684, 0x60
+sGligarSprites37:
+ax_sprite sGligarGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx38:
+.incbin "baserom.gba", 0xE5C72C, 0x60
+sGligarGfx38_1:
+.incbin "baserom.gba", 0xE5C78C, 0x60
+sGligarGfx38_2:
+.incbin "baserom.gba", 0xE5C7EC, 0x60
+sGligarGfx38_3:
+.incbin "baserom.gba", 0xE5C84C, 0x60
+sGligarSprites38:
+ax_sprite sGligarGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx39:
+.incbin "baserom.gba", 0xE5C8F4, 0x140
+sGligarGfx39_1:
+.incbin "baserom.gba", 0xE5CA34, 0x40
+sGligarSprites39:
+ax_sprite sGligarGfx39, 0x140
+ax_sprite 0, 0x40
+ax_sprite sGligarGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGligarGfx40:
+.incbin "baserom.gba", 0xE5CA9C, 0x60
+sGligarGfx40_1:
+.incbin "baserom.gba", 0xE5CAFC, 0x60
+sGligarGfx40_2:
+.incbin "baserom.gba", 0xE5CB5C, 0xE0
+sGligarSprites40:
+ax_sprite sGligarGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx40_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx41:
+.incbin "baserom.gba", 0xE5CC74, 0x60
+sGligarGfx41_1:
+.incbin "baserom.gba", 0xE5CCD4, 0x60
+sGligarGfx41_2:
+.incbin "baserom.gba", 0xE5CD34, 0x20
+sGligarGfx41_3:
+.incbin "baserom.gba", 0xE5CD54, 0x20
+sGligarSprites41:
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx41_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sGligarGfx41_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGligarGfx41_3, 0x20
+ax_sprite_terminator
+sGligarGfx42:
+.incbin "baserom.gba", 0xE5CDBC, 0x40
+sGligarGfx42_1:
+.incbin "baserom.gba", 0xE5CDFC, 0x160
+sGligarSprites42:
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGligarGfx42_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGligarGfx43:
+.incbin "baserom.gba", 0xE5CF8C, 0x200
+sGligarSprites43:
+ax_sprite sGligarGfx43, 0x200
+ax_sprite_terminator
+sGligarGfx44:
+.incbin "baserom.gba", 0xE5D19C, 0x200
+sGligarSprites44:
+ax_sprite sGligarGfx44, 0x200
+ax_sprite_terminator
+sGligarGfx45:
+.incbin "baserom.gba", 0xE5D3AC, 0x200
+sGligarSprites45:
+ax_sprite sGligarGfx45, 0x200
+ax_sprite_terminator
+sGligarGfx46:
+.incbin "baserom.gba", 0xE5D5BC, 0x200
+sGligarSprites46:
+ax_sprite sGligarGfx46, 0x200
+ax_sprite_terminator
+sGligarGfx47:
+.incbin "baserom.gba", 0xE5D7CC, 0x200
+sGligarSprites47:
+ax_sprite sGligarGfx47, 0x200
+ax_sprite_terminator
+sGligarGfx48:
+.incbin "baserom.gba", 0xE5D9DC, 0x200
+sGligarSprites48:
+ax_sprite sGligarGfx48, 0x200
+ax_sprite_terminator
+sGligarGfx49:
+.incbin "baserom.gba", 0xE5DBEC, 0x200
+sGligarSprites49:
+ax_sprite sGligarGfx49, 0x200
+ax_sprite_terminator
+sAxPosesGligar:
+.4byte sGligarPose1
+.4byte sGligarPose2
+.4byte sGligarPose3
+.4byte sGligarPose4
+.4byte sGligarPose5
+.4byte sGligarPose6
+.4byte sGligarPose7
+.4byte sGligarPose8
+.4byte sGligarPose9
+.4byte sGligarPose10
+.4byte sGligarPose11
+.4byte sGligarPose12
+.4byte sGligarPose13
+.4byte sGligarPose14
+.4byte sGligarPose15
+.4byte sGligarPose16
+.4byte sGligarPose17
+.4byte sGligarPose18
+.4byte sGligarPose19
+.4byte sGligarPose20
+.4byte sGligarPose21
+.4byte sGligarPose22
+.4byte sGligarPose23
+.4byte sGligarPose24
+.4byte sGligarPose25
+.4byte sGligarPose26
+.4byte sGligarPose27
+.4byte sGligarPose28
+.4byte sGligarPose29
+.4byte sGligarPose30
+.4byte sGligarPose31
+.4byte sGligarPose32
+.4byte sGligarPose33
+.4byte sGligarPose34
+.4byte sGligarPose35
+.4byte sGligarPose36
+.4byte sGligarPose37
+.4byte sGligarPose38
+.4byte sGligarPose39
+.4byte sGligarPose40
+.4byte sGligarPose41
+.4byte sGligarPose42
+.4byte sGligarPose43
+.4byte sGligarPose44
+.4byte sGligarPose45
+.4byte sGligarPose46
+.4byte sGligarPose47
+.4byte sGligarPose48
+.4byte sGligarPose49
+.4byte sGligarPose50
+.4byte sGligarPose51
+.4byte sGligarPose52
+.4byte sGligarPose53
+.4byte sGligarPose54
+.4byte sGligarPose55
+.4byte sGligarPose56
+.4byte sGligarPose57
+.4byte sGligarPose58
+.4byte sGligarPose59
+.4byte sGligarPose60
+.4byte sGligarPose61
+.4byte sGligarPose62
+.4byte sGligarPose63
+.4byte sGligarPose64
+.4byte sGligarPose65
+.4byte sGligarPose66
+.4byte sGligarPose67
+.4byte sGligarPose68
+.4byte sGligarPose69
+.4byte sGligarPose70
+.4byte sGligarPose71
+.4byte sGligarPose72
+.4byte sGligarPose73
+.4byte sGligarPose74
+.4byte sGligarPose75
+.4byte sGligarPose76
+.4byte sGligarPose77
+.4byte sGligarPose78
+.4byte sGligarPose79
+.4byte sGligarPose80
+.4byte sGligarPose81
+.4byte sGligarPose82
+.4byte sGligarPose83
+.4byte sGligarPose84
+.4byte sGligarPose85
+.4byte sGligarPose86
+.4byte sGligarPose87
+.4byte sGligarPose88
+.4byte sGligarPose89
+.4byte sGligarPose90
+.4byte sGligarPose91
+.4byte sGligarPose92
+.4byte sGligarPose93
+.4byte sGligarPose94
+.4byte sGligarPose95
+.4byte sGligarPose96
+.4byte sGligarPose97
+.4byte sGligarPose98
+.4byte sGligarPose99
+.4byte sGligarPose100
+.4byte sGligarPose101
+.4byte sGligarPose102
+.4byte sGligarPose103
+.4byte sGligarPose104
+.4byte sGligarPose105
+.4byte sGligarPose106
+.4byte sGligarPose107
+.4byte sGligarPose108
+.4byte sGligarPose109
+.4byte sGligarPose110
+.4byte sGligarPose111
+.4byte sGligarPose112
+.4byte sGligarPose113
+.4byte sGligarPose114
+.4byte sGligarPose115
+.4byte sGligarPose116
+.4byte sGligarPose117
+.4byte sGligarPose118
+.4byte sGligarPose119
+.4byte sGligarPose120
+.4byte sGligarPose121
+.4byte sGligarPose122
+.4byte sGligarPose123
+.4byte sGligarPose124
+.4byte sGligarPose125
+.4byte sGligarPose126
+.4byte sGligarPose127
+.4byte sGligarPose128
+.4byte sGligarPose129
+.4byte sGligarPose130
+.4byte sGligarPose131
+.4byte sGligarPose132
+.4byte sGligarPose133
+.4byte sGligarPose134
+.4byte sGligarPose135
+.4byte sGligarPose136
+.4byte sGligarPose137
+.4byte sGligarPose138
+.4byte sGligarPose139
+.4byte sGligarPose140
+.4byte sGligarPose141
+.4byte sGligarPose142
+.4byte sGligarPose143
+.4byte sGligarPose144
+.4byte sGligarPose145
+.4byte sGligarPose146
+.4byte sGligarPose147
+.4byte sGligarPose148
+.4byte sGligarPose149
+.4byte sGligarPose150
+.4byte sGligarPose151
+.4byte sGligarPose152
+.4byte sGligarPose153
+.4byte sGligarPose154
+.4byte sGligarPose155
+.4byte sGligarPose156
+.4byte sGligarPose157
+.4byte sGligarPose158
+.4byte sGligarPose159
+.4byte sGligarPose160
+.4byte sGligarPose161
+.4byte sGligarPose162
+.4byte sGligarPose163
+.4byte sGligarPose164
+.4byte sGligarPose165
+.4byte sGligarPose166
+.4byte sGligarPose167
+.4byte sGligarPose168
+.4byte sGligarPose169
+.4byte sGligarPose170
+.4byte sGligarPose171
+.4byte sGligarPose172
+.4byte sGligarPose173
+.4byte sGligarPose174
+.4byte sGligarPose175
+.4byte sGligarPose176
+.4byte sGligarPose177
+.4byte sGligarPose178
+.4byte sGligarPose179
+.4byte sGligarPose180
+.4byte sGligarPose181
+.4byte sGligarPose182
+.4byte sGligarPose183
+.4byte sGligarPose184
+.4byte sGligarPose185
+.4byte sGligarPose186
+.4byte sGligarPose187
+.4byte sGligarPose188
+.4byte sGligarPose189
+.4byte sGligarPose190
+.4byte sGligarPose191
+.4byte sGligarPose192
+.4byte sGligarPose193
+.4byte sGligarPose194
+.4byte sGligarPose195
+.4byte sGligarPose196
+.4byte sGligarPose197
+.4byte sGligarPose198
+.4byte sGligarPose199
+.4byte sGligarPose200
+.4byte sGligarPose201
+.4byte sGligarPose202
+.4byte sGligarPose203
+.4byte sGligarPose204
+.4byte sGligarPose205
+.4byte sGligarPose206
+.4byte sGligarPose207
+.4byte sGligarPose208
+.4byte sGligarPose209
+.4byte sGligarPose210
+.4byte sGligarPose211
+.4byte sGligarPose212
+.4byte sGligarPose213
+.4byte sGligarPose214
+.4byte sGligarPose215
+.4byte sGligarPose216
+.4byte sGligarPose217
+.4byte sGligarPose218
+.4byte sGligarPose219
+.4byte sGligarPose220
+.4byte sGligarPose221
+.4byte sGligarPose222
+.4byte sGligarPose223
+.4byte sGligarPose224
+.4byte sGligarPose225
+.4byte sGligarPose226
+.4byte sGligarPose227
+.4byte sGligarPose228
+.4byte sGligarPose229
+.4byte sGligarPose230
+.4byte sGligarPose231
+.4byte sGligarPose232
+.4byte sGligarPose233
+.4byte sGligarPose234
+.4byte sGligarPose235
+.4byte sGligarPose236
+.4byte sGligarPose237
+.4byte sGligarPose238
+.4byte sGligarPose239
+.4byte sGligarPose240
+.4byte sGligarPose241
+.4byte sGligarPose242
+.4byte sGligarPose243
+.4byte sGligarPose244
+.4byte sGligarPose245
+.4byte sGligarPose246
+.4byte sGligarPose247
+.4byte sGligarPose248
+.4byte sGligarPose249
+.4byte sGligarPose250
+.4byte sGligarPose251
+.4byte sGligarPose252
+.4byte sGligarPose253
+.4byte sGligarPose254
+.4byte sGligarPose255
+.4byte sGligarPose256
+.4byte sGligarPose257
+.4byte sGligarPose258
+.4byte sGligarPose259
+.4byte sGligarPose260
+.4byte sGligarPose261
+.4byte sGligarPose262
+.4byte sGligarPose263
+.4byte sGligarPose264
+.4byte sGligarPose265
+.4byte sGligarPose266
+.4byte sGligarPose267
+.4byte sGligarPose268
+.4byte sGligarPose269
+.4byte sGligarPose270
+.4byte sGligarPose271
+.4byte sGligarPose272
+.4byte sGligarPose273
+.4byte sGligarPose274
+.4byte sGligarPose275
+.4byte sGligarPose276
+.4byte sGligarPose277
+.4byte sGligarPose278
+.4byte sGligarPose279
+.4byte sGligarPose280
+.4byte sGligarPose281
+.4byte sGligarPose282
+.4byte sGligarPose283
+.4byte sGligarPose284
+.4byte sGligarPose285
+.4byte sGligarPose286
+sAxPositionsGligar:
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -1,  -14, 	 -13,  -25, 	  11,  -25, 	  -1,  -15
+.2byte   -1,  -16, 	 -10,  -22, 	   8,  -22, 	  -1,  -15
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+.2byte    4,  -14, 	   7,  -28, 	 -10,  -21, 	  -1,  -14
+.2byte    4,  -16, 	  10,  -26, 	  -7,  -20, 	   0,  -16
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    6,  -13, 	   0,  -27, 	  -4,  -19, 	  -2,  -14
+.2byte    4,  -15, 	   4,  -27, 	  -1,  -17, 	  -2,  -13
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    2,  -17, 	  -7,  -25, 	   9,  -18, 	  -2,  -14
+.2byte    1,  -17, 	  -3,  -26, 	  12,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte   -1,  -19, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -1,  -17, 	  10,  -25, 	 -12,  -25, 	  -1,  -14
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -3,  -17, 	   6,  -25, 	 -10,  -18, 	   1,  -14
+.2byte   -2,  -17, 	   2,  -26, 	 -13,  -18, 	   0,  -14
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -7,  -13, 	  -1,  -27, 	   3,  -19, 	   1,  -14
+.2byte   -5,  -15, 	  -5,  -27, 	   0,  -17, 	   1,  -13
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -5,  -14, 	  -8,  -28, 	   9,  -21, 	   0,  -14
+.2byte   -5,  -16, 	 -11,  -26, 	   6,  -20, 	  -1,  -16
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -1,  -15, 	 -13,  -26, 	  11,  -26, 	  -1,  -16
+.2byte   -1,  -15, 	 -10,  -21, 	   8,  -21, 	  -1,  -14
+.2byte   -1,   -6, 	 -12,   -8, 	   9,   -8, 	  -1,  -13
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+.2byte    4,  -15, 	   7,  -29, 	 -10,  -22, 	  -1,  -15
+.2byte    4,  -15, 	  10,  -25, 	  -7,  -19, 	   0,  -15
+.2byte    7,  -11, 	  11,  -17, 	   0,   -6, 	  -2,  -17
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    5,  -14, 	  -1,  -28, 	  -5,  -20, 	  -3,  -15
+.2byte    5,  -14, 	   5,  -26, 	   0,  -16, 	  -1,  -12
+.2byte    7,  -12, 	   8,  -17, 	   6,   -8, 	  -1,  -16
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    1,  -17, 	  -8,  -25, 	   8,  -18, 	  -3,  -14
+.2byte    2,  -17, 	  -2,  -26, 	  13,  -18, 	   0,  -14
+.2byte    6,  -14, 	   0,  -23, 	  12,  -11, 	   2,  -14
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte   -1,  -18, 	  11,  -21, 	 -13,  -21, 	  -1,  -14
+.2byte   -1,  -18, 	  10,  -26, 	 -12,  -26, 	  -1,  -15
+.2byte   -1,  -16, 	  10,  -19, 	 -12,  -19, 	  -1,  -12
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -2,  -17, 	   7,  -25, 	  -9,  -18, 	   2,  -14
+.2byte   -3,  -17, 	   1,  -26, 	 -14,  -18, 	  -1,  -14
+.2byte   -6,  -15, 	   0,  -24, 	 -12,  -12, 	  -2,  -15
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -6,  -14, 	   0,  -28, 	   4,  -20, 	   2,  -15
+.2byte   -6,  -14, 	  -6,  -26, 	  -1,  -16, 	   0,  -12
+.2byte   -8,  -12, 	  -9,  -17, 	  -7,   -8, 	   0,  -16
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -5,  -15, 	  -8,  -29, 	   9,  -22, 	   0,  -15
+.2byte   -5,  -15, 	 -11,  -25, 	   6,  -19, 	  -1,  -15
+.2byte   -8,  -10, 	 -12,  -16, 	  -1,   -5, 	   1,  -16
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -1,  -14, 	 -13,  -25, 	  11,  -25, 	  -1,  -15
+.2byte   -1,  -16, 	 -10,  -22, 	   8,  -22, 	  -1,  -15
+.2byte    1,  -13, 	   4,   -4, 	   4,  -26, 	   0,  -11
+.2byte    1,  -13, 	   4,   -4, 	   4,  -26, 	   0,  -11
+.2byte   -2,  -13, 	  -5,   -4, 	  -5,  -26, 	  -1,  -11
+.2byte   -2,  -13, 	  -5,   -4, 	  -5,  -26, 	  -1,  -11
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+.2byte    4,  -14, 	   7,  -28, 	 -10,  -21, 	  -1,  -14
+.2byte    4,  -16, 	  10,  -26, 	  -7,  -20, 	   0,  -16
+.2byte    4,  -11, 	   0,  -25, 	   5,   -3, 	  -2,  -11
+.2byte    4,  -11, 	   0,  -25, 	   5,   -3, 	  -2,  -11
+.2byte    4,  -11, 	   3,   -2, 	  -6,  -24, 	  -1,  -12
+.2byte    4,  -11, 	   3,   -2, 	  -6,  -24, 	  -1,  -12
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    6,  -13, 	   0,  -27, 	  -4,  -19, 	  -2,  -14
+.2byte    4,  -15, 	   4,  -27, 	  -1,  -17, 	  -2,  -13
+.2byte    8,  -10, 	  -3,  -24, 	  10,   -8, 	  -1,  -13
+.2byte    8,  -10, 	  -3,  -24, 	  10,   -8, 	  -1,  -13
+.2byte    7,  -11, 	   7,   -3, 	  -5,  -24, 	  -2,  -14
+.2byte    7,  -11, 	   7,   -3, 	  -5,  -24, 	  -2,  -14
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    2,  -17, 	  -7,  -25, 	   9,  -18, 	  -2,  -14
+.2byte    1,  -17, 	  -3,  -26, 	  12,  -18, 	  -1,  -14
+.2byte    2,  -17, 	  -8,  -26, 	   7,  -17, 	  -1,  -15
+.2byte    2,  -17, 	  -8,  -26, 	   7,  -17, 	  -1,  -15
+.2byte    4,  -17, 	   9,  -21, 	  -1,  -21, 	  -1,  -14
+.2byte    4,  -17, 	   9,  -21, 	  -1,  -21, 	  -1,  -14
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte   -1,  -19, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -1,  -17, 	  10,  -25, 	 -12,  -25, 	  -1,  -14
+.2byte   -2,  -18, 	  -1,  -18, 	 -11,  -21, 	   0,  -15
+.2byte    2,  -18, 	   3,  -15, 	  -3,  -20, 	   3,  -14
+.2byte    1,  -18, 	   0,  -18, 	  10,  -21, 	  -1,  -15
+.2byte   -1,  -18, 	  -2,  -15, 	   4,  -20, 	  -2,  -14
+.2byte   -3,  -18, 	  -2,  -18, 	 -12,  -21, 	  -1,  -15
+.2byte    2,  -18, 	   1,  -18, 	  11,  -21, 	   0,  -15
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -3,  -17, 	   6,  -25, 	 -10,  -18, 	   1,  -14
+.2byte   -2,  -17, 	   2,  -26, 	 -13,  -18, 	   0,  -14
+.2byte   -5,  -17, 	 -10,  -21, 	   0,  -21, 	   0,  -14
+.2byte   -5,  -17, 	 -10,  -21, 	   0,  -21, 	   0,  -14
+.2byte   -3,  -17, 	   7,  -26, 	  -8,  -17, 	   0,  -15
+.2byte   -3,  -17, 	   7,  -26, 	  -8,  -17, 	   0,  -15
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -7,  -13, 	  -1,  -27, 	   3,  -19, 	   1,  -14
+.2byte   -5,  -15, 	  -5,  -27, 	   0,  -17, 	   1,  -13
+.2byte   -8,  -11, 	  -8,   -3, 	   4,  -24, 	   1,  -14
+.2byte   -8,  -11, 	  -8,   -3, 	   4,  -24, 	   1,  -14
+.2byte   -9,  -10, 	   2,  -24, 	 -11,   -8, 	   0,  -13
+.2byte   -9,  -10, 	   2,  -24, 	 -11,   -8, 	   0,  -13
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -5,  -14, 	  -8,  -28, 	   9,  -21, 	   0,  -14
+.2byte   -5,  -16, 	 -11,  -26, 	   6,  -20, 	  -1,  -16
+.2byte   -5,  -11, 	  -4,   -2, 	   5,  -24, 	   0,  -12
+.2byte   -5,  -11, 	  -4,   -2, 	   5,  -24, 	   0,  -12
+.2byte   -5,  -11, 	  -1,  -25, 	  -6,   -3, 	   1,  -11
+.2byte   -5,  -11, 	  -1,  -25, 	  -6,   -3, 	   1,  -11
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -1,  -14, 	 -13,  -25, 	  11,  -25, 	  -1,  -15
+.2byte   -1,  -16, 	 -10,  -22, 	   8,  -22, 	  -1,  -15
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+.2byte    4,  -14, 	   7,  -28, 	 -10,  -21, 	  -1,  -14
+.2byte    4,  -16, 	  10,  -26, 	  -7,  -20, 	   0,  -16
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    5,  -13, 	  -1,  -27, 	  -5,  -19, 	  -3,  -14
+.2byte    5,  -15, 	   5,  -27, 	   0,  -17, 	  -1,  -13
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    2,  -17, 	  -7,  -25, 	   9,  -18, 	  -2,  -14
+.2byte    1,  -17, 	  -3,  -26, 	  12,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte   -1,  -19, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -1,  -17, 	  10,  -25, 	 -12,  -25, 	  -1,  -14
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -3,  -17, 	   6,  -25, 	 -10,  -18, 	   1,  -14
+.2byte   -2,  -17, 	   2,  -26, 	 -13,  -18, 	   0,  -14
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -6,  -13, 	   0,  -27, 	   4,  -19, 	   2,  -14
+.2byte   -6,  -15, 	  -6,  -27, 	  -1,  -17, 	   0,  -13
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -5,  -14, 	  -8,  -28, 	   9,  -21, 	   0,  -14
+.2byte   -5,  -16, 	 -11,  -26, 	   6,  -20, 	  -1,  -16
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -1,  -14, 	 -13,  -25, 	  11,  -25, 	  -1,  -15
+.2byte   -1,  -16, 	 -10,  -22, 	   8,  -22, 	  -1,  -15
+.2byte    1,  -13, 	   4,   -4, 	   4,  -26, 	   0,  -11
+.2byte    1,  -13, 	   4,   -4, 	   4,  -26, 	   0,  -11
+.2byte   -2,  -13, 	  -5,   -4, 	  -5,  -26, 	  -1,  -11
+.2byte   -2,  -13, 	  -5,   -4, 	  -5,  -26, 	  -1,  -11
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+.2byte    4,  -14, 	   7,  -28, 	 -10,  -21, 	  -1,  -14
+.2byte    4,  -16, 	  10,  -26, 	  -7,  -20, 	   0,  -16
+.2byte    4,  -11, 	   0,  -25, 	   5,   -3, 	  -2,  -11
+.2byte    4,  -11, 	   0,  -25, 	   5,   -3, 	  -2,  -11
+.2byte    4,  -11, 	   3,   -2, 	  -6,  -24, 	  -1,  -12
+.2byte    4,  -11, 	   3,   -2, 	  -6,  -24, 	  -1,  -12
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    6,  -13, 	   0,  -27, 	  -4,  -19, 	  -2,  -14
+.2byte    4,  -15, 	   4,  -27, 	  -1,  -17, 	  -2,  -13
+.2byte    8,  -10, 	  -3,  -24, 	  10,   -8, 	  -1,  -13
+.2byte    8,  -10, 	  -3,  -24, 	  10,   -8, 	  -1,  -13
+.2byte    7,  -11, 	   7,   -3, 	  -5,  -24, 	  -2,  -14
+.2byte    7,  -11, 	   7,   -3, 	  -5,  -24, 	  -2,  -14
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    2,  -17, 	  -7,  -25, 	   9,  -18, 	  -2,  -14
+.2byte    1,  -17, 	  -3,  -26, 	  12,  -18, 	  -1,  -14
+.2byte    2,  -17, 	  -8,  -26, 	   7,  -17, 	  -1,  -15
+.2byte    2,  -17, 	  -8,  -26, 	   7,  -17, 	  -1,  -15
+.2byte    4,  -17, 	   9,  -21, 	  -1,  -21, 	  -1,  -14
+.2byte    4,  -17, 	   9,  -21, 	  -1,  -21, 	  -1,  -14
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte   -1,  -19, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -1,  -17, 	  10,  -25, 	 -12,  -25, 	  -1,  -14
+.2byte   -2,  -18, 	  -1,  -18, 	 -11,  -21, 	   0,  -15
+.2byte    2,  -18, 	   3,  -15, 	  -3,  -20, 	   3,  -14
+.2byte    1,  -18, 	   0,  -18, 	  10,  -21, 	  -1,  -15
+.2byte   -1,  -18, 	  -2,  -15, 	   4,  -20, 	  -2,  -14
+.2byte   -3,  -18, 	  -2,  -18, 	 -12,  -21, 	  -1,  -15
+.2byte    2,  -18, 	   1,  -18, 	  11,  -21, 	   0,  -15
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -3,  -17, 	   6,  -25, 	 -10,  -18, 	   1,  -14
+.2byte   -2,  -17, 	   2,  -26, 	 -13,  -18, 	   0,  -14
+.2byte   -5,  -17, 	 -10,  -21, 	   0,  -21, 	   0,  -14
+.2byte   -5,  -17, 	 -10,  -21, 	   0,  -21, 	   0,  -14
+.2byte   -3,  -17, 	   7,  -26, 	  -8,  -17, 	   0,  -15
+.2byte   -3,  -17, 	   7,  -26, 	  -8,  -17, 	   0,  -15
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -7,  -13, 	  -1,  -27, 	   3,  -19, 	   1,  -14
+.2byte   -5,  -15, 	  -5,  -27, 	   0,  -17, 	   1,  -13
+.2byte   -8,  -11, 	  -8,   -3, 	   4,  -24, 	   1,  -14
+.2byte   -8,  -11, 	  -8,   -3, 	   4,  -24, 	   1,  -14
+.2byte   -9,  -10, 	   2,  -24, 	 -11,   -8, 	   0,  -13
+.2byte   -9,  -10, 	   2,  -24, 	 -11,   -8, 	   0,  -13
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -5,  -14, 	  -8,  -28, 	   9,  -21, 	   0,  -14
+.2byte   -5,  -16, 	 -11,  -26, 	   6,  -20, 	  -1,  -16
+.2byte   -5,  -11, 	  -4,   -2, 	   5,  -24, 	   0,  -12
+.2byte   -5,  -11, 	  -4,   -2, 	   5,  -24, 	   0,  -12
+.2byte   -5,  -11, 	  -1,  -25, 	  -6,   -3, 	   1,  -11
+.2byte   -5,  -11, 	  -1,  -25, 	  -6,   -3, 	   1,  -11
+.2byte   -1,   -6, 	 -13,    1, 	  10,    1, 	  -1,   -5
+.2byte   -1,   -5, 	 -13,    2, 	  11,    2, 	  -1,   -4
+.2byte   -1,  -19, 	 -11,  -21, 	   9,  -21, 	  -1,  -13
+.2byte    1,  -17, 	   2,  -24, 	 -10,  -17, 	  -1,  -13
+.2byte   -1,  -17, 	  -2,  -20, 	  -4,  -16, 	  -2,  -11
+.2byte    0,  -15, 	  -7,  -21, 	   7,  -15, 	   1,  -10
+.2byte    0,  -10, 	  10,  -18, 	 -10,  -18, 	   0,  -11
+.2byte   -1,  -15, 	   6,  -21, 	  -8,  -15, 	  -2,  -10
+.2byte    0,  -17, 	   1,  -20, 	   3,  -16, 	   1,  -11
+.2byte   -2,  -17, 	  -3,  -24, 	   9,  -17, 	   0,  -13
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -1,  -14, 	 -13,  -25, 	  11,  -25, 	  -1,  -15
+.2byte   -1,  -16, 	 -10,  -22, 	   8,  -22, 	  -1,  -15
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+.2byte    4,  -14, 	   7,  -28, 	 -10,  -21, 	  -1,  -14
+.2byte    4,  -16, 	  10,  -26, 	  -7,  -20, 	   0,  -16
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    6,  -13, 	   0,  -27, 	  -4,  -19, 	  -2,  -14
+.2byte    4,  -15, 	   4,  -27, 	  -1,  -17, 	  -2,  -13
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    2,  -17, 	  -7,  -25, 	   9,  -18, 	  -2,  -14
+.2byte    1,  -17, 	  -3,  -26, 	  12,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte   -1,  -19, 	  11,  -22, 	 -13,  -22, 	  -1,  -15
+.2byte   -1,  -17, 	  10,  -25, 	 -12,  -25, 	  -1,  -14
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -3,  -17, 	   6,  -25, 	 -10,  -18, 	   1,  -14
+.2byte   -2,  -17, 	   2,  -26, 	 -13,  -18, 	   0,  -14
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -7,  -13, 	  -1,  -27, 	   3,  -19, 	   1,  -14
+.2byte   -5,  -15, 	  -5,  -27, 	   0,  -17, 	   1,  -13
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -5,  -14, 	  -8,  -28, 	   9,  -21, 	   0,  -14
+.2byte   -5,  -16, 	 -11,  -26, 	   6,  -20, 	  -1,  -16
+.2byte   -1,   -6, 	 -12,   -8, 	   9,   -8, 	  -1,  -13
+.2byte   -9,   -9, 	 -13,  -15, 	  -2,   -4, 	   0,  -15
+.2byte  -11,  -10, 	 -12,  -15, 	 -10,   -6, 	  -3,  -14
+.2byte   -5,  -15, 	   1,  -24, 	 -11,  -12, 	  -1,  -15
+.2byte   -1,  -17, 	  10,  -20, 	 -12,  -20, 	  -1,  -13
+.2byte    4,  -15, 	  -2,  -24, 	  10,  -12, 	   0,  -15
+.2byte   10,  -10, 	  11,  -15, 	   9,   -6, 	   2,  -14
+.2byte    8,   -9, 	  12,  -15, 	   1,   -4, 	  -1,  -15
+.2byte   -1,  -14, 	 -13,  -25, 	  11,  -25, 	  -1,  -15
+.2byte    5,  -14, 	   8,  -28, 	  -9,  -21, 	   0,  -14
+.2byte    7,  -13, 	   1,  -27, 	  -3,  -19, 	  -1,  -14
+.2byte    2,  -17, 	  -7,  -25, 	   9,  -18, 	  -2,  -14
+.2byte   -1,  -18, 	  11,  -21, 	 -13,  -21, 	  -1,  -14
+.2byte   -3,  -17, 	   6,  -25, 	 -10,  -18, 	   1,  -14
+.2byte   -8,  -13, 	  -2,  -27, 	   2,  -19, 	   0,  -14
+.2byte   -5,  -14, 	  -8,  -28, 	   9,  -21, 	   0,  -14
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -1,  -15, 	 -13,  -26, 	  11,  -26, 	  -1,  -16
+.2byte   -1,  -15, 	 -10,  -21, 	   8,  -21, 	  -1,  -14
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+.2byte    4,  -15, 	   7,  -29, 	 -10,  -22, 	  -1,  -15
+.2byte    4,  -15, 	  10,  -25, 	  -7,  -19, 	   0,  -15
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    6,  -14, 	   0,  -28, 	  -4,  -20, 	  -2,  -15
+.2byte    4,  -14, 	   4,  -26, 	  -1,  -16, 	  -2,  -12
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    2,  -18, 	  -7,  -26, 	   9,  -19, 	  -2,  -15
+.2byte    1,  -17, 	  -3,  -26, 	  12,  -18, 	  -1,  -14
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte   -1,  -18, 	  11,  -21, 	 -13,  -21, 	  -1,  -14
+.2byte   -1,  -18, 	  10,  -26, 	 -12,  -26, 	  -1,  -15
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -3,  -18, 	   6,  -26, 	 -10,  -19, 	   1,  -15
+.2byte   -2,  -17, 	   2,  -26, 	 -13,  -18, 	   0,  -14
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -7,  -14, 	  -1,  -28, 	   3,  -20, 	   1,  -15
+.2byte   -5,  -14, 	  -5,  -26, 	   0,  -16, 	   1,  -12
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -5,  -15, 	  -8,  -29, 	   9,  -22, 	   0,  -15
+.2byte   -5,  -15, 	 -11,  -25, 	   6,  -19, 	  -1,  -15
+.2byte   -1,  -14, 	 -13,  -25, 	  11,  -25, 	  -1,  -15
+.2byte   -5,  -14, 	  -8,  -28, 	   9,  -21, 	   0,  -14
+.2byte   -8,  -13, 	  -2,  -27, 	   2,  -19, 	   0,  -14
+.2byte   -3,  -17, 	   6,  -25, 	 -10,  -18, 	   1,  -14
+.2byte   -1,  -18, 	  11,  -21, 	 -13,  -21, 	  -1,  -14
+.2byte    2,  -17, 	  -7,  -25, 	   9,  -18, 	  -2,  -14
+.2byte    7,  -13, 	   1,  -27, 	  -3,  -19, 	  -1,  -14
+.2byte    5,  -14, 	   8,  -28, 	  -9,  -21, 	   0,  -14
+.2byte   -1,  -15, 	 -12,  -23, 	  10,  -23, 	  -1,  -16
+.2byte   -5,  -15, 	 -10,  -26, 	   7,  -20, 	  -1,  -15
+.2byte   -6,  -14, 	  -2,  -28, 	   1,  -18, 	   1,  -13
+.2byte   -3,  -18, 	   4,  -26, 	 -11,  -18, 	   0,  -15
+.2byte   -1,  -18, 	  11,  -24, 	 -13,  -24, 	  -1,  -13
+.2byte    2,  -18, 	  -5,  -26, 	  10,  -18, 	  -1,  -15
+.2byte    5,  -14, 	   1,  -28, 	  -2,  -18, 	  -2,  -13
+.2byte    4,  -15, 	   9,  -26, 	  -8,  -20, 	   0,  -15
+sGligarAnimTable1:
+.4byte sGligarAnims_1_1
+.4byte sGligarAnims_1_2
+.4byte sGligarAnims_1_3
+.4byte sGligarAnims_1_4
+.4byte sGligarAnims_1_5
+.4byte sGligarAnims_1_6
+.4byte sGligarAnims_1_7
+.4byte sGligarAnims_1_8
+sGligarAnimTable2:
+.4byte sGligarAnims_2_1
+.4byte sGligarAnims_2_2
+.4byte sGligarAnims_2_3
+.4byte sGligarAnims_2_4
+.4byte sGligarAnims_2_5
+.4byte sGligarAnims_2_6
+.4byte sGligarAnims_2_7
+.4byte sGligarAnims_2_8
+sGligarAnimTable3:
+.4byte sGligarAnims_3_1
+.4byte sGligarAnims_3_2
+.4byte sGligarAnims_3_3
+.4byte sGligarAnims_3_4
+.4byte sGligarAnims_3_5
+.4byte sGligarAnims_3_6
+.4byte sGligarAnims_3_7
+.4byte sGligarAnims_3_8
+sGligarAnimTable4:
+.4byte sGligarAnims_4_1
+.4byte sGligarAnims_4_2
+.4byte sGligarAnims_4_3
+.4byte sGligarAnims_4_4
+.4byte sGligarAnims_4_5
+.4byte sGligarAnims_4_6
+.4byte sGligarAnims_4_7
+.4byte sGligarAnims_4_8
+sGligarAnimTable5:
+.4byte sGligarAnims_5_1
+.4byte sGligarAnims_5_2
+.4byte sGligarAnims_5_3
+.4byte sGligarAnims_5_4
+.4byte sGligarAnims_5_5
+.4byte sGligarAnims_5_6
+.4byte sGligarAnims_5_7
+.4byte sGligarAnims_5_8
+sGligarAnimTable6:
+.4byte sGligarAnims_6_1
+.4byte sGligarAnims_6_1
+.4byte sGligarAnims_6_1
+.4byte sGligarAnims_6_1
+.4byte sGligarAnims_6_1
+.4byte sGligarAnims_6_1
+.4byte sGligarAnims_6_1
+.4byte sGligarAnims_6_1
+sGligarAnimTable7:
+.4byte sGligarAnims_7_1
+.4byte sGligarAnims_7_2
+.4byte sGligarAnims_7_3
+.4byte sGligarAnims_7_4
+.4byte sGligarAnims_7_5
+.4byte sGligarAnims_7_6
+.4byte sGligarAnims_7_7
+.4byte sGligarAnims_7_8
+sGligarAnimTable8:
+.4byte sGligarAnims_8_1
+.4byte sGligarAnims_8_2
+.4byte sGligarAnims_8_3
+.4byte sGligarAnims_8_4
+.4byte sGligarAnims_8_5
+.4byte sGligarAnims_8_6
+.4byte sGligarAnims_8_7
+.4byte sGligarAnims_8_8
+sGligarAnimTable9:
+.4byte sGligarAnims_9_1
+.4byte sGligarAnims_9_2
+.4byte sGligarAnims_9_3
+.4byte sGligarAnims_9_4
+.4byte sGligarAnims_9_5
+.4byte sGligarAnims_9_6
+.4byte sGligarAnims_9_7
+.4byte sGligarAnims_9_8
+sGligarAnimTable10:
+.4byte sGligarAnims_10_1
+.4byte sGligarAnims_10_2
+.4byte sGligarAnims_10_3
+.4byte sGligarAnims_10_4
+.4byte sGligarAnims_10_5
+.4byte sGligarAnims_10_6
+.4byte sGligarAnims_10_7
+.4byte sGligarAnims_10_8
+sGligarAnimTable11:
+.4byte sGligarAnims_11_1
+.4byte sGligarAnims_11_2
+.4byte sGligarAnims_11_3
+.4byte sGligarAnims_11_4
+.4byte sGligarAnims_11_5
+.4byte sGligarAnims_11_6
+.4byte sGligarAnims_11_7
+.4byte sGligarAnims_11_8
+sGligarAnimTable12:
+.4byte sGligarAnims_12_1
+.4byte sGligarAnims_12_2
+.4byte sGligarAnims_12_3
+.4byte sGligarAnims_12_4
+.4byte sGligarAnims_12_5
+.4byte sGligarAnims_12_6
+.4byte sGligarAnims_12_7
+.4byte sGligarAnims_12_8
+sGligarAnimTable13:
+.4byte sGligarAnims_13_1
+.4byte sGligarAnims_13_2
+.4byte sGligarAnims_13_3
+.4byte sGligarAnims_13_4
+.4byte sGligarAnims_13_5
+.4byte sGligarAnims_13_6
+.4byte sGligarAnims_13_7
+.4byte sGligarAnims_13_8
+sAxAnimationsGligar:
+.4byte sGligarAnimTable1
+.4byte sGligarAnimTable2
+.4byte sGligarAnimTable3
+.4byte sGligarAnimTable4
+.4byte sGligarAnimTable5
+.4byte sGligarAnimTable6
+.4byte sGligarAnimTable7
+.4byte sGligarAnimTable8
+.4byte sGligarAnimTable9
+.4byte sGligarAnimTable10
+.4byte sGligarAnimTable11
+.4byte sGligarAnimTable12
+.4byte sGligarAnimTable13
+sAxSpritesGligar:
+.4byte sGligarSprites1
+.4byte sGligarSprites2
+.4byte sGligarSprites3
+.4byte sGligarSprites4
+.4byte sGligarSprites5
+.4byte sGligarSprites6
+.4byte sGligarSprites7
+.4byte sGligarSprites8
+.4byte sGligarSprites9
+.4byte sGligarSprites10
+.4byte sGligarSprites11
+.4byte sGligarSprites12
+.4byte sGligarSprites13
+.4byte sGligarSprites14
+.4byte sGligarSprites15
+.4byte sGligarSprites16
+.4byte sGligarSprites17
+.4byte sGligarSprites18
+.4byte sGligarSprites19
+.4byte sGligarSprites20
+.4byte sGligarSprites21
+.4byte sGligarSprites22
+.4byte sGligarSprites23
+.4byte sGligarSprites24
+.4byte sGligarSprites25
+.4byte sGligarSprites26
+.4byte sGligarSprites27
+.4byte sGligarSprites28
+.4byte sGligarSprites29
+.4byte sGligarSprites30
+.4byte sGligarSprites31
+.4byte sGligarSprites32
+.4byte sGligarSprites33
+.4byte sGligarSprites34
+.4byte sGligarSprites35
+.4byte sGligarSprites36
+.4byte sGligarSprites37
+.4byte sGligarSprites38
+.4byte sGligarSprites39
+.4byte sGligarSprites40
+.4byte sGligarSprites41
+.4byte sGligarSprites42
+.4byte sGligarSprites43
+.4byte sGligarSprites44
+.4byte sGligarSprites45
+.4byte sGligarSprites46
+.4byte sGligarSprites47
+.4byte sGligarSprites48
+.4byte sGligarSprites49
+sAxMainGligar:
+ax_main sAxPosesGligar, sAxAnimationsGligar, 13, sAxSpritesGligar, sAxPositionsGligar

--- a/data/ax/gloom.inc
+++ b/data/ax/gloom.inc
@@ -1,0 +1,2842 @@
+.global gAxGloom
+gAxGloom:
+ax_siro sAxMainGloom
+sGloomPose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose4:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose5:
+ax_pose 4, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose6:
+ax_pose 5, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose7:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose8:
+ax_pose 7, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose9:
+ax_pose 8, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose10:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose11:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose12:
+ax_pose 11, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose19:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose20:
+ax_pose 16, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose21:
+ax_pose 17, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose22:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose23:
+ax_pose 19, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose24:
+ax_pose 20, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose25:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose28:
+ax_pose 21, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose29:
+ax_pose 22, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose30:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose31:
+ax_pose 4, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose32:
+ax_pose 5, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose33:
+ax_pose 23, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose34:
+ax_pose 24, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sGloomPose35:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose36:
+ax_pose 7, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose37:
+ax_pose 8, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose38:
+ax_pose 25, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose39:
+ax_pose 26, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGloomPose40:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose41:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose42:
+ax_pose 11, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose43:
+ax_pose 27, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose44:
+ax_pose 28, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose45:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose46:
+ax_pose 13, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose47:
+ax_pose 14, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose48:
+ax_pose 29, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose49:
+ax_pose 30, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose50:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose51:
+ax_pose 10, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose52:
+ax_pose 11, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose53:
+ax_pose 27, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose54:
+ax_pose 28, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose55:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose56:
+ax_pose 16, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose57:
+ax_pose 17, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose58:
+ax_pose 31, 0x01ea, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose59:
+ax_pose 26, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose60:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose61:
+ax_pose 19, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose62:
+ax_pose 20, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose63:
+ax_pose 32, 0x01ea, 0x80ed, 0x6c00
+ax_pose_terminator
+sGloomPose64:
+ax_pose 24, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose65:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose66:
+ax_pose 1, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose67:
+ax_pose 2, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose68:
+ax_pose 21, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose69:
+ax_pose 22, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose70:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose71:
+ax_pose 4, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose72:
+ax_pose 5, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose73:
+ax_pose 23, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose74:
+ax_pose 24, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sGloomPose75:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose76:
+ax_pose 7, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose77:
+ax_pose 8, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose78:
+ax_pose 25, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose79:
+ax_pose 26, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGloomPose80:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose81:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose82:
+ax_pose 11, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose83:
+ax_pose 27, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose84:
+ax_pose 28, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose85:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose86:
+ax_pose 13, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose87:
+ax_pose 14, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose88:
+ax_pose 29, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose89:
+ax_pose 30, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose90:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose91:
+ax_pose 10, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose92:
+ax_pose 11, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose93:
+ax_pose 27, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose94:
+ax_pose 28, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose95:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose96:
+ax_pose 16, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose97:
+ax_pose 17, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose98:
+ax_pose 31, 0x01ea, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose99:
+ax_pose 26, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose100:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose101:
+ax_pose 19, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose102:
+ax_pose 20, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose103:
+ax_pose 32, 0x01ea, 0x80ed, 0x6c00
+ax_pose_terminator
+sGloomPose104:
+ax_pose 24, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose105:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose106:
+ax_pose 21, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose107:
+ax_pose 22, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose108:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose109:
+ax_pose 23, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose110:
+ax_pose 24, 0x01ea, 0x90f4, 0x6c00
+ax_pose_terminator
+sGloomPose111:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose112:
+ax_pose 25, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose113:
+ax_pose 26, 0x01ea, 0x90f4, 0x6c00
+ax_pose_terminator
+sGloomPose114:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose115:
+ax_pose 27, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose116:
+ax_pose 28, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose117:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose118:
+ax_pose 29, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose119:
+ax_pose 30, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose120:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose121:
+ax_pose 27, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose122:
+ax_pose 28, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose123:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose124:
+ax_pose 31, 0x01ea, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose125:
+ax_pose 26, 0x01ea, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose126:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose127:
+ax_pose 32, 0x01ea, 0x80ed, 0x6c00
+ax_pose_terminator
+sGloomPose128:
+ax_pose 24, 0x01ea, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose129:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose130:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose131:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose132:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose133:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose134:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose135:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose136:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose137:
+ax_pose 33, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose138:
+ax_pose 34, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose139:
+ax_pose 35, 0x01e1, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose140:
+ax_pose 36, 0x01e1, 0x80ed, 0x6c00
+ax_pose_terminator
+sGloomPose141:
+ax_pose 37, 0x01e1, 0x80eb, 0x6c00
+ax_pose_terminator
+sGloomPose142:
+ax_pose 38, 0x01e2, 0x80eb, 0x6c00
+ax_pose_terminator
+sGloomPose143:
+ax_pose 39, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose144:
+ax_pose 40, 0x01e2, 0x80f5, 0x6c00
+ax_pose_terminator
+sGloomPose145:
+ax_pose 41, 0x01e2, 0x80f5, 0x6c00
+ax_pose_terminator
+sGloomPose146:
+ax_pose 42, 0x01e1, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose147:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose148:
+ax_pose 1, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose149:
+ax_pose 2, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose150:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose151:
+ax_pose 4, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose152:
+ax_pose 5, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose153:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose154:
+ax_pose 7, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose155:
+ax_pose 8, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose156:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose157:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose158:
+ax_pose 11, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose159:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose160:
+ax_pose 13, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose161:
+ax_pose 14, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose162:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose163:
+ax_pose 10, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose164:
+ax_pose 11, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose165:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose166:
+ax_pose 16, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose167:
+ax_pose 17, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose168:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose169:
+ax_pose 19, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose170:
+ax_pose 20, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose171:
+ax_pose 22, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose172:
+ax_pose 24, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose173:
+ax_pose 26, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGloomPose174:
+ax_pose 28, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose175:
+ax_pose 30, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose176:
+ax_pose 28, 0x01e9, 0x90ed, 0x6c00
+ax_pose_terminator
+sGloomPose177:
+ax_pose 26, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGloomPose178:
+ax_pose 24, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sGloomPose179:
+ax_pose 21, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose180:
+ax_pose 23, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose181:
+ax_pose 25, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose182:
+ax_pose 27, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose183:
+ax_pose 29, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose184:
+ax_pose 27, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose185:
+ax_pose 31, 0x01ea, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose186:
+ax_pose 32, 0x01ea, 0x80ed, 0x6c00
+ax_pose_terminator
+sGloomPose187:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose188:
+ax_pose 21, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose189:
+ax_pose 22, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose190:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose191:
+ax_pose 23, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose192:
+ax_pose 24, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sGloomPose193:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose194:
+ax_pose 25, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose195:
+ax_pose 26, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGloomPose196:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose197:
+ax_pose 27, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sGloomPose198:
+ax_pose 28, 0x01e9, 0x90ed, 0x6c00
+ax_pose_terminator
+sGloomPose199:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose200:
+ax_pose 29, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose201:
+ax_pose 30, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose202:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose203:
+ax_pose 27, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sGloomPose204:
+ax_pose 28, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose205:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose206:
+ax_pose 31, 0x01ea, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose207:
+ax_pose 26, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGloomPose208:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose209:
+ax_pose 32, 0x01ea, 0x80ed, 0x6c00
+ax_pose_terminator
+sGloomPose210:
+ax_pose 24, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose211:
+ax_pose 22, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose212:
+ax_pose 24, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose213:
+ax_pose 26, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGloomPose214:
+ax_pose 28, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sGloomPose215:
+ax_pose 30, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose216:
+ax_pose 28, 0x01e9, 0x90ed, 0x6c00
+ax_pose_terminator
+sGloomPose217:
+ax_pose 26, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGloomPose218:
+ax_pose 24, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sGloomPose219:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose220:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose221:
+ax_pose 15, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose222:
+ax_pose 9, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sGloomPose223:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGloomPose224:
+ax_pose 9, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sGloomPose225:
+ax_pose 6, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+sGloomPose226:
+ax_pose 3, 0x01eb, 0x80ec, 0x6c00
+ax_pose_terminator
+.align 2
+sGloomAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 4, 0, 4,
+ax_anim 2, 2, 25, 0, 14, 0, 14,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sGloomAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 31, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 1, 0, 31, 5, 6, 5, 6,
+ax_anim 2, 2, 30, 12, 14, 12, 14,
+ax_anim 2, 0, 33, 16, 20, 16, 20,
+ax_anim 2, 1, 33, 17, 19, 17, 19,
+ax_anim 2, 0, 33, 16, 20, 16, 20,
+ax_anim 2, 0, 33, 17, 19, 17, 19,
+ax_anim 2, 0, 33, 16, 20, 16, 20,
+ax_anim 2, 0, 29, 10, 13, 10, 13,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sGloomAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 2, 0, 36, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 1, 0, 36, 3, 0, 3, 0,
+ax_anim 2, 2, 35, 9, 0, 9, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, -1, 18, -1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, -1, 18, -1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 34, 3, 0, 3, 0,
+ax_anim_terminator
+sGloomAnims_2_4:
+ax_anim 2, 0, 40, -1, 1, -1, 1,
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 2, 0, 41, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -2, 2, -2, 2,
+ax_anim 2, 0, 40, -3, 3, -3, 3,
+ax_anim 2, 0, 39, -3, 3, -3, 3,
+ax_anim 1, 0, 41, 5, -6, 5, -6,
+ax_anim 2, 2, 40, 12, -14, 12, -14,
+ax_anim 2, 0, 43, 16, -20, 16, -20,
+ax_anim 2, 1, 43, 17, -19, 17, -19,
+ax_anim 2, 0, 43, 16, -20, 16, -20,
+ax_anim 2, 0, 43, 17, -19, 17, -19,
+ax_anim 2, 0, 43, 16, -20, 16, -20,
+ax_anim 2, 0, 39, 11, -12, 11, -12,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sGloomAnims_2_5:
+ax_anim 2, 0, 45, 0, 1, 0, 1,
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 2, 0, 46, 0, 2, 0, 2,
+ax_anim 2, 0, 44, 0, 2, 0, 2,
+ax_anim 2, 0, 45, 0, 3, 0, 3,
+ax_anim 2, 0, 44, 0, 3, 0, 3,
+ax_anim 1, 0, 46, 0, -4, 0, -4,
+ax_anim 2, 2, 45, 0, -14, 0, -14,
+ax_anim 2, 0, 48, 0, -22, 0, -22,
+ax_anim 2, 1, 48, 1, -22, 1, -22,
+ax_anim 2, 0, 48, 0, -22, 0, -22,
+ax_anim 2, 0, 48, 1, -22, 1, -22,
+ax_anim 2, 0, 48, 0, -22, 0, -22,
+ax_anim 2, 0, 44, 0, -10, 0, -10,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sGloomAnims_2_6:
+ax_anim 2, 0, 50, 1, 1, 1, 1,
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 2, 0, 51, 2, 2, 2, 2,
+ax_anim 2, 0, 49, 2, 2, 2, 2,
+ax_anim 2, 0, 50, 3, 3, 3, 3,
+ax_anim 2, 0, 49, 3, 3, 3, 3,
+ax_anim 1, 0, 51, -5, -6, -5, -6,
+ax_anim 2, 2, 50, -12, -14, -12, -14,
+ax_anim 2, 0, 53, -16, -20, -16, -20,
+ax_anim 2, 1, 53, -17, -19, -17, -19,
+ax_anim 2, 0, 53, -16, -20, -16, -20,
+ax_anim 2, 0, 53, -17, -19, -17, -19,
+ax_anim 2, 0, 53, -16, -20, -16, -20,
+ax_anim 2, 0, 49, -11, -12, -11, -12,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sGloomAnims_2_7:
+ax_anim 2, 0, 55, 1, 0, 1, 0,
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim 2, 0, 54, 2, 0, 2, 0,
+ax_anim 2, 0, 55, 3, 0, 3, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim 1, 0, 56, -3, 0, -3, 0,
+ax_anim 2, 2, 55, -9, 0, -9, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, -1, -18, -1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, -1, -18, -1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 54, -8, 0, -8, 0,
+ax_anim 2, 0, 54, -3, 0, -3, 0,
+ax_anim_terminator
+sGloomAnims_2_8:
+ax_anim 2, 0, 60, 1, -1, 1, -1,
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 2, 0, 61, 2, -2, 2, -2,
+ax_anim 2, 0, 59, 2, -2, 2, -2,
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim 2, 0, 59, 3, -3, 3, -3,
+ax_anim 1, 0, 61, -5, 6, -5, 6,
+ax_anim 2, 2, 60, -12, 14, -12, 14,
+ax_anim 2, 0, 63, -16, 20, -16, 20,
+ax_anim 2, 1, 63, -17, 19, -17, 19,
+ax_anim 2, 0, 63, -16, 20, -16, 20,
+ax_anim 2, 0, 63, -17, 19, -17, 19,
+ax_anim 2, 0, 63, -16, 20, -16, 20,
+ax_anim 2, 0, 59, -10, 13, -10, 13,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGloomAnims_3_1:
+ax_anim 2, 0, 65, 0, -1, 0, -1,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 2, 0, 66, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim 1, 0, 66, 0, 4, 0, 4,
+ax_anim 2, 2, 65, 0, 14, 0, 14,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 1, 68, 1, 20, 1, 20,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 0, 68, 1, 20, 1, 20,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sGloomAnims_3_2:
+ax_anim 2, 0, 70, -1, -1, -1, -1,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 0, 71, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -2, -2, -2, -2,
+ax_anim 2, 0, 70, -3, -3, -3, -3,
+ax_anim 2, 0, 69, -3, -3, -3, -3,
+ax_anim 1, 0, 71, 5, 6, 5, 6,
+ax_anim 2, 2, 70, 12, 14, 12, 14,
+ax_anim 2, 0, 73, 16, 20, 16, 20,
+ax_anim 2, 1, 73, 17, 19, 17, 19,
+ax_anim 2, 0, 73, 16, 20, 16, 20,
+ax_anim 2, 0, 73, 17, 19, 17, 19,
+ax_anim 2, 0, 73, 16, 20, 16, 20,
+ax_anim 2, 0, 69, 10, 13, 10, 13,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sGloomAnims_3_3:
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 0, 75, -3, 0, -3, 0,
+ax_anim 2, 0, 74, -3, 0, -3, 0,
+ax_anim 1, 0, 76, 3, 0, 3, 0,
+ax_anim 2, 2, 75, 9, 0, 9, 0,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 1, 78, 18, -1, 18, -1,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 78, 18, -1, 18, -1,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 8, 0, 8, 0,
+ax_anim 2, 0, 74, 3, 0, 3, 0,
+ax_anim_terminator
+sGloomAnims_3_4:
+ax_anim 2, 0, 80, -1, 1, -1, 1,
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim 2, 0, 79, -2, 2, -2, 2,
+ax_anim 2, 0, 80, -3, 3, -3, 3,
+ax_anim 2, 0, 79, -3, 3, -3, 3,
+ax_anim 1, 0, 81, 5, -6, 5, -6,
+ax_anim 2, 2, 80, 12, -14, 12, -14,
+ax_anim 2, 0, 83, 16, -20, 16, -20,
+ax_anim 2, 1, 83, 17, -19, 17, -19,
+ax_anim 2, 0, 83, 16, -20, 16, -20,
+ax_anim 2, 0, 83, 17, -19, 17, -19,
+ax_anim 2, 0, 83, 16, -20, 16, -20,
+ax_anim 2, 0, 79, 11, -12, 11, -12,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sGloomAnims_3_5:
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 2, 0, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 3, 0, 3,
+ax_anim 1, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 2, 85, 0, -14, 0, -14,
+ax_anim 2, 0, 88, 0, -22, 0, -22,
+ax_anim 2, 1, 88, 1, -22, 1, -22,
+ax_anim 2, 0, 88, 0, -22, 0, -22,
+ax_anim 2, 0, 88, 1, -22, 1, -22,
+ax_anim 2, 0, 88, 0, -22, 0, -22,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sGloomAnims_3_6:
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 0, 90, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 3, 3, 3, 3,
+ax_anim 1, 0, 91, -5, -6, -5, -6,
+ax_anim 2, 2, 90, -12, -14, -12, -14,
+ax_anim 2, 0, 93, -16, -20, -16, -20,
+ax_anim 2, 1, 93, -17, -19, -17, -19,
+ax_anim 2, 0, 93, -16, -20, -16, -20,
+ax_anim 2, 0, 93, -17, -19, -17, -19,
+ax_anim 2, 0, 93, -16, -20, -16, -20,
+ax_anim 2, 0, 89, -11, -12, -11, -12,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sGloomAnims_3_7:
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 3, 0, 3, 0,
+ax_anim 1, 0, 96, -3, 0, -3, 0,
+ax_anim 2, 2, 95, -9, 0, -9, 0,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 1, 98, -18, -1, -18, -1,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 0, 98, -18, -1, -18, -1,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 0, 94, -8, 0, -8, 0,
+ax_anim 2, 0, 94, -3, 0, -3, 0,
+ax_anim_terminator
+sGloomAnims_3_8:
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 1, 0, 101, -5, 6, -5, 6,
+ax_anim 2, 2, 100, -12, 14, -12, 14,
+ax_anim 2, 0, 103, -16, 20, -16, 20,
+ax_anim 2, 1, 103, -17, 19, -17, 19,
+ax_anim 2, 0, 103, -16, 20, -16, 20,
+ax_anim 2, 0, 103, -17, 19, -17, 19,
+ax_anim 2, 0, 103, -16, 20, -16, 20,
+ax_anim 2, 0, 99, -10, 13, -10, 13,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGloomAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 104, 0, -3, 0, -3,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 0, 6, 0, 6,
+ax_anim 2, 0, 106, -1, 6, -1, 6,
+ax_anim 2, 0, 106, 0, 6, 0, 6,
+ax_anim 2, 0, 106, -1, 6, -1, 6,
+ax_anim 2, 0, 106, 0, 6, 0, 6,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sGloomAnims_4_2:
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, -3, -3, -3, -3,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 1, 109, 4, 4, 6, 6,
+ax_anim 2, 0, 109, 3, 5, 5, 7,
+ax_anim 2, 0, 109, 4, 4, 6, 6,
+ax_anim 2, 0, 109, 3, 5, 5, 7,
+ax_anim 2, 0, 109, 4, 4, 6, 6,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim_terminator
+sGloomAnims_4_3:
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 110, -3, 0, -3, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 4, 0, 6, 0,
+ax_anim 2, 0, 112, 4, 1, 6, 1,
+ax_anim 2, 0, 112, 4, 0, 6, 0,
+ax_anim 2, 0, 112, 4, 1, 6, 1,
+ax_anim 2, 0, 112, 4, 0, 6, 0,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sGloomAnims_4_4:
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 0, 113, -3, 3, -3, 3,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 4, -4, 6, -6,
+ax_anim 2, 0, 115, 3, -5, 5, -7,
+ax_anim 2, 0, 115, 4, -4, 6, -6,
+ax_anim 2, 0, 115, 3, -5, 5, -7,
+ax_anim 2, 0, 115, 4, -4, 6, -6,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim_terminator
+sGloomAnims_4_5:
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 0, 116, 0, 3, 0, 3,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 0, -4, 0, -6,
+ax_anim 2, 0, 118, 1, -4, 1, -6,
+ax_anim 2, 0, 118, 0, -4, 0, -6,
+ax_anim 2, 0, 118, 1, -4, 1, -6,
+ax_anim 2, 0, 118, 0, -4, 0, -6,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sGloomAnims_4_6:
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 3, 3, 3, 3,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 121, -4, -4, -6, -6,
+ax_anim 2, 0, 121, -3, -5, -5, -7,
+ax_anim 2, 0, 121, -4, -4, -6, -6,
+ax_anim 2, 0, 121, -3, -5, -5, -7,
+ax_anim 2, 0, 121, -4, -4, -6, -6,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim_terminator
+sGloomAnims_4_7:
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 0, 122, 3, 0, 3, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 1, 124, -4, 0, -6, 0,
+ax_anim 2, 0, 124, -4, 1, -6, 1,
+ax_anim 2, 0, 124, -4, 0, -6, 0,
+ax_anim 2, 0, 124, -4, 1, -6, 1,
+ax_anim 2, 0, 124, -4, 0, -6, 0,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sGloomAnims_4_8:
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 125, 3, -3, 3, -3,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 127, -4, 4, -6, 6,
+ax_anim 2, 0, 127, -3, 5, -5, 7,
+ax_anim 2, 0, 127, -4, 4, -6, 6,
+ax_anim 2, 0, 127, -3, 5, -5, 7,
+ax_anim 2, 0, 127, -4, 4, -6, 6,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGloomAnims_5_1:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 2, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 1, 0, 130, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 1, 0, 134, 0, -9, 0, 0,
+ax_anim 1, 0, 133, 0, -8, 0, 0,
+ax_anim 1, 0, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 1, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim_terminator
+sGloomAnims_5_2:
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 1, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 132, 0, -6, 0, 0,
+ax_anim 1, 2, 131, 0, -7, 0, 0,
+ax_anim 1, 0, 130, 0, -8, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 1, 0, 133, 0, -9, 0, 0,
+ax_anim 1, 0, 132, 0, -8, 0, 0,
+ax_anim 1, 0, 131, 0, -7, 0, 0,
+ax_anim 1, 0, 130, 0, -6, 0, 0,
+ax_anim 1, 1, 129, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sGloomAnims_5_3:
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 1, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 2, 130, 0, -7, 0, 0,
+ax_anim 1, 0, 129, 0, -8, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 1, 0, 132, 0, -9, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 1, 0, 130, 0, -7, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 1, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim_terminator
+sGloomAnims_5_4:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -6, 0, 0,
+ax_anim 1, 2, 129, 0, -7, 0, 0,
+ax_anim 1, 0, 128, 0, -8, 0, 0,
+ax_anim 1, 0, 135, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 1, 0, 131, 0, -9, 0, 0,
+ax_anim 1, 0, 130, 0, -8, 0, 0,
+ax_anim 1, 0, 129, 0, -7, 0, 0,
+ax_anim 1, 0, 128, 0, -6, 0, 0,
+ax_anim 1, 1, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim_terminator
+sGloomAnims_5_5:
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 1, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 2, 128, 0, -7, 0, 0,
+ax_anim 1, 0, 135, 0, -8, 0, 0,
+ax_anim 1, 0, 134, 0, -9, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 1, 0, 130, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -8, 0, 0,
+ax_anim 1, 0, 128, 0, -7, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 1, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sGloomAnims_5_6:
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 128, 0, -6, 0, 0,
+ax_anim 1, 2, 135, 0, -7, 0, 0,
+ax_anim 1, 0, 134, 0, -8, 0, 0,
+ax_anim 1, 0, 133, 0, -9, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 128, 0, -8, 0, 0,
+ax_anim 1, 0, 135, 0, -7, 0, 0,
+ax_anim 1, 0, 134, 0, -6, 0, 0,
+ax_anim 1, 1, 133, 0, -5, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim_terminator
+sGloomAnims_5_7:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 1, 0, 129, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 2, 134, 0, -7, 0, 0,
+ax_anim 1, 0, 133, 0, -8, 0, 0,
+ax_anim 1, 0, 132, 0, -9, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 0, 135, 0, -8, 0, 0,
+ax_anim 1, 0, 134, 0, -7, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 1, 132, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim_terminator
+sGloomAnims_5_8:
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 1, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -6, 0, 0,
+ax_anim 1, 2, 133, 0, -7, 0, 0,
+ax_anim 1, 0, 132, 0, -8, 0, 0,
+ax_anim 1, 0, 131, 0, -9, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 1, 0, 135, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -8, 0, 0,
+ax_anim 1, 0, 133, 0, -7, 0, 0,
+ax_anim 1, 0, 132, 0, -6, 0, 0,
+ax_anim 1, 1, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sGloomAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sGloomAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sGloomAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sGloomAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sGloomAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sGloomAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sGloomAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGloomAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_8_2:
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_8_3:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_8_4:
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_8_5:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_8_6:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_8_7:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_8_8:
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 3, 19, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 21, 20, 21, 20,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 22, -2, 22, -2,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 21, -23, 21, -23,
+ax_anim 2, 3, 172, 22, -15, 22, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, 1, 7, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -23, 0, -23,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -21, -23, -21, -23,
+ax_anim 2, 3, 176, -22, -15, -22, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, 1, -7, 1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -22, -2, -22, -2,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 3, -19, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -21, 20, -21, 20,
+ax_anim 2, 3, 174, -11, 21, -11, 21,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -24, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -24, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGloomAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sGloomGfx1:
+.incbin "baserom.gba", 0x6DEC24, 0x200
+sGloomSprites1:
+ax_sprite sGloomGfx1, 0x200
+ax_sprite_terminator
+sGloomGfx2:
+.incbin "baserom.gba", 0x6DEE34, 0x200
+sGloomSprites2:
+ax_sprite sGloomGfx2, 0x200
+ax_sprite_terminator
+sGloomGfx3:
+.incbin "baserom.gba", 0x6DF044, 0x200
+sGloomSprites3:
+ax_sprite sGloomGfx3, 0x200
+ax_sprite_terminator
+sGloomGfx4:
+.incbin "baserom.gba", 0x6DF254, 0x200
+sGloomSprites4:
+ax_sprite sGloomGfx4, 0x200
+ax_sprite_terminator
+sGloomGfx5:
+.incbin "baserom.gba", 0x6DF464, 0x200
+sGloomSprites5:
+ax_sprite sGloomGfx5, 0x200
+ax_sprite_terminator
+sGloomGfx6:
+.incbin "baserom.gba", 0x6DF674, 0x200
+sGloomSprites6:
+ax_sprite sGloomGfx6, 0x200
+ax_sprite_terminator
+sGloomGfx7:
+.incbin "baserom.gba", 0x6DF884, 0x200
+sGloomSprites7:
+ax_sprite sGloomGfx7, 0x200
+ax_sprite_terminator
+sGloomGfx8:
+.incbin "baserom.gba", 0x6DFA94, 0x200
+sGloomSprites8:
+ax_sprite sGloomGfx8, 0x200
+ax_sprite_terminator
+sGloomGfx9:
+.incbin "baserom.gba", 0x6DFCA4, 0x200
+sGloomSprites9:
+ax_sprite sGloomGfx9, 0x200
+ax_sprite_terminator
+sGloomGfx10:
+.incbin "baserom.gba", 0x6DFEB4, 0x200
+sGloomSprites10:
+ax_sprite sGloomGfx10, 0x200
+ax_sprite_terminator
+sGloomGfx11:
+.incbin "baserom.gba", 0x6E00C4, 0x200
+sGloomSprites11:
+ax_sprite sGloomGfx11, 0x200
+ax_sprite_terminator
+sGloomGfx12:
+.incbin "baserom.gba", 0x6E02D4, 0x200
+sGloomSprites12:
+ax_sprite sGloomGfx12, 0x200
+ax_sprite_terminator
+sGloomGfx13:
+.incbin "baserom.gba", 0x6E04E4, 0x200
+sGloomSprites13:
+ax_sprite sGloomGfx13, 0x200
+ax_sprite_terminator
+sGloomGfx14:
+.incbin "baserom.gba", 0x6E06F4, 0x200
+sGloomSprites14:
+ax_sprite sGloomGfx14, 0x200
+ax_sprite_terminator
+sGloomGfx15:
+.incbin "baserom.gba", 0x6E0904, 0x200
+sGloomSprites15:
+ax_sprite sGloomGfx15, 0x200
+ax_sprite_terminator
+sGloomGfx16:
+.incbin "baserom.gba", 0x6E0B14, 0x200
+sGloomSprites16:
+ax_sprite sGloomGfx16, 0x200
+ax_sprite_terminator
+sGloomGfx17:
+.incbin "baserom.gba", 0x6E0D24, 0x200
+sGloomSprites17:
+ax_sprite sGloomGfx17, 0x200
+ax_sprite_terminator
+sGloomGfx18:
+.incbin "baserom.gba", 0x6E0F34, 0x200
+sGloomSprites18:
+ax_sprite sGloomGfx18, 0x200
+ax_sprite_terminator
+sGloomGfx19:
+.incbin "baserom.gba", 0x6E1144, 0x200
+sGloomSprites19:
+ax_sprite sGloomGfx19, 0x200
+ax_sprite_terminator
+sGloomGfx20:
+.incbin "baserom.gba", 0x6E1354, 0x200
+sGloomSprites20:
+ax_sprite sGloomGfx20, 0x200
+ax_sprite_terminator
+sGloomGfx21:
+.incbin "baserom.gba", 0x6E1564, 0x200
+sGloomSprites21:
+ax_sprite sGloomGfx21, 0x200
+ax_sprite_terminator
+sGloomGfx22:
+.incbin "baserom.gba", 0x6E1774, 0x180
+sGloomSprites22:
+ax_sprite sGloomGfx22, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGloomGfx23:
+.incbin "baserom.gba", 0x6E190C, 0x40
+sGloomGfx23_1:
+.incbin "baserom.gba", 0x6E194C, 0x100
+sGloomSprites23:
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx23_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGloomGfx24:
+.incbin "baserom.gba", 0x6E1A7C, 0x60
+sGloomGfx24_1:
+.incbin "baserom.gba", 0x6E1ADC, 0x60
+sGloomGfx24_2:
+.incbin "baserom.gba", 0x6E1B3C, 0x60
+sGloomGfx24_3:
+.incbin "baserom.gba", 0x6E1B9C, 0x20
+sGloomSprites24:
+ax_sprite sGloomGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx24_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGloomGfx25:
+.incbin "baserom.gba", 0x6E1C04, 0x40
+sGloomGfx25_1:
+.incbin "baserom.gba", 0x6E1C44, 0x60
+sGloomGfx25_2:
+.incbin "baserom.gba", 0x6E1CA4, 0x80
+sGloomGfx25_3:
+.incbin "baserom.gba", 0x6E1D24, 0x40
+sGloomSprites25:
+ax_sprite sGloomGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGloomGfx26:
+.incbin "baserom.gba", 0x6E1DAC, 0x60
+sGloomGfx26_1:
+.incbin "baserom.gba", 0x6E1E0C, 0x60
+sGloomGfx26_2:
+.incbin "baserom.gba", 0x6E1E6C, 0x60
+sGloomGfx26_3:
+.incbin "baserom.gba", 0x6E1ECC, 0x20
+sGloomSprites26:
+ax_sprite sGloomGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGloomGfx27:
+.incbin "baserom.gba", 0x6E1F34, 0x40
+sGloomGfx27_1:
+.incbin "baserom.gba", 0x6E1F74, 0x60
+sGloomGfx27_2:
+.incbin "baserom.gba", 0x6E1FD4, 0x60
+sGloomGfx27_3:
+.incbin "baserom.gba", 0x6E2034, 0x60
+sGloomSprites27:
+ax_sprite sGloomGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGloomGfx28:
+.incbin "baserom.gba", 0x6E20DC, 0xE0
+sGloomGfx28_1:
+.incbin "baserom.gba", 0x6E21BC, 0x40
+sGloomGfx28_2:
+.incbin "baserom.gba", 0x6E21FC, 0x20
+sGloomSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx28, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx28_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGloomGfx29:
+.incbin "baserom.gba", 0x6E225C, 0x60
+sGloomGfx29_1:
+.incbin "baserom.gba", 0x6E22BC, 0x60
+sGloomGfx29_2:
+.incbin "baserom.gba", 0x6E231C, 0x60
+sGloomGfx29_3:
+.incbin "baserom.gba", 0x6E237C, 0x20
+sGloomSprites29:
+ax_sprite sGloomGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGloomGfx30:
+.incbin "baserom.gba", 0x6E23E4, 0x40
+sGloomGfx30_1:
+.incbin "baserom.gba", 0x6E2424, 0x100
+sGloomSprites30:
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGloomGfx31:
+.incbin "baserom.gba", 0x6E2554, 0x40
+sGloomGfx31_1:
+.incbin "baserom.gba", 0x6E2594, 0x100
+sGloomSprites31:
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx31_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGloomGfx32:
+.incbin "baserom.gba", 0x6E26C4, 0x60
+sGloomGfx32_1:
+.incbin "baserom.gba", 0x6E2724, 0x60
+sGloomGfx32_2:
+.incbin "baserom.gba", 0x6E2784, 0x60
+sGloomGfx32_3:
+.incbin "baserom.gba", 0x6E27E4, 0x20
+sGloomSprites32:
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx32_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGloomGfx33:
+.incbin "baserom.gba", 0x6E2854, 0x60
+sGloomGfx33_1:
+.incbin "baserom.gba", 0x6E28B4, 0x60
+sGloomGfx33_2:
+.incbin "baserom.gba", 0x6E2914, 0x60
+sGloomGfx33_3:
+.incbin "baserom.gba", 0x6E2974, 0x20
+sGloomSprites33:
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGloomGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGloomGfx33_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGloomGfx34:
+.incbin "baserom.gba", 0x6E29E4, 0x200
+sGloomSprites34:
+ax_sprite sGloomGfx34, 0x200
+ax_sprite_terminator
+sGloomGfx35:
+.incbin "baserom.gba", 0x6E2BF4, 0x200
+sGloomSprites35:
+ax_sprite sGloomGfx35, 0x200
+ax_sprite_terminator
+sGloomGfx36:
+.incbin "baserom.gba", 0x6E2E04, 0x200
+sGloomSprites36:
+ax_sprite sGloomGfx36, 0x200
+ax_sprite_terminator
+sGloomGfx37:
+.incbin "baserom.gba", 0x6E3014, 0x200
+sGloomSprites37:
+ax_sprite sGloomGfx37, 0x200
+ax_sprite_terminator
+sGloomGfx38:
+.incbin "baserom.gba", 0x6E3224, 0x200
+sGloomSprites38:
+ax_sprite sGloomGfx38, 0x200
+ax_sprite_terminator
+sGloomGfx39:
+.incbin "baserom.gba", 0x6E3434, 0x200
+sGloomSprites39:
+ax_sprite sGloomGfx39, 0x200
+ax_sprite_terminator
+sGloomGfx40:
+.incbin "baserom.gba", 0x6E3644, 0x200
+sGloomSprites40:
+ax_sprite sGloomGfx40, 0x200
+ax_sprite_terminator
+sGloomGfx41:
+.incbin "baserom.gba", 0x6E3854, 0x200
+sGloomSprites41:
+ax_sprite sGloomGfx41, 0x200
+ax_sprite_terminator
+sGloomGfx42:
+.incbin "baserom.gba", 0x6E3A64, 0x200
+sGloomSprites42:
+ax_sprite sGloomGfx42, 0x200
+ax_sprite_terminator
+sGloomGfx43:
+.incbin "baserom.gba", 0x6E3C74, 0x200
+sGloomSprites43:
+ax_sprite sGloomGfx43, 0x200
+ax_sprite_terminator
+sAxPosesGloom:
+.4byte sGloomPose1
+.4byte sGloomPose2
+.4byte sGloomPose3
+.4byte sGloomPose4
+.4byte sGloomPose5
+.4byte sGloomPose6
+.4byte sGloomPose7
+.4byte sGloomPose8
+.4byte sGloomPose9
+.4byte sGloomPose10
+.4byte sGloomPose11
+.4byte sGloomPose12
+.4byte sGloomPose13
+.4byte sGloomPose14
+.4byte sGloomPose15
+.4byte sGloomPose16
+.4byte sGloomPose17
+.4byte sGloomPose18
+.4byte sGloomPose19
+.4byte sGloomPose20
+.4byte sGloomPose21
+.4byte sGloomPose22
+.4byte sGloomPose23
+.4byte sGloomPose24
+.4byte sGloomPose25
+.4byte sGloomPose26
+.4byte sGloomPose27
+.4byte sGloomPose28
+.4byte sGloomPose29
+.4byte sGloomPose30
+.4byte sGloomPose31
+.4byte sGloomPose32
+.4byte sGloomPose33
+.4byte sGloomPose34
+.4byte sGloomPose35
+.4byte sGloomPose36
+.4byte sGloomPose37
+.4byte sGloomPose38
+.4byte sGloomPose39
+.4byte sGloomPose40
+.4byte sGloomPose41
+.4byte sGloomPose42
+.4byte sGloomPose43
+.4byte sGloomPose44
+.4byte sGloomPose45
+.4byte sGloomPose46
+.4byte sGloomPose47
+.4byte sGloomPose48
+.4byte sGloomPose49
+.4byte sGloomPose50
+.4byte sGloomPose51
+.4byte sGloomPose52
+.4byte sGloomPose53
+.4byte sGloomPose54
+.4byte sGloomPose55
+.4byte sGloomPose56
+.4byte sGloomPose57
+.4byte sGloomPose58
+.4byte sGloomPose59
+.4byte sGloomPose60
+.4byte sGloomPose61
+.4byte sGloomPose62
+.4byte sGloomPose63
+.4byte sGloomPose64
+.4byte sGloomPose65
+.4byte sGloomPose66
+.4byte sGloomPose67
+.4byte sGloomPose68
+.4byte sGloomPose69
+.4byte sGloomPose70
+.4byte sGloomPose71
+.4byte sGloomPose72
+.4byte sGloomPose73
+.4byte sGloomPose74
+.4byte sGloomPose75
+.4byte sGloomPose76
+.4byte sGloomPose77
+.4byte sGloomPose78
+.4byte sGloomPose79
+.4byte sGloomPose80
+.4byte sGloomPose81
+.4byte sGloomPose82
+.4byte sGloomPose83
+.4byte sGloomPose84
+.4byte sGloomPose85
+.4byte sGloomPose86
+.4byte sGloomPose87
+.4byte sGloomPose88
+.4byte sGloomPose89
+.4byte sGloomPose90
+.4byte sGloomPose91
+.4byte sGloomPose92
+.4byte sGloomPose93
+.4byte sGloomPose94
+.4byte sGloomPose95
+.4byte sGloomPose96
+.4byte sGloomPose97
+.4byte sGloomPose98
+.4byte sGloomPose99
+.4byte sGloomPose100
+.4byte sGloomPose101
+.4byte sGloomPose102
+.4byte sGloomPose103
+.4byte sGloomPose104
+.4byte sGloomPose105
+.4byte sGloomPose106
+.4byte sGloomPose107
+.4byte sGloomPose108
+.4byte sGloomPose109
+.4byte sGloomPose110
+.4byte sGloomPose111
+.4byte sGloomPose112
+.4byte sGloomPose113
+.4byte sGloomPose114
+.4byte sGloomPose115
+.4byte sGloomPose116
+.4byte sGloomPose117
+.4byte sGloomPose118
+.4byte sGloomPose119
+.4byte sGloomPose120
+.4byte sGloomPose121
+.4byte sGloomPose122
+.4byte sGloomPose123
+.4byte sGloomPose124
+.4byte sGloomPose125
+.4byte sGloomPose126
+.4byte sGloomPose127
+.4byte sGloomPose128
+.4byte sGloomPose129
+.4byte sGloomPose130
+.4byte sGloomPose131
+.4byte sGloomPose132
+.4byte sGloomPose133
+.4byte sGloomPose134
+.4byte sGloomPose135
+.4byte sGloomPose136
+.4byte sGloomPose137
+.4byte sGloomPose138
+.4byte sGloomPose139
+.4byte sGloomPose140
+.4byte sGloomPose141
+.4byte sGloomPose142
+.4byte sGloomPose143
+.4byte sGloomPose144
+.4byte sGloomPose145
+.4byte sGloomPose146
+.4byte sGloomPose147
+.4byte sGloomPose148
+.4byte sGloomPose149
+.4byte sGloomPose150
+.4byte sGloomPose151
+.4byte sGloomPose152
+.4byte sGloomPose153
+.4byte sGloomPose154
+.4byte sGloomPose155
+.4byte sGloomPose156
+.4byte sGloomPose157
+.4byte sGloomPose158
+.4byte sGloomPose159
+.4byte sGloomPose160
+.4byte sGloomPose161
+.4byte sGloomPose162
+.4byte sGloomPose163
+.4byte sGloomPose164
+.4byte sGloomPose165
+.4byte sGloomPose166
+.4byte sGloomPose167
+.4byte sGloomPose168
+.4byte sGloomPose169
+.4byte sGloomPose170
+.4byte sGloomPose171
+.4byte sGloomPose172
+.4byte sGloomPose173
+.4byte sGloomPose174
+.4byte sGloomPose175
+.4byte sGloomPose176
+.4byte sGloomPose177
+.4byte sGloomPose178
+.4byte sGloomPose179
+.4byte sGloomPose180
+.4byte sGloomPose181
+.4byte sGloomPose182
+.4byte sGloomPose183
+.4byte sGloomPose184
+.4byte sGloomPose185
+.4byte sGloomPose186
+.4byte sGloomPose187
+.4byte sGloomPose188
+.4byte sGloomPose189
+.4byte sGloomPose190
+.4byte sGloomPose191
+.4byte sGloomPose192
+.4byte sGloomPose193
+.4byte sGloomPose194
+.4byte sGloomPose195
+.4byte sGloomPose196
+.4byte sGloomPose197
+.4byte sGloomPose198
+.4byte sGloomPose199
+.4byte sGloomPose200
+.4byte sGloomPose201
+.4byte sGloomPose202
+.4byte sGloomPose203
+.4byte sGloomPose204
+.4byte sGloomPose205
+.4byte sGloomPose206
+.4byte sGloomPose207
+.4byte sGloomPose208
+.4byte sGloomPose209
+.4byte sGloomPose210
+.4byte sGloomPose211
+.4byte sGloomPose212
+.4byte sGloomPose213
+.4byte sGloomPose214
+.4byte sGloomPose215
+.4byte sGloomPose216
+.4byte sGloomPose217
+.4byte sGloomPose218
+.4byte sGloomPose219
+.4byte sGloomPose220
+.4byte sGloomPose221
+.4byte sGloomPose222
+.4byte sGloomPose223
+.4byte sGloomPose224
+.4byte sGloomPose225
+.4byte sGloomPose226
+sAxPositionsGloom:
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -3, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -3, 	   6,   -4, 	   0,   -9
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+.2byte    3,   -5, 	  -3,   -2, 	   2,   -4, 	   0,   -9
+.2byte    1,   -5, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte    5,   -5, 	   1,   -2, 	  -2,   -5, 	   0,   -8
+.2byte    4,   -5, 	  -2,   -3, 	   2,   -5, 	   0,   -8
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte    1,   -6, 	  -7,   -4, 	   6,   -4, 	  -1,   -9
+.2byte    2,   -5, 	  -3,   -6, 	   2,   -3, 	  -1,   -9
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte   -1,   -6, 	   6,   -4, 	  -7,   -5, 	  -1,   -8
+.2byte    0,   -6, 	   6,   -5, 	  -7,   -4, 	   0,   -8
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte   -2,   -6, 	   6,   -4, 	  -7,   -4, 	   0,   -9
+.2byte   -3,   -5, 	   2,   -6, 	  -3,   -3, 	   0,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -6,   -5, 	   0,   -6, 	  -2,   -2, 	   0,   -9
+.2byte   -4,   -5, 	  -2,   -6, 	   2,   -3, 	   0,   -9
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte   -3,   -5, 	  -4,   -5, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -3, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -3, 	   6,   -4, 	   0,   -9
+.2byte    0,  -15, 	  -9,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -8, 	  -8,   -4, 	   7,   -4, 	   0,   -7
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+.2byte    3,   -5, 	  -3,   -2, 	   2,   -4, 	   0,   -9
+.2byte    1,   -5, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte   -3,  -18, 	  -7,   -5, 	   4,   -7, 	  -1,  -10
+.2byte    6,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte    5,   -5, 	   1,   -2, 	  -2,   -5, 	   0,   -8
+.2byte    4,   -5, 	  -2,   -3, 	   2,   -5, 	   0,   -8
+.2byte   -4,  -18, 	  -1,   -6, 	   1,   -7, 	   0,   -9
+.2byte   10,   -9, 	   0,   -4, 	  -1,   -1, 	   1,   -7
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte    1,   -6, 	  -7,   -4, 	   6,   -4, 	  -1,   -9
+.2byte    2,   -5, 	  -3,   -6, 	   2,   -3, 	  -1,   -9
+.2byte   -2,  -16, 	  -6,   -7, 	   5,   -5, 	  -3,  -10
+.2byte    7,  -13, 	  -6,   -7, 	   6,   -3, 	   3,   -9
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -7,   -6, 	  -1,   -9
+.2byte    0,   -7, 	   6,   -6, 	  -7,   -5, 	   0,   -9
+.2byte    0,  -16, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -15, 	   7,   -4, 	  -8,   -4, 	   0,  -10
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte   -2,   -6, 	   6,   -4, 	  -7,   -4, 	   0,   -9
+.2byte   -3,   -5, 	   2,   -6, 	  -3,   -3, 	   0,   -9
+.2byte    1,  -16, 	   5,   -7, 	  -6,   -5, 	   2,  -10
+.2byte   -8,  -13, 	   5,   -7, 	  -7,   -3, 	  -4,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -6,   -5, 	   0,   -6, 	  -2,   -2, 	   0,   -9
+.2byte   -4,   -5, 	  -2,   -6, 	   2,   -3, 	   0,   -9
+.2byte    3,  -18, 	   0,   -6, 	   2,   -4, 	   0,   -9
+.2byte  -10,   -9, 	   0,   -4, 	   1,   -1, 	  -1,   -7
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte   -3,   -5, 	  -4,   -5, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte    2,  -18, 	  -5,   -7, 	   6,   -5, 	   1,  -10
+.2byte   -7,   -7, 	  -5,   -5, 	   4,   -3, 	  -2,   -7
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -3, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -3, 	   6,   -4, 	   0,   -9
+.2byte    0,  -15, 	  -9,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -8, 	  -8,   -4, 	   7,   -4, 	   0,   -7
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+.2byte    3,   -5, 	  -3,   -2, 	   2,   -4, 	   0,   -9
+.2byte    1,   -5, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte   -3,  -18, 	  -7,   -5, 	   4,   -7, 	  -1,  -10
+.2byte    6,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte    5,   -5, 	   1,   -2, 	  -2,   -5, 	   0,   -8
+.2byte    4,   -5, 	  -2,   -3, 	   2,   -5, 	   0,   -8
+.2byte   -4,  -18, 	  -1,   -6, 	   1,   -7, 	   0,   -9
+.2byte   10,   -9, 	   0,   -4, 	  -1,   -1, 	   1,   -7
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte    1,   -6, 	  -7,   -4, 	   6,   -4, 	  -1,   -9
+.2byte    2,   -5, 	  -3,   -6, 	   2,   -3, 	  -1,   -9
+.2byte   -2,  -16, 	  -6,   -7, 	   5,   -5, 	  -3,  -10
+.2byte    7,  -13, 	  -6,   -7, 	   6,   -3, 	   3,   -9
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -7,   -6, 	  -1,   -9
+.2byte    0,   -7, 	   6,   -6, 	  -7,   -5, 	   0,   -9
+.2byte    0,  -16, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -15, 	   7,   -4, 	  -8,   -4, 	   0,  -10
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte   -2,   -6, 	   6,   -4, 	  -7,   -4, 	   0,   -9
+.2byte   -3,   -5, 	   2,   -6, 	  -3,   -3, 	   0,   -9
+.2byte    1,  -16, 	   5,   -7, 	  -6,   -5, 	   2,  -10
+.2byte   -8,  -13, 	   5,   -7, 	  -7,   -3, 	  -4,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -6,   -5, 	   0,   -6, 	  -2,   -2, 	   0,   -9
+.2byte   -4,   -5, 	  -2,   -6, 	   2,   -3, 	   0,   -9
+.2byte    3,  -18, 	   0,   -6, 	   2,   -4, 	   0,   -9
+.2byte  -10,   -9, 	   0,   -4, 	   1,   -1, 	  -1,   -7
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte   -3,   -5, 	  -4,   -5, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte    2,  -18, 	  -5,   -7, 	   6,   -5, 	   1,  -10
+.2byte   -7,   -7, 	  -5,   -5, 	   4,   -3, 	  -2,   -7
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte    0,  -15, 	  -9,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -8, 	  -8,   -4, 	   7,   -4, 	   0,   -7
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+.2byte   -3,  -18, 	  -7,   -5, 	   4,   -7, 	  -1,  -10
+.2byte   10,   -7, 	   8,   -5, 	  -1,   -3, 	   5,   -7
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte   -4,  -18, 	  -1,   -6, 	   1,   -7, 	   0,   -9
+.2byte   16,   -9, 	   6,   -4, 	   5,   -1, 	   7,   -7
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte   -2,  -16, 	  -6,   -7, 	   5,   -5, 	  -3,  -10
+.2byte    7,  -13, 	  -6,   -7, 	   6,   -3, 	   3,   -9
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte    0,  -16, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -15, 	   7,   -4, 	  -8,   -4, 	   0,  -10
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte    1,  -16, 	   5,   -7, 	  -6,   -5, 	   2,  -10
+.2byte   -8,  -13, 	   5,   -7, 	  -7,   -3, 	  -4,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    3,  -18, 	   0,   -6, 	   2,   -4, 	   0,   -9
+.2byte  -17,   -9, 	  -7,   -4, 	  -6,   -1, 	  -8,   -7
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte    2,  -18, 	  -5,   -7, 	   6,   -5, 	   1,  -10
+.2byte  -11,   -7, 	  -9,   -5, 	   0,   -3, 	  -6,   -7
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+.2byte    0,   -4, 	  -8,   -2, 	   7,   -2, 	   0,   -8
+.2byte    0,   -3, 	  -8,   -1, 	   7,   -1, 	   0,   -7
+.2byte    0,   -9, 	  -8,  -12, 	   7,  -12, 	   0,  -12
+.2byte    0,   -9, 	  -7,  -12, 	   5,  -13, 	   0,  -12
+.2byte    1,   -9, 	  -4,  -11, 	  -5,  -12, 	  -3,  -11
+.2byte    1,   -8, 	   3,  -10, 	  -9,  -11, 	  -3,  -10
+.2byte    0,   -7, 	   7,  -10, 	  -8,  -10, 	   0,   -9
+.2byte   -1,   -8, 	   9,  -12, 	  -4,  -10, 	   3,  -11
+.2byte   -2,   -8, 	   2,  -12, 	   3,  -10, 	   3,  -12
+.2byte   -1,   -9, 	  -6,  -13, 	   6,  -12, 	   0,  -12
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -3, 	   0,   -9
+.2byte    1,   -5, 	  -7,   -3, 	   6,   -4, 	   0,   -9
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+.2byte    3,   -5, 	  -3,   -2, 	   2,   -4, 	   0,   -9
+.2byte    1,   -5, 	  -6,   -5, 	   6,   -5, 	   0,   -9
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte    5,   -5, 	   1,   -2, 	  -2,   -5, 	   0,   -8
+.2byte    4,   -5, 	  -2,   -3, 	   2,   -5, 	   0,   -8
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte    1,   -6, 	  -7,   -4, 	   6,   -4, 	  -1,   -9
+.2byte    2,   -5, 	  -3,   -6, 	   2,   -3, 	  -1,   -9
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte   -1,   -6, 	   6,   -4, 	  -7,   -5, 	  -1,   -8
+.2byte    0,   -6, 	   6,   -5, 	  -7,   -4, 	   0,   -8
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte   -2,   -6, 	   6,   -4, 	  -7,   -4, 	   0,   -9
+.2byte   -3,   -5, 	   2,   -6, 	  -3,   -3, 	   0,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -6,   -5, 	   0,   -6, 	  -2,   -2, 	   0,   -9
+.2byte   -4,   -5, 	  -2,   -6, 	   2,   -3, 	   0,   -9
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte   -3,   -5, 	  -4,   -5, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte    0,   -8, 	  -8,   -4, 	   7,   -4, 	   0,   -7
+.2byte   -7,   -7, 	  -5,   -5, 	   4,   -3, 	  -2,   -7
+.2byte  -11,   -9, 	  -1,   -4, 	   0,   -1, 	  -2,   -7
+.2byte   -6,  -13, 	   7,   -7, 	  -5,   -3, 	  -2,   -9
+.2byte    0,  -14, 	   7,   -3, 	  -8,   -3, 	   0,   -9
+.2byte    5,  -13, 	  -8,   -7, 	   4,   -3, 	   1,   -9
+.2byte   10,   -9, 	   0,   -4, 	  -1,   -1, 	   1,   -7
+.2byte    6,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    0,  -15, 	  -9,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -3,  -18, 	  -7,   -5, 	   4,   -7, 	  -1,  -10
+.2byte   -4,  -18, 	  -1,   -6, 	   1,   -7, 	   0,   -9
+.2byte   -2,  -16, 	  -6,   -7, 	   5,   -5, 	  -3,  -10
+.2byte    0,  -16, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    1,  -16, 	   5,   -7, 	  -6,   -5, 	   2,  -10
+.2byte    3,  -18, 	   0,   -6, 	   2,   -4, 	   0,   -9
+.2byte    2,  -18, 	  -5,   -7, 	   6,   -5, 	   1,  -10
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte    0,  -15, 	  -9,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -8, 	  -8,   -4, 	   7,   -4, 	   0,   -7
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+.2byte   -3,  -18, 	  -7,   -5, 	   4,   -7, 	  -1,  -10
+.2byte    6,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte   -4,  -18, 	  -1,   -6, 	   1,   -7, 	   0,   -9
+.2byte   10,   -9, 	   0,   -4, 	  -1,   -1, 	   1,   -7
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte   -2,  -16, 	  -6,   -7, 	   5,   -5, 	  -3,  -10
+.2byte    5,  -13, 	  -8,   -7, 	   4,   -3, 	   1,   -9
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte    0,  -16, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -15, 	   7,   -4, 	  -8,   -4, 	   0,  -10
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte    1,  -16, 	   5,   -7, 	  -6,   -5, 	   2,  -10
+.2byte   -6,  -13, 	   7,   -7, 	  -5,   -3, 	  -2,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte    3,  -18, 	   0,   -6, 	   2,   -4, 	   0,   -9
+.2byte  -11,   -9, 	  -1,   -4, 	   0,   -1, 	  -2,   -7
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte    2,  -18, 	  -5,   -7, 	   6,   -5, 	   1,  -10
+.2byte   -7,   -7, 	  -5,   -5, 	   4,   -3, 	  -2,   -7
+.2byte    0,   -8, 	  -8,   -4, 	   7,   -4, 	   0,   -7
+.2byte   -7,   -7, 	  -5,   -5, 	   4,   -3, 	  -2,   -7
+.2byte  -11,   -9, 	  -1,   -4, 	   0,   -1, 	  -2,   -7
+.2byte   -6,  -13, 	   7,   -7, 	  -5,   -3, 	  -2,   -9
+.2byte    0,  -14, 	   7,   -3, 	  -8,   -3, 	   0,   -9
+.2byte    5,  -13, 	  -8,   -7, 	   4,   -3, 	   1,   -9
+.2byte   10,   -9, 	   0,   -4, 	  -1,   -1, 	   1,   -7
+.2byte    6,   -7, 	   4,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    0,   -6, 	  -8,   -4, 	   7,   -4, 	   0,  -10
+.2byte   -3,   -6, 	  -5,   -5, 	   5,   -4, 	  -1,   -9
+.2byte   -5,   -6, 	  -1,   -6, 	   1,   -3, 	   0,  -10
+.2byte   -3,   -7, 	   4,   -6, 	  -6,   -4, 	   0,  -10
+.2byte    0,   -7, 	   7,   -5, 	  -8,   -5, 	   0,   -9
+.2byte    2,   -7, 	  -5,   -6, 	   5,   -4, 	  -1,  -10
+.2byte    5,   -6, 	  -2,   -3, 	   1,   -6, 	   0,   -9
+.2byte    2,   -6, 	  -6,   -4, 	   4,   -5, 	   0,  -10
+sGloomAnimTable1:
+.4byte sGloomAnims_1_1
+.4byte sGloomAnims_1_2
+.4byte sGloomAnims_1_3
+.4byte sGloomAnims_1_4
+.4byte sGloomAnims_1_5
+.4byte sGloomAnims_1_6
+.4byte sGloomAnims_1_7
+.4byte sGloomAnims_1_8
+sGloomAnimTable2:
+.4byte sGloomAnims_2_1
+.4byte sGloomAnims_2_2
+.4byte sGloomAnims_2_3
+.4byte sGloomAnims_2_4
+.4byte sGloomAnims_2_5
+.4byte sGloomAnims_2_6
+.4byte sGloomAnims_2_7
+.4byte sGloomAnims_2_8
+sGloomAnimTable3:
+.4byte sGloomAnims_3_1
+.4byte sGloomAnims_3_2
+.4byte sGloomAnims_3_3
+.4byte sGloomAnims_3_4
+.4byte sGloomAnims_3_5
+.4byte sGloomAnims_3_6
+.4byte sGloomAnims_3_7
+.4byte sGloomAnims_3_8
+sGloomAnimTable4:
+.4byte sGloomAnims_4_1
+.4byte sGloomAnims_4_2
+.4byte sGloomAnims_4_3
+.4byte sGloomAnims_4_4
+.4byte sGloomAnims_4_5
+.4byte sGloomAnims_4_6
+.4byte sGloomAnims_4_7
+.4byte sGloomAnims_4_8
+sGloomAnimTable5:
+.4byte sGloomAnims_5_1
+.4byte sGloomAnims_5_2
+.4byte sGloomAnims_5_3
+.4byte sGloomAnims_5_4
+.4byte sGloomAnims_5_5
+.4byte sGloomAnims_5_6
+.4byte sGloomAnims_5_7
+.4byte sGloomAnims_5_8
+sGloomAnimTable6:
+.4byte sGloomAnims_6_1
+.4byte sGloomAnims_6_1
+.4byte sGloomAnims_6_1
+.4byte sGloomAnims_6_1
+.4byte sGloomAnims_6_1
+.4byte sGloomAnims_6_1
+.4byte sGloomAnims_6_1
+.4byte sGloomAnims_6_1
+sGloomAnimTable7:
+.4byte sGloomAnims_7_1
+.4byte sGloomAnims_7_2
+.4byte sGloomAnims_7_3
+.4byte sGloomAnims_7_4
+.4byte sGloomAnims_7_5
+.4byte sGloomAnims_7_6
+.4byte sGloomAnims_7_7
+.4byte sGloomAnims_7_8
+sGloomAnimTable8:
+.4byte sGloomAnims_8_1
+.4byte sGloomAnims_8_2
+.4byte sGloomAnims_8_3
+.4byte sGloomAnims_8_4
+.4byte sGloomAnims_8_5
+.4byte sGloomAnims_8_6
+.4byte sGloomAnims_8_7
+.4byte sGloomAnims_8_8
+sGloomAnimTable9:
+.4byte sGloomAnims_9_1
+.4byte sGloomAnims_9_2
+.4byte sGloomAnims_9_3
+.4byte sGloomAnims_9_4
+.4byte sGloomAnims_9_5
+.4byte sGloomAnims_9_6
+.4byte sGloomAnims_9_7
+.4byte sGloomAnims_9_8
+sGloomAnimTable10:
+.4byte sGloomAnims_10_1
+.4byte sGloomAnims_10_2
+.4byte sGloomAnims_10_3
+.4byte sGloomAnims_10_4
+.4byte sGloomAnims_10_5
+.4byte sGloomAnims_10_6
+.4byte sGloomAnims_10_7
+.4byte sGloomAnims_10_8
+sGloomAnimTable11:
+.4byte sGloomAnims_11_1
+.4byte sGloomAnims_11_2
+.4byte sGloomAnims_11_3
+.4byte sGloomAnims_11_4
+.4byte sGloomAnims_11_5
+.4byte sGloomAnims_11_6
+.4byte sGloomAnims_11_7
+.4byte sGloomAnims_11_8
+sGloomAnimTable12:
+.4byte sGloomAnims_12_1
+.4byte sGloomAnims_12_2
+.4byte sGloomAnims_12_3
+.4byte sGloomAnims_12_4
+.4byte sGloomAnims_12_5
+.4byte sGloomAnims_12_6
+.4byte sGloomAnims_12_7
+.4byte sGloomAnims_12_8
+sGloomAnimTable13:
+.4byte sGloomAnims_13_1
+.4byte sGloomAnims_13_2
+.4byte sGloomAnims_13_3
+.4byte sGloomAnims_13_4
+.4byte sGloomAnims_13_5
+.4byte sGloomAnims_13_6
+.4byte sGloomAnims_13_7
+.4byte sGloomAnims_13_8
+sAxAnimationsGloom:
+.4byte sGloomAnimTable1
+.4byte sGloomAnimTable2
+.4byte sGloomAnimTable3
+.4byte sGloomAnimTable4
+.4byte sGloomAnimTable5
+.4byte sGloomAnimTable6
+.4byte sGloomAnimTable7
+.4byte sGloomAnimTable8
+.4byte sGloomAnimTable9
+.4byte sGloomAnimTable10
+.4byte sGloomAnimTable11
+.4byte sGloomAnimTable12
+.4byte sGloomAnimTable13
+sAxSpritesGloom:
+.4byte sGloomSprites1
+.4byte sGloomSprites2
+.4byte sGloomSprites3
+.4byte sGloomSprites4
+.4byte sGloomSprites5
+.4byte sGloomSprites6
+.4byte sGloomSprites7
+.4byte sGloomSprites8
+.4byte sGloomSprites9
+.4byte sGloomSprites10
+.4byte sGloomSprites11
+.4byte sGloomSprites12
+.4byte sGloomSprites13
+.4byte sGloomSprites14
+.4byte sGloomSprites15
+.4byte sGloomSprites16
+.4byte sGloomSprites17
+.4byte sGloomSprites18
+.4byte sGloomSprites19
+.4byte sGloomSprites20
+.4byte sGloomSprites21
+.4byte sGloomSprites22
+.4byte sGloomSprites23
+.4byte sGloomSprites24
+.4byte sGloomSprites25
+.4byte sGloomSprites26
+.4byte sGloomSprites27
+.4byte sGloomSprites28
+.4byte sGloomSprites29
+.4byte sGloomSprites30
+.4byte sGloomSprites31
+.4byte sGloomSprites32
+.4byte sGloomSprites33
+.4byte sGloomSprites34
+.4byte sGloomSprites35
+.4byte sGloomSprites36
+.4byte sGloomSprites37
+.4byte sGloomSprites38
+.4byte sGloomSprites39
+.4byte sGloomSprites40
+.4byte sGloomSprites41
+.4byte sGloomSprites42
+.4byte sGloomSprites43
+sAxMainGloom:
+ax_main sAxPosesGloom, sAxAnimationsGloom, 13, sAxSpritesGloom, sAxPositionsGloom

--- a/data/ax/golbat.inc
+++ b/data/ax/golbat.inc
@@ -1,0 +1,2490 @@
+.global gAxGolbat
+gAxGolbat:
+ax_siro sAxMainGolbat
+sGolbatPose1:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose3:
+ax_pose 2, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose4:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose5:
+ax_pose 4, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose6:
+ax_pose 5, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose7:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose8:
+ax_pose 7, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose9:
+ax_pose 8, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose10:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose11:
+ax_pose 10, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose12:
+ax_pose 11, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose13:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose15:
+ax_pose 14, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose16:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose17:
+ax_pose 10, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose18:
+ax_pose 11, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose19:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose20:
+ax_pose 7, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose21:
+ax_pose 8, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose22:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose24:
+ax_pose 5, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose25:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose27:
+ax_pose 2, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose28:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose29:
+ax_pose 4, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose30:
+ax_pose 5, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose31:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose32:
+ax_pose 7, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose33:
+ax_pose 8, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose34:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose35:
+ax_pose 10, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose36:
+ax_pose 11, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose37:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose38:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose39:
+ax_pose 14, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose40:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose41:
+ax_pose 10, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose42:
+ax_pose 11, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose43:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose44:
+ax_pose 7, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose45:
+ax_pose 8, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose46:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose47:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose48:
+ax_pose 5, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose49:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose50:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose51:
+ax_pose 2, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose52:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose53:
+ax_pose 4, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose54:
+ax_pose 5, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose55:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose56:
+ax_pose 7, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose57:
+ax_pose 8, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose58:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose59:
+ax_pose 10, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose60:
+ax_pose 11, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose61:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose62:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose63:
+ax_pose 14, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose64:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose65:
+ax_pose 10, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose66:
+ax_pose 11, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose67:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose68:
+ax_pose 7, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose69:
+ax_pose 8, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose70:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose71:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose72:
+ax_pose 5, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose73:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose74:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose75:
+ax_pose 2, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose76:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose77:
+ax_pose 4, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose78:
+ax_pose 5, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose79:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose80:
+ax_pose 7, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose81:
+ax_pose 8, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose82:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose83:
+ax_pose 10, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose84:
+ax_pose 11, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose85:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose86:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose87:
+ax_pose 14, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose88:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose89:
+ax_pose 10, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose90:
+ax_pose 11, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose91:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose92:
+ax_pose 7, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose93:
+ax_pose 8, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose94:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose95:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose96:
+ax_pose 5, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose97:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose98:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose99:
+ax_pose 2, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose100:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose101:
+ax_pose 4, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose102:
+ax_pose 5, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose103:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose104:
+ax_pose 7, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose105:
+ax_pose 8, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose106:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose107:
+ax_pose 10, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose108:
+ax_pose 11, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose109:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose110:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose111:
+ax_pose 14, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose112:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose113:
+ax_pose 10, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose114:
+ax_pose 11, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose115:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose116:
+ax_pose 7, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose117:
+ax_pose 8, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose118:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose119:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose120:
+ax_pose 5, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose121:
+ax_pose 15, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose122:
+ax_pose 16, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose123:
+ax_pose 17, 0x01dd, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose124:
+ax_pose 18, 0x01e0, 0x90ee, 0x7c00
+ax_pose_terminator
+sGolbatPose125:
+ax_pose 19, 0x01df, 0x90ec, 0x7c00
+ax_pose_terminator
+sGolbatPose126:
+ax_pose 20, 0x01e4, 0x90ec, 0x7c00
+ax_pose_terminator
+sGolbatPose127:
+ax_pose 21, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose128:
+ax_pose 20, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose129:
+ax_pose 19, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose130:
+ax_pose 18, 0x01e0, 0x80f2, 0x7c00
+ax_pose_terminator
+sGolbatPose131:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose132:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose133:
+ax_pose 2, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose134:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose135:
+ax_pose 4, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose136:
+ax_pose 5, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose137:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose138:
+ax_pose 7, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose139:
+ax_pose 8, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose140:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose141:
+ax_pose 10, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose142:
+ax_pose 11, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose143:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose144:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose145:
+ax_pose 14, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose146:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose147:
+ax_pose 10, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose148:
+ax_pose 11, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose149:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose150:
+ax_pose 7, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose151:
+ax_pose 8, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose152:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose153:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose154:
+ax_pose 5, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose155:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose156:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose157:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose158:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose159:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose160:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose161:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose162:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose163:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose164:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose165:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose166:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose167:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose168:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose169:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose170:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose171:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose172:
+ax_pose 1, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose173:
+ax_pose 2, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose174:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose175:
+ax_pose 4, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose176:
+ax_pose 5, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose177:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose178:
+ax_pose 7, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose179:
+ax_pose 8, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose180:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose181:
+ax_pose 10, 0x01df, 0x90f1, 0x7c00
+ax_pose_terminator
+sGolbatPose182:
+ax_pose 11, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose183:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose184:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose185:
+ax_pose 14, 0x01df, 0x80f4, 0x7c00
+ax_pose_terminator
+sGolbatPose186:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose187:
+ax_pose 10, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose188:
+ax_pose 11, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose189:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose190:
+ax_pose 7, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose191:
+ax_pose 8, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose192:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose193:
+ax_pose 4, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose194:
+ax_pose 5, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose195:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose196:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose197:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose198:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose199:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose200:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose201:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose202:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+sGolbatPose203:
+ax_pose 0, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose204:
+ax_pose 3, 0x01df, 0x80f9, 0x7c00
+ax_pose_terminator
+sGolbatPose205:
+ax_pose 6, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose206:
+ax_pose 9, 0x01df, 0x80f6, 0x7c00
+ax_pose_terminator
+sGolbatPose207:
+ax_pose 12, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sGolbatPose208:
+ax_pose 9, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose209:
+ax_pose 6, 0x01df, 0x90eb, 0x7c00
+ax_pose_terminator
+sGolbatPose210:
+ax_pose 3, 0x01df, 0x90e9, 0x7c00
+ax_pose_terminator
+.align 2
+sGolbatAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 1, 0, 1, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, -1, 0, -1, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, -1,
+ax_anim 6, 0, 3, 2, 0, 2, 0,
+ax_anim 6, 0, 5, 2, -1, 2, -1,
+ax_anim 6, 0, 3, 1, -3, 1, -1,
+ax_anim 6, 0, 4, 1, -2, 2, -1,
+ax_anim 6, 0, 3, 1, 0, 1, 0,
+ax_anim 6, 0, 5, 0, -1, 0, -1,
+ax_anim_terminator
+sGolbatAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, -1, 1, 0,
+ax_anim 6, 0, 6, 2, 0, 2, 0,
+ax_anim 6, 0, 8, 2, -1, 2, 0,
+ax_anim 6, 0, 6, 1, -2, 1, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -1, -1, 0,
+ax_anim 6, 0, 8, 1, -2, 1, 0,
+ax_anim_terminator
+sGolbatAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, -1,
+ax_anim 6, 0, 9, 2, -2, 2, -1,
+ax_anim 6, 0, 11, 2, -1, 2, -1,
+ax_anim 6, 0, 9, 1, -3, 1, -1,
+ax_anim 6, 0, 10, 2, -2, 2, -1,
+ax_anim 6, 0, 9, 1, 0, 1, 0,
+ax_anim 6, 0, 11, 0, -1, 0, -1,
+ax_anim_terminator
+sGolbatAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 1, 0, 1, 0,
+ax_anim 6, 0, 14, 1, -1, 1, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, -1, 0, -1, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 15, -2, -2, -2, -1,
+ax_anim 6, 0, 17, -2, -1, -2, -1,
+ax_anim 6, 0, 15, -1, -3, -1, -1,
+ax_anim 6, 0, 16, -2, -2, -2, -1,
+ax_anim 6, 0, 15, -1, 0, -1, 0,
+ax_anim 6, 0, 17, 0, -1, 0, -1,
+ax_anim_terminator
+sGolbatAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, -1, -1, 0,
+ax_anim 6, 0, 18, -2, 0, -2, 0,
+ax_anim 6, 0, 20, -2, -1, -2, 0,
+ax_anim 6, 0, 18, -1, -2, -1, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 1, -1, 1, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, -1,
+ax_anim 6, 0, 21, -2, 0, -2, 0,
+ax_anim 6, 0, 23, -2, -1, -2, -1,
+ax_anim 6, 0, 21, -1, -3, -1, -1,
+ax_anim 6, 0, 22, -1, -2, -2, -1,
+ax_anim 6, 0, 21, -1, 0, -1, 0,
+ax_anim 6, 0, 23, 0, -1, 0, -1,
+ax_anim_terminator
+.align 2
+sGolbatAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 3, 0, 26, 0, -2, 0, -2,
+ax_anim 4, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 3,
+ax_anim 1, 0, 24, 0, 12, 0, 10,
+ax_anim 2, 0, 25, 0, 24, 0, 22,
+ax_anim 2, 1, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 26, 0, 24, 0, 22,
+ax_anim 2, 0, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 25, 0, 8, 0, 6,
+ax_anim_terminator
+sGolbatAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 3, 0, 29, -2, -2, -2, -2,
+ax_anim 4, 0, 28, -3, -3, -3, -3,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 11, 13, 11, 12,
+ax_anim 2, 0, 28, 20, 24, 20, 21,
+ax_anim 2, 1, 27, 21, 23, 21, 20,
+ax_anim 2, 0, 29, 20, 24, 20, 21,
+ax_anim 2, 0, 27, 21, 23, 21, 20,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sGolbatAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 3, 0, 32, -2, 0, -2, 0,
+ax_anim 4, 0, 31, -3, 0, -3, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 11, 1, 11, 0,
+ax_anim 2, 0, 31, 22, 2, 22, 0,
+ax_anim 2, 1, 30, 22, 3, 22, 1,
+ax_anim 2, 0, 32, 22, 2, 22, 0,
+ax_anim 2, 0, 30, 22, 3, 22, 1,
+ax_anim 2, 0, 31, 8, 1, 8, 0,
+ax_anim_terminator
+sGolbatAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 3, 0, 35, -2, 2, -2, 2,
+ax_anim 4, 0, 34, -3, 3, -3, 3,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, -4, 4, -4,
+ax_anim 1, 0, 33, 13, -10, 13, -13,
+ax_anim 2, 0, 34, 20, -15, 20, -19,
+ax_anim 2, 1, 33, 21, -14, 21, -18,
+ax_anim 2, 0, 35, 20, -15, 20, -19,
+ax_anim 2, 0, 33, 21, -14, 21, -18,
+ax_anim 2, 0, 34, 8, -7, 8, -8,
+ax_anim_terminator
+sGolbatAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 3, 0, 38, 0, 2, 0, 2,
+ax_anim 4, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -10, 0, -12,
+ax_anim 2, 0, 37, 0, -15, 0, -19,
+ax_anim 2, 1, 36, -1, -15, -1, -19,
+ax_anim 2, 0, 38, 0, -15, 0, -19,
+ax_anim 2, 0, 36, -1, -15, -1, -19,
+ax_anim 2, 0, 37, 0, -7, 0, -9,
+ax_anim_terminator
+sGolbatAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 3, 0, 41, 2, 2, 2, 2,
+ax_anim 4, 0, 40, 3, 3, 3, 3,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -4, -4, -4, -4,
+ax_anim 1, 0, 39, -13, -10, -13, -13,
+ax_anim 2, 0, 40, -20, -15, -20, -19,
+ax_anim 2, 1, 39, -21, -14, -21, -18,
+ax_anim 2, 0, 41, -20, -15, -20, -19,
+ax_anim 2, 0, 39, -21, -14, -21, -18,
+ax_anim 2, 0, 40, -8, -7, -8, -8,
+ax_anim_terminator
+sGolbatAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 3, 0, 44, 2, 0, 2, 0,
+ax_anim 4, 0, 43, 3, 0, 3, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -11, 1, -11, 0,
+ax_anim 2, 0, 43, -22, 2, -22, 0,
+ax_anim 2, 1, 42, -22, 3, -22, 1,
+ax_anim 2, 0, 44, -22, 2, -22, 0,
+ax_anim 2, 0, 42, -22, 3, -22, 1,
+ax_anim 2, 0, 43, -8, 1, -8, 0,
+ax_anim_terminator
+sGolbatAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 3, 0, 47, 2, -2, 2, -2,
+ax_anim 4, 0, 46, 3, -3, 3, -3,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -11, 13, -11, 12,
+ax_anim 2, 0, 46, -20, 24, -20, 21,
+ax_anim 2, 1, 45, -21, 23, -21, 20,
+ax_anim 2, 0, 47, -20, 24, -20, 21,
+ax_anim 2, 0, 45, -21, 23, -21, 20,
+ax_anim 2, 0, 46, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGolbatAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 3, 0, 50, 0, -2, 0, -2,
+ax_anim 4, 0, 49, 0, -3, 0, -3,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 3,
+ax_anim 1, 0, 48, 0, 12, 0, 10,
+ax_anim 2, 0, 49, 0, 24, 0, 22,
+ax_anim 2, 1, 48, 1, 24, 1, 22,
+ax_anim 2, 0, 50, 0, 24, 0, 22,
+ax_anim 2, 0, 48, 1, 24, 1, 22,
+ax_anim 2, 0, 49, 0, 8, 0, 6,
+ax_anim_terminator
+sGolbatAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 3, 0, 53, -2, -2, -2, -2,
+ax_anim 4, 0, 52, -3, -3, -3, -3,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 11, 13, 11, 12,
+ax_anim 2, 0, 52, 20, 24, 20, 21,
+ax_anim 2, 1, 51, 21, 23, 21, 20,
+ax_anim 2, 0, 53, 20, 24, 20, 21,
+ax_anim 2, 0, 51, 21, 23, 21, 20,
+ax_anim 2, 0, 52, 8, 8, 8, 8,
+ax_anim_terminator
+sGolbatAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 3, 0, 56, -2, 0, -2, 0,
+ax_anim 4, 0, 55, -3, 0, -3, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 11, 1, 11, 0,
+ax_anim 2, 0, 55, 22, 2, 22, 0,
+ax_anim 2, 1, 54, 22, 3, 22, 1,
+ax_anim 2, 0, 56, 22, 2, 22, 0,
+ax_anim 2, 0, 54, 22, 3, 22, 1,
+ax_anim 2, 0, 55, 8, 1, 8, 0,
+ax_anim_terminator
+sGolbatAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 3, 0, 59, -2, 2, -2, 2,
+ax_anim 4, 0, 58, -3, 3, -3, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 4, -4, 4, -4,
+ax_anim 1, 0, 57, 13, -10, 13, -13,
+ax_anim 2, 0, 58, 20, -15, 20, -19,
+ax_anim 2, 1, 57, 21, -14, 21, -18,
+ax_anim 2, 0, 59, 20, -15, 20, -19,
+ax_anim 2, 0, 57, 21, -14, 21, -18,
+ax_anim 2, 0, 58, 8, -7, 8, -8,
+ax_anim_terminator
+sGolbatAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 3, 0, 62, 0, 2, 0, 2,
+ax_anim 4, 0, 61, 0, 3, 0, 3,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -10, 0, -12,
+ax_anim 2, 0, 61, 0, -15, 0, -19,
+ax_anim 2, 1, 60, -1, -15, -1, -19,
+ax_anim 2, 0, 62, 0, -15, 0, -19,
+ax_anim 2, 0, 60, -1, -15, -1, -19,
+ax_anim 2, 0, 61, 0, -7, 0, -9,
+ax_anim_terminator
+sGolbatAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 3, 0, 65, 2, 2, 2, 2,
+ax_anim 4, 0, 64, 3, 3, 3, 3,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 65, -4, -4, -4, -4,
+ax_anim 1, 0, 63, -13, -10, -13, -13,
+ax_anim 2, 0, 64, -20, -15, -20, -19,
+ax_anim 2, 1, 63, -21, -14, -21, -18,
+ax_anim 2, 0, 65, -20, -15, -20, -19,
+ax_anim 2, 0, 63, -21, -14, -21, -18,
+ax_anim 2, 0, 64, -8, -7, -8, -8,
+ax_anim_terminator
+sGolbatAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 3, 0, 68, 2, 0, 2, 0,
+ax_anim 4, 0, 67, 3, 0, 3, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -11, 1, -11, 0,
+ax_anim 2, 0, 67, -22, 2, -22, 0,
+ax_anim 2, 1, 66, -22, 3, -22, 1,
+ax_anim 2, 0, 68, -22, 2, -22, 0,
+ax_anim 2, 0, 66, -22, 3, -22, 1,
+ax_anim 2, 0, 67, -8, 1, -8, 0,
+ax_anim_terminator
+sGolbatAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 3, 0, 71, 2, -2, 2, -2,
+ax_anim 4, 0, 70, 3, -3, 3, -3,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -11, 13, -11, 12,
+ax_anim 2, 0, 70, -20, 24, -20, 21,
+ax_anim 2, 1, 69, -21, 23, -21, 20,
+ax_anim 2, 0, 71, -20, 24, -20, 21,
+ax_anim 2, 0, 69, -21, 23, -21, 20,
+ax_anim 2, 0, 70, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGolbatAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 1, -1, 1, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 2, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 1, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 1, -1, 1, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim_terminator
+sGolbatAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, -1,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 75, 1, -3, 1, -1,
+ax_anim 2, 2, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 77, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, -1, 0, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 76, 0, -1, 0, -1,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 75, 1, -3, 1, -1,
+ax_anim 2, 0, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 77, 1, 0, 1, 0,
+ax_anim_terminator
+sGolbatAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 79, 2, -1, 2, 0,
+ax_anim 2, 0, 78, 1, -2, 1, 0,
+ax_anim 2, 2, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -1, -1, 0,
+ax_anim 2, 0, 79, 1, -2, 1, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 1, 79, 1, -1, 1, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 79, 2, -1, 2, 0,
+ax_anim 2, 0, 78, 1, -2, 1, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -1, -1, 0,
+ax_anim_terminator
+sGolbatAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -1,
+ax_anim 2, 0, 82, 2, -1, 2, -1,
+ax_anim 2, 0, 81, 1, -3, 1, -1,
+ax_anim 2, 2, 82, 2, -2, 2, -1,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -1,
+ax_anim 2, 0, 82, 2, -1, 2, -1,
+ax_anim 2, 0, 81, 1, -3, 1, -1,
+ax_anim 2, 0, 82, 2, -2, 2, -1,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim_terminator
+sGolbatAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 1, -1, 1, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 2, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 1, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 1, -1, 1, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim_terminator
+sGolbatAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -1,
+ax_anim 2, 0, 88, -2, -1, -2, -1,
+ax_anim 2, 0, 87, -1, -3, -1, -1,
+ax_anim 2, 2, 88, -2, -2, -2, -1,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -1,
+ax_anim 2, 0, 88, -2, -1, -2, -1,
+ax_anim 2, 0, 87, -1, -3, -1, -1,
+ax_anim 2, 0, 88, -2, -2, -2, -1,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim_terminator
+sGolbatAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, -1, -1, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -2, -1, -2, 0,
+ax_anim 2, 0, 90, -1, -2, -1, 0,
+ax_anim 2, 2, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, 0,
+ax_anim 2, 0, 91, 0, -1, -1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 91, -1, -1, -1, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -2, -1, -2, 0,
+ax_anim 2, 0, 90, -1, -2, -1, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, 0,
+ax_anim_terminator
+sGolbatAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 93, -1, -3, -1, -1,
+ax_anim 2, 2, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 93, -1, -3, -1, -1,
+ax_anim 2, 0, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 2, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 98, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sGolbatAnims_5_2:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 101, 2, -1, 2, -1,
+ax_anim 2, 0, 99, 1, -3, 1, -1,
+ax_anim 2, 2, 100, 1, -2, 2, -1,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 101, 2, -1, 2, -1,
+ax_anim 2, 0, 99, 1, -3, 1, -1,
+ax_anim 2, 0, 100, 1, -2, 2, -1,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim_terminator
+sGolbatAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 102, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, -1, 2, 0,
+ax_anim 2, 0, 102, 1, -2, 1, 0,
+ax_anim 2, 2, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -1, -1, 0,
+ax_anim 2, 0, 104, 1, -2, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 102, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, -1, 2, 0,
+ax_anim 2, 0, 102, 1, -2, 1, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -1, -1, 0,
+ax_anim_terminator
+sGolbatAnims_5_4:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 2, -2, 2, -1,
+ax_anim 2, 0, 107, 2, -1, 2, -1,
+ax_anim 2, 0, 105, 1, -3, 1, -1,
+ax_anim 2, 2, 106, 2, -2, 2, -1,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 2, -2, 2, -1,
+ax_anim 2, 0, 107, 2, -1, 2, -1,
+ax_anim 2, 0, 105, 1, -3, 1, -1,
+ax_anim 2, 0, 106, 2, -2, 2, -1,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim_terminator
+sGolbatAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 1, -1, 1, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 2, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 1, -1, 1, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim_terminator
+sGolbatAnims_5_6:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 111, -2, -2, -2, -1,
+ax_anim 2, 0, 113, -2, -1, -2, -1,
+ax_anim 2, 0, 111, -1, -3, -1, -1,
+ax_anim 2, 2, 112, -2, -2, -2, -1,
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim 2, 0, 113, 0, -1, 0, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 111, -2, -2, -2, -1,
+ax_anim 2, 0, 113, -2, -1, -2, -1,
+ax_anim 2, 0, 111, -1, -3, -1, -1,
+ax_anim 2, 0, 112, -2, -2, -2, -1,
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim_terminator
+sGolbatAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, 0,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, -1, -2, 0,
+ax_anim 2, 0, 114, -1, -2, -1, 0,
+ax_anim 2, 2, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, 0,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, -1, -2, 0,
+ax_anim 2, 0, 114, -1, -2, -1, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, 0,
+ax_anim_terminator
+sGolbatAnims_5_8:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 117, -2, 0, -2, 0,
+ax_anim 2, 0, 119, -2, -1, -2, -1,
+ax_anim 2, 0, 117, -1, -3, -1, -1,
+ax_anim 2, 2, 118, -1, -2, -2, -1,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 119, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 117, -2, 0, -2, 0,
+ax_anim 2, 0, 119, -2, -1, -2, -1,
+ax_anim 2, 0, 117, -1, -3, -1, -1,
+ax_anim 2, 0, 118, -1, -2, -2, -1,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sGolbatAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sGolbatAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sGolbatAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sGolbatAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sGolbatAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sGolbatAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sGolbatAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGolbatAnims_8_1:
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, -1, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_8_2:
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, -1, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_8_3:
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, -1, 0, 0,
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 0, 1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_8_4:
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, -1, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 141, 0, 1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_8_5:
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, -1, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 144, 0, 1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_8_6:
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 0, -1, 0, 0,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_8_7:
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -1, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 1, 0, 0,
+ax_anim_terminator
+sGolbatAnims_8_8:
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 21, 7, 16,
+ax_anim 3, 0, 158, 0, 27, 0, 20,
+ax_anim 2, 3, 159, -7, 21, -7, 16,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 14, 3, 14, 3,
+ax_anim 2, 0, 156, 19, 10, 19, 8,
+ax_anim 3, 0, 157, 22, 26, 22, 21,
+ax_anim 2, 3, 158, 11, 28, 11, 23,
+ax_anim 2, 0, 159, 3, 19, 3, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -2, 16, -3,
+ax_anim 3, 0, 156, 22, 4, 22, 0,
+ax_anim 2, 3, 157, 18, 8, 18, 5,
+ax_anim 2, 0, 158, 12, 10, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 3,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -20, 12, -20,
+ax_anim 3, 0, 155, 19, -17, 19, -20,
+ax_anim 2, 3, 156, 20, -10, 20, -13,
+ax_anim 2, 0, 157, 17, -4, 17, -5,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -16, -7, -18,
+ax_anim 3, 0, 154, 0, -18, 0, -22,
+ax_anim 2, 3, 155, 7, -16, 7, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -20, -12, -20,
+ax_anim 3, 0, 161, -19, -17, -19, -20,
+ax_anim 2, 3, 160, -20, -10, -20, -13,
+ax_anim 2, 0, 159, -17, -4, -17, -5,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -2, -16, -3,
+ax_anim 3, 0, 160, -22, 4, -22, 0,
+ax_anim 2, 3, 159, -18, 8, -18, 5,
+ax_anim 2, 0, 158, -12, 10, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 3,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -14, 3, -14, 3,
+ax_anim 2, 0, 160, -19, 10, -19, 8,
+ax_anim 3, 0, 159, -22, 26, -22, 21,
+ax_anim 2, 3, 158, -11, 28, -11, 23,
+ax_anim 2, 0, 157, -3, 19, -3, 17,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -9, 0, 0,
+ax_anim 2, 2, 170, 0, 5, 0, 0,
+ax_anim_terminator
+sGolbatAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -9, 0, 0,
+ax_anim 2, 2, 173, 0, 5, 0, 0,
+ax_anim_terminator
+sGolbatAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -9, 0, 0,
+ax_anim 2, 2, 176, 0, 4, 0, 0,
+ax_anim_terminator
+sGolbatAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -8, 0, 0,
+ax_anim 2, 2, 179, 0, 5, 0, 0,
+ax_anim_terminator
+sGolbatAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -9, 0, 0,
+ax_anim 2, 2, 182, 0, 5, 0, 0,
+ax_anim_terminator
+sGolbatAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -8, 0, 0,
+ax_anim 2, 2, 185, 0, 5, 0, 0,
+ax_anim_terminator
+sGolbatAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -9, 0, 0,
+ax_anim 2, 2, 188, 0, 4, 0, 0,
+ax_anim_terminator
+sGolbatAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -9, 0, 0,
+ax_anim 2, 2, 191, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolbatAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sGolbatGfx1:
+.incbin "baserom.gba", 0x6CD77C, 0x200
+sGolbatSprites1:
+ax_sprite sGolbatGfx1, 0x200
+ax_sprite_terminator
+sGolbatGfx2:
+.incbin "baserom.gba", 0x6CD98C, 0x200
+sGolbatSprites2:
+ax_sprite sGolbatGfx2, 0x200
+ax_sprite_terminator
+sGolbatGfx3:
+.incbin "baserom.gba", 0x6CDB9C, 0x200
+sGolbatSprites3:
+ax_sprite sGolbatGfx3, 0x200
+ax_sprite_terminator
+sGolbatGfx4:
+.incbin "baserom.gba", 0x6CDDAC, 0x200
+sGolbatSprites4:
+ax_sprite sGolbatGfx4, 0x200
+ax_sprite_terminator
+sGolbatGfx5:
+.incbin "baserom.gba", 0x6CDFBC, 0x200
+sGolbatSprites5:
+ax_sprite sGolbatGfx5, 0x200
+ax_sprite_terminator
+sGolbatGfx6:
+.incbin "baserom.gba", 0x6CE1CC, 0x200
+sGolbatSprites6:
+ax_sprite sGolbatGfx6, 0x200
+ax_sprite_terminator
+sGolbatGfx7:
+.incbin "baserom.gba", 0x6CE3DC, 0x200
+sGolbatSprites7:
+ax_sprite sGolbatGfx7, 0x200
+ax_sprite_terminator
+sGolbatGfx8:
+.incbin "baserom.gba", 0x6CE5EC, 0x200
+sGolbatSprites8:
+ax_sprite sGolbatGfx8, 0x200
+ax_sprite_terminator
+sGolbatGfx9:
+.incbin "baserom.gba", 0x6CE7FC, 0x200
+sGolbatSprites9:
+ax_sprite sGolbatGfx9, 0x200
+ax_sprite_terminator
+sGolbatGfx10:
+.incbin "baserom.gba", 0x6CEA0C, 0x200
+sGolbatSprites10:
+ax_sprite sGolbatGfx10, 0x200
+ax_sprite_terminator
+sGolbatGfx11:
+.incbin "baserom.gba", 0x6CEC1C, 0x200
+sGolbatSprites11:
+ax_sprite sGolbatGfx11, 0x200
+ax_sprite_terminator
+sGolbatGfx12:
+.incbin "baserom.gba", 0x6CEE2C, 0x200
+sGolbatSprites12:
+ax_sprite sGolbatGfx12, 0x200
+ax_sprite_terminator
+sGolbatGfx13:
+.incbin "baserom.gba", 0x6CF03C, 0x200
+sGolbatSprites13:
+ax_sprite sGolbatGfx13, 0x200
+ax_sprite_terminator
+sGolbatGfx14:
+.incbin "baserom.gba", 0x6CF24C, 0x200
+sGolbatSprites14:
+ax_sprite sGolbatGfx14, 0x200
+ax_sprite_terminator
+sGolbatGfx15:
+.incbin "baserom.gba", 0x6CF45C, 0x200
+sGolbatSprites15:
+ax_sprite sGolbatGfx15, 0x200
+ax_sprite_terminator
+sGolbatGfx16:
+.incbin "baserom.gba", 0x6CF66C, 0x200
+sGolbatSprites16:
+ax_sprite sGolbatGfx16, 0x200
+ax_sprite_terminator
+sGolbatGfx17:
+.incbin "baserom.gba", 0x6CF87C, 0x200
+sGolbatSprites17:
+ax_sprite sGolbatGfx17, 0x200
+ax_sprite_terminator
+sGolbatGfx18:
+.incbin "baserom.gba", 0x6CFA8C, 0x200
+sGolbatSprites18:
+ax_sprite sGolbatGfx18, 0x200
+ax_sprite_terminator
+sGolbatGfx19:
+.incbin "baserom.gba", 0x6CFC9C, 0x200
+sGolbatSprites19:
+ax_sprite sGolbatGfx19, 0x200
+ax_sprite_terminator
+sGolbatGfx20:
+.incbin "baserom.gba", 0x6CFEAC, 0x200
+sGolbatSprites20:
+ax_sprite sGolbatGfx20, 0x200
+ax_sprite_terminator
+sGolbatGfx21:
+.incbin "baserom.gba", 0x6D00BC, 0x200
+sGolbatSprites21:
+ax_sprite sGolbatGfx21, 0x200
+ax_sprite_terminator
+sGolbatGfx22:
+.incbin "baserom.gba", 0x6D02CC, 0x200
+sGolbatSprites22:
+ax_sprite sGolbatGfx22, 0x200
+ax_sprite_terminator
+sAxPosesGolbat:
+.4byte sGolbatPose1
+.4byte sGolbatPose2
+.4byte sGolbatPose3
+.4byte sGolbatPose4
+.4byte sGolbatPose5
+.4byte sGolbatPose6
+.4byte sGolbatPose7
+.4byte sGolbatPose8
+.4byte sGolbatPose9
+.4byte sGolbatPose10
+.4byte sGolbatPose11
+.4byte sGolbatPose12
+.4byte sGolbatPose13
+.4byte sGolbatPose14
+.4byte sGolbatPose15
+.4byte sGolbatPose16
+.4byte sGolbatPose17
+.4byte sGolbatPose18
+.4byte sGolbatPose19
+.4byte sGolbatPose20
+.4byte sGolbatPose21
+.4byte sGolbatPose22
+.4byte sGolbatPose23
+.4byte sGolbatPose24
+.4byte sGolbatPose25
+.4byte sGolbatPose26
+.4byte sGolbatPose27
+.4byte sGolbatPose28
+.4byte sGolbatPose29
+.4byte sGolbatPose30
+.4byte sGolbatPose31
+.4byte sGolbatPose32
+.4byte sGolbatPose33
+.4byte sGolbatPose34
+.4byte sGolbatPose35
+.4byte sGolbatPose36
+.4byte sGolbatPose37
+.4byte sGolbatPose38
+.4byte sGolbatPose39
+.4byte sGolbatPose40
+.4byte sGolbatPose41
+.4byte sGolbatPose42
+.4byte sGolbatPose43
+.4byte sGolbatPose44
+.4byte sGolbatPose45
+.4byte sGolbatPose46
+.4byte sGolbatPose47
+.4byte sGolbatPose48
+.4byte sGolbatPose49
+.4byte sGolbatPose50
+.4byte sGolbatPose51
+.4byte sGolbatPose52
+.4byte sGolbatPose53
+.4byte sGolbatPose54
+.4byte sGolbatPose55
+.4byte sGolbatPose56
+.4byte sGolbatPose57
+.4byte sGolbatPose58
+.4byte sGolbatPose59
+.4byte sGolbatPose60
+.4byte sGolbatPose61
+.4byte sGolbatPose62
+.4byte sGolbatPose63
+.4byte sGolbatPose64
+.4byte sGolbatPose65
+.4byte sGolbatPose66
+.4byte sGolbatPose67
+.4byte sGolbatPose68
+.4byte sGolbatPose69
+.4byte sGolbatPose70
+.4byte sGolbatPose71
+.4byte sGolbatPose72
+.4byte sGolbatPose73
+.4byte sGolbatPose74
+.4byte sGolbatPose75
+.4byte sGolbatPose76
+.4byte sGolbatPose77
+.4byte sGolbatPose78
+.4byte sGolbatPose79
+.4byte sGolbatPose80
+.4byte sGolbatPose81
+.4byte sGolbatPose82
+.4byte sGolbatPose83
+.4byte sGolbatPose84
+.4byte sGolbatPose85
+.4byte sGolbatPose86
+.4byte sGolbatPose87
+.4byte sGolbatPose88
+.4byte sGolbatPose89
+.4byte sGolbatPose90
+.4byte sGolbatPose91
+.4byte sGolbatPose92
+.4byte sGolbatPose93
+.4byte sGolbatPose94
+.4byte sGolbatPose95
+.4byte sGolbatPose96
+.4byte sGolbatPose97
+.4byte sGolbatPose98
+.4byte sGolbatPose99
+.4byte sGolbatPose100
+.4byte sGolbatPose101
+.4byte sGolbatPose102
+.4byte sGolbatPose103
+.4byte sGolbatPose104
+.4byte sGolbatPose105
+.4byte sGolbatPose106
+.4byte sGolbatPose107
+.4byte sGolbatPose108
+.4byte sGolbatPose109
+.4byte sGolbatPose110
+.4byte sGolbatPose111
+.4byte sGolbatPose112
+.4byte sGolbatPose113
+.4byte sGolbatPose114
+.4byte sGolbatPose115
+.4byte sGolbatPose116
+.4byte sGolbatPose117
+.4byte sGolbatPose118
+.4byte sGolbatPose119
+.4byte sGolbatPose120
+.4byte sGolbatPose121
+.4byte sGolbatPose122
+.4byte sGolbatPose123
+.4byte sGolbatPose124
+.4byte sGolbatPose125
+.4byte sGolbatPose126
+.4byte sGolbatPose127
+.4byte sGolbatPose128
+.4byte sGolbatPose129
+.4byte sGolbatPose130
+.4byte sGolbatPose131
+.4byte sGolbatPose132
+.4byte sGolbatPose133
+.4byte sGolbatPose134
+.4byte sGolbatPose135
+.4byte sGolbatPose136
+.4byte sGolbatPose137
+.4byte sGolbatPose138
+.4byte sGolbatPose139
+.4byte sGolbatPose140
+.4byte sGolbatPose141
+.4byte sGolbatPose142
+.4byte sGolbatPose143
+.4byte sGolbatPose144
+.4byte sGolbatPose145
+.4byte sGolbatPose146
+.4byte sGolbatPose147
+.4byte sGolbatPose148
+.4byte sGolbatPose149
+.4byte sGolbatPose150
+.4byte sGolbatPose151
+.4byte sGolbatPose152
+.4byte sGolbatPose153
+.4byte sGolbatPose154
+.4byte sGolbatPose155
+.4byte sGolbatPose156
+.4byte sGolbatPose157
+.4byte sGolbatPose158
+.4byte sGolbatPose159
+.4byte sGolbatPose160
+.4byte sGolbatPose161
+.4byte sGolbatPose162
+.4byte sGolbatPose163
+.4byte sGolbatPose164
+.4byte sGolbatPose165
+.4byte sGolbatPose166
+.4byte sGolbatPose167
+.4byte sGolbatPose168
+.4byte sGolbatPose169
+.4byte sGolbatPose170
+.4byte sGolbatPose171
+.4byte sGolbatPose172
+.4byte sGolbatPose173
+.4byte sGolbatPose174
+.4byte sGolbatPose175
+.4byte sGolbatPose176
+.4byte sGolbatPose177
+.4byte sGolbatPose178
+.4byte sGolbatPose179
+.4byte sGolbatPose180
+.4byte sGolbatPose181
+.4byte sGolbatPose182
+.4byte sGolbatPose183
+.4byte sGolbatPose184
+.4byte sGolbatPose185
+.4byte sGolbatPose186
+.4byte sGolbatPose187
+.4byte sGolbatPose188
+.4byte sGolbatPose189
+.4byte sGolbatPose190
+.4byte sGolbatPose191
+.4byte sGolbatPose192
+.4byte sGolbatPose193
+.4byte sGolbatPose194
+.4byte sGolbatPose195
+.4byte sGolbatPose196
+.4byte sGolbatPose197
+.4byte sGolbatPose198
+.4byte sGolbatPose199
+.4byte sGolbatPose200
+.4byte sGolbatPose201
+.4byte sGolbatPose202
+.4byte sGolbatPose203
+.4byte sGolbatPose204
+.4byte sGolbatPose205
+.4byte sGolbatPose206
+.4byte sGolbatPose207
+.4byte sGolbatPose208
+.4byte sGolbatPose209
+.4byte sGolbatPose210
+sAxPositionsGolbat:
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    0,  -12, 	 -12,  -10, 	  12,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -5,  -28, 	   5,  -28, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    2,  -12, 	  12,  -16, 	   1,   -7, 	   2,  -14
+.2byte    2,  -12, 	   1,  -28, 	  -8,  -26, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    3,  -12, 	  10,  -18, 	   5,  -11, 	   2,  -14
+.2byte    3,  -12, 	  -4,  -27, 	  -6,  -22, 	   0,  -14
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -13, 	  -1,  -22, 	  12,  -14, 	   0,  -15
+.2byte    3,  -13, 	  -4,  -29, 	   3,  -25, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    0,  -16, 	  12,  -17, 	 -12,  -17, 	   0,  -15
+.2byte    0,  -16, 	   4,  -27, 	  -5,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -13, 	   1,  -22, 	 -12,  -14, 	   0,  -15
+.2byte   -3,  -13, 	   4,  -29, 	  -3,  -25, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -3,  -12, 	 -10,  -18, 	  -5,  -11, 	  -2,  -14
+.2byte   -3,  -12, 	   4,  -27, 	   6,  -22, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -2,  -12, 	 -12,  -16, 	  -1,   -7, 	  -2,  -14
+.2byte   -1,  -12, 	   0,  -28, 	   9,  -26, 	   1,  -15
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    0,  -12, 	 -12,  -10, 	  12,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -5,  -28, 	   5,  -28, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    2,  -12, 	  12,  -16, 	   1,   -7, 	   2,  -14
+.2byte    2,  -12, 	   1,  -28, 	  -8,  -26, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    3,  -12, 	  10,  -18, 	   5,  -11, 	   2,  -14
+.2byte    3,  -12, 	  -4,  -27, 	  -6,  -22, 	   0,  -14
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -13, 	  -1,  -22, 	  12,  -14, 	   0,  -15
+.2byte    3,  -13, 	  -4,  -29, 	   3,  -25, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    0,  -16, 	  12,  -17, 	 -12,  -17, 	   0,  -15
+.2byte    0,  -16, 	   4,  -27, 	  -5,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -13, 	   1,  -22, 	 -12,  -14, 	   0,  -15
+.2byte   -3,  -13, 	   4,  -29, 	  -3,  -25, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -3,  -12, 	 -10,  -18, 	  -5,  -11, 	  -2,  -14
+.2byte   -3,  -12, 	   4,  -27, 	   6,  -22, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -2,  -12, 	 -12,  -16, 	  -1,   -7, 	  -2,  -14
+.2byte   -1,  -12, 	   0,  -28, 	   9,  -26, 	   1,  -15
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    0,  -12, 	 -12,  -10, 	  12,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -5,  -28, 	   5,  -28, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    2,  -12, 	  12,  -16, 	   1,   -7, 	   2,  -14
+.2byte    2,  -12, 	   1,  -28, 	  -8,  -26, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    3,  -12, 	  10,  -18, 	   5,  -11, 	   2,  -14
+.2byte    3,  -12, 	  -4,  -27, 	  -6,  -22, 	   0,  -14
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -13, 	  -1,  -22, 	  12,  -14, 	   0,  -15
+.2byte    3,  -13, 	  -4,  -29, 	   3,  -25, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    0,  -16, 	  12,  -17, 	 -12,  -17, 	   0,  -15
+.2byte    0,  -16, 	   4,  -27, 	  -5,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -13, 	   1,  -22, 	 -12,  -14, 	   0,  -15
+.2byte   -3,  -13, 	   4,  -29, 	  -3,  -25, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -3,  -12, 	 -10,  -18, 	  -5,  -11, 	  -2,  -14
+.2byte   -3,  -12, 	   4,  -27, 	   6,  -22, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -2,  -12, 	 -12,  -16, 	  -1,   -7, 	  -2,  -14
+.2byte   -1,  -12, 	   0,  -28, 	   9,  -26, 	   1,  -15
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    0,  -12, 	 -12,  -10, 	  12,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -5,  -28, 	   5,  -28, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    2,  -12, 	  12,  -16, 	   1,   -7, 	   2,  -14
+.2byte    2,  -12, 	   1,  -28, 	  -8,  -26, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    3,  -12, 	  10,  -18, 	   5,  -11, 	   2,  -14
+.2byte    3,  -12, 	  -4,  -27, 	  -6,  -22, 	   0,  -14
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -13, 	  -1,  -22, 	  12,  -14, 	   0,  -15
+.2byte    3,  -13, 	  -4,  -29, 	   3,  -25, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    0,  -16, 	  12,  -17, 	 -12,  -17, 	   0,  -15
+.2byte    0,  -16, 	   4,  -27, 	  -5,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -13, 	   1,  -22, 	 -12,  -14, 	   0,  -15
+.2byte   -3,  -13, 	   4,  -29, 	  -3,  -25, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -3,  -12, 	 -10,  -18, 	  -5,  -11, 	  -2,  -14
+.2byte   -3,  -12, 	   4,  -27, 	   6,  -22, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -2,  -12, 	 -12,  -16, 	  -1,   -7, 	  -2,  -14
+.2byte   -1,  -12, 	   0,  -28, 	   9,  -26, 	   1,  -15
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    0,  -12, 	 -12,  -10, 	  12,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -5,  -28, 	   5,  -28, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    2,  -12, 	  12,  -16, 	   1,   -7, 	   2,  -14
+.2byte    2,  -12, 	   1,  -28, 	  -8,  -26, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    3,  -12, 	  10,  -18, 	   5,  -11, 	   2,  -14
+.2byte    3,  -12, 	  -4,  -27, 	  -6,  -22, 	   0,  -14
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -13, 	  -1,  -22, 	  12,  -14, 	   0,  -15
+.2byte    3,  -13, 	  -4,  -29, 	   3,  -25, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    0,  -16, 	  12,  -17, 	 -12,  -17, 	   0,  -15
+.2byte    0,  -16, 	   4,  -27, 	  -5,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -13, 	   1,  -22, 	 -12,  -14, 	   0,  -15
+.2byte   -3,  -13, 	   4,  -29, 	  -3,  -25, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -3,  -12, 	 -10,  -18, 	  -5,  -11, 	  -2,  -14
+.2byte   -3,  -12, 	   4,  -27, 	   6,  -22, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -2,  -12, 	 -12,  -16, 	  -1,   -7, 	  -2,  -14
+.2byte   -1,  -12, 	   0,  -28, 	   9,  -26, 	   1,  -15
+.2byte    0,   -6, 	 -11,   -3, 	  11,   -3, 	   0,   -7
+.2byte    0,   -5, 	 -12,   -3, 	  12,   -3, 	   0,   -6
+.2byte    0,  -14, 	   4,  -17, 	  -6,  -17, 	   0,  -15
+.2byte    1,  -13, 	   0,  -17, 	   5,  -19, 	   0,  -15
+.2byte    1,  -12, 	   1,  -17, 	   3,  -19, 	  -1,  -14
+.2byte    0,  -12, 	   3,  -16, 	  -1,  -18, 	  -2,  -12
+.2byte    0,  -13, 	  -4,  -13, 	   5,  -15, 	   0,  -12
+.2byte   -1,  -12, 	  -4,  -16, 	   0,  -18, 	   1,  -12
+.2byte   -2,  -12, 	  -2,  -17, 	  -4,  -19, 	   0,  -14
+.2byte   -2,  -13, 	  -1,  -17, 	  -6,  -19, 	  -1,  -15
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    0,  -12, 	 -12,  -10, 	  12,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -5,  -28, 	   5,  -28, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    2,  -12, 	  12,  -16, 	   1,   -7, 	   2,  -14
+.2byte    2,  -12, 	   1,  -28, 	  -8,  -26, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    3,  -12, 	  10,  -18, 	   5,  -11, 	   2,  -14
+.2byte    3,  -12, 	  -4,  -27, 	  -6,  -22, 	   0,  -14
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -13, 	  -1,  -22, 	  12,  -14, 	   0,  -15
+.2byte    3,  -13, 	  -4,  -29, 	   3,  -25, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    0,  -16, 	  12,  -17, 	 -12,  -17, 	   0,  -15
+.2byte    0,  -16, 	   4,  -27, 	  -5,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -13, 	   1,  -22, 	 -12,  -14, 	   0,  -15
+.2byte   -3,  -13, 	   4,  -29, 	  -3,  -25, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -3,  -12, 	 -10,  -18, 	  -5,  -11, 	  -2,  -14
+.2byte   -3,  -12, 	   4,  -27, 	   6,  -22, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -2,  -12, 	 -12,  -16, 	  -1,   -7, 	  -2,  -14
+.2byte   -1,  -12, 	   0,  -28, 	   9,  -26, 	   1,  -15
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte    0,  -12, 	 -12,  -10, 	  12,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -5,  -28, 	   5,  -28, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    2,  -12, 	  12,  -16, 	   1,   -7, 	   2,  -14
+.2byte    2,  -12, 	   1,  -28, 	  -8,  -26, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    3,  -12, 	  10,  -18, 	   5,  -11, 	   2,  -14
+.2byte    3,  -12, 	  -4,  -27, 	  -6,  -22, 	   0,  -14
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -13, 	  -1,  -22, 	  12,  -14, 	   0,  -15
+.2byte    3,  -13, 	  -4,  -29, 	   3,  -25, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    0,  -16, 	  12,  -17, 	 -12,  -17, 	   0,  -15
+.2byte    0,  -16, 	   4,  -27, 	  -5,  -27, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte   -3,  -13, 	   1,  -22, 	 -12,  -14, 	   0,  -15
+.2byte   -3,  -13, 	   4,  -29, 	  -3,  -25, 	   0,  -15
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -3,  -12, 	 -10,  -18, 	  -5,  -11, 	  -2,  -14
+.2byte   -3,  -12, 	   4,  -27, 	   6,  -22, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -2,  -12, 	 -12,  -16, 	  -1,   -7, 	  -2,  -14
+.2byte   -1,  -12, 	   0,  -28, 	   9,  -26, 	   1,  -15
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+.2byte    0,  -12, 	 -10,  -27, 	  10,  -27, 	   0,  -14
+.2byte   -1,  -12, 	  -3,  -26, 	  12,  -23, 	   1,  -14
+.2byte   -3,  -12, 	   4,  -28, 	   7,  -21, 	   0,  -15
+.2byte   -2,  -13, 	   8,  -28, 	  -5,  -21, 	   0,  -15
+.2byte    0,  -16, 	  10,  -27, 	 -10,  -27, 	   0,  -15
+.2byte    2,  -13, 	  -8,  -28, 	   5,  -21, 	   0,  -15
+.2byte    3,  -12, 	  -4,  -28, 	  -7,  -21, 	   0,  -15
+.2byte    2,  -12, 	   4,  -26, 	 -11,  -23, 	   0,  -14
+sGolbatAnimTable1:
+.4byte sGolbatAnims_1_1
+.4byte sGolbatAnims_1_2
+.4byte sGolbatAnims_1_3
+.4byte sGolbatAnims_1_4
+.4byte sGolbatAnims_1_5
+.4byte sGolbatAnims_1_6
+.4byte sGolbatAnims_1_7
+.4byte sGolbatAnims_1_8
+sGolbatAnimTable2:
+.4byte sGolbatAnims_2_1
+.4byte sGolbatAnims_2_2
+.4byte sGolbatAnims_2_3
+.4byte sGolbatAnims_2_4
+.4byte sGolbatAnims_2_5
+.4byte sGolbatAnims_2_6
+.4byte sGolbatAnims_2_7
+.4byte sGolbatAnims_2_8
+sGolbatAnimTable3:
+.4byte sGolbatAnims_3_1
+.4byte sGolbatAnims_3_2
+.4byte sGolbatAnims_3_3
+.4byte sGolbatAnims_3_4
+.4byte sGolbatAnims_3_5
+.4byte sGolbatAnims_3_6
+.4byte sGolbatAnims_3_7
+.4byte sGolbatAnims_3_8
+sGolbatAnimTable4:
+.4byte sGolbatAnims_4_1
+.4byte sGolbatAnims_4_2
+.4byte sGolbatAnims_4_3
+.4byte sGolbatAnims_4_4
+.4byte sGolbatAnims_4_5
+.4byte sGolbatAnims_4_6
+.4byte sGolbatAnims_4_7
+.4byte sGolbatAnims_4_8
+sGolbatAnimTable5:
+.4byte sGolbatAnims_5_1
+.4byte sGolbatAnims_5_2
+.4byte sGolbatAnims_5_3
+.4byte sGolbatAnims_5_4
+.4byte sGolbatAnims_5_5
+.4byte sGolbatAnims_5_6
+.4byte sGolbatAnims_5_7
+.4byte sGolbatAnims_5_8
+sGolbatAnimTable6:
+.4byte sGolbatAnims_6_1
+.4byte sGolbatAnims_6_1
+.4byte sGolbatAnims_6_1
+.4byte sGolbatAnims_6_1
+.4byte sGolbatAnims_6_1
+.4byte sGolbatAnims_6_1
+.4byte sGolbatAnims_6_1
+.4byte sGolbatAnims_6_1
+sGolbatAnimTable7:
+.4byte sGolbatAnims_7_1
+.4byte sGolbatAnims_7_2
+.4byte sGolbatAnims_7_3
+.4byte sGolbatAnims_7_4
+.4byte sGolbatAnims_7_5
+.4byte sGolbatAnims_7_6
+.4byte sGolbatAnims_7_7
+.4byte sGolbatAnims_7_8
+sGolbatAnimTable8:
+.4byte sGolbatAnims_8_1
+.4byte sGolbatAnims_8_2
+.4byte sGolbatAnims_8_3
+.4byte sGolbatAnims_8_4
+.4byte sGolbatAnims_8_5
+.4byte sGolbatAnims_8_6
+.4byte sGolbatAnims_8_7
+.4byte sGolbatAnims_8_8
+sGolbatAnimTable9:
+.4byte sGolbatAnims_9_1
+.4byte sGolbatAnims_9_2
+.4byte sGolbatAnims_9_3
+.4byte sGolbatAnims_9_4
+.4byte sGolbatAnims_9_5
+.4byte sGolbatAnims_9_6
+.4byte sGolbatAnims_9_7
+.4byte sGolbatAnims_9_8
+sGolbatAnimTable10:
+.4byte sGolbatAnims_10_1
+.4byte sGolbatAnims_10_2
+.4byte sGolbatAnims_10_3
+.4byte sGolbatAnims_10_4
+.4byte sGolbatAnims_10_5
+.4byte sGolbatAnims_10_6
+.4byte sGolbatAnims_10_7
+.4byte sGolbatAnims_10_8
+sGolbatAnimTable11:
+.4byte sGolbatAnims_11_1
+.4byte sGolbatAnims_11_2
+.4byte sGolbatAnims_11_3
+.4byte sGolbatAnims_11_4
+.4byte sGolbatAnims_11_5
+.4byte sGolbatAnims_11_6
+.4byte sGolbatAnims_11_7
+.4byte sGolbatAnims_11_8
+sGolbatAnimTable12:
+.4byte sGolbatAnims_12_1
+.4byte sGolbatAnims_12_2
+.4byte sGolbatAnims_12_3
+.4byte sGolbatAnims_12_4
+.4byte sGolbatAnims_12_5
+.4byte sGolbatAnims_12_6
+.4byte sGolbatAnims_12_7
+.4byte sGolbatAnims_12_8
+sGolbatAnimTable13:
+.4byte sGolbatAnims_13_1
+.4byte sGolbatAnims_13_2
+.4byte sGolbatAnims_13_3
+.4byte sGolbatAnims_13_4
+.4byte sGolbatAnims_13_5
+.4byte sGolbatAnims_13_6
+.4byte sGolbatAnims_13_7
+.4byte sGolbatAnims_13_8
+sAxAnimationsGolbat:
+.4byte sGolbatAnimTable1
+.4byte sGolbatAnimTable2
+.4byte sGolbatAnimTable3
+.4byte sGolbatAnimTable4
+.4byte sGolbatAnimTable5
+.4byte sGolbatAnimTable6
+.4byte sGolbatAnimTable7
+.4byte sGolbatAnimTable8
+.4byte sGolbatAnimTable9
+.4byte sGolbatAnimTable10
+.4byte sGolbatAnimTable11
+.4byte sGolbatAnimTable12
+.4byte sGolbatAnimTable13
+sAxSpritesGolbat:
+.4byte sGolbatSprites1
+.4byte sGolbatSprites2
+.4byte sGolbatSprites3
+.4byte sGolbatSprites4
+.4byte sGolbatSprites5
+.4byte sGolbatSprites6
+.4byte sGolbatSprites7
+.4byte sGolbatSprites8
+.4byte sGolbatSprites9
+.4byte sGolbatSprites10
+.4byte sGolbatSprites11
+.4byte sGolbatSprites12
+.4byte sGolbatSprites13
+.4byte sGolbatSprites14
+.4byte sGolbatSprites15
+.4byte sGolbatSprites16
+.4byte sGolbatSprites17
+.4byte sGolbatSprites18
+.4byte sGolbatSprites19
+.4byte sGolbatSprites20
+.4byte sGolbatSprites21
+.4byte sGolbatSprites22
+sAxMainGolbat:
+ax_main sAxPosesGolbat, sAxAnimationsGolbat, 13, sAxSpritesGolbat, sAxPositionsGolbat

--- a/data/ax/goldeen.inc
+++ b/data/ax/goldeen.inc
@@ -1,0 +1,3035 @@
+.global gAxGoldeen
+gAxGoldeen:
+ax_siro sAxMainGoldeen
+sGoldeenPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose4:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose5:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose6:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose7:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose8:
+ax_pose 7, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose9:
+ax_pose 8, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose10:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose12:
+ax_pose 11, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose19:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose20:
+ax_pose 7, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose21:
+ax_pose 8, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose22:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose23:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose24:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose28:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose29:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose30:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose31:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose32:
+ax_pose 7, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose33:
+ax_pose 8, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose34:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose35:
+ax_pose 10, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose36:
+ax_pose 11, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose41:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose43:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose44:
+ax_pose 7, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose45:
+ax_pose 8, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose46:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose47:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose48:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose50:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose51:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose52:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose53:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose54:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose55:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose56:
+ax_pose 7, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose57:
+ax_pose 8, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose58:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose59:
+ax_pose 10, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose60:
+ax_pose 11, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose61:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose62:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose63:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose64:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose65:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose66:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose67:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose68:
+ax_pose 7, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose69:
+ax_pose 8, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose70:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose71:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose72:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose73:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose74:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose75:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose76:
+ax_pose 15, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose77:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose78:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose79:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose80:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose81:
+ax_pose 17, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose82:
+ax_pose 18, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose83:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose84:
+ax_pose 7, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose85:
+ax_pose 8, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose86:
+ax_pose 19, 0x01e9, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose87:
+ax_pose 20, 0x41f2, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose88:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose89:
+ax_pose 10, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose90:
+ax_pose 11, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose91:
+ax_pose 21, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sGoldeenPose92:
+ax_pose 22, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sGoldeenPose93:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose94:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose95:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose96:
+ax_pose 23, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose97:
+ax_pose 24, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose98:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose99:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose100:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose101:
+ax_pose 21, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose102:
+ax_pose 22, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose103:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose104:
+ax_pose 7, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose105:
+ax_pose 8, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose106:
+ax_pose 19, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose107:
+ax_pose 20, 0x41f2, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose108:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose109:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose110:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose111:
+ax_pose 17, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose112:
+ax_pose 18, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose113:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose114:
+ax_pose 15, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose115:
+ax_pose 25, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose116:
+ax_pose 26, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose117:
+ax_pose 27, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose118:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose119:
+ax_pose 17, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose120:
+ax_pose 28, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose121:
+ax_pose 29, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose122:
+ax_pose 30, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose123:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose124:
+ax_pose 19, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose125:
+ax_pose 31, 0x81e7, 0x90f9, 0x0c00
+ax_pose_terminator
+sGoldeenPose126:
+ax_pose 32, 0x81e7, 0x90f9, 0x0c00
+ax_pose_terminator
+sGoldeenPose127:
+ax_pose 33, 0x81e7, 0x90f9, 0x0c00
+ax_pose_terminator
+sGoldeenPose128:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose129:
+ax_pose 21, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose130:
+ax_pose 34, 0x81e8, 0x90fb, 0x0c00
+ax_pose_terminator
+sGoldeenPose131:
+ax_pose 35, 0x81e7, 0x90fb, 0x0c00
+ax_pose_terminator
+sGoldeenPose132:
+ax_pose 36, 0x81e8, 0x90fa, 0x0c00
+ax_pose_terminator
+sGoldeenPose133:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose134:
+ax_pose 23, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose135:
+ax_pose 37, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose136:
+ax_pose 38, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose137:
+ax_pose 39, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose138:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose139:
+ax_pose 21, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose140:
+ax_pose 34, 0x81e8, 0x80f6, 0x0c00
+ax_pose_terminator
+sGoldeenPose141:
+ax_pose 35, 0x81e7, 0x80f6, 0x0c00
+ax_pose_terminator
+sGoldeenPose142:
+ax_pose 36, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sGoldeenPose143:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose144:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose145:
+ax_pose 31, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sGoldeenPose146:
+ax_pose 32, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sGoldeenPose147:
+ax_pose 33, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sGoldeenPose148:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose149:
+ax_pose 17, 0x01ea, 0x80ef, 0x0c00
+ax_pose_terminator
+sGoldeenPose150:
+ax_pose 28, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose151:
+ax_pose 29, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose152:
+ax_pose 30, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose153:
+ax_pose 40, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose154:
+ax_pose 41, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose155:
+ax_pose 42, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose156:
+ax_pose 43, 0x01e3, 0x90ec, 0x0c00
+ax_pose_terminator
+sGoldeenPose157:
+ax_pose 44, 0x01e4, 0x90ec, 0x0c00
+ax_pose_terminator
+sGoldeenPose158:
+ax_pose 45, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sGoldeenPose159:
+ax_pose 46, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose160:
+ax_pose 45, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sGoldeenPose161:
+ax_pose 44, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose162:
+ax_pose 43, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose163:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose164:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose165:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose166:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose167:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose168:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose169:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose170:
+ax_pose 7, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose171:
+ax_pose 8, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose172:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose173:
+ax_pose 10, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose174:
+ax_pose 11, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose175:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose176:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose177:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose178:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose179:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose180:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose181:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose182:
+ax_pose 7, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose183:
+ax_pose 8, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose184:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose185:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose186:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose187:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose188:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose189:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose190:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose191:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose192:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose193:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose194:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose195:
+ax_pose 25, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose196:
+ax_pose 28, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose197:
+ax_pose 31, 0x81e7, 0x90f9, 0x0c00
+ax_pose_terminator
+sGoldeenPose198:
+ax_pose 34, 0x81e7, 0x90f9, 0x0c00
+ax_pose_terminator
+sGoldeenPose199:
+ax_pose 37, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose200:
+ax_pose 34, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sGoldeenPose201:
+ax_pose 31, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sGoldeenPose202:
+ax_pose 28, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sGoldeenPose203:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose204:
+ax_pose 15, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose205:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose206:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose207:
+ax_pose 17, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose208:
+ax_pose 18, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose209:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose210:
+ax_pose 19, 0x01e9, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose211:
+ax_pose 20, 0x41f2, 0x90ef, 0x0c00
+ax_pose_terminator
+sGoldeenPose212:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose213:
+ax_pose 21, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sGoldeenPose214:
+ax_pose 22, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sGoldeenPose215:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose216:
+ax_pose 23, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose217:
+ax_pose 24, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose218:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose219:
+ax_pose 21, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose220:
+ax_pose 22, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose221:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose222:
+ax_pose 19, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose223:
+ax_pose 20, 0x41f2, 0x80f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose224:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose225:
+ax_pose 17, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose226:
+ax_pose 18, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose227:
+ax_pose 15, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose228:
+ax_pose 17, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose229:
+ax_pose 19, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose230:
+ax_pose 21, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sGoldeenPose231:
+ax_pose 23, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sGoldeenPose232:
+ax_pose 21, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sGoldeenPose233:
+ax_pose 19, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose234:
+ax_pose 17, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sGoldeenPose235:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose236:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sGoldeenPose237:
+ax_pose 6, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose238:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose239:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sGoldeenPose240:
+ax_pose 9, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose241:
+ax_pose 6, 0x41f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sGoldeenPose242:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sGoldeenAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, -1, 0, 0,
+ax_anim 10, 0, 0, 0, -2, 0, 0,
+ax_anim 10, 0, 2, 0, -3, 0, 0,
+ax_anim 10, 0, 0, 0, -3, 0, 0,
+ax_anim 10, 0, 1, 0, -2, 0, 0,
+ax_anim 10, 0, 0, 0, -1, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, -1, 0, 0,
+ax_anim 10, 0, 3, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -3, 0, 0,
+ax_anim 10, 0, 3, 0, -3, 0, 0,
+ax_anim 10, 0, 4, 0, -2, 0, 0,
+ax_anim 10, 0, 3, 0, -1, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, -1, 0, 0,
+ax_anim 10, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -3, 0, 0,
+ax_anim 10, 0, 6, 0, -3, 0, 0,
+ax_anim 10, 0, 7, 0, -2, 0, 0,
+ax_anim 10, 0, 6, 0, -1, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, -1, 0, 0,
+ax_anim 10, 0, 9, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -3, 0, 0,
+ax_anim 10, 0, 9, 0, -3, 0, 0,
+ax_anim 10, 0, 10, 0, -2, 0, 0,
+ax_anim 10, 0, 9, 0, -1, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, -1, 0, 0,
+ax_anim 10, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -3, 0, 0,
+ax_anim 10, 0, 12, 0, -3, 0, 0,
+ax_anim 10, 0, 13, 0, -2, 0, 0,
+ax_anim 10, 0, 12, 0, -1, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, -1, 0, 0,
+ax_anim 10, 0, 15, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -3, 0, 0,
+ax_anim 10, 0, 15, 0, -3, 0, 0,
+ax_anim 10, 0, 16, 0, -2, 0, 0,
+ax_anim 10, 0, 15, 0, -1, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, -1, 0, 0,
+ax_anim 10, 0, 18, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -3, 0, 0,
+ax_anim 10, 0, 18, 0, -3, 0, 0,
+ax_anim 10, 0, 19, 0, -2, 0, 0,
+ax_anim 10, 0, 18, 0, -1, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, -1, 0, 0,
+ax_anim 10, 0, 21, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -3, 0, 0,
+ax_anim 10, 0, 21, 0, -3, 0, 0,
+ax_anim 10, 0, 22, 0, -2, 0, 0,
+ax_anim 10, 0, 21, 0, -1, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGoldeenAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 9, 11, 9, 11,
+ax_anim 2, 0, 27, 17, 20, 17, 20,
+ax_anim 2, 1, 27, 15, 18, 15, 18,
+ax_anim 2, 0, 27, 17, 20, 17, 20,
+ax_anim 2, 0, 27, 15, 18, 15, 18,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sGoldeenAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 9, 0, 9, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 16, 0, 16, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 16, 0, 16, 0,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sGoldeenAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, -4, 4, -4,
+ax_anim 1, 0, 34, 10, -11, 10, -11,
+ax_anim 2, 0, 33, 19, -20, 19, -20,
+ax_anim 2, 1, 33, 17, -18, 17, -18,
+ax_anim 2, 0, 33, 19, -20, 19, -20,
+ax_anim 2, 0, 33, 17, -18, 17, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sGoldeenAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -10, 0, -10,
+ax_anim 2, 0, 36, 0, -20, 0, -20,
+ax_anim 2, 1, 36, 0, -18, 0, -18,
+ax_anim 2, 0, 36, 0, -20, 0, -20,
+ax_anim 2, 0, 36, 0, -18, 0, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sGoldeenAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -4, -4, -4, -4,
+ax_anim 1, 0, 40, -10, -11, -10, -11,
+ax_anim 2, 0, 39, -19, -20, -19, -20,
+ax_anim 2, 1, 39, -17, -18, -17, -18,
+ax_anim 2, 0, 39, -19, -20, -19, -20,
+ax_anim 2, 0, 39, -17, -18, -17, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sGoldeenAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -9, 0, -9, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -16, 0, -16, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -16, 0, -16, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sGoldeenAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -9, 11, -9, 11,
+ax_anim 2, 0, 45, -17, 20, -17, 20,
+ax_anim 2, 1, 45, -15, 18, -15, 18,
+ax_anim 2, 0, 45, -17, 20, -17, 20,
+ax_anim 2, 0, 45, -15, 18, -15, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sGoldeenAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 9, 11, 9, 11,
+ax_anim 2, 0, 51, 17, 20, 17, 20,
+ax_anim 2, 1, 51, 15, 18, 15, 18,
+ax_anim 2, 0, 51, 17, 20, 17, 20,
+ax_anim 2, 0, 51, 15, 18, 15, 18,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sGoldeenAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 9, 0, 9, 0,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 1, 54, 16, 0, 16, 0,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 0, 54, 16, 0, 16, 0,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sGoldeenAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 4, -4, 4, -4,
+ax_anim 1, 0, 58, 10, -11, 10, -11,
+ax_anim 2, 0, 57, 19, -20, 19, -20,
+ax_anim 2, 1, 57, 17, -18, 17, -18,
+ax_anim 2, 0, 57, 19, -20, 19, -20,
+ax_anim 2, 0, 57, 17, -18, 17, -18,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sGoldeenAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -10, 0, -10,
+ax_anim 2, 0, 60, 0, -20, 0, -20,
+ax_anim 2, 1, 60, 0, -18, 0, -18,
+ax_anim 2, 0, 60, 0, -20, 0, -20,
+ax_anim 2, 0, 60, 0, -18, 0, -18,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sGoldeenAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 65, -4, -4, -4, -4,
+ax_anim 1, 0, 64, -10, -11, -10, -11,
+ax_anim 2, 0, 63, -19, -20, -19, -20,
+ax_anim 2, 1, 63, -17, -18, -17, -18,
+ax_anim 2, 0, 63, -19, -20, -19, -20,
+ax_anim 2, 0, 63, -17, -18, -17, -18,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sGoldeenAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -9, 0, -9, 0,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 1, 66, -16, 0, -16, 0,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -16, 0, -16, 0,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sGoldeenAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -9, 11, -9, 11,
+ax_anim 2, 0, 69, -17, 20, -17, 20,
+ax_anim 2, 1, 69, -15, 18, -15, 18,
+ax_anim 2, 0, 69, -17, 20, -17, 20,
+ax_anim 2, 0, 69, -15, 18, -15, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 75, 0, -2, 0, -2,
+ax_anim 6, 2, 75, 0, -3, 0, -3,
+ax_anim 1, 0, 72, 0, -1, 0, -1,
+ax_anim 1, 0, 76, 0, 2, 0, 2,
+ax_anim 2, 1, 76, 0, 3, 0, 3,
+ax_anim 2, 0, 76, -1, 3, -1, 3,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 2, 0, 76, -1, 3, -1, 3,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 2, 0, 76, -1, 3, -1, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sGoldeenAnims_4_2:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 80, -2, -2, -2, -2,
+ax_anim 6, 2, 80, -3, -3, -3, -3,
+ax_anim 1, 0, 77, -1, -1, -1, -1,
+ax_anim 1, 0, 81, 2, 2, 2, 2,
+ax_anim 2, 1, 81, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 4, 2, 4, 2,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 4, 2, 4, 2,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 4, 2, 4, 2,
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim_terminator
+sGoldeenAnims_4_3:
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 2, 0, 85, -2, 0, -2, 0,
+ax_anim 6, 2, 85, -3, 0, -3, 0,
+ax_anim 1, 0, 82, -1, 0, -1, 0,
+ax_anim 1, 0, 86, 2, 0, 2, 0,
+ax_anim 2, 1, 86, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 3, 1, 3, 1,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 3, 1, 3, 1,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 3, 1, 3, 1,
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim_terminator
+sGoldeenAnims_4_4:
+ax_anim 2, 0, 87, -1, 1, -1, 1,
+ax_anim 2, 0, 90, -2, 2, -2, 2,
+ax_anim 6, 2, 90, -3, 3, -3, 3,
+ax_anim 1, 0, 87, -1, 1, -1, 1,
+ax_anim 1, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 1, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 2, -4, 2, -4,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 2, -4, 2, -4,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 2, -4, 2, -4,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim_terminator
+sGoldeenAnims_4_5:
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 2, 0, 95, 0, 2, 0, 2,
+ax_anim 6, 2, 95, 0, 3, 0, 3,
+ax_anim 1, 0, 92, 0, 1, 0, 1,
+ax_anim 1, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 1, 96, 0, -3, 0, -3,
+ax_anim 2, 0, 96, -1, -3, -1, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 2, 0, 96, -1, -3, -1, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 2, 0, 96, -1, -3, -1, -3,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim_terminator
+sGoldeenAnims_4_6:
+ax_anim 2, 0, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 100, 2, 2, 2, 2,
+ax_anim 6, 2, 100, 3, 3, 3, 3,
+ax_anim 1, 0, 97, 1, 1, 1, 1,
+ax_anim 1, 0, 101, -2, -2, -2, -2,
+ax_anim 2, 1, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim_terminator
+sGoldeenAnims_4_7:
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 2, 0, 2, 0,
+ax_anim 6, 2, 105, 3, 0, 3, 0,
+ax_anim 1, 0, 102, 1, 0, 1, 0,
+ax_anim 1, 0, 106, -2, 0, -2, 0,
+ax_anim 2, 1, 106, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -3, 1, -3, 1,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -3, 1, -3, 1,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -3, 1, -3, 1,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim_terminator
+sGoldeenAnims_4_8:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 107, 1, -1, 1, -1,
+ax_anim 1, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 1, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 107, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_5_1:
+ax_anim 1, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim 2, 0, 113, 0, 2, 0, 2,
+ax_anim 2, 0, 114, 0, 2, 0, 2,
+ax_anim 3, 0, 115, 0, 1, 0, 2,
+ax_anim 3, 2, 114, 0, 0, 0, 2,
+ax_anim 3, 0, 116, 0, -1, 0, 2,
+ax_anim 3, 0, 114, 0, -2, 0, 2,
+ax_anim 3, 0, 115, 0, -3, 0, 2,
+ax_anim 3, 0, 114, 0, -3, 0, 2,
+ax_anim 3, 0, 116, 0, -2, 0, 2,
+ax_anim 2, 0, 113, 0, -1, 0, 1,
+ax_anim_terminator
+sGoldeenAnims_5_2:
+ax_anim 1, 0, 117, 1, 1, 1, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 118, 2, 2, 2, 2,
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 3, 0, 120, 2, 1, 2, 2,
+ax_anim 3, 2, 119, 2, 0, 2, 2,
+ax_anim 3, 0, 121, 2, -1, 2, 2,
+ax_anim 3, 0, 119, 2, -2, 2, 2,
+ax_anim 3, 0, 120, 2, -3, 2, 2,
+ax_anim 3, 0, 119, 2, -3, 2, 2,
+ax_anim 3, 0, 121, 2, -2, 2, 2,
+ax_anim 2, 0, 118, 1, -1, 1, 1,
+ax_anim_terminator
+sGoldeenAnims_5_3:
+ax_anim 1, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 6, 0, 6, 0,
+ax_anim 3, 0, 125, 6, -1, 6, 0,
+ax_anim 3, 2, 124, 6, -2, 6, 0,
+ax_anim 3, 0, 126, 6, -3, 6, 0,
+ax_anim 3, 0, 124, 6, -4, 6, 0,
+ax_anim 3, 0, 125, 6, -5, 6, 0,
+ax_anim 3, 0, 124, 6, -5, 6, 0,
+ax_anim 3, 0, 126, 6, -4, 6, 0,
+ax_anim 2, 0, 123, 3, -3, 2, 0,
+ax_anim_terminator
+sGoldeenAnims_5_4:
+ax_anim 1, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 128, 3, -3, 2, -2,
+ax_anim 2, 0, 129, 3, -4, 2, -2,
+ax_anim 3, 0, 130, 3, -4, 2, -2,
+ax_anim 3, 2, 129, 3, -5, 2, -2,
+ax_anim 3, 0, 131, 3, -6, 2, -2,
+ax_anim 3, 0, 129, 3, -7, 2, -2,
+ax_anim 3, 0, 130, 3, -8, 2, -2,
+ax_anim 3, 0, 129, 3, -8, 2, -2,
+ax_anim 3, 0, 131, 3, -7, 2, -2,
+ax_anim 2, 0, 128, 1, -3, 1, -1,
+ax_anim_terminator
+sGoldeenAnims_5_5:
+ax_anim 1, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, -2, 0, -2,
+ax_anim 2, 0, 133, 0, -2, 0, -2,
+ax_anim 2, 0, 134, 0, -2, 0, -2,
+ax_anim 3, 0, 135, 0, -3, 0, -2,
+ax_anim 3, 2, 134, 0, -4, 0, -2,
+ax_anim 3, 0, 136, 0, -5, 0, -2,
+ax_anim 3, 0, 134, 0, -6, 0, -2,
+ax_anim 3, 0, 135, 0, -7, 0, -2,
+ax_anim 3, 0, 134, 0, -7, 0, -2,
+ax_anim 3, 0, 136, 0, -6, 0, -2,
+ax_anim 2, 0, 133, 0, -5, 0, -1,
+ax_anim_terminator
+sGoldeenAnims_5_6:
+ax_anim 1, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, -2, -2, -2, -2,
+ax_anim 2, 0, 138, -3, -3, -2, -2,
+ax_anim 2, 0, 139, -3, -4, -2, -2,
+ax_anim 3, 0, 140, -3, -4, -2, -2,
+ax_anim 3, 2, 139, -3, -5, -2, -2,
+ax_anim 3, 0, 141, -3, -6, -2, -2,
+ax_anim 3, 0, 139, -3, -7, -2, -2,
+ax_anim 3, 0, 140, -3, -8, -2, -2,
+ax_anim 3, 0, 139, -3, -8, -2, -2,
+ax_anim 3, 0, 141, -3, -7, -2, -2,
+ax_anim 2, 0, 138, -1, -3, -1, -1,
+ax_anim_terminator
+sGoldeenAnims_5_7:
+ax_anim 1, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 0, 142, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -3, 0, -3, 0,
+ax_anim 2, 0, 144, -6, 0, -6, 0,
+ax_anim 3, 0, 145, -6, -1, -6, 0,
+ax_anim 3, 2, 144, -6, -2, -6, 0,
+ax_anim 3, 0, 146, -6, -3, -6, 0,
+ax_anim 3, 0, 144, -6, -4, -6, 0,
+ax_anim 3, 0, 145, -6, -5, -6, 0,
+ax_anim 3, 0, 144, -6, -5, -6, 0,
+ax_anim 3, 0, 146, -6, -4, -6, 0,
+ax_anim 2, 0, 143, -3, -3, -2, 0,
+ax_anim_terminator
+sGoldeenAnims_5_8:
+ax_anim 1, 0, 147, -1, 1, -1, 1,
+ax_anim 2, 0, 147, -2, 2, -2, 2,
+ax_anim 2, 0, 148, -2, 2, -2, 2,
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 3, 0, 150, -2, 1, -2, 2,
+ax_anim 3, 2, 149, -2, 0, -2, 2,
+ax_anim 3, 0, 151, -2, -1, -2, 2,
+ax_anim 3, 0, 149, -2, -2, -2, 2,
+ax_anim 3, 0, 150, -2, -3, -2, 2,
+ax_anim 3, 0, 149, -2, -3, -2, 2,
+ax_anim 3, 0, 151, -2, -2, -2, 2,
+ax_anim 2, 0, 148, -1, -1, -1, 1,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_6_1:
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, -1, 0, 0,
+ax_anim 10, 0, 153, 0, -1, 0, 0,
+ax_anim 10, 0, 153, 0, -1, 0, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sGoldeenAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sGoldeenAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sGoldeenAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sGoldeenAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sGoldeenAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sGoldeenAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sGoldeenAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_8_1:
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, -1, 0, 0,
+ax_anim 16, 0, 162, 0, -2, 0, 0,
+ax_anim 10, 0, 162, 0, -1, 0, 0,
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, -1, 0, 0,
+ax_anim 16, 0, 162, 0, -2, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, 0,
+ax_anim 4, 0, 163, 0, -1, 0, 0,
+ax_anim 4, 0, 162, 0, -1, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, -1, 0, 0,
+ax_anim 16, 0, 162, 0, -2, 0, 0,
+ax_anim 10, 0, 162, 0, -1, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_8_2:
+ax_anim 16, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim 16, 0, 165, 0, -2, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim 16, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim 16, 0, 165, 0, -2, 0, 0,
+ax_anim 2, 0, 165, 0, -1, 0, 0,
+ax_anim 4, 0, 166, 0, -1, 0, 0,
+ax_anim 4, 0, 165, 0, -1, 0, 0,
+ax_anim 4, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim 16, 0, 165, 0, -2, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_8_3:
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, -1, 0, 0,
+ax_anim 16, 0, 168, 0, -2, 0, 0,
+ax_anim 10, 0, 168, 0, -1, 0, 0,
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, -1, 0, 0,
+ax_anim 16, 0, 168, 0, -2, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, 0,
+ax_anim 4, 0, 169, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, -1, 0, 0,
+ax_anim 4, 0, 170, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, -1, 0, 0,
+ax_anim 16, 0, 168, 0, -2, 0, 0,
+ax_anim 10, 0, 168, 0, -1, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_8_4:
+ax_anim 16, 0, 171, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim 16, 0, 171, 0, -2, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim 16, 0, 171, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim 16, 0, 171, 0, -2, 0, 0,
+ax_anim 2, 0, 171, 0, -1, 0, 0,
+ax_anim 4, 0, 172, 0, -1, 0, 0,
+ax_anim 4, 0, 171, 0, -1, 0, 0,
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim 16, 0, 171, 0, -2, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_8_5:
+ax_anim 16, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, -1, 0, 0,
+ax_anim 16, 0, 174, 0, -2, 0, 0,
+ax_anim 10, 0, 174, 0, -1, 0, 0,
+ax_anim 16, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, -1, 0, 0,
+ax_anim 16, 0, 174, 0, -2, 0, 0,
+ax_anim 2, 0, 174, 0, -1, 0, 0,
+ax_anim 4, 0, 175, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, -1, 0, 0,
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim 12, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, -1, 0, 0,
+ax_anim 16, 0, 174, 0, -2, 0, 0,
+ax_anim 10, 0, 174, 0, -1, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_8_6:
+ax_anim 16, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim 16, 0, 177, 0, -2, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim 16, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim 16, 0, 177, 0, -2, 0, 0,
+ax_anim 2, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 178, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim 16, 0, 177, 0, -2, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_8_7:
+ax_anim 16, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim 16, 0, 180, 0, -2, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim 16, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim 16, 0, 180, 0, -2, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, 0,
+ax_anim 4, 0, 181, 0, -1, 0, 0,
+ax_anim 4, 0, 180, 0, -1, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 12, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim 16, 0, 180, 0, -2, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_8_8:
+ax_anim 16, 0, 183, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim 16, 0, 183, 0, -2, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim 16, 0, 183, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim 16, 0, 183, 0, -2, 0, 0,
+ax_anim 2, 0, 183, 0, -1, 0, 0,
+ax_anim 4, 0, 184, 0, -1, 0, 0,
+ax_anim 4, 0, 183, 0, -1, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 12, 0, 183, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim 16, 0, 183, 0, -2, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 17, 7, 17,
+ax_anim 3, 0, 190, 0, 20, 0, 20,
+ax_anim 2, 3, 191, -7, 17, -7, 17,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 19, 10, 19, 10,
+ax_anim 3, 0, 189, 19, 20, 19, 20,
+ax_anim 2, 3, 190, 11, 20, 11, 20,
+ax_anim 2, 0, 191, 5, 16, 5, 16,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 18, -4, 18, -4,
+ax_anim 3, 0, 188, 19, 1, 19, 1,
+ax_anim 2, 3, 189, 16, 4, 16, 4,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 6, 4, 6, 4,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 2, -16, 2, -16,
+ax_anim 2, 0, 186, 11, -21, 11, -21,
+ax_anim 3, 0, 187, 21, -21, 21, -21,
+ax_anim 2, 3, 188, 20, -15, 20, -15,
+ax_anim 2, 0, 189, 17, -6, 17, -6,
+ax_anim 1, 0, 190, 8, 0, 8, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -22, 0, -22,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 9, -10, 9, -10,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -2, -16, -2, -16,
+ax_anim 2, 0, 186, -11, -21, -11, -21,
+ax_anim 3, 0, 193, -21, -21, -21, -21,
+ax_anim 2, 3, 192, -20, -15, -20, -15,
+ax_anim 2, 0, 191, -17, -6, -17, -6,
+ax_anim 1, 0, 190, -8, 0, -8, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -18, -4, -18, -4,
+ax_anim 3, 0, 192, -19, 1, -19, 1,
+ax_anim 2, 3, 191, -16, 4, -16, 4,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -6, 4, -6, 4,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -19, 10, -19, 10,
+ax_anim 3, 0, 191, -19, 20, -19, 20,
+ax_anim 2, 3, 190, -11, 20, -11, 20,
+ax_anim 2, 0, 189, -5, 16, -5, 16,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 2, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 2, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 2, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 2, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -11, 0, 0,
+ax_anim 2, 2, 214, 0, 4, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 2, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 2, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGoldeenAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sGoldeenGfx1:
+.incbin "baserom.gba", 0xA13C38, 0x200
+sGoldeenSprites1:
+ax_sprite sGoldeenGfx1, 0x200
+ax_sprite_terminator
+sGoldeenGfx2:
+.incbin "baserom.gba", 0xA13E48, 0x200
+sGoldeenSprites2:
+ax_sprite sGoldeenGfx2, 0x200
+ax_sprite_terminator
+sGoldeenGfx3:
+.incbin "baserom.gba", 0xA14058, 0x200
+sGoldeenSprites3:
+ax_sprite sGoldeenGfx3, 0x200
+ax_sprite_terminator
+sGoldeenGfx4:
+.incbin "baserom.gba", 0xA14268, 0x200
+sGoldeenSprites4:
+ax_sprite sGoldeenGfx4, 0x200
+ax_sprite_terminator
+sGoldeenGfx5:
+.incbin "baserom.gba", 0xA14478, 0x200
+sGoldeenSprites5:
+ax_sprite sGoldeenGfx5, 0x200
+ax_sprite_terminator
+sGoldeenGfx6:
+.incbin "baserom.gba", 0xA14688, 0x200
+sGoldeenSprites6:
+ax_sprite sGoldeenGfx6, 0x200
+ax_sprite_terminator
+sGoldeenGfx7:
+.incbin "baserom.gba", 0xA14898, 0x100
+sGoldeenSprites7:
+ax_sprite sGoldeenGfx7, 0x100
+ax_sprite_terminator
+sGoldeenGfx8:
+.incbin "baserom.gba", 0xA149A8, 0x200
+sGoldeenSprites8:
+ax_sprite sGoldeenGfx8, 0x200
+ax_sprite_terminator
+sGoldeenGfx9:
+.incbin "baserom.gba", 0xA14BB8, 0x100
+sGoldeenSprites9:
+ax_sprite sGoldeenGfx9, 0x100
+ax_sprite_terminator
+sGoldeenGfx10:
+.incbin "baserom.gba", 0xA14CC8, 0x200
+sGoldeenSprites10:
+ax_sprite sGoldeenGfx10, 0x200
+ax_sprite_terminator
+sGoldeenGfx11:
+.incbin "baserom.gba", 0xA14ED8, 0x200
+sGoldeenSprites11:
+ax_sprite sGoldeenGfx11, 0x200
+ax_sprite_terminator
+sGoldeenGfx12:
+.incbin "baserom.gba", 0xA150E8, 0x200
+sGoldeenSprites12:
+ax_sprite sGoldeenGfx12, 0x200
+ax_sprite_terminator
+sGoldeenGfx13:
+.incbin "baserom.gba", 0xA152F8, 0x200
+sGoldeenSprites13:
+ax_sprite sGoldeenGfx13, 0x200
+ax_sprite_terminator
+sGoldeenGfx14:
+.incbin "baserom.gba", 0xA15508, 0x200
+sGoldeenSprites14:
+ax_sprite sGoldeenGfx14, 0x200
+ax_sprite_terminator
+sGoldeenGfx15:
+.incbin "baserom.gba", 0xA15718, 0x200
+sGoldeenSprites15:
+ax_sprite sGoldeenGfx15, 0x200
+ax_sprite_terminator
+sGoldeenGfx16:
+.incbin "baserom.gba", 0xA15928, 0x40
+sGoldeenGfx16_1:
+.incbin "baserom.gba", 0xA15968, 0x100
+sGoldeenSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx16_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGoldeenGfx17:
+.incbin "baserom.gba", 0xA15A98, 0x40
+sGoldeenGfx17_1:
+.incbin "baserom.gba", 0xA15AD8, 0x100
+sGoldeenGfx17_2:
+.incbin "baserom.gba", 0xA15BD8, 0x40
+sGoldeenSprites17:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx18:
+.incbin "baserom.gba", 0xA15C58, 0x20
+sGoldeenGfx18_1:
+.incbin "baserom.gba", 0xA15C78, 0x60
+sGoldeenGfx18_2:
+.incbin "baserom.gba", 0xA15CD8, 0x80
+sGoldeenSprites18:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx18_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGoldeenGfx19:
+.incbin "baserom.gba", 0xA15D98, 0x20
+sGoldeenGfx19_1:
+.incbin "baserom.gba", 0xA15DB8, 0x100
+sGoldeenGfx19_2:
+.incbin "baserom.gba", 0xA15EB8, 0x20
+sGoldeenSprites19:
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx19_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx19_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGoldeenGfx20:
+.incbin "baserom.gba", 0xA15F18, 0x40
+sGoldeenGfx20_1:
+.incbin "baserom.gba", 0xA15F58, 0x100
+sGoldeenGfx20_2:
+.incbin "baserom.gba", 0xA16058, 0x20
+sGoldeenSprites20:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx20_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx20_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx21:
+.incbin "baserom.gba", 0xA160B8, 0x100
+sGoldeenSprites21:
+ax_sprite sGoldeenGfx21, 0x100
+ax_sprite_terminator
+sGoldeenGfx22:
+.incbin "baserom.gba", 0xA161C8, 0x40
+sGoldeenGfx22_1:
+.incbin "baserom.gba", 0xA16208, 0x60
+sGoldeenGfx22_2:
+.incbin "baserom.gba", 0xA16268, 0x80
+sGoldeenGfx22_3:
+.incbin "baserom.gba", 0xA162E8, 0x20
+sGoldeenSprites22:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx22_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx22_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx23:
+.incbin "baserom.gba", 0xA16358, 0x20
+sGoldeenGfx23_1:
+.incbin "baserom.gba", 0xA16378, 0x100
+sGoldeenSprites23:
+ax_sprite sGoldeenGfx23, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGoldeenGfx23_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGoldeenGfx24:
+.incbin "baserom.gba", 0xA164A0, 0x40
+sGoldeenGfx24_1:
+.incbin "baserom.gba", 0xA164E0, 0x80
+sGoldeenGfx24_2:
+.incbin "baserom.gba", 0xA16560, 0x40
+sGoldeenGfx24_3:
+.incbin "baserom.gba", 0xA165A0, 0x40
+sGoldeenSprites24:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx25:
+.incbin "baserom.gba", 0xA16630, 0x40
+sGoldeenGfx25_1:
+.incbin "baserom.gba", 0xA16670, 0x100
+sGoldeenSprites25:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx25_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGoldeenGfx26:
+.incbin "baserom.gba", 0xA167A0, 0x40
+sGoldeenGfx26_1:
+.incbin "baserom.gba", 0xA167E0, 0x100
+sGoldeenGfx26_2:
+.incbin "baserom.gba", 0xA168E0, 0x40
+sGoldeenSprites26:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx27:
+.incbin "baserom.gba", 0xA16960, 0x40
+sGoldeenGfx27_1:
+.incbin "baserom.gba", 0xA169A0, 0x60
+sGoldeenGfx27_2:
+.incbin "baserom.gba", 0xA16A00, 0x60
+sGoldeenGfx27_3:
+.incbin "baserom.gba", 0xA16A60, 0x40
+sGoldeenSprites27:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx28:
+.incbin "baserom.gba", 0xA16AF0, 0x40
+sGoldeenGfx28_1:
+.incbin "baserom.gba", 0xA16B30, 0xE0
+sGoldeenGfx28_2:
+.incbin "baserom.gba", 0xA16C10, 0x40
+sGoldeenSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx28_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx29:
+.incbin "baserom.gba", 0xA16C90, 0x40
+sGoldeenGfx29_1:
+.incbin "baserom.gba", 0xA16CD0, 0x60
+sGoldeenGfx29_2:
+.incbin "baserom.gba", 0xA16D30, 0x60
+sGoldeenGfx29_3:
+.incbin "baserom.gba", 0xA16D90, 0x40
+sGoldeenSprites29:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx30:
+.incbin "baserom.gba", 0xA16E20, 0x40
+sGoldeenGfx30_1:
+.incbin "baserom.gba", 0xA16E60, 0x60
+sGoldeenGfx30_2:
+.incbin "baserom.gba", 0xA16EC0, 0x60
+sGoldeenGfx30_3:
+.incbin "baserom.gba", 0xA16F20, 0x40
+sGoldeenSprites30:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx31:
+.incbin "baserom.gba", 0xA16FB0, 0x40
+sGoldeenGfx31_1:
+.incbin "baserom.gba", 0xA16FF0, 0x60
+sGoldeenGfx31_2:
+.incbin "baserom.gba", 0xA17050, 0x60
+sGoldeenGfx31_3:
+.incbin "baserom.gba", 0xA170B0, 0x40
+sGoldeenSprites31:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx32:
+.incbin "baserom.gba", 0xA17140, 0x100
+sGoldeenSprites32:
+ax_sprite sGoldeenGfx32, 0x100
+ax_sprite_terminator
+sGoldeenGfx33:
+.incbin "baserom.gba", 0xA17250, 0xC0
+sGoldeenGfx33_1:
+.incbin "baserom.gba", 0xA17310, 0x20
+sGoldeenSprites33:
+ax_sprite sGoldeenGfx33, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx33_1, 0x20
+ax_sprite_terminator
+sGoldeenGfx34:
+.incbin "baserom.gba", 0xA17350, 0x100
+sGoldeenSprites34:
+ax_sprite sGoldeenGfx34, 0x100
+ax_sprite_terminator
+sGoldeenGfx35:
+.incbin "baserom.gba", 0xA17460, 0x100
+sGoldeenSprites35:
+ax_sprite sGoldeenGfx35, 0x100
+ax_sprite_terminator
+sGoldeenGfx36:
+.incbin "baserom.gba", 0xA17570, 0xC0
+sGoldeenGfx36_1:
+.incbin "baserom.gba", 0xA17630, 0x20
+sGoldeenSprites36:
+ax_sprite sGoldeenGfx36, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx36_1, 0x20
+ax_sprite_terminator
+sGoldeenGfx37:
+.incbin "baserom.gba", 0xA17670, 0x100
+sGoldeenSprites37:
+ax_sprite sGoldeenGfx37, 0x100
+ax_sprite_terminator
+sGoldeenGfx38:
+.incbin "baserom.gba", 0xA17780, 0x40
+sGoldeenGfx38_1:
+.incbin "baserom.gba", 0xA177C0, 0x100
+sGoldeenGfx38_2:
+.incbin "baserom.gba", 0xA178C0, 0x40
+sGoldeenSprites38:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx39:
+.incbin "baserom.gba", 0xA17940, 0x40
+sGoldeenGfx39_1:
+.incbin "baserom.gba", 0xA17980, 0x80
+sGoldeenGfx39_2:
+.incbin "baserom.gba", 0xA17A00, 0x60
+sGoldeenGfx39_3:
+.incbin "baserom.gba", 0xA17A60, 0x40
+sGoldeenSprites39:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx39_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx40:
+.incbin "baserom.gba", 0xA17AF0, 0x40
+sGoldeenGfx40_1:
+.incbin "baserom.gba", 0xA17B30, 0x60
+sGoldeenGfx40_2:
+.incbin "baserom.gba", 0xA17B90, 0x60
+sGoldeenGfx40_3:
+.incbin "baserom.gba", 0xA17BF0, 0x40
+sGoldeenSprites40:
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGoldeenGfx40_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGoldeenGfx40_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGoldeenGfx41:
+.incbin "baserom.gba", 0xA17C80, 0x200
+sGoldeenSprites41:
+ax_sprite sGoldeenGfx41, 0x200
+ax_sprite_terminator
+sGoldeenGfx42:
+.incbin "baserom.gba", 0xA17E90, 0x200
+sGoldeenSprites42:
+ax_sprite sGoldeenGfx42, 0x200
+ax_sprite_terminator
+sGoldeenGfx43:
+.incbin "baserom.gba", 0xA180A0, 0x200
+sGoldeenSprites43:
+ax_sprite sGoldeenGfx43, 0x200
+ax_sprite_terminator
+sGoldeenGfx44:
+.incbin "baserom.gba", 0xA182B0, 0x200
+sGoldeenSprites44:
+ax_sprite sGoldeenGfx44, 0x200
+ax_sprite_terminator
+sGoldeenGfx45:
+.incbin "baserom.gba", 0xA184C0, 0x200
+sGoldeenSprites45:
+ax_sprite sGoldeenGfx45, 0x200
+ax_sprite_terminator
+sGoldeenGfx46:
+.incbin "baserom.gba", 0xA186D0, 0x200
+sGoldeenSprites46:
+ax_sprite sGoldeenGfx46, 0x200
+ax_sprite_terminator
+sGoldeenGfx47:
+.incbin "baserom.gba", 0xA188E0, 0x200
+sGoldeenSprites47:
+ax_sprite sGoldeenGfx47, 0x200
+ax_sprite_terminator
+sAxPosesGoldeen:
+.4byte sGoldeenPose1
+.4byte sGoldeenPose2
+.4byte sGoldeenPose3
+.4byte sGoldeenPose4
+.4byte sGoldeenPose5
+.4byte sGoldeenPose6
+.4byte sGoldeenPose7
+.4byte sGoldeenPose8
+.4byte sGoldeenPose9
+.4byte sGoldeenPose10
+.4byte sGoldeenPose11
+.4byte sGoldeenPose12
+.4byte sGoldeenPose13
+.4byte sGoldeenPose14
+.4byte sGoldeenPose15
+.4byte sGoldeenPose16
+.4byte sGoldeenPose17
+.4byte sGoldeenPose18
+.4byte sGoldeenPose19
+.4byte sGoldeenPose20
+.4byte sGoldeenPose21
+.4byte sGoldeenPose22
+.4byte sGoldeenPose23
+.4byte sGoldeenPose24
+.4byte sGoldeenPose25
+.4byte sGoldeenPose26
+.4byte sGoldeenPose27
+.4byte sGoldeenPose28
+.4byte sGoldeenPose29
+.4byte sGoldeenPose30
+.4byte sGoldeenPose31
+.4byte sGoldeenPose32
+.4byte sGoldeenPose33
+.4byte sGoldeenPose34
+.4byte sGoldeenPose35
+.4byte sGoldeenPose36
+.4byte sGoldeenPose37
+.4byte sGoldeenPose38
+.4byte sGoldeenPose39
+.4byte sGoldeenPose40
+.4byte sGoldeenPose41
+.4byte sGoldeenPose42
+.4byte sGoldeenPose43
+.4byte sGoldeenPose44
+.4byte sGoldeenPose45
+.4byte sGoldeenPose46
+.4byte sGoldeenPose47
+.4byte sGoldeenPose48
+.4byte sGoldeenPose49
+.4byte sGoldeenPose50
+.4byte sGoldeenPose51
+.4byte sGoldeenPose52
+.4byte sGoldeenPose53
+.4byte sGoldeenPose54
+.4byte sGoldeenPose55
+.4byte sGoldeenPose56
+.4byte sGoldeenPose57
+.4byte sGoldeenPose58
+.4byte sGoldeenPose59
+.4byte sGoldeenPose60
+.4byte sGoldeenPose61
+.4byte sGoldeenPose62
+.4byte sGoldeenPose63
+.4byte sGoldeenPose64
+.4byte sGoldeenPose65
+.4byte sGoldeenPose66
+.4byte sGoldeenPose67
+.4byte sGoldeenPose68
+.4byte sGoldeenPose69
+.4byte sGoldeenPose70
+.4byte sGoldeenPose71
+.4byte sGoldeenPose72
+.4byte sGoldeenPose73
+.4byte sGoldeenPose74
+.4byte sGoldeenPose75
+.4byte sGoldeenPose76
+.4byte sGoldeenPose77
+.4byte sGoldeenPose78
+.4byte sGoldeenPose79
+.4byte sGoldeenPose80
+.4byte sGoldeenPose81
+.4byte sGoldeenPose82
+.4byte sGoldeenPose83
+.4byte sGoldeenPose84
+.4byte sGoldeenPose85
+.4byte sGoldeenPose86
+.4byte sGoldeenPose87
+.4byte sGoldeenPose88
+.4byte sGoldeenPose89
+.4byte sGoldeenPose90
+.4byte sGoldeenPose91
+.4byte sGoldeenPose92
+.4byte sGoldeenPose93
+.4byte sGoldeenPose94
+.4byte sGoldeenPose95
+.4byte sGoldeenPose96
+.4byte sGoldeenPose97
+.4byte sGoldeenPose98
+.4byte sGoldeenPose99
+.4byte sGoldeenPose100
+.4byte sGoldeenPose101
+.4byte sGoldeenPose102
+.4byte sGoldeenPose103
+.4byte sGoldeenPose104
+.4byte sGoldeenPose105
+.4byte sGoldeenPose106
+.4byte sGoldeenPose107
+.4byte sGoldeenPose108
+.4byte sGoldeenPose109
+.4byte sGoldeenPose110
+.4byte sGoldeenPose111
+.4byte sGoldeenPose112
+.4byte sGoldeenPose113
+.4byte sGoldeenPose114
+.4byte sGoldeenPose115
+.4byte sGoldeenPose116
+.4byte sGoldeenPose117
+.4byte sGoldeenPose118
+.4byte sGoldeenPose119
+.4byte sGoldeenPose120
+.4byte sGoldeenPose121
+.4byte sGoldeenPose122
+.4byte sGoldeenPose123
+.4byte sGoldeenPose124
+.4byte sGoldeenPose125
+.4byte sGoldeenPose126
+.4byte sGoldeenPose127
+.4byte sGoldeenPose128
+.4byte sGoldeenPose129
+.4byte sGoldeenPose130
+.4byte sGoldeenPose131
+.4byte sGoldeenPose132
+.4byte sGoldeenPose133
+.4byte sGoldeenPose134
+.4byte sGoldeenPose135
+.4byte sGoldeenPose136
+.4byte sGoldeenPose137
+.4byte sGoldeenPose138
+.4byte sGoldeenPose139
+.4byte sGoldeenPose140
+.4byte sGoldeenPose141
+.4byte sGoldeenPose142
+.4byte sGoldeenPose143
+.4byte sGoldeenPose144
+.4byte sGoldeenPose145
+.4byte sGoldeenPose146
+.4byte sGoldeenPose147
+.4byte sGoldeenPose148
+.4byte sGoldeenPose149
+.4byte sGoldeenPose150
+.4byte sGoldeenPose151
+.4byte sGoldeenPose152
+.4byte sGoldeenPose153
+.4byte sGoldeenPose154
+.4byte sGoldeenPose155
+.4byte sGoldeenPose156
+.4byte sGoldeenPose157
+.4byte sGoldeenPose158
+.4byte sGoldeenPose159
+.4byte sGoldeenPose160
+.4byte sGoldeenPose161
+.4byte sGoldeenPose162
+.4byte sGoldeenPose163
+.4byte sGoldeenPose164
+.4byte sGoldeenPose165
+.4byte sGoldeenPose166
+.4byte sGoldeenPose167
+.4byte sGoldeenPose168
+.4byte sGoldeenPose169
+.4byte sGoldeenPose170
+.4byte sGoldeenPose171
+.4byte sGoldeenPose172
+.4byte sGoldeenPose173
+.4byte sGoldeenPose174
+.4byte sGoldeenPose175
+.4byte sGoldeenPose176
+.4byte sGoldeenPose177
+.4byte sGoldeenPose178
+.4byte sGoldeenPose179
+.4byte sGoldeenPose180
+.4byte sGoldeenPose181
+.4byte sGoldeenPose182
+.4byte sGoldeenPose183
+.4byte sGoldeenPose184
+.4byte sGoldeenPose185
+.4byte sGoldeenPose186
+.4byte sGoldeenPose187
+.4byte sGoldeenPose188
+.4byte sGoldeenPose189
+.4byte sGoldeenPose190
+.4byte sGoldeenPose191
+.4byte sGoldeenPose192
+.4byte sGoldeenPose193
+.4byte sGoldeenPose194
+.4byte sGoldeenPose195
+.4byte sGoldeenPose196
+.4byte sGoldeenPose197
+.4byte sGoldeenPose198
+.4byte sGoldeenPose199
+.4byte sGoldeenPose200
+.4byte sGoldeenPose201
+.4byte sGoldeenPose202
+.4byte sGoldeenPose203
+.4byte sGoldeenPose204
+.4byte sGoldeenPose205
+.4byte sGoldeenPose206
+.4byte sGoldeenPose207
+.4byte sGoldeenPose208
+.4byte sGoldeenPose209
+.4byte sGoldeenPose210
+.4byte sGoldeenPose211
+.4byte sGoldeenPose212
+.4byte sGoldeenPose213
+.4byte sGoldeenPose214
+.4byte sGoldeenPose215
+.4byte sGoldeenPose216
+.4byte sGoldeenPose217
+.4byte sGoldeenPose218
+.4byte sGoldeenPose219
+.4byte sGoldeenPose220
+.4byte sGoldeenPose221
+.4byte sGoldeenPose222
+.4byte sGoldeenPose223
+.4byte sGoldeenPose224
+.4byte sGoldeenPose225
+.4byte sGoldeenPose226
+.4byte sGoldeenPose227
+.4byte sGoldeenPose228
+.4byte sGoldeenPose229
+.4byte sGoldeenPose230
+.4byte sGoldeenPose231
+.4byte sGoldeenPose232
+.4byte sGoldeenPose233
+.4byte sGoldeenPose234
+.4byte sGoldeenPose235
+.4byte sGoldeenPose236
+.4byte sGoldeenPose237
+.4byte sGoldeenPose238
+.4byte sGoldeenPose239
+.4byte sGoldeenPose240
+.4byte sGoldeenPose241
+.4byte sGoldeenPose242
+sAxPositionsGoldeen:
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte    1,    0, 	  -7,   -4, 	   7,   -3, 	   2,   -7
+.2byte   -1,    0, 	  -7,   -3, 	   8,   -4, 	  -2,   -7
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    9,   -3, 	   8,   -6, 	  -1,   -2, 	   3,   -8
+.2byte    8,   -2, 	  11,   -4, 	   0,    0, 	   2,   -7
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    9,   -5, 	   8,   -7, 	   7,   -2, 	   3,   -8
+.2byte    9,   -5, 	   9,   -7, 	   3,    1, 	   2,   -7
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    6,   -9, 	  -3,  -11, 	   7,   -5, 	   3,  -10
+.2byte    6,  -10, 	   0,  -13, 	   7,   -5, 	   3,  -10
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    2,  -13, 	   8,   -9, 	  -9,   -9, 	   0,  -12
+.2byte   -1,  -13, 	   6,   -9, 	  -6,   -7, 	   1,  -12
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte   -6,   -9, 	   3,  -11, 	  -7,   -5, 	  -3,  -10
+.2byte   -6,  -10, 	   0,  -13, 	  -7,   -5, 	  -3,  -10
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,   -5, 	  -8,   -7, 	  -7,   -2, 	  -3,   -8
+.2byte   -9,   -5, 	  -9,   -7, 	  -3,    1, 	  -2,   -7
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -9,   -3, 	  -8,   -6, 	   1,   -2, 	  -3,   -8
+.2byte   -8,   -2, 	 -11,   -4, 	   0,    0, 	  -2,   -7
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte    1,    0, 	  -7,   -4, 	   7,   -3, 	   2,   -7
+.2byte   -1,    0, 	  -7,   -3, 	   8,   -4, 	  -2,   -7
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    9,   -3, 	   8,   -6, 	  -1,   -2, 	   3,   -8
+.2byte    8,   -2, 	  11,   -4, 	   0,    0, 	   2,   -7
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    9,   -5, 	   8,   -7, 	   7,   -2, 	   3,   -8
+.2byte    9,   -5, 	   9,   -7, 	   3,    1, 	   2,   -7
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    6,   -9, 	  -3,  -11, 	   7,   -5, 	   3,  -10
+.2byte    6,  -10, 	   0,  -13, 	   7,   -5, 	   3,  -10
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    2,  -13, 	   8,   -9, 	  -9,   -9, 	   0,  -12
+.2byte   -1,  -13, 	   6,   -9, 	  -6,   -7, 	   1,  -12
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte   -6,   -9, 	   3,  -11, 	  -7,   -5, 	  -3,  -10
+.2byte   -6,  -10, 	   0,  -13, 	  -7,   -5, 	  -3,  -10
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,   -5, 	  -8,   -7, 	  -7,   -2, 	  -3,   -8
+.2byte   -9,   -5, 	  -9,   -7, 	  -3,    1, 	  -2,   -7
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -9,   -3, 	  -8,   -6, 	   1,   -2, 	  -3,   -8
+.2byte   -8,   -2, 	 -11,   -4, 	   0,    0, 	  -2,   -7
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte    1,    0, 	  -7,   -4, 	   7,   -3, 	   2,   -7
+.2byte   -1,    0, 	  -7,   -3, 	   8,   -4, 	  -2,   -7
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    9,   -3, 	   8,   -6, 	  -1,   -2, 	   3,   -8
+.2byte    8,   -2, 	  11,   -4, 	   0,    0, 	   2,   -7
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    9,   -5, 	   8,   -7, 	   7,   -2, 	   3,   -8
+.2byte    9,   -5, 	   9,   -7, 	   3,    1, 	   2,   -7
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    6,   -9, 	  -3,  -11, 	   7,   -5, 	   3,  -10
+.2byte    6,  -10, 	   0,  -13, 	   7,   -5, 	   3,  -10
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    2,  -13, 	   8,   -9, 	  -9,   -9, 	   0,  -12
+.2byte   -1,  -13, 	   6,   -9, 	  -6,   -7, 	   1,  -12
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte   -6,   -9, 	   3,  -11, 	  -7,   -5, 	  -3,  -10
+.2byte   -6,  -10, 	   0,  -13, 	  -7,   -5, 	  -3,  -10
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,   -5, 	  -8,   -7, 	  -7,   -2, 	  -3,   -8
+.2byte   -9,   -5, 	  -9,   -7, 	  -3,    1, 	  -2,   -7
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -9,   -3, 	  -8,   -6, 	   1,   -2, 	  -3,   -8
+.2byte   -8,   -2, 	 -11,   -4, 	   0,    0, 	  -2,   -7
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte    1,    0, 	  -7,   -4, 	   7,   -3, 	   2,   -7
+.2byte   -1,    0, 	  -7,   -3, 	   8,   -4, 	  -2,   -7
+.2byte    0,   -6, 	  -8,   -6, 	   8,   -6, 	   0,   -7
+.2byte    0,    2, 	  -7,   -3, 	   7,   -3, 	   0,   -2
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    9,   -3, 	   8,   -6, 	  -1,   -2, 	   3,   -8
+.2byte    8,   -2, 	  11,   -4, 	   0,    0, 	   2,   -7
+.2byte    6,   -7, 	   8,   -6, 	  -2,   -3, 	   1,   -7
+.2byte    8,    0, 	   6,   -6, 	  -4,   -2, 	   2,   -3
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    9,   -5, 	   8,   -7, 	   7,   -2, 	   3,   -8
+.2byte    9,   -5, 	   9,   -7, 	   3,    1, 	   2,   -7
+.2byte    8,  -11, 	   5,   -9, 	   7,   -5, 	   2,   -9
+.2byte   10,   -4, 	   4,   -8, 	   0,    0, 	   3,   -6
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    6,   -9, 	  -3,  -11, 	   7,   -5, 	   3,  -10
+.2byte    6,  -10, 	   0,  -13, 	   7,   -5, 	   3,  -10
+.2byte    5,  -15, 	  -5,  -12, 	   7,   -8, 	   1,  -11
+.2byte    7,   -9, 	  -2,  -10, 	   7,   -3, 	   3,   -8
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    2,  -13, 	   8,   -9, 	  -9,   -9, 	   0,  -12
+.2byte   -1,  -13, 	   6,   -9, 	  -6,   -7, 	   1,  -12
+.2byte    0,  -15, 	   8,  -11, 	  -8,  -11, 	   0,  -10
+.2byte    0,  -11, 	   7,   -7, 	  -7,   -7, 	   0,  -10
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte   -6,   -9, 	   3,  -11, 	  -7,   -5, 	  -3,  -10
+.2byte   -6,  -10, 	   0,  -13, 	  -7,   -5, 	  -3,  -10
+.2byte   -5,  -15, 	   5,  -12, 	  -7,   -8, 	  -1,  -11
+.2byte   -7,   -9, 	   2,  -10, 	  -7,   -3, 	  -3,   -8
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,   -5, 	  -8,   -7, 	  -7,   -2, 	  -3,   -8
+.2byte   -9,   -5, 	  -9,   -7, 	  -3,    1, 	  -2,   -7
+.2byte   -8,  -11, 	  -5,   -9, 	  -7,   -5, 	  -2,   -9
+.2byte  -10,   -4, 	  -4,   -8, 	   0,    0, 	  -3,   -6
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -9,   -3, 	  -8,   -6, 	   1,   -2, 	  -3,   -8
+.2byte   -8,   -2, 	 -11,   -4, 	   0,    0, 	  -2,   -7
+.2byte   -6,   -7, 	  -8,   -6, 	   2,   -3, 	  -1,   -7
+.2byte   -8,    0, 	  -6,   -6, 	   4,   -2, 	  -2,   -3
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -8,   -6, 	   8,   -6, 	   0,   -7
+.2byte    0,  -20, 	  -7,  -11, 	   7,  -11, 	   0,  -13
+.2byte    3,  -18, 	  -7,  -11, 	   6,   -9, 	   0,  -13
+.2byte   -4,  -18, 	  -5,   -8, 	   7,  -12, 	   0,  -14
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    7,   -7, 	   9,   -6, 	  -1,   -3, 	   2,   -7
+.2byte    0,  -20, 	   6,  -12, 	  -7,   -9, 	   1,  -13
+.2byte   -2,  -19, 	   6,  -11, 	  -6,   -9, 	   0,  -14
+.2byte    2,  -20, 	   6,  -10, 	  -6,  -10, 	   0,  -13
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    9,  -10, 	   6,   -8, 	   8,   -4, 	   3,   -8
+.2byte    2,  -19, 	  -1,  -11, 	   2,   -9, 	   0,  -12
+.2byte    2,  -19, 	   1,  -13, 	   3,  -10, 	   0,  -12
+.2byte    1,  -19, 	  -1,  -12, 	   2,  -10, 	   0,  -13
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    7,  -15, 	  -3,  -12, 	   9,   -8, 	   3,  -11
+.2byte    3,  -19, 	  -2,  -10, 	   7,   -8, 	   2,  -11
+.2byte    5,  -18, 	  -1,  -13, 	   7,   -9, 	   1,  -11
+.2byte    0,  -19, 	  -3,   -9, 	   6,   -8, 	   1,  -11
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    0,  -16, 	   8,  -12, 	  -8,  -12, 	   0,  -11
+.2byte    0,  -19, 	   7,   -9, 	  -8,   -9, 	   0,  -12
+.2byte   -4,  -17, 	   8,  -10, 	  -6,   -9, 	   1,  -12
+.2byte    3,  -18, 	   6,   -9, 	  -8,  -10, 	  -1,  -11
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte   -7,  -15, 	   3,  -12, 	  -9,   -8, 	  -3,  -11
+.2byte   -3,  -19, 	   2,  -10, 	  -7,   -8, 	  -2,  -11
+.2byte   -5,  -18, 	   1,  -13, 	  -7,   -9, 	  -1,  -11
+.2byte    0,  -19, 	   3,   -9, 	  -6,   -8, 	  -1,  -11
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,  -10, 	  -6,   -8, 	  -8,   -4, 	  -3,   -8
+.2byte   -2,  -19, 	   1,  -11, 	  -2,   -9, 	   0,  -12
+.2byte   -2,  -19, 	  -1,  -13, 	  -3,  -10, 	   0,  -12
+.2byte   -1,  -19, 	   1,  -12, 	  -2,  -10, 	   0,  -13
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -8,   -7, 	 -10,   -6, 	   0,   -3, 	  -3,   -7
+.2byte   -1,  -20, 	  -7,  -12, 	   6,   -9, 	  -2,  -13
+.2byte    1,  -19, 	  -7,  -11, 	   5,   -9, 	  -1,  -14
+.2byte   -3,  -20, 	  -7,  -10, 	   5,  -10, 	  -1,  -13
+.2byte   -7,   -2, 	  -9,   -4, 	   1,    0, 	  -2,   -7
+.2byte   -7,   -3, 	  -9,   -6, 	   2,   -2, 	  -2,   -7
+.2byte    0,   -2, 	  -8,   -6, 	   8,   -6, 	   0,   -9
+.2byte    3,   -2, 	   7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte    5,   -3, 	   4,   -5, 	   0,   -3, 	   1,   -8
+.2byte    4,   -9, 	  -2,  -11, 	   3,   -5, 	   0,  -10
+.2byte    0,   -8, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte   -5,   -9, 	   1,  -11, 	  -4,   -5, 	  -1,  -10
+.2byte   -6,   -3, 	  -5,   -5, 	  -1,   -3, 	  -2,   -8
+.2byte   -4,   -2, 	  -8,   -5, 	   5,   -3, 	   0,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte    1,    0, 	  -7,   -4, 	   7,   -3, 	   2,   -7
+.2byte   -1,    0, 	  -7,   -3, 	   8,   -4, 	  -2,   -7
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    9,   -3, 	   8,   -6, 	  -1,   -2, 	   3,   -8
+.2byte    8,   -2, 	  11,   -4, 	   0,    0, 	   2,   -7
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    9,   -5, 	   8,   -7, 	   7,   -2, 	   3,   -8
+.2byte    9,   -5, 	   9,   -7, 	   3,    1, 	   2,   -7
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    6,   -9, 	  -3,  -11, 	   7,   -5, 	   3,  -10
+.2byte    6,  -10, 	   0,  -13, 	   7,   -5, 	   3,  -10
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    2,  -13, 	   8,   -9, 	  -9,   -9, 	   0,  -12
+.2byte   -1,  -13, 	   6,   -9, 	  -6,   -7, 	   1,  -12
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte   -6,   -9, 	   3,  -11, 	  -7,   -5, 	  -3,  -10
+.2byte   -6,  -10, 	   0,  -13, 	  -7,   -5, 	  -3,  -10
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,   -5, 	  -8,   -7, 	  -7,   -2, 	  -3,   -8
+.2byte   -9,   -5, 	  -9,   -7, 	  -3,    1, 	  -2,   -7
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -9,   -3, 	  -8,   -6, 	   1,   -2, 	  -3,   -8
+.2byte   -8,   -2, 	 -11,   -4, 	   0,    0, 	  -2,   -7
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    0,  -20, 	  -7,  -11, 	   7,  -11, 	   0,  -13
+.2byte   -1,  -20, 	   5,  -12, 	  -8,   -9, 	   0,  -13
+.2byte    2,  -19, 	  -1,  -11, 	   2,   -9, 	   0,  -12
+.2byte    1,  -20, 	  -4,  -11, 	   5,   -9, 	   0,  -12
+.2byte    0,  -20, 	   7,  -10, 	  -8,  -10, 	   0,  -13
+.2byte   -1,  -20, 	   4,  -11, 	  -5,   -9, 	   0,  -12
+.2byte   -2,  -19, 	   1,  -11, 	  -2,   -9, 	   0,  -12
+.2byte    0,  -20, 	  -6,  -12, 	   7,   -9, 	  -1,  -13
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -8,   -6, 	   8,   -6, 	   0,   -7
+.2byte    0,    2, 	  -7,   -3, 	   7,   -3, 	   0,   -2
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+.2byte    6,   -7, 	   8,   -6, 	  -2,   -3, 	   1,   -7
+.2byte    8,    0, 	   6,   -6, 	  -4,   -2, 	   2,   -3
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    8,  -11, 	   5,   -9, 	   7,   -5, 	   2,   -9
+.2byte    9,   -4, 	   3,   -8, 	  -1,    0, 	   2,   -6
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    5,  -15, 	  -5,  -12, 	   7,   -8, 	   1,  -11
+.2byte    6,   -9, 	  -3,  -10, 	   6,   -3, 	   2,   -8
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    0,  -15, 	   8,  -11, 	  -8,  -11, 	   0,  -10
+.2byte    0,  -11, 	   7,   -7, 	  -7,   -7, 	   0,  -10
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte   -5,  -15, 	   5,  -12, 	  -7,   -8, 	  -1,  -11
+.2byte   -6,   -9, 	   3,  -10, 	  -6,   -3, 	  -2,   -8
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -8,  -11, 	  -5,   -9, 	  -7,   -5, 	  -2,   -9
+.2byte   -9,   -4, 	  -3,   -8, 	   1,    0, 	  -2,   -6
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -6,   -7, 	  -8,   -6, 	   2,   -3, 	  -1,   -7
+.2byte   -8,    0, 	  -6,   -6, 	   4,   -2, 	  -2,   -3
+.2byte    0,   -6, 	  -8,   -6, 	   8,   -6, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -6, 	   2,   -3, 	  -1,   -7
+.2byte   -8,   -9, 	  -5,   -7, 	  -7,   -3, 	  -2,   -7
+.2byte   -5,  -13, 	   5,  -10, 	  -7,   -6, 	  -1,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -8
+.2byte    5,  -13, 	  -5,  -10, 	   7,   -6, 	   1,   -9
+.2byte    8,   -9, 	   5,   -7, 	   7,   -3, 	   2,   -7
+.2byte    6,   -7, 	   8,   -6, 	  -2,   -3, 	   1,   -7
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -7
+.2byte   -8,   -2, 	 -11,   -5, 	   0,    0, 	  -2,   -7
+.2byte   -9,   -5, 	  -7,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -7,  -10, 	   3,  -11, 	  -8,   -4, 	  -2,  -10
+.2byte    0,  -11, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    7,  -10, 	  -3,  -11, 	   8,   -4, 	   2,  -10
+.2byte    9,   -5, 	   7,   -7, 	   4,   -1, 	   2,   -8
+.2byte    8,   -2, 	  11,   -5, 	   0,    0, 	   2,   -7
+sGoldeenAnimTable1:
+.4byte sGoldeenAnims_1_1
+.4byte sGoldeenAnims_1_2
+.4byte sGoldeenAnims_1_3
+.4byte sGoldeenAnims_1_4
+.4byte sGoldeenAnims_1_5
+.4byte sGoldeenAnims_1_6
+.4byte sGoldeenAnims_1_7
+.4byte sGoldeenAnims_1_8
+sGoldeenAnimTable2:
+.4byte sGoldeenAnims_2_1
+.4byte sGoldeenAnims_2_2
+.4byte sGoldeenAnims_2_3
+.4byte sGoldeenAnims_2_4
+.4byte sGoldeenAnims_2_5
+.4byte sGoldeenAnims_2_6
+.4byte sGoldeenAnims_2_7
+.4byte sGoldeenAnims_2_8
+sGoldeenAnimTable3:
+.4byte sGoldeenAnims_3_1
+.4byte sGoldeenAnims_3_2
+.4byte sGoldeenAnims_3_3
+.4byte sGoldeenAnims_3_4
+.4byte sGoldeenAnims_3_5
+.4byte sGoldeenAnims_3_6
+.4byte sGoldeenAnims_3_7
+.4byte sGoldeenAnims_3_8
+sGoldeenAnimTable4:
+.4byte sGoldeenAnims_4_1
+.4byte sGoldeenAnims_4_2
+.4byte sGoldeenAnims_4_3
+.4byte sGoldeenAnims_4_4
+.4byte sGoldeenAnims_4_5
+.4byte sGoldeenAnims_4_6
+.4byte sGoldeenAnims_4_7
+.4byte sGoldeenAnims_4_8
+sGoldeenAnimTable5:
+.4byte sGoldeenAnims_5_1
+.4byte sGoldeenAnims_5_2
+.4byte sGoldeenAnims_5_3
+.4byte sGoldeenAnims_5_4
+.4byte sGoldeenAnims_5_5
+.4byte sGoldeenAnims_5_6
+.4byte sGoldeenAnims_5_7
+.4byte sGoldeenAnims_5_8
+sGoldeenAnimTable6:
+.4byte sGoldeenAnims_6_1
+.4byte sGoldeenAnims_6_1
+.4byte sGoldeenAnims_6_1
+.4byte sGoldeenAnims_6_1
+.4byte sGoldeenAnims_6_1
+.4byte sGoldeenAnims_6_1
+.4byte sGoldeenAnims_6_1
+.4byte sGoldeenAnims_6_1
+sGoldeenAnimTable7:
+.4byte sGoldeenAnims_7_1
+.4byte sGoldeenAnims_7_2
+.4byte sGoldeenAnims_7_3
+.4byte sGoldeenAnims_7_4
+.4byte sGoldeenAnims_7_5
+.4byte sGoldeenAnims_7_6
+.4byte sGoldeenAnims_7_7
+.4byte sGoldeenAnims_7_8
+sGoldeenAnimTable8:
+.4byte sGoldeenAnims_8_1
+.4byte sGoldeenAnims_8_2
+.4byte sGoldeenAnims_8_3
+.4byte sGoldeenAnims_8_4
+.4byte sGoldeenAnims_8_5
+.4byte sGoldeenAnims_8_6
+.4byte sGoldeenAnims_8_7
+.4byte sGoldeenAnims_8_8
+sGoldeenAnimTable9:
+.4byte sGoldeenAnims_9_1
+.4byte sGoldeenAnims_9_2
+.4byte sGoldeenAnims_9_3
+.4byte sGoldeenAnims_9_4
+.4byte sGoldeenAnims_9_5
+.4byte sGoldeenAnims_9_6
+.4byte sGoldeenAnims_9_7
+.4byte sGoldeenAnims_9_8
+sGoldeenAnimTable10:
+.4byte sGoldeenAnims_10_1
+.4byte sGoldeenAnims_10_2
+.4byte sGoldeenAnims_10_3
+.4byte sGoldeenAnims_10_4
+.4byte sGoldeenAnims_10_5
+.4byte sGoldeenAnims_10_6
+.4byte sGoldeenAnims_10_7
+.4byte sGoldeenAnims_10_8
+sGoldeenAnimTable11:
+.4byte sGoldeenAnims_11_1
+.4byte sGoldeenAnims_11_2
+.4byte sGoldeenAnims_11_3
+.4byte sGoldeenAnims_11_4
+.4byte sGoldeenAnims_11_5
+.4byte sGoldeenAnims_11_6
+.4byte sGoldeenAnims_11_7
+.4byte sGoldeenAnims_11_8
+sGoldeenAnimTable12:
+.4byte sGoldeenAnims_12_1
+.4byte sGoldeenAnims_12_2
+.4byte sGoldeenAnims_12_3
+.4byte sGoldeenAnims_12_4
+.4byte sGoldeenAnims_12_5
+.4byte sGoldeenAnims_12_6
+.4byte sGoldeenAnims_12_7
+.4byte sGoldeenAnims_12_8
+sGoldeenAnimTable13:
+.4byte sGoldeenAnims_13_1
+.4byte sGoldeenAnims_13_2
+.4byte sGoldeenAnims_13_3
+.4byte sGoldeenAnims_13_4
+.4byte sGoldeenAnims_13_5
+.4byte sGoldeenAnims_13_6
+.4byte sGoldeenAnims_13_7
+.4byte sGoldeenAnims_13_8
+sAxAnimationsGoldeen:
+.4byte sGoldeenAnimTable1
+.4byte sGoldeenAnimTable2
+.4byte sGoldeenAnimTable3
+.4byte sGoldeenAnimTable4
+.4byte sGoldeenAnimTable5
+.4byte sGoldeenAnimTable6
+.4byte sGoldeenAnimTable7
+.4byte sGoldeenAnimTable8
+.4byte sGoldeenAnimTable9
+.4byte sGoldeenAnimTable10
+.4byte sGoldeenAnimTable11
+.4byte sGoldeenAnimTable12
+.4byte sGoldeenAnimTable13
+sAxSpritesGoldeen:
+.4byte sGoldeenSprites1
+.4byte sGoldeenSprites2
+.4byte sGoldeenSprites3
+.4byte sGoldeenSprites4
+.4byte sGoldeenSprites5
+.4byte sGoldeenSprites6
+.4byte sGoldeenSprites7
+.4byte sGoldeenSprites8
+.4byte sGoldeenSprites9
+.4byte sGoldeenSprites10
+.4byte sGoldeenSprites11
+.4byte sGoldeenSprites12
+.4byte sGoldeenSprites13
+.4byte sGoldeenSprites14
+.4byte sGoldeenSprites15
+.4byte sGoldeenSprites16
+.4byte sGoldeenSprites17
+.4byte sGoldeenSprites18
+.4byte sGoldeenSprites19
+.4byte sGoldeenSprites20
+.4byte sGoldeenSprites21
+.4byte sGoldeenSprites22
+.4byte sGoldeenSprites23
+.4byte sGoldeenSprites24
+.4byte sGoldeenSprites25
+.4byte sGoldeenSprites26
+.4byte sGoldeenSprites27
+.4byte sGoldeenSprites28
+.4byte sGoldeenSprites29
+.4byte sGoldeenSprites30
+.4byte sGoldeenSprites31
+.4byte sGoldeenSprites32
+.4byte sGoldeenSprites33
+.4byte sGoldeenSprites34
+.4byte sGoldeenSprites35
+.4byte sGoldeenSprites36
+.4byte sGoldeenSprites37
+.4byte sGoldeenSprites38
+.4byte sGoldeenSprites39
+.4byte sGoldeenSprites40
+.4byte sGoldeenSprites41
+.4byte sGoldeenSprites42
+.4byte sGoldeenSprites43
+.4byte sGoldeenSprites44
+.4byte sGoldeenSprites45
+.4byte sGoldeenSprites46
+.4byte sGoldeenSprites47
+sAxMainGoldeen:
+ax_main sAxPosesGoldeen, sAxAnimationsGoldeen, 13, sAxSpritesGoldeen, sAxPositionsGoldeen

--- a/data/ax/golduck.inc
+++ b/data/ax/golduck.inc
@@ -1,0 +1,3128 @@
+.global gAxGolduck
+gAxGolduck:
+ax_siro sAxMainGolduck
+sGolduckPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose4:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose5:
+ax_pose 4, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose6:
+ax_pose 5, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose7:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose8:
+ax_pose 7, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose9:
+ax_pose 8, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose10:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose11:
+ax_pose 10, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose12:
+ax_pose 11, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose13:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose14:
+ax_pose 13, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose15:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose16:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose17:
+ax_pose 10, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose18:
+ax_pose 11, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose19:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose28:
+ax_pose 15, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose29:
+ax_pose 16, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose30:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose31:
+ax_pose 4, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose32:
+ax_pose 5, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose33:
+ax_pose 17, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose34:
+ax_pose 18, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose35:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose36:
+ax_pose 7, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose37:
+ax_pose 8, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose38:
+ax_pose 19, 0x01e4, 0x90ee, 0x0c00
+ax_pose_terminator
+sGolduckPose39:
+ax_pose 20, 0x01e4, 0x90ee, 0x0c00
+ax_pose_terminator
+sGolduckPose40:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose41:
+ax_pose 10, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose42:
+ax_pose 11, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose43:
+ax_pose 21, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose44:
+ax_pose 22, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose45:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose46:
+ax_pose 13, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose47:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose48:
+ax_pose 23, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose49:
+ax_pose 24, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose50:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose51:
+ax_pose 10, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose52:
+ax_pose 11, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose53:
+ax_pose 21, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose54:
+ax_pose 22, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose55:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose56:
+ax_pose 7, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose57:
+ax_pose 8, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose58:
+ax_pose 19, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sGolduckPose59:
+ax_pose 20, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sGolduckPose60:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose61:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose62:
+ax_pose 5, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose63:
+ax_pose 17, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose64:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose65:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose66:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose67:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose68:
+ax_pose 25, 0x01e7, 0x80f0, 0x0c00
+ax_pose 26, 0x01e5, 0x80f0, 0x0c10
+ax_pose_terminator
+sGolduckPose69:
+ax_pose 26, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose70:
+ax_pose 25, 0x01e7, 0x90f0, 0x0c00
+ax_pose 27, 0x01e5, 0x80f0, 0x0c10
+ax_pose_terminator
+sGolduckPose71:
+ax_pose 27, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose72:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose73:
+ax_pose 4, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose74:
+ax_pose 5, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose75:
+ax_pose 28, 0x81e6, 0x9100, 0x0c00
+ax_pose 29, 0x01e4, 0x90ef, 0x0c08
+ax_pose_terminator
+sGolduckPose76:
+ax_pose 29, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose77:
+ax_pose 30, 0x01e7, 0x90f0, 0x0c00
+ax_pose 31, 0x01e4, 0x90ef, 0x0c10
+ax_pose_terminator
+sGolduckPose78:
+ax_pose 31, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose79:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose80:
+ax_pose 7, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose81:
+ax_pose 8, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose82:
+ax_pose 32, 0x01e6, 0x90f1, 0x0c00
+ax_pose 33, 0x01e6, 0x90f1, 0x0c10
+ax_pose_terminator
+sGolduckPose83:
+ax_pose 33, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sGolduckPose84:
+ax_pose 34, 0x01e6, 0x90f1, 0x0c00
+ax_pose 35, 0x01e6, 0x90f1, 0x0c10
+ax_pose_terminator
+sGolduckPose85:
+ax_pose 35, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sGolduckPose86:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose87:
+ax_pose 10, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose88:
+ax_pose 11, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose89:
+ax_pose 36, 0x01e6, 0x90ef, 0x0c00
+ax_pose 37, 0x01e6, 0x90ef, 0x0c10
+ax_pose_terminator
+sGolduckPose90:
+ax_pose 37, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose91:
+ax_pose 38, 0x01e6, 0x90ef, 0x0c00
+ax_pose 39, 0x01e6, 0x90ef, 0x0c10
+ax_pose_terminator
+sGolduckPose92:
+ax_pose 39, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose93:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose94:
+ax_pose 13, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose95:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose96:
+ax_pose 40, 0x81e6, 0x8100, 0x0c00
+ax_pose 41, 0x01e6, 0x80f0, 0x0c08
+ax_pose_terminator
+sGolduckPose97:
+ax_pose 41, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose98:
+ax_pose 40, 0x81e6, 0x90f0, 0x0c00
+ax_pose 42, 0x01e6, 0x80f0, 0x0c08
+ax_pose_terminator
+sGolduckPose99:
+ax_pose 42, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose100:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose101:
+ax_pose 10, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose102:
+ax_pose 11, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose103:
+ax_pose 36, 0x01e6, 0x80f0, 0x0c00
+ax_pose 37, 0x01e6, 0x80f0, 0x0c10
+ax_pose_terminator
+sGolduckPose104:
+ax_pose 37, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose105:
+ax_pose 38, 0x01e6, 0x80f0, 0x0c00
+ax_pose 39, 0x01e6, 0x80f0, 0x0c10
+ax_pose_terminator
+sGolduckPose106:
+ax_pose 39, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose107:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose108:
+ax_pose 7, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose109:
+ax_pose 8, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose110:
+ax_pose 32, 0x01e6, 0x80ee, 0x0c00
+ax_pose 33, 0x01e6, 0x80ee, 0x0c10
+ax_pose_terminator
+sGolduckPose111:
+ax_pose 33, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sGolduckPose112:
+ax_pose 34, 0x01e6, 0x80ee, 0x0c00
+ax_pose 35, 0x01e6, 0x80ee, 0x0c10
+ax_pose_terminator
+sGolduckPose113:
+ax_pose 35, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sGolduckPose114:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose115:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose116:
+ax_pose 5, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose117:
+ax_pose 28, 0x81e6, 0x80ef, 0x0c00
+ax_pose 29, 0x01e4, 0x80f0, 0x0c08
+ax_pose_terminator
+sGolduckPose118:
+ax_pose 29, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose119:
+ax_pose 30, 0x01e6, 0x80ee, 0x0c00
+ax_pose 31, 0x01e4, 0x80f0, 0x0c10
+ax_pose_terminator
+sGolduckPose120:
+ax_pose 31, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose121:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose122:
+ax_pose 43, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose123:
+ax_pose 44, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose124:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose125:
+ax_pose 45, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose126:
+ax_pose 46, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose127:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose128:
+ax_pose 47, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sGolduckPose129:
+ax_pose 48, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sGolduckPose130:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose131:
+ax_pose 49, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose132:
+ax_pose 50, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose133:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose134:
+ax_pose 51, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose135:
+ax_pose 52, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose136:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose137:
+ax_pose 49, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose138:
+ax_pose 50, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose139:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose140:
+ax_pose 47, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sGolduckPose141:
+ax_pose 48, 0x01e6, 0x80ed, 0x0c00
+ax_pose_terminator
+sGolduckPose142:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose143:
+ax_pose 45, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose144:
+ax_pose 46, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose145:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose146:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose147:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose148:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose149:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose150:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose151:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose152:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose153:
+ax_pose 53, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose154:
+ax_pose 54, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose155:
+ax_pose 55, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sGolduckPose156:
+ax_pose 56, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose157:
+ax_pose 57, 0x01e4, 0x90ec, 0x0c00
+ax_pose_terminator
+sGolduckPose158:
+ax_pose 58, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose159:
+ax_pose 59, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose160:
+ax_pose 58, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sGolduckPose161:
+ax_pose 57, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sGolduckPose162:
+ax_pose 56, 0x01e3, 0x80f6, 0x0c00
+ax_pose_terminator
+sGolduckPose163:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose164:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose165:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose166:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose167:
+ax_pose 4, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose168:
+ax_pose 5, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose169:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose170:
+ax_pose 7, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose171:
+ax_pose 8, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose172:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose173:
+ax_pose 10, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose174:
+ax_pose 11, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose175:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose176:
+ax_pose 13, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose177:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose178:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose179:
+ax_pose 10, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose180:
+ax_pose 11, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose181:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose182:
+ax_pose 7, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose183:
+ax_pose 8, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose184:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose185:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose186:
+ax_pose 5, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose187:
+ax_pose 44, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose188:
+ax_pose 46, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose189:
+ax_pose 48, 0x01e6, 0x80ef, 0x0c00
+ax_pose_terminator
+sGolduckPose190:
+ax_pose 50, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose191:
+ax_pose 52, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose192:
+ax_pose 50, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sGolduckPose193:
+ax_pose 48, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sGolduckPose194:
+ax_pose 46, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sGolduckPose195:
+ax_pose 44, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose196:
+ax_pose 46, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sGolduckPose197:
+ax_pose 48, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sGolduckPose198:
+ax_pose 50, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sGolduckPose199:
+ax_pose 52, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose200:
+ax_pose 50, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose201:
+ax_pose 48, 0x01e6, 0x80ef, 0x0c00
+ax_pose_terminator
+sGolduckPose202:
+ax_pose 46, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose203:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose204:
+ax_pose 43, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose205:
+ax_pose 44, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose206:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose207:
+ax_pose 45, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose208:
+ax_pose 46, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose209:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose210:
+ax_pose 47, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sGolduckPose211:
+ax_pose 48, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sGolduckPose212:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose213:
+ax_pose 49, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose214:
+ax_pose 50, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose215:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose216:
+ax_pose 51, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose217:
+ax_pose 52, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose218:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose219:
+ax_pose 49, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose220:
+ax_pose 50, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose221:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose222:
+ax_pose 47, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sGolduckPose223:
+ax_pose 48, 0x01e6, 0x80ef, 0x0c00
+ax_pose_terminator
+sGolduckPose224:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose225:
+ax_pose 45, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose226:
+ax_pose 46, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose227:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose228:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose229:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose230:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose231:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose232:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose233:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose234:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose235:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose236:
+ax_pose 3, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose237:
+ax_pose 6, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGolduckPose238:
+ax_pose 9, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGolduckPose239:
+ax_pose 12, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGolduckPose240:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGolduckPose241:
+ax_pose 6, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGolduckPose242:
+ax_pose 3, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+.align 2
+sGolduckAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_2_1:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, -2, 0, 0,
+ax_anim 6, 0, 27, 0, -6, 0, 1,
+ax_anim 1, 0, 28, 0, -4, 0, 3,
+ax_anim 2, 2, 28, 0, 7, 0, 12,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sGolduckAnims_2_2:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 1, -2, 2, 2,
+ax_anim 6, 0, 32, 3, -6, 3, 2,
+ax_anim 1, 0, 33, 8, -2, 8, 8,
+ax_anim 2, 2, 33, 13, 9, 13, 14,
+ax_anim 2, 0, 33, 17, 19, 17, 19,
+ax_anim 2, 1, 33, 16, 20, 17, 20,
+ax_anim 2, 0, 33, 17, 19, 17, 19,
+ax_anim 2, 0, 33, 16, 20, 17, 20,
+ax_anim 2, 0, 33, 17, 19, 17, 19,
+ax_anim 2, 0, 33, 16, 20, 17, 20,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sGolduckAnims_2_3:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 2, -2, 2, 0,
+ax_anim 6, 0, 37, 3, -6, 3, 0,
+ax_anim 1, 0, 38, 8, -9, 8, 0,
+ax_anim 2, 2, 38, 13, -6, 13, 0,
+ax_anim 2, 0, 38, 17, 0, 17, 0,
+ax_anim 2, 1, 38, 17, 1, 17, 1,
+ax_anim 2, 0, 38, 17, 0, 17, 0,
+ax_anim 2, 0, 38, 17, 1, 17, 1,
+ax_anim 2, 0, 38, 17, 0, 17, 0,
+ax_anim 2, 0, 38, 17, 1, 17, 1,
+ax_anim 2, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sGolduckAnims_2_4:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, -2, 1, -2,
+ax_anim 6, 0, 42, 2, -6, 2, -3,
+ax_anim 1, 0, 43, 6, -13, 6, -7,
+ax_anim 2, 2, 43, 13, -16, 13, -13,
+ax_anim 2, 0, 43, 18, -18, 18, -18,
+ax_anim 2, 1, 43, 19, -17, 19, -17,
+ax_anim 2, 0, 43, 18, -18, 18, -18,
+ax_anim 2, 0, 43, 19, -17, 19, -17,
+ax_anim 2, 0, 43, 18, -18, 18, -18,
+ax_anim 2, 0, 43, 19, -17, 19, -17,
+ax_anim 2, 0, 39, 8, -8, 8, -8,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sGolduckAnims_2_5:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, -2, 0, -1,
+ax_anim 6, 0, 47, 0, -6, 0, -2,
+ax_anim 1, 0, 48, 0, -9, 0, -7,
+ax_anim 2, 2, 48, 0, -13, 0, -10,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 1, 48, 1, -16, 1, -16,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 0, 48, 1, -16, 1, -16,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 0, 48, 1, -16, 1, -16,
+ax_anim 2, 0, 44, 0, -8, 0, -8,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sGolduckAnims_2_6:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 52, -1, -2, -1, -2,
+ax_anim 6, 0, 52, -2, -6, -2, -3,
+ax_anim 1, 0, 53, -6, -13, -6, -7,
+ax_anim 2, 2, 53, -13, -16, -13, -13,
+ax_anim 2, 0, 53, -18, -18, -18, -18,
+ax_anim 2, 1, 53, -19, -17, -19, -17,
+ax_anim 2, 0, 53, -18, -18, -18, -18,
+ax_anim 2, 0, 53, -19, -17, -19, -17,
+ax_anim 2, 0, 53, -18, -18, -18, -18,
+ax_anim 2, 0, 53, -19, -17, -19, -17,
+ax_anim 2, 0, 49, -8, -8, -8, -8,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sGolduckAnims_2_7:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -2, -2, -2, 0,
+ax_anim 6, 0, 57, -3, -6, -3, 0,
+ax_anim 1, 0, 58, -8, -9, -8, 0,
+ax_anim 2, 2, 58, -13, -6, -13, 0,
+ax_anim 2, 0, 58, -17, 0, -17, 0,
+ax_anim 2, 1, 58, -17, 1, -17, 1,
+ax_anim 2, 0, 58, -17, 0, -17, 0,
+ax_anim 2, 0, 58, -17, 1, -17, 1,
+ax_anim 2, 0, 58, -17, 0, -17, 0,
+ax_anim 2, 0, 58, -17, 1, -17, 1,
+ax_anim 2, 0, 54, -8, 0, -8, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sGolduckAnims_2_8:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 62, -1, -2, -2, 2,
+ax_anim 6, 0, 62, -3, -6, -3, 2,
+ax_anim 1, 0, 63, -8, -2, -8, 8,
+ax_anim 2, 2, 63, -13, 9, -13, 14,
+ax_anim 2, 0, 63, -17, 19, -17, 19,
+ax_anim 2, 1, 63, -16, 20, -17, 20,
+ax_anim 2, 0, 63, -17, 19, -17, 19,
+ax_anim 2, 0, 63, -16, 20, -17, 20,
+ax_anim 2, 0, 63, -17, 19, -17, 19,
+ax_anim 2, 0, 63, -16, 20, -17, 20,
+ax_anim 2, 0, 59, -8, 8, -8, 8,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGolduckAnims_3_1:
+ax_anim 4, 0, 119, 0, 3, 0, 3,
+ax_anim 2, 2, 119, 0, 3, 0, 3,
+ax_anim 2, 0, 67, 0, 16, 0, 16,
+ax_anim 2, 1, 68, 1, 17, 1, 17,
+ax_anim 2, 0, 72, 1, 13, 1, 13,
+ax_anim 6, 0, 77, 0, 11, 0, 11,
+ax_anim 2, 0, 69, 0, 16, 0, 16,
+ax_anim 2, 0, 70, -1, 17, -1, 17,
+ax_anim 2, 0, 65, -1, 13, -1, 13,
+ax_anim 2, 0, 66, 0, 9, 0, 9,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim_terminator
+sGolduckAnims_3_2:
+ax_anim 4, 0, 84, 6, 6, 6, 6,
+ax_anim 2, 2, 84, 6, 6, 6, 6,
+ax_anim 2, 0, 74, 16, 17, 16, 17,
+ax_anim 2, 1, 75, 15, 19, 15, 19,
+ax_anim 2, 0, 65, 13, 15, 13, 15,
+ax_anim 6, 0, 70, 11, 13, 11, 13,
+ax_anim 2, 0, 76, 16, 17, 16, 17,
+ax_anim 2, 0, 77, 18, 16, 18, 16,
+ax_anim 2, 0, 73, 17, 13, 17, 13,
+ax_anim 2, 0, 72, 8, 7, 8, 7,
+ax_anim 2, 0, 73, 3, 3, 3, 3,
+ax_anim_terminator
+sGolduckAnims_3_3:
+ax_anim 4, 0, 91, 6, 0, 6, 0,
+ax_anim 2, 2, 91, 6, 0, 6, 0,
+ax_anim 2, 0, 81, 14, 0, 14, 0,
+ax_anim 2, 1, 82, 15, 2, 15, 2,
+ax_anim 2, 0, 73, 13, 2, 13, 2,
+ax_anim 6, 0, 75, 9, 2, 9, 2,
+ax_anim 2, 0, 83, 14, 0, 14, 0,
+ax_anim 2, 0, 84, 15, -2, 15, -2,
+ax_anim 2, 0, 80, 8, -1, 8, -2,
+ax_anim 2, 0, 79, 5, 0, 5, -2,
+ax_anim 2, 0, 80, 3, 0, 3, -1,
+ax_anim_terminator
+sGolduckAnims_3_4:
+ax_anim 4, 0, 96, 6, -7, 6, -7,
+ax_anim 2, 2, 96, 6, -7, 6, -7,
+ax_anim 2, 0, 88, 16, -18, 16, -18,
+ax_anim 2, 1, 89, 18, -18, 18, -18,
+ax_anim 2, 0, 80, 14, -14, 14, -14,
+ax_anim 6, 0, 82, 10, -12, 10, -12,
+ax_anim 2, 0, 90, 16, -18, 16, -18,
+ax_anim 2, 0, 91, 16, -20, 16, -20,
+ax_anim 2, 0, 87, 9, -11, 9, -11,
+ax_anim 2, 0, 86, 6, -7, 6, -7,
+ax_anim 2, 0, 87, 3, -4, 3, -4,
+ax_anim_terminator
+sGolduckAnims_3_5:
+ax_anim 4, 0, 89, 0, -6, 0, -6,
+ax_anim 2, 2, 89, 0, -6, 0, -6,
+ax_anim 2, 0, 95, 0, -17, 0, -17,
+ax_anim 2, 1, 96, -1, -18, -1, -18,
+ax_anim 2, 0, 101, -1, -14, -1, -14,
+ax_anim 6, 0, 103, 0, -10, 0, -10,
+ax_anim 2, 0, 97, 0, -17, 0, -17,
+ax_anim 2, 0, 98, 1, -18, 1, -18,
+ax_anim 2, 0, 94, 1, -7, 1, -7,
+ax_anim 2, 0, 93, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim_terminator
+sGolduckAnims_3_6:
+ax_anim 4, 0, 98, -6, -7, -6, -7,
+ax_anim 2, 2, 98, -6, -7, -6, -7,
+ax_anim 2, 0, 102, -16, -18, -16, -18,
+ax_anim 2, 1, 103, -18, -18, -18, -18,
+ax_anim 2, 0, 108, -14, -14, -14, -14,
+ax_anim 6, 0, 110, -10, -12, -10, -12,
+ax_anim 2, 0, 104, -16, -18, -16, -18,
+ax_anim 2, 0, 105, -16, -20, -16, -20,
+ax_anim 2, 0, 101, -9, -11, -9, -11,
+ax_anim 2, 0, 100, -6, -7, -6, -7,
+ax_anim 2, 0, 101, -3, -4, -3, -4,
+ax_anim_terminator
+sGolduckAnims_3_7:
+ax_anim 4, 0, 105, -6, 0, -6, 0,
+ax_anim 2, 2, 105, -6, 0, -6, 0,
+ax_anim 2, 0, 109, -14, 0, -14, 0,
+ax_anim 2, 1, 110, -15, 2, -15, 2,
+ax_anim 2, 0, 115, -13, 2, -13, 2,
+ax_anim 6, 0, 117, -9, 2, -9, 2,
+ax_anim 2, 0, 111, -14, 0, -14, 0,
+ax_anim 2, 0, 112, -15, -2, -15, -2,
+ax_anim 2, 0, 108, -8, -1, -8, -2,
+ax_anim 2, 0, 107, -5, 0, -5, -2,
+ax_anim 2, 0, 108, -3, 0, -3, -1,
+ax_anim_terminator
+sGolduckAnims_3_8:
+ax_anim 4, 0, 112, -6, 6, -6, 6,
+ax_anim 2, 2, 112, -6, 6, -6, 6,
+ax_anim 2, 0, 116, -16, 17, -16, 17,
+ax_anim 2, 1, 117, -15, 19, -15, 19,
+ax_anim 2, 0, 66, -13, 15, -13, 15,
+ax_anim 6, 0, 68, -11, 13, -11, 13,
+ax_anim 2, 0, 118, -16, 17, -16, 17,
+ax_anim 2, 0, 119, -18, 16, -18, 16,
+ax_anim 2, 0, 115, -17, 13, -17, 13,
+ax_anim 2, 0, 114, -8, 7, -8, 7,
+ax_anim 2, 0, 115, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sGolduckAnims_4_1:
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim 2, 0, 121, 0, -3, 0, -3,
+ax_anim 6, 2, 121, 0, -4, 0, -4,
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 2, 1, 122, 0, 1, 0, 1,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim 2, 0, 122, 0, 1, 0, 1,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim 2, 0, 122, 0, 1, 0, 1,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim_terminator
+sGolduckAnims_4_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim 6, 2, 124, -4, -4, -4, -4,
+ax_anim 2, 0, 125, -2, -2, -2, -2,
+ax_anim 2, 1, 125, 1, 1, 1, 1,
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim 2, 0, 125, 1, 1, 1, 1,
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim 2, 0, 125, 1, 1, 1, 1,
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim_terminator
+sGolduckAnims_4_3:
+ax_anim 2, 0, 126, -2, 0, -2, 0,
+ax_anim 2, 0, 127, -3, 0, -3, 0,
+ax_anim 6, 2, 127, -4, 0, -4, 0,
+ax_anim 2, 0, 128, -2, 0, -2, 0,
+ax_anim 2, 1, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 1, 1, 1, 1,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 1, 1, 1, 1,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 1, 1, 1, 1,
+ax_anim_terminator
+sGolduckAnims_4_4:
+ax_anim 2, 0, 129, -2, 2, -2, 2,
+ax_anim 2, 0, 130, -3, 3, -3, 3,
+ax_anim 6, 2, 130, -4, 4, -4, 4,
+ax_anim 2, 0, 131, -2, 2, -2, 2,
+ax_anim 2, 1, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim_terminator
+sGolduckAnims_4_5:
+ax_anim 2, 0, 132, 0, 2, 0, 2,
+ax_anim 2, 0, 133, 0, 3, 0, 3,
+ax_anim 6, 2, 133, 0, 4, 0, 4,
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 2, 1, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim_terminator
+sGolduckAnims_4_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 2, 0, 136, 3, 3, 3, 3,
+ax_anim 6, 2, 136, 4, 4, 4, 4,
+ax_anim 2, 0, 137, 2, 2, 2, 2,
+ax_anim 2, 1, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, -2, 0, -2, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, -2, 0, -2, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, -2, 0, -2, 0,
+ax_anim_terminator
+sGolduckAnims_4_7:
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 0, 139, 3, 0, 3, 0,
+ax_anim 6, 2, 139, 4, 0, 4, 0,
+ax_anim 2, 0, 140, 2, 0, 2, 0,
+ax_anim 2, 1, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, -1, 1, -1, 1,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, -1, 1, -1, 1,
+ax_anim 2, 0, 140, -1, 0, -1, 0,
+ax_anim 2, 0, 140, -1, 1, -1, 1,
+ax_anim_terminator
+sGolduckAnims_4_8:
+ax_anim 2, 0, 141, 2, -2, 2, -2,
+ax_anim 2, 0, 142, 3, -3, 3, -3,
+ax_anim 6, 2, 142, 4, -4, 4, -4,
+ax_anim 2, 0, 143, 2, -2, 2, -2,
+ax_anim 2, 1, 143, -1, 1, -1, 1,
+ax_anim 2, 0, 143, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -1, 1, -1, 1,
+ax_anim 2, 0, 143, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -1, 1, -1, 1,
+ax_anim 2, 0, 143, -2, 0, -2, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_5_1:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_5_2:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_5_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_5_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_5_5:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_5_6:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_5_7:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_5_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_6_1:
+ax_anim 35, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sGolduckAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sGolduckAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sGolduckAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sGolduckAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sGolduckAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sGolduckAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sGolduckAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGolduckAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_8_2:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_8_4:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 0, 0, 0, 0,
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_8_5:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_8_6:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 178, 0, 0, 0, 0,
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_8_7:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 20, 0, 181, 0, 0, 0, 0,
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 20, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_8_8:
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 20, 0, 184, 0, 0, 0, 0,
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 20, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 16, 7, 16,
+ax_anim 3, 0, 190, 0, 20, 0, 20,
+ax_anim 2, 3, 191, -7, 16, -7, 16,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 19, 3, 19, 3,
+ax_anim 2, 0, 188, 23, 10, 23, 10,
+ax_anim 3, 0, 189, 22, 20, 22, 20,
+ax_anim 2, 3, 190, 11, 19, 11, 19,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 18, -5, 18, -5,
+ax_anim 3, 0, 188, 21, -2, 21, -2,
+ax_anim 2, 3, 189, 18, 4, 18, 4,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -6, -1, -6,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 21, -22, 21, -22,
+ax_anim 2, 3, 188, 22, -15, 22, -15,
+ax_anim 2, 0, 189, 17, -4, 17, -4,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -22, 0, -22,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 9, -10, 9, -10,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -6, 1, -6,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -21, -22, -21, -22,
+ax_anim 2, 3, 192, -22, -15, -22, -15,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -18, -5, -18, -5,
+ax_anim 3, 0, 192, -21, -2, -21, -2,
+ax_anim 2, 3, 191, -18, 4, -18, 4,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -19, 3, -19, 3,
+ax_anim 2, 0, 192, -23, 10, -23, 10,
+ax_anim 3, 0, 191, -22, 20, -22, 20,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -24, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -24, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -24, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -24, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -24, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolduckAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sGolduckGfx1:
+.incbin "baserom.gba", 0x765B94, 0x200
+sGolduckSprites1:
+ax_sprite sGolduckGfx1, 0x200
+ax_sprite_terminator
+sGolduckGfx2:
+.incbin "baserom.gba", 0x765DA4, 0x200
+sGolduckSprites2:
+ax_sprite sGolduckGfx2, 0x200
+ax_sprite_terminator
+sGolduckGfx3:
+.incbin "baserom.gba", 0x765FB4, 0x200
+sGolduckSprites3:
+ax_sprite sGolduckGfx3, 0x200
+ax_sprite_terminator
+sGolduckGfx4:
+.incbin "baserom.gba", 0x7661C4, 0x200
+sGolduckSprites4:
+ax_sprite sGolduckGfx4, 0x200
+ax_sprite_terminator
+sGolduckGfx5:
+.incbin "baserom.gba", 0x7663D4, 0x200
+sGolduckSprites5:
+ax_sprite sGolduckGfx5, 0x200
+ax_sprite_terminator
+sGolduckGfx6:
+.incbin "baserom.gba", 0x7665E4, 0x200
+sGolduckSprites6:
+ax_sprite sGolduckGfx6, 0x200
+ax_sprite_terminator
+sGolduckGfx7:
+.incbin "baserom.gba", 0x7667F4, 0x200
+sGolduckSprites7:
+ax_sprite sGolduckGfx7, 0x200
+ax_sprite_terminator
+sGolduckGfx8:
+.incbin "baserom.gba", 0x766A04, 0x200
+sGolduckSprites8:
+ax_sprite sGolduckGfx8, 0x200
+ax_sprite_terminator
+sGolduckGfx9:
+.incbin "baserom.gba", 0x766C14, 0x200
+sGolduckSprites9:
+ax_sprite sGolduckGfx9, 0x200
+ax_sprite_terminator
+sGolduckGfx10:
+.incbin "baserom.gba", 0x766E24, 0x200
+sGolduckSprites10:
+ax_sprite sGolduckGfx10, 0x200
+ax_sprite_terminator
+sGolduckGfx11:
+.incbin "baserom.gba", 0x767034, 0x200
+sGolduckSprites11:
+ax_sprite sGolduckGfx11, 0x200
+ax_sprite_terminator
+sGolduckGfx12:
+.incbin "baserom.gba", 0x767244, 0x200
+sGolduckSprites12:
+ax_sprite sGolduckGfx12, 0x200
+ax_sprite_terminator
+sGolduckGfx13:
+.incbin "baserom.gba", 0x767454, 0x200
+sGolduckSprites13:
+ax_sprite sGolduckGfx13, 0x200
+ax_sprite_terminator
+sGolduckGfx14:
+.incbin "baserom.gba", 0x767664, 0x200
+sGolduckSprites14:
+ax_sprite sGolduckGfx14, 0x200
+ax_sprite_terminator
+sGolduckGfx15:
+.incbin "baserom.gba", 0x767874, 0x200
+sGolduckSprites15:
+ax_sprite sGolduckGfx15, 0x200
+ax_sprite_terminator
+sGolduckGfx16:
+.incbin "baserom.gba", 0x767A84, 0x40
+sGolduckGfx16_1:
+.incbin "baserom.gba", 0x767AC4, 0x100
+sGolduckGfx16_2:
+.incbin "baserom.gba", 0x767BC4, 0x40
+sGolduckSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx17:
+.incbin "baserom.gba", 0x767C44, 0x140
+sGolduckSprites17:
+ax_sprite 0, 0xa0
+ax_sprite sGolduckGfx17, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx18:
+.incbin "baserom.gba", 0x767DA4, 0x60
+sGolduckGfx18_1:
+.incbin "baserom.gba", 0x767E04, 0x160
+sGolduckSprites18:
+ax_sprite sGolduckGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx18_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx19:
+.incbin "baserom.gba", 0x767F8C, 0x60
+sGolduckGfx19_1:
+.incbin "baserom.gba", 0x767FEC, 0x60
+sGolduckGfx19_2:
+.incbin "baserom.gba", 0x76804C, 0x60
+sGolduckSprites19:
+ax_sprite 0, 0x80
+ax_sprite sGolduckGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx20:
+.incbin "baserom.gba", 0x7680EC, 0x60
+sGolduckGfx20_1:
+.incbin "baserom.gba", 0x76814C, 0x100
+sGolduckGfx20_2:
+.incbin "baserom.gba", 0x76824C, 0x40
+sGolduckSprites20:
+ax_sprite sGolduckGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx21:
+.incbin "baserom.gba", 0x7682C4, 0x160
+sGolduckSprites21:
+ax_sprite 0, 0x80
+ax_sprite sGolduckGfx21, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx22:
+.incbin "baserom.gba", 0x768444, 0x40
+sGolduckGfx22_1:
+.incbin "baserom.gba", 0x768484, 0x160
+sGolduckSprites22:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx23:
+.incbin "baserom.gba", 0x768614, 0x40
+sGolduckGfx23_1:
+.incbin "baserom.gba", 0x768654, 0x60
+sGolduckGfx23_2:
+.incbin "baserom.gba", 0x7686B4, 0x60
+sGolduckGfx23_3:
+.incbin "baserom.gba", 0x768714, 0x60
+sGolduckSprites23:
+ax_sprite sGolduckGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx24:
+.incbin "baserom.gba", 0x7687BC, 0x40
+sGolduckGfx24_1:
+.incbin "baserom.gba", 0x7687FC, 0x60
+sGolduckGfx24_2:
+.incbin "baserom.gba", 0x76885C, 0xE0
+sGolduckSprites24:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx24_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx25:
+.incbin "baserom.gba", 0x76897C, 0x60
+sGolduckGfx25_1:
+.incbin "baserom.gba", 0x7689DC, 0x60
+sGolduckGfx25_2:
+.incbin "baserom.gba", 0x768A3C, 0x60
+sGolduckGfx25_3:
+.incbin "baserom.gba", 0x768A9C, 0x60
+sGolduckSprites25:
+ax_sprite sGolduckGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx26:
+.incbin "baserom.gba", 0x768B44, 0x20
+sGolduckGfx26_1:
+.incbin "baserom.gba", 0x768B64, 0x20
+sGolduckGfx26_2:
+.incbin "baserom.gba", 0x768B84, 0x60
+sGolduckGfx26_3:
+.incbin "baserom.gba", 0x768BE4, 0x60
+sGolduckSprites26:
+ax_sprite sGolduckGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGolduckGfx26_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGolduckGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx27:
+.incbin "baserom.gba", 0x768C8C, 0x1E0
+sGolduckSprites27:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx27, 0x1e0
+ax_sprite_terminator
+sGolduckGfx28:
+.incbin "baserom.gba", 0x768E84, 0x60
+sGolduckGfx28_1:
+.incbin "baserom.gba", 0x768EE4, 0x180
+sGolduckSprites28:
+ax_sprite sGolduckGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx28_1, 0x180
+ax_sprite_terminator
+sGolduckGfx29:
+.incbin "baserom.gba", 0x769084, 0x40
+sGolduckGfx29_1:
+.incbin "baserom.gba", 0x7690C4, 0x20
+sGolduckGfx29_2:
+.incbin "baserom.gba", 0x7690E4, 0x40
+sGolduckSprites29:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx29_2, 0x40
+ax_sprite_terminator
+sGolduckGfx30:
+.incbin "baserom.gba", 0x76915C, 0x40
+sGolduckGfx30_1:
+.incbin "baserom.gba", 0x76919C, 0x180
+sGolduckSprites30:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx30_1, 0x180
+ax_sprite_terminator
+sGolduckGfx31:
+.incbin "baserom.gba", 0x769344, 0xA0
+sGolduckGfx31_1:
+.incbin "baserom.gba", 0x7693E4, 0x60
+sGolduckSprites31:
+ax_sprite 0, 0xc0
+ax_sprite sGolduckGfx31, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx32:
+.incbin "baserom.gba", 0x769474, 0x20
+sGolduckGfx32_1:
+.incbin "baserom.gba", 0x769494, 0x60
+sGolduckGfx32_2:
+.incbin "baserom.gba", 0x7694F4, 0x60
+sGolduckGfx32_3:
+.incbin "baserom.gba", 0x769554, 0x60
+sGolduckSprites32:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx32, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx33:
+.incbin "baserom.gba", 0x769604, 0x20
+sGolduckGfx33_1:
+.incbin "baserom.gba", 0x769624, 0x20
+sGolduckGfx33_2:
+.incbin "baserom.gba", 0x769644, 0x20
+sGolduckGfx33_3:
+.incbin "baserom.gba", 0x769664, 0x20
+sGolduckGfx33_4:
+.incbin "baserom.gba", 0x769684, 0x40
+sGolduckSprites33:
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx33_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx33_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx33_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGolduckGfx33_4, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGolduckGfx34:
+.incbin "baserom.gba", 0x769724, 0x20
+sGolduckGfx34_1:
+.incbin "baserom.gba", 0x769744, 0x100
+sGolduckGfx34_2:
+.incbin "baserom.gba", 0x769844, 0x60
+sGolduckSprites34:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx34, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx34_2, 0x60
+ax_sprite_terminator
+sGolduckGfx35:
+.incbin "baserom.gba", 0x7698DC, 0xA0
+sGolduckGfx35_1:
+.incbin "baserom.gba", 0x76997C, 0x40
+sGolduckSprites35:
+ax_sprite 0, 0x80
+ax_sprite sGolduckGfx35, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGolduckGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGolduckGfx36:
+.incbin "baserom.gba", 0x7699EC, 0x40
+sGolduckGfx36_1:
+.incbin "baserom.gba", 0x769A2C, 0x60
+sGolduckGfx36_2:
+.incbin "baserom.gba", 0x769A8C, 0x80
+sGolduckGfx36_3:
+.incbin "baserom.gba", 0x769B0C, 0x60
+sGolduckSprites36:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx36_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx36_3, 0x60
+ax_sprite_terminator
+sGolduckGfx37:
+.incbin "baserom.gba", 0x769BB4, 0x60
+sGolduckGfx37_1:
+.incbin "baserom.gba", 0x769C14, 0x20
+sGolduckGfx37_2:
+.incbin "baserom.gba", 0x769C34, 0x80
+sGolduckGfx37_3:
+.incbin "baserom.gba", 0x769CB4, 0x40
+sGolduckSprites37:
+ax_sprite sGolduckGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx37_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx37_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGolduckGfx38:
+.incbin "baserom.gba", 0x769D3C, 0x40
+sGolduckGfx38_1:
+.incbin "baserom.gba", 0x769D7C, 0x60
+sGolduckGfx38_2:
+.incbin "baserom.gba", 0x769DDC, 0x100
+sGolduckSprites38:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx38_2, 0x100
+ax_sprite_terminator
+sGolduckGfx39:
+.incbin "baserom.gba", 0x769F14, 0x20
+sGolduckGfx39_1:
+.incbin "baserom.gba", 0x769F34, 0x60
+sGolduckGfx39_2:
+.incbin "baserom.gba", 0x769F94, 0x40
+sGolduckSprites39:
+ax_sprite sGolduckGfx39, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGolduckGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx39_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sGolduckGfx40:
+.incbin "baserom.gba", 0x76A00C, 0xE0
+sGolduckGfx40_1:
+.incbin "baserom.gba", 0x76A0EC, 0xE0
+sGolduckSprites40:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx40, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx40_1, 0xe0
+ax_sprite_terminator
+sGolduckGfx41:
+.incbin "baserom.gba", 0x76A1F4, 0x40
+sGolduckGfx41_1:
+.incbin "baserom.gba", 0x76A234, 0x60
+sGolduckSprites41:
+ax_sprite sGolduckGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx41_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGolduckGfx42:
+.incbin "baserom.gba", 0x76A2BC, 0x40
+sGolduckGfx42_1:
+.incbin "baserom.gba", 0x76A2FC, 0x160
+sGolduckSprites42:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx42_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx43:
+.incbin "baserom.gba", 0x76A48C, 0x40
+sGolduckGfx43_1:
+.incbin "baserom.gba", 0x76A4CC, 0x100
+sGolduckGfx43_2:
+.incbin "baserom.gba", 0x76A5CC, 0x60
+sGolduckSprites43:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx43_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx43_2, 0x60
+ax_sprite_terminator
+sGolduckGfx44:
+.incbin "baserom.gba", 0x76A664, 0x40
+sGolduckGfx44_1:
+.incbin "baserom.gba", 0x76A6A4, 0x180
+sGolduckSprites44:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx44_1, 0x180
+ax_sprite_terminator
+sGolduckGfx45:
+.incbin "baserom.gba", 0x76A84C, 0x40
+sGolduckGfx45_1:
+.incbin "baserom.gba", 0x76A88C, 0x60
+sGolduckGfx45_2:
+.incbin "baserom.gba", 0x76A8EC, 0x100
+sGolduckSprites45:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx45_2, 0x100
+ax_sprite_terminator
+sGolduckGfx46:
+.incbin "baserom.gba", 0x76AA24, 0x40
+sGolduckGfx46_1:
+.incbin "baserom.gba", 0x76AA64, 0x160
+sGolduckSprites46:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx46_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx47:
+.incbin "baserom.gba", 0x76ABF4, 0x20
+sGolduckGfx47_1:
+.incbin "baserom.gba", 0x76AC14, 0x160
+sGolduckSprites47:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx47, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx47_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx48:
+.incbin "baserom.gba", 0x76ADA4, 0x60
+sGolduckGfx48_1:
+.incbin "baserom.gba", 0x76AE04, 0x60
+sGolduckGfx48_2:
+.incbin "baserom.gba", 0x76AE64, 0x60
+sGolduckGfx48_3:
+.incbin "baserom.gba", 0x76AEC4, 0x40
+sGolduckSprites48:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx48_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx49:
+.incbin "baserom.gba", 0x76AF54, 0x20
+sGolduckGfx49_1:
+.incbin "baserom.gba", 0x76AF74, 0x60
+sGolduckGfx49_2:
+.incbin "baserom.gba", 0x76AFD4, 0x80
+sGolduckGfx49_3:
+.incbin "baserom.gba", 0x76B054, 0x40
+sGolduckSprites49:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx49, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx49_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx49_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx50:
+.incbin "baserom.gba", 0x76B0E4, 0x40
+sGolduckGfx50_1:
+.incbin "baserom.gba", 0x76B124, 0x60
+sGolduckGfx50_2:
+.incbin "baserom.gba", 0x76B184, 0x60
+sGolduckGfx50_3:
+.incbin "baserom.gba", 0x76B1E4, 0x60
+sGolduckSprites50:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx50_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx51:
+.incbin "baserom.gba", 0x76B294, 0x40
+sGolduckGfx51_1:
+.incbin "baserom.gba", 0x76B2D4, 0x60
+sGolduckGfx51_2:
+.incbin "baserom.gba", 0x76B334, 0xE0
+sGolduckSprites51:
+ax_sprite sGolduckGfx51, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGolduckGfx51_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx51_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx52:
+.incbin "baserom.gba", 0x76B44C, 0x40
+sGolduckGfx52_1:
+.incbin "baserom.gba", 0x76B48C, 0x60
+sGolduckGfx52_2:
+.incbin "baserom.gba", 0x76B4EC, 0x60
+sGolduckGfx52_3:
+.incbin "baserom.gba", 0x76B54C, 0x60
+sGolduckSprites52:
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx52, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx52_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx53:
+.incbin "baserom.gba", 0x76B5FC, 0x60
+sGolduckGfx53_1:
+.incbin "baserom.gba", 0x76B65C, 0x60
+sGolduckGfx53_2:
+.incbin "baserom.gba", 0x76B6BC, 0x60
+sGolduckGfx53_3:
+.incbin "baserom.gba", 0x76B71C, 0x60
+sGolduckSprites53:
+ax_sprite sGolduckGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx53_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx53_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolduckGfx53_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGolduckGfx54:
+.incbin "baserom.gba", 0x76B7C4, 0x200
+sGolduckSprites54:
+ax_sprite sGolduckGfx54, 0x200
+ax_sprite_terminator
+sGolduckGfx55:
+.incbin "baserom.gba", 0x76B9D4, 0x200
+sGolduckSprites55:
+ax_sprite sGolduckGfx55, 0x200
+ax_sprite_terminator
+sGolduckGfx56:
+.incbin "baserom.gba", 0x76BBE4, 0x200
+sGolduckSprites56:
+ax_sprite sGolduckGfx56, 0x200
+ax_sprite_terminator
+sGolduckGfx57:
+.incbin "baserom.gba", 0x76BDF4, 0x200
+sGolduckSprites57:
+ax_sprite sGolduckGfx57, 0x200
+ax_sprite_terminator
+sGolduckGfx58:
+.incbin "baserom.gba", 0x76C004, 0x200
+sGolduckSprites58:
+ax_sprite sGolduckGfx58, 0x200
+ax_sprite_terminator
+sGolduckGfx59:
+.incbin "baserom.gba", 0x76C214, 0x200
+sGolduckSprites59:
+ax_sprite sGolduckGfx59, 0x200
+ax_sprite_terminator
+sGolduckGfx60:
+.incbin "baserom.gba", 0x76C424, 0x200
+sGolduckSprites60:
+ax_sprite sGolduckGfx60, 0x200
+ax_sprite_terminator
+sAxPosesGolduck:
+.4byte sGolduckPose1
+.4byte sGolduckPose2
+.4byte sGolduckPose3
+.4byte sGolduckPose4
+.4byte sGolduckPose5
+.4byte sGolduckPose6
+.4byte sGolduckPose7
+.4byte sGolduckPose8
+.4byte sGolduckPose9
+.4byte sGolduckPose10
+.4byte sGolduckPose11
+.4byte sGolduckPose12
+.4byte sGolduckPose13
+.4byte sGolduckPose14
+.4byte sGolduckPose15
+.4byte sGolduckPose16
+.4byte sGolduckPose17
+.4byte sGolduckPose18
+.4byte sGolduckPose19
+.4byte sGolduckPose20
+.4byte sGolduckPose21
+.4byte sGolduckPose22
+.4byte sGolduckPose23
+.4byte sGolduckPose24
+.4byte sGolduckPose25
+.4byte sGolduckPose26
+.4byte sGolduckPose27
+.4byte sGolduckPose28
+.4byte sGolduckPose29
+.4byte sGolduckPose30
+.4byte sGolduckPose31
+.4byte sGolduckPose32
+.4byte sGolduckPose33
+.4byte sGolduckPose34
+.4byte sGolduckPose35
+.4byte sGolduckPose36
+.4byte sGolduckPose37
+.4byte sGolduckPose38
+.4byte sGolduckPose39
+.4byte sGolduckPose40
+.4byte sGolduckPose41
+.4byte sGolduckPose42
+.4byte sGolduckPose43
+.4byte sGolduckPose44
+.4byte sGolduckPose45
+.4byte sGolduckPose46
+.4byte sGolduckPose47
+.4byte sGolduckPose48
+.4byte sGolduckPose49
+.4byte sGolduckPose50
+.4byte sGolduckPose51
+.4byte sGolduckPose52
+.4byte sGolduckPose53
+.4byte sGolduckPose54
+.4byte sGolduckPose55
+.4byte sGolduckPose56
+.4byte sGolduckPose57
+.4byte sGolduckPose58
+.4byte sGolduckPose59
+.4byte sGolduckPose60
+.4byte sGolduckPose61
+.4byte sGolduckPose62
+.4byte sGolduckPose63
+.4byte sGolduckPose64
+.4byte sGolduckPose65
+.4byte sGolduckPose66
+.4byte sGolduckPose67
+.4byte sGolduckPose68
+.4byte sGolduckPose69
+.4byte sGolduckPose70
+.4byte sGolduckPose71
+.4byte sGolduckPose72
+.4byte sGolduckPose73
+.4byte sGolduckPose74
+.4byte sGolduckPose75
+.4byte sGolduckPose76
+.4byte sGolduckPose77
+.4byte sGolduckPose78
+.4byte sGolduckPose79
+.4byte sGolduckPose80
+.4byte sGolduckPose81
+.4byte sGolduckPose82
+.4byte sGolduckPose83
+.4byte sGolduckPose84
+.4byte sGolduckPose85
+.4byte sGolduckPose86
+.4byte sGolduckPose87
+.4byte sGolduckPose88
+.4byte sGolduckPose89
+.4byte sGolduckPose90
+.4byte sGolduckPose91
+.4byte sGolduckPose92
+.4byte sGolduckPose93
+.4byte sGolduckPose94
+.4byte sGolduckPose95
+.4byte sGolduckPose96
+.4byte sGolduckPose97
+.4byte sGolduckPose98
+.4byte sGolduckPose99
+.4byte sGolduckPose100
+.4byte sGolduckPose101
+.4byte sGolduckPose102
+.4byte sGolduckPose103
+.4byte sGolduckPose104
+.4byte sGolduckPose105
+.4byte sGolduckPose106
+.4byte sGolduckPose107
+.4byte sGolduckPose108
+.4byte sGolduckPose109
+.4byte sGolduckPose110
+.4byte sGolduckPose111
+.4byte sGolduckPose112
+.4byte sGolduckPose113
+.4byte sGolduckPose114
+.4byte sGolduckPose115
+.4byte sGolduckPose116
+.4byte sGolduckPose117
+.4byte sGolduckPose118
+.4byte sGolduckPose119
+.4byte sGolduckPose120
+.4byte sGolduckPose121
+.4byte sGolduckPose122
+.4byte sGolduckPose123
+.4byte sGolduckPose124
+.4byte sGolduckPose125
+.4byte sGolduckPose126
+.4byte sGolduckPose127
+.4byte sGolduckPose128
+.4byte sGolduckPose129
+.4byte sGolduckPose130
+.4byte sGolduckPose131
+.4byte sGolduckPose132
+.4byte sGolduckPose133
+.4byte sGolduckPose134
+.4byte sGolduckPose135
+.4byte sGolduckPose136
+.4byte sGolduckPose137
+.4byte sGolduckPose138
+.4byte sGolduckPose139
+.4byte sGolduckPose140
+.4byte sGolduckPose141
+.4byte sGolduckPose142
+.4byte sGolduckPose143
+.4byte sGolduckPose144
+.4byte sGolduckPose145
+.4byte sGolduckPose146
+.4byte sGolduckPose147
+.4byte sGolduckPose148
+.4byte sGolduckPose149
+.4byte sGolduckPose150
+.4byte sGolduckPose151
+.4byte sGolduckPose152
+.4byte sGolduckPose153
+.4byte sGolduckPose154
+.4byte sGolduckPose155
+.4byte sGolduckPose156
+.4byte sGolduckPose157
+.4byte sGolduckPose158
+.4byte sGolduckPose159
+.4byte sGolduckPose160
+.4byte sGolduckPose161
+.4byte sGolduckPose162
+.4byte sGolduckPose163
+.4byte sGolduckPose164
+.4byte sGolduckPose165
+.4byte sGolduckPose166
+.4byte sGolduckPose167
+.4byte sGolduckPose168
+.4byte sGolduckPose169
+.4byte sGolduckPose170
+.4byte sGolduckPose171
+.4byte sGolduckPose172
+.4byte sGolduckPose173
+.4byte sGolduckPose174
+.4byte sGolduckPose175
+.4byte sGolduckPose176
+.4byte sGolduckPose177
+.4byte sGolduckPose178
+.4byte sGolduckPose179
+.4byte sGolduckPose180
+.4byte sGolduckPose181
+.4byte sGolduckPose182
+.4byte sGolduckPose183
+.4byte sGolduckPose184
+.4byte sGolduckPose185
+.4byte sGolduckPose186
+.4byte sGolduckPose187
+.4byte sGolduckPose188
+.4byte sGolduckPose189
+.4byte sGolduckPose190
+.4byte sGolduckPose191
+.4byte sGolduckPose192
+.4byte sGolduckPose193
+.4byte sGolduckPose194
+.4byte sGolduckPose195
+.4byte sGolduckPose196
+.4byte sGolduckPose197
+.4byte sGolduckPose198
+.4byte sGolduckPose199
+.4byte sGolduckPose200
+.4byte sGolduckPose201
+.4byte sGolduckPose202
+.4byte sGolduckPose203
+.4byte sGolduckPose204
+.4byte sGolduckPose205
+.4byte sGolduckPose206
+.4byte sGolduckPose207
+.4byte sGolduckPose208
+.4byte sGolduckPose209
+.4byte sGolduckPose210
+.4byte sGolduckPose211
+.4byte sGolduckPose212
+.4byte sGolduckPose213
+.4byte sGolduckPose214
+.4byte sGolduckPose215
+.4byte sGolduckPose216
+.4byte sGolduckPose217
+.4byte sGolduckPose218
+.4byte sGolduckPose219
+.4byte sGolduckPose220
+.4byte sGolduckPose221
+.4byte sGolduckPose222
+.4byte sGolduckPose223
+.4byte sGolduckPose224
+.4byte sGolduckPose225
+.4byte sGolduckPose226
+.4byte sGolduckPose227
+.4byte sGolduckPose228
+.4byte sGolduckPose229
+.4byte sGolduckPose230
+.4byte sGolduckPose231
+.4byte sGolduckPose232
+.4byte sGolduckPose233
+.4byte sGolduckPose234
+.4byte sGolduckPose235
+.4byte sGolduckPose236
+.4byte sGolduckPose237
+.4byte sGolduckPose238
+.4byte sGolduckPose239
+.4byte sGolduckPose240
+.4byte sGolduckPose241
+.4byte sGolduckPose242
+sAxPositionsGolduck:
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	 -11,  -12, 	   7,   -5, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -8, 	   9,   -9, 	  -1,  -10
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte    5,  -10, 	   9,  -11, 	  -2,   -3, 	   0,   -9
+.2byte    4,  -10, 	  11,   -9, 	  -6,   -6, 	  -1,   -9
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte    8,  -11, 	   0,   -8, 	   5,   -5, 	  -2,   -9
+.2byte    8,  -11, 	   5,   -9, 	   0,   -5, 	  -1,   -8
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte    7,  -12, 	  -5,  -11, 	  10,   -7, 	   0,   -9
+.2byte    7,  -12, 	   1,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -9,  -12, 	   3,  -11, 	 -12,   -7, 	  -2,   -9
+.2byte   -9,  -12, 	  -3,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,   -8, 	  -7,   -5, 	   0,   -9
+.2byte  -10,  -11, 	  -7,   -9, 	  -2,   -5, 	  -1,   -8
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte   -7,  -10, 	 -11,  -11, 	   0,   -3, 	  -2,   -9
+.2byte   -6,  -10, 	 -13,   -9, 	   4,   -6, 	  -1,   -9
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	 -11,  -12, 	   7,   -5, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -8, 	   9,   -9, 	  -1,  -10
+.2byte   -2,  -16, 	 -10,  -11, 	   3,   -8, 	   0,  -12
+.2byte    2,   -2, 	   0,    2, 	   9,  -11, 	  -3,   -5
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte    5,  -10, 	   9,  -11, 	  -2,   -3, 	   0,   -9
+.2byte    4,  -10, 	  11,   -9, 	  -6,   -6, 	  -1,   -9
+.2byte    3,  -19, 	   6,  -11, 	   1,   -9, 	   1,  -10
+.2byte    2,   -2, 	   0,   -2, 	  -5,  -10, 	   3,   -7
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte    8,  -11, 	   0,   -8, 	   5,   -5, 	  -2,   -9
+.2byte    8,  -11, 	   5,   -9, 	   0,   -5, 	  -1,   -8
+.2byte    2,  -19, 	   5,   -8, 	   4,   -9, 	   0,  -10
+.2byte    5,   -5, 	   3,   -4, 	  -2,   -3, 	   1,   -9
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte    7,  -12, 	  -5,  -11, 	  10,   -7, 	   0,   -9
+.2byte    7,  -12, 	   1,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -2,  -20, 	 -11,   -6, 	   5,  -15, 	  -4,   -9
+.2byte    5,  -10, 	   6,   -6, 	   9,  -10, 	   1,  -11
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte    2,  -20, 	   9,   -6, 	  -8,  -16, 	   0,  -10
+.2byte   -3,  -13, 	  -1,   -7, 	 -12,  -11, 	  -1,  -12
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -9,  -12, 	   3,  -11, 	 -12,   -7, 	  -2,   -9
+.2byte   -9,  -12, 	  -3,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    0,  -20, 	   9,   -6, 	  -7,  -15, 	   2,   -9
+.2byte   -7,  -10, 	  -8,   -6, 	 -11,  -10, 	  -3,  -11
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,   -8, 	  -7,   -5, 	   0,   -9
+.2byte  -10,  -11, 	  -7,   -9, 	  -2,   -5, 	  -1,   -8
+.2byte   -4,  -19, 	  -7,   -8, 	  -6,   -9, 	  -2,  -10
+.2byte   -7,   -5, 	  -5,   -4, 	   0,   -3, 	  -3,   -9
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte   -7,  -10, 	 -11,  -11, 	   0,   -3, 	  -2,   -9
+.2byte   -6,  -10, 	 -13,   -9, 	   4,   -6, 	  -1,   -9
+.2byte   -5,  -19, 	  -8,  -11, 	  -3,   -9, 	  -3,  -10
+.2byte   -4,   -2, 	  -2,   -2, 	   3,  -10, 	  -5,   -7
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	 -11,  -12, 	   7,   -5, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -8, 	   9,   -9, 	  -1,  -10
+.2byte    2,   -7, 	   3,    1, 	   7,  -18, 	   0,   -7
+.2byte    2,   -7, 	   3,    1, 	   7,  -18, 	   0,   -7
+.2byte   -3,   -7, 	  -8,  -18, 	  -4,    1, 	  -1,   -7
+.2byte   -3,   -7, 	  -8,  -18, 	  -4,    1, 	  -1,   -7
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte    5,  -10, 	   9,  -11, 	  -2,   -3, 	   0,   -9
+.2byte    4,  -10, 	  11,   -9, 	  -6,   -6, 	  -1,   -9
+.2byte    2,   -8, 	   2,    1, 	  -8,  -18, 	  -1,   -9
+.2byte    2,   -8, 	   2,    1, 	  -8,  -18, 	  -1,   -9
+.2byte    8,   -9, 	   6,  -19, 	   8,   -2, 	   1,   -8
+.2byte    8,   -9, 	   6,  -19, 	   8,   -2, 	   1,   -8
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte    8,  -11, 	   0,   -8, 	   5,   -5, 	  -2,   -9
+.2byte    8,  -11, 	   5,   -9, 	   0,   -5, 	  -1,   -8
+.2byte    5,   -6, 	   3,   -1, 	  -7,  -14, 	  -2,   -7
+.2byte    5,   -6, 	   3,   -1, 	  -7,  -14, 	  -2,   -7
+.2byte    7,   -6, 	  -2,  -16, 	   7,   -1, 	   0,   -8
+.2byte    7,   -6, 	  -2,  -16, 	   7,   -1, 	   0,   -8
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte    7,  -12, 	  -5,  -11, 	  10,   -7, 	   0,   -9
+.2byte    7,  -12, 	   1,  -11, 	   6,   -7, 	  -1,   -9
+.2byte    7,   -7, 	   6,   -3, 	   6,  -14, 	   0,   -8
+.2byte    7,   -7, 	   6,   -3, 	   6,  -14, 	   0,   -8
+.2byte    0,  -12, 	  -8,  -18, 	  -1,   -6, 	   0,   -9
+.2byte    0,  -12, 	  -8,  -18, 	  -1,   -6, 	   0,   -9
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte   -1,  -10, 	  -2,   -5, 	  -8,  -13, 	   0,   -9
+.2byte   -1,  -10, 	  -2,   -5, 	  -8,  -13, 	   0,   -9
+.2byte    0,  -10, 	   7,  -13, 	   1,   -5, 	  -1,   -9
+.2byte    0,  -10, 	   7,  -13, 	   1,   -5, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -9,  -12, 	   3,  -11, 	 -12,   -7, 	  -2,   -9
+.2byte   -9,  -12, 	  -3,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte   -9,   -7, 	  -8,   -3, 	  -8,  -14, 	  -2,   -8
+.2byte   -9,   -7, 	  -8,   -3, 	  -8,  -14, 	  -2,   -8
+.2byte   -2,  -12, 	   6,  -18, 	  -1,   -6, 	  -2,   -9
+.2byte   -2,  -12, 	   6,  -18, 	  -1,   -6, 	  -2,   -9
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,   -8, 	  -7,   -5, 	   0,   -9
+.2byte  -10,  -11, 	  -7,   -9, 	  -2,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	  -5,   -1, 	   5,  -14, 	   0,   -7
+.2byte   -7,   -6, 	  -5,   -1, 	   5,  -14, 	   0,   -7
+.2byte   -9,   -6, 	   0,  -16, 	  -9,   -1, 	  -2,   -8
+.2byte   -9,   -6, 	   0,  -16, 	  -9,   -1, 	  -2,   -8
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte   -7,  -10, 	 -11,  -11, 	   0,   -3, 	  -2,   -9
+.2byte   -6,  -10, 	 -13,   -9, 	   4,   -6, 	  -1,   -9
+.2byte   -4,   -8, 	  -4,    1, 	   6,  -18, 	  -1,   -9
+.2byte   -4,   -8, 	  -4,    1, 	   6,  -18, 	  -1,   -9
+.2byte  -10,   -9, 	  -8,  -19, 	 -10,   -2, 	  -3,   -8
+.2byte  -10,   -9, 	  -8,  -19, 	 -10,   -2, 	  -3,   -8
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -2,  -23, 	 -10,  -11, 	   9,  -10, 	  -1,  -12
+.2byte   -1,   -6, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte   -1,  -21, 	   7,  -14, 	  -6,  -10, 	  -1,  -11
+.2byte    6,   -6, 	  11,   -9, 	  -7,   -5, 	   0,   -7
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte   -1,  -21, 	   4,  -14, 	   1,   -6, 	  -4,   -9
+.2byte   11,   -9, 	   4,   -6, 	   2,   -3, 	   0,   -8
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte   -1,  -21, 	  -4,  -15, 	   7,  -10, 	  -2,  -10
+.2byte    8,  -12, 	  -5,   -9, 	   8,   -4, 	   1,   -9
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte    1,  -21, 	   8,  -11, 	 -10,  -10, 	  -1,   -8
+.2byte   -1,  -15, 	   8,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -1,  -21, 	   2,  -15, 	  -9,  -10, 	   0,  -10
+.2byte  -10,  -12, 	   3,   -9, 	 -10,   -4, 	  -3,   -9
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte   -1,  -21, 	  -6,  -14, 	  -3,   -6, 	   2,   -9
+.2byte  -13,   -9, 	  -6,   -6, 	  -4,   -3, 	  -2,   -8
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte   -1,  -21, 	  -9,  -14, 	   4,  -10, 	  -1,  -11
+.2byte   -8,   -6, 	 -13,   -9, 	   5,   -5, 	  -2,   -7
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte   -3,   -8, 	  -5,   -2, 	   8,    1, 	   2,   -5
+.2byte   -4,   -6, 	  -5,   -1, 	   7,    2, 	   1,   -5
+.2byte    0,  -16, 	  -9,  -18, 	  10,  -17, 	   0,  -10
+.2byte    1,  -17, 	   3,  -24, 	 -12,  -21, 	  -2,  -11
+.2byte    0,  -16, 	   1,  -22, 	  -9,  -16, 	  -2,   -9
+.2byte    1,  -20, 	  -7,  -20, 	   4,  -16, 	  -2,  -10
+.2byte    0,  -18, 	  10,  -16, 	 -11,  -15, 	   0,   -8
+.2byte   -2,  -20, 	   6,  -20, 	  -5,  -16, 	   1,  -10
+.2byte    1,  -16, 	   0,  -22, 	  10,  -16, 	   3,   -9
+.2byte    3,  -18, 	   1,  -25, 	  16,  -22, 	   6,  -12
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	 -11,  -12, 	   7,   -5, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -8, 	   9,   -9, 	  -1,  -10
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte    5,  -10, 	   9,  -11, 	  -2,   -3, 	   0,   -9
+.2byte    4,  -10, 	  11,   -9, 	  -6,   -6, 	  -1,   -9
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte    8,  -11, 	   0,   -8, 	   5,   -5, 	  -2,   -9
+.2byte    8,  -11, 	   5,   -9, 	   0,   -5, 	  -1,   -8
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte    7,  -12, 	  -5,  -11, 	  10,   -7, 	   0,   -9
+.2byte    7,  -12, 	   1,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -9, 	  -9,   -9, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -9,  -12, 	   3,  -11, 	 -12,   -7, 	  -2,   -9
+.2byte   -9,  -12, 	  -3,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte  -10,  -11, 	  -2,   -8, 	  -7,   -5, 	   0,   -9
+.2byte  -10,  -11, 	  -7,   -9, 	  -2,   -5, 	  -1,   -8
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte   -7,  -10, 	 -11,  -11, 	   0,   -3, 	  -2,   -9
+.2byte   -6,  -10, 	 -13,   -9, 	   4,   -6, 	  -1,   -9
+.2byte   -1,   -6, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte   -6,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -7
+.2byte  -11,   -9, 	  -4,   -6, 	  -2,   -3, 	   0,   -8
+.2byte   -9,  -12, 	   4,   -9, 	  -9,   -4, 	  -2,   -9
+.2byte   -1,  -15, 	   8,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte    7,  -12, 	  -6,   -9, 	   7,   -4, 	   0,   -9
+.2byte    9,   -9, 	   2,   -6, 	   0,   -3, 	  -2,   -8
+.2byte    5,   -6, 	  10,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte    5,   -6, 	  10,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte    9,   -9, 	   2,   -6, 	   0,   -3, 	  -2,   -8
+.2byte    7,  -12, 	  -6,   -9, 	   7,   -4, 	   0,   -9
+.2byte   -1,  -15, 	   8,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -9,  -12, 	   4,   -9, 	  -9,   -4, 	  -2,   -9
+.2byte  -11,   -9, 	  -4,   -6, 	  -2,   -3, 	   0,   -8
+.2byte   -6,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -7
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -2,  -23, 	 -10,  -11, 	   9,  -10, 	  -1,  -12
+.2byte   -1,   -6, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte   -1,  -21, 	   7,  -14, 	  -6,  -10, 	  -1,  -11
+.2byte    4,   -6, 	   9,   -9, 	  -9,   -5, 	  -2,   -7
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte   -1,  -21, 	   4,  -14, 	   1,   -6, 	  -4,   -9
+.2byte    9,   -9, 	   2,   -6, 	   0,   -3, 	  -2,   -8
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte   -1,  -21, 	  -4,  -15, 	   7,  -10, 	  -2,  -10
+.2byte    8,  -12, 	  -5,   -9, 	   8,   -4, 	   1,   -9
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte    1,  -21, 	   8,  -11, 	 -10,  -10, 	  -1,   -8
+.2byte   -1,  -15, 	   8,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -1,  -21, 	   2,  -15, 	  -9,  -10, 	   0,  -10
+.2byte  -10,  -12, 	   3,   -9, 	 -10,   -4, 	  -3,   -9
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte   -1,  -21, 	  -6,  -14, 	  -3,   -6, 	   2,   -9
+.2byte  -11,   -9, 	  -4,   -6, 	  -2,   -3, 	   0,   -8
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte   -1,  -21, 	  -9,  -14, 	   4,  -10, 	  -1,  -11
+.2byte   -6,   -6, 	 -11,   -9, 	   7,   -5, 	   0,   -7
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+.2byte   -1,  -10, 	 -11,  -11, 	   9,   -8, 	  -1,  -11
+.2byte   -7,  -11, 	 -11,  -12, 	   3,   -6, 	  -2,  -10
+.2byte  -10,  -12, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte   -9,  -13, 	   2,  -13, 	 -11,   -8, 	  -2,  -10
+.2byte   -1,  -16, 	   8,  -10, 	 -10,  -10, 	  -1,   -9
+.2byte    7,  -13, 	  -4,  -13, 	   9,   -8, 	   0,  -10
+.2byte    8,  -12, 	   3,   -7, 	   3,   -6, 	  -1,   -9
+.2byte    5,  -11, 	   9,  -12, 	  -5,   -6, 	   0,  -10
+sGolduckAnimTable1:
+.4byte sGolduckAnims_1_1
+.4byte sGolduckAnims_1_2
+.4byte sGolduckAnims_1_3
+.4byte sGolduckAnims_1_4
+.4byte sGolduckAnims_1_5
+.4byte sGolduckAnims_1_6
+.4byte sGolduckAnims_1_7
+.4byte sGolduckAnims_1_8
+sGolduckAnimTable2:
+.4byte sGolduckAnims_2_1
+.4byte sGolduckAnims_2_2
+.4byte sGolduckAnims_2_3
+.4byte sGolduckAnims_2_4
+.4byte sGolduckAnims_2_5
+.4byte sGolduckAnims_2_6
+.4byte sGolduckAnims_2_7
+.4byte sGolduckAnims_2_8
+sGolduckAnimTable3:
+.4byte sGolduckAnims_3_1
+.4byte sGolduckAnims_3_2
+.4byte sGolduckAnims_3_3
+.4byte sGolduckAnims_3_4
+.4byte sGolduckAnims_3_5
+.4byte sGolduckAnims_3_6
+.4byte sGolduckAnims_3_7
+.4byte sGolduckAnims_3_8
+sGolduckAnimTable4:
+.4byte sGolduckAnims_4_1
+.4byte sGolduckAnims_4_2
+.4byte sGolduckAnims_4_3
+.4byte sGolduckAnims_4_4
+.4byte sGolduckAnims_4_5
+.4byte sGolduckAnims_4_6
+.4byte sGolduckAnims_4_7
+.4byte sGolduckAnims_4_8
+sGolduckAnimTable5:
+.4byte sGolduckAnims_5_1
+.4byte sGolduckAnims_5_2
+.4byte sGolduckAnims_5_3
+.4byte sGolduckAnims_5_4
+.4byte sGolduckAnims_5_5
+.4byte sGolduckAnims_5_6
+.4byte sGolduckAnims_5_7
+.4byte sGolduckAnims_5_8
+sGolduckAnimTable6:
+.4byte sGolduckAnims_6_1
+.4byte sGolduckAnims_6_1
+.4byte sGolduckAnims_6_1
+.4byte sGolduckAnims_6_1
+.4byte sGolduckAnims_6_1
+.4byte sGolduckAnims_6_1
+.4byte sGolduckAnims_6_1
+.4byte sGolduckAnims_6_1
+sGolduckAnimTable7:
+.4byte sGolduckAnims_7_1
+.4byte sGolduckAnims_7_2
+.4byte sGolduckAnims_7_3
+.4byte sGolduckAnims_7_4
+.4byte sGolduckAnims_7_5
+.4byte sGolduckAnims_7_6
+.4byte sGolduckAnims_7_7
+.4byte sGolduckAnims_7_8
+sGolduckAnimTable8:
+.4byte sGolduckAnims_8_1
+.4byte sGolduckAnims_8_2
+.4byte sGolduckAnims_8_3
+.4byte sGolduckAnims_8_4
+.4byte sGolduckAnims_8_5
+.4byte sGolduckAnims_8_6
+.4byte sGolduckAnims_8_7
+.4byte sGolduckAnims_8_8
+sGolduckAnimTable9:
+.4byte sGolduckAnims_9_1
+.4byte sGolduckAnims_9_2
+.4byte sGolduckAnims_9_3
+.4byte sGolduckAnims_9_4
+.4byte sGolduckAnims_9_5
+.4byte sGolduckAnims_9_6
+.4byte sGolduckAnims_9_7
+.4byte sGolduckAnims_9_8
+sGolduckAnimTable10:
+.4byte sGolduckAnims_10_1
+.4byte sGolduckAnims_10_2
+.4byte sGolduckAnims_10_3
+.4byte sGolduckAnims_10_4
+.4byte sGolduckAnims_10_5
+.4byte sGolduckAnims_10_6
+.4byte sGolduckAnims_10_7
+.4byte sGolduckAnims_10_8
+sGolduckAnimTable11:
+.4byte sGolduckAnims_11_1
+.4byte sGolduckAnims_11_2
+.4byte sGolduckAnims_11_3
+.4byte sGolduckAnims_11_4
+.4byte sGolduckAnims_11_5
+.4byte sGolduckAnims_11_6
+.4byte sGolduckAnims_11_7
+.4byte sGolduckAnims_11_8
+sGolduckAnimTable12:
+.4byte sGolduckAnims_12_1
+.4byte sGolduckAnims_12_2
+.4byte sGolduckAnims_12_3
+.4byte sGolduckAnims_12_4
+.4byte sGolduckAnims_12_5
+.4byte sGolduckAnims_12_6
+.4byte sGolduckAnims_12_7
+.4byte sGolduckAnims_12_8
+sGolduckAnimTable13:
+.4byte sGolduckAnims_13_1
+.4byte sGolduckAnims_13_2
+.4byte sGolduckAnims_13_3
+.4byte sGolduckAnims_13_4
+.4byte sGolduckAnims_13_5
+.4byte sGolduckAnims_13_6
+.4byte sGolduckAnims_13_7
+.4byte sGolduckAnims_13_8
+sAxAnimationsGolduck:
+.4byte sGolduckAnimTable1
+.4byte sGolduckAnimTable2
+.4byte sGolduckAnimTable3
+.4byte sGolduckAnimTable4
+.4byte sGolduckAnimTable5
+.4byte sGolduckAnimTable6
+.4byte sGolduckAnimTable7
+.4byte sGolduckAnimTable8
+.4byte sGolduckAnimTable9
+.4byte sGolduckAnimTable10
+.4byte sGolduckAnimTable11
+.4byte sGolduckAnimTable12
+.4byte sGolduckAnimTable13
+sAxSpritesGolduck:
+.4byte sGolduckSprites1
+.4byte sGolduckSprites2
+.4byte sGolduckSprites3
+.4byte sGolduckSprites4
+.4byte sGolduckSprites5
+.4byte sGolduckSprites6
+.4byte sGolduckSprites7
+.4byte sGolduckSprites8
+.4byte sGolduckSprites9
+.4byte sGolduckSprites10
+.4byte sGolduckSprites11
+.4byte sGolduckSprites12
+.4byte sGolduckSprites13
+.4byte sGolduckSprites14
+.4byte sGolduckSprites15
+.4byte sGolduckSprites16
+.4byte sGolduckSprites17
+.4byte sGolduckSprites18
+.4byte sGolduckSprites19
+.4byte sGolduckSprites20
+.4byte sGolduckSprites21
+.4byte sGolduckSprites22
+.4byte sGolduckSprites23
+.4byte sGolduckSprites24
+.4byte sGolduckSprites25
+.4byte sGolduckSprites26
+.4byte sGolduckSprites27
+.4byte sGolduckSprites28
+.4byte sGolduckSprites29
+.4byte sGolduckSprites30
+.4byte sGolduckSprites31
+.4byte sGolduckSprites32
+.4byte sGolduckSprites33
+.4byte sGolduckSprites34
+.4byte sGolduckSprites35
+.4byte sGolduckSprites36
+.4byte sGolduckSprites37
+.4byte sGolduckSprites38
+.4byte sGolduckSprites39
+.4byte sGolduckSprites40
+.4byte sGolduckSprites41
+.4byte sGolduckSprites42
+.4byte sGolduckSprites43
+.4byte sGolduckSprites44
+.4byte sGolduckSprites45
+.4byte sGolduckSprites46
+.4byte sGolduckSprites47
+.4byte sGolduckSprites48
+.4byte sGolduckSprites49
+.4byte sGolduckSprites50
+.4byte sGolduckSprites51
+.4byte sGolduckSprites52
+.4byte sGolduckSprites53
+.4byte sGolduckSprites54
+.4byte sGolduckSprites55
+.4byte sGolduckSprites56
+.4byte sGolduckSprites57
+.4byte sGolduckSprites58
+.4byte sGolduckSprites59
+.4byte sGolduckSprites60
+sAxMainGolduck:
+ax_main sAxPosesGolduck, sAxAnimationsGolduck, 13, sAxSpritesGolduck, sAxPositionsGolduck

--- a/data/ax/golem.inc
+++ b/data/ax/golem.inc
@@ -1,0 +1,2782 @@
+.global gAxGolem
+gAxGolem:
+ax_siro sAxMainGolem
+sGolemPose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose4:
+ax_pose 3, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose5:
+ax_pose 4, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose6:
+ax_pose 5, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose7:
+ax_pose 6, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose8:
+ax_pose 7, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose9:
+ax_pose 8, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose10:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose11:
+ax_pose 10, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose12:
+ax_pose 11, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose14:
+ax_pose 13, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose15:
+ax_pose 14, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose16:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose17:
+ax_pose 10, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose18:
+ax_pose 11, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose19:
+ax_pose 6, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose20:
+ax_pose 7, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose21:
+ax_pose 8, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose22:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose23:
+ax_pose 4, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose24:
+ax_pose 5, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose25:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose26:
+ax_pose 15, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose27:
+ax_pose 16, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose28:
+ax_pose 17, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose29:
+ax_pose 3, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose30:
+ax_pose 18, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose31:
+ax_pose 19, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose32:
+ax_pose 20, 0x01ef, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose33:
+ax_pose 6, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose34:
+ax_pose 21, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose35:
+ax_pose 22, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose36:
+ax_pose 23, 0x01ee, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose37:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose38:
+ax_pose 24, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose39:
+ax_pose 25, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose40:
+ax_pose 26, 0x01ee, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose41:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose42:
+ax_pose 27, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose43:
+ax_pose 28, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose44:
+ax_pose 29, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose45:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose46:
+ax_pose 24, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose47:
+ax_pose 25, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose48:
+ax_pose 26, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose49:
+ax_pose 6, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose50:
+ax_pose 21, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose51:
+ax_pose 22, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose52:
+ax_pose 23, 0x01ee, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose53:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose54:
+ax_pose 18, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose55:
+ax_pose 19, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose56:
+ax_pose 20, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose57:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose58:
+ax_pose 15, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose59:
+ax_pose 16, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose60:
+ax_pose 17, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose61:
+ax_pose 3, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose62:
+ax_pose 18, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose63:
+ax_pose 19, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose64:
+ax_pose 20, 0x01ef, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose65:
+ax_pose 6, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose66:
+ax_pose 21, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose67:
+ax_pose 22, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose68:
+ax_pose 23, 0x01ee, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose69:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose70:
+ax_pose 24, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose71:
+ax_pose 25, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose72:
+ax_pose 26, 0x01ee, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose73:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose74:
+ax_pose 27, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose75:
+ax_pose 28, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose76:
+ax_pose 29, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose77:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose78:
+ax_pose 24, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose79:
+ax_pose 25, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose80:
+ax_pose 26, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose81:
+ax_pose 6, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose82:
+ax_pose 21, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose83:
+ax_pose 22, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose84:
+ax_pose 23, 0x01ee, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose85:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose86:
+ax_pose 18, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose87:
+ax_pose 19, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose88:
+ax_pose 20, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose89:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose90:
+ax_pose 15, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose91:
+ax_pose 30, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose92:
+ax_pose 3, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose93:
+ax_pose 18, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose94:
+ax_pose 31, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose95:
+ax_pose 6, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose96:
+ax_pose 21, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose97:
+ax_pose 32, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose98:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose99:
+ax_pose 24, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose100:
+ax_pose 33, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose101:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose102:
+ax_pose 27, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose103:
+ax_pose 34, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose104:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose105:
+ax_pose 24, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose106:
+ax_pose 33, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose107:
+ax_pose 6, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose108:
+ax_pose 21, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose109:
+ax_pose 32, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose110:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose111:
+ax_pose 18, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose112:
+ax_pose 31, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose113:
+ax_pose 17, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose114:
+ax_pose 20, 0x01ee, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose115:
+ax_pose 23, 0x01ee, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose116:
+ax_pose 26, 0x01ee, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose117:
+ax_pose 29, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose118:
+ax_pose 26, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose119:
+ax_pose 23, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose120:
+ax_pose 20, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose121:
+ax_pose 35, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose122:
+ax_pose 36, 0x01ee, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose123:
+ax_pose 37, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose124:
+ax_pose 38, 0x01e3, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose125:
+ax_pose 39, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sGolemPose126:
+ax_pose 40, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sGolemPose127:
+ax_pose 41, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose128:
+ax_pose 40, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sGolemPose129:
+ax_pose 39, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGolemPose130:
+ax_pose 38, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose131:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose132:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose133:
+ax_pose 6, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose134:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose135:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose136:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose137:
+ax_pose 6, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose138:
+ax_pose 3, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose139:
+ax_pose 15, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose140:
+ax_pose 18, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose141:
+ax_pose 21, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose142:
+ax_pose 24, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose143:
+ax_pose 27, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose144:
+ax_pose 24, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose145:
+ax_pose 21, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose146:
+ax_pose 18, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose147:
+ax_pose 15, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose148:
+ax_pose 18, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose149:
+ax_pose 21, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose150:
+ax_pose 24, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose151:
+ax_pose 27, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose152:
+ax_pose 24, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose153:
+ax_pose 21, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose154:
+ax_pose 18, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose155:
+ax_pose 30, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose156:
+ax_pose 31, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose157:
+ax_pose 32, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose158:
+ax_pose 33, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose159:
+ax_pose 34, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose160:
+ax_pose 33, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose161:
+ax_pose 32, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose162:
+ax_pose 31, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose163:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose164:
+ax_pose 15, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose165:
+ax_pose 16, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose166:
+ax_pose 3, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose167:
+ax_pose 18, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose168:
+ax_pose 19, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose169:
+ax_pose 6, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose170:
+ax_pose 21, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose171:
+ax_pose 22, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose172:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose173:
+ax_pose 24, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose174:
+ax_pose 25, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose175:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose176:
+ax_pose 27, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose177:
+ax_pose 28, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose178:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose179:
+ax_pose 24, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose180:
+ax_pose 25, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose181:
+ax_pose 6, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose182:
+ax_pose 21, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose183:
+ax_pose 22, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose184:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose185:
+ax_pose 18, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose186:
+ax_pose 19, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose187:
+ax_pose 30, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose188:
+ax_pose 31, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose189:
+ax_pose 32, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose190:
+ax_pose 33, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sGolemPose191:
+ax_pose 34, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose192:
+ax_pose 33, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose193:
+ax_pose 32, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose194:
+ax_pose 31, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sGolemPose195:
+ax_pose 0, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose196:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose197:
+ax_pose 6, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sGolemPose198:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose199:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose200:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose201:
+ax_pose 6, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sGolemPose202:
+ax_pose 3, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sGolemPose203:
+ax_pose 42, 0x01eb, 0x80ef, 0x6c00
+ax_pose_terminator
+sGolemPose204:
+ax_pose 42, 0x01eb, 0x90f1, 0x6c00
+ax_pose_terminator
+sGolemPose205:
+ax_pose 42, 0x01eb, 0x80ef, 0x6c00
+ax_pose_terminator
+sGolemPose206:
+ax_pose 43, 0x01eb, 0x80ef, 0x6c00
+ax_pose_terminator
+sGolemPose207:
+ax_pose 44, 0x01eb, 0x80ef, 0x6c00
+ax_pose_terminator
+sGolemPose208:
+ax_pose 45, 0x01eb, 0x80ef, 0x6c00
+ax_pose_terminator
+sGolemPose209:
+ax_pose 9, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sGolemPose210:
+ax_pose 42, 0x01eb, 0x90f1, 0x6c00
+ax_pose_terminator
+sGolemPose211:
+ax_pose 43, 0x01eb, 0x90f1, 0x6c00
+ax_pose_terminator
+sGolemPose212:
+ax_pose 44, 0x01eb, 0x90f1, 0x6c00
+ax_pose_terminator
+sGolemPose213:
+ax_pose 45, 0x01eb, 0x90f1, 0x6c00
+ax_pose_terminator
+sGolemPose214:
+ax_pose 9, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+.align 2
+sGolemAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_2_1:
+ax_anim 6, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -3, 0, 2,
+ax_anim 2, 0, 24, 0, -4, 0, 4,
+ax_anim 2, 0, 24, 0, -5, 0, 6,
+ax_anim 2, 0, 26, 0, -3, 0, 8,
+ax_anim 2, 0, 26, 0, 4, 0, 10,
+ax_anim 2, 2, 26, 0, 10, 1, 12,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, -1, 18, -1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, -1, 18, -1, 18,
+ax_anim 2, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 0, 27, 0, 4, 0, 10,
+ax_anim 2, 0, 27, 0, 7, 0, 7,
+ax_anim 2, 0, 27, 0, 1, 0, 4,
+ax_anim_terminator
+sGolemAnims_2_2:
+ax_anim 6, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 2, -3, 2, 2,
+ax_anim 2, 0, 28, 4, -4, 4, 4,
+ax_anim 2, 0, 28, 6, -5, 6, 6,
+ax_anim 2, 0, 30, 9, -3, 8, 8,
+ax_anim 2, 0, 30, 13, 4, 10, 10,
+ax_anim 2, 2, 30, 16, 10, 14, 14,
+ax_anim 2, 0, 30, 20, 20, 20, 20,
+ax_anim 2, 1, 30, 19, 21, 19, 21,
+ax_anim 2, 0, 30, 20, 20, 20, 20,
+ax_anim 2, 0, 30, 19, 21, 19, 21,
+ax_anim 2, 0, 31, 14, 14, 14, 14,
+ax_anim 2, 0, 31, 10, 6, 10, 10,
+ax_anim 2, 0, 31, 8, 9, 8, 8,
+ax_anim 2, 0, 31, 4, 1, 4, 4,
+ax_anim_terminator
+sGolemAnims_2_3:
+ax_anim 6, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 2, -3, 2, 0,
+ax_anim 2, 0, 32, 4, -6, 4, 0,
+ax_anim 2, 0, 32, 6, -9, 6, 0,
+ax_anim 2, 0, 34, 9, -12, 8, 0,
+ax_anim 2, 0, 34, 11, -11, 10, 0,
+ax_anim 2, 2, 34, 14, -9, 14, 0,
+ax_anim 2, 0, 34, 20, -4, 20, 0,
+ax_anim 2, 1, 34, 20, -5, 20, -1,
+ax_anim 2, 0, 34, 20, -6, 20, 0,
+ax_anim 2, 0, 34, 20, -5, 20, -1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 14, -4, 14, 0,
+ax_anim 2, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 8, -2, 8, 0,
+ax_anim_terminator
+sGolemAnims_2_4:
+ax_anim 6, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 2, -5, 2, -2,
+ax_anim 2, 0, 36, 4, -10, 4, -4,
+ax_anim 2, 0, 36, 6, -15, 6, -6,
+ax_anim 2, 0, 38, 9, -20, 8, -8,
+ax_anim 2, 0, 38, 11, -21, 10, -10,
+ax_anim 2, 2, 38, 14, -20, 14, -14,
+ax_anim 2, 0, 38, 20, -19, 20, -19,
+ax_anim 2, 1, 38, 19, -20, 19, -20,
+ax_anim 2, 0, 38, 20, -19, 20, -19,
+ax_anim 2, 0, 38, 19, -20, 19, -20,
+ax_anim 2, 0, 39, 16, -16, 16, -16,
+ax_anim 2, 0, 39, 12, -16, 12, -12,
+ax_anim 2, 0, 39, 8, -8, 8, -8,
+ax_anim 2, 0, 39, 4, -8, 4, -4,
+ax_anim_terminator
+sGolemAnims_2_5:
+ax_anim 6, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, -5, 0, -2,
+ax_anim 2, 0, 40, 0, -10, 0, -4,
+ax_anim 2, 0, 40, 0, -15, 0, -6,
+ax_anim 2, 0, 42, 0, -20, 0, -8,
+ax_anim 2, 0, 42, 0, -21, 0, -10,
+ax_anim 2, 2, 42, 0, -20, 0, -14,
+ax_anim 2, 0, 42, 0, -19, 0, -19,
+ax_anim 2, 1, 42, 0, -20, 0, -20,
+ax_anim 2, 0, 42, 0, -19, 0, -19,
+ax_anim 2, 0, 42, 0, -20, 0, -20,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 43, 0, -16, 0, -12,
+ax_anim 2, 0, 43, 0, -8, 0, -8,
+ax_anim 2, 0, 43, 0, -8, 0, -4,
+ax_anim_terminator
+sGolemAnims_2_6:
+ax_anim 6, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 44, -2, -5, -2, -2,
+ax_anim 2, 0, 44, -4, -10, -4, -4,
+ax_anim 2, 0, 44, -6, -15, -6, -6,
+ax_anim 2, 0, 46, -9, -20, -8, -8,
+ax_anim 2, 0, 46, -11, -21, -10, -10,
+ax_anim 2, 2, 46, -14, -20, -14, -14,
+ax_anim 2, 0, 46, -20, -19, -20, -19,
+ax_anim 2, 1, 46, -19, -20, -19, -20,
+ax_anim 2, 0, 46, -20, -19, -20, -19,
+ax_anim 2, 0, 46, -19, -20, -19, -20,
+ax_anim 2, 0, 47, -16, -16, -16, -16,
+ax_anim 2, 0, 47, -12, -16, -12, -12,
+ax_anim 2, 0, 47, -8, -8, -8, -8,
+ax_anim 2, 0, 47, -4, -8, -4, -4,
+ax_anim_terminator
+sGolemAnims_2_7:
+ax_anim 6, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 48, -2, -3, -2, 0,
+ax_anim 2, 0, 48, -4, -6, -4, 0,
+ax_anim 2, 0, 48, -6, -9, -6, 0,
+ax_anim 2, 0, 50, -9, -12, -8, 0,
+ax_anim 2, 0, 50, -11, -11, -10, 0,
+ax_anim 2, 2, 50, -14, -9, -14, 0,
+ax_anim 2, 0, 50, -20, -4, -20, 0,
+ax_anim 2, 1, 50, -20, -5, -20, -1,
+ax_anim 2, 0, 50, -20, -6, -20, 0,
+ax_anim 2, 0, 50, -20, -5, -20, -1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -14, -4, -14, 0,
+ax_anim 2, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -8, -2, -8, 0,
+ax_anim_terminator
+sGolemAnims_2_8:
+ax_anim 6, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 52, -2, -3, -2, 2,
+ax_anim 2, 0, 52, -4, -4, -4, 4,
+ax_anim 2, 0, 52, -6, -5, -6, 6,
+ax_anim 2, 0, 54, -9, -3, -8, 8,
+ax_anim 2, 0, 54, -13, 4, -10, 10,
+ax_anim 2, 2, 54, -16, 10, -14, 14,
+ax_anim 2, 0, 54, -20, 20, -20, 20,
+ax_anim 2, 1, 54, -19, 21, -19, 21,
+ax_anim 2, 0, 54, -20, 20, -20, 20,
+ax_anim 2, 0, 54, -19, 21, -19, 21,
+ax_anim 2, 0, 55, -14, 14, -14, 14,
+ax_anim 2, 0, 55, -10, 6, -10, 10,
+ax_anim 2, 0, 55, -8, 9, -8, 8,
+ax_anim 2, 0, 55, -4, 1, -4, 4,
+ax_anim_terminator
+.align 2
+sGolemAnims_3_1:
+ax_anim 6, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -3, 0, 2,
+ax_anim 2, 0, 56, 0, -4, 0, 4,
+ax_anim 2, 0, 56, 0, -5, 0, 6,
+ax_anim 2, 0, 58, 0, -3, 0, 8,
+ax_anim 2, 0, 58, 0, 4, 0, 10,
+ax_anim 2, 2, 58, 0, 10, 1, 12,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 1, 58, -1, 18, -1, 18,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 0, 58, -1, 18, -1, 18,
+ax_anim 2, 0, 59, 0, 14, 0, 14,
+ax_anim 2, 0, 59, 0, 4, 0, 10,
+ax_anim 2, 0, 59, 0, 7, 0, 7,
+ax_anim 2, 0, 59, 0, 1, 0, 4,
+ax_anim_terminator
+sGolemAnims_3_2:
+ax_anim 6, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 2, -3, 2, 2,
+ax_anim 2, 0, 60, 4, -4, 4, 4,
+ax_anim 2, 0, 60, 6, -5, 6, 6,
+ax_anim 2, 0, 62, 9, -3, 8, 8,
+ax_anim 2, 0, 62, 13, 4, 10, 10,
+ax_anim 2, 2, 62, 16, 10, 14, 14,
+ax_anim 2, 0, 62, 20, 20, 20, 20,
+ax_anim 2, 1, 62, 19, 21, 19, 21,
+ax_anim 2, 0, 62, 20, 20, 20, 20,
+ax_anim 2, 0, 62, 19, 21, 19, 21,
+ax_anim 2, 0, 63, 14, 14, 14, 14,
+ax_anim 2, 0, 63, 10, 6, 10, 10,
+ax_anim 2, 0, 63, 8, 9, 8, 8,
+ax_anim 2, 0, 63, 4, 1, 4, 4,
+ax_anim_terminator
+sGolemAnims_3_3:
+ax_anim 6, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 2, -3, 2, 0,
+ax_anim 2, 0, 64, 4, -6, 4, 0,
+ax_anim 2, 0, 64, 6, -9, 6, 0,
+ax_anim 2, 0, 66, 9, -12, 8, 0,
+ax_anim 2, 0, 66, 11, -11, 10, 0,
+ax_anim 2, 2, 66, 14, -9, 14, 0,
+ax_anim 2, 0, 66, 20, -4, 20, 0,
+ax_anim 2, 1, 66, 20, -5, 20, -1,
+ax_anim 2, 0, 66, 20, -6, 20, 0,
+ax_anim 2, 0, 66, 20, -5, 20, -1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 14, -4, 14, 0,
+ax_anim 2, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 8, -2, 8, 0,
+ax_anim_terminator
+sGolemAnims_3_4:
+ax_anim 6, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 2, -5, 2, -2,
+ax_anim 2, 0, 68, 4, -10, 4, -4,
+ax_anim 2, 0, 68, 6, -15, 6, -6,
+ax_anim 2, 0, 70, 9, -20, 8, -8,
+ax_anim 2, 0, 70, 11, -21, 10, -10,
+ax_anim 2, 2, 70, 14, -20, 14, -14,
+ax_anim 2, 0, 70, 20, -19, 20, -19,
+ax_anim 2, 1, 70, 19, -20, 19, -20,
+ax_anim 2, 0, 70, 20, -19, 20, -19,
+ax_anim 2, 0, 70, 19, -20, 19, -20,
+ax_anim 2, 0, 71, 16, -16, 16, -16,
+ax_anim 2, 0, 71, 12, -16, 12, -12,
+ax_anim 2, 0, 71, 8, -8, 8, -8,
+ax_anim 2, 0, 71, 4, -8, 4, -4,
+ax_anim_terminator
+sGolemAnims_3_5:
+ax_anim 6, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, -5, 0, -2,
+ax_anim 2, 0, 72, 0, -10, 0, -4,
+ax_anim 2, 0, 72, 0, -15, 0, -6,
+ax_anim 2, 0, 74, 0, -20, 0, -8,
+ax_anim 2, 0, 74, 0, -21, 0, -10,
+ax_anim 2, 2, 74, 0, -20, 0, -14,
+ax_anim 2, 0, 74, 0, -19, 0, -19,
+ax_anim 2, 1, 74, 0, -20, 0, -20,
+ax_anim 2, 0, 74, 0, -19, 0, -19,
+ax_anim 2, 0, 74, 0, -20, 0, -20,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 0, 75, 0, -16, 0, -12,
+ax_anim 2, 0, 75, 0, -8, 0, -8,
+ax_anim 2, 0, 75, 0, -8, 0, -4,
+ax_anim_terminator
+sGolemAnims_3_6:
+ax_anim 6, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 76, -2, -5, -2, -2,
+ax_anim 2, 0, 76, -4, -10, -4, -4,
+ax_anim 2, 0, 76, -6, -15, -6, -6,
+ax_anim 2, 0, 78, -9, -20, -8, -8,
+ax_anim 2, 0, 78, -11, -21, -10, -10,
+ax_anim 2, 2, 78, -14, -20, -14, -14,
+ax_anim 2, 0, 78, -20, -19, -20, -19,
+ax_anim 2, 1, 78, -19, -20, -19, -20,
+ax_anim 2, 0, 78, -20, -19, -20, -19,
+ax_anim 2, 0, 78, -19, -20, -19, -20,
+ax_anim 2, 0, 79, -16, -16, -16, -16,
+ax_anim 2, 0, 79, -12, -16, -12, -12,
+ax_anim 2, 0, 79, -8, -8, -8, -8,
+ax_anim 2, 0, 79, -4, -8, -4, -4,
+ax_anim_terminator
+sGolemAnims_3_7:
+ax_anim 6, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -2, -3, -2, 0,
+ax_anim 2, 0, 80, -4, -6, -4, 0,
+ax_anim 2, 0, 80, -6, -9, -6, 0,
+ax_anim 2, 0, 82, -9, -12, -8, 0,
+ax_anim 2, 0, 82, -11, -11, -10, 0,
+ax_anim 2, 2, 82, -14, -9, -14, 0,
+ax_anim 2, 0, 82, -20, -4, -20, 0,
+ax_anim 2, 1, 82, -20, -5, -20, -1,
+ax_anim 2, 0, 82, -20, -6, -20, 0,
+ax_anim 2, 0, 82, -20, -5, -20, -1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -14, -4, -14, 0,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -8, -2, -8, 0,
+ax_anim_terminator
+sGolemAnims_3_8:
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -2, -3, -2, 2,
+ax_anim 2, 0, 84, -4, -4, -4, 4,
+ax_anim 2, 0, 84, -6, -5, -6, 6,
+ax_anim 2, 0, 86, -9, -3, -8, 8,
+ax_anim 2, 0, 86, -13, 4, -10, 10,
+ax_anim 2, 2, 86, -16, 10, -14, 14,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 1, 86, -19, 21, -19, 21,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 86, -19, 21, -19, 21,
+ax_anim 2, 0, 87, -14, 14, -14, 14,
+ax_anim 2, 0, 87, -10, 6, -10, 10,
+ax_anim 2, 0, 87, -8, 9, -8, 8,
+ax_anim 2, 0, 87, -4, 1, -4, 4,
+ax_anim_terminator
+.align 2
+sGolemAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 89, 1, -3, 1, -3,
+ax_anim 2, 0, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 89, 1, -3, 1, -3,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 4, 2, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 4, 1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 1, 90, 1, 4, 1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 1, 4, 1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 1, 4, 1, 4,
+ax_anim_terminator
+sGolemAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -2, -4, -2, -4,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -2, -4, -2, -4,
+ax_anim 4, 2, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 1, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim_terminator
+sGolemAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 4, 2, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 1, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim_terminator
+sGolemAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 98, -2, 4, -2, 4,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 98, -2, 4, -2, 4,
+ax_anim 4, 2, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 1, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim_terminator
+sGolemAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 2, 0, 101, 1, 3, 1, 3,
+ax_anim 2, 0, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 101, 1, 3, 1, 3,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 4, 2, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 1, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim_terminator
+sGolemAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 104, 2, 4, 2, 4,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 104, 2, 4, 2, 4,
+ax_anim 4, 2, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 2, 1, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -5, -3, -5, -3,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim_terminator
+sGolemAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 4, 2, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 1, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim_terminator
+sGolemAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 110, 2, -4, 2, -4,
+ax_anim 2, 0, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 110, 2, -4, 2, -4,
+ax_anim 4, 2, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 1, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGolemAnims_5_1:
+ax_anim 16, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_5_2:
+ax_anim 16, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_5_3:
+ax_anim 16, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_5_4:
+ax_anim 16, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_5_5:
+ax_anim 16, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_5_6:
+ax_anim 16, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_5_7:
+ax_anim 16, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 118, -1, 0, -1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_5_8:
+ax_anim 16, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sGolemAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sGolemAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sGolemAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sGolemAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sGolemAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sGolemAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sGolemAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGolemAnims_8_1:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 25, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_8_2:
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim 25, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_8_3:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 25, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_8_4:
+ax_anim 30, 0, 135, 0, 0, 0, 0,
+ax_anim 25, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_8_5:
+ax_anim 30, 0, 134, 0, 0, 0, 0,
+ax_anim 25, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_8_6:
+ax_anim 30, 0, 133, 0, 0, 0, 0,
+ax_anim 25, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_8_7:
+ax_anim 30, 0, 132, 0, 0, 0, 0,
+ax_anim 25, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_8_8:
+ax_anim 30, 0, 131, 0, 0, 0, 0,
+ax_anim 25, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 19, 7, 19,
+ax_anim 3, 0, 150, 0, 22, 0, 22,
+ax_anim 2, 3, 151, -7, 19, -7, 19,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 24, 9, 24, 9,
+ax_anim 3, 0, 149, 23, 21, 23, 21,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 2, 12, 2, 12,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 17, -4, 17, -4,
+ax_anim 3, 0, 148, 20, 1, 20, 1,
+ax_anim 2, 3, 149, 17, 5, 17, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -20, 11, -20,
+ax_anim 3, 0, 147, 20, -21, 20, -21,
+ax_anim 2, 3, 148, 22, -12, 22, -12,
+ax_anim 2, 0, 149, 16, -4, 16, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -10, -8, -10,
+ax_anim 2, 0, 153, -7, -18, -7, -18,
+ax_anim 3, 0, 146, 0, -22, 0, -22,
+ax_anim 2, 3, 147, 7, -18, 7, -18,
+ax_anim 2, 0, 148, 8, -8, 8, -8,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -11, -20, -11, -20,
+ax_anim 3, 0, 153, -20, -21, -20, -21,
+ax_anim 2, 3, 152, -22, -12, -22, -12,
+ax_anim 2, 0, 151, -16, -4, -16, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -17, -4, -17, -4,
+ax_anim 3, 0, 152, -20, 1, -20, 1,
+ax_anim 2, 3, 151, -17, 5, -17, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -24, 9, -24, 9,
+ax_anim 3, 0, 151, -23, 21, -23, 16,
+ax_anim 2, 3, 150, -11, 21, -11, 16,
+ax_anim 2, 0, 149, -2, 12, -4, 12,
+ax_anim 1, 0, 148, 0, 7, -3, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 1, 0, 0,
+ax_anim_terminator
+sGolemAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 2, 0, 0,
+ax_anim_terminator
+sGolemAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 1, 0, 0,
+ax_anim_terminator
+sGolemAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 1, 0, 0,
+ax_anim_terminator
+sGolemAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 1, 0, 0,
+ax_anim_terminator
+sGolemAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_14_1:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_14_2:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_14_3:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_14_4:
+ax_anim 8, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_14_5:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_14_6:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_14_7:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_14_8:
+ax_anim 8, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGolemAnims_15_1:
+ax_anim 18, 0, 204, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_15_2:
+ax_anim 18, 0, 204, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_15_3:
+ax_anim 18, 0, 204, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_15_4:
+ax_anim 18, 0, 209, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 212, 0, 0, 0, 0,
+ax_anim 18, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_15_5:
+ax_anim 18, 0, 204, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_15_6:
+ax_anim 18, 0, 204, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_15_7:
+ax_anim 18, 0, 204, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemAnims_15_8:
+ax_anim 18, 0, 204, 0, 0, 0, 0,
+ax_anim 6, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 18, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGolemGfx1:
+.incbin "baserom.gba", 0x84AB38, 0x200
+sGolemSprites1:
+ax_sprite sGolemGfx1, 0x200
+ax_sprite_terminator
+sGolemGfx2:
+.incbin "baserom.gba", 0x84AD48, 0x200
+sGolemSprites2:
+ax_sprite sGolemGfx2, 0x200
+ax_sprite_terminator
+sGolemGfx3:
+.incbin "baserom.gba", 0x84AF58, 0x200
+sGolemSprites3:
+ax_sprite sGolemGfx3, 0x200
+ax_sprite_terminator
+sGolemGfx4:
+.incbin "baserom.gba", 0x84B168, 0x200
+sGolemSprites4:
+ax_sprite sGolemGfx4, 0x200
+ax_sprite_terminator
+sGolemGfx5:
+.incbin "baserom.gba", 0x84B378, 0x200
+sGolemSprites5:
+ax_sprite sGolemGfx5, 0x200
+ax_sprite_terminator
+sGolemGfx6:
+.incbin "baserom.gba", 0x84B588, 0x200
+sGolemSprites6:
+ax_sprite sGolemGfx6, 0x200
+ax_sprite_terminator
+sGolemGfx7:
+.incbin "baserom.gba", 0x84B798, 0x200
+sGolemSprites7:
+ax_sprite sGolemGfx7, 0x200
+ax_sprite_terminator
+sGolemGfx8:
+.incbin "baserom.gba", 0x84B9A8, 0x200
+sGolemSprites8:
+ax_sprite sGolemGfx8, 0x200
+ax_sprite_terminator
+sGolemGfx9:
+.incbin "baserom.gba", 0x84BBB8, 0x200
+sGolemSprites9:
+ax_sprite sGolemGfx9, 0x200
+ax_sprite_terminator
+sGolemGfx10:
+.incbin "baserom.gba", 0x84BDC8, 0x200
+sGolemSprites10:
+ax_sprite sGolemGfx10, 0x200
+ax_sprite_terminator
+sGolemGfx11:
+.incbin "baserom.gba", 0x84BFD8, 0x200
+sGolemSprites11:
+ax_sprite sGolemGfx11, 0x200
+ax_sprite_terminator
+sGolemGfx12:
+.incbin "baserom.gba", 0x84C1E8, 0x200
+sGolemSprites12:
+ax_sprite sGolemGfx12, 0x200
+ax_sprite_terminator
+sGolemGfx13:
+.incbin "baserom.gba", 0x84C3F8, 0x200
+sGolemSprites13:
+ax_sprite sGolemGfx13, 0x200
+ax_sprite_terminator
+sGolemGfx14:
+.incbin "baserom.gba", 0x84C608, 0x200
+sGolemSprites14:
+ax_sprite sGolemGfx14, 0x200
+ax_sprite_terminator
+sGolemGfx15:
+.incbin "baserom.gba", 0x84C818, 0x200
+sGolemSprites15:
+ax_sprite sGolemGfx15, 0x200
+ax_sprite_terminator
+sGolemGfx16:
+.incbin "baserom.gba", 0x84CA28, 0x40
+sGolemGfx16_1:
+.incbin "baserom.gba", 0x84CA68, 0x100
+sGolemSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx16_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx17:
+.incbin "baserom.gba", 0x84CB98, 0x180
+sGolemSprites17:
+ax_sprite sGolemGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx18:
+.incbin "baserom.gba", 0x84CD30, 0x100
+sGolemGfx18_1:
+.incbin "baserom.gba", 0x84CE30, 0x40
+sGolemSprites18:
+ax_sprite sGolemGfx18, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx18_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx19:
+.incbin "baserom.gba", 0x84CE98, 0x60
+sGolemGfx19_1:
+.incbin "baserom.gba", 0x84CEF8, 0x100
+sGolemSprites19:
+ax_sprite sGolemGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx19_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx20:
+.incbin "baserom.gba", 0x84D020, 0x180
+sGolemSprites20:
+ax_sprite sGolemGfx20, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx21:
+.incbin "baserom.gba", 0x84D1B8, 0x100
+sGolemGfx21_1:
+.incbin "baserom.gba", 0x84D2B8, 0x40
+sGolemSprites21:
+ax_sprite sGolemGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx21_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx22:
+.incbin "baserom.gba", 0x84D320, 0x60
+sGolemGfx22_1:
+.incbin "baserom.gba", 0x84D380, 0x60
+sGolemGfx22_2:
+.incbin "baserom.gba", 0x84D3E0, 0x60
+sGolemGfx22_3:
+.incbin "baserom.gba", 0x84D440, 0x20
+sGolemSprites22:
+ax_sprite sGolemGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGolemGfx22_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGolemGfx23:
+.incbin "baserom.gba", 0x84D4A8, 0x60
+sGolemGfx23_1:
+.incbin "baserom.gba", 0x84D508, 0x60
+sGolemGfx23_2:
+.incbin "baserom.gba", 0x84D568, 0x60
+sGolemGfx23_3:
+.incbin "baserom.gba", 0x84D5C8, 0x20
+sGolemSprites23:
+ax_sprite sGolemGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx23_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sGolemGfx24:
+.incbin "baserom.gba", 0x84D630, 0x60
+sGolemGfx24_1:
+.incbin "baserom.gba", 0x84D690, 0x80
+sGolemGfx24_2:
+.incbin "baserom.gba", 0x84D710, 0x40
+sGolemSprites24:
+ax_sprite sGolemGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx25:
+.incbin "baserom.gba", 0x84D788, 0x60
+sGolemGfx25_1:
+.incbin "baserom.gba", 0x84D7E8, 0xE0
+sGolemSprites25:
+ax_sprite sGolemGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx25_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx26:
+.incbin "baserom.gba", 0x84D8F0, 0x60
+sGolemGfx26_1:
+.incbin "baserom.gba", 0x84D950, 0x100
+sGolemSprites26:
+ax_sprite sGolemGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx26_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx27:
+.incbin "baserom.gba", 0x84DA78, 0x100
+sGolemGfx27_1:
+.incbin "baserom.gba", 0x84DB78, 0x40
+sGolemSprites27:
+ax_sprite sGolemGfx27, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx27_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx28:
+.incbin "baserom.gba", 0x84DBE0, 0x40
+sGolemGfx28_1:
+.incbin "baserom.gba", 0x84DC20, 0x100
+sGolemSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx28_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx29:
+.incbin "baserom.gba", 0x84DD50, 0x180
+sGolemSprites29:
+ax_sprite sGolemGfx29, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx30:
+.incbin "baserom.gba", 0x84DEE8, 0x100
+sGolemGfx30_1:
+.incbin "baserom.gba", 0x84DFE8, 0x40
+sGolemSprites30:
+ax_sprite sGolemGfx30, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx30_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx31:
+.incbin "baserom.gba", 0x84E050, 0x180
+sGolemSprites31:
+ax_sprite sGolemGfx31, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx32:
+.incbin "baserom.gba", 0x84E1E8, 0x60
+sGolemGfx32_1:
+.incbin "baserom.gba", 0x84E248, 0xE0
+sGolemSprites32:
+ax_sprite sGolemGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx32_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx33:
+.incbin "baserom.gba", 0x84E350, 0x60
+sGolemGfx33_1:
+.incbin "baserom.gba", 0x84E3B0, 0x60
+sGolemGfx33_2:
+.incbin "baserom.gba", 0x84E410, 0x60
+sGolemSprites33:
+ax_sprite sGolemGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx34:
+.incbin "baserom.gba", 0x84E4A8, 0x60
+sGolemGfx34_1:
+.incbin "baserom.gba", 0x84E508, 0xE0
+sGolemSprites34:
+ax_sprite sGolemGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGolemGfx34_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGolemGfx35:
+.incbin "baserom.gba", 0x84E610, 0x180
+sGolemSprites35:
+ax_sprite sGolemGfx35, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGolemGfx36:
+.incbin "baserom.gba", 0x84E7A8, 0x200
+sGolemSprites36:
+ax_sprite sGolemGfx36, 0x200
+ax_sprite_terminator
+sGolemGfx37:
+.incbin "baserom.gba", 0x84E9B8, 0x200
+sGolemSprites37:
+ax_sprite sGolemGfx37, 0x200
+ax_sprite_terminator
+sGolemGfx38:
+.incbin "baserom.gba", 0x84EBC8, 0x200
+sGolemSprites38:
+ax_sprite sGolemGfx38, 0x200
+ax_sprite_terminator
+sGolemGfx39:
+.incbin "baserom.gba", 0x84EDD8, 0x200
+sGolemSprites39:
+ax_sprite sGolemGfx39, 0x200
+ax_sprite_terminator
+sGolemGfx40:
+.incbin "baserom.gba", 0x84EFE8, 0x200
+sGolemSprites40:
+ax_sprite sGolemGfx40, 0x200
+ax_sprite_terminator
+sGolemGfx41:
+.incbin "baserom.gba", 0x84F1F8, 0x200
+sGolemSprites41:
+ax_sprite sGolemGfx41, 0x200
+ax_sprite_terminator
+sGolemGfx42:
+.incbin "baserom.gba", 0x84F408, 0x200
+sGolemSprites42:
+ax_sprite sGolemGfx42, 0x200
+ax_sprite_terminator
+sGolemGfx43:
+.incbin "baserom.gba", 0x84F618, 0x200
+sGolemSprites43:
+ax_sprite sGolemGfx43, 0x200
+ax_sprite_terminator
+sGolemGfx44:
+.incbin "baserom.gba", 0x84F828, 0x200
+sGolemSprites44:
+ax_sprite sGolemGfx44, 0x200
+ax_sprite_terminator
+sGolemGfx45:
+.incbin "baserom.gba", 0x84FA38, 0x200
+sGolemSprites45:
+ax_sprite sGolemGfx45, 0x200
+ax_sprite_terminator
+sGolemGfx46:
+.incbin "baserom.gba", 0x84FC48, 0x200
+sGolemSprites46:
+ax_sprite sGolemGfx46, 0x200
+ax_sprite_terminator
+sAxPosesGolem:
+.4byte sGolemPose1
+.4byte sGolemPose2
+.4byte sGolemPose3
+.4byte sGolemPose4
+.4byte sGolemPose5
+.4byte sGolemPose6
+.4byte sGolemPose7
+.4byte sGolemPose8
+.4byte sGolemPose9
+.4byte sGolemPose10
+.4byte sGolemPose11
+.4byte sGolemPose12
+.4byte sGolemPose13
+.4byte sGolemPose14
+.4byte sGolemPose15
+.4byte sGolemPose16
+.4byte sGolemPose17
+.4byte sGolemPose18
+.4byte sGolemPose19
+.4byte sGolemPose20
+.4byte sGolemPose21
+.4byte sGolemPose22
+.4byte sGolemPose23
+.4byte sGolemPose24
+.4byte sGolemPose25
+.4byte sGolemPose26
+.4byte sGolemPose27
+.4byte sGolemPose28
+.4byte sGolemPose29
+.4byte sGolemPose30
+.4byte sGolemPose31
+.4byte sGolemPose32
+.4byte sGolemPose33
+.4byte sGolemPose34
+.4byte sGolemPose35
+.4byte sGolemPose36
+.4byte sGolemPose37
+.4byte sGolemPose38
+.4byte sGolemPose39
+.4byte sGolemPose40
+.4byte sGolemPose41
+.4byte sGolemPose42
+.4byte sGolemPose43
+.4byte sGolemPose44
+.4byte sGolemPose45
+.4byte sGolemPose46
+.4byte sGolemPose47
+.4byte sGolemPose48
+.4byte sGolemPose49
+.4byte sGolemPose50
+.4byte sGolemPose51
+.4byte sGolemPose52
+.4byte sGolemPose53
+.4byte sGolemPose54
+.4byte sGolemPose55
+.4byte sGolemPose56
+.4byte sGolemPose57
+.4byte sGolemPose58
+.4byte sGolemPose59
+.4byte sGolemPose60
+.4byte sGolemPose61
+.4byte sGolemPose62
+.4byte sGolemPose63
+.4byte sGolemPose64
+.4byte sGolemPose65
+.4byte sGolemPose66
+.4byte sGolemPose67
+.4byte sGolemPose68
+.4byte sGolemPose69
+.4byte sGolemPose70
+.4byte sGolemPose71
+.4byte sGolemPose72
+.4byte sGolemPose73
+.4byte sGolemPose74
+.4byte sGolemPose75
+.4byte sGolemPose76
+.4byte sGolemPose77
+.4byte sGolemPose78
+.4byte sGolemPose79
+.4byte sGolemPose80
+.4byte sGolemPose81
+.4byte sGolemPose82
+.4byte sGolemPose83
+.4byte sGolemPose84
+.4byte sGolemPose85
+.4byte sGolemPose86
+.4byte sGolemPose87
+.4byte sGolemPose88
+.4byte sGolemPose89
+.4byte sGolemPose90
+.4byte sGolemPose91
+.4byte sGolemPose92
+.4byte sGolemPose93
+.4byte sGolemPose94
+.4byte sGolemPose95
+.4byte sGolemPose96
+.4byte sGolemPose97
+.4byte sGolemPose98
+.4byte sGolemPose99
+.4byte sGolemPose100
+.4byte sGolemPose101
+.4byte sGolemPose102
+.4byte sGolemPose103
+.4byte sGolemPose104
+.4byte sGolemPose105
+.4byte sGolemPose106
+.4byte sGolemPose107
+.4byte sGolemPose108
+.4byte sGolemPose109
+.4byte sGolemPose110
+.4byte sGolemPose111
+.4byte sGolemPose112
+.4byte sGolemPose113
+.4byte sGolemPose114
+.4byte sGolemPose115
+.4byte sGolemPose116
+.4byte sGolemPose117
+.4byte sGolemPose118
+.4byte sGolemPose119
+.4byte sGolemPose120
+.4byte sGolemPose121
+.4byte sGolemPose122
+.4byte sGolemPose123
+.4byte sGolemPose124
+.4byte sGolemPose125
+.4byte sGolemPose126
+.4byte sGolemPose127
+.4byte sGolemPose128
+.4byte sGolemPose129
+.4byte sGolemPose130
+.4byte sGolemPose131
+.4byte sGolemPose132
+.4byte sGolemPose133
+.4byte sGolemPose134
+.4byte sGolemPose135
+.4byte sGolemPose136
+.4byte sGolemPose137
+.4byte sGolemPose138
+.4byte sGolemPose139
+.4byte sGolemPose140
+.4byte sGolemPose141
+.4byte sGolemPose142
+.4byte sGolemPose143
+.4byte sGolemPose144
+.4byte sGolemPose145
+.4byte sGolemPose146
+.4byte sGolemPose147
+.4byte sGolemPose148
+.4byte sGolemPose149
+.4byte sGolemPose150
+.4byte sGolemPose151
+.4byte sGolemPose152
+.4byte sGolemPose153
+.4byte sGolemPose154
+.4byte sGolemPose155
+.4byte sGolemPose156
+.4byte sGolemPose157
+.4byte sGolemPose158
+.4byte sGolemPose159
+.4byte sGolemPose160
+.4byte sGolemPose161
+.4byte sGolemPose162
+.4byte sGolemPose163
+.4byte sGolemPose164
+.4byte sGolemPose165
+.4byte sGolemPose166
+.4byte sGolemPose167
+.4byte sGolemPose168
+.4byte sGolemPose169
+.4byte sGolemPose170
+.4byte sGolemPose171
+.4byte sGolemPose172
+.4byte sGolemPose173
+.4byte sGolemPose174
+.4byte sGolemPose175
+.4byte sGolemPose176
+.4byte sGolemPose177
+.4byte sGolemPose178
+.4byte sGolemPose179
+.4byte sGolemPose180
+.4byte sGolemPose181
+.4byte sGolemPose182
+.4byte sGolemPose183
+.4byte sGolemPose184
+.4byte sGolemPose185
+.4byte sGolemPose186
+.4byte sGolemPose187
+.4byte sGolemPose188
+.4byte sGolemPose189
+.4byte sGolemPose190
+.4byte sGolemPose191
+.4byte sGolemPose192
+.4byte sGolemPose193
+.4byte sGolemPose194
+.4byte sGolemPose195
+.4byte sGolemPose196
+.4byte sGolemPose197
+.4byte sGolemPose198
+.4byte sGolemPose199
+.4byte sGolemPose200
+.4byte sGolemPose201
+.4byte sGolemPose202
+.4byte sGolemPose203
+.4byte sGolemPose204
+.4byte sGolemPose205
+.4byte sGolemPose206
+.4byte sGolemPose207
+.4byte sGolemPose208
+.4byte sGolemPose209
+.4byte sGolemPose210
+.4byte sGolemPose211
+.4byte sGolemPose212
+.4byte sGolemPose213
+.4byte sGolemPose214
+sAxPositionsGolem:
+.2byte    0,   -4, 	 -11,   -3, 	  10,   -3, 	  -1,  -11
+.2byte    0,   -3, 	 -12,   -3, 	  11,   -4, 	   0,  -10
+.2byte   -1,   -3, 	 -12,   -4, 	  11,   -3, 	  -1,  -10
+.2byte    4,   -5, 	  12,   -6, 	  -3,   -2, 	  -1,  -13
+.2byte    3,   -4, 	  13,   -5, 	  -5,   -1, 	  -2,  -12
+.2byte    4,   -4, 	  11,   -4, 	  -2,   -2, 	  -1,  -12
+.2byte    8,   -8, 	   6,   -9, 	   5,   -3, 	  -2,  -12
+.2byte    7,   -7, 	   6,   -4, 	   3,   -3, 	  -2,  -11
+.2byte    9,   -7, 	   7,   -8, 	   6,   -3, 	  -2,  -10
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+.2byte    8,  -12, 	   1,  -10, 	  11,   -4, 	  -1,  -11
+.2byte    4,  -13, 	  -3,   -9, 	  12,   -7, 	  -2,  -11
+.2byte   -1,  -16, 	  10,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte   -1,  -15, 	  10,   -7, 	 -12,   -5, 	   0,  -11
+.2byte    1,  -15, 	  11,   -5, 	 -11,   -7, 	   0,  -12
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte   -9,  -12, 	  -2,  -10, 	 -12,   -4, 	   0,  -11
+.2byte   -5,  -13, 	   2,   -9, 	 -13,   -7, 	   1,  -11
+.2byte   -9,   -8, 	  -7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte   -8,   -7, 	  -7,   -4, 	  -4,   -3, 	   1,  -11
+.2byte  -10,   -7, 	  -8,   -8, 	  -7,   -3, 	   1,  -10
+.2byte   -5,   -5, 	 -13,   -6, 	   2,   -2, 	   0,  -13
+.2byte   -4,   -4, 	 -14,   -5, 	   4,   -1, 	   1,  -12
+.2byte   -5,   -4, 	 -12,   -4, 	   1,   -2, 	   0,  -12
+.2byte    0,   -4, 	 -11,   -3, 	  10,   -3, 	  -1,  -11
+.2byte    0,   -1, 	 -13,   -1, 	  12,   -1, 	  -1,   -9
+.2byte    0,  -12, 	 -14,  -17, 	  13,  -17, 	   0,  -10
+.2byte    0,   -7, 	  -8,   -7, 	   7,   -7, 	   0,   -8
+.2byte    4,   -5, 	  12,   -6, 	  -3,   -2, 	  -1,  -13
+.2byte    3,   -3, 	  14,   -3, 	  -8,    1, 	  -1,  -11
+.2byte    2,  -12, 	   9,  -19, 	  -9,  -16, 	   0,  -10
+.2byte   -1,   -7, 	   6,  -12, 	  -6,   -4, 	  -2,   -8
+.2byte    8,   -8, 	   6,   -9, 	   5,   -3, 	  -2,  -12
+.2byte    9,   -6, 	   6,   -9, 	   2,    2, 	  -1,  -10
+.2byte    7,  -12, 	   2,  -20, 	   1,  -14, 	  -2,   -7
+.2byte    0,   -8, 	   1,  -14, 	   0,   -4, 	  -1,   -8
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+.2byte    8,   -9, 	  -6,   -9, 	  13,    0, 	   0,   -9
+.2byte    4,  -16, 	  -7,  -22, 	  10,  -19, 	  -1,  -10
+.2byte   -1,   -9, 	  -7,  -13, 	   7,   -8, 	  -2,   -9
+.2byte   -1,  -16, 	  10,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte    0,  -13, 	  12,   -3, 	 -13,   -3, 	  -1,  -11
+.2byte    0,  -18, 	  10,  -18, 	 -11,  -18, 	  -1,  -11
+.2byte    0,  -10, 	   7,  -10, 	  -8,  -10, 	  -1,  -10
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte   -9,   -9, 	   5,   -9, 	 -14,    0, 	  -1,   -9
+.2byte   -5,  -16, 	   6,  -22, 	 -11,  -19, 	   0,  -10
+.2byte    0,   -9, 	   6,  -13, 	  -8,   -8, 	   1,   -9
+.2byte   -9,   -8, 	  -7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte  -10,   -6, 	  -7,   -9, 	  -3,    2, 	   0,  -10
+.2byte   -8,  -12, 	  -3,  -20, 	  -2,  -14, 	   1,   -7
+.2byte   -1,   -8, 	  -2,  -14, 	  -1,   -4, 	   0,   -8
+.2byte   -5,   -5, 	 -13,   -6, 	   2,   -2, 	   0,  -13
+.2byte   -4,   -3, 	 -15,   -3, 	   7,    1, 	   0,  -11
+.2byte   -3,  -12, 	 -10,  -19, 	   8,  -16, 	  -1,  -10
+.2byte    0,   -7, 	  -7,  -12, 	   5,   -4, 	   1,   -8
+.2byte    0,   -4, 	 -11,   -3, 	  10,   -3, 	  -1,  -11
+.2byte    0,   -1, 	 -13,   -1, 	  12,   -1, 	  -1,   -9
+.2byte    0,  -12, 	 -14,  -17, 	  13,  -17, 	   0,  -10
+.2byte    0,   -7, 	  -8,   -7, 	   7,   -7, 	   0,   -8
+.2byte    4,   -5, 	  12,   -6, 	  -3,   -2, 	  -1,  -13
+.2byte    3,   -3, 	  14,   -3, 	  -8,    1, 	  -1,  -11
+.2byte    2,  -12, 	   9,  -19, 	  -9,  -16, 	   0,  -10
+.2byte   -1,   -7, 	   6,  -12, 	  -6,   -4, 	  -2,   -8
+.2byte    8,   -8, 	   6,   -9, 	   5,   -3, 	  -2,  -12
+.2byte    9,   -6, 	   6,   -9, 	   2,    2, 	  -1,  -10
+.2byte    7,  -12, 	   2,  -20, 	   1,  -14, 	  -2,   -7
+.2byte    0,   -8, 	   1,  -14, 	   0,   -4, 	  -1,   -8
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+.2byte    8,   -9, 	  -6,   -9, 	  13,    0, 	   0,   -9
+.2byte    4,  -16, 	  -7,  -22, 	  10,  -19, 	  -1,  -10
+.2byte   -1,   -9, 	  -7,  -13, 	   7,   -8, 	  -2,   -9
+.2byte   -1,  -16, 	  10,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte    0,  -13, 	  12,   -3, 	 -13,   -3, 	  -1,  -11
+.2byte    0,  -18, 	  10,  -18, 	 -11,  -18, 	  -1,  -11
+.2byte    0,  -10, 	   7,  -10, 	  -8,  -10, 	  -1,  -10
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte   -9,   -9, 	   5,   -9, 	 -14,    0, 	  -1,   -9
+.2byte   -5,  -16, 	   6,  -22, 	 -11,  -19, 	   0,  -10
+.2byte    0,   -9, 	   6,  -13, 	  -8,   -8, 	   1,   -9
+.2byte   -9,   -8, 	  -7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte  -10,   -6, 	  -7,   -9, 	  -3,    2, 	   0,  -10
+.2byte   -8,  -12, 	  -3,  -20, 	  -2,  -14, 	   1,   -7
+.2byte   -1,   -8, 	  -2,  -14, 	  -1,   -4, 	   0,   -8
+.2byte   -5,   -5, 	 -13,   -6, 	   2,   -2, 	   0,  -13
+.2byte   -4,   -3, 	 -15,   -3, 	   7,    1, 	   0,  -11
+.2byte   -3,  -12, 	 -10,  -19, 	   8,  -16, 	  -1,  -10
+.2byte    0,   -7, 	  -7,  -12, 	   5,   -4, 	   1,   -8
+.2byte    0,   -4, 	 -11,   -3, 	  10,   -3, 	  -1,  -11
+.2byte    0,   -1, 	 -13,   -1, 	  12,   -1, 	  -1,   -9
+.2byte    0,   -4, 	 -11,   -6, 	  10,   -6, 	   0,  -11
+.2byte    4,   -5, 	  12,   -6, 	  -3,   -2, 	  -1,  -13
+.2byte    3,   -3, 	  14,   -3, 	  -8,    1, 	  -1,  -11
+.2byte    5,   -4, 	  14,   -8, 	  -1,   -4, 	  -1,  -11
+.2byte    8,   -8, 	   6,   -9, 	   5,   -3, 	  -2,  -12
+.2byte    9,   -6, 	   6,   -9, 	   2,    2, 	  -1,  -10
+.2byte    9,   -5, 	  10,  -10, 	   7,   -4, 	   0,  -10
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+.2byte    8,   -9, 	  -6,   -9, 	  13,    0, 	   0,   -9
+.2byte    9,   -9, 	   1,  -14, 	  13,   -9, 	   0,  -10
+.2byte   -1,  -16, 	  10,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte    0,  -13, 	  12,   -3, 	 -13,   -3, 	  -1,  -11
+.2byte    0,  -14, 	  10,  -12, 	 -11,  -12, 	   0,  -12
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte   -9,   -9, 	   5,   -9, 	 -14,    0, 	  -1,   -9
+.2byte  -10,   -9, 	  -2,  -14, 	 -14,   -9, 	  -1,  -10
+.2byte   -9,   -8, 	  -7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte  -10,   -6, 	  -7,   -9, 	  -3,    2, 	   0,  -10
+.2byte  -10,   -5, 	 -11,  -10, 	  -8,   -4, 	  -1,  -10
+.2byte   -5,   -5, 	 -13,   -6, 	   2,   -2, 	   0,  -13
+.2byte   -4,   -3, 	 -15,   -3, 	   7,    1, 	   0,  -11
+.2byte   -6,   -4, 	 -15,   -8, 	   0,   -4, 	   0,  -11
+.2byte    0,   -8, 	  -8,   -8, 	   7,   -8, 	   0,   -9
+.2byte   -1,   -8, 	   6,  -13, 	  -6,   -5, 	  -2,   -9
+.2byte    1,   -8, 	   2,  -14, 	   1,   -4, 	   0,   -8
+.2byte   -1,   -9, 	  -7,  -13, 	   7,   -8, 	  -2,   -9
+.2byte    0,  -10, 	   7,  -10, 	  -8,  -10, 	  -1,  -10
+.2byte    0,   -9, 	   6,  -13, 	  -8,   -8, 	   1,   -9
+.2byte   -2,   -8, 	  -3,  -14, 	  -2,   -4, 	  -1,   -8
+.2byte    0,   -8, 	  -7,  -13, 	   5,   -5, 	   1,   -9
+.2byte   -4,   -3, 	 -10,   -2, 	   6,    2, 	   1,   -8
+.2byte   -5,   -2, 	 -10,   -1, 	   6,    3, 	   1,   -7
+.2byte    0,  -19, 	 -11,  -17, 	  10,  -17, 	   0,   -9
+.2byte   -3,  -17, 	   6,  -19, 	 -10,  -17, 	   0,   -9
+.2byte   -8,  -12, 	  -5,  -20, 	  -6,   -6, 	   0,   -8
+.2byte   -4,  -11, 	 -11,  -17, 	   5,   -8, 	  -1,  -10
+.2byte    0,  -13, 	  11,  -17, 	 -12,  -17, 	   0,   -8
+.2byte    3,  -11, 	  10,  -17, 	  -6,   -8, 	   0,  -10
+.2byte    7,  -12, 	   4,  -20, 	   5,   -6, 	  -1,   -8
+.2byte    2,  -17, 	  -7,  -19, 	   9,  -17, 	  -1,   -9
+.2byte    0,   -4, 	 -11,   -3, 	  10,   -3, 	  -1,  -11
+.2byte   -5,   -5, 	 -13,   -6, 	   2,   -2, 	   0,  -13
+.2byte   -9,   -8, 	  -7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte   -1,  -16, 	  10,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+.2byte    8,   -8, 	   6,   -9, 	   5,   -3, 	  -2,  -12
+.2byte    4,   -5, 	  12,   -6, 	  -3,   -2, 	  -1,  -13
+.2byte    0,   -1, 	 -13,   -1, 	  12,   -1, 	  -1,   -9
+.2byte   -4,   -3, 	 -15,   -3, 	   7,    1, 	   0,  -11
+.2byte  -10,   -5, 	  -7,   -8, 	  -3,    3, 	   0,   -9
+.2byte   -9,   -9, 	   5,   -9, 	 -14,    0, 	  -1,   -9
+.2byte    0,  -13, 	  12,   -3, 	 -13,   -3, 	  -1,  -11
+.2byte    8,   -9, 	  -6,   -9, 	  13,    0, 	   0,   -9
+.2byte    9,   -5, 	   6,   -8, 	   2,    3, 	  -1,   -9
+.2byte    3,   -3, 	  14,   -3, 	  -8,    1, 	  -1,  -11
+.2byte    0,   -1, 	 -13,   -1, 	  12,   -1, 	  -1,   -9
+.2byte   -4,   -3, 	 -15,   -3, 	   7,    1, 	   0,  -11
+.2byte  -10,   -6, 	  -7,   -9, 	  -3,    2, 	   0,  -10
+.2byte   -8,   -9, 	   6,   -9, 	 -13,    0, 	   0,   -9
+.2byte    0,  -13, 	  12,   -3, 	 -13,   -3, 	  -1,  -11
+.2byte    7,   -9, 	  -7,   -9, 	  12,    0, 	  -1,   -9
+.2byte    9,   -6, 	   6,   -9, 	   2,    2, 	  -1,  -10
+.2byte    3,   -3, 	  14,   -3, 	  -8,    1, 	  -1,  -11
+.2byte    0,   -4, 	 -11,   -6, 	  10,   -6, 	   0,  -11
+.2byte    4,   -4, 	  13,   -8, 	  -2,   -4, 	  -2,  -11
+.2byte    8,   -5, 	   9,  -10, 	   6,   -4, 	  -1,  -10
+.2byte    8,   -9, 	   0,  -14, 	  12,   -9, 	  -1,  -10
+.2byte    0,  -14, 	  10,  -12, 	 -11,  -12, 	   0,  -12
+.2byte   -9,   -9, 	  -1,  -14, 	 -13,   -9, 	   0,  -10
+.2byte   -9,   -5, 	 -10,  -10, 	  -7,   -4, 	   0,  -10
+.2byte   -5,   -4, 	 -14,   -8, 	   1,   -4, 	   1,  -11
+.2byte    0,   -4, 	 -11,   -3, 	  10,   -3, 	  -1,  -11
+.2byte    0,   -1, 	 -13,   -1, 	  12,   -1, 	  -1,   -9
+.2byte    0,  -12, 	 -14,  -17, 	  13,  -17, 	   0,  -10
+.2byte    4,   -5, 	  12,   -6, 	  -3,   -2, 	  -1,  -13
+.2byte    3,   -3, 	  14,   -3, 	  -8,    1, 	  -1,  -11
+.2byte    2,  -12, 	   9,  -19, 	  -9,  -16, 	   0,  -10
+.2byte    8,   -8, 	   6,   -9, 	   5,   -3, 	  -2,  -12
+.2byte    9,   -6, 	   6,   -9, 	   2,    2, 	  -1,  -10
+.2byte    7,  -12, 	   2,  -20, 	   1,  -14, 	  -2,   -7
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+.2byte    8,   -9, 	  -6,   -9, 	  13,    0, 	   0,   -9
+.2byte    4,  -16, 	  -7,  -22, 	  10,  -19, 	  -1,  -10
+.2byte   -1,  -16, 	  10,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte    0,  -13, 	  12,   -3, 	 -13,   -3, 	  -1,  -11
+.2byte    0,  -18, 	  10,  -18, 	 -11,  -18, 	  -1,  -11
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte   -9,   -9, 	   5,   -9, 	 -14,    0, 	  -1,   -9
+.2byte   -5,  -16, 	   6,  -22, 	 -11,  -19, 	   0,  -10
+.2byte   -9,   -8, 	  -7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte  -10,   -6, 	  -7,   -9, 	  -3,    2, 	   0,  -10
+.2byte   -8,  -12, 	  -3,  -20, 	  -2,  -14, 	   1,   -7
+.2byte   -5,   -5, 	 -13,   -6, 	   2,   -2, 	   0,  -13
+.2byte   -4,   -3, 	 -15,   -3, 	   7,    1, 	   0,  -11
+.2byte   -3,  -12, 	 -10,  -19, 	   8,  -16, 	  -1,  -10
+.2byte    0,   -4, 	 -11,   -6, 	  10,   -6, 	   0,  -11
+.2byte   -5,   -4, 	 -14,   -8, 	   1,   -4, 	   1,  -11
+.2byte   -9,   -5, 	 -10,  -10, 	  -7,   -4, 	   0,  -10
+.2byte   -9,   -9, 	  -1,  -14, 	 -13,   -9, 	   0,  -10
+.2byte    0,  -14, 	  10,  -12, 	 -11,  -12, 	   0,  -12
+.2byte    8,   -9, 	   0,  -14, 	  12,   -9, 	  -1,  -10
+.2byte    8,   -5, 	   9,  -10, 	   6,   -4, 	  -1,  -10
+.2byte    4,   -4, 	  13,   -8, 	  -2,   -4, 	  -2,  -11
+.2byte    0,   -4, 	 -11,   -3, 	  10,   -3, 	  -1,  -11
+.2byte   -5,   -5, 	 -13,   -6, 	   2,   -2, 	   0,  -13
+.2byte   -9,   -8, 	  -7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte   -1,  -16, 	  10,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+.2byte    8,   -8, 	   6,   -9, 	   5,   -3, 	  -2,  -12
+.2byte    4,   -5, 	  12,   -6, 	  -3,   -2, 	  -1,  -13
+.2byte  -10,   -4, 	   1,   -6, 	 -15,   -2, 	  -2,   -8
+.2byte    9,   -4, 	  -2,   -6, 	  14,   -2, 	   1,   -8
+.2byte  -10,   -4, 	   1,   -6, 	 -15,   -2, 	  -2,   -8
+.2byte  -10,   -5, 	   1,   -5, 	 -14,   -2, 	  -1,   -9
+.2byte   -9,   -9, 	   1,   -5, 	 -14,   -2, 	  -1,  -11
+.2byte   -9,  -11, 	  -1,   -7, 	 -13,   -3, 	  -1,  -11
+.2byte   -8,  -13, 	  -1,  -10, 	 -13,   -5, 	   2,  -12
+.2byte    9,   -4, 	  -2,   -6, 	  14,   -2, 	   1,   -8
+.2byte    9,   -5, 	  -2,   -5, 	  13,   -2, 	   0,   -9
+.2byte    8,   -9, 	  -2,   -5, 	  13,   -2, 	   0,  -11
+.2byte    8,  -11, 	   0,   -7, 	  12,   -3, 	   0,  -11
+.2byte    7,  -13, 	   0,  -10, 	  12,   -5, 	  -3,  -12
+sGolemAnimTable1:
+.4byte sGolemAnims_1_1
+.4byte sGolemAnims_1_2
+.4byte sGolemAnims_1_3
+.4byte sGolemAnims_1_4
+.4byte sGolemAnims_1_5
+.4byte sGolemAnims_1_6
+.4byte sGolemAnims_1_7
+.4byte sGolemAnims_1_8
+sGolemAnimTable2:
+.4byte sGolemAnims_2_1
+.4byte sGolemAnims_2_2
+.4byte sGolemAnims_2_3
+.4byte sGolemAnims_2_4
+.4byte sGolemAnims_2_5
+.4byte sGolemAnims_2_6
+.4byte sGolemAnims_2_7
+.4byte sGolemAnims_2_8
+sGolemAnimTable3:
+.4byte sGolemAnims_3_1
+.4byte sGolemAnims_3_2
+.4byte sGolemAnims_3_3
+.4byte sGolemAnims_3_4
+.4byte sGolemAnims_3_5
+.4byte sGolemAnims_3_6
+.4byte sGolemAnims_3_7
+.4byte sGolemAnims_3_8
+sGolemAnimTable4:
+.4byte sGolemAnims_4_1
+.4byte sGolemAnims_4_2
+.4byte sGolemAnims_4_3
+.4byte sGolemAnims_4_4
+.4byte sGolemAnims_4_5
+.4byte sGolemAnims_4_6
+.4byte sGolemAnims_4_7
+.4byte sGolemAnims_4_8
+sGolemAnimTable5:
+.4byte sGolemAnims_5_1
+.4byte sGolemAnims_5_2
+.4byte sGolemAnims_5_3
+.4byte sGolemAnims_5_4
+.4byte sGolemAnims_5_5
+.4byte sGolemAnims_5_6
+.4byte sGolemAnims_5_7
+.4byte sGolemAnims_5_8
+sGolemAnimTable6:
+.4byte sGolemAnims_6_1
+.4byte sGolemAnims_6_1
+.4byte sGolemAnims_6_1
+.4byte sGolemAnims_6_1
+.4byte sGolemAnims_6_1
+.4byte sGolemAnims_6_1
+.4byte sGolemAnims_6_1
+.4byte sGolemAnims_6_1
+sGolemAnimTable7:
+.4byte sGolemAnims_7_1
+.4byte sGolemAnims_7_2
+.4byte sGolemAnims_7_3
+.4byte sGolemAnims_7_4
+.4byte sGolemAnims_7_5
+.4byte sGolemAnims_7_6
+.4byte sGolemAnims_7_7
+.4byte sGolemAnims_7_8
+sGolemAnimTable8:
+.4byte sGolemAnims_8_1
+.4byte sGolemAnims_8_2
+.4byte sGolemAnims_8_3
+.4byte sGolemAnims_8_4
+.4byte sGolemAnims_8_5
+.4byte sGolemAnims_8_6
+.4byte sGolemAnims_8_7
+.4byte sGolemAnims_8_8
+sGolemAnimTable9:
+.4byte sGolemAnims_9_1
+.4byte sGolemAnims_9_2
+.4byte sGolemAnims_9_3
+.4byte sGolemAnims_9_4
+.4byte sGolemAnims_9_5
+.4byte sGolemAnims_9_6
+.4byte sGolemAnims_9_7
+.4byte sGolemAnims_9_8
+sGolemAnimTable10:
+.4byte sGolemAnims_10_1
+.4byte sGolemAnims_10_2
+.4byte sGolemAnims_10_3
+.4byte sGolemAnims_10_4
+.4byte sGolemAnims_10_5
+.4byte sGolemAnims_10_6
+.4byte sGolemAnims_10_7
+.4byte sGolemAnims_10_8
+sGolemAnimTable11:
+.4byte sGolemAnims_11_1
+.4byte sGolemAnims_11_2
+.4byte sGolemAnims_11_3
+.4byte sGolemAnims_11_4
+.4byte sGolemAnims_11_5
+.4byte sGolemAnims_11_6
+.4byte sGolemAnims_11_7
+.4byte sGolemAnims_11_8
+sGolemAnimTable12:
+.4byte sGolemAnims_12_1
+.4byte sGolemAnims_12_2
+.4byte sGolemAnims_12_3
+.4byte sGolemAnims_12_4
+.4byte sGolemAnims_12_5
+.4byte sGolemAnims_12_6
+.4byte sGolemAnims_12_7
+.4byte sGolemAnims_12_8
+sGolemAnimTable13:
+.4byte sGolemAnims_13_1
+.4byte sGolemAnims_13_2
+.4byte sGolemAnims_13_3
+.4byte sGolemAnims_13_4
+.4byte sGolemAnims_13_5
+.4byte sGolemAnims_13_6
+.4byte sGolemAnims_13_7
+.4byte sGolemAnims_13_8
+sGolemAnimTable14:
+.4byte sGolemAnims_14_1
+.4byte sGolemAnims_14_2
+.4byte sGolemAnims_14_3
+.4byte sGolemAnims_14_4
+.4byte sGolemAnims_14_5
+.4byte sGolemAnims_14_6
+.4byte sGolemAnims_14_7
+.4byte sGolemAnims_14_8
+sGolemAnimTable15:
+.4byte sGolemAnims_15_1
+.4byte sGolemAnims_15_2
+.4byte sGolemAnims_15_3
+.4byte sGolemAnims_15_4
+.4byte sGolemAnims_15_5
+.4byte sGolemAnims_15_6
+.4byte sGolemAnims_15_7
+.4byte sGolemAnims_15_8
+sAxAnimationsGolem:
+.4byte sGolemAnimTable1
+.4byte sGolemAnimTable2
+.4byte sGolemAnimTable3
+.4byte sGolemAnimTable4
+.4byte sGolemAnimTable5
+.4byte sGolemAnimTable6
+.4byte sGolemAnimTable7
+.4byte sGolemAnimTable8
+.4byte sGolemAnimTable9
+.4byte sGolemAnimTable10
+.4byte sGolemAnimTable11
+.4byte sGolemAnimTable12
+.4byte sGolemAnimTable13
+.4byte sGolemAnimTable14
+.4byte sGolemAnimTable15
+sAxSpritesGolem:
+.4byte sGolemSprites1
+.4byte sGolemSprites2
+.4byte sGolemSprites3
+.4byte sGolemSprites4
+.4byte sGolemSprites5
+.4byte sGolemSprites6
+.4byte sGolemSprites7
+.4byte sGolemSprites8
+.4byte sGolemSprites9
+.4byte sGolemSprites10
+.4byte sGolemSprites11
+.4byte sGolemSprites12
+.4byte sGolemSprites13
+.4byte sGolemSprites14
+.4byte sGolemSprites15
+.4byte sGolemSprites16
+.4byte sGolemSprites17
+.4byte sGolemSprites18
+.4byte sGolemSprites19
+.4byte sGolemSprites20
+.4byte sGolemSprites21
+.4byte sGolemSprites22
+.4byte sGolemSprites23
+.4byte sGolemSprites24
+.4byte sGolemSprites25
+.4byte sGolemSprites26
+.4byte sGolemSprites27
+.4byte sGolemSprites28
+.4byte sGolemSprites29
+.4byte sGolemSprites30
+.4byte sGolemSprites31
+.4byte sGolemSprites32
+.4byte sGolemSprites33
+.4byte sGolemSprites34
+.4byte sGolemSprites35
+.4byte sGolemSprites36
+.4byte sGolemSprites37
+.4byte sGolemSprites38
+.4byte sGolemSprites39
+.4byte sGolemSprites40
+.4byte sGolemSprites41
+.4byte sGolemSprites42
+.4byte sGolemSprites43
+.4byte sGolemSprites44
+.4byte sGolemSprites45
+.4byte sGolemSprites46
+sAxMainGolem:
+ax_main sAxPosesGolem, sAxAnimationsGolem, 15, sAxSpritesGolem, sAxPositionsGolem

--- a/data/ax/gorebyss.inc
+++ b/data/ax/gorebyss.inc
@@ -1,0 +1,2845 @@
+.global gAxGorebyss
+gAxGorebyss:
+ax_siro sAxMainGorebyss
+sGorebyssPose1:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose2:
+ax_pose 1, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose3:
+ax_pose 2, 0x81de, 0x80f8, 0xac00
+ax_pose 3, 0x01d6, 0x0100, 0xac08
+ax_pose_terminator
+sGorebyssPose4:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose5:
+ax_pose 5, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose6:
+ax_pose 6, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose7:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose8:
+ax_pose 8, 0x81e1, 0x9101, 0xac00
+ax_pose 9, 0x81e1, 0x50f9, 0xac08
+ax_pose 10, 0x81f1, 0x10f1, 0xac0c
+ax_pose 11, 0x01e9, 0x10f1, 0xac0e
+ax_pose 12, 0x01eb, 0x10e9, 0xac0f
+ax_pose_terminator
+sGorebyssPose9:
+ax_pose 13, 0x81e9, 0x1109, 0xac00
+ax_pose 14, 0x81e1, 0x90f9, 0xac02
+ax_pose 15, 0x01f1, 0x10f1, 0xac0a
+ax_pose 16, 0x81e9, 0x10e9, 0xac0b
+ax_pose_terminator
+sGorebyssPose10:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose11:
+ax_pose 18, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose12:
+ax_pose 19, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose13:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose14:
+ax_pose 21, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose15:
+ax_pose 22, 0x81e4, 0x80f5, 0xac00
+ax_pose 23, 0x0204, 0x00fa, 0xac08
+ax_pose_terminator
+sGorebyssPose16:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose17:
+ax_pose 18, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose18:
+ax_pose 19, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose19:
+ax_pose 7, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sGorebyssPose20:
+ax_pose 8, 0x81e1, 0x80f0, 0xac00
+ax_pose 9, 0x81e1, 0x4100, 0xac08
+ax_pose 10, 0x81f1, 0x0108, 0xac0c
+ax_pose 11, 0x01e9, 0x0108, 0xac0e
+ax_pose 12, 0x01eb, 0x0110, 0xac0f
+ax_pose_terminator
+sGorebyssPose21:
+ax_pose 13, 0x81e9, 0x00f0, 0xac00
+ax_pose 14, 0x81e1, 0x80f8, 0xac02
+ax_pose 15, 0x01f1, 0x0108, 0xac0a
+ax_pose 16, 0x81e9, 0x0110, 0xac0b
+ax_pose_terminator
+sGorebyssPose22:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose23:
+ax_pose 5, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose24:
+ax_pose 6, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose25:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose26:
+ax_pose 1, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose27:
+ax_pose 2, 0x81de, 0x80f8, 0xac00
+ax_pose 3, 0x01d6, 0x0100, 0xac08
+ax_pose_terminator
+sGorebyssPose28:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose29:
+ax_pose 5, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose30:
+ax_pose 6, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose31:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose32:
+ax_pose 8, 0x81e1, 0x9101, 0xac00
+ax_pose 9, 0x81e1, 0x50f9, 0xac08
+ax_pose 10, 0x81f1, 0x10f1, 0xac0c
+ax_pose 11, 0x01e9, 0x10f1, 0xac0e
+ax_pose 12, 0x01eb, 0x10e9, 0xac0f
+ax_pose_terminator
+sGorebyssPose33:
+ax_pose 13, 0x81e9, 0x1109, 0xac00
+ax_pose 14, 0x81e1, 0x90f9, 0xac02
+ax_pose 15, 0x01f1, 0x10f1, 0xac0a
+ax_pose 16, 0x81e9, 0x10e9, 0xac0b
+ax_pose_terminator
+sGorebyssPose34:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose35:
+ax_pose 18, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose36:
+ax_pose 19, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose37:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose38:
+ax_pose 21, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose39:
+ax_pose 22, 0x81e4, 0x80f5, 0xac00
+ax_pose 23, 0x0204, 0x00fa, 0xac08
+ax_pose_terminator
+sGorebyssPose40:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose41:
+ax_pose 18, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose42:
+ax_pose 19, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose43:
+ax_pose 7, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sGorebyssPose44:
+ax_pose 8, 0x81e1, 0x80f0, 0xac00
+ax_pose 9, 0x81e1, 0x4100, 0xac08
+ax_pose 10, 0x81f1, 0x0108, 0xac0c
+ax_pose 11, 0x01e9, 0x0108, 0xac0e
+ax_pose 12, 0x01eb, 0x0110, 0xac0f
+ax_pose_terminator
+sGorebyssPose45:
+ax_pose 13, 0x81e9, 0x00f0, 0xac00
+ax_pose 14, 0x81e1, 0x80f8, 0xac02
+ax_pose 15, 0x01f1, 0x0108, 0xac0a
+ax_pose 16, 0x81e9, 0x0110, 0xac0b
+ax_pose_terminator
+sGorebyssPose46:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose47:
+ax_pose 5, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose48:
+ax_pose 6, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose49:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose50:
+ax_pose 1, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose51:
+ax_pose 2, 0x81de, 0x80f8, 0xac00
+ax_pose 3, 0x01d6, 0x0100, 0xac08
+ax_pose_terminator
+sGorebyssPose52:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose53:
+ax_pose 5, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose54:
+ax_pose 6, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose55:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose56:
+ax_pose 8, 0x81e1, 0x9101, 0xac00
+ax_pose 9, 0x81e1, 0x50f9, 0xac08
+ax_pose 10, 0x81f1, 0x10f1, 0xac0c
+ax_pose 11, 0x01e9, 0x10f1, 0xac0e
+ax_pose 12, 0x01eb, 0x10e9, 0xac0f
+ax_pose_terminator
+sGorebyssPose57:
+ax_pose 13, 0x81e9, 0x1109, 0xac00
+ax_pose 14, 0x81e1, 0x90f9, 0xac02
+ax_pose 15, 0x01f1, 0x10f1, 0xac0a
+ax_pose 16, 0x81e9, 0x10e9, 0xac0b
+ax_pose_terminator
+sGorebyssPose58:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose59:
+ax_pose 18, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose60:
+ax_pose 19, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose61:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose62:
+ax_pose 21, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose63:
+ax_pose 22, 0x81e4, 0x80f5, 0xac00
+ax_pose 23, 0x0204, 0x00fa, 0xac08
+ax_pose_terminator
+sGorebyssPose64:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose65:
+ax_pose 18, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose66:
+ax_pose 19, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose67:
+ax_pose 7, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sGorebyssPose68:
+ax_pose 8, 0x81e1, 0x80f0, 0xac00
+ax_pose 9, 0x81e1, 0x4100, 0xac08
+ax_pose 10, 0x81f1, 0x0108, 0xac0c
+ax_pose 11, 0x01e9, 0x0108, 0xac0e
+ax_pose 12, 0x01eb, 0x0110, 0xac0f
+ax_pose_terminator
+sGorebyssPose69:
+ax_pose 13, 0x81e9, 0x00f0, 0xac00
+ax_pose 14, 0x81e1, 0x80f8, 0xac02
+ax_pose 15, 0x01f1, 0x0108, 0xac0a
+ax_pose 16, 0x81e9, 0x0110, 0xac0b
+ax_pose_terminator
+sGorebyssPose70:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose71:
+ax_pose 5, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose72:
+ax_pose 6, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose73:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose74:
+ax_pose 1, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose75:
+ax_pose 2, 0x81e6, 0x80f8, 0xac00
+ax_pose 3, 0x01de, 0x0100, 0xac08
+ax_pose_terminator
+sGorebyssPose76:
+ax_pose 24, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose77:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose78:
+ax_pose 5, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose79:
+ax_pose 6, 0x01e3, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose80:
+ax_pose 25, 0x01e6, 0x90ed, 0xac00
+ax_pose_terminator
+sGorebyssPose81:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose82:
+ax_pose 8, 0x81e1, 0x9101, 0xac00
+ax_pose 9, 0x81e1, 0x50f9, 0xac08
+ax_pose 10, 0x81f1, 0x10f1, 0xac0c
+ax_pose 11, 0x01e9, 0x10f1, 0xac0e
+ax_pose 12, 0x01eb, 0x10e9, 0xac0f
+ax_pose_terminator
+sGorebyssPose83:
+ax_pose 13, 0x81ec, 0x1109, 0xac00
+ax_pose 14, 0x81e4, 0x90f9, 0xac02
+ax_pose 15, 0x01f4, 0x10f1, 0xac0a
+ax_pose 16, 0x81ec, 0x10e9, 0xac0b
+ax_pose_terminator
+sGorebyssPose84:
+ax_pose 26, 0x41e5, 0x90ee, 0xac00
+ax_pose 27, 0x01f5, 0x50ed, 0xac08
+ax_pose 28, 0x01f5, 0x10fd, 0xac0c
+ax_pose 29, 0x81f5, 0x10e5, 0xac0d
+ax_pose_terminator
+sGorebyssPose85:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose86:
+ax_pose 18, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose87:
+ax_pose 19, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose88:
+ax_pose 30, 0x01e2, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose89:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose90:
+ax_pose 21, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose91:
+ax_pose 22, 0x81e4, 0x80f5, 0xac00
+ax_pose 23, 0x0204, 0x00fa, 0xac08
+ax_pose_terminator
+sGorebyssPose92:
+ax_pose 31, 0x81e4, 0x80f5, 0xac00
+ax_pose 32, 0x0204, 0x00fb, 0xac08
+ax_pose_terminator
+sGorebyssPose93:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose94:
+ax_pose 18, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose95:
+ax_pose 19, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose96:
+ax_pose 30, 0x01e2, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose97:
+ax_pose 7, 0x01e1, 0x80ef, 0xac00
+ax_pose_terminator
+sGorebyssPose98:
+ax_pose 8, 0x81e1, 0x80ef, 0xac00
+ax_pose 9, 0x81e1, 0x40ff, 0xac08
+ax_pose 10, 0x81f1, 0x0107, 0xac0c
+ax_pose 11, 0x01e9, 0x0107, 0xac0e
+ax_pose 12, 0x01eb, 0x010f, 0xac0f
+ax_pose_terminator
+sGorebyssPose99:
+ax_pose 13, 0x81ec, 0x00ef, 0xac00
+ax_pose 14, 0x81e4, 0x80f7, 0xac02
+ax_pose 15, 0x01f4, 0x0107, 0xac0a
+ax_pose 16, 0x81ec, 0x010f, 0xac0b
+ax_pose_terminator
+sGorebyssPose100:
+ax_pose 26, 0x41e5, 0x80f2, 0xac00
+ax_pose 27, 0x01f5, 0x4103, 0xac08
+ax_pose 28, 0x01f5, 0x00fb, 0xac0c
+ax_pose 29, 0x81f5, 0x0113, 0xac0d
+ax_pose_terminator
+sGorebyssPose101:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose102:
+ax_pose 5, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose103:
+ax_pose 6, 0x01e3, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose104:
+ax_pose 25, 0x01e6, 0x80f3, 0xac00
+ax_pose_terminator
+sGorebyssPose105:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose106:
+ax_pose 1, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose107:
+ax_pose 2, 0x81de, 0x80f8, 0xac00
+ax_pose 3, 0x01d6, 0x0100, 0xac08
+ax_pose_terminator
+sGorebyssPose108:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose109:
+ax_pose 5, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose110:
+ax_pose 6, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose111:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose112:
+ax_pose 8, 0x81e1, 0x9101, 0xac00
+ax_pose 9, 0x81e1, 0x50f9, 0xac08
+ax_pose 10, 0x81f1, 0x10f1, 0xac0c
+ax_pose 11, 0x01e9, 0x10f1, 0xac0e
+ax_pose 12, 0x01eb, 0x10e9, 0xac0f
+ax_pose_terminator
+sGorebyssPose113:
+ax_pose 13, 0x81e9, 0x1109, 0xac00
+ax_pose 14, 0x81e1, 0x90f9, 0xac02
+ax_pose 15, 0x01f1, 0x10f1, 0xac0a
+ax_pose 16, 0x81e9, 0x10e9, 0xac0b
+ax_pose_terminator
+sGorebyssPose114:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose115:
+ax_pose 18, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose116:
+ax_pose 19, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose117:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose118:
+ax_pose 21, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose119:
+ax_pose 22, 0x81e4, 0x80f5, 0xac00
+ax_pose 23, 0x0204, 0x00fa, 0xac08
+ax_pose_terminator
+sGorebyssPose120:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose121:
+ax_pose 18, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose122:
+ax_pose 19, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose123:
+ax_pose 7, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sGorebyssPose124:
+ax_pose 8, 0x81e1, 0x80f0, 0xac00
+ax_pose 9, 0x81e1, 0x4100, 0xac08
+ax_pose 10, 0x81f1, 0x0108, 0xac0c
+ax_pose 11, 0x01e9, 0x0108, 0xac0e
+ax_pose 12, 0x01eb, 0x0110, 0xac0f
+ax_pose_terminator
+sGorebyssPose125:
+ax_pose 13, 0x81e9, 0x00f0, 0xac00
+ax_pose 14, 0x81e1, 0x80f8, 0xac02
+ax_pose 15, 0x01f1, 0x0108, 0xac0a
+ax_pose 16, 0x81e9, 0x0110, 0xac0b
+ax_pose_terminator
+sGorebyssPose126:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose127:
+ax_pose 5, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose128:
+ax_pose 6, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose129:
+ax_pose 33, 0x01e2, 0x80f1, 0xac00
+ax_pose_terminator
+sGorebyssPose130:
+ax_pose 34, 0x01e2, 0x80f1, 0xac00
+ax_pose_terminator
+sGorebyssPose131:
+ax_pose 35, 0x81db, 0x80f7, 0xac00
+ax_pose 36, 0x41fb, 0x00f7, 0xac08
+ax_pose 37, 0x81eb, 0x0107, 0xac0a
+ax_pose_terminator
+sGorebyssPose132:
+ax_pose 38, 0x01f3, 0x10ee, 0xac00
+ax_pose 39, 0x41fb, 0x10f6, 0xac01
+ax_pose 40, 0x81db, 0x10ee, 0xac03
+ax_pose 41, 0x81db, 0x90f6, 0xac05
+ax_pose_terminator
+sGorebyssPose133:
+ax_pose 42, 0x01e0, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose134:
+ax_pose 43, 0x01f7, 0x10ed, 0xac00
+ax_pose 44, 0x41ff, 0x10f0, 0xac01
+ax_pose 45, 0x81df, 0x10ed, 0xac03
+ax_pose 46, 0x81df, 0x90f5, 0xac05
+ax_pose_terminator
+sGorebyssPose135:
+ax_pose 47, 0x01f9, 0x40f9, 0xac00
+ax_pose 48, 0x81d9, 0x80f9, 0xac04
+ax_pose_terminator
+sGorebyssPose136:
+ax_pose 43, 0x01f7, 0x010b, 0xac00
+ax_pose 44, 0x41ff, 0x0100, 0xac01
+ax_pose 45, 0x81df, 0x010b, 0xac03
+ax_pose 46, 0x81df, 0x80fb, 0xac05
+ax_pose_terminator
+sGorebyssPose137:
+ax_pose 42, 0x01e0, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose138:
+ax_pose 38, 0x01f3, 0x010a, 0xac00
+ax_pose 39, 0x41fb, 0x00fa, 0xac01
+ax_pose 40, 0x81db, 0x010a, 0xac03
+ax_pose 41, 0x81db, 0x80fa, 0xac05
+ax_pose_terminator
+sGorebyssPose139:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose140:
+ax_pose 1, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose141:
+ax_pose 2, 0x81de, 0x80f8, 0xac00
+ax_pose 3, 0x01d6, 0x0100, 0xac08
+ax_pose_terminator
+sGorebyssPose142:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose143:
+ax_pose 5, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose144:
+ax_pose 6, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose145:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose146:
+ax_pose 8, 0x81e1, 0x9101, 0xac00
+ax_pose 9, 0x81e1, 0x50f9, 0xac08
+ax_pose 10, 0x81f1, 0x10f1, 0xac0c
+ax_pose 11, 0x01e9, 0x10f1, 0xac0e
+ax_pose 12, 0x01eb, 0x10e9, 0xac0f
+ax_pose_terminator
+sGorebyssPose147:
+ax_pose 13, 0x81e9, 0x1109, 0xac00
+ax_pose 14, 0x81e1, 0x90f9, 0xac02
+ax_pose 15, 0x01f1, 0x10f1, 0xac0a
+ax_pose 16, 0x81e9, 0x10e9, 0xac0b
+ax_pose_terminator
+sGorebyssPose148:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose149:
+ax_pose 18, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose150:
+ax_pose 19, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose151:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose152:
+ax_pose 21, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose153:
+ax_pose 22, 0x81e4, 0x80f5, 0xac00
+ax_pose 23, 0x0204, 0x00fa, 0xac08
+ax_pose_terminator
+sGorebyssPose154:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose155:
+ax_pose 18, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose156:
+ax_pose 19, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose157:
+ax_pose 7, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sGorebyssPose158:
+ax_pose 8, 0x81e1, 0x80f0, 0xac00
+ax_pose 9, 0x81e1, 0x4100, 0xac08
+ax_pose 10, 0x81f1, 0x0108, 0xac0c
+ax_pose 11, 0x01e9, 0x0108, 0xac0e
+ax_pose 12, 0x01eb, 0x0110, 0xac0f
+ax_pose_terminator
+sGorebyssPose159:
+ax_pose 13, 0x81e9, 0x00f0, 0xac00
+ax_pose 14, 0x81e1, 0x80f8, 0xac02
+ax_pose 15, 0x01f1, 0x0108, 0xac0a
+ax_pose 16, 0x81e9, 0x0110, 0xac0b
+ax_pose_terminator
+sGorebyssPose160:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose161:
+ax_pose 5, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose162:
+ax_pose 6, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose163:
+ax_pose 2, 0x81e4, 0x80f8, 0xac00
+ax_pose 3, 0x01dc, 0x0100, 0xac08
+ax_pose_terminator
+sGorebyssPose164:
+ax_pose 6, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sGorebyssPose165:
+ax_pose 13, 0x81ed, 0x00ed, 0xac00
+ax_pose 14, 0x81e5, 0x80f5, 0xac02
+ax_pose 15, 0x01f5, 0x0105, 0xac0a
+ax_pose 16, 0x81ed, 0x010d, 0xac0b
+ax_pose_terminator
+sGorebyssPose166:
+ax_pose 19, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose167:
+ax_pose 22, 0x81e4, 0x80f5, 0xac00
+ax_pose 23, 0x0204, 0x00fa, 0xac08
+ax_pose_terminator
+sGorebyssPose168:
+ax_pose 19, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose169:
+ax_pose 13, 0x81ed, 0x110b, 0xac00
+ax_pose 14, 0x81e5, 0x90fb, 0xac02
+ax_pose 15, 0x01f5, 0x10f3, 0xac0a
+ax_pose 16, 0x81ed, 0x10eb, 0xac0b
+ax_pose_terminator
+sGorebyssPose170:
+ax_pose 6, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sGorebyssPose171:
+ax_pose 24, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose172:
+ax_pose 25, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sGorebyssPose173:
+ax_pose 26, 0x41e5, 0x90ee, 0xac00
+ax_pose 27, 0x01f5, 0x50ed, 0xac08
+ax_pose 28, 0x01f5, 0x10fd, 0xac0c
+ax_pose 29, 0x81f5, 0x10e5, 0xac0d
+ax_pose_terminator
+sGorebyssPose174:
+ax_pose 30, 0x01e3, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose175:
+ax_pose 31, 0x81e2, 0x80f5, 0xac00
+ax_pose 32, 0x0202, 0x00fb, 0xac08
+ax_pose_terminator
+sGorebyssPose176:
+ax_pose 30, 0x01e3, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose177:
+ax_pose 26, 0x41e5, 0x80f2, 0xac00
+ax_pose 27, 0x01f5, 0x4103, 0xac08
+ax_pose 28, 0x01f5, 0x00fb, 0xac0c
+ax_pose 29, 0x81f5, 0x0113, 0xac0d
+ax_pose_terminator
+sGorebyssPose178:
+ax_pose 25, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sGorebyssPose179:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose180:
+ax_pose 1, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose181:
+ax_pose 24, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose182:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose183:
+ax_pose 5, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose184:
+ax_pose 25, 0x01e6, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose185:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose186:
+ax_pose 8, 0x81e1, 0x9101, 0xac00
+ax_pose 9, 0x81e1, 0x50f9, 0xac08
+ax_pose 10, 0x81f1, 0x10f1, 0xac0c
+ax_pose 11, 0x01e9, 0x10f1, 0xac0e
+ax_pose 12, 0x01eb, 0x10e9, 0xac0f
+ax_pose_terminator
+sGorebyssPose187:
+ax_pose 26, 0x41e5, 0x90ee, 0xac00
+ax_pose 27, 0x01f5, 0x50ed, 0xac08
+ax_pose 28, 0x01f5, 0x10fd, 0xac0c
+ax_pose 29, 0x81f5, 0x10e5, 0xac0d
+ax_pose_terminator
+sGorebyssPose188:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose189:
+ax_pose 18, 0x01e1, 0x90ea, 0xac00
+ax_pose_terminator
+sGorebyssPose190:
+ax_pose 30, 0x01e2, 0x90ea, 0xac00
+ax_pose_terminator
+sGorebyssPose191:
+ax_pose 20, 0x81e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose192:
+ax_pose 21, 0x81e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose193:
+ax_pose 31, 0x81e1, 0x80f5, 0xac00
+ax_pose 32, 0x0201, 0x00fe, 0xac08
+ax_pose_terminator
+sGorebyssPose194:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose195:
+ax_pose 18, 0x01e1, 0x80f6, 0xac00
+ax_pose_terminator
+sGorebyssPose196:
+ax_pose 30, 0x01e2, 0x80f6, 0xac00
+ax_pose_terminator
+sGorebyssPose197:
+ax_pose 7, 0x01e1, 0x80ef, 0xac00
+ax_pose_terminator
+sGorebyssPose198:
+ax_pose 8, 0x81e1, 0x80ef, 0xac00
+ax_pose 9, 0x81e1, 0x40ff, 0xac08
+ax_pose 10, 0x81f1, 0x0107, 0xac0c
+ax_pose 11, 0x01e9, 0x0107, 0xac0e
+ax_pose 12, 0x01eb, 0x010f, 0xac0f
+ax_pose_terminator
+sGorebyssPose199:
+ax_pose 26, 0x41e5, 0x80f2, 0xac00
+ax_pose 27, 0x01f5, 0x4103, 0xac08
+ax_pose 28, 0x01f5, 0x00fb, 0xac0c
+ax_pose 29, 0x81f5, 0x0113, 0xac0d
+ax_pose_terminator
+sGorebyssPose200:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose201:
+ax_pose 5, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose202:
+ax_pose 25, 0x01e6, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose203:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose204:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose205:
+ax_pose 7, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sGorebyssPose206:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose207:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose208:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose209:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose210:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+sGorebyssPose211:
+ax_pose 0, 0x81de, 0x80f8, 0xac00
+ax_pose_terminator
+sGorebyssPose212:
+ax_pose 4, 0x01e1, 0x80f2, 0xac00
+ax_pose_terminator
+sGorebyssPose213:
+ax_pose 7, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sGorebyssPose214:
+ax_pose 17, 0x01e1, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose215:
+ax_pose 20, 0x81e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGorebyssPose216:
+ax_pose 17, 0x01e1, 0x90eb, 0xac00
+ax_pose_terminator
+sGorebyssPose217:
+ax_pose 7, 0x01e1, 0x90f1, 0xac00
+ax_pose_terminator
+sGorebyssPose218:
+ax_pose 4, 0x01e1, 0x90ee, 0xac00
+ax_pose_terminator
+.align 2
+sGorebyssAnims_1_1:
+ax_anim 14, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 2, 0, 2, 0, 1,
+ax_anim 8, 0, 2, 0, 3, 0, 2,
+ax_anim 8, 0, 2, 0, 2, 0, 1,
+ax_anim 8, 0, 2, 0, 3, 0, 2,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, -1,
+ax_anim 6, 0, 0, 0, -1, 0, -1,
+ax_anim_terminator
+sGorebyssAnims_1_2:
+ax_anim 14, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 3, 1, 1,
+ax_anim 8, 0, 5, 1, 4, 1, 1,
+ax_anim 8, 0, 5, 2, 5, 2, 2,
+ax_anim 8, 0, 5, 1, 4, 1, 1,
+ax_anim 8, 0, 5, 0, 3, 0, 0,
+ax_anim 6, 0, 4, -1, 1, -1, -1,
+ax_anim 6, 0, 4, -2, 0, -2, -2,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim_terminator
+sGorebyssAnims_1_3:
+ax_anim 14, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, 1, 1, 0,
+ax_anim 8, 0, 8, 1, 2, 1, 0,
+ax_anim 8, 0, 8, 2, 2, 2, 0,
+ax_anim 8, 0, 8, 1, 2, 1, 0,
+ax_anim 8, 0, 8, 0, 2, 0, 0,
+ax_anim 6, 0, 7, -1, 1, -1, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_1_4:
+ax_anim 14, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 11, 2, -1, 2, -2,
+ax_anim 8, 0, 11, 3, -2, 3, -3,
+ax_anim 8, 0, 11, 2, -1, 2, -2,
+ax_anim 8, 0, 11, 1, 0, 1, -1,
+ax_anim 6, 0, 10, -1, 1, -1, 1,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_1_5:
+ax_anim 14, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, -1,
+ax_anim 8, 0, 14, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, -3, 0, -3,
+ax_anim 8, 0, 14, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, -3, 0, -3,
+ax_anim 6, 0, 13, 0, -1, 0, -1,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 1, 0, 1,
+ax_anim_terminator
+sGorebyssAnims_1_6:
+ax_anim 14, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 17, -2, -1, -2, -2,
+ax_anim 8, 0, 17, -3, -2, -3, -3,
+ax_anim 8, 0, 17, -2, -1, -2, -2,
+ax_anim 8, 0, 17, -1, 0, -1, -1,
+ax_anim 6, 0, 16, 1, 1, 1, 1,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_1_7:
+ax_anim 14, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, 1, -1, 0,
+ax_anim 8, 0, 20, -1, 2, -1, 0,
+ax_anim 8, 0, 20, -2, 2, -2, 0,
+ax_anim 8, 0, 20, -1, 2, -1, 0,
+ax_anim 8, 0, 20, 0, 2, 0, 0,
+ax_anim 6, 0, 19, 1, 1, 1, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_1_8:
+ax_anim 14, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 3, -1, 1,
+ax_anim 8, 0, 23, -1, 4, -1, 1,
+ax_anim 8, 0, 23, -2, 5, -2, 2,
+ax_anim 8, 0, 23, -1, 4, -1, 1,
+ax_anim 8, 0, 23, 0, 3, 0, 0,
+ax_anim 6, 0, 22, 1, 1, 1, -1,
+ax_anim 6, 0, 22, 2, 0, 2, -2,
+ax_anim 6, 0, 21, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 2,
+ax_anim 1, 0, 26, 0, 10, 0, 8,
+ax_anim 2, 0, 26, 0, 25, 0, 18,
+ax_anim 2, 1, 26, 1, 25, 1, 18,
+ax_anim 2, 0, 26, 0, 25, 0, 18,
+ax_anim 2, 0, 26, 1, 25, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGorebyssAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 3, 6, 3, 3,
+ax_anim 1, 0, 29, 8, 14, 9, 12,
+ax_anim 2, 0, 29, 16, 28, 17, 22,
+ax_anim 2, 1, 29, 17, 27, 18, 21,
+ax_anim 2, 0, 29, 16, 28, 17, 22,
+ax_anim 2, 0, 29, 17, 27, 18, 21,
+ax_anim 2, 0, 27, 5, 10, 5, 6,
+ax_anim_terminator
+sGorebyssAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 2, 4, 0,
+ax_anim 1, 0, 32, 10, 4, 10, 0,
+ax_anim 2, 0, 32, 16, 7, 16, 0,
+ax_anim 2, 1, 32, 16, 8, 16, 1,
+ax_anim 2, 0, 32, 16, 7, 16, 0,
+ax_anim 2, 0, 32, 16, 8, 16, 1,
+ax_anim 2, 0, 30, 6, 2, 6, 0,
+ax_anim_terminator
+sGorebyssAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 5, -4, 5, -6,
+ax_anim 1, 0, 35, 11, -9, 11, -12,
+ax_anim 2, 0, 35, 20, -15, 21, -21,
+ax_anim 2, 1, 35, 21, -14, 22, -20,
+ax_anim 2, 0, 35, 20, -15, 21, -21,
+ax_anim 2, 0, 35, 21, -14, 22, -20,
+ax_anim 2, 0, 33, 7, -6, 7, -8,
+ax_anim_terminator
+sGorebyssAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -13,
+ax_anim 2, 0, 38, 0, -16, 0, -22,
+ax_anim 2, 1, 38, 1, -16, 1, -22,
+ax_anim 2, 0, 38, 0, -16, 0, -22,
+ax_anim 2, 0, 38, 1, -16, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sGorebyssAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -5, -4, -5, -6,
+ax_anim 1, 0, 41, -11, -9, -11, -12,
+ax_anim 2, 0, 41, -20, -15, -21, -21,
+ax_anim 2, 1, 41, -21, -14, -22, -20,
+ax_anim 2, 0, 41, -20, -15, -21, -21,
+ax_anim 2, 0, 41, -21, -14, -22, -20,
+ax_anim 2, 0, 39, -7, -6, -7, -8,
+ax_anim_terminator
+sGorebyssAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 2, -4, 0,
+ax_anim 1, 0, 44, -10, 4, -10, 0,
+ax_anim 2, 0, 44, -16, 7, -16, 0,
+ax_anim 2, 1, 44, -16, 8, -16, 1,
+ax_anim 2, 0, 44, -16, 7, -16, 0,
+ax_anim 2, 0, 44, -16, 8, -16, 1,
+ax_anim 2, 0, 42, -6, 2, -6, 0,
+ax_anim_terminator
+sGorebyssAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -3, 6, -3, 3,
+ax_anim 1, 0, 47, -8, 14, -9, 12,
+ax_anim 2, 0, 47, -16, 28, -17, 22,
+ax_anim 2, 1, 47, -17, 27, -18, 21,
+ax_anim 2, 0, 47, -16, 28, -17, 22,
+ax_anim 2, 0, 47, -17, 27, -18, 21,
+ax_anim 2, 0, 45, -5, 10, -5, 6,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 8, 0, 8,
+ax_anim 1, 0, 50, 0, 20, 0, 20,
+ax_anim 2, 0, 50, 0, 49, 0, 43,
+ax_anim 2, 1, 50, 1, 49, 1, 43,
+ax_anim 2, 0, 50, 0, 49, 0, 43,
+ax_anim 2, 0, 50, 1, 49, 1, 43,
+ax_anim 2, 0, 48, 0, 15, 0, 15,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sGorebyssAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 8, 10, 8, 9,
+ax_anim 1, 0, 53, 20, 25, 20, 22,
+ax_anim 2, 0, 53, 40, 52, 43, 46,
+ax_anim 2, 1, 53, 41, 51, 44, 45,
+ax_anim 2, 0, 53, 40, 52, 43, 46,
+ax_anim 2, 0, 53, 41, 51, 44, 45,
+ax_anim 2, 0, 51, 15, 18, 15, 16,
+ax_anim 2, 0, 51, 6, 8, 6, 7,
+ax_anim_terminator
+sGorebyssAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 8, 2, 8, 0,
+ax_anim 1, 0, 56, 20, 4, 20, 0,
+ax_anim 2, 0, 56, 39, 7, 39, 0,
+ax_anim 2, 1, 56, 39, 8, 39, 1,
+ax_anim 2, 0, 56, 39, 7, 39, 0,
+ax_anim 2, 0, 56, 39, 8, 39, 1,
+ax_anim 2, 0, 54, 16, 2, 16, 0,
+ax_anim 2, 0, 54, 6, 1, 6, 0,
+ax_anim_terminator
+sGorebyssAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 59, 8, -8, 8, -8,
+ax_anim 1, 0, 59, 22, -20, 22, -22,
+ax_anim 2, 0, 59, 44, -39, 45, -44,
+ax_anim 2, 1, 59, 44, -38, 45, -43,
+ax_anim 2, 0, 59, 43, -39, 44, -44,
+ax_anim 2, 0, 59, 44, -38, 45, -43,
+ax_anim 2, 0, 57, 16, -15, 16, -16,
+ax_anim 2, 0, 57, 8, -8, 8, -8,
+ax_anim_terminator
+sGorebyssAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -8, 0, -8,
+ax_anim 1, 0, 62, 0, -19, 0, -19,
+ax_anim 2, 0, 62, 0, -40, 0, -46,
+ax_anim 2, 1, 62, 1, -40, 1, -46,
+ax_anim 2, 0, 62, 0, -40, 0, -46,
+ax_anim 2, 0, 62, 1, -40, 1, -46,
+ax_anim 2, 0, 60, 0, -15, 0, -15,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sGorebyssAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 65, -8, -8, -8, -8,
+ax_anim 1, 0, 65, -22, -20, -22, -22,
+ax_anim 2, 0, 65, -44, -39, -45, -44,
+ax_anim 2, 1, 65, -44, -38, -45, -43,
+ax_anim 2, 0, 65, -43, -39, -44, -44,
+ax_anim 2, 0, 65, -44, -38, -45, -43,
+ax_anim 2, 0, 63, -16, -15, -16, -16,
+ax_anim 2, 0, 63, -8, -8, -8, -8,
+ax_anim_terminator
+sGorebyssAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -8, 2, -8, 0,
+ax_anim 1, 0, 68, -20, 4, -20, 0,
+ax_anim 2, 0, 68, -39, 7, -39, 0,
+ax_anim 2, 1, 68, -39, 8, -39, 1,
+ax_anim 2, 0, 68, -39, 7, -39, 0,
+ax_anim 2, 0, 68, -39, 8, -39, 1,
+ax_anim 2, 0, 66, -16, 2, -16, 0,
+ax_anim 2, 0, 66, -6, 1, -6, 0,
+ax_anim_terminator
+sGorebyssAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -8, 10, -8, 9,
+ax_anim 1, 0, 71, -20, 25, -20, 22,
+ax_anim 2, 0, 71, -40, 52, -43, 46,
+ax_anim 2, 1, 71, -41, 51, -44, 45,
+ax_anim 2, 0, 71, -40, 52, -43, 46,
+ax_anim 2, 0, 71, -41, 51, -44, 45,
+ax_anim 2, 0, 69, -15, 18, -15, 16,
+ax_anim 2, 0, 69, -6, 8, -6, 7,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_4_1:
+ax_anim 2, 0, 75, 0, -2, 0, -2,
+ax_anim 6, 2, 75, 0, -3, 0, -3,
+ax_anim 2, 0, 75, 0, -1, 0, -1,
+ax_anim 2, 1, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 4, 1, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 1, 4, 1, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 1, 4, 1, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sGorebyssAnims_4_2:
+ax_anim 2, 0, 79, -2, -2, -2, -2,
+ax_anim 6, 2, 79, -3, -3, -3, -3,
+ax_anim 2, 0, 79, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 6, 4, 6, 4,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 6, 4, 6, 4,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 78, 6, 4, 6, 4,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim_terminator
+sGorebyssAnims_4_3:
+ax_anim 2, 0, 83, -2, 0, -2, 0,
+ax_anim 6, 2, 83, -3, 0, -3, 0,
+ax_anim 2, 0, 83, -1, 0, -1, 0,
+ax_anim 2, 1, 81, 3, 0, 3, 0,
+ax_anim 2, 0, 82, 5, 1, 5, 1,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 1, 5, 1,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 5, 1, 5, 1,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim_terminator
+sGorebyssAnims_4_4:
+ax_anim 2, 0, 87, -2, 2, -2, 2,
+ax_anim 6, 2, 87, -3, 3, -3, 3,
+ax_anim 2, 0, 87, -1, 1, -1, 1,
+ax_anim 2, 1, 85, 2, -2, 2, -2,
+ax_anim 2, 0, 86, 4, -4, 4, -4,
+ax_anim 2, 0, 86, 3, -5, 3, -5,
+ax_anim 2, 0, 86, 4, -4, 4, -4,
+ax_anim 2, 0, 86, 3, -5, 3, -5,
+ax_anim 2, 0, 86, 4, -4, 4, -4,
+ax_anim 2, 0, 86, 3, -5, 3, -5,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim_terminator
+sGorebyssAnims_4_5:
+ax_anim 2, 0, 91, 0, 2, 0, 2,
+ax_anim 6, 2, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 0, 1, 0, 1,
+ax_anim 2, 1, 89, 0, -5, 0, -5,
+ax_anim 2, 0, 89, 1, -5, 1, -5,
+ax_anim 2, 0, 89, 0, -5, 0, -5,
+ax_anim 2, 0, 89, 1, -5, 1, -5,
+ax_anim 2, 0, 89, 0, -5, 0, -5,
+ax_anim 2, 0, 89, 1, -5, 1, -5,
+ax_anim 2, 0, 89, 0, -5, 0, -5,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim_terminator
+sGorebyssAnims_4_6:
+ax_anim 2, 0, 95, 2, 2, 2, 2,
+ax_anim 6, 2, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 1, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 94, -4, -4, -4, -4,
+ax_anim 2, 0, 94, -3, -5, -3, -5,
+ax_anim 2, 0, 94, -4, -4, -4, -4,
+ax_anim 2, 0, 94, -3, -5, -3, -5,
+ax_anim 2, 0, 94, -4, -4, -4, -4,
+ax_anim 2, 0, 94, -3, -5, -3, -5,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim_terminator
+sGorebyssAnims_4_7:
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 6, 2, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 1, 97, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -5, 1, -5, 1,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 1, -5, 1,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 98, -5, 1, -5, 1,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sGorebyssAnims_4_8:
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim 6, 2, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 1, 101, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -6, 4, -6, 4,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -6, 4, -6, 4,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -6, 4, -6, 4,
+ax_anim 2, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 2, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_5_2:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 2, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 2, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_5_4:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 6, 2, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 1, 0, 1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 1, 0, 1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_5_6:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 2, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 1, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 2, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 1, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_5_8:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 2, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 1, 126, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_6_1:
+ax_anim 16, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, -1, 0, 0,
+ax_anim 16, 0, 128, 0, -2, 0, 0,
+ax_anim 16, 0, 129, 0, -2, 0, 0,
+ax_anim 12, 0, 129, 0, -1, 0, 0,
+ax_anim 16, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sGorebyssAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sGorebyssAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sGorebyssAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sGorebyssAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sGorebyssAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sGorebyssAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sGorebyssAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_8_1:
+ax_anim 16, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_8_2:
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 142, -1, 1, 0, 0,
+ax_anim 8, 0, 143, 0, 1, 0, 0,
+ax_anim 8, 0, 142, -1, 1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_8_3:
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 2, 0, 0, 0,
+ax_anim 8, 0, 146, 3, 2, 0, 0,
+ax_anim 8, 0, 145, 2, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_8_4:
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 1, -1, 0, 0,
+ax_anim 8, 0, 149, 2, -2, 0, 0,
+ax_anim 8, 0, 148, 1, -1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_8_5:
+ax_anim 16, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim 8, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_8_6:
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 154, -1, -1, 0, 0,
+ax_anim 8, 0, 155, -2, -2, 0, 0,
+ax_anim 8, 0, 154, -1, -1, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_8_7:
+ax_anim 16, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, -2, 0, 0, 0,
+ax_anim 8, 0, 158, -3, 2, 0, 0,
+ax_anim 8, 0, 157, -2, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_8_8:
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 1, 1, 0, 0,
+ax_anim 8, 0, 161, 0, 1, 0, 0,
+ax_anim 8, 0, 160, 1, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 8, 6, 8, 6,
+ax_anim 2, 0, 164, 8, 13, 8, 13,
+ax_anim 2, 0, 165, 3, 19, 3, 19,
+ax_anim 3, 0, 166, 0, 19, 0, 19,
+ax_anim 2, 3, 167, -5, 19, -5, 19,
+ax_anim 2, 0, 168, -8, 13, -8, 13,
+ax_anim 1, 0, 169, -8, 6, -8, 6,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 14, 1, 14, 1,
+ax_anim 2, 0, 163, 26, 8, 26, 8,
+ax_anim 2, 0, 164, 27, 17, 27, 16,
+ax_anim 3, 0, 165, 22, 24, 22, 22,
+ax_anim 2, 3, 166, 14, 25, 14, 23,
+ax_anim 2, 0, 167, 6, 19, 6, 19,
+ax_anim 1, 0, 168, 1, 10, 1, 10,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 2, -4, 2, -4,
+ax_anim 2, 0, 162, 10, -7, 10, -7,
+ax_anim 2, 0, 163, 20, -1, 20, -2,
+ax_anim 3, 0, 164, 22, 4, 22, 2,
+ax_anim 2, 3, 165, 17, 10, 17, 8,
+ax_anim 2, 0, 166, 11, 10, 11, 10,
+ax_anim 1, 0, 167, 4, 7, 4, 7,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -5, -7, -5, -7,
+ax_anim 2, 0, 169, -1, -11, -1, -13,
+ax_anim 2, 0, 162, 10, -19, 10, -19,
+ax_anim 3, 0, 163, 19, -18, 19, -20,
+ax_anim 2, 3, 164, 22, -10, 22, -12,
+ax_anim 2, 0, 165, 15, -1, 15, -1,
+ax_anim 1, 0, 166, 7, 1, 7, 1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -5, -1, -5, -1,
+ax_anim 2, 0, 168, -8, -5, -8, -5,
+ax_anim 2, 0, 169, -7, -11, -7, -13,
+ax_anim 3, 0, 162, 0, -15, 0, -18,
+ax_anim 2, 3, 163, 7, -11, 7, -13,
+ax_anim 2, 0, 164, 8, -5, 8, -5,
+ax_anim 1, 0, 165, 5, -1, 5, -1,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 5, -7, 5, -7,
+ax_anim 2, 0, 163, 1, -11, 1, -13,
+ax_anim 2, 0, 162, -10, -19, -10, -19,
+ax_anim 3, 0, 169, -19, -18, -19, -20,
+ax_anim 2, 3, 168, -22, -10, -22, -12,
+ax_anim 2, 0, 167, -15, -1, -15, -1,
+ax_anim 1, 0, 166, -7, 1, -7, 1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -2, -4, -2, -4,
+ax_anim 2, 0, 162, -10, -7, -10, -7,
+ax_anim 2, 0, 169, -20, -1, -20, -2,
+ax_anim 3, 0, 168, -22, 4, -22, 2,
+ax_anim 2, 3, 167, -17, 10, -17, 8,
+ax_anim 2, 0, 166, -11, 10, -11, 10,
+ax_anim 1, 0, 165, -4, 7, -4, 7,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -14, 1, -14, 1,
+ax_anim 2, 0, 169, -26, 8, -26, 8,
+ax_anim 2, 0, 168, -27, 17, -27, 16,
+ax_anim 3, 0, 167, -22, 24, -22, 22,
+ax_anim 2, 3, 166, -14, 25, -14, 23,
+ax_anim 2, 0, 165, -6, 19, -6, 19,
+ax_anim 1, 0, 164, -1, 10, -1, 10,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 3, 0, 179, 0, -18, 0, 0,
+ax_anim 2, 0, 179, 0, -14, 0, 0,
+ax_anim 1, 0, 179, 0, -8, 0, 0,
+ax_anim 2, 2, 179, 0, 4, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -5, 0, 0,
+ax_anim 2, 0, 183, 0, -11, 0, 0,
+ax_anim 3, 0, 183, 0, -15, 0, 0,
+ax_anim 4, 0, 183, 0, -16, 0, 0,
+ax_anim 4, 0, 182, 0, -20, 0, 0,
+ax_anim 3, 0, 182, 0, -19, 0, 0,
+ax_anim 2, 0, 182, 0, -15, 0, 0,
+ax_anim 1, 0, 182, 0, -9, 0, 0,
+ax_anim 2, 2, 182, 0, 5, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -7, 0, 0,
+ax_anim 2, 0, 186, 0, -13, 0, 0,
+ax_anim 3, 0, 186, 0, -17, 0, 0,
+ax_anim 4, 0, 186, 0, -18, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -13, 0, 0,
+ax_anim 1, 0, 185, 0, -7, 0, 0,
+ax_anim 2, 2, 185, 0, 4, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -3, 0, 0,
+ax_anim 2, 0, 189, 0, -9, 0, 0,
+ax_anim 3, 0, 189, 0, -13, 0, 0,
+ax_anim 4, 0, 189, 0, -14, 0, 0,
+ax_anim 4, 0, 188, 0, -19, 0, 0,
+ax_anim 3, 0, 188, 0, -18, 0, 0,
+ax_anim 2, 0, 188, 0, -14, 0, 0,
+ax_anim 1, 0, 188, 0, -8, 0, 0,
+ax_anim 2, 2, 188, 0, 2, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -19, 0, 0,
+ax_anim 3, 0, 191, 0, -18, 0, 0,
+ax_anim 2, 0, 191, 0, -14, 0, 0,
+ax_anim 1, 0, 191, 0, -8, 0, 0,
+ax_anim 2, 2, 191, 0, 3, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -3, 0, 0,
+ax_anim 2, 0, 195, 0, -9, 0, 0,
+ax_anim 3, 0, 195, 0, -13, 0, 0,
+ax_anim 4, 0, 195, 0, -14, 0, 0,
+ax_anim 4, 0, 194, 0, -19, 0, 0,
+ax_anim 3, 0, 194, 0, -18, 0, 0,
+ax_anim 2, 0, 194, 0, -14, 0, 0,
+ax_anim 1, 0, 194, 0, -8, 0, 0,
+ax_anim 2, 2, 194, 0, 2, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -7, 0, 0,
+ax_anim 2, 0, 198, 0, -13, 0, 0,
+ax_anim 3, 0, 198, 0, -17, 0, 0,
+ax_anim 4, 0, 198, 0, -18, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -13, 0, 0,
+ax_anim 1, 0, 197, 0, -7, 0, 0,
+ax_anim 2, 2, 197, 0, 4, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -5, 0, 0,
+ax_anim 2, 0, 201, 0, -11, 0, 0,
+ax_anim 3, 0, 201, 0, -15, 0, 0,
+ax_anim 4, 0, 201, 0, -16, 0, 0,
+ax_anim 4, 0, 200, 0, -20, 0, 0,
+ax_anim 3, 0, 200, 0, -19, 0, 0,
+ax_anim 2, 0, 200, 0, -15, 0, 0,
+ax_anim 1, 0, 200, 0, -9, 0, 0,
+ax_anim 2, 2, 200, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGorebyssAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGorebyssGfx1:
+.incbin "baserom.gba", 0x152FC68, 0x100
+sGorebyssSprites1:
+ax_sprite sGorebyssGfx1, 0x100
+ax_sprite_terminator
+sGorebyssGfx2:
+.incbin "baserom.gba", 0x152FD78, 0x100
+sGorebyssSprites2:
+ax_sprite sGorebyssGfx2, 0x100
+ax_sprite_terminator
+sGorebyssGfx3:
+.incbin "baserom.gba", 0x152FE88, 0x100
+sGorebyssSprites3:
+ax_sprite sGorebyssGfx3, 0x100
+ax_sprite_terminator
+sGorebyssGfx4:
+.incbin "baserom.gba", 0x152FF98, 0x20
+sGorebyssSprites4:
+ax_sprite sGorebyssGfx4, 0x20
+ax_sprite_terminator
+sGorebyssGfx5:
+.incbin "baserom.gba", 0x152FFC8, 0x200
+sGorebyssSprites5:
+ax_sprite sGorebyssGfx5, 0x200
+ax_sprite_terminator
+sGorebyssGfx6:
+.incbin "baserom.gba", 0x15301D8, 0x200
+sGorebyssSprites6:
+ax_sprite sGorebyssGfx6, 0x200
+ax_sprite_terminator
+sGorebyssGfx7:
+.incbin "baserom.gba", 0x15303E8, 0x200
+sGorebyssSprites7:
+ax_sprite sGorebyssGfx7, 0x200
+ax_sprite_terminator
+sGorebyssGfx8:
+.incbin "baserom.gba", 0x15305F8, 0x200
+sGorebyssSprites8:
+ax_sprite sGorebyssGfx8, 0x200
+ax_sprite_terminator
+sGorebyssGfx9:
+.incbin "baserom.gba", 0x1530808, 0x100
+sGorebyssSprites9:
+ax_sprite sGorebyssGfx9, 0x100
+ax_sprite_terminator
+sGorebyssGfx10:
+.incbin "baserom.gba", 0x1530918, 0x80
+sGorebyssSprites10:
+ax_sprite sGorebyssGfx10, 0x80
+ax_sprite_terminator
+sGorebyssGfx11:
+.incbin "baserom.gba", 0x15309A8, 0x40
+sGorebyssSprites11:
+ax_sprite sGorebyssGfx11, 0x40
+ax_sprite_terminator
+sGorebyssGfx12:
+.incbin "baserom.gba", 0x15309F8, 0x20
+sGorebyssSprites12:
+ax_sprite sGorebyssGfx12, 0x20
+ax_sprite_terminator
+sGorebyssGfx13:
+.incbin "baserom.gba", 0x1530A28, 0x20
+sGorebyssSprites13:
+ax_sprite sGorebyssGfx13, 0x20
+ax_sprite_terminator
+sGorebyssGfx14:
+.incbin "baserom.gba", 0x1530A58, 0x40
+sGorebyssSprites14:
+ax_sprite sGorebyssGfx14, 0x40
+ax_sprite_terminator
+sGorebyssGfx15:
+.incbin "baserom.gba", 0x1530AA8, 0x100
+sGorebyssSprites15:
+ax_sprite sGorebyssGfx15, 0x100
+ax_sprite_terminator
+sGorebyssGfx16:
+.incbin "baserom.gba", 0x1530BB8, 0x20
+sGorebyssSprites16:
+ax_sprite sGorebyssGfx16, 0x20
+ax_sprite_terminator
+sGorebyssGfx17:
+.incbin "baserom.gba", 0x1530BE8, 0x40
+sGorebyssSprites17:
+ax_sprite sGorebyssGfx17, 0x40
+ax_sprite_terminator
+sGorebyssGfx18:
+.incbin "baserom.gba", 0x1530C38, 0x200
+sGorebyssSprites18:
+ax_sprite sGorebyssGfx18, 0x200
+ax_sprite_terminator
+sGorebyssGfx19:
+.incbin "baserom.gba", 0x1530E48, 0x200
+sGorebyssSprites19:
+ax_sprite sGorebyssGfx19, 0x200
+ax_sprite_terminator
+sGorebyssGfx20:
+.incbin "baserom.gba", 0x1531058, 0x200
+sGorebyssSprites20:
+ax_sprite sGorebyssGfx20, 0x200
+ax_sprite_terminator
+sGorebyssGfx21:
+.incbin "baserom.gba", 0x1531268, 0x100
+sGorebyssSprites21:
+ax_sprite sGorebyssGfx21, 0x100
+ax_sprite_terminator
+sGorebyssGfx22:
+.incbin "baserom.gba", 0x1531378, 0x100
+sGorebyssSprites22:
+ax_sprite sGorebyssGfx22, 0x100
+ax_sprite_terminator
+sGorebyssGfx23:
+.incbin "baserom.gba", 0x1531488, 0x100
+sGorebyssSprites23:
+ax_sprite sGorebyssGfx23, 0x100
+ax_sprite_terminator
+sGorebyssGfx24:
+.incbin "baserom.gba", 0x1531598, 0x20
+sGorebyssSprites24:
+ax_sprite sGorebyssGfx24, 0x20
+ax_sprite_terminator
+sGorebyssGfx25:
+.incbin "baserom.gba", 0x15315C8, 0x100
+sGorebyssSprites25:
+ax_sprite sGorebyssGfx25, 0x100
+ax_sprite_terminator
+sGorebyssGfx26:
+.incbin "baserom.gba", 0x15316D8, 0x60
+sGorebyssGfx26_1:
+.incbin "baserom.gba", 0x1531738, 0x60
+sGorebyssGfx26_2:
+.incbin "baserom.gba", 0x1531798, 0x60
+sGorebyssGfx26_3:
+.incbin "baserom.gba", 0x15317F8, 0x40
+sGorebyssSprites26:
+ax_sprite sGorebyssGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGorebyssGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGorebyssGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGorebyssGfx26_3, 0x40
+ax_sprite_terminator
+sGorebyssGfx27:
+.incbin "baserom.gba", 0x1531878, 0xE0
+sGorebyssSprites27:
+ax_sprite sGorebyssGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGorebyssGfx28:
+.incbin "baserom.gba", 0x1531970, 0x80
+sGorebyssSprites28:
+ax_sprite sGorebyssGfx28, 0x80
+ax_sprite_terminator
+sGorebyssGfx29:
+.incbin "baserom.gba", 0x1531A00, 0x20
+sGorebyssSprites29:
+ax_sprite sGorebyssGfx29, 0x20
+ax_sprite_terminator
+sGorebyssGfx30:
+.incbin "baserom.gba", 0x1531A30, 0x40
+sGorebyssSprites30:
+ax_sprite sGorebyssGfx30, 0x40
+ax_sprite_terminator
+sGorebyssGfx31:
+.incbin "baserom.gba", 0x1531A80, 0x40
+sGorebyssGfx31_1:
+.incbin "baserom.gba", 0x1531AC0, 0x60
+sGorebyssGfx31_2:
+.incbin "baserom.gba", 0x1531B20, 0x60
+sGorebyssGfx31_3:
+.incbin "baserom.gba", 0x1531B80, 0x60
+sGorebyssSprites31:
+ax_sprite sGorebyssGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGorebyssGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGorebyssGfx31_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGorebyssGfx31_3, 0x60
+ax_sprite_terminator
+sGorebyssGfx32:
+.incbin "baserom.gba", 0x1531C20, 0x100
+sGorebyssSprites32:
+ax_sprite sGorebyssGfx32, 0x100
+ax_sprite_terminator
+sGorebyssGfx33:
+.incbin "baserom.gba", 0x1531D30, 0x20
+sGorebyssSprites33:
+ax_sprite sGorebyssGfx33, 0x20
+ax_sprite_terminator
+sGorebyssGfx34:
+.incbin "baserom.gba", 0x1531D60, 0x200
+sGorebyssSprites34:
+ax_sprite sGorebyssGfx34, 0x200
+ax_sprite_terminator
+sGorebyssGfx35:
+.incbin "baserom.gba", 0x1531F70, 0x200
+sGorebyssSprites35:
+ax_sprite sGorebyssGfx35, 0x200
+ax_sprite_terminator
+sGorebyssGfx36:
+.incbin "baserom.gba", 0x1532180, 0x100
+sGorebyssSprites36:
+ax_sprite sGorebyssGfx36, 0x100
+ax_sprite_terminator
+sGorebyssGfx37:
+.incbin "baserom.gba", 0x1532290, 0x40
+sGorebyssSprites37:
+ax_sprite sGorebyssGfx37, 0x40
+ax_sprite_terminator
+sGorebyssGfx38:
+.incbin "baserom.gba", 0x15322E0, 0x40
+sGorebyssSprites38:
+ax_sprite sGorebyssGfx38, 0x40
+ax_sprite_terminator
+sGorebyssGfx39:
+.incbin "baserom.gba", 0x1532330, 0x20
+sGorebyssSprites39:
+ax_sprite sGorebyssGfx39, 0x20
+ax_sprite_terminator
+sGorebyssGfx40:
+.incbin "baserom.gba", 0x1532360, 0x40
+sGorebyssSprites40:
+ax_sprite sGorebyssGfx40, 0x40
+ax_sprite_terminator
+sGorebyssGfx41:
+.incbin "baserom.gba", 0x15323B0, 0x40
+sGorebyssSprites41:
+ax_sprite sGorebyssGfx41, 0x40
+ax_sprite_terminator
+sGorebyssGfx42:
+.incbin "baserom.gba", 0x1532400, 0x100
+sGorebyssSprites42:
+ax_sprite sGorebyssGfx42, 0x100
+ax_sprite_terminator
+sGorebyssGfx43:
+.incbin "baserom.gba", 0x1532510, 0x200
+sGorebyssSprites43:
+ax_sprite sGorebyssGfx43, 0x200
+ax_sprite_terminator
+sGorebyssGfx44:
+.incbin "baserom.gba", 0x1532720, 0x20
+sGorebyssSprites44:
+ax_sprite sGorebyssGfx44, 0x20
+ax_sprite_terminator
+sGorebyssGfx45:
+.incbin "baserom.gba", 0x1532750, 0x40
+sGorebyssSprites45:
+ax_sprite sGorebyssGfx45, 0x40
+ax_sprite_terminator
+sGorebyssGfx46:
+.incbin "baserom.gba", 0x15327A0, 0x40
+sGorebyssSprites46:
+ax_sprite sGorebyssGfx46, 0x40
+ax_sprite_terminator
+sGorebyssGfx47:
+.incbin "baserom.gba", 0x15327F0, 0x100
+sGorebyssSprites47:
+ax_sprite sGorebyssGfx47, 0x100
+ax_sprite_terminator
+sGorebyssGfx48:
+.incbin "baserom.gba", 0x1532900, 0x80
+sGorebyssSprites48:
+ax_sprite sGorebyssGfx48, 0x80
+ax_sprite_terminator
+sGorebyssGfx49:
+.incbin "baserom.gba", 0x1532990, 0x100
+sGorebyssSprites49:
+ax_sprite sGorebyssGfx49, 0x100
+ax_sprite_terminator
+sAxPosesGorebyss:
+.4byte sGorebyssPose1
+.4byte sGorebyssPose2
+.4byte sGorebyssPose3
+.4byte sGorebyssPose4
+.4byte sGorebyssPose5
+.4byte sGorebyssPose6
+.4byte sGorebyssPose7
+.4byte sGorebyssPose8
+.4byte sGorebyssPose9
+.4byte sGorebyssPose10
+.4byte sGorebyssPose11
+.4byte sGorebyssPose12
+.4byte sGorebyssPose13
+.4byte sGorebyssPose14
+.4byte sGorebyssPose15
+.4byte sGorebyssPose16
+.4byte sGorebyssPose17
+.4byte sGorebyssPose18
+.4byte sGorebyssPose19
+.4byte sGorebyssPose20
+.4byte sGorebyssPose21
+.4byte sGorebyssPose22
+.4byte sGorebyssPose23
+.4byte sGorebyssPose24
+.4byte sGorebyssPose25
+.4byte sGorebyssPose26
+.4byte sGorebyssPose27
+.4byte sGorebyssPose28
+.4byte sGorebyssPose29
+.4byte sGorebyssPose30
+.4byte sGorebyssPose31
+.4byte sGorebyssPose32
+.4byte sGorebyssPose33
+.4byte sGorebyssPose34
+.4byte sGorebyssPose35
+.4byte sGorebyssPose36
+.4byte sGorebyssPose37
+.4byte sGorebyssPose38
+.4byte sGorebyssPose39
+.4byte sGorebyssPose40
+.4byte sGorebyssPose41
+.4byte sGorebyssPose42
+.4byte sGorebyssPose43
+.4byte sGorebyssPose44
+.4byte sGorebyssPose45
+.4byte sGorebyssPose46
+.4byte sGorebyssPose47
+.4byte sGorebyssPose48
+.4byte sGorebyssPose49
+.4byte sGorebyssPose50
+.4byte sGorebyssPose51
+.4byte sGorebyssPose52
+.4byte sGorebyssPose53
+.4byte sGorebyssPose54
+.4byte sGorebyssPose55
+.4byte sGorebyssPose56
+.4byte sGorebyssPose57
+.4byte sGorebyssPose58
+.4byte sGorebyssPose59
+.4byte sGorebyssPose60
+.4byte sGorebyssPose61
+.4byte sGorebyssPose62
+.4byte sGorebyssPose63
+.4byte sGorebyssPose64
+.4byte sGorebyssPose65
+.4byte sGorebyssPose66
+.4byte sGorebyssPose67
+.4byte sGorebyssPose68
+.4byte sGorebyssPose69
+.4byte sGorebyssPose70
+.4byte sGorebyssPose71
+.4byte sGorebyssPose72
+.4byte sGorebyssPose73
+.4byte sGorebyssPose74
+.4byte sGorebyssPose75
+.4byte sGorebyssPose76
+.4byte sGorebyssPose77
+.4byte sGorebyssPose78
+.4byte sGorebyssPose79
+.4byte sGorebyssPose80
+.4byte sGorebyssPose81
+.4byte sGorebyssPose82
+.4byte sGorebyssPose83
+.4byte sGorebyssPose84
+.4byte sGorebyssPose85
+.4byte sGorebyssPose86
+.4byte sGorebyssPose87
+.4byte sGorebyssPose88
+.4byte sGorebyssPose89
+.4byte sGorebyssPose90
+.4byte sGorebyssPose91
+.4byte sGorebyssPose92
+.4byte sGorebyssPose93
+.4byte sGorebyssPose94
+.4byte sGorebyssPose95
+.4byte sGorebyssPose96
+.4byte sGorebyssPose97
+.4byte sGorebyssPose98
+.4byte sGorebyssPose99
+.4byte sGorebyssPose100
+.4byte sGorebyssPose101
+.4byte sGorebyssPose102
+.4byte sGorebyssPose103
+.4byte sGorebyssPose104
+.4byte sGorebyssPose105
+.4byte sGorebyssPose106
+.4byte sGorebyssPose107
+.4byte sGorebyssPose108
+.4byte sGorebyssPose109
+.4byte sGorebyssPose110
+.4byte sGorebyssPose111
+.4byte sGorebyssPose112
+.4byte sGorebyssPose113
+.4byte sGorebyssPose114
+.4byte sGorebyssPose115
+.4byte sGorebyssPose116
+.4byte sGorebyssPose117
+.4byte sGorebyssPose118
+.4byte sGorebyssPose119
+.4byte sGorebyssPose120
+.4byte sGorebyssPose121
+.4byte sGorebyssPose122
+.4byte sGorebyssPose123
+.4byte sGorebyssPose124
+.4byte sGorebyssPose125
+.4byte sGorebyssPose126
+.4byte sGorebyssPose127
+.4byte sGorebyssPose128
+.4byte sGorebyssPose129
+.4byte sGorebyssPose130
+.4byte sGorebyssPose131
+.4byte sGorebyssPose132
+.4byte sGorebyssPose133
+.4byte sGorebyssPose134
+.4byte sGorebyssPose135
+.4byte sGorebyssPose136
+.4byte sGorebyssPose137
+.4byte sGorebyssPose138
+.4byte sGorebyssPose139
+.4byte sGorebyssPose140
+.4byte sGorebyssPose141
+.4byte sGorebyssPose142
+.4byte sGorebyssPose143
+.4byte sGorebyssPose144
+.4byte sGorebyssPose145
+.4byte sGorebyssPose146
+.4byte sGorebyssPose147
+.4byte sGorebyssPose148
+.4byte sGorebyssPose149
+.4byte sGorebyssPose150
+.4byte sGorebyssPose151
+.4byte sGorebyssPose152
+.4byte sGorebyssPose153
+.4byte sGorebyssPose154
+.4byte sGorebyssPose155
+.4byte sGorebyssPose156
+.4byte sGorebyssPose157
+.4byte sGorebyssPose158
+.4byte sGorebyssPose159
+.4byte sGorebyssPose160
+.4byte sGorebyssPose161
+.4byte sGorebyssPose162
+.4byte sGorebyssPose163
+.4byte sGorebyssPose164
+.4byte sGorebyssPose165
+.4byte sGorebyssPose166
+.4byte sGorebyssPose167
+.4byte sGorebyssPose168
+.4byte sGorebyssPose169
+.4byte sGorebyssPose170
+.4byte sGorebyssPose171
+.4byte sGorebyssPose172
+.4byte sGorebyssPose173
+.4byte sGorebyssPose174
+.4byte sGorebyssPose175
+.4byte sGorebyssPose176
+.4byte sGorebyssPose177
+.4byte sGorebyssPose178
+.4byte sGorebyssPose179
+.4byte sGorebyssPose180
+.4byte sGorebyssPose181
+.4byte sGorebyssPose182
+.4byte sGorebyssPose183
+.4byte sGorebyssPose184
+.4byte sGorebyssPose185
+.4byte sGorebyssPose186
+.4byte sGorebyssPose187
+.4byte sGorebyssPose188
+.4byte sGorebyssPose189
+.4byte sGorebyssPose190
+.4byte sGorebyssPose191
+.4byte sGorebyssPose192
+.4byte sGorebyssPose193
+.4byte sGorebyssPose194
+.4byte sGorebyssPose195
+.4byte sGorebyssPose196
+.4byte sGorebyssPose197
+.4byte sGorebyssPose198
+.4byte sGorebyssPose199
+.4byte sGorebyssPose200
+.4byte sGorebyssPose201
+.4byte sGorebyssPose202
+.4byte sGorebyssPose203
+.4byte sGorebyssPose204
+.4byte sGorebyssPose205
+.4byte sGorebyssPose206
+.4byte sGorebyssPose207
+.4byte sGorebyssPose208
+.4byte sGorebyssPose209
+.4byte sGorebyssPose210
+.4byte sGorebyssPose211
+.4byte sGorebyssPose212
+.4byte sGorebyssPose213
+.4byte sGorebyssPose214
+.4byte sGorebyssPose215
+.4byte sGorebyssPose216
+.4byte sGorebyssPose217
+.4byte sGorebyssPose218
+sAxPositionsGorebyss:
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,  -12
+.2byte   -1,   -6, 	  -2,  -12, 	   4,  -12, 	   1,  -14
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   12,  -10, 	   8,  -10, 	   3,   -8, 	   2,  -10
+.2byte   12,   -9, 	   7,   -9, 	   2,   -8, 	   0,  -11
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte   12,  -15, 	   1,  -12, 	   1,   -9, 	   0,  -10
+.2byte   12,  -14, 	   1,  -14, 	  -1,  -12, 	  -1,  -14
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -16, 	   0,  -12, 	   3,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -16, 	  -1,  -12, 	  -4,   -8, 	   0,  -10
+.2byte  -12,  -15, 	  -3,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte  -12,  -15, 	  -1,  -12, 	  -1,   -9, 	   0,  -10
+.2byte  -12,  -14, 	  -1,  -14, 	   1,  -12, 	   1,  -14
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -13,  -10, 	  -9,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte  -13,   -9, 	  -8,   -9, 	  -3,   -8, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,  -12
+.2byte   -1,   -6, 	  -2,  -12, 	   4,  -12, 	   1,  -14
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   12,  -10, 	   8,  -10, 	   3,   -8, 	   2,  -10
+.2byte   12,   -9, 	   7,   -9, 	   2,   -8, 	   0,  -11
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte   12,  -15, 	   1,  -12, 	   1,   -9, 	   0,  -10
+.2byte   12,  -14, 	   1,  -14, 	  -1,  -12, 	  -1,  -14
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -16, 	   0,  -12, 	   3,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -16, 	  -1,  -12, 	  -4,   -8, 	   0,  -10
+.2byte  -12,  -15, 	  -3,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte  -12,  -15, 	  -1,  -12, 	  -1,   -9, 	   0,  -10
+.2byte  -12,  -14, 	  -1,  -14, 	   1,  -12, 	   1,  -14
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -13,  -10, 	  -9,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte  -13,   -9, 	  -8,   -9, 	  -3,   -8, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,  -12
+.2byte   -1,   -6, 	  -2,  -12, 	   4,  -12, 	   1,  -14
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   12,  -10, 	   8,  -10, 	   3,   -8, 	   2,  -10
+.2byte   12,   -9, 	   7,   -9, 	   2,   -8, 	   0,  -11
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte   12,  -15, 	   1,  -12, 	   1,   -9, 	   0,  -10
+.2byte   12,  -14, 	   1,  -14, 	  -1,  -12, 	  -1,  -14
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -16, 	   0,  -12, 	   3,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -16, 	  -1,  -12, 	  -4,   -8, 	   0,  -10
+.2byte  -12,  -15, 	  -3,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte  -12,  -15, 	  -1,  -12, 	  -1,   -9, 	   0,  -10
+.2byte  -12,  -14, 	  -1,  -14, 	   1,  -12, 	   1,  -14
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -13,  -10, 	  -9,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte  -13,   -9, 	  -8,   -9, 	  -3,   -8, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,  -12
+.2byte   -1,    2, 	  -2,   -4, 	   4,   -4, 	   1,   -6
+.2byte   -1,  -15, 	  -3,  -11, 	   1,  -11, 	  -1,   -8
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   12,  -10, 	   8,  -10, 	   3,   -8, 	   2,  -10
+.2byte   12,   -7, 	   7,   -7, 	   2,   -6, 	   0,   -9
+.2byte    7,  -24, 	   2,  -15, 	  -1,  -11, 	  -2,  -13
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte   12,  -15, 	   1,  -12, 	   1,   -9, 	   0,  -10
+.2byte   12,  -11, 	   1,  -11, 	  -1,   -9, 	  -1,  -11
+.2byte   11,  -25, 	   0,  -16, 	   1,  -14, 	  -1,  -14
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -16, 	   0,  -12, 	   3,   -8, 	  -1,  -10
+.2byte    6,  -28, 	  -1,  -17, 	   3,  -15, 	  -1,  -14
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -1,  -26, 	   2,  -12, 	  -4,  -12, 	   0,  -10
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -16, 	  -1,  -12, 	  -4,   -8, 	   0,  -10
+.2byte   -7,  -28, 	   0,  -17, 	  -4,  -15, 	   0,  -14
+.2byte  -13,  -15, 	  -4,  -12, 	  -3,  -10, 	  -2,  -11
+.2byte  -13,  -15, 	  -2,  -12, 	  -2,   -9, 	  -1,  -10
+.2byte  -13,  -11, 	  -2,  -11, 	   0,   -9, 	   0,  -11
+.2byte  -12,  -25, 	  -1,  -16, 	  -2,  -14, 	   0,  -14
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -13,  -10, 	  -9,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte  -13,   -7, 	  -8,   -7, 	  -3,   -6, 	  -1,   -9
+.2byte   -8,  -24, 	  -3,  -15, 	   0,  -11, 	   1,  -13
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,  -12
+.2byte   -1,   -6, 	  -2,  -12, 	   4,  -12, 	   1,  -14
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   12,  -10, 	   8,  -10, 	   3,   -8, 	   2,  -10
+.2byte   12,   -9, 	   7,   -9, 	   2,   -8, 	   0,  -11
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte   12,  -15, 	   1,  -12, 	   1,   -9, 	   0,  -10
+.2byte   12,  -14, 	   1,  -14, 	  -1,  -12, 	  -1,  -14
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -16, 	   0,  -12, 	   3,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -16, 	  -1,  -12, 	  -4,   -8, 	   0,  -10
+.2byte  -12,  -15, 	  -3,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte  -12,  -15, 	  -1,  -12, 	  -1,   -9, 	   0,  -10
+.2byte  -12,  -14, 	  -1,  -14, 	   1,  -12, 	   1,  -14
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -13,  -10, 	  -9,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte  -13,   -9, 	  -8,   -9, 	  -3,   -8, 	  -1,  -11
+.2byte  -12,  -12, 	  -3,  -12, 	  -1,   -9, 	   1,  -10
+.2byte  -12,  -10, 	  -3,  -11, 	  -1,   -9, 	   1,  -10
+.2byte   -2,  -26, 	  -4,   -9, 	   0,   -9, 	  -2,   -8
+.2byte   -1,  -29, 	   3,  -12, 	   0,  -11, 	   1,   -9
+.2byte   -1,  -29, 	  -2,  -15, 	  -1,  -13, 	   0,  -11
+.2byte    1,  -28, 	  -3,  -18, 	   3,  -17, 	  -1,  -12
+.2byte    0,  -29, 	   3,  -15, 	  -3,  -15, 	   0,  -13
+.2byte   -2,  -28, 	   2,  -18, 	  -4,  -17, 	   0,  -12
+.2byte    0,  -29, 	   1,  -15, 	   0,  -13, 	  -1,  -11
+.2byte    0,  -29, 	  -4,  -12, 	  -1,  -11, 	  -2,   -9
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,  -12
+.2byte   -1,   -6, 	  -2,  -12, 	   4,  -12, 	   1,  -14
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   12,  -10, 	   8,  -10, 	   3,   -8, 	   2,  -10
+.2byte   12,   -9, 	   7,   -9, 	   2,   -8, 	   0,  -11
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte   12,  -15, 	   1,  -12, 	   1,   -9, 	   0,  -10
+.2byte   12,  -14, 	   1,  -14, 	  -1,  -12, 	  -1,  -14
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    7,  -16, 	   0,  -12, 	   3,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -8,  -16, 	  -1,  -12, 	  -4,   -8, 	   0,  -10
+.2byte  -12,  -15, 	  -3,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte  -12,  -15, 	  -1,  -12, 	  -1,   -9, 	   0,  -10
+.2byte  -12,  -14, 	  -1,  -14, 	   1,  -12, 	   1,  -14
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -13,  -10, 	  -9,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte  -13,   -9, 	  -8,   -9, 	  -3,   -8, 	  -1,  -11
+.2byte   -1,    0, 	  -2,   -6, 	   4,   -6, 	   1,   -8
+.2byte  -14,   -6, 	  -9,   -6, 	  -4,   -5, 	  -2,   -8
+.2byte  -15,  -10, 	  -4,  -10, 	  -2,   -8, 	  -2,  -10
+.2byte   -8,  -16, 	  -1,  -12, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -19, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte    7,  -16, 	   0,  -12, 	   3,   -8, 	  -1,  -10
+.2byte   14,  -10, 	   3,  -10, 	   1,   -8, 	   1,  -10
+.2byte   13,   -6, 	   8,   -6, 	   3,   -5, 	   1,   -8
+.2byte   -1,  -15, 	  -3,  -11, 	   1,  -11, 	  -1,   -8
+.2byte    7,  -25, 	   2,  -16, 	  -1,  -12, 	  -2,  -14
+.2byte   11,  -25, 	   0,  -16, 	   1,  -14, 	  -1,  -14
+.2byte    6,  -27, 	  -1,  -16, 	   3,  -14, 	  -1,  -13
+.2byte   -1,  -28, 	   2,  -14, 	  -4,  -14, 	   0,  -12
+.2byte   -7,  -27, 	   0,  -16, 	  -4,  -14, 	   0,  -13
+.2byte  -12,  -25, 	  -1,  -16, 	  -2,  -14, 	   0,  -14
+.2byte   -8,  -25, 	  -3,  -16, 	   0,  -12, 	   1,  -14
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,  -11, 	   1,  -11, 	  -1,   -8
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   12,  -10, 	   8,  -10, 	   3,   -8, 	   2,  -10
+.2byte    8,  -24, 	   3,  -15, 	   0,  -11, 	  -1,  -13
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte   12,  -15, 	   1,  -12, 	   1,   -9, 	   0,  -10
+.2byte   11,  -25, 	   0,  -16, 	   1,  -14, 	  -1,  -14
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte    6,  -17, 	  -1,  -13, 	   3,  -10, 	  -1,  -11
+.2byte    5,  -28, 	  -2,  -17, 	   2,  -15, 	  -2,  -14
+.2byte   -1,  -20, 	   2,  -14, 	  -4,  -14, 	  -1,  -15
+.2byte   -1,  -20, 	   2,  -14, 	  -4,  -14, 	  -1,  -14
+.2byte   -1,  -29, 	   2,  -15, 	  -4,  -15, 	   0,  -13
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -7,  -17, 	   0,  -13, 	  -4,  -10, 	   0,  -11
+.2byte   -6,  -28, 	   1,  -17, 	  -3,  -15, 	   1,  -14
+.2byte  -13,  -15, 	  -4,  -12, 	  -3,  -10, 	  -2,  -11
+.2byte  -13,  -15, 	  -2,  -12, 	  -2,   -9, 	  -1,  -10
+.2byte  -12,  -25, 	  -1,  -16, 	  -2,  -14, 	   0,  -14
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -13,  -10, 	  -9,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte   -9,  -24, 	  -4,  -15, 	  -1,  -11, 	   0,  -13
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -12,  -15, 	  -3,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -9,  -10, 	  -5,  -11, 	  -1,  -10, 	   0,  -10
+.2byte  -12,  -15, 	  -3,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte   -8,  -17, 	  -1,  -13, 	  -5,  -10, 	  -1,  -11
+.2byte   -1,  -17, 	   2,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte    7,  -17, 	   0,  -13, 	   4,  -10, 	   0,  -11
+.2byte   12,  -15, 	   3,  -12, 	   2,  -10, 	   1,  -11
+.2byte    8,  -10, 	   4,  -11, 	   0,  -10, 	  -1,  -10
+sGorebyssAnimTable1:
+.4byte sGorebyssAnims_1_1
+.4byte sGorebyssAnims_1_2
+.4byte sGorebyssAnims_1_3
+.4byte sGorebyssAnims_1_4
+.4byte sGorebyssAnims_1_5
+.4byte sGorebyssAnims_1_6
+.4byte sGorebyssAnims_1_7
+.4byte sGorebyssAnims_1_8
+sGorebyssAnimTable2:
+.4byte sGorebyssAnims_2_1
+.4byte sGorebyssAnims_2_2
+.4byte sGorebyssAnims_2_3
+.4byte sGorebyssAnims_2_4
+.4byte sGorebyssAnims_2_5
+.4byte sGorebyssAnims_2_6
+.4byte sGorebyssAnims_2_7
+.4byte sGorebyssAnims_2_8
+sGorebyssAnimTable3:
+.4byte sGorebyssAnims_3_1
+.4byte sGorebyssAnims_3_2
+.4byte sGorebyssAnims_3_3
+.4byte sGorebyssAnims_3_4
+.4byte sGorebyssAnims_3_5
+.4byte sGorebyssAnims_3_6
+.4byte sGorebyssAnims_3_7
+.4byte sGorebyssAnims_3_8
+sGorebyssAnimTable4:
+.4byte sGorebyssAnims_4_1
+.4byte sGorebyssAnims_4_2
+.4byte sGorebyssAnims_4_3
+.4byte sGorebyssAnims_4_4
+.4byte sGorebyssAnims_4_5
+.4byte sGorebyssAnims_4_6
+.4byte sGorebyssAnims_4_7
+.4byte sGorebyssAnims_4_8
+sGorebyssAnimTable5:
+.4byte sGorebyssAnims_5_1
+.4byte sGorebyssAnims_5_2
+.4byte sGorebyssAnims_5_3
+.4byte sGorebyssAnims_5_4
+.4byte sGorebyssAnims_5_5
+.4byte sGorebyssAnims_5_6
+.4byte sGorebyssAnims_5_7
+.4byte sGorebyssAnims_5_8
+sGorebyssAnimTable6:
+.4byte sGorebyssAnims_6_1
+.4byte sGorebyssAnims_6_1
+.4byte sGorebyssAnims_6_1
+.4byte sGorebyssAnims_6_1
+.4byte sGorebyssAnims_6_1
+.4byte sGorebyssAnims_6_1
+.4byte sGorebyssAnims_6_1
+.4byte sGorebyssAnims_6_1
+sGorebyssAnimTable7:
+.4byte sGorebyssAnims_7_1
+.4byte sGorebyssAnims_7_2
+.4byte sGorebyssAnims_7_3
+.4byte sGorebyssAnims_7_4
+.4byte sGorebyssAnims_7_5
+.4byte sGorebyssAnims_7_6
+.4byte sGorebyssAnims_7_7
+.4byte sGorebyssAnims_7_8
+sGorebyssAnimTable8:
+.4byte sGorebyssAnims_8_1
+.4byte sGorebyssAnims_8_2
+.4byte sGorebyssAnims_8_3
+.4byte sGorebyssAnims_8_4
+.4byte sGorebyssAnims_8_5
+.4byte sGorebyssAnims_8_6
+.4byte sGorebyssAnims_8_7
+.4byte sGorebyssAnims_8_8
+sGorebyssAnimTable9:
+.4byte sGorebyssAnims_9_1
+.4byte sGorebyssAnims_9_2
+.4byte sGorebyssAnims_9_3
+.4byte sGorebyssAnims_9_4
+.4byte sGorebyssAnims_9_5
+.4byte sGorebyssAnims_9_6
+.4byte sGorebyssAnims_9_7
+.4byte sGorebyssAnims_9_8
+sGorebyssAnimTable10:
+.4byte sGorebyssAnims_10_1
+.4byte sGorebyssAnims_10_2
+.4byte sGorebyssAnims_10_3
+.4byte sGorebyssAnims_10_4
+.4byte sGorebyssAnims_10_5
+.4byte sGorebyssAnims_10_6
+.4byte sGorebyssAnims_10_7
+.4byte sGorebyssAnims_10_8
+sGorebyssAnimTable11:
+.4byte sGorebyssAnims_11_1
+.4byte sGorebyssAnims_11_2
+.4byte sGorebyssAnims_11_3
+.4byte sGorebyssAnims_11_4
+.4byte sGorebyssAnims_11_5
+.4byte sGorebyssAnims_11_6
+.4byte sGorebyssAnims_11_7
+.4byte sGorebyssAnims_11_8
+sGorebyssAnimTable12:
+.4byte sGorebyssAnims_12_1
+.4byte sGorebyssAnims_12_2
+.4byte sGorebyssAnims_12_3
+.4byte sGorebyssAnims_12_4
+.4byte sGorebyssAnims_12_5
+.4byte sGorebyssAnims_12_6
+.4byte sGorebyssAnims_12_7
+.4byte sGorebyssAnims_12_8
+sGorebyssAnimTable13:
+.4byte sGorebyssAnims_13_1
+.4byte sGorebyssAnims_13_2
+.4byte sGorebyssAnims_13_3
+.4byte sGorebyssAnims_13_4
+.4byte sGorebyssAnims_13_5
+.4byte sGorebyssAnims_13_6
+.4byte sGorebyssAnims_13_7
+.4byte sGorebyssAnims_13_8
+sAxAnimationsGorebyss:
+.4byte sGorebyssAnimTable1
+.4byte sGorebyssAnimTable2
+.4byte sGorebyssAnimTable3
+.4byte sGorebyssAnimTable4
+.4byte sGorebyssAnimTable5
+.4byte sGorebyssAnimTable6
+.4byte sGorebyssAnimTable7
+.4byte sGorebyssAnimTable8
+.4byte sGorebyssAnimTable9
+.4byte sGorebyssAnimTable10
+.4byte sGorebyssAnimTable11
+.4byte sGorebyssAnimTable12
+.4byte sGorebyssAnimTable13
+sAxSpritesGorebyss:
+.4byte sGorebyssSprites1
+.4byte sGorebyssSprites2
+.4byte sGorebyssSprites3
+.4byte sGorebyssSprites4
+.4byte sGorebyssSprites5
+.4byte sGorebyssSprites6
+.4byte sGorebyssSprites7
+.4byte sGorebyssSprites8
+.4byte sGorebyssSprites9
+.4byte sGorebyssSprites10
+.4byte sGorebyssSprites11
+.4byte sGorebyssSprites12
+.4byte sGorebyssSprites13
+.4byte sGorebyssSprites14
+.4byte sGorebyssSprites15
+.4byte sGorebyssSprites16
+.4byte sGorebyssSprites17
+.4byte sGorebyssSprites18
+.4byte sGorebyssSprites19
+.4byte sGorebyssSprites20
+.4byte sGorebyssSprites21
+.4byte sGorebyssSprites22
+.4byte sGorebyssSprites23
+.4byte sGorebyssSprites24
+.4byte sGorebyssSprites25
+.4byte sGorebyssSprites26
+.4byte sGorebyssSprites27
+.4byte sGorebyssSprites28
+.4byte sGorebyssSprites29
+.4byte sGorebyssSprites30
+.4byte sGorebyssSprites31
+.4byte sGorebyssSprites32
+.4byte sGorebyssSprites33
+.4byte sGorebyssSprites34
+.4byte sGorebyssSprites35
+.4byte sGorebyssSprites36
+.4byte sGorebyssSprites37
+.4byte sGorebyssSprites38
+.4byte sGorebyssSprites39
+.4byte sGorebyssSprites40
+.4byte sGorebyssSprites41
+.4byte sGorebyssSprites42
+.4byte sGorebyssSprites43
+.4byte sGorebyssSprites44
+.4byte sGorebyssSprites45
+.4byte sGorebyssSprites46
+.4byte sGorebyssSprites47
+.4byte sGorebyssSprites48
+.4byte sGorebyssSprites49
+sAxMainGorebyss:
+ax_main sAxPosesGorebyss, sAxAnimationsGorebyss, 13, sAxSpritesGorebyss, sAxPositionsGorebyss

--- a/data/ax/granbull.inc
+++ b/data/ax/granbull.inc
@@ -1,0 +1,3124 @@
+.global gAxGranbull
+gAxGranbull:
+ax_siro sAxMainGranbull
+sGranbullPose1:
+ax_pose 0, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose2:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose3:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose4:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose5:
+ax_pose 4, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose6:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose7:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose8:
+ax_pose 7, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose9:
+ax_pose 8, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose10:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose11:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose12:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose13:
+ax_pose 12, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose14:
+ax_pose 13, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose15:
+ax_pose 14, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose16:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose17:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose18:
+ax_pose 11, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose19:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose20:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose21:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose22:
+ax_pose 3, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose23:
+ax_pose 4, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose24:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose25:
+ax_pose 0, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose26:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose27:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose28:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose29:
+ax_pose 4, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose30:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose31:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose32:
+ax_pose 7, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose33:
+ax_pose 8, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose34:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose35:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose36:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose37:
+ax_pose 12, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose38:
+ax_pose 13, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose39:
+ax_pose 14, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose40:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose41:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose42:
+ax_pose 11, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose43:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose44:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose45:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose46:
+ax_pose 3, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose47:
+ax_pose 4, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose48:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose49:
+ax_pose 0, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose50:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose51:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose52:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose53:
+ax_pose 4, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose54:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose55:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose56:
+ax_pose 7, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose57:
+ax_pose 8, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose58:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose59:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose60:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose61:
+ax_pose 12, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose62:
+ax_pose 13, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose63:
+ax_pose 14, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose64:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose65:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose66:
+ax_pose 11, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose67:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose68:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose69:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose70:
+ax_pose 3, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose71:
+ax_pose 4, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose72:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose73:
+ax_pose 0, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose74:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose75:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose76:
+ax_pose 15, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose77:
+ax_pose 16, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose78:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose79:
+ax_pose 4, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose80:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose81:
+ax_pose 17, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose82:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose83:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose84:
+ax_pose 7, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose85:
+ax_pose 8, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose86:
+ax_pose 19, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose87:
+ax_pose 20, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose88:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose89:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose90:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose91:
+ax_pose 21, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose92:
+ax_pose 22, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose93:
+ax_pose 12, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose94:
+ax_pose 13, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose95:
+ax_pose 14, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose96:
+ax_pose 23, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose97:
+ax_pose 24, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose98:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose99:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose100:
+ax_pose 11, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose101:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose102:
+ax_pose 22, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose103:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose104:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose105:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose106:
+ax_pose 19, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sGranbullPose107:
+ax_pose 20, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sGranbullPose108:
+ax_pose 3, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose109:
+ax_pose 4, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose110:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose111:
+ax_pose 17, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose112:
+ax_pose 18, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose113:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose114:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose115:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose116:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose117:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose118:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose119:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose120:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose121:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose122:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose123:
+ax_pose 15, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose124:
+ax_pose 16, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose125:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose126:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose127:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose128:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose129:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose130:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose131:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose132:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose133:
+ax_pose 4, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose134:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose135:
+ax_pose 17, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose136:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose137:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose138:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose139:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose140:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose141:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose142:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose143:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose144:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose145:
+ax_pose 7, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose146:
+ax_pose 8, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose147:
+ax_pose 19, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose148:
+ax_pose 20, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose149:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose150:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose151:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose152:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose153:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose154:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose155:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose156:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose157:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose158:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose159:
+ax_pose 21, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose160:
+ax_pose 22, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose161:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose162:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose163:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose164:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose165:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose166:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose167:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose168:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose169:
+ax_pose 13, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose170:
+ax_pose 14, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose171:
+ax_pose 23, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose172:
+ax_pose 24, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose173:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose174:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose175:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose176:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose177:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose178:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose179:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose180:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose181:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose182:
+ax_pose 11, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose183:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose184:
+ax_pose 22, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose185:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose186:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose187:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose188:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose189:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose190:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose191:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose192:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose193:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose194:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose195:
+ax_pose 19, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sGranbullPose196:
+ax_pose 20, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sGranbullPose197:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose198:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose199:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose200:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose201:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose202:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose203:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose204:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose205:
+ax_pose 4, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose206:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose207:
+ax_pose 17, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose208:
+ax_pose 18, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose209:
+ax_pose 25, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sGranbullPose210:
+ax_pose 26, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sGranbullPose211:
+ax_pose 27, 0x01e1, 0x80f1, 0x2c00
+ax_pose_terminator
+sGranbullPose212:
+ax_pose 28, 0x01e2, 0x90ea, 0x2c00
+ax_pose_terminator
+sGranbullPose213:
+ax_pose 29, 0x01e2, 0x90ea, 0x2c00
+ax_pose_terminator
+sGranbullPose214:
+ax_pose 30, 0x01e2, 0x90ea, 0x2c00
+ax_pose_terminator
+sGranbullPose215:
+ax_pose 31, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sGranbullPose216:
+ax_pose 30, 0x01e2, 0x80f6, 0x2c00
+ax_pose_terminator
+sGranbullPose217:
+ax_pose 29, 0x01e2, 0x80f6, 0x2c00
+ax_pose_terminator
+sGranbullPose218:
+ax_pose 28, 0x01e2, 0x80f6, 0x2c00
+ax_pose_terminator
+sGranbullPose219:
+ax_pose 0, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose220:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose221:
+ax_pose 2, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose222:
+ax_pose 15, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose223:
+ax_pose 16, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose224:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose225:
+ax_pose 4, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose226:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose227:
+ax_pose 17, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose228:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose229:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose230:
+ax_pose 7, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose231:
+ax_pose 8, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose232:
+ax_pose 19, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose233:
+ax_pose 20, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose234:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose235:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose236:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose237:
+ax_pose 21, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose238:
+ax_pose 22, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose239:
+ax_pose 12, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose240:
+ax_pose 13, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose241:
+ax_pose 14, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose242:
+ax_pose 23, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose243:
+ax_pose 24, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose244:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose245:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose246:
+ax_pose 11, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose247:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose248:
+ax_pose 22, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose249:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose250:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose251:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose252:
+ax_pose 19, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sGranbullPose253:
+ax_pose 20, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sGranbullPose254:
+ax_pose 3, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose255:
+ax_pose 4, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose256:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose257:
+ax_pose 17, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose258:
+ax_pose 18, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose259:
+ax_pose 16, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose260:
+ax_pose 18, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose261:
+ax_pose 20, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sGranbullPose262:
+ax_pose 22, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose263:
+ax_pose 24, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose264:
+ax_pose 22, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose265:
+ax_pose 20, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose266:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose267:
+ax_pose 1, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose268:
+ax_pose 4, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose269:
+ax_pose 8, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose270:
+ax_pose 11, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sGranbullPose271:
+ax_pose 13, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sGranbullPose272:
+ax_pose 11, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sGranbullPose273:
+ax_pose 8, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sGranbullPose274:
+ax_pose 4, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sGranbullPose275:
+ax_pose 0, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose276:
+ax_pose 15, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose277:
+ax_pose 16, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose278:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose279:
+ax_pose 17, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sGranbullPose280:
+ax_pose 18, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sGranbullPose281:
+ax_pose 6, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose282:
+ax_pose 19, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sGranbullPose283:
+ax_pose 20, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sGranbullPose284:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose285:
+ax_pose 21, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose286:
+ax_pose 22, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose287:
+ax_pose 12, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose288:
+ax_pose 23, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose289:
+ax_pose 24, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose290:
+ax_pose 9, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose291:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose292:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sGranbullPose293:
+ax_pose 6, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose294:
+ax_pose 19, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sGranbullPose295:
+ax_pose 20, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sGranbullPose296:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sGranbullPose297:
+ax_pose 17, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose298:
+ax_pose 18, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose299:
+ax_pose 16, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose300:
+ax_pose 18, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose301:
+ax_pose 20, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose302:
+ax_pose 22, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sGranbullPose303:
+ax_pose 24, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sGranbullPose304:
+ax_pose 22, 0x01e8, 0x90f0, 0x2c00
+ax_pose_terminator
+sGranbullPose305:
+ax_pose 20, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose306:
+ax_pose 18, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sGranbullPose307:
+ax_pose 0, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose308:
+ax_pose 3, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose309:
+ax_pose 6, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose310:
+ax_pose 9, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose311:
+ax_pose 12, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGranbullPose312:
+ax_pose 9, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose313:
+ax_pose 6, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGranbullPose314:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sGranbullAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGranbullAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 1, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sGranbullAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sGranbullAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 18, -20, 18, -20,
+ax_anim 2, 1, 34, 19, -19, 19, -19,
+ax_anim 2, 0, 34, 18, -20, 18, -20,
+ax_anim 2, 0, 34, 19, -19, 19, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sGranbullAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 1, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 0, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sGranbullAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -20, -18, -20,
+ax_anim 2, 1, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -18, -20, -18, -20,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sGranbullAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sGranbullAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 1, 46, -21, 18, -21, 18,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGranbullAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sGranbullAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 1, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 0, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sGranbullAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sGranbullAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 11, -12, 11, -12,
+ax_anim 2, 0, 58, 18, -20, 18, -20,
+ax_anim 2, 1, 58, 19, -19, 19, -19,
+ax_anim 2, 0, 58, 18, -20, 18, -20,
+ax_anim 2, 0, 58, 19, -19, 19, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sGranbullAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 1, 61, 1, -20, 1, -20,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 0, 61, 1, -20, 1, -20,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sGranbullAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -11, -12, -11, -12,
+ax_anim 2, 0, 64, -18, -20, -18, -20,
+ax_anim 2, 1, 64, -19, -19, -19, -19,
+ax_anim 2, 0, 64, -18, -20, -18, -20,
+ax_anim 2, 0, 64, -19, -19, -19, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sGranbullAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sGranbullAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 1, 70, -21, 18, -21, 18,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGranbullAnims_4_1:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 6, 2, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 2, 1, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 4, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 4, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 4, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim_terminator
+sGranbullAnims_4_2:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 6, 2, 80, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 1, 80, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 4, 0, 80, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 4, 0, 80, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 4, 0, 80, 3, 3, 3, 3,
+ax_anim 2, 0, 78, 2, 2, 2, 2,
+ax_anim_terminator
+sGranbullAnims_4_3:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 6, 2, 85, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 2, 1, 85, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 4, 0, 85, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 4, 0, 85, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 4, 0, 85, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim_terminator
+sGranbullAnims_4_4:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim 6, 2, 90, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 1, 90, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 4, 0, 90, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 4, 0, 90, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 4, 0, 90, 3, -3, 3, -3,
+ax_anim 2, 0, 88, 2, -2, 2, -2,
+ax_anim_terminator
+sGranbullAnims_4_5:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, -2,
+ax_anim 6, 2, 95, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 2, 1, 95, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 4, 0, 95, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 4, 0, 95, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 4, 0, 95, 0, -3, 0, -3,
+ax_anim 2, 0, 93, 0, -2, 0, -2,
+ax_anim_terminator
+sGranbullAnims_4_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 6, 2, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 1, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 4, 0, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 4, 0, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 4, 0, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 98, -2, -2, -2, -2,
+ax_anim_terminator
+sGranbullAnims_4_7:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, -2, 0, -2, 0,
+ax_anim 6, 2, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 2, 1, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 4, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 4, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 4, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim_terminator
+sGranbullAnims_4_8:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 6, 2, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 1, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 4, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 4, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 4, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 108, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGranbullAnims_5_1:
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 1, 0, 114, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 2, 116, 0, -6, 0, 0,
+ax_anim 1, 0, 117, 0, -6, 0, 0,
+ax_anim 1, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -3, 0, 0,
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 1, 0, 114, 0, -1, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_5_2:
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 124, 0, -3, 0, 0,
+ax_anim 1, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -5, 0, 0,
+ax_anim 1, 2, 127, 0, -6, 0, 0,
+ax_anim 1, 0, 128, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 1, 0, 125, 0, -1, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_5_3:
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 1, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 2, 138, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 140, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -4, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 1, 0, 143, 0, -2, 0, 0,
+ax_anim 1, 0, 136, 0, -1, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_5_4:
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -3, 0, 0,
+ax_anim 1, 0, 155, 0, -4, 0, 0,
+ax_anim 1, 0, 148, 0, -5, 0, 0,
+ax_anim 1, 2, 149, 0, -6, 0, 0,
+ax_anim 1, 0, 150, 0, -6, 0, 0,
+ax_anim 1, 0, 151, 0, -5, 0, 0,
+ax_anim 1, 0, 152, 0, -4, 0, 0,
+ax_anim 1, 0, 153, 0, -3, 0, 0,
+ax_anim 1, 0, 154, 0, -2, 0, 0,
+ax_anim 1, 0, 155, 0, -1, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_5_5:
+ax_anim 3, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -2, 0, 0,
+ax_anim 2, 0, 165, 0, -3, 0, 0,
+ax_anim 1, 0, 166, 0, -4, 0, 0,
+ax_anim 1, 0, 167, 0, -5, 0, 0,
+ax_anim 1, 2, 160, 0, -6, 0, 0,
+ax_anim 1, 0, 161, 0, -6, 0, 0,
+ax_anim 1, 0, 162, 0, -5, 0, 0,
+ax_anim 1, 0, 163, 0, -4, 0, 0,
+ax_anim 1, 0, 164, 0, -3, 0, 0,
+ax_anim 1, 0, 165, 0, -2, 0, 0,
+ax_anim 1, 0, 166, 0, -1, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 3, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_5_6:
+ax_anim 3, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -2, 0, 0,
+ax_anim 2, 0, 176, 0, -3, 0, 0,
+ax_anim 1, 0, 177, 0, -4, 0, 0,
+ax_anim 1, 0, 178, 0, -5, 0, 0,
+ax_anim 1, 2, 179, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -5, 0, 0,
+ax_anim 1, 0, 174, 0, -4, 0, 0,
+ax_anim 1, 0, 175, 0, -3, 0, 0,
+ax_anim 1, 0, 176, 0, -2, 0, 0,
+ax_anim 1, 0, 177, 0, -1, 0, 0,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 3, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_5_7:
+ax_anim 3, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -2, 0, 0,
+ax_anim 2, 0, 187, 0, -3, 0, 0,
+ax_anim 1, 0, 188, 0, -4, 0, 0,
+ax_anim 1, 0, 189, 0, -5, 0, 0,
+ax_anim 1, 2, 190, 0, -6, 0, 0,
+ax_anim 1, 0, 191, 0, -6, 0, 0,
+ax_anim 1, 0, 184, 0, -5, 0, 0,
+ax_anim 1, 0, 185, 0, -4, 0, 0,
+ax_anim 1, 0, 186, 0, -3, 0, 0,
+ax_anim 1, 0, 187, 0, -2, 0, 0,
+ax_anim 1, 0, 188, 0, -1, 0, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 3, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_5_8:
+ax_anim 3, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -2, 0, 0,
+ax_anim 2, 0, 198, 0, -3, 0, 0,
+ax_anim 1, 0, 199, 0, -4, 0, 0,
+ax_anim 1, 0, 200, 0, -5, 0, 0,
+ax_anim 1, 2, 201, 0, -6, 0, 0,
+ax_anim 1, 0, 202, 0, -6, 0, 0,
+ax_anim 1, 0, 203, 0, -5, 0, 0,
+ax_anim 1, 0, 196, 0, -4, 0, 0,
+ax_anim 1, 0, 197, 0, -3, 0, 0,
+ax_anim 1, 0, 198, 0, -2, 0, 0,
+ax_anim 1, 0, 199, 0, -1, 0, 0,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 3, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_6_1:
+ax_anim 30, 0, 208, 0, 0, 0, 0,
+ax_anim 35, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_7_1:
+ax_anim 2, 0, 210, 0, -2, 0, -2,
+ax_anim 8, 0, 210, 0, -3, 0, -3,
+ax_anim_terminator
+sGranbullAnims_7_2:
+ax_anim 2, 0, 211, -2, -2, -2, -2,
+ax_anim 8, 0, 211, -3, -3, -3, -3,
+ax_anim_terminator
+sGranbullAnims_7_3:
+ax_anim 2, 0, 212, -2, 0, -2, 0,
+ax_anim 8, 0, 212, -3, 0, -3, 0,
+ax_anim_terminator
+sGranbullAnims_7_4:
+ax_anim 2, 0, 213, -2, 2, -2, 2,
+ax_anim 8, 0, 213, -3, 3, -3, 3,
+ax_anim_terminator
+sGranbullAnims_7_5:
+ax_anim 2, 0, 214, 0, 2, 0, 2,
+ax_anim 8, 0, 214, 0, 3, 0, 3,
+ax_anim_terminator
+sGranbullAnims_7_6:
+ax_anim 2, 0, 215, 2, 2, 2, 2,
+ax_anim 8, 0, 215, 3, 3, 3, 3,
+ax_anim_terminator
+sGranbullAnims_7_7:
+ax_anim 2, 0, 216, 2, 0, 2, 0,
+ax_anim 8, 0, 216, 3, 0, 3, 0,
+ax_anim_terminator
+sGranbullAnims_7_8:
+ax_anim 2, 0, 217, 2, -2, 2, -2,
+ax_anim 8, 0, 217, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGranbullAnims_8_1:
+ax_anim 40, 0, 218, 0, 0, 0, 0,
+ax_anim 30, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_8_2:
+ax_anim 40, 0, 223, 0, 0, 0, 0,
+ax_anim 30, 0, 226, 0, -1, 0, 0,
+ax_anim_terminator
+sGranbullAnims_8_3:
+ax_anim 40, 0, 228, 0, 0, 0, 0,
+ax_anim 30, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_8_4:
+ax_anim 40, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 236, 1, -1, 0, 0,
+ax_anim_terminator
+sGranbullAnims_8_5:
+ax_anim 40, 0, 238, 0, 0, 0, 0,
+ax_anim 30, 0, 241, 0, -1, 0, 0,
+ax_anim_terminator
+sGranbullAnims_8_6:
+ax_anim 40, 0, 243, 0, 0, 0, 0,
+ax_anim 30, 0, 246, -1, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_8_7:
+ax_anim 40, 0, 248, 0, 0, 0, 0,
+ax_anim 30, 0, 251, -1, -1, 0, 0,
+ax_anim_terminator
+sGranbullAnims_8_8:
+ax_anim 40, 0, 253, 0, 0, 0, 0,
+ax_anim 30, 0, 256, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_9_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 1, 0, 259, 6, 4, 6, 4,
+ax_anim 2, 0, 260, 8, 9, 8, 9,
+ax_anim 2, 0, 261, 7, 17, 7, 17,
+ax_anim 3, 0, 262, 0, 20, 0, 20,
+ax_anim 2, 3, 263, -7, 17, -7, 17,
+ax_anim 2, 0, 264, -8, 9, -8, 9,
+ax_anim 1, 0, 265, -6, 4, -6, 4,
+ax_anim 1, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_9_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 6, 0, 6, 0,
+ax_anim 2, 0, 259, 17, 3, 17, 3,
+ax_anim 2, 0, 260, 24, 9, 24, 9,
+ax_anim 3, 0, 261, 22, 20, 22, 20,
+ax_anim 2, 3, 262, 11, 21, 11, 21,
+ax_anim 2, 0, 263, 2, 14, 2, 14,
+ax_anim 1, 0, 264, -1, 7, -1, 7,
+ax_anim 1, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_9_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 1, 0, 265, 3, -4, 3, -4,
+ax_anim 2, 0, 258, 11, -6, 11, -6,
+ax_anim 2, 0, 259, 17, -4, 17, -4,
+ax_anim 3, 0, 260, 23, 1, 23, 1,
+ax_anim 2, 3, 261, 18, 6, 18, 6,
+ax_anim 2, 0, 262, 12, 7, 12, 7,
+ax_anim 1, 0, 263, 4, 5, 4, 5,
+ax_anim 1, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_9_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 264, -1, -6, -1, -6,
+ax_anim 2, 0, 265, 2, -16, 2, -16,
+ax_anim 2, 0, 258, 11, -24, 11, -24,
+ax_anim 3, 0, 259, 20, -25, 20, -25,
+ax_anim 2, 3, 260, 21, -12, 21, -12,
+ax_anim 2, 0, 261, 17, -4, 17, -4,
+ax_anim 1, 0, 262, 7, -1, 7, -1,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_9_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 263, -6, -4, -6, -4,
+ax_anim 2, 0, 264, -8, -10, -8, -10,
+ax_anim 2, 0, 265, -7, -20, -7, -20,
+ax_anim 3, 0, 258, 0, -24, 0, -24,
+ax_anim 2, 3, 259, 7, -20, 7, -20,
+ax_anim 2, 0, 260, 8, -8, 8, -8,
+ax_anim 1, 0, 261, 6, -4, 6, -4,
+ax_anim 1, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_9_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 1, -6, 1, -6,
+ax_anim 2, 0, 259, -2, -16, -2, -16,
+ax_anim 2, 0, 258, -11, -24, -11, -24,
+ax_anim 3, 0, 265, -20, -25, -20, -25,
+ax_anim 2, 3, 264, -21, -12, -21, -12,
+ax_anim 2, 0, 263, -17, -4, -17, -4,
+ax_anim 1, 0, 262, -7, -1, -7, -1,
+ax_anim 1, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_9_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 259, -3, -4, -3, -4,
+ax_anim 2, 0, 258, -11, -6, -11, -6,
+ax_anim 2, 0, 265, -17, -4, -17, -4,
+ax_anim 3, 0, 264, -23, 1, -23, 1,
+ax_anim 2, 3, 263, -18, 6, -18, 6,
+ax_anim 2, 0, 262, -12, 7, -12, 7,
+ax_anim 1, 0, 261, -4, 5, -4, 5,
+ax_anim 1, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_9_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 258, -6, 0, -6, 0,
+ax_anim 2, 0, 265, -17, 3, -17, 3,
+ax_anim 2, 0, 264, -24, 9, -24, 9,
+ax_anim 3, 0, 263, -22, 20, -22, 20,
+ax_anim 2, 3, 262, -11, 21, -11, 21,
+ax_anim 2, 0, 261, -2, 14, -2, 14,
+ax_anim 1, 0, 260, 1, 7, 1, 7,
+ax_anim 1, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_10_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 6, 0, 6, 0,
+ax_anim 2, 0, 266, -6, 0, -6, 0,
+ax_anim 2, 0, 266, 10, 0, 10, 0,
+ax_anim 2, 0, 266, -10, 0, -10, 0,
+ax_anim 2, 0, 266, 12, 0, 12, 0,
+ax_anim 3, 0, 266, -12, 0, -12, 0,
+ax_anim 3, 0, 266, 13, 0, 13, 0,
+ax_anim 3, 0, 266, -13, 0, -13, 0,
+ax_anim 2, 0, 266, 12, 0, 12, 0,
+ax_anim 3, 0, 266, -12, 0, -12, 0,
+ax_anim 2, 0, 266, 10, 0, 10, 0,
+ax_anim 2, 0, 266, -10, 0, -10, 0,
+ax_anim 2, 0, 266, 6, 0, 6, 0,
+ax_anim 2, 0, 266, -6, 0, -6, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_10_2:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 6, -6, 6, -6,
+ax_anim 2, 0, 267, -6, 6, -6, 6,
+ax_anim 2, 0, 267, 10, -10, 10, -10,
+ax_anim 2, 0, 267, -10, 10, -10, 10,
+ax_anim 2, 0, 267, 12, -12, 12, -12,
+ax_anim 3, 0, 267, -12, 12, -12, 12,
+ax_anim 3, 0, 267, 13, -13, 13, -13,
+ax_anim 3, 0, 267, -13, 13, -13, 13,
+ax_anim 2, 0, 267, 12, -12, 12, -12,
+ax_anim 3, 0, 267, -12, 12, -12, 12,
+ax_anim 2, 0, 267, 10, -10, 10, -10,
+ax_anim 2, 0, 267, -10, 10, -10, 10,
+ax_anim 2, 0, 267, 6, -6, 6, -6,
+ax_anim 2, 0, 267, -6, 6, -6, 6,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_10_3:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -6, 0, -6,
+ax_anim 2, 0, 268, 0, 6, 0, 6,
+ax_anim 2, 0, 268, 0, -10, 0, -10,
+ax_anim 2, 0, 268, 0, 10, 0, 10,
+ax_anim 2, 0, 268, 0, -12, 0, -12,
+ax_anim 3, 0, 268, 0, 12, 0, 12,
+ax_anim 3, 0, 268, 0, -13, 0, -13,
+ax_anim 3, 0, 268, 0, 13, 0, 13,
+ax_anim 2, 0, 268, 0, -12, 0, -12,
+ax_anim 3, 0, 268, 0, 12, 0, 12,
+ax_anim 2, 0, 268, 0, -10, 0, -10,
+ax_anim 2, 0, 268, 0, 10, 0, 10,
+ax_anim 2, 0, 268, 0, -6, 0, -6,
+ax_anim 2, 0, 268, 0, 6, 0, 6,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_10_4:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, -6, -6, -6, -6,
+ax_anim 2, 0, 269, 6, 6, 6, 6,
+ax_anim 2, 0, 269, -10, -10, -10, -10,
+ax_anim 2, 0, 269, 10, 10, 10, 10,
+ax_anim 2, 0, 269, -12, -12, -12, -12,
+ax_anim 3, 0, 269, 12, 12, 12, 12,
+ax_anim 3, 0, 269, -13, -13, -13, -13,
+ax_anim 3, 0, 269, 13, 13, 13, 13,
+ax_anim 2, 0, 269, -12, -12, -12, -12,
+ax_anim 3, 0, 269, 12, 12, 12, 12,
+ax_anim 2, 0, 269, -10, -10, -10, -10,
+ax_anim 2, 0, 269, 10, 10, 10, 10,
+ax_anim 2, 0, 269, -6, -6, -6, -6,
+ax_anim 2, 0, 269, 6, 6, 6, 6,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_10_5:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 6, 0, 6, 0,
+ax_anim 2, 0, 270, -6, 0, -6, 0,
+ax_anim 2, 0, 270, 10, 0, 10, 0,
+ax_anim 2, 0, 270, -10, 0, -10, 0,
+ax_anim 2, 0, 270, 12, 0, 12, 0,
+ax_anim 3, 0, 270, -12, 0, -12, 0,
+ax_anim 3, 0, 270, 13, 0, 13, 0,
+ax_anim 3, 0, 270, -13, 0, -13, 0,
+ax_anim 2, 0, 270, 12, 0, 12, 0,
+ax_anim 3, 0, 270, -12, 0, -12, 0,
+ax_anim 2, 0, 270, 10, 0, 10, 0,
+ax_anim 2, 0, 270, -10, 0, -10, 0,
+ax_anim 2, 0, 270, 6, 0, 6, 0,
+ax_anim 2, 0, 270, -6, 0, -6, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_10_6:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 6, -6, 6, -6,
+ax_anim 2, 0, 271, -6, 6, -6, 6,
+ax_anim 2, 0, 271, 10, -10, 10, -10,
+ax_anim 2, 0, 271, -10, 10, -10, 10,
+ax_anim 2, 0, 271, 12, -12, 12, -12,
+ax_anim 3, 0, 271, -12, 12, -12, 12,
+ax_anim 3, 0, 271, 13, -13, 13, -13,
+ax_anim 3, 0, 271, -13, 13, -13, 13,
+ax_anim 2, 0, 271, 12, -12, 12, -12,
+ax_anim 3, 0, 271, -12, 12, -12, 12,
+ax_anim 2, 0, 271, 10, -10, 10, -10,
+ax_anim 2, 0, 271, -10, 10, -10, 10,
+ax_anim 2, 0, 271, 6, -6, 6, -6,
+ax_anim 2, 0, 271, -6, 6, -6, 6,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_10_7:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -6, 0, -6,
+ax_anim 2, 0, 272, 0, 6, 0, 6,
+ax_anim 2, 0, 272, 0, -10, 0, -10,
+ax_anim 2, 0, 272, 0, 10, 0, 10,
+ax_anim 2, 0, 272, 0, -12, 0, -12,
+ax_anim 3, 0, 272, 0, 12, 0, 12,
+ax_anim 3, 0, 272, 0, -13, 0, -13,
+ax_anim 3, 0, 272, 0, 13, 0, 13,
+ax_anim 2, 0, 272, 0, -12, 0, -12,
+ax_anim 3, 0, 272, 0, 12, 0, 12,
+ax_anim 2, 0, 272, 0, -10, 0, -10,
+ax_anim 2, 0, 272, 0, 10, 0, 10,
+ax_anim 2, 0, 272, 0, -6, 0, -6,
+ax_anim 2, 0, 272, 0, 6, 0, 6,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_10_8:
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, -6, -6, -6, -6,
+ax_anim 2, 0, 273, 6, 6, 6, 6,
+ax_anim 2, 0, 273, -10, -10, -10, -10,
+ax_anim 2, 0, 273, 10, 10, 10, 10,
+ax_anim 2, 0, 273, -12, -12, -12, -12,
+ax_anim 3, 0, 273, 12, 12, 12, 12,
+ax_anim 3, 0, 273, -13, -13, -13, -13,
+ax_anim 3, 0, 273, 13, 13, 13, 13,
+ax_anim 2, 0, 273, -12, -12, -12, -12,
+ax_anim 3, 0, 273, 12, 12, 12, 12,
+ax_anim 2, 0, 273, -10, -10, -10, -10,
+ax_anim 2, 0, 273, 10, 10, 10, 10,
+ax_anim 2, 0, 273, -6, -6, -6, -6,
+ax_anim 2, 0, 273, 6, 6, 6, 6,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_11_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -10, 0, 0,
+ax_anim 2, 0, 274, 0, -16, 0, 0,
+ax_anim 3, 0, 275, 0, -20, 0, 0,
+ax_anim 4, 0, 275, 0, -21, 0, 0,
+ax_anim 4, 0, 276, 0, -23, 0, 0,
+ax_anim 3, 0, 276, 0, -22, 0, 0,
+ax_anim 2, 0, 276, 0, -18, 0, 0,
+ax_anim 1, 0, 276, 0, -12, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_11_2:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 1, 0, 277, 0, -10, 0, 0,
+ax_anim 2, 0, 277, 0, -16, 0, 0,
+ax_anim 3, 0, 278, 0, -20, 0, 0,
+ax_anim 4, 0, 278, 0, -21, 0, 0,
+ax_anim 4, 0, 279, 0, -23, 0, 0,
+ax_anim 3, 0, 279, 0, -22, 0, 0,
+ax_anim 2, 0, 279, 0, -18, 0, 0,
+ax_anim 1, 0, 279, 0, -12, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_11_3:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 1, 0, 280, 0, -10, 0, 0,
+ax_anim 2, 0, 282, 0, -16, 0, 0,
+ax_anim 3, 0, 281, 0, -20, 0, 0,
+ax_anim 4, 0, 281, 0, -21, 0, 0,
+ax_anim 4, 0, 282, 0, -23, 0, 0,
+ax_anim 3, 0, 282, 0, -22, 0, 0,
+ax_anim 2, 0, 282, 0, -18, 0, 0,
+ax_anim 1, 0, 282, 0, -12, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_11_4:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 1, 0, 283, 0, -10, 0, 0,
+ax_anim 2, 0, 283, 0, -16, 0, 0,
+ax_anim 3, 0, 284, 0, -20, 0, 0,
+ax_anim 4, 0, 284, 0, -21, 0, 0,
+ax_anim 4, 0, 285, 0, -22, 0, 0,
+ax_anim 3, 0, 285, 0, -21, 0, 0,
+ax_anim 2, 0, 285, 0, -17, 0, 0,
+ax_anim 1, 0, 285, 0, -11, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_11_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 1, 0, 286, 0, -10, 0, 0,
+ax_anim 2, 0, 286, 0, -16, 0, 0,
+ax_anim 3, 0, 287, 0, -20, 0, 0,
+ax_anim 4, 0, 287, 0, -21, 0, 0,
+ax_anim 4, 0, 288, 0, -23, 0, 0,
+ax_anim 3, 0, 288, 0, -22, 0, 0,
+ax_anim 2, 0, 288, 0, -18, 0, 0,
+ax_anim 1, 0, 288, 0, -12, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_11_6:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 1, 0, 289, 0, -10, 0, 0,
+ax_anim 2, 0, 289, 0, -16, 0, 0,
+ax_anim 3, 0, 290, 0, -20, 0, 0,
+ax_anim 4, 0, 290, 0, -21, 0, 0,
+ax_anim 4, 0, 291, 0, -22, 0, 0,
+ax_anim 3, 0, 291, 0, -21, 0, 0,
+ax_anim 2, 0, 291, 0, -17, 0, 0,
+ax_anim 1, 0, 291, 0, -11, 0, 0,
+ax_anim 2, 2, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_11_7:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 1, 0, 292, 0, -10, 0, 0,
+ax_anim 2, 0, 292, 0, -16, 0, 0,
+ax_anim 3, 0, 293, 0, -20, 0, 0,
+ax_anim 4, 0, 293, 0, -21, 0, 0,
+ax_anim 4, 0, 294, 0, -23, 0, 0,
+ax_anim 3, 0, 294, 0, -22, 0, 0,
+ax_anim 2, 0, 294, 0, -18, 0, 0,
+ax_anim 1, 0, 294, 0, -12, 0, 0,
+ax_anim 2, 2, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_11_8:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 1, 0, 295, 0, -10, 0, 0,
+ax_anim 2, 0, 295, 0, -16, 0, 0,
+ax_anim 3, 0, 296, 0, -20, 0, 0,
+ax_anim 4, 0, 296, 0, -21, 0, 0,
+ax_anim 4, 0, 297, 0, -23, 0, 0,
+ax_anim 3, 0, 297, 0, -22, 0, 0,
+ax_anim 2, 0, 297, 0, -18, 0, 0,
+ax_anim 1, 0, 297, 0, -12, 0, 0,
+ax_anim 2, 2, 297, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_12_1:
+ax_anim 2, 0, 298, 1, 0, 1, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 0, 1, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 0, 1, 0,
+ax_anim 2, 2, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 0, 1, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 0, 1, 0,
+ax_anim 2, 1, 298, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_12_2:
+ax_anim 2, 0, 305, 1, -1, 1, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 1, -1, 1, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 1, -1, 1, 0,
+ax_anim 2, 2, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 1, -1, 1, 0,
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 2, 0, 305, 1, -1, 1, 0,
+ax_anim 2, 1, 305, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_12_3:
+ax_anim 2, 0, 304, 0, -1, 0, -1,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, -1, 0, -1,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, -1, 0, -1,
+ax_anim 2, 2, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, -1, 0, -1,
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 2, 0, 304, 0, -1, 0, -1,
+ax_anim 2, 1, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_12_4:
+ax_anim 2, 0, 303, -1, -1, -1, -1,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 303, -1, -1, -1, -1,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 303, -1, -1, -1, -1,
+ax_anim 2, 2, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 303, -1, -1, -1, -1,
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 2, 0, 303, -1, -1, -1, -1,
+ax_anim 2, 1, 303, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_12_5:
+ax_anim 2, 0, 302, 1, 0, 1, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 1, 0, 1, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 1, 0, 1, 0,
+ax_anim 2, 2, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 1, 0, 1, 0,
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 2, 0, 302, 1, 0, 1, 0,
+ax_anim 2, 1, 302, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_12_6:
+ax_anim 2, 0, 301, 1, -1, 1, -1,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 1, -1, 1, -1,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 1, -1, 1, -1,
+ax_anim 2, 2, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 1, -1, 1, -1,
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 2, 0, 301, 1, -1, 1, -1,
+ax_anim 2, 1, 301, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_12_7:
+ax_anim 2, 0, 300, 0, -1, 0, -1,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, -1, 0, -1,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, -1, 0, -1,
+ax_anim 2, 2, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, -1, 0, -1,
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 2, 0, 300, 0, -1, 0, -1,
+ax_anim 2, 1, 300, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_12_8:
+ax_anim 2, 0, 299, -1, -1, -1, -1,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 299, -1, -1, -1, -1,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 299, -1, -1, -1, -1,
+ax_anim 2, 2, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 299, -1, -1, -1, -1,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 299, -1, -1, -1, -1,
+ax_anim 2, 1, 299, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGranbullAnims_13_1:
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 2, 306, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_13_2:
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 2, 313, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_13_3:
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 2, 312, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_13_4:
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 2, 311, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_13_5:
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 2, 310, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_13_6:
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 2, 309, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_13_7:
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 2, 308, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullAnims_13_8:
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 2, 307, 0, 0, 0, 0,
+ax_anim_terminator
+sGranbullGfx1:
+.incbin "baserom.gba", 0xE7D5FC, 0x200
+sGranbullSprites1:
+ax_sprite sGranbullGfx1, 0x200
+ax_sprite_terminator
+sGranbullGfx2:
+.incbin "baserom.gba", 0xE7D80C, 0x200
+sGranbullSprites2:
+ax_sprite sGranbullGfx2, 0x200
+ax_sprite_terminator
+sGranbullGfx3:
+.incbin "baserom.gba", 0xE7DA1C, 0x200
+sGranbullSprites3:
+ax_sprite sGranbullGfx3, 0x200
+ax_sprite_terminator
+sGranbullGfx4:
+.incbin "baserom.gba", 0xE7DC2C, 0x200
+sGranbullSprites4:
+ax_sprite sGranbullGfx4, 0x200
+ax_sprite_terminator
+sGranbullGfx5:
+.incbin "baserom.gba", 0xE7DE3C, 0x200
+sGranbullSprites5:
+ax_sprite sGranbullGfx5, 0x200
+ax_sprite_terminator
+sGranbullGfx6:
+.incbin "baserom.gba", 0xE7E04C, 0x200
+sGranbullSprites6:
+ax_sprite sGranbullGfx6, 0x200
+ax_sprite_terminator
+sGranbullGfx7:
+.incbin "baserom.gba", 0xE7E25C, 0x200
+sGranbullSprites7:
+ax_sprite sGranbullGfx7, 0x200
+ax_sprite_terminator
+sGranbullGfx8:
+.incbin "baserom.gba", 0xE7E46C, 0x200
+sGranbullSprites8:
+ax_sprite sGranbullGfx8, 0x200
+ax_sprite_terminator
+sGranbullGfx9:
+.incbin "baserom.gba", 0xE7E67C, 0x200
+sGranbullSprites9:
+ax_sprite sGranbullGfx9, 0x200
+ax_sprite_terminator
+sGranbullGfx10:
+.incbin "baserom.gba", 0xE7E88C, 0x200
+sGranbullSprites10:
+ax_sprite sGranbullGfx10, 0x200
+ax_sprite_terminator
+sGranbullGfx11:
+.incbin "baserom.gba", 0xE7EA9C, 0x200
+sGranbullSprites11:
+ax_sprite sGranbullGfx11, 0x200
+ax_sprite_terminator
+sGranbullGfx12:
+.incbin "baserom.gba", 0xE7ECAC, 0x200
+sGranbullSprites12:
+ax_sprite sGranbullGfx12, 0x200
+ax_sprite_terminator
+sGranbullGfx13:
+.incbin "baserom.gba", 0xE7EEBC, 0x200
+sGranbullSprites13:
+ax_sprite sGranbullGfx13, 0x200
+ax_sprite_terminator
+sGranbullGfx14:
+.incbin "baserom.gba", 0xE7F0CC, 0x200
+sGranbullSprites14:
+ax_sprite sGranbullGfx14, 0x200
+ax_sprite_terminator
+sGranbullGfx15:
+.incbin "baserom.gba", 0xE7F2DC, 0x200
+sGranbullSprites15:
+ax_sprite sGranbullGfx15, 0x200
+ax_sprite_terminator
+sGranbullGfx16:
+.incbin "baserom.gba", 0xE7F4EC, 0x60
+sGranbullGfx16_1:
+.incbin "baserom.gba", 0xE7F54C, 0x60
+sGranbullGfx16_2:
+.incbin "baserom.gba", 0xE7F5AC, 0x60
+sGranbullSprites16:
+ax_sprite sGranbullGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGranbullGfx17:
+.incbin "baserom.gba", 0xE7F644, 0x60
+sGranbullGfx17_1:
+.incbin "baserom.gba", 0xE7F6A4, 0x60
+sGranbullGfx17_2:
+.incbin "baserom.gba", 0xE7F704, 0x60
+sGranbullSprites17:
+ax_sprite sGranbullGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGranbullGfx18:
+.incbin "baserom.gba", 0xE7F79C, 0x60
+sGranbullGfx18_1:
+.incbin "baserom.gba", 0xE7F7FC, 0x60
+sGranbullGfx18_2:
+.incbin "baserom.gba", 0xE7F85C, 0x60
+sGranbullGfx18_3:
+.incbin "baserom.gba", 0xE7F8BC, 0x20
+sGranbullSprites18:
+ax_sprite sGranbullGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx18_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sGranbullGfx18_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx19:
+.incbin "baserom.gba", 0xE7F924, 0x60
+sGranbullGfx19_1:
+.incbin "baserom.gba", 0xE7F984, 0x100
+sGranbullGfx19_2:
+.incbin "baserom.gba", 0xE7FA84, 0x20
+sGranbullSprites19:
+ax_sprite sGranbullGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx19_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sGranbullGfx19_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx20:
+.incbin "baserom.gba", 0xE7FADC, 0x60
+sGranbullGfx20_1:
+.incbin "baserom.gba", 0xE7FB3C, 0x60
+sGranbullGfx20_2:
+.incbin "baserom.gba", 0xE7FB9C, 0x80
+sGranbullGfx20_3:
+.incbin "baserom.gba", 0xE7FC1C, 0x40
+sGranbullSprites20:
+ax_sprite sGranbullGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx20_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx21:
+.incbin "baserom.gba", 0xE7FCA4, 0x60
+sGranbullGfx21_1:
+.incbin "baserom.gba", 0xE7FD04, 0x60
+sGranbullGfx21_2:
+.incbin "baserom.gba", 0xE7FD64, 0x80
+sGranbullGfx21_3:
+.incbin "baserom.gba", 0xE7FDE4, 0x40
+sGranbullSprites21:
+ax_sprite sGranbullGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx21_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx22:
+.incbin "baserom.gba", 0xE7FE6C, 0x60
+sGranbullGfx22_1:
+.incbin "baserom.gba", 0xE7FECC, 0x60
+sGranbullGfx22_2:
+.incbin "baserom.gba", 0xE7FF2C, 0x60
+sGranbullGfx22_3:
+.incbin "baserom.gba", 0xE7FF8C, 0x60
+sGranbullSprites22:
+ax_sprite sGranbullGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx23:
+.incbin "baserom.gba", 0xE80034, 0x60
+sGranbullGfx23_1:
+.incbin "baserom.gba", 0xE80094, 0x60
+sGranbullGfx23_2:
+.incbin "baserom.gba", 0xE800F4, 0x60
+sGranbullGfx23_3:
+.incbin "baserom.gba", 0xE80154, 0x60
+sGranbullSprites23:
+ax_sprite sGranbullGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx24:
+.incbin "baserom.gba", 0xE801FC, 0x60
+sGranbullGfx24_1:
+.incbin "baserom.gba", 0xE8025C, 0x60
+sGranbullGfx24_2:
+.incbin "baserom.gba", 0xE802BC, 0x60
+sGranbullGfx24_3:
+.incbin "baserom.gba", 0xE8031C, 0x60
+sGranbullSprites24:
+ax_sprite sGranbullGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx25:
+.incbin "baserom.gba", 0xE803C4, 0x60
+sGranbullGfx25_1:
+.incbin "baserom.gba", 0xE80424, 0x60
+sGranbullGfx25_2:
+.incbin "baserom.gba", 0xE80484, 0x60
+sGranbullGfx25_3:
+.incbin "baserom.gba", 0xE804E4, 0x60
+sGranbullSprites25:
+ax_sprite sGranbullGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGranbullGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGranbullGfx26:
+.incbin "baserom.gba", 0xE8058C, 0x200
+sGranbullSprites26:
+ax_sprite sGranbullGfx26, 0x200
+ax_sprite_terminator
+sGranbullGfx27:
+.incbin "baserom.gba", 0xE8079C, 0x200
+sGranbullSprites27:
+ax_sprite sGranbullGfx27, 0x200
+ax_sprite_terminator
+sGranbullGfx28:
+.incbin "baserom.gba", 0xE809AC, 0x200
+sGranbullSprites28:
+ax_sprite sGranbullGfx28, 0x200
+ax_sprite_terminator
+sGranbullGfx29:
+.incbin "baserom.gba", 0xE80BBC, 0x200
+sGranbullSprites29:
+ax_sprite sGranbullGfx29, 0x200
+ax_sprite_terminator
+sGranbullGfx30:
+.incbin "baserom.gba", 0xE80DCC, 0x200
+sGranbullSprites30:
+ax_sprite sGranbullGfx30, 0x200
+ax_sprite_terminator
+sGranbullGfx31:
+.incbin "baserom.gba", 0xE80FDC, 0x200
+sGranbullSprites31:
+ax_sprite sGranbullGfx31, 0x200
+ax_sprite_terminator
+sGranbullGfx32:
+.incbin "baserom.gba", 0xE811EC, 0x200
+sGranbullSprites32:
+ax_sprite sGranbullGfx32, 0x200
+ax_sprite_terminator
+sAxPosesGranbull:
+.4byte sGranbullPose1
+.4byte sGranbullPose2
+.4byte sGranbullPose3
+.4byte sGranbullPose4
+.4byte sGranbullPose5
+.4byte sGranbullPose6
+.4byte sGranbullPose7
+.4byte sGranbullPose8
+.4byte sGranbullPose9
+.4byte sGranbullPose10
+.4byte sGranbullPose11
+.4byte sGranbullPose12
+.4byte sGranbullPose13
+.4byte sGranbullPose14
+.4byte sGranbullPose15
+.4byte sGranbullPose16
+.4byte sGranbullPose17
+.4byte sGranbullPose18
+.4byte sGranbullPose19
+.4byte sGranbullPose20
+.4byte sGranbullPose21
+.4byte sGranbullPose22
+.4byte sGranbullPose23
+.4byte sGranbullPose24
+.4byte sGranbullPose25
+.4byte sGranbullPose26
+.4byte sGranbullPose27
+.4byte sGranbullPose28
+.4byte sGranbullPose29
+.4byte sGranbullPose30
+.4byte sGranbullPose31
+.4byte sGranbullPose32
+.4byte sGranbullPose33
+.4byte sGranbullPose34
+.4byte sGranbullPose35
+.4byte sGranbullPose36
+.4byte sGranbullPose37
+.4byte sGranbullPose38
+.4byte sGranbullPose39
+.4byte sGranbullPose40
+.4byte sGranbullPose41
+.4byte sGranbullPose42
+.4byte sGranbullPose43
+.4byte sGranbullPose44
+.4byte sGranbullPose45
+.4byte sGranbullPose46
+.4byte sGranbullPose47
+.4byte sGranbullPose48
+.4byte sGranbullPose49
+.4byte sGranbullPose50
+.4byte sGranbullPose51
+.4byte sGranbullPose52
+.4byte sGranbullPose53
+.4byte sGranbullPose54
+.4byte sGranbullPose55
+.4byte sGranbullPose56
+.4byte sGranbullPose57
+.4byte sGranbullPose58
+.4byte sGranbullPose59
+.4byte sGranbullPose60
+.4byte sGranbullPose61
+.4byte sGranbullPose62
+.4byte sGranbullPose63
+.4byte sGranbullPose64
+.4byte sGranbullPose65
+.4byte sGranbullPose66
+.4byte sGranbullPose67
+.4byte sGranbullPose68
+.4byte sGranbullPose69
+.4byte sGranbullPose70
+.4byte sGranbullPose71
+.4byte sGranbullPose72
+.4byte sGranbullPose73
+.4byte sGranbullPose74
+.4byte sGranbullPose75
+.4byte sGranbullPose76
+.4byte sGranbullPose77
+.4byte sGranbullPose78
+.4byte sGranbullPose79
+.4byte sGranbullPose80
+.4byte sGranbullPose81
+.4byte sGranbullPose82
+.4byte sGranbullPose83
+.4byte sGranbullPose84
+.4byte sGranbullPose85
+.4byte sGranbullPose86
+.4byte sGranbullPose87
+.4byte sGranbullPose88
+.4byte sGranbullPose89
+.4byte sGranbullPose90
+.4byte sGranbullPose91
+.4byte sGranbullPose92
+.4byte sGranbullPose93
+.4byte sGranbullPose94
+.4byte sGranbullPose95
+.4byte sGranbullPose96
+.4byte sGranbullPose97
+.4byte sGranbullPose98
+.4byte sGranbullPose99
+.4byte sGranbullPose100
+.4byte sGranbullPose101
+.4byte sGranbullPose102
+.4byte sGranbullPose103
+.4byte sGranbullPose104
+.4byte sGranbullPose105
+.4byte sGranbullPose106
+.4byte sGranbullPose107
+.4byte sGranbullPose108
+.4byte sGranbullPose109
+.4byte sGranbullPose110
+.4byte sGranbullPose111
+.4byte sGranbullPose112
+.4byte sGranbullPose113
+.4byte sGranbullPose114
+.4byte sGranbullPose115
+.4byte sGranbullPose116
+.4byte sGranbullPose117
+.4byte sGranbullPose118
+.4byte sGranbullPose119
+.4byte sGranbullPose120
+.4byte sGranbullPose121
+.4byte sGranbullPose122
+.4byte sGranbullPose123
+.4byte sGranbullPose124
+.4byte sGranbullPose125
+.4byte sGranbullPose126
+.4byte sGranbullPose127
+.4byte sGranbullPose128
+.4byte sGranbullPose129
+.4byte sGranbullPose130
+.4byte sGranbullPose131
+.4byte sGranbullPose132
+.4byte sGranbullPose133
+.4byte sGranbullPose134
+.4byte sGranbullPose135
+.4byte sGranbullPose136
+.4byte sGranbullPose137
+.4byte sGranbullPose138
+.4byte sGranbullPose139
+.4byte sGranbullPose140
+.4byte sGranbullPose141
+.4byte sGranbullPose142
+.4byte sGranbullPose143
+.4byte sGranbullPose144
+.4byte sGranbullPose145
+.4byte sGranbullPose146
+.4byte sGranbullPose147
+.4byte sGranbullPose148
+.4byte sGranbullPose149
+.4byte sGranbullPose150
+.4byte sGranbullPose151
+.4byte sGranbullPose152
+.4byte sGranbullPose153
+.4byte sGranbullPose154
+.4byte sGranbullPose155
+.4byte sGranbullPose156
+.4byte sGranbullPose157
+.4byte sGranbullPose158
+.4byte sGranbullPose159
+.4byte sGranbullPose160
+.4byte sGranbullPose161
+.4byte sGranbullPose162
+.4byte sGranbullPose163
+.4byte sGranbullPose164
+.4byte sGranbullPose165
+.4byte sGranbullPose166
+.4byte sGranbullPose167
+.4byte sGranbullPose168
+.4byte sGranbullPose169
+.4byte sGranbullPose170
+.4byte sGranbullPose171
+.4byte sGranbullPose172
+.4byte sGranbullPose173
+.4byte sGranbullPose174
+.4byte sGranbullPose175
+.4byte sGranbullPose176
+.4byte sGranbullPose177
+.4byte sGranbullPose178
+.4byte sGranbullPose179
+.4byte sGranbullPose180
+.4byte sGranbullPose181
+.4byte sGranbullPose182
+.4byte sGranbullPose183
+.4byte sGranbullPose184
+.4byte sGranbullPose185
+.4byte sGranbullPose186
+.4byte sGranbullPose187
+.4byte sGranbullPose188
+.4byte sGranbullPose189
+.4byte sGranbullPose190
+.4byte sGranbullPose191
+.4byte sGranbullPose192
+.4byte sGranbullPose193
+.4byte sGranbullPose194
+.4byte sGranbullPose195
+.4byte sGranbullPose196
+.4byte sGranbullPose197
+.4byte sGranbullPose198
+.4byte sGranbullPose199
+.4byte sGranbullPose200
+.4byte sGranbullPose201
+.4byte sGranbullPose202
+.4byte sGranbullPose203
+.4byte sGranbullPose204
+.4byte sGranbullPose205
+.4byte sGranbullPose206
+.4byte sGranbullPose207
+.4byte sGranbullPose208
+.4byte sGranbullPose209
+.4byte sGranbullPose210
+.4byte sGranbullPose211
+.4byte sGranbullPose212
+.4byte sGranbullPose213
+.4byte sGranbullPose214
+.4byte sGranbullPose215
+.4byte sGranbullPose216
+.4byte sGranbullPose217
+.4byte sGranbullPose218
+.4byte sGranbullPose219
+.4byte sGranbullPose220
+.4byte sGranbullPose221
+.4byte sGranbullPose222
+.4byte sGranbullPose223
+.4byte sGranbullPose224
+.4byte sGranbullPose225
+.4byte sGranbullPose226
+.4byte sGranbullPose227
+.4byte sGranbullPose228
+.4byte sGranbullPose229
+.4byte sGranbullPose230
+.4byte sGranbullPose231
+.4byte sGranbullPose232
+.4byte sGranbullPose233
+.4byte sGranbullPose234
+.4byte sGranbullPose235
+.4byte sGranbullPose236
+.4byte sGranbullPose237
+.4byte sGranbullPose238
+.4byte sGranbullPose239
+.4byte sGranbullPose240
+.4byte sGranbullPose241
+.4byte sGranbullPose242
+.4byte sGranbullPose243
+.4byte sGranbullPose244
+.4byte sGranbullPose245
+.4byte sGranbullPose246
+.4byte sGranbullPose247
+.4byte sGranbullPose248
+.4byte sGranbullPose249
+.4byte sGranbullPose250
+.4byte sGranbullPose251
+.4byte sGranbullPose252
+.4byte sGranbullPose253
+.4byte sGranbullPose254
+.4byte sGranbullPose255
+.4byte sGranbullPose256
+.4byte sGranbullPose257
+.4byte sGranbullPose258
+.4byte sGranbullPose259
+.4byte sGranbullPose260
+.4byte sGranbullPose261
+.4byte sGranbullPose262
+.4byte sGranbullPose263
+.4byte sGranbullPose264
+.4byte sGranbullPose265
+.4byte sGranbullPose266
+.4byte sGranbullPose267
+.4byte sGranbullPose268
+.4byte sGranbullPose269
+.4byte sGranbullPose270
+.4byte sGranbullPose271
+.4byte sGranbullPose272
+.4byte sGranbullPose273
+.4byte sGranbullPose274
+.4byte sGranbullPose275
+.4byte sGranbullPose276
+.4byte sGranbullPose277
+.4byte sGranbullPose278
+.4byte sGranbullPose279
+.4byte sGranbullPose280
+.4byte sGranbullPose281
+.4byte sGranbullPose282
+.4byte sGranbullPose283
+.4byte sGranbullPose284
+.4byte sGranbullPose285
+.4byte sGranbullPose286
+.4byte sGranbullPose287
+.4byte sGranbullPose288
+.4byte sGranbullPose289
+.4byte sGranbullPose290
+.4byte sGranbullPose291
+.4byte sGranbullPose292
+.4byte sGranbullPose293
+.4byte sGranbullPose294
+.4byte sGranbullPose295
+.4byte sGranbullPose296
+.4byte sGranbullPose297
+.4byte sGranbullPose298
+.4byte sGranbullPose299
+.4byte sGranbullPose300
+.4byte sGranbullPose301
+.4byte sGranbullPose302
+.4byte sGranbullPose303
+.4byte sGranbullPose304
+.4byte sGranbullPose305
+.4byte sGranbullPose306
+.4byte sGranbullPose307
+.4byte sGranbullPose308
+.4byte sGranbullPose309
+.4byte sGranbullPose310
+.4byte sGranbullPose311
+.4byte sGranbullPose312
+.4byte sGranbullPose313
+.4byte sGranbullPose314
+sAxPositionsGranbull:
+.2byte   -1,  -12, 	  -5,   -7, 	   3,   -7, 	  -1,   -9
+.2byte   -2,  -11, 	  -4,   -5, 	   6,   -7, 	  -1,   -8
+.2byte    0,  -11, 	  -8,   -7, 	   2,   -5, 	  -1,   -8
+.2byte    5,  -12, 	   6,   -8, 	  -2,   -6, 	   2,   -9
+.2byte    4,  -11, 	   7,   -6, 	  -4,   -6, 	   1,   -7
+.2byte    3,  -11, 	   5,   -8, 	   0,   -5, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    6,  -12, 	   8,   -7, 	   2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   5,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,   -8
+.2byte    5,  -14, 	   3,  -10, 	   5,   -7, 	   0,   -7
+.2byte    4,  -15, 	  -3,   -9, 	   8,   -9, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte    0,  -13, 	   6,  -12, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,  -13, 	   0,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -7,  -13, 	  -5,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -6,  -14, 	   1,   -8, 	 -10,   -8, 	  -1,   -6
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -8,  -12, 	 -10,   -7, 	  -4,   -4, 	  -2,   -7
+.2byte   -6,  -10, 	  -7,   -8, 	  -7,   -4, 	  -1,   -7
+.2byte   -7,  -12, 	  -8,   -8, 	   0,   -6, 	  -4,   -9
+.2byte   -6,  -11, 	  -9,   -6, 	   2,   -6, 	  -3,   -7
+.2byte   -5,  -11, 	  -7,   -8, 	  -2,   -5, 	  -2,   -7
+.2byte   -1,  -12, 	  -5,   -7, 	   3,   -7, 	  -1,   -9
+.2byte   -2,  -11, 	  -4,   -5, 	   6,   -7, 	  -1,   -8
+.2byte    0,  -11, 	  -8,   -7, 	   2,   -5, 	  -1,   -8
+.2byte    5,  -12, 	   6,   -8, 	  -2,   -6, 	   2,   -9
+.2byte    4,  -11, 	   7,   -6, 	  -4,   -6, 	   1,   -7
+.2byte    3,  -11, 	   5,   -8, 	   0,   -5, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    6,  -12, 	   8,   -7, 	   2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   5,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,   -8
+.2byte    5,  -14, 	   3,  -10, 	   5,   -7, 	   0,   -7
+.2byte    4,  -15, 	  -3,   -9, 	   8,   -9, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte    0,  -13, 	   6,  -12, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,  -13, 	   0,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -7,  -13, 	  -5,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -6,  -14, 	   1,   -8, 	 -10,   -8, 	  -1,   -6
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -8,  -12, 	 -10,   -7, 	  -4,   -4, 	  -2,   -7
+.2byte   -6,  -10, 	  -7,   -8, 	  -7,   -4, 	  -1,   -7
+.2byte   -7,  -12, 	  -8,   -8, 	   0,   -6, 	  -4,   -9
+.2byte   -6,  -11, 	  -9,   -6, 	   2,   -6, 	  -3,   -7
+.2byte   -5,  -11, 	  -7,   -8, 	  -2,   -5, 	  -2,   -7
+.2byte   -1,  -12, 	  -5,   -7, 	   3,   -7, 	  -1,   -9
+.2byte   -2,  -11, 	  -4,   -5, 	   6,   -7, 	  -1,   -8
+.2byte    0,  -11, 	  -8,   -7, 	   2,   -5, 	  -1,   -8
+.2byte    5,  -12, 	   6,   -8, 	  -2,   -6, 	   2,   -9
+.2byte    4,  -11, 	   7,   -6, 	  -4,   -6, 	   1,   -7
+.2byte    3,  -11, 	   5,   -8, 	   0,   -5, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    6,  -12, 	   8,   -7, 	   2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   5,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,   -8
+.2byte    5,  -14, 	   3,  -10, 	   5,   -7, 	   0,   -7
+.2byte    4,  -15, 	  -3,   -9, 	   8,   -9, 	  -1,   -7
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte    0,  -13, 	   6,  -12, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,  -13, 	   0,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -7,  -13, 	  -5,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -6,  -14, 	   1,   -8, 	 -10,   -8, 	  -1,   -6
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -8,  -12, 	 -10,   -7, 	  -4,   -4, 	  -2,   -7
+.2byte   -6,  -10, 	  -7,   -8, 	  -7,   -4, 	  -1,   -7
+.2byte   -7,  -12, 	  -8,   -8, 	   0,   -6, 	  -4,   -9
+.2byte   -6,  -11, 	  -9,   -6, 	   2,   -6, 	  -3,   -7
+.2byte   -5,  -11, 	  -7,   -8, 	  -2,   -5, 	  -2,   -7
+.2byte   -1,  -12, 	  -5,   -7, 	   3,   -7, 	  -1,   -9
+.2byte   -2,  -11, 	  -4,   -5, 	   6,   -7, 	  -1,   -8
+.2byte    0,  -11, 	  -8,   -7, 	   2,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte    5,  -12, 	   6,   -8, 	  -2,   -6, 	   2,   -9
+.2byte    4,  -11, 	   7,   -6, 	  -4,   -6, 	   1,   -7
+.2byte    3,  -11, 	   5,   -8, 	   0,   -5, 	   0,   -7
+.2byte    6,   -8, 	   7,   -5, 	  -6,   -3, 	   2,   -8
+.2byte    4,   -7, 	   7,   -6, 	  -9,   -4, 	   1,   -9
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    6,  -12, 	   8,   -7, 	   2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   5,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    8,   -9, 	   5,   -5, 	  -1,   -3, 	   1,   -7
+.2byte    6,   -7, 	   2,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,   -8
+.2byte    5,  -14, 	   3,  -10, 	   5,   -7, 	   0,   -7
+.2byte    4,  -15, 	  -3,   -9, 	   8,   -9, 	  -1,   -7
+.2byte    6,  -13, 	   0,   -7, 	   7,   -3, 	  -2,   -8
+.2byte    6,  -11, 	  -4,   -6, 	   5,   -3, 	  -1,   -9
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte    0,  -13, 	   6,  -12, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,  -13, 	   0,   -8
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -7,  -13, 	  -5,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -6,  -14, 	   1,   -8, 	 -10,   -8, 	  -1,   -6
+.2byte   -8,  -13, 	  -2,   -7, 	  -9,   -3, 	   0,   -8
+.2byte   -8,  -11, 	   2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -8,  -12, 	 -10,   -7, 	  -4,   -4, 	  -2,   -7
+.2byte   -6,  -10, 	  -7,   -8, 	  -7,   -4, 	  -1,   -7
+.2byte  -10,   -9, 	  -7,   -5, 	  -1,   -3, 	  -3,   -7
+.2byte   -8,   -7, 	  -4,   -5, 	   3,   -3, 	  -3,   -7
+.2byte   -7,  -12, 	  -8,   -8, 	   0,   -6, 	  -4,   -9
+.2byte   -6,  -11, 	  -9,   -6, 	   2,   -6, 	  -3,   -7
+.2byte   -5,  -11, 	  -7,   -8, 	  -2,   -5, 	  -2,   -7
+.2byte   -8,   -8, 	  -9,   -5, 	   4,   -3, 	  -4,   -8
+.2byte   -6,   -7, 	  -9,   -6, 	   7,   -4, 	  -3,   -9
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte   -2,  -11, 	  -4,   -5, 	   6,   -7, 	  -1,   -8
+.2byte    0,  -11, 	  -8,   -7, 	   2,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte    4,  -11, 	   7,   -6, 	  -4,   -6, 	   1,   -7
+.2byte    3,  -11, 	   5,   -8, 	   0,   -5, 	   0,   -7
+.2byte    6,   -8, 	   7,   -5, 	  -6,   -3, 	   2,   -8
+.2byte    4,   -7, 	   7,   -6, 	  -9,   -4, 	   1,   -9
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte    6,  -12, 	   8,   -7, 	   2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   5,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    8,   -9, 	   5,   -5, 	  -1,   -3, 	   1,   -7
+.2byte    6,   -7, 	   2,   -5, 	  -5,   -3, 	   1,   -7
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte    5,  -14, 	   3,  -10, 	   5,   -7, 	   0,   -7
+.2byte    4,  -15, 	  -3,   -9, 	   8,   -9, 	  -1,   -7
+.2byte    6,  -13, 	   0,   -7, 	   7,   -3, 	  -2,   -8
+.2byte    6,  -11, 	  -4,   -6, 	   5,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte    0,  -13, 	   6,  -12, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,  -13, 	   0,   -8
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte   -7,  -13, 	  -5,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -6,  -14, 	   1,   -8, 	 -10,   -8, 	  -1,   -6
+.2byte   -8,  -13, 	  -2,   -7, 	  -9,   -3, 	   0,   -8
+.2byte   -8,  -11, 	   2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte   -8,  -12, 	 -10,   -7, 	  -4,   -4, 	  -2,   -7
+.2byte   -6,  -10, 	  -7,   -8, 	  -7,   -4, 	  -1,   -7
+.2byte  -10,   -9, 	  -7,   -5, 	  -1,   -3, 	  -3,   -7
+.2byte   -8,   -7, 	  -4,   -5, 	   3,   -3, 	  -3,   -7
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+.2byte   -6,  -11, 	  -9,   -6, 	   2,   -6, 	  -3,   -7
+.2byte   -5,  -11, 	  -7,   -8, 	  -2,   -5, 	  -2,   -7
+.2byte   -8,   -8, 	  -9,   -5, 	   4,   -3, 	  -4,   -8
+.2byte   -6,   -7, 	  -9,   -6, 	   7,   -4, 	  -3,   -9
+.2byte   -5,  -10, 	  -5,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -4, 	  -3,   -4, 	  -1,   -6
+.2byte    0,  -17, 	  -4,  -12, 	   4,  -12, 	   0,  -11
+.2byte    0,  -16, 	   7,  -14, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -18, 	   5,  -14, 	   1,  -11, 	  -2,  -10
+.2byte    2,  -19, 	  -2,  -18, 	   6,  -15, 	  -2,  -10
+.2byte    0,  -17, 	   5,  -14, 	  -3,  -14, 	   0,   -8
+.2byte   -3,  -19, 	   1,  -18, 	  -7,  -15, 	   1,  -10
+.2byte   -1,  -18, 	  -6,  -14, 	  -2,  -11, 	   1,  -10
+.2byte   -1,  -16, 	  -8,  -14, 	   1,  -11, 	   0,  -11
+.2byte   -1,  -12, 	  -5,   -7, 	   3,   -7, 	  -1,   -9
+.2byte   -2,  -11, 	  -4,   -5, 	   6,   -7, 	  -1,   -8
+.2byte    0,  -11, 	  -8,   -7, 	   2,   -5, 	  -1,   -8
+.2byte   -1,   -9, 	  -9,   -6, 	   7,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte    5,  -12, 	   6,   -8, 	  -2,   -6, 	   2,   -9
+.2byte    4,  -11, 	   7,   -6, 	  -4,   -6, 	   1,   -7
+.2byte    3,  -11, 	   5,   -8, 	   0,   -5, 	   0,   -7
+.2byte    6,   -8, 	   7,   -5, 	  -6,   -3, 	   2,   -8
+.2byte    4,   -7, 	   7,   -6, 	  -9,   -4, 	   1,   -9
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    6,  -12, 	   8,   -7, 	   2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   5,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    8,   -9, 	   5,   -5, 	  -1,   -3, 	   1,   -7
+.2byte    6,   -7, 	   2,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,   -8
+.2byte    5,  -14, 	   3,  -10, 	   5,   -7, 	   0,   -7
+.2byte    4,  -15, 	  -3,   -9, 	   8,   -9, 	  -1,   -7
+.2byte    6,  -13, 	   0,   -7, 	   7,   -3, 	  -2,   -8
+.2byte    6,  -11, 	  -4,   -6, 	   5,   -3, 	  -1,   -9
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte    0,  -13, 	   6,  -12, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,  -13, 	   4,   -7, 	  -6,  -13, 	   0,   -8
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -7,  -13, 	  -5,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -6,  -14, 	   1,   -8, 	 -10,   -8, 	  -1,   -6
+.2byte   -8,  -13, 	  -2,   -7, 	  -9,   -3, 	   0,   -8
+.2byte   -8,  -11, 	   2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -8,  -12, 	 -10,   -7, 	  -4,   -4, 	  -2,   -7
+.2byte   -6,  -10, 	  -7,   -8, 	  -7,   -4, 	  -1,   -7
+.2byte  -10,   -9, 	  -7,   -5, 	  -1,   -3, 	  -3,   -7
+.2byte   -8,   -7, 	  -4,   -5, 	   3,   -3, 	  -3,   -7
+.2byte   -7,  -12, 	  -8,   -8, 	   0,   -6, 	  -4,   -9
+.2byte   -6,  -11, 	  -9,   -6, 	   2,   -6, 	  -3,   -7
+.2byte   -5,  -11, 	  -7,   -8, 	  -2,   -5, 	  -2,   -7
+.2byte   -8,   -8, 	  -9,   -5, 	   4,   -3, 	  -4,   -8
+.2byte   -6,   -7, 	  -9,   -6, 	   7,   -4, 	  -3,   -9
+.2byte   -1,   -6, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte   -6,   -7, 	  -9,   -6, 	   7,   -4, 	  -3,   -9
+.2byte   -8,   -7, 	  -4,   -5, 	   3,   -3, 	  -3,   -7
+.2byte   -8,  -11, 	   2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte    6,  -11, 	  -4,   -6, 	   5,   -3, 	  -1,   -9
+.2byte    6,   -7, 	   2,   -5, 	  -5,   -3, 	   1,   -7
+.2byte    4,   -7, 	   7,   -6, 	  -9,   -4, 	   1,   -9
+.2byte   -2,  -11, 	  -4,   -5, 	   6,   -7, 	  -1,   -8
+.2byte    4,  -11, 	   7,   -6, 	  -4,   -6, 	   1,   -7
+.2byte    4,  -11, 	   5,   -9, 	   5,   -5, 	  -1,   -8
+.2byte    5,  -16, 	  -2,  -10, 	   9,  -10, 	   0,   -8
+.2byte    1,  -14, 	   7,  -13, 	  -5,   -8, 	   0,   -9
+.2byte   -5,  -16, 	   2,  -10, 	  -9,  -10, 	   0,   -8
+.2byte   -5,  -11, 	  -6,   -9, 	  -6,   -5, 	   0,   -8
+.2byte   -5,  -11, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -11, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -1,   -8, 	  -9,   -5, 	   7,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte    5,  -12, 	   6,   -8, 	  -2,   -6, 	   2,   -9
+.2byte    4,   -9, 	   5,   -6, 	  -8,   -4, 	   0,   -9
+.2byte    2,   -8, 	   5,   -7, 	 -11,   -5, 	  -1,  -10
+.2byte    5,  -13, 	   7,   -8, 	   4,   -6, 	   0,   -9
+.2byte    6,  -10, 	   3,   -6, 	  -3,   -4, 	  -1,   -8
+.2byte    4,   -8, 	   0,   -6, 	  -7,   -4, 	  -1,   -8
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,   -8
+.2byte    6,  -14, 	   0,   -8, 	   7,   -4, 	  -2,   -9
+.2byte    6,  -12, 	  -4,   -7, 	   5,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	   4,  -11, 	  -6,  -11, 	  -1,   -9
+.2byte   -1,  -15, 	   8,   -9, 	 -10,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   8,   -7, 	 -10,   -7, 	  -1,  -11
+.2byte   -6,  -16, 	  -1,  -11, 	  -8,   -9, 	  -2,   -8
+.2byte   -8,  -14, 	  -2,   -8, 	  -9,   -4, 	   0,   -9
+.2byte   -8,  -12, 	   2,   -7, 	  -7,   -4, 	  -1,  -10
+.2byte   -7,  -13, 	  -9,   -8, 	  -6,   -6, 	  -2,   -9
+.2byte   -8,  -10, 	  -5,   -6, 	   1,   -4, 	  -1,   -8
+.2byte   -6,   -8, 	  -2,   -6, 	   5,   -4, 	  -1,   -8
+.2byte   -6,  -12, 	  -7,   -8, 	   1,   -6, 	  -3,   -9
+.2byte   -5,   -9, 	  -6,   -6, 	   7,   -4, 	  -1,   -9
+.2byte   -3,   -8, 	  -6,   -7, 	  10,   -5, 	   0,  -10
+.2byte   -1,   -8, 	 -11,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -4,   -9, 	  -7,   -8, 	   9,   -6, 	  -1,  -11
+.2byte   -5,   -8, 	  -1,   -6, 	   6,   -4, 	   0,   -8
+.2byte   -7,  -11, 	   3,   -6, 	  -6,   -3, 	   0,   -9
+.2byte   -1,  -14, 	   8,   -6, 	 -10,   -6, 	  -1,  -10
+.2byte    7,  -11, 	  -3,   -6, 	   6,   -3, 	   0,   -9
+.2byte    5,   -8, 	   1,   -6, 	  -6,   -4, 	   0,   -8
+.2byte    4,   -9, 	   7,   -8, 	  -9,   -6, 	   1,  -11
+.2byte   -1,  -10, 	  -5,   -5, 	   3,   -5, 	  -1,   -7
+.2byte   -7,  -11, 	  -8,   -7, 	   0,   -5, 	  -4,   -8
+.2byte   -7,  -12, 	  -9,   -7, 	  -6,   -5, 	  -2,   -8
+.2byte   -6,  -15, 	  -1,  -10, 	  -8,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    4,  -15, 	  -1,  -10, 	   6,   -8, 	   0,   -7
+.2byte    5,  -12, 	   7,   -7, 	   4,   -5, 	   0,   -8
+.2byte    5,  -11, 	   6,   -7, 	  -2,   -5, 	   2,   -8
+sGranbullAnimTable1:
+.4byte sGranbullAnims_1_1
+.4byte sGranbullAnims_1_2
+.4byte sGranbullAnims_1_3
+.4byte sGranbullAnims_1_4
+.4byte sGranbullAnims_1_5
+.4byte sGranbullAnims_1_6
+.4byte sGranbullAnims_1_7
+.4byte sGranbullAnims_1_8
+sGranbullAnimTable2:
+.4byte sGranbullAnims_2_1
+.4byte sGranbullAnims_2_2
+.4byte sGranbullAnims_2_3
+.4byte sGranbullAnims_2_4
+.4byte sGranbullAnims_2_5
+.4byte sGranbullAnims_2_6
+.4byte sGranbullAnims_2_7
+.4byte sGranbullAnims_2_8
+sGranbullAnimTable3:
+.4byte sGranbullAnims_3_1
+.4byte sGranbullAnims_3_2
+.4byte sGranbullAnims_3_3
+.4byte sGranbullAnims_3_4
+.4byte sGranbullAnims_3_5
+.4byte sGranbullAnims_3_6
+.4byte sGranbullAnims_3_7
+.4byte sGranbullAnims_3_8
+sGranbullAnimTable4:
+.4byte sGranbullAnims_4_1
+.4byte sGranbullAnims_4_2
+.4byte sGranbullAnims_4_3
+.4byte sGranbullAnims_4_4
+.4byte sGranbullAnims_4_5
+.4byte sGranbullAnims_4_6
+.4byte sGranbullAnims_4_7
+.4byte sGranbullAnims_4_8
+sGranbullAnimTable5:
+.4byte sGranbullAnims_5_1
+.4byte sGranbullAnims_5_2
+.4byte sGranbullAnims_5_3
+.4byte sGranbullAnims_5_4
+.4byte sGranbullAnims_5_5
+.4byte sGranbullAnims_5_6
+.4byte sGranbullAnims_5_7
+.4byte sGranbullAnims_5_8
+sGranbullAnimTable6:
+.4byte sGranbullAnims_6_1
+.4byte sGranbullAnims_6_1
+.4byte sGranbullAnims_6_1
+.4byte sGranbullAnims_6_1
+.4byte sGranbullAnims_6_1
+.4byte sGranbullAnims_6_1
+.4byte sGranbullAnims_6_1
+.4byte sGranbullAnims_6_1
+sGranbullAnimTable7:
+.4byte sGranbullAnims_7_1
+.4byte sGranbullAnims_7_2
+.4byte sGranbullAnims_7_3
+.4byte sGranbullAnims_7_4
+.4byte sGranbullAnims_7_5
+.4byte sGranbullAnims_7_6
+.4byte sGranbullAnims_7_7
+.4byte sGranbullAnims_7_8
+sGranbullAnimTable8:
+.4byte sGranbullAnims_8_1
+.4byte sGranbullAnims_8_2
+.4byte sGranbullAnims_8_3
+.4byte sGranbullAnims_8_4
+.4byte sGranbullAnims_8_5
+.4byte sGranbullAnims_8_6
+.4byte sGranbullAnims_8_7
+.4byte sGranbullAnims_8_8
+sGranbullAnimTable9:
+.4byte sGranbullAnims_9_1
+.4byte sGranbullAnims_9_2
+.4byte sGranbullAnims_9_3
+.4byte sGranbullAnims_9_4
+.4byte sGranbullAnims_9_5
+.4byte sGranbullAnims_9_6
+.4byte sGranbullAnims_9_7
+.4byte sGranbullAnims_9_8
+sGranbullAnimTable10:
+.4byte sGranbullAnims_10_1
+.4byte sGranbullAnims_10_2
+.4byte sGranbullAnims_10_3
+.4byte sGranbullAnims_10_4
+.4byte sGranbullAnims_10_5
+.4byte sGranbullAnims_10_6
+.4byte sGranbullAnims_10_7
+.4byte sGranbullAnims_10_8
+sGranbullAnimTable11:
+.4byte sGranbullAnims_11_1
+.4byte sGranbullAnims_11_2
+.4byte sGranbullAnims_11_3
+.4byte sGranbullAnims_11_4
+.4byte sGranbullAnims_11_5
+.4byte sGranbullAnims_11_6
+.4byte sGranbullAnims_11_7
+.4byte sGranbullAnims_11_8
+sGranbullAnimTable12:
+.4byte sGranbullAnims_12_1
+.4byte sGranbullAnims_12_2
+.4byte sGranbullAnims_12_3
+.4byte sGranbullAnims_12_4
+.4byte sGranbullAnims_12_5
+.4byte sGranbullAnims_12_6
+.4byte sGranbullAnims_12_7
+.4byte sGranbullAnims_12_8
+sGranbullAnimTable13:
+.4byte sGranbullAnims_13_1
+.4byte sGranbullAnims_13_2
+.4byte sGranbullAnims_13_3
+.4byte sGranbullAnims_13_4
+.4byte sGranbullAnims_13_5
+.4byte sGranbullAnims_13_6
+.4byte sGranbullAnims_13_7
+.4byte sGranbullAnims_13_8
+sAxAnimationsGranbull:
+.4byte sGranbullAnimTable1
+.4byte sGranbullAnimTable2
+.4byte sGranbullAnimTable3
+.4byte sGranbullAnimTable4
+.4byte sGranbullAnimTable5
+.4byte sGranbullAnimTable6
+.4byte sGranbullAnimTable7
+.4byte sGranbullAnimTable8
+.4byte sGranbullAnimTable9
+.4byte sGranbullAnimTable10
+.4byte sGranbullAnimTable11
+.4byte sGranbullAnimTable12
+.4byte sGranbullAnimTable13
+sAxSpritesGranbull:
+.4byte sGranbullSprites1
+.4byte sGranbullSprites2
+.4byte sGranbullSprites3
+.4byte sGranbullSprites4
+.4byte sGranbullSprites5
+.4byte sGranbullSprites6
+.4byte sGranbullSprites7
+.4byte sGranbullSprites8
+.4byte sGranbullSprites9
+.4byte sGranbullSprites10
+.4byte sGranbullSprites11
+.4byte sGranbullSprites12
+.4byte sGranbullSprites13
+.4byte sGranbullSprites14
+.4byte sGranbullSprites15
+.4byte sGranbullSprites16
+.4byte sGranbullSprites17
+.4byte sGranbullSprites18
+.4byte sGranbullSprites19
+.4byte sGranbullSprites20
+.4byte sGranbullSprites21
+.4byte sGranbullSprites22
+.4byte sGranbullSprites23
+.4byte sGranbullSprites24
+.4byte sGranbullSprites25
+.4byte sGranbullSprites26
+.4byte sGranbullSprites27
+.4byte sGranbullSprites28
+.4byte sGranbullSprites29
+.4byte sGranbullSprites30
+.4byte sGranbullSprites31
+.4byte sGranbullSprites32
+sAxMainGranbull:
+ax_main sAxPosesGranbull, sAxAnimationsGranbull, 13, sAxSpritesGranbull, sAxPositionsGranbull

--- a/data/ax/graveler.inc
+++ b/data/ax/graveler.inc
@@ -1,0 +1,2821 @@
+.global gAxGraveler
+gAxGraveler:
+ax_siro sAxMainGraveler
+sGravelerPose1:
+ax_pose 0, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose2:
+ax_pose 1, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose3:
+ax_pose 2, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose4:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose5:
+ax_pose 4, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sGravelerPose6:
+ax_pose 5, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose7:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose8:
+ax_pose 7, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose9:
+ax_pose 8, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose10:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose12:
+ax_pose 11, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose22:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose23:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sGravelerPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose25:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose26:
+ax_pose 16, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose27:
+ax_pose 2, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose28:
+ax_pose 17, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose29:
+ax_pose 18, 0x01e7, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose30:
+ax_pose 5, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose31:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose32:
+ax_pose 20, 0x01e6, 0x90f3, 0x6c00
+ax_pose_terminator
+sGravelerPose33:
+ax_pose 8, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sGravelerPose34:
+ax_pose 21, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose35:
+ax_pose 22, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose36:
+ax_pose 11, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose37:
+ax_pose 23, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose38:
+ax_pose 24, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose39:
+ax_pose 14, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose40:
+ax_pose 21, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sGravelerPose41:
+ax_pose 22, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose42:
+ax_pose 11, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose43:
+ax_pose 19, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sGravelerPose44:
+ax_pose 20, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sGravelerPose45:
+ax_pose 8, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose46:
+ax_pose 17, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose47:
+ax_pose 18, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sGravelerPose48:
+ax_pose 5, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sGravelerPose49:
+ax_pose 0, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose50:
+ax_pose 16, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose51:
+ax_pose 25, 0x01ea, 0x80f0, 0x6c00
+ax_pose 15, 0x01ea, 0x80f0, 0x6c10
+ax_pose_terminator
+sGravelerPose52:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose53:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose54:
+ax_pose 18, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose55:
+ax_pose 26, 0x01e6, 0x90ef, 0x6c00
+ax_pose 17, 0x01e6, 0x90ef, 0x6c10
+ax_pose_terminator
+sGravelerPose56:
+ax_pose 17, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose57:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose58:
+ax_pose 20, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sGravelerPose59:
+ax_pose 27, 0x01e6, 0x90f2, 0x6c00
+ax_pose 19, 0x01e6, 0x90f1, 0x6c10
+ax_pose_terminator
+sGravelerPose60:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose61:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose62:
+ax_pose 22, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose63:
+ax_pose 28, 0x01e6, 0x90f1, 0x6c00
+ax_pose 21, 0x01e6, 0x90f1, 0x6c10
+ax_pose_terminator
+sGravelerPose64:
+ax_pose 21, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose65:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose66:
+ax_pose 29, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose67:
+ax_pose 30, 0x41e7, 0x80f0, 0x6c00
+ax_pose 23, 0x01e6, 0x80f0, 0x6c08
+ax_pose_terminator
+sGravelerPose68:
+ax_pose 23, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose69:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose70:
+ax_pose 22, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose71:
+ax_pose 28, 0x01e6, 0x80ee, 0x6c00
+ax_pose 21, 0x01e6, 0x80ee, 0x6c10
+ax_pose_terminator
+sGravelerPose72:
+ax_pose 21, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose73:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose74:
+ax_pose 20, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sGravelerPose75:
+ax_pose 27, 0x01e6, 0x80ed, 0x6c00
+ax_pose 19, 0x01e6, 0x80ee, 0x6c10
+ax_pose_terminator
+sGravelerPose76:
+ax_pose 19, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose77:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose78:
+ax_pose 18, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose79:
+ax_pose 26, 0x01e6, 0x80f0, 0x6c00
+ax_pose 17, 0x01e6, 0x80f0, 0x6c10
+ax_pose_terminator
+sGravelerPose80:
+ax_pose 17, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose81:
+ax_pose 31, 0x41f2, 0x80f0, 0x6c00
+ax_pose 32, 0x41ea, 0x00f8, 0x6c08
+ax_pose 33, 0x01f5, 0x00e8, 0x6c0a
+ax_pose 34, 0x01f7, 0x0110, 0x6c0b
+ax_pose_terminator
+sGravelerPose82:
+ax_pose 35, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose83:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose84:
+ax_pose 37, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose85:
+ax_pose 38, 0x41ee, 0x80f0, 0x6c00
+ax_pose 39, 0x41fe, 0x40f0, 0x6c08
+ax_pose 40, 0x01fb, 0x00e8, 0x6c0c
+ax_pose 41, 0x01fb, 0x0110, 0x6c0d
+ax_pose_terminator
+sGravelerPose86:
+ax_pose 37, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sGravelerPose87:
+ax_pose 36, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sGravelerPose88:
+ax_pose 35, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose89:
+ax_pose 0, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose90:
+ax_pose 31, 0x41f2, 0x80f0, 0x6c00
+ax_pose 32, 0x41ea, 0x00f8, 0x6c08
+ax_pose 33, 0x01f5, 0x00e8, 0x6c0a
+ax_pose 34, 0x01f7, 0x0110, 0x6c0b
+ax_pose_terminator
+sGravelerPose91:
+ax_pose 42, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose92:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose93:
+ax_pose 35, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose94:
+ax_pose 43, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sGravelerPose95:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose96:
+ax_pose 36, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose97:
+ax_pose 44, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sGravelerPose98:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose99:
+ax_pose 37, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sGravelerPose100:
+ax_pose 45, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose101:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose102:
+ax_pose 38, 0x41ee, 0x80f0, 0x6c00
+ax_pose 39, 0x41fe, 0x40f0, 0x6c08
+ax_pose 40, 0x01fb, 0x00e8, 0x6c0c
+ax_pose 41, 0x01fb, 0x0110, 0x6c0d
+ax_pose_terminator
+sGravelerPose103:
+ax_pose 24, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose104:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose105:
+ax_pose 37, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose106:
+ax_pose 45, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose107:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose108:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose109:
+ax_pose 44, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sGravelerPose110:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose111:
+ax_pose 35, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose112:
+ax_pose 43, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sGravelerPose113:
+ax_pose 46, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose114:
+ax_pose 47, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose115:
+ax_pose 48, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose116:
+ax_pose 49, 0x01e5, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose117:
+ax_pose 50, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose118:
+ax_pose 51, 0x01e3, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose119:
+ax_pose 52, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose120:
+ax_pose 51, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose121:
+ax_pose 50, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose122:
+ax_pose 49, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose123:
+ax_pose 0, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose124:
+ax_pose 16, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose125:
+ax_pose 25, 0x01ea, 0x80f0, 0x6c00
+ax_pose 15, 0x01ea, 0x80f0, 0x6c10
+ax_pose_terminator
+sGravelerPose126:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose127:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose128:
+ax_pose 18, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose129:
+ax_pose 26, 0x01e6, 0x90ef, 0x6c00
+ax_pose 17, 0x01e6, 0x90ef, 0x6c10
+ax_pose_terminator
+sGravelerPose130:
+ax_pose 17, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose131:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose132:
+ax_pose 20, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sGravelerPose133:
+ax_pose 27, 0x01e6, 0x90f2, 0x6c00
+ax_pose 19, 0x01e6, 0x90f1, 0x6c10
+ax_pose_terminator
+sGravelerPose134:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose135:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose136:
+ax_pose 22, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose137:
+ax_pose 28, 0x01e6, 0x90f1, 0x6c00
+ax_pose 21, 0x01e6, 0x90f1, 0x6c10
+ax_pose_terminator
+sGravelerPose138:
+ax_pose 21, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose139:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose140:
+ax_pose 29, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose141:
+ax_pose 30, 0x41e7, 0x80f0, 0x6c00
+ax_pose 23, 0x01e6, 0x80f0, 0x6c08
+ax_pose_terminator
+sGravelerPose142:
+ax_pose 23, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose143:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose144:
+ax_pose 22, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sGravelerPose145:
+ax_pose 28, 0x01e6, 0x80ee, 0x6c00
+ax_pose 21, 0x01e6, 0x80ee, 0x6c10
+ax_pose_terminator
+sGravelerPose146:
+ax_pose 21, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose147:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose148:
+ax_pose 20, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sGravelerPose149:
+ax_pose 27, 0x01e6, 0x80ed, 0x6c00
+ax_pose 19, 0x01e6, 0x80ee, 0x6c10
+ax_pose_terminator
+sGravelerPose150:
+ax_pose 19, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose151:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose152:
+ax_pose 18, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose153:
+ax_pose 26, 0x01e6, 0x80f0, 0x6c00
+ax_pose 17, 0x01e6, 0x80f0, 0x6c10
+ax_pose_terminator
+sGravelerPose154:
+ax_pose 17, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose155:
+ax_pose 31, 0x41f2, 0x80f0, 0x6c00
+ax_pose 32, 0x41ea, 0x00f8, 0x6c08
+ax_pose 33, 0x01f5, 0x00e8, 0x6c0a
+ax_pose 34, 0x01f7, 0x0110, 0x6c0b
+ax_pose_terminator
+sGravelerPose156:
+ax_pose 35, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose157:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose158:
+ax_pose 37, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose159:
+ax_pose 38, 0x41ee, 0x80f0, 0x6c00
+ax_pose 39, 0x41fe, 0x40f0, 0x6c08
+ax_pose 40, 0x01fb, 0x00e8, 0x6c0c
+ax_pose 41, 0x01fb, 0x0110, 0x6c0d
+ax_pose_terminator
+sGravelerPose160:
+ax_pose 37, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sGravelerPose161:
+ax_pose 36, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sGravelerPose162:
+ax_pose 35, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose163:
+ax_pose 31, 0x41f2, 0x80f0, 0x6c00
+ax_pose 32, 0x41ea, 0x00f8, 0x6c08
+ax_pose 33, 0x01f5, 0x00e8, 0x6c0a
+ax_pose 34, 0x01f7, 0x0110, 0x6c0b
+ax_pose_terminator
+sGravelerPose164:
+ax_pose 35, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose165:
+ax_pose 36, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sGravelerPose166:
+ax_pose 37, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sGravelerPose167:
+ax_pose 38, 0x41ee, 0x80f0, 0x6c00
+ax_pose 39, 0x41fe, 0x40f0, 0x6c08
+ax_pose 40, 0x01fb, 0x00e8, 0x6c0c
+ax_pose 41, 0x01fb, 0x0110, 0x6c0d
+ax_pose_terminator
+sGravelerPose168:
+ax_pose 37, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose169:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose170:
+ax_pose 35, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose171:
+ax_pose 0, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose172:
+ax_pose 16, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose173:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose174:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose175:
+ax_pose 18, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose176:
+ax_pose 17, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose177:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose178:
+ax_pose 20, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose179:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose180:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose181:
+ax_pose 22, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose182:
+ax_pose 21, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sGravelerPose183:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose184:
+ax_pose 29, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose185:
+ax_pose 23, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose186:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose187:
+ax_pose 22, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose188:
+ax_pose 21, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose189:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose190:
+ax_pose 20, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose191:
+ax_pose 19, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose192:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose193:
+ax_pose 18, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sGravelerPose194:
+ax_pose 17, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose195:
+ax_pose 31, 0x41f2, 0x80f0, 0x6c00
+ax_pose 32, 0x41ea, 0x00f8, 0x6c08
+ax_pose 33, 0x01f5, 0x00e8, 0x6c0a
+ax_pose 34, 0x01f7, 0x0110, 0x6c0b
+ax_pose_terminator
+sGravelerPose196:
+ax_pose 35, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose197:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose198:
+ax_pose 37, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sGravelerPose199:
+ax_pose 38, 0x41ee, 0x80f0, 0x6c00
+ax_pose 39, 0x41fe, 0x40f0, 0x6c08
+ax_pose 40, 0x01fb, 0x00e8, 0x6c0c
+ax_pose 41, 0x01fb, 0x0110, 0x6c0d
+ax_pose_terminator
+sGravelerPose200:
+ax_pose 37, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sGravelerPose201:
+ax_pose 36, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sGravelerPose202:
+ax_pose 35, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sGravelerPose203:
+ax_pose 0, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose204:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose205:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sGravelerPose206:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose207:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sGravelerPose208:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sGravelerPose209:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sGravelerPose210:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+.align 2
+sGravelerAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sGravelerAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 20, 20, 20, 20,
+ax_anim 2, 1, 27, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 20, 20, 20, 20,
+ax_anim 2, 0, 27, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim_terminator
+sGravelerAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sGravelerAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -3, 3, -3, 3,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 33, 12, -14, 12, -14,
+ax_anim 2, 0, 33, 19, -23, 19, -23,
+ax_anim 2, 1, 33, 20, -22, 20, -22,
+ax_anim 2, 0, 33, 19, -23, 19, -23,
+ax_anim 2, 0, 33, 20, -22, 20, -22,
+ax_anim 2, 0, 35, 8, -8, 8, -8,
+ax_anim_terminator
+sGravelerAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -14, 0, -14,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 1, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 0, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim_terminator
+sGravelerAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 3, 3, 3, 3,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -6, -6, -6, -6,
+ax_anim 1, 0, 39, -12, -14, -12, -14,
+ax_anim 2, 0, 39, -19, -23, -19, -23,
+ax_anim 2, 1, 39, -20, -22, -20, -22,
+ax_anim 2, 0, 39, -19, -23, -19, -23,
+ax_anim 2, 0, 39, -20, -22, -20, -22,
+ax_anim 2, 0, 41, -8, -8, -8, -8,
+ax_anim_terminator
+sGravelerAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -6, 0, -6, 0,
+ax_anim_terminator
+sGravelerAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -20, 20, -20, 20,
+ax_anim 2, 1, 45, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -20, 20, -20, 20,
+ax_anim 2, 0, 45, -21, 19, -21, 19,
+ax_anim 2, 0, 47, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGravelerAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 1, 2, 49, 0, 2, 0, 2,
+ax_anim 1, 0, 49, 0, 7, 0, 7,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 1, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 1, 17, 1, 17,
+ax_anim 2, 0, 48, 0, 9, 0, 9,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sGravelerAnims_3_2:
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 1, 2, 53, 2, 2, 2, 2,
+ax_anim 1, 0, 53, 7, 7, 7, 7,
+ax_anim 2, 0, 54, 17, 17, 17, 17,
+ax_anim 2, 1, 55, 18, 16, 18, 16,
+ax_anim 2, 0, 55, 17, 17, 17, 17,
+ax_anim 2, 0, 55, 18, 16, 18, 16,
+ax_anim 2, 0, 55, 17, 17, 17, 17,
+ax_anim 2, 0, 55, 18, 16, 18, 16,
+ax_anim 2, 0, 52, 9, 9, 9, 9,
+ax_anim 2, 0, 52, 3, 3, 3, 3,
+ax_anim_terminator
+sGravelerAnims_3_3:
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 6, 0, 57, -3, 0, -3, 0,
+ax_anim 1, 2, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 57, 6, 0, 6, 0,
+ax_anim 2, 0, 58, 12, 0, 12, 0,
+ax_anim 2, 1, 59, 12, 1, 12, 1,
+ax_anim 2, 0, 59, 12, 0, 12, 0,
+ax_anim 2, 0, 59, 12, 1, 12, 1,
+ax_anim 2, 0, 59, 12, 0, 12, 0,
+ax_anim 2, 0, 59, 12, 1, 12, 1,
+ax_anim 2, 0, 56, 7, 0, 7, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim_terminator
+sGravelerAnims_3_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 1, 2, 61, 2, -3, 2, -3,
+ax_anim 1, 0, 61, 7, -9, 7, -9,
+ax_anim 2, 0, 62, 13, -17, 13, -17,
+ax_anim 2, 1, 63, 14, -16, 14, -16,
+ax_anim 2, 0, 63, 13, -17, 13, -17,
+ax_anim 2, 0, 63, 14, -16, 14, -16,
+ax_anim 2, 0, 63, 13, -17, 13, -17,
+ax_anim 2, 0, 63, 14, -16, 14, -16,
+ax_anim 2, 0, 60, 9, -11, 9, -11,
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim_terminator
+sGravelerAnims_3_5:
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 1, 2, 65, 0, -3, 0, -3,
+ax_anim 1, 0, 65, 0, -8, 0, -8,
+ax_anim 2, 0, 66, 0, -17, 0, -17,
+ax_anim 2, 1, 67, 1, -17, 1, -17,
+ax_anim 2, 0, 67, 0, -17, 0, -17,
+ax_anim 2, 0, 67, 1, -17, 1, -17,
+ax_anim 2, 0, 67, 0, -17, 0, -17,
+ax_anim 2, 0, 67, 1, -17, 1, -17,
+ax_anim 2, 0, 64, 0, -11, 0, -11,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sGravelerAnims_3_6:
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 1, 2, 69, -2, -3, -2, -3,
+ax_anim 1, 0, 69, -7, -9, -7, -9,
+ax_anim 2, 0, 70, -13, -17, -13, -17,
+ax_anim 2, 1, 71, -14, -16, -14, -16,
+ax_anim 2, 0, 71, -13, -17, -13, -17,
+ax_anim 2, 0, 71, -14, -16, -14, -16,
+ax_anim 2, 0, 71, -13, -17, -13, -17,
+ax_anim 2, 0, 71, -14, -16, -14, -16,
+ax_anim 2, 0, 68, -9, -11, -9, -11,
+ax_anim 2, 0, 68, -3, -3, -3, -3,
+ax_anim_terminator
+sGravelerAnims_3_7:
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 6, 0, 73, 3, 0, 3, 0,
+ax_anim 1, 2, 73, -2, 0, -2, 0,
+ax_anim 1, 0, 73, -6, 0, -6, 0,
+ax_anim 2, 0, 74, -12, 0, -12, 0,
+ax_anim 2, 1, 75, -12, 1, -12, 1,
+ax_anim 2, 0, 75, -12, 0, -12, 0,
+ax_anim 2, 0, 75, -12, 1, -12, 1,
+ax_anim 2, 0, 75, -12, 0, -12, 0,
+ax_anim 2, 0, 75, -12, 1, -12, 1,
+ax_anim 2, 0, 72, -7, 0, -7, 0,
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim_terminator
+sGravelerAnims_3_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 1, 2, 77, -2, 2, -2, 2,
+ax_anim 1, 0, 77, -7, 7, -7, 7,
+ax_anim 2, 0, 78, -17, 17, -17, 17,
+ax_anim 2, 1, 79, -18, 16, -18, 16,
+ax_anim 2, 0, 79, -17, 17, -17, 17,
+ax_anim 2, 0, 79, -18, 16, -18, 16,
+ax_anim 2, 0, 79, -17, 17, -17, 17,
+ax_anim 2, 0, 79, -18, 16, -18, 16,
+ax_anim 2, 0, 76, -9, 9, -9, 9,
+ax_anim 2, 0, 76, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sGravelerAnims_4_1:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_4_2:
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_4_3:
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_4_4:
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_4_5:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_4_6:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_4_7:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_4_8:
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_5_1:
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -8, 0, 0,
+ax_anim 4, 0, 90, 0, -10, 0, 0,
+ax_anim 4, 0, 88, 0, -11, 0, 0,
+ax_anim 2, 0, 89, 0, -8, 0, 0,
+ax_anim 1, 0, 89, 0, -4, 0, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_5_2:
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -8, 0, 0,
+ax_anim 4, 0, 93, 0, -10, 0, 0,
+ax_anim 4, 0, 91, 0, -11, 0, 0,
+ax_anim 2, 0, 92, 0, -9, 0, 0,
+ax_anim 1, 0, 92, 0, -4, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_5_3:
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, 0,
+ax_anim 4, 0, 96, 0, -10, 0, 0,
+ax_anim 4, 0, 94, 0, -12, 0, 0,
+ax_anim 2, 0, 95, 0, -9, 0, 0,
+ax_anim 1, 0, 95, 0, -4, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, -1, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_5_4:
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -8, 0, 0,
+ax_anim 4, 0, 99, 0, -10, 0, 0,
+ax_anim 4, 0, 97, 0, -11, 0, 0,
+ax_anim 2, 0, 98, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -4, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_5_5:
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -8, 0, 0,
+ax_anim 4, 0, 102, 0, -10, 0, 0,
+ax_anim 4, 0, 100, 0, -11, 0, 0,
+ax_anim 2, 0, 101, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -4, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_5_6:
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -8, 0, 0,
+ax_anim 4, 0, 105, 0, -10, 0, 0,
+ax_anim 4, 0, 103, 0, -11, 0, 0,
+ax_anim 2, 0, 104, 0, -8, 0, 0,
+ax_anim 1, 0, 104, 0, -4, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_5_7:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, 0,
+ax_anim 4, 0, 108, 0, -10, 0, 0,
+ax_anim 4, 0, 106, 0, -12, 0, 0,
+ax_anim 2, 0, 107, 0, -8, 0, 0,
+ax_anim 1, 0, 107, 0, -4, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_5_8:
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -8, 0, 0,
+ax_anim 4, 0, 111, 0, -10, 0, 0,
+ax_anim 4, 0, 109, 0, -11, 0, 0,
+ax_anim 2, 0, 110, 0, -8, 0, 0,
+ax_anim 1, 0, 110, 0, -4, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sGravelerAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sGravelerAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sGravelerAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sGravelerAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sGravelerAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sGravelerAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sGravelerAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGravelerAnims_8_1:
+ax_anim 60, 0, 122, 0, 0, 0, 0,
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_8_2:
+ax_anim 60, 0, 126, 0, 0, 0, 0,
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_8_3:
+ax_anim 60, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_8_4:
+ax_anim 60, 0, 134, 0, 0, 0, 0,
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_8_5:
+ax_anim 60, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_8_6:
+ax_anim 60, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, 0, -1, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_8_7:
+ax_anim 60, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_8_8:
+ax_anim 60, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 17, 7, 17,
+ax_anim 3, 0, 158, 0, 20, 0, 20,
+ax_anim 2, 3, 159, -7, 17, -7, 17,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 19, 10, 19, 10,
+ax_anim 3, 0, 157, 21, 19, 21, 19,
+ax_anim 2, 3, 158, 11, 21, 11, 21,
+ax_anim 2, 0, 159, 2, 17, 2, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -5, 16, -5,
+ax_anim 3, 0, 156, 21, -2, 21, -2,
+ax_anim 2, 3, 157, 19, 4, 19, 4,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -18, 4, -18,
+ax_anim 2, 0, 154, 13, -23, 13, -23,
+ax_anim 3, 0, 155, 20, -22, 20, -22,
+ax_anim 2, 3, 156, 22, -13, 22, -13,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 9, 1, 9, 1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -18, -4, -18,
+ax_anim 2, 0, 154, -13, -23, -13, -23,
+ax_anim 3, 0, 161, -20, -22, -20, -22,
+ax_anim 2, 3, 160, -22, -13, -22, -13,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -8, -1, -8, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -5, -16, -5,
+ax_anim 3, 0, 160, -21, -2, -21, -2,
+ax_anim 2, 3, 159, -19, 4, -19, 4,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -19, 10, -19, 10,
+ax_anim 3, 0, 159, -20, 19, -20, 19,
+ax_anim 2, 3, 158, -11, 21, -11, 21,
+ax_anim 2, 0, 157, -2, 17, -2, 17,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -22, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGravelerAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sGravelerGfx1:
+.incbin "baserom.gba", 0x840080, 0x200
+sGravelerSprites1:
+ax_sprite sGravelerGfx1, 0x200
+ax_sprite_terminator
+sGravelerGfx2:
+.incbin "baserom.gba", 0x840290, 0x200
+sGravelerSprites2:
+ax_sprite sGravelerGfx2, 0x200
+ax_sprite_terminator
+sGravelerGfx3:
+.incbin "baserom.gba", 0x8404A0, 0x200
+sGravelerSprites3:
+ax_sprite sGravelerGfx3, 0x200
+ax_sprite_terminator
+sGravelerGfx4:
+.incbin "baserom.gba", 0x8406B0, 0x200
+sGravelerSprites4:
+ax_sprite sGravelerGfx4, 0x200
+ax_sprite_terminator
+sGravelerGfx5:
+.incbin "baserom.gba", 0x8408C0, 0x200
+sGravelerSprites5:
+ax_sprite sGravelerGfx5, 0x200
+ax_sprite_terminator
+sGravelerGfx6:
+.incbin "baserom.gba", 0x840AD0, 0x200
+sGravelerSprites6:
+ax_sprite sGravelerGfx6, 0x200
+ax_sprite_terminator
+sGravelerGfx7:
+.incbin "baserom.gba", 0x840CE0, 0x200
+sGravelerSprites7:
+ax_sprite sGravelerGfx7, 0x200
+ax_sprite_terminator
+sGravelerGfx8:
+.incbin "baserom.gba", 0x840EF0, 0x200
+sGravelerSprites8:
+ax_sprite sGravelerGfx8, 0x200
+ax_sprite_terminator
+sGravelerGfx9:
+.incbin "baserom.gba", 0x841100, 0x200
+sGravelerSprites9:
+ax_sprite sGravelerGfx9, 0x200
+ax_sprite_terminator
+sGravelerGfx10:
+.incbin "baserom.gba", 0x841310, 0x200
+sGravelerSprites10:
+ax_sprite sGravelerGfx10, 0x200
+ax_sprite_terminator
+sGravelerGfx11:
+.incbin "baserom.gba", 0x841520, 0x200
+sGravelerSprites11:
+ax_sprite sGravelerGfx11, 0x200
+ax_sprite_terminator
+sGravelerGfx12:
+.incbin "baserom.gba", 0x841730, 0x200
+sGravelerSprites12:
+ax_sprite sGravelerGfx12, 0x200
+ax_sprite_terminator
+sGravelerGfx13:
+.incbin "baserom.gba", 0x841940, 0x200
+sGravelerSprites13:
+ax_sprite sGravelerGfx13, 0x200
+ax_sprite_terminator
+sGravelerGfx14:
+.incbin "baserom.gba", 0x841B50, 0x200
+sGravelerSprites14:
+ax_sprite sGravelerGfx14, 0x200
+ax_sprite_terminator
+sGravelerGfx15:
+.incbin "baserom.gba", 0x841D60, 0x200
+sGravelerSprites15:
+ax_sprite sGravelerGfx15, 0x200
+ax_sprite_terminator
+sGravelerGfx16:
+.incbin "baserom.gba", 0x841F70, 0x40
+sGravelerGfx16_1:
+.incbin "baserom.gba", 0x841FB0, 0x180
+sGravelerSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx16_1, 0x180
+ax_sprite_terminator
+sGravelerGfx17:
+.incbin "baserom.gba", 0x842158, 0x180
+sGravelerSprites17:
+ax_sprite sGravelerGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGravelerGfx18:
+.incbin "baserom.gba", 0x8422F0, 0x160
+sGravelerSprites18:
+ax_sprite 0, 0x80
+ax_sprite sGravelerGfx18, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx19:
+.incbin "baserom.gba", 0x842470, 0x160
+sGravelerGfx19_1:
+.incbin "baserom.gba", 0x8425D0, 0x40
+sGravelerSprites19:
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx19, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx20:
+.incbin "baserom.gba", 0x842640, 0x140
+sGravelerSprites20:
+ax_sprite 0, 0xa0
+ax_sprite sGravelerGfx20, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx21:
+.incbin "baserom.gba", 0x8427A0, 0x40
+sGravelerGfx21_1:
+.incbin "baserom.gba", 0x8427E0, 0x60
+sGravelerGfx21_2:
+.incbin "baserom.gba", 0x842840, 0x60
+sGravelerGfx21_3:
+.incbin "baserom.gba", 0x8428A0, 0x40
+sGravelerSprites21:
+ax_sprite 0, 0x40
+ax_sprite sGravelerGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx22:
+.incbin "baserom.gba", 0x842930, 0x140
+sGravelerSprites22:
+ax_sprite 0, 0xa0
+ax_sprite sGravelerGfx22, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx23:
+.incbin "baserom.gba", 0x842A90, 0x40
+sGravelerGfx23_1:
+.incbin "baserom.gba", 0x842AD0, 0x140
+sGravelerSprites23:
+ax_sprite 0, 0x40
+ax_sprite sGravelerGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx23_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx24:
+.incbin "baserom.gba", 0x842C40, 0x160
+sGravelerSprites24:
+ax_sprite 0, 0x80
+ax_sprite sGravelerGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx25:
+.incbin "baserom.gba", 0x842DC0, 0x180
+sGravelerSprites25:
+ax_sprite sGravelerGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGravelerGfx26:
+.incbin "baserom.gba", 0x842F58, 0x200
+sGravelerSprites26:
+ax_sprite sGravelerGfx26, 0x200
+ax_sprite_terminator
+sGravelerGfx27:
+.incbin "baserom.gba", 0x843168, 0xC0
+sGravelerGfx27_1:
+.incbin "baserom.gba", 0x843228, 0x60
+sGravelerGfx27_2:
+.incbin "baserom.gba", 0x843288, 0x60
+sGravelerSprites27:
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx27, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx28:
+.incbin "baserom.gba", 0x843328, 0xC0
+sGravelerGfx28_1:
+.incbin "baserom.gba", 0x8433E8, 0x40
+sGravelerGfx28_2:
+.incbin "baserom.gba", 0x843428, 0x40
+sGravelerSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx28, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGravelerGfx28_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGravelerGfx29:
+.incbin "baserom.gba", 0x8434A8, 0x120
+sGravelerGfx29_1:
+.incbin "baserom.gba", 0x8435C8, 0x20
+sGravelerSprites29:
+ax_sprite sGravelerGfx29, 0x120
+ax_sprite 0, 0x60
+ax_sprite sGravelerGfx29_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sGravelerGfx30:
+.incbin "baserom.gba", 0x843610, 0x40
+sGravelerGfx30_1:
+.incbin "baserom.gba", 0x843650, 0x160
+sGravelerSprites30:
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx30_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx31:
+.incbin "baserom.gba", 0x8437E0, 0x100
+sGravelerSprites31:
+ax_sprite sGravelerGfx31, 0x100
+ax_sprite_terminator
+sGravelerGfx32:
+.incbin "baserom.gba", 0x8438F0, 0x100
+sGravelerSprites32:
+ax_sprite sGravelerGfx32, 0x100
+ax_sprite_terminator
+sGravelerGfx33:
+.incbin "baserom.gba", 0x843A00, 0x40
+sGravelerSprites33:
+ax_sprite sGravelerGfx33, 0x40
+ax_sprite_terminator
+sGravelerGfx34:
+.incbin "baserom.gba", 0x843A50, 0x20
+sGravelerSprites34:
+ax_sprite sGravelerGfx34, 0x20
+ax_sprite_terminator
+sGravelerGfx35:
+.incbin "baserom.gba", 0x843A80, 0x20
+sGravelerSprites35:
+ax_sprite sGravelerGfx35, 0x20
+ax_sprite_terminator
+sGravelerGfx36:
+.incbin "baserom.gba", 0x843AB0, 0x60
+sGravelerGfx36_1:
+.incbin "baserom.gba", 0x843B10, 0x100
+sGravelerSprites36:
+ax_sprite 0, 0x80
+ax_sprite sGravelerGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx36_1, 0x100
+ax_sprite_terminator
+sGravelerGfx37:
+.incbin "baserom.gba", 0x843C38, 0x60
+sGravelerGfx37_1:
+.incbin "baserom.gba", 0x843C98, 0x100
+sGravelerSprites37:
+ax_sprite 0, 0x80
+ax_sprite sGravelerGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx37_1, 0x100
+ax_sprite_terminator
+sGravelerGfx38:
+.incbin "baserom.gba", 0x843DC0, 0x60
+sGravelerGfx38_1:
+.incbin "baserom.gba", 0x843E20, 0x60
+sGravelerGfx38_2:
+.incbin "baserom.gba", 0x843E80, 0x60
+sGravelerSprites38:
+ax_sprite 0, 0x80
+ax_sprite sGravelerGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx39:
+.incbin "baserom.gba", 0x843F20, 0x60
+sGravelerGfx39_1:
+.incbin "baserom.gba", 0x843F80, 0x80
+sGravelerSprites39:
+ax_sprite sGravelerGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx39_1, 0x80
+ax_sprite_terminator
+sGravelerGfx40:
+.incbin "baserom.gba", 0x844020, 0x80
+sGravelerSprites40:
+ax_sprite sGravelerGfx40, 0x80
+ax_sprite_terminator
+sGravelerGfx41:
+.incbin "baserom.gba", 0x8440B0, 0x20
+sGravelerSprites41:
+ax_sprite sGravelerGfx41, 0x20
+ax_sprite_terminator
+sGravelerGfx42:
+.incbin "baserom.gba", 0x8440E0, 0x20
+sGravelerSprites42:
+ax_sprite sGravelerGfx42, 0x20
+ax_sprite_terminator
+sGravelerGfx43:
+.incbin "baserom.gba", 0x844110, 0x180
+sGravelerSprites43:
+ax_sprite sGravelerGfx43, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGravelerGfx44:
+.incbin "baserom.gba", 0x8442A8, 0x160
+sGravelerGfx44_1:
+.incbin "baserom.gba", 0x844408, 0x40
+sGravelerSprites44:
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx44, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx44_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx45:
+.incbin "baserom.gba", 0x844478, 0x140
+sGravelerGfx45_1:
+.incbin "baserom.gba", 0x8445B8, 0x40
+sGravelerSprites45:
+ax_sprite 0, 0x40
+ax_sprite sGravelerGfx45, 0x140
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx45_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx46:
+.incbin "baserom.gba", 0x844628, 0x140
+sGravelerGfx46_1:
+.incbin "baserom.gba", 0x844768, 0x60
+sGravelerSprites46:
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx46, 0x140
+ax_sprite 0, 0x20
+ax_sprite sGravelerGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGravelerGfx47:
+.incbin "baserom.gba", 0x8447F8, 0x200
+sGravelerSprites47:
+ax_sprite sGravelerGfx47, 0x200
+ax_sprite_terminator
+sGravelerGfx48:
+.incbin "baserom.gba", 0x844A08, 0x200
+sGravelerSprites48:
+ax_sprite sGravelerGfx48, 0x200
+ax_sprite_terminator
+sGravelerGfx49:
+.incbin "baserom.gba", 0x844C18, 0x200
+sGravelerSprites49:
+ax_sprite sGravelerGfx49, 0x200
+ax_sprite_terminator
+sGravelerGfx50:
+.incbin "baserom.gba", 0x844E28, 0x200
+sGravelerSprites50:
+ax_sprite sGravelerGfx50, 0x200
+ax_sprite_terminator
+sGravelerGfx51:
+.incbin "baserom.gba", 0x845038, 0x200
+sGravelerSprites51:
+ax_sprite sGravelerGfx51, 0x200
+ax_sprite_terminator
+sGravelerGfx52:
+.incbin "baserom.gba", 0x845248, 0x200
+sGravelerSprites52:
+ax_sprite sGravelerGfx52, 0x200
+ax_sprite_terminator
+sGravelerGfx53:
+.incbin "baserom.gba", 0x845458, 0x200
+sGravelerSprites53:
+ax_sprite sGravelerGfx53, 0x200
+ax_sprite_terminator
+sAxPosesGraveler:
+.4byte sGravelerPose1
+.4byte sGravelerPose2
+.4byte sGravelerPose3
+.4byte sGravelerPose4
+.4byte sGravelerPose5
+.4byte sGravelerPose6
+.4byte sGravelerPose7
+.4byte sGravelerPose8
+.4byte sGravelerPose9
+.4byte sGravelerPose10
+.4byte sGravelerPose11
+.4byte sGravelerPose12
+.4byte sGravelerPose13
+.4byte sGravelerPose14
+.4byte sGravelerPose15
+.4byte sGravelerPose16
+.4byte sGravelerPose17
+.4byte sGravelerPose18
+.4byte sGravelerPose19
+.4byte sGravelerPose20
+.4byte sGravelerPose21
+.4byte sGravelerPose22
+.4byte sGravelerPose23
+.4byte sGravelerPose24
+.4byte sGravelerPose25
+.4byte sGravelerPose26
+.4byte sGravelerPose27
+.4byte sGravelerPose28
+.4byte sGravelerPose29
+.4byte sGravelerPose30
+.4byte sGravelerPose31
+.4byte sGravelerPose32
+.4byte sGravelerPose33
+.4byte sGravelerPose34
+.4byte sGravelerPose35
+.4byte sGravelerPose36
+.4byte sGravelerPose37
+.4byte sGravelerPose38
+.4byte sGravelerPose39
+.4byte sGravelerPose40
+.4byte sGravelerPose41
+.4byte sGravelerPose42
+.4byte sGravelerPose43
+.4byte sGravelerPose44
+.4byte sGravelerPose45
+.4byte sGravelerPose46
+.4byte sGravelerPose47
+.4byte sGravelerPose48
+.4byte sGravelerPose49
+.4byte sGravelerPose50
+.4byte sGravelerPose51
+.4byte sGravelerPose52
+.4byte sGravelerPose53
+.4byte sGravelerPose54
+.4byte sGravelerPose55
+.4byte sGravelerPose56
+.4byte sGravelerPose57
+.4byte sGravelerPose58
+.4byte sGravelerPose59
+.4byte sGravelerPose60
+.4byte sGravelerPose61
+.4byte sGravelerPose62
+.4byte sGravelerPose63
+.4byte sGravelerPose64
+.4byte sGravelerPose65
+.4byte sGravelerPose66
+.4byte sGravelerPose67
+.4byte sGravelerPose68
+.4byte sGravelerPose69
+.4byte sGravelerPose70
+.4byte sGravelerPose71
+.4byte sGravelerPose72
+.4byte sGravelerPose73
+.4byte sGravelerPose74
+.4byte sGravelerPose75
+.4byte sGravelerPose76
+.4byte sGravelerPose77
+.4byte sGravelerPose78
+.4byte sGravelerPose79
+.4byte sGravelerPose80
+.4byte sGravelerPose81
+.4byte sGravelerPose82
+.4byte sGravelerPose83
+.4byte sGravelerPose84
+.4byte sGravelerPose85
+.4byte sGravelerPose86
+.4byte sGravelerPose87
+.4byte sGravelerPose88
+.4byte sGravelerPose89
+.4byte sGravelerPose90
+.4byte sGravelerPose91
+.4byte sGravelerPose92
+.4byte sGravelerPose93
+.4byte sGravelerPose94
+.4byte sGravelerPose95
+.4byte sGravelerPose96
+.4byte sGravelerPose97
+.4byte sGravelerPose98
+.4byte sGravelerPose99
+.4byte sGravelerPose100
+.4byte sGravelerPose101
+.4byte sGravelerPose102
+.4byte sGravelerPose103
+.4byte sGravelerPose104
+.4byte sGravelerPose105
+.4byte sGravelerPose106
+.4byte sGravelerPose107
+.4byte sGravelerPose108
+.4byte sGravelerPose109
+.4byte sGravelerPose110
+.4byte sGravelerPose111
+.4byte sGravelerPose112
+.4byte sGravelerPose113
+.4byte sGravelerPose114
+.4byte sGravelerPose115
+.4byte sGravelerPose116
+.4byte sGravelerPose117
+.4byte sGravelerPose118
+.4byte sGravelerPose119
+.4byte sGravelerPose120
+.4byte sGravelerPose121
+.4byte sGravelerPose122
+.4byte sGravelerPose123
+.4byte sGravelerPose124
+.4byte sGravelerPose125
+.4byte sGravelerPose126
+.4byte sGravelerPose127
+.4byte sGravelerPose128
+.4byte sGravelerPose129
+.4byte sGravelerPose130
+.4byte sGravelerPose131
+.4byte sGravelerPose132
+.4byte sGravelerPose133
+.4byte sGravelerPose134
+.4byte sGravelerPose135
+.4byte sGravelerPose136
+.4byte sGravelerPose137
+.4byte sGravelerPose138
+.4byte sGravelerPose139
+.4byte sGravelerPose140
+.4byte sGravelerPose141
+.4byte sGravelerPose142
+.4byte sGravelerPose143
+.4byte sGravelerPose144
+.4byte sGravelerPose145
+.4byte sGravelerPose146
+.4byte sGravelerPose147
+.4byte sGravelerPose148
+.4byte sGravelerPose149
+.4byte sGravelerPose150
+.4byte sGravelerPose151
+.4byte sGravelerPose152
+.4byte sGravelerPose153
+.4byte sGravelerPose154
+.4byte sGravelerPose155
+.4byte sGravelerPose156
+.4byte sGravelerPose157
+.4byte sGravelerPose158
+.4byte sGravelerPose159
+.4byte sGravelerPose160
+.4byte sGravelerPose161
+.4byte sGravelerPose162
+.4byte sGravelerPose163
+.4byte sGravelerPose164
+.4byte sGravelerPose165
+.4byte sGravelerPose166
+.4byte sGravelerPose167
+.4byte sGravelerPose168
+.4byte sGravelerPose169
+.4byte sGravelerPose170
+.4byte sGravelerPose171
+.4byte sGravelerPose172
+.4byte sGravelerPose173
+.4byte sGravelerPose174
+.4byte sGravelerPose175
+.4byte sGravelerPose176
+.4byte sGravelerPose177
+.4byte sGravelerPose178
+.4byte sGravelerPose179
+.4byte sGravelerPose180
+.4byte sGravelerPose181
+.4byte sGravelerPose182
+.4byte sGravelerPose183
+.4byte sGravelerPose184
+.4byte sGravelerPose185
+.4byte sGravelerPose186
+.4byte sGravelerPose187
+.4byte sGravelerPose188
+.4byte sGravelerPose189
+.4byte sGravelerPose190
+.4byte sGravelerPose191
+.4byte sGravelerPose192
+.4byte sGravelerPose193
+.4byte sGravelerPose194
+.4byte sGravelerPose195
+.4byte sGravelerPose196
+.4byte sGravelerPose197
+.4byte sGravelerPose198
+.4byte sGravelerPose199
+.4byte sGravelerPose200
+.4byte sGravelerPose201
+.4byte sGravelerPose202
+.4byte sGravelerPose203
+.4byte sGravelerPose204
+.4byte sGravelerPose205
+.4byte sGravelerPose206
+.4byte sGravelerPose207
+.4byte sGravelerPose208
+.4byte sGravelerPose209
+.4byte sGravelerPose210
+sAxPositionsGraveler:
+.2byte   -1,   -8, 	  -8,  -18, 	   6,  -18, 	  -1,   -9
+.2byte   -2,   -7, 	 -11,  -17, 	   4,  -15, 	  -1,   -8
+.2byte    0,   -7, 	  -5,  -15, 	   9,  -17, 	  -1,   -8
+.2byte    2,   -9, 	   5,  -22, 	  -5,  -17, 	  -2,   -9
+.2byte    3,   -7, 	   3,  -23, 	   0,  -17, 	  -2,   -7
+.2byte    1,   -7, 	   6,  -18, 	  -8,  -14, 	  -2,   -7
+.2byte    4,   -9, 	   0,  -22, 	   1,  -16, 	  -1,   -7
+.2byte    5,   -9, 	  -3,  -24, 	   3,  -19, 	  -1,   -7
+.2byte    3,   -7, 	   2,  -21, 	  -2,  -15, 	  -3,   -7
+.2byte    2,   -8, 	  -5,  -22, 	   6,  -18, 	  -1,   -8
+.2byte    1,  -10, 	  -8,  -21, 	   6,  -19, 	  -1,   -8
+.2byte    2,   -7, 	  -2,  -20, 	   4,  -15, 	  -1,   -8
+.2byte   -1,   -9, 	   7,  -21, 	  -9,  -21, 	  -1,   -7
+.2byte    0,   -9, 	   9,  -17, 	  -5,  -21, 	  -1,   -7
+.2byte   -2,   -9, 	   3,  -20, 	 -11,  -17, 	  -1,   -7
+.2byte   -4,   -8, 	   3,  -22, 	  -8,  -18, 	  -1,   -8
+.2byte   -3,  -10, 	   6,  -21, 	  -8,  -19, 	  -1,   -8
+.2byte   -4,   -7, 	   0,  -20, 	  -6,  -15, 	  -1,   -8
+.2byte   -6,   -9, 	  -2,  -22, 	  -3,  -16, 	  -1,   -7
+.2byte   -7,   -9, 	   1,  -24, 	  -5,  -19, 	  -1,   -7
+.2byte   -5,   -7, 	  -4,  -21, 	   0,  -15, 	   1,   -7
+.2byte   -4,   -9, 	  -7,  -22, 	   3,  -17, 	   0,   -9
+.2byte   -5,   -7, 	  -5,  -23, 	  -2,  -17, 	   0,   -7
+.2byte   -3,   -7, 	  -8,  -18, 	   6,  -14, 	   0,   -7
+.2byte   -1,   -5, 	  -9,    1, 	   7,    1, 	  -1,   -7
+.2byte   -1,  -11, 	  -6,  -20, 	   4,  -20, 	  -1,   -8
+.2byte    0,   -7, 	  -5,  -15, 	   9,  -17, 	  -1,   -8
+.2byte    3,   -6, 	  11,   -3, 	   0,    2, 	  -1,   -9
+.2byte    2,  -11, 	  -2,  -20, 	 -13,  -17, 	  -1,   -9
+.2byte    1,   -7, 	   6,  -18, 	  -8,  -14, 	  -2,   -7
+.2byte    6,   -6, 	  12,   -5, 	  10,    0, 	   1,   -8
+.2byte    5,  -11, 	  -7,  -20, 	 -10,  -15, 	   0,   -9
+.2byte    4,   -7, 	   3,  -21, 	  -1,  -15, 	  -2,   -7
+.2byte    7,   -6, 	   5,  -10, 	  12,   -6, 	   1,   -8
+.2byte    4,  -11, 	 -13,  -16, 	  -4,  -13, 	  -2,   -8
+.2byte    2,   -7, 	  -2,  -20, 	   4,  -15, 	  -1,   -8
+.2byte   -1,   -6, 	   4,  -12, 	  -6,  -12, 	  -1,   -8
+.2byte   -1,  -11, 	  11,  -16, 	 -13,  -16, 	  -1,   -7
+.2byte   -2,   -9, 	   3,  -20, 	 -11,  -17, 	  -1,   -7
+.2byte   -8,   -6, 	  -6,  -10, 	 -13,   -6, 	  -2,   -8
+.2byte   -5,  -11, 	  12,  -16, 	   3,  -13, 	   1,   -8
+.2byte   -3,   -7, 	   1,  -20, 	  -5,  -15, 	   0,   -8
+.2byte   -7,   -6, 	 -13,   -5, 	 -11,    0, 	  -2,   -8
+.2byte   -6,  -11, 	   6,  -20, 	   9,  -15, 	  -1,   -9
+.2byte   -5,   -7, 	  -4,  -21, 	   0,  -15, 	   1,   -7
+.2byte   -4,   -6, 	 -12,   -3, 	  -1,    2, 	   0,   -9
+.2byte   -3,  -11, 	   1,  -20, 	  12,  -17, 	   0,   -9
+.2byte   -2,   -7, 	  -7,  -18, 	   7,  -14, 	   1,   -7
+.2byte   -1,   -8, 	  -8,  -18, 	   6,  -18, 	  -1,   -9
+.2byte   -1,  -11, 	  -6,  -20, 	   4,  -20, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,    1, 	   7,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,    1, 	   7,    1, 	  -1,   -7
+.2byte    2,   -9, 	   5,  -22, 	  -5,  -17, 	  -2,   -9
+.2byte    0,  -12, 	  -4,  -21, 	 -15,  -18, 	  -3,  -10
+.2byte    3,   -6, 	  11,   -3, 	   0,    2, 	  -1,   -9
+.2byte    3,   -6, 	  11,   -3, 	   0,    2, 	  -1,   -9
+.2byte    4,   -9, 	   0,  -22, 	   1,  -16, 	  -1,   -7
+.2byte    2,  -11, 	 -10,  -20, 	 -13,  -15, 	  -3,   -9
+.2byte    6,   -6, 	  12,   -5, 	  10,    0, 	   1,   -8
+.2byte    6,   -6, 	  12,   -5, 	  10,    0, 	   1,   -8
+.2byte    2,   -8, 	  -5,  -22, 	   6,  -18, 	  -1,   -8
+.2byte    3,  -11, 	 -14,  -16, 	  -5,  -13, 	  -3,   -8
+.2byte    7,   -6, 	   5,  -10, 	  12,   -6, 	   1,   -8
+.2byte    7,   -6, 	   5,  -10, 	  12,   -6, 	   1,   -8
+.2byte   -1,   -9, 	   7,  -21, 	  -9,  -21, 	  -1,   -7
+.2byte   -1,   -8, 	   7,  -14, 	  -9,  -14, 	  -1,   -7
+.2byte   -1,   -6, 	   4,  -12, 	  -6,  -12, 	  -1,   -8
+.2byte   -1,   -6, 	   4,  -12, 	  -6,  -12, 	  -1,   -8
+.2byte   -4,   -8, 	   3,  -22, 	  -8,  -18, 	  -1,   -8
+.2byte   -5,  -11, 	  12,  -16, 	   3,  -13, 	   1,   -8
+.2byte   -9,   -6, 	  -7,  -10, 	 -14,   -6, 	  -3,   -8
+.2byte   -9,   -6, 	  -7,  -10, 	 -14,   -6, 	  -3,   -8
+.2byte   -6,   -9, 	  -2,  -22, 	  -3,  -16, 	  -1,   -7
+.2byte   -4,  -11, 	   8,  -20, 	  11,  -15, 	   1,   -9
+.2byte   -8,   -6, 	 -14,   -5, 	 -12,    0, 	  -3,   -8
+.2byte   -8,   -6, 	 -14,   -5, 	 -12,    0, 	  -3,   -8
+.2byte   -4,   -9, 	  -7,  -22, 	   3,  -17, 	   0,   -9
+.2byte   -2,  -12, 	   2,  -21, 	  13,  -18, 	   1,  -10
+.2byte   -5,   -6, 	 -13,   -3, 	  -2,    2, 	  -1,   -9
+.2byte   -5,   -6, 	 -13,   -3, 	  -2,    2, 	  -1,   -9
+.2byte   -1,   -3, 	 -16,   -8, 	  14,   -8, 	  -1,   -8
+.2byte   -5,   -3, 	 -12,   -8, 	  14,   -1, 	  -1,   -9
+.2byte   -6,   -5, 	   1,   -8, 	   5,    1, 	  -1,   -8
+.2byte   -8,   -6, 	   4,   -7, 	  -9,    1, 	  -1,   -8
+.2byte   -1,   -9, 	  13,   -3, 	 -15,   -3, 	  -1,   -7
+.2byte    6,   -6, 	  -6,   -7, 	   7,    1, 	  -1,   -8
+.2byte    5,   -5, 	  -2,   -8, 	  -6,    1, 	   0,   -8
+.2byte    4,   -3, 	  11,   -8, 	 -15,   -1, 	   0,   -9
+.2byte   -1,   -8, 	  -8,  -18, 	   6,  -18, 	  -1,   -9
+.2byte   -1,   -3, 	 -16,   -8, 	  14,   -8, 	  -1,   -8
+.2byte   -1,  -14, 	  -9,  -19, 	   7,  -19, 	  -1,   -9
+.2byte    2,   -9, 	   5,  -22, 	  -5,  -17, 	  -2,   -9
+.2byte    4,   -3, 	  11,   -8, 	 -15,   -1, 	   0,   -9
+.2byte    0,  -14, 	   0,  -23, 	 -13,  -19, 	  -2,   -9
+.2byte    4,   -9, 	   0,  -22, 	   1,  -16, 	  -1,   -7
+.2byte    4,   -5, 	  -3,   -8, 	  -7,    1, 	  -1,   -8
+.2byte    2,  -15, 	  -7,  -21, 	 -12,  -16, 	  -2,   -9
+.2byte    2,   -8, 	  -5,  -22, 	   6,  -18, 	  -1,   -8
+.2byte    6,   -6, 	  -6,   -7, 	   7,    1, 	  -1,   -8
+.2byte    3,  -15, 	 -15,  -19, 	  -6,  -15, 	  -2,   -9
+.2byte   -1,   -9, 	   7,  -21, 	  -9,  -21, 	  -1,   -7
+.2byte   -1,   -9, 	  13,   -3, 	 -15,   -3, 	  -1,   -7
+.2byte   -1,  -11, 	  11,  -16, 	 -13,  -16, 	  -1,   -7
+.2byte   -4,   -8, 	   3,  -22, 	  -8,  -18, 	  -1,   -8
+.2byte   -8,   -6, 	   4,   -7, 	  -9,    1, 	  -1,   -8
+.2byte   -5,  -15, 	  13,  -19, 	   4,  -15, 	   0,   -9
+.2byte   -6,   -9, 	  -2,  -22, 	  -3,  -16, 	  -1,   -7
+.2byte   -6,   -5, 	   1,   -8, 	   5,    1, 	  -1,   -8
+.2byte   -4,  -15, 	   5,  -21, 	  10,  -16, 	   0,   -9
+.2byte   -4,   -9, 	  -7,  -22, 	   3,  -17, 	   0,   -9
+.2byte   -6,   -3, 	 -13,   -8, 	  13,   -1, 	  -2,   -9
+.2byte   -2,  -14, 	  -2,  -23, 	  11,  -19, 	   0,   -9
+.2byte   -1,   -7, 	 -12,   -2, 	  10,   -2, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -1, 	  10,   -1, 	  -1,   -7
+.2byte    0,   -7, 	  -7,  -14, 	   7,  -14, 	   0,   -8
+.2byte    1,   -7, 	   6,  -17, 	  -4,  -12, 	  -2,   -8
+.2byte    3,   -7, 	   5,  -19, 	   3,  -13, 	  -2,   -7
+.2byte    4,   -7, 	  -2,  -17, 	   7,  -14, 	  -1,   -8
+.2byte    0,   -5, 	   5,  -16, 	  -5,  -16, 	   0,   -7
+.2byte   -5,   -7, 	   1,  -17, 	  -8,  -14, 	   0,   -8
+.2byte   -4,   -7, 	  -6,  -19, 	  -4,  -13, 	   1,   -7
+.2byte   -2,   -7, 	  -7,  -17, 	   3,  -12, 	   1,   -8
+.2byte   -1,   -8, 	  -8,  -18, 	   6,  -18, 	  -1,   -9
+.2byte   -1,  -11, 	  -6,  -20, 	   4,  -20, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,    1, 	   7,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,    1, 	   7,    1, 	  -1,   -7
+.2byte    2,   -9, 	   5,  -22, 	  -5,  -17, 	  -2,   -9
+.2byte    0,  -12, 	  -4,  -21, 	 -15,  -18, 	  -3,  -10
+.2byte    3,   -6, 	  11,   -3, 	   0,    2, 	  -1,   -9
+.2byte    3,   -6, 	  11,   -3, 	   0,    2, 	  -1,   -9
+.2byte    4,   -9, 	   0,  -22, 	   1,  -16, 	  -1,   -7
+.2byte    2,  -11, 	 -10,  -20, 	 -13,  -15, 	  -3,   -9
+.2byte    6,   -6, 	  12,   -5, 	  10,    0, 	   1,   -8
+.2byte    6,   -6, 	  12,   -5, 	  10,    0, 	   1,   -8
+.2byte    2,   -8, 	  -5,  -22, 	   6,  -18, 	  -1,   -8
+.2byte    3,  -11, 	 -14,  -16, 	  -5,  -13, 	  -3,   -8
+.2byte    7,   -6, 	   5,  -10, 	  12,   -6, 	   1,   -8
+.2byte    7,   -6, 	   5,  -10, 	  12,   -6, 	   1,   -8
+.2byte   -1,   -9, 	   7,  -21, 	  -9,  -21, 	  -1,   -7
+.2byte   -1,   -8, 	   7,  -14, 	  -9,  -14, 	  -1,   -7
+.2byte   -1,   -6, 	   4,  -12, 	  -6,  -12, 	  -1,   -8
+.2byte   -1,   -6, 	   4,  -12, 	  -6,  -12, 	  -1,   -8
+.2byte   -4,   -8, 	   3,  -22, 	  -8,  -18, 	  -1,   -8
+.2byte   -5,  -11, 	  12,  -16, 	   3,  -13, 	   1,   -8
+.2byte   -9,   -6, 	  -7,  -10, 	 -14,   -6, 	  -3,   -8
+.2byte   -9,   -6, 	  -7,  -10, 	 -14,   -6, 	  -3,   -8
+.2byte   -6,   -9, 	  -2,  -22, 	  -3,  -16, 	  -1,   -7
+.2byte   -4,  -11, 	   8,  -20, 	  11,  -15, 	   1,   -9
+.2byte   -8,   -6, 	 -14,   -5, 	 -12,    0, 	  -3,   -8
+.2byte   -8,   -6, 	 -14,   -5, 	 -12,    0, 	  -3,   -8
+.2byte   -4,   -9, 	  -7,  -22, 	   3,  -17, 	   0,   -9
+.2byte   -2,  -12, 	   2,  -21, 	  13,  -18, 	   1,  -10
+.2byte   -5,   -6, 	 -13,   -3, 	  -2,    2, 	  -1,   -9
+.2byte   -5,   -6, 	 -13,   -3, 	  -2,    2, 	  -1,   -9
+.2byte   -1,   -3, 	 -16,   -8, 	  14,   -8, 	  -1,   -8
+.2byte   -5,   -3, 	 -12,   -8, 	  14,   -1, 	  -1,   -9
+.2byte   -6,   -5, 	   1,   -8, 	   5,    1, 	  -1,   -8
+.2byte   -8,   -6, 	   4,   -7, 	  -9,    1, 	  -1,   -8
+.2byte   -1,   -9, 	  13,   -3, 	 -15,   -3, 	  -1,   -7
+.2byte    6,   -6, 	  -6,   -7, 	   7,    1, 	  -1,   -8
+.2byte    5,   -5, 	  -2,   -8, 	  -6,    1, 	   0,   -8
+.2byte    4,   -3, 	  11,   -8, 	 -15,   -1, 	   0,   -9
+.2byte   -1,   -3, 	 -16,   -8, 	  14,   -8, 	  -1,   -8
+.2byte    4,   -3, 	  11,   -8, 	 -15,   -1, 	   0,   -9
+.2byte    5,   -5, 	  -2,   -8, 	  -6,    1, 	   0,   -8
+.2byte    6,   -6, 	  -6,   -7, 	   7,    1, 	  -1,   -8
+.2byte   -1,   -9, 	  13,   -3, 	 -15,   -3, 	  -1,   -7
+.2byte   -8,   -6, 	   4,   -7, 	  -9,    1, 	  -1,   -8
+.2byte   -6,   -5, 	   1,   -8, 	   5,    1, 	  -1,   -8
+.2byte   -5,   -3, 	 -12,   -8, 	  14,   -1, 	  -1,   -9
+.2byte   -1,   -8, 	  -8,  -18, 	   6,  -18, 	  -1,   -9
+.2byte   -1,  -11, 	  -6,  -20, 	   4,  -20, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,    1, 	   7,    1, 	  -1,   -7
+.2byte    2,   -9, 	   5,  -22, 	  -5,  -17, 	  -2,   -9
+.2byte    2,  -12, 	  -2,  -21, 	 -13,  -18, 	  -1,  -10
+.2byte    3,   -6, 	  11,   -3, 	   0,    2, 	  -1,   -9
+.2byte    4,   -9, 	   0,  -22, 	   1,  -16, 	  -1,   -7
+.2byte    3,  -11, 	  -9,  -20, 	 -12,  -15, 	  -2,   -9
+.2byte    6,   -6, 	  12,   -5, 	  10,    0, 	   1,   -8
+.2byte    2,   -8, 	  -5,  -22, 	   6,  -18, 	  -1,   -8
+.2byte    4,  -11, 	 -13,  -16, 	  -4,  -13, 	  -2,   -8
+.2byte    7,   -6, 	   5,  -10, 	  12,   -6, 	   1,   -8
+.2byte   -1,   -9, 	   7,  -21, 	  -9,  -21, 	  -1,   -7
+.2byte   -1,   -8, 	   7,  -14, 	  -9,  -14, 	  -1,   -7
+.2byte   -1,   -6, 	   4,  -12, 	  -6,  -12, 	  -1,   -8
+.2byte   -4,   -8, 	   3,  -22, 	  -8,  -18, 	  -1,   -8
+.2byte   -6,  -11, 	  11,  -16, 	   2,  -13, 	   0,   -8
+.2byte   -9,   -6, 	  -7,  -10, 	 -14,   -6, 	  -3,   -8
+.2byte   -6,   -9, 	  -2,  -22, 	  -3,  -16, 	  -1,   -7
+.2byte   -5,  -11, 	   7,  -20, 	  10,  -15, 	   0,   -9
+.2byte   -8,   -6, 	 -14,   -5, 	 -12,    0, 	  -3,   -8
+.2byte   -4,   -9, 	  -7,  -22, 	   3,  -17, 	   0,   -9
+.2byte   -4,  -12, 	   0,  -21, 	  11,  -18, 	  -1,  -10
+.2byte   -5,   -6, 	 -13,   -3, 	  -2,    2, 	  -1,   -9
+.2byte   -1,   -3, 	 -16,   -8, 	  14,   -8, 	  -1,   -8
+.2byte   -5,   -3, 	 -12,   -8, 	  14,   -1, 	  -1,   -9
+.2byte   -6,   -5, 	   1,   -8, 	   5,    1, 	  -1,   -8
+.2byte   -8,   -6, 	   4,   -7, 	  -9,    1, 	  -1,   -8
+.2byte   -1,   -9, 	  13,   -3, 	 -15,   -3, 	  -1,   -7
+.2byte    6,   -6, 	  -6,   -7, 	   7,    1, 	  -1,   -8
+.2byte    5,   -5, 	  -2,   -8, 	  -6,    1, 	   0,   -8
+.2byte    4,   -3, 	  11,   -8, 	 -15,   -1, 	   0,   -9
+.2byte   -1,   -8, 	  -8,  -18, 	   6,  -18, 	  -1,   -9
+.2byte   -4,   -9, 	  -7,  -22, 	   3,  -17, 	   0,   -9
+.2byte   -6,   -9, 	  -2,  -22, 	  -3,  -16, 	  -1,   -7
+.2byte   -4,   -8, 	   3,  -22, 	  -8,  -18, 	  -1,   -8
+.2byte   -1,   -9, 	   7,  -21, 	  -9,  -21, 	  -1,   -7
+.2byte    2,   -8, 	  -5,  -22, 	   6,  -18, 	  -1,   -8
+.2byte    4,   -9, 	   0,  -22, 	   1,  -16, 	  -1,   -7
+.2byte    2,   -9, 	   5,  -22, 	  -5,  -17, 	  -2,   -9
+sGravelerAnimTable1:
+.4byte sGravelerAnims_1_1
+.4byte sGravelerAnims_1_2
+.4byte sGravelerAnims_1_3
+.4byte sGravelerAnims_1_4
+.4byte sGravelerAnims_1_5
+.4byte sGravelerAnims_1_6
+.4byte sGravelerAnims_1_7
+.4byte sGravelerAnims_1_8
+sGravelerAnimTable2:
+.4byte sGravelerAnims_2_1
+.4byte sGravelerAnims_2_2
+.4byte sGravelerAnims_2_3
+.4byte sGravelerAnims_2_4
+.4byte sGravelerAnims_2_5
+.4byte sGravelerAnims_2_6
+.4byte sGravelerAnims_2_7
+.4byte sGravelerAnims_2_8
+sGravelerAnimTable3:
+.4byte sGravelerAnims_3_1
+.4byte sGravelerAnims_3_2
+.4byte sGravelerAnims_3_3
+.4byte sGravelerAnims_3_4
+.4byte sGravelerAnims_3_5
+.4byte sGravelerAnims_3_6
+.4byte sGravelerAnims_3_7
+.4byte sGravelerAnims_3_8
+sGravelerAnimTable4:
+.4byte sGravelerAnims_4_1
+.4byte sGravelerAnims_4_2
+.4byte sGravelerAnims_4_3
+.4byte sGravelerAnims_4_4
+.4byte sGravelerAnims_4_5
+.4byte sGravelerAnims_4_6
+.4byte sGravelerAnims_4_7
+.4byte sGravelerAnims_4_8
+sGravelerAnimTable5:
+.4byte sGravelerAnims_5_1
+.4byte sGravelerAnims_5_2
+.4byte sGravelerAnims_5_3
+.4byte sGravelerAnims_5_4
+.4byte sGravelerAnims_5_5
+.4byte sGravelerAnims_5_6
+.4byte sGravelerAnims_5_7
+.4byte sGravelerAnims_5_8
+sGravelerAnimTable6:
+.4byte sGravelerAnims_6_1
+.4byte sGravelerAnims_6_1
+.4byte sGravelerAnims_6_1
+.4byte sGravelerAnims_6_1
+.4byte sGravelerAnims_6_1
+.4byte sGravelerAnims_6_1
+.4byte sGravelerAnims_6_1
+.4byte sGravelerAnims_6_1
+sGravelerAnimTable7:
+.4byte sGravelerAnims_7_1
+.4byte sGravelerAnims_7_2
+.4byte sGravelerAnims_7_3
+.4byte sGravelerAnims_7_4
+.4byte sGravelerAnims_7_5
+.4byte sGravelerAnims_7_6
+.4byte sGravelerAnims_7_7
+.4byte sGravelerAnims_7_8
+sGravelerAnimTable8:
+.4byte sGravelerAnims_8_1
+.4byte sGravelerAnims_8_2
+.4byte sGravelerAnims_8_3
+.4byte sGravelerAnims_8_4
+.4byte sGravelerAnims_8_5
+.4byte sGravelerAnims_8_6
+.4byte sGravelerAnims_8_7
+.4byte sGravelerAnims_8_8
+sGravelerAnimTable9:
+.4byte sGravelerAnims_9_1
+.4byte sGravelerAnims_9_2
+.4byte sGravelerAnims_9_3
+.4byte sGravelerAnims_9_4
+.4byte sGravelerAnims_9_5
+.4byte sGravelerAnims_9_6
+.4byte sGravelerAnims_9_7
+.4byte sGravelerAnims_9_8
+sGravelerAnimTable10:
+.4byte sGravelerAnims_10_1
+.4byte sGravelerAnims_10_2
+.4byte sGravelerAnims_10_3
+.4byte sGravelerAnims_10_4
+.4byte sGravelerAnims_10_5
+.4byte sGravelerAnims_10_6
+.4byte sGravelerAnims_10_7
+.4byte sGravelerAnims_10_8
+sGravelerAnimTable11:
+.4byte sGravelerAnims_11_1
+.4byte sGravelerAnims_11_2
+.4byte sGravelerAnims_11_3
+.4byte sGravelerAnims_11_4
+.4byte sGravelerAnims_11_5
+.4byte sGravelerAnims_11_6
+.4byte sGravelerAnims_11_7
+.4byte sGravelerAnims_11_8
+sGravelerAnimTable12:
+.4byte sGravelerAnims_12_1
+.4byte sGravelerAnims_12_2
+.4byte sGravelerAnims_12_3
+.4byte sGravelerAnims_12_4
+.4byte sGravelerAnims_12_5
+.4byte sGravelerAnims_12_6
+.4byte sGravelerAnims_12_7
+.4byte sGravelerAnims_12_8
+sGravelerAnimTable13:
+.4byte sGravelerAnims_13_1
+.4byte sGravelerAnims_13_2
+.4byte sGravelerAnims_13_3
+.4byte sGravelerAnims_13_4
+.4byte sGravelerAnims_13_5
+.4byte sGravelerAnims_13_6
+.4byte sGravelerAnims_13_7
+.4byte sGravelerAnims_13_8
+sAxAnimationsGraveler:
+.4byte sGravelerAnimTable1
+.4byte sGravelerAnimTable2
+.4byte sGravelerAnimTable3
+.4byte sGravelerAnimTable4
+.4byte sGravelerAnimTable5
+.4byte sGravelerAnimTable6
+.4byte sGravelerAnimTable7
+.4byte sGravelerAnimTable8
+.4byte sGravelerAnimTable9
+.4byte sGravelerAnimTable10
+.4byte sGravelerAnimTable11
+.4byte sGravelerAnimTable12
+.4byte sGravelerAnimTable13
+sAxSpritesGraveler:
+.4byte sGravelerSprites1
+.4byte sGravelerSprites2
+.4byte sGravelerSprites3
+.4byte sGravelerSprites4
+.4byte sGravelerSprites5
+.4byte sGravelerSprites6
+.4byte sGravelerSprites7
+.4byte sGravelerSprites8
+.4byte sGravelerSprites9
+.4byte sGravelerSprites10
+.4byte sGravelerSprites11
+.4byte sGravelerSprites12
+.4byte sGravelerSprites13
+.4byte sGravelerSprites14
+.4byte sGravelerSprites15
+.4byte sGravelerSprites16
+.4byte sGravelerSprites17
+.4byte sGravelerSprites18
+.4byte sGravelerSprites19
+.4byte sGravelerSprites20
+.4byte sGravelerSprites21
+.4byte sGravelerSprites22
+.4byte sGravelerSprites23
+.4byte sGravelerSprites24
+.4byte sGravelerSprites25
+.4byte sGravelerSprites26
+.4byte sGravelerSprites27
+.4byte sGravelerSprites28
+.4byte sGravelerSprites29
+.4byte sGravelerSprites30
+.4byte sGravelerSprites31
+.4byte sGravelerSprites32
+.4byte sGravelerSprites33
+.4byte sGravelerSprites34
+.4byte sGravelerSprites35
+.4byte sGravelerSprites36
+.4byte sGravelerSprites37
+.4byte sGravelerSprites38
+.4byte sGravelerSprites39
+.4byte sGravelerSprites40
+.4byte sGravelerSprites41
+.4byte sGravelerSprites42
+.4byte sGravelerSprites43
+.4byte sGravelerSprites44
+.4byte sGravelerSprites45
+.4byte sGravelerSprites46
+.4byte sGravelerSprites47
+.4byte sGravelerSprites48
+.4byte sGravelerSprites49
+.4byte sGravelerSprites50
+.4byte sGravelerSprites51
+.4byte sGravelerSprites52
+.4byte sGravelerSprites53
+sAxMainGraveler:
+ax_main sAxPosesGraveler, sAxAnimationsGraveler, 13, sAxSpritesGraveler, sAxPositionsGraveler

--- a/data/ax/grimer.inc
+++ b/data/ax/grimer.inc
@@ -1,0 +1,3035 @@
+.global gAxGrimer
+gAxGrimer:
+ax_siro sAxMainGrimer
+sGrimerPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose2:
+ax_pose 1, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose3:
+ax_pose 2, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose5:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose6:
+ax_pose 5, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose7:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose8:
+ax_pose 7, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose9:
+ax_pose 8, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose10:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose11:
+ax_pose 10, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose18:
+ax_pose 11, 0x01ed, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose19:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose21:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose24:
+ax_pose 5, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose26:
+ax_pose 1, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose27:
+ax_pose 2, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose28:
+ax_pose 15, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose29:
+ax_pose 16, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose30:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose31:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose32:
+ax_pose 5, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose33:
+ax_pose 17, 0x01ec, 0x90f3, 0x2c00
+ax_pose_terminator
+sGrimerPose34:
+ax_pose 18, 0x01ec, 0x90f3, 0x2c00
+ax_pose_terminator
+sGrimerPose35:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose36:
+ax_pose 7, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose37:
+ax_pose 8, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose38:
+ax_pose 19, 0x01ec, 0x90f2, 0x2c00
+ax_pose_terminator
+sGrimerPose39:
+ax_pose 20, 0x41ec, 0x1100, 0x2c00
+ax_pose 21, 0x41f4, 0x90f0, 0x2c02
+ax_pose 22, 0x01fc, 0x10e8, 0x2c0a
+ax_pose_terminator
+sGrimerPose40:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose41:
+ax_pose 10, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose42:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose43:
+ax_pose 23, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose44:
+ax_pose 24, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose45:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose46:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose47:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose48:
+ax_pose 25, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGrimerPose49:
+ax_pose 26, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGrimerPose50:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose51:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose52:
+ax_pose 11, 0x01ed, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose53:
+ax_pose 23, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose54:
+ax_pose 24, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose55:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose56:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose57:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose58:
+ax_pose 19, 0x01ec, 0x80ee, 0x2c00
+ax_pose_terminator
+sGrimerPose59:
+ax_pose 20, 0x41ec, 0x00f0, 0x2c00
+ax_pose 21, 0x41f4, 0x80f0, 0x2c02
+ax_pose 22, 0x01fc, 0x0110, 0x2c0a
+ax_pose_terminator
+sGrimerPose60:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose61:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose62:
+ax_pose 5, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose63:
+ax_pose 17, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sGrimerPose64:
+ax_pose 18, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sGrimerPose65:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose66:
+ax_pose 1, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose67:
+ax_pose 2, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose68:
+ax_pose 15, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose69:
+ax_pose 16, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose70:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose71:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose72:
+ax_pose 5, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose73:
+ax_pose 17, 0x01ec, 0x90f3, 0x2c00
+ax_pose_terminator
+sGrimerPose74:
+ax_pose 18, 0x01ec, 0x90f3, 0x2c00
+ax_pose_terminator
+sGrimerPose75:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose76:
+ax_pose 7, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose77:
+ax_pose 8, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose78:
+ax_pose 19, 0x01ec, 0x90f2, 0x2c00
+ax_pose_terminator
+sGrimerPose79:
+ax_pose 20, 0x41ec, 0x1100, 0x2c00
+ax_pose 21, 0x41f4, 0x90f0, 0x2c02
+ax_pose 22, 0x01fc, 0x10e8, 0x2c0a
+ax_pose_terminator
+sGrimerPose80:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose81:
+ax_pose 10, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose82:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose83:
+ax_pose 23, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose84:
+ax_pose 24, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose85:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose86:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose87:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose88:
+ax_pose 25, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sGrimerPose89:
+ax_pose 26, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sGrimerPose90:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose91:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose92:
+ax_pose 11, 0x01ed, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose93:
+ax_pose 23, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose94:
+ax_pose 24, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose95:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose96:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose97:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose98:
+ax_pose 19, 0x01ec, 0x80ee, 0x2c00
+ax_pose_terminator
+sGrimerPose99:
+ax_pose 20, 0x41ec, 0x00f0, 0x2c00
+ax_pose 21, 0x41f4, 0x80f0, 0x2c02
+ax_pose 22, 0x01fc, 0x0110, 0x2c0a
+ax_pose_terminator
+sGrimerPose100:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose101:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose102:
+ax_pose 5, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose103:
+ax_pose 17, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sGrimerPose104:
+ax_pose 18, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sGrimerPose105:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose106:
+ax_pose 1, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose107:
+ax_pose 2, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose108:
+ax_pose 27, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose109:
+ax_pose 28, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose110:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose111:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose112:
+ax_pose 5, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose113:
+ax_pose 29, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose114:
+ax_pose 30, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose115:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose116:
+ax_pose 7, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose117:
+ax_pose 8, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose118:
+ax_pose 31, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose119:
+ax_pose 32, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose120:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose121:
+ax_pose 10, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose122:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose123:
+ax_pose 33, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose124:
+ax_pose 34, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose125:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose126:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose127:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose128:
+ax_pose 35, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose129:
+ax_pose 36, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose130:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose131:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose132:
+ax_pose 11, 0x01ed, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose133:
+ax_pose 33, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose134:
+ax_pose 34, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose135:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose136:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose137:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose138:
+ax_pose 31, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose139:
+ax_pose 32, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose140:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose141:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose142:
+ax_pose 5, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose143:
+ax_pose 29, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose144:
+ax_pose 30, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose145:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose146:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose147:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose148:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose149:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose150:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose151:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose152:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose153:
+ax_pose 37, 0x01ef, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose154:
+ax_pose 38, 0x01ef, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose155:
+ax_pose 39, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose156:
+ax_pose 40, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose157:
+ax_pose 41, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose158:
+ax_pose 42, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose159:
+ax_pose 43, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose160:
+ax_pose 42, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose161:
+ax_pose 41, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose162:
+ax_pose 40, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose163:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose164:
+ax_pose 1, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose165:
+ax_pose 2, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose166:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose167:
+ax_pose 4, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose168:
+ax_pose 5, 0x01ee, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose169:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose170:
+ax_pose 7, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose171:
+ax_pose 8, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose172:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose173:
+ax_pose 10, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose174:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose175:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose176:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose177:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose178:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose179:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose180:
+ax_pose 11, 0x01ed, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose181:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose182:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose183:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose184:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose185:
+ax_pose 4, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose186:
+ax_pose 5, 0x01ee, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose187:
+ax_pose 28, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose188:
+ax_pose 30, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose189:
+ax_pose 32, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose190:
+ax_pose 34, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose191:
+ax_pose 36, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose192:
+ax_pose 34, 0x01ed, 0x90ee, 0x2c00
+ax_pose_terminator
+sGrimerPose193:
+ax_pose 32, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose194:
+ax_pose 30, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose195:
+ax_pose 28, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose196:
+ax_pose 30, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose197:
+ax_pose 32, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose198:
+ax_pose 34, 0x01ed, 0x90ee, 0x2c00
+ax_pose_terminator
+sGrimerPose199:
+ax_pose 36, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose200:
+ax_pose 34, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose201:
+ax_pose 32, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose202:
+ax_pose 30, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose203:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose204:
+ax_pose 15, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose205:
+ax_pose 27, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose206:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose207:
+ax_pose 17, 0x01ec, 0x90f3, 0x2c00
+ax_pose_terminator
+sGrimerPose208:
+ax_pose 29, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose209:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose210:
+ax_pose 19, 0x01ec, 0x90f4, 0x2c00
+ax_pose_terminator
+sGrimerPose211:
+ax_pose 31, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose212:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose213:
+ax_pose 23, 0x01e8, 0x90f1, 0x2c00
+ax_pose_terminator
+sGrimerPose214:
+ax_pose 33, 0x01ec, 0x90ee, 0x2c00
+ax_pose_terminator
+sGrimerPose215:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose216:
+ax_pose 25, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose217:
+ax_pose 35, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose218:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose219:
+ax_pose 23, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sGrimerPose220:
+ax_pose 33, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose221:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose222:
+ax_pose 19, 0x01ec, 0x80ec, 0x2c00
+ax_pose_terminator
+sGrimerPose223:
+ax_pose 31, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose224:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose225:
+ax_pose 17, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sGrimerPose226:
+ax_pose 29, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose227:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose228:
+ax_pose 1, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose229:
+ax_pose 2, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose230:
+ax_pose 27, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose231:
+ax_pose 28, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose232:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose233:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose234:
+ax_pose 5, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose235:
+ax_pose 29, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose236:
+ax_pose 30, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sGrimerPose237:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose238:
+ax_pose 7, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose239:
+ax_pose 8, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose240:
+ax_pose 31, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose241:
+ax_pose 32, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose242:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose243:
+ax_pose 10, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose244:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sGrimerPose245:
+ax_pose 33, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose246:
+ax_pose 34, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sGrimerPose247:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose248:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose249:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose250:
+ax_pose 35, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose251:
+ax_pose 36, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sGrimerPose252:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose253:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose254:
+ax_pose 11, 0x01ed, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose255:
+ax_pose 33, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose256:
+ax_pose 34, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sGrimerPose257:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose258:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose259:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose260:
+ax_pose 31, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose261:
+ax_pose 32, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose262:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose263:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose264:
+ax_pose 5, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sGrimerPose265:
+ax_pose 29, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose266:
+ax_pose 30, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sGrimerPose267:
+ax_pose 0, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose268:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose269:
+ax_pose 6, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose270:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose271:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sGrimerPose272:
+ax_pose 9, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose273:
+ax_pose 6, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sGrimerPose274:
+ax_pose 3, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sGrimerAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 1, 0, 1,
+ax_anim 8, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 0, 0, 1, 0, 1,
+ax_anim_terminator
+sGrimerAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 5, 2, 2, 2, 2,
+ax_anim 8, 0, 5, 3, 3, 3, 3,
+ax_anim 8, 0, 4, 2, 2, 2, 2,
+ax_anim 8, 0, 3, 1, 1, 1, 1,
+ax_anim_terminator
+sGrimerAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 1, 0, 1, 0,
+ax_anim 8, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 6, 1, 0, 1, 0,
+ax_anim_terminator
+sGrimerAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 1, -1, 1, -1,
+ax_anim 8, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 9, 1, -1, 1, -1,
+ax_anim_terminator
+sGrimerAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, -1,
+ax_anim 8, 0, 13, 0, -1, 0, -1,
+ax_anim 8, 0, 12, 0, -1, 0, -1,
+ax_anim_terminator
+sGrimerAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 17, -1, -1, -1, -1,
+ax_anim 8, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 15, -1, -1, -1, -1,
+ax_anim_terminator
+sGrimerAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 20, -1, 0, -1, 0,
+ax_anim 8, 0, 19, -1, 0, -1, 0,
+ax_anim 8, 0, 18, -1, 0, -1, 0,
+ax_anim_terminator
+sGrimerAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 23, -2, 2, -2, 2,
+ax_anim 8, 0, 23, -3, 3, -3, 3,
+ax_anim 8, 0, 22, -2, 2, -2, 2,
+ax_anim 8, 0, 21, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGrimerAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 4, 0, 27, 0, -3, 0, -3,
+ax_anim 1, 2, 28, 0, -2, 0, -2,
+ax_anim 1, 0, 28, 0, 4, 0, 4,
+ax_anim 2, 0, 28, 0, 11, 0, 11,
+ax_anim 2, 1, 28, -1, 11, -1, 11,
+ax_anim 2, 0, 28, 0, 11, 0, 11,
+ax_anim 2, 0, 28, -1, 11, -1, 11,
+ax_anim 2, 0, 28, 0, 11, 0, 11,
+ax_anim 2, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 25, 0, 7, 0, 7,
+ax_anim_terminator
+sGrimerAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 2, 0, 31, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 4, 0, 32, -3, -3, -3, -3,
+ax_anim 1, 2, 33, -2, -2, -2, -2,
+ax_anim 1, 0, 33, 4, 4, 4, 4,
+ax_anim 2, 0, 33, 15, 15, 15, 15,
+ax_anim 2, 1, 33, 14, 16, 14, 16,
+ax_anim 2, 0, 33, 15, 15, 15, 15,
+ax_anim 2, 0, 33, 14, 16, 14, 16,
+ax_anim 2, 0, 33, 15, 15, 15, 15,
+ax_anim 2, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 30, 4, 4, 4, 4,
+ax_anim_terminator
+sGrimerAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 2, 0, 36, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 4, 0, 37, -3, 0, -3, 0,
+ax_anim 1, 2, 38, 2, 0, 2, 0,
+ax_anim 1, 0, 38, 6, 0, 6, 0,
+ax_anim 2, 0, 38, 15, 0, 15, 0,
+ax_anim 2, 1, 38, 15, 1, 15, 1,
+ax_anim 2, 0, 38, 15, 0, 15, 0,
+ax_anim 2, 0, 38, 15, 1, 15, 1,
+ax_anim 2, 0, 38, 15, 0, 15, 0,
+ax_anim 2, 0, 36, 12, 0, 12, 0,
+ax_anim 2, 0, 35, 4, 0, 4, 0,
+ax_anim_terminator
+sGrimerAnims_2_4:
+ax_anim 2, 0, 40, -1, 1, -1, 1,
+ax_anim 2, 0, 41, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -3, 3, -3, 3,
+ax_anim 4, 0, 42, -3, 3, -3, 3,
+ax_anim 1, 2, 43, -2, 2, -2, 2,
+ax_anim 1, 0, 43, 6, -6, 6, -6,
+ax_anim 2, 0, 43, 17, -19, 17, -19,
+ax_anim 2, 1, 43, 16, -20, 16, -20,
+ax_anim 2, 0, 43, 17, -19, 17, -19,
+ax_anim 2, 0, 43, 16, -20, 16, -20,
+ax_anim 2, 0, 43, 17, -19, 17, -19,
+ax_anim 2, 0, 41, 12, -13, 12, -13,
+ax_anim 2, 0, 40, 4, -4, 4, -4,
+ax_anim_terminator
+sGrimerAnims_2_5:
+ax_anim 2, 0, 45, 0, 1, 0, 1,
+ax_anim 2, 0, 46, 0, 2, 0, 2,
+ax_anim 2, 0, 44, 0, 3, 0, 3,
+ax_anim 4, 0, 47, 0, 3, 0, 3,
+ax_anim 1, 2, 48, 0, 2, 0, 2,
+ax_anim 1, 0, 48, 0, -6, 0, -6,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 1, 48, 1, -19, 1, -19,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 0, 48, 1, -19, 1, -19,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 0, 46, 0, -13, 0, -13,
+ax_anim 2, 0, 45, 0, -4, 0, -4,
+ax_anim_terminator
+sGrimerAnims_2_6:
+ax_anim 2, 0, 50, 1, 1, 1, 1,
+ax_anim 2, 0, 51, 2, 2, 2, 2,
+ax_anim 2, 0, 49, 3, 3, 3, 3,
+ax_anim 4, 0, 52, 3, 3, 3, 3,
+ax_anim 1, 2, 53, 2, 2, 2, 2,
+ax_anim 1, 0, 53, -6, -6, -6, -6,
+ax_anim 2, 0, 53, -17, -19, -17, -19,
+ax_anim 2, 1, 53, -16, -20, -16, -20,
+ax_anim 2, 0, 53, -17, -19, -17, -19,
+ax_anim 2, 0, 53, -16, -20, -16, -20,
+ax_anim 2, 0, 53, -17, -19, -17, -19,
+ax_anim 2, 0, 51, -12, -13, -12, -13,
+ax_anim 2, 0, 50, -4, -4, -4, -4,
+ax_anim_terminator
+sGrimerAnims_2_7:
+ax_anim 2, 0, 55, 1, 0, 1, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim 4, 0, 57, 3, 0, 3, 0,
+ax_anim 1, 2, 58, -2, 0, -2, 0,
+ax_anim 1, 0, 58, -6, 0, -6, 0,
+ax_anim 2, 0, 58, -15, 0, -15, 0,
+ax_anim 2, 1, 58, -15, 1, -15, 1,
+ax_anim 2, 0, 58, -15, 0, -15, 0,
+ax_anim 2, 0, 58, -15, 1, -15, 1,
+ax_anim 2, 0, 58, -15, 0, -15, 0,
+ax_anim 2, 0, 56, -12, 0, -12, 0,
+ax_anim 2, 0, 55, -4, 0, -4, 0,
+ax_anim_terminator
+sGrimerAnims_2_8:
+ax_anim 2, 0, 60, 1, -1, 1, -1,
+ax_anim 2, 0, 61, 2, -2, 2, -2,
+ax_anim 2, 0, 59, 3, -3, 3, -3,
+ax_anim 4, 0, 62, 3, -3, 3, -3,
+ax_anim 1, 2, 63, 2, -2, 2, -2,
+ax_anim 1, 0, 63, -4, 4, -4, 4,
+ax_anim 2, 0, 63, -15, 15, -15, 15,
+ax_anim 2, 1, 63, -14, 16, -14, 16,
+ax_anim 2, 0, 63, -15, 15, -15, 15,
+ax_anim 2, 0, 63, -14, 16, -14, 16,
+ax_anim 2, 0, 63, -15, 15, -15, 15,
+ax_anim 2, 0, 61, -12, 12, -12, 12,
+ax_anim 2, 0, 60, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGrimerAnims_3_1:
+ax_anim 2, 0, 65, 0, -1, 0, -1,
+ax_anim 2, 0, 66, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim 4, 0, 67, 0, -3, 0, -3,
+ax_anim 1, 2, 68, 0, -2, 0, -2,
+ax_anim 1, 0, 68, 0, 4, 0, 4,
+ax_anim 2, 0, 68, 0, 11, 0, 11,
+ax_anim 2, 1, 68, -1, 11, -1, 11,
+ax_anim 2, 0, 68, 0, 11, 0, 11,
+ax_anim 2, 0, 68, -1, 11, -1, 11,
+ax_anim 2, 0, 68, 0, 11, 0, 11,
+ax_anim 2, 0, 66, 0, 12, 0, 12,
+ax_anim 2, 0, 65, 0, 7, 0, 7,
+ax_anim_terminator
+sGrimerAnims_3_2:
+ax_anim 2, 0, 70, -1, -1, -1, -1,
+ax_anim 2, 0, 71, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -3, -3, -3, -3,
+ax_anim 4, 0, 72, -3, -3, -3, -3,
+ax_anim 1, 2, 73, -2, -2, -2, -2,
+ax_anim 1, 0, 73, 4, 4, 4, 4,
+ax_anim 2, 0, 73, 15, 15, 15, 15,
+ax_anim 2, 1, 73, 14, 16, 14, 16,
+ax_anim 2, 0, 73, 15, 15, 15, 15,
+ax_anim 2, 0, 73, 14, 16, 14, 16,
+ax_anim 2, 0, 73, 15, 15, 15, 15,
+ax_anim 2, 0, 71, 12, 12, 12, 12,
+ax_anim 2, 0, 70, 4, 4, 4, 4,
+ax_anim_terminator
+sGrimerAnims_3_3:
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -3, 0, -3, 0,
+ax_anim 4, 0, 77, -3, 0, -3, 0,
+ax_anim 1, 2, 78, 2, 0, 2, 0,
+ax_anim 1, 0, 78, 6, 0, 6, 0,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 1, 78, 15, 1, 15, 1,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 0, 78, 15, 1, 15, 1,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 0, 76, 12, 0, 12, 0,
+ax_anim 2, 0, 75, 4, 0, 4, 0,
+ax_anim_terminator
+sGrimerAnims_3_4:
+ax_anim 2, 0, 80, -1, 1, -1, 1,
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim 2, 0, 79, -3, 3, -3, 3,
+ax_anim 4, 0, 82, -3, 3, -3, 3,
+ax_anim 1, 2, 83, -2, 2, -2, 2,
+ax_anim 1, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 83, 17, -19, 17, -19,
+ax_anim 2, 1, 83, 16, -20, 16, -20,
+ax_anim 2, 0, 83, 17, -19, 17, -19,
+ax_anim 2, 0, 83, 16, -20, 16, -20,
+ax_anim 2, 0, 83, 17, -19, 17, -19,
+ax_anim 2, 0, 81, 12, -13, 12, -13,
+ax_anim 2, 0, 80, 4, -4, 4, -4,
+ax_anim_terminator
+sGrimerAnims_3_5:
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 2, 0, 84, 0, 3, 0, 3,
+ax_anim 4, 0, 87, 0, 3, 0, 3,
+ax_anim 1, 2, 88, 0, 2, 0, 2,
+ax_anim 1, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 1, 88, 1, -19, 1, -19,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 0, 88, 1, -19, 1, -19,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 0, 86, 0, -13, 0, -13,
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim_terminator
+sGrimerAnims_3_6:
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 3, 3, 3, 3,
+ax_anim 4, 0, 92, 3, 3, 3, 3,
+ax_anim 1, 2, 93, 2, 2, 2, 2,
+ax_anim 1, 0, 93, -6, -6, -6, -6,
+ax_anim 2, 0, 93, -17, -19, -17, -19,
+ax_anim 2, 1, 93, -16, -20, -16, -20,
+ax_anim 2, 0, 93, -17, -19, -17, -19,
+ax_anim 2, 0, 93, -16, -20, -16, -20,
+ax_anim 2, 0, 93, -17, -19, -17, -19,
+ax_anim 2, 0, 91, -12, -13, -12, -13,
+ax_anim 2, 0, 90, -4, -4, -4, -4,
+ax_anim_terminator
+sGrimerAnims_3_7:
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 3, 0, 3, 0,
+ax_anim 4, 0, 97, 3, 0, 3, 0,
+ax_anim 1, 2, 98, -2, 0, -2, 0,
+ax_anim 1, 0, 98, -6, 0, -6, 0,
+ax_anim 2, 0, 98, -15, 0, -15, 0,
+ax_anim 2, 1, 98, -15, 1, -15, 1,
+ax_anim 2, 0, 98, -15, 0, -15, 0,
+ax_anim 2, 0, 98, -15, 1, -15, 1,
+ax_anim 2, 0, 98, -15, 0, -15, 0,
+ax_anim 2, 0, 96, -12, 0, -12, 0,
+ax_anim 2, 0, 95, -4, 0, -4, 0,
+ax_anim_terminator
+sGrimerAnims_3_8:
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 4, 0, 102, 3, -3, 3, -3,
+ax_anim 1, 2, 103, 2, -2, 2, -2,
+ax_anim 1, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -15, 15, -15, 15,
+ax_anim 2, 1, 103, -14, 16, -14, 16,
+ax_anim 2, 0, 103, -15, 15, -15, 15,
+ax_anim 2, 0, 103, -14, 16, -14, 16,
+ax_anim 2, 0, 103, -15, 15, -15, 15,
+ax_anim 2, 0, 101, -12, 12, -12, 12,
+ax_anim 2, 0, 100, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGrimerAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 2, 2, 106, 0, -5, 0, -5,
+ax_anim 4, 0, 107, 0, -4, 0, -4,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 1, 108, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 108, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 108, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 0, 2, 0, 2,
+ax_anim_terminator
+sGrimerAnims_4_2:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 110, -3, -3, -3, -3,
+ax_anim 2, 2, 111, -5, -5, -5, -5,
+ax_anim 4, 0, 112, -4, -4, -4, -4,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 5, 5, 5, 5,
+ax_anim 2, 1, 113, 5, 5, 5, 5,
+ax_anim 2, 0, 112, 5, 5, 5, 5,
+ax_anim 2, 0, 113, 5, 5, 5, 5,
+ax_anim 2, 0, 112, 5, 5, 5, 5,
+ax_anim 2, 0, 113, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim_terminator
+sGrimerAnims_4_3:
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 2, 116, -5, 0, -5, 0,
+ax_anim 4, 0, 117, -4, 0, -4, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 1, 118, 5, 0, 5, 0,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 118, 5, 0, 5, 0,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 118, 5, 0, 5, 0,
+ax_anim 2, 0, 116, 2, 0, 2, 0,
+ax_anim_terminator
+sGrimerAnims_4_4:
+ax_anim 2, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 0, 120, -3, 3, -3, 3,
+ax_anim 2, 2, 121, -5, 5, -5, 5,
+ax_anim 4, 0, 122, -4, 4, -4, 4,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 5, -5, 5, -5,
+ax_anim 2, 1, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 122, 5, -5, 5, -5,
+ax_anim 2, 0, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 122, 5, -5, 5, -5,
+ax_anim 2, 0, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim_terminator
+sGrimerAnims_4_5:
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 3, 0, 3,
+ax_anim 2, 2, 126, 0, 5, 0, 5,
+ax_anim 4, 0, 127, 0, 4, 0, 4,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, -5,
+ax_anim 2, 1, 128, 0, -5, 0, -5,
+ax_anim 2, 0, 127, 0, -5, 0, -5,
+ax_anim 2, 0, 128, 0, -5, 0, -5,
+ax_anim 2, 0, 127, 0, -5, 0, -5,
+ax_anim 2, 0, 128, 0, -5, 0, -5,
+ax_anim 2, 0, 126, 0, -2, 0, -2,
+ax_anim_terminator
+sGrimerAnims_4_6:
+ax_anim 2, 0, 129, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 3, 3, 3, 3,
+ax_anim 2, 2, 131, 5, 5, 5, 5,
+ax_anim 4, 0, 132, 4, 4, 4, 4,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, -5, -5, -5, -5,
+ax_anim 2, 1, 133, -5, -5, -5, -5,
+ax_anim 2, 0, 132, -5, -5, -5, -5,
+ax_anim 2, 0, 133, -5, -5, -5, -5,
+ax_anim 2, 0, 132, -5, -5, -5, -5,
+ax_anim 2, 0, 133, -5, -5, -5, -5,
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim_terminator
+sGrimerAnims_4_7:
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 0, 135, 3, 0, 3, 0,
+ax_anim 2, 2, 136, 5, 0, 5, 0,
+ax_anim 4, 0, 137, 4, 0, 4, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 1, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim_terminator
+sGrimerAnims_4_8:
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 140, 3, -3, 3, -3,
+ax_anim 2, 2, 141, 5, -5, 5, -5,
+ax_anim 4, 0, 142, 4, -4, 4, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 1, 143, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 143, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 143, -5, 5, -5, 5,
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGrimerAnims_5_1:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_5_2:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_5_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_5_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_5_5:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_5_6:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_5_7:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_5_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrimerAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrimerAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sGrimerAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sGrimerAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sGrimerAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sGrimerAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sGrimerAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sGrimerAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sGrimerAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sGrimerAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_8_2:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_8_4:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim 30, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_8_5:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_8_6:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim 30, 0, 179, 0, 0, 0, 0,
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_8_7:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 30, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_8_8:
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 30, 0, 185, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrimerAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 15, 7, 15,
+ax_anim 3, 0, 190, 0, 18, 0, 18,
+ax_anim 2, 3, 191, -7, 15, -7, 15,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 4, 17, 4,
+ax_anim 2, 0, 188, 19, 12, 19, 12,
+ax_anim 3, 0, 189, 19, 19, 19, 19,
+ax_anim 2, 3, 190, 11, 19, 11, 19,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 17, -6, 17, -6,
+ax_anim 3, 0, 188, 21, -1, 21, -1,
+ax_anim 2, 3, 189, 16, 4, 16, 4,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 4, 3, 4, 3,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 21, -24, 21, -24,
+ax_anim 2, 3, 188, 22, -14, 22, -14,
+ax_anim 2, 0, 189, 17, -6, 17, -6,
+ax_anim 1, 0, 190, 9, -1, 9, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -20, -7, -20,
+ax_anim 3, 0, 186, 0, -24, 0, -24,
+ax_anim 2, 3, 187, 7, -20, 7, -20,
+ax_anim 2, 0, 188, 9, -10, 9, -10,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -21, -24, -21, -24,
+ax_anim 2, 3, 192, -22, -14, -22, -14,
+ax_anim 2, 0, 191, -17, -6, -17, -6,
+ax_anim 1, 0, 190, -9, -1, -9, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -17, -6, -17, -6,
+ax_anim 3, 0, 192, -21, -1, -21, -1,
+ax_anim 2, 3, 191, -16, 4, -16, 4,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -4, 3, -4, 3,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 4, -17, 4,
+ax_anim 2, 0, 192, -19, 12, -19, 12,
+ax_anim 3, 0, 191, -19, 19, -19, 19,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrimerAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrimerAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -27, 0, 0,
+ax_anim 3, 0, 204, 0, -25, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -25, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -25, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrimerAnims_12_1:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_12_2:
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_12_4:
+ax_anim 2, 0, 245, -1, -1, -1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -1, -1, -1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -1, -1, -1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -1, -1, -1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -1, -1, -1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_12_5:
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_12_6:
+ax_anim 2, 0, 255, 1, -1, 1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, -1, 1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, -1, 1, -1,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, -1, 1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, -1, 1, -1,
+ax_anim 2, 1, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_12_7:
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 1, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_12_8:
+ax_anim 2, 0, 265, -1, -1, -1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, -1, -1, -1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, -1, -1, -1, -1,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, -1, -1, -1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, -1, -1, -1, -1,
+ax_anim 2, 1, 265, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrimerAnims_13_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_13_2:
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_13_3:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_13_4:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_13_5:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_13_6:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_13_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerAnims_13_8:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sGrimerGfx1:
+.incbin "baserom.gba", 0x8C27F4, 0x200
+sGrimerSprites1:
+ax_sprite sGrimerGfx1, 0x200
+ax_sprite_terminator
+sGrimerGfx2:
+.incbin "baserom.gba", 0x8C2A04, 0x200
+sGrimerSprites2:
+ax_sprite sGrimerGfx2, 0x200
+ax_sprite_terminator
+sGrimerGfx3:
+.incbin "baserom.gba", 0x8C2C14, 0x200
+sGrimerSprites3:
+ax_sprite sGrimerGfx3, 0x200
+ax_sprite_terminator
+sGrimerGfx4:
+.incbin "baserom.gba", 0x8C2E24, 0x200
+sGrimerSprites4:
+ax_sprite sGrimerGfx4, 0x200
+ax_sprite_terminator
+sGrimerGfx5:
+.incbin "baserom.gba", 0x8C3034, 0x200
+sGrimerSprites5:
+ax_sprite sGrimerGfx5, 0x200
+ax_sprite_terminator
+sGrimerGfx6:
+.incbin "baserom.gba", 0x8C3244, 0x200
+sGrimerSprites6:
+ax_sprite sGrimerGfx6, 0x200
+ax_sprite_terminator
+sGrimerGfx7:
+.incbin "baserom.gba", 0x8C3454, 0x200
+sGrimerSprites7:
+ax_sprite sGrimerGfx7, 0x200
+ax_sprite_terminator
+sGrimerGfx8:
+.incbin "baserom.gba", 0x8C3664, 0x200
+sGrimerSprites8:
+ax_sprite sGrimerGfx8, 0x200
+ax_sprite_terminator
+sGrimerGfx9:
+.incbin "baserom.gba", 0x8C3874, 0x200
+sGrimerSprites9:
+ax_sprite sGrimerGfx9, 0x200
+ax_sprite_terminator
+sGrimerGfx10:
+.incbin "baserom.gba", 0x8C3A84, 0x200
+sGrimerSprites10:
+ax_sprite sGrimerGfx10, 0x200
+ax_sprite_terminator
+sGrimerGfx11:
+.incbin "baserom.gba", 0x8C3C94, 0x200
+sGrimerSprites11:
+ax_sprite sGrimerGfx11, 0x200
+ax_sprite_terminator
+sGrimerGfx12:
+.incbin "baserom.gba", 0x8C3EA4, 0x200
+sGrimerSprites12:
+ax_sprite sGrimerGfx12, 0x200
+ax_sprite_terminator
+sGrimerGfx13:
+.incbin "baserom.gba", 0x8C40B4, 0x200
+sGrimerSprites13:
+ax_sprite sGrimerGfx13, 0x200
+ax_sprite_terminator
+sGrimerGfx14:
+.incbin "baserom.gba", 0x8C42C4, 0x200
+sGrimerSprites14:
+ax_sprite sGrimerGfx14, 0x200
+ax_sprite_terminator
+sGrimerGfx15:
+.incbin "baserom.gba", 0x8C44D4, 0x200
+sGrimerSprites15:
+ax_sprite sGrimerGfx15, 0x200
+ax_sprite_terminator
+sGrimerGfx16:
+.incbin "baserom.gba", 0x8C46E4, 0x60
+sGrimerGfx16_1:
+.incbin "baserom.gba", 0x8C4744, 0x60
+sGrimerGfx16_2:
+.incbin "baserom.gba", 0x8C47A4, 0x80
+sGrimerSprites16:
+ax_sprite sGrimerGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx16_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrimerGfx17:
+.incbin "baserom.gba", 0x8C485C, 0x40
+sGrimerGfx17_1:
+.incbin "baserom.gba", 0x8C489C, 0x60
+sGrimerGfx17_2:
+.incbin "baserom.gba", 0x8C48FC, 0xE0
+sGrimerSprites17:
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx17_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrimerGfx18:
+.incbin "baserom.gba", 0x8C4A1C, 0x60
+sGrimerGfx18_1:
+.incbin "baserom.gba", 0x8C4A7C, 0x60
+sGrimerGfx18_2:
+.incbin "baserom.gba", 0x8C4ADC, 0x60
+sGrimerSprites18:
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx18_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrimerGfx19:
+.incbin "baserom.gba", 0x8C4B7C, 0x1A0
+sGrimerSprites19:
+ax_sprite 0, 0x40
+ax_sprite sGrimerGfx19, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrimerGfx20:
+.incbin "baserom.gba", 0x8C4D3C, 0x60
+sGrimerGfx20_1:
+.incbin "baserom.gba", 0x8C4D9C, 0xE0
+sGrimerSprites20:
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx20_1, 0xe0
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrimerGfx21:
+.incbin "baserom.gba", 0x8C4EAC, 0x40
+sGrimerSprites21:
+ax_sprite sGrimerGfx21, 0x40
+ax_sprite_terminator
+sGrimerGfx22:
+.incbin "baserom.gba", 0x8C4EFC, 0x100
+sGrimerSprites22:
+ax_sprite sGrimerGfx22, 0x100
+ax_sprite_terminator
+sGrimerGfx23:
+.incbin "baserom.gba", 0x8C500C, 0x20
+sGrimerSprites23:
+ax_sprite sGrimerGfx23, 0x20
+ax_sprite_terminator
+sGrimerGfx24:
+.incbin "baserom.gba", 0x8C503C, 0x20
+sGrimerGfx24_1:
+.incbin "baserom.gba", 0x8C505C, 0x80
+sGrimerGfx24_2:
+.incbin "baserom.gba", 0x8C50DC, 0x60
+sGrimerGfx24_3:
+.incbin "baserom.gba", 0x8C513C, 0x60
+sGrimerSprites24:
+ax_sprite 0, 0x40
+ax_sprite sGrimerGfx24, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx24_3, 0x60
+ax_sprite_terminator
+sGrimerGfx25:
+.incbin "baserom.gba", 0x8C51E4, 0x40
+sGrimerGfx25_1:
+.incbin "baserom.gba", 0x8C5224, 0x60
+sGrimerGfx25_2:
+.incbin "baserom.gba", 0x8C5284, 0x80
+sGrimerGfx25_3:
+.incbin "baserom.gba", 0x8C5304, 0x60
+sGrimerSprites25:
+ax_sprite sGrimerGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrimerGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx25_3, 0x60
+ax_sprite_terminator
+sGrimerGfx26:
+.incbin "baserom.gba", 0x8C53A4, 0x40
+sGrimerGfx26_1:
+.incbin "baserom.gba", 0x8C53E4, 0x160
+sGrimerSprites26:
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx26_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrimerGfx27:
+.incbin "baserom.gba", 0x8C5574, 0x60
+sGrimerGfx27_1:
+.incbin "baserom.gba", 0x8C55D4, 0x60
+sGrimerGfx27_2:
+.incbin "baserom.gba", 0x8C5634, 0x60
+sGrimerGfx27_3:
+.incbin "baserom.gba", 0x8C5694, 0x60
+sGrimerSprites27:
+ax_sprite sGrimerGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrimerGfx28:
+.incbin "baserom.gba", 0x8C573C, 0x180
+sGrimerSprites28:
+ax_sprite sGrimerGfx28, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrimerGfx29:
+.incbin "baserom.gba", 0x8C58D4, 0x40
+sGrimerGfx29_1:
+.incbin "baserom.gba", 0x8C5914, 0x100
+sGrimerGfx29_2:
+.incbin "baserom.gba", 0x8C5A14, 0x40
+sGrimerSprites29:
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx29_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrimerGfx30:
+.incbin "baserom.gba", 0x8C5A94, 0x60
+sGrimerGfx30_1:
+.incbin "baserom.gba", 0x8C5AF4, 0x100
+sGrimerSprites30:
+ax_sprite sGrimerGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrimerGfx31:
+.incbin "baserom.gba", 0x8C5C1C, 0x20
+sGrimerGfx31_1:
+.incbin "baserom.gba", 0x8C5C3C, 0x60
+sGrimerGfx31_2:
+.incbin "baserom.gba", 0x8C5C9C, 0xC0
+sGrimerSprites31:
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx31, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGrimerGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx31_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGrimerGfx32:
+.incbin "baserom.gba", 0x8C5D9C, 0x40
+sGrimerGfx32_1:
+.incbin "baserom.gba", 0x8C5DDC, 0x60
+sGrimerGfx32_2:
+.incbin "baserom.gba", 0x8C5E3C, 0x60
+sGrimerSprites32:
+ax_sprite sGrimerGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrimerGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGrimerGfx33:
+.incbin "baserom.gba", 0x8C5ED4, 0x40
+sGrimerGfx33_1:
+.incbin "baserom.gba", 0x8C5F14, 0x60
+sGrimerGfx33_2:
+.incbin "baserom.gba", 0x8C5F74, 0x60
+sGrimerSprites33:
+ax_sprite sGrimerGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrimerGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGrimerGfx34:
+.incbin "baserom.gba", 0x8C600C, 0xE0
+sGrimerGfx34_1:
+.incbin "baserom.gba", 0x8C60EC, 0x60
+sGrimerSprites34:
+ax_sprite sGrimerGfx34, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx34_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGrimerGfx35:
+.incbin "baserom.gba", 0x8C6174, 0x60
+sGrimerGfx35_1:
+.incbin "baserom.gba", 0x8C61D4, 0x60
+sGrimerGfx35_2:
+.incbin "baserom.gba", 0x8C6234, 0x60
+sGrimerSprites35:
+ax_sprite sGrimerGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrimerGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGrimerGfx36:
+.incbin "baserom.gba", 0x8C62CC, 0x160
+sGrimerSprites36:
+ax_sprite sGrimerGfx36, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGrimerGfx37:
+.incbin "baserom.gba", 0x8C6444, 0x160
+sGrimerSprites37:
+ax_sprite sGrimerGfx37, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGrimerGfx38:
+.incbin "baserom.gba", 0x8C65BC, 0x200
+sGrimerSprites38:
+ax_sprite sGrimerGfx38, 0x200
+ax_sprite_terminator
+sGrimerGfx39:
+.incbin "baserom.gba", 0x8C67CC, 0x200
+sGrimerSprites39:
+ax_sprite sGrimerGfx39, 0x200
+ax_sprite_terminator
+sGrimerGfx40:
+.incbin "baserom.gba", 0x8C69DC, 0x200
+sGrimerSprites40:
+ax_sprite sGrimerGfx40, 0x200
+ax_sprite_terminator
+sGrimerGfx41:
+.incbin "baserom.gba", 0x8C6BEC, 0x200
+sGrimerSprites41:
+ax_sprite sGrimerGfx41, 0x200
+ax_sprite_terminator
+sGrimerGfx42:
+.incbin "baserom.gba", 0x8C6DFC, 0x200
+sGrimerSprites42:
+ax_sprite sGrimerGfx42, 0x200
+ax_sprite_terminator
+sGrimerGfx43:
+.incbin "baserom.gba", 0x8C700C, 0x200
+sGrimerSprites43:
+ax_sprite sGrimerGfx43, 0x200
+ax_sprite_terminator
+sGrimerGfx44:
+.incbin "baserom.gba", 0x8C721C, 0x200
+sGrimerSprites44:
+ax_sprite sGrimerGfx44, 0x200
+ax_sprite_terminator
+sAxPosesGrimer:
+.4byte sGrimerPose1
+.4byte sGrimerPose2
+.4byte sGrimerPose3
+.4byte sGrimerPose4
+.4byte sGrimerPose5
+.4byte sGrimerPose6
+.4byte sGrimerPose7
+.4byte sGrimerPose8
+.4byte sGrimerPose9
+.4byte sGrimerPose10
+.4byte sGrimerPose11
+.4byte sGrimerPose12
+.4byte sGrimerPose13
+.4byte sGrimerPose14
+.4byte sGrimerPose15
+.4byte sGrimerPose16
+.4byte sGrimerPose17
+.4byte sGrimerPose18
+.4byte sGrimerPose19
+.4byte sGrimerPose20
+.4byte sGrimerPose21
+.4byte sGrimerPose22
+.4byte sGrimerPose23
+.4byte sGrimerPose24
+.4byte sGrimerPose25
+.4byte sGrimerPose26
+.4byte sGrimerPose27
+.4byte sGrimerPose28
+.4byte sGrimerPose29
+.4byte sGrimerPose30
+.4byte sGrimerPose31
+.4byte sGrimerPose32
+.4byte sGrimerPose33
+.4byte sGrimerPose34
+.4byte sGrimerPose35
+.4byte sGrimerPose36
+.4byte sGrimerPose37
+.4byte sGrimerPose38
+.4byte sGrimerPose39
+.4byte sGrimerPose40
+.4byte sGrimerPose41
+.4byte sGrimerPose42
+.4byte sGrimerPose43
+.4byte sGrimerPose44
+.4byte sGrimerPose45
+.4byte sGrimerPose46
+.4byte sGrimerPose47
+.4byte sGrimerPose48
+.4byte sGrimerPose49
+.4byte sGrimerPose50
+.4byte sGrimerPose51
+.4byte sGrimerPose52
+.4byte sGrimerPose53
+.4byte sGrimerPose54
+.4byte sGrimerPose55
+.4byte sGrimerPose56
+.4byte sGrimerPose57
+.4byte sGrimerPose58
+.4byte sGrimerPose59
+.4byte sGrimerPose60
+.4byte sGrimerPose61
+.4byte sGrimerPose62
+.4byte sGrimerPose63
+.4byte sGrimerPose64
+.4byte sGrimerPose65
+.4byte sGrimerPose66
+.4byte sGrimerPose67
+.4byte sGrimerPose68
+.4byte sGrimerPose69
+.4byte sGrimerPose70
+.4byte sGrimerPose71
+.4byte sGrimerPose72
+.4byte sGrimerPose73
+.4byte sGrimerPose74
+.4byte sGrimerPose75
+.4byte sGrimerPose76
+.4byte sGrimerPose77
+.4byte sGrimerPose78
+.4byte sGrimerPose79
+.4byte sGrimerPose80
+.4byte sGrimerPose81
+.4byte sGrimerPose82
+.4byte sGrimerPose83
+.4byte sGrimerPose84
+.4byte sGrimerPose85
+.4byte sGrimerPose86
+.4byte sGrimerPose87
+.4byte sGrimerPose88
+.4byte sGrimerPose89
+.4byte sGrimerPose90
+.4byte sGrimerPose91
+.4byte sGrimerPose92
+.4byte sGrimerPose93
+.4byte sGrimerPose94
+.4byte sGrimerPose95
+.4byte sGrimerPose96
+.4byte sGrimerPose97
+.4byte sGrimerPose98
+.4byte sGrimerPose99
+.4byte sGrimerPose100
+.4byte sGrimerPose101
+.4byte sGrimerPose102
+.4byte sGrimerPose103
+.4byte sGrimerPose104
+.4byte sGrimerPose105
+.4byte sGrimerPose106
+.4byte sGrimerPose107
+.4byte sGrimerPose108
+.4byte sGrimerPose109
+.4byte sGrimerPose110
+.4byte sGrimerPose111
+.4byte sGrimerPose112
+.4byte sGrimerPose113
+.4byte sGrimerPose114
+.4byte sGrimerPose115
+.4byte sGrimerPose116
+.4byte sGrimerPose117
+.4byte sGrimerPose118
+.4byte sGrimerPose119
+.4byte sGrimerPose120
+.4byte sGrimerPose121
+.4byte sGrimerPose122
+.4byte sGrimerPose123
+.4byte sGrimerPose124
+.4byte sGrimerPose125
+.4byte sGrimerPose126
+.4byte sGrimerPose127
+.4byte sGrimerPose128
+.4byte sGrimerPose129
+.4byte sGrimerPose130
+.4byte sGrimerPose131
+.4byte sGrimerPose132
+.4byte sGrimerPose133
+.4byte sGrimerPose134
+.4byte sGrimerPose135
+.4byte sGrimerPose136
+.4byte sGrimerPose137
+.4byte sGrimerPose138
+.4byte sGrimerPose139
+.4byte sGrimerPose140
+.4byte sGrimerPose141
+.4byte sGrimerPose142
+.4byte sGrimerPose143
+.4byte sGrimerPose144
+.4byte sGrimerPose145
+.4byte sGrimerPose146
+.4byte sGrimerPose147
+.4byte sGrimerPose148
+.4byte sGrimerPose149
+.4byte sGrimerPose150
+.4byte sGrimerPose151
+.4byte sGrimerPose152
+.4byte sGrimerPose153
+.4byte sGrimerPose154
+.4byte sGrimerPose155
+.4byte sGrimerPose156
+.4byte sGrimerPose157
+.4byte sGrimerPose158
+.4byte sGrimerPose159
+.4byte sGrimerPose160
+.4byte sGrimerPose161
+.4byte sGrimerPose162
+.4byte sGrimerPose163
+.4byte sGrimerPose164
+.4byte sGrimerPose165
+.4byte sGrimerPose166
+.4byte sGrimerPose167
+.4byte sGrimerPose168
+.4byte sGrimerPose169
+.4byte sGrimerPose170
+.4byte sGrimerPose171
+.4byte sGrimerPose172
+.4byte sGrimerPose173
+.4byte sGrimerPose174
+.4byte sGrimerPose175
+.4byte sGrimerPose176
+.4byte sGrimerPose177
+.4byte sGrimerPose178
+.4byte sGrimerPose179
+.4byte sGrimerPose180
+.4byte sGrimerPose181
+.4byte sGrimerPose182
+.4byte sGrimerPose183
+.4byte sGrimerPose184
+.4byte sGrimerPose185
+.4byte sGrimerPose186
+.4byte sGrimerPose187
+.4byte sGrimerPose188
+.4byte sGrimerPose189
+.4byte sGrimerPose190
+.4byte sGrimerPose191
+.4byte sGrimerPose192
+.4byte sGrimerPose193
+.4byte sGrimerPose194
+.4byte sGrimerPose195
+.4byte sGrimerPose196
+.4byte sGrimerPose197
+.4byte sGrimerPose198
+.4byte sGrimerPose199
+.4byte sGrimerPose200
+.4byte sGrimerPose201
+.4byte sGrimerPose202
+.4byte sGrimerPose203
+.4byte sGrimerPose204
+.4byte sGrimerPose205
+.4byte sGrimerPose206
+.4byte sGrimerPose207
+.4byte sGrimerPose208
+.4byte sGrimerPose209
+.4byte sGrimerPose210
+.4byte sGrimerPose211
+.4byte sGrimerPose212
+.4byte sGrimerPose213
+.4byte sGrimerPose214
+.4byte sGrimerPose215
+.4byte sGrimerPose216
+.4byte sGrimerPose217
+.4byte sGrimerPose218
+.4byte sGrimerPose219
+.4byte sGrimerPose220
+.4byte sGrimerPose221
+.4byte sGrimerPose222
+.4byte sGrimerPose223
+.4byte sGrimerPose224
+.4byte sGrimerPose225
+.4byte sGrimerPose226
+.4byte sGrimerPose227
+.4byte sGrimerPose228
+.4byte sGrimerPose229
+.4byte sGrimerPose230
+.4byte sGrimerPose231
+.4byte sGrimerPose232
+.4byte sGrimerPose233
+.4byte sGrimerPose234
+.4byte sGrimerPose235
+.4byte sGrimerPose236
+.4byte sGrimerPose237
+.4byte sGrimerPose238
+.4byte sGrimerPose239
+.4byte sGrimerPose240
+.4byte sGrimerPose241
+.4byte sGrimerPose242
+.4byte sGrimerPose243
+.4byte sGrimerPose244
+.4byte sGrimerPose245
+.4byte sGrimerPose246
+.4byte sGrimerPose247
+.4byte sGrimerPose248
+.4byte sGrimerPose249
+.4byte sGrimerPose250
+.4byte sGrimerPose251
+.4byte sGrimerPose252
+.4byte sGrimerPose253
+.4byte sGrimerPose254
+.4byte sGrimerPose255
+.4byte sGrimerPose256
+.4byte sGrimerPose257
+.4byte sGrimerPose258
+.4byte sGrimerPose259
+.4byte sGrimerPose260
+.4byte sGrimerPose261
+.4byte sGrimerPose262
+.4byte sGrimerPose263
+.4byte sGrimerPose264
+.4byte sGrimerPose265
+.4byte sGrimerPose266
+.4byte sGrimerPose267
+.4byte sGrimerPose268
+.4byte sGrimerPose269
+.4byte sGrimerPose270
+.4byte sGrimerPose271
+.4byte sGrimerPose272
+.4byte sGrimerPose273
+.4byte sGrimerPose274
+sAxPositionsGrimer:
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -4, 	  -9,   -5, 	   9,   -6, 	   0,   -7
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -5, 	  -8,   -2, 	  -1,   -8
+.2byte    3,   -7, 	   4,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -6, 	   0,   -4, 	  -3,    0, 	  -1,   -6
+.2byte    4,   -5, 	  -6,   -5, 	  -6,    0, 	  -1,   -6
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -4, 	   5,    0, 	  -2,   -6
+.2byte    4,   -7, 	 -10,   -2, 	   2,    0, 	  -3,   -6
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -3, 	  -9,   -3, 	   0,   -7
+.2byte    0,  -12, 	   7,   -2, 	  -9,   -3, 	   0,   -6
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -4, 	  -6,    0, 	   1,   -6
+.2byte   -5,   -7, 	   9,   -2, 	  -3,    0, 	   2,   -6
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -4,   -6, 	  -1,   -4, 	   2,    0, 	   0,   -6
+.2byte   -5,   -5, 	   5,   -5, 	   5,    0, 	   0,   -6
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -7, 	  -8,   -5, 	   7,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -5,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -4, 	  -9,   -5, 	   9,   -6, 	   0,   -7
+.2byte   -2,   -7, 	 -11,  -16, 	   5,   -5, 	  -2,   -9
+.2byte    0,    6, 	  -5,    9, 	  12,   -1, 	   1,   -1
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -5, 	  -8,   -2, 	  -1,   -8
+.2byte    3,   -7, 	   4,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    2,   -6, 	   6,  -17, 	  -1,   -3, 	   0,   -7
+.2byte    8,    2, 	  13,    3, 	  -5,   -4, 	   2,   -4
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -6, 	   0,   -4, 	  -3,    0, 	  -1,   -6
+.2byte    4,   -5, 	  -6,   -5, 	  -6,    0, 	  -1,   -6
+.2byte    2,  -10, 	  -6,  -18, 	   6,   -7, 	  -2,   -8
+.2byte    8,   -4, 	  14,   -7, 	   3,   -9, 	   2,   -6
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -4, 	   5,    0, 	  -2,   -6
+.2byte    4,   -7, 	 -10,   -2, 	   2,    0, 	  -3,   -6
+.2byte    0,   -9, 	 -13,  -13, 	   6,  -10, 	  -3,   -6
+.2byte    5,  -10, 	   6,  -17, 	  12,  -11, 	   1,   -7
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -3, 	  -9,   -3, 	   0,   -7
+.2byte    0,  -12, 	   7,   -2, 	  -9,   -3, 	   0,   -6
+.2byte    2,  -11, 	  11,   -6, 	  -6,  -11, 	   1,   -5
+.2byte    0,  -16, 	   7,  -14, 	  -9,  -14, 	  -1,   -7
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -4, 	  -6,    0, 	   1,   -6
+.2byte   -5,   -7, 	   9,   -2, 	  -3,    0, 	   2,   -6
+.2byte   -1,   -9, 	  12,  -13, 	  -7,  -10, 	   2,   -6
+.2byte   -6,  -10, 	  -7,  -17, 	 -13,  -11, 	  -2,   -7
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -4,   -6, 	  -1,   -4, 	   2,    0, 	   0,   -6
+.2byte   -5,   -5, 	   5,   -5, 	   5,    0, 	   0,   -6
+.2byte   -3,  -10, 	   5,  -18, 	  -7,   -7, 	   1,   -8
+.2byte   -9,   -4, 	 -15,   -7, 	  -4,   -9, 	  -3,   -6
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -7, 	  -8,   -5, 	   7,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -5,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -3,   -6, 	  -7,  -17, 	   0,   -3, 	  -1,   -7
+.2byte   -9,    2, 	 -14,    3, 	   4,   -4, 	  -3,   -4
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -4, 	  -9,   -5, 	   9,   -6, 	   0,   -7
+.2byte   -2,   -7, 	 -11,  -16, 	   5,   -5, 	  -2,   -9
+.2byte    0,    6, 	  -5,    9, 	  12,   -1, 	   1,   -1
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -5, 	  -8,   -2, 	  -1,   -8
+.2byte    3,   -7, 	   4,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    2,   -6, 	   6,  -17, 	  -1,   -3, 	   0,   -7
+.2byte    8,    2, 	  13,    3, 	  -5,   -4, 	   2,   -4
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -6, 	   0,   -4, 	  -3,    0, 	  -1,   -6
+.2byte    4,   -5, 	  -6,   -5, 	  -6,    0, 	  -1,   -6
+.2byte    2,  -10, 	  -6,  -18, 	   6,   -7, 	  -2,   -8
+.2byte    8,   -4, 	  14,   -7, 	   3,   -9, 	   2,   -6
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -4, 	   5,    0, 	  -2,   -6
+.2byte    4,   -7, 	 -10,   -2, 	   2,    0, 	  -3,   -6
+.2byte    0,   -9, 	 -13,  -13, 	   6,  -10, 	  -3,   -6
+.2byte    5,  -10, 	   6,  -17, 	  12,  -11, 	   1,   -7
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -3, 	  -9,   -3, 	   0,   -7
+.2byte    0,  -12, 	   7,   -2, 	  -9,   -3, 	   0,   -6
+.2byte    2,  -11, 	  11,   -6, 	  -6,  -11, 	   1,   -5
+.2byte    0,  -16, 	   7,  -14, 	  -9,  -14, 	  -1,   -7
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -4, 	  -6,    0, 	   1,   -6
+.2byte   -5,   -7, 	   9,   -2, 	  -3,    0, 	   2,   -6
+.2byte   -1,   -9, 	  12,  -13, 	  -7,  -10, 	   2,   -6
+.2byte   -6,  -10, 	  -7,  -17, 	 -13,  -11, 	  -2,   -7
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -4,   -6, 	  -1,   -4, 	   2,    0, 	   0,   -6
+.2byte   -5,   -5, 	   5,   -5, 	   5,    0, 	   0,   -6
+.2byte   -3,  -10, 	   5,  -18, 	  -7,   -7, 	   1,   -8
+.2byte   -9,   -4, 	 -15,   -7, 	  -4,   -9, 	  -3,   -6
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -7, 	  -8,   -5, 	   7,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -5,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -3,   -6, 	  -7,  -17, 	   0,   -3, 	  -1,   -7
+.2byte   -9,    2, 	 -14,    3, 	   4,   -4, 	  -3,   -4
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -4, 	  -9,   -5, 	   9,   -6, 	   0,   -7
+.2byte    0,   -3, 	 -12,  -10, 	  11,  -11, 	   0,   -6
+.2byte    0,   -1, 	 -12,   -5, 	  11,   -6, 	   0,   -5
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -5, 	  -8,   -2, 	  -1,   -8
+.2byte    3,   -7, 	   4,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    3,   -4, 	  10,  -14, 	  -8,   -9, 	   0,   -6
+.2byte    5,   -1, 	  12,   -8, 	  -6,   -4, 	   2,   -4
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -6, 	   0,   -4, 	  -3,    0, 	  -1,   -6
+.2byte    4,   -5, 	  -6,   -5, 	  -6,    0, 	  -1,   -6
+.2byte    5,   -6, 	   5,  -17, 	   1,   -9, 	  -1,   -6
+.2byte    6,   -4, 	   8,  -13, 	  -4,   -6, 	   0,   -4
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -4, 	   5,    0, 	  -2,   -6
+.2byte    4,   -7, 	 -10,   -2, 	   2,    0, 	  -3,   -6
+.2byte    5,  -10, 	  -7,  -16, 	  10,  -11, 	  -1,   -7
+.2byte    6,   -8, 	  -6,  -13, 	  11,   -7, 	   0,   -6
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -3, 	  -9,   -3, 	   0,   -7
+.2byte    0,  -12, 	   7,   -2, 	  -9,   -3, 	   0,   -6
+.2byte   -1,  -16, 	  11,  -16, 	 -12,  -16, 	   0,   -9
+.2byte    0,  -14, 	  10,  -13, 	 -11,  -13, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -4, 	  -6,    0, 	   1,   -6
+.2byte   -5,   -7, 	   9,   -2, 	  -3,    0, 	   2,   -6
+.2byte   -6,  -10, 	   6,  -16, 	 -11,  -11, 	   0,   -7
+.2byte   -7,   -8, 	   5,  -13, 	 -12,   -7, 	  -1,   -6
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -4,   -6, 	  -1,   -4, 	   2,    0, 	   0,   -6
+.2byte   -5,   -5, 	   5,   -5, 	   5,    0, 	   0,   -6
+.2byte   -6,   -6, 	  -6,  -17, 	  -2,   -9, 	   0,   -6
+.2byte   -7,   -4, 	  -9,  -13, 	   3,   -6, 	  -1,   -4
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -7, 	  -8,   -5, 	   7,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -5,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -4,   -4, 	 -11,  -14, 	   7,   -9, 	  -1,   -6
+.2byte   -6,   -1, 	 -13,   -8, 	   5,   -4, 	  -3,   -4
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte   -4,   -4, 	 -10,   -4, 	   5,   -2, 	  -1,   -5
+.2byte   -4,   -3, 	  -9,   -4, 	   6,   -1, 	  -1,   -3
+.2byte    0,   -2, 	 -11,  -10, 	  12,  -12, 	   1,   -4
+.2byte    5,   -3, 	   9,  -13, 	  -9,   -9, 	   0,   -5
+.2byte    6,   -5, 	   8,  -14, 	  -5,  -11, 	   0,   -4
+.2byte    3,   -7, 	  -9,  -15, 	  10,  -12, 	  -2,   -4
+.2byte    0,   -6, 	  12,  -11, 	 -12,  -11, 	   1,   -4
+.2byte   -4,   -7, 	   8,  -15, 	 -11,  -12, 	   1,   -4
+.2byte   -7,   -5, 	  -9,  -14, 	   4,  -11, 	  -1,   -4
+.2byte   -6,   -3, 	 -10,  -13, 	   8,   -9, 	  -1,   -5
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -4, 	  -9,   -5, 	   9,   -6, 	   0,   -7
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte    3,   -6, 	   7,   -4, 	  -8,   -1, 	  -1,   -7
+.2byte    3,   -5, 	   4,   -7, 	  -9,   -3, 	   0,   -6
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -6, 	   0,   -4, 	  -3,    0, 	  -1,   -6
+.2byte    4,   -5, 	  -6,   -5, 	  -6,    0, 	  -1,   -6
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -4, 	   5,    0, 	  -2,   -6
+.2byte    4,   -7, 	 -10,   -2, 	   2,    0, 	  -3,   -6
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -3, 	  -9,   -3, 	   0,   -7
+.2byte    0,  -12, 	   7,   -2, 	  -9,   -3, 	   0,   -6
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -4, 	  -6,    0, 	   1,   -6
+.2byte   -5,   -7, 	   9,   -2, 	  -3,    0, 	   2,   -6
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -4,   -6, 	  -1,   -4, 	   2,    0, 	   0,   -6
+.2byte   -5,   -5, 	   5,   -5, 	   5,    0, 	   0,   -6
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -6, 	  -8,   -4, 	   7,   -1, 	   0,   -7
+.2byte   -4,   -5, 	  -5,   -7, 	   8,   -3, 	  -1,   -6
+.2byte    0,   -2, 	 -12,   -6, 	  11,   -7, 	   0,   -6
+.2byte   -5,   -1, 	 -12,   -8, 	   6,   -4, 	  -2,   -4
+.2byte   -6,   -4, 	  -8,  -13, 	   4,   -6, 	   0,   -4
+.2byte   -6,   -7, 	   6,  -12, 	 -11,   -6, 	   0,   -5
+.2byte    0,  -12, 	  10,  -11, 	 -11,  -11, 	   0,   -5
+.2byte    5,   -7, 	  -7,  -12, 	  10,   -6, 	  -1,   -5
+.2byte    5,   -4, 	   7,  -13, 	  -5,   -6, 	  -1,   -4
+.2byte    4,   -1, 	  11,   -8, 	  -7,   -4, 	   1,   -4
+.2byte    0,   -2, 	 -12,   -6, 	  11,   -7, 	   0,   -6
+.2byte    4,   -1, 	  11,   -8, 	  -7,   -4, 	   1,   -4
+.2byte    5,   -4, 	   7,  -13, 	  -5,   -6, 	  -1,   -4
+.2byte    5,   -7, 	  -7,  -12, 	  10,   -6, 	  -1,   -5
+.2byte    0,  -12, 	  10,  -11, 	 -11,  -11, 	   0,   -5
+.2byte   -6,   -7, 	   6,  -12, 	 -11,   -6, 	   0,   -5
+.2byte   -6,   -4, 	  -8,  -13, 	   4,   -6, 	   0,   -4
+.2byte   -5,   -1, 	 -12,   -8, 	   6,   -4, 	  -2,   -4
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -2,   -8, 	 -11,  -17, 	   5,   -6, 	  -2,  -10
+.2byte    0,   -3, 	 -12,  -10, 	  11,  -11, 	   0,   -6
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte    2,   -6, 	   6,  -17, 	  -1,   -3, 	   0,   -7
+.2byte    2,   -3, 	   9,  -13, 	  -9,   -8, 	  -1,   -5
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    4,  -10, 	  -4,  -18, 	   8,   -7, 	   0,   -8
+.2byte    4,   -6, 	   4,  -17, 	   0,   -9, 	  -2,   -6
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    1,  -10, 	 -12,  -14, 	   7,  -11, 	  -2,   -7
+.2byte    4,  -10, 	  -8,  -16, 	   9,  -11, 	  -2,   -7
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    1,  -13, 	  10,   -8, 	  -7,  -13, 	   0,   -7
+.2byte   -1,  -14, 	  11,  -14, 	 -12,  -14, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -2,  -10, 	  11,  -14, 	  -8,  -11, 	   1,   -7
+.2byte   -5,  -10, 	   7,  -16, 	 -10,  -11, 	   1,   -7
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -5,  -10, 	   3,  -18, 	  -9,   -7, 	  -1,   -8
+.2byte   -5,   -6, 	  -5,  -17, 	  -1,   -9, 	   1,   -6
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -3,   -6, 	  -7,  -17, 	   0,   -3, 	  -1,   -7
+.2byte   -3,   -3, 	 -10,  -13, 	   8,   -8, 	   0,   -5
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -1,   -4, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -4, 	  -9,   -5, 	   9,   -6, 	   0,   -7
+.2byte    0,   -3, 	 -12,  -10, 	  11,  -11, 	   0,   -6
+.2byte    0,   -1, 	 -12,   -5, 	  11,   -6, 	   0,   -5
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -5, 	  -8,   -2, 	  -1,   -8
+.2byte    3,   -7, 	   4,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    3,   -4, 	  10,  -14, 	  -8,   -9, 	   0,   -6
+.2byte    5,   -1, 	  12,   -8, 	  -6,   -4, 	   2,   -4
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -6, 	   0,   -4, 	  -3,    0, 	  -1,   -6
+.2byte    4,   -5, 	  -6,   -5, 	  -6,    0, 	  -1,   -6
+.2byte    5,   -6, 	   5,  -17, 	   1,   -9, 	  -1,   -6
+.2byte    6,   -4, 	   8,  -13, 	  -4,   -6, 	   0,   -4
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -4, 	   5,    0, 	  -2,   -6
+.2byte    4,   -7, 	 -10,   -2, 	   2,    0, 	  -3,   -6
+.2byte    5,  -10, 	  -7,  -16, 	  10,  -11, 	  -1,   -7
+.2byte    6,   -8, 	  -6,  -13, 	  11,   -7, 	   0,   -6
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -3, 	  -9,   -3, 	   0,   -7
+.2byte    0,  -12, 	   7,   -2, 	  -9,   -3, 	   0,   -6
+.2byte   -1,  -16, 	  11,  -16, 	 -12,  -16, 	   0,   -9
+.2byte    0,  -14, 	  10,  -13, 	 -11,  -13, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -5,   -9, 	   7,   -4, 	  -6,    0, 	   1,   -6
+.2byte   -5,   -7, 	   9,   -2, 	  -3,    0, 	   2,   -6
+.2byte   -6,  -10, 	   6,  -16, 	 -11,  -11, 	   0,   -7
+.2byte   -7,   -8, 	   5,  -13, 	 -12,   -7, 	  -1,   -6
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -4,   -6, 	  -1,   -4, 	   2,    0, 	   0,   -6
+.2byte   -5,   -5, 	   5,   -5, 	   5,    0, 	   0,   -6
+.2byte   -6,   -6, 	  -6,  -17, 	  -2,   -9, 	   0,   -6
+.2byte   -7,   -4, 	  -9,  -13, 	   3,   -6, 	  -1,   -4
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -7, 	  -8,   -5, 	   7,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -5,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -4,   -4, 	 -11,  -14, 	   7,   -9, 	  -1,   -6
+.2byte   -6,   -1, 	 -13,   -8, 	   5,   -4, 	  -3,   -4
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	   0,   -8
+.2byte   -4,   -7, 	  -9,   -3, 	   5,   -1, 	   0,   -7
+.2byte   -4,   -7, 	   3,   -4, 	   0,    0, 	   0,   -6
+.2byte   -5,   -9, 	   7,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -1,  -13, 	   9,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte    4,   -9, 	  -8,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    3,   -7, 	  -4,   -4, 	  -1,    0, 	  -1,   -6
+.2byte    3,   -7, 	   8,   -3, 	  -6,   -1, 	  -1,   -7
+sGrimerAnimTable1:
+.4byte sGrimerAnims_1_1
+.4byte sGrimerAnims_1_2
+.4byte sGrimerAnims_1_3
+.4byte sGrimerAnims_1_4
+.4byte sGrimerAnims_1_5
+.4byte sGrimerAnims_1_6
+.4byte sGrimerAnims_1_7
+.4byte sGrimerAnims_1_8
+sGrimerAnimTable2:
+.4byte sGrimerAnims_2_1
+.4byte sGrimerAnims_2_2
+.4byte sGrimerAnims_2_3
+.4byte sGrimerAnims_2_4
+.4byte sGrimerAnims_2_5
+.4byte sGrimerAnims_2_6
+.4byte sGrimerAnims_2_7
+.4byte sGrimerAnims_2_8
+sGrimerAnimTable3:
+.4byte sGrimerAnims_3_1
+.4byte sGrimerAnims_3_2
+.4byte sGrimerAnims_3_3
+.4byte sGrimerAnims_3_4
+.4byte sGrimerAnims_3_5
+.4byte sGrimerAnims_3_6
+.4byte sGrimerAnims_3_7
+.4byte sGrimerAnims_3_8
+sGrimerAnimTable4:
+.4byte sGrimerAnims_4_1
+.4byte sGrimerAnims_4_2
+.4byte sGrimerAnims_4_3
+.4byte sGrimerAnims_4_4
+.4byte sGrimerAnims_4_5
+.4byte sGrimerAnims_4_6
+.4byte sGrimerAnims_4_7
+.4byte sGrimerAnims_4_8
+sGrimerAnimTable5:
+.4byte sGrimerAnims_5_1
+.4byte sGrimerAnims_5_2
+.4byte sGrimerAnims_5_3
+.4byte sGrimerAnims_5_4
+.4byte sGrimerAnims_5_5
+.4byte sGrimerAnims_5_6
+.4byte sGrimerAnims_5_7
+.4byte sGrimerAnims_5_8
+sGrimerAnimTable6:
+.4byte sGrimerAnims_6_1
+.4byte sGrimerAnims_6_1
+.4byte sGrimerAnims_6_1
+.4byte sGrimerAnims_6_1
+.4byte sGrimerAnims_6_1
+.4byte sGrimerAnims_6_1
+.4byte sGrimerAnims_6_1
+.4byte sGrimerAnims_6_1
+sGrimerAnimTable7:
+.4byte sGrimerAnims_7_1
+.4byte sGrimerAnims_7_2
+.4byte sGrimerAnims_7_3
+.4byte sGrimerAnims_7_4
+.4byte sGrimerAnims_7_5
+.4byte sGrimerAnims_7_6
+.4byte sGrimerAnims_7_7
+.4byte sGrimerAnims_7_8
+sGrimerAnimTable8:
+.4byte sGrimerAnims_8_1
+.4byte sGrimerAnims_8_2
+.4byte sGrimerAnims_8_3
+.4byte sGrimerAnims_8_4
+.4byte sGrimerAnims_8_5
+.4byte sGrimerAnims_8_6
+.4byte sGrimerAnims_8_7
+.4byte sGrimerAnims_8_8
+sGrimerAnimTable9:
+.4byte sGrimerAnims_9_1
+.4byte sGrimerAnims_9_2
+.4byte sGrimerAnims_9_3
+.4byte sGrimerAnims_9_4
+.4byte sGrimerAnims_9_5
+.4byte sGrimerAnims_9_6
+.4byte sGrimerAnims_9_7
+.4byte sGrimerAnims_9_8
+sGrimerAnimTable10:
+.4byte sGrimerAnims_10_1
+.4byte sGrimerAnims_10_2
+.4byte sGrimerAnims_10_3
+.4byte sGrimerAnims_10_4
+.4byte sGrimerAnims_10_5
+.4byte sGrimerAnims_10_6
+.4byte sGrimerAnims_10_7
+.4byte sGrimerAnims_10_8
+sGrimerAnimTable11:
+.4byte sGrimerAnims_11_1
+.4byte sGrimerAnims_11_2
+.4byte sGrimerAnims_11_3
+.4byte sGrimerAnims_11_4
+.4byte sGrimerAnims_11_5
+.4byte sGrimerAnims_11_6
+.4byte sGrimerAnims_11_7
+.4byte sGrimerAnims_11_8
+sGrimerAnimTable12:
+.4byte sGrimerAnims_12_1
+.4byte sGrimerAnims_12_2
+.4byte sGrimerAnims_12_3
+.4byte sGrimerAnims_12_4
+.4byte sGrimerAnims_12_5
+.4byte sGrimerAnims_12_6
+.4byte sGrimerAnims_12_7
+.4byte sGrimerAnims_12_8
+sGrimerAnimTable13:
+.4byte sGrimerAnims_13_1
+.4byte sGrimerAnims_13_2
+.4byte sGrimerAnims_13_3
+.4byte sGrimerAnims_13_4
+.4byte sGrimerAnims_13_5
+.4byte sGrimerAnims_13_6
+.4byte sGrimerAnims_13_7
+.4byte sGrimerAnims_13_8
+sAxAnimationsGrimer:
+.4byte sGrimerAnimTable1
+.4byte sGrimerAnimTable2
+.4byte sGrimerAnimTable3
+.4byte sGrimerAnimTable4
+.4byte sGrimerAnimTable5
+.4byte sGrimerAnimTable6
+.4byte sGrimerAnimTable7
+.4byte sGrimerAnimTable8
+.4byte sGrimerAnimTable9
+.4byte sGrimerAnimTable10
+.4byte sGrimerAnimTable11
+.4byte sGrimerAnimTable12
+.4byte sGrimerAnimTable13
+sAxSpritesGrimer:
+.4byte sGrimerSprites1
+.4byte sGrimerSprites2
+.4byte sGrimerSprites3
+.4byte sGrimerSprites4
+.4byte sGrimerSprites5
+.4byte sGrimerSprites6
+.4byte sGrimerSprites7
+.4byte sGrimerSprites8
+.4byte sGrimerSprites9
+.4byte sGrimerSprites10
+.4byte sGrimerSprites11
+.4byte sGrimerSprites12
+.4byte sGrimerSprites13
+.4byte sGrimerSprites14
+.4byte sGrimerSprites15
+.4byte sGrimerSprites16
+.4byte sGrimerSprites17
+.4byte sGrimerSprites18
+.4byte sGrimerSprites19
+.4byte sGrimerSprites20
+.4byte sGrimerSprites21
+.4byte sGrimerSprites22
+.4byte sGrimerSprites23
+.4byte sGrimerSprites24
+.4byte sGrimerSprites25
+.4byte sGrimerSprites26
+.4byte sGrimerSprites27
+.4byte sGrimerSprites28
+.4byte sGrimerSprites29
+.4byte sGrimerSprites30
+.4byte sGrimerSprites31
+.4byte sGrimerSprites32
+.4byte sGrimerSprites33
+.4byte sGrimerSprites34
+.4byte sGrimerSprites35
+.4byte sGrimerSprites36
+.4byte sGrimerSprites37
+.4byte sGrimerSprites38
+.4byte sGrimerSprites39
+.4byte sGrimerSprites40
+.4byte sGrimerSprites41
+.4byte sGrimerSprites42
+.4byte sGrimerSprites43
+.4byte sGrimerSprites44
+sAxMainGrimer:
+ax_main sAxPosesGrimer, sAxAnimationsGrimer, 13, sAxSpritesGrimer, sAxPositionsGrimer

--- a/data/ax/groudon.inc
+++ b/data/ax/groudon.inc
@@ -1,0 +1,4132 @@
+.global gAxGroudon
+gAxGroudon:
+ax_siro sAxMainGroudon
+sGroudonPose1:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose2:
+ax_pose 1, 0x01df, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose3:
+ax_pose 2, 0x01df, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose4:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose5:
+ax_pose 4, 0x01de, 0xd0d8, 0x5c00
+ax_pose_terminator
+sGroudonPose6:
+ax_pose 5, 0x01de, 0xd0d6, 0x5c00
+ax_pose_terminator
+sGroudonPose7:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose8:
+ax_pose 7, 0x01da, 0xd0db, 0x5c00
+ax_pose_terminator
+sGroudonPose9:
+ax_pose 8, 0x01db, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose10:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose11:
+ax_pose 10, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose12:
+ax_pose 11, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose13:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose14:
+ax_pose 13, 0x01d5, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose15:
+ax_pose 14, 0x01d5, 0xc0ed, 0x5c00
+ax_pose_terminator
+sGroudonPose16:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose17:
+ax_pose 10, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose18:
+ax_pose 11, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose19:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose20:
+ax_pose 7, 0x01da, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose21:
+ax_pose 8, 0x01db, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose22:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose23:
+ax_pose 4, 0x01de, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose24:
+ax_pose 5, 0x01de, 0xc0ea, 0x5c00
+ax_pose_terminator
+sGroudonPose25:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose26:
+ax_pose 1, 0x01df, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose27:
+ax_pose 2, 0x01df, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose28:
+ax_pose 15, 0x01d7, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose29:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose30:
+ax_pose 4, 0x01de, 0xd0d8, 0x5c00
+ax_pose_terminator
+sGroudonPose31:
+ax_pose 5, 0x01de, 0xd0d6, 0x5c00
+ax_pose_terminator
+sGroudonPose32:
+ax_pose 16, 0x01d7, 0xd0df, 0x5c00
+ax_pose_terminator
+sGroudonPose33:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose34:
+ax_pose 7, 0x01da, 0xd0db, 0x5c00
+ax_pose_terminator
+sGroudonPose35:
+ax_pose 8, 0x01db, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose36:
+ax_pose 17, 0x01d0, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose37:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose38:
+ax_pose 10, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose39:
+ax_pose 11, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose40:
+ax_pose 18, 0x01cf, 0xd0da, 0x5c00
+ax_pose_terminator
+sGroudonPose41:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose42:
+ax_pose 13, 0x01d5, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose43:
+ax_pose 14, 0x01d5, 0xc0ed, 0x5c00
+ax_pose_terminator
+sGroudonPose44:
+ax_pose 19, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose45:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose46:
+ax_pose 10, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose47:
+ax_pose 11, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose48:
+ax_pose 18, 0x01cf, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose49:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose50:
+ax_pose 7, 0x01da, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose51:
+ax_pose 8, 0x01db, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose52:
+ax_pose 17, 0x01d0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose53:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose54:
+ax_pose 4, 0x01de, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose55:
+ax_pose 5, 0x01de, 0xc0ea, 0x5c00
+ax_pose_terminator
+sGroudonPose56:
+ax_pose 16, 0x01d7, 0xc0e1, 0x5c00
+ax_pose_terminator
+sGroudonPose57:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose58:
+ax_pose 1, 0x01df, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose59:
+ax_pose 2, 0x01df, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose60:
+ax_pose 15, 0x01d7, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose61:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose62:
+ax_pose 4, 0x01de, 0xd0d8, 0x5c00
+ax_pose_terminator
+sGroudonPose63:
+ax_pose 5, 0x01de, 0xd0d6, 0x5c00
+ax_pose_terminator
+sGroudonPose64:
+ax_pose 16, 0x01d7, 0xd0df, 0x5c00
+ax_pose_terminator
+sGroudonPose65:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose66:
+ax_pose 7, 0x01da, 0xd0db, 0x5c00
+ax_pose_terminator
+sGroudonPose67:
+ax_pose 8, 0x01db, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose68:
+ax_pose 17, 0x01d0, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose69:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose70:
+ax_pose 10, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose71:
+ax_pose 11, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose72:
+ax_pose 18, 0x01cf, 0xd0da, 0x5c00
+ax_pose_terminator
+sGroudonPose73:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose74:
+ax_pose 13, 0x01d5, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose75:
+ax_pose 14, 0x01d5, 0xc0ed, 0x5c00
+ax_pose_terminator
+sGroudonPose76:
+ax_pose 19, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose77:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose78:
+ax_pose 10, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose79:
+ax_pose 11, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose80:
+ax_pose 18, 0x01cf, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose81:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose82:
+ax_pose 7, 0x01da, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose83:
+ax_pose 8, 0x01db, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose84:
+ax_pose 17, 0x01d0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose85:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose86:
+ax_pose 4, 0x01de, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose87:
+ax_pose 5, 0x01de, 0xc0ea, 0x5c00
+ax_pose_terminator
+sGroudonPose88:
+ax_pose 16, 0x01d7, 0xc0e1, 0x5c00
+ax_pose_terminator
+sGroudonPose89:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose90:
+ax_pose 20, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose91:
+ax_pose 15, 0x01d7, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose92:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose93:
+ax_pose 21, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose94:
+ax_pose 16, 0x01d7, 0xd0df, 0x5c00
+ax_pose_terminator
+sGroudonPose95:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose96:
+ax_pose 22, 0x01d0, 0xd0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose97:
+ax_pose 17, 0x01d0, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose98:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose99:
+ax_pose 23, 0x01cd, 0xd0de, 0x5c00
+ax_pose_terminator
+sGroudonPose100:
+ax_pose 18, 0x01cf, 0xd0da, 0x5c00
+ax_pose_terminator
+sGroudonPose101:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose102:
+ax_pose 24, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose103:
+ax_pose 19, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose104:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose105:
+ax_pose 23, 0x01cd, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose106:
+ax_pose 18, 0x01cf, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose107:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose108:
+ax_pose 22, 0x01d0, 0xc0dc, 0x5c00
+ax_pose_terminator
+sGroudonPose109:
+ax_pose 17, 0x01d0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose110:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose111:
+ax_pose 21, 0x01d2, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose112:
+ax_pose 16, 0x01d7, 0xc0e1, 0x5c00
+ax_pose_terminator
+sGroudonPose113:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose114:
+ax_pose 20, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose115:
+ax_pose 25, 0x01d4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose116:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose117:
+ax_pose 21, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose118:
+ax_pose 26, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose119:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose120:
+ax_pose 22, 0x01d0, 0xd0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose121:
+ax_pose 27, 0x01d0, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose122:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose123:
+ax_pose 23, 0x01cd, 0xd0de, 0x5c00
+ax_pose_terminator
+sGroudonPose124:
+ax_pose 28, 0x01cc, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose125:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose126:
+ax_pose 24, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose127:
+ax_pose 29, 0x01cf, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose128:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose129:
+ax_pose 23, 0x01cd, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose130:
+ax_pose 28, 0x01cc, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose131:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose132:
+ax_pose 22, 0x01d0, 0xc0dc, 0x5c00
+ax_pose_terminator
+sGroudonPose133:
+ax_pose 27, 0x01d0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose134:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose135:
+ax_pose 21, 0x01d2, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose136:
+ax_pose 26, 0x01d2, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose137:
+ax_pose 30, 0x01db, 0x80ec, 0x5c00
+ax_pose 31, 0x41fb, 0x80ec, 0x5c10
+ax_pose 32, 0x81eb, 0x810c, 0x5c18
+ax_pose_terminator
+sGroudonPose138:
+ax_pose 33, 0x01db, 0x80ec, 0x5c00
+ax_pose 34, 0x41fb, 0x80ec, 0x5c10
+ax_pose 35, 0x81eb, 0x810c, 0x5c18
+ax_pose_terminator
+sGroudonPose139:
+ax_pose 36, 0x01d5, 0xc0ea, 0x5c00
+ax_pose_terminator
+sGroudonPose140:
+ax_pose 37, 0x01da, 0xd0d8, 0x5c00
+ax_pose_terminator
+sGroudonPose141:
+ax_pose 38, 0x4203, 0x10f0, 0x5c00
+ax_pose 39, 0x41e3, 0xd0d8, 0x5c02
+ax_pose_terminator
+sGroudonPose142:
+ax_pose 40, 0x01d7, 0xd0d6, 0x5c00
+ax_pose_terminator
+sGroudonPose143:
+ax_pose 41, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose144:
+ax_pose 40, 0x01d7, 0xc0ea, 0x5c00
+ax_pose_terminator
+sGroudonPose145:
+ax_pose 38, 0x4203, 0x0100, 0x5c00
+ax_pose 39, 0x41e3, 0xc0e8, 0x5c02
+ax_pose_terminator
+sGroudonPose146:
+ax_pose 37, 0x01da, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose147:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose148:
+ax_pose 20, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose149:
+ax_pose 25, 0x01d4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose150:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose151:
+ax_pose 21, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose152:
+ax_pose 26, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose153:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose154:
+ax_pose 22, 0x01d0, 0xd0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose155:
+ax_pose 27, 0x01d0, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose156:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose157:
+ax_pose 23, 0x01cd, 0xd0de, 0x5c00
+ax_pose_terminator
+sGroudonPose158:
+ax_pose 28, 0x01cc, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose159:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose160:
+ax_pose 24, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose161:
+ax_pose 29, 0x01cf, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose162:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose163:
+ax_pose 23, 0x01cd, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose164:
+ax_pose 28, 0x01cc, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose165:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose166:
+ax_pose 22, 0x01d0, 0xc0dc, 0x5c00
+ax_pose_terminator
+sGroudonPose167:
+ax_pose 27, 0x01d0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose168:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose169:
+ax_pose 21, 0x01d2, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose170:
+ax_pose 26, 0x01d2, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose171:
+ax_pose 15, 0x01d7, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose172:
+ax_pose 16, 0x01d3, 0xc0e5, 0x5c00
+ax_pose_terminator
+sGroudonPose173:
+ax_pose 17, 0x01d2, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose174:
+ax_pose 18, 0x01d0, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose175:
+ax_pose 19, 0x01cf, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose176:
+ax_pose 18, 0x01d0, 0xd0da, 0x5c00
+ax_pose_terminator
+sGroudonPose177:
+ax_pose 17, 0x01d2, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose178:
+ax_pose 16, 0x01d3, 0xd0db, 0x5c00
+ax_pose_terminator
+sGroudonPose179:
+ax_pose 15, 0x01d7, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose180:
+ax_pose 16, 0x01d3, 0xd0db, 0x5c00
+ax_pose_terminator
+sGroudonPose181:
+ax_pose 17, 0x01d2, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose182:
+ax_pose 18, 0x01d0, 0xd0da, 0x5c00
+ax_pose_terminator
+sGroudonPose183:
+ax_pose 19, 0x01cf, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose184:
+ax_pose 18, 0x01d0, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose185:
+ax_pose 17, 0x01d2, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose186:
+ax_pose 16, 0x01d3, 0xc0e5, 0x5c00
+ax_pose_terminator
+sGroudonPose187:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose188:
+ax_pose 20, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose189:
+ax_pose 25, 0x01d4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose190:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose191:
+ax_pose 21, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose192:
+ax_pose 26, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose193:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose194:
+ax_pose 22, 0x01d0, 0xd0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose195:
+ax_pose 27, 0x01d0, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose196:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose197:
+ax_pose 23, 0x01cd, 0xd0de, 0x5c00
+ax_pose_terminator
+sGroudonPose198:
+ax_pose 28, 0x01cc, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose199:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose200:
+ax_pose 24, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose201:
+ax_pose 29, 0x01cf, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose202:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose203:
+ax_pose 23, 0x01cd, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGroudonPose204:
+ax_pose 28, 0x01cc, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose205:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose206:
+ax_pose 22, 0x01d0, 0xc0dc, 0x5c00
+ax_pose_terminator
+sGroudonPose207:
+ax_pose 27, 0x01d0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose208:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose209:
+ax_pose 21, 0x01d2, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose210:
+ax_pose 26, 0x01d2, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose211:
+ax_pose 25, 0x01d4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose212:
+ax_pose 26, 0x01d2, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose213:
+ax_pose 27, 0x01d0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose214:
+ax_pose 28, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGroudonPose215:
+ax_pose 29, 0x01cf, 0xc0e4, 0x5c00
+ax_pose_terminator
+sGroudonPose216:
+ax_pose 28, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose217:
+ax_pose 27, 0x01d0, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose218:
+ax_pose 26, 0x01d2, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGroudonPose219:
+ax_pose 0, 0x01de, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose220:
+ax_pose 3, 0x01dd, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose221:
+ax_pose 6, 0x01da, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose222:
+ax_pose 9, 0x01d5, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose223:
+ax_pose 12, 0x01d4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose224:
+ax_pose 9, 0x01d5, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose225:
+ax_pose 6, 0x01da, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose226:
+ax_pose 3, 0x01dd, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose227:
+ax_pose 42, 0x01e3, 0x80e7, 0x5c00
+ax_pose 43, 0x81e3, 0x8107, 0x5c10
+ax_pose 44, 0x4203, 0x00ec, 0x5c18
+ax_pose_terminator
+sGroudonPose228:
+ax_pose 45, 0x01e3, 0x80e7, 0x5c00
+ax_pose 46, 0x81e3, 0x8107, 0x5c10
+ax_pose 47, 0x4203, 0x00ec, 0x5c18
+ax_pose_terminator
+sGroudonPose229:
+ax_pose 42, 0x01e3, 0x80e6, 0x5c00
+ax_pose 43, 0x81e3, 0x8106, 0x5c10
+ax_pose 44, 0x4203, 0x00eb, 0x5c18
+ax_pose_terminator
+sGroudonPose230:
+ax_pose 45, 0x01e3, 0x80e6, 0x5c00
+ax_pose 46, 0x81e3, 0x8106, 0x5c10
+ax_pose 47, 0x4203, 0x00eb, 0x5c18
+ax_pose_terminator
+sGroudonPose231:
+ax_pose 48, 0x01e7, 0x80e4, 0x5c00
+ax_pose 49, 0x81e7, 0x8104, 0x5c10
+ax_pose 50, 0x41df, 0x40ec, 0x5c18
+ax_pose_terminator
+sGroudonPose232:
+ax_pose 51, 0x01eb, 0x80e6, 0x5c00
+ax_pose 52, 0x81eb, 0x8106, 0x5c10
+ax_pose 53, 0x41e3, 0x40ee, 0x5c18
+ax_pose_terminator
+sGroudonPose233:
+ax_pose 54, 0x01ea, 0x80e4, 0x5c00
+ax_pose 55, 0x420a, 0x80e4, 0x5c10
+ax_pose 56, 0x81ea, 0x8104, 0x5c18
+ax_pose 57, 0x020a, 0x4104, 0x5c20
+ax_pose 58, 0x8206, 0x0114, 0x5c24
+ax_pose_terminator
+sGroudonPose234:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose235:
+ax_pose 20, 0x01d4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGroudonPose236:
+ax_pose 0, 0x01dd, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose237:
+ax_pose 1, 0x01df, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose238:
+ax_pose 2, 0x01df, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose239:
+ax_pose 3, 0x01dc, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose240:
+ax_pose 4, 0x01de, 0xd0d8, 0x5c00
+ax_pose_terminator
+sGroudonPose241:
+ax_pose 5, 0x01de, 0xd0d6, 0x5c00
+ax_pose_terminator
+sGroudonPose242:
+ax_pose 6, 0x01d9, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose243:
+ax_pose 7, 0x01da, 0xd0db, 0x5c00
+ax_pose_terminator
+sGroudonPose244:
+ax_pose 8, 0x01db, 0xd0d9, 0x5c00
+ax_pose_terminator
+sGroudonPose245:
+ax_pose 9, 0x01d4, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose246:
+ax_pose 10, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose247:
+ax_pose 11, 0x01d6, 0xd0d5, 0x5c00
+ax_pose_terminator
+sGroudonPose248:
+ax_pose 12, 0x01d3, 0xc0ec, 0x5c00
+ax_pose_terminator
+sGroudonPose249:
+ax_pose 13, 0x01d5, 0xc0ee, 0x5c00
+ax_pose_terminator
+sGroudonPose250:
+ax_pose 14, 0x01d5, 0xc0ed, 0x5c00
+ax_pose_terminator
+sGroudonPose251:
+ax_pose 9, 0x01d4, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose252:
+ax_pose 10, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose253:
+ax_pose 11, 0x01d6, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose254:
+ax_pose 6, 0x01d9, 0xc0e7, 0x5c00
+ax_pose_terminator
+sGroudonPose255:
+ax_pose 7, 0x01da, 0xc0e6, 0x5c00
+ax_pose_terminator
+sGroudonPose256:
+ax_pose 8, 0x01db, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose257:
+ax_pose 3, 0x01dc, 0xc0eb, 0x5c00
+ax_pose_terminator
+sGroudonPose258:
+ax_pose 4, 0x01de, 0xc0e8, 0x5c00
+ax_pose_terminator
+sGroudonPose259:
+ax_pose 5, 0x01de, 0xc0ea, 0x5c00
+ax_pose_terminator
+.align 2
+sGroudonAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 4, 0, 4,
+ax_anim 2, 2, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGroudonAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 3, 3, 3, 3,
+ax_anim 2, 2, 29, 8, 8, 8, 8,
+ax_anim 2, 0, 31, 12, 11, 12, 11,
+ax_anim 2, 1, 31, 13, 10, 13, 10,
+ax_anim 2, 0, 31, 12, 11, 12, 11,
+ax_anim 2, 0, 31, 13, 10, 13, 10,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sGroudonAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 2, 0, 4, 0,
+ax_anim 2, 2, 33, 6, 0, 10, 0,
+ax_anim 2, 0, 35, 12, 0, 12, 0,
+ax_anim 2, 1, 35, 12, 1, 12, 1,
+ax_anim 2, 0, 35, 12, 0, 12, 0,
+ax_anim 2, 0, 35, 12, 1, 12, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sGroudonAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -1, 0, -1,
+ax_anim 1, 0, 38, 5, -5, 5, -5,
+ax_anim 2, 2, 37, 11, -11, 11, -11,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 1, 39, 16, -14, 16, -14,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 0, 39, 15, -15, 15, -15,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sGroudonAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, -2, 0, -4,
+ax_anim 2, 2, 41, 0, -7, 0, -11,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 1, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sGroudonAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -1, 0, -1,
+ax_anim 1, 0, 46, -5, -5, -5, -5,
+ax_anim 2, 2, 45, -11, -11, -11, -11,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 1, 47, -16, -14, -16, -14,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 0, 47, -15, -15, -15, -15,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sGroudonAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 50, -2, 0, -4, 0,
+ax_anim 2, 2, 49, -6, 0, -10, 0,
+ax_anim 2, 0, 51, -12, 0, -12, 0,
+ax_anim 2, 1, 51, -12, 1, -12, 1,
+ax_anim 2, 0, 51, -12, 0, -12, 0,
+ax_anim 2, 0, 51, -12, 1, -12, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sGroudonAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 54, -3, 3, -3, 3,
+ax_anim 2, 2, 53, -8, 8, -8, 8,
+ax_anim 2, 0, 55, -12, 11, -12, 11,
+ax_anim 2, 1, 55, -13, 10, -13, 10,
+ax_anim 2, 0, 55, -12, 11, -12, 11,
+ax_anim 2, 0, 55, -13, 10, -13, 10,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGroudonAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 6, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 0, 4, 0, 4,
+ax_anim 2, 2, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sGroudonAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 6, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 62, 3, 3, 3, 3,
+ax_anim 2, 2, 61, 8, 8, 8, 8,
+ax_anim 2, 0, 63, 12, 11, 12, 11,
+ax_anim 2, 1, 63, 13, 10, 13, 10,
+ax_anim 2, 0, 63, 12, 11, 12, 11,
+ax_anim 2, 0, 63, 13, 10, 13, 10,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sGroudonAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 6, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 2, 0, 4, 0,
+ax_anim 2, 2, 65, 6, 0, 10, 0,
+ax_anim 2, 0, 67, 12, 0, 12, 0,
+ax_anim 2, 1, 67, 12, 1, 12, 1,
+ax_anim 2, 0, 67, 12, 0, 12, 0,
+ax_anim 2, 0, 67, 12, 1, 12, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sGroudonAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 6, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -1, 0, -1,
+ax_anim 1, 0, 70, 5, -5, 5, -5,
+ax_anim 2, 2, 69, 11, -11, 11, -11,
+ax_anim 2, 0, 71, 15, -15, 15, -15,
+ax_anim 2, 1, 71, 16, -14, 16, -14,
+ax_anim 2, 0, 71, 15, -15, 15, -15,
+ax_anim 2, 0, 71, 15, -15, 15, -15,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sGroudonAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -2, 0, -4,
+ax_anim 2, 2, 73, 0, -7, 0, -11,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 1, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sGroudonAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 6, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -1, 0, -1,
+ax_anim 1, 0, 78, -5, -5, -5, -5,
+ax_anim 2, 2, 77, -11, -11, -11, -11,
+ax_anim 2, 0, 79, -15, -15, -15, -15,
+ax_anim 2, 1, 79, -16, -14, -16, -14,
+ax_anim 2, 0, 79, -15, -15, -15, -15,
+ax_anim 2, 0, 79, -15, -15, -15, -15,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sGroudonAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 6, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, -2, 0, -4, 0,
+ax_anim 2, 2, 81, -6, 0, -10, 0,
+ax_anim 2, 0, 83, -12, 0, -12, 0,
+ax_anim 2, 1, 83, -12, 1, -12, 1,
+ax_anim 2, 0, 83, -12, 0, -12, 0,
+ax_anim 2, 0, 83, -12, 1, -12, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sGroudonAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 6, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 86, -3, 3, -3, 3,
+ax_anim 2, 2, 85, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -12, 11, -12, 11,
+ax_anim 2, 1, 87, -13, 10, -13, 10,
+ax_anim 2, 0, 87, -12, 11, -12, 11,
+ax_anim 2, 0, 87, -13, 10, -13, 10,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sGroudonAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 89, 0, -3, 0, -3,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sGroudonAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sGroudonAnims_4_3:
+ax_anim 2, 0, 95, -4, 0, -4, 0,
+ax_anim 2, 0, 95, -6, 0, -6, 0,
+ax_anim 6, 2, 95, -6, 0, -6, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 7, 0, 7, 0,
+ax_anim 2, 0, 96, 7, 1, 7, 1,
+ax_anim 2, 0, 96, 7, 0, 7, 0,
+ax_anim 2, 0, 96, 7, 1, 7, 1,
+ax_anim 2, 0, 96, 7, 0, 7, 0,
+ax_anim 2, 0, 96, 7, 1, 7, 1,
+ax_anim 2, 0, 96, 7, 0, 7, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sGroudonAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sGroudonAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 2, 0, 101, 0, 3, 0, 3,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sGroudonAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sGroudonAnims_4_7:
+ax_anim 2, 0, 107, 4, 0, 4, 0,
+ax_anim 2, 0, 107, 6, 0, 6, 0,
+ax_anim 6, 2, 107, 6, 0, 6, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -7, 0, -7, 0,
+ax_anim 2, 0, 108, -7, 1, -7, 1,
+ax_anim 2, 0, 108, -7, 0, -7, 0,
+ax_anim 2, 0, 108, -7, 1, -7, 1,
+ax_anim 2, 0, 108, -7, 0, -7, 0,
+ax_anim 2, 0, 108, -7, 1, -7, 1,
+ax_anim 2, 0, 108, -7, 0, -7, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sGroudonAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 110, 3, -3, 3, -3,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGroudonAnims_5_1:
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 6, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sGroudonAnims_5_2:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 6, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 117, 1, -1, 1, -1,
+ax_anim_terminator
+sGroudonAnims_5_3:
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 6, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sGroudonAnims_5_4:
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 6, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 1, 123, -1, -1, -1, -1,
+ax_anim_terminator
+sGroudonAnims_5_5:
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 6, 0, 125, 0, -7, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, 4, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 1, 0, 1, 0,
+ax_anim_terminator
+sGroudonAnims_5_6:
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 6, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 1, 129, 1, -1, 1, -1,
+ax_anim_terminator
+sGroudonAnims_5_7:
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 6, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 1, 132, 0, 1, 0, 1,
+ax_anim_terminator
+sGroudonAnims_5_8:
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 6, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 135, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sGroudonAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sGroudonAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sGroudonAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sGroudonAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sGroudonAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sGroudonAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sGroudonAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sGroudonAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sGroudonAnims_8_1:
+ax_anim 60, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_8_2:
+ax_anim 60, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 0, -1, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_8_3:
+ax_anim 60, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 1, 0, 1, 0,
+ax_anim_terminator
+sGroudonAnims_8_4:
+ax_anim 60, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_8_5:
+ax_anim 60, 0, 158, 0, 4, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, -1, 0, -1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, -1, 0, -1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, -1, 0, -1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, -1, 0, -1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, -1, 0, -1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, -1, 0, -1, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_8_6:
+ax_anim 60, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_8_7:
+ax_anim 60, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 166, -1, 0, 0, 0,
+ax_anim 2, 0, 166, -2, 0, -1, 0,
+ax_anim 2, 0, 166, -1, 0, 0, 0,
+ax_anim 2, 0, 166, -2, 0, -1, 0,
+ax_anim 2, 0, 166, -1, 0, 0, 0,
+ax_anim 2, 0, 166, -2, 0, -1, 0,
+ax_anim 2, 0, 166, -1, 0, 0, 0,
+ax_anim 2, 0, 166, -2, 0, -1, 0,
+ax_anim 2, 0, 166, -1, 0, 0, 0,
+ax_anim 2, 0, 166, -2, 0, -1, 0,
+ax_anim 2, 0, 166, -1, 0, 0, 0,
+ax_anim 2, 0, 166, -2, 0, -1, 0,
+ax_anim 6, 0, 166, -1, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_8_8:
+ax_anim 60, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 15, 7, 15,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -7, 15, -7, 15,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 7, 4, 7, 4,
+ax_anim 2, 0, 171, 13, 7, 13, 7,
+ax_anim 2, 0, 172, 14, 12, 14, 12,
+ax_anim 3, 0, 173, 9, 18, 9, 18,
+ax_anim 2, 3, 174, 6, 17, 6, 17,
+ax_anim 2, 0, 175, 2, 14, 2, 14,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 1, -3, 1, -3,
+ax_anim 2, 0, 170, 3, -5, 3, -5,
+ax_anim 2, 0, 171, 6, -4, 6, -4,
+ax_anim 3, 0, 172, 7, -1, 7, -1,
+ax_anim 2, 3, 173, 6, 3, 6, 3,
+ax_anim 2, 0, 174, 3, 4, 3, 4,
+ax_anim 1, 0, 175, 1, 3, 1, 3,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 1, -7, 1, -7,
+ax_anim 2, 0, 177, 4, -11, 4, -11,
+ax_anim 2, 0, 170, 8, -13, 8, -13,
+ax_anim 3, 0, 171, 11, -12, 11, -12,
+ax_anim 2, 3, 172, 13, -9, 13, -9,
+ax_anim 2, 0, 173, 11, -4, 11, -4,
+ax_anim 1, 0, 174, 6, -1, 6, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -5, -4, -5, -4,
+ax_anim 2, 0, 176, -5, -10, -5, -10,
+ax_anim 2, 0, 177, -4, -14, -4, -14,
+ax_anim 3, 0, 170, 0, -16, 0, -16,
+ax_anim 2, 3, 171, 4, -14, 4, -14,
+ax_anim 2, 0, 172, 5, -10, 5, -10,
+ax_anim 1, 0, 173, 5, -4, 5, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, -1, -7, -1, -7,
+ax_anim 2, 0, 171, -4, -11, -4, -11,
+ax_anim 2, 0, 170, -8, -13, -8, -13,
+ax_anim 3, 0, 177, -11, -12, -11, -12,
+ax_anim 2, 3, 176, -13, -9, -13, -9,
+ax_anim 2, 0, 175, -11, -4, -11, -4,
+ax_anim 1, 0, 174, -6, -1, -6, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -1, -3, -1, -3,
+ax_anim 2, 0, 170, -3, -5, -3, -5,
+ax_anim 2, 0, 177, -6, -4, -6, -4,
+ax_anim 3, 0, 176, -7, -1, -7, -1,
+ax_anim 2, 3, 175, -6, 3, -6, 3,
+ax_anim 2, 0, 174, -3, 4, -3, 4,
+ax_anim 1, 0, 173, -1, 3, -1, 3,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -7, 4, -7, 4,
+ax_anim 2, 0, 177, -13, 7, -13, 7,
+ax_anim 2, 0, 176, -14, 12, -14, 12,
+ax_anim 3, 0, 175, -9, 18, -9, 18,
+ax_anim 2, 3, 174, -6, 17, -6, 17,
+ax_anim 2, 0, 173, -2, 14, -2, 14,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -9, 0, 0,
+ax_anim 2, 0, 187, 0, -15, 0, 0,
+ax_anim 3, 0, 187, 0, -19, 0, 0,
+ax_anim 4, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -17, 0, 0,
+ax_anim 1, 0, 188, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -17, 0, 0,
+ax_anim 1, 0, 191, 0, -11, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -17, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -9, 0, 0,
+ax_anim 2, 0, 196, 0, -15, 0, 0,
+ax_anim 3, 0, 196, 0, -19, 0, 0,
+ax_anim 4, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -9, 0, 0,
+ax_anim 2, 0, 202, 0, -15, 0, 0,
+ax_anim 3, 0, 202, 0, -19, 0, 0,
+ax_anim 4, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -17, 0, 0,
+ax_anim 1, 0, 206, 0, -11, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -17, 0, 0,
+ax_anim 1, 0, 209, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_14_1:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_14_2:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_14_3:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_14_4:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_14_5:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_14_6:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_14_7:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_14_8:
+ax_anim 36, 0, 226, 0, 0, 0, 0,
+ax_anim 26, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_15_1:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 16, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 1, 0, 1,
+ax_anim 6, 0, 230, 0, 0, 0, 0,
+ax_anim 5, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 2, 0, 232, 0, -2, 0, 0,
+ax_anim 4, 0, 232, 0, -3, 0, 0,
+ax_anim 2, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_15_2:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 26, 0, 234, 0, 0, 0, 0,
+ax_anim 3, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 8, 0, 232, 0, -3, 0, 0,
+ax_anim 3, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_15_3:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 26, 0, 234, 0, 0, 0, 0,
+ax_anim 3, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 8, 0, 232, 0, -3, 0, 0,
+ax_anim 3, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_15_4:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 26, 0, 234, 0, 0, 0, 0,
+ax_anim 3, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 8, 0, 232, 0, -3, 0, 0,
+ax_anim 3, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_15_5:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 26, 0, 234, 0, 0, 0, 0,
+ax_anim 3, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 8, 0, 232, 0, -3, 0, 0,
+ax_anim 3, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_15_6:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 26, 0, 234, 0, 0, 0, 0,
+ax_anim 3, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 8, 0, 232, 0, -3, 0, 0,
+ax_anim 3, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_15_7:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 26, 0, 234, 0, 0, 0, 0,
+ax_anim 3, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 8, 0, 232, 0, -3, 0, 0,
+ax_anim 3, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_15_8:
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, 0, 1, 0,
+ax_anim 10, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 26, 0, 234, 0, 0, 0, 0,
+ax_anim 3, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 3, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 8, 0, 232, 0, -3, 0, 0,
+ax_anim 3, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -1, 0, 0,
+ax_anim 20, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGroudonAnims_16_1:
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_16_2:
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_16_3:
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_16_4:
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_16_5:
+ax_anim 10, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_16_6:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_16_7:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonAnims_16_8:
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sGroudonGfx1:
+.incbin "baserom.gba", 0x15D920C, 0x60
+sGroudonGfx1_1:
+.incbin "baserom.gba", 0x15D926C, 0xA0
+sGroudonGfx1_2:
+.incbin "baserom.gba", 0x15D930C, 0xA0
+sGroudonGfx1_3:
+.incbin "baserom.gba", 0x15D93AC, 0xA0
+sGroudonGfx1_4:
+.incbin "baserom.gba", 0x15D944C, 0x40
+sGroudonGfx1_5:
+.incbin "baserom.gba", 0x15D948C, 0x40
+sGroudonSprites1:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx1, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx1_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx1_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx1_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx1_4, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx1_5, 0x40
+ax_sprite 0, 0x360
+ax_sprite_terminator
+sGroudonGfx2:
+.incbin "baserom.gba", 0x15D953C, 0x80
+sGroudonGfx2_1:
+.incbin "baserom.gba", 0x15D95BC, 0xA0
+sGroudonGfx2_2:
+.incbin "baserom.gba", 0x15D965C, 0xA0
+sGroudonGfx2_3:
+.incbin "baserom.gba", 0x15D96FC, 0xA0
+sGroudonGfx2_4:
+.incbin "baserom.gba", 0x15D979C, 0x40
+sGroudonGfx2_5:
+.incbin "baserom.gba", 0x15D97DC, 0x40
+sGroudonGfx2_6:
+.incbin "baserom.gba", 0x15D981C, 0x40
+sGroudonSprites2:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx2, 0x80
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx2_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx2_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx2_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx2_4, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx2_5, 0x40
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx2_6, 0x40
+ax_sprite 0, 0x2c0
+ax_sprite_terminator
+sGroudonGfx3:
+.incbin "baserom.gba", 0x15D98DC, 0x80
+sGroudonGfx3_1:
+.incbin "baserom.gba", 0x15D995C, 0xA0
+sGroudonGfx3_2:
+.incbin "baserom.gba", 0x15D99FC, 0xA0
+sGroudonGfx3_3:
+.incbin "baserom.gba", 0x15D9A9C, 0xA0
+sGroudonGfx3_4:
+.incbin "baserom.gba", 0x15D9B3C, 0xA0
+sGroudonGfx3_5:
+.incbin "baserom.gba", 0x15D9BDC, 0x40
+sGroudonSprites3:
+ax_sprite sGroudonGfx3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx3_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx3_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx3_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx3_4, 0xa0
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx3_5, 0x40
+ax_sprite 0, 0x260
+ax_sprite_terminator
+sGroudonGfx4:
+.incbin "baserom.gba", 0x15D9C84, 0x80
+sGroudonGfx4_1:
+.incbin "baserom.gba", 0x15D9D04, 0xC0
+sGroudonGfx4_2:
+.incbin "baserom.gba", 0x15D9DC4, 0xC0
+sGroudonGfx4_3:
+.incbin "baserom.gba", 0x15D9E84, 0xC0
+sGroudonGfx4_4:
+.incbin "baserom.gba", 0x15D9F44, 0xA0
+sGroudonGfx4_5:
+.incbin "baserom.gba", 0x15D9FE4, 0x60
+sGroudonSprites4:
+ax_sprite sGroudonGfx4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx4_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx4_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx4_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx4_4, 0xa0
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx4_5, 0x60
+ax_sprite 0, 0x260
+ax_sprite_terminator
+sGroudonGfx5:
+.incbin "baserom.gba", 0x15DA0AC, 0x80
+sGroudonGfx5_1:
+.incbin "baserom.gba", 0x15DA12C, 0xC0
+sGroudonGfx5_2:
+.incbin "baserom.gba", 0x15DA1EC, 0xC0
+sGroudonGfx5_3:
+.incbin "baserom.gba", 0x15DA2AC, 0xC0
+sGroudonGfx5_4:
+.incbin "baserom.gba", 0x15DA36C, 0xC0
+sGroudonGfx5_5:
+.incbin "baserom.gba", 0x15DA42C, 0x20
+sGroudonSprites5:
+ax_sprite sGroudonGfx5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx5_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx5_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx5_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx5_4, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx5_5, 0x20
+ax_sprite 0, 0x260
+ax_sprite_terminator
+sGroudonGfx6:
+.incbin "baserom.gba", 0x15DA4B4, 0x80
+sGroudonGfx6_1:
+.incbin "baserom.gba", 0x15DA534, 0xC0
+sGroudonGfx6_2:
+.incbin "baserom.gba", 0x15DA5F4, 0xE0
+sGroudonGfx6_3:
+.incbin "baserom.gba", 0x15DA6D4, 0xE0
+sGroudonGfx6_4:
+.incbin "baserom.gba", 0x15DA7B4, 0x80
+sGroudonGfx6_5:
+.incbin "baserom.gba", 0x15DA834, 0x40
+sGroudonSprites6:
+ax_sprite sGroudonGfx6, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx6_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx6_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx6_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx6_4, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx6_5, 0x40
+ax_sprite 0, 0x280
+ax_sprite_terminator
+sGroudonGfx7:
+.incbin "baserom.gba", 0x15DA8DC, 0x80
+sGroudonGfx7_1:
+.incbin "baserom.gba", 0x15DA95C, 0xA0
+sGroudonGfx7_2:
+.incbin "baserom.gba", 0x15DA9FC, 0xE0
+sGroudonGfx7_3:
+.incbin "baserom.gba", 0x15DAADC, 0xE0
+sGroudonGfx7_4:
+.incbin "baserom.gba", 0x15DABBC, 0xA0
+sGroudonGfx7_5:
+.incbin "baserom.gba", 0x15DAC5C, 0x60
+sGroudonSprites7:
+ax_sprite sGroudonGfx7, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx7_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx7_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx7_3, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx7_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx7_5, 0x60
+ax_sprite 0, 0x260
+ax_sprite_terminator
+sGroudonGfx8:
+.incbin "baserom.gba", 0x15DAD24, 0x80
+sGroudonGfx8_1:
+.incbin "baserom.gba", 0x15DADA4, 0xA0
+sGroudonGfx8_2:
+.incbin "baserom.gba", 0x15DAE44, 0xE0
+sGroudonGfx8_3:
+.incbin "baserom.gba", 0x15DAF24, 0xE0
+sGroudonGfx8_4:
+.incbin "baserom.gba", 0x15DB004, 0xC0
+sGroudonGfx8_5:
+.incbin "baserom.gba", 0x15DB0C4, 0x60
+sGroudonSprites8:
+ax_sprite sGroudonGfx8, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx8_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx8_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx8_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx8_4, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx8_5, 0x60
+ax_sprite 0, 0x240
+ax_sprite_terminator
+sGroudonGfx9:
+.incbin "baserom.gba", 0x15DB18C, 0x80
+sGroudonGfx9_1:
+.incbin "baserom.gba", 0x15DB20C, 0xA0
+sGroudonGfx9_2:
+.incbin "baserom.gba", 0x15DB2AC, 0xC0
+sGroudonGfx9_3:
+.incbin "baserom.gba", 0x15DB36C, 0xC0
+sGroudonGfx9_4:
+.incbin "baserom.gba", 0x15DB42C, 0xC0
+sGroudonGfx9_5:
+.incbin "baserom.gba", 0x15DB4EC, 0x60
+sGroudonGfx9_6:
+.incbin "baserom.gba", 0x15DB54C, 0x20
+sGroudonSprites9:
+ax_sprite sGroudonGfx9, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx9_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx9_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx9_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx9_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx9_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx9_6, 0x20
+ax_sprite 0, 0x240
+ax_sprite_terminator
+sGroudonGfx10:
+.incbin "baserom.gba", 0x15DB5E4, 0x80
+sGroudonGfx10_1:
+.incbin "baserom.gba", 0x15DB664, 0x80
+sGroudonGfx10_2:
+.incbin "baserom.gba", 0x15DB6E4, 0xA0
+sGroudonGfx10_3:
+.incbin "baserom.gba", 0x15DB784, 0xA0
+sGroudonGfx10_4:
+.incbin "baserom.gba", 0x15DB824, 0xA0
+sGroudonGfx10_5:
+.incbin "baserom.gba", 0x15DB8C4, 0xC0
+sGroudonGfx10_6:
+.incbin "baserom.gba", 0x15DB984, 0x60
+sGroudonSprites10:
+ax_sprite sGroudonGfx10, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx10_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx10_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx10_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx10_4, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx10_5, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx10_6, 0x60
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sGroudonGfx11:
+.incbin "baserom.gba", 0x15DBA5C, 0x80
+sGroudonGfx11_1:
+.incbin "baserom.gba", 0x15DBADC, 0xA0
+sGroudonGfx11_2:
+.incbin "baserom.gba", 0x15DBB7C, 0xA0
+sGroudonGfx11_3:
+.incbin "baserom.gba", 0x15DBC1C, 0xA0
+sGroudonGfx11_4:
+.incbin "baserom.gba", 0x15DBCBC, 0xC0
+sGroudonGfx11_5:
+.incbin "baserom.gba", 0x15DBD7C, 0xC0
+sGroudonSprites11:
+ax_sprite sGroudonGfx11, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx11_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx11_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx11_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx11_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx11_5, 0xc0
+ax_sprite 0, 0x220
+ax_sprite_terminator
+sGroudonGfx12:
+.incbin "baserom.gba", 0x15DBEA4, 0x80
+sGroudonGfx12_1:
+.incbin "baserom.gba", 0x15DBF24, 0x80
+sGroudonGfx12_2:
+.incbin "baserom.gba", 0x15DBFA4, 0xA0
+sGroudonGfx12_3:
+.incbin "baserom.gba", 0x15DC044, 0xC0
+sGroudonGfx12_4:
+.incbin "baserom.gba", 0x15DC104, 0xC0
+sGroudonGfx12_5:
+.incbin "baserom.gba", 0x15DC1C4, 0xC0
+sGroudonGfx12_6:
+.incbin "baserom.gba", 0x15DC284, 0x40
+sGroudonSprites12:
+ax_sprite sGroudonGfx12, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx12_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx12_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx12_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx12_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx12_5, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx12_6, 0x40
+ax_sprite 0, 0x160
+ax_sprite_terminator
+sGroudonGfx13:
+.incbin "baserom.gba", 0x15DC33C, 0x60
+sGroudonGfx13_1:
+.incbin "baserom.gba", 0x15DC39C, 0xA0
+sGroudonGfx13_2:
+.incbin "baserom.gba", 0x15DC43C, 0xA0
+sGroudonGfx13_3:
+.incbin "baserom.gba", 0x15DC4DC, 0xA0
+sGroudonGfx13_4:
+.incbin "baserom.gba", 0x15DC57C, 0xA0
+sGroudonGfx13_5:
+.incbin "baserom.gba", 0x15DC61C, 0xA0
+sGroudonGfx13_6:
+.incbin "baserom.gba", 0x15DC6BC, 0x60
+sGroudonSprites13:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx13, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx13_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx13_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx13_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx13_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx13_5, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx13_6, 0x60
+ax_sprite 0, 0x180
+ax_sprite_terminator
+sGroudonGfx14:
+.incbin "baserom.gba", 0x15DC79C, 0x80
+sGroudonGfx14_1:
+.incbin "baserom.gba", 0x15DC81C, 0xA0
+sGroudonGfx14_2:
+.incbin "baserom.gba", 0x15DC8BC, 0xA0
+sGroudonGfx14_3:
+.incbin "baserom.gba", 0x15DC95C, 0xA0
+sGroudonGfx14_4:
+.incbin "baserom.gba", 0x15DC9FC, 0xA0
+sGroudonGfx14_5:
+.incbin "baserom.gba", 0x15DCA9C, 0xA0
+sGroudonGfx14_6:
+.incbin "baserom.gba", 0x15DCB3C, 0x60
+sGroudonSprites14:
+ax_sprite sGroudonGfx14, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx14_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx14_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx14_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx14_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx14_5, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx14_6, 0x60
+ax_sprite 0, 0x180
+ax_sprite_terminator
+sGroudonGfx15:
+.incbin "baserom.gba", 0x15DCC14, 0x80
+sGroudonGfx15_1:
+.incbin "baserom.gba", 0x15DCC94, 0xA0
+sGroudonGfx15_2:
+.incbin "baserom.gba", 0x15DCD34, 0xA0
+sGroudonGfx15_3:
+.incbin "baserom.gba", 0x15DCDD4, 0xA0
+sGroudonGfx15_4:
+.incbin "baserom.gba", 0x15DCE74, 0xA0
+sGroudonGfx15_5:
+.incbin "baserom.gba", 0x15DCF14, 0xA0
+sGroudonGfx15_6:
+.incbin "baserom.gba", 0x15DCFB4, 0x80
+sGroudonSprites15:
+ax_sprite sGroudonGfx15, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx15_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx15_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx15_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx15_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx15_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx15_6, 0x80
+ax_sprite 0, 0x180
+ax_sprite_terminator
+sGroudonGfx16:
+.incbin "baserom.gba", 0x15DD0AC, 0x60
+sGroudonGfx16_1:
+.incbin "baserom.gba", 0x15DD10C, 0x60
+sGroudonGfx16_2:
+.incbin "baserom.gba", 0x15DD16C, 0xA0
+sGroudonGfx16_3:
+.incbin "baserom.gba", 0x15DD20C, 0xA0
+sGroudonGfx16_4:
+.incbin "baserom.gba", 0x15DD2AC, 0xE0
+sGroudonGfx16_5:
+.incbin "baserom.gba", 0x15DD38C, 0xE0
+sGroudonGfx16_6:
+.incbin "baserom.gba", 0x15DD46C, 0x20
+sGroudonSprites16:
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx16, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx16_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx16_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx16_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx16_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx16_5, 0xe0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx16_6, 0x20
+ax_sprite 0, 0x180
+ax_sprite_terminator
+sGroudonGfx17:
+.incbin "baserom.gba", 0x15DD50C, 0x40
+sGroudonGfx17_1:
+.incbin "baserom.gba", 0x15DD54C, 0x60
+sGroudonGfx17_2:
+.incbin "baserom.gba", 0x15DD5AC, 0x80
+sGroudonGfx17_3:
+.incbin "baserom.gba", 0x15DD62C, 0xA0
+sGroudonGfx17_4:
+.incbin "baserom.gba", 0x15DD6CC, 0xC0
+sGroudonGfx17_5:
+.incbin "baserom.gba", 0x15DD78C, 0xC0
+sGroudonGfx17_6:
+.incbin "baserom.gba", 0x15DD84C, 0xC0
+sGroudonGfx17_7:
+.incbin "baserom.gba", 0x15DD90C, 0x20
+sGroudonSprites17:
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx17, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx17_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx17_2, 0x80
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx17_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx17_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx17_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx17_6, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx17_7, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sGroudonGfx18:
+.incbin "baserom.gba", 0x15DD9BC, 0x20
+sGroudonGfx18_1:
+.incbin "baserom.gba", 0x15DD9DC, 0x80
+sGroudonGfx18_2:
+.incbin "baserom.gba", 0x15DDA5C, 0x320
+sGroudonGfx18_3:
+.incbin "baserom.gba", 0x15DDD7C, 0xA0
+sGroudonSprites18:
+ax_sprite 0, 0x1c0
+ax_sprite sGroudonGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx18_2, 0x320
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx18_3, 0xa0
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sGroudonGfx19:
+.incbin "baserom.gba", 0x15DDE6C, 0x40
+sGroudonGfx19_1:
+.incbin "baserom.gba", 0x15DDEAC, 0xA0
+sGroudonGfx19_2:
+.incbin "baserom.gba", 0x15DDF4C, 0xE0
+sGroudonGfx19_3:
+.incbin "baserom.gba", 0x15DE02C, 0xE0
+sGroudonGfx19_4:
+.incbin "baserom.gba", 0x15DE10C, 0xE0
+sGroudonGfx19_5:
+.incbin "baserom.gba", 0x15DE1EC, 0xA0
+sGroudonGfx19_6:
+.incbin "baserom.gba", 0x15DE28C, 0x20
+sGroudonSprites19:
+ax_sprite 0, 0x120
+ax_sprite sGroudonGfx19, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx19_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx19_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx19_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx19_4, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx19_5, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx19_6, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGroudonGfx20:
+.incbin "baserom.gba", 0x15DE32C, 0x60
+sGroudonGfx20_1:
+.incbin "baserom.gba", 0x15DE38C, 0xA0
+sGroudonGfx20_2:
+.incbin "baserom.gba", 0x15DE42C, 0xE0
+sGroudonGfx20_3:
+.incbin "baserom.gba", 0x15DE50C, 0xE0
+sGroudonGfx20_4:
+.incbin "baserom.gba", 0x15DE5EC, 0xA0
+sGroudonSprites20:
+ax_sprite 0, 0x240
+ax_sprite sGroudonGfx20, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx20_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx20_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx20_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx20_4, 0xa0
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sGroudonGfx21:
+.incbin "baserom.gba", 0x15DE6EC, 0x60
+sGroudonGfx21_1:
+.incbin "baserom.gba", 0x15DE74C, 0xA0
+sGroudonGfx21_2:
+.incbin "baserom.gba", 0x15DE7EC, 0xA0
+sGroudonGfx21_3:
+.incbin "baserom.gba", 0x15DE88C, 0xC0
+sGroudonGfx21_4:
+.incbin "baserom.gba", 0x15DE94C, 0xC0
+sGroudonGfx21_5:
+.incbin "baserom.gba", 0x15DEA0C, 0xC0
+sGroudonGfx21_6:
+.incbin "baserom.gba", 0x15DEACC, 0x40
+sGroudonSprites21:
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx21, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx21_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx21_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx21_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx21_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx21_5, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx21_6, 0x40
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sGroudonGfx22:
+.incbin "baserom.gba", 0x15DEB8C, 0x60
+sGroudonGfx22_1:
+.incbin "baserom.gba", 0x15DEBEC, 0x80
+sGroudonGfx22_2:
+.incbin "baserom.gba", 0x15DEC6C, 0xA0
+sGroudonGfx22_3:
+.incbin "baserom.gba", 0x15DED0C, 0xC0
+sGroudonGfx22_4:
+.incbin "baserom.gba", 0x15DEDCC, 0xE0
+sGroudonGfx22_5:
+.incbin "baserom.gba", 0x15DEEAC, 0xE0
+sGroudonGfx22_6:
+.incbin "baserom.gba", 0x15DEF8C, 0x60
+sGroudonGfx22_7:
+.incbin "baserom.gba", 0x15DEFEC, 0x20
+sGroudonSprites22:
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx22, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx22_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx22_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx22_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx22_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx22_5, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx22_6, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx22_7, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sGroudonGfx23:
+.incbin "baserom.gba", 0x15DF09C, 0x60
+sGroudonGfx23_1:
+.incbin "baserom.gba", 0x15DF0FC, 0x60
+sGroudonGfx23_2:
+.incbin "baserom.gba", 0x15DF15C, 0xA0
+sGroudonGfx23_3:
+.incbin "baserom.gba", 0x15DF1FC, 0xA0
+sGroudonGfx23_4:
+.incbin "baserom.gba", 0x15DF29C, 0x80
+sGroudonGfx23_5:
+.incbin "baserom.gba", 0x15DF31C, 0xA0
+sGroudonGfx23_6:
+.incbin "baserom.gba", 0x15DF3BC, 0xA0
+sGroudonSprites23:
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx23, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx23_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx23_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx23_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx23_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx23_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx23_6, 0xa0
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sGroudonGfx24:
+.incbin "baserom.gba", 0x15DF4DC, 0x40
+sGroudonGfx24_1:
+.incbin "baserom.gba", 0x15DF51C, 0x60
+sGroudonGfx24_2:
+.incbin "baserom.gba", 0x15DF57C, 0xA0
+sGroudonGfx24_3:
+.incbin "baserom.gba", 0x15DF61C, 0xA0
+sGroudonGfx24_4:
+.incbin "baserom.gba", 0x15DF6BC, 0x80
+sGroudonGfx24_5:
+.incbin "baserom.gba", 0x15DF73C, 0xA0
+sGroudonGfx24_6:
+.incbin "baserom.gba", 0x15DF7DC, 0xA0
+sGroudonGfx24_7:
+.incbin "baserom.gba", 0x15DF87C, 0x80
+sGroudonSprites24:
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx24, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx24_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx24_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx24_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx24_4, 0x80
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx24_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx24_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx24_7, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGroudonGfx25:
+.incbin "baserom.gba", 0x15DF98C, 0x20
+sGroudonGfx25_1:
+.incbin "baserom.gba", 0x15DF9AC, 0x80
+sGroudonGfx25_2:
+.incbin "baserom.gba", 0x15DFA2C, 0xA0
+sGroudonGfx25_3:
+.incbin "baserom.gba", 0x15DFACC, 0xA0
+sGroudonGfx25_4:
+.incbin "baserom.gba", 0x15DFB6C, 0xC0
+sGroudonGfx25_5:
+.incbin "baserom.gba", 0x15DFC2C, 0xA0
+sGroudonGfx25_6:
+.incbin "baserom.gba", 0x15DFCCC, 0xA0
+sGroudonGfx25_7:
+.incbin "baserom.gba", 0x15DFD6C, 0x60
+sGroudonSprites25:
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx25, 0x20
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx25_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx25_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx25_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx25_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx25_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx25_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx25_7, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGroudonGfx26:
+.incbin "baserom.gba", 0x15DFE5C, 0x20
+sGroudonGfx26_1:
+.incbin "baserom.gba", 0x15DFE7C, 0xE0
+sGroudonGfx26_2:
+.incbin "baserom.gba", 0x15DFF5C, 0xE0
+sGroudonGfx26_3:
+.incbin "baserom.gba", 0x15E003C, 0xA0
+sGroudonGfx26_4:
+.incbin "baserom.gba", 0x15E00DC, 0x60
+sGroudonGfx26_5:
+.incbin "baserom.gba", 0x15E013C, 0x60
+sGroudonGfx26_6:
+.incbin "baserom.gba", 0x15E019C, 0x60
+sGroudonGfx26_7:
+.incbin "baserom.gba", 0x15E01FC, 0x60
+sGroudonSprites26:
+ax_sprite 0, 0x160
+ax_sprite sGroudonGfx26, 0x20
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx26_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx26_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx26_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx26_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx26_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx26_6, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx26_7, 0x60
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sGroudonGfx27:
+.incbin "baserom.gba", 0x15E02EC, 0x60
+sGroudonGfx27_1:
+.incbin "baserom.gba", 0x15E034C, 0xE0
+sGroudonGfx27_2:
+.incbin "baserom.gba", 0x15E042C, 0xC0
+sGroudonGfx27_3:
+.incbin "baserom.gba", 0x15E04EC, 0xC0
+sGroudonGfx27_4:
+.incbin "baserom.gba", 0x15E05AC, 0xA0
+sGroudonGfx27_5:
+.incbin "baserom.gba", 0x15E064C, 0x40
+sGroudonSprites27:
+ax_sprite 0, 0x100
+ax_sprite sGroudonGfx27, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx27_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx27_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx27_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx27_4, 0xa0
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx27_5, 0x40
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sGroudonGfx28:
+.incbin "baserom.gba", 0x15E06FC, 0x60
+sGroudonGfx28_1:
+.incbin "baserom.gba", 0x15E075C, 0xA0
+sGroudonGfx28_2:
+.incbin "baserom.gba", 0x15E07FC, 0xE0
+sGroudonGfx28_3:
+.incbin "baserom.gba", 0x15E08DC, 0xE0
+sGroudonGfx28_4:
+.incbin "baserom.gba", 0x15E09BC, 0xA0
+sGroudonGfx28_5:
+.incbin "baserom.gba", 0x15E0A5C, 0x60
+sGroudonSprites28:
+ax_sprite 0, 0x140
+ax_sprite sGroudonGfx28, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx28_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx28_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx28_3, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx28_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx28_5, 0x60
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sGroudonGfx29:
+.incbin "baserom.gba", 0x15E0B2C, 0x40
+sGroudonGfx29_1:
+.incbin "baserom.gba", 0x15E0B6C, 0x40
+sGroudonGfx29_2:
+.incbin "baserom.gba", 0x15E0BAC, 0xA0
+sGroudonGfx29_3:
+.incbin "baserom.gba", 0x15E0C4C, 0xC0
+sGroudonGfx29_4:
+.incbin "baserom.gba", 0x15E0D0C, 0xC0
+sGroudonGfx29_5:
+.incbin "baserom.gba", 0x15E0DCC, 0xC0
+sGroudonGfx29_6:
+.incbin "baserom.gba", 0x15E0E8C, 0xC0
+sGroudonSprites29:
+ax_sprite 0, 0x120
+ax_sprite sGroudonGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx29_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx29_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx29_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx29_4, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx29_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx29_6, 0xc0
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sGroudonGfx30:
+.incbin "baserom.gba", 0x15E0FCC, 0x60
+sGroudonGfx30_1:
+.incbin "baserom.gba", 0x15E102C, 0xE0
+sGroudonGfx30_2:
+.incbin "baserom.gba", 0x15E110C, 0xE0
+sGroudonGfx30_3:
+.incbin "baserom.gba", 0x15E11EC, 0xA0
+sGroudonGfx30_4:
+.incbin "baserom.gba", 0x15E128C, 0xE0
+sGroudonGfx30_5:
+.incbin "baserom.gba", 0x15E136C, 0xE0
+sGroudonSprites30:
+ax_sprite 0, 0x140
+ax_sprite sGroudonGfx30, 0x60
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx30_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx30_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx30_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx30_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx30_5, 0xe0
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sGroudonGfx31:
+.incbin "baserom.gba", 0x15E14BC, 0x40
+sGroudonGfx31_1:
+.incbin "baserom.gba", 0x15E14FC, 0x180
+sGroudonSprites31:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx31_1, 0x180
+ax_sprite_terminator
+sGroudonGfx32:
+.incbin "baserom.gba", 0x15E16A4, 0x80
+sGroudonGfx32_1:
+.incbin "baserom.gba", 0x15E1724, 0x40
+sGroudonSprites32:
+ax_sprite sGroudonGfx32, 0x80
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx32_1, 0x40
+ax_sprite_terminator
+sGroudonGfx33:
+.incbin "baserom.gba", 0x15E1784, 0xE0
+sGroudonSprites33:
+ax_sprite sGroudonGfx33, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGroudonGfx34:
+.incbin "baserom.gba", 0x15E187C, 0x180
+sGroudonSprites34:
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx34, 0x180
+ax_sprite_terminator
+sGroudonGfx35:
+.incbin "baserom.gba", 0x15E1A14, 0x80
+sGroudonGfx35_1:
+.incbin "baserom.gba", 0x15E1A94, 0x40
+sGroudonSprites35:
+ax_sprite sGroudonGfx35, 0x80
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx35_1, 0x40
+ax_sprite_terminator
+sGroudonGfx36:
+.incbin "baserom.gba", 0x15E1AF4, 0xE0
+sGroudonSprites36:
+ax_sprite sGroudonGfx36, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGroudonGfx37:
+.incbin "baserom.gba", 0x15E1BEC, 0x40
+sGroudonGfx37_1:
+.incbin "baserom.gba", 0x15E1C2C, 0xC0
+sGroudonGfx37_2:
+.incbin "baserom.gba", 0x15E1CEC, 0xC0
+sGroudonGfx37_3:
+.incbin "baserom.gba", 0x15E1DAC, 0xC0
+sGroudonGfx37_4:
+.incbin "baserom.gba", 0x15E1E6C, 0xC0
+sGroudonGfx37_5:
+.incbin "baserom.gba", 0x15E1F2C, 0xA0
+sGroudonSprites37:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx37, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx37_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx37_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx37_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx37_4, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx37_5, 0xa0
+ax_sprite 0, 0x240
+ax_sprite_terminator
+sGroudonGfx38:
+.incbin "baserom.gba", 0x15E203C, 0x40
+sGroudonGfx38_1:
+.incbin "baserom.gba", 0x15E207C, 0x80
+sGroudonGfx38_2:
+.incbin "baserom.gba", 0x15E20FC, 0xE0
+sGroudonGfx38_3:
+.incbin "baserom.gba", 0x15E21DC, 0xE0
+sGroudonGfx38_4:
+.incbin "baserom.gba", 0x15E22BC, 0xC0
+sGroudonGfx38_5:
+.incbin "baserom.gba", 0x15E237C, 0x60
+sGroudonGfx38_6:
+.incbin "baserom.gba", 0x15E23DC, 0x40
+sGroudonSprites38:
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx38, 0x40
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx38_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx38_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx38_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx38_4, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx38_5, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sGroudonGfx38_6, 0x40
+ax_sprite 0, 0x160
+ax_sprite_terminator
+sGroudonGfx39:
+.incbin "baserom.gba", 0x15E249C, 0x40
+sGroudonSprites39:
+ax_sprite sGroudonGfx39, 0x40
+ax_sprite_terminator
+sGroudonGfx40:
+.incbin "baserom.gba", 0x15E24EC, 0xC0
+sGroudonGfx40_1:
+.incbin "baserom.gba", 0x15E25AC, 0xC0
+sGroudonGfx40_2:
+.incbin "baserom.gba", 0x15E266C, 0xE0
+sGroudonGfx40_3:
+.incbin "baserom.gba", 0x15E274C, 0xC0
+sGroudonSprites40:
+ax_sprite sGroudonGfx40, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx40_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx40_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx40_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGroudonGfx41:
+.incbin "baserom.gba", 0x15E2854, 0x60
+sGroudonGfx41_1:
+.incbin "baserom.gba", 0x15E28B4, 0xA0
+sGroudonGfx41_2:
+.incbin "baserom.gba", 0x15E2954, 0xA0
+sGroudonGfx41_3:
+.incbin "baserom.gba", 0x15E29F4, 0xA0
+sGroudonGfx41_4:
+.incbin "baserom.gba", 0x15E2A94, 0xA0
+sGroudonGfx41_5:
+.incbin "baserom.gba", 0x15E2B34, 0xA0
+sGroudonSprites41:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx41, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sGroudonGfx41_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx41_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx41_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx41_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx41_5, 0xa0
+ax_sprite 0, 0x260
+ax_sprite_terminator
+sGroudonGfx42:
+.incbin "baserom.gba", 0x15E2C44, 0x60
+sGroudonGfx42_1:
+.incbin "baserom.gba", 0x15E2CA4, 0x80
+sGroudonGfx42_2:
+.incbin "baserom.gba", 0x15E2D24, 0xC0
+sGroudonGfx42_3:
+.incbin "baserom.gba", 0x15E2DE4, 0xC0
+sGroudonGfx42_4:
+.incbin "baserom.gba", 0x15E2EA4, 0xC0
+sGroudonGfx42_5:
+.incbin "baserom.gba", 0x15E2F64, 0xA0
+sGroudonSprites42:
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx42, 0x60
+ax_sprite 0, 0x80
+ax_sprite sGroudonGfx42_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx42_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx42_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGroudonGfx42_4, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sGroudonGfx42_5, 0xa0
+ax_sprite 0, 0x240
+ax_sprite_terminator
+sGroudonGfx43:
+.incbin "baserom.gba", 0x15E3074, 0x1E0
+sGroudonSprites43:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx43, 0x1e0
+ax_sprite_terminator
+sGroudonGfx44:
+.incbin "baserom.gba", 0x15E326C, 0x100
+sGroudonSprites44:
+ax_sprite sGroudonGfx44, 0x100
+ax_sprite_terminator
+sGroudonGfx45:
+.incbin "baserom.gba", 0x15E337C, 0x40
+sGroudonSprites45:
+ax_sprite sGroudonGfx45, 0x40
+ax_sprite_terminator
+sGroudonGfx46:
+.incbin "baserom.gba", 0x15E33CC, 0x1E0
+sGroudonSprites46:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx46, 0x1e0
+ax_sprite_terminator
+sGroudonGfx47:
+.incbin "baserom.gba", 0x15E35C4, 0x20
+sGroudonGfx47_1:
+.incbin "baserom.gba", 0x15E35E4, 0xC0
+sGroudonSprites47:
+ax_sprite sGroudonGfx47, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx47_1, 0xc0
+ax_sprite_terminator
+sGroudonGfx48:
+.incbin "baserom.gba", 0x15E36C4, 0x40
+sGroudonSprites48:
+ax_sprite sGroudonGfx48, 0x40
+ax_sprite_terminator
+sGroudonGfx49:
+.incbin "baserom.gba", 0x15E3714, 0x160
+sGroudonGfx49_1:
+.incbin "baserom.gba", 0x15E3874, 0x40
+sGroudonSprites49:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx49, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx49_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGroudonGfx50:
+.incbin "baserom.gba", 0x15E38E4, 0x20
+sGroudonGfx50_1:
+.incbin "baserom.gba", 0x15E3904, 0xC0
+sGroudonSprites50:
+ax_sprite sGroudonGfx50, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx50_1, 0xc0
+ax_sprite_terminator
+sGroudonGfx51:
+.incbin "baserom.gba", 0x15E39E4, 0x80
+sGroudonSprites51:
+ax_sprite sGroudonGfx51, 0x80
+ax_sprite_terminator
+sGroudonGfx52:
+.incbin "baserom.gba", 0x15E3A74, 0x1E0
+sGroudonSprites52:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx52, 0x1e0
+ax_sprite_terminator
+sGroudonGfx53:
+.incbin "baserom.gba", 0x15E3C6C, 0x20
+sGroudonGfx53_1:
+.incbin "baserom.gba", 0x15E3C8C, 0xC0
+sGroudonSprites53:
+ax_sprite sGroudonGfx53, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx53_1, 0xc0
+ax_sprite_terminator
+sGroudonGfx54:
+.incbin "baserom.gba", 0x15E3D6C, 0x80
+sGroudonSprites54:
+ax_sprite sGroudonGfx54, 0x80
+ax_sprite_terminator
+sGroudonGfx55:
+.incbin "baserom.gba", 0x15E3DFC, 0x160
+sGroudonGfx55_1:
+.incbin "baserom.gba", 0x15E3F5C, 0x60
+sGroudonSprites55:
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx55, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGroudonGfx55_1, 0x60
+ax_sprite_terminator
+sGroudonGfx56:
+.incbin "baserom.gba", 0x15E3FE4, 0x100
+sGroudonSprites56:
+ax_sprite sGroudonGfx56, 0x100
+ax_sprite_terminator
+sGroudonGfx57:
+.incbin "baserom.gba", 0x15E40F4, 0x100
+sGroudonSprites57:
+ax_sprite sGroudonGfx57, 0x100
+ax_sprite_terminator
+sGroudonGfx58:
+.incbin "baserom.gba", 0x15E4204, 0x80
+sGroudonSprites58:
+ax_sprite sGroudonGfx58, 0x80
+ax_sprite_terminator
+sGroudonGfx59:
+.incbin "baserom.gba", 0x15E4294, 0x40
+sGroudonSprites59:
+ax_sprite sGroudonGfx59, 0x40
+ax_sprite_terminator
+sAxPosesGroudon:
+.4byte sGroudonPose1
+.4byte sGroudonPose2
+.4byte sGroudonPose3
+.4byte sGroudonPose4
+.4byte sGroudonPose5
+.4byte sGroudonPose6
+.4byte sGroudonPose7
+.4byte sGroudonPose8
+.4byte sGroudonPose9
+.4byte sGroudonPose10
+.4byte sGroudonPose11
+.4byte sGroudonPose12
+.4byte sGroudonPose13
+.4byte sGroudonPose14
+.4byte sGroudonPose15
+.4byte sGroudonPose16
+.4byte sGroudonPose17
+.4byte sGroudonPose18
+.4byte sGroudonPose19
+.4byte sGroudonPose20
+.4byte sGroudonPose21
+.4byte sGroudonPose22
+.4byte sGroudonPose23
+.4byte sGroudonPose24
+.4byte sGroudonPose25
+.4byte sGroudonPose26
+.4byte sGroudonPose27
+.4byte sGroudonPose28
+.4byte sGroudonPose29
+.4byte sGroudonPose30
+.4byte sGroudonPose31
+.4byte sGroudonPose32
+.4byte sGroudonPose33
+.4byte sGroudonPose34
+.4byte sGroudonPose35
+.4byte sGroudonPose36
+.4byte sGroudonPose37
+.4byte sGroudonPose38
+.4byte sGroudonPose39
+.4byte sGroudonPose40
+.4byte sGroudonPose41
+.4byte sGroudonPose42
+.4byte sGroudonPose43
+.4byte sGroudonPose44
+.4byte sGroudonPose45
+.4byte sGroudonPose46
+.4byte sGroudonPose47
+.4byte sGroudonPose48
+.4byte sGroudonPose49
+.4byte sGroudonPose50
+.4byte sGroudonPose51
+.4byte sGroudonPose52
+.4byte sGroudonPose53
+.4byte sGroudonPose54
+.4byte sGroudonPose55
+.4byte sGroudonPose56
+.4byte sGroudonPose57
+.4byte sGroudonPose58
+.4byte sGroudonPose59
+.4byte sGroudonPose60
+.4byte sGroudonPose61
+.4byte sGroudonPose62
+.4byte sGroudonPose63
+.4byte sGroudonPose64
+.4byte sGroudonPose65
+.4byte sGroudonPose66
+.4byte sGroudonPose67
+.4byte sGroudonPose68
+.4byte sGroudonPose69
+.4byte sGroudonPose70
+.4byte sGroudonPose71
+.4byte sGroudonPose72
+.4byte sGroudonPose73
+.4byte sGroudonPose74
+.4byte sGroudonPose75
+.4byte sGroudonPose76
+.4byte sGroudonPose77
+.4byte sGroudonPose78
+.4byte sGroudonPose79
+.4byte sGroudonPose80
+.4byte sGroudonPose81
+.4byte sGroudonPose82
+.4byte sGroudonPose83
+.4byte sGroudonPose84
+.4byte sGroudonPose85
+.4byte sGroudonPose86
+.4byte sGroudonPose87
+.4byte sGroudonPose88
+.4byte sGroudonPose89
+.4byte sGroudonPose90
+.4byte sGroudonPose91
+.4byte sGroudonPose92
+.4byte sGroudonPose93
+.4byte sGroudonPose94
+.4byte sGroudonPose95
+.4byte sGroudonPose96
+.4byte sGroudonPose97
+.4byte sGroudonPose98
+.4byte sGroudonPose99
+.4byte sGroudonPose100
+.4byte sGroudonPose101
+.4byte sGroudonPose102
+.4byte sGroudonPose103
+.4byte sGroudonPose104
+.4byte sGroudonPose105
+.4byte sGroudonPose106
+.4byte sGroudonPose107
+.4byte sGroudonPose108
+.4byte sGroudonPose109
+.4byte sGroudonPose110
+.4byte sGroudonPose111
+.4byte sGroudonPose112
+.4byte sGroudonPose113
+.4byte sGroudonPose114
+.4byte sGroudonPose115
+.4byte sGroudonPose116
+.4byte sGroudonPose117
+.4byte sGroudonPose118
+.4byte sGroudonPose119
+.4byte sGroudonPose120
+.4byte sGroudonPose121
+.4byte sGroudonPose122
+.4byte sGroudonPose123
+.4byte sGroudonPose124
+.4byte sGroudonPose125
+.4byte sGroudonPose126
+.4byte sGroudonPose127
+.4byte sGroudonPose128
+.4byte sGroudonPose129
+.4byte sGroudonPose130
+.4byte sGroudonPose131
+.4byte sGroudonPose132
+.4byte sGroudonPose133
+.4byte sGroudonPose134
+.4byte sGroudonPose135
+.4byte sGroudonPose136
+.4byte sGroudonPose137
+.4byte sGroudonPose138
+.4byte sGroudonPose139
+.4byte sGroudonPose140
+.4byte sGroudonPose141
+.4byte sGroudonPose142
+.4byte sGroudonPose143
+.4byte sGroudonPose144
+.4byte sGroudonPose145
+.4byte sGroudonPose146
+.4byte sGroudonPose147
+.4byte sGroudonPose148
+.4byte sGroudonPose149
+.4byte sGroudonPose150
+.4byte sGroudonPose151
+.4byte sGroudonPose152
+.4byte sGroudonPose153
+.4byte sGroudonPose154
+.4byte sGroudonPose155
+.4byte sGroudonPose156
+.4byte sGroudonPose157
+.4byte sGroudonPose158
+.4byte sGroudonPose159
+.4byte sGroudonPose160
+.4byte sGroudonPose161
+.4byte sGroudonPose162
+.4byte sGroudonPose163
+.4byte sGroudonPose164
+.4byte sGroudonPose165
+.4byte sGroudonPose166
+.4byte sGroudonPose167
+.4byte sGroudonPose168
+.4byte sGroudonPose169
+.4byte sGroudonPose170
+.4byte sGroudonPose171
+.4byte sGroudonPose172
+.4byte sGroudonPose173
+.4byte sGroudonPose174
+.4byte sGroudonPose175
+.4byte sGroudonPose176
+.4byte sGroudonPose177
+.4byte sGroudonPose178
+.4byte sGroudonPose179
+.4byte sGroudonPose180
+.4byte sGroudonPose181
+.4byte sGroudonPose182
+.4byte sGroudonPose183
+.4byte sGroudonPose184
+.4byte sGroudonPose185
+.4byte sGroudonPose186
+.4byte sGroudonPose187
+.4byte sGroudonPose188
+.4byte sGroudonPose189
+.4byte sGroudonPose190
+.4byte sGroudonPose191
+.4byte sGroudonPose192
+.4byte sGroudonPose193
+.4byte sGroudonPose194
+.4byte sGroudonPose195
+.4byte sGroudonPose196
+.4byte sGroudonPose197
+.4byte sGroudonPose198
+.4byte sGroudonPose199
+.4byte sGroudonPose200
+.4byte sGroudonPose201
+.4byte sGroudonPose202
+.4byte sGroudonPose203
+.4byte sGroudonPose204
+.4byte sGroudonPose205
+.4byte sGroudonPose206
+.4byte sGroudonPose207
+.4byte sGroudonPose208
+.4byte sGroudonPose209
+.4byte sGroudonPose210
+.4byte sGroudonPose211
+.4byte sGroudonPose212
+.4byte sGroudonPose213
+.4byte sGroudonPose214
+.4byte sGroudonPose215
+.4byte sGroudonPose216
+.4byte sGroudonPose217
+.4byte sGroudonPose218
+.4byte sGroudonPose219
+.4byte sGroudonPose220
+.4byte sGroudonPose221
+.4byte sGroudonPose222
+.4byte sGroudonPose223
+.4byte sGroudonPose224
+.4byte sGroudonPose225
+.4byte sGroudonPose226
+.4byte sGroudonPose227
+.4byte sGroudonPose228
+.4byte sGroudonPose229
+.4byte sGroudonPose230
+.4byte sGroudonPose231
+.4byte sGroudonPose232
+.4byte sGroudonPose233
+.4byte sGroudonPose234
+.4byte sGroudonPose235
+.4byte sGroudonPose236
+.4byte sGroudonPose237
+.4byte sGroudonPose238
+.4byte sGroudonPose239
+.4byte sGroudonPose240
+.4byte sGroudonPose241
+.4byte sGroudonPose242
+.4byte sGroudonPose243
+.4byte sGroudonPose244
+.4byte sGroudonPose245
+.4byte sGroudonPose246
+.4byte sGroudonPose247
+.4byte sGroudonPose248
+.4byte sGroudonPose249
+.4byte sGroudonPose250
+.4byte sGroudonPose251
+.4byte sGroudonPose252
+.4byte sGroudonPose253
+.4byte sGroudonPose254
+.4byte sGroudonPose255
+.4byte sGroudonPose256
+.4byte sGroudonPose257
+.4byte sGroudonPose258
+.4byte sGroudonPose259
+sAxPositionsGroudon:
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -2,  -17, 	 -15,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    0,  -16, 	  -9,   -8, 	  15,  -11, 	   1,  -11
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte   14,  -18, 	  15,  -15, 	   1,   -8, 	   0,  -12
+.2byte   11,  -18, 	  17,  -13, 	  -7,  -11, 	   0,  -13
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte   22,  -23, 	  13,  -21, 	  13,  -14, 	  -1,  -15
+.2byte   20,  -22, 	  19,  -19, 	   7,  -11, 	  -3,  -15
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   13,  -31, 	  -1,  -26, 	  17,  -18, 	  -4,  -18
+.2byte   15,  -29, 	   0,  -26, 	  14,  -17, 	  -4,  -16
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte    1,  -35, 	  14,  -23, 	 -11,  -27, 	   0,  -18
+.2byte   -1,  -35, 	   9,  -28, 	 -15,  -24, 	   0,  -18
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte  -14,  -31, 	   0,  -26, 	 -18,  -18, 	   3,  -18
+.2byte  -16,  -29, 	  -1,  -26, 	 -15,  -17, 	   3,  -16
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte  -22,  -23, 	 -13,  -21, 	 -13,  -14, 	   1,  -15
+.2byte  -20,  -22, 	 -19,  -19, 	  -7,  -11, 	   3,  -15
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte  -15,  -18, 	 -16,  -15, 	  -2,   -8, 	  -1,  -12
+.2byte  -12,  -18, 	 -18,  -13, 	   6,  -11, 	  -1,  -13
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -2,  -17, 	 -15,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    0,  -16, 	  -9,   -8, 	  15,  -11, 	   1,  -11
+.2byte    0,    4, 	 -18,   -4, 	  18,   -5, 	   0,  -17
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte   14,  -18, 	  15,  -15, 	   1,   -8, 	   0,  -12
+.2byte   11,  -18, 	  17,  -13, 	  -7,  -11, 	   0,  -13
+.2byte   18,    9, 	  23,   -3, 	  -4,    6, 	   1,  -11
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte   22,  -23, 	  13,  -21, 	  13,  -14, 	  -1,  -15
+.2byte   20,  -22, 	  19,  -19, 	   7,  -11, 	  -3,  -15
+.2byte   23,  -11, 	  13,  -15, 	  11,   -4, 	  -2,  -15
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   13,  -31, 	  -1,  -26, 	  17,  -18, 	  -4,  -18
+.2byte   15,  -29, 	   0,  -26, 	  14,  -17, 	  -4,  -16
+.2byte   14,  -26, 	  -6,  -24, 	  19,  -12, 	   0,  -19
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte    1,  -35, 	  14,  -23, 	 -11,  -27, 	   0,  -18
+.2byte   -1,  -35, 	   9,  -28, 	 -15,  -24, 	   0,  -18
+.2byte    0,  -25, 	  17,  -17, 	 -18,  -17, 	   0,  -16
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte  -14,  -31, 	   0,  -26, 	 -18,  -18, 	   3,  -18
+.2byte  -16,  -29, 	  -1,  -26, 	 -15,  -17, 	   3,  -16
+.2byte  -15,  -26, 	   5,  -24, 	 -20,  -12, 	  -1,  -19
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte  -22,  -23, 	 -13,  -21, 	 -13,  -14, 	   1,  -15
+.2byte  -20,  -22, 	 -19,  -19, 	  -7,  -11, 	   3,  -15
+.2byte  -24,  -11, 	 -14,  -15, 	 -12,   -4, 	   1,  -15
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte  -15,  -18, 	 -16,  -15, 	  -2,   -8, 	  -1,  -12
+.2byte  -12,  -18, 	 -18,  -13, 	   6,  -11, 	  -1,  -13
+.2byte  -19,    9, 	 -24,   -3, 	   3,    6, 	  -2,  -11
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -2,  -17, 	 -15,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    0,  -16, 	  -9,   -8, 	  15,  -11, 	   1,  -11
+.2byte    0,    4, 	 -18,   -4, 	  18,   -5, 	   0,  -17
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte   14,  -18, 	  15,  -15, 	   1,   -8, 	   0,  -12
+.2byte   11,  -18, 	  17,  -13, 	  -7,  -11, 	   0,  -13
+.2byte   18,    9, 	  23,   -3, 	  -4,    6, 	   1,  -11
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte   22,  -23, 	  13,  -21, 	  13,  -14, 	  -1,  -15
+.2byte   20,  -22, 	  19,  -19, 	   7,  -11, 	  -3,  -15
+.2byte   23,  -11, 	  13,  -15, 	  11,   -4, 	  -2,  -15
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   13,  -31, 	  -1,  -26, 	  17,  -18, 	  -4,  -18
+.2byte   15,  -29, 	   0,  -26, 	  14,  -17, 	  -4,  -16
+.2byte   14,  -26, 	  -6,  -24, 	  19,  -12, 	   0,  -19
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte    1,  -35, 	  14,  -23, 	 -11,  -27, 	   0,  -18
+.2byte   -1,  -35, 	   9,  -28, 	 -15,  -24, 	   0,  -18
+.2byte    0,  -25, 	  17,  -17, 	 -18,  -17, 	   0,  -16
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte  -14,  -31, 	   0,  -26, 	 -18,  -18, 	   3,  -18
+.2byte  -16,  -29, 	  -1,  -26, 	 -15,  -17, 	   3,  -16
+.2byte  -15,  -26, 	   5,  -24, 	 -20,  -12, 	  -1,  -19
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte  -22,  -23, 	 -13,  -21, 	 -13,  -14, 	   1,  -15
+.2byte  -20,  -22, 	 -19,  -19, 	  -7,  -11, 	   3,  -15
+.2byte  -24,  -11, 	 -14,  -15, 	 -12,   -4, 	   1,  -15
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte  -15,  -18, 	 -16,  -15, 	  -2,   -8, 	  -1,  -12
+.2byte  -12,  -18, 	 -18,  -13, 	   6,  -11, 	  -1,  -13
+.2byte  -19,    9, 	 -24,   -3, 	   3,    6, 	  -2,  -11
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -7,  -36, 	 -15,  -24, 	  10,  -17, 	   0,  -18
+.2byte    0,    4, 	 -18,   -4, 	  18,   -5, 	   0,  -17
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte    8,  -37, 	  11,  -27, 	  -6,  -17, 	  -2,  -19
+.2byte   18,    9, 	  23,   -3, 	  -4,    6, 	   1,  -11
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte    8,  -38, 	  -6,  -30, 	  11,  -22, 	  -6,  -20
+.2byte   23,  -11, 	  13,  -15, 	  11,   -4, 	  -2,  -15
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   -1,  -40, 	 -16,  -28, 	  13,  -25, 	  -4,  -16
+.2byte   14,  -26, 	  -6,  -24, 	  19,  -12, 	   0,  -19
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte   10,  -39, 	  19,  -21, 	  -6,  -28, 	   0,  -15
+.2byte    0,  -25, 	  17,  -17, 	 -18,  -17, 	   0,  -16
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte    0,  -40, 	  15,  -28, 	 -14,  -25, 	   3,  -16
+.2byte  -15,  -26, 	   5,  -24, 	 -20,  -12, 	  -1,  -19
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte   -9,  -38, 	   5,  -30, 	 -12,  -22, 	   5,  -20
+.2byte  -24,  -11, 	 -14,  -15, 	 -12,   -4, 	   1,  -15
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte   -9,  -37, 	 -12,  -27, 	   5,  -17, 	   1,  -19
+.2byte  -19,    9, 	 -24,   -3, 	   3,    6, 	  -2,  -11
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -7,  -36, 	 -15,  -24, 	  10,  -17, 	   0,  -18
+.2byte   -1,  -12, 	 -19,  -23, 	  18,  -23, 	   0,  -14
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte    8,  -37, 	  11,  -27, 	  -6,  -17, 	  -2,  -19
+.2byte   13,  -11, 	  15,  -31, 	 -11,  -20, 	   0,  -15
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte    8,  -38, 	  -6,  -30, 	  11,  -22, 	  -6,  -20
+.2byte   20,  -16, 	   3,  -35, 	  -1,  -18, 	  -5,  -17
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   -1,  -40, 	 -16,  -28, 	  13,  -25, 	  -4,  -16
+.2byte   17,  -28, 	 -10,  -33, 	  15,  -19, 	  -1,  -20
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte   10,  -39, 	  19,  -21, 	  -6,  -28, 	   0,  -15
+.2byte    0,  -31, 	  19,  -27, 	 -18,  -26, 	   0,  -17
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte    0,  -40, 	  15,  -28, 	 -14,  -25, 	   3,  -16
+.2byte  -18,  -28, 	   9,  -33, 	 -16,  -19, 	   0,  -20
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte   -9,  -38, 	   5,  -30, 	 -12,  -22, 	   5,  -20
+.2byte  -21,  -16, 	  -4,  -35, 	   0,  -18, 	   4,  -17
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte   -9,  -37, 	 -12,  -27, 	   5,  -17, 	   1,  -19
+.2byte  -13,  -11, 	 -15,  -31, 	  11,  -20, 	   0,  -15
+.2byte  -10,  -14, 	 -13,  -14, 	   3,   -9, 	   1,  -12
+.2byte   -9,  -13, 	 -13,  -14, 	   3,   -9, 	   2,  -12
+.2byte  -13,  -15, 	  -5,  -33, 	  -2,   -5, 	   1,  -16
+.2byte   16,  -11, 	   0,  -33, 	   6,   -3, 	  -1,  -14
+.2byte   10,  -11, 	  17,   -6, 	  -9,  -22, 	  -1,  -13
+.2byte   -3,  -30, 	 -17,  -25, 	  -2,  -21, 	   0,  -16
+.2byte   11,  -29, 	  18,  -19, 	   5,  -24, 	   2,  -17
+.2byte    2,  -30, 	  16,  -25, 	   1,  -21, 	  -1,  -16
+.2byte  -11,  -11, 	 -18,   -6, 	   8,  -22, 	   0,  -13
+.2byte  -17,  -11, 	  -1,  -33, 	  -7,   -3, 	   0,  -14
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -7,  -36, 	 -15,  -24, 	  10,  -17, 	   0,  -18
+.2byte   -1,  -12, 	 -19,  -23, 	  18,  -23, 	   0,  -14
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte    8,  -37, 	  11,  -27, 	  -6,  -17, 	  -2,  -19
+.2byte   13,  -11, 	  15,  -31, 	 -11,  -20, 	   0,  -15
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte    8,  -38, 	  -6,  -30, 	  11,  -22, 	  -6,  -20
+.2byte   20,  -16, 	   3,  -35, 	  -1,  -18, 	  -5,  -17
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   -1,  -40, 	 -16,  -28, 	  13,  -25, 	  -4,  -16
+.2byte   17,  -28, 	 -10,  -33, 	  15,  -19, 	  -1,  -20
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte   10,  -39, 	  19,  -21, 	  -6,  -28, 	   0,  -15
+.2byte    0,  -31, 	  19,  -27, 	 -18,  -26, 	   0,  -17
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte    0,  -40, 	  15,  -28, 	 -14,  -25, 	   3,  -16
+.2byte  -18,  -28, 	   9,  -33, 	 -16,  -19, 	   0,  -20
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte   -9,  -38, 	   5,  -30, 	 -12,  -22, 	   5,  -20
+.2byte  -21,  -16, 	  -4,  -35, 	   0,  -18, 	   4,  -17
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte   -9,  -37, 	 -12,  -27, 	   5,  -17, 	   1,  -19
+.2byte  -13,  -11, 	 -15,  -31, 	  11,  -20, 	   0,  -15
+.2byte    0,    4, 	 -18,   -4, 	  18,   -5, 	   0,  -17
+.2byte  -15,    5, 	 -20,   -7, 	   7,    2, 	   2,  -15
+.2byte  -24,   -9, 	 -14,  -13, 	 -12,   -2, 	   1,  -13
+.2byte  -15,  -25, 	   5,  -23, 	 -20,  -11, 	  -1,  -18
+.2byte    0,  -24, 	  17,  -16, 	 -18,  -16, 	   0,  -15
+.2byte   14,  -25, 	  -6,  -23, 	  19,  -11, 	   0,  -18
+.2byte   23,   -9, 	  13,  -13, 	  11,   -2, 	  -2,  -13
+.2byte   14,    5, 	  19,   -7, 	  -8,    2, 	  -3,  -15
+.2byte    0,    4, 	 -18,   -4, 	  18,   -5, 	   0,  -17
+.2byte   14,    5, 	  19,   -7, 	  -8,    2, 	  -3,  -15
+.2byte   23,   -9, 	  13,  -13, 	  11,   -2, 	  -2,  -13
+.2byte   14,  -25, 	  -6,  -23, 	  19,  -11, 	   0,  -18
+.2byte    0,  -24, 	  17,  -16, 	 -18,  -16, 	   0,  -15
+.2byte  -15,  -25, 	   5,  -23, 	 -20,  -11, 	  -1,  -18
+.2byte  -24,   -9, 	 -14,  -13, 	 -12,   -2, 	   1,  -13
+.2byte  -15,    5, 	 -20,   -7, 	   7,    2, 	   2,  -15
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -7,  -36, 	 -15,  -24, 	  10,  -17, 	   0,  -18
+.2byte   -1,  -12, 	 -19,  -23, 	  18,  -23, 	   0,  -14
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte    8,  -37, 	  11,  -27, 	  -6,  -17, 	  -2,  -19
+.2byte   13,  -11, 	  15,  -31, 	 -11,  -20, 	   0,  -15
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte    8,  -38, 	  -6,  -30, 	  11,  -22, 	  -6,  -20
+.2byte   20,  -16, 	   3,  -35, 	  -1,  -18, 	  -5,  -17
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   -1,  -40, 	 -16,  -28, 	  13,  -25, 	  -4,  -16
+.2byte   17,  -28, 	 -10,  -33, 	  15,  -19, 	  -1,  -20
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte   10,  -39, 	  19,  -21, 	  -6,  -28, 	   0,  -15
+.2byte    0,  -31, 	  19,  -27, 	 -18,  -26, 	   0,  -17
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte    0,  -40, 	  15,  -28, 	 -14,  -25, 	   3,  -16
+.2byte  -18,  -28, 	   9,  -33, 	 -16,  -19, 	   0,  -20
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte   -9,  -38, 	   5,  -30, 	 -12,  -22, 	   5,  -20
+.2byte  -21,  -16, 	  -4,  -35, 	   0,  -18, 	   4,  -17
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte   -9,  -37, 	 -12,  -27, 	   5,  -17, 	   1,  -19
+.2byte  -13,  -11, 	 -15,  -31, 	  11,  -20, 	   0,  -15
+.2byte   -1,  -12, 	 -19,  -23, 	  18,  -23, 	   0,  -14
+.2byte  -13,  -11, 	 -15,  -31, 	  11,  -20, 	   0,  -15
+.2byte  -21,  -16, 	  -4,  -35, 	   0,  -18, 	   4,  -17
+.2byte  -18,  -25, 	   9,  -30, 	 -16,  -16, 	   0,  -17
+.2byte    0,  -31, 	  19,  -27, 	 -18,  -26, 	   0,  -17
+.2byte   17,  -25, 	 -10,  -30, 	  15,  -16, 	  -1,  -17
+.2byte   20,  -16, 	   3,  -35, 	  -1,  -18, 	  -5,  -17
+.2byte   13,  -11, 	  15,  -31, 	 -11,  -20, 	   0,  -15
+.2byte   -1,  -18, 	 -12,  -10, 	  11,  -10, 	   0,  -13
+.2byte  -14,  -19, 	 -18,  -15, 	   2,  -10, 	   0,  -14
+.2byte  -21,  -23, 	  -9,  -16, 	 -11,  -12, 	   1,  -15
+.2byte  -15,  -32, 	   0,  -25, 	 -17,  -18, 	   3,  -18
+.2byte    0,  -36, 	  13,  -25, 	 -14,  -25, 	   0,  -18
+.2byte   14,  -32, 	  -1,  -25, 	  16,  -18, 	  -4,  -18
+.2byte   20,  -23, 	   8,  -16, 	  10,  -12, 	  -2,  -15
+.2byte   13,  -19, 	  17,  -15, 	  -3,  -10, 	  -1,  -14
+.2byte    3,   -7, 	 -15,   -7, 	  15,  -15, 	  -1,  -14
+.2byte    3,   -4, 	 -13,   -5, 	  15,  -12, 	  -1,  -12
+.2byte    2,   -7, 	 -16,   -7, 	  14,  -15, 	  -2,  -14
+.2byte    2,   -4, 	 -14,   -5, 	  14,  -12, 	  -2,  -12
+.2byte   -4,  -10, 	 -18,  -11, 	  12,  -12, 	  -1,  -13
+.2byte    0,    6, 	 -18,   -3, 	  15,   -1, 	  -2,   -9
+.2byte    7,   14, 	 -16,    7, 	  19,    8, 	   1,   -5
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -9,  -36, 	 -17,  -24, 	   8,  -17, 	  -2,  -18
+.2byte   -1,  -19, 	 -12,  -11, 	  11,  -11, 	   0,  -14
+.2byte   -2,  -17, 	 -15,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    0,  -16, 	  -9,   -8, 	  15,  -11, 	   1,  -11
+.2byte   13,  -20, 	  17,  -16, 	  -3,  -11, 	  -1,  -15
+.2byte   14,  -18, 	  15,  -15, 	   1,   -8, 	   0,  -12
+.2byte   11,  -18, 	  17,  -13, 	  -7,  -11, 	   0,  -13
+.2byte   20,  -24, 	   8,  -17, 	  10,  -13, 	  -2,  -16
+.2byte   22,  -23, 	  13,  -21, 	  13,  -14, 	  -1,  -15
+.2byte   20,  -22, 	  19,  -19, 	   7,  -11, 	  -3,  -15
+.2byte   14,  -33, 	  -1,  -26, 	  16,  -19, 	  -4,  -19
+.2byte   13,  -31, 	  -1,  -26, 	  17,  -18, 	  -4,  -18
+.2byte   15,  -29, 	   0,  -26, 	  14,  -17, 	  -4,  -16
+.2byte    0,  -37, 	  13,  -26, 	 -14,  -26, 	   0,  -19
+.2byte    1,  -35, 	  14,  -23, 	 -11,  -27, 	   0,  -18
+.2byte   -1,  -35, 	   9,  -28, 	 -15,  -24, 	   0,  -18
+.2byte  -15,  -33, 	   0,  -26, 	 -17,  -19, 	   3,  -19
+.2byte  -14,  -31, 	   0,  -26, 	 -18,  -18, 	   3,  -18
+.2byte  -16,  -29, 	  -1,  -26, 	 -15,  -17, 	   3,  -16
+.2byte  -21,  -24, 	  -9,  -17, 	 -11,  -13, 	   1,  -16
+.2byte  -22,  -23, 	 -13,  -21, 	 -13,  -14, 	   1,  -15
+.2byte  -20,  -22, 	 -19,  -19, 	  -7,  -11, 	   3,  -15
+.2byte  -14,  -20, 	 -18,  -16, 	   2,  -11, 	   0,  -15
+.2byte  -15,  -18, 	 -16,  -15, 	  -2,   -8, 	  -1,  -12
+.2byte  -12,  -18, 	 -18,  -13, 	   6,  -11, 	  -1,  -13
+sGroudonAnimTable1:
+.4byte sGroudonAnims_1_1
+.4byte sGroudonAnims_1_2
+.4byte sGroudonAnims_1_3
+.4byte sGroudonAnims_1_4
+.4byte sGroudonAnims_1_5
+.4byte sGroudonAnims_1_6
+.4byte sGroudonAnims_1_7
+.4byte sGroudonAnims_1_8
+sGroudonAnimTable2:
+.4byte sGroudonAnims_2_1
+.4byte sGroudonAnims_2_2
+.4byte sGroudonAnims_2_3
+.4byte sGroudonAnims_2_4
+.4byte sGroudonAnims_2_5
+.4byte sGroudonAnims_2_6
+.4byte sGroudonAnims_2_7
+.4byte sGroudonAnims_2_8
+sGroudonAnimTable3:
+.4byte sGroudonAnims_3_1
+.4byte sGroudonAnims_3_2
+.4byte sGroudonAnims_3_3
+.4byte sGroudonAnims_3_4
+.4byte sGroudonAnims_3_5
+.4byte sGroudonAnims_3_6
+.4byte sGroudonAnims_3_7
+.4byte sGroudonAnims_3_8
+sGroudonAnimTable4:
+.4byte sGroudonAnims_4_1
+.4byte sGroudonAnims_4_2
+.4byte sGroudonAnims_4_3
+.4byte sGroudonAnims_4_4
+.4byte sGroudonAnims_4_5
+.4byte sGroudonAnims_4_6
+.4byte sGroudonAnims_4_7
+.4byte sGroudonAnims_4_8
+sGroudonAnimTable5:
+.4byte sGroudonAnims_5_1
+.4byte sGroudonAnims_5_2
+.4byte sGroudonAnims_5_3
+.4byte sGroudonAnims_5_4
+.4byte sGroudonAnims_5_5
+.4byte sGroudonAnims_5_6
+.4byte sGroudonAnims_5_7
+.4byte sGroudonAnims_5_8
+sGroudonAnimTable6:
+.4byte sGroudonAnims_6_1
+.4byte sGroudonAnims_6_1
+.4byte sGroudonAnims_6_1
+.4byte sGroudonAnims_6_1
+.4byte sGroudonAnims_6_1
+.4byte sGroudonAnims_6_1
+.4byte sGroudonAnims_6_1
+.4byte sGroudonAnims_6_1
+sGroudonAnimTable7:
+.4byte sGroudonAnims_7_1
+.4byte sGroudonAnims_7_2
+.4byte sGroudonAnims_7_3
+.4byte sGroudonAnims_7_4
+.4byte sGroudonAnims_7_5
+.4byte sGroudonAnims_7_6
+.4byte sGroudonAnims_7_7
+.4byte sGroudonAnims_7_8
+sGroudonAnimTable8:
+.4byte sGroudonAnims_8_1
+.4byte sGroudonAnims_8_2
+.4byte sGroudonAnims_8_3
+.4byte sGroudonAnims_8_4
+.4byte sGroudonAnims_8_5
+.4byte sGroudonAnims_8_6
+.4byte sGroudonAnims_8_7
+.4byte sGroudonAnims_8_8
+sGroudonAnimTable9:
+.4byte sGroudonAnims_9_1
+.4byte sGroudonAnims_9_2
+.4byte sGroudonAnims_9_3
+.4byte sGroudonAnims_9_4
+.4byte sGroudonAnims_9_5
+.4byte sGroudonAnims_9_6
+.4byte sGroudonAnims_9_7
+.4byte sGroudonAnims_9_8
+sGroudonAnimTable10:
+.4byte sGroudonAnims_10_1
+.4byte sGroudonAnims_10_2
+.4byte sGroudonAnims_10_3
+.4byte sGroudonAnims_10_4
+.4byte sGroudonAnims_10_5
+.4byte sGroudonAnims_10_6
+.4byte sGroudonAnims_10_7
+.4byte sGroudonAnims_10_8
+sGroudonAnimTable11:
+.4byte sGroudonAnims_11_1
+.4byte sGroudonAnims_11_2
+.4byte sGroudonAnims_11_3
+.4byte sGroudonAnims_11_4
+.4byte sGroudonAnims_11_5
+.4byte sGroudonAnims_11_6
+.4byte sGroudonAnims_11_7
+.4byte sGroudonAnims_11_8
+sGroudonAnimTable12:
+.4byte sGroudonAnims_12_1
+.4byte sGroudonAnims_12_2
+.4byte sGroudonAnims_12_3
+.4byte sGroudonAnims_12_4
+.4byte sGroudonAnims_12_5
+.4byte sGroudonAnims_12_6
+.4byte sGroudonAnims_12_7
+.4byte sGroudonAnims_12_8
+sGroudonAnimTable13:
+.4byte sGroudonAnims_13_1
+.4byte sGroudonAnims_13_2
+.4byte sGroudonAnims_13_3
+.4byte sGroudonAnims_13_4
+.4byte sGroudonAnims_13_5
+.4byte sGroudonAnims_13_6
+.4byte sGroudonAnims_13_7
+.4byte sGroudonAnims_13_8
+sGroudonAnimTable14:
+.4byte sGroudonAnims_14_1
+.4byte sGroudonAnims_14_2
+.4byte sGroudonAnims_14_3
+.4byte sGroudonAnims_14_4
+.4byte sGroudonAnims_14_5
+.4byte sGroudonAnims_14_6
+.4byte sGroudonAnims_14_7
+.4byte sGroudonAnims_14_8
+sGroudonAnimTable15:
+.4byte sGroudonAnims_15_1
+.4byte sGroudonAnims_15_2
+.4byte sGroudonAnims_15_3
+.4byte sGroudonAnims_15_4
+.4byte sGroudonAnims_15_5
+.4byte sGroudonAnims_15_6
+.4byte sGroudonAnims_15_7
+.4byte sGroudonAnims_15_8
+sGroudonAnimTable16:
+.4byte sGroudonAnims_16_1
+.4byte sGroudonAnims_16_2
+.4byte sGroudonAnims_16_3
+.4byte sGroudonAnims_16_4
+.4byte sGroudonAnims_16_5
+.4byte sGroudonAnims_16_6
+.4byte sGroudonAnims_16_7
+.4byte sGroudonAnims_16_8
+sAxAnimationsGroudon:
+.4byte sGroudonAnimTable1
+.4byte sGroudonAnimTable2
+.4byte sGroudonAnimTable3
+.4byte sGroudonAnimTable4
+.4byte sGroudonAnimTable5
+.4byte sGroudonAnimTable6
+.4byte sGroudonAnimTable7
+.4byte sGroudonAnimTable8
+.4byte sGroudonAnimTable9
+.4byte sGroudonAnimTable10
+.4byte sGroudonAnimTable11
+.4byte sGroudonAnimTable12
+.4byte sGroudonAnimTable13
+.4byte sGroudonAnimTable14
+.4byte sGroudonAnimTable15
+.4byte sGroudonAnimTable16
+sAxSpritesGroudon:
+.4byte sGroudonSprites1
+.4byte sGroudonSprites2
+.4byte sGroudonSprites3
+.4byte sGroudonSprites4
+.4byte sGroudonSprites5
+.4byte sGroudonSprites6
+.4byte sGroudonSprites7
+.4byte sGroudonSprites8
+.4byte sGroudonSprites9
+.4byte sGroudonSprites10
+.4byte sGroudonSprites11
+.4byte sGroudonSprites12
+.4byte sGroudonSprites13
+.4byte sGroudonSprites14
+.4byte sGroudonSprites15
+.4byte sGroudonSprites16
+.4byte sGroudonSprites17
+.4byte sGroudonSprites18
+.4byte sGroudonSprites19
+.4byte sGroudonSprites20
+.4byte sGroudonSprites21
+.4byte sGroudonSprites22
+.4byte sGroudonSprites23
+.4byte sGroudonSprites24
+.4byte sGroudonSprites25
+.4byte sGroudonSprites26
+.4byte sGroudonSprites27
+.4byte sGroudonSprites28
+.4byte sGroudonSprites29
+.4byte sGroudonSprites30
+.4byte sGroudonSprites31
+.4byte sGroudonSprites32
+.4byte sGroudonSprites33
+.4byte sGroudonSprites34
+.4byte sGroudonSprites35
+.4byte sGroudonSprites36
+.4byte sGroudonSprites37
+.4byte sGroudonSprites38
+.4byte sGroudonSprites39
+.4byte sGroudonSprites40
+.4byte sGroudonSprites41
+.4byte sGroudonSprites42
+.4byte sGroudonSprites43
+.4byte sGroudonSprites44
+.4byte sGroudonSprites45
+.4byte sGroudonSprites46
+.4byte sGroudonSprites47
+.4byte sGroudonSprites48
+.4byte sGroudonSprites49
+.4byte sGroudonSprites50
+.4byte sGroudonSprites51
+.4byte sGroudonSprites52
+.4byte sGroudonSprites53
+.4byte sGroudonSprites54
+.4byte sGroudonSprites55
+.4byte sGroudonSprites56
+.4byte sGroudonSprites57
+.4byte sGroudonSprites58
+.4byte sGroudonSprites59
+sAxMainGroudon:
+ax_main sAxPosesGroudon, sAxAnimationsGroudon, 16, sAxSpritesGroudon, sAxPositionsGroudon

--- a/data/ax/grovyle.inc
+++ b/data/ax/grovyle.inc
@@ -1,0 +1,2545 @@
+.global gAxGrovyle
+gAxGrovyle:
+ax_siro sAxMainGrovyle
+sGrovylePose1:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose2:
+ax_pose 1, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose3:
+ax_pose 2, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose4:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose5:
+ax_pose 4, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose6:
+ax_pose 5, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose7:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose8:
+ax_pose 7, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose9:
+ax_pose 8, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose10:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose11:
+ax_pose 10, 0x01e6, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose12:
+ax_pose 11, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose13:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose14:
+ax_pose 13, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose15:
+ax_pose 14, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose16:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose17:
+ax_pose 10, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose18:
+ax_pose 11, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose19:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose20:
+ax_pose 7, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose21:
+ax_pose 8, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose22:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose23:
+ax_pose 4, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose24:
+ax_pose 5, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose25:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose26:
+ax_pose 15, 0x81e7, 0x80f9, 0xcc00
+ax_pose 16, 0x81e7, 0x4109, 0xcc08
+ax_pose 17, 0x81f7, 0x00f1, 0xcc0c
+ax_pose 18, 0x01ef, 0x00f1, 0xcc0e
+ax_pose 19, 0x01ef, 0x00e9, 0xcc0f
+ax_pose_terminator
+sGrovylePose27:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose28:
+ax_pose 20, 0x01eb, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose29:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose30:
+ax_pose 21, 0x01ec, 0x90f2, 0xcc00
+ax_pose_terminator
+sGrovylePose31:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose32:
+ax_pose 22, 0x01ec, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose33:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose34:
+ax_pose 23, 0x41ea, 0x00f9, 0xcc00
+ax_pose 24, 0x41f2, 0x80f1, 0xcc02
+ax_pose 25, 0x01f2, 0x00e9, 0xcc0a
+ax_pose_terminator
+sGrovylePose35:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose36:
+ax_pose 22, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose37:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose38:
+ax_pose 21, 0x01ec, 0x80ee, 0xcc00
+ax_pose_terminator
+sGrovylePose39:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose40:
+ax_pose 20, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose41:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose42:
+ax_pose 26, 0x01e7, 0x80f1, 0xcc00
+ax_pose_terminator
+sGrovylePose43:
+ax_pose 27, 0x81e8, 0x80ff, 0xcc00
+ax_pose 28, 0x01e7, 0x80f1, 0xcc08
+ax_pose_terminator
+sGrovylePose44:
+ax_pose 28, 0x01e7, 0x80f1, 0xcc00
+ax_pose_terminator
+sGrovylePose45:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose46:
+ax_pose 29, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose47:
+ax_pose 30, 0x01e7, 0x90ee, 0xcc00
+ax_pose 31, 0x01e7, 0x90f0, 0xcc10
+ax_pose_terminator
+sGrovylePose48:
+ax_pose 31, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose49:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose50:
+ax_pose 32, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose51:
+ax_pose 33, 0x01e8, 0x90f1, 0xcc00
+ax_pose 34, 0x01ed, 0x90f0, 0xcc10
+ax_pose_terminator
+sGrovylePose52:
+ax_pose 34, 0x01ed, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose53:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose54:
+ax_pose 35, 0x01e7, 0x90eb, 0xcc00
+ax_pose_terminator
+sGrovylePose55:
+ax_pose 36, 0x81e7, 0x9102, 0xcc00
+ax_pose 37, 0x01ed, 0x90f3, 0xcc08
+ax_pose_terminator
+sGrovylePose56:
+ax_pose 37, 0x01ed, 0x90f3, 0xcc00
+ax_pose_terminator
+sGrovylePose57:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose58:
+ax_pose 38, 0x01e6, 0x80ef, 0xcc00
+ax_pose_terminator
+sGrovylePose59:
+ax_pose 39, 0x81e2, 0x80ef, 0xcc00
+ax_pose 40, 0x01e6, 0x80ef, 0xcc08
+ax_pose_terminator
+sGrovylePose60:
+ax_pose 40, 0x01e6, 0x80ef, 0xcc00
+ax_pose_terminator
+sGrovylePose61:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose62:
+ax_pose 35, 0x01e7, 0x80f5, 0xcc00
+ax_pose_terminator
+sGrovylePose63:
+ax_pose 36, 0x81e7, 0x80ee, 0xcc00
+ax_pose 37, 0x01ed, 0x80ed, 0xcc08
+ax_pose_terminator
+sGrovylePose64:
+ax_pose 37, 0x01ed, 0x80ed, 0xcc00
+ax_pose_terminator
+sGrovylePose65:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose66:
+ax_pose 32, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose67:
+ax_pose 33, 0x01e8, 0x80f1, 0xcc00
+ax_pose 34, 0x01ed, 0x80f0, 0xcc10
+ax_pose_terminator
+sGrovylePose68:
+ax_pose 34, 0x01ed, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose69:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose70:
+ax_pose 29, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose71:
+ax_pose 30, 0x01e7, 0x80f2, 0xcc00
+ax_pose 31, 0x01e7, 0x80f0, 0xcc10
+ax_pose_terminator
+sGrovylePose72:
+ax_pose 31, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose73:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose74:
+ax_pose 15, 0x81e7, 0x80f9, 0xcc00
+ax_pose 16, 0x81e7, 0x4109, 0xcc08
+ax_pose 17, 0x81f7, 0x00f1, 0xcc0c
+ax_pose 18, 0x01ef, 0x00f1, 0xcc0e
+ax_pose 19, 0x01ef, 0x00e9, 0xcc0f
+ax_pose_terminator
+sGrovylePose75:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose76:
+ax_pose 20, 0x01eb, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose77:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose78:
+ax_pose 21, 0x01ec, 0x90f2, 0xcc00
+ax_pose_terminator
+sGrovylePose79:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose80:
+ax_pose 22, 0x01ec, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose81:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose82:
+ax_pose 23, 0x41ea, 0x00f9, 0xcc00
+ax_pose 24, 0x41f2, 0x80f1, 0xcc02
+ax_pose 25, 0x01f2, 0x00e9, 0xcc0a
+ax_pose_terminator
+sGrovylePose83:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose84:
+ax_pose 22, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose85:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose86:
+ax_pose 21, 0x01ec, 0x80ee, 0xcc00
+ax_pose_terminator
+sGrovylePose87:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose88:
+ax_pose 20, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose89:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose90:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose91:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose92:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose93:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose94:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose95:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose96:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose97:
+ax_pose 41, 0x01e9, 0x80f6, 0xcc00
+ax_pose_terminator
+sGrovylePose98:
+ax_pose 42, 0x01e9, 0x80f6, 0xcc00
+ax_pose_terminator
+sGrovylePose99:
+ax_pose 43, 0x01e6, 0x80f1, 0xcc00
+ax_pose_terminator
+sGrovylePose100:
+ax_pose 44, 0x01e7, 0x90ee, 0xcc00
+ax_pose_terminator
+sGrovylePose101:
+ax_pose 45, 0x01e8, 0x90ed, 0xcc00
+ax_pose_terminator
+sGrovylePose102:
+ax_pose 46, 0x01e4, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose103:
+ax_pose 47, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose104:
+ax_pose 46, 0x01e4, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose105:
+ax_pose 45, 0x01e8, 0x80f3, 0xcc00
+ax_pose_terminator
+sGrovylePose106:
+ax_pose 44, 0x01e7, 0x80f2, 0xcc00
+ax_pose_terminator
+sGrovylePose107:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose108:
+ax_pose 1, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose109:
+ax_pose 2, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose110:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose111:
+ax_pose 4, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose112:
+ax_pose 5, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose113:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose114:
+ax_pose 7, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose115:
+ax_pose 8, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose116:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose117:
+ax_pose 10, 0x01e6, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose118:
+ax_pose 11, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose119:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose120:
+ax_pose 13, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose121:
+ax_pose 14, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose122:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose123:
+ax_pose 10, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose124:
+ax_pose 11, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose125:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose126:
+ax_pose 7, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose127:
+ax_pose 8, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose128:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose129:
+ax_pose 4, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose130:
+ax_pose 5, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose131:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose132:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose133:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose134:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose135:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose136:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose137:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose138:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose139:
+ax_pose 15, 0x81e7, 0x80f9, 0xcc00
+ax_pose 16, 0x81e7, 0x4109, 0xcc08
+ax_pose 17, 0x81f7, 0x00f1, 0xcc0c
+ax_pose 18, 0x01ef, 0x00f1, 0xcc0e
+ax_pose 19, 0x01ef, 0x00e9, 0xcc0f
+ax_pose_terminator
+sGrovylePose140:
+ax_pose 20, 0x01eb, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose141:
+ax_pose 21, 0x01ec, 0x90f2, 0xcc00
+ax_pose_terminator
+sGrovylePose142:
+ax_pose 22, 0x01ec, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose143:
+ax_pose 23, 0x41ea, 0x00f9, 0xcc00
+ax_pose 24, 0x41f2, 0x80f1, 0xcc02
+ax_pose 25, 0x01f2, 0x00e9, 0xcc0a
+ax_pose_terminator
+sGrovylePose144:
+ax_pose 22, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose145:
+ax_pose 21, 0x01ec, 0x80ee, 0xcc00
+ax_pose_terminator
+sGrovylePose146:
+ax_pose 20, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose147:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose148:
+ax_pose 1, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose149:
+ax_pose 2, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose150:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose151:
+ax_pose 4, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose152:
+ax_pose 5, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose153:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose154:
+ax_pose 7, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose155:
+ax_pose 8, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose156:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose157:
+ax_pose 10, 0x01e6, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose158:
+ax_pose 11, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose159:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose160:
+ax_pose 13, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose161:
+ax_pose 14, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose162:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose163:
+ax_pose 10, 0x01e6, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose164:
+ax_pose 11, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose165:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose166:
+ax_pose 7, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose167:
+ax_pose 8, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose168:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose169:
+ax_pose 4, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose170:
+ax_pose 5, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose171:
+ax_pose 15, 0x81e7, 0x80f9, 0xcc00
+ax_pose 16, 0x81e7, 0x4109, 0xcc08
+ax_pose 17, 0x81f7, 0x00f1, 0xcc0c
+ax_pose 18, 0x01ef, 0x00f1, 0xcc0e
+ax_pose 19, 0x01ef, 0x00e9, 0xcc0f
+ax_pose_terminator
+sGrovylePose172:
+ax_pose 20, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose173:
+ax_pose 21, 0x01ec, 0x80ee, 0xcc00
+ax_pose_terminator
+sGrovylePose174:
+ax_pose 22, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose175:
+ax_pose 23, 0x41ea, 0x00f9, 0xcc00
+ax_pose 24, 0x41f2, 0x80f1, 0xcc02
+ax_pose 25, 0x01f2, 0x00e9, 0xcc0a
+ax_pose_terminator
+sGrovylePose176:
+ax_pose 22, 0x01ec, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose177:
+ax_pose 21, 0x01ec, 0x90f2, 0xcc00
+ax_pose_terminator
+sGrovylePose178:
+ax_pose 20, 0x01eb, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose179:
+ax_pose 20, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose180:
+ax_pose 0, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose181:
+ax_pose 3, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose182:
+ax_pose 6, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose183:
+ax_pose 9, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sGrovylePose184:
+ax_pose 12, 0x01e7, 0x80f0, 0xcc00
+ax_pose_terminator
+sGrovylePose185:
+ax_pose 9, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+sGrovylePose186:
+ax_pose 6, 0x01e7, 0x90f0, 0xcc00
+ax_pose_terminator
+sGrovylePose187:
+ax_pose 3, 0x01e7, 0x90ec, 0xcc00
+ax_pose_terminator
+.align 2
+sGrovyleAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -4, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -4, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -4, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -4, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -4, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -4, 0, 0,
+ax_anim 6, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -4, 0, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -4, 0, 0,
+ax_anim 6, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 1, 25, 1, 22, 1, 22,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 4, 0, 25, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGrovyleAnims_2_2:
+ax_anim 4, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, -1, -1, -1, -1,
+ax_anim 4, 0, 26, -2, -2, -2, -2,
+ax_anim 2, 0, 27, 0, -1, 0, 0,
+ax_anim 2, 0, 27, 2, -1, 2, 2,
+ax_anim 2, 2, 27, 6, 2, 6, 6,
+ax_anim 2, 0, 27, 15, 15, 15, 15,
+ax_anim 2, 1, 27, 16, 14, 16, 14,
+ax_anim 2, 0, 27, 15, 15, 15, 15,
+ax_anim 4, 0, 27, 16, 14, 16, 14,
+ax_anim 2, 0, 26, 8, 8, 8, 8,
+ax_anim_terminator
+sGrovyleAnims_2_3:
+ax_anim 4, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, 0, -1, 0,
+ax_anim 4, 0, 28, -2, 0, -2, 0,
+ax_anim 2, 0, 29, -2, -4, -2, -4,
+ax_anim 2, 0, 29, 0, -4, 0, -4,
+ax_anim 2, 2, 29, 5, -3, 5, -3,
+ax_anim 2, 0, 29, 10, 0, 10, 0,
+ax_anim 2, 1, 29, 10, 1, 10, 1,
+ax_anim 2, 0, 29, 10, 0, 10, 0,
+ax_anim 4, 0, 29, 10, 1, 10, 1,
+ax_anim 2, 0, 28, 6, -2, 6, 0,
+ax_anim_terminator
+sGrovyleAnims_2_4:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 4, 0, 30, -2, 2, -2, 2,
+ax_anim 2, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 31, 4, -8, 4, -4,
+ax_anim 2, 2, 31, 8, -12, 8, -8,
+ax_anim 2, 0, 31, 15, -16, 15, -16,
+ax_anim 2, 1, 31, 16, -15, 16, -15,
+ax_anim 2, 0, 31, 15, -16, 15, -16,
+ax_anim 4, 0, 31, 16, -15, 16, -15,
+ax_anim 2, 0, 30, 6, -9, 6, -9,
+ax_anim_terminator
+sGrovyleAnims_2_5:
+ax_anim 4, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 1, 0, 1,
+ax_anim 4, 0, 32, 0, 2, 0, 2,
+ax_anim 2, 0, 33, 0, -2, 0, 0,
+ax_anim 2, 0, 33, 0, -7, 0, -3,
+ax_anim 2, 2, 33, 0, -12, 0, -8,
+ax_anim 2, 0, 33, 0, -18, 0, -18,
+ax_anim 2, 1, 33, 1, -18, 1, -18,
+ax_anim 2, 0, 33, 0, -18, 0, -18,
+ax_anim 4, 0, 33, 1, -18, 1, -18,
+ax_anim 2, 0, 32, 0, -6, 0, -6,
+ax_anim_terminator
+sGrovyleAnims_2_6:
+ax_anim 4, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 1, 1, 1, 1,
+ax_anim 4, 0, 34, 2, 2, 2, 2,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 35, -4, -8, -4, -4,
+ax_anim 2, 2, 35, -8, -12, -8, -8,
+ax_anim 2, 0, 35, -15, -16, -15, -16,
+ax_anim 2, 1, 35, -16, -15, -16, -15,
+ax_anim 2, 0, 35, -15, -16, -15, -16,
+ax_anim 4, 0, 35, -16, -15, -16, -15,
+ax_anim 2, 0, 34, -6, -9, -6, -9,
+ax_anim_terminator
+sGrovyleAnims_2_7:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 4, 0, 36, 2, 0, 2, 0,
+ax_anim 2, 0, 37, 2, -4, 2, -4,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 37, -5, -3, -5, -3,
+ax_anim 2, 0, 37, -10, 0, -10, 0,
+ax_anim 2, 1, 37, -10, 1, -10, 1,
+ax_anim 2, 0, 37, -10, 0, -10, 0,
+ax_anim 4, 0, 37, -10, 1, -10, 1,
+ax_anim 2, 0, 36, -6, -2, -6, 0,
+ax_anim_terminator
+sGrovyleAnims_2_8:
+ax_anim 4, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 1, -1, 1, -1,
+ax_anim 4, 0, 38, 2, -2, 2, -2,
+ax_anim 2, 0, 39, 0, -1, 0, 0,
+ax_anim 2, 0, 39, -2, -1, -2, 2,
+ax_anim 2, 2, 39, -6, 2, -6, 6,
+ax_anim 2, 0, 39, -15, 15, -15, 15,
+ax_anim 2, 1, 39, -16, 14, -16, 14,
+ax_anim 2, 0, 39, -15, 15, -15, 15,
+ax_anim 4, 0, 39, -16, 14, -16, 14,
+ax_anim 2, 0, 38, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_3_1:
+ax_anim 2, 0, 41, 0, -1, 0, -1,
+ax_anim 4, 0, 41, 0, -3, 0, -3,
+ax_anim 2, 2, 41, 0, -1, 0, -1,
+ax_anim 2, 0, 41, 0, 6, 0, 6,
+ax_anim 2, 1, 42, 0, 18, 0, 18,
+ax_anim 2, 0, 43, -1, 18, -1, 18,
+ax_anim 2, 0, 43, 0, 18, 0, 18,
+ax_anim 2, 0, 43, -1, 18, -1, 18,
+ax_anim 2, 0, 40, 0, 8, 0, 8,
+ax_anim_terminator
+sGrovyleAnims_3_2:
+ax_anim 2, 0, 45, -1, -1, -1, -1,
+ax_anim 4, 0, 45, -3, -3, -3, -3,
+ax_anim 2, 2, 45, -1, -1, -1, -1,
+ax_anim 2, 0, 45, 6, 6, 6, 6,
+ax_anim 2, 1, 46, 18, 18, 18, 18,
+ax_anim 2, 0, 47, 19, 17, 19, 17,
+ax_anim 2, 0, 47, 18, 18, 18, 18,
+ax_anim 2, 0, 47, 19, 17, 19, 17,
+ax_anim 2, 0, 44, 8, 8, 8, 8,
+ax_anim_terminator
+sGrovyleAnims_3_3:
+ax_anim 2, 0, 49, -1, 0, -1, 0,
+ax_anim 4, 0, 49, -3, 0, -3, 0,
+ax_anim 2, 2, 49, -1, 0, -1, 0,
+ax_anim 2, 0, 49, 4, 0, 4, 0,
+ax_anim 2, 1, 50, 15, 0, 15, 0,
+ax_anim 2, 0, 51, 15, 1, 15, 1,
+ax_anim 2, 0, 51, 15, 0, 15, 0,
+ax_anim 2, 0, 51, 15, 1, 15, 1,
+ax_anim 2, 0, 48, 6, 0, 6, 0,
+ax_anim_terminator
+sGrovyleAnims_3_4:
+ax_anim 2, 0, 53, -1, 1, -1, 1,
+ax_anim 4, 0, 53, -3, 3, -3, 3,
+ax_anim 2, 2, 53, -1, 1, -1, 1,
+ax_anim 2, 0, 53, 6, -8, 6, -8,
+ax_anim 2, 1, 54, 15, -17, 15, -17,
+ax_anim 2, 0, 55, 16, -16, 16, -16,
+ax_anim 2, 0, 55, 15, -17, 15, -17,
+ax_anim 2, 0, 55, 16, -16, 16, -16,
+ax_anim 2, 0, 52, 8, -8, 8, -8,
+ax_anim_terminator
+sGrovyleAnims_3_5:
+ax_anim 2, 0, 57, 0, 1, 0, 1,
+ax_anim 4, 0, 57, 0, 3, 0, 3,
+ax_anim 2, 2, 57, 0, 1, 0, 1,
+ax_anim 2, 0, 57, 0, -6, 0, -6,
+ax_anim 2, 1, 58, 0, -16, 0, -16,
+ax_anim 2, 0, 59, -1, -16, -1, -16,
+ax_anim 2, 0, 59, 0, -16, 0, -16,
+ax_anim 2, 0, 59, -1, -16, -1, -16,
+ax_anim 2, 0, 56, 0, -8, 0, -8,
+ax_anim_terminator
+sGrovyleAnims_3_6:
+ax_anim 2, 0, 61, 1, 1, 1, 1,
+ax_anim 4, 0, 61, 3, 3, 3, 3,
+ax_anim 2, 2, 61, 1, 1, 1, 1,
+ax_anim 2, 0, 61, -6, -8, -6, -8,
+ax_anim 2, 1, 62, -15, -17, -15, -17,
+ax_anim 2, 0, 63, -16, -16, -16, -16,
+ax_anim 2, 0, 63, -15, -17, -15, -17,
+ax_anim 2, 0, 63, -16, -16, -16, -16,
+ax_anim 2, 0, 60, -8, -8, -8, -8,
+ax_anim_terminator
+sGrovyleAnims_3_7:
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim 4, 0, 65, 3, 0, 3, 0,
+ax_anim 2, 2, 65, 1, 0, 1, 0,
+ax_anim 2, 0, 65, -4, 0, -4, 0,
+ax_anim 2, 1, 66, -15, 0, -15, 0,
+ax_anim 2, 0, 67, -15, 1, -15, 1,
+ax_anim 2, 0, 67, -15, 0, -15, 0,
+ax_anim 2, 0, 67, -15, 1, -15, 1,
+ax_anim 2, 0, 64, -6, 0, -6, 0,
+ax_anim_terminator
+sGrovyleAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 3, -3, 3, -3,
+ax_anim 2, 2, 69, 1, -1, 1, -1,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 71, -19, 17, -19, 17,
+ax_anim 2, 0, 71, -18, 18, -18, 18,
+ax_anim 2, 0, 71, -19, 17, -19, 17,
+ax_anim 2, 0, 68, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 4, 0, 72, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 2, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 1, 4, 1, 4,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 1, 4, 1, 4,
+ax_anim 2, 1, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 1, 4, 1, 4,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sGrovyleAnims_4_2:
+ax_anim 2, 0, 74, -1, -1, -1, -1,
+ax_anim 4, 0, 74, -3, -3, -3, -3,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim 2, 2, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 5, 3, 5, 3,
+ax_anim 2, 0, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 5, 3, 5, 3,
+ax_anim 2, 1, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 5, 3, 5, 3,
+ax_anim 4, 0, 74, 2, 2, 2, 2,
+ax_anim_terminator
+sGrovyleAnims_4_3:
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 4, 0, 76, -3, 0, -3, 0,
+ax_anim 2, 0, 77, 1, 0, 1, 0,
+ax_anim 2, 2, 77, 4, 0, 4, 0,
+ax_anim 2, 0, 77, 4, 1, 4, 1,
+ax_anim 2, 0, 77, 4, 0, 4, 0,
+ax_anim 2, 0, 77, 4, 1, 4, 1,
+ax_anim 2, 1, 77, 4, 0, 4, 0,
+ax_anim 2, 0, 77, 4, 1, 4, 1,
+ax_anim 4, 0, 76, 2, 0, 2, 0,
+ax_anim_terminator
+sGrovyleAnims_4_4:
+ax_anim 2, 0, 78, -1, 1, -1, 1,
+ax_anim 4, 0, 78, -3, 3, -3, 3,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 4, -4, 4, -4,
+ax_anim 2, 0, 79, 5, -3, 5, -3,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim 2, 0, 79, 5, -3, 5, -3,
+ax_anim 2, 1, 79, 4, -4, 4, -4,
+ax_anim 2, 0, 79, 5, -3, 5, -3,
+ax_anim 4, 0, 78, 2, -2, 2, -2,
+ax_anim_terminator
+sGrovyleAnims_4_5:
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 4, 0, 80, 0, 3, 0, 3,
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 2, 81, 0, -4, 0, -4,
+ax_anim 2, 0, 81, 1, -4, 1, -4,
+ax_anim 2, 0, 81, 0, -4, 0, -4,
+ax_anim 2, 0, 81, 1, -4, 1, -4,
+ax_anim 2, 1, 81, 0, -4, 0, -4,
+ax_anim 2, 0, 81, 1, -4, 1, -4,
+ax_anim 4, 0, 80, 0, -2, 0, -2,
+ax_anim_terminator
+sGrovyleAnims_4_6:
+ax_anim 2, 0, 82, 1, 1, 1, 1,
+ax_anim 4, 0, 82, 3, 3, 3, 3,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 2, 83, -4, -4, -4, -4,
+ax_anim 2, 0, 83, -5, -3, -5, -3,
+ax_anim 2, 0, 83, -4, -4, -4, -4,
+ax_anim 2, 0, 83, -5, -3, -5, -3,
+ax_anim 2, 1, 83, -4, -4, -4, -4,
+ax_anim 2, 0, 83, -5, -3, -5, -3,
+ax_anim 4, 0, 82, -2, -2, -2, -2,
+ax_anim_terminator
+sGrovyleAnims_4_7:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 4, 0, 84, 3, 0, 3, 0,
+ax_anim 2, 0, 85, -1, 0, -1, 0,
+ax_anim 2, 2, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 85, -4, 1, -4, 1,
+ax_anim 2, 0, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 85, -4, 1, -4, 1,
+ax_anim 2, 1, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 85, -4, 1, -4, 1,
+ax_anim 4, 0, 84, -2, 0, -2, 0,
+ax_anim_terminator
+sGrovyleAnims_4_8:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 4, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 87, -1, 1, -1, 1,
+ax_anim 2, 2, 87, -4, 4, -4, 4,
+ax_anim 2, 0, 87, -5, 3, -5, 3,
+ax_anim 2, 0, 87, -4, 4, -4, 4,
+ax_anim 2, 0, 87, -5, 3, -5, 3,
+ax_anim 2, 1, 87, -4, 4, -4, 4,
+ax_anim 2, 0, 87, -5, 3, -5, 3,
+ax_anim 4, 0, 86, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_5_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_5_2:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_5_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_5_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_5_6:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_5_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_5_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_6_1:
+ax_anim 30, 0, 96, 0, 0, 0, 0,
+ax_anim 35, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sGrovyleAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sGrovyleAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sGrovyleAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sGrovyleAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sGrovyleAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sGrovyleAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sGrovyleAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_8_1:
+ax_anim 18, 0, 106, 0, 0, 0, 0,
+ax_anim 12, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_8_2:
+ax_anim 18, 0, 109, 0, 0, 0, 0,
+ax_anim 12, 0, 111, -1, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_8_3:
+ax_anim 18, 0, 112, 0, 0, 0, 0,
+ax_anim 12, 0, 114, -3, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_8_4:
+ax_anim 18, 0, 115, 0, 0, 0, 0,
+ax_anim 12, 0, 117, -1, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_8_5:
+ax_anim 18, 0, 118, 0, 0, 0, 0,
+ax_anim 12, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_8_6:
+ax_anim 18, 0, 121, 0, 0, 0, 0,
+ax_anim 12, 0, 123, 1, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_8_7:
+ax_anim 18, 0, 124, 0, 0, 0, 0,
+ax_anim 12, 0, 126, 3, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_8_8:
+ax_anim 18, 0, 127, 0, 0, 0, 0,
+ax_anim 12, 0, 129, 1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 7, 4, 7, 4,
+ax_anim 2, 0, 132, 10, 9, 10, 9,
+ax_anim 2, 0, 133, 7, 17, 7, 17,
+ax_anim 3, 0, 134, 0, 21, 0, 21,
+ax_anim 2, 3, 135, -7, 17, -7, 17,
+ax_anim 2, 0, 136, -10, 9, -10, 9,
+ax_anim 1, 0, 137, -7, 4, -7, 4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 131, 17, 3, 17, 3,
+ax_anim 2, 0, 132, 24, 9, 24, 9,
+ax_anim 3, 0, 133, 23, 22, 23, 22,
+ax_anim 2, 3, 134, 11, 21, 11, 21,
+ax_anim 2, 0, 135, 0, 12, 0, 12,
+ax_anim 1, 0, 136, -2, 7, -2, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -4, 3, -4,
+ax_anim 2, 0, 130, 11, -6, 11, -6,
+ax_anim 2, 0, 131, 17, -4, 17, -4,
+ax_anim 3, 0, 132, 20, 1, 20, 1,
+ax_anim 2, 3, 133, 17, 5, 17, 5,
+ax_anim 2, 0, 134, 12, 7, 12, 7,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -2, -6, -2, -6,
+ax_anim 2, 0, 137, 4, -16, 4, -16,
+ax_anim 2, 0, 130, 11, -20, 11, -20,
+ax_anim 3, 0, 131, 19, -20, 19, -20,
+ax_anim 2, 3, 132, 20, -12, 20, -12,
+ax_anim 2, 0, 133, 14, -4, 14, -4,
+ax_anim 1, 0, 134, 7, -1, 7, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -6, -4, -6, -4,
+ax_anim 2, 0, 136, -10, -9, -10, -9,
+ax_anim 2, 0, 137, -8, -16, -8, -16,
+ax_anim 3, 0, 130, -1, -19, -1, -19,
+ax_anim 2, 3, 131, 8, -16, 8, -16,
+ax_anim 2, 0, 132, 10, -9, 10, -9,
+ax_anim 1, 0, 133, 6, -4, 6, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 2, -6, 2, -6,
+ax_anim 2, 0, 131, -4, -16, -4, -16,
+ax_anim 2, 0, 130, -11, -20, -11, -20,
+ax_anim 3, 0, 137, -19, -20, -19, -20,
+ax_anim 2, 3, 136, -20, -12, -20, -12,
+ax_anim 2, 0, 135, -14, -4, -14, -4,
+ax_anim 1, 0, 134, -7, -1, -7, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -4, -3, -4,
+ax_anim 2, 0, 130, -11, -6, -11, -6,
+ax_anim 2, 0, 137, -17, -4, -17, -4,
+ax_anim 3, 0, 136, -20, 1, -20, 1,
+ax_anim 2, 3, 135, -17, 5, -17, 5,
+ax_anim 2, 0, 134, -12, 7, -12, 7,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -17, 3, -17, 3,
+ax_anim 2, 0, 136, -24, 9, -24, 9,
+ax_anim 3, 0, 135, -23, 22, -23, 22,
+ax_anim 2, 3, 134, -11, 21, -11, 21,
+ax_anim 2, 0, 133, 0, 12, 0, 12,
+ax_anim 1, 0, 132, 2, 7, 2, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -23, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 151, 0, -23, 0, 0,
+ax_anim 3, 0, 151, 0, -22, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -23, 0, 0,
+ax_anim 3, 0, 154, 0, -22, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -21, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -21, 0, 0,
+ax_anim 2, 0, 163, 0, -17, 0, 0,
+ax_anim 1, 0, 163, 0, -11, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 166, 0, -22, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -23, 0, 0,
+ax_anim 3, 0, 169, 0, -22, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrovyleAnims_13_1:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_13_2:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_13_3:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_13_4:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_13_5:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_13_6:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_13_7:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleAnims_13_8:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sGrovyleGfx1:
+.incbin "baserom.gba", 0x105F650, 0x200
+sGrovyleSprites1:
+ax_sprite sGrovyleGfx1, 0x200
+ax_sprite_terminator
+sGrovyleGfx2:
+.incbin "baserom.gba", 0x105F860, 0x200
+sGrovyleSprites2:
+ax_sprite sGrovyleGfx2, 0x200
+ax_sprite_terminator
+sGrovyleGfx3:
+.incbin "baserom.gba", 0x105FA70, 0x200
+sGrovyleSprites3:
+ax_sprite sGrovyleGfx3, 0x200
+ax_sprite_terminator
+sGrovyleGfx4:
+.incbin "baserom.gba", 0x105FC80, 0x200
+sGrovyleSprites4:
+ax_sprite sGrovyleGfx4, 0x200
+ax_sprite_terminator
+sGrovyleGfx5:
+.incbin "baserom.gba", 0x105FE90, 0x200
+sGrovyleSprites5:
+ax_sprite sGrovyleGfx5, 0x200
+ax_sprite_terminator
+sGrovyleGfx6:
+.incbin "baserom.gba", 0x10600A0, 0x200
+sGrovyleSprites6:
+ax_sprite sGrovyleGfx6, 0x200
+ax_sprite_terminator
+sGrovyleGfx7:
+.incbin "baserom.gba", 0x10602B0, 0x200
+sGrovyleSprites7:
+ax_sprite sGrovyleGfx7, 0x200
+ax_sprite_terminator
+sGrovyleGfx8:
+.incbin "baserom.gba", 0x10604C0, 0x200
+sGrovyleSprites8:
+ax_sprite sGrovyleGfx8, 0x200
+ax_sprite_terminator
+sGrovyleGfx9:
+.incbin "baserom.gba", 0x10606D0, 0x200
+sGrovyleSprites9:
+ax_sprite sGrovyleGfx9, 0x200
+ax_sprite_terminator
+sGrovyleGfx10:
+.incbin "baserom.gba", 0x10608E0, 0x200
+sGrovyleSprites10:
+ax_sprite sGrovyleGfx10, 0x200
+ax_sprite_terminator
+sGrovyleGfx11:
+.incbin "baserom.gba", 0x1060AF0, 0x200
+sGrovyleSprites11:
+ax_sprite sGrovyleGfx11, 0x200
+ax_sprite_terminator
+sGrovyleGfx12:
+.incbin "baserom.gba", 0x1060D00, 0x200
+sGrovyleSprites12:
+ax_sprite sGrovyleGfx12, 0x200
+ax_sprite_terminator
+sGrovyleGfx13:
+.incbin "baserom.gba", 0x1060F10, 0x200
+sGrovyleSprites13:
+ax_sprite sGrovyleGfx13, 0x200
+ax_sprite_terminator
+sGrovyleGfx14:
+.incbin "baserom.gba", 0x1061120, 0x200
+sGrovyleSprites14:
+ax_sprite sGrovyleGfx14, 0x200
+ax_sprite_terminator
+sGrovyleGfx15:
+.incbin "baserom.gba", 0x1061330, 0x200
+sGrovyleSprites15:
+ax_sprite sGrovyleGfx15, 0x200
+ax_sprite_terminator
+sGrovyleGfx16:
+.incbin "baserom.gba", 0x1061540, 0x100
+sGrovyleSprites16:
+ax_sprite sGrovyleGfx16, 0x100
+ax_sprite_terminator
+sGrovyleGfx17:
+.incbin "baserom.gba", 0x1061650, 0x20
+sGrovyleGfx17_1:
+.incbin "baserom.gba", 0x1061670, 0x20
+sGrovyleSprites17:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx17_1, 0x20
+ax_sprite_terminator
+sGrovyleGfx18:
+.incbin "baserom.gba", 0x10616B8, 0x40
+sGrovyleSprites18:
+ax_sprite sGrovyleGfx18, 0x40
+ax_sprite_terminator
+sGrovyleGfx19:
+.incbin "baserom.gba", 0x1061708, 0x20
+sGrovyleSprites19:
+ax_sprite sGrovyleGfx19, 0x20
+ax_sprite_terminator
+sGrovyleGfx20:
+.incbin "baserom.gba", 0x1061738, 0x20
+sGrovyleSprites20:
+ax_sprite sGrovyleGfx20, 0x20
+ax_sprite_terminator
+sGrovyleGfx21:
+.incbin "baserom.gba", 0x1061768, 0x180
+sGrovyleSprites21:
+ax_sprite sGrovyleGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrovyleGfx22:
+.incbin "baserom.gba", 0x1061900, 0x180
+sGrovyleSprites22:
+ax_sprite sGrovyleGfx22, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrovyleGfx23:
+.incbin "baserom.gba", 0x1061A98, 0x100
+sGrovyleGfx23_1:
+.incbin "baserom.gba", 0x1061B98, 0x60
+sGrovyleSprites23:
+ax_sprite sGrovyleGfx23, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx23_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrovyleGfx24:
+.incbin "baserom.gba", 0x1061C20, 0x40
+sGrovyleSprites24:
+ax_sprite sGrovyleGfx24, 0x40
+ax_sprite_terminator
+sGrovyleGfx25:
+.incbin "baserom.gba", 0x1061C70, 0x100
+sGrovyleSprites25:
+ax_sprite sGrovyleGfx25, 0x100
+ax_sprite_terminator
+sGrovyleGfx26:
+.incbin "baserom.gba", 0x1061D80, 0x20
+sGrovyleSprites26:
+ax_sprite sGrovyleGfx26, 0x20
+ax_sprite_terminator
+sGrovyleGfx27:
+.incbin "baserom.gba", 0x1061DB0, 0x60
+sGrovyleGfx27_1:
+.incbin "baserom.gba", 0x1061E10, 0xC0
+sGrovyleGfx27_2:
+.incbin "baserom.gba", 0x1061ED0, 0x60
+sGrovyleSprites27:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx27_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrovyleGfx28:
+.incbin "baserom.gba", 0x1061F70, 0xE0
+sGrovyleSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx28, 0xe0
+ax_sprite_terminator
+sGrovyleGfx29:
+.incbin "baserom.gba", 0x1062068, 0x20
+sGrovyleGfx29_1:
+.incbin "baserom.gba", 0x1062088, 0x60
+sGrovyleGfx29_2:
+.incbin "baserom.gba", 0x10620E8, 0x60
+sGrovyleGfx29_3:
+.incbin "baserom.gba", 0x1062148, 0x60
+sGrovyleSprites29:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGrovyleGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrovyleGfx30:
+.incbin "baserom.gba", 0x10621F8, 0x60
+sGrovyleGfx30_1:
+.incbin "baserom.gba", 0x1062258, 0x160
+sGrovyleSprites30:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx30_1, 0x160
+ax_sprite_terminator
+sGrovyleGfx31:
+.incbin "baserom.gba", 0x10623E0, 0x20
+sGrovyleGfx31_1:
+.incbin "baserom.gba", 0x1062400, 0x40
+sGrovyleGfx31_2:
+.incbin "baserom.gba", 0x1062440, 0x40
+sGrovyleGfx31_3:
+.incbin "baserom.gba", 0x1062480, 0x40
+sGrovyleSprites31:
+ax_sprite 0, 0x40
+ax_sprite sGrovyleGfx31, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGrovyleGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrovyleGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGrovyleGfx32:
+.incbin "baserom.gba", 0x1062510, 0x1E0
+sGrovyleSprites32:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx32, 0x1e0
+ax_sprite_terminator
+sGrovyleGfx33:
+.incbin "baserom.gba", 0x1062708, 0x160
+sGrovyleGfx33_1:
+.incbin "baserom.gba", 0x1062868, 0x40
+sGrovyleSprites33:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx33, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx33_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrovyleGfx34:
+.incbin "baserom.gba", 0x10628D8, 0x40
+sGrovyleGfx34_1:
+.incbin "baserom.gba", 0x1062918, 0x60
+sGrovyleGfx34_2:
+.incbin "baserom.gba", 0x1062978, 0x40
+sGrovyleGfx34_3:
+.incbin "baserom.gba", 0x10629B8, 0x20
+sGrovyleSprites34:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrovyleGfx34_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sGrovyleGfx35:
+.incbin "baserom.gba", 0x1062A28, 0x180
+sGrovyleSprites35:
+ax_sprite sGrovyleGfx35, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrovyleGfx36:
+.incbin "baserom.gba", 0x1062BC0, 0x60
+sGrovyleGfx36_1:
+.incbin "baserom.gba", 0x1062C20, 0x60
+sGrovyleGfx36_2:
+.incbin "baserom.gba", 0x1062C80, 0x60
+sGrovyleGfx36_3:
+.incbin "baserom.gba", 0x1062CE0, 0x60
+sGrovyleSprites36:
+ax_sprite sGrovyleGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx36_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrovyleGfx37:
+.incbin "baserom.gba", 0x1062D88, 0xA0
+sGrovyleGfx37_1:
+.incbin "baserom.gba", 0x1062E28, 0x20
+sGrovyleSprites37:
+ax_sprite sGrovyleGfx37, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrovyleGfx38:
+.incbin "baserom.gba", 0x1062E70, 0x180
+sGrovyleSprites38:
+ax_sprite sGrovyleGfx38, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrovyleGfx39:
+.incbin "baserom.gba", 0x1063008, 0x60
+sGrovyleGfx39_1:
+.incbin "baserom.gba", 0x1063068, 0x80
+sGrovyleGfx39_2:
+.incbin "baserom.gba", 0x10630E8, 0x60
+sGrovyleGfx39_3:
+.incbin "baserom.gba", 0x1063148, 0x60
+sGrovyleSprites39:
+ax_sprite sGrovyleGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx39_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx39_3, 0x60
+ax_sprite_terminator
+sGrovyleGfx40:
+.incbin "baserom.gba", 0x10631E8, 0x20
+sGrovyleGfx40_1:
+.incbin "baserom.gba", 0x1063208, 0x20
+sGrovyleGfx40_2:
+.incbin "baserom.gba", 0x1063228, 0x80
+sGrovyleSprites40:
+ax_sprite sGrovyleGfx40, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx40_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx40_2, 0x80
+ax_sprite_terminator
+sGrovyleGfx41:
+.incbin "baserom.gba", 0x10632D8, 0x40
+sGrovyleGfx41_1:
+.incbin "baserom.gba", 0x1063318, 0xE0
+sGrovyleGfx41_2:
+.incbin "baserom.gba", 0x10633F8, 0x60
+sGrovyleSprites41:
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrovyleGfx41_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGrovyleGfx41_2, 0x60
+ax_sprite_terminator
+sGrovyleGfx42:
+.incbin "baserom.gba", 0x1063490, 0x200
+sGrovyleSprites42:
+ax_sprite sGrovyleGfx42, 0x200
+ax_sprite_terminator
+sGrovyleGfx43:
+.incbin "baserom.gba", 0x10636A0, 0x200
+sGrovyleSprites43:
+ax_sprite sGrovyleGfx43, 0x200
+ax_sprite_terminator
+sGrovyleGfx44:
+.incbin "baserom.gba", 0x10638B0, 0x200
+sGrovyleSprites44:
+ax_sprite sGrovyleGfx44, 0x200
+ax_sprite_terminator
+sGrovyleGfx45:
+.incbin "baserom.gba", 0x1063AC0, 0x200
+sGrovyleSprites45:
+ax_sprite sGrovyleGfx45, 0x200
+ax_sprite_terminator
+sGrovyleGfx46:
+.incbin "baserom.gba", 0x1063CD0, 0x200
+sGrovyleSprites46:
+ax_sprite sGrovyleGfx46, 0x200
+ax_sprite_terminator
+sGrovyleGfx47:
+.incbin "baserom.gba", 0x1063EE0, 0x200
+sGrovyleSprites47:
+ax_sprite sGrovyleGfx47, 0x200
+ax_sprite_terminator
+sGrovyleGfx48:
+.incbin "baserom.gba", 0x10640F0, 0x200
+sGrovyleSprites48:
+ax_sprite sGrovyleGfx48, 0x200
+ax_sprite_terminator
+sAxPosesGrovyle:
+.4byte sGrovylePose1
+.4byte sGrovylePose2
+.4byte sGrovylePose3
+.4byte sGrovylePose4
+.4byte sGrovylePose5
+.4byte sGrovylePose6
+.4byte sGrovylePose7
+.4byte sGrovylePose8
+.4byte sGrovylePose9
+.4byte sGrovylePose10
+.4byte sGrovylePose11
+.4byte sGrovylePose12
+.4byte sGrovylePose13
+.4byte sGrovylePose14
+.4byte sGrovylePose15
+.4byte sGrovylePose16
+.4byte sGrovylePose17
+.4byte sGrovylePose18
+.4byte sGrovylePose19
+.4byte sGrovylePose20
+.4byte sGrovylePose21
+.4byte sGrovylePose22
+.4byte sGrovylePose23
+.4byte sGrovylePose24
+.4byte sGrovylePose25
+.4byte sGrovylePose26
+.4byte sGrovylePose27
+.4byte sGrovylePose28
+.4byte sGrovylePose29
+.4byte sGrovylePose30
+.4byte sGrovylePose31
+.4byte sGrovylePose32
+.4byte sGrovylePose33
+.4byte sGrovylePose34
+.4byte sGrovylePose35
+.4byte sGrovylePose36
+.4byte sGrovylePose37
+.4byte sGrovylePose38
+.4byte sGrovylePose39
+.4byte sGrovylePose40
+.4byte sGrovylePose41
+.4byte sGrovylePose42
+.4byte sGrovylePose43
+.4byte sGrovylePose44
+.4byte sGrovylePose45
+.4byte sGrovylePose46
+.4byte sGrovylePose47
+.4byte sGrovylePose48
+.4byte sGrovylePose49
+.4byte sGrovylePose50
+.4byte sGrovylePose51
+.4byte sGrovylePose52
+.4byte sGrovylePose53
+.4byte sGrovylePose54
+.4byte sGrovylePose55
+.4byte sGrovylePose56
+.4byte sGrovylePose57
+.4byte sGrovylePose58
+.4byte sGrovylePose59
+.4byte sGrovylePose60
+.4byte sGrovylePose61
+.4byte sGrovylePose62
+.4byte sGrovylePose63
+.4byte sGrovylePose64
+.4byte sGrovylePose65
+.4byte sGrovylePose66
+.4byte sGrovylePose67
+.4byte sGrovylePose68
+.4byte sGrovylePose69
+.4byte sGrovylePose70
+.4byte sGrovylePose71
+.4byte sGrovylePose72
+.4byte sGrovylePose73
+.4byte sGrovylePose74
+.4byte sGrovylePose75
+.4byte sGrovylePose76
+.4byte sGrovylePose77
+.4byte sGrovylePose78
+.4byte sGrovylePose79
+.4byte sGrovylePose80
+.4byte sGrovylePose81
+.4byte sGrovylePose82
+.4byte sGrovylePose83
+.4byte sGrovylePose84
+.4byte sGrovylePose85
+.4byte sGrovylePose86
+.4byte sGrovylePose87
+.4byte sGrovylePose88
+.4byte sGrovylePose89
+.4byte sGrovylePose90
+.4byte sGrovylePose91
+.4byte sGrovylePose92
+.4byte sGrovylePose93
+.4byte sGrovylePose94
+.4byte sGrovylePose95
+.4byte sGrovylePose96
+.4byte sGrovylePose97
+.4byte sGrovylePose98
+.4byte sGrovylePose99
+.4byte sGrovylePose100
+.4byte sGrovylePose101
+.4byte sGrovylePose102
+.4byte sGrovylePose103
+.4byte sGrovylePose104
+.4byte sGrovylePose105
+.4byte sGrovylePose106
+.4byte sGrovylePose107
+.4byte sGrovylePose108
+.4byte sGrovylePose109
+.4byte sGrovylePose110
+.4byte sGrovylePose111
+.4byte sGrovylePose112
+.4byte sGrovylePose113
+.4byte sGrovylePose114
+.4byte sGrovylePose115
+.4byte sGrovylePose116
+.4byte sGrovylePose117
+.4byte sGrovylePose118
+.4byte sGrovylePose119
+.4byte sGrovylePose120
+.4byte sGrovylePose121
+.4byte sGrovylePose122
+.4byte sGrovylePose123
+.4byte sGrovylePose124
+.4byte sGrovylePose125
+.4byte sGrovylePose126
+.4byte sGrovylePose127
+.4byte sGrovylePose128
+.4byte sGrovylePose129
+.4byte sGrovylePose130
+.4byte sGrovylePose131
+.4byte sGrovylePose132
+.4byte sGrovylePose133
+.4byte sGrovylePose134
+.4byte sGrovylePose135
+.4byte sGrovylePose136
+.4byte sGrovylePose137
+.4byte sGrovylePose138
+.4byte sGrovylePose139
+.4byte sGrovylePose140
+.4byte sGrovylePose141
+.4byte sGrovylePose142
+.4byte sGrovylePose143
+.4byte sGrovylePose144
+.4byte sGrovylePose145
+.4byte sGrovylePose146
+.4byte sGrovylePose147
+.4byte sGrovylePose148
+.4byte sGrovylePose149
+.4byte sGrovylePose150
+.4byte sGrovylePose151
+.4byte sGrovylePose152
+.4byte sGrovylePose153
+.4byte sGrovylePose154
+.4byte sGrovylePose155
+.4byte sGrovylePose156
+.4byte sGrovylePose157
+.4byte sGrovylePose158
+.4byte sGrovylePose159
+.4byte sGrovylePose160
+.4byte sGrovylePose161
+.4byte sGrovylePose162
+.4byte sGrovylePose163
+.4byte sGrovylePose164
+.4byte sGrovylePose165
+.4byte sGrovylePose166
+.4byte sGrovylePose167
+.4byte sGrovylePose168
+.4byte sGrovylePose169
+.4byte sGrovylePose170
+.4byte sGrovylePose171
+.4byte sGrovylePose172
+.4byte sGrovylePose173
+.4byte sGrovylePose174
+.4byte sGrovylePose175
+.4byte sGrovylePose176
+.4byte sGrovylePose177
+.4byte sGrovylePose178
+.4byte sGrovylePose179
+.4byte sGrovylePose180
+.4byte sGrovylePose181
+.4byte sGrovylePose182
+.4byte sGrovylePose183
+.4byte sGrovylePose184
+.4byte sGrovylePose185
+.4byte sGrovylePose186
+.4byte sGrovylePose187
+sAxPositionsGrovyle:
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	  -8,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte    9,  -11, 	  11,  -12, 	   2,   -9, 	   3,  -11
+.2byte    8,   -8, 	  10,   -5, 	   0,   -4, 	   2,   -8
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte   12,  -13, 	  12,  -11, 	   8,   -9, 	   4,  -12
+.2byte   11,   -9, 	   6,   -6, 	   7,   -4, 	   3,   -8
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte    9,  -17, 	   2,  -17, 	  11,  -13, 	   3,  -13
+.2byte    9,  -13, 	   2,  -11, 	   9,   -6, 	   3,   -9
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte   -1,  -17, 	   7,  -15, 	  -8,  -15, 	  -1,  -12
+.2byte   -1,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte  -10,  -17, 	  -3,  -17, 	 -12,  -13, 	  -4,  -13
+.2byte  -10,  -13, 	  -3,  -11, 	 -10,   -6, 	  -4,   -9
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte  -13,  -13, 	 -13,  -11, 	  -9,   -9, 	  -5,  -12
+.2byte  -12,   -9, 	  -7,   -6, 	  -8,   -4, 	  -4,   -8
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte  -10,  -11, 	 -12,  -12, 	  -3,   -9, 	  -4,  -11
+.2byte   -9,   -8, 	 -11,   -5, 	  -1,   -4, 	  -3,   -8
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -1,   -5, 	 -11,  -13, 	  10,  -13, 	  -1,   -6
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte    8,   -6, 	  12,  -13, 	  -6,   -9, 	   1,   -7
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte   14,   -7, 	   6,  -12, 	   5,   -8, 	   4,   -8
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte    8,  -11, 	  -4,  -11, 	  13,  -10, 	   1,   -8
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	  10,  -13, 	 -11,  -12, 	  -1,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte   -9,  -11, 	   3,  -11, 	 -14,  -10, 	  -2,   -8
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte  -15,   -7, 	  -7,  -12, 	  -6,   -8, 	  -5,   -8
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte   -9,   -6, 	 -13,  -13, 	   5,   -9, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -1,  -10, 	  -4,   -7, 	  10,  -21, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,  -10, 	   2,    3, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,  -10, 	   2,    3, 	  -1,   -6
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte    3,  -12, 	   4,   -5, 	  -9,  -18, 	  -1,  -11
+.2byte    8,   -6, 	   4,  -10, 	   8,    2, 	   2,   -6
+.2byte    8,   -6, 	   4,  -10, 	   8,    2, 	   2,   -6
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte    6,  -14, 	   5,   -8, 	  -5,  -19, 	  -1,  -12
+.2byte   11,   -8, 	   0,   -7, 	  12,    1, 	   2,   -7
+.2byte   11,   -8, 	   0,   -7, 	  12,    1, 	   2,   -7
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte    6,  -17, 	   5,  -10, 	   3,  -17, 	   0,  -11
+.2byte   11,  -11, 	   0,   -8, 	  15,   -3, 	   3,   -7
+.2byte   11,  -11, 	   0,   -8, 	  15,   -3, 	   3,   -7
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte   -1,  -19, 	   2,  -13, 	 -11,  -20, 	  -1,  -13
+.2byte   -1,  -13, 	   7,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -1,  -13, 	   7,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte   -7,  -17, 	  -6,  -10, 	  -4,  -17, 	  -1,  -11
+.2byte  -12,  -11, 	  -1,   -8, 	 -16,   -3, 	  -4,   -7
+.2byte  -12,  -11, 	  -1,   -8, 	 -16,   -3, 	  -4,   -7
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte   -7,  -14, 	  -6,   -8, 	   4,  -19, 	   0,  -12
+.2byte  -12,   -8, 	  -1,   -7, 	 -13,    1, 	  -3,   -7
+.2byte  -12,   -8, 	  -1,   -7, 	 -13,    1, 	  -3,   -7
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte   -4,  -12, 	  -5,   -5, 	   8,  -18, 	   0,  -11
+.2byte   -9,   -6, 	  -5,  -10, 	  -9,    2, 	  -3,   -6
+.2byte   -9,   -6, 	  -5,  -10, 	  -9,    2, 	  -3,   -6
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -1,   -5, 	 -11,  -13, 	  10,  -13, 	  -1,   -6
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte    8,   -6, 	  12,  -13, 	  -6,   -9, 	   1,   -7
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte   14,   -7, 	   6,  -12, 	   5,   -8, 	   4,   -8
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte    8,  -11, 	  -4,  -11, 	  13,  -10, 	   1,   -8
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	  10,  -13, 	 -11,  -12, 	  -1,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte   -9,  -11, 	   3,  -11, 	 -14,  -10, 	  -2,   -8
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte  -15,   -7, 	  -7,  -12, 	  -6,   -8, 	  -5,   -8
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte   -9,   -6, 	 -13,  -13, 	   5,   -9, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte   -4,   -8, 	  -5,   -3, 	   5,    1, 	   0,   -7
+.2byte   -4,   -7, 	  -5,   -3, 	   5,    1, 	   0,   -7
+.2byte    0,   -7, 	  -9,  -11, 	  10,  -11, 	   0,   -6
+.2byte    6,   -6, 	   9,  -11, 	  -2,   -3, 	   0,   -6
+.2byte    7,   -7, 	   5,  -10, 	   0,   -8, 	  -2,   -7
+.2byte    5,  -11, 	  -4,  -13, 	   7,   -9, 	  -2,   -7
+.2byte   -1,  -12, 	   9,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -6,  -11, 	   3,  -13, 	  -8,   -9, 	   1,   -7
+.2byte   -8,   -7, 	  -6,  -10, 	  -1,   -8, 	   1,   -7
+.2byte   -7,   -6, 	 -10,  -11, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	  -8,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte    9,  -11, 	  11,  -12, 	   2,   -9, 	   3,  -11
+.2byte    8,   -8, 	  10,   -5, 	   0,   -4, 	   2,   -8
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte   12,  -13, 	  12,  -11, 	   8,   -9, 	   4,  -12
+.2byte   11,   -9, 	   6,   -6, 	   7,   -4, 	   3,   -8
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte    9,  -17, 	   2,  -17, 	  11,  -13, 	   3,  -13
+.2byte    9,  -13, 	   2,  -11, 	   9,   -6, 	   3,   -9
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte   -1,  -17, 	   7,  -15, 	  -8,  -15, 	  -1,  -12
+.2byte   -1,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte  -10,  -17, 	  -3,  -17, 	 -12,  -13, 	  -4,  -13
+.2byte  -10,  -13, 	  -3,  -11, 	 -10,   -6, 	  -4,   -9
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte  -13,  -13, 	 -13,  -11, 	  -9,   -9, 	  -5,  -12
+.2byte  -12,   -9, 	  -7,   -6, 	  -8,   -4, 	  -4,   -8
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte  -10,  -11, 	 -12,  -12, 	  -3,   -9, 	  -4,  -11
+.2byte   -9,   -8, 	 -11,   -5, 	  -1,   -4, 	  -3,   -8
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte   -1,   -5, 	 -11,  -13, 	  10,  -13, 	  -1,   -6
+.2byte    8,   -6, 	  12,  -13, 	  -6,   -9, 	   1,   -7
+.2byte   14,   -7, 	   6,  -12, 	   5,   -8, 	   4,   -8
+.2byte    8,  -11, 	  -4,  -11, 	  13,  -10, 	   1,   -8
+.2byte   -1,  -12, 	  10,  -13, 	 -11,  -12, 	  -1,   -9
+.2byte   -9,  -11, 	   3,  -11, 	 -14,  -10, 	  -2,   -8
+.2byte  -15,   -7, 	  -7,  -12, 	  -6,   -8, 	  -5,   -8
+.2byte   -9,   -6, 	 -13,  -13, 	   5,   -9, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	  -8,  -13, 	   7,  -13, 	  -1,  -10
+.2byte   -1,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+.2byte    9,  -11, 	  11,  -12, 	   2,   -9, 	   3,  -11
+.2byte    8,   -8, 	  10,   -5, 	   0,   -4, 	   2,   -8
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte   12,  -13, 	  12,  -11, 	   8,   -9, 	   4,  -12
+.2byte   11,   -9, 	   6,   -6, 	   7,   -4, 	   3,   -8
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte    9,  -17, 	   2,  -17, 	  11,  -13, 	   3,  -13
+.2byte    9,  -13, 	   2,  -11, 	   9,   -6, 	   3,   -9
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte   -1,  -17, 	   7,  -15, 	  -8,  -15, 	  -1,  -12
+.2byte   -1,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte  -10,  -17, 	  -3,  -17, 	 -12,  -13, 	  -4,  -13
+.2byte  -10,  -13, 	  -3,  -11, 	 -10,   -6, 	  -4,   -9
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte  -13,  -13, 	 -13,  -11, 	  -9,   -9, 	  -5,  -12
+.2byte  -12,   -9, 	  -7,   -6, 	  -8,   -4, 	  -4,   -8
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte  -10,  -11, 	 -12,  -12, 	  -3,   -9, 	  -4,  -11
+.2byte   -9,   -8, 	 -11,   -5, 	  -1,   -4, 	  -3,   -8
+.2byte   -1,   -5, 	 -11,  -13, 	  10,  -13, 	  -1,   -6
+.2byte   -9,   -6, 	 -13,  -13, 	   5,   -9, 	  -2,   -7
+.2byte  -15,   -7, 	  -7,  -12, 	  -6,   -8, 	  -5,   -8
+.2byte   -9,  -11, 	   3,  -11, 	 -14,  -10, 	  -2,   -8
+.2byte   -1,  -12, 	  10,  -13, 	 -11,  -12, 	  -1,   -9
+.2byte    8,  -11, 	  -4,  -11, 	  13,  -10, 	   1,   -8
+.2byte   14,   -7, 	   6,  -12, 	   5,   -8, 	   4,   -8
+.2byte    8,   -6, 	  12,  -13, 	  -6,   -9, 	   1,   -7
+.2byte   -9,   -6, 	 -13,  -13, 	   5,   -9, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -9, 	   7,   -9, 	  -1,   -7
+.2byte   -8,   -9, 	 -10,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte  -11,  -11, 	 -10,   -9, 	  -7,   -7, 	  -4,   -9
+.2byte   -9,  -14, 	  -2,  -14, 	 -10,   -9, 	  -3,  -10
+.2byte   -1,  -15, 	   6,  -12, 	  -7,  -12, 	  -1,  -10
+.2byte    8,  -14, 	   1,  -14, 	   9,   -9, 	   2,  -10
+.2byte   10,  -11, 	   9,   -9, 	   6,   -7, 	   3,   -9
+.2byte    7,   -9, 	   9,  -10, 	   0,   -7, 	   1,   -9
+sGrovyleAnimTable1:
+.4byte sGrovyleAnims_1_1
+.4byte sGrovyleAnims_1_2
+.4byte sGrovyleAnims_1_3
+.4byte sGrovyleAnims_1_4
+.4byte sGrovyleAnims_1_5
+.4byte sGrovyleAnims_1_6
+.4byte sGrovyleAnims_1_7
+.4byte sGrovyleAnims_1_8
+sGrovyleAnimTable2:
+.4byte sGrovyleAnims_2_1
+.4byte sGrovyleAnims_2_2
+.4byte sGrovyleAnims_2_3
+.4byte sGrovyleAnims_2_4
+.4byte sGrovyleAnims_2_5
+.4byte sGrovyleAnims_2_6
+.4byte sGrovyleAnims_2_7
+.4byte sGrovyleAnims_2_8
+sGrovyleAnimTable3:
+.4byte sGrovyleAnims_3_1
+.4byte sGrovyleAnims_3_2
+.4byte sGrovyleAnims_3_3
+.4byte sGrovyleAnims_3_4
+.4byte sGrovyleAnims_3_5
+.4byte sGrovyleAnims_3_6
+.4byte sGrovyleAnims_3_7
+.4byte sGrovyleAnims_3_8
+sGrovyleAnimTable4:
+.4byte sGrovyleAnims_4_1
+.4byte sGrovyleAnims_4_2
+.4byte sGrovyleAnims_4_3
+.4byte sGrovyleAnims_4_4
+.4byte sGrovyleAnims_4_5
+.4byte sGrovyleAnims_4_6
+.4byte sGrovyleAnims_4_7
+.4byte sGrovyleAnims_4_8
+sGrovyleAnimTable5:
+.4byte sGrovyleAnims_5_1
+.4byte sGrovyleAnims_5_2
+.4byte sGrovyleAnims_5_3
+.4byte sGrovyleAnims_5_4
+.4byte sGrovyleAnims_5_5
+.4byte sGrovyleAnims_5_6
+.4byte sGrovyleAnims_5_7
+.4byte sGrovyleAnims_5_8
+sGrovyleAnimTable6:
+.4byte sGrovyleAnims_6_1
+.4byte sGrovyleAnims_6_1
+.4byte sGrovyleAnims_6_1
+.4byte sGrovyleAnims_6_1
+.4byte sGrovyleAnims_6_1
+.4byte sGrovyleAnims_6_1
+.4byte sGrovyleAnims_6_1
+.4byte sGrovyleAnims_6_1
+sGrovyleAnimTable7:
+.4byte sGrovyleAnims_7_1
+.4byte sGrovyleAnims_7_2
+.4byte sGrovyleAnims_7_3
+.4byte sGrovyleAnims_7_4
+.4byte sGrovyleAnims_7_5
+.4byte sGrovyleAnims_7_6
+.4byte sGrovyleAnims_7_7
+.4byte sGrovyleAnims_7_8
+sGrovyleAnimTable8:
+.4byte sGrovyleAnims_8_1
+.4byte sGrovyleAnims_8_2
+.4byte sGrovyleAnims_8_3
+.4byte sGrovyleAnims_8_4
+.4byte sGrovyleAnims_8_5
+.4byte sGrovyleAnims_8_6
+.4byte sGrovyleAnims_8_7
+.4byte sGrovyleAnims_8_8
+sGrovyleAnimTable9:
+.4byte sGrovyleAnims_9_1
+.4byte sGrovyleAnims_9_2
+.4byte sGrovyleAnims_9_3
+.4byte sGrovyleAnims_9_4
+.4byte sGrovyleAnims_9_5
+.4byte sGrovyleAnims_9_6
+.4byte sGrovyleAnims_9_7
+.4byte sGrovyleAnims_9_8
+sGrovyleAnimTable10:
+.4byte sGrovyleAnims_10_1
+.4byte sGrovyleAnims_10_2
+.4byte sGrovyleAnims_10_3
+.4byte sGrovyleAnims_10_4
+.4byte sGrovyleAnims_10_5
+.4byte sGrovyleAnims_10_6
+.4byte sGrovyleAnims_10_7
+.4byte sGrovyleAnims_10_8
+sGrovyleAnimTable11:
+.4byte sGrovyleAnims_11_1
+.4byte sGrovyleAnims_11_2
+.4byte sGrovyleAnims_11_3
+.4byte sGrovyleAnims_11_4
+.4byte sGrovyleAnims_11_5
+.4byte sGrovyleAnims_11_6
+.4byte sGrovyleAnims_11_7
+.4byte sGrovyleAnims_11_8
+sGrovyleAnimTable12:
+.4byte sGrovyleAnims_12_1
+.4byte sGrovyleAnims_12_2
+.4byte sGrovyleAnims_12_3
+.4byte sGrovyleAnims_12_4
+.4byte sGrovyleAnims_12_5
+.4byte sGrovyleAnims_12_6
+.4byte sGrovyleAnims_12_7
+.4byte sGrovyleAnims_12_8
+sGrovyleAnimTable13:
+.4byte sGrovyleAnims_13_1
+.4byte sGrovyleAnims_13_2
+.4byte sGrovyleAnims_13_3
+.4byte sGrovyleAnims_13_4
+.4byte sGrovyleAnims_13_5
+.4byte sGrovyleAnims_13_6
+.4byte sGrovyleAnims_13_7
+.4byte sGrovyleAnims_13_8
+sAxAnimationsGrovyle:
+.4byte sGrovyleAnimTable1
+.4byte sGrovyleAnimTable2
+.4byte sGrovyleAnimTable3
+.4byte sGrovyleAnimTable4
+.4byte sGrovyleAnimTable5
+.4byte sGrovyleAnimTable6
+.4byte sGrovyleAnimTable7
+.4byte sGrovyleAnimTable8
+.4byte sGrovyleAnimTable9
+.4byte sGrovyleAnimTable10
+.4byte sGrovyleAnimTable11
+.4byte sGrovyleAnimTable12
+.4byte sGrovyleAnimTable13
+sAxSpritesGrovyle:
+.4byte sGrovyleSprites1
+.4byte sGrovyleSprites2
+.4byte sGrovyleSprites3
+.4byte sGrovyleSprites4
+.4byte sGrovyleSprites5
+.4byte sGrovyleSprites6
+.4byte sGrovyleSprites7
+.4byte sGrovyleSprites8
+.4byte sGrovyleSprites9
+.4byte sGrovyleSprites10
+.4byte sGrovyleSprites11
+.4byte sGrovyleSprites12
+.4byte sGrovyleSprites13
+.4byte sGrovyleSprites14
+.4byte sGrovyleSprites15
+.4byte sGrovyleSprites16
+.4byte sGrovyleSprites17
+.4byte sGrovyleSprites18
+.4byte sGrovyleSprites19
+.4byte sGrovyleSprites20
+.4byte sGrovyleSprites21
+.4byte sGrovyleSprites22
+.4byte sGrovyleSprites23
+.4byte sGrovyleSprites24
+.4byte sGrovyleSprites25
+.4byte sGrovyleSprites26
+.4byte sGrovyleSprites27
+.4byte sGrovyleSprites28
+.4byte sGrovyleSprites29
+.4byte sGrovyleSprites30
+.4byte sGrovyleSprites31
+.4byte sGrovyleSprites32
+.4byte sGrovyleSprites33
+.4byte sGrovyleSprites34
+.4byte sGrovyleSprites35
+.4byte sGrovyleSprites36
+.4byte sGrovyleSprites37
+.4byte sGrovyleSprites38
+.4byte sGrovyleSprites39
+.4byte sGrovyleSprites40
+.4byte sGrovyleSprites41
+.4byte sGrovyleSprites42
+.4byte sGrovyleSprites43
+.4byte sGrovyleSprites44
+.4byte sGrovyleSprites45
+.4byte sGrovyleSprites46
+.4byte sGrovyleSprites47
+.4byte sGrovyleSprites48
+sAxMainGrovyle:
+ax_main sAxPosesGrovyle, sAxAnimationsGrovyle, 13, sAxSpritesGrovyle, sAxPositionsGrovyle

--- a/data/ax/growlithe.inc
+++ b/data/ax/growlithe.inc
@@ -1,0 +1,2840 @@
+.global gAxGrowlithe
+gAxGrowlithe:
+ax_siro sAxMainGrowlithe
+sGrowlithePose1:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose2:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose3:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose4:
+ax_pose 3, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose5:
+ax_pose 4, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose6:
+ax_pose 5, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose7:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose8:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose9:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose10:
+ax_pose 9, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose11:
+ax_pose 10, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose12:
+ax_pose 11, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose13:
+ax_pose 12, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose14:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose15:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose16:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose17:
+ax_pose 10, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose18:
+ax_pose 11, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose22:
+ax_pose 3, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose23:
+ax_pose 4, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose24:
+ax_pose 5, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose25:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose26:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose27:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose28:
+ax_pose 15, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose29:
+ax_pose 16, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose30:
+ax_pose 3, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose31:
+ax_pose 4, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose32:
+ax_pose 5, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose33:
+ax_pose 17, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose34:
+ax_pose 18, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose35:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose36:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose37:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose38:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose39:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose40:
+ax_pose 9, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose41:
+ax_pose 10, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose42:
+ax_pose 11, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose43:
+ax_pose 21, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose44:
+ax_pose 22, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose45:
+ax_pose 12, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose46:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose47:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose48:
+ax_pose 23, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose49:
+ax_pose 24, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose50:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose51:
+ax_pose 10, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose52:
+ax_pose 11, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose53:
+ax_pose 21, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose54:
+ax_pose 22, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose55:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose56:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose57:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose58:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose59:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose60:
+ax_pose 3, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose61:
+ax_pose 4, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose62:
+ax_pose 5, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose63:
+ax_pose 17, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose64:
+ax_pose 18, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose65:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose66:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose67:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose68:
+ax_pose 15, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose69:
+ax_pose 16, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose70:
+ax_pose 3, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose71:
+ax_pose 4, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose72:
+ax_pose 5, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose73:
+ax_pose 17, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose74:
+ax_pose 18, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose75:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose76:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose77:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose78:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose79:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose80:
+ax_pose 9, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose81:
+ax_pose 10, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose82:
+ax_pose 11, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose83:
+ax_pose 21, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose84:
+ax_pose 22, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose85:
+ax_pose 12, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose86:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose87:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose88:
+ax_pose 23, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose89:
+ax_pose 24, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose90:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose91:
+ax_pose 10, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose92:
+ax_pose 11, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose93:
+ax_pose 21, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose94:
+ax_pose 22, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose95:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose96:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose97:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose98:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose99:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose100:
+ax_pose 3, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose101:
+ax_pose 4, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose102:
+ax_pose 5, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose103:
+ax_pose 17, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose104:
+ax_pose 18, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose105:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose106:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose107:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose108:
+ax_pose 25, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose109:
+ax_pose 3, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose110:
+ax_pose 4, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose111:
+ax_pose 5, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose112:
+ax_pose 26, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sGrowlithePose113:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose114:
+ax_pose 7, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose115:
+ax_pose 8, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose116:
+ax_pose 27, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose117:
+ax_pose 9, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose118:
+ax_pose 10, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose119:
+ax_pose 11, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose120:
+ax_pose 28, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose121:
+ax_pose 12, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose122:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose123:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose124:
+ax_pose 29, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose125:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose126:
+ax_pose 10, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose127:
+ax_pose 11, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose128:
+ax_pose 28, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose129:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose130:
+ax_pose 7, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose131:
+ax_pose 8, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose132:
+ax_pose 27, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose133:
+ax_pose 3, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose134:
+ax_pose 4, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose135:
+ax_pose 5, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose136:
+ax_pose 26, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGrowlithePose137:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose138:
+ax_pose 15, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose139:
+ax_pose 30, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose140:
+ax_pose 3, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose141:
+ax_pose 17, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sGrowlithePose142:
+ax_pose 31, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose143:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose144:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose145:
+ax_pose 32, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose146:
+ax_pose 9, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose147:
+ax_pose 21, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose148:
+ax_pose 33, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose149:
+ax_pose 12, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose150:
+ax_pose 23, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose151:
+ax_pose 34, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose152:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose153:
+ax_pose 21, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose154:
+ax_pose 33, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose155:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose156:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose157:
+ax_pose 32, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose158:
+ax_pose 3, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose159:
+ax_pose 17, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGrowlithePose160:
+ax_pose 31, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose161:
+ax_pose 35, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose162:
+ax_pose 36, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose163:
+ax_pose 37, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose164:
+ax_pose 38, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose165:
+ax_pose 39, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sGrowlithePose166:
+ax_pose 40, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose167:
+ax_pose 41, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose168:
+ax_pose 40, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose169:
+ax_pose 39, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGrowlithePose170:
+ax_pose 38, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose171:
+ax_pose 30, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose172:
+ax_pose 31, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose173:
+ax_pose 32, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose174:
+ax_pose 33, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose175:
+ax_pose 34, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose176:
+ax_pose 33, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose177:
+ax_pose 32, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose178:
+ax_pose 31, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose179:
+ax_pose 16, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose180:
+ax_pose 18, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose181:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose182:
+ax_pose 22, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sGrowlithePose183:
+ax_pose 24, 0x01e7, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose184:
+ax_pose 22, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sGrowlithePose185:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose186:
+ax_pose 18, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose187:
+ax_pose 25, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose188:
+ax_pose 26, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sGrowlithePose189:
+ax_pose 27, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose190:
+ax_pose 28, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose191:
+ax_pose 29, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose192:
+ax_pose 28, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose193:
+ax_pose 27, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose194:
+ax_pose 26, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sGrowlithePose195:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose196:
+ax_pose 15, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose197:
+ax_pose 16, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose198:
+ax_pose 3, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose199:
+ax_pose 17, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose200:
+ax_pose 18, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose201:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose202:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose203:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose204:
+ax_pose 9, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose205:
+ax_pose 21, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose206:
+ax_pose 22, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose207:
+ax_pose 12, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose208:
+ax_pose 23, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose209:
+ax_pose 24, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sGrowlithePose210:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose211:
+ax_pose 21, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose212:
+ax_pose 22, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose213:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose214:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose215:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose216:
+ax_pose 3, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose217:
+ax_pose 17, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose218:
+ax_pose 18, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose219:
+ax_pose 30, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose220:
+ax_pose 31, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose221:
+ax_pose 32, 0x01ea, 0x80ef, 0x0c00
+ax_pose_terminator
+sGrowlithePose222:
+ax_pose 33, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sGrowlithePose223:
+ax_pose 34, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose224:
+ax_pose 33, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sGrowlithePose225:
+ax_pose 32, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sGrowlithePose226:
+ax_pose 31, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sGrowlithePose227:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose228:
+ax_pose 3, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sGrowlithePose229:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose230:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sGrowlithePose231:
+ax_pose 12, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sGrowlithePose232:
+ax_pose 9, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sGrowlithePose233:
+ax_pose 6, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sGrowlithePose234:
+ax_pose 3, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+.align 2
+sGrowlitheAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_2_1:
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, -6, 0, -6,
+ax_anim 6, 0, 24, 0, -8, 0, -8,
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 2, 2, 28, 0, 7, 0, 7,
+ax_anim 2, 0, 27, 0, 9, 0, 9,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, -1, 20, -1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, -1, 20, -1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 0, 11, 0, 11,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sGrowlitheAnims_2_2:
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim 6, 0, 29, -8, -8, -8, -8,
+ax_anim 2, 0, 32, -2, -2, -2, -2,
+ax_anim 2, 2, 33, 5, 5, 5, 5,
+ax_anim 2, 0, 32, 11, 11, 11, 11,
+ax_anim 2, 0, 33, 20, 18, 20, 18,
+ax_anim 2, 1, 33, 19, 19, 19, 19,
+ax_anim 2, 0, 33, 20, 18, 20, 18,
+ax_anim 2, 0, 33, 19, 19, 19, 19,
+ax_anim 2, 0, 33, 20, 18, 20, 18,
+ax_anim 2, 0, 30, 11, 11, 11, 11,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sGrowlitheAnims_2_3:
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 2, 0, 36, -6, 0, -6, 0,
+ax_anim 6, 0, 34, -8, 0, -8, 0,
+ax_anim 2, 0, 37, -2, 0, -2, 0,
+ax_anim 2, 2, 38, 5, 0, 5, 0,
+ax_anim 2, 0, 37, 11, 0, 11, 0,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 1, 38, 16, 1, 16, 1,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 0, 38, 16, 1, 16, 1,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sGrowlitheAnims_2_4:
+ax_anim 2, 0, 40, -3, 3, -3, 3,
+ax_anim 2, 0, 41, -6, 6, -6, 6,
+ax_anim 6, 0, 39, -8, 8, -8, 8,
+ax_anim 2, 0, 42, -2, 2, -2, 2,
+ax_anim 2, 2, 43, 4, -7, 4, -7,
+ax_anim 2, 0, 42, 11, -14, 11, -14,
+ax_anim 2, 0, 43, 15, -21, 15, -21,
+ax_anim 2, 1, 43, 14, -22, 14, -22,
+ax_anim 2, 0, 43, 15, -21, 15, -21,
+ax_anim 2, 0, 43, 14, -22, 14, -22,
+ax_anim 2, 0, 43, 15, -21, 15, -21,
+ax_anim 2, 0, 40, 9, -13, 9, -13,
+ax_anim 2, 0, 39, 3, -5, 3, -5,
+ax_anim_terminator
+sGrowlitheAnims_2_5:
+ax_anim 2, 0, 45, 0, 3, 0, 3,
+ax_anim 2, 0, 46, 0, 6, 0, 6,
+ax_anim 6, 0, 44, 0, 8, 0, 8,
+ax_anim 2, 0, 47, 0, 2, 0, 2,
+ax_anim 2, 2, 48, 0, -7, 0, -7,
+ax_anim 2, 0, 47, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 1, 48, -1, -20, -1, -20,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 48, -1, -20, -1, -20,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 45, 0, -11, 0, -11,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sGrowlitheAnims_2_6:
+ax_anim 2, 0, 50, 3, 3, 3, 3,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim 6, 0, 49, 8, 8, 8, 8,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim 2, 2, 53, -4, -7, -4, -7,
+ax_anim 2, 0, 52, -11, -14, -11, -14,
+ax_anim 2, 0, 53, -15, -21, -15, -21,
+ax_anim 2, 1, 53, -14, -22, -14, -22,
+ax_anim 2, 0, 53, -15, -21, -15, -21,
+ax_anim 2, 0, 53, -14, -22, -14, -22,
+ax_anim 2, 0, 53, -15, -21, -15, -21,
+ax_anim 2, 0, 50, -9, -13, -9, -13,
+ax_anim 2, 0, 49, -3, -5, -3, -5,
+ax_anim_terminator
+sGrowlitheAnims_2_7:
+ax_anim 2, 0, 55, 3, 0, 3, 0,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim 6, 0, 54, 8, 0, 8, 0,
+ax_anim 2, 0, 57, 2, 0, 2, 0,
+ax_anim 2, 2, 58, -5, 0, -5, 0,
+ax_anim 2, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 1, 58, -16, 1, -16, 1,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 0, 58, -16, 1, -16, 1,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 0, 55, -11, 0, -11, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sGrowlitheAnims_2_8:
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim 2, 0, 61, 6, -6, 6, -6,
+ax_anim 6, 0, 59, 8, -8, 8, -8,
+ax_anim 2, 0, 62, 2, -2, 2, -2,
+ax_anim 2, 2, 63, -5, 5, -5, 5,
+ax_anim 2, 0, 62, -11, 11, -11, 11,
+ax_anim 2, 0, 63, -20, 18, -20, 18,
+ax_anim 2, 1, 63, -19, 19, -19, 19,
+ax_anim 2, 0, 63, -20, 18, -20, 18,
+ax_anim 2, 0, 63, -19, 19, -19, 19,
+ax_anim 2, 0, 63, -20, 18, -20, 18,
+ax_anim 2, 0, 60, -11, 11, -11, 11,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_3_1:
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 66, 0, -6, 0, -6,
+ax_anim 6, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 67, 0, -2, 0, -2,
+ax_anim 2, 2, 68, 0, 7, 0, 7,
+ax_anim 2, 0, 67, 0, 9, 0, 9,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 1, 68, -1, 20, -1, 20,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 0, 68, -1, 20, -1, 20,
+ax_anim 2, 0, 68, 0, 20, 0, 20,
+ax_anim 2, 0, 65, 0, 11, 0, 11,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sGrowlitheAnims_3_2:
+ax_anim 2, 0, 70, -3, -3, -3, -3,
+ax_anim 2, 0, 71, -6, -6, -6, -6,
+ax_anim 6, 0, 69, -8, -8, -8, -8,
+ax_anim 2, 0, 72, -2, -2, -2, -2,
+ax_anim 2, 2, 73, 5, 5, 5, 5,
+ax_anim 2, 0, 72, 11, 11, 11, 11,
+ax_anim 2, 0, 73, 20, 18, 20, 18,
+ax_anim 2, 1, 73, 19, 19, 19, 19,
+ax_anim 2, 0, 73, 20, 18, 20, 18,
+ax_anim 2, 0, 73, 19, 19, 19, 19,
+ax_anim 2, 0, 73, 20, 18, 20, 18,
+ax_anim 2, 0, 70, 11, 11, 11, 11,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sGrowlitheAnims_3_3:
+ax_anim 2, 0, 75, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -6, 0, -6, 0,
+ax_anim 6, 0, 74, -8, 0, -8, 0,
+ax_anim 2, 0, 77, -2, 0, -2, 0,
+ax_anim 2, 2, 78, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 11, 0, 11, 0,
+ax_anim 2, 0, 78, 16, 0, 16, 0,
+ax_anim 2, 1, 78, 16, 1, 16, 1,
+ax_anim 2, 0, 78, 16, 0, 16, 0,
+ax_anim 2, 0, 78, 16, 1, 16, 1,
+ax_anim 2, 0, 78, 16, 0, 16, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sGrowlitheAnims_3_4:
+ax_anim 2, 0, 80, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -6, 6, -6, 6,
+ax_anim 6, 0, 79, -8, 8, -8, 8,
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 2, 2, 83, 4, -7, 4, -7,
+ax_anim 2, 0, 82, 11, -14, 11, -14,
+ax_anim 2, 0, 83, 15, -21, 15, -21,
+ax_anim 2, 1, 83, 14, -22, 14, -22,
+ax_anim 2, 0, 83, 15, -21, 15, -21,
+ax_anim 2, 0, 83, 14, -22, 14, -22,
+ax_anim 2, 0, 83, 15, -21, 15, -21,
+ax_anim 2, 0, 80, 9, -13, 9, -13,
+ax_anim 2, 0, 79, 3, -5, 3, -5,
+ax_anim_terminator
+sGrowlitheAnims_3_5:
+ax_anim 2, 0, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 86, 0, 6, 0, 6,
+ax_anim 6, 0, 84, 0, 8, 0, 8,
+ax_anim 2, 0, 87, 0, 2, 0, 2,
+ax_anim 2, 2, 88, 0, -7, 0, -7,
+ax_anim 2, 0, 87, 0, -11, 0, -11,
+ax_anim 2, 0, 88, 0, -20, 0, -20,
+ax_anim 2, 1, 88, -1, -20, -1, -20,
+ax_anim 2, 0, 88, 0, -20, 0, -20,
+ax_anim 2, 0, 88, -1, -20, -1, -20,
+ax_anim 2, 0, 88, 0, -20, 0, -20,
+ax_anim 2, 0, 85, 0, -11, 0, -11,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sGrowlitheAnims_3_6:
+ax_anim 2, 0, 90, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 6, 6, 6, 6,
+ax_anim 6, 0, 89, 8, 8, 8, 8,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 2, 93, -4, -7, -4, -7,
+ax_anim 2, 0, 92, -11, -14, -11, -14,
+ax_anim 2, 0, 93, -15, -21, -15, -21,
+ax_anim 2, 1, 93, -14, -22, -14, -22,
+ax_anim 2, 0, 93, -15, -21, -15, -21,
+ax_anim 2, 0, 93, -14, -22, -14, -22,
+ax_anim 2, 0, 93, -15, -21, -15, -21,
+ax_anim 2, 0, 90, -9, -13, -9, -13,
+ax_anim 2, 0, 89, -3, -5, -3, -5,
+ax_anim_terminator
+sGrowlitheAnims_3_7:
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 6, 0, 94, 8, 0, 8, 0,
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 2, 98, -5, 0, -5, 0,
+ax_anim 2, 0, 97, -11, 0, -11, 0,
+ax_anim 2, 0, 98, -16, 0, -16, 0,
+ax_anim 2, 1, 98, -16, 1, -16, 1,
+ax_anim 2, 0, 98, -16, 0, -16, 0,
+ax_anim 2, 0, 98, -16, 1, -16, 1,
+ax_anim 2, 0, 98, -16, 0, -16, 0,
+ax_anim 2, 0, 95, -11, 0, -11, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sGrowlitheAnims_3_8:
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 6, -6, 6, -6,
+ax_anim 6, 0, 99, 8, -8, 8, -8,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 2, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -11, 11, -11, 11,
+ax_anim 2, 0, 103, -20, 18, -20, 18,
+ax_anim 2, 1, 103, -19, 19, -19, 19,
+ax_anim 2, 0, 103, -20, 18, -20, 18,
+ax_anim 2, 0, 103, -19, 19, -19, 19,
+ax_anim 2, 0, 103, -20, 18, -20, 18,
+ax_anim 2, 0, 100, -11, 11, -11, 11,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 105, 0, -4, 0, -4,
+ax_anim 6, 2, 104, 0, -4, 0, -5,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 1, 107, 1, 3, 1, 3,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 107, 1, 3, 1, 3,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 107, 1, 3, 1, 3,
+ax_anim 2, 0, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sGrowlitheAnims_4_2:
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 109, -4, -4, -4, -4,
+ax_anim 6, 2, 108, -5, -5, -5, -5,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 1, 111, 4, 2, 4, 2,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 4, 2, 4, 2,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 4, 2, 4, 2,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim_terminator
+sGrowlitheAnims_4_3:
+ax_anim 2, 0, 113, -2, 0, -2, 0,
+ax_anim 2, 0, 113, -4, 0, -4, 0,
+ax_anim 6, 2, 112, -5, 0, -5, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 1, 115, 3, 1, 3, 1,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 115, 3, 1, 3, 1,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 115, 3, 1, 3, 1,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim_terminator
+sGrowlitheAnims_4_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 6, 2, 116, -5, 5, -5, 5,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 1, 119, 4, -2, 4, -2,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 0, 119, 4, -2, 4, -2,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 0, 119, 4, -2, 4, -2,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim_terminator
+sGrowlitheAnims_4_5:
+ax_anim 2, 0, 121, 0, 2, 0, 2,
+ax_anim 2, 0, 121, 0, 3, 0, 3,
+ax_anim 6, 2, 120, 0, 5, 0, 5,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 1, 123, 1, -3, 1, -3,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 0, 123, 1, -3, 1, -3,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 0, 123, 1, -3, 1, -3,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim_terminator
+sGrowlitheAnims_4_6:
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 125, 4, 4, 4, 4,
+ax_anim 6, 2, 124, 5, 5, 5, 5,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 1, 127, -4, -2, -4, -2,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 0, 127, -4, -2, -4, -2,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 0, 127, -4, -2, -4, -2,
+ax_anim 2, 0, 127, -3, -3, -3, -3,
+ax_anim 2, 0, 124, -1, -1, -1, -1,
+ax_anim_terminator
+sGrowlitheAnims_4_7:
+ax_anim 2, 0, 129, 2, 0, 2, 0,
+ax_anim 2, 0, 129, 4, 0, 4, 0,
+ax_anim 6, 2, 128, 5, 0, 5, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 1, 131, -3, 1, -3, 1,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 131, -3, 1, -3, 1,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 131, -3, 1, -3, 1,
+ax_anim 2, 0, 131, -3, 0, -3, 0,
+ax_anim 2, 0, 128, -1, 0, -1, 0,
+ax_anim_terminator
+sGrowlitheAnims_4_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 133, 4, -4, 4, -4,
+ax_anim 6, 2, 132, 5, -5, 5, -5,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 1, 135, -4, 2, -4, 2,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 135, -4, 2, -4, 2,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 135, -4, 2, -4, 2,
+ax_anim 2, 0, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 132, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_5_1:
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 3, 0, 137, 0, -8, 0, 0,
+ax_anim 3, 0, 137, 0, -9, 0, 0,
+ax_anim 3, 2, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 138, -1, 0, -1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 1, 138, -1, 0, -1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, -1, 0, -1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_5_2:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 3, 0, 140, 0, -8, 0, 0,
+ax_anim 3, 0, 140, 0, -9, 0, 0,
+ax_anim 3, 2, 140, 0, -8, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 1, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_5_3:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 3, 0, 143, 0, -8, 0, 0,
+ax_anim 3, 0, 143, 0, -9, 0, 0,
+ax_anim 3, 2, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 1, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_5_4:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -3, 0, 0,
+ax_anim 3, 0, 146, 0, -8, 0, 0,
+ax_anim 3, 0, 146, 0, -9, 0, 0,
+ax_anim 3, 2, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 1, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_5_5:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 3, 0, 149, 0, -8, 0, 0,
+ax_anim 3, 0, 149, 0, -9, 0, 0,
+ax_anim 3, 2, 149, 0, -8, 0, 0,
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 1, 150, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -1, 0, -1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_5_6:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -3, 0, 0,
+ax_anim 3, 0, 152, 0, -8, 0, 0,
+ax_anim 3, 0, 152, 0, -9, 0, 0,
+ax_anim 3, 2, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 1, -1, 1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 1, 153, -1, 1, -1, 1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 1, -1, 1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_5_7:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 3, 0, 155, 0, -8, 0, 0,
+ax_anim 3, 0, 155, 0, -9, 0, 0,
+ax_anim 3, 2, 155, 0, -8, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 1, 0, 1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 1, 156, 0, 1, 0, 1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 1, 0, 1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_5_8:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -3, 0, 0,
+ax_anim 3, 0, 158, 0, -8, 0, 0,
+ax_anim 3, 0, 158, 0, -9, 0, 0,
+ax_anim 3, 2, 158, 0, -8, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 1, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sGrowlitheAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sGrowlitheAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sGrowlitheAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sGrowlitheAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sGrowlitheAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sGrowlitheAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sGrowlitheAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_8_1:
+ax_anim 40, 0, 170, 0, -1, 0, 0,
+ax_anim 4, 0, 170, 0, -2, 0, 0,
+ax_anim 2, 0, 170, 0, -1, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_8_2:
+ax_anim 40, 0, 171, 0, -1, 0, 0,
+ax_anim 4, 0, 171, 0, -2, 0, 0,
+ax_anim 2, 0, 171, 0, -1, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_8_3:
+ax_anim 40, 0, 172, 0, -1, 0, 0,
+ax_anim 4, 0, 172, 0, -2, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_8_4:
+ax_anim 40, 0, 173, 0, -1, 0, 0,
+ax_anim 4, 0, 173, 0, -2, 0, 0,
+ax_anim 2, 0, 173, 0, -1, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_8_5:
+ax_anim 40, 0, 174, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, -2, 0, 0,
+ax_anim 2, 0, 174, 0, -1, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_8_6:
+ax_anim 40, 0, 175, 0, -1, 0, 0,
+ax_anim 4, 0, 175, 0, -2, 0, 0,
+ax_anim 2, 0, 175, 0, -1, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_8_7:
+ax_anim 40, 0, 176, 0, -1, 0, 0,
+ax_anim 4, 0, 176, 0, -2, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_8_8:
+ax_anim 40, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim 2, 0, 177, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 16, 7, 16,
+ax_anim 3, 0, 182, 0, 22, 0, 22,
+ax_anim 2, 3, 183, -7, 16, -7, 16,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 19, 3, 19, 3,
+ax_anim 2, 0, 180, 23, 10, 23, 10,
+ax_anim 3, 0, 181, 20, 21, 20, 21,
+ax_anim 2, 3, 182, 11, 19, 11, 19,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 18, -5, 18, -5,
+ax_anim 3, 0, 180, 21, -2, 21, -2,
+ax_anim 2, 3, 181, 18, 4, 18, 4,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 2, -16, 2, -16,
+ax_anim 2, 0, 178, 12, -20, 12, -20,
+ax_anim 3, 0, 179, 21, -21, 21, -21,
+ax_anim 2, 3, 180, 22, -13, 22, -13,
+ax_anim 2, 0, 181, 17, -4, 17, -4,
+ax_anim 1, 0, 182, 9, 0, 9, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -12, -9, -12,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -20, 0, -20,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -2, -16, -2, -16,
+ax_anim 2, 0, 178, -12, -20, -12, -20,
+ax_anim 3, 0, 185, -21, -21, -21, -21,
+ax_anim 2, 3, 184, -22, -13, -22, -13,
+ax_anim 2, 0, 183, -17, -4, -17, -4,
+ax_anim 1, 0, 182, -9, 0, -9, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -18, -5, -18, -5,
+ax_anim 3, 0, 184, -21, -2, -21, -2,
+ax_anim 2, 3, 183, -18, 4, -18, 4,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -19, 3, -19, 3,
+ax_anim 2, 0, 184, -23, 10, -23, 10,
+ax_anim 3, 0, 183, -20, 21, -20, 21,
+ax_anim 2, 3, 182, -11, 19, -11, 19,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrowlitheAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sGrowlitheGfx1:
+.incbin "baserom.gba", 0x788860, 0x100
+sGrowlitheSprites1:
+ax_sprite sGrowlitheGfx1, 0x100
+ax_sprite_terminator
+sGrowlitheGfx2:
+.incbin "baserom.gba", 0x788970, 0x100
+sGrowlitheSprites2:
+ax_sprite sGrowlitheGfx2, 0x100
+ax_sprite_terminator
+sGrowlitheGfx3:
+.incbin "baserom.gba", 0x788A80, 0x100
+sGrowlitheSprites3:
+ax_sprite sGrowlitheGfx3, 0x100
+ax_sprite_terminator
+sGrowlitheGfx4:
+.incbin "baserom.gba", 0x788B90, 0x200
+sGrowlitheSprites4:
+ax_sprite sGrowlitheGfx4, 0x200
+ax_sprite_terminator
+sGrowlitheGfx5:
+.incbin "baserom.gba", 0x788DA0, 0x200
+sGrowlitheSprites5:
+ax_sprite sGrowlitheGfx5, 0x200
+ax_sprite_terminator
+sGrowlitheGfx6:
+.incbin "baserom.gba", 0x788FB0, 0x200
+sGrowlitheSprites6:
+ax_sprite sGrowlitheGfx6, 0x200
+ax_sprite_terminator
+sGrowlitheGfx7:
+.incbin "baserom.gba", 0x7891C0, 0x200
+sGrowlitheSprites7:
+ax_sprite sGrowlitheGfx7, 0x200
+ax_sprite_terminator
+sGrowlitheGfx8:
+.incbin "baserom.gba", 0x7893D0, 0x200
+sGrowlitheSprites8:
+ax_sprite sGrowlitheGfx8, 0x200
+ax_sprite_terminator
+sGrowlitheGfx9:
+.incbin "baserom.gba", 0x7895E0, 0x200
+sGrowlitheSprites9:
+ax_sprite sGrowlitheGfx9, 0x200
+ax_sprite_terminator
+sGrowlitheGfx10:
+.incbin "baserom.gba", 0x7897F0, 0x200
+sGrowlitheSprites10:
+ax_sprite sGrowlitheGfx10, 0x200
+ax_sprite_terminator
+sGrowlitheGfx11:
+.incbin "baserom.gba", 0x789A00, 0x200
+sGrowlitheSprites11:
+ax_sprite sGrowlitheGfx11, 0x200
+ax_sprite_terminator
+sGrowlitheGfx12:
+.incbin "baserom.gba", 0x789C10, 0x200
+sGrowlitheSprites12:
+ax_sprite sGrowlitheGfx12, 0x200
+ax_sprite_terminator
+sGrowlitheGfx13:
+.incbin "baserom.gba", 0x789E20, 0x100
+sGrowlitheSprites13:
+ax_sprite sGrowlitheGfx13, 0x100
+ax_sprite_terminator
+sGrowlitheGfx14:
+.incbin "baserom.gba", 0x789F30, 0x100
+sGrowlitheSprites14:
+ax_sprite sGrowlitheGfx14, 0x100
+ax_sprite_terminator
+sGrowlitheGfx15:
+.incbin "baserom.gba", 0x78A040, 0x100
+sGrowlitheSprites15:
+ax_sprite sGrowlitheGfx15, 0x100
+ax_sprite_terminator
+sGrowlitheGfx16:
+.incbin "baserom.gba", 0x78A150, 0x40
+sGrowlitheGfx16_1:
+.incbin "baserom.gba", 0x78A190, 0x60
+sGrowlitheGfx16_2:
+.incbin "baserom.gba", 0x78A1F0, 0x60
+sGrowlitheSprites16:
+ax_sprite sGrowlitheGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGrowlitheGfx17:
+.incbin "baserom.gba", 0x78A288, 0x40
+sGrowlitheGfx17_1:
+.incbin "baserom.gba", 0x78A2C8, 0x60
+sGrowlitheGfx17_2:
+.incbin "baserom.gba", 0x78A328, 0x60
+sGrowlitheGfx17_3:
+.incbin "baserom.gba", 0x78A388, 0x40
+sGrowlitheSprites17:
+ax_sprite sGrowlitheGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx17_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGrowlitheGfx18:
+.incbin "baserom.gba", 0x78A410, 0x180
+sGrowlitheGfx18_1:
+.incbin "baserom.gba", 0x78A590, 0x20
+sGrowlitheSprites18:
+ax_sprite sGrowlitheGfx18, 0x180
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx18_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx19:
+.incbin "baserom.gba", 0x78A5D8, 0x40
+sGrowlitheGfx19_1:
+.incbin "baserom.gba", 0x78A618, 0x60
+sGrowlitheGfx19_2:
+.incbin "baserom.gba", 0x78A678, 0x60
+sGrowlitheGfx19_3:
+.incbin "baserom.gba", 0x78A6D8, 0x60
+sGrowlitheSprites19:
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx20:
+.incbin "baserom.gba", 0x78A788, 0x180
+sGrowlitheGfx20_1:
+.incbin "baserom.gba", 0x78A908, 0x40
+sGrowlitheSprites20:
+ax_sprite sGrowlitheGfx20, 0x180
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx20_1, 0x40
+ax_sprite_terminator
+sGrowlitheGfx21:
+.incbin "baserom.gba", 0x78A968, 0x140
+sGrowlitheGfx21_1:
+.incbin "baserom.gba", 0x78AAA8, 0x40
+sGrowlitheSprites21:
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx21, 0x140
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx21_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx22:
+.incbin "baserom.gba", 0x78AB18, 0x60
+sGrowlitheGfx22_1:
+.incbin "baserom.gba", 0x78AB78, 0x100
+sGrowlitheGfx22_2:
+.incbin "baserom.gba", 0x78AC78, 0x60
+sGrowlitheSprites22:
+ax_sprite sGrowlitheGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx22_2, 0x60
+ax_sprite_terminator
+sGrowlitheGfx23:
+.incbin "baserom.gba", 0x78AD08, 0x40
+sGrowlitheGfx23_1:
+.incbin "baserom.gba", 0x78AD48, 0x60
+sGrowlitheGfx23_2:
+.incbin "baserom.gba", 0x78ADA8, 0x60
+sGrowlitheGfx23_3:
+.incbin "baserom.gba", 0x78AE08, 0x40
+sGrowlitheSprites23:
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx24:
+.incbin "baserom.gba", 0x78AE98, 0x100
+sGrowlitheSprites24:
+ax_sprite sGrowlitheGfx24, 0x100
+ax_sprite_terminator
+sGrowlitheGfx25:
+.incbin "baserom.gba", 0x78AFA8, 0x40
+sGrowlitheGfx25_1:
+.incbin "baserom.gba", 0x78AFE8, 0x60
+sGrowlitheGfx25_2:
+.incbin "baserom.gba", 0x78B048, 0x60
+sGrowlitheGfx25_3:
+.incbin "baserom.gba", 0x78B0A8, 0x40
+sGrowlitheSprites25:
+ax_sprite sGrowlitheGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx25_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGrowlitheGfx26:
+.incbin "baserom.gba", 0x78B130, 0x40
+sGrowlitheGfx26_1:
+.incbin "baserom.gba", 0x78B170, 0x40
+sGrowlitheGfx26_2:
+.incbin "baserom.gba", 0x78B1B0, 0x60
+sGrowlitheGfx26_3:
+.incbin "baserom.gba", 0x78B210, 0x60
+sGrowlitheSprites26:
+ax_sprite sGrowlitheGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx27:
+.incbin "baserom.gba", 0x78B2B8, 0x40
+sGrowlitheGfx27_1:
+.incbin "baserom.gba", 0x78B2F8, 0x60
+sGrowlitheGfx27_2:
+.incbin "baserom.gba", 0x78B358, 0x60
+sGrowlitheGfx27_3:
+.incbin "baserom.gba", 0x78B3B8, 0x60
+sGrowlitheSprites27:
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx28:
+.incbin "baserom.gba", 0x78B468, 0x180
+sGrowlitheSprites28:
+ax_sprite sGrowlitheGfx28, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGrowlitheGfx29:
+.incbin "baserom.gba", 0x78B600, 0x20
+sGrowlitheGfx29_1:
+.incbin "baserom.gba", 0x78B620, 0x60
+sGrowlitheGfx29_2:
+.incbin "baserom.gba", 0x78B680, 0x60
+sGrowlitheGfx29_3:
+.incbin "baserom.gba", 0x78B6E0, 0x60
+sGrowlitheSprites29:
+ax_sprite sGrowlitheGfx29, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGrowlitheGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx30:
+.incbin "baserom.gba", 0x78B788, 0x100
+sGrowlitheSprites30:
+ax_sprite sGrowlitheGfx30, 0x100
+ax_sprite_terminator
+sGrowlitheGfx31:
+.incbin "baserom.gba", 0x78B898, 0x100
+sGrowlitheSprites31:
+ax_sprite sGrowlitheGfx31, 0x100
+ax_sprite_terminator
+sGrowlitheGfx32:
+.incbin "baserom.gba", 0x78B9A8, 0x40
+sGrowlitheGfx32_1:
+.incbin "baserom.gba", 0x78B9E8, 0x160
+sGrowlitheSprites32:
+ax_sprite sGrowlitheGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrowlitheGfx32_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx33:
+.incbin "baserom.gba", 0x78BB70, 0x60
+sGrowlitheGfx33_1:
+.incbin "baserom.gba", 0x78BBD0, 0x80
+sGrowlitheGfx33_2:
+.incbin "baserom.gba", 0x78BC50, 0x60
+sGrowlitheGfx33_3:
+.incbin "baserom.gba", 0x78BCB0, 0x40
+sGrowlitheSprites33:
+ax_sprite sGrowlitheGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx33_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx34:
+.incbin "baserom.gba", 0x78BD38, 0x60
+sGrowlitheGfx34_1:
+.incbin "baserom.gba", 0x78BD98, 0x60
+sGrowlitheGfx34_2:
+.incbin "baserom.gba", 0x78BDF8, 0x60
+sGrowlitheGfx34_3:
+.incbin "baserom.gba", 0x78BE58, 0x60
+sGrowlitheSprites34:
+ax_sprite sGrowlitheGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrowlitheGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrowlitheGfx35:
+.incbin "baserom.gba", 0x78BF00, 0x100
+sGrowlitheSprites35:
+ax_sprite sGrowlitheGfx35, 0x100
+ax_sprite_terminator
+sGrowlitheGfx36:
+.incbin "baserom.gba", 0x78C010, 0x200
+sGrowlitheSprites36:
+ax_sprite sGrowlitheGfx36, 0x200
+ax_sprite_terminator
+sGrowlitheGfx37:
+.incbin "baserom.gba", 0x78C220, 0x200
+sGrowlitheSprites37:
+ax_sprite sGrowlitheGfx37, 0x200
+ax_sprite_terminator
+sGrowlitheGfx38:
+.incbin "baserom.gba", 0x78C430, 0x200
+sGrowlitheSprites38:
+ax_sprite sGrowlitheGfx38, 0x200
+ax_sprite_terminator
+sGrowlitheGfx39:
+.incbin "baserom.gba", 0x78C640, 0x200
+sGrowlitheSprites39:
+ax_sprite sGrowlitheGfx39, 0x200
+ax_sprite_terminator
+sGrowlitheGfx40:
+.incbin "baserom.gba", 0x78C850, 0x200
+sGrowlitheSprites40:
+ax_sprite sGrowlitheGfx40, 0x200
+ax_sprite_terminator
+sGrowlitheGfx41:
+.incbin "baserom.gba", 0x78CA60, 0x200
+sGrowlitheSprites41:
+ax_sprite sGrowlitheGfx41, 0x200
+ax_sprite_terminator
+sGrowlitheGfx42:
+.incbin "baserom.gba", 0x78CC70, 0x200
+sGrowlitheSprites42:
+ax_sprite sGrowlitheGfx42, 0x200
+ax_sprite_terminator
+sAxPosesGrowlithe:
+.4byte sGrowlithePose1
+.4byte sGrowlithePose2
+.4byte sGrowlithePose3
+.4byte sGrowlithePose4
+.4byte sGrowlithePose5
+.4byte sGrowlithePose6
+.4byte sGrowlithePose7
+.4byte sGrowlithePose8
+.4byte sGrowlithePose9
+.4byte sGrowlithePose10
+.4byte sGrowlithePose11
+.4byte sGrowlithePose12
+.4byte sGrowlithePose13
+.4byte sGrowlithePose14
+.4byte sGrowlithePose15
+.4byte sGrowlithePose16
+.4byte sGrowlithePose17
+.4byte sGrowlithePose18
+.4byte sGrowlithePose19
+.4byte sGrowlithePose20
+.4byte sGrowlithePose21
+.4byte sGrowlithePose22
+.4byte sGrowlithePose23
+.4byte sGrowlithePose24
+.4byte sGrowlithePose25
+.4byte sGrowlithePose26
+.4byte sGrowlithePose27
+.4byte sGrowlithePose28
+.4byte sGrowlithePose29
+.4byte sGrowlithePose30
+.4byte sGrowlithePose31
+.4byte sGrowlithePose32
+.4byte sGrowlithePose33
+.4byte sGrowlithePose34
+.4byte sGrowlithePose35
+.4byte sGrowlithePose36
+.4byte sGrowlithePose37
+.4byte sGrowlithePose38
+.4byte sGrowlithePose39
+.4byte sGrowlithePose40
+.4byte sGrowlithePose41
+.4byte sGrowlithePose42
+.4byte sGrowlithePose43
+.4byte sGrowlithePose44
+.4byte sGrowlithePose45
+.4byte sGrowlithePose46
+.4byte sGrowlithePose47
+.4byte sGrowlithePose48
+.4byte sGrowlithePose49
+.4byte sGrowlithePose50
+.4byte sGrowlithePose51
+.4byte sGrowlithePose52
+.4byte sGrowlithePose53
+.4byte sGrowlithePose54
+.4byte sGrowlithePose55
+.4byte sGrowlithePose56
+.4byte sGrowlithePose57
+.4byte sGrowlithePose58
+.4byte sGrowlithePose59
+.4byte sGrowlithePose60
+.4byte sGrowlithePose61
+.4byte sGrowlithePose62
+.4byte sGrowlithePose63
+.4byte sGrowlithePose64
+.4byte sGrowlithePose65
+.4byte sGrowlithePose66
+.4byte sGrowlithePose67
+.4byte sGrowlithePose68
+.4byte sGrowlithePose69
+.4byte sGrowlithePose70
+.4byte sGrowlithePose71
+.4byte sGrowlithePose72
+.4byte sGrowlithePose73
+.4byte sGrowlithePose74
+.4byte sGrowlithePose75
+.4byte sGrowlithePose76
+.4byte sGrowlithePose77
+.4byte sGrowlithePose78
+.4byte sGrowlithePose79
+.4byte sGrowlithePose80
+.4byte sGrowlithePose81
+.4byte sGrowlithePose82
+.4byte sGrowlithePose83
+.4byte sGrowlithePose84
+.4byte sGrowlithePose85
+.4byte sGrowlithePose86
+.4byte sGrowlithePose87
+.4byte sGrowlithePose88
+.4byte sGrowlithePose89
+.4byte sGrowlithePose90
+.4byte sGrowlithePose91
+.4byte sGrowlithePose92
+.4byte sGrowlithePose93
+.4byte sGrowlithePose94
+.4byte sGrowlithePose95
+.4byte sGrowlithePose96
+.4byte sGrowlithePose97
+.4byte sGrowlithePose98
+.4byte sGrowlithePose99
+.4byte sGrowlithePose100
+.4byte sGrowlithePose101
+.4byte sGrowlithePose102
+.4byte sGrowlithePose103
+.4byte sGrowlithePose104
+.4byte sGrowlithePose105
+.4byte sGrowlithePose106
+.4byte sGrowlithePose107
+.4byte sGrowlithePose108
+.4byte sGrowlithePose109
+.4byte sGrowlithePose110
+.4byte sGrowlithePose111
+.4byte sGrowlithePose112
+.4byte sGrowlithePose113
+.4byte sGrowlithePose114
+.4byte sGrowlithePose115
+.4byte sGrowlithePose116
+.4byte sGrowlithePose117
+.4byte sGrowlithePose118
+.4byte sGrowlithePose119
+.4byte sGrowlithePose120
+.4byte sGrowlithePose121
+.4byte sGrowlithePose122
+.4byte sGrowlithePose123
+.4byte sGrowlithePose124
+.4byte sGrowlithePose125
+.4byte sGrowlithePose126
+.4byte sGrowlithePose127
+.4byte sGrowlithePose128
+.4byte sGrowlithePose129
+.4byte sGrowlithePose130
+.4byte sGrowlithePose131
+.4byte sGrowlithePose132
+.4byte sGrowlithePose133
+.4byte sGrowlithePose134
+.4byte sGrowlithePose135
+.4byte sGrowlithePose136
+.4byte sGrowlithePose137
+.4byte sGrowlithePose138
+.4byte sGrowlithePose139
+.4byte sGrowlithePose140
+.4byte sGrowlithePose141
+.4byte sGrowlithePose142
+.4byte sGrowlithePose143
+.4byte sGrowlithePose144
+.4byte sGrowlithePose145
+.4byte sGrowlithePose146
+.4byte sGrowlithePose147
+.4byte sGrowlithePose148
+.4byte sGrowlithePose149
+.4byte sGrowlithePose150
+.4byte sGrowlithePose151
+.4byte sGrowlithePose152
+.4byte sGrowlithePose153
+.4byte sGrowlithePose154
+.4byte sGrowlithePose155
+.4byte sGrowlithePose156
+.4byte sGrowlithePose157
+.4byte sGrowlithePose158
+.4byte sGrowlithePose159
+.4byte sGrowlithePose160
+.4byte sGrowlithePose161
+.4byte sGrowlithePose162
+.4byte sGrowlithePose163
+.4byte sGrowlithePose164
+.4byte sGrowlithePose165
+.4byte sGrowlithePose166
+.4byte sGrowlithePose167
+.4byte sGrowlithePose168
+.4byte sGrowlithePose169
+.4byte sGrowlithePose170
+.4byte sGrowlithePose171
+.4byte sGrowlithePose172
+.4byte sGrowlithePose173
+.4byte sGrowlithePose174
+.4byte sGrowlithePose175
+.4byte sGrowlithePose176
+.4byte sGrowlithePose177
+.4byte sGrowlithePose178
+.4byte sGrowlithePose179
+.4byte sGrowlithePose180
+.4byte sGrowlithePose181
+.4byte sGrowlithePose182
+.4byte sGrowlithePose183
+.4byte sGrowlithePose184
+.4byte sGrowlithePose185
+.4byte sGrowlithePose186
+.4byte sGrowlithePose187
+.4byte sGrowlithePose188
+.4byte sGrowlithePose189
+.4byte sGrowlithePose190
+.4byte sGrowlithePose191
+.4byte sGrowlithePose192
+.4byte sGrowlithePose193
+.4byte sGrowlithePose194
+.4byte sGrowlithePose195
+.4byte sGrowlithePose196
+.4byte sGrowlithePose197
+.4byte sGrowlithePose198
+.4byte sGrowlithePose199
+.4byte sGrowlithePose200
+.4byte sGrowlithePose201
+.4byte sGrowlithePose202
+.4byte sGrowlithePose203
+.4byte sGrowlithePose204
+.4byte sGrowlithePose205
+.4byte sGrowlithePose206
+.4byte sGrowlithePose207
+.4byte sGrowlithePose208
+.4byte sGrowlithePose209
+.4byte sGrowlithePose210
+.4byte sGrowlithePose211
+.4byte sGrowlithePose212
+.4byte sGrowlithePose213
+.4byte sGrowlithePose214
+.4byte sGrowlithePose215
+.4byte sGrowlithePose216
+.4byte sGrowlithePose217
+.4byte sGrowlithePose218
+.4byte sGrowlithePose219
+.4byte sGrowlithePose220
+.4byte sGrowlithePose221
+.4byte sGrowlithePose222
+.4byte sGrowlithePose223
+.4byte sGrowlithePose224
+.4byte sGrowlithePose225
+.4byte sGrowlithePose226
+.4byte sGrowlithePose227
+.4byte sGrowlithePose228
+.4byte sGrowlithePose229
+.4byte sGrowlithePose230
+.4byte sGrowlithePose231
+.4byte sGrowlithePose232
+.4byte sGrowlithePose233
+.4byte sGrowlithePose234
+sAxPositionsGrowlithe:
+.2byte    0,   -3, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,   -2, 	  -5,    4, 	   3,    1, 	   0,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    4, 	  -1,   -6
+.2byte    6,   -5, 	   7,    0, 	   2,    2, 	  -1,   -8
+.2byte    6,   -4, 	   9,    1, 	  -1,    1, 	   0,   -7
+.2byte    6,   -4, 	   6,    0, 	   3,    4, 	   0,   -7
+.2byte   10,   -8, 	   7,   -3, 	   5,    1, 	  -1,   -8
+.2byte   10,   -7, 	  10,   -2, 	   3,    1, 	  -1,   -7
+.2byte   10,   -7, 	   1,   -2, 	   8,    1, 	  -1,   -7
+.2byte    9,  -14, 	   1,   -4, 	   6,   -2, 	  -2,   -8
+.2byte    9,  -13, 	   3,   -4, 	   5,    0, 	  -3,   -7
+.2byte    9,  -13, 	  -1,   -3, 	   8,   -2, 	  -2,   -7
+.2byte    0,  -16, 	   3,   -6, 	  -4,   -6, 	   0,  -11
+.2byte    0,  -15, 	   2,   -9, 	  -4,   -3, 	   0,   -9
+.2byte    0,  -15, 	   3,   -3, 	  -4,   -9, 	   0,   -9
+.2byte  -10,  -14, 	  -2,   -4, 	  -7,   -2, 	   1,   -8
+.2byte  -10,  -13, 	  -4,   -4, 	  -6,    0, 	   2,   -7
+.2byte  -10,  -13, 	   0,   -3, 	  -9,   -2, 	   1,   -7
+.2byte  -11,   -8, 	  -8,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -11,   -7, 	 -11,   -2, 	  -4,    1, 	   0,   -7
+.2byte  -11,   -7, 	  -2,   -2, 	  -9,    1, 	   0,   -7
+.2byte   -7,   -5, 	  -8,    0, 	  -3,    2, 	   0,   -8
+.2byte   -7,   -4, 	 -10,    1, 	   0,    1, 	  -1,   -7
+.2byte   -7,   -4, 	  -7,    0, 	  -4,    4, 	  -1,   -7
+.2byte    0,   -3, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,   -2, 	  -5,    4, 	   3,    1, 	   0,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    4, 	  -1,   -6
+.2byte    0,   -9, 	  -7,   -9, 	   6,   -9, 	   0,  -11
+.2byte    0,   -2, 	  -3,    0, 	   2,    0, 	   0,  -11
+.2byte    6,   -5, 	   7,    0, 	   2,    2, 	  -1,   -8
+.2byte    6,   -4, 	   9,    1, 	  -1,    1, 	   0,   -7
+.2byte    6,   -4, 	   6,    0, 	   3,    4, 	   0,   -7
+.2byte    8,   -8, 	  11,   -7, 	   5,   -5, 	   0,  -10
+.2byte    9,   -3, 	   0,   -1, 	  -3,    0, 	   1,   -8
+.2byte   10,   -8, 	   7,   -3, 	   5,    1, 	  -1,   -8
+.2byte   10,   -7, 	  10,   -2, 	   3,    1, 	  -1,   -7
+.2byte   10,   -7, 	   1,   -2, 	   8,    1, 	  -1,   -7
+.2byte   10,  -10, 	  11,   -8, 	   9,   -6, 	  -1,   -9
+.2byte   10,   -4, 	   1,   -1, 	  -2,    0, 	   0,  -10
+.2byte    9,  -14, 	   1,   -4, 	   6,   -2, 	  -2,   -8
+.2byte    9,  -13, 	   3,   -4, 	   5,    0, 	  -3,   -7
+.2byte    9,  -13, 	  -1,   -3, 	   8,   -2, 	  -2,   -7
+.2byte    7,  -16, 	   0,  -13, 	   7,  -10, 	  -3,  -11
+.2byte   10,   -7, 	  -4,   -2, 	  -2,   -1, 	   1,  -10
+.2byte    0,  -16, 	   3,   -6, 	  -4,   -6, 	   0,  -11
+.2byte    0,  -15, 	   2,   -9, 	  -4,   -3, 	   0,   -9
+.2byte    0,  -15, 	   3,   -3, 	  -4,   -9, 	   0,   -9
+.2byte   -1,  -18, 	   6,  -13, 	  -7,  -13, 	  -1,  -10
+.2byte   -1,  -14, 	   1,   -3, 	  -2,   -3, 	  -1,  -12
+.2byte  -10,  -14, 	  -2,   -4, 	  -7,   -2, 	   1,   -8
+.2byte  -10,  -13, 	  -4,   -4, 	  -6,    0, 	   2,   -7
+.2byte  -10,  -13, 	   0,   -3, 	  -9,   -2, 	   1,   -7
+.2byte   -8,  -16, 	  -1,  -13, 	  -8,  -10, 	   2,  -11
+.2byte  -11,   -7, 	   3,   -2, 	   1,   -1, 	  -2,  -10
+.2byte  -11,   -8, 	  -8,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -11,   -7, 	 -11,   -2, 	  -4,    1, 	   0,   -7
+.2byte  -11,   -7, 	  -2,   -2, 	  -9,    1, 	   0,   -7
+.2byte  -11,  -10, 	 -12,   -8, 	 -10,   -6, 	   0,   -9
+.2byte  -11,   -4, 	  -2,   -1, 	   1,    0, 	  -1,  -10
+.2byte   -7,   -5, 	  -8,    0, 	  -3,    2, 	   0,   -8
+.2byte   -7,   -4, 	 -10,    1, 	   0,    1, 	  -1,   -7
+.2byte   -7,   -4, 	  -7,    0, 	  -4,    4, 	  -1,   -7
+.2byte   -9,   -8, 	 -12,   -7, 	  -6,   -5, 	  -1,  -10
+.2byte  -10,   -3, 	  -1,   -1, 	   2,    0, 	  -2,   -8
+.2byte    0,   -3, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,   -2, 	  -5,    4, 	   3,    1, 	   0,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    4, 	  -1,   -6
+.2byte    0,   -9, 	  -7,   -9, 	   6,   -9, 	   0,  -11
+.2byte    0,   -2, 	  -3,    0, 	   2,    0, 	   0,  -11
+.2byte    6,   -5, 	   7,    0, 	   2,    2, 	  -1,   -8
+.2byte    6,   -4, 	   9,    1, 	  -1,    1, 	   0,   -7
+.2byte    6,   -4, 	   6,    0, 	   3,    4, 	   0,   -7
+.2byte    8,   -8, 	  11,   -7, 	   5,   -5, 	   0,  -10
+.2byte    9,   -3, 	   0,   -1, 	  -3,    0, 	   1,   -8
+.2byte   10,   -8, 	   7,   -3, 	   5,    1, 	  -1,   -8
+.2byte   10,   -7, 	  10,   -2, 	   3,    1, 	  -1,   -7
+.2byte   10,   -7, 	   1,   -2, 	   8,    1, 	  -1,   -7
+.2byte   10,  -10, 	  11,   -8, 	   9,   -6, 	  -1,   -9
+.2byte   10,   -4, 	   1,   -1, 	  -2,    0, 	   0,  -10
+.2byte    9,  -14, 	   1,   -4, 	   6,   -2, 	  -2,   -8
+.2byte    9,  -13, 	   3,   -4, 	   5,    0, 	  -3,   -7
+.2byte    9,  -13, 	  -1,   -3, 	   8,   -2, 	  -2,   -7
+.2byte    7,  -16, 	   0,  -13, 	   7,  -10, 	  -3,  -11
+.2byte   10,   -7, 	  -4,   -2, 	  -2,   -1, 	   1,  -10
+.2byte    0,  -16, 	   3,   -6, 	  -4,   -6, 	   0,  -11
+.2byte    0,  -15, 	   2,   -9, 	  -4,   -3, 	   0,   -9
+.2byte    0,  -15, 	   3,   -3, 	  -4,   -9, 	   0,   -9
+.2byte   -1,  -18, 	   6,  -13, 	  -7,  -13, 	  -1,  -10
+.2byte   -1,  -14, 	   1,   -3, 	  -2,   -3, 	  -1,  -12
+.2byte  -10,  -14, 	  -2,   -4, 	  -7,   -2, 	   1,   -8
+.2byte  -10,  -13, 	  -4,   -4, 	  -6,    0, 	   2,   -7
+.2byte  -10,  -13, 	   0,   -3, 	  -9,   -2, 	   1,   -7
+.2byte   -8,  -16, 	  -1,  -13, 	  -8,  -10, 	   2,  -11
+.2byte  -11,   -7, 	   3,   -2, 	   1,   -1, 	  -2,  -10
+.2byte  -11,   -8, 	  -8,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -11,   -7, 	 -11,   -2, 	  -4,    1, 	   0,   -7
+.2byte  -11,   -7, 	  -2,   -2, 	  -9,    1, 	   0,   -7
+.2byte  -11,  -10, 	 -12,   -8, 	 -10,   -6, 	   0,   -9
+.2byte  -11,   -4, 	  -2,   -1, 	   1,    0, 	  -1,  -10
+.2byte   -7,   -5, 	  -8,    0, 	  -3,    2, 	   0,   -8
+.2byte   -7,   -4, 	 -10,    1, 	   0,    1, 	  -1,   -7
+.2byte   -7,   -4, 	  -7,    0, 	  -4,    4, 	  -1,   -7
+.2byte   -9,   -8, 	 -12,   -7, 	  -6,   -5, 	  -1,  -10
+.2byte  -10,   -3, 	  -1,   -1, 	   2,    0, 	  -2,   -8
+.2byte    0,   -3, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,   -2, 	  -5,    4, 	   3,    1, 	   0,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    4, 	  -1,   -6
+.2byte    0,   -2, 	  -7,    1, 	   6,    1, 	   0,  -10
+.2byte    6,   -5, 	   7,    0, 	   2,    2, 	  -1,   -8
+.2byte    6,   -4, 	   9,    1, 	  -1,    1, 	   0,   -7
+.2byte    6,   -4, 	   6,    0, 	   3,    4, 	   0,   -7
+.2byte    9,   -4, 	   9,   -1, 	   1,    2, 	   0,   -7
+.2byte   10,   -8, 	   7,   -3, 	   5,    1, 	  -1,   -8
+.2byte   10,   -7, 	  10,   -2, 	   3,    1, 	  -1,   -7
+.2byte   10,   -7, 	   1,   -2, 	   8,    1, 	  -1,   -7
+.2byte   11,   -6, 	   6,   -3, 	   4,    1, 	   0,   -7
+.2byte    9,  -14, 	   1,   -4, 	   6,   -2, 	  -2,   -8
+.2byte    9,  -13, 	   3,   -4, 	   5,    0, 	  -3,   -7
+.2byte    9,  -13, 	  -1,   -3, 	   8,   -2, 	  -2,   -7
+.2byte   10,  -11, 	   0,   -4, 	   5,   -2, 	   0,   -8
+.2byte    0,  -16, 	   3,   -6, 	  -4,   -6, 	   0,  -11
+.2byte    0,  -15, 	   2,   -9, 	  -4,   -3, 	   0,   -9
+.2byte    0,  -15, 	   3,   -3, 	  -4,   -9, 	   0,   -9
+.2byte   -1,  -14, 	   4,  -14, 	  -5,  -14, 	  -1,  -10
+.2byte  -10,  -14, 	  -2,   -4, 	  -7,   -2, 	   1,   -8
+.2byte  -10,  -13, 	  -4,   -4, 	  -6,    0, 	   2,   -7
+.2byte  -10,  -13, 	   0,   -3, 	  -9,   -2, 	   1,   -7
+.2byte  -11,  -11, 	  -1,   -4, 	  -6,   -2, 	  -1,   -8
+.2byte  -11,   -8, 	  -8,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -11,   -7, 	 -11,   -2, 	  -4,    1, 	   0,   -7
+.2byte  -11,   -7, 	  -2,   -2, 	  -9,    1, 	   0,   -7
+.2byte  -12,   -6, 	  -7,   -3, 	  -5,    1, 	  -1,   -7
+.2byte   -7,   -5, 	  -8,    0, 	  -3,    2, 	   0,   -8
+.2byte   -7,   -4, 	 -10,    1, 	   0,    1, 	  -1,   -7
+.2byte   -7,   -4, 	  -7,    0, 	  -4,    4, 	  -1,   -7
+.2byte  -10,   -4, 	 -10,   -1, 	  -2,    2, 	  -1,   -7
+.2byte    0,   -3, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,   -9, 	  -7,   -9, 	   6,   -9, 	   0,  -11
+.2byte    0,   -8, 	  -4,    1, 	   3,    1, 	   0,   -7
+.2byte    6,   -5, 	   7,    0, 	   2,    2, 	  -1,   -8
+.2byte    7,   -8, 	  10,   -7, 	   4,   -5, 	  -1,  -10
+.2byte    5,   -9, 	   7,   -1, 	   1,    1, 	  -2,   -7
+.2byte   10,   -8, 	   7,   -3, 	   5,    1, 	  -1,   -8
+.2byte   10,  -10, 	  11,   -8, 	   9,   -6, 	  -1,   -9
+.2byte    8,  -10, 	   6,   -3, 	   4,    1, 	  -1,   -7
+.2byte    9,  -14, 	   1,   -4, 	   6,   -2, 	  -2,   -8
+.2byte    7,  -16, 	   0,  -13, 	   7,  -10, 	  -3,  -11
+.2byte    6,  -14, 	  -1,   -2, 	   4,   -1, 	  -2,   -8
+.2byte    0,  -16, 	   3,   -6, 	  -4,   -6, 	   0,  -11
+.2byte   -1,  -18, 	   6,  -13, 	  -7,  -13, 	  -1,  -10
+.2byte   -1,  -19, 	   3,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte  -10,  -14, 	  -2,   -4, 	  -7,   -2, 	   1,   -8
+.2byte   -8,  -16, 	  -1,  -13, 	  -8,  -10, 	   2,  -11
+.2byte   -7,  -14, 	   0,   -2, 	  -5,   -1, 	   1,   -8
+.2byte  -11,   -8, 	  -8,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -11,  -10, 	 -12,   -8, 	 -10,   -6, 	   0,   -9
+.2byte   -7,  -10, 	  -5,   -3, 	  -3,    1, 	   2,   -7
+.2byte   -7,   -5, 	  -8,    0, 	  -3,    2, 	   0,   -8
+.2byte   -8,   -8, 	 -11,   -7, 	  -5,   -5, 	   0,  -10
+.2byte   -6,   -9, 	  -8,   -1, 	  -2,    1, 	   1,   -7
+.2byte   -5,    0, 	 -10,    0, 	  -3,    2, 	   0,   -7
+.2byte   -5,    1, 	 -10,    0, 	  -3,    2, 	   0,   -6
+.2byte    0,    0, 	  -7,    2, 	   6,    2, 	   0,   -8
+.2byte    6,   -2, 	  13,   -5, 	   2,    0, 	  -1,   -8
+.2byte    8,   -4, 	  12,   -6, 	  11,   -2, 	  -4,   -7
+.2byte    7,   -9, 	   3,  -11, 	   9,   -8, 	  -4,   -5
+.2byte    0,  -10, 	   6,  -12, 	  -7,  -12, 	   0,   -5
+.2byte   -8,   -9, 	  -4,  -11, 	 -10,   -8, 	   3,   -5
+.2byte   -9,   -4, 	 -13,   -6, 	 -12,   -2, 	   3,   -7
+.2byte   -7,   -2, 	 -14,   -5, 	  -3,    0, 	   0,   -8
+.2byte    0,   -8, 	  -4,    1, 	   3,    1, 	   0,   -7
+.2byte    5,   -9, 	   7,   -1, 	   1,    1, 	  -2,   -7
+.2byte    8,  -10, 	   6,   -3, 	   4,    1, 	  -1,   -7
+.2byte    6,  -14, 	  -1,   -2, 	   4,   -1, 	  -2,   -8
+.2byte   -1,  -19, 	   3,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -7,  -14, 	   0,   -2, 	  -5,   -1, 	   1,   -8
+.2byte   -7,  -10, 	  -5,   -3, 	  -3,    1, 	   2,   -7
+.2byte   -6,   -9, 	  -8,   -1, 	  -2,    1, 	   1,   -7
+.2byte    0,   -2, 	  -3,    0, 	   2,    0, 	   0,  -11
+.2byte  -10,   -3, 	  -1,   -1, 	   2,    0, 	  -2,   -8
+.2byte  -11,   -4, 	  -2,   -1, 	   1,    0, 	  -1,  -10
+.2byte  -10,   -7, 	   4,   -2, 	   2,   -1, 	  -1,  -10
+.2byte   -1,  -13, 	   1,   -2, 	  -2,   -2, 	  -1,  -11
+.2byte    9,   -7, 	  -5,   -2, 	  -3,   -1, 	   0,  -10
+.2byte   10,   -4, 	   1,   -1, 	  -2,    0, 	   0,  -10
+.2byte    9,   -3, 	   0,   -1, 	  -3,    0, 	   1,   -8
+.2byte    0,   -2, 	  -7,    1, 	   6,    1, 	   0,  -10
+.2byte    9,   -4, 	   9,   -1, 	   1,    2, 	   0,   -7
+.2byte   11,   -6, 	   6,   -3, 	   4,    1, 	   0,   -7
+.2byte   10,  -11, 	   0,   -4, 	   5,   -2, 	   0,   -8
+.2byte   -1,  -14, 	   4,  -14, 	  -5,  -14, 	  -1,  -10
+.2byte  -11,  -11, 	  -1,   -4, 	  -6,   -2, 	  -1,   -8
+.2byte  -12,   -6, 	  -7,   -3, 	  -5,    1, 	  -1,   -7
+.2byte  -10,   -4, 	 -10,   -1, 	  -2,    2, 	  -1,   -7
+.2byte    0,   -3, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,   -9, 	  -7,   -9, 	   6,   -9, 	   0,  -11
+.2byte    0,   -2, 	  -3,    0, 	   2,    0, 	   0,  -11
+.2byte    6,   -5, 	   7,    0, 	   2,    2, 	  -1,   -8
+.2byte    8,   -8, 	  11,   -7, 	   5,   -5, 	   0,  -10
+.2byte    9,   -3, 	   0,   -1, 	  -3,    0, 	   1,   -8
+.2byte   10,   -8, 	   7,   -3, 	   5,    1, 	  -1,   -8
+.2byte   10,  -10, 	  11,   -8, 	   9,   -6, 	  -1,   -9
+.2byte   10,   -4, 	   1,   -1, 	  -2,    0, 	   0,  -10
+.2byte    9,  -14, 	   1,   -4, 	   6,   -2, 	  -2,   -8
+.2byte    7,  -16, 	   0,  -13, 	   7,  -10, 	  -3,  -11
+.2byte   10,   -7, 	  -4,   -2, 	  -2,   -1, 	   1,  -10
+.2byte    0,  -16, 	   3,   -6, 	  -4,   -6, 	   0,  -11
+.2byte   -1,  -18, 	   6,  -13, 	  -7,  -13, 	  -1,  -10
+.2byte   -1,  -14, 	   1,   -3, 	  -2,   -3, 	  -1,  -12
+.2byte  -10,  -14, 	  -2,   -4, 	  -7,   -2, 	   1,   -8
+.2byte   -8,  -16, 	  -1,  -13, 	  -8,  -10, 	   2,  -11
+.2byte  -11,   -7, 	   3,   -2, 	   1,   -1, 	  -2,  -10
+.2byte  -11,   -8, 	  -8,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -11,  -10, 	 -12,   -8, 	 -10,   -6, 	   0,   -9
+.2byte  -11,   -4, 	  -2,   -1, 	   1,    0, 	  -1,  -10
+.2byte   -7,   -5, 	  -8,    0, 	  -3,    2, 	   0,   -8
+.2byte   -9,   -8, 	 -12,   -7, 	  -6,   -5, 	  -1,  -10
+.2byte  -10,   -3, 	  -1,   -1, 	   2,    0, 	  -2,   -8
+.2byte    0,   -8, 	  -4,    1, 	   3,    1, 	   0,   -7
+.2byte   -6,   -9, 	  -8,   -1, 	  -2,    1, 	   1,   -7
+.2byte   -9,  -10, 	  -7,   -3, 	  -5,    1, 	   0,   -7
+.2byte   -8,  -14, 	  -1,   -2, 	  -6,   -1, 	   0,   -8
+.2byte   -1,  -18, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte    7,  -14, 	   0,   -2, 	   5,   -1, 	  -1,   -8
+.2byte    8,  -10, 	   6,   -3, 	   4,    1, 	  -1,   -7
+.2byte    5,   -9, 	   7,   -1, 	   1,    1, 	  -2,   -7
+.2byte    0,   -3, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte   -7,   -5, 	  -8,    0, 	  -3,    2, 	   0,   -8
+.2byte  -11,   -8, 	  -8,   -3, 	  -6,    1, 	   0,   -8
+.2byte  -10,  -14, 	  -2,   -4, 	  -7,   -2, 	   1,   -8
+.2byte    0,  -16, 	   3,   -6, 	  -4,   -6, 	   0,  -11
+.2byte    9,  -14, 	   1,   -4, 	   6,   -2, 	  -2,   -8
+.2byte   10,   -8, 	   7,   -3, 	   5,    1, 	  -1,   -8
+.2byte    6,   -5, 	   7,    0, 	   2,    2, 	  -1,   -8
+sGrowlitheAnimTable1:
+.4byte sGrowlitheAnims_1_1
+.4byte sGrowlitheAnims_1_2
+.4byte sGrowlitheAnims_1_3
+.4byte sGrowlitheAnims_1_4
+.4byte sGrowlitheAnims_1_5
+.4byte sGrowlitheAnims_1_6
+.4byte sGrowlitheAnims_1_7
+.4byte sGrowlitheAnims_1_8
+sGrowlitheAnimTable2:
+.4byte sGrowlitheAnims_2_1
+.4byte sGrowlitheAnims_2_2
+.4byte sGrowlitheAnims_2_3
+.4byte sGrowlitheAnims_2_4
+.4byte sGrowlitheAnims_2_5
+.4byte sGrowlitheAnims_2_6
+.4byte sGrowlitheAnims_2_7
+.4byte sGrowlitheAnims_2_8
+sGrowlitheAnimTable3:
+.4byte sGrowlitheAnims_3_1
+.4byte sGrowlitheAnims_3_2
+.4byte sGrowlitheAnims_3_3
+.4byte sGrowlitheAnims_3_4
+.4byte sGrowlitheAnims_3_5
+.4byte sGrowlitheAnims_3_6
+.4byte sGrowlitheAnims_3_7
+.4byte sGrowlitheAnims_3_8
+sGrowlitheAnimTable4:
+.4byte sGrowlitheAnims_4_1
+.4byte sGrowlitheAnims_4_2
+.4byte sGrowlitheAnims_4_3
+.4byte sGrowlitheAnims_4_4
+.4byte sGrowlitheAnims_4_5
+.4byte sGrowlitheAnims_4_6
+.4byte sGrowlitheAnims_4_7
+.4byte sGrowlitheAnims_4_8
+sGrowlitheAnimTable5:
+.4byte sGrowlitheAnims_5_1
+.4byte sGrowlitheAnims_5_2
+.4byte sGrowlitheAnims_5_3
+.4byte sGrowlitheAnims_5_4
+.4byte sGrowlitheAnims_5_5
+.4byte sGrowlitheAnims_5_6
+.4byte sGrowlitheAnims_5_7
+.4byte sGrowlitheAnims_5_8
+sGrowlitheAnimTable6:
+.4byte sGrowlitheAnims_6_1
+.4byte sGrowlitheAnims_6_1
+.4byte sGrowlitheAnims_6_1
+.4byte sGrowlitheAnims_6_1
+.4byte sGrowlitheAnims_6_1
+.4byte sGrowlitheAnims_6_1
+.4byte sGrowlitheAnims_6_1
+.4byte sGrowlitheAnims_6_1
+sGrowlitheAnimTable7:
+.4byte sGrowlitheAnims_7_1
+.4byte sGrowlitheAnims_7_2
+.4byte sGrowlitheAnims_7_3
+.4byte sGrowlitheAnims_7_4
+.4byte sGrowlitheAnims_7_5
+.4byte sGrowlitheAnims_7_6
+.4byte sGrowlitheAnims_7_7
+.4byte sGrowlitheAnims_7_8
+sGrowlitheAnimTable8:
+.4byte sGrowlitheAnims_8_1
+.4byte sGrowlitheAnims_8_2
+.4byte sGrowlitheAnims_8_3
+.4byte sGrowlitheAnims_8_4
+.4byte sGrowlitheAnims_8_5
+.4byte sGrowlitheAnims_8_6
+.4byte sGrowlitheAnims_8_7
+.4byte sGrowlitheAnims_8_8
+sGrowlitheAnimTable9:
+.4byte sGrowlitheAnims_9_1
+.4byte sGrowlitheAnims_9_2
+.4byte sGrowlitheAnims_9_3
+.4byte sGrowlitheAnims_9_4
+.4byte sGrowlitheAnims_9_5
+.4byte sGrowlitheAnims_9_6
+.4byte sGrowlitheAnims_9_7
+.4byte sGrowlitheAnims_9_8
+sGrowlitheAnimTable10:
+.4byte sGrowlitheAnims_10_1
+.4byte sGrowlitheAnims_10_2
+.4byte sGrowlitheAnims_10_3
+.4byte sGrowlitheAnims_10_4
+.4byte sGrowlitheAnims_10_5
+.4byte sGrowlitheAnims_10_6
+.4byte sGrowlitheAnims_10_7
+.4byte sGrowlitheAnims_10_8
+sGrowlitheAnimTable11:
+.4byte sGrowlitheAnims_11_1
+.4byte sGrowlitheAnims_11_2
+.4byte sGrowlitheAnims_11_3
+.4byte sGrowlitheAnims_11_4
+.4byte sGrowlitheAnims_11_5
+.4byte sGrowlitheAnims_11_6
+.4byte sGrowlitheAnims_11_7
+.4byte sGrowlitheAnims_11_8
+sGrowlitheAnimTable12:
+.4byte sGrowlitheAnims_12_1
+.4byte sGrowlitheAnims_12_2
+.4byte sGrowlitheAnims_12_3
+.4byte sGrowlitheAnims_12_4
+.4byte sGrowlitheAnims_12_5
+.4byte sGrowlitheAnims_12_6
+.4byte sGrowlitheAnims_12_7
+.4byte sGrowlitheAnims_12_8
+sGrowlitheAnimTable13:
+.4byte sGrowlitheAnims_13_1
+.4byte sGrowlitheAnims_13_2
+.4byte sGrowlitheAnims_13_3
+.4byte sGrowlitheAnims_13_4
+.4byte sGrowlitheAnims_13_5
+.4byte sGrowlitheAnims_13_6
+.4byte sGrowlitheAnims_13_7
+.4byte sGrowlitheAnims_13_8
+sAxAnimationsGrowlithe:
+.4byte sGrowlitheAnimTable1
+.4byte sGrowlitheAnimTable2
+.4byte sGrowlitheAnimTable3
+.4byte sGrowlitheAnimTable4
+.4byte sGrowlitheAnimTable5
+.4byte sGrowlitheAnimTable6
+.4byte sGrowlitheAnimTable7
+.4byte sGrowlitheAnimTable8
+.4byte sGrowlitheAnimTable9
+.4byte sGrowlitheAnimTable10
+.4byte sGrowlitheAnimTable11
+.4byte sGrowlitheAnimTable12
+.4byte sGrowlitheAnimTable13
+sAxSpritesGrowlithe:
+.4byte sGrowlitheSprites1
+.4byte sGrowlitheSprites2
+.4byte sGrowlitheSprites3
+.4byte sGrowlitheSprites4
+.4byte sGrowlitheSprites5
+.4byte sGrowlitheSprites6
+.4byte sGrowlitheSprites7
+.4byte sGrowlitheSprites8
+.4byte sGrowlitheSprites9
+.4byte sGrowlitheSprites10
+.4byte sGrowlitheSprites11
+.4byte sGrowlitheSprites12
+.4byte sGrowlitheSprites13
+.4byte sGrowlitheSprites14
+.4byte sGrowlitheSprites15
+.4byte sGrowlitheSprites16
+.4byte sGrowlitheSprites17
+.4byte sGrowlitheSprites18
+.4byte sGrowlitheSprites19
+.4byte sGrowlitheSprites20
+.4byte sGrowlitheSprites21
+.4byte sGrowlitheSprites22
+.4byte sGrowlitheSprites23
+.4byte sGrowlitheSprites24
+.4byte sGrowlitheSprites25
+.4byte sGrowlitheSprites26
+.4byte sGrowlitheSprites27
+.4byte sGrowlitheSprites28
+.4byte sGrowlitheSprites29
+.4byte sGrowlitheSprites30
+.4byte sGrowlitheSprites31
+.4byte sGrowlitheSprites32
+.4byte sGrowlitheSprites33
+.4byte sGrowlitheSprites34
+.4byte sGrowlitheSprites35
+.4byte sGrowlitheSprites36
+.4byte sGrowlitheSprites37
+.4byte sGrowlitheSprites38
+.4byte sGrowlitheSprites39
+.4byte sGrowlitheSprites40
+.4byte sGrowlitheSprites41
+.4byte sGrowlitheSprites42
+sAxMainGrowlithe:
+ax_main sAxPosesGrowlithe, sAxAnimationsGrowlithe, 13, sAxSpritesGrowlithe, sAxPositionsGrowlithe

--- a/data/ax/grumpig.inc
+++ b/data/ax/grumpig.inc
@@ -1,0 +1,2826 @@
+.global gAxGrumpig
+gAxGrumpig:
+ax_siro sAxMainGrumpig
+sGrumpigPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose3:
+ax_pose 2, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose4:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose5:
+ax_pose 4, 0x01e4, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose6:
+ax_pose 5, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose7:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose8:
+ax_pose 7, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose9:
+ax_pose 8, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose10:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose11:
+ax_pose 10, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose12:
+ax_pose 11, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose17:
+ax_pose 10, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose19:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose20:
+ax_pose 7, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose21:
+ax_pose 8, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose23:
+ax_pose 4, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose24:
+ax_pose 5, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose26:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose27:
+ax_pose 2, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose28:
+ax_pose 15, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose29:
+ax_pose 16, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose30:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose31:
+ax_pose 4, 0x01e4, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose32:
+ax_pose 5, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose33:
+ax_pose 17, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose34:
+ax_pose 18, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose35:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose36:
+ax_pose 7, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose37:
+ax_pose 8, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose38:
+ax_pose 19, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose39:
+ax_pose 20, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose40:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose41:
+ax_pose 10, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose42:
+ax_pose 11, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose43:
+ax_pose 21, 0x01e5, 0x90f2, 0xac00
+ax_pose_terminator
+sGrumpigPose44:
+ax_pose 22, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose45:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose46:
+ax_pose 13, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose47:
+ax_pose 14, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose48:
+ax_pose 23, 0x01e5, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose49:
+ax_pose 24, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose50:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose51:
+ax_pose 10, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose52:
+ax_pose 11, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose53:
+ax_pose 21, 0x01e5, 0x80ee, 0xac00
+ax_pose_terminator
+sGrumpigPose54:
+ax_pose 22, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose55:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose56:
+ax_pose 7, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose57:
+ax_pose 8, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose58:
+ax_pose 19, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose59:
+ax_pose 20, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose60:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose61:
+ax_pose 4, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose62:
+ax_pose 5, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose63:
+ax_pose 17, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose64:
+ax_pose 18, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose65:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose66:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose67:
+ax_pose 2, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose68:
+ax_pose 15, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose69:
+ax_pose 16, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose70:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose71:
+ax_pose 4, 0x01e4, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose72:
+ax_pose 5, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose73:
+ax_pose 17, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose74:
+ax_pose 18, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose75:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose76:
+ax_pose 7, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose77:
+ax_pose 8, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose78:
+ax_pose 19, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose79:
+ax_pose 20, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose80:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose81:
+ax_pose 10, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose82:
+ax_pose 11, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose83:
+ax_pose 21, 0x01e5, 0x90f2, 0xac00
+ax_pose_terminator
+sGrumpigPose84:
+ax_pose 22, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose85:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose86:
+ax_pose 13, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose87:
+ax_pose 14, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose88:
+ax_pose 23, 0x01e5, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose89:
+ax_pose 24, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose90:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose91:
+ax_pose 10, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose92:
+ax_pose 11, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose93:
+ax_pose 21, 0x01e5, 0x80ee, 0xac00
+ax_pose_terminator
+sGrumpigPose94:
+ax_pose 22, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose95:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose96:
+ax_pose 7, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose97:
+ax_pose 8, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose98:
+ax_pose 19, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose99:
+ax_pose 20, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose100:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose101:
+ax_pose 4, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose102:
+ax_pose 5, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose103:
+ax_pose 17, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose104:
+ax_pose 18, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose105:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose106:
+ax_pose 16, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose107:
+ax_pose 25, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose108:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose109:
+ax_pose 18, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose110:
+ax_pose 26, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose111:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose112:
+ax_pose 20, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose113:
+ax_pose 27, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose114:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose115:
+ax_pose 22, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose116:
+ax_pose 28, 0x01e4, 0x90f1, 0xac00
+ax_pose_terminator
+sGrumpigPose117:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose118:
+ax_pose 24, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose119:
+ax_pose 29, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose120:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose121:
+ax_pose 22, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose122:
+ax_pose 28, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose123:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose124:
+ax_pose 20, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose125:
+ax_pose 27, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose126:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose127:
+ax_pose 18, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose128:
+ax_pose 26, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose129:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose130:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose131:
+ax_pose 2, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose132:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose133:
+ax_pose 4, 0x01e4, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose134:
+ax_pose 5, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sGrumpigPose135:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose136:
+ax_pose 7, 0x01e3, 0x90ed, 0xac00
+ax_pose_terminator
+sGrumpigPose137:
+ax_pose 8, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose138:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose139:
+ax_pose 10, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose140:
+ax_pose 11, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sGrumpigPose141:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose142:
+ax_pose 13, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose143:
+ax_pose 14, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose144:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose145:
+ax_pose 10, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sGrumpigPose146:
+ax_pose 11, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose147:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose148:
+ax_pose 7, 0x01e4, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose149:
+ax_pose 8, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sGrumpigPose150:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose151:
+ax_pose 4, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sGrumpigPose152:
+ax_pose 5, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose153:
+ax_pose 30, 0x01e6, 0x80f3, 0xac00
+ax_pose_terminator
+sGrumpigPose154:
+ax_pose 31, 0x01e6, 0x80f3, 0xac00
+ax_pose_terminator
+sGrumpigPose155:
+ax_pose 32, 0x01df, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose156:
+ax_pose 33, 0x01e0, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose157:
+ax_pose 34, 0x01e1, 0x90e8, 0xac00
+ax_pose_terminator
+sGrumpigPose158:
+ax_pose 35, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose159:
+ax_pose 36, 0x81e3, 0x4103, 0xac00
+ax_pose 37, 0x0203, 0x0103, 0xac04
+ax_pose 38, 0x0203, 0x00fb, 0xac05
+ax_pose 39, 0x0203, 0x00f3, 0xac06
+ax_pose 40, 0x81e3, 0x80f3, 0xac07
+ax_pose_terminator
+sGrumpigPose160:
+ax_pose 35, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose161:
+ax_pose 34, 0x01e1, 0x80f8, 0xac00
+ax_pose_terminator
+sGrumpigPose162:
+ax_pose 33, 0x01e0, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose163:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose164:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose165:
+ax_pose 2, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose166:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose167:
+ax_pose 4, 0x01e4, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose168:
+ax_pose 5, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose169:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose170:
+ax_pose 7, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose171:
+ax_pose 8, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose172:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose173:
+ax_pose 10, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose174:
+ax_pose 11, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose175:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose176:
+ax_pose 13, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose177:
+ax_pose 14, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose178:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose179:
+ax_pose 10, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose180:
+ax_pose 11, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose181:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose182:
+ax_pose 7, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose183:
+ax_pose 8, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose184:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose185:
+ax_pose 4, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose186:
+ax_pose 5, 0x01e5, 0x80f3, 0xac00
+ax_pose_terminator
+sGrumpigPose187:
+ax_pose 25, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose188:
+ax_pose 26, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose189:
+ax_pose 27, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose190:
+ax_pose 28, 0x01e5, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose191:
+ax_pose 29, 0x01e6, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose192:
+ax_pose 28, 0x01e5, 0x90f1, 0xac00
+ax_pose_terminator
+sGrumpigPose193:
+ax_pose 27, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose194:
+ax_pose 26, 0x01e4, 0x90f1, 0xac00
+ax_pose_terminator
+sGrumpigPose195:
+ax_pose 15, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose196:
+ax_pose 17, 0x01e3, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose197:
+ax_pose 19, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose198:
+ax_pose 21, 0x01e4, 0x90f2, 0xac00
+ax_pose_terminator
+sGrumpigPose199:
+ax_pose 23, 0x01e5, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose200:
+ax_pose 21, 0x01e4, 0x80ee, 0xac00
+ax_pose_terminator
+sGrumpigPose201:
+ax_pose 19, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose202:
+ax_pose 17, 0x01e3, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose203:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose204:
+ax_pose 15, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose205:
+ax_pose 25, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose206:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose207:
+ax_pose 17, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose208:
+ax_pose 26, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sGrumpigPose209:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose210:
+ax_pose 19, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose211:
+ax_pose 27, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sGrumpigPose212:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose213:
+ax_pose 21, 0x01e5, 0x90f2, 0xac00
+ax_pose_terminator
+sGrumpigPose214:
+ax_pose 28, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose215:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose216:
+ax_pose 23, 0x01e5, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose217:
+ax_pose 29, 0x01e6, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose218:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose219:
+ax_pose 21, 0x01e5, 0x80ee, 0xac00
+ax_pose_terminator
+sGrumpigPose220:
+ax_pose 28, 0x01e5, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose221:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose222:
+ax_pose 19, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose223:
+ax_pose 27, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose224:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose225:
+ax_pose 17, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose226:
+ax_pose 26, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose227:
+ax_pose 16, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose228:
+ax_pose 18, 0x01e4, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose229:
+ax_pose 20, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose230:
+ax_pose 22, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sGrumpigPose231:
+ax_pose 24, 0x01e5, 0x80ef, 0xac00
+ax_pose_terminator
+sGrumpigPose232:
+ax_pose 22, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose233:
+ax_pose 20, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose234:
+ax_pose 18, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sGrumpigPose235:
+ax_pose 0, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose236:
+ax_pose 3, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose237:
+ax_pose 6, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sGrumpigPose238:
+ax_pose 9, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose239:
+ax_pose 12, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sGrumpigPose240:
+ax_pose 9, 0x01e5, 0x90ec, 0xac00
+ax_pose_terminator
+sGrumpigPose241:
+ax_pose 6, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sGrumpigPose242:
+ax_pose 3, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+.align 2
+sGrumpigAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_2_1:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, -1, 0, -1,
+ax_anim 6, 0, 28, 0, -2, 0, -2,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 2, 27, 0, 1, 0, 7,
+ax_anim 2, 0, 27, 0, 10, 0, 14,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 1, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 0, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sGrumpigAnims_2_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 6, 0, 33, -2, -2, -2, -2,
+ax_anim 2, 0, 32, 3, -4, 3, 2,
+ax_anim 2, 2, 32, 10, 0, 10, 10,
+ax_anim 2, 0, 32, 16, 11, 16, 16,
+ax_anim 2, 0, 31, 21, 21, 21, 21,
+ax_anim 2, 1, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 31, 21, 21, 21, 21,
+ax_anim 2, 0, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim_terminator
+sGrumpigAnims_2_3:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 6, 0, 38, -2, 0, -2, 0,
+ax_anim 2, 0, 37, 4, -5, 4, 0,
+ax_anim 2, 2, 37, 9, -7, 9, 0,
+ax_anim 2, 0, 37, 15, -6, 15, 0,
+ax_anim 2, 0, 36, 21, 0, 21, 0,
+ax_anim 2, 1, 36, 21, -1, 21, -1,
+ax_anim 2, 0, 36, 21, 0, 21, 0,
+ax_anim 2, 0, 36, 21, -1, 21, -1,
+ax_anim 2, 0, 34, 6, 0, 6, -1,
+ax_anim_terminator
+sGrumpigAnims_2_4:
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 6, 0, 43, -2, 2, -2, 2,
+ax_anim 2, 0, 42, 3, -9, 3, -2,
+ax_anim 2, 2, 42, 8, -17, 8, -8,
+ax_anim 2, 0, 42, 16, -20, 16, -15,
+ax_anim 2, 0, 41, 20, -19, 20, -19,
+ax_anim 2, 1, 41, 21, -18, 21, -18,
+ax_anim 2, 0, 41, 20, -19, 20, -19,
+ax_anim 2, 0, 41, 21, -18, 21, -18,
+ax_anim 2, 0, 39, 7, -7, 7, -7,
+ax_anim_terminator
+sGrumpigAnims_2_5:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 6, 0, 48, 0, 2, 0, 2,
+ax_anim 2, 0, 47, 0, -5, 0, -1,
+ax_anim 2, 2, 47, 0, -11, 0, -6,
+ax_anim 2, 0, 47, 0, -15, 0, -15,
+ax_anim 2, 0, 46, 0, -18, 0, -18,
+ax_anim 2, 1, 46, 1, -18, 1, -18,
+ax_anim 2, 0, 46, 0, -18, 0, -18,
+ax_anim 2, 0, 46, 1, -18, 1, -18,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sGrumpigAnims_2_6:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, 1, 1, 1,
+ax_anim 6, 0, 53, 2, 2, 2, 2,
+ax_anim 2, 0, 52, -3, -9, -3, -2,
+ax_anim 2, 2, 52, -8, -17, -8, -8,
+ax_anim 2, 0, 52, -16, -20, -16, -15,
+ax_anim 2, 0, 51, -20, -19, -20, -19,
+ax_anim 2, 1, 51, -21, -18, -21, -18,
+ax_anim 2, 0, 51, -20, -19, -20, -19,
+ax_anim 2, 0, 51, -21, -18, -21, -18,
+ax_anim 2, 0, 49, -7, -7, -7, -7,
+ax_anim_terminator
+sGrumpigAnims_2_7:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 6, 0, 58, 2, 0, 2, 0,
+ax_anim 2, 0, 57, -4, -5, -4, 0,
+ax_anim 2, 2, 57, -9, -7, -9, 0,
+ax_anim 2, 0, 57, -15, -6, -15, 0,
+ax_anim 2, 0, 56, -21, 0, -21, 0,
+ax_anim 2, 1, 56, -21, -1, -21, -1,
+ax_anim 2, 0, 56, -21, 0, -21, 0,
+ax_anim 2, 0, 56, -21, -1, -21, -1,
+ax_anim 2, 0, 54, -6, 0, -6, -1,
+ax_anim_terminator
+sGrumpigAnims_2_8:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, -1, 1, -1,
+ax_anim 6, 0, 63, 2, -2, 2, -2,
+ax_anim 2, 0, 62, -3, -4, -3, 2,
+ax_anim 2, 2, 62, -10, 0, -10, 10,
+ax_anim 2, 0, 62, -16, 11, -16, 16,
+ax_anim 2, 0, 61, -21, 21, -21, 21,
+ax_anim 2, 1, 61, -22, 20, -22, 20,
+ax_anim 2, 0, 61, -21, 21, -21, 21,
+ax_anim 2, 0, 61, -22, 20, -22, 20,
+ax_anim 2, 0, 59, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_3_1:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, -1, 0, -1,
+ax_anim 6, 0, 68, 0, -2, 0, -2,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 2, 67, 0, 1, 0, 7,
+ax_anim 2, 0, 67, 0, 10, 0, 14,
+ax_anim 2, 0, 66, 0, 21, 0, 21,
+ax_anim 2, 1, 66, 1, 21, 1, 21,
+ax_anim 2, 0, 66, 0, 21, 0, 21,
+ax_anim 2, 0, 66, 1, 21, 1, 21,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sGrumpigAnims_3_2:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 6, 0, 73, -2, -2, -2, -2,
+ax_anim 2, 0, 72, 3, -4, 3, 2,
+ax_anim 2, 2, 72, 10, 0, 10, 10,
+ax_anim 2, 0, 72, 16, 11, 16, 16,
+ax_anim 2, 0, 71, 21, 21, 21, 21,
+ax_anim 2, 1, 71, 22, 20, 22, 20,
+ax_anim 2, 0, 71, 21, 21, 21, 21,
+ax_anim 2, 0, 71, 22, 20, 22, 20,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim_terminator
+sGrumpigAnims_3_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 6, 0, 78, -2, 0, -2, 0,
+ax_anim 2, 0, 77, 4, -5, 4, 0,
+ax_anim 2, 2, 77, 9, -7, 9, 0,
+ax_anim 2, 0, 77, 15, -6, 15, 0,
+ax_anim 2, 0, 76, 21, 0, 21, 0,
+ax_anim 2, 1, 76, 21, -1, 21, -1,
+ax_anim 2, 0, 76, 21, 0, 21, 0,
+ax_anim 2, 0, 76, 21, -1, 21, -1,
+ax_anim 2, 0, 74, 6, 0, 6, -1,
+ax_anim_terminator
+sGrumpigAnims_3_4:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 6, 0, 83, -2, 2, -2, 2,
+ax_anim 2, 0, 82, 3, -9, 3, -2,
+ax_anim 2, 2, 82, 8, -17, 8, -8,
+ax_anim 2, 0, 82, 16, -20, 16, -15,
+ax_anim 2, 0, 81, 20, -19, 20, -19,
+ax_anim 2, 1, 81, 21, -18, 21, -18,
+ax_anim 2, 0, 81, 20, -19, 20, -19,
+ax_anim 2, 0, 81, 21, -18, 21, -18,
+ax_anim 2, 0, 79, 7, -7, 7, -7,
+ax_anim_terminator
+sGrumpigAnims_3_5:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 6, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 87, 0, -5, 0, -1,
+ax_anim 2, 2, 87, 0, -11, 0, -6,
+ax_anim 2, 0, 87, 0, -15, 0, -15,
+ax_anim 2, 0, 86, 0, -18, 0, -18,
+ax_anim 2, 1, 86, 1, -18, 1, -18,
+ax_anim 2, 0, 86, 0, -18, 0, -18,
+ax_anim 2, 0, 86, 1, -18, 1, -18,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sGrumpigAnims_3_6:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 6, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 92, -3, -9, -3, -2,
+ax_anim 2, 2, 92, -8, -17, -8, -8,
+ax_anim 2, 0, 92, -16, -20, -16, -15,
+ax_anim 2, 0, 91, -20, -19, -20, -19,
+ax_anim 2, 1, 91, -21, -18, -21, -18,
+ax_anim 2, 0, 91, -20, -19, -20, -19,
+ax_anim 2, 0, 91, -21, -18, -21, -18,
+ax_anim 2, 0, 89, -7, -7, -7, -7,
+ax_anim_terminator
+sGrumpigAnims_3_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 6, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 97, -4, -5, -4, 0,
+ax_anim 2, 2, 97, -9, -7, -9, 0,
+ax_anim 2, 0, 97, -15, -6, -15, 0,
+ax_anim 2, 0, 96, -21, 0, -21, 0,
+ax_anim 2, 1, 96, -21, -1, -21, -1,
+ax_anim 2, 0, 96, -21, 0, -21, 0,
+ax_anim 2, 0, 96, -21, -1, -21, -1,
+ax_anim 2, 0, 94, -6, 0, -6, -1,
+ax_anim_terminator
+sGrumpigAnims_3_8:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 6, 0, 103, 2, -2, 2, -2,
+ax_anim 2, 0, 102, -3, -4, -3, 2,
+ax_anim 2, 2, 102, -10, 0, -10, 10,
+ax_anim 2, 0, 102, -16, 11, -16, 16,
+ax_anim 2, 0, 101, -21, 21, -21, 21,
+ax_anim 2, 1, 101, -22, 20, -22, 20,
+ax_anim 2, 0, 101, -21, 21, -21, 21,
+ax_anim 2, 0, 101, -22, 20, -22, 20,
+ax_anim 2, 0, 99, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sGrumpigAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sGrumpigAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sGrumpigAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 115, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sGrumpigAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 118, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sGrumpigAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 121, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sGrumpigAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sGrumpigAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_5_1:
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, -1, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 2, 135, 0, -1, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, -1, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, -1, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, -1, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 1, 151, 0, -1, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_5_2:
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, -1, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 2, 138, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, -1, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, -1, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 1, 130, 0, -1, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_5_3:
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, -1, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 2, 141, 0, -1, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, -1, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, -1, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 1, 133, 0, -1, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_5_4:
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 2, 144, 0, -1, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, -1, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, -1, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, -1, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 1, 136, 0, -1, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_5_5:
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 2, 147, 0, -1, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, -1, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, -1, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, -1, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 1, 139, 0, -1, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_5_6:
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 2, 150, 0, -1, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, -1, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, -1, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, -1, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 1, 142, 0, -1, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_5_7:
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 2, 129, 0, -1, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, -1, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, -1, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, -1, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, -1, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 1, 145, 0, -1, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_5_8:
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, -1, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 2, 132, 0, -1, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, -1, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, -1, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 1, 148, 0, -1, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sGrumpigAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sGrumpigAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sGrumpigAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sGrumpigAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sGrumpigAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sGrumpigAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sGrumpigAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_8_2:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_8_4:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_8_5:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_8_6:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 12, 0, 179, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 12, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_8_7:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 12, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim 12, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_8_8:
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 12, 0, 185, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 12, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 4, 7, 4,
+ax_anim 2, 0, 188, 10, 10, 10, 10,
+ax_anim 2, 0, 189, 9, 16, 9, 16,
+ax_anim 3, 0, 190, 0, 19, 0, 19,
+ax_anim 2, 3, 191, -9, 16, -9, 16,
+ax_anim 2, 0, 192, -10, 10, -10, 10,
+ax_anim 1, 0, 193, -7, 4, -7, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 1, 8, 1,
+ax_anim 2, 0, 187, 17, 4, 17, 4,
+ax_anim 2, 0, 188, 21, 12, 21, 12,
+ax_anim 3, 0, 189, 22, 19, 22, 19,
+ax_anim 2, 3, 190, 11, 19, 11, 19,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 16, -5, 16, -5,
+ax_anim 3, 0, 188, 22, 0, 22, 0,
+ax_anim 2, 3, 189, 17, 4, 17, 4,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 21, -21, 21, -21,
+ax_anim 2, 3, 188, 24, -13, 24, -13,
+ax_anim 2, 0, 189, 20, -5, 20, -5,
+ax_anim 1, 0, 190, 10, -1, 10, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -23, 0, -23,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 9, -12, 9, -12,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -21, -22, -21, -22,
+ax_anim 2, 3, 192, -24, -13, -24, -13,
+ax_anim 2, 0, 191, -20, -5, -20, -5,
+ax_anim 1, 0, 190, -10, -1, -10, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -16, -5, -16, -5,
+ax_anim 3, 0, 192, -22, 0, -22, 0,
+ax_anim 2, 3, 191, -17, 4, -17, 4,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 4, -17, 4,
+ax_anim 2, 0, 192, -21, 12, -21, 12,
+ax_anim 3, 0, 191, -22, 19, -22, 19,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -27, 0, 0,
+ax_anim 3, 0, 204, 0, -26, 0, 0,
+ax_anim 2, 0, 204, 0, -20, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -24, 0, 0,
+ax_anim 3, 0, 207, 0, -23, 0, 0,
+ax_anim 2, 0, 207, 0, -20, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -24, 0, 0,
+ax_anim 3, 0, 210, 0, -23, 0, 0,
+ax_anim 2, 0, 210, 0, -20, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -19, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -24, 0, 0,
+ax_anim 3, 0, 216, 0, -23, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 219, 0, -19, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -24, 0, 0,
+ax_anim 3, 0, 222, 0, -23, 0, 0,
+ax_anim 2, 0, 222, 0, -20, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -24, 0, 0,
+ax_anim 3, 0, 225, 0, -23, 0, 0,
+ax_anim 2, 0, 225, 0, -20, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGrumpigAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sGrumpigGfx1:
+.incbin "baserom.gba", 0x134D328, 0x200
+sGrumpigSprites1:
+ax_sprite sGrumpigGfx1, 0x200
+ax_sprite_terminator
+sGrumpigGfx2:
+.incbin "baserom.gba", 0x134D538, 0x200
+sGrumpigSprites2:
+ax_sprite sGrumpigGfx2, 0x200
+ax_sprite_terminator
+sGrumpigGfx3:
+.incbin "baserom.gba", 0x134D748, 0x200
+sGrumpigSprites3:
+ax_sprite sGrumpigGfx3, 0x200
+ax_sprite_terminator
+sGrumpigGfx4:
+.incbin "baserom.gba", 0x134D958, 0x200
+sGrumpigSprites4:
+ax_sprite sGrumpigGfx4, 0x200
+ax_sprite_terminator
+sGrumpigGfx5:
+.incbin "baserom.gba", 0x134DB68, 0x200
+sGrumpigSprites5:
+ax_sprite sGrumpigGfx5, 0x200
+ax_sprite_terminator
+sGrumpigGfx6:
+.incbin "baserom.gba", 0x134DD78, 0x200
+sGrumpigSprites6:
+ax_sprite sGrumpigGfx6, 0x200
+ax_sprite_terminator
+sGrumpigGfx7:
+.incbin "baserom.gba", 0x134DF88, 0x200
+sGrumpigSprites7:
+ax_sprite sGrumpigGfx7, 0x200
+ax_sprite_terminator
+sGrumpigGfx8:
+.incbin "baserom.gba", 0x134E198, 0x200
+sGrumpigSprites8:
+ax_sprite sGrumpigGfx8, 0x200
+ax_sprite_terminator
+sGrumpigGfx9:
+.incbin "baserom.gba", 0x134E3A8, 0x200
+sGrumpigSprites9:
+ax_sprite sGrumpigGfx9, 0x200
+ax_sprite_terminator
+sGrumpigGfx10:
+.incbin "baserom.gba", 0x134E5B8, 0x200
+sGrumpigSprites10:
+ax_sprite sGrumpigGfx10, 0x200
+ax_sprite_terminator
+sGrumpigGfx11:
+.incbin "baserom.gba", 0x134E7C8, 0x200
+sGrumpigSprites11:
+ax_sprite sGrumpigGfx11, 0x200
+ax_sprite_terminator
+sGrumpigGfx12:
+.incbin "baserom.gba", 0x134E9D8, 0x200
+sGrumpigSprites12:
+ax_sprite sGrumpigGfx12, 0x200
+ax_sprite_terminator
+sGrumpigGfx13:
+.incbin "baserom.gba", 0x134EBE8, 0x200
+sGrumpigSprites13:
+ax_sprite sGrumpigGfx13, 0x200
+ax_sprite_terminator
+sGrumpigGfx14:
+.incbin "baserom.gba", 0x134EDF8, 0x200
+sGrumpigSprites14:
+ax_sprite sGrumpigGfx14, 0x200
+ax_sprite_terminator
+sGrumpigGfx15:
+.incbin "baserom.gba", 0x134F008, 0x200
+sGrumpigSprites15:
+ax_sprite sGrumpigGfx15, 0x200
+ax_sprite_terminator
+sGrumpigGfx16:
+.incbin "baserom.gba", 0x134F218, 0x160
+sGrumpigGfx16_1:
+.incbin "baserom.gba", 0x134F378, 0x40
+sGrumpigSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx16, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrumpigGfx17:
+.incbin "baserom.gba", 0x134F3E8, 0x100
+sGrumpigGfx17_1:
+.incbin "baserom.gba", 0x134F4E8, 0x60
+sGrumpigSprites17:
+ax_sprite 0, 0x80
+ax_sprite sGrumpigGfx17, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx17_1, 0x60
+ax_sprite_terminator
+sGrumpigGfx18:
+.incbin "baserom.gba", 0x134F570, 0x160
+sGrumpigGfx18_1:
+.incbin "baserom.gba", 0x134F6D0, 0x60
+sGrumpigSprites18:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx18, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx18_1, 0x60
+ax_sprite_terminator
+sGrumpigGfx19:
+.incbin "baserom.gba", 0x134F758, 0x40
+sGrumpigGfx19_1:
+.incbin "baserom.gba", 0x134F798, 0x100
+sGrumpigGfx19_2:
+.incbin "baserom.gba", 0x134F898, 0x60
+sGrumpigSprites19:
+ax_sprite sGrumpigGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrumpigGfx19_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx19_2, 0x60
+ax_sprite_terminator
+sGrumpigGfx20:
+.incbin "baserom.gba", 0x134F928, 0x40
+sGrumpigGfx20_1:
+.incbin "baserom.gba", 0x134F968, 0x60
+sGrumpigGfx20_2:
+.incbin "baserom.gba", 0x134F9C8, 0x80
+sGrumpigGfx20_3:
+.incbin "baserom.gba", 0x134FA48, 0x60
+sGrumpigSprites20:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx20_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx20_3, 0x60
+ax_sprite_terminator
+sGrumpigGfx21:
+.incbin "baserom.gba", 0x134FAF0, 0x20
+sGrumpigGfx21_1:
+.incbin "baserom.gba", 0x134FB10, 0x60
+sGrumpigGfx21_2:
+.incbin "baserom.gba", 0x134FB70, 0x80
+sGrumpigGfx21_3:
+.incbin "baserom.gba", 0x134FBF0, 0x60
+sGrumpigSprites21:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGrumpigGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx21_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx21_3, 0x60
+ax_sprite_terminator
+sGrumpigGfx22:
+.incbin "baserom.gba", 0x134FC98, 0x60
+sGrumpigGfx22_1:
+.incbin "baserom.gba", 0x134FCF8, 0xE0
+sGrumpigGfx22_2:
+.incbin "baserom.gba", 0x134FDD8, 0x60
+sGrumpigSprites22:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx22_2, 0x60
+ax_sprite_terminator
+sGrumpigGfx23:
+.incbin "baserom.gba", 0x134FE70, 0x40
+sGrumpigGfx23_1:
+.incbin "baserom.gba", 0x134FEB0, 0x60
+sGrumpigGfx23_2:
+.incbin "baserom.gba", 0x134FF10, 0x80
+sGrumpigGfx23_3:
+.incbin "baserom.gba", 0x134FF90, 0x60
+sGrumpigSprites23:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx23_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx23_3, 0x60
+ax_sprite_terminator
+sGrumpigGfx24:
+.incbin "baserom.gba", 0x1350038, 0x160
+sGrumpigGfx24_1:
+.incbin "baserom.gba", 0x1350198, 0x40
+sGrumpigSprites24:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGrumpigGfx25:
+.incbin "baserom.gba", 0x1350208, 0x160
+sGrumpigGfx25_1:
+.incbin "baserom.gba", 0x1350368, 0x60
+sGrumpigSprites25:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx25, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx25_1, 0x60
+ax_sprite_terminator
+sGrumpigGfx26:
+.incbin "baserom.gba", 0x13503F0, 0x180
+sGrumpigSprites26:
+ax_sprite 0, 0x80
+ax_sprite sGrumpigGfx26, 0x180
+ax_sprite_terminator
+sGrumpigGfx27:
+.incbin "baserom.gba", 0x1350588, 0x40
+sGrumpigGfx27_1:
+.incbin "baserom.gba", 0x13505C8, 0x60
+sGrumpigGfx27_2:
+.incbin "baserom.gba", 0x1350628, 0x80
+sGrumpigGfx27_3:
+.incbin "baserom.gba", 0x13506A8, 0x60
+sGrumpigSprites27:
+ax_sprite sGrumpigGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGrumpigGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx27_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx27_3, 0x60
+ax_sprite_terminator
+sGrumpigGfx28:
+.incbin "baserom.gba", 0x1350748, 0x20
+sGrumpigGfx28_1:
+.incbin "baserom.gba", 0x1350768, 0x60
+sGrumpigGfx28_2:
+.incbin "baserom.gba", 0x13507C8, 0x80
+sGrumpigGfx28_3:
+.incbin "baserom.gba", 0x1350848, 0x60
+sGrumpigSprites28:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGrumpigGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx28_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx28_3, 0x60
+ax_sprite_terminator
+sGrumpigGfx29:
+.incbin "baserom.gba", 0x13508F0, 0x60
+sGrumpigGfx29_1:
+.incbin "baserom.gba", 0x1350950, 0x80
+sGrumpigGfx29_2:
+.incbin "baserom.gba", 0x13509D0, 0x60
+sGrumpigGfx29_3:
+.incbin "baserom.gba", 0x1350A30, 0x60
+sGrumpigSprites29:
+ax_sprite sGrumpigGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx29_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx29_3, 0x60
+ax_sprite_terminator
+sGrumpigGfx30:
+.incbin "baserom.gba", 0x1350AD0, 0x1E0
+sGrumpigSprites30:
+ax_sprite 0, 0x20
+ax_sprite sGrumpigGfx30, 0x1e0
+ax_sprite_terminator
+sGrumpigGfx31:
+.incbin "baserom.gba", 0x1350CC8, 0x200
+sGrumpigSprites31:
+ax_sprite sGrumpigGfx31, 0x200
+ax_sprite_terminator
+sGrumpigGfx32:
+.incbin "baserom.gba", 0x1350ED8, 0x200
+sGrumpigSprites32:
+ax_sprite sGrumpigGfx32, 0x200
+ax_sprite_terminator
+sGrumpigGfx33:
+.incbin "baserom.gba", 0x13510E8, 0x200
+sGrumpigSprites33:
+ax_sprite sGrumpigGfx33, 0x200
+ax_sprite_terminator
+sGrumpigGfx34:
+.incbin "baserom.gba", 0x13512F8, 0x200
+sGrumpigSprites34:
+ax_sprite sGrumpigGfx34, 0x200
+ax_sprite_terminator
+sGrumpigGfx35:
+.incbin "baserom.gba", 0x1351508, 0x200
+sGrumpigSprites35:
+ax_sprite sGrumpigGfx35, 0x200
+ax_sprite_terminator
+sGrumpigGfx36:
+.incbin "baserom.gba", 0x1351718, 0x200
+sGrumpigSprites36:
+ax_sprite sGrumpigGfx36, 0x200
+ax_sprite_terminator
+sGrumpigGfx37:
+.incbin "baserom.gba", 0x1351928, 0x80
+sGrumpigSprites37:
+ax_sprite sGrumpigGfx37, 0x80
+ax_sprite_terminator
+sGrumpigGfx38:
+.incbin "baserom.gba", 0x13519B8, 0x20
+sGrumpigSprites38:
+ax_sprite sGrumpigGfx38, 0x20
+ax_sprite_terminator
+sGrumpigGfx39:
+.incbin "baserom.gba", 0x13519E8, 0x20
+sGrumpigSprites39:
+ax_sprite sGrumpigGfx39, 0x20
+ax_sprite_terminator
+sGrumpigGfx40:
+.incbin "baserom.gba", 0x1351A18, 0x20
+sGrumpigSprites40:
+ax_sprite sGrumpigGfx40, 0x20
+ax_sprite_terminator
+sGrumpigGfx41:
+.incbin "baserom.gba", 0x1351A48, 0x100
+sGrumpigSprites41:
+ax_sprite sGrumpigGfx41, 0x100
+ax_sprite_terminator
+sAxPosesGrumpig:
+.4byte sGrumpigPose1
+.4byte sGrumpigPose2
+.4byte sGrumpigPose3
+.4byte sGrumpigPose4
+.4byte sGrumpigPose5
+.4byte sGrumpigPose6
+.4byte sGrumpigPose7
+.4byte sGrumpigPose8
+.4byte sGrumpigPose9
+.4byte sGrumpigPose10
+.4byte sGrumpigPose11
+.4byte sGrumpigPose12
+.4byte sGrumpigPose13
+.4byte sGrumpigPose14
+.4byte sGrumpigPose15
+.4byte sGrumpigPose16
+.4byte sGrumpigPose17
+.4byte sGrumpigPose18
+.4byte sGrumpigPose19
+.4byte sGrumpigPose20
+.4byte sGrumpigPose21
+.4byte sGrumpigPose22
+.4byte sGrumpigPose23
+.4byte sGrumpigPose24
+.4byte sGrumpigPose25
+.4byte sGrumpigPose26
+.4byte sGrumpigPose27
+.4byte sGrumpigPose28
+.4byte sGrumpigPose29
+.4byte sGrumpigPose30
+.4byte sGrumpigPose31
+.4byte sGrumpigPose32
+.4byte sGrumpigPose33
+.4byte sGrumpigPose34
+.4byte sGrumpigPose35
+.4byte sGrumpigPose36
+.4byte sGrumpigPose37
+.4byte sGrumpigPose38
+.4byte sGrumpigPose39
+.4byte sGrumpigPose40
+.4byte sGrumpigPose41
+.4byte sGrumpigPose42
+.4byte sGrumpigPose43
+.4byte sGrumpigPose44
+.4byte sGrumpigPose45
+.4byte sGrumpigPose46
+.4byte sGrumpigPose47
+.4byte sGrumpigPose48
+.4byte sGrumpigPose49
+.4byte sGrumpigPose50
+.4byte sGrumpigPose51
+.4byte sGrumpigPose52
+.4byte sGrumpigPose53
+.4byte sGrumpigPose54
+.4byte sGrumpigPose55
+.4byte sGrumpigPose56
+.4byte sGrumpigPose57
+.4byte sGrumpigPose58
+.4byte sGrumpigPose59
+.4byte sGrumpigPose60
+.4byte sGrumpigPose61
+.4byte sGrumpigPose62
+.4byte sGrumpigPose63
+.4byte sGrumpigPose64
+.4byte sGrumpigPose65
+.4byte sGrumpigPose66
+.4byte sGrumpigPose67
+.4byte sGrumpigPose68
+.4byte sGrumpigPose69
+.4byte sGrumpigPose70
+.4byte sGrumpigPose71
+.4byte sGrumpigPose72
+.4byte sGrumpigPose73
+.4byte sGrumpigPose74
+.4byte sGrumpigPose75
+.4byte sGrumpigPose76
+.4byte sGrumpigPose77
+.4byte sGrumpigPose78
+.4byte sGrumpigPose79
+.4byte sGrumpigPose80
+.4byte sGrumpigPose81
+.4byte sGrumpigPose82
+.4byte sGrumpigPose83
+.4byte sGrumpigPose84
+.4byte sGrumpigPose85
+.4byte sGrumpigPose86
+.4byte sGrumpigPose87
+.4byte sGrumpigPose88
+.4byte sGrumpigPose89
+.4byte sGrumpigPose90
+.4byte sGrumpigPose91
+.4byte sGrumpigPose92
+.4byte sGrumpigPose93
+.4byte sGrumpigPose94
+.4byte sGrumpigPose95
+.4byte sGrumpigPose96
+.4byte sGrumpigPose97
+.4byte sGrumpigPose98
+.4byte sGrumpigPose99
+.4byte sGrumpigPose100
+.4byte sGrumpigPose101
+.4byte sGrumpigPose102
+.4byte sGrumpigPose103
+.4byte sGrumpigPose104
+.4byte sGrumpigPose105
+.4byte sGrumpigPose106
+.4byte sGrumpigPose107
+.4byte sGrumpigPose108
+.4byte sGrumpigPose109
+.4byte sGrumpigPose110
+.4byte sGrumpigPose111
+.4byte sGrumpigPose112
+.4byte sGrumpigPose113
+.4byte sGrumpigPose114
+.4byte sGrumpigPose115
+.4byte sGrumpigPose116
+.4byte sGrumpigPose117
+.4byte sGrumpigPose118
+.4byte sGrumpigPose119
+.4byte sGrumpigPose120
+.4byte sGrumpigPose121
+.4byte sGrumpigPose122
+.4byte sGrumpigPose123
+.4byte sGrumpigPose124
+.4byte sGrumpigPose125
+.4byte sGrumpigPose126
+.4byte sGrumpigPose127
+.4byte sGrumpigPose128
+.4byte sGrumpigPose129
+.4byte sGrumpigPose130
+.4byte sGrumpigPose131
+.4byte sGrumpigPose132
+.4byte sGrumpigPose133
+.4byte sGrumpigPose134
+.4byte sGrumpigPose135
+.4byte sGrumpigPose136
+.4byte sGrumpigPose137
+.4byte sGrumpigPose138
+.4byte sGrumpigPose139
+.4byte sGrumpigPose140
+.4byte sGrumpigPose141
+.4byte sGrumpigPose142
+.4byte sGrumpigPose143
+.4byte sGrumpigPose144
+.4byte sGrumpigPose145
+.4byte sGrumpigPose146
+.4byte sGrumpigPose147
+.4byte sGrumpigPose148
+.4byte sGrumpigPose149
+.4byte sGrumpigPose150
+.4byte sGrumpigPose151
+.4byte sGrumpigPose152
+.4byte sGrumpigPose153
+.4byte sGrumpigPose154
+.4byte sGrumpigPose155
+.4byte sGrumpigPose156
+.4byte sGrumpigPose157
+.4byte sGrumpigPose158
+.4byte sGrumpigPose159
+.4byte sGrumpigPose160
+.4byte sGrumpigPose161
+.4byte sGrumpigPose162
+.4byte sGrumpigPose163
+.4byte sGrumpigPose164
+.4byte sGrumpigPose165
+.4byte sGrumpigPose166
+.4byte sGrumpigPose167
+.4byte sGrumpigPose168
+.4byte sGrumpigPose169
+.4byte sGrumpigPose170
+.4byte sGrumpigPose171
+.4byte sGrumpigPose172
+.4byte sGrumpigPose173
+.4byte sGrumpigPose174
+.4byte sGrumpigPose175
+.4byte sGrumpigPose176
+.4byte sGrumpigPose177
+.4byte sGrumpigPose178
+.4byte sGrumpigPose179
+.4byte sGrumpigPose180
+.4byte sGrumpigPose181
+.4byte sGrumpigPose182
+.4byte sGrumpigPose183
+.4byte sGrumpigPose184
+.4byte sGrumpigPose185
+.4byte sGrumpigPose186
+.4byte sGrumpigPose187
+.4byte sGrumpigPose188
+.4byte sGrumpigPose189
+.4byte sGrumpigPose190
+.4byte sGrumpigPose191
+.4byte sGrumpigPose192
+.4byte sGrumpigPose193
+.4byte sGrumpigPose194
+.4byte sGrumpigPose195
+.4byte sGrumpigPose196
+.4byte sGrumpigPose197
+.4byte sGrumpigPose198
+.4byte sGrumpigPose199
+.4byte sGrumpigPose200
+.4byte sGrumpigPose201
+.4byte sGrumpigPose202
+.4byte sGrumpigPose203
+.4byte sGrumpigPose204
+.4byte sGrumpigPose205
+.4byte sGrumpigPose206
+.4byte sGrumpigPose207
+.4byte sGrumpigPose208
+.4byte sGrumpigPose209
+.4byte sGrumpigPose210
+.4byte sGrumpigPose211
+.4byte sGrumpigPose212
+.4byte sGrumpigPose213
+.4byte sGrumpigPose214
+.4byte sGrumpigPose215
+.4byte sGrumpigPose216
+.4byte sGrumpigPose217
+.4byte sGrumpigPose218
+.4byte sGrumpigPose219
+.4byte sGrumpigPose220
+.4byte sGrumpigPose221
+.4byte sGrumpigPose222
+.4byte sGrumpigPose223
+.4byte sGrumpigPose224
+.4byte sGrumpigPose225
+.4byte sGrumpigPose226
+.4byte sGrumpigPose227
+.4byte sGrumpigPose228
+.4byte sGrumpigPose229
+.4byte sGrumpigPose230
+.4byte sGrumpigPose231
+.4byte sGrumpigPose232
+.4byte sGrumpigPose233
+.4byte sGrumpigPose234
+.4byte sGrumpigPose235
+.4byte sGrumpigPose236
+.4byte sGrumpigPose237
+.4byte sGrumpigPose238
+.4byte sGrumpigPose239
+.4byte sGrumpigPose240
+.4byte sGrumpigPose241
+.4byte sGrumpigPose242
+sAxPositionsGrumpig:
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -2,  -10, 	  -6,   -6, 	   7,  -11, 	  -1,   -7
+.2byte    0,  -10, 	  -9,  -11, 	   4,   -5, 	  -1,   -7
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+.2byte    2,  -11, 	   6,  -12, 	   0,   -4, 	  -1,   -6
+.2byte    4,  -11, 	   8,   -6, 	  -9,   -5, 	  -2,   -6
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    4,  -11, 	  -6,   -7, 	   5,   -5, 	  -2,   -4
+.2byte    5,  -12, 	   6,   -7, 	  -5,   -3, 	  -1,   -5
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    6,  -13, 	  -7,   -8, 	   7,   -8, 	  -3,   -7
+.2byte    4,  -14, 	  -3,   -8, 	   1,   -3, 	  -2,   -6
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte    0,  -16, 	   9,   -8, 	  -7,  -10, 	   0,   -7
+.2byte   -2,  -16, 	   6,  -10, 	 -11,   -8, 	  -2,   -7
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -7,  -13, 	   6,   -8, 	  -8,   -8, 	   2,   -7
+.2byte   -5,  -14, 	   2,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -5,  -11, 	   5,   -7, 	  -6,   -5, 	   1,   -4
+.2byte   -6,  -12, 	  -7,   -7, 	   4,   -3, 	   0,   -5
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -8,  -12, 	  -2,   -4, 	  -1,   -6
+.2byte   -6,  -11, 	 -10,   -6, 	   7,   -5, 	   0,   -6
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -2,  -10, 	  -6,   -6, 	   7,  -11, 	  -1,   -7
+.2byte    0,  -10, 	  -9,  -11, 	   4,   -5, 	  -1,   -7
+.2byte   -1,  -14, 	 -11,  -11, 	   9,  -11, 	  -1,  -10
+.2byte   -1,   -8, 	  -8,   -8, 	   6,   -8, 	  -1,   -5
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+.2byte    2,  -11, 	   6,  -12, 	   0,   -4, 	  -1,   -6
+.2byte    4,  -11, 	   8,   -6, 	  -9,   -5, 	  -2,   -6
+.2byte    3,  -14, 	   7,  -13, 	  -9,   -6, 	  -1,   -8
+.2byte    3,   -9, 	  10,  -12, 	  -2,   -8, 	   0,   -6
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    4,  -11, 	  -6,   -7, 	   5,   -5, 	  -2,   -4
+.2byte    5,  -12, 	   6,   -7, 	  -5,   -3, 	  -1,   -5
+.2byte    6,  -15, 	   0,   -7, 	   2,   -4, 	  -2,   -7
+.2byte    6,  -10, 	   8,  -15, 	   7,   -8, 	  -2,   -6
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    6,  -13, 	  -7,   -8, 	   7,   -8, 	  -3,   -7
+.2byte    4,  -14, 	  -3,   -8, 	   1,   -3, 	  -2,   -6
+.2byte    6,  -17, 	  -8,  -13, 	   9,   -7, 	  -1,   -9
+.2byte    5,  -11, 	  -1,  -16, 	   8,  -11, 	  -4,   -7
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte    0,  -16, 	   9,   -8, 	  -7,  -10, 	   0,   -7
+.2byte   -2,  -16, 	   6,  -10, 	 -11,   -8, 	  -2,   -7
+.2byte   -1,  -17, 	  10,   -9, 	 -11,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   5,  -16, 	  -7,  -16, 	  -1,   -8
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -7,  -13, 	   6,   -8, 	  -8,   -8, 	   2,   -7
+.2byte   -5,  -14, 	   2,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   -7,  -17, 	   7,  -13, 	 -10,   -7, 	   0,   -9
+.2byte   -6,  -11, 	   0,  -16, 	  -9,  -11, 	   3,   -7
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -5,  -11, 	   5,   -7, 	  -6,   -5, 	   1,   -4
+.2byte   -6,  -12, 	  -7,   -7, 	   4,   -3, 	   0,   -5
+.2byte   -7,  -15, 	  -1,   -7, 	  -3,   -4, 	   1,   -7
+.2byte   -7,  -10, 	  -9,  -15, 	  -8,   -8, 	   1,   -6
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -8,  -12, 	  -2,   -4, 	  -1,   -6
+.2byte   -6,  -11, 	 -10,   -6, 	   7,   -5, 	   0,   -6
+.2byte   -5,  -14, 	  -9,  -13, 	   7,   -6, 	  -1,   -8
+.2byte   -5,   -9, 	 -12,  -12, 	   0,   -8, 	  -2,   -6
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -2,  -10, 	  -6,   -6, 	   7,  -11, 	  -1,   -7
+.2byte    0,  -10, 	  -9,  -11, 	   4,   -5, 	  -1,   -7
+.2byte   -1,  -14, 	 -11,  -11, 	   9,  -11, 	  -1,  -10
+.2byte   -1,   -8, 	  -8,   -8, 	   6,   -8, 	  -1,   -5
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+.2byte    2,  -11, 	   6,  -12, 	   0,   -4, 	  -1,   -6
+.2byte    4,  -11, 	   8,   -6, 	  -9,   -5, 	  -2,   -6
+.2byte    3,  -14, 	   7,  -13, 	  -9,   -6, 	  -1,   -8
+.2byte    3,   -9, 	  10,  -12, 	  -2,   -8, 	   0,   -6
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    4,  -11, 	  -6,   -7, 	   5,   -5, 	  -2,   -4
+.2byte    5,  -12, 	   6,   -7, 	  -5,   -3, 	  -1,   -5
+.2byte    6,  -15, 	   0,   -7, 	   2,   -4, 	  -2,   -7
+.2byte    6,  -10, 	   8,  -15, 	   7,   -8, 	  -2,   -6
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    6,  -13, 	  -7,   -8, 	   7,   -8, 	  -3,   -7
+.2byte    4,  -14, 	  -3,   -8, 	   1,   -3, 	  -2,   -6
+.2byte    6,  -17, 	  -8,  -13, 	   9,   -7, 	  -1,   -9
+.2byte    5,  -11, 	  -1,  -16, 	   8,  -11, 	  -4,   -7
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte    0,  -16, 	   9,   -8, 	  -7,  -10, 	   0,   -7
+.2byte   -2,  -16, 	   6,  -10, 	 -11,   -8, 	  -2,   -7
+.2byte   -1,  -17, 	  10,   -9, 	 -11,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   5,  -16, 	  -7,  -16, 	  -1,   -8
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -7,  -13, 	   6,   -8, 	  -8,   -8, 	   2,   -7
+.2byte   -5,  -14, 	   2,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   -7,  -17, 	   7,  -13, 	 -10,   -7, 	   0,   -9
+.2byte   -6,  -11, 	   0,  -16, 	  -9,  -11, 	   3,   -7
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -5,  -11, 	   5,   -7, 	  -6,   -5, 	   1,   -4
+.2byte   -6,  -12, 	  -7,   -7, 	   4,   -3, 	   0,   -5
+.2byte   -7,  -15, 	  -1,   -7, 	  -3,   -4, 	   1,   -7
+.2byte   -7,  -10, 	  -9,  -15, 	  -8,   -8, 	   1,   -6
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -8,  -12, 	  -2,   -4, 	  -1,   -6
+.2byte   -6,  -11, 	 -10,   -6, 	   7,   -5, 	   0,   -6
+.2byte   -5,  -14, 	  -9,  -13, 	   7,   -6, 	  -1,   -8
+.2byte   -5,   -9, 	 -12,  -12, 	   0,   -8, 	  -2,   -6
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -1,   -8, 	  -8,   -8, 	   6,   -8, 	  -1,   -5
+.2byte   -1,   -7, 	 -12,  -11, 	  10,  -11, 	  -1,   -5
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+.2byte    3,   -9, 	  10,  -12, 	  -2,   -8, 	   0,   -6
+.2byte    7,  -10, 	   1,  -10, 	 -10,   -8, 	  -1,   -7
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    6,  -10, 	   8,  -15, 	   7,   -8, 	  -2,   -6
+.2byte   10,  -11, 	  -6,   -7, 	  -6,   -5, 	  -1,   -7
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    5,  -11, 	  -1,  -16, 	   8,  -11, 	  -4,   -7
+.2byte    9,  -17, 	 -11,  -13, 	   3,   -4, 	  -3,   -9
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte   -1,  -15, 	   5,  -16, 	  -7,  -16, 	  -1,   -8
+.2byte   -1,  -18, 	  11,   -9, 	 -12,   -9, 	  -1,   -9
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -6,  -11, 	   0,  -16, 	  -9,  -11, 	   3,   -7
+.2byte  -10,  -17, 	  10,  -13, 	  -4,   -4, 	   2,   -9
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -7,  -10, 	  -9,  -15, 	  -8,   -8, 	   1,   -6
+.2byte  -11,  -11, 	   5,   -7, 	   5,   -5, 	   0,   -7
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -5,   -9, 	 -12,  -12, 	   0,   -8, 	  -2,   -6
+.2byte   -9,  -10, 	  -3,  -10, 	   8,   -8, 	  -1,   -7
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -2,  -10, 	  -6,   -6, 	   7,  -11, 	  -1,   -7
+.2byte    0,  -10, 	  -9,  -11, 	   4,   -5, 	  -1,   -7
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+.2byte    2,  -11, 	   6,  -12, 	   0,   -4, 	  -1,   -6
+.2byte    6,  -11, 	  10,   -6, 	  -7,   -5, 	   0,   -6
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    6,  -13, 	  -4,   -9, 	   7,   -7, 	   0,   -6
+.2byte    5,  -12, 	   6,   -7, 	  -5,   -3, 	  -1,   -5
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    6,  -13, 	  -7,   -8, 	   7,   -8, 	  -3,   -7
+.2byte    5,  -14, 	  -2,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte    0,  -16, 	   9,   -8, 	  -7,  -10, 	   0,   -7
+.2byte   -2,  -16, 	   6,  -10, 	 -11,   -8, 	  -2,   -7
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -8,  -14, 	   5,   -9, 	  -9,   -9, 	   1,   -8
+.2byte   -5,  -14, 	   2,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -5,  -12, 	   5,   -8, 	  -6,   -6, 	   1,   -5
+.2byte   -8,  -13, 	  -9,   -8, 	   2,   -4, 	  -2,   -6
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -6,  -11, 	 -10,  -12, 	  -4,   -4, 	  -3,   -6
+.2byte   -6,  -11, 	 -10,   -6, 	   7,   -5, 	   0,   -6
+.2byte    0,  -10, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte   -1,  -14, 	 -10,  -18, 	   8,  -18, 	  -1,   -8
+.2byte    1,  -14, 	  -1,  -18, 	 -12,  -15, 	  -1,   -9
+.2byte    0,  -17, 	  -8,  -20, 	 -12,  -17, 	  -2,   -9
+.2byte    0,  -17, 	  -9,  -22, 	   3,  -17, 	  -4,   -8
+.2byte   -1,  -15, 	   8,  -17, 	 -10,  -17, 	  -1,   -7
+.2byte   -1,  -17, 	   8,  -22, 	  -4,  -17, 	   3,   -8
+.2byte   -1,  -17, 	   7,  -20, 	  11,  -17, 	   1,   -9
+.2byte   -2,  -14, 	   0,  -18, 	  11,  -15, 	   0,   -9
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -2,  -10, 	  -6,   -6, 	   7,  -11, 	  -1,   -7
+.2byte    0,   -9, 	  -9,  -10, 	   4,   -4, 	  -1,   -6
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+.2byte    2,  -11, 	   6,  -12, 	   0,   -4, 	  -1,   -6
+.2byte    5,  -11, 	   9,   -6, 	  -8,   -5, 	  -1,   -6
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    4,  -11, 	  -6,   -7, 	   5,   -5, 	  -2,   -4
+.2byte    5,  -12, 	   6,   -7, 	  -5,   -3, 	  -1,   -5
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    6,  -13, 	  -7,   -8, 	   7,   -8, 	  -3,   -7
+.2byte    4,  -14, 	  -3,   -8, 	   1,   -3, 	  -2,   -6
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte    0,  -16, 	   9,   -8, 	  -7,  -10, 	   0,   -7
+.2byte   -2,  -16, 	   6,  -10, 	 -11,   -8, 	  -2,   -7
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -7,  -13, 	   6,   -8, 	  -8,   -8, 	   2,   -7
+.2byte   -5,  -14, 	   2,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -5,  -11, 	   5,   -7, 	  -6,   -5, 	   1,   -4
+.2byte   -6,  -12, 	  -7,   -7, 	   4,   -3, 	   0,   -5
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -8,  -12, 	  -2,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	 -11,   -6, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -7, 	 -12,  -11, 	  10,  -11, 	  -1,   -5
+.2byte   -9,  -10, 	  -3,  -10, 	   8,   -8, 	  -1,   -7
+.2byte  -11,  -11, 	   5,   -7, 	   5,   -5, 	   0,   -7
+.2byte  -10,  -16, 	  10,  -12, 	  -4,   -3, 	   2,   -8
+.2byte   -1,  -16, 	  11,   -7, 	 -12,   -7, 	  -1,   -7
+.2byte    9,  -16, 	 -11,  -12, 	   3,   -3, 	  -3,   -8
+.2byte   10,  -11, 	  -6,   -7, 	  -6,   -5, 	  -1,   -7
+.2byte    8,  -10, 	   2,  -10, 	  -9,   -8, 	   0,   -7
+.2byte   -1,  -14, 	 -11,  -11, 	   9,  -11, 	  -1,  -10
+.2byte    3,  -15, 	   7,  -14, 	  -9,   -7, 	  -1,   -9
+.2byte    6,  -16, 	   0,   -8, 	   2,   -5, 	  -2,   -8
+.2byte    6,  -18, 	  -8,  -14, 	   9,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	  10,   -9, 	 -11,   -9, 	  -1,   -9
+.2byte   -7,  -18, 	   7,  -14, 	 -10,   -8, 	   0,  -10
+.2byte   -7,  -16, 	  -1,   -8, 	  -3,   -5, 	   1,   -8
+.2byte   -5,  -15, 	  -9,  -14, 	   7,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -1,  -14, 	 -11,  -11, 	   9,  -11, 	  -1,  -10
+.2byte   -1,   -7, 	 -12,  -11, 	  10,  -11, 	  -1,   -5
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+.2byte    3,  -14, 	   7,  -13, 	  -9,   -6, 	  -1,   -8
+.2byte    6,  -10, 	   0,  -10, 	 -11,   -8, 	  -2,   -7
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    6,  -15, 	   0,   -7, 	   2,   -4, 	  -2,   -7
+.2byte    9,  -11, 	  -7,   -7, 	  -7,   -5, 	  -2,   -7
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    6,  -17, 	  -8,  -13, 	   9,   -7, 	  -1,   -9
+.2byte    8,  -16, 	 -12,  -12, 	   2,   -3, 	  -4,   -8
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte   -1,  -17, 	  10,   -9, 	 -11,   -9, 	  -1,   -9
+.2byte   -1,  -16, 	  11,   -7, 	 -12,   -7, 	  -1,   -7
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -7,  -17, 	   7,  -13, 	 -10,   -7, 	   0,   -9
+.2byte  -10,  -16, 	  10,  -12, 	  -4,   -3, 	   2,   -8
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -7,  -15, 	  -1,   -7, 	  -3,   -4, 	   1,   -7
+.2byte  -11,  -11, 	   5,   -7, 	   5,   -5, 	   0,   -7
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -5,  -14, 	  -9,  -13, 	   7,   -6, 	  -1,   -8
+.2byte   -8,  -10, 	  -2,  -10, 	   9,   -8, 	   0,   -7
+.2byte   -1,   -8, 	  -8,   -8, 	   6,   -8, 	  -1,   -5
+.2byte   -5,   -9, 	 -12,  -12, 	   0,   -8, 	  -2,   -6
+.2byte   -7,  -10, 	  -9,  -15, 	  -8,   -8, 	   1,   -6
+.2byte   -6,  -11, 	   0,  -16, 	  -9,  -11, 	   3,   -7
+.2byte   -1,  -14, 	   5,  -15, 	  -7,  -15, 	  -1,   -7
+.2byte    5,  -11, 	  -1,  -16, 	   8,  -11, 	  -4,   -7
+.2byte    6,  -10, 	   8,  -15, 	   7,   -8, 	  -2,   -6
+.2byte    3,   -9, 	  10,  -12, 	  -2,   -8, 	   0,   -6
+.2byte   -1,  -11, 	  -9,   -7, 	   7,   -7, 	  -1,   -8
+.2byte   -5,  -12, 	  -9,   -8, 	   2,   -4, 	  -1,   -6
+.2byte   -5,  -13, 	  -7,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -6,  -15, 	   4,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -8
+.2byte    5,  -15, 	  -5,  -10, 	   7,   -7, 	  -2,   -7
+.2byte    4,  -13, 	   6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte    3,  -12, 	   7,   -8, 	  -4,   -4, 	  -1,   -6
+sGrumpigAnimTable1:
+.4byte sGrumpigAnims_1_1
+.4byte sGrumpigAnims_1_2
+.4byte sGrumpigAnims_1_3
+.4byte sGrumpigAnims_1_4
+.4byte sGrumpigAnims_1_5
+.4byte sGrumpigAnims_1_6
+.4byte sGrumpigAnims_1_7
+.4byte sGrumpigAnims_1_8
+sGrumpigAnimTable2:
+.4byte sGrumpigAnims_2_1
+.4byte sGrumpigAnims_2_2
+.4byte sGrumpigAnims_2_3
+.4byte sGrumpigAnims_2_4
+.4byte sGrumpigAnims_2_5
+.4byte sGrumpigAnims_2_6
+.4byte sGrumpigAnims_2_7
+.4byte sGrumpigAnims_2_8
+sGrumpigAnimTable3:
+.4byte sGrumpigAnims_3_1
+.4byte sGrumpigAnims_3_2
+.4byte sGrumpigAnims_3_3
+.4byte sGrumpigAnims_3_4
+.4byte sGrumpigAnims_3_5
+.4byte sGrumpigAnims_3_6
+.4byte sGrumpigAnims_3_7
+.4byte sGrumpigAnims_3_8
+sGrumpigAnimTable4:
+.4byte sGrumpigAnims_4_1
+.4byte sGrumpigAnims_4_2
+.4byte sGrumpigAnims_4_3
+.4byte sGrumpigAnims_4_4
+.4byte sGrumpigAnims_4_5
+.4byte sGrumpigAnims_4_6
+.4byte sGrumpigAnims_4_7
+.4byte sGrumpigAnims_4_8
+sGrumpigAnimTable5:
+.4byte sGrumpigAnims_5_1
+.4byte sGrumpigAnims_5_2
+.4byte sGrumpigAnims_5_3
+.4byte sGrumpigAnims_5_4
+.4byte sGrumpigAnims_5_5
+.4byte sGrumpigAnims_5_6
+.4byte sGrumpigAnims_5_7
+.4byte sGrumpigAnims_5_8
+sGrumpigAnimTable6:
+.4byte sGrumpigAnims_6_1
+.4byte sGrumpigAnims_6_1
+.4byte sGrumpigAnims_6_1
+.4byte sGrumpigAnims_6_1
+.4byte sGrumpigAnims_6_1
+.4byte sGrumpigAnims_6_1
+.4byte sGrumpigAnims_6_1
+.4byte sGrumpigAnims_6_1
+sGrumpigAnimTable7:
+.4byte sGrumpigAnims_7_1
+.4byte sGrumpigAnims_7_2
+.4byte sGrumpigAnims_7_3
+.4byte sGrumpigAnims_7_4
+.4byte sGrumpigAnims_7_5
+.4byte sGrumpigAnims_7_6
+.4byte sGrumpigAnims_7_7
+.4byte sGrumpigAnims_7_8
+sGrumpigAnimTable8:
+.4byte sGrumpigAnims_8_1
+.4byte sGrumpigAnims_8_2
+.4byte sGrumpigAnims_8_3
+.4byte sGrumpigAnims_8_4
+.4byte sGrumpigAnims_8_5
+.4byte sGrumpigAnims_8_6
+.4byte sGrumpigAnims_8_7
+.4byte sGrumpigAnims_8_8
+sGrumpigAnimTable9:
+.4byte sGrumpigAnims_9_1
+.4byte sGrumpigAnims_9_2
+.4byte sGrumpigAnims_9_3
+.4byte sGrumpigAnims_9_4
+.4byte sGrumpigAnims_9_5
+.4byte sGrumpigAnims_9_6
+.4byte sGrumpigAnims_9_7
+.4byte sGrumpigAnims_9_8
+sGrumpigAnimTable10:
+.4byte sGrumpigAnims_10_1
+.4byte sGrumpigAnims_10_2
+.4byte sGrumpigAnims_10_3
+.4byte sGrumpigAnims_10_4
+.4byte sGrumpigAnims_10_5
+.4byte sGrumpigAnims_10_6
+.4byte sGrumpigAnims_10_7
+.4byte sGrumpigAnims_10_8
+sGrumpigAnimTable11:
+.4byte sGrumpigAnims_11_1
+.4byte sGrumpigAnims_11_2
+.4byte sGrumpigAnims_11_3
+.4byte sGrumpigAnims_11_4
+.4byte sGrumpigAnims_11_5
+.4byte sGrumpigAnims_11_6
+.4byte sGrumpigAnims_11_7
+.4byte sGrumpigAnims_11_8
+sGrumpigAnimTable12:
+.4byte sGrumpigAnims_12_1
+.4byte sGrumpigAnims_12_2
+.4byte sGrumpigAnims_12_3
+.4byte sGrumpigAnims_12_4
+.4byte sGrumpigAnims_12_5
+.4byte sGrumpigAnims_12_6
+.4byte sGrumpigAnims_12_7
+.4byte sGrumpigAnims_12_8
+sGrumpigAnimTable13:
+.4byte sGrumpigAnims_13_1
+.4byte sGrumpigAnims_13_2
+.4byte sGrumpigAnims_13_3
+.4byte sGrumpigAnims_13_4
+.4byte sGrumpigAnims_13_5
+.4byte sGrumpigAnims_13_6
+.4byte sGrumpigAnims_13_7
+.4byte sGrumpigAnims_13_8
+sAxAnimationsGrumpig:
+.4byte sGrumpigAnimTable1
+.4byte sGrumpigAnimTable2
+.4byte sGrumpigAnimTable3
+.4byte sGrumpigAnimTable4
+.4byte sGrumpigAnimTable5
+.4byte sGrumpigAnimTable6
+.4byte sGrumpigAnimTable7
+.4byte sGrumpigAnimTable8
+.4byte sGrumpigAnimTable9
+.4byte sGrumpigAnimTable10
+.4byte sGrumpigAnimTable11
+.4byte sGrumpigAnimTable12
+.4byte sGrumpigAnimTable13
+sAxSpritesGrumpig:
+.4byte sGrumpigSprites1
+.4byte sGrumpigSprites2
+.4byte sGrumpigSprites3
+.4byte sGrumpigSprites4
+.4byte sGrumpigSprites5
+.4byte sGrumpigSprites6
+.4byte sGrumpigSprites7
+.4byte sGrumpigSprites8
+.4byte sGrumpigSprites9
+.4byte sGrumpigSprites10
+.4byte sGrumpigSprites11
+.4byte sGrumpigSprites12
+.4byte sGrumpigSprites13
+.4byte sGrumpigSprites14
+.4byte sGrumpigSprites15
+.4byte sGrumpigSprites16
+.4byte sGrumpigSprites17
+.4byte sGrumpigSprites18
+.4byte sGrumpigSprites19
+.4byte sGrumpigSprites20
+.4byte sGrumpigSprites21
+.4byte sGrumpigSprites22
+.4byte sGrumpigSprites23
+.4byte sGrumpigSprites24
+.4byte sGrumpigSprites25
+.4byte sGrumpigSprites26
+.4byte sGrumpigSprites27
+.4byte sGrumpigSprites28
+.4byte sGrumpigSprites29
+.4byte sGrumpigSprites30
+.4byte sGrumpigSprites31
+.4byte sGrumpigSprites32
+.4byte sGrumpigSprites33
+.4byte sGrumpigSprites34
+.4byte sGrumpigSprites35
+.4byte sGrumpigSprites36
+.4byte sGrumpigSprites37
+.4byte sGrumpigSprites38
+.4byte sGrumpigSprites39
+.4byte sGrumpigSprites40
+.4byte sGrumpigSprites41
+sAxMainGrumpig:
+ax_main sAxPosesGrumpig, sAxAnimationsGrumpig, 13, sAxSpritesGrumpig, sAxPositionsGrumpig

--- a/data/ax/gulpin.inc
+++ b/data/ax/gulpin.inc
@@ -1,0 +1,3019 @@
+.global gAxGulpin
+gAxGulpin:
+ax_siro sAxMainGulpin
+sGulpinPose1:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose2:
+ax_pose 1, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose3:
+ax_pose 2, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose4:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose5:
+ax_pose 4, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose6:
+ax_pose 5, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose7:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose8:
+ax_pose 7, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose9:
+ax_pose 8, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose10:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose11:
+ax_pose 10, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose12:
+ax_pose 11, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose13:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose14:
+ax_pose 13, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose15:
+ax_pose 14, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose16:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose17:
+ax_pose 10, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose18:
+ax_pose 11, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose19:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose20:
+ax_pose 7, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose21:
+ax_pose 8, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose22:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose23:
+ax_pose 4, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose24:
+ax_pose 5, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose25:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose26:
+ax_pose 1, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose27:
+ax_pose 2, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose28:
+ax_pose 15, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose29:
+ax_pose 16, 0x81ed, 0x80f7, 0xac00
+ax_pose 17, 0x01fd, 0x0107, 0xac08
+ax_pose_terminator
+sGulpinPose30:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose31:
+ax_pose 4, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose32:
+ax_pose 5, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose33:
+ax_pose 18, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose34:
+ax_pose 19, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose35:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose36:
+ax_pose 7, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose37:
+ax_pose 8, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose38:
+ax_pose 20, 0x01ee, 0x90ee, 0xac00
+ax_pose_terminator
+sGulpinPose39:
+ax_pose 21, 0x81ec, 0x90fa, 0xac00
+ax_pose 22, 0x01fc, 0x10f2, 0xac08
+ax_pose_terminator
+sGulpinPose40:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose41:
+ax_pose 10, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose42:
+ax_pose 11, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose43:
+ax_pose 23, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose44:
+ax_pose 24, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose45:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose46:
+ax_pose 13, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose47:
+ax_pose 14, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose48:
+ax_pose 25, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose49:
+ax_pose 26, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose50:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose51:
+ax_pose 10, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose52:
+ax_pose 11, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose53:
+ax_pose 23, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose54:
+ax_pose 24, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose55:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose56:
+ax_pose 7, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose57:
+ax_pose 8, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose58:
+ax_pose 20, 0x01ee, 0x80f2, 0xac00
+ax_pose_terminator
+sGulpinPose59:
+ax_pose 21, 0x81ec, 0x80f6, 0xac00
+ax_pose 22, 0x01fc, 0x0106, 0xac08
+ax_pose_terminator
+sGulpinPose60:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose61:
+ax_pose 4, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose62:
+ax_pose 5, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose63:
+ax_pose 18, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose64:
+ax_pose 19, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose65:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose66:
+ax_pose 1, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose67:
+ax_pose 2, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose68:
+ax_pose 15, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose69:
+ax_pose 16, 0x81ed, 0x80f7, 0xac00
+ax_pose 17, 0x01fd, 0x0107, 0xac08
+ax_pose_terminator
+sGulpinPose70:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose71:
+ax_pose 4, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose72:
+ax_pose 5, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose73:
+ax_pose 18, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose74:
+ax_pose 19, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose75:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose76:
+ax_pose 7, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose77:
+ax_pose 8, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose78:
+ax_pose 20, 0x01ee, 0x90ee, 0xac00
+ax_pose_terminator
+sGulpinPose79:
+ax_pose 21, 0x81ec, 0x90fa, 0xac00
+ax_pose 22, 0x01fc, 0x10f2, 0xac08
+ax_pose_terminator
+sGulpinPose80:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose81:
+ax_pose 10, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose82:
+ax_pose 11, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose83:
+ax_pose 23, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose84:
+ax_pose 24, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose85:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose86:
+ax_pose 13, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose87:
+ax_pose 14, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose88:
+ax_pose 25, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose89:
+ax_pose 26, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose90:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose91:
+ax_pose 10, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose92:
+ax_pose 11, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose93:
+ax_pose 23, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose94:
+ax_pose 24, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose95:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose96:
+ax_pose 7, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose97:
+ax_pose 8, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose98:
+ax_pose 20, 0x01ee, 0x80f2, 0xac00
+ax_pose_terminator
+sGulpinPose99:
+ax_pose 21, 0x81ec, 0x80f6, 0xac00
+ax_pose 22, 0x01fc, 0x0106, 0xac08
+ax_pose_terminator
+sGulpinPose100:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose101:
+ax_pose 4, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose102:
+ax_pose 5, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose103:
+ax_pose 18, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose104:
+ax_pose 19, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose105:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose106:
+ax_pose 27, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose107:
+ax_pose 28, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose108:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose109:
+ax_pose 29, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose110:
+ax_pose 30, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose111:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose112:
+ax_pose 31, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose113:
+ax_pose 32, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose114:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose115:
+ax_pose 33, 0x01ef, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose116:
+ax_pose 34, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose117:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose118:
+ax_pose 35, 0x81f0, 0x80f6, 0xac00
+ax_pose 36, 0x81f0, 0x0106, 0xac08
+ax_pose_terminator
+sGulpinPose119:
+ax_pose 37, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose120:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose121:
+ax_pose 33, 0x01ef, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose122:
+ax_pose 34, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose123:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose124:
+ax_pose 31, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose125:
+ax_pose 32, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose126:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose127:
+ax_pose 29, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose128:
+ax_pose 30, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose129:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose130:
+ax_pose 28, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose131:
+ax_pose 38, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose132:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose133:
+ax_pose 30, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose134:
+ax_pose 39, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose135:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose136:
+ax_pose 32, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose137:
+ax_pose 40, 0x01ea, 0x90ee, 0xac00
+ax_pose_terminator
+sGulpinPose138:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose139:
+ax_pose 34, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose140:
+ax_pose 41, 0x01ed, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose141:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose142:
+ax_pose 37, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose143:
+ax_pose 42, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose144:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose145:
+ax_pose 34, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose146:
+ax_pose 41, 0x01ed, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose147:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose148:
+ax_pose 32, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose149:
+ax_pose 40, 0x01ea, 0x80f2, 0xac00
+ax_pose_terminator
+sGulpinPose150:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose151:
+ax_pose 30, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose152:
+ax_pose 39, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose153:
+ax_pose 43, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose154:
+ax_pose 44, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose155:
+ax_pose 45, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sGulpinPose156:
+ax_pose 46, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose157:
+ax_pose 47, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose158:
+ax_pose 48, 0x01e9, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose159:
+ax_pose 49, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sGulpinPose160:
+ax_pose 48, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose161:
+ax_pose 47, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose162:
+ax_pose 46, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose163:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose164:
+ax_pose 1, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose165:
+ax_pose 2, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose166:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose167:
+ax_pose 4, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose168:
+ax_pose 5, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose169:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose170:
+ax_pose 7, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose171:
+ax_pose 8, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose172:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose173:
+ax_pose 10, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose174:
+ax_pose 11, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose175:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose176:
+ax_pose 13, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose177:
+ax_pose 14, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose178:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose179:
+ax_pose 10, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose180:
+ax_pose 11, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose181:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose182:
+ax_pose 7, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose183:
+ax_pose 8, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose184:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose185:
+ax_pose 4, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose186:
+ax_pose 5, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose187:
+ax_pose 38, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose188:
+ax_pose 39, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose189:
+ax_pose 40, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose190:
+ax_pose 41, 0x01ec, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose191:
+ax_pose 42, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose192:
+ax_pose 41, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose193:
+ax_pose 40, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose194:
+ax_pose 39, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose195:
+ax_pose 16, 0x81ed, 0x80f7, 0xac00
+ax_pose 17, 0x01fd, 0x0107, 0xac08
+ax_pose_terminator
+sGulpinPose196:
+ax_pose 19, 0x01ed, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose197:
+ax_pose 21, 0x81ed, 0x90f9, 0xac00
+ax_pose 22, 0x01fd, 0x10f1, 0xac08
+ax_pose_terminator
+sGulpinPose198:
+ax_pose 24, 0x01ef, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose199:
+ax_pose 26, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose200:
+ax_pose 24, 0x01ef, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose201:
+ax_pose 21, 0x81ed, 0x80f7, 0xac00
+ax_pose 22, 0x01fd, 0x0107, 0xac08
+ax_pose_terminator
+sGulpinPose202:
+ax_pose 19, 0x01ed, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose203:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose204:
+ax_pose 1, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose205:
+ax_pose 27, 0x01ef, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose206:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose207:
+ax_pose 4, 0x01ee, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose208:
+ax_pose 29, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose209:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose210:
+ax_pose 7, 0x01ee, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose211:
+ax_pose 31, 0x01ef, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose212:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose213:
+ax_pose 10, 0x01ef, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose214:
+ax_pose 33, 0x01ef, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose215:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose216:
+ax_pose 13, 0x01ef, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose217:
+ax_pose 35, 0x81f0, 0x80f6, 0xac00
+ax_pose 36, 0x81f0, 0x0106, 0xac08
+ax_pose_terminator
+sGulpinPose218:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose219:
+ax_pose 10, 0x01ef, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose220:
+ax_pose 33, 0x01ef, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose221:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose222:
+ax_pose 7, 0x01ee, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose223:
+ax_pose 31, 0x01ef, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose224:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose225:
+ax_pose 4, 0x01ee, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose226:
+ax_pose 29, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose227:
+ax_pose 28, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose228:
+ax_pose 30, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose229:
+ax_pose 32, 0x01eb, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose230:
+ax_pose 34, 0x01ec, 0x80f5, 0xac00
+ax_pose_terminator
+sGulpinPose231:
+ax_pose 37, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose232:
+ax_pose 34, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose233:
+ax_pose 32, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose234:
+ax_pose 30, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sGulpinPose235:
+ax_pose 0, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose236:
+ax_pose 3, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose237:
+ax_pose 6, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sGulpinPose238:
+ax_pose 9, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose239:
+ax_pose 12, 0x01ee, 0x80f4, 0xac00
+ax_pose_terminator
+sGulpinPose240:
+ax_pose 9, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+sGulpinPose241:
+ax_pose 6, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sGulpinPose242:
+ax_pose 3, 0x01ee, 0x90ec, 0xac00
+ax_pose_terminator
+.align 2
+sGulpinAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 1,
+ax_anim 10, 0, 1, 0, 2, 0, 2,
+ax_anim 8, 0, 2, 0, 3, 0, 2,
+ax_anim 8, 0, 2, 0, 2, 0, 1,
+ax_anim 10, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sGulpinAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 10, 0, 4, 2, 2, 2, 2,
+ax_anim 8, 0, 5, 2, 2, 2, 2,
+ax_anim 8, 0, 5, 1, 1, 2, 2,
+ax_anim 10, 0, 5, 0, 0, 1, 1,
+ax_anim_terminator
+sGulpinAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 1, 0, 1, 0,
+ax_anim 10, 0, 7, 2, 0, 2, 0,
+ax_anim 8, 0, 8, 2, 0, 2, 0,
+ax_anim 8, 0, 8, 1, 0, 1, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 1, -1, 1, -1,
+ax_anim 10, 0, 10, 2, -2, 2, -2,
+ax_anim 8, 0, 11, 2, -2, 2, -2,
+ax_anim 8, 0, 11, 1, -1, 1, -1,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, -1,
+ax_anim 10, 0, 13, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, -1, 0, -1,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, -1, -1, -1, -1,
+ax_anim 10, 0, 16, -2, -2, -2, -2,
+ax_anim 8, 0, 17, -2, -2, -2, -2,
+ax_anim 8, 0, 17, -1, -1, -1, -1,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, -1, 0, -1, 0,
+ax_anim 10, 0, 19, -2, 0, -2, 0,
+ax_anim 8, 0, 20, -2, 0, -2, 0,
+ax_anim 8, 0, 20, -1, 0, -1, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, -1, 1,
+ax_anim 10, 0, 22, -2, 2, -2, 2,
+ax_anim 8, 0, 23, -2, 2, -2, 2,
+ax_anim 8, 0, 23, -1, 1, -2, 2,
+ax_anim 10, 0, 23, 0, 0, -1, 1,
+ax_anim_terminator
+.align 2
+sGulpinAnims_2_1:
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 2, 0, 24, 0, -5, 0, -5,
+ax_anim 4, 0, 27, 0, -5, 0, -5,
+ax_anim 1, 0, 28, 0, -9, 0, -3,
+ax_anim 2, 0, 28, 0, -2, 0, 5,
+ax_anim 2, 2, 28, 0, 10, 0, 15,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 0, 18, 0, 17,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 17,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 17,
+ax_anim 2, 0, 24, 0, 7, 0, 7,
+ax_anim_terminator
+sGulpinAnims_2_2:
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -4, -4, -4, -4,
+ax_anim 2, 0, 29, -5, -5, -5, -5,
+ax_anim 4, 0, 32, -5, -5, -5, -5,
+ax_anim 1, 0, 33, 1, -5, 1, 2,
+ax_anim 2, 0, 33, 11, 0, 11, 11,
+ax_anim 2, 2, 33, 16, 8, 16, 15,
+ax_anim 2, 0, 32, 18, 17, 18, 17,
+ax_anim 2, 1, 33, 18, 17, 18, 17,
+ax_anim 2, 0, 32, 18, 17, 18, 17,
+ax_anim 2, 0, 33, 18, 17, 18, 17,
+ax_anim 2, 0, 32, 18, 17, 18, 17,
+ax_anim 2, 0, 33, 18, 17, 18, 17,
+ax_anim 2, 0, 29, 7, 7, 7, 7,
+ax_anim_terminator
+sGulpinAnims_2_3:
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -4, 0, -4, 0,
+ax_anim 2, 0, 34, -5, 0, -5, 0,
+ax_anim 4, 0, 37, -5, 0, -5, 0,
+ax_anim 1, 0, 38, 2, -3, 2, 0,
+ax_anim 2, 0, 38, 7, -4, 7, 0,
+ax_anim 2, 2, 38, 13, -3, 13, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 7, 0, 7, 0,
+ax_anim_terminator
+sGulpinAnims_2_4:
+ax_anim 2, 0, 39, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -4, 4, -4, 4,
+ax_anim 2, 0, 39, -5, 5, -5, 5,
+ax_anim 4, 0, 42, -5, 5, -5, 5,
+ax_anim 1, 0, 43, -2, -3, -2, 2,
+ax_anim 2, 0, 43, 3, -14, 3, -4,
+ax_anim 2, 2, 43, 12, -20, 12, -16,
+ax_anim 2, 0, 42, 18, -24, 18, -24,
+ax_anim 2, 1, 43, 18, -24, 19, -25,
+ax_anim 2, 0, 42, 18, -24, 18, -24,
+ax_anim 2, 0, 43, 18, -24, 19, -25,
+ax_anim 2, 0, 42, 18, -24, 18, -24,
+ax_anim 2, 0, 43, 18, -24, 19, -25,
+ax_anim 2, 0, 39, 7, -9, 7, -9,
+ax_anim_terminator
+sGulpinAnims_2_5:
+ax_anim 2, 0, 44, 0, 2, 0, 2,
+ax_anim 2, 0, 44, 0, 4, 0, 4,
+ax_anim 2, 0, 44, 0, 5, 0, 5,
+ax_anim 4, 0, 47, 0, 5, 0, 5,
+ax_anim 1, 0, 48, 0, -3, 0, -1,
+ax_anim 2, 0, 48, 0, -14, 0, -10,
+ax_anim 2, 2, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 47, 0, -24, 0, -24,
+ax_anim 2, 1, 48, 0, -24, 0, -24,
+ax_anim 2, 0, 47, 0, -24, 0, -24,
+ax_anim 2, 0, 48, 0, -24, 0, -24,
+ax_anim 2, 0, 47, 0, -24, 0, -24,
+ax_anim 2, 0, 48, 0, -24, 0, -24,
+ax_anim 2, 0, 44, 0, -9, 0, -9,
+ax_anim_terminator
+sGulpinAnims_2_6:
+ax_anim 2, 0, 49, 2, 2, 2, 2,
+ax_anim 2, 0, 49, 4, 4, 4, 4,
+ax_anim 2, 0, 49, 5, 5, 5, 5,
+ax_anim 4, 0, 52, 5, 5, 5, 5,
+ax_anim 1, 0, 53, 2, -3, 2, 2,
+ax_anim 2, 0, 53, -3, -14, -3, -4,
+ax_anim 2, 2, 53, -12, -20, -12, -16,
+ax_anim 2, 0, 52, -18, -24, -18, -24,
+ax_anim 2, 1, 53, -18, -24, -19, -25,
+ax_anim 2, 0, 52, -18, -24, -18, -24,
+ax_anim 2, 0, 53, -18, -24, -19, -25,
+ax_anim 2, 0, 52, -18, -24, -18, -24,
+ax_anim 2, 0, 53, -18, -24, -19, -25,
+ax_anim 2, 0, 49, -7, -9, -7, -9,
+ax_anim_terminator
+sGulpinAnims_2_7:
+ax_anim 2, 0, 54, 2, 0, 2, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim 2, 0, 54, 5, 0, 5, 0,
+ax_anim 4, 0, 57, 5, 0, 5, 0,
+ax_anim 1, 0, 58, -2, -3, -2, 0,
+ax_anim 2, 0, 58, -7, -4, -7, 0,
+ax_anim 2, 2, 58, -13, -3, -13, 0,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, 0, -19, 0,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, 0, -19, 0,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, 0, -19, 0,
+ax_anim 2, 0, 54, -7, 0, -7, 0,
+ax_anim_terminator
+sGulpinAnims_2_8:
+ax_anim 2, 0, 59, 2, -2, 2, -2,
+ax_anim 2, 0, 59, 4, -4, 4, -4,
+ax_anim 2, 0, 59, 5, -5, 5, -5,
+ax_anim 4, 0, 62, 5, -5, 5, -5,
+ax_anim 1, 0, 63, -1, -5, -1, 2,
+ax_anim 2, 0, 63, -11, 0, -11, 11,
+ax_anim 2, 2, 63, -16, 8, -16, 15,
+ax_anim 2, 0, 62, -18, 17, -18, 17,
+ax_anim 2, 1, 63, -18, 17, -18, 17,
+ax_anim 2, 0, 62, -18, 17, -18, 17,
+ax_anim 2, 0, 63, -18, 17, -18, 17,
+ax_anim 2, 0, 62, -18, 17, -18, 17,
+ax_anim 2, 0, 63, -18, 17, -18, 17,
+ax_anim 2, 0, 59, -7, 7, -7, 7,
+ax_anim_terminator
+.align 2
+sGulpinAnims_3_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -4, 0, -4,
+ax_anim 2, 0, 64, 0, -5, 0, -5,
+ax_anim 4, 0, 67, 0, -5, 0, -5,
+ax_anim 1, 0, 68, 0, -9, 0, -3,
+ax_anim 2, 0, 68, 0, -2, 0, 5,
+ax_anim 2, 2, 68, 0, 10, 0, 15,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 1, 68, 0, 18, 0, 17,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 0, 68, 0, 18, 0, 17,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 0, 68, 0, 18, 0, 17,
+ax_anim 2, 0, 64, 0, 7, 0, 7,
+ax_anim_terminator
+sGulpinAnims_3_2:
+ax_anim 2, 0, 69, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -4, -4, -4, -4,
+ax_anim 2, 0, 69, -5, -5, -5, -5,
+ax_anim 4, 0, 72, -5, -5, -5, -5,
+ax_anim 1, 0, 73, 1, -5, 1, 2,
+ax_anim 2, 0, 73, 11, 0, 11, 11,
+ax_anim 2, 2, 73, 16, 8, 16, 15,
+ax_anim 2, 0, 72, 18, 17, 18, 17,
+ax_anim 2, 1, 73, 18, 17, 18, 17,
+ax_anim 2, 0, 72, 18, 17, 18, 17,
+ax_anim 2, 0, 73, 18, 17, 18, 17,
+ax_anim 2, 0, 72, 18, 17, 18, 17,
+ax_anim 2, 0, 73, 18, 17, 18, 17,
+ax_anim 2, 0, 69, 7, 7, 7, 7,
+ax_anim_terminator
+sGulpinAnims_3_3:
+ax_anim 2, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -4, 0, -4, 0,
+ax_anim 2, 0, 74, -5, 0, -5, 0,
+ax_anim 4, 0, 77, -5, 0, -5, 0,
+ax_anim 1, 0, 78, 2, -3, 2, 0,
+ax_anim 2, 0, 78, 7, -4, 7, 0,
+ax_anim 2, 2, 78, 13, -3, 13, 0,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 1, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 7, 0, 7, 0,
+ax_anim_terminator
+sGulpinAnims_3_4:
+ax_anim 2, 0, 79, -2, 2, -2, 2,
+ax_anim 2, 0, 79, -4, 4, -4, 4,
+ax_anim 2, 0, 79, -5, 5, -5, 5,
+ax_anim 4, 0, 82, -5, 5, -5, 5,
+ax_anim 1, 0, 83, -2, -3, -2, 2,
+ax_anim 2, 0, 83, 3, -14, 3, -4,
+ax_anim 2, 2, 83, 12, -20, 12, -16,
+ax_anim 2, 0, 82, 18, -24, 18, -24,
+ax_anim 2, 1, 83, 18, -24, 19, -25,
+ax_anim 2, 0, 82, 18, -24, 18, -24,
+ax_anim 2, 0, 83, 18, -24, 19, -25,
+ax_anim 2, 0, 82, 18, -24, 18, -24,
+ax_anim 2, 0, 83, 18, -24, 19, -25,
+ax_anim 2, 0, 79, 7, -9, 7, -9,
+ax_anim_terminator
+sGulpinAnims_3_5:
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 2, 0, 84, 0, 4, 0, 4,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 4, 0, 87, 0, 5, 0, 5,
+ax_anim 1, 0, 88, 0, -3, 0, -1,
+ax_anim 2, 0, 88, 0, -14, 0, -10,
+ax_anim 2, 2, 88, 0, -20, 0, -20,
+ax_anim 2, 0, 87, 0, -24, 0, -24,
+ax_anim 2, 1, 88, 0, -24, 0, -24,
+ax_anim 2, 0, 87, 0, -24, 0, -24,
+ax_anim 2, 0, 88, 0, -24, 0, -24,
+ax_anim 2, 0, 87, 0, -24, 0, -24,
+ax_anim 2, 0, 88, 0, -24, 0, -24,
+ax_anim 2, 0, 84, 0, -9, 0, -9,
+ax_anim_terminator
+sGulpinAnims_3_6:
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 4, 4, 4, 4,
+ax_anim 2, 0, 89, 5, 5, 5, 5,
+ax_anim 4, 0, 92, 5, 5, 5, 5,
+ax_anim 1, 0, 93, 2, -3, 2, 2,
+ax_anim 2, 0, 93, -3, -14, -3, -4,
+ax_anim 2, 2, 93, -12, -20, -12, -16,
+ax_anim 2, 0, 92, -18, -24, -18, -24,
+ax_anim 2, 1, 93, -18, -24, -19, -25,
+ax_anim 2, 0, 92, -18, -24, -18, -24,
+ax_anim 2, 0, 93, -18, -24, -19, -25,
+ax_anim 2, 0, 92, -18, -24, -18, -24,
+ax_anim 2, 0, 93, -18, -24, -19, -25,
+ax_anim 2, 0, 89, -7, -9, -7, -9,
+ax_anim_terminator
+sGulpinAnims_3_7:
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim 2, 0, 94, 5, 0, 5, 0,
+ax_anim 4, 0, 97, 5, 0, 5, 0,
+ax_anim 1, 0, 98, -2, -3, -2, 0,
+ax_anim 2, 0, 98, -7, -4, -7, 0,
+ax_anim 2, 2, 98, -13, -3, -13, 0,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 1, 98, -18, 0, -19, 0,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 0, 98, -18, 0, -19, 0,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 0, 98, -18, 0, -19, 0,
+ax_anim 2, 0, 94, -7, 0, -7, 0,
+ax_anim_terminator
+sGulpinAnims_3_8:
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 4, 0, 102, 5, -5, 5, -5,
+ax_anim 1, 0, 103, -1, -5, -1, 2,
+ax_anim 2, 0, 103, -11, 0, -11, 11,
+ax_anim 2, 2, 103, -16, 8, -16, 15,
+ax_anim 2, 0, 102, -18, 17, -18, 17,
+ax_anim 2, 1, 103, -18, 17, -18, 17,
+ax_anim 2, 0, 102, -18, 17, -18, 17,
+ax_anim 2, 0, 103, -18, 17, -18, 17,
+ax_anim 2, 0, 102, -18, 17, -18, 17,
+ax_anim 2, 0, 103, -18, 17, -18, 17,
+ax_anim 2, 0, 99, -7, 7, -7, 7,
+ax_anim_terminator
+.align 2
+sGulpinAnims_4_1:
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 5, 0, 105, 0, -4, 0, -4,
+ax_anim 3, 2, 105, 0, -4, 0, -4,
+ax_anim 1, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 1, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sGulpinAnims_4_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 108, -3, -3, -3, -3,
+ax_anim 5, 0, 108, -4, -4, -4, -4,
+ax_anim 3, 2, 108, -4, -4, -4, -4,
+ax_anim 1, 0, 109, -3, -3, -3, -3,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 1, 109, 2, 4, 2, 4,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 2, 4, 2, 4,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 2, 4, 2, 4,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sGulpinAnims_4_3:
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 5, 0, 111, -4, 0, -4, 0,
+ax_anim 3, 2, 111, -4, 0, -4, 0,
+ax_anim 1, 0, 112, -3, 0, -3, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 1, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sGulpinAnims_4_4:
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 114, -3, 3, -3, 3,
+ax_anim 5, 0, 114, -4, 4, -4, 4,
+ax_anim 3, 2, 114, -4, 4, -4, 4,
+ax_anim 1, 0, 115, -3, 3, -3, 3,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 1, 115, 2, -4, 2, -4,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 2, -4, 2, -4,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 2, -4, 2, -4,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sGulpinAnims_4_5:
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim 2, 0, 117, 0, 3, 0, 3,
+ax_anim 5, 0, 117, 0, 4, 0, 4,
+ax_anim 3, 2, 117, 0, 4, 0, 4,
+ax_anim 1, 0, 118, 0, 3, 0, 3,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 1, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sGulpinAnims_4_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 2, 0, 120, 3, 3, 3, 3,
+ax_anim 5, 0, 120, 4, 4, 4, 4,
+ax_anim 3, 2, 120, 4, 4, 4, 4,
+ax_anim 1, 0, 121, 3, 3, 3, 3,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 1, 121, -2, -4, -2, -4,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -2, -4, -2, -4,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -2, -4, -2, -4,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sGulpinAnims_4_7:
+ax_anim 2, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 3, 0, 3, 0,
+ax_anim 5, 0, 123, 4, 0, 4, 0,
+ax_anim 3, 2, 123, 4, 0, 4, 0,
+ax_anim 1, 0, 124, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 1, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sGulpinAnims_4_8:
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 3, -3, 3, -3,
+ax_anim 5, 0, 126, 4, -4, 4, -4,
+ax_anim 3, 2, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 127, 3, -3, 3, -3,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 1, 127, -2, 4, -2, 4,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -2, 4, -2, 4,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -2, 4, -2, 4,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGulpinAnims_5_1:
+ax_anim 2, 0, 129, 0, -2, 0, -2,
+ax_anim 6, 0, 130, 0, -3, 0, -3,
+ax_anim 1, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 3, 0, 3,
+ax_anim 2, 0, 130, 0, 3, 0, 3,
+ax_anim 2, 2, 130, 0, 3, 0, 3,
+ax_anim 2, 0, 130, 1, 3, 1, 3,
+ax_anim 2, 0, 130, 0, 3, 0, 3,
+ax_anim 2, 1, 129, 1, 3, 1, 3,
+ax_anim 2, 0, 128, 0, 3, 0, 3,
+ax_anim 2, 0, 128, 1, 3, 1, 3,
+ax_anim 2, 0, 128, 0, 1, 0, 1,
+ax_anim_terminator
+sGulpinAnims_5_2:
+ax_anim 2, 0, 132, -2, -2, -2, -2,
+ax_anim 6, 0, 133, -3, -3, -3, -3,
+ax_anim 1, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 2, 2, 133, 3, 3, 3, 3,
+ax_anim 2, 0, 133, 4, 2, 4, 2,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 2, 1, 132, 4, 2, 4, 2,
+ax_anim 2, 0, 131, 3, 3, 3, 3,
+ax_anim 2, 0, 131, 4, 2, 4, 2,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim_terminator
+sGulpinAnims_5_3:
+ax_anim 2, 0, 135, -2, 0, -2, 0,
+ax_anim 6, 0, 136, -3, 0, -3, 0,
+ax_anim 1, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 2, 2, 136, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 3, 1, 3, 1,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 2, 1, 135, 3, 1, 3, 1,
+ax_anim 2, 0, 134, 3, 0, 3, 0,
+ax_anim 2, 0, 134, 3, 1, 3, 1,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim_terminator
+sGulpinAnims_5_4:
+ax_anim 2, 0, 138, -2, 2, -2, 2,
+ax_anim 6, 0, 139, -3, 3, -3, 3,
+ax_anim 1, 0, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 2, 2, 139, 3, -3, 3, -3,
+ax_anim 2, 0, 139, 4, -2, 4, -2,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 2, 1, 138, 4, -2, 4, -2,
+ax_anim 2, 0, 137, 3, -3, 3, -3,
+ax_anim 2, 0, 137, 4, -2, 4, -2,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim_terminator
+sGulpinAnims_5_5:
+ax_anim 2, 0, 141, 0, 2, 0, 2,
+ax_anim 6, 0, 142, 0, 3, 0, 3,
+ax_anim 1, 0, 142, 0, 1, 0, 1,
+ax_anim 2, 0, 142, 0, -3, 0, -3,
+ax_anim 2, 0, 142, 0, -3, 0, -3,
+ax_anim 2, 2, 142, 0, -3, 0, -3,
+ax_anim 2, 0, 142, 1, -3, 1, -3,
+ax_anim 2, 0, 142, 0, -3, 0, -3,
+ax_anim 2, 1, 141, 1, -3, 1, -3,
+ax_anim 2, 0, 140, 0, -3, 0, -3,
+ax_anim 2, 0, 140, 1, -3, 1, -3,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim_terminator
+sGulpinAnims_5_6:
+ax_anim 2, 0, 144, 2, 2, 2, 2,
+ax_anim 6, 0, 145, 3, 3, 3, 3,
+ax_anim 1, 0, 145, 1, 1, 1, 1,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 2, 145, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -4, -2, -4, -2,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 1, 144, -4, -2, -4, -2,
+ax_anim 2, 0, 143, -3, -3, -3, -3,
+ax_anim 2, 0, 143, -4, -2, -4, -2,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim_terminator
+sGulpinAnims_5_7:
+ax_anim 2, 0, 147, 2, 0, 2, 0,
+ax_anim 6, 0, 148, 3, 0, 3, 0,
+ax_anim 1, 0, 148, 1, 0, 1, 0,
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim 2, 2, 148, -3, 0, -3, 0,
+ax_anim 2, 0, 148, -3, 1, -3, 1,
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim 2, 1, 147, -3, 1, -3, 1,
+ax_anim 2, 0, 146, -3, 0, -3, 0,
+ax_anim 2, 0, 146, -3, 1, -3, 1,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim_terminator
+sGulpinAnims_5_8:
+ax_anim 2, 0, 150, 2, -2, 2, -2,
+ax_anim 6, 0, 151, 3, -3, 3, -3,
+ax_anim 1, 0, 151, 1, -1, 1, -1,
+ax_anim 2, 0, 151, -3, 3, -3, 3,
+ax_anim 2, 0, 151, -3, 3, -3, 3,
+ax_anim 2, 2, 151, -3, 3, -3, 3,
+ax_anim 2, 0, 151, -4, 2, -4, 2,
+ax_anim 2, 0, 151, -3, 3, -3, 3,
+ax_anim 2, 1, 150, -4, 2, -4, 2,
+ax_anim 2, 0, 149, -3, 3, -3, 3,
+ax_anim 2, 0, 149, -4, 2, -4, 2,
+ax_anim 2, 0, 149, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sGulpinAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGulpinAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sGulpinAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sGulpinAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sGulpinAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sGulpinAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sGulpinAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sGulpinAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sGulpinAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGulpinAnims_8_1:
+ax_anim 20, 0, 162, 0, 0, 0, 0,
+ax_anim 30, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_8_2:
+ax_anim 20, 0, 165, 0, 0, 0, 0,
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_8_3:
+ax_anim 20, 0, 168, 0, 0, 0, 0,
+ax_anim 30, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_8_4:
+ax_anim 20, 0, 171, 0, 0, 0, 0,
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_8_5:
+ax_anim 20, 0, 174, 0, 0, 0, 0,
+ax_anim 30, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_8_6:
+ax_anim 20, 0, 177, 0, 0, 0, 0,
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_8_7:
+ax_anim 20, 0, 180, 0, 0, 0, 0,
+ax_anim 30, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_8_8:
+ax_anim 20, 0, 183, 0, 0, 0, 0,
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGulpinAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 15, 7, 15,
+ax_anim 3, 0, 190, 0, 18, 0, 18,
+ax_anim 2, 3, 191, -7, 15, -7, 15,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 16, 4, 16, 4,
+ax_anim 2, 0, 188, 22, 10, 22, 10,
+ax_anim 3, 0, 189, 21, 19, 21, 19,
+ax_anim 2, 3, 190, 11, 19, 11, 19,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -7, 11, -7,
+ax_anim 2, 0, 187, 16, -6, 16, -6,
+ax_anim 3, 0, 188, 20, -1, 20, -1,
+ax_anim 2, 3, 189, 18, 4, 18, 4,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 3, 4, 3, 4,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 3, -17, 3, -17,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 20, -21, 20, -21,
+ax_anim 2, 3, 188, 22, -13, 22, -13,
+ax_anim 2, 0, 189, 19, -3, 19, -3,
+ax_anim 1, 0, 190, 8, 1, 8, 1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -10, -3, -10, -3,
+ax_anim 2, 0, 192, -11, -8, -11, -8,
+ax_anim 2, 0, 193, -9, -18, -9, -18,
+ax_anim 3, 0, 186, 0, -22, 0, -22,
+ax_anim 2, 3, 187, 9, -18, 9, -18,
+ax_anim 2, 0, 188, 11, -8, 11, -8,
+ax_anim 1, 0, 189, 10, -3, 10, -3,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -3, -17, -3, -17,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -20, -21, -20, -21,
+ax_anim 2, 3, 192, -22, -13, -22, -13,
+ax_anim 2, 0, 191, -19, -3, -19, -3,
+ax_anim 1, 0, 190, -8, 1, -8, 1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -7, -11, -7,
+ax_anim 2, 0, 193, -16, -6, -16, -6,
+ax_anim 3, 0, 192, -20, -1, -20, -1,
+ax_anim 2, 3, 191, -18, 4, -18, 4,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -3, 4, -3, 4,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -16, 4, -16, 4,
+ax_anim 2, 0, 192, -22, 10, -22, 10,
+ax_anim 3, 0, 191, -21, 19, -21, 19,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGulpinAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGulpinAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -22, 0, 0,
+ax_anim 2, 0, 203, 0, -18, 0, 0,
+ax_anim 1, 0, 203, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -24, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -25, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 3, 0, 212, 0, -19, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 1, 0, 212, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 3, 0, 218, 0, -19, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 1, 0, 218, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -25, 0, 0,
+ax_anim 3, 0, 221, 0, -22, 0, 0,
+ax_anim 2, 0, 221, 0, -18, 0, 0,
+ax_anim 1, 0, 221, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -24, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGulpinAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGulpinAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sGulpinGfx1:
+.incbin "baserom.gba", 0x12E0264, 0x200
+sGulpinSprites1:
+ax_sprite sGulpinGfx1, 0x200
+ax_sprite_terminator
+sGulpinGfx2:
+.incbin "baserom.gba", 0x12E0474, 0x200
+sGulpinSprites2:
+ax_sprite sGulpinGfx2, 0x200
+ax_sprite_terminator
+sGulpinGfx3:
+.incbin "baserom.gba", 0x12E0684, 0x200
+sGulpinSprites3:
+ax_sprite sGulpinGfx3, 0x200
+ax_sprite_terminator
+sGulpinGfx4:
+.incbin "baserom.gba", 0x12E0894, 0x200
+sGulpinSprites4:
+ax_sprite sGulpinGfx4, 0x200
+ax_sprite_terminator
+sGulpinGfx5:
+.incbin "baserom.gba", 0x12E0AA4, 0x200
+sGulpinSprites5:
+ax_sprite sGulpinGfx5, 0x200
+ax_sprite_terminator
+sGulpinGfx6:
+.incbin "baserom.gba", 0x12E0CB4, 0x200
+sGulpinSprites6:
+ax_sprite sGulpinGfx6, 0x200
+ax_sprite_terminator
+sGulpinGfx7:
+.incbin "baserom.gba", 0x12E0EC4, 0x200
+sGulpinSprites7:
+ax_sprite sGulpinGfx7, 0x200
+ax_sprite_terminator
+sGulpinGfx8:
+.incbin "baserom.gba", 0x12E10D4, 0x200
+sGulpinSprites8:
+ax_sprite sGulpinGfx8, 0x200
+ax_sprite_terminator
+sGulpinGfx9:
+.incbin "baserom.gba", 0x12E12E4, 0x200
+sGulpinSprites9:
+ax_sprite sGulpinGfx9, 0x200
+ax_sprite_terminator
+sGulpinGfx10:
+.incbin "baserom.gba", 0x12E14F4, 0x200
+sGulpinSprites10:
+ax_sprite sGulpinGfx10, 0x200
+ax_sprite_terminator
+sGulpinGfx11:
+.incbin "baserom.gba", 0x12E1704, 0x200
+sGulpinSprites11:
+ax_sprite sGulpinGfx11, 0x200
+ax_sprite_terminator
+sGulpinGfx12:
+.incbin "baserom.gba", 0x12E1914, 0x100
+sGulpinSprites12:
+ax_sprite sGulpinGfx12, 0x100
+ax_sprite_terminator
+sGulpinGfx13:
+.incbin "baserom.gba", 0x12E1A24, 0x200
+sGulpinSprites13:
+ax_sprite sGulpinGfx13, 0x200
+ax_sprite_terminator
+sGulpinGfx14:
+.incbin "baserom.gba", 0x12E1C34, 0x200
+sGulpinSprites14:
+ax_sprite sGulpinGfx14, 0x200
+ax_sprite_terminator
+sGulpinGfx15:
+.incbin "baserom.gba", 0x12E1E44, 0x200
+sGulpinSprites15:
+ax_sprite sGulpinGfx15, 0x200
+ax_sprite_terminator
+sGulpinGfx16:
+.incbin "baserom.gba", 0x12E2054, 0x20
+sGulpinGfx16_1:
+.incbin "baserom.gba", 0x12E2074, 0x60
+sGulpinGfx16_2:
+.incbin "baserom.gba", 0x12E20D4, 0x60
+sGulpinSprites16:
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGulpinGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx17:
+.incbin "baserom.gba", 0x12E2174, 0xC0
+sGulpinSprites17:
+ax_sprite sGulpinGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGulpinGfx18:
+.incbin "baserom.gba", 0x12E224C, 0x20
+sGulpinSprites18:
+ax_sprite sGulpinGfx18, 0x20
+ax_sprite_terminator
+sGulpinGfx19:
+.incbin "baserom.gba", 0x12E227C, 0x40
+sGulpinGfx19_1:
+.incbin "baserom.gba", 0x12E22BC, 0x60
+sGulpinGfx19_2:
+.incbin "baserom.gba", 0x12E231C, 0x60
+sGulpinSprites19:
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx20:
+.incbin "baserom.gba", 0x12E23BC, 0x60
+sGulpinGfx20_1:
+.incbin "baserom.gba", 0x12E241C, 0x60
+sGulpinGfx20_2:
+.incbin "baserom.gba", 0x12E247C, 0x60
+sGulpinSprites20:
+ax_sprite sGulpinGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx21:
+.incbin "baserom.gba", 0x12E2514, 0x40
+sGulpinGfx21_1:
+.incbin "baserom.gba", 0x12E2554, 0x100
+sGulpinSprites21:
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sGulpinGfx22:
+.incbin "baserom.gba", 0x12E2684, 0xC0
+sGulpinSprites22:
+ax_sprite sGulpinGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGulpinGfx23:
+.incbin "baserom.gba", 0x12E275C, 0x20
+sGulpinSprites23:
+ax_sprite sGulpinGfx23, 0x20
+ax_sprite_terminator
+sGulpinGfx24:
+.incbin "baserom.gba", 0x12E278C, 0x60
+sGulpinGfx24_1:
+.incbin "baserom.gba", 0x12E27EC, 0x60
+sGulpinSprites24:
+ax_sprite sGulpinGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGulpinGfx25:
+.incbin "baserom.gba", 0x12E2874, 0x60
+sGulpinGfx25_1:
+.incbin "baserom.gba", 0x12E28D4, 0x60
+sGulpinGfx25_2:
+.incbin "baserom.gba", 0x12E2934, 0x60
+sGulpinSprites25:
+ax_sprite sGulpinGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx26:
+.incbin "baserom.gba", 0x12E29CC, 0x60
+sGulpinGfx26_1:
+.incbin "baserom.gba", 0x12E2A2C, 0x60
+sGulpinGfx26_2:
+.incbin "baserom.gba", 0x12E2A8C, 0x60
+sGulpinSprites26:
+ax_sprite sGulpinGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx27:
+.incbin "baserom.gba", 0x12E2B24, 0x60
+sGulpinGfx27_1:
+.incbin "baserom.gba", 0x12E2B84, 0x60
+sGulpinGfx27_2:
+.incbin "baserom.gba", 0x12E2BE4, 0x60
+sGulpinSprites27:
+ax_sprite sGulpinGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx28:
+.incbin "baserom.gba", 0x12E2C7C, 0x60
+sGulpinGfx28_1:
+.incbin "baserom.gba", 0x12E2CDC, 0x60
+sGulpinGfx28_2:
+.incbin "baserom.gba", 0x12E2D3C, 0x60
+sGulpinSprites28:
+ax_sprite sGulpinGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx29:
+.incbin "baserom.gba", 0x12E2DD4, 0x20
+sGulpinGfx29_1:
+.incbin "baserom.gba", 0x12E2DF4, 0x60
+sGulpinGfx29_2:
+.incbin "baserom.gba", 0x12E2E54, 0x60
+sGulpinGfx29_3:
+.incbin "baserom.gba", 0x12E2EB4, 0x60
+sGulpinSprites29:
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGulpinGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGulpinGfx30:
+.incbin "baserom.gba", 0x12E2F64, 0x60
+sGulpinGfx30_1:
+.incbin "baserom.gba", 0x12E2FC4, 0x60
+sGulpinGfx30_2:
+.incbin "baserom.gba", 0x12E3024, 0x60
+sGulpinSprites30:
+ax_sprite sGulpinGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx31:
+.incbin "baserom.gba", 0x12E30BC, 0x60
+sGulpinGfx31_1:
+.incbin "baserom.gba", 0x12E311C, 0x60
+sGulpinGfx31_2:
+.incbin "baserom.gba", 0x12E317C, 0x60
+sGulpinGfx31_3:
+.incbin "baserom.gba", 0x12E31DC, 0x20
+sGulpinSprites31:
+ax_sprite sGulpinGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx31_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGulpinGfx31_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGulpinGfx32:
+.incbin "baserom.gba", 0x12E3244, 0xE0
+sGulpinGfx32_1:
+.incbin "baserom.gba", 0x12E3324, 0x60
+sGulpinSprites32:
+ax_sprite sGulpinGfx32, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx32_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx33:
+.incbin "baserom.gba", 0x12E33AC, 0x60
+sGulpinGfx33_1:
+.incbin "baserom.gba", 0x12E340C, 0x60
+sGulpinGfx33_2:
+.incbin "baserom.gba", 0x12E346C, 0x60
+sGulpinSprites33:
+ax_sprite sGulpinGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx34:
+.incbin "baserom.gba", 0x12E3504, 0x60
+sGulpinGfx34_1:
+.incbin "baserom.gba", 0x12E3564, 0x60
+sGulpinGfx34_2:
+.incbin "baserom.gba", 0x12E35C4, 0x60
+sGulpinSprites34:
+ax_sprite sGulpinGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx35:
+.incbin "baserom.gba", 0x12E365C, 0x60
+sGulpinGfx35_1:
+.incbin "baserom.gba", 0x12E36BC, 0x60
+sGulpinGfx35_2:
+.incbin "baserom.gba", 0x12E371C, 0x60
+sGulpinSprites35:
+ax_sprite sGulpinGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx36:
+.incbin "baserom.gba", 0x12E37B4, 0xC0
+sGulpinSprites36:
+ax_sprite sGulpinGfx36, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGulpinGfx37:
+.incbin "baserom.gba", 0x12E388C, 0x40
+sGulpinSprites37:
+ax_sprite sGulpinGfx37, 0x40
+ax_sprite_terminator
+sGulpinGfx38:
+.incbin "baserom.gba", 0x12E38DC, 0x60
+sGulpinGfx38_1:
+.incbin "baserom.gba", 0x12E393C, 0x60
+sGulpinGfx38_2:
+.incbin "baserom.gba", 0x12E399C, 0x60
+sGulpinSprites38:
+ax_sprite sGulpinGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx39:
+.incbin "baserom.gba", 0x12E3A34, 0x20
+sGulpinGfx39_1:
+.incbin "baserom.gba", 0x12E3A54, 0x60
+sGulpinGfx39_2:
+.incbin "baserom.gba", 0x12E3AB4, 0x60
+sGulpinGfx39_3:
+.incbin "baserom.gba", 0x12E3B14, 0x60
+sGulpinSprites39:
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx39, 0x20
+ax_sprite 0, 0x40
+ax_sprite sGulpinGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGulpinGfx40:
+.incbin "baserom.gba", 0x12E3BC4, 0x60
+sGulpinGfx40_1:
+.incbin "baserom.gba", 0x12E3C24, 0x60
+sGulpinGfx40_2:
+.incbin "baserom.gba", 0x12E3C84, 0x60
+sGulpinGfx40_3:
+.incbin "baserom.gba", 0x12E3CE4, 0x20
+sGulpinSprites40:
+ax_sprite sGulpinGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx40_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGulpinGfx40_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGulpinGfx41:
+.incbin "baserom.gba", 0x12E3D4C, 0xE0
+sGulpinGfx41_1:
+.incbin "baserom.gba", 0x12E3E2C, 0x60
+sGulpinGfx41_2:
+.incbin "baserom.gba", 0x12E3E8C, 0x20
+sGulpinSprites41:
+ax_sprite sGulpinGfx41, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx41_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGulpinGfx41_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGulpinGfx42:
+.incbin "baserom.gba", 0x12E3EE4, 0x60
+sGulpinGfx42_1:
+.incbin "baserom.gba", 0x12E3F44, 0x60
+sGulpinGfx42_2:
+.incbin "baserom.gba", 0x12E3FA4, 0x60
+sGulpinSprites42:
+ax_sprite sGulpinGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx42_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sGulpinGfx43:
+.incbin "baserom.gba", 0x12E403C, 0x60
+sGulpinGfx43_1:
+.incbin "baserom.gba", 0x12E409C, 0x60
+sGulpinGfx43_2:
+.incbin "baserom.gba", 0x12E40FC, 0x60
+sGulpinGfx43_3:
+.incbin "baserom.gba", 0x12E415C, 0x20
+sGulpinSprites43:
+ax_sprite sGulpinGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGulpinGfx43_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGulpinGfx43_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGulpinGfx44:
+.incbin "baserom.gba", 0x12E41C4, 0x200
+sGulpinSprites44:
+ax_sprite sGulpinGfx44, 0x200
+ax_sprite_terminator
+sGulpinGfx45:
+.incbin "baserom.gba", 0x12E43D4, 0x200
+sGulpinSprites45:
+ax_sprite sGulpinGfx45, 0x200
+ax_sprite_terminator
+sGulpinGfx46:
+.incbin "baserom.gba", 0x12E45E4, 0x200
+sGulpinSprites46:
+ax_sprite sGulpinGfx46, 0x200
+ax_sprite_terminator
+sGulpinGfx47:
+.incbin "baserom.gba", 0x12E47F4, 0x200
+sGulpinSprites47:
+ax_sprite sGulpinGfx47, 0x200
+ax_sprite_terminator
+sGulpinGfx48:
+.incbin "baserom.gba", 0x12E4A04, 0x200
+sGulpinSprites48:
+ax_sprite sGulpinGfx48, 0x200
+ax_sprite_terminator
+sGulpinGfx49:
+.incbin "baserom.gba", 0x12E4C14, 0x200
+sGulpinSprites49:
+ax_sprite sGulpinGfx49, 0x200
+ax_sprite_terminator
+sGulpinGfx50:
+.incbin "baserom.gba", 0x12E4E24, 0x200
+sGulpinSprites50:
+ax_sprite sGulpinGfx50, 0x200
+ax_sprite_terminator
+sAxPosesGulpin:
+.4byte sGulpinPose1
+.4byte sGulpinPose2
+.4byte sGulpinPose3
+.4byte sGulpinPose4
+.4byte sGulpinPose5
+.4byte sGulpinPose6
+.4byte sGulpinPose7
+.4byte sGulpinPose8
+.4byte sGulpinPose9
+.4byte sGulpinPose10
+.4byte sGulpinPose11
+.4byte sGulpinPose12
+.4byte sGulpinPose13
+.4byte sGulpinPose14
+.4byte sGulpinPose15
+.4byte sGulpinPose16
+.4byte sGulpinPose17
+.4byte sGulpinPose18
+.4byte sGulpinPose19
+.4byte sGulpinPose20
+.4byte sGulpinPose21
+.4byte sGulpinPose22
+.4byte sGulpinPose23
+.4byte sGulpinPose24
+.4byte sGulpinPose25
+.4byte sGulpinPose26
+.4byte sGulpinPose27
+.4byte sGulpinPose28
+.4byte sGulpinPose29
+.4byte sGulpinPose30
+.4byte sGulpinPose31
+.4byte sGulpinPose32
+.4byte sGulpinPose33
+.4byte sGulpinPose34
+.4byte sGulpinPose35
+.4byte sGulpinPose36
+.4byte sGulpinPose37
+.4byte sGulpinPose38
+.4byte sGulpinPose39
+.4byte sGulpinPose40
+.4byte sGulpinPose41
+.4byte sGulpinPose42
+.4byte sGulpinPose43
+.4byte sGulpinPose44
+.4byte sGulpinPose45
+.4byte sGulpinPose46
+.4byte sGulpinPose47
+.4byte sGulpinPose48
+.4byte sGulpinPose49
+.4byte sGulpinPose50
+.4byte sGulpinPose51
+.4byte sGulpinPose52
+.4byte sGulpinPose53
+.4byte sGulpinPose54
+.4byte sGulpinPose55
+.4byte sGulpinPose56
+.4byte sGulpinPose57
+.4byte sGulpinPose58
+.4byte sGulpinPose59
+.4byte sGulpinPose60
+.4byte sGulpinPose61
+.4byte sGulpinPose62
+.4byte sGulpinPose63
+.4byte sGulpinPose64
+.4byte sGulpinPose65
+.4byte sGulpinPose66
+.4byte sGulpinPose67
+.4byte sGulpinPose68
+.4byte sGulpinPose69
+.4byte sGulpinPose70
+.4byte sGulpinPose71
+.4byte sGulpinPose72
+.4byte sGulpinPose73
+.4byte sGulpinPose74
+.4byte sGulpinPose75
+.4byte sGulpinPose76
+.4byte sGulpinPose77
+.4byte sGulpinPose78
+.4byte sGulpinPose79
+.4byte sGulpinPose80
+.4byte sGulpinPose81
+.4byte sGulpinPose82
+.4byte sGulpinPose83
+.4byte sGulpinPose84
+.4byte sGulpinPose85
+.4byte sGulpinPose86
+.4byte sGulpinPose87
+.4byte sGulpinPose88
+.4byte sGulpinPose89
+.4byte sGulpinPose90
+.4byte sGulpinPose91
+.4byte sGulpinPose92
+.4byte sGulpinPose93
+.4byte sGulpinPose94
+.4byte sGulpinPose95
+.4byte sGulpinPose96
+.4byte sGulpinPose97
+.4byte sGulpinPose98
+.4byte sGulpinPose99
+.4byte sGulpinPose100
+.4byte sGulpinPose101
+.4byte sGulpinPose102
+.4byte sGulpinPose103
+.4byte sGulpinPose104
+.4byte sGulpinPose105
+.4byte sGulpinPose106
+.4byte sGulpinPose107
+.4byte sGulpinPose108
+.4byte sGulpinPose109
+.4byte sGulpinPose110
+.4byte sGulpinPose111
+.4byte sGulpinPose112
+.4byte sGulpinPose113
+.4byte sGulpinPose114
+.4byte sGulpinPose115
+.4byte sGulpinPose116
+.4byte sGulpinPose117
+.4byte sGulpinPose118
+.4byte sGulpinPose119
+.4byte sGulpinPose120
+.4byte sGulpinPose121
+.4byte sGulpinPose122
+.4byte sGulpinPose123
+.4byte sGulpinPose124
+.4byte sGulpinPose125
+.4byte sGulpinPose126
+.4byte sGulpinPose127
+.4byte sGulpinPose128
+.4byte sGulpinPose129
+.4byte sGulpinPose130
+.4byte sGulpinPose131
+.4byte sGulpinPose132
+.4byte sGulpinPose133
+.4byte sGulpinPose134
+.4byte sGulpinPose135
+.4byte sGulpinPose136
+.4byte sGulpinPose137
+.4byte sGulpinPose138
+.4byte sGulpinPose139
+.4byte sGulpinPose140
+.4byte sGulpinPose141
+.4byte sGulpinPose142
+.4byte sGulpinPose143
+.4byte sGulpinPose144
+.4byte sGulpinPose145
+.4byte sGulpinPose146
+.4byte sGulpinPose147
+.4byte sGulpinPose148
+.4byte sGulpinPose149
+.4byte sGulpinPose150
+.4byte sGulpinPose151
+.4byte sGulpinPose152
+.4byte sGulpinPose153
+.4byte sGulpinPose154
+.4byte sGulpinPose155
+.4byte sGulpinPose156
+.4byte sGulpinPose157
+.4byte sGulpinPose158
+.4byte sGulpinPose159
+.4byte sGulpinPose160
+.4byte sGulpinPose161
+.4byte sGulpinPose162
+.4byte sGulpinPose163
+.4byte sGulpinPose164
+.4byte sGulpinPose165
+.4byte sGulpinPose166
+.4byte sGulpinPose167
+.4byte sGulpinPose168
+.4byte sGulpinPose169
+.4byte sGulpinPose170
+.4byte sGulpinPose171
+.4byte sGulpinPose172
+.4byte sGulpinPose173
+.4byte sGulpinPose174
+.4byte sGulpinPose175
+.4byte sGulpinPose176
+.4byte sGulpinPose177
+.4byte sGulpinPose178
+.4byte sGulpinPose179
+.4byte sGulpinPose180
+.4byte sGulpinPose181
+.4byte sGulpinPose182
+.4byte sGulpinPose183
+.4byte sGulpinPose184
+.4byte sGulpinPose185
+.4byte sGulpinPose186
+.4byte sGulpinPose187
+.4byte sGulpinPose188
+.4byte sGulpinPose189
+.4byte sGulpinPose190
+.4byte sGulpinPose191
+.4byte sGulpinPose192
+.4byte sGulpinPose193
+.4byte sGulpinPose194
+.4byte sGulpinPose195
+.4byte sGulpinPose196
+.4byte sGulpinPose197
+.4byte sGulpinPose198
+.4byte sGulpinPose199
+.4byte sGulpinPose200
+.4byte sGulpinPose201
+.4byte sGulpinPose202
+.4byte sGulpinPose203
+.4byte sGulpinPose204
+.4byte sGulpinPose205
+.4byte sGulpinPose206
+.4byte sGulpinPose207
+.4byte sGulpinPose208
+.4byte sGulpinPose209
+.4byte sGulpinPose210
+.4byte sGulpinPose211
+.4byte sGulpinPose212
+.4byte sGulpinPose213
+.4byte sGulpinPose214
+.4byte sGulpinPose215
+.4byte sGulpinPose216
+.4byte sGulpinPose217
+.4byte sGulpinPose218
+.4byte sGulpinPose219
+.4byte sGulpinPose220
+.4byte sGulpinPose221
+.4byte sGulpinPose222
+.4byte sGulpinPose223
+.4byte sGulpinPose224
+.4byte sGulpinPose225
+.4byte sGulpinPose226
+.4byte sGulpinPose227
+.4byte sGulpinPose228
+.4byte sGulpinPose229
+.4byte sGulpinPose230
+.4byte sGulpinPose231
+.4byte sGulpinPose232
+.4byte sGulpinPose233
+.4byte sGulpinPose234
+.4byte sGulpinPose235
+.4byte sGulpinPose236
+.4byte sGulpinPose237
+.4byte sGulpinPose238
+.4byte sGulpinPose239
+.4byte sGulpinPose240
+.4byte sGulpinPose241
+.4byte sGulpinPose242
+sAxPositionsGulpin:
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte    0,    2, 	  -7,   -2, 	   7,   -2, 	   0,   -3
+.2byte    0,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -6
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+.2byte    7,    0, 	   9,   -3, 	  -2,    1, 	   1,   -5
+.2byte    6,   -2, 	   9,   -2, 	   1,    1, 	   1,   -5
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    9,   -4, 	   5,   -5, 	   5,    0, 	   1,   -5
+.2byte    7,   -6, 	   3,   -6, 	   6,   -1, 	   0,   -5
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    8,   -8, 	   0,   -9, 	   7,   -3, 	   1,   -7
+.2byte    7,   -9, 	   2,   -9, 	   8,   -4, 	   0,   -6
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    0,  -12, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,   -8, 	   7,   -7, 	  -8,   -7, 	   0,   -5
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -9,   -8, 	  -1,   -9, 	  -8,   -3, 	  -2,   -7
+.2byte   -8,   -9, 	  -3,   -9, 	  -9,   -4, 	  -1,   -6
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -6,   -5, 	  -6,    0, 	  -2,   -5
+.2byte   -8,   -6, 	  -4,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -8,    0, 	 -10,   -3, 	   1,    1, 	  -2,   -5
+.2byte   -7,   -2, 	 -10,   -2, 	  -2,    1, 	  -2,   -5
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte    0,    2, 	  -7,   -2, 	   7,   -2, 	   0,   -3
+.2byte    0,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -6
+.2byte   -1,    1, 	  -8,   -1, 	   7,   -1, 	   0,   -4
+.2byte   -1,   -1, 	  -6,   -1, 	   5,   -1, 	   0,   -6
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+.2byte    7,    0, 	   9,   -3, 	  -2,    1, 	   1,   -5
+.2byte    6,   -2, 	   9,   -2, 	   1,    1, 	   1,   -5
+.2byte    6,    1, 	   9,   -3, 	  -2,    2, 	   1,   -4
+.2byte    5,   -1, 	   7,   -2, 	   0,    2, 	   0,   -6
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    9,   -4, 	   5,   -5, 	   5,    0, 	   1,   -5
+.2byte    7,   -6, 	   3,   -6, 	   6,   -1, 	   0,   -5
+.2byte   11,   -5, 	   5,   -8, 	   8,    0, 	   0,   -5
+.2byte    8,   -7, 	   4,   -8, 	   5,    0, 	   0,   -6
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    8,   -8, 	   0,   -9, 	   7,   -3, 	   1,   -7
+.2byte    7,   -9, 	   2,   -9, 	   8,   -4, 	   0,   -6
+.2byte    8,   -8, 	   2,   -9, 	   9,   -3, 	  -1,   -6
+.2byte    6,   -9, 	  -2,  -10, 	   7,   -4, 	  -1,   -8
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    0,  -12, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,   -8, 	   7,   -7, 	  -8,   -7, 	   0,   -5
+.2byte    0,   -9, 	   8,   -7, 	  -9,   -7, 	   0,   -5
+.2byte   -1,   -9, 	   6,   -2, 	  -7,   -2, 	  -1,   -6
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -9,   -8, 	  -1,   -9, 	  -8,   -3, 	  -2,   -7
+.2byte   -8,   -9, 	  -3,   -9, 	  -9,   -4, 	  -1,   -6
+.2byte   -9,   -8, 	  -3,   -9, 	 -10,   -3, 	   0,   -6
+.2byte   -7,   -9, 	   1,  -10, 	  -8,   -4, 	   0,   -8
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -6,   -5, 	  -6,    0, 	  -2,   -5
+.2byte   -8,   -6, 	  -4,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte  -12,   -5, 	  -6,   -8, 	  -9,    0, 	  -1,   -5
+.2byte   -9,   -7, 	  -5,   -8, 	  -6,    0, 	  -1,   -6
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -8,    0, 	 -10,   -3, 	   1,    1, 	  -2,   -5
+.2byte   -7,   -2, 	 -10,   -2, 	  -2,    1, 	  -2,   -5
+.2byte   -7,    1, 	 -10,   -3, 	   1,    2, 	  -2,   -4
+.2byte   -6,   -1, 	  -8,   -2, 	  -1,    2, 	  -1,   -6
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte    0,    2, 	  -7,   -2, 	   7,   -2, 	   0,   -3
+.2byte    0,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -6
+.2byte   -1,    1, 	  -8,   -1, 	   7,   -1, 	   0,   -4
+.2byte   -1,   -1, 	  -6,   -1, 	   5,   -1, 	   0,   -6
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+.2byte    7,    0, 	   9,   -3, 	  -2,    1, 	   1,   -5
+.2byte    6,   -2, 	   9,   -2, 	   1,    1, 	   1,   -5
+.2byte    6,    1, 	   9,   -3, 	  -2,    2, 	   1,   -4
+.2byte    5,   -1, 	   7,   -2, 	   0,    2, 	   0,   -6
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    9,   -4, 	   5,   -5, 	   5,    0, 	   1,   -5
+.2byte    7,   -6, 	   3,   -6, 	   6,   -1, 	   0,   -5
+.2byte   11,   -5, 	   5,   -8, 	   8,    0, 	   0,   -5
+.2byte    8,   -7, 	   4,   -8, 	   5,    0, 	   0,   -6
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    8,   -8, 	   0,   -9, 	   7,   -3, 	   1,   -7
+.2byte    7,   -9, 	   2,   -9, 	   8,   -4, 	   0,   -6
+.2byte    8,   -8, 	   2,   -9, 	   9,   -3, 	  -1,   -6
+.2byte    6,   -9, 	  -2,  -10, 	   7,   -4, 	  -1,   -8
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    0,  -12, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,   -8, 	   7,   -7, 	  -8,   -7, 	   0,   -5
+.2byte    0,   -9, 	   8,   -7, 	  -9,   -7, 	   0,   -5
+.2byte   -1,   -9, 	   6,   -2, 	  -7,   -2, 	  -1,   -6
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -9,   -8, 	  -1,   -9, 	  -8,   -3, 	  -2,   -7
+.2byte   -8,   -9, 	  -3,   -9, 	  -9,   -4, 	  -1,   -6
+.2byte   -9,   -8, 	  -3,   -9, 	 -10,   -3, 	   0,   -6
+.2byte   -7,   -9, 	   1,  -10, 	  -8,   -4, 	   0,   -8
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -6,   -5, 	  -6,    0, 	  -2,   -5
+.2byte   -8,   -6, 	  -4,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte  -12,   -5, 	  -6,   -8, 	  -9,    0, 	  -1,   -5
+.2byte   -9,   -7, 	  -5,   -8, 	  -6,    0, 	  -1,   -6
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -8,    0, 	 -10,   -3, 	   1,    1, 	  -2,   -5
+.2byte   -7,   -2, 	 -10,   -2, 	  -2,    1, 	  -2,   -5
+.2byte   -7,    1, 	 -10,   -3, 	   1,    2, 	  -2,   -4
+.2byte   -6,   -1, 	  -8,   -2, 	  -1,    2, 	  -1,   -6
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte   -1,   -6, 	  -7,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,   -4, 	  -8,   -3, 	   8,   -3, 	   0,   -7
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+.2byte    4,   -7, 	   8,   -6, 	  -1,   -1, 	  -1,   -6
+.2byte    3,   -1, 	   9,   -2, 	  -5,    2, 	  -1,   -4
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    7,  -11, 	  -1,  -11, 	   5,   -4, 	  -2,   -7
+.2byte    5,   -6, 	   7,   -5, 	   3,    0, 	  -1,   -8
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    6,  -10, 	  -2,   -9, 	   8,   -4, 	  -2,   -6
+.2byte    5,   -7, 	   2,   -4, 	   7,   -1, 	  -2,   -8
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    0,   -9, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -7,  -10, 	   1,   -9, 	  -9,   -4, 	   1,   -6
+.2byte   -6,   -7, 	  -3,   -4, 	  -8,   -1, 	   1,   -8
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte   -8,  -11, 	   0,  -11, 	  -6,   -4, 	   1,   -7
+.2byte   -6,   -6, 	  -8,   -5, 	  -4,    0, 	   0,   -8
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -5,   -7, 	  -9,   -6, 	   0,   -1, 	   0,   -6
+.2byte   -4,   -1, 	 -10,   -2, 	   4,    2, 	   0,   -4
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte    0,   -4, 	  -8,   -3, 	   8,   -3, 	   0,   -7
+.2byte    0,   -5, 	  -9,   -2, 	   8,   -1, 	   0,   -8
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+.2byte    3,   -1, 	   9,   -2, 	  -5,    2, 	  -1,   -4
+.2byte    0,   -3, 	   7,   -2, 	  -4,    3, 	  -2,   -5
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    5,   -6, 	   7,   -5, 	   3,    0, 	  -1,   -8
+.2byte    3,   -7, 	   5,   -3, 	   5,    0, 	  -2,   -7
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    5,   -7, 	   2,   -4, 	   7,   -1, 	  -2,   -8
+.2byte    2,   -7, 	   4,   -3, 	   5,    0, 	  -3,   -6
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    0,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte    0,  -13, 	   7,   -3, 	  -8,   -3, 	   0,   -7
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -6,   -7, 	  -3,   -4, 	  -8,   -1, 	   1,   -8
+.2byte   -3,   -7, 	  -5,   -3, 	  -6,    0, 	   2,   -6
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte   -6,   -6, 	  -8,   -5, 	  -4,    0, 	   0,   -8
+.2byte   -4,   -7, 	  -6,   -3, 	  -6,    0, 	   1,   -7
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -4,   -1, 	 -10,   -2, 	   4,    2, 	   0,   -4
+.2byte   -1,   -3, 	  -8,   -2, 	   3,    3, 	   1,   -5
+.2byte   -7,   -1, 	 -10,   -1, 	   3,    2, 	  -1,   -3
+.2byte   -7,    0, 	 -10,    0, 	   4,    2, 	  -1,   -2
+.2byte    0,   -1, 	 -10,   -3, 	   9,   -2, 	   0,   -4
+.2byte    4,   -2, 	   9,   -5, 	  -8,   -1, 	  -1,   -4
+.2byte    7,   -4, 	   6,   -7, 	   4,    1, 	  -2,   -4
+.2byte    7,   -7, 	   1,   -8, 	   8,   -2, 	  -2,   -3
+.2byte    0,   -5, 	  10,   -3, 	 -11,   -3, 	   0,   -1
+.2byte   -8,   -7, 	  -2,   -8, 	  -9,   -2, 	   1,   -3
+.2byte   -8,   -4, 	  -7,   -7, 	  -5,    1, 	   1,   -4
+.2byte   -5,   -2, 	 -10,   -5, 	   7,   -1, 	   0,   -4
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte    0,    2, 	  -7,   -2, 	   7,   -2, 	   0,   -3
+.2byte    0,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -6
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+.2byte    7,    0, 	   9,   -3, 	  -2,    1, 	   1,   -5
+.2byte    6,   -2, 	   9,   -2, 	   1,    1, 	   1,   -5
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    9,   -4, 	   5,   -5, 	   5,    0, 	   1,   -5
+.2byte    7,   -6, 	   3,   -6, 	   6,   -1, 	   0,   -5
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    8,   -8, 	   0,   -9, 	   7,   -3, 	   1,   -7
+.2byte    7,   -9, 	   2,   -9, 	   8,   -4, 	   0,   -6
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    0,  -12, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,   -8, 	   7,   -7, 	  -8,   -7, 	   0,   -5
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -9,   -8, 	  -1,   -9, 	  -8,   -3, 	  -2,   -7
+.2byte   -8,   -9, 	  -3,   -9, 	  -9,   -4, 	  -1,   -6
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte  -10,   -4, 	  -6,   -5, 	  -6,    0, 	  -2,   -5
+.2byte   -8,   -6, 	  -4,   -6, 	  -7,   -1, 	  -1,   -5
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -8,    0, 	 -10,   -3, 	   1,    1, 	  -2,   -5
+.2byte   -7,   -2, 	 -10,   -2, 	  -2,    1, 	  -2,   -5
+.2byte    0,   -5, 	  -9,   -2, 	   8,   -1, 	   0,   -8
+.2byte    0,   -5, 	  -7,   -4, 	   4,    1, 	   2,   -7
+.2byte   -2,   -6, 	  -4,   -2, 	  -4,    1, 	   3,   -6
+.2byte   -3,   -8, 	  -5,   -4, 	  -6,   -1, 	   2,   -7
+.2byte    0,  -14, 	   7,   -4, 	  -8,   -4, 	   0,   -8
+.2byte    3,   -8, 	   5,   -4, 	   6,   -1, 	  -2,   -7
+.2byte    2,   -7, 	   4,   -3, 	   4,    0, 	  -3,   -7
+.2byte    0,   -5, 	   7,   -4, 	  -4,    1, 	  -2,   -7
+.2byte   -1,   -1, 	  -6,   -1, 	   5,   -1, 	   0,   -6
+.2byte    4,   -2, 	   6,   -3, 	  -1,    1, 	  -1,   -7
+.2byte    7,   -6, 	   3,   -7, 	   4,    1, 	  -1,   -5
+.2byte    5,   -8, 	  -3,   -9, 	   6,   -3, 	  -2,   -7
+.2byte   -1,   -9, 	   6,   -2, 	  -7,   -2, 	  -1,   -6
+.2byte   -6,   -8, 	   2,   -9, 	  -7,   -3, 	   1,   -7
+.2byte   -8,   -6, 	  -4,   -7, 	  -5,    1, 	   0,   -5
+.2byte   -5,   -2, 	  -7,   -3, 	   0,    1, 	   0,   -7
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte    0,    1, 	  -7,   -3, 	   7,   -3, 	   0,   -4
+.2byte   -1,   -5, 	  -7,   -2, 	   6,   -2, 	   0,   -5
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+.2byte    6,    0, 	   8,   -3, 	  -3,    1, 	   0,   -5
+.2byte    4,   -7, 	   8,   -6, 	  -1,   -1, 	  -1,   -6
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    7,   -4, 	   3,   -5, 	   3,    0, 	  -1,   -5
+.2byte    8,  -10, 	   0,  -10, 	   6,   -3, 	  -1,   -6
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    8,   -7, 	   0,   -8, 	   7,   -2, 	   1,   -6
+.2byte    6,  -10, 	  -2,   -9, 	   8,   -4, 	  -2,   -6
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    0,  -11, 	   7,   -6, 	  -8,   -6, 	   0,   -8
+.2byte    0,   -9, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte   -9,   -7, 	  -1,   -8, 	  -8,   -2, 	  -2,   -6
+.2byte   -7,  -10, 	   1,   -9, 	  -9,   -4, 	   1,   -6
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte   -8,   -4, 	  -4,   -5, 	  -4,    0, 	   0,   -5
+.2byte   -9,  -10, 	  -1,  -10, 	  -7,   -3, 	   0,   -6
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -7,    0, 	  -9,   -3, 	   2,    1, 	  -1,   -5
+.2byte   -5,   -7, 	  -9,   -6, 	   0,   -1, 	   0,   -6
+.2byte    0,   -3, 	  -8,   -2, 	   8,   -2, 	   0,   -6
+.2byte   -3,   -3, 	  -9,   -4, 	   5,    0, 	   1,   -6
+.2byte   -5,   -6, 	  -7,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -5,   -7, 	  -2,   -4, 	  -7,   -1, 	   2,   -8
+.2byte    0,  -13, 	   7,   -5, 	  -8,   -5, 	   0,   -7
+.2byte    4,   -7, 	   1,   -4, 	   6,   -1, 	  -3,   -8
+.2byte    4,   -6, 	   6,   -5, 	   2,    0, 	  -2,   -8
+.2byte    2,   -3, 	   8,   -4, 	  -6,    0, 	  -2,   -6
+.2byte    0,    0, 	  -7,   -1, 	   6,   -1, 	   0,   -4
+.2byte   -6,   -1, 	  -9,   -3, 	   0,    1, 	  -1,   -6
+.2byte   -9,   -6, 	  -4,   -7, 	  -6,    0, 	   0,   -6
+.2byte   -8,   -8, 	  -3,   -8, 	  -8,   -3, 	  -1,   -6
+.2byte    0,   -9, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte    7,   -8, 	   2,   -8, 	   7,   -3, 	   0,   -6
+.2byte    8,   -6, 	   3,   -7, 	   5,    0, 	  -1,   -6
+.2byte    5,   -1, 	   8,   -3, 	  -1,    1, 	   0,   -6
+sGulpinAnimTable1:
+.4byte sGulpinAnims_1_1
+.4byte sGulpinAnims_1_2
+.4byte sGulpinAnims_1_3
+.4byte sGulpinAnims_1_4
+.4byte sGulpinAnims_1_5
+.4byte sGulpinAnims_1_6
+.4byte sGulpinAnims_1_7
+.4byte sGulpinAnims_1_8
+sGulpinAnimTable2:
+.4byte sGulpinAnims_2_1
+.4byte sGulpinAnims_2_2
+.4byte sGulpinAnims_2_3
+.4byte sGulpinAnims_2_4
+.4byte sGulpinAnims_2_5
+.4byte sGulpinAnims_2_6
+.4byte sGulpinAnims_2_7
+.4byte sGulpinAnims_2_8
+sGulpinAnimTable3:
+.4byte sGulpinAnims_3_1
+.4byte sGulpinAnims_3_2
+.4byte sGulpinAnims_3_3
+.4byte sGulpinAnims_3_4
+.4byte sGulpinAnims_3_5
+.4byte sGulpinAnims_3_6
+.4byte sGulpinAnims_3_7
+.4byte sGulpinAnims_3_8
+sGulpinAnimTable4:
+.4byte sGulpinAnims_4_1
+.4byte sGulpinAnims_4_2
+.4byte sGulpinAnims_4_3
+.4byte sGulpinAnims_4_4
+.4byte sGulpinAnims_4_5
+.4byte sGulpinAnims_4_6
+.4byte sGulpinAnims_4_7
+.4byte sGulpinAnims_4_8
+sGulpinAnimTable5:
+.4byte sGulpinAnims_5_1
+.4byte sGulpinAnims_5_2
+.4byte sGulpinAnims_5_3
+.4byte sGulpinAnims_5_4
+.4byte sGulpinAnims_5_5
+.4byte sGulpinAnims_5_6
+.4byte sGulpinAnims_5_7
+.4byte sGulpinAnims_5_8
+sGulpinAnimTable6:
+.4byte sGulpinAnims_6_1
+.4byte sGulpinAnims_6_1
+.4byte sGulpinAnims_6_1
+.4byte sGulpinAnims_6_1
+.4byte sGulpinAnims_6_1
+.4byte sGulpinAnims_6_1
+.4byte sGulpinAnims_6_1
+.4byte sGulpinAnims_6_1
+sGulpinAnimTable7:
+.4byte sGulpinAnims_7_1
+.4byte sGulpinAnims_7_2
+.4byte sGulpinAnims_7_3
+.4byte sGulpinAnims_7_4
+.4byte sGulpinAnims_7_5
+.4byte sGulpinAnims_7_6
+.4byte sGulpinAnims_7_7
+.4byte sGulpinAnims_7_8
+sGulpinAnimTable8:
+.4byte sGulpinAnims_8_1
+.4byte sGulpinAnims_8_2
+.4byte sGulpinAnims_8_3
+.4byte sGulpinAnims_8_4
+.4byte sGulpinAnims_8_5
+.4byte sGulpinAnims_8_6
+.4byte sGulpinAnims_8_7
+.4byte sGulpinAnims_8_8
+sGulpinAnimTable9:
+.4byte sGulpinAnims_9_1
+.4byte sGulpinAnims_9_2
+.4byte sGulpinAnims_9_3
+.4byte sGulpinAnims_9_4
+.4byte sGulpinAnims_9_5
+.4byte sGulpinAnims_9_6
+.4byte sGulpinAnims_9_7
+.4byte sGulpinAnims_9_8
+sGulpinAnimTable10:
+.4byte sGulpinAnims_10_1
+.4byte sGulpinAnims_10_2
+.4byte sGulpinAnims_10_3
+.4byte sGulpinAnims_10_4
+.4byte sGulpinAnims_10_5
+.4byte sGulpinAnims_10_6
+.4byte sGulpinAnims_10_7
+.4byte sGulpinAnims_10_8
+sGulpinAnimTable11:
+.4byte sGulpinAnims_11_1
+.4byte sGulpinAnims_11_2
+.4byte sGulpinAnims_11_3
+.4byte sGulpinAnims_11_4
+.4byte sGulpinAnims_11_5
+.4byte sGulpinAnims_11_6
+.4byte sGulpinAnims_11_7
+.4byte sGulpinAnims_11_8
+sGulpinAnimTable12:
+.4byte sGulpinAnims_12_1
+.4byte sGulpinAnims_12_2
+.4byte sGulpinAnims_12_3
+.4byte sGulpinAnims_12_4
+.4byte sGulpinAnims_12_5
+.4byte sGulpinAnims_12_6
+.4byte sGulpinAnims_12_7
+.4byte sGulpinAnims_12_8
+sGulpinAnimTable13:
+.4byte sGulpinAnims_13_1
+.4byte sGulpinAnims_13_2
+.4byte sGulpinAnims_13_3
+.4byte sGulpinAnims_13_4
+.4byte sGulpinAnims_13_5
+.4byte sGulpinAnims_13_6
+.4byte sGulpinAnims_13_7
+.4byte sGulpinAnims_13_8
+sAxAnimationsGulpin:
+.4byte sGulpinAnimTable1
+.4byte sGulpinAnimTable2
+.4byte sGulpinAnimTable3
+.4byte sGulpinAnimTable4
+.4byte sGulpinAnimTable5
+.4byte sGulpinAnimTable6
+.4byte sGulpinAnimTable7
+.4byte sGulpinAnimTable8
+.4byte sGulpinAnimTable9
+.4byte sGulpinAnimTable10
+.4byte sGulpinAnimTable11
+.4byte sGulpinAnimTable12
+.4byte sGulpinAnimTable13
+sAxSpritesGulpin:
+.4byte sGulpinSprites1
+.4byte sGulpinSprites2
+.4byte sGulpinSprites3
+.4byte sGulpinSprites4
+.4byte sGulpinSprites5
+.4byte sGulpinSprites6
+.4byte sGulpinSprites7
+.4byte sGulpinSprites8
+.4byte sGulpinSprites9
+.4byte sGulpinSprites10
+.4byte sGulpinSprites11
+.4byte sGulpinSprites12
+.4byte sGulpinSprites13
+.4byte sGulpinSprites14
+.4byte sGulpinSprites15
+.4byte sGulpinSprites16
+.4byte sGulpinSprites17
+.4byte sGulpinSprites18
+.4byte sGulpinSprites19
+.4byte sGulpinSprites20
+.4byte sGulpinSprites21
+.4byte sGulpinSprites22
+.4byte sGulpinSprites23
+.4byte sGulpinSprites24
+.4byte sGulpinSprites25
+.4byte sGulpinSprites26
+.4byte sGulpinSprites27
+.4byte sGulpinSprites28
+.4byte sGulpinSprites29
+.4byte sGulpinSprites30
+.4byte sGulpinSprites31
+.4byte sGulpinSprites32
+.4byte sGulpinSprites33
+.4byte sGulpinSprites34
+.4byte sGulpinSprites35
+.4byte sGulpinSprites36
+.4byte sGulpinSprites37
+.4byte sGulpinSprites38
+.4byte sGulpinSprites39
+.4byte sGulpinSprites40
+.4byte sGulpinSprites41
+.4byte sGulpinSprites42
+.4byte sGulpinSprites43
+.4byte sGulpinSprites44
+.4byte sGulpinSprites45
+.4byte sGulpinSprites46
+.4byte sGulpinSprites47
+.4byte sGulpinSprites48
+.4byte sGulpinSprites49
+.4byte sGulpinSprites50
+sAxMainGulpin:
+ax_main sAxPosesGulpin, sAxAnimationsGulpin, 13, sAxSpritesGulpin, sAxPositionsGulpin

--- a/data/ax/gyarados.inc
+++ b/data/ax/gyarados.inc
@@ -1,0 +1,3607 @@
+.global gAxGyarados
+gAxGyarados:
+ax_siro sAxMainGyarados
+sGyaradosPose1:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose2:
+ax_pose 2, 0x81d9, 0x410e, 0x5c00
+ax_pose 3, 0x81c9, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose3:
+ax_pose 4, 0x81d5, 0x010e, 0x5c00
+ax_pose 5, 0x81c5, 0xc0ee, 0x5c02
+ax_pose_terminator
+sGyaradosPose4:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose5:
+ax_pose 7, 0x41c6, 0x10fb, 0x5c00
+ax_pose 8, 0x01ee, 0x50f3, 0x5c02
+ax_pose 9, 0x41ee, 0x9103, 0x5c06
+ax_pose 10, 0x41ce, 0xd0e3, 0x5c0e
+ax_pose_terminator
+sGyaradosPose6:
+ax_pose 11, 0x81e1, 0x50e6, 0x5c00
+ax_pose 12, 0x01d9, 0x10e6, 0x5c04
+ax_pose 13, 0x41e9, 0x110e, 0x5c05
+ax_pose 14, 0x81c9, 0x910e, 0x5c07
+ax_pose 15, 0x81c1, 0xd0ee, 0x5c0f
+ax_pose_terminator
+sGyaradosPose7:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose8:
+ax_pose 17, 0x41e7, 0x10cf, 0x5c00
+ax_pose 18, 0x41df, 0x50c7, 0x5c02
+ax_pose 19, 0x01cf, 0x50d7, 0x5c06
+ax_pose 20, 0x41f7, 0x50ef, 0x5c0a
+ax_pose 21, 0x41e7, 0x90e7, 0x5c0e
+ax_pose 22, 0x41e7, 0x9107, 0x5c16
+ax_pose 23, 0x41c7, 0xd0e7, 0x5c1e
+ax_pose_terminator
+sGyaradosPose9:
+ax_pose 24, 0x01d8, 0x10e4, 0x5c00
+ax_pose 25, 0x01c8, 0x10e4, 0x5c01
+ax_pose 26, 0x4200, 0x10e4, 0x5c02
+ax_pose 27, 0x01e0, 0x90dc, 0x5c04
+ax_pose 28, 0x81c0, 0x90ec, 0x5c14
+ax_pose 29, 0x81c0, 0xd0fc, 0x5c1c
+ax_pose_terminator
+sGyaradosPose10:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose11:
+ax_pose 34, 0x41e5, 0x90fe, 0x5c00
+ax_pose 35, 0x41f5, 0x50ee, 0x5c08
+ax_pose 36, 0x01d5, 0x90de, 0x5c0c
+ax_pose 37, 0x01c5, 0x90fe, 0x5c1c
+ax_pose_terminator
+sGyaradosPose12:
+ax_pose 38, 0x4200, 0x10e5, 0x5c00
+ax_pose 39, 0x81c0, 0x50ed, 0x5c02
+ax_pose 40, 0x81e0, 0x90e5, 0x5c06
+ax_pose 41, 0x81c0, 0xd0f5, 0x5c0e
+ax_pose_terminator
+sGyaradosPose13:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose14:
+ax_pose 44, 0x01cf, 0x0110, 0x5c00
+ax_pose 45, 0x81bf, 0xc0f0, 0x5c01
+ax_pose_terminator
+sGyaradosPose15:
+ax_pose 46, 0x41ff, 0x00f8, 0x5c00
+ax_pose 47, 0x81cf, 0x410d, 0x5c02
+ax_pose 48, 0x81bf, 0xc0ed, 0x5c06
+ax_pose_terminator
+sGyaradosPose16:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose17:
+ax_pose 34, 0x41e5, 0x80e2, 0x5c00
+ax_pose 35, 0x41f5, 0x40f2, 0x5c08
+ax_pose 36, 0x01d5, 0x8102, 0x5c0c
+ax_pose 37, 0x01c5, 0x80e2, 0x5c1c
+ax_pose_terminator
+sGyaradosPose18:
+ax_pose 38, 0x4200, 0x010b, 0x5c00
+ax_pose 39, 0x81c0, 0x410b, 0x5c02
+ax_pose 40, 0x81e0, 0x810b, 0x5c06
+ax_pose 41, 0x81c0, 0xc0eb, 0x5c0e
+ax_pose_terminator
+sGyaradosPose19:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose20:
+ax_pose 17, 0x41e7, 0x0121, 0x5c00
+ax_pose 18, 0x41df, 0x4119, 0x5c02
+ax_pose 19, 0x01cf, 0x4119, 0x5c06
+ax_pose 20, 0x41f7, 0x40f1, 0x5c0a
+ax_pose 21, 0x41e7, 0x80f9, 0x5c0e
+ax_pose 22, 0x41e7, 0x80d9, 0x5c16
+ax_pose 23, 0x41c7, 0xc0d9, 0x5c1e
+ax_pose_terminator
+sGyaradosPose21:
+ax_pose 24, 0x01d8, 0x0114, 0x5c00
+ax_pose 25, 0x01c8, 0x0114, 0x5c01
+ax_pose 26, 0x4200, 0x010c, 0x5c02
+ax_pose 27, 0x01e0, 0x8104, 0x5c04
+ax_pose 28, 0x81c0, 0x8104, 0x5c14
+ax_pose 29, 0x81c0, 0xc0e4, 0x5c1c
+ax_pose_terminator
+sGyaradosPose22:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose23:
+ax_pose 7, 0x41c6, 0x00f5, 0x5c00
+ax_pose 8, 0x01ee, 0x40fd, 0x5c02
+ax_pose 9, 0x41ee, 0x80dd, 0x5c06
+ax_pose 10, 0x41ce, 0xc0dd, 0x5c0e
+ax_pose_terminator
+sGyaradosPose24:
+ax_pose 11, 0x81e1, 0x4112, 0x5c00
+ax_pose 12, 0x01d9, 0x0112, 0x5c04
+ax_pose 13, 0x41e9, 0x00e2, 0x5c05
+ax_pose 14, 0x81c9, 0x80e2, 0x5c07
+ax_pose 15, 0x81c1, 0xc0f2, 0x5c0f
+ax_pose_terminator
+sGyaradosPose25:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose26:
+ax_pose 2, 0x81d9, 0x410e, 0x5c00
+ax_pose 3, 0x81c9, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose27:
+ax_pose 4, 0x81d5, 0x010e, 0x5c00
+ax_pose 5, 0x81c5, 0xc0ee, 0x5c02
+ax_pose_terminator
+sGyaradosPose28:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose29:
+ax_pose 7, 0x41c6, 0x10fb, 0x5c00
+ax_pose 8, 0x01ee, 0x50f3, 0x5c02
+ax_pose 9, 0x41ee, 0x9103, 0x5c06
+ax_pose 10, 0x41ce, 0xd0e3, 0x5c0e
+ax_pose_terminator
+sGyaradosPose30:
+ax_pose 11, 0x81e1, 0x50e6, 0x5c00
+ax_pose 12, 0x01d9, 0x10e6, 0x5c04
+ax_pose 13, 0x41e9, 0x110e, 0x5c05
+ax_pose 14, 0x81c9, 0x910e, 0x5c07
+ax_pose 15, 0x81c1, 0xd0ee, 0x5c0f
+ax_pose_terminator
+sGyaradosPose31:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose32:
+ax_pose 17, 0x41e7, 0x10cf, 0x5c00
+ax_pose 18, 0x41df, 0x50c7, 0x5c02
+ax_pose 19, 0x01cf, 0x50d7, 0x5c06
+ax_pose 20, 0x41f7, 0x50ef, 0x5c0a
+ax_pose 21, 0x41e7, 0x90e7, 0x5c0e
+ax_pose 22, 0x41e7, 0x9107, 0x5c16
+ax_pose 23, 0x41c7, 0xd0e7, 0x5c1e
+ax_pose_terminator
+sGyaradosPose33:
+ax_pose 24, 0x01d8, 0x10e4, 0x5c00
+ax_pose 25, 0x01c8, 0x10e4, 0x5c01
+ax_pose 26, 0x4200, 0x10e4, 0x5c02
+ax_pose 27, 0x01e0, 0x90dc, 0x5c04
+ax_pose 28, 0x81c0, 0x90ec, 0x5c14
+ax_pose 29, 0x81c0, 0xd0fc, 0x5c1c
+ax_pose_terminator
+sGyaradosPose34:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose35:
+ax_pose 34, 0x41e5, 0x90fe, 0x5c00
+ax_pose 35, 0x41f5, 0x50ee, 0x5c08
+ax_pose 36, 0x01d5, 0x90de, 0x5c0c
+ax_pose 37, 0x01c5, 0x90fe, 0x5c1c
+ax_pose_terminator
+sGyaradosPose36:
+ax_pose 38, 0x4200, 0x10e5, 0x5c00
+ax_pose 39, 0x81c0, 0x50ed, 0x5c02
+ax_pose 40, 0x81e0, 0x90e5, 0x5c06
+ax_pose 41, 0x81c0, 0xd0f5, 0x5c0e
+ax_pose_terminator
+sGyaradosPose37:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose38:
+ax_pose 44, 0x01cf, 0x0110, 0x5c00
+ax_pose 45, 0x81bf, 0xc0f0, 0x5c01
+ax_pose_terminator
+sGyaradosPose39:
+ax_pose 46, 0x41ff, 0x00f8, 0x5c00
+ax_pose 47, 0x81cf, 0x410d, 0x5c02
+ax_pose 48, 0x81bf, 0xc0ed, 0x5c06
+ax_pose_terminator
+sGyaradosPose40:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose41:
+ax_pose 34, 0x41e5, 0x80e2, 0x5c00
+ax_pose 35, 0x41f5, 0x40f2, 0x5c08
+ax_pose 36, 0x01d5, 0x8102, 0x5c0c
+ax_pose 37, 0x01c5, 0x80e2, 0x5c1c
+ax_pose_terminator
+sGyaradosPose42:
+ax_pose 38, 0x4200, 0x010b, 0x5c00
+ax_pose 39, 0x81c0, 0x410b, 0x5c02
+ax_pose 40, 0x81e0, 0x810b, 0x5c06
+ax_pose 41, 0x81c0, 0xc0eb, 0x5c0e
+ax_pose_terminator
+sGyaradosPose43:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose44:
+ax_pose 17, 0x41e7, 0x0121, 0x5c00
+ax_pose 18, 0x41df, 0x4119, 0x5c02
+ax_pose 19, 0x01cf, 0x4119, 0x5c06
+ax_pose 20, 0x41f7, 0x40f1, 0x5c0a
+ax_pose 21, 0x41e7, 0x80f9, 0x5c0e
+ax_pose 22, 0x41e7, 0x80d9, 0x5c16
+ax_pose 23, 0x41c7, 0xc0d9, 0x5c1e
+ax_pose_terminator
+sGyaradosPose45:
+ax_pose 24, 0x01d8, 0x0114, 0x5c00
+ax_pose 25, 0x01c8, 0x0114, 0x5c01
+ax_pose 26, 0x4200, 0x010c, 0x5c02
+ax_pose 27, 0x01e0, 0x8104, 0x5c04
+ax_pose 28, 0x81c0, 0x8104, 0x5c14
+ax_pose 29, 0x81c0, 0xc0e4, 0x5c1c
+ax_pose_terminator
+sGyaradosPose46:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose47:
+ax_pose 7, 0x41c6, 0x00f5, 0x5c00
+ax_pose 8, 0x01ee, 0x40fd, 0x5c02
+ax_pose 9, 0x41ee, 0x80dd, 0x5c06
+ax_pose 10, 0x41ce, 0xc0dd, 0x5c0e
+ax_pose_terminator
+sGyaradosPose48:
+ax_pose 11, 0x81e1, 0x4112, 0x5c00
+ax_pose 12, 0x01d9, 0x0112, 0x5c04
+ax_pose 13, 0x41e9, 0x00e2, 0x5c05
+ax_pose 14, 0x81c9, 0x80e2, 0x5c07
+ax_pose 15, 0x81c1, 0xc0f2, 0x5c0f
+ax_pose_terminator
+sGyaradosPose49:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose50:
+ax_pose 2, 0x81d9, 0x410e, 0x5c00
+ax_pose 3, 0x81c9, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose51:
+ax_pose 4, 0x81d5, 0x010e, 0x5c00
+ax_pose 5, 0x81c5, 0xc0ee, 0x5c02
+ax_pose_terminator
+sGyaradosPose52:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose53:
+ax_pose 7, 0x41c6, 0x10fb, 0x5c00
+ax_pose 8, 0x01ee, 0x50f3, 0x5c02
+ax_pose 9, 0x41ee, 0x9103, 0x5c06
+ax_pose 10, 0x41ce, 0xd0e3, 0x5c0e
+ax_pose_terminator
+sGyaradosPose54:
+ax_pose 11, 0x81e1, 0x50e6, 0x5c00
+ax_pose 12, 0x01d9, 0x10e6, 0x5c04
+ax_pose 13, 0x41e9, 0x110e, 0x5c05
+ax_pose 14, 0x81c9, 0x910e, 0x5c07
+ax_pose 15, 0x81c1, 0xd0ee, 0x5c0f
+ax_pose_terminator
+sGyaradosPose55:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose56:
+ax_pose 17, 0x41e7, 0x10cf, 0x5c00
+ax_pose 18, 0x41df, 0x50c7, 0x5c02
+ax_pose 19, 0x01cf, 0x50d7, 0x5c06
+ax_pose 20, 0x41f7, 0x50ef, 0x5c0a
+ax_pose 21, 0x41e7, 0x90e7, 0x5c0e
+ax_pose 22, 0x41e7, 0x9107, 0x5c16
+ax_pose 23, 0x41c7, 0xd0e7, 0x5c1e
+ax_pose_terminator
+sGyaradosPose57:
+ax_pose 24, 0x01d8, 0x10e4, 0x5c00
+ax_pose 25, 0x01c8, 0x10e4, 0x5c01
+ax_pose 26, 0x4200, 0x10e4, 0x5c02
+ax_pose 27, 0x01e0, 0x90dc, 0x5c04
+ax_pose 28, 0x81c0, 0x90ec, 0x5c14
+ax_pose 29, 0x81c0, 0xd0fc, 0x5c1c
+ax_pose_terminator
+sGyaradosPose58:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose59:
+ax_pose 34, 0x41e5, 0x90fe, 0x5c00
+ax_pose 35, 0x41f5, 0x50ee, 0x5c08
+ax_pose 36, 0x01d5, 0x90de, 0x5c0c
+ax_pose 37, 0x01c5, 0x90fe, 0x5c1c
+ax_pose_terminator
+sGyaradosPose60:
+ax_pose 38, 0x4200, 0x10e5, 0x5c00
+ax_pose 39, 0x81c0, 0x50ed, 0x5c02
+ax_pose 40, 0x81e0, 0x90e5, 0x5c06
+ax_pose 41, 0x81c0, 0xd0f5, 0x5c0e
+ax_pose_terminator
+sGyaradosPose61:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose62:
+ax_pose 44, 0x01cf, 0x0110, 0x5c00
+ax_pose 45, 0x81bf, 0xc0f0, 0x5c01
+ax_pose_terminator
+sGyaradosPose63:
+ax_pose 46, 0x41ff, 0x00f8, 0x5c00
+ax_pose 47, 0x81cf, 0x410d, 0x5c02
+ax_pose 48, 0x81bf, 0xc0ed, 0x5c06
+ax_pose_terminator
+sGyaradosPose64:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose65:
+ax_pose 34, 0x41e5, 0x80e2, 0x5c00
+ax_pose 35, 0x41f5, 0x40f2, 0x5c08
+ax_pose 36, 0x01d5, 0x8102, 0x5c0c
+ax_pose 37, 0x01c5, 0x80e2, 0x5c1c
+ax_pose_terminator
+sGyaradosPose66:
+ax_pose 38, 0x4200, 0x010b, 0x5c00
+ax_pose 39, 0x81c0, 0x410b, 0x5c02
+ax_pose 40, 0x81e0, 0x810b, 0x5c06
+ax_pose 41, 0x81c0, 0xc0eb, 0x5c0e
+ax_pose_terminator
+sGyaradosPose67:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose68:
+ax_pose 17, 0x41e7, 0x0121, 0x5c00
+ax_pose 18, 0x41df, 0x4119, 0x5c02
+ax_pose 19, 0x01cf, 0x4119, 0x5c06
+ax_pose 20, 0x41f7, 0x40f1, 0x5c0a
+ax_pose 21, 0x41e7, 0x80f9, 0x5c0e
+ax_pose 22, 0x41e7, 0x80d9, 0x5c16
+ax_pose 23, 0x41c7, 0xc0d9, 0x5c1e
+ax_pose_terminator
+sGyaradosPose69:
+ax_pose 24, 0x01d8, 0x0114, 0x5c00
+ax_pose 25, 0x01c8, 0x0114, 0x5c01
+ax_pose 26, 0x4200, 0x010c, 0x5c02
+ax_pose 27, 0x01e0, 0x8104, 0x5c04
+ax_pose 28, 0x81c0, 0x8104, 0x5c14
+ax_pose 29, 0x81c0, 0xc0e4, 0x5c1c
+ax_pose_terminator
+sGyaradosPose70:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose71:
+ax_pose 7, 0x41c6, 0x00f5, 0x5c00
+ax_pose 8, 0x01ee, 0x40fd, 0x5c02
+ax_pose 9, 0x41ee, 0x80dd, 0x5c06
+ax_pose 10, 0x41ce, 0xc0dd, 0x5c0e
+ax_pose_terminator
+sGyaradosPose72:
+ax_pose 11, 0x81e1, 0x4112, 0x5c00
+ax_pose 12, 0x01d9, 0x0112, 0x5c04
+ax_pose 13, 0x41e9, 0x00e2, 0x5c05
+ax_pose 14, 0x81c9, 0x80e2, 0x5c07
+ax_pose 15, 0x81c1, 0xc0f2, 0x5c0f
+ax_pose_terminator
+sGyaradosPose73:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose74:
+ax_pose 2, 0x81d9, 0x410e, 0x5c00
+ax_pose 3, 0x81c9, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose75:
+ax_pose 4, 0x81d5, 0x010e, 0x5c00
+ax_pose 5, 0x81c5, 0xc0ee, 0x5c02
+ax_pose_terminator
+sGyaradosPose76:
+ax_pose 49, 0x81c0, 0xc0ef, 0x5c00
+ax_pose 50, 0x81d8, 0x010f, 0x5c20
+ax_pose_terminator
+sGyaradosPose77:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose78:
+ax_pose 7, 0x41c6, 0x10fb, 0x5c00
+ax_pose 8, 0x01ee, 0x50f3, 0x5c02
+ax_pose 9, 0x41ee, 0x9103, 0x5c06
+ax_pose 10, 0x41ce, 0xd0e3, 0x5c0e
+ax_pose_terminator
+sGyaradosPose79:
+ax_pose 11, 0x81e1, 0x50e6, 0x5c00
+ax_pose 12, 0x01d9, 0x10e6, 0x5c04
+ax_pose 13, 0x41e9, 0x110e, 0x5c05
+ax_pose 14, 0x81c9, 0x910e, 0x5c07
+ax_pose 15, 0x81c1, 0xd0ee, 0x5c0f
+ax_pose_terminator
+sGyaradosPose80:
+ax_pose 51, 0x41cd, 0x9103, 0x5c00
+ax_pose 52, 0x41cd, 0x90e3, 0x5c08
+ax_pose 53, 0x41dd, 0xd0e3, 0x5c10
+ax_pose 54, 0x81d8, 0x1123, 0x5c30
+ax_pose_terminator
+sGyaradosPose81:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose82:
+ax_pose 17, 0x41e7, 0x10cf, 0x5c00
+ax_pose 18, 0x41df, 0x50c7, 0x5c02
+ax_pose 19, 0x01cf, 0x50d7, 0x5c06
+ax_pose 20, 0x41f7, 0x50ef, 0x5c0a
+ax_pose 21, 0x41e7, 0x90e7, 0x5c0e
+ax_pose 22, 0x41e7, 0x9107, 0x5c16
+ax_pose 23, 0x41c7, 0xd0e7, 0x5c1e
+ax_pose_terminator
+sGyaradosPose83:
+ax_pose 24, 0x01d8, 0x10e4, 0x5c00
+ax_pose 25, 0x01c8, 0x10e4, 0x5c01
+ax_pose 26, 0x4200, 0x10e4, 0x5c02
+ax_pose 27, 0x01e0, 0x90dc, 0x5c04
+ax_pose 28, 0x81c0, 0x90ec, 0x5c14
+ax_pose 29, 0x81c0, 0xd0fc, 0x5c1c
+ax_pose_terminator
+sGyaradosPose84:
+ax_pose 55, 0x41cc, 0xd0de, 0x5c00
+ax_pose 56, 0x41ec, 0x90fe, 0x5c20
+ax_pose 57, 0x01ec, 0x50ee, 0x5c28
+ax_pose 58, 0x81cc, 0x911e, 0x5c2c
+ax_pose 59, 0x01d7, 0x50ce, 0x5c34
+ax_pose 60, 0x01ec, 0x111e, 0x5c38
+ax_pose_terminator
+sGyaradosPose85:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose86:
+ax_pose 34, 0x41e5, 0x90fe, 0x5c00
+ax_pose 35, 0x41f5, 0x50ee, 0x5c08
+ax_pose 36, 0x01d5, 0x90de, 0x5c0c
+ax_pose 37, 0x01c5, 0x90fe, 0x5c1c
+ax_pose_terminator
+sGyaradosPose87:
+ax_pose 38, 0x4200, 0x10e5, 0x5c00
+ax_pose 39, 0x81c0, 0x50ed, 0x5c02
+ax_pose 40, 0x81e0, 0x90e5, 0x5c06
+ax_pose 41, 0x81c0, 0xd0f5, 0x5c0e
+ax_pose_terminator
+sGyaradosPose88:
+ax_pose 61, 0x81c0, 0xd0fe, 0x5c00
+ax_pose 62, 0x01d0, 0x50ee, 0x5c20
+ax_pose 63, 0x81d0, 0x10e6, 0x5c24
+ax_pose 64, 0x01e0, 0x90de, 0x5c26
+ax_pose 65, 0x81d0, 0x511e, 0x5c36
+ax_pose_terminator
+sGyaradosPose89:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose90:
+ax_pose 44, 0x01cf, 0x0110, 0x5c00
+ax_pose 45, 0x81bf, 0xc0f0, 0x5c01
+ax_pose_terminator
+sGyaradosPose91:
+ax_pose 46, 0x41ff, 0x00f8, 0x5c00
+ax_pose 47, 0x81cf, 0x410d, 0x5c02
+ax_pose 48, 0x81bf, 0xc0ed, 0x5c06
+ax_pose_terminator
+sGyaradosPose92:
+ax_pose 66, 0x81c0, 0xc0f0, 0x5c00
+ax_pose 67, 0x81d0, 0x4110, 0x5c20
+ax_pose_terminator
+sGyaradosPose93:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose94:
+ax_pose 34, 0x41e5, 0x80e2, 0x5c00
+ax_pose 35, 0x41f5, 0x40f2, 0x5c08
+ax_pose 36, 0x01d5, 0x8102, 0x5c0c
+ax_pose 37, 0x01c5, 0x80e2, 0x5c1c
+ax_pose_terminator
+sGyaradosPose95:
+ax_pose 38, 0x4200, 0x010b, 0x5c00
+ax_pose 39, 0x81c0, 0x410b, 0x5c02
+ax_pose 40, 0x81e0, 0x810b, 0x5c06
+ax_pose 41, 0x81c0, 0xc0eb, 0x5c0e
+ax_pose_terminator
+sGyaradosPose96:
+ax_pose 61, 0x81c0, 0xc0e2, 0x5c00
+ax_pose 62, 0x01d0, 0x4102, 0x5c20
+ax_pose 63, 0x81d0, 0x0112, 0x5c24
+ax_pose 64, 0x01e0, 0x8102, 0x5c26
+ax_pose 65, 0x81d0, 0x40da, 0x5c36
+ax_pose_terminator
+sGyaradosPose97:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose98:
+ax_pose 17, 0x41e7, 0x0121, 0x5c00
+ax_pose 18, 0x41df, 0x4119, 0x5c02
+ax_pose 19, 0x01cf, 0x4119, 0x5c06
+ax_pose 20, 0x41f7, 0x40f1, 0x5c0a
+ax_pose 21, 0x41e7, 0x80f9, 0x5c0e
+ax_pose 22, 0x41e7, 0x80d9, 0x5c16
+ax_pose 23, 0x41c7, 0xc0d9, 0x5c1e
+ax_pose_terminator
+sGyaradosPose99:
+ax_pose 24, 0x01d8, 0x0114, 0x5c00
+ax_pose 25, 0x01c8, 0x0114, 0x5c01
+ax_pose 26, 0x4200, 0x010c, 0x5c02
+ax_pose 27, 0x01e0, 0x8104, 0x5c04
+ax_pose 28, 0x81c0, 0x8104, 0x5c14
+ax_pose 29, 0x81c0, 0xc0e4, 0x5c1c
+ax_pose_terminator
+sGyaradosPose100:
+ax_pose 55, 0x41cc, 0xc0e2, 0x5c00
+ax_pose 56, 0x41ec, 0x80e2, 0x5c20
+ax_pose 57, 0x01ec, 0x4102, 0x5c28
+ax_pose 58, 0x81cc, 0x80d2, 0x5c2c
+ax_pose 59, 0x01d7, 0x4122, 0x5c34
+ax_pose 60, 0x01ec, 0x00da, 0x5c38
+ax_pose_terminator
+sGyaradosPose101:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose102:
+ax_pose 7, 0x41c6, 0x00f5, 0x5c00
+ax_pose 8, 0x01ee, 0x40fd, 0x5c02
+ax_pose 9, 0x41ee, 0x80dd, 0x5c06
+ax_pose 10, 0x41ce, 0xc0dd, 0x5c0e
+ax_pose_terminator
+sGyaradosPose103:
+ax_pose 11, 0x81e1, 0x4112, 0x5c00
+ax_pose 12, 0x01d9, 0x0112, 0x5c04
+ax_pose 13, 0x41e9, 0x00e2, 0x5c05
+ax_pose 14, 0x81c9, 0x80e2, 0x5c07
+ax_pose 15, 0x81c1, 0xc0f2, 0x5c0f
+ax_pose_terminator
+sGyaradosPose104:
+ax_pose 51, 0x41cd, 0x80dd, 0x5c00
+ax_pose 52, 0x41cd, 0x80fd, 0x5c08
+ax_pose 53, 0x41dd, 0xc0dd, 0x5c10
+ax_pose 54, 0x81d8, 0x00d5, 0x5c30
+ax_pose_terminator
+sGyaradosPose105:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose106:
+ax_pose 2, 0x81d9, 0x410e, 0x5c00
+ax_pose 3, 0x81c9, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose107:
+ax_pose 4, 0x81d5, 0x010e, 0x5c00
+ax_pose 5, 0x81c5, 0xc0ee, 0x5c02
+ax_pose_terminator
+sGyaradosPose108:
+ax_pose 68, 0x81c8, 0xc0e8, 0x5c00
+ax_pose 69, 0x81c8, 0x8108, 0x5c20
+ax_pose 70, 0x81e8, 0x4108, 0x5c28
+ax_pose 71, 0x4208, 0x00f8, 0x5c2c
+ax_pose_terminator
+sGyaradosPose109:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose110:
+ax_pose 7, 0x41c6, 0x10fb, 0x5c00
+ax_pose 8, 0x01ee, 0x50f3, 0x5c02
+ax_pose 9, 0x41ee, 0x9103, 0x5c06
+ax_pose 10, 0x41ce, 0xd0e3, 0x5c0e
+ax_pose_terminator
+sGyaradosPose111:
+ax_pose 11, 0x81e1, 0x50e6, 0x5c00
+ax_pose 12, 0x01d9, 0x10e6, 0x5c04
+ax_pose 13, 0x41e9, 0x110e, 0x5c05
+ax_pose 14, 0x81c9, 0x910e, 0x5c07
+ax_pose 15, 0x81c1, 0xd0ee, 0x5c0f
+ax_pose_terminator
+sGyaradosPose112:
+ax_pose 72, 0x81c0, 0xd0f9, 0x5c00
+ax_pose 73, 0x01d0, 0x50e9, 0x5c20
+ax_pose 74, 0x81e0, 0x90e9, 0x5c24
+ax_pose 75, 0x4200, 0x10e9, 0x5c2c
+ax_pose_terminator
+sGyaradosPose113:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose114:
+ax_pose 17, 0x41e7, 0x10cf, 0x5c00
+ax_pose 18, 0x41df, 0x50c7, 0x5c02
+ax_pose 19, 0x01cf, 0x50d7, 0x5c06
+ax_pose 20, 0x41f7, 0x50ef, 0x5c0a
+ax_pose 21, 0x41e7, 0x90e7, 0x5c0e
+ax_pose 22, 0x41e7, 0x9107, 0x5c16
+ax_pose 23, 0x41c7, 0xd0e7, 0x5c1e
+ax_pose_terminator
+sGyaradosPose115:
+ax_pose 24, 0x01d8, 0x10e4, 0x5c00
+ax_pose 25, 0x01c8, 0x10e4, 0x5c01
+ax_pose 26, 0x4200, 0x10e4, 0x5c02
+ax_pose 27, 0x01e0, 0x90dc, 0x5c04
+ax_pose 28, 0x81c0, 0x90ec, 0x5c14
+ax_pose 29, 0x81c0, 0xd0fc, 0x5c1c
+ax_pose_terminator
+sGyaradosPose116:
+ax_pose 76, 0x81c0, 0xd0fe, 0x5c00
+ax_pose 77, 0x81c0, 0x90ee, 0x5c20
+ax_pose 78, 0x01e0, 0x90de, 0x5c28
+ax_pose 79, 0x0200, 0x50e5, 0x5c38
+ax_pose 80, 0x4210, 0x10e5, 0x5c3c
+ax_pose 81, 0x01d0, 0x111e, 0x5c3e
+ax_pose_terminator
+sGyaradosPose117:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose118:
+ax_pose 34, 0x41e5, 0x90fe, 0x5c00
+ax_pose 35, 0x41f5, 0x50ee, 0x5c08
+ax_pose 36, 0x01d5, 0x90de, 0x5c0c
+ax_pose 37, 0x01c5, 0x90fe, 0x5c1c
+ax_pose_terminator
+sGyaradosPose119:
+ax_pose 38, 0x4200, 0x10e5, 0x5c00
+ax_pose 39, 0x81c0, 0x50ed, 0x5c02
+ax_pose 40, 0x81e0, 0x90e5, 0x5c06
+ax_pose 41, 0x81c0, 0xd0f5, 0x5c0e
+ax_pose_terminator
+sGyaradosPose120:
+ax_pose 82, 0x81c0, 0xd0fe, 0x5c00
+ax_pose 83, 0x81c0, 0x90ee, 0x5c20
+ax_pose 84, 0x01e0, 0x90de, 0x5c28
+ax_pose 85, 0x8200, 0x90ea, 0x5c38
+ax_pose_terminator
+sGyaradosPose121:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose122:
+ax_pose 44, 0x01cf, 0x0110, 0x5c00
+ax_pose 45, 0x81bf, 0xc0f0, 0x5c01
+ax_pose_terminator
+sGyaradosPose123:
+ax_pose 46, 0x41ff, 0x00f8, 0x5c00
+ax_pose 47, 0x81cf, 0x410d, 0x5c02
+ax_pose 48, 0x81bf, 0xc0ed, 0x5c06
+ax_pose_terminator
+sGyaradosPose124:
+ax_pose 86, 0x81bf, 0xc0ef, 0x5c00
+ax_pose 87, 0x81cf, 0x010f, 0x5c20
+ax_pose 88, 0x81ff, 0x80f8, 0x5c22
+ax_pose_terminator
+sGyaradosPose125:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose126:
+ax_pose 34, 0x41e5, 0x80e2, 0x5c00
+ax_pose 35, 0x41f5, 0x40f2, 0x5c08
+ax_pose 36, 0x01d5, 0x8102, 0x5c0c
+ax_pose 37, 0x01c5, 0x80e2, 0x5c1c
+ax_pose_terminator
+sGyaradosPose127:
+ax_pose 38, 0x4200, 0x010b, 0x5c00
+ax_pose 39, 0x81c0, 0x410b, 0x5c02
+ax_pose 40, 0x81e0, 0x810b, 0x5c06
+ax_pose 41, 0x81c0, 0xc0eb, 0x5c0e
+ax_pose_terminator
+sGyaradosPose128:
+ax_pose 82, 0x81c0, 0xc0e2, 0x5c00
+ax_pose 83, 0x81c0, 0x8102, 0x5c20
+ax_pose 84, 0x01e0, 0x8102, 0x5c28
+ax_pose 85, 0x8200, 0x8106, 0x5c38
+ax_pose_terminator
+sGyaradosPose129:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose130:
+ax_pose 17, 0x41e7, 0x0121, 0x5c00
+ax_pose 18, 0x41df, 0x4119, 0x5c02
+ax_pose 19, 0x01cf, 0x4119, 0x5c06
+ax_pose 20, 0x41f7, 0x40f1, 0x5c0a
+ax_pose 21, 0x41e7, 0x80f9, 0x5c0e
+ax_pose 22, 0x41e7, 0x80d9, 0x5c16
+ax_pose 23, 0x41c7, 0xc0d9, 0x5c1e
+ax_pose_terminator
+sGyaradosPose131:
+ax_pose 24, 0x01d8, 0x0114, 0x5c00
+ax_pose 25, 0x01c8, 0x0114, 0x5c01
+ax_pose 26, 0x4200, 0x010c, 0x5c02
+ax_pose 27, 0x01e0, 0x8104, 0x5c04
+ax_pose 28, 0x81c0, 0x8104, 0x5c14
+ax_pose 29, 0x81c0, 0xc0e4, 0x5c1c
+ax_pose_terminator
+sGyaradosPose132:
+ax_pose 76, 0x81c0, 0xc0e2, 0x5c00
+ax_pose 77, 0x81c0, 0x8102, 0x5c20
+ax_pose 78, 0x01e0, 0x8102, 0x5c28
+ax_pose 79, 0x0200, 0x410b, 0x5c38
+ax_pose 80, 0x4210, 0x010b, 0x5c3c
+ax_pose 81, 0x01d0, 0x00da, 0x5c3e
+ax_pose_terminator
+sGyaradosPose133:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose134:
+ax_pose 7, 0x41c6, 0x00f5, 0x5c00
+ax_pose 8, 0x01ee, 0x40fd, 0x5c02
+ax_pose 9, 0x41ee, 0x80dd, 0x5c06
+ax_pose 10, 0x41ce, 0xc0dd, 0x5c0e
+ax_pose_terminator
+sGyaradosPose135:
+ax_pose 11, 0x81e1, 0x4112, 0x5c00
+ax_pose 12, 0x01d9, 0x0112, 0x5c04
+ax_pose 13, 0x41e9, 0x00e2, 0x5c05
+ax_pose 14, 0x81c9, 0x80e2, 0x5c07
+ax_pose 15, 0x81c1, 0xc0f2, 0x5c0f
+ax_pose_terminator
+sGyaradosPose136:
+ax_pose 72, 0x81c0, 0xc0e7, 0x5c00
+ax_pose 73, 0x01d0, 0x4107, 0x5c20
+ax_pose 74, 0x81e0, 0x8107, 0x5c24
+ax_pose 75, 0x4200, 0x0107, 0x5c2c
+ax_pose_terminator
+sGyaradosPose137:
+ax_pose 89, 0x01c0, 0xc0df, 0x5c00
+ax_pose_terminator
+sGyaradosPose138:
+ax_pose 90, 0x01c0, 0xc0df, 0x5c00
+ax_pose_terminator
+sGyaradosPose139:
+ax_pose 91, 0x01c5, 0xc0df, 0x5c00
+ax_pose_terminator
+sGyaradosPose140:
+ax_pose 92, 0x01c1, 0xd0dd, 0x5c00
+ax_pose_terminator
+sGyaradosPose141:
+ax_pose 93, 0x01c3, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose142:
+ax_pose 94, 0x01c3, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose143:
+ax_pose 95, 0x01e2, 0x80f1, 0x5c00
+ax_pose 96, 0x41c2, 0xc0e1, 0x5c10
+ax_pose_terminator
+sGyaradosPose144:
+ax_pose 94, 0x01c3, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose145:
+ax_pose 93, 0x01c3, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose146:
+ax_pose 92, 0x01c1, 0xc0e3, 0x5c00
+ax_pose_terminator
+sGyaradosPose147:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose148:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose149:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose150:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose151:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose152:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose153:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose154:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose155:
+ax_pose 49, 0x81c9, 0xc0ef, 0x5c00
+ax_pose 50, 0x81e1, 0x010f, 0x5c20
+ax_pose_terminator
+sGyaradosPose156:
+ax_pose 51, 0x41d0, 0x80df, 0x5c00
+ax_pose 52, 0x41d0, 0x80ff, 0x5c08
+ax_pose 53, 0x41e0, 0xc0df, 0x5c10
+ax_pose 54, 0x81db, 0x00d7, 0x5c30
+ax_pose_terminator
+sGyaradosPose157:
+ax_pose 55, 0x41cc, 0xc0e5, 0x5c00
+ax_pose 56, 0x41ec, 0x80e5, 0x5c20
+ax_pose 57, 0x01ec, 0x4105, 0x5c28
+ax_pose 58, 0x81cc, 0x80d5, 0x5c2c
+ax_pose 59, 0x01d7, 0x4125, 0x5c34
+ax_pose 60, 0x01ec, 0x00dd, 0x5c38
+ax_pose_terminator
+sGyaradosPose158:
+ax_pose 61, 0x81c0, 0xc0e5, 0x5c00
+ax_pose 62, 0x01d0, 0x4105, 0x5c20
+ax_pose 63, 0x81d0, 0x0115, 0x5c24
+ax_pose 64, 0x01e0, 0x8105, 0x5c26
+ax_pose 65, 0x81d0, 0x40dd, 0x5c36
+ax_pose_terminator
+sGyaradosPose159:
+ax_pose 66, 0x81bf, 0xc0f0, 0x5c00
+ax_pose 67, 0x81cf, 0x4110, 0x5c20
+ax_pose_terminator
+sGyaradosPose160:
+ax_pose 61, 0x81c0, 0xd0fb, 0x5c00
+ax_pose 62, 0x01d0, 0x50eb, 0x5c20
+ax_pose 63, 0x81d0, 0x10e3, 0x5c24
+ax_pose 64, 0x01e0, 0x90db, 0x5c26
+ax_pose 65, 0x81d0, 0x511b, 0x5c36
+ax_pose_terminator
+sGyaradosPose161:
+ax_pose 55, 0x41cc, 0xd0db, 0x5c00
+ax_pose 56, 0x41ec, 0x90fb, 0x5c20
+ax_pose 57, 0x01ec, 0x50eb, 0x5c28
+ax_pose 58, 0x81cc, 0x911b, 0x5c2c
+ax_pose 59, 0x01d7, 0x50cb, 0x5c34
+ax_pose 60, 0x01ec, 0x111b, 0x5c38
+ax_pose_terminator
+sGyaradosPose162:
+ax_pose 51, 0x41d0, 0x9101, 0x5c00
+ax_pose 52, 0x41d0, 0x90e1, 0x5c08
+ax_pose 53, 0x41e0, 0xd0e1, 0x5c10
+ax_pose 54, 0x81db, 0x1121, 0x5c30
+ax_pose_terminator
+sGyaradosPose163:
+ax_pose 4, 0x81d5, 0x010e, 0x5c00
+ax_pose 5, 0x81c5, 0xc0ee, 0x5c02
+ax_pose_terminator
+sGyaradosPose164:
+ax_pose 11, 0x81e1, 0x50e6, 0x5c00
+ax_pose 12, 0x01d9, 0x10e6, 0x5c04
+ax_pose 13, 0x41e9, 0x110e, 0x5c05
+ax_pose 14, 0x81c9, 0x910e, 0x5c07
+ax_pose 15, 0x81c1, 0xd0ee, 0x5c0f
+ax_pose_terminator
+sGyaradosPose165:
+ax_pose 24, 0x01d8, 0x10e4, 0x5c00
+ax_pose 25, 0x01c8, 0x10e4, 0x5c01
+ax_pose 26, 0x4200, 0x10e4, 0x5c02
+ax_pose 27, 0x01e0, 0x90dc, 0x5c04
+ax_pose 28, 0x81c0, 0x90ec, 0x5c14
+ax_pose 29, 0x81c0, 0xd0fc, 0x5c1c
+ax_pose_terminator
+sGyaradosPose166:
+ax_pose 38, 0x4200, 0x10e5, 0x5c00
+ax_pose 39, 0x81c0, 0x50ed, 0x5c02
+ax_pose 40, 0x81e0, 0x90e5, 0x5c06
+ax_pose 41, 0x81c0, 0xd0f5, 0x5c0e
+ax_pose_terminator
+sGyaradosPose167:
+ax_pose 46, 0x41ff, 0x00f8, 0x5c00
+ax_pose 47, 0x81cf, 0x410d, 0x5c02
+ax_pose 48, 0x81bf, 0xc0ed, 0x5c06
+ax_pose_terminator
+sGyaradosPose168:
+ax_pose 38, 0x4200, 0x010b, 0x5c00
+ax_pose 39, 0x81c0, 0x410b, 0x5c02
+ax_pose 40, 0x81e0, 0x810b, 0x5c06
+ax_pose 41, 0x81c0, 0xc0eb, 0x5c0e
+ax_pose_terminator
+sGyaradosPose169:
+ax_pose 24, 0x01d8, 0x0114, 0x5c00
+ax_pose 25, 0x01c8, 0x0114, 0x5c01
+ax_pose 26, 0x4200, 0x010c, 0x5c02
+ax_pose 27, 0x01e0, 0x8104, 0x5c04
+ax_pose 28, 0x81c0, 0x8104, 0x5c14
+ax_pose 29, 0x81c0, 0xc0e4, 0x5c1c
+ax_pose_terminator
+sGyaradosPose170:
+ax_pose 11, 0x81e1, 0x4112, 0x5c00
+ax_pose 12, 0x01d9, 0x0112, 0x5c04
+ax_pose 13, 0x41e9, 0x00e2, 0x5c05
+ax_pose 14, 0x81c9, 0x80e2, 0x5c07
+ax_pose 15, 0x81c1, 0xc0f2, 0x5c0f
+ax_pose_terminator
+sGyaradosPose171:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose172:
+ax_pose 2, 0x81d9, 0x410e, 0x5c00
+ax_pose 3, 0x81c9, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose173:
+ax_pose 68, 0x81c8, 0xc0e8, 0x5c00
+ax_pose 69, 0x81c8, 0x8108, 0x5c20
+ax_pose 70, 0x81e8, 0x4108, 0x5c28
+ax_pose 71, 0x4208, 0x00f8, 0x5c2c
+ax_pose_terminator
+sGyaradosPose174:
+ax_pose 49, 0x81c9, 0xc0ef, 0x5c00
+ax_pose 50, 0x81e1, 0x010f, 0x5c20
+ax_pose_terminator
+sGyaradosPose175:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose176:
+ax_pose 7, 0x41c6, 0x10f9, 0x5c00
+ax_pose 8, 0x01ee, 0x50f1, 0x5c02
+ax_pose 9, 0x41ee, 0x9101, 0x5c06
+ax_pose 10, 0x41ce, 0xd0e1, 0x5c0e
+ax_pose_terminator
+sGyaradosPose177:
+ax_pose 72, 0x81c0, 0xd0f7, 0x5c00
+ax_pose 73, 0x01d0, 0x50e7, 0x5c20
+ax_pose 74, 0x81e0, 0x90e7, 0x5c24
+ax_pose 75, 0x4200, 0x10e7, 0x5c2c
+ax_pose_terminator
+sGyaradosPose178:
+ax_pose 51, 0x41d0, 0x90ff, 0x5c00
+ax_pose 52, 0x41d0, 0x90df, 0x5c08
+ax_pose 53, 0x41e0, 0xd0df, 0x5c10
+ax_pose 54, 0x81db, 0x111f, 0x5c30
+ax_pose_terminator
+sGyaradosPose179:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose180:
+ax_pose 17, 0x41e7, 0x10cf, 0x5c00
+ax_pose 18, 0x41df, 0x50c7, 0x5c02
+ax_pose 19, 0x01cf, 0x50d7, 0x5c06
+ax_pose 20, 0x41f7, 0x50ef, 0x5c0a
+ax_pose 21, 0x41e7, 0x90e7, 0x5c0e
+ax_pose 22, 0x41e7, 0x9107, 0x5c16
+ax_pose 23, 0x41c7, 0xd0e7, 0x5c1e
+ax_pose_terminator
+sGyaradosPose181:
+ax_pose 76, 0x81c0, 0xd0fe, 0x5c00
+ax_pose 77, 0x81c0, 0x90ee, 0x5c20
+ax_pose 78, 0x01e0, 0x90de, 0x5c28
+ax_pose 79, 0x0200, 0x50e5, 0x5c38
+ax_pose 80, 0x4210, 0x10e5, 0x5c3c
+ax_pose 81, 0x01d0, 0x111e, 0x5c3e
+ax_pose_terminator
+sGyaradosPose182:
+ax_pose 55, 0x41cc, 0xd0dc, 0x5c00
+ax_pose 56, 0x41ec, 0x90fc, 0x5c20
+ax_pose 57, 0x01ec, 0x50ec, 0x5c28
+ax_pose 58, 0x81cc, 0x911c, 0x5c2c
+ax_pose 59, 0x01d7, 0x50cc, 0x5c34
+ax_pose 60, 0x01ec, 0x111c, 0x5c38
+ax_pose_terminator
+sGyaradosPose183:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose184:
+ax_pose 34, 0x41e5, 0x90fe, 0x5c00
+ax_pose 35, 0x41f5, 0x50ee, 0x5c08
+ax_pose 36, 0x01d5, 0x90de, 0x5c0c
+ax_pose 37, 0x01c5, 0x90fe, 0x5c1c
+ax_pose_terminator
+sGyaradosPose185:
+ax_pose 82, 0x81c0, 0xd0fc, 0x5c00
+ax_pose 83, 0x81c0, 0x90ec, 0x5c20
+ax_pose 84, 0x01e0, 0x90dc, 0x5c28
+ax_pose 85, 0x8200, 0x90e8, 0x5c38
+ax_pose_terminator
+sGyaradosPose186:
+ax_pose 61, 0x81c0, 0xd0fb, 0x5c00
+ax_pose 62, 0x01d0, 0x50eb, 0x5c20
+ax_pose 63, 0x81d0, 0x10e3, 0x5c24
+ax_pose 64, 0x01e0, 0x90db, 0x5c26
+ax_pose 65, 0x81d0, 0x511b, 0x5c36
+ax_pose_terminator
+sGyaradosPose187:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose188:
+ax_pose 44, 0x01cf, 0x0110, 0x5c00
+ax_pose 45, 0x81bf, 0xc0f0, 0x5c01
+ax_pose_terminator
+sGyaradosPose189:
+ax_pose 86, 0x81bf, 0xc0ef, 0x5c00
+ax_pose 87, 0x81cf, 0x010f, 0x5c20
+ax_pose 88, 0x81ff, 0x80f8, 0x5c22
+ax_pose_terminator
+sGyaradosPose190:
+ax_pose 66, 0x81bf, 0xc0f0, 0x5c00
+ax_pose 67, 0x81cf, 0x4110, 0x5c20
+ax_pose_terminator
+sGyaradosPose191:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose192:
+ax_pose 34, 0x41e5, 0x80e2, 0x5c00
+ax_pose 35, 0x41f5, 0x40f2, 0x5c08
+ax_pose 36, 0x01d5, 0x8102, 0x5c0c
+ax_pose 37, 0x01c5, 0x80e2, 0x5c1c
+ax_pose_terminator
+sGyaradosPose193:
+ax_pose 82, 0x81c0, 0xc0e4, 0x5c00
+ax_pose 83, 0x81c0, 0x8104, 0x5c20
+ax_pose 84, 0x01e0, 0x8104, 0x5c28
+ax_pose 85, 0x8200, 0x8108, 0x5c38
+ax_pose_terminator
+sGyaradosPose194:
+ax_pose 61, 0x81c0, 0xc0e5, 0x5c00
+ax_pose 62, 0x01d0, 0x4105, 0x5c20
+ax_pose 63, 0x81d0, 0x0115, 0x5c24
+ax_pose 64, 0x01e0, 0x8105, 0x5c26
+ax_pose 65, 0x81d0, 0x40dd, 0x5c36
+ax_pose_terminator
+sGyaradosPose195:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose196:
+ax_pose 17, 0x41e7, 0x0121, 0x5c00
+ax_pose 18, 0x41df, 0x4119, 0x5c02
+ax_pose 19, 0x01cf, 0x4119, 0x5c06
+ax_pose 20, 0x41f7, 0x40f1, 0x5c0a
+ax_pose 21, 0x41e7, 0x80f9, 0x5c0e
+ax_pose 22, 0x41e7, 0x80d9, 0x5c16
+ax_pose 23, 0x41c7, 0xc0d9, 0x5c1e
+ax_pose_terminator
+sGyaradosPose197:
+ax_pose 76, 0x81c0, 0xc0e2, 0x5c00
+ax_pose 77, 0x81c0, 0x8102, 0x5c20
+ax_pose 78, 0x01e0, 0x8102, 0x5c28
+ax_pose 79, 0x0200, 0x410b, 0x5c38
+ax_pose 80, 0x4210, 0x010b, 0x5c3c
+ax_pose 81, 0x01d0, 0x00da, 0x5c3e
+ax_pose_terminator
+sGyaradosPose198:
+ax_pose 55, 0x41cc, 0xc0e4, 0x5c00
+ax_pose 56, 0x41ec, 0x80e4, 0x5c20
+ax_pose 57, 0x01ec, 0x4104, 0x5c28
+ax_pose 58, 0x81cc, 0x80d4, 0x5c2c
+ax_pose 59, 0x01d7, 0x4124, 0x5c34
+ax_pose 60, 0x01ec, 0x00dc, 0x5c38
+ax_pose_terminator
+sGyaradosPose199:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose200:
+ax_pose 7, 0x41c6, 0x00f7, 0x5c00
+ax_pose 8, 0x01ee, 0x40ff, 0x5c02
+ax_pose 9, 0x41ee, 0x80df, 0x5c06
+ax_pose 10, 0x41ce, 0xc0df, 0x5c0e
+ax_pose_terminator
+sGyaradosPose201:
+ax_pose 72, 0x81c0, 0xc0e9, 0x5c00
+ax_pose 73, 0x01d0, 0x4109, 0x5c20
+ax_pose 74, 0x81e0, 0x8109, 0x5c24
+ax_pose 75, 0x4200, 0x0109, 0x5c2c
+ax_pose_terminator
+sGyaradosPose202:
+ax_pose 51, 0x41d0, 0x80e1, 0x5c00
+ax_pose 52, 0x41d0, 0x8101, 0x5c08
+ax_pose 53, 0x41e0, 0xc0e1, 0x5c10
+ax_pose 54, 0x81db, 0x00d9, 0x5c30
+ax_pose_terminator
+sGyaradosPose203:
+ax_pose 49, 0x81c9, 0xc0ef, 0x5c00
+ax_pose 50, 0x81e1, 0x010f, 0x5c20
+ax_pose_terminator
+sGyaradosPose204:
+ax_pose 51, 0x41d0, 0x80dd, 0x5c00
+ax_pose 52, 0x41d0, 0x80fd, 0x5c08
+ax_pose 53, 0x41e0, 0xc0dd, 0x5c10
+ax_pose 54, 0x81db, 0x00d5, 0x5c30
+ax_pose_terminator
+sGyaradosPose205:
+ax_pose 55, 0x41cc, 0xc0e2, 0x5c00
+ax_pose 56, 0x41ec, 0x80e2, 0x5c20
+ax_pose 57, 0x01ec, 0x4102, 0x5c28
+ax_pose 58, 0x81cc, 0x80d2, 0x5c2c
+ax_pose 59, 0x01d7, 0x4122, 0x5c34
+ax_pose 60, 0x01ec, 0x00da, 0x5c38
+ax_pose_terminator
+sGyaradosPose206:
+ax_pose 61, 0x81c0, 0xc0e7, 0x5c00
+ax_pose 62, 0x01d0, 0x4107, 0x5c20
+ax_pose 63, 0x81d0, 0x0117, 0x5c24
+ax_pose 64, 0x01e0, 0x8107, 0x5c26
+ax_pose 65, 0x81d0, 0x40df, 0x5c36
+ax_pose_terminator
+sGyaradosPose207:
+ax_pose 66, 0x81bf, 0xc0f0, 0x5c00
+ax_pose 67, 0x81cf, 0x4110, 0x5c20
+ax_pose_terminator
+sGyaradosPose208:
+ax_pose 61, 0x81c0, 0xd0fa, 0x5c00
+ax_pose 62, 0x01d0, 0x50ea, 0x5c20
+ax_pose 63, 0x81d0, 0x10e2, 0x5c24
+ax_pose 64, 0x01e0, 0x90da, 0x5c26
+ax_pose 65, 0x81d0, 0x511a, 0x5c36
+ax_pose_terminator
+sGyaradosPose209:
+ax_pose 55, 0x41cc, 0xd0de, 0x5c00
+ax_pose 56, 0x41ec, 0x90fe, 0x5c20
+ax_pose 57, 0x01ec, 0x50ee, 0x5c28
+ax_pose 58, 0x81cc, 0x911e, 0x5c2c
+ax_pose 59, 0x01d7, 0x50ce, 0x5c34
+ax_pose 60, 0x01ec, 0x111e, 0x5c38
+ax_pose_terminator
+sGyaradosPose210:
+ax_pose 51, 0x41d0, 0x9103, 0x5c00
+ax_pose 52, 0x41d0, 0x90e3, 0x5c08
+ax_pose 53, 0x41e0, 0xd0e3, 0x5c10
+ax_pose 54, 0x81db, 0x1123, 0x5c30
+ax_pose_terminator
+sGyaradosPose211:
+ax_pose 0, 0x81d6, 0x410e, 0x5c00
+ax_pose 1, 0x81c6, 0xc0ee, 0x5c04
+ax_pose_terminator
+sGyaradosPose212:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sGyaradosPose213:
+ax_pose 16, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sGyaradosPose214:
+ax_pose 30, 0x01c8, 0x0107, 0x5c00
+ax_pose 31, 0x01d0, 0x4107, 0x5c01
+ax_pose 32, 0x81e0, 0x8107, 0x5c05
+ax_pose 33, 0x81c0, 0xc0e7, 0x5c0d
+ax_pose_terminator
+sGyaradosPose215:
+ax_pose 42, 0x81d0, 0x410d, 0x5c00
+ax_pose 43, 0x81c0, 0xc0ed, 0x5c04
+ax_pose_terminator
+sGyaradosPose216:
+ax_pose 30, 0x01c8, 0x10f1, 0x5c00
+ax_pose 31, 0x01d0, 0x50e9, 0x5c01
+ax_pose 32, 0x81e0, 0x90e9, 0x5c05
+ax_pose 33, 0x81c0, 0xd0f9, 0x5c0d
+ax_pose_terminator
+sGyaradosPose217:
+ax_pose 16, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sGyaradosPose218:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+.align 2
+sGyaradosAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_2_1:
+ax_anim 4, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -3, 0, -3,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 9, 0, 9,
+ax_anim 2, 0, 25, 0, 23, 0, 21,
+ax_anim 2, 1, 25, -1, 23, -1, 21,
+ax_anim 2, 0, 25, 0, 23, 0, 21,
+ax_anim 2, 0, 25, -1, 23, -1, 21,
+ax_anim 2, 0, 24, 0, 2, 0, 2,
+ax_anim_terminator
+sGyaradosAnims_2_2:
+ax_anim 4, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -3, -3, -3, -3,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 2, 2, 2, 2,
+ax_anim 1, 0, 28, 6, 6, 6, 8,
+ax_anim 2, 0, 28, 14, 21, 14, 19,
+ax_anim 2, 1, 28, 13, 22, 13, 20,
+ax_anim 2, 0, 28, 14, 21, 14, 19,
+ax_anim 2, 0, 28, 13, 22, 13, 20,
+ax_anim 2, 0, 27, 2, 2, 2, 2,
+ax_anim_terminator
+sGyaradosAnims_2_3:
+ax_anim 4, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -3, 0, -3, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 2, 1, 2, 0,
+ax_anim 1, 0, 31, 6, 2, 6, 0,
+ax_anim 2, 0, 31, 11, 3, 11, 0,
+ax_anim 2, 1, 31, 11, 4, 11, 1,
+ax_anim 2, 0, 31, 11, 3, 11, 0,
+ax_anim 2, 0, 31, 11, 4, 11, 1,
+ax_anim 2, 0, 30, 2, 2, 2, 0,
+ax_anim_terminator
+sGyaradosAnims_2_4:
+ax_anim 4, 0, 35, -1, 1, -1, 0,
+ax_anim 6, 0, 35, -3, 3, -3, 3,
+ax_anim 1, 0, 33, 0, -6, 0, 0,
+ax_anim 1, 2, 34, 2, -7, 2, -3,
+ax_anim 1, 0, 34, 6, -9, 6, -7,
+ax_anim 2, 0, 34, 11, -11, 11, -13,
+ax_anim 2, 1, 34, 12, -10, 12, -12,
+ax_anim 2, 0, 34, 11, -11, 11, -13,
+ax_anim 2, 0, 34, 12, -10, 12, -12,
+ax_anim 2, 0, 33, 2, -3, 2, -2,
+ax_anim_terminator
+sGyaradosAnims_2_5:
+ax_anim 4, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 3, 0, 3,
+ax_anim 1, 0, 36, 0, -6, 0, -6,
+ax_anim 1, 2, 37, 0, -7, 0, -7,
+ax_anim 1, 0, 37, 0, -9, 0, -11,
+ax_anim 2, 0, 37, 0, -11, 0, -15,
+ax_anim 2, 1, 37, -1, -11, -1, -15,
+ax_anim 2, 0, 37, 0, -11, 0, -15,
+ax_anim 2, 0, 37, -1, -11, -1, -15,
+ax_anim 2, 0, 36, 0, -3, 0, -3,
+ax_anim_terminator
+sGyaradosAnims_2_6:
+ax_anim 4, 0, 41, 1, 1, 1, 0,
+ax_anim 6, 0, 41, 3, 3, 3, 3,
+ax_anim 1, 0, 39, 0, -6, 0, 0,
+ax_anim 1, 2, 40, -2, -7, -2, -3,
+ax_anim 1, 0, 40, -6, -9, -6, -7,
+ax_anim 2, 0, 40, -11, -11, -11, -13,
+ax_anim 2, 1, 40, -12, -10, -12, -12,
+ax_anim 2, 0, 40, -11, -11, -11, -13,
+ax_anim 2, 0, 40, -12, -10, -12, -12,
+ax_anim 2, 0, 39, -2, -3, -2, -2,
+ax_anim_terminator
+sGyaradosAnims_2_7:
+ax_anim 4, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 3, 0, 3, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -2, 1, -2, 0,
+ax_anim 1, 0, 43, -6, 2, -6, 0,
+ax_anim 2, 0, 43, -11, 3, -11, 0,
+ax_anim 2, 1, 43, -11, 4, -11, 1,
+ax_anim 2, 0, 43, -11, 3, -11, 0,
+ax_anim 2, 0, 43, -11, 4, -11, 1,
+ax_anim 2, 0, 42, -2, 2, -2, 0,
+ax_anim_terminator
+sGyaradosAnims_2_8:
+ax_anim 4, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 3, -3, 3, -3,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -2, 2, -2, 2,
+ax_anim 1, 0, 46, -6, 6, -6, 8,
+ax_anim 2, 0, 46, -14, 21, -14, 19,
+ax_anim 2, 1, 46, -13, 22, -13, 20,
+ax_anim 2, 0, 46, -14, 21, -14, 19,
+ax_anim 2, 0, 46, -13, 22, -13, 20,
+ax_anim 2, 0, 45, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_3_1:
+ax_anim 4, 0, 50, 0, -1, 0, -1,
+ax_anim 6, 0, 50, 0, -3, 0, -3,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 2, 0, 2,
+ax_anim 1, 0, 49, 0, 9, 0, 9,
+ax_anim 2, 0, 49, 0, 23, 0, 21,
+ax_anim 2, 1, 49, -1, 23, -1, 21,
+ax_anim 2, 0, 49, 0, 23, 0, 21,
+ax_anim 2, 0, 49, -1, 23, -1, 21,
+ax_anim 2, 0, 48, 0, 2, 0, 2,
+ax_anim_terminator
+sGyaradosAnims_3_2:
+ax_anim 4, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 52, 6, 6, 6, 8,
+ax_anim 2, 0, 52, 14, 21, 14, 19,
+ax_anim 2, 1, 52, 13, 22, 13, 20,
+ax_anim 2, 0, 52, 14, 21, 14, 19,
+ax_anim 2, 0, 52, 13, 22, 13, 20,
+ax_anim 2, 0, 51, 2, 2, 2, 2,
+ax_anim_terminator
+sGyaradosAnims_3_3:
+ax_anim 4, 0, 56, -1, 0, -1, 0,
+ax_anim 6, 0, 56, -3, 0, -3, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 2, 1, 2, 0,
+ax_anim 1, 0, 55, 6, 2, 6, 0,
+ax_anim 2, 0, 55, 11, 3, 11, 0,
+ax_anim 2, 1, 55, 11, 4, 11, 1,
+ax_anim 2, 0, 55, 11, 3, 11, 0,
+ax_anim 2, 0, 55, 11, 4, 11, 1,
+ax_anim 2, 0, 54, 2, 2, 2, 0,
+ax_anim_terminator
+sGyaradosAnims_3_4:
+ax_anim 4, 0, 59, -1, 1, -1, 0,
+ax_anim 6, 0, 59, -3, 3, -3, 3,
+ax_anim 1, 0, 57, 0, -6, 0, 0,
+ax_anim 1, 2, 58, 2, -7, 2, -3,
+ax_anim 1, 0, 58, 6, -9, 6, -7,
+ax_anim 2, 0, 58, 11, -11, 11, -13,
+ax_anim 2, 1, 58, 12, -10, 12, -12,
+ax_anim 2, 0, 58, 11, -11, 11, -13,
+ax_anim 2, 0, 58, 12, -10, 12, -12,
+ax_anim 2, 0, 57, 2, -3, 2, -2,
+ax_anim_terminator
+sGyaradosAnims_3_5:
+ax_anim 4, 0, 62, 0, 1, 0, 1,
+ax_anim 6, 0, 62, 0, 3, 0, 3,
+ax_anim 1, 0, 60, 0, -6, 0, -6,
+ax_anim 1, 2, 61, 0, -7, 0, -7,
+ax_anim 1, 0, 61, 0, -9, 0, -11,
+ax_anim 2, 0, 61, 0, -11, 0, -15,
+ax_anim 2, 1, 61, -1, -11, -1, -15,
+ax_anim 2, 0, 61, 0, -11, 0, -15,
+ax_anim 2, 0, 61, -1, -11, -1, -15,
+ax_anim 2, 0, 60, 0, -3, 0, -3,
+ax_anim_terminator
+sGyaradosAnims_3_6:
+ax_anim 4, 0, 65, 1, 1, 1, 0,
+ax_anim 6, 0, 65, 3, 3, 3, 3,
+ax_anim 1, 0, 63, 0, -6, 0, 0,
+ax_anim 1, 2, 64, -2, -7, -2, -3,
+ax_anim 1, 0, 64, -6, -9, -6, -7,
+ax_anim 2, 0, 64, -11, -11, -11, -13,
+ax_anim 2, 1, 64, -12, -10, -12, -12,
+ax_anim 2, 0, 64, -11, -11, -11, -13,
+ax_anim 2, 0, 64, -12, -10, -12, -12,
+ax_anim 2, 0, 63, -2, -3, -2, -2,
+ax_anim_terminator
+sGyaradosAnims_3_7:
+ax_anim 4, 0, 68, 1, 0, 1, 0,
+ax_anim 6, 0, 68, 3, 0, 3, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -2, 1, -2, 0,
+ax_anim 1, 0, 67, -6, 2, -6, 0,
+ax_anim 2, 0, 67, -11, 3, -11, 0,
+ax_anim 2, 1, 67, -11, 4, -11, 1,
+ax_anim 2, 0, 67, -11, 3, -11, 0,
+ax_anim 2, 0, 67, -11, 4, -11, 1,
+ax_anim 2, 0, 66, -2, 2, -2, 0,
+ax_anim_terminator
+sGyaradosAnims_3_8:
+ax_anim 4, 0, 71, 1, -1, 1, -1,
+ax_anim 6, 0, 71, 3, -3, 3, -3,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -2, 2, -2, 2,
+ax_anim 1, 0, 70, -6, 6, -6, 8,
+ax_anim 2, 0, 70, -14, 21, -14, 19,
+ax_anim 2, 1, 70, -13, 22, -13, 20,
+ax_anim 2, 0, 70, -14, 21, -14, 19,
+ax_anim 2, 0, 70, -13, 22, -13, 20,
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_4_1:
+ax_anim 2, 0, 74, 0, -2, 0, -2,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim 4, 2, 74, 0, -5, 0, -5,
+ax_anim 1, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 75, 0, 7, 0, 7,
+ax_anim 2, 0, 75, -1, 7, -1, 7,
+ax_anim 2, 1, 75, 0, 7, 0, 7,
+ax_anim 2, 0, 75, -1, 7, -1, 7,
+ax_anim 2, 0, 75, 0, 7, 0, 7,
+ax_anim 2, 0, 75, -1, 7, -1, 7,
+ax_anim 2, 0, 75, 0, 7, 0, 7,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim_terminator
+sGyaradosAnims_4_2:
+ax_anim 2, 0, 78, -2, -2, -2, -2,
+ax_anim 2, 0, 78, -4, -4, -4, -4,
+ax_anim 4, 2, 78, -5, -5, -5, -5,
+ax_anim 1, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 8, 8, 8, 8,
+ax_anim 2, 0, 79, 7, 9, 7, 9,
+ax_anim 2, 1, 79, 8, 8, 8, 8,
+ax_anim 2, 0, 79, 7, 9, 7, 9,
+ax_anim 2, 0, 79, 8, 8, 8, 8,
+ax_anim 2, 0, 79, 7, 9, 7, 9,
+ax_anim 2, 0, 79, 8, 8, 8, 8,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim_terminator
+sGyaradosAnims_4_3:
+ax_anim 2, 0, 82, -2, 0, -2, 0,
+ax_anim 2, 0, 82, -4, 0, -4, 0,
+ax_anim 4, 2, 82, -5, 0, -5, 0,
+ax_anim 1, 0, 81, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 8, 0, 8, 0,
+ax_anim 2, 0, 83, 8, 1, 8, 1,
+ax_anim 2, 1, 83, 8, 0, 8, 0,
+ax_anim 2, 0, 83, 8, 1, 8, 1,
+ax_anim 2, 0, 83, 8, 0, 8, 0,
+ax_anim 2, 0, 83, 8, 1, 8, 1,
+ax_anim 2, 0, 83, 8, 0, 8, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim_terminator
+sGyaradosAnims_4_4:
+ax_anim 2, 0, 86, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -4, 4, -4, 4,
+ax_anim 4, 2, 86, -5, 5, -5, 5,
+ax_anim 1, 0, 85, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 8, -8, 8, -8,
+ax_anim 2, 0, 87, 7, -9, 7, -9,
+ax_anim 2, 1, 87, 8, -8, 8, -8,
+ax_anim 2, 0, 87, 7, -9, 7, -9,
+ax_anim 2, 0, 87, 8, -8, 8, -8,
+ax_anim 2, 0, 87, 7, -9, 7, -9,
+ax_anim 2, 0, 87, 8, -8, 8, -8,
+ax_anim 2, 0, 84, 3, -3, 3, -3,
+ax_anim_terminator
+sGyaradosAnims_4_5:
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 4, 2, 90, 0, 5, 0, 5,
+ax_anim 1, 0, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 91, 0, -8, 0, -8,
+ax_anim 2, 0, 91, -1, -8, -1, -8,
+ax_anim 2, 1, 91, 0, -8, 0, -8,
+ax_anim 2, 0, 91, -1, -8, -1, -8,
+ax_anim 2, 0, 91, 0, -8, 0, -8,
+ax_anim 2, 0, 91, -1, -8, -1, -8,
+ax_anim 2, 0, 91, 0, -8, 0, -8,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim_terminator
+sGyaradosAnims_4_6:
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 4, 2, 94, 5, 5, 5, 5,
+ax_anim 1, 0, 93, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -8, -8, -8, -8,
+ax_anim 2, 0, 95, -7, -9, -7, -9,
+ax_anim 2, 1, 95, -8, -8, -8, -8,
+ax_anim 2, 0, 95, -7, -9, -7, -9,
+ax_anim 2, 0, 95, -8, -8, -8, -8,
+ax_anim 2, 0, 95, -7, -9, -7, -9,
+ax_anim 2, 0, 95, -8, -8, -8, -8,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim_terminator
+sGyaradosAnims_4_7:
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 4, 2, 98, 5, 0, 5, 0,
+ax_anim 1, 0, 97, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -8, 0, -8, 0,
+ax_anim 2, 0, 99, -8, 1, -8, 1,
+ax_anim 2, 1, 99, -8, 0, -8, 0,
+ax_anim 2, 0, 99, -8, 1, -8, 1,
+ax_anim 2, 0, 99, -8, 0, -8, 0,
+ax_anim 2, 0, 99, -8, 1, -8, 1,
+ax_anim 2, 0, 99, -8, 0, -8, 0,
+ax_anim 2, 0, 96, -3, 0, -3, 0,
+ax_anim_terminator
+sGyaradosAnims_4_8:
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 4, 2, 102, 5, -5, 5, -5,
+ax_anim 1, 0, 101, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -8, 8, -8, 8,
+ax_anim 2, 0, 103, -7, 9, -7, 9,
+ax_anim 2, 1, 103, -8, 8, -8, 8,
+ax_anim 2, 0, 103, -7, 9, -7, 9,
+ax_anim 2, 0, 103, -8, 8, -8, 8,
+ax_anim 2, 0, 103, -7, 9, -7, 9,
+ax_anim 2, 0, 103, -8, 8, -8, 8,
+ax_anim 2, 0, 100, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_5_1:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 2, 0, 0,
+ax_anim 2, 0, 106, 0, 2, 0, 0,
+ax_anim 2, 2, 107, 0, -16, 0, 0,
+ax_anim 2, 0, 107, -1, -16, -1, 0,
+ax_anim 2, 0, 107, 0, -16, 0, 0,
+ax_anim 2, 0, 107, -1, -16, -1, 0,
+ax_anim 2, 1, 107, 0, -16, 0, 0,
+ax_anim 2, 0, 107, -1, -16, -1, 0,
+ax_anim 2, 0, 107, 0, -16, 0, 0,
+ax_anim 2, 0, 107, -1, -16, -1, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_5_2:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 2, 0, 0,
+ax_anim 2, 0, 110, 2, -2, 1, 1,
+ax_anim 2, 2, 111, 0, -16, 0, 0,
+ax_anim 2, 0, 111, -1, -15, -1, 1,
+ax_anim 2, 0, 111, 0, -16, 0, 0,
+ax_anim 2, 0, 111, -1, -15, -1, 1,
+ax_anim 2, 1, 111, 0, -16, 0, 0,
+ax_anim 2, 0, 111, -1, -15, -1, 1,
+ax_anim 2, 0, 111, 0, -16, 0, 0,
+ax_anim 2, 0, 111, -1, -15, -1, 1,
+ax_anim 2, 0, 110, 1, -4, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_5_3:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 2, 0, 0,
+ax_anim 2, 0, 114, 6, -1, 0, 0,
+ax_anim 2, 2, 115, 0, -16, 0, 0,
+ax_anim 2, 0, 115, 0, -17, 0, -1,
+ax_anim 2, 0, 115, 0, -16, 0, 0,
+ax_anim 2, 0, 115, 0, -17, 0, -1,
+ax_anim 2, 1, 115, 0, -16, 0, 0,
+ax_anim 2, 0, 115, 0, -17, 0, -1,
+ax_anim 2, 0, 115, 0, -16, 0, 0,
+ax_anim 2, 0, 115, 0, -17, 0, -1,
+ax_anim 2, 0, 114, 6, -3, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 2, 0, 0,
+ax_anim 2, 0, 118, 3, -4, 0, 0,
+ax_anim 2, 2, 119, 0, -16, 0, 0,
+ax_anim 2, 0, 119, -1, -17, -1, -1,
+ax_anim 2, 0, 119, 0, -16, 0, 0,
+ax_anim 2, 0, 119, -1, -17, -1, -1,
+ax_anim 2, 1, 119, 0, -16, 0, 0,
+ax_anim 2, 0, 119, -1, -17, -1, -1,
+ax_anim 2, 0, 119, 0, -16, 0, 0,
+ax_anim 2, 0, 119, -1, -17, -1, -1,
+ax_anim 2, 0, 118, 3, -4, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_5_5:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 2, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 2, 123, 0, -16, 0, 0,
+ax_anim 2, 0, 123, -1, -16, -1, 0,
+ax_anim 2, 0, 123, 0, -16, 0, 0,
+ax_anim 2, 0, 123, -1, -16, -1, 0,
+ax_anim 2, 1, 123, 0, -16, 0, 0,
+ax_anim 2, 0, 123, -1, -16, -1, 0,
+ax_anim 2, 0, 123, 0, -16, 0, 0,
+ax_anim 2, 0, 123, -1, -16, -1, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_5_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 2, 0, 0,
+ax_anim 2, 0, 126, -3, -4, 0, 0,
+ax_anim 2, 2, 127, 0, -16, 0, 0,
+ax_anim 2, 0, 127, 1, -17, 1, -1,
+ax_anim 2, 0, 127, 0, -16, 0, 0,
+ax_anim 2, 0, 127, 1, -17, 1, -1,
+ax_anim 2, 1, 127, 0, -16, 0, 0,
+ax_anim 2, 0, 127, 1, -17, 1, -1,
+ax_anim 2, 0, 127, 0, -16, 0, 0,
+ax_anim 2, 0, 127, 1, -17, 1, -1,
+ax_anim 2, 0, 126, -3, -4, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_5_7:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 2, 0, 0,
+ax_anim 2, 0, 130, -6, -1, 0, 0,
+ax_anim 2, 2, 131, 0, -16, 0, 0,
+ax_anim 2, 0, 131, 0, -17, 0, -1,
+ax_anim 2, 0, 131, 0, -16, 0, 0,
+ax_anim 2, 0, 131, 0, -17, 0, -1,
+ax_anim 2, 1, 131, 0, -16, 0, 0,
+ax_anim 2, 0, 131, 0, -17, 0, -1,
+ax_anim 2, 0, 131, 0, -16, 0, 0,
+ax_anim 2, 0, 131, 0, -17, 0, -1,
+ax_anim 2, 0, 130, -6, -3, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_5_8:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 133, 0, 2, 0, 0,
+ax_anim 2, 0, 134, -2, -2, -1, 1,
+ax_anim 2, 2, 135, 0, -16, 0, 0,
+ax_anim 2, 0, 135, 1, -15, 1, 1,
+ax_anim 2, 0, 135, 0, -16, 0, 0,
+ax_anim 2, 0, 135, 1, -15, 1, 1,
+ax_anim 2, 1, 135, 0, -16, 0, 0,
+ax_anim 2, 0, 135, 1, -15, 1, 1,
+ax_anim 2, 0, 135, 0, -16, 0, 0,
+ax_anim 2, 0, 135, 1, -15, 1, 1,
+ax_anim 2, 0, 134, -1, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_6_1:
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, -1, 0, 0,
+ax_anim 16, 0, 136, 0, -2, 0, 0,
+ax_anim 16, 0, 137, 0, -2, 0, 0,
+ax_anim 12, 0, 137, 0, -1, 0, 0,
+ax_anim 16, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sGyaradosAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sGyaradosAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sGyaradosAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sGyaradosAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sGyaradosAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sGyaradosAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sGyaradosAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_8_1:
+ax_anim 18, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim 18, 0, 146, 0, -2, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_8_2:
+ax_anim 18, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 18, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_8_3:
+ax_anim 18, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 18, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_8_4:
+ax_anim 18, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim 18, 0, 151, 0, -2, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_8_5:
+ax_anim 18, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, -1, 0, 0,
+ax_anim 18, 0, 150, 0, -2, 0, 0,
+ax_anim 8, 0, 150, 0, -1, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_8_6:
+ax_anim 18, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 18, 0, 149, 0, -2, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_8_7:
+ax_anim 18, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, -1, 0, 0,
+ax_anim 18, 0, 148, 0, -2, 0, 0,
+ax_anim 8, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_8_8:
+ax_anim 18, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim 18, 0, 147, 0, -2, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 10, 12, 10, 10,
+ax_anim 2, 0, 157, 8, 22, 8, 19,
+ax_anim 3, 0, 158, 0, 26, 0, 24,
+ax_anim 2, 3, 159, -8, 22, -8, 19,
+ax_anim 2, 0, 160, -10, 12, -10, 10,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 20, 5, 19, 5,
+ax_anim 2, 0, 156, 19, 16, 22, 14,
+ax_anim 3, 0, 157, 18, 25, 18, 22,
+ax_anim 2, 3, 158, 7, 27, 7, 24,
+ax_anim 2, 0, 159, 2, 21, 0, 18,
+ax_anim 1, 0, 160, 0, 10, -2, 8,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 4, -4, 4, -4,
+ax_anim 2, 0, 154, 11, -2, 11, -4,
+ax_anim 2, 0, 155, 16, -1, 17, -2,
+ax_anim 3, 0, 156, 20, 5, 22, 1,
+ax_anim 2, 3, 157, 17, 8, 17, 6,
+ax_anim 2, 0, 158, 10, 10, 10, 8,
+ax_anim 1, 0, 159, 4, 6, 3, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 2, -7, -1, -8,
+ax_anim 2, 0, 161, 4, -14, 3, -13,
+ax_anim 2, 0, 154, 11, -15, 11, -18,
+ax_anim 3, 0, 155, 18, -15, 18, -16,
+ax_anim 2, 3, 156, 19, -9, 20, -10,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, 2, 7, 1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -3, -8, -3,
+ax_anim 2, 0, 160, -9, -6, -10, -6,
+ax_anim 2, 0, 161, -7, -13, -7, -13,
+ax_anim 3, 0, 154, 0, -18, 0, -17,
+ax_anim 2, 3, 155, 7, -13, 7, -13,
+ax_anim 2, 0, 156, 9, -6, 10, -6,
+ax_anim 1, 0, 157, 8, -3, 8, -3,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 2, -7, 1, -8,
+ax_anim 2, 0, 155, -4, -14, -3, -13,
+ax_anim 2, 0, 154, -11, -15, -11, -18,
+ax_anim 3, 0, 161, -18, -15, -18, -16,
+ax_anim 2, 3, 160, -19, -9, -20, -10,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, 2, -7, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -4, -4, -4, -4,
+ax_anim 2, 0, 154, -11, -2, -11, -4,
+ax_anim 2, 0, 161, -16, -1, -17, -2,
+ax_anim 3, 0, 160, -20, 5, -22, 1,
+ax_anim 2, 3, 159, -17, 8, -17, 6,
+ax_anim 2, 0, 158, -10, 10, -10, 8,
+ax_anim 1, 0, 157, -4, 6, -3, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -20, 5, -19, 5,
+ax_anim 2, 0, 160, -19, 16, -22, 14,
+ax_anim 3, 0, 159, -18, 25, -18, 22,
+ax_anim 2, 3, 158, -7, 27, -7, 24,
+ax_anim 2, 0, 157, -2, 21, 0, 18,
+ax_anim 1, 0, 156, 0, 10, 2, 8,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 4, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_11_2:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 3, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_11_3:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 179, -1, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 6, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_11_4:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 6, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_11_5:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 6, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_11_6:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 6, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_11_7:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 6, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_11_8:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sGyaradosAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sGyaradosGfx1:
+.incbin "baserom.gba", 0xA93F24, 0x80
+sGyaradosSprites1:
+ax_sprite sGyaradosGfx1, 0x80
+ax_sprite_terminator
+sGyaradosGfx2:
+.incbin "baserom.gba", 0xA93FB4, 0x400
+sGyaradosSprites2:
+ax_sprite sGyaradosGfx2, 0x400
+ax_sprite_terminator
+sGyaradosGfx3:
+.incbin "baserom.gba", 0xA943C4, 0x80
+sGyaradosSprites3:
+ax_sprite sGyaradosGfx3, 0x80
+ax_sprite_terminator
+sGyaradosGfx4:
+.incbin "baserom.gba", 0xA94454, 0x400
+sGyaradosSprites4:
+ax_sprite sGyaradosGfx4, 0x400
+ax_sprite_terminator
+sGyaradosGfx5:
+.incbin "baserom.gba", 0xA94864, 0x40
+sGyaradosSprites5:
+ax_sprite sGyaradosGfx5, 0x40
+ax_sprite_terminator
+sGyaradosGfx6:
+.incbin "baserom.gba", 0xA948B4, 0x400
+sGyaradosSprites6:
+ax_sprite sGyaradosGfx6, 0x400
+ax_sprite_terminator
+sGyaradosGfx7:
+.incbin "baserom.gba", 0xA94CC4, 0x800
+sGyaradosSprites7:
+ax_sprite sGyaradosGfx7, 0x800
+ax_sprite_terminator
+sGyaradosGfx8:
+.incbin "baserom.gba", 0xA954D4, 0x40
+sGyaradosSprites8:
+ax_sprite sGyaradosGfx8, 0x40
+ax_sprite_terminator
+sGyaradosGfx9:
+.incbin "baserom.gba", 0xA95524, 0x80
+sGyaradosSprites9:
+ax_sprite sGyaradosGfx9, 0x80
+ax_sprite_terminator
+sGyaradosGfx10:
+.incbin "baserom.gba", 0xA955B4, 0x100
+sGyaradosSprites10:
+ax_sprite sGyaradosGfx10, 0x100
+ax_sprite_terminator
+sGyaradosGfx11:
+.incbin "baserom.gba", 0xA956C4, 0x400
+sGyaradosSprites11:
+ax_sprite sGyaradosGfx11, 0x400
+ax_sprite_terminator
+sGyaradosGfx12:
+.incbin "baserom.gba", 0xA95AD4, 0x80
+sGyaradosSprites12:
+ax_sprite sGyaradosGfx12, 0x80
+ax_sprite_terminator
+sGyaradosGfx13:
+.incbin "baserom.gba", 0xA95B64, 0x20
+sGyaradosSprites13:
+ax_sprite sGyaradosGfx13, 0x20
+ax_sprite_terminator
+sGyaradosGfx14:
+.incbin "baserom.gba", 0xA95B94, 0x40
+sGyaradosSprites14:
+ax_sprite sGyaradosGfx14, 0x40
+ax_sprite_terminator
+sGyaradosGfx15:
+.incbin "baserom.gba", 0xA95BE4, 0x100
+sGyaradosSprites15:
+ax_sprite sGyaradosGfx15, 0x100
+ax_sprite_terminator
+sGyaradosGfx16:
+.incbin "baserom.gba", 0xA95CF4, 0x400
+sGyaradosSprites16:
+ax_sprite sGyaradosGfx16, 0x400
+ax_sprite_terminator
+sGyaradosGfx17:
+.incbin "baserom.gba", 0xA96104, 0x800
+sGyaradosSprites17:
+ax_sprite sGyaradosGfx17, 0x800
+ax_sprite_terminator
+sGyaradosGfx18:
+.incbin "baserom.gba", 0xA96914, 0x40
+sGyaradosSprites18:
+ax_sprite sGyaradosGfx18, 0x40
+ax_sprite_terminator
+sGyaradosGfx19:
+.incbin "baserom.gba", 0xA96964, 0x80
+sGyaradosSprites19:
+ax_sprite sGyaradosGfx19, 0x80
+ax_sprite_terminator
+sGyaradosGfx20:
+.incbin "baserom.gba", 0xA969F4, 0x80
+sGyaradosSprites20:
+ax_sprite sGyaradosGfx20, 0x80
+ax_sprite_terminator
+sGyaradosGfx21:
+.incbin "baserom.gba", 0xA96A84, 0x80
+sGyaradosSprites21:
+ax_sprite sGyaradosGfx21, 0x80
+ax_sprite_terminator
+sGyaradosGfx22:
+.incbin "baserom.gba", 0xA96B14, 0x100
+sGyaradosSprites22:
+ax_sprite sGyaradosGfx22, 0x100
+ax_sprite_terminator
+sGyaradosGfx23:
+.incbin "baserom.gba", 0xA96C24, 0x100
+sGyaradosSprites23:
+ax_sprite sGyaradosGfx23, 0x100
+ax_sprite_terminator
+sGyaradosGfx24:
+.incbin "baserom.gba", 0xA96D34, 0x400
+sGyaradosSprites24:
+ax_sprite sGyaradosGfx24, 0x400
+ax_sprite_terminator
+sGyaradosGfx25:
+.incbin "baserom.gba", 0xA97144, 0x20
+sGyaradosSprites25:
+ax_sprite sGyaradosGfx25, 0x20
+ax_sprite_terminator
+sGyaradosGfx26:
+.incbin "baserom.gba", 0xA97174, 0x20
+sGyaradosSprites26:
+ax_sprite sGyaradosGfx26, 0x20
+ax_sprite_terminator
+sGyaradosGfx27:
+.incbin "baserom.gba", 0xA971A4, 0x40
+sGyaradosSprites27:
+ax_sprite sGyaradosGfx27, 0x40
+ax_sprite_terminator
+sGyaradosGfx28:
+.incbin "baserom.gba", 0xA971F4, 0x200
+sGyaradosSprites28:
+ax_sprite sGyaradosGfx28, 0x200
+ax_sprite_terminator
+sGyaradosGfx29:
+.incbin "baserom.gba", 0xA97404, 0x100
+sGyaradosSprites29:
+ax_sprite sGyaradosGfx29, 0x100
+ax_sprite_terminator
+sGyaradosGfx30:
+.incbin "baserom.gba", 0xA97514, 0x400
+sGyaradosSprites30:
+ax_sprite sGyaradosGfx30, 0x400
+ax_sprite_terminator
+sGyaradosGfx31:
+.incbin "baserom.gba", 0xA97924, 0x20
+sGyaradosSprites31:
+ax_sprite sGyaradosGfx31, 0x20
+ax_sprite_terminator
+sGyaradosGfx32:
+.incbin "baserom.gba", 0xA97954, 0x80
+sGyaradosSprites32:
+ax_sprite sGyaradosGfx32, 0x80
+ax_sprite_terminator
+sGyaradosGfx33:
+.incbin "baserom.gba", 0xA979E4, 0x100
+sGyaradosSprites33:
+ax_sprite sGyaradosGfx33, 0x100
+ax_sprite_terminator
+sGyaradosGfx34:
+.incbin "baserom.gba", 0xA97AF4, 0x400
+sGyaradosSprites34:
+ax_sprite sGyaradosGfx34, 0x400
+ax_sprite_terminator
+sGyaradosGfx35:
+.incbin "baserom.gba", 0xA97F04, 0x100
+sGyaradosSprites35:
+ax_sprite sGyaradosGfx35, 0x100
+ax_sprite_terminator
+sGyaradosGfx36:
+.incbin "baserom.gba", 0xA98014, 0x80
+sGyaradosSprites36:
+ax_sprite sGyaradosGfx36, 0x80
+ax_sprite_terminator
+sGyaradosGfx37:
+.incbin "baserom.gba", 0xA980A4, 0x200
+sGyaradosSprites37:
+ax_sprite sGyaradosGfx37, 0x200
+ax_sprite_terminator
+sGyaradosGfx38:
+.incbin "baserom.gba", 0xA982B4, 0x200
+sGyaradosSprites38:
+ax_sprite sGyaradosGfx38, 0x200
+ax_sprite_terminator
+sGyaradosGfx39:
+.incbin "baserom.gba", 0xA984C4, 0x40
+sGyaradosSprites39:
+ax_sprite sGyaradosGfx39, 0x40
+ax_sprite_terminator
+sGyaradosGfx40:
+.incbin "baserom.gba", 0xA98514, 0x80
+sGyaradosSprites40:
+ax_sprite sGyaradosGfx40, 0x80
+ax_sprite_terminator
+sGyaradosGfx41:
+.incbin "baserom.gba", 0xA985A4, 0x100
+sGyaradosSprites41:
+ax_sprite sGyaradosGfx41, 0x100
+ax_sprite_terminator
+sGyaradosGfx42:
+.incbin "baserom.gba", 0xA986B4, 0x400
+sGyaradosSprites42:
+ax_sprite sGyaradosGfx42, 0x400
+ax_sprite_terminator
+sGyaradosGfx43:
+.incbin "baserom.gba", 0xA98AC4, 0x80
+sGyaradosSprites43:
+ax_sprite sGyaradosGfx43, 0x80
+ax_sprite_terminator
+sGyaradosGfx44:
+.incbin "baserom.gba", 0xA98B54, 0x400
+sGyaradosSprites44:
+ax_sprite sGyaradosGfx44, 0x400
+ax_sprite_terminator
+sGyaradosGfx45:
+.incbin "baserom.gba", 0xA98F64, 0x20
+sGyaradosSprites45:
+ax_sprite sGyaradosGfx45, 0x20
+ax_sprite_terminator
+sGyaradosGfx46:
+.incbin "baserom.gba", 0xA98F94, 0x400
+sGyaradosSprites46:
+ax_sprite sGyaradosGfx46, 0x400
+ax_sprite_terminator
+sGyaradosGfx47:
+.incbin "baserom.gba", 0xA993A4, 0x40
+sGyaradosSprites47:
+ax_sprite sGyaradosGfx47, 0x40
+ax_sprite_terminator
+sGyaradosGfx48:
+.incbin "baserom.gba", 0xA993F4, 0x80
+sGyaradosSprites48:
+ax_sprite sGyaradosGfx48, 0x80
+ax_sprite_terminator
+sGyaradosGfx49:
+.incbin "baserom.gba", 0xA99484, 0x400
+sGyaradosSprites49:
+ax_sprite sGyaradosGfx49, 0x400
+ax_sprite_terminator
+sGyaradosGfx50:
+.incbin "baserom.gba", 0xA99894, 0x20
+sGyaradosGfx50_1:
+.incbin "baserom.gba", 0xA998B4, 0x60
+sGyaradosGfx50_2:
+.incbin "baserom.gba", 0xA99914, 0x260
+sGyaradosGfx50_3:
+.incbin "baserom.gba", 0xA99B74, 0x40
+sGyaradosSprites50:
+ax_sprite 0, 0x60
+ax_sprite sGyaradosGfx50, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx50_2, 0x260
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx50_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGyaradosGfx51:
+.incbin "baserom.gba", 0xA99C04, 0x40
+sGyaradosSprites51:
+ax_sprite sGyaradosGfx51, 0x40
+ax_sprite_terminator
+sGyaradosGfx52:
+.incbin "baserom.gba", 0xA99C54, 0xC0
+sGyaradosSprites52:
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx52, 0xc0
+ax_sprite_terminator
+sGyaradosGfx53:
+.incbin "baserom.gba", 0xA99D2C, 0x100
+sGyaradosSprites53:
+ax_sprite sGyaradosGfx53, 0x100
+ax_sprite_terminator
+sGyaradosGfx54:
+.incbin "baserom.gba", 0xA99E3C, 0x1C0
+sGyaradosGfx54_1:
+.incbin "baserom.gba", 0xA99FFC, 0xC0
+sGyaradosGfx54_2:
+.incbin "baserom.gba", 0xA9A0BC, 0xC0
+sGyaradosSprites54:
+ax_sprite sGyaradosGfx54, 0x1c0
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx54_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx54_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGyaradosGfx55:
+.incbin "baserom.gba", 0xA9A1B4, 0x40
+sGyaradosSprites55:
+ax_sprite sGyaradosGfx55, 0x40
+ax_sprite_terminator
+sGyaradosGfx56:
+.incbin "baserom.gba", 0xA9A204, 0x3C0
+sGyaradosSprites56:
+ax_sprite sGyaradosGfx56, 0x3c0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGyaradosGfx57:
+.incbin "baserom.gba", 0xA9A5DC, 0x100
+sGyaradosSprites57:
+ax_sprite sGyaradosGfx57, 0x100
+ax_sprite_terminator
+sGyaradosGfx58:
+.incbin "baserom.gba", 0xA9A6EC, 0x80
+sGyaradosSprites58:
+ax_sprite sGyaradosGfx58, 0x80
+ax_sprite_terminator
+sGyaradosGfx59:
+.incbin "baserom.gba", 0xA9A77C, 0x100
+sGyaradosSprites59:
+ax_sprite sGyaradosGfx59, 0x100
+ax_sprite_terminator
+sGyaradosGfx60:
+.incbin "baserom.gba", 0xA9A88C, 0x80
+sGyaradosSprites60:
+ax_sprite sGyaradosGfx60, 0x80
+ax_sprite_terminator
+sGyaradosGfx61:
+.incbin "baserom.gba", 0xA9A91C, 0x20
+sGyaradosSprites61:
+ax_sprite sGyaradosGfx61, 0x20
+ax_sprite_terminator
+sGyaradosGfx62:
+.incbin "baserom.gba", 0xA9A94C, 0x300
+sGyaradosGfx62_1:
+.incbin "baserom.gba", 0xA9AC4C, 0x40
+sGyaradosSprites62:
+ax_sprite 0, 0x80
+ax_sprite sGyaradosGfx62, 0x300
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx62_1, 0x40
+ax_sprite_terminator
+sGyaradosGfx63:
+.incbin "baserom.gba", 0xA9ACB4, 0x80
+sGyaradosSprites63:
+ax_sprite sGyaradosGfx63, 0x80
+ax_sprite_terminator
+sGyaradosGfx64:
+.incbin "baserom.gba", 0xA9AD44, 0x40
+sGyaradosSprites64:
+ax_sprite sGyaradosGfx64, 0x40
+ax_sprite_terminator
+sGyaradosGfx65:
+.incbin "baserom.gba", 0xA9AD94, 0x140
+sGyaradosGfx65_1:
+.incbin "baserom.gba", 0xA9AED4, 0x20
+sGyaradosSprites65:
+ax_sprite sGyaradosGfx65, 0x140
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx65_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sGyaradosGfx66:
+.incbin "baserom.gba", 0xA9AF1C, 0x60
+sGyaradosSprites66:
+ax_sprite sGyaradosGfx66, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGyaradosGfx67:
+.incbin "baserom.gba", 0xA9AF94, 0x40
+sGyaradosGfx67_1:
+.incbin "baserom.gba", 0xA9AFD4, 0x200
+sGyaradosGfx67_2:
+.incbin "baserom.gba", 0xA9B1D4, 0x40
+sGyaradosGfx67_3:
+.incbin "baserom.gba", 0xA9B214, 0x40
+sGyaradosGfx67_4:
+.incbin "baserom.gba", 0xA9B254, 0x40
+sGyaradosSprites67:
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx67, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx67_1, 0x200
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx67_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx67_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx67_4, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGyaradosGfx68:
+.incbin "baserom.gba", 0xA9B2F4, 0x60
+sGyaradosSprites68:
+ax_sprite sGyaradosGfx68, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGyaradosGfx69:
+.incbin "baserom.gba", 0xA9B36C, 0x60
+sGyaradosGfx69_1:
+.incbin "baserom.gba", 0xA9B3CC, 0x160
+sGyaradosGfx69_2:
+.incbin "baserom.gba", 0xA9B52C, 0x60
+sGyaradosGfx69_3:
+.incbin "baserom.gba", 0xA9B58C, 0x40
+sGyaradosGfx69_4:
+.incbin "baserom.gba", 0xA9B5CC, 0x40
+sGyaradosGfx69_5:
+.incbin "baserom.gba", 0xA9B60C, 0x20
+sGyaradosSprites69:
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx69, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx69_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx69_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx69_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx69_4, 0x40
+ax_sprite 0, 0x60
+ax_sprite sGyaradosGfx69_5, 0x20
+ax_sprite_terminator
+sGyaradosGfx70:
+.incbin "baserom.gba", 0xA9B694, 0x20
+sGyaradosGfx70_1:
+.incbin "baserom.gba", 0xA9B6B4, 0x20
+sGyaradosGfx70_2:
+.incbin "baserom.gba", 0xA9B6D4, 0x80
+sGyaradosSprites70:
+ax_sprite sGyaradosGfx70, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx70_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx70_2, 0x80
+ax_sprite_terminator
+sGyaradosGfx71:
+.incbin "baserom.gba", 0xA9B784, 0x80
+sGyaradosSprites71:
+ax_sprite sGyaradosGfx71, 0x80
+ax_sprite_terminator
+sGyaradosGfx72:
+.incbin "baserom.gba", 0xA9B814, 0x40
+sGyaradosSprites72:
+ax_sprite sGyaradosGfx72, 0x40
+ax_sprite_terminator
+sGyaradosGfx73:
+.incbin "baserom.gba", 0xA9B864, 0x60
+sGyaradosGfx73_1:
+.incbin "baserom.gba", 0xA9B8C4, 0x260
+sGyaradosGfx73_2:
+.incbin "baserom.gba", 0xA9BB24, 0x60
+sGyaradosGfx73_3:
+.incbin "baserom.gba", 0xA9BB84, 0x60
+sGyaradosSprites73:
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx73, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx73_1, 0x260
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx73_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx73_3, 0x60
+ax_sprite_terminator
+sGyaradosGfx74:
+.incbin "baserom.gba", 0xA9BC2C, 0x80
+sGyaradosSprites74:
+ax_sprite sGyaradosGfx74, 0x80
+ax_sprite_terminator
+sGyaradosGfx75:
+.incbin "baserom.gba", 0xA9BCBC, 0x100
+sGyaradosSprites75:
+ax_sprite sGyaradosGfx75, 0x100
+ax_sprite_terminator
+sGyaradosGfx76:
+.incbin "baserom.gba", 0xA9BDCC, 0x40
+sGyaradosSprites76:
+ax_sprite sGyaradosGfx76, 0x40
+ax_sprite_terminator
+sGyaradosGfx77:
+.incbin "baserom.gba", 0xA9BE1C, 0x260
+sGyaradosGfx77_1:
+.incbin "baserom.gba", 0xA9C07C, 0x60
+sGyaradosGfx77_2:
+.incbin "baserom.gba", 0xA9C0DC, 0x60
+sGyaradosGfx77_3:
+.incbin "baserom.gba", 0xA9C13C, 0x40
+sGyaradosSprites77:
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx77, 0x260
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx77_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx77_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx77_3, 0x40
+ax_sprite_terminator
+sGyaradosGfx78:
+.incbin "baserom.gba", 0xA9C1C4, 0x20
+sGyaradosGfx78_1:
+.incbin "baserom.gba", 0xA9C1E4, 0x80
+sGyaradosSprites78:
+ax_sprite sGyaradosGfx78, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGyaradosGfx78_1, 0x80
+ax_sprite_terminator
+sGyaradosGfx79:
+.incbin "baserom.gba", 0xA9C284, 0x40
+sGyaradosGfx79_1:
+.incbin "baserom.gba", 0xA9C2C4, 0x180
+sGyaradosSprites79:
+ax_sprite sGyaradosGfx79, 0x40
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx79_1, 0x180
+ax_sprite_terminator
+sGyaradosGfx80:
+.incbin "baserom.gba", 0xA9C464, 0x80
+sGyaradosSprites80:
+ax_sprite sGyaradosGfx80, 0x80
+ax_sprite_terminator
+sGyaradosGfx81:
+.incbin "baserom.gba", 0xA9C4F4, 0x40
+sGyaradosSprites81:
+ax_sprite sGyaradosGfx81, 0x40
+ax_sprite_terminator
+sGyaradosGfx82:
+.incbin "baserom.gba", 0xA9C544, 0x20
+sGyaradosSprites82:
+ax_sprite sGyaradosGfx82, 0x20
+ax_sprite_terminator
+sGyaradosGfx83:
+.incbin "baserom.gba", 0xA9C574, 0x40
+sGyaradosGfx83_1:
+.incbin "baserom.gba", 0xA9C5B4, 0x60
+sGyaradosGfx83_2:
+.incbin "baserom.gba", 0xA9C614, 0x60
+sGyaradosGfx83_3:
+.incbin "baserom.gba", 0xA9C674, 0x60
+sGyaradosGfx83_4:
+.incbin "baserom.gba", 0xA9C6D4, 0x60
+sGyaradosGfx83_5:
+.incbin "baserom.gba", 0xA9C734, 0x60
+sGyaradosGfx83_6:
+.incbin "baserom.gba", 0xA9C794, 0x60
+sGyaradosGfx83_7:
+.incbin "baserom.gba", 0xA9C7F4, 0x40
+sGyaradosSprites83:
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx83, 0x40
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx83_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx83_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx83_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx83_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx83_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx83_6, 0x60
+ax_sprite 0, 0x40
+ax_sprite sGyaradosGfx83_7, 0x40
+ax_sprite_terminator
+sGyaradosGfx84:
+.incbin "baserom.gba", 0xA9C8BC, 0x20
+sGyaradosGfx84_1:
+.incbin "baserom.gba", 0xA9C8DC, 0xC0
+sGyaradosSprites84:
+ax_sprite sGyaradosGfx84, 0x20
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx84_1, 0xc0
+ax_sprite_terminator
+sGyaradosGfx85:
+.incbin "baserom.gba", 0xA9C9BC, 0x20
+sGyaradosGfx85_1:
+.incbin "baserom.gba", 0xA9C9DC, 0x60
+sGyaradosGfx85_2:
+.incbin "baserom.gba", 0xA9CA3C, 0x60
+sGyaradosGfx85_3:
+.incbin "baserom.gba", 0xA9CA9C, 0x60
+sGyaradosSprites85:
+ax_sprite sGyaradosGfx85, 0x20
+ax_sprite 0, 0x60
+ax_sprite sGyaradosGfx85_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx85_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx85_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sGyaradosGfx86:
+.incbin "baserom.gba", 0xA9CB44, 0xC0
+sGyaradosSprites86:
+ax_sprite sGyaradosGfx86, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGyaradosGfx87:
+.incbin "baserom.gba", 0xA9CC1C, 0x280
+sGyaradosGfx87_1:
+.incbin "baserom.gba", 0xA9CE9C, 0x60
+sGyaradosGfx87_2:
+.incbin "baserom.gba", 0xA9CEFC, 0x60
+sGyaradosGfx87_3:
+.incbin "baserom.gba", 0xA9CF5C, 0x60
+sGyaradosSprites87:
+ax_sprite sGyaradosGfx87, 0x280
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx87_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx87_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sGyaradosGfx87_3, 0x60
+ax_sprite_terminator
+sGyaradosGfx88:
+.incbin "baserom.gba", 0xA9CFFC, 0x40
+sGyaradosSprites88:
+ax_sprite sGyaradosGfx88, 0x40
+ax_sprite_terminator
+sGyaradosGfx89:
+.incbin "baserom.gba", 0xA9D04C, 0xC0
+sGyaradosSprites89:
+ax_sprite sGyaradosGfx89, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sGyaradosGfx90:
+.incbin "baserom.gba", 0xA9D124, 0x800
+sGyaradosSprites90:
+ax_sprite sGyaradosGfx90, 0x800
+ax_sprite_terminator
+sGyaradosGfx91:
+.incbin "baserom.gba", 0xA9D934, 0x800
+sGyaradosSprites91:
+ax_sprite sGyaradosGfx91, 0x800
+ax_sprite_terminator
+sGyaradosGfx92:
+.incbin "baserom.gba", 0xA9E144, 0x800
+sGyaradosSprites92:
+ax_sprite sGyaradosGfx92, 0x800
+ax_sprite_terminator
+sGyaradosGfx93:
+.incbin "baserom.gba", 0xA9E954, 0x800
+sGyaradosSprites93:
+ax_sprite sGyaradosGfx93, 0x800
+ax_sprite_terminator
+sGyaradosGfx94:
+.incbin "baserom.gba", 0xA9F164, 0x800
+sGyaradosSprites94:
+ax_sprite sGyaradosGfx94, 0x800
+ax_sprite_terminator
+sGyaradosGfx95:
+.incbin "baserom.gba", 0xA9F974, 0x800
+sGyaradosSprites95:
+ax_sprite sGyaradosGfx95, 0x800
+ax_sprite_terminator
+sGyaradosGfx96:
+.incbin "baserom.gba", 0xAA0184, 0x200
+sGyaradosSprites96:
+ax_sprite sGyaradosGfx96, 0x200
+ax_sprite_terminator
+sGyaradosGfx97:
+.incbin "baserom.gba", 0xAA0394, 0x400
+sGyaradosSprites97:
+ax_sprite sGyaradosGfx97, 0x400
+ax_sprite_terminator
+sAxPosesGyarados:
+.4byte sGyaradosPose1
+.4byte sGyaradosPose2
+.4byte sGyaradosPose3
+.4byte sGyaradosPose4
+.4byte sGyaradosPose5
+.4byte sGyaradosPose6
+.4byte sGyaradosPose7
+.4byte sGyaradosPose8
+.4byte sGyaradosPose9
+.4byte sGyaradosPose10
+.4byte sGyaradosPose11
+.4byte sGyaradosPose12
+.4byte sGyaradosPose13
+.4byte sGyaradosPose14
+.4byte sGyaradosPose15
+.4byte sGyaradosPose16
+.4byte sGyaradosPose17
+.4byte sGyaradosPose18
+.4byte sGyaradosPose19
+.4byte sGyaradosPose20
+.4byte sGyaradosPose21
+.4byte sGyaradosPose22
+.4byte sGyaradosPose23
+.4byte sGyaradosPose24
+.4byte sGyaradosPose25
+.4byte sGyaradosPose26
+.4byte sGyaradosPose27
+.4byte sGyaradosPose28
+.4byte sGyaradosPose29
+.4byte sGyaradosPose30
+.4byte sGyaradosPose31
+.4byte sGyaradosPose32
+.4byte sGyaradosPose33
+.4byte sGyaradosPose34
+.4byte sGyaradosPose35
+.4byte sGyaradosPose36
+.4byte sGyaradosPose37
+.4byte sGyaradosPose38
+.4byte sGyaradosPose39
+.4byte sGyaradosPose40
+.4byte sGyaradosPose41
+.4byte sGyaradosPose42
+.4byte sGyaradosPose43
+.4byte sGyaradosPose44
+.4byte sGyaradosPose45
+.4byte sGyaradosPose46
+.4byte sGyaradosPose47
+.4byte sGyaradosPose48
+.4byte sGyaradosPose49
+.4byte sGyaradosPose50
+.4byte sGyaradosPose51
+.4byte sGyaradosPose52
+.4byte sGyaradosPose53
+.4byte sGyaradosPose54
+.4byte sGyaradosPose55
+.4byte sGyaradosPose56
+.4byte sGyaradosPose57
+.4byte sGyaradosPose58
+.4byte sGyaradosPose59
+.4byte sGyaradosPose60
+.4byte sGyaradosPose61
+.4byte sGyaradosPose62
+.4byte sGyaradosPose63
+.4byte sGyaradosPose64
+.4byte sGyaradosPose65
+.4byte sGyaradosPose66
+.4byte sGyaradosPose67
+.4byte sGyaradosPose68
+.4byte sGyaradosPose69
+.4byte sGyaradosPose70
+.4byte sGyaradosPose71
+.4byte sGyaradosPose72
+.4byte sGyaradosPose73
+.4byte sGyaradosPose74
+.4byte sGyaradosPose75
+.4byte sGyaradosPose76
+.4byte sGyaradosPose77
+.4byte sGyaradosPose78
+.4byte sGyaradosPose79
+.4byte sGyaradosPose80
+.4byte sGyaradosPose81
+.4byte sGyaradosPose82
+.4byte sGyaradosPose83
+.4byte sGyaradosPose84
+.4byte sGyaradosPose85
+.4byte sGyaradosPose86
+.4byte sGyaradosPose87
+.4byte sGyaradosPose88
+.4byte sGyaradosPose89
+.4byte sGyaradosPose90
+.4byte sGyaradosPose91
+.4byte sGyaradosPose92
+.4byte sGyaradosPose93
+.4byte sGyaradosPose94
+.4byte sGyaradosPose95
+.4byte sGyaradosPose96
+.4byte sGyaradosPose97
+.4byte sGyaradosPose98
+.4byte sGyaradosPose99
+.4byte sGyaradosPose100
+.4byte sGyaradosPose101
+.4byte sGyaradosPose102
+.4byte sGyaradosPose103
+.4byte sGyaradosPose104
+.4byte sGyaradosPose105
+.4byte sGyaradosPose106
+.4byte sGyaradosPose107
+.4byte sGyaradosPose108
+.4byte sGyaradosPose109
+.4byte sGyaradosPose110
+.4byte sGyaradosPose111
+.4byte sGyaradosPose112
+.4byte sGyaradosPose113
+.4byte sGyaradosPose114
+.4byte sGyaradosPose115
+.4byte sGyaradosPose116
+.4byte sGyaradosPose117
+.4byte sGyaradosPose118
+.4byte sGyaradosPose119
+.4byte sGyaradosPose120
+.4byte sGyaradosPose121
+.4byte sGyaradosPose122
+.4byte sGyaradosPose123
+.4byte sGyaradosPose124
+.4byte sGyaradosPose125
+.4byte sGyaradosPose126
+.4byte sGyaradosPose127
+.4byte sGyaradosPose128
+.4byte sGyaradosPose129
+.4byte sGyaradosPose130
+.4byte sGyaradosPose131
+.4byte sGyaradosPose132
+.4byte sGyaradosPose133
+.4byte sGyaradosPose134
+.4byte sGyaradosPose135
+.4byte sGyaradosPose136
+.4byte sGyaradosPose137
+.4byte sGyaradosPose138
+.4byte sGyaradosPose139
+.4byte sGyaradosPose140
+.4byte sGyaradosPose141
+.4byte sGyaradosPose142
+.4byte sGyaradosPose143
+.4byte sGyaradosPose144
+.4byte sGyaradosPose145
+.4byte sGyaradosPose146
+.4byte sGyaradosPose147
+.4byte sGyaradosPose148
+.4byte sGyaradosPose149
+.4byte sGyaradosPose150
+.4byte sGyaradosPose151
+.4byte sGyaradosPose152
+.4byte sGyaradosPose153
+.4byte sGyaradosPose154
+.4byte sGyaradosPose155
+.4byte sGyaradosPose156
+.4byte sGyaradosPose157
+.4byte sGyaradosPose158
+.4byte sGyaradosPose159
+.4byte sGyaradosPose160
+.4byte sGyaradosPose161
+.4byte sGyaradosPose162
+.4byte sGyaradosPose163
+.4byte sGyaradosPose164
+.4byte sGyaradosPose165
+.4byte sGyaradosPose166
+.4byte sGyaradosPose167
+.4byte sGyaradosPose168
+.4byte sGyaradosPose169
+.4byte sGyaradosPose170
+.4byte sGyaradosPose171
+.4byte sGyaradosPose172
+.4byte sGyaradosPose173
+.4byte sGyaradosPose174
+.4byte sGyaradosPose175
+.4byte sGyaradosPose176
+.4byte sGyaradosPose177
+.4byte sGyaradosPose178
+.4byte sGyaradosPose179
+.4byte sGyaradosPose180
+.4byte sGyaradosPose181
+.4byte sGyaradosPose182
+.4byte sGyaradosPose183
+.4byte sGyaradosPose184
+.4byte sGyaradosPose185
+.4byte sGyaradosPose186
+.4byte sGyaradosPose187
+.4byte sGyaradosPose188
+.4byte sGyaradosPose189
+.4byte sGyaradosPose190
+.4byte sGyaradosPose191
+.4byte sGyaradosPose192
+.4byte sGyaradosPose193
+.4byte sGyaradosPose194
+.4byte sGyaradosPose195
+.4byte sGyaradosPose196
+.4byte sGyaradosPose197
+.4byte sGyaradosPose198
+.4byte sGyaradosPose199
+.4byte sGyaradosPose200
+.4byte sGyaradosPose201
+.4byte sGyaradosPose202
+.4byte sGyaradosPose203
+.4byte sGyaradosPose204
+.4byte sGyaradosPose205
+.4byte sGyaradosPose206
+.4byte sGyaradosPose207
+.4byte sGyaradosPose208
+.4byte sGyaradosPose209
+.4byte sGyaradosPose210
+.4byte sGyaradosPose211
+.4byte sGyaradosPose212
+.4byte sGyaradosPose213
+.4byte sGyaradosPose214
+.4byte sGyaradosPose215
+.4byte sGyaradosPose216
+.4byte sGyaradosPose217
+.4byte sGyaradosPose218
+sAxPositionsGyarados:
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte    0,  -18, 	 -14,  -28, 	  13,  -28, 	   0,  -26
+.2byte    0,  -29, 	 -13,  -33, 	  13,  -33, 	   0,  -32
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+.2byte   25,  -20, 	  31,  -31, 	   8,  -24, 	   2,  -11
+.2byte   15,  -30, 	  23,  -36, 	   2,  -31, 	  -1,  -14
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   33,  -28, 	  21,  -38, 	  18,  -28, 	   1,  -15
+.2byte   18,  -39, 	  12,  -43, 	  11,  -32, 	   2,  -14
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   23,  -34, 	   6,  -42, 	  22,  -37, 	   2,  -17
+.2byte   11,  -41, 	  -4,  -46, 	  17,  -42, 	   3,  -15
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte    1,  -41, 	  13,  -39, 	 -13,  -39, 	   1,  -31
+.2byte    0,  -45, 	  15,  -45, 	 -15,  -45, 	   0,  -29
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte  -24,  -34, 	  -7,  -42, 	 -23,  -37, 	  -3,  -17
+.2byte  -12,  -41, 	   3,  -46, 	 -18,  -42, 	  -4,  -15
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -34,  -28, 	 -22,  -38, 	 -19,  -28, 	  -2,  -15
+.2byte  -19,  -39, 	 -13,  -43, 	 -12,  -32, 	  -3,  -14
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -26,  -20, 	 -32,  -31, 	  -9,  -24, 	  -3,  -11
+.2byte  -16,  -30, 	 -24,  -36, 	  -3,  -31, 	   0,  -14
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte    0,  -18, 	 -14,  -28, 	  13,  -28, 	   0,  -26
+.2byte    0,  -29, 	 -13,  -33, 	  13,  -33, 	   0,  -32
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+.2byte   25,  -20, 	  31,  -31, 	   8,  -24, 	   2,  -11
+.2byte   15,  -30, 	  23,  -36, 	   2,  -31, 	  -1,  -14
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   33,  -28, 	  21,  -38, 	  18,  -28, 	   1,  -15
+.2byte   18,  -39, 	  12,  -43, 	  11,  -32, 	   2,  -14
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   23,  -34, 	   6,  -42, 	  22,  -37, 	   2,  -17
+.2byte   11,  -41, 	  -4,  -46, 	  17,  -42, 	   3,  -15
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte    1,  -41, 	  13,  -39, 	 -13,  -39, 	   1,  -31
+.2byte    0,  -45, 	  15,  -45, 	 -15,  -45, 	   0,  -29
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte  -24,  -34, 	  -7,  -42, 	 -23,  -37, 	  -3,  -17
+.2byte  -12,  -41, 	   3,  -46, 	 -18,  -42, 	  -4,  -15
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -34,  -28, 	 -22,  -38, 	 -19,  -28, 	  -2,  -15
+.2byte  -19,  -39, 	 -13,  -43, 	 -12,  -32, 	  -3,  -14
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -26,  -20, 	 -32,  -31, 	  -9,  -24, 	  -3,  -11
+.2byte  -16,  -30, 	 -24,  -36, 	  -3,  -31, 	   0,  -14
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte    0,  -18, 	 -14,  -28, 	  13,  -28, 	   0,  -26
+.2byte    0,  -29, 	 -13,  -33, 	  13,  -33, 	   0,  -32
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+.2byte   25,  -20, 	  31,  -31, 	   8,  -24, 	   2,  -11
+.2byte   15,  -30, 	  23,  -36, 	   2,  -31, 	  -1,  -14
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   33,  -28, 	  21,  -38, 	  18,  -28, 	   1,  -15
+.2byte   18,  -39, 	  12,  -43, 	  11,  -32, 	   2,  -14
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   23,  -34, 	   6,  -42, 	  22,  -37, 	   2,  -17
+.2byte   11,  -41, 	  -4,  -46, 	  17,  -42, 	   3,  -15
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte    1,  -41, 	  13,  -39, 	 -13,  -39, 	   1,  -31
+.2byte    0,  -45, 	  15,  -45, 	 -15,  -45, 	   0,  -29
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte  -24,  -34, 	  -7,  -42, 	 -23,  -37, 	  -3,  -17
+.2byte  -12,  -41, 	   3,  -46, 	 -18,  -42, 	  -4,  -15
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -34,  -28, 	 -22,  -38, 	 -19,  -28, 	  -2,  -15
+.2byte  -19,  -39, 	 -13,  -43, 	 -12,  -32, 	  -3,  -14
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -26,  -20, 	 -32,  -31, 	  -9,  -24, 	  -3,  -11
+.2byte  -16,  -30, 	 -24,  -36, 	  -3,  -31, 	   0,  -14
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte    0,  -18, 	 -14,  -28, 	  13,  -28, 	   0,  -26
+.2byte    0,  -29, 	 -13,  -33, 	  13,  -33, 	   0,  -32
+.2byte    0,  -17, 	 -14,  -29, 	  13,  -29, 	   1,  -32
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+.2byte   25,  -20, 	  31,  -31, 	   8,  -24, 	   2,  -11
+.2byte   15,  -30, 	  23,  -36, 	   2,  -31, 	  -1,  -14
+.2byte   26,  -17, 	  32,  -27, 	  11,  -23, 	   0,  -14
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   33,  -28, 	  21,  -38, 	  18,  -28, 	   1,  -15
+.2byte   18,  -39, 	  12,  -43, 	  11,  -32, 	   2,  -14
+.2byte   33,  -25, 	  25,  -41, 	  21,  -28, 	   5,  -13
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   23,  -34, 	   6,  -42, 	  22,  -37, 	   2,  -17
+.2byte   11,  -41, 	  -4,  -46, 	  17,  -42, 	   3,  -15
+.2byte   24,  -32, 	  13,  -42, 	  26,  -35, 	   6,  -15
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte    1,  -41, 	  13,  -39, 	 -13,  -39, 	   1,  -31
+.2byte    0,  -45, 	  15,  -45, 	 -15,  -45, 	   0,  -29
+.2byte    1,  -41, 	  12,  -40, 	 -12,  -40, 	   1,  -28
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte  -24,  -34, 	  -7,  -42, 	 -23,  -37, 	  -3,  -17
+.2byte  -12,  -41, 	   3,  -46, 	 -18,  -42, 	  -4,  -15
+.2byte  -25,  -32, 	 -14,  -42, 	 -27,  -35, 	  -7,  -15
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -34,  -28, 	 -22,  -38, 	 -19,  -28, 	  -2,  -15
+.2byte  -19,  -39, 	 -13,  -43, 	 -12,  -32, 	  -3,  -14
+.2byte  -34,  -25, 	 -26,  -41, 	 -22,  -28, 	  -6,  -13
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -26,  -20, 	 -32,  -31, 	  -9,  -24, 	  -3,  -11
+.2byte  -16,  -30, 	 -24,  -36, 	  -3,  -31, 	   0,  -14
+.2byte  -27,  -17, 	 -33,  -27, 	 -12,  -23, 	  -1,  -14
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte    0,  -18, 	 -14,  -28, 	  13,  -28, 	   0,  -26
+.2byte    0,  -29, 	 -13,  -33, 	  13,  -33, 	   0,  -32
+.2byte    0,  -36, 	 -17,  -34, 	  15,  -33, 	   0,  -17
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+.2byte   25,  -20, 	  31,  -31, 	   8,  -24, 	   2,  -11
+.2byte   15,  -30, 	  23,  -36, 	   2,  -31, 	  -1,  -14
+.2byte   13,  -40, 	  18,  -44, 	  -1,  -35, 	   6,  -14
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   33,  -28, 	  21,  -38, 	  18,  -28, 	   1,  -15
+.2byte   18,  -39, 	  12,  -43, 	  11,  -32, 	   2,  -14
+.2byte   19,  -53, 	   9,  -51, 	  10,  -42, 	   5,  -13
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   23,  -34, 	   6,  -42, 	  22,  -37, 	   2,  -17
+.2byte   11,  -41, 	  -4,  -46, 	  17,  -42, 	   3,  -15
+.2byte    8,  -46, 	  -6,  -48, 	  13,  -49, 	   6,  -19
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte    1,  -41, 	  13,  -39, 	 -13,  -39, 	   1,  -31
+.2byte    0,  -45, 	  15,  -45, 	 -15,  -45, 	   0,  -29
+.2byte    0,  -50, 	  14,  -41, 	 -14,  -41, 	   1,  -25
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte  -24,  -34, 	  -7,  -42, 	 -23,  -37, 	  -3,  -17
+.2byte  -12,  -41, 	   3,  -46, 	 -18,  -42, 	  -4,  -15
+.2byte   -9,  -46, 	   5,  -48, 	 -14,  -49, 	  -7,  -19
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -34,  -28, 	 -22,  -38, 	 -19,  -28, 	  -2,  -15
+.2byte  -19,  -39, 	 -13,  -43, 	 -12,  -32, 	  -3,  -14
+.2byte  -20,  -53, 	 -10,  -51, 	 -11,  -42, 	  -6,  -13
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -26,  -20, 	 -32,  -31, 	  -9,  -24, 	  -3,  -11
+.2byte  -16,  -30, 	 -24,  -36, 	  -3,  -31, 	   0,  -14
+.2byte  -14,  -40, 	 -19,  -44, 	   0,  -35, 	  -7,  -14
+.2byte  -21,  -24, 	 -28,  -34, 	  -3,  -29, 	  -2,  -13
+.2byte  -22,  -23, 	 -29,  -33, 	  -6,  -28, 	  -3,  -12
+.2byte    0,  -36, 	 -14,  -33, 	  13,  -33, 	   1,  -20
+.2byte   18,  -38, 	  19,  -46, 	   3,  -30, 	   4,  -11
+.2byte   21,  -48, 	  10,  -43, 	  11,  -35, 	   1,   -8
+.2byte    9,  -42, 	  -5,  -45, 	  13,  -43, 	   5,  -10
+.2byte    0,  -47, 	  14,  -36, 	 -14,  -36, 	   0,  -24
+.2byte  -10,  -42, 	   4,  -45, 	 -14,  -43, 	  -6,  -10
+.2byte  -22,  -48, 	 -11,  -43, 	 -12,  -35, 	  -2,   -8
+.2byte  -19,  -38, 	 -20,  -46, 	  -4,  -30, 	  -5,  -11
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+.2byte    0,   -8, 	 -14,  -20, 	  13,  -20, 	   1,  -23
+.2byte  -25,  -14, 	 -31,  -24, 	 -10,  -20, 	   1,  -11
+.2byte  -31,  -25, 	 -23,  -41, 	 -19,  -28, 	  -3,  -13
+.2byte  -22,  -32, 	 -11,  -42, 	 -24,  -35, 	  -4,  -15
+.2byte    1,  -42, 	  12,  -41, 	 -12,  -41, 	   1,  -29
+.2byte   21,  -32, 	  10,  -42, 	  23,  -35, 	   3,  -15
+.2byte   30,  -25, 	  22,  -41, 	  18,  -28, 	   2,  -13
+.2byte   24,  -14, 	  30,  -24, 	   9,  -20, 	  -2,  -11
+.2byte    0,  -29, 	 -13,  -33, 	  13,  -33, 	   0,  -32
+.2byte   15,  -30, 	  23,  -36, 	   2,  -31, 	  -1,  -14
+.2byte   18,  -39, 	  12,  -43, 	  11,  -32, 	   2,  -14
+.2byte   11,  -41, 	  -4,  -46, 	  17,  -42, 	   3,  -15
+.2byte    0,  -45, 	  15,  -45, 	 -15,  -45, 	   0,  -29
+.2byte  -12,  -41, 	   3,  -46, 	 -18,  -42, 	  -4,  -15
+.2byte  -19,  -39, 	 -13,  -43, 	 -12,  -32, 	  -3,  -14
+.2byte  -16,  -30, 	 -24,  -36, 	  -3,  -31, 	   0,  -14
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte    0,  -18, 	 -14,  -28, 	  13,  -28, 	   0,  -26
+.2byte    0,  -36, 	 -17,  -34, 	  15,  -33, 	   0,  -17
+.2byte    0,   -8, 	 -14,  -20, 	  13,  -20, 	   1,  -23
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+.2byte   23,  -20, 	  29,  -31, 	   6,  -24, 	   0,  -11
+.2byte   11,  -40, 	  16,  -44, 	  -3,  -35, 	   4,  -14
+.2byte   22,  -14, 	  28,  -24, 	   7,  -20, 	  -4,  -11
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   33,  -28, 	  21,  -38, 	  18,  -28, 	   1,  -15
+.2byte   19,  -53, 	   9,  -51, 	  10,  -42, 	   5,  -13
+.2byte   31,  -25, 	  23,  -41, 	  19,  -28, 	   3,  -13
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   23,  -34, 	   6,  -42, 	  22,  -37, 	   2,  -17
+.2byte    6,  -46, 	  -8,  -48, 	  11,  -49, 	   4,  -19
+.2byte   21,  -32, 	  10,  -42, 	  23,  -35, 	   3,  -15
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte    1,  -41, 	  13,  -39, 	 -13,  -39, 	   1,  -31
+.2byte    0,  -50, 	  14,  -41, 	 -14,  -41, 	   1,  -25
+.2byte    1,  -42, 	  12,  -41, 	 -12,  -41, 	   1,  -29
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte  -24,  -34, 	  -7,  -42, 	 -23,  -37, 	  -3,  -17
+.2byte   -7,  -46, 	   7,  -48, 	 -12,  -49, 	  -5,  -19
+.2byte  -22,  -32, 	 -11,  -42, 	 -24,  -35, 	  -4,  -15
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -34,  -28, 	 -22,  -38, 	 -19,  -28, 	  -2,  -15
+.2byte  -20,  -53, 	 -10,  -51, 	 -11,  -42, 	  -6,  -13
+.2byte  -32,  -25, 	 -24,  -41, 	 -20,  -28, 	  -4,  -13
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -24,  -20, 	 -30,  -31, 	  -7,  -24, 	  -1,  -11
+.2byte  -12,  -40, 	 -17,  -44, 	   2,  -35, 	  -5,  -14
+.2byte  -23,  -14, 	 -29,  -24, 	  -8,  -20, 	   3,  -11
+.2byte    0,   -8, 	 -14,  -20, 	  13,  -20, 	   1,  -23
+.2byte  -27,  -14, 	 -33,  -24, 	 -12,  -20, 	  -1,  -11
+.2byte  -34,  -25, 	 -26,  -41, 	 -22,  -28, 	  -6,  -13
+.2byte  -20,  -32, 	  -9,  -42, 	 -22,  -35, 	  -2,  -15
+.2byte    1,  -42, 	  12,  -41, 	 -12,  -41, 	   1,  -29
+.2byte   20,  -32, 	   9,  -42, 	  22,  -35, 	   2,  -15
+.2byte   33,  -25, 	  25,  -41, 	  21,  -28, 	   5,  -13
+.2byte   26,  -14, 	  32,  -24, 	  11,  -20, 	   0,  -11
+.2byte    0,  -24, 	 -16,  -30, 	  16,  -30, 	   0,  -30
+.2byte  -19,  -26, 	 -27,  -34, 	  -3,  -29, 	  -2,  -10
+.2byte  -25,  -33, 	 -16,  -43, 	 -15,  -32, 	  -3,  -14
+.2byte  -16,  -39, 	  -1,  -42, 	 -20,  -38, 	  -4,  -17
+.2byte    0,  -44, 	  15,  -41, 	 -15,  -41, 	   0,  -31
+.2byte   15,  -39, 	   0,  -42, 	  19,  -38, 	   3,  -17
+.2byte   24,  -33, 	  15,  -43, 	  14,  -32, 	   2,  -14
+.2byte   18,  -26, 	  26,  -34, 	   2,  -29, 	   1,  -10
+sGyaradosAnimTable1:
+.4byte sGyaradosAnims_1_1
+.4byte sGyaradosAnims_1_2
+.4byte sGyaradosAnims_1_3
+.4byte sGyaradosAnims_1_4
+.4byte sGyaradosAnims_1_5
+.4byte sGyaradosAnims_1_6
+.4byte sGyaradosAnims_1_7
+.4byte sGyaradosAnims_1_8
+sGyaradosAnimTable2:
+.4byte sGyaradosAnims_2_1
+.4byte sGyaradosAnims_2_2
+.4byte sGyaradosAnims_2_3
+.4byte sGyaradosAnims_2_4
+.4byte sGyaradosAnims_2_5
+.4byte sGyaradosAnims_2_6
+.4byte sGyaradosAnims_2_7
+.4byte sGyaradosAnims_2_8
+sGyaradosAnimTable3:
+.4byte sGyaradosAnims_3_1
+.4byte sGyaradosAnims_3_2
+.4byte sGyaradosAnims_3_3
+.4byte sGyaradosAnims_3_4
+.4byte sGyaradosAnims_3_5
+.4byte sGyaradosAnims_3_6
+.4byte sGyaradosAnims_3_7
+.4byte sGyaradosAnims_3_8
+sGyaradosAnimTable4:
+.4byte sGyaradosAnims_4_1
+.4byte sGyaradosAnims_4_2
+.4byte sGyaradosAnims_4_3
+.4byte sGyaradosAnims_4_4
+.4byte sGyaradosAnims_4_5
+.4byte sGyaradosAnims_4_6
+.4byte sGyaradosAnims_4_7
+.4byte sGyaradosAnims_4_8
+sGyaradosAnimTable5:
+.4byte sGyaradosAnims_5_1
+.4byte sGyaradosAnims_5_2
+.4byte sGyaradosAnims_5_3
+.4byte sGyaradosAnims_5_4
+.4byte sGyaradosAnims_5_5
+.4byte sGyaradosAnims_5_6
+.4byte sGyaradosAnims_5_7
+.4byte sGyaradosAnims_5_8
+sGyaradosAnimTable6:
+.4byte sGyaradosAnims_6_1
+.4byte sGyaradosAnims_6_1
+.4byte sGyaradosAnims_6_1
+.4byte sGyaradosAnims_6_1
+.4byte sGyaradosAnims_6_1
+.4byte sGyaradosAnims_6_1
+.4byte sGyaradosAnims_6_1
+.4byte sGyaradosAnims_6_1
+sGyaradosAnimTable7:
+.4byte sGyaradosAnims_7_1
+.4byte sGyaradosAnims_7_2
+.4byte sGyaradosAnims_7_3
+.4byte sGyaradosAnims_7_4
+.4byte sGyaradosAnims_7_5
+.4byte sGyaradosAnims_7_6
+.4byte sGyaradosAnims_7_7
+.4byte sGyaradosAnims_7_8
+sGyaradosAnimTable8:
+.4byte sGyaradosAnims_8_1
+.4byte sGyaradosAnims_8_2
+.4byte sGyaradosAnims_8_3
+.4byte sGyaradosAnims_8_4
+.4byte sGyaradosAnims_8_5
+.4byte sGyaradosAnims_8_6
+.4byte sGyaradosAnims_8_7
+.4byte sGyaradosAnims_8_8
+sGyaradosAnimTable9:
+.4byte sGyaradosAnims_9_1
+.4byte sGyaradosAnims_9_2
+.4byte sGyaradosAnims_9_3
+.4byte sGyaradosAnims_9_4
+.4byte sGyaradosAnims_9_5
+.4byte sGyaradosAnims_9_6
+.4byte sGyaradosAnims_9_7
+.4byte sGyaradosAnims_9_8
+sGyaradosAnimTable10:
+.4byte sGyaradosAnims_10_1
+.4byte sGyaradosAnims_10_2
+.4byte sGyaradosAnims_10_3
+.4byte sGyaradosAnims_10_4
+.4byte sGyaradosAnims_10_5
+.4byte sGyaradosAnims_10_6
+.4byte sGyaradosAnims_10_7
+.4byte sGyaradosAnims_10_8
+sGyaradosAnimTable11:
+.4byte sGyaradosAnims_11_1
+.4byte sGyaradosAnims_11_2
+.4byte sGyaradosAnims_11_3
+.4byte sGyaradosAnims_11_4
+.4byte sGyaradosAnims_11_5
+.4byte sGyaradosAnims_11_6
+.4byte sGyaradosAnims_11_7
+.4byte sGyaradosAnims_11_8
+sGyaradosAnimTable12:
+.4byte sGyaradosAnims_12_1
+.4byte sGyaradosAnims_12_2
+.4byte sGyaradosAnims_12_3
+.4byte sGyaradosAnims_12_4
+.4byte sGyaradosAnims_12_5
+.4byte sGyaradosAnims_12_6
+.4byte sGyaradosAnims_12_7
+.4byte sGyaradosAnims_12_8
+sGyaradosAnimTable13:
+.4byte sGyaradosAnims_13_1
+.4byte sGyaradosAnims_13_2
+.4byte sGyaradosAnims_13_3
+.4byte sGyaradosAnims_13_4
+.4byte sGyaradosAnims_13_5
+.4byte sGyaradosAnims_13_6
+.4byte sGyaradosAnims_13_7
+.4byte sGyaradosAnims_13_8
+sAxAnimationsGyarados:
+.4byte sGyaradosAnimTable1
+.4byte sGyaradosAnimTable2
+.4byte sGyaradosAnimTable3
+.4byte sGyaradosAnimTable4
+.4byte sGyaradosAnimTable5
+.4byte sGyaradosAnimTable6
+.4byte sGyaradosAnimTable7
+.4byte sGyaradosAnimTable8
+.4byte sGyaradosAnimTable9
+.4byte sGyaradosAnimTable10
+.4byte sGyaradosAnimTable11
+.4byte sGyaradosAnimTable12
+.4byte sGyaradosAnimTable13
+sAxSpritesGyarados:
+.4byte sGyaradosSprites1
+.4byte sGyaradosSprites2
+.4byte sGyaradosSprites3
+.4byte sGyaradosSprites4
+.4byte sGyaradosSprites5
+.4byte sGyaradosSprites6
+.4byte sGyaradosSprites7
+.4byte sGyaradosSprites8
+.4byte sGyaradosSprites9
+.4byte sGyaradosSprites10
+.4byte sGyaradosSprites11
+.4byte sGyaradosSprites12
+.4byte sGyaradosSprites13
+.4byte sGyaradosSprites14
+.4byte sGyaradosSprites15
+.4byte sGyaradosSprites16
+.4byte sGyaradosSprites17
+.4byte sGyaradosSprites18
+.4byte sGyaradosSprites19
+.4byte sGyaradosSprites20
+.4byte sGyaradosSprites21
+.4byte sGyaradosSprites22
+.4byte sGyaradosSprites23
+.4byte sGyaradosSprites24
+.4byte sGyaradosSprites25
+.4byte sGyaradosSprites26
+.4byte sGyaradosSprites27
+.4byte sGyaradosSprites28
+.4byte sGyaradosSprites29
+.4byte sGyaradosSprites30
+.4byte sGyaradosSprites31
+.4byte sGyaradosSprites32
+.4byte sGyaradosSprites33
+.4byte sGyaradosSprites34
+.4byte sGyaradosSprites35
+.4byte sGyaradosSprites36
+.4byte sGyaradosSprites37
+.4byte sGyaradosSprites38
+.4byte sGyaradosSprites39
+.4byte sGyaradosSprites40
+.4byte sGyaradosSprites41
+.4byte sGyaradosSprites42
+.4byte sGyaradosSprites43
+.4byte sGyaradosSprites44
+.4byte sGyaradosSprites45
+.4byte sGyaradosSprites46
+.4byte sGyaradosSprites47
+.4byte sGyaradosSprites48
+.4byte sGyaradosSprites49
+.4byte sGyaradosSprites50
+.4byte sGyaradosSprites51
+.4byte sGyaradosSprites52
+.4byte sGyaradosSprites53
+.4byte sGyaradosSprites54
+.4byte sGyaradosSprites55
+.4byte sGyaradosSprites56
+.4byte sGyaradosSprites57
+.4byte sGyaradosSprites58
+.4byte sGyaradosSprites59
+.4byte sGyaradosSprites60
+.4byte sGyaradosSprites61
+.4byte sGyaradosSprites62
+.4byte sGyaradosSprites63
+.4byte sGyaradosSprites64
+.4byte sGyaradosSprites65
+.4byte sGyaradosSprites66
+.4byte sGyaradosSprites67
+.4byte sGyaradosSprites68
+.4byte sGyaradosSprites69
+.4byte sGyaradosSprites70
+.4byte sGyaradosSprites71
+.4byte sGyaradosSprites72
+.4byte sGyaradosSprites73
+.4byte sGyaradosSprites74
+.4byte sGyaradosSprites75
+.4byte sGyaradosSprites76
+.4byte sGyaradosSprites77
+.4byte sGyaradosSprites78
+.4byte sGyaradosSprites79
+.4byte sGyaradosSprites80
+.4byte sGyaradosSprites81
+.4byte sGyaradosSprites82
+.4byte sGyaradosSprites83
+.4byte sGyaradosSprites84
+.4byte sGyaradosSprites85
+.4byte sGyaradosSprites86
+.4byte sGyaradosSprites87
+.4byte sGyaradosSprites88
+.4byte sGyaradosSprites89
+.4byte sGyaradosSprites90
+.4byte sGyaradosSprites91
+.4byte sGyaradosSprites92
+.4byte sGyaradosSprites93
+.4byte sGyaradosSprites94
+.4byte sGyaradosSprites95
+.4byte sGyaradosSprites96
+.4byte sGyaradosSprites97
+sAxMainGyarados:
+ax_main sAxPosesGyarados, sAxAnimationsGyarados, 13, sAxSpritesGyarados, sAxPositionsGyarados

--- a/data/ax/hariyama.inc
+++ b/data/ax/hariyama.inc
@@ -1,0 +1,2499 @@
+.global gAxHariyama
+gAxHariyama:
+ax_siro sAxMainHariyama
+sHariyamaPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose2:
+ax_pose 1, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose4:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose5:
+ax_pose 4, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose6:
+ax_pose 5, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose7:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose8:
+ax_pose 7, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose9:
+ax_pose 8, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose10:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose11:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose12:
+ax_pose 11, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose13:
+ax_pose 12, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose14:
+ax_pose 13, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose15:
+ax_pose 14, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose16:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose17:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose18:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose19:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose20:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose21:
+ax_pose 20, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose22:
+ax_pose 21, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose23:
+ax_pose 22, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose24:
+ax_pose 23, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose26:
+ax_pose 1, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose28:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose29:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose30:
+ax_pose 4, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose31:
+ax_pose 5, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose32:
+ax_pose 25, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose33:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose34:
+ax_pose 7, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose35:
+ax_pose 8, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose36:
+ax_pose 26, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose37:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose38:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose39:
+ax_pose 11, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose40:
+ax_pose 27, 0x01e4, 0x90f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose41:
+ax_pose 12, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose42:
+ax_pose 13, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose43:
+ax_pose 14, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose44:
+ax_pose 28, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose45:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose46:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose47:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose48:
+ax_pose 27, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose49:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose50:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose51:
+ax_pose 20, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose52:
+ax_pose 26, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose53:
+ax_pose 21, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose54:
+ax_pose 22, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose55:
+ax_pose 23, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose56:
+ax_pose 25, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose57:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose58:
+ax_pose 1, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose59:
+ax_pose 2, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose60:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose61:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose62:
+ax_pose 4, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose63:
+ax_pose 5, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose64:
+ax_pose 25, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose65:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose66:
+ax_pose 7, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose67:
+ax_pose 8, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose68:
+ax_pose 26, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose69:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose70:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose71:
+ax_pose 11, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose72:
+ax_pose 27, 0x01e4, 0x90f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose73:
+ax_pose 12, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose74:
+ax_pose 13, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose75:
+ax_pose 14, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose76:
+ax_pose 28, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose77:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose78:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose79:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose80:
+ax_pose 27, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose81:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose82:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose83:
+ax_pose 20, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose84:
+ax_pose 26, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose85:
+ax_pose 21, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose86:
+ax_pose 22, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose87:
+ax_pose 23, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose88:
+ax_pose 25, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose89:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose90:
+ax_pose 25, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose91:
+ax_pose 26, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose92:
+ax_pose 27, 0x01e4, 0x90f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose93:
+ax_pose 28, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose94:
+ax_pose 27, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose95:
+ax_pose 26, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose96:
+ax_pose 25, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose97:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose98:
+ax_pose 21, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose99:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose100:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose101:
+ax_pose 12, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose102:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose103:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose104:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose105:
+ax_pose 29, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose106:
+ax_pose 30, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose107:
+ax_pose 31, 0x01e6, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose108:
+ax_pose 32, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose109:
+ax_pose 33, 0x01e5, 0x90ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose110:
+ax_pose 34, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose111:
+ax_pose 35, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose112:
+ax_pose 34, 0x01e8, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose113:
+ax_pose 33, 0x01e5, 0x80f2, 0x9c00
+ax_pose_terminator
+sHariyamaPose114:
+ax_pose 32, 0x01e5, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose115:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose116:
+ax_pose 1, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose117:
+ax_pose 2, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose118:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose119:
+ax_pose 4, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose120:
+ax_pose 5, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose121:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose122:
+ax_pose 7, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose123:
+ax_pose 8, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose124:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose125:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose126:
+ax_pose 11, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose127:
+ax_pose 12, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose128:
+ax_pose 13, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose129:
+ax_pose 14, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose130:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose131:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose132:
+ax_pose 17, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose133:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose134:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose135:
+ax_pose 20, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose136:
+ax_pose 21, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose137:
+ax_pose 22, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose138:
+ax_pose 23, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose139:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose140:
+ax_pose 25, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose141:
+ax_pose 26, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose142:
+ax_pose 27, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose143:
+ax_pose 28, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose144:
+ax_pose 27, 0x01e4, 0x90f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose145:
+ax_pose 26, 0x01e4, 0x90ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose146:
+ax_pose 25, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose147:
+ax_pose 2, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose148:
+ax_pose 5, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose149:
+ax_pose 8, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose150:
+ax_pose 11, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose151:
+ax_pose 14, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose152:
+ax_pose 17, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose153:
+ax_pose 20, 0x01e3, 0x80ed, 0x9c00
+ax_pose_terminator
+sHariyamaPose154:
+ax_pose 23, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose155:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose156:
+ax_pose 2, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose157:
+ax_pose 24, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose158:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose159:
+ax_pose 5, 0x01e5, 0x80ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose160:
+ax_pose 25, 0x01e6, 0x90ed, 0x9c00
+ax_pose_terminator
+sHariyamaPose161:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose162:
+ax_pose 8, 0x01e3, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose163:
+ax_pose 26, 0x01e4, 0x90ed, 0x9c00
+ax_pose_terminator
+sHariyamaPose164:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose165:
+ax_pose 11, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose166:
+ax_pose 27, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose167:
+ax_pose 12, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose168:
+ax_pose 14, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose169:
+ax_pose 28, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose170:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose171:
+ax_pose 17, 0x01e4, 0x80f2, 0x9c00
+ax_pose_terminator
+sHariyamaPose172:
+ax_pose 27, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose173:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose174:
+ax_pose 20, 0x01e3, 0x80ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose175:
+ax_pose 26, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose176:
+ax_pose 21, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose177:
+ax_pose 23, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose178:
+ax_pose 25, 0x01e6, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose179:
+ax_pose 24, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose180:
+ax_pose 25, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose181:
+ax_pose 26, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sHariyamaPose182:
+ax_pose 27, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose183:
+ax_pose 28, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose184:
+ax_pose 27, 0x01e4, 0x90f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose185:
+ax_pose 26, 0x01e4, 0x90ee, 0x9c00
+ax_pose_terminator
+sHariyamaPose186:
+ax_pose 25, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose187:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose188:
+ax_pose 21, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose189:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose190:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose191:
+ax_pose 12, 0x01e4, 0x80ef, 0x9c00
+ax_pose_terminator
+sHariyamaPose192:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose193:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sHariyamaPose194:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+.align 2
+sHariyamaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_2_1:
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 2, 0, 27, 0, -3, 0, -3,
+ax_anim 6, 0, 27, 0, -4, 0, -4,
+ax_anim 1, 2, 24, 0, 3, 0, 3,
+ax_anim 1, 0, 26, 0, 11, 0, 11,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sHariyamaAnims_2_2:
+ax_anim 2, 0, 31, -2, -2, -2, -2,
+ax_anim 2, 0, 31, -3, -3, -3, -3,
+ax_anim 6, 0, 31, -4, -4, -4, -4,
+ax_anim 1, 2, 28, 3, 3, 3, 3,
+ax_anim 1, 0, 30, 11, 10, 11, 10,
+ax_anim 2, 0, 30, 19, 18, 19, 18,
+ax_anim 2, 1, 30, 20, 17, 20, 17,
+ax_anim 2, 0, 30, 19, 18, 19, 18,
+ax_anim 2, 0, 30, 20, 17, 20, 17,
+ax_anim 2, 0, 30, 19, 18, 19, 18,
+ax_anim 2, 0, 30, 20, 17, 20, 17,
+ax_anim 2, 0, 28, 10, 9, 10, 9,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sHariyamaAnims_2_3:
+ax_anim 2, 0, 35, -2, 0, -2, 0,
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 6, 0, 35, -4, 0, -4, 0,
+ax_anim 1, 2, 32, 1, 0, 1, 0,
+ax_anim 1, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 34, 17, 0, 17, 0,
+ax_anim 2, 1, 34, 17, 1, 17, 1,
+ax_anim 2, 0, 34, 17, 0, 17, 0,
+ax_anim 2, 0, 34, 17, 1, 17, 1,
+ax_anim 2, 0, 34, 17, 0, 17, 0,
+ax_anim 2, 0, 34, 17, 1, 17, 1,
+ax_anim 2, 0, 32, 8, 0, 8, 0,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim_terminator
+sHariyamaAnims_2_4:
+ax_anim 2, 0, 39, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -3, 3, -3, 3,
+ax_anim 6, 0, 39, -4, 4, -4, 4,
+ax_anim 1, 2, 36, 3, -3, 3, -3,
+ax_anim 1, 0, 38, 10, -9, 10, -9,
+ax_anim 2, 0, 38, 19, -16, 19, -16,
+ax_anim 2, 1, 38, 20, -15, 20, -15,
+ax_anim 2, 0, 38, 19, -16, 19, -16,
+ax_anim 2, 0, 38, 20, -15, 20, -15,
+ax_anim 2, 0, 38, 19, -16, 19, -16,
+ax_anim 2, 0, 38, 20, -15, 20, -15,
+ax_anim 2, 0, 36, 10, -9, 10, -9,
+ax_anim 2, 0, 36, 4, -4, 4, -4,
+ax_anim_terminator
+sHariyamaAnims_2_5:
+ax_anim 2, 0, 43, 0, 2, 0, 2,
+ax_anim 2, 0, 43, 0, 3, 0, 3,
+ax_anim 6, 0, 43, 0, 4, 0, 4,
+ax_anim 1, 2, 40, 0, -2, 0, -2,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 42, 0, -17, 0, -17,
+ax_anim 2, 1, 42, 1, -17, 1, -17,
+ax_anim 2, 0, 42, 0, -17, 0, -17,
+ax_anim 2, 0, 42, 1, -17, 1, -17,
+ax_anim 2, 0, 42, 0, -17, 0, -17,
+ax_anim 2, 0, 42, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -8, 0, -8,
+ax_anim 2, 0, 40, 0, -3, 0, -3,
+ax_anim_terminator
+sHariyamaAnims_2_6:
+ax_anim 2, 0, 47, 2, 2, 2, 2,
+ax_anim 2, 0, 47, 3, 3, 3, 3,
+ax_anim 6, 0, 47, 4, 4, 4, 4,
+ax_anim 1, 2, 44, -3, -3, -3, -3,
+ax_anim 1, 0, 46, -10, -10, -10, -10,
+ax_anim 2, 0, 46, -17, -17, -17, -17,
+ax_anim 2, 1, 46, -18, -16, -18, -16,
+ax_anim 2, 0, 46, -17, -17, -17, -17,
+ax_anim 2, 0, 46, -18, -16, -18, -16,
+ax_anim 2, 0, 46, -17, -17, -17, -17,
+ax_anim 2, 0, 46, -18, -16, -18, -16,
+ax_anim 2, 0, 44, -10, -10, -10, -10,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim_terminator
+sHariyamaAnims_2_7:
+ax_anim 2, 0, 51, 2, 0, 2, 0,
+ax_anim 2, 0, 51, 3, 0, 3, 0,
+ax_anim 6, 0, 51, 4, 0, 4, 0,
+ax_anim 1, 2, 48, -1, 0, -1, 0,
+ax_anim 1, 0, 50, -8, 0, -8, 0,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 1, 50, -17, 1, -17, 1,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 0, 50, -17, 1, -17, 1,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 0, 50, -17, 1, -17, 1,
+ax_anim 2, 0, 48, -8, 0, -8, 0,
+ax_anim 2, 0, 48, -3, 0, -3, 0,
+ax_anim_terminator
+sHariyamaAnims_2_8:
+ax_anim 2, 0, 55, 2, -2, 2, -2,
+ax_anim 2, 0, 55, 3, -3, 3, -3,
+ax_anim 6, 0, 55, 4, -4, 4, -4,
+ax_anim 1, 2, 52, -3, 3, -3, 3,
+ax_anim 1, 0, 54, -11, 10, -11, 10,
+ax_anim 2, 0, 54, -19, 18, -19, 18,
+ax_anim 2, 1, 54, -20, 17, -20, 17,
+ax_anim 2, 0, 54, -19, 18, -19, 18,
+ax_anim 2, 0, 54, -20, 17, -20, 17,
+ax_anim 2, 0, 54, -19, 18, -19, 18,
+ax_anim 2, 0, 54, -20, 17, -20, 17,
+ax_anim 2, 0, 52, -10, 9, -10, 9,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_3_1:
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 2, 0, 59, 0, -3, 0, -3,
+ax_anim 6, 0, 59, 0, -4, 0, -4,
+ax_anim 2, 2, 56, 0, 3, 0, 3,
+ax_anim 1, 0, 58, 1, 11, 1, 11,
+ax_anim 4, 0, 58, 2, 12, 1, 11,
+ax_anim 1, 0, 57, -2, 19, -2, 19,
+ax_anim 4, 1, 57, -3, 20, -3, 20,
+ax_anim 1, 0, 58, 1, 19, 1, 19,
+ax_anim 4, 0, 58, 2, 20, 2, 20,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sHariyamaAnims_3_2:
+ax_anim 2, 0, 63, -2, -2, -2, -2,
+ax_anim 2, 0, 63, -3, -3, -3, -3,
+ax_anim 6, 0, 63, -4, -4, -4, -4,
+ax_anim 2, 2, 60, 3, 3, 3, 3,
+ax_anim 1, 0, 61, 11, 10, 11, 10,
+ax_anim 4, 0, 61, 12, 10, 12, 10,
+ax_anim 1, 0, 62, 18, 16, 18, 16,
+ax_anim 4, 1, 62, 17, 17, 17, 17,
+ax_anim 1, 0, 61, 20, 18, 20, 18,
+ax_anim 4, 0, 61, 21, 18, 21, 18,
+ax_anim 2, 0, 60, 10, 9, 10, 9,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sHariyamaAnims_3_3:
+ax_anim 2, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 67, -3, 0, -3, 0,
+ax_anim 6, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 64, 3, 0, 3, 0,
+ax_anim 1, 0, 65, 9, 0, 9, 0,
+ax_anim 4, 0, 65, 10, -1, 10, -1,
+ax_anim 1, 0, 66, 15, 0, 15, 0,
+ax_anim 4, 1, 66, 16, 1, 16, 1,
+ax_anim 1, 0, 65, 18, -1, 18, -1,
+ax_anim 4, 0, 65, 19, -2, 19, -2,
+ax_anim 2, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sHariyamaAnims_3_4:
+ax_anim 2, 0, 71, -2, 2, -2, 2,
+ax_anim 2, 0, 71, -3, 3, -3, 3,
+ax_anim 6, 0, 71, -4, 4, -4, 4,
+ax_anim 2, 2, 68, 3, -3, 3, -3,
+ax_anim 1, 0, 69, 10, -11, 10, -11,
+ax_anim 4, 0, 69, 10, -12, 10, -11,
+ax_anim 1, 0, 70, 18, -18, 18, -18,
+ax_anim 4, 1, 70, 19, -18, 18, -19,
+ax_anim 1, 0, 69, 18, -19, 18, -18,
+ax_anim 4, 0, 69, 18, -21, 20, -19,
+ax_anim 2, 0, 68, 9, -10, 9, -10,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sHariyamaAnims_3_5:
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 6, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 2, 72, 0, -2, 0, -2,
+ax_anim 1, 0, 74, 0, -8, 0, -8,
+ax_anim 4, 0, 74, -1, -9, 0, -8,
+ax_anim 1, 0, 73, 0, -16, 0, -16,
+ax_anim 4, 1, 73, 1, -17, -1, -17,
+ax_anim 1, 0, 74, -2, -17, 0, -16,
+ax_anim 4, 0, 74, -3, -18, 1, -17,
+ax_anim 2, 0, 72, 0, -8, 0, -8,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sHariyamaAnims_3_6:
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 6, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 2, 76, -3, -3, -3, -3,
+ax_anim 1, 0, 77, -10, -11, -10, -11,
+ax_anim 4, 0, 77, -10, -12, -10, -11,
+ax_anim 1, 0, 78, -18, -18, -18, -18,
+ax_anim 4, 1, 78, -19, -18, -18, -19,
+ax_anim 1, 0, 77, -18, -20, -18, -18,
+ax_anim 4, 0, 77, -19, -21, -20, -19,
+ax_anim 2, 0, 76, -9, -10, -9, -10,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim_terminator
+sHariyamaAnims_3_7:
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 6, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 2, 80, -3, 0, -3, 0,
+ax_anim 1, 0, 81, -9, 0, -9, 0,
+ax_anim 4, 0, 81, -10, -1, -10, -1,
+ax_anim 1, 0, 82, -15, 0, -15, 0,
+ax_anim 4, 1, 82, -16, 1, -16, 1,
+ax_anim 1, 0, 81, -18, -1, -18, -1,
+ax_anim 4, 0, 81, -19, -2, -19, -2,
+ax_anim 2, 0, 80, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sHariyamaAnims_3_8:
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 6, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 2, 84, -3, 3, -3, 3,
+ax_anim 1, 0, 85, -11, 10, -11, 10,
+ax_anim 4, 0, 85, -12, 10, -12, 10,
+ax_anim 1, 0, 86, -18, 16, -18, 16,
+ax_anim 4, 1, 86, -17, 17, -17, 17,
+ax_anim 1, 0, 85, -20, 18, -20, 18,
+ax_anim 4, 0, 85, -21, 18, -21, 18,
+ax_anim 2, 0, 84, -10, 9, -10, 9,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_4_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 1, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim_terminator
+sHariyamaAnims_4_2:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 1, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim_terminator
+sHariyamaAnims_4_3:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim_terminator
+sHariyamaAnims_4_4:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sHariyamaAnims_4_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 1, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim_terminator
+sHariyamaAnims_4_6:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+sHariyamaAnims_4_7:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 1, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim_terminator
+sHariyamaAnims_4_8:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sHariyamaAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sHariyamaAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sHariyamaAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sHariyamaAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sHariyamaAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sHariyamaAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sHariyamaAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_8_1:
+ax_anim 26, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 4, 0, 116, 0, -4, 0, 0,
+ax_anim 4, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 26, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 0, 115, 0, -4, 0, 0,
+ax_anim 4, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_8_2:
+ax_anim 26, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 4, 0, 119, 0, -4, 0, 0,
+ax_anim 4, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 26, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 118, 0, -4, 0, 0,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_8_3:
+ax_anim 26, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 4, 0, 122, 0, -4, 0, 0,
+ax_anim 4, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 26, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 4, 0, 121, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_8_4:
+ax_anim 26, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 4, 0, 125, 0, -4, 0, 0,
+ax_anim 4, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 26, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 4, 0, 124, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 125, 0, -2, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_8_5:
+ax_anim 26, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 4, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 26, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_8_6:
+ax_anim 26, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 26, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 130, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_8_7:
+ax_anim 26, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 133, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 26, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 133, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_8_8:
+ax_anim 26, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 4, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 0, 136, 0, -2, 0, 0,
+ax_anim 26, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 0, 136, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 1, 0, 137, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 16, 7, 16,
+ax_anim 3, 0, 142, 0, 19, 0, 19,
+ax_anim 2, 3, 143, -7, 16, -7, 16,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 20, 11, 20, 11,
+ax_anim 3, 0, 141, 20, 19, 20, 19,
+ax_anim 2, 3, 142, 10, 19, 10, 19,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 2, -5, 2, -5,
+ax_anim 2, 0, 138, 10, -6, 10, -6,
+ax_anim 2, 0, 139, 16, -5, 16, -5,
+ax_anim 3, 0, 140, 20, 0, 20, 0,
+ax_anim 2, 3, 141, 16, 6, 16, 6,
+ax_anim 2, 0, 142, 9, 8, 9, 8,
+ax_anim 1, 0, 143, 4, 6, 4, 6,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 3, -16, 3, -16,
+ax_anim 2, 0, 138, 12, -20, 12, -20,
+ax_anim 3, 0, 139, 20, -20, 20, -20,
+ax_anim 2, 3, 140, 21, -13, 21, -13,
+ax_anim 2, 0, 141, 19, -6, 19, -6,
+ax_anim 1, 0, 142, 10, -1, 10, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -18, -7, -18,
+ax_anim 3, 0, 138, 0, -19, 0, -19,
+ax_anim 2, 3, 139, 7, -18, 7, -18,
+ax_anim 2, 0, 140, 9, -12, 9, -12,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -3, -16, -3, -16,
+ax_anim 2, 0, 138, -12, -20, -12, -20,
+ax_anim 3, 0, 145, -20, -20, -20, -20,
+ax_anim 2, 3, 144, -21, -13, -21, -13,
+ax_anim 2, 0, 143, -19, -6, -19, -6,
+ax_anim 1, 0, 142, -10, -1, -10, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -2, -5, -2, -5,
+ax_anim 2, 0, 138, -10, -6, -10, -6,
+ax_anim 2, 0, 145, -16, -5, -16, -5,
+ax_anim 3, 0, 144, -20, 0, -20, 0,
+ax_anim 2, 3, 143, -16, 6, -16, 6,
+ax_anim 2, 0, 142, -9, 8, -9, 8,
+ax_anim 1, 0, 141, -4, 6, -4, 6,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -20, 11, -20, 11,
+ax_anim 3, 0, 143, -20, 19, -20, 19,
+ax_anim 2, 3, 142, -10, 19, -10, 19,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -25, 0, 0,
+ax_anim 3, 0, 156, 0, -23, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -11, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -27, 0, 0,
+ax_anim 3, 0, 159, 0, -25, 0, 0,
+ax_anim 2, 0, 159, 0, -20, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -25, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -15, 0, 0,
+ax_anim 3, 0, 164, 0, -19, 0, 0,
+ax_anim 4, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -24, 0, 0,
+ax_anim 3, 0, 165, 0, -23, 0, 0,
+ax_anim 2, 0, 165, 0, -19, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -15, 0, 0,
+ax_anim 3, 0, 170, 0, -19, 0, 0,
+ax_anim 4, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -24, 0, 0,
+ax_anim 3, 0, 171, 0, -23, 0, 0,
+ax_anim 2, 0, 171, 0, -19, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -25, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -27, 0, 0,
+ax_anim 3, 0, 177, 0, -25, 0, 0,
+ax_anim 2, 0, 177, 0, -20, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHariyamaAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHariyamaGfx1:
+.incbin "baserom.gba", 0x1211D78, 0x200
+sHariyamaSprites1:
+ax_sprite sHariyamaGfx1, 0x200
+ax_sprite_terminator
+sHariyamaGfx2:
+.incbin "baserom.gba", 0x1211F88, 0x200
+sHariyamaSprites2:
+ax_sprite sHariyamaGfx2, 0x200
+ax_sprite_terminator
+sHariyamaGfx3:
+.incbin "baserom.gba", 0x1212198, 0x200
+sHariyamaSprites3:
+ax_sprite sHariyamaGfx3, 0x200
+ax_sprite_terminator
+sHariyamaGfx4:
+.incbin "baserom.gba", 0x12123A8, 0x200
+sHariyamaSprites4:
+ax_sprite sHariyamaGfx4, 0x200
+ax_sprite_terminator
+sHariyamaGfx5:
+.incbin "baserom.gba", 0x12125B8, 0x200
+sHariyamaSprites5:
+ax_sprite sHariyamaGfx5, 0x200
+ax_sprite_terminator
+sHariyamaGfx6:
+.incbin "baserom.gba", 0x12127C8, 0x200
+sHariyamaSprites6:
+ax_sprite sHariyamaGfx6, 0x200
+ax_sprite_terminator
+sHariyamaGfx7:
+.incbin "baserom.gba", 0x12129D8, 0x200
+sHariyamaSprites7:
+ax_sprite sHariyamaGfx7, 0x200
+ax_sprite_terminator
+sHariyamaGfx8:
+.incbin "baserom.gba", 0x1212BE8, 0x200
+sHariyamaSprites8:
+ax_sprite sHariyamaGfx8, 0x200
+ax_sprite_terminator
+sHariyamaGfx9:
+.incbin "baserom.gba", 0x1212DF8, 0x200
+sHariyamaSprites9:
+ax_sprite sHariyamaGfx9, 0x200
+ax_sprite_terminator
+sHariyamaGfx10:
+.incbin "baserom.gba", 0x1213008, 0x200
+sHariyamaSprites10:
+ax_sprite sHariyamaGfx10, 0x200
+ax_sprite_terminator
+sHariyamaGfx11:
+.incbin "baserom.gba", 0x1213218, 0x200
+sHariyamaSprites11:
+ax_sprite sHariyamaGfx11, 0x200
+ax_sprite_terminator
+sHariyamaGfx12:
+.incbin "baserom.gba", 0x1213428, 0x200
+sHariyamaSprites12:
+ax_sprite sHariyamaGfx12, 0x200
+ax_sprite_terminator
+sHariyamaGfx13:
+.incbin "baserom.gba", 0x1213638, 0x200
+sHariyamaSprites13:
+ax_sprite sHariyamaGfx13, 0x200
+ax_sprite_terminator
+sHariyamaGfx14:
+.incbin "baserom.gba", 0x1213848, 0x200
+sHariyamaSprites14:
+ax_sprite sHariyamaGfx14, 0x200
+ax_sprite_terminator
+sHariyamaGfx15:
+.incbin "baserom.gba", 0x1213A58, 0x200
+sHariyamaSprites15:
+ax_sprite sHariyamaGfx15, 0x200
+ax_sprite_terminator
+sHariyamaGfx16:
+.incbin "baserom.gba", 0x1213C68, 0x200
+sHariyamaSprites16:
+ax_sprite sHariyamaGfx16, 0x200
+ax_sprite_terminator
+sHariyamaGfx17:
+.incbin "baserom.gba", 0x1213E78, 0x200
+sHariyamaSprites17:
+ax_sprite sHariyamaGfx17, 0x200
+ax_sprite_terminator
+sHariyamaGfx18:
+.incbin "baserom.gba", 0x1214088, 0x200
+sHariyamaSprites18:
+ax_sprite sHariyamaGfx18, 0x200
+ax_sprite_terminator
+sHariyamaGfx19:
+.incbin "baserom.gba", 0x1214298, 0x200
+sHariyamaSprites19:
+ax_sprite sHariyamaGfx19, 0x200
+ax_sprite_terminator
+sHariyamaGfx20:
+.incbin "baserom.gba", 0x12144A8, 0x200
+sHariyamaSprites20:
+ax_sprite sHariyamaGfx20, 0x200
+ax_sprite_terminator
+sHariyamaGfx21:
+.incbin "baserom.gba", 0x12146B8, 0x200
+sHariyamaSprites21:
+ax_sprite sHariyamaGfx21, 0x200
+ax_sprite_terminator
+sHariyamaGfx22:
+.incbin "baserom.gba", 0x12148C8, 0x200
+sHariyamaSprites22:
+ax_sprite sHariyamaGfx22, 0x200
+ax_sprite_terminator
+sHariyamaGfx23:
+.incbin "baserom.gba", 0x1214AD8, 0x200
+sHariyamaSprites23:
+ax_sprite sHariyamaGfx23, 0x200
+ax_sprite_terminator
+sHariyamaGfx24:
+.incbin "baserom.gba", 0x1214CE8, 0x200
+sHariyamaSprites24:
+ax_sprite sHariyamaGfx24, 0x200
+ax_sprite_terminator
+sHariyamaGfx25:
+.incbin "baserom.gba", 0x1214EF8, 0x180
+sHariyamaSprites25:
+ax_sprite 0, 0x80
+ax_sprite sHariyamaGfx25, 0x180
+ax_sprite_terminator
+sHariyamaGfx26:
+.incbin "baserom.gba", 0x1215090, 0x40
+sHariyamaGfx26_1:
+.incbin "baserom.gba", 0x12150D0, 0x180
+sHariyamaSprites26:
+ax_sprite 0, 0x20
+ax_sprite sHariyamaGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHariyamaGfx26_1, 0x180
+ax_sprite_terminator
+sHariyamaGfx27:
+.incbin "baserom.gba", 0x1215278, 0x20
+sHariyamaGfx27_1:
+.incbin "baserom.gba", 0x1215298, 0x180
+sHariyamaSprites27:
+ax_sprite 0, 0x20
+ax_sprite sHariyamaGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHariyamaGfx27_1, 0x180
+ax_sprite_terminator
+sHariyamaGfx28:
+.incbin "baserom.gba", 0x1215440, 0x40
+sHariyamaGfx28_1:
+.incbin "baserom.gba", 0x1215480, 0x180
+sHariyamaSprites28:
+ax_sprite 0, 0x20
+ax_sprite sHariyamaGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHariyamaGfx28_1, 0x180
+ax_sprite_terminator
+sHariyamaGfx29:
+.incbin "baserom.gba", 0x1215628, 0x40
+sHariyamaGfx29_1:
+.incbin "baserom.gba", 0x1215668, 0x180
+sHariyamaSprites29:
+ax_sprite 0, 0x20
+ax_sprite sHariyamaGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHariyamaGfx29_1, 0x180
+ax_sprite_terminator
+sHariyamaGfx30:
+.incbin "baserom.gba", 0x1215810, 0x200
+sHariyamaSprites30:
+ax_sprite sHariyamaGfx30, 0x200
+ax_sprite_terminator
+sHariyamaGfx31:
+.incbin "baserom.gba", 0x1215A20, 0x200
+sHariyamaSprites31:
+ax_sprite sHariyamaGfx31, 0x200
+ax_sprite_terminator
+sHariyamaGfx32:
+.incbin "baserom.gba", 0x1215C30, 0x200
+sHariyamaSprites32:
+ax_sprite sHariyamaGfx32, 0x200
+ax_sprite_terminator
+sHariyamaGfx33:
+.incbin "baserom.gba", 0x1215E40, 0x200
+sHariyamaSprites33:
+ax_sprite sHariyamaGfx33, 0x200
+ax_sprite_terminator
+sHariyamaGfx34:
+.incbin "baserom.gba", 0x1216050, 0x200
+sHariyamaSprites34:
+ax_sprite sHariyamaGfx34, 0x200
+ax_sprite_terminator
+sHariyamaGfx35:
+.incbin "baserom.gba", 0x1216260, 0x200
+sHariyamaSprites35:
+ax_sprite sHariyamaGfx35, 0x200
+ax_sprite_terminator
+sHariyamaGfx36:
+.incbin "baserom.gba", 0x1216470, 0x200
+sHariyamaSprites36:
+ax_sprite sHariyamaGfx36, 0x200
+ax_sprite_terminator
+sAxPosesHariyama:
+.4byte sHariyamaPose1
+.4byte sHariyamaPose2
+.4byte sHariyamaPose3
+.4byte sHariyamaPose4
+.4byte sHariyamaPose5
+.4byte sHariyamaPose6
+.4byte sHariyamaPose7
+.4byte sHariyamaPose8
+.4byte sHariyamaPose9
+.4byte sHariyamaPose10
+.4byte sHariyamaPose11
+.4byte sHariyamaPose12
+.4byte sHariyamaPose13
+.4byte sHariyamaPose14
+.4byte sHariyamaPose15
+.4byte sHariyamaPose16
+.4byte sHariyamaPose17
+.4byte sHariyamaPose18
+.4byte sHariyamaPose19
+.4byte sHariyamaPose20
+.4byte sHariyamaPose21
+.4byte sHariyamaPose22
+.4byte sHariyamaPose23
+.4byte sHariyamaPose24
+.4byte sHariyamaPose25
+.4byte sHariyamaPose26
+.4byte sHariyamaPose27
+.4byte sHariyamaPose28
+.4byte sHariyamaPose29
+.4byte sHariyamaPose30
+.4byte sHariyamaPose31
+.4byte sHariyamaPose32
+.4byte sHariyamaPose33
+.4byte sHariyamaPose34
+.4byte sHariyamaPose35
+.4byte sHariyamaPose36
+.4byte sHariyamaPose37
+.4byte sHariyamaPose38
+.4byte sHariyamaPose39
+.4byte sHariyamaPose40
+.4byte sHariyamaPose41
+.4byte sHariyamaPose42
+.4byte sHariyamaPose43
+.4byte sHariyamaPose44
+.4byte sHariyamaPose45
+.4byte sHariyamaPose46
+.4byte sHariyamaPose47
+.4byte sHariyamaPose48
+.4byte sHariyamaPose49
+.4byte sHariyamaPose50
+.4byte sHariyamaPose51
+.4byte sHariyamaPose52
+.4byte sHariyamaPose53
+.4byte sHariyamaPose54
+.4byte sHariyamaPose55
+.4byte sHariyamaPose56
+.4byte sHariyamaPose57
+.4byte sHariyamaPose58
+.4byte sHariyamaPose59
+.4byte sHariyamaPose60
+.4byte sHariyamaPose61
+.4byte sHariyamaPose62
+.4byte sHariyamaPose63
+.4byte sHariyamaPose64
+.4byte sHariyamaPose65
+.4byte sHariyamaPose66
+.4byte sHariyamaPose67
+.4byte sHariyamaPose68
+.4byte sHariyamaPose69
+.4byte sHariyamaPose70
+.4byte sHariyamaPose71
+.4byte sHariyamaPose72
+.4byte sHariyamaPose73
+.4byte sHariyamaPose74
+.4byte sHariyamaPose75
+.4byte sHariyamaPose76
+.4byte sHariyamaPose77
+.4byte sHariyamaPose78
+.4byte sHariyamaPose79
+.4byte sHariyamaPose80
+.4byte sHariyamaPose81
+.4byte sHariyamaPose82
+.4byte sHariyamaPose83
+.4byte sHariyamaPose84
+.4byte sHariyamaPose85
+.4byte sHariyamaPose86
+.4byte sHariyamaPose87
+.4byte sHariyamaPose88
+.4byte sHariyamaPose89
+.4byte sHariyamaPose90
+.4byte sHariyamaPose91
+.4byte sHariyamaPose92
+.4byte sHariyamaPose93
+.4byte sHariyamaPose94
+.4byte sHariyamaPose95
+.4byte sHariyamaPose96
+.4byte sHariyamaPose97
+.4byte sHariyamaPose98
+.4byte sHariyamaPose99
+.4byte sHariyamaPose100
+.4byte sHariyamaPose101
+.4byte sHariyamaPose102
+.4byte sHariyamaPose103
+.4byte sHariyamaPose104
+.4byte sHariyamaPose105
+.4byte sHariyamaPose106
+.4byte sHariyamaPose107
+.4byte sHariyamaPose108
+.4byte sHariyamaPose109
+.4byte sHariyamaPose110
+.4byte sHariyamaPose111
+.4byte sHariyamaPose112
+.4byte sHariyamaPose113
+.4byte sHariyamaPose114
+.4byte sHariyamaPose115
+.4byte sHariyamaPose116
+.4byte sHariyamaPose117
+.4byte sHariyamaPose118
+.4byte sHariyamaPose119
+.4byte sHariyamaPose120
+.4byte sHariyamaPose121
+.4byte sHariyamaPose122
+.4byte sHariyamaPose123
+.4byte sHariyamaPose124
+.4byte sHariyamaPose125
+.4byte sHariyamaPose126
+.4byte sHariyamaPose127
+.4byte sHariyamaPose128
+.4byte sHariyamaPose129
+.4byte sHariyamaPose130
+.4byte sHariyamaPose131
+.4byte sHariyamaPose132
+.4byte sHariyamaPose133
+.4byte sHariyamaPose134
+.4byte sHariyamaPose135
+.4byte sHariyamaPose136
+.4byte sHariyamaPose137
+.4byte sHariyamaPose138
+.4byte sHariyamaPose139
+.4byte sHariyamaPose140
+.4byte sHariyamaPose141
+.4byte sHariyamaPose142
+.4byte sHariyamaPose143
+.4byte sHariyamaPose144
+.4byte sHariyamaPose145
+.4byte sHariyamaPose146
+.4byte sHariyamaPose147
+.4byte sHariyamaPose148
+.4byte sHariyamaPose149
+.4byte sHariyamaPose150
+.4byte sHariyamaPose151
+.4byte sHariyamaPose152
+.4byte sHariyamaPose153
+.4byte sHariyamaPose154
+.4byte sHariyamaPose155
+.4byte sHariyamaPose156
+.4byte sHariyamaPose157
+.4byte sHariyamaPose158
+.4byte sHariyamaPose159
+.4byte sHariyamaPose160
+.4byte sHariyamaPose161
+.4byte sHariyamaPose162
+.4byte sHariyamaPose163
+.4byte sHariyamaPose164
+.4byte sHariyamaPose165
+.4byte sHariyamaPose166
+.4byte sHariyamaPose167
+.4byte sHariyamaPose168
+.4byte sHariyamaPose169
+.4byte sHariyamaPose170
+.4byte sHariyamaPose171
+.4byte sHariyamaPose172
+.4byte sHariyamaPose173
+.4byte sHariyamaPose174
+.4byte sHariyamaPose175
+.4byte sHariyamaPose176
+.4byte sHariyamaPose177
+.4byte sHariyamaPose178
+.4byte sHariyamaPose179
+.4byte sHariyamaPose180
+.4byte sHariyamaPose181
+.4byte sHariyamaPose182
+.4byte sHariyamaPose183
+.4byte sHariyamaPose184
+.4byte sHariyamaPose185
+.4byte sHariyamaPose186
+.4byte sHariyamaPose187
+.4byte sHariyamaPose188
+.4byte sHariyamaPose189
+.4byte sHariyamaPose190
+.4byte sHariyamaPose191
+.4byte sHariyamaPose192
+.4byte sHariyamaPose193
+.4byte sHariyamaPose194
+sAxPositionsHariyama:
+.2byte   -1,  -13, 	  -9,  -13, 	  12,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	 -14,  -14, 	   7,  -11, 	  -2,  -10
+.2byte    0,  -12, 	  -1,  -10, 	   9,  -16, 	   0,  -10
+.2byte    4,  -13, 	  -1,  -11, 	   6,  -18, 	  -1,  -12
+.2byte    2,  -13, 	 -11,  -12, 	  10,  -13, 	  -2,  -11
+.2byte    5,  -13, 	   6,  -12, 	   1,  -21, 	  -2,  -11
+.2byte    4,  -13, 	  10,  -13, 	  -2,  -19, 	  -2,  -11
+.2byte    3,  -12, 	  -2,   -8, 	   9,  -14, 	  -2,  -10
+.2byte    5,  -12, 	  10,  -14, 	 -10,  -15, 	  -1,  -10
+.2byte    3,  -15, 	   9,  -16, 	  -8,  -18, 	  -3,  -12
+.2byte    4,  -14, 	   7,   -8, 	   5,  -17, 	  -2,  -11
+.2byte    2,  -15, 	   5,  -16, 	 -14,  -16, 	  -3,  -12
+.2byte   -1,  -17, 	   8,  -19, 	 -12,  -16, 	  -1,  -13
+.2byte    0,  -16, 	  10,  -15, 	 -10,  -17, 	   0,  -12
+.2byte   -2,  -16, 	   4,  -19, 	 -13,  -11, 	  -2,  -12
+.2byte   -5,  -15, 	  -5,  -18, 	  -8,   -9, 	   1,  -11
+.2byte   -4,  -15, 	   8,  -16, 	 -10,  -15, 	   1,  -11
+.2byte   -6,  -14, 	 -11,  -14, 	   0,   -8, 	   0,  -10
+.2byte   -6,  -13, 	 -11,  -16, 	   1,   -7, 	   0,  -10
+.2byte   -7,  -12, 	   4,  -16, 	 -10,  -12, 	   0,  -10
+.2byte   -5,  -13, 	 -14,  -12, 	   8,  -10, 	  -1,  -10
+.2byte   -5,  -14, 	 -12,  -14, 	  10,  -10, 	   0,  -12
+.2byte   -6,  -13, 	  -9,  -21, 	  -2,   -8, 	   0,  -10
+.2byte   -3,  -13, 	  -5,  -11, 	  10,  -15, 	   1,  -11
+.2byte   -1,  -13, 	  -9,  -13, 	  12,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	 -14,  -14, 	   7,  -11, 	  -2,  -10
+.2byte    0,  -12, 	  -1,  -10, 	   9,  -16, 	   0,  -10
+.2byte   -1,   -8, 	  -8,   -1, 	   6,   -1, 	  -1,  -10
+.2byte    4,  -13, 	  -1,  -11, 	   6,  -18, 	  -1,  -12
+.2byte    2,  -13, 	 -11,  -12, 	  10,  -13, 	  -2,  -11
+.2byte    5,  -13, 	   6,  -12, 	   1,  -21, 	  -2,  -11
+.2byte    4,   -8, 	   9,   -4, 	  -4,    2, 	  -1,   -8
+.2byte    4,  -13, 	  10,  -13, 	  -2,  -19, 	  -2,  -11
+.2byte    3,  -12, 	  -2,   -8, 	   9,  -14, 	  -2,  -10
+.2byte    5,  -12, 	  10,  -14, 	 -10,  -15, 	  -1,  -10
+.2byte    9,   -8, 	   7,   -5, 	   3,    0, 	   0,   -9
+.2byte    3,  -15, 	   9,  -16, 	  -8,  -18, 	  -3,  -12
+.2byte    4,  -14, 	   7,   -8, 	   5,  -17, 	  -2,  -11
+.2byte    2,  -15, 	   5,  -16, 	 -14,  -16, 	  -3,  -12
+.2byte    7,  -10, 	  -5,   -6, 	   8,   -3, 	   0,  -10
+.2byte   -1,  -17, 	   8,  -19, 	 -12,  -16, 	  -1,  -13
+.2byte    0,  -16, 	  10,  -15, 	 -10,  -17, 	   0,  -12
+.2byte   -2,  -16, 	   4,  -19, 	 -13,  -11, 	  -2,  -12
+.2byte   -1,  -13, 	   7,   -6, 	  -9,   -6, 	  -1,  -11
+.2byte   -5,  -15, 	  -5,  -18, 	  -8,   -9, 	   1,  -11
+.2byte   -4,  -15, 	   8,  -16, 	 -10,  -15, 	   1,  -11
+.2byte   -6,  -14, 	 -11,  -14, 	   0,   -8, 	   0,  -10
+.2byte   -9,  -10, 	   3,   -6, 	 -10,   -3, 	  -2,  -10
+.2byte   -6,  -13, 	 -11,  -16, 	   1,   -7, 	   0,  -10
+.2byte   -7,  -12, 	   4,  -16, 	 -10,  -12, 	   0,  -10
+.2byte   -5,  -13, 	 -14,  -12, 	   8,  -10, 	  -1,  -10
+.2byte  -11,   -8, 	  -9,   -5, 	  -5,    0, 	  -2,   -9
+.2byte   -5,  -14, 	 -12,  -14, 	  10,  -10, 	   0,  -12
+.2byte   -6,  -13, 	  -9,  -21, 	  -2,   -8, 	   0,  -10
+.2byte   -3,  -13, 	  -5,  -11, 	  10,  -15, 	   1,  -11
+.2byte   -6,   -8, 	 -11,   -4, 	   2,    2, 	  -1,   -8
+.2byte   -1,  -13, 	  -9,  -13, 	  12,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	 -14,  -14, 	   7,  -11, 	  -2,  -10
+.2byte    0,  -12, 	  -1,  -10, 	   9,  -16, 	   0,  -10
+.2byte   -1,   -8, 	  -8,   -1, 	   6,   -1, 	  -1,  -10
+.2byte    4,  -13, 	  -1,  -11, 	   6,  -18, 	  -1,  -12
+.2byte    2,  -13, 	 -11,  -12, 	  10,  -13, 	  -2,  -11
+.2byte    5,  -13, 	   6,  -12, 	   1,  -21, 	  -2,  -11
+.2byte    4,   -8, 	   9,   -4, 	  -4,    2, 	  -1,   -8
+.2byte    4,  -13, 	  10,  -13, 	  -2,  -19, 	  -2,  -11
+.2byte    3,  -12, 	  -2,   -8, 	   9,  -14, 	  -2,  -10
+.2byte    5,  -12, 	  10,  -14, 	 -10,  -15, 	  -1,  -10
+.2byte    9,   -8, 	   7,   -5, 	   3,    0, 	   0,   -9
+.2byte    3,  -15, 	   9,  -16, 	  -8,  -18, 	  -3,  -12
+.2byte    4,  -14, 	   7,   -8, 	   5,  -17, 	  -2,  -11
+.2byte    2,  -15, 	   5,  -16, 	 -14,  -16, 	  -3,  -12
+.2byte    7,  -10, 	  -5,   -6, 	   8,   -3, 	   0,  -10
+.2byte   -1,  -17, 	   8,  -19, 	 -12,  -16, 	  -1,  -13
+.2byte    0,  -16, 	  10,  -15, 	 -10,  -17, 	   0,  -12
+.2byte   -2,  -16, 	   4,  -19, 	 -13,  -11, 	  -2,  -12
+.2byte   -1,  -13, 	   7,   -6, 	  -9,   -6, 	  -1,  -11
+.2byte   -5,  -15, 	  -5,  -18, 	  -8,   -9, 	   1,  -11
+.2byte   -4,  -15, 	   8,  -16, 	 -10,  -15, 	   1,  -11
+.2byte   -6,  -14, 	 -11,  -14, 	   0,   -8, 	   0,  -10
+.2byte   -9,  -10, 	   3,   -6, 	 -10,   -3, 	  -2,  -10
+.2byte   -6,  -13, 	 -11,  -16, 	   1,   -7, 	   0,  -10
+.2byte   -7,  -12, 	   4,  -16, 	 -10,  -12, 	   0,  -10
+.2byte   -5,  -13, 	 -14,  -12, 	   8,  -10, 	  -1,  -10
+.2byte  -11,   -8, 	  -9,   -5, 	  -5,    0, 	  -2,   -9
+.2byte   -5,  -14, 	 -12,  -14, 	  10,  -10, 	   0,  -12
+.2byte   -6,  -13, 	  -9,  -21, 	  -2,   -8, 	   0,  -10
+.2byte   -3,  -13, 	  -5,  -11, 	  10,  -15, 	   1,  -11
+.2byte   -6,   -8, 	 -11,   -4, 	   2,    2, 	  -1,   -8
+.2byte   -1,   -8, 	  -8,   -1, 	   6,   -1, 	  -1,  -10
+.2byte    4,   -8, 	   9,   -4, 	  -4,    2, 	  -1,   -8
+.2byte    9,   -8, 	   7,   -5, 	   3,    0, 	   0,   -9
+.2byte    7,  -10, 	  -5,   -6, 	   8,   -3, 	   0,  -10
+.2byte   -1,  -13, 	   7,   -6, 	  -9,   -6, 	  -1,  -11
+.2byte   -9,  -10, 	   3,   -6, 	 -10,   -3, 	  -2,  -10
+.2byte  -11,   -8, 	  -9,   -5, 	  -5,    0, 	  -2,   -9
+.2byte   -6,   -8, 	 -11,   -4, 	   2,    2, 	  -1,   -8
+.2byte   -1,  -13, 	  -9,  -13, 	  12,  -14, 	  -1,  -11
+.2byte   -5,  -14, 	 -12,  -14, 	  10,  -10, 	   0,  -12
+.2byte   -6,  -13, 	 -11,  -16, 	   1,   -7, 	   0,  -10
+.2byte   -5,  -15, 	  -5,  -18, 	  -8,   -9, 	   1,  -11
+.2byte   -1,  -17, 	   8,  -19, 	 -12,  -16, 	  -1,  -13
+.2byte    3,  -15, 	   9,  -16, 	  -8,  -18, 	  -3,  -12
+.2byte    4,  -13, 	  10,  -13, 	  -2,  -19, 	  -2,  -11
+.2byte    4,  -13, 	  -1,  -11, 	   6,  -18, 	  -1,  -12
+.2byte   -4,  -10, 	   1,   -5, 	  -6,   -7, 	   0,   -8
+.2byte   -3,  -11, 	   1,   -5, 	  -5,   -9, 	   1,   -9
+.2byte    0,  -12, 	 -11,  -20, 	  11,  -20, 	   0,  -10
+.2byte    0,  -15, 	   4,  -20, 	 -14,  -17, 	  -3,  -11
+.2byte    2,  -14, 	   0,  -22, 	 -11,  -14, 	  -1,  -10
+.2byte    2,  -14, 	 -10,  -17, 	   4,  -12, 	  -1,   -9
+.2byte    0,  -13, 	  10,  -16, 	 -11,  -16, 	   0,   -9
+.2byte   -3,  -14, 	   9,  -17, 	  -5,  -12, 	   0,   -9
+.2byte   -3,  -14, 	  -1,  -22, 	  10,  -14, 	   0,  -10
+.2byte   -1,  -15, 	  -5,  -20, 	  13,  -17, 	   2,  -11
+.2byte   -1,  -13, 	  -9,  -13, 	  12,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	 -14,  -14, 	   7,  -11, 	  -2,  -10
+.2byte    0,  -12, 	  -1,  -10, 	   9,  -16, 	   0,  -10
+.2byte    4,  -13, 	  -1,  -11, 	   6,  -18, 	  -1,  -12
+.2byte    2,  -13, 	 -11,  -12, 	  10,  -13, 	  -2,  -11
+.2byte    5,  -13, 	   6,  -12, 	   1,  -21, 	  -2,  -11
+.2byte    4,  -13, 	  10,  -13, 	  -2,  -19, 	  -2,  -11
+.2byte    3,  -12, 	  -2,   -8, 	   9,  -14, 	  -2,  -10
+.2byte    5,  -12, 	  10,  -14, 	 -10,  -15, 	  -1,  -10
+.2byte    3,  -15, 	   9,  -16, 	  -8,  -18, 	  -3,  -12
+.2byte    4,  -14, 	   7,   -8, 	   5,  -17, 	  -2,  -11
+.2byte    2,  -15, 	   5,  -16, 	 -14,  -16, 	  -3,  -12
+.2byte   -1,  -17, 	   8,  -19, 	 -12,  -16, 	  -1,  -13
+.2byte    0,  -16, 	  10,  -15, 	 -10,  -17, 	   0,  -12
+.2byte   -2,  -16, 	   4,  -19, 	 -13,  -11, 	  -2,  -12
+.2byte   -5,  -15, 	  -5,  -18, 	  -8,   -9, 	   1,  -11
+.2byte   -4,  -15, 	   8,  -16, 	 -10,  -15, 	   1,  -11
+.2byte   -6,  -14, 	 -11,  -14, 	   0,   -8, 	   0,  -10
+.2byte   -6,  -13, 	 -11,  -16, 	   1,   -7, 	   0,  -10
+.2byte   -7,  -12, 	   4,  -16, 	 -10,  -12, 	   0,  -10
+.2byte   -5,  -13, 	 -14,  -12, 	   8,  -10, 	  -1,  -10
+.2byte   -5,  -14, 	 -12,  -14, 	  10,  -10, 	   0,  -12
+.2byte   -6,  -13, 	  -9,  -21, 	  -2,   -8, 	   0,  -10
+.2byte   -3,  -13, 	  -5,  -11, 	  10,  -15, 	   1,  -11
+.2byte   -1,   -8, 	  -8,   -1, 	   6,   -1, 	  -1,  -10
+.2byte   -6,   -8, 	 -11,   -4, 	   2,    2, 	  -1,   -8
+.2byte  -10,   -8, 	  -8,   -5, 	  -4,    0, 	  -1,   -9
+.2byte   -9,  -10, 	   3,   -6, 	 -10,   -3, 	  -2,  -10
+.2byte   -1,  -13, 	   7,   -6, 	  -9,   -6, 	  -1,  -11
+.2byte    7,  -10, 	  -5,   -6, 	   8,   -3, 	   0,  -10
+.2byte    8,   -8, 	   6,   -5, 	   2,    0, 	  -1,   -9
+.2byte    4,   -8, 	   9,   -4, 	  -4,    2, 	  -1,   -8
+.2byte   -1,  -13, 	  -2,  -11, 	   8,  -17, 	  -1,  -11
+.2byte    4,  -13, 	   5,  -12, 	   0,  -21, 	  -3,  -11
+.2byte    4,  -13, 	   9,  -15, 	 -11,  -16, 	  -2,  -11
+.2byte    4,  -15, 	   7,  -16, 	 -12,  -16, 	  -1,  -12
+.2byte   -1,  -17, 	   5,  -20, 	 -12,  -12, 	  -1,  -13
+.2byte   -6,  -15, 	 -11,  -15, 	   0,   -9, 	   0,  -11
+.2byte   -6,  -14, 	 -15,  -13, 	   7,  -11, 	  -2,  -11
+.2byte   -4,  -14, 	  -6,  -12, 	   9,  -16, 	   0,  -12
+.2byte   -1,  -13, 	  -9,  -13, 	  12,  -14, 	  -1,  -11
+.2byte   -1,  -14, 	  -2,  -12, 	   8,  -18, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,   -2, 	   6,   -2, 	  -1,  -11
+.2byte    4,  -13, 	  -1,  -11, 	   6,  -18, 	  -1,  -12
+.2byte    3,  -13, 	   4,  -12, 	  -1,  -21, 	  -4,  -11
+.2byte    2,   -8, 	   7,   -4, 	  -6,    2, 	  -3,   -8
+.2byte    4,  -13, 	  10,  -13, 	  -2,  -19, 	  -2,  -11
+.2byte    3,  -13, 	   8,  -15, 	 -12,  -16, 	  -3,  -11
+.2byte    7,   -8, 	   5,   -5, 	   1,    0, 	  -2,   -9
+.2byte    3,  -15, 	   9,  -16, 	  -8,  -18, 	  -3,  -12
+.2byte    2,  -15, 	   5,  -16, 	 -14,  -16, 	  -3,  -12
+.2byte    6,   -9, 	  -6,   -5, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -17, 	   8,  -19, 	 -12,  -16, 	  -1,  -13
+.2byte   -1,  -16, 	   5,  -19, 	 -12,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	   7,   -6, 	  -9,   -6, 	  -1,  -11
+.2byte   -5,  -15, 	  -5,  -18, 	  -8,   -9, 	   1,  -11
+.2byte   -4,  -15, 	  -9,  -15, 	   2,   -9, 	   2,  -11
+.2byte   -8,   -9, 	   4,   -5, 	  -9,   -2, 	  -1,   -9
+.2byte   -6,  -13, 	 -11,  -16, 	   1,   -7, 	   0,  -10
+.2byte   -5,  -14, 	 -14,  -13, 	   8,  -11, 	  -1,  -11
+.2byte  -10,   -8, 	  -8,   -5, 	  -4,    0, 	  -1,   -9
+.2byte   -5,  -14, 	 -12,  -14, 	  10,  -10, 	   0,  -12
+.2byte   -3,  -14, 	  -5,  -12, 	  10,  -16, 	   1,  -12
+.2byte   -5,   -8, 	 -10,   -4, 	   3,    2, 	   0,   -8
+.2byte   -1,   -8, 	  -8,   -1, 	   6,   -1, 	  -1,  -10
+.2byte   -6,   -8, 	 -11,   -4, 	   2,    2, 	  -1,   -8
+.2byte  -10,   -8, 	  -8,   -5, 	  -4,    0, 	  -1,   -9
+.2byte   -9,  -10, 	   3,   -6, 	 -10,   -3, 	  -2,  -10
+.2byte   -1,  -13, 	   7,   -6, 	  -9,   -6, 	  -1,  -11
+.2byte    7,  -10, 	  -5,   -6, 	   8,   -3, 	   0,  -10
+.2byte    8,   -8, 	   6,   -5, 	   2,    0, 	  -1,   -9
+.2byte    4,   -8, 	   9,   -4, 	  -4,    2, 	  -1,   -8
+.2byte   -1,  -13, 	  -9,  -13, 	  12,  -14, 	  -1,  -11
+.2byte   -5,  -14, 	 -12,  -14, 	  10,  -10, 	   0,  -12
+.2byte   -6,  -13, 	 -11,  -16, 	   1,   -7, 	   0,  -10
+.2byte   -5,  -15, 	  -5,  -18, 	  -8,   -9, 	   1,  -11
+.2byte   -1,  -17, 	   8,  -19, 	 -12,  -16, 	  -1,  -13
+.2byte    3,  -15, 	   9,  -16, 	  -8,  -18, 	  -3,  -12
+.2byte    4,  -13, 	  10,  -13, 	  -2,  -19, 	  -2,  -11
+.2byte    4,  -13, 	  -1,  -11, 	   6,  -18, 	  -1,  -12
+sHariyamaAnimTable1:
+.4byte sHariyamaAnims_1_1
+.4byte sHariyamaAnims_1_2
+.4byte sHariyamaAnims_1_3
+.4byte sHariyamaAnims_1_4
+.4byte sHariyamaAnims_1_5
+.4byte sHariyamaAnims_1_6
+.4byte sHariyamaAnims_1_7
+.4byte sHariyamaAnims_1_8
+sHariyamaAnimTable2:
+.4byte sHariyamaAnims_2_1
+.4byte sHariyamaAnims_2_2
+.4byte sHariyamaAnims_2_3
+.4byte sHariyamaAnims_2_4
+.4byte sHariyamaAnims_2_5
+.4byte sHariyamaAnims_2_6
+.4byte sHariyamaAnims_2_7
+.4byte sHariyamaAnims_2_8
+sHariyamaAnimTable3:
+.4byte sHariyamaAnims_3_1
+.4byte sHariyamaAnims_3_2
+.4byte sHariyamaAnims_3_3
+.4byte sHariyamaAnims_3_4
+.4byte sHariyamaAnims_3_5
+.4byte sHariyamaAnims_3_6
+.4byte sHariyamaAnims_3_7
+.4byte sHariyamaAnims_3_8
+sHariyamaAnimTable4:
+.4byte sHariyamaAnims_4_1
+.4byte sHariyamaAnims_4_2
+.4byte sHariyamaAnims_4_3
+.4byte sHariyamaAnims_4_4
+.4byte sHariyamaAnims_4_5
+.4byte sHariyamaAnims_4_6
+.4byte sHariyamaAnims_4_7
+.4byte sHariyamaAnims_4_8
+sHariyamaAnimTable5:
+.4byte sHariyamaAnims_5_1
+.4byte sHariyamaAnims_5_2
+.4byte sHariyamaAnims_5_3
+.4byte sHariyamaAnims_5_4
+.4byte sHariyamaAnims_5_5
+.4byte sHariyamaAnims_5_6
+.4byte sHariyamaAnims_5_7
+.4byte sHariyamaAnims_5_8
+sHariyamaAnimTable6:
+.4byte sHariyamaAnims_6_1
+.4byte sHariyamaAnims_6_1
+.4byte sHariyamaAnims_6_1
+.4byte sHariyamaAnims_6_1
+.4byte sHariyamaAnims_6_1
+.4byte sHariyamaAnims_6_1
+.4byte sHariyamaAnims_6_1
+.4byte sHariyamaAnims_6_1
+sHariyamaAnimTable7:
+.4byte sHariyamaAnims_7_1
+.4byte sHariyamaAnims_7_2
+.4byte sHariyamaAnims_7_3
+.4byte sHariyamaAnims_7_4
+.4byte sHariyamaAnims_7_5
+.4byte sHariyamaAnims_7_6
+.4byte sHariyamaAnims_7_7
+.4byte sHariyamaAnims_7_8
+sHariyamaAnimTable8:
+.4byte sHariyamaAnims_8_1
+.4byte sHariyamaAnims_8_2
+.4byte sHariyamaAnims_8_3
+.4byte sHariyamaAnims_8_4
+.4byte sHariyamaAnims_8_5
+.4byte sHariyamaAnims_8_6
+.4byte sHariyamaAnims_8_7
+.4byte sHariyamaAnims_8_8
+sHariyamaAnimTable9:
+.4byte sHariyamaAnims_9_1
+.4byte sHariyamaAnims_9_2
+.4byte sHariyamaAnims_9_3
+.4byte sHariyamaAnims_9_4
+.4byte sHariyamaAnims_9_5
+.4byte sHariyamaAnims_9_6
+.4byte sHariyamaAnims_9_7
+.4byte sHariyamaAnims_9_8
+sHariyamaAnimTable10:
+.4byte sHariyamaAnims_10_1
+.4byte sHariyamaAnims_10_2
+.4byte sHariyamaAnims_10_3
+.4byte sHariyamaAnims_10_4
+.4byte sHariyamaAnims_10_5
+.4byte sHariyamaAnims_10_6
+.4byte sHariyamaAnims_10_7
+.4byte sHariyamaAnims_10_8
+sHariyamaAnimTable11:
+.4byte sHariyamaAnims_11_1
+.4byte sHariyamaAnims_11_2
+.4byte sHariyamaAnims_11_3
+.4byte sHariyamaAnims_11_4
+.4byte sHariyamaAnims_11_5
+.4byte sHariyamaAnims_11_6
+.4byte sHariyamaAnims_11_7
+.4byte sHariyamaAnims_11_8
+sHariyamaAnimTable12:
+.4byte sHariyamaAnims_12_1
+.4byte sHariyamaAnims_12_2
+.4byte sHariyamaAnims_12_3
+.4byte sHariyamaAnims_12_4
+.4byte sHariyamaAnims_12_5
+.4byte sHariyamaAnims_12_6
+.4byte sHariyamaAnims_12_7
+.4byte sHariyamaAnims_12_8
+sHariyamaAnimTable13:
+.4byte sHariyamaAnims_13_1
+.4byte sHariyamaAnims_13_2
+.4byte sHariyamaAnims_13_3
+.4byte sHariyamaAnims_13_4
+.4byte sHariyamaAnims_13_5
+.4byte sHariyamaAnims_13_6
+.4byte sHariyamaAnims_13_7
+.4byte sHariyamaAnims_13_8
+sAxAnimationsHariyama:
+.4byte sHariyamaAnimTable1
+.4byte sHariyamaAnimTable2
+.4byte sHariyamaAnimTable3
+.4byte sHariyamaAnimTable4
+.4byte sHariyamaAnimTable5
+.4byte sHariyamaAnimTable6
+.4byte sHariyamaAnimTable7
+.4byte sHariyamaAnimTable8
+.4byte sHariyamaAnimTable9
+.4byte sHariyamaAnimTable10
+.4byte sHariyamaAnimTable11
+.4byte sHariyamaAnimTable12
+.4byte sHariyamaAnimTable13
+sAxSpritesHariyama:
+.4byte sHariyamaSprites1
+.4byte sHariyamaSprites2
+.4byte sHariyamaSprites3
+.4byte sHariyamaSprites4
+.4byte sHariyamaSprites5
+.4byte sHariyamaSprites6
+.4byte sHariyamaSprites7
+.4byte sHariyamaSprites8
+.4byte sHariyamaSprites9
+.4byte sHariyamaSprites10
+.4byte sHariyamaSprites11
+.4byte sHariyamaSprites12
+.4byte sHariyamaSprites13
+.4byte sHariyamaSprites14
+.4byte sHariyamaSprites15
+.4byte sHariyamaSprites16
+.4byte sHariyamaSprites17
+.4byte sHariyamaSprites18
+.4byte sHariyamaSprites19
+.4byte sHariyamaSprites20
+.4byte sHariyamaSprites21
+.4byte sHariyamaSprites22
+.4byte sHariyamaSprites23
+.4byte sHariyamaSprites24
+.4byte sHariyamaSprites25
+.4byte sHariyamaSprites26
+.4byte sHariyamaSprites27
+.4byte sHariyamaSprites28
+.4byte sHariyamaSprites29
+.4byte sHariyamaSprites30
+.4byte sHariyamaSprites31
+.4byte sHariyamaSprites32
+.4byte sHariyamaSprites33
+.4byte sHariyamaSprites34
+.4byte sHariyamaSprites35
+.4byte sHariyamaSprites36
+sAxMainHariyama:
+ax_main sAxPosesHariyama, sAxAnimationsHariyama, 13, sAxSpritesHariyama, sAxPositionsHariyama

--- a/data/ax/haunter.inc
+++ b/data/ax/haunter.inc
@@ -1,0 +1,3041 @@
+.global gAxHaunter
+gAxHaunter:
+ax_siro sAxMainHaunter
+sHaunterPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose4:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose5:
+ax_pose 4, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose6:
+ax_pose 5, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose7:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose8:
+ax_pose 7, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose9:
+ax_pose 8, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose10:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose11:
+ax_pose 10, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose12:
+ax_pose 11, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose13:
+ax_pose 12, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose14:
+ax_pose 13, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose15:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose22:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose23:
+ax_pose 4, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose24:
+ax_pose 5, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose28:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose29:
+ax_pose 4, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose30:
+ax_pose 5, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose31:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose32:
+ax_pose 7, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose33:
+ax_pose 8, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose34:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose35:
+ax_pose 10, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose36:
+ax_pose 11, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose37:
+ax_pose 12, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose38:
+ax_pose 13, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose39:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose40:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose41:
+ax_pose 10, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose42:
+ax_pose 11, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose43:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose44:
+ax_pose 7, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose45:
+ax_pose 8, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose46:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose47:
+ax_pose 4, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose48:
+ax_pose 5, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose49:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose50:
+ax_pose 15, 0x01f4, 0x40ed, 0x2c00
+ax_pose 16, 0x01f4, 0x4103, 0x2c04
+ax_pose 17, 0x01e4, 0x80f0, 0x2c08
+ax_pose_terminator
+sHaunterPose51:
+ax_pose 15, 0x01f1, 0x40eb, 0x2c00
+ax_pose 16, 0x01f1, 0x4105, 0x2c04
+ax_pose 17, 0x01e4, 0x80f0, 0x2c08
+ax_pose_terminator
+sHaunterPose52:
+ax_pose 18, 0x81ed, 0x9104, 0x2c00
+ax_pose 15, 0x01eb, 0x40e9, 0x2c08
+ax_pose 16, 0x0205, 0x40fd, 0x2c0c
+ax_pose 17, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sHaunterPose53:
+ax_pose 15, 0x01e3, 0x40e8, 0x2c00
+ax_pose 16, 0x0205, 0x40f8, 0x2c04
+ax_pose 17, 0x01e4, 0x80f0, 0x2c08
+ax_pose_terminator
+sHaunterPose54:
+ax_pose 18, 0x81ed, 0x80ec, 0x2c00
+ax_pose 15, 0x0204, 0x40f3, 0x2c08
+ax_pose 16, 0x01eb, 0x4107, 0x2c0c
+ax_pose 17, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sHaunterPose55:
+ax_pose 15, 0x0205, 0x40f8, 0x2c00
+ax_pose 16, 0x01e3, 0x4108, 0x2c04
+ax_pose 17, 0x01e4, 0x80f0, 0x2c08
+ax_pose_terminator
+sHaunterPose56:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose57:
+ax_pose 19, 0x01f6, 0x50f2, 0x2c00
+ax_pose 20, 0x01e4, 0x90eb, 0x2c04
+ax_pose 21, 0x01ed, 0x5102, 0x2c14
+ax_pose_terminator
+sHaunterPose58:
+ax_pose 19, 0x01f7, 0x50ed, 0x2c00
+ax_pose 20, 0x01e4, 0x90eb, 0x2c04
+ax_pose 21, 0x01ec, 0x5103, 0x2c14
+ax_pose_terminator
+sHaunterPose59:
+ax_pose 22, 0x01ee, 0x90ea, 0x2c00
+ax_pose 19, 0x0201, 0x50fe, 0x2c10
+ax_pose 20, 0x01e4, 0x90eb, 0x2c14
+ax_pose 21, 0x01e7, 0x5100, 0x2c24
+ax_pose_terminator
+sHaunterPose60:
+ax_pose 19, 0x0200, 0x5106, 0x2c00
+ax_pose 20, 0x01e4, 0x90eb, 0x2c04
+ax_pose 21, 0x01e2, 0x50fd, 0x2c14
+ax_pose_terminator
+sHaunterPose61:
+ax_pose 19, 0x01f5, 0x50e8, 0x2c00
+ax_pose 20, 0x01e4, 0x90eb, 0x2c04
+ax_pose 23, 0x01e5, 0x90f9, 0x2c14
+ax_pose 21, 0x01fd, 0x510c, 0x2c24
+ax_pose_terminator
+sHaunterPose62:
+ax_pose 19, 0x01ef, 0x50e3, 0x2c00
+ax_pose 20, 0x01e4, 0x90eb, 0x2c04
+ax_pose 21, 0x0201, 0x510c, 0x2c14
+ax_pose_terminator
+sHaunterPose63:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose64:
+ax_pose 24, 0x01f7, 0x50fe, 0x2c00
+ax_pose 25, 0x01e4, 0x90ea, 0x2c04
+ax_pose 26, 0x01e7, 0x5100, 0x2c14
+ax_pose_terminator
+sHaunterPose65:
+ax_pose 24, 0x01f7, 0x50f3, 0x2c00
+ax_pose 25, 0x01e4, 0x90e9, 0x2c04
+ax_pose 26, 0x01e0, 0x50fb, 0x2c14
+ax_pose_terminator
+sHaunterPose66:
+ax_pose 27, 0x41f9, 0xb0f2, 0x2c00
+ax_pose 24, 0x01f2, 0x510d, 0x2c08
+ax_pose 25, 0x01e4, 0x90e9, 0x2c0c
+ax_pose 26, 0x01de, 0x50f4, 0x2c1c
+ax_pose_terminator
+sHaunterPose67:
+ax_pose 24, 0x01ef, 0x510f, 0x2c00
+ax_pose 25, 0x01e4, 0x90e9, 0x2c04
+ax_pose 26, 0x01df, 0x50f0, 0x2c14
+ax_pose_terminator
+sHaunterPose68:
+ax_pose 24, 0x01f9, 0x50f6, 0x2c00
+ax_pose 25, 0x01e4, 0x90e9, 0x2c04
+ax_pose 27, 0x41e8, 0x90f5, 0x2c14
+ax_pose 26, 0x01eb, 0x510c, 0x2c1c
+ax_pose_terminator
+sHaunterPose69:
+ax_pose 24, 0x01f2, 0x50ef, 0x2c00
+ax_pose 25, 0x01e4, 0x90e9, 0x2c04
+ax_pose 26, 0x01ee, 0x510d, 0x2c14
+ax_pose_terminator
+sHaunterPose70:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose71:
+ax_pose 28, 0x01e6, 0x90ed, 0x2c00
+ax_pose 29, 0x41eb, 0x10ef, 0x2c10
+ax_pose 30, 0x41f5, 0x1102, 0x2c12
+ax_pose_terminator
+sHaunterPose72:
+ax_pose 28, 0x01e6, 0x90ed, 0x2c00
+ax_pose 29, 0x41ee, 0x10ec, 0x2c10
+ax_pose 30, 0x41f8, 0x1101, 0x2c12
+ax_pose_terminator
+sHaunterPose73:
+ax_pose 28, 0x01e6, 0x90ed, 0x2c00
+ax_pose 29, 0x41f0, 0x10e8, 0x2c10
+ax_pose 31, 0x01e8, 0x90fa, 0x2c12
+ax_pose 30, 0x41e6, 0x110e, 0x2c22
+ax_pose_terminator
+sHaunterPose74:
+ax_pose 28, 0x01e6, 0x90ed, 0x2c00
+ax_pose 29, 0x41f4, 0x10e6, 0x2c10
+ax_pose 30, 0x41e1, 0x110d, 0x2c12
+ax_pose_terminator
+sHaunterPose75:
+ax_pose 28, 0x01e6, 0x90ed, 0x2c00
+ax_pose 32, 0x01db, 0x90ed, 0x2c10
+ax_pose 29, 0x41dd, 0x1101, 0x2c20
+ax_pose 30, 0x41fc, 0x10ff, 0x2c22
+ax_pose_terminator
+sHaunterPose76:
+ax_pose 30, 0x4200, 0x10f9, 0x2c00
+ax_pose 28, 0x01e6, 0x90ed, 0x2c02
+ax_pose 29, 0x41dd, 0x1106, 0x2c12
+ax_pose_terminator
+sHaunterPose77:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose78:
+ax_pose 33, 0x01e4, 0x80f0, 0x2c00
+ax_pose 34, 0x41f2, 0x00eb, 0x2c10
+ax_pose 35, 0x41f2, 0x0105, 0x2c12
+ax_pose_terminator
+sHaunterPose79:
+ax_pose 33, 0x01e4, 0x80f0, 0x2c00
+ax_pose 34, 0x41f4, 0x00e9, 0x2c10
+ax_pose 35, 0x41f4, 0x0107, 0x2c12
+ax_pose_terminator
+sHaunterPose80:
+ax_pose 33, 0x01e4, 0x80f0, 0x2c00
+ax_pose 36, 0x81e1, 0x80ea, 0x2c10
+ax_pose 34, 0x41e0, 0x00ef, 0x2c18
+ax_pose 35, 0x41f7, 0x0106, 0x2c1a
+ax_pose_terminator
+sHaunterPose81:
+ax_pose 33, 0x01e4, 0x80f0, 0x2c00
+ax_pose 34, 0x41dd, 0x00f5, 0x2c10
+ax_pose 35, 0x41fb, 0x0105, 0x2c12
+ax_pose_terminator
+sHaunterPose82:
+ax_pose 33, 0x01e4, 0x80f0, 0x2c00
+ax_pose 36, 0x81e1, 0x9106, 0x2c10
+ax_pose 34, 0x41f7, 0x00ea, 0x2c18
+ax_pose 35, 0x41e0, 0x0101, 0x2c1a
+ax_pose_terminator
+sHaunterPose83:
+ax_pose 33, 0x01e4, 0x80f0, 0x2c00
+ax_pose 34, 0x41fb, 0x00eb, 0x2c10
+ax_pose 35, 0x41dd, 0x00fc, 0x2c12
+ax_pose_terminator
+sHaunterPose84:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose85:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose 29, 0x41eb, 0x0101, 0x2c10
+ax_pose 30, 0x41f5, 0x00ee, 0x2c12
+ax_pose_terminator
+sHaunterPose86:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose 29, 0x41ee, 0x0104, 0x2c10
+ax_pose 30, 0x41f8, 0x00ef, 0x2c12
+ax_pose_terminator
+sHaunterPose87:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose 29, 0x41f0, 0x0108, 0x2c10
+ax_pose 31, 0x01e8, 0x80e6, 0x2c12
+ax_pose 30, 0x41ee, 0x00e7, 0x2c22
+ax_pose_terminator
+sHaunterPose88:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose 29, 0x41f4, 0x010a, 0x2c10
+ax_pose 30, 0x41de, 0x00e4, 0x2c12
+ax_pose_terminator
+sHaunterPose89:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose 32, 0x01db, 0x80f3, 0x2c10
+ax_pose 29, 0x41df, 0x00f8, 0x2c20
+ax_pose 30, 0x41fc, 0x00f1, 0x2c22
+ax_pose_terminator
+sHaunterPose90:
+ax_pose 30, 0x4200, 0x00f7, 0x2c00
+ax_pose 28, 0x01e6, 0x80f3, 0x2c02
+ax_pose 29, 0x41dc, 0x00e8, 0x2c12
+ax_pose_terminator
+sHaunterPose91:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose92:
+ax_pose 24, 0x01f7, 0x40f2, 0x2c00
+ax_pose 25, 0x01e4, 0x80f7, 0x2c04
+ax_pose 26, 0x01e7, 0x40f0, 0x2c14
+ax_pose_terminator
+sHaunterPose93:
+ax_pose 24, 0x01f7, 0x40fd, 0x2c00
+ax_pose 25, 0x01e4, 0x80f7, 0x2c04
+ax_pose 26, 0x01e0, 0x40f5, 0x2c14
+ax_pose_terminator
+sHaunterPose94:
+ax_pose 27, 0x41f9, 0xa0ee, 0x2c00
+ax_pose 24, 0x01f7, 0x40ee, 0x2c08
+ax_pose 25, 0x01e4, 0x80f7, 0x2c0c
+ax_pose 26, 0x01de, 0x40fc, 0x2c1c
+ax_pose_terminator
+sHaunterPose95:
+ax_pose 24, 0x01f1, 0x40e4, 0x2c00
+ax_pose 25, 0x01e4, 0x80f7, 0x2c04
+ax_pose 26, 0x01df, 0x4100, 0x2c14
+ax_pose_terminator
+sHaunterPose96:
+ax_pose 24, 0x01f9, 0x40fa, 0x2c00
+ax_pose 25, 0x01e4, 0x80f7, 0x2c04
+ax_pose 27, 0x41e8, 0x80eb, 0x2c14
+ax_pose 26, 0x01e5, 0x40ed, 0x2c1c
+ax_pose_terminator
+sHaunterPose97:
+ax_pose 24, 0x01f2, 0x4101, 0x2c00
+ax_pose 25, 0x01e4, 0x80f7, 0x2c04
+ax_pose 26, 0x01ec, 0x40e5, 0x2c14
+ax_pose_terminator
+sHaunterPose98:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose99:
+ax_pose 19, 0x01f6, 0x40fe, 0x2c00
+ax_pose 20, 0x01e4, 0x80f5, 0x2c04
+ax_pose 21, 0x01ed, 0x40ee, 0x2c14
+ax_pose_terminator
+sHaunterPose100:
+ax_pose 19, 0x01f7, 0x4103, 0x2c00
+ax_pose 20, 0x01e4, 0x80f5, 0x2c04
+ax_pose 21, 0x01ec, 0x40ed, 0x2c14
+ax_pose_terminator
+sHaunterPose101:
+ax_pose 22, 0x01ee, 0x80f6, 0x2c00
+ax_pose 19, 0x01fe, 0x40fc, 0x2c10
+ax_pose 20, 0x01e4, 0x80f5, 0x2c14
+ax_pose 21, 0x01e7, 0x40f0, 0x2c24
+ax_pose_terminator
+sHaunterPose102:
+ax_pose 19, 0x0200, 0x40e8, 0x2c00
+ax_pose 20, 0x01e4, 0x80f5, 0x2c04
+ax_pose 21, 0x01e2, 0x40f3, 0x2c14
+ax_pose_terminator
+sHaunterPose103:
+ax_pose 19, 0x01f5, 0x4108, 0x2c00
+ax_pose 20, 0x01e4, 0x80f5, 0x2c04
+ax_pose 23, 0x01e5, 0x80e7, 0x2c14
+ax_pose 21, 0x01f2, 0x40e7, 0x2c24
+ax_pose_terminator
+sHaunterPose104:
+ax_pose 19, 0x01ef, 0x410d, 0x2c00
+ax_pose 20, 0x01e4, 0x80f5, 0x2c04
+ax_pose 21, 0x0201, 0x40e4, 0x2c14
+ax_pose_terminator
+sHaunterPose105:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose106:
+ax_pose 37, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose107:
+ax_pose 38, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose108:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose109:
+ax_pose 39, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose110:
+ax_pose 40, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose111:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose112:
+ax_pose 41, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose113:
+ax_pose 42, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose114:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose115:
+ax_pose 43, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sHaunterPose116:
+ax_pose 44, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sHaunterPose117:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose118:
+ax_pose 45, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose119:
+ax_pose 46, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose120:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose121:
+ax_pose 43, 0x01e4, 0x80ed, 0x2c00
+ax_pose_terminator
+sHaunterPose122:
+ax_pose 44, 0x01e4, 0x80ed, 0x2c00
+ax_pose_terminator
+sHaunterPose123:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose124:
+ax_pose 41, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose125:
+ax_pose 42, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose126:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose127:
+ax_pose 39, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose128:
+ax_pose 40, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose129:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose130:
+ax_pose 37, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose131:
+ax_pose 38, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose132:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose133:
+ax_pose 39, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose134:
+ax_pose 40, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose135:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose136:
+ax_pose 41, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose137:
+ax_pose 42, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose138:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose139:
+ax_pose 43, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sHaunterPose140:
+ax_pose 44, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sHaunterPose141:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose142:
+ax_pose 45, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose143:
+ax_pose 46, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose144:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose145:
+ax_pose 43, 0x01e4, 0x80ed, 0x2c00
+ax_pose_terminator
+sHaunterPose146:
+ax_pose 44, 0x01e4, 0x80ed, 0x2c00
+ax_pose_terminator
+sHaunterPose147:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose148:
+ax_pose 41, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose149:
+ax_pose 42, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose150:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose151:
+ax_pose 39, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose152:
+ax_pose 40, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose153:
+ax_pose 47, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose154:
+ax_pose 48, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose155:
+ax_pose 49, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose156:
+ax_pose 50, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHaunterPose157:
+ax_pose 51, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sHaunterPose158:
+ax_pose 52, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sHaunterPose159:
+ax_pose 53, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose160:
+ax_pose 52, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sHaunterPose161:
+ax_pose 51, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sHaunterPose162:
+ax_pose 50, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose163:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose164:
+ax_pose 2, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose165:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose166:
+ax_pose 5, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose167:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose168:
+ax_pose 8, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose169:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose170:
+ax_pose 11, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose171:
+ax_pose 12, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose172:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose173:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose174:
+ax_pose 11, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose175:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose176:
+ax_pose 8, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose177:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose178:
+ax_pose 5, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose179:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose180:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose181:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose182:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose183:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose184:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose185:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose186:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose187:
+ax_pose 37, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose188:
+ax_pose 39, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose189:
+ax_pose 41, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose190:
+ax_pose 43, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sHaunterPose191:
+ax_pose 45, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose192:
+ax_pose 43, 0x01e4, 0x80ed, 0x2c00
+ax_pose_terminator
+sHaunterPose193:
+ax_pose 41, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose194:
+ax_pose 39, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose195:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose196:
+ax_pose 1, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose197:
+ax_pose 2, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose198:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose199:
+ax_pose 4, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose200:
+ax_pose 5, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose201:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose202:
+ax_pose 7, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose203:
+ax_pose 8, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose204:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose205:
+ax_pose 10, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose206:
+ax_pose 11, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose207:
+ax_pose 12, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose208:
+ax_pose 13, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose209:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose210:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose211:
+ax_pose 10, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose212:
+ax_pose 11, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose213:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose214:
+ax_pose 7, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose215:
+ax_pose 8, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose216:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose217:
+ax_pose 4, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose218:
+ax_pose 5, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose219:
+ax_pose 37, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose220:
+ax_pose 39, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose221:
+ax_pose 41, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose222:
+ax_pose 43, 0x01e4, 0x80ed, 0x2c00
+ax_pose_terminator
+sHaunterPose223:
+ax_pose 45, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose224:
+ax_pose 43, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sHaunterPose225:
+ax_pose 41, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose226:
+ax_pose 39, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose227:
+ax_pose 0, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sHaunterPose228:
+ax_pose 3, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose229:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose230:
+ax_pose 9, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose231:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHaunterPose232:
+ax_pose 9, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose233:
+ax_pose 6, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sHaunterPose234:
+ax_pose 3, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+.align 2
+sHaunterAnims_1_1:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 2, 0, 0,
+ax_anim 10, 0, 1, 0, 3, 0, 0,
+ax_anim 6, 0, 0, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 10, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_1_2:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 2, 0, 0,
+ax_anim 10, 0, 4, 0, 3, 0, 0,
+ax_anim 6, 0, 3, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_1_3:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 7, 0, 2, 0, 0,
+ax_anim 10, 0, 7, 0, 3, 0, 0,
+ax_anim 6, 0, 6, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_1_4:
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 10, 0, 2, 0, 0,
+ax_anim 10, 0, 10, 0, 3, 0, 0,
+ax_anim 6, 0, 9, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_1_5:
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 13, 0, 2, 0, 0,
+ax_anim 10, 0, 13, 0, 3, 0, 0,
+ax_anim 6, 0, 12, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_1_6:
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 16, 0, 2, 0, 0,
+ax_anim 10, 0, 16, 0, 3, 0, 0,
+ax_anim 6, 0, 15, 0, 1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_1_7:
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 19, 0, 2, 0, 0,
+ax_anim 10, 0, 19, 0, 3, 0, 0,
+ax_anim 6, 0, 18, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_1_8:
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 22, 0, 2, 0, 0,
+ax_anim 10, 0, 22, 0, 3, 0, 0,
+ax_anim 6, 0, 21, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sHaunterAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -2, 0, -1,
+ax_anim 2, 0, 26, 0, -4, 0, -2,
+ax_anim 6, 0, 26, 0, -5, 0, -3,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 23, 0, 18,
+ax_anim 2, 1, 25, 1, 23, 1, 18,
+ax_anim 2, 0, 25, 0, 23, 0, 18,
+ax_anim 2, 0, 25, 1, 23, 1, 18,
+ax_anim 4, 0, 24, 0, 8, 0, 6,
+ax_anim_terminator
+sHaunterAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -4, -5, -4, -4,
+ax_anim 6, 0, 29, -5, -8, -5, -5,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 5, 4, 4,
+ax_anim 1, 0, 28, 10, 12, 10, 10,
+ax_anim 2, 0, 28, 19, 22, 19, 19,
+ax_anim 2, 1, 28, 20, 21, 20, 17,
+ax_anim 2, 0, 28, 19, 22, 19, 18,
+ax_anim 2, 0, 28, 20, 21, 20, 17,
+ax_anim 4, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sHaunterAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -2, -1, -2, 0,
+ax_anim 2, 0, 32, -4, -2, -4, 0,
+ax_anim 6, 0, 32, -5, -4, -5, 0,
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 2, 10, 0,
+ax_anim 2, 0, 31, 17, 3, 17, 1,
+ax_anim 2, 1, 31, 17, 2, 17, 0,
+ax_anim 2, 0, 31, 17, 3, 17, 1,
+ax_anim 2, 0, 31, 17, 2, 17, 0,
+ax_anim 4, 0, 30, 8, 1, 8, 0,
+ax_anim_terminator
+sHaunterAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -2, 2, -2, 2,
+ax_anim 2, 0, 35, -4, 3, -4, 4,
+ax_anim 6, 0, 35, -5, 3, -5, 5,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 34, 8, -8, 8, -10,
+ax_anim 2, 0, 34, 16, -15, 16, -18,
+ax_anim 2, 1, 34, 15, -16, 15, -19,
+ax_anim 2, 0, 34, 16, -15, 16, -18,
+ax_anim 2, 0, 34, 15, -16, 15, -19,
+ax_anim 4, 0, 33, 8, -8, 8, -8,
+ax_anim_terminator
+sHaunterAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 4, 0, 4,
+ax_anim 6, 0, 38, 0, 5, 0, 5,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -10, 0, -12,
+ax_anim 2, 0, 37, 0, -20, 0, -25,
+ax_anim 2, 1, 37, 1, -20, 1, -25,
+ax_anim 2, 0, 37, 0, -20, 0, -25,
+ax_anim 2, 0, 37, 1, -20, 1, -25,
+ax_anim 4, 0, 36, 0, -8, 0, -8,
+ax_anim_terminator
+sHaunterAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 4, 3, 4, 4,
+ax_anim 6, 0, 41, 5, 3, 5, 5,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 40, -8, -8, -8, -10,
+ax_anim 2, 0, 40, -16, -15, -16, -18,
+ax_anim 2, 1, 40, -15, -16, -15, -19,
+ax_anim 2, 0, 40, -16, -15, -16, -18,
+ax_anim 2, 0, 40, -15, -16, -15, -19,
+ax_anim 4, 0, 39, -8, -8, -8, -8,
+ax_anim_terminator
+sHaunterAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 2, -1, 2, 0,
+ax_anim 2, 0, 44, 4, -2, 4, 0,
+ax_anim 6, 0, 44, 5, -4, 5, 0,
+ax_anim 2, 0, 43, 0, -1, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 2, -10, 0,
+ax_anim 2, 0, 43, -17, 3, -17, 1,
+ax_anim 2, 1, 43, -17, 2, -17, 0,
+ax_anim 2, 0, 43, -17, 3, -17, 1,
+ax_anim 2, 0, 43, -17, 2, -17, 0,
+ax_anim 4, 0, 42, -8, 1, -8, 0,
+ax_anim_terminator
+sHaunterAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 2, -2, 2, -2,
+ax_anim 2, 0, 47, 4, -5, 4, -4,
+ax_anim 6, 0, 47, 5, -8, 5, -5,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 5, -4, 4,
+ax_anim 1, 0, 46, -10, 12, -10, 10,
+ax_anim 2, 0, 46, -19, 22, -19, 19,
+ax_anim 2, 1, 46, -20, 21, -20, 17,
+ax_anim 2, 0, 46, -19, 22, -19, 18,
+ax_anim 2, 0, 46, -20, 21, -20, 17,
+ax_anim 4, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sHaunterAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -3, 0, -3,
+ax_anim 4, 0, 50, 0, -4, 0, -4,
+ax_anim 2, 2, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 1, 0, 1,
+ax_anim 2, 1, 52, 0, 2, 0, 2,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 1, 0, 1,
+ax_anim 2, 0, 54, 0, 2, 0, 2,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 1, 0, 1,
+ax_anim 2, 0, 52, 0, 2, 0, 2,
+ax_anim 2, 0, 49, 0, 1, 0, 1,
+ax_anim_terminator
+sHaunterAnims_3_2:
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 0, 56, -3, -3, -3, -3,
+ax_anim 4, 0, 57, -4, -4, -4, -4,
+ax_anim 2, 2, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 1, 1, 1, 1,
+ax_anim 2, 1, 59, 2, 2, 2, 2,
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 1, 1, 1, 1,
+ax_anim 2, 0, 61, 2, 2, 2, 2,
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 1, 1, 1, 1,
+ax_anim 2, 0, 59, 2, 2, 2, 2,
+ax_anim 2, 0, 56, 1, 1, 1, 1,
+ax_anim_terminator
+sHaunterAnims_3_3:
+ax_anim 2, 0, 62, -1, 0, -1, 0,
+ax_anim 2, 0, 63, -3, 0, -3, 0,
+ax_anim 4, 0, 64, -4, 0, -4, 0,
+ax_anim 2, 2, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim 2, 1, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 2, 0, 68, 2, 0, 2, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim 2, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 63, 1, 0, 1, 0,
+ax_anim_terminator
+sHaunterAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 2, 0, 70, -3, 3, -3, 3,
+ax_anim 4, 0, 71, -4, 4, -4, 4,
+ax_anim 2, 2, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, -1, 1, -1,
+ax_anim 2, 1, 73, 2, -2, 2, -2,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 2, -2, 2, -2,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, -1, 1, -1,
+ax_anim 2, 0, 73, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim_terminator
+sHaunterAnims_3_5:
+ax_anim 2, 0, 76, 0, 1, 0, 1,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 4, 0, 78, 0, 4, 0, 4,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, -1,
+ax_anim 2, 1, 80, 0, -2, 0, -2,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, -2, 0, -2,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, -1,
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim 2, 0, 77, 0, -1, 0, -1,
+ax_anim_terminator
+sHaunterAnims_3_6:
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 84, 3, 3, 3, 3,
+ax_anim 4, 0, 85, 4, 4, 4, 4,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -1, -1, -1, -1,
+ax_anim 2, 1, 87, -2, -2, -2, -2,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -1, -1, -1, -1,
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim_terminator
+sHaunterAnims_3_7:
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 91, 3, 0, 3, 0,
+ax_anim 4, 0, 92, 4, 0, 4, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 0, -1, 0,
+ax_anim 2, 1, 94, -2, 0, -2, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 0, -1, 0,
+ax_anim 2, 0, 94, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -1, 0, -1, 0,
+ax_anim_terminator
+sHaunterAnims_3_8:
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 98, 3, -3, 3, -3,
+ax_anim 4, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 1, 101, -2, 2, -2, 2,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sHaunterAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 6, 0, 104, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 2, 105, 0, 7, 0, 7,
+ax_anim 2, 0, 105, -1, 7, -1, 7,
+ax_anim 2, 0, 105, 0, 7, 0, 7,
+ax_anim 2, 0, 105, -1, 7, -1, 7,
+ax_anim 2, 1, 105, 0, 7, 0, 7,
+ax_anim 2, 0, 105, -1, 7, -1, 7,
+ax_anim 2, 0, 104, 0, 3, -1, 3,
+ax_anim_terminator
+sHaunterAnims_4_2:
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 6, 0, 107, -3, -3, -3, -3,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 107, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 2, 108, 7, 7, 7, 7,
+ax_anim 2, 0, 108, 8, 6, 8, 6,
+ax_anim 2, 0, 108, 7, 7, 7, 7,
+ax_anim 2, 0, 108, 8, 6, 8, 6,
+ax_anim 2, 1, 108, 7, 7, 7, 7,
+ax_anim 2, 0, 108, 8, 6, 8, 6,
+ax_anim 2, 0, 107, 0, 6, 0, 6,
+ax_anim_terminator
+sHaunterAnims_4_3:
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 6, 0, 110, -3, 0, -3, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 2, 111, 7, 0, 7, 0,
+ax_anim 2, 0, 111, 7, -1, 7, -1,
+ax_anim 2, 0, 111, 7, 0, 7, 0,
+ax_anim 2, 0, 111, 7, -1, 7, -1,
+ax_anim 2, 1, 111, 7, 0, 7, 0,
+ax_anim 2, 0, 111, 7, -1, 7, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_4_4:
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 6, 0, 113, -3, 3, -3, 3,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 2, 114, 7, -7, 7, -7,
+ax_anim 2, 0, 114, 8, -6, 8, -6,
+ax_anim 2, 0, 114, 7, -7, 7, -7,
+ax_anim 2, 0, 114, 8, -6, 8, -6,
+ax_anim 2, 1, 114, 7, -7, 7, -7,
+ax_anim 2, 0, 114, 8, -6, 8, -6,
+ax_anim 2, 0, 113, 0, -6, 0, -6,
+ax_anim_terminator
+sHaunterAnims_4_5:
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 6, 0, 116, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 2, 117, 0, -7, 0, -7,
+ax_anim 2, 0, 117, -1, -7, -1, -7,
+ax_anim 2, 0, 117, 0, -7, 0, -7,
+ax_anim 2, 0, 117, -1, -7, -1, -7,
+ax_anim 2, 1, 117, 0, -7, 0, -7,
+ax_anim 2, 0, 117, -1, -7, -1, -7,
+ax_anim 2, 0, 116, 0, -3, -1, -3,
+ax_anim_terminator
+sHaunterAnims_4_6:
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 6, 0, 119, 3, 3, 3, 3,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 2, 120, -7, -7, -7, -7,
+ax_anim 2, 0, 120, -8, -6, -8, -6,
+ax_anim 2, 0, 120, -7, -7, -7, -7,
+ax_anim 2, 0, 120, -8, -6, -8, -6,
+ax_anim 2, 1, 120, -7, -7, -7, -7,
+ax_anim 2, 0, 120, -8, -6, -8, -6,
+ax_anim 2, 0, 119, 0, -6, 0, -6,
+ax_anim_terminator
+sHaunterAnims_4_7:
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 6, 0, 122, 3, 0, 3, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 2, 123, -7, 0, -7, 0,
+ax_anim 2, 0, 123, -7, -1, -7, -1,
+ax_anim 2, 0, 123, -7, 0, -7, 0,
+ax_anim 2, 0, 123, -7, -1, -7, -1,
+ax_anim 2, 1, 123, -7, 0, -7, 0,
+ax_anim 2, 0, 123, -7, -1, -7, -1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_4_8:
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 6, 0, 125, 3, -3, 3, -3,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim 2, 0, 125, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 2, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 126, -8, 6, -8, 6,
+ax_anim 2, 0, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 126, -8, 6, -8, 6,
+ax_anim 2, 1, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 126, -8, 6, -8, 6,
+ax_anim 2, 0, 125, 0, 6, 0, 6,
+ax_anim_terminator
+.align 2
+sHaunterAnims_5_1:
+ax_anim 2, 0, 128, 0, -1, 0, -1,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 4, 0, 128, 0, -5, 0, -5,
+ax_anim 4, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 1, 0, 128, 0, 1, 0, 1,
+ax_anim 2, 0, 128, 0, 13, 0, 13,
+ax_anim 2, 2, 129, 0, 13, 0, 13,
+ax_anim 2, 0, 130, 0, 13, 0, 13,
+ax_anim 2, 0, 129, 0, 13, 0, 13,
+ax_anim 2, 0, 130, 0, 13, 0, 13,
+ax_anim 2, 1, 129, 0, 13, 0, 13,
+ax_anim 2, 0, 130, 0, 3, 0, 3,
+ax_anim_terminator
+sHaunterAnims_5_2:
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, -3, -3, -3, -3,
+ax_anim 4, 0, 131, -5, -5, -5, -5,
+ax_anim 4, 0, 131, -6, -7, -6, -7,
+ax_anim 2, 0, 131, -3, -3, -3, -3,
+ax_anim 1, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 13, 13, 13, 13,
+ax_anim 2, 2, 132, 13, 13, 13, 13,
+ax_anim 2, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 132, 13, 13, 13, 13,
+ax_anim 2, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 1, 132, 13, 13, 13, 13,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim_terminator
+sHaunterAnims_5_3:
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim 2, 0, 134, -3, 0, -3, 0,
+ax_anim 4, 0, 134, -5, -1, -5, 0,
+ax_anim 4, 0, 134, -6, -2, -6, 0,
+ax_anim 2, 0, 134, -3, -1, -3, 0,
+ax_anim 1, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 0, 134, 13, 0, 13, 0,
+ax_anim 2, 2, 135, 13, 0, 13, 0,
+ax_anim 2, 0, 136, 13, 0, 13, 0,
+ax_anim 2, 0, 135, 13, 0, 13, 0,
+ax_anim 2, 0, 136, 13, 0, 13, 0,
+ax_anim 2, 1, 135, 13, 0, 13, 0,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sHaunterAnims_5_4:
+ax_anim 2, 0, 137, -1, 1, -1, 1,
+ax_anim 2, 0, 137, -3, 3, -3, 3,
+ax_anim 4, 0, 137, -5, 5, -5, 5,
+ax_anim 4, 0, 137, -6, 7, -6, 7,
+ax_anim 2, 0, 137, -3, 3, -3, 3,
+ax_anim 1, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 0, 137, 13, -13, 13, -13,
+ax_anim 2, 2, 138, 13, -13, 13, -13,
+ax_anim 2, 0, 139, 13, -13, 13, -13,
+ax_anim 2, 0, 138, 13, -13, 13, -13,
+ax_anim 2, 0, 139, 13, -13, 13, -13,
+ax_anim 2, 1, 138, 13, -13, 13, -13,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim_terminator
+sHaunterAnims_5_5:
+ax_anim 2, 0, 140, 0, 1, 0, 1,
+ax_anim 2, 0, 140, 0, 3, 0, 3,
+ax_anim 4, 0, 140, 0, 5, 0, 5,
+ax_anim 4, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 3, 0, 3,
+ax_anim 1, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, -13, 0, -13,
+ax_anim 2, 2, 141, 0, -13, 0, -13,
+ax_anim 2, 0, 142, 0, -13, 0, -13,
+ax_anim 2, 0, 141, 0, -13, 0, -13,
+ax_anim 2, 0, 142, 0, -13, 0, -13,
+ax_anim 2, 1, 141, 0, -13, 0, -13,
+ax_anim 2, 0, 142, 0, -3, 0, -3,
+ax_anim_terminator
+sHaunterAnims_5_6:
+ax_anim 2, 0, 143, 1, 1, 1, 1,
+ax_anim 2, 0, 143, 3, 3, 3, 3,
+ax_anim 4, 0, 143, 5, 5, 5, 5,
+ax_anim 4, 0, 143, 6, 7, 6, 7,
+ax_anim 2, 0, 143, 3, 3, 3, 3,
+ax_anim 1, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, -13, -13, -13, -13,
+ax_anim 2, 2, 144, -13, -13, -13, -13,
+ax_anim 2, 0, 145, -13, -13, -13, -13,
+ax_anim 2, 0, 144, -13, -13, -13, -13,
+ax_anim 2, 0, 145, -13, -13, -13, -13,
+ax_anim 2, 1, 144, -13, -13, -13, -13,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim_terminator
+sHaunterAnims_5_7:
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 0, 146, 3, 0, 3, 0,
+ax_anim 4, 0, 146, 5, -1, 5, 0,
+ax_anim 4, 0, 146, 6, -2, 6, 0,
+ax_anim 2, 0, 146, 3, -1, 3, 0,
+ax_anim 1, 0, 146, -1, 0, -1, 0,
+ax_anim 2, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 2, 147, -13, 0, -13, 0,
+ax_anim 2, 0, 148, -13, 0, -13, 0,
+ax_anim 2, 0, 147, -13, 0, -13, 0,
+ax_anim 2, 0, 148, -13, 0, -13, 0,
+ax_anim 2, 1, 147, -13, 0, -13, 0,
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sHaunterAnims_5_8:
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 0, 149, 3, -3, 3, -3,
+ax_anim 4, 0, 149, 5, -5, 5, -5,
+ax_anim 4, 0, 149, 6, -7, 6, -7,
+ax_anim 2, 0, 149, 3, -3, 3, -3,
+ax_anim 1, 0, 149, -1, 1, -1, 1,
+ax_anim 2, 0, 149, -13, 13, -13, 13,
+ax_anim 2, 2, 150, -13, 13, -13, 13,
+ax_anim 2, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 150, -13, 13, -13, 13,
+ax_anim 2, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 1, 150, -13, 13, -13, 13,
+ax_anim 2, 0, 151, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sHaunterAnims_6_1:
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 20, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 20, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHaunterAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sHaunterAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sHaunterAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sHaunterAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sHaunterAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sHaunterAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sHaunterAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sHaunterAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sHaunterAnims_8_1:
+ax_anim 14, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, -1, 0, 0,
+ax_anim 14, 0, 163, 0, -2, 0, 0,
+ax_anim 8, 0, 162, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_8_2:
+ax_anim 14, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, -1, 0, 0,
+ax_anim 14, 0, 165, 0, -2, 0, 0,
+ax_anim 8, 0, 164, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_8_3:
+ax_anim 14, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, -1, 0, 0,
+ax_anim 14, 0, 167, 0, -2, 0, 0,
+ax_anim 8, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_8_4:
+ax_anim 14, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, -1, 0, 0,
+ax_anim 14, 0, 169, 0, -2, 0, 0,
+ax_anim 8, 0, 168, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_8_5:
+ax_anim 14, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, -1, 0, 0,
+ax_anim 14, 0, 171, 0, -2, 0, 0,
+ax_anim 8, 0, 170, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_8_6:
+ax_anim 14, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, -1, 0, 0,
+ax_anim 14, 0, 173, 0, -2, 0, 0,
+ax_anim 8, 0, 172, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_8_7:
+ax_anim 14, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, -1, 0, 0,
+ax_anim 14, 0, 175, 0, -2, 0, 0,
+ax_anim 8, 0, 174, 0, -1, 0, 0,
+ax_anim_terminator
+sHaunterAnims_8_8:
+ax_anim 14, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, -1, 0, 0,
+ax_anim 14, 0, 177, 0, -2, 0, 0,
+ax_anim 8, 0, 176, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sHaunterAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 19, 7, 19,
+ax_anim 3, 0, 182, 0, 24, 0, 24,
+ax_anim 2, 3, 183, -7, 19, -7, 19,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 24, 9, 24, 9,
+ax_anim 3, 0, 181, 23, 21, 23, 21,
+ax_anim 2, 3, 182, 11, 21, 11, 21,
+ax_anim 2, 0, 183, 2, 12, 2, 12,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 20, 1, 20, 1,
+ax_anim 2, 3, 181, 17, 5, 17, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 11, -20, 11, -20,
+ax_anim 3, 0, 179, 16, -20, 16, -20,
+ax_anim 2, 3, 180, 18, -12, 18, -12,
+ax_anim 2, 0, 181, 16, -6, 16, -6,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -8, -10, -8, -10,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 8, -8, 8, -8,
+ax_anim 1, 0, 181, 6, -4, 6, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -11, -20, -11, -20,
+ax_anim 3, 0, 185, -16, -20, -16, -20,
+ax_anim 2, 3, 184, -18, -12, -18, -12,
+ax_anim 2, 0, 183, -16, -6, -16, -6,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -4, -17, -4,
+ax_anim 3, 0, 184, -20, 1, -20, 1,
+ax_anim 2, 3, 183, -17, 5, -17, 5,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -24, 9, -24, 9,
+ax_anim 3, 0, 183, -23, 21, -23, 16,
+ax_anim 2, 3, 182, -11, 21, -11, 16,
+ax_anim 2, 0, 181, -2, 12, -4, 12,
+ax_anim 1, 0, 180, 0, 7, -3, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHaunterAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHaunterAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -9, 0, 0,
+ax_anim 2, 2, 194, 0, 5, 0, 0,
+ax_anim_terminator
+sHaunterAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -9, 0, 0,
+ax_anim 2, 2, 197, 0, 6, 0, 0,
+ax_anim_terminator
+sHaunterAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -9, 0, 0,
+ax_anim 2, 2, 200, 0, 6, 0, 0,
+ax_anim_terminator
+sHaunterAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -8, 0, 0,
+ax_anim 2, 2, 203, 0, 6, 0, 0,
+ax_anim_terminator
+sHaunterAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 2, 206, 0, 4, 0, 0,
+ax_anim_terminator
+sHaunterAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -8, 0, 0,
+ax_anim 2, 2, 209, 0, 6, 0, 0,
+ax_anim_terminator
+sHaunterAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -9, 0, 0,
+ax_anim 2, 2, 212, 0, 6, 0, 0,
+ax_anim_terminator
+sHaunterAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -9, 0, 0,
+ax_anim 2, 2, 215, 0, 6, 0, 0,
+ax_anim_terminator
+.align 2
+sHaunterAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHaunterAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sHaunterGfx1:
+.incbin "baserom.gba", 0x8F5378, 0x200
+sHaunterSprites1:
+ax_sprite sHaunterGfx1, 0x200
+ax_sprite_terminator
+sHaunterGfx2:
+.incbin "baserom.gba", 0x8F5588, 0x200
+sHaunterSprites2:
+ax_sprite sHaunterGfx2, 0x200
+ax_sprite_terminator
+sHaunterGfx3:
+.incbin "baserom.gba", 0x8F5798, 0x200
+sHaunterSprites3:
+ax_sprite sHaunterGfx3, 0x200
+ax_sprite_terminator
+sHaunterGfx4:
+.incbin "baserom.gba", 0x8F59A8, 0x200
+sHaunterSprites4:
+ax_sprite sHaunterGfx4, 0x200
+ax_sprite_terminator
+sHaunterGfx5:
+.incbin "baserom.gba", 0x8F5BB8, 0x200
+sHaunterSprites5:
+ax_sprite sHaunterGfx5, 0x200
+ax_sprite_terminator
+sHaunterGfx6:
+.incbin "baserom.gba", 0x8F5DC8, 0x200
+sHaunterSprites6:
+ax_sprite sHaunterGfx6, 0x200
+ax_sprite_terminator
+sHaunterGfx7:
+.incbin "baserom.gba", 0x8F5FD8, 0x200
+sHaunterSprites7:
+ax_sprite sHaunterGfx7, 0x200
+ax_sprite_terminator
+sHaunterGfx8:
+.incbin "baserom.gba", 0x8F61E8, 0x200
+sHaunterSprites8:
+ax_sprite sHaunterGfx8, 0x200
+ax_sprite_terminator
+sHaunterGfx9:
+.incbin "baserom.gba", 0x8F63F8, 0x200
+sHaunterSprites9:
+ax_sprite sHaunterGfx9, 0x200
+ax_sprite_terminator
+sHaunterGfx10:
+.incbin "baserom.gba", 0x8F6608, 0x200
+sHaunterSprites10:
+ax_sprite sHaunterGfx10, 0x200
+ax_sprite_terminator
+sHaunterGfx11:
+.incbin "baserom.gba", 0x8F6818, 0x200
+sHaunterSprites11:
+ax_sprite sHaunterGfx11, 0x200
+ax_sprite_terminator
+sHaunterGfx12:
+.incbin "baserom.gba", 0x8F6A28, 0x200
+sHaunterSprites12:
+ax_sprite sHaunterGfx12, 0x200
+ax_sprite_terminator
+sHaunterGfx13:
+.incbin "baserom.gba", 0x8F6C38, 0x200
+sHaunterSprites13:
+ax_sprite sHaunterGfx13, 0x200
+ax_sprite_terminator
+sHaunterGfx14:
+.incbin "baserom.gba", 0x8F6E48, 0x200
+sHaunterSprites14:
+ax_sprite sHaunterGfx14, 0x200
+ax_sprite_terminator
+sHaunterGfx15:
+.incbin "baserom.gba", 0x8F7058, 0x200
+sHaunterSprites15:
+ax_sprite sHaunterGfx15, 0x200
+ax_sprite_terminator
+sHaunterGfx16:
+.incbin "baserom.gba", 0x8F7268, 0x80
+sHaunterSprites16:
+ax_sprite sHaunterGfx16, 0x80
+ax_sprite_terminator
+sHaunterGfx17:
+.incbin "baserom.gba", 0x8F72F8, 0x80
+sHaunterSprites17:
+ax_sprite sHaunterGfx17, 0x80
+ax_sprite_terminator
+sHaunterGfx18:
+.incbin "baserom.gba", 0x8F7388, 0x180
+sHaunterSprites18:
+ax_sprite sHaunterGfx18, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHaunterGfx19:
+.incbin "baserom.gba", 0x8F7520, 0x20
+sHaunterGfx19_1:
+.incbin "baserom.gba", 0x8F7540, 0x20
+sHaunterGfx19_2:
+.incbin "baserom.gba", 0x8F7560, 0x80
+sHaunterSprites19:
+ax_sprite sHaunterGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx19_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx19_2, 0x80
+ax_sprite_terminator
+sHaunterGfx20:
+.incbin "baserom.gba", 0x8F7610, 0x80
+sHaunterSprites20:
+ax_sprite sHaunterGfx20, 0x80
+ax_sprite_terminator
+sHaunterGfx21:
+.incbin "baserom.gba", 0x8F76A0, 0x60
+sHaunterGfx21_1:
+.incbin "baserom.gba", 0x8F7700, 0x60
+sHaunterGfx21_2:
+.incbin "baserom.gba", 0x8F7760, 0x60
+sHaunterSprites21:
+ax_sprite sHaunterGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHaunterGfx22:
+.incbin "baserom.gba", 0x8F77F8, 0x80
+sHaunterSprites22:
+ax_sprite sHaunterGfx22, 0x80
+ax_sprite_terminator
+sHaunterGfx23:
+.incbin "baserom.gba", 0x8F7888, 0x20
+sHaunterGfx23_1:
+.incbin "baserom.gba", 0x8F78A8, 0xC0
+sHaunterSprites23:
+ax_sprite 0, 0xe0
+ax_sprite sHaunterGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx23_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHaunterGfx24:
+.incbin "baserom.gba", 0x8F7998, 0x40
+sHaunterGfx24_1:
+.incbin "baserom.gba", 0x8F79D8, 0x60
+sHaunterGfx24_2:
+.incbin "baserom.gba", 0x8F7A38, 0x40
+sHaunterGfx24_3:
+.incbin "baserom.gba", 0x8F7A78, 0x20
+sHaunterSprites24:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHaunterGfx24_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sHaunterGfx25:
+.incbin "baserom.gba", 0x8F7AE8, 0x80
+sHaunterSprites25:
+ax_sprite sHaunterGfx25, 0x80
+ax_sprite_terminator
+sHaunterGfx26:
+.incbin "baserom.gba", 0x8F7B78, 0x40
+sHaunterGfx26_1:
+.incbin "baserom.gba", 0x8F7BB8, 0x60
+sHaunterGfx26_2:
+.incbin "baserom.gba", 0x8F7C18, 0x60
+sHaunterSprites26:
+ax_sprite sHaunterGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHaunterGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHaunterGfx27:
+.incbin "baserom.gba", 0x8F7CB0, 0x40
+sHaunterSprites27:
+ax_sprite 0, 0x40
+ax_sprite sHaunterGfx27, 0x40
+ax_sprite_terminator
+sHaunterGfx28:
+.incbin "baserom.gba", 0x8F7D08, 0xC0
+sHaunterSprites28:
+ax_sprite sHaunterGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHaunterGfx29:
+.incbin "baserom.gba", 0x8F7DE0, 0x60
+sHaunterGfx29_1:
+.incbin "baserom.gba", 0x8F7E40, 0x60
+sHaunterGfx29_2:
+.incbin "baserom.gba", 0x8F7EA0, 0x60
+sHaunterSprites29:
+ax_sprite sHaunterGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHaunterGfx30:
+.incbin "baserom.gba", 0x8F7F38, 0x40
+sHaunterSprites30:
+ax_sprite sHaunterGfx30, 0x40
+ax_sprite_terminator
+sHaunterGfx31:
+.incbin "baserom.gba", 0x8F7F88, 0x40
+sHaunterSprites31:
+ax_sprite sHaunterGfx31, 0x40
+ax_sprite_terminator
+sHaunterGfx32:
+.incbin "baserom.gba", 0x8F7FD8, 0x20
+sHaunterGfx32_1:
+.incbin "baserom.gba", 0x8F7FF8, 0x40
+sHaunterGfx32_2:
+.incbin "baserom.gba", 0x8F8038, 0x60
+sHaunterGfx32_3:
+.incbin "baserom.gba", 0x8F8098, 0x40
+sHaunterSprites32:
+ax_sprite sHaunterGfx32, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHaunterGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHaunterGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHaunterGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHaunterGfx33:
+.incbin "baserom.gba", 0x8F8120, 0x60
+sHaunterGfx33_1:
+.incbin "baserom.gba", 0x8F8180, 0x80
+sHaunterGfx33_2:
+.incbin "baserom.gba", 0x8F8200, 0x40
+sHaunterSprites33:
+ax_sprite sHaunterGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx33_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sHaunterGfx33_2, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHaunterGfx34:
+.incbin "baserom.gba", 0x8F8278, 0x180
+sHaunterGfx34_1:
+.incbin "baserom.gba", 0x8F83F8, 0x40
+sHaunterSprites34:
+ax_sprite sHaunterGfx34, 0x180
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHaunterGfx35:
+.incbin "baserom.gba", 0x8F8460, 0x40
+sHaunterSprites35:
+ax_sprite sHaunterGfx35, 0x40
+ax_sprite_terminator
+sHaunterGfx36:
+.incbin "baserom.gba", 0x8F84B0, 0x40
+sHaunterSprites36:
+ax_sprite sHaunterGfx36, 0x40
+ax_sprite_terminator
+sHaunterGfx37:
+.incbin "baserom.gba", 0x8F8500, 0xA0
+sHaunterGfx37_1:
+.incbin "baserom.gba", 0x8F85A0, 0x20
+sHaunterSprites37:
+ax_sprite sHaunterGfx37, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHaunterGfx38:
+.incbin "baserom.gba", 0x8F85E8, 0x200
+sHaunterSprites38:
+ax_sprite sHaunterGfx38, 0x200
+ax_sprite_terminator
+sHaunterGfx39:
+.incbin "baserom.gba", 0x8F87F8, 0x200
+sHaunterSprites39:
+ax_sprite sHaunterGfx39, 0x200
+ax_sprite_terminator
+sHaunterGfx40:
+.incbin "baserom.gba", 0x8F8A08, 0x1E0
+sHaunterSprites40:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx40, 0x1e0
+ax_sprite_terminator
+sHaunterGfx41:
+.incbin "baserom.gba", 0x8F8C00, 0x1E0
+sHaunterSprites41:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx41, 0x1e0
+ax_sprite_terminator
+sHaunterGfx42:
+.incbin "baserom.gba", 0x8F8DF8, 0x40
+sHaunterGfx42_1:
+.incbin "baserom.gba", 0x8F8E38, 0x180
+sHaunterSprites42:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx42_1, 0x180
+ax_sprite_terminator
+sHaunterGfx43:
+.incbin "baserom.gba", 0x8F8FE0, 0x40
+sHaunterGfx43_1:
+.incbin "baserom.gba", 0x8F9020, 0x100
+sHaunterGfx43_2:
+.incbin "baserom.gba", 0x8F9120, 0x60
+sHaunterSprites43:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx43_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx43_2, 0x60
+ax_sprite_terminator
+sHaunterGfx44:
+.incbin "baserom.gba", 0x8F91B8, 0x1E0
+sHaunterSprites44:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx44, 0x1e0
+ax_sprite_terminator
+sHaunterGfx45:
+.incbin "baserom.gba", 0x8F93B0, 0x1E0
+sHaunterSprites45:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx45, 0x1e0
+ax_sprite_terminator
+sHaunterGfx46:
+.incbin "baserom.gba", 0x8F95A8, 0x40
+sHaunterGfx46_1:
+.incbin "baserom.gba", 0x8F95E8, 0x100
+sHaunterGfx46_2:
+.incbin "baserom.gba", 0x8F96E8, 0x40
+sHaunterSprites46:
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx46_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx46_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHaunterGfx47:
+.incbin "baserom.gba", 0x8F9768, 0x180
+sHaunterGfx47_1:
+.incbin "baserom.gba", 0x8F98E8, 0x40
+sHaunterSprites47:
+ax_sprite sHaunterGfx47, 0x180
+ax_sprite 0, 0x20
+ax_sprite sHaunterGfx47_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHaunterGfx48:
+.incbin "baserom.gba", 0x8F9950, 0x200
+sHaunterSprites48:
+ax_sprite sHaunterGfx48, 0x200
+ax_sprite_terminator
+sHaunterGfx49:
+.incbin "baserom.gba", 0x8F9B60, 0x200
+sHaunterSprites49:
+ax_sprite sHaunterGfx49, 0x200
+ax_sprite_terminator
+sHaunterGfx50:
+.incbin "baserom.gba", 0x8F9D70, 0x200
+sHaunterSprites50:
+ax_sprite sHaunterGfx50, 0x200
+ax_sprite_terminator
+sHaunterGfx51:
+.incbin "baserom.gba", 0x8F9F80, 0x200
+sHaunterSprites51:
+ax_sprite sHaunterGfx51, 0x200
+ax_sprite_terminator
+sHaunterGfx52:
+.incbin "baserom.gba", 0x8FA190, 0x200
+sHaunterSprites52:
+ax_sprite sHaunterGfx52, 0x200
+ax_sprite_terminator
+sHaunterGfx53:
+.incbin "baserom.gba", 0x8FA3A0, 0x200
+sHaunterSprites53:
+ax_sprite sHaunterGfx53, 0x200
+ax_sprite_terminator
+sHaunterGfx54:
+.incbin "baserom.gba", 0x8FA5B0, 0x200
+sHaunterSprites54:
+ax_sprite sHaunterGfx54, 0x200
+ax_sprite_terminator
+sAxPosesHaunter:
+.4byte sHaunterPose1
+.4byte sHaunterPose2
+.4byte sHaunterPose3
+.4byte sHaunterPose4
+.4byte sHaunterPose5
+.4byte sHaunterPose6
+.4byte sHaunterPose7
+.4byte sHaunterPose8
+.4byte sHaunterPose9
+.4byte sHaunterPose10
+.4byte sHaunterPose11
+.4byte sHaunterPose12
+.4byte sHaunterPose13
+.4byte sHaunterPose14
+.4byte sHaunterPose15
+.4byte sHaunterPose16
+.4byte sHaunterPose17
+.4byte sHaunterPose18
+.4byte sHaunterPose19
+.4byte sHaunterPose20
+.4byte sHaunterPose21
+.4byte sHaunterPose22
+.4byte sHaunterPose23
+.4byte sHaunterPose24
+.4byte sHaunterPose25
+.4byte sHaunterPose26
+.4byte sHaunterPose27
+.4byte sHaunterPose28
+.4byte sHaunterPose29
+.4byte sHaunterPose30
+.4byte sHaunterPose31
+.4byte sHaunterPose32
+.4byte sHaunterPose33
+.4byte sHaunterPose34
+.4byte sHaunterPose35
+.4byte sHaunterPose36
+.4byte sHaunterPose37
+.4byte sHaunterPose38
+.4byte sHaunterPose39
+.4byte sHaunterPose40
+.4byte sHaunterPose41
+.4byte sHaunterPose42
+.4byte sHaunterPose43
+.4byte sHaunterPose44
+.4byte sHaunterPose45
+.4byte sHaunterPose46
+.4byte sHaunterPose47
+.4byte sHaunterPose48
+.4byte sHaunterPose49
+.4byte sHaunterPose50
+.4byte sHaunterPose51
+.4byte sHaunterPose52
+.4byte sHaunterPose53
+.4byte sHaunterPose54
+.4byte sHaunterPose55
+.4byte sHaunterPose56
+.4byte sHaunterPose57
+.4byte sHaunterPose58
+.4byte sHaunterPose59
+.4byte sHaunterPose60
+.4byte sHaunterPose61
+.4byte sHaunterPose62
+.4byte sHaunterPose63
+.4byte sHaunterPose64
+.4byte sHaunterPose65
+.4byte sHaunterPose66
+.4byte sHaunterPose67
+.4byte sHaunterPose68
+.4byte sHaunterPose69
+.4byte sHaunterPose70
+.4byte sHaunterPose71
+.4byte sHaunterPose72
+.4byte sHaunterPose73
+.4byte sHaunterPose74
+.4byte sHaunterPose75
+.4byte sHaunterPose76
+.4byte sHaunterPose77
+.4byte sHaunterPose78
+.4byte sHaunterPose79
+.4byte sHaunterPose80
+.4byte sHaunterPose81
+.4byte sHaunterPose82
+.4byte sHaunterPose83
+.4byte sHaunterPose84
+.4byte sHaunterPose85
+.4byte sHaunterPose86
+.4byte sHaunterPose87
+.4byte sHaunterPose88
+.4byte sHaunterPose89
+.4byte sHaunterPose90
+.4byte sHaunterPose91
+.4byte sHaunterPose92
+.4byte sHaunterPose93
+.4byte sHaunterPose94
+.4byte sHaunterPose95
+.4byte sHaunterPose96
+.4byte sHaunterPose97
+.4byte sHaunterPose98
+.4byte sHaunterPose99
+.4byte sHaunterPose100
+.4byte sHaunterPose101
+.4byte sHaunterPose102
+.4byte sHaunterPose103
+.4byte sHaunterPose104
+.4byte sHaunterPose105
+.4byte sHaunterPose106
+.4byte sHaunterPose107
+.4byte sHaunterPose108
+.4byte sHaunterPose109
+.4byte sHaunterPose110
+.4byte sHaunterPose111
+.4byte sHaunterPose112
+.4byte sHaunterPose113
+.4byte sHaunterPose114
+.4byte sHaunterPose115
+.4byte sHaunterPose116
+.4byte sHaunterPose117
+.4byte sHaunterPose118
+.4byte sHaunterPose119
+.4byte sHaunterPose120
+.4byte sHaunterPose121
+.4byte sHaunterPose122
+.4byte sHaunterPose123
+.4byte sHaunterPose124
+.4byte sHaunterPose125
+.4byte sHaunterPose126
+.4byte sHaunterPose127
+.4byte sHaunterPose128
+.4byte sHaunterPose129
+.4byte sHaunterPose130
+.4byte sHaunterPose131
+.4byte sHaunterPose132
+.4byte sHaunterPose133
+.4byte sHaunterPose134
+.4byte sHaunterPose135
+.4byte sHaunterPose136
+.4byte sHaunterPose137
+.4byte sHaunterPose138
+.4byte sHaunterPose139
+.4byte sHaunterPose140
+.4byte sHaunterPose141
+.4byte sHaunterPose142
+.4byte sHaunterPose143
+.4byte sHaunterPose144
+.4byte sHaunterPose145
+.4byte sHaunterPose146
+.4byte sHaunterPose147
+.4byte sHaunterPose148
+.4byte sHaunterPose149
+.4byte sHaunterPose150
+.4byte sHaunterPose151
+.4byte sHaunterPose152
+.4byte sHaunterPose153
+.4byte sHaunterPose154
+.4byte sHaunterPose155
+.4byte sHaunterPose156
+.4byte sHaunterPose157
+.4byte sHaunterPose158
+.4byte sHaunterPose159
+.4byte sHaunterPose160
+.4byte sHaunterPose161
+.4byte sHaunterPose162
+.4byte sHaunterPose163
+.4byte sHaunterPose164
+.4byte sHaunterPose165
+.4byte sHaunterPose166
+.4byte sHaunterPose167
+.4byte sHaunterPose168
+.4byte sHaunterPose169
+.4byte sHaunterPose170
+.4byte sHaunterPose171
+.4byte sHaunterPose172
+.4byte sHaunterPose173
+.4byte sHaunterPose174
+.4byte sHaunterPose175
+.4byte sHaunterPose176
+.4byte sHaunterPose177
+.4byte sHaunterPose178
+.4byte sHaunterPose179
+.4byte sHaunterPose180
+.4byte sHaunterPose181
+.4byte sHaunterPose182
+.4byte sHaunterPose183
+.4byte sHaunterPose184
+.4byte sHaunterPose185
+.4byte sHaunterPose186
+.4byte sHaunterPose187
+.4byte sHaunterPose188
+.4byte sHaunterPose189
+.4byte sHaunterPose190
+.4byte sHaunterPose191
+.4byte sHaunterPose192
+.4byte sHaunterPose193
+.4byte sHaunterPose194
+.4byte sHaunterPose195
+.4byte sHaunterPose196
+.4byte sHaunterPose197
+.4byte sHaunterPose198
+.4byte sHaunterPose199
+.4byte sHaunterPose200
+.4byte sHaunterPose201
+.4byte sHaunterPose202
+.4byte sHaunterPose203
+.4byte sHaunterPose204
+.4byte sHaunterPose205
+.4byte sHaunterPose206
+.4byte sHaunterPose207
+.4byte sHaunterPose208
+.4byte sHaunterPose209
+.4byte sHaunterPose210
+.4byte sHaunterPose211
+.4byte sHaunterPose212
+.4byte sHaunterPose213
+.4byte sHaunterPose214
+.4byte sHaunterPose215
+.4byte sHaunterPose216
+.4byte sHaunterPose217
+.4byte sHaunterPose218
+.4byte sHaunterPose219
+.4byte sHaunterPose220
+.4byte sHaunterPose221
+.4byte sHaunterPose222
+.4byte sHaunterPose223
+.4byte sHaunterPose224
+.4byte sHaunterPose225
+.4byte sHaunterPose226
+.4byte sHaunterPose227
+.4byte sHaunterPose228
+.4byte sHaunterPose229
+.4byte sHaunterPose230
+.4byte sHaunterPose231
+.4byte sHaunterPose232
+.4byte sHaunterPose233
+.4byte sHaunterPose234
+sAxPositionsHaunter:
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte   -1,   -8, 	  -8,   -6, 	   8,   -6, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -4, 	   8,   -4, 	  -1,  -15
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    4,   -8, 	  12,  -13, 	  -1,   -5, 	   1,  -16
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -1, 	   0,  -16
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    2,   -8, 	  10,  -15, 	   7,   -8, 	  -1,  -14
+.2byte    4,   -8, 	  10,  -11, 	   6,   -4, 	   0,  -13
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    2,  -17, 	  -5,  -17, 	   9,   -9, 	  -1,  -14
+.2byte    2,  -17, 	  -5,  -18, 	   9,   -8, 	  -1,  -13
+.2byte    0,  -13, 	   8,   -6, 	  -9,   -6, 	   0,   -9
+.2byte   -1,  -13, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte    0,  -13, 	   9,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte   -3,  -17, 	   4,  -17, 	 -10,   -9, 	   0,  -14
+.2byte   -3,  -17, 	   4,  -18, 	 -10,   -8, 	   0,  -13
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -3,   -8, 	 -11,  -15, 	  -8,   -8, 	   0,  -14
+.2byte   -5,   -8, 	 -11,  -11, 	  -7,   -4, 	  -1,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -5,   -8, 	 -13,  -13, 	   0,   -5, 	  -2,  -16
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -1, 	  -1,  -16
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte   -1,   -8, 	  -8,   -6, 	   8,   -6, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -4, 	   8,   -4, 	  -1,  -15
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    4,   -8, 	  12,  -13, 	  -1,   -5, 	   1,  -16
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -1, 	   0,  -16
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    2,   -8, 	  10,  -15, 	   7,   -8, 	  -1,  -14
+.2byte    4,   -8, 	  10,  -11, 	   6,   -4, 	   0,  -13
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    2,  -17, 	  -5,  -17, 	   9,   -9, 	  -1,  -14
+.2byte    2,  -17, 	  -5,  -18, 	   9,   -8, 	  -1,  -13
+.2byte    0,  -13, 	   8,   -6, 	  -9,   -6, 	   0,   -9
+.2byte   -1,  -13, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte    0,  -13, 	   9,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte   -3,  -17, 	   4,  -17, 	 -10,   -9, 	   0,  -14
+.2byte   -3,  -17, 	   4,  -18, 	 -10,   -8, 	   0,  -13
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -3,   -8, 	 -11,  -15, 	  -8,   -8, 	   0,  -14
+.2byte   -5,   -8, 	 -11,  -11, 	  -7,   -4, 	  -1,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -5,   -8, 	 -13,  -13, 	   0,   -5, 	  -2,  -16
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -1, 	  -1,  -16
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte   -1,   -7, 	 -14,   -6, 	  12,   -6, 	  -1,  -16
+.2byte   -1,   -7, 	 -16,   -9, 	  14,   -9, 	  -1,  -16
+.2byte   -1,   -7, 	 -18,  -15, 	   6,   11, 	  -1,  -16
+.2byte   -1,   -7, 	 -19,  -23, 	   1,   11, 	  -1,  -16
+.2byte   -1,   -7, 	  -8,   10, 	  16,  -15, 	  -1,  -16
+.2byte   -1,   -7, 	  -3,   11, 	  17,  -23, 	  -1,  -16
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    3,   -8, 	  14,  -12, 	  -3,   -1, 	   0,  -15
+.2byte    3,   -8, 	  15,  -13, 	  -8,    0, 	   0,  -15
+.2byte    3,   -8, 	  12,  -18, 	   9,   10, 	   0,  -15
+.2byte    3,   -8, 	   9,  -23, 	  17,    9, 	   0,  -15
+.2byte    3,   -8, 	  24,    4, 	 -13,   -2, 	   0,  -15
+.2byte    3,   -8, 	  24,    8, 	 -18,   -8, 	   0,  -15
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    4,   -8, 	  10,  -15, 	   3,   -1, 	   0,  -14
+.2byte    3,   -8, 	   5,  -22, 	  -8,   -1, 	  -1,  -14
+.2byte    3,   -8, 	  -2,  -24, 	  18,   -6, 	  -1,  -14
+.2byte    3,   -8, 	  -6,  -23, 	  20,   -9, 	  -1,  -14
+.2byte    3,   -8, 	  22,  -11, 	  -5,    1, 	  -1,  -14
+.2byte    3,   -8, 	  23,   -8, 	 -12,   -6, 	  -1,  -14
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    2,  -16, 	  -7,  -19, 	  12,   -8, 	  -1,  -14
+.2byte    2,  -16, 	 -10,  -16, 	  11,   -5, 	  -1,  -14
+.2byte    2,  -16, 	 -14,  -14, 	  24,  -23, 	  -1,  -14
+.2byte    2,  -16, 	 -16,  -10, 	  23,  -28, 	  -1,  -14
+.2byte    2,  -16, 	  11,  -33, 	   9,   -1, 	  -1,  -14
+.2byte    2,  -16, 	  16,  -33, 	   3,    3, 	  -1,  -14
+.2byte    0,  -18, 	   8,  -11, 	  -9,  -11, 	   0,  -14
+.2byte    0,  -19, 	  12,  -11, 	 -13,  -11, 	   0,  -14
+.2byte    0,  -19, 	  14,   -9, 	 -15,   -9, 	   0,  -14
+.2byte    0,  -19, 	  13,   -6, 	  -9,  -29, 	   0,  -14
+.2byte    0,  -19, 	  12,   -2, 	  -3,  -32, 	   0,  -14
+.2byte    0,  -19, 	   8,  -29, 	 -14,   -6, 	   0,  -14
+.2byte    0,  -19, 	   3,  -32, 	 -13,   -2, 	   0,  -14
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte   -3,  -16, 	   6,  -19, 	 -13,   -8, 	   0,  -14
+.2byte   -3,  -16, 	   9,  -16, 	 -12,   -5, 	   0,  -14
+.2byte   -3,  -16, 	  13,  -14, 	 -20,  -15, 	   0,  -14
+.2byte   -3,  -16, 	  15,  -10, 	 -23,  -31, 	   0,  -14
+.2byte   -3,  -16, 	  -3,  -31, 	 -10,   -1, 	   0,  -14
+.2byte   -3,  -16, 	 -19,  -34, 	  -4,    3, 	   0,  -14
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -4,   -8, 	 -11,  -15, 	  -4,   -1, 	   0,  -14
+.2byte   -4,   -8, 	  -6,  -22, 	   7,   -1, 	   0,  -14
+.2byte   -4,   -8, 	   1,  -24, 	  -8,   -1, 	   0,  -14
+.2byte   -4,   -8, 	   5,  -23, 	 -18,   -7, 	   0,  -14
+.2byte   -4,   -8, 	 -14,  -17, 	   4,    1, 	   0,  -14
+.2byte   -4,   -8, 	 -22,  -10, 	  11,   -6, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -4,   -8, 	 -15,  -12, 	   2,   -1, 	  -1,  -15
+.2byte   -4,   -8, 	 -16,  -13, 	   7,    0, 	  -1,  -15
+.2byte   -4,   -8, 	 -13,  -18, 	   0,    7, 	  -1,  -15
+.2byte   -4,   -8, 	 -10,  -23, 	 -20,    9, 	  -1,  -15
+.2byte   -4,   -8, 	 -22,   -7, 	  12,   -2, 	  -1,  -15
+.2byte   -4,   -8, 	 -25,    8, 	  17,   -8, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte    0,   -9, 	 -13,   -1, 	  12,   -1, 	  -1,  -16
+.2byte   -1,   -7, 	 -13,   -4, 	  12,   -4, 	  -1,  -16
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    3,  -10, 	  13,   -7, 	  -4,   -2, 	  -1,  -15
+.2byte    4,   -9, 	  12,  -10, 	  -3,   -4, 	  -1,  -15
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    4,  -10, 	  10,  -11, 	   2,   -2, 	   0,  -13
+.2byte    4,   -9, 	   9,  -13, 	   4,   -4, 	  -1,  -13
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    5,  -14, 	  -6,  -17, 	  13,   -7, 	  -2,  -12
+.2byte    7,  -16, 	  -7,  -18, 	  12,   -9, 	  -2,  -12
+.2byte    0,  -18, 	   8,  -11, 	  -9,  -11, 	   0,  -14
+.2byte    0,  -19, 	  13,  -11, 	 -14,  -11, 	   0,  -13
+.2byte    0,  -19, 	  13,  -13, 	 -14,  -12, 	   0,  -13
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte   -6,  -14, 	   5,  -17, 	 -14,   -7, 	   1,  -12
+.2byte   -8,  -16, 	   6,  -18, 	 -13,   -9, 	   1,  -12
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -5,  -10, 	 -11,  -11, 	  -3,   -2, 	  -1,  -13
+.2byte   -5,   -9, 	 -10,  -13, 	  -5,   -4, 	   0,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -4,  -10, 	 -14,   -7, 	   3,   -2, 	   0,  -15
+.2byte   -5,   -9, 	 -13,  -10, 	   2,   -4, 	   0,  -15
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte    0,   -9, 	 -13,   -1, 	  12,   -1, 	  -1,  -16
+.2byte   -1,   -7, 	 -13,   -4, 	  12,   -4, 	  -1,  -16
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    3,  -10, 	  13,   -7, 	  -4,   -2, 	  -1,  -15
+.2byte    4,   -9, 	  12,  -10, 	  -3,   -4, 	  -1,  -15
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    4,  -10, 	  10,  -11, 	   2,   -2, 	   0,  -13
+.2byte    4,   -9, 	   9,  -13, 	   4,   -4, 	  -1,  -13
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    5,  -14, 	  -6,  -17, 	  13,   -7, 	  -2,  -12
+.2byte    7,  -16, 	  -7,  -18, 	  12,   -9, 	  -2,  -12
+.2byte    0,  -18, 	   8,  -11, 	  -9,  -11, 	   0,  -14
+.2byte    0,  -19, 	  13,  -11, 	 -14,  -11, 	   0,  -13
+.2byte    0,  -19, 	  13,  -13, 	 -14,  -12, 	   0,  -13
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte   -6,  -14, 	   5,  -17, 	 -14,   -7, 	   1,  -12
+.2byte   -8,  -16, 	   6,  -18, 	 -13,   -9, 	   1,  -12
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -5,  -10, 	 -11,  -11, 	  -3,   -2, 	  -1,  -13
+.2byte   -5,   -9, 	 -10,  -13, 	  -5,   -4, 	   0,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -4,  -10, 	 -14,   -7, 	   3,   -2, 	   0,  -15
+.2byte   -5,   -9, 	 -13,  -10, 	   2,   -4, 	   0,  -15
+.2byte   -6,   -9, 	 -13,   -9, 	   0,   -1, 	  -1,  -14
+.2byte   -6,   -8, 	 -14,   -9, 	   1,   -2, 	  -1,  -14
+.2byte    0,  -11, 	  -7,  -16, 	   6,  -17, 	   0,  -13
+.2byte    6,   -9, 	   9,  -15, 	  -1,  -11, 	   0,  -13
+.2byte    7,  -16, 	   3,  -21, 	   6,  -13, 	  -2,  -12
+.2byte    3,  -19, 	  -2,  -23, 	   9,  -17, 	  -2,  -14
+.2byte    0,  -17, 	   5,  -19, 	  -6,  -19, 	   0,  -12
+.2byte   -4,  -19, 	   1,  -23, 	 -10,  -17, 	   1,  -14
+.2byte   -9,  -16, 	  -5,  -21, 	  -8,  -13, 	   0,  -12
+.2byte   -6,   -9, 	  -9,  -15, 	   1,  -11, 	   0,  -13
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte   -1,   -8, 	  -8,   -4, 	   8,   -4, 	  -1,  -15
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -1, 	   0,  -16
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    4,   -8, 	  10,  -11, 	   6,   -4, 	   0,  -13
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    2,  -17, 	  -5,  -18, 	   9,   -8, 	  -1,  -13
+.2byte    0,  -13, 	   8,   -6, 	  -9,   -6, 	   0,   -9
+.2byte    0,  -13, 	   9,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte   -3,  -17, 	   4,  -18, 	 -10,   -8, 	   0,  -13
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -5,   -8, 	 -11,  -11, 	  -7,   -4, 	  -1,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -1, 	  -1,  -16
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte    0,  -18, 	   8,  -11, 	  -9,  -11, 	   0,  -14
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    0,   -9, 	 -13,   -1, 	  12,   -1, 	  -1,  -16
+.2byte    3,  -10, 	  13,   -7, 	  -4,   -2, 	  -1,  -15
+.2byte    4,  -10, 	  10,  -11, 	   2,   -2, 	   0,  -13
+.2byte    5,  -14, 	  -6,  -17, 	  13,   -7, 	  -2,  -12
+.2byte    0,  -19, 	  13,  -11, 	 -14,  -11, 	   0,  -13
+.2byte   -6,  -14, 	   5,  -17, 	 -14,   -7, 	   1,  -12
+.2byte   -5,  -10, 	 -11,  -11, 	  -3,   -2, 	  -1,  -13
+.2byte   -4,  -10, 	 -14,   -7, 	   3,   -2, 	   0,  -15
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte   -1,   -8, 	  -8,   -6, 	   8,   -6, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -4, 	   8,   -4, 	  -1,  -15
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+.2byte    4,   -8, 	  12,  -13, 	  -1,   -5, 	   1,  -16
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -1, 	   0,  -16
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    2,   -8, 	  10,  -15, 	   7,   -8, 	  -1,  -14
+.2byte    4,   -8, 	  10,  -11, 	   6,   -4, 	   0,  -13
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    2,  -17, 	  -5,  -17, 	   9,   -9, 	  -1,  -14
+.2byte    2,  -17, 	  -5,  -18, 	   9,   -8, 	  -1,  -13
+.2byte    0,  -13, 	   8,   -6, 	  -9,   -6, 	   0,   -9
+.2byte   -1,  -13, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte    0,  -13, 	   9,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte   -3,  -17, 	   4,  -17, 	 -10,   -9, 	   0,  -14
+.2byte   -3,  -17, 	   4,  -18, 	 -10,   -8, 	   0,  -13
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -3,   -8, 	 -11,  -15, 	  -8,   -8, 	   0,  -14
+.2byte   -5,   -8, 	 -11,  -11, 	  -7,   -4, 	  -1,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -5,   -8, 	 -13,  -13, 	   0,   -5, 	  -2,  -16
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -1, 	  -1,  -16
+.2byte    0,   -9, 	 -13,   -1, 	  12,   -1, 	  -1,  -16
+.2byte   -4,  -10, 	 -14,   -7, 	   3,   -2, 	   0,  -15
+.2byte   -5,  -10, 	 -11,  -11, 	  -3,   -2, 	  -1,  -13
+.2byte   -6,  -14, 	   5,  -17, 	 -14,   -7, 	   1,  -12
+.2byte    0,  -19, 	  13,  -11, 	 -14,  -11, 	   0,  -13
+.2byte    5,  -14, 	  -6,  -17, 	  13,   -7, 	  -2,  -12
+.2byte    4,  -10, 	  10,  -11, 	   2,   -2, 	   0,  -13
+.2byte    3,  -10, 	  13,   -7, 	  -4,   -2, 	  -1,  -15
+.2byte   -1,   -8, 	  -8,   -5, 	   7,   -5, 	  -1,  -13
+.2byte   -5,   -8, 	 -12,  -10, 	   0,   -3, 	  -1,  -15
+.2byte   -4,   -8, 	 -11,  -13, 	  -9,   -5, 	   0,  -13
+.2byte   -3,  -17, 	   3,  -16, 	 -10,   -8, 	   0,  -13
+.2byte    0,  -18, 	   8,  -11, 	  -9,  -11, 	   0,  -14
+.2byte    2,  -17, 	  -4,  -16, 	   9,   -8, 	  -1,  -13
+.2byte    3,   -8, 	  10,  -13, 	   8,   -5, 	  -1,  -13
+.2byte    4,   -8, 	  11,  -10, 	  -1,   -3, 	   0,  -15
+sHaunterAnimTable1:
+.4byte sHaunterAnims_1_1
+.4byte sHaunterAnims_1_2
+.4byte sHaunterAnims_1_3
+.4byte sHaunterAnims_1_4
+.4byte sHaunterAnims_1_5
+.4byte sHaunterAnims_1_6
+.4byte sHaunterAnims_1_7
+.4byte sHaunterAnims_1_8
+sHaunterAnimTable2:
+.4byte sHaunterAnims_2_1
+.4byte sHaunterAnims_2_2
+.4byte sHaunterAnims_2_3
+.4byte sHaunterAnims_2_4
+.4byte sHaunterAnims_2_5
+.4byte sHaunterAnims_2_6
+.4byte sHaunterAnims_2_7
+.4byte sHaunterAnims_2_8
+sHaunterAnimTable3:
+.4byte sHaunterAnims_3_1
+.4byte sHaunterAnims_3_2
+.4byte sHaunterAnims_3_3
+.4byte sHaunterAnims_3_4
+.4byte sHaunterAnims_3_5
+.4byte sHaunterAnims_3_6
+.4byte sHaunterAnims_3_7
+.4byte sHaunterAnims_3_8
+sHaunterAnimTable4:
+.4byte sHaunterAnims_4_1
+.4byte sHaunterAnims_4_2
+.4byte sHaunterAnims_4_3
+.4byte sHaunterAnims_4_4
+.4byte sHaunterAnims_4_5
+.4byte sHaunterAnims_4_6
+.4byte sHaunterAnims_4_7
+.4byte sHaunterAnims_4_8
+sHaunterAnimTable5:
+.4byte sHaunterAnims_5_1
+.4byte sHaunterAnims_5_2
+.4byte sHaunterAnims_5_3
+.4byte sHaunterAnims_5_4
+.4byte sHaunterAnims_5_5
+.4byte sHaunterAnims_5_6
+.4byte sHaunterAnims_5_7
+.4byte sHaunterAnims_5_8
+sHaunterAnimTable6:
+.4byte sHaunterAnims_6_1
+.4byte sHaunterAnims_6_1
+.4byte sHaunterAnims_6_1
+.4byte sHaunterAnims_6_1
+.4byte sHaunterAnims_6_1
+.4byte sHaunterAnims_6_1
+.4byte sHaunterAnims_6_1
+.4byte sHaunterAnims_6_1
+sHaunterAnimTable7:
+.4byte sHaunterAnims_7_1
+.4byte sHaunterAnims_7_2
+.4byte sHaunterAnims_7_3
+.4byte sHaunterAnims_7_4
+.4byte sHaunterAnims_7_5
+.4byte sHaunterAnims_7_6
+.4byte sHaunterAnims_7_7
+.4byte sHaunterAnims_7_8
+sHaunterAnimTable8:
+.4byte sHaunterAnims_8_1
+.4byte sHaunterAnims_8_2
+.4byte sHaunterAnims_8_3
+.4byte sHaunterAnims_8_4
+.4byte sHaunterAnims_8_5
+.4byte sHaunterAnims_8_6
+.4byte sHaunterAnims_8_7
+.4byte sHaunterAnims_8_8
+sHaunterAnimTable9:
+.4byte sHaunterAnims_9_1
+.4byte sHaunterAnims_9_2
+.4byte sHaunterAnims_9_3
+.4byte sHaunterAnims_9_4
+.4byte sHaunterAnims_9_5
+.4byte sHaunterAnims_9_6
+.4byte sHaunterAnims_9_7
+.4byte sHaunterAnims_9_8
+sHaunterAnimTable10:
+.4byte sHaunterAnims_10_1
+.4byte sHaunterAnims_10_2
+.4byte sHaunterAnims_10_3
+.4byte sHaunterAnims_10_4
+.4byte sHaunterAnims_10_5
+.4byte sHaunterAnims_10_6
+.4byte sHaunterAnims_10_7
+.4byte sHaunterAnims_10_8
+sHaunterAnimTable11:
+.4byte sHaunterAnims_11_1
+.4byte sHaunterAnims_11_2
+.4byte sHaunterAnims_11_3
+.4byte sHaunterAnims_11_4
+.4byte sHaunterAnims_11_5
+.4byte sHaunterAnims_11_6
+.4byte sHaunterAnims_11_7
+.4byte sHaunterAnims_11_8
+sHaunterAnimTable12:
+.4byte sHaunterAnims_12_1
+.4byte sHaunterAnims_12_2
+.4byte sHaunterAnims_12_3
+.4byte sHaunterAnims_12_4
+.4byte sHaunterAnims_12_5
+.4byte sHaunterAnims_12_6
+.4byte sHaunterAnims_12_7
+.4byte sHaunterAnims_12_8
+sHaunterAnimTable13:
+.4byte sHaunterAnims_13_1
+.4byte sHaunterAnims_13_2
+.4byte sHaunterAnims_13_3
+.4byte sHaunterAnims_13_4
+.4byte sHaunterAnims_13_5
+.4byte sHaunterAnims_13_6
+.4byte sHaunterAnims_13_7
+.4byte sHaunterAnims_13_8
+sAxAnimationsHaunter:
+.4byte sHaunterAnimTable1
+.4byte sHaunterAnimTable2
+.4byte sHaunterAnimTable3
+.4byte sHaunterAnimTable4
+.4byte sHaunterAnimTable5
+.4byte sHaunterAnimTable6
+.4byte sHaunterAnimTable7
+.4byte sHaunterAnimTable8
+.4byte sHaunterAnimTable9
+.4byte sHaunterAnimTable10
+.4byte sHaunterAnimTable11
+.4byte sHaunterAnimTable12
+.4byte sHaunterAnimTable13
+sAxSpritesHaunter:
+.4byte sHaunterSprites1
+.4byte sHaunterSprites2
+.4byte sHaunterSprites3
+.4byte sHaunterSprites4
+.4byte sHaunterSprites5
+.4byte sHaunterSprites6
+.4byte sHaunterSprites7
+.4byte sHaunterSprites8
+.4byte sHaunterSprites9
+.4byte sHaunterSprites10
+.4byte sHaunterSprites11
+.4byte sHaunterSprites12
+.4byte sHaunterSprites13
+.4byte sHaunterSprites14
+.4byte sHaunterSprites15
+.4byte sHaunterSprites16
+.4byte sHaunterSprites17
+.4byte sHaunterSprites18
+.4byte sHaunterSprites19
+.4byte sHaunterSprites20
+.4byte sHaunterSprites21
+.4byte sHaunterSprites22
+.4byte sHaunterSprites23
+.4byte sHaunterSprites24
+.4byte sHaunterSprites25
+.4byte sHaunterSprites26
+.4byte sHaunterSprites27
+.4byte sHaunterSprites28
+.4byte sHaunterSprites29
+.4byte sHaunterSprites30
+.4byte sHaunterSprites31
+.4byte sHaunterSprites32
+.4byte sHaunterSprites33
+.4byte sHaunterSprites34
+.4byte sHaunterSprites35
+.4byte sHaunterSprites36
+.4byte sHaunterSprites37
+.4byte sHaunterSprites38
+.4byte sHaunterSprites39
+.4byte sHaunterSprites40
+.4byte sHaunterSprites41
+.4byte sHaunterSprites42
+.4byte sHaunterSprites43
+.4byte sHaunterSprites44
+.4byte sHaunterSprites45
+.4byte sHaunterSprites46
+.4byte sHaunterSprites47
+.4byte sHaunterSprites48
+.4byte sHaunterSprites49
+.4byte sHaunterSprites50
+.4byte sHaunterSprites51
+.4byte sHaunterSprites52
+.4byte sHaunterSprites53
+.4byte sHaunterSprites54
+sAxMainHaunter:
+ax_main sAxPosesHaunter, sAxAnimationsHaunter, 13, sAxSpritesHaunter, sAxPositionsHaunter

--- a/data/ax/heracross.inc
+++ b/data/ax/heracross.inc
@@ -1,0 +1,3230 @@
+.global gAxHeracross
+gAxHeracross:
+ax_siro sAxMainHeracross
+sHeracrossPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose4:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose5:
+ax_pose 4, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose6:
+ax_pose 5, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose7:
+ax_pose 6, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose8:
+ax_pose 7, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose9:
+ax_pose 8, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose10:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose11:
+ax_pose 10, 0x01e4, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose12:
+ax_pose 11, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose13:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose16:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose17:
+ax_pose 10, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose18:
+ax_pose 11, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose19:
+ax_pose 6, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose20:
+ax_pose 7, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose21:
+ax_pose 8, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose22:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose23:
+ax_pose 4, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose24:
+ax_pose 5, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose26:
+ax_pose 15, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose28:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose29:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose30:
+ax_pose 17, 0x01e3, 0x90f2, 0x2c00
+ax_pose_terminator
+sHeracrossPose31:
+ax_pose 5, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose32:
+ax_pose 18, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose33:
+ax_pose 6, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose34:
+ax_pose 19, 0x01e3, 0x90f7, 0x2c00
+ax_pose_terminator
+sHeracrossPose35:
+ax_pose 8, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose36:
+ax_pose 20, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose37:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose38:
+ax_pose 21, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose39:
+ax_pose 11, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose40:
+ax_pose 22, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose41:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose42:
+ax_pose 23, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose43:
+ax_pose 14, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose44:
+ax_pose 24, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose45:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose46:
+ax_pose 21, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose47:
+ax_pose 11, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose48:
+ax_pose 22, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose49:
+ax_pose 6, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose50:
+ax_pose 19, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose51:
+ax_pose 8, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose52:
+ax_pose 20, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose53:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose54:
+ax_pose 17, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose55:
+ax_pose 5, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose56:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose57:
+ax_pose 0, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose58:
+ax_pose 1, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose59:
+ax_pose 2, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose60:
+ax_pose 25, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose61:
+ax_pose 26, 0x01eb, 0x80f0, 0x2c00
+ax_pose 27, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sHeracrossPose62:
+ax_pose 27, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose63:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose64:
+ax_pose 4, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose65:
+ax_pose 5, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose66:
+ax_pose 28, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose67:
+ax_pose 29, 0x01e5, 0x90ee, 0x2c00
+ax_pose 30, 0x01e3, 0x90ed, 0x2c10
+ax_pose_terminator
+sHeracrossPose68:
+ax_pose 30, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose69:
+ax_pose 6, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose70:
+ax_pose 7, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose71:
+ax_pose 8, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose72:
+ax_pose 31, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose73:
+ax_pose 32, 0x01e3, 0x90f5, 0x2c00
+ax_pose 33, 0x01e3, 0x90f1, 0x2c10
+ax_pose_terminator
+sHeracrossPose74:
+ax_pose 33, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose75:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose76:
+ax_pose 10, 0x01e4, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose77:
+ax_pose 11, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose78:
+ax_pose 34, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose79:
+ax_pose 35, 0x01e3, 0x90ef, 0x2c00
+ax_pose 36, 0x01e3, 0x90ed, 0x2c10
+ax_pose_terminator
+sHeracrossPose80:
+ax_pose 36, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose81:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose82:
+ax_pose 13, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose83:
+ax_pose 14, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose84:
+ax_pose 37, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose85:
+ax_pose 38, 0x01e3, 0x80f0, 0x2c00
+ax_pose 39, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sHeracrossPose86:
+ax_pose 39, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose87:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose88:
+ax_pose 10, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose89:
+ax_pose 11, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose90:
+ax_pose 34, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose91:
+ax_pose 35, 0x01e3, 0x80f2, 0x2c00
+ax_pose 36, 0x01e3, 0x80f4, 0x2c10
+ax_pose_terminator
+sHeracrossPose92:
+ax_pose 36, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose93:
+ax_pose 6, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose94:
+ax_pose 7, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose95:
+ax_pose 8, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose96:
+ax_pose 31, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose97:
+ax_pose 32, 0x01e3, 0x80ec, 0x2c00
+ax_pose 33, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sHeracrossPose98:
+ax_pose 33, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose99:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose100:
+ax_pose 4, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose101:
+ax_pose 5, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose102:
+ax_pose 28, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose103:
+ax_pose 29, 0x01e5, 0x80f3, 0x2c00
+ax_pose 30, 0x01e3, 0x80f4, 0x2c10
+ax_pose_terminator
+sHeracrossPose104:
+ax_pose 30, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose105:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose106:
+ax_pose 18, 0x01e3, 0x80ef, 0x2c00
+ax_pose_terminator
+sHeracrossPose107:
+ax_pose 20, 0x01e5, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose108:
+ax_pose 22, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sHeracrossPose109:
+ax_pose 24, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose110:
+ax_pose 22, 0x01e5, 0x90f2, 0x2c00
+ax_pose_terminator
+sHeracrossPose111:
+ax_pose 20, 0x01e5, 0x90f3, 0x2c00
+ax_pose_terminator
+sHeracrossPose112:
+ax_pose 18, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose113:
+ax_pose 0, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose114:
+ax_pose 40, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose115:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose116:
+ax_pose 40, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose117:
+ax_pose 15, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose118:
+ax_pose 41, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose119:
+ax_pose 42, 0x01e4, 0x80ee, 0x2c00
+ax_pose_terminator
+sHeracrossPose120:
+ax_pose 42, 0x01e4, 0x90f2, 0x2c00
+ax_pose_terminator
+sHeracrossPose121:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose122:
+ax_pose 43, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose123:
+ax_pose 18, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose124:
+ax_pose 42, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose125:
+ax_pose 17, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose126:
+ax_pose 44, 0x01ea, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose127:
+ax_pose 6, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose128:
+ax_pose 45, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose129:
+ax_pose 20, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose130:
+ax_pose 46, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose131:
+ax_pose 19, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose132:
+ax_pose 47, 0x01e3, 0x90f7, 0x2c00
+ax_pose_terminator
+sHeracrossPose133:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose134:
+ax_pose 48, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose135:
+ax_pose 22, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose136:
+ax_pose 49, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose137:
+ax_pose 21, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose138:
+ax_pose 50, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose139:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose140:
+ax_pose 51, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose141:
+ax_pose 24, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose142:
+ax_pose 51, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose143:
+ax_pose 23, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose144:
+ax_pose 52, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose145:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose146:
+ax_pose 49, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose147:
+ax_pose 22, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose148:
+ax_pose 48, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose149:
+ax_pose 21, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose150:
+ax_pose 50, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose151:
+ax_pose 6, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose152:
+ax_pose 46, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose153:
+ax_pose 20, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose154:
+ax_pose 45, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose155:
+ax_pose 19, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose156:
+ax_pose 47, 0x01e3, 0x80ea, 0x2c00
+ax_pose_terminator
+sHeracrossPose157:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose158:
+ax_pose 42, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose159:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose160:
+ax_pose 43, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose161:
+ax_pose 17, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose162:
+ax_pose 44, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose163:
+ax_pose 53, 0x01f0, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose164:
+ax_pose 54, 0x01f0, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose165:
+ax_pose 55, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose166:
+ax_pose 56, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sHeracrossPose167:
+ax_pose 57, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose168:
+ax_pose 58, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose169:
+ax_pose 59, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose170:
+ax_pose 58, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sHeracrossPose171:
+ax_pose 57, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sHeracrossPose172:
+ax_pose 56, 0x01e2, 0x80f2, 0x2c00
+ax_pose_terminator
+sHeracrossPose173:
+ax_pose 0, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose174:
+ax_pose 40, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose175:
+ax_pose 40, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose176:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose177:
+ax_pose 43, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose178:
+ax_pose 42, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose179:
+ax_pose 6, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose180:
+ax_pose 45, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose181:
+ax_pose 46, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose182:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose183:
+ax_pose 48, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose184:
+ax_pose 49, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose185:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose186:
+ax_pose 51, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose187:
+ax_pose 51, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose188:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose189:
+ax_pose 49, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose190:
+ax_pose 48, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose191:
+ax_pose 6, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose192:
+ax_pose 46, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose193:
+ax_pose 45, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose194:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose195:
+ax_pose 42, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose196:
+ax_pose 43, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose197:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose198:
+ax_pose 18, 0x01e2, 0x80ef, 0x2c00
+ax_pose_terminator
+sHeracrossPose199:
+ax_pose 20, 0x01e4, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose200:
+ax_pose 22, 0x01e4, 0x80ee, 0x2c00
+ax_pose_terminator
+sHeracrossPose201:
+ax_pose 24, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose202:
+ax_pose 22, 0x01e4, 0x90f2, 0x2c00
+ax_pose_terminator
+sHeracrossPose203:
+ax_pose 20, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sHeracrossPose204:
+ax_pose 18, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose205:
+ax_pose 15, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose206:
+ax_pose 17, 0x01e3, 0x90f3, 0x2c00
+ax_pose_terminator
+sHeracrossPose207:
+ax_pose 19, 0x01e3, 0x90f7, 0x2c00
+ax_pose_terminator
+sHeracrossPose208:
+ax_pose 21, 0x01e3, 0x90f5, 0x2c00
+ax_pose_terminator
+sHeracrossPose209:
+ax_pose 23, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose210:
+ax_pose 21, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose211:
+ax_pose 19, 0x01e3, 0x80e9, 0x2c00
+ax_pose_terminator
+sHeracrossPose212:
+ax_pose 17, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose213:
+ax_pose 0, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose214:
+ax_pose 15, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose215:
+ax_pose 41, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose216:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose217:
+ax_pose 17, 0x01e3, 0x90f2, 0x2c00
+ax_pose_terminator
+sHeracrossPose218:
+ax_pose 44, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sHeracrossPose219:
+ax_pose 6, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose220:
+ax_pose 19, 0x01e3, 0x90f6, 0x2c00
+ax_pose_terminator
+sHeracrossPose221:
+ax_pose 47, 0x01e3, 0x90f5, 0x2c00
+ax_pose_terminator
+sHeracrossPose222:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose223:
+ax_pose 21, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose224:
+ax_pose 50, 0x01e3, 0x90f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose225:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose226:
+ax_pose 23, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose227:
+ax_pose 52, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose228:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose229:
+ax_pose 21, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose230:
+ax_pose 50, 0x01e3, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose231:
+ax_pose 6, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose232:
+ax_pose 19, 0x01e3, 0x80eb, 0x2c00
+ax_pose_terminator
+sHeracrossPose233:
+ax_pose 47, 0x01e3, 0x80ec, 0x2c00
+ax_pose_terminator
+sHeracrossPose234:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose235:
+ax_pose 17, 0x01e3, 0x80ef, 0x2c00
+ax_pose_terminator
+sHeracrossPose236:
+ax_pose 44, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose237:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose238:
+ax_pose 18, 0x01e3, 0x80ef, 0x2c00
+ax_pose_terminator
+sHeracrossPose239:
+ax_pose 20, 0x01e5, 0x80ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose240:
+ax_pose 22, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sHeracrossPose241:
+ax_pose 24, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose242:
+ax_pose 22, 0x01e5, 0x90f2, 0x2c00
+ax_pose_terminator
+sHeracrossPose243:
+ax_pose 20, 0x01e5, 0x90f3, 0x2c00
+ax_pose_terminator
+sHeracrossPose244:
+ax_pose 18, 0x01e3, 0x90f1, 0x2c00
+ax_pose_terminator
+sHeracrossPose245:
+ax_pose 0, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose246:
+ax_pose 3, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose247:
+ax_pose 6, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose248:
+ax_pose 9, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sHeracrossPose249:
+ax_pose 12, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sHeracrossPose250:
+ax_pose 9, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose251:
+ax_pose 6, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sHeracrossPose252:
+ax_pose 3, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sHeracrossAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 4, 2, 27, 0, 20, 0, 20,
+ax_anim 1, 1, 24, 0, 20, 0, 20,
+ax_anim 1, 0, 25, 0, 16, 0, 19,
+ax_anim 2, 0, 25, 0, 11, 0, 17,
+ax_anim 2, 0, 25, 0, 9, 0, 15,
+ax_anim 2, 0, 25, 0, 7, 0, 13,
+ax_anim 1, 0, 25, 0, 6, 0, 12,
+ax_anim 1, 0, 25, 0, 7, 0, 11,
+ax_anim 2, 0, 25, 0, 9, 0, 9,
+ax_anim_terminator
+sHeracrossAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 4, 2, 31, 20, 20, 20, 20,
+ax_anim 1, 1, 28, 20, 20, 20, 20,
+ax_anim 1, 0, 29, 19, 14, 19, 19,
+ax_anim 2, 0, 29, 17, 8, 17, 17,
+ax_anim 2, 0, 29, 15, 6, 15, 15,
+ax_anim 2, 0, 29, 13, 5, 13, 13,
+ax_anim 1, 0, 29, 12, 6, 12, 12,
+ax_anim 1, 0, 29, 11, 7, 11, 11,
+ax_anim 2, 0, 29, 9, 9, 9, 9,
+ax_anim_terminator
+sHeracrossAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 4, 2, 35, 20, 0, 20, 0,
+ax_anim 1, 1, 32, 20, 0, 20, 0,
+ax_anim 1, 0, 33, 19, -3, 19, 0,
+ax_anim 2, 0, 33, 17, -6, 17, 0,
+ax_anim 2, 0, 33, 15, -8, 15, 0,
+ax_anim 2, 0, 33, 13, -9, 13, 0,
+ax_anim 1, 0, 33, 12, -7, 12, 0,
+ax_anim 1, 0, 33, 11, -3, 11, 0,
+ax_anim 2, 0, 33, 9, 0, 9, 0,
+ax_anim_terminator
+sHeracrossAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 4, -4, 4, -4,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 4, 2, 39, 20, -20, 20, -20,
+ax_anim 1, 1, 36, 20, -20, 20, -20,
+ax_anim 1, 0, 37, 19, -24, 19, -19,
+ax_anim 2, 0, 37, 17, -25, 17, -17,
+ax_anim 2, 0, 37, 15, -26, 15, -15,
+ax_anim 2, 0, 37, 13, -20, 13, -13,
+ax_anim 1, 0, 37, 12, -16, 12, -12,
+ax_anim 1, 0, 37, 11, -12, 11, -11,
+ax_anim 2, 0, 37, 9, -9, 9, -9,
+ax_anim_terminator
+sHeracrossAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -10, 0, -10,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 4, 2, 43, 0, -20, 0, -20,
+ax_anim 1, 1, 40, 0, -20, 0, -20,
+ax_anim 1, 0, 41, 0, -24, 0, -19,
+ax_anim 2, 0, 41, 0, -23, 0, -17,
+ax_anim 2, 0, 41, 0, -22, 0, -15,
+ax_anim 2, 0, 41, 0, -20, 0, -13,
+ax_anim 1, 0, 41, 0, -16, 0, -12,
+ax_anim 1, 0, 41, 0, -12, 0, -11,
+ax_anim 2, 0, 41, 0, -9, 0, -9,
+ax_anim_terminator
+sHeracrossAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 47, -4, -4, -4, -4,
+ax_anim 1, 0, 47, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -20, -20, -20, -20,
+ax_anim 4, 2, 47, -20, -20, -20, -20,
+ax_anim 1, 1, 44, -20, -20, -20, -20,
+ax_anim 1, 0, 45, -19, -24, -19, -19,
+ax_anim 2, 0, 45, -17, -25, -17, -17,
+ax_anim 2, 0, 45, -15, -26, -15, -15,
+ax_anim 2, 0, 45, -13, -20, -13, -13,
+ax_anim 1, 0, 45, -12, -16, -12, -12,
+ax_anim 1, 0, 45, -11, -12, -11, -11,
+ax_anim 2, 0, 45, -9, -9, -9, -9,
+ax_anim_terminator
+sHeracrossAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 4, 2, 51, -20, 0, -20, 0,
+ax_anim 1, 1, 48, -20, 0, -20, 0,
+ax_anim 1, 0, 49, -19, -3, -19, 0,
+ax_anim 2, 0, 49, -17, -6, -17, 0,
+ax_anim 2, 0, 49, -15, -8, -15, 0,
+ax_anim 2, 0, 49, -13, -9, -13, 0,
+ax_anim 1, 0, 49, -12, -7, -12, 0,
+ax_anim 1, 0, 49, -11, -3, -11, 0,
+ax_anim 2, 0, 49, -9, 0, -9, 0,
+ax_anim_terminator
+sHeracrossAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 4, 2, 55, -20, 20, -20, 20,
+ax_anim 1, 1, 52, -20, 20, -20, 20,
+ax_anim 1, 0, 53, -19, 14, -19, 19,
+ax_anim 2, 0, 53, -17, 8, -17, 17,
+ax_anim 2, 0, 53, -15, 6, -15, 15,
+ax_anim 2, 0, 53, -13, 5, -13, 13,
+ax_anim 1, 0, 53, -12, 6, -12, 12,
+ax_anim 1, 0, 53, -11, 7, -11, 11,
+ax_anim 2, 0, 53, -9, 9, -9, 9,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 4, 0, 59, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, -1, 0, -4,
+ax_anim 1, 0, 60, 0, 3, 0, 3,
+ax_anim 2, 0, 60, 0, 12, 0, 12,
+ax_anim 2, 1, 61, 1, 12, 1, 12,
+ax_anim 2, 0, 61, 0, 12, 0, 12,
+ax_anim 2, 0, 61, 1, 12, 1, 12,
+ax_anim 2, 0, 61, 0, 12, 0, 12,
+ax_anim 2, 0, 61, 1, 12, 1, 12,
+ax_anim 2, 0, 61, 0, 12, 0, 12,
+ax_anim 2, 0, 56, 0, 8, 0, 8,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sHeracrossAnims_3_2:
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 2, 0, 64, -2, -2, -2, -2,
+ax_anim 4, 0, 65, -4, -4, -4, -4,
+ax_anim 1, 2, 65, -1, -1, -1, -1,
+ax_anim 1, 0, 66, 5, 5, 5, 5,
+ax_anim 2, 0, 66, 16, 17, 16, 17,
+ax_anim 2, 1, 67, 17, 17, 17, 17,
+ax_anim 2, 0, 67, 16, 17, 16, 17,
+ax_anim 2, 0, 67, 17, 17, 17, 17,
+ax_anim 2, 0, 67, 16, 17, 16, 17,
+ax_anim 2, 0, 67, 17, 17, 17, 17,
+ax_anim 2, 0, 67, 16, 17, 16, 17,
+ax_anim 2, 0, 62, 8, 8, 8, 8,
+ax_anim 2, 0, 62, 3, 3, 3, 3,
+ax_anim_terminator
+sHeracrossAnims_3_3:
+ax_anim 2, 0, 68, -1, 0, -1, 0,
+ax_anim 2, 0, 70, -2, 0, -2, 0,
+ax_anim 4, 0, 71, -4, 0, -4, 0,
+ax_anim 1, 2, 71, -1, 0, -1, 0,
+ax_anim 1, 0, 72, 5, 0, 5, 0,
+ax_anim 2, 0, 72, 10, 0, 10, 0,
+ax_anim 2, 1, 73, 10, 1, 10, 1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 73, 10, 1, 10, 1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 73, 10, 1, 10, 1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 68, 6, 0, 6, 0,
+ax_anim 2, 0, 68, 2, 0, 2, 0,
+ax_anim_terminator
+sHeracrossAnims_3_4:
+ax_anim 2, 0, 74, -1, 1, -1, 1,
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 4, 0, 77, -4, 4, -4, 4,
+ax_anim 1, 2, 77, -1, 1, -1, 1,
+ax_anim 1, 0, 78, 5, -5, 5, -5,
+ax_anim 2, 0, 78, 15, -13, 15, -13,
+ax_anim 2, 1, 79, 16, -12, 16, -12,
+ax_anim 2, 0, 79, 15, -13, 15, -13,
+ax_anim 2, 0, 79, 16, -12, 16, -12,
+ax_anim 2, 0, 79, 15, -13, 15, -13,
+ax_anim 2, 0, 79, 16, -12, 16, -12,
+ax_anim 2, 0, 79, 15, -13, 15, -13,
+ax_anim 2, 0, 74, 8, -8, 8, -8,
+ax_anim 2, 0, 74, 3, -3, 3, -3,
+ax_anim_terminator
+sHeracrossAnims_3_5:
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 0, 82, 0, 2, 0, 2,
+ax_anim 4, 0, 83, 0, 4, 0, 4,
+ax_anim 1, 2, 83, 0, 1, 0, 1,
+ax_anim 1, 0, 84, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 1, 85, 1, -10, 1, -10,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 85, 1, -10, 1, -10,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 85, 1, -10, 1, -10,
+ax_anim 2, 0, 85, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -6, 0, -6,
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim_terminator
+sHeracrossAnims_3_6:
+ax_anim 2, 0, 86, 1, 1, 1, 1,
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 4, 0, 89, 4, 4, 4, 4,
+ax_anim 1, 2, 89, 1, 1, 1, 1,
+ax_anim 1, 0, 90, -5, -5, -5, -5,
+ax_anim 2, 0, 90, -15, -13, -15, -13,
+ax_anim 2, 1, 91, -16, -12, -16, -12,
+ax_anim 2, 0, 91, -15, -13, -15, -13,
+ax_anim 2, 0, 91, -16, -12, -16, -12,
+ax_anim 2, 0, 91, -15, -13, -15, -13,
+ax_anim 2, 0, 91, -16, -12, -16, -12,
+ax_anim 2, 0, 91, -15, -13, -15, -13,
+ax_anim 2, 0, 86, -8, -8, -8, -8,
+ax_anim 2, 0, 86, -3, -3, -3, -3,
+ax_anim_terminator
+sHeracrossAnims_3_7:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim 4, 0, 95, 4, 0, 4, 0,
+ax_anim 1, 2, 95, 1, 0, 1, 0,
+ax_anim 1, 0, 96, -5, 0, -5, 0,
+ax_anim 2, 0, 96, -10, 0, -10, 0,
+ax_anim 2, 1, 97, -10, 1, -10, 1,
+ax_anim 2, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -10, 1, -10, 1,
+ax_anim 2, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -10, 1, -10, 1,
+ax_anim 2, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 92, -6, 0, -6, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim_terminator
+sHeracrossAnims_3_8:
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 4, 0, 101, 4, -4, 4, -4,
+ax_anim 1, 2, 101, 1, -1, 1, -1,
+ax_anim 1, 0, 102, -5, 5, -5, 5,
+ax_anim 2, 0, 102, -16, 17, -16, 17,
+ax_anim 2, 1, 103, -17, 17, -17, 17,
+ax_anim 2, 0, 103, -16, 17, -16, 17,
+ax_anim 2, 0, 103, -17, 17, -17, 17,
+ax_anim 2, 0, 103, -16, 17, -16, 17,
+ax_anim 2, 0, 103, -17, 17, -17, 17,
+ax_anim 2, 0, 103, -16, 17, -16, 17,
+ax_anim 2, 0, 98, -8, 8, -8, 8,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_4_1:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 1, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_4_2:
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_4_3:
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_4_4:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_4_5:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_4_6:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_4_7:
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_4_8:
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_5_1:
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 2, 0, 2,
+ax_anim 2, 0, 117, 0, 4, 0, 4,
+ax_anim 2, 1, 117, 1, 4, 1, 4,
+ax_anim 2, 0, 117, 0, 4, 0, 4,
+ax_anim 2, 0, 117, 1, 4, 1, 4,
+ax_anim 2, 0, 117, 0, 4, 0, 4,
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim_terminator
+sHeracrossAnims_5_2:
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 2, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 125, 4, 4, 4, 4,
+ax_anim 2, 1, 125, 5, 3, 5, 3,
+ax_anim 2, 0, 125, 4, 4, 4, 4,
+ax_anim 2, 0, 125, 5, 3, 5, 3,
+ax_anim 2, 0, 125, 4, 4, 4, 4,
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim_terminator
+sHeracrossAnims_5_3:
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 1, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 2, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 2, 0, 2, 0,
+ax_anim 2, 0, 131, 4, 0, 4, 0,
+ax_anim 2, 1, 131, 4, 1, 4, 1,
+ax_anim 2, 0, 131, 4, 0, 4, 0,
+ax_anim 2, 0, 131, 4, 1, 4, 1,
+ax_anim 2, 0, 131, 4, 0, 4, 0,
+ax_anim 2, 0, 126, 2, 0, 2, 0,
+ax_anim_terminator
+sHeracrossAnims_5_4:
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 2, -2, 2, -2,
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 2, 1, 137, 5, -3, 5, -3,
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 2, 0, 137, 5, -3, 5, -3,
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 2, 0, 132, 2, -2, 2, -2,
+ax_anim_terminator
+sHeracrossAnims_5_5:
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 2, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -2, 0, -2,
+ax_anim 2, 0, 143, 0, -4, 0, -4,
+ax_anim 2, 1, 143, 1, -4, 1, -4,
+ax_anim 2, 0, 143, 0, -4, 0, -4,
+ax_anim 2, 0, 143, 1, -4, 1, -4,
+ax_anim 2, 0, 143, 0, -4, 0, -4,
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim_terminator
+sHeracrossAnims_5_6:
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 2, 0, 0, 0,
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 2, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, -2, -2, -2, -2,
+ax_anim 2, 0, 149, -4, -4, -4, -4,
+ax_anim 2, 1, 149, -5, -3, -5, -3,
+ax_anim 2, 0, 149, -4, -4, -4, -4,
+ax_anim 2, 0, 149, -5, -3, -5, -3,
+ax_anim 2, 0, 149, -4, -4, -4, -4,
+ax_anim 2, 0, 144, -2, -2, -2, -2,
+ax_anim_terminator
+sHeracrossAnims_5_7:
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 0, 158, -1, 0, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 146, -2, 0, 0, 0,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 2, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -2, 0, -2, 0,
+ax_anim 2, 0, 155, -4, 0, -4, 0,
+ax_anim 2, 1, 155, -4, 1, -4, 1,
+ax_anim 2, 0, 155, -4, 0, -4, 0,
+ax_anim 2, 0, 155, -4, 1, -4, 1,
+ax_anim 2, 0, 155, -4, 0, -4, 0,
+ax_anim 2, 0, 150, -2, 0, -2, 0,
+ax_anim_terminator
+sHeracrossAnims_5_8:
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, 0, 0, 0,
+ax_anim 6, 2, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, -2, 2, -2, 2,
+ax_anim 2, 0, 161, -4, 4, -4, 4,
+ax_anim 2, 1, 161, -5, 3, -5, 3,
+ax_anim 2, 0, 161, -4, 4, -4, 4,
+ax_anim 2, 0, 161, -5, 3, -5, 3,
+ax_anim 2, 0, 161, -4, 4, -4, 4,
+ax_anim 2, 0, 156, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_6_1:
+ax_anim 30, 0, 162, 0, 0, 0, 0,
+ax_anim 35, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_7_1:
+ax_anim 2, 0, 164, 0, -2, 0, -2,
+ax_anim 8, 0, 164, 0, -3, 0, -3,
+ax_anim_terminator
+sHeracrossAnims_7_2:
+ax_anim 2, 0, 165, -2, -2, -2, -2,
+ax_anim 8, 0, 165, -3, -3, -3, -3,
+ax_anim_terminator
+sHeracrossAnims_7_3:
+ax_anim 2, 0, 166, -2, 0, -2, 0,
+ax_anim 8, 0, 166, -3, 0, -3, 0,
+ax_anim_terminator
+sHeracrossAnims_7_4:
+ax_anim 2, 0, 167, -2, 2, -2, 2,
+ax_anim 8, 0, 167, -3, 3, -3, 3,
+ax_anim_terminator
+sHeracrossAnims_7_5:
+ax_anim 2, 0, 168, 0, 2, 0, 2,
+ax_anim 8, 0, 168, 0, 3, 0, 3,
+ax_anim_terminator
+sHeracrossAnims_7_6:
+ax_anim 2, 0, 169, 2, 2, 2, 2,
+ax_anim 8, 0, 169, 3, 3, 3, 3,
+ax_anim_terminator
+sHeracrossAnims_7_7:
+ax_anim 2, 0, 170, 2, 0, 2, 0,
+ax_anim 8, 0, 170, 3, 0, 3, 0,
+ax_anim_terminator
+sHeracrossAnims_7_8:
+ax_anim 2, 0, 171, 2, -2, 2, -2,
+ax_anim 8, 0, 171, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_8_1:
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_8_2:
+ax_anim 30, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_8_3:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_8_4:
+ax_anim 30, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_8_5:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_8_6:
+ax_anim 30, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim 4, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_8_7:
+ax_anim 30, 0, 190, 0, 0, 0, 0,
+ax_anim 8, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 190, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim 4, 0, 190, 0, 0, 0, 0,
+ax_anim 8, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_8_8:
+ax_anim 30, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 195, 0, 0, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_9_1:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 6, 3, 6, 3,
+ax_anim 2, 0, 198, 8, 9, 8, 9,
+ax_anim 2, 0, 199, 7, 16, 7, 16,
+ax_anim 3, 0, 200, 0, 19, 0, 19,
+ax_anim 2, 3, 201, -7, 16, -7, 16,
+ax_anim 2, 0, 202, -8, 9, -8, 9,
+ax_anim 1, 0, 203, -6, 3, -6, 3,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_9_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 8, 0, 8, 0,
+ax_anim 2, 0, 197, 17, 3, 17, 3,
+ax_anim 2, 0, 198, 21, 12, 21, 12,
+ax_anim 3, 0, 199, 19, 19, 19, 19,
+ax_anim 2, 3, 200, 11, 19, 11, 19,
+ax_anim 2, 0, 201, 3, 15, 3, 15,
+ax_anim 1, 0, 202, -1, 9, -1, 9,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_9_3:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 3, -5, 3, -5,
+ax_anim 2, 0, 196, 11, -6, 11, -6,
+ax_anim 2, 0, 197, 18, -5, 18, -5,
+ax_anim 3, 0, 198, 21, -2, 21, -2,
+ax_anim 2, 3, 199, 18, 4, 18, 4,
+ax_anim 2, 0, 200, 12, 5, 12, 5,
+ax_anim 1, 0, 201, 4, 5, 4, 5,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_9_4:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -1, -8, -1, -8,
+ax_anim 2, 0, 203, 4, -16, 4, -16,
+ax_anim 2, 0, 196, 12, -23, 12, -23,
+ax_anim 3, 0, 197, 20, -23, 20, -23,
+ax_anim 2, 3, 198, 22, -15, 22, -15,
+ax_anim 2, 0, 199, 17, -4, 17, -4,
+ax_anim 1, 0, 200, 7, -1, 7, -1,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_9_5:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, -8, -4, -8, -4,
+ax_anim 2, 0, 202, -9, -12, -9, -12,
+ax_anim 2, 0, 203, -7, -19, -7, -19,
+ax_anim 3, 0, 196, 0, -23, 0, -23,
+ax_anim 2, 3, 197, 7, -19, 7, -19,
+ax_anim 2, 0, 198, 9, -12, 9, -12,
+ax_anim 1, 0, 199, 8, -4, 8, -4,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_9_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 1, -8, 1, -8,
+ax_anim 2, 0, 197, -4, -16, -4, -16,
+ax_anim 2, 0, 196, -12, -23, -12, -23,
+ax_anim 3, 0, 203, -20, -23, -20, -23,
+ax_anim 2, 3, 202, -22, -15, -22, -15,
+ax_anim 2, 0, 201, -17, -4, -17, -4,
+ax_anim 1, 0, 200, -7, -1, -7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_9_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 197, -3, -5, -3, -5,
+ax_anim 2, 0, 196, -11, -6, -11, -6,
+ax_anim 2, 0, 203, -18, -5, -18, -5,
+ax_anim 3, 0, 202, -21, -2, -21, -2,
+ax_anim 2, 3, 201, -18, 4, -18, 4,
+ax_anim 2, 0, 200, -12, 5, -12, 5,
+ax_anim 1, 0, 199, -4, 5, -4, 5,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_9_8:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, -8, 0, -8, 0,
+ax_anim 2, 0, 203, -17, 3, -17, 3,
+ax_anim 2, 0, 202, -21, 12, -21, 12,
+ax_anim 3, 0, 201, -19, 19, -19, 19,
+ax_anim 2, 3, 200, -11, 19, -11, 19,
+ax_anim 2, 0, 199, -3, 15, -3, 15,
+ax_anim 1, 0, 198, 1, 9, 1, 9,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_10_1:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 6, 0, 6, 0,
+ax_anim 2, 0, 204, -6, 0, -6, 0,
+ax_anim 2, 0, 204, 10, 0, 10, 0,
+ax_anim 2, 0, 204, -10, 0, -10, 0,
+ax_anim 2, 0, 204, 12, 0, 12, 0,
+ax_anim 3, 0, 204, -12, 0, -12, 0,
+ax_anim 3, 0, 204, 13, 0, 13, 0,
+ax_anim 3, 0, 204, -13, 0, -13, 0,
+ax_anim 2, 0, 204, 12, 0, 12, 0,
+ax_anim 3, 0, 204, -12, 0, -12, 0,
+ax_anim 2, 0, 204, 10, 0, 10, 0,
+ax_anim 2, 0, 204, -10, 0, -10, 0,
+ax_anim 2, 0, 204, 6, 0, 6, 0,
+ax_anim 2, 0, 204, -6, 0, -6, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_10_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 6, -6, 6, -6,
+ax_anim 2, 0, 205, -6, 6, -6, 6,
+ax_anim 2, 0, 205, 10, -10, 10, -10,
+ax_anim 2, 0, 205, -10, 10, -10, 10,
+ax_anim 2, 0, 205, 12, -12, 12, -12,
+ax_anim 3, 0, 205, -12, 12, -12, 12,
+ax_anim 3, 0, 205, 13, -13, 13, -13,
+ax_anim 3, 0, 205, -13, 13, -13, 13,
+ax_anim 2, 0, 205, 12, -12, 12, -12,
+ax_anim 3, 0, 205, -12, 12, -12, 12,
+ax_anim 2, 0, 205, 10, -10, 10, -10,
+ax_anim 2, 0, 205, -10, 10, -10, 10,
+ax_anim 2, 0, 205, 6, -6, 6, -6,
+ax_anim 2, 0, 205, -6, 6, -6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_10_3:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, -6, 0, -6,
+ax_anim 2, 0, 206, 0, 6, 0, 6,
+ax_anim 2, 0, 206, 0, -10, 0, -10,
+ax_anim 2, 0, 206, 0, 10, 0, 10,
+ax_anim 2, 0, 206, 0, -12, 0, -12,
+ax_anim 3, 0, 206, 0, 12, 0, 12,
+ax_anim 3, 0, 206, 0, -13, 0, -13,
+ax_anim 3, 0, 206, 0, 13, 0, 13,
+ax_anim 2, 0, 206, 0, -12, 0, -12,
+ax_anim 3, 0, 206, 0, 12, 0, 12,
+ax_anim 2, 0, 206, 0, -10, 0, -10,
+ax_anim 2, 0, 206, 0, 10, 0, 10,
+ax_anim 2, 0, 206, 0, -6, 0, -6,
+ax_anim 2, 0, 206, 0, 6, 0, 6,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_10_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -6, -6, -6, -6,
+ax_anim 2, 0, 207, 6, 6, 6, 6,
+ax_anim 2, 0, 207, -10, -10, -10, -10,
+ax_anim 2, 0, 207, 10, 10, 10, 10,
+ax_anim 2, 0, 207, -12, -12, -12, -12,
+ax_anim 3, 0, 207, 12, 12, 12, 12,
+ax_anim 3, 0, 207, -13, -13, -13, -13,
+ax_anim 3, 0, 207, 13, 13, 13, 13,
+ax_anim 2, 0, 207, -12, -12, -12, -12,
+ax_anim 3, 0, 207, 12, 12, 12, 12,
+ax_anim 2, 0, 207, -10, -10, -10, -10,
+ax_anim 2, 0, 207, 10, 10, 10, 10,
+ax_anim 2, 0, 207, -6, -6, -6, -6,
+ax_anim 2, 0, 207, 6, 6, 6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_10_5:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 6, 0, 6, 0,
+ax_anim 2, 0, 208, -6, 0, -6, 0,
+ax_anim 2, 0, 208, 10, 0, 10, 0,
+ax_anim 2, 0, 208, -10, 0, -10, 0,
+ax_anim 2, 0, 208, 12, 0, 12, 0,
+ax_anim 3, 0, 208, -12, 0, -12, 0,
+ax_anim 3, 0, 208, 13, 0, 13, 0,
+ax_anim 3, 0, 208, -13, 0, -13, 0,
+ax_anim 2, 0, 208, 12, 0, 12, 0,
+ax_anim 3, 0, 208, -12, 0, -12, 0,
+ax_anim 2, 0, 208, 10, 0, 10, 0,
+ax_anim 2, 0, 208, -10, 0, -10, 0,
+ax_anim 2, 0, 208, 6, 0, 6, 0,
+ax_anim 2, 0, 208, -6, 0, -6, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_10_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 6, -6, 6, -6,
+ax_anim 2, 0, 209, -6, 6, -6, 6,
+ax_anim 2, 0, 209, 10, -10, 10, -10,
+ax_anim 2, 0, 209, -10, 10, -10, 10,
+ax_anim 2, 0, 209, 12, -12, 12, -12,
+ax_anim 3, 0, 209, -12, 12, -12, 12,
+ax_anim 3, 0, 209, 13, -13, 13, -13,
+ax_anim 3, 0, 209, -13, 13, -13, 13,
+ax_anim 2, 0, 209, 12, -12, 12, -12,
+ax_anim 3, 0, 209, -12, 12, -12, 12,
+ax_anim 2, 0, 209, 10, -10, 10, -10,
+ax_anim 2, 0, 209, -10, 10, -10, 10,
+ax_anim 2, 0, 209, 6, -6, 6, -6,
+ax_anim 2, 0, 209, -6, 6, -6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_10_7:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, -6, 0, -6,
+ax_anim 2, 0, 210, 0, 6, 0, 6,
+ax_anim 2, 0, 210, 0, -10, 0, -10,
+ax_anim 2, 0, 210, 0, 10, 0, 10,
+ax_anim 2, 0, 210, 0, -12, 0, -12,
+ax_anim 3, 0, 210, 0, 12, 0, 12,
+ax_anim 3, 0, 210, 0, -13, 0, -13,
+ax_anim 3, 0, 210, 0, 13, 0, 13,
+ax_anim 2, 0, 210, 0, -12, 0, -12,
+ax_anim 3, 0, 210, 0, 12, 0, 12,
+ax_anim 2, 0, 210, 0, -10, 0, -10,
+ax_anim 2, 0, 210, 0, 10, 0, 10,
+ax_anim 2, 0, 210, 0, -6, 0, -6,
+ax_anim 2, 0, 210, 0, 6, 0, 6,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_10_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -6, -6, -6, -6,
+ax_anim 2, 0, 211, 6, 6, 6, 6,
+ax_anim 2, 0, 211, -10, -10, -10, -10,
+ax_anim 2, 0, 211, 10, 10, 10, 10,
+ax_anim 2, 0, 211, -12, -12, -12, -12,
+ax_anim 3, 0, 211, 12, 12, 12, 12,
+ax_anim 3, 0, 211, -13, -13, -13, -13,
+ax_anim 3, 0, 211, 13, 13, 13, 13,
+ax_anim 2, 0, 211, -12, -12, -12, -12,
+ax_anim 3, 0, 211, 12, 12, 12, 12,
+ax_anim 2, 0, 211, -10, -10, -10, -10,
+ax_anim 2, 0, 211, 10, 10, 10, 10,
+ax_anim 2, 0, 211, -6, -6, -6, -6,
+ax_anim 2, 0, 211, 6, 6, 6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_11_1:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -19, 0, 0,
+ax_anim 4, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -24, 0, 0,
+ax_anim 2, 0, 214, 0, -20, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_11_2:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -22, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_11_3:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -22, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_11_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 223, 0, -21, 0, 0,
+ax_anim 2, 0, 223, 0, -17, 0, 0,
+ax_anim 1, 0, 223, 0, -11, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_11_5:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -20, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_11_6:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_11_7:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -22, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_11_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -22, 0, 0,
+ax_anim 2, 0, 235, 0, -18, 0, 0,
+ax_anim 1, 0, 235, 0, -12, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_12_1:
+ax_anim 2, 0, 236, 1, 0, 1, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, 0, 1, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, 0, 1, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, 0, 1, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, 0, 1, 0,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_12_2:
+ax_anim 2, 0, 243, 1, -1, 1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, -1, 1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, -1, 1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, -1, 1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, -1, 1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_12_3:
+ax_anim 2, 0, 242, 0, -1, 0, -1,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, -1, 0, -1,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, -1, 0, -1,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, -1, 0, -1,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, -1, 0, -1,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_12_4:
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_12_5:
+ax_anim 2, 0, 240, 1, 0, 1, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 1, 0, 1, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 1, 0, 1, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 1, 0, 1, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 1, 0, 1, 0,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_12_6:
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_12_7:
+ax_anim 2, 0, 238, 0, -1, 0, -1,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, -1, 0, -1,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, -1, 0, -1,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, -1, 0, -1,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, -1, 0, -1,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_12_8:
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHeracrossAnims_13_1:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_13_2:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_13_3:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_13_4:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_13_5:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_13_6:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_13_7:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossAnims_13_8:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sHeracrossGfx1:
+.incbin "baserom.gba", 0xEA5E48, 0x200
+sHeracrossSprites1:
+ax_sprite sHeracrossGfx1, 0x200
+ax_sprite_terminator
+sHeracrossGfx2:
+.incbin "baserom.gba", 0xEA6058, 0x200
+sHeracrossSprites2:
+ax_sprite sHeracrossGfx2, 0x200
+ax_sprite_terminator
+sHeracrossGfx3:
+.incbin "baserom.gba", 0xEA6268, 0x200
+sHeracrossSprites3:
+ax_sprite sHeracrossGfx3, 0x200
+ax_sprite_terminator
+sHeracrossGfx4:
+.incbin "baserom.gba", 0xEA6478, 0x200
+sHeracrossSprites4:
+ax_sprite sHeracrossGfx4, 0x200
+ax_sprite_terminator
+sHeracrossGfx5:
+.incbin "baserom.gba", 0xEA6688, 0x200
+sHeracrossSprites5:
+ax_sprite sHeracrossGfx5, 0x200
+ax_sprite_terminator
+sHeracrossGfx6:
+.incbin "baserom.gba", 0xEA6898, 0x200
+sHeracrossSprites6:
+ax_sprite sHeracrossGfx6, 0x200
+ax_sprite_terminator
+sHeracrossGfx7:
+.incbin "baserom.gba", 0xEA6AA8, 0x200
+sHeracrossSprites7:
+ax_sprite sHeracrossGfx7, 0x200
+ax_sprite_terminator
+sHeracrossGfx8:
+.incbin "baserom.gba", 0xEA6CB8, 0x200
+sHeracrossSprites8:
+ax_sprite sHeracrossGfx8, 0x200
+ax_sprite_terminator
+sHeracrossGfx9:
+.incbin "baserom.gba", 0xEA6EC8, 0x200
+sHeracrossSprites9:
+ax_sprite sHeracrossGfx9, 0x200
+ax_sprite_terminator
+sHeracrossGfx10:
+.incbin "baserom.gba", 0xEA70D8, 0x200
+sHeracrossSprites10:
+ax_sprite sHeracrossGfx10, 0x200
+ax_sprite_terminator
+sHeracrossGfx11:
+.incbin "baserom.gba", 0xEA72E8, 0x200
+sHeracrossSprites11:
+ax_sprite sHeracrossGfx11, 0x200
+ax_sprite_terminator
+sHeracrossGfx12:
+.incbin "baserom.gba", 0xEA74F8, 0x200
+sHeracrossSprites12:
+ax_sprite sHeracrossGfx12, 0x200
+ax_sprite_terminator
+sHeracrossGfx13:
+.incbin "baserom.gba", 0xEA7708, 0x200
+sHeracrossSprites13:
+ax_sprite sHeracrossGfx13, 0x200
+ax_sprite_terminator
+sHeracrossGfx14:
+.incbin "baserom.gba", 0xEA7918, 0x200
+sHeracrossSprites14:
+ax_sprite sHeracrossGfx14, 0x200
+ax_sprite_terminator
+sHeracrossGfx15:
+.incbin "baserom.gba", 0xEA7B28, 0x200
+sHeracrossSprites15:
+ax_sprite sHeracrossGfx15, 0x200
+ax_sprite_terminator
+sHeracrossGfx16:
+.incbin "baserom.gba", 0xEA7D38, 0x40
+sHeracrossGfx16_1:
+.incbin "baserom.gba", 0xEA7D78, 0x160
+sHeracrossSprites16:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx16_1, 0x160
+ax_sprite_terminator
+sHeracrossGfx17:
+.incbin "baserom.gba", 0xEA7F00, 0x100
+sHeracrossSprites17:
+ax_sprite 0, 0x100
+ax_sprite sHeracrossGfx17, 0x100
+ax_sprite_terminator
+sHeracrossGfx18:
+.incbin "baserom.gba", 0xEA8018, 0x60
+sHeracrossGfx18_1:
+.incbin "baserom.gba", 0xEA8078, 0xE0
+sHeracrossGfx18_2:
+.incbin "baserom.gba", 0xEA8158, 0x60
+sHeracrossSprites18:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx18_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx18_2, 0x60
+ax_sprite_terminator
+sHeracrossGfx19:
+.incbin "baserom.gba", 0xEA81F0, 0x100
+sHeracrossSprites19:
+ax_sprite 0, 0x100
+ax_sprite sHeracrossGfx19, 0x100
+ax_sprite_terminator
+sHeracrossGfx20:
+.incbin "baserom.gba", 0xEA8308, 0x40
+sHeracrossGfx20_1:
+.incbin "baserom.gba", 0xEA8348, 0x60
+sHeracrossGfx20_2:
+.incbin "baserom.gba", 0xEA83A8, 0x60
+sHeracrossGfx20_3:
+.incbin "baserom.gba", 0xEA8408, 0x40
+sHeracrossSprites20:
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx20_3, 0x40
+ax_sprite_terminator
+sHeracrossGfx21:
+.incbin "baserom.gba", 0xEA8490, 0x60
+sHeracrossGfx21_1:
+.incbin "baserom.gba", 0xEA84F0, 0x80
+sHeracrossGfx21_2:
+.incbin "baserom.gba", 0xEA8570, 0x60
+sHeracrossSprites21:
+ax_sprite 0, 0x80
+ax_sprite sHeracrossGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx21_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx21_2, 0x60
+ax_sprite_terminator
+sHeracrossGfx22:
+.incbin "baserom.gba", 0xEA8608, 0x40
+sHeracrossGfx22_1:
+.incbin "baserom.gba", 0xEA8648, 0x40
+sHeracrossGfx22_2:
+.incbin "baserom.gba", 0xEA8688, 0x60
+sHeracrossGfx22_3:
+.incbin "baserom.gba", 0xEA86E8, 0x60
+sHeracrossSprites22:
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx22_3, 0x60
+ax_sprite_terminator
+sHeracrossGfx23:
+.incbin "baserom.gba", 0xEA8790, 0x40
+sHeracrossGfx23_1:
+.incbin "baserom.gba", 0xEA87D0, 0x180
+sHeracrossSprites23:
+ax_sprite sHeracrossGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx23_1, 0x180
+ax_sprite_terminator
+sHeracrossGfx24:
+.incbin "baserom.gba", 0xEA8970, 0x40
+sHeracrossGfx24_1:
+.incbin "baserom.gba", 0xEA89B0, 0x40
+sHeracrossGfx24_2:
+.incbin "baserom.gba", 0xEA89F0, 0x100
+sHeracrossSprites24:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx24_2, 0x100
+ax_sprite_terminator
+sHeracrossGfx25:
+.incbin "baserom.gba", 0xEA8B28, 0x40
+sHeracrossGfx25_1:
+.incbin "baserom.gba", 0xEA8B68, 0x40
+sHeracrossGfx25_2:
+.incbin "baserom.gba", 0xEA8BA8, 0x100
+sHeracrossSprites25:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx25_2, 0x100
+ax_sprite_terminator
+sHeracrossGfx26:
+.incbin "baserom.gba", 0xEA8CE0, 0x40
+sHeracrossGfx26_1:
+.incbin "baserom.gba", 0xEA8D20, 0x60
+sHeracrossGfx26_2:
+.incbin "baserom.gba", 0xEA8D80, 0x60
+sHeracrossGfx26_3:
+.incbin "baserom.gba", 0xEA8DE0, 0x80
+sHeracrossSprites26:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx26_3, 0x80
+ax_sprite_terminator
+sHeracrossGfx27:
+.incbin "baserom.gba", 0xEA8EA8, 0x20
+sHeracrossGfx27_1:
+.incbin "baserom.gba", 0xEA8EC8, 0x20
+sHeracrossGfx27_2:
+.incbin "baserom.gba", 0xEA8EE8, 0x60
+sHeracrossGfx27_3:
+.incbin "baserom.gba", 0xEA8F48, 0x60
+sHeracrossSprites27:
+ax_sprite sHeracrossGfx27, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHeracrossGfx27_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHeracrossGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx28:
+.incbin "baserom.gba", 0xEA8FF0, 0x160
+sHeracrossSprites28:
+ax_sprite 0, 0xa0
+ax_sprite sHeracrossGfx28, 0x160
+ax_sprite_terminator
+sHeracrossGfx29:
+.incbin "baserom.gba", 0xEA9168, 0x40
+sHeracrossGfx29_1:
+.incbin "baserom.gba", 0xEA91A8, 0x60
+sHeracrossGfx29_2:
+.incbin "baserom.gba", 0xEA9208, 0x60
+sHeracrossGfx29_3:
+.incbin "baserom.gba", 0xEA9268, 0x40
+sHeracrossSprites29:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx30:
+.incbin "baserom.gba", 0xEA92F8, 0x20
+sHeracrossGfx30_1:
+.incbin "baserom.gba", 0xEA9318, 0x40
+sHeracrossGfx30_2:
+.incbin "baserom.gba", 0xEA9358, 0x40
+sHeracrossGfx30_3:
+.incbin "baserom.gba", 0xEA9398, 0x60
+sHeracrossSprites30:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx30_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx31:
+.incbin "baserom.gba", 0xEA9448, 0xC0
+sHeracrossGfx31_1:
+.incbin "baserom.gba", 0xEA9508, 0x40
+sHeracrossSprites31:
+ax_sprite 0, 0xa0
+ax_sprite sHeracrossGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx32:
+.incbin "baserom.gba", 0xEA9578, 0x40
+sHeracrossGfx32_1:
+.incbin "baserom.gba", 0xEA95B8, 0x60
+sHeracrossGfx32_2:
+.incbin "baserom.gba", 0xEA9618, 0x60
+sHeracrossGfx32_3:
+.incbin "baserom.gba", 0xEA9678, 0x60
+sHeracrossSprites32:
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx32_3, 0x60
+ax_sprite_terminator
+sHeracrossGfx33:
+.incbin "baserom.gba", 0xEA9720, 0xC0
+sHeracrossGfx33_1:
+.incbin "baserom.gba", 0xEA97E0, 0x40
+sHeracrossSprites33:
+ax_sprite 0, 0x80
+ax_sprite sHeracrossGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx33_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHeracrossGfx34:
+.incbin "baserom.gba", 0xEA9850, 0x40
+sHeracrossGfx34_1:
+.incbin "baserom.gba", 0xEA9890, 0x100
+sHeracrossSprites34:
+ax_sprite 0, 0xa0
+ax_sprite sHeracrossGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx34_1, 0x100
+ax_sprite_terminator
+sHeracrossGfx35:
+.incbin "baserom.gba", 0xEA99B8, 0x60
+sHeracrossGfx35_1:
+.incbin "baserom.gba", 0xEA9A18, 0x60
+sHeracrossGfx35_2:
+.incbin "baserom.gba", 0xEA9A78, 0x60
+sHeracrossGfx35_3:
+.incbin "baserom.gba", 0xEA9AD8, 0x60
+sHeracrossSprites35:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx35_3, 0x60
+ax_sprite_terminator
+sHeracrossGfx36:
+.incbin "baserom.gba", 0xEA9B80, 0x60
+sHeracrossGfx36_1:
+.incbin "baserom.gba", 0xEA9BE0, 0xC0
+sHeracrossGfx36_2:
+.incbin "baserom.gba", 0xEA9CA0, 0x60
+sHeracrossSprites36:
+ax_sprite sHeracrossGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx36_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHeracrossGfx37:
+.incbin "baserom.gba", 0xEA9D38, 0x60
+sHeracrossGfx37_1:
+.incbin "baserom.gba", 0xEA9D98, 0x60
+sHeracrossGfx37_2:
+.incbin "baserom.gba", 0xEA9DF8, 0x80
+sHeracrossSprites37:
+ax_sprite 0, 0x80
+ax_sprite sHeracrossGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx37_2, 0x80
+ax_sprite_terminator
+sHeracrossGfx38:
+.incbin "baserom.gba", 0xEA9EB0, 0x20
+sHeracrossGfx38_1:
+.incbin "baserom.gba", 0xEA9ED0, 0x40
+sHeracrossGfx38_2:
+.incbin "baserom.gba", 0xEA9F10, 0x60
+sHeracrossGfx38_3:
+.incbin "baserom.gba", 0xEA9F70, 0x40
+sHeracrossSprites38:
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx38, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx39:
+.incbin "baserom.gba", 0xEAA000, 0x60
+sHeracrossGfx39_1:
+.incbin "baserom.gba", 0xEAA060, 0x60
+sHeracrossGfx39_2:
+.incbin "baserom.gba", 0xEAA0C0, 0x20
+sHeracrossSprites39:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx39_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sHeracrossGfx39_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHeracrossGfx40:
+.incbin "baserom.gba", 0xEAA120, 0x40
+sHeracrossGfx40_1:
+.incbin "baserom.gba", 0xEAA160, 0x60
+sHeracrossGfx40_2:
+.incbin "baserom.gba", 0xEAA1C0, 0x60
+sHeracrossGfx40_3:
+.incbin "baserom.gba", 0xEAA220, 0x60
+sHeracrossSprites40:
+ax_sprite sHeracrossGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx40_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx41:
+.incbin "baserom.gba", 0xEAA2C8, 0x20
+sHeracrossGfx41_1:
+.incbin "baserom.gba", 0xEAA2E8, 0x160
+sHeracrossSprites41:
+ax_sprite 0, 0x60
+ax_sprite sHeracrossGfx41, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx41_1, 0x160
+ax_sprite_terminator
+sHeracrossGfx42:
+.incbin "baserom.gba", 0xEAA470, 0x100
+sHeracrossGfx42_1:
+.incbin "baserom.gba", 0xEAA570, 0x40
+sHeracrossSprites42:
+ax_sprite 0, 0x80
+ax_sprite sHeracrossGfx42, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx42_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx43:
+.incbin "baserom.gba", 0xEAA5E0, 0xE0
+sHeracrossGfx43_1:
+.incbin "baserom.gba", 0xEAA6C0, 0x60
+sHeracrossSprites43:
+ax_sprite 0, 0xa0
+ax_sprite sHeracrossGfx43, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx43_1, 0x60
+ax_sprite_terminator
+sHeracrossGfx44:
+.incbin "baserom.gba", 0xEAA748, 0x40
+sHeracrossGfx44_1:
+.incbin "baserom.gba", 0xEAA788, 0x60
+sHeracrossGfx44_2:
+.incbin "baserom.gba", 0xEAA7E8, 0x100
+sHeracrossSprites44:
+ax_sprite sHeracrossGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx44_2, 0x100
+ax_sprite_terminator
+sHeracrossGfx45:
+.incbin "baserom.gba", 0xEAA918, 0x20
+sHeracrossGfx45_1:
+.incbin "baserom.gba", 0xEAA938, 0x160
+sHeracrossSprites45:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx45, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx45_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHeracrossGfx46:
+.incbin "baserom.gba", 0xEAAAC8, 0x20
+sHeracrossGfx46_1:
+.incbin "baserom.gba", 0xEAAAE8, 0x60
+sHeracrossGfx46_2:
+.incbin "baserom.gba", 0xEAAB48, 0x60
+sHeracrossGfx46_3:
+.incbin "baserom.gba", 0xEAABA8, 0x60
+sHeracrossSprites46:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx46, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHeracrossGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx46_3, 0x60
+ax_sprite_terminator
+sHeracrossGfx47:
+.incbin "baserom.gba", 0xEAAC50, 0x60
+sHeracrossGfx47_1:
+.incbin "baserom.gba", 0xEAACB0, 0x60
+sHeracrossGfx47_2:
+.incbin "baserom.gba", 0xEAAD10, 0x60
+sHeracrossSprites47:
+ax_sprite 0, 0xa0
+ax_sprite sHeracrossGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx47_2, 0x60
+ax_sprite_terminator
+sHeracrossGfx48:
+.incbin "baserom.gba", 0xEAADA8, 0x160
+sHeracrossSprites48:
+ax_sprite 0, 0xa0
+ax_sprite sHeracrossGfx48, 0x160
+ax_sprite_terminator
+sHeracrossGfx49:
+.incbin "baserom.gba", 0xEAAF20, 0x40
+sHeracrossGfx49_1:
+.incbin "baserom.gba", 0xEAAF60, 0xC0
+sHeracrossGfx49_2:
+.incbin "baserom.gba", 0xEAB020, 0x60
+sHeracrossSprites49:
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx49, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx49_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx49_2, 0x60
+ax_sprite_terminator
+sHeracrossGfx50:
+.incbin "baserom.gba", 0xEAB0B8, 0x40
+sHeracrossGfx50_1:
+.incbin "baserom.gba", 0xEAB0F8, 0x180
+sHeracrossSprites50:
+ax_sprite sHeracrossGfx50, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx50_1, 0x180
+ax_sprite_terminator
+sHeracrossGfx51:
+.incbin "baserom.gba", 0xEAB298, 0x100
+sHeracrossGfx51_1:
+.incbin "baserom.gba", 0xEAB398, 0x60
+sHeracrossSprites51:
+ax_sprite 0, 0x80
+ax_sprite sHeracrossGfx51, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx51_1, 0x60
+ax_sprite_terminator
+sHeracrossGfx52:
+.incbin "baserom.gba", 0xEAB420, 0x20
+sHeracrossGfx52_1:
+.incbin "baserom.gba", 0xEAB440, 0x60
+sHeracrossGfx52_2:
+.incbin "baserom.gba", 0xEAB4A0, 0x60
+sHeracrossGfx52_3:
+.incbin "baserom.gba", 0xEAB500, 0x80
+sHeracrossSprites52:
+ax_sprite sHeracrossGfx52, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHeracrossGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx52_3, 0x80
+ax_sprite_terminator
+sHeracrossGfx53:
+.incbin "baserom.gba", 0xEAB5C0, 0x40
+sHeracrossGfx53_1:
+.incbin "baserom.gba", 0xEAB600, 0x40
+sHeracrossGfx53_2:
+.incbin "baserom.gba", 0xEAB640, 0x100
+sHeracrossSprites53:
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx53, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHeracrossGfx53_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHeracrossGfx53_2, 0x100
+ax_sprite_terminator
+sHeracrossGfx54:
+.incbin "baserom.gba", 0xEAB778, 0x200
+sHeracrossSprites54:
+ax_sprite sHeracrossGfx54, 0x200
+ax_sprite_terminator
+sHeracrossGfx55:
+.incbin "baserom.gba", 0xEAB988, 0x200
+sHeracrossSprites55:
+ax_sprite sHeracrossGfx55, 0x200
+ax_sprite_terminator
+sHeracrossGfx56:
+.incbin "baserom.gba", 0xEABB98, 0x200
+sHeracrossSprites56:
+ax_sprite sHeracrossGfx56, 0x200
+ax_sprite_terminator
+sHeracrossGfx57:
+.incbin "baserom.gba", 0xEABDA8, 0x200
+sHeracrossSprites57:
+ax_sprite sHeracrossGfx57, 0x200
+ax_sprite_terminator
+sHeracrossGfx58:
+.incbin "baserom.gba", 0xEABFB8, 0x200
+sHeracrossSprites58:
+ax_sprite sHeracrossGfx58, 0x200
+ax_sprite_terminator
+sHeracrossGfx59:
+.incbin "baserom.gba", 0xEAC1C8, 0x200
+sHeracrossSprites59:
+ax_sprite sHeracrossGfx59, 0x200
+ax_sprite_terminator
+sHeracrossGfx60:
+.incbin "baserom.gba", 0xEAC3D8, 0x200
+sHeracrossSprites60:
+ax_sprite sHeracrossGfx60, 0x200
+ax_sprite_terminator
+sAxPosesHeracross:
+.4byte sHeracrossPose1
+.4byte sHeracrossPose2
+.4byte sHeracrossPose3
+.4byte sHeracrossPose4
+.4byte sHeracrossPose5
+.4byte sHeracrossPose6
+.4byte sHeracrossPose7
+.4byte sHeracrossPose8
+.4byte sHeracrossPose9
+.4byte sHeracrossPose10
+.4byte sHeracrossPose11
+.4byte sHeracrossPose12
+.4byte sHeracrossPose13
+.4byte sHeracrossPose14
+.4byte sHeracrossPose15
+.4byte sHeracrossPose16
+.4byte sHeracrossPose17
+.4byte sHeracrossPose18
+.4byte sHeracrossPose19
+.4byte sHeracrossPose20
+.4byte sHeracrossPose21
+.4byte sHeracrossPose22
+.4byte sHeracrossPose23
+.4byte sHeracrossPose24
+.4byte sHeracrossPose25
+.4byte sHeracrossPose26
+.4byte sHeracrossPose27
+.4byte sHeracrossPose28
+.4byte sHeracrossPose29
+.4byte sHeracrossPose30
+.4byte sHeracrossPose31
+.4byte sHeracrossPose32
+.4byte sHeracrossPose33
+.4byte sHeracrossPose34
+.4byte sHeracrossPose35
+.4byte sHeracrossPose36
+.4byte sHeracrossPose37
+.4byte sHeracrossPose38
+.4byte sHeracrossPose39
+.4byte sHeracrossPose40
+.4byte sHeracrossPose41
+.4byte sHeracrossPose42
+.4byte sHeracrossPose43
+.4byte sHeracrossPose44
+.4byte sHeracrossPose45
+.4byte sHeracrossPose46
+.4byte sHeracrossPose47
+.4byte sHeracrossPose48
+.4byte sHeracrossPose49
+.4byte sHeracrossPose50
+.4byte sHeracrossPose51
+.4byte sHeracrossPose52
+.4byte sHeracrossPose53
+.4byte sHeracrossPose54
+.4byte sHeracrossPose55
+.4byte sHeracrossPose56
+.4byte sHeracrossPose57
+.4byte sHeracrossPose58
+.4byte sHeracrossPose59
+.4byte sHeracrossPose60
+.4byte sHeracrossPose61
+.4byte sHeracrossPose62
+.4byte sHeracrossPose63
+.4byte sHeracrossPose64
+.4byte sHeracrossPose65
+.4byte sHeracrossPose66
+.4byte sHeracrossPose67
+.4byte sHeracrossPose68
+.4byte sHeracrossPose69
+.4byte sHeracrossPose70
+.4byte sHeracrossPose71
+.4byte sHeracrossPose72
+.4byte sHeracrossPose73
+.4byte sHeracrossPose74
+.4byte sHeracrossPose75
+.4byte sHeracrossPose76
+.4byte sHeracrossPose77
+.4byte sHeracrossPose78
+.4byte sHeracrossPose79
+.4byte sHeracrossPose80
+.4byte sHeracrossPose81
+.4byte sHeracrossPose82
+.4byte sHeracrossPose83
+.4byte sHeracrossPose84
+.4byte sHeracrossPose85
+.4byte sHeracrossPose86
+.4byte sHeracrossPose87
+.4byte sHeracrossPose88
+.4byte sHeracrossPose89
+.4byte sHeracrossPose90
+.4byte sHeracrossPose91
+.4byte sHeracrossPose92
+.4byte sHeracrossPose93
+.4byte sHeracrossPose94
+.4byte sHeracrossPose95
+.4byte sHeracrossPose96
+.4byte sHeracrossPose97
+.4byte sHeracrossPose98
+.4byte sHeracrossPose99
+.4byte sHeracrossPose100
+.4byte sHeracrossPose101
+.4byte sHeracrossPose102
+.4byte sHeracrossPose103
+.4byte sHeracrossPose104
+.4byte sHeracrossPose105
+.4byte sHeracrossPose106
+.4byte sHeracrossPose107
+.4byte sHeracrossPose108
+.4byte sHeracrossPose109
+.4byte sHeracrossPose110
+.4byte sHeracrossPose111
+.4byte sHeracrossPose112
+.4byte sHeracrossPose113
+.4byte sHeracrossPose114
+.4byte sHeracrossPose115
+.4byte sHeracrossPose116
+.4byte sHeracrossPose117
+.4byte sHeracrossPose118
+.4byte sHeracrossPose119
+.4byte sHeracrossPose120
+.4byte sHeracrossPose121
+.4byte sHeracrossPose122
+.4byte sHeracrossPose123
+.4byte sHeracrossPose124
+.4byte sHeracrossPose125
+.4byte sHeracrossPose126
+.4byte sHeracrossPose127
+.4byte sHeracrossPose128
+.4byte sHeracrossPose129
+.4byte sHeracrossPose130
+.4byte sHeracrossPose131
+.4byte sHeracrossPose132
+.4byte sHeracrossPose133
+.4byte sHeracrossPose134
+.4byte sHeracrossPose135
+.4byte sHeracrossPose136
+.4byte sHeracrossPose137
+.4byte sHeracrossPose138
+.4byte sHeracrossPose139
+.4byte sHeracrossPose140
+.4byte sHeracrossPose141
+.4byte sHeracrossPose142
+.4byte sHeracrossPose143
+.4byte sHeracrossPose144
+.4byte sHeracrossPose145
+.4byte sHeracrossPose146
+.4byte sHeracrossPose147
+.4byte sHeracrossPose148
+.4byte sHeracrossPose149
+.4byte sHeracrossPose150
+.4byte sHeracrossPose151
+.4byte sHeracrossPose152
+.4byte sHeracrossPose153
+.4byte sHeracrossPose154
+.4byte sHeracrossPose155
+.4byte sHeracrossPose156
+.4byte sHeracrossPose157
+.4byte sHeracrossPose158
+.4byte sHeracrossPose159
+.4byte sHeracrossPose160
+.4byte sHeracrossPose161
+.4byte sHeracrossPose162
+.4byte sHeracrossPose163
+.4byte sHeracrossPose164
+.4byte sHeracrossPose165
+.4byte sHeracrossPose166
+.4byte sHeracrossPose167
+.4byte sHeracrossPose168
+.4byte sHeracrossPose169
+.4byte sHeracrossPose170
+.4byte sHeracrossPose171
+.4byte sHeracrossPose172
+.4byte sHeracrossPose173
+.4byte sHeracrossPose174
+.4byte sHeracrossPose175
+.4byte sHeracrossPose176
+.4byte sHeracrossPose177
+.4byte sHeracrossPose178
+.4byte sHeracrossPose179
+.4byte sHeracrossPose180
+.4byte sHeracrossPose181
+.4byte sHeracrossPose182
+.4byte sHeracrossPose183
+.4byte sHeracrossPose184
+.4byte sHeracrossPose185
+.4byte sHeracrossPose186
+.4byte sHeracrossPose187
+.4byte sHeracrossPose188
+.4byte sHeracrossPose189
+.4byte sHeracrossPose190
+.4byte sHeracrossPose191
+.4byte sHeracrossPose192
+.4byte sHeracrossPose193
+.4byte sHeracrossPose194
+.4byte sHeracrossPose195
+.4byte sHeracrossPose196
+.4byte sHeracrossPose197
+.4byte sHeracrossPose198
+.4byte sHeracrossPose199
+.4byte sHeracrossPose200
+.4byte sHeracrossPose201
+.4byte sHeracrossPose202
+.4byte sHeracrossPose203
+.4byte sHeracrossPose204
+.4byte sHeracrossPose205
+.4byte sHeracrossPose206
+.4byte sHeracrossPose207
+.4byte sHeracrossPose208
+.4byte sHeracrossPose209
+.4byte sHeracrossPose210
+.4byte sHeracrossPose211
+.4byte sHeracrossPose212
+.4byte sHeracrossPose213
+.4byte sHeracrossPose214
+.4byte sHeracrossPose215
+.4byte sHeracrossPose216
+.4byte sHeracrossPose217
+.4byte sHeracrossPose218
+.4byte sHeracrossPose219
+.4byte sHeracrossPose220
+.4byte sHeracrossPose221
+.4byte sHeracrossPose222
+.4byte sHeracrossPose223
+.4byte sHeracrossPose224
+.4byte sHeracrossPose225
+.4byte sHeracrossPose226
+.4byte sHeracrossPose227
+.4byte sHeracrossPose228
+.4byte sHeracrossPose229
+.4byte sHeracrossPose230
+.4byte sHeracrossPose231
+.4byte sHeracrossPose232
+.4byte sHeracrossPose233
+.4byte sHeracrossPose234
+.4byte sHeracrossPose235
+.4byte sHeracrossPose236
+.4byte sHeracrossPose237
+.4byte sHeracrossPose238
+.4byte sHeracrossPose239
+.4byte sHeracrossPose240
+.4byte sHeracrossPose241
+.4byte sHeracrossPose242
+.4byte sHeracrossPose243
+.4byte sHeracrossPose244
+.4byte sHeracrossPose245
+.4byte sHeracrossPose246
+.4byte sHeracrossPose247
+.4byte sHeracrossPose248
+.4byte sHeracrossPose249
+.4byte sHeracrossPose250
+.4byte sHeracrossPose251
+.4byte sHeracrossPose252
+sAxPositionsHeracross:
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -7
+.2byte    1,   -7, 	  -8,   -3, 	   9,   -8, 	   1,   -8
+.2byte   -2,   -7, 	 -10,   -8, 	   7,   -4, 	   0,   -8
+.2byte    3,   -8, 	   8,   -8, 	  -3,   -4, 	  -2,   -9
+.2byte    2,   -7, 	   9,   -6, 	  -5,   -4, 	  -2,   -8
+.2byte    4,   -8, 	   7,   -9, 	   1,   -3, 	  -2,   -9
+.2byte    4,   -8, 	   6,   -8, 	   3,   -3, 	  -1,   -9
+.2byte    3,   -7, 	   7,   -7, 	  -2,   -2, 	  -2,   -8
+.2byte    3,   -9, 	   0,   -6, 	   6,   -4, 	  -1,   -9
+.2byte    3,  -12, 	  -2,   -9, 	   8,   -4, 	  -1,   -9
+.2byte    3,   -9, 	   0,   -7, 	   6,   -1, 	  -1,   -8
+.2byte    3,  -11, 	  -6,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    1,  -10, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte   -1,   -8, 	   8,   -9, 	 -10,   -3, 	   1,   -7
+.2byte    1,   -9, 	   9,   -4, 	  -8,   -9, 	   0,   -8
+.2byte   -3,  -12, 	   2,   -9, 	  -8,   -4, 	   1,   -9
+.2byte   -3,   -9, 	   0,   -7, 	  -6,   -1, 	   1,   -8
+.2byte   -3,  -11, 	   6,   -8, 	  -9,   -8, 	   1,   -9
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,   -3, 	   1,   -9
+.2byte   -3,   -7, 	  -7,   -7, 	   2,   -2, 	   2,   -8
+.2byte   -3,   -9, 	   0,   -6, 	  -6,   -4, 	   1,   -9
+.2byte   -3,   -8, 	  -8,   -8, 	   3,   -4, 	   2,   -9
+.2byte   -2,   -7, 	  -9,   -6, 	   5,   -4, 	   2,   -8
+.2byte   -4,   -8, 	  -7,   -9, 	  -1,   -3, 	   2,   -9
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -7
+.2byte    0,  -11, 	 -11,   -8, 	  11,   -9, 	   0,  -10
+.2byte   -2,   -7, 	 -10,   -8, 	   7,   -4, 	   0,   -8
+.2byte    0,   -4, 	 -12,   -3, 	  12,   -3, 	   0,   -7
+.2byte    3,   -8, 	   8,   -8, 	  -3,   -4, 	  -2,   -9
+.2byte    0,  -10, 	   9,   -9, 	  -7,   -4, 	  -2,  -10
+.2byte    4,   -8, 	   7,   -9, 	   1,   -3, 	  -2,   -9
+.2byte   10,   -6, 	   9,   -7, 	  -9,   -2, 	  -1,   -8
+.2byte    4,   -8, 	   6,   -8, 	   3,   -3, 	  -1,   -9
+.2byte    3,  -12, 	   7,  -15, 	   4,   -4, 	  -2,   -9
+.2byte    3,   -9, 	   0,   -6, 	   6,   -4, 	  -1,   -9
+.2byte   16,  -15, 	   5,  -13, 	   5,   -2, 	   2,  -10
+.2byte    3,  -12, 	  -2,   -9, 	   8,   -4, 	  -1,   -9
+.2byte    0,  -11, 	  -5,  -11, 	   7,   -6, 	  -3,  -10
+.2byte    3,  -11, 	  -6,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    8,  -20, 	  -3,  -12, 	  13,   -5, 	   1,  -10
+.2byte    1,  -10, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte    0,   -8, 	   9,   -7, 	  -9,   -7, 	   0,   -7
+.2byte    1,   -9, 	   9,   -4, 	  -8,   -9, 	   0,   -8
+.2byte    0,  -21, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -3,  -12, 	   2,   -9, 	  -8,   -4, 	   1,   -9
+.2byte    0,  -11, 	   5,  -11, 	  -7,   -6, 	   3,  -10
+.2byte   -3,  -11, 	   6,   -8, 	  -9,   -8, 	   1,   -9
+.2byte   -8,  -20, 	   3,  -12, 	 -13,   -5, 	  -1,  -10
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,   -3, 	   1,   -9
+.2byte   -2,  -12, 	  -6,  -15, 	  -3,   -4, 	   3,   -9
+.2byte   -3,   -9, 	   0,   -6, 	  -6,   -4, 	   1,   -9
+.2byte  -16,  -15, 	  -5,  -13, 	  -5,   -2, 	  -2,  -10
+.2byte   -3,   -8, 	  -8,   -8, 	   3,   -4, 	   2,   -9
+.2byte    1,  -10, 	  -8,   -9, 	   8,   -4, 	   3,  -10
+.2byte   -4,   -8, 	  -7,   -9, 	  -1,   -3, 	   2,   -9
+.2byte  -10,   -6, 	  -9,   -7, 	   9,   -2, 	   1,   -8
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -7
+.2byte    1,   -7, 	  -8,   -3, 	   9,   -8, 	   1,   -8
+.2byte   -2,   -7, 	 -10,   -8, 	   7,   -4, 	   0,   -8
+.2byte   -4,   -9, 	 -11,  -12, 	   0,  -14, 	  -2,   -9
+.2byte    3,   -4, 	   3,    2, 	   5,  -16, 	   0,   -7
+.2byte    3,   -4, 	   3,    2, 	   5,  -16, 	   0,   -7
+.2byte    3,   -8, 	   8,   -8, 	  -3,   -4, 	  -2,   -9
+.2byte    2,   -7, 	   9,   -6, 	  -5,   -4, 	  -2,   -8
+.2byte    4,   -8, 	   7,   -9, 	   1,   -3, 	  -2,   -9
+.2byte    1,  -11, 	   4,  -14, 	   3,  -13, 	  -4,  -10
+.2byte   -3,   -8, 	  -1,   -1, 	 -13,  -16, 	  -3,  -10
+.2byte   -3,   -8, 	  -1,   -1, 	 -13,  -16, 	  -3,  -10
+.2byte    4,   -8, 	   6,   -8, 	   3,   -3, 	  -1,   -9
+.2byte    3,   -7, 	   7,   -7, 	  -2,   -2, 	  -2,   -8
+.2byte    3,   -9, 	   0,   -6, 	   6,   -4, 	  -1,   -9
+.2byte   -5,  -10, 	  -9,  -14, 	   4,  -16, 	  -7,   -7
+.2byte    1,   -5, 	   7,   -1, 	 -11,   -5, 	  -2,   -8
+.2byte    1,   -5, 	   7,   -1, 	 -11,   -5, 	  -2,   -8
+.2byte    3,  -12, 	  -2,   -9, 	   8,   -4, 	  -1,   -9
+.2byte    3,   -9, 	   0,   -7, 	   6,   -1, 	  -1,   -8
+.2byte    3,  -11, 	  -6,   -8, 	   9,   -8, 	  -1,   -9
+.2byte   -8,  -11, 	 -17,  -11, 	  -2,  -21, 	  -8,  -10
+.2byte   -1,   -8, 	  -9,   -7, 	  -4,    0, 	  -4,   -9
+.2byte   -1,   -8, 	  -9,   -7, 	  -4,    0, 	  -4,   -9
+.2byte    1,  -10, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte   -1,   -8, 	   8,   -9, 	 -10,   -3, 	   1,   -7
+.2byte    1,   -9, 	   9,   -4, 	  -8,   -9, 	   0,   -8
+.2byte    3,  -12, 	   8,   -8, 	   0,  -20, 	  -1,  -11
+.2byte   -4,  -13, 	  -2,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -4,  -13, 	  -2,   -8, 	 -10,   -2, 	  -1,  -11
+.2byte   -3,  -12, 	   2,   -9, 	  -8,   -4, 	   1,   -9
+.2byte   -3,   -9, 	   0,   -7, 	  -6,   -1, 	   1,   -8
+.2byte   -3,  -11, 	   6,   -8, 	  -9,   -8, 	   1,   -9
+.2byte    8,  -11, 	  17,  -11, 	   2,  -21, 	   8,  -10
+.2byte    1,   -8, 	   9,   -7, 	   4,    0, 	   4,   -9
+.2byte    1,   -8, 	   9,   -7, 	   4,    0, 	   4,   -9
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,   -3, 	   1,   -9
+.2byte   -3,   -7, 	  -7,   -7, 	   2,   -2, 	   2,   -8
+.2byte   -3,   -9, 	   0,   -6, 	  -6,   -4, 	   1,   -9
+.2byte    5,  -10, 	   9,  -14, 	  -4,  -16, 	   7,   -7
+.2byte   -1,   -5, 	  -7,   -1, 	  11,   -5, 	   2,   -8
+.2byte   -1,   -5, 	  -7,   -1, 	  11,   -5, 	   2,   -8
+.2byte   -3,   -8, 	  -8,   -8, 	   3,   -4, 	   2,   -9
+.2byte   -2,   -7, 	  -9,   -6, 	   5,   -4, 	   2,   -8
+.2byte   -4,   -8, 	  -7,   -9, 	  -1,   -3, 	   2,   -9
+.2byte   -1,  -11, 	  -4,  -14, 	  -3,  -13, 	   4,  -10
+.2byte    3,   -8, 	   1,   -1, 	  13,  -16, 	   3,  -10
+.2byte    3,   -8, 	   1,   -1, 	  13,  -16, 	   3,  -10
+.2byte    0,   -4, 	 -12,   -3, 	  12,   -3, 	   0,   -7
+.2byte  -11,   -5, 	 -10,   -6, 	   8,   -1, 	   0,   -7
+.2byte  -14,  -13, 	  -3,  -11, 	  -3,    0, 	   0,   -8
+.2byte   -7,  -18, 	   4,  -10, 	 -12,   -3, 	   0,   -8
+.2byte    0,  -20, 	  10,   -6, 	 -10,   -6, 	   0,   -9
+.2byte    6,  -18, 	  -5,  -10, 	  11,   -3, 	  -1,   -8
+.2byte   13,  -13, 	   2,  -11, 	   2,    0, 	  -1,   -8
+.2byte   10,   -5, 	   9,   -6, 	  -9,   -1, 	  -1,   -7
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -7
+.2byte    2,   -7, 	  -9,   -9, 	  11,   -4, 	   1,   -7
+.2byte    0,   -4, 	 -12,   -3, 	  12,   -3, 	   0,   -7
+.2byte   -2,   -7, 	   9,   -9, 	 -11,   -4, 	  -1,   -7
+.2byte    0,  -11, 	 -11,   -8, 	  11,   -9, 	   0,  -10
+.2byte    0,    7, 	 -11,   -9, 	  11,   -9, 	   0,   -7
+.2byte    1,   -5, 	  -9,  -10, 	   8,    0, 	   1,   -6
+.2byte   -2,   -5, 	   8,  -10, 	  -9,    0, 	  -2,   -6
+.2byte    3,   -8, 	   8,   -8, 	  -3,   -4, 	  -2,   -9
+.2byte    4,   -8, 	  11,   -6, 	  -4,   -5, 	  -1,   -8
+.2byte   10,   -6, 	   9,   -7, 	  -9,   -2, 	  -1,   -8
+.2byte   -3,   -6, 	   7,  -11, 	 -10,   -1, 	  -3,   -7
+.2byte   -1,  -10, 	   8,   -9, 	  -8,   -4, 	  -3,  -10
+.2byte   11,    6, 	   8,  -14, 	  -7,   -7, 	   3,   -7
+.2byte    4,   -8, 	   6,   -8, 	   3,   -3, 	  -1,   -9
+.2byte    5,  -10, 	   8,  -11, 	   6,   -5, 	   0,   -9
+.2byte   16,  -15, 	   5,  -13, 	   5,   -2, 	   2,  -10
+.2byte    0,   -8, 	   4,  -14, 	   4,    0, 	  -2,   -7
+.2byte    2,  -12, 	   6,  -15, 	   3,   -4, 	  -3,   -9
+.2byte   19,   -8, 	  -2,  -19, 	  -5,   -4, 	   1,  -11
+.2byte    3,  -12, 	  -2,   -9, 	   8,   -4, 	  -1,   -9
+.2byte   -2,  -11, 	  -9,   -7, 	   9,   -8, 	  -3,  -10
+.2byte    8,  -20, 	  -3,  -12, 	  13,   -5, 	   1,  -10
+.2byte    2,  -11, 	  -4,  -17, 	  11,   -5, 	  -1,   -9
+.2byte    0,  -11, 	  -5,  -11, 	   7,   -6, 	  -3,  -10
+.2byte   13,  -16, 	  -7,  -11, 	   3,   -3, 	   2,  -10
+.2byte    1,  -10, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte   -5,  -11, 	   5,  -14, 	 -12,   -1, 	  -2,   -8
+.2byte    0,  -21, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte    5,  -11, 	  -5,  -14, 	  12,   -1, 	   2,   -8
+.2byte    0,   -8, 	   9,   -7, 	  -9,   -7, 	   0,   -7
+.2byte   -1,  -19, 	  10,   -6, 	 -12,   -6, 	  -1,  -11
+.2byte   -3,  -12, 	   2,   -9, 	  -8,   -4, 	   1,   -9
+.2byte   -2,  -11, 	   4,  -17, 	 -11,   -5, 	   1,   -9
+.2byte   -8,  -20, 	   3,  -12, 	 -13,   -5, 	  -1,  -10
+.2byte    2,  -11, 	   9,   -7, 	  -9,   -8, 	   3,  -10
+.2byte    0,  -11, 	   5,  -11, 	  -7,   -6, 	   3,  -10
+.2byte  -13,  -16, 	   7,  -11, 	  -3,   -3, 	  -2,  -10
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,   -3, 	   1,   -9
+.2byte    0,   -8, 	  -4,  -14, 	  -4,    0, 	   2,   -7
+.2byte  -16,  -15, 	  -5,  -13, 	  -5,   -2, 	  -2,  -10
+.2byte   -5,  -10, 	  -8,  -11, 	  -6,   -5, 	   0,   -9
+.2byte   -2,  -12, 	  -6,  -15, 	  -3,   -4, 	   3,   -9
+.2byte  -19,   -8, 	   2,  -19, 	   5,   -4, 	  -1,  -11
+.2byte   -3,   -8, 	  -8,   -8, 	   3,   -4, 	   2,   -9
+.2byte    3,   -6, 	  -7,  -11, 	  10,   -1, 	   3,   -7
+.2byte  -10,   -6, 	  -9,   -7, 	   9,   -2, 	   1,   -8
+.2byte   -4,   -8, 	 -11,   -6, 	   4,   -5, 	   1,   -8
+.2byte    1,  -10, 	  -8,   -9, 	   8,   -4, 	   3,  -10
+.2byte  -11,    6, 	  -8,  -14, 	   7,   -7, 	  -3,   -7
+.2byte  -14,   -1, 	   0,   -8, 	   7,    3, 	   1,   -6
+.2byte  -13,    1, 	   2,   -8, 	   7,    3, 	   2,   -5
+.2byte    0,  -14, 	  -7,  -19, 	   8,  -19, 	   0,  -10
+.2byte    2,  -14, 	   4,  -20, 	  -4,  -19, 	   0,  -10
+.2byte    3,  -15, 	   3,  -21, 	   2,  -19, 	  -1,  -10
+.2byte    0,  -15, 	  -5,  -19, 	   5,  -18, 	  -2,   -8
+.2byte    0,  -11, 	   7,  -19, 	  -7,  -19, 	   1,   -9
+.2byte   -1,  -15, 	   4,  -19, 	  -6,  -18, 	   1,   -8
+.2byte   -4,  -15, 	  -4,  -21, 	  -3,  -19, 	   0,  -10
+.2byte   -3,  -14, 	  -5,  -20, 	   3,  -19, 	  -1,  -10
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -7
+.2byte    2,   -7, 	  -9,   -9, 	  11,   -4, 	   1,   -7
+.2byte   -2,   -7, 	   9,   -9, 	 -11,   -4, 	  -1,   -7
+.2byte    3,   -8, 	   8,   -8, 	  -3,   -4, 	  -2,   -9
+.2byte    4,   -8, 	  11,   -6, 	  -4,   -5, 	  -1,   -8
+.2byte   -3,   -6, 	   7,  -11, 	 -10,   -1, 	  -3,   -7
+.2byte    4,   -8, 	   6,   -8, 	   3,   -3, 	  -1,   -9
+.2byte    5,  -10, 	   8,  -11, 	   6,   -5, 	   0,   -9
+.2byte    0,   -8, 	   4,  -14, 	   4,    0, 	  -2,   -7
+.2byte    3,  -12, 	  -2,   -9, 	   8,   -4, 	  -1,   -9
+.2byte   -2,  -11, 	  -9,   -7, 	   9,   -8, 	  -3,  -10
+.2byte    2,  -11, 	  -4,  -17, 	  11,   -5, 	  -1,   -9
+.2byte    1,  -10, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte   -5,  -11, 	   5,  -14, 	 -12,   -1, 	  -2,   -8
+.2byte    5,  -11, 	  -5,  -14, 	  12,   -1, 	   2,   -8
+.2byte   -3,  -12, 	   2,   -9, 	  -8,   -4, 	   1,   -9
+.2byte   -2,  -11, 	   4,  -17, 	 -11,   -5, 	   1,   -9
+.2byte    2,  -11, 	   9,   -7, 	  -9,   -8, 	   3,  -10
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,   -3, 	   1,   -9
+.2byte    0,   -8, 	  -4,  -14, 	  -4,    0, 	   2,   -7
+.2byte   -5,  -10, 	  -8,  -11, 	  -6,   -5, 	   0,   -9
+.2byte   -3,   -8, 	  -8,   -8, 	   3,   -4, 	   2,   -9
+.2byte    3,   -6, 	  -7,  -11, 	  10,   -1, 	   3,   -7
+.2byte   -4,   -8, 	 -11,   -6, 	   4,   -5, 	   1,   -8
+.2byte    0,   -4, 	 -12,   -3, 	  12,   -3, 	   0,   -7
+.2byte  -11,   -6, 	 -10,   -7, 	   8,   -2, 	   0,   -8
+.2byte  -14,  -14, 	  -3,  -12, 	  -3,   -1, 	   0,   -9
+.2byte   -7,  -19, 	   4,  -11, 	 -12,   -4, 	   0,   -9
+.2byte    0,  -20, 	  10,   -6, 	 -10,   -6, 	   0,   -9
+.2byte    6,  -19, 	  -5,  -11, 	  11,   -4, 	  -1,   -9
+.2byte   13,  -14, 	   2,  -12, 	   2,   -1, 	  -1,   -9
+.2byte   10,   -6, 	   9,   -7, 	  -9,   -2, 	  -1,   -8
+.2byte    0,  -11, 	 -11,   -8, 	  11,   -9, 	   0,  -10
+.2byte    1,  -10, 	  10,   -9, 	  -6,   -4, 	  -1,  -10
+.2byte    3,  -12, 	   7,  -15, 	   4,   -4, 	  -2,   -9
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,  -10
+.2byte    0,   -9, 	   9,   -8, 	  -9,   -8, 	   0,   -8
+.2byte   -2,  -11, 	   3,  -11, 	  -9,   -6, 	   1,  -10
+.2byte   -4,  -12, 	  -8,  -15, 	  -5,   -4, 	   1,   -9
+.2byte   -2,  -10, 	 -11,   -9, 	   5,   -4, 	   0,  -10
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -7
+.2byte    0,  -11, 	 -11,   -8, 	  11,   -9, 	   0,  -10
+.2byte    0,    7, 	 -11,   -9, 	  11,   -9, 	   0,   -7
+.2byte    3,   -8, 	   8,   -8, 	  -3,   -4, 	  -2,   -9
+.2byte    0,  -10, 	   9,   -9, 	  -7,   -4, 	  -2,  -10
+.2byte    9,    6, 	   6,  -14, 	  -9,   -7, 	   1,   -7
+.2byte    4,   -8, 	   6,   -8, 	   3,   -3, 	  -1,   -9
+.2byte    2,  -12, 	   6,  -15, 	   3,   -4, 	  -3,   -9
+.2byte   17,   -8, 	  -4,  -19, 	  -7,   -4, 	  -1,  -11
+.2byte    3,  -12, 	  -2,   -9, 	   8,   -4, 	  -1,   -9
+.2byte    0,  -11, 	  -5,  -11, 	   7,   -6, 	  -3,  -10
+.2byte   13,  -16, 	  -7,  -11, 	   3,   -3, 	   2,  -10
+.2byte    1,  -10, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte    0,   -8, 	   9,   -7, 	  -9,   -7, 	   0,   -7
+.2byte    0,  -19, 	  11,   -6, 	 -11,   -6, 	   0,  -11
+.2byte   -3,  -12, 	   2,   -9, 	  -8,   -4, 	   1,   -9
+.2byte    0,  -11, 	   5,  -11, 	  -7,   -6, 	   3,  -10
+.2byte  -13,  -16, 	   7,  -11, 	  -3,   -3, 	  -2,  -10
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,   -3, 	   1,   -9
+.2byte   -2,  -12, 	  -6,  -15, 	  -3,   -4, 	   3,   -9
+.2byte  -17,   -8, 	   4,  -19, 	   7,   -4, 	   1,  -11
+.2byte   -3,   -8, 	  -8,   -8, 	   3,   -4, 	   2,   -9
+.2byte    0,  -10, 	  -9,   -9, 	   7,   -4, 	   2,  -10
+.2byte  -10,    6, 	  -7,  -14, 	   8,   -7, 	  -2,   -7
+.2byte    0,   -4, 	 -12,   -3, 	  12,   -3, 	   0,   -7
+.2byte  -11,   -5, 	 -10,   -6, 	   8,   -1, 	   0,   -7
+.2byte  -14,  -13, 	  -3,  -11, 	  -3,    0, 	   0,   -8
+.2byte   -7,  -18, 	   4,  -10, 	 -12,   -3, 	   0,   -8
+.2byte    0,  -20, 	  10,   -6, 	 -10,   -6, 	   0,   -9
+.2byte    6,  -18, 	  -5,  -10, 	  11,   -3, 	  -1,   -8
+.2byte   13,  -13, 	   2,  -11, 	   2,    0, 	  -1,   -8
+.2byte   10,   -5, 	   9,   -6, 	  -9,   -1, 	  -1,   -7
+.2byte    0,   -8, 	 -10,   -5, 	  10,   -5, 	   0,   -7
+.2byte   -3,   -8, 	  -8,   -8, 	   3,   -4, 	   2,   -9
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,   -3, 	   1,   -9
+.2byte   -3,  -12, 	   2,   -9, 	  -8,   -4, 	   1,   -9
+.2byte    1,  -10, 	  10,   -5, 	 -10,   -5, 	   0,   -8
+.2byte    3,  -12, 	  -2,   -9, 	   8,   -4, 	  -1,   -9
+.2byte    4,   -8, 	   6,   -8, 	   3,   -3, 	  -1,   -9
+.2byte    3,   -8, 	   8,   -8, 	  -3,   -4, 	  -2,   -9
+sHeracrossAnimTable1:
+.4byte sHeracrossAnims_1_1
+.4byte sHeracrossAnims_1_2
+.4byte sHeracrossAnims_1_3
+.4byte sHeracrossAnims_1_4
+.4byte sHeracrossAnims_1_5
+.4byte sHeracrossAnims_1_6
+.4byte sHeracrossAnims_1_7
+.4byte sHeracrossAnims_1_8
+sHeracrossAnimTable2:
+.4byte sHeracrossAnims_2_1
+.4byte sHeracrossAnims_2_2
+.4byte sHeracrossAnims_2_3
+.4byte sHeracrossAnims_2_4
+.4byte sHeracrossAnims_2_5
+.4byte sHeracrossAnims_2_6
+.4byte sHeracrossAnims_2_7
+.4byte sHeracrossAnims_2_8
+sHeracrossAnimTable3:
+.4byte sHeracrossAnims_3_1
+.4byte sHeracrossAnims_3_2
+.4byte sHeracrossAnims_3_3
+.4byte sHeracrossAnims_3_4
+.4byte sHeracrossAnims_3_5
+.4byte sHeracrossAnims_3_6
+.4byte sHeracrossAnims_3_7
+.4byte sHeracrossAnims_3_8
+sHeracrossAnimTable4:
+.4byte sHeracrossAnims_4_1
+.4byte sHeracrossAnims_4_2
+.4byte sHeracrossAnims_4_3
+.4byte sHeracrossAnims_4_4
+.4byte sHeracrossAnims_4_5
+.4byte sHeracrossAnims_4_6
+.4byte sHeracrossAnims_4_7
+.4byte sHeracrossAnims_4_8
+sHeracrossAnimTable5:
+.4byte sHeracrossAnims_5_1
+.4byte sHeracrossAnims_5_2
+.4byte sHeracrossAnims_5_3
+.4byte sHeracrossAnims_5_4
+.4byte sHeracrossAnims_5_5
+.4byte sHeracrossAnims_5_6
+.4byte sHeracrossAnims_5_7
+.4byte sHeracrossAnims_5_8
+sHeracrossAnimTable6:
+.4byte sHeracrossAnims_6_1
+.4byte sHeracrossAnims_6_1
+.4byte sHeracrossAnims_6_1
+.4byte sHeracrossAnims_6_1
+.4byte sHeracrossAnims_6_1
+.4byte sHeracrossAnims_6_1
+.4byte sHeracrossAnims_6_1
+.4byte sHeracrossAnims_6_1
+sHeracrossAnimTable7:
+.4byte sHeracrossAnims_7_1
+.4byte sHeracrossAnims_7_2
+.4byte sHeracrossAnims_7_3
+.4byte sHeracrossAnims_7_4
+.4byte sHeracrossAnims_7_5
+.4byte sHeracrossAnims_7_6
+.4byte sHeracrossAnims_7_7
+.4byte sHeracrossAnims_7_8
+sHeracrossAnimTable8:
+.4byte sHeracrossAnims_8_1
+.4byte sHeracrossAnims_8_2
+.4byte sHeracrossAnims_8_3
+.4byte sHeracrossAnims_8_4
+.4byte sHeracrossAnims_8_5
+.4byte sHeracrossAnims_8_6
+.4byte sHeracrossAnims_8_7
+.4byte sHeracrossAnims_8_8
+sHeracrossAnimTable9:
+.4byte sHeracrossAnims_9_1
+.4byte sHeracrossAnims_9_2
+.4byte sHeracrossAnims_9_3
+.4byte sHeracrossAnims_9_4
+.4byte sHeracrossAnims_9_5
+.4byte sHeracrossAnims_9_6
+.4byte sHeracrossAnims_9_7
+.4byte sHeracrossAnims_9_8
+sHeracrossAnimTable10:
+.4byte sHeracrossAnims_10_1
+.4byte sHeracrossAnims_10_2
+.4byte sHeracrossAnims_10_3
+.4byte sHeracrossAnims_10_4
+.4byte sHeracrossAnims_10_5
+.4byte sHeracrossAnims_10_6
+.4byte sHeracrossAnims_10_7
+.4byte sHeracrossAnims_10_8
+sHeracrossAnimTable11:
+.4byte sHeracrossAnims_11_1
+.4byte sHeracrossAnims_11_2
+.4byte sHeracrossAnims_11_3
+.4byte sHeracrossAnims_11_4
+.4byte sHeracrossAnims_11_5
+.4byte sHeracrossAnims_11_6
+.4byte sHeracrossAnims_11_7
+.4byte sHeracrossAnims_11_8
+sHeracrossAnimTable12:
+.4byte sHeracrossAnims_12_1
+.4byte sHeracrossAnims_12_2
+.4byte sHeracrossAnims_12_3
+.4byte sHeracrossAnims_12_4
+.4byte sHeracrossAnims_12_5
+.4byte sHeracrossAnims_12_6
+.4byte sHeracrossAnims_12_7
+.4byte sHeracrossAnims_12_8
+sHeracrossAnimTable13:
+.4byte sHeracrossAnims_13_1
+.4byte sHeracrossAnims_13_2
+.4byte sHeracrossAnims_13_3
+.4byte sHeracrossAnims_13_4
+.4byte sHeracrossAnims_13_5
+.4byte sHeracrossAnims_13_6
+.4byte sHeracrossAnims_13_7
+.4byte sHeracrossAnims_13_8
+sAxAnimationsHeracross:
+.4byte sHeracrossAnimTable1
+.4byte sHeracrossAnimTable2
+.4byte sHeracrossAnimTable3
+.4byte sHeracrossAnimTable4
+.4byte sHeracrossAnimTable5
+.4byte sHeracrossAnimTable6
+.4byte sHeracrossAnimTable7
+.4byte sHeracrossAnimTable8
+.4byte sHeracrossAnimTable9
+.4byte sHeracrossAnimTable10
+.4byte sHeracrossAnimTable11
+.4byte sHeracrossAnimTable12
+.4byte sHeracrossAnimTable13
+sAxSpritesHeracross:
+.4byte sHeracrossSprites1
+.4byte sHeracrossSprites2
+.4byte sHeracrossSprites3
+.4byte sHeracrossSprites4
+.4byte sHeracrossSprites5
+.4byte sHeracrossSprites6
+.4byte sHeracrossSprites7
+.4byte sHeracrossSprites8
+.4byte sHeracrossSprites9
+.4byte sHeracrossSprites10
+.4byte sHeracrossSprites11
+.4byte sHeracrossSprites12
+.4byte sHeracrossSprites13
+.4byte sHeracrossSprites14
+.4byte sHeracrossSprites15
+.4byte sHeracrossSprites16
+.4byte sHeracrossSprites17
+.4byte sHeracrossSprites18
+.4byte sHeracrossSprites19
+.4byte sHeracrossSprites20
+.4byte sHeracrossSprites21
+.4byte sHeracrossSprites22
+.4byte sHeracrossSprites23
+.4byte sHeracrossSprites24
+.4byte sHeracrossSprites25
+.4byte sHeracrossSprites26
+.4byte sHeracrossSprites27
+.4byte sHeracrossSprites28
+.4byte sHeracrossSprites29
+.4byte sHeracrossSprites30
+.4byte sHeracrossSprites31
+.4byte sHeracrossSprites32
+.4byte sHeracrossSprites33
+.4byte sHeracrossSprites34
+.4byte sHeracrossSprites35
+.4byte sHeracrossSprites36
+.4byte sHeracrossSprites37
+.4byte sHeracrossSprites38
+.4byte sHeracrossSprites39
+.4byte sHeracrossSprites40
+.4byte sHeracrossSprites41
+.4byte sHeracrossSprites42
+.4byte sHeracrossSprites43
+.4byte sHeracrossSprites44
+.4byte sHeracrossSprites45
+.4byte sHeracrossSprites46
+.4byte sHeracrossSprites47
+.4byte sHeracrossSprites48
+.4byte sHeracrossSprites49
+.4byte sHeracrossSprites50
+.4byte sHeracrossSprites51
+.4byte sHeracrossSprites52
+.4byte sHeracrossSprites53
+.4byte sHeracrossSprites54
+.4byte sHeracrossSprites55
+.4byte sHeracrossSprites56
+.4byte sHeracrossSprites57
+.4byte sHeracrossSprites58
+.4byte sHeracrossSprites59
+.4byte sHeracrossSprites60
+sAxMainHeracross:
+ax_main sAxPosesHeracross, sAxAnimationsHeracross, 13, sAxSpritesHeracross, sAxPositionsHeracross

--- a/data/ax/hitmonchan.inc
+++ b/data/ax/hitmonchan.inc
@@ -1,0 +1,3368 @@
+.global gAxHitmonchan
+gAxHitmonchan:
+ax_siro sAxMainHitmonchan
+sHitmonchanPose1:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose2:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose3:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose4:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose5:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose6:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose7:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose8:
+ax_pose 7, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose9:
+ax_pose 8, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose10:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose12:
+ax_pose 11, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose13:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose14:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose15:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose19:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose20:
+ax_pose 7, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose21:
+ax_pose 8, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose22:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose23:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose24:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose25:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose26:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose27:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose28:
+ax_pose 15, 0x01e5, 0x80ef, 0x6c00
+ax_pose 16, 0x01e5, 0x80ef, 0x6c10
+ax_pose_terminator
+sHitmonchanPose29:
+ax_pose 16, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose30:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose31:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose32:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose33:
+ax_pose 17, 0x01e9, 0x90f4, 0x6c00
+ax_pose 18, 0x01e9, 0x90f4, 0x6c10
+ax_pose_terminator
+sHitmonchanPose34:
+ax_pose 18, 0x01e9, 0x90f4, 0x6c00
+ax_pose_terminator
+sHitmonchanPose35:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose36:
+ax_pose 7, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose37:
+ax_pose 8, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose38:
+ax_pose 19, 0x01e7, 0x90f5, 0x6c00
+ax_pose 20, 0x01e7, 0x90f5, 0x6c10
+ax_pose_terminator
+sHitmonchanPose39:
+ax_pose 20, 0x01e7, 0x90f5, 0x6c00
+ax_pose_terminator
+sHitmonchanPose40:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose41:
+ax_pose 10, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose42:
+ax_pose 11, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose43:
+ax_pose 21, 0x01e8, 0x90f0, 0x6c00
+ax_pose 22, 0x01e8, 0x90f1, 0x6c10
+ax_pose_terminator
+sHitmonchanPose44:
+ax_pose 22, 0x01e8, 0x90f1, 0x6c00
+ax_pose_terminator
+sHitmonchanPose45:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose46:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose47:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose48:
+ax_pose 23, 0x01e4, 0x80ee, 0x6c00
+ax_pose 24, 0x01e4, 0x80ee, 0x6c10
+ax_pose_terminator
+sHitmonchanPose49:
+ax_pose 24, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonchanPose50:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose51:
+ax_pose 10, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose52:
+ax_pose 11, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose53:
+ax_pose 21, 0x01e8, 0x80ee, 0x6c00
+ax_pose 22, 0x01e8, 0x80ee, 0x6c10
+ax_pose_terminator
+sHitmonchanPose54:
+ax_pose 22, 0x01e8, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonchanPose55:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose56:
+ax_pose 7, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose57:
+ax_pose 8, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose58:
+ax_pose 19, 0x01e7, 0x80ec, 0x6c00
+ax_pose 20, 0x01e7, 0x80ec, 0x6c10
+ax_pose_terminator
+sHitmonchanPose59:
+ax_pose 20, 0x01e7, 0x80ec, 0x6c00
+ax_pose_terminator
+sHitmonchanPose60:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose61:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose62:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose63:
+ax_pose 17, 0x01e8, 0x80ed, 0x6c00
+ax_pose 18, 0x01e8, 0x80ed, 0x6c10
+ax_pose_terminator
+sHitmonchanPose64:
+ax_pose 18, 0x01e8, 0x80ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose65:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose66:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose67:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose68:
+ax_pose 25, 0x01e6, 0x80f0, 0x6c00
+ax_pose 26, 0x01e6, 0x80f0, 0x6c10
+ax_pose_terminator
+sHitmonchanPose69:
+ax_pose 26, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose70:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose71:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose72:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose73:
+ax_pose 27, 0x01e7, 0x90f6, 0x6c00
+ax_pose 28, 0x01e7, 0x90f6, 0x6c10
+ax_pose_terminator
+sHitmonchanPose74:
+ax_pose 28, 0x01e7, 0x90f6, 0x6c00
+ax_pose_terminator
+sHitmonchanPose75:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose76:
+ax_pose 7, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose77:
+ax_pose 8, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose78:
+ax_pose 29, 0x01e5, 0x90f7, 0x6c00
+ax_pose 30, 0x01e5, 0x90f7, 0x6c10
+ax_pose_terminator
+sHitmonchanPose79:
+ax_pose 30, 0x01e5, 0x90f7, 0x6c00
+ax_pose_terminator
+sHitmonchanPose80:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose81:
+ax_pose 10, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose82:
+ax_pose 11, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose83:
+ax_pose 31, 0x01e5, 0x90f4, 0x6c00
+ax_pose 32, 0x01e5, 0x90f4, 0x6c10
+ax_pose_terminator
+sHitmonchanPose84:
+ax_pose 32, 0x01e5, 0x90f4, 0x6c00
+ax_pose_terminator
+sHitmonchanPose85:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose86:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose87:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose88:
+ax_pose 33, 0x01dd, 0x80f1, 0x6c00
+ax_pose 34, 0x81e5, 0x80f2, 0x6c10
+ax_pose 35, 0x81e5, 0x4102, 0x6c18
+ax_pose 36, 0x01dd, 0x00fe, 0x6c1c
+ax_pose_terminator
+sHitmonchanPose89:
+ax_pose 34, 0x81e5, 0x80f2, 0x6c00
+ax_pose 35, 0x81e5, 0x4102, 0x6c08
+ax_pose 36, 0x01dd, 0x00fc, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose90:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose91:
+ax_pose 10, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose92:
+ax_pose 11, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose93:
+ax_pose 31, 0x01e5, 0x80ec, 0x6c00
+ax_pose 32, 0x01e5, 0x80ec, 0x6c10
+ax_pose_terminator
+sHitmonchanPose94:
+ax_pose 32, 0x01e5, 0x80ec, 0x6c00
+ax_pose_terminator
+sHitmonchanPose95:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose96:
+ax_pose 7, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose97:
+ax_pose 8, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose98:
+ax_pose 29, 0x01e5, 0x80e7, 0x6c00
+ax_pose 30, 0x01e5, 0x80e7, 0x6c10
+ax_pose_terminator
+sHitmonchanPose99:
+ax_pose 30, 0x01e5, 0x80e7, 0x6c00
+ax_pose_terminator
+sHitmonchanPose100:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose101:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose102:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose103:
+ax_pose 27, 0x01e7, 0x80eb, 0x6c00
+ax_pose 28, 0x01e7, 0x80eb, 0x6c10
+ax_pose_terminator
+sHitmonchanPose104:
+ax_pose 28, 0x01e7, 0x80eb, 0x6c00
+ax_pose_terminator
+sHitmonchanPose105:
+ax_pose 37, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sHitmonchanPose106:
+ax_pose 38, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose107:
+ax_pose 39, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose108:
+ax_pose 40, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose109:
+ax_pose 41, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose110:
+ax_pose 40, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose111:
+ax_pose 39, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose112:
+ax_pose 38, 0x01e4, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose113:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose114:
+ax_pose 37, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose115:
+ax_pose 42, 0x01df, 0x80ef, 0x6c00
+ax_pose 43, 0x81e2, 0x80f3, 0x6c10
+ax_pose 44, 0x81e2, 0x4103, 0x6c18
+ax_pose 45, 0x01da, 0x00f5, 0x6c1c
+ax_pose_terminator
+sHitmonchanPose116:
+ax_pose 43, 0x81e2, 0x80f3, 0x6c00
+ax_pose 44, 0x81e2, 0x4103, 0x6c08
+ax_pose 45, 0x01da, 0x00f5, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose117:
+ax_pose 1, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose118:
+ax_pose 2, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose119:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose120:
+ax_pose 38, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose121:
+ax_pose 46, 0x01e0, 0x80ee, 0x6c00
+ax_pose 47, 0x01e2, 0x80ee, 0x6c10
+ax_pose_terminator
+sHitmonchanPose122:
+ax_pose 47, 0x01e2, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonchanPose123:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose124:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose125:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose126:
+ax_pose 39, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose127:
+ax_pose 48, 0x01df, 0x80f7, 0x6c00
+ax_pose 49, 0x81e2, 0x80f7, 0x6c10
+ax_pose 50, 0x01da, 0x00ff, 0x6c18
+ax_pose_terminator
+sHitmonchanPose128:
+ax_pose 49, 0x81e2, 0x80f7, 0x6c00
+ax_pose 50, 0x01da, 0x00ff, 0x6c08
+ax_pose_terminator
+sHitmonchanPose129:
+ax_pose 7, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose130:
+ax_pose 8, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose131:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose132:
+ax_pose 40, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose133:
+ax_pose 51, 0x81de, 0x80f8, 0x6c00
+ax_pose 52, 0x81de, 0x4108, 0x6c08
+ax_pose 53, 0x01fe, 0x0100, 0x6c0c
+ax_pose 54, 0x81e2, 0x80f2, 0x6c0d
+ax_pose 55, 0x81e2, 0x4102, 0x6c15
+ax_pose 56, 0x01da, 0x0102, 0x6c19
+ax_pose_terminator
+sHitmonchanPose134:
+ax_pose 54, 0x81e2, 0x80f2, 0x6c00
+ax_pose 55, 0x81e2, 0x4102, 0x6c08
+ax_pose 56, 0x01da, 0x0102, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose135:
+ax_pose 10, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose136:
+ax_pose 11, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose137:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose138:
+ax_pose 41, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose139:
+ax_pose 57, 0x01dd, 0x80f3, 0x6c00
+ax_pose 58, 0x81e2, 0x80f2, 0x6c10
+ax_pose 59, 0x81e2, 0x4102, 0x6c18
+ax_pose 60, 0x01da, 0x0102, 0x6c1c
+ax_pose_terminator
+sHitmonchanPose140:
+ax_pose 58, 0x81e2, 0x80f2, 0x6c00
+ax_pose 59, 0x81e2, 0x4102, 0x6c08
+ax_pose 60, 0x01da, 0x0102, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose141:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose142:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose143:
+ax_pose 58, 0x81e1, 0x90fe, 0x6c00
+ax_pose 59, 0x81e1, 0x50f6, 0x6c08
+ax_pose 60, 0x01d9, 0x10f6, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose144:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose145:
+ax_pose 40, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose146:
+ax_pose 61, 0x01dc, 0x80f0, 0x6c00
+ax_pose 62, 0x81e4, 0x80f0, 0x6c10
+ax_pose 63, 0x81e4, 0x4100, 0x6c18
+ax_pose 64, 0x01dc, 0x00fe, 0x6c1c
+ax_pose_terminator
+sHitmonchanPose147:
+ax_pose 62, 0x81e4, 0x80f0, 0x6c00
+ax_pose 63, 0x81e4, 0x4100, 0x6c08
+ax_pose 64, 0x01dc, 0x00fe, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose148:
+ax_pose 10, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose149:
+ax_pose 11, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose150:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose151:
+ax_pose 39, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose152:
+ax_pose 65, 0x01dc, 0x80f0, 0x6c00
+ax_pose 66, 0x81e4, 0x80f8, 0x6c10
+ax_pose 67, 0x01dc, 0x00fa, 0x6c18
+ax_pose_terminator
+sHitmonchanPose153:
+ax_pose 66, 0x81e4, 0x80f8, 0x6c00
+ax_pose 67, 0x01dc, 0x00fa, 0x6c08
+ax_pose_terminator
+sHitmonchanPose154:
+ax_pose 7, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose155:
+ax_pose 8, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose156:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose157:
+ax_pose 38, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose158:
+ax_pose 68, 0x01dc, 0x80f1, 0x6c00
+ax_pose 69, 0x81e3, 0x80f4, 0x6c10
+ax_pose 70, 0x81e3, 0x4104, 0x6c18
+ax_pose 71, 0x01db, 0x00f9, 0x6c1c
+ax_pose_terminator
+sHitmonchanPose159:
+ax_pose 69, 0x81e3, 0x80f4, 0x6c00
+ax_pose 70, 0x81e3, 0x4104, 0x6c08
+ax_pose 71, 0x01db, 0x00f9, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose160:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose161:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose162:
+ax_pose 72, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose163:
+ax_pose 73, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose164:
+ax_pose 74, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose165:
+ax_pose 75, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sHitmonchanPose166:
+ax_pose 76, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose167:
+ax_pose 77, 0x01e9, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose168:
+ax_pose 78, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose169:
+ax_pose 77, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose170:
+ax_pose 76, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose171:
+ax_pose 75, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose172:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose173:
+ax_pose 26, 0x01e9, 0x80ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose174:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose175:
+ax_pose 28, 0x01e6, 0x90f6, 0x6c00
+ax_pose_terminator
+sHitmonchanPose176:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose177:
+ax_pose 30, 0x01e5, 0x90f7, 0x6c00
+ax_pose_terminator
+sHitmonchanPose178:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose179:
+ax_pose 32, 0x01e6, 0x90f4, 0x6c00
+ax_pose_terminator
+sHitmonchanPose180:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose181:
+ax_pose 34, 0x81e7, 0x80f2, 0x6c00
+ax_pose 35, 0x81e7, 0x4102, 0x6c08
+ax_pose 36, 0x01df, 0x00fc, 0x6c0c
+ax_pose_terminator
+sHitmonchanPose182:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose183:
+ax_pose 32, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose184:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose185:
+ax_pose 30, 0x01e5, 0x80e9, 0x6c00
+ax_pose_terminator
+sHitmonchanPose186:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose187:
+ax_pose 28, 0x01e6, 0x80ea, 0x6c00
+ax_pose_terminator
+sHitmonchanPose188:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose189:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose190:
+ax_pose 7, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose191:
+ax_pose 10, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose192:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose193:
+ax_pose 10, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose194:
+ax_pose 7, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose195:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose196:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose197:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose198:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose199:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose200:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose201:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose202:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose203:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose204:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose205:
+ax_pose 2, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose206:
+ax_pose 37, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose207:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose208:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose209:
+ax_pose 38, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose210:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose211:
+ax_pose 7, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose212:
+ax_pose 39, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose213:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose214:
+ax_pose 10, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose215:
+ax_pose 40, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose216:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose217:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose218:
+ax_pose 41, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose219:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose220:
+ax_pose 10, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose221:
+ax_pose 40, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose222:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose223:
+ax_pose 7, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose224:
+ax_pose 39, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose225:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose226:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose227:
+ax_pose 38, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose228:
+ax_pose 37, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sHitmonchanPose229:
+ax_pose 38, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose230:
+ax_pose 39, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose231:
+ax_pose 40, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose232:
+ax_pose 41, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose233:
+ax_pose 40, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose234:
+ax_pose 39, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose235:
+ax_pose 38, 0x01e4, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose236:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose237:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose238:
+ax_pose 6, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sHitmonchanPose239:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonchanPose240:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonchanPose241:
+ax_pose 9, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sHitmonchanPose242:
+ax_pose 6, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHitmonchanPose243:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+.align 2
+sHitmonchanAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 6, 0, 24, 0, -4, 0, -4,
+ax_anim 1, 2, 25, 0, -1, 0, -1,
+ax_anim 1, 0, 26, 0, 6, 0, 6,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 28, 1, 17, 1, 17,
+ax_anim 2, 0, 28, 0, 17, 0, 17,
+ax_anim 2, 0, 28, 1, 17, 1, 17,
+ax_anim 2, 0, 28, 0, 17, 0, 17,
+ax_anim 2, 0, 28, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sHitmonchanAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 6, 0, 29, -4, -4, -4, -4,
+ax_anim 1, 2, 30, -1, -1, -1, -1,
+ax_anim 1, 0, 31, 6, 7, 6, 7,
+ax_anim 2, 0, 32, 12, 15, 12, 15,
+ax_anim 2, 1, 33, 13, 15, 13, 15,
+ax_anim 2, 0, 33, 12, 16, 12, 16,
+ax_anim 2, 0, 33, 13, 15, 13, 15,
+ax_anim 2, 0, 33, 12, 16, 12, 16,
+ax_anim 2, 0, 33, 13, 15, 13, 15,
+ax_anim 2, 0, 29, 11, 12, 11, 12,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sHitmonchanAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 6, 0, 34, -4, 0, -4, 0,
+ax_anim 1, 2, 35, -1, 0, -1, 0,
+ax_anim 1, 0, 36, 6, 0, 6, 0,
+ax_anim 2, 0, 37, 12, 0, 12, 0,
+ax_anim 2, 1, 38, 12, 1, 12, 1,
+ax_anim 2, 0, 38, 12, 0, 12, 0,
+ax_anim 2, 0, 38, 12, 1, 12, 1,
+ax_anim 2, 0, 38, 12, 0, 12, 0,
+ax_anim 2, 0, 38, 12, 1, 12, 1,
+ax_anim 2, 0, 34, 11, 0, 11, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sHitmonchanAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 2, 0, 39, -3, 3, -3, 3,
+ax_anim 6, 0, 39, -4, 4, -4, 4,
+ax_anim 1, 2, 40, -1, 1, -1, 1,
+ax_anim 1, 0, 41, 6, -7, 6, -7,
+ax_anim 2, 0, 42, 14, -15, 14, -15,
+ax_anim 2, 1, 43, 15, -15, 15, -15,
+ax_anim 2, 0, 43, 14, -16, 14, -16,
+ax_anim 2, 0, 43, 15, -15, 15, -15,
+ax_anim 2, 0, 43, 14, -16, 14, -16,
+ax_anim 2, 0, 43, 15, -15, 15, -15,
+ax_anim 2, 0, 39, 11, -12, 11, -12,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sHitmonchanAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 2, 0, 44, 0, 3, 0, 3,
+ax_anim 6, 0, 44, 0, 4, 0, 4,
+ax_anim 1, 2, 45, 0, 1, 0, 1,
+ax_anim 1, 0, 46, 0, -6, 0, -6,
+ax_anim 2, 0, 47, 0, -12, 0, -12,
+ax_anim 2, 1, 48, 1, -12, 1, -12,
+ax_anim 2, 0, 48, 0, -12, 0, -12,
+ax_anim 2, 0, 48, 1, -12, 1, -12,
+ax_anim 2, 0, 48, 0, -12, 0, -12,
+ax_anim 2, 0, 48, 1, -12, 1, -12,
+ax_anim 2, 0, 44, 0, -9, 0, -9,
+ax_anim 2, 0, 44, 0, -2, 0, -2,
+ax_anim_terminator
+sHitmonchanAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 2, 0, 49, 3, 3, 3, 3,
+ax_anim 6, 0, 49, 4, 4, 4, 4,
+ax_anim 1, 2, 50, 1, 1, 1, 1,
+ax_anim 1, 0, 51, -6, -7, -6, -7,
+ax_anim 2, 0, 52, -14, -15, -14, -15,
+ax_anim 2, 1, 53, -15, -15, -15, -15,
+ax_anim 2, 0, 53, -14, -16, -14, -16,
+ax_anim 2, 0, 53, -15, -15, -15, -15,
+ax_anim 2, 0, 53, -14, -16, -14, -16,
+ax_anim 2, 0, 53, -15, -15, -15, -15,
+ax_anim 2, 0, 49, -11, -12, -11, -12,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sHitmonchanAnims_2_7:
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim 6, 0, 54, 4, 0, 4, 0,
+ax_anim 1, 2, 55, 1, 0, 1, 0,
+ax_anim 1, 0, 56, -6, 0, -6, 0,
+ax_anim 2, 0, 57, -12, 0, -12, 0,
+ax_anim 2, 1, 58, -12, 1, -12, 1,
+ax_anim 2, 0, 58, -12, 0, -12, 0,
+ax_anim 2, 0, 58, -12, 1, -12, 1,
+ax_anim 2, 0, 58, -12, 0, -12, 0,
+ax_anim 2, 0, 58, -12, 1, -12, 1,
+ax_anim 2, 0, 54, -11, 0, -11, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sHitmonchanAnims_2_8:
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 2, 0, 59, 3, -3, 3, -3,
+ax_anim 6, 0, 59, 4, -4, 4, -4,
+ax_anim 1, 2, 60, 1, -1, 1, -1,
+ax_anim 1, 0, 61, -6, 7, -6, 7,
+ax_anim 2, 0, 62, -12, 15, -12, 15,
+ax_anim 2, 1, 63, -13, 15, -13, 15,
+ax_anim 2, 0, 63, -12, 16, -12, 16,
+ax_anim 2, 0, 63, -13, 15, -13, 15,
+ax_anim 2, 0, 63, -12, 16, -12, 16,
+ax_anim 2, 0, 63, -13, 15, -13, 15,
+ax_anim 2, 0, 59, -11, 12, -11, 12,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_3_1:
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 6, 0, 101, 0, -3, 0, -3,
+ax_anim 1, 0, 101, 0, 1, 0, 1,
+ax_anim 1, 2, 101, 0, 7, 0, 7,
+ax_anim 2, 0, 67, 0, 16, 0, 16,
+ax_anim 2, 1, 68, 1, 16, 1, 16,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 0, 68, 1, 16, 1, 16,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 0, 68, 1, 16, 1, 16,
+ax_anim 2, 0, 64, 0, 11, 0, 11,
+ax_anim 2, 0, 64, 0, 5, 0, 5,
+ax_anim_terminator
+sHitmonchanAnims_3_2:
+ax_anim 2, 0, 74, -2, -2, -2, -2,
+ax_anim 6, 0, 75, -3, -3, -3, -3,
+ax_anim 1, 0, 75, 1, 1, 1, 1,
+ax_anim 1, 2, 75, 7, 7, 7, 7,
+ax_anim 2, 0, 72, 10, 16, 10, 16,
+ax_anim 2, 1, 73, 11, 15, 11, 15,
+ax_anim 2, 0, 73, 10, 16, 10, 16,
+ax_anim 2, 0, 73, 11, 15, 11, 15,
+ax_anim 2, 0, 73, 10, 16, 10, 16,
+ax_anim 2, 0, 73, 11, 15, 11, 15,
+ax_anim 2, 0, 69, 9, 11, 9, 11,
+ax_anim 2, 0, 69, 4, 5, 4, 5,
+ax_anim_terminator
+sHitmonchanAnims_3_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 0, 80, -3, 0, -3, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 6, 0, 6, 0,
+ax_anim 2, 1, 78, 6, 1, 6, 1,
+ax_anim 2, 0, 78, 6, 0, 6, 0,
+ax_anim 2, 0, 78, 6, 1, 6, 1,
+ax_anim 2, 0, 78, 6, 0, 6, 0,
+ax_anim 2, 0, 78, 6, 1, 6, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim 2, 0, 74, 2, 0, 2, 0,
+ax_anim_terminator
+sHitmonchanAnims_3_4:
+ax_anim 2, 0, 84, -2, 2, -2, 2,
+ax_anim 6, 0, 86, -3, 3, -3, 3,
+ax_anim 1, 0, 86, 1, -1, 1, -1,
+ax_anim 1, 2, 86, 5, -5, 5, -5,
+ax_anim 2, 0, 82, 11, -10, 11, -10,
+ax_anim 2, 1, 83, 12, -10, 12, -10,
+ax_anim 2, 0, 83, 11, -11, 11, -11,
+ax_anim 2, 0, 83, 12, -10, 12, -10,
+ax_anim 2, 0, 83, 11, -11, 11, -11,
+ax_anim 2, 0, 83, 12, -10, 12, -10,
+ax_anim 2, 0, 79, 7, -7, 7, -7,
+ax_anim 2, 0, 79, 3, -3, 3, -3,
+ax_anim_terminator
+sHitmonchanAnims_3_5:
+ax_anim 2, 0, 79, 0, 3, 0, 3,
+ax_anim 6, 0, 81, 0, 4, 0, 4,
+ax_anim 1, 0, 81, 0, 3, 0, 3,
+ax_anim 1, 2, 81, 0, 1, 0, 1,
+ax_anim 2, 0, 87, 0, -6, 0, -6,
+ax_anim 2, 1, 88, 1, -6, 1, -6,
+ax_anim 2, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 88, 1, -6, 1, -6,
+ax_anim 2, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 88, 1, -6, 1, -6,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sHitmonchanAnims_3_6:
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim 6, 0, 85, 3, 3, 3, 3,
+ax_anim 1, 0, 85, -1, -1, -1, -1,
+ax_anim 1, 2, 85, -5, -5, -5, -5,
+ax_anim 2, 0, 92, -11, -10, -11, -10,
+ax_anim 2, 1, 93, -12, -10, -12, -10,
+ax_anim 2, 0, 93, -11, -11, -11, -11,
+ax_anim 2, 0, 93, -12, -10, -12, -10,
+ax_anim 2, 0, 93, -11, -11, -11, -11,
+ax_anim 2, 0, 93, -12, -10, -12, -10,
+ax_anim 2, 0, 89, -7, -7, -7, -7,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim_terminator
+sHitmonchanAnims_3_7:
+ax_anim 2, 0, 89, 2, 0, 2, 0,
+ax_anim 6, 0, 90, 3, 0, 3, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 2, 90, -3, 0, -3, 0,
+ax_anim 2, 0, 97, -6, 0, -6, 0,
+ax_anim 2, 1, 98, -6, 1, -6, 1,
+ax_anim 2, 0, 98, -6, 0, -6, 0,
+ax_anim 2, 0, 98, -6, 1, -6, 1,
+ax_anim 2, 0, 98, -6, 0, -6, 0,
+ax_anim 2, 0, 98, -6, 1, -6, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim 2, 0, 94, -2, 0, -2, 0,
+ax_anim_terminator
+sHitmonchanAnims_3_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 0, 95, 3, -3, 3, -3,
+ax_anim 1, 0, 95, -1, 1, -1, 1,
+ax_anim 1, 2, 95, -7, 7, -7, 7,
+ax_anim 2, 0, 102, -10, 16, -10, 16,
+ax_anim 2, 1, 103, -11, 15, -11, 15,
+ax_anim 2, 0, 103, -10, 16, -10, 16,
+ax_anim 2, 0, 103, -11, 15, -11, 15,
+ax_anim 2, 0, 103, -10, 16, -10, 16,
+ax_anim 2, 0, 103, -11, 15, -11, 15,
+ax_anim 2, 0, 99, -9, 11, -9, 11,
+ax_anim 2, 0, 99, -4, 5, -4, 5,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_4_1:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 1, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_4_2:
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_4_3:
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_4_4:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_4_5:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_4_6:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_4_7:
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_4_8:
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_5_1:
+ax_anim 1, 0, 113, 0, 11, 0, 11,
+ax_anim 2, 0, 156, 0, 19, 0, 19,
+ax_anim 4, 0, 156, 0, 20, 0, 20,
+ax_anim 3, 2, 156, 0, 20, 0, 20,
+ax_anim 1, 0, 114, 0, 20, 0, 20,
+ax_anim 1, 1, 115, 1, 13, 0, 20,
+ax_anim 2, 0, 121, 2, 8, 0, 20,
+ax_anim 2, 0, 127, 1, 5, 0, 20,
+ax_anim 2, 0, 133, 0, 2, 0, 20,
+ax_anim 2, 0, 139, -1, 3, 0, 20,
+ax_anim 2, 0, 146, -1, 6, 0, 20,
+ax_anim 2, 0, 152, -1, 10, 0, 20,
+ax_anim 2, 0, 159, 0, 15, 0, 20,
+ax_anim 4, 0, 113, 0, 20, 0, 20,
+ax_anim 1, 0, 116, 0, 10, 0, 10,
+ax_anim 1, 0, 117, 0, 4, 0, 4,
+ax_anim_terminator
+sHitmonchanAnims_5_2:
+ax_anim 1, 0, 119, 11, 11, 11, 11,
+ax_anim 2, 0, 113, 19, 19, 19, 19,
+ax_anim 4, 0, 113, 20, 20, 20, 20,
+ax_anim 3, 2, 113, 20, 20, 20, 20,
+ax_anim 1, 0, 120, 23, 20, 22, 20,
+ax_anim 1, 1, 121, 23, 13, 22, 20,
+ax_anim 2, 0, 127, 21, 8, 22, 20,
+ax_anim 2, 0, 133, 20, 5, 22, 20,
+ax_anim 2, 0, 139, 21, 2, 22, 20,
+ax_anim 2, 0, 146, 20, 2, 22, 20,
+ax_anim 2, 0, 152, 19, 5, 22, 20,
+ax_anim 2, 0, 158, 19, 8, 22, 20,
+ax_anim 2, 0, 116, 21, 11, 22, 20,
+ax_anim 4, 0, 119, 20, 20, 22, 20,
+ax_anim 1, 0, 122, 10, 10, 10, 10,
+ax_anim 1, 0, 123, 4, 4, 4, 4,
+ax_anim_terminator
+sHitmonchanAnims_5_3:
+ax_anim 1, 0, 125, 11, 0, 11, 0,
+ax_anim 2, 0, 119, 16, 0, 16, 0,
+ax_anim 4, 0, 119, 17, 0, 17, 0,
+ax_anim 3, 2, 119, 17, 0, 17, 0,
+ax_anim 1, 0, 126, 20, -4, 20, 0,
+ax_anim 1, 1, 127, 20, -9, 20, 0,
+ax_anim 2, 0, 133, 19, -12, 20, 0,
+ax_anim 2, 0, 139, 20, -14, 20, 0,
+ax_anim 2, 0, 146, 19, -15, 20, 0,
+ax_anim 2, 0, 152, 19, -13, 20, 0,
+ax_anim 2, 0, 158, 18, -11, 20, 0,
+ax_anim 2, 0, 115, 20, -8, 20, 0,
+ax_anim 2, 0, 122, 20, -5, 20, 0,
+ax_anim 4, 0, 125, 20, 0, 20, 0,
+ax_anim 1, 0, 128, 10, 0, 10, 0,
+ax_anim 1, 0, 129, 4, 0, 4, 0,
+ax_anim_terminator
+sHitmonchanAnims_5_4:
+ax_anim 1, 0, 131, 11, -11, 11, -11,
+ax_anim 2, 0, 125, 19, -19, 19, -19,
+ax_anim 4, 0, 125, 20, -20, 20, -20,
+ax_anim 3, 2, 125, 20, -20, 20, -20,
+ax_anim 1, 0, 132, 20, -24, 22, -22,
+ax_anim 1, 1, 133, 21, -30, 23, -22,
+ax_anim 2, 0, 139, 20, -36, 22, -22,
+ax_anim 2, 0, 146, 19, -37, 22, -22,
+ax_anim 2, 0, 152, 19, -34, 22, -22,
+ax_anim 2, 0, 158, 19, -32, 22, -22,
+ax_anim 2, 0, 115, 20, -29, 22, -22,
+ax_anim 2, 0, 121, 21, -27, 22, -22,
+ax_anim 2, 0, 128, 22, -26, 22, -22,
+ax_anim 4, 0, 131, 20, -20, 22, -22,
+ax_anim 1, 0, 134, 10, -10, 10, -10,
+ax_anim 1, 0, 135, 4, -4, 4, -4,
+ax_anim_terminator
+sHitmonchanAnims_5_5:
+ax_anim 1, 0, 137, 0, -11, 0, -11,
+ax_anim 2, 0, 131, 0, -19, 0, -19,
+ax_anim 4, 0, 131, 0, -20, 0, -20,
+ax_anim 3, 2, 131, 0, -20, 0, -20,
+ax_anim 1, 0, 138, 0, -27, 0, -22,
+ax_anim 1, 1, 139, 0, -32, 0, -22,
+ax_anim 2, 0, 146, -1, -36, 0, -22,
+ax_anim 2, 0, 152, -1, -39, 0, -22,
+ax_anim 2, 0, 158, -1, -36, 0, -22,
+ax_anim 2, 0, 115, 0, -33, 0, -22,
+ax_anim 2, 0, 121, 0, -31, 0, -22,
+ax_anim 2, 0, 127, 0, -28, 0, -22,
+ax_anim 2, 0, 134, 0, -26, 0, -22,
+ax_anim 4, 0, 137, 0, -20, 0, -20,
+ax_anim 1, 0, 140, 0, -10, 0, -10,
+ax_anim 1, 0, 141, 0, -4, 0, -4,
+ax_anim_terminator
+sHitmonchanAnims_5_6:
+ax_anim 1, 0, 144, -11, -11, -11, -11,
+ax_anim 2, 0, 137, -19, -19, -19, -19,
+ax_anim 4, 0, 137, -20, -20, -20, -20,
+ax_anim 3, 2, 137, -20, -20, -20, -20,
+ax_anim 1, 0, 145, -22, -24, -22, -22,
+ax_anim 1, 1, 146, -23, -30, -23, -22,
+ax_anim 2, 0, 152, -24, -36, -22, -22,
+ax_anim 2, 0, 158, -25, -37, -22, -22,
+ax_anim 2, 0, 115, -23, -34, -22, -22,
+ax_anim 2, 0, 121, -21, -32, -22, -22,
+ax_anim 2, 0, 127, -21, -29, -22, -22,
+ax_anim 2, 0, 133, -21, -27, -22, -22,
+ax_anim 2, 0, 140, -21, -26, -22, -22,
+ax_anim 4, 0, 144, -20, -20, -22, -22,
+ax_anim 1, 0, 147, -10, -10, -10, -10,
+ax_anim 1, 0, 148, -4, -4, -4, -4,
+ax_anim_terminator
+sHitmonchanAnims_5_7:
+ax_anim 1, 0, 150, -11, 0, -11, 0,
+ax_anim 2, 0, 144, -16, 0, -16, 0,
+ax_anim 4, 0, 144, -17, 0, -17, 0,
+ax_anim 3, 2, 144, -17, 0, -17, 0,
+ax_anim 1, 0, 151, -21, -4, -20, 0,
+ax_anim 1, 1, 152, -21, -9, -20, 0,
+ax_anim 2, 0, 158, -22, -12, -20, 0,
+ax_anim 2, 0, 115, -20, -15, -20, 0,
+ax_anim 2, 0, 121, -20, -15, -20, 0,
+ax_anim 2, 0, 127, -19, -13, -20, 0,
+ax_anim 2, 0, 133, -20, -11, -20, 0,
+ax_anim 2, 0, 139, -20, -8, -20, 0,
+ax_anim 2, 0, 147, -20, -5, -20, 0,
+ax_anim 4, 0, 150, -20, 0, -20, 0,
+ax_anim 1, 0, 153, -10, 0, -10, 0,
+ax_anim 1, 0, 154, -4, 0, -4, 0,
+ax_anim_terminator
+sHitmonchanAnims_5_8:
+ax_anim 1, 0, 156, -11, 11, -11, 11,
+ax_anim 2, 0, 150, -19, 19, -19, 19,
+ax_anim 4, 0, 150, -20, 20, -20, 20,
+ax_anim 3, 2, 150, -20, 20, -20, 20,
+ax_anim 1, 0, 157, -23, 20, -22, 20,
+ax_anim 1, 1, 158, -23, 13, -22, 20,
+ax_anim 2, 0, 115, -22, 8, -22, 20,
+ax_anim 2, 0, 121, -22, 5, -22, 20,
+ax_anim 2, 0, 127, -21, 2, -22, 20,
+ax_anim 2, 0, 133, -22, 3, -22, 20,
+ax_anim 2, 0, 139, -22, 6, -22, 20,
+ax_anim 2, 0, 146, -23, 7, -22, 20,
+ax_anim 2, 0, 153, -22, 9, -22, 20,
+ax_anim 4, 0, 156, -20, 20, -22, 20,
+ax_anim 1, 0, 159, -10, 10, -10, 10,
+ax_anim 1, 0, 160, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_6_1:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 35, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_7_1:
+ax_anim 2, 0, 163, 0, -4, 0, -4,
+ax_anim 8, 0, 163, 0, -5, 0, -5,
+ax_anim_terminator
+sHitmonchanAnims_7_2:
+ax_anim 2, 0, 164, -4, -4, -4, -4,
+ax_anim 8, 0, 164, -5, -5, -5, -5,
+ax_anim_terminator
+sHitmonchanAnims_7_3:
+ax_anim 2, 0, 165, -4, 0, -4, 0,
+ax_anim 8, 0, 165, -5, 0, -5, 0,
+ax_anim_terminator
+sHitmonchanAnims_7_4:
+ax_anim 2, 0, 166, -4, 4, -4, 4,
+ax_anim 8, 0, 166, -5, 5, -5, 5,
+ax_anim_terminator
+sHitmonchanAnims_7_5:
+ax_anim 2, 0, 167, 0, 4, 0, 4,
+ax_anim 8, 0, 167, 0, 5, 0, 5,
+ax_anim_terminator
+sHitmonchanAnims_7_6:
+ax_anim 2, 0, 168, 4, 4, 4, 4,
+ax_anim 8, 0, 168, 5, 5, 5, 5,
+ax_anim_terminator
+sHitmonchanAnims_7_7:
+ax_anim 2, 0, 169, 4, 0, 4, 0,
+ax_anim 8, 0, 169, 5, 0, 5, 0,
+ax_anim_terminator
+sHitmonchanAnims_7_8:
+ax_anim 2, 0, 170, 4, -4, 4, -4,
+ax_anim 8, 0, 170, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_8_1:
+ax_anim 30, 0, 171, 0, 0, 0, 0,
+ax_anim 6, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 6, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_8_2:
+ax_anim 30, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_8_3:
+ax_anim 30, 0, 175, 0, 0, 0, 0,
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_8_4:
+ax_anim 30, 0, 177, 0, 0, 0, 0,
+ax_anim 6, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 6, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_8_5:
+ax_anim 30, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_8_6:
+ax_anim 30, 0, 181, 0, 0, 0, 0,
+ax_anim 6, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 6, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_8_7:
+ax_anim 30, 0, 183, 0, 0, 0, 0,
+ax_anim 6, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 6, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_8_8:
+ax_anim 30, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 186, 0, 0, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_9_1:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 6, 3, 6, 3,
+ax_anim 2, 0, 189, 8, 9, 8, 9,
+ax_anim 2, 0, 190, 7, 15, 7, 15,
+ax_anim 3, 0, 191, 0, 18, 0, 18,
+ax_anim 2, 3, 192, -7, 15, -7, 15,
+ax_anim 2, 0, 193, -8, 9, -8, 9,
+ax_anim 1, 0, 194, -6, 3, -6, 3,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_9_2:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 8, 0, 8, 0,
+ax_anim 2, 0, 188, 17, 3, 17, 3,
+ax_anim 2, 0, 189, 21, 11, 21, 11,
+ax_anim 3, 0, 190, 20, 17, 20, 17,
+ax_anim 2, 3, 191, 13, 20, 13, 20,
+ax_anim 2, 0, 192, 3, 15, 3, 15,
+ax_anim 1, 0, 193, 0, 7, 0, 7,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_9_3:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 3, -5, 3, -5,
+ax_anim 2, 0, 187, 11, -6, 11, -6,
+ax_anim 2, 0, 188, 18, -5, 18, -5,
+ax_anim 3, 0, 189, 23, -2, 23, -2,
+ax_anim 2, 3, 190, 19, 3, 19, 3,
+ax_anim 2, 0, 191, 12, 5, 12, 5,
+ax_anim 1, 0, 192, 4, 3, 4, 3,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_9_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, -1, -8, -1, -8,
+ax_anim 2, 0, 194, 3, -14, 3, -14,
+ax_anim 2, 0, 187, 10, -21, 10, -21,
+ax_anim 3, 0, 188, 21, -20, 21, -20,
+ax_anim 2, 3, 189, 22, -13, 22, -13,
+ax_anim 2, 0, 190, 17, -4, 17, -4,
+ax_anim 1, 0, 191, 9, 0, 9, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_9_5:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -8, -4, -8, -4,
+ax_anim 2, 0, 193, -9, -12, -9, -12,
+ax_anim 2, 0, 194, -7, -17, -7, -17,
+ax_anim 3, 0, 187, 0, -20, 0, -20,
+ax_anim 2, 3, 188, 7, -17, 7, -17,
+ax_anim 2, 0, 189, 9, -10, 9, -10,
+ax_anim 1, 0, 190, 8, -4, 8, -4,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_9_6:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 1, -8, 1, -8,
+ax_anim 2, 0, 188, -3, -14, -3, -14,
+ax_anim 2, 0, 187, -10, -21, -10, -21,
+ax_anim 3, 0, 194, -21, -20, -21, -20,
+ax_anim 2, 3, 193, -22, -13, -22, -13,
+ax_anim 2, 0, 192, -17, -4, -17, -4,
+ax_anim 1, 0, 191, -9, 0, -9, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_9_7:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, -3, -5, -3, -5,
+ax_anim 2, 0, 187, -11, -6, -11, -6,
+ax_anim 2, 0, 194, -18, -5, -18, -5,
+ax_anim 3, 0, 193, -23, -2, -23, -2,
+ax_anim 2, 3, 192, -19, 3, -19, 3,
+ax_anim 2, 0, 191, -12, 5, -12, 5,
+ax_anim 1, 0, 190, -4, 3, -4, 3,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_9_8:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -8, 0, -8, 0,
+ax_anim 2, 0, 194, -17, 3, -17, 3,
+ax_anim 2, 0, 193, -21, 11, -21, 11,
+ax_anim 3, 0, 192, -20, 17, -20, 17,
+ax_anim 2, 3, 191, -13, 20, -13, 20,
+ax_anim 2, 0, 190, -3, 15, -3, 15,
+ax_anim 1, 0, 189, 0, 7, 0, 7,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_10_1:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, 0, 6, 0,
+ax_anim 2, 0, 195, -6, 0, -6, 0,
+ax_anim 2, 0, 195, 10, 0, 10, 0,
+ax_anim 2, 0, 195, -10, 0, -10, 0,
+ax_anim 2, 0, 195, 12, 0, 12, 0,
+ax_anim 3, 0, 195, -12, 0, -12, 0,
+ax_anim 3, 0, 195, 13, 0, 13, 0,
+ax_anim 3, 0, 195, -13, 0, -13, 0,
+ax_anim 2, 0, 195, 12, 0, 12, 0,
+ax_anim 3, 0, 195, -12, 0, -12, 0,
+ax_anim 2, 0, 195, 10, 0, 10, 0,
+ax_anim 2, 0, 195, -10, 0, -10, 0,
+ax_anim 2, 0, 195, 6, 0, 6, 0,
+ax_anim 2, 0, 195, -6, 0, -6, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_10_2:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 6, -6, 6, -6,
+ax_anim 2, 0, 196, -6, 6, -6, 6,
+ax_anim 2, 0, 196, 10, -10, 10, -10,
+ax_anim 2, 0, 196, -10, 10, -10, 10,
+ax_anim 2, 0, 196, 12, -12, 12, -12,
+ax_anim 3, 0, 196, -12, 12, -12, 12,
+ax_anim 3, 0, 196, 13, -13, 13, -13,
+ax_anim 3, 0, 196, -13, 13, -13, 13,
+ax_anim 2, 0, 196, 12, -12, 12, -12,
+ax_anim 3, 0, 196, -12, 12, -12, 12,
+ax_anim 2, 0, 196, 10, -10, 10, -10,
+ax_anim 2, 0, 196, -10, 10, -10, 10,
+ax_anim 2, 0, 196, 6, -6, 6, -6,
+ax_anim 2, 0, 196, -6, 6, -6, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_10_3:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -6, 0, -6,
+ax_anim 2, 0, 197, 0, 6, 0, 6,
+ax_anim 2, 0, 197, 0, -10, 0, -10,
+ax_anim 2, 0, 197, 0, 10, 0, 10,
+ax_anim 2, 0, 197, 0, -12, 0, -12,
+ax_anim 3, 0, 197, 0, 12, 0, 12,
+ax_anim 3, 0, 197, 0, -13, 0, -13,
+ax_anim 3, 0, 197, 0, 13, 0, 13,
+ax_anim 2, 0, 197, 0, -12, 0, -12,
+ax_anim 3, 0, 197, 0, 12, 0, 12,
+ax_anim 2, 0, 197, 0, -10, 0, -10,
+ax_anim 2, 0, 197, 0, 10, 0, 10,
+ax_anim 2, 0, 197, 0, -6, 0, -6,
+ax_anim 2, 0, 197, 0, 6, 0, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_10_4:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -6, -6, -6, -6,
+ax_anim 2, 0, 198, 6, 6, 6, 6,
+ax_anim 2, 0, 198, -10, -10, -10, -10,
+ax_anim 2, 0, 198, 10, 10, 10, 10,
+ax_anim 2, 0, 198, -12, -12, -12, -12,
+ax_anim 3, 0, 198, 12, 12, 12, 12,
+ax_anim 3, 0, 198, -13, -13, -13, -13,
+ax_anim 3, 0, 198, 13, 13, 13, 13,
+ax_anim 2, 0, 198, -12, -12, -12, -12,
+ax_anim 3, 0, 198, 12, 12, 12, 12,
+ax_anim 2, 0, 198, -10, -10, -10, -10,
+ax_anim 2, 0, 198, 10, 10, 10, 10,
+ax_anim 2, 0, 198, -6, -6, -6, -6,
+ax_anim 2, 0, 198, 6, 6, 6, 6,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_10_5:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, 0, 6, 0,
+ax_anim 2, 0, 199, -6, 0, -6, 0,
+ax_anim 2, 0, 199, 10, 0, 10, 0,
+ax_anim 2, 0, 199, -10, 0, -10, 0,
+ax_anim 2, 0, 199, 12, 0, 12, 0,
+ax_anim 3, 0, 199, -12, 0, -12, 0,
+ax_anim 3, 0, 199, 13, 0, 13, 0,
+ax_anim 3, 0, 199, -13, 0, -13, 0,
+ax_anim 2, 0, 199, 12, 0, 12, 0,
+ax_anim 3, 0, 199, -12, 0, -12, 0,
+ax_anim 2, 0, 199, 10, 0, 10, 0,
+ax_anim 2, 0, 199, -10, 0, -10, 0,
+ax_anim 2, 0, 199, 6, 0, 6, 0,
+ax_anim 2, 0, 199, -6, 0, -6, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_10_6:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 6, -6, 6, -6,
+ax_anim 2, 0, 200, -6, 6, -6, 6,
+ax_anim 2, 0, 200, 10, -10, 10, -10,
+ax_anim 2, 0, 200, -10, 10, -10, 10,
+ax_anim 2, 0, 200, 12, -12, 12, -12,
+ax_anim 3, 0, 200, -12, 12, -12, 12,
+ax_anim 3, 0, 200, 13, -13, 13, -13,
+ax_anim 3, 0, 200, -13, 13, -13, 13,
+ax_anim 2, 0, 200, 12, -12, 12, -12,
+ax_anim 3, 0, 200, -12, 12, -12, 12,
+ax_anim 2, 0, 200, 10, -10, 10, -10,
+ax_anim 2, 0, 200, -10, 10, -10, 10,
+ax_anim 2, 0, 200, 6, -6, 6, -6,
+ax_anim 2, 0, 200, -6, 6, -6, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_10_7:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, -6, 0, -6,
+ax_anim 2, 0, 201, 0, 6, 0, 6,
+ax_anim 2, 0, 201, 0, -10, 0, -10,
+ax_anim 2, 0, 201, 0, 10, 0, 10,
+ax_anim 2, 0, 201, 0, -12, 0, -12,
+ax_anim 3, 0, 201, 0, 12, 0, 12,
+ax_anim 3, 0, 201, 0, -13, 0, -13,
+ax_anim 3, 0, 201, 0, 13, 0, 13,
+ax_anim 2, 0, 201, 0, -12, 0, -12,
+ax_anim 3, 0, 201, 0, 12, 0, 12,
+ax_anim 2, 0, 201, 0, -10, 0, -10,
+ax_anim 2, 0, 201, 0, 10, 0, 10,
+ax_anim 2, 0, 201, 0, -6, 0, -6,
+ax_anim 2, 0, 201, 0, 6, 0, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_10_8:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -6, -6, -6, -6,
+ax_anim 2, 0, 202, 6, 6, 6, 6,
+ax_anim 2, 0, 202, -10, -10, -10, -10,
+ax_anim 2, 0, 202, 10, 10, 10, 10,
+ax_anim 2, 0, 202, -12, -12, -12, -12,
+ax_anim 3, 0, 202, 12, 12, 12, 12,
+ax_anim 3, 0, 202, -13, -13, -13, -13,
+ax_anim 3, 0, 202, 13, 13, 13, 13,
+ax_anim 2, 0, 202, -12, -12, -12, -12,
+ax_anim 3, 0, 202, 12, 12, 12, 12,
+ax_anim 2, 0, 202, -10, -10, -10, -10,
+ax_anim 2, 0, 202, 10, 10, 10, 10,
+ax_anim 2, 0, 202, -6, -6, -6, -6,
+ax_anim 2, 0, 202, 6, 6, 6, 6,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_11_1:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_11_2:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -25, 0, 0,
+ax_anim 3, 0, 208, 0, -24, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_11_3:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -25, 0, 0,
+ax_anim 3, 0, 211, 0, -24, 0, 0,
+ax_anim 2, 0, 211, 0, -18, 0, 0,
+ax_anim 1, 0, 211, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_11_4:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -17, 0, 0,
+ax_anim 1, 0, 214, 0, -11, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_11_5:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -24, 0, 0,
+ax_anim 3, 0, 217, 0, -23, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_11_6:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -17, 0, 0,
+ax_anim 1, 0, 220, 0, -11, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_11_7:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -25, 0, 0,
+ax_anim 3, 0, 223, 0, -24, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_11_8:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -25, 0, 0,
+ax_anim 3, 0, 226, 0, -24, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_12_1:
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_12_2:
+ax_anim 2, 0, 234, 1, -1, 1, -1,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, -1, 1, -1,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, -1, 1, -1,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, -1, 1, -1,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, -1, 1, -1,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_12_3:
+ax_anim 2, 0, 233, 0, -1, 0, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, -1, 0, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, -1, 0, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, -1, 0, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, -1, 0, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_12_4:
+ax_anim 2, 0, 232, -1, -1, -1, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, -1, -1, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, -1, -1, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, -1, -1, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, -1, -1, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_12_5:
+ax_anim 2, 0, 231, 1, 0, 1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, 0, 1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, 0, 1, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, 0, 1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, 0, 1, 0,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_12_6:
+ax_anim 2, 0, 230, 1, -1, 1, -1,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, -1, 1, -1,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, -1, 1, -1,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, -1, 1, -1,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, -1, 1, -1,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_12_7:
+ax_anim 2, 0, 229, 0, -1, 0, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, -1, 0, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, -1, 0, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, -1, 0, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, -1, 0, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_12_8:
+ax_anim 2, 0, 228, -1, -1, -1, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, -1, -1, -1, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, -1, -1, -1, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, -1, -1, -1, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, -1, -1, -1, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonchanAnims_13_1:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_13_2:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_13_3:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_13_4:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_13_5:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_13_6:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_13_7:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanAnims_13_8:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonchanGfx1:
+.incbin "baserom.gba", 0x99B8A4, 0x200
+sHitmonchanSprites1:
+ax_sprite sHitmonchanGfx1, 0x200
+ax_sprite_terminator
+sHitmonchanGfx2:
+.incbin "baserom.gba", 0x99BAB4, 0x200
+sHitmonchanSprites2:
+ax_sprite sHitmonchanGfx2, 0x200
+ax_sprite_terminator
+sHitmonchanGfx3:
+.incbin "baserom.gba", 0x99BCC4, 0x200
+sHitmonchanSprites3:
+ax_sprite sHitmonchanGfx3, 0x200
+ax_sprite_terminator
+sHitmonchanGfx4:
+.incbin "baserom.gba", 0x99BED4, 0x200
+sHitmonchanSprites4:
+ax_sprite sHitmonchanGfx4, 0x200
+ax_sprite_terminator
+sHitmonchanGfx5:
+.incbin "baserom.gba", 0x99C0E4, 0x200
+sHitmonchanSprites5:
+ax_sprite sHitmonchanGfx5, 0x200
+ax_sprite_terminator
+sHitmonchanGfx6:
+.incbin "baserom.gba", 0x99C2F4, 0x200
+sHitmonchanSprites6:
+ax_sprite sHitmonchanGfx6, 0x200
+ax_sprite_terminator
+sHitmonchanGfx7:
+.incbin "baserom.gba", 0x99C504, 0x200
+sHitmonchanSprites7:
+ax_sprite sHitmonchanGfx7, 0x200
+ax_sprite_terminator
+sHitmonchanGfx8:
+.incbin "baserom.gba", 0x99C714, 0x200
+sHitmonchanSprites8:
+ax_sprite sHitmonchanGfx8, 0x200
+ax_sprite_terminator
+sHitmonchanGfx9:
+.incbin "baserom.gba", 0x99C924, 0x200
+sHitmonchanSprites9:
+ax_sprite sHitmonchanGfx9, 0x200
+ax_sprite_terminator
+sHitmonchanGfx10:
+.incbin "baserom.gba", 0x99CB34, 0x200
+sHitmonchanSprites10:
+ax_sprite sHitmonchanGfx10, 0x200
+ax_sprite_terminator
+sHitmonchanGfx11:
+.incbin "baserom.gba", 0x99CD44, 0x200
+sHitmonchanSprites11:
+ax_sprite sHitmonchanGfx11, 0x200
+ax_sprite_terminator
+sHitmonchanGfx12:
+.incbin "baserom.gba", 0x99CF54, 0x200
+sHitmonchanSprites12:
+ax_sprite sHitmonchanGfx12, 0x200
+ax_sprite_terminator
+sHitmonchanGfx13:
+.incbin "baserom.gba", 0x99D164, 0x200
+sHitmonchanSprites13:
+ax_sprite sHitmonchanGfx13, 0x200
+ax_sprite_terminator
+sHitmonchanGfx14:
+.incbin "baserom.gba", 0x99D374, 0x200
+sHitmonchanSprites14:
+ax_sprite sHitmonchanGfx14, 0x200
+ax_sprite_terminator
+sHitmonchanGfx15:
+.incbin "baserom.gba", 0x99D584, 0x200
+sHitmonchanSprites15:
+ax_sprite sHitmonchanGfx15, 0x200
+ax_sprite_terminator
+sHitmonchanGfx16:
+.incbin "baserom.gba", 0x99D794, 0x40
+sHitmonchanGfx16_1:
+.incbin "baserom.gba", 0x99D7D4, 0x120
+sHitmonchanSprites16:
+ax_sprite 0, 0x60
+ax_sprite sHitmonchanGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx16_1, 0x120
+ax_sprite_terminator
+sHitmonchanGfx17:
+.incbin "baserom.gba", 0x99D91C, 0x40
+sHitmonchanGfx17_1:
+.incbin "baserom.gba", 0x99D95C, 0x60
+sHitmonchanGfx17_2:
+.incbin "baserom.gba", 0x99D9BC, 0x60
+sHitmonchanGfx17_3:
+.incbin "baserom.gba", 0x99DA1C, 0x60
+sHitmonchanSprites17:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx17_3, 0x60
+ax_sprite_terminator
+sHitmonchanGfx18:
+.incbin "baserom.gba", 0x99DAC4, 0x200
+sHitmonchanSprites18:
+ax_sprite sHitmonchanGfx18, 0x200
+ax_sprite_terminator
+sHitmonchanGfx19:
+.incbin "baserom.gba", 0x99DCD4, 0x160
+sHitmonchanGfx19_1:
+.incbin "baserom.gba", 0x99DE34, 0x40
+sHitmonchanSprites19:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx19, 0x160
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx20:
+.incbin "baserom.gba", 0x99DEA4, 0x60
+sHitmonchanGfx20_1:
+.incbin "baserom.gba", 0x99DF04, 0xE0
+sHitmonchanGfx20_2:
+.incbin "baserom.gba", 0x99DFE4, 0x40
+sHitmonchanSprites20:
+ax_sprite sHitmonchanGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx20_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx20_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmonchanGfx21:
+.incbin "baserom.gba", 0x99E05C, 0x40
+sHitmonchanGfx21_1:
+.incbin "baserom.gba", 0x99E09C, 0x160
+sHitmonchanSprites21:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx22:
+.incbin "baserom.gba", 0x99E22C, 0xE0
+sHitmonchanGfx22_1:
+.incbin "baserom.gba", 0x99E30C, 0xE0
+sHitmonchanSprites22:
+ax_sprite sHitmonchanGfx22, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx23:
+.incbin "baserom.gba", 0x99E414, 0x60
+sHitmonchanGfx23_1:
+.incbin "baserom.gba", 0x99E474, 0x100
+sHitmonchanGfx23_2:
+.incbin "baserom.gba", 0x99E574, 0x20
+sHitmonchanSprites23:
+ax_sprite sHitmonchanGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx23_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx23_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx24:
+.incbin "baserom.gba", 0x99E5CC, 0x1C0
+sHitmonchanGfx24_1:
+.incbin "baserom.gba", 0x99E78C, 0x20
+sHitmonchanSprites24:
+ax_sprite sHitmonchanGfx24, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx24_1, 0x20
+ax_sprite_terminator
+sHitmonchanGfx25:
+.incbin "baserom.gba", 0x99E7CC, 0x40
+sHitmonchanGfx25_1:
+.incbin "baserom.gba", 0x99E80C, 0x60
+sHitmonchanGfx25_2:
+.incbin "baserom.gba", 0x99E86C, 0x40
+sHitmonchanGfx25_3:
+.incbin "baserom.gba", 0x99E8AC, 0x40
+sHitmonchanSprites25:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx25_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx26:
+.incbin "baserom.gba", 0x99E93C, 0x40
+sHitmonchanGfx26_1:
+.incbin "baserom.gba", 0x99E97C, 0x60
+sHitmonchanGfx26_2:
+.incbin "baserom.gba", 0x99E9DC, 0xE0
+sHitmonchanSprites26:
+ax_sprite sHitmonchanGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx26_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx27:
+.incbin "baserom.gba", 0x99EAF4, 0x60
+sHitmonchanGfx27_1:
+.incbin "baserom.gba", 0x99EB54, 0xE0
+sHitmonchanGfx27_2:
+.incbin "baserom.gba", 0x99EC34, 0x40
+sHitmonchanSprites27:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx27_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx28:
+.incbin "baserom.gba", 0x99ECB4, 0x40
+sHitmonchanGfx28_1:
+.incbin "baserom.gba", 0x99ECF4, 0x60
+sHitmonchanGfx28_2:
+.incbin "baserom.gba", 0x99ED54, 0x60
+sHitmonchanGfx28_3:
+.incbin "baserom.gba", 0x99EDB4, 0x40
+sHitmonchanSprites28:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx28_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmonchanGfx29:
+.incbin "baserom.gba", 0x99EE44, 0x20
+sHitmonchanGfx29_1:
+.incbin "baserom.gba", 0x99EE64, 0x160
+sHitmonchanSprites29:
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx29_1, 0x160
+ax_sprite_terminator
+sHitmonchanGfx30:
+.incbin "baserom.gba", 0x99EFEC, 0x40
+sHitmonchanGfx30_1:
+.incbin "baserom.gba", 0x99F02C, 0x60
+sHitmonchanGfx30_2:
+.incbin "baserom.gba", 0x99F08C, 0x60
+sHitmonchanGfx30_3:
+.incbin "baserom.gba", 0x99F0EC, 0x80
+sHitmonchanSprites30:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx30_3, 0x80
+ax_sprite_terminator
+sHitmonchanGfx31:
+.incbin "baserom.gba", 0x99F1B4, 0x20
+sHitmonchanGfx31_1:
+.incbin "baserom.gba", 0x99F1D4, 0x100
+sHitmonchanGfx31_2:
+.incbin "baserom.gba", 0x99F2D4, 0x60
+sHitmonchanSprites31:
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx31, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx31_2, 0x60
+ax_sprite_terminator
+sHitmonchanGfx32:
+.incbin "baserom.gba", 0x99F36C, 0x100
+sHitmonchanGfx32_1:
+.incbin "baserom.gba", 0x99F46C, 0x20
+sHitmonchanGfx32_2:
+.incbin "baserom.gba", 0x99F48C, 0x20
+sHitmonchanSprites32:
+ax_sprite sHitmonchanGfx32, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx32_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx32_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHitmonchanGfx33:
+.incbin "baserom.gba", 0x99F4E4, 0x60
+sHitmonchanGfx33_1:
+.incbin "baserom.gba", 0x99F544, 0x60
+sHitmonchanGfx33_2:
+.incbin "baserom.gba", 0x99F5A4, 0x60
+sHitmonchanGfx33_3:
+.incbin "baserom.gba", 0x99F604, 0x60
+sHitmonchanSprites33:
+ax_sprite sHitmonchanGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx33_3, 0x60
+ax_sprite_terminator
+sHitmonchanGfx34:
+.incbin "baserom.gba", 0x99F6A4, 0x60
+sHitmonchanGfx34_1:
+.incbin "baserom.gba", 0x99F704, 0x60
+sHitmonchanGfx34_2:
+.incbin "baserom.gba", 0x99F764, 0x40
+sHitmonchanGfx34_3:
+.incbin "baserom.gba", 0x99F7A4, 0x40
+sHitmonchanSprites34:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx34_3, 0x40
+ax_sprite_terminator
+sHitmonchanGfx35:
+.incbin "baserom.gba", 0x99F82C, 0xC0
+sHitmonchanGfx35_1:
+.incbin "baserom.gba", 0x99F8EC, 0x20
+sHitmonchanSprites35:
+ax_sprite sHitmonchanGfx35, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx35_1, 0x20
+ax_sprite_terminator
+sHitmonchanGfx36:
+.incbin "baserom.gba", 0x99F92C, 0x60
+sHitmonchanSprites36:
+ax_sprite sHitmonchanGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx37:
+.incbin "baserom.gba", 0x99F9A4, 0x20
+sHitmonchanSprites37:
+ax_sprite sHitmonchanGfx37, 0x20
+ax_sprite_terminator
+sHitmonchanGfx38:
+.incbin "baserom.gba", 0x99F9D4, 0x20
+sHitmonchanGfx38_1:
+.incbin "baserom.gba", 0x99F9F4, 0x60
+sHitmonchanGfx38_2:
+.incbin "baserom.gba", 0x99FA54, 0x60
+sHitmonchanGfx38_3:
+.incbin "baserom.gba", 0x99FAB4, 0x60
+sHitmonchanSprites38:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx38, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx39:
+.incbin "baserom.gba", 0x99FB64, 0x60
+sHitmonchanGfx39_1:
+.incbin "baserom.gba", 0x99FBC4, 0x60
+sHitmonchanGfx39_2:
+.incbin "baserom.gba", 0x99FC24, 0x40
+sHitmonchanSprites39:
+ax_sprite 0, 0x80
+ax_sprite sHitmonchanGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx39_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx39_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx40:
+.incbin "baserom.gba", 0x99FCA4, 0x60
+sHitmonchanGfx40_1:
+.incbin "baserom.gba", 0x99FD04, 0x60
+sHitmonchanGfx40_2:
+.incbin "baserom.gba", 0x99FD64, 0x60
+sHitmonchanSprites40:
+ax_sprite 0, 0x80
+ax_sprite sHitmonchanGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx41:
+.incbin "baserom.gba", 0x99FE04, 0x40
+sHitmonchanGfx41_1:
+.incbin "baserom.gba", 0x99FE44, 0x60
+sHitmonchanGfx41_2:
+.incbin "baserom.gba", 0x99FEA4, 0x80
+sHitmonchanGfx41_3:
+.incbin "baserom.gba", 0x99FF24, 0x40
+sHitmonchanSprites41:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx41_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx41_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx42:
+.incbin "baserom.gba", 0x99FFB4, 0x20
+sHitmonchanGfx42_1:
+.incbin "baserom.gba", 0x99FFD4, 0x60
+sHitmonchanGfx42_2:
+.incbin "baserom.gba", 0x9A0034, 0x60
+sHitmonchanGfx42_3:
+.incbin "baserom.gba", 0x9A0094, 0x60
+sHitmonchanSprites42:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx42, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx42_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx43:
+.incbin "baserom.gba", 0x9A0144, 0x60
+sHitmonchanGfx43_1:
+.incbin "baserom.gba", 0x9A01A4, 0xC0
+sHitmonchanGfx43_2:
+.incbin "baserom.gba", 0x9A0264, 0x40
+sHitmonchanSprites43:
+ax_sprite sHitmonchanGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx43_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx43_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmonchanGfx44:
+.incbin "baserom.gba", 0x9A02DC, 0xC0
+sHitmonchanGfx44_1:
+.incbin "baserom.gba", 0x9A039C, 0x20
+sHitmonchanSprites44:
+ax_sprite sHitmonchanGfx44, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx44_1, 0x20
+ax_sprite_terminator
+sHitmonchanGfx45:
+.incbin "baserom.gba", 0x9A03DC, 0x60
+sHitmonchanSprites45:
+ax_sprite sHitmonchanGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx46:
+.incbin "baserom.gba", 0x9A0454, 0x20
+sHitmonchanSprites46:
+ax_sprite sHitmonchanGfx46, 0x20
+ax_sprite_terminator
+sHitmonchanGfx47:
+.incbin "baserom.gba", 0x9A0484, 0xE0
+sHitmonchanGfx47_1:
+.incbin "baserom.gba", 0x9A0564, 0x40
+sHitmonchanGfx47_2:
+.incbin "baserom.gba", 0x9A05A4, 0x40
+sHitmonchanSprites47:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx47, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx47_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx47_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx48:
+.incbin "baserom.gba", 0x9A0624, 0x60
+sHitmonchanGfx48_1:
+.incbin "baserom.gba", 0x9A0684, 0x60
+sHitmonchanGfx48_2:
+.incbin "baserom.gba", 0x9A06E4, 0x60
+sHitmonchanGfx48_3:
+.incbin "baserom.gba", 0x9A0744, 0x40
+sHitmonchanSprites48:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx48_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx49:
+.incbin "baserom.gba", 0x9A07D4, 0xE0
+sHitmonchanGfx49_1:
+.incbin "baserom.gba", 0x9A08B4, 0x40
+sHitmonchanGfx49_2:
+.incbin "baserom.gba", 0x9A08F4, 0x20
+sHitmonchanSprites49:
+ax_sprite sHitmonchanGfx49, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx49_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sHitmonchanGfx49_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx50:
+.incbin "baserom.gba", 0x9A094C, 0x100
+sHitmonchanSprites50:
+ax_sprite sHitmonchanGfx50, 0x100
+ax_sprite_terminator
+sHitmonchanGfx51:
+.incbin "baserom.gba", 0x9A0A5C, 0x20
+sHitmonchanSprites51:
+ax_sprite sHitmonchanGfx51, 0x20
+ax_sprite_terminator
+sHitmonchanGfx52:
+.incbin "baserom.gba", 0x9A0A8C, 0x40
+sHitmonchanGfx52_1:
+.incbin "baserom.gba", 0x9A0ACC, 0x20
+sHitmonchanGfx52_2:
+.incbin "baserom.gba", 0x9A0AEC, 0x20
+sHitmonchanGfx52_3:
+.incbin "baserom.gba", 0x9A0B0C, 0x20
+sHitmonchanSprites52:
+ax_sprite sHitmonchanGfx52, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx52_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx52_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx52_3, 0x20
+ax_sprite_terminator
+sHitmonchanGfx53:
+.incbin "baserom.gba", 0x9A0B6C, 0x60
+sHitmonchanSprites53:
+ax_sprite sHitmonchanGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx54:
+.incbin "baserom.gba", 0x9A0BE4, 0x20
+sHitmonchanSprites54:
+ax_sprite sHitmonchanGfx54, 0x20
+ax_sprite_terminator
+sHitmonchanGfx55:
+.incbin "baserom.gba", 0x9A0C14, 0xC0
+sHitmonchanGfx55_1:
+.incbin "baserom.gba", 0x9A0CD4, 0x20
+sHitmonchanSprites55:
+ax_sprite sHitmonchanGfx55, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx55_1, 0x20
+ax_sprite_terminator
+sHitmonchanGfx56:
+.incbin "baserom.gba", 0x9A0D14, 0x80
+sHitmonchanSprites56:
+ax_sprite sHitmonchanGfx56, 0x80
+ax_sprite_terminator
+sHitmonchanGfx57:
+.incbin "baserom.gba", 0x9A0DA4, 0x20
+sHitmonchanSprites57:
+ax_sprite sHitmonchanGfx57, 0x20
+ax_sprite_terminator
+sHitmonchanGfx58:
+.incbin "baserom.gba", 0x9A0DD4, 0x100
+sHitmonchanGfx58_1:
+.incbin "baserom.gba", 0x9A0ED4, 0x40
+sHitmonchanGfx58_2:
+.incbin "baserom.gba", 0x9A0F14, 0x20
+sHitmonchanSprites58:
+ax_sprite sHitmonchanGfx58, 0x100
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx58_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx58_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonchanGfx59:
+.incbin "baserom.gba", 0x9A0F6C, 0xC0
+sHitmonchanGfx59_1:
+.incbin "baserom.gba", 0x9A102C, 0x20
+sHitmonchanSprites59:
+ax_sprite sHitmonchanGfx59, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx59_1, 0x20
+ax_sprite_terminator
+sHitmonchanGfx60:
+.incbin "baserom.gba", 0x9A106C, 0x80
+sHitmonchanSprites60:
+ax_sprite sHitmonchanGfx60, 0x80
+ax_sprite_terminator
+sHitmonchanGfx61:
+.incbin "baserom.gba", 0x9A10FC, 0x20
+sHitmonchanSprites61:
+ax_sprite sHitmonchanGfx61, 0x20
+ax_sprite_terminator
+sHitmonchanGfx62:
+.incbin "baserom.gba", 0x9A112C, 0x60
+sHitmonchanGfx62_1:
+.incbin "baserom.gba", 0x9A118C, 0x60
+sHitmonchanGfx62_2:
+.incbin "baserom.gba", 0x9A11EC, 0x20
+sHitmonchanGfx62_3:
+.incbin "baserom.gba", 0x9A120C, 0x20
+sHitmonchanSprites62:
+ax_sprite sHitmonchanGfx62, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx62_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx62_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHitmonchanGfx62_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmonchanGfx63:
+.incbin "baserom.gba", 0x9A1274, 0xA0
+sHitmonchanGfx63_1:
+.incbin "baserom.gba", 0x9A1314, 0x20
+sHitmonchanSprites63:
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx63, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx63_1, 0x20
+ax_sprite_terminator
+sHitmonchanGfx64:
+.incbin "baserom.gba", 0x9A135C, 0x80
+sHitmonchanSprites64:
+ax_sprite sHitmonchanGfx64, 0x80
+ax_sprite_terminator
+sHitmonchanGfx65:
+.incbin "baserom.gba", 0x9A13EC, 0x20
+sHitmonchanSprites65:
+ax_sprite sHitmonchanGfx65, 0x20
+ax_sprite_terminator
+sHitmonchanGfx66:
+.incbin "baserom.gba", 0x9A141C, 0x60
+sHitmonchanGfx66_1:
+.incbin "baserom.gba", 0x9A147C, 0x60
+sHitmonchanGfx66_2:
+.incbin "baserom.gba", 0x9A14DC, 0x40
+sHitmonchanGfx66_3:
+.incbin "baserom.gba", 0x9A151C, 0x40
+sHitmonchanSprites66:
+ax_sprite sHitmonchanGfx66, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx66_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx66_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx66_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmonchanGfx67:
+.incbin "baserom.gba", 0x9A15A4, 0x100
+sHitmonchanSprites67:
+ax_sprite sHitmonchanGfx67, 0x100
+ax_sprite_terminator
+sHitmonchanGfx68:
+.incbin "baserom.gba", 0x9A16B4, 0x20
+sHitmonchanSprites68:
+ax_sprite sHitmonchanGfx68, 0x20
+ax_sprite_terminator
+sHitmonchanGfx69:
+.incbin "baserom.gba", 0x9A16E4, 0x60
+sHitmonchanGfx69_1:
+.incbin "baserom.gba", 0x9A1744, 0x60
+sHitmonchanGfx69_2:
+.incbin "baserom.gba", 0x9A17A4, 0x40
+sHitmonchanGfx69_3:
+.incbin "baserom.gba", 0x9A17E4, 0x20
+sHitmonchanSprites69:
+ax_sprite sHitmonchanGfx69, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx69_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonchanGfx69_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonchanGfx69_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sHitmonchanGfx70:
+.incbin "baserom.gba", 0x9A184C, 0x100
+sHitmonchanSprites70:
+ax_sprite sHitmonchanGfx70, 0x100
+ax_sprite_terminator
+sHitmonchanGfx71:
+.incbin "baserom.gba", 0x9A195C, 0x80
+sHitmonchanSprites71:
+ax_sprite sHitmonchanGfx71, 0x80
+ax_sprite_terminator
+sHitmonchanGfx72:
+.incbin "baserom.gba", 0x9A19EC, 0x20
+sHitmonchanSprites72:
+ax_sprite sHitmonchanGfx72, 0x20
+ax_sprite_terminator
+sHitmonchanGfx73:
+.incbin "baserom.gba", 0x9A1A1C, 0x200
+sHitmonchanSprites73:
+ax_sprite sHitmonchanGfx73, 0x200
+ax_sprite_terminator
+sHitmonchanGfx74:
+.incbin "baserom.gba", 0x9A1C2C, 0x200
+sHitmonchanSprites74:
+ax_sprite sHitmonchanGfx74, 0x200
+ax_sprite_terminator
+sHitmonchanGfx75:
+.incbin "baserom.gba", 0x9A1E3C, 0x200
+sHitmonchanSprites75:
+ax_sprite sHitmonchanGfx75, 0x200
+ax_sprite_terminator
+sHitmonchanGfx76:
+.incbin "baserom.gba", 0x9A204C, 0x200
+sHitmonchanSprites76:
+ax_sprite sHitmonchanGfx76, 0x200
+ax_sprite_terminator
+sHitmonchanGfx77:
+.incbin "baserom.gba", 0x9A225C, 0x200
+sHitmonchanSprites77:
+ax_sprite sHitmonchanGfx77, 0x200
+ax_sprite_terminator
+sHitmonchanGfx78:
+.incbin "baserom.gba", 0x9A246C, 0x200
+sHitmonchanSprites78:
+ax_sprite sHitmonchanGfx78, 0x200
+ax_sprite_terminator
+sHitmonchanGfx79:
+.incbin "baserom.gba", 0x9A267C, 0x200
+sHitmonchanSprites79:
+ax_sprite sHitmonchanGfx79, 0x200
+ax_sprite_terminator
+sAxPosesHitmonchan:
+.4byte sHitmonchanPose1
+.4byte sHitmonchanPose2
+.4byte sHitmonchanPose3
+.4byte sHitmonchanPose4
+.4byte sHitmonchanPose5
+.4byte sHitmonchanPose6
+.4byte sHitmonchanPose7
+.4byte sHitmonchanPose8
+.4byte sHitmonchanPose9
+.4byte sHitmonchanPose10
+.4byte sHitmonchanPose11
+.4byte sHitmonchanPose12
+.4byte sHitmonchanPose13
+.4byte sHitmonchanPose14
+.4byte sHitmonchanPose15
+.4byte sHitmonchanPose16
+.4byte sHitmonchanPose17
+.4byte sHitmonchanPose18
+.4byte sHitmonchanPose19
+.4byte sHitmonchanPose20
+.4byte sHitmonchanPose21
+.4byte sHitmonchanPose22
+.4byte sHitmonchanPose23
+.4byte sHitmonchanPose24
+.4byte sHitmonchanPose25
+.4byte sHitmonchanPose26
+.4byte sHitmonchanPose27
+.4byte sHitmonchanPose28
+.4byte sHitmonchanPose29
+.4byte sHitmonchanPose30
+.4byte sHitmonchanPose31
+.4byte sHitmonchanPose32
+.4byte sHitmonchanPose33
+.4byte sHitmonchanPose34
+.4byte sHitmonchanPose35
+.4byte sHitmonchanPose36
+.4byte sHitmonchanPose37
+.4byte sHitmonchanPose38
+.4byte sHitmonchanPose39
+.4byte sHitmonchanPose40
+.4byte sHitmonchanPose41
+.4byte sHitmonchanPose42
+.4byte sHitmonchanPose43
+.4byte sHitmonchanPose44
+.4byte sHitmonchanPose45
+.4byte sHitmonchanPose46
+.4byte sHitmonchanPose47
+.4byte sHitmonchanPose48
+.4byte sHitmonchanPose49
+.4byte sHitmonchanPose50
+.4byte sHitmonchanPose51
+.4byte sHitmonchanPose52
+.4byte sHitmonchanPose53
+.4byte sHitmonchanPose54
+.4byte sHitmonchanPose55
+.4byte sHitmonchanPose56
+.4byte sHitmonchanPose57
+.4byte sHitmonchanPose58
+.4byte sHitmonchanPose59
+.4byte sHitmonchanPose60
+.4byte sHitmonchanPose61
+.4byte sHitmonchanPose62
+.4byte sHitmonchanPose63
+.4byte sHitmonchanPose64
+.4byte sHitmonchanPose65
+.4byte sHitmonchanPose66
+.4byte sHitmonchanPose67
+.4byte sHitmonchanPose68
+.4byte sHitmonchanPose69
+.4byte sHitmonchanPose70
+.4byte sHitmonchanPose71
+.4byte sHitmonchanPose72
+.4byte sHitmonchanPose73
+.4byte sHitmonchanPose74
+.4byte sHitmonchanPose75
+.4byte sHitmonchanPose76
+.4byte sHitmonchanPose77
+.4byte sHitmonchanPose78
+.4byte sHitmonchanPose79
+.4byte sHitmonchanPose80
+.4byte sHitmonchanPose81
+.4byte sHitmonchanPose82
+.4byte sHitmonchanPose83
+.4byte sHitmonchanPose84
+.4byte sHitmonchanPose85
+.4byte sHitmonchanPose86
+.4byte sHitmonchanPose87
+.4byte sHitmonchanPose88
+.4byte sHitmonchanPose89
+.4byte sHitmonchanPose90
+.4byte sHitmonchanPose91
+.4byte sHitmonchanPose92
+.4byte sHitmonchanPose93
+.4byte sHitmonchanPose94
+.4byte sHitmonchanPose95
+.4byte sHitmonchanPose96
+.4byte sHitmonchanPose97
+.4byte sHitmonchanPose98
+.4byte sHitmonchanPose99
+.4byte sHitmonchanPose100
+.4byte sHitmonchanPose101
+.4byte sHitmonchanPose102
+.4byte sHitmonchanPose103
+.4byte sHitmonchanPose104
+.4byte sHitmonchanPose105
+.4byte sHitmonchanPose106
+.4byte sHitmonchanPose107
+.4byte sHitmonchanPose108
+.4byte sHitmonchanPose109
+.4byte sHitmonchanPose110
+.4byte sHitmonchanPose111
+.4byte sHitmonchanPose112
+.4byte sHitmonchanPose113
+.4byte sHitmonchanPose114
+.4byte sHitmonchanPose115
+.4byte sHitmonchanPose116
+.4byte sHitmonchanPose117
+.4byte sHitmonchanPose118
+.4byte sHitmonchanPose119
+.4byte sHitmonchanPose120
+.4byte sHitmonchanPose121
+.4byte sHitmonchanPose122
+.4byte sHitmonchanPose123
+.4byte sHitmonchanPose124
+.4byte sHitmonchanPose125
+.4byte sHitmonchanPose126
+.4byte sHitmonchanPose127
+.4byte sHitmonchanPose128
+.4byte sHitmonchanPose129
+.4byte sHitmonchanPose130
+.4byte sHitmonchanPose131
+.4byte sHitmonchanPose132
+.4byte sHitmonchanPose133
+.4byte sHitmonchanPose134
+.4byte sHitmonchanPose135
+.4byte sHitmonchanPose136
+.4byte sHitmonchanPose137
+.4byte sHitmonchanPose138
+.4byte sHitmonchanPose139
+.4byte sHitmonchanPose140
+.4byte sHitmonchanPose141
+.4byte sHitmonchanPose142
+.4byte sHitmonchanPose143
+.4byte sHitmonchanPose144
+.4byte sHitmonchanPose145
+.4byte sHitmonchanPose146
+.4byte sHitmonchanPose147
+.4byte sHitmonchanPose148
+.4byte sHitmonchanPose149
+.4byte sHitmonchanPose150
+.4byte sHitmonchanPose151
+.4byte sHitmonchanPose152
+.4byte sHitmonchanPose153
+.4byte sHitmonchanPose154
+.4byte sHitmonchanPose155
+.4byte sHitmonchanPose156
+.4byte sHitmonchanPose157
+.4byte sHitmonchanPose158
+.4byte sHitmonchanPose159
+.4byte sHitmonchanPose160
+.4byte sHitmonchanPose161
+.4byte sHitmonchanPose162
+.4byte sHitmonchanPose163
+.4byte sHitmonchanPose164
+.4byte sHitmonchanPose165
+.4byte sHitmonchanPose166
+.4byte sHitmonchanPose167
+.4byte sHitmonchanPose168
+.4byte sHitmonchanPose169
+.4byte sHitmonchanPose170
+.4byte sHitmonchanPose171
+.4byte sHitmonchanPose172
+.4byte sHitmonchanPose173
+.4byte sHitmonchanPose174
+.4byte sHitmonchanPose175
+.4byte sHitmonchanPose176
+.4byte sHitmonchanPose177
+.4byte sHitmonchanPose178
+.4byte sHitmonchanPose179
+.4byte sHitmonchanPose180
+.4byte sHitmonchanPose181
+.4byte sHitmonchanPose182
+.4byte sHitmonchanPose183
+.4byte sHitmonchanPose184
+.4byte sHitmonchanPose185
+.4byte sHitmonchanPose186
+.4byte sHitmonchanPose187
+.4byte sHitmonchanPose188
+.4byte sHitmonchanPose189
+.4byte sHitmonchanPose190
+.4byte sHitmonchanPose191
+.4byte sHitmonchanPose192
+.4byte sHitmonchanPose193
+.4byte sHitmonchanPose194
+.4byte sHitmonchanPose195
+.4byte sHitmonchanPose196
+.4byte sHitmonchanPose197
+.4byte sHitmonchanPose198
+.4byte sHitmonchanPose199
+.4byte sHitmonchanPose200
+.4byte sHitmonchanPose201
+.4byte sHitmonchanPose202
+.4byte sHitmonchanPose203
+.4byte sHitmonchanPose204
+.4byte sHitmonchanPose205
+.4byte sHitmonchanPose206
+.4byte sHitmonchanPose207
+.4byte sHitmonchanPose208
+.4byte sHitmonchanPose209
+.4byte sHitmonchanPose210
+.4byte sHitmonchanPose211
+.4byte sHitmonchanPose212
+.4byte sHitmonchanPose213
+.4byte sHitmonchanPose214
+.4byte sHitmonchanPose215
+.4byte sHitmonchanPose216
+.4byte sHitmonchanPose217
+.4byte sHitmonchanPose218
+.4byte sHitmonchanPose219
+.4byte sHitmonchanPose220
+.4byte sHitmonchanPose221
+.4byte sHitmonchanPose222
+.4byte sHitmonchanPose223
+.4byte sHitmonchanPose224
+.4byte sHitmonchanPose225
+.4byte sHitmonchanPose226
+.4byte sHitmonchanPose227
+.4byte sHitmonchanPose228
+.4byte sHitmonchanPose229
+.4byte sHitmonchanPose230
+.4byte sHitmonchanPose231
+.4byte sHitmonchanPose232
+.4byte sHitmonchanPose233
+.4byte sHitmonchanPose234
+.4byte sHitmonchanPose235
+.4byte sHitmonchanPose236
+.4byte sHitmonchanPose237
+.4byte sHitmonchanPose238
+.4byte sHitmonchanPose239
+.4byte sHitmonchanPose240
+.4byte sHitmonchanPose241
+.4byte sHitmonchanPose242
+.4byte sHitmonchanPose243
+sAxPositionsHitmonchan:
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte   -1,  -11, 	  -8,  -11, 	   2,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	  -7,   -9, 	   3,   -9, 	  -1,  -10
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+.2byte    1,  -12, 	   8,  -13, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   8,  -11, 	   0,   -9, 	  -2,   -9
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    2,  -12, 	   4,  -14, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -12, 	   8,  -14, 	   4,   -9, 	  -1,   -9
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    2,  -13, 	  -3,  -16, 	  10,  -16, 	  -2,  -11
+.2byte    1,  -13, 	  -1,  -18, 	   8,  -13, 	  -2,  -11
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte   -1,  -16, 	   5,  -15, 	  -7,  -19, 	  -1,  -12
+.2byte   -1,  -16, 	   4,  -17, 	  -8,  -17, 	  -1,  -12
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -4,  -13, 	   1,  -16, 	 -12,  -16, 	   0,  -11
+.2byte   -3,  -13, 	  -1,  -18, 	 -10,  -13, 	   0,  -11
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -4,  -12, 	  -6,  -14, 	 -10,  -10, 	  -1,   -9
+.2byte   -4,  -12, 	 -10,  -14, 	  -6,   -9, 	  -1,   -9
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	 -10,  -13, 	  -5,   -7, 	  -1,  -10
+.2byte   -3,  -12, 	 -10,  -11, 	  -2,   -9, 	   0,   -9
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte   -1,  -11, 	  -8,  -11, 	   2,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	  -7,   -9, 	   3,   -9, 	  -1,  -10
+.2byte    1,   -9, 	   5,   -6, 	   6,  -17, 	   1,   -7
+.2byte    1,   -9, 	   5,   -6, 	   6,  -17, 	   1,   -7
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+.2byte    1,  -12, 	   8,  -13, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   8,  -11, 	   0,   -9, 	  -2,   -9
+.2byte    2,   -8, 	   4,   -3, 	  -4,  -13, 	   4,   -7
+.2byte    2,   -8, 	   4,   -3, 	  -4,  -13, 	   4,   -7
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    2,  -12, 	   4,  -14, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -12, 	   8,  -14, 	   4,   -9, 	  -1,   -9
+.2byte    6,  -10, 	   7,   -4, 	  -1,  -15, 	   6,   -9
+.2byte    6,  -10, 	   7,   -4, 	  -1,  -15, 	   6,   -9
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    2,  -13, 	  -3,  -16, 	  10,  -16, 	  -2,  -11
+.2byte    1,  -13, 	  -1,  -18, 	   8,  -13, 	  -2,  -11
+.2byte    6,  -12, 	   8,   -9, 	   1,   -8, 	   3,  -10
+.2byte    6,  -12, 	   8,   -9, 	   1,   -8, 	   3,  -10
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte   -1,  -16, 	   5,  -15, 	  -7,  -19, 	  -1,  -12
+.2byte   -1,  -16, 	   4,  -17, 	  -8,  -17, 	  -1,  -12
+.2byte   -5,  -14, 	  -9,  -17, 	  -7,  -11, 	  -2,  -12
+.2byte   -5,  -14, 	  -9,  -17, 	  -7,  -11, 	  -2,  -12
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -4,  -13, 	   1,  -16, 	 -12,  -16, 	   0,  -11
+.2byte   -3,  -13, 	  -1,  -18, 	 -10,  -13, 	   0,  -11
+.2byte   -8,  -12, 	 -10,   -9, 	  -3,   -8, 	  -5,  -10
+.2byte   -8,  -12, 	 -10,   -9, 	  -3,   -8, 	  -5,  -10
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -4,  -12, 	  -6,  -14, 	 -10,  -10, 	  -1,   -9
+.2byte   -4,  -12, 	 -10,  -14, 	  -6,   -9, 	  -1,   -9
+.2byte   -6,  -10, 	  -7,   -4, 	   1,  -15, 	  -6,   -9
+.2byte   -6,  -10, 	  -7,   -4, 	   1,  -15, 	  -6,   -9
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	 -10,  -13, 	  -5,   -7, 	  -1,  -10
+.2byte   -3,  -12, 	 -10,  -11, 	  -2,   -9, 	   0,   -9
+.2byte   -2,   -9, 	  -4,   -4, 	   4,  -14, 	  -4,   -8
+.2byte   -2,   -9, 	  -4,   -4, 	   4,  -14, 	  -4,   -8
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte   -1,  -11, 	  -8,  -11, 	   2,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	  -7,   -9, 	   3,   -9, 	  -1,  -10
+.2byte    2,  -10, 	  -4,    2, 	   8,  -11, 	   2,  -12
+.2byte    2,  -10, 	  -4,    2, 	   8,  -11, 	   2,  -12
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+.2byte    1,  -12, 	   8,  -13, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   8,  -11, 	   0,   -9, 	  -2,   -9
+.2byte    5,   -7, 	  17,    0, 	  -2,   -4, 	   2,   -7
+.2byte    5,   -7, 	  17,    0, 	  -2,   -4, 	   2,   -7
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    2,  -12, 	   4,  -14, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -12, 	   8,  -14, 	   4,   -9, 	  -1,   -9
+.2byte    7,  -10, 	  20,  -12, 	   5,   -6, 	   2,   -9
+.2byte    7,  -10, 	  20,  -12, 	   5,   -6, 	   2,   -9
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    2,  -13, 	  -3,  -16, 	  10,  -16, 	  -2,  -11
+.2byte    1,  -13, 	  -1,  -18, 	   8,  -13, 	  -2,  -11
+.2byte    6,  -12, 	  14,  -23, 	   8,   -6, 	   1,  -11
+.2byte    6,  -12, 	  14,  -23, 	   8,   -6, 	   1,  -11
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte   -1,  -16, 	   5,  -15, 	  -7,  -19, 	  -1,  -12
+.2byte   -1,  -16, 	   4,  -17, 	  -8,  -17, 	  -1,  -12
+.2byte   -4,  -18, 	   1,  -31, 	 -12,  -14, 	  -3,  -13
+.2byte   -4,  -18, 	  -1,  -31, 	 -12,  -14, 	  -3,  -13
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -4,  -13, 	   1,  -16, 	 -12,  -16, 	   0,  -11
+.2byte   -3,  -13, 	  -1,  -18, 	 -10,  -13, 	   0,  -11
+.2byte   -7,  -12, 	 -15,  -23, 	  -9,   -6, 	  -2,  -11
+.2byte   -7,  -12, 	 -15,  -23, 	  -9,   -6, 	  -2,  -11
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -4,  -12, 	  -6,  -14, 	 -10,  -10, 	  -1,   -9
+.2byte   -4,  -12, 	 -10,  -14, 	  -6,   -9, 	  -1,   -9
+.2byte  -10,  -10, 	 -23,  -12, 	  -8,   -6, 	  -5,   -9
+.2byte  -10,  -10, 	 -23,  -12, 	  -8,   -6, 	  -5,   -9
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	 -10,  -11, 	  -2,   -9, 	   0,   -9
+.2byte   -3,  -12, 	 -10,  -13, 	  -5,   -7, 	  -1,  -10
+.2byte   -5,   -7, 	 -17,    0, 	   2,   -4, 	  -2,   -7
+.2byte   -5,   -7, 	 -17,    0, 	   2,   -4, 	  -2,   -7
+.2byte    0,   -8, 	  -9,   -9, 	   4,   -6, 	   0,   -9
+.2byte   -5,   -9, 	  -8,  -11, 	  -2,   -6, 	  -1,   -9
+.2byte   -6,  -10, 	  -6,  -13, 	  -7,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	   1,  -15, 	 -10,   -8, 	   0,   -9
+.2byte   -1,  -15, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte    3,  -12, 	  -3,  -15, 	   8,   -8, 	  -2,   -9
+.2byte    4,  -10, 	   4,  -13, 	   5,   -7, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -11, 	   0,   -6, 	  -1,   -9
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte   -1,   -9, 	 -10,  -10, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -18, 	  -6,  -29, 	   5,  -12, 	   0,  -16
+.2byte   -1,  -18, 	  -6,  -29, 	   5,  -12, 	   0,  -16
+.2byte   -1,  -12, 	  -8,  -12, 	   2,   -9, 	  -1,  -11
+.2byte   -1,  -12, 	  -7,  -10, 	   3,  -10, 	  -1,  -11
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+.2byte    3,   -8, 	   6,  -10, 	   0,   -5, 	  -1,   -8
+.2byte    1,  -18, 	  -3,  -28, 	   7,  -15, 	  -1,  -15
+.2byte    1,  -18, 	  -3,  -28, 	   7,  -15, 	  -1,  -15
+.2byte    1,  -12, 	   8,  -13, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   8,  -11, 	   0,   -9, 	  -2,   -9
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    4,   -8, 	   4,  -11, 	   5,   -5, 	  -1,   -7
+.2byte    2,  -18, 	   2,  -29, 	   4,  -16, 	  -1,  -15
+.2byte    2,  -18, 	   2,  -29, 	   4,  -16, 	  -1,  -15
+.2byte    2,  -12, 	   4,  -14, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -12, 	   8,  -14, 	   4,   -9, 	  -1,   -9
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    3,  -12, 	  -3,  -15, 	   8,   -8, 	  -2,   -9
+.2byte    3,  -19, 	   5,  -30, 	  -2,  -17, 	  -2,  -15
+.2byte    3,  -19, 	   5,  -30, 	  -2,  -17, 	  -2,  -15
+.2byte    2,  -13, 	  -3,  -16, 	  10,  -16, 	  -2,  -11
+.2byte    1,  -13, 	  -1,  -18, 	   8,  -13, 	  -2,  -11
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte   -1,  -15, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -1,  -20, 	   5,  -32, 	  -9,  -17, 	  -1,  -14
+.2byte   -1,  -20, 	   5,  -32, 	  -9,  -17, 	  -1,  -14
+.2byte   -1,  -16, 	   5,  -15, 	  -7,  -19, 	  -1,  -12
+.2byte   -1,  -16, 	   4,  -17, 	  -8,  -17, 	  -1,  -12
+.2byte    0,  -21, 	  -6,  -33, 	   8,  -18, 	   0,  -15
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -5,  -12, 	   1,  -15, 	 -10,   -8, 	   0,   -9
+.2byte   -3,  -18, 	   1,  -32, 	 -10,  -14, 	  -1,  -13
+.2byte   -3,  -18, 	   1,  -32, 	 -10,  -14, 	  -1,  -13
+.2byte   -4,  -13, 	   1,  -16, 	 -12,  -16, 	   0,  -11
+.2byte   -3,  -13, 	  -1,  -18, 	 -10,  -13, 	   0,  -11
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -6,   -8, 	  -6,  -11, 	  -7,   -5, 	  -1,   -7
+.2byte   -3,  -17, 	  -3,  -32, 	  -6,  -13, 	   0,  -12
+.2byte   -3,  -17, 	  -3,  -32, 	  -6,  -13, 	   0,  -12
+.2byte   -4,  -12, 	  -6,  -14, 	 -10,  -10, 	  -1,   -9
+.2byte   -4,  -12, 	 -10,  -14, 	  -6,   -9, 	  -1,   -9
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -5,   -8, 	  -8,  -10, 	  -2,   -5, 	  -1,   -8
+.2byte   -2,  -17, 	  -4,  -31, 	   3,  -12, 	   0,  -14
+.2byte   -2,  -17, 	  -4,  -31, 	   3,  -12, 	   0,  -14
+.2byte   -3,  -12, 	 -10,  -13, 	  -5,   -7, 	  -1,  -10
+.2byte   -3,  -12, 	 -10,  -11, 	  -2,   -9, 	   0,   -9
+.2byte   -3,   -8, 	  -8,   -6, 	   1,    0, 	   0,   -7
+.2byte   -3,   -7, 	  -8,   -6, 	   1,    1, 	   0,   -6
+.2byte   -2,  -14, 	 -11,  -13, 	   2,   -9, 	  -1,  -11
+.2byte    1,  -14, 	   7,  -17, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   1,  -17, 	   7,  -14, 	  -1,  -12
+.2byte    1,  -17, 	  -4,  -19, 	   8,  -16, 	  -1,  -11
+.2byte    2,  -17, 	   7,  -15, 	  -7,  -19, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -19, 	  -9,  -16, 	   0,  -11
+.2byte   -1,  -15, 	  -2,  -17, 	  -8,  -14, 	   0,  -12
+.2byte   -2,  -14, 	  -8,  -17, 	  -2,   -9, 	   0,  -10
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte   -1,   -7, 	  -7,    5, 	   5,   -8, 	  -1,   -9
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+.2byte    5,   -8, 	  17,   -1, 	  -2,   -5, 	   2,   -8
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    7,  -10, 	  20,  -12, 	   5,   -6, 	   2,   -9
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    6,  -11, 	  14,  -22, 	   8,   -5, 	   1,  -10
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte   -4,  -16, 	  -1,  -29, 	 -12,  -12, 	  -3,  -11
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -6,  -11, 	 -14,  -22, 	  -8,   -5, 	  -1,  -10
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -8,  -10, 	 -21,  -12, 	  -6,   -6, 	  -3,   -9
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -6,   -8, 	 -18,   -1, 	   1,   -5, 	  -3,   -8
+.2byte   -1,  -11, 	  -8,  -11, 	   2,   -8, 	  -1,  -10
+.2byte   -3,  -12, 	 -10,  -13, 	  -5,   -7, 	  -1,  -10
+.2byte   -4,  -12, 	  -6,  -14, 	 -10,  -10, 	  -1,   -9
+.2byte   -4,  -13, 	   1,  -16, 	 -12,  -16, 	   0,  -11
+.2byte   -1,  -16, 	   5,  -15, 	  -7,  -19, 	  -1,  -12
+.2byte    2,  -13, 	  -3,  -16, 	  10,  -16, 	  -2,  -11
+.2byte    2,  -12, 	   4,  -14, 	   8,  -10, 	  -1,   -9
+.2byte    1,  -12, 	   8,  -13, 	   3,   -7, 	  -1,  -10
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte   -1,  -12, 	  -7,  -10, 	   3,  -10, 	  -1,  -11
+.2byte   -1,   -9, 	 -10,  -10, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+.2byte    1,  -12, 	   8,  -13, 	   3,   -7, 	  -1,  -10
+.2byte    3,   -8, 	   6,  -10, 	   0,   -5, 	  -1,   -8
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    2,  -12, 	   4,  -14, 	   8,  -10, 	  -1,   -9
+.2byte    4,   -8, 	   4,  -11, 	   5,   -5, 	  -1,   -7
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    2,  -13, 	  -3,  -16, 	  10,  -16, 	  -2,  -11
+.2byte    3,  -12, 	  -3,  -15, 	   8,   -8, 	  -2,   -9
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte   -1,  -16, 	   5,  -15, 	  -7,  -19, 	  -1,  -12
+.2byte   -1,  -15, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -4,  -13, 	   1,  -16, 	 -12,  -16, 	   0,  -11
+.2byte   -5,  -12, 	   1,  -15, 	 -10,   -8, 	   0,   -9
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -4,  -12, 	  -6,  -14, 	 -10,  -10, 	  -1,   -9
+.2byte   -6,   -8, 	  -6,  -11, 	  -7,   -5, 	  -1,   -7
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	 -10,  -13, 	  -5,   -7, 	  -1,  -10
+.2byte   -5,   -8, 	  -8,  -10, 	  -2,   -5, 	  -1,   -8
+.2byte    0,   -8, 	  -9,   -9, 	   4,   -6, 	   0,   -9
+.2byte   -5,   -9, 	  -8,  -11, 	  -2,   -6, 	  -1,   -9
+.2byte   -6,  -10, 	  -6,  -13, 	  -7,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	   1,  -15, 	 -10,   -8, 	   0,   -9
+.2byte   -1,  -15, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte    3,  -12, 	  -3,  -15, 	   8,   -8, 	  -2,   -9
+.2byte    4,  -10, 	   4,  -13, 	   5,   -7, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -11, 	   0,   -6, 	  -1,   -9
+.2byte   -1,  -12, 	  -7,  -11, 	   2,   -9, 	  -1,  -11
+.2byte   -3,  -13, 	  -9,  -13, 	  -3,  -10, 	  -1,  -11
+.2byte   -4,  -13, 	  -8,  -16, 	  -8,  -11, 	  -1,  -10
+.2byte   -4,  -14, 	   1,  -19, 	 -10,  -15, 	   0,  -12
+.2byte   -1,  -17, 	   5,  -17, 	  -8,  -18, 	  -1,  -13
+.2byte    2,  -14, 	  -3,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    2,  -13, 	   6,  -16, 	   6,  -11, 	  -1,  -10
+.2byte    1,  -13, 	   7,  -13, 	   1,  -10, 	  -1,  -11
+sHitmonchanAnimTable1:
+.4byte sHitmonchanAnims_1_1
+.4byte sHitmonchanAnims_1_2
+.4byte sHitmonchanAnims_1_3
+.4byte sHitmonchanAnims_1_4
+.4byte sHitmonchanAnims_1_5
+.4byte sHitmonchanAnims_1_6
+.4byte sHitmonchanAnims_1_7
+.4byte sHitmonchanAnims_1_8
+sHitmonchanAnimTable2:
+.4byte sHitmonchanAnims_2_1
+.4byte sHitmonchanAnims_2_2
+.4byte sHitmonchanAnims_2_3
+.4byte sHitmonchanAnims_2_4
+.4byte sHitmonchanAnims_2_5
+.4byte sHitmonchanAnims_2_6
+.4byte sHitmonchanAnims_2_7
+.4byte sHitmonchanAnims_2_8
+sHitmonchanAnimTable3:
+.4byte sHitmonchanAnims_3_1
+.4byte sHitmonchanAnims_3_2
+.4byte sHitmonchanAnims_3_3
+.4byte sHitmonchanAnims_3_4
+.4byte sHitmonchanAnims_3_5
+.4byte sHitmonchanAnims_3_6
+.4byte sHitmonchanAnims_3_7
+.4byte sHitmonchanAnims_3_8
+sHitmonchanAnimTable4:
+.4byte sHitmonchanAnims_4_1
+.4byte sHitmonchanAnims_4_2
+.4byte sHitmonchanAnims_4_3
+.4byte sHitmonchanAnims_4_4
+.4byte sHitmonchanAnims_4_5
+.4byte sHitmonchanAnims_4_6
+.4byte sHitmonchanAnims_4_7
+.4byte sHitmonchanAnims_4_8
+sHitmonchanAnimTable5:
+.4byte sHitmonchanAnims_5_1
+.4byte sHitmonchanAnims_5_2
+.4byte sHitmonchanAnims_5_3
+.4byte sHitmonchanAnims_5_4
+.4byte sHitmonchanAnims_5_5
+.4byte sHitmonchanAnims_5_6
+.4byte sHitmonchanAnims_5_7
+.4byte sHitmonchanAnims_5_8
+sHitmonchanAnimTable6:
+.4byte sHitmonchanAnims_6_1
+.4byte sHitmonchanAnims_6_1
+.4byte sHitmonchanAnims_6_1
+.4byte sHitmonchanAnims_6_1
+.4byte sHitmonchanAnims_6_1
+.4byte sHitmonchanAnims_6_1
+.4byte sHitmonchanAnims_6_1
+.4byte sHitmonchanAnims_6_1
+sHitmonchanAnimTable7:
+.4byte sHitmonchanAnims_7_1
+.4byte sHitmonchanAnims_7_2
+.4byte sHitmonchanAnims_7_3
+.4byte sHitmonchanAnims_7_4
+.4byte sHitmonchanAnims_7_5
+.4byte sHitmonchanAnims_7_6
+.4byte sHitmonchanAnims_7_7
+.4byte sHitmonchanAnims_7_8
+sHitmonchanAnimTable8:
+.4byte sHitmonchanAnims_8_1
+.4byte sHitmonchanAnims_8_2
+.4byte sHitmonchanAnims_8_3
+.4byte sHitmonchanAnims_8_4
+.4byte sHitmonchanAnims_8_5
+.4byte sHitmonchanAnims_8_6
+.4byte sHitmonchanAnims_8_7
+.4byte sHitmonchanAnims_8_8
+sHitmonchanAnimTable9:
+.4byte sHitmonchanAnims_9_1
+.4byte sHitmonchanAnims_9_2
+.4byte sHitmonchanAnims_9_3
+.4byte sHitmonchanAnims_9_4
+.4byte sHitmonchanAnims_9_5
+.4byte sHitmonchanAnims_9_6
+.4byte sHitmonchanAnims_9_7
+.4byte sHitmonchanAnims_9_8
+sHitmonchanAnimTable10:
+.4byte sHitmonchanAnims_10_1
+.4byte sHitmonchanAnims_10_2
+.4byte sHitmonchanAnims_10_3
+.4byte sHitmonchanAnims_10_4
+.4byte sHitmonchanAnims_10_5
+.4byte sHitmonchanAnims_10_6
+.4byte sHitmonchanAnims_10_7
+.4byte sHitmonchanAnims_10_8
+sHitmonchanAnimTable11:
+.4byte sHitmonchanAnims_11_1
+.4byte sHitmonchanAnims_11_2
+.4byte sHitmonchanAnims_11_3
+.4byte sHitmonchanAnims_11_4
+.4byte sHitmonchanAnims_11_5
+.4byte sHitmonchanAnims_11_6
+.4byte sHitmonchanAnims_11_7
+.4byte sHitmonchanAnims_11_8
+sHitmonchanAnimTable12:
+.4byte sHitmonchanAnims_12_1
+.4byte sHitmonchanAnims_12_2
+.4byte sHitmonchanAnims_12_3
+.4byte sHitmonchanAnims_12_4
+.4byte sHitmonchanAnims_12_5
+.4byte sHitmonchanAnims_12_6
+.4byte sHitmonchanAnims_12_7
+.4byte sHitmonchanAnims_12_8
+sHitmonchanAnimTable13:
+.4byte sHitmonchanAnims_13_1
+.4byte sHitmonchanAnims_13_2
+.4byte sHitmonchanAnims_13_3
+.4byte sHitmonchanAnims_13_4
+.4byte sHitmonchanAnims_13_5
+.4byte sHitmonchanAnims_13_6
+.4byte sHitmonchanAnims_13_7
+.4byte sHitmonchanAnims_13_8
+sAxAnimationsHitmonchan:
+.4byte sHitmonchanAnimTable1
+.4byte sHitmonchanAnimTable2
+.4byte sHitmonchanAnimTable3
+.4byte sHitmonchanAnimTable4
+.4byte sHitmonchanAnimTable5
+.4byte sHitmonchanAnimTable6
+.4byte sHitmonchanAnimTable7
+.4byte sHitmonchanAnimTable8
+.4byte sHitmonchanAnimTable9
+.4byte sHitmonchanAnimTable10
+.4byte sHitmonchanAnimTable11
+.4byte sHitmonchanAnimTable12
+.4byte sHitmonchanAnimTable13
+sAxSpritesHitmonchan:
+.4byte sHitmonchanSprites1
+.4byte sHitmonchanSprites2
+.4byte sHitmonchanSprites3
+.4byte sHitmonchanSprites4
+.4byte sHitmonchanSprites5
+.4byte sHitmonchanSprites6
+.4byte sHitmonchanSprites7
+.4byte sHitmonchanSprites8
+.4byte sHitmonchanSprites9
+.4byte sHitmonchanSprites10
+.4byte sHitmonchanSprites11
+.4byte sHitmonchanSprites12
+.4byte sHitmonchanSprites13
+.4byte sHitmonchanSprites14
+.4byte sHitmonchanSprites15
+.4byte sHitmonchanSprites16
+.4byte sHitmonchanSprites17
+.4byte sHitmonchanSprites18
+.4byte sHitmonchanSprites19
+.4byte sHitmonchanSprites20
+.4byte sHitmonchanSprites21
+.4byte sHitmonchanSprites22
+.4byte sHitmonchanSprites23
+.4byte sHitmonchanSprites24
+.4byte sHitmonchanSprites25
+.4byte sHitmonchanSprites26
+.4byte sHitmonchanSprites27
+.4byte sHitmonchanSprites28
+.4byte sHitmonchanSprites29
+.4byte sHitmonchanSprites30
+.4byte sHitmonchanSprites31
+.4byte sHitmonchanSprites32
+.4byte sHitmonchanSprites33
+.4byte sHitmonchanSprites34
+.4byte sHitmonchanSprites35
+.4byte sHitmonchanSprites36
+.4byte sHitmonchanSprites37
+.4byte sHitmonchanSprites38
+.4byte sHitmonchanSprites39
+.4byte sHitmonchanSprites40
+.4byte sHitmonchanSprites41
+.4byte sHitmonchanSprites42
+.4byte sHitmonchanSprites43
+.4byte sHitmonchanSprites44
+.4byte sHitmonchanSprites45
+.4byte sHitmonchanSprites46
+.4byte sHitmonchanSprites47
+.4byte sHitmonchanSprites48
+.4byte sHitmonchanSprites49
+.4byte sHitmonchanSprites50
+.4byte sHitmonchanSprites51
+.4byte sHitmonchanSprites52
+.4byte sHitmonchanSprites53
+.4byte sHitmonchanSprites54
+.4byte sHitmonchanSprites55
+.4byte sHitmonchanSprites56
+.4byte sHitmonchanSprites57
+.4byte sHitmonchanSprites58
+.4byte sHitmonchanSprites59
+.4byte sHitmonchanSprites60
+.4byte sHitmonchanSprites61
+.4byte sHitmonchanSprites62
+.4byte sHitmonchanSprites63
+.4byte sHitmonchanSprites64
+.4byte sHitmonchanSprites65
+.4byte sHitmonchanSprites66
+.4byte sHitmonchanSprites67
+.4byte sHitmonchanSprites68
+.4byte sHitmonchanSprites69
+.4byte sHitmonchanSprites70
+.4byte sHitmonchanSprites71
+.4byte sHitmonchanSprites72
+.4byte sHitmonchanSprites73
+.4byte sHitmonchanSprites74
+.4byte sHitmonchanSprites75
+.4byte sHitmonchanSprites76
+.4byte sHitmonchanSprites77
+.4byte sHitmonchanSprites78
+.4byte sHitmonchanSprites79
+sAxMainHitmonchan:
+ax_main sAxPosesHitmonchan, sAxAnimationsHitmonchan, 13, sAxSpritesHitmonchan, sAxPositionsHitmonchan

--- a/data/ax/hitmonlee.inc
+++ b/data/ax/hitmonlee.inc
@@ -1,0 +1,3115 @@
+.global gAxHitmonlee
+gAxHitmonlee:
+ax_siro sAxMainHitmonlee
+sHitmonleePose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose4:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose5:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose6:
+ax_pose 5, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose7:
+ax_pose 6, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose8:
+ax_pose 7, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose9:
+ax_pose 8, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose10:
+ax_pose 9, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose11:
+ax_pose 10, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose12:
+ax_pose 11, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose16:
+ax_pose 15, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose17:
+ax_pose 16, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose18:
+ax_pose 17, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose19:
+ax_pose 18, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose20:
+ax_pose 19, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose21:
+ax_pose 20, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose22:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose23:
+ax_pose 22, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose24:
+ax_pose 23, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose28:
+ax_pose 24, 0x41ee, 0x80f0, 0x6c00
+ax_pose 25, 0x41fd, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose29:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose30:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose31:
+ax_pose 5, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose32:
+ax_pose 26, 0x41ed, 0x90f3, 0x6c00
+ax_pose 27, 0x41fd, 0x50f3, 0x6c08
+ax_pose_terminator
+sHitmonleePose33:
+ax_pose 6, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose34:
+ax_pose 7, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose35:
+ax_pose 8, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose36:
+ax_pose 28, 0x81e4, 0x90f7, 0x6c00
+ax_pose 29, 0x81ec, 0x1107, 0x6c08
+ax_pose_terminator
+sHitmonleePose37:
+ax_pose 9, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose38:
+ax_pose 10, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose39:
+ax_pose 11, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose40:
+ax_pose 30, 0x81e2, 0x9100, 0x6c00
+ax_pose 31, 0x81e2, 0x50f8, 0x6c08
+ax_pose_terminator
+sHitmonleePose41:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose42:
+ax_pose 13, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose43:
+ax_pose 14, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose44:
+ax_pose 32, 0x41ea, 0x80f0, 0x6c00
+ax_pose 33, 0x41fa, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose45:
+ax_pose 15, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose46:
+ax_pose 16, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose47:
+ax_pose 17, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose48:
+ax_pose 30, 0x81e3, 0x80f0, 0x6c00
+ax_pose 31, 0x81e3, 0x4100, 0x6c08
+ax_pose_terminator
+sHitmonleePose49:
+ax_pose 18, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose50:
+ax_pose 19, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose51:
+ax_pose 20, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose52:
+ax_pose 28, 0x81e4, 0x80f8, 0x6c00
+ax_pose 29, 0x81ec, 0x00f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose53:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose54:
+ax_pose 22, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose55:
+ax_pose 23, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose56:
+ax_pose 26, 0x41ec, 0x80ee, 0x6c00
+ax_pose 27, 0x41fc, 0x40ee, 0x6c08
+ax_pose_terminator
+sHitmonleePose57:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose58:
+ax_pose 1, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose59:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose60:
+ax_pose 34, 0x81ed, 0x00f0, 0x6c00
+ax_pose 35, 0x81e5, 0x80f8, 0x6c02
+ax_pose 36, 0x01ed, 0x0108, 0x6c0a
+ax_pose_terminator
+sHitmonleePose61:
+ax_pose 37, 0x41fa, 0x80ee, 0x6c00
+ax_pose 38, 0x01f1, 0x00ee, 0x6c08
+ax_pose 39, 0x81f1, 0x00ee, 0x6c09
+ax_pose 40, 0x81e9, 0x80f6, 0x6c0b
+ax_pose 41, 0x81e9, 0x4106, 0x6c13
+ax_pose 42, 0x01e1, 0x0106, 0x6c17
+ax_pose_terminator
+sHitmonleePose62:
+ax_pose 39, 0x81f1, 0x00ee, 0x6c00
+ax_pose 40, 0x81e9, 0x80f6, 0x6c02
+ax_pose 41, 0x81e9, 0x4106, 0x6c0a
+ax_pose 42, 0x01e1, 0x0106, 0x6c0e
+ax_pose_terminator
+sHitmonleePose63:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose64:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose65:
+ax_pose 5, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose66:
+ax_pose 43, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose67:
+ax_pose 44, 0x41f7, 0x80f1, 0x6c00
+ax_pose 45, 0x01e2, 0x80f1, 0x6c08
+ax_pose_terminator
+sHitmonleePose68:
+ax_pose 45, 0x01e2, 0x80f1, 0x6c00
+ax_pose_terminator
+sHitmonleePose69:
+ax_pose 6, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose70:
+ax_pose 7, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose71:
+ax_pose 8, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose72:
+ax_pose 46, 0x81e6, 0x80f9, 0x6c00
+ax_pose 47, 0x81ee, 0x00f1, 0x6c08
+ax_pose 48, 0x01ef, 0x0109, 0x6c0a
+ax_pose_terminator
+sHitmonleePose73:
+ax_pose 49, 0x01e7, 0x80f2, 0x6c00
+ax_pose 50, 0x81e1, 0x80f4, 0x6c10
+ax_pose 51, 0x01e9, 0x4104, 0x6c18
+ax_pose_terminator
+sHitmonleePose74:
+ax_pose 50, 0x81e1, 0x80f4, 0x6c00
+ax_pose 51, 0x01e9, 0x4104, 0x6c08
+ax_pose_terminator
+sHitmonleePose75:
+ax_pose 9, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose76:
+ax_pose 10, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose77:
+ax_pose 11, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose78:
+ax_pose 52, 0x81e4, 0x80f8, 0x6c00
+ax_pose 53, 0x81ec, 0x00f0, 0x6c08
+ax_pose 54, 0x81ec, 0x0108, 0x6c0a
+ax_pose_terminator
+sHitmonleePose79:
+ax_pose 55, 0x81e4, 0x8106, 0x6c00
+ax_pose 56, 0x01fc, 0x00fe, 0x6c08
+ax_pose 57, 0x81e3, 0x80f6, 0x6c09
+ax_pose 58, 0x81e3, 0x4106, 0x6c11
+ax_pose 59, 0x01f3, 0x010e, 0x6c15
+ax_pose_terminator
+sHitmonleePose80:
+ax_pose 57, 0x81e3, 0x80f6, 0x6c00
+ax_pose 58, 0x81e3, 0x4106, 0x6c08
+ax_pose 59, 0x01f3, 0x010e, 0x6c0c
+ax_pose_terminator
+sHitmonleePose81:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose82:
+ax_pose 13, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose83:
+ax_pose 14, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose84:
+ax_pose 60, 0x81e5, 0x80fa, 0x6c00
+ax_pose 61, 0x81ed, 0x00f2, 0x6c08
+ax_pose 62, 0x81e5, 0x010a, 0x6c0a
+ax_pose_terminator
+sHitmonleePose85:
+ax_pose 63, 0x01e1, 0x80f2, 0x6c00
+ax_pose 64, 0x81e3, 0x80f2, 0x6c10
+ax_pose 65, 0x01eb, 0x4102, 0x6c18
+ax_pose_terminator
+sHitmonleePose86:
+ax_pose 64, 0x81e3, 0x80f2, 0x6c00
+ax_pose 65, 0x01eb, 0x4102, 0x6c08
+ax_pose_terminator
+sHitmonleePose87:
+ax_pose 15, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose88:
+ax_pose 16, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose89:
+ax_pose 17, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose90:
+ax_pose 66, 0x81e4, 0x80f1, 0x6c00
+ax_pose 67, 0x81e4, 0x4101, 0x6c08
+ax_pose_terminator
+sHitmonleePose91:
+ax_pose 68, 0x81e4, 0x80f6, 0x6c00
+ax_pose 69, 0x81e4, 0x00ee, 0x6c08
+ax_pose 70, 0x81ec, 0x0106, 0x6c0a
+ax_pose 71, 0x01df, 0x80ef, 0x6c0c
+ax_pose_terminator
+sHitmonleePose92:
+ax_pose 68, 0x81e4, 0x80f6, 0x6c00
+ax_pose 69, 0x81e4, 0x00ee, 0x6c08
+ax_pose 70, 0x81ec, 0x0106, 0x6c0a
+ax_pose_terminator
+sHitmonleePose93:
+ax_pose 18, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose94:
+ax_pose 19, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose95:
+ax_pose 20, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose96:
+ax_pose 72, 0x81e6, 0x80f8, 0x6c00
+ax_pose 73, 0x81e6, 0x00f0, 0x6c08
+ax_pose 74, 0x81ee, 0x0108, 0x6c0a
+ax_pose_terminator
+sHitmonleePose97:
+ax_pose 75, 0x81e4, 0x80f9, 0x6c00
+ax_pose 76, 0x01ec, 0x40e9, 0x6c08
+ax_pose 77, 0x01e3, 0x80e8, 0x6c0c
+ax_pose_terminator
+sHitmonleePose98:
+ax_pose 75, 0x81e4, 0x80f9, 0x6c00
+ax_pose 76, 0x01ec, 0x40e9, 0x6c08
+ax_pose_terminator
+sHitmonleePose99:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose100:
+ax_pose 22, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose101:
+ax_pose 23, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose102:
+ax_pose 78, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sHitmonleePose103:
+ax_pose 79, 0x01e6, 0x80e8, 0x6c00
+ax_pose 80, 0x01e8, 0x80ee, 0x6c10
+ax_pose_terminator
+sHitmonleePose104:
+ax_pose 80, 0x01e8, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose105:
+ax_pose 24, 0x41ee, 0x80f0, 0x6c00
+ax_pose 25, 0x41fd, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose106:
+ax_pose 26, 0x41ec, 0x80f0, 0x6c00
+ax_pose 27, 0x41fc, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose107:
+ax_pose 28, 0x81e4, 0x80fa, 0x6c00
+ax_pose 29, 0x81ec, 0x00f2, 0x6c08
+ax_pose_terminator
+sHitmonleePose108:
+ax_pose 30, 0x81e4, 0x80f1, 0x6c00
+ax_pose 31, 0x81e4, 0x4101, 0x6c08
+ax_pose_terminator
+sHitmonleePose109:
+ax_pose 32, 0x41eb, 0x80f0, 0x6c00
+ax_pose 33, 0x41fb, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose110:
+ax_pose 30, 0x81e4, 0x90ff, 0x6c00
+ax_pose 31, 0x81e4, 0x50f7, 0x6c08
+ax_pose_terminator
+sHitmonleePose111:
+ax_pose 28, 0x81e4, 0x90f7, 0x6c00
+ax_pose 29, 0x81ec, 0x1107, 0x6c08
+ax_pose_terminator
+sHitmonleePose112:
+ax_pose 26, 0x41ec, 0x90f1, 0x6c00
+ax_pose 27, 0x41fc, 0x50f1, 0x6c08
+ax_pose_terminator
+sHitmonleePose113:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose114:
+ax_pose 81, 0x81e3, 0x80f5, 0x6c00
+ax_pose 82, 0x81e3, 0x4105, 0x6c08
+ax_pose_terminator
+sHitmonleePose115:
+ax_pose 24, 0x41ee, 0x80f0, 0x6c00
+ax_pose 25, 0x41fd, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose116:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose117:
+ax_pose 83, 0x81e5, 0x90fc, 0x6c00
+ax_pose 84, 0x81e5, 0x50f4, 0x6c08
+ax_pose_terminator
+sHitmonleePose118:
+ax_pose 26, 0x41ed, 0x90f3, 0x6c00
+ax_pose 27, 0x41fd, 0x50f3, 0x6c08
+ax_pose_terminator
+sHitmonleePose119:
+ax_pose 6, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose120:
+ax_pose 85, 0x81e4, 0x90f8, 0x6c00
+ax_pose 86, 0x01ec, 0x1108, 0x6c08
+ax_pose_terminator
+sHitmonleePose121:
+ax_pose 28, 0x81e4, 0x90f7, 0x6c00
+ax_pose 29, 0x81ec, 0x1107, 0x6c08
+ax_pose_terminator
+sHitmonleePose122:
+ax_pose 9, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose123:
+ax_pose 87, 0x81e5, 0x90fc, 0x6c00
+ax_pose 88, 0x81e5, 0x50f4, 0x6c08
+ax_pose_terminator
+sHitmonleePose124:
+ax_pose 30, 0x81e4, 0x90ff, 0x6c00
+ax_pose 31, 0x81e4, 0x50f7, 0x6c08
+ax_pose_terminator
+sHitmonleePose125:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose126:
+ax_pose 89, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose127:
+ax_pose 32, 0x41ea, 0x80f0, 0x6c00
+ax_pose 33, 0x41fa, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose128:
+ax_pose 15, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose129:
+ax_pose 87, 0x81e4, 0x80f3, 0x6c00
+ax_pose 88, 0x81e4, 0x4103, 0x6c08
+ax_pose_terminator
+sHitmonleePose130:
+ax_pose 30, 0x81e3, 0x80f0, 0x6c00
+ax_pose 31, 0x81e3, 0x4100, 0x6c08
+ax_pose_terminator
+sHitmonleePose131:
+ax_pose 18, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose132:
+ax_pose 85, 0x81e4, 0x80f8, 0x6c00
+ax_pose 86, 0x01ec, 0x00f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose133:
+ax_pose 28, 0x81e4, 0x80f8, 0x6c00
+ax_pose 29, 0x81ec, 0x00f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose134:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose135:
+ax_pose 83, 0x81e4, 0x80f5, 0x6c00
+ax_pose 84, 0x81e4, 0x4105, 0x6c08
+ax_pose_terminator
+sHitmonleePose136:
+ax_pose 26, 0x41ec, 0x80ee, 0x6c00
+ax_pose 27, 0x41fc, 0x40ee, 0x6c08
+ax_pose_terminator
+sHitmonleePose137:
+ax_pose 90, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose138:
+ax_pose 91, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose139:
+ax_pose 92, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose140:
+ax_pose 93, 0x01e4, 0x90f1, 0x6c00
+ax_pose_terminator
+sHitmonleePose141:
+ax_pose 94, 0x01e3, 0x90f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose142:
+ax_pose 95, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose143:
+ax_pose 96, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose144:
+ax_pose 95, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose145:
+ax_pose 94, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose146:
+ax_pose 93, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose147:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose148:
+ax_pose 24, 0x41ee, 0x80f0, 0x6c00
+ax_pose 25, 0x41fd, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose149:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose150:
+ax_pose 26, 0x41ed, 0x90f3, 0x6c00
+ax_pose 27, 0x41fd, 0x50f3, 0x6c08
+ax_pose_terminator
+sHitmonleePose151:
+ax_pose 6, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose152:
+ax_pose 28, 0x81e4, 0x90f9, 0x6c00
+ax_pose 29, 0x81ec, 0x1109, 0x6c08
+ax_pose_terminator
+sHitmonleePose153:
+ax_pose 9, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose154:
+ax_pose 30, 0x81e4, 0x90ff, 0x6c00
+ax_pose 31, 0x81e4, 0x50f7, 0x6c08
+ax_pose_terminator
+sHitmonleePose155:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose156:
+ax_pose 32, 0x41eb, 0x80f0, 0x6c00
+ax_pose 33, 0x41fb, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose157:
+ax_pose 15, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose158:
+ax_pose 30, 0x81e4, 0x80f0, 0x6c00
+ax_pose 31, 0x81e4, 0x4100, 0x6c08
+ax_pose_terminator
+sHitmonleePose159:
+ax_pose 18, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose160:
+ax_pose 28, 0x81e4, 0x80f9, 0x6c00
+ax_pose 29, 0x81ec, 0x00f1, 0x6c08
+ax_pose_terminator
+sHitmonleePose161:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose162:
+ax_pose 26, 0x41ec, 0x80ef, 0x6c00
+ax_pose 27, 0x41fc, 0x40ef, 0x6c08
+ax_pose_terminator
+sHitmonleePose163:
+ax_pose 24, 0x41ee, 0x80f0, 0x6c00
+ax_pose 25, 0x41fd, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose164:
+ax_pose 26, 0x41ec, 0x80f0, 0x6c00
+ax_pose 27, 0x41fc, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose165:
+ax_pose 28, 0x81e4, 0x80fa, 0x6c00
+ax_pose 29, 0x81ec, 0x00f2, 0x6c08
+ax_pose_terminator
+sHitmonleePose166:
+ax_pose 30, 0x81e4, 0x80f1, 0x6c00
+ax_pose 31, 0x81e4, 0x4101, 0x6c08
+ax_pose_terminator
+sHitmonleePose167:
+ax_pose 32, 0x41eb, 0x80f0, 0x6c00
+ax_pose 33, 0x41fb, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose168:
+ax_pose 30, 0x81e4, 0x90ff, 0x6c00
+ax_pose 31, 0x81e4, 0x50f7, 0x6c08
+ax_pose_terminator
+sHitmonleePose169:
+ax_pose 28, 0x81e4, 0x90f7, 0x6c00
+ax_pose 29, 0x81ec, 0x1107, 0x6c08
+ax_pose_terminator
+sHitmonleePose170:
+ax_pose 26, 0x41ec, 0x90f1, 0x6c00
+ax_pose 27, 0x41fc, 0x50f1, 0x6c08
+ax_pose_terminator
+sHitmonleePose171:
+ax_pose 81, 0x81e3, 0x80f5, 0x6c00
+ax_pose 82, 0x81e3, 0x4105, 0x6c08
+ax_pose_terminator
+sHitmonleePose172:
+ax_pose 83, 0x81e5, 0x90fc, 0x6c00
+ax_pose 84, 0x81e5, 0x50f4, 0x6c08
+ax_pose_terminator
+sHitmonleePose173:
+ax_pose 85, 0x81e4, 0x90f8, 0x6c00
+ax_pose 86, 0x01ec, 0x1108, 0x6c08
+ax_pose_terminator
+sHitmonleePose174:
+ax_pose 87, 0x81e5, 0x90fd, 0x6c00
+ax_pose 88, 0x81e5, 0x50f5, 0x6c08
+ax_pose_terminator
+sHitmonleePose175:
+ax_pose 89, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose176:
+ax_pose 87, 0x81e4, 0x80f3, 0x6c00
+ax_pose 88, 0x81e4, 0x4103, 0x6c08
+ax_pose_terminator
+sHitmonleePose177:
+ax_pose 85, 0x81e4, 0x80f8, 0x6c00
+ax_pose 86, 0x01ec, 0x00f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose178:
+ax_pose 83, 0x81e4, 0x80f5, 0x6c00
+ax_pose 84, 0x81e4, 0x4105, 0x6c08
+ax_pose_terminator
+sHitmonleePose179:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose180:
+ax_pose 81, 0x81e3, 0x80f5, 0x6c00
+ax_pose 82, 0x81e3, 0x4105, 0x6c08
+ax_pose_terminator
+sHitmonleePose181:
+ax_pose 24, 0x41ee, 0x80f0, 0x6c00
+ax_pose 25, 0x41fd, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose182:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose183:
+ax_pose 83, 0x81e5, 0x90fc, 0x6c00
+ax_pose 84, 0x81e5, 0x50f4, 0x6c08
+ax_pose_terminator
+sHitmonleePose184:
+ax_pose 26, 0x41ed, 0x90f1, 0x6c00
+ax_pose 27, 0x41fd, 0x50f1, 0x6c08
+ax_pose_terminator
+sHitmonleePose185:
+ax_pose 6, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose186:
+ax_pose 85, 0x81e5, 0x90f8, 0x6c00
+ax_pose 86, 0x01ed, 0x1108, 0x6c08
+ax_pose_terminator
+sHitmonleePose187:
+ax_pose 28, 0x81e4, 0x90f6, 0x6c00
+ax_pose 29, 0x81ec, 0x1106, 0x6c08
+ax_pose_terminator
+sHitmonleePose188:
+ax_pose 9, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose189:
+ax_pose 87, 0x81e5, 0x90fd, 0x6c00
+ax_pose 88, 0x81e5, 0x50f5, 0x6c08
+ax_pose_terminator
+sHitmonleePose190:
+ax_pose 30, 0x81e4, 0x90ff, 0x6c00
+ax_pose 31, 0x81e4, 0x50f7, 0x6c08
+ax_pose_terminator
+sHitmonleePose191:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose192:
+ax_pose 89, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose193:
+ax_pose 32, 0x41ea, 0x80f0, 0x6c00
+ax_pose 33, 0x41fa, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose194:
+ax_pose 15, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose195:
+ax_pose 87, 0x81e4, 0x80f3, 0x6c00
+ax_pose 88, 0x81e4, 0x4103, 0x6c08
+ax_pose_terminator
+sHitmonleePose196:
+ax_pose 30, 0x81e3, 0x80f2, 0x6c00
+ax_pose 31, 0x81e3, 0x4102, 0x6c08
+ax_pose_terminator
+sHitmonleePose197:
+ax_pose 18, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose198:
+ax_pose 85, 0x81e4, 0x80f8, 0x6c00
+ax_pose 86, 0x01ec, 0x00f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose199:
+ax_pose 28, 0x81e4, 0x80f9, 0x6c00
+ax_pose 29, 0x81ec, 0x00f1, 0x6c08
+ax_pose_terminator
+sHitmonleePose200:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose201:
+ax_pose 83, 0x81e4, 0x80f5, 0x6c00
+ax_pose 84, 0x81e4, 0x4105, 0x6c08
+ax_pose_terminator
+sHitmonleePose202:
+ax_pose 26, 0x41ec, 0x80f0, 0x6c00
+ax_pose 27, 0x41fc, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose203:
+ax_pose 24, 0x41ee, 0x80f0, 0x6c00
+ax_pose 25, 0x41fd, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose204:
+ax_pose 26, 0x41ec, 0x80f0, 0x6c00
+ax_pose 27, 0x41fc, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose205:
+ax_pose 28, 0x81e4, 0x80fa, 0x6c00
+ax_pose 29, 0x81ec, 0x00f2, 0x6c08
+ax_pose_terminator
+sHitmonleePose206:
+ax_pose 30, 0x81e4, 0x80f1, 0x6c00
+ax_pose 31, 0x81e4, 0x4101, 0x6c08
+ax_pose_terminator
+sHitmonleePose207:
+ax_pose 32, 0x41eb, 0x80f0, 0x6c00
+ax_pose 33, 0x41fb, 0x40f0, 0x6c08
+ax_pose_terminator
+sHitmonleePose208:
+ax_pose 30, 0x81e4, 0x90ff, 0x6c00
+ax_pose 31, 0x81e4, 0x50f7, 0x6c08
+ax_pose_terminator
+sHitmonleePose209:
+ax_pose 28, 0x81e4, 0x90f7, 0x6c00
+ax_pose 29, 0x81ec, 0x1107, 0x6c08
+ax_pose_terminator
+sHitmonleePose210:
+ax_pose 26, 0x41ec, 0x90f1, 0x6c00
+ax_pose 27, 0x41fc, 0x50f1, 0x6c08
+ax_pose_terminator
+sHitmonleePose211:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose212:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose213:
+ax_pose 18, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sHitmonleePose214:
+ax_pose 15, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sHitmonleePose215:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHitmonleePose216:
+ax_pose 9, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHitmonleePose217:
+ax_pose 6, 0x01e4, 0x80f7, 0x6c00
+ax_pose_terminator
+sHitmonleePose218:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+.align 2
+sHitmonleeAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHitmonleeAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 9, 11, 9, 11,
+ax_anim 2, 0, 31, 16, 18, 16, 18,
+ax_anim 2, 1, 31, 17, 17, 17, 17,
+ax_anim 2, 0, 31, 16, 18, 16, 18,
+ax_anim 2, 0, 31, 17, 17, 17, 17,
+ax_anim 2, 0, 28, 5, 6, 5, 6,
+ax_anim_terminator
+sHitmonleeAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sHitmonleeAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -6, 6, -6,
+ax_anim 1, 0, 38, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 18, -16, 18, -16,
+ax_anim 2, 1, 39, 19, -15, 19, -15,
+ax_anim 2, 0, 39, 18, -16, 18, -16,
+ax_anim 2, 0, 39, 19, -15, 19, -15,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sHitmonleeAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -3, 0, -3,
+ax_anim 1, 0, 42, 0, -10, 0, -10,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sHitmonleeAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -6, -6, -6,
+ax_anim 1, 0, 46, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -18, -16, -18, -16,
+ax_anim 2, 1, 47, -19, -15, -19, -15,
+ax_anim 2, 0, 47, -18, -16, -18, -16,
+ax_anim 2, 0, 47, -19, -15, -19, -15,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sHitmonleeAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sHitmonleeAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -9, 11, -9, 11,
+ax_anim 2, 0, 55, -16, 18, -16, 18,
+ax_anim 2, 1, 55, -17, 17, -17, 17,
+ax_anim 2, 0, 55, -16, 18, -16, 18,
+ax_anim 2, 0, 55, -17, 17, -17, 17,
+ax_anim 2, 0, 52, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_3_1:
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 8, 0, 101, 0, -4, 0, -4,
+ax_anim 1, 2, 101, 0, -1, 0, -1,
+ax_anim 1, 0, 101, 0, 4, 0, 4,
+ax_anim 2, 0, 60, 0, 13, 0, 13,
+ax_anim 1, 1, 66, 0, 13, 0, 13,
+ax_anim 1, 0, 73, 0, 13, 0, 13,
+ax_anim 1, 0, 79, 0, 13, 0, 13,
+ax_anim 1, 0, 85, 0, 13, 0, 13,
+ax_anim 2, 0, 91, 0, 13, 0, 13,
+ax_anim 2, 0, 97, 0, 13, 0, 13,
+ax_anim 2, 0, 99, 0, 13, 0, 13,
+ax_anim 2, 0, 58, 0, 8, 0, 8,
+ax_anim 2, 0, 57, 0, 3, 0, 3,
+ax_anim_terminator
+sHitmonleeAnims_3_2:
+ax_anim 2, 0, 65, -2, -2, -2, -2,
+ax_anim 8, 0, 59, -4, -4, -4, -4,
+ax_anim 1, 2, 59, -1, -1, -1, -1,
+ax_anim 1, 0, 59, 4, 6, 4, 6,
+ax_anim 2, 0, 66, 11, 17, 11, 17,
+ax_anim 1, 1, 72, 11, 17, 11, 17,
+ax_anim 1, 0, 79, 11, 17, 11, 17,
+ax_anim 1, 0, 85, 11, 17, 11, 17,
+ax_anim 1, 0, 91, 11, 17, 11, 17,
+ax_anim 2, 0, 97, 11, 17, 11, 17,
+ax_anim 2, 0, 103, 11, 17, 11, 17,
+ax_anim 2, 0, 57, 11, 17, 11, 17,
+ax_anim 2, 0, 64, 7, 11, 7, 11,
+ax_anim 2, 0, 63, 3, 5, 3, 5,
+ax_anim_terminator
+sHitmonleeAnims_3_3:
+ax_anim 2, 0, 71, -2, 0, -2, 0,
+ax_anim 8, 0, 65, -6, 0, -6, 0,
+ax_anim 1, 2, 65, -3, 0, -3, 0,
+ax_anim 1, 0, 65, 4, 0, 4, 0,
+ax_anim 2, 0, 72, 13, 0, 13, 0,
+ax_anim 1, 1, 78, 13, 0, 13, 0,
+ax_anim 1, 0, 85, 13, 0, 13, 0,
+ax_anim 1, 0, 91, 13, 0, 13, 0,
+ax_anim 1, 0, 97, 13, 0, 13, 0,
+ax_anim 2, 0, 103, 13, 0, 13, 0,
+ax_anim 2, 0, 61, 13, 0, 13, 0,
+ax_anim 2, 0, 63, 13, 0, 13, 0,
+ax_anim 2, 0, 70, 7, 0, 7, 0,
+ax_anim 2, 0, 69, 3, 0, 3, 0,
+ax_anim_terminator
+sHitmonleeAnims_3_4:
+ax_anim 2, 0, 77, -2, 2, -2, 2,
+ax_anim 8, 0, 71, -6, 4, -4, 4,
+ax_anim 1, 2, 71, -3, 1, -1, 1,
+ax_anim 1, 0, 71, 4, -6, 6, -6,
+ax_anim 2, 0, 78, 11, -13, 13, -13,
+ax_anim 1, 1, 84, 13, -13, 13, -13,
+ax_anim 1, 0, 91, 13, -13, 13, -13,
+ax_anim 1, 0, 97, 13, -13, 13, -13,
+ax_anim 1, 0, 103, 13, -13, 13, -13,
+ax_anim 2, 0, 61, 13, -13, 13, -13,
+ax_anim 2, 0, 67, 13, -13, 13, -13,
+ax_anim 2, 0, 69, 13, -13, 13, -13,
+ax_anim 2, 0, 76, 9, -9, 9, -9,
+ax_anim 2, 0, 75, 3, -3, 3, -3,
+ax_anim_terminator
+sHitmonleeAnims_3_5:
+ax_anim 2, 0, 83, 0, 2, 0, 2,
+ax_anim 8, 0, 77, 0, 4, 0, 4,
+ax_anim 1, 2, 77, 0, 1, 0, 1,
+ax_anim 1, 0, 77, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 0, -11, 0, -11,
+ax_anim 1, 1, 90, 0, -11, 0, -11,
+ax_anim 1, 0, 97, 0, -11, 0, -11,
+ax_anim 1, 0, 103, 0, -11, 0, -11,
+ax_anim 1, 0, 61, 0, -11, 0, -11,
+ax_anim 2, 0, 67, 0, -11, 0, -11,
+ax_anim 2, 0, 73, 0, -11, 0, -11,
+ax_anim 2, 0, 81, 0, -11, 0, -11,
+ax_anim 2, 0, 82, 0, -6, 0, -6,
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim_terminator
+sHitmonleeAnims_3_6:
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 8, 0, 83, 4, 4, 4, 4,
+ax_anim 1, 2, 83, 1, 1, 1, 1,
+ax_anim 1, 0, 83, -6, -6, -6, -6,
+ax_anim 2, 0, 90, -13, -13, -13, -13,
+ax_anim 1, 1, 96, -13, -13, -13, -13,
+ax_anim 1, 0, 103, -13, -13, -13, -13,
+ax_anim 1, 0, 61, -13, -13, -13, -13,
+ax_anim 1, 0, 67, -13, -13, -13, -13,
+ax_anim 2, 0, 73, -13, -13, -13, -13,
+ax_anim 2, 0, 79, -13, -13, -13, -13,
+ax_anim 2, 0, 87, -13, -13, -13, -13,
+ax_anim 2, 0, 88, -9, -9, -9, -9,
+ax_anim 2, 0, 87, -3, -3, -3, -3,
+ax_anim_terminator
+sHitmonleeAnims_3_7:
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 8, 0, 89, 7, 0, 7, 0,
+ax_anim 1, 2, 89, 3, 0, 3, 0,
+ax_anim 1, 0, 89, -2, 0, -2, 0,
+ax_anim 2, 0, 96, -10, 0, -10, 0,
+ax_anim 1, 1, 102, -10, 0, -10, 0,
+ax_anim 1, 0, 61, -10, 0, -10, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 1, 0, 73, -10, 0, -10, 0,
+ax_anim 2, 0, 79, -10, 0, -10, 0,
+ax_anim 2, 0, 85, -10, 0, -10, 0,
+ax_anim 2, 0, 93, -10, 0, -10, 0,
+ax_anim 2, 0, 94, -7, 0, -7, 0,
+ax_anim 2, 0, 93, -3, 0, -3, 0,
+ax_anim_terminator
+sHitmonleeAnims_3_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 8, 0, 95, 6, -4, 6, -4,
+ax_anim 1, 2, 95, 1, -1, 1, -1,
+ax_anim 1, 0, 95, -4, 6, -4, 6,
+ax_anim 2, 0, 102, -12, 15, -12, 15,
+ax_anim 1, 1, 60, -12, 15, -12, 15,
+ax_anim 1, 0, 67, -12, 15, -12, 15,
+ax_anim 1, 0, 73, -12, 15, -12, 15,
+ax_anim 1, 0, 79, -12, 15, -12, 15,
+ax_anim 2, 0, 85, -12, 15, -12, 15,
+ax_anim 2, 0, 91, -12, 15, -12, 15,
+ax_anim 2, 0, 99, -12, 15, -12, 15,
+ax_anim 2, 0, 100, -9, 10, -9, 10,
+ax_anim 2, 0, 99, -4, 5, -4, 5,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_4_1:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 1, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_4_2:
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_4_3:
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_4_4:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_4_5:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_4_6:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_4_7:
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_4_8:
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_5_1:
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 4, 0, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_5_2:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 4, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_5_3:
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_5_4:
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_5_5:
+ax_anim 1, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 126, -1, 0, -1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_5_6:
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_5_7:
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_5_8:
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sHitmonleeAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sHitmonleeAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sHitmonleeAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sHitmonleeAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sHitmonleeAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sHitmonleeAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sHitmonleeAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 20, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_8_2:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_8_3:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 20, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_8_4:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 20, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_8_5:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_8_6:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 20, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_8_7:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 20, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_8_8:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 16, 7, 16,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 16, -7, 16,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 21, 19, 21, 19,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -7, 11, -7,
+ax_anim 2, 0, 163, 18, -5, 18, -5,
+ax_anim 3, 0, 164, 21, -2, 21, -2,
+ax_anim 2, 3, 165, 19, 3, 19, 3,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 4, 4, 4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 11, -21, 11, -21,
+ax_anim 3, 0, 163, 20, -21, 20, -21,
+ax_anim 2, 3, 164, 20, -13, 20, -13,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -23, 0, -23,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -11, -21, -11, -21,
+ax_anim 3, 0, 169, -20, -21, -20, -21,
+ax_anim 2, 3, 168, -20, -13, -20, -13,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -7, -11, -7,
+ax_anim 2, 0, 169, -18, -5, -18, -5,
+ax_anim 3, 0, 168, -21, -2, -21, -2,
+ax_anim 2, 3, 167, -19, 3, -19, 3,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -21, 19, -21, 19,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -14, 0, 0,
+ax_anim 3, 0, 179, 0, -16, 0, 0,
+ax_anim 4, 0, 179, 0, -17, 0, 0,
+ax_anim 4, 0, 178, 0, -28, 0, 0,
+ax_anim 3, 0, 180, 0, -27, 0, 0,
+ax_anim 2, 0, 180, 0, -22, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -14, 0, 0,
+ax_anim 3, 0, 182, 0, -18, 0, 0,
+ax_anim 4, 0, 182, 0, -19, 0, 0,
+ax_anim 4, 0, 181, 0, -27, 0, 0,
+ax_anim 3, 0, 183, 0, -26, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -18, 0, 0,
+ax_anim 4, 0, 185, 0, -19, 0, 0,
+ax_anim 4, 0, 184, 0, -25, 0, 0,
+ax_anim 3, 0, 186, 0, -24, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -18, 0, 0,
+ax_anim 4, 0, 188, 0, -19, 0, 0,
+ax_anim 4, 0, 187, 0, -25, 0, 0,
+ax_anim 3, 0, 189, 0, -24, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -12, 0, 0,
+ax_anim 3, 0, 191, 0, -16, 0, 0,
+ax_anim 4, 0, 191, 0, -17, 0, 0,
+ax_anim 4, 0, 190, 0, -25, 0, 0,
+ax_anim 3, 0, 192, 0, -24, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -14, 0, 0,
+ax_anim 3, 0, 194, 0, -16, 0, 0,
+ax_anim 4, 0, 194, 0, -17, 0, 0,
+ax_anim 4, 0, 193, 0, -25, 0, 0,
+ax_anim 3, 0, 195, 0, -24, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -18, 0, 0,
+ax_anim 4, 0, 197, 0, -19, 0, 0,
+ax_anim 4, 0, 196, 0, -25, 0, 0,
+ax_anim 3, 0, 198, 0, -24, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -14, 0, 0,
+ax_anim 3, 0, 200, 0, -18, 0, 0,
+ax_anim 4, 0, 200, 0, -19, 0, 0,
+ax_anim 4, 0, 199, 0, -27, 0, 0,
+ax_anim 3, 0, 201, 0, -26, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmonleeAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmonleeGfx1:
+.incbin "baserom.gba", 0x98EA74, 0x200
+sHitmonleeSprites1:
+ax_sprite sHitmonleeGfx1, 0x200
+ax_sprite_terminator
+sHitmonleeGfx2:
+.incbin "baserom.gba", 0x98EC84, 0x200
+sHitmonleeSprites2:
+ax_sprite sHitmonleeGfx2, 0x200
+ax_sprite_terminator
+sHitmonleeGfx3:
+.incbin "baserom.gba", 0x98EE94, 0x200
+sHitmonleeSprites3:
+ax_sprite sHitmonleeGfx3, 0x200
+ax_sprite_terminator
+sHitmonleeGfx4:
+.incbin "baserom.gba", 0x98F0A4, 0x200
+sHitmonleeSprites4:
+ax_sprite sHitmonleeGfx4, 0x200
+ax_sprite_terminator
+sHitmonleeGfx5:
+.incbin "baserom.gba", 0x98F2B4, 0x200
+sHitmonleeSprites5:
+ax_sprite sHitmonleeGfx5, 0x200
+ax_sprite_terminator
+sHitmonleeGfx6:
+.incbin "baserom.gba", 0x98F4C4, 0x200
+sHitmonleeSprites6:
+ax_sprite sHitmonleeGfx6, 0x200
+ax_sprite_terminator
+sHitmonleeGfx7:
+.incbin "baserom.gba", 0x98F6D4, 0x200
+sHitmonleeSprites7:
+ax_sprite sHitmonleeGfx7, 0x200
+ax_sprite_terminator
+sHitmonleeGfx8:
+.incbin "baserom.gba", 0x98F8E4, 0x200
+sHitmonleeSprites8:
+ax_sprite sHitmonleeGfx8, 0x200
+ax_sprite_terminator
+sHitmonleeGfx9:
+.incbin "baserom.gba", 0x98FAF4, 0x200
+sHitmonleeSprites9:
+ax_sprite sHitmonleeGfx9, 0x200
+ax_sprite_terminator
+sHitmonleeGfx10:
+.incbin "baserom.gba", 0x98FD04, 0x200
+sHitmonleeSprites10:
+ax_sprite sHitmonleeGfx10, 0x200
+ax_sprite_terminator
+sHitmonleeGfx11:
+.incbin "baserom.gba", 0x98FF14, 0x200
+sHitmonleeSprites11:
+ax_sprite sHitmonleeGfx11, 0x200
+ax_sprite_terminator
+sHitmonleeGfx12:
+.incbin "baserom.gba", 0x990124, 0x200
+sHitmonleeSprites12:
+ax_sprite sHitmonleeGfx12, 0x200
+ax_sprite_terminator
+sHitmonleeGfx13:
+.incbin "baserom.gba", 0x990334, 0x200
+sHitmonleeSprites13:
+ax_sprite sHitmonleeGfx13, 0x200
+ax_sprite_terminator
+sHitmonleeGfx14:
+.incbin "baserom.gba", 0x990544, 0x200
+sHitmonleeSprites14:
+ax_sprite sHitmonleeGfx14, 0x200
+ax_sprite_terminator
+sHitmonleeGfx15:
+.incbin "baserom.gba", 0x990754, 0x200
+sHitmonleeSprites15:
+ax_sprite sHitmonleeGfx15, 0x200
+ax_sprite_terminator
+sHitmonleeGfx16:
+.incbin "baserom.gba", 0x990964, 0x200
+sHitmonleeSprites16:
+ax_sprite sHitmonleeGfx16, 0x200
+ax_sprite_terminator
+sHitmonleeGfx17:
+.incbin "baserom.gba", 0x990B74, 0x200
+sHitmonleeSprites17:
+ax_sprite sHitmonleeGfx17, 0x200
+ax_sprite_terminator
+sHitmonleeGfx18:
+.incbin "baserom.gba", 0x990D84, 0x200
+sHitmonleeSprites18:
+ax_sprite sHitmonleeGfx18, 0x200
+ax_sprite_terminator
+sHitmonleeGfx19:
+.incbin "baserom.gba", 0x990F94, 0x200
+sHitmonleeSprites19:
+ax_sprite sHitmonleeGfx19, 0x200
+ax_sprite_terminator
+sHitmonleeGfx20:
+.incbin "baserom.gba", 0x9911A4, 0x200
+sHitmonleeSprites20:
+ax_sprite sHitmonleeGfx20, 0x200
+ax_sprite_terminator
+sHitmonleeGfx21:
+.incbin "baserom.gba", 0x9913B4, 0x200
+sHitmonleeSprites21:
+ax_sprite sHitmonleeGfx21, 0x200
+ax_sprite_terminator
+sHitmonleeGfx22:
+.incbin "baserom.gba", 0x9915C4, 0x200
+sHitmonleeSprites22:
+ax_sprite sHitmonleeGfx22, 0x200
+ax_sprite_terminator
+sHitmonleeGfx23:
+.incbin "baserom.gba", 0x9917D4, 0x200
+sHitmonleeSprites23:
+ax_sprite sHitmonleeGfx23, 0x200
+ax_sprite_terminator
+sHitmonleeGfx24:
+.incbin "baserom.gba", 0x9919E4, 0x200
+sHitmonleeSprites24:
+ax_sprite sHitmonleeGfx24, 0x200
+ax_sprite_terminator
+sHitmonleeGfx25:
+.incbin "baserom.gba", 0x991BF4, 0x100
+sHitmonleeSprites25:
+ax_sprite sHitmonleeGfx25, 0x100
+ax_sprite_terminator
+sHitmonleeGfx26:
+.incbin "baserom.gba", 0x991D04, 0x80
+sHitmonleeSprites26:
+ax_sprite sHitmonleeGfx26, 0x80
+ax_sprite_terminator
+sHitmonleeGfx27:
+.incbin "baserom.gba", 0x991D94, 0x60
+sHitmonleeGfx27_1:
+.incbin "baserom.gba", 0x991DF4, 0x80
+sHitmonleeSprites27:
+ax_sprite sHitmonleeGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx27_1, 0x80
+ax_sprite_terminator
+sHitmonleeGfx28:
+.incbin "baserom.gba", 0x991E94, 0x60
+sHitmonleeSprites28:
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx28, 0x60
+ax_sprite_terminator
+sHitmonleeGfx29:
+.incbin "baserom.gba", 0x991F0C, 0xC0
+sHitmonleeSprites29:
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx29, 0xc0
+ax_sprite_terminator
+sHitmonleeGfx30:
+.incbin "baserom.gba", 0x991FE4, 0x40
+sHitmonleeSprites30:
+ax_sprite sHitmonleeGfx30, 0x40
+ax_sprite_terminator
+sHitmonleeGfx31:
+.incbin "baserom.gba", 0x992034, 0xC0
+sHitmonleeSprites31:
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx31, 0xc0
+ax_sprite_terminator
+sHitmonleeGfx32:
+.incbin "baserom.gba", 0x99210C, 0x60
+sHitmonleeSprites32:
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx32, 0x60
+ax_sprite_terminator
+sHitmonleeGfx33:
+.incbin "baserom.gba", 0x992184, 0x100
+sHitmonleeSprites33:
+ax_sprite sHitmonleeGfx33, 0x100
+ax_sprite_terminator
+sHitmonleeGfx34:
+.incbin "baserom.gba", 0x992294, 0x80
+sHitmonleeSprites34:
+ax_sprite sHitmonleeGfx34, 0x80
+ax_sprite_terminator
+sHitmonleeGfx35:
+.incbin "baserom.gba", 0x992324, 0x40
+sHitmonleeSprites35:
+ax_sprite sHitmonleeGfx35, 0x40
+ax_sprite_terminator
+sHitmonleeGfx36:
+.incbin "baserom.gba", 0x992374, 0x100
+sHitmonleeSprites36:
+ax_sprite sHitmonleeGfx36, 0x100
+ax_sprite_terminator
+sHitmonleeGfx37:
+.incbin "baserom.gba", 0x992484, 0x20
+sHitmonleeSprites37:
+ax_sprite sHitmonleeGfx37, 0x20
+ax_sprite_terminator
+sHitmonleeGfx38:
+.incbin "baserom.gba", 0x9924B4, 0x40
+sHitmonleeGfx38_1:
+.incbin "baserom.gba", 0x9924F4, 0x80
+sHitmonleeSprites38:
+ax_sprite sHitmonleeGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx38_1, 0x80
+ax_sprite_terminator
+sHitmonleeGfx39:
+.incbin "baserom.gba", 0x992594, 0x20
+sHitmonleeSprites39:
+ax_sprite sHitmonleeGfx39, 0x20
+ax_sprite_terminator
+sHitmonleeGfx40:
+.incbin "baserom.gba", 0x9925C4, 0x40
+sHitmonleeSprites40:
+ax_sprite sHitmonleeGfx40, 0x40
+ax_sprite_terminator
+sHitmonleeGfx41:
+.incbin "baserom.gba", 0x992614, 0xC0
+sHitmonleeGfx41_1:
+.incbin "baserom.gba", 0x9926D4, 0x20
+sHitmonleeSprites41:
+ax_sprite sHitmonleeGfx41, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx41_1, 0x20
+ax_sprite_terminator
+sHitmonleeGfx42:
+.incbin "baserom.gba", 0x992714, 0x40
+sHitmonleeGfx42_1:
+.incbin "baserom.gba", 0x992754, 0x20
+sHitmonleeSprites42:
+ax_sprite sHitmonleeGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx42_1, 0x20
+ax_sprite_terminator
+sHitmonleeGfx43:
+.incbin "baserom.gba", 0x992794, 0x20
+sHitmonleeSprites43:
+ax_sprite sHitmonleeGfx43, 0x20
+ax_sprite_terminator
+sHitmonleeGfx44:
+.incbin "baserom.gba", 0x9927C4, 0x160
+sHitmonleeGfx44_1:
+.incbin "baserom.gba", 0x992924, 0x40
+sHitmonleeSprites44:
+ax_sprite sHitmonleeGfx44, 0x160
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx44_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonleeGfx45:
+.incbin "baserom.gba", 0x99298C, 0x20
+sHitmonleeGfx45_1:
+.incbin "baserom.gba", 0x9929AC, 0xC0
+sHitmonleeSprites45:
+ax_sprite sHitmonleeGfx45, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx45_1, 0xc0
+ax_sprite_terminator
+sHitmonleeGfx46:
+.incbin "baserom.gba", 0x992A8C, 0x1C0
+sHitmonleeSprites46:
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx46, 0x1c0
+ax_sprite_terminator
+sHitmonleeGfx47:
+.incbin "baserom.gba", 0x992C64, 0x100
+sHitmonleeSprites47:
+ax_sprite sHitmonleeGfx47, 0x100
+ax_sprite_terminator
+sHitmonleeGfx48:
+.incbin "baserom.gba", 0x992D74, 0x40
+sHitmonleeSprites48:
+ax_sprite sHitmonleeGfx48, 0x40
+ax_sprite_terminator
+sHitmonleeGfx49:
+.incbin "baserom.gba", 0x992DC4, 0x20
+sHitmonleeSprites49:
+ax_sprite sHitmonleeGfx49, 0x20
+ax_sprite_terminator
+sHitmonleeGfx50:
+.incbin "baserom.gba", 0x992DF4, 0x20
+sHitmonleeGfx50_1:
+.incbin "baserom.gba", 0x992E14, 0xC0
+sHitmonleeSprites50:
+ax_sprite 0, 0xe0
+ax_sprite sHitmonleeGfx50, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx50_1, 0xc0
+ax_sprite_terminator
+sHitmonleeGfx51:
+.incbin "baserom.gba", 0x992EFC, 0x100
+sHitmonleeSprites51:
+ax_sprite sHitmonleeGfx51, 0x100
+ax_sprite_terminator
+sHitmonleeGfx52:
+.incbin "baserom.gba", 0x99300C, 0x80
+sHitmonleeSprites52:
+ax_sprite sHitmonleeGfx52, 0x80
+ax_sprite_terminator
+sHitmonleeGfx53:
+.incbin "baserom.gba", 0x99309C, 0x100
+sHitmonleeSprites53:
+ax_sprite sHitmonleeGfx53, 0x100
+ax_sprite_terminator
+sHitmonleeGfx54:
+.incbin "baserom.gba", 0x9931AC, 0x40
+sHitmonleeSprites54:
+ax_sprite sHitmonleeGfx54, 0x40
+ax_sprite_terminator
+sHitmonleeGfx55:
+.incbin "baserom.gba", 0x9931FC, 0x40
+sHitmonleeSprites55:
+ax_sprite sHitmonleeGfx55, 0x40
+ax_sprite_terminator
+sHitmonleeGfx56:
+.incbin "baserom.gba", 0x99324C, 0x80
+sHitmonleeGfx56_1:
+.incbin "baserom.gba", 0x9932CC, 0x60
+sHitmonleeSprites56:
+ax_sprite sHitmonleeGfx56, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx56_1, 0x60
+ax_sprite_terminator
+sHitmonleeGfx57:
+.incbin "baserom.gba", 0x99334C, 0x20
+sHitmonleeSprites57:
+ax_sprite sHitmonleeGfx57, 0x20
+ax_sprite_terminator
+sHitmonleeGfx58:
+.incbin "baserom.gba", 0x99337C, 0x100
+sHitmonleeSprites58:
+ax_sprite sHitmonleeGfx58, 0x100
+ax_sprite_terminator
+sHitmonleeGfx59:
+.incbin "baserom.gba", 0x99348C, 0x80
+sHitmonleeSprites59:
+ax_sprite sHitmonleeGfx59, 0x80
+ax_sprite_terminator
+sHitmonleeGfx60:
+.incbin "baserom.gba", 0x99351C, 0x20
+sHitmonleeSprites60:
+ax_sprite sHitmonleeGfx60, 0x20
+ax_sprite_terminator
+sHitmonleeGfx61:
+.incbin "baserom.gba", 0x99354C, 0x100
+sHitmonleeSprites61:
+ax_sprite sHitmonleeGfx61, 0x100
+ax_sprite_terminator
+sHitmonleeGfx62:
+.incbin "baserom.gba", 0x99365C, 0x40
+sHitmonleeSprites62:
+ax_sprite sHitmonleeGfx62, 0x40
+ax_sprite_terminator
+sHitmonleeGfx63:
+.incbin "baserom.gba", 0x9936AC, 0x40
+sHitmonleeSprites63:
+ax_sprite sHitmonleeGfx63, 0x40
+ax_sprite_terminator
+sHitmonleeGfx64:
+.incbin "baserom.gba", 0x9936FC, 0x80
+sHitmonleeGfx64_1:
+.incbin "baserom.gba", 0x99377C, 0x20
+sHitmonleeGfx64_2:
+.incbin "baserom.gba", 0x99379C, 0x20
+sHitmonleeGfx64_3:
+.incbin "baserom.gba", 0x9937BC, 0x20
+sHitmonleeGfx64_4:
+.incbin "baserom.gba", 0x9937DC, 0x40
+sHitmonleeSprites64:
+ax_sprite sHitmonleeGfx64, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx64_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx64_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHitmonleeGfx64_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx64_4, 0x40
+ax_sprite_terminator
+sHitmonleeGfx65:
+.incbin "baserom.gba", 0x99386C, 0xC0
+sHitmonleeGfx65_1:
+.incbin "baserom.gba", 0x99392C, 0x20
+sHitmonleeSprites65:
+ax_sprite sHitmonleeGfx65, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx65_1, 0x20
+ax_sprite_terminator
+sHitmonleeGfx66:
+.incbin "baserom.gba", 0x99396C, 0x80
+sHitmonleeSprites66:
+ax_sprite sHitmonleeGfx66, 0x80
+ax_sprite_terminator
+sHitmonleeGfx67:
+.incbin "baserom.gba", 0x9939FC, 0xE0
+sHitmonleeSprites67:
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx67, 0xe0
+ax_sprite_terminator
+sHitmonleeGfx68:
+.incbin "baserom.gba", 0x993AF4, 0x80
+sHitmonleeSprites68:
+ax_sprite sHitmonleeGfx68, 0x80
+ax_sprite_terminator
+sHitmonleeGfx69:
+.incbin "baserom.gba", 0x993B84, 0x100
+sHitmonleeSprites69:
+ax_sprite sHitmonleeGfx69, 0x100
+ax_sprite_terminator
+sHitmonleeGfx70:
+.incbin "baserom.gba", 0x993C94, 0x40
+sHitmonleeSprites70:
+ax_sprite sHitmonleeGfx70, 0x40
+ax_sprite_terminator
+sHitmonleeGfx71:
+.incbin "baserom.gba", 0x993CE4, 0x40
+sHitmonleeSprites71:
+ax_sprite sHitmonleeGfx71, 0x40
+ax_sprite_terminator
+sHitmonleeGfx72:
+.incbin "baserom.gba", 0x993D34, 0xC0
+sHitmonleeGfx72_1:
+.incbin "baserom.gba", 0x993DF4, 0x20
+sHitmonleeGfx72_2:
+.incbin "baserom.gba", 0x993E14, 0x20
+sHitmonleeGfx72_3:
+.incbin "baserom.gba", 0x993E34, 0x20
+sHitmonleeSprites72:
+ax_sprite sHitmonleeGfx72, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx72_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHitmonleeGfx72_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHitmonleeGfx72_3, 0x20
+ax_sprite_terminator
+sHitmonleeGfx73:
+.incbin "baserom.gba", 0x993E94, 0x100
+sHitmonleeSprites73:
+ax_sprite sHitmonleeGfx73, 0x100
+ax_sprite_terminator
+sHitmonleeGfx74:
+.incbin "baserom.gba", 0x993FA4, 0x40
+sHitmonleeSprites74:
+ax_sprite sHitmonleeGfx74, 0x40
+ax_sprite_terminator
+sHitmonleeGfx75:
+.incbin "baserom.gba", 0x993FF4, 0x40
+sHitmonleeSprites75:
+ax_sprite sHitmonleeGfx75, 0x40
+ax_sprite_terminator
+sHitmonleeGfx76:
+.incbin "baserom.gba", 0x994044, 0x100
+sHitmonleeSprites76:
+ax_sprite sHitmonleeGfx76, 0x100
+ax_sprite_terminator
+sHitmonleeGfx77:
+.incbin "baserom.gba", 0x994154, 0x80
+sHitmonleeSprites77:
+ax_sprite sHitmonleeGfx77, 0x80
+ax_sprite_terminator
+sHitmonleeGfx78:
+.incbin "baserom.gba", 0x9941E4, 0x60
+sHitmonleeGfx78_1:
+.incbin "baserom.gba", 0x994244, 0xC0
+sHitmonleeGfx78_2:
+.incbin "baserom.gba", 0x994304, 0x20
+sHitmonleeSprites78:
+ax_sprite sHitmonleeGfx78, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx78_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx78_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHitmonleeGfx79:
+.incbin "baserom.gba", 0x99435C, 0x40
+sHitmonleeGfx79_1:
+.incbin "baserom.gba", 0x99439C, 0x100
+sHitmonleeGfx79_2:
+.incbin "baserom.gba", 0x99449C, 0x60
+sHitmonleeSprites79:
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx79, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx79_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx79_2, 0x60
+ax_sprite_terminator
+sHitmonleeGfx80:
+.incbin "baserom.gba", 0x994534, 0xA0
+sHitmonleeGfx80_1:
+.incbin "baserom.gba", 0x9945D4, 0x40
+sHitmonleeGfx80_2:
+.incbin "baserom.gba", 0x994614, 0x60
+sHitmonleeSprites80:
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx80, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx80_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHitmonleeGfx80_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHitmonleeGfx81:
+.incbin "baserom.gba", 0x9946B4, 0x140
+sHitmonleeGfx81_1:
+.incbin "baserom.gba", 0x9947F4, 0x80
+sHitmonleeSprites81:
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx81, 0x140
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx81_1, 0x80
+ax_sprite_terminator
+sHitmonleeGfx82:
+.incbin "baserom.gba", 0x99489C, 0x100
+sHitmonleeSprites82:
+ax_sprite sHitmonleeGfx82, 0x100
+ax_sprite_terminator
+sHitmonleeGfx83:
+.incbin "baserom.gba", 0x9949AC, 0x80
+sHitmonleeSprites83:
+ax_sprite sHitmonleeGfx83, 0x80
+ax_sprite_terminator
+sHitmonleeGfx84:
+.incbin "baserom.gba", 0x994A3C, 0x100
+sHitmonleeSprites84:
+ax_sprite sHitmonleeGfx84, 0x100
+ax_sprite_terminator
+sHitmonleeGfx85:
+.incbin "baserom.gba", 0x994B4C, 0x80
+sHitmonleeSprites85:
+ax_sprite sHitmonleeGfx85, 0x80
+ax_sprite_terminator
+sHitmonleeGfx86:
+.incbin "baserom.gba", 0x994BDC, 0x100
+sHitmonleeSprites86:
+ax_sprite sHitmonleeGfx86, 0x100
+ax_sprite_terminator
+sHitmonleeGfx87:
+.incbin "baserom.gba", 0x994CEC, 0x20
+sHitmonleeSprites87:
+ax_sprite sHitmonleeGfx87, 0x20
+ax_sprite_terminator
+sHitmonleeGfx88:
+.incbin "baserom.gba", 0x994D1C, 0x100
+sHitmonleeSprites88:
+ax_sprite sHitmonleeGfx88, 0x100
+ax_sprite_terminator
+sHitmonleeGfx89:
+.incbin "baserom.gba", 0x994E2C, 0x80
+sHitmonleeSprites89:
+ax_sprite sHitmonleeGfx89, 0x80
+ax_sprite_terminator
+sHitmonleeGfx90:
+.incbin "baserom.gba", 0x994EBC, 0x100
+sHitmonleeGfx90_1:
+.incbin "baserom.gba", 0x994FBC, 0x40
+sHitmonleeGfx90_2:
+.incbin "baserom.gba", 0x994FFC, 0x80
+sHitmonleeSprites90:
+ax_sprite sHitmonleeGfx90, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx90_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmonleeGfx90_2, 0x80
+ax_sprite_terminator
+sHitmonleeGfx91:
+.incbin "baserom.gba", 0x9950AC, 0x200
+sHitmonleeSprites91:
+ax_sprite sHitmonleeGfx91, 0x200
+ax_sprite_terminator
+sHitmonleeGfx92:
+.incbin "baserom.gba", 0x9952BC, 0x200
+sHitmonleeSprites92:
+ax_sprite sHitmonleeGfx92, 0x200
+ax_sprite_terminator
+sHitmonleeGfx93:
+.incbin "baserom.gba", 0x9954CC, 0x200
+sHitmonleeSprites93:
+ax_sprite sHitmonleeGfx93, 0x200
+ax_sprite_terminator
+sHitmonleeGfx94:
+.incbin "baserom.gba", 0x9956DC, 0x200
+sHitmonleeSprites94:
+ax_sprite sHitmonleeGfx94, 0x200
+ax_sprite_terminator
+sHitmonleeGfx95:
+.incbin "baserom.gba", 0x9958EC, 0x200
+sHitmonleeSprites95:
+ax_sprite sHitmonleeGfx95, 0x200
+ax_sprite_terminator
+sHitmonleeGfx96:
+.incbin "baserom.gba", 0x995AFC, 0x200
+sHitmonleeSprites96:
+ax_sprite sHitmonleeGfx96, 0x200
+ax_sprite_terminator
+sHitmonleeGfx97:
+.incbin "baserom.gba", 0x995D0C, 0x200
+sHitmonleeSprites97:
+ax_sprite sHitmonleeGfx97, 0x200
+ax_sprite_terminator
+sAxPosesHitmonlee:
+.4byte sHitmonleePose1
+.4byte sHitmonleePose2
+.4byte sHitmonleePose3
+.4byte sHitmonleePose4
+.4byte sHitmonleePose5
+.4byte sHitmonleePose6
+.4byte sHitmonleePose7
+.4byte sHitmonleePose8
+.4byte sHitmonleePose9
+.4byte sHitmonleePose10
+.4byte sHitmonleePose11
+.4byte sHitmonleePose12
+.4byte sHitmonleePose13
+.4byte sHitmonleePose14
+.4byte sHitmonleePose15
+.4byte sHitmonleePose16
+.4byte sHitmonleePose17
+.4byte sHitmonleePose18
+.4byte sHitmonleePose19
+.4byte sHitmonleePose20
+.4byte sHitmonleePose21
+.4byte sHitmonleePose22
+.4byte sHitmonleePose23
+.4byte sHitmonleePose24
+.4byte sHitmonleePose25
+.4byte sHitmonleePose26
+.4byte sHitmonleePose27
+.4byte sHitmonleePose28
+.4byte sHitmonleePose29
+.4byte sHitmonleePose30
+.4byte sHitmonleePose31
+.4byte sHitmonleePose32
+.4byte sHitmonleePose33
+.4byte sHitmonleePose34
+.4byte sHitmonleePose35
+.4byte sHitmonleePose36
+.4byte sHitmonleePose37
+.4byte sHitmonleePose38
+.4byte sHitmonleePose39
+.4byte sHitmonleePose40
+.4byte sHitmonleePose41
+.4byte sHitmonleePose42
+.4byte sHitmonleePose43
+.4byte sHitmonleePose44
+.4byte sHitmonleePose45
+.4byte sHitmonleePose46
+.4byte sHitmonleePose47
+.4byte sHitmonleePose48
+.4byte sHitmonleePose49
+.4byte sHitmonleePose50
+.4byte sHitmonleePose51
+.4byte sHitmonleePose52
+.4byte sHitmonleePose53
+.4byte sHitmonleePose54
+.4byte sHitmonleePose55
+.4byte sHitmonleePose56
+.4byte sHitmonleePose57
+.4byte sHitmonleePose58
+.4byte sHitmonleePose59
+.4byte sHitmonleePose60
+.4byte sHitmonleePose61
+.4byte sHitmonleePose62
+.4byte sHitmonleePose63
+.4byte sHitmonleePose64
+.4byte sHitmonleePose65
+.4byte sHitmonleePose66
+.4byte sHitmonleePose67
+.4byte sHitmonleePose68
+.4byte sHitmonleePose69
+.4byte sHitmonleePose70
+.4byte sHitmonleePose71
+.4byte sHitmonleePose72
+.4byte sHitmonleePose73
+.4byte sHitmonleePose74
+.4byte sHitmonleePose75
+.4byte sHitmonleePose76
+.4byte sHitmonleePose77
+.4byte sHitmonleePose78
+.4byte sHitmonleePose79
+.4byte sHitmonleePose80
+.4byte sHitmonleePose81
+.4byte sHitmonleePose82
+.4byte sHitmonleePose83
+.4byte sHitmonleePose84
+.4byte sHitmonleePose85
+.4byte sHitmonleePose86
+.4byte sHitmonleePose87
+.4byte sHitmonleePose88
+.4byte sHitmonleePose89
+.4byte sHitmonleePose90
+.4byte sHitmonleePose91
+.4byte sHitmonleePose92
+.4byte sHitmonleePose93
+.4byte sHitmonleePose94
+.4byte sHitmonleePose95
+.4byte sHitmonleePose96
+.4byte sHitmonleePose97
+.4byte sHitmonleePose98
+.4byte sHitmonleePose99
+.4byte sHitmonleePose100
+.4byte sHitmonleePose101
+.4byte sHitmonleePose102
+.4byte sHitmonleePose103
+.4byte sHitmonleePose104
+.4byte sHitmonleePose105
+.4byte sHitmonleePose106
+.4byte sHitmonleePose107
+.4byte sHitmonleePose108
+.4byte sHitmonleePose109
+.4byte sHitmonleePose110
+.4byte sHitmonleePose111
+.4byte sHitmonleePose112
+.4byte sHitmonleePose113
+.4byte sHitmonleePose114
+.4byte sHitmonleePose115
+.4byte sHitmonleePose116
+.4byte sHitmonleePose117
+.4byte sHitmonleePose118
+.4byte sHitmonleePose119
+.4byte sHitmonleePose120
+.4byte sHitmonleePose121
+.4byte sHitmonleePose122
+.4byte sHitmonleePose123
+.4byte sHitmonleePose124
+.4byte sHitmonleePose125
+.4byte sHitmonleePose126
+.4byte sHitmonleePose127
+.4byte sHitmonleePose128
+.4byte sHitmonleePose129
+.4byte sHitmonleePose130
+.4byte sHitmonleePose131
+.4byte sHitmonleePose132
+.4byte sHitmonleePose133
+.4byte sHitmonleePose134
+.4byte sHitmonleePose135
+.4byte sHitmonleePose136
+.4byte sHitmonleePose137
+.4byte sHitmonleePose138
+.4byte sHitmonleePose139
+.4byte sHitmonleePose140
+.4byte sHitmonleePose141
+.4byte sHitmonleePose142
+.4byte sHitmonleePose143
+.4byte sHitmonleePose144
+.4byte sHitmonleePose145
+.4byte sHitmonleePose146
+.4byte sHitmonleePose147
+.4byte sHitmonleePose148
+.4byte sHitmonleePose149
+.4byte sHitmonleePose150
+.4byte sHitmonleePose151
+.4byte sHitmonleePose152
+.4byte sHitmonleePose153
+.4byte sHitmonleePose154
+.4byte sHitmonleePose155
+.4byte sHitmonleePose156
+.4byte sHitmonleePose157
+.4byte sHitmonleePose158
+.4byte sHitmonleePose159
+.4byte sHitmonleePose160
+.4byte sHitmonleePose161
+.4byte sHitmonleePose162
+.4byte sHitmonleePose163
+.4byte sHitmonleePose164
+.4byte sHitmonleePose165
+.4byte sHitmonleePose166
+.4byte sHitmonleePose167
+.4byte sHitmonleePose168
+.4byte sHitmonleePose169
+.4byte sHitmonleePose170
+.4byte sHitmonleePose171
+.4byte sHitmonleePose172
+.4byte sHitmonleePose173
+.4byte sHitmonleePose174
+.4byte sHitmonleePose175
+.4byte sHitmonleePose176
+.4byte sHitmonleePose177
+.4byte sHitmonleePose178
+.4byte sHitmonleePose179
+.4byte sHitmonleePose180
+.4byte sHitmonleePose181
+.4byte sHitmonleePose182
+.4byte sHitmonleePose183
+.4byte sHitmonleePose184
+.4byte sHitmonleePose185
+.4byte sHitmonleePose186
+.4byte sHitmonleePose187
+.4byte sHitmonleePose188
+.4byte sHitmonleePose189
+.4byte sHitmonleePose190
+.4byte sHitmonleePose191
+.4byte sHitmonleePose192
+.4byte sHitmonleePose193
+.4byte sHitmonleePose194
+.4byte sHitmonleePose195
+.4byte sHitmonleePose196
+.4byte sHitmonleePose197
+.4byte sHitmonleePose198
+.4byte sHitmonleePose199
+.4byte sHitmonleePose200
+.4byte sHitmonleePose201
+.4byte sHitmonleePose202
+.4byte sHitmonleePose203
+.4byte sHitmonleePose204
+.4byte sHitmonleePose205
+.4byte sHitmonleePose206
+.4byte sHitmonleePose207
+.4byte sHitmonleePose208
+.4byte sHitmonleePose209
+.4byte sHitmonleePose210
+.4byte sHitmonleePose211
+.4byte sHitmonleePose212
+.4byte sHitmonleePose213
+.4byte sHitmonleePose214
+.4byte sHitmonleePose215
+.4byte sHitmonleePose216
+.4byte sHitmonleePose217
+.4byte sHitmonleePose218
+sAxPositionsHitmonlee:
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,  -13
+.2byte   -2,   -9, 	 -11,   -9, 	   6,   -5, 	  -1,  -12
+.2byte    1,   -9, 	  -7,   -5, 	  11,   -8, 	   1,  -12
+.2byte    3,  -10, 	  -3,   -5, 	  14,  -12, 	   1,  -13
+.2byte    2,   -9, 	  -6,   -5, 	  15,  -10, 	   0,  -12
+.2byte    4,  -10, 	   0,   -4, 	  12,  -12, 	   1,  -11
+.2byte    4,  -12, 	   7,   -7, 	  10,  -17, 	   0,  -12
+.2byte    3,  -11, 	   4,   -6, 	  11,  -16, 	  -1,  -12
+.2byte    4,  -11, 	  10,   -7, 	   8,  -16, 	   0,  -11
+.2byte    3,  -15, 	  12,  -12, 	   2,  -23, 	  -1,  -14
+.2byte    2,  -14, 	  10,  -10, 	   4,  -22, 	   0,  -13
+.2byte    3,  -14, 	  14,  -14, 	   1,  -22, 	   0,  -13
+.2byte    0,  -15, 	  11,  -15, 	  -9,  -21, 	   0,  -12
+.2byte    0,  -14, 	  11,  -12, 	  -6,  -23, 	   0,  -12
+.2byte    0,  -13, 	   8,  -17, 	 -11,  -17, 	   0,  -12
+.2byte   -1,  -18, 	   5,  -20, 	 -12,  -17, 	   1,  -12
+.2byte   -1,  -17, 	   5,  -17, 	 -12,  -18, 	   1,  -12
+.2byte    0,  -18, 	   4,  -17, 	 -12,  -14, 	   1,  -11
+.2byte   -5,  -14, 	  -8,  -15, 	 -12,  -12, 	   0,  -14
+.2byte   -5,  -13, 	  -5,  -16, 	 -14,  -12, 	   0,  -11
+.2byte   -5,  -13, 	  -9,  -15, 	 -10,   -9, 	   0,  -11
+.2byte   -3,  -11, 	 -12,  -11, 	  -1,   -8, 	  -1,  -12
+.2byte   -3,  -10, 	 -10,  -10, 	  -3,   -6, 	  -1,  -11
+.2byte   -2,  -10, 	 -14,   -9, 	   3,   -5, 	   0,  -11
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,  -13
+.2byte   -2,   -9, 	 -11,   -9, 	   6,   -5, 	  -1,  -12
+.2byte    1,   -9, 	  -7,   -5, 	  11,   -8, 	   1,  -12
+.2byte    0,   -4, 	 -10,   -5, 	  10,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -3,   -5, 	  14,  -12, 	   1,  -13
+.2byte    2,   -9, 	  -6,   -5, 	  15,  -10, 	   0,  -12
+.2byte    4,  -10, 	   0,   -4, 	  12,  -12, 	   1,  -11
+.2byte    5,   -5, 	  14,   -7, 	  -1,   -2, 	   3,   -9
+.2byte    4,  -12, 	   7,   -7, 	  10,  -17, 	   0,  -12
+.2byte    3,  -11, 	   4,   -6, 	  11,  -16, 	  -1,  -12
+.2byte    4,  -11, 	  10,   -7, 	   8,  -16, 	   0,  -11
+.2byte    4,   -9, 	   6,   -9, 	   5,   -7, 	   0,  -11
+.2byte    3,  -15, 	  12,  -12, 	   2,  -23, 	  -1,  -14
+.2byte    2,  -14, 	  10,  -10, 	   4,  -22, 	   0,  -13
+.2byte    3,  -14, 	  14,  -14, 	   1,  -22, 	   0,  -13
+.2byte    4,  -13, 	  -1,  -18, 	   9,  -10, 	   0,  -13
+.2byte    0,  -15, 	  11,  -15, 	  -9,  -21, 	   0,  -12
+.2byte    0,  -14, 	  11,  -12, 	  -6,  -23, 	   0,  -12
+.2byte    0,  -13, 	   8,  -17, 	 -11,  -17, 	   0,  -12
+.2byte    1,  -15, 	  12,  -11, 	 -10,  -13, 	   0,  -12
+.2byte   -1,  -18, 	   5,  -20, 	 -12,  -17, 	   1,  -12
+.2byte   -1,  -17, 	   5,  -17, 	 -12,  -18, 	   1,  -12
+.2byte    0,  -18, 	   4,  -17, 	 -12,  -14, 	   1,  -11
+.2byte   -5,  -12, 	   0,  -17, 	 -10,   -9, 	  -1,  -12
+.2byte   -5,  -14, 	  -8,  -15, 	 -12,  -12, 	   0,  -14
+.2byte   -5,  -13, 	  -5,  -16, 	 -14,  -12, 	   0,  -11
+.2byte   -5,  -13, 	  -9,  -15, 	 -10,   -9, 	   0,  -11
+.2byte   -6,   -9, 	  -8,   -9, 	  -7,   -7, 	  -2,  -11
+.2byte   -3,  -11, 	 -12,  -11, 	  -1,   -8, 	  -1,  -12
+.2byte   -3,  -10, 	 -10,  -10, 	  -3,   -6, 	  -1,  -11
+.2byte   -2,  -10, 	 -14,   -9, 	   3,   -5, 	   0,  -11
+.2byte   -5,   -6, 	 -14,   -8, 	   1,   -3, 	  -3,  -10
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,  -13
+.2byte   -2,   -9, 	 -11,   -9, 	   6,   -5, 	  -1,  -12
+.2byte    1,   -9, 	  -7,   -5, 	  11,   -8, 	   1,  -12
+.2byte    0,  -10, 	 -10,  -10, 	   9,  -15, 	   0,  -12
+.2byte    2,  -12, 	 -12,   -7, 	   9,  -21, 	  -1,  -14
+.2byte    2,  -12, 	 -12,   -7, 	   9,  -21, 	  -1,  -14
+.2byte    3,  -10, 	  -3,   -5, 	  14,  -12, 	   1,  -13
+.2byte    2,   -9, 	  -6,   -5, 	  15,  -10, 	   0,  -12
+.2byte    4,  -10, 	   0,   -4, 	  12,  -12, 	   1,  -11
+.2byte    4,  -12, 	  -3,  -10, 	   9,  -12, 	   2,  -15
+.2byte    2,  -13, 	 -10,   -3, 	   5,  -24, 	  -2,  -13
+.2byte    2,  -13, 	 -10,   -3, 	   5,  -24, 	  -2,  -13
+.2byte    4,  -12, 	   7,   -7, 	  10,  -17, 	   0,  -12
+.2byte    3,  -11, 	   4,   -6, 	  11,  -16, 	  -1,  -12
+.2byte    4,  -11, 	  10,   -7, 	   8,  -16, 	   0,  -11
+.2byte    6,  -15, 	  13,  -14, 	  -1,  -13, 	   1,  -15
+.2byte    0,  -16, 	  -2,   -3, 	  -1,  -26, 	  -2,  -14
+.2byte    0,  -16, 	  -2,   -3, 	  -1,  -26, 	  -2,  -14
+.2byte    3,  -15, 	  12,  -12, 	   2,  -23, 	  -1,  -14
+.2byte    2,  -14, 	  10,  -10, 	   4,  -22, 	   0,  -13
+.2byte    3,  -14, 	  14,  -14, 	   1,  -22, 	   0,  -13
+.2byte    4,  -17, 	  11,  -17, 	  -9,  -11, 	  -1,  -14
+.2byte    3,  -16, 	  10,   -6, 	  -4,  -24, 	  -1,  -13
+.2byte    3,  -16, 	  10,   -6, 	  -4,  -24, 	  -1,  -13
+.2byte    0,  -15, 	  11,  -15, 	  -9,  -21, 	   0,  -12
+.2byte    0,  -14, 	  11,  -12, 	  -6,  -23, 	   0,  -12
+.2byte    0,  -13, 	   8,  -17, 	 -11,  -17, 	   0,  -12
+.2byte    0,  -15, 	   7,  -23, 	 -10,   -6, 	   0,  -12
+.2byte   -4,  -16, 	  12,  -11, 	 -10,  -23, 	  -2,  -13
+.2byte   -4,  -16, 	  12,  -11, 	 -10,  -23, 	  -2,  -13
+.2byte   -1,  -18, 	   5,  -20, 	 -12,  -17, 	   1,  -12
+.2byte   -1,  -17, 	   5,  -17, 	 -12,  -18, 	   1,  -12
+.2byte    0,  -18, 	   4,  -17, 	 -12,  -14, 	   1,  -11
+.2byte   -5,  -14, 	   0,  -23, 	  -8,   -4, 	  -1,  -13
+.2byte   -3,  -17, 	   0,  -20, 	  -5,  -20, 	   0,  -12
+.2byte   -3,  -17, 	   0,  -20, 	  -5,  -20, 	   0,  -12
+.2byte   -5,  -14, 	  -8,  -15, 	 -12,  -12, 	   0,  -14
+.2byte   -5,  -13, 	  -5,  -16, 	 -14,  -12, 	   0,  -11
+.2byte   -5,  -13, 	  -9,  -15, 	 -10,   -9, 	   0,  -11
+.2byte   -5,  -11, 	 -11,  -15, 	   3,   -7, 	  -1,  -12
+.2byte   -4,  -11, 	  -5,  -15, 	  -1,  -19, 	   0,  -12
+.2byte   -4,  -11, 	  -5,  -15, 	  -1,  -19, 	   0,  -12
+.2byte   -3,  -11, 	 -12,  -11, 	  -1,   -8, 	  -1,  -12
+.2byte   -3,  -10, 	 -10,  -10, 	  -3,   -6, 	  -1,  -11
+.2byte   -2,  -10, 	 -14,   -9, 	   3,   -5, 	   0,  -11
+.2byte   -2,   -9, 	 -10,  -12, 	  13,   -7, 	   0,  -13
+.2byte    1,  -10, 	 -15,  -10, 	   8,  -18, 	  -1,  -12
+.2byte    1,  -10, 	 -15,  -10, 	   8,  -18, 	  -1,  -12
+.2byte    0,   -4, 	 -10,   -5, 	  10,   -5, 	   0,   -8
+.2byte   -3,   -6, 	 -12,   -8, 	   3,   -3, 	  -1,  -10
+.2byte   -4,   -9, 	  -6,   -9, 	  -5,   -7, 	   0,  -11
+.2byte   -4,  -11, 	   1,  -16, 	  -9,   -8, 	   0,  -11
+.2byte    1,  -14, 	  12,  -10, 	 -10,  -12, 	   0,  -11
+.2byte    3,  -11, 	  -2,  -16, 	   8,   -8, 	  -1,  -11
+.2byte    4,   -9, 	   6,   -9, 	   5,   -7, 	   0,  -11
+.2byte    3,   -6, 	  12,   -8, 	  -3,   -3, 	   1,  -10
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,  -13
+.2byte    0,  -17, 	  -7,  -25, 	   7,  -24, 	   0,  -19
+.2byte    0,   -4, 	 -10,   -5, 	  10,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -3,   -5, 	  14,  -12, 	   1,  -13
+.2byte    1,  -14, 	   5,  -24, 	  -3,  -20, 	  -1,  -16
+.2byte    5,   -5, 	  14,   -7, 	  -1,   -2, 	   3,   -9
+.2byte    4,  -12, 	   7,   -7, 	  10,  -17, 	   0,  -12
+.2byte    3,  -18, 	   0,  -25, 	   5,  -21, 	  -1,  -17
+.2byte    4,   -9, 	   6,   -9, 	   5,   -7, 	   0,  -11
+.2byte    3,  -15, 	  12,  -12, 	   2,  -23, 	  -1,  -14
+.2byte   -1,  -19, 	  -6,  -24, 	   6,  -22, 	  -2,  -15
+.2byte    3,  -11, 	  -2,  -16, 	   8,   -8, 	  -1,  -11
+.2byte    0,  -15, 	  11,  -15, 	  -9,  -21, 	   0,  -12
+.2byte    1,  -23, 	  11,  -27, 	  -6,  -27, 	   0,  -20
+.2byte    1,  -15, 	  12,  -11, 	 -10,  -13, 	   0,  -12
+.2byte   -1,  -18, 	   5,  -20, 	 -12,  -17, 	   1,  -12
+.2byte   -1,  -20, 	   4,  -25, 	  -8,  -23, 	   0,  -16
+.2byte   -5,  -12, 	   0,  -17, 	 -10,   -9, 	  -1,  -12
+.2byte   -5,  -14, 	  -8,  -15, 	 -12,  -12, 	   0,  -14
+.2byte   -4,  -18, 	  -1,  -25, 	  -6,  -21, 	   0,  -17
+.2byte   -6,   -9, 	  -8,   -9, 	  -7,   -7, 	  -2,  -11
+.2byte   -3,  -11, 	 -12,  -11, 	  -1,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	  -5,  -25, 	   3,  -21, 	   1,  -17
+.2byte   -5,   -6, 	 -14,   -8, 	   1,   -3, 	  -3,  -10
+.2byte    0,   -4, 	  -6,    1, 	   4,    2, 	   0,   -7
+.2byte    0,   -5, 	  -5,    1, 	   3,    1, 	   0,   -8
+.2byte   -1,  -13, 	 -11,  -14, 	   8,   -7, 	  -1,  -14
+.2byte    0,  -14, 	  10,  -17, 	   1,   -7, 	  -1,  -12
+.2byte    1,  -18, 	   4,  -21, 	  12,  -15, 	  -3,  -12
+.2byte   -1,  -17, 	  -3,  -21, 	  10,  -19, 	  -2,  -11
+.2byte    0,  -10, 	  10,  -16, 	  -8,  -13, 	   0,   -9
+.2byte    0,  -17, 	   2,  -21, 	 -11,  -19, 	   1,  -11
+.2byte   -2,  -18, 	  -5,  -21, 	 -13,  -15, 	   2,  -12
+.2byte    0,  -14, 	 -10,  -17, 	  -1,   -7, 	   1,  -12
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,  -13
+.2byte    0,   -4, 	 -10,   -5, 	  10,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -3,   -5, 	  14,  -12, 	   1,  -13
+.2byte    5,   -5, 	  14,   -7, 	  -1,   -2, 	   3,   -9
+.2byte    4,  -12, 	   7,   -7, 	  10,  -17, 	   0,  -12
+.2byte    6,   -9, 	   8,   -9, 	   7,   -7, 	   2,  -11
+.2byte    3,  -15, 	  12,  -12, 	   2,  -23, 	  -1,  -14
+.2byte    3,  -11, 	  -2,  -16, 	   8,   -8, 	  -1,  -11
+.2byte    0,  -15, 	  11,  -15, 	  -9,  -21, 	   0,  -12
+.2byte    1,  -14, 	  12,  -10, 	 -10,  -12, 	   0,  -11
+.2byte   -1,  -18, 	   5,  -20, 	 -12,  -17, 	   1,  -12
+.2byte   -5,  -11, 	   0,  -16, 	 -10,   -8, 	  -1,  -11
+.2byte   -5,  -14, 	  -8,  -15, 	 -12,  -12, 	   0,  -14
+.2byte   -5,   -9, 	  -7,   -9, 	  -6,   -7, 	  -1,  -11
+.2byte   -3,  -11, 	 -12,  -11, 	  -1,   -8, 	  -1,  -12
+.2byte   -4,   -6, 	 -13,   -8, 	   2,   -3, 	  -2,  -10
+.2byte    0,   -4, 	 -10,   -5, 	  10,   -5, 	   0,   -8
+.2byte   -3,   -6, 	 -12,   -8, 	   3,   -3, 	  -1,  -10
+.2byte   -4,   -9, 	  -6,   -9, 	  -5,   -7, 	   0,  -11
+.2byte   -4,  -11, 	   1,  -16, 	  -9,   -8, 	   0,  -11
+.2byte    1,  -14, 	  12,  -10, 	 -10,  -12, 	   0,  -11
+.2byte    3,  -11, 	  -2,  -16, 	   8,   -8, 	  -1,  -11
+.2byte    4,   -9, 	   6,   -9, 	   5,   -7, 	   0,  -11
+.2byte    3,   -6, 	  12,   -8, 	  -3,   -3, 	   1,  -10
+.2byte    0,  -17, 	  -7,  -25, 	   7,  -24, 	   0,  -19
+.2byte    1,  -14, 	   5,  -24, 	  -3,  -20, 	  -1,  -16
+.2byte    3,  -18, 	   0,  -25, 	   5,  -21, 	  -1,  -17
+.2byte    0,  -19, 	  -5,  -24, 	   7,  -22, 	  -1,  -15
+.2byte    1,  -22, 	  11,  -26, 	  -6,  -26, 	   0,  -19
+.2byte   -1,  -20, 	   4,  -25, 	  -8,  -23, 	   0,  -16
+.2byte   -4,  -18, 	  -1,  -25, 	  -6,  -21, 	   0,  -17
+.2byte   -1,  -15, 	  -5,  -25, 	   3,  -21, 	   1,  -17
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,  -13
+.2byte    0,  -17, 	  -7,  -25, 	   7,  -24, 	   0,  -19
+.2byte    0,   -4, 	 -10,   -5, 	  10,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -3,   -5, 	  14,  -12, 	   1,  -13
+.2byte    1,  -14, 	   5,  -24, 	  -3,  -20, 	  -1,  -16
+.2byte    3,   -5, 	  12,   -7, 	  -3,   -2, 	   1,   -9
+.2byte    4,  -12, 	   7,   -7, 	  10,  -17, 	   0,  -12
+.2byte    3,  -17, 	   0,  -24, 	   5,  -20, 	  -1,  -16
+.2byte    3,   -9, 	   5,   -9, 	   4,   -7, 	  -1,  -11
+.2byte    3,  -15, 	  12,  -12, 	   2,  -23, 	  -1,  -14
+.2byte    0,  -19, 	  -5,  -24, 	   7,  -22, 	  -1,  -15
+.2byte    3,  -11, 	  -2,  -16, 	   8,   -8, 	  -1,  -11
+.2byte    0,  -15, 	  11,  -15, 	  -9,  -21, 	   0,  -12
+.2byte    1,  -23, 	  11,  -27, 	  -6,  -27, 	   0,  -20
+.2byte    1,  -15, 	  12,  -11, 	 -10,  -13, 	   0,  -12
+.2byte   -1,  -18, 	   5,  -20, 	 -12,  -17, 	   1,  -12
+.2byte   -1,  -20, 	   4,  -25, 	  -8,  -23, 	   0,  -16
+.2byte   -3,  -12, 	   2,  -17, 	  -8,   -9, 	   1,  -12
+.2byte   -5,  -14, 	  -8,  -15, 	 -12,  -12, 	   0,  -14
+.2byte   -4,  -18, 	  -1,  -25, 	  -6,  -21, 	   0,  -17
+.2byte   -5,   -9, 	  -7,   -9, 	  -6,   -7, 	  -1,  -11
+.2byte   -3,  -11, 	 -12,  -11, 	  -1,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	  -5,  -25, 	   3,  -21, 	   1,  -17
+.2byte   -3,   -6, 	 -12,   -8, 	   3,   -3, 	  -1,  -10
+.2byte    0,   -4, 	 -10,   -5, 	  10,   -5, 	   0,   -8
+.2byte   -3,   -6, 	 -12,   -8, 	   3,   -3, 	  -1,  -10
+.2byte   -4,   -9, 	  -6,   -9, 	  -5,   -7, 	   0,  -11
+.2byte   -4,  -11, 	   1,  -16, 	  -9,   -8, 	   0,  -11
+.2byte    1,  -14, 	  12,  -10, 	 -10,  -12, 	   0,  -11
+.2byte    3,  -11, 	  -2,  -16, 	   8,   -8, 	  -1,  -11
+.2byte    4,   -9, 	   6,   -9, 	   5,   -7, 	   0,  -11
+.2byte    3,   -6, 	  12,   -8, 	  -3,   -3, 	   1,  -10
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,  -13
+.2byte   -3,  -11, 	 -12,  -11, 	  -1,   -8, 	  -1,  -12
+.2byte   -5,  -14, 	  -8,  -15, 	 -12,  -12, 	   0,  -14
+.2byte   -1,  -18, 	   5,  -20, 	 -12,  -17, 	   1,  -12
+.2byte    0,  -15, 	  11,  -15, 	  -9,  -21, 	   0,  -12
+.2byte    3,  -15, 	  12,  -12, 	   2,  -23, 	  -1,  -14
+.2byte    4,  -12, 	   7,   -7, 	  10,  -17, 	   0,  -12
+.2byte    3,  -10, 	  -3,   -5, 	  14,  -12, 	   1,  -13
+sHitmonleeAnimTable1:
+.4byte sHitmonleeAnims_1_1
+.4byte sHitmonleeAnims_1_2
+.4byte sHitmonleeAnims_1_3
+.4byte sHitmonleeAnims_1_4
+.4byte sHitmonleeAnims_1_5
+.4byte sHitmonleeAnims_1_6
+.4byte sHitmonleeAnims_1_7
+.4byte sHitmonleeAnims_1_8
+sHitmonleeAnimTable2:
+.4byte sHitmonleeAnims_2_1
+.4byte sHitmonleeAnims_2_2
+.4byte sHitmonleeAnims_2_3
+.4byte sHitmonleeAnims_2_4
+.4byte sHitmonleeAnims_2_5
+.4byte sHitmonleeAnims_2_6
+.4byte sHitmonleeAnims_2_7
+.4byte sHitmonleeAnims_2_8
+sHitmonleeAnimTable3:
+.4byte sHitmonleeAnims_3_1
+.4byte sHitmonleeAnims_3_2
+.4byte sHitmonleeAnims_3_3
+.4byte sHitmonleeAnims_3_4
+.4byte sHitmonleeAnims_3_5
+.4byte sHitmonleeAnims_3_6
+.4byte sHitmonleeAnims_3_7
+.4byte sHitmonleeAnims_3_8
+sHitmonleeAnimTable4:
+.4byte sHitmonleeAnims_4_1
+.4byte sHitmonleeAnims_4_2
+.4byte sHitmonleeAnims_4_3
+.4byte sHitmonleeAnims_4_4
+.4byte sHitmonleeAnims_4_5
+.4byte sHitmonleeAnims_4_6
+.4byte sHitmonleeAnims_4_7
+.4byte sHitmonleeAnims_4_8
+sHitmonleeAnimTable5:
+.4byte sHitmonleeAnims_5_1
+.4byte sHitmonleeAnims_5_2
+.4byte sHitmonleeAnims_5_3
+.4byte sHitmonleeAnims_5_4
+.4byte sHitmonleeAnims_5_5
+.4byte sHitmonleeAnims_5_6
+.4byte sHitmonleeAnims_5_7
+.4byte sHitmonleeAnims_5_8
+sHitmonleeAnimTable6:
+.4byte sHitmonleeAnims_6_1
+.4byte sHitmonleeAnims_6_1
+.4byte sHitmonleeAnims_6_1
+.4byte sHitmonleeAnims_6_1
+.4byte sHitmonleeAnims_6_1
+.4byte sHitmonleeAnims_6_1
+.4byte sHitmonleeAnims_6_1
+.4byte sHitmonleeAnims_6_1
+sHitmonleeAnimTable7:
+.4byte sHitmonleeAnims_7_1
+.4byte sHitmonleeAnims_7_2
+.4byte sHitmonleeAnims_7_3
+.4byte sHitmonleeAnims_7_4
+.4byte sHitmonleeAnims_7_5
+.4byte sHitmonleeAnims_7_6
+.4byte sHitmonleeAnims_7_7
+.4byte sHitmonleeAnims_7_8
+sHitmonleeAnimTable8:
+.4byte sHitmonleeAnims_8_1
+.4byte sHitmonleeAnims_8_2
+.4byte sHitmonleeAnims_8_3
+.4byte sHitmonleeAnims_8_4
+.4byte sHitmonleeAnims_8_5
+.4byte sHitmonleeAnims_8_6
+.4byte sHitmonleeAnims_8_7
+.4byte sHitmonleeAnims_8_8
+sHitmonleeAnimTable9:
+.4byte sHitmonleeAnims_9_1
+.4byte sHitmonleeAnims_9_2
+.4byte sHitmonleeAnims_9_3
+.4byte sHitmonleeAnims_9_4
+.4byte sHitmonleeAnims_9_5
+.4byte sHitmonleeAnims_9_6
+.4byte sHitmonleeAnims_9_7
+.4byte sHitmonleeAnims_9_8
+sHitmonleeAnimTable10:
+.4byte sHitmonleeAnims_10_1
+.4byte sHitmonleeAnims_10_2
+.4byte sHitmonleeAnims_10_3
+.4byte sHitmonleeAnims_10_4
+.4byte sHitmonleeAnims_10_5
+.4byte sHitmonleeAnims_10_6
+.4byte sHitmonleeAnims_10_7
+.4byte sHitmonleeAnims_10_8
+sHitmonleeAnimTable11:
+.4byte sHitmonleeAnims_11_1
+.4byte sHitmonleeAnims_11_2
+.4byte sHitmonleeAnims_11_3
+.4byte sHitmonleeAnims_11_4
+.4byte sHitmonleeAnims_11_5
+.4byte sHitmonleeAnims_11_6
+.4byte sHitmonleeAnims_11_7
+.4byte sHitmonleeAnims_11_8
+sHitmonleeAnimTable12:
+.4byte sHitmonleeAnims_12_1
+.4byte sHitmonleeAnims_12_2
+.4byte sHitmonleeAnims_12_3
+.4byte sHitmonleeAnims_12_4
+.4byte sHitmonleeAnims_12_5
+.4byte sHitmonleeAnims_12_6
+.4byte sHitmonleeAnims_12_7
+.4byte sHitmonleeAnims_12_8
+sHitmonleeAnimTable13:
+.4byte sHitmonleeAnims_13_1
+.4byte sHitmonleeAnims_13_2
+.4byte sHitmonleeAnims_13_3
+.4byte sHitmonleeAnims_13_4
+.4byte sHitmonleeAnims_13_5
+.4byte sHitmonleeAnims_13_6
+.4byte sHitmonleeAnims_13_7
+.4byte sHitmonleeAnims_13_8
+sAxAnimationsHitmonlee:
+.4byte sHitmonleeAnimTable1
+.4byte sHitmonleeAnimTable2
+.4byte sHitmonleeAnimTable3
+.4byte sHitmonleeAnimTable4
+.4byte sHitmonleeAnimTable5
+.4byte sHitmonleeAnimTable6
+.4byte sHitmonleeAnimTable7
+.4byte sHitmonleeAnimTable8
+.4byte sHitmonleeAnimTable9
+.4byte sHitmonleeAnimTable10
+.4byte sHitmonleeAnimTable11
+.4byte sHitmonleeAnimTable12
+.4byte sHitmonleeAnimTable13
+sAxSpritesHitmonlee:
+.4byte sHitmonleeSprites1
+.4byte sHitmonleeSprites2
+.4byte sHitmonleeSprites3
+.4byte sHitmonleeSprites4
+.4byte sHitmonleeSprites5
+.4byte sHitmonleeSprites6
+.4byte sHitmonleeSprites7
+.4byte sHitmonleeSprites8
+.4byte sHitmonleeSprites9
+.4byte sHitmonleeSprites10
+.4byte sHitmonleeSprites11
+.4byte sHitmonleeSprites12
+.4byte sHitmonleeSprites13
+.4byte sHitmonleeSprites14
+.4byte sHitmonleeSprites15
+.4byte sHitmonleeSprites16
+.4byte sHitmonleeSprites17
+.4byte sHitmonleeSprites18
+.4byte sHitmonleeSprites19
+.4byte sHitmonleeSprites20
+.4byte sHitmonleeSprites21
+.4byte sHitmonleeSprites22
+.4byte sHitmonleeSprites23
+.4byte sHitmonleeSprites24
+.4byte sHitmonleeSprites25
+.4byte sHitmonleeSprites26
+.4byte sHitmonleeSprites27
+.4byte sHitmonleeSprites28
+.4byte sHitmonleeSprites29
+.4byte sHitmonleeSprites30
+.4byte sHitmonleeSprites31
+.4byte sHitmonleeSprites32
+.4byte sHitmonleeSprites33
+.4byte sHitmonleeSprites34
+.4byte sHitmonleeSprites35
+.4byte sHitmonleeSprites36
+.4byte sHitmonleeSprites37
+.4byte sHitmonleeSprites38
+.4byte sHitmonleeSprites39
+.4byte sHitmonleeSprites40
+.4byte sHitmonleeSprites41
+.4byte sHitmonleeSprites42
+.4byte sHitmonleeSprites43
+.4byte sHitmonleeSprites44
+.4byte sHitmonleeSprites45
+.4byte sHitmonleeSprites46
+.4byte sHitmonleeSprites47
+.4byte sHitmonleeSprites48
+.4byte sHitmonleeSprites49
+.4byte sHitmonleeSprites50
+.4byte sHitmonleeSprites51
+.4byte sHitmonleeSprites52
+.4byte sHitmonleeSprites53
+.4byte sHitmonleeSprites54
+.4byte sHitmonleeSprites55
+.4byte sHitmonleeSprites56
+.4byte sHitmonleeSprites57
+.4byte sHitmonleeSprites58
+.4byte sHitmonleeSprites59
+.4byte sHitmonleeSprites60
+.4byte sHitmonleeSprites61
+.4byte sHitmonleeSprites62
+.4byte sHitmonleeSprites63
+.4byte sHitmonleeSprites64
+.4byte sHitmonleeSprites65
+.4byte sHitmonleeSprites66
+.4byte sHitmonleeSprites67
+.4byte sHitmonleeSprites68
+.4byte sHitmonleeSprites69
+.4byte sHitmonleeSprites70
+.4byte sHitmonleeSprites71
+.4byte sHitmonleeSprites72
+.4byte sHitmonleeSprites73
+.4byte sHitmonleeSprites74
+.4byte sHitmonleeSprites75
+.4byte sHitmonleeSprites76
+.4byte sHitmonleeSprites77
+.4byte sHitmonleeSprites78
+.4byte sHitmonleeSprites79
+.4byte sHitmonleeSprites80
+.4byte sHitmonleeSprites81
+.4byte sHitmonleeSprites82
+.4byte sHitmonleeSprites83
+.4byte sHitmonleeSprites84
+.4byte sHitmonleeSprites85
+.4byte sHitmonleeSprites86
+.4byte sHitmonleeSprites87
+.4byte sHitmonleeSprites88
+.4byte sHitmonleeSprites89
+.4byte sHitmonleeSprites90
+.4byte sHitmonleeSprites91
+.4byte sHitmonleeSprites92
+.4byte sHitmonleeSprites93
+.4byte sHitmonleeSprites94
+.4byte sHitmonleeSprites95
+.4byte sHitmonleeSprites96
+.4byte sHitmonleeSprites97
+sAxMainHitmonlee:
+ax_main sAxPosesHitmonlee, sAxAnimationsHitmonlee, 13, sAxSpritesHitmonlee, sAxPositionsHitmonlee

--- a/data/ax/hitmontop.inc
+++ b/data/ax/hitmontop.inc
@@ -1,0 +1,2425 @@
+.global gAxHitmontop
+gAxHitmontop:
+ax_siro sAxMainHitmontop
+sHitmontopPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose4:
+ax_pose 3, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose5:
+ax_pose 4, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose6:
+ax_pose 5, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose7:
+ax_pose 6, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose8:
+ax_pose 7, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose9:
+ax_pose 8, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose10:
+ax_pose 9, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose11:
+ax_pose 10, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose12:
+ax_pose 11, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose17:
+ax_pose 10, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose20:
+ax_pose 7, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose21:
+ax_pose 8, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose24:
+ax_pose 5, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose25:
+ax_pose 15, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose26:
+ax_pose 16, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose27:
+ax_pose 17, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose28:
+ax_pose 18, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose29:
+ax_pose 19, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose30:
+ax_pose 18, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose31:
+ax_pose 17, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose32:
+ax_pose 16, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose33:
+ax_pose 15, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose34:
+ax_pose 16, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose35:
+ax_pose 17, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose36:
+ax_pose 18, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose37:
+ax_pose 19, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose38:
+ax_pose 18, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose39:
+ax_pose 17, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose40:
+ax_pose 16, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose41:
+ax_pose 20, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose42:
+ax_pose 21, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose43:
+ax_pose 22, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose44:
+ax_pose 23, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose45:
+ax_pose 24, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose46:
+ax_pose 23, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose47:
+ax_pose 22, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose48:
+ax_pose 21, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose49:
+ax_pose 20, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose50:
+ax_pose 21, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose51:
+ax_pose 22, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose52:
+ax_pose 23, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose53:
+ax_pose 24, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose54:
+ax_pose 23, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose55:
+ax_pose 22, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose56:
+ax_pose 21, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose57:
+ax_pose 25, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose58:
+ax_pose 26, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose59:
+ax_pose 27, 0x01e2, 0x80f5, 0x9c00
+ax_pose_terminator
+sHitmontopPose60:
+ax_pose 28, 0x01e4, 0x90ec, 0x9c00
+ax_pose_terminator
+sHitmontopPose61:
+ax_pose 29, 0x01e2, 0x90ea, 0x9c00
+ax_pose_terminator
+sHitmontopPose62:
+ax_pose 30, 0x01e3, 0x90ec, 0x9c00
+ax_pose_terminator
+sHitmontopPose63:
+ax_pose 31, 0x01e3, 0x80f5, 0x9c00
+ax_pose_terminator
+sHitmontopPose64:
+ax_pose 30, 0x01e3, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose65:
+ax_pose 29, 0x01e2, 0x80f6, 0x9c00
+ax_pose_terminator
+sHitmontopPose66:
+ax_pose 28, 0x01e4, 0x80f6, 0x9c00
+ax_pose_terminator
+sHitmontopPose67:
+ax_pose 0, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose68:
+ax_pose 1, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose69:
+ax_pose 2, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose70:
+ax_pose 3, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose71:
+ax_pose 4, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose72:
+ax_pose 5, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose73:
+ax_pose 6, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose74:
+ax_pose 7, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose75:
+ax_pose 8, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose76:
+ax_pose 9, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose77:
+ax_pose 10, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose78:
+ax_pose 11, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose79:
+ax_pose 12, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose80:
+ax_pose 13, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose81:
+ax_pose 14, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose82:
+ax_pose 9, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose83:
+ax_pose 10, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose84:
+ax_pose 11, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose85:
+ax_pose 6, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose86:
+ax_pose 7, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose87:
+ax_pose 8, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose88:
+ax_pose 3, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose89:
+ax_pose 4, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose90:
+ax_pose 5, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose91:
+ax_pose 20, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose92:
+ax_pose 21, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose93:
+ax_pose 22, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose94:
+ax_pose 23, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose95:
+ax_pose 24, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose96:
+ax_pose 23, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose97:
+ax_pose 22, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose98:
+ax_pose 21, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose99:
+ax_pose 15, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose100:
+ax_pose 16, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose101:
+ax_pose 17, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose102:
+ax_pose 18, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose103:
+ax_pose 19, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose104:
+ax_pose 18, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose105:
+ax_pose 17, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose106:
+ax_pose 16, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose107:
+ax_pose 0, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose108:
+ax_pose 1, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose109:
+ax_pose 2, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose110:
+ax_pose 3, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose111:
+ax_pose 4, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose112:
+ax_pose 5, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose113:
+ax_pose 6, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose114:
+ax_pose 7, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose115:
+ax_pose 8, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose116:
+ax_pose 9, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose117:
+ax_pose 10, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose118:
+ax_pose 11, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose119:
+ax_pose 12, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose120:
+ax_pose 13, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose121:
+ax_pose 14, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose122:
+ax_pose 9, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose123:
+ax_pose 10, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose124:
+ax_pose 11, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose125:
+ax_pose 6, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose126:
+ax_pose 7, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose127:
+ax_pose 8, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose128:
+ax_pose 3, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose129:
+ax_pose 4, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose130:
+ax_pose 5, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose131:
+ax_pose 0, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose132:
+ax_pose 3, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose133:
+ax_pose 6, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose134:
+ax_pose 9, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose135:
+ax_pose 12, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose136:
+ax_pose 9, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose137:
+ax_pose 6, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose138:
+ax_pose 3, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose139:
+ax_pose 0, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose140:
+ax_pose 3, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose141:
+ax_pose 6, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose142:
+ax_pose 9, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose143:
+ax_pose 12, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sHitmontopPose144:
+ax_pose 9, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose145:
+ax_pose 6, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+sHitmontopPose146:
+ax_pose 3, 0x01e5, 0x90eb, 0x9c00
+ax_pose_terminator
+.align 2
+sHitmontopAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 29, -2, 5, -2, 5,
+ax_anim 1, 2, 30, -4, 11, -4, 11,
+ax_anim 1, 0, 31, -2, 17, -2, 17,
+ax_anim 1, 0, 24, 0, 22, 0, 22,
+ax_anim 1, 0, 25, 0, 22, 0, 22,
+ax_anim 1, 1, 26, 0, 22, 0, 22,
+ax_anim 1, 0, 27, 0, 22, 0, 22,
+ax_anim 2, 0, 28, 0, 22, 0, 22,
+ax_anim 2, 0, 29, 0, 22, 0, 22,
+ax_anim 2, 0, 30, 0, 22, 0, 22,
+ax_anim 1, 0, 31, 0, 13, 0, 13,
+ax_anim 1, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHitmontopAnims_2_2:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 4, 10, 4, 10,
+ax_anim 1, 2, 31, 8, 15, 8, 15,
+ax_anim 1, 0, 24, 17, 20, 17, 20,
+ax_anim 1, 0, 25, 24, 21, 24, 21,
+ax_anim 1, 0, 26, 24, 21, 24, 21,
+ax_anim 1, 1, 27, 24, 21, 24, 21,
+ax_anim 1, 0, 28, 24, 21, 24, 21,
+ax_anim 2, 0, 29, 24, 21, 24, 21,
+ax_anim 2, 0, 30, 24, 21, 24, 21,
+ax_anim 2, 0, 31, 24, 21, 24, 21,
+ax_anim 1, 0, 24, 13, 13, 13, 13,
+ax_anim 1, 0, 25, 6, 6, 6, 6,
+ax_anim_terminator
+sHitmontopAnims_2_3:
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 5, 2, 5, 2,
+ax_anim 1, 2, 24, 8, 3, 8, 3,
+ax_anim 1, 0, 25, 19, 3, 19, 3,
+ax_anim 1, 0, 26, 24, 0, 24, 0,
+ax_anim 1, 0, 27, 24, 0, 24, 0,
+ax_anim 1, 1, 28, 24, 0, 24, 0,
+ax_anim 1, 0, 29, 24, 0, 24, 0,
+ax_anim 2, 0, 30, 24, 0, 24, 0,
+ax_anim 2, 0, 31, 24, 0, 24, 0,
+ax_anim 2, 0, 24, 24, 0, 24, 0,
+ax_anim 1, 0, 25, 13, 0, 13, 0,
+ax_anim 1, 0, 26, 6, 0, 6, 0,
+ax_anim_terminator
+sHitmontopAnims_2_4:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 7, -2, 7, -2,
+ax_anim 1, 2, 25, 15, -5, 15, -5,
+ax_anim 1, 0, 26, 20, -11, 20, -11,
+ax_anim 1, 0, 27, 24, -19, 24, -19,
+ax_anim 1, 0, 28, 24, -19, 24, -19,
+ax_anim 1, 1, 29, 24, -19, 24, -19,
+ax_anim 1, 0, 30, 24, -19, 24, -19,
+ax_anim 2, 0, 31, 24, -19, 24, -19,
+ax_anim 2, 0, 24, 24, -19, 24, -19,
+ax_anim 2, 0, 25, 24, -19, 24, -19,
+ax_anim 1, 0, 26, 12, -11, 12, -11,
+ax_anim 1, 0, 27, 6, -6, 6, -6,
+ax_anim_terminator
+sHitmontopAnims_2_5:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 2, -5, 2, -5,
+ax_anim 1, 2, 26, 4, -11, 4, -11,
+ax_anim 1, 0, 27, 2, -17, 2, -17,
+ax_anim 1, 0, 28, 0, -19, 0, -19,
+ax_anim 1, 0, 29, 0, -19, 0, -19,
+ax_anim 1, 1, 30, 0, -19, 0, -19,
+ax_anim 1, 0, 31, 0, -19, 0, -19,
+ax_anim 2, 0, 24, 0, -19, 0, -19,
+ax_anim 2, 0, 25, 0, -19, 0, -19,
+ax_anim 2, 0, 26, 0, -19, 0, -19,
+ax_anim 1, 0, 27, 0, -13, 0, -13,
+ax_anim 1, 0, 28, 0, -6, 0, -6,
+ax_anim_terminator
+sHitmontopAnims_2_6:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 26, -4, -8, -4, -8,
+ax_anim 1, 2, 27, -9, -14, -9, -14,
+ax_anim 1, 0, 28, -16, -17, -16, -17,
+ax_anim 1, 0, 29, -24, -19, -24, -19,
+ax_anim 1, 0, 30, -24, -19, -24, -19,
+ax_anim 1, 1, 31, -24, -19, -24, -19,
+ax_anim 1, 0, 24, -24, -19, -24, -19,
+ax_anim 2, 0, 25, -24, -19, -24, -19,
+ax_anim 2, 0, 26, -24, -19, -24, -19,
+ax_anim 2, 0, 27, -24, -19, -24, -19,
+ax_anim 1, 0, 28, -12, -11, -12, -11,
+ax_anim 1, 0, 29, -6, -6, -6, -6,
+ax_anim_terminator
+sHitmontopAnims_2_7:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 27, -5, -2, -5, -2,
+ax_anim 1, 2, 28, -8, -3, -8, -3,
+ax_anim 1, 0, 29, -19, -3, -19, -3,
+ax_anim 1, 0, 30, -24, 0, -24, 0,
+ax_anim 1, 0, 31, -24, 0, -24, 0,
+ax_anim 1, 1, 24, -24, 0, -24, 0,
+ax_anim 1, 0, 25, -24, 0, -24, 0,
+ax_anim 2, 0, 26, -24, 0, -24, 0,
+ax_anim 2, 0, 27, -24, 0, -24, 0,
+ax_anim 2, 0, 28, -24, 0, -24, 0,
+ax_anim 1, 0, 29, -13, 0, -13, 0,
+ax_anim 1, 0, 30, -6, 0, -6, 0,
+ax_anim_terminator
+sHitmontopAnims_2_8:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 28, -7, 3, -7, 3,
+ax_anim 1, 2, 29, -14, 7, -14, 7,
+ax_anim 1, 0, 30, -21, 14, -21, 14,
+ax_anim 1, 0, 31, -24, 21, -24, 21,
+ax_anim 1, 0, 24, -24, 21, -24, 21,
+ax_anim 1, 1, 25, -24, 21, -24, 21,
+ax_anim 1, 0, 26, -24, 21, -24, 21,
+ax_anim 2, 0, 27, -24, 21, -24, 21,
+ax_anim 2, 0, 28, -24, 21, -24, 21,
+ax_anim 2, 0, 29, -24, 21, -24, 21,
+ax_anim 1, 0, 30, -14, 13, -14, 13,
+ax_anim 1, 0, 31, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_3_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, 5, 0, 5,
+ax_anim 1, 0, 38, 0, 11, 0, 11,
+ax_anim 1, 2, 39, 0, 17, 0, 17,
+ax_anim 1, 0, 32, 0, 38, 0, 38,
+ax_anim 1, 0, 33, 0, 46, 0, 46,
+ax_anim 1, 0, 34, 0, 46, 0, 46,
+ax_anim 2, 1, 35, 0, 46, 0, 46,
+ax_anim 2, 0, 36, 0, 46, 0, 46,
+ax_anim 2, 0, 37, 0, 46, 0, 46,
+ax_anim 2, 0, 38, 0, 22, 0, 22,
+ax_anim 1, 0, 39, 0, 13, 0, 13,
+ax_anim 1, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sHitmontopAnims_3_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 0, 38, 10, 10, 10, 10,
+ax_anim 1, 0, 39, 15, 15, 15, 15,
+ax_anim 1, 2, 32, 28, 28, 28, 28,
+ax_anim 1, 0, 33, 40, 37, 40, 37,
+ax_anim 1, 0, 34, 48, 45, 48, 45,
+ax_anim 1, 0, 35, 48, 45, 48, 45,
+ax_anim 2, 1, 36, 48, 45, 48, 45,
+ax_anim 2, 0, 37, 48, 45, 48, 45,
+ax_anim 2, 0, 38, 48, 45, 48, 45,
+ax_anim 2, 0, 39, 24, 21, 24, 21,
+ax_anim 1, 0, 32, 13, 13, 13, 13,
+ax_anim 1, 0, 33, 6, 6, 6, 6,
+ax_anim_terminator
+sHitmontopAnims_3_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 5, 0, 5, 0,
+ax_anim 1, 0, 32, 8, 0, 8, 0,
+ax_anim 1, 2, 33, 27, 0, 27, 0,
+ax_anim 1, 0, 34, 40, 0, 40, 0,
+ax_anim 1, 0, 35, 48, 0, 48, 0,
+ax_anim 1, 0, 36, 48, 0, 48, 0,
+ax_anim 2, 1, 37, 48, 0, 48, 0,
+ax_anim 2, 0, 38, 48, 0, 48, 0,
+ax_anim 2, 0, 39, 48, 0, 48, 0,
+ax_anim 2, 0, 32, 24, 0, 24, 0,
+ax_anim 1, 0, 33, 13, 0, 13, 0,
+ax_anim 1, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sHitmontopAnims_3_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 32, 7, -7, 7, -7,
+ax_anim 1, 0, 33, 15, -15, 15, -15,
+ax_anim 1, 2, 34, 28, -28, 28, -28,
+ax_anim 1, 0, 35, 40, -40, 40, -40,
+ax_anim 1, 0, 36, 48, -48, 48, -48,
+ax_anim 1, 0, 37, 48, -48, 48, -48,
+ax_anim 2, 1, 38, 48, -48, 48, -48,
+ax_anim 2, 0, 39, 48, -48, 48, -48,
+ax_anim 2, 0, 32, 48, -48, 48, -48,
+ax_anim 2, 0, 33, 48, -48, 48, -48,
+ax_anim 1, 0, 34, 12, -11, 12, -11,
+ax_anim 1, 0, 35, 6, -6, 6, -6,
+ax_anim_terminator
+sHitmontopAnims_3_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, -5, 0, -5,
+ax_anim 1, 0, 34, 0, -11, 0, -11,
+ax_anim 1, 2, 35, 0, -25, 0, -25,
+ax_anim 1, 0, 36, 0, -35, 0, -35,
+ax_anim 1, 0, 37, 0, -43, 0, -43,
+ax_anim 1, 0, 38, 0, -43, 0, -43,
+ax_anim 2, 1, 39, 0, -43, 0, -43,
+ax_anim 2, 0, 32, 0, -43, 0, -43,
+ax_anim 2, 0, 33, 0, -43, 0, -43,
+ax_anim 2, 0, 34, 0, -19, 0, -19,
+ax_anim 1, 0, 35, 0, -13, 0, -13,
+ax_anim 1, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sHitmontopAnims_3_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 34, -5, -5, -5, -5,
+ax_anim 1, 0, 35, -10, -10, -10, -10,
+ax_anim 1, 2, 36, -23, -23, -23, -23,
+ax_anim 1, 0, 37, -40, -40, -40, -40,
+ax_anim 1, 0, 38, -48, -48, -48, -48,
+ax_anim 1, 0, 39, -48, -48, -48, -48,
+ax_anim 2, 1, 32, -48, -48, -48, -48,
+ax_anim 2, 0, 33, -48, -48, -48, -48,
+ax_anim 2, 0, 34, -48, -48, -48, -48,
+ax_anim 2, 0, 35, -24, -24, -24, -24,
+ax_anim 1, 0, 36, -12, -11, -12, -11,
+ax_anim 1, 0, 37, -6, -6, -6, -6,
+ax_anim_terminator
+sHitmontopAnims_3_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 0, 35, -5, -2, -5, -2,
+ax_anim 1, 0, 36, -8, -3, -8, -3,
+ax_anim 1, 2, 37, -27, -3, -27, -3,
+ax_anim 1, 0, 38, -48, 0, -48, 0,
+ax_anim 1, 0, 39, -48, 0, -48, 0,
+ax_anim 1, 0, 32, -48, 0, -48, 0,
+ax_anim 2, 1, 33, -48, 0, -48, 0,
+ax_anim 2, 0, 34, -48, 0, -48, 0,
+ax_anim 2, 0, 35, -48, 0, -48, 0,
+ax_anim 2, 0, 36, -24, 0, -24, 0,
+ax_anim 1, 0, 37, -13, 0, -13, 0,
+ax_anim 1, 0, 38, -6, 0, -6, 0,
+ax_anim_terminator
+sHitmontopAnims_3_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 0, 36, -7, 7, -7, 7,
+ax_anim 1, 0, 37, -14, 14, -14, 14,
+ax_anim 1, 2, 38, -27, 27, -27, 27,
+ax_anim 1, 0, 39, -40, 40, -40, 40,
+ax_anim 1, 0, 32, -48, 48, -48, 48,
+ax_anim 1, 0, 33, -48, 48, -48, 48,
+ax_anim 2, 1, 34, -48, 48, -48, 48,
+ax_anim 2, 0, 35, -48, 48, -48, 48,
+ax_anim 2, 0, 36, -48, 48, -48, 48,
+ax_anim 2, 0, 37, -24, 21, -24, 21,
+ax_anim 1, 0, 38, -14, 13, -14, 13,
+ax_anim 1, 0, 39, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_4_1:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 2, 40, 0, 0, 0, 0,
+ax_anim 1, 1, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 40, 0, -6, 0, 0,
+ax_anim 1, 0, 41, 0, -6, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 44, 0, -3, 0, 0,
+ax_anim 2, 0, 45, 0, -2, 0, 0,
+ax_anim 2, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_4_2:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 4, 2, 47, 0, 0, 0, 0,
+ax_anim 1, 1, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 47, -6, -6, 0, 0,
+ax_anim 1, 0, 40, -6, -6, 0, 0,
+ax_anim 2, 0, 41, -5, -5, 0, 0,
+ax_anim 2, 0, 42, -4, -4, 0, 0,
+ax_anim 2, 0, 43, -3, -3, 0, 0,
+ax_anim 2, 0, 44, -2, -2, 0, 0,
+ax_anim 2, 0, 45, -1, -1, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_4_3:
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 4, 2, 46, 0, 0, 0, 0,
+ax_anim 1, 1, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -6, 0, 0, 0,
+ax_anim 1, 0, 47, -6, 0, 0, 0,
+ax_anim 2, 0, 40, -5, 0, 0, 0,
+ax_anim 2, 0, 41, -4, 0, 0, 0,
+ax_anim 2, 0, 42, -3, 0, 0, 0,
+ax_anim 2, 0, 43, -2, 0, 0, 0,
+ax_anim 2, 0, 44, -1, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_4_4:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 4, 2, 45, 0, 0, 0, 0,
+ax_anim 1, 1, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 45, -6, 6, 0, 0,
+ax_anim 1, 0, 46, -6, 6, 0, 0,
+ax_anim 2, 0, 47, -5, 5, 0, 0,
+ax_anim 2, 0, 40, -4, 4, 0, 0,
+ax_anim 2, 0, 41, -3, 3, 0, 0,
+ax_anim 2, 0, 42, -2, 2, 0, 0,
+ax_anim 2, 0, 43, -1, 1, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_4_5:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 4, 2, 44, 0, 0, 0, 0,
+ax_anim 1, 1, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, 6, 0, 0,
+ax_anim 1, 0, 45, 0, 6, 0, 0,
+ax_anim 2, 0, 46, 0, 5, 0, 0,
+ax_anim 2, 0, 47, 0, 4, 0, 0,
+ax_anim 2, 0, 40, 0, 3, 0, 0,
+ax_anim 2, 0, 41, 0, 2, 0, 0,
+ax_anim 2, 0, 42, 0, 1, 0, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_4_6:
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 4, 2, 43, 0, 0, 0, 0,
+ax_anim 1, 1, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 6, 6, 0, 0,
+ax_anim 1, 0, 44, 6, 6, 0, 0,
+ax_anim 2, 0, 45, 5, 5, 0, 0,
+ax_anim 2, 0, 46, 4, 4, 0, 0,
+ax_anim 2, 0, 47, 3, 3, 0, 0,
+ax_anim 2, 0, 40, 2, 2, 0, 0,
+ax_anim 2, 0, 41, 1, 1, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_4_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 4, 2, 42, 0, 0, 0, 0,
+ax_anim 1, 1, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 6, 0, 0, 0,
+ax_anim 1, 0, 43, 6, 0, 0, 0,
+ax_anim 2, 0, 44, 5, 0, 0, 0,
+ax_anim 2, 0, 45, 4, 0, 0, 0,
+ax_anim 2, 0, 46, 3, 0, 0, 0,
+ax_anim 2, 0, 47, 2, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_4_8:
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 4, 2, 41, 0, 0, 0, 0,
+ax_anim 1, 1, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 41, 6, -6, 0, 0,
+ax_anim 1, 0, 42, 6, -6, 0, 0,
+ax_anim 2, 0, 43, 5, -5, 0, 0,
+ax_anim 2, 0, 44, 4, -4, 0, 0,
+ax_anim 2, 0, 45, 3, -3, 0, 0,
+ax_anim 2, 0, 46, 2, -2, 0, 0,
+ax_anim 2, 0, 47, 1, -1, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_5_1:
+ax_anim 1, 0, 48, 0, -3, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 4, 0, 48, 0, -6, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 1, 0, 48, 0, -3, 0, 0,
+ax_anim 6, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_5_2:
+ax_anim 1, 0, 55, 0, -3, 0, 0,
+ax_anim 2, 0, 55, 0, -5, 0, 0,
+ax_anim 4, 0, 55, 0, -6, 0, 0,
+ax_anim 2, 0, 55, 0, -5, 0, 0,
+ax_anim 1, 0, 55, 0, -3, 0, 0,
+ax_anim 6, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_5_3:
+ax_anim 1, 0, 54, 0, -3, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 4, 0, 54, 0, -6, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 1, 0, 54, 0, -3, 0, 0,
+ax_anim 6, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_5_4:
+ax_anim 1, 0, 53, 0, -3, 0, 0,
+ax_anim 2, 0, 53, 0, -5, 0, 0,
+ax_anim 4, 0, 53, 0, -6, 0, 0,
+ax_anim 2, 0, 53, 0, -5, 0, 0,
+ax_anim 1, 0, 53, 0, -3, 0, 0,
+ax_anim 6, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_5_5:
+ax_anim 1, 0, 52, 0, -3, 0, 0,
+ax_anim 2, 0, 52, 0, -5, 0, 0,
+ax_anim 4, 0, 52, 0, -6, 0, 0,
+ax_anim 2, 0, 52, 0, -5, 0, 0,
+ax_anim 1, 0, 52, 0, -3, 0, 0,
+ax_anim 6, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_5_6:
+ax_anim 1, 0, 51, 0, -3, 0, 0,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -6, 0, 0,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 0, 51, 0, -3, 0, 0,
+ax_anim 6, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_5_7:
+ax_anim 1, 0, 50, 0, -3, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 4, 0, 50, 0, -6, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 1, 0, 50, 0, -3, 0, 0,
+ax_anim 6, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_5_8:
+ax_anim 1, 0, 49, 0, -3, 0, 0,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 4, 0, 49, 0, -6, 0, 0,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 1, 0, 49, 0, -3, 0, 0,
+ax_anim 6, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_6_1:
+ax_anim 30, 0, 56, 0, 0, 0, 0,
+ax_anim 35, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_7_1:
+ax_anim 2, 0, 58, 0, -4, 0, -4,
+ax_anim 8, 0, 58, 0, -5, 0, -5,
+ax_anim_terminator
+sHitmontopAnims_7_2:
+ax_anim 2, 0, 59, -4, -4, -4, -4,
+ax_anim 8, 0, 59, -5, -5, -5, -5,
+ax_anim_terminator
+sHitmontopAnims_7_3:
+ax_anim 2, 0, 60, -4, 0, -4, 0,
+ax_anim 8, 0, 60, -5, 0, -5, 0,
+ax_anim_terminator
+sHitmontopAnims_7_4:
+ax_anim 2, 0, 61, -4, 4, -4, 4,
+ax_anim 8, 0, 61, -5, 5, -5, 5,
+ax_anim_terminator
+sHitmontopAnims_7_5:
+ax_anim 2, 0, 62, 0, 4, 0, 4,
+ax_anim 8, 0, 62, 0, 5, 0, 5,
+ax_anim_terminator
+sHitmontopAnims_7_6:
+ax_anim 2, 0, 63, 4, 4, 4, 4,
+ax_anim 8, 0, 63, 5, 5, 5, 5,
+ax_anim_terminator
+sHitmontopAnims_7_7:
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim 8, 0, 64, 5, 0, 5, 0,
+ax_anim_terminator
+sHitmontopAnims_7_8:
+ax_anim 2, 0, 65, 4, -4, 4, -4,
+ax_anim 8, 0, 65, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_8_1:
+ax_anim 30, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -3, 0, 0,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, 0,
+ax_anim 2, 0, 66, 0, -6, 0, 0,
+ax_anim 2, 0, 68, 0, -6, 0, 0,
+ax_anim 2, 0, 68, 0, -5, 0, 0,
+ax_anim 2, 0, 68, 0, -3, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_8_2:
+ax_anim 30, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, -3, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 2, 0, 70, 0, -6, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, 0,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, 0, -3, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_8_3:
+ax_anim 30, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -6, 0, 0,
+ax_anim 2, 0, 72, 0, -6, 0, 0,
+ax_anim 2, 0, 74, 0, -6, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_8_4:
+ax_anim 30, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 76, 0, -6, 0, 0,
+ax_anim 2, 0, 75, 0, -6, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, 0,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_8_5:
+ax_anim 30, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, 0, -6, 0, 0,
+ax_anim 2, 0, 78, 0, -6, 0, 0,
+ax_anim 2, 0, 80, 0, -6, 0, 0,
+ax_anim 2, 0, 80, 0, -5, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_8_6:
+ax_anim 30, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 2, 0, 82, 0, -6, 0, 0,
+ax_anim 2, 0, 81, 0, -6, 0, 0,
+ax_anim 2, 0, 83, 0, -6, 0, 0,
+ax_anim 2, 0, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_8_7:
+ax_anim 30, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, 0,
+ax_anim 2, 0, 84, 0, -6, 0, 0,
+ax_anim 2, 0, 86, 0, -6, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_8_8:
+ax_anim 30, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -6, 0, 0,
+ax_anim 2, 0, 87, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_9_1:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 6, 3, 6, 3,
+ax_anim 2, 0, 92, 8, 9, 8, 9,
+ax_anim 2, 0, 93, 7, 17, 7, 17,
+ax_anim 3, 0, 94, 0, 21, 0, 21,
+ax_anim 2, 3, 95, -7, 17, -7, 17,
+ax_anim 2, 0, 96, -8, 9, -8, 9,
+ax_anim 1, 0, 97, -6, 3, -6, 3,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_9_2:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 8, 0, 8, 0,
+ax_anim 2, 0, 91, 17, 3, 17, 3,
+ax_anim 2, 0, 92, 22, 13, 22, 13,
+ax_anim 3, 0, 93, 24, 21, 24, 21,
+ax_anim 2, 3, 94, 13, 21, 13, 21,
+ax_anim 2, 0, 95, 3, 15, 3, 15,
+ax_anim 1, 0, 96, 0, 7, 0, 7,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_9_3:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 3, -5, 3, -5,
+ax_anim 2, 0, 90, 11, -6, 11, -6,
+ax_anim 2, 0, 91, 18, -5, 18, -5,
+ax_anim 3, 0, 92, 24, 0, 24, 0,
+ax_anim 2, 3, 93, 21, 4, 21, 4,
+ax_anim 2, 0, 94, 12, 5, 12, 5,
+ax_anim 1, 0, 95, 4, 3, 4, 3,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_9_4:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 96, -1, -8, -1, -8,
+ax_anim 2, 0, 97, 4, -16, 4, -16,
+ax_anim 2, 0, 90, 14, -18, 14, -18,
+ax_anim 3, 0, 91, 24, -16, 24, -16,
+ax_anim 2, 3, 92, 23, -9, 23, -9,
+ax_anim 2, 0, 93, 17, -4, 17, -4,
+ax_anim 1, 0, 94, 7, -1, 7, -1,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_9_5:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -8, -4, -8, -4,
+ax_anim 2, 0, 96, -9, -10, -9, -10,
+ax_anim 2, 0, 97, -7, -13, -7, -13,
+ax_anim 3, 0, 90, 0, -16, 0, -16,
+ax_anim 2, 3, 91, 7, -13, 7, -13,
+ax_anim 2, 0, 92, 9, -10, 9, -10,
+ax_anim 1, 0, 93, 8, -4, 8, -4,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_9_6:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 1, -8, 1, -8,
+ax_anim 2, 0, 91, -4, -16, -4, -16,
+ax_anim 2, 0, 90, -14, -18, -14, -18,
+ax_anim 3, 0, 97, -24, -16, -24, -16,
+ax_anim 2, 3, 96, -23, -9, -23, -9,
+ax_anim 2, 0, 95, -17, -4, -17, -4,
+ax_anim 1, 0, 94, -7, -1, -7, -1,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_9_7:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 91, -3, -5, -3, -5,
+ax_anim 2, 0, 90, -11, -6, -11, -6,
+ax_anim 2, 0, 97, -18, -5, -18, -5,
+ax_anim 3, 0, 96, -24, 0, -24, 0,
+ax_anim 2, 3, 95, -21, 6, -21, 6,
+ax_anim 2, 0, 94, -12, 5, -12, 5,
+ax_anim 1, 0, 93, -4, 3, -4, 3,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_9_8:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, -8, 0, -8, 0,
+ax_anim 2, 0, 97, -17, 3, -17, 3,
+ax_anim 2, 0, 96, -22, 13, -22, 13,
+ax_anim 3, 0, 95, -24, 21, -24, 21,
+ax_anim 2, 3, 94, -13, 21, -13, 21,
+ax_anim 2, 0, 93, -3, 15, -3, 15,
+ax_anim 1, 0, 92, 0, 7, 0, 7,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_10_1:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, -6, 0, -6, 0,
+ax_anim 2, 0, 98, 10, 0, 10, 0,
+ax_anim 2, 0, 98, -10, 0, -10, 0,
+ax_anim 2, 0, 98, 12, 0, 12, 0,
+ax_anim 3, 0, 98, -12, 0, -12, 0,
+ax_anim 3, 0, 98, 13, 0, 13, 0,
+ax_anim 3, 0, 98, -13, 0, -13, 0,
+ax_anim 2, 0, 98, 12, 0, 12, 0,
+ax_anim 3, 0, 98, -12, 0, -12, 0,
+ax_anim 2, 0, 98, 10, 0, 10, 0,
+ax_anim 2, 0, 98, -10, 0, -10, 0,
+ax_anim 2, 0, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, -6, 0, -6, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_10_2:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim 2, 0, 99, 10, -10, 10, -10,
+ax_anim 2, 0, 99, -10, 10, -10, 10,
+ax_anim 2, 0, 99, 12, -12, 12, -12,
+ax_anim 3, 0, 99, -12, 12, -12, 12,
+ax_anim 3, 0, 99, 13, -13, 13, -13,
+ax_anim 3, 0, 99, -13, 13, -13, 13,
+ax_anim 2, 0, 99, 12, -12, 12, -12,
+ax_anim 3, 0, 99, -12, 12, -12, 12,
+ax_anim 2, 0, 99, 10, -10, 10, -10,
+ax_anim 2, 0, 99, -10, 10, -10, 10,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_10_3:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -6, 0, -6,
+ax_anim 2, 0, 100, 0, 6, 0, 6,
+ax_anim 2, 0, 100, 0, -10, 0, -10,
+ax_anim 2, 0, 100, 0, 10, 0, 10,
+ax_anim 2, 0, 100, 0, -12, 0, -12,
+ax_anim 3, 0, 100, 0, 12, 0, 12,
+ax_anim 3, 0, 100, 0, -13, 0, -13,
+ax_anim 3, 0, 100, 0, 13, 0, 13,
+ax_anim 2, 0, 100, 0, -12, 0, -12,
+ax_anim 3, 0, 100, 0, 12, 0, 12,
+ax_anim 2, 0, 100, 0, -10, 0, -10,
+ax_anim 2, 0, 100, 0, 10, 0, 10,
+ax_anim 2, 0, 100, 0, -6, 0, -6,
+ax_anim 2, 0, 100, 0, 6, 0, 6,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_10_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -6, -6, -6, -6,
+ax_anim 2, 0, 101, 6, 6, 6, 6,
+ax_anim 2, 0, 101, -10, -10, -10, -10,
+ax_anim 2, 0, 101, 10, 10, 10, 10,
+ax_anim 2, 0, 101, -12, -12, -12, -12,
+ax_anim 3, 0, 101, 12, 12, 12, 12,
+ax_anim 3, 0, 101, -13, -13, -13, -13,
+ax_anim 3, 0, 101, 13, 13, 13, 13,
+ax_anim 2, 0, 101, -12, -12, -12, -12,
+ax_anim 3, 0, 101, 12, 12, 12, 12,
+ax_anim 2, 0, 101, -10, -10, -10, -10,
+ax_anim 2, 0, 101, 10, 10, 10, 10,
+ax_anim 2, 0, 101, -6, -6, -6, -6,
+ax_anim 2, 0, 101, 6, 6, 6, 6,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_10_5:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 6, 0, 6, 0,
+ax_anim 2, 0, 102, -6, 0, -6, 0,
+ax_anim 2, 0, 102, 10, 0, 10, 0,
+ax_anim 2, 0, 102, -10, 0, -10, 0,
+ax_anim 2, 0, 102, 12, 0, 12, 0,
+ax_anim 3, 0, 102, -12, 0, -12, 0,
+ax_anim 3, 0, 102, 13, 0, 13, 0,
+ax_anim 3, 0, 102, -13, 0, -13, 0,
+ax_anim 2, 0, 102, 12, 0, 12, 0,
+ax_anim 3, 0, 102, -12, 0, -12, 0,
+ax_anim 2, 0, 102, 10, 0, 10, 0,
+ax_anim 2, 0, 102, -10, 0, -10, 0,
+ax_anim 2, 0, 102, 6, 0, 6, 0,
+ax_anim 2, 0, 102, -6, 0, -6, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_10_6:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 103, -6, 6, -6, 6,
+ax_anim 2, 0, 103, 10, -10, 10, -10,
+ax_anim 2, 0, 103, -10, 10, -10, 10,
+ax_anim 2, 0, 103, 12, -12, 12, -12,
+ax_anim 3, 0, 103, -12, 12, -12, 12,
+ax_anim 3, 0, 103, 13, -13, 13, -13,
+ax_anim 3, 0, 103, -13, 13, -13, 13,
+ax_anim 2, 0, 103, 12, -12, 12, -12,
+ax_anim 3, 0, 103, -12, 12, -12, 12,
+ax_anim 2, 0, 103, 10, -10, 10, -10,
+ax_anim 2, 0, 103, -10, 10, -10, 10,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 103, -6, 6, -6, 6,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_10_7:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, -6,
+ax_anim 2, 0, 104, 0, 6, 0, 6,
+ax_anim 2, 0, 104, 0, -10, 0, -10,
+ax_anim 2, 0, 104, 0, 10, 0, 10,
+ax_anim 2, 0, 104, 0, -12, 0, -12,
+ax_anim 3, 0, 104, 0, 12, 0, 12,
+ax_anim 3, 0, 104, 0, -13, 0, -13,
+ax_anim 3, 0, 104, 0, 13, 0, 13,
+ax_anim 2, 0, 104, 0, -12, 0, -12,
+ax_anim 3, 0, 104, 0, 12, 0, 12,
+ax_anim 2, 0, 104, 0, -10, 0, -10,
+ax_anim 2, 0, 104, 0, 10, 0, 10,
+ax_anim 2, 0, 104, 0, -6, 0, -6,
+ax_anim 2, 0, 104, 0, 6, 0, 6,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_10_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, 6, 6, 6, 6,
+ax_anim 2, 0, 105, -10, -10, -10, -10,
+ax_anim 2, 0, 105, 10, 10, 10, 10,
+ax_anim 2, 0, 105, -12, -12, -12, -12,
+ax_anim 3, 0, 105, 12, 12, 12, 12,
+ax_anim 3, 0, 105, -13, -13, -13, -13,
+ax_anim 3, 0, 105, 13, 13, 13, 13,
+ax_anim 2, 0, 105, -12, -12, -12, -12,
+ax_anim 3, 0, 105, 12, 12, 12, 12,
+ax_anim 2, 0, 105, -10, -10, -10, -10,
+ax_anim 2, 0, 105, 10, 10, 10, 10,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, 6, 6, 6, 6,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_11_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -10, 0, 0,
+ax_anim 2, 0, 107, 0, -16, 0, 0,
+ax_anim 3, 0, 107, 0, -20, 0, 0,
+ax_anim 4, 0, 107, 0, -21, 0, 0,
+ax_anim 4, 0, 106, 0, -21, 0, 0,
+ax_anim 3, 0, 108, 0, -21, 0, 0,
+ax_anim 2, 0, 108, 0, -18, 0, 0,
+ax_anim 1, 0, 108, 0, -12, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_11_2:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -10, 0, 0,
+ax_anim 2, 0, 110, 0, -16, 0, 0,
+ax_anim 3, 0, 110, 0, -20, 0, 0,
+ax_anim 4, 0, 110, 0, -21, 0, 0,
+ax_anim 4, 0, 109, 0, -21, 0, 0,
+ax_anim 3, 0, 111, 0, -21, 0, 0,
+ax_anim 2, 0, 111, 0, -18, 0, 0,
+ax_anim 1, 0, 111, 0, -12, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_11_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, -10, 0, 0,
+ax_anim 2, 0, 113, 0, -16, 0, 0,
+ax_anim 3, 0, 113, 0, -20, 0, 0,
+ax_anim 4, 0, 113, 0, -21, 0, 0,
+ax_anim 4, 0, 112, 0, -21, 0, 0,
+ax_anim 3, 0, 114, 0, -21, 0, 0,
+ax_anim 2, 0, 114, 0, -18, 0, 0,
+ax_anim 1, 0, 114, 0, -12, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_11_4:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, -10, 0, 0,
+ax_anim 2, 0, 116, 0, -16, 0, 0,
+ax_anim 3, 0, 116, 0, -20, 0, 0,
+ax_anim 4, 0, 116, 0, -21, 0, 0,
+ax_anim 4, 0, 115, 0, -21, 0, 0,
+ax_anim 3, 0, 117, 0, -21, 0, 0,
+ax_anim 2, 0, 117, 0, -17, 0, 0,
+ax_anim 1, 0, 117, 0, -11, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_11_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, -10, 0, 0,
+ax_anim 2, 0, 119, 0, -16, 0, 0,
+ax_anim 3, 0, 119, 0, -20, 0, 0,
+ax_anim 4, 0, 119, 0, -21, 0, 0,
+ax_anim 4, 0, 118, 0, -21, 0, 0,
+ax_anim 3, 0, 120, 0, -21, 0, 0,
+ax_anim 2, 0, 120, 0, -18, 0, 0,
+ax_anim 1, 0, 120, 0, -12, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_11_6:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -10, 0, 0,
+ax_anim 2, 0, 122, 0, -16, 0, 0,
+ax_anim 3, 0, 122, 0, -20, 0, 0,
+ax_anim 4, 0, 122, 0, -21, 0, 0,
+ax_anim 4, 0, 121, 0, -21, 0, 0,
+ax_anim 3, 0, 123, 0, -21, 0, 0,
+ax_anim 2, 0, 123, 0, -17, 0, 0,
+ax_anim 1, 0, 123, 0, -11, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_11_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -10, 0, 0,
+ax_anim 2, 0, 125, 0, -16, 0, 0,
+ax_anim 3, 0, 125, 0, -20, 0, 0,
+ax_anim 4, 0, 125, 0, -21, 0, 0,
+ax_anim 4, 0, 124, 0, -21, 0, 0,
+ax_anim 3, 0, 126, 0, -21, 0, 0,
+ax_anim 2, 0, 126, 0, -18, 0, 0,
+ax_anim 1, 0, 126, 0, -12, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_11_8:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 2, 0, 128, 0, -16, 0, 0,
+ax_anim 3, 0, 128, 0, -20, 0, 0,
+ax_anim 4, 0, 128, 0, -21, 0, 0,
+ax_anim 4, 0, 127, 0, -21, 0, 0,
+ax_anim 3, 0, 129, 0, -21, 0, 0,
+ax_anim 2, 0, 129, 0, -18, 0, 0,
+ax_anim 1, 0, 129, 0, -12, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_12_1:
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 1, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_12_2:
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 1, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_12_3:
+ax_anim 2, 0, 136, 0, -1, 0, -1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, -1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, -1,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, -1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, -1,
+ax_anim 2, 1, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_12_4:
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_12_5:
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 1, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_12_6:
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 1, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_12_7:
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_12_8:
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 1, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHitmontopAnims_13_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_13_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_13_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_13_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_13_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_13_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_13_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopAnims_13_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sHitmontopGfx1:
+.incbin "baserom.gba", 0xF9DAC4, 0x200
+sHitmontopSprites1:
+ax_sprite sHitmontopGfx1, 0x200
+ax_sprite_terminator
+sHitmontopGfx2:
+.incbin "baserom.gba", 0xF9DCD4, 0x200
+sHitmontopSprites2:
+ax_sprite sHitmontopGfx2, 0x200
+ax_sprite_terminator
+sHitmontopGfx3:
+.incbin "baserom.gba", 0xF9DEE4, 0x200
+sHitmontopSprites3:
+ax_sprite sHitmontopGfx3, 0x200
+ax_sprite_terminator
+sHitmontopGfx4:
+.incbin "baserom.gba", 0xF9E0F4, 0x200
+sHitmontopSprites4:
+ax_sprite sHitmontopGfx4, 0x200
+ax_sprite_terminator
+sHitmontopGfx5:
+.incbin "baserom.gba", 0xF9E304, 0x200
+sHitmontopSprites5:
+ax_sprite sHitmontopGfx5, 0x200
+ax_sprite_terminator
+sHitmontopGfx6:
+.incbin "baserom.gba", 0xF9E514, 0x200
+sHitmontopSprites6:
+ax_sprite sHitmontopGfx6, 0x200
+ax_sprite_terminator
+sHitmontopGfx7:
+.incbin "baserom.gba", 0xF9E724, 0x200
+sHitmontopSprites7:
+ax_sprite sHitmontopGfx7, 0x200
+ax_sprite_terminator
+sHitmontopGfx8:
+.incbin "baserom.gba", 0xF9E934, 0x200
+sHitmontopSprites8:
+ax_sprite sHitmontopGfx8, 0x200
+ax_sprite_terminator
+sHitmontopGfx9:
+.incbin "baserom.gba", 0xF9EB44, 0x200
+sHitmontopSprites9:
+ax_sprite sHitmontopGfx9, 0x200
+ax_sprite_terminator
+sHitmontopGfx10:
+.incbin "baserom.gba", 0xF9ED54, 0x200
+sHitmontopSprites10:
+ax_sprite sHitmontopGfx10, 0x200
+ax_sprite_terminator
+sHitmontopGfx11:
+.incbin "baserom.gba", 0xF9EF64, 0x200
+sHitmontopSprites11:
+ax_sprite sHitmontopGfx11, 0x200
+ax_sprite_terminator
+sHitmontopGfx12:
+.incbin "baserom.gba", 0xF9F174, 0x200
+sHitmontopSprites12:
+ax_sprite sHitmontopGfx12, 0x200
+ax_sprite_terminator
+sHitmontopGfx13:
+.incbin "baserom.gba", 0xF9F384, 0x200
+sHitmontopSprites13:
+ax_sprite sHitmontopGfx13, 0x200
+ax_sprite_terminator
+sHitmontopGfx14:
+.incbin "baserom.gba", 0xF9F594, 0x200
+sHitmontopSprites14:
+ax_sprite sHitmontopGfx14, 0x200
+ax_sprite_terminator
+sHitmontopGfx15:
+.incbin "baserom.gba", 0xF9F7A4, 0x200
+sHitmontopSprites15:
+ax_sprite sHitmontopGfx15, 0x200
+ax_sprite_terminator
+sHitmontopGfx16:
+.incbin "baserom.gba", 0xF9F9B4, 0x60
+sHitmontopGfx16_1:
+.incbin "baserom.gba", 0xF9FA14, 0x60
+sHitmontopGfx16_2:
+.incbin "baserom.gba", 0xF9FA74, 0x60
+sHitmontopGfx16_3:
+.incbin "baserom.gba", 0xF9FAD4, 0x20
+sHitmontopSprites16:
+ax_sprite sHitmontopGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx16_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx17:
+.incbin "baserom.gba", 0xF9FB3C, 0x60
+sHitmontopGfx17_1:
+.incbin "baserom.gba", 0xF9FB9C, 0x60
+sHitmontopGfx17_2:
+.incbin "baserom.gba", 0xF9FBFC, 0x60
+sHitmontopGfx17_3:
+.incbin "baserom.gba", 0xF9FC5C, 0x20
+sHitmontopSprites17:
+ax_sprite sHitmontopGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx17_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx18:
+.incbin "baserom.gba", 0xF9FCC4, 0x60
+sHitmontopGfx18_1:
+.incbin "baserom.gba", 0xF9FD24, 0x60
+sHitmontopGfx18_2:
+.incbin "baserom.gba", 0xF9FD84, 0x60
+sHitmontopGfx18_3:
+.incbin "baserom.gba", 0xF9FDE4, 0x20
+sHitmontopSprites18:
+ax_sprite sHitmontopGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx19:
+.incbin "baserom.gba", 0xF9FE4C, 0x40
+sHitmontopGfx19_1:
+.incbin "baserom.gba", 0xF9FE8C, 0x60
+sHitmontopGfx19_2:
+.incbin "baserom.gba", 0xF9FEEC, 0x60
+sHitmontopGfx19_3:
+.incbin "baserom.gba", 0xF9FF4C, 0x20
+sHitmontopSprites19:
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx20:
+.incbin "baserom.gba", 0xF9FFBC, 0x60
+sHitmontopGfx20_1:
+.incbin "baserom.gba", 0xFA001C, 0x60
+sHitmontopGfx20_2:
+.incbin "baserom.gba", 0xFA007C, 0x60
+sHitmontopGfx20_3:
+.incbin "baserom.gba", 0xFA00DC, 0x20
+sHitmontopSprites20:
+ax_sprite sHitmontopGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx20_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx21:
+.incbin "baserom.gba", 0xFA0144, 0x60
+sHitmontopGfx21_1:
+.incbin "baserom.gba", 0xFA01A4, 0x60
+sHitmontopGfx21_2:
+.incbin "baserom.gba", 0xFA0204, 0x60
+sHitmontopGfx21_3:
+.incbin "baserom.gba", 0xFA0264, 0x20
+sHitmontopSprites21:
+ax_sprite sHitmontopGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx22:
+.incbin "baserom.gba", 0xFA02CC, 0x60
+sHitmontopGfx22_1:
+.incbin "baserom.gba", 0xFA032C, 0x60
+sHitmontopGfx22_2:
+.incbin "baserom.gba", 0xFA038C, 0x60
+sHitmontopGfx22_3:
+.incbin "baserom.gba", 0xFA03EC, 0x20
+sHitmontopSprites22:
+ax_sprite sHitmontopGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx22_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx23:
+.incbin "baserom.gba", 0xFA0454, 0x60
+sHitmontopGfx23_1:
+.incbin "baserom.gba", 0xFA04B4, 0x60
+sHitmontopGfx23_2:
+.incbin "baserom.gba", 0xFA0514, 0x60
+sHitmontopGfx23_3:
+.incbin "baserom.gba", 0xFA0574, 0x20
+sHitmontopSprites23:
+ax_sprite sHitmontopGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx24:
+.incbin "baserom.gba", 0xFA05DC, 0x60
+sHitmontopGfx24_1:
+.incbin "baserom.gba", 0xFA063C, 0x60
+sHitmontopGfx24_2:
+.incbin "baserom.gba", 0xFA069C, 0x60
+sHitmontopGfx24_3:
+.incbin "baserom.gba", 0xFA06FC, 0x20
+sHitmontopSprites24:
+ax_sprite sHitmontopGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx24_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx25:
+.incbin "baserom.gba", 0xFA0764, 0x60
+sHitmontopGfx25_1:
+.incbin "baserom.gba", 0xFA07C4, 0x60
+sHitmontopGfx25_2:
+.incbin "baserom.gba", 0xFA0824, 0x60
+sHitmontopGfx25_3:
+.incbin "baserom.gba", 0xFA0884, 0x20
+sHitmontopSprites25:
+ax_sprite sHitmontopGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHitmontopGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHitmontopGfx25_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHitmontopGfx26:
+.incbin "baserom.gba", 0xFA08EC, 0x200
+sHitmontopSprites26:
+ax_sprite sHitmontopGfx26, 0x200
+ax_sprite_terminator
+sHitmontopGfx27:
+.incbin "baserom.gba", 0xFA0AFC, 0x200
+sHitmontopSprites27:
+ax_sprite sHitmontopGfx27, 0x200
+ax_sprite_terminator
+sHitmontopGfx28:
+.incbin "baserom.gba", 0xFA0D0C, 0x200
+sHitmontopSprites28:
+ax_sprite sHitmontopGfx28, 0x200
+ax_sprite_terminator
+sHitmontopGfx29:
+.incbin "baserom.gba", 0xFA0F1C, 0x200
+sHitmontopSprites29:
+ax_sprite sHitmontopGfx29, 0x200
+ax_sprite_terminator
+sHitmontopGfx30:
+.incbin "baserom.gba", 0xFA112C, 0x200
+sHitmontopSprites30:
+ax_sprite sHitmontopGfx30, 0x200
+ax_sprite_terminator
+sHitmontopGfx31:
+.incbin "baserom.gba", 0xFA133C, 0x200
+sHitmontopSprites31:
+ax_sprite sHitmontopGfx31, 0x200
+ax_sprite_terminator
+sHitmontopGfx32:
+.incbin "baserom.gba", 0xFA154C, 0x200
+sHitmontopSprites32:
+ax_sprite sHitmontopGfx32, 0x200
+ax_sprite_terminator
+sAxPosesHitmontop:
+.4byte sHitmontopPose1
+.4byte sHitmontopPose2
+.4byte sHitmontopPose3
+.4byte sHitmontopPose4
+.4byte sHitmontopPose5
+.4byte sHitmontopPose6
+.4byte sHitmontopPose7
+.4byte sHitmontopPose8
+.4byte sHitmontopPose9
+.4byte sHitmontopPose10
+.4byte sHitmontopPose11
+.4byte sHitmontopPose12
+.4byte sHitmontopPose13
+.4byte sHitmontopPose14
+.4byte sHitmontopPose15
+.4byte sHitmontopPose16
+.4byte sHitmontopPose17
+.4byte sHitmontopPose18
+.4byte sHitmontopPose19
+.4byte sHitmontopPose20
+.4byte sHitmontopPose21
+.4byte sHitmontopPose22
+.4byte sHitmontopPose23
+.4byte sHitmontopPose24
+.4byte sHitmontopPose25
+.4byte sHitmontopPose26
+.4byte sHitmontopPose27
+.4byte sHitmontopPose28
+.4byte sHitmontopPose29
+.4byte sHitmontopPose30
+.4byte sHitmontopPose31
+.4byte sHitmontopPose32
+.4byte sHitmontopPose33
+.4byte sHitmontopPose34
+.4byte sHitmontopPose35
+.4byte sHitmontopPose36
+.4byte sHitmontopPose37
+.4byte sHitmontopPose38
+.4byte sHitmontopPose39
+.4byte sHitmontopPose40
+.4byte sHitmontopPose41
+.4byte sHitmontopPose42
+.4byte sHitmontopPose43
+.4byte sHitmontopPose44
+.4byte sHitmontopPose45
+.4byte sHitmontopPose46
+.4byte sHitmontopPose47
+.4byte sHitmontopPose48
+.4byte sHitmontopPose49
+.4byte sHitmontopPose50
+.4byte sHitmontopPose51
+.4byte sHitmontopPose52
+.4byte sHitmontopPose53
+.4byte sHitmontopPose54
+.4byte sHitmontopPose55
+.4byte sHitmontopPose56
+.4byte sHitmontopPose57
+.4byte sHitmontopPose58
+.4byte sHitmontopPose59
+.4byte sHitmontopPose60
+.4byte sHitmontopPose61
+.4byte sHitmontopPose62
+.4byte sHitmontopPose63
+.4byte sHitmontopPose64
+.4byte sHitmontopPose65
+.4byte sHitmontopPose66
+.4byte sHitmontopPose67
+.4byte sHitmontopPose68
+.4byte sHitmontopPose69
+.4byte sHitmontopPose70
+.4byte sHitmontopPose71
+.4byte sHitmontopPose72
+.4byte sHitmontopPose73
+.4byte sHitmontopPose74
+.4byte sHitmontopPose75
+.4byte sHitmontopPose76
+.4byte sHitmontopPose77
+.4byte sHitmontopPose78
+.4byte sHitmontopPose79
+.4byte sHitmontopPose80
+.4byte sHitmontopPose81
+.4byte sHitmontopPose82
+.4byte sHitmontopPose83
+.4byte sHitmontopPose84
+.4byte sHitmontopPose85
+.4byte sHitmontopPose86
+.4byte sHitmontopPose87
+.4byte sHitmontopPose88
+.4byte sHitmontopPose89
+.4byte sHitmontopPose90
+.4byte sHitmontopPose91
+.4byte sHitmontopPose92
+.4byte sHitmontopPose93
+.4byte sHitmontopPose94
+.4byte sHitmontopPose95
+.4byte sHitmontopPose96
+.4byte sHitmontopPose97
+.4byte sHitmontopPose98
+.4byte sHitmontopPose99
+.4byte sHitmontopPose100
+.4byte sHitmontopPose101
+.4byte sHitmontopPose102
+.4byte sHitmontopPose103
+.4byte sHitmontopPose104
+.4byte sHitmontopPose105
+.4byte sHitmontopPose106
+.4byte sHitmontopPose107
+.4byte sHitmontopPose108
+.4byte sHitmontopPose109
+.4byte sHitmontopPose110
+.4byte sHitmontopPose111
+.4byte sHitmontopPose112
+.4byte sHitmontopPose113
+.4byte sHitmontopPose114
+.4byte sHitmontopPose115
+.4byte sHitmontopPose116
+.4byte sHitmontopPose117
+.4byte sHitmontopPose118
+.4byte sHitmontopPose119
+.4byte sHitmontopPose120
+.4byte sHitmontopPose121
+.4byte sHitmontopPose122
+.4byte sHitmontopPose123
+.4byte sHitmontopPose124
+.4byte sHitmontopPose125
+.4byte sHitmontopPose126
+.4byte sHitmontopPose127
+.4byte sHitmontopPose128
+.4byte sHitmontopPose129
+.4byte sHitmontopPose130
+.4byte sHitmontopPose131
+.4byte sHitmontopPose132
+.4byte sHitmontopPose133
+.4byte sHitmontopPose134
+.4byte sHitmontopPose135
+.4byte sHitmontopPose136
+.4byte sHitmontopPose137
+.4byte sHitmontopPose138
+.4byte sHitmontopPose139
+.4byte sHitmontopPose140
+.4byte sHitmontopPose141
+.4byte sHitmontopPose142
+.4byte sHitmontopPose143
+.4byte sHitmontopPose144
+.4byte sHitmontopPose145
+.4byte sHitmontopPose146
+sAxPositionsHitmontop:
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -7
+.2byte   -2,   -8, 	  -9,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    0,   -8, 	  -7,   -2, 	   7,   -5, 	   0,   -6
+.2byte    2,   -9, 	   5,   -7, 	  -6,   -2, 	   1,   -7
+.2byte    3,   -8, 	  -4,   -3, 	   1,   -3, 	   0,   -6
+.2byte    1,   -8, 	   7,   -4, 	  -8,   -1, 	   1,   -6
+.2byte    4,   -9, 	  -1,   -2, 	  -1,   -1, 	   0,   -7
+.2byte    4,   -8, 	  -4,   -2, 	   3,   -4, 	   0,   -6
+.2byte    4,   -8, 	   5,   -6, 	  -3,    0, 	   0,   -6
+.2byte    2,  -10, 	  -7,   -8, 	   3,   -1, 	  -2,   -8
+.2byte    3,   -9, 	  -9,   -5, 	   6,   -5, 	  -3,   -7
+.2byte    1,   -9, 	  -5,   -4, 	   2,    0, 	  -3,   -7
+.2byte   -1,  -10, 	   7,   -4, 	  -9,   -4, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -2, 	  -9,   -8, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -2, 	  -1,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -5,   -1, 	   0,   -8
+.2byte   -5,   -9, 	   7,   -5, 	  -8,   -5, 	   1,   -7
+.2byte   -3,   -9, 	   3,   -4, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -9, 	  -1,   -2, 	  -1,   -1, 	  -2,   -7
+.2byte   -6,   -8, 	   2,   -2, 	  -5,   -4, 	  -2,   -6
+.2byte   -6,   -8, 	  -7,   -6, 	   1,    0, 	  -2,   -6
+.2byte   -4,   -9, 	  -7,   -7, 	   4,   -2, 	  -3,   -7
+.2byte   -5,   -8, 	   2,   -3, 	  -3,   -3, 	  -2,   -6
+.2byte   -3,   -8, 	  -9,   -4, 	   6,   -1, 	  -3,   -6
+.2byte   -1,  -10, 	   8,  -20, 	  -2,  -14, 	  -1,  -13
+.2byte    1,  -10, 	 -11,  -16, 	   1,  -14, 	  -2,  -12
+.2byte    4,  -11, 	  -9,  -12, 	   5,  -14, 	  -1,  -13
+.2byte    2,  -11, 	  -2,  -10, 	   1,  -15, 	  -2,  -12
+.2byte   -1,  -11, 	  -8,   -9, 	   5,  -16, 	  -1,  -12
+.2byte   -4,  -11, 	   0,  -10, 	  -3,  -15, 	   0,  -12
+.2byte   -6,  -11, 	   7,  -12, 	  -7,  -14, 	  -1,  -13
+.2byte   -3,  -10, 	   9,  -16, 	  -3,  -14, 	   0,  -12
+.2byte   -1,  -10, 	   8,  -20, 	  -2,  -14, 	  -1,  -13
+.2byte    1,  -10, 	 -11,  -16, 	   1,  -14, 	  -2,  -12
+.2byte    4,  -11, 	  -9,  -12, 	   5,  -14, 	  -1,  -13
+.2byte    2,  -11, 	  -2,  -10, 	   1,  -15, 	  -2,  -12
+.2byte   -1,  -11, 	  -8,   -9, 	   5,  -16, 	  -1,  -12
+.2byte   -4,  -11, 	   0,  -10, 	  -3,  -15, 	   0,  -12
+.2byte   -6,  -11, 	   7,  -12, 	  -7,  -14, 	  -1,  -13
+.2byte   -3,  -10, 	   9,  -16, 	  -3,  -14, 	   0,  -12
+.2byte   -1,  -10, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte   -3,  -10, 	   6,  -12, 	  -7,  -18, 	  -1,  -12
+.2byte   -5,  -12, 	   1,  -10, 	  -4,  -19, 	   0,  -13
+.2byte   -3,  -10, 	  -8,  -12, 	   6,  -18, 	   0,  -12
+.2byte   -1,  -11, 	 -11,  -14, 	   9,  -14, 	  -1,  -12
+.2byte    1,  -10, 	   6,  -12, 	  -8,  -18, 	  -2,  -12
+.2byte    3,  -12, 	  -3,  -10, 	   2,  -19, 	  -2,  -13
+.2byte    1,  -10, 	  -8,  -12, 	   5,  -18, 	  -1,  -12
+.2byte   -1,  -10, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte   -3,  -10, 	   6,  -12, 	  -7,  -18, 	  -1,  -12
+.2byte   -5,  -12, 	   1,  -10, 	  -4,  -19, 	   0,  -13
+.2byte   -3,  -10, 	  -8,  -12, 	   6,  -18, 	   0,  -12
+.2byte   -1,  -11, 	 -11,  -14, 	   9,  -14, 	  -1,  -12
+.2byte    1,  -10, 	   6,  -12, 	  -8,  -18, 	  -2,  -12
+.2byte    3,  -12, 	  -3,  -10, 	   2,  -19, 	  -2,  -13
+.2byte    1,  -10, 	  -8,  -12, 	   5,  -18, 	  -1,  -12
+.2byte   -3,   -6, 	  -6,   -4, 	   5,    2, 	  -1,   -4
+.2byte   -4,   -5, 	  -6,   -4, 	   5,    2, 	  -1,   -3
+.2byte    0,  -11, 	 -10,  -11, 	  10,  -11, 	   0,   -9
+.2byte    2,  -10, 	   8,  -15, 	  -7,   -8, 	   2,   -8
+.2byte    2,  -11, 	  -6,  -12, 	  -5,  -10, 	   0,   -8
+.2byte    0,  -14, 	  -6,  -14, 	   7,  -13, 	  -1,  -10
+.2byte    0,  -12, 	   9,  -11, 	  -9,  -11, 	   0,  -10
+.2byte   -1,  -14, 	   5,  -14, 	  -8,  -13, 	   0,  -10
+.2byte   -3,  -11, 	   5,  -12, 	   4,  -10, 	  -1,   -8
+.2byte   -1,  -10, 	  -7,  -15, 	   8,   -8, 	  -1,   -8
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -7
+.2byte   -2,   -8, 	  -9,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    0,   -8, 	  -7,   -2, 	   7,   -5, 	   0,   -6
+.2byte    2,   -9, 	   5,   -7, 	  -6,   -2, 	   1,   -7
+.2byte    3,   -8, 	  -4,   -3, 	   1,   -3, 	   0,   -6
+.2byte    1,   -8, 	   7,   -4, 	  -8,   -1, 	   1,   -6
+.2byte    4,   -9, 	  -1,   -2, 	  -1,   -1, 	   0,   -7
+.2byte    4,   -8, 	  -4,   -2, 	   3,   -4, 	   0,   -6
+.2byte    4,   -8, 	   5,   -6, 	  -3,    0, 	   0,   -6
+.2byte    2,  -10, 	  -7,   -8, 	   3,   -1, 	  -2,   -8
+.2byte    3,   -9, 	  -9,   -5, 	   6,   -5, 	  -3,   -7
+.2byte    1,   -9, 	  -5,   -4, 	   2,    0, 	  -3,   -7
+.2byte   -1,  -10, 	   7,   -4, 	  -9,   -4, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -2, 	  -9,   -8, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -2, 	  -1,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -5,   -1, 	   0,   -8
+.2byte   -5,   -9, 	   7,   -5, 	  -8,   -5, 	   1,   -7
+.2byte   -3,   -9, 	   3,   -4, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -9, 	  -1,   -2, 	  -1,   -1, 	  -2,   -7
+.2byte   -6,   -8, 	   2,   -2, 	  -5,   -4, 	  -2,   -6
+.2byte   -6,   -8, 	  -7,   -6, 	   1,    0, 	  -2,   -6
+.2byte   -4,   -9, 	  -7,   -7, 	   4,   -2, 	  -3,   -7
+.2byte   -5,   -8, 	   2,   -3, 	  -3,   -3, 	  -2,   -6
+.2byte   -3,   -8, 	  -9,   -4, 	   6,   -1, 	  -3,   -6
+.2byte   -1,  -10, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte   -3,  -10, 	   6,  -12, 	  -7,  -18, 	  -1,  -12
+.2byte   -5,  -12, 	   1,  -10, 	  -4,  -19, 	   0,  -13
+.2byte   -3,  -10, 	  -8,  -12, 	   6,  -18, 	   0,  -12
+.2byte   -1,  -11, 	 -11,  -14, 	   9,  -14, 	  -1,  -12
+.2byte    1,  -10, 	   6,  -12, 	  -8,  -18, 	  -2,  -12
+.2byte    3,  -12, 	  -3,  -10, 	   2,  -19, 	  -2,  -13
+.2byte    1,  -10, 	  -8,  -12, 	   5,  -18, 	  -1,  -12
+.2byte   -1,  -10, 	   8,  -20, 	  -2,  -14, 	  -1,  -13
+.2byte    1,  -10, 	 -11,  -16, 	   1,  -14, 	  -2,  -12
+.2byte    4,  -11, 	  -9,  -12, 	   5,  -14, 	  -1,  -13
+.2byte    2,  -11, 	  -2,  -10, 	   1,  -15, 	  -2,  -12
+.2byte   -1,  -11, 	  -8,   -9, 	   5,  -16, 	  -1,  -12
+.2byte   -4,  -11, 	   0,  -10, 	  -3,  -15, 	   0,  -12
+.2byte   -6,  -11, 	   7,  -12, 	  -7,  -14, 	  -1,  -13
+.2byte   -3,  -10, 	   9,  -16, 	  -3,  -14, 	   0,  -12
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -7
+.2byte   -2,   -8, 	  -9,   -5, 	   4,   -2, 	  -2,   -6
+.2byte    0,   -8, 	  -7,   -2, 	   7,   -5, 	   0,   -6
+.2byte    2,   -9, 	   5,   -7, 	  -6,   -2, 	   1,   -7
+.2byte    3,   -8, 	  -4,   -3, 	   1,   -3, 	   0,   -6
+.2byte    1,   -8, 	   7,   -4, 	  -8,   -1, 	   1,   -6
+.2byte    4,   -9, 	  -1,   -2, 	  -1,   -1, 	   0,   -7
+.2byte    4,   -8, 	  -4,   -2, 	   3,   -4, 	   0,   -6
+.2byte    4,   -8, 	   5,   -6, 	  -3,    0, 	   0,   -6
+.2byte    2,  -10, 	  -7,   -8, 	   3,   -1, 	  -2,   -8
+.2byte    3,   -9, 	  -9,   -5, 	   6,   -5, 	  -3,   -7
+.2byte    1,   -9, 	  -5,   -4, 	   2,    0, 	  -3,   -7
+.2byte   -1,  -10, 	   7,   -4, 	  -9,   -4, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -2, 	  -9,   -8, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -6, 	  -8,   -2, 	  -1,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -5,   -1, 	   0,   -8
+.2byte   -5,   -9, 	   7,   -5, 	  -8,   -5, 	   1,   -7
+.2byte   -3,   -9, 	   3,   -4, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -9, 	  -1,   -2, 	  -1,   -1, 	  -2,   -7
+.2byte   -6,   -8, 	   2,   -2, 	  -5,   -4, 	  -2,   -6
+.2byte   -6,   -8, 	  -7,   -6, 	   1,    0, 	  -2,   -6
+.2byte   -4,   -9, 	  -7,   -7, 	   4,   -2, 	  -3,   -7
+.2byte   -5,   -8, 	   2,   -3, 	  -3,   -3, 	  -2,   -6
+.2byte   -3,   -8, 	  -9,   -4, 	   6,   -1, 	  -3,   -6
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -7
+.2byte   -4,   -9, 	  -7,   -7, 	   4,   -2, 	  -3,   -7
+.2byte   -6,   -9, 	  -1,   -2, 	  -1,   -1, 	  -2,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -5,   -1, 	   0,   -8
+.2byte   -1,  -10, 	   7,   -4, 	  -9,   -4, 	  -1,   -8
+.2byte    2,  -10, 	  -7,   -8, 	   3,   -1, 	  -2,   -8
+.2byte    4,   -9, 	  -1,   -2, 	  -1,   -1, 	   0,   -7
+.2byte    2,   -9, 	   5,   -7, 	  -6,   -2, 	   1,   -7
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -7
+.2byte   -4,   -9, 	  -7,   -7, 	   4,   -2, 	  -3,   -7
+.2byte   -6,   -9, 	  -1,   -2, 	  -1,   -1, 	  -2,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -5,   -1, 	   0,   -8
+.2byte   -1,  -10, 	   7,   -4, 	  -9,   -4, 	  -1,   -8
+.2byte    2,  -10, 	  -7,   -8, 	   3,   -1, 	  -2,   -8
+.2byte    4,   -9, 	  -1,   -2, 	  -1,   -1, 	   0,   -7
+.2byte    2,   -9, 	   5,   -7, 	  -6,   -2, 	   1,   -7
+sHitmontopAnimTable1:
+.4byte sHitmontopAnims_1_1
+.4byte sHitmontopAnims_1_2
+.4byte sHitmontopAnims_1_3
+.4byte sHitmontopAnims_1_4
+.4byte sHitmontopAnims_1_5
+.4byte sHitmontopAnims_1_6
+.4byte sHitmontopAnims_1_7
+.4byte sHitmontopAnims_1_8
+sHitmontopAnimTable2:
+.4byte sHitmontopAnims_2_1
+.4byte sHitmontopAnims_2_2
+.4byte sHitmontopAnims_2_3
+.4byte sHitmontopAnims_2_4
+.4byte sHitmontopAnims_2_5
+.4byte sHitmontopAnims_2_6
+.4byte sHitmontopAnims_2_7
+.4byte sHitmontopAnims_2_8
+sHitmontopAnimTable3:
+.4byte sHitmontopAnims_3_1
+.4byte sHitmontopAnims_3_2
+.4byte sHitmontopAnims_3_3
+.4byte sHitmontopAnims_3_4
+.4byte sHitmontopAnims_3_5
+.4byte sHitmontopAnims_3_6
+.4byte sHitmontopAnims_3_7
+.4byte sHitmontopAnims_3_8
+sHitmontopAnimTable4:
+.4byte sHitmontopAnims_4_1
+.4byte sHitmontopAnims_4_2
+.4byte sHitmontopAnims_4_3
+.4byte sHitmontopAnims_4_4
+.4byte sHitmontopAnims_4_5
+.4byte sHitmontopAnims_4_6
+.4byte sHitmontopAnims_4_7
+.4byte sHitmontopAnims_4_8
+sHitmontopAnimTable5:
+.4byte sHitmontopAnims_5_1
+.4byte sHitmontopAnims_5_2
+.4byte sHitmontopAnims_5_3
+.4byte sHitmontopAnims_5_4
+.4byte sHitmontopAnims_5_5
+.4byte sHitmontopAnims_5_6
+.4byte sHitmontopAnims_5_7
+.4byte sHitmontopAnims_5_8
+sHitmontopAnimTable6:
+.4byte sHitmontopAnims_6_1
+.4byte sHitmontopAnims_6_1
+.4byte sHitmontopAnims_6_1
+.4byte sHitmontopAnims_6_1
+.4byte sHitmontopAnims_6_1
+.4byte sHitmontopAnims_6_1
+.4byte sHitmontopAnims_6_1
+.4byte sHitmontopAnims_6_1
+sHitmontopAnimTable7:
+.4byte sHitmontopAnims_7_1
+.4byte sHitmontopAnims_7_2
+.4byte sHitmontopAnims_7_3
+.4byte sHitmontopAnims_7_4
+.4byte sHitmontopAnims_7_5
+.4byte sHitmontopAnims_7_6
+.4byte sHitmontopAnims_7_7
+.4byte sHitmontopAnims_7_8
+sHitmontopAnimTable8:
+.4byte sHitmontopAnims_8_1
+.4byte sHitmontopAnims_8_2
+.4byte sHitmontopAnims_8_3
+.4byte sHitmontopAnims_8_4
+.4byte sHitmontopAnims_8_5
+.4byte sHitmontopAnims_8_6
+.4byte sHitmontopAnims_8_7
+.4byte sHitmontopAnims_8_8
+sHitmontopAnimTable9:
+.4byte sHitmontopAnims_9_1
+.4byte sHitmontopAnims_9_2
+.4byte sHitmontopAnims_9_3
+.4byte sHitmontopAnims_9_4
+.4byte sHitmontopAnims_9_5
+.4byte sHitmontopAnims_9_6
+.4byte sHitmontopAnims_9_7
+.4byte sHitmontopAnims_9_8
+sHitmontopAnimTable10:
+.4byte sHitmontopAnims_10_1
+.4byte sHitmontopAnims_10_2
+.4byte sHitmontopAnims_10_3
+.4byte sHitmontopAnims_10_4
+.4byte sHitmontopAnims_10_5
+.4byte sHitmontopAnims_10_6
+.4byte sHitmontopAnims_10_7
+.4byte sHitmontopAnims_10_8
+sHitmontopAnimTable11:
+.4byte sHitmontopAnims_11_1
+.4byte sHitmontopAnims_11_2
+.4byte sHitmontopAnims_11_3
+.4byte sHitmontopAnims_11_4
+.4byte sHitmontopAnims_11_5
+.4byte sHitmontopAnims_11_6
+.4byte sHitmontopAnims_11_7
+.4byte sHitmontopAnims_11_8
+sHitmontopAnimTable12:
+.4byte sHitmontopAnims_12_1
+.4byte sHitmontopAnims_12_2
+.4byte sHitmontopAnims_12_3
+.4byte sHitmontopAnims_12_4
+.4byte sHitmontopAnims_12_5
+.4byte sHitmontopAnims_12_6
+.4byte sHitmontopAnims_12_7
+.4byte sHitmontopAnims_12_8
+sHitmontopAnimTable13:
+.4byte sHitmontopAnims_13_1
+.4byte sHitmontopAnims_13_2
+.4byte sHitmontopAnims_13_3
+.4byte sHitmontopAnims_13_4
+.4byte sHitmontopAnims_13_5
+.4byte sHitmontopAnims_13_6
+.4byte sHitmontopAnims_13_7
+.4byte sHitmontopAnims_13_8
+sAxAnimationsHitmontop:
+.4byte sHitmontopAnimTable1
+.4byte sHitmontopAnimTable2
+.4byte sHitmontopAnimTable3
+.4byte sHitmontopAnimTable4
+.4byte sHitmontopAnimTable5
+.4byte sHitmontopAnimTable6
+.4byte sHitmontopAnimTable7
+.4byte sHitmontopAnimTable8
+.4byte sHitmontopAnimTable9
+.4byte sHitmontopAnimTable10
+.4byte sHitmontopAnimTable11
+.4byte sHitmontopAnimTable12
+.4byte sHitmontopAnimTable13
+sAxSpritesHitmontop:
+.4byte sHitmontopSprites1
+.4byte sHitmontopSprites2
+.4byte sHitmontopSprites3
+.4byte sHitmontopSprites4
+.4byte sHitmontopSprites5
+.4byte sHitmontopSprites6
+.4byte sHitmontopSprites7
+.4byte sHitmontopSprites8
+.4byte sHitmontopSprites9
+.4byte sHitmontopSprites10
+.4byte sHitmontopSprites11
+.4byte sHitmontopSprites12
+.4byte sHitmontopSprites13
+.4byte sHitmontopSprites14
+.4byte sHitmontopSprites15
+.4byte sHitmontopSprites16
+.4byte sHitmontopSprites17
+.4byte sHitmontopSprites18
+.4byte sHitmontopSprites19
+.4byte sHitmontopSprites20
+.4byte sHitmontopSprites21
+.4byte sHitmontopSprites22
+.4byte sHitmontopSprites23
+.4byte sHitmontopSprites24
+.4byte sHitmontopSprites25
+.4byte sHitmontopSprites26
+.4byte sHitmontopSprites27
+.4byte sHitmontopSprites28
+.4byte sHitmontopSprites29
+.4byte sHitmontopSprites30
+.4byte sHitmontopSprites31
+.4byte sHitmontopSprites32
+sAxMainHitmontop:
+ax_main sAxPosesHitmontop, sAxAnimationsHitmontop, 13, sAxSpritesHitmontop, sAxPositionsHitmontop

--- a/data/ax/hooh.inc
+++ b/data/ax/hooh.inc
@@ -1,0 +1,4190 @@
+.global gAxHoOh
+gAxHoOh:
+ax_siro sAxMainHoOh
+sHoOhPose1:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose2:
+ax_pose 1, 0x41c9, 0x40f0, 0x3c00
+ax_pose 2, 0x41d1, 0x80e0, 0x3c04
+ax_pose 3, 0x41d1, 0x8100, 0x3c0c
+ax_pose 4, 0x01de, 0x00d8, 0x3c14
+ax_pose 5, 0x01de, 0x0120, 0x3c15
+ax_pose 6, 0x41e1, 0xc0e0, 0x3c16
+ax_pose_terminator
+sHoOhPose3:
+ax_pose 7, 0x01cd, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose4:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose5:
+ax_pose 9, 0x01c6, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose6:
+ax_pose 10, 0x01c6, 0xd0d7, 0x3c00
+ax_pose_terminator
+sHoOhPose7:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose8:
+ax_pose 12, 0x41ee, 0x90ff, 0x3c00
+ax_pose 13, 0x41ce, 0xd0df, 0x3c08
+ax_pose 14, 0x41ee, 0x90df, 0x3c28
+ax_pose_terminator
+sHoOhPose9:
+ax_pose 15, 0x81c6, 0xd0df, 0x3c00
+ax_pose 16, 0x01d6, 0x90ff, 0x3c20
+ax_pose 17, 0x01f6, 0x50ff, 0x3c30
+ax_pose_terminator
+sHoOhPose10:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose11:
+ax_pose 19, 0x01e2, 0x111f, 0x3c00
+ax_pose 20, 0x01c6, 0x90df, 0x3c01
+ax_pose 21, 0x41d6, 0x90ff, 0x3c11
+ax_pose 22, 0x41e6, 0xd0df, 0x3c19
+ax_pose_terminator
+sHoOhPose12:
+ax_pose 23, 0x41d6, 0x90df, 0x3c00
+ax_pose 24, 0x41d6, 0x90ff, 0x3c08
+ax_pose 25, 0x41e6, 0xd0df, 0x3c10
+ax_pose_terminator
+sHoOhPose13:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose14:
+ax_pose 27, 0x01de, 0x0120, 0x3c00
+ax_pose 28, 0x81db, 0x00d8, 0x3c01
+ax_pose 29, 0x41d6, 0x8100, 0x3c03
+ax_pose 30, 0x41d6, 0x80e0, 0x3c0b
+ax_pose 31, 0x41e6, 0xc0e0, 0x3c13
+ax_pose_terminator
+sHoOhPose15:
+ax_pose 32, 0x01d0, 0x00fc, 0x3c00
+ax_pose 33, 0x01d8, 0x4104, 0x3c01
+ax_pose 34, 0x41d8, 0x80e4, 0x3c05
+ax_pose 35, 0x41e8, 0xc0e4, 0x3c0d
+ax_pose_terminator
+sHoOhPose16:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose17:
+ax_pose 22, 0x41e6, 0xc0e0, 0x3c00
+ax_pose 21, 0x41d6, 0x80e0, 0x3c20
+ax_pose 20, 0x01c6, 0x8100, 0x3c28
+ax_pose 19, 0x01e2, 0x00d8, 0x3c38
+ax_pose_terminator
+sHoOhPose18:
+ax_pose 25, 0x41e6, 0xc0e1, 0x3c00
+ax_pose 23, 0x41d6, 0x8101, 0x3c20
+ax_pose 24, 0x41d6, 0x80e1, 0x3c28
+ax_pose_terminator
+sHoOhPose19:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose20:
+ax_pose 13, 0x41ce, 0xc0e0, 0x3c00
+ax_pose 12, 0x41ee, 0x80e0, 0x3c20
+ax_pose 14, 0x41ee, 0x8100, 0x3c28
+ax_pose_terminator
+sHoOhPose21:
+ax_pose 15, 0x81c6, 0xc100, 0x3c00
+ax_pose 16, 0x01d6, 0x80e0, 0x3c20
+ax_pose 17, 0x01f6, 0x40f0, 0x3c30
+ax_pose_terminator
+sHoOhPose22:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose23:
+ax_pose 9, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sHoOhPose24:
+ax_pose 10, 0x01c6, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose25:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose26:
+ax_pose 1, 0x41c9, 0x40f0, 0x3c00
+ax_pose 2, 0x41d1, 0x80e0, 0x3c04
+ax_pose 3, 0x41d1, 0x8100, 0x3c0c
+ax_pose 4, 0x01de, 0x00d8, 0x3c14
+ax_pose 5, 0x01de, 0x0120, 0x3c15
+ax_pose 6, 0x41e1, 0xc0e0, 0x3c16
+ax_pose_terminator
+sHoOhPose27:
+ax_pose 7, 0x01cd, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose28:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose29:
+ax_pose 9, 0x01c6, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose30:
+ax_pose 10, 0x01c6, 0xd0d7, 0x3c00
+ax_pose_terminator
+sHoOhPose31:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose32:
+ax_pose 12, 0x41ee, 0x90ff, 0x3c00
+ax_pose 13, 0x41ce, 0xd0df, 0x3c08
+ax_pose 14, 0x41ee, 0x90df, 0x3c28
+ax_pose_terminator
+sHoOhPose33:
+ax_pose 15, 0x81c6, 0xd0df, 0x3c00
+ax_pose 16, 0x01d6, 0x90ff, 0x3c20
+ax_pose 17, 0x01f6, 0x50ff, 0x3c30
+ax_pose_terminator
+sHoOhPose34:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose35:
+ax_pose 19, 0x01e2, 0x111f, 0x3c00
+ax_pose 20, 0x01c6, 0x90df, 0x3c01
+ax_pose 21, 0x41d6, 0x90ff, 0x3c11
+ax_pose 22, 0x41e6, 0xd0df, 0x3c19
+ax_pose_terminator
+sHoOhPose36:
+ax_pose 23, 0x41d6, 0x90df, 0x3c00
+ax_pose 24, 0x41d6, 0x90ff, 0x3c08
+ax_pose 25, 0x41e6, 0xd0df, 0x3c10
+ax_pose_terminator
+sHoOhPose37:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose38:
+ax_pose 27, 0x01de, 0x0120, 0x3c00
+ax_pose 28, 0x81db, 0x00d8, 0x3c01
+ax_pose 29, 0x41d6, 0x8100, 0x3c03
+ax_pose 30, 0x41d6, 0x80e0, 0x3c0b
+ax_pose 31, 0x41e6, 0xc0e0, 0x3c13
+ax_pose_terminator
+sHoOhPose39:
+ax_pose 32, 0x01d0, 0x00fc, 0x3c00
+ax_pose 33, 0x01d8, 0x4104, 0x3c01
+ax_pose 34, 0x41d8, 0x80e4, 0x3c05
+ax_pose 35, 0x41e8, 0xc0e4, 0x3c0d
+ax_pose_terminator
+sHoOhPose40:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose41:
+ax_pose 22, 0x41e6, 0xc0e0, 0x3c00
+ax_pose 21, 0x41d6, 0x80e0, 0x3c20
+ax_pose 20, 0x01c6, 0x8100, 0x3c28
+ax_pose 19, 0x01e2, 0x00d8, 0x3c38
+ax_pose_terminator
+sHoOhPose42:
+ax_pose 25, 0x41e6, 0xc0e1, 0x3c00
+ax_pose 23, 0x41d6, 0x8101, 0x3c20
+ax_pose 24, 0x41d6, 0x80e1, 0x3c28
+ax_pose_terminator
+sHoOhPose43:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose44:
+ax_pose 13, 0x41ce, 0xc0e0, 0x3c00
+ax_pose 12, 0x41ee, 0x80e0, 0x3c20
+ax_pose 14, 0x41ee, 0x8100, 0x3c28
+ax_pose_terminator
+sHoOhPose45:
+ax_pose 15, 0x81c6, 0xc100, 0x3c00
+ax_pose 16, 0x01d6, 0x80e0, 0x3c20
+ax_pose 17, 0x01f6, 0x40f0, 0x3c30
+ax_pose_terminator
+sHoOhPose46:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose47:
+ax_pose 9, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sHoOhPose48:
+ax_pose 10, 0x01c6, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose49:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose50:
+ax_pose 1, 0x41c9, 0x40f0, 0x3c00
+ax_pose 2, 0x41d1, 0x80e0, 0x3c04
+ax_pose 3, 0x41d1, 0x8100, 0x3c0c
+ax_pose 4, 0x01de, 0x00d8, 0x3c14
+ax_pose 5, 0x01de, 0x0120, 0x3c15
+ax_pose 6, 0x41e1, 0xc0e0, 0x3c16
+ax_pose_terminator
+sHoOhPose51:
+ax_pose 7, 0x01cd, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose52:
+ax_pose 36, 0x81c9, 0xc0f0, 0x3c00
+ax_pose 37, 0x41e3, 0x80d0, 0x3c20
+ax_pose -1, 0x41e3, 0x910f, 0x3c20
+ax_pose_terminator
+sHoOhPose53:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose54:
+ax_pose 9, 0x01c6, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose55:
+ax_pose 10, 0x01c6, 0xd0d7, 0x3c00
+ax_pose_terminator
+sHoOhPose56:
+ax_pose 38, 0x41d0, 0xd0dd, 0x3c00
+ax_pose 39, 0x41f0, 0x90fe, 0x3c20
+ax_pose 40, 0x41f0, 0x90de, 0x3c28
+ax_pose 41, 0x0200, 0x1112, 0x3c30
+ax_pose 42, 0x01f5, 0x10d6, 0x3c31
+ax_pose_terminator
+sHoOhPose57:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose58:
+ax_pose 12, 0x41ee, 0x90ff, 0x3c00
+ax_pose 13, 0x41ce, 0xd0df, 0x3c08
+ax_pose 14, 0x41ee, 0x90df, 0x3c28
+ax_pose_terminator
+sHoOhPose59:
+ax_pose 15, 0x81c6, 0xd0df, 0x3c00
+ax_pose 16, 0x01d6, 0x90ff, 0x3c20
+ax_pose 17, 0x01f6, 0x50ff, 0x3c30
+ax_pose_terminator
+sHoOhPose60:
+ax_pose 43, 0x41d8, 0xd0df, 0x3c00
+ax_pose 44, 0x01f8, 0x50f5, 0x3c20
+ax_pose_terminator
+sHoOhPose61:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose62:
+ax_pose 19, 0x01e2, 0x111f, 0x3c00
+ax_pose 20, 0x01c6, 0x90df, 0x3c01
+ax_pose 21, 0x41d6, 0x90ff, 0x3c11
+ax_pose 22, 0x41e6, 0xd0df, 0x3c19
+ax_pose_terminator
+sHoOhPose63:
+ax_pose 23, 0x41d6, 0x90df, 0x3c00
+ax_pose 24, 0x41d6, 0x90ff, 0x3c08
+ax_pose 25, 0x41e6, 0xd0df, 0x3c10
+ax_pose_terminator
+sHoOhPose64:
+ax_pose 45, 0x41d8, 0xd0df, 0x3c00
+ax_pose 46, 0x41f8, 0x50ff, 0x3c20
+ax_pose 47, 0x41f8, 0x90df, 0x3c24
+ax_pose_terminator
+sHoOhPose65:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose66:
+ax_pose 27, 0x01de, 0x0120, 0x3c00
+ax_pose 28, 0x81db, 0x00d8, 0x3c01
+ax_pose 29, 0x41d6, 0x8100, 0x3c03
+ax_pose 30, 0x41d6, 0x80e0, 0x3c0b
+ax_pose 31, 0x41e6, 0xc0e0, 0x3c13
+ax_pose_terminator
+sHoOhPose67:
+ax_pose 32, 0x01d0, 0x00fc, 0x3c00
+ax_pose 33, 0x01d8, 0x4104, 0x3c01
+ax_pose 34, 0x41d8, 0x80e4, 0x3c05
+ax_pose 35, 0x41e8, 0xc0e4, 0x3c0d
+ax_pose_terminator
+sHoOhPose68:
+ax_pose 48, 0x81ce, 0xc0f4, 0x3c00
+ax_pose 49, 0x81ee, 0x40ec, 0x3c20
+ax_pose 50, 0x41e3, 0x80d4, 0x3c24
+ax_pose -1, 0x41e3, 0x910b, 0x3c24
+ax_pose_terminator
+sHoOhPose69:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose70:
+ax_pose 22, 0x41e6, 0xc0e0, 0x3c00
+ax_pose 21, 0x41d6, 0x80e0, 0x3c20
+ax_pose 20, 0x01c6, 0x8100, 0x3c28
+ax_pose 19, 0x01e2, 0x00d8, 0x3c38
+ax_pose_terminator
+sHoOhPose71:
+ax_pose 25, 0x41e6, 0xc0e1, 0x3c00
+ax_pose 23, 0x41d6, 0x8101, 0x3c20
+ax_pose 24, 0x41d6, 0x80e1, 0x3c28
+ax_pose_terminator
+sHoOhPose72:
+ax_pose 45, 0x41d8, 0xc0e1, 0x3c00
+ax_pose 46, 0x41f8, 0x40e1, 0x3c20
+ax_pose 47, 0x41f8, 0x8101, 0x3c24
+ax_pose_terminator
+sHoOhPose73:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose74:
+ax_pose 13, 0x41ce, 0xc0e0, 0x3c00
+ax_pose 12, 0x41ee, 0x80e0, 0x3c20
+ax_pose 14, 0x41ee, 0x8100, 0x3c28
+ax_pose_terminator
+sHoOhPose75:
+ax_pose 15, 0x81c6, 0xc100, 0x3c00
+ax_pose 16, 0x01d6, 0x80e0, 0x3c20
+ax_pose 17, 0x01f6, 0x40f0, 0x3c30
+ax_pose_terminator
+sHoOhPose76:
+ax_pose 43, 0x41d8, 0xc0e1, 0x3c00
+ax_pose 44, 0x01f8, 0x40fb, 0x3c20
+ax_pose_terminator
+sHoOhPose77:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose78:
+ax_pose 9, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sHoOhPose79:
+ax_pose 10, 0x01c6, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose80:
+ax_pose 38, 0x41d0, 0xc0e3, 0x3c00
+ax_pose 39, 0x41f0, 0x80e2, 0x3c20
+ax_pose 40, 0x41f0, 0x8102, 0x3c28
+ax_pose 41, 0x0200, 0x00e6, 0x3c30
+ax_pose 42, 0x01f5, 0x0122, 0x3c31
+ax_pose_terminator
+sHoOhPose81:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose82:
+ax_pose 1, 0x41c9, 0x40f0, 0x3c00
+ax_pose 2, 0x41d1, 0x80e0, 0x3c04
+ax_pose 3, 0x41d1, 0x8100, 0x3c0c
+ax_pose 4, 0x01de, 0x00d8, 0x3c14
+ax_pose 5, 0x01de, 0x0120, 0x3c15
+ax_pose 6, 0x41e1, 0xc0e0, 0x3c16
+ax_pose_terminator
+sHoOhPose83:
+ax_pose 7, 0x01cd, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose84:
+ax_pose 51, 0x41d8, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose85:
+ax_pose 52, 0x01c6, 0x80e4, 0x3c00
+ax_pose -1, 0x01c6, 0x90fb, 0x3c00
+ax_pose 53, 0x81e6, 0x80e4, 0x3c10
+ax_pose 54, 0x81e6, 0x40f4, 0x3c18
+ax_pose 55, 0x81e6, 0x40fc, 0x3c1c
+ax_pose -1, 0x81e6, 0x910b, 0x3c10
+ax_pose -1, 0x81e6, 0x5103, 0x3c18
+ax_pose_terminator
+sHoOhPose86:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose87:
+ax_pose 9, 0x01c6, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose88:
+ax_pose 10, 0x01c6, 0xd0d7, 0x3c00
+ax_pose_terminator
+sHoOhPose89:
+ax_pose 56, 0x41d4, 0xd0db, 0x3c00
+ax_pose 57, 0x41f4, 0x50eb, 0x3c20
+ax_pose_terminator
+sHoOhPose90:
+ax_pose 58, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose91:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose92:
+ax_pose 12, 0x41ee, 0x90ff, 0x3c00
+ax_pose 13, 0x41ce, 0xd0df, 0x3c08
+ax_pose 14, 0x41ee, 0x90df, 0x3c28
+ax_pose_terminator
+sHoOhPose93:
+ax_pose 15, 0x81c6, 0xd0df, 0x3c00
+ax_pose 16, 0x01d6, 0x90ff, 0x3c20
+ax_pose 17, 0x01f6, 0x50ff, 0x3c30
+ax_pose_terminator
+sHoOhPose94:
+ax_pose 59, 0x41d1, 0xd0df, 0x3c00
+ax_pose 60, 0x41f1, 0x90df, 0x3c20
+ax_pose 61, 0x41f1, 0x50ff, 0x3c28
+ax_pose_terminator
+sHoOhPose95:
+ax_pose 62, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose96:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose97:
+ax_pose 19, 0x01e2, 0x111f, 0x3c00
+ax_pose 20, 0x01c6, 0x90df, 0x3c01
+ax_pose 21, 0x41d6, 0x90ff, 0x3c11
+ax_pose 22, 0x41e6, 0xd0df, 0x3c19
+ax_pose_terminator
+sHoOhPose98:
+ax_pose 23, 0x41d6, 0x90df, 0x3c00
+ax_pose 24, 0x41d6, 0x90ff, 0x3c08
+ax_pose 25, 0x41e6, 0xd0df, 0x3c10
+ax_pose_terminator
+sHoOhPose99:
+ax_pose 63, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose100:
+ax_pose 64, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose101:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose102:
+ax_pose 27, 0x01de, 0x0120, 0x3c00
+ax_pose 28, 0x81db, 0x00d8, 0x3c01
+ax_pose 29, 0x41d6, 0x8100, 0x3c03
+ax_pose 30, 0x41d6, 0x80e0, 0x3c0b
+ax_pose 31, 0x41e6, 0xc0e0, 0x3c13
+ax_pose_terminator
+sHoOhPose103:
+ax_pose 32, 0x01d0, 0x00fc, 0x3c00
+ax_pose 33, 0x01d8, 0x4104, 0x3c01
+ax_pose 34, 0x41d8, 0x80e4, 0x3c05
+ax_pose 35, 0x41e8, 0xc0e4, 0x3c0d
+ax_pose_terminator
+sHoOhPose104:
+ax_pose 65, 0x01cc, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose105:
+ax_pose 66, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose106:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose107:
+ax_pose 22, 0x41e6, 0xc0e0, 0x3c00
+ax_pose 21, 0x41d6, 0x80e0, 0x3c20
+ax_pose 20, 0x01c6, 0x8100, 0x3c28
+ax_pose 19, 0x01e2, 0x00d8, 0x3c38
+ax_pose_terminator
+sHoOhPose108:
+ax_pose 25, 0x41e6, 0xc0e1, 0x3c00
+ax_pose 23, 0x41d6, 0x8101, 0x3c20
+ax_pose 24, 0x41d6, 0x80e1, 0x3c28
+ax_pose_terminator
+sHoOhPose109:
+ax_pose 63, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose110:
+ax_pose 64, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose111:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose112:
+ax_pose 13, 0x41ce, 0xc0e0, 0x3c00
+ax_pose 12, 0x41ee, 0x80e0, 0x3c20
+ax_pose 14, 0x41ee, 0x8100, 0x3c28
+ax_pose_terminator
+sHoOhPose113:
+ax_pose 15, 0x81c6, 0xc100, 0x3c00
+ax_pose 16, 0x01d6, 0x80e0, 0x3c20
+ax_pose 17, 0x01f6, 0x40f0, 0x3c30
+ax_pose_terminator
+sHoOhPose114:
+ax_pose 59, 0x41d1, 0xc0e1, 0x3c00
+ax_pose 60, 0x41f1, 0x8101, 0x3c20
+ax_pose 61, 0x41f1, 0x40e1, 0x3c28
+ax_pose_terminator
+sHoOhPose115:
+ax_pose 62, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose116:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose117:
+ax_pose 9, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sHoOhPose118:
+ax_pose 10, 0x01c6, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose119:
+ax_pose 56, 0x41d4, 0xc0e5, 0x3c00
+ax_pose 57, 0x41f4, 0x40f5, 0x3c20
+ax_pose_terminator
+sHoOhPose120:
+ax_pose 58, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose121:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose122:
+ax_pose 1, 0x41c9, 0x40f0, 0x3c00
+ax_pose 2, 0x41d1, 0x80e0, 0x3c04
+ax_pose 3, 0x41d1, 0x8100, 0x3c0c
+ax_pose 4, 0x01de, 0x00d8, 0x3c14
+ax_pose 5, 0x01de, 0x0120, 0x3c15
+ax_pose 6, 0x41e1, 0xc0e0, 0x3c16
+ax_pose_terminator
+sHoOhPose123:
+ax_pose 7, 0x01cd, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose124:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose125:
+ax_pose 9, 0x01c6, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose126:
+ax_pose 10, 0x01c6, 0xd0d7, 0x3c00
+ax_pose_terminator
+sHoOhPose127:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose128:
+ax_pose 12, 0x41ee, 0x90ff, 0x3c00
+ax_pose 13, 0x41ce, 0xd0df, 0x3c08
+ax_pose 14, 0x41ee, 0x90df, 0x3c28
+ax_pose_terminator
+sHoOhPose129:
+ax_pose 15, 0x81c6, 0xd0df, 0x3c00
+ax_pose 16, 0x01d6, 0x90ff, 0x3c20
+ax_pose 17, 0x01f6, 0x50ff, 0x3c30
+ax_pose_terminator
+sHoOhPose130:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose131:
+ax_pose 19, 0x01e2, 0x111f, 0x3c00
+ax_pose 20, 0x01c6, 0x90df, 0x3c01
+ax_pose 21, 0x41d6, 0x90ff, 0x3c11
+ax_pose 22, 0x41e6, 0xd0df, 0x3c19
+ax_pose_terminator
+sHoOhPose132:
+ax_pose 23, 0x41d6, 0x90df, 0x3c00
+ax_pose 24, 0x41d6, 0x90ff, 0x3c08
+ax_pose 25, 0x41e6, 0xd0df, 0x3c10
+ax_pose_terminator
+sHoOhPose133:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose134:
+ax_pose 27, 0x01de, 0x0120, 0x3c00
+ax_pose 28, 0x81db, 0x00d8, 0x3c01
+ax_pose 29, 0x41d6, 0x8100, 0x3c03
+ax_pose 30, 0x41d6, 0x80e0, 0x3c0b
+ax_pose 31, 0x41e6, 0xc0e0, 0x3c13
+ax_pose_terminator
+sHoOhPose135:
+ax_pose 32, 0x01d0, 0x00fc, 0x3c00
+ax_pose 33, 0x01d8, 0x4104, 0x3c01
+ax_pose 34, 0x41d8, 0x80e4, 0x3c05
+ax_pose 35, 0x41e8, 0xc0e4, 0x3c0d
+ax_pose_terminator
+sHoOhPose136:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose137:
+ax_pose 22, 0x41e6, 0xc0e0, 0x3c00
+ax_pose 21, 0x41d6, 0x80e0, 0x3c20
+ax_pose 20, 0x01c6, 0x8100, 0x3c28
+ax_pose 19, 0x01e2, 0x00d8, 0x3c38
+ax_pose_terminator
+sHoOhPose138:
+ax_pose 25, 0x41e6, 0xc0e1, 0x3c00
+ax_pose 23, 0x41d6, 0x8101, 0x3c20
+ax_pose 24, 0x41d6, 0x80e1, 0x3c28
+ax_pose_terminator
+sHoOhPose139:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose140:
+ax_pose 13, 0x41ce, 0xc0e0, 0x3c00
+ax_pose 12, 0x41ee, 0x80e0, 0x3c20
+ax_pose 14, 0x41ee, 0x8100, 0x3c28
+ax_pose_terminator
+sHoOhPose141:
+ax_pose 15, 0x81c6, 0xc100, 0x3c00
+ax_pose 16, 0x01d6, 0x80e0, 0x3c20
+ax_pose 17, 0x01f6, 0x40f0, 0x3c30
+ax_pose_terminator
+sHoOhPose142:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose143:
+ax_pose 9, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sHoOhPose144:
+ax_pose 10, 0x01c6, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose145:
+ax_pose 67, 0x01e0, 0x80fe, 0x3c00
+ax_pose 68, 0x41f7, 0x80de, 0x3c10
+ax_pose 69, 0x41ef, 0x40de, 0x3c18
+ax_pose 70, 0x01e7, 0x00f6, 0x3c1c
+ax_pose 71, 0x0200, 0x00fe, 0x3c1d
+ax_pose 72, 0x4200, 0x0106, 0x3c1e
+ax_pose_terminator
+sHoOhPose146:
+ax_pose 73, 0x01e0, 0x80fe, 0x3c00
+ax_pose 74, 0x81e9, 0x80ee, 0x3c10
+ax_pose 75, 0x01f1, 0x00e6, 0x3c18
+ax_pose 76, 0x81f9, 0x00e6, 0x3c19
+ax_pose 77, 0x0200, 0x00fe, 0x3c1b
+ax_pose 78, 0x0200, 0x010a, 0x3c1c
+ax_pose_terminator
+sHoOhPose147:
+ax_pose 79, 0x01c2, 0xc0e1, 0x3c00
+ax_pose_terminator
+sHoOhPose148:
+ax_pose 80, 0x01c2, 0xd0d4, 0x3c00
+ax_pose_terminator
+sHoOhPose149:
+ax_pose 81, 0x01c7, 0xd0da, 0x3c00
+ax_pose_terminator
+sHoOhPose150:
+ax_pose 82, 0x01c3, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose151:
+ax_pose 83, 0x01c3, 0xc0e1, 0x3c00
+ax_pose_terminator
+sHoOhPose152:
+ax_pose 82, 0x01c3, 0xc0e3, 0x3c00
+ax_pose_terminator
+sHoOhPose153:
+ax_pose 81, 0x01c7, 0xc0e5, 0x3c00
+ax_pose_terminator
+sHoOhPose154:
+ax_pose 80, 0x01c2, 0xc0ec, 0x3c00
+ax_pose_terminator
+sHoOhPose155:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose156:
+ax_pose 1, 0x41c9, 0x40f0, 0x3c00
+ax_pose 2, 0x41d1, 0x80e0, 0x3c04
+ax_pose 3, 0x41d1, 0x8100, 0x3c0c
+ax_pose 4, 0x01de, 0x00d8, 0x3c14
+ax_pose 5, 0x01de, 0x0120, 0x3c15
+ax_pose 6, 0x41e1, 0xc0e0, 0x3c16
+ax_pose_terminator
+sHoOhPose157:
+ax_pose 7, 0x01cd, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose158:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose159:
+ax_pose 9, 0x01c6, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose160:
+ax_pose 10, 0x01c6, 0xd0d7, 0x3c00
+ax_pose_terminator
+sHoOhPose161:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose162:
+ax_pose 12, 0x41ee, 0x90ff, 0x3c00
+ax_pose 13, 0x41ce, 0xd0df, 0x3c08
+ax_pose 14, 0x41ee, 0x90df, 0x3c28
+ax_pose_terminator
+sHoOhPose163:
+ax_pose 15, 0x81c6, 0xd0df, 0x3c00
+ax_pose 16, 0x01d6, 0x90ff, 0x3c20
+ax_pose 17, 0x01f6, 0x50ff, 0x3c30
+ax_pose_terminator
+sHoOhPose164:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose165:
+ax_pose 19, 0x01e2, 0x111f, 0x3c00
+ax_pose 20, 0x01c6, 0x90df, 0x3c01
+ax_pose 21, 0x41d6, 0x90ff, 0x3c11
+ax_pose 22, 0x41e6, 0xd0df, 0x3c19
+ax_pose_terminator
+sHoOhPose166:
+ax_pose 23, 0x41d6, 0x90df, 0x3c00
+ax_pose 24, 0x41d6, 0x90ff, 0x3c08
+ax_pose 25, 0x41e6, 0xd0df, 0x3c10
+ax_pose_terminator
+sHoOhPose167:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose168:
+ax_pose 27, 0x01de, 0x0120, 0x3c00
+ax_pose 28, 0x81db, 0x00d8, 0x3c01
+ax_pose 29, 0x41d6, 0x8100, 0x3c03
+ax_pose 30, 0x41d6, 0x80e0, 0x3c0b
+ax_pose 31, 0x41e6, 0xc0e0, 0x3c13
+ax_pose_terminator
+sHoOhPose169:
+ax_pose 32, 0x01d0, 0x00fc, 0x3c00
+ax_pose 33, 0x01d8, 0x4104, 0x3c01
+ax_pose 34, 0x41d8, 0x80e4, 0x3c05
+ax_pose 35, 0x41e8, 0xc0e4, 0x3c0d
+ax_pose_terminator
+sHoOhPose170:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose171:
+ax_pose 22, 0x41e6, 0xc0e0, 0x3c00
+ax_pose 21, 0x41d6, 0x80e0, 0x3c20
+ax_pose 20, 0x01c6, 0x8100, 0x3c28
+ax_pose 19, 0x01e2, 0x00d8, 0x3c38
+ax_pose_terminator
+sHoOhPose172:
+ax_pose 25, 0x41e6, 0xc0e1, 0x3c00
+ax_pose 23, 0x41d6, 0x8101, 0x3c20
+ax_pose 24, 0x41d6, 0x80e1, 0x3c28
+ax_pose_terminator
+sHoOhPose173:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose174:
+ax_pose 13, 0x41ce, 0xc0e0, 0x3c00
+ax_pose 12, 0x41ee, 0x80e0, 0x3c20
+ax_pose 14, 0x41ee, 0x8100, 0x3c28
+ax_pose_terminator
+sHoOhPose175:
+ax_pose 15, 0x81c6, 0xc100, 0x3c00
+ax_pose 16, 0x01d6, 0x80e0, 0x3c20
+ax_pose 17, 0x01f6, 0x40f0, 0x3c30
+ax_pose_terminator
+sHoOhPose176:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose177:
+ax_pose 9, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sHoOhPose178:
+ax_pose 10, 0x01c6, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose179:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose180:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose181:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose182:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose183:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose184:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose185:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose186:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose187:
+ax_pose 52, 0x01c6, 0x80e4, 0x3c00
+ax_pose -1, 0x01c6, 0x90fb, 0x3c00
+ax_pose 53, 0x81e6, 0x80e4, 0x3c10
+ax_pose 54, 0x81e6, 0x40f4, 0x3c18
+ax_pose 55, 0x81e6, 0x40fc, 0x3c1c
+ax_pose -1, 0x81e6, 0x910b, 0x3c10
+ax_pose -1, 0x81e6, 0x5103, 0x3c18
+ax_pose_terminator
+sHoOhPose188:
+ax_pose 58, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose189:
+ax_pose 62, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose190:
+ax_pose 64, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose191:
+ax_pose 66, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose192:
+ax_pose 64, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose193:
+ax_pose 62, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose194:
+ax_pose 58, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose195:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose196:
+ax_pose 1, 0x41c9, 0x40f0, 0x3c00
+ax_pose 2, 0x41d1, 0x80e0, 0x3c04
+ax_pose 3, 0x41d1, 0x8100, 0x3c0c
+ax_pose 4, 0x01de, 0x00d8, 0x3c14
+ax_pose 5, 0x01de, 0x0120, 0x3c15
+ax_pose 6, 0x41e1, 0xc0e0, 0x3c16
+ax_pose_terminator
+sHoOhPose197:
+ax_pose 7, 0x01cd, 0xc0e8, 0x3c00
+ax_pose_terminator
+sHoOhPose198:
+ax_pose 51, 0x41da, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose199:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose200:
+ax_pose 9, 0x01c6, 0xd0dd, 0x3c00
+ax_pose_terminator
+sHoOhPose201:
+ax_pose 10, 0x01c6, 0xd0d7, 0x3c00
+ax_pose_terminator
+sHoOhPose202:
+ax_pose 56, 0x41d6, 0xd0db, 0x3c00
+ax_pose 57, 0x41f6, 0x50eb, 0x3c20
+ax_pose_terminator
+sHoOhPose203:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose204:
+ax_pose 12, 0x41ee, 0x90ff, 0x3c00
+ax_pose 13, 0x41ce, 0xd0df, 0x3c08
+ax_pose 14, 0x41ee, 0x90df, 0x3c28
+ax_pose_terminator
+sHoOhPose205:
+ax_pose 15, 0x81c6, 0xd0df, 0x3c00
+ax_pose 16, 0x01d6, 0x90ff, 0x3c20
+ax_pose 17, 0x01f6, 0x50ff, 0x3c30
+ax_pose_terminator
+sHoOhPose206:
+ax_pose 59, 0x41dc, 0xd0df, 0x3c00
+ax_pose 60, 0x41fc, 0x90df, 0x3c20
+ax_pose 61, 0x41fc, 0x50ff, 0x3c28
+ax_pose_terminator
+sHoOhPose207:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose208:
+ax_pose 19, 0x01e2, 0x111f, 0x3c00
+ax_pose 20, 0x01c6, 0x90df, 0x3c01
+ax_pose 21, 0x41d6, 0x90ff, 0x3c11
+ax_pose 22, 0x41e6, 0xd0df, 0x3c19
+ax_pose_terminator
+sHoOhPose209:
+ax_pose 23, 0x41d6, 0x90df, 0x3c00
+ax_pose 24, 0x41d6, 0x90ff, 0x3c08
+ax_pose 25, 0x41e6, 0xd0df, 0x3c10
+ax_pose_terminator
+sHoOhPose210:
+ax_pose 63, 0x01d6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose211:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose212:
+ax_pose 27, 0x01de, 0x0120, 0x3c00
+ax_pose 28, 0x81db, 0x00d8, 0x3c01
+ax_pose 29, 0x41d6, 0x8100, 0x3c03
+ax_pose 30, 0x41d6, 0x80e0, 0x3c0b
+ax_pose 31, 0x41e6, 0xc0e0, 0x3c13
+ax_pose_terminator
+sHoOhPose213:
+ax_pose 32, 0x01d0, 0x00fc, 0x3c00
+ax_pose 33, 0x01d8, 0x4104, 0x3c01
+ax_pose 34, 0x41d8, 0x80e4, 0x3c05
+ax_pose 35, 0x41e8, 0xc0e4, 0x3c0d
+ax_pose_terminator
+sHoOhPose214:
+ax_pose 65, 0x01db, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose215:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose216:
+ax_pose 22, 0x41e6, 0xc0e0, 0x3c00
+ax_pose 21, 0x41d6, 0x80e0, 0x3c20
+ax_pose 20, 0x01c6, 0x8100, 0x3c28
+ax_pose 19, 0x01e2, 0x00d8, 0x3c38
+ax_pose_terminator
+sHoOhPose217:
+ax_pose 25, 0x41e6, 0xc0e1, 0x3c00
+ax_pose 23, 0x41d6, 0x8101, 0x3c20
+ax_pose 24, 0x41d6, 0x80e1, 0x3c28
+ax_pose_terminator
+sHoOhPose218:
+ax_pose 63, 0x01d6, 0xc0e1, 0x3c00
+ax_pose_terminator
+sHoOhPose219:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose220:
+ax_pose 13, 0x41ce, 0xc0e0, 0x3c00
+ax_pose 12, 0x41ee, 0x80e0, 0x3c20
+ax_pose 14, 0x41ee, 0x8100, 0x3c28
+ax_pose_terminator
+sHoOhPose221:
+ax_pose 15, 0x81c6, 0xc100, 0x3c00
+ax_pose 16, 0x01d6, 0x80e0, 0x3c20
+ax_pose 17, 0x01f6, 0x40f0, 0x3c30
+ax_pose_terminator
+sHoOhPose222:
+ax_pose 59, 0x41dc, 0xc0e1, 0x3c00
+ax_pose 60, 0x41fc, 0x8101, 0x3c20
+ax_pose 61, 0x41fc, 0x40e1, 0x3c28
+ax_pose_terminator
+sHoOhPose223:
+ax_pose 8, 0x01c6, 0xc0e5, 0x3c00
+ax_pose_terminator
+sHoOhPose224:
+ax_pose 9, 0x01c6, 0xc0e3, 0x3c00
+ax_pose_terminator
+sHoOhPose225:
+ax_pose 10, 0x01c6, 0xc0e9, 0x3c00
+ax_pose_terminator
+sHoOhPose226:
+ax_pose 56, 0x41d6, 0xc0e5, 0x3c00
+ax_pose 57, 0x41f6, 0x40f5, 0x3c20
+ax_pose_terminator
+sHoOhPose227:
+ax_pose 52, 0x01c6, 0x80e4, 0x3c00
+ax_pose -1, 0x01c6, 0x90fb, 0x3c00
+ax_pose 53, 0x81e6, 0x80e4, 0x3c10
+ax_pose 54, 0x81e6, 0x40f4, 0x3c18
+ax_pose 55, 0x81e6, 0x40fc, 0x3c1c
+ax_pose -1, 0x81e6, 0x910b, 0x3c10
+ax_pose -1, 0x81e6, 0x5103, 0x3c18
+ax_pose_terminator
+sHoOhPose228:
+ax_pose 58, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+sHoOhPose229:
+ax_pose 62, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose230:
+ax_pose 64, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose231:
+ax_pose 66, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose232:
+ax_pose 64, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose233:
+ax_pose 62, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose234:
+ax_pose 58, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose235:
+ax_pose 0, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose236:
+ax_pose 8, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose237:
+ax_pose 11, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose238:
+ax_pose 18, 0x01c6, 0xc0e0, 0x3c00
+ax_pose_terminator
+sHoOhPose239:
+ax_pose 26, 0x01c6, 0xc0e4, 0x3c00
+ax_pose_terminator
+sHoOhPose240:
+ax_pose 18, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose241:
+ax_pose 11, 0x01c6, 0xd0df, 0x3c00
+ax_pose_terminator
+sHoOhPose242:
+ax_pose 8, 0x01c6, 0xd0db, 0x3c00
+ax_pose_terminator
+.align 2
+sHoOhAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 26, 0, -4, 0, -4,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 22, 0, 22,
+ax_anim 2, 1, 24, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 22, 0, 22,
+ax_anim 2, 0, 24, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHoOhAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, -3, -3, -3, -3,
+ax_anim 2, 0, 27, -4, -4, -4, -4,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 2, 0, 29, -4, -4, -4, -4,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 2, 0, 27, -4, -4, -4, -4,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 7, 4, 5,
+ax_anim 1, 0, 28, 10, 14, 10, 10,
+ax_anim 2, 0, 27, 15, 22, 15, 18,
+ax_anim 2, 1, 27, 16, 21, 16, 17,
+ax_anim 2, 0, 27, 15, 22, 15, 18,
+ax_anim 2, 0, 27, 16, 21, 16, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sHoOhAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 2, 0, 30, -4, 0, -4, 0,
+ax_anim 2, 0, 31, -4, 0, -4, 0,
+ax_anim 2, 0, 32, -4, 0, -4, 0,
+ax_anim 2, 0, 31, -4, 0, -4, 0,
+ax_anim 2, 0, 30, -4, 0, -4, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 2, 4, 0,
+ax_anim 1, 0, 31, 10, 4, 10, 0,
+ax_anim 2, 0, 30, 15, 5, 15, 1,
+ax_anim 2, 1, 30, 15, 4, 15, 0,
+ax_anim 2, 0, 30, 15, 5, 15, 1,
+ax_anim 2, 0, 30, 15, 4, 15, 0,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sHoOhAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 33, -3, 3, -3, 3,
+ax_anim 2, 0, 33, -4, 4, -4, 4,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 2, 0, 35, -4, 4, -4, 4,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 2, 0, 33, -4, 4, -4, 4,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, -1, 4, -4,
+ax_anim 1, 0, 34, 8, -4, 8, -8,
+ax_anim 2, 0, 33, 10, -3, 10, -10,
+ax_anim 2, 1, 33, 9, -4, 9, -11,
+ax_anim 2, 0, 33, 10, -3, 10, -10,
+ax_anim 2, 0, 33, 9, -4, 9, -11,
+ax_anim 2, 0, 33, 6, -1, 6, -1,
+ax_anim_terminator
+sHoOhAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 3, 0, 3,
+ax_anim 2, 0, 36, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 2, 0, 38, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 2, 0, 36, 0, 4, 0, 4,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -1, 0, -4,
+ax_anim 1, 0, 37, 0, -4, 0, -12,
+ax_anim 2, 0, 36, 0, -4, 0, -12,
+ax_anim 2, 1, 36, 1, -4, 1, -12,
+ax_anim 2, 0, 36, 0, -4, 0, -12,
+ax_anim 2, 0, 36, 1, -4, 1, -12,
+ax_anim 2, 0, 36, 0, -1, 0, -4,
+ax_anim_terminator
+sHoOhAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 3, 3, 3, 3,
+ax_anim 2, 0, 39, 4, 4, 4, 4,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 2, 0, 41, 4, 4, 4, 4,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 2, 0, 39, 4, 4, 4, 4,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -4, -1, -4, -4,
+ax_anim 1, 0, 40, -8, -4, -8, -8,
+ax_anim 2, 0, 39, -10, -3, -10, -10,
+ax_anim 2, 1, 39, -9, -4, -9, -11,
+ax_anim 2, 0, 39, -10, -3, -10, -10,
+ax_anim 2, 0, 39, -9, -4, -9, -11,
+ax_anim 2, 0, 39, -6, -1, -6, -1,
+ax_anim_terminator
+sHoOhAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 2, 0, 42, 4, 0, 4, 0,
+ax_anim 2, 0, 43, 4, 0, 4, 0,
+ax_anim 2, 0, 44, 4, 0, 4, 0,
+ax_anim 2, 0, 43, 4, 0, 4, 0,
+ax_anim 2, 0, 42, 4, 0, 4, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 2, -4, 0,
+ax_anim 1, 0, 43, -10, 4, -10, 0,
+ax_anim 2, 0, 42, -15, 5, -15, 1,
+ax_anim 2, 1, 42, -15, 4, -15, 0,
+ax_anim 2, 0, 42, -15, 5, -15, 1,
+ax_anim 2, 0, 42, -15, 4, -15, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sHoOhAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 45, 3, -3, 3, -3,
+ax_anim 2, 0, 45, 4, -4, 4, -4,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 2, 0, 47, 4, -4, 4, -4,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 2, 0, 45, 4, -4, 4, -4,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 7, -4, 5,
+ax_anim 1, 0, 46, -10, 14, -10, 10,
+ax_anim 2, 0, 45, -15, 22, -15, 18,
+ax_anim 2, 1, 45, -16, 21, -16, 17,
+ax_anim 2, 0, 45, -15, 22, -15, 18,
+ax_anim 2, 0, 45, -16, 21, -16, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHoOhAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 0, 50, 0, -5, 0, -5,
+ax_anim 2, 0, 50, 0, -7, 0, -7,
+ax_anim 2, 0, 49, 0, -7, 0, -7,
+ax_anim 2, 0, 48, 0, -6, 0, -6,
+ax_anim 2, 0, 48, 0, -4, 0, -4,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 0, 4, 0, 4,
+ax_anim 1, 0, 51, 0, 10, 0, 10,
+ax_anim 2, 0, 51, 0, 22, 0, 22,
+ax_anim 2, 1, 51, 1, 22, 1, 22,
+ax_anim 2, 0, 51, 0, 22, 0, 22,
+ax_anim 2, 0, 51, 1, 22, 1, 22,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sHoOhAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -3, -3, -3, -3,
+ax_anim 2, 0, 54, -5, -5, -5, -5,
+ax_anim 2, 0, 54, -7, -7, -7, -7,
+ax_anim 2, 0, 53, -7, -7, -7, -7,
+ax_anim 2, 0, 52, -6, -6, -6, -6,
+ax_anim 2, 0, 52, -4, -4, -4, -4,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 9, 4, 5,
+ax_anim 1, 0, 55, 8, 13, 8, 10,
+ax_anim 2, 0, 55, 12, 24, 12, 14,
+ax_anim 2, 1, 55, 13, 23, 13, 13,
+ax_anim 2, 0, 55, 12, 24, 12, 14,
+ax_anim 2, 0, 55, 13, 23, 13, 13,
+ax_anim 2, 0, 52, 6, 6, 6, 7,
+ax_anim_terminator
+sHoOhAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 2, 0, 57, -3, 0, -3, 0,
+ax_anim 2, 0, 58, -5, 0, -5, 0,
+ax_anim 2, 0, 58, -7, 0, -7, 0,
+ax_anim 2, 0, 57, -7, 0, -7, 0,
+ax_anim 2, 0, 56, -6, 0, -6, 0,
+ax_anim 2, 0, 56, -4, 0, -4, 0,
+ax_anim 1, 0, 57, 0, 2, 0, 0,
+ax_anim 1, 2, 59, 2, 6, 2, 0,
+ax_anim 1, 0, 59, 7, 8, 7, 0,
+ax_anim 2, 0, 59, 11, 12, 11, 0,
+ax_anim 2, 1, 59, 11, 11, 11, -1,
+ax_anim 2, 0, 59, 11, 12, 11, 0,
+ax_anim 2, 0, 59, 11, 11, 11, -1,
+ax_anim 2, 0, 56, 6, 5, 6, 0,
+ax_anim_terminator
+sHoOhAnims_3_4:
+ax_anim 2, 0, 60, -1, 1, -1, 1,
+ax_anim 2, 0, 61, -3, 3, -3, 3,
+ax_anim 2, 0, 62, -5, 5, -5, 5,
+ax_anim 2, 0, 62, -7, 7, -7, 7,
+ax_anim 2, 0, 61, -7, 7, -7, 7,
+ax_anim 2, 0, 60, -6, 6, -6, 6,
+ax_anim 2, 0, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 61, 0, 2, 0, -1,
+ax_anim 1, 2, 63, 4, 0, 4, -6,
+ax_anim 1, 0, 63, 10, -2, 10, -12,
+ax_anim 2, 0, 63, 12, -6, 12, -14,
+ax_anim 2, 1, 63, 13, -5, 13, -13,
+ax_anim 2, 0, 63, 12, -6, 12, -14,
+ax_anim 2, 0, 63, 13, -5, 13, -13,
+ax_anim 2, 0, 60, 6, -6, 6, -7,
+ax_anim_terminator
+sHoOhAnims_3_5:
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 0, 65, 0, 4, 0, 4,
+ax_anim 2, 0, 66, 0, 7, 0, 7,
+ax_anim 2, 0, 66, 0, 8, 0, 8,
+ax_anim 2, 0, 65, 0, 7, 0, 7,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim 1, 0, 65, 0, 2, 0, 2,
+ax_anim 1, 2, 67, 0, 0, 0, -4,
+ax_anim 1, 0, 67, 0, -1, 0, -9,
+ax_anim 2, 0, 67, 0, -3, 0, -9,
+ax_anim 2, 1, 67, 1, -3, 1, -9,
+ax_anim 2, 0, 67, 0, -3, 0, -9,
+ax_anim 2, 0, 67, 1, -3, 1, -9,
+ax_anim 2, 0, 64, 0, -3, 0, -5,
+ax_anim_terminator
+sHoOhAnims_3_6:
+ax_anim 2, 0, 68, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 3, 3, 3, 3,
+ax_anim 2, 0, 70, 5, 5, 5, 5,
+ax_anim 2, 0, 70, 7, 7, 7, 7,
+ax_anim 2, 0, 69, 7, 7, 7, 7,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 4, 4, 4, 4,
+ax_anim 1, 0, 69, 0, 2, 0, -1,
+ax_anim 1, 2, 71, -4, 0, -4, -6,
+ax_anim 1, 0, 71, -10, -2, -10, -12,
+ax_anim 2, 0, 71, -12, -6, -12, -14,
+ax_anim 2, 1, 71, -13, -5, -13, -13,
+ax_anim 2, 0, 71, -12, -6, -12, -14,
+ax_anim 2, 0, 71, -13, -5, -13, -13,
+ax_anim 2, 0, 68, -6, -6, -6, -7,
+ax_anim_terminator
+sHoOhAnims_3_7:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 3, 0, 3, 0,
+ax_anim 2, 0, 74, 5, 0, 5, 0,
+ax_anim 2, 0, 74, 7, 0, 7, 0,
+ax_anim 2, 0, 73, 7, 0, 7, 0,
+ax_anim 2, 0, 72, 6, 0, 6, 0,
+ax_anim 2, 0, 72, 4, 0, 4, 0,
+ax_anim 1, 0, 73, 0, 2, 0, 0,
+ax_anim 1, 2, 75, -2, 6, -2, 0,
+ax_anim 1, 0, 75, -7, 8, -7, 0,
+ax_anim 2, 0, 75, -11, 12, -11, 0,
+ax_anim 2, 1, 75, -11, 11, -11, -1,
+ax_anim 2, 0, 75, -11, 12, -11, 0,
+ax_anim 2, 0, 75, -11, 11, -11, -1,
+ax_anim 2, 0, 72, -6, 5, -6, 0,
+ax_anim_terminator
+sHoOhAnims_3_8:
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 2, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 0, 78, 5, -5, 5, -5,
+ax_anim 2, 0, 78, 7, -7, 7, -7,
+ax_anim 2, 0, 77, 7, -7, 7, -7,
+ax_anim 2, 0, 76, 6, -6, 6, -6,
+ax_anim 2, 0, 76, 4, -4, 4, -4,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 2, 79, -4, 9, -4, 5,
+ax_anim 1, 0, 79, -8, 13, -8, 10,
+ax_anim 2, 0, 79, -12, 24, -12, 14,
+ax_anim 2, 1, 79, -13, 23, -13, 13,
+ax_anim 2, 0, 79, -12, 24, -12, 14,
+ax_anim 2, 0, 79, -13, 23, -13, 13,
+ax_anim 2, 0, 76, -6, 6, -6, 7,
+ax_anim_terminator
+.align 2
+sHoOhAnims_4_1:
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, -1, 0, -1,
+ax_anim 1, 0, 82, 0, -2, 0, -1,
+ax_anim 1, 0, 83, 0, -3, 0, -1,
+ax_anim 2, 0, 83, 0, -4, 0, -3,
+ax_anim 4, 2, 83, 0, -5, 0, -5,
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, 1, 5, 1, 5,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, 1, 5, 1, 5,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, 1, 5, 1, 5,
+ax_anim 4, 0, 84, 0, 2, 0, 2,
+ax_anim_terminator
+sHoOhAnims_4_2:
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, -1, -1, -1, -1,
+ax_anim 1, 0, 87, -2, -2, -2, -2,
+ax_anim 1, 0, 88, -3, -3, -3, -3,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim 4, 2, 88, -5, -5, -5, -5,
+ax_anim 2, 0, 86, -2, -2, -2, -2,
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 1, 89, 5, 5, 5, 5,
+ax_anim 2, 0, 89, 6, 4, 6, 4,
+ax_anim 2, 0, 89, 5, 5, 5, 5,
+ax_anim 2, 0, 89, 6, 4, 6, 4,
+ax_anim 2, 0, 89, 5, 5, 5, 5,
+ax_anim 2, 0, 89, 6, 4, 6, 4,
+ax_anim 4, 0, 89, 2, 2, 2, 2,
+ax_anim_terminator
+sHoOhAnims_4_3:
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, -1, 0, -1, 0,
+ax_anim 1, 0, 92, -2, 0, -2, 0,
+ax_anim 1, 0, 93, -5, 0, -5, 0,
+ax_anim 2, 0, 93, -6, 0, -6, 0,
+ax_anim 4, 2, 93, -7, 0, -7, 0,
+ax_anim 2, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 2, 1, 94, 5, 0, 5, 0,
+ax_anim 2, 0, 94, 5, 1, 5, 1,
+ax_anim 2, 0, 94, 5, 0, 5, 0,
+ax_anim 2, 0, 94, 5, 1, 5, 1,
+ax_anim 2, 0, 94, 5, 0, 5, 0,
+ax_anim 2, 0, 94, 5, 1, 5, 1,
+ax_anim 4, 0, 94, 2, 0, 2, 0,
+ax_anim_terminator
+sHoOhAnims_4_4:
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, -1, 1, -1, 1,
+ax_anim 1, 0, 97, -2, 2, -2, 2,
+ax_anim 1, 0, 98, -5, 5, -5, 5,
+ax_anim 2, 0, 98, -6, 6, -6, 6,
+ax_anim 4, 2, 98, -7, 7, -7, 7,
+ax_anim 2, 0, 96, -2, 2, -2, 2,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 1, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim_terminator
+sHoOhAnims_4_5:
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 1, 0, 1,
+ax_anim 1, 0, 102, 0, 2, 0, 2,
+ax_anim 1, 0, 103, 0, 3, 0, 3,
+ax_anim 2, 0, 103, 0, 4, 0, 4,
+ax_anim 4, 2, 103, 0, 5, 0, 5,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 104, 0, -5, -5, -5,
+ax_anim 2, 0, 104, 0, -4, -6, -4,
+ax_anim 2, 0, 104, 0, -5, -5, -5,
+ax_anim 2, 0, 104, 0, -4, -6, -4,
+ax_anim 2, 0, 104, 0, -5, -5, -5,
+ax_anim 2, 0, 104, 0, -4, -6, -4,
+ax_anim 4, 0, 104, 0, -2, -2, -2,
+ax_anim_terminator
+sHoOhAnims_4_6:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 1, 1, 1, 1,
+ax_anim 1, 0, 107, 2, 2, 2, 2,
+ax_anim 1, 0, 108, 5, 5, 5, 5,
+ax_anim 2, 0, 108, 6, 6, 6, 6,
+ax_anim 4, 2, 108, 7, 7, 7, 7,
+ax_anim 2, 0, 106, 2, 2, 2, 2,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 109, -5, -5, -5, -5,
+ax_anim 2, 0, 109, -6, -4, -6, -4,
+ax_anim 2, 0, 109, -5, -5, -5, -5,
+ax_anim 2, 0, 109, -6, -4, -6, -4,
+ax_anim 2, 0, 109, -5, -5, -5, -5,
+ax_anim 2, 0, 109, -6, -4, -6, -4,
+ax_anim 4, 0, 109, -2, -2, -2, -2,
+ax_anim_terminator
+sHoOhAnims_4_7:
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 1, 0, 1, 0,
+ax_anim 1, 0, 112, 2, 0, 2, 0,
+ax_anim 1, 0, 113, 5, 0, 5, 0,
+ax_anim 2, 0, 113, 6, 0, 6, 0,
+ax_anim 4, 2, 113, 7, 0, 7, 0,
+ax_anim 2, 0, 111, 2, 0, 2, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 1, 114, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -5, 1, -5, 1,
+ax_anim 2, 0, 114, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -5, 1, -5, 1,
+ax_anim 2, 0, 114, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -5, 1, -5, 1,
+ax_anim 4, 0, 114, -2, 0, -2, 0,
+ax_anim_terminator
+sHoOhAnims_4_8:
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 1, -1, 1, -1,
+ax_anim 1, 0, 117, 2, -2, 2, -2,
+ax_anim 1, 0, 118, 3, -3, 3, -3,
+ax_anim 2, 0, 118, 4, -4, 4, -4,
+ax_anim 4, 2, 118, 5, -5, 5, -5,
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim 2, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 1, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -6, 4, -6, 4,
+ax_anim 4, 0, 119, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sHoOhAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_5_2:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_5_4:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_5_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_5_8:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sHoOhAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sHoOhAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sHoOhAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sHoOhAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sHoOhAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sHoOhAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sHoOhAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHoOhAnims_8_1:
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_8_2:
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_8_3:
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_8_4:
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim 10, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_8_5:
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, -1, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_8_6:
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_8_7:
+ax_anim 12, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 12, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, -1, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_8_8:
+ax_anim 12, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim 12, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 19, 7, 19,
+ax_anim 3, 0, 182, 0, 24, 0, 24,
+ax_anim 2, 3, 183, -7, 19, -7, 19,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 179, 11, 3, 11, 3,
+ax_anim 2, 0, 180, 15, 9, 15, 9,
+ax_anim 3, 0, 181, 12, 21, 12, 21,
+ax_anim 2, 3, 182, 11, 21, 11, 21,
+ax_anim 2, 0, 183, 2, 16, 2, 16,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 11, -4, 11, -4,
+ax_anim 3, 0, 180, 10, 1, 10, 1,
+ax_anim 2, 3, 181, 12, 5, 12, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 2, -3, 2, -3,
+ax_anim 2, 0, 185, 4, -7, 4, -7,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 3, 0, 179, 10, -3, 10, -3,
+ax_anim 2, 3, 180, 9, 0, 9, 0,
+ax_anim 2, 0, 181, 8, 0, 8, 0,
+ax_anim 1, 0, 182, 7, 1, 7, 1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -1, -6, -1,
+ax_anim 2, 0, 184, -8, -3, -8, -3,
+ax_anim 2, 0, 185, -7, -5, -7, -5,
+ax_anim 3, 0, 178, 0, -6, 0, -6,
+ax_anim 2, 3, 179, 7, -5, 7, -5,
+ax_anim 2, 0, 180, 8, -3, 8, -3,
+ax_anim 1, 0, 181, 6, -1, 6, -1,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -2, -3, -2, -3,
+ax_anim 2, 0, 179, -4, -7, -4, -7,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 3, 0, 185, -10, -3, -10, -3,
+ax_anim 2, 3, 184, -9, 0, -9, 0,
+ax_anim 2, 0, 183, -8, 0, -8, 0,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -11, -4, -11, -4,
+ax_anim 3, 0, 184, -10, 1, -10, 1,
+ax_anim 2, 3, 183, -12, 5, -12, 5,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -11, 3, -11, 3,
+ax_anim 2, 0, 184, -15, 9, -15, 9,
+ax_anim 3, 0, 183, -12, 21, -12, 21,
+ax_anim 2, 3, 182, -11, 21, -11, 21,
+ax_anim 2, 0, 181, -2, 16, -2, 16,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 9, 0, 0,
+ax_anim_terminator
+sHoOhAnims_11_2:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -8, 0, 0,
+ax_anim 2, 2, 201, 0, 12, 0, 0,
+ax_anim_terminator
+sHoOhAnims_11_3:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -8, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_11_4:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -17, 0, 0,
+ax_anim 1, 0, 206, 0, -8, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_11_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -8, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_11_6:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -22, 0, 0,
+ax_anim 3, 0, 215, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -17, 0, 0,
+ax_anim 1, 0, 214, 0, -8, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_11_7:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -8, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_11_8:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -8, 0, 0,
+ax_anim 2, 2, 225, 0, 12, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_12_2:
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, 0,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_12_3:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_12_4:
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_12_6:
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_12_7:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_12_8:
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoOhAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sHoOhGfx1:
+.incbin "baserom.gba", 0x1034D5C, 0xE0
+sHoOhGfx1_1:
+.incbin "baserom.gba", 0x1034E3C, 0xE0
+sHoOhGfx1_2:
+.incbin "baserom.gba", 0x1034F1C, 0xE0
+sHoOhGfx1_3:
+.incbin "baserom.gba", 0x1034FFC, 0xE0
+sHoOhGfx1_4:
+.incbin "baserom.gba", 0x10350DC, 0xE0
+sHoOhGfx1_5:
+.incbin "baserom.gba", 0x10351BC, 0xE0
+sHoOhGfx1_6:
+.incbin "baserom.gba", 0x103529C, 0xA0
+sHoOhGfx1_7:
+.incbin "baserom.gba", 0x103533C, 0x60
+sHoOhSprites1:
+ax_sprite sHoOhGfx1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx1_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx1_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx1_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx1_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx1_5, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx1_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx1_7, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sHoOhGfx2:
+.incbin "baserom.gba", 0x1035424, 0x60
+sHoOhSprites2:
+ax_sprite sHoOhGfx2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx3:
+.incbin "baserom.gba", 0x103549C, 0xE0
+sHoOhSprites3:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx3, 0xe0
+ax_sprite_terminator
+sHoOhGfx4:
+.incbin "baserom.gba", 0x1035594, 0x60
+sHoOhGfx4_1:
+.incbin "baserom.gba", 0x10355F4, 0x80
+sHoOhSprites4:
+ax_sprite sHoOhGfx4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx4_1, 0x80
+ax_sprite_terminator
+sHoOhGfx5:
+.incbin "baserom.gba", 0x1035694, 0x20
+sHoOhSprites5:
+ax_sprite sHoOhGfx5, 0x20
+ax_sprite_terminator
+sHoOhGfx6:
+.incbin "baserom.gba", 0x10356C4, 0x20
+sHoOhSprites6:
+ax_sprite sHoOhGfx6, 0x20
+ax_sprite_terminator
+sHoOhGfx7:
+.incbin "baserom.gba", 0x10356F4, 0x200
+sHoOhGfx7_1:
+.incbin "baserom.gba", 0x10358F4, 0xC0
+sHoOhGfx7_2:
+.incbin "baserom.gba", 0x10359B4, 0x80
+sHoOhSprites7:
+ax_sprite sHoOhGfx7, 0x200
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx7_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx7_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx8:
+.incbin "baserom.gba", 0x1035A6C, 0x80
+sHoOhGfx8_1:
+.incbin "baserom.gba", 0x1035AEC, 0xC0
+sHoOhGfx8_2:
+.incbin "baserom.gba", 0x1035BAC, 0xC0
+sHoOhGfx8_3:
+.incbin "baserom.gba", 0x1035C6C, 0xC0
+sHoOhGfx8_4:
+.incbin "baserom.gba", 0x1035D2C, 0xC0
+sHoOhGfx8_5:
+.incbin "baserom.gba", 0x1035DEC, 0xC0
+sHoOhGfx8_6:
+.incbin "baserom.gba", 0x1035EAC, 0x20
+sHoOhGfx8_7:
+.incbin "baserom.gba", 0x1035ECC, 0x20
+sHoOhGfx8_8:
+.incbin "baserom.gba", 0x1035EEC, 0x20
+sHoOhSprites8:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx8, 0x80
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx8_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx8_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx8_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx8_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx8_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx8_6, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx8_7, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx8_8, 0x20
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sHoOhGfx9:
+.incbin "baserom.gba", 0x1035FAC, 0xA0
+sHoOhGfx9_1:
+.incbin "baserom.gba", 0x103604C, 0xE0
+sHoOhGfx9_2:
+.incbin "baserom.gba", 0x103612C, 0xE0
+sHoOhGfx9_3:
+.incbin "baserom.gba", 0x103620C, 0xE0
+sHoOhGfx9_4:
+.incbin "baserom.gba", 0x10362EC, 0xC0
+sHoOhGfx9_5:
+.incbin "baserom.gba", 0x10363AC, 0xE0
+sHoOhGfx9_6:
+.incbin "baserom.gba", 0x103648C, 0xE0
+sHoOhSprites9:
+ax_sprite sHoOhGfx9, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx9_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx9_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx9_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx9_4, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx9_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx9_6, 0xe0
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sHoOhGfx10:
+.incbin "baserom.gba", 0x10365E4, 0x60
+sHoOhGfx10_1:
+.incbin "baserom.gba", 0x1036644, 0x80
+sHoOhGfx10_2:
+.incbin "baserom.gba", 0x10366C4, 0x200
+sHoOhGfx10_3:
+.incbin "baserom.gba", 0x10368C4, 0xE0
+sHoOhGfx10_4:
+.incbin "baserom.gba", 0x10369A4, 0xE0
+sHoOhGfx10_5:
+.incbin "baserom.gba", 0x1036A84, 0xC0
+sHoOhSprites10:
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx10, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx10_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx10_2, 0x200
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx10_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx10_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx10_5, 0xc0
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sHoOhGfx11:
+.incbin "baserom.gba", 0x1036BB4, 0x60
+sHoOhGfx11_1:
+.incbin "baserom.gba", 0x1036C14, 0xA0
+sHoOhGfx11_2:
+.incbin "baserom.gba", 0x1036CB4, 0xA0
+sHoOhGfx11_3:
+.incbin "baserom.gba", 0x1036D54, 0xE0
+sHoOhGfx11_4:
+.incbin "baserom.gba", 0x1036E34, 0xE0
+sHoOhGfx11_5:
+.incbin "baserom.gba", 0x1036F14, 0xE0
+sHoOhGfx11_6:
+.incbin "baserom.gba", 0x1036FF4, 0x40
+sHoOhGfx11_7:
+.incbin "baserom.gba", 0x1037034, 0x60
+sHoOhGfx11_8:
+.incbin "baserom.gba", 0x1037094, 0x40
+sHoOhSprites11:
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx11, 0x60
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx11_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx11_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx11_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx11_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx11_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx11_6, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx11_7, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sHoOhGfx11_8, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx12:
+.incbin "baserom.gba", 0x1037174, 0x40
+sHoOhGfx12_1:
+.incbin "baserom.gba", 0x10371B4, 0x40
+sHoOhGfx12_2:
+.incbin "baserom.gba", 0x10371F4, 0x60
+sHoOhGfx12_3:
+.incbin "baserom.gba", 0x1037254, 0x40
+sHoOhGfx12_4:
+.incbin "baserom.gba", 0x1037294, 0x60
+sHoOhGfx12_5:
+.incbin "baserom.gba", 0x10372F4, 0x2E0
+sHoOhGfx12_6:
+.incbin "baserom.gba", 0x10375D4, 0x40
+sHoOhGfx12_7:
+.incbin "baserom.gba", 0x1037614, 0x60
+sHoOhGfx12_8:
+.incbin "baserom.gba", 0x1037674, 0x20
+sHoOhSprites12:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx12, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sHoOhGfx12_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx12_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx12_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx12_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx12_5, 0x2e0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx12_6, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx12_7, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sHoOhGfx12_8, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx13:
+.incbin "baserom.gba", 0x1037734, 0x80
+sHoOhGfx13_1:
+.incbin "baserom.gba", 0x10377B4, 0x20
+sHoOhSprites13:
+ax_sprite sHoOhGfx13, 0x80
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx13_1, 0x20
+ax_sprite_terminator
+sHoOhGfx14:
+.incbin "baserom.gba", 0x10377F4, 0x20
+sHoOhGfx14_1:
+.incbin "baserom.gba", 0x1037814, 0x60
+sHoOhGfx14_2:
+.incbin "baserom.gba", 0x1037874, 0x40
+sHoOhGfx14_3:
+.incbin "baserom.gba", 0x10378B4, 0x60
+sHoOhGfx14_4:
+.incbin "baserom.gba", 0x1037914, 0x1E0
+sHoOhSprites14:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx14, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx14_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx14_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx14_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx14_4, 0x1e0
+ax_sprite_terminator
+sHoOhGfx15:
+.incbin "baserom.gba", 0x1037B4C, 0x80
+sHoOhGfx15_1:
+.incbin "baserom.gba", 0x1037BCC, 0x40
+sHoOhSprites15:
+ax_sprite sHoOhGfx15, 0x80
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx15_1, 0x40
+ax_sprite_terminator
+sHoOhGfx16:
+.incbin "baserom.gba", 0x1037C2C, 0x60
+sHoOhGfx16_1:
+.incbin "baserom.gba", 0x1037C8C, 0x2A0
+sHoOhSprites16:
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx16_1, 0x2a0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx17:
+.incbin "baserom.gba", 0x1037F5C, 0x40
+sHoOhGfx17_1:
+.incbin "baserom.gba", 0x1037F9C, 0x100
+sHoOhGfx17_2:
+.incbin "baserom.gba", 0x103809C, 0x60
+sHoOhSprites17:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx17_2, 0x60
+ax_sprite_terminator
+sHoOhGfx18:
+.incbin "baserom.gba", 0x1038134, 0x40
+sHoOhGfx18_1:
+.incbin "baserom.gba", 0x1038174, 0x20
+sHoOhSprites18:
+ax_sprite sHoOhGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx18_1, 0x20
+ax_sprite_terminator
+sHoOhGfx19:
+.incbin "baserom.gba", 0x10381B4, 0xA0
+sHoOhGfx19_1:
+.incbin "baserom.gba", 0x1038254, 0x60
+sHoOhGfx19_2:
+.incbin "baserom.gba", 0x10382B4, 0x60
+sHoOhGfx19_3:
+.incbin "baserom.gba", 0x1038314, 0x200
+sHoOhGfx19_4:
+.incbin "baserom.gba", 0x1038514, 0xE0
+sHoOhGfx19_5:
+.incbin "baserom.gba", 0x10385F4, 0xE0
+sHoOhGfx19_6:
+.incbin "baserom.gba", 0x10386D4, 0xC0
+sHoOhGfx19_7:
+.incbin "baserom.gba", 0x1038794, 0x60
+sHoOhSprites19:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx19, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx19_3, 0x200
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx19_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx19_5, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx19_6, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx19_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx20:
+.incbin "baserom.gba", 0x1038884, 0x20
+sHoOhSprites20:
+ax_sprite sHoOhGfx20, 0x20
+ax_sprite_terminator
+sHoOhGfx21:
+.incbin "baserom.gba", 0x10388B4, 0x20
+sHoOhGfx21_1:
+.incbin "baserom.gba", 0x10388D4, 0x100
+sHoOhSprites21:
+ax_sprite 0, 0xc0
+ax_sprite sHoOhGfx21, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx21_1, 0x100
+ax_sprite_terminator
+sHoOhGfx22:
+.incbin "baserom.gba", 0x10389FC, 0xC0
+sHoOhSprites22:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx22, 0xc0
+ax_sprite_terminator
+sHoOhGfx23:
+.incbin "baserom.gba", 0x1038AD4, 0x200
+sHoOhGfx23_1:
+.incbin "baserom.gba", 0x1038CD4, 0xA0
+sHoOhGfx23_2:
+.incbin "baserom.gba", 0x1038D74, 0x60
+sHoOhSprites23:
+ax_sprite sHoOhGfx23, 0x200
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx23_1, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx24:
+.incbin "baserom.gba", 0x1038E0C, 0x100
+sHoOhSprites24:
+ax_sprite sHoOhGfx24, 0x100
+ax_sprite_terminator
+sHoOhGfx25:
+.incbin "baserom.gba", 0x1038F1C, 0x40
+sHoOhGfx25_1:
+.incbin "baserom.gba", 0x1038F5C, 0x60
+sHoOhSprites25:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx25_1, 0x60
+ax_sprite_terminator
+sHoOhGfx26:
+.incbin "baserom.gba", 0x1038FE4, 0xE0
+sHoOhGfx26_1:
+.incbin "baserom.gba", 0x10390C4, 0xE0
+sHoOhGfx26_2:
+.incbin "baserom.gba", 0x10391A4, 0xE0
+sHoOhGfx26_3:
+.incbin "baserom.gba", 0x1039284, 0x40
+sHoOhGfx26_4:
+.incbin "baserom.gba", 0x10392C4, 0x60
+sHoOhSprites26:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx26, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx26_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx26_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx26_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx27:
+.incbin "baserom.gba", 0x1039384, 0xE0
+sHoOhGfx27_1:
+.incbin "baserom.gba", 0x1039464, 0x60
+sHoOhGfx27_2:
+.incbin "baserom.gba", 0x10394C4, 0x60
+sHoOhGfx27_3:
+.incbin "baserom.gba", 0x1039524, 0xE0
+sHoOhGfx27_4:
+.incbin "baserom.gba", 0x1039604, 0xE0
+sHoOhGfx27_5:
+.incbin "baserom.gba", 0x10396E4, 0xE0
+sHoOhGfx27_6:
+.incbin "baserom.gba", 0x10397C4, 0xE0
+sHoOhGfx27_7:
+.incbin "baserom.gba", 0x10398A4, 0xC0
+sHoOhGfx27_8:
+.incbin "baserom.gba", 0x1039964, 0xA0
+sHoOhSprites27:
+ax_sprite sHoOhGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx27_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx27_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx27_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx27_6, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx27_7, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx27_8, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx28:
+.incbin "baserom.gba", 0x1039A9C, 0x20
+sHoOhSprites28:
+ax_sprite sHoOhGfx28, 0x20
+ax_sprite_terminator
+sHoOhGfx29:
+.incbin "baserom.gba", 0x1039ACC, 0x40
+sHoOhSprites29:
+ax_sprite sHoOhGfx29, 0x40
+ax_sprite_terminator
+sHoOhGfx30:
+.incbin "baserom.gba", 0x1039B1C, 0x40
+sHoOhGfx30_1:
+.incbin "baserom.gba", 0x1039B5C, 0xA0
+sHoOhSprites30:
+ax_sprite sHoOhGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx30_1, 0xa0
+ax_sprite_terminator
+sHoOhGfx31:
+.incbin "baserom.gba", 0x1039C1C, 0x20
+sHoOhGfx31_1:
+.incbin "baserom.gba", 0x1039C3C, 0xC0
+sHoOhSprites31:
+ax_sprite sHoOhGfx31, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx31_1, 0xc0
+ax_sprite_terminator
+sHoOhGfx32:
+.incbin "baserom.gba", 0x1039D1C, 0x200
+sHoOhGfx32_1:
+.incbin "baserom.gba", 0x1039F1C, 0xC0
+sHoOhGfx32_2:
+.incbin "baserom.gba", 0x1039FDC, 0x80
+sHoOhSprites32:
+ax_sprite sHoOhGfx32, 0x200
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx32_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx32_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx33:
+.incbin "baserom.gba", 0x103A094, 0x20
+sHoOhSprites33:
+ax_sprite sHoOhGfx33, 0x20
+ax_sprite_terminator
+sHoOhGfx34:
+.incbin "baserom.gba", 0x103A0C4, 0x20
+sHoOhGfx34_1:
+.incbin "baserom.gba", 0x103A0E4, 0x40
+sHoOhSprites34:
+ax_sprite sHoOhGfx34, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx34_1, 0x40
+ax_sprite_terminator
+sHoOhGfx35:
+.incbin "baserom.gba", 0x103A144, 0x40
+sHoOhGfx35_1:
+.incbin "baserom.gba", 0x103A184, 0x60
+sHoOhSprites35:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx35_1, 0x60
+ax_sprite_terminator
+sHoOhGfx36:
+.incbin "baserom.gba", 0x103A20C, 0xC0
+sHoOhGfx36_1:
+.incbin "baserom.gba", 0x103A2CC, 0xE0
+sHoOhGfx36_2:
+.incbin "baserom.gba", 0x103A3AC, 0xE0
+sHoOhGfx36_3:
+.incbin "baserom.gba", 0x103A48C, 0xE0
+sHoOhSprites36:
+ax_sprite sHoOhGfx36, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx36_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx36_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx36_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx37:
+.incbin "baserom.gba", 0x103A5B4, 0x300
+sHoOhGfx37_1:
+.incbin "baserom.gba", 0x103A8B4, 0x40
+sHoOhGfx37_2:
+.incbin "baserom.gba", 0x103A8F4, 0x40
+sHoOhSprites37:
+ax_sprite sHoOhGfx37, 0x300
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx37_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx37_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx38:
+.incbin "baserom.gba", 0x103A96C, 0x100
+sHoOhSprites38:
+ax_sprite sHoOhGfx38, 0x100
+ax_sprite_terminator
+sHoOhGfx39:
+.incbin "baserom.gba", 0x103AA7C, 0x80
+sHoOhGfx39_1:
+.incbin "baserom.gba", 0x103AAFC, 0x200
+sHoOhGfx39_2:
+.incbin "baserom.gba", 0x103ACFC, 0xE0
+sHoOhSprites39:
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx39, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx39_1, 0x200
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx39_2, 0xe0
+ax_sprite_terminator
+sHoOhGfx40:
+.incbin "baserom.gba", 0x103AE14, 0xC0
+sHoOhSprites40:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx40, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx41:
+.incbin "baserom.gba", 0x103AEF4, 0x80
+sHoOhGfx41_1:
+.incbin "baserom.gba", 0x103AF74, 0x20
+sHoOhSprites41:
+ax_sprite sHoOhGfx41, 0x80
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx41_1, 0x20
+ax_sprite_terminator
+sHoOhGfx42:
+.incbin "baserom.gba", 0x103AFB4, 0x20
+sHoOhSprites42:
+ax_sprite sHoOhGfx42, 0x20
+ax_sprite_terminator
+sHoOhGfx43:
+.incbin "baserom.gba", 0x103AFE4, 0x20
+sHoOhSprites43:
+ax_sprite sHoOhGfx43, 0x20
+ax_sprite_terminator
+sHoOhGfx44:
+.incbin "baserom.gba", 0x103B014, 0xA0
+sHoOhGfx44_1:
+.incbin "baserom.gba", 0x103B0B4, 0x220
+sHoOhGfx44_2:
+.incbin "baserom.gba", 0x103B2D4, 0xA0
+sHoOhSprites44:
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx44, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx44_1, 0x220
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx44_2, 0xa0
+ax_sprite_terminator
+sHoOhGfx45:
+.incbin "baserom.gba", 0x103B3AC, 0x80
+sHoOhSprites45:
+ax_sprite sHoOhGfx45, 0x80
+ax_sprite_terminator
+sHoOhGfx46:
+.incbin "baserom.gba", 0x103B43C, 0xA0
+sHoOhGfx46_1:
+.incbin "baserom.gba", 0x103B4DC, 0xE0
+sHoOhGfx46_2:
+.incbin "baserom.gba", 0x103B5BC, 0x1E0
+sHoOhSprites46:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx46, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx46_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx46_2, 0x1e0
+ax_sprite_terminator
+sHoOhGfx47:
+.incbin "baserom.gba", 0x103B7D4, 0x80
+sHoOhSprites47:
+ax_sprite sHoOhGfx47, 0x80
+ax_sprite_terminator
+sHoOhGfx48:
+.incbin "baserom.gba", 0x103B864, 0xE0
+sHoOhSprites48:
+ax_sprite sHoOhGfx48, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx49:
+.incbin "baserom.gba", 0x103B95C, 0x20
+sHoOhGfx49_1:
+.incbin "baserom.gba", 0x103B97C, 0x60
+sHoOhGfx49_2:
+.incbin "baserom.gba", 0x103B9DC, 0x60
+sHoOhGfx49_3:
+.incbin "baserom.gba", 0x103BA3C, 0x1E0
+sHoOhSprites49:
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx49, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx49_3, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx50:
+.incbin "baserom.gba", 0x103BC6C, 0x80
+sHoOhSprites50:
+ax_sprite sHoOhGfx50, 0x80
+ax_sprite_terminator
+sHoOhGfx51:
+.incbin "baserom.gba", 0x103BCFC, 0x100
+sHoOhSprites51:
+ax_sprite sHoOhGfx51, 0x100
+ax_sprite_terminator
+sHoOhGfx52:
+.incbin "baserom.gba", 0x103BE0C, 0xC0
+sHoOhGfx52_1:
+.incbin "baserom.gba", 0x103BECC, 0xC0
+sHoOhGfx52_2:
+.incbin "baserom.gba", 0x103BF8C, 0xC0
+sHoOhGfx52_3:
+.incbin "baserom.gba", 0x103C04C, 0x60
+sHoOhSprites52:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx52, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx52_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx52_2, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx52_3, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx53:
+.incbin "baserom.gba", 0x103C0FC, 0x200
+sHoOhSprites53:
+ax_sprite sHoOhGfx53, 0x200
+ax_sprite_terminator
+sHoOhGfx54:
+.incbin "baserom.gba", 0x103C30C, 0x80
+sHoOhGfx54_1:
+.incbin "baserom.gba", 0x103C38C, 0x20
+sHoOhSprites54:
+ax_sprite sHoOhGfx54, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx54_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx55:
+.incbin "baserom.gba", 0x103C3D4, 0x80
+sHoOhSprites55:
+ax_sprite sHoOhGfx55, 0x80
+ax_sprite_terminator
+sHoOhGfx56:
+.incbin "baserom.gba", 0x103C464, 0x80
+sHoOhSprites56:
+ax_sprite sHoOhGfx56, 0x80
+ax_sprite_terminator
+sHoOhGfx57:
+.incbin "baserom.gba", 0x103C4F4, 0xC0
+sHoOhGfx57_1:
+.incbin "baserom.gba", 0x103C5B4, 0xC0
+sHoOhGfx57_2:
+.incbin "baserom.gba", 0x103C674, 0xE0
+sHoOhGfx57_3:
+.incbin "baserom.gba", 0x103C754, 0xA0
+sHoOhSprites57:
+ax_sprite sHoOhGfx57, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx57_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx57_2, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx57_3, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx58:
+.incbin "baserom.gba", 0x103C83C, 0x80
+sHoOhSprites58:
+ax_sprite sHoOhGfx58, 0x80
+ax_sprite_terminator
+sHoOhGfx59:
+.incbin "baserom.gba", 0x103C8CC, 0xA0
+sHoOhGfx59_1:
+.incbin "baserom.gba", 0x103C96C, 0xE0
+sHoOhGfx59_2:
+.incbin "baserom.gba", 0x103CA4C, 0xE0
+sHoOhGfx59_3:
+.incbin "baserom.gba", 0x103CB2C, 0xE0
+sHoOhGfx59_4:
+.incbin "baserom.gba", 0x103CC0C, 0xC0
+sHoOhGfx59_5:
+.incbin "baserom.gba", 0x103CCCC, 0xE0
+sHoOhGfx59_6:
+.incbin "baserom.gba", 0x103CDAC, 0xE0
+sHoOhSprites59:
+ax_sprite sHoOhGfx59, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx59_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx59_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx59_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx59_4, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx59_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx59_6, 0xe0
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sHoOhGfx60:
+.incbin "baserom.gba", 0x103CF04, 0x60
+sHoOhGfx60_1:
+.incbin "baserom.gba", 0x103CF64, 0x80
+sHoOhGfx60_2:
+.incbin "baserom.gba", 0x103CFE4, 0xA0
+sHoOhGfx60_3:
+.incbin "baserom.gba", 0x103D084, 0xC0
+sHoOhSprites60:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx60, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx60_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx60_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx60_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx61:
+.incbin "baserom.gba", 0x103D194, 0x80
+sHoOhGfx61_1:
+.incbin "baserom.gba", 0x103D214, 0x60
+sHoOhSprites61:
+ax_sprite sHoOhGfx61, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx61_1, 0x60
+ax_sprite_terminator
+sHoOhGfx62:
+.incbin "baserom.gba", 0x103D294, 0x60
+sHoOhSprites62:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx62, 0x60
+ax_sprite_terminator
+sHoOhGfx63:
+.incbin "baserom.gba", 0x103D30C, 0x40
+sHoOhGfx63_1:
+.incbin "baserom.gba", 0x103D34C, 0x40
+sHoOhGfx63_2:
+.incbin "baserom.gba", 0x103D38C, 0x60
+sHoOhGfx63_3:
+.incbin "baserom.gba", 0x103D3EC, 0x60
+sHoOhGfx63_4:
+.incbin "baserom.gba", 0x103D44C, 0x260
+sHoOhGfx63_5:
+.incbin "baserom.gba", 0x103D6AC, 0xE0
+sHoOhGfx63_6:
+.incbin "baserom.gba", 0x103D78C, 0x40
+sHoOhGfx63_7:
+.incbin "baserom.gba", 0x103D7CC, 0x60
+sHoOhGfx63_8:
+.incbin "baserom.gba", 0x103D82C, 0x20
+sHoOhSprites63:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx63, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sHoOhGfx63_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx63_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx63_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx63_4, 0x260
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx63_5, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx63_6, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx63_7, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sHoOhGfx63_8, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx64:
+.incbin "baserom.gba", 0x103D8EC, 0x40
+sHoOhGfx64_1:
+.incbin "baserom.gba", 0x103D92C, 0xA0
+sHoOhGfx64_2:
+.incbin "baserom.gba", 0x103D9CC, 0xC0
+sHoOhGfx64_3:
+.incbin "baserom.gba", 0x103DA8C, 0xC0
+sHoOhGfx64_4:
+.incbin "baserom.gba", 0x103DB4C, 0xC0
+sHoOhGfx64_5:
+.incbin "baserom.gba", 0x103DC0C, 0xC0
+sHoOhGfx64_6:
+.incbin "baserom.gba", 0x103DCCC, 0x60
+sHoOhGfx64_7:
+.incbin "baserom.gba", 0x103DD2C, 0x80
+sHoOhSprites64:
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx64, 0x40
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx64_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx64_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx64_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx64_4, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx64_5, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx64_6, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx64_7, 0x80
+ax_sprite_terminator
+sHoOhGfx65:
+.incbin "baserom.gba", 0x103DE34, 0xA0
+sHoOhGfx65_1:
+.incbin "baserom.gba", 0x103DED4, 0x60
+sHoOhGfx65_2:
+.incbin "baserom.gba", 0x103DF34, 0x60
+sHoOhGfx65_3:
+.incbin "baserom.gba", 0x103DF94, 0x200
+sHoOhGfx65_4:
+.incbin "baserom.gba", 0x103E194, 0xE0
+sHoOhGfx65_5:
+.incbin "baserom.gba", 0x103E274, 0xE0
+sHoOhGfx65_6:
+.incbin "baserom.gba", 0x103E354, 0xC0
+sHoOhGfx65_7:
+.incbin "baserom.gba", 0x103E414, 0x60
+sHoOhSprites65:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx65, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx65_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx65_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx65_3, 0x200
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx65_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx65_5, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx65_6, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx65_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx66:
+.incbin "baserom.gba", 0x103E504, 0x60
+sHoOhGfx66_1:
+.incbin "baserom.gba", 0x103E564, 0x60
+sHoOhGfx66_2:
+.incbin "baserom.gba", 0x103E5C4, 0xE0
+sHoOhGfx66_3:
+.incbin "baserom.gba", 0x103E6A4, 0x80
+sHoOhGfx66_4:
+.incbin "baserom.gba", 0x103E724, 0x40
+sHoOhGfx66_5:
+.incbin "baserom.gba", 0x103E764, 0xE0
+sHoOhGfx66_6:
+.incbin "baserom.gba", 0x103E844, 0xA0
+sHoOhGfx66_7:
+.incbin "baserom.gba", 0x103E8E4, 0x60
+sHoOhGfx66_8:
+.incbin "baserom.gba", 0x103E944, 0x60
+sHoOhGfx66_9:
+.incbin "baserom.gba", 0x103E9A4, 0x60
+sHoOhSprites66:
+ax_sprite sHoOhGfx66, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx66_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx66_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx66_3, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx66_4, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx66_5, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx66_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sHoOhGfx66_7, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx66_8, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sHoOhGfx66_9, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sHoOhGfx67:
+.incbin "baserom.gba", 0x103EAAC, 0xE0
+sHoOhGfx67_1:
+.incbin "baserom.gba", 0x103EB8C, 0x60
+sHoOhGfx67_2:
+.incbin "baserom.gba", 0x103EBEC, 0x60
+sHoOhGfx67_3:
+.incbin "baserom.gba", 0x103EC4C, 0xE0
+sHoOhGfx67_4:
+.incbin "baserom.gba", 0x103ED2C, 0xE0
+sHoOhGfx67_5:
+.incbin "baserom.gba", 0x103EE0C, 0xE0
+sHoOhGfx67_6:
+.incbin "baserom.gba", 0x103EEEC, 0xE0
+sHoOhGfx67_7:
+.incbin "baserom.gba", 0x103EFCC, 0xC0
+sHoOhGfx67_8:
+.incbin "baserom.gba", 0x103F08C, 0xA0
+sHoOhSprites67:
+ax_sprite sHoOhGfx67, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx67_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx67_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx67_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx67_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx67_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx67_6, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx67_7, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx67_8, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx68:
+.incbin "baserom.gba", 0x103F1C4, 0x200
+sHoOhSprites68:
+ax_sprite sHoOhGfx68, 0x200
+ax_sprite_terminator
+sHoOhGfx69:
+.incbin "baserom.gba", 0x103F3D4, 0xE0
+sHoOhSprites69:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx69, 0xe0
+ax_sprite_terminator
+sHoOhGfx70:
+.incbin "baserom.gba", 0x103F4CC, 0x60
+sHoOhSprites70:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx70, 0x60
+ax_sprite_terminator
+sHoOhGfx71:
+.incbin "baserom.gba", 0x103F544, 0x20
+sHoOhSprites71:
+ax_sprite sHoOhGfx71, 0x20
+ax_sprite_terminator
+sHoOhGfx72:
+.incbin "baserom.gba", 0x103F574, 0x20
+sHoOhSprites72:
+ax_sprite sHoOhGfx72, 0x20
+ax_sprite_terminator
+sHoOhGfx73:
+.incbin "baserom.gba", 0x103F5A4, 0x40
+sHoOhSprites73:
+ax_sprite sHoOhGfx73, 0x40
+ax_sprite_terminator
+sHoOhGfx74:
+.incbin "baserom.gba", 0x103F5F4, 0x200
+sHoOhSprites74:
+ax_sprite sHoOhGfx74, 0x200
+ax_sprite_terminator
+sHoOhGfx75:
+.incbin "baserom.gba", 0x103F804, 0xE0
+sHoOhSprites75:
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx75, 0xe0
+ax_sprite_terminator
+sHoOhGfx76:
+.incbin "baserom.gba", 0x103F8FC, 0x20
+sHoOhSprites76:
+ax_sprite sHoOhGfx76, 0x20
+ax_sprite_terminator
+sHoOhGfx77:
+.incbin "baserom.gba", 0x103F92C, 0x40
+sHoOhSprites77:
+ax_sprite sHoOhGfx77, 0x40
+ax_sprite_terminator
+sHoOhGfx78:
+.incbin "baserom.gba", 0x103F97C, 0x20
+sHoOhSprites78:
+ax_sprite sHoOhGfx78, 0x20
+ax_sprite_terminator
+sHoOhGfx79:
+.incbin "baserom.gba", 0x103F9AC, 0x20
+sHoOhSprites79:
+ax_sprite sHoOhGfx79, 0x20
+ax_sprite_terminator
+sHoOhGfx80:
+.incbin "baserom.gba", 0x103F9DC, 0x40
+sHoOhGfx80_1:
+.incbin "baserom.gba", 0x103FA1C, 0x60
+sHoOhGfx80_2:
+.incbin "baserom.gba", 0x103FA7C, 0xE0
+sHoOhGfx80_3:
+.incbin "baserom.gba", 0x103FB5C, 0x400
+sHoOhGfx80_4:
+.incbin "baserom.gba", 0x103FF5C, 0xC0
+sHoOhGfx80_5:
+.incbin "baserom.gba", 0x104001C, 0xC0
+sHoOhSprites80:
+ax_sprite sHoOhGfx80, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx80_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx80_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx80_3, 0x400
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx80_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx80_5, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoOhGfx81:
+.incbin "baserom.gba", 0x1040144, 0x80
+sHoOhGfx81_1:
+.incbin "baserom.gba", 0x10401C4, 0x20
+sHoOhGfx81_2:
+.incbin "baserom.gba", 0x10401E4, 0xA0
+sHoOhGfx81_3:
+.incbin "baserom.gba", 0x1040284, 0x40
+sHoOhGfx81_4:
+.incbin "baserom.gba", 0x10402C4, 0xA0
+sHoOhGfx81_5:
+.incbin "baserom.gba", 0x1040364, 0x500
+sHoOhSprites81:
+ax_sprite sHoOhGfx81, 0x80
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx81_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx81_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx81_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx81_4, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx81_5, 0x500
+ax_sprite_terminator
+sHoOhGfx82:
+.incbin "baserom.gba", 0x10408C4, 0x40
+sHoOhGfx82_1:
+.incbin "baserom.gba", 0x1040904, 0xC0
+sHoOhGfx82_2:
+.incbin "baserom.gba", 0x10409C4, 0x20
+sHoOhGfx82_3:
+.incbin "baserom.gba", 0x10409E4, 0xA0
+sHoOhGfx82_4:
+.incbin "baserom.gba", 0x1040A84, 0x3E0
+sHoOhGfx82_5:
+.incbin "baserom.gba", 0x1040E64, 0x80
+sHoOhSprites82:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx82, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sHoOhGfx82_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx82_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx82_3, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx82_4, 0x3e0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx82_5, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sHoOhGfx83:
+.incbin "baserom.gba", 0x1040F54, 0xC0
+sHoOhGfx83_1:
+.incbin "baserom.gba", 0x1041014, 0x2A0
+sHoOhGfx83_2:
+.incbin "baserom.gba", 0x10412B4, 0xE0
+sHoOhGfx83_3:
+.incbin "baserom.gba", 0x1041394, 0xC0
+sHoOhGfx83_4:
+.incbin "baserom.gba", 0x1041454, 0xE0
+sHoOhGfx83_5:
+.incbin "baserom.gba", 0x1041534, 0xA0
+sHoOhSprites83:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx83, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx83_1, 0x2a0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx83_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx83_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx83_4, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx83_5, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoOhGfx84:
+.incbin "baserom.gba", 0x1041644, 0x40
+sHoOhGfx84_1:
+.incbin "baserom.gba", 0x1041684, 0x20
+sHoOhGfx84_2:
+.incbin "baserom.gba", 0x10416A4, 0x20
+sHoOhGfx84_3:
+.incbin "baserom.gba", 0x10416C4, 0x20
+sHoOhGfx84_4:
+.incbin "baserom.gba", 0x10416E4, 0x3E0
+sHoOhGfx84_5:
+.incbin "baserom.gba", 0x1041AC4, 0xE0
+sHoOhGfx84_6:
+.incbin "baserom.gba", 0x1041BA4, 0xE0
+sHoOhSprites84:
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx84, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoOhGfx84_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx84_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHoOhGfx84_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx84_4, 0x3e0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx84_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoOhGfx84_6, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAxPosesHoOh:
+.4byte sHoOhPose1
+.4byte sHoOhPose2
+.4byte sHoOhPose3
+.4byte sHoOhPose4
+.4byte sHoOhPose5
+.4byte sHoOhPose6
+.4byte sHoOhPose7
+.4byte sHoOhPose8
+.4byte sHoOhPose9
+.4byte sHoOhPose10
+.4byte sHoOhPose11
+.4byte sHoOhPose12
+.4byte sHoOhPose13
+.4byte sHoOhPose14
+.4byte sHoOhPose15
+.4byte sHoOhPose16
+.4byte sHoOhPose17
+.4byte sHoOhPose18
+.4byte sHoOhPose19
+.4byte sHoOhPose20
+.4byte sHoOhPose21
+.4byte sHoOhPose22
+.4byte sHoOhPose23
+.4byte sHoOhPose24
+.4byte sHoOhPose25
+.4byte sHoOhPose26
+.4byte sHoOhPose27
+.4byte sHoOhPose28
+.4byte sHoOhPose29
+.4byte sHoOhPose30
+.4byte sHoOhPose31
+.4byte sHoOhPose32
+.4byte sHoOhPose33
+.4byte sHoOhPose34
+.4byte sHoOhPose35
+.4byte sHoOhPose36
+.4byte sHoOhPose37
+.4byte sHoOhPose38
+.4byte sHoOhPose39
+.4byte sHoOhPose40
+.4byte sHoOhPose41
+.4byte sHoOhPose42
+.4byte sHoOhPose43
+.4byte sHoOhPose44
+.4byte sHoOhPose45
+.4byte sHoOhPose46
+.4byte sHoOhPose47
+.4byte sHoOhPose48
+.4byte sHoOhPose49
+.4byte sHoOhPose50
+.4byte sHoOhPose51
+.4byte sHoOhPose52
+.4byte sHoOhPose53
+.4byte sHoOhPose54
+.4byte sHoOhPose55
+.4byte sHoOhPose56
+.4byte sHoOhPose57
+.4byte sHoOhPose58
+.4byte sHoOhPose59
+.4byte sHoOhPose60
+.4byte sHoOhPose61
+.4byte sHoOhPose62
+.4byte sHoOhPose63
+.4byte sHoOhPose64
+.4byte sHoOhPose65
+.4byte sHoOhPose66
+.4byte sHoOhPose67
+.4byte sHoOhPose68
+.4byte sHoOhPose69
+.4byte sHoOhPose70
+.4byte sHoOhPose71
+.4byte sHoOhPose72
+.4byte sHoOhPose73
+.4byte sHoOhPose74
+.4byte sHoOhPose75
+.4byte sHoOhPose76
+.4byte sHoOhPose77
+.4byte sHoOhPose78
+.4byte sHoOhPose79
+.4byte sHoOhPose80
+.4byte sHoOhPose81
+.4byte sHoOhPose82
+.4byte sHoOhPose83
+.4byte sHoOhPose84
+.4byte sHoOhPose85
+.4byte sHoOhPose86
+.4byte sHoOhPose87
+.4byte sHoOhPose88
+.4byte sHoOhPose89
+.4byte sHoOhPose90
+.4byte sHoOhPose91
+.4byte sHoOhPose92
+.4byte sHoOhPose93
+.4byte sHoOhPose94
+.4byte sHoOhPose95
+.4byte sHoOhPose96
+.4byte sHoOhPose97
+.4byte sHoOhPose98
+.4byte sHoOhPose99
+.4byte sHoOhPose100
+.4byte sHoOhPose101
+.4byte sHoOhPose102
+.4byte sHoOhPose103
+.4byte sHoOhPose104
+.4byte sHoOhPose105
+.4byte sHoOhPose106
+.4byte sHoOhPose107
+.4byte sHoOhPose108
+.4byte sHoOhPose109
+.4byte sHoOhPose110
+.4byte sHoOhPose111
+.4byte sHoOhPose112
+.4byte sHoOhPose113
+.4byte sHoOhPose114
+.4byte sHoOhPose115
+.4byte sHoOhPose116
+.4byte sHoOhPose117
+.4byte sHoOhPose118
+.4byte sHoOhPose119
+.4byte sHoOhPose120
+.4byte sHoOhPose121
+.4byte sHoOhPose122
+.4byte sHoOhPose123
+.4byte sHoOhPose124
+.4byte sHoOhPose125
+.4byte sHoOhPose126
+.4byte sHoOhPose127
+.4byte sHoOhPose128
+.4byte sHoOhPose129
+.4byte sHoOhPose130
+.4byte sHoOhPose131
+.4byte sHoOhPose132
+.4byte sHoOhPose133
+.4byte sHoOhPose134
+.4byte sHoOhPose135
+.4byte sHoOhPose136
+.4byte sHoOhPose137
+.4byte sHoOhPose138
+.4byte sHoOhPose139
+.4byte sHoOhPose140
+.4byte sHoOhPose141
+.4byte sHoOhPose142
+.4byte sHoOhPose143
+.4byte sHoOhPose144
+.4byte sHoOhPose145
+.4byte sHoOhPose146
+.4byte sHoOhPose147
+.4byte sHoOhPose148
+.4byte sHoOhPose149
+.4byte sHoOhPose150
+.4byte sHoOhPose151
+.4byte sHoOhPose152
+.4byte sHoOhPose153
+.4byte sHoOhPose154
+.4byte sHoOhPose155
+.4byte sHoOhPose156
+.4byte sHoOhPose157
+.4byte sHoOhPose158
+.4byte sHoOhPose159
+.4byte sHoOhPose160
+.4byte sHoOhPose161
+.4byte sHoOhPose162
+.4byte sHoOhPose163
+.4byte sHoOhPose164
+.4byte sHoOhPose165
+.4byte sHoOhPose166
+.4byte sHoOhPose167
+.4byte sHoOhPose168
+.4byte sHoOhPose169
+.4byte sHoOhPose170
+.4byte sHoOhPose171
+.4byte sHoOhPose172
+.4byte sHoOhPose173
+.4byte sHoOhPose174
+.4byte sHoOhPose175
+.4byte sHoOhPose176
+.4byte sHoOhPose177
+.4byte sHoOhPose178
+.4byte sHoOhPose179
+.4byte sHoOhPose180
+.4byte sHoOhPose181
+.4byte sHoOhPose182
+.4byte sHoOhPose183
+.4byte sHoOhPose184
+.4byte sHoOhPose185
+.4byte sHoOhPose186
+.4byte sHoOhPose187
+.4byte sHoOhPose188
+.4byte sHoOhPose189
+.4byte sHoOhPose190
+.4byte sHoOhPose191
+.4byte sHoOhPose192
+.4byte sHoOhPose193
+.4byte sHoOhPose194
+.4byte sHoOhPose195
+.4byte sHoOhPose196
+.4byte sHoOhPose197
+.4byte sHoOhPose198
+.4byte sHoOhPose199
+.4byte sHoOhPose200
+.4byte sHoOhPose201
+.4byte sHoOhPose202
+.4byte sHoOhPose203
+.4byte sHoOhPose204
+.4byte sHoOhPose205
+.4byte sHoOhPose206
+.4byte sHoOhPose207
+.4byte sHoOhPose208
+.4byte sHoOhPose209
+.4byte sHoOhPose210
+.4byte sHoOhPose211
+.4byte sHoOhPose212
+.4byte sHoOhPose213
+.4byte sHoOhPose214
+.4byte sHoOhPose215
+.4byte sHoOhPose216
+.4byte sHoOhPose217
+.4byte sHoOhPose218
+.4byte sHoOhPose219
+.4byte sHoOhPose220
+.4byte sHoOhPose221
+.4byte sHoOhPose222
+.4byte sHoOhPose223
+.4byte sHoOhPose224
+.4byte sHoOhPose225
+.4byte sHoOhPose226
+.4byte sHoOhPose227
+.4byte sHoOhPose228
+.4byte sHoOhPose229
+.4byte sHoOhPose230
+.4byte sHoOhPose231
+.4byte sHoOhPose232
+.4byte sHoOhPose233
+.4byte sHoOhPose234
+.4byte sHoOhPose235
+.4byte sHoOhPose236
+.4byte sHoOhPose237
+.4byte sHoOhPose238
+.4byte sHoOhPose239
+.4byte sHoOhPose240
+.4byte sHoOhPose241
+.4byte sHoOhPose242
+sAxPositionsHoOh:
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte   -1,   -6, 	 -28,  -31, 	  26,  -31, 	  -1,  -24
+.2byte   -1,   -9, 	 -21,   -7, 	  19,   -7, 	  -1,  -23
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   14,  -11, 	 -29,  -22, 	  21,  -35, 	   0,  -24
+.2byte   13,  -14, 	 -18,   -3, 	  19,   -9, 	   0,  -25
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   18,  -20, 	   1,  -30, 	   7,  -35, 	  -4,  -24
+.2byte   18,  -23, 	  -7,   -4, 	   4,   -8, 	  -2,  -26
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   12,  -26, 	  25,  -27, 	 -21,  -37, 	  -2,  -26
+.2byte   12,  -28, 	  13,   -3, 	 -18,  -11, 	  -1,  -26
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   -1,  -30, 	  26,  -29, 	 -28,  -29, 	  -1,  -21
+.2byte   -1,  -32, 	  21,    0, 	 -23,    0, 	  -1,  -21
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte  -14,  -26, 	  19,  -37, 	 -27,  -27, 	   0,  -26
+.2byte  -13,  -28, 	  17,  -11, 	 -14,   -3, 	   0,  -26
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -20,  -20, 	  -9,  -35, 	  -3,  -30, 	   2,  -24
+.2byte  -20,  -23, 	  -6,   -8, 	   5,   -4, 	   0,  -26
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -16,  -11, 	 -23,  -35, 	  27,  -22, 	  -2,  -24
+.2byte  -15,  -14, 	 -21,   -9, 	  16,   -3, 	  -2,  -25
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte   -1,   -6, 	 -28,  -31, 	  26,  -31, 	  -1,  -24
+.2byte   -1,   -9, 	 -21,   -7, 	  19,   -7, 	  -1,  -23
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   14,  -11, 	 -29,  -22, 	  21,  -35, 	   0,  -24
+.2byte   13,  -14, 	 -18,   -3, 	  19,   -9, 	   0,  -25
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   18,  -20, 	   1,  -30, 	   7,  -35, 	  -4,  -24
+.2byte   18,  -23, 	  -7,   -4, 	   4,   -8, 	  -2,  -26
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   12,  -26, 	  25,  -27, 	 -21,  -37, 	  -2,  -26
+.2byte   12,  -28, 	  13,   -3, 	 -18,  -11, 	  -1,  -26
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   -1,  -30, 	  26,  -29, 	 -28,  -29, 	  -1,  -21
+.2byte   -1,  -32, 	  21,    0, 	 -23,    0, 	  -1,  -21
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte  -14,  -26, 	  19,  -37, 	 -27,  -27, 	   0,  -26
+.2byte  -13,  -28, 	  17,  -11, 	 -14,   -3, 	   0,  -26
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -20,  -20, 	  -9,  -35, 	  -3,  -30, 	   2,  -24
+.2byte  -20,  -23, 	  -6,   -8, 	   5,   -4, 	   0,  -26
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -16,  -11, 	 -23,  -35, 	  27,  -22, 	  -2,  -24
+.2byte  -15,  -14, 	 -21,   -9, 	  16,   -3, 	  -2,  -25
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte   -1,   -6, 	 -28,  -31, 	  26,  -31, 	  -1,  -24
+.2byte   -1,   -9, 	 -21,   -7, 	  19,   -7, 	  -1,  -23
+.2byte   -1,    3, 	 -33,  -22, 	  31,  -22, 	  -1,  -22
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   14,  -11, 	 -29,  -22, 	  21,  -35, 	   0,  -24
+.2byte   13,  -14, 	 -18,   -3, 	  19,   -9, 	   0,  -25
+.2byte   17,   -4, 	 -29,  -12, 	  20,  -32, 	  -1,  -22
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   18,  -20, 	   1,  -30, 	   7,  -35, 	  -4,  -24
+.2byte   18,  -23, 	  -7,   -4, 	   4,   -8, 	  -2,  -26
+.2byte   21,  -18, 	  -2,   -4, 	   0,  -37, 	  -2,  -22
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   12,  -26, 	  25,  -27, 	 -21,  -37, 	  -2,  -26
+.2byte   12,  -28, 	  13,   -3, 	 -18,  -11, 	  -1,  -26
+.2byte   18,  -30, 	  22,   -9, 	 -19,  -32, 	  -1,  -23
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   -1,  -30, 	  26,  -29, 	 -28,  -29, 	  -1,  -21
+.2byte   -1,  -32, 	  21,    0, 	 -23,    0, 	  -1,  -21
+.2byte   -1,  -33, 	 -33,  -23, 	  31,  -23, 	  -1,  -23
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte  -14,  -26, 	  19,  -37, 	 -27,  -27, 	   0,  -26
+.2byte  -13,  -28, 	  17,  -11, 	 -14,   -3, 	   0,  -26
+.2byte  -19,  -30, 	  18,  -32, 	 -23,   -9, 	   0,  -23
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -20,  -20, 	  -9,  -35, 	  -3,  -30, 	   2,  -24
+.2byte  -20,  -23, 	  -6,   -8, 	   5,   -4, 	   0,  -26
+.2byte  -22,  -18, 	  -1,  -37, 	   1,   -4, 	   1,  -22
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -16,  -11, 	 -23,  -35, 	  27,  -22, 	  -2,  -24
+.2byte  -15,  -14, 	 -21,   -9, 	  16,   -3, 	  -2,  -25
+.2byte  -18,   -4, 	 -21,  -32, 	  28,  -12, 	   0,  -22
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte   -1,   -6, 	 -28,  -31, 	  26,  -31, 	  -1,  -24
+.2byte   -1,   -9, 	 -21,   -7, 	  19,   -7, 	  -1,  -23
+.2byte   -1,  -23, 	 -14,  -35, 	  12,  -35, 	  -1,  -24
+.2byte   -1,   -3, 	 -12,  -47, 	  10,  -47, 	  -1,  -22
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   14,  -11, 	 -29,  -22, 	  21,  -35, 	   0,  -24
+.2byte   13,  -14, 	 -18,   -3, 	  19,   -9, 	   0,  -25
+.2byte    3,  -26, 	 -10,  -36, 	  15,  -42, 	  -1,  -26
+.2byte   13,  -12, 	  -3,  -46, 	  14,  -51, 	  -3,  -24
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   18,  -20, 	   1,  -30, 	   7,  -35, 	  -4,  -24
+.2byte   18,  -23, 	  -7,   -4, 	   4,   -8, 	  -2,  -26
+.2byte    4,  -26, 	  12,  -25, 	  13,  -39, 	  -2,  -24
+.2byte   18,  -20, 	   5,  -44, 	   5,  -51, 	  -4,  -22
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   12,  -26, 	  25,  -27, 	 -21,  -37, 	  -2,  -26
+.2byte   12,  -28, 	  13,   -3, 	 -18,  -11, 	  -1,  -26
+.2byte    3,  -34, 	  13,  -42, 	  -6,  -48, 	  -6,  -26
+.2byte   10,  -28, 	  12,  -49, 	  -4,  -52, 	   0,  -25
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   -1,  -30, 	  26,  -29, 	 -28,  -29, 	  -1,  -21
+.2byte   -1,  -32, 	  21,    0, 	 -23,    0, 	  -1,  -21
+.2byte   -1,  -33, 	  12,  -42, 	 -13,  -42, 	  -1,  -22
+.2byte   -1,  -31, 	  11,  -50, 	 -13,  -50, 	  -1,  -24
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte  -14,  -26, 	  19,  -37, 	 -27,  -27, 	   0,  -26
+.2byte  -13,  -28, 	  17,  -11, 	 -14,   -3, 	   0,  -26
+.2byte   -5,  -34, 	   4,  -48, 	 -15,  -42, 	   4,  -26
+.2byte  -12,  -28, 	   2,  -52, 	 -14,  -49, 	  -2,  -25
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -20,  -20, 	  -9,  -35, 	  -3,  -30, 	   2,  -24
+.2byte  -20,  -23, 	  -6,   -8, 	   5,   -4, 	   0,  -26
+.2byte   -5,  -26, 	 -14,  -39, 	 -13,  -25, 	   1,  -24
+.2byte  -20,  -20, 	  -7,  -51, 	  -7,  -44, 	   2,  -22
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -16,  -11, 	 -23,  -35, 	  27,  -22, 	  -2,  -24
+.2byte  -15,  -14, 	 -21,   -9, 	  16,   -3, 	  -2,  -25
+.2byte   -4,  -26, 	 -16,  -42, 	   9,  -36, 	   0,  -26
+.2byte  -15,  -12, 	 -16,  -51, 	   1,  -46, 	   1,  -24
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte   -1,   -6, 	 -28,  -31, 	  26,  -31, 	  -1,  -24
+.2byte   -1,   -9, 	 -21,   -7, 	  19,   -7, 	  -1,  -23
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   14,  -11, 	 -29,  -22, 	  21,  -35, 	   0,  -24
+.2byte   13,  -14, 	 -18,   -3, 	  19,   -9, 	   0,  -25
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   18,  -20, 	   1,  -30, 	   7,  -35, 	  -4,  -24
+.2byte   18,  -23, 	  -7,   -4, 	   4,   -8, 	  -2,  -26
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   12,  -26, 	  25,  -27, 	 -21,  -37, 	  -2,  -26
+.2byte   12,  -28, 	  13,   -3, 	 -18,  -11, 	  -1,  -26
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   -1,  -30, 	  26,  -29, 	 -28,  -29, 	  -1,  -21
+.2byte   -1,  -32, 	  21,    0, 	 -23,    0, 	  -1,  -21
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte  -14,  -26, 	  19,  -37, 	 -27,  -27, 	   0,  -26
+.2byte  -13,  -28, 	  17,  -11, 	 -14,   -3, 	   0,  -26
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -20,  -20, 	  -9,  -35, 	  -3,  -30, 	   2,  -24
+.2byte  -20,  -23, 	  -6,   -8, 	   5,   -4, 	   0,  -26
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -16,  -11, 	 -23,  -35, 	  27,  -22, 	  -2,  -24
+.2byte  -15,  -14, 	 -21,   -9, 	  16,   -3, 	  -2,  -25
+.2byte  -20,    0, 	   0,  -17, 	   4,  -16, 	  -2,  -12
+.2byte  -20,    4, 	   0,  -17, 	   4,  -16, 	  -2,  -12
+.2byte    0,  -53, 	 -14,  -46, 	  14,  -46, 	   0,  -26
+.2byte  -14,  -44, 	 -34,  -28, 	  -6,  -56, 	  -1,  -30
+.2byte  -11,  -40, 	 -29,  -24, 	 -25,  -41, 	   2,  -26
+.2byte  -10,  -39, 	  -1,  -48, 	 -23,  -47, 	   0,  -23
+.2byte    0,  -39, 	  19,  -37, 	 -19,  -37, 	   0,  -22
+.2byte    9,  -39, 	  22,  -47, 	   0,  -48, 	  -1,  -23
+.2byte    9,  -40, 	  23,  -41, 	  27,  -24, 	  -4,  -26
+.2byte   13,  -44, 	   5,  -56, 	  33,  -28, 	   0,  -30
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte   -1,   -6, 	 -28,  -31, 	  26,  -31, 	  -1,  -24
+.2byte   -1,   -9, 	 -21,   -7, 	  19,   -7, 	  -1,  -23
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   14,  -11, 	 -29,  -22, 	  21,  -35, 	   0,  -24
+.2byte   13,  -14, 	 -18,   -3, 	  19,   -9, 	   0,  -25
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   18,  -20, 	   1,  -30, 	   7,  -35, 	  -4,  -24
+.2byte   18,  -23, 	  -7,   -4, 	   4,   -8, 	  -2,  -26
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   12,  -26, 	  25,  -27, 	 -21,  -37, 	  -2,  -26
+.2byte   12,  -28, 	  13,   -3, 	 -18,  -11, 	  -1,  -26
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   -1,  -30, 	  26,  -29, 	 -28,  -29, 	  -1,  -21
+.2byte   -1,  -32, 	  21,    0, 	 -23,    0, 	  -1,  -21
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte  -14,  -26, 	  19,  -37, 	 -27,  -27, 	   0,  -26
+.2byte  -13,  -28, 	  17,  -11, 	 -14,   -3, 	   0,  -26
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -20,  -20, 	  -9,  -35, 	  -3,  -30, 	   2,  -24
+.2byte  -20,  -23, 	  -6,   -8, 	   5,   -4, 	   0,  -26
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -16,  -11, 	 -23,  -35, 	  27,  -22, 	  -2,  -24
+.2byte  -15,  -14, 	 -21,   -9, 	  16,   -3, 	  -2,  -25
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   -1,   -3, 	 -12,  -47, 	  10,  -47, 	  -1,  -22
+.2byte   13,  -12, 	  -3,  -46, 	  14,  -51, 	  -3,  -24
+.2byte   18,  -20, 	   5,  -44, 	   5,  -51, 	  -4,  -22
+.2byte   10,  -28, 	  12,  -49, 	  -4,  -52, 	   0,  -25
+.2byte   -1,  -31, 	  11,  -50, 	 -13,  -50, 	  -1,  -24
+.2byte  -12,  -28, 	   2,  -52, 	 -14,  -49, 	  -2,  -25
+.2byte  -20,  -20, 	  -7,  -51, 	  -7,  -44, 	   2,  -22
+.2byte  -15,  -12, 	 -16,  -51, 	   1,  -46, 	   1,  -24
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte   -1,   -6, 	 -28,  -31, 	  26,  -31, 	  -1,  -24
+.2byte   -1,   -9, 	 -21,   -7, 	  19,   -7, 	  -1,  -23
+.2byte   -1,  -21, 	 -14,  -33, 	  12,  -33, 	  -1,  -22
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+.2byte   14,  -11, 	 -29,  -22, 	  21,  -35, 	   0,  -24
+.2byte   13,  -14, 	 -18,   -3, 	  19,   -9, 	   0,  -25
+.2byte    3,  -24, 	 -10,  -34, 	  15,  -40, 	  -1,  -24
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   18,  -20, 	   1,  -30, 	   7,  -35, 	  -4,  -24
+.2byte   18,  -23, 	  -7,   -4, 	   4,   -8, 	  -2,  -26
+.2byte    4,  -15, 	  12,  -14, 	  13,  -28, 	  -2,  -13
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   12,  -26, 	  25,  -27, 	 -21,  -37, 	  -2,  -26
+.2byte   12,  -28, 	  13,   -3, 	 -18,  -11, 	  -1,  -26
+.2byte    3,  -18, 	  13,  -26, 	  -6,  -32, 	  -6,  -10
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   -1,  -30, 	  26,  -29, 	 -28,  -29, 	  -1,  -21
+.2byte   -1,  -32, 	  21,    0, 	 -23,    0, 	  -1,  -21
+.2byte   -1,  -18, 	  12,  -27, 	 -13,  -27, 	  -1,   -7
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte  -14,  -26, 	  19,  -37, 	 -27,  -27, 	   0,  -26
+.2byte  -13,  -28, 	  17,  -11, 	 -14,   -3, 	   0,  -26
+.2byte   -4,  -18, 	   5,  -32, 	 -14,  -26, 	   5,  -10
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -20,  -20, 	  -9,  -35, 	  -3,  -30, 	   2,  -24
+.2byte  -20,  -23, 	  -6,   -8, 	   5,   -4, 	   0,  -26
+.2byte   -5,  -15, 	 -14,  -28, 	 -13,  -14, 	   1,  -13
+.2byte  -15,   -9, 	 -15,  -50, 	   2,  -46, 	  -1,  -23
+.2byte  -15,  -11, 	 -22,  -35, 	  28,  -22, 	  -1,  -24
+.2byte  -14,  -14, 	 -20,   -9, 	  17,   -3, 	  -1,  -25
+.2byte   -4,  -24, 	 -16,  -40, 	   9,  -34, 	   0,  -24
+.2byte   -1,   -3, 	 -12,  -47, 	  10,  -47, 	  -1,  -22
+.2byte   13,  -12, 	  -3,  -46, 	  14,  -51, 	  -3,  -24
+.2byte   18,  -20, 	   5,  -44, 	   5,  -51, 	  -4,  -22
+.2byte   10,  -28, 	  12,  -49, 	  -4,  -52, 	   0,  -25
+.2byte   -1,  -31, 	  11,  -50, 	 -13,  -50, 	  -1,  -24
+.2byte  -12,  -28, 	   2,  -52, 	 -14,  -49, 	  -2,  -25
+.2byte  -20,  -20, 	  -7,  -51, 	  -7,  -44, 	   2,  -22
+.2byte  -15,  -12, 	 -16,  -51, 	   1,  -46, 	   1,  -24
+.2byte   -1,   -4, 	 -12,  -47, 	  10,  -47, 	  -1,  -20
+.2byte  -16,   -9, 	 -16,  -50, 	   1,  -46, 	  -2,  -23
+.2byte  -20,  -18, 	  -7,  -51, 	  -6,  -44, 	   0,  -22
+.2byte  -15,  -26, 	   5,  -49, 	 -15,  -48, 	  -1,  -25
+.2byte   -1,  -29, 	  11,  -50, 	 -12,  -50, 	  -1,  -21
+.2byte   13,  -26, 	  13,  -48, 	  -7,  -49, 	  -1,  -25
+.2byte   18,  -18, 	   4,  -44, 	   5,  -51, 	  -2,  -22
+.2byte   14,   -9, 	  -3,  -46, 	  14,  -50, 	   0,  -23
+sHoOhAnimTable1:
+.4byte sHoOhAnims_1_1
+.4byte sHoOhAnims_1_2
+.4byte sHoOhAnims_1_3
+.4byte sHoOhAnims_1_4
+.4byte sHoOhAnims_1_5
+.4byte sHoOhAnims_1_6
+.4byte sHoOhAnims_1_7
+.4byte sHoOhAnims_1_8
+sHoOhAnimTable2:
+.4byte sHoOhAnims_2_1
+.4byte sHoOhAnims_2_2
+.4byte sHoOhAnims_2_3
+.4byte sHoOhAnims_2_4
+.4byte sHoOhAnims_2_5
+.4byte sHoOhAnims_2_6
+.4byte sHoOhAnims_2_7
+.4byte sHoOhAnims_2_8
+sHoOhAnimTable3:
+.4byte sHoOhAnims_3_1
+.4byte sHoOhAnims_3_2
+.4byte sHoOhAnims_3_3
+.4byte sHoOhAnims_3_4
+.4byte sHoOhAnims_3_5
+.4byte sHoOhAnims_3_6
+.4byte sHoOhAnims_3_7
+.4byte sHoOhAnims_3_8
+sHoOhAnimTable4:
+.4byte sHoOhAnims_4_1
+.4byte sHoOhAnims_4_2
+.4byte sHoOhAnims_4_3
+.4byte sHoOhAnims_4_4
+.4byte sHoOhAnims_4_5
+.4byte sHoOhAnims_4_6
+.4byte sHoOhAnims_4_7
+.4byte sHoOhAnims_4_8
+sHoOhAnimTable5:
+.4byte sHoOhAnims_5_1
+.4byte sHoOhAnims_5_2
+.4byte sHoOhAnims_5_3
+.4byte sHoOhAnims_5_4
+.4byte sHoOhAnims_5_5
+.4byte sHoOhAnims_5_6
+.4byte sHoOhAnims_5_7
+.4byte sHoOhAnims_5_8
+sHoOhAnimTable6:
+.4byte sHoOhAnims_6_1
+.4byte sHoOhAnims_6_1
+.4byte sHoOhAnims_6_1
+.4byte sHoOhAnims_6_1
+.4byte sHoOhAnims_6_1
+.4byte sHoOhAnims_6_1
+.4byte sHoOhAnims_6_1
+.4byte sHoOhAnims_6_1
+sHoOhAnimTable7:
+.4byte sHoOhAnims_7_1
+.4byte sHoOhAnims_7_2
+.4byte sHoOhAnims_7_3
+.4byte sHoOhAnims_7_4
+.4byte sHoOhAnims_7_5
+.4byte sHoOhAnims_7_6
+.4byte sHoOhAnims_7_7
+.4byte sHoOhAnims_7_8
+sHoOhAnimTable8:
+.4byte sHoOhAnims_8_1
+.4byte sHoOhAnims_8_2
+.4byte sHoOhAnims_8_3
+.4byte sHoOhAnims_8_4
+.4byte sHoOhAnims_8_5
+.4byte sHoOhAnims_8_6
+.4byte sHoOhAnims_8_7
+.4byte sHoOhAnims_8_8
+sHoOhAnimTable9:
+.4byte sHoOhAnims_9_1
+.4byte sHoOhAnims_9_2
+.4byte sHoOhAnims_9_3
+.4byte sHoOhAnims_9_4
+.4byte sHoOhAnims_9_5
+.4byte sHoOhAnims_9_6
+.4byte sHoOhAnims_9_7
+.4byte sHoOhAnims_9_8
+sHoOhAnimTable10:
+.4byte sHoOhAnims_10_1
+.4byte sHoOhAnims_10_2
+.4byte sHoOhAnims_10_3
+.4byte sHoOhAnims_10_4
+.4byte sHoOhAnims_10_5
+.4byte sHoOhAnims_10_6
+.4byte sHoOhAnims_10_7
+.4byte sHoOhAnims_10_8
+sHoOhAnimTable11:
+.4byte sHoOhAnims_11_1
+.4byte sHoOhAnims_11_2
+.4byte sHoOhAnims_11_3
+.4byte sHoOhAnims_11_4
+.4byte sHoOhAnims_11_5
+.4byte sHoOhAnims_11_6
+.4byte sHoOhAnims_11_7
+.4byte sHoOhAnims_11_8
+sHoOhAnimTable12:
+.4byte sHoOhAnims_12_1
+.4byte sHoOhAnims_12_2
+.4byte sHoOhAnims_12_3
+.4byte sHoOhAnims_12_4
+.4byte sHoOhAnims_12_5
+.4byte sHoOhAnims_12_6
+.4byte sHoOhAnims_12_7
+.4byte sHoOhAnims_12_8
+sHoOhAnimTable13:
+.4byte sHoOhAnims_13_1
+.4byte sHoOhAnims_13_2
+.4byte sHoOhAnims_13_3
+.4byte sHoOhAnims_13_4
+.4byte sHoOhAnims_13_5
+.4byte sHoOhAnims_13_6
+.4byte sHoOhAnims_13_7
+.4byte sHoOhAnims_13_8
+sAxAnimationsHoOh:
+.4byte sHoOhAnimTable1
+.4byte sHoOhAnimTable2
+.4byte sHoOhAnimTable3
+.4byte sHoOhAnimTable4
+.4byte sHoOhAnimTable5
+.4byte sHoOhAnimTable6
+.4byte sHoOhAnimTable7
+.4byte sHoOhAnimTable8
+.4byte sHoOhAnimTable9
+.4byte sHoOhAnimTable10
+.4byte sHoOhAnimTable11
+.4byte sHoOhAnimTable12
+.4byte sHoOhAnimTable13
+sAxSpritesHoOh:
+.4byte sHoOhSprites1
+.4byte sHoOhSprites2
+.4byte sHoOhSprites3
+.4byte sHoOhSprites4
+.4byte sHoOhSprites5
+.4byte sHoOhSprites6
+.4byte sHoOhSprites7
+.4byte sHoOhSprites8
+.4byte sHoOhSprites9
+.4byte sHoOhSprites10
+.4byte sHoOhSprites11
+.4byte sHoOhSprites12
+.4byte sHoOhSprites13
+.4byte sHoOhSprites14
+.4byte sHoOhSprites15
+.4byte sHoOhSprites16
+.4byte sHoOhSprites17
+.4byte sHoOhSprites18
+.4byte sHoOhSprites19
+.4byte sHoOhSprites20
+.4byte sHoOhSprites21
+.4byte sHoOhSprites22
+.4byte sHoOhSprites23
+.4byte sHoOhSprites24
+.4byte sHoOhSprites25
+.4byte sHoOhSprites26
+.4byte sHoOhSprites27
+.4byte sHoOhSprites28
+.4byte sHoOhSprites29
+.4byte sHoOhSprites30
+.4byte sHoOhSprites31
+.4byte sHoOhSprites32
+.4byte sHoOhSprites33
+.4byte sHoOhSprites34
+.4byte sHoOhSprites35
+.4byte sHoOhSprites36
+.4byte sHoOhSprites37
+.4byte sHoOhSprites38
+.4byte sHoOhSprites39
+.4byte sHoOhSprites40
+.4byte sHoOhSprites41
+.4byte sHoOhSprites42
+.4byte sHoOhSprites43
+.4byte sHoOhSprites44
+.4byte sHoOhSprites45
+.4byte sHoOhSprites46
+.4byte sHoOhSprites47
+.4byte sHoOhSprites48
+.4byte sHoOhSprites49
+.4byte sHoOhSprites50
+.4byte sHoOhSprites51
+.4byte sHoOhSprites52
+.4byte sHoOhSprites53
+.4byte sHoOhSprites54
+.4byte sHoOhSprites55
+.4byte sHoOhSprites56
+.4byte sHoOhSprites57
+.4byte sHoOhSprites58
+.4byte sHoOhSprites59
+.4byte sHoOhSprites60
+.4byte sHoOhSprites61
+.4byte sHoOhSprites62
+.4byte sHoOhSprites63
+.4byte sHoOhSprites64
+.4byte sHoOhSprites65
+.4byte sHoOhSprites66
+.4byte sHoOhSprites67
+.4byte sHoOhSprites68
+.4byte sHoOhSprites69
+.4byte sHoOhSprites70
+.4byte sHoOhSprites71
+.4byte sHoOhSprites72
+.4byte sHoOhSprites73
+.4byte sHoOhSprites74
+.4byte sHoOhSprites75
+.4byte sHoOhSprites76
+.4byte sHoOhSprites77
+.4byte sHoOhSprites78
+.4byte sHoOhSprites79
+.4byte sHoOhSprites80
+.4byte sHoOhSprites81
+.4byte sHoOhSprites82
+.4byte sHoOhSprites83
+.4byte sHoOhSprites84
+sAxMainHoOh:
+ax_main sAxPosesHoOh, sAxAnimationsHoOh, 13, sAxSpritesHoOh, sAxPositionsHoOh

--- a/data/ax/hoothoot.inc
+++ b/data/ax/hoothoot.inc
@@ -1,0 +1,2202 @@
+.global gAxHoothoot
+gAxHoothoot:
+ax_siro sAxMainHoothoot
+sHoothootPose1:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose2:
+ax_pose 1, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose3:
+ax_pose 2, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose4:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose5:
+ax_pose 4, 0x01e7, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoothootPose6:
+ax_pose 5, 0x01eb, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoothootPose7:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose8:
+ax_pose 7, 0x01e8, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoothootPose9:
+ax_pose 8, 0x01ea, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoothootPose10:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose11:
+ax_pose 10, 0x01e8, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose12:
+ax_pose 11, 0x81e9, 0x90f9, 0x6c00
+ax_pose_terminator
+sHoothootPose13:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose14:
+ax_pose 13, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose15:
+ax_pose 14, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose16:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose17:
+ax_pose 10, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoothootPose18:
+ax_pose 11, 0x81e9, 0x80f6, 0x6c00
+ax_pose_terminator
+sHoothootPose19:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose20:
+ax_pose 7, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoothootPose21:
+ax_pose 8, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoothootPose22:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose23:
+ax_pose 4, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoothootPose24:
+ax_pose 5, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoothootPose25:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose26:
+ax_pose 1, 0x01ef, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose27:
+ax_pose 2, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose28:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose29:
+ax_pose 4, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose30:
+ax_pose 5, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoothootPose31:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose32:
+ax_pose 7, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose33:
+ax_pose 8, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose34:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose35:
+ax_pose 10, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose36:
+ax_pose 11, 0x81ea, 0x90f8, 0x6c00
+ax_pose_terminator
+sHoothootPose37:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose38:
+ax_pose 13, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose39:
+ax_pose 14, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose40:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose41:
+ax_pose 10, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose42:
+ax_pose 11, 0x81ea, 0x80f9, 0x6c00
+ax_pose_terminator
+sHoothootPose43:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose44:
+ax_pose 7, 0x01ec, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose45:
+ax_pose 8, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose46:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose47:
+ax_pose 4, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose48:
+ax_pose 5, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoothootPose49:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose50:
+ax_pose 1, 0x01ef, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose51:
+ax_pose 2, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose52:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose53:
+ax_pose 4, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose54:
+ax_pose 5, 0x01ea, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoothootPose55:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose56:
+ax_pose 7, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose57:
+ax_pose 8, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose58:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose59:
+ax_pose 10, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose60:
+ax_pose 11, 0x81ea, 0x90f8, 0x6c00
+ax_pose_terminator
+sHoothootPose61:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose62:
+ax_pose 13, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose63:
+ax_pose 14, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose64:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose65:
+ax_pose 10, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose66:
+ax_pose 11, 0x81ea, 0x80f9, 0x6c00
+ax_pose_terminator
+sHoothootPose67:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose68:
+ax_pose 7, 0x01ec, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose69:
+ax_pose 8, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose70:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose71:
+ax_pose 4, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose72:
+ax_pose 5, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoothootPose73:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose74:
+ax_pose 1, 0x01ef, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose75:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose76:
+ax_pose 4, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose77:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose78:
+ax_pose 7, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose79:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose80:
+ax_pose 10, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose81:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose82:
+ax_pose 13, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose83:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose84:
+ax_pose 10, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose85:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose86:
+ax_pose 7, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose87:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose88:
+ax_pose 4, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose89:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose90:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose91:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose92:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose93:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose94:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose95:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose96:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose97:
+ax_pose 15, 0x01ec, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoothootPose98:
+ax_pose 16, 0x01ec, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoothootPose99:
+ax_pose 17, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoothootPose100:
+ax_pose 18, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoothootPose101:
+ax_pose 19, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoothootPose102:
+ax_pose 20, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoothootPose103:
+ax_pose 21, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose104:
+ax_pose 20, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoothootPose105:
+ax_pose 19, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose106:
+ax_pose 18, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoothootPose107:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose108:
+ax_pose 2, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose109:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose110:
+ax_pose 5, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose111:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose112:
+ax_pose 8, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose113:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose114:
+ax_pose 11, 0x81ea, 0x90f9, 0x6c00
+ax_pose_terminator
+sHoothootPose115:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose116:
+ax_pose 14, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose117:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose118:
+ax_pose 11, 0x81ea, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoothootPose119:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose120:
+ax_pose 8, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose121:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose122:
+ax_pose 5, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose123:
+ax_pose 1, 0x01ef, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose124:
+ax_pose 4, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose125:
+ax_pose 7, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose126:
+ax_pose 10, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose127:
+ax_pose 13, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose128:
+ax_pose 10, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose129:
+ax_pose 7, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose130:
+ax_pose 4, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose131:
+ax_pose 1, 0x01ef, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose132:
+ax_pose 4, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose133:
+ax_pose 7, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose134:
+ax_pose 10, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose135:
+ax_pose 13, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose136:
+ax_pose 10, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose137:
+ax_pose 7, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose138:
+ax_pose 4, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose139:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose140:
+ax_pose 1, 0x01ef, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose141:
+ax_pose 2, 0x01e9, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose142:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose143:
+ax_pose 4, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose144:
+ax_pose 5, 0x01e9, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoothootPose145:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose146:
+ax_pose 7, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose147:
+ax_pose 8, 0x01e9, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoothootPose148:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose149:
+ax_pose 10, 0x01ec, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose150:
+ax_pose 11, 0x81e9, 0x90f8, 0x6c00
+ax_pose_terminator
+sHoothootPose151:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose152:
+ax_pose 13, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose153:
+ax_pose 14, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose154:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose155:
+ax_pose 10, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose156:
+ax_pose 11, 0x81e9, 0x80f9, 0x6c00
+ax_pose_terminator
+sHoothootPose157:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose158:
+ax_pose 7, 0x01ec, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose159:
+ax_pose 8, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoothootPose160:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose161:
+ax_pose 4, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose162:
+ax_pose 5, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoothootPose163:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose164:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose165:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose166:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose167:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose168:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose169:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose170:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose171:
+ax_pose 0, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose172:
+ax_pose 3, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose173:
+ax_pose 6, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose174:
+ax_pose 9, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoothootPose175:
+ax_pose 12, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoothootPose176:
+ax_pose 9, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoothootPose177:
+ax_pose 6, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoothootPose178:
+ax_pose 3, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+.align 2
+sHoothootAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 2, 0, 1,
+ax_anim 8, 0, 2, 0, 0, 0, 1,
+ax_anim_terminator
+sHoothootAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -1, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 2, 1, 1,
+ax_anim 8, 0, 5, 0, 0, 2, 2,
+ax_anim_terminator
+sHoothootAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -1, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 1, 2, 1, 0,
+ax_anim 8, 0, 8, 0, 0, 2, 0,
+ax_anim_terminator
+sHoothootAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 1, -1,
+ax_anim 6, 0, 10, 1, 1, 2, -2,
+ax_anim 8, 0, 11, 0, 0, 1, -1,
+ax_anim_terminator
+sHoothootAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 2, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, -1,
+ax_anim 6, 0, 13, 0, 1, 0, -2,
+ax_anim 8, 0, 14, 0, 0, 0, -1,
+ax_anim_terminator
+sHoothootAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 1, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, -1, -1,
+ax_anim 6, 0, 16, -1, 1, -2, -2,
+ax_anim 8, 0, 17, 0, 0, -1, -1,
+ax_anim_terminator
+sHoothootAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 1, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, -1, 2, -1, 0,
+ax_anim 8, 0, 20, 0, 0, -2, 0,
+ax_anim_terminator
+sHoothootAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 1, 1, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 2, -1, 1,
+ax_anim 8, 0, 23, 0, 0, -2, 2,
+ax_anim_terminator
+.align 2
+sHoothootAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, -1, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 6,
+ax_anim 1, 0, 25, 0, 8, 0, 13,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHoothootAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 3, -2, 3, 3,
+ax_anim 1, 2, 28, 9, 1, 9, 9,
+ax_anim 1, 0, 28, 15, 7, 15, 15,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 1, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 0, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sHoothootAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, -3, 0, 0,
+ax_anim 1, 2, 31, 7, -5, 7, 0,
+ax_anim 1, 0, 31, 13, -4, 13, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sHoothootAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -4, 0, -1,
+ax_anim 1, 2, 34, 5, -13, 5, -6,
+ax_anim 1, 0, 34, 13, -18, 13, -13,
+ax_anim 2, 0, 34, 21, -20, 21, -20,
+ax_anim 2, 1, 34, 22, -19, 22, -19,
+ax_anim 2, 0, 34, 21, -20, 21, -20,
+ax_anim 2, 0, 34, 22, -19, 22, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sHoothootAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, -6, 0, -3,
+ax_anim 1, 2, 37, 0, -10, 0, -6,
+ax_anim 1, 0, 37, 0, -16, 0, -13,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sHoothootAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -4, 0, -1,
+ax_anim 1, 2, 40, -5, -13, -5, -6,
+ax_anim 1, 0, 40, -13, -18, -13, -13,
+ax_anim 2, 0, 40, -21, -20, -21, -20,
+ax_anim 2, 1, 40, -22, -19, -22, -19,
+ax_anim 2, 0, 40, -21, -20, -21, -20,
+ax_anim 2, 0, 40, -22, -19, -22, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sHoothootAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, -3, 0, 0,
+ax_anim 1, 2, 43, -7, -5, -7, 0,
+ax_anim 1, 0, 43, -13, -4, -13, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sHoothootAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, -3, -2, -3, 3,
+ax_anim 1, 2, 46, -9, 1, -9, 9,
+ax_anim 1, 0, 46, -15, 7, -15, 15,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 1, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 0, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHoothootAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, -1, 0, 0,
+ax_anim 1, 2, 49, 0, 2, 0, 6,
+ax_anim 1, 0, 49, 0, 8, 0, 13,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 1, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sHoothootAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 3, -2, 3, 3,
+ax_anim 1, 2, 52, 9, 1, 9, 9,
+ax_anim 1, 0, 52, 15, 7, 15, 15,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 1, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 0, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sHoothootAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, -3, 0, 0,
+ax_anim 1, 2, 55, 7, -5, 7, 0,
+ax_anim 1, 0, 55, 13, -4, 13, 0,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 1, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sHoothootAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -4, 0, -1,
+ax_anim 1, 2, 58, 5, -13, 5, -6,
+ax_anim 1, 0, 58, 13, -18, 13, -13,
+ax_anim 2, 0, 58, 21, -20, 21, -20,
+ax_anim 2, 1, 58, 22, -19, 22, -19,
+ax_anim 2, 0, 58, 21, -20, 21, -20,
+ax_anim 2, 0, 58, 22, -19, 22, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sHoothootAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, -6, 0, -3,
+ax_anim 1, 2, 61, 0, -10, 0, -6,
+ax_anim 1, 0, 61, 0, -16, 0, -13,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 1, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 0, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sHoothootAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -4, 0, -1,
+ax_anim 1, 2, 64, -5, -13, -5, -6,
+ax_anim 1, 0, 64, -13, -18, -13, -13,
+ax_anim 2, 0, 64, -21, -20, -21, -20,
+ax_anim 2, 1, 64, -22, -19, -22, -19,
+ax_anim 2, 0, 64, -21, -20, -21, -20,
+ax_anim 2, 0, 64, -22, -19, -22, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sHoothootAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, -3, 0, 0,
+ax_anim 1, 2, 67, -7, -5, -7, 0,
+ax_anim 1, 0, 67, -13, -4, -13, 0,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 1, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sHoothootAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, -3, -2, -3, 3,
+ax_anim 1, 2, 70, -9, 1, -9, 9,
+ax_anim 1, 0, 70, -15, 7, -15, 15,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 1, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 0, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHoothootAnims_4_1:
+ax_anim 3, 0, 73, 0, -1, 0, 0,
+ax_anim 3, 0, 72, 0, -3, 0, 0,
+ax_anim 3, 0, 73, 0, -4, 0, 0,
+ax_anim 3, 2, 72, 0, -4, 0, 0,
+ax_anim 3, 0, 73, 0, -4, 0, 0,
+ax_anim 3, 0, 72, 0, -4, 0, 0,
+ax_anim 3, 1, 73, 0, -4, 0, 0,
+ax_anim 3, 0, 72, 0, -4, 0, 0,
+ax_anim 3, 0, 73, 0, -4, 0, 0,
+ax_anim 3, 0, 72, 0, -2, 0, 0,
+ax_anim_terminator
+sHoothootAnims_4_2:
+ax_anim 3, 0, 75, 0, -1, 0, 0,
+ax_anim 3, 0, 74, 0, -3, 0, 0,
+ax_anim 3, 0, 75, 0, -4, 0, 0,
+ax_anim 3, 2, 74, 0, -4, 0, 0,
+ax_anim 3, 0, 75, 0, -4, 0, 0,
+ax_anim 3, 0, 74, 0, -4, 0, 0,
+ax_anim 3, 1, 75, 0, -4, 0, 0,
+ax_anim 3, 0, 74, 0, -4, 0, 0,
+ax_anim 3, 0, 75, 0, -4, 0, 0,
+ax_anim 3, 0, 74, 0, -2, 0, 0,
+ax_anim_terminator
+sHoothootAnims_4_3:
+ax_anim 3, 0, 77, 0, -1, 0, 0,
+ax_anim 3, 0, 76, 0, -3, 0, 0,
+ax_anim 3, 0, 77, 0, -4, 0, 0,
+ax_anim 3, 2, 76, 0, -4, 0, 0,
+ax_anim 3, 0, 77, 0, -4, 0, 0,
+ax_anim 3, 0, 76, 0, -4, 0, 0,
+ax_anim 3, 1, 77, 0, -4, 0, 0,
+ax_anim 3, 0, 76, 0, -4, 0, 0,
+ax_anim 3, 0, 77, 0, -4, 0, 0,
+ax_anim 3, 0, 76, 0, -2, 0, 0,
+ax_anim_terminator
+sHoothootAnims_4_4:
+ax_anim 3, 0, 79, 0, -1, 0, 0,
+ax_anim 3, 0, 78, 0, -3, 0, 0,
+ax_anim 3, 0, 79, 0, -4, 0, 0,
+ax_anim 3, 2, 78, 0, -4, 0, 0,
+ax_anim 3, 0, 79, 0, -4, 0, 0,
+ax_anim 3, 0, 78, 0, -4, 0, 0,
+ax_anim 3, 1, 79, 0, -4, 0, 0,
+ax_anim 3, 0, 78, 0, -4, 0, 0,
+ax_anim 3, 0, 79, 0, -4, 0, 0,
+ax_anim 3, 0, 78, 0, -2, 0, 0,
+ax_anim_terminator
+sHoothootAnims_4_5:
+ax_anim 3, 0, 81, 0, -1, 0, 0,
+ax_anim 3, 0, 80, 0, -3, 0, 0,
+ax_anim 3, 0, 81, 0, -4, 0, 0,
+ax_anim 3, 2, 80, 0, -4, 0, 0,
+ax_anim 3, 0, 81, 0, -4, 0, 0,
+ax_anim 3, 0, 80, 0, -4, 0, 0,
+ax_anim 3, 1, 81, 0, -4, 0, 0,
+ax_anim 3, 0, 80, 0, -4, 0, 0,
+ax_anim 3, 0, 81, 0, -4, 0, 0,
+ax_anim 3, 0, 80, 0, -2, 0, 0,
+ax_anim_terminator
+sHoothootAnims_4_6:
+ax_anim 3, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 0, 82, 0, -3, 0, 0,
+ax_anim 3, 0, 83, 0, -4, 0, 0,
+ax_anim 3, 2, 82, 0, -4, 0, 0,
+ax_anim 3, 0, 83, 0, -4, 0, 0,
+ax_anim 3, 0, 82, 0, -4, 0, 0,
+ax_anim 3, 1, 83, 0, -4, 0, 0,
+ax_anim 3, 0, 82, 0, -4, 0, 0,
+ax_anim 3, 0, 83, 0, -4, 0, 0,
+ax_anim 3, 0, 82, 0, -2, 0, 0,
+ax_anim_terminator
+sHoothootAnims_4_7:
+ax_anim 3, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 0, 84, 0, -3, 0, 0,
+ax_anim 3, 0, 85, 0, -4, 0, 0,
+ax_anim 3, 2, 84, 0, -4, 0, 0,
+ax_anim 3, 0, 85, 0, -4, 0, 0,
+ax_anim 3, 0, 84, 0, -4, 0, 0,
+ax_anim 3, 1, 85, 0, -4, 0, 0,
+ax_anim 3, 0, 84, 0, -4, 0, 0,
+ax_anim 3, 0, 85, 0, -4, 0, 0,
+ax_anim 3, 0, 84, 0, -2, 0, 0,
+ax_anim_terminator
+sHoothootAnims_4_8:
+ax_anim 3, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 0, 86, 0, -3, 0, 0,
+ax_anim 3, 0, 87, 0, -4, 0, 0,
+ax_anim 3, 2, 86, 0, -4, 0, 0,
+ax_anim 3, 0, 87, 0, -4, 0, 0,
+ax_anim 3, 0, 86, 0, -4, 0, 0,
+ax_anim 3, 1, 87, 0, -4, 0, 0,
+ax_anim 3, 0, 86, 0, -4, 0, 0,
+ax_anim 3, 0, 87, 0, -4, 0, 0,
+ax_anim 3, 0, 86, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_5_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_5_2:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_5_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_5_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_5_6:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_5_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_5_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_6_1:
+ax_anim 30, 0, 96, 0, 0, 0, 0,
+ax_anim 35, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sHoothootAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sHoothootAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sHoothootAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sHoothootAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sHoothootAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sHoothootAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sHoothootAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sHoothootAnims_8_1:
+ax_anim 48, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_8_2:
+ax_anim 48, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_8_3:
+ax_anim 48, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_8_4:
+ax_anim 48, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_8_5:
+ax_anim 48, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_8_6:
+ax_anim 48, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_8_7:
+ax_anim 48, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_8_8:
+ax_anim 48, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 6, 3, 6, 3,
+ax_anim 2, 0, 124, 8, 9, 8, 9,
+ax_anim 2, 0, 125, 7, 17, 7, 17,
+ax_anim 3, 0, 126, 0, 20, 0, 20,
+ax_anim 2, 3, 127, -7, 17, -7, 17,
+ax_anim 2, 0, 128, -8, 9, -8, 9,
+ax_anim 1, 0, 129, -6, 3, -6, 3,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 8, 0, 8, 0,
+ax_anim 2, 0, 123, 17, 3, 17, 3,
+ax_anim 2, 0, 124, 20, 11, 20, 11,
+ax_anim 3, 0, 125, 20, 20, 20, 20,
+ax_anim 2, 3, 126, 11, 21, 11, 21,
+ax_anim 2, 0, 127, 3, 15, 3, 15,
+ax_anim 1, 0, 128, 0, 7, 0, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 3, -5, 3, -5,
+ax_anim 2, 0, 122, 11, -6, 11, -6,
+ax_anim 2, 0, 123, 17, -5, 17, -5,
+ax_anim 3, 0, 124, 21, -1, 21, -1,
+ax_anim 2, 3, 125, 17, 4, 17, 4,
+ax_anim 2, 0, 126, 12, 7, 12, 7,
+ax_anim 1, 0, 127, 4, 5, 4, 5,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, -1, -8, -1, -8,
+ax_anim 2, 0, 129, 4, -16, 4, -16,
+ax_anim 2, 0, 122, 12, -22, 12, -22,
+ax_anim 3, 0, 123, 21, -22, 21, -22,
+ax_anim 2, 3, 124, 21, -15, 21, -15,
+ax_anim 2, 0, 125, 17, -6, 17, -6,
+ax_anim 1, 0, 126, 7, -1, 7, -1,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -8, -4, -8, -4,
+ax_anim 2, 0, 128, -9, -12, -9, -12,
+ax_anim 2, 0, 129, -7, -19, -7, -19,
+ax_anim 3, 0, 122, 0, -23, 0, -23,
+ax_anim 2, 3, 123, 7, -19, 7, -19,
+ax_anim 2, 0, 124, 9, -10, 9, -10,
+ax_anim 1, 0, 125, 8, -4, 8, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 1, -8, 1, -8,
+ax_anim 2, 0, 123, -4, -16, -4, -16,
+ax_anim 2, 0, 122, -12, -22, -12, -22,
+ax_anim 3, 0, 129, -21, -22, -21, -22,
+ax_anim 2, 3, 128, -21, -15, -21, -15,
+ax_anim 2, 0, 127, -17, -6, -17, -6,
+ax_anim 1, 0, 126, -7, -1, -7, -1,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -3, -5, -3, -5,
+ax_anim 2, 0, 122, -11, -6, -11, -6,
+ax_anim 2, 0, 129, -17, -5, -17, -5,
+ax_anim 3, 0, 128, -21, -1, -21, -1,
+ax_anim 2, 3, 127, -17, 4, -17, 4,
+ax_anim 2, 0, 126, -12, 7, -12, 7,
+ax_anim 1, 0, 125, -4, 5, -4, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -8, 0, -8, 0,
+ax_anim 2, 0, 129, -17, 3, -17, 3,
+ax_anim 2, 0, 128, -20, 11, -20, 11,
+ax_anim 3, 0, 127, -20, 20, -20, 20,
+ax_anim 2, 3, 126, -11, 21, -11, 21,
+ax_anim 2, 0, 125, -3, 15, -3, 15,
+ax_anim 1, 0, 124, 0, 7, 0, 7,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -21, 0, 0,
+ax_anim 3, 0, 140, 0, -20, 0, 0,
+ax_anim 2, 0, 140, 0, -18, 0, 0,
+ax_anim 1, 0, 140, 0, -12, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_11_2:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -10, 0, 0,
+ax_anim 2, 0, 142, 0, -16, 0, 0,
+ax_anim 3, 0, 142, 0, -20, 0, 0,
+ax_anim 4, 0, 142, 0, -21, 0, 0,
+ax_anim 4, 0, 141, 0, -22, 0, 0,
+ax_anim 3, 0, 143, 0, -21, 0, 0,
+ax_anim 2, 0, 143, 0, -18, 0, 0,
+ax_anim 1, 0, 143, 0, -12, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_11_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -22, 0, 0,
+ax_anim 3, 0, 146, 0, -21, 0, 0,
+ax_anim 2, 0, 146, 0, -18, 0, 0,
+ax_anim 1, 0, 146, 0, -12, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_11_4:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -22, 0, 0,
+ax_anim 3, 0, 149, 0, -21, 0, 0,
+ax_anim 2, 0, 149, 0, -17, 0, 0,
+ax_anim 1, 0, 149, 0, -11, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -22, 0, 0,
+ax_anim 3, 0, 152, 0, -21, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -12, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_11_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -22, 0, 0,
+ax_anim 3, 0, 155, 0, -21, 0, 0,
+ax_anim 2, 0, 155, 0, -17, 0, 0,
+ax_anim 1, 0, 155, 0, -11, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_11_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -22, 0, 0,
+ax_anim 3, 0, 158, 0, -21, 0, 0,
+ax_anim 2, 0, 158, 0, -18, 0, 0,
+ax_anim 1, 0, 158, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -22, 0, 0,
+ax_anim 3, 0, 161, 0, -21, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoothootAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sHoothootGfx1:
+.incbin "baserom.gba", 0xC2C790, 0x200
+sHoothootSprites1:
+ax_sprite sHoothootGfx1, 0x200
+ax_sprite_terminator
+sHoothootGfx2:
+.incbin "baserom.gba", 0xC2C9A0, 0x200
+sHoothootSprites2:
+ax_sprite sHoothootGfx2, 0x200
+ax_sprite_terminator
+sHoothootGfx3:
+.incbin "baserom.gba", 0xC2CBB0, 0x200
+sHoothootSprites3:
+ax_sprite sHoothootGfx3, 0x200
+ax_sprite_terminator
+sHoothootGfx4:
+.incbin "baserom.gba", 0xC2CDC0, 0x200
+sHoothootSprites4:
+ax_sprite sHoothootGfx4, 0x200
+ax_sprite_terminator
+sHoothootGfx5:
+.incbin "baserom.gba", 0xC2CFD0, 0x200
+sHoothootSprites5:
+ax_sprite sHoothootGfx5, 0x200
+ax_sprite_terminator
+sHoothootGfx6:
+.incbin "baserom.gba", 0xC2D1E0, 0x200
+sHoothootSprites6:
+ax_sprite sHoothootGfx6, 0x200
+ax_sprite_terminator
+sHoothootGfx7:
+.incbin "baserom.gba", 0xC2D3F0, 0x200
+sHoothootSprites7:
+ax_sprite sHoothootGfx7, 0x200
+ax_sprite_terminator
+sHoothootGfx8:
+.incbin "baserom.gba", 0xC2D600, 0x200
+sHoothootSprites8:
+ax_sprite sHoothootGfx8, 0x200
+ax_sprite_terminator
+sHoothootGfx9:
+.incbin "baserom.gba", 0xC2D810, 0x200
+sHoothootSprites9:
+ax_sprite sHoothootGfx9, 0x200
+ax_sprite_terminator
+sHoothootGfx10:
+.incbin "baserom.gba", 0xC2DA20, 0x200
+sHoothootSprites10:
+ax_sprite sHoothootGfx10, 0x200
+ax_sprite_terminator
+sHoothootGfx11:
+.incbin "baserom.gba", 0xC2DC30, 0x200
+sHoothootSprites11:
+ax_sprite sHoothootGfx11, 0x200
+ax_sprite_terminator
+sHoothootGfx12:
+.incbin "baserom.gba", 0xC2DE40, 0x100
+sHoothootSprites12:
+ax_sprite sHoothootGfx12, 0x100
+ax_sprite_terminator
+sHoothootGfx13:
+.incbin "baserom.gba", 0xC2DF50, 0x200
+sHoothootSprites13:
+ax_sprite sHoothootGfx13, 0x200
+ax_sprite_terminator
+sHoothootGfx14:
+.incbin "baserom.gba", 0xC2E160, 0x200
+sHoothootSprites14:
+ax_sprite sHoothootGfx14, 0x200
+ax_sprite_terminator
+sHoothootGfx15:
+.incbin "baserom.gba", 0xC2E370, 0x200
+sHoothootSprites15:
+ax_sprite sHoothootGfx15, 0x200
+ax_sprite_terminator
+sHoothootGfx16:
+.incbin "baserom.gba", 0xC2E580, 0x200
+sHoothootSprites16:
+ax_sprite sHoothootGfx16, 0x200
+ax_sprite_terminator
+sHoothootGfx17:
+.incbin "baserom.gba", 0xC2E790, 0x200
+sHoothootSprites17:
+ax_sprite sHoothootGfx17, 0x200
+ax_sprite_terminator
+sHoothootGfx18:
+.incbin "baserom.gba", 0xC2E9A0, 0x200
+sHoothootSprites18:
+ax_sprite sHoothootGfx18, 0x200
+ax_sprite_terminator
+sHoothootGfx19:
+.incbin "baserom.gba", 0xC2EBB0, 0x200
+sHoothootSprites19:
+ax_sprite sHoothootGfx19, 0x200
+ax_sprite_terminator
+sHoothootGfx20:
+.incbin "baserom.gba", 0xC2EDC0, 0x200
+sHoothootSprites20:
+ax_sprite sHoothootGfx20, 0x200
+ax_sprite_terminator
+sHoothootGfx21:
+.incbin "baserom.gba", 0xC2EFD0, 0x200
+sHoothootSprites21:
+ax_sprite sHoothootGfx21, 0x200
+ax_sprite_terminator
+sHoothootGfx22:
+.incbin "baserom.gba", 0xC2F1E0, 0x200
+sHoothootSprites22:
+ax_sprite sHoothootGfx22, 0x200
+ax_sprite_terminator
+sAxPosesHoothoot:
+.4byte sHoothootPose1
+.4byte sHoothootPose2
+.4byte sHoothootPose3
+.4byte sHoothootPose4
+.4byte sHoothootPose5
+.4byte sHoothootPose6
+.4byte sHoothootPose7
+.4byte sHoothootPose8
+.4byte sHoothootPose9
+.4byte sHoothootPose10
+.4byte sHoothootPose11
+.4byte sHoothootPose12
+.4byte sHoothootPose13
+.4byte sHoothootPose14
+.4byte sHoothootPose15
+.4byte sHoothootPose16
+.4byte sHoothootPose17
+.4byte sHoothootPose18
+.4byte sHoothootPose19
+.4byte sHoothootPose20
+.4byte sHoothootPose21
+.4byte sHoothootPose22
+.4byte sHoothootPose23
+.4byte sHoothootPose24
+.4byte sHoothootPose25
+.4byte sHoothootPose26
+.4byte sHoothootPose27
+.4byte sHoothootPose28
+.4byte sHoothootPose29
+.4byte sHoothootPose30
+.4byte sHoothootPose31
+.4byte sHoothootPose32
+.4byte sHoothootPose33
+.4byte sHoothootPose34
+.4byte sHoothootPose35
+.4byte sHoothootPose36
+.4byte sHoothootPose37
+.4byte sHoothootPose38
+.4byte sHoothootPose39
+.4byte sHoothootPose40
+.4byte sHoothootPose41
+.4byte sHoothootPose42
+.4byte sHoothootPose43
+.4byte sHoothootPose44
+.4byte sHoothootPose45
+.4byte sHoothootPose46
+.4byte sHoothootPose47
+.4byte sHoothootPose48
+.4byte sHoothootPose49
+.4byte sHoothootPose50
+.4byte sHoothootPose51
+.4byte sHoothootPose52
+.4byte sHoothootPose53
+.4byte sHoothootPose54
+.4byte sHoothootPose55
+.4byte sHoothootPose56
+.4byte sHoothootPose57
+.4byte sHoothootPose58
+.4byte sHoothootPose59
+.4byte sHoothootPose60
+.4byte sHoothootPose61
+.4byte sHoothootPose62
+.4byte sHoothootPose63
+.4byte sHoothootPose64
+.4byte sHoothootPose65
+.4byte sHoothootPose66
+.4byte sHoothootPose67
+.4byte sHoothootPose68
+.4byte sHoothootPose69
+.4byte sHoothootPose70
+.4byte sHoothootPose71
+.4byte sHoothootPose72
+.4byte sHoothootPose73
+.4byte sHoothootPose74
+.4byte sHoothootPose75
+.4byte sHoothootPose76
+.4byte sHoothootPose77
+.4byte sHoothootPose78
+.4byte sHoothootPose79
+.4byte sHoothootPose80
+.4byte sHoothootPose81
+.4byte sHoothootPose82
+.4byte sHoothootPose83
+.4byte sHoothootPose84
+.4byte sHoothootPose85
+.4byte sHoothootPose86
+.4byte sHoothootPose87
+.4byte sHoothootPose88
+.4byte sHoothootPose89
+.4byte sHoothootPose90
+.4byte sHoothootPose91
+.4byte sHoothootPose92
+.4byte sHoothootPose93
+.4byte sHoothootPose94
+.4byte sHoothootPose95
+.4byte sHoothootPose96
+.4byte sHoothootPose97
+.4byte sHoothootPose98
+.4byte sHoothootPose99
+.4byte sHoothootPose100
+.4byte sHoothootPose101
+.4byte sHoothootPose102
+.4byte sHoothootPose103
+.4byte sHoothootPose104
+.4byte sHoothootPose105
+.4byte sHoothootPose106
+.4byte sHoothootPose107
+.4byte sHoothootPose108
+.4byte sHoothootPose109
+.4byte sHoothootPose110
+.4byte sHoothootPose111
+.4byte sHoothootPose112
+.4byte sHoothootPose113
+.4byte sHoothootPose114
+.4byte sHoothootPose115
+.4byte sHoothootPose116
+.4byte sHoothootPose117
+.4byte sHoothootPose118
+.4byte sHoothootPose119
+.4byte sHoothootPose120
+.4byte sHoothootPose121
+.4byte sHoothootPose122
+.4byte sHoothootPose123
+.4byte sHoothootPose124
+.4byte sHoothootPose125
+.4byte sHoothootPose126
+.4byte sHoothootPose127
+.4byte sHoothootPose128
+.4byte sHoothootPose129
+.4byte sHoothootPose130
+.4byte sHoothootPose131
+.4byte sHoothootPose132
+.4byte sHoothootPose133
+.4byte sHoothootPose134
+.4byte sHoothootPose135
+.4byte sHoothootPose136
+.4byte sHoothootPose137
+.4byte sHoothootPose138
+.4byte sHoothootPose139
+.4byte sHoothootPose140
+.4byte sHoothootPose141
+.4byte sHoothootPose142
+.4byte sHoothootPose143
+.4byte sHoothootPose144
+.4byte sHoothootPose145
+.4byte sHoothootPose146
+.4byte sHoothootPose147
+.4byte sHoothootPose148
+.4byte sHoothootPose149
+.4byte sHoothootPose150
+.4byte sHoothootPose151
+.4byte sHoothootPose152
+.4byte sHoothootPose153
+.4byte sHoothootPose154
+.4byte sHoothootPose155
+.4byte sHoothootPose156
+.4byte sHoothootPose157
+.4byte sHoothootPose158
+.4byte sHoothootPose159
+.4byte sHoothootPose160
+.4byte sHoothootPose161
+.4byte sHoothootPose162
+.4byte sHoothootPose163
+.4byte sHoothootPose164
+.4byte sHoothootPose165
+.4byte sHoothootPose166
+.4byte sHoothootPose167
+.4byte sHoothootPose168
+.4byte sHoothootPose169
+.4byte sHoothootPose170
+.4byte sHoothootPose171
+.4byte sHoothootPose172
+.4byte sHoothootPose173
+.4byte sHoothootPose174
+.4byte sHoothootPose175
+.4byte sHoothootPose176
+.4byte sHoothootPose177
+.4byte sHoothootPose178
+sAxPositionsHoothoot:
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,  -11, 	  -8,  -12, 	   8,  -12, 	   0,  -12
+.2byte    0,   -3, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte    5,  -12, 	   8,  -15, 	  -4,  -11, 	   1,  -12
+.2byte    8,   -4, 	  10,   -5, 	   0,   -2, 	   3,   -7
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte   10,  -14, 	   2,  -15, 	   1,  -12, 	   2,  -12
+.2byte   11,   -5, 	   5,   -7, 	   5,   -3, 	   2,   -8
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    5,  -17, 	  -4,  -18, 	   7,  -13, 	  -1,  -13
+.2byte    6,   -9, 	  -1,  -10, 	   7,   -4, 	   0,   -9
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -18, 	   8,  -14, 	  -8,  -14, 	   0,  -14
+.2byte    0,  -15, 	   7,   -6, 	  -7,   -6, 	   0,   -9
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte   -7,  -17, 	   2,  -18, 	  -9,  -13, 	  -1,  -13
+.2byte   -8,   -9, 	  -1,  -10, 	  -9,   -4, 	  -2,   -9
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte  -10,  -14, 	  -2,  -15, 	  -1,  -12, 	  -2,  -12
+.2byte  -11,   -5, 	  -5,   -7, 	  -5,   -3, 	  -2,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -5,  -12, 	  -8,  -15, 	   4,  -11, 	  -1,  -12
+.2byte   -8,   -4, 	 -10,   -5, 	   0,   -2, 	  -3,   -7
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,   -4, 	  -7,   -3, 	   7,   -3, 	   0,   -6
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte    4,   -9, 	   7,  -12, 	  -5,   -8, 	   0,   -9
+.2byte    5,   -5, 	   7,   -6, 	  -3,   -3, 	   0,   -8
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte    9,  -10, 	   1,  -11, 	   0,   -8, 	   1,   -8
+.2byte    9,   -5, 	   3,   -7, 	   3,   -3, 	   0,   -8
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    5,  -14, 	  -4,  -15, 	   7,  -10, 	  -1,  -10
+.2byte    5,   -8, 	  -2,   -9, 	   6,   -3, 	  -1,   -8
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -14, 	   8,  -10, 	  -8,  -10, 	   0,  -10
+.2byte    0,  -13, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte   -5,  -14, 	   4,  -15, 	  -7,  -10, 	   1,  -10
+.2byte   -5,   -8, 	   2,   -9, 	  -6,   -3, 	   1,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte   -9,  -10, 	  -1,  -11, 	   0,   -8, 	  -1,   -8
+.2byte   -9,   -5, 	  -3,   -7, 	  -3,   -3, 	   0,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -9, 	  -7,  -12, 	   5,   -8, 	   0,   -9
+.2byte   -5,   -5, 	  -7,   -6, 	   3,   -3, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,   -4, 	  -7,   -3, 	   7,   -3, 	   0,   -6
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte    4,   -9, 	   7,  -12, 	  -5,   -8, 	   0,   -9
+.2byte    5,   -5, 	   7,   -6, 	  -3,   -3, 	   0,   -8
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte    9,  -10, 	   1,  -11, 	   0,   -8, 	   1,   -8
+.2byte    9,   -5, 	   3,   -7, 	   3,   -3, 	   0,   -8
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    5,  -14, 	  -4,  -15, 	   7,  -10, 	  -1,  -10
+.2byte    5,   -8, 	  -2,   -9, 	   6,   -3, 	  -1,   -8
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -14, 	   8,  -10, 	  -8,  -10, 	   0,  -10
+.2byte    0,  -13, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte   -5,  -14, 	   4,  -15, 	  -7,  -10, 	   1,  -10
+.2byte   -5,   -8, 	   2,   -9, 	  -6,   -3, 	   1,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte   -9,  -10, 	  -1,  -11, 	   0,   -8, 	  -1,   -8
+.2byte   -9,   -5, 	  -3,   -7, 	  -3,   -3, 	   0,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -9, 	  -7,  -12, 	   5,   -8, 	   0,   -9
+.2byte   -5,   -5, 	  -7,   -6, 	   3,   -3, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte    4,   -8, 	   7,  -11, 	  -5,   -7, 	   0,   -8
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte    8,  -10, 	   0,  -11, 	  -1,   -8, 	   0,   -8
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    5,  -13, 	  -4,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -14, 	   8,  -10, 	  -8,  -10, 	   0,  -10
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte   -5,  -13, 	   4,  -14, 	  -7,   -9, 	   1,   -9
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte   -8,  -10, 	   0,  -11, 	   1,   -8, 	   0,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -8, 	  -7,  -11, 	   5,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte   -5,   -5, 	  -4,   -6, 	   4,   -3, 	   0,   -8
+.2byte   -5,   -3, 	  -3,   -5, 	   4,   -2, 	   1,   -7
+.2byte    0,   -9, 	  -8,  -10, 	   8,  -10, 	   0,   -8
+.2byte    2,  -10, 	   6,  -13, 	  -6,   -9, 	   0,   -8
+.2byte    6,  -12, 	  -2,  -12, 	  -2,   -9, 	  -1,   -9
+.2byte    3,  -14, 	  -3,  -15, 	   5,  -10, 	  -2,   -9
+.2byte    0,  -15, 	   8,   -9, 	  -8,   -9, 	   0,   -8
+.2byte   -4,  -14, 	   2,  -15, 	  -6,  -10, 	   1,   -9
+.2byte   -7,  -12, 	   1,  -12, 	   1,   -9, 	   0,   -9
+.2byte   -3,  -10, 	  -7,  -13, 	   5,   -9, 	  -1,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -4, 	  -7,   -3, 	   7,   -3, 	   0,   -6
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte    6,   -5, 	   8,   -6, 	  -2,   -3, 	   1,   -8
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte   10,   -5, 	   4,   -7, 	   4,   -3, 	   1,   -8
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    6,   -8, 	  -1,   -9, 	   7,   -3, 	   0,   -8
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -14, 	   7,   -5, 	  -7,   -5, 	   0,   -8
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte   -6,   -8, 	   1,   -9, 	  -7,   -3, 	   0,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte  -10,   -5, 	  -4,   -7, 	  -4,   -3, 	  -1,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -6,   -5, 	  -8,   -6, 	   2,   -3, 	  -1,   -8
+.2byte    0,   -7, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte   -4,   -8, 	  -7,  -11, 	   5,   -7, 	   0,   -8
+.2byte   -8,  -10, 	   0,  -11, 	   1,   -8, 	   0,   -8
+.2byte   -5,  -13, 	   4,  -14, 	  -7,   -9, 	   1,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    5,  -13, 	  -4,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    8,  -10, 	   0,  -11, 	  -1,   -8, 	   0,   -8
+.2byte    4,   -8, 	   7,  -11, 	  -5,   -7, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    4,   -8, 	   7,  -11, 	  -5,   -7, 	   0,   -8
+.2byte    8,  -10, 	   0,  -11, 	  -1,   -8, 	   0,   -8
+.2byte    5,  -13, 	  -4,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte   -5,  -13, 	   4,  -14, 	  -7,   -9, 	   1,   -9
+.2byte   -8,  -10, 	   0,  -11, 	   1,   -8, 	   0,   -8
+.2byte   -4,   -8, 	  -7,  -11, 	   5,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    0,   -5, 	  -7,   -4, 	   7,   -4, 	   0,   -7
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte    4,   -8, 	   7,  -11, 	  -5,   -7, 	   0,   -8
+.2byte    5,   -6, 	   7,   -7, 	  -3,   -4, 	   0,   -9
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte    8,  -10, 	   0,  -11, 	  -1,   -8, 	   0,   -8
+.2byte    8,   -6, 	   2,   -8, 	   2,   -4, 	  -1,   -9
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    5,  -13, 	  -4,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    5,   -9, 	  -2,  -10, 	   6,   -4, 	  -1,   -9
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -9, 	   0,   -9
+.2byte    0,  -15, 	   7,   -6, 	  -7,   -6, 	   0,   -9
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte   -5,  -13, 	   4,  -14, 	  -7,   -9, 	   1,   -9
+.2byte   -5,   -9, 	   2,  -10, 	  -6,   -4, 	   1,   -9
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte   -8,  -10, 	   0,  -11, 	   1,   -8, 	   0,   -8
+.2byte   -8,   -6, 	  -2,   -8, 	  -2,   -4, 	   1,   -9
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -4,   -8, 	  -7,  -11, 	   5,   -7, 	   0,   -8
+.2byte   -5,   -6, 	  -7,   -7, 	   3,   -4, 	   0,   -9
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -5,   -7, 	  -7,   -8, 	   4,   -4, 	   0,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	  -1,   -4, 	   0,   -9
+.2byte   -6,  -12, 	   3,  -10, 	  -7,   -5, 	   1,   -9
+.2byte    0,  -14, 	   8,   -7, 	  -8,   -7, 	   0,   -9
+.2byte    6,  -12, 	  -3,  -10, 	   7,   -5, 	  -1,   -9
+.2byte    8,   -8, 	   1,   -8, 	   1,   -4, 	   0,   -9
+.2byte    5,   -7, 	   7,   -8, 	  -4,   -4, 	   0,   -8
+sHoothootAnimTable1:
+.4byte sHoothootAnims_1_1
+.4byte sHoothootAnims_1_2
+.4byte sHoothootAnims_1_3
+.4byte sHoothootAnims_1_4
+.4byte sHoothootAnims_1_5
+.4byte sHoothootAnims_1_6
+.4byte sHoothootAnims_1_7
+.4byte sHoothootAnims_1_8
+sHoothootAnimTable2:
+.4byte sHoothootAnims_2_1
+.4byte sHoothootAnims_2_2
+.4byte sHoothootAnims_2_3
+.4byte sHoothootAnims_2_4
+.4byte sHoothootAnims_2_5
+.4byte sHoothootAnims_2_6
+.4byte sHoothootAnims_2_7
+.4byte sHoothootAnims_2_8
+sHoothootAnimTable3:
+.4byte sHoothootAnims_3_1
+.4byte sHoothootAnims_3_2
+.4byte sHoothootAnims_3_3
+.4byte sHoothootAnims_3_4
+.4byte sHoothootAnims_3_5
+.4byte sHoothootAnims_3_6
+.4byte sHoothootAnims_3_7
+.4byte sHoothootAnims_3_8
+sHoothootAnimTable4:
+.4byte sHoothootAnims_4_1
+.4byte sHoothootAnims_4_2
+.4byte sHoothootAnims_4_3
+.4byte sHoothootAnims_4_4
+.4byte sHoothootAnims_4_5
+.4byte sHoothootAnims_4_6
+.4byte sHoothootAnims_4_7
+.4byte sHoothootAnims_4_8
+sHoothootAnimTable5:
+.4byte sHoothootAnims_5_1
+.4byte sHoothootAnims_5_2
+.4byte sHoothootAnims_5_3
+.4byte sHoothootAnims_5_4
+.4byte sHoothootAnims_5_5
+.4byte sHoothootAnims_5_6
+.4byte sHoothootAnims_5_7
+.4byte sHoothootAnims_5_8
+sHoothootAnimTable6:
+.4byte sHoothootAnims_6_1
+.4byte sHoothootAnims_6_1
+.4byte sHoothootAnims_6_1
+.4byte sHoothootAnims_6_1
+.4byte sHoothootAnims_6_1
+.4byte sHoothootAnims_6_1
+.4byte sHoothootAnims_6_1
+.4byte sHoothootAnims_6_1
+sHoothootAnimTable7:
+.4byte sHoothootAnims_7_1
+.4byte sHoothootAnims_7_2
+.4byte sHoothootAnims_7_3
+.4byte sHoothootAnims_7_4
+.4byte sHoothootAnims_7_5
+.4byte sHoothootAnims_7_6
+.4byte sHoothootAnims_7_7
+.4byte sHoothootAnims_7_8
+sHoothootAnimTable8:
+.4byte sHoothootAnims_8_1
+.4byte sHoothootAnims_8_2
+.4byte sHoothootAnims_8_3
+.4byte sHoothootAnims_8_4
+.4byte sHoothootAnims_8_5
+.4byte sHoothootAnims_8_6
+.4byte sHoothootAnims_8_7
+.4byte sHoothootAnims_8_8
+sHoothootAnimTable9:
+.4byte sHoothootAnims_9_1
+.4byte sHoothootAnims_9_2
+.4byte sHoothootAnims_9_3
+.4byte sHoothootAnims_9_4
+.4byte sHoothootAnims_9_5
+.4byte sHoothootAnims_9_6
+.4byte sHoothootAnims_9_7
+.4byte sHoothootAnims_9_8
+sHoothootAnimTable10:
+.4byte sHoothootAnims_10_1
+.4byte sHoothootAnims_10_2
+.4byte sHoothootAnims_10_3
+.4byte sHoothootAnims_10_4
+.4byte sHoothootAnims_10_5
+.4byte sHoothootAnims_10_6
+.4byte sHoothootAnims_10_7
+.4byte sHoothootAnims_10_8
+sHoothootAnimTable11:
+.4byte sHoothootAnims_11_1
+.4byte sHoothootAnims_11_2
+.4byte sHoothootAnims_11_3
+.4byte sHoothootAnims_11_4
+.4byte sHoothootAnims_11_5
+.4byte sHoothootAnims_11_6
+.4byte sHoothootAnims_11_7
+.4byte sHoothootAnims_11_8
+sHoothootAnimTable12:
+.4byte sHoothootAnims_12_1
+.4byte sHoothootAnims_12_2
+.4byte sHoothootAnims_12_3
+.4byte sHoothootAnims_12_4
+.4byte sHoothootAnims_12_5
+.4byte sHoothootAnims_12_6
+.4byte sHoothootAnims_12_7
+.4byte sHoothootAnims_12_8
+sHoothootAnimTable13:
+.4byte sHoothootAnims_13_1
+.4byte sHoothootAnims_13_2
+.4byte sHoothootAnims_13_3
+.4byte sHoothootAnims_13_4
+.4byte sHoothootAnims_13_5
+.4byte sHoothootAnims_13_6
+.4byte sHoothootAnims_13_7
+.4byte sHoothootAnims_13_8
+sAxAnimationsHoothoot:
+.4byte sHoothootAnimTable1
+.4byte sHoothootAnimTable2
+.4byte sHoothootAnimTable3
+.4byte sHoothootAnimTable4
+.4byte sHoothootAnimTable5
+.4byte sHoothootAnimTable6
+.4byte sHoothootAnimTable7
+.4byte sHoothootAnimTable8
+.4byte sHoothootAnimTable9
+.4byte sHoothootAnimTable10
+.4byte sHoothootAnimTable11
+.4byte sHoothootAnimTable12
+.4byte sHoothootAnimTable13
+sAxSpritesHoothoot:
+.4byte sHoothootSprites1
+.4byte sHoothootSprites2
+.4byte sHoothootSprites3
+.4byte sHoothootSprites4
+.4byte sHoothootSprites5
+.4byte sHoothootSprites6
+.4byte sHoothootSprites7
+.4byte sHoothootSprites8
+.4byte sHoothootSprites9
+.4byte sHoothootSprites10
+.4byte sHoothootSprites11
+.4byte sHoothootSprites12
+.4byte sHoothootSprites13
+.4byte sHoothootSprites14
+.4byte sHoothootSprites15
+.4byte sHoothootSprites16
+.4byte sHoothootSprites17
+.4byte sHoothootSprites18
+.4byte sHoothootSprites19
+.4byte sHoothootSprites20
+.4byte sHoothootSprites21
+.4byte sHoothootSprites22
+sAxMainHoothoot:
+ax_main sAxPosesHoothoot, sAxAnimationsHoothoot, 13, sAxSpritesHoothoot, sAxPositionsHoothoot

--- a/data/ax/hoppip.inc
+++ b/data/ax/hoppip.inc
@@ -1,0 +1,3163 @@
+.global gAxHoppip
+gAxHoppip:
+ax_siro sAxMainHoppip
+sHoppipPose1:
+ax_pose 0, 0x41e7, 0x80f0, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose2:
+ax_pose 2, 0x41e7, 0x80f0, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose3:
+ax_pose 3, 0x01e7, 0x40f8, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac04
+ax_pose_terminator
+sHoppipPose4:
+ax_pose 4, 0x41e7, 0x80f0, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose5:
+ax_pose 5, 0x41e7, 0x80f0, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose6:
+ax_pose 4, 0x41e7, 0x90f0, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose7:
+ax_pose 3, 0x01e7, 0x50f8, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac04
+ax_pose_terminator
+sHoppipPose8:
+ax_pose 2, 0x41e7, 0x90f0, 0xac00
+ax_pose 1, 0x41ee, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose9:
+ax_pose 0, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac08
+ax_pose_terminator
+sHoppipPose10:
+ax_pose 2, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac08
+ax_pose_terminator
+sHoppipPose11:
+ax_pose 3, 0x01e5, 0x40f8, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac04
+ax_pose_terminator
+sHoppipPose12:
+ax_pose 4, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac08
+ax_pose_terminator
+sHoppipPose13:
+ax_pose 5, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac08
+ax_pose_terminator
+sHoppipPose14:
+ax_pose 4, 0x41e5, 0x90f0, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac08
+ax_pose_terminator
+sHoppipPose15:
+ax_pose 3, 0x01e5, 0x50f8, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac04
+ax_pose_terminator
+sHoppipPose16:
+ax_pose 2, 0x41e5, 0x90f0, 0xac00
+ax_pose 6, 0x41ee, 0x90ea, 0xac08
+ax_pose_terminator
+sHoppipPose17:
+ax_pose 0, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac08
+ax_pose_terminator
+sHoppipPose18:
+ax_pose 2, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac08
+ax_pose_terminator
+sHoppipPose19:
+ax_pose 3, 0x01e4, 0x40f8, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac04
+ax_pose_terminator
+sHoppipPose20:
+ax_pose 4, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac08
+ax_pose_terminator
+sHoppipPose21:
+ax_pose 5, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac08
+ax_pose_terminator
+sHoppipPose22:
+ax_pose 4, 0x41e4, 0x90f0, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac08
+ax_pose_terminator
+sHoppipPose23:
+ax_pose 3, 0x01e4, 0x50f8, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac04
+ax_pose_terminator
+sHoppipPose24:
+ax_pose 2, 0x41e4, 0x90f0, 0xac00
+ax_pose 7, 0x41ed, 0x90ec, 0xac08
+ax_pose_terminator
+sHoppipPose25:
+ax_pose 0, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac08
+ax_pose_terminator
+sHoppipPose26:
+ax_pose 2, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac08
+ax_pose_terminator
+sHoppipPose27:
+ax_pose 3, 0x01e6, 0x40f8, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac04
+ax_pose_terminator
+sHoppipPose28:
+ax_pose 4, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac08
+ax_pose_terminator
+sHoppipPose29:
+ax_pose 5, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac08
+ax_pose_terminator
+sHoppipPose30:
+ax_pose 4, 0x41e6, 0x90f0, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac08
+ax_pose_terminator
+sHoppipPose31:
+ax_pose 3, 0x01e6, 0x50f8, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac04
+ax_pose_terminator
+sHoppipPose32:
+ax_pose 2, 0x41e6, 0x90f0, 0xac00
+ax_pose 8, 0x81e7, 0x90f8, 0xac08
+ax_pose_terminator
+sHoppipPose33:
+ax_pose 0, 0x41e6, 0x80f0, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose34:
+ax_pose 2, 0x41e6, 0x80f0, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose35:
+ax_pose 3, 0x01e6, 0x40f8, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac04
+ax_pose_terminator
+sHoppipPose36:
+ax_pose 4, 0x41e6, 0x80f0, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose37:
+ax_pose 5, 0x41e6, 0x80f0, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose38:
+ax_pose 4, 0x41e6, 0x90f0, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose39:
+ax_pose 3, 0x01e6, 0x50f8, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac04
+ax_pose_terminator
+sHoppipPose40:
+ax_pose 2, 0x41e6, 0x90f0, 0xac00
+ax_pose 9, 0x41f0, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose41:
+ax_pose 0, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac08
+ax_pose_terminator
+sHoppipPose42:
+ax_pose 2, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac08
+ax_pose_terminator
+sHoppipPose43:
+ax_pose 3, 0x01e6, 0x40f8, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac04
+ax_pose_terminator
+sHoppipPose44:
+ax_pose 4, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac08
+ax_pose_terminator
+sHoppipPose45:
+ax_pose 5, 0x41e6, 0x80f0, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac08
+ax_pose_terminator
+sHoppipPose46:
+ax_pose 4, 0x41e6, 0x90f0, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac08
+ax_pose_terminator
+sHoppipPose47:
+ax_pose 3, 0x01e6, 0x50f8, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac04
+ax_pose_terminator
+sHoppipPose48:
+ax_pose 2, 0x41e6, 0x90f0, 0xac00
+ax_pose 8, 0x81e7, 0x80f8, 0xac08
+ax_pose_terminator
+sHoppipPose49:
+ax_pose 0, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose50:
+ax_pose 2, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose51:
+ax_pose 3, 0x01e4, 0x40f8, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac04
+ax_pose_terminator
+sHoppipPose52:
+ax_pose 4, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose53:
+ax_pose 5, 0x41e4, 0x80f0, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose54:
+ax_pose 4, 0x41e4, 0x90f0, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose55:
+ax_pose 3, 0x01e4, 0x50f8, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac04
+ax_pose_terminator
+sHoppipPose56:
+ax_pose 2, 0x41e4, 0x90f0, 0xac00
+ax_pose 7, 0x41ed, 0x80f4, 0xac08
+ax_pose_terminator
+sHoppipPose57:
+ax_pose 0, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac08
+ax_pose_terminator
+sHoppipPose58:
+ax_pose 2, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac08
+ax_pose_terminator
+sHoppipPose59:
+ax_pose 3, 0x01e5, 0x40f8, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac04
+ax_pose_terminator
+sHoppipPose60:
+ax_pose 4, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac08
+ax_pose_terminator
+sHoppipPose61:
+ax_pose 5, 0x41e5, 0x80f0, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac08
+ax_pose_terminator
+sHoppipPose62:
+ax_pose 4, 0x41e5, 0x90f0, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac08
+ax_pose_terminator
+sHoppipPose63:
+ax_pose 3, 0x01e5, 0x50f8, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac04
+ax_pose_terminator
+sHoppipPose64:
+ax_pose 2, 0x41e5, 0x90f0, 0xac00
+ax_pose 6, 0x41ee, 0x80f6, 0xac08
+ax_pose_terminator
+sHoppipPose65:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose66:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose67:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose68:
+ax_pose 13, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose69:
+ax_pose 14, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose70:
+ax_pose 15, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose71:
+ax_pose 16, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose72:
+ax_pose 17, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose73:
+ax_pose 18, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose74:
+ax_pose 19, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose75:
+ax_pose 20, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose76:
+ax_pose 21, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose77:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose78:
+ax_pose 23, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose79:
+ax_pose 24, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose80:
+ax_pose 19, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose81:
+ax_pose 20, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose82:
+ax_pose 21, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose83:
+ax_pose 16, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose84:
+ax_pose 17, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose85:
+ax_pose 18, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose86:
+ax_pose 13, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose87:
+ax_pose 14, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose88:
+ax_pose 15, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose89:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose90:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose91:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose92:
+ax_pose 13, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose93:
+ax_pose 14, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose94:
+ax_pose 15, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose95:
+ax_pose 16, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose96:
+ax_pose 17, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose97:
+ax_pose 18, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose98:
+ax_pose 19, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose99:
+ax_pose 20, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose100:
+ax_pose 21, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose101:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose102:
+ax_pose 23, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose103:
+ax_pose 24, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose104:
+ax_pose 19, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose105:
+ax_pose 20, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose106:
+ax_pose 21, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose107:
+ax_pose 16, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose108:
+ax_pose 17, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose109:
+ax_pose 18, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose110:
+ax_pose 13, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose111:
+ax_pose 14, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose112:
+ax_pose 15, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose113:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose114:
+ax_pose 25, 0x01e6, 0x80f3, 0xac00
+ax_pose_terminator
+sHoppipPose115:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose116:
+ax_pose 13, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose117:
+ax_pose 26, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose118:
+ax_pose 15, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose119:
+ax_pose 16, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose120:
+ax_pose 27, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose121:
+ax_pose 18, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose122:
+ax_pose 19, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose123:
+ax_pose 28, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose124:
+ax_pose 21, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose125:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose126:
+ax_pose 29, 0x01e8, 0x80f3, 0xac00
+ax_pose_terminator
+sHoppipPose127:
+ax_pose 24, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose128:
+ax_pose 19, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose129:
+ax_pose 28, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose130:
+ax_pose 21, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose131:
+ax_pose 16, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose132:
+ax_pose 27, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose133:
+ax_pose 18, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose134:
+ax_pose 13, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose135:
+ax_pose 26, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose136:
+ax_pose 15, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose137:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose138:
+ax_pose 15, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose139:
+ax_pose 18, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose140:
+ax_pose 21, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose141:
+ax_pose 24, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose142:
+ax_pose 21, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose143:
+ax_pose 18, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose144:
+ax_pose 15, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose145:
+ax_pose 30, 0x01e9, 0x80f5, 0xac00
+ax_pose_terminator
+sHoppipPose146:
+ax_pose 31, 0x01e9, 0x80f5, 0xac00
+ax_pose_terminator
+sHoppipPose147:
+ax_pose 32, 0x01dd, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose148:
+ax_pose 33, 0x01dd, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose149:
+ax_pose 34, 0x01dd, 0x90eb, 0xac00
+ax_pose_terminator
+sHoppipPose150:
+ax_pose 35, 0x01dc, 0x90ee, 0xac00
+ax_pose_terminator
+sHoppipPose151:
+ax_pose 36, 0x01de, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose152:
+ax_pose 35, 0x01dc, 0x80f2, 0xac00
+ax_pose_terminator
+sHoppipPose153:
+ax_pose 34, 0x01dd, 0x80f5, 0xac00
+ax_pose_terminator
+sHoppipPose154:
+ax_pose 33, 0x01dd, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose155:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose156:
+ax_pose 13, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose157:
+ax_pose 16, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose158:
+ax_pose 19, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose159:
+ax_pose 22, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose160:
+ax_pose 19, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose161:
+ax_pose 16, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose162:
+ax_pose 13, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose163:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose164:
+ax_pose 14, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose165:
+ax_pose 17, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose166:
+ax_pose 20, 0x01e2, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose167:
+ax_pose 23, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose168:
+ax_pose 20, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose169:
+ax_pose 17, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose170:
+ax_pose 14, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose171:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose172:
+ax_pose 15, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose173:
+ax_pose 18, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose174:
+ax_pose 21, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose175:
+ax_pose 24, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose176:
+ax_pose 21, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose177:
+ax_pose 18, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose178:
+ax_pose 15, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose179:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose180:
+ax_pose 13, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose181:
+ax_pose 16, 0x01e4, 0x80f5, 0xac00
+ax_pose_terminator
+sHoppipPose182:
+ax_pose 19, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose183:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose184:
+ax_pose 19, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose185:
+ax_pose 16, 0x01e4, 0x90eb, 0xac00
+ax_pose_terminator
+sHoppipPose186:
+ax_pose 13, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose187:
+ax_pose 25, 0x01e6, 0x80f3, 0xac00
+ax_pose_terminator
+sHoppipPose188:
+ax_pose 26, 0x01e7, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose189:
+ax_pose 27, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sHoppipPose190:
+ax_pose 28, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose191:
+ax_pose 29, 0x01e8, 0x80f3, 0xac00
+ax_pose_terminator
+sHoppipPose192:
+ax_pose 28, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose193:
+ax_pose 27, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose194:
+ax_pose 26, 0x01e7, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose195:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose196:
+ax_pose 25, 0x01e6, 0x80f3, 0xac00
+ax_pose_terminator
+sHoppipPose197:
+ax_pose 11, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose198:
+ax_pose 13, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose199:
+ax_pose 26, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose200:
+ax_pose 14, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose201:
+ax_pose 16, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose202:
+ax_pose 27, 0x01e3, 0x90ed, 0xac00
+ax_pose_terminator
+sHoppipPose203:
+ax_pose 17, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose204:
+ax_pose 19, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose205:
+ax_pose 28, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose206:
+ax_pose 20, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose207:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose208:
+ax_pose 29, 0x01e8, 0x80f3, 0xac00
+ax_pose_terminator
+sHoppipPose209:
+ax_pose 23, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose210:
+ax_pose 19, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose211:
+ax_pose 28, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose212:
+ax_pose 20, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose213:
+ax_pose 16, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose214:
+ax_pose 27, 0x01e3, 0x80f3, 0xac00
+ax_pose_terminator
+sHoppipPose215:
+ax_pose 17, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose216:
+ax_pose 13, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose217:
+ax_pose 26, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose218:
+ax_pose 14, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose219:
+ax_pose 12, 0x01e6, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose220:
+ax_pose 15, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose221:
+ax_pose 18, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose222:
+ax_pose 21, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose223:
+ax_pose 24, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sHoppipPose224:
+ax_pose 21, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose225:
+ax_pose 18, 0x01e6, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose226:
+ax_pose 15, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+sHoppipPose227:
+ax_pose 10, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose228:
+ax_pose 13, 0x01e6, 0x80f6, 0xac00
+ax_pose_terminator
+sHoppipPose229:
+ax_pose 16, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose230:
+ax_pose 19, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose231:
+ax_pose 22, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sHoppipPose232:
+ax_pose 19, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose233:
+ax_pose 16, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sHoppipPose234:
+ax_pose 13, 0x01e6, 0x90ea, 0xac00
+ax_pose_terminator
+.align 2
+sHoppipAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_1_2:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_1_3:
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, -1, 0, 0,
+ax_anim 4, 0, 18, 0, -2, 0, 0,
+ax_anim 4, 0, 19, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 21, 0, -2, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_1_4:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 4, 0, 25, 0, -1, 0, 0,
+ax_anim 4, 0, 26, 0, -2, 0, 0,
+ax_anim 4, 0, 27, 0, -3, 0, 0,
+ax_anim 4, 0, 28, 0, -3, 0, 0,
+ax_anim 4, 0, 29, 0, -2, 0, 0,
+ax_anim 4, 0, 30, 0, -1, 0, 0,
+ax_anim 4, 0, 31, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_1_5:
+ax_anim 4, 0, 32, 0, 0, 0, 0,
+ax_anim 4, 0, 33, 0, -1, 0, 0,
+ax_anim 4, 0, 34, 0, -2, 0, 0,
+ax_anim 4, 0, 35, 0, -3, 0, 0,
+ax_anim 4, 0, 36, 0, -3, 0, 0,
+ax_anim 4, 0, 37, 0, -2, 0, 0,
+ax_anim 4, 0, 38, 0, -1, 0, 0,
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_1_6:
+ax_anim 4, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 41, 0, -1, 0, 0,
+ax_anim 4, 0, 42, 0, -2, 0, 0,
+ax_anim 4, 0, 43, 0, -3, 0, 0,
+ax_anim 4, 0, 44, 0, -3, 0, 0,
+ax_anim 4, 0, 45, 0, -2, 0, 0,
+ax_anim 4, 0, 46, 0, -1, 0, 0,
+ax_anim 4, 0, 47, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_1_7:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 4, 0, 49, 0, -1, 0, 0,
+ax_anim 4, 0, 50, 0, -2, 0, 0,
+ax_anim 4, 0, 51, 0, -3, 0, 0,
+ax_anim 4, 0, 52, 0, -3, 0, 0,
+ax_anim 4, 0, 53, 0, -2, 0, 0,
+ax_anim 4, 0, 54, 0, -1, 0, 0,
+ax_anim 4, 0, 55, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_1_8:
+ax_anim 4, 0, 56, 0, 0, 0, 0,
+ax_anim 4, 0, 57, 0, -1, 0, 0,
+ax_anim 4, 0, 58, 0, -2, 0, 0,
+ax_anim 4, 0, 59, 0, -3, 0, 0,
+ax_anim 4, 0, 60, 0, -3, 0, 0,
+ax_anim 4, 0, 61, 0, -2, 0, 0,
+ax_anim 4, 0, 62, 0, -1, 0, 0,
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_2_1:
+ax_anim 2, 0, 64, 0, -1, 0, 0,
+ax_anim 2, 0, 65, 0, -2, 0, 0,
+ax_anim 2, 0, 64, 0, -3, 0, 0,
+ax_anim 2, 0, 66, 0, -4, 0, 0,
+ax_anim 2, 0, 64, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 0, -6, 0, 0,
+ax_anim 1, 0, 64, 0, -2, 0, 3,
+ax_anim 1, 0, 66, 0, 2, 0, 6,
+ax_anim 1, 2, 64, 0, 6, 0, 9,
+ax_anim 1, 0, 65, 0, 14, 0, 12,
+ax_anim 2, 0, 64, 0, 22, 0, 16,
+ax_anim 2, 1, 66, -1, 22, -1, 16,
+ax_anim 2, 0, 64, 0, 22, 0, 16,
+ax_anim 2, 0, 65, -1, 22, -1, 16,
+ax_anim 2, 0, 64, 0, 22, 0, 16,
+ax_anim 1, 0, 66, 0, 8, 0, 0,
+ax_anim 1, 0, 64, 0, 2, 0, 0,
+ax_anim 1, 0, 65, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_2_2:
+ax_anim 2, 0, 67, 0, -1, 0, 0,
+ax_anim 2, 0, 68, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -3, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 68, 0, -6, 0, 0,
+ax_anim 1, 0, 67, 3, -2, 3, 3,
+ax_anim 1, 0, 69, 6, 2, 6, 6,
+ax_anim 1, 2, 67, 9, 6, 9, 8,
+ax_anim 1, 0, 68, 14, 14, 12, 10,
+ax_anim 2, 0, 67, 22, 22, 22, 19,
+ax_anim 2, 1, 69, 21, 23, 21, 20,
+ax_anim 2, 0, 67, 22, 22, 22, 19,
+ax_anim 2, 0, 68, 21, 23, 21, 20,
+ax_anim 2, 0, 67, 22, 22, 22, 19,
+ax_anim 1, 0, 69, 8, 4, 8, 8,
+ax_anim 1, 0, 67, 4, 0, 4, 4,
+ax_anim 1, 0, 68, 2, -1, 2, 2,
+ax_anim_terminator
+sHoppipAnims_2_3:
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 71, 0, -2, 0, 0,
+ax_anim 2, 0, 70, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, 0,
+ax_anim 1, 0, 70, 3, -5, 3, 0,
+ax_anim 1, 0, 72, 6, -4, 6, 0,
+ax_anim 1, 2, 70, 9, -3, 9, 0,
+ax_anim 1, 0, 71, 12, -2, 12, 0,
+ax_anim 2, 0, 70, 18, -1, 18, 0,
+ax_anim 2, 1, 72, 18, -2, 17, 0,
+ax_anim 2, 0, 70, 18, -1, 18, 0,
+ax_anim 2, 0, 71, 18, -2, 17, 0,
+ax_anim 2, 0, 70, 18, -1, 18, 0,
+ax_anim 1, 0, 72, 8, -3, 8, 0,
+ax_anim 1, 0, 70, 4, -2, 4, 0,
+ax_anim 1, 0, 71, 2, -1, 2, 0,
+ax_anim_terminator
+sHoppipAnims_2_4:
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 74, 0, -6, 0, 0,
+ax_anim 1, 0, 73, 3, -8, 3, -3,
+ax_anim 1, 0, 75, 6, -10, 6, -6,
+ax_anim 1, 2, 73, 9, -13, 9, -9,
+ax_anim 1, 0, 74, 12, -15, 12, -12,
+ax_anim 2, 0, 73, 18, -18, 18, -18,
+ax_anim 2, 1, 75, 17, -19, 17, -19,
+ax_anim 2, 0, 73, 18, -18, 18, -18,
+ax_anim 2, 0, 74, 17, -19, 17, -19,
+ax_anim 2, 0, 73, 18, -18, 18, -18,
+ax_anim 1, 0, 75, 8, -12, 8, -8,
+ax_anim 1, 0, 73, 4, -8, 4, -4,
+ax_anim 1, 0, 74, 2, -4, 2, -2,
+ax_anim_terminator
+sHoppipAnims_2_5:
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, 0,
+ax_anim 1, 0, 76, 0, -8, 0, -3,
+ax_anim 1, 0, 78, 0, -10, 0, -6,
+ax_anim 1, 2, 76, 0, -13, 0, -9,
+ax_anim 1, 0, 77, 0, -15, 0, -12,
+ax_anim 2, 0, 76, 0, -18, 0, -18,
+ax_anim 2, 1, 78, -1, -18, -1, -18,
+ax_anim 2, 0, 76, 0, -18, 0, -18,
+ax_anim 2, 0, 77, -1, -18, -1, -18,
+ax_anim 2, 0, 76, 0, -18, 0, -18,
+ax_anim 1, 0, 78, 0, -12, 0, -8,
+ax_anim 1, 0, 76, 0, -8, 0, -4,
+ax_anim 1, 0, 77, 0, -4, 0, -2,
+ax_anim_terminator
+sHoppipAnims_2_6:
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 80, 0, -6, 0, 0,
+ax_anim 1, 0, 79, -3, -8, -3, -3,
+ax_anim 1, 0, 81, -6, -10, -6, -6,
+ax_anim 1, 2, 79, -9, -13, -9, -9,
+ax_anim 1, 0, 80, -12, -15, -12, -12,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 1, 81, -17, -19, -17, -19,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 0, 80, -17, -19, -17, -19,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 1, 0, 81, -8, -12, -8, -8,
+ax_anim 1, 0, 79, -4, -8, -4, -4,
+ax_anim 1, 0, 80, -2, -4, -2, -2,
+ax_anim_terminator
+sHoppipAnims_2_7:
+ax_anim 2, 0, 82, 0, -1, 0, 0,
+ax_anim 2, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 0, -6, 0, 0,
+ax_anim 1, 0, 82, -3, -5, -3, 0,
+ax_anim 1, 0, 84, -6, -4, -6, 0,
+ax_anim 1, 2, 82, -9, -3, -9, 0,
+ax_anim 1, 0, 83, -12, -2, -12, 0,
+ax_anim 2, 0, 82, -18, -1, -18, 0,
+ax_anim 2, 1, 84, -18, -2, -17, 0,
+ax_anim 2, 0, 82, -18, -1, -18, 0,
+ax_anim 2, 0, 83, -18, -2, -17, 0,
+ax_anim 2, 0, 82, -18, -1, -18, 0,
+ax_anim 1, 0, 84, -8, -3, -8, 0,
+ax_anim 1, 0, 82, -4, -2, -4, 0,
+ax_anim 1, 0, 83, -2, -1, -2, 0,
+ax_anim_terminator
+sHoppipAnims_2_8:
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 86, 0, -6, 0, 0,
+ax_anim 1, 0, 85, -3, -2, -3, 3,
+ax_anim 1, 0, 87, -6, 2, -6, 6,
+ax_anim 1, 2, 85, -9, 6, -9, 8,
+ax_anim 1, 0, 86, -14, 14, -12, 10,
+ax_anim 2, 0, 85, -22, 22, -22, 19,
+ax_anim 2, 1, 87, -21, 23, -21, 20,
+ax_anim 2, 0, 85, -22, 22, -22, 19,
+ax_anim 2, 0, 86, -21, 23, -21, 20,
+ax_anim 2, 0, 85, -22, 22, -22, 19,
+ax_anim 1, 0, 87, -8, 4, -8, 8,
+ax_anim 1, 0, 85, -4, 0, -4, 4,
+ax_anim 1, 0, 86, -2, -1, -2, 2,
+ax_anim_terminator
+.align 2
+sHoppipAnims_3_1:
+ax_anim 2, 0, 88, 0, -1, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 1, 0, 88, 0, -2, 0, 3,
+ax_anim 1, 0, 90, 0, 2, 0, 6,
+ax_anim 1, 2, 88, 0, 6, 0, 9,
+ax_anim 1, 0, 89, 0, 14, 0, 12,
+ax_anim 2, 0, 88, 0, 22, 0, 16,
+ax_anim 2, 1, 90, -1, 22, -1, 16,
+ax_anim 2, 0, 88, 0, 22, 0, 16,
+ax_anim 2, 0, 89, -1, 22, -1, 16,
+ax_anim 2, 0, 88, 0, 22, 0, 16,
+ax_anim 1, 0, 90, 0, 8, 0, 0,
+ax_anim 1, 0, 88, 0, 2, 0, 0,
+ax_anim 1, 0, 89, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_3_2:
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -6, 0, 0,
+ax_anim 1, 0, 91, 3, -2, 3, 3,
+ax_anim 1, 0, 93, 6, 2, 6, 6,
+ax_anim 1, 2, 91, 9, 6, 9, 8,
+ax_anim 1, 0, 92, 14, 14, 12, 10,
+ax_anim 2, 0, 91, 22, 22, 22, 19,
+ax_anim 2, 1, 93, 21, 23, 21, 20,
+ax_anim 2, 0, 91, 22, 22, 22, 19,
+ax_anim 2, 0, 92, 21, 23, 21, 20,
+ax_anim 2, 0, 91, 22, 22, 22, 19,
+ax_anim 1, 0, 93, 8, 4, 8, 8,
+ax_anim 1, 0, 91, 4, 0, 4, 4,
+ax_anim 1, 0, 92, 2, -1, 2, 2,
+ax_anim_terminator
+sHoppipAnims_3_3:
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -6, 0, 0,
+ax_anim 1, 0, 94, 3, -5, 3, 0,
+ax_anim 1, 0, 96, 6, -4, 6, 0,
+ax_anim 1, 2, 94, 9, -3, 9, 0,
+ax_anim 1, 0, 95, 12, -2, 12, 0,
+ax_anim 2, 0, 94, 18, -1, 18, 0,
+ax_anim 2, 1, 96, 18, -2, 17, 0,
+ax_anim 2, 0, 94, 18, -1, 18, 0,
+ax_anim 2, 0, 95, 18, -2, 17, 0,
+ax_anim 2, 0, 94, 18, -1, 18, 0,
+ax_anim 1, 0, 96, 8, -3, 8, 0,
+ax_anim 1, 0, 94, 4, -2, 4, 0,
+ax_anim 1, 0, 95, 2, -1, 2, 0,
+ax_anim_terminator
+sHoppipAnims_3_4:
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -6, 0, 0,
+ax_anim 1, 0, 97, 3, -8, 3, -3,
+ax_anim 1, 0, 99, 6, -10, 6, -6,
+ax_anim 1, 2, 97, 9, -13, 9, -9,
+ax_anim 1, 0, 98, 12, -15, 12, -12,
+ax_anim 2, 0, 97, 18, -18, 18, -18,
+ax_anim 2, 1, 99, 17, -19, 17, -19,
+ax_anim 2, 0, 97, 18, -18, 18, -18,
+ax_anim 2, 0, 98, 17, -19, 17, -19,
+ax_anim 2, 0, 97, 18, -18, 18, -18,
+ax_anim 1, 0, 99, 8, -12, 8, -8,
+ax_anim 1, 0, 97, 4, -8, 4, -4,
+ax_anim 1, 0, 98, 2, -4, 2, -2,
+ax_anim_terminator
+sHoppipAnims_3_5:
+ax_anim 2, 0, 100, 0, -1, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 0, 100, 0, -8, 0, -3,
+ax_anim 1, 0, 102, 0, -10, 0, -6,
+ax_anim 1, 2, 100, 0, -13, 0, -9,
+ax_anim 1, 0, 101, 0, -15, 0, -12,
+ax_anim 2, 0, 100, 0, -18, 0, -18,
+ax_anim 2, 1, 102, -1, -18, -1, -18,
+ax_anim 2, 0, 100, 0, -18, 0, -18,
+ax_anim 2, 0, 101, -1, -18, -1, -18,
+ax_anim 2, 0, 100, 0, -18, 0, -18,
+ax_anim 1, 0, 102, 0, -12, 0, -8,
+ax_anim 1, 0, 100, 0, -8, 0, -4,
+ax_anim 1, 0, 101, 0, -4, 0, -2,
+ax_anim_terminator
+sHoppipAnims_3_6:
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 1, 0, 103, -3, -8, -3, -3,
+ax_anim 1, 0, 105, -6, -10, -6, -6,
+ax_anim 1, 2, 103, -9, -13, -9, -9,
+ax_anim 1, 0, 104, -12, -15, -12, -12,
+ax_anim 2, 0, 103, -18, -18, -18, -18,
+ax_anim 2, 1, 105, -17, -19, -17, -19,
+ax_anim 2, 0, 103, -18, -18, -18, -18,
+ax_anim 2, 0, 104, -17, -19, -17, -19,
+ax_anim 2, 0, 103, -18, -18, -18, -18,
+ax_anim 1, 0, 105, -8, -12, -8, -8,
+ax_anim 1, 0, 103, -4, -8, -4, -4,
+ax_anim 1, 0, 104, -2, -4, -2, -2,
+ax_anim_terminator
+sHoppipAnims_3_7:
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 1, 0, 106, -3, -5, -3, 0,
+ax_anim 1, 0, 108, -6, -4, -6, 0,
+ax_anim 1, 2, 106, -9, -3, -9, 0,
+ax_anim 1, 0, 107, -12, -2, -12, 0,
+ax_anim 2, 0, 106, -18, -1, -18, 0,
+ax_anim 2, 1, 108, -18, -2, -17, 0,
+ax_anim 2, 0, 106, -18, -1, -18, 0,
+ax_anim 2, 0, 107, -18, -2, -17, 0,
+ax_anim 2, 0, 106, -18, -1, -18, 0,
+ax_anim 1, 0, 108, -8, -3, -8, 0,
+ax_anim 1, 0, 106, -4, -2, -4, 0,
+ax_anim 1, 0, 107, -2, -1, -2, 0,
+ax_anim_terminator
+sHoppipAnims_3_8:
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 1, 0, 109, -3, -2, -3, 3,
+ax_anim 1, 0, 111, -6, 2, -6, 6,
+ax_anim 1, 2, 109, -9, 6, -9, 8,
+ax_anim 1, 0, 110, -14, 14, -12, 10,
+ax_anim 2, 0, 109, -22, 22, -22, 19,
+ax_anim 2, 1, 111, -21, 23, -21, 20,
+ax_anim 2, 0, 109, -22, 22, -22, 19,
+ax_anim 2, 0, 110, -21, 23, -21, 20,
+ax_anim 2, 0, 109, -22, 22, -22, 19,
+ax_anim 1, 0, 111, -8, 4, -8, 8,
+ax_anim 1, 0, 109, -4, 0, -4, 4,
+ax_anim 1, 0, 110, -2, -1, -2, 2,
+ax_anim_terminator
+.align 2
+sHoppipAnims_4_1:
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 113, 0, -2, 0, -2,
+ax_anim 2, 0, 113, 0, -4, 0, -4,
+ax_anim 6, 2, 113, 0, -5, 0, -5,
+ax_anim 1, 0, 114, 0, -3, 0, -3,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 1, 5, 1, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 1, 5, 1, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 1, 5, 1, 5,
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim_terminator
+sHoppipAnims_4_2:
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim 2, 0, 116, -4, -4, -4, -4,
+ax_anim 6, 2, 116, -5, -5, -5, -5,
+ax_anim 1, 0, 117, -3, -3, -3, -3,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 117, 5, 5, 5, 5,
+ax_anim 2, 0, 117, 6, 4, 6, 4,
+ax_anim 2, 0, 117, 5, 5, 5, 5,
+ax_anim 2, 0, 117, 6, 4, 6, 4,
+ax_anim 2, 0, 117, 5, 5, 5, 5,
+ax_anim 2, 0, 117, 6, 4, 6, 4,
+ax_anim 2, 0, 115, 2, 2, 2, 2,
+ax_anim_terminator
+sHoppipAnims_4_3:
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim 2, 0, 119, -2, 0, -2, 0,
+ax_anim 2, 0, 119, -4, 0, -4, 0,
+ax_anim 6, 2, 119, -5, 0, -5, 0,
+ax_anim 1, 0, 120, -3, 0, -3, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 5, 0, 5, 0,
+ax_anim 2, 0, 120, 5, -1, 5, -1,
+ax_anim 2, 0, 120, 5, 0, 5, 0,
+ax_anim 2, 0, 120, 5, -1, 5, -1,
+ax_anim 2, 0, 120, 5, 0, 5, 0,
+ax_anim 2, 0, 120, 5, -1, 5, -1,
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim_terminator
+sHoppipAnims_4_4:
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 122, -2, 2, -2, 2,
+ax_anim 2, 0, 122, -4, 4, -4, 4,
+ax_anim 6, 2, 122, -5, 5, -5, 5,
+ax_anim 1, 0, 123, -3, 3, -3, 3,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 1, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 123, 6, -4, 6, -4,
+ax_anim 2, 0, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 123, 6, -4, 6, -4,
+ax_anim 2, 0, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 123, 6, -4, 6, -4,
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim_terminator
+sHoppipAnims_4_5:
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 2, 0, 2,
+ax_anim 2, 0, 125, 0, 4, 0, 4,
+ax_anim 6, 2, 125, 0, 5, 0, 5,
+ax_anim 1, 0, 126, 0, 3, 0, 3,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 0, -5, 0, -5,
+ax_anim 2, 0, 126, 1, -5, 1, -5,
+ax_anim 2, 0, 126, 0, -5, 0, -5,
+ax_anim 2, 0, 126, 1, -5, 1, -5,
+ax_anim 2, 0, 126, 0, -5, 0, -5,
+ax_anim 2, 0, 126, 1, -5, 1, -5,
+ax_anim 2, 0, 124, 0, -2, 0, -2,
+ax_anim_terminator
+sHoppipAnims_4_6:
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 128, 2, 2, 2, 2,
+ax_anim 2, 0, 128, 4, 4, 4, 4,
+ax_anim 6, 2, 128, 5, 5, 5, 5,
+ax_anim 1, 0, 129, 3, 3, 3, 3,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 1, 129, -5, -5, -5, -5,
+ax_anim 2, 0, 129, -6, -4, -6, -4,
+ax_anim 2, 0, 129, -5, -5, -5, -5,
+ax_anim 2, 0, 129, -6, -4, -6, -4,
+ax_anim 2, 0, 129, -5, -5, -5, -5,
+ax_anim 2, 0, 129, -6, -4, -6, -4,
+ax_anim 2, 0, 127, -2, -2, -2, -2,
+ax_anim_terminator
+sHoppipAnims_4_7:
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 2, 0, 131, 4, 0, 4, 0,
+ax_anim 6, 2, 131, 5, 0, 5, 0,
+ax_anim 1, 0, 132, 3, 0, 3, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 1, 132, -5, 0, -5, 0,
+ax_anim 2, 0, 132, -5, -1, -5, -1,
+ax_anim 2, 0, 132, -5, 0, -5, 0,
+ax_anim 2, 0, 132, -5, -1, -5, -1,
+ax_anim 2, 0, 132, -5, 0, -5, 0,
+ax_anim 2, 0, 132, -5, -1, -5, -1,
+ax_anim 2, 0, 130, -2, 0, -2, 0,
+ax_anim_terminator
+sHoppipAnims_4_8:
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 134, 2, -2, 2, -2,
+ax_anim 2, 0, 134, 4, -4, 4, -4,
+ax_anim 6, 2, 134, 5, -5, 5, -5,
+ax_anim 1, 0, 135, 3, -3, 3, -3,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sHoppipAnims_5_1:
+ax_anim 1, 0, 136, 0, -1, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 141, 0, -8, 0, 0,
+ax_anim 1, 0, 142, 0, -9, 0, 0,
+ax_anim 1, 0, 143, 0, -9, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, 0,
+ax_anim 1, 2, 137, 0, -9, 0, 0,
+ax_anim 1, 0, 138, 0, -9, 0, 0,
+ax_anim 2, 0, 139, 0, -9, 0, 0,
+ax_anim 2, 0, 140, 0, -9, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_5_2:
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 1, 0, 136, 0, -3, 0, 0,
+ax_anim 1, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -8, 0, 0,
+ax_anim 1, 0, 141, 0, -9, 0, 0,
+ax_anim 1, 0, 142, 0, -9, 0, 0,
+ax_anim 1, 0, 143, 0, -9, 0, 0,
+ax_anim 1, 2, 136, 0, -9, 0, 0,
+ax_anim 1, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 138, 0, -9, 0, 0,
+ax_anim 2, 0, 139, 0, -9, 0, 0,
+ax_anim 2, 0, 140, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 142, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, -1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_5_3:
+ax_anim 1, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 1, 0, 136, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 138, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -8, 0, 0,
+ax_anim 1, 0, 140, 0, -9, 0, 0,
+ax_anim 1, 0, 141, 0, -9, 0, 0,
+ax_anim 1, 0, 142, 0, -9, 0, 0,
+ax_anim 1, 2, 143, 0, -9, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, 0,
+ax_anim 2, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 138, 0, -9, 0, 0,
+ax_anim 2, 0, 139, 0, -8, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 4, 0, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_5_4:
+ax_anim 1, 0, 141, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 136, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -7, 0, 0,
+ax_anim 1, 0, 138, 0, -8, 0, 0,
+ax_anim 1, 0, 139, 0, -9, 0, 0,
+ax_anim 1, 0, 140, 0, -9, 0, 0,
+ax_anim 1, 0, 141, 0, -9, 0, 0,
+ax_anim 1, 2, 142, 0, -9, 0, 0,
+ax_anim 1, 0, 143, 0, -9, 0, 0,
+ax_anim 2, 0, 136, 0, -9, 0, 0,
+ax_anim 2, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 138, 0, -8, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 141, 0, -1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_5_5:
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 136, 0, -7, 0, 0,
+ax_anim 1, 0, 137, 0, -8, 0, 0,
+ax_anim 1, 0, 138, 0, -9, 0, 0,
+ax_anim 1, 0, 139, 0, -9, 0, 0,
+ax_anim 1, 0, 140, 0, -9, 0, 0,
+ax_anim 1, 2, 141, 0, -9, 0, 0,
+ax_anim 1, 0, 142, 0, -9, 0, 0,
+ax_anim 2, 0, 143, 0, -9, 0, 0,
+ax_anim 2, 0, 136, 0, -9, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_5_6:
+ax_anim 1, 0, 139, 0, -1, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 1, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -7, 0, 0,
+ax_anim 1, 0, 136, 0, -8, 0, 0,
+ax_anim 1, 0, 137, 0, -9, 0, 0,
+ax_anim 1, 0, 138, 0, -9, 0, 0,
+ax_anim 1, 0, 139, 0, -9, 0, 0,
+ax_anim 1, 2, 140, 0, -9, 0, 0,
+ax_anim 1, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 0, 142, 0, -9, 0, 0,
+ax_anim 2, 0, 143, 0, -9, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 4, 0, 139, 0, -1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_5_7:
+ax_anim 1, 0, 138, 0, -1, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 1, 0, 140, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 142, 0, -7, 0, 0,
+ax_anim 1, 0, 143, 0, -8, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, 0,
+ax_anim 1, 0, 137, 0, -9, 0, 0,
+ax_anim 1, 0, 138, 0, -9, 0, 0,
+ax_anim 1, 2, 139, 0, -9, 0, 0,
+ax_anim 1, 0, 140, 0, -9, 0, 0,
+ax_anim 2, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 0, 142, 0, -9, 0, 0,
+ax_anim 2, 0, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 138, 0, -1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_5_8:
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 1, 0, 138, 0, -3, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 140, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 142, 0, -8, 0, 0,
+ax_anim 1, 0, 143, 0, -9, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, 0,
+ax_anim 1, 0, 137, 0, -9, 0, 0,
+ax_anim 1, 2, 138, 0, -9, 0, 0,
+ax_anim 1, 0, 139, 0, -9, 0, 0,
+ax_anim 2, 0, 140, 0, -9, 0, 0,
+ax_anim 2, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 0, -3, 0, 0,
+ax_anim 4, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_6_1:
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, -1, 0, 0,
+ax_anim 26, 0, 144, 0, -2, 0, 0,
+ax_anim 8, 0, 145, 0, -2, 0, 0,
+ax_anim 8, 0, 145, 0, -1, 0, 0,
+ax_anim 26, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sHoppipAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sHoppipAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sHoppipAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sHoppipAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sHoppipAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sHoppipAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sHoppipAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sHoppipAnims_8_1:
+ax_anim 60, 0, 154, 0, 3, 0, 0,
+ax_anim 10, 0, 162, -1, 2, 0, 0,
+ax_anim 8, 0, 162, 0, 3, 0, 0,
+ax_anim 10, 0, 162, 0, 3, 0, 0,
+ax_anim 8, 0, 162, -1, 2, 0, 0,
+ax_anim 6, 0, 162, 0, 3, 0, 0,
+ax_anim 4, 0, 162, -1, 2, 0, 0,
+ax_anim 2, 0, 162, 0, 3, 0, 0,
+ax_anim 8, 0, 163, -1, -1, 0, 0,
+ax_anim 8, 0, 164, -1, -2, 0, 0,
+ax_anim 8, 0, 165, -2, -3, 0, 0,
+ax_anim 8, 0, 158, -2, -3, 0, 0,
+ax_anim 8, 0, 159, -1, -2, 0, 0,
+ax_anim 8, 0, 160, -1, -1, 0, 0,
+ax_anim 8, 0, 161, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_8_2:
+ax_anim 60, 0, 161, 0, 3, 0, 0,
+ax_anim 10, 0, 169, 1, 2, 0, 0,
+ax_anim 8, 0, 169, 0, 3, 0, 0,
+ax_anim 10, 0, 169, 0, 3, 0, 0,
+ax_anim 8, 0, 169, 1, 2, 0, 0,
+ax_anim 6, 0, 169, 0, 3, 0, 0,
+ax_anim 4, 0, 169, 1, 2, 0, 0,
+ax_anim 2, 0, 169, 0, 3, 0, 0,
+ax_anim 8, 0, 162, 1, -1, 0, 0,
+ax_anim 8, 0, 163, 1, -2, 0, 0,
+ax_anim 8, 0, 164, 2, -3, 0, 0,
+ax_anim 8, 0, 157, 2, -3, 0, 0,
+ax_anim 8, 0, 158, 1, -2, 0, 0,
+ax_anim 8, 0, 159, 1, -1, 0, 0,
+ax_anim 8, 0, 160, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_8_3:
+ax_anim 60, 0, 160, 0, 3, 0, 0,
+ax_anim 10, 0, 168, 0, 2, 0, 0,
+ax_anim 8, 0, 168, 0, 3, 0, 0,
+ax_anim 10, 0, 168, 0, 3, 0, 0,
+ax_anim 8, 0, 168, 0, 2, 0, 0,
+ax_anim 6, 0, 168, 0, 3, 0, 0,
+ax_anim 4, 0, 168, 0, 2, 0, 0,
+ax_anim 2, 0, 168, 0, 3, 0, 0,
+ax_anim 8, 0, 169, 0, -1, 0, 0,
+ax_anim 8, 0, 162, 1, -2, 0, 0,
+ax_anim 8, 0, 163, 2, -3, 0, 0,
+ax_anim 8, 0, 156, 2, -3, 0, 0,
+ax_anim 8, 0, 157, 1, -2, 0, 0,
+ax_anim 8, 0, 158, 1, -1, 0, 0,
+ax_anim 8, 0, 159, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_8_4:
+ax_anim 60, 0, 159, 0, 3, 0, 0,
+ax_anim 10, 0, 167, -1, 2, 0, 0,
+ax_anim 8, 0, 167, 0, 3, 0, 0,
+ax_anim 10, 0, 167, 0, 3, 0, 0,
+ax_anim 8, 0, 167, -1, 2, 0, 0,
+ax_anim 6, 0, 167, 0, 3, 0, 0,
+ax_anim 4, 0, 167, -1, 2, 0, 0,
+ax_anim 2, 0, 167, 0, 3, 0, 0,
+ax_anim 8, 0, 168, -1, -1, 0, 0,
+ax_anim 8, 0, 169, 1, -2, 0, 0,
+ax_anim 8, 0, 162, 2, -3, 0, 0,
+ax_anim 8, 0, 155, 2, -3, 0, 0,
+ax_anim 8, 0, 156, 1, -2, 0, 0,
+ax_anim 8, 0, 157, 1, -1, 0, 0,
+ax_anim 8, 0, 158, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_8_5:
+ax_anim 60, 0, 158, 0, 3, 0, 0,
+ax_anim 10, 0, 166, 1, 2, 0, 0,
+ax_anim 8, 0, 166, 0, 3, 0, 0,
+ax_anim 10, 0, 166, 0, 3, 0, 0,
+ax_anim 8, 0, 166, 1, 2, 0, 0,
+ax_anim 6, 0, 166, 0, 3, 0, 0,
+ax_anim 4, 0, 166, 1, 2, 0, 0,
+ax_anim 2, 0, 166, 0, 3, 0, 0,
+ax_anim 8, 0, 167, 1, -1, 0, 0,
+ax_anim 8, 0, 168, 1, -2, 0, 0,
+ax_anim 8, 0, 169, 2, -3, 0, 0,
+ax_anim 8, 0, 154, 2, -3, 0, 0,
+ax_anim 8, 0, 155, 1, -2, 0, 0,
+ax_anim 8, 0, 156, 1, -1, 0, 0,
+ax_anim 8, 0, 157, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_8_6:
+ax_anim 60, 0, 157, 0, 3, 0, 0,
+ax_anim 10, 0, 165, 1, 2, 0, 0,
+ax_anim 8, 0, 165, 0, 3, 0, 0,
+ax_anim 10, 0, 165, 0, 3, 0, 0,
+ax_anim 8, 0, 165, 1, 2, 0, 0,
+ax_anim 6, 0, 165, 0, 3, 0, 0,
+ax_anim 4, 0, 165, 1, 2, 0, 0,
+ax_anim 2, 0, 165, 0, 3, 0, 0,
+ax_anim 8, 0, 166, 1, -1, 0, 0,
+ax_anim 8, 0, 167, 1, -2, 0, 0,
+ax_anim 8, 0, 168, 2, -3, 0, 0,
+ax_anim 8, 0, 161, 2, -3, 0, 0,
+ax_anim 8, 0, 154, 1, -2, 0, 0,
+ax_anim 8, 0, 155, 1, -1, 0, 0,
+ax_anim 8, 0, 156, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_8_7:
+ax_anim 60, 0, 156, 0, 3, 0, 0,
+ax_anim 10, 0, 164, -1, 2, 0, 0,
+ax_anim 8, 0, 164, 0, 3, 0, 0,
+ax_anim 10, 0, 164, 0, 3, 0, 0,
+ax_anim 8, 0, 164, -1, 2, 0, 0,
+ax_anim 6, 0, 164, 0, 3, 0, 0,
+ax_anim 4, 0, 164, -1, 2, 0, 0,
+ax_anim 2, 0, 164, 0, 3, 0, 0,
+ax_anim 8, 0, 165, -1, -1, 0, 0,
+ax_anim 8, 0, 166, -1, -2, 0, 0,
+ax_anim 8, 0, 167, -2, -3, 0, 0,
+ax_anim 8, 0, 168, -2, -3, 0, 0,
+ax_anim 8, 0, 177, -1, -2, 0, 0,
+ax_anim 8, 0, 154, -1, -1, 0, 0,
+ax_anim 8, 0, 155, 0, 1, 0, 0,
+ax_anim_terminator
+sHoppipAnims_8_8:
+ax_anim 60, 0, 155, 0, 3, 0, 0,
+ax_anim 10, 0, 163, -1, 2, 0, 0,
+ax_anim 8, 0, 163, 0, 3, 0, 0,
+ax_anim 10, 0, 163, 0, 3, 0, 0,
+ax_anim 8, 0, 163, -1, 2, 0, 0,
+ax_anim 6, 0, 163, 0, 3, 0, 0,
+ax_anim 4, 0, 163, -1, 2, 0, 0,
+ax_anim 2, 0, 163, 0, 3, 0, 0,
+ax_anim 8, 0, 164, -1, -1, 0, 0,
+ax_anim 8, 0, 165, -1, -2, 0, 0,
+ax_anim 8, 0, 166, -2, -3, 0, 0,
+ax_anim 8, 0, 159, -2, -3, 0, 0,
+ax_anim 8, 0, 160, -1, -2, 0, 0,
+ax_anim 8, 0, 161, -1, -1, 0, 0,
+ax_anim 8, 0, 154, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 11, 8, 11,
+ax_anim 2, 0, 181, 7, 20, 7, 20,
+ax_anim 3, 0, 182, 0, 23, 0, 22,
+ax_anim 2, 3, 183, -7, 20, -7, 20,
+ax_anim 2, 0, 184, -8, 11, -8, 11,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 18, 5, 18, 5,
+ax_anim 2, 0, 180, 21, 13, 21, 13,
+ax_anim 3, 0, 181, 21, 22, 21, 21,
+ax_anim 2, 3, 182, 11, 25, 11, 23,
+ax_anim 2, 0, 183, 4, 18, 4, 18,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -3, 17, -3,
+ax_anim 3, 0, 180, 19, 2, 19, 0,
+ax_anim 2, 3, 181, 18, 7, 18, 6,
+ax_anim 2, 0, 182, 12, 8, 12, 8,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -8, 0, -8,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -20, 12, -21,
+ax_anim 3, 0, 179, 20, -18, 20, -20,
+ax_anim 2, 3, 180, 21, -12, 21, -13,
+ax_anim 2, 0, 181, 18, -4, 18, -4,
+ax_anim 1, 0, 182, 8, 0, 8, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -10, -9, -10,
+ax_anim 2, 0, 185, -7, -17, -7, -18,
+ax_anim 3, 0, 178, 0, -19, 0, -21,
+ax_anim 2, 3, 179, 7, -17, 7, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -8, 0, -8,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -20, -12, -19,
+ax_anim 3, 0, 185, -20, -18, -20, -16,
+ax_anim 2, 3, 184, -21, -12, -21, -11,
+ax_anim 2, 0, 183, -18, -4, -18, -4,
+ax_anim 1, 0, 182, -8, 0, -8, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -3, -17, -3,
+ax_anim 3, 0, 184, -19, 2, -19, 0,
+ax_anim 2, 3, 183, -18, 7, -18, 6,
+ax_anim 2, 0, 182, -12, 8, -12, 8,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -18, 5, -18, 5,
+ax_anim 2, 0, 184, -21, 13, -21, 13,
+ax_anim 3, 0, 183, -21, 22, -21, 21,
+ax_anim 2, 3, 182, -11, 25, -11, 23,
+ax_anim 2, 0, 181, -4, 18, -4, 18,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 3, 0, 0,
+ax_anim_terminator
+sHoppipAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 3, 0, 0,
+ax_anim_terminator
+sHoppipAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 4, 0, 0,
+ax_anim_terminator
+sHoppipAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 4, 0, 0,
+ax_anim_terminator
+sHoppipAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 4, 0, 0,
+ax_anim_terminator
+sHoppipAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 4, 0, 0,
+ax_anim_terminator
+sHoppipAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 4, 0, 0,
+ax_anim_terminator
+sHoppipAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoppipAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sHoppipGfx1:
+.incbin "baserom.gba", 0xD13F74, 0x100
+sHoppipSprites1:
+ax_sprite sHoppipGfx1, 0x100
+ax_sprite_terminator
+sHoppipGfx2:
+.incbin "baserom.gba", 0xD14084, 0x100
+sHoppipSprites2:
+ax_sprite sHoppipGfx2, 0x100
+ax_sprite_terminator
+sHoppipGfx3:
+.incbin "baserom.gba", 0xD14194, 0x100
+sHoppipSprites3:
+ax_sprite sHoppipGfx3, 0x100
+ax_sprite_terminator
+sHoppipGfx4:
+.incbin "baserom.gba", 0xD142A4, 0x80
+sHoppipSprites4:
+ax_sprite sHoppipGfx4, 0x80
+ax_sprite_terminator
+sHoppipGfx5:
+.incbin "baserom.gba", 0xD14334, 0x100
+sHoppipSprites5:
+ax_sprite sHoppipGfx5, 0x100
+ax_sprite_terminator
+sHoppipGfx6:
+.incbin "baserom.gba", 0xD14444, 0x100
+sHoppipSprites6:
+ax_sprite sHoppipGfx6, 0x100
+ax_sprite_terminator
+sHoppipGfx7:
+.incbin "baserom.gba", 0xD14554, 0x100
+sHoppipSprites7:
+ax_sprite sHoppipGfx7, 0x100
+ax_sprite_terminator
+sHoppipGfx8:
+.incbin "baserom.gba", 0xD14664, 0x100
+sHoppipSprites8:
+ax_sprite sHoppipGfx8, 0x100
+ax_sprite_terminator
+sHoppipGfx9:
+.incbin "baserom.gba", 0xD14774, 0x100
+sHoppipSprites9:
+ax_sprite sHoppipGfx9, 0x100
+ax_sprite_terminator
+sHoppipGfx10:
+.incbin "baserom.gba", 0xD14884, 0x100
+sHoppipSprites10:
+ax_sprite sHoppipGfx10, 0x100
+ax_sprite_terminator
+sHoppipGfx11:
+.incbin "baserom.gba", 0xD14994, 0x60
+sHoppipGfx11_1:
+.incbin "baserom.gba", 0xD149F4, 0x60
+sHoppipGfx11_2:
+.incbin "baserom.gba", 0xD14A54, 0x60
+sHoppipSprites11:
+ax_sprite sHoppipGfx11, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx11_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx11_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx12:
+.incbin "baserom.gba", 0xD14AEC, 0x60
+sHoppipGfx12_1:
+.incbin "baserom.gba", 0xD14B4C, 0x60
+sHoppipGfx12_2:
+.incbin "baserom.gba", 0xD14BAC, 0x60
+sHoppipSprites12:
+ax_sprite sHoppipGfx12, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx12_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx12_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx13:
+.incbin "baserom.gba", 0xD14C44, 0x100
+sHoppipGfx13_1:
+.incbin "baserom.gba", 0xD14D44, 0x40
+sHoppipSprites13:
+ax_sprite sHoppipGfx13, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx13_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx14:
+.incbin "baserom.gba", 0xD14DAC, 0x60
+sHoppipGfx14_1:
+.incbin "baserom.gba", 0xD14E0C, 0x60
+sHoppipGfx14_2:
+.incbin "baserom.gba", 0xD14E6C, 0x60
+sHoppipSprites14:
+ax_sprite sHoppipGfx14, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx14_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx14_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx15:
+.incbin "baserom.gba", 0xD14F04, 0x60
+sHoppipGfx15_1:
+.incbin "baserom.gba", 0xD14F64, 0x60
+sHoppipGfx15_2:
+.incbin "baserom.gba", 0xD14FC4, 0x60
+sHoppipSprites15:
+ax_sprite sHoppipGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx15_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx15_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx16:
+.incbin "baserom.gba", 0xD1505C, 0x40
+sHoppipGfx16_1:
+.incbin "baserom.gba", 0xD1509C, 0x60
+sHoppipGfx16_2:
+.incbin "baserom.gba", 0xD150FC, 0x60
+sHoppipSprites16:
+ax_sprite sHoppipGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoppipGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx17:
+.incbin "baserom.gba", 0xD15194, 0x40
+sHoppipGfx17_1:
+.incbin "baserom.gba", 0xD151D4, 0x60
+sHoppipGfx17_2:
+.incbin "baserom.gba", 0xD15234, 0x60
+sHoppipGfx17_3:
+.incbin "baserom.gba", 0xD15294, 0x60
+sHoppipSprites17:
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoppipGfx18:
+.incbin "baserom.gba", 0xD15344, 0x40
+sHoppipGfx18_1:
+.incbin "baserom.gba", 0xD15384, 0x60
+sHoppipGfx18_2:
+.incbin "baserom.gba", 0xD153E4, 0x60
+sHoppipSprites18:
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx19:
+.incbin "baserom.gba", 0xD15484, 0x40
+sHoppipGfx19_1:
+.incbin "baserom.gba", 0xD154C4, 0x60
+sHoppipGfx19_2:
+.incbin "baserom.gba", 0xD15524, 0x60
+sHoppipSprites19:
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx20:
+.incbin "baserom.gba", 0xD155C4, 0x60
+sHoppipGfx20_1:
+.incbin "baserom.gba", 0xD15624, 0x60
+sHoppipGfx20_2:
+.incbin "baserom.gba", 0xD15684, 0x60
+sHoppipGfx20_3:
+.incbin "baserom.gba", 0xD156E4, 0x20
+sHoppipSprites20:
+ax_sprite sHoppipGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoppipGfx20_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoppipGfx21:
+.incbin "baserom.gba", 0xD1574C, 0x60
+sHoppipGfx21_1:
+.incbin "baserom.gba", 0xD157AC, 0x60
+sHoppipGfx21_2:
+.incbin "baserom.gba", 0xD1580C, 0x60
+sHoppipGfx21_3:
+.incbin "baserom.gba", 0xD1586C, 0x60
+sHoppipSprites21:
+ax_sprite sHoppipGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoppipGfx22:
+.incbin "baserom.gba", 0xD15914, 0x40
+sHoppipGfx22_1:
+.incbin "baserom.gba", 0xD15954, 0x60
+sHoppipGfx22_2:
+.incbin "baserom.gba", 0xD159B4, 0x60
+sHoppipGfx22_3:
+.incbin "baserom.gba", 0xD15A14, 0x20
+sHoppipSprites22:
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoppipGfx22_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoppipGfx23:
+.incbin "baserom.gba", 0xD15A84, 0x60
+sHoppipGfx23_1:
+.incbin "baserom.gba", 0xD15AE4, 0x60
+sHoppipGfx23_2:
+.incbin "baserom.gba", 0xD15B44, 0x60
+sHoppipSprites23:
+ax_sprite sHoppipGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx24:
+.incbin "baserom.gba", 0xD15BDC, 0x60
+sHoppipGfx24_1:
+.incbin "baserom.gba", 0xD15C3C, 0x60
+sHoppipGfx24_2:
+.incbin "baserom.gba", 0xD15C9C, 0x60
+sHoppipSprites24:
+ax_sprite sHoppipGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx25:
+.incbin "baserom.gba", 0xD15D34, 0x100
+sHoppipGfx25_1:
+.incbin "baserom.gba", 0xD15E34, 0x40
+sHoppipSprites25:
+ax_sprite sHoppipGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx25_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx26:
+.incbin "baserom.gba", 0xD15E9C, 0x160
+sHoppipGfx26_1:
+.incbin "baserom.gba", 0xD15FFC, 0x20
+sHoppipSprites26:
+ax_sprite sHoppipGfx26, 0x160
+ax_sprite 0, 0x40
+ax_sprite sHoppipGfx26_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoppipGfx27:
+.incbin "baserom.gba", 0xD16044, 0x60
+sHoppipGfx27_1:
+.incbin "baserom.gba", 0xD160A4, 0xE0
+sHoppipSprites27:
+ax_sprite sHoppipGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx27_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoppipGfx28:
+.incbin "baserom.gba", 0xD161AC, 0x40
+sHoppipGfx28_1:
+.incbin "baserom.gba", 0xD161EC, 0x60
+sHoppipGfx28_2:
+.incbin "baserom.gba", 0xD1624C, 0x60
+sHoppipGfx28_3:
+.incbin "baserom.gba", 0xD162AC, 0x40
+sHoppipSprites28:
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoppipGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoppipGfx29:
+.incbin "baserom.gba", 0xD1633C, 0x40
+sHoppipGfx29_1:
+.incbin "baserom.gba", 0xD1637C, 0x60
+sHoppipGfx29_2:
+.incbin "baserom.gba", 0xD163DC, 0x60
+sHoppipGfx29_3:
+.incbin "baserom.gba", 0xD1643C, 0x40
+sHoppipSprites29:
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoppipGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoppipGfx30:
+.incbin "baserom.gba", 0xD164CC, 0x40
+sHoppipGfx30_1:
+.incbin "baserom.gba", 0xD1650C, 0xE0
+sHoppipGfx30_2:
+.incbin "baserom.gba", 0xD165EC, 0x20
+sHoppipSprites30:
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoppipGfx30_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sHoppipGfx30_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoppipGfx31:
+.incbin "baserom.gba", 0xD1664C, 0x200
+sHoppipSprites31:
+ax_sprite sHoppipGfx31, 0x200
+ax_sprite_terminator
+sHoppipGfx32:
+.incbin "baserom.gba", 0xD1685C, 0x200
+sHoppipSprites32:
+ax_sprite sHoppipGfx32, 0x200
+ax_sprite_terminator
+sHoppipGfx33:
+.incbin "baserom.gba", 0xD16A6C, 0x200
+sHoppipSprites33:
+ax_sprite sHoppipGfx33, 0x200
+ax_sprite_terminator
+sHoppipGfx34:
+.incbin "baserom.gba", 0xD16C7C, 0x200
+sHoppipSprites34:
+ax_sprite sHoppipGfx34, 0x200
+ax_sprite_terminator
+sHoppipGfx35:
+.incbin "baserom.gba", 0xD16E8C, 0x200
+sHoppipSprites35:
+ax_sprite sHoppipGfx35, 0x200
+ax_sprite_terminator
+sHoppipGfx36:
+.incbin "baserom.gba", 0xD1709C, 0x200
+sHoppipSprites36:
+ax_sprite sHoppipGfx36, 0x200
+ax_sprite_terminator
+sHoppipGfx37:
+.incbin "baserom.gba", 0xD172AC, 0x200
+sHoppipSprites37:
+ax_sprite sHoppipGfx37, 0x200
+ax_sprite_terminator
+sAxPosesHoppip:
+.4byte sHoppipPose1
+.4byte sHoppipPose2
+.4byte sHoppipPose3
+.4byte sHoppipPose4
+.4byte sHoppipPose5
+.4byte sHoppipPose6
+.4byte sHoppipPose7
+.4byte sHoppipPose8
+.4byte sHoppipPose9
+.4byte sHoppipPose10
+.4byte sHoppipPose11
+.4byte sHoppipPose12
+.4byte sHoppipPose13
+.4byte sHoppipPose14
+.4byte sHoppipPose15
+.4byte sHoppipPose16
+.4byte sHoppipPose17
+.4byte sHoppipPose18
+.4byte sHoppipPose19
+.4byte sHoppipPose20
+.4byte sHoppipPose21
+.4byte sHoppipPose22
+.4byte sHoppipPose23
+.4byte sHoppipPose24
+.4byte sHoppipPose25
+.4byte sHoppipPose26
+.4byte sHoppipPose27
+.4byte sHoppipPose28
+.4byte sHoppipPose29
+.4byte sHoppipPose30
+.4byte sHoppipPose31
+.4byte sHoppipPose32
+.4byte sHoppipPose33
+.4byte sHoppipPose34
+.4byte sHoppipPose35
+.4byte sHoppipPose36
+.4byte sHoppipPose37
+.4byte sHoppipPose38
+.4byte sHoppipPose39
+.4byte sHoppipPose40
+.4byte sHoppipPose41
+.4byte sHoppipPose42
+.4byte sHoppipPose43
+.4byte sHoppipPose44
+.4byte sHoppipPose45
+.4byte sHoppipPose46
+.4byte sHoppipPose47
+.4byte sHoppipPose48
+.4byte sHoppipPose49
+.4byte sHoppipPose50
+.4byte sHoppipPose51
+.4byte sHoppipPose52
+.4byte sHoppipPose53
+.4byte sHoppipPose54
+.4byte sHoppipPose55
+.4byte sHoppipPose56
+.4byte sHoppipPose57
+.4byte sHoppipPose58
+.4byte sHoppipPose59
+.4byte sHoppipPose60
+.4byte sHoppipPose61
+.4byte sHoppipPose62
+.4byte sHoppipPose63
+.4byte sHoppipPose64
+.4byte sHoppipPose65
+.4byte sHoppipPose66
+.4byte sHoppipPose67
+.4byte sHoppipPose68
+.4byte sHoppipPose69
+.4byte sHoppipPose70
+.4byte sHoppipPose71
+.4byte sHoppipPose72
+.4byte sHoppipPose73
+.4byte sHoppipPose74
+.4byte sHoppipPose75
+.4byte sHoppipPose76
+.4byte sHoppipPose77
+.4byte sHoppipPose78
+.4byte sHoppipPose79
+.4byte sHoppipPose80
+.4byte sHoppipPose81
+.4byte sHoppipPose82
+.4byte sHoppipPose83
+.4byte sHoppipPose84
+.4byte sHoppipPose85
+.4byte sHoppipPose86
+.4byte sHoppipPose87
+.4byte sHoppipPose88
+.4byte sHoppipPose89
+.4byte sHoppipPose90
+.4byte sHoppipPose91
+.4byte sHoppipPose92
+.4byte sHoppipPose93
+.4byte sHoppipPose94
+.4byte sHoppipPose95
+.4byte sHoppipPose96
+.4byte sHoppipPose97
+.4byte sHoppipPose98
+.4byte sHoppipPose99
+.4byte sHoppipPose100
+.4byte sHoppipPose101
+.4byte sHoppipPose102
+.4byte sHoppipPose103
+.4byte sHoppipPose104
+.4byte sHoppipPose105
+.4byte sHoppipPose106
+.4byte sHoppipPose107
+.4byte sHoppipPose108
+.4byte sHoppipPose109
+.4byte sHoppipPose110
+.4byte sHoppipPose111
+.4byte sHoppipPose112
+.4byte sHoppipPose113
+.4byte sHoppipPose114
+.4byte sHoppipPose115
+.4byte sHoppipPose116
+.4byte sHoppipPose117
+.4byte sHoppipPose118
+.4byte sHoppipPose119
+.4byte sHoppipPose120
+.4byte sHoppipPose121
+.4byte sHoppipPose122
+.4byte sHoppipPose123
+.4byte sHoppipPose124
+.4byte sHoppipPose125
+.4byte sHoppipPose126
+.4byte sHoppipPose127
+.4byte sHoppipPose128
+.4byte sHoppipPose129
+.4byte sHoppipPose130
+.4byte sHoppipPose131
+.4byte sHoppipPose132
+.4byte sHoppipPose133
+.4byte sHoppipPose134
+.4byte sHoppipPose135
+.4byte sHoppipPose136
+.4byte sHoppipPose137
+.4byte sHoppipPose138
+.4byte sHoppipPose139
+.4byte sHoppipPose140
+.4byte sHoppipPose141
+.4byte sHoppipPose142
+.4byte sHoppipPose143
+.4byte sHoppipPose144
+.4byte sHoppipPose145
+.4byte sHoppipPose146
+.4byte sHoppipPose147
+.4byte sHoppipPose148
+.4byte sHoppipPose149
+.4byte sHoppipPose150
+.4byte sHoppipPose151
+.4byte sHoppipPose152
+.4byte sHoppipPose153
+.4byte sHoppipPose154
+.4byte sHoppipPose155
+.4byte sHoppipPose156
+.4byte sHoppipPose157
+.4byte sHoppipPose158
+.4byte sHoppipPose159
+.4byte sHoppipPose160
+.4byte sHoppipPose161
+.4byte sHoppipPose162
+.4byte sHoppipPose163
+.4byte sHoppipPose164
+.4byte sHoppipPose165
+.4byte sHoppipPose166
+.4byte sHoppipPose167
+.4byte sHoppipPose168
+.4byte sHoppipPose169
+.4byte sHoppipPose170
+.4byte sHoppipPose171
+.4byte sHoppipPose172
+.4byte sHoppipPose173
+.4byte sHoppipPose174
+.4byte sHoppipPose175
+.4byte sHoppipPose176
+.4byte sHoppipPose177
+.4byte sHoppipPose178
+.4byte sHoppipPose179
+.4byte sHoppipPose180
+.4byte sHoppipPose181
+.4byte sHoppipPose182
+.4byte sHoppipPose183
+.4byte sHoppipPose184
+.4byte sHoppipPose185
+.4byte sHoppipPose186
+.4byte sHoppipPose187
+.4byte sHoppipPose188
+.4byte sHoppipPose189
+.4byte sHoppipPose190
+.4byte sHoppipPose191
+.4byte sHoppipPose192
+.4byte sHoppipPose193
+.4byte sHoppipPose194
+.4byte sHoppipPose195
+.4byte sHoppipPose196
+.4byte sHoppipPose197
+.4byte sHoppipPose198
+.4byte sHoppipPose199
+.4byte sHoppipPose200
+.4byte sHoppipPose201
+.4byte sHoppipPose202
+.4byte sHoppipPose203
+.4byte sHoppipPose204
+.4byte sHoppipPose205
+.4byte sHoppipPose206
+.4byte sHoppipPose207
+.4byte sHoppipPose208
+.4byte sHoppipPose209
+.4byte sHoppipPose210
+.4byte sHoppipPose211
+.4byte sHoppipPose212
+.4byte sHoppipPose213
+.4byte sHoppipPose214
+.4byte sHoppipPose215
+.4byte sHoppipPose216
+.4byte sHoppipPose217
+.4byte sHoppipPose218
+.4byte sHoppipPose219
+.4byte sHoppipPose220
+.4byte sHoppipPose221
+.4byte sHoppipPose222
+.4byte sHoppipPose223
+.4byte sHoppipPose224
+.4byte sHoppipPose225
+.4byte sHoppipPose226
+.4byte sHoppipPose227
+.4byte sHoppipPose228
+.4byte sHoppipPose229
+.4byte sHoppipPose230
+.4byte sHoppipPose231
+.4byte sHoppipPose232
+.4byte sHoppipPose233
+.4byte sHoppipPose234
+sAxPositionsHoppip:
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -8
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -10, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -1,   -9, 	   6,   -6, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,   -9, 	   2,   -7, 	  -3,   -7, 	   0,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   0,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	  -1,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,  -11, 	   0,   -9, 	   6,   -6, 	   0,  -10
+.2byte    2,  -12, 	  -1,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    1,  -10, 	   0,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte   -3,  -11, 	  -1,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -3,  -12, 	   0,   -9, 	  -7,   -6, 	   0,  -10
+.2byte   -2,  -10, 	  -1,   -9, 	  -7,   -6, 	   0,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	  -1,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,  -11, 	   0,   -9, 	   6,   -6, 	   0,  -10
+.2byte    2,  -12, 	  -1,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    1,  -10, 	   0,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte   -3,  -11, 	  -1,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -3,  -12, 	   0,   -9, 	  -7,   -6, 	   0,  -10
+.2byte   -2,  -10, 	  -1,   -9, 	  -7,   -6, 	   0,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte    0,  -12, 	  -7,   -9, 	   6,   -9, 	  -1,  -10
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,  -13, 	   6,  -12, 	  -2,   -9, 	   0,  -12
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    5,  -13, 	   6,  -14, 	   5,  -10, 	  -1,  -11
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,  -11, 	   0,   -9, 	   6,   -6, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -15, 	   4,  -12, 	  -1,   -9
+.2byte    1,  -10, 	   0,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -11, 	  -1,  -11
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte   -3,  -11, 	  -1,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -2,  -13, 	   2,  -15, 	  -5,  -12, 	   0,   -9
+.2byte   -2,  -10, 	  -1,   -9, 	  -7,   -6, 	   0,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -6,  -13, 	  -7,  -14, 	  -6,  -10, 	   0,  -11
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,  -13, 	  -7,  -12, 	   1,   -9, 	  -1,  -12
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -2,  -10, 	  -1,   -9, 	  -7,   -6, 	   0,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    1,  -10, 	   0,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte   -4,   -7, 	  -6,   -5, 	  -1,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,   -4, 	  -1,   -2, 	  -2,   -7
+.2byte   -1,  -12, 	  -5,   -8, 	   4,   -8, 	  -1,  -11
+.2byte    1,  -13, 	   6,  -10, 	   1,   -8, 	  -1,  -11
+.2byte    4,  -14, 	   7,  -13, 	   4,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -1,  -14, 	   7,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	   3,  -11, 	  -4,  -11, 	   0,  -12
+.2byte   -1,  -14, 	   0,  -14, 	  -8,  -11, 	   0,  -12
+.2byte   -5,  -14, 	  -8,  -13, 	  -5,   -9, 	   0,  -12
+.2byte   -2,  -13, 	  -7,  -10, 	  -2,   -8, 	   0,  -11
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,  -12, 	  -1,  -10, 	  -7,   -7, 	  -1,  -11
+.2byte    0,  -11, 	   2,   -9, 	  -3,   -9, 	  -1,  -10
+.2byte    2,  -11, 	   0,   -9, 	   6,   -6, 	   0,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	  -1,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,  -13, 	   0,  -10, 	  -7,   -7, 	   0,  -11
+.2byte    0,  -11, 	   2,   -9, 	  -3,   -9, 	  -1,  -10
+.2byte    2,  -12, 	  -1,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -2,  -11, 	  -1,  -10, 	  -7,   -7, 	   0,  -11
+.2byte    0,  -11, 	   2,   -9, 	  -3,   -9, 	  -1,  -10
+.2byte    1,  -10, 	   0,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -5,   -8, 	  -7,   -7, 	  -5,   -4, 	   0,   -9
+.2byte   -3,  -11, 	  -1,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    2,  -11, 	   0,   -9, 	   6,   -6, 	   0,  -10
+.2byte    4,   -8, 	   6,   -7, 	   4,   -4, 	  -1,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    0,  -12, 	  -7,   -9, 	   6,   -9, 	  -1,  -10
+.2byte    2,  -12, 	   6,  -11, 	  -2,   -8, 	   0,  -11
+.2byte    6,  -12, 	   7,  -13, 	   6,   -9, 	   0,  -10
+.2byte    1,  -14, 	  -3,  -16, 	   4,  -13, 	  -1,  -10
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -11, 	  -1,  -11
+.2byte   -2,  -14, 	   2,  -16, 	  -5,  -13, 	   0,  -10
+.2byte   -6,  -12, 	  -7,  -13, 	  -6,   -9, 	   0,  -10
+.2byte   -3,  -12, 	  -7,  -11, 	   1,   -8, 	  -1,  -11
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte    0,  -12, 	  -7,   -9, 	   6,   -9, 	  -1,  -10
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	  -1,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    2,  -13, 	   6,  -12, 	  -2,   -9, 	   0,  -12
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    6,  -13, 	   7,  -14, 	   6,  -10, 	   0,  -11
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,  -11, 	   0,   -9, 	   6,   -6, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -15, 	   4,  -12, 	  -1,   -9
+.2byte    2,  -12, 	  -1,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -11, 	  -1,  -11
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte   -3,  -11, 	  -1,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte   -2,  -13, 	   2,  -15, 	  -5,  -12, 	   0,   -9
+.2byte   -3,  -12, 	   0,   -9, 	  -7,   -6, 	   0,  -10
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -7,  -13, 	  -8,  -14, 	  -7,  -10, 	  -1,  -11
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -3,  -13, 	  -7,  -12, 	   1,   -9, 	  -1,  -12
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -2,  -10, 	  -1,   -9, 	  -7,   -6, 	   0,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    1,  -10, 	   0,   -9, 	   6,   -6, 	  -1,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+.2byte   -1,   -8, 	  -3,   -5, 	   2,   -5, 	   0,   -9
+.2byte   -3,   -9, 	  -7,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -6,   -9, 	  -8,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,  -11, 	  -1,   -9, 	  -7,   -6, 	  -1,  -10
+.2byte    0,  -10, 	   2,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    2,  -11, 	   0,   -9, 	   6,   -6, 	   0,  -10
+.2byte    5,   -9, 	   7,   -8, 	   5,   -5, 	   0,  -10
+.2byte    2,   -9, 	   6,   -6, 	   1,   -4, 	   0,   -9
+sHoppipAnimTable1:
+.4byte sHoppipAnims_1_1
+.4byte sHoppipAnims_1_2
+.4byte sHoppipAnims_1_3
+.4byte sHoppipAnims_1_4
+.4byte sHoppipAnims_1_5
+.4byte sHoppipAnims_1_6
+.4byte sHoppipAnims_1_7
+.4byte sHoppipAnims_1_8
+sHoppipAnimTable2:
+.4byte sHoppipAnims_2_1
+.4byte sHoppipAnims_2_2
+.4byte sHoppipAnims_2_3
+.4byte sHoppipAnims_2_4
+.4byte sHoppipAnims_2_5
+.4byte sHoppipAnims_2_6
+.4byte sHoppipAnims_2_7
+.4byte sHoppipAnims_2_8
+sHoppipAnimTable3:
+.4byte sHoppipAnims_3_1
+.4byte sHoppipAnims_3_2
+.4byte sHoppipAnims_3_3
+.4byte sHoppipAnims_3_4
+.4byte sHoppipAnims_3_5
+.4byte sHoppipAnims_3_6
+.4byte sHoppipAnims_3_7
+.4byte sHoppipAnims_3_8
+sHoppipAnimTable4:
+.4byte sHoppipAnims_4_1
+.4byte sHoppipAnims_4_2
+.4byte sHoppipAnims_4_3
+.4byte sHoppipAnims_4_4
+.4byte sHoppipAnims_4_5
+.4byte sHoppipAnims_4_6
+.4byte sHoppipAnims_4_7
+.4byte sHoppipAnims_4_8
+sHoppipAnimTable5:
+.4byte sHoppipAnims_5_1
+.4byte sHoppipAnims_5_2
+.4byte sHoppipAnims_5_3
+.4byte sHoppipAnims_5_4
+.4byte sHoppipAnims_5_5
+.4byte sHoppipAnims_5_6
+.4byte sHoppipAnims_5_7
+.4byte sHoppipAnims_5_8
+sHoppipAnimTable6:
+.4byte sHoppipAnims_6_1
+.4byte sHoppipAnims_6_1
+.4byte sHoppipAnims_6_1
+.4byte sHoppipAnims_6_1
+.4byte sHoppipAnims_6_1
+.4byte sHoppipAnims_6_1
+.4byte sHoppipAnims_6_1
+.4byte sHoppipAnims_6_1
+sHoppipAnimTable7:
+.4byte sHoppipAnims_7_1
+.4byte sHoppipAnims_7_2
+.4byte sHoppipAnims_7_3
+.4byte sHoppipAnims_7_4
+.4byte sHoppipAnims_7_5
+.4byte sHoppipAnims_7_6
+.4byte sHoppipAnims_7_7
+.4byte sHoppipAnims_7_8
+sHoppipAnimTable8:
+.4byte sHoppipAnims_8_1
+.4byte sHoppipAnims_8_2
+.4byte sHoppipAnims_8_3
+.4byte sHoppipAnims_8_4
+.4byte sHoppipAnims_8_5
+.4byte sHoppipAnims_8_6
+.4byte sHoppipAnims_8_7
+.4byte sHoppipAnims_8_8
+sHoppipAnimTable9:
+.4byte sHoppipAnims_9_1
+.4byte sHoppipAnims_9_2
+.4byte sHoppipAnims_9_3
+.4byte sHoppipAnims_9_4
+.4byte sHoppipAnims_9_5
+.4byte sHoppipAnims_9_6
+.4byte sHoppipAnims_9_7
+.4byte sHoppipAnims_9_8
+sHoppipAnimTable10:
+.4byte sHoppipAnims_10_1
+.4byte sHoppipAnims_10_2
+.4byte sHoppipAnims_10_3
+.4byte sHoppipAnims_10_4
+.4byte sHoppipAnims_10_5
+.4byte sHoppipAnims_10_6
+.4byte sHoppipAnims_10_7
+.4byte sHoppipAnims_10_8
+sHoppipAnimTable11:
+.4byte sHoppipAnims_11_1
+.4byte sHoppipAnims_11_2
+.4byte sHoppipAnims_11_3
+.4byte sHoppipAnims_11_4
+.4byte sHoppipAnims_11_5
+.4byte sHoppipAnims_11_6
+.4byte sHoppipAnims_11_7
+.4byte sHoppipAnims_11_8
+sHoppipAnimTable12:
+.4byte sHoppipAnims_12_1
+.4byte sHoppipAnims_12_2
+.4byte sHoppipAnims_12_3
+.4byte sHoppipAnims_12_4
+.4byte sHoppipAnims_12_5
+.4byte sHoppipAnims_12_6
+.4byte sHoppipAnims_12_7
+.4byte sHoppipAnims_12_8
+sHoppipAnimTable13:
+.4byte sHoppipAnims_13_1
+.4byte sHoppipAnims_13_2
+.4byte sHoppipAnims_13_3
+.4byte sHoppipAnims_13_4
+.4byte sHoppipAnims_13_5
+.4byte sHoppipAnims_13_6
+.4byte sHoppipAnims_13_7
+.4byte sHoppipAnims_13_8
+sAxAnimationsHoppip:
+.4byte sHoppipAnimTable1
+.4byte sHoppipAnimTable2
+.4byte sHoppipAnimTable3
+.4byte sHoppipAnimTable4
+.4byte sHoppipAnimTable5
+.4byte sHoppipAnimTable6
+.4byte sHoppipAnimTable7
+.4byte sHoppipAnimTable8
+.4byte sHoppipAnimTable9
+.4byte sHoppipAnimTable10
+.4byte sHoppipAnimTable11
+.4byte sHoppipAnimTable12
+.4byte sHoppipAnimTable13
+sAxSpritesHoppip:
+.4byte sHoppipSprites1
+.4byte sHoppipSprites2
+.4byte sHoppipSprites3
+.4byte sHoppipSprites4
+.4byte sHoppipSprites5
+.4byte sHoppipSprites6
+.4byte sHoppipSprites7
+.4byte sHoppipSprites8
+.4byte sHoppipSprites9
+.4byte sHoppipSprites10
+.4byte sHoppipSprites11
+.4byte sHoppipSprites12
+.4byte sHoppipSprites13
+.4byte sHoppipSprites14
+.4byte sHoppipSprites15
+.4byte sHoppipSprites16
+.4byte sHoppipSprites17
+.4byte sHoppipSprites18
+.4byte sHoppipSprites19
+.4byte sHoppipSprites20
+.4byte sHoppipSprites21
+.4byte sHoppipSprites22
+.4byte sHoppipSprites23
+.4byte sHoppipSprites24
+.4byte sHoppipSprites25
+.4byte sHoppipSprites26
+.4byte sHoppipSprites27
+.4byte sHoppipSprites28
+.4byte sHoppipSprites29
+.4byte sHoppipSprites30
+.4byte sHoppipSprites31
+.4byte sHoppipSprites32
+.4byte sHoppipSprites33
+.4byte sHoppipSprites34
+.4byte sHoppipSprites35
+.4byte sHoppipSprites36
+.4byte sHoppipSprites37
+sAxMainHoppip:
+ax_main sAxPosesHoppip, sAxAnimationsHoppip, 13, sAxSpritesHoppip, sAxPositionsHoppip

--- a/data/ax/horsea.inc
+++ b/data/ax/horsea.inc
@@ -1,0 +1,2522 @@
+.global gAxHorsea
+gAxHorsea:
+ax_siro sAxMainHorsea
+sHorseaPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose4:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose5:
+ax_pose 4, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose6:
+ax_pose 5, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose7:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose8:
+ax_pose 7, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose9:
+ax_pose 8, 0x81e5, 0x90f9, 0x0c00
+ax_pose_terminator
+sHorseaPose10:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose11:
+ax_pose 10, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose12:
+ax_pose 11, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose17:
+ax_pose 10, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose20:
+ax_pose 7, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose21:
+ax_pose 8, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sHorseaPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose24:
+ax_pose 5, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose26:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose27:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose28:
+ax_pose 15, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose29:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose30:
+ax_pose 4, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose31:
+ax_pose 5, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose32:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose33:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose34:
+ax_pose 7, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose35:
+ax_pose 8, 0x81e5, 0x90f9, 0x0c00
+ax_pose_terminator
+sHorseaPose36:
+ax_pose 17, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose37:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose38:
+ax_pose 10, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose39:
+ax_pose 11, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose40:
+ax_pose 18, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose41:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose42:
+ax_pose 13, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose43:
+ax_pose 14, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose44:
+ax_pose 19, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose45:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose46:
+ax_pose 10, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose47:
+ax_pose 11, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose48:
+ax_pose 18, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose49:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose50:
+ax_pose 7, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose51:
+ax_pose 8, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sHorseaPose52:
+ax_pose 17, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose53:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose54:
+ax_pose 4, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose55:
+ax_pose 5, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose56:
+ax_pose 16, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose57:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose58:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose59:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose60:
+ax_pose 15, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose61:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose62:
+ax_pose 4, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose63:
+ax_pose 5, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose64:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose65:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose66:
+ax_pose 7, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose67:
+ax_pose 8, 0x81e5, 0x90f9, 0x0c00
+ax_pose_terminator
+sHorseaPose68:
+ax_pose 17, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose69:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose70:
+ax_pose 10, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose71:
+ax_pose 11, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose72:
+ax_pose 18, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose73:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose74:
+ax_pose 13, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose75:
+ax_pose 14, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose76:
+ax_pose 19, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose77:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose78:
+ax_pose 10, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose79:
+ax_pose 11, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose80:
+ax_pose 18, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose81:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose82:
+ax_pose 7, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose83:
+ax_pose 8, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sHorseaPose84:
+ax_pose 17, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose85:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose86:
+ax_pose 4, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose87:
+ax_pose 5, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose88:
+ax_pose 16, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose89:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose90:
+ax_pose 20, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose91:
+ax_pose 21, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose92:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose93:
+ax_pose 22, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose94:
+ax_pose 23, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose95:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose96:
+ax_pose 24, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose97:
+ax_pose 25, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose98:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose99:
+ax_pose 26, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose100:
+ax_pose 27, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose101:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose102:
+ax_pose 28, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose103:
+ax_pose 29, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose104:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose105:
+ax_pose 26, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose106:
+ax_pose 27, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose107:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose108:
+ax_pose 24, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose109:
+ax_pose 25, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose110:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose111:
+ax_pose 22, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose112:
+ax_pose 23, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose113:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose114:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose115:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose116:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose117:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose118:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose119:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose120:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose121:
+ax_pose 30, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sHorseaPose122:
+ax_pose 31, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sHorseaPose123:
+ax_pose 32, 0x01de, 0x80f2, 0x0c00
+ax_pose_terminator
+sHorseaPose124:
+ax_pose 33, 0x01df, 0x90ef, 0x0c00
+ax_pose_terminator
+sHorseaPose125:
+ax_pose 34, 0x01e0, 0x90ee, 0x0c00
+ax_pose_terminator
+sHorseaPose126:
+ax_pose 35, 0x01de, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose127:
+ax_pose 36, 0x01df, 0x80f1, 0x0c00
+ax_pose_terminator
+sHorseaPose128:
+ax_pose 35, 0x01de, 0x80f3, 0x0c00
+ax_pose_terminator
+sHorseaPose129:
+ax_pose 34, 0x01e0, 0x80f2, 0x0c00
+ax_pose_terminator
+sHorseaPose130:
+ax_pose 33, 0x01df, 0x80f1, 0x0c00
+ax_pose_terminator
+sHorseaPose131:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose132:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose133:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose134:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose135:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose136:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose137:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose138:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose139:
+ax_pose 15, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose140:
+ax_pose 16, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose141:
+ax_pose 17, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sHorseaPose142:
+ax_pose 18, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose143:
+ax_pose 19, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose144:
+ax_pose 18, 0x01e4, 0x90ec, 0x0c00
+ax_pose_terminator
+sHorseaPose145:
+ax_pose 17, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose146:
+ax_pose 16, 0x01e3, 0x90ec, 0x0c00
+ax_pose_terminator
+sHorseaPose147:
+ax_pose 20, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose148:
+ax_pose 22, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose149:
+ax_pose 24, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose150:
+ax_pose 26, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sHorseaPose151:
+ax_pose 28, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose152:
+ax_pose 26, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sHorseaPose153:
+ax_pose 24, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose154:
+ax_pose 22, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose155:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose156:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose157:
+ax_pose 1, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose158:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose159:
+ax_pose 5, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose160:
+ax_pose 4, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose161:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose162:
+ax_pose 8, 0x81e5, 0x90f9, 0x0c00
+ax_pose_terminator
+sHorseaPose163:
+ax_pose 7, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose164:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose165:
+ax_pose 11, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose166:
+ax_pose 10, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose167:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose168:
+ax_pose 14, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose169:
+ax_pose 13, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose170:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose171:
+ax_pose 11, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose172:
+ax_pose 10, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose173:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose174:
+ax_pose 8, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sHorseaPose175:
+ax_pose 7, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose176:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose177:
+ax_pose 5, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose178:
+ax_pose 4, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose179:
+ax_pose 21, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose180:
+ax_pose 23, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose181:
+ax_pose 25, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose182:
+ax_pose 27, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose183:
+ax_pose 29, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose184:
+ax_pose 27, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose185:
+ax_pose 25, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose186:
+ax_pose 23, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose187:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose188:
+ax_pose 3, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose189:
+ax_pose 6, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose190:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose191:
+ax_pose 12, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sHorseaPose192:
+ax_pose 9, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose193:
+ax_pose 6, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sHorseaPose194:
+ax_pose 3, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+.align 2
+sHorseaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 13, 0, 10,
+ax_anim 2, 0, 27, 0, 26, 0, 21,
+ax_anim 2, 1, 27, 1, 26, 1, 21,
+ax_anim 2, 0, 27, 0, 26, 0, 21,
+ax_anim 2, 0, 27, 1, 26, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHorseaAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 4, 0, 30, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 5, 4, 5,
+ax_anim 1, 0, 29, 12, 15, 12, 14,
+ax_anim 2, 0, 31, 20, 25, 20, 23,
+ax_anim 2, 1, 31, 21, 24, 21, 22,
+ax_anim 2, 0, 31, 20, 25, 20, 23,
+ax_anim 2, 0, 31, 21, 24, 21, 22,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sHorseaAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 13, 3, 13, 0,
+ax_anim 2, 0, 35, 18, 5, 18, 0,
+ax_anim 2, 1, 35, 18, 6, 18, 1,
+ax_anim 2, 0, 35, 18, 5, 18, 0,
+ax_anim 2, 0, 35, 18, 6, 18, 1,
+ax_anim 2, 0, 32, 6, 1, 6, 0,
+ax_anim_terminator
+sHorseaAnims_2_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 4, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -5, 6, -6,
+ax_anim 1, 0, 37, 12, -9, 12, -12,
+ax_anim 2, 0, 39, 20, -15, 20, -21,
+ax_anim 2, 1, 39, 21, -14, 21, -20,
+ax_anim 2, 0, 39, 20, -15, 20, -21,
+ax_anim 2, 0, 39, 21, -14, 21, -20,
+ax_anim 2, 0, 36, 7, -5, 7, -6,
+ax_anim_terminator
+sHorseaAnims_2_5:
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 4, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -5,
+ax_anim 1, 0, 41, 0, -11, 0, -13,
+ax_anim 2, 0, 43, 0, -16, 0, -19,
+ax_anim 2, 1, 43, 1, -16, 1, -19,
+ax_anim 2, 0, 43, 0, -16, 0, -19,
+ax_anim 2, 0, 43, 1, -16, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -7,
+ax_anim_terminator
+sHorseaAnims_2_6:
+ax_anim 2, 0, 46, 1, 1, 1, 1,
+ax_anim 4, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -5, -6, -6,
+ax_anim 1, 0, 45, -12, -9, -12, -12,
+ax_anim 2, 0, 47, -20, -15, -20, -21,
+ax_anim 2, 1, 47, -21, -14, -21, -20,
+ax_anim 2, 0, 47, -20, -15, -20, -21,
+ax_anim 2, 0, 47, -21, -14, -21, -20,
+ax_anim 2, 0, 44, -7, -5, -7, -6,
+ax_anim_terminator
+sHorseaAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 4, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 49, -13, 3, -13, 0,
+ax_anim 2, 0, 51, -18, 5, -18, 0,
+ax_anim 2, 1, 51, -18, 6, -18, 1,
+ax_anim 2, 0, 51, -18, 5, -18, 0,
+ax_anim 2, 0, 51, -18, 6, -18, 1,
+ax_anim 2, 0, 48, -6, 1, -6, 0,
+ax_anim_terminator
+sHorseaAnims_2_8:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 4, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 5, -4, 5,
+ax_anim 1, 0, 53, -12, 15, -12, 14,
+ax_anim 2, 0, 55, -20, 25, -20, 23,
+ax_anim 2, 1, 55, -21, 24, -21, 22,
+ax_anim 2, 0, 55, -20, 25, -20, 23,
+ax_anim 2, 0, 55, -21, 24, -21, 22,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHorseaAnims_3_1:
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 4, 0, 58, 0, -2, 0, -2,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 13, 0, 10,
+ax_anim 2, 0, 59, 0, 26, 0, 21,
+ax_anim 2, 1, 59, 1, 26, 1, 21,
+ax_anim 2, 0, 59, 0, 26, 0, 21,
+ax_anim 2, 0, 59, 1, 26, 1, 21,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sHorseaAnims_3_2:
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 4, 0, 62, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 5, 4, 5,
+ax_anim 1, 0, 61, 12, 15, 12, 14,
+ax_anim 2, 0, 63, 20, 25, 20, 23,
+ax_anim 2, 1, 63, 21, 24, 21, 22,
+ax_anim 2, 0, 63, 20, 25, 20, 23,
+ax_anim 2, 0, 63, 21, 24, 21, 22,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sHorseaAnims_3_3:
+ax_anim 2, 0, 66, -1, 0, -1, 0,
+ax_anim 4, 0, 66, -2, 0, -2, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 65, 13, 3, 13, 0,
+ax_anim 2, 0, 67, 18, 5, 18, 0,
+ax_anim 2, 1, 67, 18, 6, 18, 1,
+ax_anim 2, 0, 67, 18, 5, 18, 0,
+ax_anim 2, 0, 67, 18, 6, 18, 1,
+ax_anim 2, 0, 64, 6, 1, 6, 0,
+ax_anim_terminator
+sHorseaAnims_3_4:
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim 4, 0, 70, -2, 2, -2, 2,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 6, -5, 6, -6,
+ax_anim 1, 0, 69, 12, -9, 12, -12,
+ax_anim 2, 0, 71, 20, -15, 20, -21,
+ax_anim 2, 1, 71, 21, -14, 21, -20,
+ax_anim 2, 0, 71, 20, -15, 20, -21,
+ax_anim 2, 0, 71, 21, -14, 21, -20,
+ax_anim 2, 0, 68, 7, -5, 7, -6,
+ax_anim_terminator
+sHorseaAnims_3_5:
+ax_anim 2, 0, 74, 0, 1, 0, 1,
+ax_anim 4, 0, 74, 0, 2, 0, 2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -5,
+ax_anim 1, 0, 73, 0, -11, 0, -13,
+ax_anim 2, 0, 75, 0, -16, 0, -19,
+ax_anim 2, 1, 75, 1, -16, 1, -19,
+ax_anim 2, 0, 75, 0, -16, 0, -19,
+ax_anim 2, 0, 75, 1, -16, 1, -19,
+ax_anim 2, 0, 72, 0, -6, 0, -7,
+ax_anim_terminator
+sHorseaAnims_3_6:
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim 4, 0, 78, 2, 2, 2, 2,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -6, -5, -6, -6,
+ax_anim 1, 0, 77, -12, -9, -12, -12,
+ax_anim 2, 0, 79, -20, -15, -20, -21,
+ax_anim 2, 1, 79, -21, -14, -21, -20,
+ax_anim 2, 0, 79, -20, -15, -20, -21,
+ax_anim 2, 0, 79, -21, -14, -21, -20,
+ax_anim 2, 0, 76, -7, -5, -7, -6,
+ax_anim_terminator
+sHorseaAnims_3_7:
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 4, 0, 82, 2, 0, 2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 81, -13, 3, -13, 0,
+ax_anim 2, 0, 83, -18, 5, -18, 0,
+ax_anim 2, 1, 83, -18, 6, -18, 1,
+ax_anim 2, 0, 83, -18, 5, -18, 0,
+ax_anim 2, 0, 83, -18, 6, -18, 1,
+ax_anim 2, 0, 80, -6, 1, -6, 0,
+ax_anim_terminator
+sHorseaAnims_3_8:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 4, 0, 86, 2, -2, 2, -2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 5, -4, 5,
+ax_anim 1, 0, 85, -12, 15, -12, 14,
+ax_anim 2, 0, 87, -20, 25, -20, 23,
+ax_anim 2, 1, 87, -21, 24, -21, 22,
+ax_anim 2, 0, 87, -20, 25, -20, 23,
+ax_anim 2, 0, 87, -21, 24, -21, 22,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHorseaAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, 1, 0, 1,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 1, 90, -1, 4, -1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, -1, 4, -1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 90, -1, 4, -1, 4,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sHorseaAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 1, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 1, 93, 3, 5, 3, 5,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 3, 5, 3, 5,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 3, 5, 3, 5,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim_terminator
+sHorseaAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 1, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 1, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 4, 1, 4, 1,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim_terminator
+sHorseaAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 1, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 1, 99, 3, -5, 3, -5,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 3, -5, 3, -5,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 3, -5, 3, -5,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim_terminator
+sHorseaAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 1, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 1, 102, -1, -4, -1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, -1, -4, -1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, -1, -4, -1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sHorseaAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 1, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 1, 105, -3, -5, -3, -5,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -3, -5, -3, -5,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 105, -3, -5, -3, -5,
+ax_anim 2, 0, 105, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim_terminator
+sHorseaAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 1, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -4, 1, -4, 1,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim_terminator
+sHorseaAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 1, 111, -3, 5, -3, 5,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -3, 5, -3, 5,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -3, 5, -3, 5,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sHorseaAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_6_1:
+ax_anim 16, 0, 120, 0, 0, 0, 0,
+ax_anim 12, 0, 120, 0, -1, 0, 0,
+ax_anim 16, 0, 120, 0, -2, 0, 0,
+ax_anim 16, 0, 121, 0, -2, 0, 0,
+ax_anim 12, 0, 121, 0, -1, 0, 0,
+ax_anim 16, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sHorseaAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sHorseaAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sHorseaAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sHorseaAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sHorseaAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sHorseaAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sHorseaAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHorseaAnims_8_1:
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 16, 0, 130, 0, -1, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 16, 0, 130, 0, 1, 0, 0,
+ax_anim_terminator
+sHorseaAnims_8_2:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 16, 0, 137, 0, -1, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 16, 0, 137, 0, 1, 0, 0,
+ax_anim_terminator
+sHorseaAnims_8_3:
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 16, 0, 136, 0, -1, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 16, 0, 136, 0, 1, 0, 0,
+ax_anim_terminator
+sHorseaAnims_8_4:
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 16, 0, 135, 0, -1, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 16, 0, 135, 0, 1, 0, 0,
+ax_anim_terminator
+sHorseaAnims_8_5:
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 16, 0, 134, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 16, 0, 134, 0, 1, 0, 0,
+ax_anim_terminator
+sHorseaAnims_8_6:
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 16, 0, 133, 0, -1, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 16, 0, 133, 0, 1, 0, 0,
+ax_anim_terminator
+sHorseaAnims_8_7:
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 16, 0, 132, 0, -1, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 16, 0, 132, 0, 1, 0, 0,
+ax_anim_terminator
+sHorseaAnims_8_8:
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 16, 0, 131, 0, -1, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 16, 0, 131, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 5, 6, 5,
+ax_anim 2, 0, 140, 8, 14, 8, 13,
+ax_anim 2, 0, 141, 5, 23, 5, 20,
+ax_anim 3, 0, 142, 0, 25, 0, 23,
+ax_anim 2, 3, 143, -5, 23, -5, 20,
+ax_anim 2, 0, 144, -8, 14, -8, 13,
+ax_anim 1, 0, 145, -6, 5, -6, 5,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 18, 5, 18, 5,
+ax_anim 2, 0, 140, 21, 15, 21, 12,
+ax_anim 3, 0, 141, 21, 26, 21, 22,
+ax_anim 2, 3, 142, 13, 25, 13, 23,
+ax_anim 2, 0, 143, 5, 19, 5, 17,
+ax_anim 1, 0, 144, 0, 9, 0, 9,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 17, -3, 17, -4,
+ax_anim 3, 0, 140, 20, 4, 20, 0,
+ax_anim 2, 3, 141, 17, 10, 17, 7,
+ax_anim 2, 0, 142, 12, 9, 12, 9,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -20, 12, -20,
+ax_anim 3, 0, 139, 21, -17, 21, -21,
+ax_anim 2, 3, 140, 20, -13, 20, -15,
+ax_anim 2, 0, 141, 17, -4, 17, -6,
+ax_anim 1, 0, 142, 7, -2, 7, -2,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -17, -7, -19,
+ax_anim 3, 0, 138, 0, -19, 0, -22,
+ax_anim 2, 3, 139, 7, -17, 7, -19,
+ax_anim 2, 0, 140, 9, -10, 9, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -20, -12, -20,
+ax_anim 3, 0, 145, -21, -17, -21, -21,
+ax_anim 2, 3, 144, -20, -13, -20, -15,
+ax_anim 2, 0, 143, -17, -4, -17, -6,
+ax_anim 1, 0, 142, -7, -2, -7, -2,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -17, -3, -17, -4,
+ax_anim 3, 0, 144, -20, 4, -20, 0,
+ax_anim 2, 3, 143, -17, 10, -17, 7,
+ax_anim 2, 0, 142, -12, 9, -12, 9,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -19, 10, -19, 10,
+ax_anim 3, 0, 143, -17, 19, -17, 19,
+ax_anim 2, 3, 142, -11, 19, -11, 19,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 2, 156, 0, 5, 0, 0,
+ax_anim_terminator
+sHorseaAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 2, 159, 0, 5, 0, 0,
+ax_anim_terminator
+sHorseaAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 2, 162, 0, 7, 0, 0,
+ax_anim_terminator
+sHorseaAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -9, 0, 0,
+ax_anim 2, 2, 165, 0, 7, 0, 0,
+ax_anim_terminator
+sHorseaAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 2, 168, 0, 7, 0, 0,
+ax_anim_terminator
+sHorseaAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -9, 0, 0,
+ax_anim 2, 2, 171, 0, 7, 0, 0,
+ax_anim_terminator
+sHorseaAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 2, 174, 0, 7, 0, 0,
+ax_anim_terminator
+sHorseaAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 2, 177, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHorseaAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHorseaGfx1:
+.incbin "baserom.gba", 0xA0037C, 0x200
+sHorseaSprites1:
+ax_sprite sHorseaGfx1, 0x200
+ax_sprite_terminator
+sHorseaGfx2:
+.incbin "baserom.gba", 0xA0058C, 0x200
+sHorseaSprites2:
+ax_sprite sHorseaGfx2, 0x200
+ax_sprite_terminator
+sHorseaGfx3:
+.incbin "baserom.gba", 0xA0079C, 0x200
+sHorseaSprites3:
+ax_sprite sHorseaGfx3, 0x200
+ax_sprite_terminator
+sHorseaGfx4:
+.incbin "baserom.gba", 0xA009AC, 0x200
+sHorseaSprites4:
+ax_sprite sHorseaGfx4, 0x200
+ax_sprite_terminator
+sHorseaGfx5:
+.incbin "baserom.gba", 0xA00BBC, 0x200
+sHorseaSprites5:
+ax_sprite sHorseaGfx5, 0x200
+ax_sprite_terminator
+sHorseaGfx6:
+.incbin "baserom.gba", 0xA00DCC, 0x200
+sHorseaSprites6:
+ax_sprite sHorseaGfx6, 0x200
+ax_sprite_terminator
+sHorseaGfx7:
+.incbin "baserom.gba", 0xA00FDC, 0x200
+sHorseaSprites7:
+ax_sprite sHorseaGfx7, 0x200
+ax_sprite_terminator
+sHorseaGfx8:
+.incbin "baserom.gba", 0xA011EC, 0x200
+sHorseaSprites8:
+ax_sprite sHorseaGfx8, 0x200
+ax_sprite_terminator
+sHorseaGfx9:
+.incbin "baserom.gba", 0xA013FC, 0x100
+sHorseaSprites9:
+ax_sprite sHorseaGfx9, 0x100
+ax_sprite_terminator
+sHorseaGfx10:
+.incbin "baserom.gba", 0xA0150C, 0x200
+sHorseaSprites10:
+ax_sprite sHorseaGfx10, 0x200
+ax_sprite_terminator
+sHorseaGfx11:
+.incbin "baserom.gba", 0xA0171C, 0x200
+sHorseaSprites11:
+ax_sprite sHorseaGfx11, 0x200
+ax_sprite_terminator
+sHorseaGfx12:
+.incbin "baserom.gba", 0xA0192C, 0x200
+sHorseaSprites12:
+ax_sprite sHorseaGfx12, 0x200
+ax_sprite_terminator
+sHorseaGfx13:
+.incbin "baserom.gba", 0xA01B3C, 0x200
+sHorseaSprites13:
+ax_sprite sHorseaGfx13, 0x200
+ax_sprite_terminator
+sHorseaGfx14:
+.incbin "baserom.gba", 0xA01D4C, 0x200
+sHorseaSprites14:
+ax_sprite sHorseaGfx14, 0x200
+ax_sprite_terminator
+sHorseaGfx15:
+.incbin "baserom.gba", 0xA01F5C, 0x200
+sHorseaSprites15:
+ax_sprite sHorseaGfx15, 0x200
+ax_sprite_terminator
+sHorseaGfx16:
+.incbin "baserom.gba", 0xA0216C, 0x20
+sHorseaGfx16_1:
+.incbin "baserom.gba", 0xA0218C, 0x60
+sHorseaGfx16_2:
+.incbin "baserom.gba", 0xA021EC, 0x60
+sHorseaSprites16:
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx17:
+.incbin "baserom.gba", 0xA0228C, 0x20
+sHorseaGfx17_1:
+.incbin "baserom.gba", 0xA022AC, 0x60
+sHorseaGfx17_2:
+.incbin "baserom.gba", 0xA0230C, 0x60
+sHorseaSprites17:
+ax_sprite sHorseaGfx17, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHorseaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx18:
+.incbin "baserom.gba", 0xA023A4, 0x40
+sHorseaGfx18_1:
+.incbin "baserom.gba", 0xA023E4, 0x60
+sHorseaGfx18_2:
+.incbin "baserom.gba", 0xA02444, 0x60
+sHorseaSprites18:
+ax_sprite sHorseaGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx19:
+.incbin "baserom.gba", 0xA024DC, 0x40
+sHorseaGfx19_1:
+.incbin "baserom.gba", 0xA0251C, 0x60
+sHorseaGfx19_2:
+.incbin "baserom.gba", 0xA0257C, 0x60
+sHorseaSprites19:
+ax_sprite sHorseaGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx20:
+.incbin "baserom.gba", 0xA02614, 0x60
+sHorseaGfx20_1:
+.incbin "baserom.gba", 0xA02674, 0x60
+sHorseaGfx20_2:
+.incbin "baserom.gba", 0xA026D4, 0x60
+sHorseaGfx20_3:
+.incbin "baserom.gba", 0xA02734, 0x20
+sHorseaSprites20:
+ax_sprite sHorseaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx20_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHorseaGfx21:
+.incbin "baserom.gba", 0xA0279C, 0x60
+sHorseaGfx21_1:
+.incbin "baserom.gba", 0xA027FC, 0x60
+sHorseaGfx21_2:
+.incbin "baserom.gba", 0xA0285C, 0x40
+sHorseaSprites21:
+ax_sprite sHorseaGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx21_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx22:
+.incbin "baserom.gba", 0xA028D4, 0x60
+sHorseaGfx22_1:
+.incbin "baserom.gba", 0xA02934, 0x60
+sHorseaGfx22_2:
+.incbin "baserom.gba", 0xA02994, 0x60
+sHorseaSprites22:
+ax_sprite sHorseaGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx23:
+.incbin "baserom.gba", 0xA02A2C, 0x60
+sHorseaGfx23_1:
+.incbin "baserom.gba", 0xA02A8C, 0x60
+sHorseaGfx23_2:
+.incbin "baserom.gba", 0xA02AEC, 0x60
+sHorseaSprites23:
+ax_sprite sHorseaGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx24:
+.incbin "baserom.gba", 0xA02B84, 0x40
+sHorseaGfx24_1:
+.incbin "baserom.gba", 0xA02BC4, 0x60
+sHorseaGfx24_2:
+.incbin "baserom.gba", 0xA02C24, 0x60
+sHorseaSprites24:
+ax_sprite sHorseaGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx25:
+.incbin "baserom.gba", 0xA02CBC, 0x40
+sHorseaGfx25_1:
+.incbin "baserom.gba", 0xA02CFC, 0x60
+sHorseaGfx25_2:
+.incbin "baserom.gba", 0xA02D5C, 0x40
+sHorseaSprites25:
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx26:
+.incbin "baserom.gba", 0xA02DDC, 0x40
+sHorseaGfx26_1:
+.incbin "baserom.gba", 0xA02E1C, 0x60
+sHorseaGfx26_2:
+.incbin "baserom.gba", 0xA02E7C, 0x60
+sHorseaSprites26:
+ax_sprite sHorseaGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx27:
+.incbin "baserom.gba", 0xA02F14, 0x60
+sHorseaGfx27_1:
+.incbin "baserom.gba", 0xA02F74, 0x60
+sHorseaGfx27_2:
+.incbin "baserom.gba", 0xA02FD4, 0x60
+sHorseaSprites27:
+ax_sprite sHorseaGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx28:
+.incbin "baserom.gba", 0xA0306C, 0x60
+sHorseaGfx28_1:
+.incbin "baserom.gba", 0xA030CC, 0x60
+sHorseaGfx28_2:
+.incbin "baserom.gba", 0xA0312C, 0x60
+sHorseaSprites28:
+ax_sprite sHorseaGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx29:
+.incbin "baserom.gba", 0xA031C4, 0x20
+sHorseaGfx29_1:
+.incbin "baserom.gba", 0xA031E4, 0x60
+sHorseaGfx29_2:
+.incbin "baserom.gba", 0xA03244, 0x60
+sHorseaGfx29_3:
+.incbin "baserom.gba", 0xA032A4, 0x20
+sHorseaSprites29:
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHorseaGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHorseaGfx30:
+.incbin "baserom.gba", 0xA03314, 0x60
+sHorseaGfx30_1:
+.incbin "baserom.gba", 0xA03374, 0x60
+sHorseaGfx30_2:
+.incbin "baserom.gba", 0xA033D4, 0x60
+sHorseaSprites30:
+ax_sprite sHorseaGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHorseaGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHorseaGfx31:
+.incbin "baserom.gba", 0xA0346C, 0x200
+sHorseaSprites31:
+ax_sprite sHorseaGfx31, 0x200
+ax_sprite_terminator
+sHorseaGfx32:
+.incbin "baserom.gba", 0xA0367C, 0x200
+sHorseaSprites32:
+ax_sprite sHorseaGfx32, 0x200
+ax_sprite_terminator
+sHorseaGfx33:
+.incbin "baserom.gba", 0xA0388C, 0x200
+sHorseaSprites33:
+ax_sprite sHorseaGfx33, 0x200
+ax_sprite_terminator
+sHorseaGfx34:
+.incbin "baserom.gba", 0xA03A9C, 0x200
+sHorseaSprites34:
+ax_sprite sHorseaGfx34, 0x200
+ax_sprite_terminator
+sHorseaGfx35:
+.incbin "baserom.gba", 0xA03CAC, 0x200
+sHorseaSprites35:
+ax_sprite sHorseaGfx35, 0x200
+ax_sprite_terminator
+sHorseaGfx36:
+.incbin "baserom.gba", 0xA03EBC, 0x200
+sHorseaSprites36:
+ax_sprite sHorseaGfx36, 0x200
+ax_sprite_terminator
+sHorseaGfx37:
+.incbin "baserom.gba", 0xA040CC, 0x200
+sHorseaSprites37:
+ax_sprite sHorseaGfx37, 0x200
+ax_sprite_terminator
+sAxPosesHorsea:
+.4byte sHorseaPose1
+.4byte sHorseaPose2
+.4byte sHorseaPose3
+.4byte sHorseaPose4
+.4byte sHorseaPose5
+.4byte sHorseaPose6
+.4byte sHorseaPose7
+.4byte sHorseaPose8
+.4byte sHorseaPose9
+.4byte sHorseaPose10
+.4byte sHorseaPose11
+.4byte sHorseaPose12
+.4byte sHorseaPose13
+.4byte sHorseaPose14
+.4byte sHorseaPose15
+.4byte sHorseaPose16
+.4byte sHorseaPose17
+.4byte sHorseaPose18
+.4byte sHorseaPose19
+.4byte sHorseaPose20
+.4byte sHorseaPose21
+.4byte sHorseaPose22
+.4byte sHorseaPose23
+.4byte sHorseaPose24
+.4byte sHorseaPose25
+.4byte sHorseaPose26
+.4byte sHorseaPose27
+.4byte sHorseaPose28
+.4byte sHorseaPose29
+.4byte sHorseaPose30
+.4byte sHorseaPose31
+.4byte sHorseaPose32
+.4byte sHorseaPose33
+.4byte sHorseaPose34
+.4byte sHorseaPose35
+.4byte sHorseaPose36
+.4byte sHorseaPose37
+.4byte sHorseaPose38
+.4byte sHorseaPose39
+.4byte sHorseaPose40
+.4byte sHorseaPose41
+.4byte sHorseaPose42
+.4byte sHorseaPose43
+.4byte sHorseaPose44
+.4byte sHorseaPose45
+.4byte sHorseaPose46
+.4byte sHorseaPose47
+.4byte sHorseaPose48
+.4byte sHorseaPose49
+.4byte sHorseaPose50
+.4byte sHorseaPose51
+.4byte sHorseaPose52
+.4byte sHorseaPose53
+.4byte sHorseaPose54
+.4byte sHorseaPose55
+.4byte sHorseaPose56
+.4byte sHorseaPose57
+.4byte sHorseaPose58
+.4byte sHorseaPose59
+.4byte sHorseaPose60
+.4byte sHorseaPose61
+.4byte sHorseaPose62
+.4byte sHorseaPose63
+.4byte sHorseaPose64
+.4byte sHorseaPose65
+.4byte sHorseaPose66
+.4byte sHorseaPose67
+.4byte sHorseaPose68
+.4byte sHorseaPose69
+.4byte sHorseaPose70
+.4byte sHorseaPose71
+.4byte sHorseaPose72
+.4byte sHorseaPose73
+.4byte sHorseaPose74
+.4byte sHorseaPose75
+.4byte sHorseaPose76
+.4byte sHorseaPose77
+.4byte sHorseaPose78
+.4byte sHorseaPose79
+.4byte sHorseaPose80
+.4byte sHorseaPose81
+.4byte sHorseaPose82
+.4byte sHorseaPose83
+.4byte sHorseaPose84
+.4byte sHorseaPose85
+.4byte sHorseaPose86
+.4byte sHorseaPose87
+.4byte sHorseaPose88
+.4byte sHorseaPose89
+.4byte sHorseaPose90
+.4byte sHorseaPose91
+.4byte sHorseaPose92
+.4byte sHorseaPose93
+.4byte sHorseaPose94
+.4byte sHorseaPose95
+.4byte sHorseaPose96
+.4byte sHorseaPose97
+.4byte sHorseaPose98
+.4byte sHorseaPose99
+.4byte sHorseaPose100
+.4byte sHorseaPose101
+.4byte sHorseaPose102
+.4byte sHorseaPose103
+.4byte sHorseaPose104
+.4byte sHorseaPose105
+.4byte sHorseaPose106
+.4byte sHorseaPose107
+.4byte sHorseaPose108
+.4byte sHorseaPose109
+.4byte sHorseaPose110
+.4byte sHorseaPose111
+.4byte sHorseaPose112
+.4byte sHorseaPose113
+.4byte sHorseaPose114
+.4byte sHorseaPose115
+.4byte sHorseaPose116
+.4byte sHorseaPose117
+.4byte sHorseaPose118
+.4byte sHorseaPose119
+.4byte sHorseaPose120
+.4byte sHorseaPose121
+.4byte sHorseaPose122
+.4byte sHorseaPose123
+.4byte sHorseaPose124
+.4byte sHorseaPose125
+.4byte sHorseaPose126
+.4byte sHorseaPose127
+.4byte sHorseaPose128
+.4byte sHorseaPose129
+.4byte sHorseaPose130
+.4byte sHorseaPose131
+.4byte sHorseaPose132
+.4byte sHorseaPose133
+.4byte sHorseaPose134
+.4byte sHorseaPose135
+.4byte sHorseaPose136
+.4byte sHorseaPose137
+.4byte sHorseaPose138
+.4byte sHorseaPose139
+.4byte sHorseaPose140
+.4byte sHorseaPose141
+.4byte sHorseaPose142
+.4byte sHorseaPose143
+.4byte sHorseaPose144
+.4byte sHorseaPose145
+.4byte sHorseaPose146
+.4byte sHorseaPose147
+.4byte sHorseaPose148
+.4byte sHorseaPose149
+.4byte sHorseaPose150
+.4byte sHorseaPose151
+.4byte sHorseaPose152
+.4byte sHorseaPose153
+.4byte sHorseaPose154
+.4byte sHorseaPose155
+.4byte sHorseaPose156
+.4byte sHorseaPose157
+.4byte sHorseaPose158
+.4byte sHorseaPose159
+.4byte sHorseaPose160
+.4byte sHorseaPose161
+.4byte sHorseaPose162
+.4byte sHorseaPose163
+.4byte sHorseaPose164
+.4byte sHorseaPose165
+.4byte sHorseaPose166
+.4byte sHorseaPose167
+.4byte sHorseaPose168
+.4byte sHorseaPose169
+.4byte sHorseaPose170
+.4byte sHorseaPose171
+.4byte sHorseaPose172
+.4byte sHorseaPose173
+.4byte sHorseaPose174
+.4byte sHorseaPose175
+.4byte sHorseaPose176
+.4byte sHorseaPose177
+.4byte sHorseaPose178
+.4byte sHorseaPose179
+.4byte sHorseaPose180
+.4byte sHorseaPose181
+.4byte sHorseaPose182
+.4byte sHorseaPose183
+.4byte sHorseaPose184
+.4byte sHorseaPose185
+.4byte sHorseaPose186
+.4byte sHorseaPose187
+.4byte sHorseaPose188
+.4byte sHorseaPose189
+.4byte sHorseaPose190
+.4byte sHorseaPose191
+.4byte sHorseaPose192
+.4byte sHorseaPose193
+.4byte sHorseaPose194
+sAxPositionsHorsea:
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte    0,   -9, 	  -3,  -10, 	   3,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -3,  -12, 	   3,  -12, 	   0,  -15
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+.2byte    6,  -10, 	   2,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte    4,  -12, 	   0,  -13, 	  -3,  -12, 	  -1,  -13
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    9,  -14, 	   0,  -13, 	  -1,  -10, 	  -1,  -13
+.2byte    7,  -16, 	   0,  -14, 	   0,  -11, 	  -1,  -14
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    8,  -18, 	  -2,  -12, 	   1,  -11, 	   0,  -14
+.2byte    6,  -19, 	  -3,  -13, 	   1,  -11, 	  -1,  -15
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    0,  -20, 	   3,  -12, 	  -3,  -12, 	   0,  -15
+.2byte    0,  -23, 	   3,  -13, 	  -3,  -13, 	   0,  -14
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte   -8,  -18, 	   2,  -12, 	  -1,  -11, 	   0,  -14
+.2byte   -6,  -19, 	   3,  -13, 	  -1,  -11, 	   1,  -15
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -9,  -14, 	   0,  -13, 	   1,  -10, 	   1,  -13
+.2byte   -7,  -16, 	   0,  -14, 	   0,  -11, 	   1,  -14
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -6,  -10, 	  -2,  -12, 	   2,  -10, 	   1,  -11
+.2byte   -4,  -12, 	   0,  -13, 	   3,  -12, 	   1,  -13
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte    0,   -9, 	  -3,  -10, 	   3,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -3,  -12, 	   3,  -12, 	   0,  -15
+.2byte    0,   -6, 	  -3,  -10, 	   3,  -10, 	   0,  -13
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+.2byte    6,  -10, 	   2,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte    4,  -12, 	   0,  -13, 	  -3,  -12, 	  -1,  -13
+.2byte    7,   -6, 	   2,   -9, 	  -1,   -8, 	   0,   -9
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    9,  -14, 	   0,  -13, 	  -1,  -10, 	  -1,  -13
+.2byte    7,  -16, 	   0,  -14, 	   0,  -11, 	  -1,  -14
+.2byte   10,  -11, 	  -1,  -15, 	  -1,  -12, 	   0,  -14
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    8,  -18, 	  -2,  -12, 	   1,  -11, 	   0,  -14
+.2byte    6,  -19, 	  -3,  -13, 	   1,  -11, 	  -1,  -15
+.2byte    8,  -12, 	  -2,  -14, 	   1,  -12, 	   0,  -15
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    0,  -20, 	   3,  -12, 	  -3,  -12, 	   0,  -15
+.2byte    0,  -23, 	   3,  -13, 	  -3,  -13, 	   0,  -14
+.2byte    0,  -18, 	   3,  -11, 	  -3,  -11, 	   0,  -13
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte   -8,  -18, 	   2,  -12, 	  -1,  -11, 	   0,  -14
+.2byte   -6,  -19, 	   3,  -13, 	  -1,  -11, 	   1,  -15
+.2byte   -8,  -12, 	   2,  -14, 	  -1,  -12, 	   0,  -15
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -9,  -14, 	   0,  -13, 	   1,  -10, 	   1,  -13
+.2byte   -7,  -16, 	   0,  -14, 	   0,  -11, 	   1,  -14
+.2byte  -10,  -11, 	   1,  -15, 	   1,  -12, 	   0,  -14
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -6,  -10, 	  -2,  -12, 	   2,  -10, 	   1,  -11
+.2byte   -4,  -12, 	   0,  -13, 	   3,  -12, 	   1,  -13
+.2byte   -7,   -6, 	  -2,   -9, 	   1,   -8, 	   0,   -9
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte    0,   -9, 	  -3,  -10, 	   3,  -10, 	   0,  -13
+.2byte    0,  -12, 	  -3,  -12, 	   3,  -12, 	   0,  -15
+.2byte    0,   -6, 	  -3,  -10, 	   3,  -10, 	   0,  -13
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+.2byte    6,  -10, 	   2,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte    4,  -12, 	   0,  -13, 	  -3,  -12, 	  -1,  -13
+.2byte    7,   -6, 	   2,   -9, 	  -1,   -8, 	   0,   -9
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    9,  -14, 	   0,  -13, 	  -1,  -10, 	  -1,  -13
+.2byte    7,  -16, 	   0,  -14, 	   0,  -11, 	  -1,  -14
+.2byte   10,  -11, 	  -1,  -15, 	  -1,  -12, 	   0,  -14
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    8,  -18, 	  -2,  -12, 	   1,  -11, 	   0,  -14
+.2byte    6,  -19, 	  -3,  -13, 	   1,  -11, 	  -1,  -15
+.2byte    8,  -12, 	  -2,  -14, 	   1,  -12, 	   0,  -15
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    0,  -20, 	   3,  -12, 	  -3,  -12, 	   0,  -15
+.2byte    0,  -23, 	   3,  -13, 	  -3,  -13, 	   0,  -14
+.2byte    0,  -18, 	   3,  -11, 	  -3,  -11, 	   0,  -13
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte   -8,  -18, 	   2,  -12, 	  -1,  -11, 	   0,  -14
+.2byte   -6,  -19, 	   3,  -13, 	  -1,  -11, 	   1,  -15
+.2byte   -8,  -12, 	   2,  -14, 	  -1,  -12, 	   0,  -15
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -9,  -14, 	   0,  -13, 	   1,  -10, 	   1,  -13
+.2byte   -7,  -16, 	   0,  -14, 	   0,  -11, 	   1,  -14
+.2byte  -10,  -11, 	   1,  -15, 	   1,  -12, 	   0,  -14
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -6,  -10, 	  -2,  -12, 	   2,  -10, 	   1,  -11
+.2byte   -4,  -12, 	   0,  -13, 	   3,  -12, 	   1,  -13
+.2byte   -7,   -6, 	  -2,   -9, 	   1,   -8, 	   0,   -9
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte    0,  -13, 	  -3,  -12, 	   3,  -12, 	   0,  -14
+.2byte    0,   -8, 	  -4,  -11, 	   4,  -11, 	   0,  -13
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+.2byte    4,  -11, 	   1,  -11, 	  -2,   -9, 	  -2,  -11
+.2byte    7,  -10, 	   1,  -11, 	  -2,  -10, 	  -1,  -12
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    5,  -15, 	  -1,  -10, 	  -2,   -8, 	  -2,  -11
+.2byte   10,  -13, 	   2,  -12, 	   0,  -11, 	   1,  -12
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    6,  -20, 	  -3,  -11, 	   1,  -10, 	  -2,  -13
+.2byte   10,  -16, 	  -1,  -12, 	   2,  -11, 	   1,  -13
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    0,  -20, 	   3,   -9, 	  -3,   -9, 	   0,  -12
+.2byte    0,  -23, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte   -6,  -20, 	   3,  -11, 	  -1,  -10, 	   2,  -13
+.2byte  -10,  -16, 	   1,  -12, 	  -2,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -5,  -15, 	   1,  -10, 	   2,   -8, 	   2,  -11
+.2byte  -10,  -13, 	  -2,  -12, 	   0,  -11, 	  -1,  -12
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -4,  -11, 	  -1,  -11, 	   2,   -9, 	   2,  -11
+.2byte   -7,  -10, 	  -1,  -11, 	   2,  -10, 	   1,  -12
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+.2byte   -4,   -9, 	  -1,  -10, 	   3,   -9, 	   1,  -10
+.2byte   -4,   -9, 	  -1,  -10, 	   3,   -9, 	   1,  -10
+.2byte    0,   -6, 	  -4,  -12, 	   4,  -12, 	   0,  -12
+.2byte    6,   -7, 	   0,  -11, 	  -4,  -10, 	  -1,  -12
+.2byte   10,  -10, 	   1,  -10, 	   0,   -8, 	  -1,  -10
+.2byte    7,  -14, 	  -2,  -10, 	   1,   -9, 	   0,  -12
+.2byte    0,  -14, 	   3,   -9, 	  -3,   -9, 	   0,  -11
+.2byte   -8,  -14, 	   1,  -10, 	  -2,   -9, 	  -1,  -12
+.2byte  -11,  -10, 	  -2,  -10, 	  -1,   -8, 	   0,  -10
+.2byte   -7,   -7, 	  -1,  -11, 	   3,  -10, 	   0,  -12
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+.2byte    0,   -6, 	  -3,  -10, 	   3,  -10, 	   0,  -13
+.2byte   -7,   -8, 	  -2,  -11, 	   1,  -10, 	   0,  -11
+.2byte  -11,  -10, 	   0,  -14, 	   0,  -11, 	  -1,  -13
+.2byte   -8,  -11, 	   2,  -13, 	  -1,  -11, 	   0,  -14
+.2byte    0,  -18, 	   3,  -11, 	  -3,  -11, 	   0,  -13
+.2byte    7,  -11, 	  -3,  -13, 	   0,  -11, 	  -1,  -14
+.2byte   10,  -10, 	  -1,  -14, 	  -1,  -11, 	   0,  -13
+.2byte    6,   -8, 	   1,  -11, 	  -2,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   3,  -12, 	   0,  -14
+.2byte    4,  -13, 	   1,  -13, 	  -2,  -11, 	  -2,  -13
+.2byte    5,  -16, 	  -1,  -11, 	  -2,   -9, 	  -2,  -12
+.2byte    5,  -20, 	  -4,  -11, 	   0,  -10, 	  -3,  -13
+.2byte    0,  -21, 	   3,  -10, 	  -3,  -10, 	   0,  -13
+.2byte   -5,  -20, 	   4,  -11, 	   0,  -10, 	   3,  -13
+.2byte   -5,  -16, 	   1,  -11, 	   2,   -9, 	   2,  -12
+.2byte   -4,  -13, 	  -1,  -13, 	   2,  -11, 	   2,  -13
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte    0,  -12, 	  -3,  -12, 	   3,  -12, 	   0,  -15
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+.2byte    4,  -12, 	   0,  -13, 	  -3,  -12, 	  -1,  -13
+.2byte    6,  -11, 	   2,  -13, 	  -2,  -11, 	  -1,  -12
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    7,  -16, 	   0,  -14, 	   0,  -11, 	  -1,  -14
+.2byte    9,  -14, 	   0,  -13, 	  -1,  -10, 	  -1,  -13
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    6,  -19, 	  -3,  -13, 	   1,  -11, 	  -1,  -15
+.2byte    8,  -18, 	  -2,  -12, 	   1,  -11, 	   0,  -14
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    0,  -23, 	   3,  -13, 	  -3,  -13, 	   0,  -14
+.2byte    0,  -20, 	   3,  -12, 	  -3,  -12, 	   0,  -15
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte   -6,  -19, 	   3,  -13, 	  -1,  -11, 	   1,  -15
+.2byte   -8,  -18, 	   2,  -12, 	  -1,  -11, 	   0,  -14
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -7,  -16, 	   0,  -14, 	   0,  -11, 	   1,  -14
+.2byte   -9,  -14, 	   0,  -13, 	   1,  -10, 	   1,  -13
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -4,  -12, 	   0,  -13, 	   3,  -12, 	   1,  -13
+.2byte   -6,  -11, 	  -2,  -13, 	   2,  -11, 	   1,  -12
+.2byte    0,   -4, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -7,   -5, 	  -1,   -6, 	   2,   -5, 	   1,   -7
+.2byte  -10,   -9, 	  -2,   -8, 	   0,   -7, 	  -1,   -8
+.2byte  -10,  -12, 	   1,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte    0,  -19, 	   3,   -8, 	  -3,   -8, 	   0,   -9
+.2byte   10,  -12, 	  -1,   -8, 	   2,   -7, 	   1,   -9
+.2byte   10,   -9, 	   2,   -8, 	   0,   -7, 	   1,   -8
+.2byte    7,   -5, 	   1,   -6, 	  -2,   -5, 	  -1,   -7
+.2byte    0,  -10, 	  -3,  -11, 	   3,  -11, 	   0,  -14
+.2byte   -5,  -11, 	  -2,  -12, 	   2,  -11, 	   0,  -12
+.2byte   -8,  -14, 	   0,  -13, 	   1,  -11, 	   1,  -13
+.2byte   -7,  -18, 	   2,  -12, 	  -1,  -12, 	   1,  -14
+.2byte    0,  -17, 	   3,  -12, 	  -3,  -12, 	   0,  -13
+.2byte    7,  -18, 	  -2,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    8,  -14, 	   0,  -13, 	  -1,  -11, 	  -1,  -13
+.2byte    5,  -11, 	   2,  -12, 	  -2,  -11, 	   0,  -12
+sHorseaAnimTable1:
+.4byte sHorseaAnims_1_1
+.4byte sHorseaAnims_1_2
+.4byte sHorseaAnims_1_3
+.4byte sHorseaAnims_1_4
+.4byte sHorseaAnims_1_5
+.4byte sHorseaAnims_1_6
+.4byte sHorseaAnims_1_7
+.4byte sHorseaAnims_1_8
+sHorseaAnimTable2:
+.4byte sHorseaAnims_2_1
+.4byte sHorseaAnims_2_2
+.4byte sHorseaAnims_2_3
+.4byte sHorseaAnims_2_4
+.4byte sHorseaAnims_2_5
+.4byte sHorseaAnims_2_6
+.4byte sHorseaAnims_2_7
+.4byte sHorseaAnims_2_8
+sHorseaAnimTable3:
+.4byte sHorseaAnims_3_1
+.4byte sHorseaAnims_3_2
+.4byte sHorseaAnims_3_3
+.4byte sHorseaAnims_3_4
+.4byte sHorseaAnims_3_5
+.4byte sHorseaAnims_3_6
+.4byte sHorseaAnims_3_7
+.4byte sHorseaAnims_3_8
+sHorseaAnimTable4:
+.4byte sHorseaAnims_4_1
+.4byte sHorseaAnims_4_2
+.4byte sHorseaAnims_4_3
+.4byte sHorseaAnims_4_4
+.4byte sHorseaAnims_4_5
+.4byte sHorseaAnims_4_6
+.4byte sHorseaAnims_4_7
+.4byte sHorseaAnims_4_8
+sHorseaAnimTable5:
+.4byte sHorseaAnims_5_1
+.4byte sHorseaAnims_5_2
+.4byte sHorseaAnims_5_3
+.4byte sHorseaAnims_5_4
+.4byte sHorseaAnims_5_5
+.4byte sHorseaAnims_5_6
+.4byte sHorseaAnims_5_7
+.4byte sHorseaAnims_5_8
+sHorseaAnimTable6:
+.4byte sHorseaAnims_6_1
+.4byte sHorseaAnims_6_1
+.4byte sHorseaAnims_6_1
+.4byte sHorseaAnims_6_1
+.4byte sHorseaAnims_6_1
+.4byte sHorseaAnims_6_1
+.4byte sHorseaAnims_6_1
+.4byte sHorseaAnims_6_1
+sHorseaAnimTable7:
+.4byte sHorseaAnims_7_1
+.4byte sHorseaAnims_7_2
+.4byte sHorseaAnims_7_3
+.4byte sHorseaAnims_7_4
+.4byte sHorseaAnims_7_5
+.4byte sHorseaAnims_7_6
+.4byte sHorseaAnims_7_7
+.4byte sHorseaAnims_7_8
+sHorseaAnimTable8:
+.4byte sHorseaAnims_8_1
+.4byte sHorseaAnims_8_2
+.4byte sHorseaAnims_8_3
+.4byte sHorseaAnims_8_4
+.4byte sHorseaAnims_8_5
+.4byte sHorseaAnims_8_6
+.4byte sHorseaAnims_8_7
+.4byte sHorseaAnims_8_8
+sHorseaAnimTable9:
+.4byte sHorseaAnims_9_1
+.4byte sHorseaAnims_9_2
+.4byte sHorseaAnims_9_3
+.4byte sHorseaAnims_9_4
+.4byte sHorseaAnims_9_5
+.4byte sHorseaAnims_9_6
+.4byte sHorseaAnims_9_7
+.4byte sHorseaAnims_9_8
+sHorseaAnimTable10:
+.4byte sHorseaAnims_10_1
+.4byte sHorseaAnims_10_2
+.4byte sHorseaAnims_10_3
+.4byte sHorseaAnims_10_4
+.4byte sHorseaAnims_10_5
+.4byte sHorseaAnims_10_6
+.4byte sHorseaAnims_10_7
+.4byte sHorseaAnims_10_8
+sHorseaAnimTable11:
+.4byte sHorseaAnims_11_1
+.4byte sHorseaAnims_11_2
+.4byte sHorseaAnims_11_3
+.4byte sHorseaAnims_11_4
+.4byte sHorseaAnims_11_5
+.4byte sHorseaAnims_11_6
+.4byte sHorseaAnims_11_7
+.4byte sHorseaAnims_11_8
+sHorseaAnimTable12:
+.4byte sHorseaAnims_12_1
+.4byte sHorseaAnims_12_2
+.4byte sHorseaAnims_12_3
+.4byte sHorseaAnims_12_4
+.4byte sHorseaAnims_12_5
+.4byte sHorseaAnims_12_6
+.4byte sHorseaAnims_12_7
+.4byte sHorseaAnims_12_8
+sHorseaAnimTable13:
+.4byte sHorseaAnims_13_1
+.4byte sHorseaAnims_13_2
+.4byte sHorseaAnims_13_3
+.4byte sHorseaAnims_13_4
+.4byte sHorseaAnims_13_5
+.4byte sHorseaAnims_13_6
+.4byte sHorseaAnims_13_7
+.4byte sHorseaAnims_13_8
+sAxAnimationsHorsea:
+.4byte sHorseaAnimTable1
+.4byte sHorseaAnimTable2
+.4byte sHorseaAnimTable3
+.4byte sHorseaAnimTable4
+.4byte sHorseaAnimTable5
+.4byte sHorseaAnimTable6
+.4byte sHorseaAnimTable7
+.4byte sHorseaAnimTable8
+.4byte sHorseaAnimTable9
+.4byte sHorseaAnimTable10
+.4byte sHorseaAnimTable11
+.4byte sHorseaAnimTable12
+.4byte sHorseaAnimTable13
+sAxSpritesHorsea:
+.4byte sHorseaSprites1
+.4byte sHorseaSprites2
+.4byte sHorseaSprites3
+.4byte sHorseaSprites4
+.4byte sHorseaSprites5
+.4byte sHorseaSprites6
+.4byte sHorseaSprites7
+.4byte sHorseaSprites8
+.4byte sHorseaSprites9
+.4byte sHorseaSprites10
+.4byte sHorseaSprites11
+.4byte sHorseaSprites12
+.4byte sHorseaSprites13
+.4byte sHorseaSprites14
+.4byte sHorseaSprites15
+.4byte sHorseaSprites16
+.4byte sHorseaSprites17
+.4byte sHorseaSprites18
+.4byte sHorseaSprites19
+.4byte sHorseaSprites20
+.4byte sHorseaSprites21
+.4byte sHorseaSprites22
+.4byte sHorseaSprites23
+.4byte sHorseaSprites24
+.4byte sHorseaSprites25
+.4byte sHorseaSprites26
+.4byte sHorseaSprites27
+.4byte sHorseaSprites28
+.4byte sHorseaSprites29
+.4byte sHorseaSprites30
+.4byte sHorseaSprites31
+.4byte sHorseaSprites32
+.4byte sHorseaSprites33
+.4byte sHorseaSprites34
+.4byte sHorseaSprites35
+.4byte sHorseaSprites36
+.4byte sHorseaSprites37
+sAxMainHorsea:
+ax_main sAxPosesHorsea, sAxAnimationsHorsea, 13, sAxSpritesHorsea, sAxPositionsHorsea

--- a/data/ax/houndoom.inc
+++ b/data/ax/houndoom.inc
@@ -1,0 +1,3823 @@
+.global gAxHoundoom
+gAxHoundoom:
+ax_siro sAxMainHoundoom
+sHoundoomPose1:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose2:
+ax_pose 2, 0x01ea, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose3:
+ax_pose 3, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose4:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+sHoundoomPose5:
+ax_pose 8, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose6:
+ax_pose 9, 0x0208, 0x1100, 0x6c00
+ax_pose 10, 0x81ef, 0x10f0, 0x6c01
+ax_pose 11, 0x81e7, 0x50f8, 0x6c03
+ax_pose 12, 0x81e8, 0x9100, 0x6c07
+ax_pose_terminator
+sHoundoomPose7:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose8:
+ax_pose 18, 0x01fd, 0x10e9, 0x6c00
+ax_pose 19, 0x01fd, 0x10f1, 0x6c01
+ax_pose 20, 0x81ed, 0x10f1, 0x6c02
+ax_pose 21, 0x81e5, 0x50f9, 0x6c04
+ax_pose 22, 0x81e5, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose9:
+ax_pose 23, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose10:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose11:
+ax_pose 29, 0x0202, 0x10fa, 0x6c00
+ax_pose 30, 0x0202, 0x10f2, 0x6c01
+ax_pose 31, 0x81f2, 0x10ed, 0x6c02
+ax_pose 32, 0x81e2, 0x50f5, 0x6c04
+ax_pose 33, 0x81e2, 0x90fd, 0x6c08
+ax_pose_terminator
+sHoundoomPose12:
+ax_pose 34, 0x0202, 0x10f5, 0x6c00
+ax_pose 35, 0x81f2, 0x10ed, 0x6c01
+ax_pose 36, 0x81e2, 0x50f5, 0x6c03
+ax_pose 37, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose13:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose14:
+ax_pose 40, 0x4202, 0x00f8, 0x6c00
+ax_pose 41, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose15:
+ax_pose 42, 0x0202, 0x0108, 0x6c00
+ax_pose 43, 0x01fa, 0x0108, 0x6c01
+ax_pose 44, 0x4202, 0x00f8, 0x6c02
+ax_pose 45, 0x81e2, 0x80f8, 0x6c04
+ax_pose_terminator
+sHoundoomPose16:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose17:
+ax_pose 29, 0x0202, 0x00fe, 0x6c00
+ax_pose 30, 0x0202, 0x0106, 0x6c01
+ax_pose 31, 0x81f2, 0x010b, 0x6c02
+ax_pose 32, 0x81e2, 0x4103, 0x6c04
+ax_pose 33, 0x81e2, 0x80f3, 0x6c08
+ax_pose_terminator
+sHoundoomPose18:
+ax_pose 34, 0x0202, 0x0103, 0x6c00
+ax_pose 35, 0x81f2, 0x010b, 0x6c01
+ax_pose 36, 0x81e2, 0x4103, 0x6c03
+ax_pose 37, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose19:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose20:
+ax_pose 18, 0x01fd, 0x010f, 0x6c00
+ax_pose 19, 0x01fd, 0x0107, 0x6c01
+ax_pose 20, 0x81ed, 0x0107, 0x6c02
+ax_pose 21, 0x81e5, 0x40ff, 0x6c04
+ax_pose 22, 0x81e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose21:
+ax_pose 23, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose22:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose23:
+ax_pose 8, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose24:
+ax_pose 9, 0x0208, 0x00f8, 0x6c00
+ax_pose 10, 0x81ef, 0x0108, 0x6c01
+ax_pose 11, 0x81e7, 0x4100, 0x6c03
+ax_pose 12, 0x81e8, 0x80f0, 0x6c07
+ax_pose_terminator
+sHoundoomPose25:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose26:
+ax_pose 2, 0x01ea, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose27:
+ax_pose 3, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose28:
+ax_pose 46, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose29:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+sHoundoomPose30:
+ax_pose 8, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose31:
+ax_pose 9, 0x0208, 0x1100, 0x6c00
+ax_pose 10, 0x81ef, 0x10f0, 0x6c01
+ax_pose 11, 0x81e7, 0x50f8, 0x6c03
+ax_pose 12, 0x81e8, 0x9100, 0x6c07
+ax_pose_terminator
+sHoundoomPose32:
+ax_pose 47, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose33:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose34:
+ax_pose 18, 0x01fd, 0x10e9, 0x6c00
+ax_pose 19, 0x01fd, 0x10f1, 0x6c01
+ax_pose 20, 0x81ed, 0x10f1, 0x6c02
+ax_pose 21, 0x81e5, 0x50f9, 0x6c04
+ax_pose 22, 0x81e5, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose35:
+ax_pose 23, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose36:
+ax_pose 48, 0x81e4, 0x110c, 0x6c00
+ax_pose 49, 0x81e4, 0x5104, 0x6c02
+ax_pose 50, 0x01dc, 0x1104, 0x6c06
+ax_pose 51, 0x01f4, 0x50f4, 0x6c07
+ax_pose 52, 0x41ec, 0x10f4, 0x6c0b
+ax_pose 53, 0x01f4, 0x10ec, 0x6c0d
+ax_pose 54, 0x01fc, 0x10ec, 0x6c0e
+ax_pose_terminator
+sHoundoomPose37:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose38:
+ax_pose 29, 0x0202, 0x10fa, 0x6c00
+ax_pose 30, 0x0202, 0x10f2, 0x6c01
+ax_pose 31, 0x81f2, 0x10ed, 0x6c02
+ax_pose 32, 0x81e2, 0x50f5, 0x6c04
+ax_pose 33, 0x81e2, 0x90fd, 0x6c08
+ax_pose_terminator
+sHoundoomPose39:
+ax_pose 34, 0x0202, 0x10f5, 0x6c00
+ax_pose 35, 0x81f2, 0x10ed, 0x6c01
+ax_pose 36, 0x81e2, 0x50f5, 0x6c03
+ax_pose 37, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose40:
+ax_pose 55, 0x81e1, 0x90ff, 0x6c00
+ax_pose 56, 0x01f1, 0x50ef, 0x6c08
+ax_pose 57, 0x0201, 0x10ef, 0x6c0c
+ax_pose 58, 0x0201, 0x10f7, 0x6c0d
+ax_pose 59, 0x81e1, 0x10f7, 0x6c0e
+ax_pose_terminator
+sHoundoomPose41:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose42:
+ax_pose 40, 0x4202, 0x00f8, 0x6c00
+ax_pose 41, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose43:
+ax_pose 42, 0x0202, 0x0108, 0x6c00
+ax_pose 43, 0x01fa, 0x0108, 0x6c01
+ax_pose 44, 0x4202, 0x00f8, 0x6c02
+ax_pose 45, 0x81e2, 0x80f8, 0x6c04
+ax_pose_terminator
+sHoundoomPose44:
+ax_pose 60, 0x0201, 0x00f8, 0x6c00
+ax_pose 61, 0x0201, 0x0100, 0x6c01
+ax_pose 62, 0x81e1, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose45:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose46:
+ax_pose 29, 0x0202, 0x00fe, 0x6c00
+ax_pose 30, 0x0202, 0x0106, 0x6c01
+ax_pose 31, 0x81f2, 0x010b, 0x6c02
+ax_pose 32, 0x81e2, 0x4103, 0x6c04
+ax_pose 33, 0x81e2, 0x80f3, 0x6c08
+ax_pose_terminator
+sHoundoomPose47:
+ax_pose 34, 0x0202, 0x0103, 0x6c00
+ax_pose 35, 0x81f2, 0x010b, 0x6c01
+ax_pose 36, 0x81e2, 0x4103, 0x6c03
+ax_pose 37, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose48:
+ax_pose 55, 0x81e1, 0x80f1, 0x6c00
+ax_pose 56, 0x01f1, 0x4101, 0x6c08
+ax_pose 57, 0x0201, 0x0109, 0x6c0c
+ax_pose 58, 0x0201, 0x0101, 0x6c0d
+ax_pose 59, 0x81e1, 0x0101, 0x6c0e
+ax_pose_terminator
+sHoundoomPose49:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose50:
+ax_pose 18, 0x01fd, 0x010f, 0x6c00
+ax_pose 19, 0x01fd, 0x0107, 0x6c01
+ax_pose 20, 0x81ed, 0x0107, 0x6c02
+ax_pose 21, 0x81e5, 0x40ff, 0x6c04
+ax_pose 22, 0x81e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose51:
+ax_pose 23, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose52:
+ax_pose 48, 0x81e4, 0x00ec, 0x6c00
+ax_pose 49, 0x81e4, 0x40f4, 0x6c02
+ax_pose 50, 0x01dc, 0x00f4, 0x6c06
+ax_pose 51, 0x01f4, 0x40fc, 0x6c07
+ax_pose 52, 0x41ec, 0x00fc, 0x6c0b
+ax_pose 53, 0x01f4, 0x010c, 0x6c0d
+ax_pose 54, 0x01fc, 0x010c, 0x6c0e
+ax_pose_terminator
+sHoundoomPose53:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose54:
+ax_pose 8, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose55:
+ax_pose 9, 0x0208, 0x00f8, 0x6c00
+ax_pose 10, 0x81ef, 0x0108, 0x6c01
+ax_pose 11, 0x81e7, 0x4100, 0x6c03
+ax_pose 12, 0x81e8, 0x80f0, 0x6c07
+ax_pose_terminator
+sHoundoomPose56:
+ax_pose 47, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose57:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose58:
+ax_pose 2, 0x01ea, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose59:
+ax_pose 3, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose60:
+ax_pose 46, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose61:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+sHoundoomPose62:
+ax_pose 8, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose63:
+ax_pose 9, 0x0208, 0x1100, 0x6c00
+ax_pose 10, 0x81ef, 0x10f0, 0x6c01
+ax_pose 11, 0x81e7, 0x50f8, 0x6c03
+ax_pose 12, 0x81e8, 0x9100, 0x6c07
+ax_pose_terminator
+sHoundoomPose64:
+ax_pose 47, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose65:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose66:
+ax_pose 18, 0x01fd, 0x10e9, 0x6c00
+ax_pose 19, 0x01fd, 0x10f1, 0x6c01
+ax_pose 20, 0x81ed, 0x10f1, 0x6c02
+ax_pose 21, 0x81e5, 0x50f9, 0x6c04
+ax_pose 22, 0x81e5, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose67:
+ax_pose 23, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose68:
+ax_pose 48, 0x81e4, 0x110c, 0x6c00
+ax_pose 49, 0x81e4, 0x5104, 0x6c02
+ax_pose 50, 0x01dc, 0x1104, 0x6c06
+ax_pose 51, 0x01f4, 0x50f4, 0x6c07
+ax_pose 52, 0x41ec, 0x10f4, 0x6c0b
+ax_pose 53, 0x01f4, 0x10ec, 0x6c0d
+ax_pose 54, 0x01fc, 0x10ec, 0x6c0e
+ax_pose_terminator
+sHoundoomPose69:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose70:
+ax_pose 29, 0x0202, 0x10fa, 0x6c00
+ax_pose 30, 0x0202, 0x10f2, 0x6c01
+ax_pose 31, 0x81f2, 0x10ed, 0x6c02
+ax_pose 32, 0x81e2, 0x50f5, 0x6c04
+ax_pose 33, 0x81e2, 0x90fd, 0x6c08
+ax_pose_terminator
+sHoundoomPose71:
+ax_pose 34, 0x0202, 0x10f5, 0x6c00
+ax_pose 35, 0x81f2, 0x10ed, 0x6c01
+ax_pose 36, 0x81e2, 0x50f5, 0x6c03
+ax_pose 37, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose72:
+ax_pose 55, 0x81e1, 0x90ff, 0x6c00
+ax_pose 56, 0x01f1, 0x50ef, 0x6c08
+ax_pose 57, 0x0201, 0x10ef, 0x6c0c
+ax_pose 58, 0x0201, 0x10f7, 0x6c0d
+ax_pose 59, 0x81e1, 0x10f7, 0x6c0e
+ax_pose_terminator
+sHoundoomPose73:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose74:
+ax_pose 40, 0x4202, 0x00f8, 0x6c00
+ax_pose 41, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose75:
+ax_pose 42, 0x0202, 0x0108, 0x6c00
+ax_pose 43, 0x01fa, 0x0108, 0x6c01
+ax_pose 44, 0x4202, 0x00f8, 0x6c02
+ax_pose 45, 0x81e2, 0x80f8, 0x6c04
+ax_pose_terminator
+sHoundoomPose76:
+ax_pose 60, 0x0201, 0x00f8, 0x6c00
+ax_pose 61, 0x0201, 0x0100, 0x6c01
+ax_pose 62, 0x81e1, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose77:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose78:
+ax_pose 29, 0x0202, 0x00fe, 0x6c00
+ax_pose 30, 0x0202, 0x0106, 0x6c01
+ax_pose 31, 0x81f2, 0x010b, 0x6c02
+ax_pose 32, 0x81e2, 0x4103, 0x6c04
+ax_pose 33, 0x81e2, 0x80f3, 0x6c08
+ax_pose_terminator
+sHoundoomPose79:
+ax_pose 34, 0x0202, 0x0103, 0x6c00
+ax_pose 35, 0x81f2, 0x010b, 0x6c01
+ax_pose 36, 0x81e2, 0x4103, 0x6c03
+ax_pose 37, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose80:
+ax_pose 55, 0x81e1, 0x80f1, 0x6c00
+ax_pose 56, 0x01f1, 0x4101, 0x6c08
+ax_pose 57, 0x0201, 0x0109, 0x6c0c
+ax_pose 58, 0x0201, 0x0101, 0x6c0d
+ax_pose 59, 0x81e1, 0x0101, 0x6c0e
+ax_pose_terminator
+sHoundoomPose81:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose82:
+ax_pose 18, 0x01fd, 0x010f, 0x6c00
+ax_pose 19, 0x01fd, 0x0107, 0x6c01
+ax_pose 20, 0x81ed, 0x0107, 0x6c02
+ax_pose 21, 0x81e5, 0x40ff, 0x6c04
+ax_pose 22, 0x81e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose83:
+ax_pose 23, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose84:
+ax_pose 48, 0x81e4, 0x00ec, 0x6c00
+ax_pose 49, 0x81e4, 0x40f4, 0x6c02
+ax_pose 50, 0x01dc, 0x00f4, 0x6c06
+ax_pose 51, 0x01f4, 0x40fc, 0x6c07
+ax_pose 52, 0x41ec, 0x00fc, 0x6c0b
+ax_pose 53, 0x01f4, 0x010c, 0x6c0d
+ax_pose 54, 0x01fc, 0x010c, 0x6c0e
+ax_pose_terminator
+sHoundoomPose85:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose86:
+ax_pose 8, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose87:
+ax_pose 9, 0x0208, 0x00f8, 0x6c00
+ax_pose 10, 0x81ef, 0x0108, 0x6c01
+ax_pose 11, 0x81e7, 0x4100, 0x6c03
+ax_pose 12, 0x81e8, 0x80f0, 0x6c07
+ax_pose_terminator
+sHoundoomPose88:
+ax_pose 47, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose89:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose90:
+ax_pose 2, 0x01ea, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose91:
+ax_pose 63, 0x01e6, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose92:
+ax_pose 46, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose93:
+ax_pose 64, 0x81e5, 0x80f7, 0x6c00
+ax_pose 65, 0x01e5, 0x0107, 0x6c08
+ax_pose_terminator
+sHoundoomPose94:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+sHoundoomPose95:
+ax_pose 8, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose96:
+ax_pose 66, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose97:
+ax_pose 47, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose98:
+ax_pose 67, 0x81e6, 0x90fe, 0x6c00
+ax_pose 68, 0x81e6, 0x50f6, 0x6c08
+ax_pose 69, 0x01de, 0x10f6, 0x6c0c
+ax_pose 70, 0x01de, 0x10fe, 0x6c0d
+ax_pose 71, 0x01f6, 0x10ee, 0x6c0e
+ax_pose_terminator
+sHoundoomPose99:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose100:
+ax_pose 18, 0x01fd, 0x10e9, 0x6c00
+ax_pose 19, 0x01fd, 0x10f1, 0x6c01
+ax_pose 20, 0x81ed, 0x10f1, 0x6c02
+ax_pose 21, 0x81e5, 0x50f9, 0x6c04
+ax_pose 22, 0x81e5, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose101:
+ax_pose 72, 0x81e4, 0x90fb, 0x6c00
+ax_pose 73, 0x01f4, 0x50eb, 0x6c08
+ax_pose 74, 0x01ec, 0x10f3, 0x6c0c
+ax_pose 75, 0x01dc, 0x1103, 0x6c0d
+ax_pose_terminator
+sHoundoomPose102:
+ax_pose 48, 0x81e4, 0x110c, 0x6c00
+ax_pose 49, 0x81e4, 0x5104, 0x6c02
+ax_pose 50, 0x01dc, 0x1104, 0x6c06
+ax_pose 51, 0x01f4, 0x50f4, 0x6c07
+ax_pose 52, 0x41ec, 0x10f4, 0x6c0b
+ax_pose 53, 0x01f4, 0x10ec, 0x6c0d
+ax_pose 54, 0x01fc, 0x10ec, 0x6c0e
+ax_pose_terminator
+sHoundoomPose103:
+ax_pose 76, 0x81e4, 0x90fc, 0x6c00
+ax_pose 77, 0x01ec, 0x10f4, 0x6c08
+ax_pose 78, 0x81f4, 0x10ec, 0x6c09
+ax_pose 79, 0x41dc, 0x10fc, 0x6c0b
+ax_pose 80, 0x81f4, 0x10f4, 0x6c0d
+ax_pose_terminator
+sHoundoomPose104:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose105:
+ax_pose 29, 0x0202, 0x10fa, 0x6c00
+ax_pose 30, 0x0202, 0x10f2, 0x6c01
+ax_pose 31, 0x81f2, 0x10ed, 0x6c02
+ax_pose 32, 0x81e2, 0x50f5, 0x6c04
+ax_pose 33, 0x81e2, 0x90fd, 0x6c08
+ax_pose_terminator
+sHoundoomPose106:
+ax_pose 81, 0x81e2, 0x90fb, 0x6c00
+ax_pose 82, 0x01f2, 0x50eb, 0x6c08
+ax_pose 83, 0x01da, 0x1103, 0x6c0c
+ax_pose 84, 0x4202, 0x10f3, 0x6c0d
+ax_pose_terminator
+sHoundoomPose107:
+ax_pose 55, 0x81e1, 0x90ff, 0x6c00
+ax_pose 56, 0x01f1, 0x50ef, 0x6c08
+ax_pose 57, 0x0201, 0x10ef, 0x6c0c
+ax_pose 58, 0x0201, 0x10f7, 0x6c0d
+ax_pose 59, 0x81e1, 0x10f7, 0x6c0e
+ax_pose_terminator
+sHoundoomPose108:
+ax_pose 85, 0x81e5, 0x90fd, 0x6c00
+ax_pose 86, 0x01ed, 0x10f5, 0x6c08
+ax_pose 87, 0x01f5, 0x50ed, 0x6c09
+ax_pose 88, 0x41dd, 0x10f5, 0x6c0d
+ax_pose_terminator
+sHoundoomPose109:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose110:
+ax_pose 40, 0x4202, 0x00f8, 0x6c00
+ax_pose 41, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose111:
+ax_pose 89, 0x01df, 0x0100, 0x6c00
+ax_pose 90, 0x01df, 0x00f8, 0x6c01
+ax_pose 91, 0x81e7, 0x80f8, 0x6c02
+ax_pose 92, 0x81e7, 0x0108, 0x6c0a
+ax_pose_terminator
+sHoundoomPose112:
+ax_pose 60, 0x0201, 0x00f8, 0x6c00
+ax_pose 61, 0x0201, 0x0100, 0x6c01
+ax_pose 62, 0x81e1, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose113:
+ax_pose 93, 0x81e1, 0x80f8, 0x6c00
+ax_pose 94, 0x4201, 0x00f8, 0x6c08
+ax_pose_terminator
+sHoundoomPose114:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose115:
+ax_pose 29, 0x0202, 0x00fe, 0x6c00
+ax_pose 30, 0x0202, 0x0106, 0x6c01
+ax_pose 31, 0x81f2, 0x010b, 0x6c02
+ax_pose 32, 0x81e2, 0x4103, 0x6c04
+ax_pose 33, 0x81e2, 0x80f3, 0x6c08
+ax_pose_terminator
+sHoundoomPose116:
+ax_pose 81, 0x81e2, 0x80f5, 0x6c00
+ax_pose 82, 0x01f2, 0x4105, 0x6c08
+ax_pose 83, 0x01da, 0x00f5, 0x6c0c
+ax_pose 84, 0x4202, 0x00fd, 0x6c0d
+ax_pose_terminator
+sHoundoomPose117:
+ax_pose 55, 0x81e1, 0x80f1, 0x6c00
+ax_pose 56, 0x01f1, 0x4101, 0x6c08
+ax_pose 57, 0x0201, 0x0109, 0x6c0c
+ax_pose 58, 0x0201, 0x0101, 0x6c0d
+ax_pose 59, 0x81e1, 0x0101, 0x6c0e
+ax_pose_terminator
+sHoundoomPose118:
+ax_pose 85, 0x81e5, 0x80f3, 0x6c00
+ax_pose 86, 0x01ed, 0x0103, 0x6c08
+ax_pose 87, 0x01f5, 0x4103, 0x6c09
+ax_pose 88, 0x41dd, 0x00fb, 0x6c0d
+ax_pose_terminator
+sHoundoomPose119:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose120:
+ax_pose 18, 0x01fd, 0x010f, 0x6c00
+ax_pose 19, 0x01fd, 0x0107, 0x6c01
+ax_pose 20, 0x81ed, 0x0107, 0x6c02
+ax_pose 21, 0x81e5, 0x40ff, 0x6c04
+ax_pose 22, 0x81e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose121:
+ax_pose 72, 0x81e4, 0x80f5, 0x6c00
+ax_pose 73, 0x01f4, 0x4105, 0x6c08
+ax_pose 74, 0x01ec, 0x0105, 0x6c0c
+ax_pose 75, 0x01dc, 0x00f5, 0x6c0d
+ax_pose_terminator
+sHoundoomPose122:
+ax_pose 48, 0x81e4, 0x00ec, 0x6c00
+ax_pose 49, 0x81e4, 0x40f4, 0x6c02
+ax_pose 50, 0x01dc, 0x00f4, 0x6c06
+ax_pose 51, 0x01f4, 0x40fc, 0x6c07
+ax_pose 52, 0x41ec, 0x00fc, 0x6c0b
+ax_pose 53, 0x01f4, 0x010c, 0x6c0d
+ax_pose 54, 0x01fc, 0x010c, 0x6c0e
+ax_pose_terminator
+sHoundoomPose123:
+ax_pose 76, 0x81e4, 0x80f4, 0x6c00
+ax_pose 77, 0x01ec, 0x0104, 0x6c08
+ax_pose 78, 0x81f4, 0x010c, 0x6c09
+ax_pose 79, 0x41dc, 0x00f4, 0x6c0b
+ax_pose 80, 0x81f4, 0x0104, 0x6c0d
+ax_pose_terminator
+sHoundoomPose124:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose125:
+ax_pose 8, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose126:
+ax_pose 66, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose127:
+ax_pose 47, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose128:
+ax_pose 67, 0x81e6, 0x80f2, 0x6c00
+ax_pose 68, 0x81e6, 0x4102, 0x6c08
+ax_pose 69, 0x01de, 0x0102, 0x6c0c
+ax_pose 70, 0x01de, 0x00fa, 0x6c0d
+ax_pose 71, 0x01f6, 0x010a, 0x6c0e
+ax_pose_terminator
+sHoundoomPose129:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose130:
+ax_pose 63, 0x01e6, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose131:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+sHoundoomPose132:
+ax_pose 66, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose133:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose134:
+ax_pose 72, 0x81e4, 0x90fb, 0x6c00
+ax_pose 73, 0x01f4, 0x50eb, 0x6c08
+ax_pose 74, 0x01ec, 0x10f3, 0x6c0c
+ax_pose 75, 0x01dc, 0x1103, 0x6c0d
+ax_pose_terminator
+sHoundoomPose135:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose136:
+ax_pose 81, 0x81e2, 0x90fb, 0x6c00
+ax_pose 82, 0x01f2, 0x50eb, 0x6c08
+ax_pose 83, 0x01da, 0x1103, 0x6c0c
+ax_pose 84, 0x4202, 0x10f3, 0x6c0d
+ax_pose_terminator
+sHoundoomPose137:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose138:
+ax_pose 89, 0x01df, 0x0100, 0x6c00
+ax_pose 90, 0x01df, 0x00f8, 0x6c01
+ax_pose 91, 0x81e7, 0x80f8, 0x6c02
+ax_pose 92, 0x81e7, 0x0108, 0x6c0a
+ax_pose_terminator
+sHoundoomPose139:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose140:
+ax_pose 81, 0x81e2, 0x80f5, 0x6c00
+ax_pose 82, 0x01f2, 0x4105, 0x6c08
+ax_pose 83, 0x01da, 0x00f5, 0x6c0c
+ax_pose 84, 0x4202, 0x00fd, 0x6c0d
+ax_pose_terminator
+sHoundoomPose141:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose142:
+ax_pose 72, 0x81e4, 0x80f5, 0x6c00
+ax_pose 73, 0x01f4, 0x4105, 0x6c08
+ax_pose 74, 0x01ec, 0x0105, 0x6c0c
+ax_pose 75, 0x01dc, 0x00f5, 0x6c0d
+ax_pose_terminator
+sHoundoomPose143:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose144:
+ax_pose 66, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose145:
+ax_pose 95, 0x01ec, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundoomPose146:
+ax_pose 96, 0x01ec, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundoomPose147:
+ax_pose 97, 0x81e7, 0x80f4, 0x6c00
+ax_pose 98, 0x81e7, 0x4104, 0x6c08
+ax_pose 99, 0x01e7, 0x010c, 0x6c0c
+ax_pose 100, 0x01df, 0x0100, 0x6c0d
+ax_pose_terminator
+sHoundoomPose148:
+ax_pose 101, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose149:
+ax_pose 102, 0x01e4, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose150:
+ax_pose 103, 0x81e5, 0x90fe, 0x6c00
+ax_pose 104, 0x01e2, 0x10f6, 0x6c08
+ax_pose 105, 0x0205, 0x10f7, 0x6c09
+ax_pose 106, 0x41ed, 0x10ee, 0x6c0a
+ax_pose 107, 0x01f5, 0x50ee, 0x6c0c
+ax_pose_terminator
+sHoundoomPose151:
+ax_pose 108, 0x0201, 0x00f5, 0x6c00
+ax_pose -1, 0x0201, 0x1102, 0x6c00
+ax_pose 109, 0x81e6, 0x80f1, 0x6c01
+ax_pose 110, 0x81e6, 0x4101, 0x6c09
+ax_pose_terminator
+sHoundoomPose152:
+ax_pose 103, 0x81e5, 0x80f1, 0x6c00
+ax_pose 104, 0x01e2, 0x0101, 0x6c08
+ax_pose 105, 0x0205, 0x0100, 0x6c09
+ax_pose 106, 0x41ed, 0x0101, 0x6c0a
+ax_pose 107, 0x01f5, 0x4101, 0x6c0c
+ax_pose_terminator
+sHoundoomPose153:
+ax_pose 102, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundoomPose154:
+ax_pose 101, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose155:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose156:
+ax_pose 2, 0x01ea, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose157:
+ax_pose 63, 0x01e6, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose158:
+ax_pose 46, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose159:
+ax_pose 64, 0x81e5, 0x80f7, 0x6c00
+ax_pose 65, 0x01e5, 0x0107, 0x6c08
+ax_pose_terminator
+sHoundoomPose160:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+sHoundoomPose161:
+ax_pose 8, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundoomPose162:
+ax_pose 66, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose163:
+ax_pose 47, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose164:
+ax_pose 67, 0x81e6, 0x90fe, 0x6c00
+ax_pose 68, 0x81e6, 0x50f6, 0x6c08
+ax_pose 69, 0x01de, 0x10f6, 0x6c0c
+ax_pose 70, 0x01de, 0x10fe, 0x6c0d
+ax_pose 71, 0x01f6, 0x10ee, 0x6c0e
+ax_pose_terminator
+sHoundoomPose165:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose166:
+ax_pose 18, 0x01fd, 0x10e9, 0x6c00
+ax_pose 19, 0x01fd, 0x10f1, 0x6c01
+ax_pose 20, 0x81ed, 0x10f1, 0x6c02
+ax_pose 21, 0x81e5, 0x50f9, 0x6c04
+ax_pose 22, 0x81e5, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose167:
+ax_pose 72, 0x81e4, 0x90fb, 0x6c00
+ax_pose 73, 0x01f4, 0x50eb, 0x6c08
+ax_pose 74, 0x01ec, 0x10f3, 0x6c0c
+ax_pose 75, 0x01dc, 0x1103, 0x6c0d
+ax_pose_terminator
+sHoundoomPose168:
+ax_pose 48, 0x81e4, 0x110c, 0x6c00
+ax_pose 49, 0x81e4, 0x5104, 0x6c02
+ax_pose 50, 0x01dc, 0x1104, 0x6c06
+ax_pose 51, 0x01f4, 0x50f4, 0x6c07
+ax_pose 52, 0x41ec, 0x10f4, 0x6c0b
+ax_pose 53, 0x01f4, 0x10ec, 0x6c0d
+ax_pose 54, 0x01fc, 0x10ec, 0x6c0e
+ax_pose_terminator
+sHoundoomPose169:
+ax_pose 76, 0x81e4, 0x90fc, 0x6c00
+ax_pose 77, 0x01ec, 0x10f4, 0x6c08
+ax_pose 78, 0x81f4, 0x10ec, 0x6c09
+ax_pose 79, 0x41dc, 0x10fc, 0x6c0b
+ax_pose 80, 0x81f4, 0x10f4, 0x6c0d
+ax_pose_terminator
+sHoundoomPose170:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose171:
+ax_pose 29, 0x0202, 0x10fa, 0x6c00
+ax_pose 30, 0x0202, 0x10f2, 0x6c01
+ax_pose 31, 0x81f2, 0x10ed, 0x6c02
+ax_pose 32, 0x81e2, 0x50f5, 0x6c04
+ax_pose 33, 0x81e2, 0x90fd, 0x6c08
+ax_pose_terminator
+sHoundoomPose172:
+ax_pose 81, 0x81e2, 0x90fb, 0x6c00
+ax_pose 82, 0x01f2, 0x50eb, 0x6c08
+ax_pose 83, 0x01da, 0x1103, 0x6c0c
+ax_pose 84, 0x4202, 0x10f3, 0x6c0d
+ax_pose_terminator
+sHoundoomPose173:
+ax_pose 55, 0x81e1, 0x90ff, 0x6c00
+ax_pose 56, 0x01f1, 0x50ef, 0x6c08
+ax_pose 57, 0x0201, 0x10ef, 0x6c0c
+ax_pose 58, 0x0201, 0x10f7, 0x6c0d
+ax_pose 59, 0x81e1, 0x10f7, 0x6c0e
+ax_pose_terminator
+sHoundoomPose174:
+ax_pose 85, 0x81e5, 0x90fd, 0x6c00
+ax_pose 86, 0x01ed, 0x10f5, 0x6c08
+ax_pose 87, 0x01f5, 0x50ed, 0x6c09
+ax_pose 88, 0x41dd, 0x10f5, 0x6c0d
+ax_pose_terminator
+sHoundoomPose175:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose176:
+ax_pose 40, 0x4202, 0x00f8, 0x6c00
+ax_pose 41, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose177:
+ax_pose 89, 0x01df, 0x0100, 0x6c00
+ax_pose 90, 0x01df, 0x00f8, 0x6c01
+ax_pose 91, 0x81e7, 0x80f8, 0x6c02
+ax_pose 92, 0x81e7, 0x0108, 0x6c0a
+ax_pose_terminator
+sHoundoomPose178:
+ax_pose 60, 0x0201, 0x00f8, 0x6c00
+ax_pose 61, 0x0201, 0x0100, 0x6c01
+ax_pose 62, 0x81e1, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose179:
+ax_pose 93, 0x81e1, 0x80f8, 0x6c00
+ax_pose 94, 0x4201, 0x00f8, 0x6c08
+ax_pose_terminator
+sHoundoomPose180:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose181:
+ax_pose 29, 0x0202, 0x00fe, 0x6c00
+ax_pose 30, 0x0202, 0x0106, 0x6c01
+ax_pose 31, 0x81f2, 0x010b, 0x6c02
+ax_pose 32, 0x81e2, 0x4103, 0x6c04
+ax_pose 33, 0x81e2, 0x80f3, 0x6c08
+ax_pose_terminator
+sHoundoomPose182:
+ax_pose 81, 0x81e2, 0x80f5, 0x6c00
+ax_pose 82, 0x01f2, 0x4105, 0x6c08
+ax_pose 83, 0x01da, 0x00f5, 0x6c0c
+ax_pose 84, 0x4202, 0x00fd, 0x6c0d
+ax_pose_terminator
+sHoundoomPose183:
+ax_pose 55, 0x81e1, 0x80f1, 0x6c00
+ax_pose 56, 0x01f1, 0x4101, 0x6c08
+ax_pose 57, 0x0201, 0x0109, 0x6c0c
+ax_pose 58, 0x0201, 0x0101, 0x6c0d
+ax_pose 59, 0x81e1, 0x0101, 0x6c0e
+ax_pose_terminator
+sHoundoomPose184:
+ax_pose 85, 0x81e5, 0x80f3, 0x6c00
+ax_pose 86, 0x01ed, 0x0103, 0x6c08
+ax_pose 87, 0x01f5, 0x4103, 0x6c09
+ax_pose 88, 0x41dd, 0x00fb, 0x6c0d
+ax_pose_terminator
+sHoundoomPose185:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose186:
+ax_pose 18, 0x01fd, 0x010f, 0x6c00
+ax_pose 19, 0x01fd, 0x0107, 0x6c01
+ax_pose 20, 0x81ed, 0x0107, 0x6c02
+ax_pose 21, 0x81e5, 0x40ff, 0x6c04
+ax_pose 22, 0x81e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose187:
+ax_pose 72, 0x81e4, 0x80f5, 0x6c00
+ax_pose 73, 0x01f4, 0x4105, 0x6c08
+ax_pose 74, 0x01ec, 0x0105, 0x6c0c
+ax_pose 75, 0x01dc, 0x00f5, 0x6c0d
+ax_pose_terminator
+sHoundoomPose188:
+ax_pose 48, 0x81e4, 0x00ec, 0x6c00
+ax_pose 49, 0x81e4, 0x40f4, 0x6c02
+ax_pose 50, 0x01dc, 0x00f4, 0x6c06
+ax_pose 51, 0x01f4, 0x40fc, 0x6c07
+ax_pose 52, 0x41ec, 0x00fc, 0x6c0b
+ax_pose 53, 0x01f4, 0x010c, 0x6c0d
+ax_pose 54, 0x01fc, 0x010c, 0x6c0e
+ax_pose_terminator
+sHoundoomPose189:
+ax_pose 76, 0x81e4, 0x80f4, 0x6c00
+ax_pose 77, 0x01ec, 0x0104, 0x6c08
+ax_pose 78, 0x81f4, 0x010c, 0x6c09
+ax_pose 79, 0x41dc, 0x00f4, 0x6c0b
+ax_pose 80, 0x81f4, 0x0104, 0x6c0d
+ax_pose_terminator
+sHoundoomPose190:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose191:
+ax_pose 8, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundoomPose192:
+ax_pose 66, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose193:
+ax_pose 47, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose194:
+ax_pose 67, 0x81e6, 0x80f2, 0x6c00
+ax_pose 68, 0x81e6, 0x4102, 0x6c08
+ax_pose 69, 0x01de, 0x0102, 0x6c0c
+ax_pose 70, 0x01de, 0x00fa, 0x6c0d
+ax_pose 71, 0x01f6, 0x010a, 0x6c0e
+ax_pose_terminator
+sHoundoomPose195:
+ax_pose 46, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose196:
+ax_pose 47, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose197:
+ax_pose 48, 0x81e4, 0x00ec, 0x6c00
+ax_pose 49, 0x81e4, 0x40f4, 0x6c02
+ax_pose 50, 0x01dc, 0x00f4, 0x6c06
+ax_pose 51, 0x01f4, 0x40fc, 0x6c07
+ax_pose 52, 0x41ec, 0x00fc, 0x6c0b
+ax_pose 53, 0x01f4, 0x010c, 0x6c0d
+ax_pose 54, 0x01fc, 0x010c, 0x6c0e
+ax_pose_terminator
+sHoundoomPose198:
+ax_pose 55, 0x81e1, 0x80f1, 0x6c00
+ax_pose 56, 0x01f1, 0x4101, 0x6c08
+ax_pose 57, 0x0201, 0x0109, 0x6c0c
+ax_pose 58, 0x0201, 0x0101, 0x6c0d
+ax_pose 59, 0x81e1, 0x0101, 0x6c0e
+ax_pose_terminator
+sHoundoomPose199:
+ax_pose 60, 0x0201, 0x00f8, 0x6c00
+ax_pose 61, 0x0201, 0x0100, 0x6c01
+ax_pose 62, 0x81e1, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose200:
+ax_pose 55, 0x81e1, 0x90ff, 0x6c00
+ax_pose 56, 0x01f1, 0x50ef, 0x6c08
+ax_pose 57, 0x0201, 0x10ef, 0x6c0c
+ax_pose 58, 0x0201, 0x10f7, 0x6c0d
+ax_pose 59, 0x81e1, 0x10f7, 0x6c0e
+ax_pose_terminator
+sHoundoomPose201:
+ax_pose 48, 0x81e4, 0x110c, 0x6c00
+ax_pose 49, 0x81e4, 0x5104, 0x6c02
+ax_pose 50, 0x01dc, 0x1104, 0x6c06
+ax_pose 51, 0x01f4, 0x50f4, 0x6c07
+ax_pose 52, 0x41ec, 0x10f4, 0x6c0b
+ax_pose 53, 0x01f4, 0x10ec, 0x6c0d
+ax_pose 54, 0x01fc, 0x10ec, 0x6c0e
+ax_pose_terminator
+sHoundoomPose202:
+ax_pose 47, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose203:
+ax_pose 63, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose204:
+ax_pose 66, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose205:
+ax_pose 72, 0x81e4, 0x90fc, 0x6c00
+ax_pose 73, 0x01f4, 0x50ec, 0x6c08
+ax_pose 74, 0x01ec, 0x10f4, 0x6c0c
+ax_pose 75, 0x01dc, 0x1104, 0x6c0d
+ax_pose_terminator
+sHoundoomPose206:
+ax_pose 81, 0x81e3, 0x90fc, 0x6c00
+ax_pose 82, 0x01f3, 0x50ec, 0x6c08
+ax_pose 83, 0x01db, 0x1104, 0x6c0c
+ax_pose 84, 0x4203, 0x10f4, 0x6c0d
+ax_pose_terminator
+sHoundoomPose207:
+ax_pose 89, 0x01e0, 0x0100, 0x6c00
+ax_pose 90, 0x01e0, 0x00f8, 0x6c01
+ax_pose 91, 0x81e8, 0x80f8, 0x6c02
+ax_pose 92, 0x81e8, 0x0108, 0x6c0a
+ax_pose_terminator
+sHoundoomPose208:
+ax_pose 81, 0x81e3, 0x80f4, 0x6c00
+ax_pose 82, 0x01f3, 0x4104, 0x6c08
+ax_pose 83, 0x01db, 0x00f4, 0x6c0c
+ax_pose 84, 0x4203, 0x00fc, 0x6c0d
+ax_pose_terminator
+sHoundoomPose209:
+ax_pose 72, 0x81e4, 0x80f4, 0x6c00
+ax_pose 73, 0x01f4, 0x4104, 0x6c08
+ax_pose 74, 0x01ec, 0x0104, 0x6c0c
+ax_pose 75, 0x01dc, 0x00f4, 0x6c0d
+ax_pose_terminator
+sHoundoomPose210:
+ax_pose 66, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose211:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose212:
+ax_pose 63, 0x01e6, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose213:
+ax_pose 46, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose214:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+sHoundoomPose215:
+ax_pose 66, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose216:
+ax_pose 47, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose217:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose218:
+ax_pose 72, 0x81e4, 0x90fb, 0x6c00
+ax_pose 73, 0x01f4, 0x50eb, 0x6c08
+ax_pose 74, 0x01ec, 0x10f3, 0x6c0c
+ax_pose 75, 0x01dc, 0x1103, 0x6c0d
+ax_pose_terminator
+sHoundoomPose219:
+ax_pose 48, 0x81e4, 0x110b, 0x6c00
+ax_pose 49, 0x81e4, 0x5103, 0x6c02
+ax_pose 50, 0x01dc, 0x1103, 0x6c06
+ax_pose 51, 0x01f4, 0x50f3, 0x6c07
+ax_pose 52, 0x41ec, 0x10f3, 0x6c0b
+ax_pose 53, 0x01f4, 0x10eb, 0x6c0d
+ax_pose 54, 0x01fc, 0x10eb, 0x6c0e
+ax_pose_terminator
+sHoundoomPose220:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose221:
+ax_pose 81, 0x81e2, 0x90fb, 0x6c00
+ax_pose 82, 0x01f2, 0x50eb, 0x6c08
+ax_pose 83, 0x01da, 0x1103, 0x6c0c
+ax_pose 84, 0x4202, 0x10f3, 0x6c0d
+ax_pose_terminator
+sHoundoomPose222:
+ax_pose 55, 0x81e1, 0x90fe, 0x6c00
+ax_pose 56, 0x01f1, 0x50ee, 0x6c08
+ax_pose 57, 0x0201, 0x10ee, 0x6c0c
+ax_pose 58, 0x0201, 0x10f6, 0x6c0d
+ax_pose 59, 0x81e1, 0x10f6, 0x6c0e
+ax_pose_terminator
+sHoundoomPose223:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose224:
+ax_pose 89, 0x01df, 0x0100, 0x6c00
+ax_pose 90, 0x01df, 0x00f8, 0x6c01
+ax_pose 91, 0x81e7, 0x80f8, 0x6c02
+ax_pose 92, 0x81e7, 0x0108, 0x6c0a
+ax_pose_terminator
+sHoundoomPose225:
+ax_pose 60, 0x0201, 0x00f8, 0x6c00
+ax_pose 61, 0x0201, 0x0100, 0x6c01
+ax_pose 62, 0x81e1, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose226:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose227:
+ax_pose 81, 0x81e2, 0x80f5, 0x6c00
+ax_pose 82, 0x01f2, 0x4105, 0x6c08
+ax_pose 83, 0x01da, 0x00f5, 0x6c0c
+ax_pose 84, 0x4202, 0x00fd, 0x6c0d
+ax_pose_terminator
+sHoundoomPose228:
+ax_pose 55, 0x81e1, 0x80f2, 0x6c00
+ax_pose 56, 0x01f1, 0x4102, 0x6c08
+ax_pose 57, 0x0201, 0x010a, 0x6c0c
+ax_pose 58, 0x0201, 0x0102, 0x6c0d
+ax_pose 59, 0x81e1, 0x0102, 0x6c0e
+ax_pose_terminator
+sHoundoomPose229:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose230:
+ax_pose 72, 0x81e4, 0x80f5, 0x6c00
+ax_pose 73, 0x01f4, 0x4105, 0x6c08
+ax_pose 74, 0x01ec, 0x0105, 0x6c0c
+ax_pose 75, 0x01dc, 0x00f5, 0x6c0d
+ax_pose_terminator
+sHoundoomPose231:
+ax_pose 48, 0x81e4, 0x00ed, 0x6c00
+ax_pose 49, 0x81e4, 0x40f5, 0x6c02
+ax_pose 50, 0x01dc, 0x00f5, 0x6c06
+ax_pose 51, 0x01f4, 0x40fd, 0x6c07
+ax_pose 52, 0x41ec, 0x00fd, 0x6c0b
+ax_pose 53, 0x01f4, 0x010d, 0x6c0d
+ax_pose 54, 0x01fc, 0x010d, 0x6c0e
+ax_pose_terminator
+sHoundoomPose232:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose233:
+ax_pose 66, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose234:
+ax_pose 47, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose235:
+ax_pose 46, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sHoundoomPose236:
+ax_pose 47, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundoomPose237:
+ax_pose 48, 0x81e4, 0x00ec, 0x6c00
+ax_pose 49, 0x81e4, 0x40f4, 0x6c02
+ax_pose 50, 0x01dc, 0x00f4, 0x6c06
+ax_pose 51, 0x01f4, 0x40fc, 0x6c07
+ax_pose 52, 0x41ec, 0x00fc, 0x6c0b
+ax_pose 53, 0x01f4, 0x010c, 0x6c0d
+ax_pose 54, 0x01fc, 0x010c, 0x6c0e
+ax_pose_terminator
+sHoundoomPose238:
+ax_pose 55, 0x81e1, 0x80f1, 0x6c00
+ax_pose 56, 0x01f1, 0x4101, 0x6c08
+ax_pose 57, 0x0201, 0x0109, 0x6c0c
+ax_pose 58, 0x0201, 0x0101, 0x6c0d
+ax_pose 59, 0x81e1, 0x0101, 0x6c0e
+ax_pose_terminator
+sHoundoomPose239:
+ax_pose 60, 0x0201, 0x00f8, 0x6c00
+ax_pose 61, 0x0201, 0x0100, 0x6c01
+ax_pose 62, 0x81e1, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose240:
+ax_pose 55, 0x81e1, 0x90ff, 0x6c00
+ax_pose 56, 0x01f1, 0x50ef, 0x6c08
+ax_pose 57, 0x0201, 0x10ef, 0x6c0c
+ax_pose 58, 0x0201, 0x10f7, 0x6c0d
+ax_pose 59, 0x81e1, 0x10f7, 0x6c0e
+ax_pose_terminator
+sHoundoomPose241:
+ax_pose 48, 0x81e4, 0x110c, 0x6c00
+ax_pose 49, 0x81e4, 0x5104, 0x6c02
+ax_pose 50, 0x01dc, 0x1104, 0x6c06
+ax_pose 51, 0x01f4, 0x50f4, 0x6c07
+ax_pose 52, 0x41ec, 0x10f4, 0x6c0b
+ax_pose 53, 0x01f4, 0x10ec, 0x6c0d
+ax_pose 54, 0x01fc, 0x10ec, 0x6c0e
+ax_pose_terminator
+sHoundoomPose242:
+ax_pose 47, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundoomPose243:
+ax_pose 0, 0x01e7, 0x0107, 0x6c00
+ax_pose 1, 0x81e7, 0x80f7, 0x6c01
+ax_pose_terminator
+sHoundoomPose244:
+ax_pose 4, 0x0207, 0x00fa, 0x6c00
+ax_pose 5, 0x81ef, 0x010a, 0x6c01
+ax_pose 6, 0x81e7, 0x4102, 0x6c03
+ax_pose 7, 0x81e7, 0x80f2, 0x6c07
+ax_pose_terminator
+sHoundoomPose245:
+ax_pose 13, 0x01fb, 0x010f, 0x6c00
+ax_pose 14, 0x01ec, 0x0107, 0x6c01
+ax_pose 15, 0x81f4, 0x0107, 0x6c02
+ax_pose 16, 0x81e4, 0x40ff, 0x6c04
+ax_pose 17, 0x81e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sHoundoomPose246:
+ax_pose 24, 0x0202, 0x0107, 0x6c00
+ax_pose 25, 0x0202, 0x00ff, 0x6c01
+ax_pose 26, 0x01fa, 0x010b, 0x6c02
+ax_pose 27, 0x81e2, 0x4103, 0x6c03
+ax_pose 28, 0x81e2, 0x80f3, 0x6c07
+ax_pose_terminator
+sHoundoomPose247:
+ax_pose 38, 0x4202, 0x00f8, 0x6c00
+ax_pose 39, 0x81e2, 0x80f8, 0x6c02
+ax_pose_terminator
+sHoundoomPose248:
+ax_pose 24, 0x0202, 0x10f1, 0x6c00
+ax_pose 25, 0x0202, 0x10f9, 0x6c01
+ax_pose 26, 0x01fa, 0x10ed, 0x6c02
+ax_pose 27, 0x81e2, 0x50f5, 0x6c03
+ax_pose 28, 0x81e2, 0x90fd, 0x6c07
+ax_pose_terminator
+sHoundoomPose249:
+ax_pose 13, 0x01fb, 0x10e9, 0x6c00
+ax_pose 14, 0x01ec, 0x10f1, 0x6c01
+ax_pose 15, 0x81f4, 0x10f1, 0x6c02
+ax_pose 16, 0x81e4, 0x50f9, 0x6c04
+ax_pose 17, 0x81e4, 0x9101, 0x6c08
+ax_pose_terminator
+sHoundoomPose250:
+ax_pose 4, 0x0207, 0x10fe, 0x6c00
+ax_pose 5, 0x81ef, 0x10ee, 0x6c01
+ax_pose 6, 0x81e7, 0x50f6, 0x6c03
+ax_pose 7, 0x81e7, 0x90fe, 0x6c07
+ax_pose_terminator
+.align 2
+sHoundoomAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 1, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHoundoomAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 16, 15, 16, 15,
+ax_anim 2, 1, 31, 17, 14, 17, 14,
+ax_anim 2, 0, 31, 16, 15, 16, 15,
+ax_anim 2, 0, 31, 17, 14, 17, 14,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sHoundoomAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 4, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 6, 0, 6, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 1, 35, 11, 1, 11, 1,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 35, 11, 1, 11, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sHoundoomAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 38, 5, -5, 5, -5,
+ax_anim 1, 0, 38, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 15, -13, 15, -13,
+ax_anim 2, 1, 39, 16, -12, 16, -12,
+ax_anim 2, 0, 39, 15, -13, 15, -13,
+ax_anim 2, 0, 39, 16, -12, 16, -12,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sHoundoomAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 4, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -6, 0, -6,
+ax_anim 2, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 1, 43, 1, -12, 1, -12,
+ax_anim 2, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 43, 1, -12, 1, -12,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sHoundoomAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 4, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 46, -5, -5, -5, -5,
+ax_anim 1, 0, 46, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -15, -13, -15, -13,
+ax_anim 2, 1, 47, -16, -12, -16, -12,
+ax_anim 2, 0, 47, -15, -13, -15, -13,
+ax_anim 2, 0, 47, -16, -12, -16, -12,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sHoundoomAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 4, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -6, 0, -6, 0,
+ax_anim 2, 0, 51, -11, 0, -11, 0,
+ax_anim 2, 1, 51, -11, 1, -11, 1,
+ax_anim 2, 0, 51, -11, 0, -11, 0,
+ax_anim 2, 0, 51, -11, 1, -11, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sHoundoomAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -16, 15, -16, 15,
+ax_anim 2, 1, 55, -17, 14, -17, 14,
+ax_anim 2, 0, 55, -16, 15, -16, 15,
+ax_anim 2, 0, 55, -17, 14, -17, 14,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 4, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 1, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sHoundoomAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 4, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 16, 15, 16, 15,
+ax_anim 2, 1, 63, 17, 14, 17, 14,
+ax_anim 2, 0, 63, 16, 15, 16, 15,
+ax_anim 2, 0, 63, 17, 14, 17, 14,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sHoundoomAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 4, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 6, 0, 6, 0,
+ax_anim 2, 0, 67, 11, 0, 11, 0,
+ax_anim 2, 1, 67, 11, 1, 11, 1,
+ax_anim 2, 0, 67, 11, 0, 11, 0,
+ax_anim 2, 0, 67, 11, 1, 11, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sHoundoomAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 4, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 70, 5, -5, 5, -5,
+ax_anim 1, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 15, -13, 15, -13,
+ax_anim 2, 1, 71, 16, -12, 16, -12,
+ax_anim 2, 0, 71, 15, -13, 15, -13,
+ax_anim 2, 0, 71, 16, -12, 16, -12,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sHoundoomAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 4, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -6, 0, -6,
+ax_anim 2, 0, 75, 0, -12, 0, -12,
+ax_anim 2, 1, 75, 1, -12, 1, -12,
+ax_anim 2, 0, 75, 0, -12, 0, -12,
+ax_anim 2, 0, 75, 1, -12, 1, -12,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sHoundoomAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 4, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 78, -5, -5, -5, -5,
+ax_anim 1, 0, 78, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -15, -13, -15, -13,
+ax_anim 2, 1, 79, -16, -12, -16, -12,
+ax_anim 2, 0, 79, -15, -13, -15, -13,
+ax_anim 2, 0, 79, -16, -12, -16, -12,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sHoundoomAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 4, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -6, 0, -6, 0,
+ax_anim 2, 0, 83, -11, 0, -11, 0,
+ax_anim 2, 1, 83, -11, 1, -11, 1,
+ax_anim 2, 0, 83, -11, 0, -11, 0,
+ax_anim 2, 0, 83, -11, 1, -11, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sHoundoomAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 4, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 86, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -16, 15, -16, 15,
+ax_anim 2, 1, 87, -17, 14, -17, 14,
+ax_anim 2, 0, 87, -16, 15, -16, 15,
+ax_anim 2, 0, 87, -17, 14, -17, 14,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_4_1:
+ax_anim 6, 0, 92, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 6, 2, 90, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 1, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 3, 0, 2,
+ax_anim_terminator
+sHoundoomAnims_4_2:
+ax_anim 6, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 6, 2, 95, -3, -3, -3, -3,
+ax_anim 1, 0, 95, -1, -1, -1, -1,
+ax_anim 1, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 1, 96, 3, 1, 2, 0,
+ax_anim 2, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 0, 96, 3, 1, 2, 0,
+ax_anim 2, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 0, 96, 3, 1, 2, 0,
+ax_anim 2, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim_terminator
+sHoundoomAnims_4_3:
+ax_anim 6, 0, 102, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 6, 2, 100, -3, 0, -3, 0,
+ax_anim 1, 0, 100, -1, 0, -1, 0,
+ax_anim 1, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 1, 101, 2, 1, 2, 1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 101, 2, 1, 2, 1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 101, 2, 1, 2, 1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sHoundoomAnims_4_4:
+ax_anim 6, 0, 107, -2, 2, -2, 2,
+ax_anim 2, 0, 105, -2, 2, -2, 2,
+ax_anim 6, 2, 105, -3, 3, -3, 3,
+ax_anim 1, 0, 105, -1, 1, -1, 1,
+ax_anim 1, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 1, 106, 3, -1, 2, 0,
+ax_anim 2, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 0, 106, 3, -1, 2, 0,
+ax_anim 2, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 0, 106, 3, -1, 2, 0,
+ax_anim 2, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 0, 103, 2, -2, 1, -1,
+ax_anim_terminator
+sHoundoomAnims_4_5:
+ax_anim 6, 0, 112, 0, 2, 0, 2,
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 6, 2, 110, 0, 3, 0, 3,
+ax_anim 1, 0, 110, 0, 1, 0, 1,
+ax_anim 1, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 1, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sHoundoomAnims_4_6:
+ax_anim 6, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 115, 2, 2, 2, 2,
+ax_anim 6, 2, 115, 3, 3, 3, 3,
+ax_anim 1, 0, 115, 1, 1, 1, 1,
+ax_anim 1, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 1, 116, -3, -1, -2, 0,
+ax_anim 2, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 0, 116, -3, -1, -2, 0,
+ax_anim 2, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 0, 116, -3, -1, -2, 0,
+ax_anim 2, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 0, 113, -2, -2, -1, -1,
+ax_anim_terminator
+sHoundoomAnims_4_7:
+ax_anim 6, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 6, 2, 120, 3, 0, 3, 0,
+ax_anim 1, 0, 120, 1, 0, 1, 0,
+ax_anim 1, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 1, 121, -2, 1, -2, 1,
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 0, 121, -2, 1, -2, 1,
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 0, 121, -2, 1, -2, 1,
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sHoundoomAnims_4_8:
+ax_anim 6, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 6, 2, 125, 3, -3, 3, -3,
+ax_anim 1, 0, 125, 1, -1, 1, -1,
+ax_anim 1, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 1, 126, -3, 1, -2, 0,
+ax_anim 2, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 0, 126, -3, 1, -2, 0,
+ax_anim 2, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 0, 126, -3, 1, -2, 0,
+ax_anim 2, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 0, 123, -2, 2, -1, 1,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_5_1:
+ax_anim 10, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim_terminator
+sHoundoomAnims_5_2:
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 2, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim_terminator
+sHoundoomAnims_5_3:
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 2, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim_terminator
+sHoundoomAnims_5_4:
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 2, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim_terminator
+sHoundoomAnims_5_5:
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 6, 2, 137, 1, 0, 1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim_terminator
+sHoundoomAnims_5_6:
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 2, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+sHoundoomAnims_5_7:
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 2, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim_terminator
+sHoundoomAnims_5_8:
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 6, 2, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sHoundoomAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sHoundoomAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sHoundoomAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sHoundoomAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sHoundoomAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sHoundoomAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sHoundoomAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_8_1:
+ax_anim 60, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_8_2:
+ax_anim 60, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_8_3:
+ax_anim 60, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_8_4:
+ax_anim 60, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_8_5:
+ax_anim 60, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_8_6:
+ax_anim 60, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_8_7:
+ax_anim 60, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_8_8:
+ax_anim 60, 0, 189, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 10, 2, 10, 2,
+ax_anim 2, 0, 196, 16, 10, 16, 10,
+ax_anim 2, 0, 197, 11, 15, 11, 15,
+ax_anim 3, 0, 198, 0, 18, 0, 18,
+ax_anim 2, 3, 199, -11, 15, -11, 15,
+ax_anim 2, 0, 200, -16, 10, -16, 10,
+ax_anim 1, 0, 201, -10, 2, -10, 2,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 11, 0, 11, 0,
+ax_anim 2, 0, 195, 22, 2, 22, 2,
+ax_anim 2, 0, 196, 25, 11, 25, 11,
+ax_anim 3, 0, 197, 19, 17, 19, 17,
+ax_anim 2, 3, 198, 9, 21, 9, 21,
+ax_anim 2, 0, 199, -2, 16, -2, 16,
+ax_anim 1, 0, 200, -6, 10, -6, 10,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 5, -6, 5, -6,
+ax_anim 2, 0, 194, 10, -6, 10, -6,
+ax_anim 2, 0, 195, 17, -6, 17, -6,
+ax_anim 3, 0, 196, 19, 0, 19, 0,
+ax_anim 2, 3, 197, 16, 3, 16, 3,
+ax_anim 2, 0, 198, 8, 5, 8, 5,
+ax_anim 1, 0, 199, 3, 4, 3, 4,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -4, -8, -4, -8,
+ax_anim 2, 0, 201, 2, -17, 2, -17,
+ax_anim 2, 0, 194, 10, -23, 10, -23,
+ax_anim 3, 0, 195, 19, -20, 19, -20,
+ax_anim 2, 3, 196, 24, -11, 24, -11,
+ax_anim 2, 0, 197, 23, -4, 23, -4,
+ax_anim 1, 0, 198, 13, 0, 13, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -13, -5, -13, -5,
+ax_anim 2, 0, 200, -18, -10, -18, -10,
+ax_anim 2, 0, 201, -11, -20, -11, -20,
+ax_anim 3, 0, 194, 0, -22, 0, -22,
+ax_anim 2, 3, 195, 11, -20, 11, -20,
+ax_anim 2, 0, 196, 18, -10, 18, -10,
+ax_anim 1, 0, 197, 13, -5, 13, -5,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 4, -8, 4, -8,
+ax_anim 2, 0, 195, -2, -17, -2, -17,
+ax_anim 2, 0, 194, -10, -23, -10, -23,
+ax_anim 3, 0, 201, -19, -20, -19, -20,
+ax_anim 2, 3, 200, -24, -11, -24, -11,
+ax_anim 2, 0, 199, -23, -4, -23, -4,
+ax_anim 1, 0, 198, -13, 0, -13, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -5, -6, -5, -6,
+ax_anim 2, 0, 194, -10, -6, -10, -6,
+ax_anim 2, 0, 201, -17, -6, -17, -6,
+ax_anim 3, 0, 200, -19, 0, -19, 0,
+ax_anim 2, 3, 199, -16, 3, -16, 3,
+ax_anim 2, 0, 198, -8, 5, -8, 5,
+ax_anim 1, 0, 197, -3, 4, -3, 4,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -11, 0, -11, 0,
+ax_anim 2, 0, 201, -22, 2, -22, 2,
+ax_anim 2, 0, 200, -25, 11, -25, 11,
+ax_anim 3, 0, 199, -19, 17, -19, 17,
+ax_anim 2, 3, 198, -9, 21, -9, 21,
+ax_anim 2, 0, 197, 2, 16, 2, 16,
+ax_anim 1, 0, 196, 6, 10, 6, 10,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -24, 0, 0,
+ax_anim 3, 0, 212, 0, -23, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -24, 0, 0,
+ax_anim 3, 0, 215, 0, -24, 0, 0,
+ax_anim 2, 0, 215, 0, -20, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 3, 0, 221, 0, -19, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -22, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -11, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 3, 0, 227, 0, -19, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -24, 0, 0,
+ax_anim 3, 0, 233, 0, -24, 0, 0,
+ax_anim 2, 0, 233, 0, -20, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundoomAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundoomGfx1:
+.incbin "baserom.gba", 0xF4BF38, 0x20
+sHoundoomSprites1:
+ax_sprite sHoundoomGfx1, 0x20
+ax_sprite_terminator
+sHoundoomGfx2:
+.incbin "baserom.gba", 0xF4BF68, 0x100
+sHoundoomSprites2:
+ax_sprite sHoundoomGfx2, 0x100
+ax_sprite_terminator
+sHoundoomGfx3:
+.incbin "baserom.gba", 0xF4C078, 0x200
+sHoundoomSprites3:
+ax_sprite sHoundoomGfx3, 0x200
+ax_sprite_terminator
+sHoundoomGfx4:
+.incbin "baserom.gba", 0xF4C288, 0x200
+sHoundoomSprites4:
+ax_sprite sHoundoomGfx4, 0x200
+ax_sprite_terminator
+sHoundoomGfx5:
+.incbin "baserom.gba", 0xF4C498, 0x20
+sHoundoomSprites5:
+ax_sprite sHoundoomGfx5, 0x20
+ax_sprite_terminator
+sHoundoomGfx6:
+.incbin "baserom.gba", 0xF4C4C8, 0x40
+sHoundoomSprites6:
+ax_sprite sHoundoomGfx6, 0x40
+ax_sprite_terminator
+sHoundoomGfx7:
+.incbin "baserom.gba", 0xF4C518, 0x80
+sHoundoomSprites7:
+ax_sprite sHoundoomGfx7, 0x80
+ax_sprite_terminator
+sHoundoomGfx8:
+.incbin "baserom.gba", 0xF4C5A8, 0x100
+sHoundoomSprites8:
+ax_sprite sHoundoomGfx8, 0x100
+ax_sprite_terminator
+sHoundoomGfx9:
+.incbin "baserom.gba", 0xF4C6B8, 0x200
+sHoundoomSprites9:
+ax_sprite sHoundoomGfx9, 0x200
+ax_sprite_terminator
+sHoundoomGfx10:
+.incbin "baserom.gba", 0xF4C8C8, 0x20
+sHoundoomSprites10:
+ax_sprite sHoundoomGfx10, 0x20
+ax_sprite_terminator
+sHoundoomGfx11:
+.incbin "baserom.gba", 0xF4C8F8, 0x40
+sHoundoomSprites11:
+ax_sprite sHoundoomGfx11, 0x40
+ax_sprite_terminator
+sHoundoomGfx12:
+.incbin "baserom.gba", 0xF4C948, 0x80
+sHoundoomSprites12:
+ax_sprite sHoundoomGfx12, 0x80
+ax_sprite_terminator
+sHoundoomGfx13:
+.incbin "baserom.gba", 0xF4C9D8, 0x100
+sHoundoomSprites13:
+ax_sprite sHoundoomGfx13, 0x100
+ax_sprite_terminator
+sHoundoomGfx14:
+.incbin "baserom.gba", 0xF4CAE8, 0x20
+sHoundoomSprites14:
+ax_sprite sHoundoomGfx14, 0x20
+ax_sprite_terminator
+sHoundoomGfx15:
+.incbin "baserom.gba", 0xF4CB18, 0x20
+sHoundoomSprites15:
+ax_sprite sHoundoomGfx15, 0x20
+ax_sprite_terminator
+sHoundoomGfx16:
+.incbin "baserom.gba", 0xF4CB48, 0x40
+sHoundoomSprites16:
+ax_sprite sHoundoomGfx16, 0x40
+ax_sprite_terminator
+sHoundoomGfx17:
+.incbin "baserom.gba", 0xF4CB98, 0x80
+sHoundoomSprites17:
+ax_sprite sHoundoomGfx17, 0x80
+ax_sprite_terminator
+sHoundoomGfx18:
+.incbin "baserom.gba", 0xF4CC28, 0x100
+sHoundoomSprites18:
+ax_sprite sHoundoomGfx18, 0x100
+ax_sprite_terminator
+sHoundoomGfx19:
+.incbin "baserom.gba", 0xF4CD38, 0x20
+sHoundoomSprites19:
+ax_sprite sHoundoomGfx19, 0x20
+ax_sprite_terminator
+sHoundoomGfx20:
+.incbin "baserom.gba", 0xF4CD68, 0x20
+sHoundoomSprites20:
+ax_sprite sHoundoomGfx20, 0x20
+ax_sprite_terminator
+sHoundoomGfx21:
+.incbin "baserom.gba", 0xF4CD98, 0x40
+sHoundoomSprites21:
+ax_sprite sHoundoomGfx21, 0x40
+ax_sprite_terminator
+sHoundoomGfx22:
+.incbin "baserom.gba", 0xF4CDE8, 0x80
+sHoundoomSprites22:
+ax_sprite sHoundoomGfx22, 0x80
+ax_sprite_terminator
+sHoundoomGfx23:
+.incbin "baserom.gba", 0xF4CE78, 0x100
+sHoundoomSprites23:
+ax_sprite sHoundoomGfx23, 0x100
+ax_sprite_terminator
+sHoundoomGfx24:
+.incbin "baserom.gba", 0xF4CF88, 0x200
+sHoundoomSprites24:
+ax_sprite sHoundoomGfx24, 0x200
+ax_sprite_terminator
+sHoundoomGfx25:
+.incbin "baserom.gba", 0xF4D198, 0x20
+sHoundoomSprites25:
+ax_sprite sHoundoomGfx25, 0x20
+ax_sprite_terminator
+sHoundoomGfx26:
+.incbin "baserom.gba", 0xF4D1C8, 0x20
+sHoundoomSprites26:
+ax_sprite sHoundoomGfx26, 0x20
+ax_sprite_terminator
+sHoundoomGfx27:
+.incbin "baserom.gba", 0xF4D1F8, 0x20
+sHoundoomSprites27:
+ax_sprite sHoundoomGfx27, 0x20
+ax_sprite_terminator
+sHoundoomGfx28:
+.incbin "baserom.gba", 0xF4D228, 0x80
+sHoundoomSprites28:
+ax_sprite sHoundoomGfx28, 0x80
+ax_sprite_terminator
+sHoundoomGfx29:
+.incbin "baserom.gba", 0xF4D2B8, 0x100
+sHoundoomSprites29:
+ax_sprite sHoundoomGfx29, 0x100
+ax_sprite_terminator
+sHoundoomGfx30:
+.incbin "baserom.gba", 0xF4D3C8, 0x20
+sHoundoomSprites30:
+ax_sprite sHoundoomGfx30, 0x20
+ax_sprite_terminator
+sHoundoomGfx31:
+.incbin "baserom.gba", 0xF4D3F8, 0x20
+sHoundoomSprites31:
+ax_sprite sHoundoomGfx31, 0x20
+ax_sprite_terminator
+sHoundoomGfx32:
+.incbin "baserom.gba", 0xF4D428, 0x40
+sHoundoomSprites32:
+ax_sprite sHoundoomGfx32, 0x40
+ax_sprite_terminator
+sHoundoomGfx33:
+.incbin "baserom.gba", 0xF4D478, 0x80
+sHoundoomSprites33:
+ax_sprite sHoundoomGfx33, 0x80
+ax_sprite_terminator
+sHoundoomGfx34:
+.incbin "baserom.gba", 0xF4D508, 0x100
+sHoundoomSprites34:
+ax_sprite sHoundoomGfx34, 0x100
+ax_sprite_terminator
+sHoundoomGfx35:
+.incbin "baserom.gba", 0xF4D618, 0x20
+sHoundoomSprites35:
+ax_sprite sHoundoomGfx35, 0x20
+ax_sprite_terminator
+sHoundoomGfx36:
+.incbin "baserom.gba", 0xF4D648, 0x40
+sHoundoomSprites36:
+ax_sprite sHoundoomGfx36, 0x40
+ax_sprite_terminator
+sHoundoomGfx37:
+.incbin "baserom.gba", 0xF4D698, 0x80
+sHoundoomSprites37:
+ax_sprite sHoundoomGfx37, 0x80
+ax_sprite_terminator
+sHoundoomGfx38:
+.incbin "baserom.gba", 0xF4D728, 0x100
+sHoundoomSprites38:
+ax_sprite sHoundoomGfx38, 0x100
+ax_sprite_terminator
+sHoundoomGfx39:
+.incbin "baserom.gba", 0xF4D838, 0x40
+sHoundoomSprites39:
+ax_sprite sHoundoomGfx39, 0x40
+ax_sprite_terminator
+sHoundoomGfx40:
+.incbin "baserom.gba", 0xF4D888, 0x100
+sHoundoomSprites40:
+ax_sprite sHoundoomGfx40, 0x100
+ax_sprite_terminator
+sHoundoomGfx41:
+.incbin "baserom.gba", 0xF4D998, 0x40
+sHoundoomSprites41:
+ax_sprite sHoundoomGfx41, 0x40
+ax_sprite_terminator
+sHoundoomGfx42:
+.incbin "baserom.gba", 0xF4D9E8, 0x100
+sHoundoomSprites42:
+ax_sprite sHoundoomGfx42, 0x100
+ax_sprite_terminator
+sHoundoomGfx43:
+.incbin "baserom.gba", 0xF4DAF8, 0x20
+sHoundoomSprites43:
+ax_sprite sHoundoomGfx43, 0x20
+ax_sprite_terminator
+sHoundoomGfx44:
+.incbin "baserom.gba", 0xF4DB28, 0x20
+sHoundoomSprites44:
+ax_sprite sHoundoomGfx44, 0x20
+ax_sprite_terminator
+sHoundoomGfx45:
+.incbin "baserom.gba", 0xF4DB58, 0x40
+sHoundoomSprites45:
+ax_sprite sHoundoomGfx45, 0x40
+ax_sprite_terminator
+sHoundoomGfx46:
+.incbin "baserom.gba", 0xF4DBA8, 0x100
+sHoundoomSprites46:
+ax_sprite sHoundoomGfx46, 0x100
+ax_sprite_terminator
+sHoundoomGfx47:
+.incbin "baserom.gba", 0xF4DCB8, 0x60
+sHoundoomGfx47_1:
+.incbin "baserom.gba", 0xF4DD18, 0x40
+sHoundoomGfx47_2:
+.incbin "baserom.gba", 0xF4DD58, 0x40
+sHoundoomGfx47_3:
+.incbin "baserom.gba", 0xF4DD98, 0x60
+sHoundoomSprites47:
+ax_sprite sHoundoomGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx47_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoundoomGfx47_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoundoomGfx47_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoundoomGfx48:
+.incbin "baserom.gba", 0xF4DE40, 0x60
+sHoundoomGfx48_1:
+.incbin "baserom.gba", 0xF4DEA0, 0x140
+sHoundoomSprites48:
+ax_sprite sHoundoomGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx48_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoundoomGfx49:
+.incbin "baserom.gba", 0xF4E008, 0x40
+sHoundoomSprites49:
+ax_sprite sHoundoomGfx49, 0x40
+ax_sprite_terminator
+sHoundoomGfx50:
+.incbin "baserom.gba", 0xF4E058, 0x80
+sHoundoomSprites50:
+ax_sprite sHoundoomGfx50, 0x80
+ax_sprite_terminator
+sHoundoomGfx51:
+.incbin "baserom.gba", 0xF4E0E8, 0x20
+sHoundoomSprites51:
+ax_sprite sHoundoomGfx51, 0x20
+ax_sprite_terminator
+sHoundoomGfx52:
+.incbin "baserom.gba", 0xF4E118, 0x80
+sHoundoomSprites52:
+ax_sprite sHoundoomGfx52, 0x80
+ax_sprite_terminator
+sHoundoomGfx53:
+.incbin "baserom.gba", 0xF4E1A8, 0x40
+sHoundoomSprites53:
+ax_sprite sHoundoomGfx53, 0x40
+ax_sprite_terminator
+sHoundoomGfx54:
+.incbin "baserom.gba", 0xF4E1F8, 0x20
+sHoundoomSprites54:
+ax_sprite sHoundoomGfx54, 0x20
+ax_sprite_terminator
+sHoundoomGfx55:
+.incbin "baserom.gba", 0xF4E228, 0x20
+sHoundoomSprites55:
+ax_sprite sHoundoomGfx55, 0x20
+ax_sprite_terminator
+sHoundoomGfx56:
+.incbin "baserom.gba", 0xF4E258, 0x100
+sHoundoomSprites56:
+ax_sprite sHoundoomGfx56, 0x100
+ax_sprite_terminator
+sHoundoomGfx57:
+.incbin "baserom.gba", 0xF4E368, 0x80
+sHoundoomSprites57:
+ax_sprite sHoundoomGfx57, 0x80
+ax_sprite_terminator
+sHoundoomGfx58:
+.incbin "baserom.gba", 0xF4E3F8, 0x20
+sHoundoomSprites58:
+ax_sprite sHoundoomGfx58, 0x20
+ax_sprite_terminator
+sHoundoomGfx59:
+.incbin "baserom.gba", 0xF4E428, 0x20
+sHoundoomSprites59:
+ax_sprite sHoundoomGfx59, 0x20
+ax_sprite_terminator
+sHoundoomGfx60:
+.incbin "baserom.gba", 0xF4E458, 0x40
+sHoundoomSprites60:
+ax_sprite sHoundoomGfx60, 0x40
+ax_sprite_terminator
+sHoundoomGfx61:
+.incbin "baserom.gba", 0xF4E4A8, 0x20
+sHoundoomSprites61:
+ax_sprite sHoundoomGfx61, 0x20
+ax_sprite_terminator
+sHoundoomGfx62:
+.incbin "baserom.gba", 0xF4E4D8, 0x20
+sHoundoomSprites62:
+ax_sprite sHoundoomGfx62, 0x20
+ax_sprite_terminator
+sHoundoomGfx63:
+.incbin "baserom.gba", 0xF4E508, 0x100
+sHoundoomSprites63:
+ax_sprite sHoundoomGfx63, 0x100
+ax_sprite_terminator
+sHoundoomGfx64:
+.incbin "baserom.gba", 0xF4E618, 0x60
+sHoundoomGfx64_1:
+.incbin "baserom.gba", 0xF4E678, 0x60
+sHoundoomGfx64_2:
+.incbin "baserom.gba", 0xF4E6D8, 0x40
+sHoundoomGfx64_3:
+.incbin "baserom.gba", 0xF4E718, 0x40
+sHoundoomSprites64:
+ax_sprite sHoundoomGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx64_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx64_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoundoomGfx64_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoundoomGfx65:
+.incbin "baserom.gba", 0xF4E7A0, 0x100
+sHoundoomSprites65:
+ax_sprite sHoundoomGfx65, 0x100
+ax_sprite_terminator
+sHoundoomGfx66:
+.incbin "baserom.gba", 0xF4E8B0, 0x20
+sHoundoomSprites66:
+ax_sprite sHoundoomGfx66, 0x20
+ax_sprite_terminator
+sHoundoomGfx67:
+.incbin "baserom.gba", 0xF4E8E0, 0x60
+sHoundoomGfx67_1:
+.incbin "baserom.gba", 0xF4E940, 0x140
+sHoundoomSprites67:
+ax_sprite sHoundoomGfx67, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx67_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoundoomGfx68:
+.incbin "baserom.gba", 0xF4EAA8, 0x100
+sHoundoomSprites68:
+ax_sprite sHoundoomGfx68, 0x100
+ax_sprite_terminator
+sHoundoomGfx69:
+.incbin "baserom.gba", 0xF4EBB8, 0x80
+sHoundoomSprites69:
+ax_sprite sHoundoomGfx69, 0x80
+ax_sprite_terminator
+sHoundoomGfx70:
+.incbin "baserom.gba", 0xF4EC48, 0x20
+sHoundoomSprites70:
+ax_sprite sHoundoomGfx70, 0x20
+ax_sprite_terminator
+sHoundoomGfx71:
+.incbin "baserom.gba", 0xF4EC78, 0x20
+sHoundoomSprites71:
+ax_sprite sHoundoomGfx71, 0x20
+ax_sprite_terminator
+sHoundoomGfx72:
+.incbin "baserom.gba", 0xF4ECA8, 0x20
+sHoundoomSprites72:
+ax_sprite sHoundoomGfx72, 0x20
+ax_sprite_terminator
+sHoundoomGfx73:
+.incbin "baserom.gba", 0xF4ECD8, 0x100
+sHoundoomSprites73:
+ax_sprite sHoundoomGfx73, 0x100
+ax_sprite_terminator
+sHoundoomGfx74:
+.incbin "baserom.gba", 0xF4EDE8, 0x80
+sHoundoomSprites74:
+ax_sprite sHoundoomGfx74, 0x80
+ax_sprite_terminator
+sHoundoomGfx75:
+.incbin "baserom.gba", 0xF4EE78, 0x20
+sHoundoomSprites75:
+ax_sprite sHoundoomGfx75, 0x20
+ax_sprite_terminator
+sHoundoomGfx76:
+.incbin "baserom.gba", 0xF4EEA8, 0x20
+sHoundoomSprites76:
+ax_sprite sHoundoomGfx76, 0x20
+ax_sprite_terminator
+sHoundoomGfx77:
+.incbin "baserom.gba", 0xF4EED8, 0x100
+sHoundoomSprites77:
+ax_sprite sHoundoomGfx77, 0x100
+ax_sprite_terminator
+sHoundoomGfx78:
+.incbin "baserom.gba", 0xF4EFE8, 0x20
+sHoundoomSprites78:
+ax_sprite sHoundoomGfx78, 0x20
+ax_sprite_terminator
+sHoundoomGfx79:
+.incbin "baserom.gba", 0xF4F018, 0x40
+sHoundoomSprites79:
+ax_sprite sHoundoomGfx79, 0x40
+ax_sprite_terminator
+sHoundoomGfx80:
+.incbin "baserom.gba", 0xF4F068, 0x40
+sHoundoomSprites80:
+ax_sprite sHoundoomGfx80, 0x40
+ax_sprite_terminator
+sHoundoomGfx81:
+.incbin "baserom.gba", 0xF4F0B8, 0x40
+sHoundoomSprites81:
+ax_sprite sHoundoomGfx81, 0x40
+ax_sprite_terminator
+sHoundoomGfx82:
+.incbin "baserom.gba", 0xF4F108, 0x100
+sHoundoomSprites82:
+ax_sprite sHoundoomGfx82, 0x100
+ax_sprite_terminator
+sHoundoomGfx83:
+.incbin "baserom.gba", 0xF4F218, 0x20
+sHoundoomGfx83_1:
+.incbin "baserom.gba", 0xF4F238, 0x20
+sHoundoomSprites83:
+ax_sprite sHoundoomGfx83, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx83_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoundoomGfx84:
+.incbin "baserom.gba", 0xF4F280, 0x20
+sHoundoomSprites84:
+ax_sprite sHoundoomGfx84, 0x20
+ax_sprite_terminator
+sHoundoomGfx85:
+.incbin "baserom.gba", 0xF4F2B0, 0x40
+sHoundoomSprites85:
+ax_sprite sHoundoomGfx85, 0x40
+ax_sprite_terminator
+sHoundoomGfx86:
+.incbin "baserom.gba", 0xF4F300, 0x40
+sHoundoomGfx86_1:
+.incbin "baserom.gba", 0xF4F340, 0xA0
+sHoundoomSprites86:
+ax_sprite sHoundoomGfx86, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx86_1, 0xa0
+ax_sprite_terminator
+sHoundoomGfx87:
+.incbin "baserom.gba", 0xF4F400, 0x20
+sHoundoomSprites87:
+ax_sprite sHoundoomGfx87, 0x20
+ax_sprite_terminator
+sHoundoomGfx88:
+.incbin "baserom.gba", 0xF4F430, 0x20
+sHoundoomGfx88_1:
+.incbin "baserom.gba", 0xF4F450, 0x40
+sHoundoomSprites88:
+ax_sprite sHoundoomGfx88, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHoundoomGfx88_1, 0x40
+ax_sprite_terminator
+sHoundoomGfx89:
+.incbin "baserom.gba", 0xF4F4B0, 0x40
+sHoundoomSprites89:
+ax_sprite sHoundoomGfx89, 0x40
+ax_sprite_terminator
+sHoundoomGfx90:
+.incbin "baserom.gba", 0xF4F500, 0x20
+sHoundoomSprites90:
+ax_sprite sHoundoomGfx90, 0x20
+ax_sprite_terminator
+sHoundoomGfx91:
+.incbin "baserom.gba", 0xF4F530, 0x20
+sHoundoomSprites91:
+ax_sprite sHoundoomGfx91, 0x20
+ax_sprite_terminator
+sHoundoomGfx92:
+.incbin "baserom.gba", 0xF4F560, 0x100
+sHoundoomSprites92:
+ax_sprite sHoundoomGfx92, 0x100
+ax_sprite_terminator
+sHoundoomGfx93:
+.incbin "baserom.gba", 0xF4F670, 0x20
+sHoundoomSprites93:
+ax_sprite sHoundoomGfx93, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoundoomGfx94:
+.incbin "baserom.gba", 0xF4F6A8, 0x100
+sHoundoomSprites94:
+ax_sprite sHoundoomGfx94, 0x100
+ax_sprite_terminator
+sHoundoomGfx95:
+.incbin "baserom.gba", 0xF4F7B8, 0x40
+sHoundoomSprites95:
+ax_sprite sHoundoomGfx95, 0x40
+ax_sprite_terminator
+sHoundoomGfx96:
+.incbin "baserom.gba", 0xF4F808, 0x200
+sHoundoomSprites96:
+ax_sprite sHoundoomGfx96, 0x200
+ax_sprite_terminator
+sHoundoomGfx97:
+.incbin "baserom.gba", 0xF4FA18, 0x200
+sHoundoomSprites97:
+ax_sprite sHoundoomGfx97, 0x200
+ax_sprite_terminator
+sHoundoomGfx98:
+.incbin "baserom.gba", 0xF4FC28, 0x100
+sHoundoomSprites98:
+ax_sprite sHoundoomGfx98, 0x100
+ax_sprite_terminator
+sHoundoomGfx99:
+.incbin "baserom.gba", 0xF4FD38, 0x80
+sHoundoomSprites99:
+ax_sprite sHoundoomGfx99, 0x80
+ax_sprite_terminator
+sHoundoomGfx100:
+.incbin "baserom.gba", 0xF4FDC8, 0x20
+sHoundoomSprites100:
+ax_sprite sHoundoomGfx100, 0x20
+ax_sprite_terminator
+sHoundoomGfx101:
+.incbin "baserom.gba", 0xF4FDF8, 0x20
+sHoundoomSprites101:
+ax_sprite sHoundoomGfx101, 0x20
+ax_sprite_terminator
+sHoundoomGfx102:
+.incbin "baserom.gba", 0xF4FE28, 0x200
+sHoundoomSprites102:
+ax_sprite sHoundoomGfx102, 0x200
+ax_sprite_terminator
+sHoundoomGfx103:
+.incbin "baserom.gba", 0xF50038, 0x200
+sHoundoomSprites103:
+ax_sprite sHoundoomGfx103, 0x200
+ax_sprite_terminator
+sHoundoomGfx104:
+.incbin "baserom.gba", 0xF50248, 0x100
+sHoundoomSprites104:
+ax_sprite sHoundoomGfx104, 0x100
+ax_sprite_terminator
+sHoundoomGfx105:
+.incbin "baserom.gba", 0xF50358, 0x20
+sHoundoomSprites105:
+ax_sprite sHoundoomGfx105, 0x20
+ax_sprite_terminator
+sHoundoomGfx106:
+.incbin "baserom.gba", 0xF50388, 0x20
+sHoundoomSprites106:
+ax_sprite sHoundoomGfx106, 0x20
+ax_sprite_terminator
+sHoundoomGfx107:
+.incbin "baserom.gba", 0xF503B8, 0x40
+sHoundoomSprites107:
+ax_sprite sHoundoomGfx107, 0x40
+ax_sprite_terminator
+sHoundoomGfx108:
+.incbin "baserom.gba", 0xF50408, 0x80
+sHoundoomSprites108:
+ax_sprite sHoundoomGfx108, 0x80
+ax_sprite_terminator
+sHoundoomGfx109:
+.incbin "baserom.gba", 0xF50498, 0x20
+sHoundoomSprites109:
+ax_sprite sHoundoomGfx109, 0x20
+ax_sprite_terminator
+sHoundoomGfx110:
+.incbin "baserom.gba", 0xF504C8, 0x100
+sHoundoomSprites110:
+ax_sprite sHoundoomGfx110, 0x100
+ax_sprite_terminator
+sHoundoomGfx111:
+.incbin "baserom.gba", 0xF505D8, 0x80
+sHoundoomSprites111:
+ax_sprite sHoundoomGfx111, 0x80
+ax_sprite_terminator
+sAxPosesHoundoom:
+.4byte sHoundoomPose1
+.4byte sHoundoomPose2
+.4byte sHoundoomPose3
+.4byte sHoundoomPose4
+.4byte sHoundoomPose5
+.4byte sHoundoomPose6
+.4byte sHoundoomPose7
+.4byte sHoundoomPose8
+.4byte sHoundoomPose9
+.4byte sHoundoomPose10
+.4byte sHoundoomPose11
+.4byte sHoundoomPose12
+.4byte sHoundoomPose13
+.4byte sHoundoomPose14
+.4byte sHoundoomPose15
+.4byte sHoundoomPose16
+.4byte sHoundoomPose17
+.4byte sHoundoomPose18
+.4byte sHoundoomPose19
+.4byte sHoundoomPose20
+.4byte sHoundoomPose21
+.4byte sHoundoomPose22
+.4byte sHoundoomPose23
+.4byte sHoundoomPose24
+.4byte sHoundoomPose25
+.4byte sHoundoomPose26
+.4byte sHoundoomPose27
+.4byte sHoundoomPose28
+.4byte sHoundoomPose29
+.4byte sHoundoomPose30
+.4byte sHoundoomPose31
+.4byte sHoundoomPose32
+.4byte sHoundoomPose33
+.4byte sHoundoomPose34
+.4byte sHoundoomPose35
+.4byte sHoundoomPose36
+.4byte sHoundoomPose37
+.4byte sHoundoomPose38
+.4byte sHoundoomPose39
+.4byte sHoundoomPose40
+.4byte sHoundoomPose41
+.4byte sHoundoomPose42
+.4byte sHoundoomPose43
+.4byte sHoundoomPose44
+.4byte sHoundoomPose45
+.4byte sHoundoomPose46
+.4byte sHoundoomPose47
+.4byte sHoundoomPose48
+.4byte sHoundoomPose49
+.4byte sHoundoomPose50
+.4byte sHoundoomPose51
+.4byte sHoundoomPose52
+.4byte sHoundoomPose53
+.4byte sHoundoomPose54
+.4byte sHoundoomPose55
+.4byte sHoundoomPose56
+.4byte sHoundoomPose57
+.4byte sHoundoomPose58
+.4byte sHoundoomPose59
+.4byte sHoundoomPose60
+.4byte sHoundoomPose61
+.4byte sHoundoomPose62
+.4byte sHoundoomPose63
+.4byte sHoundoomPose64
+.4byte sHoundoomPose65
+.4byte sHoundoomPose66
+.4byte sHoundoomPose67
+.4byte sHoundoomPose68
+.4byte sHoundoomPose69
+.4byte sHoundoomPose70
+.4byte sHoundoomPose71
+.4byte sHoundoomPose72
+.4byte sHoundoomPose73
+.4byte sHoundoomPose74
+.4byte sHoundoomPose75
+.4byte sHoundoomPose76
+.4byte sHoundoomPose77
+.4byte sHoundoomPose78
+.4byte sHoundoomPose79
+.4byte sHoundoomPose80
+.4byte sHoundoomPose81
+.4byte sHoundoomPose82
+.4byte sHoundoomPose83
+.4byte sHoundoomPose84
+.4byte sHoundoomPose85
+.4byte sHoundoomPose86
+.4byte sHoundoomPose87
+.4byte sHoundoomPose88
+.4byte sHoundoomPose89
+.4byte sHoundoomPose90
+.4byte sHoundoomPose91
+.4byte sHoundoomPose92
+.4byte sHoundoomPose93
+.4byte sHoundoomPose94
+.4byte sHoundoomPose95
+.4byte sHoundoomPose96
+.4byte sHoundoomPose97
+.4byte sHoundoomPose98
+.4byte sHoundoomPose99
+.4byte sHoundoomPose100
+.4byte sHoundoomPose101
+.4byte sHoundoomPose102
+.4byte sHoundoomPose103
+.4byte sHoundoomPose104
+.4byte sHoundoomPose105
+.4byte sHoundoomPose106
+.4byte sHoundoomPose107
+.4byte sHoundoomPose108
+.4byte sHoundoomPose109
+.4byte sHoundoomPose110
+.4byte sHoundoomPose111
+.4byte sHoundoomPose112
+.4byte sHoundoomPose113
+.4byte sHoundoomPose114
+.4byte sHoundoomPose115
+.4byte sHoundoomPose116
+.4byte sHoundoomPose117
+.4byte sHoundoomPose118
+.4byte sHoundoomPose119
+.4byte sHoundoomPose120
+.4byte sHoundoomPose121
+.4byte sHoundoomPose122
+.4byte sHoundoomPose123
+.4byte sHoundoomPose124
+.4byte sHoundoomPose125
+.4byte sHoundoomPose126
+.4byte sHoundoomPose127
+.4byte sHoundoomPose128
+.4byte sHoundoomPose129
+.4byte sHoundoomPose130
+.4byte sHoundoomPose131
+.4byte sHoundoomPose132
+.4byte sHoundoomPose133
+.4byte sHoundoomPose134
+.4byte sHoundoomPose135
+.4byte sHoundoomPose136
+.4byte sHoundoomPose137
+.4byte sHoundoomPose138
+.4byte sHoundoomPose139
+.4byte sHoundoomPose140
+.4byte sHoundoomPose141
+.4byte sHoundoomPose142
+.4byte sHoundoomPose143
+.4byte sHoundoomPose144
+.4byte sHoundoomPose145
+.4byte sHoundoomPose146
+.4byte sHoundoomPose147
+.4byte sHoundoomPose148
+.4byte sHoundoomPose149
+.4byte sHoundoomPose150
+.4byte sHoundoomPose151
+.4byte sHoundoomPose152
+.4byte sHoundoomPose153
+.4byte sHoundoomPose154
+.4byte sHoundoomPose155
+.4byte sHoundoomPose156
+.4byte sHoundoomPose157
+.4byte sHoundoomPose158
+.4byte sHoundoomPose159
+.4byte sHoundoomPose160
+.4byte sHoundoomPose161
+.4byte sHoundoomPose162
+.4byte sHoundoomPose163
+.4byte sHoundoomPose164
+.4byte sHoundoomPose165
+.4byte sHoundoomPose166
+.4byte sHoundoomPose167
+.4byte sHoundoomPose168
+.4byte sHoundoomPose169
+.4byte sHoundoomPose170
+.4byte sHoundoomPose171
+.4byte sHoundoomPose172
+.4byte sHoundoomPose173
+.4byte sHoundoomPose174
+.4byte sHoundoomPose175
+.4byte sHoundoomPose176
+.4byte sHoundoomPose177
+.4byte sHoundoomPose178
+.4byte sHoundoomPose179
+.4byte sHoundoomPose180
+.4byte sHoundoomPose181
+.4byte sHoundoomPose182
+.4byte sHoundoomPose183
+.4byte sHoundoomPose184
+.4byte sHoundoomPose185
+.4byte sHoundoomPose186
+.4byte sHoundoomPose187
+.4byte sHoundoomPose188
+.4byte sHoundoomPose189
+.4byte sHoundoomPose190
+.4byte sHoundoomPose191
+.4byte sHoundoomPose192
+.4byte sHoundoomPose193
+.4byte sHoundoomPose194
+.4byte sHoundoomPose195
+.4byte sHoundoomPose196
+.4byte sHoundoomPose197
+.4byte sHoundoomPose198
+.4byte sHoundoomPose199
+.4byte sHoundoomPose200
+.4byte sHoundoomPose201
+.4byte sHoundoomPose202
+.4byte sHoundoomPose203
+.4byte sHoundoomPose204
+.4byte sHoundoomPose205
+.4byte sHoundoomPose206
+.4byte sHoundoomPose207
+.4byte sHoundoomPose208
+.4byte sHoundoomPose209
+.4byte sHoundoomPose210
+.4byte sHoundoomPose211
+.4byte sHoundoomPose212
+.4byte sHoundoomPose213
+.4byte sHoundoomPose214
+.4byte sHoundoomPose215
+.4byte sHoundoomPose216
+.4byte sHoundoomPose217
+.4byte sHoundoomPose218
+.4byte sHoundoomPose219
+.4byte sHoundoomPose220
+.4byte sHoundoomPose221
+.4byte sHoundoomPose222
+.4byte sHoundoomPose223
+.4byte sHoundoomPose224
+.4byte sHoundoomPose225
+.4byte sHoundoomPose226
+.4byte sHoundoomPose227
+.4byte sHoundoomPose228
+.4byte sHoundoomPose229
+.4byte sHoundoomPose230
+.4byte sHoundoomPose231
+.4byte sHoundoomPose232
+.4byte sHoundoomPose233
+.4byte sHoundoomPose234
+.4byte sHoundoomPose235
+.4byte sHoundoomPose236
+.4byte sHoundoomPose237
+.4byte sHoundoomPose238
+.4byte sHoundoomPose239
+.4byte sHoundoomPose240
+.4byte sHoundoomPose241
+.4byte sHoundoomPose242
+.4byte sHoundoomPose243
+.4byte sHoundoomPose244
+.4byte sHoundoomPose245
+.4byte sHoundoomPose246
+.4byte sHoundoomPose247
+.4byte sHoundoomPose248
+.4byte sHoundoomPose249
+.4byte sHoundoomPose250
+sAxPositionsHoundoom:
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,    7, 	   2,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   3,    7, 	  -1,   -7
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+.2byte    9,   -7, 	   9,    4, 	  -3,    4, 	   0,   -7
+.2byte    9,   -7, 	   5,    1, 	   4,    8, 	   0,   -6
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte   13,  -13, 	   9,   -4, 	   1,    2, 	   1,   -9
+.2byte   13,  -13, 	  -1,   -4, 	  11,    2, 	   4,   -8
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte   10,  -20, 	   1,   -8, 	   2,   -1, 	  -1,  -12
+.2byte    9,  -20, 	  -1,   -6, 	   8,   -5, 	   1,  -12
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte    0,  -20, 	   6,   -8, 	  -5,   -4, 	   1,  -11
+.2byte    0,  -20, 	   5,   -4, 	  -6,   -8, 	  -1,  -11
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte  -11,  -20, 	  -2,   -8, 	  -3,   -1, 	   0,  -12
+.2byte  -10,  -20, 	   0,   -6, 	  -9,   -5, 	  -2,  -12
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -14,  -13, 	 -10,   -4, 	  -2,    2, 	  -2,   -9
+.2byte  -14,  -13, 	   0,   -4, 	 -12,    2, 	  -5,   -8
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte  -10,   -7, 	 -10,    4, 	   2,    4, 	  -1,   -7
+.2byte  -10,   -7, 	  -6,    1, 	  -5,    8, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,    7, 	   2,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   3,    7, 	  -1,   -7
+.2byte   -1,   -7, 	  -7,    4, 	   5,    4, 	  -1,   -8
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+.2byte    9,   -7, 	   9,    4, 	  -3,    4, 	   0,   -7
+.2byte    9,   -7, 	   5,    1, 	   4,    8, 	   0,   -6
+.2byte    8,   -8, 	   8,    2, 	   1,    5, 	   0,   -9
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte   13,  -13, 	   9,   -4, 	   1,    2, 	   1,   -9
+.2byte   13,  -13, 	  -1,   -4, 	  11,    2, 	   4,   -8
+.2byte   15,  -16, 	   8,   -5, 	   7,    1, 	   2,  -11
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte   10,  -20, 	   1,   -8, 	   2,   -1, 	  -1,  -12
+.2byte    9,  -20, 	  -1,   -6, 	   8,   -5, 	   1,  -12
+.2byte   11,  -21, 	   3,   -8, 	   6,   -4, 	   0,  -13
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte    0,  -20, 	   6,   -8, 	  -5,   -4, 	   1,  -11
+.2byte    0,  -20, 	   5,   -4, 	  -6,   -8, 	  -1,  -11
+.2byte    0,  -28, 	   5,   -5, 	  -5,   -5, 	   0,  -12
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte  -11,  -20, 	  -2,   -8, 	  -3,   -1, 	   0,  -12
+.2byte  -10,  -20, 	   0,   -6, 	  -9,   -5, 	  -2,  -12
+.2byte  -12,  -21, 	  -4,   -8, 	  -7,   -4, 	  -1,  -13
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -14,  -13, 	 -10,   -4, 	  -2,    2, 	  -2,   -9
+.2byte  -14,  -13, 	   0,   -4, 	 -12,    2, 	  -5,   -8
+.2byte  -16,  -16, 	  -9,   -5, 	  -8,    1, 	  -3,  -11
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte  -10,   -7, 	 -10,    4, 	   2,    4, 	  -1,   -7
+.2byte  -10,   -7, 	  -6,    1, 	  -5,    8, 	  -1,   -6
+.2byte   -9,   -8, 	  -9,    2, 	  -2,    5, 	  -1,   -9
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,    7, 	   2,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,    1, 	   3,    7, 	  -1,   -7
+.2byte   -1,   -7, 	  -7,    4, 	   5,    4, 	  -1,   -8
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+.2byte    9,   -7, 	   9,    4, 	  -3,    4, 	   0,   -7
+.2byte    9,   -7, 	   5,    1, 	   4,    8, 	   0,   -6
+.2byte    8,   -8, 	   8,    2, 	   1,    5, 	   0,   -9
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte   13,  -13, 	   9,   -4, 	   1,    2, 	   1,   -9
+.2byte   13,  -13, 	  -1,   -4, 	  11,    2, 	   4,   -8
+.2byte   15,  -16, 	   8,   -5, 	   7,    1, 	   2,  -11
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte   10,  -20, 	   1,   -8, 	   2,   -1, 	  -1,  -12
+.2byte    9,  -20, 	  -1,   -6, 	   8,   -5, 	   1,  -12
+.2byte   11,  -21, 	   3,   -8, 	   6,   -4, 	   0,  -13
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte    0,  -20, 	   6,   -8, 	  -5,   -4, 	   1,  -11
+.2byte    0,  -20, 	   5,   -4, 	  -6,   -8, 	  -1,  -11
+.2byte    0,  -28, 	   5,   -5, 	  -5,   -5, 	   0,  -12
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte  -11,  -20, 	  -2,   -8, 	  -3,   -1, 	   0,  -12
+.2byte  -10,  -20, 	   0,   -6, 	  -9,   -5, 	  -2,  -12
+.2byte  -12,  -21, 	  -4,   -8, 	  -7,   -4, 	  -1,  -13
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -14,  -13, 	 -10,   -4, 	  -2,    2, 	  -2,   -9
+.2byte  -14,  -13, 	   0,   -4, 	 -12,    2, 	  -5,   -8
+.2byte  -16,  -16, 	  -9,   -5, 	  -8,    1, 	  -3,  -11
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte  -10,   -7, 	 -10,    4, 	   2,    4, 	  -1,   -7
+.2byte  -10,   -7, 	  -6,    1, 	  -5,    8, 	  -1,   -6
+.2byte   -9,   -8, 	  -9,    2, 	  -2,    5, 	  -1,   -9
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,    7, 	   2,    1, 	  -1,   -7
+.2byte   -1,  -24, 	  -6,    4, 	   4,    4, 	  -1,  -10
+.2byte   -1,   -7, 	  -7,    4, 	   5,    4, 	  -1,   -8
+.2byte   -1,  -11, 	  -6,    3, 	   4,    3, 	  -1,  -10
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+.2byte    9,   -7, 	   9,    4, 	  -3,    4, 	   0,   -7
+.2byte    7,  -20, 	   8,    2, 	   1,    5, 	  -1,  -10
+.2byte    8,   -8, 	   8,    2, 	   1,    5, 	   0,   -9
+.2byte    6,  -14, 	   6,    0, 	   0,    3, 	  -2,  -10
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte   13,  -13, 	   9,   -4, 	   1,    2, 	   1,   -9
+.2byte    9,  -28, 	   7,   -5, 	   6,    1, 	   0,  -10
+.2byte   15,  -16, 	   8,   -5, 	   7,    1, 	   2,  -11
+.2byte    9,  -18, 	   6,   -6, 	   5,    1, 	  -1,  -10
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte   10,  -20, 	   1,   -8, 	   2,   -1, 	  -1,  -12
+.2byte    9,  -28, 	   4,   -6, 	   6,   -4, 	  -2,  -11
+.2byte   11,  -21, 	   3,   -8, 	   6,   -4, 	   0,  -13
+.2byte    7,  -23, 	   0,   -5, 	   5,   -3, 	  -3,  -12
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte    0,  -20, 	   6,   -8, 	  -5,   -4, 	   1,  -11
+.2byte    0,  -32, 	   5,   -5, 	  -5,   -5, 	   0,  -11
+.2byte    0,  -28, 	   5,   -5, 	  -5,   -5, 	   0,  -12
+.2byte    0,  -25, 	   5,   -4, 	  -5,   -4, 	   0,  -13
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte  -11,  -20, 	  -2,   -8, 	  -3,   -1, 	   0,  -12
+.2byte  -10,  -28, 	  -5,   -6, 	  -7,   -4, 	   1,  -11
+.2byte  -12,  -21, 	  -4,   -8, 	  -7,   -4, 	  -1,  -13
+.2byte   -8,  -23, 	  -1,   -5, 	  -6,   -3, 	   2,  -12
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -14,  -13, 	 -10,   -4, 	  -2,    2, 	  -2,   -9
+.2byte  -10,  -28, 	  -8,   -5, 	  -7,    1, 	  -1,  -10
+.2byte  -16,  -16, 	  -9,   -5, 	  -8,    1, 	  -3,  -11
+.2byte  -10,  -18, 	  -7,   -6, 	  -6,    1, 	   0,  -10
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte  -10,   -7, 	 -10,    4, 	   2,    4, 	  -1,   -7
+.2byte   -8,  -20, 	  -9,    2, 	  -2,    5, 	   0,  -10
+.2byte   -9,   -8, 	  -9,    2, 	  -2,    5, 	  -1,   -9
+.2byte   -7,  -14, 	  -7,    0, 	  -1,    3, 	   1,  -10
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte   -1,  -24, 	  -6,    4, 	   4,    4, 	  -1,  -10
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+.2byte    7,  -20, 	   8,    2, 	   1,    5, 	  -1,  -10
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte    9,  -28, 	   7,   -5, 	   6,    1, 	   0,  -10
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte    9,  -28, 	   4,   -6, 	   6,   -4, 	  -2,  -11
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte    0,  -32, 	   5,   -5, 	  -5,   -5, 	   0,  -11
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte  -10,  -28, 	  -5,   -6, 	  -7,   -4, 	   1,  -11
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -10,  -28, 	  -8,   -5, 	  -7,    1, 	  -1,  -10
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte   -8,  -20, 	  -9,    2, 	  -2,    5, 	   0,  -10
+.2byte  -11,   -2, 	 -11,    0, 	  -9,    2, 	   0,   -5
+.2byte  -11,   -2, 	 -11,    0, 	  -9,    2, 	   0,   -5
+.2byte   -2,   -5, 	  -7,    3, 	   8,    5, 	   0,   -7
+.2byte   11,   -7, 	  12,   -1, 	   2,    3, 	   2,  -10
+.2byte   13,  -11, 	   9,   -6, 	   8,    1, 	   3,  -10
+.2byte   11,  -17, 	   4,   -8, 	   9,   -3, 	   1,  -13
+.2byte    3,  -17, 	   5,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte  -13,  -17, 	  -6,   -8, 	 -11,   -3, 	  -3,  -13
+.2byte  -13,  -11, 	  -9,   -6, 	  -8,    1, 	  -3,  -10
+.2byte  -10,   -7, 	 -11,   -1, 	  -1,    3, 	  -1,  -10
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,    7, 	   2,    1, 	  -1,   -7
+.2byte   -1,  -24, 	  -6,    4, 	   4,    4, 	  -1,  -10
+.2byte   -1,   -7, 	  -7,    4, 	   5,    4, 	  -1,   -8
+.2byte   -1,  -11, 	  -6,    3, 	   4,    3, 	  -1,  -10
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+.2byte    9,   -7, 	   9,    4, 	  -3,    4, 	   0,   -7
+.2byte    7,  -20, 	   8,    2, 	   1,    5, 	  -1,  -10
+.2byte    8,   -8, 	   8,    2, 	   1,    5, 	   0,   -9
+.2byte    6,  -14, 	   6,    0, 	   0,    3, 	  -2,  -10
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte   13,  -13, 	   9,   -4, 	   1,    2, 	   1,   -9
+.2byte    9,  -28, 	   7,   -5, 	   6,    1, 	   0,  -10
+.2byte   15,  -16, 	   8,   -5, 	   7,    1, 	   2,  -11
+.2byte    9,  -18, 	   6,   -6, 	   5,    1, 	  -1,  -10
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte   10,  -20, 	   1,   -8, 	   2,   -1, 	  -1,  -12
+.2byte    9,  -28, 	   4,   -6, 	   6,   -4, 	  -2,  -11
+.2byte   11,  -21, 	   3,   -8, 	   6,   -4, 	   0,  -13
+.2byte    7,  -23, 	   0,   -5, 	   5,   -3, 	  -3,  -12
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte    0,  -20, 	   6,   -8, 	  -5,   -4, 	   1,  -11
+.2byte    0,  -32, 	   5,   -5, 	  -5,   -5, 	   0,  -11
+.2byte    0,  -28, 	   5,   -5, 	  -5,   -5, 	   0,  -12
+.2byte    0,  -25, 	   5,   -4, 	  -5,   -4, 	   0,  -13
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte  -11,  -20, 	  -2,   -8, 	  -3,   -1, 	   0,  -12
+.2byte  -10,  -28, 	  -5,   -6, 	  -7,   -4, 	   1,  -11
+.2byte  -12,  -21, 	  -4,   -8, 	  -7,   -4, 	  -1,  -13
+.2byte   -8,  -23, 	  -1,   -5, 	  -6,   -3, 	   2,  -12
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -14,  -13, 	 -10,   -4, 	  -2,    2, 	  -2,   -9
+.2byte  -10,  -28, 	  -8,   -5, 	  -7,    1, 	  -1,  -10
+.2byte  -16,  -16, 	  -9,   -5, 	  -8,    1, 	  -3,  -11
+.2byte  -10,  -18, 	  -7,   -6, 	  -6,    1, 	   0,  -10
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte  -10,   -7, 	 -10,    4, 	   2,    4, 	  -1,   -7
+.2byte   -8,  -20, 	  -9,    2, 	  -2,    5, 	   0,  -10
+.2byte   -9,   -8, 	  -9,    2, 	  -2,    5, 	  -1,   -9
+.2byte   -7,  -14, 	  -7,    0, 	  -1,    3, 	   1,  -10
+.2byte   -1,   -7, 	  -7,    4, 	   5,    4, 	  -1,   -8
+.2byte   -9,   -8, 	  -9,    2, 	  -2,    5, 	  -1,   -9
+.2byte  -16,  -16, 	  -9,   -5, 	  -8,    1, 	  -3,  -11
+.2byte  -12,  -21, 	  -4,   -8, 	  -7,   -4, 	  -1,  -13
+.2byte    0,  -28, 	   5,   -5, 	  -5,   -5, 	   0,  -12
+.2byte   11,  -21, 	   3,   -8, 	   6,   -4, 	   0,  -13
+.2byte   15,  -16, 	   8,   -5, 	   7,    1, 	   2,  -11
+.2byte    8,   -8, 	   8,    2, 	   1,    5, 	   0,   -9
+.2byte   -1,  -23, 	  -6,    5, 	   4,    5, 	  -1,   -9
+.2byte    7,  -21, 	   8,    1, 	   1,    4, 	  -1,  -11
+.2byte   10,  -28, 	   8,   -5, 	   7,    1, 	   1,  -10
+.2byte   10,  -27, 	   5,   -5, 	   7,   -3, 	  -1,  -10
+.2byte    0,  -31, 	   5,   -4, 	  -5,   -4, 	   0,  -10
+.2byte  -11,  -27, 	  -6,   -5, 	  -8,   -3, 	   0,  -10
+.2byte  -11,  -28, 	  -9,   -5, 	  -8,    1, 	  -2,  -10
+.2byte   -8,  -21, 	  -9,    1, 	  -2,    4, 	   0,  -11
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte   -1,  -24, 	  -6,    4, 	   4,    4, 	  -1,  -10
+.2byte   -1,   -7, 	  -7,    4, 	   5,    4, 	  -1,   -8
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+.2byte    7,  -20, 	   8,    2, 	   1,    5, 	  -1,  -10
+.2byte    8,   -8, 	   8,    2, 	   1,    5, 	   0,   -9
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte    9,  -28, 	   7,   -5, 	   6,    1, 	   0,  -10
+.2byte   14,  -16, 	   7,   -5, 	   6,    1, 	   1,  -11
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte    9,  -28, 	   4,   -6, 	   6,   -4, 	  -2,  -11
+.2byte   10,  -21, 	   2,   -8, 	   5,   -4, 	  -1,  -13
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte    0,  -32, 	   5,   -5, 	  -5,   -5, 	   0,  -11
+.2byte    0,  -28, 	   5,   -5, 	  -5,   -5, 	   0,  -12
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte  -10,  -28, 	  -5,   -6, 	  -7,   -4, 	   1,  -11
+.2byte  -11,  -21, 	  -3,   -8, 	  -6,   -4, 	   0,  -13
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -10,  -28, 	  -8,   -5, 	  -7,    1, 	  -1,  -10
+.2byte  -15,  -16, 	  -8,   -5, 	  -7,    1, 	  -2,  -11
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte   -8,  -20, 	  -9,    2, 	  -2,    5, 	   0,  -10
+.2byte   -9,   -8, 	  -9,    2, 	  -2,    5, 	  -1,   -9
+.2byte   -1,   -7, 	  -7,    4, 	   5,    4, 	  -1,   -8
+.2byte   -9,   -8, 	  -9,    2, 	  -2,    5, 	  -1,   -9
+.2byte  -16,  -16, 	  -9,   -5, 	  -8,    1, 	  -3,  -11
+.2byte  -12,  -21, 	  -4,   -8, 	  -7,   -4, 	  -1,  -13
+.2byte    0,  -28, 	   5,   -5, 	  -5,   -5, 	   0,  -12
+.2byte   11,  -21, 	   3,   -8, 	   6,   -4, 	   0,  -13
+.2byte   15,  -16, 	   8,   -5, 	   7,    1, 	   2,  -11
+.2byte    8,   -8, 	   8,    2, 	   1,    5, 	   0,   -9
+.2byte   -1,   -8, 	  -6,    4, 	   4,    4, 	  -1,   -7
+.2byte  -10,   -9, 	  -9,    2, 	  -2,    5, 	  -1,   -8
+.2byte  -14,  -15, 	  -9,   -5, 	  -8,    1, 	  -3,  -10
+.2byte  -11,  -21, 	  -3,   -8, 	  -8,   -4, 	  -2,  -13
+.2byte    0,  -22, 	   5,   -4, 	  -5,   -4, 	   0,  -12
+.2byte   10,  -21, 	   2,   -8, 	   7,   -4, 	   1,  -13
+.2byte   13,  -15, 	   8,   -5, 	   7,    1, 	   2,  -10
+.2byte    9,   -9, 	   8,    2, 	   1,    5, 	   0,   -8
+sHoundoomAnimTable1:
+.4byte sHoundoomAnims_1_1
+.4byte sHoundoomAnims_1_2
+.4byte sHoundoomAnims_1_3
+.4byte sHoundoomAnims_1_4
+.4byte sHoundoomAnims_1_5
+.4byte sHoundoomAnims_1_6
+.4byte sHoundoomAnims_1_7
+.4byte sHoundoomAnims_1_8
+sHoundoomAnimTable2:
+.4byte sHoundoomAnims_2_1
+.4byte sHoundoomAnims_2_2
+.4byte sHoundoomAnims_2_3
+.4byte sHoundoomAnims_2_4
+.4byte sHoundoomAnims_2_5
+.4byte sHoundoomAnims_2_6
+.4byte sHoundoomAnims_2_7
+.4byte sHoundoomAnims_2_8
+sHoundoomAnimTable3:
+.4byte sHoundoomAnims_3_1
+.4byte sHoundoomAnims_3_2
+.4byte sHoundoomAnims_3_3
+.4byte sHoundoomAnims_3_4
+.4byte sHoundoomAnims_3_5
+.4byte sHoundoomAnims_3_6
+.4byte sHoundoomAnims_3_7
+.4byte sHoundoomAnims_3_8
+sHoundoomAnimTable4:
+.4byte sHoundoomAnims_4_1
+.4byte sHoundoomAnims_4_2
+.4byte sHoundoomAnims_4_3
+.4byte sHoundoomAnims_4_4
+.4byte sHoundoomAnims_4_5
+.4byte sHoundoomAnims_4_6
+.4byte sHoundoomAnims_4_7
+.4byte sHoundoomAnims_4_8
+sHoundoomAnimTable5:
+.4byte sHoundoomAnims_5_1
+.4byte sHoundoomAnims_5_2
+.4byte sHoundoomAnims_5_3
+.4byte sHoundoomAnims_5_4
+.4byte sHoundoomAnims_5_5
+.4byte sHoundoomAnims_5_6
+.4byte sHoundoomAnims_5_7
+.4byte sHoundoomAnims_5_8
+sHoundoomAnimTable6:
+.4byte sHoundoomAnims_6_1
+.4byte sHoundoomAnims_6_1
+.4byte sHoundoomAnims_6_1
+.4byte sHoundoomAnims_6_1
+.4byte sHoundoomAnims_6_1
+.4byte sHoundoomAnims_6_1
+.4byte sHoundoomAnims_6_1
+.4byte sHoundoomAnims_6_1
+sHoundoomAnimTable7:
+.4byte sHoundoomAnims_7_1
+.4byte sHoundoomAnims_7_2
+.4byte sHoundoomAnims_7_3
+.4byte sHoundoomAnims_7_4
+.4byte sHoundoomAnims_7_5
+.4byte sHoundoomAnims_7_6
+.4byte sHoundoomAnims_7_7
+.4byte sHoundoomAnims_7_8
+sHoundoomAnimTable8:
+.4byte sHoundoomAnims_8_1
+.4byte sHoundoomAnims_8_2
+.4byte sHoundoomAnims_8_3
+.4byte sHoundoomAnims_8_4
+.4byte sHoundoomAnims_8_5
+.4byte sHoundoomAnims_8_6
+.4byte sHoundoomAnims_8_7
+.4byte sHoundoomAnims_8_8
+sHoundoomAnimTable9:
+.4byte sHoundoomAnims_9_1
+.4byte sHoundoomAnims_9_2
+.4byte sHoundoomAnims_9_3
+.4byte sHoundoomAnims_9_4
+.4byte sHoundoomAnims_9_5
+.4byte sHoundoomAnims_9_6
+.4byte sHoundoomAnims_9_7
+.4byte sHoundoomAnims_9_8
+sHoundoomAnimTable10:
+.4byte sHoundoomAnims_10_1
+.4byte sHoundoomAnims_10_2
+.4byte sHoundoomAnims_10_3
+.4byte sHoundoomAnims_10_4
+.4byte sHoundoomAnims_10_5
+.4byte sHoundoomAnims_10_6
+.4byte sHoundoomAnims_10_7
+.4byte sHoundoomAnims_10_8
+sHoundoomAnimTable11:
+.4byte sHoundoomAnims_11_1
+.4byte sHoundoomAnims_11_2
+.4byte sHoundoomAnims_11_3
+.4byte sHoundoomAnims_11_4
+.4byte sHoundoomAnims_11_5
+.4byte sHoundoomAnims_11_6
+.4byte sHoundoomAnims_11_7
+.4byte sHoundoomAnims_11_8
+sHoundoomAnimTable12:
+.4byte sHoundoomAnims_12_1
+.4byte sHoundoomAnims_12_2
+.4byte sHoundoomAnims_12_3
+.4byte sHoundoomAnims_12_4
+.4byte sHoundoomAnims_12_5
+.4byte sHoundoomAnims_12_6
+.4byte sHoundoomAnims_12_7
+.4byte sHoundoomAnims_12_8
+sHoundoomAnimTable13:
+.4byte sHoundoomAnims_13_1
+.4byte sHoundoomAnims_13_2
+.4byte sHoundoomAnims_13_3
+.4byte sHoundoomAnims_13_4
+.4byte sHoundoomAnims_13_5
+.4byte sHoundoomAnims_13_6
+.4byte sHoundoomAnims_13_7
+.4byte sHoundoomAnims_13_8
+sAxAnimationsHoundoom:
+.4byte sHoundoomAnimTable1
+.4byte sHoundoomAnimTable2
+.4byte sHoundoomAnimTable3
+.4byte sHoundoomAnimTable4
+.4byte sHoundoomAnimTable5
+.4byte sHoundoomAnimTable6
+.4byte sHoundoomAnimTable7
+.4byte sHoundoomAnimTable8
+.4byte sHoundoomAnimTable9
+.4byte sHoundoomAnimTable10
+.4byte sHoundoomAnimTable11
+.4byte sHoundoomAnimTable12
+.4byte sHoundoomAnimTable13
+sAxSpritesHoundoom:
+.4byte sHoundoomSprites1
+.4byte sHoundoomSprites2
+.4byte sHoundoomSprites3
+.4byte sHoundoomSprites4
+.4byte sHoundoomSprites5
+.4byte sHoundoomSprites6
+.4byte sHoundoomSprites7
+.4byte sHoundoomSprites8
+.4byte sHoundoomSprites9
+.4byte sHoundoomSprites10
+.4byte sHoundoomSprites11
+.4byte sHoundoomSprites12
+.4byte sHoundoomSprites13
+.4byte sHoundoomSprites14
+.4byte sHoundoomSprites15
+.4byte sHoundoomSprites16
+.4byte sHoundoomSprites17
+.4byte sHoundoomSprites18
+.4byte sHoundoomSprites19
+.4byte sHoundoomSprites20
+.4byte sHoundoomSprites21
+.4byte sHoundoomSprites22
+.4byte sHoundoomSprites23
+.4byte sHoundoomSprites24
+.4byte sHoundoomSprites25
+.4byte sHoundoomSprites26
+.4byte sHoundoomSprites27
+.4byte sHoundoomSprites28
+.4byte sHoundoomSprites29
+.4byte sHoundoomSprites30
+.4byte sHoundoomSprites31
+.4byte sHoundoomSprites32
+.4byte sHoundoomSprites33
+.4byte sHoundoomSprites34
+.4byte sHoundoomSprites35
+.4byte sHoundoomSprites36
+.4byte sHoundoomSprites37
+.4byte sHoundoomSprites38
+.4byte sHoundoomSprites39
+.4byte sHoundoomSprites40
+.4byte sHoundoomSprites41
+.4byte sHoundoomSprites42
+.4byte sHoundoomSprites43
+.4byte sHoundoomSprites44
+.4byte sHoundoomSprites45
+.4byte sHoundoomSprites46
+.4byte sHoundoomSprites47
+.4byte sHoundoomSprites48
+.4byte sHoundoomSprites49
+.4byte sHoundoomSprites50
+.4byte sHoundoomSprites51
+.4byte sHoundoomSprites52
+.4byte sHoundoomSprites53
+.4byte sHoundoomSprites54
+.4byte sHoundoomSprites55
+.4byte sHoundoomSprites56
+.4byte sHoundoomSprites57
+.4byte sHoundoomSprites58
+.4byte sHoundoomSprites59
+.4byte sHoundoomSprites60
+.4byte sHoundoomSprites61
+.4byte sHoundoomSprites62
+.4byte sHoundoomSprites63
+.4byte sHoundoomSprites64
+.4byte sHoundoomSprites65
+.4byte sHoundoomSprites66
+.4byte sHoundoomSprites67
+.4byte sHoundoomSprites68
+.4byte sHoundoomSprites69
+.4byte sHoundoomSprites70
+.4byte sHoundoomSprites71
+.4byte sHoundoomSprites72
+.4byte sHoundoomSprites73
+.4byte sHoundoomSprites74
+.4byte sHoundoomSprites75
+.4byte sHoundoomSprites76
+.4byte sHoundoomSprites77
+.4byte sHoundoomSprites78
+.4byte sHoundoomSprites79
+.4byte sHoundoomSprites80
+.4byte sHoundoomSprites81
+.4byte sHoundoomSprites82
+.4byte sHoundoomSprites83
+.4byte sHoundoomSprites84
+.4byte sHoundoomSprites85
+.4byte sHoundoomSprites86
+.4byte sHoundoomSprites87
+.4byte sHoundoomSprites88
+.4byte sHoundoomSprites89
+.4byte sHoundoomSprites90
+.4byte sHoundoomSprites91
+.4byte sHoundoomSprites92
+.4byte sHoundoomSprites93
+.4byte sHoundoomSprites94
+.4byte sHoundoomSprites95
+.4byte sHoundoomSprites96
+.4byte sHoundoomSprites97
+.4byte sHoundoomSprites98
+.4byte sHoundoomSprites99
+.4byte sHoundoomSprites100
+.4byte sHoundoomSprites101
+.4byte sHoundoomSprites102
+.4byte sHoundoomSprites103
+.4byte sHoundoomSprites104
+.4byte sHoundoomSprites105
+.4byte sHoundoomSprites106
+.4byte sHoundoomSprites107
+.4byte sHoundoomSprites108
+.4byte sHoundoomSprites109
+.4byte sHoundoomSprites110
+.4byte sHoundoomSprites111
+sAxMainHoundoom:
+ax_main sAxPosesHoundoom, sAxAnimationsHoundoom, 13, sAxSpritesHoundoom, sAxPositionsHoundoom

--- a/data/ax/houndour.inc
+++ b/data/ax/houndour.inc
@@ -1,0 +1,2817 @@
+.global gAxHoundour
+gAxHoundour:
+ax_siro sAxMainHoundour
+sHoundourPose1:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose2:
+ax_pose 1, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose3:
+ax_pose 2, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose4:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose5:
+ax_pose 4, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose6:
+ax_pose 5, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose7:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose8:
+ax_pose 7, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose9:
+ax_pose 8, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose10:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose11:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose12:
+ax_pose 11, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose13:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose14:
+ax_pose 13, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose15:
+ax_pose 14, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose16:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose17:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose18:
+ax_pose 11, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose22:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose23:
+ax_pose 4, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose24:
+ax_pose 5, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose25:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose26:
+ax_pose 1, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose27:
+ax_pose 2, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose28:
+ax_pose 15, 0x81ed, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose29:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose30:
+ax_pose 4, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose31:
+ax_pose 5, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose32:
+ax_pose 16, 0x01ee, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose33:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose34:
+ax_pose 7, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose35:
+ax_pose 8, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose36:
+ax_pose 17, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose37:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose38:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose39:
+ax_pose 11, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose40:
+ax_pose 18, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundourPose41:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose42:
+ax_pose 13, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose43:
+ax_pose 14, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose44:
+ax_pose 19, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose45:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose46:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose47:
+ax_pose 11, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose48:
+ax_pose 18, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose49:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose50:
+ax_pose 7, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose51:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose52:
+ax_pose 17, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose53:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose54:
+ax_pose 4, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose55:
+ax_pose 5, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose56:
+ax_pose 16, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose57:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose58:
+ax_pose 1, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose59:
+ax_pose 2, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose60:
+ax_pose 15, 0x81ed, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose61:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose62:
+ax_pose 4, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose63:
+ax_pose 5, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose64:
+ax_pose 16, 0x01ee, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose65:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose66:
+ax_pose 7, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose67:
+ax_pose 8, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose68:
+ax_pose 17, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose69:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose70:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose71:
+ax_pose 11, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose72:
+ax_pose 18, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundourPose73:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose74:
+ax_pose 13, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose75:
+ax_pose 14, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose76:
+ax_pose 19, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose77:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose78:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose79:
+ax_pose 11, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose80:
+ax_pose 18, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose81:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose82:
+ax_pose 7, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose83:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose84:
+ax_pose 17, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose85:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose86:
+ax_pose 4, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose87:
+ax_pose 5, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose88:
+ax_pose 16, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose89:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose90:
+ax_pose 1, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose91:
+ax_pose 20, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose92:
+ax_pose 15, 0x81ed, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose93:
+ax_pose 21, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose94:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose95:
+ax_pose 4, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose96:
+ax_pose 22, 0x01ed, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose97:
+ax_pose 16, 0x01ee, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose98:
+ax_pose 23, 0x01ea, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose99:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose100:
+ax_pose 7, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose101:
+ax_pose 24, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose102:
+ax_pose 17, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose103:
+ax_pose 25, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundourPose104:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose105:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose106:
+ax_pose 26, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose107:
+ax_pose 18, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundourPose108:
+ax_pose 27, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose109:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose110:
+ax_pose 13, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose111:
+ax_pose 28, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose112:
+ax_pose 19, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose113:
+ax_pose 29, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose114:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose115:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose116:
+ax_pose 26, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose117:
+ax_pose 18, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose118:
+ax_pose 27, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose119:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose120:
+ax_pose 7, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose121:
+ax_pose 24, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose122:
+ax_pose 17, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose123:
+ax_pose 25, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundourPose124:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose125:
+ax_pose 4, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose126:
+ax_pose 22, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose127:
+ax_pose 16, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose128:
+ax_pose 23, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose129:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose130:
+ax_pose 20, 0x81ed, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose131:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose132:
+ax_pose 22, 0x01ed, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose133:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose134:
+ax_pose 24, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose135:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose136:
+ax_pose 26, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose137:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose138:
+ax_pose 28, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose139:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose140:
+ax_pose 26, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose141:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose142:
+ax_pose 24, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose143:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose144:
+ax_pose 22, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose145:
+ax_pose 30, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose146:
+ax_pose 31, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose147:
+ax_pose 32, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose148:
+ax_pose 33, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundourPose149:
+ax_pose 34, 0x01e7, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundourPose150:
+ax_pose 35, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose151:
+ax_pose 36, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose152:
+ax_pose 35, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose153:
+ax_pose 34, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundourPose154:
+ax_pose 33, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundourPose155:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose156:
+ax_pose 1, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose157:
+ax_pose 20, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose158:
+ax_pose 15, 0x81ed, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose159:
+ax_pose 21, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose160:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose161:
+ax_pose 4, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose162:
+ax_pose 22, 0x01ed, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose163:
+ax_pose 16, 0x01ee, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose164:
+ax_pose 23, 0x01ea, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose165:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose166:
+ax_pose 7, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose167:
+ax_pose 24, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose168:
+ax_pose 17, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose169:
+ax_pose 25, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundourPose170:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose171:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose172:
+ax_pose 26, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose173:
+ax_pose 18, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundourPose174:
+ax_pose 27, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose175:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose176:
+ax_pose 13, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose177:
+ax_pose 28, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose178:
+ax_pose 19, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose179:
+ax_pose 29, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose180:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose181:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose182:
+ax_pose 26, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose183:
+ax_pose 18, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose184:
+ax_pose 27, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose185:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose186:
+ax_pose 7, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose187:
+ax_pose 24, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose188:
+ax_pose 17, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose189:
+ax_pose 25, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundourPose190:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose191:
+ax_pose 4, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose192:
+ax_pose 22, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose193:
+ax_pose 16, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose194:
+ax_pose 23, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose195:
+ax_pose 15, 0x81ed, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose196:
+ax_pose 16, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose197:
+ax_pose 17, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose198:
+ax_pose 18, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose199:
+ax_pose 19, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose200:
+ax_pose 18, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundourPose201:
+ax_pose 17, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose202:
+ax_pose 16, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose203:
+ax_pose 20, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose204:
+ax_pose 22, 0x01ec, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose205:
+ax_pose 24, 0x01e9, 0x90f1, 0x6c00
+ax_pose_terminator
+sHoundourPose206:
+ax_pose 26, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose207:
+ax_pose 28, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose208:
+ax_pose 26, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose209:
+ax_pose 24, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sHoundourPose210:
+ax_pose 22, 0x01ec, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose211:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose212:
+ax_pose 20, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose213:
+ax_pose 15, 0x81ed, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose214:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose215:
+ax_pose 22, 0x01ed, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose216:
+ax_pose 16, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose217:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose218:
+ax_pose 24, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose219:
+ax_pose 17, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sHoundourPose220:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose221:
+ax_pose 26, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose222:
+ax_pose 18, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundourPose223:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose224:
+ax_pose 28, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose225:
+ax_pose 19, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose226:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose227:
+ax_pose 26, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose228:
+ax_pose 18, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose229:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose230:
+ax_pose 24, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose231:
+ax_pose 17, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sHoundourPose232:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose233:
+ax_pose 22, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose234:
+ax_pose 16, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose235:
+ax_pose 15, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose236:
+ax_pose 16, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose237:
+ax_pose 17, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose238:
+ax_pose 18, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sHoundourPose239:
+ax_pose 19, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose240:
+ax_pose 18, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sHoundourPose241:
+ax_pose 17, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose242:
+ax_pose 16, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+sHoundourPose243:
+ax_pose 0, 0x81ef, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose244:
+ax_pose 3, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sHoundourPose245:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sHoundourPose246:
+ax_pose 9, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sHoundourPose247:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sHoundourPose248:
+ax_pose 9, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sHoundourPose249:
+ax_pose 6, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sHoundourPose250:
+ax_pose 3, 0x01ee, 0x90ec, 0x6c00
+ax_pose_terminator
+.align 2
+sHoundourAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundourAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHoundourAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sHoundourAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 15, 0, 18, 0,
+ax_anim 2, 1, 35, 15, 1, 18, 1,
+ax_anim 2, 0, 35, 15, 0, 18, 0,
+ax_anim 2, 0, 35, 15, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sHoundourAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 16, -19, 16, -19,
+ax_anim 2, 1, 39, 17, -18, 17, -18,
+ax_anim 2, 0, 39, 16, -19, 16, -19,
+ax_anim 2, 0, 39, 17, -18, 17, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sHoundourAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sHoundourAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -16, -19, -16, -19,
+ax_anim 2, 1, 47, -17, -18, -17, -18,
+ax_anim 2, 0, 47, -16, -19, -16, -19,
+ax_anim 2, 0, 47, -17, -18, -17, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sHoundourAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -15, 0, -18, 0,
+ax_anim 2, 1, 51, -15, 1, -18, 1,
+ax_anim 2, 0, 51, -15, 0, -18, 0,
+ax_anim 2, 0, 51, -15, 1, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sHoundourAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 1, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHoundourAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 1, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sHoundourAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 1, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sHoundourAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 15, 0, 18, 0,
+ax_anim 2, 1, 67, 15, 1, 18, 1,
+ax_anim 2, 0, 67, 15, 0, 18, 0,
+ax_anim 2, 0, 67, 15, 1, 18, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sHoundourAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 16, -19, 16, -19,
+ax_anim 2, 1, 71, 17, -18, 17, -18,
+ax_anim 2, 0, 71, 16, -19, 16, -19,
+ax_anim 2, 0, 71, 17, -18, 17, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sHoundourAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sHoundourAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -16, -19, -16, -19,
+ax_anim 2, 1, 79, -17, -18, -17, -18,
+ax_anim 2, 0, 79, -16, -19, -16, -19,
+ax_anim 2, 0, 79, -17, -18, -17, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sHoundourAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -15, 0, -18, 0,
+ax_anim 2, 1, 83, -15, 1, -18, 1,
+ax_anim 2, 0, 83, -15, 0, -18, 0,
+ax_anim 2, 0, 83, -15, 1, -18, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sHoundourAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 1, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHoundourAnims_4_1:
+ax_anim 6, 0, 92, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 6, 2, 90, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 1, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 3, 0, 2,
+ax_anim_terminator
+sHoundourAnims_4_2:
+ax_anim 6, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 6, 2, 95, -3, -3, -3, -3,
+ax_anim 1, 0, 95, -1, -1, -1, -1,
+ax_anim 1, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 1, 96, 3, 1, 2, 0,
+ax_anim 2, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 0, 96, 3, 1, 2, 0,
+ax_anim 2, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 0, 96, 3, 1, 2, 0,
+ax_anim 2, 0, 96, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim_terminator
+sHoundourAnims_4_3:
+ax_anim 6, 0, 102, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 6, 2, 100, -3, 0, -3, 0,
+ax_anim 1, 0, 100, -1, 0, -1, 0,
+ax_anim 1, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 1, 101, 2, 1, 2, 1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 101, 2, 1, 2, 1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 101, 2, 1, 2, 1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sHoundourAnims_4_4:
+ax_anim 6, 0, 107, -2, 2, -2, 2,
+ax_anim 2, 0, 105, -2, 2, -2, 2,
+ax_anim 6, 2, 105, -3, 3, -3, 3,
+ax_anim 1, 0, 105, -1, 1, -1, 1,
+ax_anim 1, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 1, 106, 3, -1, 2, 0,
+ax_anim 2, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 0, 106, 3, -1, 2, 0,
+ax_anim 2, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 0, 106, 3, -1, 2, 0,
+ax_anim 2, 0, 106, 2, -2, 1, -1,
+ax_anim 2, 0, 103, 2, -2, 1, -1,
+ax_anim_terminator
+sHoundourAnims_4_5:
+ax_anim 6, 0, 112, 0, 2, 0, 2,
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 6, 2, 110, 0, 3, 0, 3,
+ax_anim 1, 0, 110, 0, 1, 0, 1,
+ax_anim 1, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 1, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sHoundourAnims_4_6:
+ax_anim 6, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 115, 2, 2, 2, 2,
+ax_anim 6, 2, 115, 3, 3, 3, 3,
+ax_anim 1, 0, 115, 1, 1, 1, 1,
+ax_anim 1, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 1, 116, -3, -1, -2, 0,
+ax_anim 2, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 0, 116, -3, -1, -2, 0,
+ax_anim 2, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 0, 116, -3, -1, -2, 0,
+ax_anim 2, 0, 116, -2, -2, -1, -1,
+ax_anim 2, 0, 113, -2, -2, -1, -1,
+ax_anim_terminator
+sHoundourAnims_4_7:
+ax_anim 6, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 6, 2, 120, 3, 0, 3, 0,
+ax_anim 1, 0, 120, 1, 0, 1, 0,
+ax_anim 1, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 1, 121, -2, 1, -2, 1,
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 0, 121, -2, 1, -2, 1,
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 0, 121, -2, 1, -2, 1,
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sHoundourAnims_4_8:
+ax_anim 6, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 6, 2, 125, 3, -3, 3, -3,
+ax_anim 1, 0, 125, 1, -1, 1, -1,
+ax_anim 1, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 1, 126, -3, 1, -2, 0,
+ax_anim 2, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 0, 126, -3, 1, -2, 0,
+ax_anim 2, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 0, 126, -3, 1, -2, 0,
+ax_anim 2, 0, 126, -2, 2, -1, 1,
+ax_anim 2, 0, 123, -2, 2, -1, 1,
+ax_anim_terminator
+.align 2
+sHoundourAnims_5_1:
+ax_anim 10, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim_terminator
+sHoundourAnims_5_2:
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 2, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim_terminator
+sHoundourAnims_5_3:
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 2, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim_terminator
+sHoundourAnims_5_4:
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 2, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim_terminator
+sHoundourAnims_5_5:
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 6, 2, 137, 1, 0, 1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim_terminator
+sHoundourAnims_5_6:
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 2, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+sHoundourAnims_5_7:
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 2, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim_terminator
+sHoundourAnims_5_8:
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 6, 2, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sHoundourAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundourAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sHoundourAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sHoundourAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sHoundourAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sHoundourAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sHoundourAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sHoundourAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sHoundourAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sHoundourAnims_8_1:
+ax_anim 60, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_8_2:
+ax_anim 60, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_8_3:
+ax_anim 60, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_8_4:
+ax_anim 60, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_8_5:
+ax_anim 60, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_8_6:
+ax_anim 60, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_8_7:
+ax_anim 60, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -1, 0, -1, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_8_8:
+ax_anim 60, 0, 189, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundourAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 9, 4, 9, 4,
+ax_anim 2, 0, 196, 14, 11, 14, 11,
+ax_anim 2, 0, 197, 10, 16, 10, 16,
+ax_anim 3, 0, 198, 0, 18, 0, 18,
+ax_anim 2, 3, 199, -10, 16, -10, 16,
+ax_anim 2, 0, 200, -14, 11, -14, 11,
+ax_anim 1, 0, 201, -9, 4, -9, 4,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 10, -2, 10, -2,
+ax_anim 2, 0, 195, 22, 2, 22, 2,
+ax_anim 2, 0, 196, 26, 9, 26, 9,
+ax_anim 3, 0, 197, 23, 18, 23, 18,
+ax_anim 2, 3, 198, 9, 17, 9, 17,
+ax_anim 2, 0, 199, -1, 15, -1, 15,
+ax_anim 1, 0, 200, -3, 8, -3, 8,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 5, -5, 5, -5,
+ax_anim 2, 0, 194, 15, -9, 15, -9,
+ax_anim 2, 0, 195, 24, -5, 24, -5,
+ax_anim 3, 0, 196, 24, 0, 24, 0,
+ax_anim 2, 3, 197, 22, 4, 22, 4,
+ax_anim 2, 0, 198, 13, 5, 13, 5,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -3, -5, -3, -5,
+ax_anim 2, 0, 201, 3, -16, 3, -16,
+ax_anim 2, 0, 194, 13, -22, 13, -22,
+ax_anim 3, 0, 195, 23, -22, 23, -22,
+ax_anim 2, 3, 196, 28, -13, 28, -13,
+ax_anim 2, 0, 197, 25, -5, 25, -5,
+ax_anim 1, 0, 198, 12, 2, 12, 2,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -12, -3, -12, -3,
+ax_anim 2, 0, 200, -13, -9, -13, -9,
+ax_anim 2, 0, 201, -9, -15, -9, -15,
+ax_anim 3, 0, 194, 0, -22, 0, -22,
+ax_anim 2, 3, 195, 9, -15, 9, -15,
+ax_anim 2, 0, 196, 13, -9, 13, -9,
+ax_anim 1, 0, 197, 12, -3, 12, -3,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 3, -5, 3, -5,
+ax_anim 2, 0, 195, -3, -16, -3, -16,
+ax_anim 2, 0, 194, -13, -22, -13, -22,
+ax_anim 3, 0, 201, -23, -22, -23, -22,
+ax_anim 2, 3, 200, -28, -13, -28, -13,
+ax_anim 2, 0, 199, -25, -5, -25, -5,
+ax_anim 1, 0, 198, -12, 2, -12, 2,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -5, -5, -5, -5,
+ax_anim 2, 0, 194, -15, -9, -15, -9,
+ax_anim 2, 0, 201, -24, -5, -24, -5,
+ax_anim 3, 0, 200, -24, 0, -24, 0,
+ax_anim 2, 3, 199, -22, 4, -22, 4,
+ax_anim 2, 0, 198, -13, 5, -13, 5,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -10, -2, -10, -2,
+ax_anim 2, 0, 201, -22, 2, -22, 2,
+ax_anim 2, 0, 200, -26, 9, -26, 9,
+ax_anim 3, 0, 199, -23, 18, -23, 18,
+ax_anim 2, 3, 198, -9, 17, -9, 17,
+ax_anim 2, 0, 197, 1, 15, 1, 15,
+ax_anim 1, 0, 196, 3, 8, 3, 8,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundourAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundourAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -25, 0, 0,
+ax_anim 3, 0, 212, 0, -23, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -24, 0, 0,
+ax_anim 3, 0, 215, 0, -23, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -21, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 221, 0, -22, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -22, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -17, 0, 0,
+ax_anim 1, 0, 224, 0, -11, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -23, 0, 0,
+ax_anim 3, 0, 227, 0, -22, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -24, 0, 0,
+ax_anim 3, 0, 233, 0, -23, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundourAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHoundourAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sHoundourGfx1:
+.incbin "baserom.gba", 0xF413EC, 0x100
+sHoundourSprites1:
+ax_sprite sHoundourGfx1, 0x100
+ax_sprite_terminator
+sHoundourGfx2:
+.incbin "baserom.gba", 0xF414FC, 0x100
+sHoundourSprites2:
+ax_sprite sHoundourGfx2, 0x100
+ax_sprite_terminator
+sHoundourGfx3:
+.incbin "baserom.gba", 0xF4160C, 0x100
+sHoundourSprites3:
+ax_sprite sHoundourGfx3, 0x100
+ax_sprite_terminator
+sHoundourGfx4:
+.incbin "baserom.gba", 0xF4171C, 0x200
+sHoundourSprites4:
+ax_sprite sHoundourGfx4, 0x200
+ax_sprite_terminator
+sHoundourGfx5:
+.incbin "baserom.gba", 0xF4192C, 0x200
+sHoundourSprites5:
+ax_sprite sHoundourGfx5, 0x200
+ax_sprite_terminator
+sHoundourGfx6:
+.incbin "baserom.gba", 0xF41B3C, 0x200
+sHoundourSprites6:
+ax_sprite sHoundourGfx6, 0x200
+ax_sprite_terminator
+sHoundourGfx7:
+.incbin "baserom.gba", 0xF41D4C, 0x200
+sHoundourSprites7:
+ax_sprite sHoundourGfx7, 0x200
+ax_sprite_terminator
+sHoundourGfx8:
+.incbin "baserom.gba", 0xF41F5C, 0x200
+sHoundourSprites8:
+ax_sprite sHoundourGfx8, 0x200
+ax_sprite_terminator
+sHoundourGfx9:
+.incbin "baserom.gba", 0xF4216C, 0x200
+sHoundourSprites9:
+ax_sprite sHoundourGfx9, 0x200
+ax_sprite_terminator
+sHoundourGfx10:
+.incbin "baserom.gba", 0xF4237C, 0x200
+sHoundourSprites10:
+ax_sprite sHoundourGfx10, 0x200
+ax_sprite_terminator
+sHoundourGfx11:
+.incbin "baserom.gba", 0xF4258C, 0x200
+sHoundourSprites11:
+ax_sprite sHoundourGfx11, 0x200
+ax_sprite_terminator
+sHoundourGfx12:
+.incbin "baserom.gba", 0xF4279C, 0x200
+sHoundourSprites12:
+ax_sprite sHoundourGfx12, 0x200
+ax_sprite_terminator
+sHoundourGfx13:
+.incbin "baserom.gba", 0xF429AC, 0x100
+sHoundourSprites13:
+ax_sprite sHoundourGfx13, 0x100
+ax_sprite_terminator
+sHoundourGfx14:
+.incbin "baserom.gba", 0xF42ABC, 0x100
+sHoundourSprites14:
+ax_sprite sHoundourGfx14, 0x100
+ax_sprite_terminator
+sHoundourGfx15:
+.incbin "baserom.gba", 0xF42BCC, 0x100
+sHoundourSprites15:
+ax_sprite sHoundourGfx15, 0x100
+ax_sprite_terminator
+sHoundourGfx16:
+.incbin "baserom.gba", 0xF42CDC, 0xC0
+sHoundourSprites16:
+ax_sprite sHoundourGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoundourGfx17:
+.incbin "baserom.gba", 0xF42DB4, 0x60
+sHoundourGfx17_1:
+.incbin "baserom.gba", 0xF42E14, 0x60
+sHoundourGfx17_2:
+.incbin "baserom.gba", 0xF42E74, 0x60
+sHoundourSprites17:
+ax_sprite sHoundourGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoundourGfx18:
+.incbin "baserom.gba", 0xF42F0C, 0x60
+sHoundourGfx18_1:
+.incbin "baserom.gba", 0xF42F6C, 0x100
+sHoundourSprites18:
+ax_sprite sHoundourGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx18_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHoundourGfx19:
+.incbin "baserom.gba", 0xF43094, 0x40
+sHoundourGfx19_1:
+.incbin "baserom.gba", 0xF430D4, 0x60
+sHoundourGfx19_2:
+.incbin "baserom.gba", 0xF43134, 0x60
+sHoundourGfx19_3:
+.incbin "baserom.gba", 0xF43194, 0x60
+sHoundourSprites19:
+ax_sprite sHoundourGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoundourGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoundourGfx20:
+.incbin "baserom.gba", 0xF4323C, 0x100
+sHoundourSprites20:
+ax_sprite sHoundourGfx20, 0x100
+ax_sprite_terminator
+sHoundourGfx21:
+.incbin "baserom.gba", 0xF4334C, 0xC0
+sHoundourSprites21:
+ax_sprite sHoundourGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoundourGfx22:
+.incbin "baserom.gba", 0xF43424, 0xC0
+sHoundourSprites22:
+ax_sprite sHoundourGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoundourGfx23:
+.incbin "baserom.gba", 0xF434FC, 0x60
+sHoundourGfx23_1:
+.incbin "baserom.gba", 0xF4355C, 0x60
+sHoundourGfx23_2:
+.incbin "baserom.gba", 0xF435BC, 0x60
+sHoundourSprites23:
+ax_sprite sHoundourGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHoundourGfx24:
+.incbin "baserom.gba", 0xF43654, 0x40
+sHoundourGfx24_1:
+.incbin "baserom.gba", 0xF43694, 0x60
+sHoundourGfx24_2:
+.incbin "baserom.gba", 0xF436F4, 0x60
+sHoundourGfx24_3:
+.incbin "baserom.gba", 0xF43754, 0x20
+sHoundourSprites24:
+ax_sprite sHoundourGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoundourGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoundourGfx24_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHoundourGfx25:
+.incbin "baserom.gba", 0xF437BC, 0x40
+sHoundourGfx25_1:
+.incbin "baserom.gba", 0xF437FC, 0xE0
+sHoundourGfx25_2:
+.incbin "baserom.gba", 0xF438DC, 0x60
+sHoundourSprites25:
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoundourGfx25_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx25_2, 0x60
+ax_sprite_terminator
+sHoundourGfx26:
+.incbin "baserom.gba", 0xF43974, 0x40
+sHoundourGfx26_1:
+.incbin "baserom.gba", 0xF439B4, 0x60
+sHoundourGfx26_2:
+.incbin "baserom.gba", 0xF43A14, 0x60
+sHoundourGfx26_3:
+.incbin "baserom.gba", 0xF43A74, 0x40
+sHoundourSprites26:
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHoundourGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoundourGfx27:
+.incbin "baserom.gba", 0xF43B04, 0x40
+sHoundourGfx27_1:
+.incbin "baserom.gba", 0xF43B44, 0x60
+sHoundourGfx27_2:
+.incbin "baserom.gba", 0xF43BA4, 0x60
+sHoundourGfx27_3:
+.incbin "baserom.gba", 0xF43C04, 0x60
+sHoundourSprites27:
+ax_sprite sHoundourGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHoundourGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoundourGfx28:
+.incbin "baserom.gba", 0xF43CAC, 0x60
+sHoundourGfx28_1:
+.incbin "baserom.gba", 0xF43D0C, 0x60
+sHoundourGfx28_2:
+.incbin "baserom.gba", 0xF43D6C, 0x60
+sHoundourGfx28_3:
+.incbin "baserom.gba", 0xF43DCC, 0x60
+sHoundourSprites28:
+ax_sprite sHoundourGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHoundourGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHoundourGfx29:
+.incbin "baserom.gba", 0xF43E74, 0x100
+sHoundourSprites29:
+ax_sprite sHoundourGfx29, 0x100
+ax_sprite_terminator
+sHoundourGfx30:
+.incbin "baserom.gba", 0xF43F84, 0x100
+sHoundourSprites30:
+ax_sprite sHoundourGfx30, 0x100
+ax_sprite_terminator
+sHoundourGfx31:
+.incbin "baserom.gba", 0xF44094, 0x200
+sHoundourSprites31:
+ax_sprite sHoundourGfx31, 0x200
+ax_sprite_terminator
+sHoundourGfx32:
+.incbin "baserom.gba", 0xF442A4, 0x200
+sHoundourSprites32:
+ax_sprite sHoundourGfx32, 0x200
+ax_sprite_terminator
+sHoundourGfx33:
+.incbin "baserom.gba", 0xF444B4, 0x200
+sHoundourSprites33:
+ax_sprite sHoundourGfx33, 0x200
+ax_sprite_terminator
+sHoundourGfx34:
+.incbin "baserom.gba", 0xF446C4, 0x200
+sHoundourSprites34:
+ax_sprite sHoundourGfx34, 0x200
+ax_sprite_terminator
+sHoundourGfx35:
+.incbin "baserom.gba", 0xF448D4, 0x200
+sHoundourSprites35:
+ax_sprite sHoundourGfx35, 0x200
+ax_sprite_terminator
+sHoundourGfx36:
+.incbin "baserom.gba", 0xF44AE4, 0x200
+sHoundourSprites36:
+ax_sprite sHoundourGfx36, 0x200
+ax_sprite_terminator
+sHoundourGfx37:
+.incbin "baserom.gba", 0xF44CF4, 0x200
+sHoundourSprites37:
+ax_sprite sHoundourGfx37, 0x200
+ax_sprite_terminator
+sAxPosesHoundour:
+.4byte sHoundourPose1
+.4byte sHoundourPose2
+.4byte sHoundourPose3
+.4byte sHoundourPose4
+.4byte sHoundourPose5
+.4byte sHoundourPose6
+.4byte sHoundourPose7
+.4byte sHoundourPose8
+.4byte sHoundourPose9
+.4byte sHoundourPose10
+.4byte sHoundourPose11
+.4byte sHoundourPose12
+.4byte sHoundourPose13
+.4byte sHoundourPose14
+.4byte sHoundourPose15
+.4byte sHoundourPose16
+.4byte sHoundourPose17
+.4byte sHoundourPose18
+.4byte sHoundourPose19
+.4byte sHoundourPose20
+.4byte sHoundourPose21
+.4byte sHoundourPose22
+.4byte sHoundourPose23
+.4byte sHoundourPose24
+.4byte sHoundourPose25
+.4byte sHoundourPose26
+.4byte sHoundourPose27
+.4byte sHoundourPose28
+.4byte sHoundourPose29
+.4byte sHoundourPose30
+.4byte sHoundourPose31
+.4byte sHoundourPose32
+.4byte sHoundourPose33
+.4byte sHoundourPose34
+.4byte sHoundourPose35
+.4byte sHoundourPose36
+.4byte sHoundourPose37
+.4byte sHoundourPose38
+.4byte sHoundourPose39
+.4byte sHoundourPose40
+.4byte sHoundourPose41
+.4byte sHoundourPose42
+.4byte sHoundourPose43
+.4byte sHoundourPose44
+.4byte sHoundourPose45
+.4byte sHoundourPose46
+.4byte sHoundourPose47
+.4byte sHoundourPose48
+.4byte sHoundourPose49
+.4byte sHoundourPose50
+.4byte sHoundourPose51
+.4byte sHoundourPose52
+.4byte sHoundourPose53
+.4byte sHoundourPose54
+.4byte sHoundourPose55
+.4byte sHoundourPose56
+.4byte sHoundourPose57
+.4byte sHoundourPose58
+.4byte sHoundourPose59
+.4byte sHoundourPose60
+.4byte sHoundourPose61
+.4byte sHoundourPose62
+.4byte sHoundourPose63
+.4byte sHoundourPose64
+.4byte sHoundourPose65
+.4byte sHoundourPose66
+.4byte sHoundourPose67
+.4byte sHoundourPose68
+.4byte sHoundourPose69
+.4byte sHoundourPose70
+.4byte sHoundourPose71
+.4byte sHoundourPose72
+.4byte sHoundourPose73
+.4byte sHoundourPose74
+.4byte sHoundourPose75
+.4byte sHoundourPose76
+.4byte sHoundourPose77
+.4byte sHoundourPose78
+.4byte sHoundourPose79
+.4byte sHoundourPose80
+.4byte sHoundourPose81
+.4byte sHoundourPose82
+.4byte sHoundourPose83
+.4byte sHoundourPose84
+.4byte sHoundourPose85
+.4byte sHoundourPose86
+.4byte sHoundourPose87
+.4byte sHoundourPose88
+.4byte sHoundourPose89
+.4byte sHoundourPose90
+.4byte sHoundourPose91
+.4byte sHoundourPose92
+.4byte sHoundourPose93
+.4byte sHoundourPose94
+.4byte sHoundourPose95
+.4byte sHoundourPose96
+.4byte sHoundourPose97
+.4byte sHoundourPose98
+.4byte sHoundourPose99
+.4byte sHoundourPose100
+.4byte sHoundourPose101
+.4byte sHoundourPose102
+.4byte sHoundourPose103
+.4byte sHoundourPose104
+.4byte sHoundourPose105
+.4byte sHoundourPose106
+.4byte sHoundourPose107
+.4byte sHoundourPose108
+.4byte sHoundourPose109
+.4byte sHoundourPose110
+.4byte sHoundourPose111
+.4byte sHoundourPose112
+.4byte sHoundourPose113
+.4byte sHoundourPose114
+.4byte sHoundourPose115
+.4byte sHoundourPose116
+.4byte sHoundourPose117
+.4byte sHoundourPose118
+.4byte sHoundourPose119
+.4byte sHoundourPose120
+.4byte sHoundourPose121
+.4byte sHoundourPose122
+.4byte sHoundourPose123
+.4byte sHoundourPose124
+.4byte sHoundourPose125
+.4byte sHoundourPose126
+.4byte sHoundourPose127
+.4byte sHoundourPose128
+.4byte sHoundourPose129
+.4byte sHoundourPose130
+.4byte sHoundourPose131
+.4byte sHoundourPose132
+.4byte sHoundourPose133
+.4byte sHoundourPose134
+.4byte sHoundourPose135
+.4byte sHoundourPose136
+.4byte sHoundourPose137
+.4byte sHoundourPose138
+.4byte sHoundourPose139
+.4byte sHoundourPose140
+.4byte sHoundourPose141
+.4byte sHoundourPose142
+.4byte sHoundourPose143
+.4byte sHoundourPose144
+.4byte sHoundourPose145
+.4byte sHoundourPose146
+.4byte sHoundourPose147
+.4byte sHoundourPose148
+.4byte sHoundourPose149
+.4byte sHoundourPose150
+.4byte sHoundourPose151
+.4byte sHoundourPose152
+.4byte sHoundourPose153
+.4byte sHoundourPose154
+.4byte sHoundourPose155
+.4byte sHoundourPose156
+.4byte sHoundourPose157
+.4byte sHoundourPose158
+.4byte sHoundourPose159
+.4byte sHoundourPose160
+.4byte sHoundourPose161
+.4byte sHoundourPose162
+.4byte sHoundourPose163
+.4byte sHoundourPose164
+.4byte sHoundourPose165
+.4byte sHoundourPose166
+.4byte sHoundourPose167
+.4byte sHoundourPose168
+.4byte sHoundourPose169
+.4byte sHoundourPose170
+.4byte sHoundourPose171
+.4byte sHoundourPose172
+.4byte sHoundourPose173
+.4byte sHoundourPose174
+.4byte sHoundourPose175
+.4byte sHoundourPose176
+.4byte sHoundourPose177
+.4byte sHoundourPose178
+.4byte sHoundourPose179
+.4byte sHoundourPose180
+.4byte sHoundourPose181
+.4byte sHoundourPose182
+.4byte sHoundourPose183
+.4byte sHoundourPose184
+.4byte sHoundourPose185
+.4byte sHoundourPose186
+.4byte sHoundourPose187
+.4byte sHoundourPose188
+.4byte sHoundourPose189
+.4byte sHoundourPose190
+.4byte sHoundourPose191
+.4byte sHoundourPose192
+.4byte sHoundourPose193
+.4byte sHoundourPose194
+.4byte sHoundourPose195
+.4byte sHoundourPose196
+.4byte sHoundourPose197
+.4byte sHoundourPose198
+.4byte sHoundourPose199
+.4byte sHoundourPose200
+.4byte sHoundourPose201
+.4byte sHoundourPose202
+.4byte sHoundourPose203
+.4byte sHoundourPose204
+.4byte sHoundourPose205
+.4byte sHoundourPose206
+.4byte sHoundourPose207
+.4byte sHoundourPose208
+.4byte sHoundourPose209
+.4byte sHoundourPose210
+.4byte sHoundourPose211
+.4byte sHoundourPose212
+.4byte sHoundourPose213
+.4byte sHoundourPose214
+.4byte sHoundourPose215
+.4byte sHoundourPose216
+.4byte sHoundourPose217
+.4byte sHoundourPose218
+.4byte sHoundourPose219
+.4byte sHoundourPose220
+.4byte sHoundourPose221
+.4byte sHoundourPose222
+.4byte sHoundourPose223
+.4byte sHoundourPose224
+.4byte sHoundourPose225
+.4byte sHoundourPose226
+.4byte sHoundourPose227
+.4byte sHoundourPose228
+.4byte sHoundourPose229
+.4byte sHoundourPose230
+.4byte sHoundourPose231
+.4byte sHoundourPose232
+.4byte sHoundourPose233
+.4byte sHoundourPose234
+.4byte sHoundourPose235
+.4byte sHoundourPose236
+.4byte sHoundourPose237
+.4byte sHoundourPose238
+.4byte sHoundourPose239
+.4byte sHoundourPose240
+.4byte sHoundourPose241
+.4byte sHoundourPose242
+.4byte sHoundourPose243
+.4byte sHoundourPose244
+.4byte sHoundourPose245
+.4byte sHoundourPose246
+.4byte sHoundourPose247
+.4byte sHoundourPose248
+.4byte sHoundourPose249
+.4byte sHoundourPose250
+sAxPositionsHoundour:
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    5, 	   3,    2, 	   0,   -3
+.2byte   -1,   -2, 	  -4,    2, 	   4,    5, 	  -1,   -3
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+.2byte    8,   -5, 	   8,    2, 	  -2,    2, 	   2,   -5
+.2byte    7,   -5, 	   1,    0, 	   3,    4, 	   1,   -4
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    9,   -8, 	   7,   -4, 	   1,    1, 	   2,   -6
+.2byte    9,   -8, 	   0,   -2, 	   6,    1, 	   1,   -6
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte    8,  -12, 	   0,   -2, 	   3,    1, 	   2,   -8
+.2byte    8,  -12, 	  -2,   -3, 	   9,   -3, 	   2,   -8
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -1,  -15, 	   4,   -6, 	  -5,   -2, 	   0,   -8
+.2byte    0,  -15, 	   4,   -2, 	  -5,   -6, 	   0,   -8
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -9,  -12, 	  -1,   -2, 	  -4,    1, 	  -3,   -8
+.2byte   -9,  -12, 	   1,   -3, 	 -10,   -3, 	  -3,   -8
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte  -10,   -8, 	  -8,   -4, 	  -2,    1, 	  -3,   -6
+.2byte  -10,   -8, 	  -1,   -2, 	  -7,    1, 	  -2,   -6
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte   -9,   -5, 	  -9,    2, 	   1,    2, 	  -3,   -5
+.2byte   -8,   -5, 	  -2,    0, 	  -4,    4, 	  -2,   -4
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    5, 	   3,    2, 	   0,   -3
+.2byte   -1,   -2, 	  -4,    2, 	   4,    5, 	  -1,   -3
+.2byte    0,   -2, 	  -5,    2, 	   4,    3, 	  -1,   -5
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+.2byte    8,   -5, 	   8,    2, 	  -2,    2, 	   2,   -5
+.2byte    7,   -5, 	   1,    0, 	   3,    4, 	   1,   -4
+.2byte    8,   -6, 	   6,    0, 	   1,    3, 	   1,   -5
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    9,   -8, 	   7,   -4, 	   1,    1, 	   2,   -6
+.2byte    9,   -8, 	   0,   -2, 	   6,    1, 	   1,   -6
+.2byte   11,  -10, 	   7,   -4, 	   4,    0, 	   3,   -8
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte    8,  -12, 	   0,   -2, 	   3,    1, 	   2,   -8
+.2byte    8,  -12, 	  -2,   -3, 	   9,   -3, 	   2,   -8
+.2byte   10,  -14, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -1,  -15, 	   4,   -6, 	  -5,   -2, 	   0,   -8
+.2byte    0,  -15, 	   4,   -2, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -18, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -9,  -12, 	  -1,   -2, 	  -4,    1, 	  -3,   -8
+.2byte   -9,  -12, 	   1,   -3, 	 -10,   -3, 	  -3,   -8
+.2byte  -11,  -14, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte  -10,   -8, 	  -8,   -4, 	  -2,    1, 	  -3,   -6
+.2byte  -10,   -8, 	  -1,   -2, 	  -7,    1, 	  -2,   -6
+.2byte  -12,  -10, 	  -8,   -4, 	  -5,    0, 	  -4,   -8
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte   -9,   -5, 	  -9,    2, 	   1,    2, 	  -3,   -5
+.2byte   -8,   -5, 	  -2,    0, 	  -4,    4, 	  -2,   -4
+.2byte   -9,   -6, 	  -7,    0, 	  -2,    3, 	  -2,   -5
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    5, 	   3,    2, 	   0,   -3
+.2byte   -1,   -2, 	  -4,    2, 	   4,    5, 	  -1,   -3
+.2byte    0,   -2, 	  -5,    2, 	   4,    3, 	  -1,   -5
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+.2byte    8,   -5, 	   8,    2, 	  -2,    2, 	   2,   -5
+.2byte    7,   -5, 	   1,    0, 	   3,    4, 	   1,   -4
+.2byte    8,   -6, 	   6,    0, 	   1,    3, 	   1,   -5
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    9,   -8, 	   7,   -4, 	   1,    1, 	   2,   -6
+.2byte    9,   -8, 	   0,   -2, 	   6,    1, 	   1,   -6
+.2byte   11,  -10, 	   7,   -4, 	   4,    0, 	   3,   -8
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte    8,  -12, 	   0,   -2, 	   3,    1, 	   2,   -8
+.2byte    8,  -12, 	  -2,   -3, 	   9,   -3, 	   2,   -8
+.2byte   10,  -14, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -1,  -15, 	   4,   -6, 	  -5,   -2, 	   0,   -8
+.2byte    0,  -15, 	   4,   -2, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -18, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -9,  -12, 	  -1,   -2, 	  -4,    1, 	  -3,   -8
+.2byte   -9,  -12, 	   1,   -3, 	 -10,   -3, 	  -3,   -8
+.2byte  -11,  -14, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte  -10,   -8, 	  -8,   -4, 	  -2,    1, 	  -3,   -6
+.2byte  -10,   -8, 	  -1,   -2, 	  -7,    1, 	  -2,   -6
+.2byte  -12,  -10, 	  -8,   -4, 	  -5,    0, 	  -4,   -8
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte   -9,   -5, 	  -9,    2, 	   1,    2, 	  -3,   -5
+.2byte   -8,   -5, 	  -2,    0, 	  -4,    4, 	  -2,   -4
+.2byte   -9,   -6, 	  -7,    0, 	  -2,    3, 	  -2,   -5
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    5, 	   3,    2, 	   0,   -3
+.2byte   -1,  -17, 	  -4,    1, 	   3,    1, 	  -1,  -10
+.2byte    0,   -2, 	  -5,    2, 	   4,    3, 	  -1,   -5
+.2byte    0,   -7, 	  -4,    2, 	   3,    2, 	  -1,   -7
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+.2byte    8,   -5, 	   8,    2, 	  -2,    2, 	   2,   -5
+.2byte    4,  -17, 	   6,    0, 	   1,    3, 	   2,   -8
+.2byte    8,   -6, 	   6,    0, 	   1,    3, 	   1,   -5
+.2byte    4,   -9, 	   5,   -1, 	   0,    2, 	   0,   -7
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    9,   -8, 	   7,   -4, 	   1,    1, 	   2,   -6
+.2byte    5,  -20, 	   5,   -5, 	   4,    0, 	   1,  -10
+.2byte   11,  -10, 	   7,   -4, 	   4,    0, 	   3,   -8
+.2byte    5,  -11, 	   3,   -3, 	   1,    1, 	  -2,   -8
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte    8,  -12, 	   0,   -2, 	   3,    1, 	   2,   -8
+.2byte    6,  -20, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   10,  -14, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte    5,  -13, 	  -2,   -2, 	   4,    1, 	  -1,   -8
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -1,  -15, 	   4,   -6, 	  -5,   -2, 	   0,   -8
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	  -1,  -11
+.2byte    0,  -18, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte    0,  -18, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -9,  -12, 	  -1,   -2, 	  -4,    1, 	  -3,   -8
+.2byte   -7,  -20, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte  -11,  -14, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte   -6,  -13, 	   1,   -2, 	  -5,    1, 	   0,   -8
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte  -10,   -8, 	  -8,   -4, 	  -2,    1, 	  -3,   -6
+.2byte   -6,  -20, 	  -6,   -5, 	  -5,    0, 	  -2,  -10
+.2byte  -12,  -10, 	  -8,   -4, 	  -5,    0, 	  -4,   -8
+.2byte   -6,  -11, 	  -4,   -3, 	  -2,    1, 	   1,   -8
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte   -9,   -5, 	  -9,    2, 	   1,    2, 	  -3,   -5
+.2byte   -5,  -17, 	  -7,    0, 	  -2,    3, 	  -3,   -8
+.2byte   -9,   -6, 	  -7,    0, 	  -2,    3, 	  -2,   -5
+.2byte   -5,   -9, 	  -6,   -1, 	  -1,    2, 	  -1,   -7
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -1,  -15, 	  -4,    3, 	   3,    3, 	  -1,   -8
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+.2byte    4,  -17, 	   6,    0, 	   1,    3, 	   2,   -8
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    5,  -20, 	   5,   -5, 	   4,    0, 	   1,  -10
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte    6,  -20, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	  -1,  -11
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -7,  -20, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte   -6,  -20, 	  -6,   -5, 	  -5,    0, 	  -2,  -10
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte   -5,  -17, 	  -7,    0, 	  -2,    3, 	  -3,   -8
+.2byte   -7,   -3, 	  -7,    0, 	  -5,    2, 	   1,   -4
+.2byte   -8,   -2, 	  -7,    0, 	  -5,    2, 	   1,   -5
+.2byte    0,  -15, 	  -4,    2, 	   3,    2, 	   0,   -8
+.2byte    9,  -15, 	   7,   -1, 	   2,    2, 	   3,   -7
+.2byte    9,  -18, 	   8,   -4, 	   7,    1, 	   3,   -7
+.2byte    6,  -21, 	   0,   -5, 	   7,   -3, 	   1,   -9
+.2byte    1,  -17, 	   5,   -4, 	  -4,   -4, 	   1,   -9
+.2byte   -7,  -21, 	  -1,   -5, 	  -8,   -3, 	  -2,   -9
+.2byte   -8,  -18, 	  -7,   -4, 	  -6,    1, 	  -2,   -7
+.2byte   -8,  -15, 	  -6,   -1, 	  -1,    2, 	  -2,   -7
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    5, 	   3,    2, 	   0,   -3
+.2byte   -1,  -17, 	  -4,    1, 	   3,    1, 	  -1,  -10
+.2byte    0,   -2, 	  -5,    2, 	   4,    3, 	  -1,   -5
+.2byte    0,   -7, 	  -4,    2, 	   3,    2, 	  -1,   -7
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+.2byte    8,   -5, 	   8,    2, 	  -2,    2, 	   2,   -5
+.2byte    4,  -17, 	   6,    0, 	   1,    3, 	   2,   -8
+.2byte    8,   -6, 	   6,    0, 	   1,    3, 	   1,   -5
+.2byte    4,   -9, 	   5,   -1, 	   0,    2, 	   0,   -7
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    9,   -8, 	   7,   -4, 	   1,    1, 	   2,   -6
+.2byte    5,  -20, 	   5,   -5, 	   4,    0, 	   1,  -10
+.2byte   11,  -10, 	   7,   -4, 	   4,    0, 	   3,   -8
+.2byte    5,  -11, 	   3,   -3, 	   1,    1, 	  -2,   -8
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte    8,  -12, 	   0,   -2, 	   3,    1, 	   2,   -8
+.2byte    6,  -20, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   10,  -14, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte    5,  -13, 	  -2,   -2, 	   4,    1, 	  -1,   -8
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -1,  -15, 	   4,   -6, 	  -5,   -2, 	   0,   -8
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	  -1,  -11
+.2byte    0,  -18, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte    0,  -18, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -9,  -12, 	  -1,   -2, 	  -4,    1, 	  -3,   -8
+.2byte   -7,  -20, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte  -11,  -14, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte   -6,  -13, 	   1,   -2, 	  -5,    1, 	   0,   -8
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte  -10,   -8, 	  -8,   -4, 	  -2,    1, 	  -3,   -6
+.2byte   -6,  -20, 	  -6,   -5, 	  -5,    0, 	  -2,  -10
+.2byte  -12,  -10, 	  -8,   -4, 	  -5,    0, 	  -4,   -8
+.2byte   -6,  -11, 	  -4,   -3, 	  -2,    1, 	   1,   -8
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte   -9,   -5, 	  -9,    2, 	   1,    2, 	  -3,   -5
+.2byte   -5,  -17, 	  -7,    0, 	  -2,    3, 	  -3,   -8
+.2byte   -9,   -6, 	  -7,    0, 	  -2,    3, 	  -2,   -5
+.2byte   -5,   -9, 	  -6,   -1, 	  -1,    2, 	  -1,   -7
+.2byte    0,   -2, 	  -5,    2, 	   4,    3, 	  -1,   -5
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -1,   -5
+.2byte  -12,  -10, 	  -8,   -4, 	  -5,    0, 	  -4,   -8
+.2byte  -11,  -14, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte    0,  -17, 	   4,   -3, 	  -5,   -3, 	   0,   -8
+.2byte   10,  -14, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   11,  -10, 	   7,   -4, 	   4,    0, 	   3,   -8
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   0,   -5
+.2byte   -1,  -16, 	  -4,    2, 	   3,    2, 	  -1,   -9
+.2byte    4,  -18, 	   6,   -1, 	   1,    2, 	   2,   -9
+.2byte    6,  -19, 	   6,   -4, 	   5,    1, 	   2,   -9
+.2byte    6,  -20, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	  -1,  -11
+.2byte   -7,  -20, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte   -7,  -19, 	  -7,   -4, 	  -6,    1, 	  -3,   -9
+.2byte   -5,  -18, 	  -7,   -1, 	  -2,    2, 	  -3,   -9
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -1,  -17, 	  -4,    1, 	   3,    1, 	  -1,  -10
+.2byte    0,   -2, 	  -5,    2, 	   4,    3, 	  -1,   -5
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+.2byte    4,  -17, 	   6,    0, 	   1,    3, 	   2,   -8
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   0,   -5
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    5,  -20, 	   5,   -5, 	   4,    0, 	   1,  -10
+.2byte   10,  -10, 	   6,   -4, 	   3,    0, 	   2,   -8
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte    6,  -20, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   10,  -13, 	  -1,   -3, 	   6,   -1, 	   1,   -9
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -1,  -19, 	   4,   -4, 	  -5,   -4, 	  -1,  -11
+.2byte    0,  -18, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -7,  -20, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte  -11,  -13, 	   0,   -3, 	  -7,   -1, 	  -2,   -9
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte   -6,  -20, 	  -6,   -5, 	  -5,    0, 	  -2,  -10
+.2byte  -11,  -10, 	  -7,   -4, 	  -4,    0, 	  -3,   -8
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte   -5,  -17, 	  -7,    0, 	  -2,    3, 	  -3,   -8
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -1,   -5
+.2byte    0,   -3, 	  -5,    1, 	   4,    2, 	  -1,   -6
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -1,   -5
+.2byte  -12,  -10, 	  -8,   -4, 	  -5,    0, 	  -4,   -8
+.2byte  -11,  -14, 	   0,   -4, 	  -7,   -2, 	  -2,  -10
+.2byte    0,  -17, 	   4,   -3, 	  -5,   -3, 	   0,   -8
+.2byte   10,  -14, 	  -1,   -4, 	   6,   -2, 	   1,  -10
+.2byte   11,  -10, 	   7,   -4, 	   4,    0, 	   3,   -8
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   0,   -5
+.2byte   -1,   -3, 	  -4,    3, 	   3,    3, 	  -1,   -4
+.2byte   -8,   -6, 	  -6,    0, 	  -1,    3, 	  -2,   -6
+.2byte  -11,   -9, 	  -7,   -4, 	  -5,    1, 	  -3,   -7
+.2byte   -9,  -13, 	  -1,   -5, 	  -7,   -1, 	  -2,   -8
+.2byte   -1,  -17, 	   4,   -4, 	  -5,   -4, 	   0,   -9
+.2byte    8,  -13, 	   0,   -5, 	   6,   -1, 	   1,   -8
+.2byte   10,   -9, 	   6,   -4, 	   4,    1, 	   2,   -7
+.2byte    7,   -6, 	   5,    0, 	   0,    3, 	   1,   -6
+sHoundourAnimTable1:
+.4byte sHoundourAnims_1_1
+.4byte sHoundourAnims_1_2
+.4byte sHoundourAnims_1_3
+.4byte sHoundourAnims_1_4
+.4byte sHoundourAnims_1_5
+.4byte sHoundourAnims_1_6
+.4byte sHoundourAnims_1_7
+.4byte sHoundourAnims_1_8
+sHoundourAnimTable2:
+.4byte sHoundourAnims_2_1
+.4byte sHoundourAnims_2_2
+.4byte sHoundourAnims_2_3
+.4byte sHoundourAnims_2_4
+.4byte sHoundourAnims_2_5
+.4byte sHoundourAnims_2_6
+.4byte sHoundourAnims_2_7
+.4byte sHoundourAnims_2_8
+sHoundourAnimTable3:
+.4byte sHoundourAnims_3_1
+.4byte sHoundourAnims_3_2
+.4byte sHoundourAnims_3_3
+.4byte sHoundourAnims_3_4
+.4byte sHoundourAnims_3_5
+.4byte sHoundourAnims_3_6
+.4byte sHoundourAnims_3_7
+.4byte sHoundourAnims_3_8
+sHoundourAnimTable4:
+.4byte sHoundourAnims_4_1
+.4byte sHoundourAnims_4_2
+.4byte sHoundourAnims_4_3
+.4byte sHoundourAnims_4_4
+.4byte sHoundourAnims_4_5
+.4byte sHoundourAnims_4_6
+.4byte sHoundourAnims_4_7
+.4byte sHoundourAnims_4_8
+sHoundourAnimTable5:
+.4byte sHoundourAnims_5_1
+.4byte sHoundourAnims_5_2
+.4byte sHoundourAnims_5_3
+.4byte sHoundourAnims_5_4
+.4byte sHoundourAnims_5_5
+.4byte sHoundourAnims_5_6
+.4byte sHoundourAnims_5_7
+.4byte sHoundourAnims_5_8
+sHoundourAnimTable6:
+.4byte sHoundourAnims_6_1
+.4byte sHoundourAnims_6_1
+.4byte sHoundourAnims_6_1
+.4byte sHoundourAnims_6_1
+.4byte sHoundourAnims_6_1
+.4byte sHoundourAnims_6_1
+.4byte sHoundourAnims_6_1
+.4byte sHoundourAnims_6_1
+sHoundourAnimTable7:
+.4byte sHoundourAnims_7_1
+.4byte sHoundourAnims_7_2
+.4byte sHoundourAnims_7_3
+.4byte sHoundourAnims_7_4
+.4byte sHoundourAnims_7_5
+.4byte sHoundourAnims_7_6
+.4byte sHoundourAnims_7_7
+.4byte sHoundourAnims_7_8
+sHoundourAnimTable8:
+.4byte sHoundourAnims_8_1
+.4byte sHoundourAnims_8_2
+.4byte sHoundourAnims_8_3
+.4byte sHoundourAnims_8_4
+.4byte sHoundourAnims_8_5
+.4byte sHoundourAnims_8_6
+.4byte sHoundourAnims_8_7
+.4byte sHoundourAnims_8_8
+sHoundourAnimTable9:
+.4byte sHoundourAnims_9_1
+.4byte sHoundourAnims_9_2
+.4byte sHoundourAnims_9_3
+.4byte sHoundourAnims_9_4
+.4byte sHoundourAnims_9_5
+.4byte sHoundourAnims_9_6
+.4byte sHoundourAnims_9_7
+.4byte sHoundourAnims_9_8
+sHoundourAnimTable10:
+.4byte sHoundourAnims_10_1
+.4byte sHoundourAnims_10_2
+.4byte sHoundourAnims_10_3
+.4byte sHoundourAnims_10_4
+.4byte sHoundourAnims_10_5
+.4byte sHoundourAnims_10_6
+.4byte sHoundourAnims_10_7
+.4byte sHoundourAnims_10_8
+sHoundourAnimTable11:
+.4byte sHoundourAnims_11_1
+.4byte sHoundourAnims_11_2
+.4byte sHoundourAnims_11_3
+.4byte sHoundourAnims_11_4
+.4byte sHoundourAnims_11_5
+.4byte sHoundourAnims_11_6
+.4byte sHoundourAnims_11_7
+.4byte sHoundourAnims_11_8
+sHoundourAnimTable12:
+.4byte sHoundourAnims_12_1
+.4byte sHoundourAnims_12_2
+.4byte sHoundourAnims_12_3
+.4byte sHoundourAnims_12_4
+.4byte sHoundourAnims_12_5
+.4byte sHoundourAnims_12_6
+.4byte sHoundourAnims_12_7
+.4byte sHoundourAnims_12_8
+sHoundourAnimTable13:
+.4byte sHoundourAnims_13_1
+.4byte sHoundourAnims_13_2
+.4byte sHoundourAnims_13_3
+.4byte sHoundourAnims_13_4
+.4byte sHoundourAnims_13_5
+.4byte sHoundourAnims_13_6
+.4byte sHoundourAnims_13_7
+.4byte sHoundourAnims_13_8
+sAxAnimationsHoundour:
+.4byte sHoundourAnimTable1
+.4byte sHoundourAnimTable2
+.4byte sHoundourAnimTable3
+.4byte sHoundourAnimTable4
+.4byte sHoundourAnimTable5
+.4byte sHoundourAnimTable6
+.4byte sHoundourAnimTable7
+.4byte sHoundourAnimTable8
+.4byte sHoundourAnimTable9
+.4byte sHoundourAnimTable10
+.4byte sHoundourAnimTable11
+.4byte sHoundourAnimTable12
+.4byte sHoundourAnimTable13
+sAxSpritesHoundour:
+.4byte sHoundourSprites1
+.4byte sHoundourSprites2
+.4byte sHoundourSprites3
+.4byte sHoundourSprites4
+.4byte sHoundourSprites5
+.4byte sHoundourSprites6
+.4byte sHoundourSprites7
+.4byte sHoundourSprites8
+.4byte sHoundourSprites9
+.4byte sHoundourSprites10
+.4byte sHoundourSprites11
+.4byte sHoundourSprites12
+.4byte sHoundourSprites13
+.4byte sHoundourSprites14
+.4byte sHoundourSprites15
+.4byte sHoundourSprites16
+.4byte sHoundourSprites17
+.4byte sHoundourSprites18
+.4byte sHoundourSprites19
+.4byte sHoundourSprites20
+.4byte sHoundourSprites21
+.4byte sHoundourSprites22
+.4byte sHoundourSprites23
+.4byte sHoundourSprites24
+.4byte sHoundourSprites25
+.4byte sHoundourSprites26
+.4byte sHoundourSprites27
+.4byte sHoundourSprites28
+.4byte sHoundourSprites29
+.4byte sHoundourSprites30
+.4byte sHoundourSprites31
+.4byte sHoundourSprites32
+.4byte sHoundourSprites33
+.4byte sHoundourSprites34
+.4byte sHoundourSprites35
+.4byte sHoundourSprites36
+.4byte sHoundourSprites37
+sAxMainHoundour:
+ax_main sAxPosesHoundour, sAxAnimationsHoundour, 13, sAxSpritesHoundour, sAxPositionsHoundour

--- a/data/ax/huntail.inc
+++ b/data/ax/huntail.inc
@@ -1,0 +1,3250 @@
+.global gAxHuntail
+gAxHuntail:
+ax_siro sAxMainHuntail
+sHuntailPose1:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose2:
+ax_pose 1, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose3:
+ax_pose 2, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose4:
+ax_pose 3, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose9:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose10:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose11:
+ax_pose 10, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose12:
+ax_pose 11, 0x41e7, 0x90ef, 0x1c00
+ax_pose 12, 0x41f7, 0x50ef, 0x1c08
+ax_pose 13, 0x01ef, 0x10e7, 0x1c0c
+ax_pose_terminator
+sHuntailPose13:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose14:
+ax_pose 15, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose15:
+ax_pose 16, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose16:
+ax_pose 17, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose17:
+ax_pose 18, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose18:
+ax_pose 19, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose19:
+ax_pose 20, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose20:
+ax_pose 21, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose21:
+ax_pose 14, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose22:
+ax_pose 15, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose23:
+ax_pose 16, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose24:
+ax_pose 17, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose25:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose26:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose27:
+ax_pose 10, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose28:
+ax_pose 11, 0x41e7, 0x80f0, 0x1c00
+ax_pose 12, 0x41f7, 0x40f0, 0x1c08
+ax_pose 13, 0x01ef, 0x0110, 0x1c0c
+ax_pose_terminator
+sHuntailPose29:
+ax_pose 4, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose30:
+ax_pose 5, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose31:
+ax_pose 6, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose32:
+ax_pose 7, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose33:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose34:
+ax_pose 22, 0x81e5, 0x80f7, 0x1c00
+ax_pose 23, 0x81d5, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose35:
+ax_pose 24, 0x81e5, 0x80f7, 0x1c00
+ax_pose 25, 0x81d5, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose36:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose37:
+ax_pose 26, 0x41ec, 0x90f0, 0x1c00
+ax_pose 27, 0x41fc, 0x1100, 0x1c08
+ax_pose 28, 0x01e4, 0x10f0, 0x1c0a
+ax_pose 29, 0x01e5, 0x10e8, 0x1c0b
+ax_pose_terminator
+sHuntailPose38:
+ax_pose 30, 0x41eb, 0x90f0, 0x1c00
+ax_pose 31, 0x41fb, 0x1100, 0x1c08
+ax_pose 32, 0x01e3, 0x10f0, 0x1c0a
+ax_pose 33, 0x01e5, 0x10e8, 0x1c0b
+ax_pose_terminator
+sHuntailPose39:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose40:
+ax_pose 34, 0x81e0, 0x9101, 0x1c00
+ax_pose 35, 0x41f0, 0x10f1, 0x1c08
+ax_pose 36, 0x01f0, 0x50e1, 0x1c0a
+ax_pose_terminator
+sHuntailPose41:
+ax_pose 37, 0x81e0, 0x9101, 0x1c00
+ax_pose 38, 0x41f0, 0x10f1, 0x1c08
+ax_pose 39, 0x01f0, 0x50e1, 0x1c0a
+ax_pose_terminator
+sHuntailPose42:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose43:
+ax_pose 40, 0x41eb, 0x90f1, 0x1c00
+ax_pose 41, 0x41e3, 0x1101, 0x1c08
+ax_pose 42, 0x41fb, 0x10f1, 0x1c0a
+ax_pose 43, 0x01fb, 0x10e9, 0x1c0c
+ax_pose 44, 0x0203, 0x10f1, 0x1c0d
+ax_pose_terminator
+sHuntailPose44:
+ax_pose 45, 0x41ed, 0x90f2, 0x1c00
+ax_pose 46, 0x41e5, 0x1102, 0x1c08
+ax_pose 47, 0x41fd, 0x10f2, 0x1c0a
+ax_pose 48, 0x01fc, 0x10ea, 0x1c0c
+ax_pose_terminator
+sHuntailPose45:
+ax_pose 18, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose46:
+ax_pose 49, 0x81e2, 0x80f9, 0x1c00
+ax_pose 50, 0x0202, 0x00fb, 0x1c08
+ax_pose_terminator
+sHuntailPose47:
+ax_pose 51, 0x81e4, 0x80f9, 0x1c00
+ax_pose 52, 0x0204, 0x00fb, 0x1c08
+ax_pose_terminator
+sHuntailPose48:
+ax_pose 14, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose49:
+ax_pose 40, 0x41ed, 0x80f0, 0x1c00
+ax_pose 41, 0x41e5, 0x00f0, 0x1c08
+ax_pose 42, 0x41fd, 0x0100, 0x1c0a
+ax_pose 43, 0x01fd, 0x0110, 0x1c0c
+ax_pose 44, 0x0205, 0x0108, 0x1c0d
+ax_pose_terminator
+sHuntailPose50:
+ax_pose 45, 0x41ef, 0x80ef, 0x1c00
+ax_pose 46, 0x41e7, 0x00ef, 0x1c08
+ax_pose 47, 0x41ff, 0x00ff, 0x1c0a
+ax_pose 48, 0x01fe, 0x010f, 0x1c0c
+ax_pose_terminator
+sHuntailPose51:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose52:
+ax_pose 34, 0x81e0, 0x80ee, 0x1c00
+ax_pose 35, 0x41f0, 0x00fe, 0x1c08
+ax_pose 36, 0x01f0, 0x410e, 0x1c0a
+ax_pose_terminator
+sHuntailPose53:
+ax_pose 37, 0x81e0, 0x80ee, 0x1c00
+ax_pose 38, 0x41f0, 0x00fe, 0x1c08
+ax_pose 39, 0x01f0, 0x410e, 0x1c0a
+ax_pose_terminator
+sHuntailPose54:
+ax_pose 4, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose55:
+ax_pose 26, 0x41ec, 0x80ef, 0x1c00
+ax_pose 27, 0x41fc, 0x00ef, 0x1c08
+ax_pose 28, 0x01e4, 0x0107, 0x1c0a
+ax_pose 29, 0x01e5, 0x010f, 0x1c0b
+ax_pose_terminator
+sHuntailPose56:
+ax_pose 30, 0x41eb, 0x80ef, 0x1c00
+ax_pose 31, 0x41fb, 0x00ef, 0x1c08
+ax_pose 32, 0x01e3, 0x0107, 0x1c0a
+ax_pose 33, 0x01e5, 0x010f, 0x1c0b
+ax_pose_terminator
+sHuntailPose57:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose58:
+ax_pose 22, 0x81e5, 0x80f7, 0x1c00
+ax_pose 23, 0x81d5, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose59:
+ax_pose 24, 0x81e5, 0x80f7, 0x1c00
+ax_pose 25, 0x81d5, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose60:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose61:
+ax_pose 26, 0x41ec, 0x90f0, 0x1c00
+ax_pose 27, 0x41fc, 0x1100, 0x1c08
+ax_pose 28, 0x01e4, 0x10f0, 0x1c0a
+ax_pose 29, 0x01e5, 0x10e8, 0x1c0b
+ax_pose_terminator
+sHuntailPose62:
+ax_pose 30, 0x41eb, 0x90f0, 0x1c00
+ax_pose 31, 0x41fb, 0x1100, 0x1c08
+ax_pose 32, 0x01e3, 0x10f0, 0x1c0a
+ax_pose 33, 0x01e5, 0x10e8, 0x1c0b
+ax_pose_terminator
+sHuntailPose63:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose64:
+ax_pose 34, 0x81e0, 0x9101, 0x1c00
+ax_pose 35, 0x41f0, 0x10f1, 0x1c08
+ax_pose 36, 0x01f0, 0x50e1, 0x1c0a
+ax_pose_terminator
+sHuntailPose65:
+ax_pose 37, 0x81e0, 0x9101, 0x1c00
+ax_pose 38, 0x41f0, 0x10f1, 0x1c08
+ax_pose 39, 0x01f0, 0x50e1, 0x1c0a
+ax_pose_terminator
+sHuntailPose66:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose67:
+ax_pose 40, 0x41eb, 0x90f1, 0x1c00
+ax_pose 41, 0x41e3, 0x1101, 0x1c08
+ax_pose 42, 0x41fb, 0x10f1, 0x1c0a
+ax_pose 43, 0x01fb, 0x10e9, 0x1c0c
+ax_pose 44, 0x0203, 0x10f1, 0x1c0d
+ax_pose_terminator
+sHuntailPose68:
+ax_pose 45, 0x41ed, 0x90f2, 0x1c00
+ax_pose 46, 0x41e5, 0x1102, 0x1c08
+ax_pose 47, 0x41fd, 0x10f2, 0x1c0a
+ax_pose 48, 0x01fc, 0x10ea, 0x1c0c
+ax_pose_terminator
+sHuntailPose69:
+ax_pose 18, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose70:
+ax_pose 49, 0x81e2, 0x80f9, 0x1c00
+ax_pose 50, 0x0202, 0x00fb, 0x1c08
+ax_pose_terminator
+sHuntailPose71:
+ax_pose 51, 0x81e4, 0x80f9, 0x1c00
+ax_pose 52, 0x0204, 0x00fb, 0x1c08
+ax_pose_terminator
+sHuntailPose72:
+ax_pose 14, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose73:
+ax_pose 40, 0x41ed, 0x80f0, 0x1c00
+ax_pose 41, 0x41e5, 0x00f0, 0x1c08
+ax_pose 42, 0x41fd, 0x0100, 0x1c0a
+ax_pose 43, 0x01fd, 0x0110, 0x1c0c
+ax_pose 44, 0x0205, 0x0108, 0x1c0d
+ax_pose_terminator
+sHuntailPose74:
+ax_pose 45, 0x41ef, 0x80ef, 0x1c00
+ax_pose 46, 0x41e7, 0x00ef, 0x1c08
+ax_pose 47, 0x41ff, 0x00ff, 0x1c0a
+ax_pose 48, 0x01fe, 0x010f, 0x1c0c
+ax_pose_terminator
+sHuntailPose75:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose76:
+ax_pose 34, 0x81e0, 0x80ee, 0x1c00
+ax_pose 35, 0x41f0, 0x00fe, 0x1c08
+ax_pose 36, 0x01f0, 0x410e, 0x1c0a
+ax_pose_terminator
+sHuntailPose77:
+ax_pose 37, 0x81e0, 0x80ee, 0x1c00
+ax_pose 38, 0x41f0, 0x00fe, 0x1c08
+ax_pose 39, 0x01f0, 0x410e, 0x1c0a
+ax_pose_terminator
+sHuntailPose78:
+ax_pose 4, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose79:
+ax_pose 26, 0x41ec, 0x80ef, 0x1c00
+ax_pose 27, 0x41fc, 0x00ef, 0x1c08
+ax_pose 28, 0x01e4, 0x0107, 0x1c0a
+ax_pose 29, 0x01e5, 0x010f, 0x1c0b
+ax_pose_terminator
+sHuntailPose80:
+ax_pose 30, 0x41eb, 0x80ef, 0x1c00
+ax_pose 31, 0x41fb, 0x00ef, 0x1c08
+ax_pose 32, 0x01e3, 0x0107, 0x1c0a
+ax_pose 33, 0x01e5, 0x010f, 0x1c0b
+ax_pose_terminator
+sHuntailPose81:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose82:
+ax_pose 53, 0x81e4, 0x80f7, 0x1c00
+ax_pose 54, 0x01dc, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose83:
+ax_pose 55, 0x81e4, 0x80f8, 0x1c00
+ax_pose 56, 0x01f4, 0x0108, 0x1c08
+ax_pose 57, 0x01dc, 0x0100, 0x1c09
+ax_pose_terminator
+sHuntailPose84:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose85:
+ax_pose 58, 0x41ec, 0x90f0, 0x1c00
+ax_pose 59, 0x41fc, 0x1100, 0x1c08
+ax_pose 60, 0x41e4, 0x10f0, 0x1c0a
+ax_pose_terminator
+sHuntailPose86:
+ax_pose 61, 0x81e3, 0x9100, 0x1c00
+ax_pose 62, 0x81f3, 0x10f8, 0x1c08
+ax_pose 63, 0x81e3, 0x50f0, 0x1c0a
+ax_pose 64, 0x81e9, 0x10e8, 0x1c0e
+ax_pose_terminator
+sHuntailPose87:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose88:
+ax_pose 65, 0x41eb, 0x90f1, 0x1c00
+ax_pose 66, 0x41fb, 0x1101, 0x1c08
+ax_pose 67, 0x01ec, 0x10e9, 0x1c0a
+ax_pose_terminator
+sHuntailPose89:
+ax_pose 68, 0x81dd, 0x9101, 0x1c00
+ax_pose 69, 0x01ed, 0x50f1, 0x1c08
+ax_pose 70, 0x01e5, 0x10f1, 0x1c0c
+ax_pose 71, 0x01ec, 0x10e9, 0x1c0d
+ax_pose_terminator
+sHuntailPose90:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose91:
+ax_pose 72, 0x41ea, 0x90f1, 0x1c00
+ax_pose 73, 0x41fa, 0x50f1, 0x1c08
+ax_pose_terminator
+sHuntailPose92:
+ax_pose 74, 0x81e3, 0x90ff, 0x1c00
+ax_pose 75, 0x01f3, 0x50ef, 0x1c08
+ax_pose 76, 0x01fb, 0x10e7, 0x1c0c
+ax_pose_terminator
+sHuntailPose93:
+ax_pose 18, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose94:
+ax_pose 77, 0x81e3, 0x80f9, 0x1c00
+ax_pose_terminator
+sHuntailPose95:
+ax_pose 78, 0x81e0, 0x80f9, 0x1c00
+ax_pose 79, 0x0200, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose96:
+ax_pose 14, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose97:
+ax_pose 72, 0x41ea, 0x80f0, 0x1c00
+ax_pose 73, 0x41fa, 0x40f0, 0x1c08
+ax_pose_terminator
+sHuntailPose98:
+ax_pose 74, 0x81e3, 0x80f2, 0x1c00
+ax_pose 75, 0x01f3, 0x4102, 0x1c08
+ax_pose 76, 0x01fb, 0x0112, 0x1c0c
+ax_pose_terminator
+sHuntailPose99:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose100:
+ax_pose 65, 0x41eb, 0x80ee, 0x1c00
+ax_pose 66, 0x41fb, 0x00ee, 0x1c08
+ax_pose 67, 0x01ec, 0x010e, 0x1c0a
+ax_pose_terminator
+sHuntailPose101:
+ax_pose 68, 0x81dd, 0x80ee, 0x1c00
+ax_pose 69, 0x01ed, 0x40fe, 0x1c08
+ax_pose 70, 0x01e5, 0x0106, 0x1c0c
+ax_pose 71, 0x01ec, 0x010e, 0x1c0d
+ax_pose_terminator
+sHuntailPose102:
+ax_pose 4, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose103:
+ax_pose 58, 0x41ec, 0x80ef, 0x1c00
+ax_pose 59, 0x41fc, 0x00ef, 0x1c08
+ax_pose 60, 0x41e4, 0x00ff, 0x1c0a
+ax_pose_terminator
+sHuntailPose104:
+ax_pose 61, 0x81e3, 0x80ef, 0x1c00
+ax_pose 62, 0x81f3, 0x00ff, 0x1c08
+ax_pose 63, 0x81e3, 0x4107, 0x1c0a
+ax_pose 64, 0x81e9, 0x010f, 0x1c0e
+ax_pose_terminator
+sHuntailPose105:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose106:
+ax_pose 1, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose107:
+ax_pose 2, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose108:
+ax_pose 3, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose109:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose110:
+ax_pose 5, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose111:
+ax_pose 6, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose112:
+ax_pose 7, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose113:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose114:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose115:
+ax_pose 10, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose116:
+ax_pose 11, 0x41e7, 0x90ef, 0x1c00
+ax_pose 12, 0x41f7, 0x50ef, 0x1c08
+ax_pose 13, 0x01ef, 0x10e7, 0x1c0c
+ax_pose_terminator
+sHuntailPose117:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose118:
+ax_pose 15, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose119:
+ax_pose 16, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose120:
+ax_pose 17, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose121:
+ax_pose 18, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose122:
+ax_pose 19, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose123:
+ax_pose 20, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose124:
+ax_pose 21, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose125:
+ax_pose 14, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose126:
+ax_pose 15, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose127:
+ax_pose 16, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose128:
+ax_pose 17, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose129:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose130:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose131:
+ax_pose 10, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose132:
+ax_pose 11, 0x41e7, 0x80f0, 0x1c00
+ax_pose 12, 0x41f7, 0x40f0, 0x1c08
+ax_pose 13, 0x01ef, 0x0110, 0x1c0c
+ax_pose_terminator
+sHuntailPose133:
+ax_pose 4, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose134:
+ax_pose 5, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose135:
+ax_pose 6, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose136:
+ax_pose 7, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose137:
+ax_pose 80, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose138:
+ax_pose 81, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose139:
+ax_pose 82, 0x81e4, 0x4103, 0x1c00
+ax_pose 83, 0x81d4, 0x00fb, 0x1c04
+ax_pose 84, 0x81e4, 0x80f3, 0x1c06
+ax_pose_terminator
+sHuntailPose140:
+ax_pose 85, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose141:
+ax_pose 86, 0x41e7, 0x10f0, 0x1c00
+ax_pose 87, 0x01e7, 0x1100, 0x1c02
+ax_pose 88, 0x01f9, 0x10e8, 0x1c03
+ax_pose 89, 0x41f1, 0x10e0, 0x1c04
+ax_pose 90, 0x41df, 0x10f0, 0x1c06
+ax_pose 91, 0x41ef, 0x90f0, 0x1c08
+ax_pose_terminator
+sHuntailPose142:
+ax_pose 92, 0x81e4, 0x50f6, 0x1c00
+ax_pose 93, 0x0204, 0x10ee, 0x1c04
+ax_pose 94, 0x81fc, 0x10e6, 0x1c05
+ax_pose 95, 0x01fc, 0x10ee, 0x1c07
+ax_pose 96, 0x81e4, 0x90fe, 0x1c08
+ax_pose_terminator
+sHuntailPose143:
+ax_pose 97, 0x8203, 0x00fb, 0x1c00
+ax_pose 98, 0x81e3, 0x4103, 0x1c02
+ax_pose 99, 0x81e3, 0x80f3, 0x1c06
+ax_pose_terminator
+sHuntailPose144:
+ax_pose 92, 0x81e4, 0x4102, 0x1c00
+ax_pose 93, 0x0204, 0x010a, 0x1c04
+ax_pose 94, 0x81fc, 0x0112, 0x1c05
+ax_pose 95, 0x01fc, 0x010a, 0x1c07
+ax_pose 96, 0x81e4, 0x80f2, 0x1c08
+ax_pose_terminator
+sHuntailPose145:
+ax_pose 86, 0x41e7, 0x0100, 0x1c00
+ax_pose 87, 0x01e7, 0x00f8, 0x1c02
+ax_pose 88, 0x01f9, 0x0110, 0x1c03
+ax_pose 89, 0x41f1, 0x0110, 0x1c04
+ax_pose 90, 0x41df, 0x0100, 0x1c06
+ax_pose 91, 0x41ef, 0x80f0, 0x1c08
+ax_pose_terminator
+sHuntailPose146:
+ax_pose 85, 0x01e3, 0x80f1, 0x1c00
+ax_pose_terminator
+sHuntailPose147:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose148:
+ax_pose 1, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose149:
+ax_pose 2, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose150:
+ax_pose 3, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose151:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose152:
+ax_pose 5, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose153:
+ax_pose 6, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose154:
+ax_pose 7, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose155:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose156:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose157:
+ax_pose 10, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose158:
+ax_pose 11, 0x41e7, 0x90ef, 0x1c00
+ax_pose 12, 0x41f7, 0x50ef, 0x1c08
+ax_pose 13, 0x01ef, 0x10e7, 0x1c0c
+ax_pose_terminator
+sHuntailPose159:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose160:
+ax_pose 15, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose161:
+ax_pose 16, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose162:
+ax_pose 17, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose163:
+ax_pose 18, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose164:
+ax_pose 19, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose165:
+ax_pose 20, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose166:
+ax_pose 21, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose167:
+ax_pose 14, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose168:
+ax_pose 15, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose169:
+ax_pose 16, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose170:
+ax_pose 17, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose171:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose172:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose173:
+ax_pose 10, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose174:
+ax_pose 11, 0x41e7, 0x80f0, 0x1c00
+ax_pose 12, 0x41f7, 0x40f0, 0x1c08
+ax_pose 13, 0x01ef, 0x0110, 0x1c0c
+ax_pose_terminator
+sHuntailPose175:
+ax_pose 4, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose176:
+ax_pose 5, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose177:
+ax_pose 6, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose178:
+ax_pose 7, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose179:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose180:
+ax_pose 4, 0x01e5, 0x80ef, 0x1c00
+ax_pose_terminator
+sHuntailPose181:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose182:
+ax_pose 14, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose183:
+ax_pose 18, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose184:
+ax_pose 14, 0x01e3, 0x90f0, 0x1c00
+ax_pose_terminator
+sHuntailPose185:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose186:
+ax_pose 4, 0x01e5, 0x90f0, 0x1c00
+ax_pose_terminator
+sHuntailPose187:
+ax_pose 55, 0x81e4, 0x80f8, 0x1c00
+ax_pose 56, 0x01f4, 0x0108, 0x1c08
+ax_pose 57, 0x01dc, 0x0100, 0x1c09
+ax_pose_terminator
+sHuntailPose188:
+ax_pose 61, 0x81e3, 0x9102, 0x1c00
+ax_pose 62, 0x81f3, 0x10fa, 0x1c08
+ax_pose 63, 0x81e3, 0x50f2, 0x1c0a
+ax_pose 64, 0x81e9, 0x10ea, 0x1c0e
+ax_pose_terminator
+sHuntailPose189:
+ax_pose 68, 0x81df, 0x9103, 0x1c00
+ax_pose 69, 0x01ef, 0x50f3, 0x1c08
+ax_pose 70, 0x01e7, 0x10f3, 0x1c0c
+ax_pose 71, 0x01ee, 0x10eb, 0x1c0d
+ax_pose_terminator
+sHuntailPose190:
+ax_pose 74, 0x81e4, 0x90ff, 0x1c00
+ax_pose 75, 0x01f4, 0x50ef, 0x1c08
+ax_pose 76, 0x01fc, 0x10e7, 0x1c0c
+ax_pose_terminator
+sHuntailPose191:
+ax_pose 78, 0x81e2, 0x80f9, 0x1c00
+ax_pose 79, 0x0202, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose192:
+ax_pose 74, 0x81e4, 0x80f1, 0x1c00
+ax_pose 75, 0x01f4, 0x4101, 0x1c08
+ax_pose 76, 0x01fc, 0x0111, 0x1c0c
+ax_pose_terminator
+sHuntailPose193:
+ax_pose 68, 0x81df, 0x80ed, 0x1c00
+ax_pose 69, 0x01ef, 0x40fd, 0x1c08
+ax_pose 70, 0x01e7, 0x0105, 0x1c0c
+ax_pose 71, 0x01ee, 0x010d, 0x1c0d
+ax_pose_terminator
+sHuntailPose194:
+ax_pose 61, 0x81e3, 0x80ee, 0x1c00
+ax_pose 62, 0x81f3, 0x00fe, 0x1c08
+ax_pose 63, 0x81e3, 0x4106, 0x1c0a
+ax_pose 64, 0x81e9, 0x010e, 0x1c0e
+ax_pose_terminator
+sHuntailPose195:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose196:
+ax_pose 53, 0x81e4, 0x80f7, 0x1c00
+ax_pose 54, 0x01dc, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose197:
+ax_pose 55, 0x81e4, 0x80f8, 0x1c00
+ax_pose 56, 0x01f4, 0x0108, 0x1c08
+ax_pose 57, 0x01dc, 0x0100, 0x1c09
+ax_pose_terminator
+sHuntailPose198:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose199:
+ax_pose 58, 0x41ec, 0x90ef, 0x1c00
+ax_pose 59, 0x41fc, 0x10ff, 0x1c08
+ax_pose 60, 0x41e4, 0x10ef, 0x1c0a
+ax_pose_terminator
+sHuntailPose200:
+ax_pose 61, 0x81e3, 0x90fe, 0x1c00
+ax_pose 62, 0x81f3, 0x10f6, 0x1c08
+ax_pose 63, 0x81e3, 0x50ee, 0x1c0a
+ax_pose 64, 0x81e9, 0x10e6, 0x1c0e
+ax_pose_terminator
+sHuntailPose201:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose202:
+ax_pose 65, 0x41eb, 0x90ef, 0x1c00
+ax_pose 66, 0x41fb, 0x10ff, 0x1c08
+ax_pose 67, 0x01ec, 0x10e7, 0x1c0a
+ax_pose_terminator
+sHuntailPose203:
+ax_pose 68, 0x81dd, 0x90ff, 0x1c00
+ax_pose 69, 0x01ed, 0x50ef, 0x1c08
+ax_pose 70, 0x01e5, 0x10ef, 0x1c0c
+ax_pose 71, 0x01ec, 0x10e7, 0x1c0d
+ax_pose_terminator
+sHuntailPose204:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose205:
+ax_pose 72, 0x41ea, 0x90ef, 0x1c00
+ax_pose 73, 0x41fa, 0x50ef, 0x1c08
+ax_pose_terminator
+sHuntailPose206:
+ax_pose 74, 0x81e3, 0x90fd, 0x1c00
+ax_pose 75, 0x01f3, 0x50ed, 0x1c08
+ax_pose 76, 0x01fb, 0x10e5, 0x1c0c
+ax_pose_terminator
+sHuntailPose207:
+ax_pose 18, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose208:
+ax_pose 77, 0x81e3, 0x80fa, 0x1c00
+ax_pose_terminator
+sHuntailPose209:
+ax_pose 78, 0x81e0, 0x80fa, 0x1c00
+ax_pose 79, 0x0200, 0x00fd, 0x1c08
+ax_pose_terminator
+sHuntailPose210:
+ax_pose 14, 0x01e3, 0x80f1, 0x1c00
+ax_pose_terminator
+sHuntailPose211:
+ax_pose 72, 0x41ea, 0x80f2, 0x1c00
+ax_pose 73, 0x41fa, 0x40f2, 0x1c08
+ax_pose_terminator
+sHuntailPose212:
+ax_pose 74, 0x81e3, 0x80f3, 0x1c00
+ax_pose 75, 0x01f3, 0x4103, 0x1c08
+ax_pose 76, 0x01fb, 0x0113, 0x1c0c
+ax_pose_terminator
+sHuntailPose213:
+ax_pose 8, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sHuntailPose214:
+ax_pose 65, 0x41eb, 0x80f1, 0x1c00
+ax_pose 66, 0x41fb, 0x00f1, 0x1c08
+ax_pose 67, 0x01ec, 0x0111, 0x1c0a
+ax_pose_terminator
+sHuntailPose215:
+ax_pose 68, 0x81dd, 0x80f1, 0x1c00
+ax_pose 69, 0x01ed, 0x4101, 0x1c08
+ax_pose 70, 0x01e5, 0x0109, 0x1c0c
+ax_pose 71, 0x01ec, 0x0111, 0x1c0d
+ax_pose_terminator
+sHuntailPose216:
+ax_pose 4, 0x01e5, 0x80f1, 0x1c00
+ax_pose_terminator
+sHuntailPose217:
+ax_pose 58, 0x41ec, 0x80f1, 0x1c00
+ax_pose 59, 0x41fc, 0x00f1, 0x1c08
+ax_pose 60, 0x41e4, 0x0101, 0x1c0a
+ax_pose_terminator
+sHuntailPose218:
+ax_pose 61, 0x81e3, 0x80f2, 0x1c00
+ax_pose 62, 0x81f3, 0x0102, 0x1c08
+ax_pose 63, 0x81e3, 0x410a, 0x1c0a
+ax_pose 64, 0x81e9, 0x0112, 0x1c0e
+ax_pose_terminator
+sHuntailPose219:
+ax_pose 53, 0x81e4, 0x80f7, 0x1c00
+ax_pose 54, 0x01dc, 0x00fc, 0x1c08
+ax_pose_terminator
+sHuntailPose220:
+ax_pose 58, 0x41ec, 0x80f0, 0x1c00
+ax_pose 59, 0x41fc, 0x00f0, 0x1c08
+ax_pose 60, 0x41e4, 0x0100, 0x1c0a
+ax_pose_terminator
+sHuntailPose221:
+ax_pose 65, 0x41ec, 0x80ef, 0x1c00
+ax_pose 66, 0x41fc, 0x00ef, 0x1c08
+ax_pose 67, 0x01ed, 0x010f, 0x1c0a
+ax_pose_terminator
+sHuntailPose222:
+ax_pose 72, 0x41e9, 0x80ef, 0x1c00
+ax_pose 73, 0x41f9, 0x40ef, 0x1c08
+ax_pose_terminator
+sHuntailPose223:
+ax_pose 77, 0x81e6, 0x80f9, 0x1c00
+ax_pose_terminator
+sHuntailPose224:
+ax_pose 72, 0x41e9, 0x90f1, 0x1c00
+ax_pose 73, 0x41f9, 0x50f1, 0x1c08
+ax_pose_terminator
+sHuntailPose225:
+ax_pose 65, 0x41ec, 0x90f1, 0x1c00
+ax_pose 66, 0x41fc, 0x1101, 0x1c08
+ax_pose 67, 0x01ed, 0x10e9, 0x1c0a
+ax_pose_terminator
+sHuntailPose226:
+ax_pose 58, 0x41ec, 0x90f0, 0x1c00
+ax_pose 59, 0x41fc, 0x1100, 0x1c08
+ax_pose 60, 0x41e4, 0x10f0, 0x1c0a
+ax_pose_terminator
+sHuntailPose227:
+ax_pose 0, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose228:
+ax_pose 4, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose229:
+ax_pose 8, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose230:
+ax_pose 14, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sHuntailPose231:
+ax_pose 18, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sHuntailPose232:
+ax_pose 14, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose233:
+ax_pose 8, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sHuntailPose234:
+ax_pose 4, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+.align 2
+sHuntailAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_1_2:
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_1_3:
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_1_4:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_1_5:
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_1_6:
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_1_7:
+ax_anim 8, 0, 24, 0, 0, 0, 0,
+ax_anim 8, 0, 25, 0, 0, 0, 0,
+ax_anim 8, 0, 26, 0, 0, 0, 0,
+ax_anim 8, 0, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_1_8:
+ax_anim 8, 0, 28, 0, 0, 0, 0,
+ax_anim 8, 0, 29, 0, 0, 0, 0,
+ax_anim 8, 0, 30, 0, 0, 0, 0,
+ax_anim 8, 0, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 4, 0, 32, 0, -2, 0, -2,
+ax_anim 1, 0, 33, 0, 7, 0, 7,
+ax_anim 1, 2, 33, 0, 12, 0, 12,
+ax_anim 1, 0, 33, 0, 16, 0, 16,
+ax_anim 2, 0, 34, 0, 18, 0, 18,
+ax_anim 2, 1, 33, 0, 16, 0, 16,
+ax_anim 2, 0, 34, 0, 18, 0, 18,
+ax_anim 2, 0, 33, 0, 16, 0, 16,
+ax_anim 2, 0, 34, 0, 18, 0, 18,
+ax_anim 2, 0, 32, 0, 7, 0, 7,
+ax_anim_terminator
+sHuntailAnims_2_2:
+ax_anim 2, 0, 35, -1, -1, -1, -1,
+ax_anim 4, 0, 35, -2, -2, -2, -2,
+ax_anim 1, 0, 36, 4, 4, 4, 4,
+ax_anim 1, 2, 36, 8, 8, 8, 8,
+ax_anim 1, 0, 36, 14, 14, 14, 14,
+ax_anim 2, 0, 37, 14, 16, 14, 16,
+ax_anim 2, 1, 36, 14, 14, 14, 14,
+ax_anim 2, 0, 37, 14, 16, 14, 16,
+ax_anim 2, 0, 36, 14, 14, 14, 14,
+ax_anim 2, 0, 37, 14, 16, 14, 16,
+ax_anim 2, 0, 35, 5, 7, 5, 7,
+ax_anim_terminator
+sHuntailAnims_2_3:
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 4, 0, 38, -2, 0, -2, 0,
+ax_anim 1, 0, 39, 4, 0, 4, 0,
+ax_anim 1, 2, 39, 8, 0, 8, 0,
+ax_anim 1, 0, 39, 14, 0, 14, 0,
+ax_anim 2, 0, 40, 14, 1, 14, 1,
+ax_anim 2, 1, 39, 14, 0, 14, 0,
+ax_anim 2, 0, 40, 14, 1, 14, 1,
+ax_anim 2, 0, 39, 14, 0, 14, 0,
+ax_anim 2, 0, 40, 14, 1, 14, 1,
+ax_anim 2, 0, 38, 5, 0, 5, 0,
+ax_anim_terminator
+sHuntailAnims_2_4:
+ax_anim 2, 0, 41, -1, 1, -1, 1,
+ax_anim 4, 0, 41, -2, 2, -2, 2,
+ax_anim 1, 0, 42, 4, -4, 4, -4,
+ax_anim 1, 2, 42, 8, -8, 8, -8,
+ax_anim 1, 0, 42, 14, -14, 14, -14,
+ax_anim 2, 0, 43, 14, -16, 14, -16,
+ax_anim 2, 1, 42, 14, -14, 14, -14,
+ax_anim 2, 0, 43, 14, -16, 14, -16,
+ax_anim 2, 0, 42, 14, -14, 14, -14,
+ax_anim 2, 0, 43, 14, -16, 14, -16,
+ax_anim 2, 0, 41, 5, -7, 5, -7,
+ax_anim_terminator
+sHuntailAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 45, 0, -5, 0, -5,
+ax_anim 1, 2, 45, 0, -8, 0, -8,
+ax_anim 1, 0, 45, 0, -10, 0, -10,
+ax_anim 2, 0, 46, 0, -13, 0, -13,
+ax_anim 2, 1, 45, 0, -10, 0, -10,
+ax_anim 2, 0, 46, 0, -13, 0, -13,
+ax_anim 2, 0, 45, 0, -10, 0, -10,
+ax_anim 2, 0, 46, 0, -13, 0, -13,
+ax_anim 2, 0, 44, 0, -7, 0, -7,
+ax_anim_terminator
+sHuntailAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 4, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 48, -4, -4, -4, -4,
+ax_anim 1, 2, 48, -8, -8, -8, -8,
+ax_anim 1, 0, 48, -14, -14, -14, -14,
+ax_anim 2, 0, 49, -14, -16, -14, -16,
+ax_anim 2, 1, 48, -14, -14, -14, -14,
+ax_anim 2, 0, 49, -14, -16, -14, -16,
+ax_anim 2, 0, 48, -14, -14, -14, -14,
+ax_anim 2, 0, 49, -14, -16, -14, -16,
+ax_anim 2, 0, 47, -5, -7, -5, -7,
+ax_anim_terminator
+sHuntailAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 4, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 51, -4, 0, -4, 0,
+ax_anim 1, 2, 51, -8, 0, -8, 0,
+ax_anim 1, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 52, -14, 1, -14, 1,
+ax_anim 2, 1, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 52, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 52, -14, 1, -14, 1,
+ax_anim 2, 0, 50, -5, 0, -5, 0,
+ax_anim_terminator
+sHuntailAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 54, -4, 4, -4, 4,
+ax_anim 1, 2, 54, -8, 8, -8, 8,
+ax_anim 1, 0, 54, -14, 14, -14, 14,
+ax_anim 2, 0, 55, -14, 16, -14, 16,
+ax_anim 2, 1, 54, -14, 14, -14, 14,
+ax_anim 2, 0, 55, -14, 16, -14, 16,
+ax_anim 2, 0, 54, -14, 14, -14, 14,
+ax_anim 2, 0, 55, -14, 16, -14, 16,
+ax_anim 2, 0, 53, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sHuntailAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 7, 0, 7,
+ax_anim 1, 2, 57, 0, 12, 0, 12,
+ax_anim 1, 0, 57, 0, 16, 0, 16,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 1, 57, 0, 16, 0, 16,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 0, 57, 0, 16, 0, 16,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 0, 56, 0, 7, 0, 7,
+ax_anim_terminator
+sHuntailAnims_3_2:
+ax_anim 2, 0, 59, -1, -1, -1, -1,
+ax_anim 4, 0, 59, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 4, 4, 4, 4,
+ax_anim 1, 2, 60, 8, 8, 8, 8,
+ax_anim 1, 0, 60, 14, 14, 14, 14,
+ax_anim 2, 0, 61, 14, 16, 14, 16,
+ax_anim 2, 1, 60, 14, 14, 14, 14,
+ax_anim 2, 0, 61, 14, 16, 14, 16,
+ax_anim 2, 0, 60, 14, 14, 14, 14,
+ax_anim 2, 0, 61, 14, 16, 14, 16,
+ax_anim 2, 0, 59, 5, 7, 5, 7,
+ax_anim_terminator
+sHuntailAnims_3_3:
+ax_anim 2, 0, 62, -1, 0, -1, 0,
+ax_anim 4, 0, 62, -2, 0, -2, 0,
+ax_anim 1, 0, 63, 4, 0, 4, 0,
+ax_anim 1, 2, 63, 8, 0, 8, 0,
+ax_anim 1, 0, 63, 14, 0, 14, 0,
+ax_anim 2, 0, 64, 14, 1, 14, 1,
+ax_anim 2, 1, 63, 14, 0, 14, 0,
+ax_anim 2, 0, 64, 14, 1, 14, 1,
+ax_anim 2, 0, 63, 14, 0, 14, 0,
+ax_anim 2, 0, 64, 14, 1, 14, 1,
+ax_anim 2, 0, 62, 5, 0, 5, 0,
+ax_anim_terminator
+sHuntailAnims_3_4:
+ax_anim 2, 0, 65, -1, 1, -1, 1,
+ax_anim 4, 0, 65, -2, 2, -2, 2,
+ax_anim 1, 0, 66, 4, -4, 4, -4,
+ax_anim 1, 2, 66, 8, -8, 8, -8,
+ax_anim 1, 0, 66, 14, -14, 14, -14,
+ax_anim 2, 0, 67, 14, -16, 14, -16,
+ax_anim 2, 1, 66, 14, -14, 14, -14,
+ax_anim 2, 0, 67, 14, -16, 14, -16,
+ax_anim 2, 0, 66, 14, -14, 14, -14,
+ax_anim 2, 0, 67, 14, -16, 14, -16,
+ax_anim 2, 0, 65, 5, -7, 5, -7,
+ax_anim_terminator
+sHuntailAnims_3_5:
+ax_anim 2, 0, 68, 0, 1, 0, 1,
+ax_anim 4, 0, 68, 0, 2, 0, 2,
+ax_anim 1, 0, 69, 0, -5, 0, -5,
+ax_anim 1, 2, 69, 0, -8, 0, -8,
+ax_anim 1, 0, 69, 0, -10, 0, -10,
+ax_anim 2, 0, 70, 0, -13, 0, -13,
+ax_anim 2, 1, 69, 0, -10, 0, -10,
+ax_anim 2, 0, 70, 0, -13, 0, -13,
+ax_anim 2, 0, 69, 0, -10, 0, -10,
+ax_anim 2, 0, 70, 0, -13, 0, -13,
+ax_anim 2, 0, 68, 0, -7, 0, -7,
+ax_anim_terminator
+sHuntailAnims_3_6:
+ax_anim 2, 0, 71, 1, 1, 1, 1,
+ax_anim 4, 0, 71, 2, 2, 2, 2,
+ax_anim 1, 0, 72, -4, -4, -4, -4,
+ax_anim 1, 2, 72, -8, -8, -8, -8,
+ax_anim 1, 0, 72, -14, -14, -14, -14,
+ax_anim 2, 0, 73, -14, -16, -14, -16,
+ax_anim 2, 1, 72, -14, -14, -14, -14,
+ax_anim 2, 0, 73, -14, -16, -14, -16,
+ax_anim 2, 0, 72, -14, -14, -14, -14,
+ax_anim 2, 0, 73, -14, -16, -14, -16,
+ax_anim 2, 0, 71, -5, -7, -5, -7,
+ax_anim_terminator
+sHuntailAnims_3_7:
+ax_anim 2, 0, 74, 1, 0, 1, 0,
+ax_anim 4, 0, 74, 2, 0, 2, 0,
+ax_anim 1, 0, 75, -4, 0, -4, 0,
+ax_anim 1, 2, 75, -8, 0, -8, 0,
+ax_anim 1, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 76, -14, 1, -14, 1,
+ax_anim 2, 1, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 76, -14, 1, -14, 1,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 76, -14, 1, -14, 1,
+ax_anim 2, 0, 74, -5, 0, -5, 0,
+ax_anim_terminator
+sHuntailAnims_3_8:
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim 4, 0, 77, 2, -2, 2, -2,
+ax_anim 1, 0, 78, -4, 4, -4, 4,
+ax_anim 1, 2, 78, -8, 8, -8, 8,
+ax_anim 1, 0, 78, -14, 14, -14, 14,
+ax_anim 2, 0, 79, -14, 16, -14, 16,
+ax_anim 2, 1, 78, -14, 14, -14, 14,
+ax_anim 2, 0, 79, -14, 16, -14, 16,
+ax_anim 2, 0, 78, -14, 14, -14, 14,
+ax_anim 2, 0, 79, -14, 16, -14, 16,
+ax_anim 2, 0, 77, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sHuntailAnims_4_1:
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 6, 2, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim_terminator
+sHuntailAnims_4_2:
+ax_anim 2, 0, 84, -2, -2, -2, -2,
+ax_anim 6, 2, 84, -3, -3, -3, -3,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 3, 1, 3, 1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 3, 1, 3, 1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 3, 1, 3, 1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim_terminator
+sHuntailAnims_4_3:
+ax_anim 2, 0, 87, -2, 0, -2, 0,
+ax_anim 6, 2, 87, -3, 0, -3, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 1, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim_terminator
+sHuntailAnims_4_4:
+ax_anim 2, 0, 90, -2, 2, -2, 2,
+ax_anim 6, 2, 90, -3, 3, -3, 3,
+ax_anim 2, 0, 89, -1, 1, -1, 1,
+ax_anim 2, 1, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim_terminator
+sHuntailAnims_4_5:
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 6, 2, 93, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 2, 1, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim_terminator
+sHuntailAnims_4_6:
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 6, 2, 96, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 1, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -1, -3, -1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -1, -3, -1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -1, -3, -1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim_terminator
+sHuntailAnims_4_7:
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 6, 2, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 1, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, 1, -3, 1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, 1, -3, 1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, 1, -3, 1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim_terminator
+sHuntailAnims_4_8:
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 6, 2, 102, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sHuntailAnims_5_1:
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_5_2:
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_5_3:
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_5_4:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_5_5:
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_5_6:
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_5_7:
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_5_8:
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sHuntailAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sHuntailAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sHuntailAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sHuntailAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sHuntailAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sHuntailAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sHuntailAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sHuntailAnims_8_1:
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 0, -1, 0, 0,
+ax_anim 10, 0, 148, 0, -2, 0, 0,
+ax_anim 10, 0, 149, 0, -3, 0, 0,
+ax_anim 10, 0, 146, 0, -3, 0, 0,
+ax_anim 10, 0, 147, 0, -2, 0, 0,
+ax_anim 10, 0, 148, 0, -1, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_8_2:
+ax_anim 10, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 151, 0, -2, 0, 0,
+ax_anim 10, 0, 152, 0, -3, 0, 0,
+ax_anim 10, 0, 153, 0, -3, 0, 0,
+ax_anim 10, 0, 150, 0, -3, 0, 0,
+ax_anim 10, 0, 151, 0, -3, 0, 0,
+ax_anim 10, 0, 152, 0, -2, 0, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_8_3:
+ax_anim 10, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, -2, 0, 0,
+ax_anim 10, 0, 156, 0, -4, 0, 0,
+ax_anim 10, 0, 157, 0, -4, 0, 0,
+ax_anim 10, 0, 154, 0, -4, 0, 0,
+ax_anim 10, 0, 155, 0, -4, 0, 0,
+ax_anim 10, 0, 156, 0, -3, 0, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_8_4:
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, -2, 0, 0,
+ax_anim 10, 0, 160, 0, -3, 0, 0,
+ax_anim 10, 0, 161, 0, -3, 0, 0,
+ax_anim 10, 0, 158, 0, -3, 0, 0,
+ax_anim 10, 0, 159, 0, -3, 0, 0,
+ax_anim 10, 0, 160, 0, -2, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_8_5:
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 163, 0, -1, 0, 0,
+ax_anim 10, 0, 164, 0, -2, 0, 0,
+ax_anim 10, 0, 165, 0, -3, 0, 0,
+ax_anim 10, 0, 162, 0, -3, 0, 0,
+ax_anim 10, 0, 163, 0, -2, 0, 0,
+ax_anim 10, 0, 164, 0, -1, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_8_6:
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 167, 0, -2, 0, 0,
+ax_anim 10, 0, 168, 0, -3, 0, 0,
+ax_anim 10, 0, 169, 0, -3, 0, 0,
+ax_anim 10, 0, 166, 0, -3, 0, 0,
+ax_anim 10, 0, 167, 0, -3, 0, 0,
+ax_anim 10, 0, 168, 0, -2, 0, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_8_7:
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, -2, 0, 0,
+ax_anim 10, 0, 172, 0, -4, 0, 0,
+ax_anim 10, 0, 173, 0, -4, 0, 0,
+ax_anim 10, 0, 170, 0, -4, 0, 0,
+ax_anim 10, 0, 171, 0, -4, 0, 0,
+ax_anim 10, 0, 172, 0, -3, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_8_8:
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, -2, 0, 0,
+ax_anim 10, 0, 176, 0, -3, 0, 0,
+ax_anim 10, 0, 177, 0, -3, 0, 0,
+ax_anim 10, 0, 174, 0, -3, 0, 0,
+ax_anim 10, 0, 175, 0, -3, 0, 0,
+ax_anim 10, 0, 176, 0, -2, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 7, 4, 6, 3,
+ax_anim 2, 0, 180, 9, 13, 8, 9,
+ax_anim 2, 0, 181, 6, 19, 7, 15,
+ax_anim 3, 0, 182, 0, 22, 0, 18,
+ax_anim 2, 3, 183, -6, 19, -7, 15,
+ax_anim 2, 0, 184, -9, 13, -8, 9,
+ax_anim 1, 0, 185, -7, 4, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 11, 0, 11, 0,
+ax_anim 2, 0, 179, 23, 6, 23, 6,
+ax_anim 2, 0, 180, 23, 15, 23, 13,
+ax_anim 3, 0, 181, 19, 21, 19, 19,
+ax_anim 2, 3, 182, 11, 23, 11, 21,
+ax_anim 2, 0, 183, 4, 17, 4, 17,
+ax_anim 1, 0, 184, 0, 9, 0, 9,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 2, -4, 2, -4,
+ax_anim 2, 0, 178, 10, -6, 10, -6,
+ax_anim 2, 0, 179, 18, -3, 18, -4,
+ax_anim 3, 0, 180, 20, 5, 20, 1,
+ax_anim 2, 3, 181, 16, 10, 16, 8,
+ax_anim 2, 0, 182, 9, 13, 9, 12,
+ax_anim 1, 0, 183, 2, 9, 2, 9,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -5, -1, -5,
+ax_anim 2, 0, 185, 2, -13, 2, -13,
+ax_anim 2, 0, 178, 10, -17, 10, -19,
+ax_anim 3, 0, 179, 18, -15, 18, -19,
+ax_anim 2, 3, 180, 19, -9, 19, -11,
+ax_anim 2, 0, 181, 17, -3, 17, -3,
+ax_anim 1, 0, 182, 7, 1, 7, 1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -2, -6, -2,
+ax_anim 2, 0, 184, -9, -7, -9, -8,
+ax_anim 2, 0, 185, -8, -12, -8, -16,
+ax_anim 3, 0, 178, 0, -14, 0, -20,
+ax_anim 2, 3, 179, 7, -12, 7, -16,
+ax_anim 2, 0, 180, 8, -7, 8, -8,
+ax_anim 1, 0, 181, 6, -2, 6, -2,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -5, 1, -5,
+ax_anim 2, 0, 179, -2, -13, -2, -13,
+ax_anim 2, 0, 178, -10, -17, -10, -19,
+ax_anim 3, 0, 185, -18, -15, -18, -19,
+ax_anim 2, 3, 184, -19, -9, -19, -11,
+ax_anim 2, 0, 183, -17, -3, -17, -3,
+ax_anim 1, 0, 182, -7, 1, -7, 1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -2, -4, -2, -4,
+ax_anim 2, 0, 178, -10, -6, -10, -6,
+ax_anim 2, 0, 185, -18, -3, -18, -4,
+ax_anim 3, 0, 184, -20, 5, -20, 1,
+ax_anim 2, 3, 183, -16, 10, -16, 8,
+ax_anim 2, 0, 182, -9, 13, -9, 12,
+ax_anim 1, 0, 181, -2, 9, -2, 9,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -11, 0, -11, 0,
+ax_anim 2, 0, 185, -23, 6, -23, 6,
+ax_anim 2, 0, 184, -23, 15, -23, 13,
+ax_anim 3, 0, 183, -19, 21, -19, 19,
+ax_anim 2, 3, 182, -11, 23, -11, 21,
+ax_anim 2, 0, 181, -4, 17, -4, 17,
+ax_anim 1, 0, 180, 0, 9, 0, 9,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 2, 0, 196, 0, -15, 0, 0,
+ax_anim 1, 0, 196, 0, -6, 0, 0,
+ax_anim 2, 2, 194, 0, 5, 0, 0,
+ax_anim_terminator
+sHuntailAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -15, 0, 0,
+ax_anim 1, 0, 199, 0, -6, 0, 0,
+ax_anim 2, 2, 197, 0, 5, 0, 0,
+ax_anim_terminator
+sHuntailAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -19, 0, 0,
+ax_anim 2, 0, 202, 0, -15, 0, 0,
+ax_anim 1, 0, 202, 0, -6, 0, 0,
+ax_anim 2, 2, 200, 0, 6, 0, 0,
+ax_anim_terminator
+sHuntailAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -20, 0, 0,
+ax_anim 3, 0, 205, 0, -19, 0, 0,
+ax_anim 2, 0, 205, 0, -15, 0, 0,
+ax_anim 1, 0, 205, 0, -6, 0, 0,
+ax_anim 2, 2, 203, 0, 5, 0, 0,
+ax_anim_terminator
+sHuntailAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -18, 0, 0,
+ax_anim 2, 0, 208, 0, -15, 0, 0,
+ax_anim 1, 0, 208, 0, -6, 0, 0,
+ax_anim 2, 2, 206, 0, 7, 0, 0,
+ax_anim_terminator
+sHuntailAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -20, 0, 0,
+ax_anim 3, 0, 211, 0, -19, 0, 0,
+ax_anim 2, 0, 211, 0, -15, 0, 0,
+ax_anim 1, 0, 211, 0, -6, 0, 0,
+ax_anim 2, 2, 209, 0, 5, 0, 0,
+ax_anim_terminator
+sHuntailAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -19, 0, 0,
+ax_anim 2, 0, 214, 0, -15, 0, 0,
+ax_anim 1, 0, 214, 0, -6, 0, 0,
+ax_anim 2, 2, 212, 0, 6, 0, 0,
+ax_anim_terminator
+sHuntailAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 2, 0, 217, 0, -15, 0, 0,
+ax_anim 1, 0, 217, 0, -6, 0, 0,
+ax_anim 2, 2, 215, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHuntailAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sHuntailGfx1:
+.incbin "baserom.gba", 0x1524824, 0x200
+sHuntailSprites1:
+ax_sprite sHuntailGfx1, 0x200
+ax_sprite_terminator
+sHuntailGfx2:
+.incbin "baserom.gba", 0x1524A34, 0x200
+sHuntailSprites2:
+ax_sprite sHuntailGfx2, 0x200
+ax_sprite_terminator
+sHuntailGfx3:
+.incbin "baserom.gba", 0x1524C44, 0x200
+sHuntailSprites3:
+ax_sprite sHuntailGfx3, 0x200
+ax_sprite_terminator
+sHuntailGfx4:
+.incbin "baserom.gba", 0x1524E54, 0x200
+sHuntailSprites4:
+ax_sprite sHuntailGfx4, 0x200
+ax_sprite_terminator
+sHuntailGfx5:
+.incbin "baserom.gba", 0x1525064, 0x200
+sHuntailSprites5:
+ax_sprite sHuntailGfx5, 0x200
+ax_sprite_terminator
+sHuntailGfx6:
+.incbin "baserom.gba", 0x1525274, 0x200
+sHuntailSprites6:
+ax_sprite sHuntailGfx6, 0x200
+ax_sprite_terminator
+sHuntailGfx7:
+.incbin "baserom.gba", 0x1525484, 0x200
+sHuntailSprites7:
+ax_sprite sHuntailGfx7, 0x200
+ax_sprite_terminator
+sHuntailGfx8:
+.incbin "baserom.gba", 0x1525694, 0x200
+sHuntailSprites8:
+ax_sprite sHuntailGfx8, 0x200
+ax_sprite_terminator
+sHuntailGfx9:
+.incbin "baserom.gba", 0x15258A4, 0x200
+sHuntailSprites9:
+ax_sprite sHuntailGfx9, 0x200
+ax_sprite_terminator
+sHuntailGfx10:
+.incbin "baserom.gba", 0x1525AB4, 0x200
+sHuntailSprites10:
+ax_sprite sHuntailGfx10, 0x200
+ax_sprite_terminator
+sHuntailGfx11:
+.incbin "baserom.gba", 0x1525CC4, 0x200
+sHuntailSprites11:
+ax_sprite sHuntailGfx11, 0x200
+ax_sprite_terminator
+sHuntailGfx12:
+.incbin "baserom.gba", 0x1525ED4, 0x100
+sHuntailSprites12:
+ax_sprite sHuntailGfx12, 0x100
+ax_sprite_terminator
+sHuntailGfx13:
+.incbin "baserom.gba", 0x1525FE4, 0x80
+sHuntailSprites13:
+ax_sprite sHuntailGfx13, 0x80
+ax_sprite_terminator
+sHuntailGfx14:
+.incbin "baserom.gba", 0x1526074, 0x20
+sHuntailSprites14:
+ax_sprite sHuntailGfx14, 0x20
+ax_sprite_terminator
+sHuntailGfx15:
+.incbin "baserom.gba", 0x15260A4, 0x200
+sHuntailSprites15:
+ax_sprite sHuntailGfx15, 0x200
+ax_sprite_terminator
+sHuntailGfx16:
+.incbin "baserom.gba", 0x15262B4, 0x200
+sHuntailSprites16:
+ax_sprite sHuntailGfx16, 0x200
+ax_sprite_terminator
+sHuntailGfx17:
+.incbin "baserom.gba", 0x15264C4, 0x200
+sHuntailSprites17:
+ax_sprite sHuntailGfx17, 0x200
+ax_sprite_terminator
+sHuntailGfx18:
+.incbin "baserom.gba", 0x15266D4, 0x200
+sHuntailSprites18:
+ax_sprite sHuntailGfx18, 0x200
+ax_sprite_terminator
+sHuntailGfx19:
+.incbin "baserom.gba", 0x15268E4, 0x200
+sHuntailSprites19:
+ax_sprite sHuntailGfx19, 0x200
+ax_sprite_terminator
+sHuntailGfx20:
+.incbin "baserom.gba", 0x1526AF4, 0x200
+sHuntailSprites20:
+ax_sprite sHuntailGfx20, 0x200
+ax_sprite_terminator
+sHuntailGfx21:
+.incbin "baserom.gba", 0x1526D04, 0x200
+sHuntailSprites21:
+ax_sprite sHuntailGfx21, 0x200
+ax_sprite_terminator
+sHuntailGfx22:
+.incbin "baserom.gba", 0x1526F14, 0x200
+sHuntailSprites22:
+ax_sprite sHuntailGfx22, 0x200
+ax_sprite_terminator
+sHuntailGfx23:
+.incbin "baserom.gba", 0x1527124, 0x100
+sHuntailSprites23:
+ax_sprite sHuntailGfx23, 0x100
+ax_sprite_terminator
+sHuntailGfx24:
+.incbin "baserom.gba", 0x1527234, 0x40
+sHuntailSprites24:
+ax_sprite sHuntailGfx24, 0x40
+ax_sprite_terminator
+sHuntailGfx25:
+.incbin "baserom.gba", 0x1527284, 0x100
+sHuntailSprites25:
+ax_sprite sHuntailGfx25, 0x100
+ax_sprite_terminator
+sHuntailGfx26:
+.incbin "baserom.gba", 0x1527394, 0x40
+sHuntailSprites26:
+ax_sprite sHuntailGfx26, 0x40
+ax_sprite_terminator
+sHuntailGfx27:
+.incbin "baserom.gba", 0x15273E4, 0xE0
+sHuntailSprites27:
+ax_sprite sHuntailGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHuntailGfx28:
+.incbin "baserom.gba", 0x15274DC, 0x40
+sHuntailSprites28:
+ax_sprite sHuntailGfx28, 0x40
+ax_sprite_terminator
+sHuntailGfx29:
+.incbin "baserom.gba", 0x152752C, 0x20
+sHuntailSprites29:
+ax_sprite sHuntailGfx29, 0x20
+ax_sprite_terminator
+sHuntailGfx30:
+.incbin "baserom.gba", 0x152755C, 0x20
+sHuntailSprites30:
+ax_sprite sHuntailGfx30, 0x20
+ax_sprite_terminator
+sHuntailGfx31:
+.incbin "baserom.gba", 0x152758C, 0xE0
+sHuntailSprites31:
+ax_sprite sHuntailGfx31, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHuntailGfx32:
+.incbin "baserom.gba", 0x1527684, 0x40
+sHuntailSprites32:
+ax_sprite sHuntailGfx32, 0x40
+ax_sprite_terminator
+sHuntailGfx33:
+.incbin "baserom.gba", 0x15276D4, 0x20
+sHuntailSprites33:
+ax_sprite sHuntailGfx33, 0x20
+ax_sprite_terminator
+sHuntailGfx34:
+.incbin "baserom.gba", 0x1527704, 0x20
+sHuntailSprites34:
+ax_sprite sHuntailGfx34, 0x20
+ax_sprite_terminator
+sHuntailGfx35:
+.incbin "baserom.gba", 0x1527734, 0x20
+sHuntailGfx35_1:
+.incbin "baserom.gba", 0x1527754, 0xC0
+sHuntailSprites35:
+ax_sprite sHuntailGfx35, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHuntailGfx35_1, 0xc0
+ax_sprite_terminator
+sHuntailGfx36:
+.incbin "baserom.gba", 0x1527834, 0x40
+sHuntailSprites36:
+ax_sprite sHuntailGfx36, 0x40
+ax_sprite_terminator
+sHuntailGfx37:
+.incbin "baserom.gba", 0x1527884, 0x60
+sHuntailSprites37:
+ax_sprite sHuntailGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHuntailGfx38:
+.incbin "baserom.gba", 0x15278FC, 0xC0
+sHuntailSprites38:
+ax_sprite 0, 0x40
+ax_sprite sHuntailGfx38, 0xc0
+ax_sprite_terminator
+sHuntailGfx39:
+.incbin "baserom.gba", 0x15279D4, 0x40
+sHuntailSprites39:
+ax_sprite sHuntailGfx39, 0x40
+ax_sprite_terminator
+sHuntailGfx40:
+.incbin "baserom.gba", 0x1527A24, 0x60
+sHuntailSprites40:
+ax_sprite sHuntailGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHuntailGfx41:
+.incbin "baserom.gba", 0x1527A9C, 0x60
+sHuntailGfx41_1:
+.incbin "baserom.gba", 0x1527AFC, 0x80
+sHuntailSprites41:
+ax_sprite sHuntailGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHuntailGfx41_1, 0x80
+ax_sprite_terminator
+sHuntailGfx42:
+.incbin "baserom.gba", 0x1527B9C, 0x40
+sHuntailSprites42:
+ax_sprite sHuntailGfx42, 0x40
+ax_sprite_terminator
+sHuntailGfx43:
+.incbin "baserom.gba", 0x1527BEC, 0x40
+sHuntailSprites43:
+ax_sprite sHuntailGfx43, 0x40
+ax_sprite_terminator
+sHuntailGfx44:
+.incbin "baserom.gba", 0x1527C3C, 0x20
+sHuntailSprites44:
+ax_sprite sHuntailGfx44, 0x20
+ax_sprite_terminator
+sHuntailGfx45:
+.incbin "baserom.gba", 0x1527C6C, 0x20
+sHuntailSprites45:
+ax_sprite sHuntailGfx45, 0x20
+ax_sprite_terminator
+sHuntailGfx46:
+.incbin "baserom.gba", 0x1527C9C, 0x60
+sHuntailGfx46_1:
+.incbin "baserom.gba", 0x1527CFC, 0x80
+sHuntailSprites46:
+ax_sprite sHuntailGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHuntailGfx46_1, 0x80
+ax_sprite_terminator
+sHuntailGfx47:
+.incbin "baserom.gba", 0x1527D9C, 0x40
+sHuntailSprites47:
+ax_sprite sHuntailGfx47, 0x40
+ax_sprite_terminator
+sHuntailGfx48:
+.incbin "baserom.gba", 0x1527DEC, 0x40
+sHuntailSprites48:
+ax_sprite sHuntailGfx48, 0x40
+ax_sprite_terminator
+sHuntailGfx49:
+.incbin "baserom.gba", 0x1527E3C, 0x20
+sHuntailSprites49:
+ax_sprite sHuntailGfx49, 0x20
+ax_sprite_terminator
+sHuntailGfx50:
+.incbin "baserom.gba", 0x1527E6C, 0x100
+sHuntailSprites50:
+ax_sprite sHuntailGfx50, 0x100
+ax_sprite_terminator
+sHuntailGfx51:
+.incbin "baserom.gba", 0x1527F7C, 0x20
+sHuntailSprites51:
+ax_sprite sHuntailGfx51, 0x20
+ax_sprite_terminator
+sHuntailGfx52:
+.incbin "baserom.gba", 0x1527FAC, 0x100
+sHuntailSprites52:
+ax_sprite sHuntailGfx52, 0x100
+ax_sprite_terminator
+sHuntailGfx53:
+.incbin "baserom.gba", 0x15280BC, 0x20
+sHuntailSprites53:
+ax_sprite sHuntailGfx53, 0x20
+ax_sprite_terminator
+sHuntailGfx54:
+.incbin "baserom.gba", 0x15280EC, 0x100
+sHuntailSprites54:
+ax_sprite sHuntailGfx54, 0x100
+ax_sprite_terminator
+sHuntailGfx55:
+.incbin "baserom.gba", 0x15281FC, 0x20
+sHuntailSprites55:
+ax_sprite sHuntailGfx55, 0x20
+ax_sprite_terminator
+sHuntailGfx56:
+.incbin "baserom.gba", 0x152822C, 0x100
+sHuntailSprites56:
+ax_sprite sHuntailGfx56, 0x100
+ax_sprite_terminator
+sHuntailGfx57:
+.incbin "baserom.gba", 0x152833C, 0x20
+sHuntailSprites57:
+ax_sprite sHuntailGfx57, 0x20
+ax_sprite_terminator
+sHuntailGfx58:
+.incbin "baserom.gba", 0x152836C, 0x20
+sHuntailSprites58:
+ax_sprite sHuntailGfx58, 0x20
+ax_sprite_terminator
+sHuntailGfx59:
+.incbin "baserom.gba", 0x152839C, 0xE0
+sHuntailSprites59:
+ax_sprite sHuntailGfx59, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHuntailGfx60:
+.incbin "baserom.gba", 0x1528494, 0x40
+sHuntailSprites60:
+ax_sprite sHuntailGfx60, 0x40
+ax_sprite_terminator
+sHuntailGfx61:
+.incbin "baserom.gba", 0x15284E4, 0x40
+sHuntailSprites61:
+ax_sprite sHuntailGfx61, 0x40
+ax_sprite_terminator
+sHuntailGfx62:
+.incbin "baserom.gba", 0x1528534, 0xC0
+sHuntailSprites62:
+ax_sprite 0, 0x40
+ax_sprite sHuntailGfx62, 0xc0
+ax_sprite_terminator
+sHuntailGfx63:
+.incbin "baserom.gba", 0x152860C, 0x40
+sHuntailSprites63:
+ax_sprite sHuntailGfx63, 0x40
+ax_sprite_terminator
+sHuntailGfx64:
+.incbin "baserom.gba", 0x152865C, 0x60
+sHuntailSprites64:
+ax_sprite sHuntailGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHuntailGfx65:
+.incbin "baserom.gba", 0x15286D4, 0x40
+sHuntailSprites65:
+ax_sprite sHuntailGfx65, 0x40
+ax_sprite_terminator
+sHuntailGfx66:
+.incbin "baserom.gba", 0x1528724, 0x100
+sHuntailSprites66:
+ax_sprite sHuntailGfx66, 0x100
+ax_sprite_terminator
+sHuntailGfx67:
+.incbin "baserom.gba", 0x1528834, 0x40
+sHuntailSprites67:
+ax_sprite sHuntailGfx67, 0x40
+ax_sprite_terminator
+sHuntailGfx68:
+.incbin "baserom.gba", 0x1528884, 0x20
+sHuntailSprites68:
+ax_sprite sHuntailGfx68, 0x20
+ax_sprite_terminator
+sHuntailGfx69:
+.incbin "baserom.gba", 0x15288B4, 0x100
+sHuntailSprites69:
+ax_sprite sHuntailGfx69, 0x100
+ax_sprite_terminator
+sHuntailGfx70:
+.incbin "baserom.gba", 0x15289C4, 0x80
+sHuntailSprites70:
+ax_sprite sHuntailGfx70, 0x80
+ax_sprite_terminator
+sHuntailGfx71:
+.incbin "baserom.gba", 0x1528A54, 0x20
+sHuntailSprites71:
+ax_sprite sHuntailGfx71, 0x20
+ax_sprite_terminator
+sHuntailGfx72:
+.incbin "baserom.gba", 0x1528A84, 0x20
+sHuntailSprites72:
+ax_sprite sHuntailGfx72, 0x20
+ax_sprite_terminator
+sHuntailGfx73:
+.incbin "baserom.gba", 0x1528AB4, 0x60
+sHuntailGfx73_1:
+.incbin "baserom.gba", 0x1528B14, 0x80
+sHuntailSprites73:
+ax_sprite sHuntailGfx73, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHuntailGfx73_1, 0x80
+ax_sprite_terminator
+sHuntailGfx74:
+.incbin "baserom.gba", 0x1528BB4, 0x80
+sHuntailSprites74:
+ax_sprite sHuntailGfx74, 0x80
+ax_sprite_terminator
+sHuntailGfx75:
+.incbin "baserom.gba", 0x1528C44, 0xC0
+sHuntailGfx75_1:
+.incbin "baserom.gba", 0x1528D04, 0x20
+sHuntailSprites75:
+ax_sprite sHuntailGfx75, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sHuntailGfx75_1, 0x20
+ax_sprite_terminator
+sHuntailGfx76:
+.incbin "baserom.gba", 0x1528D44, 0x80
+sHuntailSprites76:
+ax_sprite sHuntailGfx76, 0x80
+ax_sprite_terminator
+sHuntailGfx77:
+.incbin "baserom.gba", 0x1528DD4, 0x20
+sHuntailSprites77:
+ax_sprite sHuntailGfx77, 0x20
+ax_sprite_terminator
+sHuntailGfx78:
+.incbin "baserom.gba", 0x1528E04, 0x100
+sHuntailSprites78:
+ax_sprite sHuntailGfx78, 0x100
+ax_sprite_terminator
+sHuntailGfx79:
+.incbin "baserom.gba", 0x1528F14, 0x100
+sHuntailSprites79:
+ax_sprite sHuntailGfx79, 0x100
+ax_sprite_terminator
+sHuntailGfx80:
+.incbin "baserom.gba", 0x1529024, 0x20
+sHuntailSprites80:
+ax_sprite sHuntailGfx80, 0x20
+ax_sprite_terminator
+sHuntailGfx81:
+.incbin "baserom.gba", 0x1529054, 0x200
+sHuntailSprites81:
+ax_sprite sHuntailGfx81, 0x200
+ax_sprite_terminator
+sHuntailGfx82:
+.incbin "baserom.gba", 0x1529264, 0x200
+sHuntailSprites82:
+ax_sprite sHuntailGfx82, 0x200
+ax_sprite_terminator
+sHuntailGfx83:
+.incbin "baserom.gba", 0x1529474, 0x80
+sHuntailSprites83:
+ax_sprite sHuntailGfx83, 0x80
+ax_sprite_terminator
+sHuntailGfx84:
+.incbin "baserom.gba", 0x1529504, 0x40
+sHuntailSprites84:
+ax_sprite sHuntailGfx84, 0x40
+ax_sprite_terminator
+sHuntailGfx85:
+.incbin "baserom.gba", 0x1529554, 0x100
+sHuntailSprites85:
+ax_sprite sHuntailGfx85, 0x100
+ax_sprite_terminator
+sHuntailGfx86:
+.incbin "baserom.gba", 0x1529664, 0x200
+sHuntailSprites86:
+ax_sprite sHuntailGfx86, 0x200
+ax_sprite_terminator
+sHuntailGfx87:
+.incbin "baserom.gba", 0x1529874, 0x40
+sHuntailSprites87:
+ax_sprite sHuntailGfx87, 0x40
+ax_sprite_terminator
+sHuntailGfx88:
+.incbin "baserom.gba", 0x15298C4, 0x20
+sHuntailSprites88:
+ax_sprite sHuntailGfx88, 0x20
+ax_sprite_terminator
+sHuntailGfx89:
+.incbin "baserom.gba", 0x15298F4, 0x20
+sHuntailSprites89:
+ax_sprite sHuntailGfx89, 0x20
+ax_sprite_terminator
+sHuntailGfx90:
+.incbin "baserom.gba", 0x1529924, 0x40
+sHuntailSprites90:
+ax_sprite sHuntailGfx90, 0x40
+ax_sprite_terminator
+sHuntailGfx91:
+.incbin "baserom.gba", 0x1529974, 0x40
+sHuntailSprites91:
+ax_sprite sHuntailGfx91, 0x40
+ax_sprite_terminator
+sHuntailGfx92:
+.incbin "baserom.gba", 0x15299C4, 0x100
+sHuntailSprites92:
+ax_sprite sHuntailGfx92, 0x100
+ax_sprite_terminator
+sHuntailGfx93:
+.incbin "baserom.gba", 0x1529AD4, 0x80
+sHuntailSprites93:
+ax_sprite sHuntailGfx93, 0x80
+ax_sprite_terminator
+sHuntailGfx94:
+.incbin "baserom.gba", 0x1529B64, 0x20
+sHuntailSprites94:
+ax_sprite sHuntailGfx94, 0x20
+ax_sprite_terminator
+sHuntailGfx95:
+.incbin "baserom.gba", 0x1529B94, 0x40
+sHuntailSprites95:
+ax_sprite sHuntailGfx95, 0x40
+ax_sprite_terminator
+sHuntailGfx96:
+.incbin "baserom.gba", 0x1529BE4, 0x20
+sHuntailSprites96:
+ax_sprite sHuntailGfx96, 0x20
+ax_sprite_terminator
+sHuntailGfx97:
+.incbin "baserom.gba", 0x1529C14, 0x100
+sHuntailSprites97:
+ax_sprite sHuntailGfx97, 0x100
+ax_sprite_terminator
+sHuntailGfx98:
+.incbin "baserom.gba", 0x1529D24, 0x40
+sHuntailSprites98:
+ax_sprite sHuntailGfx98, 0x40
+ax_sprite_terminator
+sHuntailGfx99:
+.incbin "baserom.gba", 0x1529D74, 0x80
+sHuntailSprites99:
+ax_sprite sHuntailGfx99, 0x80
+ax_sprite_terminator
+sHuntailGfx100:
+.incbin "baserom.gba", 0x1529E04, 0x100
+sHuntailSprites100:
+ax_sprite sHuntailGfx100, 0x100
+ax_sprite_terminator
+sAxPosesHuntail:
+.4byte sHuntailPose1
+.4byte sHuntailPose2
+.4byte sHuntailPose3
+.4byte sHuntailPose4
+.4byte sHuntailPose5
+.4byte sHuntailPose6
+.4byte sHuntailPose7
+.4byte sHuntailPose8
+.4byte sHuntailPose9
+.4byte sHuntailPose10
+.4byte sHuntailPose11
+.4byte sHuntailPose12
+.4byte sHuntailPose13
+.4byte sHuntailPose14
+.4byte sHuntailPose15
+.4byte sHuntailPose16
+.4byte sHuntailPose17
+.4byte sHuntailPose18
+.4byte sHuntailPose19
+.4byte sHuntailPose20
+.4byte sHuntailPose21
+.4byte sHuntailPose22
+.4byte sHuntailPose23
+.4byte sHuntailPose24
+.4byte sHuntailPose25
+.4byte sHuntailPose26
+.4byte sHuntailPose27
+.4byte sHuntailPose28
+.4byte sHuntailPose29
+.4byte sHuntailPose30
+.4byte sHuntailPose31
+.4byte sHuntailPose32
+.4byte sHuntailPose33
+.4byte sHuntailPose34
+.4byte sHuntailPose35
+.4byte sHuntailPose36
+.4byte sHuntailPose37
+.4byte sHuntailPose38
+.4byte sHuntailPose39
+.4byte sHuntailPose40
+.4byte sHuntailPose41
+.4byte sHuntailPose42
+.4byte sHuntailPose43
+.4byte sHuntailPose44
+.4byte sHuntailPose45
+.4byte sHuntailPose46
+.4byte sHuntailPose47
+.4byte sHuntailPose48
+.4byte sHuntailPose49
+.4byte sHuntailPose50
+.4byte sHuntailPose51
+.4byte sHuntailPose52
+.4byte sHuntailPose53
+.4byte sHuntailPose54
+.4byte sHuntailPose55
+.4byte sHuntailPose56
+.4byte sHuntailPose57
+.4byte sHuntailPose58
+.4byte sHuntailPose59
+.4byte sHuntailPose60
+.4byte sHuntailPose61
+.4byte sHuntailPose62
+.4byte sHuntailPose63
+.4byte sHuntailPose64
+.4byte sHuntailPose65
+.4byte sHuntailPose66
+.4byte sHuntailPose67
+.4byte sHuntailPose68
+.4byte sHuntailPose69
+.4byte sHuntailPose70
+.4byte sHuntailPose71
+.4byte sHuntailPose72
+.4byte sHuntailPose73
+.4byte sHuntailPose74
+.4byte sHuntailPose75
+.4byte sHuntailPose76
+.4byte sHuntailPose77
+.4byte sHuntailPose78
+.4byte sHuntailPose79
+.4byte sHuntailPose80
+.4byte sHuntailPose81
+.4byte sHuntailPose82
+.4byte sHuntailPose83
+.4byte sHuntailPose84
+.4byte sHuntailPose85
+.4byte sHuntailPose86
+.4byte sHuntailPose87
+.4byte sHuntailPose88
+.4byte sHuntailPose89
+.4byte sHuntailPose90
+.4byte sHuntailPose91
+.4byte sHuntailPose92
+.4byte sHuntailPose93
+.4byte sHuntailPose94
+.4byte sHuntailPose95
+.4byte sHuntailPose96
+.4byte sHuntailPose97
+.4byte sHuntailPose98
+.4byte sHuntailPose99
+.4byte sHuntailPose100
+.4byte sHuntailPose101
+.4byte sHuntailPose102
+.4byte sHuntailPose103
+.4byte sHuntailPose104
+.4byte sHuntailPose105
+.4byte sHuntailPose106
+.4byte sHuntailPose107
+.4byte sHuntailPose108
+.4byte sHuntailPose109
+.4byte sHuntailPose110
+.4byte sHuntailPose111
+.4byte sHuntailPose112
+.4byte sHuntailPose113
+.4byte sHuntailPose114
+.4byte sHuntailPose115
+.4byte sHuntailPose116
+.4byte sHuntailPose117
+.4byte sHuntailPose118
+.4byte sHuntailPose119
+.4byte sHuntailPose120
+.4byte sHuntailPose121
+.4byte sHuntailPose122
+.4byte sHuntailPose123
+.4byte sHuntailPose124
+.4byte sHuntailPose125
+.4byte sHuntailPose126
+.4byte sHuntailPose127
+.4byte sHuntailPose128
+.4byte sHuntailPose129
+.4byte sHuntailPose130
+.4byte sHuntailPose131
+.4byte sHuntailPose132
+.4byte sHuntailPose133
+.4byte sHuntailPose134
+.4byte sHuntailPose135
+.4byte sHuntailPose136
+.4byte sHuntailPose137
+.4byte sHuntailPose138
+.4byte sHuntailPose139
+.4byte sHuntailPose140
+.4byte sHuntailPose141
+.4byte sHuntailPose142
+.4byte sHuntailPose143
+.4byte sHuntailPose144
+.4byte sHuntailPose145
+.4byte sHuntailPose146
+.4byte sHuntailPose147
+.4byte sHuntailPose148
+.4byte sHuntailPose149
+.4byte sHuntailPose150
+.4byte sHuntailPose151
+.4byte sHuntailPose152
+.4byte sHuntailPose153
+.4byte sHuntailPose154
+.4byte sHuntailPose155
+.4byte sHuntailPose156
+.4byte sHuntailPose157
+.4byte sHuntailPose158
+.4byte sHuntailPose159
+.4byte sHuntailPose160
+.4byte sHuntailPose161
+.4byte sHuntailPose162
+.4byte sHuntailPose163
+.4byte sHuntailPose164
+.4byte sHuntailPose165
+.4byte sHuntailPose166
+.4byte sHuntailPose167
+.4byte sHuntailPose168
+.4byte sHuntailPose169
+.4byte sHuntailPose170
+.4byte sHuntailPose171
+.4byte sHuntailPose172
+.4byte sHuntailPose173
+.4byte sHuntailPose174
+.4byte sHuntailPose175
+.4byte sHuntailPose176
+.4byte sHuntailPose177
+.4byte sHuntailPose178
+.4byte sHuntailPose179
+.4byte sHuntailPose180
+.4byte sHuntailPose181
+.4byte sHuntailPose182
+.4byte sHuntailPose183
+.4byte sHuntailPose184
+.4byte sHuntailPose185
+.4byte sHuntailPose186
+.4byte sHuntailPose187
+.4byte sHuntailPose188
+.4byte sHuntailPose189
+.4byte sHuntailPose190
+.4byte sHuntailPose191
+.4byte sHuntailPose192
+.4byte sHuntailPose193
+.4byte sHuntailPose194
+.4byte sHuntailPose195
+.4byte sHuntailPose196
+.4byte sHuntailPose197
+.4byte sHuntailPose198
+.4byte sHuntailPose199
+.4byte sHuntailPose200
+.4byte sHuntailPose201
+.4byte sHuntailPose202
+.4byte sHuntailPose203
+.4byte sHuntailPose204
+.4byte sHuntailPose205
+.4byte sHuntailPose206
+.4byte sHuntailPose207
+.4byte sHuntailPose208
+.4byte sHuntailPose209
+.4byte sHuntailPose210
+.4byte sHuntailPose211
+.4byte sHuntailPose212
+.4byte sHuntailPose213
+.4byte sHuntailPose214
+.4byte sHuntailPose215
+.4byte sHuntailPose216
+.4byte sHuntailPose217
+.4byte sHuntailPose218
+.4byte sHuntailPose219
+.4byte sHuntailPose220
+.4byte sHuntailPose221
+.4byte sHuntailPose222
+.4byte sHuntailPose223
+.4byte sHuntailPose224
+.4byte sHuntailPose225
+.4byte sHuntailPose226
+.4byte sHuntailPose227
+.4byte sHuntailPose228
+.4byte sHuntailPose229
+.4byte sHuntailPose230
+.4byte sHuntailPose231
+.4byte sHuntailPose232
+.4byte sHuntailPose233
+.4byte sHuntailPose234
+sAxPositionsHuntail:
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte    0,   -1, 	  -2,  -11, 	   5,  -10, 	   0,  -11
+.2byte    1,   -1, 	  -3,  -11, 	   3,  -11, 	   1,  -11
+.2byte    0,   -2, 	  -4,  -10, 	   3,  -10, 	   0,  -11
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+.2byte    7,   -3, 	   2,  -11, 	  -1,   -7, 	  -3,  -11
+.2byte    6,   -2, 	   1,  -12, 	  -3,   -7, 	  -3,  -13
+.2byte    7,   -4, 	   2,  -12, 	  -1,   -7, 	  -3,  -13
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte   10,   -9, 	   0,  -12, 	   0,   -9, 	  -3,  -10
+.2byte   10,   -8, 	   1,  -12, 	   1,   -8, 	  -2,  -12
+.2byte   10,   -9, 	   0,  -14, 	   0,  -10, 	  -3,  -12
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte    8,  -14, 	  -2,  -12, 	   1,  -10, 	  -1,   -9
+.2byte    9,  -14, 	  -1,  -15, 	   2,  -11, 	  -1,  -12
+.2byte    8,  -15, 	  -1,  -14, 	   3,  -12, 	   0,  -11
+.2byte    1,  -19, 	  -1,  -13, 	  -5,  -14, 	  -4,  -13
+.2byte    0,  -19, 	   2,  -13, 	  -3,  -13, 	  -1,  -12
+.2byte   -1,  -18, 	   5,  -14, 	   2,  -13, 	   4,  -12
+.2byte    1,  -19, 	   3,  -13, 	  -2,  -14, 	   1,  -12
+.2byte   -9,  -15, 	  -1,  -12, 	  -4,  -10, 	  -1,   -9
+.2byte  -10,  -14, 	   0,  -12, 	  -3,  -10, 	  -1,   -9
+.2byte  -11,  -14, 	  -1,  -15, 	  -4,  -11, 	  -1,  -12
+.2byte  -10,  -15, 	  -1,  -14, 	  -5,  -12, 	  -2,  -11
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte  -12,   -9, 	  -2,  -12, 	  -2,   -9, 	   1,  -10
+.2byte  -12,   -8, 	  -3,  -12, 	  -3,   -8, 	   0,  -12
+.2byte  -12,   -9, 	  -2,  -14, 	  -2,  -10, 	   1,  -12
+.2byte  -10,   -4, 	  -3,  -11, 	  -1,   -7, 	   1,  -10
+.2byte   -9,   -3, 	  -4,  -11, 	  -1,   -7, 	   1,  -11
+.2byte   -8,   -2, 	  -3,  -12, 	   1,   -7, 	   1,  -13
+.2byte   -9,   -4, 	  -4,  -12, 	  -1,   -7, 	   1,  -13
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte   -1,    1, 	  -3,  -11, 	   1,  -11, 	  -1,  -15
+.2byte   -1,    2, 	  -3,  -11, 	   1,  -11, 	  -1,  -13
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+.2byte   10,   -2, 	   3,  -11, 	   0,   -8, 	  -2,  -11
+.2byte   10,   -2, 	   4,  -10, 	   1,   -7, 	  -1,  -11
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte   12,  -10, 	   2,  -14, 	   2,  -10, 	  -2,  -11
+.2byte   12,  -10, 	   2,  -14, 	   2,  -10, 	  -2,  -12
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte   12,  -16, 	   2,  -15, 	   5,  -12, 	   2,  -12
+.2byte   13,  -16, 	   2,  -16, 	   5,  -13, 	   2,  -12
+.2byte    1,  -17, 	  -1,  -11, 	  -5,  -12, 	  -4,  -11
+.2byte    0,  -20, 	   3,  -14, 	  -3,  -14, 	   0,  -12
+.2byte    0,  -18, 	   3,  -13, 	  -3,  -13, 	   0,  -10
+.2byte   -9,  -13, 	  -1,  -10, 	  -4,   -8, 	  -1,   -7
+.2byte  -12,  -14, 	  -2,  -13, 	  -5,  -10, 	  -2,  -10
+.2byte  -13,  -14, 	  -2,  -14, 	  -5,  -11, 	  -2,  -10
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte  -14,  -10, 	  -4,  -14, 	  -4,  -10, 	   0,  -11
+.2byte  -14,  -10, 	  -4,  -14, 	  -4,  -10, 	   0,  -12
+.2byte  -10,   -4, 	  -3,  -11, 	  -1,   -7, 	   1,  -10
+.2byte  -12,   -2, 	  -5,  -11, 	  -2,   -8, 	   0,  -11
+.2byte  -12,   -2, 	  -6,  -10, 	  -3,   -7, 	  -1,  -11
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte   -1,    1, 	  -3,  -11, 	   1,  -11, 	  -1,  -15
+.2byte   -1,    2, 	  -3,  -11, 	   1,  -11, 	  -1,  -13
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+.2byte   10,   -2, 	   3,  -11, 	   0,   -8, 	  -2,  -11
+.2byte   10,   -2, 	   4,  -10, 	   1,   -7, 	  -1,  -11
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte   12,  -10, 	   2,  -14, 	   2,  -10, 	  -2,  -11
+.2byte   12,  -10, 	   2,  -14, 	   2,  -10, 	  -2,  -12
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte   12,  -16, 	   2,  -15, 	   5,  -12, 	   2,  -12
+.2byte   13,  -16, 	   2,  -16, 	   5,  -13, 	   2,  -12
+.2byte    1,  -17, 	  -1,  -11, 	  -5,  -12, 	  -4,  -11
+.2byte    0,  -20, 	   3,  -14, 	  -3,  -14, 	   0,  -12
+.2byte    0,  -18, 	   3,  -13, 	  -3,  -13, 	   0,  -10
+.2byte   -9,  -13, 	  -1,  -10, 	  -4,   -8, 	  -1,   -7
+.2byte  -12,  -14, 	  -2,  -13, 	  -5,  -10, 	  -2,  -10
+.2byte  -13,  -14, 	  -2,  -14, 	  -5,  -11, 	  -2,  -10
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte  -14,  -10, 	  -4,  -14, 	  -4,  -10, 	   0,  -11
+.2byte  -14,  -10, 	  -4,  -14, 	  -4,  -10, 	   0,  -12
+.2byte  -10,   -4, 	  -3,  -11, 	  -1,   -7, 	   1,  -10
+.2byte  -12,   -2, 	  -5,  -11, 	  -2,   -8, 	   0,  -11
+.2byte  -12,   -2, 	  -6,  -10, 	  -3,   -7, 	  -1,  -11
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte   -1,    1, 	  -2,  -10, 	   3,   -9, 	   0,  -13
+.2byte   -1,   -2, 	   1,  -11, 	   6,   -8, 	   3,  -13
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+.2byte   10,   -1, 	   6,  -10, 	   1,   -5, 	   0,   -9
+.2byte   10,   -4, 	  -1,   -8, 	  -2,   -4, 	  -6,   -6
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte   12,   -8, 	   3,  -14, 	   3,  -10, 	   0,  -13
+.2byte   11,  -12, 	   2,  -14, 	   2,  -10, 	   0,   -9
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte   11,  -10, 	   1,  -12, 	   2,   -9, 	  -2,  -11
+.2byte   10,  -14, 	   1,  -11, 	   4,   -8, 	   0,   -7
+.2byte    1,  -19, 	  -1,  -13, 	  -5,  -14, 	  -4,  -13
+.2byte    0,  -20, 	   4,  -14, 	  -1,  -14, 	   1,  -11
+.2byte    0,  -22, 	   2,  -15, 	  -2,  -15, 	   0,  -13
+.2byte   -9,  -15, 	  -1,  -12, 	  -4,  -10, 	  -1,   -9
+.2byte  -11,  -10, 	  -1,  -12, 	  -2,   -9, 	   2,  -11
+.2byte  -10,  -14, 	  -1,  -11, 	  -4,   -8, 	   0,   -7
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte  -14,   -8, 	  -5,  -14, 	  -5,  -10, 	  -2,  -13
+.2byte  -13,  -12, 	  -4,  -14, 	  -4,  -10, 	  -2,   -9
+.2byte  -10,   -4, 	  -3,  -11, 	  -1,   -7, 	   1,  -10
+.2byte  -12,   -1, 	  -8,  -10, 	  -3,   -5, 	  -2,   -9
+.2byte  -12,   -4, 	  -1,   -8, 	   0,   -4, 	   4,   -6
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte    0,   -1, 	  -2,  -11, 	   5,  -10, 	   0,  -11
+.2byte    1,   -1, 	  -3,  -11, 	   3,  -11, 	   1,  -11
+.2byte    0,   -2, 	  -4,  -10, 	   3,  -10, 	   0,  -11
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+.2byte    7,   -3, 	   2,  -11, 	  -1,   -7, 	  -3,  -11
+.2byte    6,   -2, 	   1,  -12, 	  -3,   -7, 	  -3,  -13
+.2byte    7,   -4, 	   2,  -12, 	  -1,   -7, 	  -3,  -13
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte   10,   -9, 	   0,  -12, 	   0,   -9, 	  -3,  -10
+.2byte   10,   -8, 	   1,  -12, 	   1,   -8, 	  -2,  -12
+.2byte   10,   -9, 	   0,  -14, 	   0,  -10, 	  -3,  -12
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte    8,  -14, 	  -2,  -12, 	   1,  -10, 	  -1,   -9
+.2byte    9,  -14, 	  -1,  -15, 	   2,  -11, 	  -1,  -12
+.2byte    8,  -15, 	  -1,  -14, 	   3,  -12, 	   0,  -11
+.2byte    1,  -19, 	  -1,  -13, 	  -5,  -14, 	  -4,  -13
+.2byte    0,  -19, 	   2,  -13, 	  -3,  -13, 	  -1,  -12
+.2byte   -1,  -18, 	   5,  -14, 	   2,  -13, 	   4,  -12
+.2byte    1,  -19, 	   3,  -13, 	  -2,  -14, 	   1,  -12
+.2byte   -9,  -15, 	  -1,  -12, 	  -4,  -10, 	  -1,   -9
+.2byte  -10,  -14, 	   0,  -12, 	  -3,  -10, 	  -1,   -9
+.2byte  -11,  -14, 	  -1,  -15, 	  -4,  -11, 	  -1,  -12
+.2byte  -10,  -15, 	  -1,  -14, 	  -5,  -12, 	  -2,  -11
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte  -12,   -9, 	  -2,  -12, 	  -2,   -9, 	   1,  -10
+.2byte  -12,   -8, 	  -3,  -12, 	  -3,   -8, 	   0,  -12
+.2byte  -12,   -9, 	  -2,  -14, 	  -2,  -10, 	   1,  -12
+.2byte  -10,   -4, 	  -3,  -11, 	  -1,   -7, 	   1,  -10
+.2byte   -9,   -3, 	  -4,  -11, 	  -1,   -7, 	   1,  -11
+.2byte   -8,   -2, 	  -3,  -12, 	   1,   -7, 	   1,  -13
+.2byte   -9,   -4, 	  -4,  -12, 	  -1,   -7, 	   1,  -13
+.2byte  -10,    1, 	  -3,   -8, 	  -1,   -4, 	   1,   -8
+.2byte  -10,    1, 	  -3,   -8, 	   0,   -5, 	   2,   -8
+.2byte   -1,    0, 	  -4,  -12, 	   1,  -12, 	  -1,  -14
+.2byte    9,   -3, 	   1,  -11, 	  -2,   -8, 	  -3,  -12
+.2byte   10,   -8, 	  -1,  -12, 	  -1,   -8, 	  -4,  -10
+.2byte    9,  -13, 	  -2,  -11, 	   1,   -8, 	  -3,   -7
+.2byte   -1,  -14, 	   2,   -6, 	  -3,   -6, 	  -1,   -4
+.2byte  -10,  -13, 	   1,  -11, 	  -2,   -8, 	   2,   -7
+.2byte  -11,   -8, 	   0,  -12, 	   0,   -8, 	   3,  -10
+.2byte  -10,   -3, 	  -2,  -11, 	   1,   -8, 	   2,  -12
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte    0,   -1, 	  -2,  -11, 	   5,  -10, 	   0,  -11
+.2byte    1,   -1, 	  -3,  -11, 	   3,  -11, 	   1,  -11
+.2byte    0,   -2, 	  -4,  -10, 	   3,  -10, 	   0,  -11
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+.2byte    7,   -3, 	   2,  -11, 	  -1,   -7, 	  -3,  -11
+.2byte    6,   -2, 	   1,  -12, 	  -3,   -7, 	  -3,  -13
+.2byte    7,   -4, 	   2,  -12, 	  -1,   -7, 	  -3,  -13
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte   10,   -9, 	   0,  -12, 	   0,   -9, 	  -3,  -10
+.2byte   10,   -8, 	   1,  -12, 	   1,   -8, 	  -2,  -12
+.2byte   10,   -9, 	   0,  -14, 	   0,  -10, 	  -3,  -12
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte    8,  -14, 	  -2,  -12, 	   1,  -10, 	  -1,   -9
+.2byte    9,  -14, 	  -1,  -15, 	   2,  -11, 	  -1,  -12
+.2byte    8,  -15, 	  -1,  -14, 	   3,  -12, 	   0,  -11
+.2byte    1,  -19, 	  -1,  -13, 	  -5,  -14, 	  -4,  -13
+.2byte    0,  -19, 	   2,  -13, 	  -3,  -13, 	  -1,  -12
+.2byte   -1,  -18, 	   5,  -14, 	   2,  -13, 	   4,  -12
+.2byte    1,  -19, 	   3,  -13, 	  -2,  -14, 	   1,  -12
+.2byte   -9,  -15, 	  -1,  -12, 	  -4,  -10, 	  -1,   -9
+.2byte  -10,  -14, 	   0,  -12, 	  -3,  -10, 	  -1,   -9
+.2byte  -11,  -14, 	  -1,  -15, 	  -4,  -11, 	  -1,  -12
+.2byte  -10,  -15, 	  -1,  -14, 	  -5,  -12, 	  -2,  -11
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte  -12,   -9, 	  -2,  -12, 	  -2,   -9, 	   1,  -10
+.2byte  -12,   -8, 	  -3,  -12, 	  -3,   -8, 	   0,  -12
+.2byte  -12,   -9, 	  -2,  -14, 	  -2,  -10, 	   1,  -12
+.2byte  -10,   -4, 	  -3,  -11, 	  -1,   -7, 	   1,  -10
+.2byte   -9,   -3, 	  -4,  -11, 	  -1,   -7, 	   1,  -11
+.2byte   -8,   -2, 	  -3,  -12, 	   1,   -7, 	   1,  -13
+.2byte   -9,   -4, 	  -4,  -12, 	  -1,   -7, 	   1,  -13
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte  -11,   -4, 	  -4,  -11, 	  -2,   -7, 	   0,  -10
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte   -9,  -15, 	  -1,  -12, 	  -4,  -10, 	  -1,   -9
+.2byte    1,  -19, 	  -1,  -13, 	  -5,  -14, 	  -4,  -13
+.2byte    8,  -15, 	   0,  -12, 	   3,  -10, 	   0,   -9
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte    9,   -4, 	   2,  -11, 	   0,   -7, 	  -2,  -10
+.2byte   -1,   -2, 	   1,  -11, 	   6,   -8, 	   3,  -13
+.2byte   12,   -4, 	   1,   -8, 	   0,   -4, 	  -4,   -6
+.2byte   13,  -10, 	   4,  -12, 	   4,   -8, 	   2,   -7
+.2byte   10,  -13, 	   1,  -10, 	   4,   -7, 	   0,   -6
+.2byte    0,  -20, 	   2,  -13, 	  -2,  -13, 	   0,  -11
+.2byte  -11,  -13, 	  -2,  -10, 	  -5,   -7, 	  -1,   -6
+.2byte  -14,  -10, 	  -5,  -12, 	  -5,   -8, 	  -3,   -7
+.2byte  -13,   -4, 	  -2,   -8, 	  -1,   -4, 	   3,   -6
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte   -1,    1, 	  -2,  -10, 	   3,   -9, 	   0,  -13
+.2byte   -1,   -2, 	   1,  -11, 	   6,   -8, 	   3,  -13
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+.2byte    9,   -1, 	   5,  -10, 	   0,   -5, 	  -1,   -9
+.2byte    8,   -4, 	  -3,   -8, 	  -4,   -4, 	  -8,   -6
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte   10,   -8, 	   1,  -14, 	   1,  -10, 	  -2,  -13
+.2byte    9,  -12, 	   0,  -14, 	   0,  -10, 	  -2,   -9
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte    9,  -10, 	  -1,  -12, 	   0,   -9, 	  -4,  -11
+.2byte    8,  -14, 	  -1,  -11, 	   2,   -8, 	  -2,   -7
+.2byte    1,  -19, 	  -1,  -13, 	  -5,  -14, 	  -4,  -13
+.2byte    1,  -20, 	   5,  -14, 	   0,  -14, 	   2,  -11
+.2byte    1,  -22, 	   3,  -15, 	  -1,  -15, 	   1,  -13
+.2byte   -8,  -15, 	   0,  -12, 	  -3,  -10, 	   0,   -9
+.2byte   -9,  -10, 	   1,  -12, 	   0,   -9, 	   4,  -11
+.2byte   -9,  -14, 	   0,  -11, 	  -3,   -8, 	   1,   -7
+.2byte  -10,  -10, 	  -1,  -13, 	  -2,  -10, 	   1,   -9
+.2byte  -11,   -8, 	  -2,  -14, 	  -2,  -10, 	   1,  -13
+.2byte  -10,  -12, 	  -1,  -14, 	  -1,  -10, 	   1,   -9
+.2byte   -9,   -4, 	  -2,  -11, 	   0,   -7, 	   2,  -10
+.2byte  -10,   -1, 	  -6,  -10, 	  -1,   -5, 	   0,   -9
+.2byte   -9,   -4, 	   2,   -8, 	   3,   -4, 	   7,   -6
+.2byte   -1,    1, 	  -2,  -10, 	   3,   -9, 	   0,  -13
+.2byte  -11,   -1, 	  -7,  -10, 	  -2,   -5, 	  -1,   -9
+.2byte  -13,   -7, 	  -4,  -13, 	  -4,   -9, 	  -1,  -12
+.2byte  -12,  -11, 	  -2,  -13, 	  -3,  -10, 	   1,  -12
+.2byte    0,  -17, 	   4,  -11, 	  -1,  -11, 	   1,   -8
+.2byte   11,  -11, 	   1,  -13, 	   2,  -10, 	  -2,  -12
+.2byte   12,   -7, 	   3,  -13, 	   3,   -9, 	   0,  -12
+.2byte   10,   -1, 	   6,  -10, 	   1,   -5, 	   0,   -9
+.2byte   -1,   -1, 	  -1,  -11, 	   4,  -10, 	   2,  -11
+.2byte  -10,   -4, 	  -3,  -11, 	  -1,   -7, 	   1,  -10
+.2byte  -11,  -10, 	  -2,  -13, 	  -3,  -10, 	   0,   -9
+.2byte   -9,  -15, 	  -1,  -12, 	  -4,  -10, 	  -1,   -9
+.2byte    1,  -19, 	  -1,  -13, 	  -5,  -14, 	  -4,  -13
+.2byte    7,  -15, 	  -1,  -12, 	   2,  -10, 	  -1,   -9
+.2byte    9,  -10, 	   0,  -13, 	   1,  -10, 	  -2,   -9
+.2byte    8,   -4, 	   1,  -11, 	  -1,   -7, 	  -3,  -10
+sHuntailAnimTable1:
+.4byte sHuntailAnims_1_1
+.4byte sHuntailAnims_1_2
+.4byte sHuntailAnims_1_3
+.4byte sHuntailAnims_1_4
+.4byte sHuntailAnims_1_5
+.4byte sHuntailAnims_1_6
+.4byte sHuntailAnims_1_7
+.4byte sHuntailAnims_1_8
+sHuntailAnimTable2:
+.4byte sHuntailAnims_2_1
+.4byte sHuntailAnims_2_2
+.4byte sHuntailAnims_2_3
+.4byte sHuntailAnims_2_4
+.4byte sHuntailAnims_2_5
+.4byte sHuntailAnims_2_6
+.4byte sHuntailAnims_2_7
+.4byte sHuntailAnims_2_8
+sHuntailAnimTable3:
+.4byte sHuntailAnims_3_1
+.4byte sHuntailAnims_3_2
+.4byte sHuntailAnims_3_3
+.4byte sHuntailAnims_3_4
+.4byte sHuntailAnims_3_5
+.4byte sHuntailAnims_3_6
+.4byte sHuntailAnims_3_7
+.4byte sHuntailAnims_3_8
+sHuntailAnimTable4:
+.4byte sHuntailAnims_4_1
+.4byte sHuntailAnims_4_2
+.4byte sHuntailAnims_4_3
+.4byte sHuntailAnims_4_4
+.4byte sHuntailAnims_4_5
+.4byte sHuntailAnims_4_6
+.4byte sHuntailAnims_4_7
+.4byte sHuntailAnims_4_8
+sHuntailAnimTable5:
+.4byte sHuntailAnims_5_1
+.4byte sHuntailAnims_5_2
+.4byte sHuntailAnims_5_3
+.4byte sHuntailAnims_5_4
+.4byte sHuntailAnims_5_5
+.4byte sHuntailAnims_5_6
+.4byte sHuntailAnims_5_7
+.4byte sHuntailAnims_5_8
+sHuntailAnimTable6:
+.4byte sHuntailAnims_6_1
+.4byte sHuntailAnims_6_1
+.4byte sHuntailAnims_6_1
+.4byte sHuntailAnims_6_1
+.4byte sHuntailAnims_6_1
+.4byte sHuntailAnims_6_1
+.4byte sHuntailAnims_6_1
+.4byte sHuntailAnims_6_1
+sHuntailAnimTable7:
+.4byte sHuntailAnims_7_1
+.4byte sHuntailAnims_7_2
+.4byte sHuntailAnims_7_3
+.4byte sHuntailAnims_7_4
+.4byte sHuntailAnims_7_5
+.4byte sHuntailAnims_7_6
+.4byte sHuntailAnims_7_7
+.4byte sHuntailAnims_7_8
+sHuntailAnimTable8:
+.4byte sHuntailAnims_8_1
+.4byte sHuntailAnims_8_2
+.4byte sHuntailAnims_8_3
+.4byte sHuntailAnims_8_4
+.4byte sHuntailAnims_8_5
+.4byte sHuntailAnims_8_6
+.4byte sHuntailAnims_8_7
+.4byte sHuntailAnims_8_8
+sHuntailAnimTable9:
+.4byte sHuntailAnims_9_1
+.4byte sHuntailAnims_9_2
+.4byte sHuntailAnims_9_3
+.4byte sHuntailAnims_9_4
+.4byte sHuntailAnims_9_5
+.4byte sHuntailAnims_9_6
+.4byte sHuntailAnims_9_7
+.4byte sHuntailAnims_9_8
+sHuntailAnimTable10:
+.4byte sHuntailAnims_10_1
+.4byte sHuntailAnims_10_2
+.4byte sHuntailAnims_10_3
+.4byte sHuntailAnims_10_4
+.4byte sHuntailAnims_10_5
+.4byte sHuntailAnims_10_6
+.4byte sHuntailAnims_10_7
+.4byte sHuntailAnims_10_8
+sHuntailAnimTable11:
+.4byte sHuntailAnims_11_1
+.4byte sHuntailAnims_11_2
+.4byte sHuntailAnims_11_3
+.4byte sHuntailAnims_11_4
+.4byte sHuntailAnims_11_5
+.4byte sHuntailAnims_11_6
+.4byte sHuntailAnims_11_7
+.4byte sHuntailAnims_11_8
+sHuntailAnimTable12:
+.4byte sHuntailAnims_12_1
+.4byte sHuntailAnims_12_2
+.4byte sHuntailAnims_12_3
+.4byte sHuntailAnims_12_4
+.4byte sHuntailAnims_12_5
+.4byte sHuntailAnims_12_6
+.4byte sHuntailAnims_12_7
+.4byte sHuntailAnims_12_8
+sHuntailAnimTable13:
+.4byte sHuntailAnims_13_1
+.4byte sHuntailAnims_13_2
+.4byte sHuntailAnims_13_3
+.4byte sHuntailAnims_13_4
+.4byte sHuntailAnims_13_5
+.4byte sHuntailAnims_13_6
+.4byte sHuntailAnims_13_7
+.4byte sHuntailAnims_13_8
+sAxAnimationsHuntail:
+.4byte sHuntailAnimTable1
+.4byte sHuntailAnimTable2
+.4byte sHuntailAnimTable3
+.4byte sHuntailAnimTable4
+.4byte sHuntailAnimTable5
+.4byte sHuntailAnimTable6
+.4byte sHuntailAnimTable7
+.4byte sHuntailAnimTable8
+.4byte sHuntailAnimTable9
+.4byte sHuntailAnimTable10
+.4byte sHuntailAnimTable11
+.4byte sHuntailAnimTable12
+.4byte sHuntailAnimTable13
+sAxSpritesHuntail:
+.4byte sHuntailSprites1
+.4byte sHuntailSprites2
+.4byte sHuntailSprites3
+.4byte sHuntailSprites4
+.4byte sHuntailSprites5
+.4byte sHuntailSprites6
+.4byte sHuntailSprites7
+.4byte sHuntailSprites8
+.4byte sHuntailSprites9
+.4byte sHuntailSprites10
+.4byte sHuntailSprites11
+.4byte sHuntailSprites12
+.4byte sHuntailSprites13
+.4byte sHuntailSprites14
+.4byte sHuntailSprites15
+.4byte sHuntailSprites16
+.4byte sHuntailSprites17
+.4byte sHuntailSprites18
+.4byte sHuntailSprites19
+.4byte sHuntailSprites20
+.4byte sHuntailSprites21
+.4byte sHuntailSprites22
+.4byte sHuntailSprites23
+.4byte sHuntailSprites24
+.4byte sHuntailSprites25
+.4byte sHuntailSprites26
+.4byte sHuntailSprites27
+.4byte sHuntailSprites28
+.4byte sHuntailSprites29
+.4byte sHuntailSprites30
+.4byte sHuntailSprites31
+.4byte sHuntailSprites32
+.4byte sHuntailSprites33
+.4byte sHuntailSprites34
+.4byte sHuntailSprites35
+.4byte sHuntailSprites36
+.4byte sHuntailSprites37
+.4byte sHuntailSprites38
+.4byte sHuntailSprites39
+.4byte sHuntailSprites40
+.4byte sHuntailSprites41
+.4byte sHuntailSprites42
+.4byte sHuntailSprites43
+.4byte sHuntailSprites44
+.4byte sHuntailSprites45
+.4byte sHuntailSprites46
+.4byte sHuntailSprites47
+.4byte sHuntailSprites48
+.4byte sHuntailSprites49
+.4byte sHuntailSprites50
+.4byte sHuntailSprites51
+.4byte sHuntailSprites52
+.4byte sHuntailSprites53
+.4byte sHuntailSprites54
+.4byte sHuntailSprites55
+.4byte sHuntailSprites56
+.4byte sHuntailSprites57
+.4byte sHuntailSprites58
+.4byte sHuntailSprites59
+.4byte sHuntailSprites60
+.4byte sHuntailSprites61
+.4byte sHuntailSprites62
+.4byte sHuntailSprites63
+.4byte sHuntailSprites64
+.4byte sHuntailSprites65
+.4byte sHuntailSprites66
+.4byte sHuntailSprites67
+.4byte sHuntailSprites68
+.4byte sHuntailSprites69
+.4byte sHuntailSprites70
+.4byte sHuntailSprites71
+.4byte sHuntailSprites72
+.4byte sHuntailSprites73
+.4byte sHuntailSprites74
+.4byte sHuntailSprites75
+.4byte sHuntailSprites76
+.4byte sHuntailSprites77
+.4byte sHuntailSprites78
+.4byte sHuntailSprites79
+.4byte sHuntailSprites80
+.4byte sHuntailSprites81
+.4byte sHuntailSprites82
+.4byte sHuntailSprites83
+.4byte sHuntailSprites84
+.4byte sHuntailSprites85
+.4byte sHuntailSprites86
+.4byte sHuntailSprites87
+.4byte sHuntailSprites88
+.4byte sHuntailSprites89
+.4byte sHuntailSprites90
+.4byte sHuntailSprites91
+.4byte sHuntailSprites92
+.4byte sHuntailSprites93
+.4byte sHuntailSprites94
+.4byte sHuntailSprites95
+.4byte sHuntailSprites96
+.4byte sHuntailSprites97
+.4byte sHuntailSprites98
+.4byte sHuntailSprites99
+.4byte sHuntailSprites100
+sAxMainHuntail:
+ax_main sAxPosesHuntail, sAxAnimationsHuntail, 13, sAxSpritesHuntail, sAxPositionsHuntail

--- a/data/ax/hypno.inc
+++ b/data/ax/hypno.inc
@@ -1,0 +1,3753 @@
+.global gAxHypno
+gAxHypno:
+ax_siro sAxMainHypno
+sHypnoPose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose4:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose5:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose6:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose7:
+ax_pose 6, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose8:
+ax_pose 7, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose9:
+ax_pose 8, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose10:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose11:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose12:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose16:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose17:
+ax_pose 16, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose18:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose19:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose20:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose21:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose22:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose23:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose24:
+ax_pose 23, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose25:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose28:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose29:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose30:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose31:
+ax_pose 6, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose32:
+ax_pose 7, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose33:
+ax_pose 8, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose34:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose35:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose36:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose37:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose39:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose40:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose41:
+ax_pose 16, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose42:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose43:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose44:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose45:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose46:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose47:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose48:
+ax_pose 23, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose49:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose52:
+ax_pose 24, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose53:
+ax_pose 25, 0x01ea, 0x80f1, 0x2c00
+ax_pose 26, 0x01ea, 0x80f1, 0x2c10
+ax_pose_terminator
+sHypnoPose54:
+ax_pose 26, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose55:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose56:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose57:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose58:
+ax_pose 27, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose59:
+ax_pose 28, 0x01e6, 0x80f0, 0x2c00
+ax_pose 29, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sHypnoPose60:
+ax_pose 29, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose61:
+ax_pose 6, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose62:
+ax_pose 7, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose63:
+ax_pose 8, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose64:
+ax_pose 30, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose65:
+ax_pose 31, 0x41f2, 0x80ee, 0x2c00
+ax_pose 32, 0x01e6, 0x80ee, 0x2c08
+ax_pose_terminator
+sHypnoPose66:
+ax_pose 32, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sHypnoPose67:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose68:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose69:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose70:
+ax_pose 33, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose71:
+ax_pose 34, 0x01e5, 0x80ef, 0x2c00
+ax_pose 35, 0x01e5, 0x80ef, 0x2c10
+ax_pose_terminator
+sHypnoPose72:
+ax_pose 35, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose73:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose74:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose75:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose76:
+ax_pose 36, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose77:
+ax_pose 37, 0x01e5, 0x80f0, 0x2c00
+ax_pose 38, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sHypnoPose78:
+ax_pose 38, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose79:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose80:
+ax_pose 16, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose81:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose82:
+ax_pose 39, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose83:
+ax_pose 40, 0x01e5, 0x80f5, 0x2c00
+ax_pose 41, 0x01e5, 0x80f5, 0x2c10
+ax_pose_terminator
+sHypnoPose84:
+ax_pose 41, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sHypnoPose85:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose86:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose87:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose88:
+ax_pose 42, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sHypnoPose89:
+ax_pose 43, 0x01e6, 0x80f0, 0x2c00
+ax_pose 44, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sHypnoPose90:
+ax_pose 44, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose91:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose92:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose93:
+ax_pose 23, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose94:
+ax_pose 45, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose95:
+ax_pose 46, 0x01e9, 0x80f0, 0x2c00
+ax_pose 47, 0x01e9, 0x80f0, 0x2c10
+ax_pose_terminator
+sHypnoPose96:
+ax_pose 47, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose97:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose98:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose99:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose100:
+ax_pose 48, 0x01f4, 0x04f3, 0x4c00
+ax_pose 24, 0x01ea, 0x80ef, 0x2c01
+ax_pose_terminator
+sHypnoPose101:
+ax_pose 49, 0x01f2, 0x44ed, 0x4c00
+ax_pose 50, 0x01eb, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose102:
+ax_pose 51, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose103:
+ax_pose 49, 0x01f0, 0x44ef, 0x4c00
+ax_pose 24, 0x01ea, 0x80ef, 0x2c04
+ax_pose_terminator
+sHypnoPose104:
+ax_pose 48, 0x01f7, 0x04f6, 0x4c00
+ax_pose 51, 0x01eb, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose105:
+ax_pose 49, 0x01f3, 0x44f2, 0x4c00
+ax_pose 51, 0x01eb, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose106:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose107:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose108:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose109:
+ax_pose 48, 0x01ee, 0x04ef, 0x4c00
+ax_pose 27, 0x01e6, 0x80f2, 0x2c01
+ax_pose_terminator
+sHypnoPose110:
+ax_pose 49, 0x01f5, 0x44f7, 0x4c00
+ax_pose 52, 0x01e6, 0x80f1, 0x2c04
+ax_pose_terminator
+sHypnoPose111:
+ax_pose 53, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose112:
+ax_pose 49, 0x01ea, 0x44eb, 0x4c00
+ax_pose 27, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sHypnoPose113:
+ax_pose 48, 0x01f9, 0x0500, 0x4c00
+ax_pose 53, 0x01e6, 0x80f1, 0x2c01
+ax_pose_terminator
+sHypnoPose114:
+ax_pose 49, 0x01f5, 0x44fc, 0x4c00
+ax_pose 53, 0x01e6, 0x80f1, 0x2c04
+ax_pose_terminator
+sHypnoPose115:
+ax_pose 6, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose116:
+ax_pose 7, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose117:
+ax_pose 8, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose118:
+ax_pose 48, 0x01f4, 0x04f1, 0x4c00
+ax_pose 30, 0x01e6, 0x80f3, 0x2c01
+ax_pose_terminator
+sHypnoPose119:
+ax_pose 49, 0x01f2, 0x4500, 0x4c00
+ax_pose 54, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose120:
+ax_pose 55, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose121:
+ax_pose 49, 0x01f0, 0x44ed, 0x4c00
+ax_pose 30, 0x01e6, 0x80f3, 0x2c04
+ax_pose_terminator
+sHypnoPose122:
+ax_pose 48, 0x01f4, 0x0507, 0x4c00
+ax_pose 55, 0x01e6, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose123:
+ax_pose 49, 0x01f0, 0x4503, 0x4c00
+ax_pose 55, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose124:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose125:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose126:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose127:
+ax_pose 48, 0x01fa, 0x04f8, 0x4c00
+ax_pose 33, 0x01e7, 0x80f1, 0x2c01
+ax_pose_terminator
+sHypnoPose128:
+ax_pose 49, 0x01ed, 0x4508, 0x4c00
+ax_pose 56, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sHypnoPose129:
+ax_pose 57, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose130:
+ax_pose 49, 0x01f6, 0x44f4, 0x4c00
+ax_pose 33, 0x01e7, 0x80f1, 0x2c04
+ax_pose_terminator
+sHypnoPose131:
+ax_pose 48, 0x01f0, 0x050a, 0x4c00
+ax_pose 57, 0x01e6, 0x80f2, 0x2c01
+ax_pose_terminator
+sHypnoPose132:
+ax_pose 49, 0x01ec, 0x4506, 0x4c00
+ax_pose 57, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sHypnoPose133:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose134:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose135:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose136:
+ax_pose 48, 0x01f9, 0x0505, 0x4c00
+ax_pose 36, 0x01e4, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose137:
+ax_pose 58, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01e8, 0x4500, 0x4c10
+ax_pose_terminator
+sHypnoPose138:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose139:
+ax_pose 49, 0x01f5, 0x4501, 0x4c00
+ax_pose 36, 0x01e4, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose140:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose 48, 0x01ed, 0x0501, 0x4c10
+ax_pose_terminator
+sHypnoPose141:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01e9, 0x44fd, 0x4c10
+ax_pose_terminator
+sHypnoPose142:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose143:
+ax_pose 16, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose144:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose145:
+ax_pose 48, 0x01f8, 0x050a, 0x4c00
+ax_pose 39, 0x01e6, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose146:
+ax_pose 60, 0x01e6, 0x80ed, 0x2c00
+ax_pose 49, 0x01e9, 0x44f9, 0x4c10
+ax_pose_terminator
+sHypnoPose147:
+ax_pose 61, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sHypnoPose148:
+ax_pose 49, 0x01f4, 0x4506, 0x4c00
+ax_pose 39, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose149:
+ax_pose 61, 0x01e6, 0x80ed, 0x2c00
+ax_pose 48, 0x01eb, 0x04f7, 0x4c10
+ax_pose_terminator
+sHypnoPose150:
+ax_pose 61, 0x01e6, 0x80ed, 0x2c00
+ax_pose 49, 0x01e7, 0x44f3, 0x4c10
+ax_pose_terminator
+sHypnoPose151:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose152:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose153:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose154:
+ax_pose 42, 0x01e6, 0x80ee, 0x2c00
+ax_pose 48, 0x01f4, 0x0507, 0x4c10
+ax_pose_terminator
+sHypnoPose155:
+ax_pose 62, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01ea, 0x44ea, 0x4c10
+ax_pose_terminator
+sHypnoPose156:
+ax_pose 63, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose157:
+ax_pose 42, 0x01e6, 0x80ee, 0x2c00
+ax_pose 49, 0x01f0, 0x4503, 0x4c10
+ax_pose_terminator
+sHypnoPose158:
+ax_pose 63, 0x01e6, 0x80ef, 0x2c00
+ax_pose 48, 0x01f4, 0x04ec, 0x4c10
+ax_pose_terminator
+sHypnoPose159:
+ax_pose 63, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01f0, 0x44e8, 0x4c10
+ax_pose_terminator
+sHypnoPose160:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose161:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose162:
+ax_pose 23, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose163:
+ax_pose 45, 0x01e6, 0x80f3, 0x2c00
+ax_pose 48, 0x01f0, 0x04f7, 0x4c10
+ax_pose_terminator
+sHypnoPose164:
+ax_pose 49, 0x01f0, 0x44e9, 0x4c00
+ax_pose 64, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose165:
+ax_pose 65, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose166:
+ax_pose 45, 0x01e6, 0x80f3, 0x2c00
+ax_pose 49, 0x01ec, 0x44f3, 0x4c10
+ax_pose_terminator
+sHypnoPose167:
+ax_pose 48, 0x01f7, 0x04ee, 0x4c00
+ax_pose 65, 0x01e6, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose168:
+ax_pose 49, 0x01f3, 0x44ea, 0x4c00
+ax_pose 65, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose169:
+ax_pose 50, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose170:
+ax_pose 49, 0x01f2, 0x44ed, 0x4c00
+ax_pose 50, 0x01eb, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose171:
+ax_pose 51, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose172:
+ax_pose 48, 0x01f7, 0x04f6, 0x4c00
+ax_pose 51, 0x01eb, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose173:
+ax_pose 49, 0x01f3, 0x44f2, 0x4c00
+ax_pose 51, 0x01eb, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose174:
+ax_pose 52, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose175:
+ax_pose 49, 0x01f5, 0x44f7, 0x4c00
+ax_pose 52, 0x01e6, 0x80f1, 0x2c04
+ax_pose_terminator
+sHypnoPose176:
+ax_pose 53, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose177:
+ax_pose 48, 0x01f9, 0x0500, 0x4c00
+ax_pose 53, 0x01e6, 0x80f1, 0x2c01
+ax_pose_terminator
+sHypnoPose178:
+ax_pose 49, 0x01f5, 0x44fc, 0x4c00
+ax_pose 53, 0x01e6, 0x80f1, 0x2c04
+ax_pose_terminator
+sHypnoPose179:
+ax_pose 54, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose180:
+ax_pose 49, 0x01f2, 0x4500, 0x4c00
+ax_pose 54, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose181:
+ax_pose 55, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose182:
+ax_pose 48, 0x01f4, 0x0507, 0x4c00
+ax_pose 55, 0x01e6, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose183:
+ax_pose 49, 0x01f0, 0x4503, 0x4c00
+ax_pose 55, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose184:
+ax_pose 56, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose185:
+ax_pose 49, 0x01ed, 0x4508, 0x4c00
+ax_pose 56, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sHypnoPose186:
+ax_pose 57, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose187:
+ax_pose 48, 0x01f0, 0x050a, 0x4c00
+ax_pose 57, 0x01e6, 0x80f2, 0x2c01
+ax_pose_terminator
+sHypnoPose188:
+ax_pose 49, 0x01ec, 0x4506, 0x4c00
+ax_pose 57, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sHypnoPose189:
+ax_pose 58, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose190:
+ax_pose 58, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01e8, 0x4500, 0x4c10
+ax_pose_terminator
+sHypnoPose191:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose192:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose 48, 0x01ed, 0x0501, 0x4c10
+ax_pose_terminator
+sHypnoPose193:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01e9, 0x44fd, 0x4c10
+ax_pose_terminator
+sHypnoPose194:
+ax_pose 60, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sHypnoPose195:
+ax_pose 60, 0x01e6, 0x80ed, 0x2c00
+ax_pose 49, 0x01e9, 0x44f9, 0x4c10
+ax_pose_terminator
+sHypnoPose196:
+ax_pose 61, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sHypnoPose197:
+ax_pose 61, 0x01e6, 0x80ed, 0x2c00
+ax_pose 48, 0x01eb, 0x04f7, 0x4c10
+ax_pose_terminator
+sHypnoPose198:
+ax_pose 61, 0x01e6, 0x80ed, 0x2c00
+ax_pose 49, 0x01e7, 0x44f3, 0x4c10
+ax_pose_terminator
+sHypnoPose199:
+ax_pose 62, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose200:
+ax_pose 62, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01ea, 0x44ea, 0x4c10
+ax_pose_terminator
+sHypnoPose201:
+ax_pose 63, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose202:
+ax_pose 63, 0x01e6, 0x80ef, 0x2c00
+ax_pose 48, 0x01f4, 0x04ec, 0x4c10
+ax_pose_terminator
+sHypnoPose203:
+ax_pose 63, 0x01e6, 0x80ef, 0x2c00
+ax_pose 49, 0x01f0, 0x44e8, 0x4c10
+ax_pose_terminator
+sHypnoPose204:
+ax_pose 64, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose205:
+ax_pose 48, 0x01f4, 0x04ed, 0x4c00
+ax_pose 64, 0x01e6, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose206:
+ax_pose 65, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose207:
+ax_pose 49, 0x01f3, 0x44ea, 0x4c00
+ax_pose 65, 0x01e6, 0x80f0, 0x2c04
+ax_pose_terminator
+sHypnoPose208:
+ax_pose 48, 0x01f7, 0x04ee, 0x4c00
+ax_pose 65, 0x01e6, 0x80f0, 0x2c01
+ax_pose_terminator
+sHypnoPose209:
+ax_pose 66, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose210:
+ax_pose 67, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose211:
+ax_pose 68, 0x01e2, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose212:
+ax_pose 69, 0x01e1, 0x90ee, 0x2c00
+ax_pose_terminator
+sHypnoPose213:
+ax_pose 70, 0x01e0, 0x90ee, 0x2c00
+ax_pose_terminator
+sHypnoPose214:
+ax_pose 71, 0x01e1, 0x90ed, 0x2c00
+ax_pose_terminator
+sHypnoPose215:
+ax_pose 72, 0x01e1, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose216:
+ax_pose 71, 0x01e1, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose217:
+ax_pose 70, 0x01e0, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose218:
+ax_pose 69, 0x01e1, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose219:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose220:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose221:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose222:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose223:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose224:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose225:
+ax_pose 6, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose226:
+ax_pose 7, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose227:
+ax_pose 8, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose228:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose229:
+ax_pose 10, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose230:
+ax_pose 11, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose231:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose232:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose233:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose234:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose235:
+ax_pose 16, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose236:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose237:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose238:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose239:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose240:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose241:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose242:
+ax_pose 23, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose243:
+ax_pose 50, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose244:
+ax_pose 64, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose245:
+ax_pose 62, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose246:
+ax_pose 60, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sHypnoPose247:
+ax_pose 58, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose248:
+ax_pose 56, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose249:
+ax_pose 54, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose250:
+ax_pose 52, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose251:
+ax_pose 50, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose252:
+ax_pose 52, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose253:
+ax_pose 54, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose254:
+ax_pose 56, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose255:
+ax_pose 58, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose256:
+ax_pose 60, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sHypnoPose257:
+ax_pose 62, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose258:
+ax_pose 64, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose259:
+ax_pose 50, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose260:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose261:
+ax_pose 24, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose262:
+ax_pose 51, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose263:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose264:
+ax_pose 27, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose265:
+ax_pose 53, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose266:
+ax_pose 6, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose267:
+ax_pose 30, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose268:
+ax_pose 55, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose269:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose270:
+ax_pose 33, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose271:
+ax_pose 57, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose272:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose273:
+ax_pose 36, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose274:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose275:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose276:
+ax_pose 39, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose277:
+ax_pose 61, 0x01e5, 0x80ed, 0x2c00
+ax_pose_terminator
+sHypnoPose278:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose279:
+ax_pose 42, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sHypnoPose280:
+ax_pose 63, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose281:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose282:
+ax_pose 45, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose283:
+ax_pose 65, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose284:
+ax_pose 50, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose285:
+ax_pose 64, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose286:
+ax_pose 62, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose287:
+ax_pose 60, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sHypnoPose288:
+ax_pose 58, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sHypnoPose289:
+ax_pose 56, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sHypnoPose290:
+ax_pose 54, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose291:
+ax_pose 52, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sHypnoPose292:
+ax_pose 50, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose293:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose294:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sHypnoPose295:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose296:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose297:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sHypnoPose298:
+ax_pose 9, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sHypnoPose299:
+ax_pose 6, 0x01e6, 0x80f6, 0x2c00
+ax_pose_terminator
+sHypnoPose300:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+.align 2
+sHypnoAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_2_1:
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 4, 0, 45, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sHypnoAnims_2_2:
+ax_anim 2, 0, 24, -1, -1, -1, -1,
+ax_anim 4, 0, 24, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 1, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sHypnoAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 4, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sHypnoAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 4, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 12, -12, 12, -12,
+ax_anim 2, 0, 34, 20, -19, 20, -19,
+ax_anim 2, 1, 34, 21, -18, 21, -18,
+ax_anim 2, 0, 34, 20, -19, 20, -19,
+ax_anim 2, 0, 34, 21, -18, 21, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sHypnoAnims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 4, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 1, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 0, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sHypnoAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 4, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -6, -6, -6, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -19, -18, -19,
+ax_anim 2, 1, 40, -19, -18, -19, -18,
+ax_anim 2, 0, 40, -18, -19, -18, -19,
+ax_anim 2, 0, 40, -19, -18, -19, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sHypnoAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 4, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sHypnoAnims_2_8:
+ax_anim 2, 0, 42, 1, -1, 1, -1,
+ax_anim 4, 0, 42, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 1, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sHypnoAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 2, 0, 51, 0, -4, 0, -4,
+ax_anim 4, 0, 93, 0, -5, 0, -5,
+ax_anim 1, 0, 93, 0, -2, 0, -2,
+ax_anim 1, 2, 51, -1, 4, -1, 4,
+ax_anim 1, 0, 51, -2, 10, -2, 10,
+ax_anim 2, 0, 52, 0, 18, 0, 18,
+ax_anim 2, 1, 53, 2, 19, 2, 19,
+ax_anim 2, 0, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 53, 2, 19, 2, 19,
+ax_anim 2, 0, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 53, 2, 19, 2, 19,
+ax_anim 2, 0, 48, 0, 11, 0, 11,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim_terminator
+sHypnoAnims_3_2:
+ax_anim 2, 0, 55, -2, -2, -2, -2,
+ax_anim 2, 0, 57, -4, -4, -4, -4,
+ax_anim 4, 0, 51, -5, -5, -5, -5,
+ax_anim 1, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 2, 57, 4, 6, 4, 6,
+ax_anim 1, 0, 57, 9, 13, 9, 13,
+ax_anim 2, 0, 58, 15, 16, 15, 16,
+ax_anim 2, 1, 59, 15, 17, 15, 17,
+ax_anim 2, 0, 59, 16, 16, 16, 16,
+ax_anim 2, 0, 59, 15, 17, 15, 17,
+ax_anim 2, 0, 59, 16, 16, 16, 16,
+ax_anim 2, 0, 59, 15, 17, 15, 17,
+ax_anim 2, 0, 54, 13, 11, 13, 11,
+ax_anim 2, 0, 55, 4, 5, 4, 5,
+ax_anim_terminator
+sHypnoAnims_3_3:
+ax_anim 2, 0, 61, -2, 0, -2, 0,
+ax_anim 2, 0, 63, -4, 0, -4, 0,
+ax_anim 4, 0, 57, -5, -2, -5, -2,
+ax_anim 1, 0, 57, -2, -2, -2, -2,
+ax_anim 1, 2, 63, 4, 1, 4, 1,
+ax_anim 1, 0, 63, 10, 1, 10, 1,
+ax_anim 2, 0, 64, 15, 0, 15, 0,
+ax_anim 2, 1, 65, 16, 0, 16, 0,
+ax_anim 2, 0, 65, 16, -1, 16, -1,
+ax_anim 2, 0, 65, 16, 0, 16, 0,
+ax_anim 2, 0, 65, 16, -1, 16, -1,
+ax_anim 2, 0, 65, 16, 0, 16, 0,
+ax_anim 2, 0, 60, 10, 0, 10, 0,
+ax_anim 2, 0, 61, 4, 0, 4, 0,
+ax_anim_terminator
+sHypnoAnims_3_4:
+ax_anim 2, 0, 67, -2, 2, -2, 2,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim 4, 0, 63, -7, 5, -7, 5,
+ax_anim 1, 0, 63, -4, 2, -4, 2,
+ax_anim 1, 2, 69, 5, -5, 5, -5,
+ax_anim 1, 0, 69, 12, -12, 12, -12,
+ax_anim 2, 0, 70, 17, -15, 17, -15,
+ax_anim 2, 1, 71, 17, -16, 17, -16,
+ax_anim 2, 0, 71, 16, -17, 16, -17,
+ax_anim 2, 0, 71, 17, -16, 17, -16,
+ax_anim 2, 0, 71, 16, -17, 16, -17,
+ax_anim 2, 0, 71, 17, -16, 17, -16,
+ax_anim 2, 0, 66, 11, -13, 11, -13,
+ax_anim 2, 0, 67, 4, -5, 4, -5,
+ax_anim_terminator
+sHypnoAnims_3_5:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 4, 0, 69, -3, 8, -3, 8,
+ax_anim 1, 0, 69, -3, 5, -3, 5,
+ax_anim 1, 2, 75, 1, -4, 1, -4,
+ax_anim 1, 0, 75, 2, -8, 2, -8,
+ax_anim 2, 0, 76, 1, -14, 1, -14,
+ax_anim 2, 1, 77, -1, -15, -1, -15,
+ax_anim 2, 0, 77, 0, -15, 0, -15,
+ax_anim 2, 0, 77, -1, -15, -1, -15,
+ax_anim 2, 0, 77, 0, -15, 0, -15,
+ax_anim 2, 0, 77, -1, -15, -1, -15,
+ax_anim 2, 0, 72, 0, -11, 0, -11,
+ax_anim 2, 0, 73, 0, -4, 0, -4,
+ax_anim_terminator
+sHypnoAnims_3_6:
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 4, 4, 4, 4,
+ax_anim 4, 0, 75, 5, 5, 5, 5,
+ax_anim 1, 0, 75, 2, 2, 2, 2,
+ax_anim 1, 2, 81, -5, -5, -5, -5,
+ax_anim 1, 0, 81, -12, -9, -12, -9,
+ax_anim 2, 0, 82, -18, -12, -18, -12,
+ax_anim 2, 1, 83, -19, -12, -19, -12,
+ax_anim 2, 0, 83, -18, -13, -18, -13,
+ax_anim 2, 0, 83, -19, -12, -19, -12,
+ax_anim 2, 0, 83, -18, -13, -18, -13,
+ax_anim 2, 0, 83, -19, -12, -19, -12,
+ax_anim 2, 0, 78, -13, -9, -13, -9,
+ax_anim 2, 0, 79, -6, -4, -6, -4,
+ax_anim_terminator
+sHypnoAnims_3_7:
+ax_anim 2, 0, 85, 2, 0, 2, 0,
+ax_anim 2, 0, 87, 4, 0, 4, 0,
+ax_anim 4, 0, 81, 6, 1, 6, 1,
+ax_anim 1, 0, 81, 3, 1, 3, 1,
+ax_anim 1, 2, 87, -4, -1, -4, -1,
+ax_anim 1, 0, 87, -10, -1, -10, -1,
+ax_anim 2, 0, 88, -14, 0, -14, 0,
+ax_anim 2, 1, 89, -15, 1, -15, 1,
+ax_anim 2, 0, 89, -15, 0, -15, 0,
+ax_anim 2, 0, 89, -15, 1, -15, 1,
+ax_anim 2, 0, 89, -15, 0, -15, 0,
+ax_anim 2, 0, 89, -15, 1, -15, 1,
+ax_anim 2, 0, 84, -10, 0, -10, 0,
+ax_anim 2, 0, 85, -4, 0, -4, 0,
+ax_anim_terminator
+sHypnoAnims_3_8:
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 4, -4, 4, -4,
+ax_anim 4, 0, 87, 12, -5, 12, -5,
+ax_anim 1, 0, 87, 9, -2, 9, -2,
+ax_anim 1, 2, 93, -1, 2, -1, 2,
+ax_anim 1, 0, 93, -8, 8, -8, 8,
+ax_anim 2, 0, 94, -14, 16, -14, 16,
+ax_anim 2, 1, 95, -14, 17, -14, 17,
+ax_anim 2, 0, 95, -15, 16, -15, 16,
+ax_anim 2, 0, 95, -14, 17, -14, 17,
+ax_anim 2, 0, 95, -15, 16, -15, 16,
+ax_anim 2, 0, 95, -14, 17, -14, 17,
+ax_anim 2, 0, 90, -9, 12, -9, 12,
+ax_anim 2, 0, 91, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sHypnoAnims_4_1:
+ax_anim 2, 0, 99, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 99, 0, -4, 0, -4,
+ax_anim 2, 2, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 0, -4, 0, -4,
+ax_anim 1, 0, 102, 0, -3, 0, -3,
+ax_anim 1, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 0, 103, 0, 6, 0, 6,
+ax_anim 2, 1, 104, 1, 6, 1, 6,
+ax_anim 2, 0, 101, 0, 6, 0, 6,
+ax_anim 2, 0, 101, 1, 6, 1, 6,
+ax_anim 2, 0, 101, 0, 6, 0, 6,
+ax_anim 2, 0, 101, 1, 6, 1, 6,
+ax_anim 2, 0, 96, 0, 3, 0, 3,
+ax_anim_terminator
+sHypnoAnims_4_2:
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 108, -4, -4, -4, -4,
+ax_anim 2, 2, 111, -4, -4, -4, -4,
+ax_anim 2, 0, 108, -4, -4, -4, -4,
+ax_anim 1, 0, 111, -3, -3, -3, -3,
+ax_anim 1, 0, 109, 1, 1, 1, 1,
+ax_anim 2, 0, 112, 6, 6, 6, 6,
+ax_anim 2, 1, 113, 7, 6, 7, 6,
+ax_anim 2, 0, 110, 6, 6, 6, 6,
+ax_anim 2, 0, 110, 7, 6, 7, 6,
+ax_anim 2, 0, 110, 6, 6, 6, 6,
+ax_anim 2, 0, 110, 7, 6, 7, 6,
+ax_anim 2, 0, 106, 3, 3, 3, 3,
+ax_anim_terminator
+sHypnoAnims_4_3:
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 120, -3, 0, -3, 0,
+ax_anim 2, 0, 117, -4, 0, -4, 0,
+ax_anim 2, 2, 120, -4, 0, -4, 0,
+ax_anim 2, 0, 117, -4, 0, -4, 0,
+ax_anim 1, 0, 120, -3, 0, -3, 0,
+ax_anim 1, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 6, 0, 6, 0,
+ax_anim 2, 1, 122, 7, 0, 7, 0,
+ax_anim 2, 0, 119, 6, 0, 6, 0,
+ax_anim 2, 0, 119, 7, 0, 7, 0,
+ax_anim 2, 0, 119, 6, 0, 6, 0,
+ax_anim 2, 0, 119, 7, 0, 7, 0,
+ax_anim 2, 0, 115, 3, 0, 3, 0,
+ax_anim_terminator
+sHypnoAnims_4_4:
+ax_anim 2, 0, 126, -1, 1, -1, 1,
+ax_anim 2, 0, 129, -3, 3, -3, 3,
+ax_anim 2, 0, 126, -4, 4, -4, 4,
+ax_anim 2, 2, 129, -4, 4, -4, 4,
+ax_anim 2, 0, 126, -4, 4, -4, 4,
+ax_anim 1, 0, 129, -3, 3, -3, 3,
+ax_anim 1, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 130, 6, -6, 6, -6,
+ax_anim 2, 1, 131, 7, -6, 7, -6,
+ax_anim 2, 0, 128, 6, -6, 6, -6,
+ax_anim 2, 0, 128, 7, -6, 7, -6,
+ax_anim 2, 0, 128, 6, -6, 6, -6,
+ax_anim 2, 0, 128, 7, -6, 7, -6,
+ax_anim 2, 0, 124, 3, -3, 3, -3,
+ax_anim_terminator
+sHypnoAnims_4_5:
+ax_anim 2, 0, 135, 0, 1, 0, 1,
+ax_anim 2, 0, 138, 0, 3, 0, 3,
+ax_anim 2, 0, 135, 0, 4, 0, 4,
+ax_anim 2, 2, 138, 0, 4, 0, 4,
+ax_anim 2, 0, 135, 0, 4, 0, 4,
+ax_anim 1, 0, 138, 0, 3, 0, 3,
+ax_anim 1, 0, 136, 0, -1, 0, -1,
+ax_anim 2, 0, 139, 0, -6, 0, -6,
+ax_anim 2, 1, 140, -1, -6, -1, -6,
+ax_anim 2, 0, 137, 0, -6, 0, -6,
+ax_anim 2, 0, 137, -1, -6, -1, -6,
+ax_anim 2, 0, 137, 0, -6, 0, -6,
+ax_anim 2, 0, 137, -1, -6, -1, -6,
+ax_anim 2, 0, 133, 0, -3, 0, -3,
+ax_anim_terminator
+sHypnoAnims_4_6:
+ax_anim 2, 0, 144, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 3, 3, 3, 3,
+ax_anim 2, 0, 144, 4, 4, 4, 4,
+ax_anim 2, 2, 147, 4, 4, 4, 4,
+ax_anim 2, 0, 144, 4, 4, 4, 4,
+ax_anim 1, 0, 147, 3, 3, 3, 3,
+ax_anim 1, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 0, 148, -6, -6, -6, -6,
+ax_anim 2, 1, 149, -7, -6, -7, -6,
+ax_anim 2, 0, 146, -6, -6, -6, -6,
+ax_anim 2, 0, 146, -7, -6, -7, -6,
+ax_anim 2, 0, 146, -6, -6, -6, -6,
+ax_anim 2, 0, 146, -7, -6, -7, -6,
+ax_anim 2, 0, 142, -3, -3, -3, -3,
+ax_anim_terminator
+sHypnoAnims_4_7:
+ax_anim 2, 0, 153, 1, 0, 1, 0,
+ax_anim 2, 0, 156, 3, 0, 3, 0,
+ax_anim 2, 0, 153, 4, 0, 4, 0,
+ax_anim 2, 2, 156, 4, 0, 4, 0,
+ax_anim 2, 0, 153, 4, 0, 4, 0,
+ax_anim 1, 0, 156, 3, 0, 3, 0,
+ax_anim 1, 0, 154, -1, 0, -1, 0,
+ax_anim 2, 0, 157, -6, 0, -6, 0,
+ax_anim 2, 1, 158, -7, 0, -7, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, -7, 0, -7, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, -7, 0, -7, 0,
+ax_anim 2, 0, 151, -3, 0, -3, 0,
+ax_anim_terminator
+sHypnoAnims_4_8:
+ax_anim 2, 0, 162, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 3, -3, 3, -3,
+ax_anim 2, 0, 162, 4, -4, 4, -4,
+ax_anim 2, 2, 165, 4, -4, 4, -4,
+ax_anim 2, 0, 162, 4, -4, 4, -4,
+ax_anim 1, 0, 165, 3, -3, 3, -3,
+ax_anim 1, 0, 163, -1, 1, -1, 1,
+ax_anim 2, 0, 166, -6, 6, -6, 6,
+ax_anim 2, 1, 167, -7, 6, -7, 6,
+ax_anim 2, 0, 164, -6, 6, -6, 6,
+ax_anim 2, 0, 164, -7, 6, -7, 6,
+ax_anim 2, 0, 164, -6, 6, -6, 6,
+ax_anim 2, 0, 164, -7, 6, -7, 6,
+ax_anim 2, 0, 160, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sHypnoAnims_5_1:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 2, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 1, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_5_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 2, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 1, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_5_3:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 2, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 1, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_5_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 2, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 1, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_5_5:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 2, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 1, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_5_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 2, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 1, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_5_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 2, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 1, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_5_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 2, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 1, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_6_1:
+ax_anim 35, 0, 208, 0, 0, 0, 0,
+ax_anim 35, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_7_1:
+ax_anim 2, 0, 210, 0, -2, 0, -2,
+ax_anim 8, 0, 210, 0, -3, 0, -3,
+ax_anim_terminator
+sHypnoAnims_7_2:
+ax_anim 2, 0, 211, -2, -2, -2, -2,
+ax_anim 8, 0, 211, -3, -3, -3, -3,
+ax_anim_terminator
+sHypnoAnims_7_3:
+ax_anim 2, 0, 212, -2, 0, -2, 0,
+ax_anim 8, 0, 212, -3, 0, -3, 0,
+ax_anim_terminator
+sHypnoAnims_7_4:
+ax_anim 2, 0, 213, -2, 2, -2, 2,
+ax_anim 8, 0, 213, -3, 3, -3, 3,
+ax_anim_terminator
+sHypnoAnims_7_5:
+ax_anim 2, 0, 214, 0, 2, 0, 2,
+ax_anim 8, 0, 214, 0, 3, 0, 3,
+ax_anim_terminator
+sHypnoAnims_7_6:
+ax_anim 2, 0, 215, 2, 2, 2, 2,
+ax_anim 8, 0, 215, 3, 3, 3, 3,
+ax_anim_terminator
+sHypnoAnims_7_7:
+ax_anim 2, 0, 216, 2, 0, 2, 0,
+ax_anim 8, 0, 216, 3, 0, 3, 0,
+ax_anim_terminator
+sHypnoAnims_7_8:
+ax_anim 2, 0, 217, 2, -2, 2, -2,
+ax_anim 8, 0, 217, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sHypnoAnims_8_1:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -2, 0, 0,
+ax_anim 2, 0, 219, 0, -4, 0, 0,
+ax_anim 3, 0, 219, 0, -5, 0, 0,
+ax_anim 3, 0, 218, 0, -5, 0, 0,
+ax_anim 3, 0, 220, 0, -5, 0, 0,
+ax_anim 2, 0, 220, 0, -4, 0, 0,
+ax_anim 1, 0, 220, 0, -2, 0, 0,
+ax_anim_terminator
+sHypnoAnims_8_2:
+ax_anim 30, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -2, 0, 0,
+ax_anim 2, 0, 222, 0, -4, 0, 0,
+ax_anim 3, 0, 222, 0, -5, 0, 0,
+ax_anim 3, 0, 221, 0, -5, 0, 0,
+ax_anim 3, 0, 223, 0, -5, 0, 0,
+ax_anim 2, 0, 223, 0, -4, 0, 0,
+ax_anim 1, 0, 223, 0, -2, 0, 0,
+ax_anim_terminator
+sHypnoAnims_8_3:
+ax_anim 30, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 2, 0, 225, 0, -4, 0, 0,
+ax_anim 3, 0, 225, 0, -5, 0, 0,
+ax_anim 3, 0, 224, 0, -5, 0, 0,
+ax_anim 3, 0, 226, 0, -5, 0, 0,
+ax_anim 2, 0, 226, 0, -4, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim_terminator
+sHypnoAnims_8_4:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -2, 0, 0,
+ax_anim 2, 0, 228, 0, -4, 0, 0,
+ax_anim 3, 0, 228, 0, -5, 0, 0,
+ax_anim 3, 0, 227, 0, -5, 0, 0,
+ax_anim 3, 0, 229, 0, -5, 0, 0,
+ax_anim 2, 0, 229, 0, -4, 0, 0,
+ax_anim 1, 0, 229, 0, -2, 0, 0,
+ax_anim_terminator
+sHypnoAnims_8_5:
+ax_anim 30, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -2, 0, 0,
+ax_anim 2, 0, 231, 0, -4, 0, 0,
+ax_anim 3, 0, 231, 0, -5, 0, 0,
+ax_anim 3, 0, 230, 0, -5, 0, 0,
+ax_anim 3, 0, 232, 0, -5, 0, 0,
+ax_anim 2, 0, 232, 0, -4, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim_terminator
+sHypnoAnims_8_6:
+ax_anim 30, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 2, 0, 234, 0, -4, 0, 0,
+ax_anim 3, 0, 234, 0, -5, 0, 0,
+ax_anim 3, 0, 233, 0, -5, 0, 0,
+ax_anim 3, 0, 235, 0, -5, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim_terminator
+sHypnoAnims_8_7:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -2, 0, 0,
+ax_anim 2, 0, 237, 0, -4, 0, 0,
+ax_anim 3, 0, 237, 0, -5, 0, 0,
+ax_anim 3, 0, 236, 0, -5, 0, 0,
+ax_anim 3, 0, 238, 0, -5, 0, 0,
+ax_anim 2, 0, 238, 0, -4, 0, 0,
+ax_anim 1, 0, 238, 0, -2, 0, 0,
+ax_anim_terminator
+sHypnoAnims_8_8:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 2, 0, 240, 0, -4, 0, 0,
+ax_anim 3, 0, 240, 0, -5, 0, 0,
+ax_anim 3, 0, 239, 0, -5, 0, 0,
+ax_anim 3, 0, 241, 0, -5, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_9_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 6, 3, 6, 3,
+ax_anim 2, 0, 244, 8, 9, 8, 9,
+ax_anim 2, 0, 245, 7, 18, 7, 18,
+ax_anim 3, 0, 246, 0, 21, 0, 21,
+ax_anim 2, 3, 247, -7, 18, -7, 18,
+ax_anim 2, 0, 248, -8, 9, -8, 9,
+ax_anim 1, 0, 249, -6, 3, -6, 3,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_9_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 243, 19, 5, 19, 5,
+ax_anim 2, 0, 244, 23, 12, 23, 12,
+ax_anim 3, 0, 245, 23, 20, 23, 20,
+ax_anim 2, 3, 246, 13, 22, 13, 22,
+ax_anim 2, 0, 247, 3, 17, 3, 17,
+ax_anim 1, 0, 248, 0, 7, 0, 7,
+ax_anim 1, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_9_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 3, -5, 3, -5,
+ax_anim 2, 0, 242, 11, -5, 11, -6,
+ax_anim 2, 0, 243, 18, -5, 18, -5,
+ax_anim 3, 0, 244, 23, -2, 23, -2,
+ax_anim 2, 3, 245, 20, 4, 20, 4,
+ax_anim 2, 0, 246, 12, 5, 12, 5,
+ax_anim 1, 0, 247, 4, 5, 4, 5,
+ax_anim 1, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_9_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, -1, -8, -1, -8,
+ax_anim 2, 0, 249, 2, -16, 2, -16,
+ax_anim 2, 0, 242, 11, -20, 11, -20,
+ax_anim 3, 0, 243, 22, -22, 22, -22,
+ax_anim 2, 3, 244, 23, -13, 23, -13,
+ax_anim 2, 0, 245, 17, -4, 17, -4,
+ax_anim 1, 0, 246, 8, -1, 8, -1,
+ax_anim 1, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_9_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 247, -8, -4, -8, -4,
+ax_anim 2, 0, 248, -9, -12, -9, -12,
+ax_anim 2, 0, 249, -7, -18, -7, -18,
+ax_anim 3, 0, 242, 0, -21, 0, -22,
+ax_anim 2, 3, 243, 7, -18, 7, -18,
+ax_anim 2, 0, 244, 9, -10, 9, -10,
+ax_anim 1, 0, 245, 8, -4, 8, -4,
+ax_anim 1, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_9_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 244, 1, -8, 1, -8,
+ax_anim 2, 0, 243, -2, -16, -2, -16,
+ax_anim 2, 0, 242, -11, -20, -11, -20,
+ax_anim 3, 0, 249, -22, -22, -22, -22,
+ax_anim 2, 3, 248, -23, -13, -23, -13,
+ax_anim 2, 0, 247, -17, -4, -17, -4,
+ax_anim 1, 0, 246, -8, -1, -8, -1,
+ax_anim 1, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_9_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 243, -3, -5, -3, -5,
+ax_anim 2, 0, 242, -11, -5, -11, -6,
+ax_anim 2, 0, 249, -18, -5, -18, -5,
+ax_anim 3, 0, 248, -23, -2, -23, -2,
+ax_anim 2, 3, 247, -20, 4, -20, 4,
+ax_anim 2, 0, 246, -12, 5, -12, 5,
+ax_anim 1, 0, 245, -4, 5, -4, 5,
+ax_anim 1, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_9_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 249, -19, 5, -19, 5,
+ax_anim 2, 0, 248, -23, 12, -23, 12,
+ax_anim 3, 0, 247, -23, 20, -23, 20,
+ax_anim 2, 3, 246, -13, 22, -13, 22,
+ax_anim 2, 0, 245, -3, 17, -3, 17,
+ax_anim 1, 0, 244, 0, 7, 0, 7,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_10_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 3, 0, 250, 13, 0, 13, 0,
+ax_anim 3, 0, 250, -13, 0, -13, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_10_2:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 3, 0, 251, 13, -13, 13, -13,
+ax_anim 3, 0, 251, -13, 13, -13, 13,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_10_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 3, 0, 252, 0, -13, 0, -13,
+ax_anim 3, 0, 252, 0, 13, 0, 13,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_10_4:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 3, 0, 253, -13, -13, -13, -13,
+ax_anim 3, 0, 253, 13, 13, 13, 13,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_10_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 6, 0, 6, 0,
+ax_anim 2, 0, 254, -6, 0, -6, 0,
+ax_anim 2, 0, 254, 10, 0, 10, 0,
+ax_anim 2, 0, 254, -10, 0, -10, 0,
+ax_anim 2, 0, 254, 12, 0, 12, 0,
+ax_anim 3, 0, 254, -12, 0, -12, 0,
+ax_anim 3, 0, 254, 13, 0, 13, 0,
+ax_anim 3, 0, 254, -13, 0, -13, 0,
+ax_anim 2, 0, 254, 12, 0, 12, 0,
+ax_anim 3, 0, 254, -12, 0, -12, 0,
+ax_anim 2, 0, 254, 10, 0, 10, 0,
+ax_anim 2, 0, 254, -10, 0, -10, 0,
+ax_anim 2, 0, 254, 6, 0, 6, 0,
+ax_anim 2, 0, 254, -6, 0, -6, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_10_6:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 6, -6, 6, -6,
+ax_anim 2, 0, 255, -6, 6, -6, 6,
+ax_anim 2, 0, 255, 10, -10, 10, -10,
+ax_anim 2, 0, 255, -10, 10, -10, 10,
+ax_anim 2, 0, 255, 12, -12, 12, -12,
+ax_anim 3, 0, 255, -12, 12, -12, 12,
+ax_anim 3, 0, 255, 13, -13, 13, -13,
+ax_anim 3, 0, 255, -13, 13, -13, 13,
+ax_anim 2, 0, 255, 12, -12, 12, -12,
+ax_anim 3, 0, 255, -12, 12, -12, 12,
+ax_anim 2, 0, 255, 10, -10, 10, -10,
+ax_anim 2, 0, 255, -10, 10, -10, 10,
+ax_anim 2, 0, 255, 6, -6, 6, -6,
+ax_anim 2, 0, 255, -6, 6, -6, 6,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_10_7:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -6, 0, -6,
+ax_anim 2, 0, 256, 0, 6, 0, 6,
+ax_anim 2, 0, 256, 0, -10, 0, -10,
+ax_anim 2, 0, 256, 0, 10, 0, 10,
+ax_anim 2, 0, 256, 0, -12, 0, -12,
+ax_anim 3, 0, 256, 0, 12, 0, 12,
+ax_anim 3, 0, 256, 0, -13, 0, -13,
+ax_anim 3, 0, 256, 0, 13, 0, 13,
+ax_anim 2, 0, 256, 0, -12, 0, -12,
+ax_anim 3, 0, 256, 0, 12, 0, 12,
+ax_anim 2, 0, 256, 0, -10, 0, -10,
+ax_anim 2, 0, 256, 0, 10, 0, 10,
+ax_anim 2, 0, 256, 0, -6, 0, -6,
+ax_anim 2, 0, 256, 0, 6, 0, 6,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_10_8:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, -6, -6, -6, -6,
+ax_anim 2, 0, 257, 6, 6, 6, 6,
+ax_anim 2, 0, 257, -10, -10, -10, -10,
+ax_anim 2, 0, 257, 10, 10, 10, 10,
+ax_anim 2, 0, 257, -12, -12, -12, -12,
+ax_anim 3, 0, 257, 12, 12, 12, 12,
+ax_anim 3, 0, 257, -13, -13, -13, -13,
+ax_anim 3, 0, 257, 13, 13, 13, 13,
+ax_anim 2, 0, 257, -12, -12, -12, -12,
+ax_anim 3, 0, 257, 12, 12, 12, 12,
+ax_anim 2, 0, 257, -10, -10, -10, -10,
+ax_anim 2, 0, 257, 10, 10, 10, 10,
+ax_anim 2, 0, 257, -6, -6, -6, -6,
+ax_anim 2, 0, 257, 6, 6, 6, 6,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_11_1:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -10, 0, 0,
+ax_anim 2, 0, 260, 0, -16, 0, 0,
+ax_anim 3, 0, 260, 0, -20, 0, 0,
+ax_anim 4, 0, 260, 0, -21, 0, 0,
+ax_anim 4, 0, 261, 0, -25, 0, 0,
+ax_anim 3, 0, 261, 0, -23, 0, 0,
+ax_anim 2, 0, 261, 0, -18, 0, 0,
+ax_anim 1, 0, 261, 0, -12, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_11_2:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 264, 0, -23, 0, 0,
+ax_anim 3, 0, 264, 0, -22, 0, 0,
+ax_anim 2, 0, 264, 0, -18, 0, 0,
+ax_anim 1, 0, 264, 0, -12, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_11_3:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 267, 0, -25, 0, 0,
+ax_anim 3, 0, 267, 0, -24, 0, 0,
+ax_anim 2, 0, 267, 0, -18, 0, 0,
+ax_anim 1, 0, 267, 0, -12, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_11_4:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 270, 0, -22, 0, 0,
+ax_anim 3, 0, 270, 0, -21, 0, 0,
+ax_anim 2, 0, 270, 0, -17, 0, 0,
+ax_anim 1, 0, 270, 0, -11, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_11_5:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 273, 0, -24, 0, 0,
+ax_anim 3, 0, 273, 0, -23, 0, 0,
+ax_anim 2, 0, 273, 0, -18, 0, 0,
+ax_anim 1, 0, 273, 0, -12, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_11_6:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 275, 0, -10, 0, 0,
+ax_anim 2, 0, 275, 0, -16, 0, 0,
+ax_anim 3, 0, 275, 0, -20, 0, 0,
+ax_anim 4, 0, 275, 0, -21, 0, 0,
+ax_anim 4, 0, 276, 0, -23, 0, 0,
+ax_anim 3, 0, 276, 0, -21, 0, 0,
+ax_anim 2, 0, 276, 0, -17, 0, 0,
+ax_anim 1, 0, 276, 0, -11, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_11_7:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 1, 0, 278, 0, -10, 0, 0,
+ax_anim 2, 0, 278, 0, -16, 0, 0,
+ax_anim 3, 0, 278, 0, -20, 0, 0,
+ax_anim 4, 0, 278, 0, -21, 0, 0,
+ax_anim 4, 0, 279, 0, -25, 0, 0,
+ax_anim 3, 0, 279, 0, -24, 0, 0,
+ax_anim 2, 0, 279, 0, -18, 0, 0,
+ax_anim 1, 0, 279, 0, -12, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_11_8:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 1, 0, 281, 0, -10, 0, 0,
+ax_anim 2, 0, 281, 0, -16, 0, 0,
+ax_anim 3, 0, 281, 0, -20, 0, 0,
+ax_anim 4, 0, 281, 0, -21, 0, 0,
+ax_anim 4, 0, 282, 0, -24, 0, 0,
+ax_anim 3, 0, 282, 0, -23, 0, 0,
+ax_anim 2, 0, 282, 0, -18, 0, 0,
+ax_anim 1, 0, 282, 0, -12, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_12_1:
+ax_anim 2, 0, 283, 1, 0, 1, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 1, 0, 1, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 1, 0, 1, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 1, 0, 1, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 1, 0, 1, 0,
+ax_anim 2, 1, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_12_2:
+ax_anim 2, 0, 290, 1, -1, 1, -1,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, -1, 1, -1,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, -1, 1, -1,
+ax_anim 2, 2, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, -1, 1, -1,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, -1, 1, -1,
+ax_anim 2, 1, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_12_3:
+ax_anim 2, 0, 289, 0, -1, 0, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, -1, 0, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, -1, 0, -1,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, -1, 0, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, -1, 0, -1,
+ax_anim 2, 1, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_12_4:
+ax_anim 2, 0, 288, -1, -1, -1, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, -1, -1, -1, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, -1, -1, -1, -1,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, -1, -1, -1, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, -1, -1, -1, -1,
+ax_anim 2, 1, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_12_5:
+ax_anim 2, 0, 287, 1, 0, 1, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 0, 1, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 0, 1, 0,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 0, 1, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 1, 0, 1, 0,
+ax_anim 2, 1, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_12_6:
+ax_anim 2, 0, 286, 1, -1, 1, -1,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, -1, 1, -1,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, -1, 1, -1,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, -1, 1, -1,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, -1, 1, -1,
+ax_anim 2, 1, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_12_7:
+ax_anim 2, 0, 285, 0, -1, 0, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, -1, 0, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, -1, 0, -1,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, -1, 0, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, -1, 0, -1,
+ax_anim 2, 1, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_12_8:
+ax_anim 2, 0, 284, -1, -1, -1, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, -1, -1, -1, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, -1, -1, -1, -1,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, -1, -1, -1, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, -1, -1, -1, -1,
+ax_anim 2, 1, 284, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sHypnoAnims_13_1:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 2, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_13_2:
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 2, 299, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_13_3:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 2, 298, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_13_4:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 2, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_13_5:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 2, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_13_6:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 2, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_13_7:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 2, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoAnims_13_8:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 2, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sHypnoGfx1:
+.incbin "baserom.gba", 0x9220B4, 0x200
+sHypnoSprites1:
+ax_sprite sHypnoGfx1, 0x200
+ax_sprite_terminator
+sHypnoGfx2:
+.incbin "baserom.gba", 0x9222C4, 0x200
+sHypnoSprites2:
+ax_sprite sHypnoGfx2, 0x200
+ax_sprite_terminator
+sHypnoGfx3:
+.incbin "baserom.gba", 0x9224D4, 0x200
+sHypnoSprites3:
+ax_sprite sHypnoGfx3, 0x200
+ax_sprite_terminator
+sHypnoGfx4:
+.incbin "baserom.gba", 0x9226E4, 0x200
+sHypnoSprites4:
+ax_sprite sHypnoGfx4, 0x200
+ax_sprite_terminator
+sHypnoGfx5:
+.incbin "baserom.gba", 0x9228F4, 0x200
+sHypnoSprites5:
+ax_sprite sHypnoGfx5, 0x200
+ax_sprite_terminator
+sHypnoGfx6:
+.incbin "baserom.gba", 0x922B04, 0x200
+sHypnoSprites6:
+ax_sprite sHypnoGfx6, 0x200
+ax_sprite_terminator
+sHypnoGfx7:
+.incbin "baserom.gba", 0x922D14, 0x200
+sHypnoSprites7:
+ax_sprite sHypnoGfx7, 0x200
+ax_sprite_terminator
+sHypnoGfx8:
+.incbin "baserom.gba", 0x922F24, 0x200
+sHypnoSprites8:
+ax_sprite sHypnoGfx8, 0x200
+ax_sprite_terminator
+sHypnoGfx9:
+.incbin "baserom.gba", 0x923134, 0x200
+sHypnoSprites9:
+ax_sprite sHypnoGfx9, 0x200
+ax_sprite_terminator
+sHypnoGfx10:
+.incbin "baserom.gba", 0x923344, 0x200
+sHypnoSprites10:
+ax_sprite sHypnoGfx10, 0x200
+ax_sprite_terminator
+sHypnoGfx11:
+.incbin "baserom.gba", 0x923554, 0x200
+sHypnoSprites11:
+ax_sprite sHypnoGfx11, 0x200
+ax_sprite_terminator
+sHypnoGfx12:
+.incbin "baserom.gba", 0x923764, 0x200
+sHypnoSprites12:
+ax_sprite sHypnoGfx12, 0x200
+ax_sprite_terminator
+sHypnoGfx13:
+.incbin "baserom.gba", 0x923974, 0x200
+sHypnoSprites13:
+ax_sprite sHypnoGfx13, 0x200
+ax_sprite_terminator
+sHypnoGfx14:
+.incbin "baserom.gba", 0x923B84, 0x200
+sHypnoSprites14:
+ax_sprite sHypnoGfx14, 0x200
+ax_sprite_terminator
+sHypnoGfx15:
+.incbin "baserom.gba", 0x923D94, 0x200
+sHypnoSprites15:
+ax_sprite sHypnoGfx15, 0x200
+ax_sprite_terminator
+sHypnoGfx16:
+.incbin "baserom.gba", 0x923FA4, 0x200
+sHypnoSprites16:
+ax_sprite sHypnoGfx16, 0x200
+ax_sprite_terminator
+sHypnoGfx17:
+.incbin "baserom.gba", 0x9241B4, 0x200
+sHypnoSprites17:
+ax_sprite sHypnoGfx17, 0x200
+ax_sprite_terminator
+sHypnoGfx18:
+.incbin "baserom.gba", 0x9243C4, 0x200
+sHypnoSprites18:
+ax_sprite sHypnoGfx18, 0x200
+ax_sprite_terminator
+sHypnoGfx19:
+.incbin "baserom.gba", 0x9245D4, 0x200
+sHypnoSprites19:
+ax_sprite sHypnoGfx19, 0x200
+ax_sprite_terminator
+sHypnoGfx20:
+.incbin "baserom.gba", 0x9247E4, 0x200
+sHypnoSprites20:
+ax_sprite sHypnoGfx20, 0x200
+ax_sprite_terminator
+sHypnoGfx21:
+.incbin "baserom.gba", 0x9249F4, 0x200
+sHypnoSprites21:
+ax_sprite sHypnoGfx21, 0x200
+ax_sprite_terminator
+sHypnoGfx22:
+.incbin "baserom.gba", 0x924C04, 0x200
+sHypnoSprites22:
+ax_sprite sHypnoGfx22, 0x200
+ax_sprite_terminator
+sHypnoGfx23:
+.incbin "baserom.gba", 0x924E14, 0x200
+sHypnoSprites23:
+ax_sprite sHypnoGfx23, 0x200
+ax_sprite_terminator
+sHypnoGfx24:
+.incbin "baserom.gba", 0x925024, 0x200
+sHypnoSprites24:
+ax_sprite sHypnoGfx24, 0x200
+ax_sprite_terminator
+sHypnoGfx25:
+.incbin "baserom.gba", 0x925234, 0x40
+sHypnoGfx25_1:
+.incbin "baserom.gba", 0x925274, 0x60
+sHypnoGfx25_2:
+.incbin "baserom.gba", 0x9252D4, 0x60
+sHypnoSprites25:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx25_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHypnoGfx26:
+.incbin "baserom.gba", 0x925374, 0x20
+sHypnoGfx26_1:
+.incbin "baserom.gba", 0x925394, 0x40
+sHypnoGfx26_2:
+.incbin "baserom.gba", 0x9253D4, 0x60
+sHypnoGfx26_3:
+.incbin "baserom.gba", 0x925434, 0x20
+sHypnoSprites26:
+ax_sprite sHypnoGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHypnoGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHypnoGfx27:
+.incbin "baserom.gba", 0x92549C, 0x40
+sHypnoGfx27_1:
+.incbin "baserom.gba", 0x9254DC, 0x120
+sHypnoSprites27:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx27_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHypnoGfx28:
+.incbin "baserom.gba", 0x92562C, 0x40
+sHypnoGfx28_1:
+.incbin "baserom.gba", 0x92566C, 0x60
+sHypnoGfx28_2:
+.incbin "baserom.gba", 0x9256CC, 0x60
+sHypnoGfx28_3:
+.incbin "baserom.gba", 0x92572C, 0x60
+sHypnoSprites28:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx29:
+.incbin "baserom.gba", 0x9257DC, 0x20
+sHypnoGfx29_1:
+.incbin "baserom.gba", 0x9257FC, 0x80
+sHypnoGfx29_2:
+.incbin "baserom.gba", 0x92587C, 0x60
+sHypnoSprites29:
+ax_sprite 0, 0x80
+ax_sprite sHypnoGfx29, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHypnoGfx29_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx29_2, 0x60
+ax_sprite_terminator
+sHypnoGfx30:
+.incbin "baserom.gba", 0x925914, 0x60
+sHypnoGfx30_1:
+.incbin "baserom.gba", 0x925974, 0x60
+sHypnoGfx30_2:
+.incbin "baserom.gba", 0x9259D4, 0x60
+sHypnoSprites30:
+ax_sprite 0, 0xa0
+ax_sprite sHypnoGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx30_2, 0x60
+ax_sprite_terminator
+sHypnoGfx31:
+.incbin "baserom.gba", 0x925A6C, 0x40
+sHypnoGfx31_1:
+.incbin "baserom.gba", 0x925AAC, 0x160
+sHypnoSprites31:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx31_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx32:
+.incbin "baserom.gba", 0x925C3C, 0xC0
+sHypnoSprites32:
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx32, 0xc0
+ax_sprite_terminator
+sHypnoGfx33:
+.incbin "baserom.gba", 0x925D14, 0x20
+sHypnoGfx33_1:
+.incbin "baserom.gba", 0x925D34, 0x100
+sHypnoGfx33_2:
+.incbin "baserom.gba", 0x925E34, 0x60
+sHypnoSprites33:
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx33_2, 0x60
+ax_sprite_terminator
+sHypnoGfx34:
+.incbin "baserom.gba", 0x925ECC, 0x1A0
+sHypnoSprites34:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx34, 0x1a0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHypnoGfx35:
+.incbin "baserom.gba", 0x92608C, 0x40
+sHypnoGfx35_1:
+.incbin "baserom.gba", 0x9260CC, 0x40
+sHypnoGfx35_2:
+.incbin "baserom.gba", 0x92610C, 0x40
+sHypnoGfx35_3:
+.incbin "baserom.gba", 0x92614C, 0x40
+sHypnoSprites35:
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx36:
+.incbin "baserom.gba", 0x9261DC, 0x160
+sHypnoGfx36_1:
+.incbin "baserom.gba", 0x92633C, 0x20
+sHypnoSprites36:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx36, 0x160
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx36_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHypnoGfx37:
+.incbin "baserom.gba", 0x92638C, 0x40
+sHypnoGfx37_1:
+.incbin "baserom.gba", 0x9263CC, 0x40
+sHypnoGfx37_2:
+.incbin "baserom.gba", 0x92640C, 0xE0
+sHypnoSprites37:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx37_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx37_2, 0xe0
+ax_sprite_terminator
+sHypnoGfx38:
+.incbin "baserom.gba", 0x926524, 0x60
+sHypnoGfx38_1:
+.incbin "baserom.gba", 0x926584, 0x40
+sHypnoGfx38_2:
+.incbin "baserom.gba", 0x9265C4, 0x20
+sHypnoGfx38_3:
+.incbin "baserom.gba", 0x9265E4, 0x20
+sHypnoSprites38:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx38, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx38_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sHypnoGfx38_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sHypnoGfx38_3, 0x20
+ax_sprite_terminator
+sHypnoGfx39:
+.incbin "baserom.gba", 0x92664C, 0x40
+sHypnoGfx39_1:
+.incbin "baserom.gba", 0x92668C, 0x40
+sHypnoGfx39_2:
+.incbin "baserom.gba", 0x9266CC, 0x60
+sHypnoGfx39_3:
+.incbin "baserom.gba", 0x92672C, 0x60
+sHypnoSprites39:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx40:
+.incbin "baserom.gba", 0x9267DC, 0x40
+sHypnoGfx40_1:
+.incbin "baserom.gba", 0x92681C, 0x60
+sHypnoGfx40_2:
+.incbin "baserom.gba", 0x92687C, 0x60
+sHypnoGfx40_3:
+.incbin "baserom.gba", 0x9268DC, 0x60
+sHypnoSprites40:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx40_3, 0x60
+ax_sprite_terminator
+sHypnoGfx41:
+.incbin "baserom.gba", 0x926984, 0x40
+sHypnoGfx41_1:
+.incbin "baserom.gba", 0x9269C4, 0x60
+sHypnoGfx41_2:
+.incbin "baserom.gba", 0x926A24, 0x20
+sHypnoSprites41:
+ax_sprite sHypnoGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx41_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sHypnoGfx41_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sHypnoGfx42:
+.incbin "baserom.gba", 0x926A7C, 0x40
+sHypnoGfx42_1:
+.incbin "baserom.gba", 0x926ABC, 0x60
+sHypnoGfx42_2:
+.incbin "baserom.gba", 0x926B1C, 0x60
+sHypnoGfx42_3:
+.incbin "baserom.gba", 0x926B7C, 0x40
+sHypnoSprites42:
+ax_sprite sHypnoGfx42, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx42_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx42_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx43:
+.incbin "baserom.gba", 0x926C04, 0x40
+sHypnoGfx43_1:
+.incbin "baserom.gba", 0x926C44, 0x100
+sHypnoGfx43_2:
+.incbin "baserom.gba", 0x926D44, 0x60
+sHypnoSprites43:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx43_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx43_2, 0x60
+ax_sprite_terminator
+sHypnoGfx44:
+.incbin "baserom.gba", 0x926DDC, 0x20
+sHypnoGfx44_1:
+.incbin "baserom.gba", 0x926DFC, 0x20
+sHypnoGfx44_2:
+.incbin "baserom.gba", 0x926E1C, 0x80
+sHypnoGfx44_3:
+.incbin "baserom.gba", 0x926E9C, 0x40
+sHypnoSprites44:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx44, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx44_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx44_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx44_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHypnoGfx45:
+.incbin "baserom.gba", 0x926F2C, 0x40
+sHypnoGfx45_1:
+.incbin "baserom.gba", 0x926F6C, 0x180
+sHypnoSprites45:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx45_1, 0x180
+ax_sprite_terminator
+sHypnoGfx46:
+.incbin "baserom.gba", 0x927114, 0x20
+sHypnoGfx46_1:
+.incbin "baserom.gba", 0x927134, 0x60
+sHypnoGfx46_2:
+.incbin "baserom.gba", 0x927194, 0x60
+sHypnoGfx46_3:
+.incbin "baserom.gba", 0x9271F4, 0x60
+sHypnoSprites46:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx46, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx46_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx47:
+.incbin "baserom.gba", 0x9272A4, 0x20
+sHypnoGfx47_1:
+.incbin "baserom.gba", 0x9272C4, 0x60
+sHypnoGfx47_2:
+.incbin "baserom.gba", 0x927324, 0x40
+sHypnoGfx47_3:
+.incbin "baserom.gba", 0x927364, 0x40
+sHypnoSprites47:
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx47, 0x20
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx47_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx47_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sHypnoGfx48:
+.incbin "baserom.gba", 0x9273F4, 0x60
+sHypnoGfx48_1:
+.incbin "baserom.gba", 0x927454, 0xE0
+sHypnoSprites48:
+ax_sprite 0, 0x80
+ax_sprite sHypnoGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx48_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx49:
+.incbin "baserom.gba", 0x927564, 0x20
+sHypnoSprites49:
+ax_sprite sHypnoGfx49, 0x20
+ax_sprite_terminator
+sHypnoGfx50:
+.incbin "baserom.gba", 0x927594, 0x80
+sHypnoSprites50:
+ax_sprite sHypnoGfx50, 0x80
+ax_sprite_terminator
+sHypnoGfx51:
+.incbin "baserom.gba", 0x927624, 0x60
+sHypnoGfx51_1:
+.incbin "baserom.gba", 0x927684, 0x100
+sHypnoSprites51:
+ax_sprite sHypnoGfx51, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx51_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHypnoGfx52:
+.incbin "baserom.gba", 0x9277AC, 0x40
+sHypnoGfx52_1:
+.incbin "baserom.gba", 0x9277EC, 0x100
+sHypnoSprites52:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx52, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx52_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sHypnoGfx53:
+.incbin "baserom.gba", 0x92791C, 0x60
+sHypnoGfx53_1:
+.incbin "baserom.gba", 0x92797C, 0xE0
+sHypnoSprites53:
+ax_sprite 0, 0xa0
+ax_sprite sHypnoGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx53_1, 0xe0
+ax_sprite_terminator
+sHypnoGfx54:
+.incbin "baserom.gba", 0x927A84, 0x20
+sHypnoGfx54_1:
+.incbin "baserom.gba", 0x927AA4, 0x60
+sHypnoGfx54_2:
+.incbin "baserom.gba", 0x927B04, 0xE0
+sHypnoSprites54:
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx54, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx54_2, 0xe0
+ax_sprite_terminator
+sHypnoGfx55:
+.incbin "baserom.gba", 0x927C1C, 0x20
+sHypnoGfx55_1:
+.incbin "baserom.gba", 0x927C3C, 0x60
+sHypnoGfx55_2:
+.incbin "baserom.gba", 0x927C9C, 0x60
+sHypnoGfx55_3:
+.incbin "baserom.gba", 0x927CFC, 0x60
+sHypnoSprites55:
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx55, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx55_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx55_3, 0x60
+ax_sprite_terminator
+sHypnoGfx56:
+.incbin "baserom.gba", 0x927DA4, 0x20
+sHypnoGfx56_1:
+.incbin "baserom.gba", 0x927DC4, 0x60
+sHypnoGfx56_2:
+.incbin "baserom.gba", 0x927E24, 0x60
+sHypnoGfx56_3:
+.incbin "baserom.gba", 0x927E84, 0x40
+sHypnoSprites56:
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx56, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx56_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx56_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx57:
+.incbin "baserom.gba", 0x927F14, 0x40
+sHypnoGfx57_1:
+.incbin "baserom.gba", 0x927F54, 0x140
+sHypnoSprites57:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx57, 0x40
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx57_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx58:
+.incbin "baserom.gba", 0x9280C4, 0x40
+sHypnoGfx58_1:
+.incbin "baserom.gba", 0x928104, 0x160
+sHypnoSprites58:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx58, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx58_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx59:
+.incbin "baserom.gba", 0x928294, 0x40
+sHypnoGfx59_1:
+.incbin "baserom.gba", 0x9282D4, 0x180
+sHypnoSprites59:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx59_1, 0x180
+ax_sprite_terminator
+sHypnoGfx60:
+.incbin "baserom.gba", 0x92847C, 0x180
+sHypnoSprites60:
+ax_sprite 0, 0x80
+ax_sprite sHypnoGfx60, 0x180
+ax_sprite_terminator
+sHypnoGfx61:
+.incbin "baserom.gba", 0x928614, 0x40
+sHypnoGfx61_1:
+.incbin "baserom.gba", 0x928654, 0x100
+sHypnoGfx61_2:
+.incbin "baserom.gba", 0x928754, 0x60
+sHypnoSprites61:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx61, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx61_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx61_2, 0x60
+ax_sprite_terminator
+sHypnoGfx62:
+.incbin "baserom.gba", 0x9287EC, 0x40
+sHypnoGfx62_1:
+.incbin "baserom.gba", 0x92882C, 0x60
+sHypnoGfx62_2:
+.incbin "baserom.gba", 0x92888C, 0x100
+sHypnoSprites62:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx62, 0x40
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx62_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx62_2, 0x100
+ax_sprite_terminator
+sHypnoGfx63:
+.incbin "baserom.gba", 0x9289C4, 0x20
+sHypnoGfx63_1:
+.incbin "baserom.gba", 0x9289E4, 0x60
+sHypnoGfx63_2:
+.incbin "baserom.gba", 0x928A44, 0x60
+sHypnoGfx63_3:
+.incbin "baserom.gba", 0x928AA4, 0x60
+sHypnoSprites63:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx63, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx63_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx63_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx63_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx64:
+.incbin "baserom.gba", 0x928B54, 0x20
+sHypnoGfx64_1:
+.incbin "baserom.gba", 0x928B74, 0x60
+sHypnoGfx64_2:
+.incbin "baserom.gba", 0x928BD4, 0x60
+sHypnoGfx64_3:
+.incbin "baserom.gba", 0x928C34, 0x40
+sHypnoSprites64:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx64, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx64_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx64_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx64_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx65:
+.incbin "baserom.gba", 0x928CC4, 0x20
+sHypnoGfx65_1:
+.incbin "baserom.gba", 0x928CE4, 0x60
+sHypnoGfx65_2:
+.incbin "baserom.gba", 0x928D44, 0x60
+sHypnoGfx65_3:
+.incbin "baserom.gba", 0x928DA4, 0x40
+sHypnoSprites65:
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx65, 0x20
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx65_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx65_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sHypnoGfx65_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sHypnoGfx66:
+.incbin "baserom.gba", 0x928E34, 0x60
+sHypnoGfx66_1:
+.incbin "baserom.gba", 0x928E94, 0x80
+sHypnoGfx66_2:
+.incbin "baserom.gba", 0x928F14, 0x60
+sHypnoSprites66:
+ax_sprite 0, 0x80
+ax_sprite sHypnoGfx66, 0x60
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx66_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sHypnoGfx66_2, 0x60
+ax_sprite_terminator
+sHypnoGfx67:
+.incbin "baserom.gba", 0x928FAC, 0x200
+sHypnoSprites67:
+ax_sprite sHypnoGfx67, 0x200
+ax_sprite_terminator
+sHypnoGfx68:
+.incbin "baserom.gba", 0x9291BC, 0x200
+sHypnoSprites68:
+ax_sprite sHypnoGfx68, 0x200
+ax_sprite_terminator
+sHypnoGfx69:
+.incbin "baserom.gba", 0x9293CC, 0x200
+sHypnoSprites69:
+ax_sprite sHypnoGfx69, 0x200
+ax_sprite_terminator
+sHypnoGfx70:
+.incbin "baserom.gba", 0x9295DC, 0x200
+sHypnoSprites70:
+ax_sprite sHypnoGfx70, 0x200
+ax_sprite_terminator
+sHypnoGfx71:
+.incbin "baserom.gba", 0x9297EC, 0x200
+sHypnoSprites71:
+ax_sprite sHypnoGfx71, 0x200
+ax_sprite_terminator
+sHypnoGfx72:
+.incbin "baserom.gba", 0x9299FC, 0x200
+sHypnoSprites72:
+ax_sprite sHypnoGfx72, 0x200
+ax_sprite_terminator
+sHypnoGfx73:
+.incbin "baserom.gba", 0x929C0C, 0x200
+sHypnoSprites73:
+ax_sprite sHypnoGfx73, 0x200
+ax_sprite_terminator
+sAxPosesHypno:
+.4byte sHypnoPose1
+.4byte sHypnoPose2
+.4byte sHypnoPose3
+.4byte sHypnoPose4
+.4byte sHypnoPose5
+.4byte sHypnoPose6
+.4byte sHypnoPose7
+.4byte sHypnoPose8
+.4byte sHypnoPose9
+.4byte sHypnoPose10
+.4byte sHypnoPose11
+.4byte sHypnoPose12
+.4byte sHypnoPose13
+.4byte sHypnoPose14
+.4byte sHypnoPose15
+.4byte sHypnoPose16
+.4byte sHypnoPose17
+.4byte sHypnoPose18
+.4byte sHypnoPose19
+.4byte sHypnoPose20
+.4byte sHypnoPose21
+.4byte sHypnoPose22
+.4byte sHypnoPose23
+.4byte sHypnoPose24
+.4byte sHypnoPose25
+.4byte sHypnoPose26
+.4byte sHypnoPose27
+.4byte sHypnoPose28
+.4byte sHypnoPose29
+.4byte sHypnoPose30
+.4byte sHypnoPose31
+.4byte sHypnoPose32
+.4byte sHypnoPose33
+.4byte sHypnoPose34
+.4byte sHypnoPose35
+.4byte sHypnoPose36
+.4byte sHypnoPose37
+.4byte sHypnoPose38
+.4byte sHypnoPose39
+.4byte sHypnoPose40
+.4byte sHypnoPose41
+.4byte sHypnoPose42
+.4byte sHypnoPose43
+.4byte sHypnoPose44
+.4byte sHypnoPose45
+.4byte sHypnoPose46
+.4byte sHypnoPose47
+.4byte sHypnoPose48
+.4byte sHypnoPose49
+.4byte sHypnoPose50
+.4byte sHypnoPose51
+.4byte sHypnoPose52
+.4byte sHypnoPose53
+.4byte sHypnoPose54
+.4byte sHypnoPose55
+.4byte sHypnoPose56
+.4byte sHypnoPose57
+.4byte sHypnoPose58
+.4byte sHypnoPose59
+.4byte sHypnoPose60
+.4byte sHypnoPose61
+.4byte sHypnoPose62
+.4byte sHypnoPose63
+.4byte sHypnoPose64
+.4byte sHypnoPose65
+.4byte sHypnoPose66
+.4byte sHypnoPose67
+.4byte sHypnoPose68
+.4byte sHypnoPose69
+.4byte sHypnoPose70
+.4byte sHypnoPose71
+.4byte sHypnoPose72
+.4byte sHypnoPose73
+.4byte sHypnoPose74
+.4byte sHypnoPose75
+.4byte sHypnoPose76
+.4byte sHypnoPose77
+.4byte sHypnoPose78
+.4byte sHypnoPose79
+.4byte sHypnoPose80
+.4byte sHypnoPose81
+.4byte sHypnoPose82
+.4byte sHypnoPose83
+.4byte sHypnoPose84
+.4byte sHypnoPose85
+.4byte sHypnoPose86
+.4byte sHypnoPose87
+.4byte sHypnoPose88
+.4byte sHypnoPose89
+.4byte sHypnoPose90
+.4byte sHypnoPose91
+.4byte sHypnoPose92
+.4byte sHypnoPose93
+.4byte sHypnoPose94
+.4byte sHypnoPose95
+.4byte sHypnoPose96
+.4byte sHypnoPose97
+.4byte sHypnoPose98
+.4byte sHypnoPose99
+.4byte sHypnoPose100
+.4byte sHypnoPose101
+.4byte sHypnoPose102
+.4byte sHypnoPose103
+.4byte sHypnoPose104
+.4byte sHypnoPose105
+.4byte sHypnoPose106
+.4byte sHypnoPose107
+.4byte sHypnoPose108
+.4byte sHypnoPose109
+.4byte sHypnoPose110
+.4byte sHypnoPose111
+.4byte sHypnoPose112
+.4byte sHypnoPose113
+.4byte sHypnoPose114
+.4byte sHypnoPose115
+.4byte sHypnoPose116
+.4byte sHypnoPose117
+.4byte sHypnoPose118
+.4byte sHypnoPose119
+.4byte sHypnoPose120
+.4byte sHypnoPose121
+.4byte sHypnoPose122
+.4byte sHypnoPose123
+.4byte sHypnoPose124
+.4byte sHypnoPose125
+.4byte sHypnoPose126
+.4byte sHypnoPose127
+.4byte sHypnoPose128
+.4byte sHypnoPose129
+.4byte sHypnoPose130
+.4byte sHypnoPose131
+.4byte sHypnoPose132
+.4byte sHypnoPose133
+.4byte sHypnoPose134
+.4byte sHypnoPose135
+.4byte sHypnoPose136
+.4byte sHypnoPose137
+.4byte sHypnoPose138
+.4byte sHypnoPose139
+.4byte sHypnoPose140
+.4byte sHypnoPose141
+.4byte sHypnoPose142
+.4byte sHypnoPose143
+.4byte sHypnoPose144
+.4byte sHypnoPose145
+.4byte sHypnoPose146
+.4byte sHypnoPose147
+.4byte sHypnoPose148
+.4byte sHypnoPose149
+.4byte sHypnoPose150
+.4byte sHypnoPose151
+.4byte sHypnoPose152
+.4byte sHypnoPose153
+.4byte sHypnoPose154
+.4byte sHypnoPose155
+.4byte sHypnoPose156
+.4byte sHypnoPose157
+.4byte sHypnoPose158
+.4byte sHypnoPose159
+.4byte sHypnoPose160
+.4byte sHypnoPose161
+.4byte sHypnoPose162
+.4byte sHypnoPose163
+.4byte sHypnoPose164
+.4byte sHypnoPose165
+.4byte sHypnoPose166
+.4byte sHypnoPose167
+.4byte sHypnoPose168
+.4byte sHypnoPose169
+.4byte sHypnoPose170
+.4byte sHypnoPose171
+.4byte sHypnoPose172
+.4byte sHypnoPose173
+.4byte sHypnoPose174
+.4byte sHypnoPose175
+.4byte sHypnoPose176
+.4byte sHypnoPose177
+.4byte sHypnoPose178
+.4byte sHypnoPose179
+.4byte sHypnoPose180
+.4byte sHypnoPose181
+.4byte sHypnoPose182
+.4byte sHypnoPose183
+.4byte sHypnoPose184
+.4byte sHypnoPose185
+.4byte sHypnoPose186
+.4byte sHypnoPose187
+.4byte sHypnoPose188
+.4byte sHypnoPose189
+.4byte sHypnoPose190
+.4byte sHypnoPose191
+.4byte sHypnoPose192
+.4byte sHypnoPose193
+.4byte sHypnoPose194
+.4byte sHypnoPose195
+.4byte sHypnoPose196
+.4byte sHypnoPose197
+.4byte sHypnoPose198
+.4byte sHypnoPose199
+.4byte sHypnoPose200
+.4byte sHypnoPose201
+.4byte sHypnoPose202
+.4byte sHypnoPose203
+.4byte sHypnoPose204
+.4byte sHypnoPose205
+.4byte sHypnoPose206
+.4byte sHypnoPose207
+.4byte sHypnoPose208
+.4byte sHypnoPose209
+.4byte sHypnoPose210
+.4byte sHypnoPose211
+.4byte sHypnoPose212
+.4byte sHypnoPose213
+.4byte sHypnoPose214
+.4byte sHypnoPose215
+.4byte sHypnoPose216
+.4byte sHypnoPose217
+.4byte sHypnoPose218
+.4byte sHypnoPose219
+.4byte sHypnoPose220
+.4byte sHypnoPose221
+.4byte sHypnoPose222
+.4byte sHypnoPose223
+.4byte sHypnoPose224
+.4byte sHypnoPose225
+.4byte sHypnoPose226
+.4byte sHypnoPose227
+.4byte sHypnoPose228
+.4byte sHypnoPose229
+.4byte sHypnoPose230
+.4byte sHypnoPose231
+.4byte sHypnoPose232
+.4byte sHypnoPose233
+.4byte sHypnoPose234
+.4byte sHypnoPose235
+.4byte sHypnoPose236
+.4byte sHypnoPose237
+.4byte sHypnoPose238
+.4byte sHypnoPose239
+.4byte sHypnoPose240
+.4byte sHypnoPose241
+.4byte sHypnoPose242
+.4byte sHypnoPose243
+.4byte sHypnoPose244
+.4byte sHypnoPose245
+.4byte sHypnoPose246
+.4byte sHypnoPose247
+.4byte sHypnoPose248
+.4byte sHypnoPose249
+.4byte sHypnoPose250
+.4byte sHypnoPose251
+.4byte sHypnoPose252
+.4byte sHypnoPose253
+.4byte sHypnoPose254
+.4byte sHypnoPose255
+.4byte sHypnoPose256
+.4byte sHypnoPose257
+.4byte sHypnoPose258
+.4byte sHypnoPose259
+.4byte sHypnoPose260
+.4byte sHypnoPose261
+.4byte sHypnoPose262
+.4byte sHypnoPose263
+.4byte sHypnoPose264
+.4byte sHypnoPose265
+.4byte sHypnoPose266
+.4byte sHypnoPose267
+.4byte sHypnoPose268
+.4byte sHypnoPose269
+.4byte sHypnoPose270
+.4byte sHypnoPose271
+.4byte sHypnoPose272
+.4byte sHypnoPose273
+.4byte sHypnoPose274
+.4byte sHypnoPose275
+.4byte sHypnoPose276
+.4byte sHypnoPose277
+.4byte sHypnoPose278
+.4byte sHypnoPose279
+.4byte sHypnoPose280
+.4byte sHypnoPose281
+.4byte sHypnoPose282
+.4byte sHypnoPose283
+.4byte sHypnoPose284
+.4byte sHypnoPose285
+.4byte sHypnoPose286
+.4byte sHypnoPose287
+.4byte sHypnoPose288
+.4byte sHypnoPose289
+.4byte sHypnoPose290
+.4byte sHypnoPose291
+.4byte sHypnoPose292
+.4byte sHypnoPose293
+.4byte sHypnoPose294
+.4byte sHypnoPose295
+.4byte sHypnoPose296
+.4byte sHypnoPose297
+.4byte sHypnoPose298
+.4byte sHypnoPose299
+.4byte sHypnoPose300
+sAxPositionsHypno:
+.2byte   -1,   -9, 	  -9,   -8, 	   8,  -16, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -5, 	  10,  -15, 	  -1,  -11
+.2byte   -1,   -8, 	 -11,   -9, 	   6,  -15, 	  -1,  -10
+.2byte    3,  -11, 	  -5,   -7, 	   8,  -18, 	   0,   -9
+.2byte    3,  -10, 	  -2,   -5, 	   9,  -18, 	  -1,   -9
+.2byte    3,  -10, 	  -8,   -7, 	   7,  -16, 	  -2,   -9
+.2byte    7,  -12, 	   0,   -6, 	   9,  -18, 	  -2,   -9
+.2byte    7,  -12, 	   2,   -6, 	   8,  -19, 	   1,   -8
+.2byte    7,  -12, 	  -4,   -6, 	  10,  -15, 	  -1,   -9
+.2byte    6,  -14, 	   7,   -6, 	  -3,  -19, 	  -2,   -9
+.2byte    6,  -13, 	   8,   -8, 	  -5,  -20, 	  -3,   -9
+.2byte    6,  -13, 	   2,   -5, 	  -2,  -17, 	  -2,  -10
+.2byte   -1,  -18, 	   8,   -9, 	 -10,  -17, 	  -1,  -10
+.2byte   -1,  -17, 	   6,   -8, 	 -12,  -16, 	   0,  -10
+.2byte   -1,  -17, 	   9,   -8, 	  -8,  -16, 	   0,   -9
+.2byte   -6,  -14, 	   2,  -11, 	 -11,  -15, 	  -1,  -10
+.2byte   -7,  -13, 	   2,  -11, 	 -14,  -13, 	  -1,  -10
+.2byte   -7,  -13, 	   4,  -10, 	 -10,  -14, 	   0,  -10
+.2byte   -8,  -12, 	  -7,  -10, 	  -5,  -13, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,   -7, 	  -2,  -12, 	  -2,   -9
+.2byte   -8,  -11, 	  -2,  -11, 	  -6,  -12, 	  -2,  -10
+.2byte   -5,  -10, 	  -8,   -8, 	   5,  -14, 	  -1,   -9
+.2byte   -6,   -9, 	 -10,   -6, 	   7,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,  -11, 	   3,  -14, 	  -2,   -9
+.2byte   -1,   -9, 	  -9,   -8, 	   8,  -16, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -5, 	  10,  -15, 	  -1,  -11
+.2byte   -1,   -8, 	 -11,   -9, 	   6,  -15, 	  -1,  -10
+.2byte    3,  -11, 	  -5,   -7, 	   8,  -18, 	   0,   -9
+.2byte    3,  -10, 	  -2,   -5, 	   9,  -18, 	  -1,   -9
+.2byte    3,  -10, 	  -8,   -7, 	   7,  -16, 	  -2,   -9
+.2byte    7,  -12, 	   0,   -6, 	   9,  -18, 	  -2,   -9
+.2byte    7,  -12, 	   2,   -6, 	   8,  -19, 	   1,   -8
+.2byte    7,  -12, 	  -4,   -6, 	  10,  -15, 	  -1,   -9
+.2byte    6,  -14, 	   7,   -6, 	  -3,  -19, 	  -2,   -9
+.2byte    6,  -13, 	   8,   -8, 	  -5,  -20, 	  -3,   -9
+.2byte    6,  -13, 	   2,   -5, 	  -2,  -17, 	  -2,  -10
+.2byte   -1,  -18, 	   8,   -9, 	 -10,  -17, 	  -1,  -10
+.2byte   -1,  -17, 	   6,   -8, 	 -12,  -16, 	   0,  -10
+.2byte   -1,  -17, 	   9,   -8, 	  -8,  -16, 	   0,   -9
+.2byte   -6,  -14, 	   2,  -11, 	 -11,  -15, 	  -1,  -10
+.2byte   -7,  -13, 	   2,  -11, 	 -14,  -13, 	  -1,  -10
+.2byte   -7,  -13, 	   4,  -10, 	 -10,  -14, 	   0,  -10
+.2byte   -8,  -12, 	  -7,  -10, 	  -5,  -13, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,   -7, 	  -2,  -12, 	  -2,   -9
+.2byte   -8,  -11, 	  -2,  -11, 	  -6,  -12, 	  -2,  -10
+.2byte   -5,  -10, 	  -8,   -8, 	   5,  -14, 	  -1,   -9
+.2byte   -6,   -9, 	 -10,   -6, 	   7,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,  -11, 	   3,  -14, 	  -2,   -9
+.2byte   -1,   -9, 	  -9,   -8, 	   8,  -16, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -5, 	  10,  -15, 	  -1,  -11
+.2byte   -1,   -8, 	 -11,   -9, 	   6,  -15, 	  -1,  -10
+.2byte   -3,  -11, 	  -8,   -9, 	   0,  -10, 	   0,   -9
+.2byte    2,   -7, 	  -2,   -1, 	   9,  -11, 	   2,   -8
+.2byte    2,   -7, 	  -2,   -1, 	   9,  -11, 	   2,   -8
+.2byte    3,  -11, 	  -5,   -7, 	   8,  -18, 	   0,   -9
+.2byte    3,  -10, 	  -2,   -5, 	   9,  -18, 	  -1,   -9
+.2byte    3,  -10, 	  -8,   -7, 	   7,  -16, 	  -2,   -9
+.2byte    0,  -11, 	 -12,  -16, 	   5,   -7, 	  -1,  -10
+.2byte    5,   -6, 	   8,    0, 	  -2,   -9, 	   0,   -7
+.2byte    5,   -6, 	   8,    0, 	  -2,   -9, 	   0,   -7
+.2byte    7,  -12, 	   0,   -6, 	   9,  -18, 	  -2,   -9
+.2byte    7,  -12, 	   2,   -6, 	   8,  -19, 	   1,   -8
+.2byte    7,  -12, 	  -4,   -6, 	  10,  -15, 	  -1,   -9
+.2byte    3,  -12, 	 -11,   -8, 	  11,  -14, 	  -1,  -10
+.2byte    5,  -11, 	  10,  -10, 	 -11,   -9, 	   0,   -9
+.2byte    5,  -11, 	  10,  -10, 	 -11,   -9, 	   0,   -9
+.2byte    6,  -14, 	   7,   -6, 	  -3,  -19, 	  -2,   -9
+.2byte    6,  -13, 	   8,   -8, 	  -5,  -20, 	  -3,   -9
+.2byte    6,  -13, 	   2,   -5, 	  -2,  -17, 	  -2,  -10
+.2byte    3,  -12, 	  -5,   -4, 	   7,  -17, 	  -2,  -10
+.2byte    2,  -19, 	   6,  -19, 	 -11,  -11, 	  -2,  -12
+.2byte    2,  -19, 	   6,  -19, 	 -11,  -11, 	  -2,  -12
+.2byte   -1,  -18, 	   8,   -9, 	 -10,  -17, 	  -1,  -10
+.2byte   -1,  -17, 	   6,   -8, 	 -12,  -16, 	   0,  -10
+.2byte   -1,  -17, 	   9,   -8, 	  -8,  -16, 	   0,   -9
+.2byte    5,  -11, 	   6,   -3, 	  -5,  -19, 	  -2,   -9
+.2byte   -1,  -17, 	   0,  -25, 	 -10,   -6, 	  -1,   -9
+.2byte   -1,  -17, 	   0,  -25, 	 -10,   -6, 	  -1,   -9
+.2byte   -6,  -14, 	   2,  -11, 	 -11,  -15, 	  -1,  -10
+.2byte   -7,  -13, 	   2,  -11, 	 -14,  -13, 	  -1,  -10
+.2byte   -7,  -13, 	   4,  -10, 	 -10,  -14, 	   0,  -10
+.2byte   -1,  -14, 	  10,   -6, 	  -6,  -17, 	   1,   -8
+.2byte   -7,  -15, 	  -8,  -23, 	  -1,   -4, 	  -1,  -12
+.2byte   -7,  -15, 	  -8,  -23, 	  -1,   -4, 	  -1,  -12
+.2byte   -8,  -12, 	  -7,  -10, 	  -5,  -13, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,   -7, 	  -2,  -12, 	  -2,   -9
+.2byte   -8,  -11, 	  -2,  -11, 	  -6,  -12, 	  -2,  -10
+.2byte   -4,  -13, 	   9,   -9, 	  -8,  -11, 	   1,   -9
+.2byte   -7,  -11, 	 -13,   -9, 	   9,   -6, 	  -1,   -8
+.2byte   -7,  -11, 	 -13,   -9, 	   9,   -6, 	  -1,   -8
+.2byte   -5,  -10, 	  -8,   -8, 	   5,  -14, 	  -1,   -9
+.2byte   -6,   -9, 	 -10,   -6, 	   7,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,  -11, 	   3,  -14, 	  -2,   -9
+.2byte   -5,  -10, 	  -1,   -8, 	  -5,   -8, 	   0,   -8
+.2byte   -6,   -2, 	 -12,    0, 	   7,   -5, 	  -2,   -5
+.2byte   -6,   -2, 	 -12,    0, 	   7,   -5, 	  -2,   -5
+.2byte   -1,   -9, 	  -9,   -8, 	   8,  -16, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -5, 	  10,  -15, 	  -1,  -11
+.2byte   -1,   -8, 	 -11,   -9, 	   6,  -15, 	  -1,  -10
+.2byte   -3,  -11, 	  -8,   -9, 	   0,  -10, 	   0,   -9
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte   -1,   -5, 	  -7,   -6, 	   9,  -10, 	  -1,   -8
+.2byte   -3,  -11, 	  -8,   -9, 	   0,  -10, 	   0,   -9
+.2byte   -1,   -5, 	  -7,   -6, 	   9,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -6, 	   9,  -10, 	  -1,   -8
+.2byte    3,  -11, 	  -5,   -7, 	   8,  -18, 	   0,   -9
+.2byte    3,  -10, 	  -2,   -5, 	   9,  -18, 	  -1,   -9
+.2byte    3,  -10, 	  -8,   -7, 	   7,  -16, 	  -2,   -9
+.2byte    0,  -11, 	 -12,  -16, 	   5,   -7, 	  -1,  -10
+.2byte    5,   -6, 	  -2,   -4, 	  11,   -9, 	   2,   -7
+.2byte    4,   -8, 	   1,   -5, 	  11,  -11, 	   0,   -9
+.2byte    0,  -11, 	 -12,  -16, 	   5,   -7, 	  -1,  -10
+.2byte    4,   -8, 	   1,   -5, 	  11,  -11, 	   0,   -9
+.2byte    4,   -8, 	   1,   -5, 	  11,  -11, 	   0,   -9
+.2byte    7,  -12, 	   0,   -6, 	   9,  -18, 	  -2,   -9
+.2byte    7,  -12, 	   2,   -6, 	   8,  -19, 	   1,   -8
+.2byte    7,  -12, 	  -4,   -6, 	  10,  -15, 	  -1,   -9
+.2byte    3,  -12, 	 -11,   -8, 	  11,  -14, 	  -1,  -10
+.2byte    8,   -7, 	   6,   -7, 	  12,  -11, 	   1,   -8
+.2byte    6,  -10, 	   8,   -9, 	  12,  -15, 	   1,  -10
+.2byte    3,  -12, 	 -11,   -8, 	  11,  -14, 	  -1,  -10
+.2byte    6,  -10, 	   8,   -9, 	  12,  -15, 	   1,  -10
+.2byte    6,  -10, 	   8,   -9, 	  12,  -15, 	   1,  -10
+.2byte    6,  -14, 	   7,   -6, 	  -3,  -19, 	  -2,   -9
+.2byte    6,  -13, 	   8,   -8, 	  -5,  -20, 	  -3,   -9
+.2byte    6,  -13, 	   2,   -5, 	  -2,  -17, 	  -2,  -10
+.2byte    3,  -12, 	  -5,   -4, 	   7,  -17, 	  -2,  -10
+.2byte    6,  -11, 	  13,  -11, 	   7,  -12, 	   0,   -9
+.2byte    5,  -12, 	  12,  -12, 	   6,  -14, 	  -1,   -9
+.2byte    3,  -12, 	  -5,   -4, 	   7,  -17, 	  -2,  -10
+.2byte    5,  -12, 	  12,  -12, 	   6,  -14, 	  -1,   -9
+.2byte    5,  -12, 	  12,  -12, 	   6,  -14, 	  -1,   -9
+.2byte   -1,  -18, 	   8,   -9, 	 -10,  -17, 	  -1,  -10
+.2byte   -1,  -17, 	   6,   -8, 	 -12,  -16, 	   0,  -10
+.2byte   -1,  -17, 	   9,   -8, 	  -8,  -16, 	   0,   -9
+.2byte    5,  -12, 	   6,   -4, 	  -5,  -20, 	  -2,  -10
+.2byte   -1,  -15, 	   7,  -17, 	 -10,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	   5,  -14, 	 -11,  -12, 	  -1,  -10
+.2byte    5,  -12, 	   6,   -4, 	  -5,  -20, 	  -2,  -10
+.2byte   -1,  -13, 	   5,  -14, 	 -11,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   5,  -14, 	 -11,  -12, 	  -1,  -10
+.2byte   -6,  -14, 	   2,  -11, 	 -11,  -15, 	  -1,  -10
+.2byte   -7,  -13, 	   2,  -11, 	 -14,  -13, 	  -1,  -10
+.2byte   -7,  -13, 	   4,  -10, 	 -10,  -14, 	   0,  -10
+.2byte    0,  -13, 	  11,   -5, 	  -5,  -16, 	   2,   -7
+.2byte   -8,  -12, 	  -4,  -17, 	 -13,  -11, 	  -1,  -10
+.2byte   -9,  -12, 	  -5,  -17, 	 -15,   -9, 	  -1,   -9
+.2byte    0,  -13, 	  11,   -5, 	  -5,  -16, 	   2,   -7
+.2byte   -9,  -12, 	  -5,  -17, 	 -15,   -9, 	  -1,   -9
+.2byte   -9,  -12, 	  -5,  -17, 	 -15,   -9, 	  -1,   -9
+.2byte   -8,  -12, 	  -7,  -10, 	  -5,  -13, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,   -7, 	  -2,  -12, 	  -2,   -9
+.2byte   -8,  -11, 	  -2,  -11, 	  -6,  -12, 	  -2,  -10
+.2byte   -4,  -13, 	   9,   -9, 	  -8,  -11, 	   1,   -9
+.2byte  -10,  -10, 	 -14,  -14, 	  -8,   -9, 	  -3,   -9
+.2byte  -10,   -8, 	 -15,   -8, 	  -7,   -7, 	  -3,   -8
+.2byte   -4,  -13, 	   9,   -9, 	  -8,  -11, 	   1,   -9
+.2byte  -10,   -8, 	 -15,   -8, 	  -7,   -7, 	  -3,   -8
+.2byte  -10,   -8, 	 -15,   -8, 	  -7,   -7, 	  -3,   -8
+.2byte   -5,  -10, 	  -8,   -8, 	   5,  -14, 	  -1,   -9
+.2byte   -6,   -9, 	 -10,   -6, 	   7,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,  -11, 	   3,  -14, 	  -2,   -9
+.2byte   -5,  -10, 	  -1,   -8, 	  -5,   -8, 	   0,   -8
+.2byte   -7,   -8, 	 -15,   -9, 	   2,   -8, 	  -2,   -9
+.2byte   -7,   -6, 	 -13,   -6, 	   3,   -8, 	  -3,   -8
+.2byte   -5,  -10, 	  -1,   -8, 	  -5,   -8, 	   0,   -8
+.2byte   -7,   -6, 	 -13,   -6, 	   3,   -8, 	  -3,   -8
+.2byte   -7,   -6, 	 -13,   -6, 	   3,   -8, 	  -3,   -8
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte   -1,   -5, 	  -7,   -6, 	   9,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -6, 	   9,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -6, 	   9,  -10, 	  -1,   -8
+.2byte    5,   -6, 	  -2,   -4, 	  11,   -9, 	   2,   -7
+.2byte    5,   -6, 	  -2,   -4, 	  11,   -9, 	   2,   -7
+.2byte    4,   -8, 	   1,   -5, 	  11,  -11, 	   0,   -9
+.2byte    4,   -8, 	   1,   -5, 	  11,  -11, 	   0,   -9
+.2byte    4,   -8, 	   1,   -5, 	  11,  -11, 	   0,   -9
+.2byte    8,   -7, 	   6,   -7, 	  12,  -11, 	   1,   -8
+.2byte    8,   -7, 	   6,   -7, 	  12,  -11, 	   1,   -8
+.2byte    6,  -10, 	   8,   -9, 	  12,  -15, 	   1,  -10
+.2byte    6,  -10, 	   8,   -9, 	  12,  -15, 	   1,  -10
+.2byte    6,  -10, 	   8,   -9, 	  12,  -15, 	   1,  -10
+.2byte    6,  -11, 	  13,  -11, 	   7,  -12, 	   0,   -9
+.2byte    6,  -11, 	  13,  -11, 	   7,  -12, 	   0,   -9
+.2byte    5,  -12, 	  12,  -12, 	   6,  -14, 	  -1,   -9
+.2byte    5,  -12, 	  12,  -12, 	   6,  -14, 	  -1,   -9
+.2byte    5,  -12, 	  12,  -12, 	   6,  -14, 	  -1,   -9
+.2byte   -1,  -15, 	   7,  -17, 	 -10,  -13, 	  -1,  -10
+.2byte   -1,  -15, 	   7,  -17, 	 -10,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	   5,  -14, 	 -11,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   5,  -14, 	 -11,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   5,  -14, 	 -11,  -12, 	  -1,  -10
+.2byte   -8,  -12, 	  -4,  -17, 	 -13,  -11, 	  -1,  -10
+.2byte   -8,  -12, 	  -4,  -17, 	 -13,  -11, 	  -1,  -10
+.2byte   -9,  -12, 	  -5,  -17, 	 -15,   -9, 	  -1,   -9
+.2byte   -9,  -12, 	  -5,  -17, 	 -15,   -9, 	  -1,   -9
+.2byte   -9,  -12, 	  -5,  -17, 	 -15,   -9, 	  -1,   -9
+.2byte  -10,  -10, 	 -14,  -14, 	  -8,   -9, 	  -3,   -9
+.2byte  -10,  -10, 	 -14,  -14, 	  -8,   -9, 	  -3,   -9
+.2byte  -10,   -8, 	 -15,   -8, 	  -7,   -7, 	  -3,   -8
+.2byte  -10,   -8, 	 -15,   -8, 	  -7,   -7, 	  -3,   -8
+.2byte  -10,   -8, 	 -15,   -8, 	  -7,   -7, 	  -3,   -8
+.2byte   -7,   -8, 	 -15,   -9, 	   2,   -8, 	  -2,   -9
+.2byte   -7,   -8, 	 -15,   -9, 	   2,   -8, 	  -2,   -9
+.2byte   -7,   -6, 	 -13,   -6, 	   3,   -8, 	  -3,   -8
+.2byte   -7,   -6, 	 -13,   -6, 	   3,   -8, 	  -3,   -8
+.2byte   -7,   -6, 	 -13,   -6, 	   3,   -8, 	  -3,   -8
+.2byte    3,   -6, 	  -5,   -3, 	  10,   -3, 	   3,   -5
+.2byte    3,   -4, 	  -5,   -3, 	  11,   -3, 	   3,   -6
+.2byte    3,  -18, 	 -11,  -22, 	  12,  -20, 	   0,  -13
+.2byte   -2,  -18, 	   6,  -25, 	 -12,  -19, 	  -2,  -13
+.2byte    0,  -19, 	   2,  -23, 	 -13,  -17, 	  -2,  -13
+.2byte    2,  -16, 	 -11,  -20, 	   6,  -15, 	  -2,  -12
+.2byte   -5,  -16, 	  11,  -18, 	 -12,  -18, 	   0,   -9
+.2byte   -4,  -16, 	   9,  -20, 	  -8,  -15, 	   0,  -12
+.2byte    0,  -19, 	  -2,  -23, 	  13,  -17, 	   2,  -13
+.2byte    1,  -18, 	  -7,  -25, 	  11,  -19, 	   1,  -13
+.2byte   -1,   -9, 	  -9,   -8, 	   8,  -16, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -5, 	  10,  -15, 	  -1,  -11
+.2byte   -1,   -8, 	 -11,   -9, 	   6,  -15, 	  -1,  -10
+.2byte    3,  -11, 	  -5,   -7, 	   8,  -18, 	   0,   -9
+.2byte    3,  -10, 	  -2,   -5, 	   9,  -18, 	  -1,   -9
+.2byte    3,  -10, 	  -8,   -7, 	   7,  -16, 	  -2,   -9
+.2byte    7,  -12, 	   0,   -6, 	   9,  -18, 	  -2,   -9
+.2byte    7,  -12, 	   2,   -6, 	   8,  -19, 	   1,   -8
+.2byte    7,  -12, 	  -4,   -6, 	  10,  -15, 	  -1,   -9
+.2byte    6,  -14, 	   7,   -6, 	  -3,  -19, 	  -2,   -9
+.2byte    6,  -13, 	   8,   -8, 	  -5,  -20, 	  -3,   -9
+.2byte    6,  -13, 	   2,   -5, 	  -2,  -17, 	  -2,  -10
+.2byte   -1,  -18, 	   8,   -9, 	 -10,  -17, 	  -1,  -10
+.2byte   -1,  -17, 	   6,   -8, 	 -12,  -16, 	   0,  -10
+.2byte   -1,  -17, 	   9,   -8, 	  -8,  -16, 	   0,   -9
+.2byte   -6,  -14, 	   2,  -11, 	 -11,  -15, 	  -1,  -10
+.2byte   -7,  -13, 	   2,  -11, 	 -14,  -13, 	  -1,  -10
+.2byte   -7,  -13, 	   4,  -10, 	 -10,  -14, 	   0,  -10
+.2byte   -8,  -12, 	  -7,  -10, 	  -5,  -13, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,   -7, 	  -2,  -12, 	  -2,   -9
+.2byte   -8,  -11, 	  -2,  -11, 	  -6,  -12, 	  -2,  -10
+.2byte   -5,  -10, 	  -8,   -8, 	   5,  -14, 	  -1,   -9
+.2byte   -6,   -9, 	 -10,   -6, 	   7,  -12, 	  -1,   -9
+.2byte   -6,   -9, 	  -2,  -11, 	   3,  -14, 	  -2,   -9
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte   -7,   -8, 	 -15,   -9, 	   2,   -8, 	  -2,   -9
+.2byte  -10,  -10, 	 -14,  -14, 	  -8,   -9, 	  -3,   -9
+.2byte   -8,  -12, 	  -4,  -17, 	 -13,  -11, 	  -1,  -10
+.2byte   -1,  -15, 	   7,  -17, 	 -10,  -13, 	  -1,  -10
+.2byte    6,  -11, 	  13,  -11, 	   7,  -12, 	   0,   -9
+.2byte    8,   -7, 	   6,   -7, 	  12,  -11, 	   1,   -8
+.2byte    5,   -6, 	  -2,   -4, 	  11,   -9, 	   2,   -7
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte    5,   -6, 	  -2,   -4, 	  11,   -9, 	   2,   -7
+.2byte    8,   -7, 	   6,   -7, 	  12,  -11, 	   1,   -8
+.2byte    6,  -11, 	  13,  -11, 	   7,  -12, 	   0,   -9
+.2byte   -1,  -15, 	   7,  -17, 	 -10,  -13, 	  -1,  -10
+.2byte   -8,  -12, 	  -4,  -17, 	 -13,  -11, 	  -1,  -10
+.2byte  -10,  -10, 	 -14,  -14, 	  -8,   -9, 	  -3,   -9
+.2byte   -7,   -8, 	 -15,   -9, 	   2,   -8, 	  -2,   -9
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -8, 	   8,  -16, 	  -1,  -11
+.2byte   -3,  -11, 	  -8,   -9, 	   0,  -10, 	   0,   -9
+.2byte   -1,   -5, 	  -7,   -6, 	   9,  -10, 	  -1,   -8
+.2byte    3,  -11, 	  -5,   -7, 	   8,  -18, 	   0,   -9
+.2byte    0,  -11, 	 -12,  -16, 	   5,   -7, 	  -1,  -10
+.2byte    4,   -8, 	   1,   -5, 	  11,  -11, 	   0,   -9
+.2byte    7,  -12, 	   0,   -6, 	   9,  -18, 	  -2,   -9
+.2byte    3,  -12, 	 -11,   -8, 	  11,  -14, 	  -1,  -10
+.2byte    5,  -10, 	   7,   -9, 	  11,  -15, 	   0,  -10
+.2byte    6,  -14, 	   7,   -6, 	  -3,  -19, 	  -2,   -9
+.2byte    3,  -12, 	  -5,   -4, 	   7,  -17, 	  -2,  -10
+.2byte    4,  -12, 	  11,  -12, 	   5,  -14, 	  -2,   -9
+.2byte   -1,  -18, 	   8,   -9, 	 -10,  -17, 	  -1,  -10
+.2byte    5,  -10, 	   6,   -2, 	  -5,  -18, 	  -2,   -8
+.2byte   -1,  -13, 	   5,  -14, 	 -11,  -12, 	  -1,  -10
+.2byte   -6,  -14, 	   2,  -11, 	 -11,  -15, 	  -1,  -10
+.2byte   -1,  -14, 	  10,   -6, 	  -6,  -17, 	   1,   -8
+.2byte   -9,  -13, 	  -5,  -18, 	 -15,  -10, 	  -1,  -10
+.2byte   -8,  -12, 	  -7,  -10, 	  -5,  -13, 	  -1,  -10
+.2byte   -4,  -13, 	   9,   -9, 	  -8,  -11, 	   1,   -9
+.2byte   -8,   -8, 	 -13,   -8, 	  -5,   -7, 	  -1,   -8
+.2byte   -5,  -10, 	  -8,   -8, 	   5,  -14, 	  -1,   -9
+.2byte   -5,  -10, 	  -1,   -8, 	  -5,   -8, 	   0,   -8
+.2byte   -7,   -6, 	 -13,   -6, 	   3,   -8, 	  -3,   -8
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte   -7,   -8, 	 -15,   -9, 	   2,   -8, 	  -2,   -9
+.2byte  -10,  -10, 	 -14,  -14, 	  -8,   -9, 	  -3,   -9
+.2byte   -8,  -12, 	  -4,  -17, 	 -13,  -11, 	  -1,  -10
+.2byte   -1,  -15, 	   7,  -17, 	 -10,  -13, 	  -1,  -10
+.2byte    6,  -11, 	  13,  -11, 	   7,  -12, 	   0,   -9
+.2byte    8,   -7, 	   6,   -7, 	  12,  -11, 	   1,   -8
+.2byte    5,   -6, 	  -2,   -4, 	  11,   -9, 	   2,   -7
+.2byte   -1,   -7, 	 -12,   -6, 	   9,   -9, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -8, 	   8,  -16, 	  -1,  -11
+.2byte   -5,  -10, 	  -8,   -8, 	   5,  -14, 	  -1,   -9
+.2byte   -8,  -12, 	  -7,  -10, 	  -5,  -13, 	  -1,  -10
+.2byte   -6,  -14, 	   2,  -11, 	 -11,  -15, 	  -1,  -10
+.2byte   -1,  -18, 	   8,   -9, 	 -10,  -17, 	  -1,  -10
+.2byte    6,  -14, 	   7,   -6, 	  -3,  -19, 	  -2,   -9
+.2byte    7,  -12, 	   0,   -6, 	   9,  -18, 	  -2,   -9
+.2byte    3,  -11, 	  -5,   -7, 	   8,  -18, 	   0,   -9
+sHypnoAnimTable1:
+.4byte sHypnoAnims_1_1
+.4byte sHypnoAnims_1_2
+.4byte sHypnoAnims_1_3
+.4byte sHypnoAnims_1_4
+.4byte sHypnoAnims_1_5
+.4byte sHypnoAnims_1_6
+.4byte sHypnoAnims_1_7
+.4byte sHypnoAnims_1_8
+sHypnoAnimTable2:
+.4byte sHypnoAnims_2_1
+.4byte sHypnoAnims_2_2
+.4byte sHypnoAnims_2_3
+.4byte sHypnoAnims_2_4
+.4byte sHypnoAnims_2_5
+.4byte sHypnoAnims_2_6
+.4byte sHypnoAnims_2_7
+.4byte sHypnoAnims_2_8
+sHypnoAnimTable3:
+.4byte sHypnoAnims_3_1
+.4byte sHypnoAnims_3_2
+.4byte sHypnoAnims_3_3
+.4byte sHypnoAnims_3_4
+.4byte sHypnoAnims_3_5
+.4byte sHypnoAnims_3_6
+.4byte sHypnoAnims_3_7
+.4byte sHypnoAnims_3_8
+sHypnoAnimTable4:
+.4byte sHypnoAnims_4_1
+.4byte sHypnoAnims_4_2
+.4byte sHypnoAnims_4_3
+.4byte sHypnoAnims_4_4
+.4byte sHypnoAnims_4_5
+.4byte sHypnoAnims_4_6
+.4byte sHypnoAnims_4_7
+.4byte sHypnoAnims_4_8
+sHypnoAnimTable5:
+.4byte sHypnoAnims_5_1
+.4byte sHypnoAnims_5_2
+.4byte sHypnoAnims_5_3
+.4byte sHypnoAnims_5_4
+.4byte sHypnoAnims_5_5
+.4byte sHypnoAnims_5_6
+.4byte sHypnoAnims_5_7
+.4byte sHypnoAnims_5_8
+sHypnoAnimTable6:
+.4byte sHypnoAnims_6_1
+.4byte sHypnoAnims_6_1
+.4byte sHypnoAnims_6_1
+.4byte sHypnoAnims_6_1
+.4byte sHypnoAnims_6_1
+.4byte sHypnoAnims_6_1
+.4byte sHypnoAnims_6_1
+.4byte sHypnoAnims_6_1
+sHypnoAnimTable7:
+.4byte sHypnoAnims_7_1
+.4byte sHypnoAnims_7_2
+.4byte sHypnoAnims_7_3
+.4byte sHypnoAnims_7_4
+.4byte sHypnoAnims_7_5
+.4byte sHypnoAnims_7_6
+.4byte sHypnoAnims_7_7
+.4byte sHypnoAnims_7_8
+sHypnoAnimTable8:
+.4byte sHypnoAnims_8_1
+.4byte sHypnoAnims_8_2
+.4byte sHypnoAnims_8_3
+.4byte sHypnoAnims_8_4
+.4byte sHypnoAnims_8_5
+.4byte sHypnoAnims_8_6
+.4byte sHypnoAnims_8_7
+.4byte sHypnoAnims_8_8
+sHypnoAnimTable9:
+.4byte sHypnoAnims_9_1
+.4byte sHypnoAnims_9_2
+.4byte sHypnoAnims_9_3
+.4byte sHypnoAnims_9_4
+.4byte sHypnoAnims_9_5
+.4byte sHypnoAnims_9_6
+.4byte sHypnoAnims_9_7
+.4byte sHypnoAnims_9_8
+sHypnoAnimTable10:
+.4byte sHypnoAnims_10_1
+.4byte sHypnoAnims_10_2
+.4byte sHypnoAnims_10_3
+.4byte sHypnoAnims_10_4
+.4byte sHypnoAnims_10_5
+.4byte sHypnoAnims_10_6
+.4byte sHypnoAnims_10_7
+.4byte sHypnoAnims_10_8
+sHypnoAnimTable11:
+.4byte sHypnoAnims_11_1
+.4byte sHypnoAnims_11_2
+.4byte sHypnoAnims_11_3
+.4byte sHypnoAnims_11_4
+.4byte sHypnoAnims_11_5
+.4byte sHypnoAnims_11_6
+.4byte sHypnoAnims_11_7
+.4byte sHypnoAnims_11_8
+sHypnoAnimTable12:
+.4byte sHypnoAnims_12_1
+.4byte sHypnoAnims_12_2
+.4byte sHypnoAnims_12_3
+.4byte sHypnoAnims_12_4
+.4byte sHypnoAnims_12_5
+.4byte sHypnoAnims_12_6
+.4byte sHypnoAnims_12_7
+.4byte sHypnoAnims_12_8
+sHypnoAnimTable13:
+.4byte sHypnoAnims_13_1
+.4byte sHypnoAnims_13_2
+.4byte sHypnoAnims_13_3
+.4byte sHypnoAnims_13_4
+.4byte sHypnoAnims_13_5
+.4byte sHypnoAnims_13_6
+.4byte sHypnoAnims_13_7
+.4byte sHypnoAnims_13_8
+sAxAnimationsHypno:
+.4byte sHypnoAnimTable1
+.4byte sHypnoAnimTable2
+.4byte sHypnoAnimTable3
+.4byte sHypnoAnimTable4
+.4byte sHypnoAnimTable5
+.4byte sHypnoAnimTable6
+.4byte sHypnoAnimTable7
+.4byte sHypnoAnimTable8
+.4byte sHypnoAnimTable9
+.4byte sHypnoAnimTable10
+.4byte sHypnoAnimTable11
+.4byte sHypnoAnimTable12
+.4byte sHypnoAnimTable13
+sAxSpritesHypno:
+.4byte sHypnoSprites1
+.4byte sHypnoSprites2
+.4byte sHypnoSprites3
+.4byte sHypnoSprites4
+.4byte sHypnoSprites5
+.4byte sHypnoSprites6
+.4byte sHypnoSprites7
+.4byte sHypnoSprites8
+.4byte sHypnoSprites9
+.4byte sHypnoSprites10
+.4byte sHypnoSprites11
+.4byte sHypnoSprites12
+.4byte sHypnoSprites13
+.4byte sHypnoSprites14
+.4byte sHypnoSprites15
+.4byte sHypnoSprites16
+.4byte sHypnoSprites17
+.4byte sHypnoSprites18
+.4byte sHypnoSprites19
+.4byte sHypnoSprites20
+.4byte sHypnoSprites21
+.4byte sHypnoSprites22
+.4byte sHypnoSprites23
+.4byte sHypnoSprites24
+.4byte sHypnoSprites25
+.4byte sHypnoSprites26
+.4byte sHypnoSprites27
+.4byte sHypnoSprites28
+.4byte sHypnoSprites29
+.4byte sHypnoSprites30
+.4byte sHypnoSprites31
+.4byte sHypnoSprites32
+.4byte sHypnoSprites33
+.4byte sHypnoSprites34
+.4byte sHypnoSprites35
+.4byte sHypnoSprites36
+.4byte sHypnoSprites37
+.4byte sHypnoSprites38
+.4byte sHypnoSprites39
+.4byte sHypnoSprites40
+.4byte sHypnoSprites41
+.4byte sHypnoSprites42
+.4byte sHypnoSprites43
+.4byte sHypnoSprites44
+.4byte sHypnoSprites45
+.4byte sHypnoSprites46
+.4byte sHypnoSprites47
+.4byte sHypnoSprites48
+.4byte sHypnoSprites49
+.4byte sHypnoSprites50
+.4byte sHypnoSprites51
+.4byte sHypnoSprites52
+.4byte sHypnoSprites53
+.4byte sHypnoSprites54
+.4byte sHypnoSprites55
+.4byte sHypnoSprites56
+.4byte sHypnoSprites57
+.4byte sHypnoSprites58
+.4byte sHypnoSprites59
+.4byte sHypnoSprites60
+.4byte sHypnoSprites61
+.4byte sHypnoSprites62
+.4byte sHypnoSprites63
+.4byte sHypnoSprites64
+.4byte sHypnoSprites65
+.4byte sHypnoSprites66
+.4byte sHypnoSprites67
+.4byte sHypnoSprites68
+.4byte sHypnoSprites69
+.4byte sHypnoSprites70
+.4byte sHypnoSprites71
+.4byte sHypnoSprites72
+.4byte sHypnoSprites73
+sAxMainHypno:
+ax_main sAxPosesHypno, sAxAnimationsHypno, 13, sAxSpritesHypno, sAxPositionsHypno

--- a/data/ax/igglybuff.inc
+++ b/data/ax/igglybuff.inc
@@ -1,0 +1,2425 @@
+.global gAxIgglybuff
+gAxIgglybuff:
+ax_siro sAxMainIgglybuff
+sIgglybuffPose1:
+ax_pose 0, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose2:
+ax_pose 1, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose3:
+ax_pose 2, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose4:
+ax_pose 3, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose5:
+ax_pose 4, 0x81ee, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose6:
+ax_pose 5, 0x01f4, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose7:
+ax_pose 6, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose8:
+ax_pose 7, 0x81ed, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose9:
+ax_pose 8, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose10:
+ax_pose 9, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose11:
+ax_pose 10, 0x81ef, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose12:
+ax_pose 11, 0x01f4, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose13:
+ax_pose 12, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose14:
+ax_pose 13, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose15:
+ax_pose 14, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose16:
+ax_pose 9, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose17:
+ax_pose 10, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose18:
+ax_pose 11, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose19:
+ax_pose 6, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose20:
+ax_pose 7, 0x81ed, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose21:
+ax_pose 8, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose22:
+ax_pose 3, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose23:
+ax_pose 4, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose24:
+ax_pose 5, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose25:
+ax_pose 15, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose26:
+ax_pose 1, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose27:
+ax_pose 2, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose28:
+ax_pose 16, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose29:
+ax_pose 4, 0x81ee, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose30:
+ax_pose 5, 0x01f4, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose31:
+ax_pose 17, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose32:
+ax_pose 7, 0x81ed, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose33:
+ax_pose 8, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose34:
+ax_pose 18, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose35:
+ax_pose 10, 0x81ef, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose36:
+ax_pose 11, 0x01f4, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose37:
+ax_pose 19, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose38:
+ax_pose 13, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose39:
+ax_pose 14, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose40:
+ax_pose 18, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose41:
+ax_pose 10, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose42:
+ax_pose 11, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose43:
+ax_pose 17, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose44:
+ax_pose 7, 0x81ed, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose45:
+ax_pose 8, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose46:
+ax_pose 16, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose47:
+ax_pose 4, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose48:
+ax_pose 5, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose49:
+ax_pose 15, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose50:
+ax_pose 1, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose51:
+ax_pose 2, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose52:
+ax_pose 16, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose53:
+ax_pose 4, 0x81ee, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose54:
+ax_pose 5, 0x01f4, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose55:
+ax_pose 17, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose56:
+ax_pose 7, 0x81ed, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose57:
+ax_pose 8, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose58:
+ax_pose 18, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose59:
+ax_pose 10, 0x81ef, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose60:
+ax_pose 11, 0x01f4, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose61:
+ax_pose 19, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose62:
+ax_pose 13, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose63:
+ax_pose 14, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose64:
+ax_pose 18, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose65:
+ax_pose 10, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose66:
+ax_pose 11, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose67:
+ax_pose 17, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose68:
+ax_pose 7, 0x81ed, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose69:
+ax_pose 8, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose70:
+ax_pose 16, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose71:
+ax_pose 4, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose72:
+ax_pose 5, 0x01f4, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose73:
+ax_pose 0, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose74:
+ax_pose 20, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose75:
+ax_pose 21, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose76:
+ax_pose 3, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose77:
+ax_pose 22, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose78:
+ax_pose 23, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose79:
+ax_pose 6, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose80:
+ax_pose 24, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose81:
+ax_pose 25, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose82:
+ax_pose 9, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose83:
+ax_pose 26, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose84:
+ax_pose 27, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose85:
+ax_pose 12, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose86:
+ax_pose 28, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose87:
+ax_pose 29, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose88:
+ax_pose 9, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose89:
+ax_pose 26, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose90:
+ax_pose 27, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose91:
+ax_pose 6, 0x01f2, 0x40f9, 0x1c00
+ax_pose_terminator
+sIgglybuffPose92:
+ax_pose 24, 0x81f0, 0x80f9, 0x1c00
+ax_pose_terminator
+sIgglybuffPose93:
+ax_pose 25, 0x01f2, 0x40f9, 0x1c00
+ax_pose_terminator
+sIgglybuffPose94:
+ax_pose 3, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose95:
+ax_pose 22, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose96:
+ax_pose 23, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose97:
+ax_pose 0, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose98:
+ax_pose 15, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose99:
+ax_pose 20, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose100:
+ax_pose 3, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose101:
+ax_pose 16, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose102:
+ax_pose 22, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose103:
+ax_pose 6, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose104:
+ax_pose 17, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose105:
+ax_pose 24, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose106:
+ax_pose 9, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose107:
+ax_pose 18, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose108:
+ax_pose 26, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose109:
+ax_pose 12, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose110:
+ax_pose 19, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose111:
+ax_pose 28, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose112:
+ax_pose 9, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose113:
+ax_pose 18, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose114:
+ax_pose 26, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose115:
+ax_pose 6, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose116:
+ax_pose 17, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose117:
+ax_pose 24, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose118:
+ax_pose 3, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose119:
+ax_pose 16, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose120:
+ax_pose 22, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose121:
+ax_pose 30, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose122:
+ax_pose 31, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose123:
+ax_pose 32, 0x01e8, 0x80f1, 0x1c00
+ax_pose_terminator
+sIgglybuffPose124:
+ax_pose 33, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sIgglybuffPose125:
+ax_pose 34, 0x01e7, 0x90e8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose126:
+ax_pose 35, 0x01e8, 0x90e9, 0x1c00
+ax_pose_terminator
+sIgglybuffPose127:
+ax_pose 36, 0x01e8, 0x80f1, 0x1c00
+ax_pose_terminator
+sIgglybuffPose128:
+ax_pose 35, 0x01e8, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose129:
+ax_pose 34, 0x01e7, 0x80f9, 0x1c00
+ax_pose_terminator
+sIgglybuffPose130:
+ax_pose 33, 0x01e7, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose131:
+ax_pose 0, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose132:
+ax_pose 1, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose133:
+ax_pose 3, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose134:
+ax_pose 4, 0x81ee, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose135:
+ax_pose 6, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose136:
+ax_pose 7, 0x81ed, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose137:
+ax_pose 9, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose138:
+ax_pose 10, 0x81ef, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose139:
+ax_pose 12, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose140:
+ax_pose 13, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose141:
+ax_pose 9, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose142:
+ax_pose 10, 0x81ef, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose143:
+ax_pose 6, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose144:
+ax_pose 7, 0x81ed, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose145:
+ax_pose 3, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose146:
+ax_pose 4, 0x81ee, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose147:
+ax_pose 20, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose148:
+ax_pose 22, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose149:
+ax_pose 24, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose150:
+ax_pose 26, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose151:
+ax_pose 28, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose152:
+ax_pose 26, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose153:
+ax_pose 24, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose154:
+ax_pose 22, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose155:
+ax_pose 20, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose156:
+ax_pose 22, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose157:
+ax_pose 24, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose158:
+ax_pose 26, 0x81f0, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose159:
+ax_pose 28, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose160:
+ax_pose 26, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose161:
+ax_pose 24, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose162:
+ax_pose 22, 0x81f0, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose163:
+ax_pose 0, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose164:
+ax_pose 1, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose165:
+ax_pose 2, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose166:
+ax_pose 3, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose167:
+ax_pose 4, 0x81f1, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose168:
+ax_pose 5, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose169:
+ax_pose 6, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose170:
+ax_pose 7, 0x81f1, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose171:
+ax_pose 8, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose172:
+ax_pose 9, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose173:
+ax_pose 10, 0x81f1, 0x90f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose174:
+ax_pose 11, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose175:
+ax_pose 12, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose176:
+ax_pose 13, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose177:
+ax_pose 14, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose178:
+ax_pose 9, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose179:
+ax_pose 10, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose180:
+ax_pose 11, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose181:
+ax_pose 6, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose182:
+ax_pose 7, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose183:
+ax_pose 8, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose184:
+ax_pose 3, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose185:
+ax_pose 4, 0x81f1, 0x80f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose186:
+ax_pose 5, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose187:
+ax_pose 15, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose188:
+ax_pose 16, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose189:
+ax_pose 17, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose190:
+ax_pose 18, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose191:
+ax_pose 19, 0x01f3, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose192:
+ax_pose 18, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose193:
+ax_pose 17, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose194:
+ax_pose 16, 0x01f3, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose195:
+ax_pose 0, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose196:
+ax_pose 3, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose197:
+ax_pose 6, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose198:
+ax_pose 9, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose199:
+ax_pose 12, 0x01f2, 0x40f8, 0x1c00
+ax_pose_terminator
+sIgglybuffPose200:
+ax_pose 9, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose201:
+ax_pose 6, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+sIgglybuffPose202:
+ax_pose 3, 0x01f2, 0x50f7, 0x1c00
+ax_pose_terminator
+.align 2
+sIgglybuffAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, -1, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, -1, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_2_1:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 4, 0, 4,
+ax_anim 2, 2, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 1, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sIgglybuffAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, -1,
+ax_anim 2, 0, 29, 6, 2, 6, 5,
+ax_anim 2, 2, 27, 14, 10, 14, 13,
+ax_anim 2, 0, 27, 22, 19, 22, 19,
+ax_anim 2, 1, 27, 23, 18, 23, 18,
+ax_anim 2, 0, 27, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 23, 18, 23, 18,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sIgglybuffAnims_2_3:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 4, -1, 4, 0,
+ax_anim 2, 2, 30, 14, -1, 14, 0,
+ax_anim 2, 0, 30, 23, -1, 23, 0,
+ax_anim 2, 1, 30, 23, 0, 23, 0,
+ax_anim 2, 0, 30, 23, -1, 23, -1,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 0, 31, 6, 0, 6, 0,
+ax_anim_terminator
+sIgglybuffAnims_2_4:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 4, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 2, 0, 35, 3, -11, 3, -4,
+ax_anim 2, 2, 33, 10, -18, 10, -12,
+ax_anim 2, 0, 33, 22, -27, 22, -27,
+ax_anim 2, 1, 33, 23, -26, 23, -26,
+ax_anim 2, 0, 33, 22, -27, 22, -27,
+ax_anim 2, 0, 33, 23, -26, 23, -26,
+ax_anim 2, 0, 34, 6, -6, 6, -6,
+ax_anim_terminator
+sIgglybuffAnims_2_5:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, -4, 0, -4,
+ax_anim 2, 2, 36, 0, -12, 0, -12,
+ax_anim 2, 0, 36, 0, -26, 0, -26,
+ax_anim 2, 1, 36, 1, -26, 1, -26,
+ax_anim 2, 0, 36, 0, -26, 0, -26,
+ax_anim 2, 0, 36, 1, -26, 1, -26,
+ax_anim 2, 0, 37, 0, -6, 0, -6,
+ax_anim_terminator
+sIgglybuffAnims_2_6:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 4, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 2, 0, 41, -3, -11, -3, -4,
+ax_anim 2, 2, 39, -10, -18, -10, -12,
+ax_anim 2, 0, 39, -22, -27, -22, -27,
+ax_anim 2, 1, 39, -23, -26, -23, -26,
+ax_anim 2, 0, 39, -22, -27, -22, -27,
+ax_anim 2, 0, 39, -23, -26, -23, -26,
+ax_anim 2, 0, 40, -6, -6, -6, -6,
+ax_anim_terminator
+sIgglybuffAnims_2_7:
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, -4, -1, -4, 0,
+ax_anim 2, 2, 42, -14, -1, -14, 0,
+ax_anim 2, 0, 42, -23, -1, -23, 0,
+ax_anim 2, 1, 42, -23, 0, -23, 0,
+ax_anim 2, 0, 42, -23, -1, -23, -1,
+ax_anim 2, 0, 42, -23, 0, -23, 0,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim_terminator
+sIgglybuffAnims_2_8:
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 4, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, -1, 0, -1,
+ax_anim 2, 0, 47, -6, 2, -6, 5,
+ax_anim 2, 2, 45, -14, 10, -14, 13,
+ax_anim 2, 0, 45, -22, 19, -22, 19,
+ax_anim 2, 1, 45, -23, 18, -23, 18,
+ax_anim 2, 0, 45, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -23, 18, -23, 18,
+ax_anim 2, 0, 46, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_3_1:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 4, 0, 4,
+ax_anim 2, 2, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 1, 48, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 48, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 6, 0, 6,
+ax_anim_terminator
+sIgglybuffAnims_3_2:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, -1,
+ax_anim 2, 0, 53, 6, 2, 6, 5,
+ax_anim 2, 2, 51, 14, 10, 14, 13,
+ax_anim 2, 0, 51, 22, 19, 22, 19,
+ax_anim 2, 1, 51, 23, 18, 23, 18,
+ax_anim 2, 0, 51, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 23, 18, 23, 18,
+ax_anim 2, 0, 52, 8, 8, 8, 8,
+ax_anim_terminator
+sIgglybuffAnims_3_3:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 4, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 4, -1, 4, 0,
+ax_anim 2, 2, 54, 14, -1, 14, 0,
+ax_anim 2, 0, 54, 23, -1, 23, 0,
+ax_anim 2, 1, 54, 23, 0, 23, 0,
+ax_anim 2, 0, 54, 23, -1, 23, -1,
+ax_anim 2, 0, 54, 23, 0, 23, 0,
+ax_anim 2, 0, 55, 6, 0, 6, 0,
+ax_anim_terminator
+sIgglybuffAnims_3_4:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 4, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 2, 0, 59, 3, -11, 3, -4,
+ax_anim 2, 2, 57, 10, -18, 10, -12,
+ax_anim 2, 0, 57, 22, -27, 22, -27,
+ax_anim 2, 1, 57, 23, -26, 23, -26,
+ax_anim 2, 0, 57, 22, -27, 22, -27,
+ax_anim 2, 0, 57, 23, -26, 23, -26,
+ax_anim 2, 0, 58, 6, -6, 6, -6,
+ax_anim_terminator
+sIgglybuffAnims_3_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 0, -4, 0, -4,
+ax_anim 2, 2, 60, 0, -12, 0, -12,
+ax_anim 2, 0, 60, 0, -26, 0, -26,
+ax_anim 2, 1, 60, 1, -26, 1, -26,
+ax_anim 2, 0, 60, 0, -26, 0, -26,
+ax_anim 2, 0, 60, 1, -26, 1, -26,
+ax_anim 2, 0, 61, 0, -6, 0, -6,
+ax_anim_terminator
+sIgglybuffAnims_3_6:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 4, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 2, 0, 65, -3, -11, -3, -4,
+ax_anim 2, 2, 63, -10, -18, -10, -12,
+ax_anim 2, 0, 63, -22, -27, -22, -27,
+ax_anim 2, 1, 63, -23, -26, -23, -26,
+ax_anim 2, 0, 63, -22, -27, -22, -27,
+ax_anim 2, 0, 63, -23, -26, -23, -26,
+ax_anim 2, 0, 64, -6, -6, -6, -6,
+ax_anim_terminator
+sIgglybuffAnims_3_7:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 4, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -4, -1, -4, 0,
+ax_anim 2, 2, 66, -14, -1, -14, 0,
+ax_anim 2, 0, 66, -23, -1, -23, 0,
+ax_anim 2, 1, 66, -23, 0, -23, 0,
+ax_anim 2, 0, 66, -23, -1, -23, -1,
+ax_anim 2, 0, 66, -23, 0, -23, 0,
+ax_anim 2, 0, 67, -6, 0, -6, 0,
+ax_anim_terminator
+sIgglybuffAnims_3_8:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 4, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, -1, 0, -1,
+ax_anim 2, 0, 71, -6, 2, -6, 5,
+ax_anim 2, 2, 69, -14, 10, -14, 13,
+ax_anim 2, 0, 69, -22, 19, -22, 19,
+ax_anim 2, 1, 69, -23, 18, -23, 18,
+ax_anim 2, 0, 69, -22, 19, -22, 19,
+ax_anim 2, 0, 69, -23, 18, -23, 18,
+ax_anim 2, 0, 70, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_4_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 2, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 1, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_4_2:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 2, 77, 0, 0, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 1, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_4_3:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 2, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 1, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_4_4:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 2, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 1, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_4_5:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 2, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_4_6:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 2, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 1, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_4_7:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 2, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 1, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_4_8:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 2, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_5_1:
+ax_anim 1, 0, 98, 0, -2, 0, -2,
+ax_anim 2, 0, 98, 0, -3, 0, -3,
+ax_anim 4, 2, 98, 0, -4, 0, -4,
+ax_anim 2, 0, 98, 0, -3, 0, -3,
+ax_anim 1, 0, 96, 0, -2, 0, -2,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 1, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim_terminator
+sIgglybuffAnims_5_2:
+ax_anim 1, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 4, 2, 101, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 1, 0, 99, 0, -2, 0, -2,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 1, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim_terminator
+sIgglybuffAnims_5_3:
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 4, 2, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 1, 103, 0, 1, 0, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 1, 0, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 1, 0, 1,
+ax_anim_terminator
+sIgglybuffAnims_5_4:
+ax_anim 1, 0, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 4, 2, 107, 0, -4, 0, -4,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 1, 0, 105, 0, -2, 0, -2,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 1, 1, 1, 1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 1, 1, 1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 1, 1, 1,
+ax_anim_terminator
+sIgglybuffAnims_5_5:
+ax_anim 1, 0, 110, 0, -2, 0, -2,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 4, 2, 110, 0, -4, 0, -4,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 1, 0, 108, 0, -1, 0, -2,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 109, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, 0, 1, 0,
+ax_anim_terminator
+sIgglybuffAnims_5_6:
+ax_anim 1, 0, 113, 0, -2, 0, -2,
+ax_anim 2, 0, 113, 0, -3, 0, -3,
+ax_anim 4, 2, 113, 0, -4, 0, -4,
+ax_anim 2, 0, 113, 0, -3, 0, -3,
+ax_anim 1, 0, 111, 0, -2, 0, -2,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 112, -1, 1, -1, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, 1, -1, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, 1, -1, 1,
+ax_anim_terminator
+sIgglybuffAnims_5_7:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 4, 2, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 0, 1, 0, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 1, 0, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 1, 0, 1,
+ax_anim_terminator
+sIgglybuffAnims_5_8:
+ax_anim 1, 0, 119, 0, -2, 0, -2,
+ax_anim 2, 0, 119, 0, -3, 0, -3,
+ax_anim 4, 2, 119, 0, -4, 0, -4,
+ax_anim 2, 0, 119, 0, -3, 0, -3,
+ax_anim 1, 0, 117, 0, -2, 0, -2,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 1, 118, -1, -1, -1, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -1, -1, -1, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sIgglybuffAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sIgglybuffAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sIgglybuffAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sIgglybuffAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sIgglybuffAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sIgglybuffAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sIgglybuffAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_8_1:
+ax_anim 16, 0, 130, 0, 0, 0, 0,
+ax_anim 16, 0, 131, 0, 3, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_8_2:
+ax_anim 16, 0, 132, 0, 0, 0, 0,
+ax_anim 16, 0, 133, 0, 3, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_8_3:
+ax_anim 16, 0, 134, 0, 0, 0, 0,
+ax_anim 16, 0, 135, 0, 4, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_8_4:
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 16, 0, 137, 1, 2, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_8_5:
+ax_anim 16, 0, 138, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 2, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_8_6:
+ax_anim 16, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 141, -1, 2, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_8_7:
+ax_anim 16, 0, 142, 0, 0, 0, 0,
+ax_anim 16, 0, 143, 0, 4, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_8_8:
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 10, 8, 10,
+ax_anim 2, 0, 149, 7, 17, 7, 17,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 17, -7, 17,
+ax_anim 2, 0, 152, -8, 10, -8, 10,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 23, 12, 23, 12,
+ax_anim 3, 0, 149, 24, 20, 24, 20,
+ax_anim 2, 3, 150, 16, 21, 16, 21,
+ax_anim 2, 0, 151, 6, 17, 6, 17,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 13, -6, 13, -6,
+ax_anim 2, 0, 147, 19, -5, 19, -5,
+ax_anim 3, 0, 148, 24, -2, 24, -2,
+ax_anim 2, 3, 149, 21, 4, 21, 4,
+ax_anim 2, 0, 150, 14, 5, 14, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 6, -21, 6, -21,
+ax_anim 2, 0, 146, 14, -25, 14, -25,
+ax_anim 3, 0, 147, 24, -24, 24, -24,
+ax_anim 2, 3, 148, 25, -14, 25, -14,
+ax_anim 2, 0, 149, 18, -5, 18, -5,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -5, -8, -5,
+ax_anim 2, 0, 152, -9, -14, -9, -14,
+ax_anim 2, 0, 153, -7, -21, -7, -21,
+ax_anim 3, 0, 146, 0, -25, 0, -25,
+ax_anim 2, 3, 147, 7, -21, 7, -21,
+ax_anim 2, 0, 148, 9, -14, 9, -14,
+ax_anim 1, 0, 149, 8, -5, 8, -5,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -6, -21, -6, -21,
+ax_anim 2, 0, 146, -14, -25, -14, -25,
+ax_anim 3, 0, 153, -24, -24, -24, -24,
+ax_anim 2, 3, 152, -25, -14, -25, -14,
+ax_anim 2, 0, 151, -18, -5, -18, -5,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -13, -6, -13, -6,
+ax_anim 2, 0, 153, -19, -5, -19, -5,
+ax_anim 3, 0, 152, -24, -2, -24, -2,
+ax_anim 2, 3, 151, -21, 4, -21, 4,
+ax_anim 2, 0, 150, -14, 5, -14, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -23, 12, -23, 12,
+ax_anim 3, 0, 151, -24, 20, -24, 20,
+ax_anim 2, 3, 150, -16, 21, -16, 21,
+ax_anim 2, 0, 149, -6, 17, -6, 17,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -22, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIgglybuffAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sIgglybuffGfx1:
+.incbin "baserom.gba", 0xC96BB8, 0x80
+sIgglybuffSprites1:
+ax_sprite sIgglybuffGfx1, 0x80
+ax_sprite_terminator
+sIgglybuffGfx2:
+.incbin "baserom.gba", 0xC96C48, 0x100
+sIgglybuffSprites2:
+ax_sprite sIgglybuffGfx2, 0x100
+ax_sprite_terminator
+sIgglybuffGfx3:
+.incbin "baserom.gba", 0xC96D58, 0x80
+sIgglybuffSprites3:
+ax_sprite sIgglybuffGfx3, 0x80
+ax_sprite_terminator
+sIgglybuffGfx4:
+.incbin "baserom.gba", 0xC96DE8, 0x80
+sIgglybuffSprites4:
+ax_sprite sIgglybuffGfx4, 0x80
+ax_sprite_terminator
+sIgglybuffGfx5:
+.incbin "baserom.gba", 0xC96E78, 0x100
+sIgglybuffSprites5:
+ax_sprite sIgglybuffGfx5, 0x100
+ax_sprite_terminator
+sIgglybuffGfx6:
+.incbin "baserom.gba", 0xC96F88, 0x80
+sIgglybuffSprites6:
+ax_sprite sIgglybuffGfx6, 0x80
+ax_sprite_terminator
+sIgglybuffGfx7:
+.incbin "baserom.gba", 0xC97018, 0x80
+sIgglybuffSprites7:
+ax_sprite sIgglybuffGfx7, 0x80
+ax_sprite_terminator
+sIgglybuffGfx8:
+.incbin "baserom.gba", 0xC970A8, 0x100
+sIgglybuffSprites8:
+ax_sprite sIgglybuffGfx8, 0x100
+ax_sprite_terminator
+sIgglybuffGfx9:
+.incbin "baserom.gba", 0xC971B8, 0x80
+sIgglybuffSprites9:
+ax_sprite sIgglybuffGfx9, 0x80
+ax_sprite_terminator
+sIgglybuffGfx10:
+.incbin "baserom.gba", 0xC97248, 0x80
+sIgglybuffSprites10:
+ax_sprite sIgglybuffGfx10, 0x80
+ax_sprite_terminator
+sIgglybuffGfx11:
+.incbin "baserom.gba", 0xC972D8, 0x100
+sIgglybuffSprites11:
+ax_sprite sIgglybuffGfx11, 0x100
+ax_sprite_terminator
+sIgglybuffGfx12:
+.incbin "baserom.gba", 0xC973E8, 0x80
+sIgglybuffSprites12:
+ax_sprite sIgglybuffGfx12, 0x80
+ax_sprite_terminator
+sIgglybuffGfx13:
+.incbin "baserom.gba", 0xC97478, 0x80
+sIgglybuffSprites13:
+ax_sprite sIgglybuffGfx13, 0x80
+ax_sprite_terminator
+sIgglybuffGfx14:
+.incbin "baserom.gba", 0xC97508, 0x100
+sIgglybuffSprites14:
+ax_sprite sIgglybuffGfx14, 0x100
+ax_sprite_terminator
+sIgglybuffGfx15:
+.incbin "baserom.gba", 0xC97618, 0x80
+sIgglybuffSprites15:
+ax_sprite sIgglybuffGfx15, 0x80
+ax_sprite_terminator
+sIgglybuffGfx16:
+.incbin "baserom.gba", 0xC976A8, 0x80
+sIgglybuffSprites16:
+ax_sprite sIgglybuffGfx16, 0x80
+ax_sprite_terminator
+sIgglybuffGfx17:
+.incbin "baserom.gba", 0xC97738, 0x80
+sIgglybuffSprites17:
+ax_sprite sIgglybuffGfx17, 0x80
+ax_sprite_terminator
+sIgglybuffGfx18:
+.incbin "baserom.gba", 0xC977C8, 0x80
+sIgglybuffSprites18:
+ax_sprite sIgglybuffGfx18, 0x80
+ax_sprite_terminator
+sIgglybuffGfx19:
+.incbin "baserom.gba", 0xC97858, 0x80
+sIgglybuffSprites19:
+ax_sprite sIgglybuffGfx19, 0x80
+ax_sprite_terminator
+sIgglybuffGfx20:
+.incbin "baserom.gba", 0xC978E8, 0x80
+sIgglybuffSprites20:
+ax_sprite sIgglybuffGfx20, 0x80
+ax_sprite_terminator
+sIgglybuffGfx21:
+.incbin "baserom.gba", 0xC97978, 0xC0
+sIgglybuffSprites21:
+ax_sprite sIgglybuffGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sIgglybuffGfx22:
+.incbin "baserom.gba", 0xC97A50, 0x80
+sIgglybuffSprites22:
+ax_sprite sIgglybuffGfx22, 0x80
+ax_sprite_terminator
+sIgglybuffGfx23:
+.incbin "baserom.gba", 0xC97AE0, 0xC0
+sIgglybuffSprites23:
+ax_sprite sIgglybuffGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sIgglybuffGfx24:
+.incbin "baserom.gba", 0xC97BB8, 0x80
+sIgglybuffSprites24:
+ax_sprite sIgglybuffGfx24, 0x80
+ax_sprite_terminator
+sIgglybuffGfx25:
+.incbin "baserom.gba", 0xC97C48, 0xC0
+sIgglybuffSprites25:
+ax_sprite sIgglybuffGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sIgglybuffGfx26:
+.incbin "baserom.gba", 0xC97D20, 0x80
+sIgglybuffSprites26:
+ax_sprite sIgglybuffGfx26, 0x80
+ax_sprite_terminator
+sIgglybuffGfx27:
+.incbin "baserom.gba", 0xC97DB0, 0xC0
+sIgglybuffSprites27:
+ax_sprite sIgglybuffGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sIgglybuffGfx28:
+.incbin "baserom.gba", 0xC97E88, 0x80
+sIgglybuffSprites28:
+ax_sprite sIgglybuffGfx28, 0x80
+ax_sprite_terminator
+sIgglybuffGfx29:
+.incbin "baserom.gba", 0xC97F18, 0xC0
+sIgglybuffSprites29:
+ax_sprite sIgglybuffGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sIgglybuffGfx30:
+.incbin "baserom.gba", 0xC97FF0, 0x80
+sIgglybuffSprites30:
+ax_sprite sIgglybuffGfx30, 0x80
+ax_sprite_terminator
+sIgglybuffGfx31:
+.incbin "baserom.gba", 0xC98080, 0x80
+sIgglybuffSprites31:
+ax_sprite sIgglybuffGfx31, 0x80
+ax_sprite_terminator
+sIgglybuffGfx32:
+.incbin "baserom.gba", 0xC98110, 0x80
+sIgglybuffSprites32:
+ax_sprite sIgglybuffGfx32, 0x80
+ax_sprite_terminator
+sIgglybuffGfx33:
+.incbin "baserom.gba", 0xC981A0, 0x200
+sIgglybuffSprites33:
+ax_sprite sIgglybuffGfx33, 0x200
+ax_sprite_terminator
+sIgglybuffGfx34:
+.incbin "baserom.gba", 0xC983B0, 0x200
+sIgglybuffSprites34:
+ax_sprite sIgglybuffGfx34, 0x200
+ax_sprite_terminator
+sIgglybuffGfx35:
+.incbin "baserom.gba", 0xC985C0, 0x200
+sIgglybuffSprites35:
+ax_sprite sIgglybuffGfx35, 0x200
+ax_sprite_terminator
+sIgglybuffGfx36:
+.incbin "baserom.gba", 0xC987D0, 0x200
+sIgglybuffSprites36:
+ax_sprite sIgglybuffGfx36, 0x200
+ax_sprite_terminator
+sIgglybuffGfx37:
+.incbin "baserom.gba", 0xC989E0, 0x200
+sIgglybuffSprites37:
+ax_sprite sIgglybuffGfx37, 0x200
+ax_sprite_terminator
+sAxPosesIgglybuff:
+.4byte sIgglybuffPose1
+.4byte sIgglybuffPose2
+.4byte sIgglybuffPose3
+.4byte sIgglybuffPose4
+.4byte sIgglybuffPose5
+.4byte sIgglybuffPose6
+.4byte sIgglybuffPose7
+.4byte sIgglybuffPose8
+.4byte sIgglybuffPose9
+.4byte sIgglybuffPose10
+.4byte sIgglybuffPose11
+.4byte sIgglybuffPose12
+.4byte sIgglybuffPose13
+.4byte sIgglybuffPose14
+.4byte sIgglybuffPose15
+.4byte sIgglybuffPose16
+.4byte sIgglybuffPose17
+.4byte sIgglybuffPose18
+.4byte sIgglybuffPose19
+.4byte sIgglybuffPose20
+.4byte sIgglybuffPose21
+.4byte sIgglybuffPose22
+.4byte sIgglybuffPose23
+.4byte sIgglybuffPose24
+.4byte sIgglybuffPose25
+.4byte sIgglybuffPose26
+.4byte sIgglybuffPose27
+.4byte sIgglybuffPose28
+.4byte sIgglybuffPose29
+.4byte sIgglybuffPose30
+.4byte sIgglybuffPose31
+.4byte sIgglybuffPose32
+.4byte sIgglybuffPose33
+.4byte sIgglybuffPose34
+.4byte sIgglybuffPose35
+.4byte sIgglybuffPose36
+.4byte sIgglybuffPose37
+.4byte sIgglybuffPose38
+.4byte sIgglybuffPose39
+.4byte sIgglybuffPose40
+.4byte sIgglybuffPose41
+.4byte sIgglybuffPose42
+.4byte sIgglybuffPose43
+.4byte sIgglybuffPose44
+.4byte sIgglybuffPose45
+.4byte sIgglybuffPose46
+.4byte sIgglybuffPose47
+.4byte sIgglybuffPose48
+.4byte sIgglybuffPose49
+.4byte sIgglybuffPose50
+.4byte sIgglybuffPose51
+.4byte sIgglybuffPose52
+.4byte sIgglybuffPose53
+.4byte sIgglybuffPose54
+.4byte sIgglybuffPose55
+.4byte sIgglybuffPose56
+.4byte sIgglybuffPose57
+.4byte sIgglybuffPose58
+.4byte sIgglybuffPose59
+.4byte sIgglybuffPose60
+.4byte sIgglybuffPose61
+.4byte sIgglybuffPose62
+.4byte sIgglybuffPose63
+.4byte sIgglybuffPose64
+.4byte sIgglybuffPose65
+.4byte sIgglybuffPose66
+.4byte sIgglybuffPose67
+.4byte sIgglybuffPose68
+.4byte sIgglybuffPose69
+.4byte sIgglybuffPose70
+.4byte sIgglybuffPose71
+.4byte sIgglybuffPose72
+.4byte sIgglybuffPose73
+.4byte sIgglybuffPose74
+.4byte sIgglybuffPose75
+.4byte sIgglybuffPose76
+.4byte sIgglybuffPose77
+.4byte sIgglybuffPose78
+.4byte sIgglybuffPose79
+.4byte sIgglybuffPose80
+.4byte sIgglybuffPose81
+.4byte sIgglybuffPose82
+.4byte sIgglybuffPose83
+.4byte sIgglybuffPose84
+.4byte sIgglybuffPose85
+.4byte sIgglybuffPose86
+.4byte sIgglybuffPose87
+.4byte sIgglybuffPose88
+.4byte sIgglybuffPose89
+.4byte sIgglybuffPose90
+.4byte sIgglybuffPose91
+.4byte sIgglybuffPose92
+.4byte sIgglybuffPose93
+.4byte sIgglybuffPose94
+.4byte sIgglybuffPose95
+.4byte sIgglybuffPose96
+.4byte sIgglybuffPose97
+.4byte sIgglybuffPose98
+.4byte sIgglybuffPose99
+.4byte sIgglybuffPose100
+.4byte sIgglybuffPose101
+.4byte sIgglybuffPose102
+.4byte sIgglybuffPose103
+.4byte sIgglybuffPose104
+.4byte sIgglybuffPose105
+.4byte sIgglybuffPose106
+.4byte sIgglybuffPose107
+.4byte sIgglybuffPose108
+.4byte sIgglybuffPose109
+.4byte sIgglybuffPose110
+.4byte sIgglybuffPose111
+.4byte sIgglybuffPose112
+.4byte sIgglybuffPose113
+.4byte sIgglybuffPose114
+.4byte sIgglybuffPose115
+.4byte sIgglybuffPose116
+.4byte sIgglybuffPose117
+.4byte sIgglybuffPose118
+.4byte sIgglybuffPose119
+.4byte sIgglybuffPose120
+.4byte sIgglybuffPose121
+.4byte sIgglybuffPose122
+.4byte sIgglybuffPose123
+.4byte sIgglybuffPose124
+.4byte sIgglybuffPose125
+.4byte sIgglybuffPose126
+.4byte sIgglybuffPose127
+.4byte sIgglybuffPose128
+.4byte sIgglybuffPose129
+.4byte sIgglybuffPose130
+.4byte sIgglybuffPose131
+.4byte sIgglybuffPose132
+.4byte sIgglybuffPose133
+.4byte sIgglybuffPose134
+.4byte sIgglybuffPose135
+.4byte sIgglybuffPose136
+.4byte sIgglybuffPose137
+.4byte sIgglybuffPose138
+.4byte sIgglybuffPose139
+.4byte sIgglybuffPose140
+.4byte sIgglybuffPose141
+.4byte sIgglybuffPose142
+.4byte sIgglybuffPose143
+.4byte sIgglybuffPose144
+.4byte sIgglybuffPose145
+.4byte sIgglybuffPose146
+.4byte sIgglybuffPose147
+.4byte sIgglybuffPose148
+.4byte sIgglybuffPose149
+.4byte sIgglybuffPose150
+.4byte sIgglybuffPose151
+.4byte sIgglybuffPose152
+.4byte sIgglybuffPose153
+.4byte sIgglybuffPose154
+.4byte sIgglybuffPose155
+.4byte sIgglybuffPose156
+.4byte sIgglybuffPose157
+.4byte sIgglybuffPose158
+.4byte sIgglybuffPose159
+.4byte sIgglybuffPose160
+.4byte sIgglybuffPose161
+.4byte sIgglybuffPose162
+.4byte sIgglybuffPose163
+.4byte sIgglybuffPose164
+.4byte sIgglybuffPose165
+.4byte sIgglybuffPose166
+.4byte sIgglybuffPose167
+.4byte sIgglybuffPose168
+.4byte sIgglybuffPose169
+.4byte sIgglybuffPose170
+.4byte sIgglybuffPose171
+.4byte sIgglybuffPose172
+.4byte sIgglybuffPose173
+.4byte sIgglybuffPose174
+.4byte sIgglybuffPose175
+.4byte sIgglybuffPose176
+.4byte sIgglybuffPose177
+.4byte sIgglybuffPose178
+.4byte sIgglybuffPose179
+.4byte sIgglybuffPose180
+.4byte sIgglybuffPose181
+.4byte sIgglybuffPose182
+.4byte sIgglybuffPose183
+.4byte sIgglybuffPose184
+.4byte sIgglybuffPose185
+.4byte sIgglybuffPose186
+.4byte sIgglybuffPose187
+.4byte sIgglybuffPose188
+.4byte sIgglybuffPose189
+.4byte sIgglybuffPose190
+.4byte sIgglybuffPose191
+.4byte sIgglybuffPose192
+.4byte sIgglybuffPose193
+.4byte sIgglybuffPose194
+.4byte sIgglybuffPose195
+.4byte sIgglybuffPose196
+.4byte sIgglybuffPose197
+.4byte sIgglybuffPose198
+.4byte sIgglybuffPose199
+.4byte sIgglybuffPose200
+.4byte sIgglybuffPose201
+.4byte sIgglybuffPose202
+sAxPositionsIgglybuff:
+.2byte   -1,   -3, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -9, 	  -6,   -6, 	   4,   -6, 	  -1,   -8
+.2byte   -1,   -1, 	  -7,   -3, 	   5,   -3, 	  -1,   -3
+.2byte    2,   -3, 	   4,   -5, 	  -6,   -2, 	   0,   -4
+.2byte    2,   -7, 	   5,   -9, 	  -5,   -5, 	   0,   -8
+.2byte    2,   -1, 	   5,   -6, 	  -7,   -2, 	  -1,   -3
+.2byte    5,   -4, 	   0,   -7, 	  -2,   -1, 	  -1,   -5
+.2byte    5,   -9, 	  -1,  -10, 	  -2,   -5, 	  -1,   -9
+.2byte    5,   -3, 	  -1,   -6, 	  -2,   -2, 	  -1,   -4
+.2byte    2,   -6, 	  -4,   -6, 	   4,   -2, 	  -1,   -5
+.2byte    2,   -9, 	  -5,   -8, 	   4,   -4, 	  -1,   -8
+.2byte    1,   -4, 	  -5,   -5, 	   5,   -2, 	  -2,   -4
+.2byte   -1,   -6, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -4, 	  -1,   -3
+.2byte   -4,   -6, 	   2,   -6, 	  -6,   -2, 	  -1,   -5
+.2byte   -4,   -9, 	   3,   -8, 	  -6,   -4, 	  -1,   -8
+.2byte   -3,   -4, 	   3,   -5, 	  -7,   -2, 	   0,   -4
+.2byte   -7,   -4, 	  -2,   -7, 	   0,   -1, 	  -1,   -5
+.2byte   -7,   -9, 	  -1,  -10, 	   0,   -5, 	  -1,   -9
+.2byte   -7,   -3, 	  -1,   -6, 	   0,   -2, 	  -1,   -4
+.2byte   -4,   -3, 	  -6,   -5, 	   4,   -2, 	  -2,   -4
+.2byte   -4,   -7, 	  -7,   -9, 	   3,   -5, 	  -2,   -8
+.2byte   -4,   -1, 	  -7,   -6, 	   5,   -2, 	  -1,   -3
+.2byte   -1,   -3, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -9, 	  -6,   -6, 	   4,   -6, 	  -1,   -8
+.2byte   -1,   -1, 	  -7,   -3, 	   5,   -3, 	  -1,   -3
+.2byte    2,   -2, 	   4,   -8, 	  -6,   -2, 	  -1,   -5
+.2byte    2,   -7, 	   5,   -9, 	  -5,   -5, 	   0,   -8
+.2byte    2,   -1, 	   5,   -6, 	  -7,   -2, 	  -1,   -3
+.2byte    2,   -1, 	   0,   -6, 	   0,   -2, 	  -1,   -5
+.2byte    5,   -9, 	  -1,  -10, 	  -2,   -5, 	  -1,   -9
+.2byte    5,   -3, 	  -1,   -6, 	  -2,   -2, 	  -1,   -4
+.2byte    0,   -4, 	  -5,   -6, 	   5,   -3, 	  -2,   -5
+.2byte    2,   -9, 	  -5,   -8, 	   4,   -4, 	  -1,   -8
+.2byte    1,   -4, 	  -5,   -5, 	   5,   -2, 	  -2,   -4
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,   -9, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -4, 	  -1,   -3
+.2byte   -2,   -4, 	   3,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -4,   -9, 	   3,   -8, 	  -6,   -4, 	  -1,   -8
+.2byte   -3,   -4, 	   3,   -5, 	  -7,   -2, 	   0,   -4
+.2byte   -4,   -1, 	  -2,   -6, 	  -2,   -2, 	  -1,   -5
+.2byte   -7,   -9, 	  -1,  -10, 	   0,   -5, 	  -1,   -9
+.2byte   -7,   -3, 	  -1,   -6, 	   0,   -2, 	  -1,   -4
+.2byte   -4,   -2, 	  -6,   -8, 	   4,   -2, 	  -1,   -5
+.2byte   -4,   -7, 	  -7,   -9, 	   3,   -5, 	  -2,   -8
+.2byte   -4,   -1, 	  -7,   -6, 	   5,   -2, 	  -1,   -3
+.2byte   -1,   -3, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -9, 	  -6,   -6, 	   4,   -6, 	  -1,   -8
+.2byte   -1,   -1, 	  -7,   -3, 	   5,   -3, 	  -1,   -3
+.2byte    2,   -2, 	   4,   -8, 	  -6,   -2, 	  -1,   -5
+.2byte    2,   -7, 	   5,   -9, 	  -5,   -5, 	   0,   -8
+.2byte    2,   -1, 	   5,   -6, 	  -7,   -2, 	  -1,   -3
+.2byte    2,   -1, 	   0,   -6, 	   0,   -2, 	  -1,   -5
+.2byte    5,   -9, 	  -1,  -10, 	  -2,   -5, 	  -1,   -9
+.2byte    5,   -3, 	  -1,   -6, 	  -2,   -2, 	  -1,   -4
+.2byte    0,   -4, 	  -5,   -6, 	   5,   -3, 	  -2,   -5
+.2byte    2,   -9, 	  -5,   -8, 	   4,   -4, 	  -1,   -8
+.2byte    1,   -4, 	  -5,   -5, 	   5,   -2, 	  -2,   -4
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,   -9, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -4, 	  -1,   -3
+.2byte   -2,   -4, 	   3,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -4,   -9, 	   3,   -8, 	  -6,   -4, 	  -1,   -8
+.2byte   -3,   -4, 	   3,   -5, 	  -7,   -2, 	   0,   -4
+.2byte   -4,   -1, 	  -2,   -6, 	  -2,   -2, 	  -1,   -5
+.2byte   -7,   -9, 	  -1,  -10, 	   0,   -5, 	  -1,   -9
+.2byte   -7,   -3, 	  -1,   -6, 	   0,   -2, 	  -1,   -4
+.2byte   -4,   -2, 	  -6,   -8, 	   4,   -2, 	  -1,   -5
+.2byte   -4,   -7, 	  -7,   -9, 	   3,   -5, 	  -2,   -8
+.2byte   -4,   -1, 	  -7,   -6, 	   5,   -2, 	  -1,   -3
+.2byte   -1,   -3, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -5, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -2, 	  -7,   -3, 	   5,   -3, 	  -1,   -4
+.2byte    2,   -3, 	   4,   -5, 	  -6,   -2, 	   0,   -4
+.2byte    2,   -5, 	   5,   -5, 	  -4,   -2, 	  -1,   -5
+.2byte    2,   -2, 	   5,   -4, 	  -6,   -3, 	  -1,   -5
+.2byte    5,   -4, 	   0,   -7, 	  -2,   -1, 	  -1,   -5
+.2byte    5,   -5, 	   0,   -6, 	  -1,   -2, 	  -1,   -6
+.2byte    5,   -3, 	  -1,   -5, 	  -2,   -2, 	  -1,   -4
+.2byte    2,   -6, 	  -4,   -6, 	   4,   -2, 	  -1,   -5
+.2byte    1,   -7, 	  -5,   -7, 	   5,   -4, 	  -2,   -6
+.2byte    1,   -5, 	  -6,   -6, 	   5,   -3, 	  -2,   -5
+.2byte   -1,   -6, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte   -1,   -5, 	   3,   -4, 	  -5,   -4, 	  -1,   -4
+.2byte   -4,   -6, 	   2,   -6, 	  -6,   -2, 	  -1,   -5
+.2byte   -3,   -7, 	   3,   -7, 	  -7,   -4, 	   0,   -6
+.2byte   -3,   -5, 	   4,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -4, 	  -1,   -7, 	   1,   -1, 	   0,   -5
+.2byte   -6,   -5, 	  -1,   -6, 	   0,   -2, 	   0,   -6
+.2byte   -6,   -3, 	   0,   -5, 	   1,   -2, 	   0,   -4
+.2byte   -4,   -3, 	  -6,   -5, 	   4,   -2, 	  -2,   -4
+.2byte   -4,   -5, 	  -7,   -5, 	   2,   -2, 	  -1,   -5
+.2byte   -4,   -2, 	  -7,   -4, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -3, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -2, 	  -6,   -2, 	   4,   -2, 	  -1,   -5
+.2byte   -1,   -5, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte    2,   -3, 	   4,   -5, 	  -6,   -2, 	   0,   -4
+.2byte    2,   -2, 	   4,   -8, 	  -6,   -2, 	  -1,   -5
+.2byte    2,   -5, 	   5,   -5, 	  -4,   -2, 	  -1,   -5
+.2byte    5,   -4, 	   0,   -7, 	  -2,   -1, 	  -1,   -5
+.2byte    2,   -1, 	   0,   -6, 	   0,   -2, 	  -1,   -5
+.2byte    5,   -5, 	   0,   -6, 	  -1,   -2, 	  -1,   -6
+.2byte    2,   -6, 	  -4,   -6, 	   4,   -2, 	  -1,   -5
+.2byte    0,   -4, 	  -5,   -6, 	   5,   -3, 	  -2,   -5
+.2byte    1,   -7, 	  -5,   -7, 	   5,   -4, 	  -2,   -6
+.2byte   -1,   -6, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte   -4,   -6, 	   2,   -6, 	  -6,   -2, 	  -1,   -5
+.2byte   -2,   -4, 	   3,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -3,   -7, 	   3,   -7, 	  -7,   -4, 	   0,   -6
+.2byte   -7,   -4, 	  -2,   -7, 	   0,   -1, 	  -1,   -5
+.2byte   -4,   -1, 	  -2,   -6, 	  -2,   -2, 	  -1,   -5
+.2byte   -7,   -5, 	  -2,   -6, 	  -1,   -2, 	  -1,   -6
+.2byte   -4,   -3, 	  -6,   -5, 	   4,   -2, 	  -2,   -4
+.2byte   -4,   -2, 	  -6,   -8, 	   4,   -2, 	  -1,   -5
+.2byte   -4,   -5, 	  -7,   -5, 	   2,   -2, 	  -1,   -5
+.2byte   -3,   -2, 	  -6,   -3, 	   5,    0, 	   0,   -4
+.2byte   -2,   -1, 	  -6,   -3, 	   5,    0, 	   0,   -3
+.2byte    0,   -8, 	  -7,  -10, 	   7,  -10, 	   0,   -7
+.2byte    4,   -8, 	   3,  -13, 	  -3,   -6, 	   0,   -8
+.2byte    6,   -7, 	  -2,   -9, 	   0,   -7, 	   0,   -8
+.2byte    2,   -9, 	  -4,  -14, 	   6,   -8, 	  -1,   -8
+.2byte    0,  -10, 	   7,  -11, 	  -7,  -11, 	   0,   -7
+.2byte   -2,   -9, 	   4,  -14, 	  -6,   -8, 	   1,   -8
+.2byte   -6,   -7, 	   2,   -9, 	   0,   -7, 	   0,   -8
+.2byte   -4,   -8, 	  -3,  -13, 	   3,   -6, 	   0,   -8
+.2byte   -1,   -3, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -9, 	  -6,   -6, 	   4,   -6, 	  -1,   -8
+.2byte    2,   -3, 	   4,   -5, 	  -6,   -2, 	   0,   -4
+.2byte    2,   -7, 	   5,   -9, 	  -5,   -5, 	   0,   -8
+.2byte    5,   -4, 	   0,   -7, 	  -2,   -1, 	  -1,   -5
+.2byte    5,   -9, 	  -1,  -10, 	  -2,   -5, 	  -1,   -9
+.2byte    2,   -6, 	  -4,   -6, 	   4,   -2, 	  -1,   -5
+.2byte    2,   -9, 	  -5,   -8, 	   4,   -4, 	  -1,   -8
+.2byte   -1,   -6, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -7, 	  -6,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	   2,   -6, 	  -6,   -2, 	  -1,   -5
+.2byte   -4,   -9, 	   3,   -8, 	  -6,   -4, 	  -1,   -8
+.2byte   -7,   -4, 	  -2,   -7, 	   0,   -1, 	  -1,   -5
+.2byte   -7,   -9, 	  -1,  -10, 	   0,   -5, 	  -1,   -9
+.2byte   -4,   -3, 	  -6,   -5, 	   4,   -2, 	  -2,   -4
+.2byte   -4,   -7, 	  -7,   -9, 	   3,   -5, 	  -2,   -8
+.2byte   -1,   -5, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte   -4,   -5, 	  -7,   -5, 	   2,   -2, 	  -1,   -5
+.2byte   -7,   -5, 	  -2,   -6, 	  -1,   -2, 	  -1,   -6
+.2byte   -3,   -7, 	   3,   -7, 	  -7,   -4, 	   0,   -6
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte    1,   -7, 	  -5,   -7, 	   5,   -4, 	  -2,   -6
+.2byte    5,   -5, 	   0,   -6, 	  -1,   -2, 	  -1,   -6
+.2byte    2,   -5, 	   5,   -5, 	  -4,   -2, 	  -1,   -5
+.2byte   -1,   -5, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte    2,   -5, 	   5,   -5, 	  -4,   -2, 	  -1,   -5
+.2byte    5,   -5, 	   0,   -6, 	  -1,   -2, 	  -1,   -6
+.2byte    1,   -7, 	  -5,   -7, 	   5,   -4, 	  -2,   -6
+.2byte   -1,   -6, 	   3,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte   -3,   -7, 	   3,   -7, 	  -7,   -4, 	   0,   -6
+.2byte   -7,   -5, 	  -2,   -6, 	  -1,   -2, 	  -1,   -6
+.2byte   -4,   -5, 	  -7,   -5, 	   2,   -2, 	  -1,   -5
+.2byte   -1,   -3, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -6, 	  -6,   -3, 	   4,   -3, 	  -1,   -5
+.2byte   -1,   -2, 	  -7,   -4, 	   5,   -4, 	  -1,   -4
+.2byte    2,   -3, 	   4,   -5, 	  -6,   -2, 	   0,   -4
+.2byte    2,   -4, 	   5,   -6, 	  -5,   -2, 	   0,   -5
+.2byte    2,   -2, 	   5,   -7, 	  -7,   -3, 	  -1,   -4
+.2byte    5,   -4, 	   0,   -7, 	  -2,   -1, 	  -1,   -5
+.2byte    5,   -5, 	  -1,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte    5,   -3, 	  -1,   -6, 	  -2,   -2, 	  -1,   -4
+.2byte    2,   -6, 	  -4,   -6, 	   4,   -2, 	  -1,   -5
+.2byte    2,   -7, 	  -5,   -6, 	   4,   -2, 	  -1,   -6
+.2byte    1,   -5, 	  -5,   -6, 	   5,   -3, 	  -2,   -5
+.2byte   -1,   -6, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte   -1,   -6, 	   5,   -5, 	  -7,   -5, 	  -1,   -4
+.2byte   -4,   -6, 	   2,   -6, 	  -6,   -2, 	  -1,   -5
+.2byte   -4,   -7, 	   3,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte   -3,   -5, 	   3,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -7,   -4, 	  -2,   -7, 	   0,   -1, 	  -1,   -5
+.2byte   -7,   -5, 	  -1,   -6, 	   0,   -1, 	  -1,   -5
+.2byte   -7,   -3, 	  -1,   -6, 	   0,   -2, 	  -1,   -4
+.2byte   -4,   -3, 	  -6,   -5, 	   4,   -2, 	  -2,   -4
+.2byte   -4,   -4, 	  -7,   -6, 	   3,   -2, 	  -2,   -5
+.2byte   -4,   -2, 	  -7,   -7, 	   5,   -3, 	  -1,   -4
+.2byte   -1,   -2, 	  -6,   -2, 	   4,   -2, 	  -1,   -5
+.2byte   -4,   -2, 	  -6,   -8, 	   4,   -2, 	  -1,   -5
+.2byte   -4,   -1, 	  -2,   -6, 	  -2,   -2, 	  -1,   -5
+.2byte   -2,   -4, 	   3,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte    0,   -4, 	  -5,   -6, 	   5,   -3, 	  -2,   -5
+.2byte    2,   -1, 	   0,   -6, 	   0,   -2, 	  -1,   -5
+.2byte    2,   -2, 	   4,   -8, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,   -3, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -4,   -3, 	  -6,   -5, 	   4,   -2, 	  -2,   -4
+.2byte   -7,   -4, 	  -2,   -7, 	   0,   -1, 	  -1,   -5
+.2byte   -4,   -6, 	   2,   -6, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,   -6, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    2,   -6, 	  -4,   -6, 	   4,   -2, 	  -1,   -5
+.2byte    5,   -4, 	   0,   -7, 	  -2,   -1, 	  -1,   -5
+.2byte    2,   -3, 	   4,   -5, 	  -6,   -2, 	   0,   -4
+sIgglybuffAnimTable1:
+.4byte sIgglybuffAnims_1_1
+.4byte sIgglybuffAnims_1_2
+.4byte sIgglybuffAnims_1_3
+.4byte sIgglybuffAnims_1_4
+.4byte sIgglybuffAnims_1_5
+.4byte sIgglybuffAnims_1_6
+.4byte sIgglybuffAnims_1_7
+.4byte sIgglybuffAnims_1_8
+sIgglybuffAnimTable2:
+.4byte sIgglybuffAnims_2_1
+.4byte sIgglybuffAnims_2_2
+.4byte sIgglybuffAnims_2_3
+.4byte sIgglybuffAnims_2_4
+.4byte sIgglybuffAnims_2_5
+.4byte sIgglybuffAnims_2_6
+.4byte sIgglybuffAnims_2_7
+.4byte sIgglybuffAnims_2_8
+sIgglybuffAnimTable3:
+.4byte sIgglybuffAnims_3_1
+.4byte sIgglybuffAnims_3_2
+.4byte sIgglybuffAnims_3_3
+.4byte sIgglybuffAnims_3_4
+.4byte sIgglybuffAnims_3_5
+.4byte sIgglybuffAnims_3_6
+.4byte sIgglybuffAnims_3_7
+.4byte sIgglybuffAnims_3_8
+sIgglybuffAnimTable4:
+.4byte sIgglybuffAnims_4_1
+.4byte sIgglybuffAnims_4_2
+.4byte sIgglybuffAnims_4_3
+.4byte sIgglybuffAnims_4_4
+.4byte sIgglybuffAnims_4_5
+.4byte sIgglybuffAnims_4_6
+.4byte sIgglybuffAnims_4_7
+.4byte sIgglybuffAnims_4_8
+sIgglybuffAnimTable5:
+.4byte sIgglybuffAnims_5_1
+.4byte sIgglybuffAnims_5_2
+.4byte sIgglybuffAnims_5_3
+.4byte sIgglybuffAnims_5_4
+.4byte sIgglybuffAnims_5_5
+.4byte sIgglybuffAnims_5_6
+.4byte sIgglybuffAnims_5_7
+.4byte sIgglybuffAnims_5_8
+sIgglybuffAnimTable6:
+.4byte sIgglybuffAnims_6_1
+.4byte sIgglybuffAnims_6_1
+.4byte sIgglybuffAnims_6_1
+.4byte sIgglybuffAnims_6_1
+.4byte sIgglybuffAnims_6_1
+.4byte sIgglybuffAnims_6_1
+.4byte sIgglybuffAnims_6_1
+.4byte sIgglybuffAnims_6_1
+sIgglybuffAnimTable7:
+.4byte sIgglybuffAnims_7_1
+.4byte sIgglybuffAnims_7_2
+.4byte sIgglybuffAnims_7_3
+.4byte sIgglybuffAnims_7_4
+.4byte sIgglybuffAnims_7_5
+.4byte sIgglybuffAnims_7_6
+.4byte sIgglybuffAnims_7_7
+.4byte sIgglybuffAnims_7_8
+sIgglybuffAnimTable8:
+.4byte sIgglybuffAnims_8_1
+.4byte sIgglybuffAnims_8_2
+.4byte sIgglybuffAnims_8_3
+.4byte sIgglybuffAnims_8_4
+.4byte sIgglybuffAnims_8_5
+.4byte sIgglybuffAnims_8_6
+.4byte sIgglybuffAnims_8_7
+.4byte sIgglybuffAnims_8_8
+sIgglybuffAnimTable9:
+.4byte sIgglybuffAnims_9_1
+.4byte sIgglybuffAnims_9_2
+.4byte sIgglybuffAnims_9_3
+.4byte sIgglybuffAnims_9_4
+.4byte sIgglybuffAnims_9_5
+.4byte sIgglybuffAnims_9_6
+.4byte sIgglybuffAnims_9_7
+.4byte sIgglybuffAnims_9_8
+sIgglybuffAnimTable10:
+.4byte sIgglybuffAnims_10_1
+.4byte sIgglybuffAnims_10_2
+.4byte sIgglybuffAnims_10_3
+.4byte sIgglybuffAnims_10_4
+.4byte sIgglybuffAnims_10_5
+.4byte sIgglybuffAnims_10_6
+.4byte sIgglybuffAnims_10_7
+.4byte sIgglybuffAnims_10_8
+sIgglybuffAnimTable11:
+.4byte sIgglybuffAnims_11_1
+.4byte sIgglybuffAnims_11_2
+.4byte sIgglybuffAnims_11_3
+.4byte sIgglybuffAnims_11_4
+.4byte sIgglybuffAnims_11_5
+.4byte sIgglybuffAnims_11_6
+.4byte sIgglybuffAnims_11_7
+.4byte sIgglybuffAnims_11_8
+sIgglybuffAnimTable12:
+.4byte sIgglybuffAnims_12_1
+.4byte sIgglybuffAnims_12_2
+.4byte sIgglybuffAnims_12_3
+.4byte sIgglybuffAnims_12_4
+.4byte sIgglybuffAnims_12_5
+.4byte sIgglybuffAnims_12_6
+.4byte sIgglybuffAnims_12_7
+.4byte sIgglybuffAnims_12_8
+sIgglybuffAnimTable13:
+.4byte sIgglybuffAnims_13_1
+.4byte sIgglybuffAnims_13_2
+.4byte sIgglybuffAnims_13_3
+.4byte sIgglybuffAnims_13_4
+.4byte sIgglybuffAnims_13_5
+.4byte sIgglybuffAnims_13_6
+.4byte sIgglybuffAnims_13_7
+.4byte sIgglybuffAnims_13_8
+sAxAnimationsIgglybuff:
+.4byte sIgglybuffAnimTable1
+.4byte sIgglybuffAnimTable2
+.4byte sIgglybuffAnimTable3
+.4byte sIgglybuffAnimTable4
+.4byte sIgglybuffAnimTable5
+.4byte sIgglybuffAnimTable6
+.4byte sIgglybuffAnimTable7
+.4byte sIgglybuffAnimTable8
+.4byte sIgglybuffAnimTable9
+.4byte sIgglybuffAnimTable10
+.4byte sIgglybuffAnimTable11
+.4byte sIgglybuffAnimTable12
+.4byte sIgglybuffAnimTable13
+sAxSpritesIgglybuff:
+.4byte sIgglybuffSprites1
+.4byte sIgglybuffSprites2
+.4byte sIgglybuffSprites3
+.4byte sIgglybuffSprites4
+.4byte sIgglybuffSprites5
+.4byte sIgglybuffSprites6
+.4byte sIgglybuffSprites7
+.4byte sIgglybuffSprites8
+.4byte sIgglybuffSprites9
+.4byte sIgglybuffSprites10
+.4byte sIgglybuffSprites11
+.4byte sIgglybuffSprites12
+.4byte sIgglybuffSprites13
+.4byte sIgglybuffSprites14
+.4byte sIgglybuffSprites15
+.4byte sIgglybuffSprites16
+.4byte sIgglybuffSprites17
+.4byte sIgglybuffSprites18
+.4byte sIgglybuffSprites19
+.4byte sIgglybuffSprites20
+.4byte sIgglybuffSprites21
+.4byte sIgglybuffSprites22
+.4byte sIgglybuffSprites23
+.4byte sIgglybuffSprites24
+.4byte sIgglybuffSprites25
+.4byte sIgglybuffSprites26
+.4byte sIgglybuffSprites27
+.4byte sIgglybuffSprites28
+.4byte sIgglybuffSprites29
+.4byte sIgglybuffSprites30
+.4byte sIgglybuffSprites31
+.4byte sIgglybuffSprites32
+.4byte sIgglybuffSprites33
+.4byte sIgglybuffSprites34
+.4byte sIgglybuffSprites35
+.4byte sIgglybuffSprites36
+.4byte sIgglybuffSprites37
+sAxMainIgglybuff:
+ax_main sAxPosesIgglybuff, sAxAnimationsIgglybuff, 13, sAxSpritesIgglybuff, sAxPositionsIgglybuff

--- a/data/ax/illumise.inc
+++ b/data/ax/illumise.inc
@@ -1,0 +1,3075 @@
+.global gAxIllumise
+gAxIllumise:
+ax_siro sAxMainIllumise
+sIllumisePose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose4:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose5:
+ax_pose 4, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose6:
+ax_pose 5, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose7:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose8:
+ax_pose 7, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose9:
+ax_pose 8, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose10:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose12:
+ax_pose 11, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose13:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose14:
+ax_pose 13, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose15:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose19:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose20:
+ax_pose 7, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose21:
+ax_pose 8, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose22:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose23:
+ax_pose 4, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose24:
+ax_pose 5, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose26:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose27:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose28:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose29:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose30:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose31:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose32:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose33:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose34:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose35:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose36:
+ax_pose 15, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose37:
+ax_pose 16, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose38:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose39:
+ax_pose 4, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose40:
+ax_pose 5, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose41:
+ax_pose 17, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sIllumisePose42:
+ax_pose 18, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sIllumisePose43:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose44:
+ax_pose 7, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose45:
+ax_pose 8, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose46:
+ax_pose 19, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose47:
+ax_pose 20, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose48:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose49:
+ax_pose 10, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose50:
+ax_pose 11, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose51:
+ax_pose 21, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose52:
+ax_pose 22, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose53:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose54:
+ax_pose 13, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose55:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose56:
+ax_pose 23, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose57:
+ax_pose 24, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose58:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose59:
+ax_pose 10, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose60:
+ax_pose 11, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose61:
+ax_pose 21, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose62:
+ax_pose 22, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose63:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose64:
+ax_pose 7, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose65:
+ax_pose 8, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose66:
+ax_pose 19, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose67:
+ax_pose 20, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose68:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose69:
+ax_pose 4, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose70:
+ax_pose 5, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose71:
+ax_pose 17, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sIllumisePose72:
+ax_pose 18, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sIllumisePose73:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose74:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose75:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose76:
+ax_pose 15, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose77:
+ax_pose 16, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose78:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose79:
+ax_pose 4, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose80:
+ax_pose 5, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose81:
+ax_pose 17, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sIllumisePose82:
+ax_pose 18, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sIllumisePose83:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose84:
+ax_pose 7, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose85:
+ax_pose 8, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose86:
+ax_pose 19, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose87:
+ax_pose 20, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose88:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose89:
+ax_pose 10, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose90:
+ax_pose 11, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose91:
+ax_pose 21, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose92:
+ax_pose 22, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose93:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose94:
+ax_pose 13, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose95:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose96:
+ax_pose 23, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose97:
+ax_pose 24, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose98:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose99:
+ax_pose 10, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose100:
+ax_pose 11, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose101:
+ax_pose 21, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose102:
+ax_pose 22, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose103:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose104:
+ax_pose 7, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose105:
+ax_pose 8, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose106:
+ax_pose 19, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose107:
+ax_pose 20, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose108:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose109:
+ax_pose 4, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose110:
+ax_pose 5, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose111:
+ax_pose 17, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sIllumisePose112:
+ax_pose 18, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sIllumisePose113:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose114:
+ax_pose 25, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose115:
+ax_pose 26, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose116:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose117:
+ax_pose 27, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose118:
+ax_pose 28, 0x01e4, 0x90ee, 0x7c00
+ax_pose_terminator
+sIllumisePose119:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose120:
+ax_pose 29, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose121:
+ax_pose 30, 0x01e4, 0x90ee, 0x7c00
+ax_pose_terminator
+sIllumisePose122:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose123:
+ax_pose 31, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose124:
+ax_pose 32, 0x01e4, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose125:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose126:
+ax_pose 33, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose127:
+ax_pose 34, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose128:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose129:
+ax_pose 31, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose130:
+ax_pose 32, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose131:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose132:
+ax_pose 29, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose133:
+ax_pose 30, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sIllumisePose134:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose135:
+ax_pose 27, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose136:
+ax_pose 28, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sIllumisePose137:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose138:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose139:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose140:
+ax_pose 15, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose141:
+ax_pose 16, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose142:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose143:
+ax_pose 4, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose144:
+ax_pose 5, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose145:
+ax_pose 17, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sIllumisePose146:
+ax_pose 18, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sIllumisePose147:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose148:
+ax_pose 7, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose149:
+ax_pose 8, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose150:
+ax_pose 19, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose151:
+ax_pose 20, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose152:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose153:
+ax_pose 10, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose154:
+ax_pose 11, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose155:
+ax_pose 21, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose156:
+ax_pose 22, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose157:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose158:
+ax_pose 13, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose159:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose160:
+ax_pose 23, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose161:
+ax_pose 24, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose162:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose163:
+ax_pose 10, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose164:
+ax_pose 11, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose165:
+ax_pose 21, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose166:
+ax_pose 22, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose167:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose168:
+ax_pose 7, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose169:
+ax_pose 8, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose170:
+ax_pose 19, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose171:
+ax_pose 20, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose172:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose173:
+ax_pose 4, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose174:
+ax_pose 5, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose175:
+ax_pose 17, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sIllumisePose176:
+ax_pose 18, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sIllumisePose177:
+ax_pose 35, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose178:
+ax_pose 36, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose179:
+ax_pose 37, 0x01e0, 0x80f1, 0x7c00
+ax_pose_terminator
+sIllumisePose180:
+ax_pose 38, 0x01e4, 0x90ea, 0x7c00
+ax_pose_terminator
+sIllumisePose181:
+ax_pose 39, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sIllumisePose182:
+ax_pose 40, 0x01e7, 0x90ea, 0x7c00
+ax_pose_terminator
+sIllumisePose183:
+ax_pose 41, 0x01e3, 0x80f1, 0x7c00
+ax_pose_terminator
+sIllumisePose184:
+ax_pose 40, 0x01e8, 0x80f7, 0x7c00
+ax_pose_terminator
+sIllumisePose185:
+ax_pose 39, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sIllumisePose186:
+ax_pose 38, 0x01e4, 0x80f6, 0x7c00
+ax_pose_terminator
+sIllumisePose187:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose188:
+ax_pose 25, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose189:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose190:
+ax_pose 27, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose191:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose192:
+ax_pose 29, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose193:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose194:
+ax_pose 31, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose195:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose196:
+ax_pose 33, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose197:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose198:
+ax_pose 31, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose199:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose200:
+ax_pose 29, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose201:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose202:
+ax_pose 27, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose203:
+ax_pose 15, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose204:
+ax_pose 17, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sIllumisePose205:
+ax_pose 19, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose206:
+ax_pose 21, 0x01e5, 0x80ed, 0x7c00
+ax_pose_terminator
+sIllumisePose207:
+ax_pose 23, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose208:
+ax_pose 21, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose209:
+ax_pose 19, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sIllumisePose210:
+ax_pose 17, 0x01e6, 0x90f1, 0x7c00
+ax_pose_terminator
+sIllumisePose211:
+ax_pose 26, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose212:
+ax_pose 28, 0x01e4, 0x90ee, 0x7c00
+ax_pose_terminator
+sIllumisePose213:
+ax_pose 30, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sIllumisePose214:
+ax_pose 32, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose215:
+ax_pose 34, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose216:
+ax_pose 32, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose217:
+ax_pose 30, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sIllumisePose218:
+ax_pose 28, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sIllumisePose219:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose220:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose221:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose222:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose223:
+ax_pose 5, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose224:
+ax_pose 4, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+sIllumisePose225:
+ax_pose 6, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose226:
+ax_pose 8, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose227:
+ax_pose 7, 0x81e6, 0x90f7, 0x7c00
+ax_pose_terminator
+sIllumisePose228:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose229:
+ax_pose 11, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose230:
+ax_pose 10, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose231:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose232:
+ax_pose 14, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose233:
+ax_pose 13, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose234:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose235:
+ax_pose 11, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose236:
+ax_pose 10, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose237:
+ax_pose 6, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose238:
+ax_pose 8, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose239:
+ax_pose 7, 0x81e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose240:
+ax_pose 3, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose241:
+ax_pose 5, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose242:
+ax_pose 4, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose243:
+ax_pose 25, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose244:
+ax_pose 27, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose245:
+ax_pose 29, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose246:
+ax_pose 31, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sIllumisePose247:
+ax_pose 33, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose248:
+ax_pose 31, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose249:
+ax_pose 29, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose250:
+ax_pose 27, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sIllumisePose251:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose252:
+ax_pose 3, 0x01e9, 0x80f4, 0x7c00
+ax_pose_terminator
+sIllumisePose253:
+ax_pose 42, 0x01e6, 0x80f8, 0x7c00
+ax_pose_terminator
+sIllumisePose254:
+ax_pose 9, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sIllumisePose255:
+ax_pose 12, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sIllumisePose256:
+ax_pose 9, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sIllumisePose257:
+ax_pose 42, 0x01e6, 0x90e8, 0x7c00
+ax_pose_terminator
+sIllumisePose258:
+ax_pose 3, 0x01e9, 0x90ec, 0x7c00
+ax_pose_terminator
+.align 2
+sIllumiseAnims_1_1:
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 2,
+ax_anim 4, 0, 0, 0, 1, 0, 3,
+ax_anim 4, 0, 2, 0, 1, 0, 3,
+ax_anim 4, 0, 0, 0, 0, 0, 2,
+ax_anim 4, 0, 1, 0, -1, 0, 1,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, -1,
+ax_anim_terminator
+sIllumiseAnims_1_2:
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 1, -2, 1, 1,
+ax_anim 4, 0, 3, 2, -3, 2, 2,
+ax_anim 4, 0, 5, 2, -4, 2, 2,
+ax_anim 4, 0, 3, 1, -5, 1, 1,
+ax_anim 4, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 3, -1, -3, -1, -1,
+ax_anim 4, 0, 5, -1, -2, -1, -1,
+ax_anim_terminator
+sIllumiseAnims_1_3:
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 1, -3, 1, 0,
+ax_anim 4, 0, 6, 2, -4, 2, 0,
+ax_anim 4, 0, 8, 2, -5, 2, 0,
+ax_anim 4, 0, 6, 1, -5, 1, 0,
+ax_anim 4, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 6, -1, -3, -1, 0,
+ax_anim 4, 0, 8, -1, -2, -1, 0,
+ax_anim_terminator
+sIllumiseAnims_1_4:
+ax_anim 4, 0, 9, 0, -2, 0, 0,
+ax_anim 4, 0, 10, 1, -3, 1, -1,
+ax_anim 4, 0, 9, 2, -5, 2, -2,
+ax_anim 4, 0, 11, 2, -6, 2, -2,
+ax_anim 4, 0, 9, 1, -7, 1, -1,
+ax_anim 4, 0, 10, 0, -6, 0, 0,
+ax_anim 4, 0, 9, -1, -3, -1, 1,
+ax_anim 4, 0, 11, -1, -2, -1, 1,
+ax_anim_terminator
+sIllumiseAnims_1_5:
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, -1,
+ax_anim 4, 0, 12, 0, -5, 0, -2,
+ax_anim 4, 0, 14, 0, -6, 0, -3,
+ax_anim 4, 0, 12, 0, -6, 0, -3,
+ax_anim 4, 0, 13, 0, -5, 0, -2,
+ax_anim 4, 0, 12, 0, -3, 0, -1,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_1_6:
+ax_anim 4, 0, 15, 0, -2, 0, 0,
+ax_anim 4, 0, 16, -1, -3, -1, -1,
+ax_anim 4, 0, 15, -2, -5, -2, -2,
+ax_anim 4, 0, 17, -2, -6, -2, -2,
+ax_anim 4, 0, 15, -1, -7, -1, -1,
+ax_anim 4, 0, 16, 0, -6, 0, 0,
+ax_anim 4, 0, 15, 1, -3, 1, 1,
+ax_anim 4, 0, 17, 1, -2, 1, 1,
+ax_anim_terminator
+sIllumiseAnims_1_7:
+ax_anim 4, 0, 18, 0, -2, 0, 0,
+ax_anim 4, 0, 19, -1, -3, -1, 0,
+ax_anim 4, 0, 18, -2, -4, -2, 0,
+ax_anim 4, 0, 20, -2, -5, -2, 0,
+ax_anim 4, 0, 18, -1, -5, -1, 0,
+ax_anim 4, 0, 19, 0, -4, 0, 0,
+ax_anim 4, 0, 18, 1, -3, 1, 0,
+ax_anim 4, 0, 20, 1, -2, 1, 0,
+ax_anim_terminator
+sIllumiseAnims_1_8:
+ax_anim 4, 0, 21, 0, -2, 0, 0,
+ax_anim 4, 0, 22, -1, -2, -1, 1,
+ax_anim 4, 0, 21, -2, -3, -2, 2,
+ax_anim 4, 0, 23, -2, -4, -2, 2,
+ax_anim 4, 0, 21, -1, -5, -1, 1,
+ax_anim 4, 0, 22, 0, -4, 0, 0,
+ax_anim 4, 0, 21, 1, -3, 1, -1,
+ax_anim 4, 0, 23, 1, -2, 1, -1,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, 0,
+ax_anim 2, 0, 32, 0, -3, 0, 0,
+ax_anim 2, 0, 36, 0, -4, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 36, 0, -4, 0, 0,
+ax_anim 2, 2, 35, 0, -4, 0, 0,
+ax_anim 1, 0, 36, 0, 7, 0, 7,
+ax_anim 1, 0, 35, 0, 14, 0, 14,
+ax_anim 2, 1, 36, 0, 22, 0, 22,
+ax_anim 2, 0, 35, 1, 22, 1, 22,
+ax_anim 2, 0, 36, 0, 22, 0, 22,
+ax_anim 2, 0, 35, 1, 22, 1, 22,
+ax_anim 2, 0, 36, 0, 22, 0, 22,
+ax_anim 2, 0, 33, 0, 10, 0, 10,
+ax_anim 2, 0, 34, 0, 4, 0, 4,
+ax_anim_terminator
+sIllumiseAnims_2_2:
+ax_anim 2, 0, 37, 0, -1, 0, 0,
+ax_anim 2, 0, 37, 0, -2, 0, 0,
+ax_anim 2, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 40, 0, -4, 0, 0,
+ax_anim 2, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 2, 40, 0, -4, 0, 0,
+ax_anim 1, 0, 41, 7, 7, 7, 7,
+ax_anim 1, 0, 40, 14, 14, 14, 14,
+ax_anim 2, 1, 41, 21, 22, 21, 22,
+ax_anim 2, 0, 40, 22, 21, 22, 21,
+ax_anim 2, 0, 41, 21, 22, 21, 22,
+ax_anim 2, 0, 40, 22, 21, 22, 21,
+ax_anim 2, 0, 41, 21, 22, 21, 22,
+ax_anim 2, 0, 38, 10, 10, 10, 10,
+ax_anim 2, 0, 39, 4, 4, 4, 4,
+ax_anim_terminator
+sIllumiseAnims_2_3:
+ax_anim 2, 0, 42, 0, -1, 0, 0,
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 46, 0, -4, 0, 0,
+ax_anim 2, 0, 45, 0, -4, 0, 0,
+ax_anim 2, 0, 46, 0, -4, 0, 0,
+ax_anim 2, 2, 45, 0, -4, 0, 0,
+ax_anim 1, 0, 46, 7, -3, 7, 0,
+ax_anim 1, 0, 45, 14, -2, 14, 0,
+ax_anim 2, 1, 46, 19, 0, 19, 0,
+ax_anim 2, 0, 45, 19, 1, 19, 1,
+ax_anim 2, 0, 46, 19, 0, 19, 0,
+ax_anim 2, 0, 45, 19, 1, 19, 1,
+ax_anim 2, 0, 46, 19, 0, 19, 0,
+ax_anim 2, 0, 43, 10, -2, 10, 0,
+ax_anim 2, 0, 44, 4, -1, 4, 0,
+ax_anim_terminator
+sIllumiseAnims_2_4:
+ax_anim 2, 0, 47, 0, -1, 0, 0,
+ax_anim 2, 0, 47, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 2, 50, 0, -4, 0, 0,
+ax_anim 1, 0, 51, 7, -10, 7, -7,
+ax_anim 1, 0, 50, 14, -15, 14, -14,
+ax_anim 2, 1, 51, 20, -19, 20, -19,
+ax_anim 2, 0, 50, 21, -18, 21, -18,
+ax_anim 2, 0, 51, 20, -19, 20, -19,
+ax_anim 2, 0, 50, 21, -18, 21, -18,
+ax_anim 2, 0, 51, 20, -19, 20, -19,
+ax_anim 2, 0, 48, 10, -10, 10, -10,
+ax_anim 2, 0, 49, 4, -4, 4, -4,
+ax_anim_terminator
+sIllumiseAnims_2_5:
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 0, -3, 0, 0,
+ax_anim 2, 0, 56, 0, -4, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 56, 0, -4, 0, 0,
+ax_anim 2, 2, 55, 0, -4, 0, 0,
+ax_anim 1, 0, 56, 0, -7, 0, -7,
+ax_anim 1, 0, 55, 0, -13, 0, -13,
+ax_anim 2, 1, 56, 0, -18, 0, -18,
+ax_anim 2, 0, 55, 1, -18, 1, -18,
+ax_anim 2, 0, 56, 0, -18, 0, -18,
+ax_anim 2, 0, 55, 1, -18, 1, -18,
+ax_anim 2, 0, 56, 0, -18, 0, -18,
+ax_anim 2, 0, 53, 0, -10, 0, -10,
+ax_anim 2, 0, 54, 0, -4, 0, -4,
+ax_anim_terminator
+sIllumiseAnims_2_6:
+ax_anim 2, 0, 57, 0, -1, 0, 0,
+ax_anim 2, 0, 57, 0, -2, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, 0,
+ax_anim 2, 0, 60, 0, -4, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, 0,
+ax_anim 2, 2, 60, 0, -4, 0, 0,
+ax_anim 1, 0, 61, -7, -10, -7, -7,
+ax_anim 1, 0, 60, -14, -15, -14, -14,
+ax_anim 2, 1, 61, -20, -19, -20, -19,
+ax_anim 2, 0, 60, -21, -18, -21, -18,
+ax_anim 2, 0, 61, -20, -19, -20, -19,
+ax_anim 2, 0, 60, -21, -18, -21, -18,
+ax_anim 2, 0, 61, -20, -19, -20, -19,
+ax_anim 2, 0, 58, -10, -10, -10, -10,
+ax_anim 2, 0, 59, -4, -4, -4, -4,
+ax_anim_terminator
+sIllumiseAnims_2_7:
+ax_anim 2, 0, 62, 0, -1, 0, 0,
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 66, 0, -4, 0, 0,
+ax_anim 2, 0, 65, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -4, 0, 0,
+ax_anim 2, 2, 65, 0, -4, 0, 0,
+ax_anim 1, 0, 66, -7, -3, -7, 0,
+ax_anim 1, 0, 65, -14, -2, -14, 0,
+ax_anim 2, 1, 66, -19, 0, -19, 0,
+ax_anim 2, 0, 65, -19, 1, -19, 1,
+ax_anim 2, 0, 66, -19, 0, -19, 0,
+ax_anim 2, 0, 65, -19, 1, -19, 1,
+ax_anim 2, 0, 66, -19, 0, -19, 0,
+ax_anim 2, 0, 63, -10, -2, -10, 0,
+ax_anim 2, 0, 64, -4, -1, -4, 0,
+ax_anim_terminator
+sIllumiseAnims_2_8:
+ax_anim 2, 0, 67, 0, -1, 0, 0,
+ax_anim 2, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -4, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 2, 70, 0, -4, 0, 0,
+ax_anim 1, 0, 71, -7, 7, -7, 7,
+ax_anim 1, 0, 70, -14, 14, -14, 14,
+ax_anim 2, 1, 71, -21, 22, -21, 22,
+ax_anim 2, 0, 70, -22, 21, -22, 21,
+ax_anim 2, 0, 71, -21, 22, -21, 22,
+ax_anim 2, 0, 70, -22, 21, -22, 21,
+ax_anim 2, 0, 71, -21, 22, -21, 22,
+ax_anim 2, 0, 68, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_3_1:
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 2, 75, 0, -4, 0, 0,
+ax_anim 1, 0, 76, 0, 10, 0, 10,
+ax_anim 1, 0, 75, 0, 23, 0, 23,
+ax_anim 2, 1, 76, 0, 46, 0, 46,
+ax_anim 2, 0, 75, 1, 46, 1, 46,
+ax_anim 2, 0, 76, 0, 46, 0, 46,
+ax_anim 2, 0, 75, 1, 46, 1, 46,
+ax_anim 2, 0, 76, 0, 46, 0, 46,
+ax_anim 2, 0, 75, 0, 20, 0, 20,
+ax_anim 2, 0, 76, 0, 8, 0, 8,
+ax_anim_terminator
+sIllumiseAnims_3_2:
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 2, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 2, 80, 0, -4, 0, 0,
+ax_anim 1, 0, 81, 10, 10, 10, 10,
+ax_anim 1, 0, 80, 23, 23, 23, 23,
+ax_anim 2, 1, 81, 46, 47, 46, 47,
+ax_anim 2, 0, 80, 47, 46, 47, 46,
+ax_anim 2, 0, 81, 46, 47, 46, 47,
+ax_anim 2, 0, 80, 47, 46, 47, 46,
+ax_anim 2, 0, 81, 46, 47, 46, 47,
+ax_anim 2, 0, 80, 20, 20, 20, 20,
+ax_anim 2, 0, 81, 8, 8, 8, 8,
+ax_anim_terminator
+sIllumiseAnims_3_3:
+ax_anim 2, 0, 82, 0, -1, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 2, 85, 0, -4, 0, 0,
+ax_anim 1, 0, 86, 14, -3, 14, 0,
+ax_anim 1, 0, 85, 21, -2, 21, 0,
+ax_anim 2, 1, 86, 42, 0, 42, 0,
+ax_anim 2, 0, 85, 42, 1, 42, 1,
+ax_anim 2, 0, 86, 42, 0, 42, 0,
+ax_anim 2, 0, 85, 42, 1, 42, 1,
+ax_anim 2, 0, 86, 42, 0, 42, 0,
+ax_anim 2, 0, 85, 22, -2, 22, 0,
+ax_anim 2, 0, 86, 10, -1, 10, 0,
+ax_anim_terminator
+sIllumiseAnims_3_4:
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 2, 90, 0, -4, 0, 0,
+ax_anim 1, 0, 91, 10, -10, 10, -10,
+ax_anim 1, 0, 90, 21, -21, 21, -21,
+ax_anim 2, 1, 91, 44, -41, 44, -41,
+ax_anim 2, 0, 90, 45, -40, 45, -40,
+ax_anim 2, 0, 91, 44, -41, 44, -41,
+ax_anim 2, 0, 90, 45, -40, 45, -40,
+ax_anim 2, 0, 91, 44, -41, 44, -41,
+ax_anim 2, 0, 90, 19, -19, 19, -19,
+ax_anim 2, 0, 91, 8, -8, 8, -8,
+ax_anim_terminator
+sIllumiseAnims_3_5:
+ax_anim 2, 0, 92, 0, -1, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 2, 95, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -11, 0, -11,
+ax_anim 1, 0, 95, 0, -23, 0, -23,
+ax_anim 2, 1, 96, 0, -42, 0, -42,
+ax_anim 2, 0, 95, 1, -42, 1, -42,
+ax_anim 2, 0, 96, 0, -42, 0, -42,
+ax_anim 2, 0, 95, 1, -42, 1, -42,
+ax_anim 2, 0, 96, 0, -42, 0, -42,
+ax_anim 2, 0, 95, 0, -21, 0, -21,
+ax_anim 2, 0, 96, 0, -8, 0, -8,
+ax_anim_terminator
+sIllumiseAnims_3_6:
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 2, 100, 0, -4, 0, 0,
+ax_anim 1, 0, 101, -10, -10, -10, -10,
+ax_anim 1, 0, 100, -21, -21, -21, -21,
+ax_anim 2, 1, 101, -44, -41, -44, -41,
+ax_anim 2, 0, 100, -45, -40, -45, -40,
+ax_anim 2, 0, 101, -44, -41, -44, -41,
+ax_anim 2, 0, 100, -45, -40, -45, -40,
+ax_anim 2, 0, 101, -44, -41, -44, -41,
+ax_anim 2, 0, 100, -19, -19, -19, -19,
+ax_anim 2, 0, 101, -8, -8, -8, -8,
+ax_anim_terminator
+sIllumiseAnims_3_7:
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 2, 105, 0, -4, 0, 0,
+ax_anim 1, 0, 106, -14, -3, -14, 0,
+ax_anim 1, 0, 105, -21, -2, -21, 0,
+ax_anim 2, 1, 106, -42, 0, -42, 0,
+ax_anim 2, 0, 105, -42, 1, -42, 1,
+ax_anim 2, 0, 106, -42, 0, -42, 0,
+ax_anim 2, 0, 105, -42, 1, -42, 1,
+ax_anim 2, 0, 106, -42, 0, -42, 0,
+ax_anim 2, 0, 105, -22, -2, -22, 0,
+ax_anim 2, 0, 106, -10, -1, -10, 0,
+ax_anim_terminator
+sIllumiseAnims_3_8:
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 2, 110, 0, -4, 0, 0,
+ax_anim 1, 0, 111, -10, 10, -10, 10,
+ax_anim 1, 0, 110, -23, 23, -23, 23,
+ax_anim 2, 1, 111, -46, 47, -46, 47,
+ax_anim 2, 0, 110, -47, 46, -47, 46,
+ax_anim 2, 0, 111, -46, 47, -46, 47,
+ax_anim 2, 0, 110, -47, 46, -47, 46,
+ax_anim 2, 0, 111, -46, 47, -46, 47,
+ax_anim 2, 0, 110, -20, 20, -20, 20,
+ax_anim 2, 0, 111, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_4_1:
+ax_anim 2, 0, 113, 0, -2, 0, -2,
+ax_anim 6, 2, 113, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 1, 114, 0, 3, 0, 2,
+ax_anim 2, 0, 114, 1, 3, 1, 2,
+ax_anim 2, 0, 114, 0, 3, 0, 2,
+ax_anim 2, 0, 114, 1, 3, 1, 2,
+ax_anim 2, 0, 114, 0, 3, 0, 2,
+ax_anim 2, 0, 114, 1, 3, 1, 2,
+ax_anim 2, 0, 114, 0, 3, 0, 2,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim_terminator
+sIllumiseAnims_4_2:
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim 6, 2, 116, -3, -3, -3, -3,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 1, 117, 2, 2, 1, 1,
+ax_anim 2, 0, 117, 3, 1, 2, 0,
+ax_anim 2, 0, 117, 2, 2, 1, 1,
+ax_anim 2, 0, 117, 3, 1, 2, 0,
+ax_anim 2, 0, 117, 2, 2, 1, 1,
+ax_anim 2, 0, 117, 3, 1, 2, 0,
+ax_anim 2, 0, 117, 2, 2, 1, 1,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim_terminator
+sIllumiseAnims_4_3:
+ax_anim 2, 0, 119, -2, 0, -2, 0,
+ax_anim 6, 2, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim 2, 1, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim_terminator
+sIllumiseAnims_4_4:
+ax_anim 2, 0, 122, -2, 2, -2, 2,
+ax_anim 6, 2, 122, -3, 3, -3, 3,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 1, 123, 2, -2, 1, -1,
+ax_anim 2, 0, 123, 3, -1, 2, 0,
+ax_anim 2, 0, 123, 2, -2, 1, -1,
+ax_anim 2, 0, 123, 3, -1, 2, 0,
+ax_anim 2, 0, 123, 2, -2, 1, -1,
+ax_anim 2, 0, 123, 3, -1, 2, 0,
+ax_anim 2, 0, 123, 2, -2, 1, -1,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim_terminator
+sIllumiseAnims_4_5:
+ax_anim 2, 0, 125, 0, 2, 0, 2,
+ax_anim 6, 2, 125, 0, 3, 0, 3,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 1, 126, 0, -3, 0, -2,
+ax_anim 2, 0, 126, 1, -3, 1, -2,
+ax_anim 2, 0, 126, 0, -3, 0, -2,
+ax_anim 2, 0, 126, 1, -3, 1, -2,
+ax_anim 2, 0, 126, 0, -3, 0, -2,
+ax_anim 2, 0, 126, 1, -3, 1, -2,
+ax_anim 2, 0, 126, 0, -3, 0, -2,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sIllumiseAnims_4_6:
+ax_anim 2, 0, 128, 2, 2, 2, 2,
+ax_anim 6, 2, 128, 3, 3, 3, 3,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 1, 129, -2, -2, -1, -1,
+ax_anim 2, 0, 129, -3, -1, -2, 0,
+ax_anim 2, 0, 129, -2, -2, -1, -1,
+ax_anim 2, 0, 129, -3, -1, -2, 0,
+ax_anim 2, 0, 129, -2, -2, -1, -1,
+ax_anim 2, 0, 129, -3, -1, -2, 0,
+ax_anim 2, 0, 129, -2, -2, -1, -1,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+sIllumiseAnims_4_7:
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 6, 2, 131, 3, 0, 3, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 1, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim_terminator
+sIllumiseAnims_4_8:
+ax_anim 2, 0, 134, 2, -2, 2, -2,
+ax_anim 6, 2, 134, 3, -3, 3, -3,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 1, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 135, -3, 1, -2, 0,
+ax_anim 2, 0, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 135, -3, 1, -2, 0,
+ax_anim 2, 0, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 135, -3, 1, -2, 0,
+ax_anim 2, 0, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 133, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_5_1:
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 140, 1, -5, 1, 0,
+ax_anim 2, 0, 140, 2, -6, 2, 0,
+ax_anim 2, 0, 139, 2, -6, 2, 0,
+ax_anim 2, 0, 139, 1, -5, 1, 0,
+ax_anim 2, 2, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 140, -1, -5, -1, 0,
+ax_anim 2, 0, 140, -2, -6, -2, 0,
+ax_anim 2, 0, 139, -2, -6, -2, 0,
+ax_anim 2, 0, 139, -1, -5, -1, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_5_2:
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 144, 0, -5, 0, 0,
+ax_anim 2, 0, 145, 1, -6, 1, -1,
+ax_anim 2, 0, 145, 2, -8, 2, -2,
+ax_anim 2, 0, 144, 2, -8, 2, -2,
+ax_anim 2, 0, 144, 1, -6, 1, -1,
+ax_anim 2, 2, 145, 0, -5, 0, 0,
+ax_anim 2, 0, 145, -1, -4, -1, 1,
+ax_anim 2, 0, 145, -2, -5, -2, 1,
+ax_anim 2, 0, 144, -2, -5, -2, 1,
+ax_anim 2, 0, 144, -1, -4, -1, 1,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_5_3:
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, -1, -5, 0, 0,
+ax_anim 2, 0, 149, 0, -5, 0, 0,
+ax_anim 2, 0, 150, 0, -6, 0, -1,
+ax_anim 2, 0, 150, 0, -7, 0, -2,
+ax_anim 2, 0, 149, 0, -8, 0, -2,
+ax_anim 2, 0, 149, 0, -6, 0, -1,
+ax_anim 2, 2, 150, 0, -5, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 1,
+ax_anim 2, 0, 150, 0, -5, 0, 2,
+ax_anim 2, 0, 149, 0, -5, 0, 2,
+ax_anim 2, 0, 149, 0, -4, 0, 1,
+ax_anim 2, 0, 146, -1, -5, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_5_4:
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 154, 0, -5, 0, 0,
+ax_anim 2, 0, 155, -1, -6, -1, -1,
+ax_anim 2, 0, 155, -2, -8, -2, -3,
+ax_anim 2, 0, 154, -2, -8, -2, -3,
+ax_anim 2, 0, 154, -1, -6, -1, -1,
+ax_anim 2, 2, 155, 0, -5, 0, 0,
+ax_anim 2, 0, 155, 1, -4, 1, 1,
+ax_anim 2, 0, 155, 2, -5, 2, 1,
+ax_anim 2, 0, 154, 2, -5, 2, 1,
+ax_anim 2, 0, 154, 1, -4, 1, 1,
+ax_anim 2, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_5_5:
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 0, 156, 0, -5, 0, 0,
+ax_anim 2, 0, 159, 0, -5, 0, 0,
+ax_anim 2, 0, 160, 1, -5, 1, 0,
+ax_anim 2, 0, 160, 2, -6, 2, 0,
+ax_anim 2, 0, 159, 2, -6, 2, 0,
+ax_anim 2, 0, 159, 1, -5, 1, 0,
+ax_anim 2, 2, 160, 0, -5, 0, 0,
+ax_anim 2, 0, 160, -1, -5, -1, 0,
+ax_anim 2, 0, 160, -2, -6, -2, 0,
+ax_anim 2, 0, 159, -2, -6, -2, 0,
+ax_anim 2, 0, 159, -1, -5, -1, 0,
+ax_anim 2, 0, 156, 0, -5, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_5_6:
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -5, 0, 0,
+ax_anim 2, 0, 164, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 1, -6, 1, -1,
+ax_anim 2, 0, 165, 2, -8, 2, -3,
+ax_anim 2, 0, 164, 2, -8, 2, -3,
+ax_anim 2, 0, 164, 1, -6, 1, -1,
+ax_anim 2, 2, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 165, -1, -4, -1, 1,
+ax_anim 2, 0, 165, -2, -5, -2, 1,
+ax_anim 2, 0, 164, -2, -5, -2, 1,
+ax_anim 2, 0, 164, -1, -4, -1, 1,
+ax_anim 2, 0, 161, 0, -5, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_5_7:
+ax_anim 2, 0, 166, 0, -2, 0, 0,
+ax_anim 4, 0, 166, 1, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 170, 0, -6, 0, -1,
+ax_anim 2, 0, 170, 0, -7, 0, -2,
+ax_anim 2, 0, 169, 0, -8, 0, -2,
+ax_anim 2, 0, 169, 0, -6, 0, -1,
+ax_anim 2, 2, 170, 0, -5, 0, 0,
+ax_anim 2, 0, 170, 0, -4, 0, 1,
+ax_anim 2, 0, 170, 0, -5, 0, 2,
+ax_anim 2, 0, 169, 0, -5, 0, 2,
+ax_anim 2, 0, 169, 0, -4, 0, 1,
+ax_anim 2, 0, 166, 1, -5, 0, 0,
+ax_anim 2, 0, 166, 0, -2, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_5_8:
+ax_anim 2, 0, 171, 0, -2, 0, 0,
+ax_anim 4, 0, 171, 0, -5, 0, 0,
+ax_anim 2, 0, 174, 0, -5, 0, 0,
+ax_anim 2, 0, 175, -1, -6, -1, -1,
+ax_anim 2, 0, 175, -2, -8, -2, -2,
+ax_anim 2, 0, 174, -2, -8, -2, -2,
+ax_anim 2, 0, 174, -1, -6, -1, -1,
+ax_anim 2, 2, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 1, -4, 1, 1,
+ax_anim 2, 0, 175, 2, -5, 2, 1,
+ax_anim 2, 0, 174, 2, -5, 2, 1,
+ax_anim 2, 0, 174, 1, -4, 1, 1,
+ax_anim 2, 0, 171, 0, -5, 0, 0,
+ax_anim 2, 0, 171, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sIllumiseAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sIllumiseAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sIllumiseAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sIllumiseAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sIllumiseAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sIllumiseAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sIllumiseAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_8_1:
+ax_anim 30, 0, 186, 0, 0, 0, 0,
+ax_anim 20, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_8_2:
+ax_anim 30, 0, 188, 0, 0, 0, 0,
+ax_anim 20, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_8_3:
+ax_anim 30, 0, 190, 0, 0, 0, 0,
+ax_anim 20, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_8_4:
+ax_anim 30, 0, 192, 0, 0, 0, 0,
+ax_anim 20, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_8_5:
+ax_anim 30, 0, 194, 0, 0, 0, 0,
+ax_anim 20, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_8_6:
+ax_anim 30, 0, 196, 0, 0, 0, 0,
+ax_anim 20, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_8_7:
+ax_anim 30, 0, 198, 0, 0, 0, 0,
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_8_8:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 20, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 7, 5, 7, 5,
+ax_anim 2, 0, 204, 10, 15, 10, 15,
+ax_anim 2, 0, 205, 7, 21, 7, 21,
+ax_anim 3, 0, 206, 0, 23, 0, 23,
+ax_anim 2, 3, 207, -7, 21, -7, 21,
+ax_anim 2, 0, 208, -10, 15, -10, 15,
+ax_anim 1, 0, 209, -7, 5, -7, 5,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 10, 3, 10, 3,
+ax_anim 2, 0, 203, 21, 8, 21, 8,
+ax_anim 2, 0, 204, 25, 18, 25, 18,
+ax_anim 3, 0, 205, 21, 23, 21, 23,
+ax_anim 2, 3, 206, 12, 22, 12, 22,
+ax_anim 2, 0, 207, 4, 16, 4, 16,
+ax_anim 1, 0, 208, 1, 8, 1, 8,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 5, -4, 5, -4,
+ax_anim 2, 0, 202, 13, -5, 13, -5,
+ax_anim 2, 0, 203, 19, -2, 19, -2,
+ax_anim 3, 0, 204, 22, 3, 22, 1,
+ax_anim 2, 3, 205, 19, 8, 19, 7,
+ax_anim 2, 0, 206, 12, 9, 12, 9,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 1, -5, 1, -5,
+ax_anim 2, 0, 209, 4, -15, 4, -15,
+ax_anim 2, 0, 202, 14, -21, 14, -21,
+ax_anim 3, 0, 203, 23, -22, 23, -23,
+ax_anim 2, 3, 204, 27, -13, 27, -14,
+ax_anim 2, 0, 205, 20, -6, 20, -6,
+ax_anim 1, 0, 206, 9, -2, 9, -2,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -7, -4, -7, -4,
+ax_anim 2, 0, 208, -11, -10, -11, -10,
+ax_anim 2, 0, 209, -10, -21, -10, -21,
+ax_anim 3, 0, 202, 0, -23, 0, -23,
+ax_anim 2, 3, 203, 10, -21, 10, -21,
+ax_anim 2, 0, 204, 11, -10, 11, -10,
+ax_anim 1, 0, 205, 7, -4, 7, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, -1, -5, -1, -5,
+ax_anim 2, 0, 203, -4, -15, -4, -15,
+ax_anim 2, 0, 202, -14, -21, -14, -21,
+ax_anim 3, 0, 209, -23, -22, -23, -23,
+ax_anim 2, 3, 208, -27, -13, -27, -14,
+ax_anim 2, 0, 207, -20, -6, -20, -6,
+ax_anim 1, 0, 206, -9, -2, -9, -2,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -5, -4, -5, -4,
+ax_anim 2, 0, 202, -13, -5, -13, -5,
+ax_anim 2, 0, 209, -19, -2, -19, -2,
+ax_anim 3, 0, 208, -22, 3, -22, 1,
+ax_anim 2, 3, 207, -19, 8, -19, 7,
+ax_anim 2, 0, 206, -12, 9, -12, 9,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -10, 3, -10, 3,
+ax_anim 2, 0, 209, -21, 8, -21, 8,
+ax_anim 2, 0, 208, -25, 18, -25, 18,
+ax_anim 3, 0, 207, -21, 23, -21, 23,
+ax_anim 2, 3, 206, -12, 22, -12, 22,
+ax_anim 2, 0, 205, -4, 16, -4, 16,
+ax_anim 1, 0, 204, -1, 8, -1, 8,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -22, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -22, 0, 0,
+ax_anim 4, 0, 227, 0, -23, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -22, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -22, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -22, 0, 0,
+ax_anim 4, 0, 236, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -22, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIllumiseAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sIllumiseGfx1:
+.incbin "baserom.gba", 0x12CA698, 0x200
+sIllumiseSprites1:
+ax_sprite sIllumiseGfx1, 0x200
+ax_sprite_terminator
+sIllumiseGfx2:
+.incbin "baserom.gba", 0x12CA8A8, 0x200
+sIllumiseSprites2:
+ax_sprite sIllumiseGfx2, 0x200
+ax_sprite_terminator
+sIllumiseGfx3:
+.incbin "baserom.gba", 0x12CAAB8, 0x200
+sIllumiseSprites3:
+ax_sprite sIllumiseGfx3, 0x200
+ax_sprite_terminator
+sIllumiseGfx4:
+.incbin "baserom.gba", 0x12CACC8, 0x200
+sIllumiseSprites4:
+ax_sprite sIllumiseGfx4, 0x200
+ax_sprite_terminator
+sIllumiseGfx5:
+.incbin "baserom.gba", 0x12CAED8, 0x200
+sIllumiseSprites5:
+ax_sprite sIllumiseGfx5, 0x200
+ax_sprite_terminator
+sIllumiseGfx6:
+.incbin "baserom.gba", 0x12CB0E8, 0x200
+sIllumiseSprites6:
+ax_sprite sIllumiseGfx6, 0x200
+ax_sprite_terminator
+sIllumiseGfx7:
+.incbin "baserom.gba", 0x12CB2F8, 0x100
+sIllumiseSprites7:
+ax_sprite sIllumiseGfx7, 0x100
+ax_sprite_terminator
+sIllumiseGfx8:
+.incbin "baserom.gba", 0x12CB408, 0x100
+sIllumiseSprites8:
+ax_sprite sIllumiseGfx8, 0x100
+ax_sprite_terminator
+sIllumiseGfx9:
+.incbin "baserom.gba", 0x12CB518, 0x100
+sIllumiseSprites9:
+ax_sprite sIllumiseGfx9, 0x100
+ax_sprite_terminator
+sIllumiseGfx10:
+.incbin "baserom.gba", 0x12CB628, 0x200
+sIllumiseSprites10:
+ax_sprite sIllumiseGfx10, 0x200
+ax_sprite_terminator
+sIllumiseGfx11:
+.incbin "baserom.gba", 0x12CB838, 0x200
+sIllumiseSprites11:
+ax_sprite sIllumiseGfx11, 0x200
+ax_sprite_terminator
+sIllumiseGfx12:
+.incbin "baserom.gba", 0x12CBA48, 0x200
+sIllumiseSprites12:
+ax_sprite sIllumiseGfx12, 0x200
+ax_sprite_terminator
+sIllumiseGfx13:
+.incbin "baserom.gba", 0x12CBC58, 0x200
+sIllumiseSprites13:
+ax_sprite sIllumiseGfx13, 0x200
+ax_sprite_terminator
+sIllumiseGfx14:
+.incbin "baserom.gba", 0x12CBE68, 0x200
+sIllumiseSprites14:
+ax_sprite sIllumiseGfx14, 0x200
+ax_sprite_terminator
+sIllumiseGfx15:
+.incbin "baserom.gba", 0x12CC078, 0x200
+sIllumiseSprites15:
+ax_sprite sIllumiseGfx15, 0x200
+ax_sprite_terminator
+sIllumiseGfx16:
+.incbin "baserom.gba", 0x12CC288, 0x100
+sIllumiseGfx16_1:
+.incbin "baserom.gba", 0x12CC388, 0x40
+sIllumiseSprites16:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx17:
+.incbin "baserom.gba", 0x12CC3F8, 0x100
+sIllumiseGfx17_1:
+.incbin "baserom.gba", 0x12CC4F8, 0x40
+sIllumiseSprites17:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx17, 0x100
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx18:
+.incbin "baserom.gba", 0x12CC568, 0x100
+sIllumiseGfx18_1:
+.incbin "baserom.gba", 0x12CC668, 0x20
+sIllumiseSprites18:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx18, 0x100
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx18_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx19:
+.incbin "baserom.gba", 0x12CC6B8, 0x100
+sIllumiseGfx19_1:
+.incbin "baserom.gba", 0x12CC7B8, 0x20
+sIllumiseSprites19:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx19, 0x100
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx19_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx20:
+.incbin "baserom.gba", 0x12CC808, 0x100
+sIllumiseGfx20_1:
+.incbin "baserom.gba", 0x12CC908, 0x40
+sIllumiseSprites20:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx20, 0x100
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx20_1, 0x40
+ax_sprite_terminator
+sIllumiseGfx21:
+.incbin "baserom.gba", 0x12CC970, 0x60
+sIllumiseGfx21_1:
+.incbin "baserom.gba", 0x12CC9D0, 0x80
+sIllumiseGfx21_2:
+.incbin "baserom.gba", 0x12CCA50, 0x40
+sIllumiseSprites21:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx21_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx21_2, 0x40
+ax_sprite_terminator
+sIllumiseGfx22:
+.incbin "baserom.gba", 0x12CCAC8, 0x80
+sIllumiseGfx22_1:
+.incbin "baserom.gba", 0x12CCB48, 0x60
+sIllumiseGfx22_2:
+.incbin "baserom.gba", 0x12CCBA8, 0x60
+sIllumiseSprites22:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx22, 0x80
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx22_2, 0x60
+ax_sprite_terminator
+sIllumiseGfx23:
+.incbin "baserom.gba", 0x12CCC40, 0x60
+sIllumiseGfx23_1:
+.incbin "baserom.gba", 0x12CCCA0, 0x60
+sIllumiseGfx23_2:
+.incbin "baserom.gba", 0x12CCD00, 0x60
+sIllumiseSprites23:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx23, 0x60
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx23_2, 0x60
+ax_sprite_terminator
+sIllumiseGfx24:
+.incbin "baserom.gba", 0x12CCD98, 0x40
+sIllumiseGfx24_1:
+.incbin "baserom.gba", 0x12CCDD8, 0x60
+sIllumiseGfx24_2:
+.incbin "baserom.gba", 0x12CCE38, 0x80
+sIllumiseGfx24_3:
+.incbin "baserom.gba", 0x12CCEB8, 0x40
+sIllumiseSprites24:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx24_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx25:
+.incbin "baserom.gba", 0x12CCF48, 0x40
+sIllumiseGfx25_1:
+.incbin "baserom.gba", 0x12CCF88, 0x60
+sIllumiseGfx25_2:
+.incbin "baserom.gba", 0x12CCFE8, 0x80
+sIllumiseGfx25_3:
+.incbin "baserom.gba", 0x12CD068, 0x40
+sIllumiseSprites25:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx26:
+.incbin "baserom.gba", 0x12CD0F8, 0x40
+sIllumiseGfx26_1:
+.incbin "baserom.gba", 0x12CD138, 0x100
+sIllumiseGfx26_2:
+.incbin "baserom.gba", 0x12CD238, 0x40
+sIllumiseSprites26:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx27:
+.incbin "baserom.gba", 0x12CD2B8, 0x60
+sIllumiseGfx27_1:
+.incbin "baserom.gba", 0x12CD318, 0x80
+sIllumiseGfx27_2:
+.incbin "baserom.gba", 0x12CD398, 0x40
+sIllumiseSprites27:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx28:
+.incbin "baserom.gba", 0x12CD418, 0x40
+sIllumiseGfx28_1:
+.incbin "baserom.gba", 0x12CD458, 0x60
+sIllumiseGfx28_2:
+.incbin "baserom.gba", 0x12CD4B8, 0x60
+sIllumiseGfx28_3:
+.incbin "baserom.gba", 0x12CD518, 0x60
+sIllumiseSprites28:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx28_3, 0x60
+ax_sprite_terminator
+sIllumiseGfx29:
+.incbin "baserom.gba", 0x12CD5C0, 0x60
+sIllumiseGfx29_1:
+.incbin "baserom.gba", 0x12CD620, 0x80
+sIllumiseGfx29_2:
+.incbin "baserom.gba", 0x12CD6A0, 0x40
+sIllumiseSprites29:
+ax_sprite 0, 0x80
+ax_sprite sIllumiseGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx29_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx30:
+.incbin "baserom.gba", 0x12CD720, 0x20
+sIllumiseGfx30_1:
+.incbin "baserom.gba", 0x12CD740, 0x60
+sIllumiseGfx30_2:
+.incbin "baserom.gba", 0x12CD7A0, 0x60
+sIllumiseGfx30_3:
+.incbin "baserom.gba", 0x12CD800, 0x40
+sIllumiseSprites30:
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx31:
+.incbin "baserom.gba", 0x12CD890, 0x20
+sIllumiseGfx31_1:
+.incbin "baserom.gba", 0x12CD8B0, 0x60
+sIllumiseGfx31_2:
+.incbin "baserom.gba", 0x12CD910, 0x60
+sIllumiseGfx31_3:
+.incbin "baserom.gba", 0x12CD970, 0x40
+sIllumiseSprites31:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx31, 0x20
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx31_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx32:
+.incbin "baserom.gba", 0x12CDA00, 0x40
+sIllumiseGfx32_1:
+.incbin "baserom.gba", 0x12CDA40, 0x60
+sIllumiseGfx32_2:
+.incbin "baserom.gba", 0x12CDAA0, 0x60
+sIllumiseGfx32_3:
+.incbin "baserom.gba", 0x12CDB00, 0x40
+sIllumiseSprites32:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx33:
+.incbin "baserom.gba", 0x12CDB90, 0x40
+sIllumiseGfx33_1:
+.incbin "baserom.gba", 0x12CDBD0, 0x60
+sIllumiseGfx33_2:
+.incbin "baserom.gba", 0x12CDC30, 0x60
+sIllumiseGfx33_3:
+.incbin "baserom.gba", 0x12CDC90, 0x40
+sIllumiseSprites33:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sIllumiseGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx34:
+.incbin "baserom.gba", 0x12CDD20, 0x40
+sIllumiseGfx34_1:
+.incbin "baserom.gba", 0x12CDD60, 0x60
+sIllumiseGfx34_2:
+.incbin "baserom.gba", 0x12CDDC0, 0x80
+sIllumiseGfx34_3:
+.incbin "baserom.gba", 0x12CDE40, 0x40
+sIllumiseSprites34:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx34_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx35:
+.incbin "baserom.gba", 0x12CDED0, 0x40
+sIllumiseGfx35_1:
+.incbin "baserom.gba", 0x12CDF10, 0x60
+sIllumiseGfx35_2:
+.incbin "baserom.gba", 0x12CDF70, 0x80
+sIllumiseGfx35_3:
+.incbin "baserom.gba", 0x12CDFF0, 0x40
+sIllumiseSprites35:
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx35_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sIllumiseGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIllumiseGfx36:
+.incbin "baserom.gba", 0x12CE080, 0x200
+sIllumiseSprites36:
+ax_sprite sIllumiseGfx36, 0x200
+ax_sprite_terminator
+sIllumiseGfx37:
+.incbin "baserom.gba", 0x12CE290, 0x200
+sIllumiseSprites37:
+ax_sprite sIllumiseGfx37, 0x200
+ax_sprite_terminator
+sIllumiseGfx38:
+.incbin "baserom.gba", 0x12CE4A0, 0x200
+sIllumiseSprites38:
+ax_sprite sIllumiseGfx38, 0x200
+ax_sprite_terminator
+sIllumiseGfx39:
+.incbin "baserom.gba", 0x12CE6B0, 0x200
+sIllumiseSprites39:
+ax_sprite sIllumiseGfx39, 0x200
+ax_sprite_terminator
+sIllumiseGfx40:
+.incbin "baserom.gba", 0x12CE8C0, 0x200
+sIllumiseSprites40:
+ax_sprite sIllumiseGfx40, 0x200
+ax_sprite_terminator
+sIllumiseGfx41:
+.incbin "baserom.gba", 0x12CEAD0, 0x200
+sIllumiseSprites41:
+ax_sprite sIllumiseGfx41, 0x200
+ax_sprite_terminator
+sIllumiseGfx42:
+.incbin "baserom.gba", 0x12CECE0, 0x200
+sIllumiseSprites42:
+ax_sprite sIllumiseGfx42, 0x200
+ax_sprite_terminator
+sIllumiseGfx43:
+.incbin "baserom.gba", 0x12CEEF0, 0x200
+sIllumiseSprites43:
+ax_sprite sIllumiseGfx43, 0x200
+ax_sprite_terminator
+sAxPosesIllumise:
+.4byte sIllumisePose1
+.4byte sIllumisePose2
+.4byte sIllumisePose3
+.4byte sIllumisePose4
+.4byte sIllumisePose5
+.4byte sIllumisePose6
+.4byte sIllumisePose7
+.4byte sIllumisePose8
+.4byte sIllumisePose9
+.4byte sIllumisePose10
+.4byte sIllumisePose11
+.4byte sIllumisePose12
+.4byte sIllumisePose13
+.4byte sIllumisePose14
+.4byte sIllumisePose15
+.4byte sIllumisePose16
+.4byte sIllumisePose17
+.4byte sIllumisePose18
+.4byte sIllumisePose19
+.4byte sIllumisePose20
+.4byte sIllumisePose21
+.4byte sIllumisePose22
+.4byte sIllumisePose23
+.4byte sIllumisePose24
+.4byte sIllumisePose25
+.4byte sIllumisePose26
+.4byte sIllumisePose27
+.4byte sIllumisePose28
+.4byte sIllumisePose29
+.4byte sIllumisePose30
+.4byte sIllumisePose31
+.4byte sIllumisePose32
+.4byte sIllumisePose33
+.4byte sIllumisePose34
+.4byte sIllumisePose35
+.4byte sIllumisePose36
+.4byte sIllumisePose37
+.4byte sIllumisePose38
+.4byte sIllumisePose39
+.4byte sIllumisePose40
+.4byte sIllumisePose41
+.4byte sIllumisePose42
+.4byte sIllumisePose43
+.4byte sIllumisePose44
+.4byte sIllumisePose45
+.4byte sIllumisePose46
+.4byte sIllumisePose47
+.4byte sIllumisePose48
+.4byte sIllumisePose49
+.4byte sIllumisePose50
+.4byte sIllumisePose51
+.4byte sIllumisePose52
+.4byte sIllumisePose53
+.4byte sIllumisePose54
+.4byte sIllumisePose55
+.4byte sIllumisePose56
+.4byte sIllumisePose57
+.4byte sIllumisePose58
+.4byte sIllumisePose59
+.4byte sIllumisePose60
+.4byte sIllumisePose61
+.4byte sIllumisePose62
+.4byte sIllumisePose63
+.4byte sIllumisePose64
+.4byte sIllumisePose65
+.4byte sIllumisePose66
+.4byte sIllumisePose67
+.4byte sIllumisePose68
+.4byte sIllumisePose69
+.4byte sIllumisePose70
+.4byte sIllumisePose71
+.4byte sIllumisePose72
+.4byte sIllumisePose73
+.4byte sIllumisePose74
+.4byte sIllumisePose75
+.4byte sIllumisePose76
+.4byte sIllumisePose77
+.4byte sIllumisePose78
+.4byte sIllumisePose79
+.4byte sIllumisePose80
+.4byte sIllumisePose81
+.4byte sIllumisePose82
+.4byte sIllumisePose83
+.4byte sIllumisePose84
+.4byte sIllumisePose85
+.4byte sIllumisePose86
+.4byte sIllumisePose87
+.4byte sIllumisePose88
+.4byte sIllumisePose89
+.4byte sIllumisePose90
+.4byte sIllumisePose91
+.4byte sIllumisePose92
+.4byte sIllumisePose93
+.4byte sIllumisePose94
+.4byte sIllumisePose95
+.4byte sIllumisePose96
+.4byte sIllumisePose97
+.4byte sIllumisePose98
+.4byte sIllumisePose99
+.4byte sIllumisePose100
+.4byte sIllumisePose101
+.4byte sIllumisePose102
+.4byte sIllumisePose103
+.4byte sIllumisePose104
+.4byte sIllumisePose105
+.4byte sIllumisePose106
+.4byte sIllumisePose107
+.4byte sIllumisePose108
+.4byte sIllumisePose109
+.4byte sIllumisePose110
+.4byte sIllumisePose111
+.4byte sIllumisePose112
+.4byte sIllumisePose113
+.4byte sIllumisePose114
+.4byte sIllumisePose115
+.4byte sIllumisePose116
+.4byte sIllumisePose117
+.4byte sIllumisePose118
+.4byte sIllumisePose119
+.4byte sIllumisePose120
+.4byte sIllumisePose121
+.4byte sIllumisePose122
+.4byte sIllumisePose123
+.4byte sIllumisePose124
+.4byte sIllumisePose125
+.4byte sIllumisePose126
+.4byte sIllumisePose127
+.4byte sIllumisePose128
+.4byte sIllumisePose129
+.4byte sIllumisePose130
+.4byte sIllumisePose131
+.4byte sIllumisePose132
+.4byte sIllumisePose133
+.4byte sIllumisePose134
+.4byte sIllumisePose135
+.4byte sIllumisePose136
+.4byte sIllumisePose137
+.4byte sIllumisePose138
+.4byte sIllumisePose139
+.4byte sIllumisePose140
+.4byte sIllumisePose141
+.4byte sIllumisePose142
+.4byte sIllumisePose143
+.4byte sIllumisePose144
+.4byte sIllumisePose145
+.4byte sIllumisePose146
+.4byte sIllumisePose147
+.4byte sIllumisePose148
+.4byte sIllumisePose149
+.4byte sIllumisePose150
+.4byte sIllumisePose151
+.4byte sIllumisePose152
+.4byte sIllumisePose153
+.4byte sIllumisePose154
+.4byte sIllumisePose155
+.4byte sIllumisePose156
+.4byte sIllumisePose157
+.4byte sIllumisePose158
+.4byte sIllumisePose159
+.4byte sIllumisePose160
+.4byte sIllumisePose161
+.4byte sIllumisePose162
+.4byte sIllumisePose163
+.4byte sIllumisePose164
+.4byte sIllumisePose165
+.4byte sIllumisePose166
+.4byte sIllumisePose167
+.4byte sIllumisePose168
+.4byte sIllumisePose169
+.4byte sIllumisePose170
+.4byte sIllumisePose171
+.4byte sIllumisePose172
+.4byte sIllumisePose173
+.4byte sIllumisePose174
+.4byte sIllumisePose175
+.4byte sIllumisePose176
+.4byte sIllumisePose177
+.4byte sIllumisePose178
+.4byte sIllumisePose179
+.4byte sIllumisePose180
+.4byte sIllumisePose181
+.4byte sIllumisePose182
+.4byte sIllumisePose183
+.4byte sIllumisePose184
+.4byte sIllumisePose185
+.4byte sIllumisePose186
+.4byte sIllumisePose187
+.4byte sIllumisePose188
+.4byte sIllumisePose189
+.4byte sIllumisePose190
+.4byte sIllumisePose191
+.4byte sIllumisePose192
+.4byte sIllumisePose193
+.4byte sIllumisePose194
+.4byte sIllumisePose195
+.4byte sIllumisePose196
+.4byte sIllumisePose197
+.4byte sIllumisePose198
+.4byte sIllumisePose199
+.4byte sIllumisePose200
+.4byte sIllumisePose201
+.4byte sIllumisePose202
+.4byte sIllumisePose203
+.4byte sIllumisePose204
+.4byte sIllumisePose205
+.4byte sIllumisePose206
+.4byte sIllumisePose207
+.4byte sIllumisePose208
+.4byte sIllumisePose209
+.4byte sIllumisePose210
+.4byte sIllumisePose211
+.4byte sIllumisePose212
+.4byte sIllumisePose213
+.4byte sIllumisePose214
+.4byte sIllumisePose215
+.4byte sIllumisePose216
+.4byte sIllumisePose217
+.4byte sIllumisePose218
+.4byte sIllumisePose219
+.4byte sIllumisePose220
+.4byte sIllumisePose221
+.4byte sIllumisePose222
+.4byte sIllumisePose223
+.4byte sIllumisePose224
+.4byte sIllumisePose225
+.4byte sIllumisePose226
+.4byte sIllumisePose227
+.4byte sIllumisePose228
+.4byte sIllumisePose229
+.4byte sIllumisePose230
+.4byte sIllumisePose231
+.4byte sIllumisePose232
+.4byte sIllumisePose233
+.4byte sIllumisePose234
+.4byte sIllumisePose235
+.4byte sIllumisePose236
+.4byte sIllumisePose237
+.4byte sIllumisePose238
+.4byte sIllumisePose239
+.4byte sIllumisePose240
+.4byte sIllumisePose241
+.4byte sIllumisePose242
+.4byte sIllumisePose243
+.4byte sIllumisePose244
+.4byte sIllumisePose245
+.4byte sIllumisePose246
+.4byte sIllumisePose247
+.4byte sIllumisePose248
+.4byte sIllumisePose249
+.4byte sIllumisePose250
+.4byte sIllumisePose251
+.4byte sIllumisePose252
+.4byte sIllumisePose253
+.4byte sIllumisePose254
+.4byte sIllumisePose255
+.4byte sIllumisePose256
+.4byte sIllumisePose257
+.4byte sIllumisePose258
+sAxPositionsIllumise:
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	  -1,   -7
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    3,  -12, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    4,  -12, 	  -5,   -7, 	   4,   -4, 	  -2,   -6
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   7,   -5, 	  -9,   -5, 	  -1,   -6
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -12, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -6,  -12, 	   3,   -7, 	  -6,   -4, 	   0,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	  -1,   -7
+.2byte    2,   -6, 	   7,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte    2,   -6, 	   7,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    3,   -7, 	  -5,   -9, 	  -5,   -6, 	  -3,   -8
+.2byte    3,   -7, 	  -5,   -9, 	  -5,   -6, 	  -3,   -8
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    3,  -12, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    4,  -12, 	  -5,   -7, 	   4,   -4, 	  -2,   -6
+.2byte    3,   -7, 	  -6,   -7, 	   1,   -3, 	  -3,   -7
+.2byte    3,   -7, 	  -6,   -7, 	   1,   -3, 	  -3,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   7,   -5, 	  -9,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -10, 	   7,   -6, 	  -9,   -6, 	  -1,   -7
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -12, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -6,  -12, 	   3,   -7, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -7, 	   4,   -7, 	  -3,   -3, 	   1,   -7
+.2byte   -5,   -7, 	   4,   -7, 	  -3,   -3, 	   1,   -7
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -5,   -7, 	   3,   -9, 	   3,   -6, 	   1,   -8
+.2byte   -5,   -7, 	   3,   -9, 	   3,   -6, 	   1,   -8
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -1,   -7
+.2byte   -4,   -6, 	  -9,   -9, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -6, 	  -9,   -9, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	  -1,   -7
+.2byte    2,   -6, 	   7,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte    2,   -6, 	   7,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    3,   -7, 	  -5,   -9, 	  -5,   -6, 	  -3,   -8
+.2byte    3,   -7, 	  -5,   -9, 	  -5,   -6, 	  -3,   -8
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    3,  -12, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    4,  -12, 	  -5,   -7, 	   4,   -4, 	  -2,   -6
+.2byte    3,   -7, 	  -6,   -7, 	   1,   -3, 	  -3,   -7
+.2byte    3,   -7, 	  -6,   -7, 	   1,   -3, 	  -3,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   7,   -5, 	  -9,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -10, 	   7,   -6, 	  -9,   -6, 	  -1,   -7
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -12, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -6,  -12, 	   3,   -7, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -7, 	   4,   -7, 	  -3,   -3, 	   1,   -7
+.2byte   -5,   -7, 	   4,   -7, 	  -3,   -3, 	   1,   -7
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -5,   -7, 	   3,   -9, 	   3,   -6, 	   1,   -8
+.2byte   -5,   -7, 	   3,   -9, 	   3,   -6, 	   1,   -8
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -1,   -7
+.2byte   -4,   -6, 	  -9,   -9, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -6, 	  -9,   -9, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,   -8
+.2byte   -1,   -7, 	  -8,   -6, 	   6,   -6, 	  -1,   -6
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    1,  -12, 	   4,   -8, 	  -8,   -7, 	  -2,   -7
+.2byte    2,   -9, 	   3,   -6, 	  -8,   -6, 	  -1,   -5
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    3,  -12, 	  -1,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    6,  -10, 	  -2,   -7, 	  -3,   -6, 	   0,   -7
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    3,  -14, 	  -6,   -5, 	   4,   -5, 	  -2,   -7
+.2byte    4,  -15, 	  -6,   -7, 	   2,   -4, 	  -2,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	   8,   -7, 	 -10,   -7, 	  -1,   -6
+.2byte   -1,  -14, 	   8,   -6, 	 -10,   -6, 	  -1,   -7
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -14, 	   4,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -6,  -15, 	   4,   -7, 	  -4,   -4, 	   0,   -7
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -5,  -12, 	  -1,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -8,  -10, 	   0,   -7, 	   1,   -6, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -3,  -12, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte   -4,   -9, 	  -5,   -6, 	   6,   -6, 	  -1,   -5
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	  -1,   -7
+.2byte    2,   -6, 	   7,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte    2,   -6, 	   7,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    3,   -7, 	  -5,   -9, 	  -5,   -6, 	  -3,   -8
+.2byte    3,   -7, 	  -5,   -9, 	  -5,   -6, 	  -3,   -8
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    3,  -12, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    4,  -12, 	  -5,   -7, 	   4,   -4, 	  -2,   -6
+.2byte    3,   -7, 	  -6,   -7, 	   1,   -3, 	  -3,   -7
+.2byte    3,   -7, 	  -6,   -7, 	   1,   -3, 	  -3,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   7,   -5, 	  -9,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -10, 	   7,   -6, 	  -9,   -6, 	  -1,   -7
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -12, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -6,  -12, 	   3,   -7, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -7, 	   4,   -7, 	  -3,   -3, 	   1,   -7
+.2byte   -5,   -7, 	   4,   -7, 	  -3,   -3, 	   1,   -7
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -5,   -7, 	   3,   -9, 	   3,   -6, 	   1,   -8
+.2byte   -5,   -7, 	   3,   -9, 	   3,   -6, 	   1,   -8
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -1,   -7
+.2byte   -4,   -6, 	  -9,   -9, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -6, 	  -9,   -9, 	   6,   -5, 	  -1,   -7
+.2byte   -3,   -9, 	  -6,   -5, 	   4,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -6,   -5, 	   4,   -4, 	  -1,   -5
+.2byte    0,  -11, 	  -7,  -10, 	   7,  -10, 	   0,   -9
+.2byte    1,   -9, 	   6,  -10, 	  -7,   -8, 	  -1,   -6
+.2byte    4,  -11, 	   2,  -10, 	  -2,   -8, 	   0,   -5
+.2byte    1,  -13, 	  -1,  -11, 	   7,   -9, 	   1,   -6
+.2byte    0,  -13, 	   8,   -7, 	  -8,   -7, 	   0,   -5
+.2byte   -1,  -12, 	   1,  -10, 	  -7,   -8, 	  -1,   -5
+.2byte   -5,  -11, 	  -3,  -10, 	   1,   -8, 	  -1,   -5
+.2byte   -2,   -9, 	  -7,  -10, 	   6,   -8, 	   0,   -6
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,   -8
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    1,  -12, 	   4,   -8, 	  -8,   -7, 	  -2,   -7
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    3,  -12, 	  -1,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    3,  -14, 	  -6,   -5, 	   4,   -5, 	  -2,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	   8,   -7, 	 -10,   -7, 	  -1,   -6
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -14, 	   4,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -5,  -12, 	  -1,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -3,  -12, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte   -4,   -6, 	  -9,   -9, 	   6,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	   3,   -9, 	   3,   -6, 	   1,   -8
+.2byte   -5,   -7, 	   4,   -7, 	  -3,   -3, 	   1,   -7
+.2byte   -1,  -10, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte    3,   -7, 	  -6,   -7, 	   1,   -3, 	  -3,   -7
+.2byte    3,   -7, 	  -5,   -9, 	  -5,   -6, 	  -3,   -8
+.2byte    2,   -6, 	   7,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -8,   -6, 	   6,   -6, 	  -1,   -6
+.2byte    2,   -9, 	   3,   -6, 	  -8,   -6, 	  -1,   -5
+.2byte    6,   -9, 	  -2,   -6, 	  -3,   -5, 	   0,   -6
+.2byte    4,  -14, 	  -6,   -6, 	   2,   -3, 	  -2,   -6
+.2byte   -1,  -13, 	   8,   -5, 	 -10,   -5, 	  -1,   -6
+.2byte   -6,  -14, 	   4,   -6, 	  -4,   -3, 	   0,   -6
+.2byte   -8,   -9, 	   0,   -6, 	   1,   -5, 	  -2,   -6
+.2byte   -4,   -9, 	  -5,   -6, 	   6,   -6, 	  -1,   -5
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	  -1,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -2,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   1,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    4,  -12, 	  -5,   -7, 	   4,   -4, 	  -2,   -6
+.2byte    3,  -12, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   7,   -5, 	  -9,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -6,  -12, 	   3,   -7, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -12, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	  -1,   -6
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -1,   -7
+.2byte   -4,  -10, 	  -7,   -7, 	   4,   -5, 	  -2,   -7
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,   -8
+.2byte   -3,  -12, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte   -5,  -12, 	  -1,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -5,  -14, 	   4,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -1,   -9, 	   8,   -7, 	 -10,   -7, 	  -1,   -6
+.2byte    3,  -14, 	  -6,   -5, 	   4,   -5, 	  -2,   -7
+.2byte    3,  -12, 	  -1,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    1,  -12, 	   4,   -8, 	  -8,   -7, 	  -2,   -7
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -3,  -10, 	  -6,   -7, 	   5,   -5, 	  -1,   -7
+.2byte   -6,  -10, 	  -3,   -5, 	  -1,   -4, 	   0,   -6
+.2byte   -6,  -11, 	   3,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte    4,  -11, 	  -5,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    5,  -10, 	   2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte    2,  -10, 	   5,   -7, 	  -6,   -5, 	   0,   -7
+sIllumiseAnimTable1:
+.4byte sIllumiseAnims_1_1
+.4byte sIllumiseAnims_1_2
+.4byte sIllumiseAnims_1_3
+.4byte sIllumiseAnims_1_4
+.4byte sIllumiseAnims_1_5
+.4byte sIllumiseAnims_1_6
+.4byte sIllumiseAnims_1_7
+.4byte sIllumiseAnims_1_8
+sIllumiseAnimTable2:
+.4byte sIllumiseAnims_2_1
+.4byte sIllumiseAnims_2_2
+.4byte sIllumiseAnims_2_3
+.4byte sIllumiseAnims_2_4
+.4byte sIllumiseAnims_2_5
+.4byte sIllumiseAnims_2_6
+.4byte sIllumiseAnims_2_7
+.4byte sIllumiseAnims_2_8
+sIllumiseAnimTable3:
+.4byte sIllumiseAnims_3_1
+.4byte sIllumiseAnims_3_2
+.4byte sIllumiseAnims_3_3
+.4byte sIllumiseAnims_3_4
+.4byte sIllumiseAnims_3_5
+.4byte sIllumiseAnims_3_6
+.4byte sIllumiseAnims_3_7
+.4byte sIllumiseAnims_3_8
+sIllumiseAnimTable4:
+.4byte sIllumiseAnims_4_1
+.4byte sIllumiseAnims_4_2
+.4byte sIllumiseAnims_4_3
+.4byte sIllumiseAnims_4_4
+.4byte sIllumiseAnims_4_5
+.4byte sIllumiseAnims_4_6
+.4byte sIllumiseAnims_4_7
+.4byte sIllumiseAnims_4_8
+sIllumiseAnimTable5:
+.4byte sIllumiseAnims_5_1
+.4byte sIllumiseAnims_5_2
+.4byte sIllumiseAnims_5_3
+.4byte sIllumiseAnims_5_4
+.4byte sIllumiseAnims_5_5
+.4byte sIllumiseAnims_5_6
+.4byte sIllumiseAnims_5_7
+.4byte sIllumiseAnims_5_8
+sIllumiseAnimTable6:
+.4byte sIllumiseAnims_6_1
+.4byte sIllumiseAnims_6_1
+.4byte sIllumiseAnims_6_1
+.4byte sIllumiseAnims_6_1
+.4byte sIllumiseAnims_6_1
+.4byte sIllumiseAnims_6_1
+.4byte sIllumiseAnims_6_1
+.4byte sIllumiseAnims_6_1
+sIllumiseAnimTable7:
+.4byte sIllumiseAnims_7_1
+.4byte sIllumiseAnims_7_2
+.4byte sIllumiseAnims_7_3
+.4byte sIllumiseAnims_7_4
+.4byte sIllumiseAnims_7_5
+.4byte sIllumiseAnims_7_6
+.4byte sIllumiseAnims_7_7
+.4byte sIllumiseAnims_7_8
+sIllumiseAnimTable8:
+.4byte sIllumiseAnims_8_1
+.4byte sIllumiseAnims_8_2
+.4byte sIllumiseAnims_8_3
+.4byte sIllumiseAnims_8_4
+.4byte sIllumiseAnims_8_5
+.4byte sIllumiseAnims_8_6
+.4byte sIllumiseAnims_8_7
+.4byte sIllumiseAnims_8_8
+sIllumiseAnimTable9:
+.4byte sIllumiseAnims_9_1
+.4byte sIllumiseAnims_9_2
+.4byte sIllumiseAnims_9_3
+.4byte sIllumiseAnims_9_4
+.4byte sIllumiseAnims_9_5
+.4byte sIllumiseAnims_9_6
+.4byte sIllumiseAnims_9_7
+.4byte sIllumiseAnims_9_8
+sIllumiseAnimTable10:
+.4byte sIllumiseAnims_10_1
+.4byte sIllumiseAnims_10_2
+.4byte sIllumiseAnims_10_3
+.4byte sIllumiseAnims_10_4
+.4byte sIllumiseAnims_10_5
+.4byte sIllumiseAnims_10_6
+.4byte sIllumiseAnims_10_7
+.4byte sIllumiseAnims_10_8
+sIllumiseAnimTable11:
+.4byte sIllumiseAnims_11_1
+.4byte sIllumiseAnims_11_2
+.4byte sIllumiseAnims_11_3
+.4byte sIllumiseAnims_11_4
+.4byte sIllumiseAnims_11_5
+.4byte sIllumiseAnims_11_6
+.4byte sIllumiseAnims_11_7
+.4byte sIllumiseAnims_11_8
+sIllumiseAnimTable12:
+.4byte sIllumiseAnims_12_1
+.4byte sIllumiseAnims_12_2
+.4byte sIllumiseAnims_12_3
+.4byte sIllumiseAnims_12_4
+.4byte sIllumiseAnims_12_5
+.4byte sIllumiseAnims_12_6
+.4byte sIllumiseAnims_12_7
+.4byte sIllumiseAnims_12_8
+sIllumiseAnimTable13:
+.4byte sIllumiseAnims_13_1
+.4byte sIllumiseAnims_13_2
+.4byte sIllumiseAnims_13_3
+.4byte sIllumiseAnims_13_4
+.4byte sIllumiseAnims_13_5
+.4byte sIllumiseAnims_13_6
+.4byte sIllumiseAnims_13_7
+.4byte sIllumiseAnims_13_8
+sAxAnimationsIllumise:
+.4byte sIllumiseAnimTable1
+.4byte sIllumiseAnimTable2
+.4byte sIllumiseAnimTable3
+.4byte sIllumiseAnimTable4
+.4byte sIllumiseAnimTable5
+.4byte sIllumiseAnimTable6
+.4byte sIllumiseAnimTable7
+.4byte sIllumiseAnimTable8
+.4byte sIllumiseAnimTable9
+.4byte sIllumiseAnimTable10
+.4byte sIllumiseAnimTable11
+.4byte sIllumiseAnimTable12
+.4byte sIllumiseAnimTable13
+sAxSpritesIllumise:
+.4byte sIllumiseSprites1
+.4byte sIllumiseSprites2
+.4byte sIllumiseSprites3
+.4byte sIllumiseSprites4
+.4byte sIllumiseSprites5
+.4byte sIllumiseSprites6
+.4byte sIllumiseSprites7
+.4byte sIllumiseSprites8
+.4byte sIllumiseSprites9
+.4byte sIllumiseSprites10
+.4byte sIllumiseSprites11
+.4byte sIllumiseSprites12
+.4byte sIllumiseSprites13
+.4byte sIllumiseSprites14
+.4byte sIllumiseSprites15
+.4byte sIllumiseSprites16
+.4byte sIllumiseSprites17
+.4byte sIllumiseSprites18
+.4byte sIllumiseSprites19
+.4byte sIllumiseSprites20
+.4byte sIllumiseSprites21
+.4byte sIllumiseSprites22
+.4byte sIllumiseSprites23
+.4byte sIllumiseSprites24
+.4byte sIllumiseSprites25
+.4byte sIllumiseSprites26
+.4byte sIllumiseSprites27
+.4byte sIllumiseSprites28
+.4byte sIllumiseSprites29
+.4byte sIllumiseSprites30
+.4byte sIllumiseSprites31
+.4byte sIllumiseSprites32
+.4byte sIllumiseSprites33
+.4byte sIllumiseSprites34
+.4byte sIllumiseSprites35
+.4byte sIllumiseSprites36
+.4byte sIllumiseSprites37
+.4byte sIllumiseSprites38
+.4byte sIllumiseSprites39
+.4byte sIllumiseSprites40
+.4byte sIllumiseSprites41
+.4byte sIllumiseSprites42
+.4byte sIllumiseSprites43
+sAxMainIllumise:
+ax_main sAxPosesIllumise, sAxAnimationsIllumise, 13, sAxSpritesIllumise, sAxPositionsIllumise

--- a/data/ax/ivysaur.inc
+++ b/data/ax/ivysaur.inc
@@ -1,0 +1,2506 @@
+.global gAxIvysaur
+gAxIvysaur:
+ax_siro sAxMainIvysaur
+sIvysaurPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose4:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose5:
+ax_pose 4, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose6:
+ax_pose 5, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose7:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose8:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose9:
+ax_pose 8, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose10:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose11:
+ax_pose 10, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose12:
+ax_pose 11, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose14:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose15:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose16:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose17:
+ax_pose 10, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose18:
+ax_pose 11, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose19:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose20:
+ax_pose 7, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose21:
+ax_pose 8, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose22:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose23:
+ax_pose 4, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose24:
+ax_pose 5, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose28:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose29:
+ax_pose 4, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose30:
+ax_pose 5, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose31:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose32:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose33:
+ax_pose 8, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose34:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose35:
+ax_pose 10, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose36:
+ax_pose 11, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose37:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose38:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose39:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose40:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose41:
+ax_pose 10, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose42:
+ax_pose 11, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose43:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose44:
+ax_pose 7, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose45:
+ax_pose 8, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose46:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose47:
+ax_pose 4, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose48:
+ax_pose 5, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose49:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose50:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose51:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose52:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose53:
+ax_pose 4, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose54:
+ax_pose 5, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose55:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose56:
+ax_pose 7, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose57:
+ax_pose 8, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose58:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose59:
+ax_pose 10, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose60:
+ax_pose 11, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose61:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose62:
+ax_pose 13, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose63:
+ax_pose 14, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose64:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose65:
+ax_pose 10, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose66:
+ax_pose 11, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose67:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose68:
+ax_pose 7, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose69:
+ax_pose 8, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose70:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose71:
+ax_pose 4, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose72:
+ax_pose 5, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose73:
+ax_pose 15, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose74:
+ax_pose 16, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose75:
+ax_pose 17, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose76:
+ax_pose 18, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose77:
+ax_pose 19, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose78:
+ax_pose 20, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose79:
+ax_pose 21, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose80:
+ax_pose 22, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose81:
+ax_pose 23, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose82:
+ax_pose 24, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose83:
+ax_pose 21, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose84:
+ax_pose 22, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose85:
+ax_pose 19, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose86:
+ax_pose 20, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose87:
+ax_pose 17, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose88:
+ax_pose 18, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose89:
+ax_pose 25, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose90:
+ax_pose 26, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose91:
+ax_pose 27, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose92:
+ax_pose 28, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose93:
+ax_pose 29, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose94:
+ax_pose 30, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose95:
+ax_pose 31, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose96:
+ax_pose 32, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose97:
+ax_pose 33, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose98:
+ax_pose 34, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose99:
+ax_pose 31, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose100:
+ax_pose 32, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose101:
+ax_pose 29, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose102:
+ax_pose 30, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose103:
+ax_pose 27, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose104:
+ax_pose 28, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose105:
+ax_pose 35, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose106:
+ax_pose 36, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose107:
+ax_pose 37, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose108:
+ax_pose 38, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose109:
+ax_pose 39, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose110:
+ax_pose 40, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose111:
+ax_pose 41, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sIvysaurPose112:
+ax_pose 40, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose113:
+ax_pose 39, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose114:
+ax_pose 38, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose115:
+ax_pose 25, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose116:
+ax_pose 26, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose117:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose118:
+ax_pose 27, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose119:
+ax_pose 28, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose120:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose121:
+ax_pose 29, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose122:
+ax_pose 30, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose123:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose124:
+ax_pose 31, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose125:
+ax_pose 32, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose126:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose127:
+ax_pose 33, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose128:
+ax_pose 34, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose129:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose130:
+ax_pose 31, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose131:
+ax_pose 32, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose132:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose133:
+ax_pose 29, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose134:
+ax_pose 30, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose135:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose136:
+ax_pose 27, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose137:
+ax_pose 28, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose138:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose139:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose140:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose141:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose142:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose143:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose144:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose145:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose146:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose147:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose148:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose149:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose150:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose151:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose152:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose153:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose154:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose155:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose156:
+ax_pose 16, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose157:
+ax_pose 15, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose158:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose159:
+ax_pose 17, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sIvysaurPose160:
+ax_pose 18, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose161:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose162:
+ax_pose 19, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sIvysaurPose163:
+ax_pose 20, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sIvysaurPose164:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose165:
+ax_pose 22, 0x01ed, 0x90ed, 0x3c00
+ax_pose_terminator
+sIvysaurPose166:
+ax_pose 21, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose167:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose168:
+ax_pose 24, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose169:
+ax_pose 23, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose170:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose171:
+ax_pose 22, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose172:
+ax_pose 21, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose173:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose174:
+ax_pose 19, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose175:
+ax_pose 20, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose176:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose177:
+ax_pose 17, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose178:
+ax_pose 18, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose179:
+ax_pose 15, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose180:
+ax_pose 18, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose181:
+ax_pose 20, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose182:
+ax_pose 22, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose183:
+ax_pose 23, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose184:
+ax_pose 22, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose185:
+ax_pose 20, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose186:
+ax_pose 18, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose187:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose188:
+ax_pose 3, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose189:
+ax_pose 6, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose190:
+ax_pose 9, 0x01ee, 0x80f3, 0x3c00
+ax_pose_terminator
+sIvysaurPose191:
+ax_pose 12, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sIvysaurPose192:
+ax_pose 9, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose193:
+ax_pose 6, 0x01ed, 0x90ec, 0x3c00
+ax_pose_terminator
+sIvysaurPose194:
+ax_pose 3, 0x01ee, 0x90ec, 0x3c00
+ax_pose_terminator
+.align 2
+sIvysaurAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 2, 25, 0, 4, 0, 4,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sIvysaurAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 2, 28, 4, 4, 4, 4,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sIvysaurAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 2, 31, 4, 0, 4, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sIvysaurAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 2, 34, 4, -4, 4, -4,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 1, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sIvysaurAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 2, 37, 0, -4, 0, -4,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sIvysaurAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 2, 40, -4, -4, -4, -4,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 1, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sIvysaurAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 2, 43, -4, 0, -4, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sIvysaurAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 2, 47, -4, 4, -4, 4,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 2, 49, 0, 4, 0, 4,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sIvysaurAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 2, 52, 4, 4, 4, 4,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sIvysaurAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 2, 55, 4, 0, 4, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sIvysaurAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 2, 58, 4, -4, 4, -4,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 1, 58, 19, -17, 19, -17,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 0, 58, 19, -17, 19, -17,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sIvysaurAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 2, 61, 0, -4, 0, -4,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 1, 61, 1, -18, 1, -18,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 0, 61, 1, -18, 1, -18,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sIvysaurAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 2, 64, -4, -4, -4, -4,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 1, 64, -19, -17, -19, -17,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 0, 64, -19, -17, -19, -17,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sIvysaurAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 2, 67, -4, 0, -4, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sIvysaurAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 2, 71, -4, 4, -4, 4,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_4_1:
+ax_anim 12, 0, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 2, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_4_2:
+ax_anim 12, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 4, 2, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_4_3:
+ax_anim 12, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 2, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_4_4:
+ax_anim 12, 0, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 2, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_4_5:
+ax_anim 12, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 2, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_4_6:
+ax_anim 12, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 2, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_4_7:
+ax_anim 12, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 2, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_4_8:
+ax_anim 12, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 2, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_5_1:
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 2, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_5_2:
+ax_anim 6, 0, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 2, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 0, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_5_3:
+ax_anim 6, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 2, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_5_4:
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 2, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_5_5:
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 2, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_5_6:
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 2, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_5_7:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 2, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_5_8:
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 2, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sIvysaurAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sIvysaurAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sIvysaurAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sIvysaurAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sIvysaurAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sIvysaurAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sIvysaurAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_8_1:
+ax_anim 40, 0, 116, 0, 0, 0, 0,
+ax_anim 12, 0, 114, 0, 0, 0, 0,
+ax_anim 12, 0, 116, 0, 0, 0, 0,
+ax_anim 12, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_8_2:
+ax_anim 40, 0, 119, 0, 0, 0, 0,
+ax_anim 12, 0, 117, 0, 0, 0, 0,
+ax_anim 12, 0, 119, 0, 0, 0, 0,
+ax_anim 12, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_8_3:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 12, 0, 120, 0, 0, 0, 0,
+ax_anim 12, 0, 122, 0, 0, 0, 0,
+ax_anim 12, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_8_4:
+ax_anim 40, 0, 125, 0, 0, 0, 0,
+ax_anim 12, 0, 123, 0, 0, 0, 0,
+ax_anim 12, 0, 125, 0, 0, 0, 0,
+ax_anim 12, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_8_5:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 126, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_8_6:
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 129, 0, 0, 0, 0,
+ax_anim 12, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_8_7:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 12, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim 12, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_8_8:
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 4, 6, 4,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 13, 7, 13,
+ax_anim 3, 0, 142, 1, 16, 1, 16,
+ax_anim 2, 3, 143, -4, 14, -4, 14,
+ax_anim 2, 0, 144, -5, 8, -5, 8,
+ax_anim 1, 0, 145, -4, 4, -4, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 24, 9, 24, 9,
+ax_anim 3, 0, 141, 23, 16, 23, 16,
+ax_anim 2, 3, 142, 11, 16, 11, 16,
+ax_anim 2, 0, 143, 4, 12, 4, 12,
+ax_anim 1, 0, 144, 3, 7, 3, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 17, -4, 17, -4,
+ax_anim 3, 0, 140, 20, 1, 20, 1,
+ax_anim 2, 3, 141, 17, 5, 17, 5,
+ax_anim 2, 0, 142, 12, 7, 12, 7,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 1, -6, 1, -6,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 11, -20, 11, -20,
+ax_anim 3, 0, 139, 16, -20, 16, -20,
+ax_anim 2, 3, 140, 16, -15, 16, -15,
+ax_anim 2, 0, 141, 14, -6, 14, -6,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -6, -4, -6, -4,
+ax_anim 2, 0, 144, -8, -9, -8, -9,
+ax_anim 2, 0, 145, -7, -13, -7, -13,
+ax_anim 3, 0, 138, -1, -16, -1, -16,
+ax_anim 2, 3, 139, 4, -14, 4, -14,
+ax_anim 2, 0, 140, 5, -8, 5, -8,
+ax_anim 1, 0, 141, 4, -4, 4, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -1, -6, -1, -6,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -11, -20, -11, -20,
+ax_anim 3, 0, 145, -16, -20, -16, -20,
+ax_anim 2, 3, 144, -16, -15, -16, -15,
+ax_anim 2, 0, 143, -14, -6, -14, -6,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -17, -4, -17, -4,
+ax_anim 3, 0, 144, -20, 1, -20, 1,
+ax_anim 2, 3, 143, -17, 5, -17, 5,
+ax_anim 2, 0, 142, -12, 7, -12, 7,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -24, 9, -24, 9,
+ax_anim 3, 0, 143, -23, 16, -23, 16,
+ax_anim 2, 3, 142, -11, 16, -11, 16,
+ax_anim 2, 0, 141, -4, 12, -4, 12,
+ax_anim 1, 0, 140, -3, 7, -3, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sIvysaurAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sIvysaurGfx1:
+.incbin "baserom.gba", 0x524ECC, 0x200
+sIvysaurSprites1:
+ax_sprite sIvysaurGfx1, 0x200
+ax_sprite_terminator
+sIvysaurGfx2:
+.incbin "baserom.gba", 0x5250DC, 0x200
+sIvysaurSprites2:
+ax_sprite sIvysaurGfx2, 0x200
+ax_sprite_terminator
+sIvysaurGfx3:
+.incbin "baserom.gba", 0x5252EC, 0x200
+sIvysaurSprites3:
+ax_sprite sIvysaurGfx3, 0x200
+ax_sprite_terminator
+sIvysaurGfx4:
+.incbin "baserom.gba", 0x5254FC, 0x200
+sIvysaurSprites4:
+ax_sprite sIvysaurGfx4, 0x200
+ax_sprite_terminator
+sIvysaurGfx5:
+.incbin "baserom.gba", 0x52570C, 0x200
+sIvysaurSprites5:
+ax_sprite sIvysaurGfx5, 0x200
+ax_sprite_terminator
+sIvysaurGfx6:
+.incbin "baserom.gba", 0x52591C, 0x200
+sIvysaurSprites6:
+ax_sprite sIvysaurGfx6, 0x200
+ax_sprite_terminator
+sIvysaurGfx7:
+.incbin "baserom.gba", 0x525B2C, 0x200
+sIvysaurSprites7:
+ax_sprite sIvysaurGfx7, 0x200
+ax_sprite_terminator
+sIvysaurGfx8:
+.incbin "baserom.gba", 0x525D3C, 0x200
+sIvysaurSprites8:
+ax_sprite sIvysaurGfx8, 0x200
+ax_sprite_terminator
+sIvysaurGfx9:
+.incbin "baserom.gba", 0x525F4C, 0x200
+sIvysaurSprites9:
+ax_sprite sIvysaurGfx9, 0x200
+ax_sprite_terminator
+sIvysaurGfx10:
+.incbin "baserom.gba", 0x52615C, 0x200
+sIvysaurSprites10:
+ax_sprite sIvysaurGfx10, 0x200
+ax_sprite_terminator
+sIvysaurGfx11:
+.incbin "baserom.gba", 0x52636C, 0x200
+sIvysaurSprites11:
+ax_sprite sIvysaurGfx11, 0x200
+ax_sprite_terminator
+sIvysaurGfx12:
+.incbin "baserom.gba", 0x52657C, 0x200
+sIvysaurSprites12:
+ax_sprite sIvysaurGfx12, 0x200
+ax_sprite_terminator
+sIvysaurGfx13:
+.incbin "baserom.gba", 0x52678C, 0x200
+sIvysaurSprites13:
+ax_sprite sIvysaurGfx13, 0x200
+ax_sprite_terminator
+sIvysaurGfx14:
+.incbin "baserom.gba", 0x52699C, 0x200
+sIvysaurSprites14:
+ax_sprite sIvysaurGfx14, 0x200
+ax_sprite_terminator
+sIvysaurGfx15:
+.incbin "baserom.gba", 0x526BAC, 0x200
+sIvysaurSprites15:
+ax_sprite sIvysaurGfx15, 0x200
+ax_sprite_terminator
+sIvysaurGfx16:
+.incbin "baserom.gba", 0x526DBC, 0x60
+sIvysaurGfx16_1:
+.incbin "baserom.gba", 0x526E1C, 0x60
+sIvysaurGfx16_2:
+.incbin "baserom.gba", 0x526E7C, 0x60
+sIvysaurSprites16:
+ax_sprite sIvysaurGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx17:
+.incbin "baserom.gba", 0x526F14, 0x60
+sIvysaurGfx17_1:
+.incbin "baserom.gba", 0x526F74, 0x60
+sIvysaurGfx17_2:
+.incbin "baserom.gba", 0x526FD4, 0x60
+sIvysaurGfx17_3:
+.incbin "baserom.gba", 0x527034, 0x60
+sIvysaurSprites17:
+ax_sprite sIvysaurGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sIvysaurGfx18:
+.incbin "baserom.gba", 0x5270DC, 0x60
+sIvysaurGfx18_1:
+.incbin "baserom.gba", 0x52713C, 0x60
+sIvysaurGfx18_2:
+.incbin "baserom.gba", 0x52719C, 0x60
+sIvysaurSprites18:
+ax_sprite sIvysaurGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx19:
+.incbin "baserom.gba", 0x527234, 0x60
+sIvysaurGfx19_1:
+.incbin "baserom.gba", 0x527294, 0x60
+sIvysaurGfx19_2:
+.incbin "baserom.gba", 0x5272F4, 0x60
+sIvysaurSprites19:
+ax_sprite sIvysaurGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx20:
+.incbin "baserom.gba", 0x52738C, 0x60
+sIvysaurGfx20_1:
+.incbin "baserom.gba", 0x5273EC, 0x60
+sIvysaurGfx20_2:
+.incbin "baserom.gba", 0x52744C, 0x60
+sIvysaurSprites20:
+ax_sprite sIvysaurGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx21:
+.incbin "baserom.gba", 0x5274E4, 0x60
+sIvysaurGfx21_1:
+.incbin "baserom.gba", 0x527544, 0x60
+sIvysaurGfx21_2:
+.incbin "baserom.gba", 0x5275A4, 0x60
+sIvysaurSprites21:
+ax_sprite sIvysaurGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx22:
+.incbin "baserom.gba", 0x52763C, 0x60
+sIvysaurGfx22_1:
+.incbin "baserom.gba", 0x52769C, 0x60
+sIvysaurGfx22_2:
+.incbin "baserom.gba", 0x5276FC, 0x60
+sIvysaurSprites22:
+ax_sprite sIvysaurGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx23:
+.incbin "baserom.gba", 0x527794, 0x60
+sIvysaurGfx23_1:
+.incbin "baserom.gba", 0x5277F4, 0x60
+sIvysaurGfx23_2:
+.incbin "baserom.gba", 0x527854, 0x60
+sIvysaurSprites23:
+ax_sprite sIvysaurGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx24:
+.incbin "baserom.gba", 0x5278EC, 0x60
+sIvysaurGfx24_1:
+.incbin "baserom.gba", 0x52794C, 0x60
+sIvysaurGfx24_2:
+.incbin "baserom.gba", 0x5279AC, 0x60
+sIvysaurSprites24:
+ax_sprite sIvysaurGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx25:
+.incbin "baserom.gba", 0x527A44, 0x60
+sIvysaurGfx25_1:
+.incbin "baserom.gba", 0x527AA4, 0x60
+sIvysaurGfx25_2:
+.incbin "baserom.gba", 0x527B04, 0x60
+sIvysaurSprites25:
+ax_sprite sIvysaurGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx26:
+.incbin "baserom.gba", 0x527B9C, 0x60
+sIvysaurGfx26_1:
+.incbin "baserom.gba", 0x527BFC, 0x60
+sIvysaurGfx26_2:
+.incbin "baserom.gba", 0x527C5C, 0x60
+sIvysaurSprites26:
+ax_sprite sIvysaurGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx27:
+.incbin "baserom.gba", 0x527CF4, 0x60
+sIvysaurGfx27_1:
+.incbin "baserom.gba", 0x527D54, 0x60
+sIvysaurGfx27_2:
+.incbin "baserom.gba", 0x527DB4, 0x60
+sIvysaurSprites27:
+ax_sprite sIvysaurGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx28:
+.incbin "baserom.gba", 0x527E4C, 0x60
+sIvysaurGfx28_1:
+.incbin "baserom.gba", 0x527EAC, 0x60
+sIvysaurGfx28_2:
+.incbin "baserom.gba", 0x527F0C, 0x60
+sIvysaurSprites28:
+ax_sprite sIvysaurGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx29:
+.incbin "baserom.gba", 0x527FA4, 0x60
+sIvysaurGfx29_1:
+.incbin "baserom.gba", 0x528004, 0x60
+sIvysaurGfx29_2:
+.incbin "baserom.gba", 0x528064, 0x60
+sIvysaurSprites29:
+ax_sprite sIvysaurGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx30:
+.incbin "baserom.gba", 0x5280FC, 0x60
+sIvysaurGfx30_1:
+.incbin "baserom.gba", 0x52815C, 0x60
+sIvysaurGfx30_2:
+.incbin "baserom.gba", 0x5281BC, 0x60
+sIvysaurSprites30:
+ax_sprite sIvysaurGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx31:
+.incbin "baserom.gba", 0x528254, 0x60
+sIvysaurGfx31_1:
+.incbin "baserom.gba", 0x5282B4, 0x60
+sIvysaurGfx31_2:
+.incbin "baserom.gba", 0x528314, 0x60
+sIvysaurSprites31:
+ax_sprite sIvysaurGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx32:
+.incbin "baserom.gba", 0x5283AC, 0x60
+sIvysaurGfx32_1:
+.incbin "baserom.gba", 0x52840C, 0x60
+sIvysaurGfx32_2:
+.incbin "baserom.gba", 0x52846C, 0x60
+sIvysaurSprites32:
+ax_sprite sIvysaurGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx33:
+.incbin "baserom.gba", 0x528504, 0x60
+sIvysaurGfx33_1:
+.incbin "baserom.gba", 0x528564, 0x60
+sIvysaurGfx33_2:
+.incbin "baserom.gba", 0x5285C4, 0x60
+sIvysaurSprites33:
+ax_sprite sIvysaurGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx34:
+.incbin "baserom.gba", 0x52865C, 0x60
+sIvysaurGfx34_1:
+.incbin "baserom.gba", 0x5286BC, 0x60
+sIvysaurGfx34_2:
+.incbin "baserom.gba", 0x52871C, 0x60
+sIvysaurSprites34:
+ax_sprite sIvysaurGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx35:
+.incbin "baserom.gba", 0x5287B4, 0x60
+sIvysaurGfx35_1:
+.incbin "baserom.gba", 0x528814, 0x60
+sIvysaurGfx35_2:
+.incbin "baserom.gba", 0x528874, 0x60
+sIvysaurSprites35:
+ax_sprite sIvysaurGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sIvysaurGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sIvysaurGfx36:
+.incbin "baserom.gba", 0x52890C, 0x200
+sIvysaurSprites36:
+ax_sprite sIvysaurGfx36, 0x200
+ax_sprite_terminator
+sIvysaurGfx37:
+.incbin "baserom.gba", 0x528B1C, 0x200
+sIvysaurSprites37:
+ax_sprite sIvysaurGfx37, 0x200
+ax_sprite_terminator
+sIvysaurGfx38:
+.incbin "baserom.gba", 0x528D2C, 0x200
+sIvysaurSprites38:
+ax_sprite sIvysaurGfx38, 0x200
+ax_sprite_terminator
+sIvysaurGfx39:
+.incbin "baserom.gba", 0x528F3C, 0x200
+sIvysaurSprites39:
+ax_sprite sIvysaurGfx39, 0x200
+ax_sprite_terminator
+sIvysaurGfx40:
+.incbin "baserom.gba", 0x52914C, 0x200
+sIvysaurSprites40:
+ax_sprite sIvysaurGfx40, 0x200
+ax_sprite_terminator
+sIvysaurGfx41:
+.incbin "baserom.gba", 0x52935C, 0x200
+sIvysaurSprites41:
+ax_sprite sIvysaurGfx41, 0x200
+ax_sprite_terminator
+sIvysaurGfx42:
+.incbin "baserom.gba", 0x52956C, 0x200
+sIvysaurSprites42:
+ax_sprite sIvysaurGfx42, 0x200
+ax_sprite_terminator
+sAxPosesIvysaur:
+.4byte sIvysaurPose1
+.4byte sIvysaurPose2
+.4byte sIvysaurPose3
+.4byte sIvysaurPose4
+.4byte sIvysaurPose5
+.4byte sIvysaurPose6
+.4byte sIvysaurPose7
+.4byte sIvysaurPose8
+.4byte sIvysaurPose9
+.4byte sIvysaurPose10
+.4byte sIvysaurPose11
+.4byte sIvysaurPose12
+.4byte sIvysaurPose13
+.4byte sIvysaurPose14
+.4byte sIvysaurPose15
+.4byte sIvysaurPose16
+.4byte sIvysaurPose17
+.4byte sIvysaurPose18
+.4byte sIvysaurPose19
+.4byte sIvysaurPose20
+.4byte sIvysaurPose21
+.4byte sIvysaurPose22
+.4byte sIvysaurPose23
+.4byte sIvysaurPose24
+.4byte sIvysaurPose25
+.4byte sIvysaurPose26
+.4byte sIvysaurPose27
+.4byte sIvysaurPose28
+.4byte sIvysaurPose29
+.4byte sIvysaurPose30
+.4byte sIvysaurPose31
+.4byte sIvysaurPose32
+.4byte sIvysaurPose33
+.4byte sIvysaurPose34
+.4byte sIvysaurPose35
+.4byte sIvysaurPose36
+.4byte sIvysaurPose37
+.4byte sIvysaurPose38
+.4byte sIvysaurPose39
+.4byte sIvysaurPose40
+.4byte sIvysaurPose41
+.4byte sIvysaurPose42
+.4byte sIvysaurPose43
+.4byte sIvysaurPose44
+.4byte sIvysaurPose45
+.4byte sIvysaurPose46
+.4byte sIvysaurPose47
+.4byte sIvysaurPose48
+.4byte sIvysaurPose49
+.4byte sIvysaurPose50
+.4byte sIvysaurPose51
+.4byte sIvysaurPose52
+.4byte sIvysaurPose53
+.4byte sIvysaurPose54
+.4byte sIvysaurPose55
+.4byte sIvysaurPose56
+.4byte sIvysaurPose57
+.4byte sIvysaurPose58
+.4byte sIvysaurPose59
+.4byte sIvysaurPose60
+.4byte sIvysaurPose61
+.4byte sIvysaurPose62
+.4byte sIvysaurPose63
+.4byte sIvysaurPose64
+.4byte sIvysaurPose65
+.4byte sIvysaurPose66
+.4byte sIvysaurPose67
+.4byte sIvysaurPose68
+.4byte sIvysaurPose69
+.4byte sIvysaurPose70
+.4byte sIvysaurPose71
+.4byte sIvysaurPose72
+.4byte sIvysaurPose73
+.4byte sIvysaurPose74
+.4byte sIvysaurPose75
+.4byte sIvysaurPose76
+.4byte sIvysaurPose77
+.4byte sIvysaurPose78
+.4byte sIvysaurPose79
+.4byte sIvysaurPose80
+.4byte sIvysaurPose81
+.4byte sIvysaurPose82
+.4byte sIvysaurPose83
+.4byte sIvysaurPose84
+.4byte sIvysaurPose85
+.4byte sIvysaurPose86
+.4byte sIvysaurPose87
+.4byte sIvysaurPose88
+.4byte sIvysaurPose89
+.4byte sIvysaurPose90
+.4byte sIvysaurPose91
+.4byte sIvysaurPose92
+.4byte sIvysaurPose93
+.4byte sIvysaurPose94
+.4byte sIvysaurPose95
+.4byte sIvysaurPose96
+.4byte sIvysaurPose97
+.4byte sIvysaurPose98
+.4byte sIvysaurPose99
+.4byte sIvysaurPose100
+.4byte sIvysaurPose101
+.4byte sIvysaurPose102
+.4byte sIvysaurPose103
+.4byte sIvysaurPose104
+.4byte sIvysaurPose105
+.4byte sIvysaurPose106
+.4byte sIvysaurPose107
+.4byte sIvysaurPose108
+.4byte sIvysaurPose109
+.4byte sIvysaurPose110
+.4byte sIvysaurPose111
+.4byte sIvysaurPose112
+.4byte sIvysaurPose113
+.4byte sIvysaurPose114
+.4byte sIvysaurPose115
+.4byte sIvysaurPose116
+.4byte sIvysaurPose117
+.4byte sIvysaurPose118
+.4byte sIvysaurPose119
+.4byte sIvysaurPose120
+.4byte sIvysaurPose121
+.4byte sIvysaurPose122
+.4byte sIvysaurPose123
+.4byte sIvysaurPose124
+.4byte sIvysaurPose125
+.4byte sIvysaurPose126
+.4byte sIvysaurPose127
+.4byte sIvysaurPose128
+.4byte sIvysaurPose129
+.4byte sIvysaurPose130
+.4byte sIvysaurPose131
+.4byte sIvysaurPose132
+.4byte sIvysaurPose133
+.4byte sIvysaurPose134
+.4byte sIvysaurPose135
+.4byte sIvysaurPose136
+.4byte sIvysaurPose137
+.4byte sIvysaurPose138
+.4byte sIvysaurPose139
+.4byte sIvysaurPose140
+.4byte sIvysaurPose141
+.4byte sIvysaurPose142
+.4byte sIvysaurPose143
+.4byte sIvysaurPose144
+.4byte sIvysaurPose145
+.4byte sIvysaurPose146
+.4byte sIvysaurPose147
+.4byte sIvysaurPose148
+.4byte sIvysaurPose149
+.4byte sIvysaurPose150
+.4byte sIvysaurPose151
+.4byte sIvysaurPose152
+.4byte sIvysaurPose153
+.4byte sIvysaurPose154
+.4byte sIvysaurPose155
+.4byte sIvysaurPose156
+.4byte sIvysaurPose157
+.4byte sIvysaurPose158
+.4byte sIvysaurPose159
+.4byte sIvysaurPose160
+.4byte sIvysaurPose161
+.4byte sIvysaurPose162
+.4byte sIvysaurPose163
+.4byte sIvysaurPose164
+.4byte sIvysaurPose165
+.4byte sIvysaurPose166
+.4byte sIvysaurPose167
+.4byte sIvysaurPose168
+.4byte sIvysaurPose169
+.4byte sIvysaurPose170
+.4byte sIvysaurPose171
+.4byte sIvysaurPose172
+.4byte sIvysaurPose173
+.4byte sIvysaurPose174
+.4byte sIvysaurPose175
+.4byte sIvysaurPose176
+.4byte sIvysaurPose177
+.4byte sIvysaurPose178
+.4byte sIvysaurPose179
+.4byte sIvysaurPose180
+.4byte sIvysaurPose181
+.4byte sIvysaurPose182
+.4byte sIvysaurPose183
+.4byte sIvysaurPose184
+.4byte sIvysaurPose185
+.4byte sIvysaurPose186
+.4byte sIvysaurPose187
+.4byte sIvysaurPose188
+.4byte sIvysaurPose189
+.4byte sIvysaurPose190
+.4byte sIvysaurPose191
+.4byte sIvysaurPose192
+.4byte sIvysaurPose193
+.4byte sIvysaurPose194
+sAxPositionsIvysaur:
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte   -1,  -12, 	  -7,    3, 	   8,   -2, 	   0,   -7
+.2byte   -1,  -12, 	  -9,    0, 	   5,    2, 	  -2,   -7
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+.2byte   -3,  -15, 	   6,   -4, 	  -4,    1, 	  -3,   -8
+.2byte   -4,  -15, 	   8,   -6, 	  -2,    3, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte   -4,  -14, 	   3,   -4, 	  -1,    0, 	  -4,   -7
+.2byte   -4,  -14, 	   4,   -6, 	   4,    0, 	  -3,   -7
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte   -3,  -13, 	   0,   -9, 	   6,   -3, 	  -4,   -6
+.2byte   -3,  -13, 	  -2,   -8, 	   7,   -4, 	  -2,   -5
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	   5,   -8, 	  -6,   -9, 	  -1,   -6
+.2byte    0,  -11, 	   5,   -9, 	  -7,   -6, 	   0,   -6
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte    1,  -13, 	  -2,   -9, 	  -8,   -3, 	   2,   -6
+.2byte    1,  -13, 	   0,   -8, 	  -9,   -4, 	   0,   -5
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte    2,  -14, 	  -5,   -4, 	  -1,    0, 	   2,   -7
+.2byte    2,  -14, 	  -6,   -6, 	  -6,    0, 	   1,   -7
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte    1,  -15, 	  -8,   -4, 	   2,    1, 	   1,   -8
+.2byte    2,  -15, 	 -10,   -6, 	   0,    3, 	  -1,   -9
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte   -1,  -12, 	  -7,    3, 	   8,   -2, 	   0,   -7
+.2byte   -1,  -12, 	  -9,    0, 	   5,    2, 	  -2,   -7
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+.2byte   -3,  -15, 	   6,   -4, 	  -4,    1, 	  -3,   -8
+.2byte   -4,  -15, 	   8,   -6, 	  -2,    3, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte   -4,  -14, 	   3,   -4, 	  -1,    0, 	  -4,   -7
+.2byte   -4,  -14, 	   4,   -6, 	   4,    0, 	  -3,   -7
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte   -3,  -13, 	   0,   -9, 	   6,   -3, 	  -4,   -6
+.2byte   -3,  -13, 	  -2,   -8, 	   7,   -4, 	  -2,   -5
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	   5,   -8, 	  -6,   -9, 	  -1,   -6
+.2byte    0,  -11, 	   5,   -9, 	  -7,   -6, 	   0,   -6
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte    1,  -13, 	  -2,   -9, 	  -8,   -3, 	   2,   -6
+.2byte    1,  -13, 	   0,   -8, 	  -9,   -4, 	   0,   -5
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte    2,  -14, 	  -5,   -4, 	  -1,    0, 	   2,   -7
+.2byte    2,  -14, 	  -6,   -6, 	  -6,    0, 	   1,   -7
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte    1,  -15, 	  -8,   -4, 	   2,    1, 	   1,   -8
+.2byte    2,  -15, 	 -10,   -6, 	   0,    3, 	  -1,   -9
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte   -1,  -12, 	  -7,    3, 	   8,   -2, 	   0,   -7
+.2byte   -1,  -12, 	  -9,    0, 	   5,    2, 	  -2,   -7
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+.2byte   -3,  -15, 	   6,   -4, 	  -4,    1, 	  -3,   -8
+.2byte   -4,  -15, 	   8,   -6, 	  -2,    3, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte   -4,  -14, 	   3,   -4, 	  -1,    0, 	  -4,   -7
+.2byte   -4,  -14, 	   4,   -6, 	   4,    0, 	  -3,   -7
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte   -3,  -13, 	   0,   -9, 	   6,   -3, 	  -4,   -6
+.2byte   -3,  -13, 	  -2,   -8, 	   7,   -4, 	  -2,   -5
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	   5,   -8, 	  -6,   -9, 	  -1,   -6
+.2byte    0,  -11, 	   5,   -9, 	  -7,   -6, 	   0,   -6
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte    1,  -13, 	  -2,   -9, 	  -8,   -3, 	   2,   -6
+.2byte    1,  -13, 	   0,   -8, 	  -9,   -4, 	   0,   -5
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte    2,  -14, 	  -5,   -4, 	  -1,    0, 	   2,   -7
+.2byte    2,  -14, 	  -6,   -6, 	  -6,    0, 	   1,   -7
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte    1,  -15, 	  -8,   -4, 	   2,    1, 	   1,   -8
+.2byte    2,  -15, 	 -10,   -6, 	   0,    3, 	  -1,   -9
+.2byte   -1,  -12, 	  -7,    1, 	   6,    0, 	  -1,   -7
+.2byte   -1,  -13, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte    0,  -15, 	   7,   -5, 	  -2,    0, 	  -1,   -8
+.2byte   -1,  -15, 	   7,   -4, 	  -3,    1, 	  -2,   -8
+.2byte    1,  -15, 	   5,   -5, 	   2,    1, 	  -1,   -7
+.2byte    0,  -15, 	   4,   -5, 	   2,    0, 	  -3,   -8
+.2byte    0,  -14, 	  -2,  -11, 	   6,   -4, 	  -1,   -7
+.2byte   -1,  -15, 	  -5,  -10, 	   6,   -4, 	  -2,   -7
+.2byte   -1,  -16, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -8, 	   0,   -7
+.2byte   -2,  -14, 	   0,  -11, 	  -8,   -4, 	  -1,   -7
+.2byte   -1,  -15, 	   3,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -3,  -15, 	  -7,   -5, 	  -4,    1, 	  -1,   -7
+.2byte   -2,  -15, 	  -6,   -5, 	  -4,    0, 	   1,   -8
+.2byte   -2,  -15, 	  -9,   -5, 	   0,    0, 	  -1,   -8
+.2byte   -1,  -15, 	  -9,   -4, 	   1,    1, 	   0,   -8
+.2byte   -3,  -14, 	  -7,    1, 	   5,    0, 	  -2,   -8
+.2byte    1,  -13, 	  -7,    1, 	   6,    0, 	   0,   -9
+.2byte   -2,  -16, 	   8,   -5, 	  -3,    1, 	  -1,   -8
+.2byte   -4,  -14, 	   6,   -4, 	  -4,    1, 	  -3,   -7
+.2byte   -2,  -15, 	   5,   -5, 	   2,    0, 	  -3,   -8
+.2byte   -5,  -12, 	   3,   -5, 	   1,    0, 	  -4,   -6
+.2byte   -7,  -13, 	  -4,  -10, 	   6,   -4, 	  -3,   -6
+.2byte   -2,  -13, 	  -6,   -9, 	   6,   -4, 	  -2,   -6
+.2byte    1,  -12, 	   5,   -9, 	  -5,   -9, 	   0,   -6
+.2byte   -3,  -12, 	   3,   -9, 	  -7,   -7, 	  -1,   -6
+.2byte    5,  -13, 	   2,  -10, 	  -8,   -4, 	   1,   -6
+.2byte    0,  -13, 	   4,   -9, 	  -8,   -4, 	   0,   -6
+.2byte    0,  -15, 	  -7,   -5, 	  -4,    0, 	   1,   -8
+.2byte    3,  -12, 	  -5,   -5, 	  -3,    0, 	   2,   -6
+.2byte    0,  -16, 	 -10,   -5, 	   1,    1, 	  -1,   -8
+.2byte    2,  -14, 	  -8,   -4, 	   2,    1, 	   1,   -7
+.2byte   -8,   -1, 	  -8,   -8, 	  -1,    2, 	   0,   -7
+.2byte   -8,    0, 	  -8,   -6, 	  -1,    3, 	   1,   -7
+.2byte    0,  -18, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte   -6,  -15, 	   8,   -2, 	  -4,    1, 	  -3,   -8
+.2byte   -7,  -14, 	   5,   -5, 	   3,    0, 	  -4,   -8
+.2byte   -6,  -11, 	  -1,   -8, 	   6,   -3, 	  -2,   -7
+.2byte    0,  -14, 	   7,  -10, 	  -7,  -10, 	   0,   -7
+.2byte    5,  -11, 	   0,   -8, 	  -7,   -3, 	   1,   -7
+.2byte    6,  -14, 	  -6,   -5, 	  -4,    0, 	   3,   -8
+.2byte    5,  -15, 	  -9,   -2, 	   3,    1, 	   2,   -8
+.2byte   -3,  -14, 	  -7,    1, 	   5,    0, 	  -2,   -8
+.2byte    1,  -13, 	  -7,    1, 	   6,    0, 	   0,   -9
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte   -2,  -16, 	   8,   -5, 	  -3,    1, 	  -1,   -8
+.2byte   -4,  -14, 	   6,   -4, 	  -4,    1, 	  -3,   -7
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+.2byte   -2,  -15, 	   5,   -5, 	   2,    0, 	  -3,   -8
+.2byte   -5,  -12, 	   3,   -5, 	   1,    0, 	  -4,   -6
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte   -7,  -13, 	  -4,  -10, 	   6,   -4, 	  -3,   -6
+.2byte   -2,  -13, 	  -6,   -9, 	   6,   -4, 	  -2,   -6
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte    1,  -12, 	   5,   -9, 	  -5,   -9, 	   0,   -6
+.2byte   -3,  -12, 	   3,   -9, 	  -7,   -7, 	  -1,   -6
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte    5,  -13, 	   2,  -10, 	  -8,   -4, 	   1,   -6
+.2byte    0,  -13, 	   4,   -9, 	  -8,   -4, 	   0,   -6
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte    0,  -15, 	  -7,   -5, 	  -4,    0, 	   1,   -8
+.2byte    3,  -12, 	  -5,   -5, 	  -3,    0, 	   2,   -6
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte    0,  -16, 	 -10,   -5, 	   1,    1, 	  -1,   -8
+.2byte    2,  -14, 	  -8,   -4, 	   2,    1, 	   1,   -7
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte   -1,  -13, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte   -1,  -12, 	  -7,    1, 	   6,    0, 	  -1,   -7
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+.2byte   -1,  -15, 	   6,   -5, 	  -3,    0, 	  -2,   -8
+.2byte   -1,  -15, 	   7,   -4, 	  -3,    1, 	  -2,   -8
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte    0,  -15, 	   4,   -5, 	   1,    1, 	  -2,   -7
+.2byte   -1,  -15, 	   3,   -5, 	   1,    0, 	  -4,   -8
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte    0,  -15, 	  -4,  -10, 	   7,   -4, 	  -1,   -7
+.2byte    0,  -14, 	  -2,  -11, 	   6,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -8, 	   0,   -7
+.2byte   -1,  -16, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte   -1,  -15, 	   3,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -1,  -14, 	   1,  -11, 	  -7,   -4, 	   0,   -7
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte   -2,  -15, 	  -6,   -5, 	  -3,    1, 	   0,   -7
+.2byte   -1,  -15, 	  -5,   -5, 	  -3,    0, 	   2,   -8
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte   -2,  -15, 	  -9,   -5, 	   0,    0, 	  -1,   -8
+.2byte   -1,  -15, 	  -9,   -4, 	   1,    1, 	   0,   -8
+.2byte   -1,  -12, 	  -7,    1, 	   6,    0, 	  -1,   -7
+.2byte   -1,  -15, 	  -9,   -4, 	   1,    1, 	   0,   -8
+.2byte   -2,  -15, 	  -6,   -5, 	  -4,    0, 	   1,   -8
+.2byte   -1,  -15, 	   3,  -10, 	  -8,   -4, 	   0,   -7
+.2byte   -1,  -16, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte   -1,  -15, 	  -5,  -10, 	   6,   -4, 	  -2,   -7
+.2byte    0,  -15, 	   4,   -5, 	   2,    0, 	  -3,   -8
+.2byte   -1,  -15, 	   7,   -4, 	  -3,    1, 	  -2,   -8
+.2byte   -1,  -13, 	  -7,    1, 	   5,    0, 	  -1,   -8
+.2byte    1,  -16, 	 -10,   -5, 	   0,    1, 	   0,   -9
+.2byte    2,  -15, 	  -5,   -6, 	  -4,    0, 	   1,   -9
+.2byte    1,  -14, 	   0,  -10, 	  -8,   -4, 	   2,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -7
+.2byte   -3,  -14, 	  -2,  -10, 	   6,   -4, 	  -4,   -7
+.2byte   -4,  -15, 	   3,   -6, 	   2,    0, 	  -3,   -9
+.2byte   -3,  -16, 	   8,   -5, 	  -2,    1, 	  -2,   -9
+sIvysaurAnimTable1:
+.4byte sIvysaurAnims_1_1
+.4byte sIvysaurAnims_1_2
+.4byte sIvysaurAnims_1_3
+.4byte sIvysaurAnims_1_4
+.4byte sIvysaurAnims_1_5
+.4byte sIvysaurAnims_1_6
+.4byte sIvysaurAnims_1_7
+.4byte sIvysaurAnims_1_8
+sIvysaurAnimTable2:
+.4byte sIvysaurAnims_2_1
+.4byte sIvysaurAnims_2_2
+.4byte sIvysaurAnims_2_3
+.4byte sIvysaurAnims_2_4
+.4byte sIvysaurAnims_2_5
+.4byte sIvysaurAnims_2_6
+.4byte sIvysaurAnims_2_7
+.4byte sIvysaurAnims_2_8
+sIvysaurAnimTable3:
+.4byte sIvysaurAnims_3_1
+.4byte sIvysaurAnims_3_2
+.4byte sIvysaurAnims_3_3
+.4byte sIvysaurAnims_3_4
+.4byte sIvysaurAnims_3_5
+.4byte sIvysaurAnims_3_6
+.4byte sIvysaurAnims_3_7
+.4byte sIvysaurAnims_3_8
+sIvysaurAnimTable4:
+.4byte sIvysaurAnims_4_1
+.4byte sIvysaurAnims_4_2
+.4byte sIvysaurAnims_4_3
+.4byte sIvysaurAnims_4_4
+.4byte sIvysaurAnims_4_5
+.4byte sIvysaurAnims_4_6
+.4byte sIvysaurAnims_4_7
+.4byte sIvysaurAnims_4_8
+sIvysaurAnimTable5:
+.4byte sIvysaurAnims_5_1
+.4byte sIvysaurAnims_5_2
+.4byte sIvysaurAnims_5_3
+.4byte sIvysaurAnims_5_4
+.4byte sIvysaurAnims_5_5
+.4byte sIvysaurAnims_5_6
+.4byte sIvysaurAnims_5_7
+.4byte sIvysaurAnims_5_8
+sIvysaurAnimTable6:
+.4byte sIvysaurAnims_6_1
+.4byte sIvysaurAnims_6_1
+.4byte sIvysaurAnims_6_1
+.4byte sIvysaurAnims_6_1
+.4byte sIvysaurAnims_6_1
+.4byte sIvysaurAnims_6_1
+.4byte sIvysaurAnims_6_1
+.4byte sIvysaurAnims_6_1
+sIvysaurAnimTable7:
+.4byte sIvysaurAnims_7_1
+.4byte sIvysaurAnims_7_2
+.4byte sIvysaurAnims_7_3
+.4byte sIvysaurAnims_7_4
+.4byte sIvysaurAnims_7_5
+.4byte sIvysaurAnims_7_6
+.4byte sIvysaurAnims_7_7
+.4byte sIvysaurAnims_7_8
+sIvysaurAnimTable8:
+.4byte sIvysaurAnims_8_1
+.4byte sIvysaurAnims_8_2
+.4byte sIvysaurAnims_8_3
+.4byte sIvysaurAnims_8_4
+.4byte sIvysaurAnims_8_5
+.4byte sIvysaurAnims_8_6
+.4byte sIvysaurAnims_8_7
+.4byte sIvysaurAnims_8_8
+sIvysaurAnimTable9:
+.4byte sIvysaurAnims_9_1
+.4byte sIvysaurAnims_9_2
+.4byte sIvysaurAnims_9_3
+.4byte sIvysaurAnims_9_4
+.4byte sIvysaurAnims_9_5
+.4byte sIvysaurAnims_9_6
+.4byte sIvysaurAnims_9_7
+.4byte sIvysaurAnims_9_8
+sIvysaurAnimTable10:
+.4byte sIvysaurAnims_10_1
+.4byte sIvysaurAnims_10_2
+.4byte sIvysaurAnims_10_3
+.4byte sIvysaurAnims_10_4
+.4byte sIvysaurAnims_10_5
+.4byte sIvysaurAnims_10_6
+.4byte sIvysaurAnims_10_7
+.4byte sIvysaurAnims_10_8
+sIvysaurAnimTable11:
+.4byte sIvysaurAnims_11_1
+.4byte sIvysaurAnims_11_2
+.4byte sIvysaurAnims_11_3
+.4byte sIvysaurAnims_11_4
+.4byte sIvysaurAnims_11_5
+.4byte sIvysaurAnims_11_6
+.4byte sIvysaurAnims_11_7
+.4byte sIvysaurAnims_11_8
+sIvysaurAnimTable12:
+.4byte sIvysaurAnims_12_1
+.4byte sIvysaurAnims_12_2
+.4byte sIvysaurAnims_12_3
+.4byte sIvysaurAnims_12_4
+.4byte sIvysaurAnims_12_5
+.4byte sIvysaurAnims_12_6
+.4byte sIvysaurAnims_12_7
+.4byte sIvysaurAnims_12_8
+sIvysaurAnimTable13:
+.4byte sIvysaurAnims_13_1
+.4byte sIvysaurAnims_13_2
+.4byte sIvysaurAnims_13_3
+.4byte sIvysaurAnims_13_4
+.4byte sIvysaurAnims_13_5
+.4byte sIvysaurAnims_13_6
+.4byte sIvysaurAnims_13_7
+.4byte sIvysaurAnims_13_8
+sAxAnimationsIvysaur:
+.4byte sIvysaurAnimTable1
+.4byte sIvysaurAnimTable2
+.4byte sIvysaurAnimTable3
+.4byte sIvysaurAnimTable4
+.4byte sIvysaurAnimTable5
+.4byte sIvysaurAnimTable6
+.4byte sIvysaurAnimTable7
+.4byte sIvysaurAnimTable8
+.4byte sIvysaurAnimTable9
+.4byte sIvysaurAnimTable10
+.4byte sIvysaurAnimTable11
+.4byte sIvysaurAnimTable12
+.4byte sIvysaurAnimTable13
+sAxSpritesIvysaur:
+.4byte sIvysaurSprites1
+.4byte sIvysaurSprites2
+.4byte sIvysaurSprites3
+.4byte sIvysaurSprites4
+.4byte sIvysaurSprites5
+.4byte sIvysaurSprites6
+.4byte sIvysaurSprites7
+.4byte sIvysaurSprites8
+.4byte sIvysaurSprites9
+.4byte sIvysaurSprites10
+.4byte sIvysaurSprites11
+.4byte sIvysaurSprites12
+.4byte sIvysaurSprites13
+.4byte sIvysaurSprites14
+.4byte sIvysaurSprites15
+.4byte sIvysaurSprites16
+.4byte sIvysaurSprites17
+.4byte sIvysaurSprites18
+.4byte sIvysaurSprites19
+.4byte sIvysaurSprites20
+.4byte sIvysaurSprites21
+.4byte sIvysaurSprites22
+.4byte sIvysaurSprites23
+.4byte sIvysaurSprites24
+.4byte sIvysaurSprites25
+.4byte sIvysaurSprites26
+.4byte sIvysaurSprites27
+.4byte sIvysaurSprites28
+.4byte sIvysaurSprites29
+.4byte sIvysaurSprites30
+.4byte sIvysaurSprites31
+.4byte sIvysaurSprites32
+.4byte sIvysaurSprites33
+.4byte sIvysaurSprites34
+.4byte sIvysaurSprites35
+.4byte sIvysaurSprites36
+.4byte sIvysaurSprites37
+.4byte sIvysaurSprites38
+.4byte sIvysaurSprites39
+.4byte sIvysaurSprites40
+.4byte sIvysaurSprites41
+.4byte sIvysaurSprites42
+sAxMainIvysaur:
+ax_main sAxPosesIvysaur, sAxAnimationsIvysaur, 13, sAxSpritesIvysaur, sAxPositionsIvysaur

--- a/data/ax/jigglypuff.inc
+++ b/data/ax/jigglypuff.inc
@@ -1,0 +1,2734 @@
+.global gAxJigglypuff
+gAxJigglypuff:
+ax_siro sAxMainJigglypuff
+sJigglypuffPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose4:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose5:
+ax_pose 4, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose6:
+ax_pose 5, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose7:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose8:
+ax_pose 7, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose9:
+ax_pose 8, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose10:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose11:
+ax_pose 10, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose12:
+ax_pose 11, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose13:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose14:
+ax_pose 13, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose15:
+ax_pose 14, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose16:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose17:
+ax_pose 10, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose18:
+ax_pose 11, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose19:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose20:
+ax_pose 7, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose21:
+ax_pose 8, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose22:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose23:
+ax_pose 4, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose24:
+ax_pose 5, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose27:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose28:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose29:
+ax_pose 4, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose30:
+ax_pose 16, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose31:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose32:
+ax_pose 7, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose33:
+ax_pose 17, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose34:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose35:
+ax_pose 10, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose36:
+ax_pose 18, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose37:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose38:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose39:
+ax_pose 19, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose40:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose41:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose42:
+ax_pose 18, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose43:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose44:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose45:
+ax_pose 17, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose46:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose47:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose48:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose49:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose50:
+ax_pose 1, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose51:
+ax_pose 2, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose52:
+ax_pose 15, 0x01f0, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose53:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose54:
+ax_pose 4, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose55:
+ax_pose 5, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose56:
+ax_pose 16, 0x01ed, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose57:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose58:
+ax_pose 7, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose59:
+ax_pose 8, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose60:
+ax_pose 17, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sJigglypuffPose61:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose62:
+ax_pose 10, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose63:
+ax_pose 11, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose64:
+ax_pose 18, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sJigglypuffPose65:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose66:
+ax_pose 13, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose67:
+ax_pose 14, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose68:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose69:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose70:
+ax_pose 10, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose71:
+ax_pose 11, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose72:
+ax_pose 18, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sJigglypuffPose73:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose74:
+ax_pose 7, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose75:
+ax_pose 8, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose76:
+ax_pose 17, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose77:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose80:
+ax_pose 16, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose81:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose82:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose83:
+ax_pose 2, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose84:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose85:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose86:
+ax_pose 21, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose87:
+ax_pose 5, 0x01e7, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose88:
+ax_pose 4, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sJigglypuffPose89:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose90:
+ax_pose 22, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose91:
+ax_pose 8, 0x01e7, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose92:
+ax_pose 7, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose93:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose94:
+ax_pose 23, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose95:
+ax_pose 11, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose96:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose97:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose98:
+ax_pose 24, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose99:
+ax_pose 14, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose100:
+ax_pose 13, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose101:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose102:
+ax_pose 23, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose103:
+ax_pose 11, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose104:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose105:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose106:
+ax_pose 22, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose107:
+ax_pose 8, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose108:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose109:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose110:
+ax_pose 21, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose111:
+ax_pose 5, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose112:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose113:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose114:
+ax_pose 25, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose115:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose116:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose117:
+ax_pose 26, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose118:
+ax_pose 21, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose119:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose120:
+ax_pose 27, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose121:
+ax_pose 22, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose122:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose123:
+ax_pose 28, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose124:
+ax_pose 23, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose125:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose126:
+ax_pose 29, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose127:
+ax_pose 24, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose128:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose129:
+ax_pose 28, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose130:
+ax_pose 23, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose131:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose132:
+ax_pose 27, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose133:
+ax_pose 22, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose134:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose135:
+ax_pose 26, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose136:
+ax_pose 21, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose137:
+ax_pose 30, 0x01ee, 0x80f5, 0x1c00
+ax_pose_terminator
+sJigglypuffPose138:
+ax_pose 31, 0x01ee, 0x80f5, 0x1c00
+ax_pose_terminator
+sJigglypuffPose139:
+ax_pose 32, 0x01e3, 0x80f2, 0x1c00
+ax_pose_terminator
+sJigglypuffPose140:
+ax_pose 33, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sJigglypuffPose141:
+ax_pose 34, 0x01e4, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose142:
+ax_pose 35, 0x01e9, 0x90ef, 0x1c00
+ax_pose_terminator
+sJigglypuffPose143:
+ax_pose 36, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose144:
+ax_pose 35, 0x01e9, 0x80f1, 0x1c00
+ax_pose_terminator
+sJigglypuffPose145:
+ax_pose 34, 0x01e4, 0x80f3, 0x1c00
+ax_pose_terminator
+sJigglypuffPose146:
+ax_pose 33, 0x01e5, 0x80f1, 0x1c00
+ax_pose_terminator
+sJigglypuffPose147:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose148:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose149:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose150:
+ax_pose 4, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose151:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose152:
+ax_pose 7, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose153:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose154:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose155:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose156:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose157:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose158:
+ax_pose 10, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sJigglypuffPose159:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose160:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose161:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose162:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose163:
+ax_pose 15, 0x01f0, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose164:
+ax_pose 16, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose165:
+ax_pose 17, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose166:
+ax_pose 18, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sJigglypuffPose167:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose168:
+ax_pose 18, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sJigglypuffPose169:
+ax_pose 17, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sJigglypuffPose170:
+ax_pose 16, 0x01ed, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose171:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose172:
+ax_pose 21, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose173:
+ax_pose 22, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose174:
+ax_pose 23, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose175:
+ax_pose 24, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose176:
+ax_pose 23, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose177:
+ax_pose 22, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose178:
+ax_pose 21, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose179:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose180:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose181:
+ax_pose 2, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose182:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose183:
+ax_pose 4, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose184:
+ax_pose 5, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose185:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose186:
+ax_pose 7, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose187:
+ax_pose 8, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose188:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose189:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose190:
+ax_pose 11, 0x01e6, 0x90ec, 0x1c00
+ax_pose_terminator
+sJigglypuffPose191:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose192:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose193:
+ax_pose 14, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose194:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose195:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose196:
+ax_pose 11, 0x01e6, 0x80f5, 0x1c00
+ax_pose_terminator
+sJigglypuffPose197:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose198:
+ax_pose 7, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose199:
+ax_pose 8, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose200:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose201:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose202:
+ax_pose 5, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose203:
+ax_pose 25, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose204:
+ax_pose 26, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose205:
+ax_pose 27, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose206:
+ax_pose 28, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose207:
+ax_pose 29, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose208:
+ax_pose 28, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose209:
+ax_pose 27, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose210:
+ax_pose 26, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose211:
+ax_pose 0, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose212:
+ax_pose 3, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose213:
+ax_pose 6, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose214:
+ax_pose 9, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose215:
+ax_pose 12, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sJigglypuffPose216:
+ax_pose 9, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose217:
+ax_pose 6, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sJigglypuffPose218:
+ax_pose 3, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+.align 2
+sJigglypuffAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 1,
+ax_anim 4, 0, 1, 0, -1, 0, 3,
+ax_anim 4, 0, 2, 0, -2, 0, 2,
+ax_anim 6, 0, 2, 0, 0, 0, 1,
+ax_anim_terminator
+sJigglypuffAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 2, 1, 2, 2,
+ax_anim 4, 0, 4, 3, 0, 3, 3,
+ax_anim 4, 0, 5, 3, -1, 3, 3,
+ax_anim 6, 0, 5, 1, 0, 1, 1,
+ax_anim_terminator
+sJigglypuffAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 2, 1, 2, 0,
+ax_anim 4, 0, 7, 3, -1, 3, 0,
+ax_anim 4, 0, 8, 2, -2, 2, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 2, 1, 2, -2,
+ax_anim 4, 0, 10, 4, -1, 4, -4,
+ax_anim 4, 0, 11, 2, -1, 2, -2,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, -2,
+ax_anim 4, 0, 13, 0, -2, 0, -3,
+ax_anim 4, 0, 14, 0, -4, 0, -2,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -2, 1, -2, -2,
+ax_anim 4, 0, 16, -4, -1, -4, -4,
+ax_anim 4, 0, 17, -2, -1, -2, -2,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -2, 1, -2, 0,
+ax_anim 4, 0, 19, -3, -1, -3, 0,
+ax_anim 4, 0, 20, -2, -2, -2, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -2, 1, -2, 2,
+ax_anim 4, 0, 22, -3, 0, -3, 3,
+ax_anim 4, 0, 23, -3, -1, -3, 3,
+ax_anim 6, 0, 23, -1, 0, -1, 1,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_2_1:
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 6, 0, 25, 0, -5, 0, -5,
+ax_anim 1, 2, 26, 0, 3, 0, 3,
+ax_anim 1, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 26, -1, 19, -1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, -1, 19, -1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, -1, 19, -1, 19,
+ax_anim 2, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim_terminator
+sJigglypuffAnims_2_2:
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 6, 0, 28, -5, -5, -5, -5,
+ax_anim 1, 2, 29, 3, 3, 3, 3,
+ax_anim 1, 0, 29, 12, 12, 12, 12,
+ax_anim 2, 0, 29, 21, 19, 21, 19,
+ax_anim 2, 1, 29, 21, 18, 21, 18,
+ax_anim 2, 0, 29, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 21, 18, 21, 18,
+ax_anim 2, 0, 29, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sJigglypuffAnims_2_3:
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, -4, 0, -4, 0,
+ax_anim 6, 0, 31, -5, 0, -5, 0,
+ax_anim 1, 2, 32, 3, 0, 3, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 1, 32, 20, -1, 20, -1,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 20, -1, 20, -1,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 20, -1, 20, -1,
+ax_anim 2, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim_terminator
+sJigglypuffAnims_2_4:
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 6, 0, 34, -5, 5, -5, 5,
+ax_anim 1, 2, 35, 3, -3, 3, -3,
+ax_anim 1, 0, 35, 12, -14, 12, -14,
+ax_anim 2, 0, 35, 19, -23, 19, -23,
+ax_anim 2, 1, 35, 19, -22, 19, -22,
+ax_anim 2, 0, 35, 19, -23, 19, -23,
+ax_anim 2, 0, 35, 19, -22, 19, -22,
+ax_anim 2, 0, 35, 19, -23, 19, -23,
+ax_anim 2, 0, 35, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 10, -11, 10, -11,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim_terminator
+sJigglypuffAnims_2_5:
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 6, 0, 37, 0, 5, 0, 5,
+ax_anim 1, 2, 38, 0, -3, 0, -3,
+ax_anim 1, 0, 38, 0, -12, 0, -12,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 1, 38, -1, -24, -1, -24,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 0, 38, -1, -24, -1, -24,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 0, 38, -1, -24, -1, -24,
+ax_anim 2, 0, 37, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim_terminator
+sJigglypuffAnims_2_6:
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 6, 0, 40, 5, 5, 5, 5,
+ax_anim 1, 2, 41, -3, -3, -3, -3,
+ax_anim 1, 0, 41, -12, -14, -12, -14,
+ax_anim 2, 0, 41, -19, -23, -19, -23,
+ax_anim 2, 1, 41, -19, -22, -19, -22,
+ax_anim 2, 0, 41, -19, -23, -19, -23,
+ax_anim 2, 0, 41, -19, -22, -19, -22,
+ax_anim 2, 0, 41, -19, -23, -19, -23,
+ax_anim 2, 0, 41, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -10, -11, -10, -11,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim_terminator
+sJigglypuffAnims_2_7:
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 4, 0, 4, 0,
+ax_anim 6, 0, 43, 5, 0, 5, 0,
+ax_anim 1, 2, 44, -3, 0, -3, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 1, 44, -20, -1, -20, -1,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -20, -1, -20, -1,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -20, -1, -20, -1,
+ax_anim 2, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim_terminator
+sJigglypuffAnims_2_8:
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 6, 0, 46, 5, -5, 5, -5,
+ax_anim 1, 2, 47, -3, 3, -3, 3,
+ax_anim 1, 0, 47, -12, 12, -12, 12,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 1, 47, -22, 18, -22, 18,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 47, -22, 18, -22, 18,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 47, -22, 18, -22, 18,
+ax_anim 2, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, 1, 0, -1,
+ax_anim 2, 2, 49, 0, 4, 0, 6,
+ax_anim 2, 0, 51, 0, 7, 0, 10,
+ax_anim 2, 0, 51, 0, 18, 0, 18,
+ax_anim 2, 1, 51, 1, 18, 1, 18,
+ax_anim 2, 0, 51, 0, 18, 0, 18,
+ax_anim 2, 0, 51, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sJigglypuffAnims_3_2:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 2, 0, 53, 3, -1, 3, 2,
+ax_anim 2, 2, 53, 7, 2, 7, 7,
+ax_anim 2, 0, 55, 14, 8, 14, 13,
+ax_anim 2, 0, 55, 21, 19, 21, 19,
+ax_anim 2, 1, 55, 22, 18, 22, 18,
+ax_anim 2, 0, 55, 21, 19, 21, 19,
+ax_anim 2, 0, 55, 22, 18, 22, 18,
+ax_anim 2, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 3, 3, 3, 3,
+ax_anim_terminator
+sJigglypuffAnims_3_3:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 4, 0, 56, -2, 0, -2, 0,
+ax_anim 2, 0, 57, 3, 0, 3, 0,
+ax_anim 2, 2, 57, 7, -2, 7, 0,
+ax_anim 2, 0, 59, 14, -5, 14, 0,
+ax_anim 2, 0, 59, 21, 0, 21, 0,
+ax_anim 2, 1, 59, 21, -1, 21, -1,
+ax_anim 2, 0, 59, 21, 0, 21, 0,
+ax_anim 2, 0, 59, 21, -1, 21, -1,
+ax_anim 2, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim_terminator
+sJigglypuffAnims_3_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, 1, -1, 1,
+ax_anim 4, 0, 60, -2, 2, -2, 2,
+ax_anim 2, 0, 61, 3, -6, 3, -4,
+ax_anim 2, 2, 61, 7, -12, 7, -10,
+ax_anim 2, 0, 63, 14, -22, 14, -16,
+ax_anim 2, 0, 63, 20, -23, 20, -23,
+ax_anim 2, 1, 63, 19, -24, 19, -24,
+ax_anim 2, 0, 63, 20, -23, 20, -23,
+ax_anim 2, 0, 63, 19, -24, 19, -24,
+ax_anim 2, 0, 60, 9, -11, 9, -11,
+ax_anim 2, 0, 60, 2, -3, 2, -3,
+ax_anim_terminator
+sJigglypuffAnims_3_5:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 4, 0, 64, 0, 2, 0, 2,
+ax_anim 2, 0, 65, 0, -3, 0, -6,
+ax_anim 2, 2, 65, 0, -10, 0, -12,
+ax_anim 2, 0, 67, 0, -19, 0, -18,
+ax_anim 2, 0, 67, 0, -23, 0, -23,
+ax_anim 2, 1, 67, -1, -23, -1, -23,
+ax_anim 2, 0, 67, 0, -23, 0, -23,
+ax_anim 2, 0, 67, -1, -23, -1, -23,
+ax_anim 2, 0, 64, 0, -11, 0, -11,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sJigglypuffAnims_3_6:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, 1, 1, 1,
+ax_anim 4, 0, 68, 2, 2, 2, 2,
+ax_anim 2, 0, 69, -3, -6, -3, -4,
+ax_anim 2, 2, 69, -7, -12, -7, -10,
+ax_anim 2, 0, 71, -14, -22, -14, -16,
+ax_anim 2, 0, 71, -20, -23, -20, -23,
+ax_anim 2, 1, 71, -19, -24, -19, -24,
+ax_anim 2, 0, 71, -20, -23, -20, -23,
+ax_anim 2, 0, 71, -19, -24, -19, -24,
+ax_anim 2, 0, 68, -9, -11, -9, -11,
+ax_anim 2, 0, 68, -2, -3, -2, -3,
+ax_anim_terminator
+sJigglypuffAnims_3_7:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 4, 0, 72, 2, 0, 2, 0,
+ax_anim 2, 0, 73, -3, 0, -3, 0,
+ax_anim 2, 2, 73, -7, -2, -7, 0,
+ax_anim 2, 0, 75, -14, -5, -14, 0,
+ax_anim 2, 0, 75, -21, 0, -21, 0,
+ax_anim 2, 1, 75, -21, -1, -21, -1,
+ax_anim 2, 0, 75, -21, 0, -21, 0,
+ax_anim 2, 0, 75, -21, -1, -21, -1,
+ax_anim 2, 0, 72, -10, 0, -10, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sJigglypuffAnims_3_8:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 4, 0, 76, 2, -2, 2, -2,
+ax_anim 2, 0, 77, -3, -1, -3, 2,
+ax_anim 2, 2, 77, -7, 2, -7, 7,
+ax_anim 2, 0, 79, -14, 8, -14, 13,
+ax_anim 2, 0, 79, -21, 19, -21, 19,
+ax_anim 2, 1, 79, -22, 18, -22, 18,
+ax_anim 2, 0, 79, -21, 19, -21, 19,
+ax_anim 2, 0, 79, -22, 18, -22, 18,
+ax_anim 2, 0, 76, -10, 10, -10, 10,
+ax_anim 2, 0, 76, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_4_1:
+ax_anim 2, 0, 82, 0, -2, 0, -2,
+ax_anim 2, 0, 83, 0, -3, 0, -3,
+ax_anim 6, 2, 83, 0, -4, 0, -4,
+ax_anim 1, 0, 80, 0, -3, 0, -3,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 1, 81, 0, 3, 0, 3,
+ax_anim 2, 0, 81, -1, 3, -1, 3,
+ax_anim 2, 0, 81, 0, 3, 0, 3,
+ax_anim 2, 0, 81, -1, 3, -1, 3,
+ax_anim 2, 0, 81, 0, 3, 0, 3,
+ax_anim 2, 0, 81, -1, 3, -1, 3,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim_terminator
+sJigglypuffAnims_4_2:
+ax_anim 2, 0, 86, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -3, -3, -3, -3,
+ax_anim 6, 2, 87, -4, -4, -4, -4,
+ax_anim 1, 0, 84, -3, -3, -3, -3,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 1, 85, 3, 3, 3, 3,
+ax_anim 2, 0, 85, 2, 4, 2, 4,
+ax_anim 2, 0, 85, 3, 3, 3, 3,
+ax_anim 2, 0, 85, 2, 4, 2, 4,
+ax_anim 2, 0, 85, 3, 3, 3, 3,
+ax_anim 2, 0, 85, 2, 4, 2, 4,
+ax_anim 2, 0, 84, 1, 1, 1, 1,
+ax_anim_terminator
+sJigglypuffAnims_4_3:
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -3, 0, -3, 0,
+ax_anim 6, 2, 91, -4, -1, -4, 0,
+ax_anim 1, 0, 88, -3, 0, -3, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 1, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 89, 3, -1, 3, -1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 89, 3, -1, 3, -1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 89, 3, -1, 3, -1,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim_terminator
+sJigglypuffAnims_4_4:
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 6, 2, 95, -4, 4, -4, 4,
+ax_anim 1, 0, 92, -3, 3, -3, 3,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 1, 93, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 2, -4, 2, -4,
+ax_anim 2, 0, 93, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 2, -4, 2, -4,
+ax_anim 2, 0, 93, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 2, -4, 2, -4,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim_terminator
+sJigglypuffAnims_4_5:
+ax_anim 2, 0, 98, 0, 2, 0, 2,
+ax_anim 2, 0, 99, 0, 3, 0, 3,
+ax_anim 6, 2, 99, 0, 4, 0, 4,
+ax_anim 1, 0, 96, 0, 3, 0, 3,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 1, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim_terminator
+sJigglypuffAnims_4_6:
+ax_anim 2, 0, 102, 2, 2, 2, 2,
+ax_anim 2, 0, 103, 3, 3, 3, 3,
+ax_anim 6, 2, 103, 4, 4, 4, 4,
+ax_anim 1, 0, 100, 3, 3, 3, 3,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 1, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -2, -4, -2, -4,
+ax_anim 2, 0, 100, -1, -1, -1, -1,
+ax_anim_terminator
+sJigglypuffAnims_4_7:
+ax_anim 2, 0, 106, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 3, 0, 3, 0,
+ax_anim 6, 2, 107, 4, -1, 4, 0,
+ax_anim 1, 0, 104, 3, 0, 3, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 1, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 104, -1, 0, -1, 0,
+ax_anim_terminator
+sJigglypuffAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 111, 3, -3, 3, -3,
+ax_anim 6, 2, 111, 4, -4, 4, -4,
+ax_anim 1, 0, 108, 3, -3, 3, -3,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 1, 109, -3, 3, -3, 3,
+ax_anim 2, 0, 109, -2, 4, -2, 4,
+ax_anim 2, 0, 109, -3, 3, -3, 3,
+ax_anim 2, 0, 109, -2, 4, -2, 4,
+ax_anim 2, 0, 109, -3, 3, -3, 3,
+ax_anim 2, 0, 109, -2, 4, -2, 4,
+ax_anim 2, 0, 108, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_5_1:
+ax_anim 1, 0, 114, 0, -2, 0, -2,
+ax_anim 2, 0, 114, 0, -3, 0, -3,
+ax_anim 4, 2, 114, 0, -4, 0, -4,
+ax_anim 2, 0, 114, 0, -3, 0, -3,
+ax_anim 1, 0, 112, 0, -2, 0, -2,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 113, 1, 0, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim_terminator
+sJigglypuffAnims_5_2:
+ax_anim 1, 0, 117, 0, -2, 0, -2,
+ax_anim 2, 0, 117, 0, -3, 0, -3,
+ax_anim 4, 2, 117, 0, -4, 0, -4,
+ax_anim 2, 0, 117, 0, -3, 0, -3,
+ax_anim 1, 0, 115, 0, -2, 0, -2,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 1, 116, 1, -1, 1, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim_terminator
+sJigglypuffAnims_5_3:
+ax_anim 1, 0, 120, 0, -2, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 4, 2, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 0, 1, 0, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 1, 0, 1,
+ax_anim_terminator
+sJigglypuffAnims_5_4:
+ax_anim 1, 0, 123, 0, -2, 0, -2,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 4, 2, 123, 0, -4, 0, -4,
+ax_anim 2, 0, 123, 0, -3, 0, -3,
+ax_anim 1, 0, 121, 0, -2, 0, -2,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 1, 122, 1, 1, 1, 1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim_terminator
+sJigglypuffAnims_5_5:
+ax_anim 1, 0, 126, 0, -2, 0, -2,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 4, 2, 126, 0, -4, 0, -4,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 1, 0, 124, 0, -1, 0, -2,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 125, 1, 0, 1, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, 0, 1, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, 0, 1, 0,
+ax_anim_terminator
+sJigglypuffAnims_5_6:
+ax_anim 1, 0, 129, 0, -2, 0, -2,
+ax_anim 2, 0, 129, 0, -3, 0, -3,
+ax_anim 4, 2, 129, 0, -4, 0, -4,
+ax_anim 2, 0, 129, 0, -3, 0, -3,
+ax_anim 1, 0, 127, 0, -2, 0, -2,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 1, 128, -1, 1, -1, 1,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, -1, 1, -1, 1,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, -1, 1, -1, 1,
+ax_anim_terminator
+sJigglypuffAnims_5_7:
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -3, 0, 0,
+ax_anim 4, 2, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -3, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 1, 131, 0, 1, 0, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 1, 0, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 1, 0, 1,
+ax_anim_terminator
+sJigglypuffAnims_5_8:
+ax_anim 1, 0, 135, 0, -2, 0, -2,
+ax_anim 2, 0, 135, 0, -3, 0, -3,
+ax_anim 4, 2, 135, 0, -4, 0, -4,
+ax_anim 2, 0, 135, 0, -3, 0, -3,
+ax_anim 1, 0, 133, 0, -2, 0, -2,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 1, 134, -1, -1, -1, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, -1, -1, -1, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_6_1:
+ax_anim 35, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sJigglypuffAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sJigglypuffAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sJigglypuffAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sJigglypuffAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sJigglypuffAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sJigglypuffAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sJigglypuffAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_8_1:
+ax_anim 25, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim 15, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim 15, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_8_2:
+ax_anim 25, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 15, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 15, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_8_3:
+ax_anim 25, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim 15, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim 15, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_8_4:
+ax_anim 25, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 15, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 15, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_8_5:
+ax_anim 25, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim 15, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim 15, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_8_6:
+ax_anim 25, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, -1, 0, 0,
+ax_anim 15, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, -1, 0, 0,
+ax_anim 15, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_8_7:
+ax_anim 25, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, -1, 0, 0,
+ax_anim 15, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, -1, 0, 0,
+ax_anim 15, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_8_8:
+ax_anim 25, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim 15, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim 15, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 16, 7, 16,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 16, -7, 16,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 19, 3, 19, 3,
+ax_anim 2, 0, 164, 23, 10, 23, 10,
+ax_anim 3, 0, 165, 19, 17, 19, 17,
+ax_anim 2, 3, 166, 11, 19, 11, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 18, -5, 18, -5,
+ax_anim 3, 0, 164, 21, -2, 21, -2,
+ax_anim 2, 3, 165, 18, 4, 18, 4,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 2, 4, 2,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 21, -25, 21, -25,
+ax_anim 2, 3, 164, 22, -15, 22, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -21, -7, -21,
+ax_anim 3, 0, 162, 0, -26, 0, -22,
+ax_anim 2, 3, 163, 7, -21, 7, -21,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -21, -25, -21, -25,
+ax_anim 2, 3, 168, -22, -15, -22, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -18, -5, -18, -5,
+ax_anim 3, 0, 168, -21, -2, -21, -2,
+ax_anim 2, 3, 167, -18, 4, -18, 4,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 2, -4, 2,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -19, 3, -19, 3,
+ax_anim 2, 0, 168, -23, 10, -23, 10,
+ax_anim 3, 0, 167, -19, 17, -19, 17,
+ax_anim 2, 3, 166, -11, 19, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -24, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -24, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -24, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -24, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJigglypuffAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sJigglypuffGfx1:
+.incbin "baserom.gba", 0x6B25E0, 0x200
+sJigglypuffSprites1:
+ax_sprite sJigglypuffGfx1, 0x200
+ax_sprite_terminator
+sJigglypuffGfx2:
+.incbin "baserom.gba", 0x6B27F0, 0x200
+sJigglypuffSprites2:
+ax_sprite sJigglypuffGfx2, 0x200
+ax_sprite_terminator
+sJigglypuffGfx3:
+.incbin "baserom.gba", 0x6B2A00, 0x200
+sJigglypuffSprites3:
+ax_sprite sJigglypuffGfx3, 0x200
+ax_sprite_terminator
+sJigglypuffGfx4:
+.incbin "baserom.gba", 0x6B2C10, 0x200
+sJigglypuffSprites4:
+ax_sprite sJigglypuffGfx4, 0x200
+ax_sprite_terminator
+sJigglypuffGfx5:
+.incbin "baserom.gba", 0x6B2E20, 0x200
+sJigglypuffSprites5:
+ax_sprite sJigglypuffGfx5, 0x200
+ax_sprite_terminator
+sJigglypuffGfx6:
+.incbin "baserom.gba", 0x6B3030, 0x200
+sJigglypuffSprites6:
+ax_sprite sJigglypuffGfx6, 0x200
+ax_sprite_terminator
+sJigglypuffGfx7:
+.incbin "baserom.gba", 0x6B3240, 0x200
+sJigglypuffSprites7:
+ax_sprite sJigglypuffGfx7, 0x200
+ax_sprite_terminator
+sJigglypuffGfx8:
+.incbin "baserom.gba", 0x6B3450, 0x200
+sJigglypuffSprites8:
+ax_sprite sJigglypuffGfx8, 0x200
+ax_sprite_terminator
+sJigglypuffGfx9:
+.incbin "baserom.gba", 0x6B3660, 0x200
+sJigglypuffSprites9:
+ax_sprite sJigglypuffGfx9, 0x200
+ax_sprite_terminator
+sJigglypuffGfx10:
+.incbin "baserom.gba", 0x6B3870, 0x200
+sJigglypuffSprites10:
+ax_sprite sJigglypuffGfx10, 0x200
+ax_sprite_terminator
+sJigglypuffGfx11:
+.incbin "baserom.gba", 0x6B3A80, 0x200
+sJigglypuffSprites11:
+ax_sprite sJigglypuffGfx11, 0x200
+ax_sprite_terminator
+sJigglypuffGfx12:
+.incbin "baserom.gba", 0x6B3C90, 0x200
+sJigglypuffSprites12:
+ax_sprite sJigglypuffGfx12, 0x200
+ax_sprite_terminator
+sJigglypuffGfx13:
+.incbin "baserom.gba", 0x6B3EA0, 0x200
+sJigglypuffSprites13:
+ax_sprite sJigglypuffGfx13, 0x200
+ax_sprite_terminator
+sJigglypuffGfx14:
+.incbin "baserom.gba", 0x6B40B0, 0x200
+sJigglypuffSprites14:
+ax_sprite sJigglypuffGfx14, 0x200
+ax_sprite_terminator
+sJigglypuffGfx15:
+.incbin "baserom.gba", 0x6B42C0, 0x200
+sJigglypuffSprites15:
+ax_sprite sJigglypuffGfx15, 0x200
+ax_sprite_terminator
+sJigglypuffGfx16:
+.incbin "baserom.gba", 0x6B44D0, 0x60
+sJigglypuffGfx16_1:
+.incbin "baserom.gba", 0x6B4530, 0x60
+sJigglypuffGfx16_2:
+.incbin "baserom.gba", 0x6B4590, 0x60
+sJigglypuffSprites16:
+ax_sprite sJigglypuffGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJigglypuffGfx17:
+.incbin "baserom.gba", 0x6B4628, 0x60
+sJigglypuffGfx17_1:
+.incbin "baserom.gba", 0x6B4688, 0x60
+sJigglypuffGfx17_2:
+.incbin "baserom.gba", 0x6B46E8, 0x60
+sJigglypuffSprites17:
+ax_sprite sJigglypuffGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJigglypuffGfx18:
+.incbin "baserom.gba", 0x6B4780, 0x60
+sJigglypuffGfx18_1:
+.incbin "baserom.gba", 0x6B47E0, 0x60
+sJigglypuffGfx18_2:
+.incbin "baserom.gba", 0x6B4840, 0x60
+sJigglypuffSprites18:
+ax_sprite sJigglypuffGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJigglypuffGfx19:
+.incbin "baserom.gba", 0x6B48D8, 0x60
+sJigglypuffGfx19_1:
+.incbin "baserom.gba", 0x6B4938, 0x60
+sJigglypuffGfx19_2:
+.incbin "baserom.gba", 0x6B4998, 0x60
+sJigglypuffGfx19_3:
+.incbin "baserom.gba", 0x6B49F8, 0x20
+sJigglypuffSprites19:
+ax_sprite sJigglypuffGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJigglypuffGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJigglypuffGfx20:
+.incbin "baserom.gba", 0x6B4A60, 0x60
+sJigglypuffGfx20_1:
+.incbin "baserom.gba", 0x6B4AC0, 0x60
+sJigglypuffGfx20_2:
+.incbin "baserom.gba", 0x6B4B20, 0x60
+sJigglypuffSprites20:
+ax_sprite sJigglypuffGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJigglypuffGfx21:
+.incbin "baserom.gba", 0x6B4BB8, 0x60
+sJigglypuffGfx21_1:
+.incbin "baserom.gba", 0x6B4C18, 0x60
+sJigglypuffGfx21_2:
+.incbin "baserom.gba", 0x6B4C78, 0x60
+sJigglypuffGfx21_3:
+.incbin "baserom.gba", 0x6B4CD8, 0x60
+sJigglypuffSprites21:
+ax_sprite sJigglypuffGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJigglypuffGfx22:
+.incbin "baserom.gba", 0x6B4D80, 0x40
+sJigglypuffGfx22_1:
+.incbin "baserom.gba", 0x6B4DC0, 0x60
+sJigglypuffGfx22_2:
+.incbin "baserom.gba", 0x6B4E20, 0x60
+sJigglypuffGfx22_3:
+.incbin "baserom.gba", 0x6B4E80, 0x40
+sJigglypuffSprites22:
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJigglypuffGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJigglypuffGfx23:
+.incbin "baserom.gba", 0x6B4F10, 0x40
+sJigglypuffGfx23_1:
+.incbin "baserom.gba", 0x6B4F50, 0x60
+sJigglypuffGfx23_2:
+.incbin "baserom.gba", 0x6B4FB0, 0x60
+sJigglypuffGfx23_3:
+.incbin "baserom.gba", 0x6B5010, 0x20
+sJigglypuffSprites23:
+ax_sprite sJigglypuffGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sJigglypuffGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJigglypuffGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJigglypuffGfx24:
+.incbin "baserom.gba", 0x6B5078, 0x60
+sJigglypuffGfx24_1:
+.incbin "baserom.gba", 0x6B50D8, 0x60
+sJigglypuffGfx24_2:
+.incbin "baserom.gba", 0x6B5138, 0x60
+sJigglypuffGfx24_3:
+.incbin "baserom.gba", 0x6B5198, 0x40
+sJigglypuffSprites24:
+ax_sprite sJigglypuffGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx24_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJigglypuffGfx25:
+.incbin "baserom.gba", 0x6B5220, 0x40
+sJigglypuffGfx25_1:
+.incbin "baserom.gba", 0x6B5260, 0x60
+sJigglypuffGfx25_2:
+.incbin "baserom.gba", 0x6B52C0, 0x60
+sJigglypuffSprites25:
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJigglypuffGfx26:
+.incbin "baserom.gba", 0x6B5360, 0x60
+sJigglypuffGfx26_1:
+.incbin "baserom.gba", 0x6B53C0, 0x60
+sJigglypuffGfx26_2:
+.incbin "baserom.gba", 0x6B5420, 0x60
+sJigglypuffSprites26:
+ax_sprite 0, 0x80
+ax_sprite sJigglypuffGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJigglypuffGfx27:
+.incbin "baserom.gba", 0x6B54C0, 0x60
+sJigglypuffGfx27_1:
+.incbin "baserom.gba", 0x6B5520, 0x60
+sJigglypuffGfx27_2:
+.incbin "baserom.gba", 0x6B5580, 0x60
+sJigglypuffSprites27:
+ax_sprite 0, 0x80
+ax_sprite sJigglypuffGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJigglypuffGfx28:
+.incbin "baserom.gba", 0x6B5620, 0x60
+sJigglypuffGfx28_1:
+.incbin "baserom.gba", 0x6B5680, 0x60
+sJigglypuffGfx28_2:
+.incbin "baserom.gba", 0x6B56E0, 0x40
+sJigglypuffSprites28:
+ax_sprite 0, 0x80
+ax_sprite sJigglypuffGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJigglypuffGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJigglypuffGfx29:
+.incbin "baserom.gba", 0x6B5760, 0x60
+sJigglypuffGfx29_1:
+.incbin "baserom.gba", 0x6B57C0, 0x60
+sJigglypuffGfx29_2:
+.incbin "baserom.gba", 0x6B5820, 0x60
+sJigglypuffSprites29:
+ax_sprite 0, 0x80
+ax_sprite sJigglypuffGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJigglypuffGfx30:
+.incbin "baserom.gba", 0x6B58C0, 0x60
+sJigglypuffGfx30_1:
+.incbin "baserom.gba", 0x6B5920, 0x60
+sJigglypuffGfx30_2:
+.incbin "baserom.gba", 0x6B5980, 0x60
+sJigglypuffSprites30:
+ax_sprite 0, 0x80
+ax_sprite sJigglypuffGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJigglypuffGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJigglypuffGfx31:
+.incbin "baserom.gba", 0x6B5A20, 0x200
+sJigglypuffSprites31:
+ax_sprite sJigglypuffGfx31, 0x200
+ax_sprite_terminator
+sJigglypuffGfx32:
+.incbin "baserom.gba", 0x6B5C30, 0x200
+sJigglypuffSprites32:
+ax_sprite sJigglypuffGfx32, 0x200
+ax_sprite_terminator
+sJigglypuffGfx33:
+.incbin "baserom.gba", 0x6B5E40, 0x200
+sJigglypuffSprites33:
+ax_sprite sJigglypuffGfx33, 0x200
+ax_sprite_terminator
+sJigglypuffGfx34:
+.incbin "baserom.gba", 0x6B6050, 0x200
+sJigglypuffSprites34:
+ax_sprite sJigglypuffGfx34, 0x200
+ax_sprite_terminator
+sJigglypuffGfx35:
+.incbin "baserom.gba", 0x6B6260, 0x200
+sJigglypuffSprites35:
+ax_sprite sJigglypuffGfx35, 0x200
+ax_sprite_terminator
+sJigglypuffGfx36:
+.incbin "baserom.gba", 0x6B6470, 0x200
+sJigglypuffSprites36:
+ax_sprite sJigglypuffGfx36, 0x200
+ax_sprite_terminator
+sJigglypuffGfx37:
+.incbin "baserom.gba", 0x6B6680, 0x200
+sJigglypuffSprites37:
+ax_sprite sJigglypuffGfx37, 0x200
+ax_sprite_terminator
+sAxPosesJigglypuff:
+.4byte sJigglypuffPose1
+.4byte sJigglypuffPose2
+.4byte sJigglypuffPose3
+.4byte sJigglypuffPose4
+.4byte sJigglypuffPose5
+.4byte sJigglypuffPose6
+.4byte sJigglypuffPose7
+.4byte sJigglypuffPose8
+.4byte sJigglypuffPose9
+.4byte sJigglypuffPose10
+.4byte sJigglypuffPose11
+.4byte sJigglypuffPose12
+.4byte sJigglypuffPose13
+.4byte sJigglypuffPose14
+.4byte sJigglypuffPose15
+.4byte sJigglypuffPose16
+.4byte sJigglypuffPose17
+.4byte sJigglypuffPose18
+.4byte sJigglypuffPose19
+.4byte sJigglypuffPose20
+.4byte sJigglypuffPose21
+.4byte sJigglypuffPose22
+.4byte sJigglypuffPose23
+.4byte sJigglypuffPose24
+.4byte sJigglypuffPose25
+.4byte sJigglypuffPose26
+.4byte sJigglypuffPose27
+.4byte sJigglypuffPose28
+.4byte sJigglypuffPose29
+.4byte sJigglypuffPose30
+.4byte sJigglypuffPose31
+.4byte sJigglypuffPose32
+.4byte sJigglypuffPose33
+.4byte sJigglypuffPose34
+.4byte sJigglypuffPose35
+.4byte sJigglypuffPose36
+.4byte sJigglypuffPose37
+.4byte sJigglypuffPose38
+.4byte sJigglypuffPose39
+.4byte sJigglypuffPose40
+.4byte sJigglypuffPose41
+.4byte sJigglypuffPose42
+.4byte sJigglypuffPose43
+.4byte sJigglypuffPose44
+.4byte sJigglypuffPose45
+.4byte sJigglypuffPose46
+.4byte sJigglypuffPose47
+.4byte sJigglypuffPose48
+.4byte sJigglypuffPose49
+.4byte sJigglypuffPose50
+.4byte sJigglypuffPose51
+.4byte sJigglypuffPose52
+.4byte sJigglypuffPose53
+.4byte sJigglypuffPose54
+.4byte sJigglypuffPose55
+.4byte sJigglypuffPose56
+.4byte sJigglypuffPose57
+.4byte sJigglypuffPose58
+.4byte sJigglypuffPose59
+.4byte sJigglypuffPose60
+.4byte sJigglypuffPose61
+.4byte sJigglypuffPose62
+.4byte sJigglypuffPose63
+.4byte sJigglypuffPose64
+.4byte sJigglypuffPose65
+.4byte sJigglypuffPose66
+.4byte sJigglypuffPose67
+.4byte sJigglypuffPose68
+.4byte sJigglypuffPose69
+.4byte sJigglypuffPose70
+.4byte sJigglypuffPose71
+.4byte sJigglypuffPose72
+.4byte sJigglypuffPose73
+.4byte sJigglypuffPose74
+.4byte sJigglypuffPose75
+.4byte sJigglypuffPose76
+.4byte sJigglypuffPose77
+.4byte sJigglypuffPose78
+.4byte sJigglypuffPose79
+.4byte sJigglypuffPose80
+.4byte sJigglypuffPose81
+.4byte sJigglypuffPose82
+.4byte sJigglypuffPose83
+.4byte sJigglypuffPose84
+.4byte sJigglypuffPose85
+.4byte sJigglypuffPose86
+.4byte sJigglypuffPose87
+.4byte sJigglypuffPose88
+.4byte sJigglypuffPose89
+.4byte sJigglypuffPose90
+.4byte sJigglypuffPose91
+.4byte sJigglypuffPose92
+.4byte sJigglypuffPose93
+.4byte sJigglypuffPose94
+.4byte sJigglypuffPose95
+.4byte sJigglypuffPose96
+.4byte sJigglypuffPose97
+.4byte sJigglypuffPose98
+.4byte sJigglypuffPose99
+.4byte sJigglypuffPose100
+.4byte sJigglypuffPose101
+.4byte sJigglypuffPose102
+.4byte sJigglypuffPose103
+.4byte sJigglypuffPose104
+.4byte sJigglypuffPose105
+.4byte sJigglypuffPose106
+.4byte sJigglypuffPose107
+.4byte sJigglypuffPose108
+.4byte sJigglypuffPose109
+.4byte sJigglypuffPose110
+.4byte sJigglypuffPose111
+.4byte sJigglypuffPose112
+.4byte sJigglypuffPose113
+.4byte sJigglypuffPose114
+.4byte sJigglypuffPose115
+.4byte sJigglypuffPose116
+.4byte sJigglypuffPose117
+.4byte sJigglypuffPose118
+.4byte sJigglypuffPose119
+.4byte sJigglypuffPose120
+.4byte sJigglypuffPose121
+.4byte sJigglypuffPose122
+.4byte sJigglypuffPose123
+.4byte sJigglypuffPose124
+.4byte sJigglypuffPose125
+.4byte sJigglypuffPose126
+.4byte sJigglypuffPose127
+.4byte sJigglypuffPose128
+.4byte sJigglypuffPose129
+.4byte sJigglypuffPose130
+.4byte sJigglypuffPose131
+.4byte sJigglypuffPose132
+.4byte sJigglypuffPose133
+.4byte sJigglypuffPose134
+.4byte sJigglypuffPose135
+.4byte sJigglypuffPose136
+.4byte sJigglypuffPose137
+.4byte sJigglypuffPose138
+.4byte sJigglypuffPose139
+.4byte sJigglypuffPose140
+.4byte sJigglypuffPose141
+.4byte sJigglypuffPose142
+.4byte sJigglypuffPose143
+.4byte sJigglypuffPose144
+.4byte sJigglypuffPose145
+.4byte sJigglypuffPose146
+.4byte sJigglypuffPose147
+.4byte sJigglypuffPose148
+.4byte sJigglypuffPose149
+.4byte sJigglypuffPose150
+.4byte sJigglypuffPose151
+.4byte sJigglypuffPose152
+.4byte sJigglypuffPose153
+.4byte sJigglypuffPose154
+.4byte sJigglypuffPose155
+.4byte sJigglypuffPose156
+.4byte sJigglypuffPose157
+.4byte sJigglypuffPose158
+.4byte sJigglypuffPose159
+.4byte sJigglypuffPose160
+.4byte sJigglypuffPose161
+.4byte sJigglypuffPose162
+.4byte sJigglypuffPose163
+.4byte sJigglypuffPose164
+.4byte sJigglypuffPose165
+.4byte sJigglypuffPose166
+.4byte sJigglypuffPose167
+.4byte sJigglypuffPose168
+.4byte sJigglypuffPose169
+.4byte sJigglypuffPose170
+.4byte sJigglypuffPose171
+.4byte sJigglypuffPose172
+.4byte sJigglypuffPose173
+.4byte sJigglypuffPose174
+.4byte sJigglypuffPose175
+.4byte sJigglypuffPose176
+.4byte sJigglypuffPose177
+.4byte sJigglypuffPose178
+.4byte sJigglypuffPose179
+.4byte sJigglypuffPose180
+.4byte sJigglypuffPose181
+.4byte sJigglypuffPose182
+.4byte sJigglypuffPose183
+.4byte sJigglypuffPose184
+.4byte sJigglypuffPose185
+.4byte sJigglypuffPose186
+.4byte sJigglypuffPose187
+.4byte sJigglypuffPose188
+.4byte sJigglypuffPose189
+.4byte sJigglypuffPose190
+.4byte sJigglypuffPose191
+.4byte sJigglypuffPose192
+.4byte sJigglypuffPose193
+.4byte sJigglypuffPose194
+.4byte sJigglypuffPose195
+.4byte sJigglypuffPose196
+.4byte sJigglypuffPose197
+.4byte sJigglypuffPose198
+.4byte sJigglypuffPose199
+.4byte sJigglypuffPose200
+.4byte sJigglypuffPose201
+.4byte sJigglypuffPose202
+.4byte sJigglypuffPose203
+.4byte sJigglypuffPose204
+.4byte sJigglypuffPose205
+.4byte sJigglypuffPose206
+.4byte sJigglypuffPose207
+.4byte sJigglypuffPose208
+.4byte sJigglypuffPose209
+.4byte sJigglypuffPose210
+.4byte sJigglypuffPose211
+.4byte sJigglypuffPose212
+.4byte sJigglypuffPose213
+.4byte sJigglypuffPose214
+.4byte sJigglypuffPose215
+.4byte sJigglypuffPose216
+.4byte sJigglypuffPose217
+.4byte sJigglypuffPose218
+sAxPositionsJigglypuff:
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,  -11, 	  -6,  -10, 	   6,  -10, 	   0,  -13
+.2byte    0,   -1, 	  -7,   -1, 	   7,   -1, 	   0,   -4
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+.2byte    4,  -10, 	   6,  -10, 	  -2,   -8, 	   1,  -13
+.2byte    4,   -1, 	   6,   -2, 	  -3,    0, 	   1,   -5
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    6,  -10, 	   2,   -9, 	   1,   -8, 	   0,  -12
+.2byte    5,   -1, 	   1,   -2, 	  -1,   -1, 	  -1,   -5
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    3,  -14, 	  -6,  -13, 	   7,  -12, 	   0,  -13
+.2byte    4,   -7, 	  -5,   -7, 	   8,   -5, 	   1,   -6
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -15, 	   6,  -12, 	  -6,  -12, 	   0,  -13
+.2byte    0,   -6, 	   7,   -5, 	  -7,   -5, 	   0,   -7
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -3,  -14, 	   6,  -13, 	  -7,  -12, 	   0,  -13
+.2byte   -4,   -7, 	   5,   -7, 	  -8,   -5, 	  -1,   -6
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -6,  -10, 	  -2,   -9, 	  -1,   -8, 	   0,  -12
+.2byte   -5,   -1, 	  -1,   -2, 	   1,   -1, 	   1,   -5
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -4,  -10, 	  -6,  -10, 	   2,   -8, 	  -1,  -13
+.2byte   -4,   -1, 	  -6,   -2, 	   3,    0, 	  -1,   -5
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -6,   -6, 	   6,   -6, 	   0,   -9
+.2byte    0,   -4, 	  -8,   -8, 	   8,   -8, 	   0,   -8
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+.2byte    4,   -7, 	   6,   -7, 	  -2,   -5, 	   1,  -10
+.2byte    3,   -4, 	   9,   -8, 	  -1,   -6, 	   0,   -9
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    6,   -7, 	   2,   -6, 	   1,   -5, 	   0,   -9
+.2byte    4,   -5, 	   3,   -8, 	   1,   -6, 	   1,   -9
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    3,  -11, 	  -6,  -10, 	   7,   -9, 	   0,  -10
+.2byte    3,   -8, 	  -3,  -12, 	   8,   -6, 	   1,  -10
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -12, 	   6,   -9, 	  -6,   -9, 	   0,  -10
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,  -12
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -3,  -11, 	   6,  -10, 	  -7,   -9, 	   0,  -10
+.2byte   -3,   -8, 	   3,  -12, 	  -8,   -6, 	  -1,  -10
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -2,   -6, 	  -1,   -5, 	   0,   -9
+.2byte   -4,   -5, 	  -3,   -8, 	  -1,   -6, 	  -1,   -9
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -4,   -7, 	  -6,   -7, 	   2,   -5, 	  -1,  -10
+.2byte   -3,   -4, 	  -9,   -8, 	   1,   -6, 	   0,   -9
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,  -11, 	  -6,  -10, 	   6,  -10, 	   0,  -13
+.2byte    0,   -1, 	  -7,   -1, 	   7,   -1, 	   0,   -4
+.2byte    0,    0, 	  -8,   -4, 	   8,   -4, 	   0,   -4
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+.2byte    4,  -10, 	   6,  -10, 	  -2,   -8, 	   1,  -13
+.2byte    4,   -1, 	   6,   -2, 	  -3,    0, 	   1,   -5
+.2byte    3,   -1, 	   9,   -5, 	  -1,   -3, 	   0,   -6
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    6,  -10, 	   2,   -9, 	   1,   -8, 	   0,  -12
+.2byte    5,   -1, 	   1,   -2, 	  -1,   -1, 	  -1,   -5
+.2byte    3,   -3, 	   2,   -6, 	   0,   -4, 	   0,   -7
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    3,  -14, 	  -6,  -13, 	   7,  -12, 	   0,  -13
+.2byte    4,   -7, 	  -5,   -7, 	   8,   -5, 	   1,   -6
+.2byte    2,   -5, 	  -4,   -9, 	   7,   -3, 	   0,   -7
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -15, 	   6,  -12, 	  -6,  -12, 	   0,  -13
+.2byte    0,   -6, 	   7,   -5, 	  -7,   -5, 	   0,   -7
+.2byte    0,   -6, 	   7,   -7, 	  -7,   -7, 	   0,   -9
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -3,  -14, 	   6,  -13, 	  -7,  -12, 	   0,  -13
+.2byte   -4,   -7, 	   5,   -7, 	  -8,   -5, 	  -1,   -6
+.2byte   -2,   -5, 	   4,   -9, 	  -7,   -3, 	   0,   -7
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -6,  -10, 	  -2,   -9, 	  -1,   -8, 	   0,  -12
+.2byte   -5,   -1, 	  -1,   -2, 	   1,   -1, 	   1,   -5
+.2byte   -4,   -3, 	  -3,   -6, 	  -1,   -4, 	  -1,   -7
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -4,  -10, 	  -6,  -10, 	   2,   -8, 	  -1,  -13
+.2byte   -4,   -1, 	  -6,   -2, 	   3,    0, 	  -1,   -5
+.2byte   -3,   -1, 	  -9,   -5, 	   1,   -3, 	   0,   -6
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -8
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -3, 	   0,   -6
+.2byte    0,   -7, 	  -6,   -6, 	   6,   -6, 	   0,   -9
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+.2byte    3,   -5, 	   8,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    4,   -2, 	   6,   -3, 	  -3,   -1, 	   1,   -6
+.2byte    3,   -7, 	   5,   -7, 	  -3,   -5, 	   0,  -10
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    6,   -6, 	   3,   -7, 	   1,   -5, 	   0,   -8
+.2byte    5,   -2, 	   1,   -3, 	  -1,   -2, 	  -1,   -6
+.2byte    6,   -7, 	   2,   -6, 	   1,   -5, 	   0,   -9
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    3,   -9, 	  -4,  -10, 	   8,   -8, 	   0,   -9
+.2byte    4,   -7, 	  -5,   -7, 	   8,   -5, 	   1,   -6
+.2byte    3,  -10, 	  -6,   -9, 	   7,   -8, 	   0,   -9
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -12, 	   8,  -11, 	  -8,  -11, 	   0,  -10
+.2byte    0,   -6, 	   7,   -5, 	  -7,   -5, 	   0,   -7
+.2byte    0,  -10, 	   6,   -7, 	  -6,   -7, 	   0,   -8
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   4,  -10, 	  -8,   -8, 	   0,   -9
+.2byte   -4,   -7, 	   5,   -7, 	  -8,   -5, 	  -1,   -6
+.2byte   -3,  -10, 	   6,   -9, 	  -7,   -8, 	   0,   -9
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -6, 	  -3,   -7, 	  -1,   -5, 	   0,   -8
+.2byte   -5,   -2, 	  -1,   -3, 	   1,   -2, 	   1,   -6
+.2byte   -6,   -7, 	  -2,   -6, 	  -1,   -5, 	   0,   -9
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -3,   -5, 	  -8,   -7, 	   2,   -5, 	   0,   -9
+.2byte   -4,   -2, 	  -6,   -3, 	   3,   -1, 	  -1,   -6
+.2byte   -4,   -7, 	  -6,   -7, 	   2,   -5, 	  -1,  -10
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte    0,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -8
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+.2byte    4,   -3, 	   7,   -5, 	  -1,   -3, 	   0,   -6
+.2byte    3,   -5, 	   8,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    5,   -3, 	   4,   -4, 	   2,   -2, 	   0,   -6
+.2byte    6,   -6, 	   3,   -7, 	   1,   -5, 	   0,   -8
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    3,   -5, 	  -4,   -8, 	   6,   -5, 	   0,   -7
+.2byte    3,  -10, 	  -4,  -11, 	   8,   -9, 	   0,  -10
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,   -6, 	   6,   -7, 	  -6,   -7, 	   0,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -8,  -11, 	   0,  -10
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -3,   -5, 	   4,   -8, 	  -6,   -5, 	   0,   -7
+.2byte   -3,  -10, 	   4,  -11, 	  -8,   -9, 	   0,  -10
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -5,   -3, 	  -4,   -4, 	  -2,   -2, 	   0,   -6
+.2byte   -6,   -6, 	  -3,   -7, 	  -1,   -5, 	   0,   -8
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -4,   -3, 	  -7,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -3,   -5, 	  -8,   -7, 	   2,   -5, 	   0,   -9
+.2byte   -2,    0, 	  -6,   -3, 	   4,   -1, 	   1,   -6
+.2byte   -2,    0, 	  -6,   -2, 	   4,    0, 	   1,   -5
+.2byte    0,   -2, 	  -9,   -3, 	   9,   -3, 	   0,   -6
+.2byte    1,   -2, 	   8,   -6, 	  -9,   -3, 	  -1,   -6
+.2byte    4,   -2, 	   2,   -3, 	   0,   -1, 	  -2,   -5
+.2byte    4,   -4, 	  -5,   -6, 	   8,   -1, 	  -1,   -4
+.2byte    0,   -2, 	   9,   -1, 	  -9,   -1, 	   0,   -3
+.2byte   -5,   -4, 	   4,   -6, 	  -9,   -1, 	   0,   -4
+.2byte   -5,   -2, 	  -3,   -3, 	  -1,   -1, 	   1,   -5
+.2byte   -2,   -2, 	  -9,   -6, 	   8,   -3, 	   0,   -6
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -6,   -6, 	   6,   -6, 	   0,   -9
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+.2byte    4,   -6, 	   6,   -6, 	  -2,   -4, 	   1,   -9
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    6,   -6, 	   2,   -5, 	   1,   -4, 	   0,   -8
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    3,  -10, 	  -6,   -9, 	   7,   -8, 	   0,   -9
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -11, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -9, 	  -8,   -8, 	  -1,   -9
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -6, 	  -2,   -5, 	  -1,   -4, 	   0,   -8
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -4,   -6, 	  -6,   -6, 	   2,   -4, 	  -1,   -9
+.2byte    0,    0, 	  -8,   -4, 	   8,   -4, 	   0,   -4
+.2byte   -3,   -1, 	  -9,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -4,   -3, 	  -3,   -6, 	  -1,   -4, 	  -1,   -7
+.2byte   -2,   -5, 	   4,   -9, 	  -7,   -3, 	   0,   -7
+.2byte    0,   -6, 	   7,   -7, 	  -7,   -7, 	   0,   -9
+.2byte    2,   -5, 	  -4,   -9, 	   7,   -3, 	   0,   -7
+.2byte    3,   -3, 	   2,   -6, 	   0,   -4, 	   0,   -7
+.2byte    3,   -1, 	   9,   -5, 	  -1,   -3, 	   0,   -6
+.2byte    0,   -6, 	  -7,   -5, 	   7,   -5, 	   0,   -8
+.2byte    3,   -5, 	   8,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    6,   -6, 	   3,   -7, 	   1,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -4,  -11, 	   8,   -9, 	   0,  -10
+.2byte    0,  -12, 	   8,  -11, 	  -8,  -11, 	   0,  -10
+.2byte   -3,  -10, 	   4,  -11, 	  -8,   -9, 	   0,  -10
+.2byte   -6,   -6, 	  -3,   -7, 	  -1,   -5, 	   0,   -8
+.2byte   -3,   -5, 	  -8,   -7, 	   2,   -5, 	   0,   -9
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -6,   -6, 	   6,   -6, 	   0,   -9
+.2byte    0,   -3, 	  -7,   -3, 	   7,   -3, 	   0,   -6
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+.2byte    4,   -6, 	   6,   -6, 	  -2,   -4, 	   1,   -9
+.2byte    4,   -3, 	   6,   -4, 	  -3,   -2, 	   1,   -7
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    6,   -7, 	   2,   -6, 	   1,   -5, 	   0,   -9
+.2byte    5,   -3, 	   1,   -4, 	  -1,   -3, 	  -1,   -7
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    3,  -10, 	  -6,   -9, 	   7,   -8, 	   0,   -9
+.2byte    3,   -9, 	  -6,   -9, 	   7,   -7, 	   0,   -8
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -11, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte    0,   -7, 	   7,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -3,  -10, 	   6,   -9, 	  -7,   -8, 	   0,   -9
+.2byte   -3,   -9, 	   6,   -9, 	  -7,   -7, 	   0,   -8
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -2,   -6, 	  -1,   -5, 	   0,   -9
+.2byte   -5,   -3, 	  -1,   -4, 	   1,   -3, 	   1,   -7
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -4,   -6, 	  -6,   -6, 	   2,   -4, 	  -1,   -9
+.2byte   -4,   -3, 	  -6,   -4, 	   3,   -2, 	  -1,   -7
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte   -4,   -3, 	  -7,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -5,   -3, 	  -4,   -4, 	  -2,   -2, 	   0,   -6
+.2byte   -3,   -5, 	   4,   -8, 	  -6,   -5, 	   0,   -7
+.2byte    0,   -6, 	   6,   -7, 	  -6,   -7, 	   0,   -7
+.2byte    3,   -5, 	  -4,   -8, 	   6,   -5, 	   0,   -7
+.2byte    5,   -3, 	   4,   -4, 	   2,   -2, 	   0,   -6
+.2byte    4,   -3, 	   7,   -5, 	  -1,   -3, 	   0,   -6
+.2byte    0,   -4, 	  -5,   -3, 	   5,   -3, 	   0,   -7
+.2byte   -4,   -4, 	  -6,   -5, 	   3,   -3, 	  -1,   -7
+.2byte   -6,   -4, 	  -2,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -3,   -8, 	   5,   -8, 	  -7,   -6, 	   0,   -7
+.2byte    0,   -9, 	   5,   -6, 	  -5,   -6, 	   0,   -8
+.2byte    3,   -8, 	  -5,   -8, 	   7,   -6, 	   0,   -7
+.2byte    6,   -4, 	   2,   -4, 	   0,   -3, 	   0,   -7
+.2byte    4,   -4, 	   6,   -5, 	  -3,   -3, 	   1,   -7
+sJigglypuffAnimTable1:
+.4byte sJigglypuffAnims_1_1
+.4byte sJigglypuffAnims_1_2
+.4byte sJigglypuffAnims_1_3
+.4byte sJigglypuffAnims_1_4
+.4byte sJigglypuffAnims_1_5
+.4byte sJigglypuffAnims_1_6
+.4byte sJigglypuffAnims_1_7
+.4byte sJigglypuffAnims_1_8
+sJigglypuffAnimTable2:
+.4byte sJigglypuffAnims_2_1
+.4byte sJigglypuffAnims_2_2
+.4byte sJigglypuffAnims_2_3
+.4byte sJigglypuffAnims_2_4
+.4byte sJigglypuffAnims_2_5
+.4byte sJigglypuffAnims_2_6
+.4byte sJigglypuffAnims_2_7
+.4byte sJigglypuffAnims_2_8
+sJigglypuffAnimTable3:
+.4byte sJigglypuffAnims_3_1
+.4byte sJigglypuffAnims_3_2
+.4byte sJigglypuffAnims_3_3
+.4byte sJigglypuffAnims_3_4
+.4byte sJigglypuffAnims_3_5
+.4byte sJigglypuffAnims_3_6
+.4byte sJigglypuffAnims_3_7
+.4byte sJigglypuffAnims_3_8
+sJigglypuffAnimTable4:
+.4byte sJigglypuffAnims_4_1
+.4byte sJigglypuffAnims_4_2
+.4byte sJigglypuffAnims_4_3
+.4byte sJigglypuffAnims_4_4
+.4byte sJigglypuffAnims_4_5
+.4byte sJigglypuffAnims_4_6
+.4byte sJigglypuffAnims_4_7
+.4byte sJigglypuffAnims_4_8
+sJigglypuffAnimTable5:
+.4byte sJigglypuffAnims_5_1
+.4byte sJigglypuffAnims_5_2
+.4byte sJigglypuffAnims_5_3
+.4byte sJigglypuffAnims_5_4
+.4byte sJigglypuffAnims_5_5
+.4byte sJigglypuffAnims_5_6
+.4byte sJigglypuffAnims_5_7
+.4byte sJigglypuffAnims_5_8
+sJigglypuffAnimTable6:
+.4byte sJigglypuffAnims_6_1
+.4byte sJigglypuffAnims_6_1
+.4byte sJigglypuffAnims_6_1
+.4byte sJigglypuffAnims_6_1
+.4byte sJigglypuffAnims_6_1
+.4byte sJigglypuffAnims_6_1
+.4byte sJigglypuffAnims_6_1
+.4byte sJigglypuffAnims_6_1
+sJigglypuffAnimTable7:
+.4byte sJigglypuffAnims_7_1
+.4byte sJigglypuffAnims_7_2
+.4byte sJigglypuffAnims_7_3
+.4byte sJigglypuffAnims_7_4
+.4byte sJigglypuffAnims_7_5
+.4byte sJigglypuffAnims_7_6
+.4byte sJigglypuffAnims_7_7
+.4byte sJigglypuffAnims_7_8
+sJigglypuffAnimTable8:
+.4byte sJigglypuffAnims_8_1
+.4byte sJigglypuffAnims_8_2
+.4byte sJigglypuffAnims_8_3
+.4byte sJigglypuffAnims_8_4
+.4byte sJigglypuffAnims_8_5
+.4byte sJigglypuffAnims_8_6
+.4byte sJigglypuffAnims_8_7
+.4byte sJigglypuffAnims_8_8
+sJigglypuffAnimTable9:
+.4byte sJigglypuffAnims_9_1
+.4byte sJigglypuffAnims_9_2
+.4byte sJigglypuffAnims_9_3
+.4byte sJigglypuffAnims_9_4
+.4byte sJigglypuffAnims_9_5
+.4byte sJigglypuffAnims_9_6
+.4byte sJigglypuffAnims_9_7
+.4byte sJigglypuffAnims_9_8
+sJigglypuffAnimTable10:
+.4byte sJigglypuffAnims_10_1
+.4byte sJigglypuffAnims_10_2
+.4byte sJigglypuffAnims_10_3
+.4byte sJigglypuffAnims_10_4
+.4byte sJigglypuffAnims_10_5
+.4byte sJigglypuffAnims_10_6
+.4byte sJigglypuffAnims_10_7
+.4byte sJigglypuffAnims_10_8
+sJigglypuffAnimTable11:
+.4byte sJigglypuffAnims_11_1
+.4byte sJigglypuffAnims_11_2
+.4byte sJigglypuffAnims_11_3
+.4byte sJigglypuffAnims_11_4
+.4byte sJigglypuffAnims_11_5
+.4byte sJigglypuffAnims_11_6
+.4byte sJigglypuffAnims_11_7
+.4byte sJigglypuffAnims_11_8
+sJigglypuffAnimTable12:
+.4byte sJigglypuffAnims_12_1
+.4byte sJigglypuffAnims_12_2
+.4byte sJigglypuffAnims_12_3
+.4byte sJigglypuffAnims_12_4
+.4byte sJigglypuffAnims_12_5
+.4byte sJigglypuffAnims_12_6
+.4byte sJigglypuffAnims_12_7
+.4byte sJigglypuffAnims_12_8
+sJigglypuffAnimTable13:
+.4byte sJigglypuffAnims_13_1
+.4byte sJigglypuffAnims_13_2
+.4byte sJigglypuffAnims_13_3
+.4byte sJigglypuffAnims_13_4
+.4byte sJigglypuffAnims_13_5
+.4byte sJigglypuffAnims_13_6
+.4byte sJigglypuffAnims_13_7
+.4byte sJigglypuffAnims_13_8
+sAxAnimationsJigglypuff:
+.4byte sJigglypuffAnimTable1
+.4byte sJigglypuffAnimTable2
+.4byte sJigglypuffAnimTable3
+.4byte sJigglypuffAnimTable4
+.4byte sJigglypuffAnimTable5
+.4byte sJigglypuffAnimTable6
+.4byte sJigglypuffAnimTable7
+.4byte sJigglypuffAnimTable8
+.4byte sJigglypuffAnimTable9
+.4byte sJigglypuffAnimTable10
+.4byte sJigglypuffAnimTable11
+.4byte sJigglypuffAnimTable12
+.4byte sJigglypuffAnimTable13
+sAxSpritesJigglypuff:
+.4byte sJigglypuffSprites1
+.4byte sJigglypuffSprites2
+.4byte sJigglypuffSprites3
+.4byte sJigglypuffSprites4
+.4byte sJigglypuffSprites5
+.4byte sJigglypuffSprites6
+.4byte sJigglypuffSprites7
+.4byte sJigglypuffSprites8
+.4byte sJigglypuffSprites9
+.4byte sJigglypuffSprites10
+.4byte sJigglypuffSprites11
+.4byte sJigglypuffSprites12
+.4byte sJigglypuffSprites13
+.4byte sJigglypuffSprites14
+.4byte sJigglypuffSprites15
+.4byte sJigglypuffSprites16
+.4byte sJigglypuffSprites17
+.4byte sJigglypuffSprites18
+.4byte sJigglypuffSprites19
+.4byte sJigglypuffSprites20
+.4byte sJigglypuffSprites21
+.4byte sJigglypuffSprites22
+.4byte sJigglypuffSprites23
+.4byte sJigglypuffSprites24
+.4byte sJigglypuffSprites25
+.4byte sJigglypuffSprites26
+.4byte sJigglypuffSprites27
+.4byte sJigglypuffSprites28
+.4byte sJigglypuffSprites29
+.4byte sJigglypuffSprites30
+.4byte sJigglypuffSprites31
+.4byte sJigglypuffSprites32
+.4byte sJigglypuffSprites33
+.4byte sJigglypuffSprites34
+.4byte sJigglypuffSprites35
+.4byte sJigglypuffSprites36
+.4byte sJigglypuffSprites37
+sAxMainJigglypuff:
+ax_main sAxPosesJigglypuff, sAxAnimationsJigglypuff, 13, sAxSpritesJigglypuff, sAxPositionsJigglypuff

--- a/data/ax/jirachi.inc
+++ b/data/ax/jirachi.inc
@@ -1,0 +1,3113 @@
+.global gAxJirachi
+gAxJirachi:
+ax_siro sAxMainJirachi
+sJirachiPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose4:
+ax_pose 3, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose5:
+ax_pose 4, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose6:
+ax_pose 5, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose7:
+ax_pose 6, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose8:
+ax_pose 7, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose9:
+ax_pose 8, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose10:
+ax_pose 9, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose11:
+ax_pose 10, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose12:
+ax_pose 11, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose19:
+ax_pose 6, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose20:
+ax_pose 7, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose21:
+ax_pose 8, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose22:
+ax_pose 3, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose23:
+ax_pose 4, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose24:
+ax_pose 5, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose25:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose26:
+ax_pose 0, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose27:
+ax_pose 1, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose28:
+ax_pose 2, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose29:
+ax_pose 16, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose30:
+ax_pose 17, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose31:
+ax_pose 3, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose32:
+ax_pose 4, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose33:
+ax_pose 5, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose34:
+ax_pose 18, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose35:
+ax_pose 19, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose36:
+ax_pose 6, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose37:
+ax_pose 7, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose38:
+ax_pose 8, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose39:
+ax_pose 20, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sJirachiPose40:
+ax_pose 21, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose41:
+ax_pose 9, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose42:
+ax_pose 10, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose43:
+ax_pose 11, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose44:
+ax_pose 22, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose45:
+ax_pose 23, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose46:
+ax_pose 12, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose47:
+ax_pose 13, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose48:
+ax_pose 14, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose49:
+ax_pose 24, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose50:
+ax_pose 21, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose51:
+ax_pose 9, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose52:
+ax_pose 10, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose53:
+ax_pose 11, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose54:
+ax_pose 22, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose55:
+ax_pose 19, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose56:
+ax_pose 6, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose57:
+ax_pose 7, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose58:
+ax_pose 8, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose59:
+ax_pose 20, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sJirachiPose60:
+ax_pose 17, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose61:
+ax_pose 3, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose62:
+ax_pose 4, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose63:
+ax_pose 5, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose64:
+ax_pose 18, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose65:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose66:
+ax_pose 0, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose69:
+ax_pose 16, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose70:
+ax_pose 17, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose71:
+ax_pose 3, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose72:
+ax_pose 4, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose73:
+ax_pose 5, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose74:
+ax_pose 18, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose75:
+ax_pose 19, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose76:
+ax_pose 6, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose77:
+ax_pose 7, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose78:
+ax_pose 8, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose79:
+ax_pose 20, 0x01e4, 0x90ed, 0xac00
+ax_pose_terminator
+sJirachiPose80:
+ax_pose 21, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose81:
+ax_pose 9, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose82:
+ax_pose 10, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose83:
+ax_pose 11, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose84:
+ax_pose 22, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose85:
+ax_pose 23, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose86:
+ax_pose 12, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose87:
+ax_pose 13, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose88:
+ax_pose 14, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose89:
+ax_pose 24, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose90:
+ax_pose 21, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose91:
+ax_pose 9, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose92:
+ax_pose 10, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose93:
+ax_pose 11, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose94:
+ax_pose 22, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose95:
+ax_pose 19, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose96:
+ax_pose 6, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose97:
+ax_pose 7, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose98:
+ax_pose 8, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose99:
+ax_pose 20, 0x01e4, 0x80f3, 0xac00
+ax_pose_terminator
+sJirachiPose100:
+ax_pose 17, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose101:
+ax_pose 3, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose102:
+ax_pose 4, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose103:
+ax_pose 5, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose104:
+ax_pose 18, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose105:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose106:
+ax_pose 25, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose107:
+ax_pose 17, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose108:
+ax_pose 26, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose109:
+ax_pose 19, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose110:
+ax_pose 27, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose111:
+ax_pose 21, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose112:
+ax_pose 28, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose113:
+ax_pose 23, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose114:
+ax_pose 29, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose115:
+ax_pose 21, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose116:
+ax_pose 28, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose117:
+ax_pose 19, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose118:
+ax_pose 27, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose119:
+ax_pose 17, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose120:
+ax_pose 26, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose121:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose122:
+ax_pose 30, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose123:
+ax_pose 17, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose124:
+ax_pose 31, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose125:
+ax_pose 19, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose126:
+ax_pose 32, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose127:
+ax_pose 21, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose128:
+ax_pose 33, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose129:
+ax_pose 23, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose130:
+ax_pose 34, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose131:
+ax_pose 21, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose132:
+ax_pose 33, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose133:
+ax_pose 19, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose134:
+ax_pose 32, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose135:
+ax_pose 17, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose136:
+ax_pose 31, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose137:
+ax_pose 35, 0x01e7, 0x80f5, 0xac00
+ax_pose_terminator
+sJirachiPose138:
+ax_pose 36, 0x01e7, 0x80f5, 0xac00
+ax_pose_terminator
+sJirachiPose139:
+ax_pose 37, 0x01e2, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose140:
+ax_pose 38, 0x01e3, 0x90ec, 0xac00
+ax_pose_terminator
+sJirachiPose141:
+ax_pose 39, 0x01e5, 0x90ee, 0xac00
+ax_pose_terminator
+sJirachiPose142:
+ax_pose 40, 0x01e6, 0x90ee, 0xac00
+ax_pose_terminator
+sJirachiPose143:
+ax_pose 41, 0x01e5, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose144:
+ax_pose 40, 0x01e6, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose145:
+ax_pose 39, 0x01e5, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose146:
+ax_pose 38, 0x01e3, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose147:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose148:
+ax_pose 17, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose149:
+ax_pose 19, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose150:
+ax_pose 21, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose151:
+ax_pose 23, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose152:
+ax_pose 21, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose153:
+ax_pose 19, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose154:
+ax_pose 17, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose155:
+ax_pose 25, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose156:
+ax_pose 26, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose157:
+ax_pose 27, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose158:
+ax_pose 28, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose159:
+ax_pose 29, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose160:
+ax_pose 28, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose161:
+ax_pose 27, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sJirachiPose162:
+ax_pose 26, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose163:
+ax_pose 25, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose164:
+ax_pose 26, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sJirachiPose165:
+ax_pose 27, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sJirachiPose166:
+ax_pose 28, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose167:
+ax_pose 29, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose168:
+ax_pose 28, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose169:
+ax_pose 27, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose170:
+ax_pose 26, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose171:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose172:
+ax_pose 25, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose173:
+ax_pose 16, 0x01e3, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose174:
+ax_pose 17, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose175:
+ax_pose 26, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose176:
+ax_pose 18, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose177:
+ax_pose 19, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose178:
+ax_pose 27, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose179:
+ax_pose 20, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sJirachiPose180:
+ax_pose 21, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose181:
+ax_pose 28, 0x01e4, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose182:
+ax_pose 22, 0x01e4, 0x90ee, 0xac00
+ax_pose_terminator
+sJirachiPose183:
+ax_pose 23, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose184:
+ax_pose 29, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose185:
+ax_pose 24, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose186:
+ax_pose 21, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose187:
+ax_pose 28, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose188:
+ax_pose 22, 0x01e4, 0x80f2, 0xac00
+ax_pose_terminator
+sJirachiPose189:
+ax_pose 19, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose190:
+ax_pose 27, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose191:
+ax_pose 20, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose192:
+ax_pose 17, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose193:
+ax_pose 26, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose194:
+ax_pose 18, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose195:
+ax_pose 30, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose196:
+ax_pose 31, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose197:
+ax_pose 32, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose198:
+ax_pose 33, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose199:
+ax_pose 34, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose200:
+ax_pose 33, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose201:
+ax_pose 32, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose202:
+ax_pose 31, 0x01e4, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose203:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose204:
+ax_pose 17, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose205:
+ax_pose 19, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose206:
+ax_pose 21, 0x01e5, 0x80f0, 0xac00
+ax_pose_terminator
+sJirachiPose207:
+ax_pose 23, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose208:
+ax_pose 21, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose209:
+ax_pose 19, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sJirachiPose210:
+ax_pose 17, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sJirachiPose211:
+ax_pose 42, 0x01e6, 0x84f0, 0x7c00
+ax_pose_terminator
+sJirachiPose212:
+ax_pose 43, 0x01d6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose213:
+ax_pose 44, 0x01d6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose214:
+ax_pose 45, 0x01de, 0x84f0, 0x7c00
+ax_pose 46, 0x41fe, 0x84f0, 0x7c10
+ax_pose_terminator
+sJirachiPose215:
+ax_pose 47, 0x41e6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose216:
+ax_pose 48, 0x41e6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose217:
+ax_pose 49, 0x41e6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose218:
+ax_pose 50, 0x01e6, 0x84f0, 0x7c00
+ax_pose_terminator
+sJirachiPose219:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose220:
+ax_pose 30, 0x01e2, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose221:
+ax_pose 25, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose222:
+ax_pose 42, 0x01e6, 0x84f0, 0x7c00
+ax_pose_terminator
+sJirachiPose223:
+ax_pose 43, 0x01d6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose224:
+ax_pose 44, 0x01d6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose225:
+ax_pose 45, 0x01de, 0x84f0, 0x7c00
+ax_pose 46, 0x41fe, 0x84f0, 0x7c10
+ax_pose_terminator
+sJirachiPose226:
+ax_pose 47, 0x41e6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose227:
+ax_pose 48, 0x41e6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose228:
+ax_pose 49, 0x41e6, 0xc4e0, 0x7c00
+ax_pose_terminator
+sJirachiPose229:
+ax_pose 50, 0x01e6, 0x84f0, 0x7c00
+ax_pose_terminator
+sJirachiPose230:
+ax_pose 15, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sJirachiPose231:
+ax_pose 30, 0x01e2, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose232:
+ax_pose 25, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sJirachiPose233:
+ax_pose 42, 0x01e6, 0x84f0, 0x7c00
+ax_pose_terminator
+.align 2
+sJirachiAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 1,
+ax_anim 6, 0, 2, 0, 2, 0, 2,
+ax_anim 6, 0, 0, 0, 1, 0, 2,
+ax_anim 6, 0, 1, 0, 0, 0, 1,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, -1,
+ax_anim 6, 0, 1, 0, -3, 0, -1,
+ax_anim 6, 0, 2, 0, -2, 0, -1,
+ax_anim_terminator
+sJirachiAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 1, 1, 1,
+ax_anim 6, 0, 5, 2, 0, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 2, 2,
+ax_anim 6, 0, 4, 2, -2, 2, 2,
+ax_anim 6, 0, 5, 1, -3, 1, 1,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, -1, -2, -1, -1,
+ax_anim 6, 0, 5, -1, -1, -1, -1,
+ax_anim_terminator
+sJirachiAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, 0, 1, 0,
+ax_anim 6, 0, 8, 2, -1, 2, 0,
+ax_anim 6, 0, 6, 2, -2, 2, 0,
+ax_anim 6, 0, 7, 2, -3, 2, 0,
+ax_anim 6, 0, 8, 1, -4, 1, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, -1, -1, -1, 0,
+ax_anim 6, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sJirachiAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, -1, 1, -1,
+ax_anim 6, 0, 11, 2, -2, 2, -2,
+ax_anim 6, 0, 9, 2, -3, 2, -2,
+ax_anim 6, 0, 10, 2, -4, 2, -2,
+ax_anim 6, 0, 11, 1, -4, 1, -1,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 10, -1, -1, -1, 1,
+ax_anim 6, 0, 11, -1, 0, -1, 1,
+ax_anim_terminator
+sJirachiAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, -1,
+ax_anim 6, 0, 14, 0, -2, 0, -2,
+ax_anim 6, 0, 12, 0, -3, 0, -3,
+ax_anim 6, 0, 13, 0, -4, 0, -3,
+ax_anim 6, 0, 14, 0, -3, 0, -2,
+ax_anim 6, 0, 12, 0, -1, 0, -1,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -1, -1, -1,
+ax_anim 6, 0, 17, -2, -2, -2, -2,
+ax_anim 6, 0, 15, -2, -3, -2, -2,
+ax_anim 6, 0, 16, -2, -4, -2, -2,
+ax_anim 6, 0, 17, -1, -4, -1, -1,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 1, -1, 1, 1,
+ax_anim 6, 0, 17, 1, 0, 1, 1,
+ax_anim_terminator
+sJirachiAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, 0, -1, 0,
+ax_anim 6, 0, 20, -2, -1, -2, 0,
+ax_anim 6, 0, 18, -2, -2, -2, 0,
+ax_anim 6, 0, 19, -2, -3, -2, 0,
+ax_anim 6, 0, 20, -1, -4, -1, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 1, -1, 1, 0,
+ax_anim 6, 0, 20, 1, 0, 1, 0,
+ax_anim_terminator
+sJirachiAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 1, -1, 1,
+ax_anim 6, 0, 23, -2, 0, -2, 2,
+ax_anim 6, 0, 21, -2, -1, -2, 2,
+ax_anim 6, 0, 22, -2, -2, -2, 2,
+ax_anim 6, 0, 23, -1, -3, -1, 1,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 1, -2, 1, -1,
+ax_anim 6, 0, 23, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sJirachiAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 0, 4, 0, 4,
+ax_anim 1, 0, 28, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 24, 0, 22,
+ax_anim 2, 1, 28, 1, 24, 1, 22,
+ax_anim 2, 0, 28, 0, 24, 0, 22,
+ax_anim 2, 0, 28, 1, 24, 1, 22,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sJirachiAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 4, 4, 4,
+ax_anim 1, 0, 33, 10, 11, 10, 11,
+ax_anim 2, 0, 33, 21, 25, 21, 23,
+ax_anim 2, 1, 33, 22, 24, 22, 22,
+ax_anim 2, 0, 33, 21, 25, 21, 23,
+ax_anim 2, 0, 33, 22, 24, 22, 22,
+ax_anim 2, 0, 30, 6, 6, 6, 6,
+ax_anim_terminator
+sJirachiAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, 0, 4, 0,
+ax_anim 1, 0, 38, 10, 1, 10, 0,
+ax_anim 2, 0, 38, 18, 2, 18, 0,
+ax_anim 2, 1, 38, 18, 3, 18, 1,
+ax_anim 2, 0, 38, 18, 2, 18, 0,
+ax_anim 2, 0, 38, 18, 3, 18, 1,
+ax_anim 2, 0, 35, 6, 0, 6, 0,
+ax_anim_terminator
+sJirachiAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 43, 5, -6, 5, -6,
+ax_anim 1, 0, 43, 12, -12, 12, -13,
+ax_anim 2, 0, 43, 18, -18, 18, -21,
+ax_anim 2, 1, 43, 19, -17, 19, -20,
+ax_anim 2, 0, 43, 18, -18, 18, -21,
+ax_anim 2, 0, 43, 19, -17, 19, -20,
+ax_anim 2, 0, 40, 6, -6, 6, -6,
+ax_anim_terminator
+sJirachiAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, -4, 0, -4,
+ax_anim 1, 0, 48, 0, -11, 0, -12,
+ax_anim 2, 0, 48, 0, -19, 0, -22,
+ax_anim 2, 1, 48, 1, -19, 1, -22,
+ax_anim 2, 0, 48, 0, -19, 0, -22,
+ax_anim 2, 0, 48, 1, -19, 1, -22,
+ax_anim 2, 0, 45, 0, -6, 0, -6,
+ax_anim_terminator
+sJirachiAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 4, 0, 49, 2, 2, 2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 53, -5, -6, -5, -6,
+ax_anim 1, 0, 53, -12, -12, -12, -13,
+ax_anim 2, 0, 53, -18, -18, -18, -21,
+ax_anim 2, 1, 53, -19, -17, -19, -20,
+ax_anim 2, 0, 53, -18, -18, -18, -21,
+ax_anim 2, 0, 53, -19, -17, -19, -20,
+ax_anim 2, 0, 50, -6, -6, -6, -6,
+ax_anim_terminator
+sJirachiAnims_2_7:
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 4, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 58, -4, 0, -4, 0,
+ax_anim 1, 0, 58, -10, 1, -10, 0,
+ax_anim 2, 0, 58, -18, 2, -18, 0,
+ax_anim 2, 1, 58, -18, 3, -18, 1,
+ax_anim 2, 0, 58, -18, 2, -18, 0,
+ax_anim 2, 0, 58, -18, 3, -18, 1,
+ax_anim 2, 0, 55, -6, 0, -6, 0,
+ax_anim_terminator
+sJirachiAnims_2_8:
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 4, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 63, -4, 4, -4, 4,
+ax_anim 1, 0, 63, -10, 11, -10, 11,
+ax_anim 2, 0, 63, -21, 25, -21, 23,
+ax_anim 2, 1, 63, -22, 24, -22, 22,
+ax_anim 2, 0, 63, -21, 25, -21, 23,
+ax_anim 2, 0, 63, -22, 24, -22, 22,
+ax_anim 2, 0, 60, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sJirachiAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 64, 0, -2, 0, -2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 68, 0, 4, 0, 4,
+ax_anim 1, 0, 68, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 24, 0, 22,
+ax_anim 2, 1, 68, 1, 24, 1, 22,
+ax_anim 2, 0, 68, 0, 24, 0, 22,
+ax_anim 2, 0, 68, 1, 24, 1, 22,
+ax_anim 2, 0, 65, 0, 6, 0, 6,
+ax_anim_terminator
+sJirachiAnims_3_2:
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 4, 0, 69, -2, -2, -2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 4, 4, 4, 4,
+ax_anim 1, 0, 73, 10, 11, 10, 11,
+ax_anim 2, 0, 73, 21, 25, 21, 23,
+ax_anim 2, 1, 73, 22, 24, 22, 22,
+ax_anim 2, 0, 73, 21, 25, 21, 23,
+ax_anim 2, 0, 73, 22, 24, 22, 22,
+ax_anim 2, 0, 70, 6, 6, 6, 6,
+ax_anim_terminator
+sJirachiAnims_3_3:
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 4, 0, 74, -2, 0, -2, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 78, 4, 0, 4, 0,
+ax_anim 1, 0, 78, 10, 1, 10, 0,
+ax_anim 2, 0, 78, 18, 2, 18, 0,
+ax_anim 2, 1, 78, 18, 3, 18, 1,
+ax_anim 2, 0, 78, 18, 2, 18, 0,
+ax_anim 2, 0, 78, 18, 3, 18, 1,
+ax_anim 2, 0, 75, 6, 0, 6, 0,
+ax_anim_terminator
+sJirachiAnims_3_4:
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 4, 0, 79, -2, 2, -2, 2,
+ax_anim 1, 0, 81, 0, -1, 0, -1,
+ax_anim 1, 2, 83, 5, -6, 5, -6,
+ax_anim 1, 0, 83, 12, -12, 12, -13,
+ax_anim 2, 0, 83, 18, -18, 18, -21,
+ax_anim 2, 1, 83, 19, -17, 19, -20,
+ax_anim 2, 0, 83, 18, -18, 18, -21,
+ax_anim 2, 0, 83, 19, -17, 19, -20,
+ax_anim 2, 0, 80, 6, -6, 6, -6,
+ax_anim_terminator
+sJirachiAnims_3_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 4, 0, 84, 0, 2, 0, 2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 88, 0, -4, 0, -4,
+ax_anim 1, 0, 88, 0, -11, 0, -12,
+ax_anim 2, 0, 88, 0, -19, 0, -22,
+ax_anim 2, 1, 88, 1, -19, 1, -22,
+ax_anim 2, 0, 88, 0, -19, 0, -22,
+ax_anim 2, 0, 88, 1, -19, 1, -22,
+ax_anim 2, 0, 85, 0, -6, 0, -6,
+ax_anim_terminator
+sJirachiAnims_3_6:
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 4, 0, 89, 2, 2, 2, 2,
+ax_anim 1, 0, 91, 0, -1, 0, -1,
+ax_anim 1, 2, 93, -5, -6, -5, -6,
+ax_anim 1, 0, 93, -12, -12, -12, -13,
+ax_anim 2, 0, 93, -18, -18, -18, -21,
+ax_anim 2, 1, 93, -19, -17, -19, -20,
+ax_anim 2, 0, 93, -18, -18, -18, -21,
+ax_anim 2, 0, 93, -19, -17, -19, -20,
+ax_anim 2, 0, 90, -6, -6, -6, -6,
+ax_anim_terminator
+sJirachiAnims_3_7:
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 4, 0, 94, 2, 0, 2, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 98, -4, 0, -4, 0,
+ax_anim 1, 0, 98, -10, 1, -10, 0,
+ax_anim 2, 0, 98, -18, 2, -18, 0,
+ax_anim 2, 1, 98, -18, 3, -18, 1,
+ax_anim 2, 0, 98, -18, 2, -18, 0,
+ax_anim 2, 0, 98, -18, 3, -18, 1,
+ax_anim 2, 0, 95, -6, 0, -6, 0,
+ax_anim_terminator
+sJirachiAnims_3_8:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 103, -4, 4, -4, 4,
+ax_anim 1, 0, 103, -10, 11, -10, 11,
+ax_anim 2, 0, 103, -21, 25, -21, 23,
+ax_anim 2, 1, 103, -22, 24, -22, 22,
+ax_anim 2, 0, 103, -21, 25, -21, 23,
+ax_anim 2, 0, 103, -22, 24, -22, 22,
+ax_anim 2, 0, 100, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sJirachiAnims_4_1:
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 1, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 4, 2, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 1, -6, 1, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 1, 105, 1, -6, 1, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 1, -6, 1, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 1, -6, 1, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_4_2:
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 4, 2, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 1, -7, 1, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 1, 107, 1, -7, 1, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 1, -7, 1, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 1, -7, 1, -1,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_4_3:
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 1, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 4, 2, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 109, 0, -7, 0, -1,
+ax_anim 2, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 1, 109, 0, -7, 0, -1,
+ax_anim 2, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 109, 0, -7, 0, -1,
+ax_anim 2, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 109, 0, -7, 0, -1,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_4_4:
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 4, 2, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 111, -1, -7, -1, -1,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 1, 111, -1, -7, -1, -1,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 111, -1, -7, -1, -1,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 111, -1, -7, -1, -1,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_4_5:
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 1, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -5, 0, 0,
+ax_anim 4, 2, 113, 0, -6, 0, 0,
+ax_anim 2, 0, 113, -1, -6, -1, 0,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim 2, 1, 113, -1, -6, -1, 0,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim 2, 0, 113, -1, -6, -1, 0,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim 2, 0, 113, -1, -6, -1, 0,
+ax_anim 2, 0, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_4_6:
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 1, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 4, 2, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, 1, -7, 1, -1,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 1, 115, 1, -7, 1, -1,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, 1, -7, 1, -1,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, 1, -7, 1, -1,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_4_7:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 4, 2, 117, 0, -6, 0, 0,
+ax_anim 2, 0, 117, 0, -7, 0, -1,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 2, 1, 117, 0, -7, 0, -1,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 2, 0, 117, 0, -7, 0, -1,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 2, 0, 117, 0, -7, 0, -1,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_4_8:
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 1, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 4, 2, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 119, -1, -7, -1, -1,
+ax_anim 2, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 1, 119, -1, -7, -1, -1,
+ax_anim 2, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 119, -1, -7, -1, -1,
+ax_anim 2, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 119, -1, -7, -1, -1,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_5_1:
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 4, 0, 121, 0, -4, 0, 0,
+ax_anim 10, 2, 121, 0, -5, 0, 0,
+ax_anim 4, 0, 121, 0, -4, 0, 0,
+ax_anim 4, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 1, 120, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_5_2:
+ax_anim 2, 0, 123, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 4, 0, 123, 0, -4, 0, 0,
+ax_anim 10, 2, 123, 0, -5, 0, 0,
+ax_anim 4, 0, 123, 0, -4, 0, 0,
+ax_anim 4, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 1, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_5_3:
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 4, 0, 125, 0, -4, 0, 0,
+ax_anim 10, 2, 125, 0, -5, 0, 0,
+ax_anim 4, 0, 125, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 1, 124, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_5_4:
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 10, 2, 127, 0, -5, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 4, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 1, 126, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_5_5:
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -3, 0, 0,
+ax_anim 4, 0, 129, 0, -4, 0, 0,
+ax_anim 10, 2, 129, 0, -5, 0, 0,
+ax_anim 4, 0, 129, 0, -4, 0, 0,
+ax_anim 4, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 1, 128, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_5_6:
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 10, 2, 131, 0, -5, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 1, 130, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_5_7:
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 0, 133, 0, -4, 0, 0,
+ax_anim 10, 2, 133, 0, -5, 0, 0,
+ax_anim 4, 0, 133, 0, -4, 0, 0,
+ax_anim 4, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 1, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_5_8:
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 4, 0, 135, 0, -4, 0, 0,
+ax_anim 10, 2, 135, 0, -5, 0, 0,
+ax_anim 4, 0, 135, 0, -4, 0, 0,
+ax_anim 4, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 1, 134, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_6_1:
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim 8, 0, 136, 0, -2, 0, 0,
+ax_anim 24, 0, 136, 0, -3, 0, 0,
+ax_anim 8, 0, 137, 0, -3, 0, 0,
+ax_anim 8, 0, 137, 0, -2, 0, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim 24, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sJirachiAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sJirachiAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sJirachiAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sJirachiAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sJirachiAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sJirachiAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sJirachiAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sJirachiAnims_8_1:
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, -2, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_8_2:
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 12, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_8_3:
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_8_4:
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim 12, 0, 151, 0, -2, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_8_5:
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, -1, 0, 0,
+ax_anim 12, 0, 150, 0, -2, 0, 0,
+ax_anim 8, 0, 150, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_8_6:
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, -2, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_8_7:
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, -1, 0, 0,
+ax_anim 12, 0, 148, 0, -2, 0, 0,
+ax_anim 8, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sJirachiAnims_8_8:
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim 12, 0, 147, 0, -2, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 7, 5, 7, 5,
+ax_anim 2, 0, 156, 11, 11, 11, 11,
+ax_anim 2, 0, 157, 10, 21, 10, 19,
+ax_anim 3, 0, 158, 0, 25, 0, 23,
+ax_anim 2, 3, 159, -10, 21, -10, 19,
+ax_anim 2, 0, 160, -11, 11, -11, 11,
+ax_anim 1, 0, 161, -7, 5, -7, 5,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 9, 3, 9, 3,
+ax_anim 2, 0, 155, 15, 7, 15, 7,
+ax_anim 2, 0, 156, 19, 16, 19, 15,
+ax_anim 3, 0, 157, 20, 24, 20, 22,
+ax_anim 2, 3, 158, 11, 23, 11, 22,
+ax_anim 2, 0, 159, 3, 16, 3, 16,
+ax_anim 1, 0, 160, -1, 7, -1, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 5, -2, 5, -2,
+ax_anim 2, 0, 154, 10, -3, 10, -3,
+ax_anim 2, 0, 155, 15, -1, 15, -2,
+ax_anim 3, 0, 156, 19, 3, 19, 1,
+ax_anim 2, 3, 157, 16, 5, 16, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 4, 4, 4,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 1, -8, 1, -8,
+ax_anim 2, 0, 161, 6, -15, 6, -15,
+ax_anim 2, 0, 154, 12, -19, 12, -21,
+ax_anim 3, 0, 155, 19, -18, 19, -22,
+ax_anim 2, 3, 156, 21, -12, 21, -14,
+ax_anim 2, 0, 157, 18, -4, 18, -4,
+ax_anim 1, 0, 158, 8, -1, 8, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -9, -3, -9, -3,
+ax_anim 2, 0, 160, -12, -11, -12, -11,
+ax_anim 2, 0, 161, -7, -17, -7, -19,
+ax_anim 3, 0, 154, 0, -19, 0, -21,
+ax_anim 2, 3, 155, 7, -17, 7, -19,
+ax_anim 2, 0, 156, 12, -11, 12, -11,
+ax_anim 1, 0, 157, 9, -3, 9, -3,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, -1, -8, -1, -8,
+ax_anim 2, 0, 155, -6, -15, -6, -15,
+ax_anim 2, 0, 154, -12, -19, -12, -21,
+ax_anim 3, 0, 161, -19, -18, -19, -22,
+ax_anim 2, 3, 160, -21, -12, -21, -14,
+ax_anim 2, 0, 159, -18, -4, -18, -4,
+ax_anim 1, 0, 158, -8, -1, -8, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -5, -2, -5, -2,
+ax_anim 2, 0, 154, -10, -3, -10, -3,
+ax_anim 2, 0, 161, -15, -1, -15, -2,
+ax_anim 3, 0, 160, -19, 3, -19, 1,
+ax_anim 2, 3, 159, -16, 5, -16, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 4, -4, 4,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -9, 3, -9, 3,
+ax_anim 2, 0, 161, -15, 7, -15, 7,
+ax_anim 2, 0, 160, -19, 16, -19, 15,
+ax_anim 3, 0, 159, -20, 24, -20, 22,
+ax_anim 2, 3, 158, -11, 23, -11, 22,
+ax_anim 2, 0, 157, -3, 16, -3, 16,
+ax_anim 1, 0, 156, 1, 7, 1, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 3, 0, 172, 0, -21, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 2, 170, 0, 4, 0, 0,
+ax_anim_terminator
+sJirachiAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -23, 0, 0,
+ax_anim 2, 0, 175, 0, -15, 0, 0,
+ax_anim 1, 0, 175, 0, -9, 0, 0,
+ax_anim 2, 2, 173, 0, 4, 0, 0,
+ax_anim_terminator
+sJirachiAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -23, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 1, 0, 178, 0, -9, 0, 0,
+ax_anim 2, 2, 176, 0, 4, 0, 0,
+ax_anim_terminator
+sJirachiAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -14, 0, 0,
+ax_anim 1, 0, 181, 0, -9, 0, 0,
+ax_anim 2, 2, 179, 0, 4, 0, 0,
+ax_anim_terminator
+sJirachiAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 1, 0, 184, 0, -9, 0, 0,
+ax_anim 2, 2, 182, 0, 4, 0, 0,
+ax_anim_terminator
+sJirachiAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -14, 0, 0,
+ax_anim 1, 0, 187, 0, -9, 0, 0,
+ax_anim 2, 2, 185, 0, 4, 0, 0,
+ax_anim_terminator
+sJirachiAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -23, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 1, 0, 190, 0, -9, 0, 0,
+ax_anim 2, 2, 188, 0, 4, 0, 0,
+ax_anim_terminator
+sJirachiAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -23, 0, 0,
+ax_anim 2, 0, 193, 0, -15, 0, 0,
+ax_anim 1, 0, 193, 0, -9, 0, 0,
+ax_anim 2, 2, 191, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sJirachiAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_14_1:
+ax_anim 20, 0, 210, 0, -3, 0, 0,
+ax_anim 5, 0, 211, 0, -3, 0, 0,
+ax_anim 4, 0, 212, 0, -3, 0, 0,
+ax_anim 4, 0, 211, 0, -3, 0, 0,
+ax_anim 3, 0, 212, 0, -3, 0, 0,
+ax_anim 3, 0, 211, 0, -4, 0, 0,
+ax_anim 3, 0, 212, 0, -5, 0, 0,
+ax_anim 3, 0, 211, 0, -6, 0, 0,
+ax_anim 3, 0, 212, 0, -7, 0, 0,
+ax_anim 3, 0, 211, 0, -8, 0, 0,
+ax_anim 3, 0, 212, 0, -9, 0, 0,
+ax_anim 3, 0, 211, 0, -10, 0, 0,
+ax_anim 3, 0, 212, 0, -10, 0, 0,
+ax_anim 3, 0, 211, 0, -10, 0, 0,
+ax_anim 4, 0, 212, 0, -10, 0, 0,
+ax_anim 4, 0, 211, 0, -10, 0, 0,
+ax_anim 4, 0, 212, 0, -10, 0, 0,
+ax_anim 4, 0, 213, 0, -10, 0, 0,
+ax_anim 4, 0, 214, 0, -10, 0, 0,
+ax_anim 4, 0, 215, 0, -10, 0, 0,
+ax_anim 3, 0, 216, 0, -10, 0, 0,
+ax_anim 3, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -10, 0, 0,
+ax_anim 3, 0, 216, 0, -10, 0, 0,
+ax_anim 3, 0, 214, 0, -10, 0, 0,
+ax_anim 4, 0, 215, 0, -10, 0, 0,
+ax_anim 4, 0, 216, 0, -10, 0, 0,
+ax_anim 5, 0, 214, 0, -10, 0, 0,
+ax_anim 6, 0, 215, 0, -10, 0, 0,
+ax_anim 7, 0, 216, 0, -10, 0, 0,
+ax_anim 4, 0, 217, 0, -10, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -10, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -10, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -10, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -10, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -10, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -10, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 3, 0, 219, 0, -10, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 4, 0, 219, 0, -10, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 10, 0, 219, 0, -10, 0, 0,
+ax_anim 6, 0, 219, 0, -9, 0, 0,
+ax_anim 5, 0, 219, 0, -8, 0, 0,
+ax_anim 4, 0, 219, 0, -7, 0, 0,
+ax_anim 3, 0, 219, 0, -6, 0, 0,
+ax_anim 3, 0, 219, 0, -5, 0, 0,
+ax_anim 3, 0, 219, 0, -4, 0, 0,
+ax_anim 3, 0, 219, 0, -3, 0, 0,
+ax_anim 4, 0, 219, 0, -2, 0, 0,
+ax_anim 5, 0, 219, 0, -1, 0, 0,
+ax_anim 10, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_15_1:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, -1, 0, 0,
+ax_anim 8, 0, 230, 0, -2, 0, 0,
+ax_anim 8, 0, 230, 0, -3, 0, 0,
+ax_anim 8, 0, 230, 0, -2, 0, 0,
+ax_anim 8, 0, 230, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sJirachiAnims_16_1:
+ax_anim 20, 0, 232, 0, -3, 0, 0,
+ax_anim_terminator
+sJirachiGfx1:
+.incbin "baserom.gba", 0x1604DF8, 0x200
+sJirachiSprites1:
+ax_sprite sJirachiGfx1, 0x200
+ax_sprite_terminator
+sJirachiGfx2:
+.incbin "baserom.gba", 0x1605008, 0x200
+sJirachiSprites2:
+ax_sprite sJirachiGfx2, 0x200
+ax_sprite_terminator
+sJirachiGfx3:
+.incbin "baserom.gba", 0x1605218, 0x200
+sJirachiSprites3:
+ax_sprite sJirachiGfx3, 0x200
+ax_sprite_terminator
+sJirachiGfx4:
+.incbin "baserom.gba", 0x1605428, 0x200
+sJirachiSprites4:
+ax_sprite sJirachiGfx4, 0x200
+ax_sprite_terminator
+sJirachiGfx5:
+.incbin "baserom.gba", 0x1605638, 0x200
+sJirachiSprites5:
+ax_sprite sJirachiGfx5, 0x200
+ax_sprite_terminator
+sJirachiGfx6:
+.incbin "baserom.gba", 0x1605848, 0x200
+sJirachiSprites6:
+ax_sprite sJirachiGfx6, 0x200
+ax_sprite_terminator
+sJirachiGfx7:
+.incbin "baserom.gba", 0x1605A58, 0x200
+sJirachiSprites7:
+ax_sprite sJirachiGfx7, 0x200
+ax_sprite_terminator
+sJirachiGfx8:
+.incbin "baserom.gba", 0x1605C68, 0x200
+sJirachiSprites8:
+ax_sprite sJirachiGfx8, 0x200
+ax_sprite_terminator
+sJirachiGfx9:
+.incbin "baserom.gba", 0x1605E78, 0x200
+sJirachiSprites9:
+ax_sprite sJirachiGfx9, 0x200
+ax_sprite_terminator
+sJirachiGfx10:
+.incbin "baserom.gba", 0x1606088, 0x200
+sJirachiSprites10:
+ax_sprite sJirachiGfx10, 0x200
+ax_sprite_terminator
+sJirachiGfx11:
+.incbin "baserom.gba", 0x1606298, 0x200
+sJirachiSprites11:
+ax_sprite sJirachiGfx11, 0x200
+ax_sprite_terminator
+sJirachiGfx12:
+.incbin "baserom.gba", 0x16064A8, 0x200
+sJirachiSprites12:
+ax_sprite sJirachiGfx12, 0x200
+ax_sprite_terminator
+sJirachiGfx13:
+.incbin "baserom.gba", 0x16066B8, 0x200
+sJirachiSprites13:
+ax_sprite sJirachiGfx13, 0x200
+ax_sprite_terminator
+sJirachiGfx14:
+.incbin "baserom.gba", 0x16068C8, 0x200
+sJirachiSprites14:
+ax_sprite sJirachiGfx14, 0x200
+ax_sprite_terminator
+sJirachiGfx15:
+.incbin "baserom.gba", 0x1606AD8, 0x200
+sJirachiSprites15:
+ax_sprite sJirachiGfx15, 0x200
+ax_sprite_terminator
+sJirachiGfx16:
+.incbin "baserom.gba", 0x1606CE8, 0x60
+sJirachiGfx16_1:
+.incbin "baserom.gba", 0x1606D48, 0x60
+sJirachiGfx16_2:
+.incbin "baserom.gba", 0x1606DA8, 0x60
+sJirachiSprites16:
+ax_sprite sJirachiGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJirachiGfx17:
+.incbin "baserom.gba", 0x1606E40, 0x100
+sJirachiGfx17_1:
+.incbin "baserom.gba", 0x1606F40, 0x40
+sJirachiSprites17:
+ax_sprite 0, 0x80
+ax_sprite sJirachiGfx17, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx18:
+.incbin "baserom.gba", 0x1606FB0, 0x60
+sJirachiGfx18_1:
+.incbin "baserom.gba", 0x1607010, 0x80
+sJirachiGfx18_2:
+.incbin "baserom.gba", 0x1607090, 0x60
+sJirachiSprites18:
+ax_sprite sJirachiGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx18_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sJirachiGfx19:
+.incbin "baserom.gba", 0x1607128, 0x20
+sJirachiGfx19_1:
+.incbin "baserom.gba", 0x1607148, 0x100
+sJirachiSprites19:
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx19_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sJirachiGfx20:
+.incbin "baserom.gba", 0x1607278, 0x40
+sJirachiGfx20_1:
+.incbin "baserom.gba", 0x16072B8, 0x80
+sJirachiGfx20_2:
+.incbin "baserom.gba", 0x1607338, 0x60
+sJirachiSprites20:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx20_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx20_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sJirachiGfx21:
+.incbin "baserom.gba", 0x16073D8, 0x100
+sJirachiGfx21_1:
+.incbin "baserom.gba", 0x16074D8, 0x20
+sJirachiSprites21:
+ax_sprite 0, 0x80
+ax_sprite sJirachiGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx21_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJirachiGfx22:
+.incbin "baserom.gba", 0x1607528, 0x40
+sJirachiGfx22_1:
+.incbin "baserom.gba", 0x1607568, 0x100
+sJirachiGfx22_2:
+.incbin "baserom.gba", 0x1607668, 0x60
+sJirachiSprites22:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx22_2, 0x60
+ax_sprite_terminator
+sJirachiGfx23:
+.incbin "baserom.gba", 0x1607700, 0x20
+sJirachiGfx23_1:
+.incbin "baserom.gba", 0x1607720, 0x100
+sJirachiGfx23_2:
+.incbin "baserom.gba", 0x1607820, 0x60
+sJirachiSprites23:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx23_2, 0x60
+ax_sprite_terminator
+sJirachiGfx24:
+.incbin "baserom.gba", 0x16078B8, 0x60
+sJirachiGfx24_1:
+.incbin "baserom.gba", 0x1607918, 0x60
+sJirachiGfx24_2:
+.incbin "baserom.gba", 0x1607978, 0x60
+sJirachiGfx24_3:
+.incbin "baserom.gba", 0x16079D8, 0x20
+sJirachiGfx24_4:
+.incbin "baserom.gba", 0x16079F8, 0x20
+sJirachiSprites24:
+ax_sprite sJirachiGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx24_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx24_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx25:
+.incbin "baserom.gba", 0x1607A70, 0x40
+sJirachiGfx25_1:
+.incbin "baserom.gba", 0x1607AB0, 0x180
+sJirachiSprites25:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx25_1, 0x180
+ax_sprite_terminator
+sJirachiGfx26:
+.incbin "baserom.gba", 0x1607C58, 0x40
+sJirachiGfx26_1:
+.incbin "baserom.gba", 0x1607C98, 0x100
+sJirachiGfx26_2:
+.incbin "baserom.gba", 0x1607D98, 0x40
+sJirachiSprites26:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx27:
+.incbin "baserom.gba", 0x1607E18, 0x40
+sJirachiGfx27_1:
+.incbin "baserom.gba", 0x1607E58, 0x100
+sJirachiGfx27_2:
+.incbin "baserom.gba", 0x1607F58, 0x40
+sJirachiSprites27:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx28:
+.incbin "baserom.gba", 0x1607FD8, 0x40
+sJirachiGfx28_1:
+.incbin "baserom.gba", 0x1608018, 0x60
+sJirachiGfx28_2:
+.incbin "baserom.gba", 0x1608078, 0x60
+sJirachiGfx28_3:
+.incbin "baserom.gba", 0x16080D8, 0x60
+sJirachiSprites28:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx28_3, 0x60
+ax_sprite_terminator
+sJirachiGfx29:
+.incbin "baserom.gba", 0x1608180, 0x40
+sJirachiGfx29_1:
+.incbin "baserom.gba", 0x16081C0, 0x100
+sJirachiGfx29_2:
+.incbin "baserom.gba", 0x16082C0, 0x60
+sJirachiSprites29:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx29_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx29_2, 0x60
+ax_sprite_terminator
+sJirachiGfx30:
+.incbin "baserom.gba", 0x1608358, 0x40
+sJirachiGfx30_1:
+.incbin "baserom.gba", 0x1608398, 0x180
+sJirachiSprites30:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx30_1, 0x180
+ax_sprite_terminator
+sJirachiGfx31:
+.incbin "baserom.gba", 0x1608540, 0x40
+sJirachiGfx31_1:
+.incbin "baserom.gba", 0x1608580, 0x100
+sJirachiGfx31_2:
+.incbin "baserom.gba", 0x1608680, 0x40
+sJirachiSprites31:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx32:
+.incbin "baserom.gba", 0x1608700, 0x40
+sJirachiGfx32_1:
+.incbin "baserom.gba", 0x1608740, 0x100
+sJirachiGfx32_2:
+.incbin "baserom.gba", 0x1608840, 0x20
+sJirachiSprites32:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx32_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJirachiGfx33:
+.incbin "baserom.gba", 0x16088A0, 0x40
+sJirachiGfx33_1:
+.incbin "baserom.gba", 0x16088E0, 0x60
+sJirachiGfx33_2:
+.incbin "baserom.gba", 0x1608940, 0x60
+sJirachiGfx33_3:
+.incbin "baserom.gba", 0x16089A0, 0x60
+sJirachiSprites33:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx33_3, 0x60
+ax_sprite_terminator
+sJirachiGfx34:
+.incbin "baserom.gba", 0x1608A48, 0x40
+sJirachiGfx34_1:
+.incbin "baserom.gba", 0x1608A88, 0x60
+sJirachiGfx34_2:
+.incbin "baserom.gba", 0x1608AE8, 0x60
+sJirachiGfx34_3:
+.incbin "baserom.gba", 0x1608B48, 0x60
+sJirachiSprites34:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx34_3, 0x60
+ax_sprite_terminator
+sJirachiGfx35:
+.incbin "baserom.gba", 0x1608BF0, 0x40
+sJirachiGfx35_1:
+.incbin "baserom.gba", 0x1608C30, 0x180
+sJirachiSprites35:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx35_1, 0x180
+ax_sprite_terminator
+sJirachiGfx36:
+.incbin "baserom.gba", 0x1608DD8, 0x200
+sJirachiSprites36:
+ax_sprite sJirachiGfx36, 0x200
+ax_sprite_terminator
+sJirachiGfx37:
+.incbin "baserom.gba", 0x1608FE8, 0x200
+sJirachiSprites37:
+ax_sprite sJirachiGfx37, 0x200
+ax_sprite_terminator
+sJirachiGfx38:
+.incbin "baserom.gba", 0x16091F8, 0x200
+sJirachiSprites38:
+ax_sprite sJirachiGfx38, 0x200
+ax_sprite_terminator
+sJirachiGfx39:
+.incbin "baserom.gba", 0x1609408, 0x200
+sJirachiSprites39:
+ax_sprite sJirachiGfx39, 0x200
+ax_sprite_terminator
+sJirachiGfx40:
+.incbin "baserom.gba", 0x1609618, 0x200
+sJirachiSprites40:
+ax_sprite sJirachiGfx40, 0x200
+ax_sprite_terminator
+sJirachiGfx41:
+.incbin "baserom.gba", 0x1609828, 0x200
+sJirachiSprites41:
+ax_sprite sJirachiGfx41, 0x200
+ax_sprite_terminator
+sJirachiGfx42:
+.incbin "baserom.gba", 0x1609A38, 0x200
+sJirachiSprites42:
+ax_sprite sJirachiGfx42, 0x200
+ax_sprite_terminator
+sJirachiGfx43:
+.incbin "baserom.gba", 0x1609C48, 0x180
+sJirachiGfx43_1:
+.incbin "baserom.gba", 0x1609DC8, 0x40
+sJirachiSprites43:
+ax_sprite sJirachiGfx43, 0x180
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx43_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx44:
+.incbin "baserom.gba", 0x1609E30, 0xA0
+sJirachiGfx44_1:
+.incbin "baserom.gba", 0x1609ED0, 0x200
+sJirachiGfx44_2:
+.incbin "baserom.gba", 0x160A0D0, 0x80
+sJirachiGfx44_3:
+.incbin "baserom.gba", 0x160A150, 0xC0
+sJirachiGfx44_4:
+.incbin "baserom.gba", 0x160A210, 0xA0
+sJirachiSprites44:
+ax_sprite 0, 0x140
+ax_sprite sJirachiGfx44, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx44_1, 0x200
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx44_2, 0x80
+ax_sprite 0, 0x60
+ax_sprite sJirachiGfx44_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx44_4, 0xa0
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sJirachiGfx45:
+.incbin "baserom.gba", 0x160A310, 0x40
+sJirachiGfx45_1:
+.incbin "baserom.gba", 0x160A350, 0x40
+sJirachiGfx45_2:
+.incbin "baserom.gba", 0x160A390, 0x80
+sJirachiGfx45_3:
+.incbin "baserom.gba", 0x160A410, 0xE0
+sJirachiGfx45_4:
+.incbin "baserom.gba", 0x160A4F0, 0x80
+sJirachiGfx45_5:
+.incbin "baserom.gba", 0x160A570, 0x1E0
+sJirachiGfx45_6:
+.incbin "baserom.gba", 0x160A750, 0x80
+sJirachiGfx45_7:
+.incbin "baserom.gba", 0x160A7D0, 0x40
+sJirachiSprites45:
+ax_sprite 0, 0x60
+ax_sprite sJirachiGfx45, 0x40
+ax_sprite 0, 0x60
+ax_sprite sJirachiGfx45_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx45_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx45_3, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sJirachiGfx45_4, 0x80
+ax_sprite 0, 0x60
+ax_sprite sJirachiGfx45_5, 0x1e0
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx45_6, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sJirachiGfx45_7, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sJirachiGfx46:
+.incbin "baserom.gba", 0x160A8A0, 0x40
+sJirachiGfx46_1:
+.incbin "baserom.gba", 0x160A8E0, 0x180
+sJirachiSprites46:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx46_1, 0x180
+ax_sprite_terminator
+sJirachiGfx47:
+.incbin "baserom.gba", 0x160AA88, 0x80
+sJirachiGfx47_1:
+.incbin "baserom.gba", 0x160AB08, 0x40
+sJirachiSprites47:
+ax_sprite sJirachiGfx47, 0x80
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx47_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx48:
+.incbin "baserom.gba", 0x160AB70, 0xC0
+sJirachiGfx48_1:
+.incbin "baserom.gba", 0x160AC30, 0x1A0
+sJirachiGfx48_2:
+.incbin "baserom.gba", 0x160ADD0, 0xE0
+sJirachiSprites48:
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx48, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx48_1, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx48_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx49:
+.incbin "baserom.gba", 0x160AEF0, 0xE0
+sJirachiGfx49_1:
+.incbin "baserom.gba", 0x160AFD0, 0xC0
+sJirachiGfx49_2:
+.incbin "baserom.gba", 0x160B090, 0xC0
+sJirachiGfx49_3:
+.incbin "baserom.gba", 0x160B150, 0xC0
+sJirachiSprites49:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx49, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx49_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx49_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sJirachiGfx49_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx50:
+.incbin "baserom.gba", 0x160B260, 0xE0
+sJirachiGfx50_1:
+.incbin "baserom.gba", 0x160B340, 0x1C0
+sJirachiGfx50_2:
+.incbin "baserom.gba", 0x160B500, 0xE0
+sJirachiSprites50:
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx50, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx50_1, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx50_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJirachiGfx51:
+.incbin "baserom.gba", 0x160B620, 0x180
+sJirachiGfx51_1:
+.incbin "baserom.gba", 0x160B7A0, 0x60
+sJirachiSprites51:
+ax_sprite sJirachiGfx51, 0x180
+ax_sprite 0, 0x20
+ax_sprite sJirachiGfx51_1, 0x60
+ax_sprite_terminator
+sAxPosesJirachi:
+.4byte sJirachiPose1
+.4byte sJirachiPose2
+.4byte sJirachiPose3
+.4byte sJirachiPose4
+.4byte sJirachiPose5
+.4byte sJirachiPose6
+.4byte sJirachiPose7
+.4byte sJirachiPose8
+.4byte sJirachiPose9
+.4byte sJirachiPose10
+.4byte sJirachiPose11
+.4byte sJirachiPose12
+.4byte sJirachiPose13
+.4byte sJirachiPose14
+.4byte sJirachiPose15
+.4byte sJirachiPose16
+.4byte sJirachiPose17
+.4byte sJirachiPose18
+.4byte sJirachiPose19
+.4byte sJirachiPose20
+.4byte sJirachiPose21
+.4byte sJirachiPose22
+.4byte sJirachiPose23
+.4byte sJirachiPose24
+.4byte sJirachiPose25
+.4byte sJirachiPose26
+.4byte sJirachiPose27
+.4byte sJirachiPose28
+.4byte sJirachiPose29
+.4byte sJirachiPose30
+.4byte sJirachiPose31
+.4byte sJirachiPose32
+.4byte sJirachiPose33
+.4byte sJirachiPose34
+.4byte sJirachiPose35
+.4byte sJirachiPose36
+.4byte sJirachiPose37
+.4byte sJirachiPose38
+.4byte sJirachiPose39
+.4byte sJirachiPose40
+.4byte sJirachiPose41
+.4byte sJirachiPose42
+.4byte sJirachiPose43
+.4byte sJirachiPose44
+.4byte sJirachiPose45
+.4byte sJirachiPose46
+.4byte sJirachiPose47
+.4byte sJirachiPose48
+.4byte sJirachiPose49
+.4byte sJirachiPose50
+.4byte sJirachiPose51
+.4byte sJirachiPose52
+.4byte sJirachiPose53
+.4byte sJirachiPose54
+.4byte sJirachiPose55
+.4byte sJirachiPose56
+.4byte sJirachiPose57
+.4byte sJirachiPose58
+.4byte sJirachiPose59
+.4byte sJirachiPose60
+.4byte sJirachiPose61
+.4byte sJirachiPose62
+.4byte sJirachiPose63
+.4byte sJirachiPose64
+.4byte sJirachiPose65
+.4byte sJirachiPose66
+.4byte sJirachiPose67
+.4byte sJirachiPose68
+.4byte sJirachiPose69
+.4byte sJirachiPose70
+.4byte sJirachiPose71
+.4byte sJirachiPose72
+.4byte sJirachiPose73
+.4byte sJirachiPose74
+.4byte sJirachiPose75
+.4byte sJirachiPose76
+.4byte sJirachiPose77
+.4byte sJirachiPose78
+.4byte sJirachiPose79
+.4byte sJirachiPose80
+.4byte sJirachiPose81
+.4byte sJirachiPose82
+.4byte sJirachiPose83
+.4byte sJirachiPose84
+.4byte sJirachiPose85
+.4byte sJirachiPose86
+.4byte sJirachiPose87
+.4byte sJirachiPose88
+.4byte sJirachiPose89
+.4byte sJirachiPose90
+.4byte sJirachiPose91
+.4byte sJirachiPose92
+.4byte sJirachiPose93
+.4byte sJirachiPose94
+.4byte sJirachiPose95
+.4byte sJirachiPose96
+.4byte sJirachiPose97
+.4byte sJirachiPose98
+.4byte sJirachiPose99
+.4byte sJirachiPose100
+.4byte sJirachiPose101
+.4byte sJirachiPose102
+.4byte sJirachiPose103
+.4byte sJirachiPose104
+.4byte sJirachiPose105
+.4byte sJirachiPose106
+.4byte sJirachiPose107
+.4byte sJirachiPose108
+.4byte sJirachiPose109
+.4byte sJirachiPose110
+.4byte sJirachiPose111
+.4byte sJirachiPose112
+.4byte sJirachiPose113
+.4byte sJirachiPose114
+.4byte sJirachiPose115
+.4byte sJirachiPose116
+.4byte sJirachiPose117
+.4byte sJirachiPose118
+.4byte sJirachiPose119
+.4byte sJirachiPose120
+.4byte sJirachiPose121
+.4byte sJirachiPose122
+.4byte sJirachiPose123
+.4byte sJirachiPose124
+.4byte sJirachiPose125
+.4byte sJirachiPose126
+.4byte sJirachiPose127
+.4byte sJirachiPose128
+.4byte sJirachiPose129
+.4byte sJirachiPose130
+.4byte sJirachiPose131
+.4byte sJirachiPose132
+.4byte sJirachiPose133
+.4byte sJirachiPose134
+.4byte sJirachiPose135
+.4byte sJirachiPose136
+.4byte sJirachiPose137
+.4byte sJirachiPose138
+.4byte sJirachiPose139
+.4byte sJirachiPose140
+.4byte sJirachiPose141
+.4byte sJirachiPose142
+.4byte sJirachiPose143
+.4byte sJirachiPose144
+.4byte sJirachiPose145
+.4byte sJirachiPose146
+.4byte sJirachiPose147
+.4byte sJirachiPose148
+.4byte sJirachiPose149
+.4byte sJirachiPose150
+.4byte sJirachiPose151
+.4byte sJirachiPose152
+.4byte sJirachiPose153
+.4byte sJirachiPose154
+.4byte sJirachiPose155
+.4byte sJirachiPose156
+.4byte sJirachiPose157
+.4byte sJirachiPose158
+.4byte sJirachiPose159
+.4byte sJirachiPose160
+.4byte sJirachiPose161
+.4byte sJirachiPose162
+.4byte sJirachiPose163
+.4byte sJirachiPose164
+.4byte sJirachiPose165
+.4byte sJirachiPose166
+.4byte sJirachiPose167
+.4byte sJirachiPose168
+.4byte sJirachiPose169
+.4byte sJirachiPose170
+.4byte sJirachiPose171
+.4byte sJirachiPose172
+.4byte sJirachiPose173
+.4byte sJirachiPose174
+.4byte sJirachiPose175
+.4byte sJirachiPose176
+.4byte sJirachiPose177
+.4byte sJirachiPose178
+.4byte sJirachiPose179
+.4byte sJirachiPose180
+.4byte sJirachiPose181
+.4byte sJirachiPose182
+.4byte sJirachiPose183
+.4byte sJirachiPose184
+.4byte sJirachiPose185
+.4byte sJirachiPose186
+.4byte sJirachiPose187
+.4byte sJirachiPose188
+.4byte sJirachiPose189
+.4byte sJirachiPose190
+.4byte sJirachiPose191
+.4byte sJirachiPose192
+.4byte sJirachiPose193
+.4byte sJirachiPose194
+.4byte sJirachiPose195
+.4byte sJirachiPose196
+.4byte sJirachiPose197
+.4byte sJirachiPose198
+.4byte sJirachiPose199
+.4byte sJirachiPose200
+.4byte sJirachiPose201
+.4byte sJirachiPose202
+.4byte sJirachiPose203
+.4byte sJirachiPose204
+.4byte sJirachiPose205
+.4byte sJirachiPose206
+.4byte sJirachiPose207
+.4byte sJirachiPose208
+.4byte sJirachiPose209
+.4byte sJirachiPose210
+.4byte sJirachiPose211
+.4byte sJirachiPose212
+.4byte sJirachiPose213
+.4byte sJirachiPose214
+.4byte sJirachiPose215
+.4byte sJirachiPose216
+.4byte sJirachiPose217
+.4byte sJirachiPose218
+.4byte sJirachiPose219
+.4byte sJirachiPose220
+.4byte sJirachiPose221
+.4byte sJirachiPose222
+.4byte sJirachiPose223
+.4byte sJirachiPose224
+.4byte sJirachiPose225
+.4byte sJirachiPose226
+.4byte sJirachiPose227
+.4byte sJirachiPose228
+.4byte sJirachiPose229
+.4byte sJirachiPose230
+.4byte sJirachiPose231
+.4byte sJirachiPose232
+.4byte sJirachiPose233
+sAxPositionsJirachi:
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    7,  -10, 	   0,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    7,  -10, 	  -2,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    7,  -10, 	  -2,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    3,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -10
+.2byte    2,  -13, 	  -2,   -8, 	   2,   -6, 	   1,  -10
+.2byte    2,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -10
+.2byte    0,  -14, 	   4,   -7, 	  -4,   -7, 	   0,   -9
+.2byte    0,  -14, 	   4,   -7, 	  -5,   -7, 	   0,   -9
+.2byte    0,  -14, 	   3,   -7, 	  -4,   -7, 	   0,   -9
+.2byte   -4,  -13, 	   2,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -3,  -13, 	   1,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -3,  -13, 	   2,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -8,  -10, 	  -1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -8,  -10, 	   1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -8,  -10, 	   1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -7, 	  -6,   -7, 	   5,   -7, 	   0,  -10
+.2byte    2,   -9, 	   5,   -7, 	  -3,   -6, 	   1,  -10
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    2,   -8, 	   4,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte    4,  -11, 	   0,   -7, 	  -1,   -4, 	   0,  -10
+.2byte    7,  -10, 	   0,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    7,  -10, 	  -2,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    7,  -10, 	  -2,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    4,   -7, 	  -1,   -8, 	  -4,   -6, 	   1,  -10
+.2byte    1,  -13, 	  -2,   -8, 	   3,   -6, 	  -1,  -10
+.2byte    3,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -10
+.2byte    2,  -13, 	  -2,   -8, 	   2,   -6, 	   1,  -10
+.2byte    2,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -10
+.2byte    3,  -12, 	  -3,   -9, 	   2,   -5, 	   0,   -9
+.2byte    0,  -16, 	   3,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,  -14, 	   4,   -7, 	  -4,   -7, 	   0,   -9
+.2byte    0,  -14, 	   4,   -7, 	  -5,   -7, 	   0,   -9
+.2byte    0,  -14, 	   3,   -7, 	  -4,   -7, 	   0,   -9
+.2byte    0,  -15, 	   4,   -6, 	  -5,   -6, 	   0,   -9
+.2byte   -2,  -13, 	   1,   -8, 	  -4,   -6, 	   0,  -10
+.2byte   -4,  -13, 	   2,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -3,  -13, 	   1,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -3,  -13, 	   2,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -4,  -12, 	   2,   -9, 	  -3,   -5, 	  -1,   -9
+.2byte   -5,  -11, 	  -1,   -7, 	   0,   -4, 	  -1,  -10
+.2byte   -8,  -10, 	  -1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -8,  -10, 	   1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -8,  -10, 	   1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -5,   -7, 	   0,   -8, 	   3,   -6, 	  -2,  -10
+.2byte   -3,   -9, 	  -6,   -7, 	   2,   -6, 	  -2,  -10
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -3,   -8, 	  -5,   -7, 	   4,   -7, 	   0,  -11
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   5,   -5, 	   0,   -7
+.2byte   -1,   -7, 	  -6,   -7, 	   5,   -7, 	   0,  -10
+.2byte    2,   -9, 	   5,   -7, 	  -3,   -6, 	   1,  -10
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    3,   -8, 	   3,   -7, 	  -4,   -5, 	   2,   -9
+.2byte    2,   -8, 	   4,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte    4,  -11, 	   0,   -7, 	  -1,   -4, 	   0,  -10
+.2byte    7,  -10, 	   0,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    7,  -10, 	  -2,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    7,  -10, 	  -2,   -7, 	  -2,   -5, 	   2,   -9
+.2byte    4,   -7, 	  -1,   -8, 	  -4,   -6, 	   1,  -10
+.2byte    1,  -13, 	  -2,   -8, 	   3,   -6, 	  -1,  -10
+.2byte    3,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -10
+.2byte    2,  -13, 	  -2,   -8, 	   2,   -6, 	   1,  -10
+.2byte    2,  -13, 	  -3,   -8, 	   2,   -6, 	   1,  -10
+.2byte    3,  -12, 	  -3,   -9, 	   2,   -5, 	   0,   -9
+.2byte    0,  -16, 	   3,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,  -14, 	   4,   -7, 	  -4,   -7, 	   0,   -9
+.2byte    0,  -14, 	   4,   -7, 	  -5,   -7, 	   0,   -9
+.2byte    0,  -14, 	   3,   -7, 	  -4,   -7, 	   0,   -9
+.2byte    0,  -15, 	   4,   -6, 	  -5,   -6, 	   0,   -9
+.2byte   -2,  -13, 	   1,   -8, 	  -4,   -6, 	   0,  -10
+.2byte   -4,  -13, 	   2,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -3,  -13, 	   1,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -3,  -13, 	   2,   -8, 	  -3,   -6, 	  -2,  -10
+.2byte   -4,  -12, 	   2,   -9, 	  -3,   -5, 	  -1,   -9
+.2byte   -5,  -11, 	  -1,   -7, 	   0,   -4, 	  -1,  -10
+.2byte   -8,  -10, 	  -1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -8,  -10, 	   1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -8,  -10, 	   1,   -7, 	   1,   -5, 	  -3,   -9
+.2byte   -5,   -7, 	   0,   -8, 	   3,   -6, 	  -2,  -10
+.2byte   -3,   -9, 	  -6,   -7, 	   2,   -6, 	  -2,  -10
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -4,   -8, 	  -4,   -7, 	   3,   -5, 	  -3,   -9
+.2byte   -3,   -8, 	  -5,   -7, 	   4,   -7, 	   0,  -11
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -1,  -11, 	  -6,  -10, 	   5,  -10, 	   0,  -10
+.2byte    2,   -9, 	   5,   -7, 	  -3,   -6, 	   1,  -10
+.2byte    3,  -11, 	   5,   -9, 	  -4,   -8, 	   1,  -10
+.2byte    4,  -11, 	   0,   -7, 	  -1,   -4, 	   0,  -10
+.2byte    5,  -13, 	   1,  -10, 	  -2,   -8, 	   0,  -10
+.2byte    1,  -13, 	  -2,   -8, 	   3,   -6, 	  -1,  -10
+.2byte    1,  -15, 	  -3,  -10, 	   5,   -8, 	   0,  -10
+.2byte    0,  -16, 	   3,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,  -16, 	   5,  -11, 	  -6,  -11, 	   0,  -11
+.2byte   -2,  -13, 	   1,   -8, 	  -4,   -6, 	   0,  -10
+.2byte   -2,  -15, 	   2,  -10, 	  -6,   -8, 	  -1,  -10
+.2byte   -5,  -11, 	  -1,   -7, 	   0,   -4, 	  -1,  -10
+.2byte   -6,  -13, 	  -2,  -10, 	   1,   -8, 	  -1,  -10
+.2byte   -3,   -9, 	  -6,   -7, 	   2,   -6, 	  -2,  -10
+.2byte   -4,  -11, 	  -6,   -9, 	   3,   -8, 	  -2,  -10
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -1,   -8, 	  -2,   -6, 	   1,   -6, 	   0,  -11
+.2byte    2,   -9, 	   5,   -7, 	  -3,   -6, 	   1,  -10
+.2byte    2,   -8, 	   4,   -6, 	   0,   -6, 	   1,  -10
+.2byte    4,  -11, 	   0,   -7, 	  -1,   -4, 	   0,  -10
+.2byte    4,  -10, 	   2,   -9, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -2,   -8, 	   3,   -6, 	  -1,  -10
+.2byte    1,  -13, 	  -1,  -10, 	   2,   -8, 	   0,  -10
+.2byte    0,  -16, 	   3,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,  -16, 	   3,   -9, 	  -4,   -9, 	   0,  -10
+.2byte   -2,  -13, 	   1,   -8, 	  -4,   -6, 	   0,  -10
+.2byte   -2,  -13, 	   0,  -10, 	  -3,   -8, 	  -1,  -10
+.2byte   -5,  -11, 	  -1,   -7, 	   0,   -4, 	  -1,  -10
+.2byte   -5,  -10, 	  -3,   -9, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -9, 	  -6,   -7, 	   2,   -6, 	  -2,  -10
+.2byte   -3,   -8, 	  -5,   -6, 	  -1,   -6, 	  -2,  -10
+.2byte   -1,  -11, 	  -4,   -8, 	   1,   -6, 	  -1,   -9
+.2byte   -1,  -10, 	  -4,   -8, 	   1,   -6, 	  -1,   -8
+.2byte    0,  -10, 	  -5,   -9, 	   4,   -9, 	  -1,   -9
+.2byte    0,  -10, 	   3,   -9, 	  -5,   -8, 	  -1,   -9
+.2byte    2,  -10, 	  -2,   -9, 	  -4,   -7, 	  -2,  -11
+.2byte    0,  -14, 	  -5,  -10, 	   3,   -7, 	  -2,   -9
+.2byte    0,  -14, 	   5,   -9, 	  -6,   -9, 	   0,  -10
+.2byte   -1,  -14, 	   4,  -10, 	  -4,   -7, 	   1,   -9
+.2byte   -3,  -10, 	   1,   -9, 	   3,   -7, 	   1,  -11
+.2byte   -1,  -10, 	  -4,   -9, 	   4,   -8, 	   0,   -9
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -3,   -9, 	  -6,   -7, 	   2,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -1,   -7, 	   0,   -4, 	  -1,  -10
+.2byte   -2,  -13, 	   1,   -8, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -16, 	   3,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -2,   -8, 	   3,   -6, 	  -1,  -10
+.2byte    4,  -11, 	   0,   -7, 	  -1,   -4, 	   0,  -10
+.2byte    2,   -9, 	   5,   -7, 	  -3,   -6, 	   1,  -10
+.2byte   -1,  -11, 	  -6,  -10, 	   5,  -10, 	   0,  -10
+.2byte   -4,  -11, 	  -6,   -9, 	   3,   -8, 	  -2,  -10
+.2byte   -5,  -13, 	  -1,  -10, 	   2,   -8, 	   0,  -10
+.2byte   -1,  -15, 	   3,  -10, 	  -5,   -8, 	   0,  -10
+.2byte    0,  -16, 	   5,  -11, 	  -6,  -11, 	   0,  -11
+.2byte    0,  -15, 	  -4,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    4,  -13, 	   0,  -10, 	  -3,   -8, 	  -1,  -10
+.2byte    3,  -11, 	   5,   -9, 	  -4,   -8, 	   1,  -10
+.2byte   -1,  -11, 	  -6,  -10, 	   5,  -10, 	   0,  -10
+.2byte    2,  -11, 	   4,   -9, 	  -5,   -8, 	   0,  -10
+.2byte    4,  -13, 	   0,  -10, 	  -3,   -8, 	  -1,  -10
+.2byte    0,  -15, 	  -4,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    0,  -16, 	   5,  -11, 	  -6,  -11, 	   0,  -11
+.2byte   -1,  -15, 	   3,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -5,  -13, 	  -1,  -10, 	   2,   -8, 	   0,  -10
+.2byte   -3,  -11, 	  -5,   -9, 	   4,   -8, 	  -1,  -10
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -1,  -11, 	  -6,  -10, 	   5,  -10, 	   0,  -10
+.2byte   -1,   -8, 	  -6,   -8, 	   5,   -8, 	   0,  -11
+.2byte    2,   -9, 	   5,   -7, 	  -3,   -6, 	   1,  -10
+.2byte    3,  -11, 	   5,   -9, 	  -4,   -8, 	   1,  -10
+.2byte    2,   -8, 	   4,   -7, 	  -5,   -7, 	  -1,  -11
+.2byte    4,  -11, 	   0,   -7, 	  -1,   -4, 	   0,  -10
+.2byte    5,  -13, 	   1,  -10, 	  -2,   -8, 	   0,  -10
+.2byte    3,   -7, 	  -2,   -8, 	  -5,   -6, 	   0,  -10
+.2byte    1,  -13, 	  -2,   -8, 	   3,   -6, 	  -1,  -10
+.2byte    1,  -15, 	  -3,  -10, 	   5,   -8, 	   0,  -10
+.2byte    2,  -12, 	  -4,   -9, 	   1,   -5, 	  -1,   -9
+.2byte    0,  -16, 	   3,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    0,  -16, 	   5,  -11, 	  -6,  -11, 	   0,  -11
+.2byte    0,  -15, 	   4,   -6, 	  -5,   -6, 	   0,   -9
+.2byte   -2,  -13, 	   1,   -8, 	  -4,   -6, 	   0,  -10
+.2byte   -2,  -15, 	   2,  -10, 	  -6,   -8, 	  -1,  -10
+.2byte   -3,  -12, 	   3,   -9, 	  -2,   -5, 	   0,   -9
+.2byte   -5,  -11, 	  -1,   -7, 	   0,   -4, 	  -1,  -10
+.2byte   -6,  -13, 	  -2,  -10, 	   1,   -8, 	  -1,  -10
+.2byte   -4,   -7, 	   1,   -8, 	   4,   -6, 	  -1,  -10
+.2byte   -3,   -9, 	  -6,   -7, 	   2,   -6, 	  -2,  -10
+.2byte   -4,  -11, 	  -6,   -9, 	   3,   -8, 	  -2,  -10
+.2byte   -3,   -8, 	  -5,   -7, 	   4,   -7, 	   0,  -11
+.2byte   -1,   -8, 	  -2,   -6, 	   1,   -6, 	   0,  -11
+.2byte   -3,   -8, 	  -5,   -6, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -10, 	  -3,   -9, 	  -3,   -7, 	  -1,  -10
+.2byte   -2,  -13, 	   0,  -10, 	  -3,   -8, 	  -1,  -10
+.2byte    0,  -16, 	   3,   -9, 	  -4,   -9, 	   0,  -10
+.2byte    1,  -13, 	  -1,  -10, 	   2,   -8, 	   0,  -10
+.2byte    4,  -10, 	   2,   -9, 	   2,   -7, 	   0,  -10
+.2byte    2,   -8, 	   4,   -6, 	   0,   -6, 	   1,  -10
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -3,   -9, 	  -6,   -7, 	   2,   -6, 	  -2,  -10
+.2byte   -5,  -11, 	  -1,   -7, 	   0,   -4, 	  -1,  -10
+.2byte   -2,  -13, 	   1,   -8, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -16, 	   3,   -7, 	  -3,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -2,   -8, 	   3,   -6, 	  -1,  -10
+.2byte    4,  -11, 	   0,   -7, 	  -1,   -4, 	   0,  -10
+.2byte    2,   -9, 	   5,   -7, 	  -3,   -6, 	   1,  -10
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -1,  -10, 	  -2,   -8, 	   1,   -8, 	   0,  -13
+.2byte   -1,  -11, 	  -6,  -10, 	   5,  -10, 	   0,  -10
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -1,   -9, 	  -5,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -1,  -10, 	  -2,   -8, 	   1,   -8, 	   0,  -13
+.2byte   -1,  -11, 	  -6,  -10, 	   5,  -10, 	   0,  -10
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+sJirachiAnimTable1:
+.4byte sJirachiAnims_1_1
+.4byte sJirachiAnims_1_2
+.4byte sJirachiAnims_1_3
+.4byte sJirachiAnims_1_4
+.4byte sJirachiAnims_1_5
+.4byte sJirachiAnims_1_6
+.4byte sJirachiAnims_1_7
+.4byte sJirachiAnims_1_8
+sJirachiAnimTable2:
+.4byte sJirachiAnims_2_1
+.4byte sJirachiAnims_2_2
+.4byte sJirachiAnims_2_3
+.4byte sJirachiAnims_2_4
+.4byte sJirachiAnims_2_5
+.4byte sJirachiAnims_2_6
+.4byte sJirachiAnims_2_7
+.4byte sJirachiAnims_2_8
+sJirachiAnimTable3:
+.4byte sJirachiAnims_3_1
+.4byte sJirachiAnims_3_2
+.4byte sJirachiAnims_3_3
+.4byte sJirachiAnims_3_4
+.4byte sJirachiAnims_3_5
+.4byte sJirachiAnims_3_6
+.4byte sJirachiAnims_3_7
+.4byte sJirachiAnims_3_8
+sJirachiAnimTable4:
+.4byte sJirachiAnims_4_1
+.4byte sJirachiAnims_4_2
+.4byte sJirachiAnims_4_3
+.4byte sJirachiAnims_4_4
+.4byte sJirachiAnims_4_5
+.4byte sJirachiAnims_4_6
+.4byte sJirachiAnims_4_7
+.4byte sJirachiAnims_4_8
+sJirachiAnimTable5:
+.4byte sJirachiAnims_5_1
+.4byte sJirachiAnims_5_2
+.4byte sJirachiAnims_5_3
+.4byte sJirachiAnims_5_4
+.4byte sJirachiAnims_5_5
+.4byte sJirachiAnims_5_6
+.4byte sJirachiAnims_5_7
+.4byte sJirachiAnims_5_8
+sJirachiAnimTable6:
+.4byte sJirachiAnims_6_1
+.4byte sJirachiAnims_6_1
+.4byte sJirachiAnims_6_1
+.4byte sJirachiAnims_6_1
+.4byte sJirachiAnims_6_1
+.4byte sJirachiAnims_6_1
+.4byte sJirachiAnims_6_1
+.4byte sJirachiAnims_6_1
+sJirachiAnimTable7:
+.4byte sJirachiAnims_7_1
+.4byte sJirachiAnims_7_2
+.4byte sJirachiAnims_7_3
+.4byte sJirachiAnims_7_4
+.4byte sJirachiAnims_7_5
+.4byte sJirachiAnims_7_6
+.4byte sJirachiAnims_7_7
+.4byte sJirachiAnims_7_8
+sJirachiAnimTable8:
+.4byte sJirachiAnims_8_1
+.4byte sJirachiAnims_8_2
+.4byte sJirachiAnims_8_3
+.4byte sJirachiAnims_8_4
+.4byte sJirachiAnims_8_5
+.4byte sJirachiAnims_8_6
+.4byte sJirachiAnims_8_7
+.4byte sJirachiAnims_8_8
+sJirachiAnimTable9:
+.4byte sJirachiAnims_9_1
+.4byte sJirachiAnims_9_2
+.4byte sJirachiAnims_9_3
+.4byte sJirachiAnims_9_4
+.4byte sJirachiAnims_9_5
+.4byte sJirachiAnims_9_6
+.4byte sJirachiAnims_9_7
+.4byte sJirachiAnims_9_8
+sJirachiAnimTable10:
+.4byte sJirachiAnims_10_1
+.4byte sJirachiAnims_10_2
+.4byte sJirachiAnims_10_3
+.4byte sJirachiAnims_10_4
+.4byte sJirachiAnims_10_5
+.4byte sJirachiAnims_10_6
+.4byte sJirachiAnims_10_7
+.4byte sJirachiAnims_10_8
+sJirachiAnimTable11:
+.4byte sJirachiAnims_11_1
+.4byte sJirachiAnims_11_2
+.4byte sJirachiAnims_11_3
+.4byte sJirachiAnims_11_4
+.4byte sJirachiAnims_11_5
+.4byte sJirachiAnims_11_6
+.4byte sJirachiAnims_11_7
+.4byte sJirachiAnims_11_8
+sJirachiAnimTable12:
+.4byte sJirachiAnims_12_1
+.4byte sJirachiAnims_12_2
+.4byte sJirachiAnims_12_3
+.4byte sJirachiAnims_12_4
+.4byte sJirachiAnims_12_5
+.4byte sJirachiAnims_12_6
+.4byte sJirachiAnims_12_7
+.4byte sJirachiAnims_12_8
+sJirachiAnimTable13:
+.4byte sJirachiAnims_13_1
+.4byte sJirachiAnims_13_2
+.4byte sJirachiAnims_13_3
+.4byte sJirachiAnims_13_4
+.4byte sJirachiAnims_13_5
+.4byte sJirachiAnims_13_6
+.4byte sJirachiAnims_13_7
+.4byte sJirachiAnims_13_8
+sJirachiAnimTable14:
+.4byte sJirachiAnims_14_1
+.4byte sJirachiAnims_14_1
+.4byte sJirachiAnims_14_1
+.4byte sJirachiAnims_14_1
+.4byte sJirachiAnims_14_1
+.4byte sJirachiAnims_14_1
+.4byte sJirachiAnims_14_1
+.4byte sJirachiAnims_14_1
+sJirachiAnimTable15:
+.4byte sJirachiAnims_15_1
+.4byte sJirachiAnims_15_1
+.4byte sJirachiAnims_15_1
+.4byte sJirachiAnims_15_1
+.4byte sJirachiAnims_15_1
+.4byte sJirachiAnims_15_1
+.4byte sJirachiAnims_15_1
+.4byte sJirachiAnims_15_1
+sJirachiAnimTable16:
+.4byte sJirachiAnims_16_1
+.4byte sJirachiAnims_16_1
+.4byte sJirachiAnims_16_1
+.4byte sJirachiAnims_16_1
+.4byte sJirachiAnims_16_1
+.4byte sJirachiAnims_16_1
+.4byte sJirachiAnims_16_1
+.4byte sJirachiAnims_16_1
+sAxAnimationsJirachi:
+.4byte sJirachiAnimTable1
+.4byte sJirachiAnimTable2
+.4byte sJirachiAnimTable3
+.4byte sJirachiAnimTable4
+.4byte sJirachiAnimTable5
+.4byte sJirachiAnimTable6
+.4byte sJirachiAnimTable7
+.4byte sJirachiAnimTable8
+.4byte sJirachiAnimTable9
+.4byte sJirachiAnimTable10
+.4byte sJirachiAnimTable11
+.4byte sJirachiAnimTable12
+.4byte sJirachiAnimTable13
+.4byte sJirachiAnimTable14
+.4byte sJirachiAnimTable15
+.4byte sJirachiAnimTable16
+sAxSpritesJirachi:
+.4byte sJirachiSprites1
+.4byte sJirachiSprites2
+.4byte sJirachiSprites3
+.4byte sJirachiSprites4
+.4byte sJirachiSprites5
+.4byte sJirachiSprites6
+.4byte sJirachiSprites7
+.4byte sJirachiSprites8
+.4byte sJirachiSprites9
+.4byte sJirachiSprites10
+.4byte sJirachiSprites11
+.4byte sJirachiSprites12
+.4byte sJirachiSprites13
+.4byte sJirachiSprites14
+.4byte sJirachiSprites15
+.4byte sJirachiSprites16
+.4byte sJirachiSprites17
+.4byte sJirachiSprites18
+.4byte sJirachiSprites19
+.4byte sJirachiSprites20
+.4byte sJirachiSprites21
+.4byte sJirachiSprites22
+.4byte sJirachiSprites23
+.4byte sJirachiSprites24
+.4byte sJirachiSprites25
+.4byte sJirachiSprites26
+.4byte sJirachiSprites27
+.4byte sJirachiSprites28
+.4byte sJirachiSprites29
+.4byte sJirachiSprites30
+.4byte sJirachiSprites31
+.4byte sJirachiSprites32
+.4byte sJirachiSprites33
+.4byte sJirachiSprites34
+.4byte sJirachiSprites35
+.4byte sJirachiSprites36
+.4byte sJirachiSprites37
+.4byte sJirachiSprites38
+.4byte sJirachiSprites39
+.4byte sJirachiSprites40
+.4byte sJirachiSprites41
+.4byte sJirachiSprites42
+.4byte sJirachiSprites43
+.4byte sJirachiSprites44
+.4byte sJirachiSprites45
+.4byte sJirachiSprites46
+.4byte sJirachiSprites47
+.4byte sJirachiSprites48
+.4byte sJirachiSprites49
+.4byte sJirachiSprites50
+.4byte sJirachiSprites51
+sAxMainJirachi:
+ax_main sAxPosesJirachi, sAxAnimationsJirachi, 16, sAxSpritesJirachi, sAxPositionsJirachi

--- a/data/ax/jolteon.inc
+++ b/data/ax/jolteon.inc
@@ -1,0 +1,2966 @@
+.global gAxJolteon
+gAxJolteon:
+ax_siro sAxMainJolteon
+sJolteonPose1:
+ax_pose 0, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose2:
+ax_pose 1, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose3:
+ax_pose 2, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose4:
+ax_pose 3, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose5:
+ax_pose 4, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose7:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose8:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose9:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose10:
+ax_pose 9, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose11:
+ax_pose 10, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose12:
+ax_pose 11, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose13:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose14:
+ax_pose 13, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose15:
+ax_pose 14, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose16:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose17:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose18:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose19:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose22:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose23:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose24:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose25:
+ax_pose 0, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose26:
+ax_pose 1, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose27:
+ax_pose 2, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose28:
+ax_pose 15, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose29:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose30:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose31:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose32:
+ax_pose 16, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose33:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose34:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose35:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose36:
+ax_pose 17, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose37:
+ax_pose 9, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose38:
+ax_pose 10, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose39:
+ax_pose 11, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose40:
+ax_pose 18, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose41:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose42:
+ax_pose 13, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose43:
+ax_pose 14, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose44:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose45:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose46:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose47:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose48:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose49:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose50:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose51:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose52:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose53:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose54:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose55:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose56:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose57:
+ax_pose 0, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose58:
+ax_pose 1, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose59:
+ax_pose 2, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose60:
+ax_pose 15, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose61:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose62:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose63:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose64:
+ax_pose 16, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose65:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose66:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose67:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose68:
+ax_pose 17, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose69:
+ax_pose 9, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose70:
+ax_pose 10, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose71:
+ax_pose 11, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose72:
+ax_pose 18, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose73:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose74:
+ax_pose 13, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose75:
+ax_pose 14, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose76:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose77:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose78:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose79:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose80:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose81:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose82:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose83:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose84:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose85:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose86:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose87:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose88:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose89:
+ax_pose 0, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose90:
+ax_pose 1, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose91:
+ax_pose 2, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose92:
+ax_pose 15, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose93:
+ax_pose 20, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose94:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose95:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose96:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose97:
+ax_pose 16, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose98:
+ax_pose 21, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sJolteonPose99:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose100:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose101:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose102:
+ax_pose 17, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose103:
+ax_pose 22, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose104:
+ax_pose 9, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose105:
+ax_pose 10, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose106:
+ax_pose 11, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose107:
+ax_pose 18, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose108:
+ax_pose 23, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose109:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose110:
+ax_pose 13, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose111:
+ax_pose 14, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose112:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose113:
+ax_pose 24, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose114:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose115:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose116:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose117:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose118:
+ax_pose 23, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose119:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose120:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose121:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose122:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose123:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose124:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose125:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose126:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose127:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose128:
+ax_pose 21, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose129:
+ax_pose 0, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose130:
+ax_pose 1, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose131:
+ax_pose 2, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose132:
+ax_pose 25, 0x01df, 0x80e7, 0x2c00
+ax_pose 26, 0x81df, 0x8107, 0x2c10
+ax_pose 27, 0x41ff, 0x80e7, 0x2c18
+ax_pose 28, 0x01ff, 0x4107, 0x2c20
+ax_pose 29, 0x01e7, 0x80f3, 0x2c24
+ax_pose_terminator
+sJolteonPose133:
+ax_pose 30, 0x01df, 0x80e7, 0x2c00
+ax_pose 31, 0x81df, 0x8107, 0x2c10
+ax_pose 32, 0x41ff, 0x80e7, 0x2c18
+ax_pose 33, 0x01ff, 0x4107, 0x2c20
+ax_pose 15, 0x01e7, 0x80f3, 0x2c24
+ax_pose_terminator
+sJolteonPose134:
+ax_pose 15, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose135:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose136:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose137:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose138:
+ax_pose 25, 0x01df, 0x80eb, 0x2c00
+ax_pose 26, 0x81df, 0x810b, 0x2c10
+ax_pose 27, 0x41ff, 0x80eb, 0x2c18
+ax_pose 28, 0x01ff, 0x410b, 0x2c20
+ax_pose 34, 0x01e6, 0x90ef, 0x2c24
+ax_pose_terminator
+sJolteonPose139:
+ax_pose 30, 0x01df, 0x80eb, 0x2c00
+ax_pose 31, 0x81df, 0x810b, 0x2c10
+ax_pose 32, 0x41ff, 0x80eb, 0x2c18
+ax_pose 33, 0x01ff, 0x410b, 0x2c20
+ax_pose 16, 0x01e6, 0x90ef, 0x2c24
+ax_pose_terminator
+sJolteonPose140:
+ax_pose 16, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose141:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose142:
+ax_pose 7, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose143:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose144:
+ax_pose 25, 0x01de, 0x80e9, 0x2c00
+ax_pose 26, 0x81de, 0x8109, 0x2c10
+ax_pose 27, 0x41fe, 0x80e9, 0x2c18
+ax_pose 28, 0x01fe, 0x4109, 0x2c20
+ax_pose 35, 0x01e6, 0x90f0, 0x2c24
+ax_pose_terminator
+sJolteonPose145:
+ax_pose 30, 0x01de, 0x80e9, 0x2c00
+ax_pose 31, 0x81de, 0x8109, 0x2c10
+ax_pose 32, 0x41fe, 0x80e9, 0x2c18
+ax_pose 33, 0x01fe, 0x4109, 0x2c20
+ax_pose 17, 0x01e6, 0x90f0, 0x2c24
+ax_pose_terminator
+sJolteonPose146:
+ax_pose 17, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose147:
+ax_pose 9, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose148:
+ax_pose 10, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose149:
+ax_pose 11, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose150:
+ax_pose 25, 0x01de, 0x80e8, 0x2c00
+ax_pose 26, 0x81de, 0x8108, 0x2c10
+ax_pose 27, 0x41fe, 0x80e8, 0x2c18
+ax_pose 28, 0x01fe, 0x4108, 0x2c20
+ax_pose 36, 0x01e6, 0x90ec, 0x2c24
+ax_pose_terminator
+sJolteonPose151:
+ax_pose 30, 0x01de, 0x80e8, 0x2c00
+ax_pose 31, 0x81de, 0x8108, 0x2c10
+ax_pose 32, 0x41fe, 0x80e8, 0x2c18
+ax_pose 33, 0x01fe, 0x4108, 0x2c20
+ax_pose 18, 0x01e6, 0x90ec, 0x2c24
+ax_pose_terminator
+sJolteonPose152:
+ax_pose 18, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose153:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose154:
+ax_pose 13, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose155:
+ax_pose 14, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose156:
+ax_pose 25, 0x01dc, 0x80e7, 0x2c00
+ax_pose 26, 0x81dc, 0x8107, 0x2c10
+ax_pose 27, 0x41fc, 0x80e7, 0x2c18
+ax_pose 28, 0x01fc, 0x4107, 0x2c20
+ax_pose 37, 0x01e6, 0x80f4, 0x2c24
+ax_pose_terminator
+sJolteonPose157:
+ax_pose 30, 0x01dc, 0x80e7, 0x2c00
+ax_pose 31, 0x81dc, 0x8107, 0x2c10
+ax_pose 32, 0x41fc, 0x80e7, 0x2c18
+ax_pose 33, 0x01fc, 0x4107, 0x2c20
+ax_pose 19, 0x01e6, 0x80f4, 0x2c24
+ax_pose_terminator
+sJolteonPose158:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose159:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose160:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose161:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose162:
+ax_pose 25, 0x01dd, 0x80e7, 0x2c00
+ax_pose 26, 0x81dd, 0x8107, 0x2c10
+ax_pose 27, 0x41fd, 0x80e7, 0x2c18
+ax_pose 28, 0x01fd, 0x4107, 0x2c20
+ax_pose 36, 0x01e6, 0x80f4, 0x2c24
+ax_pose_terminator
+sJolteonPose163:
+ax_pose 30, 0x01dd, 0x80e7, 0x2c00
+ax_pose 31, 0x81dd, 0x8107, 0x2c10
+ax_pose 32, 0x41fd, 0x80e7, 0x2c18
+ax_pose 33, 0x01fd, 0x4107, 0x2c20
+ax_pose 18, 0x01e6, 0x80f4, 0x2c24
+ax_pose_terminator
+sJolteonPose164:
+ax_pose 18, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose165:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose166:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose167:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose168:
+ax_pose 25, 0x01de, 0x80e6, 0x2c00
+ax_pose 26, 0x81de, 0x8106, 0x2c10
+ax_pose 27, 0x41fe, 0x80e6, 0x2c18
+ax_pose 28, 0x01fe, 0x4106, 0x2c20
+ax_pose 35, 0x01e6, 0x80f0, 0x2c24
+ax_pose_terminator
+sJolteonPose169:
+ax_pose 30, 0x01de, 0x80e6, 0x2c00
+ax_pose 31, 0x81de, 0x8106, 0x2c10
+ax_pose 32, 0x41fe, 0x80e6, 0x2c18
+ax_pose 33, 0x01fe, 0x4106, 0x2c20
+ax_pose 17, 0x01e6, 0x80f0, 0x2c24
+ax_pose_terminator
+sJolteonPose170:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose171:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose172:
+ax_pose 4, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose173:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose174:
+ax_pose 25, 0x01df, 0x80e5, 0x2c00
+ax_pose 26, 0x81df, 0x8105, 0x2c10
+ax_pose 27, 0x41ff, 0x80e5, 0x2c18
+ax_pose 28, 0x01ff, 0x4105, 0x2c20
+ax_pose 34, 0x01e6, 0x80f3, 0x2c24
+ax_pose_terminator
+sJolteonPose175:
+ax_pose 30, 0x01df, 0x80e5, 0x2c00
+ax_pose 31, 0x81df, 0x8105, 0x2c10
+ax_pose 32, 0x41ff, 0x80e5, 0x2c18
+ax_pose 33, 0x01ff, 0x4105, 0x2c20
+ax_pose 16, 0x01e6, 0x80f3, 0x2c24
+ax_pose_terminator
+sJolteonPose176:
+ax_pose 16, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose177:
+ax_pose 38, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sJolteonPose178:
+ax_pose 39, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sJolteonPose179:
+ax_pose 40, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sJolteonPose180:
+ax_pose 41, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sJolteonPose181:
+ax_pose 42, 0x01e4, 0x90ee, 0x2c00
+ax_pose_terminator
+sJolteonPose182:
+ax_pose 43, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose183:
+ax_pose 44, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sJolteonPose184:
+ax_pose 43, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose185:
+ax_pose 42, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sJolteonPose186:
+ax_pose 41, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose187:
+ax_pose 20, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose188:
+ax_pose 21, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose189:
+ax_pose 22, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose190:
+ax_pose 23, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose191:
+ax_pose 24, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose192:
+ax_pose 23, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose193:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose194:
+ax_pose 21, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose195:
+ax_pose 15, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose196:
+ax_pose 16, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose197:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose198:
+ax_pose 18, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose199:
+ax_pose 19, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose200:
+ax_pose 18, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sJolteonPose201:
+ax_pose 17, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose202:
+ax_pose 16, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sJolteonPose203:
+ax_pose 20, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose204:
+ax_pose 21, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sJolteonPose205:
+ax_pose 22, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose206:
+ax_pose 23, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose207:
+ax_pose 24, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose208:
+ax_pose 23, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose209:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose210:
+ax_pose 21, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose211:
+ax_pose 0, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose212:
+ax_pose 2, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose213:
+ax_pose 15, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose214:
+ax_pose 3, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose215:
+ax_pose 5, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJolteonPose216:
+ax_pose 16, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sJolteonPose217:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose218:
+ax_pose 8, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose219:
+ax_pose 17, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose220:
+ax_pose 9, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose221:
+ax_pose 11, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose222:
+ax_pose 18, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose223:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose224:
+ax_pose 14, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose225:
+ax_pose 19, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose226:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose227:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose228:
+ax_pose 18, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose229:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose230:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose231:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose232:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose233:
+ax_pose 5, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose234:
+ax_pose 16, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose235:
+ax_pose 40, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sJolteonPose236:
+ax_pose 41, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose237:
+ax_pose 42, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sJolteonPose238:
+ax_pose 43, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose239:
+ax_pose 44, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sJolteonPose240:
+ax_pose 43, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sJolteonPose241:
+ax_pose 42, 0x01e4, 0x90ee, 0x2c00
+ax_pose_terminator
+sJolteonPose242:
+ax_pose 41, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sJolteonPose243:
+ax_pose 0, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose244:
+ax_pose 3, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJolteonPose245:
+ax_pose 6, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJolteonPose246:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJolteonPose247:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJolteonPose248:
+ax_pose 9, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sJolteonPose249:
+ax_pose 6, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJolteonPose250:
+ax_pose 3, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sJolteonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sJolteonAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 12, 10, 12,
+ax_anim 2, 0, 31, 14, 18, 14, 18,
+ax_anim 2, 1, 31, 15, 17, 15, 17,
+ax_anim 2, 0, 31, 14, 18, 14, 18,
+ax_anim 2, 0, 31, 15, 17, 15, 17,
+ax_anim 2, 0, 28, 5, 6, 5, 6,
+ax_anim_terminator
+sJolteonAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 1, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 0, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sJolteonAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 18, -19, 18, -19,
+ax_anim 2, 1, 39, 19, -18, 19, -18,
+ax_anim 2, 0, 39, 18, -19, 18, -19,
+ax_anim 2, 0, 39, 19, -18, 19, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sJolteonAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sJolteonAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -18, -19, -18, -19,
+ax_anim 2, 1, 47, -19, -18, -19, -18,
+ax_anim 2, 0, 47, -18, -19, -18, -19,
+ax_anim 2, 0, 47, -19, -18, -19, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sJolteonAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 1, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sJolteonAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 12, -10, 12,
+ax_anim 2, 0, 55, -14, 18, -14, 18,
+ax_anim 2, 1, 55, -15, 17, -15, 17,
+ax_anim 2, 0, 55, -14, 18, -14, 18,
+ax_anim 2, 0, 55, -15, 17, -15, 17,
+ax_anim 2, 0, 52, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sJolteonAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 1, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sJolteonAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 12, 10, 12,
+ax_anim 2, 0, 63, 14, 18, 14, 18,
+ax_anim 2, 1, 63, 15, 17, 15, 17,
+ax_anim 2, 0, 63, 14, 18, 14, 18,
+ax_anim 2, 0, 63, 15, 17, 15, 17,
+ax_anim 2, 0, 60, 5, 6, 5, 6,
+ax_anim_terminator
+sJolteonAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 1, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 0, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sJolteonAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 18, -19, 18, -19,
+ax_anim 2, 1, 71, 19, -18, 19, -18,
+ax_anim 2, 0, 71, 18, -19, 18, -19,
+ax_anim 2, 0, 71, 19, -18, 19, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sJolteonAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sJolteonAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -18, -19, -18, -19,
+ax_anim 2, 1, 79, -19, -18, -19, -18,
+ax_anim 2, 0, 79, -18, -19, -18, -19,
+ax_anim 2, 0, 79, -19, -18, -19, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sJolteonAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 1, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 0, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sJolteonAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 12, -10, 12,
+ax_anim 2, 0, 87, -14, 18, -14, 18,
+ax_anim 2, 1, 87, -15, 17, -15, 17,
+ax_anim 2, 0, 87, -14, 18, -14, 18,
+ax_anim 2, 0, 87, -15, 17, -15, 17,
+ax_anim 2, 0, 84, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sJolteonAnims_4_1:
+ax_anim 6, 2, 92, 0, -1, 0, -1,
+ax_anim 1, 0, 88, 0, 1, 0, 1,
+ax_anim 1, 0, 91, 0, 2, 0, 2,
+ax_anim 2, 1, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim_terminator
+sJolteonAnims_4_2:
+ax_anim 6, 2, 97, -1, -1, -1, -1,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 1, 96, 6, 6, 6, 6,
+ax_anim 2, 0, 96, 7, 5, 7, 5,
+ax_anim 2, 0, 96, 6, 6, 6, 6,
+ax_anim 2, 0, 96, 7, 5, 7, 5,
+ax_anim 2, 0, 96, 6, 6, 6, 6,
+ax_anim 2, 0, 96, 7, 5, 7, 5,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim_terminator
+sJolteonAnims_4_3:
+ax_anim 6, 2, 102, -1, 0, -1, 0,
+ax_anim 1, 0, 98, 2, 0, 2, 0,
+ax_anim 1, 0, 101, 4, 0, 4, 0,
+ax_anim 2, 1, 101, 7, 0, 7, 0,
+ax_anim 2, 0, 101, 7, -1, 7, -1,
+ax_anim 2, 0, 101, 7, 0, 7, 0,
+ax_anim 2, 0, 101, 7, -1, 7, -1,
+ax_anim 2, 0, 101, 7, 0, 7, 0,
+ax_anim 2, 0, 101, 7, -1, 7, -1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim_terminator
+sJolteonAnims_4_4:
+ax_anim 6, 2, 107, -1, 1, -1, 1,
+ax_anim 1, 0, 103, 1, 0, 1, 0,
+ax_anim 1, 0, 106, 5, -4, 5, -4,
+ax_anim 2, 1, 106, 7, -6, 7, -6,
+ax_anim 2, 0, 106, 8, -5, 8, -5,
+ax_anim 2, 0, 106, 7, -6, 7, -6,
+ax_anim 2, 0, 106, 8, -5, 8, -5,
+ax_anim 2, 0, 106, 7, -6, 7, -6,
+ax_anim 2, 0, 106, 8, -5, 8, -5,
+ax_anim 2, 0, 105, 5, -3, 5, -3,
+ax_anim_terminator
+sJolteonAnims_4_5:
+ax_anim 6, 2, 112, 0, 1, 0, 1,
+ax_anim 1, 0, 108, 0, 1, 0, 1,
+ax_anim 1, 0, 111, 0, -4, 0, -4,
+ax_anim 2, 1, 111, 0, -6, 0, -6,
+ax_anim 2, 0, 111, 1, -6, 1, -6,
+ax_anim 2, 0, 111, 0, -6, 0, -6,
+ax_anim 2, 0, 111, 1, -6, 1, -6,
+ax_anim 2, 0, 111, 0, -6, 0, -6,
+ax_anim 2, 0, 111, 1, -6, 1, -6,
+ax_anim 2, 0, 109, 0, -2, 0, -2,
+ax_anim_terminator
+sJolteonAnims_4_6:
+ax_anim 6, 2, 117, 1, 1, 1, 1,
+ax_anim 1, 0, 113, -1, 0, -1, 0,
+ax_anim 1, 0, 116, -5, -4, -5, -4,
+ax_anim 2, 1, 116, -7, -6, -7, -6,
+ax_anim 2, 0, 116, -8, -5, -8, -5,
+ax_anim 2, 0, 116, -7, -6, -7, -6,
+ax_anim 2, 0, 116, -8, -5, -8, -5,
+ax_anim 2, 0, 116, -7, -6, -7, -6,
+ax_anim 2, 0, 116, -8, -5, -8, -5,
+ax_anim 2, 0, 115, -5, -3, -5, -3,
+ax_anim_terminator
+sJolteonAnims_4_7:
+ax_anim 6, 2, 122, 1, 0, 1, 0,
+ax_anim 1, 0, 118, -2, 0, -2, 0,
+ax_anim 1, 0, 121, -4, 0, -4, 0,
+ax_anim 2, 1, 121, -7, 0, -7, 0,
+ax_anim 2, 0, 121, -7, -1, -7, -1,
+ax_anim 2, 0, 121, -7, 0, -7, 0,
+ax_anim 2, 0, 121, -7, -1, -7, -1,
+ax_anim 2, 0, 121, -7, 0, -7, 0,
+ax_anim 2, 0, 121, -7, -1, -7, -1,
+ax_anim 2, 0, 119, -3, 0, -3, 0,
+ax_anim_terminator
+sJolteonAnims_4_8:
+ax_anim 6, 2, 127, 1, -1, 1, -1,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 126, -2, 1, -2, 1,
+ax_anim 2, 1, 126, -6, 6, -6, 6,
+ax_anim 2, 0, 126, -7, 5, -7, 5,
+ax_anim 2, 0, 126, -6, 6, -6, 6,
+ax_anim 2, 0, 126, -7, 5, -7, 5,
+ax_anim 2, 0, 126, -6, 6, -6, 6,
+ax_anim 2, 0, 126, -7, 5, -7, 5,
+ax_anim 2, 0, 124, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sJolteonAnims_5_1:
+ax_anim 2, 0, 129, 0, -2, 0, -2,
+ax_anim 8, 0, 129, 0, -3, 0, -3,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_5_2:
+ax_anim 2, 0, 135, -2, -2, -2, -2,
+ax_anim 8, 0, 135, -3, -3, -3, -3,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 2, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_5_3:
+ax_anim 2, 0, 141, -2, 0, -2, 0,
+ax_anim 8, 0, 141, -3, 0, -3, 0,
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 2, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_5_4:
+ax_anim 2, 0, 147, -2, 2, -2, 2,
+ax_anim 8, 0, 147, -3, 3, -3, 3,
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 2, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_5_5:
+ax_anim 2, 0, 153, 0, 2, 0, 2,
+ax_anim 8, 0, 153, 0, 3, 0, 3,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_5_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 2, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_5_7:
+ax_anim 2, 0, 165, 2, 0, 2, 0,
+ax_anim 8, 0, 165, 3, 0, 3, 0,
+ax_anim 3, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 2, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_5_8:
+ax_anim 2, 0, 171, 2, -2, 2, -2,
+ax_anim 8, 0, 171, 3, -3, 3, -3,
+ax_anim 3, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 2, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_7_1:
+ax_anim 2, 0, 178, 0, -2, 0, -2,
+ax_anim 8, 0, 178, 0, -3, 0, -3,
+ax_anim_terminator
+sJolteonAnims_7_2:
+ax_anim 2, 0, 179, -2, -2, -2, -2,
+ax_anim 8, 0, 179, -3, -3, -3, -3,
+ax_anim_terminator
+sJolteonAnims_7_3:
+ax_anim 2, 0, 180, -2, 0, -2, 0,
+ax_anim 8, 0, 180, -3, 0, -3, 0,
+ax_anim_terminator
+sJolteonAnims_7_4:
+ax_anim 2, 0, 181, -2, 2, -2, 2,
+ax_anim 8, 0, 181, -3, 3, -3, 3,
+ax_anim_terminator
+sJolteonAnims_7_5:
+ax_anim 2, 0, 182, 0, 2, 0, 2,
+ax_anim 8, 0, 182, 0, 3, 0, 3,
+ax_anim_terminator
+sJolteonAnims_7_6:
+ax_anim 2, 0, 183, 2, 2, 2, 2,
+ax_anim 8, 0, 183, 3, 3, 3, 3,
+ax_anim_terminator
+sJolteonAnims_7_7:
+ax_anim 2, 0, 184, 2, 0, 2, 0,
+ax_anim 8, 0, 184, 3, 0, 3, 0,
+ax_anim_terminator
+sJolteonAnims_7_8:
+ax_anim 2, 0, 185, 2, -2, 2, -2,
+ax_anim 8, 0, 185, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sJolteonAnims_8_1:
+ax_anim 30, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_8_2:
+ax_anim 30, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_8_3:
+ax_anim 30, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_8_4:
+ax_anim 30, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_8_5:
+ax_anim 30, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_8_6:
+ax_anim 30, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_8_7:
+ax_anim 30, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_8_8:
+ax_anim 30, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 8, 3, 8, 3,
+ax_anim 2, 0, 196, 12, 10, 12, 10,
+ax_anim 2, 0, 197, 8, 16, 8, 16,
+ax_anim 3, 0, 198, 0, 19, 0, 19,
+ax_anim 2, 3, 199, -8, 16, -8, 16,
+ax_anim 2, 0, 200, -13, 10, -13, 10,
+ax_anim 1, 0, 201, -8, 3, -8, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 195, 19, 3, 19, 3,
+ax_anim 2, 0, 196, 23, 10, 23, 10,
+ax_anim 3, 0, 197, 21, 18, 21, 18,
+ax_anim 2, 3, 198, 12, 19, 12, 19,
+ax_anim 2, 0, 199, 4, 14, 4, 14,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 13, -7, 13, -7,
+ax_anim 2, 0, 195, 19, -5, 19, -5,
+ax_anim 3, 0, 196, 21, 0, 21, 0,
+ax_anim 2, 3, 197, 18, 5, 18, 5,
+ax_anim 2, 0, 198, 12, 8, 12, 8,
+ax_anim 1, 0, 199, 4, 4, 4, 4,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 3, -16, 3, -16,
+ax_anim 2, 0, 194, 12, -20, 12, -20,
+ax_anim 3, 0, 195, 22, -20, 22, -20,
+ax_anim 2, 3, 196, 26, -12, 26, -12,
+ax_anim 2, 0, 197, 20, -4, 20, -4,
+ax_anim 1, 0, 198, 10, 1, 10, 1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -10, -10, -10, -10,
+ax_anim 2, 0, 201, -8, -18, -8, -18,
+ax_anim 3, 0, 194, 0, -20, 0, -20,
+ax_anim 2, 3, 195, 8, -18, 8, -18,
+ax_anim 2, 0, 196, 10, -10, 10, -10,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -3, -16, -3, -16,
+ax_anim 2, 0, 194, -12, -20, -12, -20,
+ax_anim 3, 0, 201, -21, -20, -21, -20,
+ax_anim 2, 3, 200, -26, -12, -26, -12,
+ax_anim 2, 0, 199, -20, -4, -20, -4,
+ax_anim 1, 0, 198, -10, -1, -10, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -13, -7, -13, -7,
+ax_anim 2, 0, 201, -19, -5, -19, -5,
+ax_anim 3, 0, 200, -21, 0, -21, 0,
+ax_anim 2, 3, 199, -18, 5, -18, 5,
+ax_anim 2, 0, 198, -12, 4, -12, 4,
+ax_anim 1, 0, 197, -4, 4, -4, 4,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 201, -19, 3, -19, 3,
+ax_anim 2, 0, 200, -23, 10, -23, 10,
+ax_anim 3, 0, 199, -21, 18, -21, 18,
+ax_anim 2, 3, 198, -12, 19, -12, 19,
+ax_anim 2, 0, 197, -4, 14, -4, 14,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -24, 0, 0,
+ax_anim 3, 0, 212, 0, -23, 0, 0,
+ax_anim 2, 0, 212, 0, -19, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -25, 0, 0,
+ax_anim 3, 0, 215, 0, -24, 0, 0,
+ax_anim 2, 0, 215, 0, -19, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -21, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 221, 0, -22, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -20, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -23, 0, 0,
+ax_anim 3, 0, 227, 0, -22, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -25, 0, 0,
+ax_anim 3, 0, 233, 0, -24, 0, 0,
+ax_anim 2, 0, 233, 0, -19, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJolteonAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sJolteonGfx1:
+.incbin "baserom.gba", 0xAD9D18, 0x200
+sJolteonSprites1:
+ax_sprite sJolteonGfx1, 0x200
+ax_sprite_terminator
+sJolteonGfx2:
+.incbin "baserom.gba", 0xAD9F28, 0x200
+sJolteonSprites2:
+ax_sprite sJolteonGfx2, 0x200
+ax_sprite_terminator
+sJolteonGfx3:
+.incbin "baserom.gba", 0xADA138, 0x200
+sJolteonSprites3:
+ax_sprite sJolteonGfx3, 0x200
+ax_sprite_terminator
+sJolteonGfx4:
+.incbin "baserom.gba", 0xADA348, 0x200
+sJolteonSprites4:
+ax_sprite sJolteonGfx4, 0x200
+ax_sprite_terminator
+sJolteonGfx5:
+.incbin "baserom.gba", 0xADA558, 0x200
+sJolteonSprites5:
+ax_sprite sJolteonGfx5, 0x200
+ax_sprite_terminator
+sJolteonGfx6:
+.incbin "baserom.gba", 0xADA768, 0x200
+sJolteonSprites6:
+ax_sprite sJolteonGfx6, 0x200
+ax_sprite_terminator
+sJolteonGfx7:
+.incbin "baserom.gba", 0xADA978, 0x200
+sJolteonSprites7:
+ax_sprite sJolteonGfx7, 0x200
+ax_sprite_terminator
+sJolteonGfx8:
+.incbin "baserom.gba", 0xADAB88, 0x200
+sJolteonSprites8:
+ax_sprite sJolteonGfx8, 0x200
+ax_sprite_terminator
+sJolteonGfx9:
+.incbin "baserom.gba", 0xADAD98, 0x200
+sJolteonSprites9:
+ax_sprite sJolteonGfx9, 0x200
+ax_sprite_terminator
+sJolteonGfx10:
+.incbin "baserom.gba", 0xADAFA8, 0x200
+sJolteonSprites10:
+ax_sprite sJolteonGfx10, 0x200
+ax_sprite_terminator
+sJolteonGfx11:
+.incbin "baserom.gba", 0xADB1B8, 0x200
+sJolteonSprites11:
+ax_sprite sJolteonGfx11, 0x200
+ax_sprite_terminator
+sJolteonGfx12:
+.incbin "baserom.gba", 0xADB3C8, 0x200
+sJolteonSprites12:
+ax_sprite sJolteonGfx12, 0x200
+ax_sprite_terminator
+sJolteonGfx13:
+.incbin "baserom.gba", 0xADB5D8, 0x200
+sJolteonSprites13:
+ax_sprite sJolteonGfx13, 0x200
+ax_sprite_terminator
+sJolteonGfx14:
+.incbin "baserom.gba", 0xADB7E8, 0x200
+sJolteonSprites14:
+ax_sprite sJolteonGfx14, 0x200
+ax_sprite_terminator
+sJolteonGfx15:
+.incbin "baserom.gba", 0xADB9F8, 0x200
+sJolteonSprites15:
+ax_sprite sJolteonGfx15, 0x200
+ax_sprite_terminator
+sJolteonGfx16:
+.incbin "baserom.gba", 0xADBC08, 0x60
+sJolteonGfx16_1:
+.incbin "baserom.gba", 0xADBC68, 0x60
+sJolteonGfx16_2:
+.incbin "baserom.gba", 0xADBCC8, 0x60
+sJolteonGfx16_3:
+.incbin "baserom.gba", 0xADBD28, 0x60
+sJolteonSprites16:
+ax_sprite sJolteonGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx17:
+.incbin "baserom.gba", 0xADBDD0, 0x20
+sJolteonGfx17_1:
+.incbin "baserom.gba", 0xADBDF0, 0x60
+sJolteonGfx17_2:
+.incbin "baserom.gba", 0xADBE50, 0x60
+sJolteonGfx17_3:
+.incbin "baserom.gba", 0xADBEB0, 0x60
+sJolteonSprites17:
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx18:
+.incbin "baserom.gba", 0xADBF60, 0x40
+sJolteonGfx18_1:
+.incbin "baserom.gba", 0xADBFA0, 0x180
+sJolteonSprites18:
+ax_sprite sJolteonGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx18_1, 0x180
+ax_sprite_terminator
+sJolteonGfx19:
+.incbin "baserom.gba", 0xADC140, 0x20
+sJolteonGfx19_1:
+.incbin "baserom.gba", 0xADC160, 0x60
+sJolteonGfx19_2:
+.incbin "baserom.gba", 0xADC1C0, 0x60
+sJolteonGfx19_3:
+.incbin "baserom.gba", 0xADC220, 0x60
+sJolteonSprites19:
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx20:
+.incbin "baserom.gba", 0xADC2D0, 0x60
+sJolteonGfx20_1:
+.incbin "baserom.gba", 0xADC330, 0x60
+sJolteonGfx20_2:
+.incbin "baserom.gba", 0xADC390, 0x60
+sJolteonGfx20_3:
+.incbin "baserom.gba", 0xADC3F0, 0x60
+sJolteonSprites20:
+ax_sprite sJolteonGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx21:
+.incbin "baserom.gba", 0xADC498, 0x60
+sJolteonGfx21_1:
+.incbin "baserom.gba", 0xADC4F8, 0x60
+sJolteonGfx21_2:
+.incbin "baserom.gba", 0xADC558, 0x60
+sJolteonGfx21_3:
+.incbin "baserom.gba", 0xADC5B8, 0x60
+sJolteonSprites21:
+ax_sprite sJolteonGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx22:
+.incbin "baserom.gba", 0xADC660, 0x60
+sJolteonGfx22_1:
+.incbin "baserom.gba", 0xADC6C0, 0x160
+sJolteonSprites22:
+ax_sprite sJolteonGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx23:
+.incbin "baserom.gba", 0xADC848, 0x40
+sJolteonGfx23_1:
+.incbin "baserom.gba", 0xADC888, 0x60
+sJolteonGfx23_2:
+.incbin "baserom.gba", 0xADC8E8, 0x60
+sJolteonGfx23_3:
+.incbin "baserom.gba", 0xADC948, 0x60
+sJolteonSprites23:
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx23_3, 0x60
+ax_sprite_terminator
+sJolteonGfx24:
+.incbin "baserom.gba", 0xADC9F0, 0x60
+sJolteonGfx24_1:
+.incbin "baserom.gba", 0xADCA50, 0x60
+sJolteonGfx24_2:
+.incbin "baserom.gba", 0xADCAB0, 0x60
+sJolteonGfx24_3:
+.incbin "baserom.gba", 0xADCB10, 0x60
+sJolteonSprites24:
+ax_sprite sJolteonGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx25:
+.incbin "baserom.gba", 0xADCBB8, 0x60
+sJolteonGfx25_1:
+.incbin "baserom.gba", 0xADCC18, 0x60
+sJolteonGfx25_2:
+.incbin "baserom.gba", 0xADCC78, 0x60
+sJolteonGfx25_3:
+.incbin "baserom.gba", 0xADCCD8, 0x60
+sJolteonSprites25:
+ax_sprite sJolteonGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx26:
+.incbin "baserom.gba", 0xADCD80, 0x1A0
+sJolteonSprites26:
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx26, 0x1a0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJolteonGfx27:
+.incbin "baserom.gba", 0xADCF40, 0x20
+sJolteonGfx27_1:
+.incbin "baserom.gba", 0xADCF60, 0xC0
+sJolteonSprites27:
+ax_sprite sJolteonGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx27_1, 0xc0
+ax_sprite_terminator
+sJolteonGfx28:
+.incbin "baserom.gba", 0xADD040, 0x80
+sJolteonGfx28_1:
+.incbin "baserom.gba", 0xADD0C0, 0x40
+sJolteonSprites28:
+ax_sprite sJolteonGfx28, 0x80
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx28_1, 0x40
+ax_sprite_terminator
+sJolteonGfx29:
+.incbin "baserom.gba", 0xADD120, 0x60
+sJolteonSprites29:
+ax_sprite sJolteonGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx30:
+.incbin "baserom.gba", 0xADD198, 0x60
+sJolteonGfx30_1:
+.incbin "baserom.gba", 0xADD1F8, 0x60
+sJolteonGfx30_2:
+.incbin "baserom.gba", 0xADD258, 0x60
+sJolteonGfx30_3:
+.incbin "baserom.gba", 0xADD2B8, 0x60
+sJolteonSprites30:
+ax_sprite sJolteonGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx31:
+.incbin "baserom.gba", 0xADD360, 0x140
+sJolteonGfx31_1:
+.incbin "baserom.gba", 0xADD4A0, 0x80
+sJolteonSprites31:
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx31, 0x140
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx31_1, 0x80
+ax_sprite_terminator
+sJolteonGfx32:
+.incbin "baserom.gba", 0xADD548, 0x20
+sJolteonGfx32_1:
+.incbin "baserom.gba", 0xADD568, 0xC0
+sJolteonSprites32:
+ax_sprite sJolteonGfx32, 0x20
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx32_1, 0xc0
+ax_sprite_terminator
+sJolteonGfx33:
+.incbin "baserom.gba", 0xADD648, 0x80
+sJolteonGfx33_1:
+.incbin "baserom.gba", 0xADD6C8, 0x20
+sJolteonSprites33:
+ax_sprite sJolteonGfx33, 0x80
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx33_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx34:
+.incbin "baserom.gba", 0xADD710, 0x60
+sJolteonSprites34:
+ax_sprite sJolteonGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx35:
+.incbin "baserom.gba", 0xADD788, 0x20
+sJolteonGfx35_1:
+.incbin "baserom.gba", 0xADD7A8, 0x20
+sJolteonGfx35_2:
+.incbin "baserom.gba", 0xADD7C8, 0x60
+sJolteonGfx35_3:
+.incbin "baserom.gba", 0xADD828, 0x60
+sJolteonGfx35_4:
+.incbin "baserom.gba", 0xADD888, 0x60
+sJolteonSprites35:
+ax_sprite sJolteonGfx35, 0x20
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx35_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx35_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx36:
+.incbin "baserom.gba", 0xADD940, 0x40
+sJolteonGfx36_1:
+.incbin "baserom.gba", 0xADD980, 0x180
+sJolteonSprites36:
+ax_sprite sJolteonGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx36_1, 0x180
+ax_sprite_terminator
+sJolteonGfx37:
+.incbin "baserom.gba", 0xADDB20, 0x20
+sJolteonGfx37_1:
+.incbin "baserom.gba", 0xADDB40, 0x60
+sJolteonGfx37_2:
+.incbin "baserom.gba", 0xADDBA0, 0x60
+sJolteonGfx37_3:
+.incbin "baserom.gba", 0xADDC00, 0x60
+sJolteonSprites37:
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx37, 0x20
+ax_sprite 0, 0x40
+ax_sprite sJolteonGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJolteonGfx38:
+.incbin "baserom.gba", 0xADDCB0, 0x60
+sJolteonGfx38_1:
+.incbin "baserom.gba", 0xADDD10, 0x60
+sJolteonGfx38_2:
+.incbin "baserom.gba", 0xADDD70, 0x60
+sJolteonGfx38_3:
+.incbin "baserom.gba", 0xADDDD0, 0x40
+sJolteonSprites38:
+ax_sprite sJolteonGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJolteonGfx38_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJolteonGfx39:
+.incbin "baserom.gba", 0xADDE58, 0x200
+sJolteonSprites39:
+ax_sprite sJolteonGfx39, 0x200
+ax_sprite_terminator
+sJolteonGfx40:
+.incbin "baserom.gba", 0xADE068, 0x200
+sJolteonSprites40:
+ax_sprite sJolteonGfx40, 0x200
+ax_sprite_terminator
+sJolteonGfx41:
+.incbin "baserom.gba", 0xADE278, 0x200
+sJolteonSprites41:
+ax_sprite sJolteonGfx41, 0x200
+ax_sprite_terminator
+sJolteonGfx42:
+.incbin "baserom.gba", 0xADE488, 0x200
+sJolteonSprites42:
+ax_sprite sJolteonGfx42, 0x200
+ax_sprite_terminator
+sJolteonGfx43:
+.incbin "baserom.gba", 0xADE698, 0x200
+sJolteonSprites43:
+ax_sprite sJolteonGfx43, 0x200
+ax_sprite_terminator
+sJolteonGfx44:
+.incbin "baserom.gba", 0xADE8A8, 0x200
+sJolteonSprites44:
+ax_sprite sJolteonGfx44, 0x200
+ax_sprite_terminator
+sJolteonGfx45:
+.incbin "baserom.gba", 0xADEAB8, 0x200
+sJolteonSprites45:
+ax_sprite sJolteonGfx45, 0x200
+ax_sprite_terminator
+sAxPosesJolteon:
+.4byte sJolteonPose1
+.4byte sJolteonPose2
+.4byte sJolteonPose3
+.4byte sJolteonPose4
+.4byte sJolteonPose5
+.4byte sJolteonPose6
+.4byte sJolteonPose7
+.4byte sJolteonPose8
+.4byte sJolteonPose9
+.4byte sJolteonPose10
+.4byte sJolteonPose11
+.4byte sJolteonPose12
+.4byte sJolteonPose13
+.4byte sJolteonPose14
+.4byte sJolteonPose15
+.4byte sJolteonPose16
+.4byte sJolteonPose17
+.4byte sJolteonPose18
+.4byte sJolteonPose19
+.4byte sJolteonPose20
+.4byte sJolteonPose21
+.4byte sJolteonPose22
+.4byte sJolteonPose23
+.4byte sJolteonPose24
+.4byte sJolteonPose25
+.4byte sJolteonPose26
+.4byte sJolteonPose27
+.4byte sJolteonPose28
+.4byte sJolteonPose29
+.4byte sJolteonPose30
+.4byte sJolteonPose31
+.4byte sJolteonPose32
+.4byte sJolteonPose33
+.4byte sJolteonPose34
+.4byte sJolteonPose35
+.4byte sJolteonPose36
+.4byte sJolteonPose37
+.4byte sJolteonPose38
+.4byte sJolteonPose39
+.4byte sJolteonPose40
+.4byte sJolteonPose41
+.4byte sJolteonPose42
+.4byte sJolteonPose43
+.4byte sJolteonPose44
+.4byte sJolteonPose45
+.4byte sJolteonPose46
+.4byte sJolteonPose47
+.4byte sJolteonPose48
+.4byte sJolteonPose49
+.4byte sJolteonPose50
+.4byte sJolteonPose51
+.4byte sJolteonPose52
+.4byte sJolteonPose53
+.4byte sJolteonPose54
+.4byte sJolteonPose55
+.4byte sJolteonPose56
+.4byte sJolteonPose57
+.4byte sJolteonPose58
+.4byte sJolteonPose59
+.4byte sJolteonPose60
+.4byte sJolteonPose61
+.4byte sJolteonPose62
+.4byte sJolteonPose63
+.4byte sJolteonPose64
+.4byte sJolteonPose65
+.4byte sJolteonPose66
+.4byte sJolteonPose67
+.4byte sJolteonPose68
+.4byte sJolteonPose69
+.4byte sJolteonPose70
+.4byte sJolteonPose71
+.4byte sJolteonPose72
+.4byte sJolteonPose73
+.4byte sJolteonPose74
+.4byte sJolteonPose75
+.4byte sJolteonPose76
+.4byte sJolteonPose77
+.4byte sJolteonPose78
+.4byte sJolteonPose79
+.4byte sJolteonPose80
+.4byte sJolteonPose81
+.4byte sJolteonPose82
+.4byte sJolteonPose83
+.4byte sJolteonPose84
+.4byte sJolteonPose85
+.4byte sJolteonPose86
+.4byte sJolteonPose87
+.4byte sJolteonPose88
+.4byte sJolteonPose89
+.4byte sJolteonPose90
+.4byte sJolteonPose91
+.4byte sJolteonPose92
+.4byte sJolteonPose93
+.4byte sJolteonPose94
+.4byte sJolteonPose95
+.4byte sJolteonPose96
+.4byte sJolteonPose97
+.4byte sJolteonPose98
+.4byte sJolteonPose99
+.4byte sJolteonPose100
+.4byte sJolteonPose101
+.4byte sJolteonPose102
+.4byte sJolteonPose103
+.4byte sJolteonPose104
+.4byte sJolteonPose105
+.4byte sJolteonPose106
+.4byte sJolteonPose107
+.4byte sJolteonPose108
+.4byte sJolteonPose109
+.4byte sJolteonPose110
+.4byte sJolteonPose111
+.4byte sJolteonPose112
+.4byte sJolteonPose113
+.4byte sJolteonPose114
+.4byte sJolteonPose115
+.4byte sJolteonPose116
+.4byte sJolteonPose117
+.4byte sJolteonPose118
+.4byte sJolteonPose119
+.4byte sJolteonPose120
+.4byte sJolteonPose121
+.4byte sJolteonPose122
+.4byte sJolteonPose123
+.4byte sJolteonPose124
+.4byte sJolteonPose125
+.4byte sJolteonPose126
+.4byte sJolteonPose127
+.4byte sJolteonPose128
+.4byte sJolteonPose129
+.4byte sJolteonPose130
+.4byte sJolteonPose131
+.4byte sJolteonPose132
+.4byte sJolteonPose133
+.4byte sJolteonPose134
+.4byte sJolteonPose135
+.4byte sJolteonPose136
+.4byte sJolteonPose137
+.4byte sJolteonPose138
+.4byte sJolteonPose139
+.4byte sJolteonPose140
+.4byte sJolteonPose141
+.4byte sJolteonPose142
+.4byte sJolteonPose143
+.4byte sJolteonPose144
+.4byte sJolteonPose145
+.4byte sJolteonPose146
+.4byte sJolteonPose147
+.4byte sJolteonPose148
+.4byte sJolteonPose149
+.4byte sJolteonPose150
+.4byte sJolteonPose151
+.4byte sJolteonPose152
+.4byte sJolteonPose153
+.4byte sJolteonPose154
+.4byte sJolteonPose155
+.4byte sJolteonPose156
+.4byte sJolteonPose157
+.4byte sJolteonPose158
+.4byte sJolteonPose159
+.4byte sJolteonPose160
+.4byte sJolteonPose161
+.4byte sJolteonPose162
+.4byte sJolteonPose163
+.4byte sJolteonPose164
+.4byte sJolteonPose165
+.4byte sJolteonPose166
+.4byte sJolteonPose167
+.4byte sJolteonPose168
+.4byte sJolteonPose169
+.4byte sJolteonPose170
+.4byte sJolteonPose171
+.4byte sJolteonPose172
+.4byte sJolteonPose173
+.4byte sJolteonPose174
+.4byte sJolteonPose175
+.4byte sJolteonPose176
+.4byte sJolteonPose177
+.4byte sJolteonPose178
+.4byte sJolteonPose179
+.4byte sJolteonPose180
+.4byte sJolteonPose181
+.4byte sJolteonPose182
+.4byte sJolteonPose183
+.4byte sJolteonPose184
+.4byte sJolteonPose185
+.4byte sJolteonPose186
+.4byte sJolteonPose187
+.4byte sJolteonPose188
+.4byte sJolteonPose189
+.4byte sJolteonPose190
+.4byte sJolteonPose191
+.4byte sJolteonPose192
+.4byte sJolteonPose193
+.4byte sJolteonPose194
+.4byte sJolteonPose195
+.4byte sJolteonPose196
+.4byte sJolteonPose197
+.4byte sJolteonPose198
+.4byte sJolteonPose199
+.4byte sJolteonPose200
+.4byte sJolteonPose201
+.4byte sJolteonPose202
+.4byte sJolteonPose203
+.4byte sJolteonPose204
+.4byte sJolteonPose205
+.4byte sJolteonPose206
+.4byte sJolteonPose207
+.4byte sJolteonPose208
+.4byte sJolteonPose209
+.4byte sJolteonPose210
+.4byte sJolteonPose211
+.4byte sJolteonPose212
+.4byte sJolteonPose213
+.4byte sJolteonPose214
+.4byte sJolteonPose215
+.4byte sJolteonPose216
+.4byte sJolteonPose217
+.4byte sJolteonPose218
+.4byte sJolteonPose219
+.4byte sJolteonPose220
+.4byte sJolteonPose221
+.4byte sJolteonPose222
+.4byte sJolteonPose223
+.4byte sJolteonPose224
+.4byte sJolteonPose225
+.4byte sJolteonPose226
+.4byte sJolteonPose227
+.4byte sJolteonPose228
+.4byte sJolteonPose229
+.4byte sJolteonPose230
+.4byte sJolteonPose231
+.4byte sJolteonPose232
+.4byte sJolteonPose233
+.4byte sJolteonPose234
+.4byte sJolteonPose235
+.4byte sJolteonPose236
+.4byte sJolteonPose237
+.4byte sJolteonPose238
+.4byte sJolteonPose239
+.4byte sJolteonPose240
+.4byte sJolteonPose241
+.4byte sJolteonPose242
+.4byte sJolteonPose243
+.4byte sJolteonPose244
+.4byte sJolteonPose245
+.4byte sJolteonPose246
+.4byte sJolteonPose247
+.4byte sJolteonPose248
+.4byte sJolteonPose249
+.4byte sJolteonPose250
+sAxPositionsJolteon:
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,  -11
+.2byte   -1,   -4, 	  -3,    4, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -4, 	  -4,    1, 	   1,    4, 	  -1,  -10
+.2byte    8,   -7, 	   7,    0, 	   2,    2, 	  -2,   -9
+.2byte    8,   -6, 	   8,    3, 	  -1,    2, 	  -1,   -7
+.2byte    8,   -6, 	   2,    0, 	   6,    3, 	  -2,   -8
+.2byte   11,  -11, 	   7,   -2, 	   5,    0, 	  -1,  -10
+.2byte   11,  -10, 	   8,   -1, 	   2,    0, 	   0,   -8
+.2byte   11,  -10, 	   2,   -1, 	   8,    0, 	  -1,   -8
+.2byte    8,  -14, 	  -1,   -5, 	   5,   -3, 	  -3,   -9
+.2byte    8,  -13, 	   3,   -8, 	   4,   -2, 	  -2,   -9
+.2byte    8,  -13, 	   0,   -4, 	   5,   -4, 	  -3,   -8
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -2,  -14, 	   4,  -11, 	  -6,   -4, 	  -2,  -10
+.2byte    0,  -14, 	   3,   -4, 	  -5,  -10, 	   0,  -10
+.2byte   -9,  -14, 	   0,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -9,  -13, 	  -4,   -8, 	  -5,   -2, 	   1,   -9
+.2byte   -9,  -13, 	  -1,   -4, 	  -6,   -4, 	   2,   -8
+.2byte  -12,  -11, 	  -8,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -12,  -10, 	  -9,   -1, 	  -3,    0, 	  -1,   -8
+.2byte  -12,  -10, 	  -3,   -1, 	  -9,    0, 	   0,   -8
+.2byte  -10,   -7, 	  -9,    0, 	  -4,    2, 	   0,   -9
+.2byte  -10,   -6, 	 -10,    3, 	  -1,    2, 	  -1,   -7
+.2byte  -10,   -6, 	  -4,    0, 	  -8,    3, 	   0,   -8
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,  -11
+.2byte   -1,   -4, 	  -3,    4, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -4, 	  -4,    1, 	   1,    4, 	  -1,  -10
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   11,   -7, 	  10,    0, 	   5,    2, 	   1,   -9
+.2byte   11,   -6, 	  11,    3, 	   2,    2, 	   2,   -7
+.2byte   11,   -6, 	   5,    0, 	   9,    3, 	   1,   -8
+.2byte   10,   -1, 	  11,    2, 	   6,    4, 	   1,   -8
+.2byte   11,  -11, 	   7,   -2, 	   5,    0, 	  -1,  -10
+.2byte   11,  -10, 	   8,   -1, 	   2,    0, 	   0,   -8
+.2byte   11,  -10, 	   2,   -1, 	   8,    0, 	  -1,   -8
+.2byte   11,   -5, 	   8,   -2, 	   6,    0, 	   0,  -10
+.2byte    8,  -14, 	  -1,   -5, 	   5,   -3, 	  -3,   -9
+.2byte    8,  -13, 	   3,   -8, 	   4,   -2, 	  -2,   -9
+.2byte    8,  -13, 	   0,   -4, 	   5,   -4, 	  -3,   -8
+.2byte    9,  -10, 	   0,   -6, 	   6,   -3, 	  -1,  -10
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -2,  -14, 	   4,  -11, 	  -6,   -4, 	  -2,  -10
+.2byte    0,  -14, 	   3,   -4, 	  -5,  -10, 	   0,  -10
+.2byte   -1,  -14, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -9,  -14, 	   0,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -9,  -13, 	  -4,   -8, 	  -5,   -2, 	   1,   -9
+.2byte   -9,  -13, 	  -1,   -4, 	  -6,   -4, 	   2,   -8
+.2byte  -10,  -10, 	  -1,   -6, 	  -7,   -3, 	   0,  -10
+.2byte  -12,  -11, 	  -8,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -12,  -10, 	  -9,   -1, 	  -3,    0, 	  -1,   -8
+.2byte  -12,  -10, 	  -3,   -1, 	  -9,    0, 	   0,   -8
+.2byte  -12,   -5, 	  -9,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -10,   -7, 	  -9,    0, 	  -4,    2, 	   0,   -9
+.2byte  -10,   -6, 	 -10,    3, 	  -1,    2, 	  -1,   -7
+.2byte  -10,   -6, 	  -4,    0, 	  -8,    3, 	   0,   -8
+.2byte   -9,   -1, 	 -10,    2, 	  -5,    4, 	   0,   -8
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,  -11
+.2byte   -1,   -4, 	  -3,    4, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -4, 	  -4,    1, 	   1,    4, 	  -1,  -10
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   11,   -7, 	  10,    0, 	   5,    2, 	   1,   -9
+.2byte   11,   -6, 	  11,    3, 	   2,    2, 	   2,   -7
+.2byte   11,   -6, 	   5,    0, 	   9,    3, 	   1,   -8
+.2byte   10,   -1, 	  11,    2, 	   6,    4, 	   1,   -8
+.2byte   11,  -11, 	   7,   -2, 	   5,    0, 	  -1,  -10
+.2byte   11,  -10, 	   8,   -1, 	   2,    0, 	   0,   -8
+.2byte   11,  -10, 	   2,   -1, 	   8,    0, 	  -1,   -8
+.2byte   11,   -5, 	   8,   -2, 	   6,    0, 	   0,  -10
+.2byte    8,  -14, 	  -1,   -5, 	   5,   -3, 	  -3,   -9
+.2byte    8,  -13, 	   3,   -8, 	   4,   -2, 	  -2,   -9
+.2byte    8,  -13, 	   0,   -4, 	   5,   -4, 	  -3,   -8
+.2byte    9,  -10, 	   0,   -6, 	   6,   -3, 	  -1,  -10
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -2,  -14, 	   4,  -11, 	  -6,   -4, 	  -2,  -10
+.2byte    0,  -14, 	   3,   -4, 	  -5,  -10, 	   0,  -10
+.2byte   -1,  -14, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -9,  -14, 	   0,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -9,  -13, 	  -4,   -8, 	  -5,   -2, 	   1,   -9
+.2byte   -9,  -13, 	  -1,   -4, 	  -6,   -4, 	   2,   -8
+.2byte  -10,  -10, 	  -1,   -6, 	  -7,   -3, 	   0,  -10
+.2byte  -12,  -11, 	  -8,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -12,  -10, 	  -9,   -1, 	  -3,    0, 	  -1,   -8
+.2byte  -12,  -10, 	  -3,   -1, 	  -9,    0, 	   0,   -8
+.2byte  -12,   -5, 	  -9,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -10,   -7, 	  -9,    0, 	  -4,    2, 	   0,   -9
+.2byte  -10,   -6, 	 -10,    3, 	  -1,    2, 	  -1,   -7
+.2byte  -10,   -6, 	  -4,    0, 	  -8,    3, 	   0,   -8
+.2byte   -9,   -1, 	 -10,    2, 	  -5,    4, 	   0,   -8
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,  -11
+.2byte   -1,   -4, 	  -3,    4, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -4, 	  -4,    1, 	   1,    4, 	  -1,  -10
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   -1,   -7, 	  -4,    2, 	   2,    2, 	  -1,  -10
+.2byte   11,   -7, 	  10,    0, 	   5,    2, 	   1,   -9
+.2byte   11,   -6, 	  11,    3, 	   2,    2, 	   2,   -7
+.2byte   11,   -6, 	   5,    0, 	   9,    3, 	   1,   -8
+.2byte   10,   -1, 	  11,    2, 	   6,    4, 	   1,   -8
+.2byte    9,  -10, 	   6,   -1, 	   3,    1, 	  -3,   -9
+.2byte   11,  -11, 	   7,   -2, 	   5,    0, 	  -1,  -10
+.2byte   11,  -10, 	   8,   -1, 	   2,    0, 	   0,   -8
+.2byte   11,  -10, 	   2,   -1, 	   8,    0, 	  -1,   -8
+.2byte   11,   -5, 	   8,   -2, 	   6,    0, 	   0,  -10
+.2byte    9,  -13, 	   5,   -1, 	   3,    0, 	  -2,   -8
+.2byte    8,  -14, 	  -1,   -5, 	   5,   -3, 	  -3,   -9
+.2byte    8,  -13, 	   3,   -8, 	   4,   -2, 	  -2,   -9
+.2byte    8,  -13, 	   0,   -4, 	   5,   -4, 	  -3,   -8
+.2byte    9,  -10, 	   0,   -6, 	   6,   -3, 	  -1,  -10
+.2byte    5,  -14, 	  -3,   -3, 	   3,   -1, 	  -3,   -7
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -2,  -14, 	   4,  -11, 	  -6,   -4, 	  -2,  -10
+.2byte    0,  -14, 	   3,   -4, 	  -5,  -10, 	   0,  -10
+.2byte   -1,  -14, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	   4,   -2, 	  -6,   -2, 	  -1,   -7
+.2byte   -9,  -14, 	   0,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -9,  -13, 	  -4,   -8, 	  -5,   -2, 	   1,   -9
+.2byte   -9,  -13, 	  -1,   -4, 	  -6,   -4, 	   2,   -8
+.2byte  -10,  -10, 	  -1,   -6, 	  -7,   -3, 	   0,  -10
+.2byte   -6,  -14, 	   2,   -3, 	  -4,   -1, 	   2,   -7
+.2byte  -12,  -11, 	  -8,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -12,  -10, 	  -9,   -1, 	  -3,    0, 	  -1,   -8
+.2byte  -12,  -10, 	  -3,   -1, 	  -9,    0, 	   0,   -8
+.2byte  -12,   -5, 	  -9,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -10,  -13, 	  -6,   -1, 	  -4,    0, 	   1,   -8
+.2byte  -10,   -7, 	  -9,    0, 	  -4,    2, 	   0,   -9
+.2byte  -10,   -6, 	 -10,    3, 	  -1,    2, 	  -1,   -7
+.2byte  -10,   -6, 	  -4,    0, 	  -8,    3, 	   0,   -8
+.2byte   -9,   -1, 	 -10,    2, 	  -5,    4, 	   0,   -8
+.2byte  -10,  -10, 	  -7,   -1, 	  -4,    1, 	   2,   -9
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,  -11
+.2byte   -1,   -4, 	  -3,    4, 	   2,    1, 	  -1,  -10
+.2byte   -1,   -4, 	  -4,    1, 	   1,    4, 	  -1,  -10
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   11,   -7, 	  10,    0, 	   5,    2, 	   1,   -9
+.2byte   11,   -6, 	  11,    3, 	   2,    2, 	   2,   -7
+.2byte   11,   -6, 	   5,    0, 	   9,    3, 	   1,   -8
+.2byte   10,   -1, 	  11,    0, 	   6,    2, 	   1,   -8
+.2byte   10,   -1, 	  11,    2, 	   6,    4, 	   1,   -8
+.2byte   10,   -1, 	  11,    2, 	   6,    4, 	   1,   -8
+.2byte   11,  -11, 	   7,   -2, 	   5,    0, 	  -1,  -10
+.2byte   11,  -10, 	   8,   -1, 	   2,    0, 	   0,   -8
+.2byte   11,  -10, 	   2,   -1, 	   8,    0, 	  -1,   -8
+.2byte   11,   -5, 	   9,   -2, 	   6,    0, 	   0,  -10
+.2byte   11,   -5, 	   8,   -2, 	   6,    0, 	   0,  -10
+.2byte   11,   -5, 	   8,   -2, 	   6,    0, 	   0,  -10
+.2byte    8,  -14, 	  -1,   -5, 	   5,   -3, 	  -3,   -9
+.2byte    8,  -13, 	   3,   -8, 	   4,   -2, 	  -2,   -9
+.2byte    8,  -13, 	   0,   -4, 	   5,   -4, 	  -3,   -8
+.2byte    9,  -10, 	   0,   -6, 	   6,   -3, 	  -1,  -10
+.2byte    9,  -10, 	   0,   -6, 	   6,   -3, 	  -1,  -10
+.2byte    9,  -10, 	   0,   -6, 	   6,   -3, 	  -1,  -10
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -2,  -14, 	   4,  -11, 	  -6,   -4, 	  -2,  -10
+.2byte    0,  -14, 	   3,   -4, 	  -5,  -10, 	   0,  -10
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,  -11
+.2byte   -1,  -14, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -9,  -14, 	   0,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -9,  -13, 	  -4,   -8, 	  -5,   -2, 	   1,   -9
+.2byte   -9,  -13, 	  -1,   -4, 	  -6,   -4, 	   2,   -8
+.2byte  -10,  -10, 	  -1,   -6, 	  -7,   -3, 	   0,  -10
+.2byte  -10,  -10, 	  -1,   -6, 	  -7,   -3, 	   0,  -10
+.2byte  -10,  -10, 	  -1,   -6, 	  -7,   -3, 	   0,  -10
+.2byte  -12,  -11, 	  -8,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -12,  -10, 	  -9,   -1, 	  -3,    0, 	  -1,   -8
+.2byte  -12,  -10, 	  -3,   -1, 	  -9,    0, 	   0,   -8
+.2byte  -12,   -5, 	 -10,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -12,   -5, 	  -9,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -12,   -5, 	  -9,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -10,   -7, 	  -9,    0, 	  -4,    2, 	   0,   -9
+.2byte  -10,   -6, 	 -10,    3, 	  -1,    2, 	  -1,   -7
+.2byte  -10,   -6, 	  -4,    0, 	  -8,    3, 	   0,   -8
+.2byte   -9,   -1, 	 -10,    0, 	  -5,    2, 	   0,   -8
+.2byte   -9,   -1, 	 -10,    2, 	  -5,    4, 	   0,   -8
+.2byte   -9,   -1, 	 -10,    2, 	  -5,    4, 	   0,   -8
+.2byte  -10,   -5, 	  -9,   -1, 	  -7,    0, 	   0,   -5
+.2byte  -10,   -4, 	  -9,   -1, 	  -7,    0, 	   0,   -5
+.2byte    0,    0, 	  -6,    3, 	   6,    3, 	   0,  -11
+.2byte    7,   -2, 	  10,   -1, 	   2,    3, 	  -1,   -9
+.2byte   10,   -4, 	   8,   -3, 	   6,    1, 	  -1,   -8
+.2byte    9,   -8, 	   0,   -6, 	   7,   -2, 	  -1,   -8
+.2byte    0,   -9, 	   6,   -2, 	  -6,   -2, 	   0,   -7
+.2byte  -10,   -8, 	  -1,   -6, 	  -8,   -2, 	   0,   -8
+.2byte  -11,   -4, 	  -9,   -3, 	  -7,    1, 	   0,   -8
+.2byte   -8,   -2, 	 -11,   -1, 	  -3,    3, 	   0,   -9
+.2byte   -1,   -7, 	  -4,    2, 	   2,    2, 	  -1,  -10
+.2byte    8,   -9, 	   5,    0, 	   2,    2, 	  -4,   -8
+.2byte    8,  -13, 	   4,   -1, 	   2,    0, 	  -3,   -8
+.2byte    5,  -14, 	  -3,   -3, 	   3,   -1, 	  -3,   -7
+.2byte   -1,  -14, 	   4,   -3, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,  -14, 	   1,   -3, 	  -5,   -1, 	   1,   -7
+.2byte  -10,  -13, 	  -6,   -1, 	  -4,    0, 	   1,   -8
+.2byte  -10,   -9, 	  -7,    0, 	  -4,    2, 	   2,   -8
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   -9,   -2, 	 -10,    1, 	  -5,    3, 	   0,   -9
+.2byte  -12,   -5, 	  -9,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -11,   -9, 	  -2,   -5, 	  -8,   -2, 	  -1,   -9
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,  -10
+.2byte   10,   -9, 	   1,   -5, 	   7,   -2, 	   0,   -9
+.2byte   11,   -5, 	   8,   -2, 	   6,    0, 	   0,  -10
+.2byte    8,   -2, 	   9,    1, 	   4,    3, 	  -1,   -9
+.2byte   -1,   -7, 	  -4,    2, 	   2,    2, 	  -1,  -10
+.2byte    9,   -9, 	   6,    0, 	   3,    2, 	  -3,   -8
+.2byte    9,  -13, 	   5,   -1, 	   3,    0, 	  -2,   -8
+.2byte    6,  -14, 	  -2,   -3, 	   4,   -1, 	  -2,   -7
+.2byte   -1,  -14, 	   4,   -3, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,  -14, 	   1,   -3, 	  -5,   -1, 	   1,   -7
+.2byte  -10,  -13, 	  -6,   -1, 	  -4,    0, 	   1,   -8
+.2byte  -10,   -9, 	  -7,    0, 	  -4,    2, 	   2,   -8
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,  -11
+.2byte   -1,   -4, 	  -4,    1, 	   1,    4, 	  -1,  -10
+.2byte   -1,   -2, 	  -6,    3, 	   4,    3, 	  -1,   -9
+.2byte   11,   -7, 	  10,    0, 	   5,    2, 	   1,   -9
+.2byte   11,   -6, 	   5,    0, 	   9,    3, 	   1,   -8
+.2byte    9,   -1, 	  10,    2, 	   5,    4, 	   0,   -8
+.2byte   11,  -11, 	   7,   -2, 	   5,    0, 	  -1,  -10
+.2byte   11,  -10, 	   2,   -1, 	   8,    0, 	  -1,   -8
+.2byte   11,   -5, 	   8,   -2, 	   6,    0, 	   0,  -10
+.2byte    8,  -14, 	  -1,   -5, 	   5,   -3, 	  -3,   -9
+.2byte    8,  -13, 	   0,   -4, 	   5,   -4, 	  -3,   -8
+.2byte    8,  -10, 	  -1,   -6, 	   5,   -3, 	  -2,  -10
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   3,   -4, 	  -5,  -10, 	   0,  -10
+.2byte   -1,  -14, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte   -9,  -14, 	   0,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -9,  -13, 	  -1,   -4, 	  -6,   -4, 	   2,   -8
+.2byte   -9,  -10, 	   0,   -6, 	  -6,   -3, 	   1,  -10
+.2byte  -12,  -11, 	  -8,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -12,  -10, 	  -3,   -1, 	  -9,    0, 	   0,   -8
+.2byte  -12,   -5, 	  -9,   -2, 	  -7,    0, 	  -1,  -10
+.2byte  -10,   -7, 	  -9,    0, 	  -4,    2, 	   0,   -9
+.2byte  -10,   -6, 	  -4,    0, 	  -8,    3, 	   0,   -8
+.2byte   -8,   -1, 	  -9,    2, 	  -4,    4, 	   1,   -8
+.2byte    0,    0, 	  -6,    3, 	   6,    3, 	   0,  -11
+.2byte   -8,   -2, 	 -11,   -1, 	  -3,    3, 	   0,   -9
+.2byte  -11,   -4, 	  -9,   -3, 	  -7,    1, 	   0,   -8
+.2byte  -10,   -8, 	  -1,   -6, 	  -8,   -2, 	   0,   -8
+.2byte    0,   -9, 	   6,   -2, 	  -6,   -2, 	   0,   -7
+.2byte    9,   -8, 	   0,   -6, 	   7,   -2, 	  -1,   -8
+.2byte   10,   -4, 	   8,   -3, 	   6,    1, 	  -1,   -8
+.2byte    7,   -2, 	  10,   -1, 	   2,    3, 	  -1,   -9
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,  -11
+.2byte  -10,   -7, 	  -9,    0, 	  -4,    2, 	   0,   -9
+.2byte  -12,  -11, 	  -8,   -2, 	  -6,    0, 	   0,  -10
+.2byte   -9,  -14, 	   0,   -5, 	  -6,   -3, 	   2,   -9
+.2byte   -1,  -15, 	   4,   -6, 	  -6,   -6, 	  -1,  -11
+.2byte    8,  -14, 	  -1,   -5, 	   5,   -3, 	  -3,   -9
+.2byte   11,  -11, 	   7,   -2, 	   5,    0, 	  -1,  -10
+.2byte    8,   -7, 	   7,    0, 	   2,    2, 	  -2,   -9
+sJolteonAnimTable1:
+.4byte sJolteonAnims_1_1
+.4byte sJolteonAnims_1_2
+.4byte sJolteonAnims_1_3
+.4byte sJolteonAnims_1_4
+.4byte sJolteonAnims_1_5
+.4byte sJolteonAnims_1_6
+.4byte sJolteonAnims_1_7
+.4byte sJolteonAnims_1_8
+sJolteonAnimTable2:
+.4byte sJolteonAnims_2_1
+.4byte sJolteonAnims_2_2
+.4byte sJolteonAnims_2_3
+.4byte sJolteonAnims_2_4
+.4byte sJolteonAnims_2_5
+.4byte sJolteonAnims_2_6
+.4byte sJolteonAnims_2_7
+.4byte sJolteonAnims_2_8
+sJolteonAnimTable3:
+.4byte sJolteonAnims_3_1
+.4byte sJolteonAnims_3_2
+.4byte sJolteonAnims_3_3
+.4byte sJolteonAnims_3_4
+.4byte sJolteonAnims_3_5
+.4byte sJolteonAnims_3_6
+.4byte sJolteonAnims_3_7
+.4byte sJolteonAnims_3_8
+sJolteonAnimTable4:
+.4byte sJolteonAnims_4_1
+.4byte sJolteonAnims_4_2
+.4byte sJolteonAnims_4_3
+.4byte sJolteonAnims_4_4
+.4byte sJolteonAnims_4_5
+.4byte sJolteonAnims_4_6
+.4byte sJolteonAnims_4_7
+.4byte sJolteonAnims_4_8
+sJolteonAnimTable5:
+.4byte sJolteonAnims_5_1
+.4byte sJolteonAnims_5_2
+.4byte sJolteonAnims_5_3
+.4byte sJolteonAnims_5_4
+.4byte sJolteonAnims_5_5
+.4byte sJolteonAnims_5_6
+.4byte sJolteonAnims_5_7
+.4byte sJolteonAnims_5_8
+sJolteonAnimTable6:
+.4byte sJolteonAnims_6_1
+.4byte sJolteonAnims_6_1
+.4byte sJolteonAnims_6_1
+.4byte sJolteonAnims_6_1
+.4byte sJolteonAnims_6_1
+.4byte sJolteonAnims_6_1
+.4byte sJolteonAnims_6_1
+.4byte sJolteonAnims_6_1
+sJolteonAnimTable7:
+.4byte sJolteonAnims_7_1
+.4byte sJolteonAnims_7_2
+.4byte sJolteonAnims_7_3
+.4byte sJolteonAnims_7_4
+.4byte sJolteonAnims_7_5
+.4byte sJolteonAnims_7_6
+.4byte sJolteonAnims_7_7
+.4byte sJolteonAnims_7_8
+sJolteonAnimTable8:
+.4byte sJolteonAnims_8_1
+.4byte sJolteonAnims_8_2
+.4byte sJolteonAnims_8_3
+.4byte sJolteonAnims_8_4
+.4byte sJolteonAnims_8_5
+.4byte sJolteonAnims_8_6
+.4byte sJolteonAnims_8_7
+.4byte sJolteonAnims_8_8
+sJolteonAnimTable9:
+.4byte sJolteonAnims_9_1
+.4byte sJolteonAnims_9_2
+.4byte sJolteonAnims_9_3
+.4byte sJolteonAnims_9_4
+.4byte sJolteonAnims_9_5
+.4byte sJolteonAnims_9_6
+.4byte sJolteonAnims_9_7
+.4byte sJolteonAnims_9_8
+sJolteonAnimTable10:
+.4byte sJolteonAnims_10_1
+.4byte sJolteonAnims_10_2
+.4byte sJolteonAnims_10_3
+.4byte sJolteonAnims_10_4
+.4byte sJolteonAnims_10_5
+.4byte sJolteonAnims_10_6
+.4byte sJolteonAnims_10_7
+.4byte sJolteonAnims_10_8
+sJolteonAnimTable11:
+.4byte sJolteonAnims_11_1
+.4byte sJolteonAnims_11_2
+.4byte sJolteonAnims_11_3
+.4byte sJolteonAnims_11_4
+.4byte sJolteonAnims_11_5
+.4byte sJolteonAnims_11_6
+.4byte sJolteonAnims_11_7
+.4byte sJolteonAnims_11_8
+sJolteonAnimTable12:
+.4byte sJolteonAnims_12_1
+.4byte sJolteonAnims_12_2
+.4byte sJolteonAnims_12_3
+.4byte sJolteonAnims_12_4
+.4byte sJolteonAnims_12_5
+.4byte sJolteonAnims_12_6
+.4byte sJolteonAnims_12_7
+.4byte sJolteonAnims_12_8
+sJolteonAnimTable13:
+.4byte sJolteonAnims_13_1
+.4byte sJolteonAnims_13_2
+.4byte sJolteonAnims_13_3
+.4byte sJolteonAnims_13_4
+.4byte sJolteonAnims_13_5
+.4byte sJolteonAnims_13_6
+.4byte sJolteonAnims_13_7
+.4byte sJolteonAnims_13_8
+sAxAnimationsJolteon:
+.4byte sJolteonAnimTable1
+.4byte sJolteonAnimTable2
+.4byte sJolteonAnimTable3
+.4byte sJolteonAnimTable4
+.4byte sJolteonAnimTable5
+.4byte sJolteonAnimTable6
+.4byte sJolteonAnimTable7
+.4byte sJolteonAnimTable8
+.4byte sJolteonAnimTable9
+.4byte sJolteonAnimTable10
+.4byte sJolteonAnimTable11
+.4byte sJolteonAnimTable12
+.4byte sJolteonAnimTable13
+sAxSpritesJolteon:
+.4byte sJolteonSprites1
+.4byte sJolteonSprites2
+.4byte sJolteonSprites3
+.4byte sJolteonSprites4
+.4byte sJolteonSprites5
+.4byte sJolteonSprites6
+.4byte sJolteonSprites7
+.4byte sJolteonSprites8
+.4byte sJolteonSprites9
+.4byte sJolteonSprites10
+.4byte sJolteonSprites11
+.4byte sJolteonSprites12
+.4byte sJolteonSprites13
+.4byte sJolteonSprites14
+.4byte sJolteonSprites15
+.4byte sJolteonSprites16
+.4byte sJolteonSprites17
+.4byte sJolteonSprites18
+.4byte sJolteonSprites19
+.4byte sJolteonSprites20
+.4byte sJolteonSprites21
+.4byte sJolteonSprites22
+.4byte sJolteonSprites23
+.4byte sJolteonSprites24
+.4byte sJolteonSprites25
+.4byte sJolteonSprites26
+.4byte sJolteonSprites27
+.4byte sJolteonSprites28
+.4byte sJolteonSprites29
+.4byte sJolteonSprites30
+.4byte sJolteonSprites31
+.4byte sJolteonSprites32
+.4byte sJolteonSprites33
+.4byte sJolteonSprites34
+.4byte sJolteonSprites35
+.4byte sJolteonSprites36
+.4byte sJolteonSprites37
+.4byte sJolteonSprites38
+.4byte sJolteonSprites39
+.4byte sJolteonSprites40
+.4byte sJolteonSprites41
+.4byte sJolteonSprites42
+.4byte sJolteonSprites43
+.4byte sJolteonSprites44
+.4byte sJolteonSprites45
+sAxMainJolteon:
+ax_main sAxPosesJolteon, sAxAnimationsJolteon, 13, sAxSpritesJolteon, sAxPositionsJolteon

--- a/data/ax/jumpluff.inc
+++ b/data/ax/jumpluff.inc
@@ -1,0 +1,2739 @@
+.global gAxJumpluff
+gAxJumpluff:
+ax_siro sAxMainJumpluff
+sJumpluffPose1:
+ax_pose 0, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose4:
+ax_pose 3, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose5:
+ax_pose 4, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose6:
+ax_pose 5, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose7:
+ax_pose 6, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose8:
+ax_pose 7, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose9:
+ax_pose 8, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose10:
+ax_pose 9, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose11:
+ax_pose 10, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose12:
+ax_pose 11, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose16:
+ax_pose 9, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose17:
+ax_pose 10, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose18:
+ax_pose 11, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose19:
+ax_pose 6, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose20:
+ax_pose 7, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose21:
+ax_pose 8, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose22:
+ax_pose 3, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose23:
+ax_pose 4, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose24:
+ax_pose 5, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose25:
+ax_pose 0, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose26:
+ax_pose 1, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose27:
+ax_pose 2, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose28:
+ax_pose 3, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose29:
+ax_pose 4, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose30:
+ax_pose 5, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose31:
+ax_pose 6, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose32:
+ax_pose 7, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose33:
+ax_pose 8, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose34:
+ax_pose 9, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose35:
+ax_pose 10, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose36:
+ax_pose 11, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose37:
+ax_pose 12, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose38:
+ax_pose 13, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose39:
+ax_pose 14, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose40:
+ax_pose 9, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose41:
+ax_pose 10, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose42:
+ax_pose 11, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose43:
+ax_pose 6, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose44:
+ax_pose 7, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose45:
+ax_pose 8, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose46:
+ax_pose 3, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose47:
+ax_pose 4, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose48:
+ax_pose 5, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose49:
+ax_pose 0, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose50:
+ax_pose 1, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose51:
+ax_pose 2, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose52:
+ax_pose 3, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose53:
+ax_pose 4, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose54:
+ax_pose 5, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose55:
+ax_pose 6, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose56:
+ax_pose 7, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose57:
+ax_pose 8, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose58:
+ax_pose 9, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose59:
+ax_pose 10, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose60:
+ax_pose 11, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose61:
+ax_pose 12, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose62:
+ax_pose 13, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose63:
+ax_pose 14, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose64:
+ax_pose 9, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose65:
+ax_pose 10, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose66:
+ax_pose 11, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose67:
+ax_pose 6, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose68:
+ax_pose 7, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose69:
+ax_pose 8, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose70:
+ax_pose 3, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose71:
+ax_pose 4, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose72:
+ax_pose 5, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose73:
+ax_pose 0, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose74:
+ax_pose 15, 0x81e7, 0x80f6, 0xcc00
+ax_pose_terminator
+sJumpluffPose75:
+ax_pose 16, 0x01e7, 0x80f3, 0xcc00
+ax_pose_terminator
+sJumpluffPose76:
+ax_pose 3, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose77:
+ax_pose 17, 0x81e8, 0x90fa, 0xcc00
+ax_pose_terminator
+sJumpluffPose78:
+ax_pose 18, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose79:
+ax_pose 6, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose80:
+ax_pose 19, 0x01e8, 0x90ec, 0xcc00
+ax_pose_terminator
+sJumpluffPose81:
+ax_pose 20, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose82:
+ax_pose 9, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose83:
+ax_pose 21, 0x81e8, 0x90f9, 0xcc00
+ax_pose_terminator
+sJumpluffPose84:
+ax_pose 22, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose85:
+ax_pose 12, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose86:
+ax_pose 23, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose87:
+ax_pose 24, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose88:
+ax_pose 9, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose89:
+ax_pose 21, 0x81e8, 0x80f6, 0xcc00
+ax_pose_terminator
+sJumpluffPose90:
+ax_pose 22, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose91:
+ax_pose 6, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose92:
+ax_pose 19, 0x01e8, 0x80f3, 0xcc00
+ax_pose_terminator
+sJumpluffPose93:
+ax_pose 20, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose94:
+ax_pose 3, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose95:
+ax_pose 17, 0x81e8, 0x80f5, 0xcc00
+ax_pose_terminator
+sJumpluffPose96:
+ax_pose 18, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose97:
+ax_pose 25, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose98:
+ax_pose 26, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose99:
+ax_pose 27, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose100:
+ax_pose 28, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose101:
+ax_pose 29, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose102:
+ax_pose 30, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose103:
+ax_pose 31, 0x81e8, 0x90f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose104:
+ax_pose 32, 0x81e8, 0x90f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose105:
+ax_pose 33, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose106:
+ax_pose 34, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose107:
+ax_pose 31, 0x81e8, 0x80f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose108:
+ax_pose 32, 0x81e8, 0x80f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose109:
+ax_pose 29, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose110:
+ax_pose 30, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose111:
+ax_pose 27, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose112:
+ax_pose 28, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose113:
+ax_pose 35, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose114:
+ax_pose 36, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose115:
+ax_pose 37, 0x01de, 0x80f1, 0xcc00
+ax_pose_terminator
+sJumpluffPose116:
+ax_pose 38, 0x01e3, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose117:
+ax_pose 39, 0x01e2, 0x90e8, 0xcc00
+ax_pose_terminator
+sJumpluffPose118:
+ax_pose 40, 0x01e3, 0x90ec, 0xcc00
+ax_pose_terminator
+sJumpluffPose119:
+ax_pose 41, 0x01e0, 0x80f1, 0xcc00
+ax_pose_terminator
+sJumpluffPose120:
+ax_pose 40, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose121:
+ax_pose 39, 0x01e2, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose122:
+ax_pose 38, 0x01e3, 0x80f5, 0xcc00
+ax_pose_terminator
+sJumpluffPose123:
+ax_pose 0, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose124:
+ax_pose 1, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose125:
+ax_pose 2, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose126:
+ax_pose 3, 0x01eb, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose127:
+ax_pose 4, 0x01eb, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose128:
+ax_pose 5, 0x01eb, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose129:
+ax_pose 6, 0x81eb, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose130:
+ax_pose 7, 0x81eb, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose131:
+ax_pose 8, 0x81eb, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose132:
+ax_pose 9, 0x01eb, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose133:
+ax_pose 10, 0x01eb, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose134:
+ax_pose 11, 0x01eb, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose135:
+ax_pose 12, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose136:
+ax_pose 13, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose137:
+ax_pose 14, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose138:
+ax_pose 9, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose139:
+ax_pose 10, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose140:
+ax_pose 11, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose141:
+ax_pose 6, 0x81eb, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose142:
+ax_pose 7, 0x81eb, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose143:
+ax_pose 8, 0x81eb, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose144:
+ax_pose 3, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose145:
+ax_pose 4, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose146:
+ax_pose 5, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose147:
+ax_pose 16, 0x01e7, 0x80f3, 0xcc00
+ax_pose_terminator
+sJumpluffPose148:
+ax_pose 18, 0x01e8, 0x80f5, 0xcc00
+ax_pose_terminator
+sJumpluffPose149:
+ax_pose 20, 0x81e8, 0x80f9, 0xcc00
+ax_pose_terminator
+sJumpluffPose150:
+ax_pose 22, 0x01e6, 0x80ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose151:
+ax_pose 24, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose152:
+ax_pose 22, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sJumpluffPose153:
+ax_pose 20, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose154:
+ax_pose 18, 0x01e8, 0x90ea, 0xcc00
+ax_pose_terminator
+sJumpluffPose155:
+ax_pose 16, 0x01e7, 0x80f3, 0xcc00
+ax_pose_terminator
+sJumpluffPose156:
+ax_pose 18, 0x01e8, 0x90ea, 0xcc00
+ax_pose_terminator
+sJumpluffPose157:
+ax_pose 20, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose158:
+ax_pose 22, 0x01e6, 0x90f1, 0xcc00
+ax_pose_terminator
+sJumpluffPose159:
+ax_pose 24, 0x01e5, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose160:
+ax_pose 22, 0x01e6, 0x80ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose161:
+ax_pose 20, 0x81e8, 0x80f9, 0xcc00
+ax_pose_terminator
+sJumpluffPose162:
+ax_pose 18, 0x01e8, 0x80f5, 0xcc00
+ax_pose_terminator
+sJumpluffPose163:
+ax_pose 0, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose164:
+ax_pose 15, 0x81e7, 0x80f6, 0xcc00
+ax_pose_terminator
+sJumpluffPose165:
+ax_pose 16, 0x01e8, 0x80f3, 0xcc00
+ax_pose_terminator
+sJumpluffPose166:
+ax_pose 3, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+sJumpluffPose167:
+ax_pose 17, 0x81e8, 0x90fa, 0xcc00
+ax_pose_terminator
+sJumpluffPose168:
+ax_pose 18, 0x01e9, 0x90ea, 0xcc00
+ax_pose_terminator
+sJumpluffPose169:
+ax_pose 6, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose170:
+ax_pose 19, 0x01e8, 0x90ec, 0xcc00
+ax_pose_terminator
+sJumpluffPose171:
+ax_pose 20, 0x81e9, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose172:
+ax_pose 9, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose173:
+ax_pose 21, 0x81e8, 0x90f9, 0xcc00
+ax_pose_terminator
+sJumpluffPose174:
+ax_pose 22, 0x01e8, 0x90f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose175:
+ax_pose 12, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose176:
+ax_pose 23, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose177:
+ax_pose 24, 0x01e6, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose178:
+ax_pose 9, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose179:
+ax_pose 21, 0x81e8, 0x80f6, 0xcc00
+ax_pose_terminator
+sJumpluffPose180:
+ax_pose 22, 0x01e8, 0x80ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose181:
+ax_pose 6, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose182:
+ax_pose 19, 0x01e8, 0x80f3, 0xcc00
+ax_pose_terminator
+sJumpluffPose183:
+ax_pose 20, 0x81e9, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose184:
+ax_pose 3, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose185:
+ax_pose 17, 0x81e8, 0x80f5, 0xcc00
+ax_pose_terminator
+sJumpluffPose186:
+ax_pose 18, 0x01e9, 0x80f5, 0xcc00
+ax_pose_terminator
+sJumpluffPose187:
+ax_pose 15, 0x81e7, 0x80f6, 0xcc00
+ax_pose_terminator
+sJumpluffPose188:
+ax_pose 17, 0x81e8, 0x80f6, 0xcc00
+ax_pose_terminator
+sJumpluffPose189:
+ax_pose 19, 0x01e8, 0x80f3, 0xcc00
+ax_pose_terminator
+sJumpluffPose190:
+ax_pose 21, 0x81e8, 0x80f6, 0xcc00
+ax_pose_terminator
+sJumpluffPose191:
+ax_pose 23, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose192:
+ax_pose 21, 0x81e8, 0x90f9, 0xcc00
+ax_pose_terminator
+sJumpluffPose193:
+ax_pose 19, 0x01e8, 0x90ec, 0xcc00
+ax_pose_terminator
+sJumpluffPose194:
+ax_pose 17, 0x81e8, 0x90fa, 0xcc00
+ax_pose_terminator
+sJumpluffPose195:
+ax_pose 0, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose196:
+ax_pose 3, 0x01e8, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose197:
+ax_pose 6, 0x81e8, 0x80f8, 0xcc00
+ax_pose_terminator
+sJumpluffPose198:
+ax_pose 9, 0x01e8, 0x80f0, 0xcc00
+ax_pose_terminator
+sJumpluffPose199:
+ax_pose 12, 0x01e7, 0x80f4, 0xcc00
+ax_pose_terminator
+sJumpluffPose200:
+ax_pose 9, 0x01e8, 0x90ef, 0xcc00
+ax_pose_terminator
+sJumpluffPose201:
+ax_pose 6, 0x81e8, 0x90f7, 0xcc00
+ax_pose_terminator
+sJumpluffPose202:
+ax_pose 3, 0x01e8, 0x90eb, 0xcc00
+ax_pose_terminator
+.align 2
+sJumpluffAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, 0,
+ax_anim 2, 0, 25, 0, -2, 0, 0,
+ax_anim 2, 0, 24, 0, -3, 0, 0,
+ax_anim 2, 0, 26, 0, -4, 0, 0,
+ax_anim 2, 0, 24, 0, -5, 0, 0,
+ax_anim 2, 0, 25, 0, -6, 0, 0,
+ax_anim 1, 0, 24, 0, -2, 0, 3,
+ax_anim 1, 0, 29, 0, 2, 0, 6,
+ax_anim 1, 2, 30, 0, 6, 0, 9,
+ax_anim 1, 0, 34, 0, 14, 0, 12,
+ax_anim 2, 0, 36, 0, 22, 0, 16,
+ax_anim 2, 1, 41, -1, 22, -1, 16,
+ax_anim 2, 0, 42, 0, 22, 0, 16,
+ax_anim 2, 0, 46, -1, 22, -1, 16,
+ax_anim 2, 0, 24, 0, 22, 0, 16,
+ax_anim 1, 0, 26, 0, 8, 0, 0,
+ax_anim 1, 0, 24, 0, 2, 0, 0,
+ax_anim 1, 0, 25, 0, 1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_2_2:
+ax_anim 2, 0, 27, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 0, -2, 0, 0,
+ax_anim 2, 0, 27, 0, -3, 0, 0,
+ax_anim 2, 0, 29, 0, -4, 0, 0,
+ax_anim 2, 0, 27, 0, -5, 0, 0,
+ax_anim 2, 0, 28, 0, -6, 0, 0,
+ax_anim 1, 0, 27, 3, -2, 3, 3,
+ax_anim 1, 0, 32, 6, 2, 6, 6,
+ax_anim 1, 2, 33, 9, 6, 9, 8,
+ax_anim 1, 0, 37, 14, 14, 12, 10,
+ax_anim 2, 0, 39, 22, 22, 22, 19,
+ax_anim 2, 1, 44, 21, 23, 21, 20,
+ax_anim 2, 0, 45, 22, 22, 22, 19,
+ax_anim 2, 0, 25, 21, 23, 21, 20,
+ax_anim 2, 0, 27, 22, 22, 22, 19,
+ax_anim 1, 0, 29, 8, 4, 8, 8,
+ax_anim 1, 0, 27, 4, 0, 4, 4,
+ax_anim 1, 0, 28, 2, -1, 2, 2,
+ax_anim_terminator
+sJumpluffAnims_2_3:
+ax_anim 2, 0, 30, 0, -1, 0, 0,
+ax_anim 2, 0, 31, 0, -2, 0, 0,
+ax_anim 2, 0, 30, 0, -3, 0, 0,
+ax_anim 2, 0, 32, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 2, 0, 31, 0, -6, 0, 0,
+ax_anim 1, 0, 30, 3, -5, 3, 0,
+ax_anim 1, 0, 35, 6, -4, 6, 0,
+ax_anim 1, 2, 36, 9, -3, 9, 0,
+ax_anim 1, 0, 40, 12, -2, 12, 0,
+ax_anim 2, 0, 42, 18, -1, 18, 0,
+ax_anim 2, 1, 47, 18, -2, 17, 0,
+ax_anim 2, 0, 24, 18, -1, 18, 0,
+ax_anim 2, 0, 28, 18, -2, 17, 0,
+ax_anim 2, 0, 30, 18, -1, 18, 0,
+ax_anim 1, 0, 32, 8, -3, 8, 0,
+ax_anim 1, 0, 30, 4, -2, 4, 0,
+ax_anim 1, 0, 31, 2, -1, 2, 0,
+ax_anim_terminator
+sJumpluffAnims_2_4:
+ax_anim 2, 0, 33, 0, -1, 0, 0,
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 33, 0, -3, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 33, 0, -5, 0, 0,
+ax_anim 2, 0, 34, 0, -6, 0, 0,
+ax_anim 1, 0, 33, 3, -8, 3, -3,
+ax_anim 1, 0, 38, 6, -10, 6, -6,
+ax_anim 1, 2, 39, 9, -13, 9, -9,
+ax_anim 1, 0, 43, 12, -15, 12, -12,
+ax_anim 2, 0, 45, 18, -18, 18, -18,
+ax_anim 2, 1, 26, 17, -19, 17, -19,
+ax_anim 2, 0, 27, 18, -18, 18, -18,
+ax_anim 2, 0, 31, 17, -19, 17, -19,
+ax_anim 2, 0, 33, 18, -18, 18, -18,
+ax_anim 1, 0, 35, 8, -12, 8, -8,
+ax_anim 1, 0, 33, 4, -8, 4, -4,
+ax_anim 1, 0, 34, 2, -4, 2, -2,
+ax_anim_terminator
+sJumpluffAnims_2_5:
+ax_anim 2, 0, 36, 0, -1, 0, 0,
+ax_anim 2, 0, 37, 0, -2, 0, 0,
+ax_anim 2, 0, 36, 0, -3, 0, 0,
+ax_anim 2, 0, 38, 0, -4, 0, 0,
+ax_anim 2, 0, 36, 0, -5, 0, 0,
+ax_anim 2, 0, 37, 0, -6, 0, 0,
+ax_anim 1, 0, 36, 0, -8, 0, -3,
+ax_anim 1, 0, 41, 0, -10, 0, -6,
+ax_anim 1, 2, 42, 0, -13, 0, -9,
+ax_anim 1, 0, 46, 0, -15, 0, -12,
+ax_anim 2, 0, 24, 0, -18, 0, -18,
+ax_anim 2, 1, 29, -1, -18, -1, -18,
+ax_anim 2, 0, 30, 0, -18, 0, -18,
+ax_anim 2, 0, 34, -1, -18, -1, -18,
+ax_anim 2, 0, 36, 0, -18, 0, -18,
+ax_anim 1, 0, 38, 0, -12, 0, -8,
+ax_anim 1, 0, 36, 0, -8, 0, -4,
+ax_anim 1, 0, 37, 0, -4, 0, -2,
+ax_anim_terminator
+sJumpluffAnims_2_6:
+ax_anim 2, 0, 39, 0, -1, 0, 0,
+ax_anim 2, 0, 40, 0, -2, 0, 0,
+ax_anim 2, 0, 39, 0, -3, 0, 0,
+ax_anim 2, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 39, 0, -5, 0, 0,
+ax_anim 2, 0, 40, 0, -6, 0, 0,
+ax_anim 1, 0, 39, -3, -8, -3, -3,
+ax_anim 1, 0, 44, -6, -10, -6, -6,
+ax_anim 1, 2, 45, -9, -13, -9, -9,
+ax_anim 1, 0, 25, -12, -15, -12, -12,
+ax_anim 2, 0, 27, -18, -18, -18, -18,
+ax_anim 2, 1, 32, -17, -19, -17, -19,
+ax_anim 2, 0, 33, -18, -18, -18, -18,
+ax_anim 2, 0, 37, -17, -19, -17, -19,
+ax_anim 2, 0, 39, -18, -18, -18, -18,
+ax_anim 1, 0, 41, -8, -12, -8, -8,
+ax_anim 1, 0, 39, -4, -8, -4, -4,
+ax_anim 1, 0, 40, -2, -4, -2, -2,
+ax_anim_terminator
+sJumpluffAnims_2_7:
+ax_anim 2, 0, 42, 0, -1, 0, 0,
+ax_anim 2, 0, 43, 0, -2, 0, 0,
+ax_anim 2, 0, 42, 0, -3, 0, 0,
+ax_anim 2, 0, 44, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 2, 0, 43, 0, -6, 0, 0,
+ax_anim 1, 0, 42, -3, -5, -3, 0,
+ax_anim 1, 0, 47, -6, -4, -6, 0,
+ax_anim 1, 2, 24, -9, -3, -9, 0,
+ax_anim 1, 0, 28, -12, -2, -12, 0,
+ax_anim 2, 0, 30, -18, -1, -18, 0,
+ax_anim 2, 1, 35, -18, -2, -17, 0,
+ax_anim 2, 0, 36, -18, -1, -18, 0,
+ax_anim 2, 0, 40, -18, -2, -17, 0,
+ax_anim 2, 0, 42, -18, -1, -18, 0,
+ax_anim 1, 0, 44, -8, -3, -8, 0,
+ax_anim 1, 0, 42, -4, -2, -4, 0,
+ax_anim 1, 0, 43, -2, -1, -2, 0,
+ax_anim_terminator
+sJumpluffAnims_2_8:
+ax_anim 2, 0, 45, 0, -1, 0, 0,
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 45, 0, -3, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 46, 0, -6, 0, 0,
+ax_anim 1, 0, 45, -3, -2, -3, 3,
+ax_anim 1, 0, 26, -6, 2, -6, 6,
+ax_anim 1, 2, 27, -9, 6, -9, 8,
+ax_anim 1, 0, 31, -14, 14, -12, 10,
+ax_anim 2, 0, 33, -22, 22, -22, 19,
+ax_anim 2, 1, 38, -21, 23, -21, 20,
+ax_anim 2, 0, 39, -22, 22, -22, 19,
+ax_anim 2, 0, 43, -21, 23, -21, 20,
+ax_anim 2, 0, 45, -22, 22, -22, 19,
+ax_anim 1, 0, 47, -8, 4, -8, 8,
+ax_anim 1, 0, 45, -4, 0, -4, 4,
+ax_anim 1, 0, 46, -2, -1, -2, 2,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 0, 48, 0, -3, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 2, 0, 49, 0, -6, 0, 0,
+ax_anim 1, 0, 48, 0, -2, 0, 3,
+ax_anim 1, 0, 53, 0, 2, 0, 6,
+ax_anim 1, 2, 54, 0, 6, 0, 9,
+ax_anim 1, 0, 58, 0, 14, 0, 12,
+ax_anim 2, 0, 60, 0, 22, 0, 16,
+ax_anim 2, 1, 65, -1, 22, -1, 16,
+ax_anim 2, 0, 66, 0, 22, 0, 16,
+ax_anim 2, 0, 70, -1, 22, -1, 16,
+ax_anim 2, 0, 48, 0, 22, 0, 16,
+ax_anim 1, 0, 50, 0, 8, 0, 0,
+ax_anim 1, 0, 48, 0, 2, 0, 0,
+ax_anim 1, 0, 49, 0, 1, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_3_2:
+ax_anim 2, 0, 51, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -3, 0, 0,
+ax_anim 2, 0, 53, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 52, 0, -6, 0, 0,
+ax_anim 1, 0, 51, 3, -2, 3, 3,
+ax_anim 1, 0, 56, 6, 2, 6, 6,
+ax_anim 1, 2, 57, 9, 6, 9, 8,
+ax_anim 1, 0, 61, 14, 14, 12, 10,
+ax_anim 2, 0, 63, 22, 22, 22, 19,
+ax_anim 2, 1, 68, 21, 23, 21, 20,
+ax_anim 2, 0, 69, 22, 22, 22, 19,
+ax_anim 2, 0, 49, 21, 23, 21, 20,
+ax_anim 2, 0, 51, 22, 22, 22, 19,
+ax_anim 1, 0, 53, 8, 4, 8, 8,
+ax_anim 1, 0, 51, 4, 0, 4, 4,
+ax_anim 1, 0, 52, 2, -1, 2, 2,
+ax_anim_terminator
+sJumpluffAnims_3_3:
+ax_anim 2, 0, 54, 0, -1, 0, 0,
+ax_anim 2, 0, 55, 0, -2, 0, 0,
+ax_anim 2, 0, 54, 0, -3, 0, 0,
+ax_anim 2, 0, 56, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 2, 0, 55, 0, -6, 0, 0,
+ax_anim 1, 0, 54, 3, -5, 3, 0,
+ax_anim 1, 0, 59, 6, -4, 6, 0,
+ax_anim 1, 2, 60, 9, -3, 9, 0,
+ax_anim 1, 0, 64, 12, -2, 12, 0,
+ax_anim 2, 0, 66, 18, -1, 18, 0,
+ax_anim 2, 1, 71, 18, -2, 17, 0,
+ax_anim 2, 0, 48, 18, -1, 18, 0,
+ax_anim 2, 0, 52, 18, -2, 17, 0,
+ax_anim 2, 0, 54, 18, -1, 18, 0,
+ax_anim 1, 0, 56, 8, -3, 8, 0,
+ax_anim 1, 0, 54, 4, -2, 4, 0,
+ax_anim 1, 0, 55, 2, -1, 2, 0,
+ax_anim_terminator
+sJumpluffAnims_3_4:
+ax_anim 2, 0, 57, 0, -1, 0, 0,
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 57, 0, -3, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 57, 0, -5, 0, 0,
+ax_anim 2, 0, 58, 0, -6, 0, 0,
+ax_anim 1, 0, 57, 3, -8, 3, -3,
+ax_anim 1, 0, 62, 6, -10, 6, -6,
+ax_anim 1, 2, 63, 9, -13, 9, -9,
+ax_anim 1, 0, 67, 12, -15, 12, -12,
+ax_anim 2, 0, 69, 18, -18, 18, -18,
+ax_anim 2, 1, 50, 17, -19, 17, -19,
+ax_anim 2, 0, 51, 18, -18, 18, -18,
+ax_anim 2, 0, 55, 17, -19, 17, -19,
+ax_anim 2, 0, 57, 18, -18, 18, -18,
+ax_anim 1, 0, 59, 8, -12, 8, -8,
+ax_anim 1, 0, 57, 4, -8, 4, -4,
+ax_anim 1, 0, 58, 2, -4, 2, -2,
+ax_anim_terminator
+sJumpluffAnims_3_5:
+ax_anim 2, 0, 60, 0, -1, 0, 0,
+ax_anim 2, 0, 61, 0, -2, 0, 0,
+ax_anim 2, 0, 60, 0, -3, 0, 0,
+ax_anim 2, 0, 62, 0, -4, 0, 0,
+ax_anim 2, 0, 60, 0, -5, 0, 0,
+ax_anim 2, 0, 61, 0, -6, 0, 0,
+ax_anim 1, 0, 60, 0, -8, 0, -3,
+ax_anim 1, 0, 65, 0, -10, 0, -6,
+ax_anim 1, 2, 66, 0, -13, 0, -9,
+ax_anim 1, 0, 70, 0, -15, 0, -12,
+ax_anim 2, 0, 48, 0, -18, 0, -18,
+ax_anim 2, 1, 53, -1, -18, -1, -18,
+ax_anim 2, 0, 54, 0, -18, 0, -18,
+ax_anim 2, 0, 58, -1, -18, -1, -18,
+ax_anim 2, 0, 60, 0, -18, 0, -18,
+ax_anim 1, 0, 62, 0, -12, 0, -8,
+ax_anim 1, 0, 60, 0, -8, 0, -4,
+ax_anim 1, 0, 61, 0, -4, 0, -2,
+ax_anim_terminator
+sJumpluffAnims_3_6:
+ax_anim 2, 0, 63, 0, -1, 0, 0,
+ax_anim 2, 0, 64, 0, -2, 0, 0,
+ax_anim 2, 0, 63, 0, -3, 0, 0,
+ax_anim 2, 0, 65, 0, -4, 0, 0,
+ax_anim 2, 0, 63, 0, -5, 0, 0,
+ax_anim 2, 0, 64, 0, -6, 0, 0,
+ax_anim 1, 0, 63, -3, -8, -3, -3,
+ax_anim 1, 0, 68, -6, -10, -6, -6,
+ax_anim 1, 2, 69, -9, -13, -9, -9,
+ax_anim 1, 0, 49, -12, -15, -12, -12,
+ax_anim 2, 0, 51, -18, -18, -18, -18,
+ax_anim 2, 1, 56, -17, -19, -17, -19,
+ax_anim 2, 0, 57, -18, -18, -18, -18,
+ax_anim 2, 0, 61, -17, -19, -17, -19,
+ax_anim 2, 0, 63, -18, -18, -18, -18,
+ax_anim 1, 0, 65, -8, -12, -8, -8,
+ax_anim 1, 0, 63, -4, -8, -4, -4,
+ax_anim 1, 0, 64, -2, -4, -2, -2,
+ax_anim_terminator
+sJumpluffAnims_3_7:
+ax_anim 2, 0, 66, 0, -1, 0, 0,
+ax_anim 2, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 66, 0, -3, 0, 0,
+ax_anim 2, 0, 68, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, 0,
+ax_anim 1, 0, 66, -3, -5, -3, 0,
+ax_anim 1, 0, 71, -6, -4, -6, 0,
+ax_anim 1, 2, 48, -9, -3, -9, 0,
+ax_anim 1, 0, 52, -12, -2, -12, 0,
+ax_anim 2, 0, 54, -18, -1, -18, 0,
+ax_anim 2, 1, 59, -18, -2, -17, 0,
+ax_anim 2, 0, 60, -18, -1, -18, 0,
+ax_anim 2, 0, 64, -18, -2, -17, 0,
+ax_anim 2, 0, 66, -18, -1, -18, 0,
+ax_anim 1, 0, 68, -8, -3, -8, 0,
+ax_anim 1, 0, 66, -4, -2, -4, 0,
+ax_anim 1, 0, 67, -2, -1, -2, 0,
+ax_anim_terminator
+sJumpluffAnims_3_8:
+ax_anim 2, 0, 69, 0, -1, 0, 0,
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 69, 0, -3, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 70, 0, -6, 0, 0,
+ax_anim 1, 0, 69, -3, -2, -3, 3,
+ax_anim 1, 0, 50, -6, 2, -6, 6,
+ax_anim 1, 2, 51, -9, 6, -9, 8,
+ax_anim 1, 0, 55, -14, 14, -12, 10,
+ax_anim 2, 0, 57, -22, 22, -22, 19,
+ax_anim 2, 1, 62, -21, 23, -21, 20,
+ax_anim 2, 0, 63, -22, 22, -22, 19,
+ax_anim 2, 0, 67, -21, 23, -21, 20,
+ax_anim 2, 0, 69, -22, 22, -22, 19,
+ax_anim 1, 0, 71, -8, 4, -8, 8,
+ax_anim 1, 0, 69, -4, 0, -4, 4,
+ax_anim 1, 0, 70, -2, -1, -2, 2,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 1, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 1, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sJumpluffAnims_4_2:
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 1, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 1, 77, 4, 2, 4, 2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 4, 2, 4, 2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 4, 2, 4, 2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sJumpluffAnims_4_3:
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 1, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 1, 80, 3, -1, 3, -1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, -1, 3, -1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, -1, 3, -1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sJumpluffAnims_4_4:
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 1, 0, 83, -1, 1, -1, 1,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 1, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sJumpluffAnims_4_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 1, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 1, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sJumpluffAnims_4_6:
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 1, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 1, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sJumpluffAnims_4_7:
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 1, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 1, 92, -3, -1, -3, -1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, -1, -3, -1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, -1, -3, -1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sJumpluffAnims_4_8:
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 1, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 1, 95, -4, 2, -4, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -4, 2, -4, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -4, 2, -4, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_5_1:
+ax_anim 3, 0, 96, 0, -1, 0, 0,
+ax_anim 3, 0, 97, 0, -2, 0, 0,
+ax_anim 3, 0, 96, 0, -4, 0, 0,
+ax_anim 3, 0, 97, 0, -5, 0, 0,
+ax_anim 3, 0, 96, 0, -6, 0, 0,
+ax_anim 3, 2, 97, 0, -6, 0, 0,
+ax_anim 3, 0, 96, 0, -6, 0, 0,
+ax_anim 3, 0, 96, 0, -4, 0, 0,
+ax_anim 3, 0, 96, 0, -2, 0, 0,
+ax_anim 3, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_5_2:
+ax_anim 3, 0, 98, 0, -1, 0, 0,
+ax_anim 3, 0, 99, 0, -2, 0, 0,
+ax_anim 3, 0, 98, 0, -4, 0, 0,
+ax_anim 3, 0, 99, 0, -5, 0, 0,
+ax_anim 3, 0, 98, 0, -6, 0, 0,
+ax_anim 3, 2, 99, 0, -6, 0, 0,
+ax_anim 3, 0, 98, 0, -6, 0, 0,
+ax_anim 3, 0, 98, 0, -4, 0, 0,
+ax_anim 3, 0, 98, 0, -2, 0, 0,
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_5_3:
+ax_anim 3, 0, 100, 0, -1, 0, 0,
+ax_anim 3, 0, 101, 0, -2, 0, 0,
+ax_anim 3, 0, 100, 0, -4, 0, 0,
+ax_anim 3, 0, 101, 0, -5, 0, 0,
+ax_anim 3, 0, 100, 0, -6, 0, 0,
+ax_anim 3, 2, 101, 0, -6, 0, 0,
+ax_anim 3, 0, 100, 0, -6, 0, 0,
+ax_anim 3, 0, 100, 0, -4, 0, 0,
+ax_anim 3, 0, 100, 0, -2, 0, 0,
+ax_anim 3, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_5_4:
+ax_anim 3, 0, 102, 0, -1, 0, 0,
+ax_anim 3, 0, 103, 0, -2, 0, 0,
+ax_anim 3, 0, 102, 0, -4, 0, 0,
+ax_anim 3, 0, 103, 0, -5, 0, 0,
+ax_anim 3, 0, 102, 0, -6, 0, 0,
+ax_anim 3, 2, 103, 0, -6, 0, 0,
+ax_anim 3, 0, 102, 0, -6, 0, 0,
+ax_anim 3, 0, 102, 0, -4, 0, 0,
+ax_anim 3, 0, 102, 0, -2, 0, 0,
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_5_5:
+ax_anim 3, 0, 104, 0, -1, 0, 0,
+ax_anim 3, 0, 105, 0, -2, 0, 0,
+ax_anim 3, 0, 104, 0, -4, 0, 0,
+ax_anim 3, 0, 105, 0, -5, 0, 0,
+ax_anim 3, 0, 104, 0, -6, 0, 0,
+ax_anim 3, 2, 105, 0, -6, 0, 0,
+ax_anim 3, 0, 104, 0, -6, 0, 0,
+ax_anim 3, 0, 104, 0, -4, 0, 0,
+ax_anim 3, 0, 104, 0, -2, 0, 0,
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_5_6:
+ax_anim 3, 0, 106, 0, -1, 0, 0,
+ax_anim 3, 0, 107, 0, -2, 0, 0,
+ax_anim 3, 0, 106, 0, -4, 0, 0,
+ax_anim 3, 0, 107, 0, -5, 0, 0,
+ax_anim 3, 0, 106, 0, -6, 0, 0,
+ax_anim 3, 2, 107, 0, -6, 0, 0,
+ax_anim 3, 0, 106, 0, -6, 0, 0,
+ax_anim 3, 0, 106, 0, -4, 0, 0,
+ax_anim 3, 0, 106, 0, -2, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_5_7:
+ax_anim 3, 0, 108, 0, -1, 0, 0,
+ax_anim 3, 0, 109, 0, -2, 0, 0,
+ax_anim 3, 0, 108, 0, -4, 0, 0,
+ax_anim 3, 0, 109, 0, -5, 0, 0,
+ax_anim 3, 0, 108, 0, -6, 0, 0,
+ax_anim 3, 2, 109, 0, -6, 0, 0,
+ax_anim 3, 0, 108, 0, -6, 0, 0,
+ax_anim 3, 0, 108, 0, -4, 0, 0,
+ax_anim 3, 0, 108, 0, -2, 0, 0,
+ax_anim 3, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_5_8:
+ax_anim 3, 0, 110, 0, -1, 0, 0,
+ax_anim 3, 0, 111, 0, -2, 0, 0,
+ax_anim 3, 0, 110, 0, -4, 0, 0,
+ax_anim 3, 0, 111, 0, -5, 0, 0,
+ax_anim 3, 0, 110, 0, -6, 0, 0,
+ax_anim 3, 2, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 110, 0, -6, 0, 0,
+ax_anim 3, 0, 110, 0, -4, 0, 0,
+ax_anim 3, 0, 110, 0, -2, 0, 0,
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_6_1:
+ax_anim 8, 0, 112, 0, 0, 0, 0,
+ax_anim 8, 0, 112, 0, -1, 0, 0,
+ax_anim 26, 0, 112, 0, -2, 0, 0,
+ax_anim 8, 0, 113, 0, -2, 0, 0,
+ax_anim 8, 0, 113, 0, -1, 0, 0,
+ax_anim 26, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sJumpluffAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sJumpluffAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sJumpluffAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sJumpluffAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sJumpluffAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sJumpluffAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sJumpluffAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_8_1:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_8_2:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_8_3:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_8_4:
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_8_5:
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_8_6:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_8_7:
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_8_8:
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 11, 8, 11,
+ax_anim 2, 0, 149, 7, 21, 7, 20,
+ax_anim 3, 0, 150, 0, 25, 0, 22,
+ax_anim 2, 3, 151, -7, 21, -7, 20,
+ax_anim 2, 0, 152, -8, 11, -8, 11,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 18, 5, 18, 5,
+ax_anim 2, 0, 148, 21, 13, 21, 13,
+ax_anim 3, 0, 149, 23, 24, 23, 22,
+ax_anim 2, 3, 150, 13, 25, 13, 24,
+ax_anim 2, 0, 151, 4, 18, 4, 18,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 19, -3, 19, -3,
+ax_anim 3, 0, 148, 23, 2, 23, 0,
+ax_anim 2, 3, 149, 20, 6, 20, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -8, 0, -8,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 14, -20, 14, -20,
+ax_anim 3, 0, 147, 23, -18, 23, -20,
+ax_anim 2, 3, 148, 23, -11, 23, -11,
+ax_anim 2, 0, 149, 18, -4, 18, -4,
+ax_anim 1, 0, 150, 8, 0, 8, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -10, -9, -10,
+ax_anim 2, 0, 153, -7, -17, -7, -18,
+ax_anim 3, 0, 146, 0, -19, 0, -21,
+ax_anim 2, 3, 147, 7, -17, 7, -18,
+ax_anim 2, 0, 148, 9, -10, 9, -10,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -8, 0, -8,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -14, -20, -14, -20,
+ax_anim 3, 0, 153, -23, -18, -23, -20,
+ax_anim 2, 3, 152, -23, -11, -23, -11,
+ax_anim 2, 0, 151, -18, -4, -18, -4,
+ax_anim 1, 0, 150, -8, 0, -8, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -19, -3, -19, -3,
+ax_anim 3, 0, 152, -23, 2, -23, 0,
+ax_anim 2, 3, 151, -20, 6, -20, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -18, 5, -18, 5,
+ax_anim 2, 0, 152, -21, 13, -21, 13,
+ax_anim 3, 0, 151, -23, 24, -23, 22,
+ax_anim 2, 3, 150, -13, 25, -13, 24,
+ax_anim 2, 0, 149, -4, 18, -4, 18,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 3, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 3, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 3, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 3, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 5, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 3, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 3, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJumpluffAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sJumpluffGfx1:
+.incbin "baserom.gba", 0xD262B8, 0x200
+sJumpluffSprites1:
+ax_sprite sJumpluffGfx1, 0x200
+ax_sprite_terminator
+sJumpluffGfx2:
+.incbin "baserom.gba", 0xD264C8, 0x200
+sJumpluffSprites2:
+ax_sprite sJumpluffGfx2, 0x200
+ax_sprite_terminator
+sJumpluffGfx3:
+.incbin "baserom.gba", 0xD266D8, 0x200
+sJumpluffSprites3:
+ax_sprite sJumpluffGfx3, 0x200
+ax_sprite_terminator
+sJumpluffGfx4:
+.incbin "baserom.gba", 0xD268E8, 0x200
+sJumpluffSprites4:
+ax_sprite sJumpluffGfx4, 0x200
+ax_sprite_terminator
+sJumpluffGfx5:
+.incbin "baserom.gba", 0xD26AF8, 0x200
+sJumpluffSprites5:
+ax_sprite sJumpluffGfx5, 0x200
+ax_sprite_terminator
+sJumpluffGfx6:
+.incbin "baserom.gba", 0xD26D08, 0x200
+sJumpluffSprites6:
+ax_sprite sJumpluffGfx6, 0x200
+ax_sprite_terminator
+sJumpluffGfx7:
+.incbin "baserom.gba", 0xD26F18, 0x100
+sJumpluffSprites7:
+ax_sprite sJumpluffGfx7, 0x100
+ax_sprite_terminator
+sJumpluffGfx8:
+.incbin "baserom.gba", 0xD27028, 0x100
+sJumpluffSprites8:
+ax_sprite sJumpluffGfx8, 0x100
+ax_sprite_terminator
+sJumpluffGfx9:
+.incbin "baserom.gba", 0xD27138, 0x100
+sJumpluffSprites9:
+ax_sprite sJumpluffGfx9, 0x100
+ax_sprite_terminator
+sJumpluffGfx10:
+.incbin "baserom.gba", 0xD27248, 0x200
+sJumpluffSprites10:
+ax_sprite sJumpluffGfx10, 0x200
+ax_sprite_terminator
+sJumpluffGfx11:
+.incbin "baserom.gba", 0xD27458, 0x200
+sJumpluffSprites11:
+ax_sprite sJumpluffGfx11, 0x200
+ax_sprite_terminator
+sJumpluffGfx12:
+.incbin "baserom.gba", 0xD27668, 0x200
+sJumpluffSprites12:
+ax_sprite sJumpluffGfx12, 0x200
+ax_sprite_terminator
+sJumpluffGfx13:
+.incbin "baserom.gba", 0xD27878, 0x200
+sJumpluffSprites13:
+ax_sprite sJumpluffGfx13, 0x200
+ax_sprite_terminator
+sJumpluffGfx14:
+.incbin "baserom.gba", 0xD27A88, 0x200
+sJumpluffSprites14:
+ax_sprite sJumpluffGfx14, 0x200
+ax_sprite_terminator
+sJumpluffGfx15:
+.incbin "baserom.gba", 0xD27C98, 0x200
+sJumpluffSprites15:
+ax_sprite sJumpluffGfx15, 0x200
+ax_sprite_terminator
+sJumpluffGfx16:
+.incbin "baserom.gba", 0xD27EA8, 0xC0
+sJumpluffSprites16:
+ax_sprite sJumpluffGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx17:
+.incbin "baserom.gba", 0xD27F80, 0x60
+sJumpluffGfx17_1:
+.incbin "baserom.gba", 0xD27FE0, 0xE0
+sJumpluffSprites17:
+ax_sprite sJumpluffGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx17_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx18:
+.incbin "baserom.gba", 0xD280E8, 0xC0
+sJumpluffSprites18:
+ax_sprite sJumpluffGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx19:
+.incbin "baserom.gba", 0xD281C0, 0x60
+sJumpluffGfx19_1:
+.incbin "baserom.gba", 0xD28220, 0x60
+sJumpluffGfx19_2:
+.incbin "baserom.gba", 0xD28280, 0x60
+sJumpluffSprites19:
+ax_sprite sJumpluffGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx20:
+.incbin "baserom.gba", 0xD28318, 0x60
+sJumpluffGfx20_1:
+.incbin "baserom.gba", 0xD28378, 0x60
+sJumpluffGfx20_2:
+.incbin "baserom.gba", 0xD283D8, 0x60
+sJumpluffSprites20:
+ax_sprite sJumpluffGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx21:
+.incbin "baserom.gba", 0xD28470, 0xC0
+sJumpluffSprites21:
+ax_sprite sJumpluffGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx22:
+.incbin "baserom.gba", 0xD28548, 0xC0
+sJumpluffSprites22:
+ax_sprite sJumpluffGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx23:
+.incbin "baserom.gba", 0xD28620, 0x40
+sJumpluffGfx23_1:
+.incbin "baserom.gba", 0xD28660, 0x60
+sJumpluffGfx23_2:
+.incbin "baserom.gba", 0xD286C0, 0x60
+sJumpluffSprites23:
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sJumpluffGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx23_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sJumpluffGfx24:
+.incbin "baserom.gba", 0xD28760, 0x60
+sJumpluffGfx24_1:
+.incbin "baserom.gba", 0xD287C0, 0x60
+sJumpluffGfx24_2:
+.incbin "baserom.gba", 0xD28820, 0x60
+sJumpluffSprites24:
+ax_sprite sJumpluffGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx25:
+.incbin "baserom.gba", 0xD288B8, 0x40
+sJumpluffGfx25_1:
+.incbin "baserom.gba", 0xD288F8, 0x60
+sJumpluffGfx25_2:
+.incbin "baserom.gba", 0xD28958, 0x60
+sJumpluffGfx25_3:
+.incbin "baserom.gba", 0xD289B8, 0x20
+sJumpluffSprites25:
+ax_sprite sJumpluffGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sJumpluffGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sJumpluffGfx25_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx26:
+.incbin "baserom.gba", 0xD28A20, 0x60
+sJumpluffGfx26_1:
+.incbin "baserom.gba", 0xD28A80, 0x60
+sJumpluffGfx26_2:
+.incbin "baserom.gba", 0xD28AE0, 0x60
+sJumpluffSprites26:
+ax_sprite sJumpluffGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx27:
+.incbin "baserom.gba", 0xD28B78, 0x60
+sJumpluffGfx27_1:
+.incbin "baserom.gba", 0xD28BD8, 0x60
+sJumpluffGfx27_2:
+.incbin "baserom.gba", 0xD28C38, 0x60
+sJumpluffSprites27:
+ax_sprite sJumpluffGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx28:
+.incbin "baserom.gba", 0xD28CD0, 0x60
+sJumpluffGfx28_1:
+.incbin "baserom.gba", 0xD28D30, 0x60
+sJumpluffGfx28_2:
+.incbin "baserom.gba", 0xD28D90, 0x60
+sJumpluffSprites28:
+ax_sprite sJumpluffGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx29:
+.incbin "baserom.gba", 0xD28E28, 0x60
+sJumpluffGfx29_1:
+.incbin "baserom.gba", 0xD28E88, 0x60
+sJumpluffGfx29_2:
+.incbin "baserom.gba", 0xD28EE8, 0x60
+sJumpluffSprites29:
+ax_sprite sJumpluffGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx30:
+.incbin "baserom.gba", 0xD28F80, 0xC0
+sJumpluffSprites30:
+ax_sprite sJumpluffGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx31:
+.incbin "baserom.gba", 0xD29058, 0xC0
+sJumpluffSprites31:
+ax_sprite sJumpluffGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx32:
+.incbin "baserom.gba", 0xD29130, 0xC0
+sJumpluffSprites32:
+ax_sprite sJumpluffGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx33:
+.incbin "baserom.gba", 0xD29208, 0xC0
+sJumpluffSprites33:
+ax_sprite sJumpluffGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sJumpluffGfx34:
+.incbin "baserom.gba", 0xD292E0, 0x60
+sJumpluffGfx34_1:
+.incbin "baserom.gba", 0xD29340, 0x60
+sJumpluffGfx34_2:
+.incbin "baserom.gba", 0xD293A0, 0x60
+sJumpluffSprites34:
+ax_sprite sJumpluffGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx35:
+.incbin "baserom.gba", 0xD29438, 0x60
+sJumpluffGfx35_1:
+.incbin "baserom.gba", 0xD29498, 0x60
+sJumpluffGfx35_2:
+.incbin "baserom.gba", 0xD294F8, 0x60
+sJumpluffSprites35:
+ax_sprite sJumpluffGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJumpluffGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sJumpluffGfx36:
+.incbin "baserom.gba", 0xD29590, 0x200
+sJumpluffSprites36:
+ax_sprite sJumpluffGfx36, 0x200
+ax_sprite_terminator
+sJumpluffGfx37:
+.incbin "baserom.gba", 0xD297A0, 0x200
+sJumpluffSprites37:
+ax_sprite sJumpluffGfx37, 0x200
+ax_sprite_terminator
+sJumpluffGfx38:
+.incbin "baserom.gba", 0xD299B0, 0x200
+sJumpluffSprites38:
+ax_sprite sJumpluffGfx38, 0x200
+ax_sprite_terminator
+sJumpluffGfx39:
+.incbin "baserom.gba", 0xD29BC0, 0x200
+sJumpluffSprites39:
+ax_sprite sJumpluffGfx39, 0x200
+ax_sprite_terminator
+sJumpluffGfx40:
+.incbin "baserom.gba", 0xD29DD0, 0x200
+sJumpluffSprites40:
+ax_sprite sJumpluffGfx40, 0x200
+ax_sprite_terminator
+sJumpluffGfx41:
+.incbin "baserom.gba", 0xD29FE0, 0x200
+sJumpluffSprites41:
+ax_sprite sJumpluffGfx41, 0x200
+ax_sprite_terminator
+sJumpluffGfx42:
+.incbin "baserom.gba", 0xD2A1F0, 0x200
+sJumpluffSprites42:
+ax_sprite sJumpluffGfx42, 0x200
+ax_sprite_terminator
+sAxPosesJumpluff:
+.4byte sJumpluffPose1
+.4byte sJumpluffPose2
+.4byte sJumpluffPose3
+.4byte sJumpluffPose4
+.4byte sJumpluffPose5
+.4byte sJumpluffPose6
+.4byte sJumpluffPose7
+.4byte sJumpluffPose8
+.4byte sJumpluffPose9
+.4byte sJumpluffPose10
+.4byte sJumpluffPose11
+.4byte sJumpluffPose12
+.4byte sJumpluffPose13
+.4byte sJumpluffPose14
+.4byte sJumpluffPose15
+.4byte sJumpluffPose16
+.4byte sJumpluffPose17
+.4byte sJumpluffPose18
+.4byte sJumpluffPose19
+.4byte sJumpluffPose20
+.4byte sJumpluffPose21
+.4byte sJumpluffPose22
+.4byte sJumpluffPose23
+.4byte sJumpluffPose24
+.4byte sJumpluffPose25
+.4byte sJumpluffPose26
+.4byte sJumpluffPose27
+.4byte sJumpluffPose28
+.4byte sJumpluffPose29
+.4byte sJumpluffPose30
+.4byte sJumpluffPose31
+.4byte sJumpluffPose32
+.4byte sJumpluffPose33
+.4byte sJumpluffPose34
+.4byte sJumpluffPose35
+.4byte sJumpluffPose36
+.4byte sJumpluffPose37
+.4byte sJumpluffPose38
+.4byte sJumpluffPose39
+.4byte sJumpluffPose40
+.4byte sJumpluffPose41
+.4byte sJumpluffPose42
+.4byte sJumpluffPose43
+.4byte sJumpluffPose44
+.4byte sJumpluffPose45
+.4byte sJumpluffPose46
+.4byte sJumpluffPose47
+.4byte sJumpluffPose48
+.4byte sJumpluffPose49
+.4byte sJumpluffPose50
+.4byte sJumpluffPose51
+.4byte sJumpluffPose52
+.4byte sJumpluffPose53
+.4byte sJumpluffPose54
+.4byte sJumpluffPose55
+.4byte sJumpluffPose56
+.4byte sJumpluffPose57
+.4byte sJumpluffPose58
+.4byte sJumpluffPose59
+.4byte sJumpluffPose60
+.4byte sJumpluffPose61
+.4byte sJumpluffPose62
+.4byte sJumpluffPose63
+.4byte sJumpluffPose64
+.4byte sJumpluffPose65
+.4byte sJumpluffPose66
+.4byte sJumpluffPose67
+.4byte sJumpluffPose68
+.4byte sJumpluffPose69
+.4byte sJumpluffPose70
+.4byte sJumpluffPose71
+.4byte sJumpluffPose72
+.4byte sJumpluffPose73
+.4byte sJumpluffPose74
+.4byte sJumpluffPose75
+.4byte sJumpluffPose76
+.4byte sJumpluffPose77
+.4byte sJumpluffPose78
+.4byte sJumpluffPose79
+.4byte sJumpluffPose80
+.4byte sJumpluffPose81
+.4byte sJumpluffPose82
+.4byte sJumpluffPose83
+.4byte sJumpluffPose84
+.4byte sJumpluffPose85
+.4byte sJumpluffPose86
+.4byte sJumpluffPose87
+.4byte sJumpluffPose88
+.4byte sJumpluffPose89
+.4byte sJumpluffPose90
+.4byte sJumpluffPose91
+.4byte sJumpluffPose92
+.4byte sJumpluffPose93
+.4byte sJumpluffPose94
+.4byte sJumpluffPose95
+.4byte sJumpluffPose96
+.4byte sJumpluffPose97
+.4byte sJumpluffPose98
+.4byte sJumpluffPose99
+.4byte sJumpluffPose100
+.4byte sJumpluffPose101
+.4byte sJumpluffPose102
+.4byte sJumpluffPose103
+.4byte sJumpluffPose104
+.4byte sJumpluffPose105
+.4byte sJumpluffPose106
+.4byte sJumpluffPose107
+.4byte sJumpluffPose108
+.4byte sJumpluffPose109
+.4byte sJumpluffPose110
+.4byte sJumpluffPose111
+.4byte sJumpluffPose112
+.4byte sJumpluffPose113
+.4byte sJumpluffPose114
+.4byte sJumpluffPose115
+.4byte sJumpluffPose116
+.4byte sJumpluffPose117
+.4byte sJumpluffPose118
+.4byte sJumpluffPose119
+.4byte sJumpluffPose120
+.4byte sJumpluffPose121
+.4byte sJumpluffPose122
+.4byte sJumpluffPose123
+.4byte sJumpluffPose124
+.4byte sJumpluffPose125
+.4byte sJumpluffPose126
+.4byte sJumpluffPose127
+.4byte sJumpluffPose128
+.4byte sJumpluffPose129
+.4byte sJumpluffPose130
+.4byte sJumpluffPose131
+.4byte sJumpluffPose132
+.4byte sJumpluffPose133
+.4byte sJumpluffPose134
+.4byte sJumpluffPose135
+.4byte sJumpluffPose136
+.4byte sJumpluffPose137
+.4byte sJumpluffPose138
+.4byte sJumpluffPose139
+.4byte sJumpluffPose140
+.4byte sJumpluffPose141
+.4byte sJumpluffPose142
+.4byte sJumpluffPose143
+.4byte sJumpluffPose144
+.4byte sJumpluffPose145
+.4byte sJumpluffPose146
+.4byte sJumpluffPose147
+.4byte sJumpluffPose148
+.4byte sJumpluffPose149
+.4byte sJumpluffPose150
+.4byte sJumpluffPose151
+.4byte sJumpluffPose152
+.4byte sJumpluffPose153
+.4byte sJumpluffPose154
+.4byte sJumpluffPose155
+.4byte sJumpluffPose156
+.4byte sJumpluffPose157
+.4byte sJumpluffPose158
+.4byte sJumpluffPose159
+.4byte sJumpluffPose160
+.4byte sJumpluffPose161
+.4byte sJumpluffPose162
+.4byte sJumpluffPose163
+.4byte sJumpluffPose164
+.4byte sJumpluffPose165
+.4byte sJumpluffPose166
+.4byte sJumpluffPose167
+.4byte sJumpluffPose168
+.4byte sJumpluffPose169
+.4byte sJumpluffPose170
+.4byte sJumpluffPose171
+.4byte sJumpluffPose172
+.4byte sJumpluffPose173
+.4byte sJumpluffPose174
+.4byte sJumpluffPose175
+.4byte sJumpluffPose176
+.4byte sJumpluffPose177
+.4byte sJumpluffPose178
+.4byte sJumpluffPose179
+.4byte sJumpluffPose180
+.4byte sJumpluffPose181
+.4byte sJumpluffPose182
+.4byte sJumpluffPose183
+.4byte sJumpluffPose184
+.4byte sJumpluffPose185
+.4byte sJumpluffPose186
+.4byte sJumpluffPose187
+.4byte sJumpluffPose188
+.4byte sJumpluffPose189
+.4byte sJumpluffPose190
+.4byte sJumpluffPose191
+.4byte sJumpluffPose192
+.4byte sJumpluffPose193
+.4byte sJumpluffPose194
+.4byte sJumpluffPose195
+.4byte sJumpluffPose196
+.4byte sJumpluffPose197
+.4byte sJumpluffPose198
+.4byte sJumpluffPose199
+.4byte sJumpluffPose200
+.4byte sJumpluffPose201
+.4byte sJumpluffPose202
+sAxPositionsJumpluff:
+.2byte   -1,   -8, 	  -9,   -9, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,  -10, 	   8,  -10, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -9
+.2byte    1,   -8, 	   5,  -13, 	  -8,   -8, 	   0,   -8
+.2byte    1,   -8, 	   5,  -11, 	  -8,   -6, 	   0,   -8
+.2byte    3,   -8, 	   4,  -12, 	  -4,   -5, 	  -1,   -8
+.2byte    3,   -8, 	   4,  -13, 	  -4,   -7, 	  -1,   -8
+.2byte    3,   -8, 	   3,  -11, 	  -4,   -5, 	  -1,   -8
+.2byte    0,   -7, 	  -6,  -10, 	   4,   -7, 	  -2,   -8
+.2byte   -1,   -7, 	  -6,  -11, 	   4,   -8, 	  -2,   -8
+.2byte   -1,   -7, 	  -6,  -10, 	   4,   -6, 	  -2,   -8
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -1,   -9, 	   8,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,   -8, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte   -2,   -7, 	   4,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -1,   -7, 	   4,  -11, 	  -6,   -8, 	   0,   -8
+.2byte   -1,   -7, 	   4,  -10, 	  -6,   -6, 	   0,   -8
+.2byte   -5,   -8, 	  -6,  -12, 	   2,   -5, 	  -1,   -8
+.2byte   -5,   -8, 	  -6,  -13, 	   2,   -7, 	  -1,   -8
+.2byte   -5,   -8, 	  -5,  -11, 	   2,   -5, 	  -1,   -8
+.2byte   -3,   -8, 	  -7,  -12, 	   6,   -7, 	  -2,   -9
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -8, 	  -2,   -8
+.2byte   -3,   -8, 	  -7,  -11, 	   6,   -6, 	  -2,   -8
+.2byte   -1,   -8, 	  -9,   -9, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,  -10, 	   8,  -10, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -9
+.2byte    1,   -8, 	   5,  -13, 	  -8,   -8, 	   0,   -8
+.2byte    1,   -8, 	   5,  -11, 	  -8,   -6, 	   0,   -8
+.2byte    3,   -8, 	   4,  -12, 	  -4,   -5, 	  -1,   -8
+.2byte    3,   -8, 	   4,  -13, 	  -4,   -7, 	  -1,   -8
+.2byte    3,   -8, 	   3,  -11, 	  -4,   -5, 	  -1,   -8
+.2byte    0,   -7, 	  -6,  -10, 	   4,   -7, 	  -2,   -8
+.2byte   -1,   -7, 	  -6,  -11, 	   4,   -8, 	  -2,   -8
+.2byte   -1,   -7, 	  -6,  -10, 	   4,   -6, 	  -2,   -8
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -1,   -9, 	   8,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,   -8, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte   -2,   -7, 	   4,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -1,   -7, 	   4,  -11, 	  -6,   -8, 	   0,   -8
+.2byte   -1,   -7, 	   4,  -10, 	  -6,   -6, 	   0,   -8
+.2byte   -5,   -8, 	  -6,  -12, 	   2,   -5, 	  -1,   -8
+.2byte   -5,   -8, 	  -6,  -13, 	   2,   -7, 	  -1,   -8
+.2byte   -5,   -8, 	  -5,  -11, 	   2,   -5, 	  -1,   -8
+.2byte   -3,   -8, 	  -7,  -12, 	   6,   -7, 	  -2,   -9
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -8, 	  -2,   -8
+.2byte   -3,   -8, 	  -7,  -11, 	   6,   -6, 	  -2,   -8
+.2byte   -1,   -8, 	  -9,   -9, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,  -10, 	   8,  -10, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -9
+.2byte    1,   -8, 	   5,  -13, 	  -8,   -8, 	   0,   -8
+.2byte    1,   -8, 	   5,  -11, 	  -8,   -6, 	   0,   -8
+.2byte    3,   -8, 	   4,  -12, 	  -4,   -5, 	  -1,   -8
+.2byte    3,   -8, 	   4,  -13, 	  -4,   -7, 	  -1,   -8
+.2byte    3,   -8, 	   3,  -11, 	  -4,   -5, 	  -1,   -8
+.2byte    0,   -7, 	  -6,  -10, 	   4,   -7, 	  -2,   -8
+.2byte   -1,   -7, 	  -6,  -11, 	   4,   -8, 	  -2,   -8
+.2byte   -1,   -7, 	  -6,  -10, 	   4,   -6, 	  -2,   -8
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -1,   -9, 	   8,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,   -8, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte   -2,   -7, 	   4,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -1,   -7, 	   4,  -11, 	  -6,   -8, 	   0,   -8
+.2byte   -1,   -7, 	   4,  -10, 	  -6,   -6, 	   0,   -8
+.2byte   -5,   -8, 	  -6,  -12, 	   2,   -5, 	  -1,   -8
+.2byte   -5,   -8, 	  -6,  -13, 	   2,   -7, 	  -1,   -8
+.2byte   -5,   -8, 	  -5,  -11, 	   2,   -5, 	  -1,   -8
+.2byte   -3,   -8, 	  -7,  -12, 	   6,   -7, 	  -2,   -9
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -8, 	  -2,   -8
+.2byte   -3,   -8, 	  -7,  -11, 	   6,   -6, 	  -2,   -8
+.2byte   -1,   -8, 	  -9,   -9, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   3,   -8, 	  -1,   -9
+.2byte   -1,  -10, 	 -10,  -10, 	   8,  -11, 	  -1,   -9
+.2byte    1,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -9
+.2byte    2,   -8, 	   4,  -10, 	  -2,   -8, 	  -1,   -8
+.2byte    2,  -10, 	   4,  -14, 	  -8,  -10, 	   0,   -9
+.2byte    3,   -8, 	   4,  -12, 	  -4,   -5, 	  -1,   -8
+.2byte    2,   -7, 	   6,  -12, 	   2,   -8, 	  -2,   -8
+.2byte    3,   -9, 	   1,  -14, 	  -6,   -8, 	   0,   -9
+.2byte    0,   -7, 	  -6,  -10, 	   4,   -7, 	  -2,   -8
+.2byte    0,   -8, 	  -4,  -11, 	   5,   -9, 	  -1,   -8
+.2byte   -2,   -7, 	  -9,   -9, 	   2,   -6, 	  -3,   -7
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -1,   -9, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte   -1,   -9, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte   -2,   -7, 	   4,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -2,   -8, 	   2,  -11, 	  -7,   -9, 	  -1,   -8
+.2byte    0,   -7, 	   7,   -9, 	  -4,   -6, 	   1,   -7
+.2byte   -5,   -8, 	  -6,  -12, 	   2,   -5, 	  -1,   -8
+.2byte   -4,   -7, 	  -8,  -12, 	  -4,   -8, 	   0,   -8
+.2byte   -5,   -9, 	  -3,  -14, 	   4,   -8, 	  -2,   -9
+.2byte   -3,   -8, 	  -7,  -12, 	   6,   -7, 	  -2,   -9
+.2byte   -4,   -8, 	  -6,  -10, 	   0,   -8, 	  -1,   -8
+.2byte   -4,  -10, 	  -6,  -14, 	   6,  -10, 	  -2,   -9
+.2byte   -1,   -8, 	  -9,  -11, 	   8,  -11, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    1,   -8, 	   5,  -14, 	  -8,  -10, 	  -1,   -8
+.2byte    1,   -8, 	   5,  -10, 	  -8,   -5, 	  -1,   -8
+.2byte    3,   -8, 	   4,  -14, 	  -4,   -8, 	   0,   -8
+.2byte    3,   -8, 	   4,  -10, 	  -4,   -4, 	  -1,   -8
+.2byte    0,   -8, 	  -6,  -13, 	   3,  -10, 	  -2,   -8
+.2byte   -1,   -8, 	  -6,   -9, 	   4,   -5, 	  -2,   -8
+.2byte   -1,   -8, 	   8,  -11, 	  -9,  -11, 	  -1,   -9
+.2byte   -1,   -8, 	   8,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -2,   -8, 	   4,  -13, 	  -5,  -10, 	   0,   -8
+.2byte   -1,   -8, 	   4,   -9, 	  -6,   -5, 	   0,   -8
+.2byte   -5,   -8, 	  -6,  -14, 	   2,   -8, 	  -2,   -8
+.2byte   -5,   -8, 	  -6,  -10, 	   2,   -4, 	  -1,   -8
+.2byte   -3,   -8, 	  -7,  -14, 	   6,  -10, 	  -1,   -8
+.2byte   -3,   -8, 	  -7,  -10, 	   6,   -5, 	  -1,   -8
+.2byte   -3,   -7, 	  -6,  -11, 	   5,   -6, 	  -1,   -8
+.2byte   -3,   -6, 	  -6,   -9, 	   4,   -5, 	  -2,   -7
+.2byte    0,  -10, 	  -8,   -8, 	   9,   -8, 	   0,   -9
+.2byte    0,  -10, 	   6,  -10, 	  -9,   -5, 	  -1,   -9
+.2byte    3,  -11, 	   1,  -14, 	  -1,   -5, 	  -1,   -9
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -6, 	   0,   -7
+.2byte    0,   -9, 	   9,   -9, 	  -8,   -9, 	   0,   -8
+.2byte   -2,  -10, 	   4,   -9, 	  -6,   -6, 	  -1,   -7
+.2byte   -4,  -11, 	  -2,  -14, 	   0,   -5, 	   0,   -9
+.2byte   -1,  -10, 	  -7,  -10, 	   8,   -5, 	   0,   -9
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -6, 	  -1,   -6
+.2byte   -1,   -5, 	  -9,   -7, 	   8,   -7, 	  -1,   -6
+.2byte   -1,   -5, 	  -9,   -5, 	   8,   -5, 	  -1,   -6
+.2byte    1,   -5, 	   5,   -9, 	  -8,   -4, 	   0,   -6
+.2byte    1,   -5, 	   5,  -10, 	  -8,   -5, 	   0,   -5
+.2byte    1,   -5, 	   5,   -8, 	  -8,   -3, 	   0,   -5
+.2byte    3,   -5, 	   4,   -9, 	  -4,   -2, 	  -1,   -5
+.2byte    3,   -5, 	   4,  -10, 	  -4,   -4, 	  -1,   -5
+.2byte    3,   -5, 	   3,   -8, 	  -4,   -2, 	  -1,   -5
+.2byte    0,   -4, 	  -6,   -7, 	   4,   -4, 	  -2,   -5
+.2byte   -1,   -4, 	  -6,   -8, 	   4,   -5, 	  -2,   -5
+.2byte   -1,   -4, 	  -6,   -7, 	   4,   -3, 	  -2,   -5
+.2byte   -1,   -6, 	   8,   -6, 	  -9,   -6, 	  -1,   -5
+.2byte   -1,   -6, 	   8,   -7, 	  -9,   -7, 	  -1,   -5
+.2byte   -1,   -5, 	   8,   -5, 	  -9,   -5, 	  -1,   -6
+.2byte   -2,   -4, 	   4,   -7, 	  -6,   -4, 	   0,   -5
+.2byte   -1,   -4, 	   4,   -8, 	  -6,   -5, 	   0,   -5
+.2byte   -1,   -4, 	   4,   -7, 	  -6,   -3, 	   0,   -5
+.2byte   -5,   -5, 	  -6,   -9, 	   2,   -2, 	  -1,   -5
+.2byte   -5,   -5, 	  -6,  -10, 	   2,   -4, 	  -1,   -5
+.2byte   -5,   -5, 	  -5,   -8, 	   2,   -2, 	  -1,   -5
+.2byte   -3,   -5, 	  -7,   -9, 	   6,   -4, 	  -2,   -6
+.2byte   -3,   -5, 	  -7,  -10, 	   6,   -5, 	  -2,   -5
+.2byte   -3,   -5, 	  -7,   -8, 	   6,   -3, 	  -2,   -5
+.2byte   -1,  -10, 	 -10,  -10, 	   8,  -11, 	  -1,   -9
+.2byte   -3,  -10, 	  -5,  -14, 	   7,  -10, 	  -1,   -9
+.2byte   -4,   -9, 	  -2,  -14, 	   5,   -8, 	  -1,   -9
+.2byte   -1,   -9, 	   6,  -11, 	  -5,   -8, 	   0,   -9
+.2byte   -1,  -11, 	   7,  -10, 	  -8,  -10, 	  -1,  -10
+.2byte    0,   -9, 	  -7,  -11, 	   4,   -8, 	  -1,   -9
+.2byte    3,   -9, 	   1,  -14, 	  -6,   -8, 	   0,   -9
+.2byte    1,  -10, 	   3,  -14, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	 -10,  -10, 	   8,  -11, 	  -1,   -9
+.2byte    1,  -10, 	   3,  -14, 	  -9,  -10, 	  -1,   -9
+.2byte    3,   -9, 	   1,  -14, 	  -6,   -8, 	   0,   -9
+.2byte    0,   -9, 	  -7,  -11, 	   4,   -8, 	  -1,   -9
+.2byte   -1,  -11, 	   7,  -10, 	  -8,  -10, 	  -1,  -10
+.2byte   -1,   -9, 	   6,  -11, 	  -5,   -8, 	   0,   -9
+.2byte   -4,   -9, 	  -2,  -14, 	   5,   -8, 	  -1,   -9
+.2byte   -3,  -10, 	  -5,  -14, 	   7,  -10, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,   -9, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   3,   -8, 	  -1,   -9
+.2byte   -1,   -9, 	 -10,   -9, 	   8,  -10, 	  -1,   -8
+.2byte    1,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -9
+.2byte    2,   -8, 	   4,  -10, 	  -2,   -8, 	  -1,   -8
+.2byte    1,   -9, 	   3,  -13, 	  -9,   -9, 	  -1,   -8
+.2byte    3,   -8, 	   4,  -12, 	  -4,   -5, 	  -1,   -8
+.2byte    2,   -7, 	   6,  -12, 	   2,   -8, 	  -2,   -8
+.2byte    3,   -8, 	   1,  -13, 	  -6,   -7, 	   0,   -8
+.2byte    0,   -7, 	  -6,  -10, 	   4,   -7, 	  -2,   -8
+.2byte    0,   -8, 	  -4,  -11, 	   5,   -9, 	  -1,   -8
+.2byte   -1,   -7, 	  -8,   -9, 	   3,   -6, 	  -2,   -7
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte   -1,   -9, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte   -1,  -10, 	   7,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -2,   -7, 	   4,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -2,   -8, 	   2,  -11, 	  -7,   -9, 	  -1,   -8
+.2byte   -1,   -7, 	   6,   -9, 	  -5,   -6, 	   0,   -7
+.2byte   -5,   -8, 	  -6,  -12, 	   2,   -5, 	  -1,   -8
+.2byte   -4,   -7, 	  -8,  -12, 	  -4,   -8, 	   0,   -8
+.2byte   -5,   -8, 	  -3,  -13, 	   4,   -7, 	  -2,   -8
+.2byte   -3,   -8, 	  -7,  -12, 	   6,   -7, 	  -2,   -9
+.2byte   -4,   -8, 	  -6,  -10, 	   0,   -8, 	  -1,   -8
+.2byte   -3,   -9, 	  -5,  -13, 	   7,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	  -5,   -8, 	   3,   -8, 	  -1,   -9
+.2byte   -3,   -8, 	  -5,  -10, 	   1,   -8, 	   0,   -8
+.2byte   -4,   -7, 	  -8,  -12, 	  -4,   -8, 	   0,   -8
+.2byte   -2,   -8, 	   2,  -11, 	  -7,   -9, 	  -1,   -8
+.2byte   -1,   -9, 	   4,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte    0,   -8, 	  -4,  -11, 	   5,   -9, 	  -1,   -8
+.2byte    2,   -7, 	   6,  -12, 	   2,   -8, 	  -2,   -8
+.2byte    2,   -8, 	   4,  -10, 	  -2,   -8, 	  -1,   -8
+.2byte   -1,   -8, 	  -9,   -9, 	   8,   -9, 	  -1,   -9
+.2byte   -3,   -8, 	  -7,  -12, 	   6,   -7, 	  -2,   -9
+.2byte   -5,   -8, 	  -6,  -12, 	   2,   -5, 	  -1,   -8
+.2byte   -2,   -7, 	   4,  -10, 	  -6,   -7, 	   0,   -8
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -9, 	  -1,   -8
+.2byte    0,   -7, 	  -6,  -10, 	   4,   -7, 	  -2,   -8
+.2byte    3,   -8, 	   4,  -12, 	  -4,   -5, 	  -1,   -8
+.2byte    1,   -8, 	   5,  -12, 	  -8,   -7, 	   0,   -9
+sJumpluffAnimTable1:
+.4byte sJumpluffAnims_1_1
+.4byte sJumpluffAnims_1_2
+.4byte sJumpluffAnims_1_3
+.4byte sJumpluffAnims_1_4
+.4byte sJumpluffAnims_1_5
+.4byte sJumpluffAnims_1_6
+.4byte sJumpluffAnims_1_7
+.4byte sJumpluffAnims_1_8
+sJumpluffAnimTable2:
+.4byte sJumpluffAnims_2_1
+.4byte sJumpluffAnims_2_2
+.4byte sJumpluffAnims_2_3
+.4byte sJumpluffAnims_2_4
+.4byte sJumpluffAnims_2_5
+.4byte sJumpluffAnims_2_6
+.4byte sJumpluffAnims_2_7
+.4byte sJumpluffAnims_2_8
+sJumpluffAnimTable3:
+.4byte sJumpluffAnims_3_1
+.4byte sJumpluffAnims_3_2
+.4byte sJumpluffAnims_3_3
+.4byte sJumpluffAnims_3_4
+.4byte sJumpluffAnims_3_5
+.4byte sJumpluffAnims_3_6
+.4byte sJumpluffAnims_3_7
+.4byte sJumpluffAnims_3_8
+sJumpluffAnimTable4:
+.4byte sJumpluffAnims_4_1
+.4byte sJumpluffAnims_4_2
+.4byte sJumpluffAnims_4_3
+.4byte sJumpluffAnims_4_4
+.4byte sJumpluffAnims_4_5
+.4byte sJumpluffAnims_4_6
+.4byte sJumpluffAnims_4_7
+.4byte sJumpluffAnims_4_8
+sJumpluffAnimTable5:
+.4byte sJumpluffAnims_5_1
+.4byte sJumpluffAnims_5_2
+.4byte sJumpluffAnims_5_3
+.4byte sJumpluffAnims_5_4
+.4byte sJumpluffAnims_5_5
+.4byte sJumpluffAnims_5_6
+.4byte sJumpluffAnims_5_7
+.4byte sJumpluffAnims_5_8
+sJumpluffAnimTable6:
+.4byte sJumpluffAnims_6_1
+.4byte sJumpluffAnims_6_1
+.4byte sJumpluffAnims_6_1
+.4byte sJumpluffAnims_6_1
+.4byte sJumpluffAnims_6_1
+.4byte sJumpluffAnims_6_1
+.4byte sJumpluffAnims_6_1
+.4byte sJumpluffAnims_6_1
+sJumpluffAnimTable7:
+.4byte sJumpluffAnims_7_1
+.4byte sJumpluffAnims_7_2
+.4byte sJumpluffAnims_7_3
+.4byte sJumpluffAnims_7_4
+.4byte sJumpluffAnims_7_5
+.4byte sJumpluffAnims_7_6
+.4byte sJumpluffAnims_7_7
+.4byte sJumpluffAnims_7_8
+sJumpluffAnimTable8:
+.4byte sJumpluffAnims_8_1
+.4byte sJumpluffAnims_8_2
+.4byte sJumpluffAnims_8_3
+.4byte sJumpluffAnims_8_4
+.4byte sJumpluffAnims_8_5
+.4byte sJumpluffAnims_8_6
+.4byte sJumpluffAnims_8_7
+.4byte sJumpluffAnims_8_8
+sJumpluffAnimTable9:
+.4byte sJumpluffAnims_9_1
+.4byte sJumpluffAnims_9_2
+.4byte sJumpluffAnims_9_3
+.4byte sJumpluffAnims_9_4
+.4byte sJumpluffAnims_9_5
+.4byte sJumpluffAnims_9_6
+.4byte sJumpluffAnims_9_7
+.4byte sJumpluffAnims_9_8
+sJumpluffAnimTable10:
+.4byte sJumpluffAnims_10_1
+.4byte sJumpluffAnims_10_2
+.4byte sJumpluffAnims_10_3
+.4byte sJumpluffAnims_10_4
+.4byte sJumpluffAnims_10_5
+.4byte sJumpluffAnims_10_6
+.4byte sJumpluffAnims_10_7
+.4byte sJumpluffAnims_10_8
+sJumpluffAnimTable11:
+.4byte sJumpluffAnims_11_1
+.4byte sJumpluffAnims_11_2
+.4byte sJumpluffAnims_11_3
+.4byte sJumpluffAnims_11_4
+.4byte sJumpluffAnims_11_5
+.4byte sJumpluffAnims_11_6
+.4byte sJumpluffAnims_11_7
+.4byte sJumpluffAnims_11_8
+sJumpluffAnimTable12:
+.4byte sJumpluffAnims_12_1
+.4byte sJumpluffAnims_12_2
+.4byte sJumpluffAnims_12_3
+.4byte sJumpluffAnims_12_4
+.4byte sJumpluffAnims_12_5
+.4byte sJumpluffAnims_12_6
+.4byte sJumpluffAnims_12_7
+.4byte sJumpluffAnims_12_8
+sJumpluffAnimTable13:
+.4byte sJumpluffAnims_13_1
+.4byte sJumpluffAnims_13_2
+.4byte sJumpluffAnims_13_3
+.4byte sJumpluffAnims_13_4
+.4byte sJumpluffAnims_13_5
+.4byte sJumpluffAnims_13_6
+.4byte sJumpluffAnims_13_7
+.4byte sJumpluffAnims_13_8
+sAxAnimationsJumpluff:
+.4byte sJumpluffAnimTable1
+.4byte sJumpluffAnimTable2
+.4byte sJumpluffAnimTable3
+.4byte sJumpluffAnimTable4
+.4byte sJumpluffAnimTable5
+.4byte sJumpluffAnimTable6
+.4byte sJumpluffAnimTable7
+.4byte sJumpluffAnimTable8
+.4byte sJumpluffAnimTable9
+.4byte sJumpluffAnimTable10
+.4byte sJumpluffAnimTable11
+.4byte sJumpluffAnimTable12
+.4byte sJumpluffAnimTable13
+sAxSpritesJumpluff:
+.4byte sJumpluffSprites1
+.4byte sJumpluffSprites2
+.4byte sJumpluffSprites3
+.4byte sJumpluffSprites4
+.4byte sJumpluffSprites5
+.4byte sJumpluffSprites6
+.4byte sJumpluffSprites7
+.4byte sJumpluffSprites8
+.4byte sJumpluffSprites9
+.4byte sJumpluffSprites10
+.4byte sJumpluffSprites11
+.4byte sJumpluffSprites12
+.4byte sJumpluffSprites13
+.4byte sJumpluffSprites14
+.4byte sJumpluffSprites15
+.4byte sJumpluffSprites16
+.4byte sJumpluffSprites17
+.4byte sJumpluffSprites18
+.4byte sJumpluffSprites19
+.4byte sJumpluffSprites20
+.4byte sJumpluffSprites21
+.4byte sJumpluffSprites22
+.4byte sJumpluffSprites23
+.4byte sJumpluffSprites24
+.4byte sJumpluffSprites25
+.4byte sJumpluffSprites26
+.4byte sJumpluffSprites27
+.4byte sJumpluffSprites28
+.4byte sJumpluffSprites29
+.4byte sJumpluffSprites30
+.4byte sJumpluffSprites31
+.4byte sJumpluffSprites32
+.4byte sJumpluffSprites33
+.4byte sJumpluffSprites34
+.4byte sJumpluffSprites35
+.4byte sJumpluffSprites36
+.4byte sJumpluffSprites37
+.4byte sJumpluffSprites38
+.4byte sJumpluffSprites39
+.4byte sJumpluffSprites40
+.4byte sJumpluffSprites41
+.4byte sJumpluffSprites42
+sAxMainJumpluff:
+ax_main sAxPosesJumpluff, sAxAnimationsJumpluff, 13, sAxSpritesJumpluff, sAxPositionsJumpluff

--- a/data/ax/jynx.inc
+++ b/data/ax/jynx.inc
@@ -1,0 +1,2955 @@
+.global gAxJynx
+gAxJynx:
+ax_siro sAxMainJynx
+sJynxPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose4:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose5:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose6:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose7:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose8:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose9:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose10:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose11:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose12:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose16:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose17:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose18:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose19:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose20:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose21:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose22:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose23:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose24:
+ax_pose 23, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose28:
+ax_pose 24, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose29:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose30:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose31:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose32:
+ax_pose 25, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose33:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose34:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose35:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose36:
+ax_pose 26, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose37:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose38:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose39:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose40:
+ax_pose 27, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose41:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose42:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose43:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose44:
+ax_pose 28, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose45:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose46:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose47:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose48:
+ax_pose 27, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose49:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose50:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose51:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose52:
+ax_pose 26, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose53:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose54:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose55:
+ax_pose 23, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose56:
+ax_pose 25, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose58:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose59:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose60:
+ax_pose 29, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose61:
+ax_pose 30, 0x01e6, 0x80f0, 0x2c00
+ax_pose 31, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sJynxPose62:
+ax_pose 31, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose63:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose64:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose65:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose66:
+ax_pose 32, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose67:
+ax_pose 33, 0x01e6, 0x90f3, 0x2c00
+ax_pose 34, 0x01e6, 0x90ef, 0x2c10
+ax_pose_terminator
+sJynxPose68:
+ax_pose 34, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose69:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose70:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose71:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose72:
+ax_pose 35, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose73:
+ax_pose 36, 0x01e6, 0x90f4, 0x2c00
+ax_pose 37, 0x01e6, 0x90ef, 0x2c10
+ax_pose_terminator
+sJynxPose74:
+ax_pose 37, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose75:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose76:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose77:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose78:
+ax_pose 38, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose79:
+ax_pose 39, 0x01e6, 0x90f2, 0x2c00
+ax_pose 40, 0x01e6, 0x90ef, 0x2c10
+ax_pose_terminator
+sJynxPose80:
+ax_pose 40, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose81:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose82:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose83:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose84:
+ax_pose 41, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose85:
+ax_pose 42, 0x01e3, 0x80f0, 0x2c00
+ax_pose 43, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sJynxPose86:
+ax_pose 43, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose87:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose88:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose89:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose90:
+ax_pose 38, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose91:
+ax_pose 39, 0x01e6, 0x80ed, 0x2c00
+ax_pose 40, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sJynxPose92:
+ax_pose 40, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose93:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose94:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose95:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose96:
+ax_pose 35, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose97:
+ax_pose 36, 0x01e6, 0x80eb, 0x2c00
+ax_pose 37, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sJynxPose98:
+ax_pose 37, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose99:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose100:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose101:
+ax_pose 23, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose102:
+ax_pose 32, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose103:
+ax_pose 33, 0x01e6, 0x80ec, 0x2c00
+ax_pose 34, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sJynxPose104:
+ax_pose 34, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose105:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose106:
+ax_pose 44, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose107:
+ax_pose 24, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose108:
+ax_pose 45, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose109:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose110:
+ax_pose 46, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose111:
+ax_pose 25, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose112:
+ax_pose 47, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose113:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose114:
+ax_pose 48, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose115:
+ax_pose 26, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose116:
+ax_pose 49, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose117:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose118:
+ax_pose 50, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose119:
+ax_pose 27, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose120:
+ax_pose 51, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose121:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose122:
+ax_pose 52, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose123:
+ax_pose 28, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose124:
+ax_pose 53, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose125:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose126:
+ax_pose 50, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose127:
+ax_pose 27, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose128:
+ax_pose 51, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose129:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose130:
+ax_pose 48, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose131:
+ax_pose 26, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose132:
+ax_pose 49, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose133:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose134:
+ax_pose 46, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose135:
+ax_pose 25, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose136:
+ax_pose 47, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose137:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose138:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose139:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose140:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose141:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose142:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose143:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose144:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose145:
+ax_pose 54, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose146:
+ax_pose 55, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose147:
+ax_pose 56, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose148:
+ax_pose 57, 0x01e3, 0x90f0, 0x2c00
+ax_pose_terminator
+sJynxPose149:
+ax_pose 58, 0x01e3, 0x90f0, 0x2c00
+ax_pose_terminator
+sJynxPose150:
+ax_pose 59, 0x01e3, 0x90f0, 0x2c00
+ax_pose_terminator
+sJynxPose151:
+ax_pose 60, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose152:
+ax_pose 59, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose153:
+ax_pose 58, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose154:
+ax_pose 57, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose155:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose156:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose157:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose158:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose159:
+ax_pose 4, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose160:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose161:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose162:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose163:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose164:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose165:
+ax_pose 10, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose166:
+ax_pose 11, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose167:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose168:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose169:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose170:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose171:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose172:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose173:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose174:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose175:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose176:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose177:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose178:
+ax_pose 23, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose179:
+ax_pose 24, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose180:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sJynxPose181:
+ax_pose 26, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sJynxPose182:
+ax_pose 27, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sJynxPose183:
+ax_pose 28, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose184:
+ax_pose 27, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sJynxPose185:
+ax_pose 26, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sJynxPose186:
+ax_pose 25, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sJynxPose187:
+ax_pose 29, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose188:
+ax_pose 32, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJynxPose189:
+ax_pose 35, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose190:
+ax_pose 38, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose191:
+ax_pose 41, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose192:
+ax_pose 38, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose193:
+ax_pose 35, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose194:
+ax_pose 32, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose195:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose196:
+ax_pose 44, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose197:
+ax_pose 24, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose198:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sJynxPose199:
+ax_pose 46, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose200:
+ax_pose 25, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose201:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose202:
+ax_pose 48, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose203:
+ax_pose 26, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sJynxPose204:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose205:
+ax_pose 50, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose206:
+ax_pose 27, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sJynxPose207:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose208:
+ax_pose 52, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose209:
+ax_pose 28, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose210:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose211:
+ax_pose 50, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose212:
+ax_pose 27, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sJynxPose213:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose214:
+ax_pose 48, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose215:
+ax_pose 26, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sJynxPose216:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose217:
+ax_pose 46, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose218:
+ax_pose 25, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose219:
+ax_pose 44, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose220:
+ax_pose 46, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose221:
+ax_pose 48, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose222:
+ax_pose 50, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose223:
+ax_pose 52, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose224:
+ax_pose 50, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sJynxPose225:
+ax_pose 48, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJynxPose226:
+ax_pose 46, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sJynxPose227:
+ax_pose 0, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose228:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose229:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose230:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose231:
+ax_pose 12, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sJynxPose232:
+ax_pose 9, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sJynxPose233:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sJynxPose234:
+ax_pose 3, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+.align 2
+sJynxAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sJynxAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 9, 11, 9, 11,
+ax_anim 2, 0, 31, 18, 21, 18, 21,
+ax_anim 2, 1, 31, 19, 20, 19, 20,
+ax_anim 2, 0, 31, 18, 21, 18, 21,
+ax_anim 2, 0, 31, 19, 20, 19, 20,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sJynxAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sJynxAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 18, -19, 18, -19,
+ax_anim 2, 1, 39, 19, -18, 19, -18,
+ax_anim 2, 0, 39, 18, -19, 18, -19,
+ax_anim 2, 0, 39, 19, -18, 19, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sJynxAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 1, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sJynxAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -18, -19, -18, -19,
+ax_anim 2, 1, 47, -19, -18, -19, -18,
+ax_anim 2, 0, 47, -18, -19, -18, -19,
+ax_anim 2, 0, 47, -19, -18, -19, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sJynxAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sJynxAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -9, 11, -9, 11,
+ax_anim 2, 0, 55, -18, 21, -18, 21,
+ax_anim 2, 1, 55, -19, 20, -19, 20,
+ax_anim 2, 0, 55, -18, 21, -18, 21,
+ax_anim 2, 0, 55, -19, 20, -19, 20,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sJynxAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 6, 0, 101, 0, -3, 0, -3,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 60, 0, 17, 0, 17,
+ax_anim 1, 0, 61, 0, 19, 0, 19,
+ax_anim 1, 1, 74, 0, 19, 0, 19,
+ax_anim 1, 0, 80, 0, 19, 0, 19,
+ax_anim 1, 0, 86, 0, 19, 0, 19,
+ax_anim 2, 0, 92, 0, 19, 0, 19,
+ax_anim 2, 0, 98, 0, 19, 0, 19,
+ax_anim 2, 0, 56, 0, 19, 0, 19,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sJynxAnims_3_2:
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 2, 0, 65, -2, -2, -2, -2,
+ax_anim 6, 0, 71, -3, -3, -3, -3,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 9, 12, 9, 12,
+ax_anim 2, 0, 66, 17, 17, 17, 17,
+ax_anim 1, 0, 67, 19, 19, 19, 19,
+ax_anim 1, 1, 92, 19, 19, 19, 19,
+ax_anim 1, 0, 86, 19, 19, 19, 19,
+ax_anim 1, 0, 80, 19, 19, 19, 19,
+ax_anim 2, 0, 74, 19, 19, 19, 19,
+ax_anim 2, 0, 68, 19, 19, 19, 19,
+ax_anim 2, 0, 62, 19, 19, 19, 19,
+ax_anim 2, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 62, 4, 4, 4, 4,
+ax_anim_terminator
+sJynxAnims_3_3:
+ax_anim 2, 0, 68, -1, 0, -1, 0,
+ax_anim 2, 0, 71, -2, 0, -2, 0,
+ax_anim 6, 0, 77, -3, 0, -3, 0,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 10, 0, 10, 0,
+ax_anim 2, 0, 72, 16, 0, 16, 0,
+ax_anim 1, 0, 73, 18, 0, 18, 0,
+ax_anim 1, 1, 98, 18, 0, 18, 0,
+ax_anim 1, 0, 92, 18, 0, 18, 0,
+ax_anim 1, 0, 86, 18, 0, 18, 0,
+ax_anim 2, 0, 80, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 18, 0, 18, 0,
+ax_anim 2, 0, 68, 18, 0, 18, 0,
+ax_anim 2, 0, 68, 10, 0, 10, 0,
+ax_anim 2, 0, 68, 4, 0, 4, 0,
+ax_anim_terminator
+sJynxAnims_3_4:
+ax_anim 2, 0, 74, -1, 1, -1, 1,
+ax_anim 2, 0, 77, -2, 2, -2, 2,
+ax_anim 6, 0, 77, -3, 3, -3, 3,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 2, 77, 9, -12, 9, -12,
+ax_anim 2, 0, 78, 17, -15, 17, -17,
+ax_anim 1, 0, 79, 19, -17, 19, -19,
+ax_anim 1, 1, 62, 19, -17, 19, -19,
+ax_anim 1, 0, 56, 19, -17, 19, -19,
+ax_anim 1, 0, 92, 19, -17, 19, -19,
+ax_anim 2, 0, 86, 19, -17, 19, -19,
+ax_anim 2, 0, 80, 19, -17, 19, -19,
+ax_anim 2, 0, 74, 19, -17, 19, -19,
+ax_anim 2, 0, 74, 10, -10, 10, -10,
+ax_anim 2, 0, 74, 4, -4, 4, -4,
+ax_anim_terminator
+sJynxAnims_3_5:
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 0, 83, 0, 2, 0, 2,
+ax_anim 6, 0, 83, 0, 3, 0, 3,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 2, 83, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, -15, 0, -15,
+ax_anim 1, 0, 85, 0, -17, 0, -17,
+ax_anim 1, 1, 98, 0, -17, 0, -17,
+ax_anim 1, 0, 56, 0, -17, 0, -17,
+ax_anim 1, 0, 62, 0, -17, 0, -17,
+ax_anim 2, 0, 68, 0, -17, 0, -17,
+ax_anim 2, 0, 74, 0, -17, 0, -17,
+ax_anim 2, 0, 80, 0, -17, 0, -17,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sJynxAnims_3_6:
+ax_anim 2, 0, 86, 1, 1, 1, 1,
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 6, 0, 89, 3, 3, 3, 3,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 2, 89, -9, -12, -9, -12,
+ax_anim 2, 0, 90, -17, -15, -17, -17,
+ax_anim 1, 0, 91, -19, -17, -19, -19,
+ax_anim 1, 1, 98, -19, -17, -19, -19,
+ax_anim 1, 0, 62, -19, -17, -19, -19,
+ax_anim 1, 0, 68, -19, -17, -19, -19,
+ax_anim 2, 0, 74, -19, -17, -19, -19,
+ax_anim 2, 0, 80, -19, -17, -19, -19,
+ax_anim 2, 0, 86, -19, -17, -19, -19,
+ax_anim 2, 0, 86, -10, -10, -10, -10,
+ax_anim 2, 0, 86, -4, -4, -4, -4,
+ax_anim_terminator
+sJynxAnims_3_7:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 6, 0, 89, 3, 0, 3, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 2, 95, -10, 0, -10, 0,
+ax_anim 2, 0, 96, -16, 0, -16, 0,
+ax_anim 1, 0, 97, -18, 0, -18, 0,
+ax_anim 1, 1, 62, -18, 0, -18, 0,
+ax_anim 1, 0, 68, -18, 0, -18, 0,
+ax_anim 1, 0, 74, -18, 0, -18, 0,
+ax_anim 2, 0, 80, -18, 0, -18, 0,
+ax_anim 2, 0, 86, -18, 0, -18, 0,
+ax_anim 2, 0, 92, -18, 0, -18, 0,
+ax_anim 2, 0, 92, -10, 0, -10, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim_terminator
+sJynxAnims_3_8:
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 6, 0, 95, 3, -3, 3, -3,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 101, -10, 10, -10, 10,
+ax_anim 2, 0, 102, -17, 17, -17, 17,
+ax_anim 1, 0, 103, -19, 19, -19, 19,
+ax_anim 1, 1, 68, -19, 19, -19, 19,
+ax_anim 1, 0, 74, -19, 19, -19, 19,
+ax_anim 1, 0, 80, -19, 19, -19, 19,
+ax_anim 2, 0, 86, -19, 19, -19, 19,
+ax_anim 2, 0, 92, -19, 19, -19, 19,
+ax_anim 2, 0, 98, -19, 19, -19, 19,
+ax_anim 2, 0, 98, -10, 10, -10, 10,
+ax_anim 2, 0, 98, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sJynxAnims_4_1:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 3, 0, 3,
+ax_anim 1, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 1, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim_terminator
+sJynxAnims_4_2:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 6, 2, 109, -3, -3, -3, -3,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 3, 3, 3, 3,
+ax_anim 1, 0, 110, 5, 5, 5, 5,
+ax_anim 2, 1, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 110, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 110, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 108, 3, 3, 3, 3,
+ax_anim_terminator
+sJynxAnims_4_3:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -2, 0, -2, 0,
+ax_anim 6, 2, 113, -3, 0, -3, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 3, 0, 3, 0,
+ax_anim 1, 0, 114, 5, 0, 5, 0,
+ax_anim 2, 1, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sJynxAnims_4_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 6, 2, 117, -3, 3, -3, 3,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 3, -3, 3, -3,
+ax_anim 1, 0, 118, 5, -5, 5, -5,
+ax_anim 2, 1, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 118, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 118, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 116, 3, -3, 3, -3,
+ax_anim_terminator
+sJynxAnims_4_5:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 2, 0, 2,
+ax_anim 6, 2, 121, 0, 3, 0, 3,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, -3,
+ax_anim 1, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 1, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 122, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 120, 0, -3, 0, -3,
+ax_anim_terminator
+sJynxAnims_4_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 6, 2, 125, 3, 3, 3, 3,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 126, -3, -3, -3, -3,
+ax_anim 1, 0, 126, -5, -5, -5, -5,
+ax_anim 2, 1, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 126, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 126, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim_terminator
+sJynxAnims_4_7:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 2, 0, 2, 0,
+ax_anim 6, 2, 129, 3, 0, 3, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -3, 0, -3, 0,
+ax_anim 1, 0, 130, -5, 0, -5, 0,
+ax_anim 2, 1, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 130, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 130, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 128, -3, 0, -3, 0,
+ax_anim_terminator
+sJynxAnims_4_8:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 6, 2, 133, 3, -3, 3, -3,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, -3, 3, -3, 3,
+ax_anim 1, 0, 134, -5, 5, -5, 5,
+ax_anim 2, 1, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 134, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 134, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 132, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sJynxAnims_5_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_5_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_5_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_5_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sJynxAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sJynxAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sJynxAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sJynxAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sJynxAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sJynxAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sJynxAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sJynxAnims_8_1:
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 14, 0, 154, 0, 0, 0, 0,
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 14, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_8_2:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 14, 0, 157, 0, 0, 0, 0,
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 14, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_8_3:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 14, 0, 160, 0, 0, 0, 0,
+ax_anim 30, 0, 162, 0, 0, 0, 0,
+ax_anim 14, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_8_4:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 14, 0, 163, 0, 0, 0, 0,
+ax_anim 30, 0, 165, 0, 0, 0, 0,
+ax_anim 14, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_8_5:
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 14, 0, 166, 0, 0, 0, 0,
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 14, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_8_6:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 14, 0, 169, 0, 0, 0, 0,
+ax_anim 30, 0, 171, 0, 0, 0, 0,
+ax_anim 14, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_8_7:
+ax_anim 30, 0, 173, 0, 0, 0, 0,
+ax_anim 14, 0, 172, 0, 0, 0, 0,
+ax_anim 30, 0, 174, 0, 0, 0, 0,
+ax_anim 14, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_8_8:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 14, 0, 175, 0, 0, 0, 0,
+ax_anim 30, 0, 177, 0, 0, 0, 0,
+ax_anim 14, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 15, 7, 15,
+ax_anim 3, 0, 182, 0, 18, 0, 18,
+ax_anim 2, 3, 183, -7, 15, -7, 15,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 20, 10, 20, 10,
+ax_anim 3, 0, 181, 20, 19, 20, 19,
+ax_anim 2, 3, 182, 11, 19, 11, 19,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 18, -5, 18, -5,
+ax_anim 3, 0, 180, 20, -2, 20, -2,
+ax_anim 2, 3, 181, 18, 4, 18, 4,
+ax_anim 2, 0, 182, 12, 4, 12, 4,
+ax_anim 1, 0, 183, 4, 4, 4, 4,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -8, -1, -8,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 19, -21, 19, -21,
+ax_anim 2, 3, 180, 20, -15, 20, -15,
+ax_anim 2, 0, 181, 17, -4, 17, -4,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -12, -9, -12,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -8, 1, -8,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -19, -21, -19, -21,
+ax_anim 2, 3, 184, -20, -15, -20, -15,
+ax_anim 2, 0, 183, -17, -4, -17, -4,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -18, -5, -18, -5,
+ax_anim 3, 0, 184, -20, -2, -20, -2,
+ax_anim 2, 3, 183, -18, 4, -18, 4,
+ax_anim 2, 0, 182, -12, 4, -12, 4,
+ax_anim 1, 0, 181, -4, 4, -4, 4,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -20, 10, -20, 10,
+ax_anim 3, 0, 183, -20, 19, -20, 19,
+ax_anim 2, 3, 182, -11, 19, -11, 19,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sJynxAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sJynxGfx1:
+.incbin "baserom.gba", 0xA52D98, 0x200
+sJynxSprites1:
+ax_sprite sJynxGfx1, 0x200
+ax_sprite_terminator
+sJynxGfx2:
+.incbin "baserom.gba", 0xA52FA8, 0x200
+sJynxSprites2:
+ax_sprite sJynxGfx2, 0x200
+ax_sprite_terminator
+sJynxGfx3:
+.incbin "baserom.gba", 0xA531B8, 0x200
+sJynxSprites3:
+ax_sprite sJynxGfx3, 0x200
+ax_sprite_terminator
+sJynxGfx4:
+.incbin "baserom.gba", 0xA533C8, 0x200
+sJynxSprites4:
+ax_sprite sJynxGfx4, 0x200
+ax_sprite_terminator
+sJynxGfx5:
+.incbin "baserom.gba", 0xA535D8, 0x200
+sJynxSprites5:
+ax_sprite sJynxGfx5, 0x200
+ax_sprite_terminator
+sJynxGfx6:
+.incbin "baserom.gba", 0xA537E8, 0x200
+sJynxSprites6:
+ax_sprite sJynxGfx6, 0x200
+ax_sprite_terminator
+sJynxGfx7:
+.incbin "baserom.gba", 0xA539F8, 0x200
+sJynxSprites7:
+ax_sprite sJynxGfx7, 0x200
+ax_sprite_terminator
+sJynxGfx8:
+.incbin "baserom.gba", 0xA53C08, 0x200
+sJynxSprites8:
+ax_sprite sJynxGfx8, 0x200
+ax_sprite_terminator
+sJynxGfx9:
+.incbin "baserom.gba", 0xA53E18, 0x200
+sJynxSprites9:
+ax_sprite sJynxGfx9, 0x200
+ax_sprite_terminator
+sJynxGfx10:
+.incbin "baserom.gba", 0xA54028, 0x200
+sJynxSprites10:
+ax_sprite sJynxGfx10, 0x200
+ax_sprite_terminator
+sJynxGfx11:
+.incbin "baserom.gba", 0xA54238, 0x200
+sJynxSprites11:
+ax_sprite sJynxGfx11, 0x200
+ax_sprite_terminator
+sJynxGfx12:
+.incbin "baserom.gba", 0xA54448, 0x200
+sJynxSprites12:
+ax_sprite sJynxGfx12, 0x200
+ax_sprite_terminator
+sJynxGfx13:
+.incbin "baserom.gba", 0xA54658, 0x200
+sJynxSprites13:
+ax_sprite sJynxGfx13, 0x200
+ax_sprite_terminator
+sJynxGfx14:
+.incbin "baserom.gba", 0xA54868, 0x200
+sJynxSprites14:
+ax_sprite sJynxGfx14, 0x200
+ax_sprite_terminator
+sJynxGfx15:
+.incbin "baserom.gba", 0xA54A78, 0x200
+sJynxSprites15:
+ax_sprite sJynxGfx15, 0x200
+ax_sprite_terminator
+sJynxGfx16:
+.incbin "baserom.gba", 0xA54C88, 0x200
+sJynxSprites16:
+ax_sprite sJynxGfx16, 0x200
+ax_sprite_terminator
+sJynxGfx17:
+.incbin "baserom.gba", 0xA54E98, 0x200
+sJynxSprites17:
+ax_sprite sJynxGfx17, 0x200
+ax_sprite_terminator
+sJynxGfx18:
+.incbin "baserom.gba", 0xA550A8, 0x200
+sJynxSprites18:
+ax_sprite sJynxGfx18, 0x200
+ax_sprite_terminator
+sJynxGfx19:
+.incbin "baserom.gba", 0xA552B8, 0x200
+sJynxSprites19:
+ax_sprite sJynxGfx19, 0x200
+ax_sprite_terminator
+sJynxGfx20:
+.incbin "baserom.gba", 0xA554C8, 0x200
+sJynxSprites20:
+ax_sprite sJynxGfx20, 0x200
+ax_sprite_terminator
+sJynxGfx21:
+.incbin "baserom.gba", 0xA556D8, 0x200
+sJynxSprites21:
+ax_sprite sJynxGfx21, 0x200
+ax_sprite_terminator
+sJynxGfx22:
+.incbin "baserom.gba", 0xA558E8, 0x200
+sJynxSprites22:
+ax_sprite sJynxGfx22, 0x200
+ax_sprite_terminator
+sJynxGfx23:
+.incbin "baserom.gba", 0xA55AF8, 0x200
+sJynxSprites23:
+ax_sprite sJynxGfx23, 0x200
+ax_sprite_terminator
+sJynxGfx24:
+.incbin "baserom.gba", 0xA55D08, 0x200
+sJynxSprites24:
+ax_sprite sJynxGfx24, 0x200
+ax_sprite_terminator
+sJynxGfx25:
+.incbin "baserom.gba", 0xA55F18, 0x40
+sJynxGfx25_1:
+.incbin "baserom.gba", 0xA55F58, 0x180
+sJynxSprites25:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx25_1, 0x180
+ax_sprite_terminator
+sJynxGfx26:
+.incbin "baserom.gba", 0xA56100, 0x40
+sJynxGfx26_1:
+.incbin "baserom.gba", 0xA56140, 0x180
+sJynxSprites26:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx26_1, 0x180
+ax_sprite_terminator
+sJynxGfx27:
+.incbin "baserom.gba", 0xA562E8, 0x60
+sJynxGfx27_1:
+.incbin "baserom.gba", 0xA56348, 0xE0
+sJynxGfx27_2:
+.incbin "baserom.gba", 0xA56428, 0x60
+sJynxSprites27:
+ax_sprite sJynxGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx27_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx28:
+.incbin "baserom.gba", 0xA564C0, 0x60
+sJynxGfx28_1:
+.incbin "baserom.gba", 0xA56520, 0x160
+sJynxSprites28:
+ax_sprite sJynxGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx28_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx29:
+.incbin "baserom.gba", 0xA566A8, 0x40
+sJynxGfx29_1:
+.incbin "baserom.gba", 0xA566E8, 0x160
+sJynxSprites29:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx29_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx30:
+.incbin "baserom.gba", 0xA56878, 0x100
+sJynxGfx30_1:
+.incbin "baserom.gba", 0xA56978, 0xE0
+sJynxSprites30:
+ax_sprite sJynxGfx30, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx30_1, 0xe0
+ax_sprite_terminator
+sJynxGfx31:
+.incbin "baserom.gba", 0xA56A78, 0x20
+sJynxGfx31_1:
+.incbin "baserom.gba", 0xA56A98, 0x20
+sJynxGfx31_2:
+.incbin "baserom.gba", 0xA56AB8, 0x100
+sJynxSprites31:
+ax_sprite sJynxGfx31, 0x20
+ax_sprite 0, 0x60
+ax_sprite sJynxGfx31_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sJynxGfx31_2, 0x100
+ax_sprite_terminator
+sJynxGfx32:
+.incbin "baserom.gba", 0xA56BE8, 0x40
+sJynxGfx32_1:
+.incbin "baserom.gba", 0xA56C28, 0x100
+sJynxGfx32_2:
+.incbin "baserom.gba", 0xA56D28, 0x60
+sJynxSprites32:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx32_2, 0x60
+ax_sprite_terminator
+sJynxGfx33:
+.incbin "baserom.gba", 0xA56DC0, 0x40
+sJynxGfx33_1:
+.incbin "baserom.gba", 0xA56E00, 0x180
+sJynxSprites33:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx33_1, 0x180
+ax_sprite_terminator
+sJynxGfx34:
+.incbin "baserom.gba", 0xA56FA8, 0x40
+sJynxGfx34_1:
+.incbin "baserom.gba", 0xA56FE8, 0x20
+sJynxGfx34_2:
+.incbin "baserom.gba", 0xA57008, 0x100
+sJynxSprites34:
+ax_sprite sJynxGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sJynxGfx34_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sJynxGfx34_2, 0x100
+ax_sprite_terminator
+sJynxGfx35:
+.incbin "baserom.gba", 0xA57138, 0x40
+sJynxGfx35_1:
+.incbin "baserom.gba", 0xA57178, 0x180
+sJynxSprites35:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx35_1, 0x180
+ax_sprite_terminator
+sJynxGfx36:
+.incbin "baserom.gba", 0xA57320, 0x1E0
+sJynxSprites36:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx36, 0x1e0
+ax_sprite_terminator
+sJynxGfx37:
+.incbin "baserom.gba", 0xA57518, 0xA0
+sJynxGfx37_1:
+.incbin "baserom.gba", 0xA575B8, 0x60
+sJynxGfx37_2:
+.incbin "baserom.gba", 0xA57618, 0x60
+sJynxSprites37:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx37, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sJynxGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx38:
+.incbin "baserom.gba", 0xA576B8, 0x60
+sJynxGfx38_1:
+.incbin "baserom.gba", 0xA57718, 0x160
+sJynxSprites38:
+ax_sprite sJynxGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx38_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx39:
+.incbin "baserom.gba", 0xA578A0, 0x60
+sJynxGfx39_1:
+.incbin "baserom.gba", 0xA57900, 0x180
+sJynxSprites39:
+ax_sprite sJynxGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx39_1, 0x180
+ax_sprite_terminator
+sJynxGfx40:
+.incbin "baserom.gba", 0xA57AA0, 0xC0
+sJynxGfx40_1:
+.incbin "baserom.gba", 0xA57B60, 0x40
+sJynxSprites40:
+ax_sprite sJynxGfx40, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sJynxGfx40_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sJynxGfx41:
+.incbin "baserom.gba", 0xA57BC8, 0x40
+sJynxGfx41_1:
+.incbin "baserom.gba", 0xA57C08, 0x180
+sJynxSprites41:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx41_1, 0x180
+ax_sprite_terminator
+sJynxGfx42:
+.incbin "baserom.gba", 0xA57DB0, 0x60
+sJynxGfx42_1:
+.incbin "baserom.gba", 0xA57E10, 0x180
+sJynxSprites42:
+ax_sprite sJynxGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx42_1, 0x180
+ax_sprite_terminator
+sJynxGfx43:
+.incbin "baserom.gba", 0xA57FB0, 0xC0
+sJynxGfx43_1:
+.incbin "baserom.gba", 0xA58070, 0x40
+sJynxGfx43_2:
+.incbin "baserom.gba", 0xA580B0, 0x20
+sJynxGfx43_3:
+.incbin "baserom.gba", 0xA580D0, 0x20
+sJynxSprites43:
+ax_sprite sJynxGfx43, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx43_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sJynxGfx43_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sJynxGfx43_3, 0x20
+ax_sprite_terminator
+sJynxGfx44:
+.incbin "baserom.gba", 0xA58130, 0x40
+sJynxGfx44_1:
+.incbin "baserom.gba", 0xA58170, 0x160
+sJynxSprites44:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx44_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx45:
+.incbin "baserom.gba", 0xA58300, 0x40
+sJynxGfx45_1:
+.incbin "baserom.gba", 0xA58340, 0x180
+sJynxSprites45:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx45_1, 0x180
+ax_sprite_terminator
+sJynxGfx46:
+.incbin "baserom.gba", 0xA584E8, 0x200
+sJynxSprites46:
+ax_sprite sJynxGfx46, 0x200
+ax_sprite_terminator
+sJynxGfx47:
+.incbin "baserom.gba", 0xA586F8, 0x40
+sJynxGfx47_1:
+.incbin "baserom.gba", 0xA58738, 0x180
+sJynxSprites47:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx47, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx47_1, 0x180
+ax_sprite_terminator
+sJynxGfx48:
+.incbin "baserom.gba", 0xA588E0, 0x1E0
+sJynxSprites48:
+ax_sprite sJynxGfx48, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx49:
+.incbin "baserom.gba", 0xA58AD8, 0x40
+sJynxGfx49_1:
+.incbin "baserom.gba", 0xA58B18, 0x80
+sJynxGfx49_2:
+.incbin "baserom.gba", 0xA58B98, 0xE0
+sJynxSprites49:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx49_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx49_2, 0xe0
+ax_sprite_terminator
+sJynxGfx50:
+.incbin "baserom.gba", 0xA58CB0, 0x60
+sJynxGfx50_1:
+.incbin "baserom.gba", 0xA58D10, 0x60
+sJynxGfx50_2:
+.incbin "baserom.gba", 0xA58D70, 0x60
+sJynxGfx50_3:
+.incbin "baserom.gba", 0xA58DD0, 0x60
+sJynxSprites50:
+ax_sprite sJynxGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx50_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx51:
+.incbin "baserom.gba", 0xA58E78, 0x40
+sJynxGfx51_1:
+.incbin "baserom.gba", 0xA58EB8, 0x180
+sJynxSprites51:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx51, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx51_1, 0x180
+ax_sprite_terminator
+sJynxGfx52:
+.incbin "baserom.gba", 0xA59060, 0x60
+sJynxGfx52_1:
+.incbin "baserom.gba", 0xA590C0, 0xE0
+sJynxGfx52_2:
+.incbin "baserom.gba", 0xA591A0, 0x60
+sJynxSprites52:
+ax_sprite sJynxGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx52_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx53:
+.incbin "baserom.gba", 0xA59238, 0x40
+sJynxGfx53_1:
+.incbin "baserom.gba", 0xA59278, 0x180
+sJynxSprites53:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx53, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx53_1, 0x180
+ax_sprite_terminator
+sJynxGfx54:
+.incbin "baserom.gba", 0xA59420, 0x40
+sJynxGfx54_1:
+.incbin "baserom.gba", 0xA59460, 0x100
+sJynxGfx54_2:
+.incbin "baserom.gba", 0xA59560, 0x40
+sJynxSprites54:
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx54, 0x40
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx54_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sJynxGfx54_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sJynxGfx55:
+.incbin "baserom.gba", 0xA595E0, 0x200
+sJynxSprites55:
+ax_sprite sJynxGfx55, 0x200
+ax_sprite_terminator
+sJynxGfx56:
+.incbin "baserom.gba", 0xA597F0, 0x200
+sJynxSprites56:
+ax_sprite sJynxGfx56, 0x200
+ax_sprite_terminator
+sJynxGfx57:
+.incbin "baserom.gba", 0xA59A00, 0x200
+sJynxSprites57:
+ax_sprite sJynxGfx57, 0x200
+ax_sprite_terminator
+sJynxGfx58:
+.incbin "baserom.gba", 0xA59C10, 0x200
+sJynxSprites58:
+ax_sprite sJynxGfx58, 0x200
+ax_sprite_terminator
+sJynxGfx59:
+.incbin "baserom.gba", 0xA59E20, 0x200
+sJynxSprites59:
+ax_sprite sJynxGfx59, 0x200
+ax_sprite_terminator
+sJynxGfx60:
+.incbin "baserom.gba", 0xA5A030, 0x200
+sJynxSprites60:
+ax_sprite sJynxGfx60, 0x200
+ax_sprite_terminator
+sJynxGfx61:
+.incbin "baserom.gba", 0xA5A240, 0x200
+sJynxSprites61:
+ax_sprite sJynxGfx61, 0x200
+ax_sprite_terminator
+sAxPosesJynx:
+.4byte sJynxPose1
+.4byte sJynxPose2
+.4byte sJynxPose3
+.4byte sJynxPose4
+.4byte sJynxPose5
+.4byte sJynxPose6
+.4byte sJynxPose7
+.4byte sJynxPose8
+.4byte sJynxPose9
+.4byte sJynxPose10
+.4byte sJynxPose11
+.4byte sJynxPose12
+.4byte sJynxPose13
+.4byte sJynxPose14
+.4byte sJynxPose15
+.4byte sJynxPose16
+.4byte sJynxPose17
+.4byte sJynxPose18
+.4byte sJynxPose19
+.4byte sJynxPose20
+.4byte sJynxPose21
+.4byte sJynxPose22
+.4byte sJynxPose23
+.4byte sJynxPose24
+.4byte sJynxPose25
+.4byte sJynxPose26
+.4byte sJynxPose27
+.4byte sJynxPose28
+.4byte sJynxPose29
+.4byte sJynxPose30
+.4byte sJynxPose31
+.4byte sJynxPose32
+.4byte sJynxPose33
+.4byte sJynxPose34
+.4byte sJynxPose35
+.4byte sJynxPose36
+.4byte sJynxPose37
+.4byte sJynxPose38
+.4byte sJynxPose39
+.4byte sJynxPose40
+.4byte sJynxPose41
+.4byte sJynxPose42
+.4byte sJynxPose43
+.4byte sJynxPose44
+.4byte sJynxPose45
+.4byte sJynxPose46
+.4byte sJynxPose47
+.4byte sJynxPose48
+.4byte sJynxPose49
+.4byte sJynxPose50
+.4byte sJynxPose51
+.4byte sJynxPose52
+.4byte sJynxPose53
+.4byte sJynxPose54
+.4byte sJynxPose55
+.4byte sJynxPose56
+.4byte sJynxPose57
+.4byte sJynxPose58
+.4byte sJynxPose59
+.4byte sJynxPose60
+.4byte sJynxPose61
+.4byte sJynxPose62
+.4byte sJynxPose63
+.4byte sJynxPose64
+.4byte sJynxPose65
+.4byte sJynxPose66
+.4byte sJynxPose67
+.4byte sJynxPose68
+.4byte sJynxPose69
+.4byte sJynxPose70
+.4byte sJynxPose71
+.4byte sJynxPose72
+.4byte sJynxPose73
+.4byte sJynxPose74
+.4byte sJynxPose75
+.4byte sJynxPose76
+.4byte sJynxPose77
+.4byte sJynxPose78
+.4byte sJynxPose79
+.4byte sJynxPose80
+.4byte sJynxPose81
+.4byte sJynxPose82
+.4byte sJynxPose83
+.4byte sJynxPose84
+.4byte sJynxPose85
+.4byte sJynxPose86
+.4byte sJynxPose87
+.4byte sJynxPose88
+.4byte sJynxPose89
+.4byte sJynxPose90
+.4byte sJynxPose91
+.4byte sJynxPose92
+.4byte sJynxPose93
+.4byte sJynxPose94
+.4byte sJynxPose95
+.4byte sJynxPose96
+.4byte sJynxPose97
+.4byte sJynxPose98
+.4byte sJynxPose99
+.4byte sJynxPose100
+.4byte sJynxPose101
+.4byte sJynxPose102
+.4byte sJynxPose103
+.4byte sJynxPose104
+.4byte sJynxPose105
+.4byte sJynxPose106
+.4byte sJynxPose107
+.4byte sJynxPose108
+.4byte sJynxPose109
+.4byte sJynxPose110
+.4byte sJynxPose111
+.4byte sJynxPose112
+.4byte sJynxPose113
+.4byte sJynxPose114
+.4byte sJynxPose115
+.4byte sJynxPose116
+.4byte sJynxPose117
+.4byte sJynxPose118
+.4byte sJynxPose119
+.4byte sJynxPose120
+.4byte sJynxPose121
+.4byte sJynxPose122
+.4byte sJynxPose123
+.4byte sJynxPose124
+.4byte sJynxPose125
+.4byte sJynxPose126
+.4byte sJynxPose127
+.4byte sJynxPose128
+.4byte sJynxPose129
+.4byte sJynxPose130
+.4byte sJynxPose131
+.4byte sJynxPose132
+.4byte sJynxPose133
+.4byte sJynxPose134
+.4byte sJynxPose135
+.4byte sJynxPose136
+.4byte sJynxPose137
+.4byte sJynxPose138
+.4byte sJynxPose139
+.4byte sJynxPose140
+.4byte sJynxPose141
+.4byte sJynxPose142
+.4byte sJynxPose143
+.4byte sJynxPose144
+.4byte sJynxPose145
+.4byte sJynxPose146
+.4byte sJynxPose147
+.4byte sJynxPose148
+.4byte sJynxPose149
+.4byte sJynxPose150
+.4byte sJynxPose151
+.4byte sJynxPose152
+.4byte sJynxPose153
+.4byte sJynxPose154
+.4byte sJynxPose155
+.4byte sJynxPose156
+.4byte sJynxPose157
+.4byte sJynxPose158
+.4byte sJynxPose159
+.4byte sJynxPose160
+.4byte sJynxPose161
+.4byte sJynxPose162
+.4byte sJynxPose163
+.4byte sJynxPose164
+.4byte sJynxPose165
+.4byte sJynxPose166
+.4byte sJynxPose167
+.4byte sJynxPose168
+.4byte sJynxPose169
+.4byte sJynxPose170
+.4byte sJynxPose171
+.4byte sJynxPose172
+.4byte sJynxPose173
+.4byte sJynxPose174
+.4byte sJynxPose175
+.4byte sJynxPose176
+.4byte sJynxPose177
+.4byte sJynxPose178
+.4byte sJynxPose179
+.4byte sJynxPose180
+.4byte sJynxPose181
+.4byte sJynxPose182
+.4byte sJynxPose183
+.4byte sJynxPose184
+.4byte sJynxPose185
+.4byte sJynxPose186
+.4byte sJynxPose187
+.4byte sJynxPose188
+.4byte sJynxPose189
+.4byte sJynxPose190
+.4byte sJynxPose191
+.4byte sJynxPose192
+.4byte sJynxPose193
+.4byte sJynxPose194
+.4byte sJynxPose195
+.4byte sJynxPose196
+.4byte sJynxPose197
+.4byte sJynxPose198
+.4byte sJynxPose199
+.4byte sJynxPose200
+.4byte sJynxPose201
+.4byte sJynxPose202
+.4byte sJynxPose203
+.4byte sJynxPose204
+.4byte sJynxPose205
+.4byte sJynxPose206
+.4byte sJynxPose207
+.4byte sJynxPose208
+.4byte sJynxPose209
+.4byte sJynxPose210
+.4byte sJynxPose211
+.4byte sJynxPose212
+.4byte sJynxPose213
+.4byte sJynxPose214
+.4byte sJynxPose215
+.4byte sJynxPose216
+.4byte sJynxPose217
+.4byte sJynxPose218
+.4byte sJynxPose219
+.4byte sJynxPose220
+.4byte sJynxPose221
+.4byte sJynxPose222
+.4byte sJynxPose223
+.4byte sJynxPose224
+.4byte sJynxPose225
+.4byte sJynxPose226
+.4byte sJynxPose227
+.4byte sJynxPose228
+.4byte sJynxPose229
+.4byte sJynxPose230
+.4byte sJynxPose231
+.4byte sJynxPose232
+.4byte sJynxPose233
+.4byte sJynxPose234
+sAxPositionsJynx:
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -2,  -10, 	 -13,   -9, 	   3,   -4, 	  -2,   -7
+.2byte    0,  -10, 	  -9,   -8, 	   8,   -6, 	   0,   -7
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    2,  -11, 	  -8,   -8, 	   6,   -5, 	  -1,   -9
+.2byte    4,  -11, 	  -2,   -6, 	   9,   -9, 	   0,   -9
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    6,  -12, 	   0,   -8, 	   7,   -7, 	   0,   -9
+.2byte    7,  -11, 	   7,   -5, 	   7,   -8, 	   1,   -9
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    4,  -15, 	   6,   -7, 	   3,  -11, 	   0,   -9
+.2byte    5,  -14, 	  10,   -9, 	   2,  -13, 	  -1,   -9
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte    0,  -17, 	  10,  -10, 	  -1,  -13, 	  -1,  -10
+.2byte   -2,  -17, 	   7,  -13, 	  -5,  -11, 	  -1,  -10
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -4,  -14, 	   7,  -15, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -14, 	   1,  -13, 	 -10,  -10, 	   0,  -10
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -9,  -12, 	  -9,  -11, 	  -9,   -5, 	  -2,   -8
+.2byte   -9,  -12, 	 -10,  -11, 	  -3,   -4, 	  -1,   -8
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -5,  -11, 	 -10,  -12, 	  -3,   -4, 	  -2,   -7
+.2byte   -3,  -11, 	 -12,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -2,  -10, 	 -13,   -9, 	   3,   -4, 	  -2,   -7
+.2byte    0,  -10, 	  -9,   -8, 	   8,   -6, 	   0,   -7
+.2byte   -1,   -8, 	 -13,  -10, 	  11,  -10, 	  -1,   -7
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    2,  -11, 	  -8,   -8, 	   6,   -5, 	  -1,   -9
+.2byte    4,  -11, 	  -2,   -6, 	   9,   -9, 	   0,   -9
+.2byte    3,  -10, 	  11,  -13, 	 -12,   -9, 	   0,   -7
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    6,  -12, 	   0,   -8, 	   7,   -7, 	   0,   -9
+.2byte    7,  -11, 	   7,   -5, 	   7,   -8, 	   1,   -9
+.2byte   11,  -11, 	   0,  -16, 	  -3,   -5, 	   1,   -8
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    4,  -15, 	   6,   -7, 	   3,  -11, 	   0,   -9
+.2byte    5,  -14, 	  10,   -9, 	   2,  -13, 	  -1,   -9
+.2byte    6,  -15, 	  -7,  -10, 	  11,   -5, 	   0,  -10
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte    0,  -17, 	  10,  -10, 	  -1,  -13, 	  -1,  -10
+.2byte   -2,  -17, 	   7,  -13, 	  -5,  -11, 	  -1,  -10
+.2byte   -1,  -20, 	  12,  -10, 	 -14,  -10, 	  -1,  -14
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -4,  -14, 	   7,  -15, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -14, 	   1,  -13, 	 -10,  -10, 	   0,  -10
+.2byte   -8,  -15, 	   5,  -10, 	 -13,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -9,  -12, 	  -9,  -11, 	  -9,   -5, 	  -2,   -8
+.2byte   -9,  -12, 	 -10,  -11, 	  -3,   -4, 	  -1,   -8
+.2byte  -13,  -11, 	  -2,  -16, 	   1,   -5, 	  -3,   -8
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -5,  -11, 	 -10,  -12, 	  -3,   -4, 	  -2,   -7
+.2byte   -3,  -11, 	 -12,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -5,  -10, 	 -13,  -13, 	  10,   -9, 	  -2,   -7
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -2,  -10, 	 -13,   -9, 	   3,   -4, 	  -2,   -7
+.2byte    0,  -10, 	  -9,   -8, 	   8,   -6, 	   0,   -7
+.2byte   -1,  -12, 	  -9,  -18, 	   0,   -6, 	   1,   -9
+.2byte    4,  -11, 	   9,   -7, 	   8,  -12, 	   1,  -10
+.2byte    4,  -11, 	   9,   -7, 	   8,  -12, 	   1,  -10
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    2,  -11, 	  -8,   -8, 	   6,   -5, 	  -1,   -9
+.2byte    4,  -11, 	  -2,   -6, 	   9,   -9, 	   0,   -9
+.2byte    2,  -12, 	   4,  -21, 	   5,   -9, 	  -2,   -9
+.2byte   -2,  -11, 	  -7,   -5, 	 -10,  -10, 	  -2,   -9
+.2byte   -2,  -11, 	  -7,   -5, 	 -10,  -10, 	  -2,   -9
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    6,  -12, 	   0,   -8, 	   7,   -7, 	   0,   -9
+.2byte    7,  -11, 	   7,   -5, 	   7,   -8, 	   1,   -9
+.2byte    1,  -14, 	 -11,  -20, 	   8,  -12, 	  -1,  -10
+.2byte    5,  -12, 	   3,   -4, 	  -9,  -11, 	   0,   -9
+.2byte    5,  -12, 	   3,   -4, 	  -9,  -11, 	   0,   -9
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    4,  -15, 	   6,   -7, 	   3,  -11, 	   0,   -9
+.2byte    5,  -14, 	  10,   -9, 	   2,  -13, 	  -1,   -9
+.2byte    2,  -15, 	 -14,  -15, 	   4,  -15, 	  -1,  -10
+.2byte    3,  -14, 	  10,   -9, 	  -1,   -7, 	  -3,   -9
+.2byte    3,  -14, 	  10,   -9, 	  -1,   -7, 	  -3,   -9
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte    0,  -17, 	  10,  -10, 	  -1,  -13, 	  -1,  -10
+.2byte   -2,  -17, 	   7,  -13, 	  -5,  -11, 	  -1,  -10
+.2byte    1,  -13, 	  10,   -8, 	  -2,  -16, 	  -4,  -11
+.2byte   -5,  -16, 	 -10,  -13, 	  -5,   -7, 	   1,  -11
+.2byte   -5,  -16, 	 -10,  -13, 	  -5,   -7, 	   1,  -11
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -4,  -14, 	   7,  -15, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -14, 	   1,  -13, 	 -10,  -10, 	   0,  -10
+.2byte   -4,  -15, 	  12,  -15, 	  -6,  -15, 	  -1,  -10
+.2byte   -5,  -14, 	 -12,   -9, 	  -1,   -7, 	   1,   -9
+.2byte   -5,  -14, 	 -12,   -9, 	  -1,   -7, 	   1,   -9
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -9,  -12, 	  -9,  -11, 	  -9,   -5, 	  -2,   -8
+.2byte   -9,  -12, 	 -10,  -11, 	  -3,   -4, 	  -1,   -8
+.2byte   -3,  -14, 	   9,  -20, 	 -10,  -12, 	  -1,  -10
+.2byte   -7,  -12, 	  -5,   -4, 	   7,  -11, 	  -2,   -9
+.2byte   -7,  -12, 	  -5,   -4, 	   7,  -11, 	  -2,   -9
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -5,  -11, 	 -10,  -12, 	  -3,   -4, 	  -2,   -7
+.2byte   -3,  -11, 	 -12,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -4,  -12, 	  -6,  -21, 	  -7,   -9, 	   0,   -9
+.2byte    0,  -11, 	   5,   -5, 	   8,  -10, 	   0,   -9
+.2byte    0,  -11, 	   5,   -5, 	   8,  -10, 	   0,   -9
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	  -4,  -13, 	   2,  -13, 	  -1,  -11
+.2byte   -1,   -8, 	 -13,  -10, 	  11,  -10, 	  -1,   -7
+.2byte   -1,   -6, 	 -12,  -11, 	  10,  -11, 	  -1,   -7
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    0,  -13, 	   3,  -13, 	  -2,  -12, 	  -1,  -10
+.2byte    3,  -10, 	  11,  -13, 	 -12,   -9, 	   0,   -7
+.2byte    5,   -8, 	  10,  -15, 	 -11,  -10, 	   1,   -8
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    3,  -14, 	   6,  -14, 	   5,  -13, 	  -3,  -10
+.2byte   11,  -11, 	   0,  -16, 	  -3,   -5, 	   1,   -8
+.2byte   12,  -10, 	   0,  -15, 	  -3,   -6, 	   2,   -7
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    3,  -15, 	   1,  -17, 	   5,  -15, 	  -2,  -10
+.2byte    6,  -15, 	  -7,  -10, 	  11,   -5, 	   0,  -10
+.2byte    9,  -16, 	  -5,  -11, 	  10,   -7, 	   2,  -10
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte   -1,  -17, 	   3,  -17, 	  -5,  -17, 	  -1,  -10
+.2byte   -1,  -20, 	  12,  -10, 	 -14,  -10, 	  -1,  -14
+.2byte   -1,  -21, 	  11,  -12, 	 -13,  -12, 	  -1,  -15
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -5,  -15, 	  -3,  -17, 	  -7,  -15, 	   0,  -10
+.2byte   -8,  -15, 	   5,  -10, 	 -13,   -5, 	  -2,  -10
+.2byte  -11,  -16, 	   3,  -11, 	 -12,   -7, 	  -4,  -10
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -5,  -14, 	  -8,  -14, 	  -7,  -13, 	   1,  -10
+.2byte  -13,  -11, 	  -2,  -16, 	   1,   -5, 	  -3,   -8
+.2byte  -14,  -10, 	  -2,  -15, 	   1,   -6, 	  -4,   -7
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -2,  -13, 	  -5,  -13, 	   0,  -12, 	  -1,  -10
+.2byte   -5,  -10, 	 -13,  -13, 	  10,   -9, 	  -2,   -7
+.2byte   -7,   -8, 	 -12,  -15, 	   9,  -10, 	  -3,   -8
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte   -4,  -11, 	 -10,   -6, 	   1,    0, 	  -1,   -7
+.2byte   -5,   -9, 	 -10,   -3, 	   0,    1, 	  -1,   -7
+.2byte   -1,  -13, 	  -5,  -12, 	   5,  -13, 	  -1,  -10
+.2byte    2,  -13, 	   7,  -13, 	  -2,  -12, 	   0,  -10
+.2byte    5,  -15, 	   5,  -16, 	   2,  -12, 	  -2,  -11
+.2byte    1,  -17, 	  -2,  -19, 	   7,  -15, 	  -2,  -13
+.2byte   -1,  -20, 	   6,  -17, 	  -8,  -17, 	  -1,  -14
+.2byte   -2,  -17, 	   1,  -19, 	  -8,  -15, 	   1,  -13
+.2byte   -6,  -15, 	  -6,  -16, 	  -3,  -12, 	   1,  -11
+.2byte   -3,  -13, 	  -8,  -13, 	   1,  -12, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -2,  -10, 	 -13,   -9, 	   3,   -4, 	  -2,   -7
+.2byte    0,  -10, 	  -9,   -8, 	   8,   -6, 	   0,   -7
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    2,  -11, 	  -8,   -8, 	   6,   -5, 	  -1,   -9
+.2byte    4,  -11, 	  -2,   -6, 	   9,   -9, 	   0,   -9
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    6,  -12, 	   0,   -8, 	   7,   -7, 	   0,   -9
+.2byte    7,  -11, 	   7,   -5, 	   7,   -8, 	   1,   -9
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    4,  -15, 	   6,   -7, 	   3,  -11, 	   0,   -9
+.2byte    5,  -14, 	  10,   -9, 	   2,  -13, 	  -1,   -9
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte    0,  -17, 	  10,  -10, 	  -1,  -13, 	  -1,  -10
+.2byte   -2,  -17, 	   7,  -13, 	  -5,  -11, 	  -1,  -10
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -4,  -14, 	   7,  -15, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -14, 	   1,  -13, 	 -10,  -10, 	   0,  -10
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -9,  -12, 	  -9,  -11, 	  -9,   -5, 	  -2,   -8
+.2byte   -9,  -12, 	 -10,  -11, 	  -3,   -4, 	  -1,   -8
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -5,  -11, 	 -10,  -12, 	  -3,   -4, 	  -2,   -7
+.2byte   -3,  -11, 	 -12,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -1,   -8, 	 -13,  -10, 	  11,  -10, 	  -1,   -7
+.2byte   -4,   -9, 	 -12,  -12, 	  11,   -8, 	  -1,   -6
+.2byte  -11,  -11, 	   0,  -16, 	   3,   -5, 	  -1,   -8
+.2byte   -6,  -15, 	   7,  -10, 	 -11,   -5, 	   0,  -10
+.2byte   -1,  -18, 	  12,   -8, 	 -14,   -8, 	  -1,  -12
+.2byte    4,  -15, 	  -9,  -10, 	   9,   -5, 	  -2,  -10
+.2byte    9,  -11, 	  -2,  -16, 	  -5,   -5, 	  -1,   -8
+.2byte    2,   -9, 	  10,  -12, 	 -13,   -8, 	  -1,   -6
+.2byte   -1,  -12, 	  -9,  -18, 	   0,   -6, 	   1,   -9
+.2byte    3,  -12, 	   5,  -21, 	   6,   -9, 	  -1,   -9
+.2byte    1,  -14, 	 -11,  -20, 	   8,  -12, 	  -1,  -10
+.2byte    2,  -15, 	 -14,  -15, 	   4,  -15, 	  -1,  -10
+.2byte    1,  -13, 	  10,   -8, 	  -2,  -16, 	  -4,  -11
+.2byte   -4,  -15, 	  12,  -15, 	  -6,  -15, 	  -1,  -10
+.2byte   -3,  -14, 	   9,  -20, 	 -10,  -12, 	  -1,  -10
+.2byte   -4,  -12, 	  -6,  -21, 	  -7,   -9, 	   0,   -9
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	  -4,  -13, 	   2,  -13, 	  -1,  -11
+.2byte   -1,   -8, 	 -13,  -10, 	  11,  -10, 	  -1,   -7
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+.2byte    0,  -13, 	   3,  -13, 	  -2,  -12, 	  -1,  -10
+.2byte    3,  -10, 	  11,  -13, 	 -12,   -9, 	   0,   -7
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    3,  -14, 	   6,  -14, 	   5,  -13, 	  -3,  -10
+.2byte    9,  -11, 	  -2,  -16, 	  -5,   -5, 	  -1,   -8
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    3,  -15, 	   1,  -17, 	   5,  -15, 	  -2,  -10
+.2byte    4,  -15, 	  -9,  -10, 	   9,   -5, 	  -2,  -10
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte   -1,  -17, 	   3,  -17, 	  -5,  -17, 	  -1,  -10
+.2byte   -1,  -20, 	  12,  -10, 	 -14,  -10, 	  -1,  -14
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -5,  -15, 	  -3,  -17, 	  -7,  -15, 	   0,  -10
+.2byte   -6,  -15, 	   7,  -10, 	 -11,   -5, 	   0,  -10
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -5,  -14, 	  -8,  -14, 	  -7,  -13, 	   1,  -10
+.2byte  -11,  -11, 	   0,  -16, 	   3,   -5, 	  -1,   -8
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -2,  -13, 	  -5,  -13, 	   0,  -12, 	  -1,  -10
+.2byte   -5,  -10, 	 -13,  -13, 	  10,   -9, 	  -2,   -7
+.2byte   -1,  -13, 	  -4,  -13, 	   2,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	  -5,  -13, 	   0,  -12, 	  -1,  -10
+.2byte   -5,  -14, 	  -8,  -14, 	  -7,  -13, 	   1,  -10
+.2byte   -5,  -15, 	  -3,  -17, 	  -7,  -15, 	   0,  -10
+.2byte   -1,  -17, 	   3,  -17, 	  -5,  -17, 	  -1,  -10
+.2byte    3,  -15, 	   1,  -17, 	   5,  -15, 	  -2,  -10
+.2byte    4,  -14, 	   7,  -14, 	   6,  -13, 	  -2,  -10
+.2byte    1,  -13, 	   4,  -13, 	  -1,  -12, 	   0,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   5,   -5, 	  -1,   -8
+.2byte   -4,  -12, 	 -11,  -11, 	  -1,   -4, 	  -3,   -9
+.2byte   -9,  -13, 	  -8,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte   -4,  -15, 	   5,  -16, 	  -8,  -10, 	   0,  -10
+.2byte   -1,  -17, 	   9,  -12, 	  -5,  -13, 	  -1,  -11
+.2byte    4,  -16, 	   8,   -9, 	  -1,  -16, 	   0,  -10
+.2byte    7,  -13, 	   2,   -8, 	   7,   -8, 	   0,  -10
+.2byte    2,  -12, 	  -5,   -8, 	   8,   -8, 	  -1,   -9
+sJynxAnimTable1:
+.4byte sJynxAnims_1_1
+.4byte sJynxAnims_1_2
+.4byte sJynxAnims_1_3
+.4byte sJynxAnims_1_4
+.4byte sJynxAnims_1_5
+.4byte sJynxAnims_1_6
+.4byte sJynxAnims_1_7
+.4byte sJynxAnims_1_8
+sJynxAnimTable2:
+.4byte sJynxAnims_2_1
+.4byte sJynxAnims_2_2
+.4byte sJynxAnims_2_3
+.4byte sJynxAnims_2_4
+.4byte sJynxAnims_2_5
+.4byte sJynxAnims_2_6
+.4byte sJynxAnims_2_7
+.4byte sJynxAnims_2_8
+sJynxAnimTable3:
+.4byte sJynxAnims_3_1
+.4byte sJynxAnims_3_2
+.4byte sJynxAnims_3_3
+.4byte sJynxAnims_3_4
+.4byte sJynxAnims_3_5
+.4byte sJynxAnims_3_6
+.4byte sJynxAnims_3_7
+.4byte sJynxAnims_3_8
+sJynxAnimTable4:
+.4byte sJynxAnims_4_1
+.4byte sJynxAnims_4_2
+.4byte sJynxAnims_4_3
+.4byte sJynxAnims_4_4
+.4byte sJynxAnims_4_5
+.4byte sJynxAnims_4_6
+.4byte sJynxAnims_4_7
+.4byte sJynxAnims_4_8
+sJynxAnimTable5:
+.4byte sJynxAnims_5_1
+.4byte sJynxAnims_5_2
+.4byte sJynxAnims_5_3
+.4byte sJynxAnims_5_4
+.4byte sJynxAnims_5_5
+.4byte sJynxAnims_5_6
+.4byte sJynxAnims_5_7
+.4byte sJynxAnims_5_8
+sJynxAnimTable6:
+.4byte sJynxAnims_6_1
+.4byte sJynxAnims_6_1
+.4byte sJynxAnims_6_1
+.4byte sJynxAnims_6_1
+.4byte sJynxAnims_6_1
+.4byte sJynxAnims_6_1
+.4byte sJynxAnims_6_1
+.4byte sJynxAnims_6_1
+sJynxAnimTable7:
+.4byte sJynxAnims_7_1
+.4byte sJynxAnims_7_2
+.4byte sJynxAnims_7_3
+.4byte sJynxAnims_7_4
+.4byte sJynxAnims_7_5
+.4byte sJynxAnims_7_6
+.4byte sJynxAnims_7_7
+.4byte sJynxAnims_7_8
+sJynxAnimTable8:
+.4byte sJynxAnims_8_1
+.4byte sJynxAnims_8_2
+.4byte sJynxAnims_8_3
+.4byte sJynxAnims_8_4
+.4byte sJynxAnims_8_5
+.4byte sJynxAnims_8_6
+.4byte sJynxAnims_8_7
+.4byte sJynxAnims_8_8
+sJynxAnimTable9:
+.4byte sJynxAnims_9_1
+.4byte sJynxAnims_9_2
+.4byte sJynxAnims_9_3
+.4byte sJynxAnims_9_4
+.4byte sJynxAnims_9_5
+.4byte sJynxAnims_9_6
+.4byte sJynxAnims_9_7
+.4byte sJynxAnims_9_8
+sJynxAnimTable10:
+.4byte sJynxAnims_10_1
+.4byte sJynxAnims_10_2
+.4byte sJynxAnims_10_3
+.4byte sJynxAnims_10_4
+.4byte sJynxAnims_10_5
+.4byte sJynxAnims_10_6
+.4byte sJynxAnims_10_7
+.4byte sJynxAnims_10_8
+sJynxAnimTable11:
+.4byte sJynxAnims_11_1
+.4byte sJynxAnims_11_2
+.4byte sJynxAnims_11_3
+.4byte sJynxAnims_11_4
+.4byte sJynxAnims_11_5
+.4byte sJynxAnims_11_6
+.4byte sJynxAnims_11_7
+.4byte sJynxAnims_11_8
+sJynxAnimTable12:
+.4byte sJynxAnims_12_1
+.4byte sJynxAnims_12_2
+.4byte sJynxAnims_12_3
+.4byte sJynxAnims_12_4
+.4byte sJynxAnims_12_5
+.4byte sJynxAnims_12_6
+.4byte sJynxAnims_12_7
+.4byte sJynxAnims_12_8
+sJynxAnimTable13:
+.4byte sJynxAnims_13_1
+.4byte sJynxAnims_13_2
+.4byte sJynxAnims_13_3
+.4byte sJynxAnims_13_4
+.4byte sJynxAnims_13_5
+.4byte sJynxAnims_13_6
+.4byte sJynxAnims_13_7
+.4byte sJynxAnims_13_8
+sAxAnimationsJynx:
+.4byte sJynxAnimTable1
+.4byte sJynxAnimTable2
+.4byte sJynxAnimTable3
+.4byte sJynxAnimTable4
+.4byte sJynxAnimTable5
+.4byte sJynxAnimTable6
+.4byte sJynxAnimTable7
+.4byte sJynxAnimTable8
+.4byte sJynxAnimTable9
+.4byte sJynxAnimTable10
+.4byte sJynxAnimTable11
+.4byte sJynxAnimTable12
+.4byte sJynxAnimTable13
+sAxSpritesJynx:
+.4byte sJynxSprites1
+.4byte sJynxSprites2
+.4byte sJynxSprites3
+.4byte sJynxSprites4
+.4byte sJynxSprites5
+.4byte sJynxSprites6
+.4byte sJynxSprites7
+.4byte sJynxSprites8
+.4byte sJynxSprites9
+.4byte sJynxSprites10
+.4byte sJynxSprites11
+.4byte sJynxSprites12
+.4byte sJynxSprites13
+.4byte sJynxSprites14
+.4byte sJynxSprites15
+.4byte sJynxSprites16
+.4byte sJynxSprites17
+.4byte sJynxSprites18
+.4byte sJynxSprites19
+.4byte sJynxSprites20
+.4byte sJynxSprites21
+.4byte sJynxSprites22
+.4byte sJynxSprites23
+.4byte sJynxSprites24
+.4byte sJynxSprites25
+.4byte sJynxSprites26
+.4byte sJynxSprites27
+.4byte sJynxSprites28
+.4byte sJynxSprites29
+.4byte sJynxSprites30
+.4byte sJynxSprites31
+.4byte sJynxSprites32
+.4byte sJynxSprites33
+.4byte sJynxSprites34
+.4byte sJynxSprites35
+.4byte sJynxSprites36
+.4byte sJynxSprites37
+.4byte sJynxSprites38
+.4byte sJynxSprites39
+.4byte sJynxSprites40
+.4byte sJynxSprites41
+.4byte sJynxSprites42
+.4byte sJynxSprites43
+.4byte sJynxSprites44
+.4byte sJynxSprites45
+.4byte sJynxSprites46
+.4byte sJynxSprites47
+.4byte sJynxSprites48
+.4byte sJynxSprites49
+.4byte sJynxSprites50
+.4byte sJynxSprites51
+.4byte sJynxSprites52
+.4byte sJynxSprites53
+.4byte sJynxSprites54
+.4byte sJynxSprites55
+.4byte sJynxSprites56
+.4byte sJynxSprites57
+.4byte sJynxSprites58
+.4byte sJynxSprites59
+.4byte sJynxSprites60
+.4byte sJynxSprites61
+sAxMainJynx:
+ax_main sAxPosesJynx, sAxAnimationsJynx, 13, sAxSpritesJynx, sAxPositionsJynx

--- a/data/ax/kabuto.inc
+++ b/data/ax/kabuto.inc
@@ -1,0 +1,2925 @@
+.global gAxKabuto
+gAxKabuto:
+ax_siro sAxMainKabuto
+sKabutoPose1:
+ax_pose 0, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose2:
+ax_pose 1, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose3:
+ax_pose 2, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose4:
+ax_pose 3, 0x41f4, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose5:
+ax_pose 4, 0x41f5, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose6:
+ax_pose 5, 0x41f5, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose7:
+ax_pose 6, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose8:
+ax_pose 7, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose9:
+ax_pose 8, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose10:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose11:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose12:
+ax_pose 11, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose13:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose14:
+ax_pose 13, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose15:
+ax_pose 14, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose16:
+ax_pose 9, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose17:
+ax_pose 10, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose18:
+ax_pose 11, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose19:
+ax_pose 6, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose20:
+ax_pose 7, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose21:
+ax_pose 8, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose22:
+ax_pose 3, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose23:
+ax_pose 4, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose24:
+ax_pose 5, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose25:
+ax_pose 0, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose26:
+ax_pose 1, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose27:
+ax_pose 2, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose28:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose29:
+ax_pose 16, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose30:
+ax_pose 3, 0x41f4, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose31:
+ax_pose 4, 0x41f5, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose32:
+ax_pose 5, 0x41f5, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose33:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose34:
+ax_pose 18, 0x01f1, 0x90ed, 0x4c00
+ax_pose_terminator
+sKabutoPose35:
+ax_pose 6, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose36:
+ax_pose 7, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose37:
+ax_pose 8, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose38:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose39:
+ax_pose 20, 0x81f0, 0x90f8, 0x4c00
+ax_pose_terminator
+sKabutoPose40:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose41:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose42:
+ax_pose 11, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose43:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose44:
+ax_pose 22, 0x01f0, 0x90ef, 0x4c00
+ax_pose_terminator
+sKabutoPose45:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose46:
+ax_pose 13, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose47:
+ax_pose 14, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose48:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose49:
+ax_pose 24, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose50:
+ax_pose 9, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose51:
+ax_pose 10, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose52:
+ax_pose 11, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose53:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose54:
+ax_pose 22, 0x01f0, 0x80f1, 0x4c00
+ax_pose_terminator
+sKabutoPose55:
+ax_pose 6, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose56:
+ax_pose 7, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose57:
+ax_pose 8, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose58:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose59:
+ax_pose 20, 0x81f0, 0x80f8, 0x4c00
+ax_pose_terminator
+sKabutoPose60:
+ax_pose 3, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose61:
+ax_pose 4, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose62:
+ax_pose 5, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose63:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose64:
+ax_pose 18, 0x01f1, 0x80f3, 0x4c00
+ax_pose_terminator
+sKabutoPose65:
+ax_pose 0, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose66:
+ax_pose 1, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose67:
+ax_pose 2, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose68:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose69:
+ax_pose 16, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose70:
+ax_pose 3, 0x41f4, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose71:
+ax_pose 4, 0x41f5, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose72:
+ax_pose 5, 0x41f5, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose73:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose74:
+ax_pose 18, 0x01f1, 0x90ed, 0x4c00
+ax_pose_terminator
+sKabutoPose75:
+ax_pose 6, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose76:
+ax_pose 7, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose77:
+ax_pose 8, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose78:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose79:
+ax_pose 20, 0x81f0, 0x90f8, 0x4c00
+ax_pose_terminator
+sKabutoPose80:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose81:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose82:
+ax_pose 11, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose83:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose84:
+ax_pose 22, 0x01f0, 0x90ef, 0x4c00
+ax_pose_terminator
+sKabutoPose85:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose86:
+ax_pose 13, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose87:
+ax_pose 14, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose88:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose89:
+ax_pose 24, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose90:
+ax_pose 9, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose91:
+ax_pose 10, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose92:
+ax_pose 11, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose93:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose94:
+ax_pose 22, 0x01f0, 0x80f1, 0x4c00
+ax_pose_terminator
+sKabutoPose95:
+ax_pose 6, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose96:
+ax_pose 7, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose97:
+ax_pose 8, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose98:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose99:
+ax_pose 20, 0x81f0, 0x80f8, 0x4c00
+ax_pose_terminator
+sKabutoPose100:
+ax_pose 3, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose101:
+ax_pose 4, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose102:
+ax_pose 5, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose103:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose104:
+ax_pose 18, 0x01f1, 0x80f3, 0x4c00
+ax_pose_terminator
+sKabutoPose105:
+ax_pose 0, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose106:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose107:
+ax_pose 25, 0x41f1, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose108:
+ax_pose 3, 0x41f4, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose109:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose110:
+ax_pose 26, 0x41f2, 0x90ec, 0x4c00
+ax_pose_terminator
+sKabutoPose111:
+ax_pose 6, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose112:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose113:
+ax_pose 27, 0x81f0, 0x90fa, 0x4c00
+ax_pose_terminator
+sKabutoPose114:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose115:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose116:
+ax_pose 28, 0x01ee, 0x90ed, 0x4c00
+ax_pose_terminator
+sKabutoPose117:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose118:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose119:
+ax_pose 29, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose120:
+ax_pose 9, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose121:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose122:
+ax_pose 28, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sKabutoPose123:
+ax_pose 6, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose124:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose125:
+ax_pose 27, 0x81f0, 0x80f6, 0x4c00
+ax_pose_terminator
+sKabutoPose126:
+ax_pose 3, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose127:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose128:
+ax_pose 26, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose129:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose130:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose131:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose132:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose133:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose134:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose135:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose136:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose137:
+ax_pose 30, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose138:
+ax_pose 31, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose139:
+ax_pose 19, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose140:
+ax_pose 21, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose141:
+ax_pose 23, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose142:
+ax_pose 21, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose143:
+ax_pose 19, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose144:
+ax_pose 31, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose145:
+ax_pose 32, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose146:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose147:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose148:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose149:
+ax_pose 12, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose150:
+ax_pose 9, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose151:
+ax_pose 6, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose152:
+ax_pose 33, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose153:
+ax_pose 34, 0x41f4, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose154:
+ax_pose 35, 0x41f4, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose155:
+ax_pose 36, 0x01ed, 0x80f6, 0x4c00
+ax_pose_terminator
+sKabutoPose156:
+ax_pose 37, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sKabutoPose157:
+ax_pose 38, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sKabutoPose158:
+ax_pose 39, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sKabutoPose159:
+ax_pose 40, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sKabutoPose160:
+ax_pose 39, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sKabutoPose161:
+ax_pose 38, 0x01ec, 0x80f5, 0x4c00
+ax_pose_terminator
+sKabutoPose162:
+ax_pose 37, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sKabutoPose163:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose164:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose165:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose166:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose167:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose168:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose169:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose170:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose171:
+ax_pose 30, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose172:
+ax_pose 31, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose173:
+ax_pose 19, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose174:
+ax_pose 21, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose175:
+ax_pose 23, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose176:
+ax_pose 21, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose177:
+ax_pose 19, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose178:
+ax_pose 31, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose179:
+ax_pose 32, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose180:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose181:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose182:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose183:
+ax_pose 12, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose184:
+ax_pose 9, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose185:
+ax_pose 6, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose186:
+ax_pose 33, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose187:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose188:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose189:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose190:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose191:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose192:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose193:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose194:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose195:
+ax_pose 30, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose196:
+ax_pose 31, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose197:
+ax_pose 19, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose198:
+ax_pose 21, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose199:
+ax_pose 23, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose200:
+ax_pose 21, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose201:
+ax_pose 19, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose202:
+ax_pose 31, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose203:
+ax_pose 32, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose204:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose205:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose206:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose207:
+ax_pose 12, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose208:
+ax_pose 9, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose209:
+ax_pose 6, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose210:
+ax_pose 33, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose211:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose212:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose213:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose214:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose215:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose216:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose217:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose218:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose219:
+ax_pose 0, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose220:
+ax_pose 16, 0x41f4, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose221:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose222:
+ax_pose 3, 0x41f4, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose223:
+ax_pose 18, 0x01f1, 0x90ed, 0x4c00
+ax_pose_terminator
+sKabutoPose224:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose225:
+ax_pose 6, 0x01ed, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose226:
+ax_pose 20, 0x81f0, 0x90f8, 0x4c00
+ax_pose_terminator
+sKabutoPose227:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose228:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose229:
+ax_pose 22, 0x01f0, 0x90ef, 0x4c00
+ax_pose_terminator
+sKabutoPose230:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose231:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose232:
+ax_pose 24, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose233:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose234:
+ax_pose 9, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose235:
+ax_pose 22, 0x01f0, 0x80f1, 0x4c00
+ax_pose_terminator
+sKabutoPose236:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose237:
+ax_pose 6, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose238:
+ax_pose 20, 0x81f0, 0x80f8, 0x4c00
+ax_pose_terminator
+sKabutoPose239:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose240:
+ax_pose 3, 0x41f5, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose241:
+ax_pose 18, 0x01f1, 0x80f3, 0x4c00
+ax_pose_terminator
+sKabutoPose242:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose243:
+ax_pose 16, 0x41f1, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose244:
+ax_pose 18, 0x01f0, 0x80f3, 0x4c00
+ax_pose_terminator
+sKabutoPose245:
+ax_pose 20, 0x81ef, 0x80f8, 0x4c00
+ax_pose_terminator
+sKabutoPose246:
+ax_pose 22, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sKabutoPose247:
+ax_pose 24, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose248:
+ax_pose 22, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sKabutoPose249:
+ax_pose 20, 0x81ef, 0x90f8, 0x4c00
+ax_pose_terminator
+sKabutoPose250:
+ax_pose 18, 0x01f0, 0x90ed, 0x4c00
+ax_pose_terminator
+sKabutoPose251:
+ax_pose 15, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose252:
+ax_pose 17, 0x41f3, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose253:
+ax_pose 19, 0x01ee, 0x80f2, 0x4c00
+ax_pose_terminator
+sKabutoPose254:
+ax_pose 21, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose255:
+ax_pose 23, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sKabutoPose256:
+ax_pose 21, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose257:
+ax_pose 19, 0x01ee, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose258:
+ax_pose 17, 0x41f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sKabutoPose259:
+ax_pose 30, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose260:
+ax_pose 31, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose261:
+ax_pose 19, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose262:
+ax_pose 21, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose263:
+ax_pose 23, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose264:
+ax_pose 21, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose265:
+ax_pose 19, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose266:
+ax_pose 31, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose267:
+ax_pose 32, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose268:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose269:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose270:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose271:
+ax_pose 12, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sKabutoPose272:
+ax_pose 9, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose273:
+ax_pose 6, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sKabutoPose274:
+ax_pose 33, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+.align 2
+sKabutoAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 27, 0, 8, 0, 10,
+ax_anim 2, 0, 28, 0, 16, 0, 18,
+ax_anim 2, 1, 28, 1, 16, 1, 18,
+ax_anim 2, 0, 28, 0, 16, 0, 18,
+ax_anim 2, 0, 28, 1, 16, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sKabutoAnims_2_2:
+ax_anim 4, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 2, 0, 30, 4, 4, 4, 4,
+ax_anim 2, 2, 32, 10, 8, 10, 10,
+ax_anim 2, 0, 33, 18, 14, 18, 18,
+ax_anim 2, 1, 33, 19, 13, 19, 17,
+ax_anim 2, 0, 33, 18, 14, 18, 18,
+ax_anim 2, 0, 33, 19, 13, 19, 17,
+ax_anim 4, 0, 29, 8, 8, 6, 6,
+ax_anim_terminator
+sKabutoAnims_2_3:
+ax_anim 4, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 4, 0, 4, 0,
+ax_anim 2, 2, 37, 10, -2, 10, 0,
+ax_anim 2, 0, 38, 18, -4, 18, 0,
+ax_anim 2, 1, 38, 18, -3, 18, 1,
+ax_anim 2, 0, 38, 18, -4, 18, 0,
+ax_anim 2, 0, 38, 18, -3, 18, 1,
+ax_anim 4, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sKabutoAnims_2_4:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 2, 0, 41, 0, -1, 0, -1,
+ax_anim 2, 0, 40, 4, -4, 4, -4,
+ax_anim 2, 2, 42, 10, -12, 10, -10,
+ax_anim 2, 0, 43, 18, -21, 18, -18,
+ax_anim 2, 1, 43, 19, -20, 19, -17,
+ax_anim 2, 0, 43, 18, -21, 18, -18,
+ax_anim 2, 0, 43, 19, -20, 19, -17,
+ax_anim 4, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sKabutoAnims_2_5:
+ax_anim 4, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -4, 0, -4,
+ax_anim 2, 2, 47, 0, -11, 0, -10,
+ax_anim 2, 0, 48, 0, -20, 0, -18,
+ax_anim 2, 1, 48, 1, -20, 1, -18,
+ax_anim 2, 0, 48, 0, -20, 0, -18,
+ax_anim 2, 0, 48, 1, -20, 1, -18,
+ax_anim 4, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sKabutoAnims_2_6:
+ax_anim 4, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 4, 0, 49, 2, 2, 2, 2,
+ax_anim 2, 0, 51, 0, 0, 0, -1,
+ax_anim 2, 0, 50, -4, -4, -4, -4,
+ax_anim 2, 2, 52, -10, -12, -10, -10,
+ax_anim 2, 0, 53, -18, -21, -18, -18,
+ax_anim 2, 1, 53, -19, -20, -19, -17,
+ax_anim 2, 0, 53, -18, -21, -18, -18,
+ax_anim 2, 0, 53, -19, -20, -19, -17,
+ax_anim 4, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sKabutoAnims_2_7:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 4, 0, 54, 2, 0, 2, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -4, 0, -4, 0,
+ax_anim 2, 2, 57, -10, -2, -10, 0,
+ax_anim 2, 0, 58, -18, -4, -18, 0,
+ax_anim 2, 1, 58, -18, -3, -18, 1,
+ax_anim 2, 0, 58, -18, -4, -18, 0,
+ax_anim 2, 0, 58, -18, -3, -18, 1,
+ax_anim 4, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sKabutoAnims_2_8:
+ax_anim 4, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 4, 0, 59, 2, -2, 2, -2,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, -4, 4, -4, 4,
+ax_anim 2, 2, 62, -10, 8, -10, 10,
+ax_anim 2, 0, 63, -17, 14, -17, 19,
+ax_anim 2, 1, 63, -18, 13, -18, 18,
+ax_anim 2, 0, 63, -17, 14, -17, 19,
+ax_anim 2, 0, 63, -17, 14, -17, 19,
+ax_anim 4, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sKabutoAnims_3_1:
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 4, 0, 4,
+ax_anim 2, 2, 67, 0, 8, 0, 10,
+ax_anim 2, 0, 68, 0, 16, 0, 18,
+ax_anim 2, 1, 68, 1, 16, 1, 18,
+ax_anim 2, 0, 68, 0, 16, 0, 18,
+ax_anim 2, 0, 68, 1, 16, 1, 18,
+ax_anim 4, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sKabutoAnims_3_2:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 4, 0, 69, -2, -2, -2, -2,
+ax_anim 2, 0, 71, 0, -1, 0, 0,
+ax_anim 2, 0, 70, 4, 4, 4, 4,
+ax_anim 2, 2, 72, 10, 8, 10, 10,
+ax_anim 2, 0, 73, 18, 14, 18, 18,
+ax_anim 2, 1, 73, 19, 13, 19, 17,
+ax_anim 2, 0, 73, 18, 14, 18, 18,
+ax_anim 2, 0, 73, 19, 13, 19, 17,
+ax_anim 4, 0, 69, 8, 8, 6, 6,
+ax_anim_terminator
+sKabutoAnims_3_3:
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 4, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 4, 0, 4, 0,
+ax_anim 2, 2, 77, 10, -2, 10, 0,
+ax_anim 2, 0, 78, 18, -4, 18, 0,
+ax_anim 2, 1, 78, 18, -3, 18, 1,
+ax_anim 2, 0, 78, 18, -4, 18, 0,
+ax_anim 2, 0, 78, 18, -3, 18, 1,
+ax_anim 4, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sKabutoAnims_3_4:
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 4, 0, 79, -2, 2, -2, 2,
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 0, 80, 4, -4, 4, -4,
+ax_anim 2, 2, 82, 10, -12, 10, -10,
+ax_anim 2, 0, 83, 18, -21, 18, -18,
+ax_anim 2, 1, 83, 19, -20, 19, -17,
+ax_anim 2, 0, 83, 18, -21, 18, -18,
+ax_anim 2, 0, 83, 19, -20, 19, -17,
+ax_anim 4, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sKabutoAnims_3_5:
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 4, 0, 84, 0, 2, 0, 2,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim 2, 2, 87, 0, -11, 0, -10,
+ax_anim 2, 0, 88, 0, -20, 0, -18,
+ax_anim 2, 1, 88, 1, -20, 1, -18,
+ax_anim 2, 0, 88, 0, -20, 0, -18,
+ax_anim 2, 0, 88, 1, -20, 1, -18,
+ax_anim 4, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sKabutoAnims_3_6:
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 4, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 0, 0, 0, -1,
+ax_anim 2, 0, 90, -4, -4, -4, -4,
+ax_anim 2, 2, 92, -10, -12, -10, -10,
+ax_anim 2, 0, 93, -18, -21, -18, -18,
+ax_anim 2, 1, 93, -19, -20, -19, -17,
+ax_anim 2, 0, 93, -18, -21, -18, -18,
+ax_anim 2, 0, 93, -19, -20, -19, -17,
+ax_anim 4, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sKabutoAnims_3_7:
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 4, 0, 94, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -4, 0, -4, 0,
+ax_anim 2, 2, 97, -10, -2, -10, 0,
+ax_anim 2, 0, 98, -18, -4, -18, 0,
+ax_anim 2, 1, 98, -18, -3, -18, 1,
+ax_anim 2, 0, 98, -18, -4, -18, 0,
+ax_anim 2, 0, 98, -18, -3, -18, 1,
+ax_anim 4, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sKabutoAnims_3_8:
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -4, 4, -4, 4,
+ax_anim 2, 2, 102, -10, 8, -10, 10,
+ax_anim 2, 0, 103, -17, 14, -17, 19,
+ax_anim 2, 1, 103, -18, 13, -18, 18,
+ax_anim 2, 0, 103, -17, 14, -17, 19,
+ax_anim 2, 0, 103, -17, 14, -17, 19,
+ax_anim 4, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sKabutoAnims_4_1:
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, -1, 0, -1,
+ax_anim 4, 0, 104, 0, -3, 0, -3,
+ax_anim 2, 0, 105, 0, -3, 0, -2,
+ax_anim 2, 0, 105, 0, -4, 0, -1,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 4, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_4_2:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 107, -1, -1, -1, -1,
+ax_anim 4, 0, 107, -3, -3, -3, -3,
+ax_anim 2, 0, 108, -3, -4, -3, -3,
+ax_anim 2, 0, 108, -2, -4, -2, -2,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 4, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_4_3:
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 110, -1, 0, -1, 0,
+ax_anim 4, 0, 110, -3, 0, -3, 0,
+ax_anim 2, 0, 111, -3, -1, -2, 0,
+ax_anim 2, 0, 111, -2, -2, -1, 0,
+ax_anim 2, 0, 112, -1, -3, 0, 0,
+ax_anim 4, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_4_4:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 113, -1, 1, -1, 1,
+ax_anim 4, 0, 113, -3, 3, -3, 3,
+ax_anim 2, 0, 114, -2, 2, -3, 3,
+ax_anim 2, 0, 114, -1, -1, -1, 1,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 4, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_4_5:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 1, 0, 1,
+ax_anim 4, 0, 116, 0, 3, 0, 3,
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 2, 0, 117, 0, -2, 0, 1,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 4, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_4_6:
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 1, 1, 1, 1,
+ax_anim 4, 0, 119, 3, 3, 3, 3,
+ax_anim 2, 0, 120, 2, 2, 3, 3,
+ax_anim 2, 0, 120, 1, -1, 1, 1,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 4, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_4_7:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 1, 0, 1, 0,
+ax_anim 4, 0, 122, 3, 0, 3, 0,
+ax_anim 2, 0, 123, 3, -1, 2, 0,
+ax_anim 2, 0, 123, 2, -2, 1, 0,
+ax_anim 2, 0, 124, 1, -3, 0, 0,
+ax_anim 4, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 1, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_4_8:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 1, -1, 1, -1,
+ax_anim 4, 0, 125, 3, -3, 3, -3,
+ax_anim 2, 0, 126, 3, -4, 3, -3,
+ax_anim 2, 0, 126, 2, -4, 2, -2,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 4, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 1, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sKabutoAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sKabutoAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sKabutoAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sKabutoAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sKabutoAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sKabutoAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sKabutoAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sKabutoAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 1, 0, 0, 0,
+ax_anim 4, 0, 162, -1, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_8_2:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 1, -1, 0, 0,
+ax_anim 4, 0, 169, -1, 1, 0, 0,
+ax_anim_terminator
+sKabutoAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 168, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, 1, 0, 0,
+ax_anim_terminator
+sKabutoAnims_8_4:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 167, -1, -1, 0, 0,
+ax_anim 4, 0, 167, 1, 1, 0, 0,
+ax_anim_terminator
+sKabutoAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 1, 0, 0, 0,
+ax_anim 4, 0, 166, -1, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_8_6:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 165, 1, -1, 0, 0,
+ax_anim 4, 0, 165, -1, 1, 0, 0,
+ax_anim_terminator
+sKabutoAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, -1, 0, 0,
+ax_anim 4, 0, 164, 0, 1, 0, 0,
+ax_anim_terminator
+sKabutoAnims_8_8:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 163, -1, -1, 0, 0,
+ax_anim 4, 0, 163, 1, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 4, 6, 4,
+ax_anim 2, 0, 188, 10, 9, 10, 9,
+ax_anim 2, 0, 189, 7, 15, 7, 15,
+ax_anim 3, 0, 190, 1, 19, 1, 19,
+ax_anim 2, 3, 191, -7, 15, -7, 15,
+ax_anim 2, 0, 192, -10, 9, -10, 9,
+ax_anim 1, 0, 193, -6, 4, -6, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 24, 9, 24, 9,
+ax_anim 3, 0, 189, 23, 16, 23, 16,
+ax_anim 2, 3, 190, 11, 16, 11, 16,
+ax_anim 2, 0, 191, 4, 12, 4, 12,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -4, 3, -4,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 17, -4, 17, -4,
+ax_anim 3, 0, 188, 20, 1, 20, 1,
+ax_anim 2, 3, 189, 17, 5, 17, 5,
+ax_anim 2, 0, 190, 12, 7, 12, 7,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 1, -6, 1, -6,
+ax_anim 2, 0, 193, 6, -16, 6, -16,
+ax_anim 2, 0, 186, 11, -20, 11, -20,
+ax_anim 3, 0, 187, 16, -20, 16, -20,
+ax_anim 2, 3, 188, 16, -15, 16, -15,
+ax_anim 2, 0, 189, 14, -6, 14, -6,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -6, -4, -6, -4,
+ax_anim 2, 0, 192, -8, -10, -8, -9,
+ax_anim 2, 0, 193, -7, -15, -7, -13,
+ax_anim 3, 0, 186, -1, -18, -1, -16,
+ax_anim 2, 3, 187, 7, -15, 7, -13,
+ax_anim 2, 0, 188, 8, -9, 8, -8,
+ax_anim 1, 0, 189, 6, -4, 6, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, -1, -6, -1, -6,
+ax_anim 2, 0, 187, -6, -16, -6, -16,
+ax_anim 2, 0, 186, -11, -20, -11, -20,
+ax_anim 3, 0, 193, -16, -20, -16, -20,
+ax_anim 2, 3, 192, -18, -15, -16, -15,
+ax_anim 2, 0, 191, -14, -6, -14, -6,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -4, -3, -4,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -17, -4, -17, -4,
+ax_anim 3, 0, 192, -20, 1, -20, 1,
+ax_anim 2, 3, 191, -17, 5, -17, 5,
+ax_anim 2, 0, 190, -12, 7, -12, 7,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -24, 9, -24, 9,
+ax_anim 3, 0, 191, -23, 16, -23, 16,
+ax_anim 2, 3, 190, -11, 16, -11, 16,
+ax_anim 2, 0, 189, -4, 12, -4, 12,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutoAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutoGfx1:
+.incbin "baserom.gba", 0xB0934C, 0x100
+sKabutoSprites1:
+ax_sprite sKabutoGfx1, 0x100
+ax_sprite_terminator
+sKabutoGfx2:
+.incbin "baserom.gba", 0xB0945C, 0x100
+sKabutoSprites2:
+ax_sprite sKabutoGfx2, 0x100
+ax_sprite_terminator
+sKabutoGfx3:
+.incbin "baserom.gba", 0xB0956C, 0x100
+sKabutoSprites3:
+ax_sprite sKabutoGfx3, 0x100
+ax_sprite_terminator
+sKabutoGfx4:
+.incbin "baserom.gba", 0xB0967C, 0x100
+sKabutoSprites4:
+ax_sprite sKabutoGfx4, 0x100
+ax_sprite_terminator
+sKabutoGfx5:
+.incbin "baserom.gba", 0xB0978C, 0x100
+sKabutoSprites5:
+ax_sprite sKabutoGfx5, 0x100
+ax_sprite_terminator
+sKabutoGfx6:
+.incbin "baserom.gba", 0xB0989C, 0x100
+sKabutoSprites6:
+ax_sprite sKabutoGfx6, 0x100
+ax_sprite_terminator
+sKabutoGfx7:
+.incbin "baserom.gba", 0xB099AC, 0x200
+sKabutoSprites7:
+ax_sprite sKabutoGfx7, 0x200
+ax_sprite_terminator
+sKabutoGfx8:
+.incbin "baserom.gba", 0xB09BBC, 0x200
+sKabutoSprites8:
+ax_sprite sKabutoGfx8, 0x200
+ax_sprite_terminator
+sKabutoGfx9:
+.incbin "baserom.gba", 0xB09DCC, 0x200
+sKabutoSprites9:
+ax_sprite sKabutoGfx9, 0x200
+ax_sprite_terminator
+sKabutoGfx10:
+.incbin "baserom.gba", 0xB09FDC, 0x200
+sKabutoSprites10:
+ax_sprite sKabutoGfx10, 0x200
+ax_sprite_terminator
+sKabutoGfx11:
+.incbin "baserom.gba", 0xB0A1EC, 0x200
+sKabutoSprites11:
+ax_sprite sKabutoGfx11, 0x200
+ax_sprite_terminator
+sKabutoGfx12:
+.incbin "baserom.gba", 0xB0A3FC, 0x200
+sKabutoSprites12:
+ax_sprite sKabutoGfx12, 0x200
+ax_sprite_terminator
+sKabutoGfx13:
+.incbin "baserom.gba", 0xB0A60C, 0x200
+sKabutoSprites13:
+ax_sprite sKabutoGfx13, 0x200
+ax_sprite_terminator
+sKabutoGfx14:
+.incbin "baserom.gba", 0xB0A81C, 0x200
+sKabutoSprites14:
+ax_sprite sKabutoGfx14, 0x200
+ax_sprite_terminator
+sKabutoGfx15:
+.incbin "baserom.gba", 0xB0AA2C, 0x200
+sKabutoSprites15:
+ax_sprite sKabutoGfx15, 0x200
+ax_sprite_terminator
+sKabutoGfx16:
+.incbin "baserom.gba", 0xB0AC3C, 0x60
+sKabutoGfx16_1:
+.incbin "baserom.gba", 0xB0AC9C, 0x60
+sKabutoSprites16:
+ax_sprite sKabutoGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutoGfx17:
+.incbin "baserom.gba", 0xB0AD24, 0x60
+sKabutoGfx17_1:
+.incbin "baserom.gba", 0xB0AD84, 0x60
+sKabutoSprites17:
+ax_sprite sKabutoGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutoGfx18:
+.incbin "baserom.gba", 0xB0AE0C, 0x60
+sKabutoGfx18_1:
+.incbin "baserom.gba", 0xB0AE6C, 0x60
+sKabutoSprites18:
+ax_sprite sKabutoGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutoGfx19:
+.incbin "baserom.gba", 0xB0AEF4, 0x60
+sKabutoGfx19_1:
+.incbin "baserom.gba", 0xB0AF54, 0x60
+sKabutoGfx19_2:
+.incbin "baserom.gba", 0xB0AFB4, 0x40
+sKabutoSprites19:
+ax_sprite sKabutoGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKabutoGfx19_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx20:
+.incbin "baserom.gba", 0xB0B02C, 0x40
+sKabutoGfx20_1:
+.incbin "baserom.gba", 0xB0B06C, 0x60
+sKabutoGfx20_2:
+.incbin "baserom.gba", 0xB0B0CC, 0x60
+sKabutoSprites20:
+ax_sprite sKabutoGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKabutoGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx21:
+.incbin "baserom.gba", 0xB0B164, 0xC0
+sKabutoSprites21:
+ax_sprite sKabutoGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKabutoGfx22:
+.incbin "baserom.gba", 0xB0B23C, 0x40
+sKabutoGfx22_1:
+.incbin "baserom.gba", 0xB0B27C, 0x60
+sKabutoGfx22_2:
+.incbin "baserom.gba", 0xB0B2DC, 0x40
+sKabutoSprites22:
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKabutoGfx22_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx23:
+.incbin "baserom.gba", 0xB0B35C, 0x40
+sKabutoGfx23_1:
+.incbin "baserom.gba", 0xB0B39C, 0x60
+sKabutoGfx23_2:
+.incbin "baserom.gba", 0xB0B3FC, 0x60
+sKabutoSprites23:
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx24:
+.incbin "baserom.gba", 0xB0B49C, 0x60
+sKabutoGfx24_1:
+.incbin "baserom.gba", 0xB0B4FC, 0x60
+sKabutoGfx24_2:
+.incbin "baserom.gba", 0xB0B55C, 0x60
+sKabutoSprites24:
+ax_sprite sKabutoGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx25:
+.incbin "baserom.gba", 0xB0B5F4, 0x60
+sKabutoGfx25_1:
+.incbin "baserom.gba", 0xB0B654, 0x60
+sKabutoGfx25_2:
+.incbin "baserom.gba", 0xB0B6B4, 0x60
+sKabutoSprites25:
+ax_sprite sKabutoGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx26:
+.incbin "baserom.gba", 0xB0B74C, 0x60
+sKabutoGfx26_1:
+.incbin "baserom.gba", 0xB0B7AC, 0x60
+sKabutoSprites26:
+ax_sprite sKabutoGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutoGfx27:
+.incbin "baserom.gba", 0xB0B834, 0x60
+sKabutoGfx27_1:
+.incbin "baserom.gba", 0xB0B894, 0x60
+sKabutoSprites27:
+ax_sprite sKabutoGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutoGfx28:
+.incbin "baserom.gba", 0xB0B91C, 0xC0
+sKabutoSprites28:
+ax_sprite sKabutoGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKabutoGfx29:
+.incbin "baserom.gba", 0xB0B9F4, 0x60
+sKabutoGfx29_1:
+.incbin "baserom.gba", 0xB0BA54, 0x60
+sKabutoGfx29_2:
+.incbin "baserom.gba", 0xB0BAB4, 0x60
+sKabutoSprites29:
+ax_sprite sKabutoGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx30:
+.incbin "baserom.gba", 0xB0BB4C, 0x60
+sKabutoGfx30_1:
+.incbin "baserom.gba", 0xB0BBAC, 0x60
+sKabutoGfx30_2:
+.incbin "baserom.gba", 0xB0BC0C, 0x60
+sKabutoSprites30:
+ax_sprite sKabutoGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutoGfx31:
+.incbin "baserom.gba", 0xB0BCA4, 0x60
+sKabutoGfx31_1:
+.incbin "baserom.gba", 0xB0BD04, 0x60
+sKabutoSprites31:
+ax_sprite sKabutoGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx31_1, 0x60
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sKabutoGfx32:
+.incbin "baserom.gba", 0xB0BD8C, 0x60
+sKabutoGfx32_1:
+.incbin "baserom.gba", 0xB0BDEC, 0x60
+sKabutoSprites32:
+ax_sprite sKabutoGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx32_1, 0x60
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sKabutoGfx33:
+.incbin "baserom.gba", 0xB0BE74, 0x60
+sKabutoGfx33_1:
+.incbin "baserom.gba", 0xB0BED4, 0x60
+sKabutoSprites33:
+ax_sprite sKabutoGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx33_1, 0x60
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sKabutoGfx34:
+.incbin "baserom.gba", 0xB0BF5C, 0x60
+sKabutoGfx34_1:
+.incbin "baserom.gba", 0xB0BFBC, 0x60
+sKabutoSprites34:
+ax_sprite sKabutoGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutoGfx34_1, 0x60
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sKabutoGfx35:
+.incbin "baserom.gba", 0xB0C044, 0x100
+sKabutoSprites35:
+ax_sprite sKabutoGfx35, 0x100
+ax_sprite_terminator
+sKabutoGfx36:
+.incbin "baserom.gba", 0xB0C154, 0x100
+sKabutoSprites36:
+ax_sprite sKabutoGfx36, 0x100
+ax_sprite_terminator
+sKabutoGfx37:
+.incbin "baserom.gba", 0xB0C264, 0x200
+sKabutoSprites37:
+ax_sprite sKabutoGfx37, 0x200
+ax_sprite_terminator
+sKabutoGfx38:
+.incbin "baserom.gba", 0xB0C474, 0x200
+sKabutoSprites38:
+ax_sprite sKabutoGfx38, 0x200
+ax_sprite_terminator
+sKabutoGfx39:
+.incbin "baserom.gba", 0xB0C684, 0x200
+sKabutoSprites39:
+ax_sprite sKabutoGfx39, 0x200
+ax_sprite_terminator
+sKabutoGfx40:
+.incbin "baserom.gba", 0xB0C894, 0x200
+sKabutoSprites40:
+ax_sprite sKabutoGfx40, 0x200
+ax_sprite_terminator
+sKabutoGfx41:
+.incbin "baserom.gba", 0xB0CAA4, 0x200
+sKabutoSprites41:
+ax_sprite sKabutoGfx41, 0x200
+ax_sprite_terminator
+sAxPosesKabuto:
+.4byte sKabutoPose1
+.4byte sKabutoPose2
+.4byte sKabutoPose3
+.4byte sKabutoPose4
+.4byte sKabutoPose5
+.4byte sKabutoPose6
+.4byte sKabutoPose7
+.4byte sKabutoPose8
+.4byte sKabutoPose9
+.4byte sKabutoPose10
+.4byte sKabutoPose11
+.4byte sKabutoPose12
+.4byte sKabutoPose13
+.4byte sKabutoPose14
+.4byte sKabutoPose15
+.4byte sKabutoPose16
+.4byte sKabutoPose17
+.4byte sKabutoPose18
+.4byte sKabutoPose19
+.4byte sKabutoPose20
+.4byte sKabutoPose21
+.4byte sKabutoPose22
+.4byte sKabutoPose23
+.4byte sKabutoPose24
+.4byte sKabutoPose25
+.4byte sKabutoPose26
+.4byte sKabutoPose27
+.4byte sKabutoPose28
+.4byte sKabutoPose29
+.4byte sKabutoPose30
+.4byte sKabutoPose31
+.4byte sKabutoPose32
+.4byte sKabutoPose33
+.4byte sKabutoPose34
+.4byte sKabutoPose35
+.4byte sKabutoPose36
+.4byte sKabutoPose37
+.4byte sKabutoPose38
+.4byte sKabutoPose39
+.4byte sKabutoPose40
+.4byte sKabutoPose41
+.4byte sKabutoPose42
+.4byte sKabutoPose43
+.4byte sKabutoPose44
+.4byte sKabutoPose45
+.4byte sKabutoPose46
+.4byte sKabutoPose47
+.4byte sKabutoPose48
+.4byte sKabutoPose49
+.4byte sKabutoPose50
+.4byte sKabutoPose51
+.4byte sKabutoPose52
+.4byte sKabutoPose53
+.4byte sKabutoPose54
+.4byte sKabutoPose55
+.4byte sKabutoPose56
+.4byte sKabutoPose57
+.4byte sKabutoPose58
+.4byte sKabutoPose59
+.4byte sKabutoPose60
+.4byte sKabutoPose61
+.4byte sKabutoPose62
+.4byte sKabutoPose63
+.4byte sKabutoPose64
+.4byte sKabutoPose65
+.4byte sKabutoPose66
+.4byte sKabutoPose67
+.4byte sKabutoPose68
+.4byte sKabutoPose69
+.4byte sKabutoPose70
+.4byte sKabutoPose71
+.4byte sKabutoPose72
+.4byte sKabutoPose73
+.4byte sKabutoPose74
+.4byte sKabutoPose75
+.4byte sKabutoPose76
+.4byte sKabutoPose77
+.4byte sKabutoPose78
+.4byte sKabutoPose79
+.4byte sKabutoPose80
+.4byte sKabutoPose81
+.4byte sKabutoPose82
+.4byte sKabutoPose83
+.4byte sKabutoPose84
+.4byte sKabutoPose85
+.4byte sKabutoPose86
+.4byte sKabutoPose87
+.4byte sKabutoPose88
+.4byte sKabutoPose89
+.4byte sKabutoPose90
+.4byte sKabutoPose91
+.4byte sKabutoPose92
+.4byte sKabutoPose93
+.4byte sKabutoPose94
+.4byte sKabutoPose95
+.4byte sKabutoPose96
+.4byte sKabutoPose97
+.4byte sKabutoPose98
+.4byte sKabutoPose99
+.4byte sKabutoPose100
+.4byte sKabutoPose101
+.4byte sKabutoPose102
+.4byte sKabutoPose103
+.4byte sKabutoPose104
+.4byte sKabutoPose105
+.4byte sKabutoPose106
+.4byte sKabutoPose107
+.4byte sKabutoPose108
+.4byte sKabutoPose109
+.4byte sKabutoPose110
+.4byte sKabutoPose111
+.4byte sKabutoPose112
+.4byte sKabutoPose113
+.4byte sKabutoPose114
+.4byte sKabutoPose115
+.4byte sKabutoPose116
+.4byte sKabutoPose117
+.4byte sKabutoPose118
+.4byte sKabutoPose119
+.4byte sKabutoPose120
+.4byte sKabutoPose121
+.4byte sKabutoPose122
+.4byte sKabutoPose123
+.4byte sKabutoPose124
+.4byte sKabutoPose125
+.4byte sKabutoPose126
+.4byte sKabutoPose127
+.4byte sKabutoPose128
+.4byte sKabutoPose129
+.4byte sKabutoPose130
+.4byte sKabutoPose131
+.4byte sKabutoPose132
+.4byte sKabutoPose133
+.4byte sKabutoPose134
+.4byte sKabutoPose135
+.4byte sKabutoPose136
+.4byte sKabutoPose137
+.4byte sKabutoPose138
+.4byte sKabutoPose139
+.4byte sKabutoPose140
+.4byte sKabutoPose141
+.4byte sKabutoPose142
+.4byte sKabutoPose143
+.4byte sKabutoPose144
+.4byte sKabutoPose145
+.4byte sKabutoPose146
+.4byte sKabutoPose147
+.4byte sKabutoPose148
+.4byte sKabutoPose149
+.4byte sKabutoPose150
+.4byte sKabutoPose151
+.4byte sKabutoPose152
+.4byte sKabutoPose153
+.4byte sKabutoPose154
+.4byte sKabutoPose155
+.4byte sKabutoPose156
+.4byte sKabutoPose157
+.4byte sKabutoPose158
+.4byte sKabutoPose159
+.4byte sKabutoPose160
+.4byte sKabutoPose161
+.4byte sKabutoPose162
+.4byte sKabutoPose163
+.4byte sKabutoPose164
+.4byte sKabutoPose165
+.4byte sKabutoPose166
+.4byte sKabutoPose167
+.4byte sKabutoPose168
+.4byte sKabutoPose169
+.4byte sKabutoPose170
+.4byte sKabutoPose171
+.4byte sKabutoPose172
+.4byte sKabutoPose173
+.4byte sKabutoPose174
+.4byte sKabutoPose175
+.4byte sKabutoPose176
+.4byte sKabutoPose177
+.4byte sKabutoPose178
+.4byte sKabutoPose179
+.4byte sKabutoPose180
+.4byte sKabutoPose181
+.4byte sKabutoPose182
+.4byte sKabutoPose183
+.4byte sKabutoPose184
+.4byte sKabutoPose185
+.4byte sKabutoPose186
+.4byte sKabutoPose187
+.4byte sKabutoPose188
+.4byte sKabutoPose189
+.4byte sKabutoPose190
+.4byte sKabutoPose191
+.4byte sKabutoPose192
+.4byte sKabutoPose193
+.4byte sKabutoPose194
+.4byte sKabutoPose195
+.4byte sKabutoPose196
+.4byte sKabutoPose197
+.4byte sKabutoPose198
+.4byte sKabutoPose199
+.4byte sKabutoPose200
+.4byte sKabutoPose201
+.4byte sKabutoPose202
+.4byte sKabutoPose203
+.4byte sKabutoPose204
+.4byte sKabutoPose205
+.4byte sKabutoPose206
+.4byte sKabutoPose207
+.4byte sKabutoPose208
+.4byte sKabutoPose209
+.4byte sKabutoPose210
+.4byte sKabutoPose211
+.4byte sKabutoPose212
+.4byte sKabutoPose213
+.4byte sKabutoPose214
+.4byte sKabutoPose215
+.4byte sKabutoPose216
+.4byte sKabutoPose217
+.4byte sKabutoPose218
+.4byte sKabutoPose219
+.4byte sKabutoPose220
+.4byte sKabutoPose221
+.4byte sKabutoPose222
+.4byte sKabutoPose223
+.4byte sKabutoPose224
+.4byte sKabutoPose225
+.4byte sKabutoPose226
+.4byte sKabutoPose227
+.4byte sKabutoPose228
+.4byte sKabutoPose229
+.4byte sKabutoPose230
+.4byte sKabutoPose231
+.4byte sKabutoPose232
+.4byte sKabutoPose233
+.4byte sKabutoPose234
+.4byte sKabutoPose235
+.4byte sKabutoPose236
+.4byte sKabutoPose237
+.4byte sKabutoPose238
+.4byte sKabutoPose239
+.4byte sKabutoPose240
+.4byte sKabutoPose241
+.4byte sKabutoPose242
+.4byte sKabutoPose243
+.4byte sKabutoPose244
+.4byte sKabutoPose245
+.4byte sKabutoPose246
+.4byte sKabutoPose247
+.4byte sKabutoPose248
+.4byte sKabutoPose249
+.4byte sKabutoPose250
+.4byte sKabutoPose251
+.4byte sKabutoPose252
+.4byte sKabutoPose253
+.4byte sKabutoPose254
+.4byte sKabutoPose255
+.4byte sKabutoPose256
+.4byte sKabutoPose257
+.4byte sKabutoPose258
+.4byte sKabutoPose259
+.4byte sKabutoPose260
+.4byte sKabutoPose261
+.4byte sKabutoPose262
+.4byte sKabutoPose263
+.4byte sKabutoPose264
+.4byte sKabutoPose265
+.4byte sKabutoPose266
+.4byte sKabutoPose267
+.4byte sKabutoPose268
+.4byte sKabutoPose269
+.4byte sKabutoPose270
+.4byte sKabutoPose271
+.4byte sKabutoPose272
+.4byte sKabutoPose273
+.4byte sKabutoPose274
+sAxPositionsKabuto:
+.2byte   -1,   -1, 	  -7,    1, 	   6,    1, 	   0,   -5
+.2byte   -2,    0, 	  -9,    0, 	   4,    2, 	   0,   -5
+.2byte    1,    0, 	  -5,    2, 	   8,    0, 	  -1,   -5
+.2byte    6,   -2, 	  10,   -3, 	   1,    2, 	   0,   -5
+.2byte    8,   -2, 	  10,   -3, 	   4,    4, 	   1,   -4
+.2byte    5,    0, 	   6,   -8, 	   9,    0, 	   1,   -4
+.2byte    9,   -5, 	   7,   -9, 	   7,    1, 	   1,   -7
+.2byte    9,   -7, 	   3,   -8, 	   9,    0, 	   1,   -5
+.2byte   10,   -6, 	  10,   -8, 	   3,    2, 	   1,   -6
+.2byte    4,  -11, 	   0,  -10, 	  10,   -4, 	   1,   -8
+.2byte    2,  -10, 	  -2,   -9, 	  10,   -6, 	   0,   -6
+.2byte    6,   -9, 	   5,  -11, 	   9,    0, 	   0,   -7
+.2byte   -1,  -10, 	   8,   -3, 	  -9,   -3, 	   0,   -6
+.2byte    1,  -11, 	   8,   -2, 	  -9,   -9, 	  -2,   -7
+.2byte   -2,  -11, 	   8,   -9, 	  -9,   -2, 	   1,   -7
+.2byte   -5,  -10, 	  -1,   -9, 	 -11,   -3, 	  -2,   -7
+.2byte   -3,   -9, 	   1,   -8, 	 -11,   -5, 	  -1,   -5
+.2byte   -7,   -8, 	  -6,  -10, 	 -10,    1, 	  -1,   -6
+.2byte  -10,   -4, 	  -8,   -8, 	  -8,    2, 	  -2,   -6
+.2byte  -10,   -6, 	  -4,   -7, 	 -10,    1, 	  -2,   -4
+.2byte  -11,   -5, 	 -11,   -7, 	  -4,    3, 	  -2,   -5
+.2byte   -7,   -1, 	 -11,   -2, 	  -2,    3, 	  -1,   -4
+.2byte   -9,   -2, 	 -11,   -3, 	  -5,    4, 	  -2,   -4
+.2byte   -6,    0, 	  -7,   -8, 	 -10,    0, 	  -2,   -4
+.2byte   -1,   -1, 	  -7,    1, 	   6,    1, 	   0,   -5
+.2byte   -2,    0, 	  -9,    0, 	   4,    2, 	   0,   -5
+.2byte    1,    0, 	  -5,    2, 	   8,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte    0,   -3, 	  -8,    0, 	   7,    0, 	  -1,   -5
+.2byte    6,   -2, 	  10,   -3, 	   1,    2, 	   0,   -5
+.2byte    8,   -2, 	  10,   -3, 	   4,    4, 	   1,   -4
+.2byte    5,    0, 	   6,   -8, 	   9,    0, 	   1,   -4
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte    4,   -6, 	   9,   -5, 	   0,    0, 	   0,   -6
+.2byte    9,   -5, 	   7,   -9, 	   7,    1, 	   1,   -7
+.2byte    9,   -7, 	   3,   -8, 	   9,    0, 	   1,   -5
+.2byte   10,   -6, 	  10,   -8, 	   3,    2, 	   1,   -6
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    4,  -10, 	   6,  -11, 	   4,   -2, 	  -2,   -8
+.2byte    4,  -11, 	   0,  -10, 	  10,   -4, 	   1,   -8
+.2byte    2,  -10, 	  -2,   -9, 	  10,   -6, 	   0,   -6
+.2byte    6,   -9, 	   5,  -11, 	   9,    0, 	   0,   -7
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte    1,  -11, 	   0,  -13, 	  10,   -6, 	  -1,   -5
+.2byte   -1,  -10, 	   8,   -3, 	  -9,   -3, 	   0,   -6
+.2byte    1,  -11, 	   8,   -2, 	  -9,   -9, 	  -2,   -7
+.2byte   -2,  -11, 	   8,   -9, 	  -9,   -2, 	   1,   -7
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -6
+.2byte   -5,  -10, 	  -1,   -9, 	 -11,   -3, 	  -2,   -7
+.2byte   -3,   -9, 	   1,   -8, 	 -11,   -5, 	  -1,   -5
+.2byte   -7,   -8, 	  -6,  -10, 	 -10,    1, 	  -1,   -6
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -2,  -11, 	  -1,  -13, 	 -11,   -6, 	   0,   -5
+.2byte  -10,   -4, 	  -8,   -8, 	  -8,    2, 	  -2,   -6
+.2byte  -10,   -6, 	  -4,   -7, 	 -10,    1, 	  -2,   -4
+.2byte  -11,   -5, 	 -11,   -7, 	  -4,    3, 	  -2,   -5
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -5,  -10, 	  -7,  -11, 	  -5,   -2, 	   1,   -8
+.2byte   -7,   -1, 	 -11,   -2, 	  -2,    3, 	  -1,   -4
+.2byte   -9,   -2, 	 -11,   -3, 	  -5,    4, 	  -2,   -4
+.2byte   -6,    0, 	  -7,   -8, 	 -10,    0, 	  -2,   -4
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -5,   -6, 	 -10,   -5, 	  -1,    0, 	  -1,   -6
+.2byte   -1,   -1, 	  -7,    1, 	   6,    1, 	   0,   -5
+.2byte   -2,    0, 	  -9,    0, 	   4,    2, 	   0,   -5
+.2byte    1,    0, 	  -5,    2, 	   8,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte    0,   -3, 	  -8,    0, 	   7,    0, 	  -1,   -5
+.2byte    6,   -2, 	  10,   -3, 	   1,    2, 	   0,   -5
+.2byte    8,   -2, 	  10,   -3, 	   4,    4, 	   1,   -4
+.2byte    5,    0, 	   6,   -8, 	   9,    0, 	   1,   -4
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte    4,   -6, 	   9,   -5, 	   0,    0, 	   0,   -6
+.2byte    9,   -5, 	   7,   -9, 	   7,    1, 	   1,   -7
+.2byte    9,   -7, 	   3,   -8, 	   9,    0, 	   1,   -5
+.2byte   10,   -6, 	  10,   -8, 	   3,    2, 	   1,   -6
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    4,  -10, 	   6,  -11, 	   4,   -2, 	  -2,   -8
+.2byte    4,  -11, 	   0,  -10, 	  10,   -4, 	   1,   -8
+.2byte    2,  -10, 	  -2,   -9, 	  10,   -6, 	   0,   -6
+.2byte    6,   -9, 	   5,  -11, 	   9,    0, 	   0,   -7
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte    1,  -11, 	   0,  -13, 	  10,   -6, 	  -1,   -5
+.2byte   -1,  -10, 	   8,   -3, 	  -9,   -3, 	   0,   -6
+.2byte    1,  -11, 	   8,   -2, 	  -9,   -9, 	  -2,   -7
+.2byte   -2,  -11, 	   8,   -9, 	  -9,   -2, 	   1,   -7
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -6
+.2byte   -5,  -10, 	  -1,   -9, 	 -11,   -3, 	  -2,   -7
+.2byte   -3,   -9, 	   1,   -8, 	 -11,   -5, 	  -1,   -5
+.2byte   -7,   -8, 	  -6,  -10, 	 -10,    1, 	  -1,   -6
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -2,  -11, 	  -1,  -13, 	 -11,   -6, 	   0,   -5
+.2byte  -10,   -4, 	  -8,   -8, 	  -8,    2, 	  -2,   -6
+.2byte  -10,   -6, 	  -4,   -7, 	 -10,    1, 	  -2,   -4
+.2byte  -11,   -5, 	 -11,   -7, 	  -4,    3, 	  -2,   -5
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -5,  -10, 	  -7,  -11, 	  -5,   -2, 	   1,   -8
+.2byte   -7,   -1, 	 -11,   -2, 	  -2,    3, 	  -1,   -4
+.2byte   -9,   -2, 	 -11,   -3, 	  -5,    4, 	  -2,   -4
+.2byte   -6,    0, 	  -7,   -8, 	 -10,    0, 	  -2,   -4
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -5,   -6, 	 -10,   -5, 	  -1,    0, 	  -1,   -6
+.2byte   -1,   -1, 	  -7,    1, 	   6,    1, 	   0,   -5
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte   -1,   -7, 	  -2,   -5, 	   1,   -5, 	   0,   -6
+.2byte    6,   -2, 	  10,   -3, 	   1,    2, 	   0,   -5
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte    3,   -6, 	   5,   -5, 	   1,   -3, 	   0,   -6
+.2byte    9,   -5, 	   7,   -9, 	   7,    1, 	   1,   -7
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    6,   -9, 	   8,   -9, 	   7,   -6, 	   1,   -7
+.2byte    4,  -11, 	   0,  -10, 	  10,   -4, 	   1,   -8
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte    2,  -13, 	   1,  -13, 	   4,  -12, 	   0,   -8
+.2byte   -1,  -10, 	   8,   -3, 	  -9,   -3, 	   0,   -6
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte   -1,  -11, 	   3,  -11, 	  -4,  -11, 	   0,   -8
+.2byte   -5,  -10, 	  -1,   -9, 	 -11,   -3, 	  -2,   -7
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -3,  -13, 	  -2,  -13, 	  -5,  -12, 	  -1,   -8
+.2byte  -10,   -4, 	  -8,   -8, 	  -8,    2, 	  -2,   -6
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -7,   -9, 	  -9,   -9, 	  -8,   -6, 	  -2,   -7
+.2byte   -7,   -1, 	 -11,   -2, 	  -2,    3, 	  -1,   -4
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte   -5,  -10, 	  -6,   -8, 	  -3,   -8, 	  -5,  -14
+.2byte   -8,  -12, 	 -10,  -12, 	  -7,  -10, 	  -4,  -14
+.2byte  -11,  -10, 	 -10,   -9, 	  -9,   -5, 	  -4,   -9
+.2byte   -4,  -15, 	  -5,  -16, 	  -6,  -15, 	  -1,  -10
+.2byte   -5,  -15, 	  -2,  -15, 	  -7,  -15, 	  -5,  -11
+.2byte    3,  -15, 	   4,  -16, 	   5,  -15, 	   0,  -10
+.2byte   10,  -10, 	   9,   -9, 	   8,   -5, 	   3,   -9
+.2byte    7,  -12, 	   9,  -12, 	   6,  -10, 	   3,  -14
+.2byte   -5,  -10, 	 -11,   -8, 	   2,   -8, 	  -4,  -14
+.2byte   -9,  -12, 	 -13,  -13, 	  -4,   -8, 	  -3,  -15
+.2byte  -12,   -8, 	 -10,  -12, 	 -10,   -2, 	  -4,  -10
+.2byte   -5,  -14, 	  -1,  -13, 	 -11,   -7, 	  -2,  -11
+.2byte   -5,  -15, 	   4,   -8, 	 -13,   -8, 	  -4,  -11
+.2byte    4,  -14, 	   0,  -13, 	  10,   -7, 	   1,  -11
+.2byte   11,   -8, 	   9,  -12, 	   9,   -2, 	   3,  -10
+.2byte    8,  -12, 	  12,  -13, 	   3,   -8, 	   2,  -15
+.2byte   -6,    0, 	  -9,   -1, 	  -3,    2, 	  -1,   -4
+.2byte   -5,    1, 	  -8,   -1, 	  -4,    2, 	  -1,   -4
+.2byte   -1,   -9, 	  -5,  -10, 	   2,   -9, 	  -1,   -7
+.2byte   -1,  -10, 	   2,  -12, 	  -1,   -9, 	   0,   -7
+.2byte   -1,   -9, 	   0,  -15, 	   1,   -9, 	  -1,   -8
+.2byte   -2,   -9, 	  -3,  -15, 	   4,  -11, 	  -1,   -7
+.2byte   -1,   -9, 	   4,  -13, 	  -3,  -13, 	   0,   -9
+.2byte    1,   -9, 	   2,  -15, 	  -5,  -11, 	   0,   -7
+.2byte    0,   -9, 	  -1,  -15, 	  -2,   -9, 	   0,   -8
+.2byte    0,  -10, 	  -3,  -12, 	   0,   -9, 	  -1,   -7
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte   -5,  -10, 	  -6,   -8, 	  -3,   -8, 	  -5,  -14
+.2byte   -8,  -12, 	 -10,  -12, 	  -7,  -10, 	  -4,  -14
+.2byte  -11,  -10, 	 -10,   -9, 	  -9,   -5, 	  -4,   -9
+.2byte   -4,  -15, 	  -5,  -16, 	  -6,  -15, 	  -1,  -10
+.2byte   -5,  -15, 	  -2,  -15, 	  -7,  -15, 	  -5,  -11
+.2byte    3,  -15, 	   4,  -16, 	   5,  -15, 	   0,  -10
+.2byte   10,  -10, 	   9,   -9, 	   8,   -5, 	   3,   -9
+.2byte    7,  -12, 	   9,  -12, 	   6,  -10, 	   3,  -14
+.2byte   -5,  -10, 	 -11,   -8, 	   2,   -8, 	  -4,  -14
+.2byte   -9,  -12, 	 -13,  -13, 	  -4,   -8, 	  -3,  -15
+.2byte  -12,   -8, 	 -10,  -12, 	 -10,   -2, 	  -4,  -10
+.2byte   -5,  -14, 	  -1,  -13, 	 -11,   -7, 	  -2,  -11
+.2byte   -5,  -15, 	   4,   -8, 	 -13,   -8, 	  -4,  -11
+.2byte    4,  -14, 	   0,  -13, 	  10,   -7, 	   1,  -11
+.2byte   11,   -8, 	   9,  -12, 	   9,   -2, 	   3,  -10
+.2byte    8,  -12, 	  12,  -13, 	   3,   -8, 	   2,  -15
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte   -5,  -10, 	  -6,   -8, 	  -3,   -8, 	  -5,  -14
+.2byte   -8,  -12, 	 -10,  -12, 	  -7,  -10, 	  -4,  -14
+.2byte  -11,  -10, 	 -10,   -9, 	  -9,   -5, 	  -4,   -9
+.2byte   -4,  -15, 	  -5,  -16, 	  -6,  -15, 	  -1,  -10
+.2byte   -5,  -15, 	  -2,  -15, 	  -7,  -15, 	  -5,  -11
+.2byte    3,  -15, 	   4,  -16, 	   5,  -15, 	   0,  -10
+.2byte   10,  -10, 	   9,   -9, 	   8,   -5, 	   3,   -9
+.2byte    7,  -12, 	   9,  -12, 	   6,  -10, 	   3,  -14
+.2byte   -5,  -10, 	 -11,   -8, 	   2,   -8, 	  -4,  -14
+.2byte   -9,  -12, 	 -13,  -13, 	  -4,   -8, 	  -3,  -15
+.2byte  -12,   -8, 	 -10,  -12, 	 -10,   -2, 	  -4,  -10
+.2byte   -5,  -14, 	  -1,  -13, 	 -11,   -7, 	  -2,  -11
+.2byte   -5,  -15, 	   4,   -8, 	 -13,   -8, 	  -4,  -11
+.2byte    4,  -14, 	   0,  -13, 	  10,   -7, 	   1,  -11
+.2byte   11,   -8, 	   9,  -12, 	   9,   -2, 	   3,  -10
+.2byte    8,  -12, 	  12,  -13, 	   3,   -8, 	   2,  -15
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -1,   -1, 	  -7,    1, 	   6,    1, 	   0,   -5
+.2byte    0,   -3, 	  -8,    0, 	   7,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte    6,   -2, 	  10,   -3, 	   1,    2, 	   0,   -5
+.2byte    4,   -6, 	   9,   -5, 	   0,    0, 	   0,   -6
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte    9,   -5, 	   7,   -9, 	   7,    1, 	   1,   -7
+.2byte    4,  -10, 	   6,  -11, 	   4,   -2, 	  -2,   -8
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    4,  -11, 	   0,  -10, 	  10,   -4, 	   1,   -8
+.2byte    1,  -11, 	   0,  -13, 	  10,   -6, 	  -1,   -5
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte   -1,  -10, 	   8,   -3, 	  -9,   -3, 	   0,   -6
+.2byte    0,   -9, 	  10,   -8, 	 -11,   -8, 	   0,   -6
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte   -5,  -10, 	  -1,   -9, 	 -11,   -3, 	  -2,   -7
+.2byte   -2,  -11, 	  -1,  -13, 	 -11,   -6, 	   0,   -5
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte  -10,   -4, 	  -8,   -8, 	  -8,    2, 	  -2,   -6
+.2byte   -5,  -10, 	  -7,  -11, 	  -5,   -2, 	   1,   -8
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -7,   -1, 	 -11,   -2, 	  -2,    3, 	  -1,   -4
+.2byte   -5,   -6, 	 -10,   -5, 	  -1,    0, 	  -1,   -6
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte    0,   -6, 	  -8,   -3, 	   7,   -3, 	  -1,   -8
+.2byte   -5,   -7, 	 -10,   -6, 	  -1,   -1, 	  -1,   -7
+.2byte   -5,  -11, 	  -7,  -12, 	  -5,   -3, 	   1,   -9
+.2byte   -2,  -13, 	  -1,  -15, 	 -11,   -8, 	   0,   -7
+.2byte    0,  -11, 	  10,  -10, 	 -11,  -10, 	   0,   -8
+.2byte    1,  -13, 	   0,  -15, 	  10,   -8, 	  -1,   -7
+.2byte    4,  -11, 	   6,  -12, 	   4,   -3, 	  -2,   -9
+.2byte    4,   -7, 	   9,   -6, 	   0,   -1, 	   0,   -7
+.2byte   -1,   -1, 	  -2,    1, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -3, 	  -8,   -3, 	  -5,   -1, 	  -2,   -5
+.2byte   -9,   -6, 	  -8,   -5, 	  -7,   -1, 	  -2,   -5
+.2byte   -4,  -11, 	  -5,  -12, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	   2,  -11, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -11, 	   4,  -12, 	   5,  -11, 	   0,   -6
+.2byte    8,   -6, 	   7,   -5, 	   6,   -1, 	   1,   -5
+.2byte    5,   -3, 	   7,   -3, 	   4,   -1, 	   1,   -5
+.2byte   -5,  -10, 	  -6,   -8, 	  -3,   -8, 	  -5,  -14
+.2byte   -8,  -12, 	 -10,  -12, 	  -7,  -10, 	  -4,  -14
+.2byte  -11,  -10, 	 -10,   -9, 	  -9,   -5, 	  -4,   -9
+.2byte   -4,  -15, 	  -5,  -16, 	  -6,  -15, 	  -1,  -10
+.2byte   -5,  -15, 	  -2,  -15, 	  -7,  -15, 	  -5,  -11
+.2byte    3,  -15, 	   4,  -16, 	   5,  -15, 	   0,  -10
+.2byte   10,  -10, 	   9,   -9, 	   8,   -5, 	   3,   -9
+.2byte    7,  -12, 	   9,  -12, 	   6,  -10, 	   3,  -14
+.2byte   -5,  -10, 	 -11,   -8, 	   2,   -8, 	  -4,  -14
+.2byte   -9,  -12, 	 -13,  -13, 	  -4,   -8, 	  -3,  -15
+.2byte  -12,   -8, 	 -10,  -12, 	 -10,   -2, 	  -4,  -10
+.2byte   -5,  -14, 	  -1,  -13, 	 -11,   -7, 	  -2,  -11
+.2byte   -5,  -15, 	   4,   -8, 	 -13,   -8, 	  -4,  -11
+.2byte    4,  -14, 	   0,  -13, 	  10,   -7, 	   1,  -11
+.2byte   11,   -8, 	   9,  -12, 	   9,   -2, 	   3,  -10
+.2byte    8,  -12, 	  12,  -13, 	   3,   -8, 	   2,  -15
+sKabutoAnimTable1:
+.4byte sKabutoAnims_1_1
+.4byte sKabutoAnims_1_2
+.4byte sKabutoAnims_1_3
+.4byte sKabutoAnims_1_4
+.4byte sKabutoAnims_1_5
+.4byte sKabutoAnims_1_6
+.4byte sKabutoAnims_1_7
+.4byte sKabutoAnims_1_8
+sKabutoAnimTable2:
+.4byte sKabutoAnims_2_1
+.4byte sKabutoAnims_2_2
+.4byte sKabutoAnims_2_3
+.4byte sKabutoAnims_2_4
+.4byte sKabutoAnims_2_5
+.4byte sKabutoAnims_2_6
+.4byte sKabutoAnims_2_7
+.4byte sKabutoAnims_2_8
+sKabutoAnimTable3:
+.4byte sKabutoAnims_3_1
+.4byte sKabutoAnims_3_2
+.4byte sKabutoAnims_3_3
+.4byte sKabutoAnims_3_4
+.4byte sKabutoAnims_3_5
+.4byte sKabutoAnims_3_6
+.4byte sKabutoAnims_3_7
+.4byte sKabutoAnims_3_8
+sKabutoAnimTable4:
+.4byte sKabutoAnims_4_1
+.4byte sKabutoAnims_4_2
+.4byte sKabutoAnims_4_3
+.4byte sKabutoAnims_4_4
+.4byte sKabutoAnims_4_5
+.4byte sKabutoAnims_4_6
+.4byte sKabutoAnims_4_7
+.4byte sKabutoAnims_4_8
+sKabutoAnimTable5:
+.4byte sKabutoAnims_5_1
+.4byte sKabutoAnims_5_2
+.4byte sKabutoAnims_5_3
+.4byte sKabutoAnims_5_4
+.4byte sKabutoAnims_5_5
+.4byte sKabutoAnims_5_6
+.4byte sKabutoAnims_5_7
+.4byte sKabutoAnims_5_8
+sKabutoAnimTable6:
+.4byte sKabutoAnims_6_1
+.4byte sKabutoAnims_6_1
+.4byte sKabutoAnims_6_1
+.4byte sKabutoAnims_6_1
+.4byte sKabutoAnims_6_1
+.4byte sKabutoAnims_6_1
+.4byte sKabutoAnims_6_1
+.4byte sKabutoAnims_6_1
+sKabutoAnimTable7:
+.4byte sKabutoAnims_7_1
+.4byte sKabutoAnims_7_2
+.4byte sKabutoAnims_7_3
+.4byte sKabutoAnims_7_4
+.4byte sKabutoAnims_7_5
+.4byte sKabutoAnims_7_6
+.4byte sKabutoAnims_7_7
+.4byte sKabutoAnims_7_8
+sKabutoAnimTable8:
+.4byte sKabutoAnims_8_1
+.4byte sKabutoAnims_8_2
+.4byte sKabutoAnims_8_3
+.4byte sKabutoAnims_8_4
+.4byte sKabutoAnims_8_5
+.4byte sKabutoAnims_8_6
+.4byte sKabutoAnims_8_7
+.4byte sKabutoAnims_8_8
+sKabutoAnimTable9:
+.4byte sKabutoAnims_9_1
+.4byte sKabutoAnims_9_2
+.4byte sKabutoAnims_9_3
+.4byte sKabutoAnims_9_4
+.4byte sKabutoAnims_9_5
+.4byte sKabutoAnims_9_6
+.4byte sKabutoAnims_9_7
+.4byte sKabutoAnims_9_8
+sKabutoAnimTable10:
+.4byte sKabutoAnims_10_1
+.4byte sKabutoAnims_10_2
+.4byte sKabutoAnims_10_3
+.4byte sKabutoAnims_10_4
+.4byte sKabutoAnims_10_5
+.4byte sKabutoAnims_10_6
+.4byte sKabutoAnims_10_7
+.4byte sKabutoAnims_10_8
+sKabutoAnimTable11:
+.4byte sKabutoAnims_11_1
+.4byte sKabutoAnims_11_2
+.4byte sKabutoAnims_11_3
+.4byte sKabutoAnims_11_4
+.4byte sKabutoAnims_11_5
+.4byte sKabutoAnims_11_6
+.4byte sKabutoAnims_11_7
+.4byte sKabutoAnims_11_8
+sKabutoAnimTable12:
+.4byte sKabutoAnims_12_1
+.4byte sKabutoAnims_12_2
+.4byte sKabutoAnims_12_3
+.4byte sKabutoAnims_12_4
+.4byte sKabutoAnims_12_5
+.4byte sKabutoAnims_12_6
+.4byte sKabutoAnims_12_7
+.4byte sKabutoAnims_12_8
+sKabutoAnimTable13:
+.4byte sKabutoAnims_13_1
+.4byte sKabutoAnims_13_2
+.4byte sKabutoAnims_13_3
+.4byte sKabutoAnims_13_4
+.4byte sKabutoAnims_13_5
+.4byte sKabutoAnims_13_6
+.4byte sKabutoAnims_13_7
+.4byte sKabutoAnims_13_8
+sAxAnimationsKabuto:
+.4byte sKabutoAnimTable1
+.4byte sKabutoAnimTable2
+.4byte sKabutoAnimTable3
+.4byte sKabutoAnimTable4
+.4byte sKabutoAnimTable5
+.4byte sKabutoAnimTable6
+.4byte sKabutoAnimTable7
+.4byte sKabutoAnimTable8
+.4byte sKabutoAnimTable9
+.4byte sKabutoAnimTable10
+.4byte sKabutoAnimTable11
+.4byte sKabutoAnimTable12
+.4byte sKabutoAnimTable13
+sAxSpritesKabuto:
+.4byte sKabutoSprites1
+.4byte sKabutoSprites2
+.4byte sKabutoSprites3
+.4byte sKabutoSprites4
+.4byte sKabutoSprites5
+.4byte sKabutoSprites6
+.4byte sKabutoSprites7
+.4byte sKabutoSprites8
+.4byte sKabutoSprites9
+.4byte sKabutoSprites10
+.4byte sKabutoSprites11
+.4byte sKabutoSprites12
+.4byte sKabutoSprites13
+.4byte sKabutoSprites14
+.4byte sKabutoSprites15
+.4byte sKabutoSprites16
+.4byte sKabutoSprites17
+.4byte sKabutoSprites18
+.4byte sKabutoSprites19
+.4byte sKabutoSprites20
+.4byte sKabutoSprites21
+.4byte sKabutoSprites22
+.4byte sKabutoSprites23
+.4byte sKabutoSprites24
+.4byte sKabutoSprites25
+.4byte sKabutoSprites26
+.4byte sKabutoSprites27
+.4byte sKabutoSprites28
+.4byte sKabutoSprites29
+.4byte sKabutoSprites30
+.4byte sKabutoSprites31
+.4byte sKabutoSprites32
+.4byte sKabutoSprites33
+.4byte sKabutoSprites34
+.4byte sKabutoSprites35
+.4byte sKabutoSprites36
+.4byte sKabutoSprites37
+.4byte sKabutoSprites38
+.4byte sKabutoSprites39
+.4byte sKabutoSprites40
+.4byte sKabutoSprites41
+sAxMainKabuto:
+ax_main sAxPosesKabuto, sAxAnimationsKabuto, 13, sAxSpritesKabuto, sAxPositionsKabuto

--- a/data/ax/kabutops.inc
+++ b/data/ax/kabutops.inc
@@ -1,0 +1,3037 @@
+.global gAxKabutops
+gAxKabutops:
+ax_siro sAxMainKabutops
+sKabutopsPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose2:
+ax_pose 1, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose3:
+ax_pose 2, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose4:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose5:
+ax_pose 4, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose6:
+ax_pose 5, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose7:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose8:
+ax_pose 7, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose9:
+ax_pose 8, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose10:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose11:
+ax_pose 10, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose12:
+ax_pose 11, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose16:
+ax_pose 9, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose17:
+ax_pose 10, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose18:
+ax_pose 11, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose19:
+ax_pose 6, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose20:
+ax_pose 7, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose21:
+ax_pose 8, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose22:
+ax_pose 3, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose23:
+ax_pose 4, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose24:
+ax_pose 5, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose26:
+ax_pose 1, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose27:
+ax_pose 2, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose28:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose29:
+ax_pose 4, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose30:
+ax_pose 5, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose31:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose32:
+ax_pose 7, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose33:
+ax_pose 8, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose34:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose35:
+ax_pose 10, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose36:
+ax_pose 11, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose37:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose39:
+ax_pose 14, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose40:
+ax_pose 9, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose41:
+ax_pose 10, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose42:
+ax_pose 11, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose43:
+ax_pose 6, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose44:
+ax_pose 7, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose45:
+ax_pose 8, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose46:
+ax_pose 3, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose47:
+ax_pose 4, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose48:
+ax_pose 5, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose49:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose50:
+ax_pose 15, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose51:
+ax_pose 16, 0x01e7, 0x80f0, 0x6c00
+ax_pose 17, 0x01e7, 0x80f0, 0x6c10
+ax_pose_terminator
+sKabutopsPose52:
+ax_pose 17, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose53:
+ax_pose 18, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose54:
+ax_pose 16, 0x01e7, 0x90f0, 0x6c00
+ax_pose 19, 0x01e7, 0x80f0, 0x6c10
+ax_pose_terminator
+sKabutopsPose55:
+ax_pose 19, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose56:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose57:
+ax_pose 20, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose58:
+ax_pose 21, 0x01ee, 0x90f2, 0x6c00
+ax_pose 22, 0x01e6, 0x90f2, 0x6c10
+ax_pose_terminator
+sKabutopsPose59:
+ax_pose 22, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose60:
+ax_pose 23, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose61:
+ax_pose 24, 0x01e6, 0x90f2, 0x6c00
+ax_pose 25, 0x01e6, 0x90f2, 0x6c10
+ax_pose_terminator
+sKabutopsPose62:
+ax_pose 25, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose63:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose64:
+ax_pose 26, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose65:
+ax_pose 27, 0x41f3, 0x90f1, 0x6c00
+ax_pose 28, 0x01e6, 0x90f1, 0x6c08
+ax_pose_terminator
+sKabutopsPose66:
+ax_pose 28, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose67:
+ax_pose 29, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose68:
+ax_pose 30, 0x01e6, 0x90f1, 0x6c00
+ax_pose 31, 0x01e6, 0x90f1, 0x6c10
+ax_pose_terminator
+sKabutopsPose69:
+ax_pose 31, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose70:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose71:
+ax_pose 32, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose72:
+ax_pose 33, 0x81e4, 0x90ff, 0x6c00
+ax_pose 34, 0x01e6, 0x90f1, 0x6c08
+ax_pose_terminator
+sKabutopsPose73:
+ax_pose 34, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose74:
+ax_pose 35, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose75:
+ax_pose 36, 0x01e6, 0x90f1, 0x6c00
+ax_pose 37, 0x01e6, 0x90f1, 0x6c10
+ax_pose_terminator
+sKabutopsPose76:
+ax_pose 36, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose77:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose78:
+ax_pose 38, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose79:
+ax_pose 39, 0x41ee, 0x80f0, 0x6c00
+ax_pose 40, 0x01e6, 0x80f0, 0x6c08
+ax_pose_terminator
+sKabutopsPose80:
+ax_pose 40, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose81:
+ax_pose 41, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose82:
+ax_pose 39, 0x41ee, 0x90f1, 0x6c00
+ax_pose 42, 0x01e6, 0x80f0, 0x6c08
+ax_pose_terminator
+sKabutopsPose83:
+ax_pose 42, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose84:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose85:
+ax_pose 32, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose86:
+ax_pose 33, 0x81e6, 0x80f4, 0x6c00
+ax_pose 34, 0x01e6, 0x80f0, 0x6c08
+ax_pose_terminator
+sKabutopsPose87:
+ax_pose 34, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose88:
+ax_pose 35, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose89:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose 37, 0x01e6, 0x80f0, 0x6c10
+ax_pose_terminator
+sKabutopsPose90:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose91:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose92:
+ax_pose 26, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose93:
+ax_pose 27, 0x41f3, 0x80f0, 0x6c00
+ax_pose 28, 0x01e6, 0x80f0, 0x6c08
+ax_pose_terminator
+sKabutopsPose94:
+ax_pose 28, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose95:
+ax_pose 29, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose96:
+ax_pose 30, 0x01e6, 0x80f0, 0x6c00
+ax_pose 31, 0x01e6, 0x80f0, 0x6c10
+ax_pose_terminator
+sKabutopsPose97:
+ax_pose 31, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose98:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sKabutopsPose99:
+ax_pose 20, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose100:
+ax_pose 21, 0x01ee, 0x80ef, 0x6c00
+ax_pose 22, 0x01e6, 0x80ef, 0x6c10
+ax_pose_terminator
+sKabutopsPose101:
+ax_pose 22, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose102:
+ax_pose 23, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose103:
+ax_pose 24, 0x01e6, 0x80ef, 0x6c00
+ax_pose 25, 0x01e6, 0x80ef, 0x6c10
+ax_pose_terminator
+sKabutopsPose104:
+ax_pose 25, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose105:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose106:
+ax_pose 43, 0x81ec, 0x40f7, 0x6c00
+ax_pose 44, 0x81ec, 0x80ff, 0x6c04
+ax_pose 45, 0x81ec, 0x00ef, 0x6c0c
+ax_pose 46, 0x01ee, 0x010f, 0x6c0e
+ax_pose_terminator
+sKabutopsPose107:
+ax_pose 47, 0x81ec, 0x40f7, 0x6c00
+ax_pose 48, 0x81ec, 0x80ff, 0x6c04
+ax_pose 49, 0x81ec, 0x00ef, 0x6c0c
+ax_pose 50, 0x01ee, 0x010f, 0x6c0e
+ax_pose_terminator
+sKabutopsPose108:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose109:
+ax_pose 51, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose110:
+ax_pose 52, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose111:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose112:
+ax_pose 53, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose113:
+ax_pose 54, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose114:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose115:
+ax_pose 55, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose116:
+ax_pose 56, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose117:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose118:
+ax_pose 57, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose119:
+ax_pose 58, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose120:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose121:
+ax_pose 55, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose122:
+ax_pose 56, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose123:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose124:
+ax_pose 53, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose125:
+ax_pose 54, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose126:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sKabutopsPose127:
+ax_pose 51, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose128:
+ax_pose 52, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose129:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose130:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sKabutopsPose131:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose132:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose133:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose134:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose135:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose136:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose137:
+ax_pose 59, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sKabutopsPose138:
+ax_pose 60, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sKabutopsPose139:
+ax_pose 61, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose140:
+ax_pose 62, 0x01e3, 0x90ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose141:
+ax_pose 63, 0x01e3, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose142:
+ax_pose 64, 0x01e3, 0x90ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose143:
+ax_pose 65, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose144:
+ax_pose 64, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose145:
+ax_pose 63, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose146:
+ax_pose 62, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose147:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose148:
+ax_pose 1, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose149:
+ax_pose 2, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose150:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose151:
+ax_pose 4, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose152:
+ax_pose 5, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose153:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose154:
+ax_pose 7, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose155:
+ax_pose 8, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose156:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose157:
+ax_pose 10, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose158:
+ax_pose 11, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose159:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose160:
+ax_pose 13, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose161:
+ax_pose 14, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose162:
+ax_pose 9, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose163:
+ax_pose 10, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose164:
+ax_pose 11, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose165:
+ax_pose 6, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose166:
+ax_pose 7, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose167:
+ax_pose 8, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose168:
+ax_pose 3, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose169:
+ax_pose 4, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose170:
+ax_pose 5, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose171:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose172:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sKabutopsPose173:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose174:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose175:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose176:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose177:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose178:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose179:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose180:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose181:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose182:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose183:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose184:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose185:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose186:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sKabutopsPose187:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose188:
+ax_pose 43, 0x81ec, 0x40f7, 0x6c00
+ax_pose 44, 0x81ec, 0x80ff, 0x6c04
+ax_pose 45, 0x81ec, 0x00ef, 0x6c0c
+ax_pose 46, 0x01ee, 0x010f, 0x6c0e
+ax_pose_terminator
+sKabutopsPose189:
+ax_pose 47, 0x81ec, 0x40f7, 0x6c00
+ax_pose 48, 0x81ec, 0x80ff, 0x6c04
+ax_pose 49, 0x81ec, 0x00ef, 0x6c0c
+ax_pose 50, 0x01ee, 0x010f, 0x6c0e
+ax_pose_terminator
+sKabutopsPose190:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sKabutopsPose191:
+ax_pose 51, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose192:
+ax_pose 52, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose193:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose194:
+ax_pose 53, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose195:
+ax_pose 54, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose196:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose197:
+ax_pose 55, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose198:
+ax_pose 56, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose199:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose200:
+ax_pose 57, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose201:
+ax_pose 58, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose202:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose203:
+ax_pose 55, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose204:
+ax_pose 56, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose205:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose206:
+ax_pose 53, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose207:
+ax_pose 54, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose208:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sKabutopsPose209:
+ax_pose 51, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose210:
+ax_pose 52, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose211:
+ax_pose 47, 0x81ec, 0x40f7, 0x6c00
+ax_pose 48, 0x81ec, 0x80ff, 0x6c04
+ax_pose 49, 0x81ec, 0x00ef, 0x6c0c
+ax_pose 50, 0x01ee, 0x010f, 0x6c0e
+ax_pose_terminator
+sKabutopsPose212:
+ax_pose 52, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose213:
+ax_pose 54, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sKabutopsPose214:
+ax_pose 56, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose215:
+ax_pose 58, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose216:
+ax_pose 56, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose217:
+ax_pose 54, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sKabutopsPose218:
+ax_pose 52, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose219:
+ax_pose 0, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose220:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sKabutopsPose221:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose222:
+ax_pose 9, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose223:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sKabutopsPose224:
+ax_pose 9, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose225:
+ax_pose 6, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sKabutopsPose226:
+ax_pose 3, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+.align 2
+sKabutopsAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 1, 1, 2, 1, 2,
+ax_anim 4, 0, 1, 0, 1, 0, 1,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 1, 1, 1, 1,
+ax_anim 8, 0, 2, 0, 2, 0, 2,
+ax_anim 4, 0, 2, 0, 1, 0, 1,
+ax_anim_terminator
+sKabutopsAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 2, 2, 2, 2,
+ax_anim 8, 0, 4, 4, 3, 4, 3,
+ax_anim 4, 0, 4, 2, 2, 2, 2,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 2, 0, 2, 0,
+ax_anim 8, 0, 5, 3, 1, 3, 1,
+ax_anim 4, 0, 5, 2, 0, 2, 0,
+ax_anim_terminator
+sKabutopsAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 2, 0, 2, 0,
+ax_anim 8, 0, 7, 3, 0, 3, 0,
+ax_anim 4, 0, 7, 2, 0, 2, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 2, 0, 2, 0,
+ax_anim 8, 0, 8, 3, 0, 3, 0,
+ax_anim 4, 0, 8, 2, 0, 2, 0,
+ax_anim_terminator
+sKabutopsAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 4, -1, 4, -1,
+ax_anim 8, 0, 10, 5, -2, 5, -2,
+ax_anim 4, 0, 10, 4, -1, 4, -1,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 1, -1, 1, -1,
+ax_anim 8, 0, 11, 3, -3, 3, -3,
+ax_anim 4, 0, 11, 1, -1, 1, -1,
+ax_anim_terminator
+sKabutopsAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 1, -2, 1, -2,
+ax_anim 8, 0, 13, 0, -3, 0, -3,
+ax_anim 4, 0, 13, 1, -2, 1, -2,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, -1, -2, -1, -2,
+ax_anim 8, 0, 14, 0, -3, 0, -3,
+ax_anim 4, 0, 14, -1, -2, -1, -2,
+ax_anim_terminator
+sKabutopsAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -4, -1, -4, -1,
+ax_anim 8, 0, 16, -5, -2, -5, -2,
+ax_anim 4, 0, 16, -4, -1, -4, -1,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, -1, -1, -1, -1,
+ax_anim 8, 0, 17, -3, -3, -3, -3,
+ax_anim 4, 0, 17, -1, -1, -1, -1,
+ax_anim_terminator
+sKabutopsAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -2, 0, -2, 0,
+ax_anim 8, 0, 19, -3, 0, -3, 0,
+ax_anim 4, 0, 19, -2, 0, -2, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, -2, 0, -2, 0,
+ax_anim 8, 0, 20, -3, 0, -3, 0,
+ax_anim 4, 0, 20, -2, 0, -2, 0,
+ax_anim_terminator
+sKabutopsAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -2, 2, -2, 2,
+ax_anim 8, 0, 22, -4, 3, -4, 3,
+ax_anim 4, 0, 22, -2, 2, -2, 2,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, -2, 0, -2, 0,
+ax_anim 8, 0, 23, -3, 1, -3, 1,
+ax_anim 4, 0, 23, -2, 0, -2, 0,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sKabutopsAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 28, 9, 9, 9, 9,
+ax_anim 2, 0, 28, 16, 16, 16, 16,
+ax_anim 2, 1, 28, 17, 15, 17, 15,
+ax_anim 2, 0, 28, 16, 16, 16, 16,
+ax_anim 2, 0, 28, 17, 15, 17, 15,
+ax_anim 4, 0, 27, 7, 7, 7, 7,
+ax_anim_terminator
+sKabutopsAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 31, 8, 0, 8, 0,
+ax_anim 2, 0, 31, 14, 0, 14, 0,
+ax_anim 2, 1, 31, 14, 1, 14, 1,
+ax_anim 2, 0, 31, 14, 0, 14, 0,
+ax_anim 2, 0, 31, 14, 1, 14, 1,
+ax_anim 4, 0, 30, 4, 0, 4, 0,
+ax_anim_terminator
+sKabutopsAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 35, 0, 0, 0, -1,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim 2, 2, 34, 8, -8, 8, -8,
+ax_anim 2, 0, 34, 14, -14, 14, -14,
+ax_anim 2, 1, 34, 15, -13, 15, -13,
+ax_anim 2, 0, 34, 14, -14, 14, -14,
+ax_anim 2, 0, 34, 15, -13, 15, -13,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sKabutopsAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 37, 0, -8, 0, -8,
+ax_anim 2, 0, 37, 0, -14, 0, -14,
+ax_anim 2, 1, 37, 1, -14, 1, -14,
+ax_anim 2, 0, 37, 0, -14, 0, -14,
+ax_anim 2, 0, 37, 1, -14, 1, -14,
+ax_anim 4, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sKabutopsAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 0, 0, 0, -1,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim 2, 2, 40, -8, -8, -8, -8,
+ax_anim 2, 0, 40, -14, -14, -14, -14,
+ax_anim 2, 1, 40, -15, -13, -15, -13,
+ax_anim 2, 0, 40, -14, -14, -14, -14,
+ax_anim 2, 0, 40, -15, -13, -15, -13,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sKabutopsAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 43, -8, 0, -8, 0,
+ax_anim 2, 0, 43, -14, 0, -14, 0,
+ax_anim 2, 1, 43, -14, 1, -14, 1,
+ax_anim 2, 0, 43, -14, 0, -14, 0,
+ax_anim 2, 0, 43, -14, 1, -14, 1,
+ax_anim 4, 0, 42, -4, 0, -4, 0,
+ax_anim_terminator
+sKabutopsAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim 2, 2, 46, -9, 9, -9, 9,
+ax_anim 2, 0, 46, -15, 17, -15, 17,
+ax_anim 2, 1, 46, -16, 16, -16, 16,
+ax_anim 2, 0, 46, -15, 17, -15, 17,
+ax_anim 2, 0, 46, -15, 17, -15, 17,
+ax_anim 4, 0, 45, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 4, 2, 50, 0, 12, 0, 12,
+ax_anim 4, 1, 51, 0, 13, 0, 13,
+ax_anim 2, 0, 52, 0, 13, 0, 13,
+ax_anim 2, 0, 52, 0, 12, 0, 12,
+ax_anim 4, 0, 52, 0, 11, 0, 11,
+ax_anim 4, 0, 53, 0, 14, 0, 14,
+ax_anim 4, 0, 54, 1, 15, 1, 15,
+ax_anim 4, 0, 48, 0, 11, 0, 11,
+ax_anim_terminator
+sKabutopsAnims_3_2:
+ax_anim 2, 0, 56, -1, -1, -1, -1,
+ax_anim 6, 0, 56, -3, -3, -3, -3,
+ax_anim 2, 0, 56, 4, 4, 4, 4,
+ax_anim 4, 2, 57, 16, 16, 16, 16,
+ax_anim 4, 1, 58, 17, 17, 17, 17,
+ax_anim 2, 0, 59, 17, 17, 17, 17,
+ax_anim 2, 0, 59, 16, 16, 16, 16,
+ax_anim 4, 0, 59, 15, 15, 15, 15,
+ax_anim 4, 0, 60, 18, 18, 18, 18,
+ax_anim 4, 0, 61, 17, 19, 17, 19,
+ax_anim 4, 0, 55, 10, 10, 10, 10,
+ax_anim_terminator
+sKabutopsAnims_3_3:
+ax_anim 2, 0, 63, -1, 0, -1, 0,
+ax_anim 6, 0, 63, -3, 0, -3, 0,
+ax_anim 2, 0, 63, 4, 0, 4, 0,
+ax_anim 4, 2, 64, 13, 0, 16, 0,
+ax_anim 4, 1, 65, 14, 0, 17, 0,
+ax_anim 2, 0, 66, 14, 0, 17, 0,
+ax_anim 2, 0, 66, 13, 0, 16, 0,
+ax_anim 4, 0, 66, 12, 0, 15, 0,
+ax_anim 4, 0, 67, 15, 0, 18, 0,
+ax_anim 4, 0, 68, 14, 0, 17, 0,
+ax_anim 4, 0, 62, 7, 0, 10, 0,
+ax_anim_terminator
+sKabutopsAnims_3_4:
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim 6, 0, 70, -3, 3, -3, 3,
+ax_anim 2, 0, 70, 4, -4, 4, -4,
+ax_anim 4, 2, 71, 16, -16, 16, -16,
+ax_anim 4, 1, 72, 16, -17, 16, -17,
+ax_anim 2, 0, 73, 17, -17, 17, -17,
+ax_anim 2, 0, 73, 16, -16, 16, -16,
+ax_anim 4, 0, 73, 15, -15, 15, -15,
+ax_anim 4, 0, 74, 18, -18, 18, -18,
+ax_anim 4, 0, 75, 20, -19, 20, -19,
+ax_anim 4, 0, 69, 10, -10, 10, -10,
+ax_anim_terminator
+sKabutopsAnims_3_5:
+ax_anim 2, 0, 77, 0, 1, 0, 1,
+ax_anim 6, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 77, 0, -4, 0, -4,
+ax_anim 4, 2, 78, 0, -16, 0, -14,
+ax_anim 4, 1, 79, 0, -17, 0, -15,
+ax_anim 2, 0, 80, 0, -17, 0, -15,
+ax_anim 2, 0, 80, 0, -16, 0, -14,
+ax_anim 4, 0, 80, 0, -15, 0, -13,
+ax_anim 4, 0, 81, 0, -18, 0, -16,
+ax_anim 4, 0, 82, 1, -19, 1, -17,
+ax_anim 4, 0, 76, 0, -15, 0, -13,
+ax_anim_terminator
+sKabutopsAnims_3_6:
+ax_anim 2, 0, 84, 1, 1, 1, 1,
+ax_anim 6, 0, 84, 3, 3, 3, 3,
+ax_anim 2, 0, 84, -4, -4, -4, -4,
+ax_anim 4, 2, 85, -16, -16, -16, -16,
+ax_anim 4, 1, 86, -15, -18, -15, -18,
+ax_anim 2, 0, 87, -17, -17, -17, -17,
+ax_anim 2, 0, 87, -16, -16, -16, -16,
+ax_anim 4, 0, 87, -15, -15, -15, -15,
+ax_anim 4, 0, 88, -18, -18, -18, -18,
+ax_anim 4, 0, 89, -20, -19, -20, -19,
+ax_anim 4, 0, 83, -10, -10, -10, -10,
+ax_anim_terminator
+sKabutopsAnims_3_7:
+ax_anim 2, 0, 91, 1, 0, 1, 0,
+ax_anim 6, 0, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 91, -4, 0, -4, 0,
+ax_anim 4, 2, 92, -13, 0, -16, 0,
+ax_anim 4, 1, 93, -14, 0, -17, 0,
+ax_anim 2, 0, 94, -14, 0, -17, 0,
+ax_anim 2, 0, 94, -13, 0, -16, 0,
+ax_anim 4, 0, 94, -12, 0, -15, 0,
+ax_anim 4, 0, 95, -15, 0, -18, 0,
+ax_anim 4, 0, 96, -14, 0, -17, 0,
+ax_anim 4, 0, 90, -7, 0, -10, 0,
+ax_anim_terminator
+sKabutopsAnims_3_8:
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim 6, 0, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, -4, 4, -4, 4,
+ax_anim 4, 2, 99, -16, 16, -16, 16,
+ax_anim 4, 1, 100, -17, 17, -17, 17,
+ax_anim 2, 0, 101, -17, 17, -17, 17,
+ax_anim 2, 0, 101, -16, 16, -16, 16,
+ax_anim 4, 0, 101, -15, 15, -15, 15,
+ax_anim 4, 0, 102, -18, 18, -18, 18,
+ax_anim 4, 0, 103, -17, 19, -17, 19,
+ax_anim 4, 0, 97, -18, 18, -18, 18,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_4_1:
+ax_anim 4, 0, 104, 0, -1, 0, -1,
+ax_anim 6, 0, 104, 0, -3, 0, -3,
+ax_anim 2, 0, 105, 0, 0, 0, 1,
+ax_anim 2, 2, 106, 0, 0, 0, 1,
+ax_anim 2, 0, 105, 0, 0, 0, 1,
+ax_anim 2, 0, 106, 0, 0, 0, 1,
+ax_anim 2, 0, 105, 0, 0, 0, 1,
+ax_anim 2, 1, 106, 0, 0, 0, 1,
+ax_anim 4, 0, 104, 0, 1, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_4_2:
+ax_anim 4, 0, 107, -1, -1, -1, -1,
+ax_anim 6, 0, 107, -3, -3, -3, -3,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 2, 109, 1, 1, 1, 1,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 1, 109, 1, 1, 1, 1,
+ax_anim 4, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sKabutopsAnims_4_3:
+ax_anim 4, 0, 110, -1, 0, -1, 0,
+ax_anim 6, 0, 110, -3, 0, -3, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 2, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 1, 112, 1, 0, 1, 0,
+ax_anim 4, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sKabutopsAnims_4_4:
+ax_anim 4, 0, 113, -1, 1, -1, 1,
+ax_anim 6, 0, 113, -3, 3, -3, 3,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 2, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 1, 115, 1, -1, 1, -1,
+ax_anim 4, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sKabutopsAnims_4_5:
+ax_anim 4, 0, 116, 0, 1, 0, 1,
+ax_anim 6, 0, 116, 0, 3, 0, 3,
+ax_anim 2, 0, 117, 0, -1, 0, -1,
+ax_anim 2, 2, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, -1, 0, -1,
+ax_anim 2, 1, 118, 0, -1, 0, -1,
+ax_anim 4, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_4_6:
+ax_anim 4, 0, 119, 1, 1, 1, 1,
+ax_anim 6, 0, 119, 3, 3, 3, 3,
+ax_anim 2, 0, 120, -1, -1, -1, -1,
+ax_anim 2, 2, 121, -1, -1, -1, -1,
+ax_anim 2, 0, 120, -1, -1, -1, -1,
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim 2, 0, 120, -1, -1, -1, -1,
+ax_anim 2, 1, 121, -1, -1, -1, -1,
+ax_anim 4, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sKabutopsAnims_4_7:
+ax_anim 4, 0, 122, 1, 0, 1, 0,
+ax_anim 6, 0, 122, 3, 0, 3, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 2, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 1, 124, -1, 0, -1, 0,
+ax_anim 4, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sKabutopsAnims_4_8:
+ax_anim 4, 0, 125, 1, -1, 1, -1,
+ax_anim 6, 0, 125, 3, -3, 3, -3,
+ax_anim 2, 0, 126, -1, 1, -1, 1,
+ax_anim 2, 2, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 126, -1, 1, -1, 1,
+ax_anim 2, 0, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 126, -1, 1, -1, 1,
+ax_anim 2, 1, 127, -1, 1, -1, 1,
+ax_anim 4, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sKabutopsAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sKabutopsAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sKabutopsAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sKabutopsAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sKabutopsAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sKabutopsAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sKabutopsAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_8_1:
+ax_anim 20, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 147, -1, -2, -1, -2,
+ax_anim 20, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 148, 2, -2, 2, -2,
+ax_anim_terminator
+sKabutopsAnims_8_2:
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim 10, 0, 150, -2, -2, -2, -2,
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim 10, 0, 151, -3, -2, -3, -2,
+ax_anim_terminator
+sKabutopsAnims_8_3:
+ax_anim 20, 0, 152, 0, 0, 0, 0,
+ax_anim 10, 0, 153, -6, -2, -6, -2,
+ax_anim 20, 0, 152, 0, 0, 0, 0,
+ax_anim 10, 0, 154, -5, 0, -5, 0,
+ax_anim_terminator
+sKabutopsAnims_8_4:
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 156, -4, 1, -4, 1,
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 157, -3, 2, -3, 2,
+ax_anim_terminator
+sKabutopsAnims_8_5:
+ax_anim 20, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, 4, 0, 4,
+ax_anim 20, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 160, 1, 4, 1, 4,
+ax_anim_terminator
+sKabutopsAnims_8_6:
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 4, 1, 4, 1,
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim 10, 0, 163, 3, 2, 3, 2,
+ax_anim_terminator
+sKabutopsAnims_8_7:
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 6, -2, 6, -2,
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 5, 0, 5, 0,
+ax_anim_terminator
+sKabutopsAnims_8_8:
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 2, -2, 2, -2,
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 4, -2, 4, -2,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 13, 7, 13,
+ax_anim 3, 0, 174, 1, 16, 1, 16,
+ax_anim 2, 3, 175, -4, 14, -4, 14,
+ax_anim 2, 0, 176, -5, 8, -5, 8,
+ax_anim 1, 0, 177, -4, 4, -4, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 24, 9, 24, 9,
+ax_anim 3, 0, 173, 23, 16, 23, 16,
+ax_anim 2, 3, 174, 11, 16, 11, 16,
+ax_anim 2, 0, 175, 4, 12, 4, 12,
+ax_anim 1, 0, 176, 3, 7, 3, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 20, 1, 20, 1,
+ax_anim 2, 3, 173, 17, 5, 17, 5,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 1, -6, 1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -20, 11, -20,
+ax_anim 3, 0, 171, 16, -20, 16, -20,
+ax_anim 2, 3, 172, 16, -15, 16, -15,
+ax_anim 2, 0, 173, 14, -6, 14, -6,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -6, -4, -6, -4,
+ax_anim 2, 0, 176, -8, -9, -8, -9,
+ax_anim 2, 0, 177, -7, -13, -7, -13,
+ax_anim 3, 0, 170, -1, -16, -1, -16,
+ax_anim 2, 3, 171, 4, -14, 4, -14,
+ax_anim 2, 0, 172, 5, -8, 5, -8,
+ax_anim 1, 0, 173, 4, -4, 4, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, -1, -6, -1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -20, -11, -20,
+ax_anim 3, 0, 177, -16, -20, -16, -20,
+ax_anim 2, 3, 176, -16, -15, -16, -15,
+ax_anim 2, 0, 175, -14, -6, -14, -6,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -20, 1, -20, 1,
+ax_anim 2, 3, 175, -17, 5, -17, 5,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -24, 9, -24, 9,
+ax_anim 3, 0, 175, -23, 16, -23, 16,
+ax_anim 2, 3, 174, -11, 16, -11, 16,
+ax_anim 2, 0, 173, -4, 12, -4, 12,
+ax_anim 1, 0, 172, -3, 7, -3, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKabutopsAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sKabutopsGfx1:
+.incbin "baserom.gba", 0xB124C4, 0x200
+sKabutopsSprites1:
+ax_sprite sKabutopsGfx1, 0x200
+ax_sprite_terminator
+sKabutopsGfx2:
+.incbin "baserom.gba", 0xB126D4, 0x200
+sKabutopsSprites2:
+ax_sprite sKabutopsGfx2, 0x200
+ax_sprite_terminator
+sKabutopsGfx3:
+.incbin "baserom.gba", 0xB128E4, 0x200
+sKabutopsSprites3:
+ax_sprite sKabutopsGfx3, 0x200
+ax_sprite_terminator
+sKabutopsGfx4:
+.incbin "baserom.gba", 0xB12AF4, 0x200
+sKabutopsSprites4:
+ax_sprite sKabutopsGfx4, 0x200
+ax_sprite_terminator
+sKabutopsGfx5:
+.incbin "baserom.gba", 0xB12D04, 0x200
+sKabutopsSprites5:
+ax_sprite sKabutopsGfx5, 0x200
+ax_sprite_terminator
+sKabutopsGfx6:
+.incbin "baserom.gba", 0xB12F14, 0x200
+sKabutopsSprites6:
+ax_sprite sKabutopsGfx6, 0x200
+ax_sprite_terminator
+sKabutopsGfx7:
+.incbin "baserom.gba", 0xB13124, 0x200
+sKabutopsSprites7:
+ax_sprite sKabutopsGfx7, 0x200
+ax_sprite_terminator
+sKabutopsGfx8:
+.incbin "baserom.gba", 0xB13334, 0x200
+sKabutopsSprites8:
+ax_sprite sKabutopsGfx8, 0x200
+ax_sprite_terminator
+sKabutopsGfx9:
+.incbin "baserom.gba", 0xB13544, 0x200
+sKabutopsSprites9:
+ax_sprite sKabutopsGfx9, 0x200
+ax_sprite_terminator
+sKabutopsGfx10:
+.incbin "baserom.gba", 0xB13754, 0x200
+sKabutopsSprites10:
+ax_sprite sKabutopsGfx10, 0x200
+ax_sprite_terminator
+sKabutopsGfx11:
+.incbin "baserom.gba", 0xB13964, 0x200
+sKabutopsSprites11:
+ax_sprite sKabutopsGfx11, 0x200
+ax_sprite_terminator
+sKabutopsGfx12:
+.incbin "baserom.gba", 0xB13B74, 0x200
+sKabutopsSprites12:
+ax_sprite sKabutopsGfx12, 0x200
+ax_sprite_terminator
+sKabutopsGfx13:
+.incbin "baserom.gba", 0xB13D84, 0x200
+sKabutopsSprites13:
+ax_sprite sKabutopsGfx13, 0x200
+ax_sprite_terminator
+sKabutopsGfx14:
+.incbin "baserom.gba", 0xB13F94, 0x200
+sKabutopsSprites14:
+ax_sprite sKabutopsGfx14, 0x200
+ax_sprite_terminator
+sKabutopsGfx15:
+.incbin "baserom.gba", 0xB141A4, 0x200
+sKabutopsSprites15:
+ax_sprite sKabutopsGfx15, 0x200
+ax_sprite_terminator
+sKabutopsGfx16:
+.incbin "baserom.gba", 0xB143B4, 0x1C0
+sKabutopsSprites16:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx16, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx17:
+.incbin "baserom.gba", 0xB14594, 0x20
+sKabutopsGfx17_1:
+.incbin "baserom.gba", 0xB145B4, 0x20
+sKabutopsGfx17_2:
+.incbin "baserom.gba", 0xB145D4, 0xC0
+sKabutopsSprites17:
+ax_sprite 0, 0x60
+ax_sprite sKabutopsGfx17, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKabutopsGfx17_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx17_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx18:
+.incbin "baserom.gba", 0xB146D4, 0x40
+sKabutopsGfx18_1:
+.incbin "baserom.gba", 0xB14714, 0xE0
+sKabutopsGfx18_2:
+.incbin "baserom.gba", 0xB147F4, 0x60
+sKabutopsSprites18:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx18_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx19:
+.incbin "baserom.gba", 0xB14894, 0x60
+sKabutopsGfx19_1:
+.incbin "baserom.gba", 0xB148F4, 0x100
+sKabutopsGfx19_2:
+.incbin "baserom.gba", 0xB149F4, 0x60
+sKabutopsSprites19:
+ax_sprite sKabutopsGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx19_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx19_2, 0x60
+ax_sprite_terminator
+sKabutopsGfx20:
+.incbin "baserom.gba", 0xB14A84, 0x40
+sKabutopsGfx20_1:
+.incbin "baserom.gba", 0xB14AC4, 0x80
+sKabutopsGfx20_2:
+.incbin "baserom.gba", 0xB14B44, 0x60
+sKabutopsGfx20_3:
+.incbin "baserom.gba", 0xB14BA4, 0x60
+sKabutopsSprites20:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx20_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx20_3, 0x60
+ax_sprite_terminator
+sKabutopsGfx21:
+.incbin "baserom.gba", 0xB14C4C, 0x160
+sKabutopsGfx21_1:
+.incbin "baserom.gba", 0xB14DAC, 0x60
+sKabutopsSprites21:
+ax_sprite sKabutopsGfx21, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx22:
+.incbin "baserom.gba", 0xB14E34, 0x100
+sKabutopsSprites22:
+ax_sprite 0, 0x60
+ax_sprite sKabutopsGfx22, 0x100
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKabutopsGfx23:
+.incbin "baserom.gba", 0xB14F54, 0x60
+sKabutopsGfx23_1:
+.incbin "baserom.gba", 0xB14FB4, 0x160
+sKabutopsSprites23:
+ax_sprite sKabutopsGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx23_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx24:
+.incbin "baserom.gba", 0xB1513C, 0x40
+sKabutopsGfx24_1:
+.incbin "baserom.gba", 0xB1517C, 0x80
+sKabutopsGfx24_2:
+.incbin "baserom.gba", 0xB151FC, 0x60
+sKabutopsGfx24_3:
+.incbin "baserom.gba", 0xB1525C, 0x20
+sKabutopsSprites24:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKabutopsGfx24_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx25:
+.incbin "baserom.gba", 0xB152CC, 0x60
+sKabutopsGfx25_1:
+.incbin "baserom.gba", 0xB1532C, 0x20
+sKabutopsGfx25_2:
+.incbin "baserom.gba", 0xB1534C, 0x40
+sKabutopsGfx25_3:
+.incbin "baserom.gba", 0xB1538C, 0x40
+sKabutopsSprites25:
+ax_sprite sKabutopsGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx25_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKabutopsGfx25_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKabutopsGfx25_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKabutopsGfx26:
+.incbin "baserom.gba", 0xB15414, 0x20
+sKabutopsGfx26_1:
+.incbin "baserom.gba", 0xB15434, 0x160
+sKabutopsSprites26:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx26, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKabutopsGfx26_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx27:
+.incbin "baserom.gba", 0xB155C4, 0x160
+sKabutopsGfx27_1:
+.incbin "baserom.gba", 0xB15724, 0x40
+sKabutopsSprites27:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx27, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx28:
+.incbin "baserom.gba", 0xB15794, 0x100
+sKabutopsSprites28:
+ax_sprite sKabutopsGfx28, 0x100
+ax_sprite_terminator
+sKabutopsGfx29:
+.incbin "baserom.gba", 0xB158A4, 0x160
+sKabutopsGfx29_1:
+.incbin "baserom.gba", 0xB15A04, 0x20
+sKabutopsGfx29_2:
+.incbin "baserom.gba", 0xB15A24, 0x20
+sKabutopsSprites29:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx29, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx29_2, 0x20
+ax_sprite_terminator
+sKabutopsGfx30:
+.incbin "baserom.gba", 0xB15A7C, 0x1E0
+sKabutopsSprites30:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx30, 0x1e0
+ax_sprite_terminator
+sKabutopsGfx31:
+.incbin "baserom.gba", 0xB15C74, 0x60
+sKabutopsGfx31_1:
+.incbin "baserom.gba", 0xB15CD4, 0x40
+sKabutopsGfx31_2:
+.incbin "baserom.gba", 0xB15D14, 0x20
+sKabutopsGfx31_3:
+.incbin "baserom.gba", 0xB15D34, 0x40
+sKabutopsSprites31:
+ax_sprite sKabutopsGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKabutopsGfx31_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKabutopsGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKabutopsGfx32:
+.incbin "baserom.gba", 0xB15DBC, 0x40
+sKabutopsGfx32_1:
+.incbin "baserom.gba", 0xB15DFC, 0x180
+sKabutopsSprites32:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx32_1, 0x180
+ax_sprite_terminator
+sKabutopsGfx33:
+.incbin "baserom.gba", 0xB15FA4, 0x40
+sKabutopsGfx33_1:
+.incbin "baserom.gba", 0xB15FE4, 0x80
+sKabutopsGfx33_2:
+.incbin "baserom.gba", 0xB16064, 0x60
+sKabutopsGfx33_3:
+.incbin "baserom.gba", 0xB160C4, 0x60
+sKabutopsSprites33:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx33_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx33_3, 0x60
+ax_sprite_terminator
+sKabutopsGfx34:
+.incbin "baserom.gba", 0xB1616C, 0x60
+sKabutopsGfx34_1:
+.incbin "baserom.gba", 0xB161CC, 0x40
+sKabutopsSprites34:
+ax_sprite sKabutopsGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKabutopsGfx35:
+.incbin "baserom.gba", 0xB16234, 0xE0
+sKabutopsGfx35_1:
+.incbin "baserom.gba", 0xB16314, 0x60
+sKabutopsGfx35_2:
+.incbin "baserom.gba", 0xB16374, 0x60
+sKabutopsSprites35:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx35, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx35_2, 0x60
+ax_sprite_terminator
+sKabutopsGfx36:
+.incbin "baserom.gba", 0xB1640C, 0x1E0
+sKabutopsSprites36:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx36, 0x1e0
+ax_sprite_terminator
+sKabutopsGfx37:
+.incbin "baserom.gba", 0xB16604, 0x40
+sKabutopsGfx37_1:
+.incbin "baserom.gba", 0xB16644, 0x100
+sKabutopsGfx37_2:
+.incbin "baserom.gba", 0xB16744, 0x60
+sKabutopsSprites37:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx37_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx37_2, 0x60
+ax_sprite_terminator
+sKabutopsGfx38:
+.incbin "baserom.gba", 0xB167DC, 0x60
+sKabutopsGfx38_1:
+.incbin "baserom.gba", 0xB1683C, 0x20
+sKabutopsGfx38_2:
+.incbin "baserom.gba", 0xB1685C, 0x40
+sKabutopsSprites38:
+ax_sprite sKabutopsGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx38_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKabutopsGfx38_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sKabutopsGfx39:
+.incbin "baserom.gba", 0xB168D4, 0x160
+sKabutopsGfx39_1:
+.incbin "baserom.gba", 0xB16A34, 0x40
+sKabutopsSprites39:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx39, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx40:
+.incbin "baserom.gba", 0xB16AA4, 0x20
+sKabutopsGfx40_1:
+.incbin "baserom.gba", 0xB16AC4, 0x60
+sKabutopsSprites40:
+ax_sprite 0, 0x60
+ax_sprite sKabutopsGfx40, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx40_1, 0x60
+ax_sprite_terminator
+sKabutopsGfx41:
+.incbin "baserom.gba", 0xB16B4C, 0x140
+sKabutopsGfx41_1:
+.incbin "baserom.gba", 0xB16C8C, 0x40
+sKabutopsSprites41:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx41, 0x140
+ax_sprite 0, 0x40
+ax_sprite sKabutopsGfx41_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx42:
+.incbin "baserom.gba", 0xB16CFC, 0x60
+sKabutopsGfx42_1:
+.incbin "baserom.gba", 0xB16D5C, 0x100
+sKabutopsGfx42_2:
+.incbin "baserom.gba", 0xB16E5C, 0x40
+sKabutopsSprites42:
+ax_sprite sKabutopsGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx42_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx42_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx43:
+.incbin "baserom.gba", 0xB16ED4, 0x60
+sKabutopsGfx43_1:
+.incbin "baserom.gba", 0xB16F34, 0x80
+sKabutopsGfx43_2:
+.incbin "baserom.gba", 0xB16FB4, 0x60
+sKabutopsGfx43_3:
+.incbin "baserom.gba", 0xB17014, 0x40
+sKabutopsSprites43:
+ax_sprite sKabutopsGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx43_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx43_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx44:
+.incbin "baserom.gba", 0xB1709C, 0x60
+sKabutopsSprites44:
+ax_sprite sKabutopsGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx45:
+.incbin "baserom.gba", 0xB17114, 0xA0
+sKabutopsSprites45:
+ax_sprite sKabutopsGfx45, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sKabutopsGfx46:
+.incbin "baserom.gba", 0xB171CC, 0x40
+sKabutopsSprites46:
+ax_sprite sKabutopsGfx46, 0x40
+ax_sprite_terminator
+sKabutopsGfx47:
+.incbin "baserom.gba", 0xB1721C, 0x20
+sKabutopsSprites47:
+ax_sprite sKabutopsGfx47, 0x20
+ax_sprite_terminator
+sKabutopsGfx48:
+.incbin "baserom.gba", 0xB1724C, 0x60
+sKabutopsSprites48:
+ax_sprite sKabutopsGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx49:
+.incbin "baserom.gba", 0xB172C4, 0xA0
+sKabutopsSprites49:
+ax_sprite sKabutopsGfx49, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sKabutopsGfx50:
+.incbin "baserom.gba", 0xB1737C, 0x40
+sKabutopsSprites50:
+ax_sprite sKabutopsGfx50, 0x40
+ax_sprite_terminator
+sKabutopsGfx51:
+.incbin "baserom.gba", 0xB173CC, 0x20
+sKabutopsSprites51:
+ax_sprite sKabutopsGfx51, 0x20
+ax_sprite_terminator
+sKabutopsGfx52:
+.incbin "baserom.gba", 0xB173FC, 0x60
+sKabutopsGfx52_1:
+.incbin "baserom.gba", 0xB1745C, 0x160
+sKabutopsSprites52:
+ax_sprite sKabutopsGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx52_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx53:
+.incbin "baserom.gba", 0xB175E4, 0x60
+sKabutopsGfx53_1:
+.incbin "baserom.gba", 0xB17644, 0x160
+sKabutopsSprites53:
+ax_sprite sKabutopsGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx53_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx54:
+.incbin "baserom.gba", 0xB177CC, 0xE0
+sKabutopsGfx54_1:
+.incbin "baserom.gba", 0xB178AC, 0x60
+sKabutopsGfx54_2:
+.incbin "baserom.gba", 0xB1790C, 0x60
+sKabutopsSprites54:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx54, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx54_2, 0x60
+ax_sprite_terminator
+sKabutopsGfx55:
+.incbin "baserom.gba", 0xB179A4, 0x160
+sKabutopsGfx55_1:
+.incbin "baserom.gba", 0xB17B04, 0x60
+sKabutopsSprites55:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx55, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx55_1, 0x60
+ax_sprite_terminator
+sKabutopsGfx56:
+.incbin "baserom.gba", 0xB17B8C, 0x60
+sKabutopsGfx56_1:
+.incbin "baserom.gba", 0xB17BEC, 0x100
+sKabutopsGfx56_2:
+.incbin "baserom.gba", 0xB17CEC, 0x40
+sKabutopsSprites56:
+ax_sprite sKabutopsGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx56_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx56_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx57:
+.incbin "baserom.gba", 0xB17D64, 0x40
+sKabutopsGfx57_1:
+.incbin "baserom.gba", 0xB17DA4, 0x100
+sKabutopsGfx57_2:
+.incbin "baserom.gba", 0xB17EA4, 0x40
+sKabutopsSprites57:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx57, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx57_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx57_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx58:
+.incbin "baserom.gba", 0xB17F24, 0x60
+sKabutopsGfx58_1:
+.incbin "baserom.gba", 0xB17F84, 0x100
+sKabutopsGfx58_2:
+.incbin "baserom.gba", 0xB18084, 0x40
+sKabutopsSprites58:
+ax_sprite sKabutopsGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx58_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx58_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKabutopsGfx59:
+.incbin "baserom.gba", 0xB180FC, 0x40
+sKabutopsGfx59_1:
+.incbin "baserom.gba", 0xB1813C, 0x180
+sKabutopsSprites59:
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKabutopsGfx59_1, 0x180
+ax_sprite_terminator
+sKabutopsGfx60:
+.incbin "baserom.gba", 0xB182E4, 0x200
+sKabutopsSprites60:
+ax_sprite sKabutopsGfx60, 0x200
+ax_sprite_terminator
+sKabutopsGfx61:
+.incbin "baserom.gba", 0xB184F4, 0x200
+sKabutopsSprites61:
+ax_sprite sKabutopsGfx61, 0x200
+ax_sprite_terminator
+sKabutopsGfx62:
+.incbin "baserom.gba", 0xB18704, 0x200
+sKabutopsSprites62:
+ax_sprite sKabutopsGfx62, 0x200
+ax_sprite_terminator
+sKabutopsGfx63:
+.incbin "baserom.gba", 0xB18914, 0x200
+sKabutopsSprites63:
+ax_sprite sKabutopsGfx63, 0x200
+ax_sprite_terminator
+sKabutopsGfx64:
+.incbin "baserom.gba", 0xB18B24, 0x200
+sKabutopsSprites64:
+ax_sprite sKabutopsGfx64, 0x200
+ax_sprite_terminator
+sKabutopsGfx65:
+.incbin "baserom.gba", 0xB18D34, 0x200
+sKabutopsSprites65:
+ax_sprite sKabutopsGfx65, 0x200
+ax_sprite_terminator
+sKabutopsGfx66:
+.incbin "baserom.gba", 0xB18F44, 0x200
+sKabutopsSprites66:
+ax_sprite sKabutopsGfx66, 0x200
+ax_sprite_terminator
+sAxPosesKabutops:
+.4byte sKabutopsPose1
+.4byte sKabutopsPose2
+.4byte sKabutopsPose3
+.4byte sKabutopsPose4
+.4byte sKabutopsPose5
+.4byte sKabutopsPose6
+.4byte sKabutopsPose7
+.4byte sKabutopsPose8
+.4byte sKabutopsPose9
+.4byte sKabutopsPose10
+.4byte sKabutopsPose11
+.4byte sKabutopsPose12
+.4byte sKabutopsPose13
+.4byte sKabutopsPose14
+.4byte sKabutopsPose15
+.4byte sKabutopsPose16
+.4byte sKabutopsPose17
+.4byte sKabutopsPose18
+.4byte sKabutopsPose19
+.4byte sKabutopsPose20
+.4byte sKabutopsPose21
+.4byte sKabutopsPose22
+.4byte sKabutopsPose23
+.4byte sKabutopsPose24
+.4byte sKabutopsPose25
+.4byte sKabutopsPose26
+.4byte sKabutopsPose27
+.4byte sKabutopsPose28
+.4byte sKabutopsPose29
+.4byte sKabutopsPose30
+.4byte sKabutopsPose31
+.4byte sKabutopsPose32
+.4byte sKabutopsPose33
+.4byte sKabutopsPose34
+.4byte sKabutopsPose35
+.4byte sKabutopsPose36
+.4byte sKabutopsPose37
+.4byte sKabutopsPose38
+.4byte sKabutopsPose39
+.4byte sKabutopsPose40
+.4byte sKabutopsPose41
+.4byte sKabutopsPose42
+.4byte sKabutopsPose43
+.4byte sKabutopsPose44
+.4byte sKabutopsPose45
+.4byte sKabutopsPose46
+.4byte sKabutopsPose47
+.4byte sKabutopsPose48
+.4byte sKabutopsPose49
+.4byte sKabutopsPose50
+.4byte sKabutopsPose51
+.4byte sKabutopsPose52
+.4byte sKabutopsPose53
+.4byte sKabutopsPose54
+.4byte sKabutopsPose55
+.4byte sKabutopsPose56
+.4byte sKabutopsPose57
+.4byte sKabutopsPose58
+.4byte sKabutopsPose59
+.4byte sKabutopsPose60
+.4byte sKabutopsPose61
+.4byte sKabutopsPose62
+.4byte sKabutopsPose63
+.4byte sKabutopsPose64
+.4byte sKabutopsPose65
+.4byte sKabutopsPose66
+.4byte sKabutopsPose67
+.4byte sKabutopsPose68
+.4byte sKabutopsPose69
+.4byte sKabutopsPose70
+.4byte sKabutopsPose71
+.4byte sKabutopsPose72
+.4byte sKabutopsPose73
+.4byte sKabutopsPose74
+.4byte sKabutopsPose75
+.4byte sKabutopsPose76
+.4byte sKabutopsPose77
+.4byte sKabutopsPose78
+.4byte sKabutopsPose79
+.4byte sKabutopsPose80
+.4byte sKabutopsPose81
+.4byte sKabutopsPose82
+.4byte sKabutopsPose83
+.4byte sKabutopsPose84
+.4byte sKabutopsPose85
+.4byte sKabutopsPose86
+.4byte sKabutopsPose87
+.4byte sKabutopsPose88
+.4byte sKabutopsPose89
+.4byte sKabutopsPose90
+.4byte sKabutopsPose91
+.4byte sKabutopsPose92
+.4byte sKabutopsPose93
+.4byte sKabutopsPose94
+.4byte sKabutopsPose95
+.4byte sKabutopsPose96
+.4byte sKabutopsPose97
+.4byte sKabutopsPose98
+.4byte sKabutopsPose99
+.4byte sKabutopsPose100
+.4byte sKabutopsPose101
+.4byte sKabutopsPose102
+.4byte sKabutopsPose103
+.4byte sKabutopsPose104
+.4byte sKabutopsPose105
+.4byte sKabutopsPose106
+.4byte sKabutopsPose107
+.4byte sKabutopsPose108
+.4byte sKabutopsPose109
+.4byte sKabutopsPose110
+.4byte sKabutopsPose111
+.4byte sKabutopsPose112
+.4byte sKabutopsPose113
+.4byte sKabutopsPose114
+.4byte sKabutopsPose115
+.4byte sKabutopsPose116
+.4byte sKabutopsPose117
+.4byte sKabutopsPose118
+.4byte sKabutopsPose119
+.4byte sKabutopsPose120
+.4byte sKabutopsPose121
+.4byte sKabutopsPose122
+.4byte sKabutopsPose123
+.4byte sKabutopsPose124
+.4byte sKabutopsPose125
+.4byte sKabutopsPose126
+.4byte sKabutopsPose127
+.4byte sKabutopsPose128
+.4byte sKabutopsPose129
+.4byte sKabutopsPose130
+.4byte sKabutopsPose131
+.4byte sKabutopsPose132
+.4byte sKabutopsPose133
+.4byte sKabutopsPose134
+.4byte sKabutopsPose135
+.4byte sKabutopsPose136
+.4byte sKabutopsPose137
+.4byte sKabutopsPose138
+.4byte sKabutopsPose139
+.4byte sKabutopsPose140
+.4byte sKabutopsPose141
+.4byte sKabutopsPose142
+.4byte sKabutopsPose143
+.4byte sKabutopsPose144
+.4byte sKabutopsPose145
+.4byte sKabutopsPose146
+.4byte sKabutopsPose147
+.4byte sKabutopsPose148
+.4byte sKabutopsPose149
+.4byte sKabutopsPose150
+.4byte sKabutopsPose151
+.4byte sKabutopsPose152
+.4byte sKabutopsPose153
+.4byte sKabutopsPose154
+.4byte sKabutopsPose155
+.4byte sKabutopsPose156
+.4byte sKabutopsPose157
+.4byte sKabutopsPose158
+.4byte sKabutopsPose159
+.4byte sKabutopsPose160
+.4byte sKabutopsPose161
+.4byte sKabutopsPose162
+.4byte sKabutopsPose163
+.4byte sKabutopsPose164
+.4byte sKabutopsPose165
+.4byte sKabutopsPose166
+.4byte sKabutopsPose167
+.4byte sKabutopsPose168
+.4byte sKabutopsPose169
+.4byte sKabutopsPose170
+.4byte sKabutopsPose171
+.4byte sKabutopsPose172
+.4byte sKabutopsPose173
+.4byte sKabutopsPose174
+.4byte sKabutopsPose175
+.4byte sKabutopsPose176
+.4byte sKabutopsPose177
+.4byte sKabutopsPose178
+.4byte sKabutopsPose179
+.4byte sKabutopsPose180
+.4byte sKabutopsPose181
+.4byte sKabutopsPose182
+.4byte sKabutopsPose183
+.4byte sKabutopsPose184
+.4byte sKabutopsPose185
+.4byte sKabutopsPose186
+.4byte sKabutopsPose187
+.4byte sKabutopsPose188
+.4byte sKabutopsPose189
+.4byte sKabutopsPose190
+.4byte sKabutopsPose191
+.4byte sKabutopsPose192
+.4byte sKabutopsPose193
+.4byte sKabutopsPose194
+.4byte sKabutopsPose195
+.4byte sKabutopsPose196
+.4byte sKabutopsPose197
+.4byte sKabutopsPose198
+.4byte sKabutopsPose199
+.4byte sKabutopsPose200
+.4byte sKabutopsPose201
+.4byte sKabutopsPose202
+.4byte sKabutopsPose203
+.4byte sKabutopsPose204
+.4byte sKabutopsPose205
+.4byte sKabutopsPose206
+.4byte sKabutopsPose207
+.4byte sKabutopsPose208
+.4byte sKabutopsPose209
+.4byte sKabutopsPose210
+.4byte sKabutopsPose211
+.4byte sKabutopsPose212
+.4byte sKabutopsPose213
+.4byte sKabutopsPose214
+.4byte sKabutopsPose215
+.4byte sKabutopsPose216
+.4byte sKabutopsPose217
+.4byte sKabutopsPose218
+.4byte sKabutopsPose219
+.4byte sKabutopsPose220
+.4byte sKabutopsPose221
+.4byte sKabutopsPose222
+.4byte sKabutopsPose223
+.4byte sKabutopsPose224
+.4byte sKabutopsPose225
+.4byte sKabutopsPose226
+sAxPositionsKabutops:
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte    1,   -9, 	  -8,    2, 	   8,   -7, 	   1,  -11
+.2byte   -2,   -9, 	  -9,   -7, 	   7,    2, 	  -2,  -11
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte    4,  -11, 	  11,   -3, 	  -9,   -5, 	  -1,  -10
+.2byte    7,  -14, 	  -2,   -9, 	   3,   -2, 	  -1,   -8
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    8,  -12, 	  12,   -7, 	   0,    1, 	  -1,  -10
+.2byte   11,  -15, 	  -1,  -12, 	  12,    0, 	  -1,   -8
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   11,  -14, 	   2,   -7, 	   4,    2, 	  -2,   -9
+.2byte    3,  -18, 	  -9,   -7, 	  10,   -6, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    0,  -16, 	   8,   -2, 	 -12,  -12, 	  -1,   -9
+.2byte   -1,  -16, 	  11,  -11, 	  -9,   -2, 	   0,   -9
+.2byte  -10,  -18, 	   1,   -8, 	 -10,   -5, 	   1,  -11
+.2byte  -12,  -14, 	  -3,   -7, 	  -5,    2, 	   1,   -9
+.2byte   -4,  -18, 	   8,   -7, 	 -11,   -6, 	   1,   -9
+.2byte  -11,  -14, 	 -10,   -9, 	  -7,   -1, 	   2,  -10
+.2byte   -9,  -12, 	 -13,   -7, 	  -1,    1, 	   0,  -10
+.2byte  -12,  -15, 	   0,  -12, 	 -13,    0, 	   0,   -8
+.2byte   -8,  -11, 	 -11,   -6, 	  -2,   -1, 	  -1,   -9
+.2byte   -5,  -11, 	 -12,   -3, 	   8,   -5, 	   0,  -10
+.2byte   -8,  -14, 	   1,   -9, 	  -4,   -2, 	   0,   -8
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte    1,   -9, 	  -8,    2, 	   8,   -7, 	   1,  -11
+.2byte   -2,   -9, 	  -9,   -7, 	   7,    2, 	  -2,  -11
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte    4,  -11, 	  11,   -3, 	  -9,   -5, 	  -1,  -10
+.2byte    7,  -14, 	  -2,   -9, 	   3,   -2, 	  -1,   -8
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    8,  -12, 	  12,   -7, 	   0,    1, 	  -1,  -10
+.2byte   11,  -15, 	  -1,  -12, 	  12,    0, 	  -1,   -8
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   11,  -14, 	   2,   -7, 	   4,    2, 	  -2,   -9
+.2byte    3,  -18, 	  -9,   -7, 	  10,   -6, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    0,  -16, 	   8,   -2, 	 -12,  -12, 	  -1,   -9
+.2byte   -1,  -16, 	  11,  -11, 	  -9,   -2, 	   0,   -9
+.2byte  -10,  -18, 	   1,   -8, 	 -10,   -5, 	   1,  -11
+.2byte  -12,  -14, 	  -3,   -7, 	  -5,    2, 	   1,   -9
+.2byte   -4,  -18, 	   8,   -7, 	 -11,   -6, 	   1,   -9
+.2byte  -11,  -14, 	 -10,   -9, 	  -7,   -1, 	   2,  -10
+.2byte   -9,  -12, 	 -13,   -7, 	  -1,    1, 	   0,  -10
+.2byte  -12,  -15, 	   0,  -12, 	 -13,    0, 	   0,   -8
+.2byte   -8,  -11, 	 -11,   -6, 	  -2,   -1, 	  -1,   -9
+.2byte   -5,  -11, 	 -12,   -3, 	   8,   -5, 	   0,  -10
+.2byte   -8,  -14, 	   1,   -9, 	  -4,   -2, 	   0,   -8
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte    1,   -8, 	 -10,   -1, 	   9,  -23, 	   0,   -9
+.2byte    0,   -6, 	  -5,  -18, 	 -10,    0, 	   0,   -7
+.2byte    0,   -6, 	  -5,  -18, 	 -10,    0, 	   0,   -7
+.2byte   -2,   -8, 	 -10,  -23, 	   9,   -1, 	  -1,   -9
+.2byte   -1,   -6, 	   9,    0, 	   4,  -18, 	  -1,   -7
+.2byte   -1,   -6, 	   9,    0, 	   4,  -18, 	  -1,   -7
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte    6,   -9, 	  13,   -4, 	 -11,  -15, 	   0,  -10
+.2byte    9,   -8, 	   3,  -20, 	  12,   -5, 	   1,   -8
+.2byte    9,   -8, 	   3,  -20, 	  12,   -5, 	   1,   -8
+.2byte    9,  -13, 	   7,  -22, 	  -1,   -1, 	  -2,   -9
+.2byte    8,   -8, 	   0,    0, 	  -8,  -16, 	   0,   -8
+.2byte    8,   -8, 	   0,    0, 	  -8,  -16, 	   0,   -8
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    8,  -11, 	  11,   -6, 	 -12,  -12, 	  -1,  -10
+.2byte   11,  -13, 	  -5,  -21, 	   8,  -11, 	   0,   -9
+.2byte   11,  -13, 	  -5,  -21, 	   8,  -11, 	   0,   -9
+.2byte    8,  -17, 	  -4,  -24, 	   8,   -3, 	  -2,  -10
+.2byte   11,  -13, 	   3,    2, 	 -11,   -8, 	  -1,   -9
+.2byte   11,  -13, 	   3,    2, 	 -11,   -8, 	  -1,   -9
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte    4,  -13, 	   1,   -9, 	   6,  -20, 	  -3,  -10
+.2byte    6,  -15, 	 -12,  -11, 	  -8,  -17, 	   0,  -10
+.2byte    6,  -15, 	 -12,  -11, 	  -8,  -17, 	   0,  -10
+.2byte    4,  -16, 	 -11,  -21, 	  10,   -4, 	  -3,  -11
+.2byte    7,  -15, 	   9,   -5, 	  -5,   -7, 	   0,   -9
+.2byte    7,  -15, 	   9,   -5, 	  -5,   -7, 	   0,   -9
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    2,  -16, 	  12,  -12, 	  -8,  -10, 	  -1,   -8
+.2byte    0,  -15, 	 -11,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -15, 	 -11,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -2,  -16, 	   9,   -9, 	 -12,  -13, 	   1,   -8
+.2byte    0,  -17, 	   9,   -8, 	  12,   -7, 	   0,   -9
+.2byte    0,  -17, 	   9,   -8, 	  12,   -7, 	   0,   -9
+.2byte   -9,  -18, 	   2,   -8, 	  -9,   -5, 	   2,  -11
+.2byte   -4,  -13, 	  -1,   -9, 	  -6,  -20, 	   3,  -10
+.2byte   -6,  -15, 	  12,  -11, 	   8,  -17, 	   0,  -10
+.2byte   -6,  -15, 	  12,  -11, 	   8,  -17, 	   0,  -10
+.2byte   -4,  -16, 	  11,  -21, 	 -10,   -4, 	   3,  -11
+.2byte   -7,  -15, 	  -9,   -5, 	   5,   -7, 	   0,   -9
+.2byte   -7,  -15, 	  -9,   -5, 	   5,   -7, 	   0,   -9
+.2byte  -10,  -14, 	  -9,   -9, 	  -6,   -1, 	   3,  -10
+.2byte   -8,  -11, 	 -11,   -6, 	  12,  -12, 	   1,  -10
+.2byte  -11,  -13, 	   5,  -21, 	  -8,  -11, 	   0,   -9
+.2byte  -11,  -13, 	   5,  -21, 	  -8,  -11, 	   0,   -9
+.2byte   -8,  -17, 	   4,  -24, 	  -8,   -3, 	   2,  -10
+.2byte  -11,  -13, 	  -3,    2, 	  11,   -8, 	   1,   -9
+.2byte  -11,  -13, 	  -3,    2, 	  11,   -8, 	   1,   -9
+.2byte   -7,  -11, 	 -10,   -6, 	  -1,   -1, 	   0,   -9
+.2byte   -6,   -9, 	 -13,   -4, 	  11,  -15, 	   0,  -10
+.2byte   -9,   -8, 	  -3,  -20, 	 -12,   -5, 	  -1,   -8
+.2byte   -9,   -8, 	  -3,  -20, 	 -12,   -5, 	  -1,   -8
+.2byte   -9,  -13, 	  -7,  -22, 	   1,   -1, 	   2,   -9
+.2byte   -8,   -8, 	   0,    0, 	   8,  -16, 	   0,   -8
+.2byte   -8,   -8, 	   0,    0, 	   8,  -16, 	   0,   -8
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte    0,   -8, 	 -15,  -17, 	  15,  -17, 	   0,   -7
+.2byte    0,   -7, 	 -14,  -18, 	  14,  -18, 	   0,   -6
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte    7,  -10, 	   5,  -19, 	 -14,  -13, 	   0,   -9
+.2byte    7,   -9, 	   2,  -19, 	 -13,  -13, 	   0,   -9
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte   11,  -13, 	  -8,  -19, 	  -8,   -6, 	  -1,   -9
+.2byte   11,  -12, 	 -11,  -17, 	  -9,   -6, 	  -1,   -9
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   10,  -16, 	 -11,  -12, 	   3,   -4, 	   0,   -9
+.2byte   11,  -15, 	 -12,  -10, 	   0,   -3, 	   0,   -8
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    0,  -16, 	  12,   -6, 	 -12,   -6, 	   0,   -8
+.2byte    0,  -15, 	  11,   -4, 	 -11,   -4, 	   0,   -8
+.2byte   -9,  -18, 	   2,   -8, 	  -9,   -5, 	   2,  -11
+.2byte  -10,  -16, 	  11,  -12, 	  -3,   -4, 	   0,   -9
+.2byte  -11,  -15, 	  12,  -10, 	   0,   -3, 	   0,   -8
+.2byte  -10,  -14, 	  -9,   -9, 	  -6,   -1, 	   3,  -10
+.2byte  -11,  -13, 	   8,  -19, 	   8,   -6, 	   1,   -9
+.2byte  -11,  -12, 	  11,  -17, 	   9,   -6, 	   1,   -9
+.2byte   -7,  -11, 	 -10,   -6, 	  -1,   -1, 	   0,   -9
+.2byte   -7,  -10, 	  -5,  -19, 	  14,  -13, 	   0,   -9
+.2byte   -7,   -9, 	  -2,  -19, 	  13,  -13, 	   0,   -9
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte   -7,  -11, 	 -10,   -6, 	  -1,   -1, 	   0,   -9
+.2byte  -10,  -14, 	  -9,   -9, 	  -6,   -1, 	   3,  -10
+.2byte   -9,  -18, 	   2,   -8, 	  -9,   -5, 	   2,  -11
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte   -7,   -9, 	  -4,   -5, 	   7,   -1, 	  -1,   -8
+.2byte   -7,   -7, 	  -3,   -4, 	   8,    0, 	  -1,   -7
+.2byte    0,  -12, 	 -15,  -11, 	   7,   -6, 	   0,  -11
+.2byte    7,  -15, 	  13,  -16, 	  -5,   -4, 	   1,  -11
+.2byte    6,  -17, 	  10,  -21, 	   0,   -1, 	  -1,   -9
+.2byte    3,  -18, 	 -10,  -11, 	  13,   -1, 	  -1,   -7
+.2byte    0,  -18, 	  10,   -9, 	 -11,   -3, 	   0,   -8
+.2byte   -4,  -18, 	   9,  -11, 	 -14,   -1, 	   0,   -7
+.2byte   -7,  -17, 	 -11,  -21, 	  -1,   -1, 	   0,   -9
+.2byte   -8,  -15, 	 -14,  -16, 	   4,   -4, 	  -2,  -11
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte    1,   -9, 	  -8,    2, 	   8,   -7, 	   1,  -11
+.2byte   -2,   -9, 	  -9,   -7, 	   7,    2, 	  -2,  -11
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte    4,  -11, 	  11,   -3, 	  -9,   -5, 	  -1,  -10
+.2byte    7,  -14, 	  -2,   -9, 	   3,   -2, 	  -1,   -8
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    8,  -12, 	  12,   -7, 	   0,    1, 	  -1,  -10
+.2byte   11,  -15, 	  -1,  -12, 	  12,    0, 	  -1,   -8
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   11,  -14, 	   2,   -7, 	   4,    2, 	  -2,   -9
+.2byte    3,  -18, 	  -9,   -7, 	  10,   -6, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    0,  -16, 	   8,   -2, 	 -12,  -12, 	  -1,   -9
+.2byte   -1,  -16, 	  11,  -11, 	  -9,   -2, 	   0,   -9
+.2byte  -10,  -18, 	   1,   -8, 	 -10,   -5, 	   1,  -11
+.2byte  -12,  -14, 	  -3,   -7, 	  -5,    2, 	   1,   -9
+.2byte   -4,  -18, 	   8,   -7, 	 -11,   -6, 	   1,   -9
+.2byte  -11,  -14, 	 -10,   -9, 	  -7,   -1, 	   2,  -10
+.2byte   -9,  -12, 	 -13,   -7, 	  -1,    1, 	   0,  -10
+.2byte  -12,  -15, 	   0,  -12, 	 -13,    0, 	   0,   -8
+.2byte   -8,  -11, 	 -11,   -6, 	  -2,   -1, 	  -1,   -9
+.2byte   -5,  -11, 	 -12,   -3, 	   8,   -5, 	   0,  -10
+.2byte   -8,  -14, 	   1,   -9, 	  -4,   -2, 	   0,   -8
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte   -7,  -11, 	 -10,   -6, 	  -1,   -1, 	   0,   -9
+.2byte  -10,  -14, 	  -9,   -9, 	  -6,   -1, 	   3,  -10
+.2byte   -9,  -18, 	   2,   -8, 	  -9,   -5, 	   2,  -11
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte   -9,  -18, 	   2,   -8, 	  -9,   -5, 	   2,  -11
+.2byte  -10,  -14, 	  -9,   -9, 	  -6,   -1, 	   3,  -10
+.2byte   -7,  -11, 	 -10,   -6, 	  -1,   -1, 	   0,   -9
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte    0,   -8, 	 -15,  -17, 	  15,  -17, 	   0,   -7
+.2byte    0,   -7, 	 -14,  -18, 	  14,  -18, 	   0,   -6
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+.2byte    7,  -10, 	   5,  -19, 	 -14,  -13, 	   0,   -9
+.2byte    7,   -9, 	   2,  -19, 	 -13,  -13, 	   0,   -9
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte   11,  -13, 	  -8,  -19, 	  -8,   -6, 	  -1,   -9
+.2byte   11,  -12, 	 -11,  -17, 	  -9,   -6, 	  -1,   -9
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   10,  -16, 	 -11,  -12, 	   3,   -4, 	   0,   -9
+.2byte   11,  -15, 	 -12,  -10, 	   0,   -3, 	   0,   -8
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    0,  -16, 	  12,   -6, 	 -12,   -6, 	   0,   -8
+.2byte    0,  -15, 	  11,   -4, 	 -11,   -4, 	   0,   -8
+.2byte   -9,  -18, 	   2,   -8, 	  -9,   -5, 	   2,  -11
+.2byte  -10,  -16, 	  11,  -12, 	  -3,   -4, 	   0,   -9
+.2byte  -11,  -15, 	  12,  -10, 	   0,   -3, 	   0,   -8
+.2byte  -10,  -14, 	  -9,   -9, 	  -6,   -1, 	   3,  -10
+.2byte  -11,  -13, 	   8,  -19, 	   8,   -6, 	   1,   -9
+.2byte  -11,  -12, 	  11,  -17, 	   9,   -6, 	   1,   -9
+.2byte   -7,  -11, 	 -10,   -6, 	  -1,   -1, 	   0,   -9
+.2byte   -7,  -10, 	  -5,  -19, 	  14,  -13, 	   0,   -9
+.2byte   -7,   -9, 	  -2,  -19, 	  13,  -13, 	   0,   -9
+.2byte    0,   -7, 	 -14,  -18, 	  14,  -18, 	   0,   -6
+.2byte   -7,   -9, 	  -2,  -19, 	  13,  -13, 	   0,   -9
+.2byte  -11,  -12, 	  11,  -17, 	   9,   -6, 	   1,   -9
+.2byte  -11,  -15, 	  12,  -10, 	   0,   -3, 	   0,   -8
+.2byte    0,  -15, 	  11,   -4, 	 -11,   -4, 	   0,   -8
+.2byte   11,  -15, 	 -12,  -10, 	   0,   -3, 	   0,   -8
+.2byte   11,  -12, 	 -11,  -17, 	  -9,   -6, 	  -1,   -9
+.2byte    7,   -9, 	   2,  -19, 	 -13,  -13, 	   0,   -9
+.2byte    0,  -10, 	  -9,   -5, 	   9,   -5, 	   0,  -12
+.2byte   -7,  -11, 	 -10,   -6, 	  -1,   -1, 	   0,   -9
+.2byte  -10,  -14, 	  -9,   -9, 	  -6,   -1, 	   3,  -10
+.2byte   -9,  -18, 	   2,   -8, 	  -9,   -5, 	   2,  -11
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte    9,  -18, 	  -2,   -8, 	   9,   -5, 	  -2,  -11
+.2byte   10,  -14, 	   9,   -9, 	   6,   -1, 	  -3,  -10
+.2byte    7,  -11, 	  10,   -6, 	   1,   -1, 	   0,   -9
+sKabutopsAnimTable1:
+.4byte sKabutopsAnims_1_1
+.4byte sKabutopsAnims_1_2
+.4byte sKabutopsAnims_1_3
+.4byte sKabutopsAnims_1_4
+.4byte sKabutopsAnims_1_5
+.4byte sKabutopsAnims_1_6
+.4byte sKabutopsAnims_1_7
+.4byte sKabutopsAnims_1_8
+sKabutopsAnimTable2:
+.4byte sKabutopsAnims_2_1
+.4byte sKabutopsAnims_2_2
+.4byte sKabutopsAnims_2_3
+.4byte sKabutopsAnims_2_4
+.4byte sKabutopsAnims_2_5
+.4byte sKabutopsAnims_2_6
+.4byte sKabutopsAnims_2_7
+.4byte sKabutopsAnims_2_8
+sKabutopsAnimTable3:
+.4byte sKabutopsAnims_3_1
+.4byte sKabutopsAnims_3_2
+.4byte sKabutopsAnims_3_3
+.4byte sKabutopsAnims_3_4
+.4byte sKabutopsAnims_3_5
+.4byte sKabutopsAnims_3_6
+.4byte sKabutopsAnims_3_7
+.4byte sKabutopsAnims_3_8
+sKabutopsAnimTable4:
+.4byte sKabutopsAnims_4_1
+.4byte sKabutopsAnims_4_2
+.4byte sKabutopsAnims_4_3
+.4byte sKabutopsAnims_4_4
+.4byte sKabutopsAnims_4_5
+.4byte sKabutopsAnims_4_6
+.4byte sKabutopsAnims_4_7
+.4byte sKabutopsAnims_4_8
+sKabutopsAnimTable5:
+.4byte sKabutopsAnims_5_1
+.4byte sKabutopsAnims_5_2
+.4byte sKabutopsAnims_5_3
+.4byte sKabutopsAnims_5_4
+.4byte sKabutopsAnims_5_5
+.4byte sKabutopsAnims_5_6
+.4byte sKabutopsAnims_5_7
+.4byte sKabutopsAnims_5_8
+sKabutopsAnimTable6:
+.4byte sKabutopsAnims_6_1
+.4byte sKabutopsAnims_6_1
+.4byte sKabutopsAnims_6_1
+.4byte sKabutopsAnims_6_1
+.4byte sKabutopsAnims_6_1
+.4byte sKabutopsAnims_6_1
+.4byte sKabutopsAnims_6_1
+.4byte sKabutopsAnims_6_1
+sKabutopsAnimTable7:
+.4byte sKabutopsAnims_7_1
+.4byte sKabutopsAnims_7_2
+.4byte sKabutopsAnims_7_3
+.4byte sKabutopsAnims_7_4
+.4byte sKabutopsAnims_7_5
+.4byte sKabutopsAnims_7_6
+.4byte sKabutopsAnims_7_7
+.4byte sKabutopsAnims_7_8
+sKabutopsAnimTable8:
+.4byte sKabutopsAnims_8_1
+.4byte sKabutopsAnims_8_2
+.4byte sKabutopsAnims_8_3
+.4byte sKabutopsAnims_8_4
+.4byte sKabutopsAnims_8_5
+.4byte sKabutopsAnims_8_6
+.4byte sKabutopsAnims_8_7
+.4byte sKabutopsAnims_8_8
+sKabutopsAnimTable9:
+.4byte sKabutopsAnims_9_1
+.4byte sKabutopsAnims_9_2
+.4byte sKabutopsAnims_9_3
+.4byte sKabutopsAnims_9_4
+.4byte sKabutopsAnims_9_5
+.4byte sKabutopsAnims_9_6
+.4byte sKabutopsAnims_9_7
+.4byte sKabutopsAnims_9_8
+sKabutopsAnimTable10:
+.4byte sKabutopsAnims_10_1
+.4byte sKabutopsAnims_10_2
+.4byte sKabutopsAnims_10_3
+.4byte sKabutopsAnims_10_4
+.4byte sKabutopsAnims_10_5
+.4byte sKabutopsAnims_10_6
+.4byte sKabutopsAnims_10_7
+.4byte sKabutopsAnims_10_8
+sKabutopsAnimTable11:
+.4byte sKabutopsAnims_11_1
+.4byte sKabutopsAnims_11_2
+.4byte sKabutopsAnims_11_3
+.4byte sKabutopsAnims_11_4
+.4byte sKabutopsAnims_11_5
+.4byte sKabutopsAnims_11_6
+.4byte sKabutopsAnims_11_7
+.4byte sKabutopsAnims_11_8
+sKabutopsAnimTable12:
+.4byte sKabutopsAnims_12_1
+.4byte sKabutopsAnims_12_2
+.4byte sKabutopsAnims_12_3
+.4byte sKabutopsAnims_12_4
+.4byte sKabutopsAnims_12_5
+.4byte sKabutopsAnims_12_6
+.4byte sKabutopsAnims_12_7
+.4byte sKabutopsAnims_12_8
+sKabutopsAnimTable13:
+.4byte sKabutopsAnims_13_1
+.4byte sKabutopsAnims_13_2
+.4byte sKabutopsAnims_13_3
+.4byte sKabutopsAnims_13_4
+.4byte sKabutopsAnims_13_5
+.4byte sKabutopsAnims_13_6
+.4byte sKabutopsAnims_13_7
+.4byte sKabutopsAnims_13_8
+sAxAnimationsKabutops:
+.4byte sKabutopsAnimTable1
+.4byte sKabutopsAnimTable2
+.4byte sKabutopsAnimTable3
+.4byte sKabutopsAnimTable4
+.4byte sKabutopsAnimTable5
+.4byte sKabutopsAnimTable6
+.4byte sKabutopsAnimTable7
+.4byte sKabutopsAnimTable8
+.4byte sKabutopsAnimTable9
+.4byte sKabutopsAnimTable10
+.4byte sKabutopsAnimTable11
+.4byte sKabutopsAnimTable12
+.4byte sKabutopsAnimTable13
+sAxSpritesKabutops:
+.4byte sKabutopsSprites1
+.4byte sKabutopsSprites2
+.4byte sKabutopsSprites3
+.4byte sKabutopsSprites4
+.4byte sKabutopsSprites5
+.4byte sKabutopsSprites6
+.4byte sKabutopsSprites7
+.4byte sKabutopsSprites8
+.4byte sKabutopsSprites9
+.4byte sKabutopsSprites10
+.4byte sKabutopsSprites11
+.4byte sKabutopsSprites12
+.4byte sKabutopsSprites13
+.4byte sKabutopsSprites14
+.4byte sKabutopsSprites15
+.4byte sKabutopsSprites16
+.4byte sKabutopsSprites17
+.4byte sKabutopsSprites18
+.4byte sKabutopsSprites19
+.4byte sKabutopsSprites20
+.4byte sKabutopsSprites21
+.4byte sKabutopsSprites22
+.4byte sKabutopsSprites23
+.4byte sKabutopsSprites24
+.4byte sKabutopsSprites25
+.4byte sKabutopsSprites26
+.4byte sKabutopsSprites27
+.4byte sKabutopsSprites28
+.4byte sKabutopsSprites29
+.4byte sKabutopsSprites30
+.4byte sKabutopsSprites31
+.4byte sKabutopsSprites32
+.4byte sKabutopsSprites33
+.4byte sKabutopsSprites34
+.4byte sKabutopsSprites35
+.4byte sKabutopsSprites36
+.4byte sKabutopsSprites37
+.4byte sKabutopsSprites38
+.4byte sKabutopsSprites39
+.4byte sKabutopsSprites40
+.4byte sKabutopsSprites41
+.4byte sKabutopsSprites42
+.4byte sKabutopsSprites43
+.4byte sKabutopsSprites44
+.4byte sKabutopsSprites45
+.4byte sKabutopsSprites46
+.4byte sKabutopsSprites47
+.4byte sKabutopsSprites48
+.4byte sKabutopsSprites49
+.4byte sKabutopsSprites50
+.4byte sKabutopsSprites51
+.4byte sKabutopsSprites52
+.4byte sKabutopsSprites53
+.4byte sKabutopsSprites54
+.4byte sKabutopsSprites55
+.4byte sKabutopsSprites56
+.4byte sKabutopsSprites57
+.4byte sKabutopsSprites58
+.4byte sKabutopsSprites59
+.4byte sKabutopsSprites60
+.4byte sKabutopsSprites61
+.4byte sKabutopsSprites62
+.4byte sKabutopsSprites63
+.4byte sKabutopsSprites64
+.4byte sKabutopsSprites65
+.4byte sKabutopsSprites66
+sAxMainKabutops:
+ax_main sAxPosesKabutops, sAxAnimationsKabutops, 13, sAxSpritesKabutops, sAxPositionsKabutops

--- a/data/ax/kadabra.inc
+++ b/data/ax/kadabra.inc
@@ -1,0 +1,2651 @@
+.global gAxKadabra
+gAxKadabra:
+ax_siro sAxMainKadabra
+sKadabraPose1:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose3:
+ax_pose 2, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose4:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose5:
+ax_pose 4, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose6:
+ax_pose 5, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose7:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose8:
+ax_pose 7, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose9:
+ax_pose 8, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose10:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose11:
+ax_pose 10, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose12:
+ax_pose 11, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose13:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose14:
+ax_pose 13, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose15:
+ax_pose 14, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose16:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose17:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose18:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose19:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose20:
+ax_pose 19, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose21:
+ax_pose 20, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose22:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose23:
+ax_pose 22, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose24:
+ax_pose 23, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose25:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose26:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose27:
+ax_pose 2, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose28:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose29:
+ax_pose 4, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose30:
+ax_pose 5, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose31:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose32:
+ax_pose 7, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose33:
+ax_pose 8, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose34:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose35:
+ax_pose 10, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose36:
+ax_pose 11, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose37:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose38:
+ax_pose 13, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose39:
+ax_pose 14, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose40:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose41:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose42:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose43:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose44:
+ax_pose 19, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose45:
+ax_pose 20, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose46:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose47:
+ax_pose 22, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose48:
+ax_pose 23, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose49:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose50:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose51:
+ax_pose 2, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose52:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose53:
+ax_pose 4, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose54:
+ax_pose 5, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose55:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose56:
+ax_pose 7, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose57:
+ax_pose 8, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose58:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose59:
+ax_pose 10, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose60:
+ax_pose 11, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose61:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose62:
+ax_pose 13, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose63:
+ax_pose 14, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose64:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose65:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose66:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose67:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose68:
+ax_pose 19, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose69:
+ax_pose 20, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose70:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose71:
+ax_pose 22, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose72:
+ax_pose 23, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose73:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose74:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose75:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose76:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose77:
+ax_pose 26, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose78:
+ax_pose 27, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose79:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose80:
+ax_pose 28, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose81:
+ax_pose 29, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose82:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose83:
+ax_pose 30, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose84:
+ax_pose 31, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose85:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose86:
+ax_pose 32, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose87:
+ax_pose 33, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose88:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose89:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose90:
+ax_pose 35, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose91:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose92:
+ax_pose 36, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose93:
+ax_pose 37, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose94:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose95:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose96:
+ax_pose 39, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose97:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose98:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose99:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose100:
+ax_pose 26, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose101:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose102:
+ax_pose 28, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose103:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose104:
+ax_pose 30, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose105:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose106:
+ax_pose 32, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose107:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose108:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose109:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose110:
+ax_pose 36, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose111:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose112:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose113:
+ax_pose 40, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose114:
+ax_pose 41, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose115:
+ax_pose 42, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose116:
+ax_pose 43, 0x01e2, 0x90ed, 0x4c00
+ax_pose_terminator
+sKadabraPose117:
+ax_pose 44, 0x01e2, 0x90ee, 0x4c00
+ax_pose_terminator
+sKadabraPose118:
+ax_pose 45, 0x01e0, 0x90ee, 0x4c00
+ax_pose_terminator
+sKadabraPose119:
+ax_pose 46, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose120:
+ax_pose 45, 0x01e0, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose121:
+ax_pose 44, 0x01e2, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose122:
+ax_pose 43, 0x01e2, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose123:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose124:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose125:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose126:
+ax_pose 26, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose127:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose128:
+ax_pose 28, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose129:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose130:
+ax_pose 30, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose131:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose132:
+ax_pose 32, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose133:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose134:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose135:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose136:
+ax_pose 36, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose137:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose138:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose139:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose140:
+ax_pose 39, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose141:
+ax_pose 37, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose142:
+ax_pose 35, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose143:
+ax_pose 33, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose144:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose145:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sKadabraPose146:
+ax_pose 27, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose147:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose148:
+ax_pose 26, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose149:
+ax_pose 28, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose150:
+ax_pose 30, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose151:
+ax_pose 32, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose152:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose153:
+ax_pose 36, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose154:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose155:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose156:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose157:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose158:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose159:
+ax_pose 26, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose160:
+ax_pose 27, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose161:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose162:
+ax_pose 28, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose163:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose164:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose165:
+ax_pose 30, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose166:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose167:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose168:
+ax_pose 32, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose169:
+ax_pose 33, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose170:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose171:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose172:
+ax_pose 35, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose173:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose174:
+ax_pose 36, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose175:
+ax_pose 37, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose176:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose177:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose178:
+ax_pose 39, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose179:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose180:
+ax_pose 39, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose181:
+ax_pose 37, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose182:
+ax_pose 35, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sKadabraPose183:
+ax_pose 33, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sKadabraPose184:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose185:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sKadabraPose186:
+ax_pose 27, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose187:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose188:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose189:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose190:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sKadabraPose191:
+ax_pose 12, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sKadabraPose192:
+ax_pose 9, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose193:
+ax_pose 6, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sKadabraPose194:
+ax_pose 3, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+.align 2
+sKadabraAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sKadabraAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 1, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 0, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sKadabraAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 19, 0, 19, 0,
+ax_anim 2, 1, 31, 19, 1, 19, 1,
+ax_anim 2, 0, 31, 19, 0, 19, 0,
+ax_anim 2, 0, 31, 19, 1, 19, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sKadabraAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -5, 4, -5,
+ax_anim 1, 0, 34, 10, -12, 10, -12,
+ax_anim 2, 0, 34, 18, -21, 18, -21,
+ax_anim 2, 1, 34, 19, -20, 19, -20,
+ax_anim 2, 0, 34, 18, -21, 18, -21,
+ax_anim 2, 0, 34, 19, -20, 19, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sKadabraAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 1, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 0, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sKadabraAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -5, -4, -5,
+ax_anim 1, 0, 40, -10, -12, -10, -12,
+ax_anim 2, 0, 40, -18, -21, -18, -21,
+ax_anim 2, 1, 40, -19, -20, -19, -20,
+ax_anim 2, 0, 40, -18, -21, -18, -21,
+ax_anim 2, 0, 40, -19, -20, -19, -20,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sKadabraAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 1, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 0, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sKadabraAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -20, 20, -20, 20,
+ax_anim 2, 1, 46, -21, 19, -21, 19,
+ax_anim 2, 0, 46, -20, 20, -20, 20,
+ax_anim 2, 0, 46, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sKadabraAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 6, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 1, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 0, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sKadabraAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 20, 20, 20, 20,
+ax_anim 2, 1, 52, 21, 19, 21, 19,
+ax_anim 2, 0, 52, 20, 20, 20, 20,
+ax_anim 2, 0, 52, 21, 19, 21, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sKadabraAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 6, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 19, 0, 19, 0,
+ax_anim 2, 1, 55, 19, 1, 19, 1,
+ax_anim 2, 0, 55, 19, 0, 19, 0,
+ax_anim 2, 0, 55, 19, 1, 19, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sKadabraAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 6, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -5, 4, -5,
+ax_anim 1, 0, 58, 10, -12, 10, -12,
+ax_anim 2, 0, 58, 18, -21, 18, -21,
+ax_anim 2, 1, 58, 19, -20, 19, -20,
+ax_anim 2, 0, 58, 18, -21, 18, -21,
+ax_anim 2, 0, 58, 19, -20, 19, -20,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sKadabraAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 6, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 1, 61, 1, -20, 1, -20,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 0, 61, 1, -20, 1, -20,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sKadabraAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 6, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -5, -4, -5,
+ax_anim 1, 0, 64, -10, -12, -10, -12,
+ax_anim 2, 0, 64, -18, -21, -18, -21,
+ax_anim 2, 1, 64, -19, -20, -19, -20,
+ax_anim 2, 0, 64, -18, -21, -18, -21,
+ax_anim 2, 0, 64, -19, -20, -19, -20,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sKadabraAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 6, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -19, 0, -19, 0,
+ax_anim 2, 1, 67, -19, 1, -19, 1,
+ax_anim 2, 0, 67, -19, 0, -19, 0,
+ax_anim 2, 0, 67, -19, 1, -19, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sKadabraAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 6, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -20, 20, -20, 20,
+ax_anim 2, 1, 70, -21, 19, -21, 19,
+ax_anim 2, 0, 70, -20, 20, -20, 20,
+ax_anim 2, 0, 70, -21, 19, -21, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sKadabraAnims_4_1:
+ax_anim 2, 0, 72, 0, -3, 0, 0,
+ax_anim 3, 0, 73, 0, -5, 0, 0,
+ax_anim 4, 0, 73, 0, -6, 0, 0,
+ax_anim 4, 2, 73, 0, -7, 0, 0,
+ax_anim 3, 0, 73, 0, -6, 0, 0,
+ax_anim 1, 0, 74, 0, -4, 0, 1,
+ax_anim 1, 0, 74, 0, -2, 0, 2,
+ax_anim 2, 1, 74, -1, -2, -1, 2,
+ax_anim 2, 0, 74, 0, -2, 0, 2,
+ax_anim 2, 0, 74, -1, -2, -1, 2,
+ax_anim 2, 0, 74, 0, -2, 0, 2,
+ax_anim 2, 0, 74, -1, -2, -1, 2,
+ax_anim 2, 0, 74, 0, -2, 0, 2,
+ax_anim_terminator
+sKadabraAnims_4_2:
+ax_anim 2, 0, 75, 0, -3, 0, 0,
+ax_anim 3, 0, 76, 0, -5, 0, 0,
+ax_anim 4, 0, 76, 0, -6, 0, 0,
+ax_anim 4, 2, 76, 0, -7, 0, 0,
+ax_anim 3, 0, 76, 0, -6, 0, 0,
+ax_anim 1, 0, 77, 2, -4, 2, 2,
+ax_anim 1, 0, 77, 4, -2, 3, 3,
+ax_anim 2, 1, 77, 3, -1, 2, 4,
+ax_anim 2, 0, 77, 4, -2, 3, 3,
+ax_anim 2, 0, 77, 3, -1, 2, 4,
+ax_anim 2, 0, 77, 4, -2, 3, 3,
+ax_anim 2, 0, 77, 3, -1, 2, 4,
+ax_anim 2, 0, 77, 4, -2, 3, 3,
+ax_anim_terminator
+sKadabraAnims_4_3:
+ax_anim 2, 0, 78, 0, -3, 0, 0,
+ax_anim 3, 0, 79, 0, -5, 0, 0,
+ax_anim 4, 0, 79, 0, -6, 0, 0,
+ax_anim 4, 2, 79, 0, -7, 0, 0,
+ax_anim 3, 0, 79, 0, -6, 0, 0,
+ax_anim 1, 0, 80, 0, -8, 2, 0,
+ax_anim 1, 0, 80, 4, -6, 4, 0,
+ax_anim 2, 1, 80, 4, -7, 4, -1,
+ax_anim 2, 0, 80, 4, -6, 4, 0,
+ax_anim 2, 0, 80, 4, -7, 4, -1,
+ax_anim 2, 0, 80, 4, -6, 4, 0,
+ax_anim 2, 0, 80, 4, -7, 4, -1,
+ax_anim 2, 0, 80, 4, -6, 4, 0,
+ax_anim_terminator
+sKadabraAnims_4_4:
+ax_anim 2, 0, 81, 0, -3, 0, 0,
+ax_anim 3, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 0, 82, 0, -6, 0, 0,
+ax_anim 4, 2, 82, 0, -7, 0, 0,
+ax_anim 3, 0, 82, 0, -6, 0, 0,
+ax_anim 1, 0, 83, 0, -7, 1, -1,
+ax_anim 1, 0, 83, 2, -8, 3, -3,
+ax_anim 2, 1, 83, 3, -7, 4, -2,
+ax_anim 2, 0, 83, 2, -8, 3, -3,
+ax_anim 2, 0, 83, 3, -7, 4, -2,
+ax_anim 2, 0, 83, 2, -8, 3, -3,
+ax_anim 2, 0, 83, 3, -7, 4, -2,
+ax_anim 2, 0, 83, 2, -8, 3, -3,
+ax_anim_terminator
+sKadabraAnims_4_5:
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 3, 0, 85, 0, -5, 0, 0,
+ax_anim 4, 0, 85, 0, -6, 0, 0,
+ax_anim 4, 2, 85, 0, -7, 0, 0,
+ax_anim 3, 0, 85, 0, -6, 0, 0,
+ax_anim 1, 0, 86, 0, -7, 0, -1,
+ax_anim 1, 0, 86, 0, -8, 0, -3,
+ax_anim 2, 1, 86, -1, -8, -1, -3,
+ax_anim 2, 0, 86, 0, -8, 0, -3,
+ax_anim 2, 0, 86, -1, -8, -1, -3,
+ax_anim 2, 0, 86, 0, -8, 0, -3,
+ax_anim 2, 0, 86, -1, -8, -1, -3,
+ax_anim 2, 0, 86, 0, -8, 0, -3,
+ax_anim_terminator
+sKadabraAnims_4_6:
+ax_anim 2, 0, 87, 0, -3, 0, 0,
+ax_anim 3, 0, 88, 0, -5, 0, 0,
+ax_anim 4, 0, 88, 0, -6, 0, 0,
+ax_anim 4, 2, 88, 0, -7, 0, 0,
+ax_anim 3, 0, 88, 0, -6, 0, 0,
+ax_anim 1, 0, 89, 0, -7, -1, -1,
+ax_anim 1, 0, 89, -2, -8, -3, -3,
+ax_anim 2, 1, 89, -3, -7, -4, -2,
+ax_anim 2, 0, 89, -2, -8, -3, -3,
+ax_anim 2, 0, 89, -3, -7, -4, -2,
+ax_anim 2, 0, 89, -2, -8, -3, -3,
+ax_anim 2, 0, 89, -3, -7, -4, -2,
+ax_anim 2, 0, 89, -2, -8, -3, -3,
+ax_anim_terminator
+sKadabraAnims_4_7:
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 3, 0, 91, 0, -5, 0, 0,
+ax_anim 4, 0, 91, 0, -6, 0, 0,
+ax_anim 4, 2, 91, 0, -7, 0, 0,
+ax_anim 3, 0, 91, 0, -6, 0, 0,
+ax_anim 1, 0, 92, 0, -8, -2, 0,
+ax_anim 1, 0, 92, -4, -6, -4, 0,
+ax_anim 2, 1, 92, -4, -7, -4, -1,
+ax_anim 2, 0, 92, -4, -6, -4, 0,
+ax_anim 2, 0, 92, -4, -7, -4, -1,
+ax_anim 2, 0, 92, -4, -6, -4, 0,
+ax_anim 2, 0, 92, -4, -7, -4, -1,
+ax_anim 2, 0, 92, -4, -6, -4, 0,
+ax_anim_terminator
+sKadabraAnims_4_8:
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 3, 0, 94, 0, -5, 0, 0,
+ax_anim 4, 0, 94, 0, -6, 0, 0,
+ax_anim 4, 2, 94, 0, -7, 0, 0,
+ax_anim 3, 0, 94, 0, -6, 0, 0,
+ax_anim 1, 0, 95, -2, -4, -2, 2,
+ax_anim 1, 0, 95, -4, -2, -3, 3,
+ax_anim 2, 1, 95, -3, -1, -2, 4,
+ax_anim 2, 0, 95, -4, -2, -3, 3,
+ax_anim 2, 0, 95, -3, -1, -2, 4,
+ax_anim 2, 0, 95, -4, -2, -3, 3,
+ax_anim 2, 0, 95, -3, -1, -2, 4,
+ax_anim 2, 0, 95, -4, -2, -3, 3,
+ax_anim_terminator
+.align 2
+sKadabraAnims_5_1:
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -7, 0, 0,
+ax_anim 3, 0, 97, 0, -8, 0, 0,
+ax_anim 3, 2, 97, 0, -7, 0, 0,
+ax_anim 3, 0, 97, 0, -6, 0, 0,
+ax_anim 3, 0, 97, 0, -7, 0, 0,
+ax_anim 3, 0, 97, 0, -8, 0, 0,
+ax_anim 3, 0, 97, 0, -7, 0, 0,
+ax_anim 2, 1, 97, 0, -6, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -1, 0, 0,
+ax_anim_terminator
+sKadabraAnims_5_2:
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 3, 0, 99, 0, -8, 0, 0,
+ax_anim 3, 2, 99, 0, -7, 0, 0,
+ax_anim 3, 0, 99, 0, -6, 0, 0,
+ax_anim 3, 0, 99, 0, -7, 0, 0,
+ax_anim 3, 0, 99, 0, -8, 0, 0,
+ax_anim 3, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 1, 99, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, 0,
+ax_anim_terminator
+sKadabraAnims_5_3:
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 3, 2, 101, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -6, 0, 0,
+ax_anim 3, 0, 101, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 3, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 1, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, 0,
+ax_anim_terminator
+sKadabraAnims_5_4:
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 103, 0, -7, 0, 0,
+ax_anim 3, 0, 103, 0, -8, 0, 0,
+ax_anim 3, 2, 103, 0, -7, 0, 0,
+ax_anim 3, 0, 103, 0, -6, 0, 0,
+ax_anim 3, 0, 103, 0, -7, 0, 0,
+ax_anim 3, 0, 103, 0, -8, 0, 0,
+ax_anim 3, 0, 103, 0, -7, 0, 0,
+ax_anim 2, 1, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim_terminator
+sKadabraAnims_5_5:
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 3, 0, 105, 0, -8, 0, 0,
+ax_anim 3, 2, 105, 0, -7, 0, 0,
+ax_anim 3, 0, 105, 0, -6, 0, 0,
+ax_anim 3, 0, 105, 0, -7, 0, 0,
+ax_anim 3, 0, 105, 0, -8, 0, 0,
+ax_anim 3, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 1, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim_terminator
+sKadabraAnims_5_6:
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 107, 0, -8, 0, 0,
+ax_anim 3, 2, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 107, 0, -6, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 107, 0, -8, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 2, 1, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim_terminator
+sKadabraAnims_5_7:
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -7, 0, 0,
+ax_anim 3, 0, 109, 0, -8, 0, 0,
+ax_anim 3, 2, 109, 0, -7, 0, 0,
+ax_anim 3, 0, 109, 0, -6, 0, 0,
+ax_anim 3, 0, 109, 0, -7, 0, 0,
+ax_anim 3, 0, 109, 0, -8, 0, 0,
+ax_anim 3, 0, 109, 0, -7, 0, 0,
+ax_anim 2, 1, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, 0,
+ax_anim_terminator
+sKadabraAnims_5_8:
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 2, 111, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 111, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 0, 111, 0, -7, 0, 0,
+ax_anim 2, 1, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sKadabraAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sKadabraAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sKadabraAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sKadabraAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sKadabraAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sKadabraAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sKadabraAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sKadabraAnims_8_1:
+ax_anim 4, 0, 123, 0, -6, 0, 0,
+ax_anim 4, 0, 123, 0, -7, 0, 0,
+ax_anim 6, 0, 123, 0, -8, 0, 0,
+ax_anim 6, 0, 123, 0, -7, 0, 0,
+ax_anim 6, 0, 123, 0, -6, 0, 0,
+ax_anim 6, 0, 123, 0, -7, 0, 0,
+ax_anim 6, 0, 123, 0, -8, 0, 0,
+ax_anim 6, 0, 123, 0, -7, 0, 0,
+ax_anim 4, 0, 123, 0, -6, 0, 0,
+ax_anim_terminator
+sKadabraAnims_8_2:
+ax_anim 4, 0, 125, 0, -6, 0, 0,
+ax_anim 4, 0, 125, 0, -7, 0, 0,
+ax_anim 6, 0, 125, 0, -8, 0, 0,
+ax_anim 6, 0, 125, 0, -7, 0, 0,
+ax_anim 6, 0, 125, 0, -6, 0, 0,
+ax_anim 6, 0, 125, 0, -7, 0, 0,
+ax_anim 6, 0, 125, 0, -8, 0, 0,
+ax_anim 6, 0, 125, 0, -7, 0, 0,
+ax_anim 4, 0, 125, 0, -6, 0, 0,
+ax_anim_terminator
+sKadabraAnims_8_3:
+ax_anim 4, 0, 127, 0, -6, 0, 0,
+ax_anim 4, 0, 127, 0, -7, 0, 0,
+ax_anim 6, 0, 127, 0, -8, 0, 0,
+ax_anim 6, 0, 127, 0, -7, 0, 0,
+ax_anim 6, 0, 127, 0, -6, 0, 0,
+ax_anim 6, 0, 127, 0, -7, 0, 0,
+ax_anim 6, 0, 127, 0, -8, 0, 0,
+ax_anim 6, 0, 127, 0, -7, 0, 0,
+ax_anim 4, 0, 127, 0, -6, 0, 0,
+ax_anim_terminator
+sKadabraAnims_8_4:
+ax_anim 4, 0, 129, 0, -6, 0, 0,
+ax_anim 4, 0, 129, 0, -7, 0, 0,
+ax_anim 6, 0, 129, 0, -8, 0, 0,
+ax_anim 6, 0, 129, 0, -7, 0, 0,
+ax_anim 6, 0, 129, 0, -6, 0, 0,
+ax_anim 6, 0, 129, 0, -7, 0, 0,
+ax_anim 6, 0, 129, 0, -8, 0, 0,
+ax_anim 6, 0, 129, 0, -7, 0, 0,
+ax_anim 4, 0, 129, 0, -6, 0, 0,
+ax_anim_terminator
+sKadabraAnims_8_5:
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 4, 0, 131, 0, -7, 0, 0,
+ax_anim 6, 0, 131, 0, -8, 0, 0,
+ax_anim 6, 0, 131, 0, -7, 0, 0,
+ax_anim 6, 0, 131, 0, -6, 0, 0,
+ax_anim 6, 0, 131, 0, -7, 0, 0,
+ax_anim 6, 0, 131, 0, -8, 0, 0,
+ax_anim 6, 0, 131, 0, -7, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim_terminator
+sKadabraAnims_8_6:
+ax_anim 4, 0, 133, 0, -6, 0, 0,
+ax_anim 4, 0, 133, 0, -7, 0, 0,
+ax_anim 6, 0, 133, 0, -8, 0, 0,
+ax_anim 6, 0, 133, 0, -7, 0, 0,
+ax_anim 6, 0, 133, 0, -6, 0, 0,
+ax_anim 6, 0, 133, 0, -7, 0, 0,
+ax_anim 6, 0, 133, 0, -8, 0, 0,
+ax_anim 6, 0, 133, 0, -7, 0, 0,
+ax_anim 4, 0, 133, 0, -6, 0, 0,
+ax_anim_terminator
+sKadabraAnims_8_7:
+ax_anim 4, 0, 135, 0, -6, 0, 0,
+ax_anim 4, 0, 135, 0, -7, 0, 0,
+ax_anim 6, 0, 135, 0, -8, 0, 0,
+ax_anim 6, 0, 135, 0, -7, 0, 0,
+ax_anim 6, 0, 135, 0, -6, 0, 0,
+ax_anim 6, 0, 135, 0, -7, 0, 0,
+ax_anim 6, 0, 135, 0, -8, 0, 0,
+ax_anim 6, 0, 135, 0, -7, 0, 0,
+ax_anim 4, 0, 135, 0, -6, 0, 0,
+ax_anim_terminator
+sKadabraAnims_8_8:
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 4, 0, 137, 0, -7, 0, 0,
+ax_anim 6, 0, 137, 0, -8, 0, 0,
+ax_anim 6, 0, 137, 0, -7, 0, 0,
+ax_anim 6, 0, 137, 0, -6, 0, 0,
+ax_anim 6, 0, 137, 0, -7, 0, 0,
+ax_anim 6, 0, 137, 0, -8, 0, 0,
+ax_anim 6, 0, 137, 0, -7, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 15, 7, 15,
+ax_anim 3, 0, 142, 0, 19, 0, 19,
+ax_anim 2, 3, 143, -7, 15, -7, 15,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 20, 12, 20, 12,
+ax_anim 3, 0, 141, 19, 20, 19, 20,
+ax_anim 2, 3, 142, 11, 21, 11, 21,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 16, -5, 16, -5,
+ax_anim 3, 0, 140, 20, -2, 20, -2,
+ax_anim 2, 3, 141, 18, 4, 18, 4,
+ax_anim 2, 0, 142, 12, 5, 12, 5,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -22, 12, -22,
+ax_anim 3, 0, 139, 18, -22, 18, -22,
+ax_anim 2, 3, 140, 20, -15, 20, -15,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -18, -7, -18,
+ax_anim 3, 0, 138, 0, -23, 0, -23,
+ax_anim 2, 3, 139, 7, -18, 7, -18,
+ax_anim 2, 0, 140, 9, -10, 9, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -6, 1, -6,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -22, -12, -22,
+ax_anim 3, 0, 145, -18, -22, -18, -22,
+ax_anim 2, 3, 144, -20, -15, -20, -15,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -16, -5, -16, -5,
+ax_anim 3, 0, 144, -20, -2, -20, -2,
+ax_anim 2, 3, 143, -18, 4, -18, 4,
+ax_anim 2, 0, 142, -12, 5, -12, 5,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -20, 12, -20, 12,
+ax_anim 3, 0, 143, -19, 20, -19, 20,
+ax_anim 2, 3, 142, -11, 21, -11, 21,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -25, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -25, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -24, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -25, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -25, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKadabraAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sKadabraGfx1:
+.incbin "baserom.gba", 0x7C567C, 0x200
+sKadabraSprites1:
+ax_sprite sKadabraGfx1, 0x200
+ax_sprite_terminator
+sKadabraGfx2:
+.incbin "baserom.gba", 0x7C588C, 0x200
+sKadabraSprites2:
+ax_sprite sKadabraGfx2, 0x200
+ax_sprite_terminator
+sKadabraGfx3:
+.incbin "baserom.gba", 0x7C5A9C, 0x200
+sKadabraSprites3:
+ax_sprite sKadabraGfx3, 0x200
+ax_sprite_terminator
+sKadabraGfx4:
+.incbin "baserom.gba", 0x7C5CAC, 0x200
+sKadabraSprites4:
+ax_sprite sKadabraGfx4, 0x200
+ax_sprite_terminator
+sKadabraGfx5:
+.incbin "baserom.gba", 0x7C5EBC, 0x200
+sKadabraSprites5:
+ax_sprite sKadabraGfx5, 0x200
+ax_sprite_terminator
+sKadabraGfx6:
+.incbin "baserom.gba", 0x7C60CC, 0x200
+sKadabraSprites6:
+ax_sprite sKadabraGfx6, 0x200
+ax_sprite_terminator
+sKadabraGfx7:
+.incbin "baserom.gba", 0x7C62DC, 0x200
+sKadabraSprites7:
+ax_sprite sKadabraGfx7, 0x200
+ax_sprite_terminator
+sKadabraGfx8:
+.incbin "baserom.gba", 0x7C64EC, 0x200
+sKadabraSprites8:
+ax_sprite sKadabraGfx8, 0x200
+ax_sprite_terminator
+sKadabraGfx9:
+.incbin "baserom.gba", 0x7C66FC, 0x200
+sKadabraSprites9:
+ax_sprite sKadabraGfx9, 0x200
+ax_sprite_terminator
+sKadabraGfx10:
+.incbin "baserom.gba", 0x7C690C, 0x200
+sKadabraSprites10:
+ax_sprite sKadabraGfx10, 0x200
+ax_sprite_terminator
+sKadabraGfx11:
+.incbin "baserom.gba", 0x7C6B1C, 0x200
+sKadabraSprites11:
+ax_sprite sKadabraGfx11, 0x200
+ax_sprite_terminator
+sKadabraGfx12:
+.incbin "baserom.gba", 0x7C6D2C, 0x200
+sKadabraSprites12:
+ax_sprite sKadabraGfx12, 0x200
+ax_sprite_terminator
+sKadabraGfx13:
+.incbin "baserom.gba", 0x7C6F3C, 0x200
+sKadabraSprites13:
+ax_sprite sKadabraGfx13, 0x200
+ax_sprite_terminator
+sKadabraGfx14:
+.incbin "baserom.gba", 0x7C714C, 0x200
+sKadabraSprites14:
+ax_sprite sKadabraGfx14, 0x200
+ax_sprite_terminator
+sKadabraGfx15:
+.incbin "baserom.gba", 0x7C735C, 0x200
+sKadabraSprites15:
+ax_sprite sKadabraGfx15, 0x200
+ax_sprite_terminator
+sKadabraGfx16:
+.incbin "baserom.gba", 0x7C756C, 0x200
+sKadabraSprites16:
+ax_sprite sKadabraGfx16, 0x200
+ax_sprite_terminator
+sKadabraGfx17:
+.incbin "baserom.gba", 0x7C777C, 0x200
+sKadabraSprites17:
+ax_sprite sKadabraGfx17, 0x200
+ax_sprite_terminator
+sKadabraGfx18:
+.incbin "baserom.gba", 0x7C798C, 0x200
+sKadabraSprites18:
+ax_sprite sKadabraGfx18, 0x200
+ax_sprite_terminator
+sKadabraGfx19:
+.incbin "baserom.gba", 0x7C7B9C, 0x200
+sKadabraSprites19:
+ax_sprite sKadabraGfx19, 0x200
+ax_sprite_terminator
+sKadabraGfx20:
+.incbin "baserom.gba", 0x7C7DAC, 0x200
+sKadabraSprites20:
+ax_sprite sKadabraGfx20, 0x200
+ax_sprite_terminator
+sKadabraGfx21:
+.incbin "baserom.gba", 0x7C7FBC, 0x200
+sKadabraSprites21:
+ax_sprite sKadabraGfx21, 0x200
+ax_sprite_terminator
+sKadabraGfx22:
+.incbin "baserom.gba", 0x7C81CC, 0x200
+sKadabraSprites22:
+ax_sprite sKadabraGfx22, 0x200
+ax_sprite_terminator
+sKadabraGfx23:
+.incbin "baserom.gba", 0x7C83DC, 0x200
+sKadabraSprites23:
+ax_sprite sKadabraGfx23, 0x200
+ax_sprite_terminator
+sKadabraGfx24:
+.incbin "baserom.gba", 0x7C85EC, 0x200
+sKadabraSprites24:
+ax_sprite sKadabraGfx24, 0x200
+ax_sprite_terminator
+sKadabraGfx25:
+.incbin "baserom.gba", 0x7C87FC, 0x40
+sKadabraGfx25_1:
+.incbin "baserom.gba", 0x7C883C, 0x100
+sKadabraGfx25_2:
+.incbin "baserom.gba", 0x7C893C, 0x40
+sKadabraSprites25:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx26:
+.incbin "baserom.gba", 0x7C89BC, 0x40
+sKadabraGfx26_1:
+.incbin "baserom.gba", 0x7C89FC, 0x160
+sKadabraSprites26:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx26_1, 0x160
+ax_sprite_terminator
+sKadabraGfx27:
+.incbin "baserom.gba", 0x7C8B84, 0x60
+sKadabraGfx27_1:
+.incbin "baserom.gba", 0x7C8BE4, 0x160
+sKadabraSprites27:
+ax_sprite sKadabraGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx28:
+.incbin "baserom.gba", 0x7C8D6C, 0x60
+sKadabraGfx28_1:
+.incbin "baserom.gba", 0x7C8DCC, 0x60
+sKadabraGfx28_2:
+.incbin "baserom.gba", 0x7C8E2C, 0x80
+sKadabraGfx28_3:
+.incbin "baserom.gba", 0x7C8EAC, 0x40
+sKadabraSprites28:
+ax_sprite sKadabraGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx28_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx29:
+.incbin "baserom.gba", 0x7C8F34, 0x40
+sKadabraGfx29_1:
+.incbin "baserom.gba", 0x7C8F74, 0xC0
+sKadabraGfx29_2:
+.incbin "baserom.gba", 0x7C9034, 0x60
+sKadabraSprites29:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx29_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx30:
+.incbin "baserom.gba", 0x7C90D4, 0x20
+sKadabraGfx30_1:
+.incbin "baserom.gba", 0x7C90F4, 0x100
+sKadabraGfx30_2:
+.incbin "baserom.gba", 0x7C91F4, 0x40
+sKadabraSprites30:
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx30, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx31:
+.incbin "baserom.gba", 0x7C9274, 0x40
+sKadabraGfx31_1:
+.incbin "baserom.gba", 0x7C92B4, 0x60
+sKadabraGfx31_2:
+.incbin "baserom.gba", 0x7C9314, 0x100
+sKadabraSprites31:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx31_2, 0x100
+ax_sprite_terminator
+sKadabraGfx32:
+.incbin "baserom.gba", 0x7C944C, 0x40
+sKadabraGfx32_1:
+.incbin "baserom.gba", 0x7C948C, 0xE0
+sKadabraGfx32_2:
+.incbin "baserom.gba", 0x7C956C, 0x40
+sKadabraSprites32:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx32_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx33:
+.incbin "baserom.gba", 0x7C95EC, 0x60
+sKadabraGfx33_1:
+.incbin "baserom.gba", 0x7C964C, 0x100
+sKadabraGfx33_2:
+.incbin "baserom.gba", 0x7C974C, 0x40
+sKadabraSprites33:
+ax_sprite sKadabraGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx34:
+.incbin "baserom.gba", 0x7C97C4, 0x160
+sKadabraGfx34_1:
+.incbin "baserom.gba", 0x7C9924, 0x40
+sKadabraSprites34:
+ax_sprite sKadabraGfx34, 0x160
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx35:
+.incbin "baserom.gba", 0x7C998C, 0x40
+sKadabraGfx35_1:
+.incbin "baserom.gba", 0x7C99CC, 0x160
+sKadabraSprites35:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx35_1, 0x160
+ax_sprite_terminator
+sKadabraGfx36:
+.incbin "baserom.gba", 0x7C9B54, 0x20
+sKadabraGfx36_1:
+.incbin "baserom.gba", 0x7C9B74, 0x60
+sKadabraGfx36_2:
+.incbin "baserom.gba", 0x7C9BD4, 0x60
+sKadabraGfx36_3:
+.incbin "baserom.gba", 0x7C9C34, 0x40
+sKadabraSprites36:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx37:
+.incbin "baserom.gba", 0x7C9CC4, 0x40
+sKadabraGfx37_1:
+.incbin "baserom.gba", 0x7C9D04, 0x60
+sKadabraGfx37_2:
+.incbin "baserom.gba", 0x7C9D64, 0x60
+sKadabraGfx37_3:
+.incbin "baserom.gba", 0x7C9DC4, 0x60
+sKadabraSprites37:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx37_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx37_3, 0x60
+ax_sprite_terminator
+sKadabraGfx38:
+.incbin "baserom.gba", 0x7C9E6C, 0x20
+sKadabraGfx38_1:
+.incbin "baserom.gba", 0x7C9E8C, 0x100
+sKadabraGfx38_2:
+.incbin "baserom.gba", 0x7C9F8C, 0x40
+sKadabraSprites38:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx38, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKadabraGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx39:
+.incbin "baserom.gba", 0x7CA00C, 0x160
+sKadabraGfx39_1:
+.incbin "baserom.gba", 0x7CA16C, 0x60
+sKadabraSprites39:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx39, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx39_1, 0x60
+ax_sprite_terminator
+sKadabraGfx40:
+.incbin "baserom.gba", 0x7CA1F4, 0x160
+sKadabraGfx40_1:
+.incbin "baserom.gba", 0x7CA354, 0x40
+sKadabraSprites40:
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx40, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKadabraGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKadabraGfx41:
+.incbin "baserom.gba", 0x7CA3C4, 0x200
+sKadabraSprites41:
+ax_sprite sKadabraGfx41, 0x200
+ax_sprite_terminator
+sKadabraGfx42:
+.incbin "baserom.gba", 0x7CA5D4, 0x200
+sKadabraSprites42:
+ax_sprite sKadabraGfx42, 0x200
+ax_sprite_terminator
+sKadabraGfx43:
+.incbin "baserom.gba", 0x7CA7E4, 0x200
+sKadabraSprites43:
+ax_sprite sKadabraGfx43, 0x200
+ax_sprite_terminator
+sKadabraGfx44:
+.incbin "baserom.gba", 0x7CA9F4, 0x200
+sKadabraSprites44:
+ax_sprite sKadabraGfx44, 0x200
+ax_sprite_terminator
+sKadabraGfx45:
+.incbin "baserom.gba", 0x7CAC04, 0x200
+sKadabraSprites45:
+ax_sprite sKadabraGfx45, 0x200
+ax_sprite_terminator
+sKadabraGfx46:
+.incbin "baserom.gba", 0x7CAE14, 0x200
+sKadabraSprites46:
+ax_sprite sKadabraGfx46, 0x200
+ax_sprite_terminator
+sKadabraGfx47:
+.incbin "baserom.gba", 0x7CB024, 0x200
+sKadabraSprites47:
+ax_sprite sKadabraGfx47, 0x200
+ax_sprite_terminator
+sAxPosesKadabra:
+.4byte sKadabraPose1
+.4byte sKadabraPose2
+.4byte sKadabraPose3
+.4byte sKadabraPose4
+.4byte sKadabraPose5
+.4byte sKadabraPose6
+.4byte sKadabraPose7
+.4byte sKadabraPose8
+.4byte sKadabraPose9
+.4byte sKadabraPose10
+.4byte sKadabraPose11
+.4byte sKadabraPose12
+.4byte sKadabraPose13
+.4byte sKadabraPose14
+.4byte sKadabraPose15
+.4byte sKadabraPose16
+.4byte sKadabraPose17
+.4byte sKadabraPose18
+.4byte sKadabraPose19
+.4byte sKadabraPose20
+.4byte sKadabraPose21
+.4byte sKadabraPose22
+.4byte sKadabraPose23
+.4byte sKadabraPose24
+.4byte sKadabraPose25
+.4byte sKadabraPose26
+.4byte sKadabraPose27
+.4byte sKadabraPose28
+.4byte sKadabraPose29
+.4byte sKadabraPose30
+.4byte sKadabraPose31
+.4byte sKadabraPose32
+.4byte sKadabraPose33
+.4byte sKadabraPose34
+.4byte sKadabraPose35
+.4byte sKadabraPose36
+.4byte sKadabraPose37
+.4byte sKadabraPose38
+.4byte sKadabraPose39
+.4byte sKadabraPose40
+.4byte sKadabraPose41
+.4byte sKadabraPose42
+.4byte sKadabraPose43
+.4byte sKadabraPose44
+.4byte sKadabraPose45
+.4byte sKadabraPose46
+.4byte sKadabraPose47
+.4byte sKadabraPose48
+.4byte sKadabraPose49
+.4byte sKadabraPose50
+.4byte sKadabraPose51
+.4byte sKadabraPose52
+.4byte sKadabraPose53
+.4byte sKadabraPose54
+.4byte sKadabraPose55
+.4byte sKadabraPose56
+.4byte sKadabraPose57
+.4byte sKadabraPose58
+.4byte sKadabraPose59
+.4byte sKadabraPose60
+.4byte sKadabraPose61
+.4byte sKadabraPose62
+.4byte sKadabraPose63
+.4byte sKadabraPose64
+.4byte sKadabraPose65
+.4byte sKadabraPose66
+.4byte sKadabraPose67
+.4byte sKadabraPose68
+.4byte sKadabraPose69
+.4byte sKadabraPose70
+.4byte sKadabraPose71
+.4byte sKadabraPose72
+.4byte sKadabraPose73
+.4byte sKadabraPose74
+.4byte sKadabraPose75
+.4byte sKadabraPose76
+.4byte sKadabraPose77
+.4byte sKadabraPose78
+.4byte sKadabraPose79
+.4byte sKadabraPose80
+.4byte sKadabraPose81
+.4byte sKadabraPose82
+.4byte sKadabraPose83
+.4byte sKadabraPose84
+.4byte sKadabraPose85
+.4byte sKadabraPose86
+.4byte sKadabraPose87
+.4byte sKadabraPose88
+.4byte sKadabraPose89
+.4byte sKadabraPose90
+.4byte sKadabraPose91
+.4byte sKadabraPose92
+.4byte sKadabraPose93
+.4byte sKadabraPose94
+.4byte sKadabraPose95
+.4byte sKadabraPose96
+.4byte sKadabraPose97
+.4byte sKadabraPose98
+.4byte sKadabraPose99
+.4byte sKadabraPose100
+.4byte sKadabraPose101
+.4byte sKadabraPose102
+.4byte sKadabraPose103
+.4byte sKadabraPose104
+.4byte sKadabraPose105
+.4byte sKadabraPose106
+.4byte sKadabraPose107
+.4byte sKadabraPose108
+.4byte sKadabraPose109
+.4byte sKadabraPose110
+.4byte sKadabraPose111
+.4byte sKadabraPose112
+.4byte sKadabraPose113
+.4byte sKadabraPose114
+.4byte sKadabraPose115
+.4byte sKadabraPose116
+.4byte sKadabraPose117
+.4byte sKadabraPose118
+.4byte sKadabraPose119
+.4byte sKadabraPose120
+.4byte sKadabraPose121
+.4byte sKadabraPose122
+.4byte sKadabraPose123
+.4byte sKadabraPose124
+.4byte sKadabraPose125
+.4byte sKadabraPose126
+.4byte sKadabraPose127
+.4byte sKadabraPose128
+.4byte sKadabraPose129
+.4byte sKadabraPose130
+.4byte sKadabraPose131
+.4byte sKadabraPose132
+.4byte sKadabraPose133
+.4byte sKadabraPose134
+.4byte sKadabraPose135
+.4byte sKadabraPose136
+.4byte sKadabraPose137
+.4byte sKadabraPose138
+.4byte sKadabraPose139
+.4byte sKadabraPose140
+.4byte sKadabraPose141
+.4byte sKadabraPose142
+.4byte sKadabraPose143
+.4byte sKadabraPose144
+.4byte sKadabraPose145
+.4byte sKadabraPose146
+.4byte sKadabraPose147
+.4byte sKadabraPose148
+.4byte sKadabraPose149
+.4byte sKadabraPose150
+.4byte sKadabraPose151
+.4byte sKadabraPose152
+.4byte sKadabraPose153
+.4byte sKadabraPose154
+.4byte sKadabraPose155
+.4byte sKadabraPose156
+.4byte sKadabraPose157
+.4byte sKadabraPose158
+.4byte sKadabraPose159
+.4byte sKadabraPose160
+.4byte sKadabraPose161
+.4byte sKadabraPose162
+.4byte sKadabraPose163
+.4byte sKadabraPose164
+.4byte sKadabraPose165
+.4byte sKadabraPose166
+.4byte sKadabraPose167
+.4byte sKadabraPose168
+.4byte sKadabraPose169
+.4byte sKadabraPose170
+.4byte sKadabraPose171
+.4byte sKadabraPose172
+.4byte sKadabraPose173
+.4byte sKadabraPose174
+.4byte sKadabraPose175
+.4byte sKadabraPose176
+.4byte sKadabraPose177
+.4byte sKadabraPose178
+.4byte sKadabraPose179
+.4byte sKadabraPose180
+.4byte sKadabraPose181
+.4byte sKadabraPose182
+.4byte sKadabraPose183
+.4byte sKadabraPose184
+.4byte sKadabraPose185
+.4byte sKadabraPose186
+.4byte sKadabraPose187
+.4byte sKadabraPose188
+.4byte sKadabraPose189
+.4byte sKadabraPose190
+.4byte sKadabraPose191
+.4byte sKadabraPose192
+.4byte sKadabraPose193
+.4byte sKadabraPose194
+sAxPositionsKadabra:
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   6,   -2, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -2, 	   8,   -5, 	   0,   -7
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+.2byte    3,   -7, 	  -1,   -1, 	   8,   -6, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -3, 	   9,   -4, 	   0,   -7
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    7,   -7, 	   2,   -2, 	   5,   -8, 	   1,   -7
+.2byte    7,   -7, 	  -1,   -2, 	   9,   -7, 	   0,   -7
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    4,   -9, 	  11,   -6, 	  -4,   -9, 	   1,   -7
+.2byte    4,   -9, 	   9,   -6, 	   0,  -12, 	   1,   -7
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    2,  -11, 	   8,   -8, 	  -8,  -11, 	   1,   -8
+.2byte   -1,  -11, 	   8,  -11, 	  -8,   -8, 	   0,   -8
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   4,  -10, 	 -11,   -6, 	   0,   -8
+.2byte   -4,  -11, 	   0,  -12, 	  -9,   -6, 	   0,   -8
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -7,   -8, 	  -7,   -9, 	  -2,   -2, 	   0,   -8
+.2byte   -7,   -8, 	  -9,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -3,   -6, 	  -8,   -6, 	   1,   -1, 	   0,   -7
+.2byte   -3,   -6, 	  -9,   -4, 	   4,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   6,   -2, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -2, 	   8,   -5, 	   0,   -7
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+.2byte    3,   -7, 	  -1,   -1, 	   8,   -6, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -3, 	   9,   -4, 	   0,   -7
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    7,   -7, 	   2,   -2, 	   5,   -8, 	   1,   -7
+.2byte    7,   -7, 	  -1,   -2, 	   9,   -7, 	   0,   -7
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    4,   -9, 	  11,   -6, 	  -4,   -9, 	   1,   -7
+.2byte    4,   -9, 	   9,   -6, 	   0,  -12, 	   1,   -7
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    2,  -11, 	   8,   -8, 	  -8,  -11, 	   1,   -8
+.2byte   -1,  -11, 	   8,  -11, 	  -8,   -8, 	   0,   -8
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   4,  -10, 	 -11,   -6, 	   0,   -8
+.2byte   -4,  -11, 	   0,  -12, 	  -9,   -6, 	   0,   -8
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -7,   -8, 	  -7,   -9, 	  -2,   -2, 	   0,   -8
+.2byte   -7,   -8, 	  -9,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -3,   -6, 	  -8,   -6, 	   1,   -1, 	   0,   -7
+.2byte   -3,   -6, 	  -9,   -4, 	   4,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -5, 	   6,   -2, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -2, 	   8,   -5, 	   0,   -7
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+.2byte    3,   -7, 	  -1,   -1, 	   8,   -6, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -3, 	   9,   -4, 	   0,   -7
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    7,   -7, 	   2,   -2, 	   5,   -8, 	   1,   -7
+.2byte    7,   -7, 	  -1,   -2, 	   9,   -7, 	   0,   -7
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    4,   -9, 	  11,   -6, 	  -4,   -9, 	   1,   -7
+.2byte    4,   -9, 	   9,   -6, 	   0,  -12, 	   1,   -7
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    2,  -11, 	   8,   -8, 	  -8,  -11, 	   1,   -8
+.2byte   -1,  -11, 	   8,  -11, 	  -8,   -8, 	   0,   -8
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   4,  -10, 	 -11,   -6, 	   0,   -8
+.2byte   -4,  -11, 	   0,  -12, 	  -9,   -6, 	   0,   -8
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -7,   -8, 	  -7,   -9, 	  -2,   -2, 	   0,   -8
+.2byte   -7,   -8, 	  -9,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -3,   -6, 	  -8,   -6, 	   1,   -1, 	   0,   -7
+.2byte   -3,   -6, 	  -9,   -4, 	   4,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte    0,   -8, 	 -11,   -5, 	  11,   -5, 	   0,  -10
+.2byte    0,   -2, 	  -8,   -1, 	   9,   -2, 	   0,   -9
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+.2byte    2,   -9, 	 -10,   -4, 	  10,   -8, 	  -1,   -9
+.2byte    3,   -5, 	  -2,   -2, 	  13,   -5, 	   1,   -8
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    6,  -10, 	  -4,   -2, 	   4,   -8, 	  -1,   -8
+.2byte    8,   -5, 	   8,   -4, 	  11,   -7, 	   3,   -6
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    5,  -12, 	  10,   -4, 	  -9,   -9, 	   1,   -8
+.2byte    6,   -7, 	  13,   -8, 	   2,  -13, 	   2,   -7
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    0,  -14, 	  11,   -9, 	 -11,   -9, 	   0,  -10
+.2byte    0,  -10, 	  10,  -14, 	  -9,  -13, 	   0,   -8
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   8,   -9, 	 -11,   -3, 	   0,  -10
+.2byte   -6,   -7, 	  -3,  -12, 	 -14,   -7, 	  -2,  -10
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -6,  -10, 	  -5,  -10, 	   4,   -2, 	   0,   -9
+.2byte   -8,   -4, 	 -12,   -8, 	  -7,   -3, 	  -2,   -8
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -2,   -9, 	 -10,   -8, 	  10,   -3, 	   1,  -10
+.2byte   -2,   -5, 	 -13,   -6, 	   2,   -2, 	   0,   -9
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte    0,   -8, 	 -11,   -5, 	  11,   -5, 	   0,  -10
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+.2byte    2,   -9, 	 -10,   -4, 	  10,   -8, 	  -1,   -9
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    6,  -10, 	  -4,   -2, 	   4,   -8, 	  -1,   -8
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    5,  -12, 	  10,   -4, 	  -9,   -9, 	   1,   -8
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    0,  -14, 	  11,   -9, 	 -11,   -9, 	   0,  -10
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   8,   -9, 	 -11,   -3, 	   0,  -10
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -6,  -10, 	  -5,  -10, 	   4,   -2, 	   0,   -9
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -2,   -9, 	 -10,   -8, 	  10,   -3, 	   1,  -10
+.2byte   -2,   -6, 	  -8,   -3, 	   5,   -1, 	   1,   -5
+.2byte   -3,   -5, 	  -8,   -2, 	   5,    0, 	   1,   -4
+.2byte    0,  -20, 	 -12,  -20, 	  12,  -20, 	   0,  -11
+.2byte   -3,  -20, 	   4,  -24, 	 -16,  -16, 	  -2,  -11
+.2byte   -2,  -21, 	   3,  -23, 	 -10,  -18, 	  -1,  -13
+.2byte   -1,  -20, 	 -12,  -23, 	   8,  -19, 	  -1,  -14
+.2byte    0,  -23, 	  12,  -22, 	 -12,  -22, 	   0,  -13
+.2byte    0,  -20, 	  11,  -23, 	  -9,  -19, 	   0,  -14
+.2byte    1,  -21, 	  -4,  -23, 	   9,  -18, 	   0,  -13
+.2byte    2,  -20, 	  -5,  -24, 	  15,  -16, 	   1,  -11
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte    0,   -8, 	 -11,   -5, 	  11,   -5, 	   0,  -10
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+.2byte    2,   -9, 	 -10,   -4, 	  10,   -8, 	  -1,   -9
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    6,  -10, 	  -4,   -2, 	   4,   -8, 	  -1,   -8
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    5,  -12, 	  10,   -4, 	  -9,   -9, 	   1,   -8
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    0,  -14, 	  11,   -9, 	 -11,   -9, 	   0,  -10
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   8,   -9, 	 -11,   -3, 	   0,  -10
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -6,  -10, 	  -5,  -10, 	   4,   -2, 	   0,   -9
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -2,   -9, 	 -10,   -8, 	  10,   -3, 	   1,  -10
+.2byte    0,   -2, 	  -8,   -1, 	   9,   -2, 	   0,   -9
+.2byte   -2,   -5, 	 -13,   -6, 	   2,   -2, 	   0,   -9
+.2byte   -6,   -4, 	 -10,   -8, 	  -5,   -3, 	   0,   -8
+.2byte   -4,   -7, 	  -1,  -12, 	 -12,   -7, 	   0,  -10
+.2byte    0,  -10, 	  10,  -14, 	  -9,  -13, 	   0,   -8
+.2byte    4,   -7, 	  11,   -8, 	   0,  -13, 	   0,   -7
+.2byte    6,   -5, 	   6,   -4, 	   9,   -7, 	   1,   -6
+.2byte    3,   -5, 	  -2,   -2, 	  13,   -5, 	   1,   -8
+.2byte    0,   -8, 	 -11,   -5, 	  11,   -5, 	   0,  -10
+.2byte    2,   -9, 	 -10,   -4, 	  10,   -8, 	  -1,   -9
+.2byte    6,  -10, 	  -4,   -2, 	   4,   -8, 	  -1,   -8
+.2byte    5,  -12, 	  10,   -4, 	  -9,   -9, 	   1,   -8
+.2byte    0,  -14, 	  11,   -9, 	 -11,   -9, 	   0,  -10
+.2byte   -4,  -11, 	   8,   -9, 	 -11,   -3, 	   0,  -10
+.2byte   -6,  -10, 	  -5,  -10, 	   4,   -2, 	   0,   -9
+.2byte   -2,   -9, 	 -10,   -8, 	  10,   -3, 	   1,  -10
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte    0,   -8, 	 -11,   -5, 	  11,   -5, 	   0,  -10
+.2byte    0,   -2, 	  -8,   -1, 	   9,   -2, 	   0,   -9
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+.2byte    2,   -9, 	 -10,   -4, 	  10,   -8, 	  -1,   -9
+.2byte    3,   -5, 	  -2,   -2, 	  13,   -5, 	   1,   -8
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    6,  -10, 	  -4,   -2, 	   4,   -8, 	  -1,   -8
+.2byte    7,   -5, 	   7,   -4, 	  10,   -7, 	   2,   -6
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    5,  -12, 	  10,   -4, 	  -9,   -9, 	   1,   -8
+.2byte    4,   -7, 	  11,   -8, 	   0,  -13, 	   0,   -7
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    0,  -14, 	  11,   -9, 	 -11,   -9, 	   0,  -10
+.2byte    0,  -10, 	  10,  -14, 	  -9,  -13, 	   0,   -8
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   8,   -9, 	 -11,   -3, 	   0,  -10
+.2byte   -4,   -7, 	  -1,  -12, 	 -12,   -7, 	   0,  -10
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -6,  -10, 	  -5,  -10, 	   4,   -2, 	   0,   -9
+.2byte   -7,   -4, 	 -11,   -8, 	  -6,   -3, 	  -1,   -8
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -2,   -9, 	 -10,   -8, 	  10,   -3, 	   1,  -10
+.2byte   -2,   -5, 	 -13,   -6, 	   2,   -2, 	   0,   -9
+.2byte    0,   -2, 	  -8,   -1, 	   9,   -2, 	   0,   -9
+.2byte   -2,   -5, 	 -13,   -6, 	   2,   -2, 	   0,   -9
+.2byte   -6,   -4, 	 -10,   -8, 	  -5,   -3, 	   0,   -8
+.2byte   -4,   -7, 	  -1,  -12, 	 -12,   -7, 	   0,  -10
+.2byte    0,  -10, 	  10,  -14, 	  -9,  -13, 	   0,   -8
+.2byte    4,   -7, 	  11,   -8, 	   0,  -13, 	   0,   -7
+.2byte    6,   -5, 	   6,   -4, 	   9,   -7, 	   1,   -6
+.2byte    3,   -5, 	  -2,   -2, 	  13,   -5, 	   1,   -8
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -8
+.2byte   -3,   -7, 	  -9,   -6, 	   3,   -3, 	   0,   -8
+.2byte   -7,   -9, 	  -8,  -10, 	   0,   -3, 	   0,   -9
+.2byte   -4,  -12, 	   3,  -12, 	 -10,   -7, 	   0,   -9
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    4,  -10, 	  10,   -7, 	  -3,  -12, 	   1,   -8
+.2byte    7,   -8, 	   0,   -3, 	   8,   -8, 	   1,   -8
+.2byte    3,   -8, 	  -3,   -3, 	   9,   -6, 	   0,   -8
+sKadabraAnimTable1:
+.4byte sKadabraAnims_1_1
+.4byte sKadabraAnims_1_2
+.4byte sKadabraAnims_1_3
+.4byte sKadabraAnims_1_4
+.4byte sKadabraAnims_1_5
+.4byte sKadabraAnims_1_6
+.4byte sKadabraAnims_1_7
+.4byte sKadabraAnims_1_8
+sKadabraAnimTable2:
+.4byte sKadabraAnims_2_1
+.4byte sKadabraAnims_2_2
+.4byte sKadabraAnims_2_3
+.4byte sKadabraAnims_2_4
+.4byte sKadabraAnims_2_5
+.4byte sKadabraAnims_2_6
+.4byte sKadabraAnims_2_7
+.4byte sKadabraAnims_2_8
+sKadabraAnimTable3:
+.4byte sKadabraAnims_3_1
+.4byte sKadabraAnims_3_2
+.4byte sKadabraAnims_3_3
+.4byte sKadabraAnims_3_4
+.4byte sKadabraAnims_3_5
+.4byte sKadabraAnims_3_6
+.4byte sKadabraAnims_3_7
+.4byte sKadabraAnims_3_8
+sKadabraAnimTable4:
+.4byte sKadabraAnims_4_1
+.4byte sKadabraAnims_4_2
+.4byte sKadabraAnims_4_3
+.4byte sKadabraAnims_4_4
+.4byte sKadabraAnims_4_5
+.4byte sKadabraAnims_4_6
+.4byte sKadabraAnims_4_7
+.4byte sKadabraAnims_4_8
+sKadabraAnimTable5:
+.4byte sKadabraAnims_5_1
+.4byte sKadabraAnims_5_2
+.4byte sKadabraAnims_5_3
+.4byte sKadabraAnims_5_4
+.4byte sKadabraAnims_5_5
+.4byte sKadabraAnims_5_6
+.4byte sKadabraAnims_5_7
+.4byte sKadabraAnims_5_8
+sKadabraAnimTable6:
+.4byte sKadabraAnims_6_1
+.4byte sKadabraAnims_6_1
+.4byte sKadabraAnims_6_1
+.4byte sKadabraAnims_6_1
+.4byte sKadabraAnims_6_1
+.4byte sKadabraAnims_6_1
+.4byte sKadabraAnims_6_1
+.4byte sKadabraAnims_6_1
+sKadabraAnimTable7:
+.4byte sKadabraAnims_7_1
+.4byte sKadabraAnims_7_2
+.4byte sKadabraAnims_7_3
+.4byte sKadabraAnims_7_4
+.4byte sKadabraAnims_7_5
+.4byte sKadabraAnims_7_6
+.4byte sKadabraAnims_7_7
+.4byte sKadabraAnims_7_8
+sKadabraAnimTable8:
+.4byte sKadabraAnims_8_1
+.4byte sKadabraAnims_8_2
+.4byte sKadabraAnims_8_3
+.4byte sKadabraAnims_8_4
+.4byte sKadabraAnims_8_5
+.4byte sKadabraAnims_8_6
+.4byte sKadabraAnims_8_7
+.4byte sKadabraAnims_8_8
+sKadabraAnimTable9:
+.4byte sKadabraAnims_9_1
+.4byte sKadabraAnims_9_2
+.4byte sKadabraAnims_9_3
+.4byte sKadabraAnims_9_4
+.4byte sKadabraAnims_9_5
+.4byte sKadabraAnims_9_6
+.4byte sKadabraAnims_9_7
+.4byte sKadabraAnims_9_8
+sKadabraAnimTable10:
+.4byte sKadabraAnims_10_1
+.4byte sKadabraAnims_10_2
+.4byte sKadabraAnims_10_3
+.4byte sKadabraAnims_10_4
+.4byte sKadabraAnims_10_5
+.4byte sKadabraAnims_10_6
+.4byte sKadabraAnims_10_7
+.4byte sKadabraAnims_10_8
+sKadabraAnimTable11:
+.4byte sKadabraAnims_11_1
+.4byte sKadabraAnims_11_2
+.4byte sKadabraAnims_11_3
+.4byte sKadabraAnims_11_4
+.4byte sKadabraAnims_11_5
+.4byte sKadabraAnims_11_6
+.4byte sKadabraAnims_11_7
+.4byte sKadabraAnims_11_8
+sKadabraAnimTable12:
+.4byte sKadabraAnims_12_1
+.4byte sKadabraAnims_12_2
+.4byte sKadabraAnims_12_3
+.4byte sKadabraAnims_12_4
+.4byte sKadabraAnims_12_5
+.4byte sKadabraAnims_12_6
+.4byte sKadabraAnims_12_7
+.4byte sKadabraAnims_12_8
+sKadabraAnimTable13:
+.4byte sKadabraAnims_13_1
+.4byte sKadabraAnims_13_2
+.4byte sKadabraAnims_13_3
+.4byte sKadabraAnims_13_4
+.4byte sKadabraAnims_13_5
+.4byte sKadabraAnims_13_6
+.4byte sKadabraAnims_13_7
+.4byte sKadabraAnims_13_8
+sAxAnimationsKadabra:
+.4byte sKadabraAnimTable1
+.4byte sKadabraAnimTable2
+.4byte sKadabraAnimTable3
+.4byte sKadabraAnimTable4
+.4byte sKadabraAnimTable5
+.4byte sKadabraAnimTable6
+.4byte sKadabraAnimTable7
+.4byte sKadabraAnimTable8
+.4byte sKadabraAnimTable9
+.4byte sKadabraAnimTable10
+.4byte sKadabraAnimTable11
+.4byte sKadabraAnimTable12
+.4byte sKadabraAnimTable13
+sAxSpritesKadabra:
+.4byte sKadabraSprites1
+.4byte sKadabraSprites2
+.4byte sKadabraSprites3
+.4byte sKadabraSprites4
+.4byte sKadabraSprites5
+.4byte sKadabraSprites6
+.4byte sKadabraSprites7
+.4byte sKadabraSprites8
+.4byte sKadabraSprites9
+.4byte sKadabraSprites10
+.4byte sKadabraSprites11
+.4byte sKadabraSprites12
+.4byte sKadabraSprites13
+.4byte sKadabraSprites14
+.4byte sKadabraSprites15
+.4byte sKadabraSprites16
+.4byte sKadabraSprites17
+.4byte sKadabraSprites18
+.4byte sKadabraSprites19
+.4byte sKadabraSprites20
+.4byte sKadabraSprites21
+.4byte sKadabraSprites22
+.4byte sKadabraSprites23
+.4byte sKadabraSprites24
+.4byte sKadabraSprites25
+.4byte sKadabraSprites26
+.4byte sKadabraSprites27
+.4byte sKadabraSprites28
+.4byte sKadabraSprites29
+.4byte sKadabraSprites30
+.4byte sKadabraSprites31
+.4byte sKadabraSprites32
+.4byte sKadabraSprites33
+.4byte sKadabraSprites34
+.4byte sKadabraSprites35
+.4byte sKadabraSprites36
+.4byte sKadabraSprites37
+.4byte sKadabraSprites38
+.4byte sKadabraSprites39
+.4byte sKadabraSprites40
+.4byte sKadabraSprites41
+.4byte sKadabraSprites42
+.4byte sKadabraSprites43
+.4byte sKadabraSprites44
+.4byte sKadabraSprites45
+.4byte sKadabraSprites46
+.4byte sKadabraSprites47
+sAxMainKadabra:
+ax_main sAxPosesKadabra, sAxAnimationsKadabra, 13, sAxSpritesKadabra, sAxPositionsKadabra

--- a/data/ax/kakuna.inc
+++ b/data/ax/kakuna.inc
@@ -1,0 +1,2777 @@
+.global gAxKakuna
+gAxKakuna:
+ax_siro sAxMainKakuna
+sKakunaPose1:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose2:
+ax_pose 1, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose3:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose4:
+ax_pose 3, 0x81e9, 0x90fa, 0x0c00
+ax_pose_terminator
+sKakunaPose5:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose6:
+ax_pose 5, 0x81e9, 0x90fa, 0x0c00
+ax_pose_terminator
+sKakunaPose7:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose8:
+ax_pose 7, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose9:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose10:
+ax_pose 9, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose11:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose12:
+ax_pose 7, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose13:
+ax_pose 4, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose14:
+ax_pose 5, 0x81e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sKakunaPose15:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose16:
+ax_pose 3, 0x81e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sKakunaPose17:
+ax_pose 10, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose18:
+ax_pose 11, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose19:
+ax_pose 12, 0x81eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKakunaPose20:
+ax_pose 13, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose21:
+ax_pose 11, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose22:
+ax_pose 14, 0x01e4, 0x80f0, 0x0c00
+ax_pose 11, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose23:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose24:
+ax_pose 15, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose25:
+ax_pose 16, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose26:
+ax_pose 17, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose27:
+ax_pose 18, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose28:
+ax_pose 16, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose29:
+ax_pose 19, 0x01e7, 0x90f1, 0x0c00
+ax_pose 16, 0x81ea, 0x90f9, 0x0c10
+ax_pose_terminator
+sKakunaPose30:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose31:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose32:
+ax_pose 21, 0x81eb, 0x90fc, 0x0c00
+ax_pose_terminator
+sKakunaPose33:
+ax_pose 22, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose34:
+ax_pose 23, 0x81eb, 0x90f3, 0x0c00
+ax_pose_terminator
+sKakunaPose35:
+ax_pose 21, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose36:
+ax_pose 24, 0x01e6, 0x90f0, 0x0c00
+ax_pose 21, 0x81eb, 0x90f8, 0x0c10
+ax_pose_terminator
+sKakunaPose37:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose38:
+ax_pose 25, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose39:
+ax_pose 26, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose40:
+ax_pose 27, 0x81eb, 0x90f5, 0x0c00
+ax_pose_terminator
+sKakunaPose41:
+ax_pose 28, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose42:
+ax_pose 26, 0x81eb, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose43:
+ax_pose 29, 0x01e7, 0x90f2, 0x0c00
+ax_pose 26, 0x81eb, 0x90f9, 0x0c10
+ax_pose_terminator
+sKakunaPose44:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose45:
+ax_pose 30, 0x81eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sKakunaPose46:
+ax_pose 31, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose47:
+ax_pose 32, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKakunaPose48:
+ax_pose 33, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose49:
+ax_pose 31, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose50:
+ax_pose 34, 0x01e7, 0x80f0, 0x0c00
+ax_pose 31, 0x81eb, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose51:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose52:
+ax_pose 25, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose53:
+ax_pose 26, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose54:
+ax_pose 27, 0x81eb, 0x80fb, 0x0c00
+ax_pose_terminator
+sKakunaPose55:
+ax_pose 28, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose56:
+ax_pose 26, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose57:
+ax_pose 29, 0x01e2, 0x80ed, 0x0c00
+ax_pose 26, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose58:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose59:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose60:
+ax_pose 21, 0x81eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKakunaPose61:
+ax_pose 22, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose62:
+ax_pose 23, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKakunaPose63:
+ax_pose 21, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose64:
+ax_pose 24, 0x01e4, 0x80eb, 0x0c00
+ax_pose 21, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose65:
+ax_pose 4, 0x81e9, 0x80f9, 0x0c00
+ax_pose_terminator
+sKakunaPose66:
+ax_pose 15, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose67:
+ax_pose 16, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose68:
+ax_pose 17, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose69:
+ax_pose 18, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose70:
+ax_pose 16, 0x81eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sKakunaPose71:
+ax_pose 19, 0x01e9, 0x80eb, 0x0c00
+ax_pose 16, 0x81eb, 0x80f6, 0x0c10
+ax_pose_terminator
+sKakunaPose72:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose73:
+ax_pose 10, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose74:
+ax_pose 11, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose75:
+ax_pose 12, 0x81eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKakunaPose76:
+ax_pose 13, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose77:
+ax_pose 11, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose78:
+ax_pose 14, 0x01e4, 0x80f0, 0x0c00
+ax_pose 11, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose79:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose80:
+ax_pose 15, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose81:
+ax_pose 16, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose82:
+ax_pose 17, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose83:
+ax_pose 18, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose84:
+ax_pose 16, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose85:
+ax_pose 19, 0x01e7, 0x90f1, 0x0c00
+ax_pose 16, 0x81ea, 0x90f9, 0x0c10
+ax_pose_terminator
+sKakunaPose86:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose87:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose88:
+ax_pose 21, 0x81eb, 0x90fc, 0x0c00
+ax_pose_terminator
+sKakunaPose89:
+ax_pose 22, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose90:
+ax_pose 23, 0x81eb, 0x90f3, 0x0c00
+ax_pose_terminator
+sKakunaPose91:
+ax_pose 21, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose92:
+ax_pose 24, 0x01e6, 0x90f0, 0x0c00
+ax_pose 21, 0x81eb, 0x90f8, 0x0c10
+ax_pose_terminator
+sKakunaPose93:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose94:
+ax_pose 25, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose95:
+ax_pose 26, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sKakunaPose96:
+ax_pose 27, 0x81eb, 0x90f5, 0x0c00
+ax_pose_terminator
+sKakunaPose97:
+ax_pose 28, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose98:
+ax_pose 26, 0x81eb, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose99:
+ax_pose 29, 0x01e7, 0x90f2, 0x0c00
+ax_pose 26, 0x81eb, 0x90f9, 0x0c10
+ax_pose_terminator
+sKakunaPose100:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose101:
+ax_pose 30, 0x81eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sKakunaPose102:
+ax_pose 31, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose103:
+ax_pose 32, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKakunaPose104:
+ax_pose 33, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose105:
+ax_pose 31, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose106:
+ax_pose 34, 0x01e7, 0x80f0, 0x0c00
+ax_pose 31, 0x81eb, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose107:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose108:
+ax_pose 25, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose109:
+ax_pose 26, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose110:
+ax_pose 27, 0x81eb, 0x80fb, 0x0c00
+ax_pose_terminator
+sKakunaPose111:
+ax_pose 28, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose112:
+ax_pose 26, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose113:
+ax_pose 29, 0x01e2, 0x80ed, 0x0c00
+ax_pose 26, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose114:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose115:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose116:
+ax_pose 21, 0x81eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKakunaPose117:
+ax_pose 22, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose118:
+ax_pose 23, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKakunaPose119:
+ax_pose 21, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose120:
+ax_pose 24, 0x01e4, 0x80eb, 0x0c00
+ax_pose 21, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sKakunaPose121:
+ax_pose 4, 0x81e9, 0x80f9, 0x0c00
+ax_pose_terminator
+sKakunaPose122:
+ax_pose 15, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose123:
+ax_pose 16, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose124:
+ax_pose 17, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sKakunaPose125:
+ax_pose 18, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose126:
+ax_pose 16, 0x81eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sKakunaPose127:
+ax_pose 19, 0x01e9, 0x80eb, 0x0c00
+ax_pose 16, 0x81eb, 0x80f6, 0x0c10
+ax_pose_terminator
+sKakunaPose128:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose129:
+ax_pose 1, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose130:
+ax_pose 3, 0x81e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose131:
+ax_pose 5, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose132:
+ax_pose 7, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose133:
+ax_pose 9, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose134:
+ax_pose 7, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose135:
+ax_pose 5, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose136:
+ax_pose 3, 0x81e9, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose137:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose138:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose139:
+ax_pose 4, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose140:
+ax_pose 6, 0x81e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose141:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose142:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose143:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose144:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose145:
+ax_pose 1, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose146:
+ax_pose 3, 0x81e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose147:
+ax_pose 5, 0x81e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose148:
+ax_pose 7, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose149:
+ax_pose 9, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose150:
+ax_pose 7, 0x81e9, 0x90f7, 0x0c00
+ax_pose_terminator
+sKakunaPose151:
+ax_pose 5, 0x81e9, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose152:
+ax_pose 3, 0x81e9, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose153:
+ax_pose 35, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose154:
+ax_pose 36, 0x81e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose155:
+ax_pose 37, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKakunaPose156:
+ax_pose 38, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sKakunaPose157:
+ax_pose 39, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sKakunaPose158:
+ax_pose 40, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sKakunaPose159:
+ax_pose 41, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sKakunaPose160:
+ax_pose 40, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sKakunaPose161:
+ax_pose 39, 0x01e4, 0x80f3, 0x0c00
+ax_pose_terminator
+sKakunaPose162:
+ax_pose 38, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sKakunaPose163:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose164:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose165:
+ax_pose 4, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose166:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose167:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose168:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose169:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose170:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose171:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose172:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose173:
+ax_pose 4, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose174:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose175:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose176:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose177:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose178:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose179:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose180:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose181:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose182:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose183:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose184:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose185:
+ax_pose 4, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose186:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose187:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose188:
+ax_pose 13, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose189:
+ax_pose 1, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose190:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose191:
+ax_pose 18, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose192:
+ax_pose 3, 0x81e9, 0x90fa, 0x0c00
+ax_pose_terminator
+sKakunaPose193:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose194:
+ax_pose 23, 0x81eb, 0x90f3, 0x0c00
+ax_pose_terminator
+sKakunaPose195:
+ax_pose 5, 0x81e9, 0x90fa, 0x0c00
+ax_pose_terminator
+sKakunaPose196:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose197:
+ax_pose 28, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sKakunaPose198:
+ax_pose 7, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose199:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose200:
+ax_pose 33, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose201:
+ax_pose 9, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose202:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose203:
+ax_pose 28, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose204:
+ax_pose 7, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose205:
+ax_pose 4, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose206:
+ax_pose 23, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKakunaPose207:
+ax_pose 5, 0x81e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sKakunaPose208:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose209:
+ax_pose 18, 0x81eb, 0x80fc, 0x0c00
+ax_pose_terminator
+sKakunaPose210:
+ax_pose 3, 0x81e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sKakunaPose211:
+ax_pose 1, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose212:
+ax_pose 3, 0x81e9, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose213:
+ax_pose 5, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sKakunaPose214:
+ax_pose 7, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose215:
+ax_pose 9, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose216:
+ax_pose 7, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose217:
+ax_pose 5, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose218:
+ax_pose 3, 0x81e9, 0x90f9, 0x0c00
+ax_pose_terminator
+sKakunaPose219:
+ax_pose 0, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose220:
+ax_pose 2, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose221:
+ax_pose 4, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose222:
+ax_pose 6, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose223:
+ax_pose 8, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sKakunaPose224:
+ax_pose 6, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose225:
+ax_pose 4, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+sKakunaPose226:
+ax_pose 2, 0x81e9, 0x90f8, 0x0c00
+ax_pose_terminator
+.align 2
+sKakunaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_1_2:
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_1_3:
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_1_4:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_1_5:
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_1_6:
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_1_7:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_1_8:
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_2_1:
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, -1, 0, -1,
+ax_anim 6, 2, 19, 0, -2, 0, -2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 0, 21, 0, 8, 0, 8,
+ax_anim 1, 1, 21, 0, 21, 0, 21,
+ax_anim 2, 0, 20, 1, 21, 1, 21,
+ax_anim 2, 0, 20, 0, 21, 0, 21,
+ax_anim 2, 0, 20, 1, 21, 1, 21,
+ax_anim_terminator
+sKakunaAnims_2_2:
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 2, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 6, 6, 6, 6,
+ax_anim 1, 1, 28, 18, 19, 18, 19,
+ax_anim 2, 0, 27, 17, 20, 17, 20,
+ax_anim 2, 0, 27, 18, 19, 18, 19,
+ax_anim 2, 0, 27, 17, 20, 17, 20,
+ax_anim_terminator
+sKakunaAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 6, 2, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 3, 0, 3, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 1, 1, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 18, 1, 18, 1,
+ax_anim_terminator
+sKakunaAnims_2_4:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 6, 2, 40, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 2, -2, 2, -2,
+ax_anim 1, 0, 42, 11, -7, 11, -7,
+ax_anim 1, 1, 42, 18, -13, 18, -13,
+ax_anim 2, 0, 41, 19, -12, 19, -12,
+ax_anim 2, 0, 41, 18, -13, 18, -13,
+ax_anim 2, 0, 41, 19, -12, 19, -12,
+ax_anim_terminator
+sKakunaAnims_2_5:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 2, 0, 2,
+ax_anim 6, 2, 47, 0, 3, 0, 3,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, -3, 0, -3,
+ax_anim 1, 1, 49, 0, -12, 0, -12,
+ax_anim 2, 0, 48, 1, -12, 1, -12,
+ax_anim 2, 0, 48, 0, -12, 0, -12,
+ax_anim 2, 0, 48, 1, -12, 1, -12,
+ax_anim_terminator
+sKakunaAnims_2_6:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 1, 1, 1, 1,
+ax_anim 6, 2, 54, 2, 2, 2, 2,
+ax_anim 1, 0, 55, -3, -3, -3, -3,
+ax_anim 1, 0, 56, -11, -7, -11, -7,
+ax_anim 1, 1, 56, -18, -13, -18, -13,
+ax_anim 2, 0, 55, -19, -12, -19, -12,
+ax_anim 2, 0, 55, -18, -13, -18, -13,
+ax_anim 2, 0, 55, -19, -12, -19, -12,
+ax_anim_terminator
+sKakunaAnims_2_7:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 6, 2, 61, 2, 0, 2, 0,
+ax_anim 1, 0, 62, -3, 0, -3, 0,
+ax_anim 1, 0, 63, -10, 0, -10, 0,
+ax_anim 1, 1, 63, -18, 0, -18, 0,
+ax_anim 2, 0, 62, -18, 1, -18, 1,
+ax_anim 2, 0, 62, -18, 0, -18, 0,
+ax_anim 2, 0, 62, -18, 1, -18, 1,
+ax_anim_terminator
+sKakunaAnims_2_8:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 6, 2, 68, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 70, -8, 8, -8, 8,
+ax_anim 1, 1, 70, -18, 19, -18, 19,
+ax_anim 2, 0, 69, -17, 20, -17, 20,
+ax_anim 2, 0, 69, -18, 19, -18, 19,
+ax_anim 2, 0, 69, -17, 20, -17, 20,
+ax_anim_terminator
+.align 2
+sKakunaAnims_3_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 6, 2, 75, 0, -2, 0, -2,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, 8, 0, 8,
+ax_anim 1, 1, 77, 0, 21, 0, 21,
+ax_anim 2, 0, 76, 1, 21, 1, 21,
+ax_anim 2, 0, 76, 0, 21, 0, 21,
+ax_anim 2, 0, 76, 1, 21, 1, 21,
+ax_anim_terminator
+sKakunaAnims_3_2:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 6, 2, 82, -2, -2, -2, -2,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 6, 6, 6, 6,
+ax_anim 1, 1, 84, 18, 19, 18, 19,
+ax_anim 2, 0, 83, 17, 20, 17, 20,
+ax_anim 2, 0, 83, 18, 19, 18, 19,
+ax_anim 2, 0, 83, 17, 20, 17, 20,
+ax_anim_terminator
+sKakunaAnims_3_3:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 6, 2, 89, -2, 0, -2, 0,
+ax_anim 1, 0, 90, 3, 0, 3, 0,
+ax_anim 1, 0, 91, 10, 0, 10, 0,
+ax_anim 1, 1, 91, 18, 0, 18, 0,
+ax_anim 2, 0, 90, 18, 1, 18, 1,
+ax_anim 2, 0, 90, 18, 0, 18, 0,
+ax_anim 2, 0, 90, 18, 1, 18, 1,
+ax_anim_terminator
+sKakunaAnims_3_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 6, 2, 96, -2, 2, -2, 2,
+ax_anim 1, 0, 97, 2, -2, 2, -2,
+ax_anim 1, 0, 98, 11, -7, 11, -7,
+ax_anim 1, 1, 98, 18, -13, 18, -13,
+ax_anim 2, 0, 97, 19, -12, 19, -12,
+ax_anim 2, 0, 97, 18, -13, 18, -13,
+ax_anim 2, 0, 97, 19, -12, 19, -12,
+ax_anim_terminator
+sKakunaAnims_3_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 2, 0, 2,
+ax_anim 6, 2, 103, 0, 3, 0, 3,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -3, 0, -3,
+ax_anim 1, 1, 105, 0, -12, 0, -12,
+ax_anim 2, 0, 104, 1, -12, 1, -12,
+ax_anim 2, 0, 104, 0, -12, 0, -12,
+ax_anim 2, 0, 104, 1, -12, 1, -12,
+ax_anim_terminator
+sKakunaAnims_3_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 1, 1, 1,
+ax_anim 6, 2, 110, 2, 2, 2, 2,
+ax_anim 1, 0, 111, -3, -3, -3, -3,
+ax_anim 1, 0, 112, -11, -7, -11, -7,
+ax_anim 1, 1, 112, -18, -13, -18, -13,
+ax_anim 2, 0, 111, -19, -12, -19, -12,
+ax_anim 2, 0, 111, -18, -13, -18, -13,
+ax_anim 2, 0, 111, -19, -12, -19, -12,
+ax_anim_terminator
+sKakunaAnims_3_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 6, 2, 117, 2, 0, 2, 0,
+ax_anim 1, 0, 118, -3, 0, -3, 0,
+ax_anim 1, 0, 119, -10, 0, -10, 0,
+ax_anim 1, 1, 119, -18, 0, -18, 0,
+ax_anim 2, 0, 118, -18, 1, -18, 1,
+ax_anim 2, 0, 118, -18, 0, -18, 0,
+ax_anim 2, 0, 118, -18, 1, -18, 1,
+ax_anim_terminator
+sKakunaAnims_3_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 6, 2, 124, 2, -2, 2, -2,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, -8, 8, -8, 8,
+ax_anim 1, 1, 126, -18, 19, -18, 19,
+ax_anim 2, 0, 125, -17, 20, -17, 20,
+ax_anim 2, 0, 125, -18, 19, -18, 19,
+ax_anim 2, 0, 125, -17, 20, -17, 20,
+ax_anim_terminator
+.align 2
+sKakunaAnims_4_1:
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 1, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_4_2:
+ax_anim 2, 0, 135, 1, -1, 1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, 0,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_4_3:
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 1, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_4_4:
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 1, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_4_5:
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_4_6:
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 1, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_4_7:
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 1, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_4_8:
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_5_1:
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 2, 138, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 142, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_5_2:
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 136, 0, -6, 0, 0,
+ax_anim 1, 2, 137, 0, -7, 0, 0,
+ax_anim 1, 0, 138, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_5_3:
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 2, 136, 0, -7, 0, 0,
+ax_anim 1, 0, 137, 0, -7, 0, 0,
+ax_anim 1, 0, 138, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -4, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_5_4:
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -6, 0, 0,
+ax_anim 1, 2, 143, 0, -7, 0, 0,
+ax_anim 1, 0, 136, 0, -7, 0, 0,
+ax_anim 1, 0, 137, 0, -7, 0, 0,
+ax_anim 1, 0, 138, 0, -7, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 140, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -4, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_5_5:
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 2, 142, 0, -7, 0, 0,
+ax_anim 1, 0, 143, 0, -7, 0, 0,
+ax_anim 1, 0, 136, 0, -7, 0, 0,
+ax_anim 1, 0, 137, 0, -7, 0, 0,
+ax_anim 1, 0, 138, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 140, 0, -4, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_5_6:
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 140, 0, -6, 0, 0,
+ax_anim 1, 2, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 142, 0, -7, 0, 0,
+ax_anim 1, 0, 143, 0, -7, 0, 0,
+ax_anim 1, 0, 136, 0, -7, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -4, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -1, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -1, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_5_7:
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 2, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 142, 0, -7, 0, 0,
+ax_anim 1, 0, 143, 0, -7, 0, 0,
+ax_anim 1, 0, 136, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -4, 0, 0,
+ax_anim 1, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_5_8:
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -6, 0, 0,
+ax_anim 1, 2, 139, 0, -7, 0, 0,
+ax_anim 1, 0, 140, 0, -7, 0, 0,
+ax_anim 1, 0, 141, 0, -7, 0, 0,
+ax_anim 1, 0, 142, 0, -7, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 136, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -4, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sKakunaAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sKakunaAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sKakunaAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sKakunaAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sKakunaAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sKakunaAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sKakunaAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sKakunaAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -1, 0, 0,
+ax_anim 1, 0, 162, 0, -2, 0, 0,
+ax_anim 4, 0, 162, 0, -3, 0, 0,
+ax_anim 1, 0, 162, 0, -2, 0, 0,
+ax_anim 1, 0, 162, 0, -1, 0, 0,
+ax_anim_terminator
+sKakunaAnims_8_2:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -1, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim 4, 0, 169, 0, -3, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim 1, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+sKakunaAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -1, 0, 0,
+ax_anim 1, 0, 168, 0, -2, 0, 0,
+ax_anim 4, 0, 168, 0, -3, 0, 0,
+ax_anim 1, 0, 168, 0, -2, 0, 0,
+ax_anim 1, 0, 168, 0, -1, 0, 0,
+ax_anim_terminator
+sKakunaAnims_8_4:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -1, 0, 0,
+ax_anim 1, 0, 167, 0, -2, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 1, 0, 167, 0, -2, 0, 0,
+ax_anim 1, 0, 167, 0, -1, 0, 0,
+ax_anim_terminator
+sKakunaAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -1, 0, 0,
+ax_anim 1, 0, 166, 0, -2, 0, 0,
+ax_anim 4, 0, 166, 0, -3, 0, 0,
+ax_anim 1, 0, 166, 0, -2, 0, 0,
+ax_anim 1, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sKakunaAnims_8_6:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -1, 0, 0,
+ax_anim 1, 0, 165, 0, -2, 0, 0,
+ax_anim 4, 0, 165, 0, -3, 0, 0,
+ax_anim 1, 0, 165, 0, -2, 0, 0,
+ax_anim 1, 0, 165, 0, -1, 0, 0,
+ax_anim_terminator
+sKakunaAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -1, 0, 0,
+ax_anim 1, 0, 164, 0, -2, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim 1, 0, 164, 0, -2, 0, 0,
+ax_anim 1, 0, 164, 0, -1, 0, 0,
+ax_anim_terminator
+sKakunaAnims_8_8:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -1, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim 4, 0, 163, 0, -3, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim 1, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 19, 7, 19,
+ax_anim 3, 0, 174, 1, 24, 1, 24,
+ax_anim 2, 3, 175, -6, 19, -6, 19,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 24, 9, 24, 9,
+ax_anim 3, 0, 173, 23, 21, 23, 21,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 2, 12, 2, 12,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 20, 1, 20, 1,
+ax_anim 2, 3, 173, 17, 5, 17, 5,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -20, 11, -20,
+ax_anim 3, 0, 171, 16, -20, 16, -20,
+ax_anim 2, 3, 172, 18, -12, 18, -12,
+ax_anim 2, 0, 173, 16, -6, 16, -6,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -6, -4, -6, -4,
+ax_anim 2, 0, 176, -8, -10, -8, -9,
+ax_anim 2, 0, 177, -7, -18, -7, -15,
+ax_anim 3, 0, 170, -1, -22, -1, -18,
+ax_anim 2, 3, 171, 4, -19, 4, -16,
+ax_anim 2, 0, 172, 5, -9, 5, -8,
+ax_anim 1, 0, 173, 4, -4, 4, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -20, -11, -20,
+ax_anim 3, 0, 177, -16, -20, -16, -20,
+ax_anim 2, 3, 176, -18, -12, -18, -12,
+ax_anim 2, 0, 175, -16, -6, -16, -6,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -20, 1, -20, 1,
+ax_anim 2, 3, 175, -17, 5, -17, 5,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -24, 9, -24, 9,
+ax_anim 3, 0, 175, -23, 21, -23, 16,
+ax_anim 2, 3, 174, -11, 21, -11, 16,
+ax_anim 2, 0, 173, -2, 12, -4, 12,
+ax_anim 1, 0, 172, 0, 7, -3, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKakunaAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sKakunaGfx1:
+.incbin "baserom.gba", 0x5AAB00, 0x100
+sKakunaSprites1:
+ax_sprite sKakunaGfx1, 0x100
+ax_sprite_terminator
+sKakunaGfx2:
+.incbin "baserom.gba", 0x5AAC10, 0x100
+sKakunaSprites2:
+ax_sprite sKakunaGfx2, 0x100
+ax_sprite_terminator
+sKakunaGfx3:
+.incbin "baserom.gba", 0x5AAD20, 0x100
+sKakunaSprites3:
+ax_sprite sKakunaGfx3, 0x100
+ax_sprite_terminator
+sKakunaGfx4:
+.incbin "baserom.gba", 0x5AAE30, 0x100
+sKakunaSprites4:
+ax_sprite sKakunaGfx4, 0x100
+ax_sprite_terminator
+sKakunaGfx5:
+.incbin "baserom.gba", 0x5AAF40, 0x100
+sKakunaSprites5:
+ax_sprite sKakunaGfx5, 0x100
+ax_sprite_terminator
+sKakunaGfx6:
+.incbin "baserom.gba", 0x5AB050, 0x100
+sKakunaSprites6:
+ax_sprite sKakunaGfx6, 0x100
+ax_sprite_terminator
+sKakunaGfx7:
+.incbin "baserom.gba", 0x5AB160, 0x100
+sKakunaSprites7:
+ax_sprite sKakunaGfx7, 0x100
+ax_sprite_terminator
+sKakunaGfx8:
+.incbin "baserom.gba", 0x5AB270, 0x100
+sKakunaSprites8:
+ax_sprite sKakunaGfx8, 0x100
+ax_sprite_terminator
+sKakunaGfx9:
+.incbin "baserom.gba", 0x5AB380, 0x100
+sKakunaSprites9:
+ax_sprite sKakunaGfx9, 0x100
+ax_sprite_terminator
+sKakunaGfx10:
+.incbin "baserom.gba", 0x5AB490, 0x100
+sKakunaSprites10:
+ax_sprite sKakunaGfx10, 0x100
+ax_sprite_terminator
+sKakunaGfx11:
+.incbin "baserom.gba", 0x5AB5A0, 0xC0
+sKakunaSprites11:
+ax_sprite sKakunaGfx11, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx12:
+.incbin "baserom.gba", 0x5AB678, 0xC0
+sKakunaSprites12:
+ax_sprite sKakunaGfx12, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx13:
+.incbin "baserom.gba", 0x5AB750, 0xC0
+sKakunaSprites13:
+ax_sprite sKakunaGfx13, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx14:
+.incbin "baserom.gba", 0x5AB828, 0xC0
+sKakunaSprites14:
+ax_sprite sKakunaGfx14, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx15:
+.incbin "baserom.gba", 0x5AB900, 0x180
+sKakunaGfx15_1:
+.incbin "baserom.gba", 0x5ABA80, 0x40
+sKakunaSprites15:
+ax_sprite sKakunaGfx15, 0x180
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx15_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKakunaGfx16:
+.incbin "baserom.gba", 0x5ABAE8, 0xC0
+sKakunaSprites16:
+ax_sprite sKakunaGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx17:
+.incbin "baserom.gba", 0x5ABBC0, 0xC0
+sKakunaSprites17:
+ax_sprite sKakunaGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx18:
+.incbin "baserom.gba", 0x5ABC98, 0xC0
+sKakunaSprites18:
+ax_sprite sKakunaGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx19:
+.incbin "baserom.gba", 0x5ABD70, 0xC0
+sKakunaSprites19:
+ax_sprite sKakunaGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx20:
+.incbin "baserom.gba", 0x5ABE48, 0x160
+sKakunaGfx20_1:
+.incbin "baserom.gba", 0x5ABFA8, 0x40
+sKakunaSprites20:
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx20, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKakunaGfx21:
+.incbin "baserom.gba", 0x5AC018, 0xC0
+sKakunaSprites21:
+ax_sprite sKakunaGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx22:
+.incbin "baserom.gba", 0x5AC0F0, 0xC0
+sKakunaSprites22:
+ax_sprite sKakunaGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx23:
+.incbin "baserom.gba", 0x5AC1C8, 0xC0
+sKakunaSprites23:
+ax_sprite sKakunaGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx24:
+.incbin "baserom.gba", 0x5AC2A0, 0xC0
+sKakunaSprites24:
+ax_sprite sKakunaGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx25:
+.incbin "baserom.gba", 0x5AC378, 0x160
+sKakunaGfx25_1:
+.incbin "baserom.gba", 0x5AC4D8, 0x60
+sKakunaSprites25:
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx25, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx25_1, 0x60
+ax_sprite_terminator
+sKakunaGfx26:
+.incbin "baserom.gba", 0x5AC560, 0xC0
+sKakunaSprites26:
+ax_sprite sKakunaGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx27:
+.incbin "baserom.gba", 0x5AC638, 0xC0
+sKakunaSprites27:
+ax_sprite sKakunaGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx28:
+.incbin "baserom.gba", 0x5AC710, 0xC0
+sKakunaSprites28:
+ax_sprite sKakunaGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx29:
+.incbin "baserom.gba", 0x5AC7E8, 0xC0
+sKakunaSprites29:
+ax_sprite sKakunaGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx30:
+.incbin "baserom.gba", 0x5AC8C0, 0xE0
+sKakunaGfx30_1:
+.incbin "baserom.gba", 0x5AC9A0, 0x60
+sKakunaGfx30_2:
+.incbin "baserom.gba", 0x5ACA00, 0x60
+sKakunaSprites30:
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx30, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx30_2, 0x60
+ax_sprite_terminator
+sKakunaGfx31:
+.incbin "baserom.gba", 0x5ACA98, 0xC0
+sKakunaSprites31:
+ax_sprite sKakunaGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx32:
+.incbin "baserom.gba", 0x5ACB70, 0xC0
+sKakunaSprites32:
+ax_sprite sKakunaGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx33:
+.incbin "baserom.gba", 0x5ACC48, 0xC0
+sKakunaSprites33:
+ax_sprite sKakunaGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx34:
+.incbin "baserom.gba", 0x5ACD20, 0xC0
+sKakunaSprites34:
+ax_sprite sKakunaGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKakunaGfx35:
+.incbin "baserom.gba", 0x5ACDF8, 0x40
+sKakunaGfx35_1:
+.incbin "baserom.gba", 0x5ACE38, 0x100
+sKakunaGfx35_2:
+.incbin "baserom.gba", 0x5ACF38, 0x40
+sKakunaSprites35:
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKakunaGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKakunaGfx36:
+.incbin "baserom.gba", 0x5ACFB8, 0x100
+sKakunaSprites36:
+ax_sprite sKakunaGfx36, 0x100
+ax_sprite_terminator
+sKakunaGfx37:
+.incbin "baserom.gba", 0x5AD0C8, 0x100
+sKakunaSprites37:
+ax_sprite sKakunaGfx37, 0x100
+ax_sprite_terminator
+sKakunaGfx38:
+.incbin "baserom.gba", 0x5AD1D8, 0x200
+sKakunaSprites38:
+ax_sprite sKakunaGfx38, 0x200
+ax_sprite_terminator
+sKakunaGfx39:
+.incbin "baserom.gba", 0x5AD3E8, 0x200
+sKakunaSprites39:
+ax_sprite sKakunaGfx39, 0x200
+ax_sprite_terminator
+sKakunaGfx40:
+.incbin "baserom.gba", 0x5AD5F8, 0x200
+sKakunaSprites40:
+ax_sprite sKakunaGfx40, 0x200
+ax_sprite_terminator
+sKakunaGfx41:
+.incbin "baserom.gba", 0x5AD808, 0x200
+sKakunaSprites41:
+ax_sprite sKakunaGfx41, 0x200
+ax_sprite_terminator
+sKakunaGfx42:
+.incbin "baserom.gba", 0x5ADA18, 0x200
+sKakunaSprites42:
+ax_sprite sKakunaGfx42, 0x200
+ax_sprite_terminator
+sAxPosesKakuna:
+.4byte sKakunaPose1
+.4byte sKakunaPose2
+.4byte sKakunaPose3
+.4byte sKakunaPose4
+.4byte sKakunaPose5
+.4byte sKakunaPose6
+.4byte sKakunaPose7
+.4byte sKakunaPose8
+.4byte sKakunaPose9
+.4byte sKakunaPose10
+.4byte sKakunaPose11
+.4byte sKakunaPose12
+.4byte sKakunaPose13
+.4byte sKakunaPose14
+.4byte sKakunaPose15
+.4byte sKakunaPose16
+.4byte sKakunaPose17
+.4byte sKakunaPose18
+.4byte sKakunaPose19
+.4byte sKakunaPose20
+.4byte sKakunaPose21
+.4byte sKakunaPose22
+.4byte sKakunaPose23
+.4byte sKakunaPose24
+.4byte sKakunaPose25
+.4byte sKakunaPose26
+.4byte sKakunaPose27
+.4byte sKakunaPose28
+.4byte sKakunaPose29
+.4byte sKakunaPose30
+.4byte sKakunaPose31
+.4byte sKakunaPose32
+.4byte sKakunaPose33
+.4byte sKakunaPose34
+.4byte sKakunaPose35
+.4byte sKakunaPose36
+.4byte sKakunaPose37
+.4byte sKakunaPose38
+.4byte sKakunaPose39
+.4byte sKakunaPose40
+.4byte sKakunaPose41
+.4byte sKakunaPose42
+.4byte sKakunaPose43
+.4byte sKakunaPose44
+.4byte sKakunaPose45
+.4byte sKakunaPose46
+.4byte sKakunaPose47
+.4byte sKakunaPose48
+.4byte sKakunaPose49
+.4byte sKakunaPose50
+.4byte sKakunaPose51
+.4byte sKakunaPose52
+.4byte sKakunaPose53
+.4byte sKakunaPose54
+.4byte sKakunaPose55
+.4byte sKakunaPose56
+.4byte sKakunaPose57
+.4byte sKakunaPose58
+.4byte sKakunaPose59
+.4byte sKakunaPose60
+.4byte sKakunaPose61
+.4byte sKakunaPose62
+.4byte sKakunaPose63
+.4byte sKakunaPose64
+.4byte sKakunaPose65
+.4byte sKakunaPose66
+.4byte sKakunaPose67
+.4byte sKakunaPose68
+.4byte sKakunaPose69
+.4byte sKakunaPose70
+.4byte sKakunaPose71
+.4byte sKakunaPose72
+.4byte sKakunaPose73
+.4byte sKakunaPose74
+.4byte sKakunaPose75
+.4byte sKakunaPose76
+.4byte sKakunaPose77
+.4byte sKakunaPose78
+.4byte sKakunaPose79
+.4byte sKakunaPose80
+.4byte sKakunaPose81
+.4byte sKakunaPose82
+.4byte sKakunaPose83
+.4byte sKakunaPose84
+.4byte sKakunaPose85
+.4byte sKakunaPose86
+.4byte sKakunaPose87
+.4byte sKakunaPose88
+.4byte sKakunaPose89
+.4byte sKakunaPose90
+.4byte sKakunaPose91
+.4byte sKakunaPose92
+.4byte sKakunaPose93
+.4byte sKakunaPose94
+.4byte sKakunaPose95
+.4byte sKakunaPose96
+.4byte sKakunaPose97
+.4byte sKakunaPose98
+.4byte sKakunaPose99
+.4byte sKakunaPose100
+.4byte sKakunaPose101
+.4byte sKakunaPose102
+.4byte sKakunaPose103
+.4byte sKakunaPose104
+.4byte sKakunaPose105
+.4byte sKakunaPose106
+.4byte sKakunaPose107
+.4byte sKakunaPose108
+.4byte sKakunaPose109
+.4byte sKakunaPose110
+.4byte sKakunaPose111
+.4byte sKakunaPose112
+.4byte sKakunaPose113
+.4byte sKakunaPose114
+.4byte sKakunaPose115
+.4byte sKakunaPose116
+.4byte sKakunaPose117
+.4byte sKakunaPose118
+.4byte sKakunaPose119
+.4byte sKakunaPose120
+.4byte sKakunaPose121
+.4byte sKakunaPose122
+.4byte sKakunaPose123
+.4byte sKakunaPose124
+.4byte sKakunaPose125
+.4byte sKakunaPose126
+.4byte sKakunaPose127
+.4byte sKakunaPose128
+.4byte sKakunaPose129
+.4byte sKakunaPose130
+.4byte sKakunaPose131
+.4byte sKakunaPose132
+.4byte sKakunaPose133
+.4byte sKakunaPose134
+.4byte sKakunaPose135
+.4byte sKakunaPose136
+.4byte sKakunaPose137
+.4byte sKakunaPose138
+.4byte sKakunaPose139
+.4byte sKakunaPose140
+.4byte sKakunaPose141
+.4byte sKakunaPose142
+.4byte sKakunaPose143
+.4byte sKakunaPose144
+.4byte sKakunaPose145
+.4byte sKakunaPose146
+.4byte sKakunaPose147
+.4byte sKakunaPose148
+.4byte sKakunaPose149
+.4byte sKakunaPose150
+.4byte sKakunaPose151
+.4byte sKakunaPose152
+.4byte sKakunaPose153
+.4byte sKakunaPose154
+.4byte sKakunaPose155
+.4byte sKakunaPose156
+.4byte sKakunaPose157
+.4byte sKakunaPose158
+.4byte sKakunaPose159
+.4byte sKakunaPose160
+.4byte sKakunaPose161
+.4byte sKakunaPose162
+.4byte sKakunaPose163
+.4byte sKakunaPose164
+.4byte sKakunaPose165
+.4byte sKakunaPose166
+.4byte sKakunaPose167
+.4byte sKakunaPose168
+.4byte sKakunaPose169
+.4byte sKakunaPose170
+.4byte sKakunaPose171
+.4byte sKakunaPose172
+.4byte sKakunaPose173
+.4byte sKakunaPose174
+.4byte sKakunaPose175
+.4byte sKakunaPose176
+.4byte sKakunaPose177
+.4byte sKakunaPose178
+.4byte sKakunaPose179
+.4byte sKakunaPose180
+.4byte sKakunaPose181
+.4byte sKakunaPose182
+.4byte sKakunaPose183
+.4byte sKakunaPose184
+.4byte sKakunaPose185
+.4byte sKakunaPose186
+.4byte sKakunaPose187
+.4byte sKakunaPose188
+.4byte sKakunaPose189
+.4byte sKakunaPose190
+.4byte sKakunaPose191
+.4byte sKakunaPose192
+.4byte sKakunaPose193
+.4byte sKakunaPose194
+.4byte sKakunaPose195
+.4byte sKakunaPose196
+.4byte sKakunaPose197
+.4byte sKakunaPose198
+.4byte sKakunaPose199
+.4byte sKakunaPose200
+.4byte sKakunaPose201
+.4byte sKakunaPose202
+.4byte sKakunaPose203
+.4byte sKakunaPose204
+.4byte sKakunaPose205
+.4byte sKakunaPose206
+.4byte sKakunaPose207
+.4byte sKakunaPose208
+.4byte sKakunaPose209
+.4byte sKakunaPose210
+.4byte sKakunaPose211
+.4byte sKakunaPose212
+.4byte sKakunaPose213
+.4byte sKakunaPose214
+.4byte sKakunaPose215
+.4byte sKakunaPose216
+.4byte sKakunaPose217
+.4byte sKakunaPose218
+.4byte sKakunaPose219
+.4byte sKakunaPose220
+.4byte sKakunaPose221
+.4byte sKakunaPose222
+.4byte sKakunaPose223
+.4byte sKakunaPose224
+.4byte sKakunaPose225
+.4byte sKakunaPose226
+sAxPositionsKakuna:
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -1,   -8, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte    4,   -9, 	   5,   -8, 	  -2,   -7, 	  -1,   -8
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    5,   -9, 	   3,   -9, 	   1,   -8, 	   0,   -8
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte    3,  -11, 	  -1,  -11, 	   4,  -10, 	  -1,  -10
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte   -4,  -11, 	   0,  -11, 	  -5,  -10, 	   0,  -10
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,  -10, 	   0,  -10
+.2byte   -6,   -9, 	  -4,   -9, 	  -2,   -8, 	  -1,   -8
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte   -5,   -9, 	  -6,   -8, 	   1,   -7, 	   0,   -8
+.2byte    2,   -9, 	   0,  -10, 	   5,   -7, 	   3,   -9
+.2byte   -1,   -6, 	  -3,   -6, 	   2,   -6, 	   0,   -7
+.2byte   -3,   -9, 	  -6,   -7, 	   0,  -10, 	  -4,   -9
+.2byte    0,  -11, 	  -4,  -10, 	   3,  -10, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -7, 	   2,   -7, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -8, 	   2,   -8, 	   0,   -9
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -2,   -8, 	   1,   -8, 	  -4,   -5, 	  -4,   -8
+.2byte    4,   -6, 	   5,   -7, 	  -1,   -7, 	   1,   -8
+.2byte    6,   -9, 	   5,   -7, 	   1,  -10, 	   2,   -9
+.2byte   -3,  -12, 	   0,  -11, 	  -6,  -10, 	  -4,   -9
+.2byte    2,   -7, 	   3,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    2,   -7, 	   3,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte    3,   -8, 	   1,   -9, 	  -1,   -7, 	  -2,   -9
+.2byte    7,   -7, 	   6,   -8, 	   4,   -8, 	   2,  -10
+.2byte    3,   -9, 	   2,   -7, 	   1,   -9, 	  -2,  -10
+.2byte   -1,  -12, 	  -1,  -11, 	  -4,  -10, 	  -5,   -9
+.2byte    3,   -7, 	   2,   -8, 	   0,   -8, 	  -2,  -10
+.2byte    3,   -7, 	   2,   -8, 	   0,   -8, 	  -2,  -10
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    4,   -9, 	   2,   -9, 	   6,   -7, 	   1,   -9
+.2byte    5,   -9, 	   2,   -9, 	   6,   -8, 	   1,  -11
+.2byte    0,  -12, 	  -2,  -10, 	   2,  -12, 	  -3,  -11
+.2byte   -1,  -14, 	  -5,  -12, 	   0,  -10, 	  -4,   -9
+.2byte    3,   -9, 	   0,   -9, 	   4,   -8, 	  -1,  -11
+.2byte    3,   -9, 	   0,   -9, 	   4,   -8, 	  -1,  -11
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -1,  -12, 	  -6,  -10, 	  -5,   -9
+.2byte    0,  -10, 	   4,  -11, 	  -5,  -11, 	   0,  -11
+.2byte    2,  -12, 	   5,  -10, 	   0,  -12, 	   4,   -9
+.2byte    0,  -13, 	   4,  -11, 	  -5,  -11, 	   0,   -9
+.2byte    0,  -10, 	   4,  -11, 	  -5,  -11, 	   0,  -11
+.2byte    0,  -10, 	   4,  -11, 	  -5,  -11, 	   0,  -11
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte   -5,   -9, 	  -3,   -9, 	  -7,   -7, 	  -2,   -9
+.2byte   -6,   -9, 	  -3,   -9, 	  -7,   -8, 	  -2,  -11
+.2byte   -1,  -12, 	   1,  -10, 	  -3,  -12, 	   2,  -11
+.2byte    0,  -14, 	   4,  -12, 	  -1,  -10, 	   3,   -9
+.2byte   -3,  -11, 	   0,  -11, 	  -4,  -10, 	   1,  -13
+.2byte   -3,  -11, 	   0,  -11, 	  -4,  -10, 	   1,  -13
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte   -4,   -8, 	  -2,   -9, 	   0,   -7, 	   1,   -9
+.2byte   -8,   -7, 	  -7,   -8, 	  -5,   -8, 	  -3,  -10
+.2byte   -4,   -9, 	  -3,   -7, 	  -2,   -9, 	   1,  -10
+.2byte    0,  -12, 	   0,  -11, 	   3,  -10, 	   4,   -9
+.2byte   -4,   -7, 	  -3,   -8, 	  -1,   -8, 	   1,  -10
+.2byte   -4,   -9, 	  -3,  -10, 	  -1,  -10, 	   1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   0,  -10, 	   1,  -10
+.2byte    1,   -8, 	  -2,   -8, 	   3,   -5, 	   3,   -8
+.2byte   -5,   -6, 	  -6,   -7, 	   0,   -7, 	  -2,   -8
+.2byte   -7,   -9, 	  -6,   -7, 	  -2,  -10, 	  -3,   -9
+.2byte    2,  -12, 	  -1,  -11, 	   5,  -10, 	   3,   -9
+.2byte   -4,   -6, 	  -5,   -7, 	   1,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -5,   -7, 	   1,   -7, 	  -1,   -8
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte    2,   -9, 	   0,  -10, 	   5,   -7, 	   3,   -9
+.2byte   -1,   -6, 	  -3,   -6, 	   2,   -6, 	   0,   -7
+.2byte   -3,   -9, 	  -6,   -7, 	   0,  -10, 	  -4,   -9
+.2byte    0,  -11, 	  -4,  -10, 	   3,  -10, 	   0,   -9
+.2byte   -1,   -7, 	  -3,   -7, 	   2,   -7, 	   0,   -8
+.2byte   -1,   -8, 	  -3,   -8, 	   2,   -8, 	   0,   -9
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -2,   -8, 	   1,   -8, 	  -4,   -5, 	  -4,   -8
+.2byte    4,   -6, 	   5,   -7, 	  -1,   -7, 	   1,   -8
+.2byte    6,   -9, 	   5,   -7, 	   1,  -10, 	   2,   -9
+.2byte   -3,  -12, 	   0,  -11, 	  -6,  -10, 	  -4,   -9
+.2byte    2,   -7, 	   3,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    2,   -7, 	   3,   -8, 	  -3,   -8, 	  -1,   -9
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte    3,   -8, 	   1,   -9, 	  -1,   -7, 	  -2,   -9
+.2byte    7,   -7, 	   6,   -8, 	   4,   -8, 	   2,  -10
+.2byte    3,   -9, 	   2,   -7, 	   1,   -9, 	  -2,  -10
+.2byte   -1,  -12, 	  -1,  -11, 	  -4,  -10, 	  -5,   -9
+.2byte    3,   -7, 	   2,   -8, 	   0,   -8, 	  -2,  -10
+.2byte    3,   -7, 	   2,   -8, 	   0,   -8, 	  -2,  -10
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    4,   -9, 	   2,   -9, 	   6,   -7, 	   1,   -9
+.2byte    5,   -9, 	   2,   -9, 	   6,   -8, 	   1,  -11
+.2byte    0,  -12, 	  -2,  -10, 	   2,  -12, 	  -3,  -11
+.2byte   -1,  -14, 	  -5,  -12, 	   0,  -10, 	  -4,   -9
+.2byte    3,   -9, 	   0,   -9, 	   4,   -8, 	  -1,  -11
+.2byte    3,   -9, 	   0,   -9, 	   4,   -8, 	  -1,  -11
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -1,  -12, 	  -6,  -10, 	  -5,   -9
+.2byte    0,  -10, 	   4,  -11, 	  -5,  -11, 	   0,  -11
+.2byte    2,  -12, 	   5,  -10, 	   0,  -12, 	   4,   -9
+.2byte    0,  -13, 	   4,  -11, 	  -5,  -11, 	   0,   -9
+.2byte    0,  -10, 	   4,  -11, 	  -5,  -11, 	   0,  -11
+.2byte    0,  -10, 	   4,  -11, 	  -5,  -11, 	   0,  -11
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte   -5,   -9, 	  -3,   -9, 	  -7,   -7, 	  -2,   -9
+.2byte   -6,   -9, 	  -3,   -9, 	  -7,   -8, 	  -2,  -11
+.2byte   -1,  -12, 	   1,  -10, 	  -3,  -12, 	   2,  -11
+.2byte    0,  -14, 	   4,  -12, 	  -1,  -10, 	   3,   -9
+.2byte   -3,  -11, 	   0,  -11, 	  -4,  -10, 	   1,  -13
+.2byte   -3,  -11, 	   0,  -11, 	  -4,  -10, 	   1,  -13
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte   -4,   -8, 	  -2,   -9, 	   0,   -7, 	   1,   -9
+.2byte   -8,   -7, 	  -7,   -8, 	  -5,   -8, 	  -3,  -10
+.2byte   -4,   -9, 	  -3,   -7, 	  -2,   -9, 	   1,  -10
+.2byte    0,  -12, 	   0,  -11, 	   3,  -10, 	   4,   -9
+.2byte   -4,   -7, 	  -3,   -8, 	  -1,   -8, 	   1,  -10
+.2byte   -4,   -9, 	  -3,  -10, 	  -1,  -10, 	   1,  -12
+.2byte   -4,  -11, 	  -2,  -11, 	   0,  -10, 	   1,  -10
+.2byte    1,   -8, 	  -2,   -8, 	   3,   -5, 	   3,   -8
+.2byte   -5,   -6, 	  -6,   -7, 	   0,   -7, 	  -2,   -8
+.2byte   -7,   -9, 	  -6,   -7, 	  -2,  -10, 	  -3,   -9
+.2byte    2,  -12, 	  -1,  -11, 	   5,  -10, 	   3,   -9
+.2byte   -4,   -6, 	  -5,   -7, 	   1,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -5,   -7, 	   1,   -7, 	  -1,   -8
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte   -1,   -8, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte   -4,   -9, 	  -5,   -8, 	   2,   -7, 	   1,   -8
+.2byte   -5,  -10, 	  -3,  -10, 	  -1,   -9, 	   0,   -9
+.2byte   -4,  -11, 	   0,  -11, 	  -5,  -10, 	   0,  -10
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    3,  -11, 	  -1,  -11, 	   4,  -10, 	  -1,  -10
+.2byte    4,  -10, 	   2,  -10, 	   0,   -9, 	  -1,   -9
+.2byte    3,   -9, 	   4,   -8, 	  -3,   -7, 	  -2,   -8
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,  -10, 	   0,  -10
+.2byte   -4,  -12, 	   0,  -12, 	  -5,  -11, 	  -1,  -11
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte   -4,   -9, 	  -5,   -8, 	   2,   -7, 	   1,   -8
+.2byte   -5,   -9, 	  -3,   -9, 	  -1,   -8, 	   0,   -8
+.2byte   -4,  -11, 	   0,  -11, 	  -5,  -10, 	   0,  -10
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    2,  -11, 	  -2,  -11, 	   3,  -10, 	  -2,  -10
+.2byte    4,   -9, 	   2,   -9, 	   0,   -8, 	  -1,   -8
+.2byte    3,   -9, 	   4,   -8, 	  -3,   -7, 	  -2,   -8
+.2byte   -4,  -12, 	  -4,  -11, 	   1,  -11, 	   0,  -11
+.2byte   -4,  -10, 	  -4,   -9, 	   1,   -9, 	   0,   -9
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -8
+.2byte    1,  -10, 	   2,  -10, 	  -2,   -8, 	  -3,   -8
+.2byte    1,  -11, 	   1,   -9, 	  -1,   -8, 	  -2,   -7
+.2byte    0,  -14, 	  -3,  -11, 	   2,   -9, 	  -3,   -9
+.2byte    0,  -13, 	   3,  -11, 	  -4,  -11, 	   0,   -9
+.2byte   -1,  -14, 	   2,  -11, 	  -3,   -9, 	   2,   -9
+.2byte   -2,  -11, 	  -2,   -9, 	   0,   -8, 	   1,   -7
+.2byte   -2,  -10, 	  -3,  -10, 	   1,   -8, 	   2,   -8
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,  -10, 	   0,  -10
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,  -10, 	   0,  -10
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,  -10, 	   0,  -10
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte    0,  -11, 	  -4,  -10, 	   3,  -10, 	   0,   -9
+.2byte   -1,   -8, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+.2byte   -3,  -12, 	   0,  -11, 	  -6,  -10, 	  -4,   -9
+.2byte    4,   -9, 	   5,   -8, 	  -2,   -7, 	  -1,   -8
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte   -1,  -12, 	  -1,  -11, 	  -4,  -10, 	  -5,   -9
+.2byte    5,   -9, 	   3,   -9, 	   1,   -8, 	   0,   -8
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,  -12, 	   0,  -10, 	  -4,   -9
+.2byte    3,  -11, 	  -1,  -11, 	   4,  -10, 	  -1,  -10
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -5,  -11, 	   0,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte    0,  -14, 	   4,  -12, 	  -1,  -10, 	   3,   -9
+.2byte   -4,  -11, 	   0,  -11, 	  -5,  -10, 	   0,  -10
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,  -10, 	   0,  -10
+.2byte    0,  -12, 	   0,  -11, 	   3,  -10, 	   4,   -9
+.2byte   -6,   -9, 	  -4,   -9, 	  -2,   -8, 	  -1,   -8
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte    2,  -12, 	  -1,  -11, 	   5,  -10, 	   3,   -9
+.2byte   -5,   -9, 	  -6,   -8, 	   1,   -7, 	   0,   -8
+.2byte   -1,   -8, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte   -4,   -9, 	  -5,   -8, 	   2,   -7, 	   1,   -8
+.2byte   -5,  -10, 	  -3,  -10, 	  -1,   -9, 	   0,   -9
+.2byte   -4,  -11, 	   0,  -11, 	  -5,  -10, 	   0,  -10
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    3,  -11, 	  -1,  -11, 	   4,  -10, 	  -1,  -10
+.2byte    4,  -10, 	   2,  -10, 	   0,   -9, 	  -1,   -9
+.2byte    3,   -9, 	   4,   -8, 	  -3,   -7, 	  -2,   -8
+.2byte   -1,  -10, 	  -4,   -9, 	   3,   -9, 	   0,   -9
+.2byte   -4,  -11, 	  -5,  -10, 	   2,   -9, 	   0,  -10
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,  -10, 	   0,  -10
+.2byte   -3,  -12, 	   1,  -12, 	  -4,  -11, 	   0,  -11
+.2byte    0,  -13, 	   3,  -12, 	  -4,  -12, 	   0,  -10
+.2byte    2,  -12, 	  -2,  -12, 	   3,  -11, 	  -1,  -11
+.2byte    4,  -11, 	   2,  -11, 	   0,  -10, 	  -1,  -10
+.2byte    3,  -11, 	   4,  -10, 	  -3,   -9, 	  -1,  -10
+sKakunaAnimTable1:
+.4byte sKakunaAnims_1_1
+.4byte sKakunaAnims_1_2
+.4byte sKakunaAnims_1_3
+.4byte sKakunaAnims_1_4
+.4byte sKakunaAnims_1_5
+.4byte sKakunaAnims_1_6
+.4byte sKakunaAnims_1_7
+.4byte sKakunaAnims_1_8
+sKakunaAnimTable2:
+.4byte sKakunaAnims_2_1
+.4byte sKakunaAnims_2_2
+.4byte sKakunaAnims_2_3
+.4byte sKakunaAnims_2_4
+.4byte sKakunaAnims_2_5
+.4byte sKakunaAnims_2_6
+.4byte sKakunaAnims_2_7
+.4byte sKakunaAnims_2_8
+sKakunaAnimTable3:
+.4byte sKakunaAnims_3_1
+.4byte sKakunaAnims_3_2
+.4byte sKakunaAnims_3_3
+.4byte sKakunaAnims_3_4
+.4byte sKakunaAnims_3_5
+.4byte sKakunaAnims_3_6
+.4byte sKakunaAnims_3_7
+.4byte sKakunaAnims_3_8
+sKakunaAnimTable4:
+.4byte sKakunaAnims_4_1
+.4byte sKakunaAnims_4_2
+.4byte sKakunaAnims_4_3
+.4byte sKakunaAnims_4_4
+.4byte sKakunaAnims_4_5
+.4byte sKakunaAnims_4_6
+.4byte sKakunaAnims_4_7
+.4byte sKakunaAnims_4_8
+sKakunaAnimTable5:
+.4byte sKakunaAnims_5_1
+.4byte sKakunaAnims_5_2
+.4byte sKakunaAnims_5_3
+.4byte sKakunaAnims_5_4
+.4byte sKakunaAnims_5_5
+.4byte sKakunaAnims_5_6
+.4byte sKakunaAnims_5_7
+.4byte sKakunaAnims_5_8
+sKakunaAnimTable6:
+.4byte sKakunaAnims_6_1
+.4byte sKakunaAnims_6_1
+.4byte sKakunaAnims_6_1
+.4byte sKakunaAnims_6_1
+.4byte sKakunaAnims_6_1
+.4byte sKakunaAnims_6_1
+.4byte sKakunaAnims_6_1
+.4byte sKakunaAnims_6_1
+sKakunaAnimTable7:
+.4byte sKakunaAnims_7_1
+.4byte sKakunaAnims_7_2
+.4byte sKakunaAnims_7_3
+.4byte sKakunaAnims_7_4
+.4byte sKakunaAnims_7_5
+.4byte sKakunaAnims_7_6
+.4byte sKakunaAnims_7_7
+.4byte sKakunaAnims_7_8
+sKakunaAnimTable8:
+.4byte sKakunaAnims_8_1
+.4byte sKakunaAnims_8_2
+.4byte sKakunaAnims_8_3
+.4byte sKakunaAnims_8_4
+.4byte sKakunaAnims_8_5
+.4byte sKakunaAnims_8_6
+.4byte sKakunaAnims_8_7
+.4byte sKakunaAnims_8_8
+sKakunaAnimTable9:
+.4byte sKakunaAnims_9_1
+.4byte sKakunaAnims_9_2
+.4byte sKakunaAnims_9_3
+.4byte sKakunaAnims_9_4
+.4byte sKakunaAnims_9_5
+.4byte sKakunaAnims_9_6
+.4byte sKakunaAnims_9_7
+.4byte sKakunaAnims_9_8
+sKakunaAnimTable10:
+.4byte sKakunaAnims_10_1
+.4byte sKakunaAnims_10_2
+.4byte sKakunaAnims_10_3
+.4byte sKakunaAnims_10_4
+.4byte sKakunaAnims_10_5
+.4byte sKakunaAnims_10_6
+.4byte sKakunaAnims_10_7
+.4byte sKakunaAnims_10_8
+sKakunaAnimTable11:
+.4byte sKakunaAnims_11_1
+.4byte sKakunaAnims_11_2
+.4byte sKakunaAnims_11_3
+.4byte sKakunaAnims_11_4
+.4byte sKakunaAnims_11_5
+.4byte sKakunaAnims_11_6
+.4byte sKakunaAnims_11_7
+.4byte sKakunaAnims_11_8
+sKakunaAnimTable12:
+.4byte sKakunaAnims_12_1
+.4byte sKakunaAnims_12_2
+.4byte sKakunaAnims_12_3
+.4byte sKakunaAnims_12_4
+.4byte sKakunaAnims_12_5
+.4byte sKakunaAnims_12_6
+.4byte sKakunaAnims_12_7
+.4byte sKakunaAnims_12_8
+sKakunaAnimTable13:
+.4byte sKakunaAnims_13_1
+.4byte sKakunaAnims_13_2
+.4byte sKakunaAnims_13_3
+.4byte sKakunaAnims_13_4
+.4byte sKakunaAnims_13_5
+.4byte sKakunaAnims_13_6
+.4byte sKakunaAnims_13_7
+.4byte sKakunaAnims_13_8
+sAxAnimationsKakuna:
+.4byte sKakunaAnimTable1
+.4byte sKakunaAnimTable2
+.4byte sKakunaAnimTable3
+.4byte sKakunaAnimTable4
+.4byte sKakunaAnimTable5
+.4byte sKakunaAnimTable6
+.4byte sKakunaAnimTable7
+.4byte sKakunaAnimTable8
+.4byte sKakunaAnimTable9
+.4byte sKakunaAnimTable10
+.4byte sKakunaAnimTable11
+.4byte sKakunaAnimTable12
+.4byte sKakunaAnimTable13
+sAxSpritesKakuna:
+.4byte sKakunaSprites1
+.4byte sKakunaSprites2
+.4byte sKakunaSprites3
+.4byte sKakunaSprites4
+.4byte sKakunaSprites5
+.4byte sKakunaSprites6
+.4byte sKakunaSprites7
+.4byte sKakunaSprites8
+.4byte sKakunaSprites9
+.4byte sKakunaSprites10
+.4byte sKakunaSprites11
+.4byte sKakunaSprites12
+.4byte sKakunaSprites13
+.4byte sKakunaSprites14
+.4byte sKakunaSprites15
+.4byte sKakunaSprites16
+.4byte sKakunaSprites17
+.4byte sKakunaSprites18
+.4byte sKakunaSprites19
+.4byte sKakunaSprites20
+.4byte sKakunaSprites21
+.4byte sKakunaSprites22
+.4byte sKakunaSprites23
+.4byte sKakunaSprites24
+.4byte sKakunaSprites25
+.4byte sKakunaSprites26
+.4byte sKakunaSprites27
+.4byte sKakunaSprites28
+.4byte sKakunaSprites29
+.4byte sKakunaSprites30
+.4byte sKakunaSprites31
+.4byte sKakunaSprites32
+.4byte sKakunaSprites33
+.4byte sKakunaSprites34
+.4byte sKakunaSprites35
+.4byte sKakunaSprites36
+.4byte sKakunaSprites37
+.4byte sKakunaSprites38
+.4byte sKakunaSprites39
+.4byte sKakunaSprites40
+.4byte sKakunaSprites41
+.4byte sKakunaSprites42
+sAxMainKakuna:
+ax_main sAxPosesKakuna, sAxAnimationsKakuna, 13, sAxSpritesKakuna, sAxPositionsKakuna

--- a/data/ax/kangaskhan.inc
+++ b/data/ax/kangaskhan.inc
@@ -1,0 +1,2707 @@
+.global gAxKangaskhan
+gAxKangaskhan:
+ax_siro sAxMainKangaskhan
+sKangaskhanPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose2:
+ax_pose 1, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose3:
+ax_pose 2, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose5:
+ax_pose 4, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose8:
+ax_pose 7, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose9:
+ax_pose 8, 0x01e3, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose10:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose11:
+ax_pose 10, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose12:
+ax_pose 11, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose14:
+ax_pose 13, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose15:
+ax_pose 14, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose21:
+ax_pose 8, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose26:
+ax_pose 1, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose27:
+ax_pose 2, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose28:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose29:
+ax_pose 4, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose30:
+ax_pose 5, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose31:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose32:
+ax_pose 7, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose33:
+ax_pose 8, 0x01e3, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose34:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose35:
+ax_pose 10, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose36:
+ax_pose 11, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose37:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose38:
+ax_pose 13, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose39:
+ax_pose 14, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose40:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose41:
+ax_pose 10, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose42:
+ax_pose 11, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose43:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose44:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose45:
+ax_pose 8, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose46:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose47:
+ax_pose 4, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose48:
+ax_pose 5, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose50:
+ax_pose 15, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose51:
+ax_pose 16, 0x01fc, 0x0101, 0x6c00
+ax_pose 17, 0x81e4, 0x80f1, 0x6c01
+ax_pose 18, 0x01e5, 0x80f0, 0x6c09
+ax_pose_terminator
+sKangaskhanPose52:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose53:
+ax_pose 17, 0x81e7, 0x90fd, 0x6c00
+ax_pose 18, 0x01e5, 0x90f0, 0x6c08
+ax_pose_terminator
+sKangaskhanPose54:
+ax_pose 18, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose55:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose56:
+ax_pose 19, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose57:
+ax_pose 20, 0x81e3, 0x9103, 0x6c00
+ax_pose 21, 0x01e5, 0x90f0, 0x6c08
+ax_pose_terminator
+sKangaskhanPose58:
+ax_pose 21, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose59:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose60:
+ax_pose 22, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose61:
+ax_pose 23, 0x01e5, 0x90f8, 0x6c00
+ax_pose 24, 0x01e5, 0x90f0, 0x6c10
+ax_pose_terminator
+sKangaskhanPose62:
+ax_pose 24, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose63:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose64:
+ax_pose 25, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose65:
+ax_pose 26, 0x01e5, 0x90f0, 0x6c00
+ax_pose 27, 0x01e2, 0x90f1, 0x6c10
+ax_pose_terminator
+sKangaskhanPose66:
+ax_pose 26, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose67:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose68:
+ax_pose 28, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose69:
+ax_pose 29, 0x01e5, 0x80f0, 0x6c00
+ax_pose 30, 0x01e1, 0x4103, 0x6c10
+ax_pose_terminator
+sKangaskhanPose70:
+ax_pose 29, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose71:
+ax_pose 28, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose72:
+ax_pose 29, 0x01e5, 0x90f0, 0x6c00
+ax_pose 30, 0x01e1, 0x50ed, 0x6c10
+ax_pose_terminator
+sKangaskhanPose73:
+ax_pose 29, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose74:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose75:
+ax_pose 25, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose76:
+ax_pose 26, 0x01e5, 0x80f0, 0x6c00
+ax_pose 27, 0x01e3, 0x80ef, 0x6c10
+ax_pose_terminator
+sKangaskhanPose77:
+ax_pose 26, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose78:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose79:
+ax_pose 22, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose80:
+ax_pose 23, 0x01e5, 0x80e8, 0x6c00
+ax_pose 24, 0x01e5, 0x80f0, 0x6c10
+ax_pose_terminator
+sKangaskhanPose81:
+ax_pose 24, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose82:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose83:
+ax_pose 19, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose84:
+ax_pose 20, 0x81e1, 0x80ec, 0x6c00
+ax_pose 21, 0x01e5, 0x80f0, 0x6c08
+ax_pose_terminator
+sKangaskhanPose85:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose86:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose87:
+ax_pose 31, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose88:
+ax_pose 32, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose89:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose90:
+ax_pose 33, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose91:
+ax_pose 34, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose92:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose93:
+ax_pose 35, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose94:
+ax_pose 36, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose95:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose96:
+ax_pose 37, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose97:
+ax_pose 38, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose98:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose99:
+ax_pose 39, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose100:
+ax_pose 40, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose101:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose102:
+ax_pose 37, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose103:
+ax_pose 38, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose104:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose105:
+ax_pose 35, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose106:
+ax_pose 36, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose107:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose108:
+ax_pose 33, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose109:
+ax_pose 34, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose110:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose111:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose112:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose113:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose114:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose115:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose116:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose117:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose118:
+ax_pose 41, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose119:
+ax_pose 42, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose120:
+ax_pose 43, 0x01e0, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose121:
+ax_pose 44, 0x01e1, 0x90f3, 0x6c00
+ax_pose_terminator
+sKangaskhanPose122:
+ax_pose 45, 0x01e2, 0x90ee, 0x6c00
+ax_pose_terminator
+sKangaskhanPose123:
+ax_pose 46, 0x01e2, 0x90ee, 0x6c00
+ax_pose_terminator
+sKangaskhanPose124:
+ax_pose 47, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose125:
+ax_pose 46, 0x01e2, 0x80f2, 0x6c00
+ax_pose_terminator
+sKangaskhanPose126:
+ax_pose 45, 0x01e2, 0x80f2, 0x6c00
+ax_pose_terminator
+sKangaskhanPose127:
+ax_pose 44, 0x01e1, 0x80ed, 0x6c00
+ax_pose_terminator
+sKangaskhanPose128:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose129:
+ax_pose 31, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose130:
+ax_pose 32, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose131:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose132:
+ax_pose 33, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose133:
+ax_pose 34, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose134:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose135:
+ax_pose 35, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose136:
+ax_pose 36, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose137:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose138:
+ax_pose 37, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose139:
+ax_pose 38, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose140:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose141:
+ax_pose 39, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose142:
+ax_pose 40, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose143:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose144:
+ax_pose 37, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose145:
+ax_pose 38, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose146:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose147:
+ax_pose 35, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose148:
+ax_pose 36, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose149:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose150:
+ax_pose 33, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose151:
+ax_pose 34, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose152:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose153:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose154:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose155:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose156:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose157:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose158:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose159:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose160:
+ax_pose 32, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose161:
+ax_pose 34, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sKangaskhanPose162:
+ax_pose 36, 0x01e5, 0x90ee, 0x6c00
+ax_pose_terminator
+sKangaskhanPose163:
+ax_pose 38, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose164:
+ax_pose 40, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose165:
+ax_pose 38, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose166:
+ax_pose 36, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sKangaskhanPose167:
+ax_pose 34, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sKangaskhanPose168:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose169:
+ax_pose 31, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose170:
+ax_pose 32, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose171:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose172:
+ax_pose 33, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose173:
+ax_pose 34, 0x01e5, 0x90ee, 0x6c00
+ax_pose_terminator
+sKangaskhanPose174:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose175:
+ax_pose 35, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose176:
+ax_pose 36, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose177:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose178:
+ax_pose 37, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose179:
+ax_pose 38, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose180:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose181:
+ax_pose 39, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose182:
+ax_pose 40, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose183:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose184:
+ax_pose 37, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose185:
+ax_pose 38, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose186:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose187:
+ax_pose 35, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose188:
+ax_pose 36, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose189:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose190:
+ax_pose 33, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose191:
+ax_pose 34, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sKangaskhanPose192:
+ax_pose 31, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose193:
+ax_pose 33, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose194:
+ax_pose 35, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose195:
+ax_pose 37, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose196:
+ax_pose 39, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose197:
+ax_pose 37, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose198:
+ax_pose 35, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sKangaskhanPose199:
+ax_pose 33, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sKangaskhanPose200:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose201:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose202:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose203:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose204:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose205:
+ax_pose 9, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose206:
+ax_pose 6, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sKangaskhanPose207:
+ax_pose 3, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+.align 2
+sKangaskhanAnims_1_1:
+ax_anim 16, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 16, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_1_2:
+ax_anim 16, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 16, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_1_3:
+ax_anim 16, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 16, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_1_4:
+ax_anim 16, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 16, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_1_5:
+ax_anim 16, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 16, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_1_6:
+ax_anim 16, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 16, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_1_7:
+ax_anim 16, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 16, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_1_8:
+ax_anim 16, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 16, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_2_1:
+ax_anim 1, 0, 24, 0, -3, 0, 0,
+ax_anim 2, 0, 45, 0, -5, 0, 1,
+ax_anim 3, 0, 42, 1, -6, 0, 2,
+ax_anim 2, 0, 43, 0, -5, 0, 3,
+ax_anim 1, 0, 43, 0, -3, 0, 4,
+ax_anim 1, 0, 43, 0, 0, 0, 5,
+ax_anim 1, 2, 46, 0, 4, 0, 6,
+ax_anim 1, 0, 46, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 1, 28, 1, 23, 1, 23,
+ax_anim 2, 0, 28, 0, 23, 0, 23,
+ax_anim 2, 0, 28, 1, 23, 1, 23,
+ax_anim 2, 0, 25, 1, 6, 0, 6,
+ax_anim_terminator
+sKangaskhanAnims_2_2:
+ax_anim 1, 0, 27, 0, -3, 0, 0,
+ax_anim 2, 0, 24, 2, -5, 1, 1,
+ax_anim 3, 0, 45, 3, -6, 2, 2,
+ax_anim 2, 0, 46, 4, -5, 3, 3,
+ax_anim 1, 0, 46, 5, -3, 4, 4,
+ax_anim 1, 0, 46, 7, 0, 5, 5,
+ax_anim 1, 2, 25, 10, 4, 6, 6,
+ax_anim 1, 0, 25, 14, 10, 10, 10,
+ax_anim 2, 0, 28, 17, 19, 17, 19,
+ax_anim 2, 1, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 31, 17, 19, 17, 19,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sKangaskhanAnims_2_3:
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, -3, 1, 0,
+ax_anim 3, 0, 24, 3, -4, 2, 0,
+ax_anim 2, 0, 25, 4, -4, 3, 0,
+ax_anim 1, 0, 25, 5, -5, 4, 0,
+ax_anim 1, 0, 25, 7, -5, 5, 0,
+ax_anim 1, 2, 29, 10, -5, 10, 0,
+ax_anim 1, 0, 29, 14, -4, 14, 0,
+ax_anim 2, 0, 32, 17, -3, 17, 0,
+ax_anim 2, 1, 35, 18, -3, 18, 0,
+ax_anim 2, 0, 35, 17, -3, 17, 0,
+ax_anim 2, 0, 35, 18, -3, 18, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sKangaskhanAnims_2_4:
+ax_anim 1, 0, 33, 0, -2, 0, 0,
+ax_anim 2, 0, 30, 1, -5, 1, -1,
+ax_anim 3, 0, 27, 2, -5, 2, -2,
+ax_anim 2, 0, 29, 4, -7, 3, -3,
+ax_anim 1, 0, 29, 5, -8, 4, -4,
+ax_anim 1, 0, 29, 7, -10, 5, -5,
+ax_anim 1, 2, 32, 8, -12, 6, -6,
+ax_anim 1, 0, 32, 12, -18, 12, -12,
+ax_anim 2, 0, 35, 17, -23, 17, -17,
+ax_anim 2, 1, 38, 18, -22, 18, -16,
+ax_anim 2, 0, 38, 17, -23, 17, -17,
+ax_anim 2, 0, 38, 18, -22, 18, -16,
+ax_anim 2, 0, 34, 6, -6, 6, -6,
+ax_anim_terminator
+sKangaskhanAnims_2_5:
+ax_anim 1, 0, 36, 0, -2, 0, 0,
+ax_anim 2, 0, 33, 0, -5, 0, -1,
+ax_anim 3, 0, 30, -1, -7, 0, -2,
+ax_anim 2, 0, 32, 0, -7, 0, -3,
+ax_anim 1, 0, 32, 0, -8, 0, -4,
+ax_anim 1, 0, 32, 0, -10, 0, -5,
+ax_anim 1, 2, 35, 0, -12, 0, -6,
+ax_anim 1, 0, 35, 0, -18, 0, -12,
+ax_anim 2, 0, 38, 0, -23, 0, -17,
+ax_anim 2, 1, 41, 0, -22, 0, -16,
+ax_anim 2, 0, 41, 0, -23, 0, -17,
+ax_anim 2, 0, 41, 0, -22, 0, -16,
+ax_anim 2, 0, 37, 0, -6, 0, -6,
+ax_anim_terminator
+sKangaskhanAnims_2_6:
+ax_anim 1, 0, 39, 0, -2, 0, 0,
+ax_anim 2, 0, 36, -1, -5, -1, -1,
+ax_anim 3, 0, 33, -2, -5, -2, -2,
+ax_anim 2, 0, 35, -4, -7, -3, -3,
+ax_anim 1, 0, 35, -5, -8, -4, -4,
+ax_anim 1, 0, 35, -7, -10, -5, -5,
+ax_anim 1, 2, 37, -8, -12, -6, -6,
+ax_anim 1, 0, 37, -12, -18, -12, -12,
+ax_anim 2, 0, 40, -17, -23, -17, -17,
+ax_anim 2, 1, 43, -18, -22, -18, -16,
+ax_anim 2, 0, 43, -17, -23, -17, -17,
+ax_anim 2, 0, 43, -18, -22, -18, -16,
+ax_anim 2, 0, 40, -6, -6, -6, -6,
+ax_anim_terminator
+sKangaskhanAnims_2_7:
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, -3, -1, 0,
+ax_anim 3, 0, 36, -2, -4, -2, 0,
+ax_anim 2, 0, 37, -4, -4, -3, 0,
+ax_anim 1, 0, 37, -5, -5, -4, 0,
+ax_anim 1, 0, 37, -7, -5, -5, 0,
+ax_anim 1, 2, 40, -10, -5, -10, 0,
+ax_anim 1, 0, 40, -14, -4, -14, 0,
+ax_anim 2, 0, 43, -17, -3, -17, 0,
+ax_anim 2, 1, 46, -17, -4, -17, -1,
+ax_anim 2, 0, 46, -17, -3, -17, 0,
+ax_anim 2, 0, 46, -17, -4, -17, -1,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim_terminator
+sKangaskhanAnims_2_8:
+ax_anim 1, 0, 45, 0, -3, 0, 0,
+ax_anim 2, 0, 42, -2, -5, -1, 1,
+ax_anim 3, 0, 39, -3, -6, -2, 2,
+ax_anim 2, 0, 40, -4, -5, -3, 3,
+ax_anim 1, 0, 40, -5, -3, -4, 4,
+ax_anim 1, 0, 40, -7, 0, -5, 5,
+ax_anim 1, 2, 43, -10, 4, -6, 6,
+ax_anim 1, 0, 43, -14, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 25, -18, 19, -18, 19,
+ax_anim 2, 0, 25, -17, 19, -17, 19,
+ax_anim 2, 0, 25, -18, 19, -18, 19,
+ax_anim 2, 0, 46, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 4, 0, 82, 0, -3, 0, -3,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 82, 0, 7, 0, 7,
+ax_anim 1, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 1, 50, 1, 20, -1, 19,
+ax_anim 2, 0, 51, 2, 20, 0, 19,
+ax_anim 2, 0, 51, 1, 20, -1, 19,
+ax_anim 2, 0, 51, 2, 20, 0, 19,
+ax_anim 2, 0, 51, 1, 20, -1, 19,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sKangaskhanAnims_3_2:
+ax_anim 2, 0, 55, -2, -2, -2, -2,
+ax_anim 4, 0, 55, -3, -3, -3, -3,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 2, 55, 7, 7, 7, 7,
+ax_anim 1, 0, 56, 14, 19, 14, 19,
+ax_anim 2, 1, 52, 20, 22, 20, 22,
+ax_anim 2, 0, 53, 19, 23, 19, 23,
+ax_anim 2, 0, 53, 20, 22, 20, 22,
+ax_anim 2, 0, 53, 19, 23, 19, 23,
+ax_anim 2, 0, 53, 20, 22, 20, 22,
+ax_anim 2, 0, 54, 8, 8, 8, 8,
+ax_anim 2, 0, 54, 4, 4, 4, 4,
+ax_anim_terminator
+sKangaskhanAnims_3_3:
+ax_anim 2, 0, 59, -2, 0, -2, 0,
+ax_anim 4, 0, 63, -3, 0, -3, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 2, 63, 7, 0, 7, 0,
+ax_anim 1, 0, 60, 15, 0, 15, 0,
+ax_anim 2, 1, 56, 16, 1, 16, 1,
+ax_anim 2, 0, 57, 16, 0, 16, 0,
+ax_anim 2, 0, 57, 16, 1, 16, 1,
+ax_anim 2, 0, 57, 16, 0, 16, 0,
+ax_anim 2, 0, 57, 16, 1, 16, 1,
+ax_anim 2, 0, 58, 8, 0, 8, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim_terminator
+sKangaskhanAnims_3_4:
+ax_anim 2, 0, 63, -2, 2, -2, 2,
+ax_anim 4, 0, 70, -3, 3, -3, 3,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 2, 70, 7, -7, 7, -7,
+ax_anim 1, 0, 64, 14, -16, 14, -16,
+ax_anim 2, 1, 60, 15, -15, 15, -15,
+ax_anim 2, 0, 61, 14, -16, 14, -16,
+ax_anim 2, 0, 61, 15, -15, 15, -15,
+ax_anim 2, 0, 61, 14, -16, 14, -16,
+ax_anim 2, 0, 61, 15, -15, 15, -15,
+ax_anim 2, 0, 62, 6, -8, 6, -8,
+ax_anim 2, 0, 62, 3, -4, 3, -4,
+ax_anim_terminator
+sKangaskhanAnims_3_5:
+ax_anim 2, 0, 67, 0, 2, 0, 2,
+ax_anim 4, 0, 59, 0, 5, 0, 5,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 2, 59, 0, -7, 0, -7,
+ax_anim 1, 0, 68, 0, -16, 0, -16,
+ax_anim 2, 1, 75, 0, -15, 0, -15,
+ax_anim 2, 0, 76, -1, -16, -1, -16,
+ax_anim 2, 0, 76, -2, -16, -2, -16,
+ax_anim 2, 0, 76, -1, -16, -1, -16,
+ax_anim 2, 0, 76, -2, -16, -2, -16,
+ax_anim 2, 0, 66, 0, -8, 0, -8,
+ax_anim 2, 0, 66, 0, -4, 0, -4,
+ax_anim_terminator
+sKangaskhanAnims_3_6:
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim 4, 0, 67, 3, 3, 3, 3,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 2, 67, -7, -7, -7, -7,
+ax_anim 1, 0, 75, -14, -16, -14, -16,
+ax_anim 2, 1, 79, -14, -16, -14, -16,
+ax_anim 2, 0, 80, -16, -15, -16, -15,
+ax_anim 2, 0, 80, -16, -14, -16, -14,
+ax_anim 2, 0, 80, -16, -15, -16, -15,
+ax_anim 2, 0, 80, -16, -14, -16, -14,
+ax_anim 2, 0, 73, -6, -8, -6, -8,
+ax_anim 2, 0, 73, -3, -4, -3, -4,
+ax_anim_terminator
+sKangaskhanAnims_3_7:
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim 4, 0, 74, 3, 0, 3, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 2, 74, -7, 0, -7, 0,
+ax_anim 1, 0, 79, -10, 0, -10, 0,
+ax_anim 2, 1, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 84, -14, 0, -14, 0,
+ax_anim 2, 0, 84, -14, 1, -14, 1,
+ax_anim 2, 0, 84, -14, 0, -14, 0,
+ax_anim 2, 0, 84, -14, 1, -14, 1,
+ax_anim 2, 0, 77, -6, 0, -6, 0,
+ax_anim 2, 0, 77, -3, 0, -3, 0,
+ax_anim_terminator
+sKangaskhanAnims_3_8:
+ax_anim 2, 0, 82, 2, -2, 2, -2,
+ax_anim 4, 0, 78, 3, -3, 3, -3,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 78, -7, 7, 0, 7,
+ax_anim 1, 0, 83, -14, 19, -14, 19,
+ax_anim 2, 1, 50, -20, 22, -15, 20,
+ax_anim 2, 0, 51, -19, 23, -14, 21,
+ax_anim 2, 0, 51, -20, 22, -15, 20,
+ax_anim 2, 0, 51, -19, 23, -14, 21,
+ax_anim 2, 0, 51, -20, 22, -15, 20,
+ax_anim 2, 0, 81, -6, 8, -6, 8,
+ax_anim 2, 0, 81, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_4_1:
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 1, 0, 86, 0, -3, 0, -3,
+ax_anim 1, 0, 86, 0, -4, 0, -4,
+ax_anim 1, 0, 86, -1, -4, -1, -4,
+ax_anim 1, 0, 86, 0, -4, 0, -4,
+ax_anim 1, 0, 86, -1, -4, -1, -4,
+ax_anim 6, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 0, 3, 0, 3,
+ax_anim 2, 0, 87, 0, 6, 0, 6,
+ax_anim 2, 0, 87, 0, 8, 0, 8,
+ax_anim 2, 0, 87, 0, 6, 0, 6,
+ax_anim 2, 1, 87, 0, 8, 0, 8,
+ax_anim 2, 0, 87, 0, 6, 0, 6,
+ax_anim 2, 0, 87, 0, 8, 0, 8,
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim_terminator
+sKangaskhanAnims_4_2:
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 1, 0, 89, -3, -3, -3, -3,
+ax_anim 1, 0, 89, -4, -4, -4, -4,
+ax_anim 1, 0, 89, -5, -3, -5, -3,
+ax_anim 1, 0, 89, -4, -4, -4, -4,
+ax_anim 1, 0, 89, -5, -3, -5, -3,
+ax_anim 6, 0, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 3, 3, 3, 3,
+ax_anim 2, 0, 90, 6, 6, 6, 6,
+ax_anim 2, 0, 90, 7, 7, 7, 7,
+ax_anim 2, 0, 90, 6, 6, 6, 6,
+ax_anim 2, 1, 90, 7, 7, 7, 7,
+ax_anim 2, 0, 90, 6, 6, 6, 6,
+ax_anim 2, 0, 90, 7, 7, 7, 7,
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim_terminator
+sKangaskhanAnims_4_3:
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 1, 0, 92, -3, 0, -3, 0,
+ax_anim 1, 0, 92, -4, 0, -4, 0,
+ax_anim 1, 0, 92, -4, 1, -4, 1,
+ax_anim 1, 0, 92, -4, 0, -4, 0,
+ax_anim 1, 0, 92, -4, 1, -4, 1,
+ax_anim 6, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 93, 6, 0, 6, 0,
+ax_anim 2, 0, 93, 7, 0, 7, 0,
+ax_anim 2, 0, 93, 6, 0, 6, 0,
+ax_anim 2, 1, 93, 7, 0, 7, 0,
+ax_anim 2, 0, 93, 6, 0, 6, 0,
+ax_anim 2, 0, 93, 7, 0, 7, 0,
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim_terminator
+sKangaskhanAnims_4_4:
+ax_anim 2, 0, 95, -1, 1, -1, 1,
+ax_anim 1, 0, 95, -3, 3, -3, 3,
+ax_anim 1, 0, 95, -4, 4, -4, 4,
+ax_anim 1, 0, 95, -5, 3, -5, 3,
+ax_anim 1, 0, 95, -4, 4, -4, 4,
+ax_anim 1, 0, 95, -5, 3, -5, 3,
+ax_anim 6, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 3, -3, 3, -3,
+ax_anim 2, 0, 96, 6, -6, 6, -6,
+ax_anim 2, 0, 96, 7, -7, 7, -7,
+ax_anim 2, 0, 96, 6, -6, 6, -6,
+ax_anim 2, 1, 96, 7, -7, 7, -7,
+ax_anim 2, 0, 96, 6, -6, 6, -6,
+ax_anim 2, 0, 96, 7, -7, 7, -7,
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim_terminator
+sKangaskhanAnims_4_5:
+ax_anim 2, 0, 98, 0, 1, 0, 1,
+ax_anim 1, 0, 98, 0, 3, 0, 3,
+ax_anim 1, 0, 98, 0, 4, 0, 4,
+ax_anim 1, 0, 98, -1, 4, -1, 4,
+ax_anim 1, 0, 98, 0, 4, 0, 4,
+ax_anim 1, 0, 98, -1, 4, -1, 4,
+ax_anim 6, 0, 98, 0, 4, 0, 4,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, -3, 0, -3,
+ax_anim 2, 0, 99, 0, -6, 0, -6,
+ax_anim 2, 0, 99, 0, -8, 0, -8,
+ax_anim 2, 0, 99, 0, -6, 0, -6,
+ax_anim 2, 1, 99, 0, -8, 0, -8,
+ax_anim 2, 0, 99, 0, -6, 0, -6,
+ax_anim 2, 0, 99, 0, -8, 0, -8,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim_terminator
+sKangaskhanAnims_4_6:
+ax_anim 2, 0, 101, 1, 1, 1, 1,
+ax_anim 1, 0, 101, 3, 3, 3, 3,
+ax_anim 1, 0, 101, 4, 4, 4, 4,
+ax_anim 1, 0, 101, 5, 3, 5, 3,
+ax_anim 1, 0, 101, 4, 4, 4, 4,
+ax_anim 1, 0, 101, 5, 3, 5, 3,
+ax_anim 6, 0, 101, 4, 4, 4, 4,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 102, -3, -3, -3, -3,
+ax_anim 2, 0, 102, -6, -6, -6, -6,
+ax_anim 2, 0, 102, -7, -7, -7, -7,
+ax_anim 2, 0, 102, -6, -6, -6, -6,
+ax_anim 2, 1, 102, -7, -7, -7, -7,
+ax_anim 2, 0, 102, -6, -6, -6, -6,
+ax_anim 2, 0, 102, -7, -7, -7, -7,
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim_terminator
+sKangaskhanAnims_4_7:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 1, 0, 104, 3, 0, 3, 0,
+ax_anim 1, 0, 104, 4, 0, 4, 0,
+ax_anim 1, 0, 104, 4, 1, 4, 1,
+ax_anim 1, 0, 104, 4, 0, 4, 0,
+ax_anim 1, 0, 104, 4, 1, 4, 1,
+ax_anim 6, 0, 104, 4, 0, 4, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 105, -6, 0, -6, 0,
+ax_anim 2, 0, 105, -7, 0, -7, 0,
+ax_anim 2, 0, 105, -6, 0, -6, 0,
+ax_anim 2, 1, 105, -7, 0, -7, 0,
+ax_anim 2, 0, 105, -6, 0, -6, 0,
+ax_anim 2, 0, 105, -7, 0, -7, 0,
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim_terminator
+sKangaskhanAnims_4_8:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 1, 0, 107, 3, -3, 3, -3,
+ax_anim 1, 0, 107, 4, -4, 4, -4,
+ax_anim 1, 0, 107, 5, -3, 5, -3,
+ax_anim 1, 0, 107, 4, -4, 4, -4,
+ax_anim 1, 0, 107, 5, -3, 5, -3,
+ax_anim 6, 0, 107, 4, -4, 4, -4,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 108, -3, 3, -3, 3,
+ax_anim 2, 0, 108, -6, 6, -6, 6,
+ax_anim 2, 0, 108, -7, 7, -7, 7,
+ax_anim 2, 0, 108, -6, 6, -6, 6,
+ax_anim 2, 1, 108, -7, 7, -7, 7,
+ax_anim 2, 0, 108, -6, 6, -6, 6,
+ax_anim 2, 0, 108, -7, 7, -7, 7,
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_5_1:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_5_2:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_5_3:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_5_4:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_5_5:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_5_6:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_5_7:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_5_8:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_6_1:
+ax_anim 30, 0, 117, 0, 0, 0, 0,
+ax_anim 35, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_7_1:
+ax_anim 2, 0, 119, 0, -2, 0, -2,
+ax_anim 8, 0, 119, 0, -3, 0, -3,
+ax_anim_terminator
+sKangaskhanAnims_7_2:
+ax_anim 2, 0, 120, -2, -2, -2, -2,
+ax_anim 8, 0, 120, -3, -3, -3, -3,
+ax_anim_terminator
+sKangaskhanAnims_7_3:
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 8, 0, 121, -3, 0, -3, 0,
+ax_anim_terminator
+sKangaskhanAnims_7_4:
+ax_anim 2, 0, 122, -2, 2, -2, 2,
+ax_anim 8, 0, 122, -3, 3, -3, 3,
+ax_anim_terminator
+sKangaskhanAnims_7_5:
+ax_anim 2, 0, 123, 0, 2, 0, 2,
+ax_anim 8, 0, 123, 0, 3, 0, 3,
+ax_anim_terminator
+sKangaskhanAnims_7_6:
+ax_anim 2, 0, 124, 2, 2, 2, 2,
+ax_anim 8, 0, 124, 3, 3, 3, 3,
+ax_anim_terminator
+sKangaskhanAnims_7_7:
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim 8, 0, 125, 3, 0, 3, 0,
+ax_anim_terminator
+sKangaskhanAnims_7_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 8, 0, 126, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_8_1:
+ax_anim 30, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, -3, 0, 0,
+ax_anim 4, 0, 128, 0, -4, 0, 0,
+ax_anim 3, 0, 129, 0, -3, 0, 0,
+ax_anim 20, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_8_2:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 3, 0, 132, 0, -3, 0, 0,
+ax_anim 20, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_8_3:
+ax_anim 30, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, -3, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 3, 0, 135, 0, -3, 0, 0,
+ax_anim 20, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_8_4:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 3, 0, 138, 0, -4, 0, 0,
+ax_anim 20, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_8_5:
+ax_anim 30, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 3, 0, 141, 0, -3, 0, 0,
+ax_anim 20, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_8_6:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 3, 0, 144, 0, -4, 0, 0,
+ax_anim 20, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_8_7:
+ax_anim 30, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, -3, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 20, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_8_8:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 149, 0, -3, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 3, 0, 150, 0, -3, 0, 0,
+ax_anim 20, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_9_1:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 6, 4, 6, 4,
+ax_anim 2, 0, 153, 8, 9, 8, 9,
+ax_anim 2, 0, 154, 7, 19, 7, 19,
+ax_anim 3, 0, 155, 0, 22, 0, 22,
+ax_anim 2, 3, 156, -7, 19, -7, 19,
+ax_anim 2, 0, 157, -8, 9, -8, 9,
+ax_anim 1, 0, 158, -6, 4, -6, 4,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_9_2:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 6, 0, 6, 0,
+ax_anim 2, 0, 152, 17, 3, 17, 3,
+ax_anim 2, 0, 153, 24, 9, 24, 9,
+ax_anim 3, 0, 154, 20, 21, 20, 21,
+ax_anim 2, 3, 155, 11, 21, 11, 21,
+ax_anim 2, 0, 156, 2, 12, 2, 12,
+ax_anim 1, 0, 157, 0, 7, 0, 7,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_9_3:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 3, -4, 3, -4,
+ax_anim 2, 0, 151, 11, -6, 11, -6,
+ax_anim 2, 0, 152, 17, -4, 17, -4,
+ax_anim 3, 0, 153, 20, 1, 20, 1,
+ax_anim 2, 3, 154, 17, 5, 17, 5,
+ax_anim 2, 0, 155, 12, 7, 12, 7,
+ax_anim 1, 0, 156, 4, 5, 4, 5,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_9_4:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, -1, -6, -1, -6,
+ax_anim 2, 0, 158, 4, -16, 4, -16,
+ax_anim 2, 0, 151, 11, -20, 11, -20,
+ax_anim 3, 0, 152, 18, -20, 18, -20,
+ax_anim 2, 3, 153, 20, -10, 20, -10,
+ax_anim 2, 0, 154, 16, -6, 16, -6,
+ax_anim 1, 0, 155, 7, -1, 7, -1,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_9_5:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, -6, -4, -6, -4,
+ax_anim 2, 0, 157, -8, -10, -8, -10,
+ax_anim 2, 0, 158, -7, -17, -7, -17,
+ax_anim 3, 0, 151, 0, -20, 0, -20,
+ax_anim 2, 3, 152, 7, -17, 7, -17,
+ax_anim 2, 0, 153, 8, -8, 8, -8,
+ax_anim 1, 0, 154, 6, -4, 6, -4,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_9_6:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 1, -6, 1, -6,
+ax_anim 2, 0, 152, -4, -16, -4, -16,
+ax_anim 2, 0, 151, -11, -20, -11, -20,
+ax_anim 3, 0, 158, -18, -20, -18, -20,
+ax_anim 2, 3, 157, -20, -10, -20, -10,
+ax_anim 2, 0, 156, -16, -6, -16, -6,
+ax_anim 1, 0, 155, -7, -1, -7, -1,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_9_7:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -3, -4, -3, -4,
+ax_anim 2, 0, 151, -11, -6, -11, -6,
+ax_anim 2, 0, 158, -17, -4, -17, -4,
+ax_anim 3, 0, 157, -20, 1, -20, 1,
+ax_anim 2, 3, 156, -17, 5, -17, 5,
+ax_anim 2, 0, 155, -12, 7, -12, 7,
+ax_anim 1, 0, 154, -4, 5, -4, 5,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_9_8:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, 0, -6, 0,
+ax_anim 2, 0, 158, -17, 3, -17, 3,
+ax_anim 2, 0, 157, -24, 9, -24, 9,
+ax_anim 3, 0, 156, -20, 21, -20, 21,
+ax_anim 2, 3, 155, -11, 21, -11, 16,
+ax_anim 2, 0, 154, -2, 12, -4, 12,
+ax_anim 1, 0, 153, 0, 7, -3, 7,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_10_1:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, 0, 6, 0,
+ax_anim 2, 0, 159, -6, 0, -6, 0,
+ax_anim 2, 0, 159, 10, 0, 10, 0,
+ax_anim 2, 0, 159, -10, 0, -10, 0,
+ax_anim 2, 0, 159, 12, 0, 12, 0,
+ax_anim 3, 0, 159, -12, 0, -12, 0,
+ax_anim 3, 0, 159, 13, 0, 13, 0,
+ax_anim 3, 0, 159, -13, 0, -13, 0,
+ax_anim 2, 0, 159, 12, 0, 12, 0,
+ax_anim 3, 0, 159, -12, 0, -12, 0,
+ax_anim 2, 0, 159, 10, 0, 10, 0,
+ax_anim 2, 0, 159, -10, 0, -10, 0,
+ax_anim 2, 0, 159, 6, 0, 6, 0,
+ax_anim 2, 0, 159, -6, 0, -6, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_10_2:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 6, -6, 6, -6,
+ax_anim 2, 0, 160, -6, 6, -6, 6,
+ax_anim 2, 0, 160, 10, -10, 10, -10,
+ax_anim 2, 0, 160, -10, 10, -10, 10,
+ax_anim 2, 0, 160, 12, -12, 12, -12,
+ax_anim 3, 0, 160, -12, 12, -12, 12,
+ax_anim 3, 0, 160, 13, -13, 13, -13,
+ax_anim 3, 0, 160, -13, 13, -13, 13,
+ax_anim 2, 0, 160, 12, -12, 12, -12,
+ax_anim 3, 0, 160, -12, 12, -12, 12,
+ax_anim 2, 0, 160, 10, -10, 10, -10,
+ax_anim 2, 0, 160, -10, 10, -10, 10,
+ax_anim 2, 0, 160, 6, -6, 6, -6,
+ax_anim 2, 0, 160, -6, 6, -6, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_10_3:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 3, 0, 161, 0, -13, 0, -13,
+ax_anim 3, 0, 161, 0, 13, 0, 13,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_10_4:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -6, -6, -6, -6,
+ax_anim 2, 0, 162, 6, 6, 6, 6,
+ax_anim 2, 0, 162, -10, -10, -10, -10,
+ax_anim 2, 0, 162, 10, 10, 10, 10,
+ax_anim 2, 0, 162, -12, -12, -12, -12,
+ax_anim 3, 0, 162, 12, 12, 12, 12,
+ax_anim 3, 0, 162, -13, -13, -13, -13,
+ax_anim 3, 0, 162, 13, 13, 13, 13,
+ax_anim 2, 0, 162, -12, -12, -12, -12,
+ax_anim 3, 0, 162, 12, 12, 12, 12,
+ax_anim 2, 0, 162, -10, -10, -10, -10,
+ax_anim 2, 0, 162, 10, 10, 10, 10,
+ax_anim 2, 0, 162, -6, -6, -6, -6,
+ax_anim 2, 0, 162, 6, 6, 6, 6,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_10_5:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, 0, 6, 0,
+ax_anim 2, 0, 163, -6, 0, -6, 0,
+ax_anim 2, 0, 163, 10, 0, 10, 0,
+ax_anim 2, 0, 163, -10, 0, -10, 0,
+ax_anim 2, 0, 163, 12, 0, 12, 0,
+ax_anim 3, 0, 163, -12, 0, -12, 0,
+ax_anim 3, 0, 163, 13, 0, 13, 0,
+ax_anim 3, 0, 163, -13, 0, -13, 0,
+ax_anim 2, 0, 163, 12, 0, 12, 0,
+ax_anim 3, 0, 163, -12, 0, -12, 0,
+ax_anim 2, 0, 163, 10, 0, 10, 0,
+ax_anim 2, 0, 163, -10, 0, -10, 0,
+ax_anim 2, 0, 163, 6, 0, 6, 0,
+ax_anim 2, 0, 163, -6, 0, -6, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_10_6:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 6, -6, 6, -6,
+ax_anim 2, 0, 164, -6, 6, -6, 6,
+ax_anim 2, 0, 164, 10, -10, 10, -10,
+ax_anim 2, 0, 164, -10, 10, -10, 10,
+ax_anim 2, 0, 164, 12, -12, 12, -12,
+ax_anim 3, 0, 164, -12, 12, -12, 12,
+ax_anim 3, 0, 164, 13, -13, 13, -13,
+ax_anim 3, 0, 164, -13, 13, -13, 13,
+ax_anim 2, 0, 164, 12, -12, 12, -12,
+ax_anim 3, 0, 164, -12, 12, -12, 12,
+ax_anim 2, 0, 164, 10, -10, 10, -10,
+ax_anim 2, 0, 164, -10, 10, -10, 10,
+ax_anim 2, 0, 164, 6, -6, 6, -6,
+ax_anim 2, 0, 164, -6, 6, -6, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_10_7:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, -6, 0, -6,
+ax_anim 2, 0, 165, 0, 6, 0, 6,
+ax_anim 2, 0, 165, 0, -10, 0, -10,
+ax_anim 2, 0, 165, 0, 10, 0, 10,
+ax_anim 2, 0, 165, 0, -12, 0, -12,
+ax_anim 3, 0, 165, 0, 12, 0, 12,
+ax_anim 3, 0, 165, 0, -13, 0, -13,
+ax_anim 3, 0, 165, 0, 13, 0, 13,
+ax_anim 2, 0, 165, 0, -12, 0, -12,
+ax_anim 3, 0, 165, 0, 12, 0, 12,
+ax_anim 2, 0, 165, 0, -10, 0, -10,
+ax_anim 2, 0, 165, 0, 10, 0, 10,
+ax_anim 2, 0, 165, 0, -6, 0, -6,
+ax_anim 2, 0, 165, 0, 6, 0, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_10_8:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -6, -6, -6, -6,
+ax_anim 2, 0, 166, 6, 6, 6, 6,
+ax_anim 2, 0, 166, -10, -10, -10, -10,
+ax_anim 2, 0, 166, 10, 10, 10, 10,
+ax_anim 2, 0, 166, -12, -12, -12, -12,
+ax_anim 3, 0, 166, 12, 12, 12, 12,
+ax_anim 3, 0, 166, -13, -13, -13, -13,
+ax_anim 3, 0, 166, 13, 13, 13, 13,
+ax_anim 2, 0, 166, -12, -12, -12, -12,
+ax_anim 3, 0, 166, 12, 12, 12, 12,
+ax_anim 2, 0, 166, -10, -10, -10, -10,
+ax_anim 2, 0, 166, 10, 10, 10, 10,
+ax_anim 2, 0, 166, -6, -6, -6, -6,
+ax_anim 2, 0, 166, 6, 6, 6, 6,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_11_1:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -23, 0, 0,
+ax_anim 3, 0, 169, 0, -22, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_11_2:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_11_3:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_11_4:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -21, 0, 0,
+ax_anim 2, 0, 178, 0, -17, 0, 0,
+ax_anim 1, 0, 178, 0, -11, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_11_5:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_11_6:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 184, 0, -21, 0, 0,
+ax_anim 2, 0, 184, 0, -17, 0, 0,
+ax_anim 1, 0, 184, 0, -11, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_11_7:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_11_8:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_12_1:
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_12_2:
+ax_anim 2, 0, 198, 1, -1, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, -1, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, -1, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, -1, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, -1, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_12_3:
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_12_4:
+ax_anim 2, 0, 196, -1, -1, -1, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, -1, -1, -1, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, -1, -1, -1, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, -1, -1, -1, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, -1, -1, -1, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_12_5:
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, 0, 1, 0,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_12_6:
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_12_7:
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_12_8:
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKangaskhanAnims_13_1:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_13_2:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_13_3:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_13_4:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_13_5:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_13_6:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_13_7:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanAnims_13_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sKangaskhanGfx1:
+.incbin "baserom.gba", 0x9F5BF4, 0x200
+sKangaskhanSprites1:
+ax_sprite sKangaskhanGfx1, 0x200
+ax_sprite_terminator
+sKangaskhanGfx2:
+.incbin "baserom.gba", 0x9F5E04, 0x200
+sKangaskhanSprites2:
+ax_sprite sKangaskhanGfx2, 0x200
+ax_sprite_terminator
+sKangaskhanGfx3:
+.incbin "baserom.gba", 0x9F6014, 0x200
+sKangaskhanSprites3:
+ax_sprite sKangaskhanGfx3, 0x200
+ax_sprite_terminator
+sKangaskhanGfx4:
+.incbin "baserom.gba", 0x9F6224, 0x200
+sKangaskhanSprites4:
+ax_sprite sKangaskhanGfx4, 0x200
+ax_sprite_terminator
+sKangaskhanGfx5:
+.incbin "baserom.gba", 0x9F6434, 0x200
+sKangaskhanSprites5:
+ax_sprite sKangaskhanGfx5, 0x200
+ax_sprite_terminator
+sKangaskhanGfx6:
+.incbin "baserom.gba", 0x9F6644, 0x200
+sKangaskhanSprites6:
+ax_sprite sKangaskhanGfx6, 0x200
+ax_sprite_terminator
+sKangaskhanGfx7:
+.incbin "baserom.gba", 0x9F6854, 0x200
+sKangaskhanSprites7:
+ax_sprite sKangaskhanGfx7, 0x200
+ax_sprite_terminator
+sKangaskhanGfx8:
+.incbin "baserom.gba", 0x9F6A64, 0x200
+sKangaskhanSprites8:
+ax_sprite sKangaskhanGfx8, 0x200
+ax_sprite_terminator
+sKangaskhanGfx9:
+.incbin "baserom.gba", 0x9F6C74, 0x200
+sKangaskhanSprites9:
+ax_sprite sKangaskhanGfx9, 0x200
+ax_sprite_terminator
+sKangaskhanGfx10:
+.incbin "baserom.gba", 0x9F6E84, 0x200
+sKangaskhanSprites10:
+ax_sprite sKangaskhanGfx10, 0x200
+ax_sprite_terminator
+sKangaskhanGfx11:
+.incbin "baserom.gba", 0x9F7094, 0x200
+sKangaskhanSprites11:
+ax_sprite sKangaskhanGfx11, 0x200
+ax_sprite_terminator
+sKangaskhanGfx12:
+.incbin "baserom.gba", 0x9F72A4, 0x200
+sKangaskhanSprites12:
+ax_sprite sKangaskhanGfx12, 0x200
+ax_sprite_terminator
+sKangaskhanGfx13:
+.incbin "baserom.gba", 0x9F74B4, 0x200
+sKangaskhanSprites13:
+ax_sprite sKangaskhanGfx13, 0x200
+ax_sprite_terminator
+sKangaskhanGfx14:
+.incbin "baserom.gba", 0x9F76C4, 0x200
+sKangaskhanSprites14:
+ax_sprite sKangaskhanGfx14, 0x200
+ax_sprite_terminator
+sKangaskhanGfx15:
+.incbin "baserom.gba", 0x9F78D4, 0x200
+sKangaskhanSprites15:
+ax_sprite sKangaskhanGfx15, 0x200
+ax_sprite_terminator
+sKangaskhanGfx16:
+.incbin "baserom.gba", 0x9F7AE4, 0x60
+sKangaskhanGfx16_1:
+.incbin "baserom.gba", 0x9F7B44, 0x180
+sKangaskhanSprites16:
+ax_sprite sKangaskhanGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx16_1, 0x180
+ax_sprite_terminator
+sKangaskhanGfx17:
+.incbin "baserom.gba", 0x9F7CE4, 0x20
+sKangaskhanSprites17:
+ax_sprite sKangaskhanGfx17, 0x20
+ax_sprite_terminator
+sKangaskhanGfx18:
+.incbin "baserom.gba", 0x9F7D14, 0x20
+sKangaskhanGfx18_1:
+.incbin "baserom.gba", 0x9F7D34, 0x20
+sKangaskhanGfx18_2:
+.incbin "baserom.gba", 0x9F7D54, 0x80
+sKangaskhanSprites18:
+ax_sprite sKangaskhanGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx18_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx18_2, 0x80
+ax_sprite_terminator
+sKangaskhanGfx19:
+.incbin "baserom.gba", 0x9F7E04, 0x40
+sKangaskhanGfx19_1:
+.incbin "baserom.gba", 0x9F7E44, 0x180
+sKangaskhanSprites19:
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx19_1, 0x180
+ax_sprite_terminator
+sKangaskhanGfx20:
+.incbin "baserom.gba", 0x9F7FEC, 0x40
+sKangaskhanGfx20_1:
+.incbin "baserom.gba", 0x9F802C, 0x180
+sKangaskhanSprites20:
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx20_1, 0x180
+ax_sprite_terminator
+sKangaskhanGfx21:
+.incbin "baserom.gba", 0x9F81D4, 0x60
+sKangaskhanGfx21_1:
+.incbin "baserom.gba", 0x9F8234, 0x20
+sKangaskhanGfx21_2:
+.incbin "baserom.gba", 0x9F8254, 0x40
+sKangaskhanSprites21:
+ax_sprite sKangaskhanGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx21_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx21_2, 0x40
+ax_sprite_terminator
+sKangaskhanGfx22:
+.incbin "baserom.gba", 0x9F82C4, 0x60
+sKangaskhanGfx22_1:
+.incbin "baserom.gba", 0x9F8324, 0x160
+sKangaskhanSprites22:
+ax_sprite sKangaskhanGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKangaskhanGfx23:
+.incbin "baserom.gba", 0x9F84AC, 0x40
+sKangaskhanGfx23_1:
+.incbin "baserom.gba", 0x9F84EC, 0x180
+sKangaskhanSprites23:
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx23_1, 0x180
+ax_sprite_terminator
+sKangaskhanGfx24:
+.incbin "baserom.gba", 0x9F8694, 0xC0
+sKangaskhanGfx24_1:
+.incbin "baserom.gba", 0x9F8754, 0x40
+sKangaskhanGfx24_2:
+.incbin "baserom.gba", 0x9F8794, 0x40
+sKangaskhanSprites24:
+ax_sprite sKangaskhanGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKangaskhanGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKangaskhanGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKangaskhanGfx25:
+.incbin "baserom.gba", 0x9F880C, 0x60
+sKangaskhanGfx25_1:
+.incbin "baserom.gba", 0x9F886C, 0x60
+sKangaskhanGfx25_2:
+.incbin "baserom.gba", 0x9F88CC, 0xE0
+sKangaskhanSprites25:
+ax_sprite sKangaskhanGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx25_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKangaskhanGfx26:
+.incbin "baserom.gba", 0x9F89E4, 0x200
+sKangaskhanSprites26:
+ax_sprite sKangaskhanGfx26, 0x200
+ax_sprite_terminator
+sKangaskhanGfx27:
+.incbin "baserom.gba", 0x9F8BF4, 0x60
+sKangaskhanGfx27_1:
+.incbin "baserom.gba", 0x9F8C54, 0x60
+sKangaskhanGfx27_2:
+.incbin "baserom.gba", 0x9F8CB4, 0x100
+sKangaskhanSprites27:
+ax_sprite sKangaskhanGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx27_2, 0x100
+ax_sprite_terminator
+sKangaskhanGfx28:
+.incbin "baserom.gba", 0x9F8DE4, 0xA0
+sKangaskhanGfx28_1:
+.incbin "baserom.gba", 0x9F8E84, 0x40
+sKangaskhanSprites28:
+ax_sprite sKangaskhanGfx28, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sKangaskhanGfx28_1, 0x40
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sKangaskhanGfx29:
+.incbin "baserom.gba", 0x9F8EEC, 0x200
+sKangaskhanSprites29:
+ax_sprite sKangaskhanGfx29, 0x200
+ax_sprite_terminator
+sKangaskhanGfx30:
+.incbin "baserom.gba", 0x9F90FC, 0x200
+sKangaskhanSprites30:
+ax_sprite sKangaskhanGfx30, 0x200
+ax_sprite_terminator
+sKangaskhanGfx31:
+.incbin "baserom.gba", 0x9F930C, 0x80
+sKangaskhanSprites31:
+ax_sprite sKangaskhanGfx31, 0x80
+ax_sprite_terminator
+sKangaskhanGfx32:
+.incbin "baserom.gba", 0x9F939C, 0x200
+sKangaskhanSprites32:
+ax_sprite sKangaskhanGfx32, 0x200
+ax_sprite_terminator
+sKangaskhanGfx33:
+.incbin "baserom.gba", 0x9F95AC, 0x40
+sKangaskhanGfx33_1:
+.incbin "baserom.gba", 0x9F95EC, 0x180
+sKangaskhanSprites33:
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx33_1, 0x180
+ax_sprite_terminator
+sKangaskhanGfx34:
+.incbin "baserom.gba", 0x9F9794, 0x200
+sKangaskhanSprites34:
+ax_sprite sKangaskhanGfx34, 0x200
+ax_sprite_terminator
+sKangaskhanGfx35:
+.incbin "baserom.gba", 0x9F99A4, 0x20
+sKangaskhanGfx35_1:
+.incbin "baserom.gba", 0x9F99C4, 0x60
+sKangaskhanGfx35_2:
+.incbin "baserom.gba", 0x9F9A24, 0x100
+sKangaskhanSprites35:
+ax_sprite sKangaskhanGfx35, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKangaskhanGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx35_2, 0x100
+ax_sprite_terminator
+sKangaskhanGfx36:
+.incbin "baserom.gba", 0x9F9B54, 0x180
+sKangaskhanGfx36_1:
+.incbin "baserom.gba", 0x9F9CD4, 0x60
+sKangaskhanSprites36:
+ax_sprite sKangaskhanGfx36, 0x180
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx36_1, 0x60
+ax_sprite_terminator
+sKangaskhanGfx37:
+.incbin "baserom.gba", 0x9F9D54, 0x40
+sKangaskhanGfx37_1:
+.incbin "baserom.gba", 0x9F9D94, 0x60
+sKangaskhanGfx37_2:
+.incbin "baserom.gba", 0x9F9DF4, 0xE0
+sKangaskhanSprites37:
+ax_sprite sKangaskhanGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKangaskhanGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx37_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKangaskhanGfx38:
+.incbin "baserom.gba", 0x9F9F0C, 0x200
+sKangaskhanSprites38:
+ax_sprite sKangaskhanGfx38, 0x200
+ax_sprite_terminator
+sKangaskhanGfx39:
+.incbin "baserom.gba", 0x9FA11C, 0x60
+sKangaskhanGfx39_1:
+.incbin "baserom.gba", 0x9FA17C, 0x180
+sKangaskhanSprites39:
+ax_sprite sKangaskhanGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx39_1, 0x180
+ax_sprite_terminator
+sKangaskhanGfx40:
+.incbin "baserom.gba", 0x9FA31C, 0x180
+sKangaskhanGfx40_1:
+.incbin "baserom.gba", 0x9FA49C, 0x60
+sKangaskhanSprites40:
+ax_sprite sKangaskhanGfx40, 0x180
+ax_sprite 0, 0x20
+ax_sprite sKangaskhanGfx40_1, 0x60
+ax_sprite_terminator
+sKangaskhanGfx41:
+.incbin "baserom.gba", 0x9FA51C, 0x200
+sKangaskhanSprites41:
+ax_sprite sKangaskhanGfx41, 0x200
+ax_sprite_terminator
+sKangaskhanGfx42:
+.incbin "baserom.gba", 0x9FA72C, 0x200
+sKangaskhanSprites42:
+ax_sprite sKangaskhanGfx42, 0x200
+ax_sprite_terminator
+sKangaskhanGfx43:
+.incbin "baserom.gba", 0x9FA93C, 0x200
+sKangaskhanSprites43:
+ax_sprite sKangaskhanGfx43, 0x200
+ax_sprite_terminator
+sKangaskhanGfx44:
+.incbin "baserom.gba", 0x9FAB4C, 0x200
+sKangaskhanSprites44:
+ax_sprite sKangaskhanGfx44, 0x200
+ax_sprite_terminator
+sKangaskhanGfx45:
+.incbin "baserom.gba", 0x9FAD5C, 0x200
+sKangaskhanSprites45:
+ax_sprite sKangaskhanGfx45, 0x200
+ax_sprite_terminator
+sKangaskhanGfx46:
+.incbin "baserom.gba", 0x9FAF6C, 0x200
+sKangaskhanSprites46:
+ax_sprite sKangaskhanGfx46, 0x200
+ax_sprite_terminator
+sKangaskhanGfx47:
+.incbin "baserom.gba", 0x9FB17C, 0x200
+sKangaskhanSprites47:
+ax_sprite sKangaskhanGfx47, 0x200
+ax_sprite_terminator
+sKangaskhanGfx48:
+.incbin "baserom.gba", 0x9FB38C, 0x200
+sKangaskhanSprites48:
+ax_sprite sKangaskhanGfx48, 0x200
+ax_sprite_terminator
+sAxPosesKangaskhan:
+.4byte sKangaskhanPose1
+.4byte sKangaskhanPose2
+.4byte sKangaskhanPose3
+.4byte sKangaskhanPose4
+.4byte sKangaskhanPose5
+.4byte sKangaskhanPose6
+.4byte sKangaskhanPose7
+.4byte sKangaskhanPose8
+.4byte sKangaskhanPose9
+.4byte sKangaskhanPose10
+.4byte sKangaskhanPose11
+.4byte sKangaskhanPose12
+.4byte sKangaskhanPose13
+.4byte sKangaskhanPose14
+.4byte sKangaskhanPose15
+.4byte sKangaskhanPose16
+.4byte sKangaskhanPose17
+.4byte sKangaskhanPose18
+.4byte sKangaskhanPose19
+.4byte sKangaskhanPose20
+.4byte sKangaskhanPose21
+.4byte sKangaskhanPose22
+.4byte sKangaskhanPose23
+.4byte sKangaskhanPose24
+.4byte sKangaskhanPose25
+.4byte sKangaskhanPose26
+.4byte sKangaskhanPose27
+.4byte sKangaskhanPose28
+.4byte sKangaskhanPose29
+.4byte sKangaskhanPose30
+.4byte sKangaskhanPose31
+.4byte sKangaskhanPose32
+.4byte sKangaskhanPose33
+.4byte sKangaskhanPose34
+.4byte sKangaskhanPose35
+.4byte sKangaskhanPose36
+.4byte sKangaskhanPose37
+.4byte sKangaskhanPose38
+.4byte sKangaskhanPose39
+.4byte sKangaskhanPose40
+.4byte sKangaskhanPose41
+.4byte sKangaskhanPose42
+.4byte sKangaskhanPose43
+.4byte sKangaskhanPose44
+.4byte sKangaskhanPose45
+.4byte sKangaskhanPose46
+.4byte sKangaskhanPose47
+.4byte sKangaskhanPose48
+.4byte sKangaskhanPose49
+.4byte sKangaskhanPose50
+.4byte sKangaskhanPose51
+.4byte sKangaskhanPose52
+.4byte sKangaskhanPose53
+.4byte sKangaskhanPose54
+.4byte sKangaskhanPose55
+.4byte sKangaskhanPose56
+.4byte sKangaskhanPose57
+.4byte sKangaskhanPose58
+.4byte sKangaskhanPose59
+.4byte sKangaskhanPose60
+.4byte sKangaskhanPose61
+.4byte sKangaskhanPose62
+.4byte sKangaskhanPose63
+.4byte sKangaskhanPose64
+.4byte sKangaskhanPose65
+.4byte sKangaskhanPose66
+.4byte sKangaskhanPose67
+.4byte sKangaskhanPose68
+.4byte sKangaskhanPose69
+.4byte sKangaskhanPose70
+.4byte sKangaskhanPose71
+.4byte sKangaskhanPose72
+.4byte sKangaskhanPose73
+.4byte sKangaskhanPose74
+.4byte sKangaskhanPose75
+.4byte sKangaskhanPose76
+.4byte sKangaskhanPose77
+.4byte sKangaskhanPose78
+.4byte sKangaskhanPose79
+.4byte sKangaskhanPose80
+.4byte sKangaskhanPose81
+.4byte sKangaskhanPose82
+.4byte sKangaskhanPose83
+.4byte sKangaskhanPose84
+.4byte sKangaskhanPose85
+.4byte sKangaskhanPose86
+.4byte sKangaskhanPose87
+.4byte sKangaskhanPose88
+.4byte sKangaskhanPose89
+.4byte sKangaskhanPose90
+.4byte sKangaskhanPose91
+.4byte sKangaskhanPose92
+.4byte sKangaskhanPose93
+.4byte sKangaskhanPose94
+.4byte sKangaskhanPose95
+.4byte sKangaskhanPose96
+.4byte sKangaskhanPose97
+.4byte sKangaskhanPose98
+.4byte sKangaskhanPose99
+.4byte sKangaskhanPose100
+.4byte sKangaskhanPose101
+.4byte sKangaskhanPose102
+.4byte sKangaskhanPose103
+.4byte sKangaskhanPose104
+.4byte sKangaskhanPose105
+.4byte sKangaskhanPose106
+.4byte sKangaskhanPose107
+.4byte sKangaskhanPose108
+.4byte sKangaskhanPose109
+.4byte sKangaskhanPose110
+.4byte sKangaskhanPose111
+.4byte sKangaskhanPose112
+.4byte sKangaskhanPose113
+.4byte sKangaskhanPose114
+.4byte sKangaskhanPose115
+.4byte sKangaskhanPose116
+.4byte sKangaskhanPose117
+.4byte sKangaskhanPose118
+.4byte sKangaskhanPose119
+.4byte sKangaskhanPose120
+.4byte sKangaskhanPose121
+.4byte sKangaskhanPose122
+.4byte sKangaskhanPose123
+.4byte sKangaskhanPose124
+.4byte sKangaskhanPose125
+.4byte sKangaskhanPose126
+.4byte sKangaskhanPose127
+.4byte sKangaskhanPose128
+.4byte sKangaskhanPose129
+.4byte sKangaskhanPose130
+.4byte sKangaskhanPose131
+.4byte sKangaskhanPose132
+.4byte sKangaskhanPose133
+.4byte sKangaskhanPose134
+.4byte sKangaskhanPose135
+.4byte sKangaskhanPose136
+.4byte sKangaskhanPose137
+.4byte sKangaskhanPose138
+.4byte sKangaskhanPose139
+.4byte sKangaskhanPose140
+.4byte sKangaskhanPose141
+.4byte sKangaskhanPose142
+.4byte sKangaskhanPose143
+.4byte sKangaskhanPose144
+.4byte sKangaskhanPose145
+.4byte sKangaskhanPose146
+.4byte sKangaskhanPose147
+.4byte sKangaskhanPose148
+.4byte sKangaskhanPose149
+.4byte sKangaskhanPose150
+.4byte sKangaskhanPose151
+.4byte sKangaskhanPose152
+.4byte sKangaskhanPose153
+.4byte sKangaskhanPose154
+.4byte sKangaskhanPose155
+.4byte sKangaskhanPose156
+.4byte sKangaskhanPose157
+.4byte sKangaskhanPose158
+.4byte sKangaskhanPose159
+.4byte sKangaskhanPose160
+.4byte sKangaskhanPose161
+.4byte sKangaskhanPose162
+.4byte sKangaskhanPose163
+.4byte sKangaskhanPose164
+.4byte sKangaskhanPose165
+.4byte sKangaskhanPose166
+.4byte sKangaskhanPose167
+.4byte sKangaskhanPose168
+.4byte sKangaskhanPose169
+.4byte sKangaskhanPose170
+.4byte sKangaskhanPose171
+.4byte sKangaskhanPose172
+.4byte sKangaskhanPose173
+.4byte sKangaskhanPose174
+.4byte sKangaskhanPose175
+.4byte sKangaskhanPose176
+.4byte sKangaskhanPose177
+.4byte sKangaskhanPose178
+.4byte sKangaskhanPose179
+.4byte sKangaskhanPose180
+.4byte sKangaskhanPose181
+.4byte sKangaskhanPose182
+.4byte sKangaskhanPose183
+.4byte sKangaskhanPose184
+.4byte sKangaskhanPose185
+.4byte sKangaskhanPose186
+.4byte sKangaskhanPose187
+.4byte sKangaskhanPose188
+.4byte sKangaskhanPose189
+.4byte sKangaskhanPose190
+.4byte sKangaskhanPose191
+.4byte sKangaskhanPose192
+.4byte sKangaskhanPose193
+.4byte sKangaskhanPose194
+.4byte sKangaskhanPose195
+.4byte sKangaskhanPose196
+.4byte sKangaskhanPose197
+.4byte sKangaskhanPose198
+.4byte sKangaskhanPose199
+.4byte sKangaskhanPose200
+.4byte sKangaskhanPose201
+.4byte sKangaskhanPose202
+.4byte sKangaskhanPose203
+.4byte sKangaskhanPose204
+.4byte sKangaskhanPose205
+.4byte sKangaskhanPose206
+.4byte sKangaskhanPose207
+sAxPositionsKangaskhan:
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte   -2,  -11, 	 -15,  -11, 	   9,  -15, 	  -3,  -10
+.2byte    1,  -11, 	 -10,  -15, 	  14,  -11, 	   2,  -10
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte    6,  -11, 	  11,  -14, 	  -7,  -13, 	   1,  -11
+.2byte    3,  -10, 	   9,  -18, 	  -6,   -7, 	   0,  -10
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    9,  -14, 	   6,  -10, 	   2,  -13, 	   0,  -11
+.2byte    8,  -11, 	   6,  -12, 	  -1,   -8, 	  -1,  -10
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    3,  -18, 	  -6,  -15, 	  10,  -15, 	  -1,  -11
+.2byte    7,  -13, 	  -2,  -19, 	  10,  -10, 	  -2,  -10
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    4,  -14, 	  14,  -13, 	 -10,  -18, 	   1,  -11
+.2byte   -4,  -15, 	   9,  -18, 	 -15,  -13, 	   0,  -11
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte   -4,  -18, 	   5,  -15, 	 -11,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   1,  -19, 	 -11,  -10, 	   1,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte  -10,  -14, 	  -7,  -10, 	  -3,  -13, 	  -1,  -11
+.2byte   -9,  -11, 	  -7,  -12, 	   0,   -8, 	   0,  -10
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte   -7,  -11, 	 -12,  -14, 	   6,  -13, 	  -2,  -11
+.2byte   -4,  -10, 	 -10,  -18, 	   5,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte   -2,  -11, 	 -15,  -11, 	   9,  -15, 	  -3,  -10
+.2byte    1,  -11, 	 -10,  -15, 	  14,  -11, 	   2,  -10
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte    6,  -11, 	  11,  -14, 	  -7,  -13, 	   1,  -11
+.2byte    3,  -10, 	   9,  -18, 	  -6,   -7, 	   0,  -10
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    9,  -14, 	   6,  -10, 	   2,  -13, 	   0,  -11
+.2byte    8,  -11, 	   6,  -12, 	  -1,   -8, 	  -1,  -10
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    3,  -18, 	  -6,  -15, 	  10,  -15, 	  -1,  -11
+.2byte    7,  -13, 	  -2,  -19, 	  10,  -10, 	  -2,  -10
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    4,  -14, 	  14,  -13, 	 -10,  -18, 	   1,  -11
+.2byte   -4,  -15, 	   9,  -18, 	 -15,  -13, 	   0,  -11
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte   -4,  -18, 	   5,  -15, 	 -11,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   1,  -19, 	 -11,  -10, 	   1,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte  -10,  -14, 	  -7,  -10, 	  -3,  -13, 	  -1,  -11
+.2byte   -9,  -11, 	  -7,  -12, 	   0,   -8, 	   0,  -10
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte   -7,  -11, 	 -12,  -14, 	   6,  -13, 	  -2,  -11
+.2byte   -4,  -10, 	 -10,  -18, 	   5,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte   -3,  -14, 	 -11,  -10, 	   8,  -16, 	  -2,  -10
+.2byte    0,   -5, 	   0,    1, 	  12,  -15, 	   1,   -6
+.2byte    0,   -5, 	   0,    1, 	  12,  -15, 	   1,   -6
+.2byte   -1,   -5, 	  -1,    1, 	 -13,  -15, 	  -2,   -6
+.2byte   -1,   -5, 	  -1,    1, 	 -13,  -15, 	  -2,   -6
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte    6,  -16, 	   5,  -23, 	   0,  -14, 	   1,  -10
+.2byte    7,   -8, 	   8,   -2, 	 -10,  -10, 	   2,   -7
+.2byte    7,   -8, 	   8,   -2, 	 -10,  -10, 	   2,   -7
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    8,  -16, 	  -6,  -13, 	   7,  -13, 	   1,  -10
+.2byte   13,  -11, 	  12,   -4, 	   1,   -9, 	   4,   -8
+.2byte   13,  -11, 	  12,   -4, 	   1,   -9, 	   4,   -8
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    3,  -18, 	 -11,  -16, 	  12,  -19, 	  -2,  -11
+.2byte    7,  -15, 	   4,  -12, 	   8,   -9, 	   0,  -11
+.2byte    7,  -15, 	   4,  -12, 	   8,   -9, 	   0,  -11
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    2,  -14, 	  11,  -10, 	 -10,  -20, 	  -2,  -10
+.2byte    0,  -15, 	   5,  -10, 	 -12,  -12, 	   0,  -11
+.2byte    0,  -15, 	   5,  -10, 	 -12,  -12, 	   0,  -11
+.2byte   -3,  -14, 	 -12,  -10, 	   9,  -20, 	   1,  -10
+.2byte   -1,  -15, 	  -6,  -10, 	  11,  -12, 	  -1,  -11
+.2byte   -1,  -15, 	  -6,  -10, 	  11,  -12, 	  -1,  -11
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte   -4,  -18, 	  10,  -16, 	 -13,  -19, 	   1,  -11
+.2byte   -8,  -15, 	  -5,  -12, 	  -9,   -9, 	  -1,  -11
+.2byte   -8,  -15, 	  -5,  -12, 	  -9,   -9, 	  -1,  -11
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte   -9,  -16, 	   5,  -13, 	  -8,  -13, 	  -2,  -10
+.2byte  -14,  -11, 	 -13,   -4, 	  -2,   -9, 	  -5,   -8
+.2byte  -14,  -11, 	 -13,   -4, 	  -2,   -9, 	  -5,   -8
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte   -7,  -16, 	  -6,  -23, 	  -1,  -14, 	  -2,  -10
+.2byte   -8,   -8, 	  -9,   -2, 	   9,  -10, 	  -3,   -7
+.2byte   -8,   -8, 	  -9,   -2, 	   9,  -10, 	  -3,   -7
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte    0,  -19, 	 -11,  -18, 	  10,  -18, 	   0,  -11
+.2byte   -1,   -7, 	 -14,  -14, 	  13,  -14, 	   0,   -6
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte    3,  -17, 	   9,  -24, 	  -9,  -17, 	   0,  -12
+.2byte   10,   -7, 	  12,  -14, 	  -9,   -7, 	   2,   -6
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    7,  -21, 	   5,  -25, 	  -1,  -20, 	   0,  -13
+.2byte   12,   -9, 	  -3,  -16, 	  -2,  -12, 	   2,   -9
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    3,  -18, 	  -8,  -25, 	   9,  -22, 	  -3,   -9
+.2byte    6,  -13, 	 -11,  -16, 	   4,   -4, 	  -1,  -10
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    0,  -17, 	  10,  -21, 	 -11,  -21, 	   0,   -8
+.2byte    0,  -13, 	  12,   -9, 	 -13,   -9, 	   0,   -8
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte   -4,  -18, 	   7,  -25, 	 -10,  -22, 	   2,   -9
+.2byte   -7,  -13, 	  10,  -16, 	  -5,   -4, 	   0,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte   -8,  -21, 	  -6,  -25, 	   0,  -20, 	  -1,  -13
+.2byte  -13,   -9, 	   2,  -16, 	   1,  -12, 	  -3,   -9
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte   -4,  -17, 	 -10,  -24, 	   8,  -17, 	  -1,  -12
+.2byte  -11,   -7, 	 -13,  -14, 	   8,   -7, 	  -3,   -6
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte   -5,   -9, 	  -9,   -9, 	   2,   -4, 	  -1,   -8
+.2byte   -5,   -8, 	  -9,   -9, 	   2,   -4, 	  -2,   -7
+.2byte    0,   -9, 	  -3,   -6, 	   2,   -6, 	   0,  -12
+.2byte    7,   -9, 	   8,   -8, 	   2,   -4, 	  -1,  -11
+.2byte    9,  -10, 	   9,   -9, 	   7,   -8, 	  -1,  -10
+.2byte    3,  -12, 	   0,  -15, 	   7,  -11, 	  -2,  -11
+.2byte   -1,  -12, 	   8,  -12, 	 -10,  -12, 	   0,  -11
+.2byte   -4,  -12, 	  -1,  -15, 	  -8,  -11, 	   1,  -11
+.2byte  -10,  -10, 	 -10,   -9, 	  -8,   -8, 	   0,  -10
+.2byte   -8,   -9, 	  -9,   -8, 	  -3,   -4, 	   0,  -11
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte    0,  -19, 	 -11,  -18, 	  10,  -18, 	   0,  -11
+.2byte   -1,   -7, 	 -14,  -14, 	  13,  -14, 	   0,   -6
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte    3,  -17, 	   9,  -24, 	  -9,  -17, 	   0,  -12
+.2byte   10,   -7, 	  12,  -14, 	  -9,   -7, 	   2,   -6
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    7,  -21, 	   5,  -25, 	  -1,  -20, 	   0,  -13
+.2byte   12,   -9, 	  -3,  -16, 	  -2,  -12, 	   2,   -9
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    3,  -18, 	  -8,  -25, 	   9,  -22, 	  -3,   -9
+.2byte    6,  -13, 	 -11,  -16, 	   4,   -4, 	  -1,  -10
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    0,  -17, 	  10,  -21, 	 -11,  -21, 	   0,   -8
+.2byte    0,  -13, 	  12,   -9, 	 -13,   -9, 	   0,   -8
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte   -4,  -18, 	   7,  -25, 	 -10,  -22, 	   2,   -9
+.2byte   -7,  -13, 	  10,  -16, 	  -5,   -4, 	   0,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte   -8,  -21, 	  -6,  -25, 	   0,  -20, 	  -1,  -13
+.2byte  -13,   -9, 	   2,  -16, 	   1,  -12, 	  -3,   -9
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte   -4,  -17, 	 -10,  -24, 	   8,  -17, 	  -1,  -12
+.2byte  -11,   -7, 	 -13,  -14, 	   8,   -7, 	  -3,   -6
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte   -1,   -7, 	 -14,  -14, 	  13,  -14, 	   0,   -6
+.2byte    7,   -7, 	   9,  -14, 	 -12,   -7, 	  -1,   -6
+.2byte    9,   -9, 	  -6,  -16, 	  -5,  -12, 	  -1,   -9
+.2byte    5,  -13, 	 -12,  -16, 	   3,   -4, 	  -2,  -10
+.2byte    0,  -13, 	  12,   -9, 	 -13,   -9, 	   0,   -8
+.2byte   -6,  -13, 	  11,  -16, 	  -4,   -4, 	   1,  -10
+.2byte  -10,   -9, 	   5,  -16, 	   4,  -12, 	   0,   -9
+.2byte   -8,   -7, 	 -10,  -14, 	  11,   -7, 	   0,   -6
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte    0,  -19, 	 -11,  -18, 	  10,  -18, 	   0,  -11
+.2byte   -1,   -7, 	 -14,  -14, 	  13,  -14, 	   0,   -6
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+.2byte    3,  -17, 	   9,  -24, 	  -9,  -17, 	   0,  -12
+.2byte    8,   -7, 	  10,  -14, 	 -11,   -7, 	   0,   -6
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    7,  -21, 	   5,  -25, 	  -1,  -20, 	   0,  -13
+.2byte   10,   -9, 	  -5,  -16, 	  -4,  -12, 	   0,   -9
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    3,  -18, 	  -8,  -25, 	   9,  -22, 	  -3,   -9
+.2byte    5,  -13, 	 -12,  -16, 	   3,   -4, 	  -2,  -10
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    0,  -17, 	  10,  -21, 	 -11,  -21, 	   0,   -8
+.2byte    0,  -13, 	  12,   -9, 	 -13,   -9, 	   0,   -8
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte   -4,  -18, 	   7,  -25, 	 -10,  -22, 	   2,   -9
+.2byte   -6,  -13, 	  11,  -16, 	  -4,   -4, 	   1,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte   -8,  -21, 	  -6,  -25, 	   0,  -20, 	  -1,  -13
+.2byte  -11,   -9, 	   4,  -16, 	   3,  -12, 	  -1,   -9
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte   -4,  -17, 	 -10,  -24, 	   8,  -17, 	  -1,  -12
+.2byte   -9,   -7, 	 -11,  -14, 	  10,   -7, 	  -1,   -6
+.2byte    0,  -19, 	 -11,  -18, 	  10,  -18, 	   0,  -11
+.2byte   -3,  -17, 	  -9,  -24, 	   9,  -17, 	   0,  -12
+.2byte   -8,  -21, 	  -6,  -25, 	   0,  -20, 	  -1,  -13
+.2byte   -4,  -18, 	   7,  -25, 	 -10,  -22, 	   2,   -9
+.2byte    0,  -17, 	  10,  -21, 	 -11,  -21, 	   0,   -8
+.2byte    3,  -18, 	  -8,  -25, 	   9,  -22, 	  -3,   -9
+.2byte    7,  -21, 	   5,  -25, 	  -1,  -20, 	   0,  -13
+.2byte    2,  -17, 	   8,  -24, 	 -10,  -17, 	  -1,  -12
+.2byte   -1,   -9, 	 -13,  -12, 	  12,  -12, 	  -1,  -10
+.2byte   -6,  -10, 	 -11,  -17, 	   7,  -10, 	  -2,  -10
+.2byte  -10,  -12, 	  -7,  -10, 	  -2,   -9, 	  -3,  -10
+.2byte   -7,  -16, 	   3,  -18, 	 -11,  -13, 	   0,  -11
+.2byte    0,  -12, 	  12,  -15, 	 -13,  -15, 	   0,   -9
+.2byte    6,  -16, 	  -4,  -18, 	  10,  -13, 	  -1,  -11
+.2byte    9,  -12, 	   6,  -10, 	   1,   -9, 	   2,  -10
+.2byte    5,  -10, 	  10,  -17, 	  -8,  -10, 	   1,  -10
+sKangaskhanAnimTable1:
+.4byte sKangaskhanAnims_1_1
+.4byte sKangaskhanAnims_1_2
+.4byte sKangaskhanAnims_1_3
+.4byte sKangaskhanAnims_1_4
+.4byte sKangaskhanAnims_1_5
+.4byte sKangaskhanAnims_1_6
+.4byte sKangaskhanAnims_1_7
+.4byte sKangaskhanAnims_1_8
+sKangaskhanAnimTable2:
+.4byte sKangaskhanAnims_2_1
+.4byte sKangaskhanAnims_2_2
+.4byte sKangaskhanAnims_2_3
+.4byte sKangaskhanAnims_2_4
+.4byte sKangaskhanAnims_2_5
+.4byte sKangaskhanAnims_2_6
+.4byte sKangaskhanAnims_2_7
+.4byte sKangaskhanAnims_2_8
+sKangaskhanAnimTable3:
+.4byte sKangaskhanAnims_3_1
+.4byte sKangaskhanAnims_3_2
+.4byte sKangaskhanAnims_3_3
+.4byte sKangaskhanAnims_3_4
+.4byte sKangaskhanAnims_3_5
+.4byte sKangaskhanAnims_3_6
+.4byte sKangaskhanAnims_3_7
+.4byte sKangaskhanAnims_3_8
+sKangaskhanAnimTable4:
+.4byte sKangaskhanAnims_4_1
+.4byte sKangaskhanAnims_4_2
+.4byte sKangaskhanAnims_4_3
+.4byte sKangaskhanAnims_4_4
+.4byte sKangaskhanAnims_4_5
+.4byte sKangaskhanAnims_4_6
+.4byte sKangaskhanAnims_4_7
+.4byte sKangaskhanAnims_4_8
+sKangaskhanAnimTable5:
+.4byte sKangaskhanAnims_5_1
+.4byte sKangaskhanAnims_5_2
+.4byte sKangaskhanAnims_5_3
+.4byte sKangaskhanAnims_5_4
+.4byte sKangaskhanAnims_5_5
+.4byte sKangaskhanAnims_5_6
+.4byte sKangaskhanAnims_5_7
+.4byte sKangaskhanAnims_5_8
+sKangaskhanAnimTable6:
+.4byte sKangaskhanAnims_6_1
+.4byte sKangaskhanAnims_6_1
+.4byte sKangaskhanAnims_6_1
+.4byte sKangaskhanAnims_6_1
+.4byte sKangaskhanAnims_6_1
+.4byte sKangaskhanAnims_6_1
+.4byte sKangaskhanAnims_6_1
+.4byte sKangaskhanAnims_6_1
+sKangaskhanAnimTable7:
+.4byte sKangaskhanAnims_7_1
+.4byte sKangaskhanAnims_7_2
+.4byte sKangaskhanAnims_7_3
+.4byte sKangaskhanAnims_7_4
+.4byte sKangaskhanAnims_7_5
+.4byte sKangaskhanAnims_7_6
+.4byte sKangaskhanAnims_7_7
+.4byte sKangaskhanAnims_7_8
+sKangaskhanAnimTable8:
+.4byte sKangaskhanAnims_8_1
+.4byte sKangaskhanAnims_8_2
+.4byte sKangaskhanAnims_8_3
+.4byte sKangaskhanAnims_8_4
+.4byte sKangaskhanAnims_8_5
+.4byte sKangaskhanAnims_8_6
+.4byte sKangaskhanAnims_8_7
+.4byte sKangaskhanAnims_8_8
+sKangaskhanAnimTable9:
+.4byte sKangaskhanAnims_9_1
+.4byte sKangaskhanAnims_9_2
+.4byte sKangaskhanAnims_9_3
+.4byte sKangaskhanAnims_9_4
+.4byte sKangaskhanAnims_9_5
+.4byte sKangaskhanAnims_9_6
+.4byte sKangaskhanAnims_9_7
+.4byte sKangaskhanAnims_9_8
+sKangaskhanAnimTable10:
+.4byte sKangaskhanAnims_10_1
+.4byte sKangaskhanAnims_10_2
+.4byte sKangaskhanAnims_10_3
+.4byte sKangaskhanAnims_10_4
+.4byte sKangaskhanAnims_10_5
+.4byte sKangaskhanAnims_10_6
+.4byte sKangaskhanAnims_10_7
+.4byte sKangaskhanAnims_10_8
+sKangaskhanAnimTable11:
+.4byte sKangaskhanAnims_11_1
+.4byte sKangaskhanAnims_11_2
+.4byte sKangaskhanAnims_11_3
+.4byte sKangaskhanAnims_11_4
+.4byte sKangaskhanAnims_11_5
+.4byte sKangaskhanAnims_11_6
+.4byte sKangaskhanAnims_11_7
+.4byte sKangaskhanAnims_11_8
+sKangaskhanAnimTable12:
+.4byte sKangaskhanAnims_12_1
+.4byte sKangaskhanAnims_12_2
+.4byte sKangaskhanAnims_12_3
+.4byte sKangaskhanAnims_12_4
+.4byte sKangaskhanAnims_12_5
+.4byte sKangaskhanAnims_12_6
+.4byte sKangaskhanAnims_12_7
+.4byte sKangaskhanAnims_12_8
+sKangaskhanAnimTable13:
+.4byte sKangaskhanAnims_13_1
+.4byte sKangaskhanAnims_13_2
+.4byte sKangaskhanAnims_13_3
+.4byte sKangaskhanAnims_13_4
+.4byte sKangaskhanAnims_13_5
+.4byte sKangaskhanAnims_13_6
+.4byte sKangaskhanAnims_13_7
+.4byte sKangaskhanAnims_13_8
+sAxAnimationsKangaskhan:
+.4byte sKangaskhanAnimTable1
+.4byte sKangaskhanAnimTable2
+.4byte sKangaskhanAnimTable3
+.4byte sKangaskhanAnimTable4
+.4byte sKangaskhanAnimTable5
+.4byte sKangaskhanAnimTable6
+.4byte sKangaskhanAnimTable7
+.4byte sKangaskhanAnimTable8
+.4byte sKangaskhanAnimTable9
+.4byte sKangaskhanAnimTable10
+.4byte sKangaskhanAnimTable11
+.4byte sKangaskhanAnimTable12
+.4byte sKangaskhanAnimTable13
+sAxSpritesKangaskhan:
+.4byte sKangaskhanSprites1
+.4byte sKangaskhanSprites2
+.4byte sKangaskhanSprites3
+.4byte sKangaskhanSprites4
+.4byte sKangaskhanSprites5
+.4byte sKangaskhanSprites6
+.4byte sKangaskhanSprites7
+.4byte sKangaskhanSprites8
+.4byte sKangaskhanSprites9
+.4byte sKangaskhanSprites10
+.4byte sKangaskhanSprites11
+.4byte sKangaskhanSprites12
+.4byte sKangaskhanSprites13
+.4byte sKangaskhanSprites14
+.4byte sKangaskhanSprites15
+.4byte sKangaskhanSprites16
+.4byte sKangaskhanSprites17
+.4byte sKangaskhanSprites18
+.4byte sKangaskhanSprites19
+.4byte sKangaskhanSprites20
+.4byte sKangaskhanSprites21
+.4byte sKangaskhanSprites22
+.4byte sKangaskhanSprites23
+.4byte sKangaskhanSprites24
+.4byte sKangaskhanSprites25
+.4byte sKangaskhanSprites26
+.4byte sKangaskhanSprites27
+.4byte sKangaskhanSprites28
+.4byte sKangaskhanSprites29
+.4byte sKangaskhanSprites30
+.4byte sKangaskhanSprites31
+.4byte sKangaskhanSprites32
+.4byte sKangaskhanSprites33
+.4byte sKangaskhanSprites34
+.4byte sKangaskhanSprites35
+.4byte sKangaskhanSprites36
+.4byte sKangaskhanSprites37
+.4byte sKangaskhanSprites38
+.4byte sKangaskhanSprites39
+.4byte sKangaskhanSprites40
+.4byte sKangaskhanSprites41
+.4byte sKangaskhanSprites42
+.4byte sKangaskhanSprites43
+.4byte sKangaskhanSprites44
+.4byte sKangaskhanSprites45
+.4byte sKangaskhanSprites46
+.4byte sKangaskhanSprites47
+.4byte sKangaskhanSprites48
+sAxMainKangaskhan:
+ax_main sAxPosesKangaskhan, sAxAnimationsKangaskhan, 13, sAxSpritesKangaskhan, sAxPositionsKangaskhan

--- a/data/ax/kecleon.inc
+++ b/data/ax/kecleon.inc
@@ -1,0 +1,3038 @@
+.global gAxKecleon
+gAxKecleon:
+ax_siro sAxMainKecleon
+sKecleonPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose4:
+ax_pose 3, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sKecleonPose5:
+ax_pose 4, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sKecleonPose6:
+ax_pose 5, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sKecleonPose7:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose8:
+ax_pose 7, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose9:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose10:
+ax_pose 9, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose11:
+ax_pose 10, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose12:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose13:
+ax_pose 12, 0x81e7, 0x80f8, 0x3c00
+ax_pose_terminator
+sKecleonPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose16:
+ax_pose 9, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose17:
+ax_pose 10, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose18:
+ax_pose 11, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose19:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose20:
+ax_pose 7, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose21:
+ax_pose 8, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose22:
+ax_pose 3, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose23:
+ax_pose 4, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose24:
+ax_pose 5, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose28:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose29:
+ax_pose 3, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sKecleonPose30:
+ax_pose 4, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sKecleonPose31:
+ax_pose 5, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sKecleonPose32:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose33:
+ax_pose 6, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose34:
+ax_pose 7, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose35:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose36:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose37:
+ax_pose 9, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose38:
+ax_pose 10, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose39:
+ax_pose 11, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose40:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose41:
+ax_pose 12, 0x81e7, 0x80f8, 0x3c00
+ax_pose_terminator
+sKecleonPose42:
+ax_pose 13, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose43:
+ax_pose 14, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose44:
+ax_pose 19, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose45:
+ax_pose 9, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose46:
+ax_pose 10, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose47:
+ax_pose 11, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose48:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose49:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose50:
+ax_pose 7, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose51:
+ax_pose 8, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose52:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose53:
+ax_pose 3, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose54:
+ax_pose 4, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose55:
+ax_pose 5, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose56:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose57:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose58:
+ax_pose 20, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose59:
+ax_pose 21, 0x01e6, 0x80f2, 0x3c00
+ax_pose 22, 0x01e6, 0x80f2, 0x3c10
+ax_pose_terminator
+sKecleonPose60:
+ax_pose 22, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose61:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose62:
+ax_pose 23, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sKecleonPose63:
+ax_pose 24, 0x01e5, 0x90f0, 0x3c00
+ax_pose 25, 0x01e5, 0x90f0, 0x3c10
+ax_pose_terminator
+sKecleonPose64:
+ax_pose 25, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sKecleonPose65:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose66:
+ax_pose 26, 0x01e5, 0x90f3, 0x3c00
+ax_pose_terminator
+sKecleonPose67:
+ax_pose 27, 0x01e5, 0x90f3, 0x3c00
+ax_pose 28, 0x01e5, 0x90f5, 0x3c10
+ax_pose_terminator
+sKecleonPose68:
+ax_pose 27, 0x01e5, 0x90f3, 0x3c00
+ax_pose_terminator
+sKecleonPose69:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose70:
+ax_pose 29, 0x01e5, 0x90f3, 0x3c00
+ax_pose_terminator
+sKecleonPose71:
+ax_pose 30, 0x01e5, 0x90f3, 0x3c00
+ax_pose 31, 0x01e3, 0x90f6, 0x3c10
+ax_pose_terminator
+sKecleonPose72:
+ax_pose 30, 0x01e5, 0x90f3, 0x3c00
+ax_pose_terminator
+sKecleonPose73:
+ax_pose 19, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose74:
+ax_pose 32, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose75:
+ax_pose 33, 0x01e6, 0x80f3, 0x3c00
+ax_pose 34, 0x01e6, 0x80f3, 0x3c10
+ax_pose_terminator
+sKecleonPose76:
+ax_pose 33, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose77:
+ax_pose 32, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sKecleonPose78:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose79:
+ax_pose 29, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sKecleonPose80:
+ax_pose 30, 0x01e5, 0x80ef, 0x3c00
+ax_pose 31, 0x01e3, 0x80ec, 0x3c10
+ax_pose_terminator
+sKecleonPose81:
+ax_pose 30, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sKecleonPose82:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose83:
+ax_pose 26, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sKecleonPose84:
+ax_pose 27, 0x01e5, 0x80ed, 0x3c00
+ax_pose 28, 0x01e5, 0x80eb, 0x3c10
+ax_pose_terminator
+sKecleonPose85:
+ax_pose 27, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sKecleonPose86:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose87:
+ax_pose 23, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sKecleonPose88:
+ax_pose 24, 0x01e5, 0x80f0, 0x3c00
+ax_pose 25, 0x01e5, 0x80f0, 0x3c10
+ax_pose_terminator
+sKecleonPose89:
+ax_pose 25, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sKecleonPose90:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose91:
+ax_pose 35, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose92:
+ax_pose 36, 0x01e5, 0x40f8, 0x3c00
+ax_pose 37, 0x01f5, 0x40f4, 0x3c04
+ax_pose 38, 0x81f5, 0x0104, 0x3c08
+ax_pose_terminator
+sKecleonPose93:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose94:
+ax_pose 39, 0x01e9, 0x90f2, 0x3c00
+ax_pose_terminator
+sKecleonPose95:
+ax_pose 40, 0x01e9, 0x90f2, 0x3c00
+ax_pose_terminator
+sKecleonPose96:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose97:
+ax_pose 41, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose98:
+ax_pose 42, 0x81eb, 0x90fb, 0x3c00
+ax_pose 43, 0x01eb, 0x50eb, 0x3c08
+ax_pose 44, 0x41fb, 0x10eb, 0x3c0c
+ax_pose 45, 0x01f3, 0x110b, 0x3c0e
+ax_pose_terminator
+sKecleonPose99:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose100:
+ax_pose 46, 0x01e9, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose101:
+ax_pose 47, 0x81e9, 0x90fd, 0x3c00
+ax_pose 48, 0x01f9, 0x50ed, 0x3c08
+ax_pose 49, 0x81e9, 0x10f5, 0x3c0c
+ax_pose_terminator
+sKecleonPose102:
+ax_pose 19, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose103:
+ax_pose 50, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose104:
+ax_pose 51, 0x81e7, 0x80f4, 0x3c00
+ax_pose 52, 0x81e7, 0x0104, 0x3c08
+ax_pose 53, 0x81f7, 0x0104, 0x3c0a
+ax_pose 54, 0x0207, 0x00fc, 0x3c0c
+ax_pose_terminator
+sKecleonPose105:
+ax_pose 12, 0x81e7, 0x80f8, 0x3c00
+ax_pose_terminator
+sKecleonPose106:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose107:
+ax_pose 46, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose108:
+ax_pose 47, 0x81e9, 0x80f3, 0x3c00
+ax_pose 48, 0x01f9, 0x4103, 0x3c08
+ax_pose 49, 0x81e9, 0x0103, 0x3c0c
+ax_pose_terminator
+sKecleonPose109:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose110:
+ax_pose 41, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose111:
+ax_pose 42, 0x81eb, 0x80f5, 0x3c00
+ax_pose 43, 0x01eb, 0x4105, 0x3c08
+ax_pose 44, 0x41fb, 0x0105, 0x3c0c
+ax_pose 45, 0x01f3, 0x00ed, 0x3c0e
+ax_pose_terminator
+sKecleonPose112:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose113:
+ax_pose 39, 0x01e9, 0x80ee, 0x3c00
+ax_pose_terminator
+sKecleonPose114:
+ax_pose 40, 0x01e9, 0x80ee, 0x3c00
+ax_pose_terminator
+sKecleonPose115:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose116:
+ax_pose 55, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose117:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose118:
+ax_pose 56, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sKecleonPose119:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose120:
+ax_pose 57, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sKecleonPose121:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose122:
+ax_pose 58, 0x01e5, 0x90f2, 0x3c00
+ax_pose_terminator
+sKecleonPose123:
+ax_pose 19, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose124:
+ax_pose 59, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose125:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose126:
+ax_pose 58, 0x01e5, 0x80ee, 0x3c00
+ax_pose_terminator
+sKecleonPose127:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose128:
+ax_pose 57, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sKecleonPose129:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose130:
+ax_pose 56, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sKecleonPose131:
+ax_pose 60, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose132:
+ax_pose 61, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose133:
+ax_pose 62, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sKecleonPose134:
+ax_pose 63, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose135:
+ax_pose 64, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sKecleonPose136:
+ax_pose 65, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose137:
+ax_pose 66, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sKecleonPose138:
+ax_pose 65, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose139:
+ax_pose 64, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose140:
+ax_pose 63, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose141:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose142:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose143:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose144:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose145:
+ax_pose 19, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose146:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose147:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose148:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose149:
+ax_pose 0, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose150:
+ax_pose 3, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose151:
+ax_pose 6, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose152:
+ax_pose 9, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose153:
+ax_pose 12, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sKecleonPose154:
+ax_pose 9, 0x01e9, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose155:
+ax_pose 6, 0x01e9, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose156:
+ax_pose 3, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sKecleonPose157:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose158:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose159:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose160:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose161:
+ax_pose 19, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose162:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose163:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose164:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose165:
+ax_pose 20, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sKecleonPose166:
+ax_pose 23, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sKecleonPose167:
+ax_pose 26, 0x01e5, 0x90f4, 0x3c00
+ax_pose_terminator
+sKecleonPose168:
+ax_pose 29, 0x01e6, 0x90f3, 0x3c00
+ax_pose_terminator
+sKecleonPose169:
+ax_pose 32, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose170:
+ax_pose 29, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sKecleonPose171:
+ax_pose 26, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sKecleonPose172:
+ax_pose 23, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sKecleonPose173:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose174:
+ax_pose 35, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose175:
+ax_pose 36, 0x01e5, 0x40f8, 0x3c00
+ax_pose 37, 0x01f5, 0x40f4, 0x3c04
+ax_pose 38, 0x81f5, 0x0104, 0x3c08
+ax_pose_terminator
+sKecleonPose176:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose177:
+ax_pose 39, 0x01e9, 0x90f2, 0x3c00
+ax_pose_terminator
+sKecleonPose178:
+ax_pose 40, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sKecleonPose179:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose180:
+ax_pose 41, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose181:
+ax_pose 42, 0x81eb, 0x90fb, 0x3c00
+ax_pose 43, 0x01eb, 0x50eb, 0x3c08
+ax_pose 44, 0x41fb, 0x10eb, 0x3c0c
+ax_pose 45, 0x01f3, 0x110b, 0x3c0e
+ax_pose_terminator
+sKecleonPose182:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose183:
+ax_pose 46, 0x01e9, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose184:
+ax_pose 47, 0x81e9, 0x90fd, 0x3c00
+ax_pose 48, 0x01f9, 0x50ed, 0x3c08
+ax_pose 49, 0x81e9, 0x10f5, 0x3c0c
+ax_pose_terminator
+sKecleonPose185:
+ax_pose 19, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose186:
+ax_pose 50, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose187:
+ax_pose 51, 0x81e7, 0x80f4, 0x3c00
+ax_pose 52, 0x81e7, 0x0104, 0x3c08
+ax_pose 53, 0x81f7, 0x0104, 0x3c0a
+ax_pose 54, 0x0207, 0x00fc, 0x3c0c
+ax_pose_terminator
+sKecleonPose188:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose189:
+ax_pose 46, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose190:
+ax_pose 47, 0x81e9, 0x80f3, 0x3c00
+ax_pose 48, 0x01f9, 0x4103, 0x3c08
+ax_pose 49, 0x81e9, 0x0103, 0x3c0c
+ax_pose_terminator
+sKecleonPose191:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose192:
+ax_pose 41, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose193:
+ax_pose 42, 0x81eb, 0x80f5, 0x3c00
+ax_pose 43, 0x01eb, 0x4105, 0x3c08
+ax_pose 44, 0x41fb, 0x0105, 0x3c0c
+ax_pose 45, 0x01f3, 0x00ed, 0x3c0e
+ax_pose_terminator
+sKecleonPose194:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose195:
+ax_pose 39, 0x01e9, 0x80ee, 0x3c00
+ax_pose_terminator
+sKecleonPose196:
+ax_pose 40, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sKecleonPose197:
+ax_pose 35, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose198:
+ax_pose 39, 0x01e9, 0x80ee, 0x3c00
+ax_pose_terminator
+sKecleonPose199:
+ax_pose 41, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose200:
+ax_pose 46, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sKecleonPose201:
+ax_pose 50, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose202:
+ax_pose 46, 0x01e9, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose203:
+ax_pose 41, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose204:
+ax_pose 39, 0x01e9, 0x90f2, 0x3c00
+ax_pose_terminator
+sKecleonPose205:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose206:
+ax_pose 16, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sKecleonPose207:
+ax_pose 17, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sKecleonPose208:
+ax_pose 18, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sKecleonPose209:
+ax_pose 19, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sKecleonPose210:
+ax_pose 18, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sKecleonPose211:
+ax_pose 17, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sKecleonPose212:
+ax_pose 16, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sKecleonPose213:
+ax_pose 67, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+.align 2
+sKecleonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sKecleonAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 6, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 1, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sKecleonAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 6, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 1, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sKecleonAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 2, 0, 36, 18, -19, 20, -21,
+ax_anim 2, 1, 36, 19, -18, 21, -20,
+ax_anim 2, 0, 36, 18, -19, 20, -21,
+ax_anim 2, 0, 36, 19, -18, 21, -20,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sKecleonAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 6, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -20, 0, -20,
+ax_anim 2, 1, 40, 1, -20, 1, -20,
+ax_anim 2, 0, 40, 0, -20, 0, -20,
+ax_anim 2, 0, 40, 1, -20, 1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sKecleonAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 6, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 2, 0, 44, -18, -19, -20, -21,
+ax_anim 2, 1, 44, -19, -18, -21, -20,
+ax_anim 2, 0, 44, -18, -19, -20, -21,
+ax_anim 2, 0, 44, -19, -18, -21, -20,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sKecleonAnims_2_7:
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 6, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -19, 0, -19, 0,
+ax_anim 2, 1, 48, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -19, 0, -19, 0,
+ax_anim 2, 0, 48, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sKecleonAnims_2_8:
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 6, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -19, 20, -19, 20,
+ax_anim 2, 1, 52, -20, 19, -20, 19,
+ax_anim 2, 0, 52, -19, 20, -19, 20,
+ax_anim 2, 0, 52, -20, 19, -20, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sKecleonAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 57, 0, -4, 0, -4,
+ax_anim 6, 0, 57, 0, -5, 0, -5,
+ax_anim 1, 2, 57, 0, -3, 0, -3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, 8, 0, 8,
+ax_anim 2, 1, 58, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sKecleonAnims_3_2:
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 65, -4, -4, -4, -4,
+ax_anim 6, 0, 65, -5, -5, -5, -5,
+ax_anim 1, 2, 65, -3, -3, -3, -3,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 8, 10, 8, 10,
+ax_anim 2, 1, 62, 14, 18, 14, 18,
+ax_anim 2, 0, 63, 15, 17, 15, 17,
+ax_anim 2, 0, 63, 14, 18, 14, 18,
+ax_anim 2, 0, 63, 15, 17, 15, 17,
+ax_anim 2, 0, 63, 14, 18, 14, 18,
+ax_anim 2, 0, 63, 15, 17, 15, 17,
+ax_anim 2, 0, 60, 10, 12, 10, 12,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sKecleonAnims_3_3:
+ax_anim 2, 0, 64, -2, 0, -2, -2,
+ax_anim 2, 0, 69, -4, 0, -4, -2,
+ax_anim 6, 0, 69, -5, 0, -5, -2,
+ax_anim 1, 2, 69, -3, 0, -3, -2,
+ax_anim 1, 0, 69, 0, 0, 0, -2,
+ax_anim 2, 0, 65, 8, 0, 8, 0,
+ax_anim 2, 1, 66, 14, 0, 19, 0,
+ax_anim 2, 0, 67, 14, -1, 19, -1,
+ax_anim 2, 0, 67, 14, 0, 19, 0,
+ax_anim 2, 0, 67, 14, -1, 19, -1,
+ax_anim 2, 0, 67, 14, 0, 19, 0,
+ax_anim 2, 0, 67, 14, -1, 19, -1,
+ax_anim 2, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, -2,
+ax_anim_terminator
+sKecleonAnims_3_4:
+ax_anim 2, 0, 68, -2, 2, -2, 2,
+ax_anim 2, 0, 76, -4, 4, -4, 4,
+ax_anim 6, 0, 76, -5, 5, -5, 5,
+ax_anim 1, 2, 76, -3, 3, -3, 3,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 8, -10, 8, -10,
+ax_anim 2, 1, 70, 14, -18, 14, -18,
+ax_anim 2, 0, 71, 15, -17, 15, -17,
+ax_anim 2, 0, 71, 14, -18, 14, -18,
+ax_anim 2, 0, 71, 15, -17, 15, -17,
+ax_anim 2, 0, 71, 14, -18, 14, -18,
+ax_anim 2, 0, 71, 15, -17, 15, -17,
+ax_anim 2, 0, 68, 10, -12, 10, -12,
+ax_anim 2, 0, 68, 5, -6, 5, -6,
+ax_anim_terminator
+sKecleonAnims_3_5:
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 6, 0, 73, 0, 5, 0, 5,
+ax_anim 1, 2, 73, 0, 3, 0, 3,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -8, 0, -8,
+ax_anim 2, 1, 74, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 1, -17, 1, -17,
+ax_anim 2, 0, 72, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sKecleonAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 73, 4, 4, 4, 4,
+ax_anim 6, 0, 73, 5, 5, 5, 5,
+ax_anim 1, 2, 73, 3, 3, 3, 3,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 78, -8, -10, -8, -10,
+ax_anim 2, 1, 79, -14, -18, -14, -18,
+ax_anim 2, 0, 80, -15, -17, -15, -17,
+ax_anim 2, 0, 80, -14, -18, -14, -18,
+ax_anim 2, 0, 80, -15, -17, -15, -17,
+ax_anim 2, 0, 80, -14, -18, -14, -18,
+ax_anim 2, 0, 80, -15, -17, -15, -17,
+ax_anim 2, 0, 77, -10, -12, -10, -12,
+ax_anim 2, 0, 77, -4, -4, -4, -4,
+ax_anim_terminator
+sKecleonAnims_3_7:
+ax_anim 2, 0, 81, 2, 0, 2, -2,
+ax_anim 2, 0, 78, 4, 0, 4, -2,
+ax_anim 6, 0, 78, 5, 0, 5, -2,
+ax_anim 1, 2, 78, 3, 0, 3, -2,
+ax_anim 1, 0, 78, 0, 0, 0, -2,
+ax_anim 2, 0, 82, -8, 0, -8, 0,
+ax_anim 2, 1, 83, -14, 0, -19, 0,
+ax_anim 2, 0, 84, -14, -1, -19, -1,
+ax_anim 2, 0, 84, -14, 0, -19, 0,
+ax_anim 2, 0, 84, -14, -1, -19, -1,
+ax_anim 2, 0, 84, -14, 0, -19, 0,
+ax_anim 2, 0, 84, -14, -1, -19, -1,
+ax_anim 2, 0, 81, -10, 0, -10, 0,
+ax_anim 2, 0, 81, -4, 0, -4, -2,
+ax_anim_terminator
+sKecleonAnims_3_8:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 2, 0, 82, 5, -2, 4, -4,
+ax_anim 6, 0, 82, 6, -3, 5, -5,
+ax_anim 1, 2, 82, 4, -1, 3, -3,
+ax_anim 1, 0, 82, 2, 0, 0, 0,
+ax_anim 2, 0, 86, -8, 10, -8, 10,
+ax_anim 2, 1, 87, -14, 18, -14, 18,
+ax_anim 2, 0, 88, -15, 17, -15, 17,
+ax_anim 2, 0, 88, -14, 18, -14, 18,
+ax_anim 2, 0, 88, -15, 17, -15, 17,
+ax_anim 2, 0, 88, -14, 18, -14, 18,
+ax_anim 2, 0, 88, -15, 17, -15, 17,
+ax_anim 2, 0, 85, -10, 12, -10, 12,
+ax_anim 2, 0, 85, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sKecleonAnims_4_1:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 6, 2, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 1, 91, 0, 6, 0, 6,
+ax_anim 2, 0, 91, 1, 6, 1, 6,
+ax_anim 2, 0, 91, 0, 6, 0, 6,
+ax_anim 2, 0, 91, 1, 6, 1, 6,
+ax_anim 2, 0, 91, 0, 6, 0, 6,
+ax_anim 2, 0, 91, 1, 6, 1, 6,
+ax_anim 2, 0, 91, 0, 6, 0, 6,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim_terminator
+sKecleonAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 2, 93, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 1, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sKecleonAnims_4_3:
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim 6, 2, 96, -3, 0, -3, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 4, 0, 4, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 4, 0, 4, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 4, 0, 4, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim_terminator
+sKecleonAnims_4_4:
+ax_anim 2, 0, 99, -2, 2, -2, 2,
+ax_anim 6, 2, 99, -3, 3, -3, 3,
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 2, 1, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -1, 3, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -1, 3, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -1, 3, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim_terminator
+sKecleonAnims_4_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 6, 2, 102, 0, 3, 0, 3,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 2, 1, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 1, -3, 1, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 1, -3, 1, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 1, -3, 1, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim_terminator
+sKecleonAnims_4_6:
+ax_anim 2, 0, 106, 2, 2, 2, 2,
+ax_anim 6, 2, 106, 3, 3, 3, 3,
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 2, 1, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim_terminator
+sKecleonAnims_4_7:
+ax_anim 2, 0, 109, 2, 0, 2, 0,
+ax_anim 6, 2, 109, 3, 0, 3, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 1, 110, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -4, 0, -4, 0,
+ax_anim 2, 0, 110, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -4, 0, -4, 0,
+ax_anim 2, 0, 110, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -4, 0, -4, 0,
+ax_anim 2, 0, 110, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim_terminator
+sKecleonAnims_4_8:
+ax_anim 2, 0, 112, 2, -2, 2, -2,
+ax_anim 6, 2, 112, 3, -3, 3, -3,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 113, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 113, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 113, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sKecleonAnims_5_1:
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 2, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_5_2:
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 2, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_5_3:
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 2, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_5_4:
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 2, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_5_5:
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 2, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_5_6:
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 2, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_5_7:
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 2, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_5_8:
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 2, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_6_1:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 35, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_7_1:
+ax_anim 2, 0, 132, 0, -4, 0, -4,
+ax_anim 8, 0, 132, 0, -5, 0, -5,
+ax_anim_terminator
+sKecleonAnims_7_2:
+ax_anim 2, 0, 133, -4, -4, -4, -4,
+ax_anim 8, 0, 133, -5, -5, -5, -5,
+ax_anim_terminator
+sKecleonAnims_7_3:
+ax_anim 2, 0, 134, -4, 0, -4, 0,
+ax_anim 8, 0, 134, -5, 0, -5, 0,
+ax_anim_terminator
+sKecleonAnims_7_4:
+ax_anim 2, 0, 135, -4, 4, -4, 4,
+ax_anim 8, 0, 135, -5, 5, -5, 5,
+ax_anim_terminator
+sKecleonAnims_7_5:
+ax_anim 2, 0, 136, 0, 4, 0, 4,
+ax_anim 8, 0, 136, 0, 5, 0, 5,
+ax_anim_terminator
+sKecleonAnims_7_6:
+ax_anim 2, 0, 137, 4, 4, 4, 4,
+ax_anim 8, 0, 137, 5, 5, 5, 5,
+ax_anim_terminator
+sKecleonAnims_7_7:
+ax_anim 2, 0, 138, 4, 0, 4, 0,
+ax_anim 8, 0, 138, 5, 0, 5, 0,
+ax_anim_terminator
+sKecleonAnims_7_8:
+ax_anim 2, 0, 139, 4, -4, 4, -4,
+ax_anim 8, 0, 139, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sKecleonAnims_8_1:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim_terminator
+sKecleonAnims_8_2:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 6, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim_terminator
+sKecleonAnims_8_3:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 154, 0, -3, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sKecleonAnims_8_4:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 6, 0, 153, 0, -3, 0, 0,
+ax_anim 2, 0, 153, 0, -1, 0, 0,
+ax_anim_terminator
+sKecleonAnims_8_5:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 6, 0, 152, 0, -3, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+sKecleonAnims_8_6:
+ax_anim 40, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 151, 0, -3, 0, 0,
+ax_anim 2, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sKecleonAnims_8_7:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 6, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -1, 0, 0,
+ax_anim_terminator
+sKecleonAnims_8_8:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 6, 0, 149, 0, -3, 0, 0,
+ax_anim 2, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_9_1:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 6, 3, 6, 3,
+ax_anim 2, 0, 158, 8, 9, 8, 9,
+ax_anim 2, 0, 159, 7, 15, 7, 15,
+ax_anim 3, 0, 160, 0, 18, 0, 18,
+ax_anim 2, 3, 161, -7, 15, -7, 15,
+ax_anim 2, 0, 162, -8, 9, -8, 9,
+ax_anim 1, 0, 163, -6, 3, -6, 3,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_9_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 8, 0, 8, 0,
+ax_anim 2, 0, 157, 17, 3, 17, 3,
+ax_anim 2, 0, 158, 23, 10, 23, 10,
+ax_anim 3, 0, 159, 22, 19, 22, 19,
+ax_anim 2, 3, 160, 11, 19, 11, 19,
+ax_anim 2, 0, 161, 3, 15, 3, 15,
+ax_anim 1, 0, 162, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_9_3:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 3, -5, 3, -5,
+ax_anim 2, 0, 156, 11, -7, 11, -7,
+ax_anim 2, 0, 157, 16, -5, 16, -5,
+ax_anim 3, 0, 158, 20, -1, 20, -1,
+ax_anim 2, 3, 159, 17, 4, 17, 4,
+ax_anim 2, 0, 160, 12, 7, 12, 7,
+ax_anim 1, 0, 161, 4, 5, 4, 5,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_9_4:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -1, -8, -1, -8,
+ax_anim 2, 0, 163, 1, -17, 1, -17,
+ax_anim 2, 0, 156, 10, -22, 10, -22,
+ax_anim 3, 0, 157, 18, -22, 18, -22,
+ax_anim 2, 3, 158, 21, -15, 21, -15,
+ax_anim 2, 0, 159, 15, -6, 15, -6,
+ax_anim 1, 0, 160, 7, -1, 7, -1,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_9_5:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, -8, -4, -8, -4,
+ax_anim 2, 0, 162, -9, -12, -9, -12,
+ax_anim 2, 0, 163, -7, -18, -7, -18,
+ax_anim 3, 0, 156, 0, -22, 0, -22,
+ax_anim 2, 3, 157, 7, -18, 7, -18,
+ax_anim 2, 0, 158, 9, -10, 9, -10,
+ax_anim 1, 0, 159, 8, -4, 8, -4,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_9_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 1, -6, 1, -6,
+ax_anim 2, 0, 157, -4, -16, -4, -16,
+ax_anim 2, 0, 156, -12, -22, -12, -22,
+ax_anim 3, 0, 163, -18, -22, -18, -22,
+ax_anim 2, 3, 162, -20, -15, -20, -15,
+ax_anim 2, 0, 161, -17, -4, -17, -4,
+ax_anim 1, 0, 160, -7, -1, -7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_9_7:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 157, -3, -5, -3, -5,
+ax_anim 2, 0, 156, -11, -6, -11, -6,
+ax_anim 2, 0, 163, -16, -5, -16, -5,
+ax_anim 3, 0, 162, -18, -2, -18, -2,
+ax_anim 2, 3, 161, -16, 4, -16, 4,
+ax_anim 2, 0, 160, -12, 5, -12, 5,
+ax_anim 1, 0, 159, -4, 5, -4, 5,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_9_8:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, -8, 0, -8, 0,
+ax_anim 2, 0, 163, -17, 3, -17, 3,
+ax_anim 2, 0, 162, -19, 10, -19, 10,
+ax_anim 3, 0, 161, -17, 19, -17, 19,
+ax_anim 2, 3, 160, -11, 19, -11, 19,
+ax_anim 2, 0, 159, -3, 15, -3, 15,
+ax_anim 1, 0, 158, 0, 7, 0, 7,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_10_1:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 6, 0, 6, 0,
+ax_anim 2, 0, 164, -6, 0, -6, 0,
+ax_anim 2, 0, 164, 10, 0, 10, 0,
+ax_anim 2, 0, 164, -10, 0, -10, 0,
+ax_anim 2, 0, 164, 12, 0, 12, 0,
+ax_anim 3, 0, 164, -12, 0, -12, 0,
+ax_anim 3, 0, 164, 13, 0, 13, 0,
+ax_anim 3, 0, 164, -13, 0, -13, 0,
+ax_anim 2, 0, 164, 12, 0, 12, 0,
+ax_anim 3, 0, 164, -12, 0, -12, 0,
+ax_anim 2, 0, 164, 10, 0, 10, 0,
+ax_anim 2, 0, 164, -10, 0, -10, 0,
+ax_anim 2, 0, 164, 6, 0, 6, 0,
+ax_anim 2, 0, 164, -6, 0, -6, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_10_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 6, -6, 6, -6,
+ax_anim 2, 0, 165, -6, 6, -6, 6,
+ax_anim 2, 0, 165, 10, -10, 10, -10,
+ax_anim 2, 0, 165, -10, 10, -10, 10,
+ax_anim 2, 0, 165, 12, -12, 12, -12,
+ax_anim 3, 0, 165, -12, 12, -12, 12,
+ax_anim 3, 0, 165, 13, -13, 13, -13,
+ax_anim 3, 0, 165, -13, 13, -13, 13,
+ax_anim 2, 0, 165, 12, -12, 12, -12,
+ax_anim 3, 0, 165, -12, 12, -12, 12,
+ax_anim 2, 0, 165, 10, -10, 10, -10,
+ax_anim 2, 0, 165, -10, 10, -10, 10,
+ax_anim 2, 0, 165, 6, -6, 6, -6,
+ax_anim 2, 0, 165, -6, 6, -6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_10_3:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -6, 0, -6,
+ax_anim 2, 0, 166, 0, 6, 0, 6,
+ax_anim 2, 0, 166, 0, -10, 0, -10,
+ax_anim 2, 0, 166, 0, 10, 0, 10,
+ax_anim 2, 0, 166, 0, -12, 0, -12,
+ax_anim 3, 0, 166, 0, 12, 0, 12,
+ax_anim 3, 0, 166, 0, -13, 0, -13,
+ax_anim 3, 0, 166, 0, 13, 0, 13,
+ax_anim 2, 0, 166, 0, -12, 0, -12,
+ax_anim 3, 0, 166, 0, 12, 0, 12,
+ax_anim 2, 0, 166, 0, -10, 0, -10,
+ax_anim 2, 0, 166, 0, 10, 0, 10,
+ax_anim 2, 0, 166, 0, -6, 0, -6,
+ax_anim 2, 0, 166, 0, 6, 0, 6,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_10_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -6, -6, -6, -6,
+ax_anim 2, 0, 167, 6, 6, 6, 6,
+ax_anim 2, 0, 167, -10, -10, -10, -10,
+ax_anim 2, 0, 167, 10, 10, 10, 10,
+ax_anim 2, 0, 167, -12, -12, -12, -12,
+ax_anim 3, 0, 167, 12, 12, 12, 12,
+ax_anim 3, 0, 167, -13, -13, -13, -13,
+ax_anim 3, 0, 167, 13, 13, 13, 13,
+ax_anim 2, 0, 167, -12, -12, -12, -12,
+ax_anim 3, 0, 167, 12, 12, 12, 12,
+ax_anim 2, 0, 167, -10, -10, -10, -10,
+ax_anim 2, 0, 167, 10, 10, 10, 10,
+ax_anim 2, 0, 167, -6, -6, -6, -6,
+ax_anim 2, 0, 167, 6, 6, 6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_10_5:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 6, 0, 6, 0,
+ax_anim 2, 0, 168, -6, 0, -6, 0,
+ax_anim 2, 0, 168, 10, 0, 10, 0,
+ax_anim 2, 0, 168, -10, 0, -10, 0,
+ax_anim 2, 0, 168, 12, 0, 12, 0,
+ax_anim 3, 0, 168, -12, 0, -12, 0,
+ax_anim 3, 0, 168, 13, 0, 13, 0,
+ax_anim 3, 0, 168, -13, 0, -13, 0,
+ax_anim 2, 0, 168, 12, 0, 12, 0,
+ax_anim 3, 0, 168, -12, 0, -12, 0,
+ax_anim 2, 0, 168, 10, 0, 10, 0,
+ax_anim 2, 0, 168, -10, 0, -10, 0,
+ax_anim 2, 0, 168, 6, 0, 6, 0,
+ax_anim 2, 0, 168, -6, 0, -6, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_10_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 6, -6, 6, -6,
+ax_anim 2, 0, 169, -6, 6, -6, 6,
+ax_anim 2, 0, 169, 10, -10, 10, -10,
+ax_anim 2, 0, 169, -10, 10, -10, 10,
+ax_anim 2, 0, 169, 12, -12, 12, -12,
+ax_anim 3, 0, 169, -12, 12, -12, 12,
+ax_anim 3, 0, 169, 13, -13, 13, -13,
+ax_anim 3, 0, 169, -13, 13, -13, 13,
+ax_anim 2, 0, 169, 12, -12, 12, -12,
+ax_anim 3, 0, 169, -12, 12, -12, 12,
+ax_anim 2, 0, 169, 10, -10, 10, -10,
+ax_anim 2, 0, 169, -10, 10, -10, 10,
+ax_anim 2, 0, 169, 6, -6, 6, -6,
+ax_anim 2, 0, 169, -6, 6, -6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_10_7:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -6, 0, -6,
+ax_anim 2, 0, 170, 0, 6, 0, 6,
+ax_anim 2, 0, 170, 0, -10, 0, -10,
+ax_anim 2, 0, 170, 0, 10, 0, 10,
+ax_anim 2, 0, 170, 0, -12, 0, -12,
+ax_anim 3, 0, 170, 0, 12, 0, 12,
+ax_anim 3, 0, 170, 0, -13, 0, -13,
+ax_anim 3, 0, 170, 0, 13, 0, 13,
+ax_anim 2, 0, 170, 0, -12, 0, -12,
+ax_anim 3, 0, 170, 0, 12, 0, 12,
+ax_anim 2, 0, 170, 0, -10, 0, -10,
+ax_anim 2, 0, 170, 0, 10, 0, 10,
+ax_anim 2, 0, 170, 0, -6, 0, -6,
+ax_anim 2, 0, 170, 0, 6, 0, 6,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_10_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -6, -6, -6, -6,
+ax_anim 2, 0, 171, 6, 6, 6, 6,
+ax_anim 2, 0, 171, -10, -10, -10, -10,
+ax_anim 2, 0, 171, 10, 10, 10, 10,
+ax_anim 2, 0, 171, -12, -12, -12, -12,
+ax_anim 3, 0, 171, 12, 12, 12, 12,
+ax_anim 3, 0, 171, -13, -13, -13, -13,
+ax_anim 3, 0, 171, 13, 13, 13, 13,
+ax_anim 2, 0, 171, -12, -12, -12, -12,
+ax_anim 3, 0, 171, 12, 12, 12, 12,
+ax_anim 2, 0, 171, -10, -10, -10, -10,
+ax_anim 2, 0, 171, 10, 10, 10, 10,
+ax_anim 2, 0, 171, -6, -6, -6, -6,
+ax_anim 2, 0, 171, 6, 6, 6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_11_1:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_11_2:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -24, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_11_3:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_11_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -17, 0, 0,
+ax_anim 1, 0, 183, 0, -11, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_11_5:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_11_6:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_11_7:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_11_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -24, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_12_1:
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_12_2:
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_12_3:
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_12_4:
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_12_5:
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_12_6:
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_12_7:
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_12_8:
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_13_1:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_13_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_13_3:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_13_4:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_13_5:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_13_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_13_7:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sKecleonAnims_13_8:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKecleonAnims_14_1:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, -3, 1, 0,
+ax_anim 3, 0, 212, 0, -4, 1, 0,
+ax_anim 3, 0, 212, 0, -4, 1, 0,
+ax_anim 3, 0, 212, 0, -3, 1, 0,
+ax_anim_terminator
+sKecleonGfx1:
+.incbin "baserom.gba", 0x1486650, 0x200
+sKecleonSprites1:
+ax_sprite sKecleonGfx1, 0x200
+ax_sprite_terminator
+sKecleonGfx2:
+.incbin "baserom.gba", 0x1486860, 0x200
+sKecleonSprites2:
+ax_sprite sKecleonGfx2, 0x200
+ax_sprite_terminator
+sKecleonGfx3:
+.incbin "baserom.gba", 0x1486A70, 0x200
+sKecleonSprites3:
+ax_sprite sKecleonGfx3, 0x200
+ax_sprite_terminator
+sKecleonGfx4:
+.incbin "baserom.gba", 0x1486C80, 0x200
+sKecleonSprites4:
+ax_sprite sKecleonGfx4, 0x200
+ax_sprite_terminator
+sKecleonGfx5:
+.incbin "baserom.gba", 0x1486E90, 0x200
+sKecleonSprites5:
+ax_sprite sKecleonGfx5, 0x200
+ax_sprite_terminator
+sKecleonGfx6:
+.incbin "baserom.gba", 0x14870A0, 0x200
+sKecleonSprites6:
+ax_sprite sKecleonGfx6, 0x200
+ax_sprite_terminator
+sKecleonGfx7:
+.incbin "baserom.gba", 0x14872B0, 0x200
+sKecleonSprites7:
+ax_sprite sKecleonGfx7, 0x200
+ax_sprite_terminator
+sKecleonGfx8:
+.incbin "baserom.gba", 0x14874C0, 0x200
+sKecleonSprites8:
+ax_sprite sKecleonGfx8, 0x200
+ax_sprite_terminator
+sKecleonGfx9:
+.incbin "baserom.gba", 0x14876D0, 0x200
+sKecleonSprites9:
+ax_sprite sKecleonGfx9, 0x200
+ax_sprite_terminator
+sKecleonGfx10:
+.incbin "baserom.gba", 0x14878E0, 0x200
+sKecleonSprites10:
+ax_sprite sKecleonGfx10, 0x200
+ax_sprite_terminator
+sKecleonGfx11:
+.incbin "baserom.gba", 0x1487AF0, 0x200
+sKecleonSprites11:
+ax_sprite sKecleonGfx11, 0x200
+ax_sprite_terminator
+sKecleonGfx12:
+.incbin "baserom.gba", 0x1487D00, 0x200
+sKecleonSprites12:
+ax_sprite sKecleonGfx12, 0x200
+ax_sprite_terminator
+sKecleonGfx13:
+.incbin "baserom.gba", 0x1487F10, 0x100
+sKecleonSprites13:
+ax_sprite sKecleonGfx13, 0x100
+ax_sprite_terminator
+sKecleonGfx14:
+.incbin "baserom.gba", 0x1488020, 0x200
+sKecleonSprites14:
+ax_sprite sKecleonGfx14, 0x200
+ax_sprite_terminator
+sKecleonGfx15:
+.incbin "baserom.gba", 0x1488230, 0x200
+sKecleonSprites15:
+ax_sprite sKecleonGfx15, 0x200
+ax_sprite_terminator
+sKecleonGfx16:
+.incbin "baserom.gba", 0x1488440, 0x60
+sKecleonGfx16_1:
+.incbin "baserom.gba", 0x14884A0, 0x60
+sKecleonGfx16_2:
+.incbin "baserom.gba", 0x1488500, 0x60
+sKecleonSprites16:
+ax_sprite sKecleonGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKecleonGfx17:
+.incbin "baserom.gba", 0x1488598, 0x40
+sKecleonGfx17_1:
+.incbin "baserom.gba", 0x14885D8, 0x60
+sKecleonGfx17_2:
+.incbin "baserom.gba", 0x1488638, 0x60
+sKecleonGfx17_3:
+.incbin "baserom.gba", 0x1488698, 0x40
+sKecleonSprites17:
+ax_sprite sKecleonGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx17_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKecleonGfx18:
+.incbin "baserom.gba", 0x1488720, 0x40
+sKecleonGfx18_1:
+.incbin "baserom.gba", 0x1488760, 0x60
+sKecleonGfx18_2:
+.incbin "baserom.gba", 0x14887C0, 0x60
+sKecleonGfx18_3:
+.incbin "baserom.gba", 0x1488820, 0x60
+sKecleonSprites18:
+ax_sprite sKecleonGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx19:
+.incbin "baserom.gba", 0x14888C8, 0x60
+sKecleonGfx19_1:
+.incbin "baserom.gba", 0x1488928, 0x60
+sKecleonGfx19_2:
+.incbin "baserom.gba", 0x1488988, 0x60
+sKecleonGfx19_3:
+.incbin "baserom.gba", 0x14889E8, 0x60
+sKecleonSprites19:
+ax_sprite sKecleonGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx20:
+.incbin "baserom.gba", 0x1488A90, 0x60
+sKecleonGfx20_1:
+.incbin "baserom.gba", 0x1488AF0, 0x60
+sKecleonGfx20_2:
+.incbin "baserom.gba", 0x1488B50, 0x60
+sKecleonGfx20_3:
+.incbin "baserom.gba", 0x1488BB0, 0x60
+sKecleonSprites20:
+ax_sprite sKecleonGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx21:
+.incbin "baserom.gba", 0x1488C58, 0x40
+sKecleonGfx21_1:
+.incbin "baserom.gba", 0x1488C98, 0x60
+sKecleonGfx21_2:
+.incbin "baserom.gba", 0x1488CF8, 0x60
+sKecleonGfx21_3:
+.incbin "baserom.gba", 0x1488D58, 0x40
+sKecleonSprites21:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx22:
+.incbin "baserom.gba", 0x1488DE8, 0x20
+sKecleonGfx22_1:
+.incbin "baserom.gba", 0x1488E08, 0x40
+sKecleonGfx22_2:
+.incbin "baserom.gba", 0x1488E48, 0x60
+sKecleonSprites22:
+ax_sprite 0, 0x80
+ax_sprite sKecleonGfx22, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKecleonGfx22_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx23:
+.incbin "baserom.gba", 0x1488EE8, 0x160
+sKecleonSprites23:
+ax_sprite 0, 0x80
+ax_sprite sKecleonGfx23, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx24:
+.incbin "baserom.gba", 0x1489068, 0x40
+sKecleonGfx24_1:
+.incbin "baserom.gba", 0x14890A8, 0xE0
+sKecleonGfx24_2:
+.incbin "baserom.gba", 0x1489188, 0x40
+sKecleonSprites24:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx24_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx25:
+.incbin "baserom.gba", 0x1489208, 0x20
+sKecleonGfx25_1:
+.incbin "baserom.gba", 0x1489228, 0x40
+sKecleonGfx25_2:
+.incbin "baserom.gba", 0x1489268, 0x20
+sKecleonGfx25_3:
+.incbin "baserom.gba", 0x1489288, 0x60
+sKecleonSprites25:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx25_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKecleonGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx26:
+.incbin "baserom.gba", 0x1489338, 0x60
+sKecleonGfx26_1:
+.incbin "baserom.gba", 0x1489398, 0x60
+sKecleonGfx26_2:
+.incbin "baserom.gba", 0x14893F8, 0x60
+sKecleonSprites26:
+ax_sprite 0, 0x80
+ax_sprite sKecleonGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx27:
+.incbin "baserom.gba", 0x1489498, 0x40
+sKecleonGfx27_1:
+.incbin "baserom.gba", 0x14894D8, 0x60
+sKecleonGfx27_2:
+.incbin "baserom.gba", 0x1489538, 0x60
+sKecleonGfx27_3:
+.incbin "baserom.gba", 0x1489598, 0x60
+sKecleonSprites27:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx27_3, 0x60
+ax_sprite_terminator
+sKecleonGfx28:
+.incbin "baserom.gba", 0x1489640, 0x20
+sKecleonGfx28_1:
+.incbin "baserom.gba", 0x1489660, 0x160
+sKecleonSprites28:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx28_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx29:
+.incbin "baserom.gba", 0x14897F0, 0x120
+sKecleonGfx29_1:
+.incbin "baserom.gba", 0x1489910, 0x40
+sKecleonSprites29:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx29, 0x120
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx29_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKecleonGfx30:
+.incbin "baserom.gba", 0x1489980, 0x60
+sKecleonGfx30_1:
+.incbin "baserom.gba", 0x14899E0, 0x60
+sKecleonGfx30_2:
+.incbin "baserom.gba", 0x1489A40, 0x60
+sKecleonGfx30_3:
+.incbin "baserom.gba", 0x1489AA0, 0x60
+sKecleonSprites30:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx30_3, 0x60
+ax_sprite_terminator
+sKecleonGfx31:
+.incbin "baserom.gba", 0x1489B48, 0x40
+sKecleonGfx31_1:
+.incbin "baserom.gba", 0x1489B88, 0x100
+sKecleonGfx31_2:
+.incbin "baserom.gba", 0x1489C88, 0x40
+sKecleonSprites31:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx32:
+.incbin "baserom.gba", 0x1489D08, 0x40
+sKecleonGfx32_1:
+.incbin "baserom.gba", 0x1489D48, 0xC0
+sKecleonSprites32:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx32_1, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sKecleonGfx33:
+.incbin "baserom.gba", 0x1489E38, 0x40
+sKecleonGfx33_1:
+.incbin "baserom.gba", 0x1489E78, 0x60
+sKecleonGfx33_2:
+.incbin "baserom.gba", 0x1489ED8, 0x40
+sKecleonGfx33_3:
+.incbin "baserom.gba", 0x1489F18, 0x40
+sKecleonSprites33:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx34:
+.incbin "baserom.gba", 0x1489FA8, 0x60
+sKecleonGfx34_1:
+.incbin "baserom.gba", 0x148A008, 0x60
+sKecleonGfx34_2:
+.incbin "baserom.gba", 0x148A068, 0x60
+sKecleonGfx34_3:
+.incbin "baserom.gba", 0x148A0C8, 0x40
+sKecleonSprites34:
+ax_sprite sKecleonGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx35:
+.incbin "baserom.gba", 0x148A150, 0x100
+sKecleonSprites35:
+ax_sprite sKecleonGfx35, 0x100
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sKecleonGfx36:
+.incbin "baserom.gba", 0x148A268, 0x60
+sKecleonGfx36_1:
+.incbin "baserom.gba", 0x148A2C8, 0x60
+sKecleonGfx36_2:
+.incbin "baserom.gba", 0x148A328, 0x60
+sKecleonGfx36_3:
+.incbin "baserom.gba", 0x148A388, 0x60
+sKecleonSprites36:
+ax_sprite sKecleonGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx36_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx37:
+.incbin "baserom.gba", 0x148A430, 0x80
+sKecleonSprites37:
+ax_sprite sKecleonGfx37, 0x80
+ax_sprite_terminator
+sKecleonGfx38:
+.incbin "baserom.gba", 0x148A4C0, 0x80
+sKecleonSprites38:
+ax_sprite sKecleonGfx38, 0x80
+ax_sprite_terminator
+sKecleonGfx39:
+.incbin "baserom.gba", 0x148A550, 0x40
+sKecleonSprites39:
+ax_sprite sKecleonGfx39, 0x40
+ax_sprite_terminator
+sKecleonGfx40:
+.incbin "baserom.gba", 0x148A5A0, 0x60
+sKecleonGfx40_1:
+.incbin "baserom.gba", 0x148A600, 0x60
+sKecleonGfx40_2:
+.incbin "baserom.gba", 0x148A660, 0x60
+sKecleonGfx40_3:
+.incbin "baserom.gba", 0x148A6C0, 0x20
+sKecleonSprites40:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx40_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx40_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx41:
+.incbin "baserom.gba", 0x148A730, 0x140
+sKecleonGfx41_1:
+.incbin "baserom.gba", 0x148A870, 0x20
+sKecleonSprites41:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx41, 0x140
+ax_sprite 0, 0x60
+ax_sprite sKecleonGfx41_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx42:
+.incbin "baserom.gba", 0x148A8C0, 0x40
+sKecleonGfx42_1:
+.incbin "baserom.gba", 0x148A900, 0x60
+sKecleonGfx42_2:
+.incbin "baserom.gba", 0x148A960, 0x80
+sKecleonSprites42:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx42_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKecleonGfx43:
+.incbin "baserom.gba", 0x148AA20, 0xC0
+sKecleonSprites43:
+ax_sprite sKecleonGfx43, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKecleonGfx44:
+.incbin "baserom.gba", 0x148AAF8, 0x60
+sKecleonSprites44:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx44, 0x60
+ax_sprite_terminator
+sKecleonGfx45:
+.incbin "baserom.gba", 0x148AB70, 0x40
+sKecleonSprites45:
+ax_sprite sKecleonGfx45, 0x40
+ax_sprite_terminator
+sKecleonGfx46:
+.incbin "baserom.gba", 0x148ABC0, 0x20
+sKecleonSprites46:
+ax_sprite sKecleonGfx46, 0x20
+ax_sprite_terminator
+sKecleonGfx47:
+.incbin "baserom.gba", 0x148ABF0, 0x40
+sKecleonGfx47_1:
+.incbin "baserom.gba", 0x148AC30, 0xE0
+sKecleonGfx47_2:
+.incbin "baserom.gba", 0x148AD10, 0x40
+sKecleonSprites47:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx47, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx47_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx47_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx48:
+.incbin "baserom.gba", 0x148AD90, 0xC0
+sKecleonGfx48_1:
+.incbin "baserom.gba", 0x148AE50, 0x20
+sKecleonSprites48:
+ax_sprite sKecleonGfx48, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx48_1, 0x20
+ax_sprite_terminator
+sKecleonGfx49:
+.incbin "baserom.gba", 0x148AE90, 0x80
+sKecleonSprites49:
+ax_sprite sKecleonGfx49, 0x80
+ax_sprite_terminator
+sKecleonGfx50:
+.incbin "baserom.gba", 0x148AF20, 0x40
+sKecleonSprites50:
+ax_sprite sKecleonGfx50, 0x40
+ax_sprite_terminator
+sKecleonGfx51:
+.incbin "baserom.gba", 0x148AF70, 0x20
+sKecleonGfx51_1:
+.incbin "baserom.gba", 0x148AF90, 0x60
+sKecleonGfx51_2:
+.incbin "baserom.gba", 0x148AFF0, 0x60
+sKecleonGfx51_3:
+.incbin "baserom.gba", 0x148B050, 0x60
+sKecleonSprites51:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx51, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx51_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx51_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx51_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx52:
+.incbin "baserom.gba", 0x148B100, 0x100
+sKecleonSprites52:
+ax_sprite sKecleonGfx52, 0x100
+ax_sprite_terminator
+sKecleonGfx53:
+.incbin "baserom.gba", 0x148B210, 0x40
+sKecleonSprites53:
+ax_sprite sKecleonGfx53, 0x40
+ax_sprite_terminator
+sKecleonGfx54:
+.incbin "baserom.gba", 0x148B260, 0x40
+sKecleonSprites54:
+ax_sprite sKecleonGfx54, 0x40
+ax_sprite_terminator
+sKecleonGfx55:
+.incbin "baserom.gba", 0x148B2B0, 0x20
+sKecleonSprites55:
+ax_sprite sKecleonGfx55, 0x20
+ax_sprite_terminator
+sKecleonGfx56:
+.incbin "baserom.gba", 0x148B2E0, 0x60
+sKecleonGfx56_1:
+.incbin "baserom.gba", 0x148B340, 0x60
+sKecleonGfx56_2:
+.incbin "baserom.gba", 0x148B3A0, 0xE0
+sKecleonSprites56:
+ax_sprite sKecleonGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx56_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx57:
+.incbin "baserom.gba", 0x148B4B8, 0x40
+sKecleonGfx57_1:
+.incbin "baserom.gba", 0x148B4F8, 0x100
+sKecleonGfx57_2:
+.incbin "baserom.gba", 0x148B5F8, 0x40
+sKecleonSprites57:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx57, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx57_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx57_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx58:
+.incbin "baserom.gba", 0x148B678, 0x60
+sKecleonGfx58_1:
+.incbin "baserom.gba", 0x148B6D8, 0x180
+sKecleonSprites58:
+ax_sprite sKecleonGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx58_1, 0x180
+ax_sprite_terminator
+sKecleonGfx59:
+.incbin "baserom.gba", 0x148B878, 0x40
+sKecleonGfx59_1:
+.incbin "baserom.gba", 0x148B8B8, 0x40
+sKecleonGfx59_2:
+.incbin "baserom.gba", 0x148B8F8, 0x80
+sKecleonGfx59_3:
+.incbin "baserom.gba", 0x148B978, 0x60
+sKecleonSprites59:
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx59, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKecleonGfx59_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx59_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx59_3, 0x60
+ax_sprite_terminator
+sKecleonGfx60:
+.incbin "baserom.gba", 0x148BA20, 0x60
+sKecleonGfx60_1:
+.incbin "baserom.gba", 0x148BA80, 0x60
+sKecleonGfx60_2:
+.incbin "baserom.gba", 0x148BAE0, 0xE0
+sKecleonSprites60:
+ax_sprite sKecleonGfx60, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKecleonGfx60_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKecleonGfx61:
+.incbin "baserom.gba", 0x148BBF8, 0x200
+sKecleonSprites61:
+ax_sprite sKecleonGfx61, 0x200
+ax_sprite_terminator
+sKecleonGfx62:
+.incbin "baserom.gba", 0x148BE08, 0x200
+sKecleonSprites62:
+ax_sprite sKecleonGfx62, 0x200
+ax_sprite_terminator
+sKecleonGfx63:
+.incbin "baserom.gba", 0x148C018, 0x200
+sKecleonSprites63:
+ax_sprite sKecleonGfx63, 0x200
+ax_sprite_terminator
+sKecleonGfx64:
+.incbin "baserom.gba", 0x148C228, 0x200
+sKecleonSprites64:
+ax_sprite sKecleonGfx64, 0x200
+ax_sprite_terminator
+sKecleonGfx65:
+.incbin "baserom.gba", 0x148C438, 0x200
+sKecleonSprites65:
+ax_sprite sKecleonGfx65, 0x200
+ax_sprite_terminator
+sKecleonGfx66:
+.incbin "baserom.gba", 0x148C648, 0x200
+sKecleonSprites66:
+ax_sprite sKecleonGfx66, 0x200
+ax_sprite_terminator
+sKecleonGfx67:
+.incbin "baserom.gba", 0x148C858, 0x200
+sKecleonSprites67:
+ax_sprite sKecleonGfx67, 0x200
+ax_sprite_terminator
+sKecleonGfx68:
+.incbin "baserom.gba", 0x148CA68, 0x200
+sKecleonSprites68:
+ax_sprite sKecleonGfx68, 0x200
+ax_sprite_terminator
+sAxPosesKecleon:
+.4byte sKecleonPose1
+.4byte sKecleonPose2
+.4byte sKecleonPose3
+.4byte sKecleonPose4
+.4byte sKecleonPose5
+.4byte sKecleonPose6
+.4byte sKecleonPose7
+.4byte sKecleonPose8
+.4byte sKecleonPose9
+.4byte sKecleonPose10
+.4byte sKecleonPose11
+.4byte sKecleonPose12
+.4byte sKecleonPose13
+.4byte sKecleonPose14
+.4byte sKecleonPose15
+.4byte sKecleonPose16
+.4byte sKecleonPose17
+.4byte sKecleonPose18
+.4byte sKecleonPose19
+.4byte sKecleonPose20
+.4byte sKecleonPose21
+.4byte sKecleonPose22
+.4byte sKecleonPose23
+.4byte sKecleonPose24
+.4byte sKecleonPose25
+.4byte sKecleonPose26
+.4byte sKecleonPose27
+.4byte sKecleonPose28
+.4byte sKecleonPose29
+.4byte sKecleonPose30
+.4byte sKecleonPose31
+.4byte sKecleonPose32
+.4byte sKecleonPose33
+.4byte sKecleonPose34
+.4byte sKecleonPose35
+.4byte sKecleonPose36
+.4byte sKecleonPose37
+.4byte sKecleonPose38
+.4byte sKecleonPose39
+.4byte sKecleonPose40
+.4byte sKecleonPose41
+.4byte sKecleonPose42
+.4byte sKecleonPose43
+.4byte sKecleonPose44
+.4byte sKecleonPose45
+.4byte sKecleonPose46
+.4byte sKecleonPose47
+.4byte sKecleonPose48
+.4byte sKecleonPose49
+.4byte sKecleonPose50
+.4byte sKecleonPose51
+.4byte sKecleonPose52
+.4byte sKecleonPose53
+.4byte sKecleonPose54
+.4byte sKecleonPose55
+.4byte sKecleonPose56
+.4byte sKecleonPose57
+.4byte sKecleonPose58
+.4byte sKecleonPose59
+.4byte sKecleonPose60
+.4byte sKecleonPose61
+.4byte sKecleonPose62
+.4byte sKecleonPose63
+.4byte sKecleonPose64
+.4byte sKecleonPose65
+.4byte sKecleonPose66
+.4byte sKecleonPose67
+.4byte sKecleonPose68
+.4byte sKecleonPose69
+.4byte sKecleonPose70
+.4byte sKecleonPose71
+.4byte sKecleonPose72
+.4byte sKecleonPose73
+.4byte sKecleonPose74
+.4byte sKecleonPose75
+.4byte sKecleonPose76
+.4byte sKecleonPose77
+.4byte sKecleonPose78
+.4byte sKecleonPose79
+.4byte sKecleonPose80
+.4byte sKecleonPose81
+.4byte sKecleonPose82
+.4byte sKecleonPose83
+.4byte sKecleonPose84
+.4byte sKecleonPose85
+.4byte sKecleonPose86
+.4byte sKecleonPose87
+.4byte sKecleonPose88
+.4byte sKecleonPose89
+.4byte sKecleonPose90
+.4byte sKecleonPose91
+.4byte sKecleonPose92
+.4byte sKecleonPose93
+.4byte sKecleonPose94
+.4byte sKecleonPose95
+.4byte sKecleonPose96
+.4byte sKecleonPose97
+.4byte sKecleonPose98
+.4byte sKecleonPose99
+.4byte sKecleonPose100
+.4byte sKecleonPose101
+.4byte sKecleonPose102
+.4byte sKecleonPose103
+.4byte sKecleonPose104
+.4byte sKecleonPose105
+.4byte sKecleonPose106
+.4byte sKecleonPose107
+.4byte sKecleonPose108
+.4byte sKecleonPose109
+.4byte sKecleonPose110
+.4byte sKecleonPose111
+.4byte sKecleonPose112
+.4byte sKecleonPose113
+.4byte sKecleonPose114
+.4byte sKecleonPose115
+.4byte sKecleonPose116
+.4byte sKecleonPose117
+.4byte sKecleonPose118
+.4byte sKecleonPose119
+.4byte sKecleonPose120
+.4byte sKecleonPose121
+.4byte sKecleonPose122
+.4byte sKecleonPose123
+.4byte sKecleonPose124
+.4byte sKecleonPose125
+.4byte sKecleonPose126
+.4byte sKecleonPose127
+.4byte sKecleonPose128
+.4byte sKecleonPose129
+.4byte sKecleonPose130
+.4byte sKecleonPose131
+.4byte sKecleonPose132
+.4byte sKecleonPose133
+.4byte sKecleonPose134
+.4byte sKecleonPose135
+.4byte sKecleonPose136
+.4byte sKecleonPose137
+.4byte sKecleonPose138
+.4byte sKecleonPose139
+.4byte sKecleonPose140
+.4byte sKecleonPose141
+.4byte sKecleonPose142
+.4byte sKecleonPose143
+.4byte sKecleonPose144
+.4byte sKecleonPose145
+.4byte sKecleonPose146
+.4byte sKecleonPose147
+.4byte sKecleonPose148
+.4byte sKecleonPose149
+.4byte sKecleonPose150
+.4byte sKecleonPose151
+.4byte sKecleonPose152
+.4byte sKecleonPose153
+.4byte sKecleonPose154
+.4byte sKecleonPose155
+.4byte sKecleonPose156
+.4byte sKecleonPose157
+.4byte sKecleonPose158
+.4byte sKecleonPose159
+.4byte sKecleonPose160
+.4byte sKecleonPose161
+.4byte sKecleonPose162
+.4byte sKecleonPose163
+.4byte sKecleonPose164
+.4byte sKecleonPose165
+.4byte sKecleonPose166
+.4byte sKecleonPose167
+.4byte sKecleonPose168
+.4byte sKecleonPose169
+.4byte sKecleonPose170
+.4byte sKecleonPose171
+.4byte sKecleonPose172
+.4byte sKecleonPose173
+.4byte sKecleonPose174
+.4byte sKecleonPose175
+.4byte sKecleonPose176
+.4byte sKecleonPose177
+.4byte sKecleonPose178
+.4byte sKecleonPose179
+.4byte sKecleonPose180
+.4byte sKecleonPose181
+.4byte sKecleonPose182
+.4byte sKecleonPose183
+.4byte sKecleonPose184
+.4byte sKecleonPose185
+.4byte sKecleonPose186
+.4byte sKecleonPose187
+.4byte sKecleonPose188
+.4byte sKecleonPose189
+.4byte sKecleonPose190
+.4byte sKecleonPose191
+.4byte sKecleonPose192
+.4byte sKecleonPose193
+.4byte sKecleonPose194
+.4byte sKecleonPose195
+.4byte sKecleonPose196
+.4byte sKecleonPose197
+.4byte sKecleonPose198
+.4byte sKecleonPose199
+.4byte sKecleonPose200
+.4byte sKecleonPose201
+.4byte sKecleonPose202
+.4byte sKecleonPose203
+.4byte sKecleonPose204
+.4byte sKecleonPose205
+.4byte sKecleonPose206
+.4byte sKecleonPose207
+.4byte sKecleonPose208
+.4byte sKecleonPose209
+.4byte sKecleonPose210
+.4byte sKecleonPose211
+.4byte sKecleonPose212
+.4byte sKecleonPose213
+sAxPositionsKecleon:
+.2byte   -1,   -5, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte    0,   -4, 	  -2,    0, 	   7,   -2, 	   2,   -4
+.2byte   -2,   -4, 	  -8,   -2, 	   2,    0, 	  -1,   -4
+.2byte    7,   -5, 	   9,   -3, 	   3,    0, 	   0,   -4
+.2byte    7,   -4, 	   8,    0, 	  -2,   -1, 	   0,   -4
+.2byte    9,   -5, 	  10,   -3, 	   5,   -2, 	   0,   -4
+.2byte   10,   -9, 	   9,   -7, 	   8,   -2, 	   0,   -5
+.2byte    9,   -8, 	  10,   -6, 	   6,   -1, 	   1,   -4
+.2byte   10,   -9, 	   2,   -6, 	   8,   -3, 	   1,   -3
+.2byte   10,  -11, 	   0,   -8, 	   9,   -5, 	   1,   -7
+.2byte   10,  -10, 	   1,   -8, 	   9,   -4, 	   1,   -7
+.2byte    8,  -10, 	  -1,   -7, 	   7,   -5, 	   0,   -7
+.2byte   -1,  -13, 	   6,   -7, 	  -6,   -7, 	   0,   -7
+.2byte   -2,  -12, 	   4,   -6, 	  -8,   -6, 	   1,   -6
+.2byte    1,  -12, 	   7,   -5, 	  -5,   -6, 	   0,   -6
+.2byte  -11,  -11, 	  -1,   -8, 	 -10,   -5, 	  -2,   -7
+.2byte  -11,  -10, 	  -2,   -8, 	 -10,   -4, 	  -2,   -7
+.2byte   -9,  -10, 	   0,   -7, 	  -8,   -5, 	  -1,   -7
+.2byte  -11,   -9, 	 -10,   -7, 	  -9,   -2, 	  -1,   -5
+.2byte  -10,   -8, 	 -11,   -6, 	  -7,   -1, 	  -2,   -4
+.2byte  -11,   -9, 	  -3,   -6, 	  -9,   -3, 	  -2,   -3
+.2byte   -8,   -5, 	 -10,   -3, 	  -4,    0, 	  -1,   -4
+.2byte   -8,   -4, 	  -9,    0, 	   1,   -1, 	  -1,   -4
+.2byte  -10,   -5, 	 -11,   -3, 	  -6,   -2, 	  -1,   -4
+.2byte   -1,   -5, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte    0,   -4, 	  -2,    0, 	   7,   -2, 	   2,   -4
+.2byte   -2,   -4, 	  -8,   -2, 	   2,    0, 	  -1,   -4
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte    7,   -5, 	   9,   -3, 	   3,    0, 	   0,   -4
+.2byte    7,   -4, 	   8,    0, 	  -2,   -1, 	   0,   -4
+.2byte    9,   -5, 	  10,   -3, 	   5,   -2, 	   0,   -4
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte   10,   -9, 	   9,   -7, 	   8,   -2, 	   0,   -5
+.2byte    9,   -8, 	  10,   -6, 	   6,   -1, 	   1,   -4
+.2byte   10,   -9, 	   2,   -6, 	   8,   -3, 	   1,   -3
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte   10,  -11, 	   0,   -8, 	   9,   -5, 	   1,   -7
+.2byte   10,  -10, 	   1,   -8, 	   9,   -4, 	   1,   -7
+.2byte    8,  -10, 	  -1,   -7, 	   7,   -5, 	   0,   -7
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte   -1,  -13, 	   6,   -7, 	  -6,   -7, 	   0,   -7
+.2byte   -2,  -12, 	   4,   -6, 	  -8,   -6, 	   1,   -6
+.2byte    1,  -12, 	   7,   -5, 	  -5,   -6, 	   0,   -6
+.2byte   -1,  -15, 	   7,   -8, 	  -7,   -8, 	   0,   -7
+.2byte  -11,  -11, 	  -1,   -8, 	 -10,   -5, 	  -2,   -7
+.2byte  -11,  -10, 	  -2,   -8, 	 -10,   -4, 	  -2,   -7
+.2byte   -9,  -10, 	   0,   -7, 	  -8,   -5, 	  -1,   -7
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte  -11,   -9, 	 -10,   -7, 	  -9,   -2, 	  -1,   -5
+.2byte  -10,   -8, 	 -11,   -6, 	  -7,   -1, 	  -2,   -4
+.2byte  -11,   -9, 	  -3,   -6, 	  -9,   -3, 	  -2,   -3
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte   -8,   -5, 	 -10,   -3, 	  -4,    0, 	  -1,   -4
+.2byte   -8,   -4, 	  -9,    0, 	   1,   -1, 	  -1,   -4
+.2byte  -10,   -5, 	 -11,   -3, 	  -6,   -2, 	  -1,   -4
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte   -3,   -7, 	  -8,  -11, 	   1,   -5, 	  -1,   -6
+.2byte    1,   -2, 	   3,    0, 	   8,  -10, 	   0,   -2
+.2byte    1,   -2, 	   3,    0, 	   8,  -10, 	   0,   -2
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte    5,   -8, 	   2,  -11, 	   2,   -6, 	  -1,   -7
+.2byte    7,   -3, 	   1,   -1, 	  -5,   -9, 	   2,   -4
+.2byte    7,   -3, 	   1,   -1, 	  -5,   -9, 	   2,   -4
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte    7,  -12, 	  -2,   -9, 	   4,   -6, 	  -1,   -7
+.2byte   14,   -8, 	  12,   -4, 	   0,  -10, 	   4,   -6
+.2byte   14,   -8, 	  12,   -4, 	   0,  -10, 	   4,   -6
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte    4,  -14, 	  -8,  -13, 	   2,  -10, 	  -2,   -9
+.2byte    9,  -13, 	  11,   -8, 	   6,  -10, 	   2,  -10
+.2byte    9,  -13, 	  11,   -8, 	   6,  -10, 	   2,  -10
+.2byte   -1,  -15, 	   7,   -8, 	  -7,   -8, 	   0,   -7
+.2byte    4,  -16, 	   9,  -11, 	   2,   -8, 	   2,   -7
+.2byte   -2,  -18, 	  -1,  -12, 	   0,   -9, 	   0,   -8
+.2byte   -2,  -18, 	  -1,  -12, 	   0,   -9, 	   0,   -8
+.2byte   -3,  -16, 	  -8,  -11, 	  -1,   -8, 	  -1,   -7
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte   -3,  -14, 	   9,  -13, 	  -1,  -10, 	   3,   -9
+.2byte   -8,  -13, 	 -10,   -8, 	  -5,  -10, 	  -1,  -10
+.2byte   -8,  -13, 	 -10,   -8, 	  -5,  -10, 	  -1,  -10
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte   -8,  -12, 	   1,   -9, 	  -5,   -6, 	   0,   -7
+.2byte  -15,   -8, 	 -13,   -4, 	  -1,  -10, 	  -5,   -6
+.2byte  -15,   -8, 	 -13,   -4, 	  -1,  -10, 	  -5,   -6
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -6,   -8, 	  -3,  -11, 	  -3,   -6, 	   0,   -7
+.2byte   -8,   -3, 	  -2,   -1, 	   4,   -9, 	  -3,   -4
+.2byte   -8,   -3, 	  -2,   -1, 	   4,   -9, 	  -3,   -4
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte    0,  -12, 	  -8,   -6, 	   7,   -6, 	  -1,   -7
+.2byte    0,    0, 	  -5,    0, 	   4,    0, 	  -1,   -5
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte    1,  -15, 	   5,   -8, 	  -5,   -3, 	  -1,   -6
+.2byte    9,   -4, 	   3,   -2, 	   0,    0, 	   1,   -4
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte    1,  -16, 	  -2,   -5, 	  -1,   -3, 	  -2,   -4
+.2byte    9,   -7, 	   4,   -3, 	   5,   -2, 	   2,   -7
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte    1,  -17, 	  -2,   -7, 	   5,   -4, 	  -2,   -4
+.2byte    8,  -18, 	  -1,  -10, 	   6,   -7, 	   0,   -6
+.2byte   -1,  -15, 	   7,   -8, 	  -7,   -8, 	   0,   -7
+.2byte    0,  -19, 	   6,   -5, 	  -7,   -5, 	  -1,   -5
+.2byte   -1,  -19, 	   6,  -10, 	  -7,  -10, 	  -1,   -7
+.2byte   -1,  -13, 	   6,   -7, 	  -6,   -7, 	   0,   -7
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte   -2,  -17, 	   1,   -7, 	  -6,   -4, 	   1,   -4
+.2byte   -9,  -18, 	   0,  -10, 	  -7,   -7, 	  -1,   -6
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte   -2,  -16, 	   1,   -5, 	   0,   -3, 	   1,   -4
+.2byte  -10,   -7, 	  -5,   -3, 	  -6,   -2, 	  -3,   -7
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -2,  -15, 	  -6,   -8, 	   4,   -3, 	   0,   -6
+.2byte  -10,   -4, 	  -4,   -2, 	  -1,    0, 	  -2,   -4
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte    0,   -9, 	 -11,   -7, 	  10,   -7, 	   0,   -7
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte    4,  -10, 	   7,   -9, 	  -7,   -5, 	  -2,   -8
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte   10,  -12, 	   3,   -9, 	   7,   -3, 	   0,   -9
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte    7,  -15, 	  -4,  -12, 	  10,   -8, 	  -1,   -9
+.2byte   -1,  -15, 	   7,   -8, 	  -7,   -8, 	   0,   -7
+.2byte   -1,  -18, 	   8,   -9, 	  -9,   -9, 	   0,   -6
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte   -8,  -15, 	   3,  -12, 	 -11,   -8, 	   0,   -9
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte  -11,  -12, 	  -4,   -9, 	  -8,   -3, 	  -1,   -9
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -5,  -10, 	  -8,   -9, 	   6,   -5, 	   1,   -8
+.2byte   -4,   -6, 	  -5,   -4, 	   5,   -1, 	   1,   -5
+.2byte   -4,   -5, 	  -5,   -4, 	   5,   -1, 	   1,   -5
+.2byte    0,  -11, 	  -8,  -12, 	   7,  -12, 	   0,   -8
+.2byte    3,  -13, 	   6,  -12, 	  -6,  -10, 	   1,   -8
+.2byte    5,  -16, 	  -3,  -13, 	  -6,  -11, 	   0,   -8
+.2byte    2,  -16, 	  -3,  -14, 	   4,  -14, 	   0,   -8
+.2byte   -1,  -16, 	   7,  -12, 	  -8,  -12, 	   0,   -7
+.2byte   -3,  -16, 	   2,  -14, 	  -5,  -14, 	  -1,   -8
+.2byte   -7,  -16, 	   1,  -13, 	   4,  -11, 	  -2,   -8
+.2byte   -4,  -13, 	  -7,  -12, 	   5,  -10, 	  -2,   -8
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -15, 	   7,   -8, 	  -7,   -8, 	   0,   -7
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -3, 	   5,   -3, 	   0,   -7
+.2byte   -6,   -8, 	  -8,   -6, 	  -2,   -3, 	   1,   -7
+.2byte  -10,  -11, 	  -9,   -9, 	  -8,   -4, 	   0,   -7
+.2byte  -11,  -14, 	  -1,  -11, 	 -10,   -8, 	  -2,  -10
+.2byte   -1,  -15, 	   6,   -9, 	  -6,   -9, 	   0,   -9
+.2byte   10,  -13, 	   0,  -10, 	   9,   -7, 	   1,   -9
+.2byte   10,  -11, 	   9,   -9, 	   8,   -4, 	   0,   -7
+.2byte    5,   -8, 	   7,   -6, 	   1,   -3, 	  -2,   -7
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte   -2,  -15, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte   -4,   -7, 	  -9,  -11, 	   0,   -5, 	  -2,   -6
+.2byte    6,   -8, 	   3,  -11, 	   3,   -6, 	   0,   -7
+.2byte    8,  -12, 	  -1,   -9, 	   5,   -6, 	   0,   -7
+.2byte    4,  -13, 	  -8,  -12, 	   2,   -9, 	  -2,   -8
+.2byte    3,  -17, 	   8,  -12, 	   1,   -9, 	   1,   -8
+.2byte   -3,  -13, 	   9,  -12, 	  -1,   -9, 	   3,   -8
+.2byte   -9,  -12, 	   0,   -9, 	  -6,   -6, 	  -1,   -7
+.2byte   -6,   -8, 	  -3,  -11, 	  -3,   -6, 	   0,   -7
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte    0,  -12, 	  -8,   -6, 	   7,   -6, 	  -1,   -7
+.2byte    0,    0, 	  -5,    0, 	   4,    0, 	  -1,   -5
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte    1,  -15, 	   5,   -8, 	  -5,   -3, 	  -1,   -6
+.2byte    8,   -4, 	   2,   -2, 	  -1,    0, 	   0,   -4
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte    1,  -16, 	  -2,   -5, 	  -1,   -3, 	  -2,   -4
+.2byte    9,   -7, 	   4,   -3, 	   5,   -2, 	   2,   -7
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte    1,  -17, 	  -2,   -7, 	   5,   -4, 	  -2,   -4
+.2byte    8,  -18, 	  -1,  -10, 	   6,   -7, 	   0,   -6
+.2byte   -1,  -15, 	   7,   -8, 	  -7,   -8, 	   0,   -7
+.2byte    0,  -19, 	   6,   -5, 	  -7,   -5, 	  -1,   -5
+.2byte   -1,  -19, 	   6,  -10, 	  -7,  -10, 	  -1,   -7
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte   -2,  -17, 	   1,   -7, 	  -6,   -4, 	   1,   -4
+.2byte   -9,  -18, 	   0,  -10, 	  -7,   -7, 	  -1,   -6
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte   -2,  -16, 	   1,   -5, 	   0,   -3, 	   1,   -4
+.2byte  -10,   -7, 	  -5,   -3, 	  -6,   -2, 	  -3,   -7
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -2,  -15, 	  -6,   -8, 	   4,   -3, 	   0,   -6
+.2byte   -9,   -4, 	  -3,   -2, 	   0,    0, 	  -1,   -4
+.2byte    0,  -12, 	  -8,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -2,  -15, 	  -6,   -8, 	   4,   -3, 	   0,   -6
+.2byte   -3,  -16, 	   0,   -5, 	  -1,   -3, 	   0,   -4
+.2byte   -3,  -18, 	   0,   -8, 	  -7,   -5, 	   0,   -5
+.2byte    0,  -19, 	   6,   -5, 	  -7,   -5, 	  -1,   -5
+.2byte    1,  -17, 	  -2,   -7, 	   5,   -4, 	  -2,   -4
+.2byte    3,  -16, 	   0,   -5, 	   1,   -3, 	   0,   -4
+.2byte    1,  -15, 	   5,   -8, 	  -5,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -9,   -6, 	   8,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -7, 	   4,   -3, 	   0,   -6
+.2byte   -8,  -11, 	  -4,   -8, 	  -6,   -3, 	   0,   -5
+.2byte   -8,  -13, 	   3,   -9, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -15, 	   7,   -8, 	  -7,   -8, 	   0,   -7
+.2byte    7,  -13, 	  -4,   -9, 	   7,   -6, 	  -1,   -7
+.2byte    7,  -11, 	   3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte    3,   -8, 	   7,   -7, 	  -5,   -3, 	  -1,   -6
+.2byte    0,  -11, 	  -8,  -13, 	   7,  -13, 	   0,   -7
+sKecleonAnimTable1:
+.4byte sKecleonAnims_1_1
+.4byte sKecleonAnims_1_2
+.4byte sKecleonAnims_1_3
+.4byte sKecleonAnims_1_4
+.4byte sKecleonAnims_1_5
+.4byte sKecleonAnims_1_6
+.4byte sKecleonAnims_1_7
+.4byte sKecleonAnims_1_8
+sKecleonAnimTable2:
+.4byte sKecleonAnims_2_1
+.4byte sKecleonAnims_2_2
+.4byte sKecleonAnims_2_3
+.4byte sKecleonAnims_2_4
+.4byte sKecleonAnims_2_5
+.4byte sKecleonAnims_2_6
+.4byte sKecleonAnims_2_7
+.4byte sKecleonAnims_2_8
+sKecleonAnimTable3:
+.4byte sKecleonAnims_3_1
+.4byte sKecleonAnims_3_2
+.4byte sKecleonAnims_3_3
+.4byte sKecleonAnims_3_4
+.4byte sKecleonAnims_3_5
+.4byte sKecleonAnims_3_6
+.4byte sKecleonAnims_3_7
+.4byte sKecleonAnims_3_8
+sKecleonAnimTable4:
+.4byte sKecleonAnims_4_1
+.4byte sKecleonAnims_4_2
+.4byte sKecleonAnims_4_3
+.4byte sKecleonAnims_4_4
+.4byte sKecleonAnims_4_5
+.4byte sKecleonAnims_4_6
+.4byte sKecleonAnims_4_7
+.4byte sKecleonAnims_4_8
+sKecleonAnimTable5:
+.4byte sKecleonAnims_5_1
+.4byte sKecleonAnims_5_2
+.4byte sKecleonAnims_5_3
+.4byte sKecleonAnims_5_4
+.4byte sKecleonAnims_5_5
+.4byte sKecleonAnims_5_6
+.4byte sKecleonAnims_5_7
+.4byte sKecleonAnims_5_8
+sKecleonAnimTable6:
+.4byte sKecleonAnims_6_1
+.4byte sKecleonAnims_6_1
+.4byte sKecleonAnims_6_1
+.4byte sKecleonAnims_6_1
+.4byte sKecleonAnims_6_1
+.4byte sKecleonAnims_6_1
+.4byte sKecleonAnims_6_1
+.4byte sKecleonAnims_6_1
+sKecleonAnimTable7:
+.4byte sKecleonAnims_7_1
+.4byte sKecleonAnims_7_2
+.4byte sKecleonAnims_7_3
+.4byte sKecleonAnims_7_4
+.4byte sKecleonAnims_7_5
+.4byte sKecleonAnims_7_6
+.4byte sKecleonAnims_7_7
+.4byte sKecleonAnims_7_8
+sKecleonAnimTable8:
+.4byte sKecleonAnims_8_1
+.4byte sKecleonAnims_8_2
+.4byte sKecleonAnims_8_3
+.4byte sKecleonAnims_8_4
+.4byte sKecleonAnims_8_5
+.4byte sKecleonAnims_8_6
+.4byte sKecleonAnims_8_7
+.4byte sKecleonAnims_8_8
+sKecleonAnimTable9:
+.4byte sKecleonAnims_9_1
+.4byte sKecleonAnims_9_2
+.4byte sKecleonAnims_9_3
+.4byte sKecleonAnims_9_4
+.4byte sKecleonAnims_9_5
+.4byte sKecleonAnims_9_6
+.4byte sKecleonAnims_9_7
+.4byte sKecleonAnims_9_8
+sKecleonAnimTable10:
+.4byte sKecleonAnims_10_1
+.4byte sKecleonAnims_10_2
+.4byte sKecleonAnims_10_3
+.4byte sKecleonAnims_10_4
+.4byte sKecleonAnims_10_5
+.4byte sKecleonAnims_10_6
+.4byte sKecleonAnims_10_7
+.4byte sKecleonAnims_10_8
+sKecleonAnimTable11:
+.4byte sKecleonAnims_11_1
+.4byte sKecleonAnims_11_2
+.4byte sKecleonAnims_11_3
+.4byte sKecleonAnims_11_4
+.4byte sKecleonAnims_11_5
+.4byte sKecleonAnims_11_6
+.4byte sKecleonAnims_11_7
+.4byte sKecleonAnims_11_8
+sKecleonAnimTable12:
+.4byte sKecleonAnims_12_1
+.4byte sKecleonAnims_12_2
+.4byte sKecleonAnims_12_3
+.4byte sKecleonAnims_12_4
+.4byte sKecleonAnims_12_5
+.4byte sKecleonAnims_12_6
+.4byte sKecleonAnims_12_7
+.4byte sKecleonAnims_12_8
+sKecleonAnimTable13:
+.4byte sKecleonAnims_13_1
+.4byte sKecleonAnims_13_2
+.4byte sKecleonAnims_13_3
+.4byte sKecleonAnims_13_4
+.4byte sKecleonAnims_13_5
+.4byte sKecleonAnims_13_6
+.4byte sKecleonAnims_13_7
+.4byte sKecleonAnims_13_8
+sKecleonAnimTable14:
+.4byte sKecleonAnims_14_1
+.4byte sKecleonAnims_14_1
+.4byte sKecleonAnims_14_1
+.4byte sKecleonAnims_14_1
+.4byte sKecleonAnims_14_1
+.4byte sKecleonAnims_14_1
+.4byte sKecleonAnims_14_1
+.4byte sKecleonAnims_14_1
+sAxAnimationsKecleon:
+.4byte sKecleonAnimTable1
+.4byte sKecleonAnimTable2
+.4byte sKecleonAnimTable3
+.4byte sKecleonAnimTable4
+.4byte sKecleonAnimTable5
+.4byte sKecleonAnimTable6
+.4byte sKecleonAnimTable7
+.4byte sKecleonAnimTable8
+.4byte sKecleonAnimTable9
+.4byte sKecleonAnimTable10
+.4byte sKecleonAnimTable11
+.4byte sKecleonAnimTable12
+.4byte sKecleonAnimTable13
+.4byte sKecleonAnimTable14
+sAxSpritesKecleon:
+.4byte sKecleonSprites1
+.4byte sKecleonSprites2
+.4byte sKecleonSprites3
+.4byte sKecleonSprites4
+.4byte sKecleonSprites5
+.4byte sKecleonSprites6
+.4byte sKecleonSprites7
+.4byte sKecleonSprites8
+.4byte sKecleonSprites9
+.4byte sKecleonSprites10
+.4byte sKecleonSprites11
+.4byte sKecleonSprites12
+.4byte sKecleonSprites13
+.4byte sKecleonSprites14
+.4byte sKecleonSprites15
+.4byte sKecleonSprites16
+.4byte sKecleonSprites17
+.4byte sKecleonSprites18
+.4byte sKecleonSprites19
+.4byte sKecleonSprites20
+.4byte sKecleonSprites21
+.4byte sKecleonSprites22
+.4byte sKecleonSprites23
+.4byte sKecleonSprites24
+.4byte sKecleonSprites25
+.4byte sKecleonSprites26
+.4byte sKecleonSprites27
+.4byte sKecleonSprites28
+.4byte sKecleonSprites29
+.4byte sKecleonSprites30
+.4byte sKecleonSprites31
+.4byte sKecleonSprites32
+.4byte sKecleonSprites33
+.4byte sKecleonSprites34
+.4byte sKecleonSprites35
+.4byte sKecleonSprites36
+.4byte sKecleonSprites37
+.4byte sKecleonSprites38
+.4byte sKecleonSprites39
+.4byte sKecleonSprites40
+.4byte sKecleonSprites41
+.4byte sKecleonSprites42
+.4byte sKecleonSprites43
+.4byte sKecleonSprites44
+.4byte sKecleonSprites45
+.4byte sKecleonSprites46
+.4byte sKecleonSprites47
+.4byte sKecleonSprites48
+.4byte sKecleonSprites49
+.4byte sKecleonSprites50
+.4byte sKecleonSprites51
+.4byte sKecleonSprites52
+.4byte sKecleonSprites53
+.4byte sKecleonSprites54
+.4byte sKecleonSprites55
+.4byte sKecleonSprites56
+.4byte sKecleonSprites57
+.4byte sKecleonSprites58
+.4byte sKecleonSprites59
+.4byte sKecleonSprites60
+.4byte sKecleonSprites61
+.4byte sKecleonSprites62
+.4byte sKecleonSprites63
+.4byte sKecleonSprites64
+.4byte sKecleonSprites65
+.4byte sKecleonSprites66
+.4byte sKecleonSprites67
+.4byte sKecleonSprites68
+sAxMainKecleon:
+ax_main sAxPosesKecleon, sAxAnimationsKecleon, 14, sAxSpritesKecleon, sAxPositionsKecleon

--- a/data/ax/kingdra.inc
+++ b/data/ax/kingdra.inc
@@ -1,0 +1,3096 @@
+.global gAxKingdra
+gAxKingdra:
+ax_siro sAxMainKingdra
+sKingdraPose1:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose2:
+ax_pose 1, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose3:
+ax_pose 2, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose4:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose5:
+ax_pose 4, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose6:
+ax_pose 5, 0x01df, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose7:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose8:
+ax_pose 7, 0x01de, 0x90f2, 0x0c00
+ax_pose_terminator
+sKingdraPose9:
+ax_pose 8, 0x81de, 0x9100, 0x0c00
+ax_pose 9, 0x81de, 0x50f8, 0x0c08
+ax_pose 10, 0x81ee, 0x10f0, 0x0c0c
+ax_pose 11, 0x01fe, 0x10fa, 0x0c0e
+ax_pose_terminator
+sKingdraPose10:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose11:
+ax_pose 13, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose12:
+ax_pose 14, 0x81de, 0x9100, 0x0c00
+ax_pose 15, 0x81de, 0x50f8, 0x0c08
+ax_pose 16, 0x01fe, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose13:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose14:
+ax_pose 18, 0x81e1, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose15:
+ax_pose 19, 0x81df, 0x80f8, 0x0c00
+ax_pose 20, 0x01ff, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose16:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose17:
+ax_pose 13, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose18:
+ax_pose 14, 0x81de, 0x80f0, 0x0c00
+ax_pose 15, 0x81de, 0x4100, 0x0c08
+ax_pose 16, 0x01fe, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose19:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose20:
+ax_pose 7, 0x01de, 0x80ee, 0x0c00
+ax_pose_terminator
+sKingdraPose21:
+ax_pose 8, 0x81de, 0x80f0, 0x0c00
+ax_pose 9, 0x81de, 0x4100, 0x0c08
+ax_pose 10, 0x81ee, 0x0108, 0x0c0c
+ax_pose 11, 0x01fe, 0x00fe, 0x0c0e
+ax_pose_terminator
+sKingdraPose22:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose23:
+ax_pose 4, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose24:
+ax_pose 5, 0x01df, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose25:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose26:
+ax_pose 1, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose27:
+ax_pose 2, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose28:
+ax_pose 21, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sKingdraPose29:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose30:
+ax_pose 4, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose31:
+ax_pose 5, 0x01df, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose32:
+ax_pose 22, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose33:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose34:
+ax_pose 7, 0x01de, 0x90f2, 0x0c00
+ax_pose_terminator
+sKingdraPose35:
+ax_pose 8, 0x81de, 0x9100, 0x0c00
+ax_pose 9, 0x81de, 0x50f8, 0x0c08
+ax_pose 10, 0x81ee, 0x10f0, 0x0c0c
+ax_pose 11, 0x01fe, 0x10fa, 0x0c0e
+ax_pose_terminator
+sKingdraPose36:
+ax_pose 23, 0x81df, 0x9102, 0x0c00
+ax_pose 24, 0x81df, 0x50fa, 0x0c08
+ax_pose 25, 0x01e7, 0x10f2, 0x0c0c
+ax_pose 26, 0x81ef, 0x10f2, 0x0c0d
+ax_pose 27, 0x01f7, 0x10ea, 0x0c0f
+ax_pose_terminator
+sKingdraPose37:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose38:
+ax_pose 13, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose39:
+ax_pose 14, 0x81de, 0x9100, 0x0c00
+ax_pose 15, 0x81de, 0x50f8, 0x0c08
+ax_pose 16, 0x01fe, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose40:
+ax_pose 28, 0x81e0, 0x90ff, 0x0c00
+ax_pose 29, 0x81e0, 0x50f7, 0x0c08
+ax_pose 30, 0x0200, 0x10f7, 0x0c0c
+ax_pose_terminator
+sKingdraPose41:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose42:
+ax_pose 18, 0x81e1, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose43:
+ax_pose 19, 0x81df, 0x80f8, 0x0c00
+ax_pose 20, 0x01ff, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose44:
+ax_pose 31, 0x81e0, 0x80f8, 0x0c00
+ax_pose 32, 0x0200, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose45:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose46:
+ax_pose 13, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose47:
+ax_pose 14, 0x81de, 0x80f0, 0x0c00
+ax_pose 15, 0x81de, 0x4100, 0x0c08
+ax_pose 16, 0x01fe, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose48:
+ax_pose 28, 0x81e0, 0x80f1, 0x0c00
+ax_pose 29, 0x81e0, 0x4101, 0x0c08
+ax_pose 30, 0x0200, 0x0101, 0x0c0c
+ax_pose_terminator
+sKingdraPose49:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose50:
+ax_pose 7, 0x01de, 0x80ee, 0x0c00
+ax_pose_terminator
+sKingdraPose51:
+ax_pose 8, 0x81de, 0x80f0, 0x0c00
+ax_pose 9, 0x81de, 0x4100, 0x0c08
+ax_pose 10, 0x81ee, 0x0108, 0x0c0c
+ax_pose 11, 0x01fe, 0x00fe, 0x0c0e
+ax_pose_terminator
+sKingdraPose52:
+ax_pose 23, 0x81df, 0x80ee, 0x0c00
+ax_pose 24, 0x81df, 0x40fe, 0x0c08
+ax_pose 25, 0x01e7, 0x0106, 0x0c0c
+ax_pose 26, 0x81ef, 0x0106, 0x0c0d
+ax_pose 27, 0x01f7, 0x010e, 0x0c0f
+ax_pose_terminator
+sKingdraPose53:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose54:
+ax_pose 4, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose55:
+ax_pose 5, 0x01df, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose56:
+ax_pose 22, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose57:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose58:
+ax_pose 1, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose59:
+ax_pose 2, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose60:
+ax_pose 21, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sKingdraPose61:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose62:
+ax_pose 4, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose63:
+ax_pose 5, 0x01df, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose64:
+ax_pose 22, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose65:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose66:
+ax_pose 7, 0x01de, 0x90f2, 0x0c00
+ax_pose_terminator
+sKingdraPose67:
+ax_pose 8, 0x81de, 0x9100, 0x0c00
+ax_pose 9, 0x81de, 0x50f8, 0x0c08
+ax_pose 10, 0x81ee, 0x10f0, 0x0c0c
+ax_pose 11, 0x01fe, 0x10fa, 0x0c0e
+ax_pose_terminator
+sKingdraPose68:
+ax_pose 23, 0x81df, 0x9102, 0x0c00
+ax_pose 24, 0x81df, 0x50fa, 0x0c08
+ax_pose 25, 0x01e7, 0x10f2, 0x0c0c
+ax_pose 26, 0x81ef, 0x10f2, 0x0c0d
+ax_pose 27, 0x01f7, 0x10ea, 0x0c0f
+ax_pose_terminator
+sKingdraPose69:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose70:
+ax_pose 13, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose71:
+ax_pose 14, 0x81de, 0x9100, 0x0c00
+ax_pose 15, 0x81de, 0x50f8, 0x0c08
+ax_pose 16, 0x01fe, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose72:
+ax_pose 28, 0x81e0, 0x90ff, 0x0c00
+ax_pose 29, 0x81e0, 0x50f7, 0x0c08
+ax_pose 30, 0x0200, 0x10f7, 0x0c0c
+ax_pose_terminator
+sKingdraPose73:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose74:
+ax_pose 18, 0x81e1, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose75:
+ax_pose 19, 0x81df, 0x80f8, 0x0c00
+ax_pose 20, 0x01ff, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose76:
+ax_pose 31, 0x81e0, 0x80f8, 0x0c00
+ax_pose 32, 0x0200, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose77:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose78:
+ax_pose 13, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose79:
+ax_pose 14, 0x81de, 0x80f0, 0x0c00
+ax_pose 15, 0x81de, 0x4100, 0x0c08
+ax_pose 16, 0x01fe, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose80:
+ax_pose 28, 0x81e0, 0x80f1, 0x0c00
+ax_pose 29, 0x81e0, 0x4101, 0x0c08
+ax_pose 30, 0x0200, 0x0101, 0x0c0c
+ax_pose_terminator
+sKingdraPose81:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose82:
+ax_pose 7, 0x01de, 0x80ee, 0x0c00
+ax_pose_terminator
+sKingdraPose83:
+ax_pose 8, 0x81de, 0x80f0, 0x0c00
+ax_pose 9, 0x81de, 0x4100, 0x0c08
+ax_pose 10, 0x81ee, 0x0108, 0x0c0c
+ax_pose 11, 0x01fe, 0x00fe, 0x0c0e
+ax_pose_terminator
+sKingdraPose84:
+ax_pose 23, 0x81df, 0x80ee, 0x0c00
+ax_pose 24, 0x81df, 0x40fe, 0x0c08
+ax_pose 25, 0x01e7, 0x0106, 0x0c0c
+ax_pose 26, 0x81ef, 0x0106, 0x0c0d
+ax_pose 27, 0x01f7, 0x010e, 0x0c0f
+ax_pose_terminator
+sKingdraPose85:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose86:
+ax_pose 4, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose87:
+ax_pose 5, 0x01df, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose88:
+ax_pose 22, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose89:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose90:
+ax_pose 1, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose91:
+ax_pose 2, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose92:
+ax_pose 33, 0x81de, 0x80f8, 0x0c00
+ax_pose 34, 0x01fe, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose93:
+ax_pose 21, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sKingdraPose94:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose95:
+ax_pose 4, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose96:
+ax_pose 5, 0x01df, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose97:
+ax_pose 35, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose98:
+ax_pose 22, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose99:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose100:
+ax_pose 7, 0x01de, 0x90f2, 0x0c00
+ax_pose_terminator
+sKingdraPose101:
+ax_pose 8, 0x81de, 0x9100, 0x0c00
+ax_pose 9, 0x81de, 0x50f8, 0x0c08
+ax_pose 10, 0x81ee, 0x10f0, 0x0c0c
+ax_pose 11, 0x01fe, 0x10fa, 0x0c0e
+ax_pose_terminator
+sKingdraPose102:
+ax_pose 36, 0x01df, 0x90e9, 0x0c00
+ax_pose_terminator
+sKingdraPose103:
+ax_pose 23, 0x81df, 0x9102, 0x0c00
+ax_pose 24, 0x81df, 0x50fa, 0x0c08
+ax_pose 25, 0x01e7, 0x10f2, 0x0c0c
+ax_pose 26, 0x81ef, 0x10f2, 0x0c0d
+ax_pose 27, 0x01f7, 0x10ea, 0x0c0f
+ax_pose_terminator
+sKingdraPose104:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose105:
+ax_pose 13, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose106:
+ax_pose 14, 0x81de, 0x9100, 0x0c00
+ax_pose 15, 0x81de, 0x50f8, 0x0c08
+ax_pose 16, 0x01fe, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose107:
+ax_pose 37, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose108:
+ax_pose 28, 0x81e0, 0x90ff, 0x0c00
+ax_pose 29, 0x81e0, 0x50f7, 0x0c08
+ax_pose 30, 0x0200, 0x10f7, 0x0c0c
+ax_pose_terminator
+sKingdraPose109:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose110:
+ax_pose 18, 0x81e1, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose111:
+ax_pose 19, 0x81df, 0x80f8, 0x0c00
+ax_pose 20, 0x01ff, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose112:
+ax_pose 38, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose113:
+ax_pose 31, 0x81e0, 0x80f8, 0x0c00
+ax_pose 32, 0x0200, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose114:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose115:
+ax_pose 13, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose116:
+ax_pose 14, 0x81de, 0x80f0, 0x0c00
+ax_pose 15, 0x81de, 0x4100, 0x0c08
+ax_pose 16, 0x01fe, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose117:
+ax_pose 37, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose118:
+ax_pose 28, 0x81e0, 0x80f1, 0x0c00
+ax_pose 29, 0x81e0, 0x4101, 0x0c08
+ax_pose 30, 0x0200, 0x0101, 0x0c0c
+ax_pose_terminator
+sKingdraPose119:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose120:
+ax_pose 7, 0x01de, 0x80ee, 0x0c00
+ax_pose_terminator
+sKingdraPose121:
+ax_pose 8, 0x81de, 0x80f0, 0x0c00
+ax_pose 9, 0x81de, 0x4100, 0x0c08
+ax_pose 10, 0x81ee, 0x0108, 0x0c0c
+ax_pose 11, 0x01fe, 0x00fe, 0x0c0e
+ax_pose_terminator
+sKingdraPose122:
+ax_pose 36, 0x01df, 0x80f7, 0x0c00
+ax_pose_terminator
+sKingdraPose123:
+ax_pose 23, 0x81df, 0x80ee, 0x0c00
+ax_pose 24, 0x81df, 0x40fe, 0x0c08
+ax_pose 25, 0x01e7, 0x0106, 0x0c0c
+ax_pose 26, 0x81ef, 0x0106, 0x0c0d
+ax_pose 27, 0x01f7, 0x010e, 0x0c0f
+ax_pose_terminator
+sKingdraPose124:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose125:
+ax_pose 4, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose126:
+ax_pose 5, 0x01df, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose127:
+ax_pose 35, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose128:
+ax_pose 22, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose129:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose130:
+ax_pose 1, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose131:
+ax_pose 2, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose132:
+ax_pose 39, 0x81de, 0x80f8, 0x0c00
+ax_pose 40, 0x01fe, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose133:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose134:
+ax_pose 4, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose135:
+ax_pose 5, 0x01df, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose136:
+ax_pose 41, 0x81dc, 0x90f8, 0x0c00
+ax_pose 42, 0x01fc, 0x10fc, 0x0c08
+ax_pose 43, 0x81e4, 0x10f0, 0x0c09
+ax_pose_terminator
+sKingdraPose137:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose138:
+ax_pose 7, 0x01de, 0x90f2, 0x0c00
+ax_pose_terminator
+sKingdraPose139:
+ax_pose 8, 0x81de, 0x9100, 0x0c00
+ax_pose 9, 0x81de, 0x50f8, 0x0c08
+ax_pose 10, 0x81ee, 0x10f0, 0x0c0c
+ax_pose 11, 0x01fe, 0x10fa, 0x0c0e
+ax_pose_terminator
+sKingdraPose140:
+ax_pose 44, 0x81dc, 0x90f7, 0x0c00
+ax_pose 45, 0x81dc, 0x50ef, 0x0c08
+ax_pose 46, 0x01fc, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose141:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose142:
+ax_pose 13, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose143:
+ax_pose 14, 0x81de, 0x9100, 0x0c00
+ax_pose 15, 0x81de, 0x50f8, 0x0c08
+ax_pose 16, 0x01fe, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose144:
+ax_pose 47, 0x81dc, 0x90f8, 0x0c00
+ax_pose 48, 0x81e4, 0x10f0, 0x0c08
+ax_pose 49, 0x01fc, 0x10fc, 0x0c0a
+ax_pose_terminator
+sKingdraPose145:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose146:
+ax_pose 18, 0x81e1, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose147:
+ax_pose 19, 0x81df, 0x80f8, 0x0c00
+ax_pose 20, 0x01ff, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose148:
+ax_pose 50, 0x81dc, 0x80f8, 0x0c00
+ax_pose 51, 0x01fc, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose149:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose150:
+ax_pose 13, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose151:
+ax_pose 14, 0x81de, 0x80f0, 0x0c00
+ax_pose 15, 0x81de, 0x4100, 0x0c08
+ax_pose 16, 0x01fe, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose152:
+ax_pose 47, 0x81dc, 0x80f8, 0x0c00
+ax_pose 48, 0x81e4, 0x0108, 0x0c08
+ax_pose 49, 0x01fc, 0x00fc, 0x0c0a
+ax_pose_terminator
+sKingdraPose153:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose154:
+ax_pose 7, 0x01de, 0x80ee, 0x0c00
+ax_pose_terminator
+sKingdraPose155:
+ax_pose 8, 0x81de, 0x80f0, 0x0c00
+ax_pose 9, 0x81de, 0x4100, 0x0c08
+ax_pose 10, 0x81ee, 0x0108, 0x0c0c
+ax_pose 11, 0x01fe, 0x00fe, 0x0c0e
+ax_pose_terminator
+sKingdraPose156:
+ax_pose 44, 0x81dc, 0x80f9, 0x0c00
+ax_pose 45, 0x81dc, 0x4109, 0x0c08
+ax_pose 46, 0x01fc, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose157:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose158:
+ax_pose 4, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose159:
+ax_pose 5, 0x01df, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose160:
+ax_pose 41, 0x81dc, 0x80f8, 0x0c00
+ax_pose 42, 0x01fc, 0x00fc, 0x0c08
+ax_pose 43, 0x81e4, 0x0108, 0x0c09
+ax_pose_terminator
+sKingdraPose161:
+ax_pose 52, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose162:
+ax_pose 53, 0x01e0, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose163:
+ax_pose 54, 0x01df, 0x80f5, 0x0c00
+ax_pose_terminator
+sKingdraPose164:
+ax_pose 55, 0x01e0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKingdraPose165:
+ax_pose 56, 0x01e1, 0x90ec, 0x0c00
+ax_pose_terminator
+sKingdraPose166:
+ax_pose 57, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sKingdraPose167:
+ax_pose 58, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sKingdraPose168:
+ax_pose 57, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sKingdraPose169:
+ax_pose 56, 0x01e1, 0x80f4, 0x0c00
+ax_pose_terminator
+sKingdraPose170:
+ax_pose 55, 0x01e0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKingdraPose171:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose172:
+ax_pose 1, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose173:
+ax_pose 2, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose174:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose175:
+ax_pose 4, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose176:
+ax_pose 5, 0x01df, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose177:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose178:
+ax_pose 7, 0x01de, 0x90f2, 0x0c00
+ax_pose_terminator
+sKingdraPose179:
+ax_pose 8, 0x81de, 0x9100, 0x0c00
+ax_pose 9, 0x81de, 0x50f8, 0x0c08
+ax_pose 10, 0x81ee, 0x10f0, 0x0c0c
+ax_pose 11, 0x01fe, 0x10fa, 0x0c0e
+ax_pose_terminator
+sKingdraPose180:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose181:
+ax_pose 13, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose182:
+ax_pose 14, 0x81de, 0x9100, 0x0c00
+ax_pose 15, 0x81de, 0x50f8, 0x0c08
+ax_pose 16, 0x01fe, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose183:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose184:
+ax_pose 18, 0x81e1, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose185:
+ax_pose 19, 0x81df, 0x80f8, 0x0c00
+ax_pose 20, 0x01ff, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose186:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose187:
+ax_pose 13, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose188:
+ax_pose 14, 0x81de, 0x80f0, 0x0c00
+ax_pose 15, 0x81de, 0x4100, 0x0c08
+ax_pose 16, 0x01fe, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose189:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose190:
+ax_pose 7, 0x01de, 0x80ee, 0x0c00
+ax_pose_terminator
+sKingdraPose191:
+ax_pose 8, 0x81de, 0x80f0, 0x0c00
+ax_pose 9, 0x81de, 0x4100, 0x0c08
+ax_pose 10, 0x81ee, 0x0108, 0x0c0c
+ax_pose 11, 0x01fe, 0x00fe, 0x0c0e
+ax_pose_terminator
+sKingdraPose192:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose193:
+ax_pose 4, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose194:
+ax_pose 5, 0x01df, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose195:
+ax_pose 21, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sKingdraPose196:
+ax_pose 22, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sKingdraPose197:
+ax_pose 23, 0x81de, 0x80ee, 0x0c00
+ax_pose 24, 0x81de, 0x40fe, 0x0c08
+ax_pose 25, 0x01e6, 0x0106, 0x0c0c
+ax_pose 26, 0x81ee, 0x0106, 0x0c0d
+ax_pose 27, 0x01f6, 0x010e, 0x0c0f
+ax_pose_terminator
+sKingdraPose198:
+ax_pose 28, 0x81e2, 0x80f3, 0x0c00
+ax_pose 29, 0x81e2, 0x4103, 0x0c08
+ax_pose 30, 0x0202, 0x0103, 0x0c0c
+ax_pose_terminator
+sKingdraPose199:
+ax_pose 31, 0x81e1, 0x80f8, 0x0c00
+ax_pose 32, 0x0201, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose200:
+ax_pose 28, 0x81e2, 0x90fd, 0x0c00
+ax_pose 29, 0x81e2, 0x50f5, 0x0c08
+ax_pose 30, 0x0202, 0x10f5, 0x0c0c
+ax_pose_terminator
+sKingdraPose201:
+ax_pose 23, 0x81de, 0x9102, 0x0c00
+ax_pose 24, 0x81de, 0x50fa, 0x0c08
+ax_pose 25, 0x01e6, 0x10f2, 0x0c0c
+ax_pose 26, 0x81ee, 0x10f2, 0x0c0d
+ax_pose 27, 0x01f6, 0x10ea, 0x0c0f
+ax_pose_terminator
+sKingdraPose202:
+ax_pose 22, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sKingdraPose203:
+ax_pose 33, 0x81de, 0x80f8, 0x0c00
+ax_pose 34, 0x01fe, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose204:
+ax_pose 35, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose205:
+ax_pose 36, 0x01df, 0x90e9, 0x0c00
+ax_pose_terminator
+sKingdraPose206:
+ax_pose 37, 0x01e0, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose207:
+ax_pose 38, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose208:
+ax_pose 37, 0x01e0, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose209:
+ax_pose 36, 0x01df, 0x80f7, 0x0c00
+ax_pose_terminator
+sKingdraPose210:
+ax_pose 35, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose211:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose212:
+ax_pose 39, 0x81de, 0x80f8, 0x0c00
+ax_pose 40, 0x01fe, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose213:
+ax_pose 21, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sKingdraPose214:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose215:
+ax_pose 41, 0x81dc, 0x90f8, 0x0c00
+ax_pose 42, 0x01fc, 0x10fc, 0x0c08
+ax_pose 43, 0x81e4, 0x10f0, 0x0c09
+ax_pose_terminator
+sKingdraPose216:
+ax_pose 22, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sKingdraPose217:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose218:
+ax_pose 44, 0x81dc, 0x90f7, 0x0c00
+ax_pose 45, 0x81dc, 0x50ef, 0x0c08
+ax_pose 46, 0x01fc, 0x10fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose219:
+ax_pose 23, 0x81df, 0x9102, 0x0c00
+ax_pose 24, 0x81df, 0x50fa, 0x0c08
+ax_pose 25, 0x01e7, 0x10f2, 0x0c0c
+ax_pose 26, 0x81ef, 0x10f2, 0x0c0d
+ax_pose 27, 0x01f7, 0x10ea, 0x0c0f
+ax_pose_terminator
+sKingdraPose220:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose221:
+ax_pose 47, 0x81dc, 0x90f8, 0x0c00
+ax_pose 48, 0x81e4, 0x10f0, 0x0c08
+ax_pose 49, 0x01fc, 0x10fc, 0x0c0a
+ax_pose_terminator
+sKingdraPose222:
+ax_pose 28, 0x81e0, 0x90fe, 0x0c00
+ax_pose 29, 0x81e0, 0x50f6, 0x0c08
+ax_pose 30, 0x0200, 0x10f6, 0x0c0c
+ax_pose_terminator
+sKingdraPose223:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose224:
+ax_pose 50, 0x81dc, 0x80f8, 0x0c00
+ax_pose 51, 0x01fc, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose225:
+ax_pose 31, 0x81e0, 0x80f8, 0x0c00
+ax_pose 32, 0x0200, 0x00fc, 0x0c08
+ax_pose_terminator
+sKingdraPose226:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose227:
+ax_pose 47, 0x81dc, 0x80f8, 0x0c00
+ax_pose 48, 0x81e4, 0x0108, 0x0c08
+ax_pose 49, 0x01fc, 0x00fc, 0x0c0a
+ax_pose_terminator
+sKingdraPose228:
+ax_pose 28, 0x81e0, 0x80f2, 0x0c00
+ax_pose 29, 0x81e0, 0x4102, 0x0c08
+ax_pose 30, 0x0200, 0x0102, 0x0c0c
+ax_pose_terminator
+sKingdraPose229:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose230:
+ax_pose 44, 0x81dc, 0x80f9, 0x0c00
+ax_pose 45, 0x81dc, 0x4109, 0x0c08
+ax_pose 46, 0x01fc, 0x00fc, 0x0c0c
+ax_pose_terminator
+sKingdraPose231:
+ax_pose 23, 0x81df, 0x80ee, 0x0c00
+ax_pose 24, 0x81df, 0x40fe, 0x0c08
+ax_pose 25, 0x01e7, 0x0106, 0x0c0c
+ax_pose 26, 0x81ef, 0x0106, 0x0c0d
+ax_pose 27, 0x01f7, 0x010e, 0x0c0f
+ax_pose_terminator
+sKingdraPose232:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose233:
+ax_pose 41, 0x81dc, 0x80f8, 0x0c00
+ax_pose 42, 0x01fc, 0x00fc, 0x0c08
+ax_pose 43, 0x81e4, 0x0108, 0x0c09
+ax_pose_terminator
+sKingdraPose234:
+ax_pose 22, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sKingdraPose235:
+ax_pose 1, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose236:
+ax_pose 4, 0x01de, 0x80f1, 0x0c00
+ax_pose_terminator
+sKingdraPose237:
+ax_pose 7, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose238:
+ax_pose 13, 0x01de, 0x80f2, 0x0c00
+ax_pose_terminator
+sKingdraPose239:
+ax_pose 18, 0x81e1, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose240:
+ax_pose 13, 0x01de, 0x90ee, 0x0c00
+ax_pose_terminator
+sKingdraPose241:
+ax_pose 7, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose242:
+ax_pose 4, 0x01de, 0x90ef, 0x0c00
+ax_pose_terminator
+sKingdraPose243:
+ax_pose 0, 0x81de, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose244:
+ax_pose 3, 0x01de, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose245:
+ax_pose 6, 0x01df, 0x80ef, 0x0c00
+ax_pose_terminator
+sKingdraPose246:
+ax_pose 12, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sKingdraPose247:
+ax_pose 17, 0x81e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sKingdraPose248:
+ax_pose 12, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sKingdraPose249:
+ax_pose 6, 0x01df, 0x90f1, 0x0c00
+ax_pose_terminator
+sKingdraPose250:
+ax_pose 3, 0x01de, 0x90f0, 0x0c00
+ax_pose_terminator
+.align 2
+sKingdraAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 1, 27, 1, 23, 1, 23,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 0, 27, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sKingdraAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 6, 0, 30, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 3, 5, 3, 5,
+ax_anim 1, 0, 29, 8, 12, 8, 12,
+ax_anim 2, 0, 31, 14, 23, 14, 23,
+ax_anim 2, 1, 31, 15, 22, 15, 22,
+ax_anim 2, 0, 31, 14, 23, 14, 23,
+ax_anim 2, 0, 31, 15, 22, 15, 22,
+ax_anim 2, 0, 28, 5, 8, 5, 8,
+ax_anim_terminator
+sKingdraAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 6, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 3, 0, 3, 0,
+ax_anim 1, 0, 33, 8, 0, 8, 0,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 1, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 0, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 32, 5, 0, 5, 0,
+ax_anim_terminator
+sKingdraAnims_2_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 6, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 5, -4, 5, -4,
+ax_anim 1, 0, 37, 11, -10, 11, -10,
+ax_anim 2, 0, 39, 14, -12, 14, -12,
+ax_anim 2, 1, 39, 15, -11, 15, -11,
+ax_anim 2, 0, 39, 14, -12, 14, -12,
+ax_anim 2, 0, 39, 15, -11, 15, -11,
+ax_anim 2, 0, 36, 8, -7, 8, -7,
+ax_anim_terminator
+sKingdraAnims_2_5:
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 6, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -2, 0, -2,
+ax_anim 1, 0, 41, 0, -7, 0, -7,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 1, 43, 1, -11, 1, -11,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 1, -11, 1, -11,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sKingdraAnims_2_6:
+ax_anim 2, 0, 46, 1, 1, 1, 1,
+ax_anim 6, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -5, -4, -5, -4,
+ax_anim 1, 0, 45, -11, -10, -11, -10,
+ax_anim 2, 0, 47, -14, -12, -14, -12,
+ax_anim 2, 1, 47, -15, -11, -15, -11,
+ax_anim 2, 0, 47, -14, -12, -14, -12,
+ax_anim 2, 0, 47, -15, -11, -15, -11,
+ax_anim 2, 0, 44, -8, -7, -8, -7,
+ax_anim_terminator
+sKingdraAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 6, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -3, 0, -3, 0,
+ax_anim 1, 0, 49, -8, 0, -8, 0,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 1, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -5, 0, -5, 0,
+ax_anim_terminator
+sKingdraAnims_2_8:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 6, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -3, 5, -3, 5,
+ax_anim 1, 0, 53, -8, 12, -8, 12,
+ax_anim 2, 0, 55, -14, 23, -14, 23,
+ax_anim 2, 1, 55, -15, 22, -15, 22,
+ax_anim 2, 0, 55, -14, 23, -14, 23,
+ax_anim 2, 0, 55, -15, 22, -15, 22,
+ax_anim 2, 0, 52, -5, 8, -5, 8,
+ax_anim_terminator
+.align 2
+sKingdraAnims_3_1:
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 6, 0, 58, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 23, 0, 23,
+ax_anim 2, 1, 59, 1, 23, 1, 23,
+ax_anim 2, 0, 59, 0, 23, 0, 23,
+ax_anim 2, 0, 59, 1, 23, 1, 23,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sKingdraAnims_3_2:
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 6, 0, 62, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 3, 5, 3, 5,
+ax_anim 1, 0, 61, 8, 12, 8, 12,
+ax_anim 2, 0, 63, 14, 23, 14, 23,
+ax_anim 2, 1, 63, 15, 22, 15, 22,
+ax_anim 2, 0, 63, 14, 23, 14, 23,
+ax_anim 2, 0, 63, 15, 22, 15, 22,
+ax_anim 2, 0, 60, 5, 8, 5, 8,
+ax_anim_terminator
+sKingdraAnims_3_3:
+ax_anim 2, 0, 66, -1, 0, -1, 0,
+ax_anim 6, 0, 66, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 3, 0, 3, 0,
+ax_anim 1, 0, 65, 8, 0, 8, 0,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 1, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 0, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 64, 5, 0, 5, 0,
+ax_anim_terminator
+sKingdraAnims_3_4:
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim 6, 0, 70, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, 5, -4, 5, -4,
+ax_anim 1, 0, 69, 11, -10, 11, -10,
+ax_anim 2, 0, 71, 14, -12, 14, -12,
+ax_anim 2, 1, 71, 15, -11, 15, -11,
+ax_anim 2, 0, 71, 14, -12, 14, -12,
+ax_anim 2, 0, 71, 15, -11, 15, -11,
+ax_anim 2, 0, 68, 8, -7, 8, -7,
+ax_anim_terminator
+sKingdraAnims_3_5:
+ax_anim 2, 0, 74, 0, 1, 0, 1,
+ax_anim 6, 0, 74, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -2, 0, -2,
+ax_anim 1, 0, 73, 0, -7, 0, -7,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 1, 75, 1, -11, 1, -11,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 1, -11, 1, -11,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sKingdraAnims_3_6:
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim 6, 0, 78, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 2, 77, -5, -4, -5, -4,
+ax_anim 1, 0, 77, -11, -10, -11, -10,
+ax_anim 2, 0, 79, -14, -12, -14, -12,
+ax_anim 2, 1, 79, -15, -11, -15, -11,
+ax_anim 2, 0, 79, -14, -12, -14, -12,
+ax_anim 2, 0, 79, -15, -11, -15, -11,
+ax_anim 2, 0, 76, -8, -7, -8, -7,
+ax_anim_terminator
+sKingdraAnims_3_7:
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 6, 0, 82, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -3, 0, -3, 0,
+ax_anim 1, 0, 81, -8, 0, -8, 0,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 1, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 0, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 80, -5, 0, -5, 0,
+ax_anim_terminator
+sKingdraAnims_3_8:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 6, 0, 86, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -3, 5, -3, 5,
+ax_anim 1, 0, 85, -8, 12, -8, 12,
+ax_anim 2, 0, 87, -14, 23, -14, 23,
+ax_anim 2, 1, 87, -15, 22, -15, 22,
+ax_anim 2, 0, 87, -14, 23, -14, 23,
+ax_anim 2, 0, 87, -15, 22, -15, 22,
+ax_anim 2, 0, 84, -5, 8, -5, 8,
+ax_anim_terminator
+.align 2
+sKingdraAnims_4_1:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, -2, 0, -2,
+ax_anim 6, 2, 91, 0, -3, 0, -3,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 1, 92, 1, 5, 1, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 1, 5, 1, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 1, 5, 1, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sKingdraAnims_4_2:
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 96, -2, -2, -2, -2,
+ax_anim 6, 2, 96, -3, -3, -3, -3,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 1, 97, 6, 4, 6, 4,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 6, 4, 6, 4,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 6, 4, 6, 4,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sKingdraAnims_4_3:
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 6, 2, 101, -3, 0, -3, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 1, 102, 5, 1, 5, 1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, 1, 5, 1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, 1, 5, 1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sKingdraAnims_4_4:
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 6, 2, 106, -3, 3, -3, 3,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 1, 107, 6, -4, 6, -4,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 6, -4, 6, -4,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 6, -4, 6, -4,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sKingdraAnims_4_5:
+ax_anim 2, 0, 110, 0, 1, 0, 1,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 6, 2, 111, 0, 3, 0, 3,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 1, 112, 1, -5, 1, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 112, 1, -5, 1, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 112, 1, -5, 1, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim_terminator
+sKingdraAnims_4_6:
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim 2, 0, 116, 2, 2, 2, 2,
+ax_anim 6, 2, 116, 3, 3, 3, 3,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 1, 117, -6, -4, -6, -4,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -6, -4, -6, -4,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -6, -4, -6, -4,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sKingdraAnims_4_7:
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 2, 0, 2, 0,
+ax_anim 6, 2, 121, 3, 0, 3, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 1, 122, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sKingdraAnims_4_8:
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 1, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sKingdraAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -7, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 1, -8, 1, 0,
+ax_anim 2, 2, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 1, -7, 1, 0,
+ax_anim 3, 0, 131, 0, -6, 0, 0,
+ax_anim 3, 0, 131, 0, -5, 0, 0,
+ax_anim 3, 0, 130, 0, -2, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_5_2:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 135, 0, -7, 0, 0,
+ax_anim 2, 0, 135, 1, -8, 1, -1,
+ax_anim 2, 2, 135, 0, -7, 0, 0,
+ax_anim 2, 0, 135, 1, -8, 1, -1,
+ax_anim 3, 0, 135, 0, -4, 0, 0,
+ax_anim 3, 0, 135, -1, -1, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_5_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 1, 0, 139, 0, -4, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 139, 0, -8, 0, 0,
+ax_anim 2, 0, 139, 1, -8, 1, 0,
+ax_anim 2, 2, 139, 0, -8, 0, 0,
+ax_anim 2, 0, 139, 1, -8, 1, 0,
+ax_anim 3, 0, 139, 1, -5, 1, 0,
+ax_anim 3, 0, 139, 1, -2, 1, 0,
+ax_anim 3, 0, 138, 1, -2, 1, 0,
+ax_anim 3, 0, 137, 1, 0, 1, 0,
+ax_anim_terminator
+sKingdraAnims_5_4:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 143, -1, -9, -1, -1,
+ax_anim 2, 2, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 143, -1, -9, -1, -1,
+ax_anim 3, 0, 143, 0, -6, 0, 0,
+ax_anim 3, 0, 143, 0, -4, 0, 0,
+ax_anim 3, 0, 142, 0, -2, 0, 0,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_5_5:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, -2, 0, 0,
+ax_anim 1, 0, 147, 0, -4, 0, 0,
+ax_anim 1, 0, 147, 0, -6, 0, 0,
+ax_anim 2, 0, 147, 0, -7, 0, 0,
+ax_anim 2, 0, 147, 1, -7, 1, 0,
+ax_anim 2, 2, 147, 0, -7, 0, 0,
+ax_anim 2, 0, 147, 1, -7, 1, 0,
+ax_anim 3, 0, 147, 0, -5, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 3, 0, 146, 0, -2, 0, 0,
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_5_6:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 151, 0, -5, 0, 0,
+ax_anim 1, 0, 151, 0, -6, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 1, -9, 1, -1,
+ax_anim 2, 2, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 1, -9, 1, -1,
+ax_anim 3, 0, 151, 0, -6, 0, 0,
+ax_anim 3, 0, 151, 0, -4, 0, 0,
+ax_anim 3, 0, 150, 0, -2, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_5_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 1, 0, 155, 0, -4, 0, 0,
+ax_anim 1, 0, 155, 0, -6, 0, 0,
+ax_anim 2, 0, 155, 0, -8, 0, 0,
+ax_anim 2, 0, 155, -1, -8, -1, 0,
+ax_anim 2, 2, 155, 0, -8, 0, 0,
+ax_anim 2, 0, 155, -1, -8, -1, 0,
+ax_anim 3, 0, 155, -1, -5, -1, 0,
+ax_anim 3, 0, 155, -1, -2, -1, 0,
+ax_anim 3, 0, 154, -1, -2, -1, 0,
+ax_anim 3, 0, 153, -1, 0, -1, 0,
+ax_anim_terminator
+sKingdraAnims_5_8:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 1, 0, 159, 0, -3, 0, 0,
+ax_anim 1, 0, 159, 0, -5, 0, 0,
+ax_anim 2, 0, 159, 0, -7, 0, 0,
+ax_anim 2, 0, 159, -1, -8, -1, -1,
+ax_anim 2, 2, 159, 0, -7, 0, 0,
+ax_anim 2, 0, 159, -1, -8, -1, -1,
+ax_anim 3, 0, 159, 0, -4, 0, 0,
+ax_anim 3, 0, 159, 1, -1, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_6_1:
+ax_anim 16, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, -1, 0, 0,
+ax_anim 16, 0, 160, 0, -2, 0, 0,
+ax_anim 16, 0, 161, 0, -2, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sKingdraAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sKingdraAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sKingdraAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sKingdraAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sKingdraAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sKingdraAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sKingdraAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sKingdraAnims_8_1:
+ax_anim 6, 0, 171, 0, -2, 0, 0,
+ax_anim 6, 0, 171, 0, -1, 0, 0,
+ax_anim 6, 0, 171, 0, 0, 0, 0,
+ax_anim 6, 0, 170, 0, 0, 0, 0,
+ax_anim 6, 0, 172, 0, 0, 0, 0,
+ax_anim 6, 0, 172, 0, -1, 0, 0,
+ax_anim 6, 0, 172, 0, -2, 0, 0,
+ax_anim 6, 0, 172, 0, -3, 0, 0,
+ax_anim 6, 0, 170, 0, -4, 0, 0,
+ax_anim 6, 0, 171, 0, -5, 0, 0,
+ax_anim 6, 0, 171, 0, -4, 0, 0,
+ax_anim 6, 0, 171, 0, -3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_8_2:
+ax_anim 6, 0, 174, 0, -2, 0, 0,
+ax_anim 6, 0, 174, 0, -1, 0, 0,
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim 6, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 175, 0, 0, 0, 0,
+ax_anim 6, 0, 175, 0, -1, 0, 0,
+ax_anim 6, 0, 175, 0, -2, 0, 0,
+ax_anim 6, 0, 175, 0, -3, 0, 0,
+ax_anim 6, 0, 173, 0, -4, 0, 0,
+ax_anim 6, 0, 174, 0, -5, 0, 0,
+ax_anim 6, 0, 174, 0, -4, 0, 0,
+ax_anim 6, 0, 174, 0, -3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_8_3:
+ax_anim 6, 0, 177, 0, -2, 0, 0,
+ax_anim 6, 0, 177, 0, -1, 0, 0,
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 0, 178, 0, 0, 0, 0,
+ax_anim 6, 0, 178, 0, -1, 0, 0,
+ax_anim 6, 0, 178, 0, -2, 0, 0,
+ax_anim 6, 0, 178, 0, -3, 0, 0,
+ax_anim 6, 0, 176, 0, -4, 0, 0,
+ax_anim 6, 0, 177, 0, -5, 0, 0,
+ax_anim 6, 0, 177, 0, -4, 0, 0,
+ax_anim 6, 0, 177, 0, -3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_8_4:
+ax_anim 6, 0, 180, 0, -2, 0, 0,
+ax_anim 6, 0, 180, 0, -1, 0, 0,
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim 6, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 181, 0, 0, 0, 0,
+ax_anim 6, 0, 181, 0, -1, 0, 0,
+ax_anim 6, 0, 181, 0, -2, 0, 0,
+ax_anim 6, 0, 181, 0, -3, 0, 0,
+ax_anim 6, 0, 179, 0, -4, 0, 0,
+ax_anim 6, 0, 180, 0, -5, 0, 0,
+ax_anim 6, 0, 180, 0, -4, 0, 0,
+ax_anim 6, 0, 180, 0, -3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_8_5:
+ax_anim 6, 0, 183, 0, -2, 0, 0,
+ax_anim 6, 0, 183, 0, -1, 0, 0,
+ax_anim 6, 0, 183, 0, 0, 0, 0,
+ax_anim 6, 0, 182, 0, 0, 0, 0,
+ax_anim 6, 0, 184, 0, -1, 0, 0,
+ax_anim 6, 0, 184, 0, -2, 0, 0,
+ax_anim 6, 0, 184, 0, -3, 0, 0,
+ax_anim 6, 0, 184, 0, -4, 0, 0,
+ax_anim 6, 0, 182, 0, -3, 0, 0,
+ax_anim 6, 0, 183, 0, -5, 0, 0,
+ax_anim 6, 0, 183, 0, -4, 0, 0,
+ax_anim 6, 0, 183, 0, -3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_8_6:
+ax_anim 6, 0, 186, 0, -2, 0, 0,
+ax_anim 6, 0, 186, 0, -1, 0, 0,
+ax_anim 6, 0, 186, 0, 0, 0, 0,
+ax_anim 6, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 187, 0, 0, 0, 0,
+ax_anim 6, 0, 187, 0, -1, 0, 0,
+ax_anim 6, 0, 187, 0, -2, 0, 0,
+ax_anim 6, 0, 187, 0, -3, 0, 0,
+ax_anim 6, 0, 185, 0, -4, 0, 0,
+ax_anim 6, 0, 186, 0, -5, 0, 0,
+ax_anim 6, 0, 186, 0, -4, 0, 0,
+ax_anim 6, 0, 186, 0, -3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_8_7:
+ax_anim 6, 0, 189, 0, -2, 0, 0,
+ax_anim 6, 0, 189, 0, -1, 0, 0,
+ax_anim 6, 0, 189, 0, 0, 0, 0,
+ax_anim 6, 0, 188, 0, 0, 0, 0,
+ax_anim 6, 0, 190, 0, 0, 0, 0,
+ax_anim 6, 0, 190, 0, -1, 0, 0,
+ax_anim 6, 0, 190, 0, -2, 0, 0,
+ax_anim 6, 0, 190, 0, -3, 0, 0,
+ax_anim 6, 0, 188, 0, -4, 0, 0,
+ax_anim 6, 0, 189, 0, -5, 0, 0,
+ax_anim 6, 0, 189, 0, -4, 0, 0,
+ax_anim 6, 0, 189, 0, -3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_8_8:
+ax_anim 6, 0, 192, 0, -2, 0, 0,
+ax_anim 6, 0, 192, 0, -1, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 6, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 193, 0, 0, 0, 0,
+ax_anim 6, 0, 193, 0, -1, 0, 0,
+ax_anim 6, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 6, 0, 191, 0, -4, 0, 0,
+ax_anim 6, 0, 192, 0, -5, 0, 0,
+ax_anim 6, 0, 192, 0, -4, 0, 0,
+ax_anim 6, 0, 192, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 9, 8, 9,
+ax_anim 2, 0, 197, 7, 17, 7, 17,
+ax_anim 3, 0, 198, 0, 20, 0, 20,
+ax_anim 2, 3, 199, -7, 17, -7, 17,
+ax_anim 2, 0, 200, -8, 9, -8, 9,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 19, 10, 19, 10,
+ax_anim 3, 0, 197, 19, 20, 19, 20,
+ax_anim 2, 3, 198, 11, 20, 11, 20,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -3, 16, -4,
+ax_anim 3, 0, 196, 18, 2, 18, 0,
+ax_anim 2, 3, 197, 16, 3, 16, 3,
+ax_anim 2, 0, 198, 12, 5, 12, 5,
+ax_anim 1, 0, 199, 4, 3, 4, 3,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -18,
+ax_anim 2, 0, 194, 13, -20, 13, -22,
+ax_anim 3, 0, 195, 19, -19, 21, -23,
+ax_anim 2, 3, 196, 20, -12, 22, -14,
+ax_anim 2, 0, 197, 18, -7, 18, -7,
+ax_anim 1, 0, 198, 9, 0, 9, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -6,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -16, -7, -19,
+ax_anim 3, 0, 194, 0, -19, 0, -23,
+ax_anim 2, 3, 195, 7, -16, 7, -19,
+ax_anim 2, 0, 196, 9, -12, 9, -12,
+ax_anim 1, 0, 197, 8, -4, 8, -6,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -18,
+ax_anim 2, 0, 194, -13, -20, -13, -22,
+ax_anim 3, 0, 201, -19, -19, -19, -23,
+ax_anim 2, 3, 200, -20, -12, -20, -14,
+ax_anim 2, 0, 199, -18, -7, -18, -7,
+ax_anim 1, 0, 198, -9, 0, -9, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -3, -16, -4,
+ax_anim 3, 0, 200, -18, 2, -18, 0,
+ax_anim 2, 3, 199, -16, 3, -16, 3,
+ax_anim 2, 0, 198, -12, 5, -12, 5,
+ax_anim 1, 0, 197, -4, 3, -4, 3,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -19, 10, -19, 10,
+ax_anim 3, 0, 199, -19, 20, -19, 20,
+ax_anim 2, 3, 198, -11, 20, -11, 20,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 3, 0, 0,
+ax_anim_terminator
+sKingdraAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 2, 0, 0,
+ax_anim_terminator
+sKingdraAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 2, 0, 0,
+ax_anim_terminator
+sKingdraAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 2, 0, 0,
+ax_anim_terminator
+sKingdraAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 2, 0, 0,
+ax_anim_terminator
+sKingdraAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 2, 0, 0,
+ax_anim_terminator
+sKingdraAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKingdraAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sKingdraGfx1:
+.incbin "baserom.gba", 0xF5682C, 0x100
+sKingdraSprites1:
+ax_sprite sKingdraGfx1, 0x100
+ax_sprite_terminator
+sKingdraGfx2:
+.incbin "baserom.gba", 0xF5693C, 0x100
+sKingdraSprites2:
+ax_sprite sKingdraGfx2, 0x100
+ax_sprite_terminator
+sKingdraGfx3:
+.incbin "baserom.gba", 0xF56A4C, 0x100
+sKingdraSprites3:
+ax_sprite sKingdraGfx3, 0x100
+ax_sprite_terminator
+sKingdraGfx4:
+.incbin "baserom.gba", 0xF56B5C, 0x200
+sKingdraSprites4:
+ax_sprite sKingdraGfx4, 0x200
+ax_sprite_terminator
+sKingdraGfx5:
+.incbin "baserom.gba", 0xF56D6C, 0x200
+sKingdraSprites5:
+ax_sprite sKingdraGfx5, 0x200
+ax_sprite_terminator
+sKingdraGfx6:
+.incbin "baserom.gba", 0xF56F7C, 0x200
+sKingdraSprites6:
+ax_sprite sKingdraGfx6, 0x200
+ax_sprite_terminator
+sKingdraGfx7:
+.incbin "baserom.gba", 0xF5718C, 0x200
+sKingdraSprites7:
+ax_sprite sKingdraGfx7, 0x200
+ax_sprite_terminator
+sKingdraGfx8:
+.incbin "baserom.gba", 0xF5739C, 0x200
+sKingdraSprites8:
+ax_sprite sKingdraGfx8, 0x200
+ax_sprite_terminator
+sKingdraGfx9:
+.incbin "baserom.gba", 0xF575AC, 0x100
+sKingdraSprites9:
+ax_sprite sKingdraGfx9, 0x100
+ax_sprite_terminator
+sKingdraGfx10:
+.incbin "baserom.gba", 0xF576BC, 0x80
+sKingdraSprites10:
+ax_sprite sKingdraGfx10, 0x80
+ax_sprite_terminator
+sKingdraGfx11:
+.incbin "baserom.gba", 0xF5774C, 0x40
+sKingdraSprites11:
+ax_sprite sKingdraGfx11, 0x40
+ax_sprite_terminator
+sKingdraGfx12:
+.incbin "baserom.gba", 0xF5779C, 0x20
+sKingdraSprites12:
+ax_sprite sKingdraGfx12, 0x20
+ax_sprite_terminator
+sKingdraGfx13:
+.incbin "baserom.gba", 0xF577CC, 0x200
+sKingdraSprites13:
+ax_sprite sKingdraGfx13, 0x200
+ax_sprite_terminator
+sKingdraGfx14:
+.incbin "baserom.gba", 0xF579DC, 0x200
+sKingdraSprites14:
+ax_sprite sKingdraGfx14, 0x200
+ax_sprite_terminator
+sKingdraGfx15:
+.incbin "baserom.gba", 0xF57BEC, 0x100
+sKingdraSprites15:
+ax_sprite sKingdraGfx15, 0x100
+ax_sprite_terminator
+sKingdraGfx16:
+.incbin "baserom.gba", 0xF57CFC, 0x80
+sKingdraSprites16:
+ax_sprite sKingdraGfx16, 0x80
+ax_sprite_terminator
+sKingdraGfx17:
+.incbin "baserom.gba", 0xF57D8C, 0x20
+sKingdraSprites17:
+ax_sprite sKingdraGfx17, 0x20
+ax_sprite_terminator
+sKingdraGfx18:
+.incbin "baserom.gba", 0xF57DBC, 0x100
+sKingdraSprites18:
+ax_sprite sKingdraGfx18, 0x100
+ax_sprite_terminator
+sKingdraGfx19:
+.incbin "baserom.gba", 0xF57ECC, 0x100
+sKingdraSprites19:
+ax_sprite sKingdraGfx19, 0x100
+ax_sprite_terminator
+sKingdraGfx20:
+.incbin "baserom.gba", 0xF57FDC, 0x100
+sKingdraSprites20:
+ax_sprite sKingdraGfx20, 0x100
+ax_sprite_terminator
+sKingdraGfx21:
+.incbin "baserom.gba", 0xF580EC, 0x20
+sKingdraSprites21:
+ax_sprite sKingdraGfx21, 0x20
+ax_sprite_terminator
+sKingdraGfx22:
+.incbin "baserom.gba", 0xF5811C, 0x60
+sKingdraGfx22_1:
+.incbin "baserom.gba", 0xF5817C, 0x60
+sKingdraGfx22_2:
+.incbin "baserom.gba", 0xF581DC, 0x40
+sKingdraSprites22:
+ax_sprite sKingdraGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx22_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sKingdraGfx23:
+.incbin "baserom.gba", 0xF58254, 0x60
+sKingdraGfx23_1:
+.incbin "baserom.gba", 0xF582B4, 0x100
+sKingdraSprites23:
+ax_sprite sKingdraGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx23_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKingdraGfx24:
+.incbin "baserom.gba", 0xF583DC, 0x100
+sKingdraSprites24:
+ax_sprite sKingdraGfx24, 0x100
+ax_sprite_terminator
+sKingdraGfx25:
+.incbin "baserom.gba", 0xF584EC, 0x80
+sKingdraSprites25:
+ax_sprite sKingdraGfx25, 0x80
+ax_sprite_terminator
+sKingdraGfx26:
+.incbin "baserom.gba", 0xF5857C, 0x20
+sKingdraSprites26:
+ax_sprite sKingdraGfx26, 0x20
+ax_sprite_terminator
+sKingdraGfx27:
+.incbin "baserom.gba", 0xF585AC, 0x40
+sKingdraSprites27:
+ax_sprite sKingdraGfx27, 0x40
+ax_sprite_terminator
+sKingdraGfx28:
+.incbin "baserom.gba", 0xF585FC, 0x20
+sKingdraSprites28:
+ax_sprite sKingdraGfx28, 0x20
+ax_sprite_terminator
+sKingdraGfx29:
+.incbin "baserom.gba", 0xF5862C, 0xC0
+sKingdraGfx29_1:
+.incbin "baserom.gba", 0xF586EC, 0x20
+sKingdraSprites29:
+ax_sprite sKingdraGfx29, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx29_1, 0x20
+ax_sprite_terminator
+sKingdraGfx30:
+.incbin "baserom.gba", 0xF5872C, 0x80
+sKingdraSprites30:
+ax_sprite sKingdraGfx30, 0x80
+ax_sprite_terminator
+sKingdraGfx31:
+.incbin "baserom.gba", 0xF587BC, 0x20
+sKingdraSprites31:
+ax_sprite sKingdraGfx31, 0x20
+ax_sprite_terminator
+sKingdraGfx32:
+.incbin "baserom.gba", 0xF587EC, 0x100
+sKingdraSprites32:
+ax_sprite sKingdraGfx32, 0x100
+ax_sprite_terminator
+sKingdraGfx33:
+.incbin "baserom.gba", 0xF588FC, 0x20
+sKingdraSprites33:
+ax_sprite sKingdraGfx33, 0x20
+ax_sprite_terminator
+sKingdraGfx34:
+.incbin "baserom.gba", 0xF5892C, 0x100
+sKingdraSprites34:
+ax_sprite sKingdraGfx34, 0x100
+ax_sprite_terminator
+sKingdraGfx35:
+.incbin "baserom.gba", 0xF58A3C, 0x20
+sKingdraSprites35:
+ax_sprite sKingdraGfx35, 0x20
+ax_sprite_terminator
+sKingdraGfx36:
+.incbin "baserom.gba", 0xF58A6C, 0x60
+sKingdraGfx36_1:
+.incbin "baserom.gba", 0xF58ACC, 0xE0
+sKingdraGfx36_2:
+.incbin "baserom.gba", 0xF58BAC, 0x60
+sKingdraSprites36:
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx36_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx36_2, 0x60
+ax_sprite_terminator
+sKingdraGfx37:
+.incbin "baserom.gba", 0xF58C44, 0x1C0
+sKingdraSprites37:
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx37, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKingdraGfx38:
+.incbin "baserom.gba", 0xF58E24, 0x40
+sKingdraGfx38_1:
+.incbin "baserom.gba", 0xF58E64, 0x60
+sKingdraGfx38_2:
+.incbin "baserom.gba", 0xF58EC4, 0x60
+sKingdraGfx38_3:
+.incbin "baserom.gba", 0xF58F24, 0x60
+sKingdraSprites38:
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKingdraGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKingdraGfx38_3, 0x60
+ax_sprite_terminator
+sKingdraGfx39:
+.incbin "baserom.gba", 0xF58FCC, 0x100
+sKingdraSprites39:
+ax_sprite sKingdraGfx39, 0x100
+ax_sprite_terminator
+sKingdraGfx40:
+.incbin "baserom.gba", 0xF590DC, 0x100
+sKingdraSprites40:
+ax_sprite sKingdraGfx40, 0x100
+ax_sprite_terminator
+sKingdraGfx41:
+.incbin "baserom.gba", 0xF591EC, 0x20
+sKingdraSprites41:
+ax_sprite sKingdraGfx41, 0x20
+ax_sprite_terminator
+sKingdraGfx42:
+.incbin "baserom.gba", 0xF5921C, 0x100
+sKingdraSprites42:
+ax_sprite sKingdraGfx42, 0x100
+ax_sprite_terminator
+sKingdraGfx43:
+.incbin "baserom.gba", 0xF5932C, 0x20
+sKingdraSprites43:
+ax_sprite sKingdraGfx43, 0x20
+ax_sprite_terminator
+sKingdraGfx44:
+.incbin "baserom.gba", 0xF5935C, 0x20
+sKingdraSprites44:
+ax_sprite sKingdraGfx44, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKingdraGfx45:
+.incbin "baserom.gba", 0xF59394, 0x100
+sKingdraSprites45:
+ax_sprite sKingdraGfx45, 0x100
+ax_sprite_terminator
+sKingdraGfx46:
+.incbin "baserom.gba", 0xF594A4, 0x80
+sKingdraSprites46:
+ax_sprite sKingdraGfx46, 0x80
+ax_sprite_terminator
+sKingdraGfx47:
+.incbin "baserom.gba", 0xF59534, 0x20
+sKingdraSprites47:
+ax_sprite sKingdraGfx47, 0x20
+ax_sprite_terminator
+sKingdraGfx48:
+.incbin "baserom.gba", 0xF59564, 0x100
+sKingdraSprites48:
+ax_sprite sKingdraGfx48, 0x100
+ax_sprite_terminator
+sKingdraGfx49:
+.incbin "baserom.gba", 0xF59674, 0x40
+sKingdraSprites49:
+ax_sprite sKingdraGfx49, 0x40
+ax_sprite_terminator
+sKingdraGfx50:
+.incbin "baserom.gba", 0xF596C4, 0x20
+sKingdraSprites50:
+ax_sprite sKingdraGfx50, 0x20
+ax_sprite_terminator
+sKingdraGfx51:
+.incbin "baserom.gba", 0xF596F4, 0x100
+sKingdraSprites51:
+ax_sprite sKingdraGfx51, 0x100
+ax_sprite_terminator
+sKingdraGfx52:
+.incbin "baserom.gba", 0xF59804, 0x20
+sKingdraSprites52:
+ax_sprite sKingdraGfx52, 0x20
+ax_sprite_terminator
+sKingdraGfx53:
+.incbin "baserom.gba", 0xF59834, 0x200
+sKingdraSprites53:
+ax_sprite sKingdraGfx53, 0x200
+ax_sprite_terminator
+sKingdraGfx54:
+.incbin "baserom.gba", 0xF59A44, 0x200
+sKingdraSprites54:
+ax_sprite sKingdraGfx54, 0x200
+ax_sprite_terminator
+sKingdraGfx55:
+.incbin "baserom.gba", 0xF59C54, 0x200
+sKingdraSprites55:
+ax_sprite sKingdraGfx55, 0x200
+ax_sprite_terminator
+sKingdraGfx56:
+.incbin "baserom.gba", 0xF59E64, 0x200
+sKingdraSprites56:
+ax_sprite sKingdraGfx56, 0x200
+ax_sprite_terminator
+sKingdraGfx57:
+.incbin "baserom.gba", 0xF5A074, 0x200
+sKingdraSprites57:
+ax_sprite sKingdraGfx57, 0x200
+ax_sprite_terminator
+sKingdraGfx58:
+.incbin "baserom.gba", 0xF5A284, 0x200
+sKingdraSprites58:
+ax_sprite sKingdraGfx58, 0x200
+ax_sprite_terminator
+sKingdraGfx59:
+.incbin "baserom.gba", 0xF5A494, 0x200
+sKingdraSprites59:
+ax_sprite sKingdraGfx59, 0x200
+ax_sprite_terminator
+sAxPosesKingdra:
+.4byte sKingdraPose1
+.4byte sKingdraPose2
+.4byte sKingdraPose3
+.4byte sKingdraPose4
+.4byte sKingdraPose5
+.4byte sKingdraPose6
+.4byte sKingdraPose7
+.4byte sKingdraPose8
+.4byte sKingdraPose9
+.4byte sKingdraPose10
+.4byte sKingdraPose11
+.4byte sKingdraPose12
+.4byte sKingdraPose13
+.4byte sKingdraPose14
+.4byte sKingdraPose15
+.4byte sKingdraPose16
+.4byte sKingdraPose17
+.4byte sKingdraPose18
+.4byte sKingdraPose19
+.4byte sKingdraPose20
+.4byte sKingdraPose21
+.4byte sKingdraPose22
+.4byte sKingdraPose23
+.4byte sKingdraPose24
+.4byte sKingdraPose25
+.4byte sKingdraPose26
+.4byte sKingdraPose27
+.4byte sKingdraPose28
+.4byte sKingdraPose29
+.4byte sKingdraPose30
+.4byte sKingdraPose31
+.4byte sKingdraPose32
+.4byte sKingdraPose33
+.4byte sKingdraPose34
+.4byte sKingdraPose35
+.4byte sKingdraPose36
+.4byte sKingdraPose37
+.4byte sKingdraPose38
+.4byte sKingdraPose39
+.4byte sKingdraPose40
+.4byte sKingdraPose41
+.4byte sKingdraPose42
+.4byte sKingdraPose43
+.4byte sKingdraPose44
+.4byte sKingdraPose45
+.4byte sKingdraPose46
+.4byte sKingdraPose47
+.4byte sKingdraPose48
+.4byte sKingdraPose49
+.4byte sKingdraPose50
+.4byte sKingdraPose51
+.4byte sKingdraPose52
+.4byte sKingdraPose53
+.4byte sKingdraPose54
+.4byte sKingdraPose55
+.4byte sKingdraPose56
+.4byte sKingdraPose57
+.4byte sKingdraPose58
+.4byte sKingdraPose59
+.4byte sKingdraPose60
+.4byte sKingdraPose61
+.4byte sKingdraPose62
+.4byte sKingdraPose63
+.4byte sKingdraPose64
+.4byte sKingdraPose65
+.4byte sKingdraPose66
+.4byte sKingdraPose67
+.4byte sKingdraPose68
+.4byte sKingdraPose69
+.4byte sKingdraPose70
+.4byte sKingdraPose71
+.4byte sKingdraPose72
+.4byte sKingdraPose73
+.4byte sKingdraPose74
+.4byte sKingdraPose75
+.4byte sKingdraPose76
+.4byte sKingdraPose77
+.4byte sKingdraPose78
+.4byte sKingdraPose79
+.4byte sKingdraPose80
+.4byte sKingdraPose81
+.4byte sKingdraPose82
+.4byte sKingdraPose83
+.4byte sKingdraPose84
+.4byte sKingdraPose85
+.4byte sKingdraPose86
+.4byte sKingdraPose87
+.4byte sKingdraPose88
+.4byte sKingdraPose89
+.4byte sKingdraPose90
+.4byte sKingdraPose91
+.4byte sKingdraPose92
+.4byte sKingdraPose93
+.4byte sKingdraPose94
+.4byte sKingdraPose95
+.4byte sKingdraPose96
+.4byte sKingdraPose97
+.4byte sKingdraPose98
+.4byte sKingdraPose99
+.4byte sKingdraPose100
+.4byte sKingdraPose101
+.4byte sKingdraPose102
+.4byte sKingdraPose103
+.4byte sKingdraPose104
+.4byte sKingdraPose105
+.4byte sKingdraPose106
+.4byte sKingdraPose107
+.4byte sKingdraPose108
+.4byte sKingdraPose109
+.4byte sKingdraPose110
+.4byte sKingdraPose111
+.4byte sKingdraPose112
+.4byte sKingdraPose113
+.4byte sKingdraPose114
+.4byte sKingdraPose115
+.4byte sKingdraPose116
+.4byte sKingdraPose117
+.4byte sKingdraPose118
+.4byte sKingdraPose119
+.4byte sKingdraPose120
+.4byte sKingdraPose121
+.4byte sKingdraPose122
+.4byte sKingdraPose123
+.4byte sKingdraPose124
+.4byte sKingdraPose125
+.4byte sKingdraPose126
+.4byte sKingdraPose127
+.4byte sKingdraPose128
+.4byte sKingdraPose129
+.4byte sKingdraPose130
+.4byte sKingdraPose131
+.4byte sKingdraPose132
+.4byte sKingdraPose133
+.4byte sKingdraPose134
+.4byte sKingdraPose135
+.4byte sKingdraPose136
+.4byte sKingdraPose137
+.4byte sKingdraPose138
+.4byte sKingdraPose139
+.4byte sKingdraPose140
+.4byte sKingdraPose141
+.4byte sKingdraPose142
+.4byte sKingdraPose143
+.4byte sKingdraPose144
+.4byte sKingdraPose145
+.4byte sKingdraPose146
+.4byte sKingdraPose147
+.4byte sKingdraPose148
+.4byte sKingdraPose149
+.4byte sKingdraPose150
+.4byte sKingdraPose151
+.4byte sKingdraPose152
+.4byte sKingdraPose153
+.4byte sKingdraPose154
+.4byte sKingdraPose155
+.4byte sKingdraPose156
+.4byte sKingdraPose157
+.4byte sKingdraPose158
+.4byte sKingdraPose159
+.4byte sKingdraPose160
+.4byte sKingdraPose161
+.4byte sKingdraPose162
+.4byte sKingdraPose163
+.4byte sKingdraPose164
+.4byte sKingdraPose165
+.4byte sKingdraPose166
+.4byte sKingdraPose167
+.4byte sKingdraPose168
+.4byte sKingdraPose169
+.4byte sKingdraPose170
+.4byte sKingdraPose171
+.4byte sKingdraPose172
+.4byte sKingdraPose173
+.4byte sKingdraPose174
+.4byte sKingdraPose175
+.4byte sKingdraPose176
+.4byte sKingdraPose177
+.4byte sKingdraPose178
+.4byte sKingdraPose179
+.4byte sKingdraPose180
+.4byte sKingdraPose181
+.4byte sKingdraPose182
+.4byte sKingdraPose183
+.4byte sKingdraPose184
+.4byte sKingdraPose185
+.4byte sKingdraPose186
+.4byte sKingdraPose187
+.4byte sKingdraPose188
+.4byte sKingdraPose189
+.4byte sKingdraPose190
+.4byte sKingdraPose191
+.4byte sKingdraPose192
+.4byte sKingdraPose193
+.4byte sKingdraPose194
+.4byte sKingdraPose195
+.4byte sKingdraPose196
+.4byte sKingdraPose197
+.4byte sKingdraPose198
+.4byte sKingdraPose199
+.4byte sKingdraPose200
+.4byte sKingdraPose201
+.4byte sKingdraPose202
+.4byte sKingdraPose203
+.4byte sKingdraPose204
+.4byte sKingdraPose205
+.4byte sKingdraPose206
+.4byte sKingdraPose207
+.4byte sKingdraPose208
+.4byte sKingdraPose209
+.4byte sKingdraPose210
+.4byte sKingdraPose211
+.4byte sKingdraPose212
+.4byte sKingdraPose213
+.4byte sKingdraPose214
+.4byte sKingdraPose215
+.4byte sKingdraPose216
+.4byte sKingdraPose217
+.4byte sKingdraPose218
+.4byte sKingdraPose219
+.4byte sKingdraPose220
+.4byte sKingdraPose221
+.4byte sKingdraPose222
+.4byte sKingdraPose223
+.4byte sKingdraPose224
+.4byte sKingdraPose225
+.4byte sKingdraPose226
+.4byte sKingdraPose227
+.4byte sKingdraPose228
+.4byte sKingdraPose229
+.4byte sKingdraPose230
+.4byte sKingdraPose231
+.4byte sKingdraPose232
+.4byte sKingdraPose233
+.4byte sKingdraPose234
+.4byte sKingdraPose235
+.4byte sKingdraPose236
+.4byte sKingdraPose237
+.4byte sKingdraPose238
+.4byte sKingdraPose239
+.4byte sKingdraPose240
+.4byte sKingdraPose241
+.4byte sKingdraPose242
+.4byte sKingdraPose243
+.4byte sKingdraPose244
+.4byte sKingdraPose245
+.4byte sKingdraPose246
+.4byte sKingdraPose247
+.4byte sKingdraPose248
+.4byte sKingdraPose249
+.4byte sKingdraPose250
+sAxPositionsKingdra:
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte    0,   -9, 	  -7,  -19, 	   6,  -19, 	   0,  -11
+.2byte    0,  -13, 	  -7,  -23, 	   6,  -23, 	   0,  -12
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+.2byte    8,  -10, 	   7,  -20, 	  -2,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   6,  -23, 	  -3,  -22, 	   0,  -13
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte   15,  -14, 	   6,  -22, 	   2,  -19, 	   1,  -13
+.2byte   13,  -17, 	   4,  -25, 	   0,  -22, 	   0,  -15
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte   12,  -16, 	   0,  -21, 	   6,  -18, 	   1,  -13
+.2byte   11,  -19, 	  -1,  -23, 	   5,  -20, 	   1,  -15
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte    0,  -17, 	   5,  -17, 	  -7,  -17, 	  -1,  -14
+.2byte    0,  -20, 	   6,  -20, 	  -7,  -20, 	   0,  -15
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte  -13,  -16, 	  -1,  -21, 	  -7,  -18, 	  -2,  -13
+.2byte  -12,  -19, 	   0,  -23, 	  -6,  -20, 	  -2,  -15
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte  -16,  -14, 	  -7,  -22, 	  -3,  -19, 	  -2,  -13
+.2byte  -14,  -17, 	  -5,  -25, 	  -1,  -22, 	  -1,  -15
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte   -9,  -10, 	  -8,  -20, 	   1,  -18, 	   0,  -12
+.2byte   -8,  -14, 	  -7,  -23, 	   2,  -22, 	  -1,  -13
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte    0,   -9, 	  -7,  -19, 	   6,  -19, 	   0,  -11
+.2byte    0,  -13, 	  -7,  -23, 	   6,  -23, 	   0,  -12
+.2byte   -1,   -4, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+.2byte    8,  -10, 	   7,  -20, 	  -2,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   6,  -23, 	  -3,  -22, 	   0,  -13
+.2byte   13,   -4, 	  10,  -13, 	   3,  -12, 	   1,  -10
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte   15,  -14, 	   6,  -22, 	   2,  -19, 	   1,  -13
+.2byte   13,  -17, 	   4,  -25, 	   0,  -22, 	   0,  -15
+.2byte   15,   -9, 	   2,  -15, 	   2,  -14, 	  -1,   -9
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte   12,  -16, 	   0,  -21, 	   6,  -18, 	   1,  -13
+.2byte   11,  -19, 	  -1,  -23, 	   5,  -20, 	   1,  -15
+.2byte   12,  -19, 	   1,  -21, 	   6,  -18, 	   2,  -13
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte    0,  -17, 	   5,  -17, 	  -7,  -17, 	  -1,  -14
+.2byte    0,  -20, 	   6,  -20, 	  -7,  -20, 	   0,  -15
+.2byte    0,  -18, 	   6,  -19, 	  -7,  -19, 	   0,  -12
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte  -13,  -16, 	  -1,  -21, 	  -7,  -18, 	  -2,  -13
+.2byte  -12,  -19, 	   0,  -23, 	  -6,  -20, 	  -2,  -15
+.2byte  -13,  -19, 	  -2,  -21, 	  -7,  -18, 	  -3,  -13
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte  -16,  -14, 	  -7,  -22, 	  -3,  -19, 	  -2,  -13
+.2byte  -14,  -17, 	  -5,  -25, 	  -1,  -22, 	  -1,  -15
+.2byte  -16,   -9, 	  -3,  -15, 	  -3,  -14, 	   0,   -9
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte   -9,  -10, 	  -8,  -20, 	   1,  -18, 	   0,  -12
+.2byte   -8,  -14, 	  -7,  -23, 	   2,  -22, 	  -1,  -13
+.2byte  -14,   -4, 	 -11,  -13, 	  -4,  -12, 	  -2,  -10
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte    0,   -9, 	  -7,  -19, 	   6,  -19, 	   0,  -11
+.2byte    0,  -13, 	  -7,  -23, 	   6,  -23, 	   0,  -12
+.2byte   -1,   -4, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+.2byte    8,  -10, 	   7,  -20, 	  -2,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   6,  -23, 	  -3,  -22, 	   0,  -13
+.2byte   13,   -4, 	  10,  -13, 	   3,  -12, 	   1,  -10
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte   15,  -14, 	   6,  -22, 	   2,  -19, 	   1,  -13
+.2byte   13,  -17, 	   4,  -25, 	   0,  -22, 	   0,  -15
+.2byte   15,   -9, 	   2,  -15, 	   2,  -14, 	  -1,   -9
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte   12,  -16, 	   0,  -21, 	   6,  -18, 	   1,  -13
+.2byte   11,  -19, 	  -1,  -23, 	   5,  -20, 	   1,  -15
+.2byte   12,  -19, 	   1,  -21, 	   6,  -18, 	   2,  -13
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte    0,  -17, 	   5,  -17, 	  -7,  -17, 	  -1,  -14
+.2byte    0,  -20, 	   6,  -20, 	  -7,  -20, 	   0,  -15
+.2byte    0,  -18, 	   6,  -19, 	  -7,  -19, 	   0,  -12
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte  -13,  -16, 	  -1,  -21, 	  -7,  -18, 	  -2,  -13
+.2byte  -12,  -19, 	   0,  -23, 	  -6,  -20, 	  -2,  -15
+.2byte  -13,  -19, 	  -2,  -21, 	  -7,  -18, 	  -3,  -13
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte  -16,  -14, 	  -7,  -22, 	  -3,  -19, 	  -2,  -13
+.2byte  -14,  -17, 	  -5,  -25, 	  -1,  -22, 	  -1,  -15
+.2byte  -16,   -9, 	  -3,  -15, 	  -3,  -14, 	   0,   -9
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte   -9,  -10, 	  -8,  -20, 	   1,  -18, 	   0,  -12
+.2byte   -8,  -14, 	  -7,  -23, 	   2,  -22, 	  -1,  -13
+.2byte  -14,   -4, 	 -11,  -13, 	  -4,  -12, 	  -2,  -10
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte    0,   -9, 	  -7,  -19, 	   6,  -19, 	   0,  -11
+.2byte    0,  -13, 	  -7,  -23, 	   6,  -23, 	   0,  -12
+.2byte   -1,  -32, 	  -6,  -20, 	   5,  -20, 	   0,  -15
+.2byte   -1,   -4, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+.2byte    8,  -10, 	   7,  -20, 	  -2,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   6,  -23, 	  -3,  -22, 	   0,  -13
+.2byte   -1,  -33, 	  -4,  -21, 	  -9,  -20, 	   2,  -16
+.2byte   13,   -4, 	  10,  -13, 	   3,  -12, 	   1,  -10
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte   15,  -14, 	   6,  -22, 	   2,  -19, 	   1,  -13
+.2byte   13,  -17, 	   4,  -25, 	   0,  -22, 	   0,  -15
+.2byte   -1,  -31, 	 -12,  -22, 	  -5,  -18, 	   2,  -17
+.2byte   15,   -9, 	   2,  -15, 	   2,  -14, 	  -1,   -9
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte   12,  -16, 	   0,  -21, 	   6,  -18, 	   1,  -13
+.2byte   11,  -19, 	  -1,  -23, 	   5,  -20, 	   1,  -15
+.2byte   -2,  -29, 	  -8,  -18, 	  -1,  -15, 	   2,  -15
+.2byte   12,  -19, 	   1,  -21, 	   6,  -18, 	   2,  -13
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte    0,  -17, 	   5,  -17, 	  -7,  -17, 	  -1,  -14
+.2byte    0,  -20, 	   6,  -20, 	  -7,  -20, 	   0,  -15
+.2byte    0,  -30, 	   5,  -17, 	  -6,  -17, 	  -1,  -13
+.2byte    0,  -18, 	   6,  -19, 	  -7,  -19, 	   0,  -12
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte  -13,  -16, 	  -1,  -21, 	  -7,  -18, 	  -2,  -13
+.2byte  -12,  -19, 	   0,  -23, 	  -6,  -20, 	  -2,  -15
+.2byte    1,  -29, 	   7,  -18, 	   0,  -15, 	  -3,  -15
+.2byte  -13,  -19, 	  -2,  -21, 	  -7,  -18, 	  -3,  -13
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte  -16,  -14, 	  -7,  -22, 	  -3,  -19, 	  -2,  -13
+.2byte  -14,  -17, 	  -5,  -25, 	  -1,  -22, 	  -1,  -15
+.2byte    0,  -31, 	  11,  -22, 	   4,  -18, 	  -3,  -17
+.2byte  -16,   -9, 	  -3,  -15, 	  -3,  -14, 	   0,   -9
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte   -9,  -10, 	  -8,  -20, 	   1,  -18, 	   0,  -12
+.2byte   -8,  -14, 	  -7,  -23, 	   2,  -22, 	  -1,  -13
+.2byte    0,  -33, 	   3,  -21, 	   8,  -20, 	  -3,  -16
+.2byte  -14,   -4, 	 -11,  -13, 	  -4,  -12, 	  -2,  -10
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte    0,   -9, 	  -7,  -19, 	   6,  -19, 	   0,  -11
+.2byte    0,  -13, 	  -7,  -23, 	   6,  -23, 	   0,  -12
+.2byte   -1,  -32, 	  -6,  -18, 	   5,  -18, 	   0,  -12
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+.2byte    8,  -10, 	   7,  -20, 	  -2,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   6,  -23, 	  -3,  -22, 	   0,  -13
+.2byte    4,  -34, 	   3,  -22, 	  -3,  -21, 	   2,  -15
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte   15,  -14, 	   6,  -22, 	   2,  -19, 	   1,  -13
+.2byte   13,  -17, 	   4,  -25, 	   0,  -22, 	   0,  -15
+.2byte    4,  -34, 	  -7,  -25, 	   0,  -20, 	   1,  -16
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte   12,  -16, 	   0,  -21, 	   6,  -18, 	   1,  -13
+.2byte   11,  -19, 	  -1,  -23, 	   5,  -20, 	   1,  -15
+.2byte    3,  -34, 	  -3,  -23, 	   4,  -20, 	   2,  -16
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte    0,  -17, 	   5,  -17, 	  -7,  -17, 	  -1,  -14
+.2byte    0,  -20, 	   6,  -20, 	  -7,  -20, 	   0,  -15
+.2byte    0,  -35, 	   5,  -18, 	  -6,  -18, 	   0,  -16
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte  -13,  -16, 	  -1,  -21, 	  -7,  -18, 	  -2,  -13
+.2byte  -12,  -19, 	   0,  -23, 	  -6,  -20, 	  -2,  -15
+.2byte   -4,  -34, 	   2,  -23, 	  -5,  -20, 	  -3,  -16
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte  -16,  -14, 	  -7,  -22, 	  -3,  -19, 	  -2,  -13
+.2byte  -14,  -17, 	  -5,  -25, 	  -1,  -22, 	  -1,  -15
+.2byte   -5,  -34, 	   6,  -25, 	  -1,  -20, 	  -2,  -16
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte   -9,  -10, 	  -8,  -20, 	   1,  -18, 	   0,  -12
+.2byte   -8,  -14, 	  -7,  -23, 	   2,  -22, 	  -1,  -13
+.2byte   -5,  -34, 	  -4,  -22, 	   2,  -21, 	  -3,  -15
+.2byte   -9,  -13, 	  -6,  -22, 	   2,  -21, 	  -1,  -14
+.2byte  -10,  -12, 	  -8,  -22, 	   1,  -20, 	  -2,  -13
+.2byte    0,  -32, 	  -8,  -21, 	   7,  -21, 	   0,  -15
+.2byte    0,  -25, 	  -6,  -22, 	 -12,  -19, 	  -1,  -15
+.2byte   -2,  -25, 	 -11,  -19, 	 -12,  -15, 	  -2,  -14
+.2byte   -3,  -26, 	 -15,  -16, 	  -6,  -10, 	  -1,  -12
+.2byte   -1,  -28, 	   6,  -13, 	  -7,  -13, 	   0,  -12
+.2byte    2,  -26, 	  14,  -16, 	   5,  -10, 	   0,  -12
+.2byte    1,  -25, 	  10,  -19, 	  11,  -15, 	   1,  -14
+.2byte   -1,  -25, 	   5,  -22, 	  11,  -19, 	   0,  -15
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte    0,   -9, 	  -7,  -19, 	   6,  -19, 	   0,  -11
+.2byte    0,  -13, 	  -7,  -23, 	   6,  -23, 	   0,  -12
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+.2byte    8,  -10, 	   7,  -20, 	  -2,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   6,  -23, 	  -3,  -22, 	   0,  -13
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte   15,  -14, 	   6,  -22, 	   2,  -19, 	   1,  -13
+.2byte   13,  -17, 	   4,  -25, 	   0,  -22, 	   0,  -15
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte   12,  -16, 	   0,  -21, 	   6,  -18, 	   1,  -13
+.2byte   11,  -19, 	  -1,  -23, 	   5,  -20, 	   1,  -15
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte    0,  -17, 	   5,  -17, 	  -7,  -17, 	  -1,  -14
+.2byte    0,  -20, 	   6,  -20, 	  -7,  -20, 	   0,  -15
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte  -13,  -16, 	  -1,  -21, 	  -7,  -18, 	  -2,  -13
+.2byte  -12,  -19, 	   0,  -23, 	  -6,  -20, 	  -2,  -15
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte  -16,  -14, 	  -7,  -22, 	  -3,  -19, 	  -2,  -13
+.2byte  -14,  -17, 	  -5,  -25, 	  -1,  -22, 	  -1,  -15
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte   -9,  -10, 	  -8,  -20, 	   1,  -18, 	   0,  -12
+.2byte   -8,  -14, 	  -7,  -23, 	   2,  -22, 	  -1,  -13
+.2byte   -1,   -4, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte  -11,   -5, 	  -8,  -14, 	  -1,  -13, 	   1,  -11
+.2byte  -16,  -10, 	  -3,  -16, 	  -3,  -15, 	   0,  -10
+.2byte  -11,  -17, 	   0,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte    0,  -17, 	   6,  -18, 	  -7,  -18, 	   0,  -11
+.2byte   10,  -17, 	  -1,  -19, 	   4,  -16, 	   0,  -11
+.2byte   15,  -10, 	   2,  -16, 	   2,  -15, 	  -1,  -10
+.2byte   10,   -5, 	   7,  -14, 	   0,  -13, 	  -2,  -11
+.2byte   -1,  -32, 	  -6,  -20, 	   5,  -20, 	   0,  -15
+.2byte   -1,  -33, 	  -4,  -21, 	  -9,  -20, 	   2,  -16
+.2byte   -1,  -31, 	 -12,  -22, 	  -5,  -18, 	   2,  -17
+.2byte   -1,  -29, 	  -7,  -18, 	   0,  -15, 	   3,  -15
+.2byte    0,  -30, 	   5,  -17, 	  -6,  -17, 	  -1,  -13
+.2byte    0,  -29, 	   6,  -18, 	  -1,  -15, 	  -4,  -15
+.2byte    0,  -31, 	  11,  -22, 	   4,  -18, 	  -3,  -17
+.2byte    0,  -33, 	   3,  -21, 	   8,  -20, 	  -3,  -16
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte   -1,  -32, 	  -6,  -18, 	   5,  -18, 	   0,  -12
+.2byte   -1,   -4, 	  -7,  -13, 	   6,  -13, 	   0,  -12
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+.2byte    4,  -34, 	   3,  -22, 	  -3,  -21, 	   2,  -15
+.2byte   11,   -4, 	   8,  -13, 	   1,  -12, 	  -1,  -10
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte    4,  -34, 	  -7,  -25, 	   0,  -20, 	   1,  -16
+.2byte   15,   -9, 	   2,  -15, 	   2,  -14, 	  -1,   -9
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte    3,  -34, 	  -3,  -23, 	   4,  -20, 	   2,  -16
+.2byte   11,  -19, 	   0,  -21, 	   5,  -18, 	   1,  -13
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte    0,  -35, 	   5,  -18, 	  -6,  -18, 	   0,  -16
+.2byte    0,  -18, 	   6,  -19, 	  -7,  -19, 	   0,  -12
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte   -4,  -34, 	   2,  -23, 	  -5,  -20, 	  -3,  -16
+.2byte  -12,  -19, 	  -1,  -21, 	  -6,  -18, 	  -2,  -13
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte   -5,  -34, 	   6,  -25, 	  -1,  -20, 	  -2,  -16
+.2byte  -16,   -9, 	  -3,  -15, 	  -3,  -14, 	   0,   -9
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte   -5,  -34, 	  -4,  -22, 	   2,  -21, 	  -3,  -15
+.2byte  -12,   -4, 	  -9,  -13, 	  -2,  -12, 	   0,  -10
+.2byte    0,   -9, 	  -7,  -19, 	   6,  -19, 	   0,  -11
+.2byte   -8,  -10, 	  -7,  -20, 	   2,  -18, 	   1,  -12
+.2byte  -14,  -14, 	  -5,  -22, 	  -1,  -19, 	   0,  -13
+.2byte  -11,  -16, 	   1,  -21, 	  -5,  -18, 	   0,  -13
+.2byte    0,  -17, 	   5,  -17, 	  -7,  -17, 	  -1,  -14
+.2byte   10,  -16, 	  -2,  -21, 	   4,  -18, 	  -1,  -13
+.2byte   13,  -14, 	   4,  -22, 	   0,  -19, 	  -1,  -13
+.2byte    7,  -10, 	   6,  -20, 	  -3,  -18, 	  -2,  -12
+.2byte    0,  -11, 	  -7,  -21, 	   6,  -21, 	   0,  -13
+.2byte   -8,  -12, 	  -7,  -22, 	   2,  -20, 	  -1,  -12
+.2byte  -15,  -15, 	  -6,  -23, 	  -2,  -20, 	  -2,  -14
+.2byte  -13,  -17, 	  -1,  -22, 	  -6,  -18, 	  -2,  -14
+.2byte    0,  -19, 	   6,  -19, 	  -7,  -19, 	   0,  -15
+.2byte   12,  -17, 	   0,  -22, 	   5,  -18, 	   1,  -14
+.2byte   14,  -15, 	   5,  -23, 	   1,  -20, 	   1,  -14
+.2byte    7,  -12, 	   6,  -22, 	  -3,  -20, 	   0,  -12
+sKingdraAnimTable1:
+.4byte sKingdraAnims_1_1
+.4byte sKingdraAnims_1_2
+.4byte sKingdraAnims_1_3
+.4byte sKingdraAnims_1_4
+.4byte sKingdraAnims_1_5
+.4byte sKingdraAnims_1_6
+.4byte sKingdraAnims_1_7
+.4byte sKingdraAnims_1_8
+sKingdraAnimTable2:
+.4byte sKingdraAnims_2_1
+.4byte sKingdraAnims_2_2
+.4byte sKingdraAnims_2_3
+.4byte sKingdraAnims_2_4
+.4byte sKingdraAnims_2_5
+.4byte sKingdraAnims_2_6
+.4byte sKingdraAnims_2_7
+.4byte sKingdraAnims_2_8
+sKingdraAnimTable3:
+.4byte sKingdraAnims_3_1
+.4byte sKingdraAnims_3_2
+.4byte sKingdraAnims_3_3
+.4byte sKingdraAnims_3_4
+.4byte sKingdraAnims_3_5
+.4byte sKingdraAnims_3_6
+.4byte sKingdraAnims_3_7
+.4byte sKingdraAnims_3_8
+sKingdraAnimTable4:
+.4byte sKingdraAnims_4_1
+.4byte sKingdraAnims_4_2
+.4byte sKingdraAnims_4_3
+.4byte sKingdraAnims_4_4
+.4byte sKingdraAnims_4_5
+.4byte sKingdraAnims_4_6
+.4byte sKingdraAnims_4_7
+.4byte sKingdraAnims_4_8
+sKingdraAnimTable5:
+.4byte sKingdraAnims_5_1
+.4byte sKingdraAnims_5_2
+.4byte sKingdraAnims_5_3
+.4byte sKingdraAnims_5_4
+.4byte sKingdraAnims_5_5
+.4byte sKingdraAnims_5_6
+.4byte sKingdraAnims_5_7
+.4byte sKingdraAnims_5_8
+sKingdraAnimTable6:
+.4byte sKingdraAnims_6_1
+.4byte sKingdraAnims_6_1
+.4byte sKingdraAnims_6_1
+.4byte sKingdraAnims_6_1
+.4byte sKingdraAnims_6_1
+.4byte sKingdraAnims_6_1
+.4byte sKingdraAnims_6_1
+.4byte sKingdraAnims_6_1
+sKingdraAnimTable7:
+.4byte sKingdraAnims_7_1
+.4byte sKingdraAnims_7_2
+.4byte sKingdraAnims_7_3
+.4byte sKingdraAnims_7_4
+.4byte sKingdraAnims_7_5
+.4byte sKingdraAnims_7_6
+.4byte sKingdraAnims_7_7
+.4byte sKingdraAnims_7_8
+sKingdraAnimTable8:
+.4byte sKingdraAnims_8_1
+.4byte sKingdraAnims_8_2
+.4byte sKingdraAnims_8_3
+.4byte sKingdraAnims_8_4
+.4byte sKingdraAnims_8_5
+.4byte sKingdraAnims_8_6
+.4byte sKingdraAnims_8_7
+.4byte sKingdraAnims_8_8
+sKingdraAnimTable9:
+.4byte sKingdraAnims_9_1
+.4byte sKingdraAnims_9_2
+.4byte sKingdraAnims_9_3
+.4byte sKingdraAnims_9_4
+.4byte sKingdraAnims_9_5
+.4byte sKingdraAnims_9_6
+.4byte sKingdraAnims_9_7
+.4byte sKingdraAnims_9_8
+sKingdraAnimTable10:
+.4byte sKingdraAnims_10_1
+.4byte sKingdraAnims_10_2
+.4byte sKingdraAnims_10_3
+.4byte sKingdraAnims_10_4
+.4byte sKingdraAnims_10_5
+.4byte sKingdraAnims_10_6
+.4byte sKingdraAnims_10_7
+.4byte sKingdraAnims_10_8
+sKingdraAnimTable11:
+.4byte sKingdraAnims_11_1
+.4byte sKingdraAnims_11_2
+.4byte sKingdraAnims_11_3
+.4byte sKingdraAnims_11_4
+.4byte sKingdraAnims_11_5
+.4byte sKingdraAnims_11_6
+.4byte sKingdraAnims_11_7
+.4byte sKingdraAnims_11_8
+sKingdraAnimTable12:
+.4byte sKingdraAnims_12_1
+.4byte sKingdraAnims_12_2
+.4byte sKingdraAnims_12_3
+.4byte sKingdraAnims_12_4
+.4byte sKingdraAnims_12_5
+.4byte sKingdraAnims_12_6
+.4byte sKingdraAnims_12_7
+.4byte sKingdraAnims_12_8
+sKingdraAnimTable13:
+.4byte sKingdraAnims_13_1
+.4byte sKingdraAnims_13_2
+.4byte sKingdraAnims_13_3
+.4byte sKingdraAnims_13_4
+.4byte sKingdraAnims_13_5
+.4byte sKingdraAnims_13_6
+.4byte sKingdraAnims_13_7
+.4byte sKingdraAnims_13_8
+sAxAnimationsKingdra:
+.4byte sKingdraAnimTable1
+.4byte sKingdraAnimTable2
+.4byte sKingdraAnimTable3
+.4byte sKingdraAnimTable4
+.4byte sKingdraAnimTable5
+.4byte sKingdraAnimTable6
+.4byte sKingdraAnimTable7
+.4byte sKingdraAnimTable8
+.4byte sKingdraAnimTable9
+.4byte sKingdraAnimTable10
+.4byte sKingdraAnimTable11
+.4byte sKingdraAnimTable12
+.4byte sKingdraAnimTable13
+sAxSpritesKingdra:
+.4byte sKingdraSprites1
+.4byte sKingdraSprites2
+.4byte sKingdraSprites3
+.4byte sKingdraSprites4
+.4byte sKingdraSprites5
+.4byte sKingdraSprites6
+.4byte sKingdraSprites7
+.4byte sKingdraSprites8
+.4byte sKingdraSprites9
+.4byte sKingdraSprites10
+.4byte sKingdraSprites11
+.4byte sKingdraSprites12
+.4byte sKingdraSprites13
+.4byte sKingdraSprites14
+.4byte sKingdraSprites15
+.4byte sKingdraSprites16
+.4byte sKingdraSprites17
+.4byte sKingdraSprites18
+.4byte sKingdraSprites19
+.4byte sKingdraSprites20
+.4byte sKingdraSprites21
+.4byte sKingdraSprites22
+.4byte sKingdraSprites23
+.4byte sKingdraSprites24
+.4byte sKingdraSprites25
+.4byte sKingdraSprites26
+.4byte sKingdraSprites27
+.4byte sKingdraSprites28
+.4byte sKingdraSprites29
+.4byte sKingdraSprites30
+.4byte sKingdraSprites31
+.4byte sKingdraSprites32
+.4byte sKingdraSprites33
+.4byte sKingdraSprites34
+.4byte sKingdraSprites35
+.4byte sKingdraSprites36
+.4byte sKingdraSprites37
+.4byte sKingdraSprites38
+.4byte sKingdraSprites39
+.4byte sKingdraSprites40
+.4byte sKingdraSprites41
+.4byte sKingdraSprites42
+.4byte sKingdraSprites43
+.4byte sKingdraSprites44
+.4byte sKingdraSprites45
+.4byte sKingdraSprites46
+.4byte sKingdraSprites47
+.4byte sKingdraSprites48
+.4byte sKingdraSprites49
+.4byte sKingdraSprites50
+.4byte sKingdraSprites51
+.4byte sKingdraSprites52
+.4byte sKingdraSprites53
+.4byte sKingdraSprites54
+.4byte sKingdraSprites55
+.4byte sKingdraSprites56
+.4byte sKingdraSprites57
+.4byte sKingdraSprites58
+.4byte sKingdraSprites59
+sAxMainKingdra:
+ax_main sAxPosesKingdra, sAxAnimationsKingdra, 13, sAxSpritesKingdra, sAxPositionsKingdra

--- a/data/ax/kingler.inc
+++ b/data/ax/kingler.inc
@@ -1,0 +1,3714 @@
+.global gAxKingler
+gAxKingler:
+ax_siro sAxMainKingler
+sKinglerPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose2:
+ax_pose 1, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose3:
+ax_pose 2, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose4:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose5:
+ax_pose 4, 0x01eb, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose6:
+ax_pose 5, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose7:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose8:
+ax_pose 7, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose9:
+ax_pose 8, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose10:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose11:
+ax_pose 10, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose12:
+ax_pose 11, 0x01f1, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose13:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose14:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose15:
+ax_pose 14, 0x01f1, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose16:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose17:
+ax_pose 16, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose18:
+ax_pose 17, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose19:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose20:
+ax_pose 19, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose21:
+ax_pose 20, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose22:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose23:
+ax_pose 22, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose24:
+ax_pose 23, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose26:
+ax_pose 1, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose27:
+ax_pose 2, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose28:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose29:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose30:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose31:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose32:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose33:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose34:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose35:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose36:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose37:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose38:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose39:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose40:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose41:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose42:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose43:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose44:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose45:
+ax_pose 4, 0x01eb, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose46:
+ax_pose 5, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose47:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose48:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose49:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose50:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose51:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose52:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose53:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose54:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose55:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose56:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose57:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose58:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose59:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose60:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose61:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose62:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose63:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose64:
+ax_pose 7, 0x01ec, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose65:
+ax_pose 8, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose66:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose67:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose68:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose69:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose70:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose71:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose72:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose73:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose74:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose75:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose76:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose77:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose78:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose79:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose80:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose81:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose82:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose83:
+ax_pose 10, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose84:
+ax_pose 11, 0x01f1, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose85:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose86:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose87:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose88:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose89:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose90:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose91:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose92:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose93:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose94:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose95:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose96:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose97:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose98:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose99:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose100:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose101:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose102:
+ax_pose 13, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose103:
+ax_pose 14, 0x01f1, 0x80f3, 0x0c00
+ax_pose_terminator
+sKinglerPose104:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose105:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose106:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose107:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose108:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose109:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose110:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose111:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose112:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose113:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose114:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose115:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose116:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose117:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose118:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose119:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose120:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose121:
+ax_pose 16, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose122:
+ax_pose 17, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose123:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose124:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose125:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose126:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose127:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose128:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose129:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose130:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose131:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose132:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose133:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose134:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose135:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose136:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose137:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose138:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose139:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose140:
+ax_pose 19, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose141:
+ax_pose 20, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose142:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose143:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose144:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose145:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose146:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose147:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose148:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose149:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose150:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose151:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose152:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose153:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose154:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose155:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose156:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose157:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose158:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose159:
+ax_pose 22, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose160:
+ax_pose 23, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose161:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose162:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose163:
+ax_pose 26, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose164:
+ax_pose 27, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose165:
+ax_pose 28, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose166:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose167:
+ax_pose 30, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose168:
+ax_pose 31, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sKinglerPose169:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose170:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose171:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose172:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose173:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose174:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose175:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose176:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose177:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose178:
+ax_pose 32, 0x81e8, 0x80f4, 0x0c00
+ax_pose 33, 0x81e8, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose179:
+ax_pose 34, 0x81f0, 0x40fb, 0x0c00
+ax_pose 35, 0x81f0, 0x4103, 0x0c04
+ax_pose 36, 0x81ef, 0x80f4, 0x0c08
+ax_pose 37, 0x81ef, 0x4104, 0x0c10
+ax_pose_terminator
+sKinglerPose180:
+ax_pose 36, 0x81ef, 0x80f4, 0x0c00
+ax_pose 37, 0x81ef, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose181:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose182:
+ax_pose 38, 0x81e8, 0x80f3, 0x0c00
+ax_pose 39, 0x81e8, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose183:
+ax_pose 40, 0x81ec, 0x5109, 0x0c00
+ax_pose 41, 0x81ec, 0x5101, 0x0c04
+ax_pose 42, 0x41f3, 0x00f9, 0x0c08
+ax_pose 43, 0x41fb, 0x80f1, 0x0c0a
+ax_pose_terminator
+sKinglerPose184:
+ax_pose 42, 0x41f3, 0x00f9, 0x0c00
+ax_pose 43, 0x41fb, 0x80f1, 0x0c02
+ax_pose_terminator
+sKinglerPose185:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose186:
+ax_pose 44, 0x81e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose187:
+ax_pose 45, 0x81e8, 0x9107, 0x0c00
+ax_pose 46, 0x01e8, 0x10ff, 0x0c08
+ax_pose 47, 0x41f2, 0x00f7, 0x0c09
+ax_pose 48, 0x41fa, 0x80f7, 0x0c0b
+ax_pose_terminator
+sKinglerPose188:
+ax_pose 47, 0x41f2, 0x00f7, 0x0c00
+ax_pose 48, 0x41fa, 0x80f7, 0x0c02
+ax_pose_terminator
+sKinglerPose189:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose190:
+ax_pose 49, 0x81e7, 0x80f3, 0x0c00
+ax_pose 50, 0x81e7, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose191:
+ax_pose 51, 0x41e8, 0x40f2, 0x0c00
+ax_pose 52, 0x41f0, 0x40f2, 0x0c04
+ax_pose 53, 0x81e8, 0x80f8, 0x0c08
+ax_pose 54, 0x81e8, 0x4108, 0x0c10
+ax_pose_terminator
+sKinglerPose192:
+ax_pose 53, 0x81e8, 0x80f8, 0x0c00
+ax_pose 54, 0x81e8, 0x4108, 0x0c08
+ax_pose_terminator
+sKinglerPose193:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose194:
+ax_pose 55, 0x41ed, 0x40f0, 0x0c00
+ax_pose 56, 0x41f5, 0x80f0, 0x0c04
+ax_pose_terminator
+sKinglerPose195:
+ax_pose 57, 0x81e3, 0x40f5, 0x0c00
+ax_pose 58, 0x81e3, 0x40fd, 0x0c04
+ax_pose 59, 0x81e6, 0x80f5, 0x0c08
+ax_pose 60, 0x81e6, 0x4105, 0x0c10
+ax_pose_terminator
+sKinglerPose196:
+ax_pose 59, 0x81e6, 0x80f5, 0x0c00
+ax_pose 60, 0x81e6, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose197:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose198:
+ax_pose 61, 0x81e7, 0x80f5, 0x0c00
+ax_pose 62, 0x81e7, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose199:
+ax_pose 63, 0x01e8, 0x40f2, 0x0c00
+ax_pose 64, 0x41ee, 0x80f1, 0x0c04
+ax_pose 65, 0x41fe, 0x40f1, 0x0c0c
+ax_pose_terminator
+sKinglerPose200:
+ax_pose 64, 0x41ee, 0x80f1, 0x0c00
+ax_pose 65, 0x41fe, 0x40f1, 0x0c08
+ax_pose_terminator
+sKinglerPose201:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose202:
+ax_pose 66, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKinglerPose203:
+ax_pose 45, 0x81eb, 0x80eb, 0x0c00
+ax_pose 46, 0x01eb, 0x00fb, 0x0c08
+ax_pose 67, 0x41f8, 0x80eb, 0x0c09
+ax_pose 68, 0x41f0, 0x00fb, 0x0c11
+ax_pose_terminator
+sKinglerPose204:
+ax_pose 67, 0x41f8, 0x80eb, 0x0c00
+ax_pose 68, 0x41f0, 0x00fb, 0x0c08
+ax_pose_terminator
+sKinglerPose205:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose206:
+ax_pose 69, 0x81ea, 0x80f6, 0x0c00
+ax_pose 70, 0x81ea, 0x4106, 0x0c08
+ax_pose_terminator
+sKinglerPose207:
+ax_pose 40, 0x81ec, 0x40f8, 0x0c00
+ax_pose 41, 0x81ec, 0x4100, 0x0c04
+ax_pose 71, 0x01f3, 0x40f4, 0x0c08
+ax_pose 72, 0x4203, 0x00f4, 0x0c0c
+ax_pose 73, 0x01f3, 0x0104, 0x0c0e
+ax_pose 74, 0x81fb, 0x0104, 0x0c0f
+ax_pose_terminator
+sKinglerPose208:
+ax_pose 71, 0x01f3, 0x40f4, 0x0c00
+ax_pose 72, 0x4203, 0x00f4, 0x0c04
+ax_pose 73, 0x01f3, 0x0104, 0x0c06
+ax_pose 74, 0x81fb, 0x0104, 0x0c07
+ax_pose_terminator
+sKinglerPose209:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose210:
+ax_pose 32, 0x81e8, 0x80f4, 0x0c00
+ax_pose 33, 0x81e8, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose211:
+ax_pose 75, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose212:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose213:
+ax_pose 38, 0x81e8, 0x80f3, 0x0c00
+ax_pose 39, 0x81e8, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose214:
+ax_pose 76, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose215:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose216:
+ax_pose 44, 0x81e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose217:
+ax_pose 77, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose218:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose219:
+ax_pose 49, 0x81e7, 0x80f3, 0x0c00
+ax_pose 50, 0x81e7, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose220:
+ax_pose 78, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose221:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose222:
+ax_pose 55, 0x41ed, 0x40f0, 0x0c00
+ax_pose 56, 0x41f5, 0x80f0, 0x0c04
+ax_pose_terminator
+sKinglerPose223:
+ax_pose 79, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose224:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose225:
+ax_pose 61, 0x81e7, 0x80f5, 0x0c00
+ax_pose 62, 0x81e7, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose226:
+ax_pose 80, 0x01ea, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose227:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose228:
+ax_pose 66, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKinglerPose229:
+ax_pose 81, 0x01eb, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose230:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose231:
+ax_pose 69, 0x81ea, 0x80f6, 0x0c00
+ax_pose 70, 0x81ea, 0x4106, 0x0c08
+ax_pose_terminator
+sKinglerPose232:
+ax_pose 82, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose233:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose234:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose235:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose236:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose237:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose238:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose239:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose240:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose241:
+ax_pose 83, 0x01f4, 0x80f5, 0x0c00
+ax_pose_terminator
+sKinglerPose242:
+ax_pose 84, 0x01f4, 0x80f5, 0x0c00
+ax_pose_terminator
+sKinglerPose243:
+ax_pose 85, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose244:
+ax_pose 86, 0x01e6, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose245:
+ax_pose 87, 0x01eb, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose246:
+ax_pose 88, 0x01ec, 0x80ec, 0x0c00
+ax_pose_terminator
+sKinglerPose247:
+ax_pose 89, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose248:
+ax_pose 90, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose249:
+ax_pose 91, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose250:
+ax_pose 92, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose251:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose252:
+ax_pose 32, 0x81e8, 0x80f4, 0x0c00
+ax_pose 33, 0x81e8, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose253:
+ax_pose 34, 0x81f0, 0x40fb, 0x0c00
+ax_pose 35, 0x81f0, 0x4103, 0x0c04
+ax_pose 36, 0x81ef, 0x80f4, 0x0c08
+ax_pose 37, 0x81ef, 0x4104, 0x0c10
+ax_pose_terminator
+sKinglerPose254:
+ax_pose 36, 0x81ef, 0x80f4, 0x0c00
+ax_pose 37, 0x81ef, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose255:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose256:
+ax_pose 38, 0x81e8, 0x80f3, 0x0c00
+ax_pose 39, 0x81e8, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose257:
+ax_pose 40, 0x81ec, 0x5109, 0x0c00
+ax_pose 41, 0x81ec, 0x5101, 0x0c04
+ax_pose 42, 0x41f3, 0x00f9, 0x0c08
+ax_pose 43, 0x41fb, 0x80f1, 0x0c0a
+ax_pose_terminator
+sKinglerPose258:
+ax_pose 42, 0x41f3, 0x00f9, 0x0c00
+ax_pose 43, 0x41fb, 0x80f1, 0x0c02
+ax_pose_terminator
+sKinglerPose259:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose260:
+ax_pose 44, 0x81e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose261:
+ax_pose 45, 0x81e8, 0x9107, 0x0c00
+ax_pose 46, 0x01e8, 0x10ff, 0x0c08
+ax_pose 47, 0x41f2, 0x00f7, 0x0c09
+ax_pose 48, 0x41fa, 0x80f7, 0x0c0b
+ax_pose_terminator
+sKinglerPose262:
+ax_pose 47, 0x41f2, 0x00f7, 0x0c00
+ax_pose 48, 0x41fa, 0x80f7, 0x0c02
+ax_pose_terminator
+sKinglerPose263:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose264:
+ax_pose 49, 0x81e7, 0x80f3, 0x0c00
+ax_pose 50, 0x81e7, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose265:
+ax_pose 51, 0x41e8, 0x40f2, 0x0c00
+ax_pose 52, 0x41f0, 0x40f2, 0x0c04
+ax_pose 53, 0x81e8, 0x80f8, 0x0c08
+ax_pose 54, 0x81e8, 0x4108, 0x0c10
+ax_pose_terminator
+sKinglerPose266:
+ax_pose 53, 0x81e8, 0x80f8, 0x0c00
+ax_pose 54, 0x81e8, 0x4108, 0x0c08
+ax_pose_terminator
+sKinglerPose267:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose268:
+ax_pose 55, 0x41ed, 0x40f0, 0x0c00
+ax_pose 56, 0x41f5, 0x80f0, 0x0c04
+ax_pose_terminator
+sKinglerPose269:
+ax_pose 57, 0x81e3, 0x40f5, 0x0c00
+ax_pose 58, 0x81e3, 0x40fd, 0x0c04
+ax_pose 59, 0x81e6, 0x80f5, 0x0c08
+ax_pose 60, 0x81e6, 0x4105, 0x0c10
+ax_pose_terminator
+sKinglerPose270:
+ax_pose 59, 0x81e6, 0x80f5, 0x0c00
+ax_pose 60, 0x81e6, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose271:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose272:
+ax_pose 61, 0x81e7, 0x80f5, 0x0c00
+ax_pose 62, 0x81e7, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose273:
+ax_pose 63, 0x01e8, 0x40f2, 0x0c00
+ax_pose 64, 0x41ee, 0x80f1, 0x0c04
+ax_pose 65, 0x41fe, 0x40f1, 0x0c0c
+ax_pose_terminator
+sKinglerPose274:
+ax_pose 64, 0x41ee, 0x80f1, 0x0c00
+ax_pose 65, 0x41fe, 0x40f1, 0x0c08
+ax_pose_terminator
+sKinglerPose275:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose276:
+ax_pose 66, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKinglerPose277:
+ax_pose 45, 0x81eb, 0x80eb, 0x0c00
+ax_pose 46, 0x01eb, 0x00fb, 0x0c08
+ax_pose 67, 0x41f8, 0x80eb, 0x0c09
+ax_pose 68, 0x41f0, 0x00fb, 0x0c11
+ax_pose_terminator
+sKinglerPose278:
+ax_pose 67, 0x41f8, 0x80eb, 0x0c00
+ax_pose 68, 0x41f0, 0x00fb, 0x0c08
+ax_pose_terminator
+sKinglerPose279:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose280:
+ax_pose 69, 0x81ea, 0x80f6, 0x0c00
+ax_pose 70, 0x81ea, 0x4106, 0x0c08
+ax_pose_terminator
+sKinglerPose281:
+ax_pose 40, 0x81ec, 0x40f8, 0x0c00
+ax_pose 41, 0x81ec, 0x4100, 0x0c04
+ax_pose 71, 0x01f3, 0x40f4, 0x0c08
+ax_pose 72, 0x4203, 0x00f4, 0x0c0c
+ax_pose 73, 0x01f3, 0x0104, 0x0c0e
+ax_pose 74, 0x81fb, 0x0104, 0x0c0f
+ax_pose_terminator
+sKinglerPose282:
+ax_pose 71, 0x01f3, 0x40f4, 0x0c00
+ax_pose 72, 0x4203, 0x00f4, 0x0c04
+ax_pose 73, 0x01f3, 0x0104, 0x0c06
+ax_pose 74, 0x81fb, 0x0104, 0x0c07
+ax_pose_terminator
+sKinglerPose283:
+ax_pose 75, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose284:
+ax_pose 82, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose285:
+ax_pose 81, 0x01ea, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose286:
+ax_pose 80, 0x01ea, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose287:
+ax_pose 79, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose288:
+ax_pose 78, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose289:
+ax_pose 77, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose290:
+ax_pose 76, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose291:
+ax_pose 32, 0x81e8, 0x80f4, 0x0c00
+ax_pose 33, 0x81e8, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose292:
+ax_pose 38, 0x81e8, 0x80f4, 0x0c00
+ax_pose 39, 0x81e8, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose293:
+ax_pose 44, 0x81e7, 0x80f7, 0x0c00
+ax_pose_terminator
+sKinglerPose294:
+ax_pose 49, 0x81e8, 0x80f5, 0x0c00
+ax_pose 50, 0x81e8, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose295:
+ax_pose 55, 0x41ed, 0x40f0, 0x0c00
+ax_pose 56, 0x41f5, 0x80f0, 0x0c04
+ax_pose_terminator
+sKinglerPose296:
+ax_pose 61, 0x81e8, 0x80f3, 0x0c00
+ax_pose 62, 0x81e8, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose297:
+ax_pose 66, 0x81eb, 0x80fa, 0x0c00
+ax_pose_terminator
+sKinglerPose298:
+ax_pose 69, 0x81ea, 0x80f5, 0x0c00
+ax_pose 70, 0x81ea, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose299:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose300:
+ax_pose 32, 0x81e8, 0x80f4, 0x0c00
+ax_pose 33, 0x81e8, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose301:
+ax_pose 75, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose302:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose303:
+ax_pose 38, 0x81e8, 0x80f5, 0x0c00
+ax_pose 39, 0x81e8, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose304:
+ax_pose 76, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose305:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose306:
+ax_pose 44, 0x81e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose307:
+ax_pose 77, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose308:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose309:
+ax_pose 49, 0x81e7, 0x80f3, 0x0c00
+ax_pose 50, 0x81e7, 0x4103, 0x0c08
+ax_pose_terminator
+sKinglerPose310:
+ax_pose 78, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose311:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose312:
+ax_pose 79, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose313:
+ax_pose 55, 0x41ed, 0x40f0, 0x0c00
+ax_pose 56, 0x41f5, 0x80f0, 0x0c04
+ax_pose_terminator
+sKinglerPose314:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose315:
+ax_pose 61, 0x81e7, 0x80f5, 0x0c00
+ax_pose 62, 0x81e7, 0x4105, 0x0c08
+ax_pose_terminator
+sKinglerPose316:
+ax_pose 80, 0x01ea, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose317:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose318:
+ax_pose 66, 0x81eb, 0x80fd, 0x0c00
+ax_pose_terminator
+sKinglerPose319:
+ax_pose 81, 0x01eb, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose320:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose321:
+ax_pose 69, 0x81ea, 0x80f4, 0x0c00
+ax_pose 70, 0x81ea, 0x4104, 0x0c08
+ax_pose_terminator
+sKinglerPose322:
+ax_pose 82, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose323:
+ax_pose 75, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sKinglerPose324:
+ax_pose 82, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose325:
+ax_pose 81, 0x01eb, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose326:
+ax_pose 80, 0x01ea, 0x80ed, 0x0c00
+ax_pose_terminator
+sKinglerPose327:
+ax_pose 79, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose328:
+ax_pose 78, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose329:
+ax_pose 77, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose330:
+ax_pose 76, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose331:
+ax_pose 18, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose332:
+ax_pose 15, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose333:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sKinglerPose334:
+ax_pose 9, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose335:
+ax_pose 6, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose336:
+ax_pose 3, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKinglerPose337:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sKinglerPose338:
+ax_pose 21, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+.align 2
+sKinglerAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_2_1:
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, -3, 0, 0,
+ax_anim 3, 0, 34, 0, -4, 0, 0,
+ax_anim 2, 0, 33, 0, -4, 0, 0,
+ax_anim 1, 0, 33, 0, -2, 0, 0,
+ax_anim 3, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 2, 0, 2,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 34, 0, 2, 0, 5,
+ax_anim 2, 0, 27, 0, -2, 0, 2,
+ax_anim 1, 0, 27, 0, -1, 0, 1,
+ax_anim_terminator
+sKinglerAnims_2_2:
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, -3, 0, 0,
+ax_anim 3, 0, 52, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 1, 0, 51, 0, -3, 0, 0,
+ax_anim 3, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 2, 44, 4, 4, 4, 4,
+ax_anim 1, 0, 45, 10, 10, 10, 10,
+ax_anim 2, 0, 44, 18, 18, 18, 18,
+ax_anim 2, 1, 44, 19, 17, 19, 17,
+ax_anim 2, 0, 44, 18, 18, 18, 18,
+ax_anim 2, 0, 44, 19, 17, 19, 17,
+ax_anim 4, 0, 32, 12, 8, 12, 12,
+ax_anim 2, 0, 33, 8, 3, 6, 6,
+ax_anim 1, 0, 34, 3, 1, 3, 3,
+ax_anim_terminator
+sKinglerAnims_2_3:
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -3, 0, 0,
+ax_anim 3, 0, 70, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 1, 0, 69, 0, -2, 0, 0,
+ax_anim 3, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 2, 0, 2, 0,
+ax_anim 1, 2, 63, 4, 0, 4, 0,
+ax_anim 1, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 63, 19, 0, 19, 0,
+ax_anim 2, 1, 63, 19, 1, 19, 1,
+ax_anim 2, 0, 63, 19, 0, 19, 0,
+ax_anim 2, 0, 63, 19, 1, 19, 1,
+ax_anim 4, 0, 31, 14, -4, 14, 0,
+ax_anim 2, 0, 32, 10, -5, 10, 0,
+ax_anim 1, 0, 33, 4, -1, 4, 0,
+ax_anim_terminator
+sKinglerAnims_2_4:
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 3, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 3, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 2, -2, 2, -2,
+ax_anim 1, 2, 82, 5, -5, 5, -5,
+ax_anim 1, 0, 83, 12, -12, 12, -12,
+ax_anim 2, 0, 82, 22, -22, 22, -22,
+ax_anim 2, 1, 82, 21, -23, 21, -23,
+ax_anim 2, 0, 82, 22, -22, 22, -22,
+ax_anim 2, 0, 82, 21, -23, 21, -23,
+ax_anim 4, 0, 30, 14, -18, 14, -14,
+ax_anim 2, 0, 31, 10, -12, 10, -10,
+ax_anim 1, 0, 32, 4, -5, 4, -4,
+ax_anim_terminator
+sKinglerAnims_2_5:
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 3, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 105, -1, -4, 0, 0,
+ax_anim 1, 0, 105, -1, -2, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 1, 2, 101, 0, -5, 0, -5,
+ax_anim 1, 0, 102, 0, -12, 0, -12,
+ax_anim 2, 0, 101, 0, -22, 0, -22,
+ax_anim 2, 1, 101, 0, -23, 0, -23,
+ax_anim 2, 0, 101, 0, -22, 0, -22,
+ax_anim 2, 0, 101, 0, -23, 0, -23,
+ax_anim 4, 0, 48, 0, -14, 0, -14,
+ax_anim 2, 0, 49, 2, -10, 0, -10,
+ax_anim 1, 0, 50, 0, -3, 0, -4,
+ax_anim_terminator
+sKinglerAnims_2_6:
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 3, 0, 124, -1, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 1, 0, 123, 0, -1, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, -2, -2, -2, -2,
+ax_anim 1, 2, 120, -5, -5, -4, -5,
+ax_anim 1, 0, 121, -14, -14, -14, -14,
+ax_anim 2, 0, 120, -20, -20, -20, -20,
+ax_anim 2, 1, 120, -19, -21, -19, -21,
+ax_anim 2, 0, 120, -20, -20, -20, -20,
+ax_anim 2, 0, 120, -19, -21, -19, -21,
+ax_anim 4, 0, 47, -13, -13, -13, -13,
+ax_anim 2, 0, 48, -9, -10, -9, -9,
+ax_anim 1, 0, 49, -3, -3, -3, -3,
+ax_anim_terminator
+sKinglerAnims_2_7:
+ax_anim 1, 0, 143, -1, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -3, 0, 0,
+ax_anim 3, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 1, 0, 141, 0, -2, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -2, 0, -2, 0,
+ax_anim 1, 2, 139, -4, 0, -4, 0,
+ax_anim 1, 0, 140, -10, 0, -10, 0,
+ax_anim 2, 0, 139, -19, 0, -19, 0,
+ax_anim 2, 1, 139, -19, -1, -19, -1,
+ax_anim 2, 0, 139, -19, 0, -19, 0,
+ax_anim 2, 0, 139, -19, -1, -19, -1,
+ax_anim 4, 0, 46, -14, -3, -14, 0,
+ax_anim 2, 0, 47, -10, -3, -10, 0,
+ax_anim 1, 0, 48, -6, -1, -6, 0,
+ax_anim_terminator
+sKinglerAnims_2_8:
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 1, 0, 167, 0, -2, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -2, 2, -2, 2,
+ax_anim 1, 2, 158, -4, 4, -4, 4,
+ax_anim 1, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 158, -18, 18, -18, 18,
+ax_anim 2, 1, 158, -19, 17, -19, 17,
+ax_anim 2, 0, 158, -18, 18, -18, 18,
+ax_anim 2, 0, 158, -19, 17, -19, 17,
+ax_anim 4, 0, 53, -12, 8, -12, 12,
+ax_anim 2, 0, 46, -8, 2, -8, 8,
+ax_anim 1, 0, 47, -4, 2, -4, 4,
+ax_anim_terminator
+.align 2
+sKinglerAnims_3_1:
+ax_anim 2, 0, 176, 0, -2, 0, -2,
+ax_anim 2, 0, 177, 0, -3, 0, -3,
+ax_anim 4, 0, 177, 0, -4, 0, -4,
+ax_anim 1, 1, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 3, 0, 3,
+ax_anim 2, 0, 178, 0, 8, 0, 8,
+ax_anim 2, 2, 179, 1, 8, 1, 8,
+ax_anim 2, 0, 179, 0, 8, 0, 8,
+ax_anim 2, 0, 179, 1, 8, 1, 8,
+ax_anim 2, 0, 179, 0, 8, 0, 8,
+ax_anim 2, 0, 179, 1, 8, 1, 8,
+ax_anim 2, 0, 176, 0, 4, 0, 4,
+ax_anim_terminator
+sKinglerAnims_3_2:
+ax_anim 2, 0, 180, -2, -2, -2, -2,
+ax_anim 2, 0, 181, -3, -3, -3, -3,
+ax_anim 4, 0, 181, -4, -4, -4, -4,
+ax_anim 1, 1, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 182, 13, 12, 13, 12,
+ax_anim 2, 2, 183, 14, 11, 14, 11,
+ax_anim 2, 0, 183, 13, 12, 13, 12,
+ax_anim 2, 0, 183, 14, 11, 14, 11,
+ax_anim 2, 0, 183, 13, 12, 13, 12,
+ax_anim 2, 0, 183, 14, 11, 14, 11,
+ax_anim 2, 0, 180, 5, 5, 5, 5,
+ax_anim_terminator
+sKinglerAnims_3_3:
+ax_anim 2, 0, 184, -2, 0, -2, 0,
+ax_anim 2, 0, 185, -3, 0, -3, 0,
+ax_anim 4, 0, 185, -4, 0, -4, 0,
+ax_anim 1, 1, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, 0, 3, 0,
+ax_anim 2, 0, 186, 9, 0, 9, 0,
+ax_anim 2, 2, 187, 9, -1, 9, -1,
+ax_anim 2, 0, 187, 9, 0, 9, 0,
+ax_anim 2, 0, 187, 9, -1, 9, -1,
+ax_anim 2, 0, 187, 9, 0, 9, 0,
+ax_anim 2, 0, 187, 9, -1, 9, -1,
+ax_anim 2, 0, 184, 3, 0, 3, 0,
+ax_anim_terminator
+sKinglerAnims_3_4:
+ax_anim 2, 0, 188, -2, 2, -2, 2,
+ax_anim 2, 0, 189, -3, 3, -3, 3,
+ax_anim 4, 0, 189, -4, 4, -4, 4,
+ax_anim 1, 1, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 5, -7, 5, -7,
+ax_anim 2, 0, 190, 13, -18, 13, -18,
+ax_anim 2, 2, 191, 12, -19, 12, -19,
+ax_anim 2, 0, 191, 13, -18, 13, -18,
+ax_anim 2, 0, 191, 12, -19, 12, -19,
+ax_anim 2, 0, 191, 13, -18, 13, -18,
+ax_anim 2, 0, 191, 12, -19, 12, -19,
+ax_anim 2, 0, 188, 5, -7, 5, -7,
+ax_anim_terminator
+sKinglerAnims_3_5:
+ax_anim 2, 0, 192, 0, 2, 0, 2,
+ax_anim 2, 0, 193, 0, 3, 0, 3,
+ax_anim 4, 0, 193, 0, 4, 0, 4,
+ax_anim 1, 1, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -7, 0, -7,
+ax_anim 2, 0, 194, 0, -11, 0, -11,
+ax_anim 2, 2, 195, 1, -11, 1, -11,
+ax_anim 2, 0, 195, 0, -11, 0, -11,
+ax_anim 2, 0, 195, 1, -11, 1, -11,
+ax_anim 2, 0, 195, 0, -11, 0, -11,
+ax_anim 2, 0, 195, 1, -11, 1, -11,
+ax_anim 2, 0, 192, 0, -4, 0, -4,
+ax_anim_terminator
+sKinglerAnims_3_6:
+ax_anim 2, 0, 196, 2, 2, 2, 2,
+ax_anim 2, 0, 197, 3, 3, 3, 3,
+ax_anim 4, 0, 197, 4, 4, 4, 4,
+ax_anim 1, 1, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 197, -5, -7, -5, -7,
+ax_anim 2, 0, 198, -13, -18, -13, -18,
+ax_anim 2, 2, 199, -12, -19, -12, -19,
+ax_anim 2, 0, 199, -13, -18, -13, -18,
+ax_anim 2, 0, 199, -12, -19, -12, -19,
+ax_anim 2, 0, 199, -13, -18, -13, -18,
+ax_anim 2, 0, 199, -12, -19, -12, -19,
+ax_anim 2, 0, 196, -5, -7, -5, -7,
+ax_anim_terminator
+sKinglerAnims_3_7:
+ax_anim 2, 0, 200, 2, 0, 2, 0,
+ax_anim 2, 0, 201, 3, 0, 3, 0,
+ax_anim 4, 0, 201, 4, 0, 4, 0,
+ax_anim 1, 1, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, -3, 0, -3, 0,
+ax_anim 2, 0, 202, -9, 0, -9, 0,
+ax_anim 2, 2, 203, -9, -1, -9, -1,
+ax_anim 2, 0, 203, -9, 0, -9, 0,
+ax_anim 2, 0, 203, -9, -1, -9, -1,
+ax_anim 2, 0, 203, -9, 0, -9, 0,
+ax_anim 2, 0, 203, -9, -1, -9, -1,
+ax_anim 2, 0, 200, -3, 0, -3, 0,
+ax_anim_terminator
+sKinglerAnims_3_8:
+ax_anim 2, 0, 204, 2, -2, 2, -2,
+ax_anim 2, 0, 205, 3, -3, 3, -3,
+ax_anim 4, 0, 205, 4, -4, 4, -4,
+ax_anim 1, 1, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 205, -6, 3, -6, 3,
+ax_anim 2, 0, 206, -20, 12, -20, 12,
+ax_anim 2, 2, 207, -21, 11, -21, 11,
+ax_anim 2, 0, 207, -20, 12, -20, 12,
+ax_anim 2, 0, 207, -21, 11, -21, 11,
+ax_anim 2, 0, 207, -20, 12, -20, 12,
+ax_anim 2, 0, 207, -21, 11, -21, 11,
+ax_anim 2, 0, 204, -5, 3, -5, 3,
+ax_anim_terminator
+.align 2
+sKinglerAnims_4_1:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 2, 0, 2,
+ax_anim 2, 0, 210, 0, 3, 0, 3,
+ax_anim 2, 0, 210, 1, 3, 1, 3,
+ax_anim 2, 0, 210, 0, 3, 0, 3,
+ax_anim 2, 1, 210, 1, 3, 1, 3,
+ax_anim 2, 0, 210, 0, 3, 0, 3,
+ax_anim 1, 0, 209, 0, -2, 0, -2,
+ax_anim 2, 0, 209, 0, -4, 0, -4,
+ax_anim 4, 0, 209, 0, -5, 0, -5,
+ax_anim 2, 0, 209, 0, -4, 0, -4,
+ax_anim 1, 0, 208, 0, -2, 0, -2,
+ax_anim_terminator
+sKinglerAnims_4_2:
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 2, 2, 2, 2,
+ax_anim 2, 0, 213, 3, 3, 3, 3,
+ax_anim 2, 0, 213, 4, 2, 4, 2,
+ax_anim 2, 0, 213, 3, 3, 3, 3,
+ax_anim 2, 1, 213, 4, 2, 4, 2,
+ax_anim 2, 0, 213, 3, 3, 3, 3,
+ax_anim 1, 0, 212, -2, -2, -2, -2,
+ax_anim 2, 0, 212, -4, -4, -4, -4,
+ax_anim 4, 0, 212, -5, -5, -5, -5,
+ax_anim 2, 0, 212, -4, -4, -4, -4,
+ax_anim 1, 0, 211, -2, -2, -2, -2,
+ax_anim_terminator
+sKinglerAnims_4_3:
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 2, 0, 2, 0,
+ax_anim 2, 0, 216, 3, 0, 3, 0,
+ax_anim 2, 0, 216, 3, -1, 3, -1,
+ax_anim 2, 0, 216, 3, 0, 3, 0,
+ax_anim 2, 1, 216, 3, -1, 3, -1,
+ax_anim 2, 0, 216, 3, 0, 3, 0,
+ax_anim 1, 0, 215, -2, 0, -2, 0,
+ax_anim 2, 0, 215, -4, 0, -4, 0,
+ax_anim 4, 0, 215, -5, 0, -5, 0,
+ax_anim 2, 0, 215, -4, 0, -4, 0,
+ax_anim 1, 0, 214, -2, 0, -2, 0,
+ax_anim_terminator
+sKinglerAnims_4_4:
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 2, -2, 2, -2,
+ax_anim 2, 0, 219, 3, -3, 3, -3,
+ax_anim 2, 0, 219, 2, -4, 2, -4,
+ax_anim 2, 0, 219, 3, -3, 3, -3,
+ax_anim 2, 1, 219, 2, -4, 2, -4,
+ax_anim 2, 0, 219, 3, -3, 3, -3,
+ax_anim 1, 0, 218, -2, 2, -2, 2,
+ax_anim 2, 0, 218, -4, 4, -4, 4,
+ax_anim 4, 0, 218, -5, 5, -5, 5,
+ax_anim 2, 0, 218, -4, 4, -4, 4,
+ax_anim 1, 0, 217, -2, 2, -2, 2,
+ax_anim_terminator
+sKinglerAnims_4_5:
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, -3, 0, -3,
+ax_anim 2, 0, 222, 0, -4, 0, -4,
+ax_anim 2, 0, 222, 1, -4, 1, -4,
+ax_anim 2, 0, 222, 0, -4, 0, -4,
+ax_anim 2, 1, 222, 1, -4, 1, -4,
+ax_anim 2, 0, 222, 0, -4, 0, -4,
+ax_anim 1, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 4, 0, 4,
+ax_anim 4, 0, 221, 0, 5, 0, 5,
+ax_anim 2, 0, 221, 0, 4, 0, 4,
+ax_anim 1, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sKinglerAnims_4_6:
+ax_anim 4, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -3, -3, -3, -3,
+ax_anim 2, 0, 225, -2, -4, -2, -4,
+ax_anim 2, 0, 225, -3, -3, -3, -3,
+ax_anim 2, 1, 225, -2, -4, -2, -4,
+ax_anim 2, 0, 225, -3, -3, -3, -3,
+ax_anim 1, 0, 224, 2, 2, 2, 2,
+ax_anim 2, 0, 224, 4, 4, 4, 4,
+ax_anim 4, 0, 224, 5, 5, 5, 5,
+ax_anim 2, 0, 224, 4, 4, 4, 4,
+ax_anim 1, 0, 223, 2, 2, 2, 2,
+ax_anim_terminator
+sKinglerAnims_4_7:
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 228, -2, 0, -2, 0,
+ax_anim 2, 0, 228, -3, 0, -3, 0,
+ax_anim 2, 0, 228, -3, -1, -3, -1,
+ax_anim 2, 0, 228, -3, 0, -3, 0,
+ax_anim 2, 1, 228, -3, -1, -3, -1,
+ax_anim 2, 0, 228, -3, 0, -3, 0,
+ax_anim 1, 0, 227, 2, 0, 2, 0,
+ax_anim 2, 0, 227, 4, 0, 4, 0,
+ax_anim 4, 0, 227, 5, 0, 5, 0,
+ax_anim 2, 0, 227, 4, 0, 4, 0,
+ax_anim 1, 0, 226, 2, 0, 2, 0,
+ax_anim_terminator
+sKinglerAnims_4_8:
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 231, -2, 2, -2, 2,
+ax_anim 2, 0, 231, -3, 3, -3, 3,
+ax_anim 2, 0, 231, -4, 2, -4, 2,
+ax_anim 2, 0, 231, -3, 3, -3, 3,
+ax_anim 2, 1, 231, -4, 2, -4, 2,
+ax_anim 2, 0, 231, -3, 3, -3, 3,
+ax_anim 1, 0, 230, 2, -2, 2, -2,
+ax_anim 2, 0, 230, 4, -4, 4, -4,
+ax_anim 4, 0, 230, 5, -5, 5, -5,
+ax_anim 2, 0, 230, 4, -4, 4, -4,
+ax_anim 1, 0, 229, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sKinglerAnims_5_1:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_5_2:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_5_3:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_5_4:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_5_5:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_5_6:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_5_7:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_5_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_6_1:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 35, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_7_1:
+ax_anim 2, 0, 242, 0, -2, 0, -2,
+ax_anim 8, 0, 242, 0, -3, 0, -3,
+ax_anim_terminator
+sKinglerAnims_7_2:
+ax_anim 2, 0, 243, -2, -2, -2, -2,
+ax_anim 8, 0, 243, -3, -3, -3, -3,
+ax_anim_terminator
+sKinglerAnims_7_3:
+ax_anim 2, 0, 244, -2, 0, -2, 0,
+ax_anim 8, 0, 244, -3, 0, -3, 0,
+ax_anim_terminator
+sKinglerAnims_7_4:
+ax_anim 2, 0, 245, -2, 2, -2, 2,
+ax_anim 8, 0, 245, -3, 3, -3, 3,
+ax_anim_terminator
+sKinglerAnims_7_5:
+ax_anim 2, 0, 246, 0, 2, 0, 2,
+ax_anim 8, 0, 246, 0, 3, 0, 3,
+ax_anim_terminator
+sKinglerAnims_7_6:
+ax_anim 2, 0, 247, 2, 2, 2, 2,
+ax_anim 8, 0, 247, 3, 3, 3, 3,
+ax_anim_terminator
+sKinglerAnims_7_7:
+ax_anim 2, 0, 248, 2, 0, 2, 0,
+ax_anim 8, 0, 248, 3, 0, 3, 0,
+ax_anim_terminator
+sKinglerAnims_7_8:
+ax_anim 2, 0, 249, 2, -2, 2, -2,
+ax_anim 8, 0, 249, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sKinglerAnims_8_1:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_8_2:
+ax_anim 30, 0, 254, 0, 0, 0, 0,
+ax_anim 30, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_8_3:
+ax_anim 30, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_8_4:
+ax_anim 30, 0, 262, 0, 0, 0, 0,
+ax_anim 30, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_8_5:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 30, 0, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_8_6:
+ax_anim 30, 0, 270, 0, 0, 0, 0,
+ax_anim 30, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_8_7:
+ax_anim 30, 0, 274, 0, 0, 0, 0,
+ax_anim 30, 0, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_8_8:
+ax_anim 30, 0, 278, 0, 0, 0, 0,
+ax_anim 30, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_9_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 1, 0, 283, 6, 3, 6, 3,
+ax_anim 2, 0, 284, 8, 9, 8, 9,
+ax_anim 2, 0, 285, 7, 16, 7, 16,
+ax_anim 3, 0, 286, 0, 19, 0, 19,
+ax_anim 2, 3, 287, -7, 16, -7, 16,
+ax_anim 2, 0, 288, -8, 9, -8, 9,
+ax_anim 1, 0, 289, -6, 3, -6, 3,
+ax_anim 1, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_9_2:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 1, 0, 282, 8, 0, 8, 0,
+ax_anim 2, 0, 283, 17, 3, 17, 3,
+ax_anim 2, 0, 284, 21, 14, 21, 14,
+ax_anim 3, 0, 285, 20, 18, 20, 18,
+ax_anim 2, 3, 286, 11, 20, 11, 20,
+ax_anim 2, 0, 287, 3, 15, 3, 15,
+ax_anim 1, 0, 288, -1, 10, -1, 10,
+ax_anim 1, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_9_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 1, 0, 289, 3, -5, 3, -5,
+ax_anim 2, 0, 282, 11, -6, 11, -6,
+ax_anim 2, 0, 283, 18, -5, 18, -5,
+ax_anim 3, 0, 284, 22, -2, 22, -2,
+ax_anim 2, 3, 285, 18, 4, 18, 4,
+ax_anim 2, 0, 286, 12, 7, 12, 7,
+ax_anim 1, 0, 287, 4, 5, 4, 5,
+ax_anim 1, 0, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_9_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 1, 0, 288, -1, -8, -1, -8,
+ax_anim 2, 0, 289, 4, -16, 4, -16,
+ax_anim 2, 0, 282, 11, -22, 11, -22,
+ax_anim 3, 0, 283, 20, -25, 20, -25,
+ax_anim 2, 3, 284, 22, -15, 22, -15,
+ax_anim 2, 0, 285, 17, -4, 17, -4,
+ax_anim 1, 0, 286, 9, 0, 9, 0,
+ax_anim 1, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_9_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 1, 0, 287, -8, -4, -8, -4,
+ax_anim 2, 0, 288, -9, -12, -9, -12,
+ax_anim 2, 0, 289, -7, -22, -7, -22,
+ax_anim 3, 0, 282, 0, -26, 0, -26,
+ax_anim 2, 3, 283, 7, -22, 7, -22,
+ax_anim 2, 0, 284, 9, -10, 9, -10,
+ax_anim 1, 0, 285, 8, -4, 8, -4,
+ax_anim 1, 0, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_9_6:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 1, 0, 284, 1, -8, 1, -8,
+ax_anim 2, 0, 283, -4, -16, -4, -16,
+ax_anim 2, 0, 282, -11, -22, -11, -22,
+ax_anim 3, 0, 289, -20, -25, -20, -25,
+ax_anim 2, 3, 288, -22, -15, -22, -15,
+ax_anim 2, 0, 287, -17, -4, -17, -4,
+ax_anim 1, 0, 286, -9, 0, -9, 0,
+ax_anim 1, 0, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_9_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 1, 0, 283, -3, -5, -3, -5,
+ax_anim 2, 0, 282, -11, -6, -11, -6,
+ax_anim 2, 0, 289, -18, -5, -18, -5,
+ax_anim 3, 0, 288, -22, -2, -22, -2,
+ax_anim 2, 3, 287, -18, 4, -18, 4,
+ax_anim 2, 0, 286, -12, 7, -12, 7,
+ax_anim 1, 0, 285, -4, 5, -4, 5,
+ax_anim 1, 0, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_9_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 1, 0, 282, -8, 0, -8, 0,
+ax_anim 2, 0, 289, -17, 3, -17, 3,
+ax_anim 2, 0, 288, -21, 14, -21, 14,
+ax_anim 3, 0, 287, -20, 18, -20, 18,
+ax_anim 2, 3, 286, -11, 20, -11, 20,
+ax_anim 2, 0, 285, -3, 15, -3, 15,
+ax_anim 1, 0, 284, -1, 10, -1, 10,
+ax_anim 1, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_10_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 6, 0, 6, 0,
+ax_anim 2, 0, 290, -6, 0, -6, 0,
+ax_anim 2, 0, 290, 10, 0, 10, 0,
+ax_anim 2, 0, 290, -10, 0, -10, 0,
+ax_anim 2, 0, 290, 12, 0, 12, 0,
+ax_anim 3, 0, 290, -12, 0, -12, 0,
+ax_anim 3, 0, 290, 13, 0, 13, 0,
+ax_anim 3, 0, 290, -13, 0, -13, 0,
+ax_anim 2, 0, 290, 12, 0, 12, 0,
+ax_anim 3, 0, 290, -12, 0, -12, 0,
+ax_anim 2, 0, 290, 10, 0, 10, 0,
+ax_anim 2, 0, 290, -10, 0, -10, 0,
+ax_anim 2, 0, 290, 6, 0, 6, 0,
+ax_anim 2, 0, 290, -6, 0, -6, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_10_2:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 6, -6, 6, -6,
+ax_anim 2, 0, 291, -6, 6, -6, 6,
+ax_anim 2, 0, 291, 10, -10, 10, -10,
+ax_anim 2, 0, 291, -10, 10, -10, 10,
+ax_anim 2, 0, 291, 12, -12, 12, -12,
+ax_anim 3, 0, 291, -12, 12, -12, 12,
+ax_anim 3, 0, 291, 13, -13, 13, -13,
+ax_anim 3, 0, 291, -13, 13, -13, 13,
+ax_anim 2, 0, 291, 12, -12, 12, -12,
+ax_anim 3, 0, 291, -12, 12, -12, 12,
+ax_anim 2, 0, 291, 10, -10, 10, -10,
+ax_anim 2, 0, 291, -10, 10, -10, 10,
+ax_anim 2, 0, 291, 6, -6, 6, -6,
+ax_anim 2, 0, 291, -6, 6, -6, 6,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_10_3:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -6, 0, -6,
+ax_anim 2, 0, 292, 0, 6, 0, 6,
+ax_anim 2, 0, 292, 0, -10, 0, -10,
+ax_anim 2, 0, 292, 0, 10, 0, 10,
+ax_anim 2, 0, 292, 0, -12, 0, -12,
+ax_anim 3, 0, 292, 0, 12, 0, 12,
+ax_anim 3, 0, 292, 0, -13, 0, -13,
+ax_anim 3, 0, 292, 0, 13, 0, 13,
+ax_anim 2, 0, 292, 0, -12, 0, -12,
+ax_anim 3, 0, 292, 0, 12, 0, 12,
+ax_anim 2, 0, 292, 0, -10, 0, -10,
+ax_anim 2, 0, 292, 0, 10, 0, 10,
+ax_anim 2, 0, 292, 0, -6, 0, -6,
+ax_anim 2, 0, 292, 0, 6, 0, 6,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_10_4:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, -6, -6, -6, -6,
+ax_anim 2, 0, 293, 6, 6, 6, 6,
+ax_anim 2, 0, 293, -10, -10, -10, -10,
+ax_anim 2, 0, 293, 10, 10, 10, 10,
+ax_anim 2, 0, 293, -12, -12, -12, -12,
+ax_anim 3, 0, 293, 12, 12, 12, 12,
+ax_anim 3, 0, 293, -13, -13, -13, -13,
+ax_anim 3, 0, 293, 13, 13, 13, 13,
+ax_anim 2, 0, 293, -12, -12, -12, -12,
+ax_anim 3, 0, 293, 12, 12, 12, 12,
+ax_anim 2, 0, 293, -10, -10, -10, -10,
+ax_anim 2, 0, 293, 10, 10, 10, 10,
+ax_anim 2, 0, 293, -6, -6, -6, -6,
+ax_anim 2, 0, 293, 6, 6, 6, 6,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_10_5:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 6, 0, 6, 0,
+ax_anim 2, 0, 294, -6, 0, -6, 0,
+ax_anim 2, 0, 294, 10, 0, 10, 0,
+ax_anim 2, 0, 294, -10, 0, -10, 0,
+ax_anim 2, 0, 294, 12, 0, 12, 0,
+ax_anim 3, 0, 294, -12, 0, -12, 0,
+ax_anim 3, 0, 294, 13, 0, 13, 0,
+ax_anim 3, 0, 294, -13, 0, -13, 0,
+ax_anim 2, 0, 294, 12, 0, 12, 0,
+ax_anim 3, 0, 294, -12, 0, -12, 0,
+ax_anim 2, 0, 294, 10, 0, 10, 0,
+ax_anim 2, 0, 294, -10, 0, -10, 0,
+ax_anim 2, 0, 294, 6, 0, 6, 0,
+ax_anim 2, 0, 294, -6, 0, -6, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_10_6:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 6, -6, 6, -6,
+ax_anim 2, 0, 295, -6, 6, -6, 6,
+ax_anim 2, 0, 295, 10, -10, 10, -10,
+ax_anim 2, 0, 295, -10, 10, -10, 10,
+ax_anim 2, 0, 295, 12, -12, 12, -12,
+ax_anim 3, 0, 295, -12, 12, -12, 12,
+ax_anim 3, 0, 295, 13, -13, 13, -13,
+ax_anim 3, 0, 295, -13, 13, -13, 13,
+ax_anim 2, 0, 295, 12, -12, 12, -12,
+ax_anim 3, 0, 295, -12, 12, -12, 12,
+ax_anim 2, 0, 295, 10, -10, 10, -10,
+ax_anim 2, 0, 295, -10, 10, -10, 10,
+ax_anim 2, 0, 295, 6, -6, 6, -6,
+ax_anim 2, 0, 295, -6, 6, -6, 6,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_10_7:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, -6, 0, -6,
+ax_anim 2, 0, 296, 0, 6, 0, 6,
+ax_anim 2, 0, 296, 0, -10, 0, -10,
+ax_anim 2, 0, 296, 0, 10, 0, 10,
+ax_anim 2, 0, 296, 0, -12, 0, -12,
+ax_anim 3, 0, 296, 0, 12, 0, 12,
+ax_anim 3, 0, 296, 0, -13, 0, -13,
+ax_anim 3, 0, 296, 0, 13, 0, 13,
+ax_anim 2, 0, 296, 0, -12, 0, -12,
+ax_anim 3, 0, 296, 0, 12, 0, 12,
+ax_anim 2, 0, 296, 0, -10, 0, -10,
+ax_anim 2, 0, 296, 0, 10, 0, 10,
+ax_anim 2, 0, 296, 0, -6, 0, -6,
+ax_anim 2, 0, 296, 0, 6, 0, 6,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_10_8:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 297, -6, -6, -6, -6,
+ax_anim 2, 0, 297, 6, 6, 6, 6,
+ax_anim 2, 0, 297, -10, -10, -10, -10,
+ax_anim 2, 0, 297, 10, 10, 10, 10,
+ax_anim 2, 0, 297, -12, -12, -12, -12,
+ax_anim 3, 0, 297, 12, 12, 12, 12,
+ax_anim 3, 0, 297, -13, -13, -13, -13,
+ax_anim 3, 0, 297, 13, 13, 13, 13,
+ax_anim 2, 0, 297, -12, -12, -12, -12,
+ax_anim 3, 0, 297, 12, 12, 12, 12,
+ax_anim 2, 0, 297, -10, -10, -10, -10,
+ax_anim 2, 0, 297, 10, 10, 10, 10,
+ax_anim 2, 0, 297, -6, -6, -6, -6,
+ax_anim 2, 0, 297, 6, 6, 6, 6,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_11_1:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 1, 0, 299, 0, -10, 0, 0,
+ax_anim 2, 0, 299, 0, -16, 0, 0,
+ax_anim 3, 0, 299, 0, -20, 0, 0,
+ax_anim 4, 0, 298, 0, -24, 0, 0,
+ax_anim 4, 0, 300, 0, -24, 0, 0,
+ax_anim 3, 0, 300, 0, -23, 0, 0,
+ax_anim 2, 0, 300, 0, -18, 0, 0,
+ax_anim 1, 0, 300, 0, -12, 0, 0,
+ax_anim 2, 2, 300, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_11_2:
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 1, 0, 302, 0, -10, 0, 0,
+ax_anim 2, 0, 302, 0, -16, 0, 0,
+ax_anim 3, 0, 302, 0, -20, 0, 0,
+ax_anim 4, 0, 301, 0, -26, 0, 0,
+ax_anim 4, 0, 303, 0, -26, 0, 0,
+ax_anim 3, 0, 303, 0, -25, 0, 0,
+ax_anim 2, 0, 303, 0, -18, 0, 0,
+ax_anim 1, 0, 303, 0, -12, 0, 0,
+ax_anim 2, 2, 303, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_11_3:
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 1, 0, 305, 0, -10, 0, 0,
+ax_anim 2, 0, 305, 0, -16, 0, 0,
+ax_anim 3, 0, 305, 0, -20, 0, 0,
+ax_anim 4, 0, 304, 0, -23, 0, 0,
+ax_anim 4, 0, 306, 0, -23, 0, 0,
+ax_anim 3, 0, 306, 0, -22, 0, 0,
+ax_anim 2, 0, 306, 0, -18, 0, 0,
+ax_anim 1, 0, 306, 0, -12, 0, 0,
+ax_anim 2, 2, 306, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_11_4:
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 1, 0, 308, 0, -10, 0, 0,
+ax_anim 2, 0, 308, 0, -16, 0, 0,
+ax_anim 3, 0, 308, 0, -20, 0, 0,
+ax_anim 4, 0, 307, 0, -27, 0, 0,
+ax_anim 4, 0, 309, 0, -26, 0, 0,
+ax_anim 3, 0, 309, 0, -25, 0, 0,
+ax_anim 2, 0, 309, 0, -17, 0, 0,
+ax_anim 1, 0, 309, 0, -11, 0, 0,
+ax_anim 2, 2, 309, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_11_5:
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 1, 0, 311, 0, -10, 0, 0,
+ax_anim 2, 0, 311, 0, -16, 0, 0,
+ax_anim 3, 0, 311, 0, -20, 0, 0,
+ax_anim 4, 0, 310, 0, -27, 0, 0,
+ax_anim 4, 0, 312, 0, -23, 0, 0,
+ax_anim 3, 0, 312, 0, -22, 0, 0,
+ax_anim 2, 0, 312, 0, -18, 0, 0,
+ax_anim 1, 0, 312, 0, -12, 0, 0,
+ax_anim 2, 2, 312, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_11_6:
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 1, 0, 314, 0, -10, 0, 0,
+ax_anim 2, 0, 314, 0, -16, 0, 0,
+ax_anim 3, 0, 314, 0, -20, 0, 0,
+ax_anim 4, 0, 313, 0, -27, 0, 0,
+ax_anim 4, 0, 315, 0, -26, 0, 0,
+ax_anim 3, 0, 315, 0, -25, 0, 0,
+ax_anim 2, 0, 315, 0, -17, 0, 0,
+ax_anim 1, 0, 315, 0, -11, 0, 0,
+ax_anim 2, 2, 315, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_11_7:
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 1, 0, 317, 0, -10, 0, 0,
+ax_anim 2, 0, 317, 0, -16, 0, 0,
+ax_anim 3, 0, 317, 0, -20, 0, 0,
+ax_anim 4, 0, 316, 0, -24, 0, 0,
+ax_anim 4, 0, 318, 0, -23, 0, 0,
+ax_anim 3, 0, 318, 0, -22, 0, 0,
+ax_anim 2, 0, 318, 0, -18, 0, 0,
+ax_anim 1, 0, 318, 0, -12, 0, 0,
+ax_anim 2, 2, 318, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_11_8:
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 1, 0, 320, 0, -10, 0, 0,
+ax_anim 2, 0, 320, 0, -16, 0, 0,
+ax_anim 3, 0, 320, 0, -20, 0, 0,
+ax_anim 4, 0, 319, 0, -26, 0, 0,
+ax_anim 4, 0, 321, 0, -26, 0, 0,
+ax_anim 3, 0, 321, 0, -25, 0, 0,
+ax_anim 2, 0, 321, 0, -18, 0, 0,
+ax_anim 1, 0, 321, 0, -12, 0, 0,
+ax_anim 2, 2, 321, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_12_1:
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 2, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 1, 322, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_12_2:
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 2, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 1, 329, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_12_3:
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 2, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 1, 328, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_12_4:
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 2, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 1, 327, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_12_5:
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 2, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 1, 326, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_12_6:
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 2, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 1, 325, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_12_7:
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 2, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 1, 324, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_12_8:
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 2, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 1, 323, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKinglerAnims_13_1:
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 2, 330, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_13_2:
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 2, 337, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_13_3:
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 2, 336, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_13_4:
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 2, 335, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_13_5:
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 2, 334, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_13_6:
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 2, 333, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_13_7:
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 2, 332, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerAnims_13_8:
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 2, 331, 0, 0, 0, 0,
+ax_anim_terminator
+sKinglerGfx1:
+.incbin "baserom.gba", 0x93B434, 0x200
+sKinglerSprites1:
+ax_sprite sKinglerGfx1, 0x200
+ax_sprite_terminator
+sKinglerGfx2:
+.incbin "baserom.gba", 0x93B644, 0x200
+sKinglerSprites2:
+ax_sprite sKinglerGfx2, 0x200
+ax_sprite_terminator
+sKinglerGfx3:
+.incbin "baserom.gba", 0x93B854, 0x200
+sKinglerSprites3:
+ax_sprite sKinglerGfx3, 0x200
+ax_sprite_terminator
+sKinglerGfx4:
+.incbin "baserom.gba", 0x93BA64, 0x200
+sKinglerSprites4:
+ax_sprite sKinglerGfx4, 0x200
+ax_sprite_terminator
+sKinglerGfx5:
+.incbin "baserom.gba", 0x93BC74, 0x200
+sKinglerSprites5:
+ax_sprite sKinglerGfx5, 0x200
+ax_sprite_terminator
+sKinglerGfx6:
+.incbin "baserom.gba", 0x93BE84, 0x200
+sKinglerSprites6:
+ax_sprite sKinglerGfx6, 0x200
+ax_sprite_terminator
+sKinglerGfx7:
+.incbin "baserom.gba", 0x93C094, 0x200
+sKinglerSprites7:
+ax_sprite sKinglerGfx7, 0x200
+ax_sprite_terminator
+sKinglerGfx8:
+.incbin "baserom.gba", 0x93C2A4, 0x200
+sKinglerSprites8:
+ax_sprite sKinglerGfx8, 0x200
+ax_sprite_terminator
+sKinglerGfx9:
+.incbin "baserom.gba", 0x93C4B4, 0x200
+sKinglerSprites9:
+ax_sprite sKinglerGfx9, 0x200
+ax_sprite_terminator
+sKinglerGfx10:
+.incbin "baserom.gba", 0x93C6C4, 0x200
+sKinglerSprites10:
+ax_sprite sKinglerGfx10, 0x200
+ax_sprite_terminator
+sKinglerGfx11:
+.incbin "baserom.gba", 0x93C8D4, 0x200
+sKinglerSprites11:
+ax_sprite sKinglerGfx11, 0x200
+ax_sprite_terminator
+sKinglerGfx12:
+.incbin "baserom.gba", 0x93CAE4, 0x200
+sKinglerSprites12:
+ax_sprite sKinglerGfx12, 0x200
+ax_sprite_terminator
+sKinglerGfx13:
+.incbin "baserom.gba", 0x93CCF4, 0x200
+sKinglerSprites13:
+ax_sprite sKinglerGfx13, 0x200
+ax_sprite_terminator
+sKinglerGfx14:
+.incbin "baserom.gba", 0x93CF04, 0x200
+sKinglerSprites14:
+ax_sprite sKinglerGfx14, 0x200
+ax_sprite_terminator
+sKinglerGfx15:
+.incbin "baserom.gba", 0x93D114, 0x200
+sKinglerSprites15:
+ax_sprite sKinglerGfx15, 0x200
+ax_sprite_terminator
+sKinglerGfx16:
+.incbin "baserom.gba", 0x93D324, 0x200
+sKinglerSprites16:
+ax_sprite sKinglerGfx16, 0x200
+ax_sprite_terminator
+sKinglerGfx17:
+.incbin "baserom.gba", 0x93D534, 0x200
+sKinglerSprites17:
+ax_sprite sKinglerGfx17, 0x200
+ax_sprite_terminator
+sKinglerGfx18:
+.incbin "baserom.gba", 0x93D744, 0x200
+sKinglerSprites18:
+ax_sprite sKinglerGfx18, 0x200
+ax_sprite_terminator
+sKinglerGfx19:
+.incbin "baserom.gba", 0x93D954, 0x200
+sKinglerSprites19:
+ax_sprite sKinglerGfx19, 0x200
+ax_sprite_terminator
+sKinglerGfx20:
+.incbin "baserom.gba", 0x93DB64, 0x200
+sKinglerSprites20:
+ax_sprite sKinglerGfx20, 0x200
+ax_sprite_terminator
+sKinglerGfx21:
+.incbin "baserom.gba", 0x93DD74, 0x200
+sKinglerSprites21:
+ax_sprite sKinglerGfx21, 0x200
+ax_sprite_terminator
+sKinglerGfx22:
+.incbin "baserom.gba", 0x93DF84, 0x200
+sKinglerSprites22:
+ax_sprite sKinglerGfx22, 0x200
+ax_sprite_terminator
+sKinglerGfx23:
+.incbin "baserom.gba", 0x93E194, 0x200
+sKinglerSprites23:
+ax_sprite sKinglerGfx23, 0x200
+ax_sprite_terminator
+sKinglerGfx24:
+.incbin "baserom.gba", 0x93E3A4, 0x200
+sKinglerSprites24:
+ax_sprite sKinglerGfx24, 0x200
+ax_sprite_terminator
+sKinglerGfx25:
+.incbin "baserom.gba", 0x93E5B4, 0x180
+sKinglerSprites25:
+ax_sprite sKinglerGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKinglerGfx26:
+.incbin "baserom.gba", 0x93E74C, 0x60
+sKinglerGfx26_1:
+.incbin "baserom.gba", 0x93E7AC, 0x60
+sKinglerGfx26_2:
+.incbin "baserom.gba", 0x93E80C, 0x80
+sKinglerGfx26_3:
+.incbin "baserom.gba", 0x93E88C, 0x40
+sKinglerSprites26:
+ax_sprite sKinglerGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx26_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx26_3, 0x40
+ax_sprite_terminator
+sKinglerGfx27:
+.incbin "baserom.gba", 0x93E90C, 0x60
+sKinglerGfx27_1:
+.incbin "baserom.gba", 0x93E96C, 0x60
+sKinglerGfx27_2:
+.incbin "baserom.gba", 0x93E9CC, 0x40
+sKinglerGfx27_3:
+.incbin "baserom.gba", 0x93EA0C, 0x60
+sKinglerSprites27:
+ax_sprite sKinglerGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx27_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx27_3, 0x60
+ax_sprite_terminator
+sKinglerGfx28:
+.incbin "baserom.gba", 0x93EAAC, 0x60
+sKinglerGfx28_1:
+.incbin "baserom.gba", 0x93EB0C, 0x80
+sKinglerGfx28_2:
+.incbin "baserom.gba", 0x93EB8C, 0xA0
+sKinglerSprites28:
+ax_sprite sKinglerGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx28_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx28_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKinglerGfx29:
+.incbin "baserom.gba", 0x93EC64, 0x200
+sKinglerSprites29:
+ax_sprite sKinglerGfx29, 0x200
+ax_sprite_terminator
+sKinglerGfx30:
+.incbin "baserom.gba", 0x93EE74, 0x60
+sKinglerGfx30_1:
+.incbin "baserom.gba", 0x93EED4, 0xC0
+sKinglerGfx30_2:
+.incbin "baserom.gba", 0x93EF94, 0x40
+sKinglerSprites30:
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx30_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sKinglerGfx30_2, 0x40
+ax_sprite_terminator
+sKinglerGfx31:
+.incbin "baserom.gba", 0x93F00C, 0x40
+sKinglerGfx31_1:
+.incbin "baserom.gba", 0x93F04C, 0x40
+sKinglerGfx31_2:
+.incbin "baserom.gba", 0x93F08C, 0x40
+sKinglerGfx31_3:
+.incbin "baserom.gba", 0x93F0CC, 0x60
+sKinglerSprites31:
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKinglerGfx32:
+.incbin "baserom.gba", 0x93F17C, 0x60
+sKinglerGfx32_1:
+.incbin "baserom.gba", 0x93F1DC, 0x120
+sKinglerSprites32:
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx32_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKinglerGfx33:
+.incbin "baserom.gba", 0x93F32C, 0xE0
+sKinglerSprites33:
+ax_sprite sKinglerGfx33, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKinglerGfx34:
+.incbin "baserom.gba", 0x93F424, 0x80
+sKinglerSprites34:
+ax_sprite sKinglerGfx34, 0x80
+ax_sprite_terminator
+sKinglerGfx35:
+.incbin "baserom.gba", 0x93F4B4, 0x80
+sKinglerSprites35:
+ax_sprite sKinglerGfx35, 0x80
+ax_sprite_terminator
+sKinglerGfx36:
+.incbin "baserom.gba", 0x93F544, 0x80
+sKinglerSprites36:
+ax_sprite sKinglerGfx36, 0x80
+ax_sprite_terminator
+sKinglerGfx37:
+.incbin "baserom.gba", 0x93F5D4, 0xC0
+sKinglerGfx37_1:
+.incbin "baserom.gba", 0x93F694, 0x20
+sKinglerSprites37:
+ax_sprite sKinglerGfx37, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx37_1, 0x20
+ax_sprite_terminator
+sKinglerGfx38:
+.incbin "baserom.gba", 0x93F6D4, 0x80
+sKinglerSprites38:
+ax_sprite sKinglerGfx38, 0x80
+ax_sprite_terminator
+sKinglerGfx39:
+.incbin "baserom.gba", 0x93F764, 0x100
+sKinglerSprites39:
+ax_sprite sKinglerGfx39, 0x100
+ax_sprite_terminator
+sKinglerGfx40:
+.incbin "baserom.gba", 0x93F874, 0x60
+sKinglerSprites40:
+ax_sprite sKinglerGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKinglerGfx41:
+.incbin "baserom.gba", 0x93F8EC, 0x80
+sKinglerSprites41:
+ax_sprite sKinglerGfx41, 0x80
+ax_sprite_terminator
+sKinglerGfx42:
+.incbin "baserom.gba", 0x93F97C, 0x80
+sKinglerSprites42:
+ax_sprite sKinglerGfx42, 0x80
+ax_sprite_terminator
+sKinglerGfx43:
+.incbin "baserom.gba", 0x93FA0C, 0x40
+sKinglerSprites43:
+ax_sprite sKinglerGfx43, 0x40
+ax_sprite_terminator
+sKinglerGfx44:
+.incbin "baserom.gba", 0x93FA5C, 0x100
+sKinglerSprites44:
+ax_sprite sKinglerGfx44, 0x100
+ax_sprite_terminator
+sKinglerGfx45:
+.incbin "baserom.gba", 0x93FB6C, 0x100
+sKinglerSprites45:
+ax_sprite sKinglerGfx45, 0x100
+ax_sprite_terminator
+sKinglerGfx46:
+.incbin "baserom.gba", 0x93FC7C, 0x100
+sKinglerSprites46:
+ax_sprite sKinglerGfx46, 0x100
+ax_sprite_terminator
+sKinglerGfx47:
+.incbin "baserom.gba", 0x93FD8C, 0x20
+sKinglerSprites47:
+ax_sprite sKinglerGfx47, 0x20
+ax_sprite_terminator
+sKinglerGfx48:
+.incbin "baserom.gba", 0x93FDBC, 0x40
+sKinglerSprites48:
+ax_sprite sKinglerGfx48, 0x40
+ax_sprite_terminator
+sKinglerGfx49:
+.incbin "baserom.gba", 0x93FE0C, 0x100
+sKinglerSprites49:
+ax_sprite sKinglerGfx49, 0x100
+ax_sprite_terminator
+sKinglerGfx50:
+.incbin "baserom.gba", 0x93FF1C, 0xC0
+sKinglerGfx50_1:
+.incbin "baserom.gba", 0x93FFDC, 0x20
+sKinglerSprites50:
+ax_sprite sKinglerGfx50, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx50_1, 0x20
+ax_sprite_terminator
+sKinglerGfx51:
+.incbin "baserom.gba", 0x94001C, 0x80
+sKinglerSprites51:
+ax_sprite sKinglerGfx51, 0x80
+ax_sprite_terminator
+sKinglerGfx52:
+.incbin "baserom.gba", 0x9400AC, 0x80
+sKinglerSprites52:
+ax_sprite sKinglerGfx52, 0x80
+ax_sprite_terminator
+sKinglerGfx53:
+.incbin "baserom.gba", 0x94013C, 0x80
+sKinglerSprites53:
+ax_sprite sKinglerGfx53, 0x80
+ax_sprite_terminator
+sKinglerGfx54:
+.incbin "baserom.gba", 0x9401CC, 0xE0
+sKinglerSprites54:
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx54, 0xe0
+ax_sprite_terminator
+sKinglerGfx55:
+.incbin "baserom.gba", 0x9402C4, 0x80
+sKinglerSprites55:
+ax_sprite sKinglerGfx55, 0x80
+ax_sprite_terminator
+sKinglerGfx56:
+.incbin "baserom.gba", 0x940354, 0x80
+sKinglerSprites56:
+ax_sprite sKinglerGfx56, 0x80
+ax_sprite_terminator
+sKinglerGfx57:
+.incbin "baserom.gba", 0x9403E4, 0x100
+sKinglerSprites57:
+ax_sprite sKinglerGfx57, 0x100
+ax_sprite_terminator
+sKinglerGfx58:
+.incbin "baserom.gba", 0x9404F4, 0x60
+sKinglerSprites58:
+ax_sprite sKinglerGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKinglerGfx59:
+.incbin "baserom.gba", 0x94056C, 0x60
+sKinglerSprites59:
+ax_sprite sKinglerGfx59, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKinglerGfx60:
+.incbin "baserom.gba", 0x9405E4, 0x100
+sKinglerSprites60:
+ax_sprite sKinglerGfx60, 0x100
+ax_sprite_terminator
+sKinglerGfx61:
+.incbin "baserom.gba", 0x9406F4, 0x60
+sKinglerSprites61:
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx61, 0x60
+ax_sprite_terminator
+sKinglerGfx62:
+.incbin "baserom.gba", 0x94076C, 0x100
+sKinglerSprites62:
+ax_sprite sKinglerGfx62, 0x100
+ax_sprite_terminator
+sKinglerGfx63:
+.incbin "baserom.gba", 0x94087C, 0x60
+sKinglerSprites63:
+ax_sprite sKinglerGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKinglerGfx64:
+.incbin "baserom.gba", 0x9408F4, 0x80
+sKinglerSprites64:
+ax_sprite sKinglerGfx64, 0x80
+ax_sprite_terminator
+sKinglerGfx65:
+.incbin "baserom.gba", 0x940984, 0x60
+sKinglerGfx65_1:
+.incbin "baserom.gba", 0x9409E4, 0x80
+sKinglerSprites65:
+ax_sprite sKinglerGfx65, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx65_1, 0x80
+ax_sprite_terminator
+sKinglerGfx66:
+.incbin "baserom.gba", 0x940A84, 0x80
+sKinglerSprites66:
+ax_sprite sKinglerGfx66, 0x80
+ax_sprite_terminator
+sKinglerGfx67:
+.incbin "baserom.gba", 0x940B14, 0x100
+sKinglerSprites67:
+ax_sprite sKinglerGfx67, 0x100
+ax_sprite_terminator
+sKinglerGfx68:
+.incbin "baserom.gba", 0x940C24, 0x100
+sKinglerSprites68:
+ax_sprite sKinglerGfx68, 0x100
+ax_sprite_terminator
+sKinglerGfx69:
+.incbin "baserom.gba", 0x940D34, 0x40
+sKinglerSprites69:
+ax_sprite sKinglerGfx69, 0x40
+ax_sprite_terminator
+sKinglerGfx70:
+.incbin "baserom.gba", 0x940D84, 0xC0
+sKinglerGfx70_1:
+.incbin "baserom.gba", 0x940E44, 0x20
+sKinglerSprites70:
+ax_sprite sKinglerGfx70, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx70_1, 0x20
+ax_sprite_terminator
+sKinglerGfx71:
+.incbin "baserom.gba", 0x940E84, 0x80
+sKinglerSprites71:
+ax_sprite sKinglerGfx71, 0x80
+ax_sprite_terminator
+sKinglerGfx72:
+.incbin "baserom.gba", 0x940F14, 0x80
+sKinglerSprites72:
+ax_sprite sKinglerGfx72, 0x80
+ax_sprite_terminator
+sKinglerGfx73:
+.incbin "baserom.gba", 0x940FA4, 0x40
+sKinglerSprites73:
+ax_sprite sKinglerGfx73, 0x40
+ax_sprite_terminator
+sKinglerGfx74:
+.incbin "baserom.gba", 0x940FF4, 0x20
+sKinglerSprites74:
+ax_sprite sKinglerGfx74, 0x20
+ax_sprite_terminator
+sKinglerGfx75:
+.incbin "baserom.gba", 0x941024, 0x40
+sKinglerSprites75:
+ax_sprite sKinglerGfx75, 0x40
+ax_sprite_terminator
+sKinglerGfx76:
+.incbin "baserom.gba", 0x941074, 0x40
+sKinglerGfx76_1:
+.incbin "baserom.gba", 0x9410B4, 0x100
+sKinglerSprites76:
+ax_sprite 0, 0xa0
+ax_sprite sKinglerGfx76, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx76_1, 0x100
+ax_sprite_terminator
+sKinglerGfx77:
+.incbin "baserom.gba", 0x9411DC, 0x60
+sKinglerGfx77_1:
+.incbin "baserom.gba", 0x94123C, 0x100
+sKinglerSprites77:
+ax_sprite 0, 0x80
+ax_sprite sKinglerGfx77, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx77_1, 0x100
+ax_sprite_terminator
+sKinglerGfx78:
+.incbin "baserom.gba", 0x941364, 0x40
+sKinglerGfx78_1:
+.incbin "baserom.gba", 0x9413A4, 0x100
+sKinglerSprites78:
+ax_sprite 0, 0x80
+ax_sprite sKinglerGfx78, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx78_1, 0x100
+ax_sprite_terminator
+sKinglerGfx79:
+.incbin "baserom.gba", 0x9414CC, 0x40
+sKinglerGfx79_1:
+.incbin "baserom.gba", 0x94150C, 0xE0
+sKinglerGfx79_2:
+.incbin "baserom.gba", 0x9415EC, 0x60
+sKinglerSprites79:
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx79, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx79_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx79_2, 0x60
+ax_sprite_terminator
+sKinglerGfx80:
+.incbin "baserom.gba", 0x941684, 0x20
+sKinglerGfx80_1:
+.incbin "baserom.gba", 0x9416A4, 0x180
+sKinglerSprites80:
+ax_sprite sKinglerGfx80, 0x20
+ax_sprite 0, 0x60
+ax_sprite sKinglerGfx80_1, 0x180
+ax_sprite_terminator
+sKinglerGfx81:
+.incbin "baserom.gba", 0x941844, 0x20
+sKinglerGfx81_1:
+.incbin "baserom.gba", 0x941864, 0x100
+sKinglerGfx81_2:
+.incbin "baserom.gba", 0x941964, 0x40
+sKinglerSprites81:
+ax_sprite 0, 0x40
+ax_sprite sKinglerGfx81, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx81_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx81_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKinglerGfx82:
+.incbin "baserom.gba", 0x9419E4, 0x180
+sKinglerSprites82:
+ax_sprite 0, 0x80
+ax_sprite sKinglerGfx82, 0x180
+ax_sprite_terminator
+sKinglerGfx83:
+.incbin "baserom.gba", 0x941B7C, 0x100
+sKinglerGfx83_1:
+.incbin "baserom.gba", 0x941C7C, 0x60
+sKinglerSprites83:
+ax_sprite 0, 0x80
+ax_sprite sKinglerGfx83, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKinglerGfx83_1, 0x60
+ax_sprite_terminator
+sKinglerGfx84:
+.incbin "baserom.gba", 0x941D04, 0x200
+sKinglerSprites84:
+ax_sprite sKinglerGfx84, 0x200
+ax_sprite_terminator
+sKinglerGfx85:
+.incbin "baserom.gba", 0x941F14, 0x200
+sKinglerSprites85:
+ax_sprite sKinglerGfx85, 0x200
+ax_sprite_terminator
+sKinglerGfx86:
+.incbin "baserom.gba", 0x942124, 0x200
+sKinglerSprites86:
+ax_sprite sKinglerGfx86, 0x200
+ax_sprite_terminator
+sKinglerGfx87:
+.incbin "baserom.gba", 0x942334, 0x200
+sKinglerSprites87:
+ax_sprite sKinglerGfx87, 0x200
+ax_sprite_terminator
+sKinglerGfx88:
+.incbin "baserom.gba", 0x942544, 0x200
+sKinglerSprites88:
+ax_sprite sKinglerGfx88, 0x200
+ax_sprite_terminator
+sKinglerGfx89:
+.incbin "baserom.gba", 0x942754, 0x200
+sKinglerSprites89:
+ax_sprite sKinglerGfx89, 0x200
+ax_sprite_terminator
+sKinglerGfx90:
+.incbin "baserom.gba", 0x942964, 0x200
+sKinglerSprites90:
+ax_sprite sKinglerGfx90, 0x200
+ax_sprite_terminator
+sKinglerGfx91:
+.incbin "baserom.gba", 0x942B74, 0x200
+sKinglerSprites91:
+ax_sprite sKinglerGfx91, 0x200
+ax_sprite_terminator
+sKinglerGfx92:
+.incbin "baserom.gba", 0x942D84, 0x200
+sKinglerSprites92:
+ax_sprite sKinglerGfx92, 0x200
+ax_sprite_terminator
+sKinglerGfx93:
+.incbin "baserom.gba", 0x942F94, 0x200
+sKinglerSprites93:
+ax_sprite sKinglerGfx93, 0x200
+ax_sprite_terminator
+sAxPosesKingler:
+.4byte sKinglerPose1
+.4byte sKinglerPose2
+.4byte sKinglerPose3
+.4byte sKinglerPose4
+.4byte sKinglerPose5
+.4byte sKinglerPose6
+.4byte sKinglerPose7
+.4byte sKinglerPose8
+.4byte sKinglerPose9
+.4byte sKinglerPose10
+.4byte sKinglerPose11
+.4byte sKinglerPose12
+.4byte sKinglerPose13
+.4byte sKinglerPose14
+.4byte sKinglerPose15
+.4byte sKinglerPose16
+.4byte sKinglerPose17
+.4byte sKinglerPose18
+.4byte sKinglerPose19
+.4byte sKinglerPose20
+.4byte sKinglerPose21
+.4byte sKinglerPose22
+.4byte sKinglerPose23
+.4byte sKinglerPose24
+.4byte sKinglerPose25
+.4byte sKinglerPose26
+.4byte sKinglerPose27
+.4byte sKinglerPose28
+.4byte sKinglerPose29
+.4byte sKinglerPose30
+.4byte sKinglerPose31
+.4byte sKinglerPose32
+.4byte sKinglerPose33
+.4byte sKinglerPose34
+.4byte sKinglerPose35
+.4byte sKinglerPose36
+.4byte sKinglerPose37
+.4byte sKinglerPose38
+.4byte sKinglerPose39
+.4byte sKinglerPose40
+.4byte sKinglerPose41
+.4byte sKinglerPose42
+.4byte sKinglerPose43
+.4byte sKinglerPose44
+.4byte sKinglerPose45
+.4byte sKinglerPose46
+.4byte sKinglerPose47
+.4byte sKinglerPose48
+.4byte sKinglerPose49
+.4byte sKinglerPose50
+.4byte sKinglerPose51
+.4byte sKinglerPose52
+.4byte sKinglerPose53
+.4byte sKinglerPose54
+.4byte sKinglerPose55
+.4byte sKinglerPose56
+.4byte sKinglerPose57
+.4byte sKinglerPose58
+.4byte sKinglerPose59
+.4byte sKinglerPose60
+.4byte sKinglerPose61
+.4byte sKinglerPose62
+.4byte sKinglerPose63
+.4byte sKinglerPose64
+.4byte sKinglerPose65
+.4byte sKinglerPose66
+.4byte sKinglerPose67
+.4byte sKinglerPose68
+.4byte sKinglerPose69
+.4byte sKinglerPose70
+.4byte sKinglerPose71
+.4byte sKinglerPose72
+.4byte sKinglerPose73
+.4byte sKinglerPose74
+.4byte sKinglerPose75
+.4byte sKinglerPose76
+.4byte sKinglerPose77
+.4byte sKinglerPose78
+.4byte sKinglerPose79
+.4byte sKinglerPose80
+.4byte sKinglerPose81
+.4byte sKinglerPose82
+.4byte sKinglerPose83
+.4byte sKinglerPose84
+.4byte sKinglerPose85
+.4byte sKinglerPose86
+.4byte sKinglerPose87
+.4byte sKinglerPose88
+.4byte sKinglerPose89
+.4byte sKinglerPose90
+.4byte sKinglerPose91
+.4byte sKinglerPose92
+.4byte sKinglerPose93
+.4byte sKinglerPose94
+.4byte sKinglerPose95
+.4byte sKinglerPose96
+.4byte sKinglerPose97
+.4byte sKinglerPose98
+.4byte sKinglerPose99
+.4byte sKinglerPose100
+.4byte sKinglerPose101
+.4byte sKinglerPose102
+.4byte sKinglerPose103
+.4byte sKinglerPose104
+.4byte sKinglerPose105
+.4byte sKinglerPose106
+.4byte sKinglerPose107
+.4byte sKinglerPose108
+.4byte sKinglerPose109
+.4byte sKinglerPose110
+.4byte sKinglerPose111
+.4byte sKinglerPose112
+.4byte sKinglerPose113
+.4byte sKinglerPose114
+.4byte sKinglerPose115
+.4byte sKinglerPose116
+.4byte sKinglerPose117
+.4byte sKinglerPose118
+.4byte sKinglerPose119
+.4byte sKinglerPose120
+.4byte sKinglerPose121
+.4byte sKinglerPose122
+.4byte sKinglerPose123
+.4byte sKinglerPose124
+.4byte sKinglerPose125
+.4byte sKinglerPose126
+.4byte sKinglerPose127
+.4byte sKinglerPose128
+.4byte sKinglerPose129
+.4byte sKinglerPose130
+.4byte sKinglerPose131
+.4byte sKinglerPose132
+.4byte sKinglerPose133
+.4byte sKinglerPose134
+.4byte sKinglerPose135
+.4byte sKinglerPose136
+.4byte sKinglerPose137
+.4byte sKinglerPose138
+.4byte sKinglerPose139
+.4byte sKinglerPose140
+.4byte sKinglerPose141
+.4byte sKinglerPose142
+.4byte sKinglerPose143
+.4byte sKinglerPose144
+.4byte sKinglerPose145
+.4byte sKinglerPose146
+.4byte sKinglerPose147
+.4byte sKinglerPose148
+.4byte sKinglerPose149
+.4byte sKinglerPose150
+.4byte sKinglerPose151
+.4byte sKinglerPose152
+.4byte sKinglerPose153
+.4byte sKinglerPose154
+.4byte sKinglerPose155
+.4byte sKinglerPose156
+.4byte sKinglerPose157
+.4byte sKinglerPose158
+.4byte sKinglerPose159
+.4byte sKinglerPose160
+.4byte sKinglerPose161
+.4byte sKinglerPose162
+.4byte sKinglerPose163
+.4byte sKinglerPose164
+.4byte sKinglerPose165
+.4byte sKinglerPose166
+.4byte sKinglerPose167
+.4byte sKinglerPose168
+.4byte sKinglerPose169
+.4byte sKinglerPose170
+.4byte sKinglerPose171
+.4byte sKinglerPose172
+.4byte sKinglerPose173
+.4byte sKinglerPose174
+.4byte sKinglerPose175
+.4byte sKinglerPose176
+.4byte sKinglerPose177
+.4byte sKinglerPose178
+.4byte sKinglerPose179
+.4byte sKinglerPose180
+.4byte sKinglerPose181
+.4byte sKinglerPose182
+.4byte sKinglerPose183
+.4byte sKinglerPose184
+.4byte sKinglerPose185
+.4byte sKinglerPose186
+.4byte sKinglerPose187
+.4byte sKinglerPose188
+.4byte sKinglerPose189
+.4byte sKinglerPose190
+.4byte sKinglerPose191
+.4byte sKinglerPose192
+.4byte sKinglerPose193
+.4byte sKinglerPose194
+.4byte sKinglerPose195
+.4byte sKinglerPose196
+.4byte sKinglerPose197
+.4byte sKinglerPose198
+.4byte sKinglerPose199
+.4byte sKinglerPose200
+.4byte sKinglerPose201
+.4byte sKinglerPose202
+.4byte sKinglerPose203
+.4byte sKinglerPose204
+.4byte sKinglerPose205
+.4byte sKinglerPose206
+.4byte sKinglerPose207
+.4byte sKinglerPose208
+.4byte sKinglerPose209
+.4byte sKinglerPose210
+.4byte sKinglerPose211
+.4byte sKinglerPose212
+.4byte sKinglerPose213
+.4byte sKinglerPose214
+.4byte sKinglerPose215
+.4byte sKinglerPose216
+.4byte sKinglerPose217
+.4byte sKinglerPose218
+.4byte sKinglerPose219
+.4byte sKinglerPose220
+.4byte sKinglerPose221
+.4byte sKinglerPose222
+.4byte sKinglerPose223
+.4byte sKinglerPose224
+.4byte sKinglerPose225
+.4byte sKinglerPose226
+.4byte sKinglerPose227
+.4byte sKinglerPose228
+.4byte sKinglerPose229
+.4byte sKinglerPose230
+.4byte sKinglerPose231
+.4byte sKinglerPose232
+.4byte sKinglerPose233
+.4byte sKinglerPose234
+.4byte sKinglerPose235
+.4byte sKinglerPose236
+.4byte sKinglerPose237
+.4byte sKinglerPose238
+.4byte sKinglerPose239
+.4byte sKinglerPose240
+.4byte sKinglerPose241
+.4byte sKinglerPose242
+.4byte sKinglerPose243
+.4byte sKinglerPose244
+.4byte sKinglerPose245
+.4byte sKinglerPose246
+.4byte sKinglerPose247
+.4byte sKinglerPose248
+.4byte sKinglerPose249
+.4byte sKinglerPose250
+.4byte sKinglerPose251
+.4byte sKinglerPose252
+.4byte sKinglerPose253
+.4byte sKinglerPose254
+.4byte sKinglerPose255
+.4byte sKinglerPose256
+.4byte sKinglerPose257
+.4byte sKinglerPose258
+.4byte sKinglerPose259
+.4byte sKinglerPose260
+.4byte sKinglerPose261
+.4byte sKinglerPose262
+.4byte sKinglerPose263
+.4byte sKinglerPose264
+.4byte sKinglerPose265
+.4byte sKinglerPose266
+.4byte sKinglerPose267
+.4byte sKinglerPose268
+.4byte sKinglerPose269
+.4byte sKinglerPose270
+.4byte sKinglerPose271
+.4byte sKinglerPose272
+.4byte sKinglerPose273
+.4byte sKinglerPose274
+.4byte sKinglerPose275
+.4byte sKinglerPose276
+.4byte sKinglerPose277
+.4byte sKinglerPose278
+.4byte sKinglerPose279
+.4byte sKinglerPose280
+.4byte sKinglerPose281
+.4byte sKinglerPose282
+.4byte sKinglerPose283
+.4byte sKinglerPose284
+.4byte sKinglerPose285
+.4byte sKinglerPose286
+.4byte sKinglerPose287
+.4byte sKinglerPose288
+.4byte sKinglerPose289
+.4byte sKinglerPose290
+.4byte sKinglerPose291
+.4byte sKinglerPose292
+.4byte sKinglerPose293
+.4byte sKinglerPose294
+.4byte sKinglerPose295
+.4byte sKinglerPose296
+.4byte sKinglerPose297
+.4byte sKinglerPose298
+.4byte sKinglerPose299
+.4byte sKinglerPose300
+.4byte sKinglerPose301
+.4byte sKinglerPose302
+.4byte sKinglerPose303
+.4byte sKinglerPose304
+.4byte sKinglerPose305
+.4byte sKinglerPose306
+.4byte sKinglerPose307
+.4byte sKinglerPose308
+.4byte sKinglerPose309
+.4byte sKinglerPose310
+.4byte sKinglerPose311
+.4byte sKinglerPose312
+.4byte sKinglerPose313
+.4byte sKinglerPose314
+.4byte sKinglerPose315
+.4byte sKinglerPose316
+.4byte sKinglerPose317
+.4byte sKinglerPose318
+.4byte sKinglerPose319
+.4byte sKinglerPose320
+.4byte sKinglerPose321
+.4byte sKinglerPose322
+.4byte sKinglerPose323
+.4byte sKinglerPose324
+.4byte sKinglerPose325
+.4byte sKinglerPose326
+.4byte sKinglerPose327
+.4byte sKinglerPose328
+.4byte sKinglerPose329
+.4byte sKinglerPose330
+.4byte sKinglerPose331
+.4byte sKinglerPose332
+.4byte sKinglerPose333
+.4byte sKinglerPose334
+.4byte sKinglerPose335
+.4byte sKinglerPose336
+.4byte sKinglerPose337
+.4byte sKinglerPose338
+sAxPositionsKingler:
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    3,   -3, 	   7,   -2, 	   7,  -15, 	  -2,   -4
+.2byte    3,   -3, 	   6,   -2, 	   6,  -15, 	  -2,   -4
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    4,   -6, 	  12,   -8, 	  -1,  -16, 	  -2,   -5
+.2byte    4,   -6, 	  11,   -8, 	  -2,  -17, 	  -2,   -5
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte   -1,   -9, 	  10,  -10, 	  -8,  -15, 	  -1,   -4
+.2byte   -1,   -9, 	   9,  -10, 	  -8,  -15, 	  -1,   -4
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -3,   -6, 	   1,  -13, 	 -11,  -13, 	   1,   -5
+.2byte   -3,   -6, 	   1,  -13, 	 -11,  -11, 	   0,   -5
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -5, 	  -6,  -12, 	  -9,   -8, 	   2,   -4
+.2byte   -4,   -5, 	  -6,  -11, 	 -10,   -7, 	   1,   -4
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -2,    0, 	 -10,  -11, 	   3,  -10, 	  -1,   -2
+.2byte   -2,    0, 	  -9,  -12, 	   3,   -9, 	  -1,   -2
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte    0,    0, 	 -10,  -10, 	  10,  -12, 	   0,   -2
+.2byte    0,    0, 	  -9,  -10, 	  11,  -12, 	   0,   -2
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte    2,   -1, 	  -4,   -5, 	  10,  -14, 	   0,   -3
+.2byte    2,   -2, 	  -5,   -5, 	  11,  -14, 	   0,   -4
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    3,   -3, 	   7,   -2, 	   7,  -15, 	  -2,   -4
+.2byte    3,   -3, 	   6,   -2, 	   6,  -15, 	  -2,   -4
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    4,   -6, 	  12,   -8, 	  -1,  -16, 	  -2,   -5
+.2byte    4,   -6, 	  11,   -8, 	  -2,  -17, 	  -2,   -5
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte   -1,   -9, 	  10,  -10, 	  -8,  -15, 	  -1,   -4
+.2byte   -1,   -9, 	   9,  -10, 	  -8,  -15, 	  -1,   -4
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -3,   -6, 	   1,  -13, 	 -11,  -13, 	   1,   -5
+.2byte   -3,   -6, 	   1,  -13, 	 -11,  -11, 	   0,   -5
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -5, 	  -6,  -12, 	  -9,   -8, 	   2,   -4
+.2byte   -4,   -5, 	  -6,  -11, 	 -10,   -7, 	   1,   -4
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -2,    0, 	 -10,  -11, 	   3,  -10, 	  -1,   -2
+.2byte   -2,    0, 	  -9,  -12, 	   3,   -9, 	  -1,   -2
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte    0,    0, 	 -10,  -10, 	  10,  -12, 	   0,   -2
+.2byte    0,    0, 	  -9,  -10, 	  11,  -12, 	   0,   -2
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte    2,   -1, 	  -4,   -5, 	  10,  -14, 	   0,   -3
+.2byte    2,   -2, 	  -5,   -5, 	  11,  -14, 	   0,   -4
+.2byte    0,   -5, 	  -7,  -15, 	   6,  -17, 	   0,   -7
+.2byte   -3,   -6, 	  -8,  -17, 	  -1,  -16, 	   0,   -8
+.2byte   -3,  -13, 	  -4,  -19, 	  -7,  -17, 	   1,   -8
+.2byte   -4,  -12, 	   0,  -21, 	  -9,  -20, 	   1,   -9
+.2byte    0,  -13, 	   7,  -19, 	  -6,  -22, 	   0,   -9
+.2byte    2,  -11, 	   9,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	   6,  -10, 	   5,  -23, 	  -1,   -9
+.2byte    1,   -7, 	  -4,  -15, 	   7,  -22, 	  -1,  -10
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte    0,   -7, 	  -8,  -16, 	   6,  -20, 	   0,   -8
+.2byte   -1,   -1, 	  -9,    1, 	   4,   11, 	  -1,   -3
+.2byte   -1,   -1, 	  -9,    1, 	   4,   11, 	  -1,   -3
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -1,   -7, 	  -9,  -14, 	   0,  -22, 	  -2,   -9
+.2byte    2,    0, 	  -3,    4, 	  12,    7, 	   1,   -1
+.2byte    2,    0, 	  -3,    4, 	  12,    7, 	   1,   -1
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    0,   -9, 	  -6,  -13, 	  -8,  -20, 	  -4,   -8
+.2byte    7,   -4, 	   6,    2, 	  19,   -2, 	   3,   -4
+.2byte    7,   -4, 	   6,    2, 	  19,   -2, 	   3,   -4
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    1,  -12, 	   3,  -16, 	  -8,  -22, 	  -3,   -9
+.2byte    6,   -8, 	  12,   -7, 	  11,  -17, 	   2,   -7
+.2byte    6,   -8, 	  12,   -7, 	  11,  -17, 	   2,   -7
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte   -1,  -13, 	   8,  -11, 	  -6,  -15, 	   0,   -8
+.2byte    3,  -11, 	   9,  -10, 	  -1,  -23, 	   1,   -8
+.2byte    3,  -11, 	   9,  -10, 	  -1,  -23, 	   1,   -8
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -13, 	   5,  -23, 	  -3,  -23, 	   3,   -9
+.2byte    0,   -9, 	   3,  -11, 	 -10,  -16, 	   1,   -5
+.2byte    0,   -9, 	   3,  -11, 	 -10,  -16, 	   1,   -5
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte    0,   -8, 	   3,  -19, 	   9,  -17, 	   4,   -7
+.2byte   -6,   -4, 	  -7,   -3, 	 -19,    2, 	   0,   -4
+.2byte   -6,   -4, 	  -7,   -3, 	 -19,    2, 	   0,   -4
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -1,   -7, 	  -3,  -19, 	   8,  -20, 	   1,   -9
+.2byte   -3,   -3, 	 -10,   -3, 	  -5,    7, 	   0,   -4
+.2byte   -3,   -3, 	 -10,   -3, 	  -5,    7, 	   0,   -4
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte    0,   -7, 	  -8,  -16, 	   6,  -20, 	   0,   -8
+.2byte    0,    0, 	  -9,    3, 	  13,    5, 	   0,   -2
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -1,   -7, 	  -9,  -14, 	   0,  -22, 	  -2,   -9
+.2byte    2,   -1, 	  -3,    3, 	  16,   -3, 	   0,   -2
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    0,   -9, 	  -6,  -13, 	  -8,  -20, 	  -4,   -8
+.2byte    5,   -3, 	  10,    3, 	  16,   -7, 	   0,   -4
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    1,  -12, 	   3,  -16, 	  -8,  -22, 	  -3,   -9
+.2byte    3,   -7, 	  12,   -6, 	   1,  -16, 	  -1,   -5
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte   -1,  -13, 	   8,  -11, 	  -6,  -15, 	   0,   -8
+.2byte    0,  -10, 	   9,  -12, 	 -12,  -15, 	   0,   -6
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -13, 	   5,  -23, 	  -3,  -23, 	   3,   -9
+.2byte   -5,   -8, 	  -1,  -13, 	 -15,   -8, 	   0,   -5
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte    0,   -8, 	   3,  -19, 	   9,  -17, 	   4,   -7
+.2byte   -6,   -4, 	 -13,   -6, 	 -16,    4, 	   0,   -4
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -1,   -7, 	  -3,  -19, 	   8,  -20, 	   1,   -9
+.2byte   -3,   -1, 	 -12,   -1, 	   2,    9, 	   0,   -2
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -2,   -2, 	  -9,   -5, 	  -2,    0, 	   1,   -3
+.2byte   -2,   -1, 	  -9,   -3, 	  -3,    1, 	   0,   -2
+.2byte    0,   -3, 	  -7,  -16, 	   7,  -19, 	   0,   -5
+.2byte    2,   -4, 	 -11,  -11, 	  -2,  -19, 	  -2,   -5
+.2byte    3,   -5, 	  -7,   -3, 	  -3,  -19, 	  -1,   -5
+.2byte    2,   -6, 	   4,   -7, 	  -8,  -16, 	  -1,   -3
+.2byte    0,   -8, 	   9,   -9, 	  -8,  -11, 	   0,   -3
+.2byte   -1,   -6, 	   5,  -14, 	  -5,  -11, 	   1,   -3
+.2byte   -4,   -5, 	   4,  -14, 	   8,   -9, 	   1,   -4
+.2byte   -2,   -3, 	   0,  -19, 	  11,  -14, 	   1,   -5
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte    0,   -7, 	  -8,  -16, 	   6,  -20, 	   0,   -8
+.2byte   -1,   -1, 	  -9,    1, 	   4,   11, 	  -1,   -3
+.2byte   -1,   -1, 	  -9,    1, 	   4,   11, 	  -1,   -3
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte   -1,   -7, 	  -9,  -14, 	   0,  -22, 	  -2,   -9
+.2byte    2,    0, 	  -3,    4, 	  12,    7, 	   1,   -1
+.2byte    2,    0, 	  -3,    4, 	  12,    7, 	   1,   -1
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    0,   -9, 	  -6,  -13, 	  -8,  -20, 	  -4,   -8
+.2byte    7,   -4, 	   6,    2, 	  19,   -2, 	   3,   -4
+.2byte    7,   -4, 	   6,    2, 	  19,   -2, 	   3,   -4
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    1,  -12, 	   3,  -16, 	  -8,  -22, 	  -3,   -9
+.2byte    6,   -8, 	  12,   -7, 	  11,  -17, 	   2,   -7
+.2byte    6,   -8, 	  12,   -7, 	  11,  -17, 	   2,   -7
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte   -1,  -13, 	   8,  -11, 	  -6,  -15, 	   0,   -8
+.2byte    3,  -11, 	   9,  -10, 	  -1,  -23, 	   1,   -8
+.2byte    3,  -11, 	   9,  -10, 	  -1,  -23, 	   1,   -8
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -13, 	   5,  -23, 	  -3,  -23, 	   3,   -9
+.2byte    0,   -9, 	   3,  -11, 	 -10,  -16, 	   1,   -5
+.2byte    0,   -9, 	   3,  -11, 	 -10,  -16, 	   1,   -5
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte    0,   -8, 	   3,  -19, 	   9,  -17, 	   4,   -7
+.2byte   -6,   -4, 	  -7,   -3, 	 -19,    2, 	   0,   -4
+.2byte   -6,   -4, 	  -7,   -3, 	 -19,    2, 	   0,   -4
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -1,   -7, 	  -3,  -19, 	   8,  -20, 	   1,   -9
+.2byte   -3,   -3, 	 -10,   -3, 	  -5,    7, 	   0,   -4
+.2byte   -3,   -3, 	 -10,   -3, 	  -5,    7, 	   0,   -4
+.2byte    0,   -1, 	  -9,    2, 	  13,    4, 	   0,   -3
+.2byte   -3,   -2, 	 -12,   -2, 	   2,    8, 	   0,   -3
+.2byte   -6,   -5, 	 -13,   -7, 	 -16,    3, 	   0,   -5
+.2byte   -5,   -8, 	  -1,  -13, 	 -15,   -8, 	   0,   -5
+.2byte    0,  -10, 	   9,  -12, 	 -12,  -15, 	   0,   -6
+.2byte    3,   -7, 	  12,   -6, 	   1,  -16, 	  -1,   -5
+.2byte    5,   -4, 	  10,    2, 	  16,   -8, 	   0,   -5
+.2byte    2,   -2, 	  -3,    2, 	  16,   -4, 	   0,   -3
+.2byte    0,   -7, 	  -8,  -16, 	   6,  -20, 	   0,   -8
+.2byte    0,   -7, 	  -8,  -14, 	   1,  -22, 	  -1,   -9
+.2byte    3,   -9, 	  -3,  -13, 	  -5,  -20, 	  -1,   -8
+.2byte    3,  -11, 	   5,  -15, 	  -6,  -21, 	  -1,   -8
+.2byte   -1,  -13, 	   8,  -11, 	  -6,  -15, 	   0,   -8
+.2byte   -3,  -12, 	   3,  -22, 	  -5,  -22, 	   1,   -8
+.2byte   -3,   -8, 	   0,  -19, 	   6,  -17, 	   1,   -7
+.2byte   -2,   -7, 	  -4,  -19, 	   7,  -20, 	   0,   -9
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte    0,   -7, 	  -8,  -16, 	   6,  -20, 	   0,   -8
+.2byte    0,    0, 	  -9,    3, 	  13,    5, 	   0,   -2
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+.2byte    1,   -7, 	  -7,  -14, 	   2,  -22, 	   0,   -9
+.2byte    2,   -1, 	  -3,    3, 	  16,   -3, 	   0,   -2
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    0,   -9, 	  -6,  -13, 	  -8,  -20, 	  -4,   -8
+.2byte    5,   -3, 	  10,    3, 	  16,   -7, 	   0,   -4
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    1,  -12, 	   3,  -16, 	  -8,  -22, 	  -3,   -9
+.2byte    3,   -7, 	  12,   -6, 	   1,  -16, 	  -1,   -5
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    0,  -10, 	   9,  -12, 	 -12,  -15, 	   0,   -6
+.2byte   -1,  -13, 	   8,  -11, 	  -6,  -15, 	   0,   -8
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -13, 	   5,  -23, 	  -3,  -23, 	   3,   -9
+.2byte   -5,   -8, 	  -1,  -13, 	 -15,   -8, 	   0,   -5
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte    0,   -8, 	   3,  -19, 	   9,  -17, 	   4,   -7
+.2byte   -6,   -4, 	 -13,   -6, 	 -16,    4, 	   0,   -4
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -3,   -7, 	  -5,  -19, 	   6,  -20, 	  -1,   -9
+.2byte   -3,   -1, 	 -12,   -1, 	   2,    9, 	   0,   -2
+.2byte    0,    0, 	  -9,    3, 	  13,    5, 	   0,   -2
+.2byte   -3,   -1, 	 -12,   -1, 	   2,    9, 	   0,   -2
+.2byte   -6,   -4, 	 -13,   -6, 	 -16,    4, 	   0,   -4
+.2byte   -5,   -8, 	  -1,  -13, 	 -15,   -8, 	   0,   -5
+.2byte    0,  -10, 	   9,  -12, 	 -12,  -15, 	   0,   -6
+.2byte    3,   -7, 	  12,   -6, 	   1,  -16, 	  -1,   -5
+.2byte    5,   -3, 	  10,    3, 	  16,   -7, 	   0,   -4
+.2byte    2,   -1, 	  -3,    3, 	  16,   -3, 	   0,   -2
+.2byte    0,   -1, 	  -9,  -12, 	  10,  -14, 	   0,   -3
+.2byte   -2,   -1, 	 -10,  -13, 	   2,  -11, 	  -1,   -3
+.2byte   -4,   -6, 	  -6,  -15, 	  -9,   -9, 	   1,   -5
+.2byte   -3,   -7, 	   0,  -15, 	 -12,  -13, 	   1,   -6
+.2byte   -1,  -10, 	  10,  -12, 	  -9,  -17, 	  -1,   -5
+.2byte    3,   -7, 	  12,  -10, 	   0,  -18, 	  -2,   -6
+.2byte    3,   -4, 	   7,   -4, 	   6,  -17, 	  -2,   -6
+.2byte    2,   -2, 	  -5,   -6, 	  10,  -16, 	   1,   -3
+sKinglerAnimTable1:
+.4byte sKinglerAnims_1_1
+.4byte sKinglerAnims_1_2
+.4byte sKinglerAnims_1_3
+.4byte sKinglerAnims_1_4
+.4byte sKinglerAnims_1_5
+.4byte sKinglerAnims_1_6
+.4byte sKinglerAnims_1_7
+.4byte sKinglerAnims_1_8
+sKinglerAnimTable2:
+.4byte sKinglerAnims_2_1
+.4byte sKinglerAnims_2_2
+.4byte sKinglerAnims_2_3
+.4byte sKinglerAnims_2_4
+.4byte sKinglerAnims_2_5
+.4byte sKinglerAnims_2_6
+.4byte sKinglerAnims_2_7
+.4byte sKinglerAnims_2_8
+sKinglerAnimTable3:
+.4byte sKinglerAnims_3_1
+.4byte sKinglerAnims_3_2
+.4byte sKinglerAnims_3_3
+.4byte sKinglerAnims_3_4
+.4byte sKinglerAnims_3_5
+.4byte sKinglerAnims_3_6
+.4byte sKinglerAnims_3_7
+.4byte sKinglerAnims_3_8
+sKinglerAnimTable4:
+.4byte sKinglerAnims_4_1
+.4byte sKinglerAnims_4_2
+.4byte sKinglerAnims_4_3
+.4byte sKinglerAnims_4_4
+.4byte sKinglerAnims_4_5
+.4byte sKinglerAnims_4_6
+.4byte sKinglerAnims_4_7
+.4byte sKinglerAnims_4_8
+sKinglerAnimTable5:
+.4byte sKinglerAnims_5_1
+.4byte sKinglerAnims_5_2
+.4byte sKinglerAnims_5_3
+.4byte sKinglerAnims_5_4
+.4byte sKinglerAnims_5_5
+.4byte sKinglerAnims_5_6
+.4byte sKinglerAnims_5_7
+.4byte sKinglerAnims_5_8
+sKinglerAnimTable6:
+.4byte sKinglerAnims_6_1
+.4byte sKinglerAnims_6_1
+.4byte sKinglerAnims_6_1
+.4byte sKinglerAnims_6_1
+.4byte sKinglerAnims_6_1
+.4byte sKinglerAnims_6_1
+.4byte sKinglerAnims_6_1
+.4byte sKinglerAnims_6_1
+sKinglerAnimTable7:
+.4byte sKinglerAnims_7_1
+.4byte sKinglerAnims_7_2
+.4byte sKinglerAnims_7_3
+.4byte sKinglerAnims_7_4
+.4byte sKinglerAnims_7_5
+.4byte sKinglerAnims_7_6
+.4byte sKinglerAnims_7_7
+.4byte sKinglerAnims_7_8
+sKinglerAnimTable8:
+.4byte sKinglerAnims_8_1
+.4byte sKinglerAnims_8_2
+.4byte sKinglerAnims_8_3
+.4byte sKinglerAnims_8_4
+.4byte sKinglerAnims_8_5
+.4byte sKinglerAnims_8_6
+.4byte sKinglerAnims_8_7
+.4byte sKinglerAnims_8_8
+sKinglerAnimTable9:
+.4byte sKinglerAnims_9_1
+.4byte sKinglerAnims_9_2
+.4byte sKinglerAnims_9_3
+.4byte sKinglerAnims_9_4
+.4byte sKinglerAnims_9_5
+.4byte sKinglerAnims_9_6
+.4byte sKinglerAnims_9_7
+.4byte sKinglerAnims_9_8
+sKinglerAnimTable10:
+.4byte sKinglerAnims_10_1
+.4byte sKinglerAnims_10_2
+.4byte sKinglerAnims_10_3
+.4byte sKinglerAnims_10_4
+.4byte sKinglerAnims_10_5
+.4byte sKinglerAnims_10_6
+.4byte sKinglerAnims_10_7
+.4byte sKinglerAnims_10_8
+sKinglerAnimTable11:
+.4byte sKinglerAnims_11_1
+.4byte sKinglerAnims_11_2
+.4byte sKinglerAnims_11_3
+.4byte sKinglerAnims_11_4
+.4byte sKinglerAnims_11_5
+.4byte sKinglerAnims_11_6
+.4byte sKinglerAnims_11_7
+.4byte sKinglerAnims_11_8
+sKinglerAnimTable12:
+.4byte sKinglerAnims_12_1
+.4byte sKinglerAnims_12_2
+.4byte sKinglerAnims_12_3
+.4byte sKinglerAnims_12_4
+.4byte sKinglerAnims_12_5
+.4byte sKinglerAnims_12_6
+.4byte sKinglerAnims_12_7
+.4byte sKinglerAnims_12_8
+sKinglerAnimTable13:
+.4byte sKinglerAnims_13_1
+.4byte sKinglerAnims_13_2
+.4byte sKinglerAnims_13_3
+.4byte sKinglerAnims_13_4
+.4byte sKinglerAnims_13_5
+.4byte sKinglerAnims_13_6
+.4byte sKinglerAnims_13_7
+.4byte sKinglerAnims_13_8
+sAxAnimationsKingler:
+.4byte sKinglerAnimTable1
+.4byte sKinglerAnimTable2
+.4byte sKinglerAnimTable3
+.4byte sKinglerAnimTable4
+.4byte sKinglerAnimTable5
+.4byte sKinglerAnimTable6
+.4byte sKinglerAnimTable7
+.4byte sKinglerAnimTable8
+.4byte sKinglerAnimTable9
+.4byte sKinglerAnimTable10
+.4byte sKinglerAnimTable11
+.4byte sKinglerAnimTable12
+.4byte sKinglerAnimTable13
+sAxSpritesKingler:
+.4byte sKinglerSprites1
+.4byte sKinglerSprites2
+.4byte sKinglerSprites3
+.4byte sKinglerSprites4
+.4byte sKinglerSprites5
+.4byte sKinglerSprites6
+.4byte sKinglerSprites7
+.4byte sKinglerSprites8
+.4byte sKinglerSprites9
+.4byte sKinglerSprites10
+.4byte sKinglerSprites11
+.4byte sKinglerSprites12
+.4byte sKinglerSprites13
+.4byte sKinglerSprites14
+.4byte sKinglerSprites15
+.4byte sKinglerSprites16
+.4byte sKinglerSprites17
+.4byte sKinglerSprites18
+.4byte sKinglerSprites19
+.4byte sKinglerSprites20
+.4byte sKinglerSprites21
+.4byte sKinglerSprites22
+.4byte sKinglerSprites23
+.4byte sKinglerSprites24
+.4byte sKinglerSprites25
+.4byte sKinglerSprites26
+.4byte sKinglerSprites27
+.4byte sKinglerSprites28
+.4byte sKinglerSprites29
+.4byte sKinglerSprites30
+.4byte sKinglerSprites31
+.4byte sKinglerSprites32
+.4byte sKinglerSprites33
+.4byte sKinglerSprites34
+.4byte sKinglerSprites35
+.4byte sKinglerSprites36
+.4byte sKinglerSprites37
+.4byte sKinglerSprites38
+.4byte sKinglerSprites39
+.4byte sKinglerSprites40
+.4byte sKinglerSprites41
+.4byte sKinglerSprites42
+.4byte sKinglerSprites43
+.4byte sKinglerSprites44
+.4byte sKinglerSprites45
+.4byte sKinglerSprites46
+.4byte sKinglerSprites47
+.4byte sKinglerSprites48
+.4byte sKinglerSprites49
+.4byte sKinglerSprites50
+.4byte sKinglerSprites51
+.4byte sKinglerSprites52
+.4byte sKinglerSprites53
+.4byte sKinglerSprites54
+.4byte sKinglerSprites55
+.4byte sKinglerSprites56
+.4byte sKinglerSprites57
+.4byte sKinglerSprites58
+.4byte sKinglerSprites59
+.4byte sKinglerSprites60
+.4byte sKinglerSprites61
+.4byte sKinglerSprites62
+.4byte sKinglerSprites63
+.4byte sKinglerSprites64
+.4byte sKinglerSprites65
+.4byte sKinglerSprites66
+.4byte sKinglerSprites67
+.4byte sKinglerSprites68
+.4byte sKinglerSprites69
+.4byte sKinglerSprites70
+.4byte sKinglerSprites71
+.4byte sKinglerSprites72
+.4byte sKinglerSprites73
+.4byte sKinglerSprites74
+.4byte sKinglerSprites75
+.4byte sKinglerSprites76
+.4byte sKinglerSprites77
+.4byte sKinglerSprites78
+.4byte sKinglerSprites79
+.4byte sKinglerSprites80
+.4byte sKinglerSprites81
+.4byte sKinglerSprites82
+.4byte sKinglerSprites83
+.4byte sKinglerSprites84
+.4byte sKinglerSprites85
+.4byte sKinglerSprites86
+.4byte sKinglerSprites87
+.4byte sKinglerSprites88
+.4byte sKinglerSprites89
+.4byte sKinglerSprites90
+.4byte sKinglerSprites91
+.4byte sKinglerSprites92
+.4byte sKinglerSprites93
+sAxMainKingler:
+ax_main sAxPosesKingler, sAxAnimationsKingler, 13, sAxSpritesKingler, sAxPositionsKingler

--- a/data/ax/kirlia.inc
+++ b/data/ax/kirlia.inc
@@ -1,0 +1,2546 @@
+.global gAxKirlia
+gAxKirlia:
+ax_siro sAxMainKirlia
+sKirliaPose1:
+ax_pose 0, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose2:
+ax_pose 1, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose3:
+ax_pose 2, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose4:
+ax_pose 3, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose5:
+ax_pose 4, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose6:
+ax_pose 3, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose7:
+ax_pose 2, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose8:
+ax_pose 1, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose9:
+ax_pose 5, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose10:
+ax_pose 6, 0x81e9, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose11:
+ax_pose 7, 0x81e9, 0x80f9, 0xac00
+ax_pose_terminator
+sKirliaPose12:
+ax_pose 8, 0x81e9, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose13:
+ax_pose 9, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose14:
+ax_pose 8, 0x81e9, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose15:
+ax_pose 7, 0x81e9, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose16:
+ax_pose 6, 0x81e9, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose17:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose18:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose19:
+ax_pose 5, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose20:
+ax_pose 12, 0x01ec, 0x80f1, 0xac00
+ax_pose_terminator
+sKirliaPose21:
+ax_pose 13, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose22:
+ax_pose 14, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose23:
+ax_pose 6, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose24:
+ax_pose 15, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sKirliaPose25:
+ax_pose 16, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose26:
+ax_pose 17, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose27:
+ax_pose 7, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose28:
+ax_pose 18, 0x81ea, 0x90fa, 0xac00
+ax_pose_terminator
+sKirliaPose29:
+ax_pose 19, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose30:
+ax_pose 20, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose31:
+ax_pose 8, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose32:
+ax_pose 21, 0x81eb, 0x90fa, 0xac00
+ax_pose_terminator
+sKirliaPose33:
+ax_pose 22, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose34:
+ax_pose 23, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose35:
+ax_pose 9, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose36:
+ax_pose 24, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose37:
+ax_pose 19, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose38:
+ax_pose 20, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose39:
+ax_pose 8, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose40:
+ax_pose 21, 0x81eb, 0x80f5, 0xac00
+ax_pose_terminator
+sKirliaPose41:
+ax_pose 16, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose42:
+ax_pose 17, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose43:
+ax_pose 7, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose44:
+ax_pose 18, 0x81ea, 0x80f5, 0xac00
+ax_pose_terminator
+sKirliaPose45:
+ax_pose 13, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose46:
+ax_pose 14, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose47:
+ax_pose 6, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose48:
+ax_pose 15, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sKirliaPose49:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose50:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose51:
+ax_pose 5, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose52:
+ax_pose 12, 0x01ec, 0x80f1, 0xac00
+ax_pose_terminator
+sKirliaPose53:
+ax_pose 13, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose54:
+ax_pose 14, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose55:
+ax_pose 6, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose56:
+ax_pose 15, 0x01eb, 0x90eb, 0xac00
+ax_pose_terminator
+sKirliaPose57:
+ax_pose 16, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose58:
+ax_pose 17, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose59:
+ax_pose 7, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose60:
+ax_pose 18, 0x81ea, 0x90fa, 0xac00
+ax_pose_terminator
+sKirliaPose61:
+ax_pose 19, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose62:
+ax_pose 20, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose63:
+ax_pose 8, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose64:
+ax_pose 21, 0x81eb, 0x90fa, 0xac00
+ax_pose_terminator
+sKirliaPose65:
+ax_pose 22, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose66:
+ax_pose 23, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose67:
+ax_pose 9, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose68:
+ax_pose 24, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose69:
+ax_pose 19, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose70:
+ax_pose 20, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose71:
+ax_pose 8, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose72:
+ax_pose 21, 0x81eb, 0x80f5, 0xac00
+ax_pose_terminator
+sKirliaPose73:
+ax_pose 16, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose74:
+ax_pose 17, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose75:
+ax_pose 7, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose76:
+ax_pose 18, 0x81ea, 0x80f5, 0xac00
+ax_pose_terminator
+sKirliaPose77:
+ax_pose 13, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose78:
+ax_pose 14, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose79:
+ax_pose 6, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose80:
+ax_pose 15, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sKirliaPose81:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose82:
+ax_pose 13, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose83:
+ax_pose 16, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose84:
+ax_pose 19, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose85:
+ax_pose 22, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose86:
+ax_pose 19, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose87:
+ax_pose 16, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose88:
+ax_pose 13, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose89:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose90:
+ax_pose 13, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose91:
+ax_pose 16, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose92:
+ax_pose 19, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose93:
+ax_pose 22, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose94:
+ax_pose 19, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose95:
+ax_pose 16, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose96:
+ax_pose 13, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose97:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose98:
+ax_pose 14, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose99:
+ax_pose 17, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose100:
+ax_pose 20, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose101:
+ax_pose 23, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose102:
+ax_pose 20, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose103:
+ax_pose 17, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose104:
+ax_pose 14, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose105:
+ax_pose 25, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose106:
+ax_pose 26, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose107:
+ax_pose 27, 0x01e3, 0x80f1, 0xac00
+ax_pose_terminator
+sKirliaPose108:
+ax_pose 28, 0x01e5, 0x90eb, 0xac00
+ax_pose_terminator
+sKirliaPose109:
+ax_pose 29, 0x01e6, 0x90e8, 0xac00
+ax_pose_terminator
+sKirliaPose110:
+ax_pose 30, 0x01e9, 0x90ea, 0xac00
+ax_pose_terminator
+sKirliaPose111:
+ax_pose 31, 0x01e4, 0x80f1, 0xac00
+ax_pose_terminator
+sKirliaPose112:
+ax_pose 30, 0x01e9, 0x80f6, 0xac00
+ax_pose_terminator
+sKirliaPose113:
+ax_pose 29, 0x01e6, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose114:
+ax_pose 28, 0x01e5, 0x80f5, 0xac00
+ax_pose_terminator
+sKirliaPose115:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose116:
+ax_pose 13, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose117:
+ax_pose 16, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose118:
+ax_pose 19, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose119:
+ax_pose 22, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose120:
+ax_pose 19, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose121:
+ax_pose 16, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose122:
+ax_pose 13, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose123:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose124:
+ax_pose 14, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose125:
+ax_pose 17, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose126:
+ax_pose 20, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose127:
+ax_pose 23, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose128:
+ax_pose 20, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose129:
+ax_pose 17, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose130:
+ax_pose 14, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose131:
+ax_pose 12, 0x01eb, 0x80f1, 0xac00
+ax_pose_terminator
+sKirliaPose132:
+ax_pose 15, 0x01ea, 0x80f6, 0xac00
+ax_pose_terminator
+sKirliaPose133:
+ax_pose 18, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose134:
+ax_pose 21, 0x81eb, 0x80f6, 0xac00
+ax_pose_terminator
+sKirliaPose135:
+ax_pose 24, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose136:
+ax_pose 21, 0x81eb, 0x90fa, 0xac00
+ax_pose_terminator
+sKirliaPose137:
+ax_pose 18, 0x81ea, 0x90fa, 0xac00
+ax_pose_terminator
+sKirliaPose138:
+ax_pose 15, 0x01ea, 0x90ea, 0xac00
+ax_pose_terminator
+sKirliaPose139:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose140:
+ax_pose 14, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose141:
+ax_pose 17, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose142:
+ax_pose 20, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose143:
+ax_pose 23, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose144:
+ax_pose 20, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose145:
+ax_pose 17, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose146:
+ax_pose 14, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose147:
+ax_pose 0, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose148:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose149:
+ax_pose 12, 0x01ec, 0x80f1, 0xac00
+ax_pose_terminator
+sKirliaPose150:
+ax_pose 1, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose151:
+ax_pose 13, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose152:
+ax_pose 15, 0x01ec, 0x90ea, 0xac00
+ax_pose_terminator
+sKirliaPose153:
+ax_pose 2, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose154:
+ax_pose 16, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose155:
+ax_pose 18, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose156:
+ax_pose 3, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose157:
+ax_pose 19, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose158:
+ax_pose 21, 0x81ed, 0x90f9, 0xac00
+ax_pose_terminator
+sKirliaPose159:
+ax_pose 4, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose160:
+ax_pose 22, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose161:
+ax_pose 24, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose162:
+ax_pose 3, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose163:
+ax_pose 19, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose164:
+ax_pose 21, 0x81ed, 0x80f6, 0xac00
+ax_pose_terminator
+sKirliaPose165:
+ax_pose 2, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose166:
+ax_pose 16, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose167:
+ax_pose 18, 0x81ea, 0x80f6, 0xac00
+ax_pose_terminator
+sKirliaPose168:
+ax_pose 1, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose169:
+ax_pose 13, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose170:
+ax_pose 15, 0x01ec, 0x80f5, 0xac00
+ax_pose_terminator
+sKirliaPose171:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose172:
+ax_pose 13, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose173:
+ax_pose 16, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose174:
+ax_pose 19, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose175:
+ax_pose 22, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose176:
+ax_pose 19, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose177:
+ax_pose 16, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose178:
+ax_pose 13, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+sKirliaPose179:
+ax_pose 0, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose180:
+ax_pose 1, 0x81ea, 0x80f7, 0xac00
+ax_pose_terminator
+sKirliaPose181:
+ax_pose 2, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose182:
+ax_pose 3, 0x81ea, 0x80f8, 0xac00
+ax_pose_terminator
+sKirliaPose183:
+ax_pose 4, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sKirliaPose184:
+ax_pose 3, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose185:
+ax_pose 2, 0x81ea, 0x90f7, 0xac00
+ax_pose_terminator
+sKirliaPose186:
+ax_pose 1, 0x81ea, 0x90f8, 0xac00
+ax_pose_terminator
+.align 2
+sKirliaAnims_1_1:
+ax_anim 1, 0, 8, 0, -2, 0, 1,
+ax_anim 2, 0, 8, 0, -3, 0, 2,
+ax_anim 3, 0, 8, 0, 0, 0, 3,
+ax_anim 3, 0, 8, 0, 3, 0, 3,
+ax_anim 1, 0, 8, 0, 4, 0, 4,
+ax_anim 4, 0, 1, 0, 4, 0, 4,
+ax_anim 2, 0, 2, 0, 3, 0, 3,
+ax_anim 2, 0, 3, 0, 3, 0, 3,
+ax_anim 2, 0, 4, 0, 2, 0, 2,
+ax_anim 2, 0, 5, 0, 2, 0, 2,
+ax_anim 2, 0, 6, 0, 1, 0, 1,
+ax_anim 2, 0, 7, 0, 1, 0, 1,
+ax_anim 2, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_1_2:
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 15, 1, -1, 1, 1,
+ax_anim 3, 0, 15, 2, 0, 2, 2,
+ax_anim 3, 0, 15, 3, 2, 3, 3,
+ax_anim 1, 0, 15, 4, 4, 4, 4,
+ax_anim 4, 0, 0, 4, 4, 4, 4,
+ax_anim 2, 0, 1, 3, 3, 3, 3,
+ax_anim 2, 0, 2, 3, 3, 3, 3,
+ax_anim 2, 0, 3, 2, 2, 2, 2,
+ax_anim 2, 0, 4, 2, 2, 2, 2,
+ax_anim 2, 0, 5, 1, 1, 1, 1,
+ax_anim 2, 0, 6, 1, 1, 1, 1,
+ax_anim 2, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_1_3:
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 2, 0, 14, 1, -1, 1, 0,
+ax_anim 3, 0, 14, 2, -2, 2, 0,
+ax_anim 3, 0, 14, 3, -2, 3, 0,
+ax_anim 1, 0, 14, 4, -1, 4, 0,
+ax_anim 4, 0, 7, 4, 0, 4, 0,
+ax_anim 2, 0, 0, 3, 0, 3, 0,
+ax_anim 2, 0, 1, 3, 0, 3, 0,
+ax_anim 2, 0, 2, 2, 0, 2, 0,
+ax_anim 2, 0, 3, 2, 0, 2, 0,
+ax_anim 2, 0, 4, 1, 0, 1, 0,
+ax_anim 2, 0, 5, 1, 0, 1, 0,
+ax_anim 2, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_1_4:
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 1, -2, 1, -1,
+ax_anim 3, 0, 13, 2, -4, 2, -2,
+ax_anim 3, 0, 13, 3, -5, 3, -3,
+ax_anim 1, 0, 13, 4, -4, 4, -4,
+ax_anim 4, 0, 6, 4, -4, 4, -4,
+ax_anim 2, 0, 7, 3, -3, 3, -3,
+ax_anim 2, 0, 0, 3, -3, 3, -3,
+ax_anim 2, 0, 1, 2, -2, 2, -2,
+ax_anim 2, 0, 2, 2, -2, 2, -2,
+ax_anim 2, 0, 3, 1, -1, 1, -1,
+ax_anim 2, 0, 4, 1, -1, 1, -1,
+ax_anim 2, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_1_5:
+ax_anim 1, 0, 12, 0, -1, 0, 0,
+ax_anim 2, 0, 12, 0, -3, 0, -1,
+ax_anim 3, 0, 12, 0, -4, 0, -2,
+ax_anim 3, 0, 12, 0, -5, 0, -3,
+ax_anim 1, 0, 12, 0, -4, 0, -4,
+ax_anim 4, 0, 5, 0, -4, 0, -4,
+ax_anim 2, 0, 6, 0, -3, 0, -3,
+ax_anim 2, 0, 7, 0, -3, 0, -3,
+ax_anim 2, 0, 0, 0, -2, 0, -2,
+ax_anim 2, 0, 1, 0, -2, 0, -2,
+ax_anim 2, 0, 2, 0, -1, 0, -1,
+ax_anim 2, 0, 3, 0, -1, 0, -1,
+ax_anim 2, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_1_6:
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 2, 0, 11, -1, -2, -1, -1,
+ax_anim 3, 0, 11, -2, -4, -2, -2,
+ax_anim 3, 0, 11, -3, -5, -3, -3,
+ax_anim 1, 0, 11, -4, -4, -4, -4,
+ax_anim 4, 0, 4, -4, -4, -4, -4,
+ax_anim 2, 0, 5, -3, -3, -3, -3,
+ax_anim 2, 0, 6, -3, -3, -3, -3,
+ax_anim 2, 0, 7, -2, -2, -2, -2,
+ax_anim 2, 0, 0, -2, -2, -2, -2,
+ax_anim 2, 0, 1, -1, -1, -1, -1,
+ax_anim 2, 0, 2, -1, -1, -1, -1,
+ax_anim 2, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_1_7:
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 10, -1, -1, -1, 0,
+ax_anim 3, 0, 10, -2, -2, -2, 0,
+ax_anim 3, 0, 10, -3, -2, -3, 0,
+ax_anim 1, 0, 10, -4, -1, -4, 0,
+ax_anim 4, 0, 3, -4, 0, -4, 0,
+ax_anim 2, 0, 4, -3, 0, -3, 0,
+ax_anim 2, 0, 5, -3, 0, -3, 0,
+ax_anim 2, 0, 6, -2, 0, -2, 0,
+ax_anim 2, 0, 7, -2, 0, -2, 0,
+ax_anim 2, 0, 0, -1, 0, -1, 0,
+ax_anim 2, 0, 1, -1, 0, -1, 0,
+ax_anim 2, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_1_8:
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 9, -1, -1, -1, 1,
+ax_anim 3, 0, 9, -2, 0, -2, 2,
+ax_anim 3, 0, 9, -3, 2, -3, 3,
+ax_anim 1, 0, 9, -4, 4, -4, 4,
+ax_anim 4, 0, 2, -4, 4, -4, 4,
+ax_anim 2, 0, 3, -3, 3, -3, 3,
+ax_anim 2, 0, 4, -3, 3, -3, 3,
+ax_anim 2, 0, 5, -2, 2, -2, 2,
+ax_anim 2, 0, 6, -2, 2, -2, 2,
+ax_anim 2, 0, 7, -1, 1, -1, 1,
+ax_anim 2, 0, 0, -1, 1, -1, 1,
+ax_anim 2, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_2_1:
+ax_anim 2, 0, 17, 0, -3, 0, 0,
+ax_anim 3, 0, 17, 0, -5, 0, 0,
+ax_anim 2, 0, 17, 0, -3, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 2, 19, 0, 7, 0, 7,
+ax_anim 2, 0, 19, 0, 20, 0, 20,
+ax_anim 2, 1, 19, 1, 20, 1, 20,
+ax_anim 2, 0, 19, 0, 20, 0, 20,
+ax_anim 2, 0, 19, 1, 20, 1, 20,
+ax_anim 2, 0, 19, 0, 20, 0, 20,
+ax_anim 2, 0, 16, 0, 13, 0, 13,
+ax_anim 2, 0, 16, 0, 5, 0, 5,
+ax_anim_terminator
+sKirliaAnims_2_2:
+ax_anim 2, 0, 21, 0, -3, 0, 0,
+ax_anim 3, 0, 21, 0, -5, 0, 0,
+ax_anim 2, 0, 21, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 2, 2, 23, 7, 7, 7, 7,
+ax_anim 2, 0, 23, 21, 20, 21, 20,
+ax_anim 2, 1, 23, 22, 19, 22, 19,
+ax_anim 2, 0, 23, 21, 20, 21, 20,
+ax_anim 2, 0, 23, 22, 19, 22, 19,
+ax_anim 2, 0, 23, 21, 20, 21, 20,
+ax_anim 2, 0, 20, 13, 13, 13, 13,
+ax_anim 2, 0, 20, 5, 5, 5, 5,
+ax_anim_terminator
+sKirliaAnims_2_3:
+ax_anim 2, 0, 25, 0, -3, 0, 0,
+ax_anim 3, 0, 25, 0, -5, 0, 0,
+ax_anim 2, 0, 25, 0, -3, 0, 0,
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 2, 27, 7, 0, 7, 0,
+ax_anim 2, 0, 27, 21, 0, 21, 0,
+ax_anim 2, 1, 27, 21, 1, 21, 1,
+ax_anim 2, 0, 27, 21, 0, 21, 0,
+ax_anim 2, 0, 27, 21, 1, 21, 1,
+ax_anim 2, 0, 27, 21, 0, 21, 0,
+ax_anim 2, 0, 24, 13, 0, 13, 0,
+ax_anim 2, 0, 24, 5, 0, 5, 0,
+ax_anim_terminator
+sKirliaAnims_2_4:
+ax_anim 2, 0, 29, 0, -3, 0, 0,
+ax_anim 3, 0, 29, 0, -5, 0, 0,
+ax_anim 2, 0, 29, 0, -3, 0, 0,
+ax_anim 4, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 2, 31, 7, -7, 7, -7,
+ax_anim 2, 0, 31, 20, -21, 20, -21,
+ax_anim 2, 1, 31, 21, -20, 21, -20,
+ax_anim 2, 0, 31, 20, -21, 20, -21,
+ax_anim 2, 0, 31, 21, -20, 21, -20,
+ax_anim 2, 0, 31, 20, -21, 20, -21,
+ax_anim 2, 0, 28, 13, -13, 13, -13,
+ax_anim 2, 0, 28, 5, -5, 5, -5,
+ax_anim_terminator
+sKirliaAnims_2_5:
+ax_anim 2, 0, 33, 0, -3, 0, -3,
+ax_anim 3, 0, 33, 0, -5, 0, -5,
+ax_anim 2, 0, 33, 0, -3, 0, -3,
+ax_anim 4, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, -7, 0, -7,
+ax_anim 2, 0, 35, 0, -21, 0, -21,
+ax_anim 2, 1, 35, 1, -21, 1, -21,
+ax_anim 2, 0, 35, 0, -21, 0, -21,
+ax_anim 2, 0, 35, 1, -21, 1, -21,
+ax_anim 2, 0, 35, 0, -21, 0, -21,
+ax_anim 2, 0, 32, 0, -13, 0, -13,
+ax_anim 2, 0, 32, 0, -5, 0, -5,
+ax_anim_terminator
+sKirliaAnims_2_6:
+ax_anim 2, 0, 37, 0, -3, 0, 0,
+ax_anim 3, 0, 37, 0, -5, 0, 0,
+ax_anim 2, 0, 37, 0, -3, 0, 0,
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 39, -7, -7, -7, -7,
+ax_anim 2, 0, 39, -20, -21, -20, -21,
+ax_anim 2, 1, 39, -21, -20, -21, -20,
+ax_anim 2, 0, 39, -20, -21, -20, -21,
+ax_anim 2, 0, 39, -21, -20, -21, -20,
+ax_anim 2, 0, 39, -20, -21, -20, -21,
+ax_anim 2, 0, 36, -13, -13, -13, -13,
+ax_anim 2, 0, 36, -5, -5, -5, -5,
+ax_anim_terminator
+sKirliaAnims_2_7:
+ax_anim 2, 0, 41, 0, -3, 0, 0,
+ax_anim 3, 0, 41, 0, -5, 0, 0,
+ax_anim 2, 0, 41, 0, -3, 0, 0,
+ax_anim 4, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 2, 43, -7, 0, -7, 0,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 1, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 0, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 0, 40, -13, 0, -13, 0,
+ax_anim 2, 0, 40, -5, 0, -5, 0,
+ax_anim_terminator
+sKirliaAnims_2_8:
+ax_anim 2, 0, 45, 0, -3, 0, 0,
+ax_anim 3, 0, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 45, 0, -3, 0, 0,
+ax_anim 4, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 2, 47, -7, 7, -7, 7,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 1, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 0, 44, -13, 13, -13, 13,
+ax_anim 2, 0, 44, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sKirliaAnims_3_1:
+ax_anim 2, 0, 49, 0, -3, 0, 0,
+ax_anim 3, 0, 49, 0, -5, 0, 0,
+ax_anim 2, 0, 49, 0, -3, 0, 0,
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 2, 51, 0, 7, 0, 7,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 1, 51, 1, 20, 1, 20,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 0, 51, 1, 20, 1, 20,
+ax_anim 2, 0, 51, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 0, 13, 0, 13,
+ax_anim 2, 0, 48, 0, 5, 0, 5,
+ax_anim_terminator
+sKirliaAnims_3_2:
+ax_anim 2, 0, 53, 0, -3, 0, 0,
+ax_anim 3, 0, 53, 0, -5, 0, 0,
+ax_anim 2, 0, 53, 0, -3, 0, 0,
+ax_anim 4, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 2, 55, 7, 7, 7, 7,
+ax_anim 2, 0, 55, 21, 20, 21, 20,
+ax_anim 2, 1, 55, 22, 19, 22, 19,
+ax_anim 2, 0, 55, 21, 20, 21, 20,
+ax_anim 2, 0, 55, 22, 19, 22, 19,
+ax_anim 2, 0, 55, 21, 20, 21, 20,
+ax_anim 2, 0, 52, 13, 13, 13, 13,
+ax_anim 2, 0, 52, 5, 5, 5, 5,
+ax_anim_terminator
+sKirliaAnims_3_3:
+ax_anim 2, 0, 57, 0, -3, 0, 0,
+ax_anim 3, 0, 57, 0, -5, 0, 0,
+ax_anim 2, 0, 57, 0, -3, 0, 0,
+ax_anim 4, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 2, 59, 7, 0, 7, 0,
+ax_anim 2, 0, 59, 21, 0, 21, 0,
+ax_anim 2, 1, 59, 21, 1, 21, 1,
+ax_anim 2, 0, 59, 21, 0, 21, 0,
+ax_anim 2, 0, 59, 21, 1, 21, 1,
+ax_anim 2, 0, 59, 21, 0, 21, 0,
+ax_anim 2, 0, 56, 13, 0, 13, 0,
+ax_anim 2, 0, 56, 5, 0, 5, 0,
+ax_anim_terminator
+sKirliaAnims_3_4:
+ax_anim 2, 0, 61, 0, -3, 0, 0,
+ax_anim 3, 0, 61, 0, -5, 0, 0,
+ax_anim 2, 0, 61, 0, -3, 0, 0,
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 2, 63, 7, -7, 7, -7,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 1, 63, 21, -20, 21, -20,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 0, 63, 21, -20, 21, -20,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 0, 60, 13, -13, 13, -13,
+ax_anim 2, 0, 60, 5, -5, 5, -5,
+ax_anim_terminator
+sKirliaAnims_3_5:
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 3, 0, 65, 0, -5, 0, -5,
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 2, 67, 0, -7, 0, -7,
+ax_anim 2, 0, 67, 0, -21, 0, -21,
+ax_anim 2, 1, 67, 1, -21, 1, -21,
+ax_anim 2, 0, 67, 0, -21, 0, -21,
+ax_anim 2, 0, 67, 1, -21, 1, -21,
+ax_anim 2, 0, 67, 0, -21, 0, -21,
+ax_anim 2, 0, 64, 0, -13, 0, -13,
+ax_anim 2, 0, 64, 0, -5, 0, -5,
+ax_anim_terminator
+sKirliaAnims_3_6:
+ax_anim 2, 0, 69, 0, -3, 0, 0,
+ax_anim 3, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -3, 0, 0,
+ax_anim 4, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 2, 71, -7, -7, -7, -7,
+ax_anim 2, 0, 71, -20, -21, -20, -21,
+ax_anim 2, 1, 71, -21, -20, -21, -20,
+ax_anim 2, 0, 71, -20, -21, -20, -21,
+ax_anim 2, 0, 71, -21, -20, -21, -20,
+ax_anim 2, 0, 71, -20, -21, -20, -21,
+ax_anim 2, 0, 68, -13, -13, -13, -13,
+ax_anim 2, 0, 68, -5, -5, -5, -5,
+ax_anim_terminator
+sKirliaAnims_3_7:
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 3, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 75, -7, 0, -7, 0,
+ax_anim 2, 0, 75, -21, 0, -21, 0,
+ax_anim 2, 1, 75, -21, 1, -21, 1,
+ax_anim 2, 0, 75, -21, 0, -21, 0,
+ax_anim 2, 0, 75, -21, 1, -21, 1,
+ax_anim 2, 0, 75, -21, 0, -21, 0,
+ax_anim 2, 0, 72, -13, 0, -13, 0,
+ax_anim 2, 0, 72, -5, 0, -5, 0,
+ax_anim_terminator
+sKirliaAnims_3_8:
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 3, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 2, 79, -7, 7, -7, 7,
+ax_anim 2, 0, 79, -21, 20, -21, 20,
+ax_anim 2, 1, 79, -22, 19, -22, 19,
+ax_anim 2, 0, 79, -21, 20, -21, 20,
+ax_anim 2, 0, 79, -22, 19, -22, 19,
+ax_anim 2, 0, 79, -21, 20, -21, 20,
+ax_anim 2, 0, 76, -13, 13, -13, 13,
+ax_anim 2, 0, 76, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sKirliaAnims_4_1:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_4_2:
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_4_3:
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_4_4:
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_4_5:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_4_6:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_4_7:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_4_8:
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_5_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_5_2:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_5_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -6, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_5_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_5_6:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_5_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_5_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -6, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sKirliaAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sKirliaAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sKirliaAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sKirliaAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sKirliaAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sKirliaAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sKirliaAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sKirliaAnims_8_1:
+ax_anim 60, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 24, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_8_2:
+ax_anim 60, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 24, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_8_3:
+ax_anim 60, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 24, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_8_4:
+ax_anim 60, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 24, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_8_5:
+ax_anim 60, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 24, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_8_6:
+ax_anim 60, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 24, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_8_7:
+ax_anim 60, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 24, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_8_8:
+ax_anim 60, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 24, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 3, 6, 3,
+ax_anim 2, 0, 132, 8, 9, 8, 9,
+ax_anim 2, 0, 133, 7, 19, 7, 19,
+ax_anim 3, 0, 134, 0, 22, 0, 22,
+ax_anim 2, 3, 135, -7, 19, -7, 19,
+ax_anim 2, 0, 136, -8, 9, -8, 9,
+ax_anim 1, 0, 137, -6, 3, -6, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 13, 0, 13, 0,
+ax_anim 2, 0, 131, 23, 5, 23, 5,
+ax_anim 2, 0, 132, 26, 13, 26, 13,
+ax_anim 3, 0, 133, 25, 21, 25, 21,
+ax_anim 2, 3, 134, 15, 22, 15, 22,
+ax_anim 2, 0, 135, 3, 15, 3, 15,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -3, 3, -3,
+ax_anim 2, 0, 130, 12, -5, 12, -5,
+ax_anim 2, 0, 131, 21, -4, 21, -4,
+ax_anim 3, 0, 132, 25, 0, 25, 0,
+ax_anim 2, 3, 133, 21, 5, 21, 5,
+ax_anim 2, 0, 134, 14, 7, 14, 7,
+ax_anim 1, 0, 135, 5, 4, 5, 4,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 2, -8, 2, -8,
+ax_anim 2, 0, 137, 6, -17, 6, -17,
+ax_anim 2, 0, 130, 14, -23, 14, -23,
+ax_anim 3, 0, 131, 24, -21, 24, -21,
+ax_anim 2, 3, 132, 26, -14, 26, -14,
+ax_anim 2, 0, 133, 21, -4, 21, -4,
+ax_anim 1, 0, 134, 10, 1, 10, 1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -6, -4, -6, -4,
+ax_anim 2, 0, 136, -9, -10, -9, -10,
+ax_anim 2, 0, 137, -7, -19, -7, -19,
+ax_anim 3, 0, 130, 0, -22, 0, -22,
+ax_anim 2, 3, 131, 7, -19, 7, -19,
+ax_anim 2, 0, 132, 9, -10, 9, -10,
+ax_anim 1, 0, 133, 6, -4, 6, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, -2, -8, -2, -8,
+ax_anim 2, 0, 131, -6, -17, -6, -17,
+ax_anim 2, 0, 130, -14, -23, -14, -23,
+ax_anim 3, 0, 137, -24, -21, -24, -21,
+ax_anim 2, 3, 136, -26, -14, -26, -14,
+ax_anim 2, 0, 135, -21, -4, -21, -4,
+ax_anim 1, 0, 134, -10, 1, -10, 1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -3, -3, -3,
+ax_anim 2, 0, 130, -12, -5, -12, -5,
+ax_anim 2, 0, 137, -21, -4, -21, -4,
+ax_anim 3, 0, 136, -25, 0, -25, 0,
+ax_anim 2, 3, 135, -21, 5, -21, 5,
+ax_anim 2, 0, 134, -14, 7, -14, 7,
+ax_anim 1, 0, 133, -5, 4, -5, 4,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 137, -23, 5, -23, 5,
+ax_anim 2, 0, 136, -26, 13, -26, 13,
+ax_anim 3, 0, 135, -25, 21, -25, 21,
+ax_anim 2, 3, 134, -15, 22, -15, 22,
+ax_anim 2, 0, 133, -3, 15, -3, 15,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 0, 146, 0, -16, 0, 0,
+ax_anim 3, 0, 146, 0, -20, 0, 0,
+ax_anim 4, 0, 146, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -23, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -23, 0, 0,
+ax_anim 3, 0, 151, 0, -22, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -23, 0, 0,
+ax_anim 3, 0, 154, 0, -22, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -23, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -23, 0, 0,
+ax_anim 2, 0, 163, 0, -17, 0, 0,
+ax_anim 1, 0, 163, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 166, 0, -22, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 169, 0, -22, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKirliaAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sKirliaGfx1:
+.incbin "baserom.gba", 0x11796CC, 0x200
+sKirliaSprites1:
+ax_sprite sKirliaGfx1, 0x200
+ax_sprite_terminator
+sKirliaGfx2:
+.incbin "baserom.gba", 0x11798DC, 0x100
+sKirliaSprites2:
+ax_sprite sKirliaGfx2, 0x100
+ax_sprite_terminator
+sKirliaGfx3:
+.incbin "baserom.gba", 0x11799EC, 0x100
+sKirliaSprites3:
+ax_sprite sKirliaGfx3, 0x100
+ax_sprite_terminator
+sKirliaGfx4:
+.incbin "baserom.gba", 0x1179AFC, 0x100
+sKirliaSprites4:
+ax_sprite sKirliaGfx4, 0x100
+ax_sprite_terminator
+sKirliaGfx5:
+.incbin "baserom.gba", 0x1179C0C, 0x200
+sKirliaSprites5:
+ax_sprite sKirliaGfx5, 0x200
+ax_sprite_terminator
+sKirliaGfx6:
+.incbin "baserom.gba", 0x1179E1C, 0x200
+sKirliaSprites6:
+ax_sprite sKirliaGfx6, 0x200
+ax_sprite_terminator
+sKirliaGfx7:
+.incbin "baserom.gba", 0x117A02C, 0x100
+sKirliaSprites7:
+ax_sprite sKirliaGfx7, 0x100
+ax_sprite_terminator
+sKirliaGfx8:
+.incbin "baserom.gba", 0x117A13C, 0x100
+sKirliaSprites8:
+ax_sprite sKirliaGfx8, 0x100
+ax_sprite_terminator
+sKirliaGfx9:
+.incbin "baserom.gba", 0x117A24C, 0x100
+sKirliaSprites9:
+ax_sprite sKirliaGfx9, 0x100
+ax_sprite_terminator
+sKirliaGfx10:
+.incbin "baserom.gba", 0x117A35C, 0x200
+sKirliaSprites10:
+ax_sprite sKirliaGfx10, 0x200
+ax_sprite_terminator
+sKirliaGfx11:
+.incbin "baserom.gba", 0x117A56C, 0x40
+sKirliaGfx11_1:
+.incbin "baserom.gba", 0x117A5AC, 0x60
+sKirliaGfx11_2:
+.incbin "baserom.gba", 0x117A60C, 0x40
+sKirliaSprites11:
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx11, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx11_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKirliaGfx11_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKirliaGfx12:
+.incbin "baserom.gba", 0x117A68C, 0x40
+sKirliaGfx12_1:
+.incbin "baserom.gba", 0x117A6CC, 0x60
+sKirliaGfx12_2:
+.incbin "baserom.gba", 0x117A72C, 0x40
+sKirliaSprites12:
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx12, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx12_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKirliaGfx12_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKirliaGfx13:
+.incbin "baserom.gba", 0x117A7AC, 0x60
+sKirliaGfx13_1:
+.incbin "baserom.gba", 0x117A80C, 0x60
+sKirliaGfx13_2:
+.incbin "baserom.gba", 0x117A86C, 0x40
+sKirliaSprites13:
+ax_sprite sKirliaGfx13, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx13_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKirliaGfx13_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKirliaGfx14:
+.incbin "baserom.gba", 0x117A8E4, 0xC0
+sKirliaSprites14:
+ax_sprite sKirliaGfx14, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx15:
+.incbin "baserom.gba", 0x117A9BC, 0xC0
+sKirliaSprites15:
+ax_sprite sKirliaGfx15, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx16:
+.incbin "baserom.gba", 0x117AA94, 0x40
+sKirliaGfx16_1:
+.incbin "baserom.gba", 0x117AAD4, 0x60
+sKirliaGfx16_2:
+.incbin "baserom.gba", 0x117AB34, 0x60
+sKirliaSprites16:
+ax_sprite sKirliaGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKirliaGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKirliaGfx17:
+.incbin "baserom.gba", 0x117ABCC, 0xC0
+sKirliaSprites17:
+ax_sprite sKirliaGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx18:
+.incbin "baserom.gba", 0x117ACA4, 0xC0
+sKirliaSprites18:
+ax_sprite sKirliaGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx19:
+.incbin "baserom.gba", 0x117AD7C, 0xC0
+sKirliaSprites19:
+ax_sprite sKirliaGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx20:
+.incbin "baserom.gba", 0x117AE54, 0xC0
+sKirliaSprites20:
+ax_sprite sKirliaGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx21:
+.incbin "baserom.gba", 0x117AF2C, 0xC0
+sKirliaSprites21:
+ax_sprite sKirliaGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx22:
+.incbin "baserom.gba", 0x117B004, 0xC0
+sKirliaSprites22:
+ax_sprite sKirliaGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKirliaGfx23:
+.incbin "baserom.gba", 0x117B0DC, 0x40
+sKirliaGfx23_1:
+.incbin "baserom.gba", 0x117B11C, 0x60
+sKirliaGfx23_2:
+.incbin "baserom.gba", 0x117B17C, 0x40
+sKirliaSprites23:
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKirliaGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKirliaGfx24:
+.incbin "baserom.gba", 0x117B1FC, 0x40
+sKirliaGfx24_1:
+.incbin "baserom.gba", 0x117B23C, 0x60
+sKirliaGfx24_2:
+.incbin "baserom.gba", 0x117B29C, 0x40
+sKirliaSprites24:
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKirliaGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKirliaGfx25:
+.incbin "baserom.gba", 0x117B31C, 0x40
+sKirliaGfx25_1:
+.incbin "baserom.gba", 0x117B35C, 0x60
+sKirliaGfx25_2:
+.incbin "baserom.gba", 0x117B3BC, 0x40
+sKirliaSprites25:
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKirliaGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKirliaGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKirliaGfx26:
+.incbin "baserom.gba", 0x117B43C, 0x100
+sKirliaSprites26:
+ax_sprite sKirliaGfx26, 0x100
+ax_sprite_terminator
+sKirliaGfx27:
+.incbin "baserom.gba", 0x117B54C, 0x100
+sKirliaSprites27:
+ax_sprite sKirliaGfx27, 0x100
+ax_sprite_terminator
+sKirliaGfx28:
+.incbin "baserom.gba", 0x117B65C, 0x200
+sKirliaSprites28:
+ax_sprite sKirliaGfx28, 0x200
+ax_sprite_terminator
+sKirliaGfx29:
+.incbin "baserom.gba", 0x117B86C, 0x200
+sKirliaSprites29:
+ax_sprite sKirliaGfx29, 0x200
+ax_sprite_terminator
+sKirliaGfx30:
+.incbin "baserom.gba", 0x117BA7C, 0x200
+sKirliaSprites30:
+ax_sprite sKirliaGfx30, 0x200
+ax_sprite_terminator
+sKirliaGfx31:
+.incbin "baserom.gba", 0x117BC8C, 0x200
+sKirliaSprites31:
+ax_sprite sKirliaGfx31, 0x200
+ax_sprite_terminator
+sKirliaGfx32:
+.incbin "baserom.gba", 0x117BE9C, 0x200
+sKirliaSprites32:
+ax_sprite sKirliaGfx32, 0x200
+ax_sprite_terminator
+sAxPosesKirlia:
+.4byte sKirliaPose1
+.4byte sKirliaPose2
+.4byte sKirliaPose3
+.4byte sKirliaPose4
+.4byte sKirliaPose5
+.4byte sKirliaPose6
+.4byte sKirliaPose7
+.4byte sKirliaPose8
+.4byte sKirliaPose9
+.4byte sKirliaPose10
+.4byte sKirliaPose11
+.4byte sKirliaPose12
+.4byte sKirliaPose13
+.4byte sKirliaPose14
+.4byte sKirliaPose15
+.4byte sKirliaPose16
+.4byte sKirliaPose17
+.4byte sKirliaPose18
+.4byte sKirliaPose19
+.4byte sKirliaPose20
+.4byte sKirliaPose21
+.4byte sKirliaPose22
+.4byte sKirliaPose23
+.4byte sKirliaPose24
+.4byte sKirliaPose25
+.4byte sKirliaPose26
+.4byte sKirliaPose27
+.4byte sKirliaPose28
+.4byte sKirliaPose29
+.4byte sKirliaPose30
+.4byte sKirliaPose31
+.4byte sKirliaPose32
+.4byte sKirliaPose33
+.4byte sKirliaPose34
+.4byte sKirliaPose35
+.4byte sKirliaPose36
+.4byte sKirliaPose37
+.4byte sKirliaPose38
+.4byte sKirliaPose39
+.4byte sKirliaPose40
+.4byte sKirliaPose41
+.4byte sKirliaPose42
+.4byte sKirliaPose43
+.4byte sKirliaPose44
+.4byte sKirliaPose45
+.4byte sKirliaPose46
+.4byte sKirliaPose47
+.4byte sKirliaPose48
+.4byte sKirliaPose49
+.4byte sKirliaPose50
+.4byte sKirliaPose51
+.4byte sKirliaPose52
+.4byte sKirliaPose53
+.4byte sKirliaPose54
+.4byte sKirliaPose55
+.4byte sKirliaPose56
+.4byte sKirliaPose57
+.4byte sKirliaPose58
+.4byte sKirliaPose59
+.4byte sKirliaPose60
+.4byte sKirliaPose61
+.4byte sKirliaPose62
+.4byte sKirliaPose63
+.4byte sKirliaPose64
+.4byte sKirliaPose65
+.4byte sKirliaPose66
+.4byte sKirliaPose67
+.4byte sKirliaPose68
+.4byte sKirliaPose69
+.4byte sKirliaPose70
+.4byte sKirliaPose71
+.4byte sKirliaPose72
+.4byte sKirliaPose73
+.4byte sKirliaPose74
+.4byte sKirliaPose75
+.4byte sKirliaPose76
+.4byte sKirliaPose77
+.4byte sKirliaPose78
+.4byte sKirliaPose79
+.4byte sKirliaPose80
+.4byte sKirliaPose81
+.4byte sKirliaPose82
+.4byte sKirliaPose83
+.4byte sKirliaPose84
+.4byte sKirliaPose85
+.4byte sKirliaPose86
+.4byte sKirliaPose87
+.4byte sKirliaPose88
+.4byte sKirliaPose89
+.4byte sKirliaPose90
+.4byte sKirliaPose91
+.4byte sKirliaPose92
+.4byte sKirliaPose93
+.4byte sKirliaPose94
+.4byte sKirliaPose95
+.4byte sKirliaPose96
+.4byte sKirliaPose97
+.4byte sKirliaPose98
+.4byte sKirliaPose99
+.4byte sKirliaPose100
+.4byte sKirliaPose101
+.4byte sKirliaPose102
+.4byte sKirliaPose103
+.4byte sKirliaPose104
+.4byte sKirliaPose105
+.4byte sKirliaPose106
+.4byte sKirliaPose107
+.4byte sKirliaPose108
+.4byte sKirliaPose109
+.4byte sKirliaPose110
+.4byte sKirliaPose111
+.4byte sKirliaPose112
+.4byte sKirliaPose113
+.4byte sKirliaPose114
+.4byte sKirliaPose115
+.4byte sKirliaPose116
+.4byte sKirliaPose117
+.4byte sKirliaPose118
+.4byte sKirliaPose119
+.4byte sKirliaPose120
+.4byte sKirliaPose121
+.4byte sKirliaPose122
+.4byte sKirliaPose123
+.4byte sKirliaPose124
+.4byte sKirliaPose125
+.4byte sKirliaPose126
+.4byte sKirliaPose127
+.4byte sKirliaPose128
+.4byte sKirliaPose129
+.4byte sKirliaPose130
+.4byte sKirliaPose131
+.4byte sKirliaPose132
+.4byte sKirliaPose133
+.4byte sKirliaPose134
+.4byte sKirliaPose135
+.4byte sKirliaPose136
+.4byte sKirliaPose137
+.4byte sKirliaPose138
+.4byte sKirliaPose139
+.4byte sKirliaPose140
+.4byte sKirliaPose141
+.4byte sKirliaPose142
+.4byte sKirliaPose143
+.4byte sKirliaPose144
+.4byte sKirliaPose145
+.4byte sKirliaPose146
+.4byte sKirliaPose147
+.4byte sKirliaPose148
+.4byte sKirliaPose149
+.4byte sKirliaPose150
+.4byte sKirliaPose151
+.4byte sKirliaPose152
+.4byte sKirliaPose153
+.4byte sKirliaPose154
+.4byte sKirliaPose155
+.4byte sKirliaPose156
+.4byte sKirliaPose157
+.4byte sKirliaPose158
+.4byte sKirliaPose159
+.4byte sKirliaPose160
+.4byte sKirliaPose161
+.4byte sKirliaPose162
+.4byte sKirliaPose163
+.4byte sKirliaPose164
+.4byte sKirliaPose165
+.4byte sKirliaPose166
+.4byte sKirliaPose167
+.4byte sKirliaPose168
+.4byte sKirliaPose169
+.4byte sKirliaPose170
+.4byte sKirliaPose171
+.4byte sKirliaPose172
+.4byte sKirliaPose173
+.4byte sKirliaPose174
+.4byte sKirliaPose175
+.4byte sKirliaPose176
+.4byte sKirliaPose177
+.4byte sKirliaPose178
+.4byte sKirliaPose179
+.4byte sKirliaPose180
+.4byte sKirliaPose181
+.4byte sKirliaPose182
+.4byte sKirliaPose183
+.4byte sKirliaPose184
+.4byte sKirliaPose185
+.4byte sKirliaPose186
+sAxPositionsKirlia:
+.2byte   -1,  -10, 	  -2,   -6, 	   0,   -6, 	  -1,   -9
+.2byte   -4,  -10, 	  -4,   -7, 	  -2,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -4,   -7, 	  -3,   -6, 	  -2,   -9
+.2byte   -3,  -11, 	  -1,   -8, 	  -3,   -6, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    1,  -11, 	  -1,   -8, 	   1,   -6, 	  -1,  -10
+.2byte    3,  -10, 	   2,   -7, 	   1,   -6, 	   0,   -9
+.2byte    2,  -10, 	   2,   -7, 	   0,   -6, 	   0,   -9
+.2byte   -1,  -10, 	  -5,   -7, 	   3,   -7, 	  -1,   -9
+.2byte   -3,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -4,  -10, 	  -6,   -6, 	   3,   -5, 	  -1,   -9
+.2byte   -2,  -11, 	   4,   -8, 	  -6,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   4,   -7, 	  -6,   -7, 	  -1,  -10
+.2byte    1,  -11, 	  -5,   -8, 	   5,   -7, 	  -1,  -10
+.2byte    3,  -10, 	   5,   -6, 	  -4,   -5, 	   0,   -9
+.2byte    2,  -10, 	   5,   -6, 	  -5,   -6, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -7, 	   4,   -7, 	  -1,   -9
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -1,   -8, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -4,   -6, 	   0,   -9
+.2byte    2,   -9, 	   2,   -6, 	  -1,   -4, 	   0,   -8
+.2byte    2,   -9, 	   5,   -5, 	  -5,   -5, 	   0,   -8
+.2byte    4,   -8, 	   4,   -7, 	  -4,   -7, 	   1,   -8
+.2byte    3,  -10, 	   1,   -7, 	   2,   -4, 	   0,   -9
+.2byte    3,   -9, 	  -2,   -6, 	   4,   -5, 	   0,   -8
+.2byte    3,   -9, 	   5,   -5, 	  -4,   -4, 	   0,   -8
+.2byte    5,   -9, 	  -2,  -10, 	  -2,   -7, 	   1,   -9
+.2byte    1,  -11, 	  -4,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -2,   -8, 	   2,   -3, 	  -1,   -9
+.2byte    1,  -10, 	  -5,   -7, 	   5,   -6, 	  -1,   -9
+.2byte    4,   -9, 	  -4,   -9, 	   3,   -6, 	   0,   -9
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	   2,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,  -10, 	   0,   -8, 	  -4,   -3, 	  -1,   -9
+.2byte   -3,  -10, 	   3,   -7, 	  -7,   -6, 	  -1,   -9
+.2byte   -6,   -9, 	   2,   -9, 	  -5,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -3,   -7, 	  -4,   -4, 	  -2,   -9
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -5, 	  -2,   -8
+.2byte   -5,   -9, 	  -7,   -5, 	   2,   -4, 	  -2,   -8
+.2byte   -7,   -9, 	   0,  -10, 	   0,   -7, 	  -3,   -9
+.2byte   -4,  -10, 	  -7,   -7, 	   2,   -6, 	  -2,   -9
+.2byte   -4,   -9, 	  -4,   -6, 	  -1,   -4, 	  -2,   -8
+.2byte   -4,   -9, 	  -7,   -5, 	   3,   -5, 	  -2,   -8
+.2byte   -6,   -8, 	  -6,   -7, 	   2,   -7, 	  -3,   -8
+.2byte   -1,  -10, 	  -6,   -7, 	   4,   -7, 	  -1,   -9
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -1,   -8, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte    2,  -10, 	   5,   -7, 	  -4,   -6, 	   0,   -9
+.2byte    2,   -9, 	   2,   -6, 	  -1,   -4, 	   0,   -8
+.2byte    2,   -9, 	   5,   -5, 	  -5,   -5, 	   0,   -8
+.2byte    4,   -8, 	   4,   -7, 	  -4,   -7, 	   1,   -8
+.2byte    3,  -10, 	   1,   -7, 	   2,   -4, 	   0,   -9
+.2byte    3,   -9, 	  -2,   -6, 	   4,   -5, 	   0,   -8
+.2byte    3,   -9, 	   5,   -5, 	  -4,   -4, 	   0,   -8
+.2byte    5,   -9, 	  -2,  -10, 	  -2,   -7, 	   1,   -9
+.2byte    1,  -11, 	  -4,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    1,  -10, 	  -2,   -8, 	   2,   -3, 	  -1,   -9
+.2byte    1,  -10, 	  -5,   -7, 	   5,   -6, 	  -1,   -9
+.2byte    4,   -9, 	  -4,   -9, 	   3,   -6, 	   0,   -9
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	   2,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -3,  -10, 	   0,   -8, 	  -4,   -3, 	  -1,   -9
+.2byte   -3,  -10, 	   3,   -7, 	  -7,   -6, 	  -1,   -9
+.2byte   -6,   -9, 	   2,   -9, 	  -5,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -3,   -7, 	  -4,   -4, 	  -2,   -9
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -5, 	  -2,   -8
+.2byte   -5,   -9, 	  -7,   -5, 	   2,   -4, 	  -2,   -8
+.2byte   -7,   -9, 	   0,  -10, 	   0,   -7, 	  -3,   -9
+.2byte   -4,  -10, 	  -7,   -7, 	   2,   -6, 	  -2,   -9
+.2byte   -4,   -9, 	  -4,   -6, 	  -1,   -4, 	  -2,   -8
+.2byte   -4,   -9, 	  -7,   -5, 	   3,   -5, 	  -2,   -8
+.2byte   -6,   -8, 	  -6,   -7, 	   2,   -7, 	  -3,   -8
+.2byte   -1,  -10, 	  -6,   -7, 	   4,   -7, 	  -1,   -9
+.2byte   -4,  -10, 	  -7,   -7, 	   2,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -3,   -7, 	  -4,   -4, 	  -2,   -9
+.2byte   -3,  -11, 	   2,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    1,  -11, 	  -4,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    3,  -10, 	   1,   -7, 	   2,   -4, 	   0,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -4,   -6, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -7, 	   4,   -7, 	  -1,   -9
+.2byte   -4,  -10, 	  -7,   -7, 	   2,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -3,   -7, 	  -4,   -4, 	  -2,   -9
+.2byte   -3,  -11, 	   2,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    1,  -11, 	  -4,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    3,  -10, 	   1,   -7, 	   2,   -4, 	   0,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -4,   -6, 	   0,   -9
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -4,   -9, 	  -4,   -6, 	  -1,   -4, 	  -2,   -8
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -5, 	  -2,   -8
+.2byte   -3,  -10, 	   0,   -8, 	  -4,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte    1,  -10, 	  -2,   -8, 	   2,   -3, 	  -1,   -9
+.2byte    3,   -9, 	  -2,   -6, 	   4,   -5, 	   0,   -8
+.2byte    2,   -9, 	   2,   -6, 	  -1,   -4, 	   0,   -8
+.2byte   -3,   -7, 	  -3,   -4, 	  -1,   -3, 	  -1,   -6
+.2byte   -4,   -6, 	  -3,   -3, 	  -1,   -2, 	  -1,   -5
+.2byte    0,   -9, 	   3,  -12, 	  -3,  -12, 	   0,   -8
+.2byte   -2,  -11, 	   3,  -15, 	  -2,  -13, 	  -1,   -7
+.2byte    0,  -11, 	   1,  -12, 	   0,   -9, 	  -1,   -6
+.2byte    0,  -10, 	  -1,  -13, 	   4,  -11, 	   2,   -5
+.2byte    0,   -8, 	   3,  -11, 	  -3,  -11, 	   0,   -5
+.2byte   -1,  -10, 	   0,  -13, 	  -5,  -11, 	  -3,   -5
+.2byte   -1,  -11, 	  -2,  -12, 	  -1,   -9, 	   0,   -6
+.2byte    1,  -11, 	  -4,  -15, 	   1,  -13, 	   0,   -7
+.2byte   -1,  -10, 	  -6,   -7, 	   4,   -7, 	  -1,   -9
+.2byte   -4,  -10, 	  -7,   -7, 	   2,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -3,   -7, 	  -4,   -4, 	  -2,   -9
+.2byte   -3,  -11, 	   2,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    1,  -11, 	  -4,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    3,  -10, 	   1,   -7, 	   2,   -4, 	   0,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -4,   -6, 	   0,   -9
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte   -4,   -9, 	  -4,   -6, 	  -1,   -4, 	  -2,   -8
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -5, 	  -2,   -8
+.2byte   -3,  -10, 	   0,   -8, 	  -4,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte    1,  -10, 	  -2,   -8, 	   2,   -3, 	  -1,   -9
+.2byte    3,   -9, 	  -2,   -6, 	   4,   -5, 	   0,   -8
+.2byte    2,   -9, 	   2,   -6, 	  -1,   -4, 	   0,   -8
+.2byte   -1,   -9, 	  -7,   -8, 	   5,   -8, 	  -1,   -8
+.2byte   -4,   -9, 	  -4,   -8, 	   4,   -8, 	  -1,   -9
+.2byte   -5,   -9, 	   2,  -10, 	   2,   -7, 	  -1,   -9
+.2byte   -5,   -9, 	   3,   -9, 	  -4,   -6, 	  -1,   -9
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte    4,   -9, 	  -4,   -9, 	   3,   -6, 	   0,   -9
+.2byte    5,   -9, 	  -2,  -10, 	  -2,   -7, 	   1,   -9
+.2byte    3,   -9, 	   3,   -8, 	  -5,   -8, 	   0,   -9
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -8
+.2byte    2,   -9, 	   2,   -6, 	  -1,   -4, 	   0,   -8
+.2byte    3,   -9, 	  -2,   -6, 	   4,   -5, 	   0,   -8
+.2byte    1,  -10, 	  -2,   -8, 	   2,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -3,  -10, 	   0,   -8, 	  -4,   -3, 	  -1,   -9
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -5, 	  -2,   -8
+.2byte   -4,   -9, 	  -4,   -6, 	  -1,   -4, 	  -2,   -8
+.2byte   -1,  -10, 	  -2,   -6, 	   0,   -6, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,   -7, 	   4,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte    2,  -10, 	   2,   -7, 	   0,   -6, 	   0,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -4,   -6, 	   0,   -9
+.2byte    3,   -7, 	   3,   -6, 	  -5,   -6, 	   0,   -7
+.2byte    3,  -10, 	   2,   -7, 	   1,   -6, 	   0,   -9
+.2byte    3,  -10, 	   1,   -7, 	   2,   -4, 	   0,   -9
+.2byte    3,   -9, 	  -4,  -10, 	  -4,   -7, 	  -1,   -9
+.2byte    1,  -11, 	  -1,   -8, 	   1,   -6, 	  -1,  -10
+.2byte    1,  -11, 	  -4,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    3,   -7, 	  -5,   -7, 	   2,   -4, 	  -1,   -7
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	  -1,   -8, 	  -3,   -6, 	  -1,  -10
+.2byte   -3,  -11, 	   2,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -5,   -7, 	   3,   -7, 	  -4,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	  -4,   -7, 	  -3,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -3,   -7, 	  -4,   -4, 	  -2,   -9
+.2byte   -6,   -9, 	   1,  -10, 	   1,   -7, 	  -2,   -9
+.2byte   -4,  -10, 	  -4,   -7, 	  -2,   -6, 	  -2,   -9
+.2byte   -4,  -10, 	  -7,   -7, 	   2,   -6, 	  -2,   -9
+.2byte   -5,   -7, 	  -5,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -10, 	  -6,   -7, 	   4,   -7, 	  -1,   -9
+.2byte   -4,  -10, 	  -7,   -7, 	   2,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -3,   -7, 	  -4,   -4, 	  -2,   -9
+.2byte   -3,  -11, 	   2,   -8, 	  -6,   -5, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    1,  -11, 	  -4,   -8, 	   4,   -5, 	  -1,  -10
+.2byte    3,  -10, 	   1,   -7, 	   2,   -4, 	   0,   -9
+.2byte    2,  -10, 	   5,   -7, 	  -4,   -6, 	   0,   -9
+.2byte   -1,  -10, 	  -2,   -6, 	   0,   -6, 	  -1,   -9
+.2byte   -4,  -10, 	  -4,   -7, 	  -2,   -6, 	  -2,   -9
+.2byte   -5,  -10, 	  -4,   -7, 	  -3,   -6, 	  -2,   -9
+.2byte   -3,  -11, 	  -1,   -8, 	  -3,   -6, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    1,  -11, 	  -1,   -8, 	   1,   -6, 	  -1,  -10
+.2byte    3,  -10, 	   2,   -7, 	   1,   -6, 	   0,   -9
+.2byte    2,  -10, 	   2,   -7, 	   0,   -6, 	   0,   -9
+sKirliaAnimTable1:
+.4byte sKirliaAnims_1_1
+.4byte sKirliaAnims_1_2
+.4byte sKirliaAnims_1_3
+.4byte sKirliaAnims_1_4
+.4byte sKirliaAnims_1_5
+.4byte sKirliaAnims_1_6
+.4byte sKirliaAnims_1_7
+.4byte sKirliaAnims_1_8
+sKirliaAnimTable2:
+.4byte sKirliaAnims_2_1
+.4byte sKirliaAnims_2_2
+.4byte sKirliaAnims_2_3
+.4byte sKirliaAnims_2_4
+.4byte sKirliaAnims_2_5
+.4byte sKirliaAnims_2_6
+.4byte sKirliaAnims_2_7
+.4byte sKirliaAnims_2_8
+sKirliaAnimTable3:
+.4byte sKirliaAnims_3_1
+.4byte sKirliaAnims_3_2
+.4byte sKirliaAnims_3_3
+.4byte sKirliaAnims_3_4
+.4byte sKirliaAnims_3_5
+.4byte sKirliaAnims_3_6
+.4byte sKirliaAnims_3_7
+.4byte sKirliaAnims_3_8
+sKirliaAnimTable4:
+.4byte sKirliaAnims_4_1
+.4byte sKirliaAnims_4_2
+.4byte sKirliaAnims_4_3
+.4byte sKirliaAnims_4_4
+.4byte sKirliaAnims_4_5
+.4byte sKirliaAnims_4_6
+.4byte sKirliaAnims_4_7
+.4byte sKirliaAnims_4_8
+sKirliaAnimTable5:
+.4byte sKirliaAnims_5_1
+.4byte sKirliaAnims_5_2
+.4byte sKirliaAnims_5_3
+.4byte sKirliaAnims_5_4
+.4byte sKirliaAnims_5_5
+.4byte sKirliaAnims_5_6
+.4byte sKirliaAnims_5_7
+.4byte sKirliaAnims_5_8
+sKirliaAnimTable6:
+.4byte sKirliaAnims_6_1
+.4byte sKirliaAnims_6_1
+.4byte sKirliaAnims_6_1
+.4byte sKirliaAnims_6_1
+.4byte sKirliaAnims_6_1
+.4byte sKirliaAnims_6_1
+.4byte sKirliaAnims_6_1
+.4byte sKirliaAnims_6_1
+sKirliaAnimTable7:
+.4byte sKirliaAnims_7_1
+.4byte sKirliaAnims_7_2
+.4byte sKirliaAnims_7_3
+.4byte sKirliaAnims_7_4
+.4byte sKirliaAnims_7_5
+.4byte sKirliaAnims_7_6
+.4byte sKirliaAnims_7_7
+.4byte sKirliaAnims_7_8
+sKirliaAnimTable8:
+.4byte sKirliaAnims_8_1
+.4byte sKirliaAnims_8_2
+.4byte sKirliaAnims_8_3
+.4byte sKirliaAnims_8_4
+.4byte sKirliaAnims_8_5
+.4byte sKirliaAnims_8_6
+.4byte sKirliaAnims_8_7
+.4byte sKirliaAnims_8_8
+sKirliaAnimTable9:
+.4byte sKirliaAnims_9_1
+.4byte sKirliaAnims_9_2
+.4byte sKirliaAnims_9_3
+.4byte sKirliaAnims_9_4
+.4byte sKirliaAnims_9_5
+.4byte sKirliaAnims_9_6
+.4byte sKirliaAnims_9_7
+.4byte sKirliaAnims_9_8
+sKirliaAnimTable10:
+.4byte sKirliaAnims_10_1
+.4byte sKirliaAnims_10_2
+.4byte sKirliaAnims_10_3
+.4byte sKirliaAnims_10_4
+.4byte sKirliaAnims_10_5
+.4byte sKirliaAnims_10_6
+.4byte sKirliaAnims_10_7
+.4byte sKirliaAnims_10_8
+sKirliaAnimTable11:
+.4byte sKirliaAnims_11_1
+.4byte sKirliaAnims_11_2
+.4byte sKirliaAnims_11_3
+.4byte sKirliaAnims_11_4
+.4byte sKirliaAnims_11_5
+.4byte sKirliaAnims_11_6
+.4byte sKirliaAnims_11_7
+.4byte sKirliaAnims_11_8
+sKirliaAnimTable12:
+.4byte sKirliaAnims_12_1
+.4byte sKirliaAnims_12_2
+.4byte sKirliaAnims_12_3
+.4byte sKirliaAnims_12_4
+.4byte sKirliaAnims_12_5
+.4byte sKirliaAnims_12_6
+.4byte sKirliaAnims_12_7
+.4byte sKirliaAnims_12_8
+sKirliaAnimTable13:
+.4byte sKirliaAnims_13_1
+.4byte sKirliaAnims_13_2
+.4byte sKirliaAnims_13_3
+.4byte sKirliaAnims_13_4
+.4byte sKirliaAnims_13_5
+.4byte sKirliaAnims_13_6
+.4byte sKirliaAnims_13_7
+.4byte sKirliaAnims_13_8
+sAxAnimationsKirlia:
+.4byte sKirliaAnimTable1
+.4byte sKirliaAnimTable2
+.4byte sKirliaAnimTable3
+.4byte sKirliaAnimTable4
+.4byte sKirliaAnimTable5
+.4byte sKirliaAnimTable6
+.4byte sKirliaAnimTable7
+.4byte sKirliaAnimTable8
+.4byte sKirliaAnimTable9
+.4byte sKirliaAnimTable10
+.4byte sKirliaAnimTable11
+.4byte sKirliaAnimTable12
+.4byte sKirliaAnimTable13
+sAxSpritesKirlia:
+.4byte sKirliaSprites1
+.4byte sKirliaSprites2
+.4byte sKirliaSprites3
+.4byte sKirliaSprites4
+.4byte sKirliaSprites5
+.4byte sKirliaSprites6
+.4byte sKirliaSprites7
+.4byte sKirliaSprites8
+.4byte sKirliaSprites9
+.4byte sKirliaSprites10
+.4byte sKirliaSprites11
+.4byte sKirliaSprites12
+.4byte sKirliaSprites13
+.4byte sKirliaSprites14
+.4byte sKirliaSprites15
+.4byte sKirliaSprites16
+.4byte sKirliaSprites17
+.4byte sKirliaSprites18
+.4byte sKirliaSprites19
+.4byte sKirliaSprites20
+.4byte sKirliaSprites21
+.4byte sKirliaSprites22
+.4byte sKirliaSprites23
+.4byte sKirliaSprites24
+.4byte sKirliaSprites25
+.4byte sKirliaSprites26
+.4byte sKirliaSprites27
+.4byte sKirliaSprites28
+.4byte sKirliaSprites29
+.4byte sKirliaSprites30
+.4byte sKirliaSprites31
+.4byte sKirliaSprites32
+sAxMainKirlia:
+ax_main sAxPosesKirlia, sAxAnimationsKirlia, 13, sAxSpritesKirlia, sAxPositionsKirlia

--- a/data/ax/koffing.inc
+++ b/data/ax/koffing.inc
@@ -1,0 +1,3841 @@
+.global gAxKoffing
+gAxKoffing:
+ax_siro sAxMainKoffing
+sKoffingPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose3:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose4:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose5:
+ax_pose 4, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose6:
+ax_pose 5, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose7:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose8:
+ax_pose 7, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose9:
+ax_pose 8, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose10:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose11:
+ax_pose 10, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose12:
+ax_pose 11, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose13:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose15:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose16:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose17:
+ax_pose 10, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose18:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose19:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose20:
+ax_pose 7, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose21:
+ax_pose 8, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose22:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose23:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose24:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose26:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose27:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose28:
+ax_pose 17, 0x41e2, 0x80f0, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c08
+ax_pose_terminator
+sKoffingPose29:
+ax_pose 19, 0x01da, 0x4104, 0x2c00
+ax_pose -1, 0x01da, 0x40ec, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose30:
+ax_pose 20, 0x01d0, 0x4106, 0x2c00
+ax_pose -1, 0x01d0, 0x40ea, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose31:
+ax_pose 21, 0x01cf, 0x4106, 0x2c00
+ax_pose -1, 0x01cf, 0x40ea, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose32:
+ax_pose 22, 0x01cf, 0x4106, 0x2c00
+ax_pose -1, 0x01cf, 0x40ea, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose33:
+ax_pose 23, 0x01cf, 0x4106, 0x2c00
+ax_pose -1, 0x01cf, 0x40ea, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose34:
+ax_pose 24, 0x01cf, 0x4106, 0x2c00
+ax_pose -1, 0x01cf, 0x40ea, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose35:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose36:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose37:
+ax_pose 25, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose38:
+ax_pose 26, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose39:
+ax_pose 27, 0x81e1, 0x90f0, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c08
+ax_pose_terminator
+sKoffingPose40:
+ax_pose 19, 0x01df, 0x50e2, 0x2c00
+ax_pose -1, 0x01d6, 0x50f0, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose41:
+ax_pose 20, 0x01d7, 0x50d5, 0x2c00
+ax_pose -1, 0x01c7, 0x50e8, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose42:
+ax_pose 21, 0x01d7, 0x50d5, 0x2c00
+ax_pose -1, 0x01c7, 0x50e8, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose43:
+ax_pose 22, 0x01d7, 0x50d5, 0x2c00
+ax_pose -1, 0x01c7, 0x50e8, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose44:
+ax_pose 23, 0x01d7, 0x50d5, 0x2c00
+ax_pose -1, 0x01c7, 0x50e8, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose45:
+ax_pose 24, 0x01d7, 0x50d5, 0x2c00
+ax_pose -1, 0x01c7, 0x50e8, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose46:
+ax_pose 28, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose47:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose48:
+ax_pose 29, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose49:
+ax_pose 30, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose50:
+ax_pose 31, 0x81e0, 0x90f0, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c08
+ax_pose_terminator
+sKoffingPose51:
+ax_pose 19, 0x01e6, 0x50e2, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01db, 0x50ea, 0x2c00
+ax_pose_terminator
+sKoffingPose52:
+ax_pose 20, 0x01e5, 0x50d8, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01d7, 0x50e0, 0x2c00
+ax_pose_terminator
+sKoffingPose53:
+ax_pose 21, 0x01e5, 0x50d8, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01d7, 0x50e0, 0x2c00
+ax_pose_terminator
+sKoffingPose54:
+ax_pose 22, 0x01e5, 0x50d8, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01d7, 0x50e0, 0x2c00
+ax_pose_terminator
+sKoffingPose55:
+ax_pose 23, 0x01e5, 0x50d8, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01d7, 0x50e0, 0x2c00
+ax_pose_terminator
+sKoffingPose56:
+ax_pose 24, 0x01e5, 0x50d8, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01d7, 0x50e0, 0x2c00
+ax_pose_terminator
+sKoffingPose57:
+ax_pose 32, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose58:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose59:
+ax_pose 33, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose60:
+ax_pose 34, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose61:
+ax_pose 35, 0x41f5, 0x90ed, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c08
+ax_pose_terminator
+sKoffingPose62:
+ax_pose 19, 0x0202, 0x50f1, 0x2c00
+ax_pose -1, 0x01f5, 0x50e0, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose63:
+ax_pose 20, 0x0209, 0x50ee, 0x2c00
+ax_pose -1, 0x01f8, 0x50d8, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose64:
+ax_pose 21, 0x0209, 0x50ee, 0x2c00
+ax_pose -1, 0x01f8, 0x50d8, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose65:
+ax_pose 22, 0x0209, 0x50ee, 0x2c00
+ax_pose -1, 0x01f8, 0x50d8, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose66:
+ax_pose 23, 0x0209, 0x50ee, 0x2c00
+ax_pose -1, 0x01f8, 0x50d8, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose67:
+ax_pose 24, 0x0209, 0x50ee, 0x2c00
+ax_pose -1, 0x01f8, 0x50d8, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose68:
+ax_pose 36, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose69:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose70:
+ax_pose 37, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose71:
+ax_pose 38, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose72:
+ax_pose 39, 0x41f5, 0x80f0, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose73:
+ax_pose 19, 0x01fd, 0x4104, 0x2c00
+ax_pose -1, 0x01fd, 0x40ec, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose74:
+ax_pose 20, 0x0204, 0x4109, 0x2c00
+ax_pose -1, 0x0204, 0x40e7, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose75:
+ax_pose 21, 0x0204, 0x4109, 0x2c00
+ax_pose -1, 0x0204, 0x40e7, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose76:
+ax_pose 22, 0x0204, 0x4109, 0x2c00
+ax_pose -1, 0x0204, 0x40e7, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose77:
+ax_pose 23, 0x0204, 0x4109, 0x2c00
+ax_pose -1, 0x0204, 0x40e7, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose78:
+ax_pose 24, 0x0204, 0x4109, 0x2c00
+ax_pose -1, 0x0204, 0x40e7, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose79:
+ax_pose 40, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose80:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sKoffingPose81:
+ax_pose 33, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose82:
+ax_pose 34, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose83:
+ax_pose 35, 0x41f5, 0x80f3, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose84:
+ax_pose 19, 0x0202, 0x40ff, 0x2c00
+ax_pose -1, 0x01f5, 0x4110, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose85:
+ax_pose 20, 0x0209, 0x4102, 0x2c00
+ax_pose -1, 0x01f8, 0x4118, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose86:
+ax_pose 21, 0x0209, 0x4102, 0x2c00
+ax_pose -1, 0x01f8, 0x4118, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose87:
+ax_pose 22, 0x0209, 0x4102, 0x2c00
+ax_pose -1, 0x01f8, 0x4118, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose88:
+ax_pose 23, 0x0209, 0x4102, 0x2c00
+ax_pose -1, 0x01f8, 0x4118, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose89:
+ax_pose 24, 0x0209, 0x4102, 0x2c00
+ax_pose -1, 0x01f8, 0x4118, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose90:
+ax_pose 36, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose91:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose92:
+ax_pose 29, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose93:
+ax_pose 30, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose94:
+ax_pose 31, 0x81e0, 0x8100, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose95:
+ax_pose 19, 0x01e6, 0x410e, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01db, 0x4106, 0x2c00
+ax_pose_terminator
+sKoffingPose96:
+ax_pose 20, 0x01e5, 0x4118, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01d7, 0x4110, 0x2c00
+ax_pose_terminator
+sKoffingPose97:
+ax_pose 21, 0x01e5, 0x4118, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01d7, 0x4110, 0x2c00
+ax_pose_terminator
+sKoffingPose98:
+ax_pose 22, 0x01e5, 0x4118, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01d7, 0x4110, 0x2c00
+ax_pose_terminator
+sKoffingPose99:
+ax_pose 23, 0x01e5, 0x4118, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01d7, 0x4110, 0x2c00
+ax_pose_terminator
+sKoffingPose100:
+ax_pose 24, 0x01e5, 0x4118, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01d7, 0x4110, 0x2c00
+ax_pose_terminator
+sKoffingPose101:
+ax_pose 32, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose102:
+ax_pose 3, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sKoffingPose103:
+ax_pose 25, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose104:
+ax_pose 26, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose105:
+ax_pose 27, 0x81e1, 0x8100, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose106:
+ax_pose 19, 0x01df, 0x410e, 0x2c00
+ax_pose -1, 0x01d6, 0x4100, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose107:
+ax_pose 20, 0x01d7, 0x411b, 0x2c00
+ax_pose -1, 0x01c7, 0x4108, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose108:
+ax_pose 21, 0x01d7, 0x411b, 0x2c00
+ax_pose -1, 0x01c7, 0x4108, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose109:
+ax_pose 22, 0x01d7, 0x411b, 0x2c00
+ax_pose -1, 0x01c7, 0x4108, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose110:
+ax_pose 23, 0x01d7, 0x411b, 0x2c00
+ax_pose -1, 0x01c7, 0x4108, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose111:
+ax_pose 24, 0x01d7, 0x411b, 0x2c00
+ax_pose -1, 0x01c7, 0x4108, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose112:
+ax_pose 28, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose113:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose114:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose115:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose116:
+ax_pose 17, 0x41e2, 0x80f0, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c08
+ax_pose_terminator
+sKoffingPose117:
+ax_pose 19, 0x01e6, 0x4104, 0x2c00
+ax_pose -1, 0x01e6, 0x40ec, 0x2c00
+ax_pose -1, 0x01f3, 0x40f8, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose118:
+ax_pose 20, 0x01e6, 0x4106, 0x2c00
+ax_pose -1, 0x01e6, 0x40ea, 0x2c00
+ax_pose -1, 0x01f4, 0x40f8, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose119:
+ax_pose 21, 0x01e5, 0x4106, 0x2c00
+ax_pose -1, 0x01e5, 0x40ea, 0x2c00
+ax_pose -1, 0x01f3, 0x40f8, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose120:
+ax_pose 22, 0x01e5, 0x4106, 0x2c00
+ax_pose -1, 0x01e5, 0x40ea, 0x2c00
+ax_pose -1, 0x01f3, 0x40f8, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose121:
+ax_pose 23, 0x01e5, 0x4106, 0x2c00
+ax_pose -1, 0x01e5, 0x40ea, 0x2c00
+ax_pose -1, 0x01f3, 0x40f8, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose122:
+ax_pose 24, 0x01e5, 0x4106, 0x2c00
+ax_pose -1, 0x01e5, 0x40ea, 0x2c00
+ax_pose -1, 0x01f3, 0x40f8, 0x2c00
+ax_pose 18, 0x01e2, 0x80f0, 0x2c04
+ax_pose_terminator
+sKoffingPose123:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose124:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose125:
+ax_pose 25, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose126:
+ax_pose 26, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose127:
+ax_pose 27, 0x81e1, 0x90f0, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c08
+ax_pose_terminator
+sKoffingPose128:
+ax_pose 19, 0x01ea, 0x50ec, 0x2c00
+ax_pose -1, 0x01ee, 0x50fb, 0x2c00
+ax_pose -1, 0x01e1, 0x50fa, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose129:
+ax_pose 20, 0x01ec, 0x50e8, 0x2c00
+ax_pose -1, 0x01ee, 0x50fc, 0x2c00
+ax_pose -1, 0x01dc, 0x50fb, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose130:
+ax_pose 21, 0x01ec, 0x50e8, 0x2c00
+ax_pose -1, 0x01ee, 0x50fc, 0x2c00
+ax_pose -1, 0x01dc, 0x50fb, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose131:
+ax_pose 22, 0x01ec, 0x50e8, 0x2c00
+ax_pose -1, 0x01ee, 0x50fc, 0x2c00
+ax_pose -1, 0x01dc, 0x50fb, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose132:
+ax_pose 23, 0x01ec, 0x50e8, 0x2c00
+ax_pose -1, 0x01ee, 0x50fc, 0x2c00
+ax_pose -1, 0x01dc, 0x50fb, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose133:
+ax_pose 24, 0x01ec, 0x50e8, 0x2c00
+ax_pose -1, 0x01ee, 0x50fc, 0x2c00
+ax_pose -1, 0x01dc, 0x50fb, 0x2c00
+ax_pose 28, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose134:
+ax_pose 28, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose135:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose136:
+ax_pose 29, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose137:
+ax_pose 30, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose138:
+ax_pose 31, 0x81e0, 0x90f0, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c08
+ax_pose_terminator
+sKoffingPose139:
+ax_pose 19, 0x01eb, 0x50f1, 0x2c00
+ax_pose -1, 0x01eb, 0x5102, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01e0, 0x50f9, 0x2c00
+ax_pose_terminator
+sKoffingPose140:
+ax_pose 20, 0x01ea, 0x50f1, 0x2c00
+ax_pose -1, 0x01ea, 0x5102, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01dc, 0x50f9, 0x2c00
+ax_pose_terminator
+sKoffingPose141:
+ax_pose 21, 0x01ea, 0x50f1, 0x2c00
+ax_pose -1, 0x01ea, 0x5102, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01dc, 0x50f9, 0x2c00
+ax_pose_terminator
+sKoffingPose142:
+ax_pose 22, 0x01ea, 0x50f1, 0x2c00
+ax_pose -1, 0x01ea, 0x5102, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01dc, 0x50f9, 0x2c00
+ax_pose_terminator
+sKoffingPose143:
+ax_pose 23, 0x01ea, 0x50f1, 0x2c00
+ax_pose -1, 0x01ea, 0x5102, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01dc, 0x50f9, 0x2c00
+ax_pose_terminator
+sKoffingPose144:
+ax_pose 24, 0x01ea, 0x50f1, 0x2c00
+ax_pose -1, 0x01ea, 0x5102, 0x2c00
+ax_pose 32, 0x01e2, 0x90ef, 0x2c04
+ax_pose -1, 0x01dc, 0x50f9, 0x2c00
+ax_pose_terminator
+sKoffingPose145:
+ax_pose 32, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose146:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose147:
+ax_pose 33, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose148:
+ax_pose 34, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose149:
+ax_pose 35, 0x41f5, 0x90ed, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c08
+ax_pose_terminator
+sKoffingPose150:
+ax_pose 19, 0x01ef, 0x50fd, 0x2c00
+ax_pose -1, 0x01e1, 0x50fd, 0x2c00
+ax_pose -1, 0x01e2, 0x50ec, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose151:
+ax_pose 20, 0x01f2, 0x5101, 0x2c00
+ax_pose -1, 0x01de, 0x5101, 0x2c00
+ax_pose -1, 0x01e1, 0x50eb, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose152:
+ax_pose 21, 0x01f2, 0x5101, 0x2c00
+ax_pose -1, 0x01de, 0x5101, 0x2c00
+ax_pose -1, 0x01e1, 0x50eb, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose153:
+ax_pose 22, 0x01f2, 0x5101, 0x2c00
+ax_pose -1, 0x01de, 0x5101, 0x2c00
+ax_pose -1, 0x01e1, 0x50eb, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose154:
+ax_pose 23, 0x01f2, 0x5101, 0x2c00
+ax_pose -1, 0x01de, 0x5101, 0x2c00
+ax_pose -1, 0x01e1, 0x50eb, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose155:
+ax_pose 24, 0x01f2, 0x5101, 0x2c00
+ax_pose -1, 0x01de, 0x5101, 0x2c00
+ax_pose -1, 0x01e1, 0x50eb, 0x2c00
+ax_pose 36, 0x01e2, 0x90ef, 0x2c04
+ax_pose_terminator
+sKoffingPose156:
+ax_pose 36, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose157:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose158:
+ax_pose 37, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose159:
+ax_pose 38, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose160:
+ax_pose 39, 0x41f5, 0x80f0, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose161:
+ax_pose 19, 0x01e8, 0x4104, 0x2c00
+ax_pose -1, 0x01e8, 0x40ec, 0x2c00
+ax_pose -1, 0x01de, 0x40f9, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose162:
+ax_pose 20, 0x01e8, 0x4109, 0x2c00
+ax_pose -1, 0x01e8, 0x40e7, 0x2c00
+ax_pose -1, 0x01dc, 0x40f9, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose163:
+ax_pose 21, 0x01e8, 0x4109, 0x2c00
+ax_pose -1, 0x01e8, 0x40e7, 0x2c00
+ax_pose -1, 0x01dc, 0x40f9, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose164:
+ax_pose 22, 0x01e8, 0x4109, 0x2c00
+ax_pose -1, 0x01e8, 0x40e7, 0x2c00
+ax_pose -1, 0x01dc, 0x40f9, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose165:
+ax_pose 23, 0x01e8, 0x4109, 0x2c00
+ax_pose -1, 0x01e8, 0x40e7, 0x2c00
+ax_pose -1, 0x01dc, 0x40f9, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose166:
+ax_pose 24, 0x01e8, 0x4109, 0x2c00
+ax_pose -1, 0x01e8, 0x40e7, 0x2c00
+ax_pose -1, 0x01dc, 0x40f9, 0x2c00
+ax_pose 40, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose167:
+ax_pose 40, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose168:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sKoffingPose169:
+ax_pose 33, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose170:
+ax_pose 34, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose171:
+ax_pose 35, 0x41f5, 0x80f3, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose172:
+ax_pose 19, 0x01ef, 0x40f3, 0x2c00
+ax_pose -1, 0x01e1, 0x40f3, 0x2c00
+ax_pose -1, 0x01e2, 0x4104, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose173:
+ax_pose 20, 0x01f2, 0x40ef, 0x2c00
+ax_pose -1, 0x01de, 0x40ef, 0x2c00
+ax_pose -1, 0x01e1, 0x4105, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose174:
+ax_pose 21, 0x01f2, 0x40ef, 0x2c00
+ax_pose -1, 0x01de, 0x40ef, 0x2c00
+ax_pose -1, 0x01e1, 0x4105, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose175:
+ax_pose 22, 0x01f2, 0x40ef, 0x2c00
+ax_pose -1, 0x01de, 0x40ef, 0x2c00
+ax_pose -1, 0x01e1, 0x4105, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose176:
+ax_pose 23, 0x01f2, 0x40ef, 0x2c00
+ax_pose -1, 0x01de, 0x40ef, 0x2c00
+ax_pose -1, 0x01e1, 0x4105, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose177:
+ax_pose 24, 0x01f2, 0x40ef, 0x2c00
+ax_pose -1, 0x01de, 0x40ef, 0x2c00
+ax_pose -1, 0x01e1, 0x4105, 0x2c00
+ax_pose 36, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose178:
+ax_pose 36, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose179:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose180:
+ax_pose 29, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose181:
+ax_pose 30, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose182:
+ax_pose 31, 0x81e0, 0x8100, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose183:
+ax_pose 19, 0x01eb, 0x40ff, 0x2c00
+ax_pose -1, 0x01eb, 0x40ee, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01e0, 0x40f7, 0x2c00
+ax_pose_terminator
+sKoffingPose184:
+ax_pose 20, 0x01ea, 0x40ff, 0x2c00
+ax_pose -1, 0x01ea, 0x40ee, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01dc, 0x40f7, 0x2c00
+ax_pose_terminator
+sKoffingPose185:
+ax_pose 21, 0x01ea, 0x40ff, 0x2c00
+ax_pose -1, 0x01ea, 0x40ee, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01dc, 0x40f7, 0x2c00
+ax_pose_terminator
+sKoffingPose186:
+ax_pose 22, 0x01ea, 0x40ff, 0x2c00
+ax_pose -1, 0x01ea, 0x40ee, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01dc, 0x40f7, 0x2c00
+ax_pose_terminator
+sKoffingPose187:
+ax_pose 23, 0x01ea, 0x40ff, 0x2c00
+ax_pose -1, 0x01ea, 0x40ee, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01dc, 0x40f7, 0x2c00
+ax_pose_terminator
+sKoffingPose188:
+ax_pose 24, 0x01ea, 0x40ff, 0x2c00
+ax_pose -1, 0x01ea, 0x40ee, 0x2c00
+ax_pose 32, 0x01e2, 0x80f1, 0x2c04
+ax_pose -1, 0x01dc, 0x40f7, 0x2c00
+ax_pose_terminator
+sKoffingPose189:
+ax_pose 32, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose190:
+ax_pose 3, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sKoffingPose191:
+ax_pose 25, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose192:
+ax_pose 26, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose193:
+ax_pose 27, 0x81e1, 0x8100, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c08
+ax_pose_terminator
+sKoffingPose194:
+ax_pose 19, 0x01ea, 0x4104, 0x2c00
+ax_pose -1, 0x01ee, 0x40f5, 0x2c00
+ax_pose -1, 0x01e1, 0x40f6, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose195:
+ax_pose 20, 0x01ec, 0x4108, 0x2c00
+ax_pose -1, 0x01ee, 0x40f4, 0x2c00
+ax_pose -1, 0x01dc, 0x40f5, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose196:
+ax_pose 21, 0x01ec, 0x4108, 0x2c00
+ax_pose -1, 0x01ee, 0x40f4, 0x2c00
+ax_pose -1, 0x01dc, 0x40f5, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose197:
+ax_pose 22, 0x01ec, 0x4108, 0x2c00
+ax_pose -1, 0x01ee, 0x40f4, 0x2c00
+ax_pose -1, 0x01dc, 0x40f5, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose198:
+ax_pose 23, 0x01ec, 0x4108, 0x2c00
+ax_pose -1, 0x01ee, 0x40f4, 0x2c00
+ax_pose -1, 0x01dc, 0x40f5, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose199:
+ax_pose 24, 0x01ec, 0x4108, 0x2c00
+ax_pose -1, 0x01ee, 0x40f4, 0x2c00
+ax_pose -1, 0x01dc, 0x40f5, 0x2c00
+ax_pose 28, 0x01e2, 0x80f1, 0x2c04
+ax_pose_terminator
+sKoffingPose200:
+ax_pose 28, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sKoffingPose201:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose202:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose203:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose204:
+ax_pose 41, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose205:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose206:
+ax_pose 25, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose207:
+ax_pose 26, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose208:
+ax_pose 42, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose209:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose210:
+ax_pose 29, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose211:
+ax_pose 30, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose212:
+ax_pose 43, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose213:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose214:
+ax_pose 33, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose215:
+ax_pose 34, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose216:
+ax_pose 44, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose217:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose218:
+ax_pose 37, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose219:
+ax_pose 38, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose220:
+ax_pose 45, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose221:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose222:
+ax_pose 33, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose223:
+ax_pose 34, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose224:
+ax_pose 44, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose225:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose226:
+ax_pose 29, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose227:
+ax_pose 30, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose228:
+ax_pose 43, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose229:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose230:
+ax_pose 25, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose231:
+ax_pose 26, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose232:
+ax_pose 42, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose233:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose234:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose235:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose236:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose237:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose238:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose239:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose240:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose241:
+ax_pose 46, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose242:
+ax_pose 47, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose243:
+ax_pose 48, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose244:
+ax_pose 49, 0x01e4, 0x90ed, 0x2c00
+ax_pose_terminator
+sKoffingPose245:
+ax_pose 50, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sKoffingPose246:
+ax_pose 51, 0x01e4, 0x90ee, 0x2c00
+ax_pose_terminator
+sKoffingPose247:
+ax_pose 52, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose248:
+ax_pose 51, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sKoffingPose249:
+ax_pose 50, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sKoffingPose250:
+ax_pose 49, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sKoffingPose251:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose252:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose253:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose254:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose255:
+ax_pose 4, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose256:
+ax_pose 5, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose257:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose258:
+ax_pose 7, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose259:
+ax_pose 8, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose260:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose261:
+ax_pose 10, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose262:
+ax_pose 11, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose263:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose264:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose265:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose266:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose267:
+ax_pose 10, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose268:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose269:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose270:
+ax_pose 7, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose271:
+ax_pose 8, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose272:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose273:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose274:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose275:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose276:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose277:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose278:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose279:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose280:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose281:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose282:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose283:
+ax_pose 15, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose284:
+ax_pose 25, 0x01e3, 0x90f0, 0x2c00
+ax_pose_terminator
+sKoffingPose285:
+ax_pose 29, 0x01e3, 0x90f0, 0x2c00
+ax_pose_terminator
+sKoffingPose286:
+ax_pose 33, 0x01e3, 0x90f0, 0x2c00
+ax_pose_terminator
+sKoffingPose287:
+ax_pose 37, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose288:
+ax_pose 33, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose289:
+ax_pose 29, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose290:
+ax_pose 25, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose291:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose292:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose293:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose294:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose295:
+ax_pose 4, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose296:
+ax_pose 5, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose297:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose298:
+ax_pose 7, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose299:
+ax_pose 8, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose300:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose301:
+ax_pose 10, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose302:
+ax_pose 11, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose303:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose304:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose305:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose306:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose307:
+ax_pose 10, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose308:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose309:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose310:
+ax_pose 7, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose311:
+ax_pose 8, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose312:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose313:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose314:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose315:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose316:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose317:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose318:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose319:
+ax_pose 4, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose320:
+ax_pose 5, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose321:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose322:
+ax_pose 7, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose323:
+ax_pose 8, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose324:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose325:
+ax_pose 10, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose326:
+ax_pose 11, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose327:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose328:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose329:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose330:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose331:
+ax_pose 10, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose332:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose333:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose334:
+ax_pose 7, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose335:
+ax_pose 8, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose336:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose337:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose338:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose339:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose340:
+ax_pose 3, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose341:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sKoffingPose342:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose343:
+ax_pose 12, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sKoffingPose344:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sKoffingPose345:
+ax_pose 6, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sKoffingPose346:
+ax_pose 3, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+.align 2
+sKoffingAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_2_1:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 1, 0, 1, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 1, 0, 1, 0,
+ax_anim 4, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 2, 27, 0, 7, 0, 2,
+ax_anim 1, 0, 28, 0, 14, 0, 8,
+ax_anim 1, 0, 29, 0, 23, 0, 23,
+ax_anim 1, 1, 30, 1, 23, 1, 23,
+ax_anim 2, 0, 31, 0, 23, 0, 23,
+ax_anim 2, 0, 32, 1, 23, 1, 23,
+ax_anim 2, 0, 33, 0, 23, 0, 23,
+ax_anim 2, 0, 24, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sKoffingAnims_2_2:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 4, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 6, 6, 6, 6,
+ax_anim 1, 0, 39, 10, 12, 10, 12,
+ax_anim 1, 0, 40, 20, 23, 20, 23,
+ax_anim 1, 1, 41, 21, 22, 21, 22,
+ax_anim 2, 0, 42, 20, 23, 20, 23,
+ax_anim 2, 0, 43, 21, 22, 21, 22,
+ax_anim 2, 0, 44, 20, 23, 20, 23,
+ax_anim 2, 0, 35, 11, 13, 11, 13,
+ax_anim 2, 0, 35, 3, 4, 3, 4,
+ax_anim_terminator
+sKoffingAnims_2_3:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 2, 49, 5, 0, 2, 0,
+ax_anim 1, 0, 50, 10, 0, 8, 0,
+ax_anim 1, 0, 51, 20, 0, 20, 0,
+ax_anim 1, 1, 52, 20, 1, 20, 1,
+ax_anim 2, 0, 53, 20, 0, 20, 0,
+ax_anim 2, 0, 54, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 46, 11, 0, 11, 0,
+ax_anim 2, 0, 46, 3, 0, 3, 0,
+ax_anim_terminator
+sKoffingAnims_2_4:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 1, 1, 1, 1,
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 1, 1, 1, 1,
+ax_anim 4, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 2, 60, 4, -4, 4, -4,
+ax_anim 1, 0, 61, 13, -10, 13, -10,
+ax_anim 1, 0, 62, 22, -16, 22, -16,
+ax_anim 1, 1, 63, 23, -15, 23, -15,
+ax_anim 2, 0, 64, 22, -16, 22, -16,
+ax_anim 2, 0, 65, 23, -15, 23, -15,
+ax_anim 2, 0, 66, 22, -16, 22, -16,
+ax_anim 2, 0, 57, 14, -11, 14, -13,
+ax_anim 2, 0, 57, 5, -4, 5, -4,
+ax_anim_terminator
+sKoffingAnims_2_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 1, 0, 1, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 1, 0, 1, 0,
+ax_anim 4, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 2, 71, 0, -4, 0, -4,
+ax_anim 1, 0, 72, 0, -9, 0, -9,
+ax_anim 1, 0, 73, 0, -17, 0, -20,
+ax_anim 1, 1, 74, 1, -17, 1, -20,
+ax_anim 2, 0, 75, 0, -17, 0, -20,
+ax_anim 2, 0, 76, 1, -17, 1, -20,
+ax_anim 2, 0, 77, 0, -17, 0, -20,
+ax_anim 2, 0, 68, 0, -12, 0, -12,
+ax_anim 2, 0, 68, 0, -4, 0, -4,
+ax_anim_terminator
+sKoffingAnims_2_6:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 82, -4, -4, -4, -4,
+ax_anim 1, 0, 83, -13, -10, -13, -10,
+ax_anim 1, 0, 84, -22, -16, -22, -16,
+ax_anim 1, 1, 85, -23, -15, -23, -15,
+ax_anim 2, 0, 86, -22, -16, -22, -16,
+ax_anim 2, 0, 87, -23, -15, -23, -15,
+ax_anim 2, 0, 88, -22, -16, -22, -16,
+ax_anim 2, 0, 79, -14, -11, -14, -13,
+ax_anim 2, 0, 79, -5, -4, -5, -4,
+ax_anim_terminator
+sKoffingAnims_2_7:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, -5, 0, -2, 0,
+ax_anim 1, 0, 94, -10, 0, -8, 0,
+ax_anim 1, 0, 95, -20, 0, -20, 0,
+ax_anim 1, 1, 96, -20, 1, -20, 1,
+ax_anim 2, 0, 97, -20, 0, -20, 0,
+ax_anim 2, 0, 98, -20, 1, -20, 1,
+ax_anim 2, 0, 99, -20, 0, -20, 0,
+ax_anim 2, 0, 90, -11, 0, -11, 0,
+ax_anim 2, 0, 90, -3, 0, -3, 0,
+ax_anim_terminator
+sKoffingAnims_2_8:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 104, -6, 6, -6, 6,
+ax_anim 1, 0, 105, -10, 12, -10, 12,
+ax_anim 1, 0, 106, -20, 23, -20, 23,
+ax_anim 1, 1, 107, -21, 22, -21, 22,
+ax_anim 2, 0, 108, -20, 23, -20, 23,
+ax_anim 2, 0, 109, -21, 22, -21, 22,
+ax_anim 2, 0, 110, -20, 23, -20, 23,
+ax_anim 2, 0, 101, -11, 13, -11, 13,
+ax_anim 2, 0, 101, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sKoffingAnims_3_1:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 7, 0, 7,
+ax_anim 1, 0, 114, 0, 16, 0, 16,
+ax_anim 1, 0, 116, 0, 23, 0, 23,
+ax_anim 1, 1, 117, 1, 23, 1, 23,
+ax_anim 2, 0, 118, 0, 23, 0, 23,
+ax_anim 2, 0, 119, 1, 23, 1, 23,
+ax_anim 2, 0, 120, 0, 23, 0, 23,
+ax_anim 2, 0, 121, 1, 23, 0, 12,
+ax_anim 2, 0, 112, 0, 4, 0, 4,
+ax_anim_terminator
+sKoffingAnims_3_2:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 6, 6, 6, 6,
+ax_anim 1, 0, 125, 10, 12, 10, 12,
+ax_anim 1, 0, 127, 20, 23, 20, 23,
+ax_anim 1, 1, 128, 21, 22, 21, 22,
+ax_anim 2, 0, 129, 20, 23, 20, 23,
+ax_anim 2, 0, 130, 21, 22, 21, 22,
+ax_anim 2, 0, 131, 20, 23, 20, 23,
+ax_anim 2, 0, 132, 21, 23, 21, 23,
+ax_anim 2, 0, 123, 3, 4, 3, 4,
+ax_anim_terminator
+sKoffingAnims_3_3:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 1,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 5, 0, 2, 0,
+ax_anim 1, 0, 136, 10, 0, 8, 0,
+ax_anim 1, 0, 138, 20, 0, 20, 0,
+ax_anim 1, 1, 139, 20, 1, 20, 1,
+ax_anim 2, 0, 140, 20, 0, 20, 0,
+ax_anim 2, 0, 141, 20, 1, 20, 1,
+ax_anim 2, 0, 142, 20, 0, 20, 0,
+ax_anim 2, 0, 143, 11, 0, 11, 0,
+ax_anim 2, 0, 134, 3, 0, 3, 0,
+ax_anim_terminator
+sKoffingAnims_3_4:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 4, -4, 4, -4,
+ax_anim 1, 0, 147, 13, -10, 13, -10,
+ax_anim 1, 0, 149, 22, -16, 22, -16,
+ax_anim 1, 1, 150, 23, -15, 23, -15,
+ax_anim 2, 0, 151, 22, -16, 22, -16,
+ax_anim 2, 0, 152, 23, -15, 23, -15,
+ax_anim 2, 0, 153, 22, -16, 22, -16,
+ax_anim 2, 0, 154, 22, -15, 22, -15,
+ax_anim 2, 0, 145, 5, -4, 5, -4,
+ax_anim_terminator
+sKoffingAnims_3_5:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 2, 158, 0, -4, 0, -4,
+ax_anim 1, 0, 158, 0, -9, 0, -9,
+ax_anim 1, 0, 160, 0, -17, 0, -20,
+ax_anim 1, 1, 161, 1, -17, 1, -20,
+ax_anim 2, 0, 162, 0, -17, 0, -20,
+ax_anim 2, 0, 163, 1, -17, 1, -20,
+ax_anim 2, 0, 164, 0, -17, 0, -20,
+ax_anim 2, 0, 165, 1, -17, 1, -20,
+ax_anim 2, 0, 156, 0, -4, 0, -4,
+ax_anim_terminator
+sKoffingAnims_3_6:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 1, -1, 1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 1, -1, 1,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 2, 169, -4, -4, -4, -4,
+ax_anim 1, 0, 169, -13, -10, -13, -10,
+ax_anim 1, 0, 171, -22, -16, -22, -16,
+ax_anim 1, 1, 172, -23, -15, -23, -15,
+ax_anim 2, 0, 173, -22, -16, -22, -16,
+ax_anim 2, 0, 174, -23, -15, -23, -15,
+ax_anim 2, 0, 175, -22, -16, -22, -16,
+ax_anim 2, 0, 176, -22, -15, -22, -15,
+ax_anim 2, 0, 167, -5, -4, -5, -4,
+ax_anim_terminator
+sKoffingAnims_3_7:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 1, 0, 1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 1, 0, 1,
+ax_anim 4, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 180, -5, 0, -2, 0,
+ax_anim 1, 0, 180, -10, 0, -8, 0,
+ax_anim 1, 0, 182, -20, 0, -20, 0,
+ax_anim 1, 1, 183, -20, 1, -20, 1,
+ax_anim 2, 0, 184, -20, 0, -20, 0,
+ax_anim 2, 0, 185, -20, 1, -20, 1,
+ax_anim 2, 0, 186, -20, 0, -20, 0,
+ax_anim 2, 0, 187, -11, 0, -11, 0,
+ax_anim 2, 0, 178, -3, 0, -3, 0,
+ax_anim_terminator
+sKoffingAnims_3_8:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 4, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 191, -6, 6, -6, 6,
+ax_anim 1, 0, 191, -10, 12, -10, 12,
+ax_anim 1, 0, 193, -20, 23, -20, 23,
+ax_anim 1, 1, 194, -21, 22, -21, 22,
+ax_anim 2, 0, 195, -20, 23, -20, 23,
+ax_anim 2, 0, 196, -21, 22, -21, 22,
+ax_anim 2, 0, 197, -20, 23, -20, 23,
+ax_anim 2, 0, 198, -21, 23, -21, 23,
+ax_anim 2, 0, 189, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sKoffingAnims_4_1:
+ax_anim 1, 0, 201, 0, -1, 0, 0,
+ax_anim 1, 0, 202, 0, -2, 0, 1,
+ax_anim 1, 0, 202, 1, -3, 1, 2,
+ax_anim 2, 2, 202, 0, -3, 0, 2,
+ax_anim 2, 0, 202, 1, -3, 1, 2,
+ax_anim 2, 0, 202, 0, -3, 0, 2,
+ax_anim 2, 0, 202, 1, -3, 1, 2,
+ax_anim 1, 0, 203, 0, 6, 0, 6,
+ax_anim 2, 1, 203, 0, 8, 0, 8,
+ax_anim 2, 0, 203, 1, 8, 1, 8,
+ax_anim 2, 0, 203, 0, 8, 0, 8,
+ax_anim 2, 0, 203, 1, 8, 1, 8,
+ax_anim 2, 0, 203, 0, 8, 0, 8,
+ax_anim 2, 0, 203, 1, 8, 1, 8,
+ax_anim 2, 0, 203, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 2, 0, 2,
+ax_anim_terminator
+sKoffingAnims_4_2:
+ax_anim 1, 0, 205, -1, -1, -1, -1,
+ax_anim 1, 0, 206, -2, -2, -2, -2,
+ax_anim 1, 0, 206, -3, -3, -3, -3,
+ax_anim 2, 2, 206, -4, -2, -4, -2,
+ax_anim 2, 0, 206, -3, -3, -3, -3,
+ax_anim 2, 0, 206, -4, -2, -4, -2,
+ax_anim 2, 0, 206, -3, -3, -3, -3,
+ax_anim 1, 0, 207, 6, 6, 6, 6,
+ax_anim 2, 1, 207, 8, 8, 8, 8,
+ax_anim 2, 0, 207, 9, 7, 9, 7,
+ax_anim 2, 0, 207, 8, 8, 8, 8,
+ax_anim 2, 0, 207, 9, 7, 9, 7,
+ax_anim 2, 0, 207, 8, 8, 8, 8,
+ax_anim 2, 0, 207, 9, 7, 9, 7,
+ax_anim 2, 0, 207, 6, 6, 6, 6,
+ax_anim 2, 0, 204, 2, 2, 2, 2,
+ax_anim_terminator
+sKoffingAnims_4_3:
+ax_anim 1, 0, 209, -1, 0, -1, 0,
+ax_anim 1, 0, 210, -2, -1, -2, 0,
+ax_anim 1, 0, 210, -3, -2, -3, 0,
+ax_anim 2, 2, 210, -3, -3, -4, -1,
+ax_anim 2, 0, 210, -3, -2, -3, 0,
+ax_anim 2, 0, 210, -3, -3, -4, -1,
+ax_anim 2, 0, 210, -3, -2, -3, 0,
+ax_anim 1, 0, 211, 6, 0, 6, 0,
+ax_anim 2, 1, 211, 8, 0, 8, 0,
+ax_anim 2, 0, 211, 8, -1, 9, 0,
+ax_anim 2, 0, 211, 8, 0, 8, 0,
+ax_anim 2, 0, 211, 8, -1, 9, 0,
+ax_anim 2, 0, 211, 8, 0, 8, 0,
+ax_anim 2, 0, 211, 8, -1, 9, 0,
+ax_anim 2, 0, 211, 6, 0, 6, 0,
+ax_anim 2, 0, 208, 2, 0, 2, 0,
+ax_anim_terminator
+sKoffingAnims_4_4:
+ax_anim 1, 0, 213, -1, 1, -1, 1,
+ax_anim 1, 0, 214, -2, 2, -2, 2,
+ax_anim 1, 0, 214, -3, 3, -3, 3,
+ax_anim 2, 2, 214, -4, 2, -4, 2,
+ax_anim 2, 0, 214, -3, 3, -3, 3,
+ax_anim 2, 0, 214, -4, 2, -4, 2,
+ax_anim 2, 0, 214, -3, 3, -3, 3,
+ax_anim 1, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 1, 215, 8, -8, 8, -8,
+ax_anim 2, 0, 215, 9, -7, 9, -7,
+ax_anim 2, 0, 215, 8, -8, 8, -8,
+ax_anim 2, 0, 215, 9, -7, 9, -7,
+ax_anim 2, 0, 215, 8, -8, 8, -8,
+ax_anim 2, 0, 215, 9, -7, 9, -7,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 212, 2, -2, 2, -2,
+ax_anim_terminator
+sKoffingAnims_4_5:
+ax_anim 1, 0, 217, 0, 1, 0, 0,
+ax_anim 1, 0, 218, 0, 2, 0, 1,
+ax_anim 1, 0, 218, 1, 3, 1, 2,
+ax_anim 2, 2, 218, 0, 3, 0, 2,
+ax_anim 2, 0, 218, 1, 3, 1, 2,
+ax_anim 2, 0, 218, 0, 3, 0, 2,
+ax_anim 2, 0, 218, 1, 3, 1, 2,
+ax_anim 1, 0, 219, 0, -6, 0, -6,
+ax_anim 2, 1, 219, 0, -8, 0, -8,
+ax_anim 2, 0, 219, 1, -8, 1, -8,
+ax_anim 2, 0, 219, 0, -8, 0, -8,
+ax_anim 2, 0, 219, 1, -8, 1, -8,
+ax_anim 2, 0, 219, 0, -8, 0, -8,
+ax_anim 2, 0, 219, 1, -8, 1, -8,
+ax_anim 2, 0, 219, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, -2, 0, -2,
+ax_anim_terminator
+sKoffingAnims_4_6:
+ax_anim 1, 0, 221, 1, 1, 1, 1,
+ax_anim 1, 0, 222, 2, 2, 2, 2,
+ax_anim 1, 0, 222, 3, 3, 3, 3,
+ax_anim 2, 2, 222, 4, 2, 4, 2,
+ax_anim 2, 0, 222, 3, 3, 3, 3,
+ax_anim 2, 0, 222, 4, 2, 4, 2,
+ax_anim 2, 0, 222, 3, 3, 3, 3,
+ax_anim 1, 0, 223, -6, -6, -6, -6,
+ax_anim 2, 1, 223, -8, -8, -8, -8,
+ax_anim 2, 0, 223, -9, -7, -9, -7,
+ax_anim 2, 0, 223, -8, -8, -8, -8,
+ax_anim 2, 0, 223, -9, -7, -9, -7,
+ax_anim 2, 0, 223, -8, -8, -8, -8,
+ax_anim 2, 0, 223, -9, -7, -9, -7,
+ax_anim 2, 0, 223, -6, -6, -6, -6,
+ax_anim 2, 0, 220, -2, -2, -2, -2,
+ax_anim_terminator
+sKoffingAnims_4_7:
+ax_anim 1, 0, 225, 1, 0, 1, 0,
+ax_anim 1, 0, 226, 2, -1, 2, 0,
+ax_anim 1, 0, 226, 3, -2, 3, 0,
+ax_anim 2, 2, 226, 3, -3, 4, -1,
+ax_anim 2, 0, 226, 3, -2, 3, 0,
+ax_anim 2, 0, 226, 3, -3, 4, -1,
+ax_anim 2, 0, 226, 3, -2, 3, 0,
+ax_anim 1, 0, 227, -6, 0, -6, 0,
+ax_anim 2, 1, 227, -8, 0, -8, 0,
+ax_anim 2, 0, 227, -8, -1, -9, 0,
+ax_anim 2, 0, 227, -8, 0, -8, 0,
+ax_anim 2, 0, 227, -8, -1, -9, 0,
+ax_anim 2, 0, 227, -8, 0, -8, 0,
+ax_anim 2, 0, 227, -8, -1, -9, 0,
+ax_anim 2, 0, 227, -6, 0, -6, 0,
+ax_anim 2, 0, 224, -2, 0, -2, 0,
+ax_anim_terminator
+sKoffingAnims_4_8:
+ax_anim 1, 0, 229, 1, -1, 1, -1,
+ax_anim 1, 0, 230, 2, -2, 2, -2,
+ax_anim 1, 0, 230, 3, -3, 3, -3,
+ax_anim 2, 2, 230, 4, -2, 4, -2,
+ax_anim 2, 0, 230, 3, -3, 3, -3,
+ax_anim 2, 0, 230, 4, -2, 4, -2,
+ax_anim 2, 0, 230, 3, -3, 3, -3,
+ax_anim 1, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 1, 231, -8, 8, -8, 8,
+ax_anim 2, 0, 231, -9, 7, -9, 7,
+ax_anim 2, 0, 231, -8, 8, -8, 8,
+ax_anim 2, 0, 231, -9, 7, -9, 7,
+ax_anim 2, 0, 231, -8, 8, -8, 8,
+ax_anim 2, 0, 231, -9, 7, -9, 7,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 228, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sKoffingAnims_5_1:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_5_2:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_5_3:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_5_4:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_5_5:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_5_6:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_5_7:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_5_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_6_1:
+ax_anim 16, 0, 240, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, -1, 0, 0,
+ax_anim 16, 0, 240, 0, -2, 0, 0,
+ax_anim 16, 0, 241, 0, -2, 0, 0,
+ax_anim 12, 0, 241, 0, -1, 0, 0,
+ax_anim 16, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_7_1:
+ax_anim 2, 0, 242, 0, -2, 0, -2,
+ax_anim 8, 0, 242, 0, -3, 0, -3,
+ax_anim_terminator
+sKoffingAnims_7_2:
+ax_anim 2, 0, 243, -2, -2, -2, -2,
+ax_anim 8, 0, 243, -3, -3, -3, -3,
+ax_anim_terminator
+sKoffingAnims_7_3:
+ax_anim 2, 0, 244, -2, 0, -2, 0,
+ax_anim 8, 0, 244, -3, 0, -3, 0,
+ax_anim_terminator
+sKoffingAnims_7_4:
+ax_anim 2, 0, 245, -2, 2, -2, 2,
+ax_anim 8, 0, 245, -3, 3, -3, 3,
+ax_anim_terminator
+sKoffingAnims_7_5:
+ax_anim 2, 0, 246, 0, 2, 0, 2,
+ax_anim 8, 0, 246, 0, 3, 0, 3,
+ax_anim_terminator
+sKoffingAnims_7_6:
+ax_anim 2, 0, 247, 2, 2, 2, 2,
+ax_anim 8, 0, 247, 3, 3, 3, 3,
+ax_anim_terminator
+sKoffingAnims_7_7:
+ax_anim 2, 0, 248, 2, 0, 2, 0,
+ax_anim 8, 0, 248, 3, 0, 3, 0,
+ax_anim_terminator
+sKoffingAnims_7_8:
+ax_anim 2, 0, 249, 2, -2, 2, -2,
+ax_anim 8, 0, 249, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sKoffingAnims_8_1:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 251, 0, -1, 0, 0,
+ax_anim 8, 0, 252, 0, -1, 0, 0,
+ax_anim 10, 0, 250, 0, -1, 0, 0,
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_8_2:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 10, 0, 254, 0, -1, 0, 0,
+ax_anim 8, 0, 255, 0, -1, 0, 0,
+ax_anim 10, 0, 253, 0, -1, 0, 0,
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_8_3:
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, -1, 0, 0,
+ax_anim 8, 0, 258, 0, -1, 0, 0,
+ax_anim 10, 0, 256, 0, -1, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_8_4:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 260, 0, -1, 0, 0,
+ax_anim 8, 0, 261, 0, -1, 0, 0,
+ax_anim 10, 0, 259, 0, -1, 0, 0,
+ax_anim 10, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_8_5:
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, -1, 0, 0,
+ax_anim 8, 0, 264, 0, -1, 0, 0,
+ax_anim 10, 0, 262, 0, -1, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_8_6:
+ax_anim 10, 0, 265, 0, 0, 0, 0,
+ax_anim 10, 0, 266, 0, -1, 0, 0,
+ax_anim 8, 0, 267, 0, -1, 0, 0,
+ax_anim 10, 0, 265, 0, -1, 0, 0,
+ax_anim 10, 0, 266, 0, 0, 0, 0,
+ax_anim 8, 0, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_8_7:
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim 10, 0, 269, 0, -1, 0, 0,
+ax_anim 8, 0, 270, 0, -1, 0, 0,
+ax_anim 10, 0, 268, 0, -1, 0, 0,
+ax_anim 10, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_8_8:
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, -1, 0, 0,
+ax_anim 8, 0, 273, 0, -1, 0, 0,
+ax_anim 10, 0, 271, 0, -1, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim 8, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_9_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 275, 6, 3, 6, 3,
+ax_anim 2, 0, 276, 8, 11, 8, 11,
+ax_anim 2, 0, 277, 7, 20, 7, 18,
+ax_anim 3, 0, 278, 0, 25, 0, 22,
+ax_anim 2, 3, 279, -7, 20, -7, 18,
+ax_anim 2, 0, 280, -8, 11, -8, 11,
+ax_anim 1, 0, 281, -6, 3, -6, 3,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_9_2:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 8, 0, 8, 0,
+ax_anim 2, 0, 275, 17, 6, 17, 6,
+ax_anim 2, 0, 276, 20, 16, 20, 15,
+ax_anim 3, 0, 277, 21, 25, 21, 22,
+ax_anim 2, 3, 278, 11, 26, 11, 24,
+ax_anim 2, 0, 279, 3, 15, 3, 15,
+ax_anim 1, 0, 280, 0, 7, 0, 7,
+ax_anim 1, 0, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_9_3:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 1, 0, 281, 4, -3, 4, -3,
+ax_anim 2, 0, 274, 11, -4, 11, -4,
+ax_anim 2, 0, 275, 18, -2, 18, -3,
+ax_anim 3, 0, 276, 22, 4, 22, 1,
+ax_anim 2, 3, 277, 17, 6, 17, 4,
+ax_anim 2, 0, 278, 10, 6, 10, 5,
+ax_anim 1, 0, 279, 4, 5, 4, 4,
+ax_anim 1, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_9_4:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 1, 0, 280, -1, -8, -1, -8,
+ax_anim 2, 0, 281, 4, -14, 4, -14,
+ax_anim 2, 0, 274, 12, -18, 12, -19,
+ax_anim 3, 0, 275, 21, -17, 21, -20,
+ax_anim 2, 3, 276, 20, -12, 20, -14,
+ax_anim 2, 0, 277, 17, -5, 17, -6,
+ax_anim 1, 0, 278, 7, -1, 7, -1,
+ax_anim 1, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_9_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 1, 0, 279, -8, -4, -8, -4,
+ax_anim 2, 0, 280, -9, -12, -9, -12,
+ax_anim 2, 0, 281, -7, -16, -7, -18,
+ax_anim 3, 0, 274, 0, -19, 0, -22,
+ax_anim 2, 3, 275, 7, -16, 7, -18,
+ax_anim 2, 0, 276, 9, -10, 9, -10,
+ax_anim 1, 0, 277, 8, -4, 8, -4,
+ax_anim 1, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_9_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 1, 0, 276, 1, -8, 1, -8,
+ax_anim 2, 0, 275, -4, -14, -4, -14,
+ax_anim 2, 0, 274, -12, -18, -12, -19,
+ax_anim 3, 0, 281, -21, -17, -21, -20,
+ax_anim 2, 3, 280, -20, -12, -20, -14,
+ax_anim 2, 0, 279, -17, -5, -17, -5,
+ax_anim 1, 0, 278, -7, -1, -7, -1,
+ax_anim 1, 0, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_9_7:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 1, 0, 275, -4, -3, -4, -3,
+ax_anim 2, 0, 274, -11, -4, -11, -4,
+ax_anim 2, 0, 281, -18, -2, -18, -3,
+ax_anim 3, 0, 280, -22, 4, -22, 1,
+ax_anim 2, 3, 279, -17, 6, -17, 4,
+ax_anim 2, 0, 278, -10, 6, -10, 5,
+ax_anim 1, 0, 277, -4, 5, -4, 4,
+ax_anim 1, 0, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_9_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 1, 0, 274, -8, 0, -8, 0,
+ax_anim 2, 0, 281, -17, 6, -17, 6,
+ax_anim 2, 0, 280, -20, 16, -20, 15,
+ax_anim 3, 0, 279, -21, 25, -21, 22,
+ax_anim 2, 3, 278, -11, 26, -11, 24,
+ax_anim 2, 0, 277, -3, 15, -3, 15,
+ax_anim 1, 0, 276, 0, 7, 0, 7,
+ax_anim 1, 0, 275, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_10_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 6, 0, 6, 0,
+ax_anim 2, 0, 282, -6, 0, -6, 0,
+ax_anim 2, 0, 282, 10, 0, 10, 0,
+ax_anim 2, 0, 282, -10, 0, -10, 0,
+ax_anim 2, 0, 282, 12, 0, 12, 0,
+ax_anim 3, 0, 282, -12, 0, -12, 0,
+ax_anim 3, 0, 282, 13, 0, 13, 0,
+ax_anim 3, 0, 282, -13, 0, -13, 0,
+ax_anim 2, 0, 282, 12, 0, 12, 0,
+ax_anim 3, 0, 282, -12, 0, -12, 0,
+ax_anim 2, 0, 282, 10, 0, 10, 0,
+ax_anim 2, 0, 282, -10, 0, -10, 0,
+ax_anim 2, 0, 282, 6, 0, 6, 0,
+ax_anim 2, 0, 282, -6, 0, -6, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_10_2:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 6, -6, 6, -6,
+ax_anim 2, 0, 283, -6, 6, -6, 6,
+ax_anim 2, 0, 283, 10, -10, 10, -10,
+ax_anim 2, 0, 283, -10, 10, -10, 10,
+ax_anim 2, 0, 283, 12, -12, 12, -12,
+ax_anim 3, 0, 283, -12, 12, -12, 12,
+ax_anim 3, 0, 283, 13, -13, 13, -13,
+ax_anim 3, 0, 283, -13, 13, -13, 13,
+ax_anim 2, 0, 283, 12, -12, 12, -12,
+ax_anim 3, 0, 283, -12, 12, -12, 12,
+ax_anim 2, 0, 283, 10, -10, 10, -10,
+ax_anim 2, 0, 283, -10, 10, -10, 10,
+ax_anim 2, 0, 283, 6, -6, 6, -6,
+ax_anim 2, 0, 283, -6, 6, -6, 6,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_10_3:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -6, 0, -6,
+ax_anim 2, 0, 284, 0, 6, 0, 6,
+ax_anim 2, 0, 284, 0, -10, 0, -10,
+ax_anim 2, 0, 284, 0, 10, 0, 10,
+ax_anim 2, 0, 284, 0, -12, 0, -12,
+ax_anim 3, 0, 284, 0, 12, 0, 12,
+ax_anim 3, 0, 284, 0, -13, 0, -13,
+ax_anim 3, 0, 284, 0, 13, 0, 13,
+ax_anim 2, 0, 284, 0, -12, 0, -12,
+ax_anim 3, 0, 284, 0, 12, 0, 12,
+ax_anim 2, 0, 284, 0, -10, 0, -10,
+ax_anim 2, 0, 284, 0, 10, 0, 10,
+ax_anim 2, 0, 284, 0, -6, 0, -6,
+ax_anim 2, 0, 284, 0, 6, 0, 6,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_10_4:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, -6, -6, -6, -6,
+ax_anim 2, 0, 285, 6, 6, 6, 6,
+ax_anim 2, 0, 285, -10, -10, -10, -10,
+ax_anim 2, 0, 285, 10, 10, 10, 10,
+ax_anim 2, 0, 285, -12, -12, -12, -12,
+ax_anim 3, 0, 285, 12, 12, 12, 12,
+ax_anim 3, 0, 285, -13, -13, -13, -13,
+ax_anim 3, 0, 285, 13, 13, 13, 13,
+ax_anim 2, 0, 285, -12, -12, -12, -12,
+ax_anim 3, 0, 285, 12, 12, 12, 12,
+ax_anim 2, 0, 285, -10, -10, -10, -10,
+ax_anim 2, 0, 285, 10, 10, 10, 10,
+ax_anim 2, 0, 285, -6, -6, -6, -6,
+ax_anim 2, 0, 285, 6, 6, 6, 6,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_10_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 6, 0, 6, 0,
+ax_anim 2, 0, 286, -6, 0, -6, 0,
+ax_anim 2, 0, 286, 10, 0, 10, 0,
+ax_anim 2, 0, 286, -10, 0, -10, 0,
+ax_anim 2, 0, 286, 12, 0, 12, 0,
+ax_anim 3, 0, 286, -12, 0, -12, 0,
+ax_anim 3, 0, 286, 13, 0, 13, 0,
+ax_anim 3, 0, 286, -13, 0, -13, 0,
+ax_anim 2, 0, 286, 12, 0, 12, 0,
+ax_anim 3, 0, 286, -12, 0, -12, 0,
+ax_anim 2, 0, 286, 10, 0, 10, 0,
+ax_anim 2, 0, 286, -10, 0, -10, 0,
+ax_anim 2, 0, 286, 6, 0, 6, 0,
+ax_anim 2, 0, 286, -6, 0, -6, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_10_6:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 6, -6, 6, -6,
+ax_anim 2, 0, 287, -6, 6, -6, 6,
+ax_anim 2, 0, 287, 10, -10, 10, -10,
+ax_anim 2, 0, 287, -10, 10, -10, 10,
+ax_anim 2, 0, 287, 12, -12, 12, -12,
+ax_anim 3, 0, 287, -12, 12, -12, 12,
+ax_anim 3, 0, 287, 13, -13, 13, -13,
+ax_anim 3, 0, 287, -13, 13, -13, 13,
+ax_anim 2, 0, 287, 12, -12, 12, -12,
+ax_anim 3, 0, 287, -12, 12, -12, 12,
+ax_anim 2, 0, 287, 10, -10, 10, -10,
+ax_anim 2, 0, 287, -10, 10, -10, 10,
+ax_anim 2, 0, 287, 6, -6, 6, -6,
+ax_anim 2, 0, 287, -6, 6, -6, 6,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_10_7:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -6, 0, -6,
+ax_anim 2, 0, 288, 0, 6, 0, 6,
+ax_anim 2, 0, 288, 0, -10, 0, -10,
+ax_anim 2, 0, 288, 0, 10, 0, 10,
+ax_anim 2, 0, 288, 0, -12, 0, -12,
+ax_anim 3, 0, 288, 0, 12, 0, 12,
+ax_anim 3, 0, 288, 0, -13, 0, -13,
+ax_anim 3, 0, 288, 0, 13, 0, 13,
+ax_anim 2, 0, 288, 0, -12, 0, -12,
+ax_anim 3, 0, 288, 0, 12, 0, 12,
+ax_anim 2, 0, 288, 0, -10, 0, -10,
+ax_anim 2, 0, 288, 0, 10, 0, 10,
+ax_anim 2, 0, 288, 0, -6, 0, -6,
+ax_anim 2, 0, 288, 0, 6, 0, 6,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_10_8:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, -6, -6, -6, -6,
+ax_anim 2, 0, 289, 6, 6, 6, 6,
+ax_anim 2, 0, 289, -10, -10, -10, -10,
+ax_anim 2, 0, 289, 10, 10, 10, 10,
+ax_anim 2, 0, 289, -12, -12, -12, -12,
+ax_anim 3, 0, 289, 12, 12, 12, 12,
+ax_anim 3, 0, 289, -13, -13, -13, -13,
+ax_anim 3, 0, 289, 13, 13, 13, 13,
+ax_anim 2, 0, 289, -12, -12, -12, -12,
+ax_anim 3, 0, 289, 12, 12, 12, 12,
+ax_anim 2, 0, 289, -10, -10, -10, -10,
+ax_anim 2, 0, 289, 10, 10, 10, 10,
+ax_anim 2, 0, 289, -6, -6, -6, -6,
+ax_anim 2, 0, 289, 6, 6, 6, 6,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_11_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 1, 0, 291, 0, -10, 0, 0,
+ax_anim 2, 0, 292, 0, -16, 0, 0,
+ax_anim 3, 0, 290, 0, -20, 0, 0,
+ax_anim 4, 0, 291, 0, -21, 0, 0,
+ax_anim 4, 0, 292, 0, -23, 0, 0,
+ax_anim 3, 0, 290, 0, -22, 0, 0,
+ax_anim 2, 0, 291, 0, -18, 0, 0,
+ax_anim 1, 0, 292, 0, -10, 0, 0,
+ax_anim 2, 2, 290, 0, 5, 0, 0,
+ax_anim_terminator
+sKoffingAnims_11_2:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 1, 0, 294, 0, -10, 0, 0,
+ax_anim 2, 0, 295, 0, -16, 0, 0,
+ax_anim 3, 0, 293, 0, -20, 0, 0,
+ax_anim 4, 0, 294, 0, -21, 0, 0,
+ax_anim 4, 0, 295, 0, -23, 0, 0,
+ax_anim 3, 0, 293, 0, -22, 0, 0,
+ax_anim 2, 0, 294, 0, -18, 0, 0,
+ax_anim 1, 0, 295, 0, -10, 0, 0,
+ax_anim 2, 2, 293, 0, 5, 0, 0,
+ax_anim_terminator
+sKoffingAnims_11_3:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 1, 0, 297, 0, -10, 0, 0,
+ax_anim 2, 0, 298, 0, -16, 0, 0,
+ax_anim 3, 0, 296, 0, -20, 0, 0,
+ax_anim 4, 0, 297, 0, -21, 0, 0,
+ax_anim 4, 0, 298, 0, -23, 0, 0,
+ax_anim 3, 0, 296, 0, -22, 0, 0,
+ax_anim 2, 0, 297, 0, -18, 0, 0,
+ax_anim 1, 0, 298, 0, -10, 0, 0,
+ax_anim 2, 2, 296, 0, 5, 0, 0,
+ax_anim_terminator
+sKoffingAnims_11_4:
+ax_anim 2, 0, 299, 0, 0, 0, 0,
+ax_anim 1, 0, 300, 0, -10, 0, 0,
+ax_anim 2, 0, 301, 0, -16, 0, 0,
+ax_anim 3, 0, 299, 0, -20, 0, 0,
+ax_anim 4, 0, 300, 0, -21, 0, 0,
+ax_anim 4, 0, 301, 0, -22, 0, 0,
+ax_anim 3, 0, 299, 0, -21, 0, 0,
+ax_anim 2, 0, 300, 0, -17, 0, 0,
+ax_anim 1, 0, 301, 0, -9, 0, 0,
+ax_anim 2, 2, 299, 0, 5, 0, 0,
+ax_anim_terminator
+sKoffingAnims_11_5:
+ax_anim 2, 0, 302, 0, 0, 0, 0,
+ax_anim 1, 0, 303, 0, -10, 0, 0,
+ax_anim 2, 0, 304, 0, -16, 0, 0,
+ax_anim 3, 0, 302, 0, -20, 0, 0,
+ax_anim 4, 0, 303, 0, -21, 0, 0,
+ax_anim 4, 0, 304, 0, -23, 0, 0,
+ax_anim 3, 0, 302, 0, -22, 0, 0,
+ax_anim 2, 0, 303, 0, -18, 0, 0,
+ax_anim 1, 0, 304, 0, -10, 0, 0,
+ax_anim 2, 2, 302, 0, 5, 0, 0,
+ax_anim_terminator
+sKoffingAnims_11_6:
+ax_anim 2, 0, 305, 0, 0, 0, 0,
+ax_anim 1, 0, 306, 0, -10, 0, 0,
+ax_anim 2, 0, 307, 0, -16, 0, 0,
+ax_anim 3, 0, 305, 0, -20, 0, 0,
+ax_anim 4, 0, 306, 0, -21, 0, 0,
+ax_anim 4, 0, 307, 0, -22, 0, 0,
+ax_anim 3, 0, 305, 0, -21, 0, 0,
+ax_anim 2, 0, 306, 0, -17, 0, 0,
+ax_anim 1, 0, 307, 0, -9, 0, 0,
+ax_anim 2, 2, 305, 0, 5, 0, 0,
+ax_anim_terminator
+sKoffingAnims_11_7:
+ax_anim 2, 0, 308, 0, 0, 0, 0,
+ax_anim 1, 0, 309, 0, -10, 0, 0,
+ax_anim 2, 0, 310, 0, -16, 0, 0,
+ax_anim 3, 0, 308, 0, -20, 0, 0,
+ax_anim 4, 0, 309, 0, -21, 0, 0,
+ax_anim 4, 0, 310, 0, -23, 0, 0,
+ax_anim 3, 0, 308, 0, -22, 0, 0,
+ax_anim 2, 0, 309, 0, -18, 0, 0,
+ax_anim 1, 0, 310, 0, -10, 0, 0,
+ax_anim 2, 2, 308, 0, 5, 0, 0,
+ax_anim_terminator
+sKoffingAnims_11_8:
+ax_anim 2, 0, 311, 0, 0, 0, 0,
+ax_anim 1, 0, 312, 0, -10, 0, 0,
+ax_anim 2, 0, 313, 0, -16, 0, 0,
+ax_anim 3, 0, 311, 0, -20, 0, 0,
+ax_anim 4, 0, 312, 0, -21, 0, 0,
+ax_anim 4, 0, 313, 0, -23, 0, 0,
+ax_anim 3, 0, 311, 0, -22, 0, 0,
+ax_anim 2, 0, 312, 0, -18, 0, 0,
+ax_anim 1, 0, 313, 0, -10, 0, 0,
+ax_anim 2, 2, 311, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_12_1:
+ax_anim 2, 0, 314, 1, 0, 1, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 1, 0, 1, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 1, 0, 1, 0,
+ax_anim 2, 2, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 1, 0, 1, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 1, 0, 1, 0,
+ax_anim 2, 1, 314, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_12_2:
+ax_anim 2, 0, 317, 1, -1, 1, -1,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 1, -1, 1, -1,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 1, -1, 1, -1,
+ax_anim 2, 2, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 1, -1, 1, -1,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 1, -1, 1, -1,
+ax_anim 2, 1, 317, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_12_3:
+ax_anim 2, 0, 320, 0, -1, 0, -1,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 0, -1, 0, -1,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, -1, 0, -1,
+ax_anim 2, 2, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, -1, 0, -1,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 0, -1, 0, -1,
+ax_anim 2, 1, 320, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_12_4:
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 325, -1, -1, -1, -1,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 324, -1, -1, -1, -1,
+ax_anim 2, 2, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 325, -1, -1, -1, -1,
+ax_anim 2, 1, 323, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_12_5:
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 1, 0, 1, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 327, 1, 0, 1, 0,
+ax_anim 2, 2, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 1, 0, 1, 0,
+ax_anim 2, 1, 326, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_12_6:
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 1, -1, 1, -1,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 1, -1, 1, -1,
+ax_anim 2, 2, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 1, -1, 1, -1,
+ax_anim 2, 1, 329, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_12_7:
+ax_anim 2, 0, 332, 0, -1, 0, -1,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, -1, 0, -1,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, -1, 0, -1,
+ax_anim 2, 2, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, -1, 0, -1,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, -1, 0, -1,
+ax_anim 2, 1, 332, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_12_8:
+ax_anim 2, 0, 335, -1, -1, -1, -1,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, -1, -1, -1, -1,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, -1, -1, -1, -1,
+ax_anim 2, 2, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 335, -1, -1, -1, -1,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, -1, -1, -1, -1,
+ax_anim 2, 1, 335, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKoffingAnims_13_1:
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 2, 338, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_13_2:
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 2, 345, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_13_3:
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 2, 344, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_13_4:
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 2, 343, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_13_5:
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 2, 342, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_13_6:
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 2, 341, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_13_7:
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 2, 340, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingAnims_13_8:
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 2, 339, 0, 0, 0, 0,
+ax_anim_terminator
+sKoffingGfx1:
+.incbin "baserom.gba", 0x9B4440, 0x200
+sKoffingSprites1:
+ax_sprite sKoffingGfx1, 0x200
+ax_sprite_terminator
+sKoffingGfx2:
+.incbin "baserom.gba", 0x9B4650, 0x200
+sKoffingSprites2:
+ax_sprite sKoffingGfx2, 0x200
+ax_sprite_terminator
+sKoffingGfx3:
+.incbin "baserom.gba", 0x9B4860, 0x200
+sKoffingSprites3:
+ax_sprite sKoffingGfx3, 0x200
+ax_sprite_terminator
+sKoffingGfx4:
+.incbin "baserom.gba", 0x9B4A70, 0x200
+sKoffingSprites4:
+ax_sprite sKoffingGfx4, 0x200
+ax_sprite_terminator
+sKoffingGfx5:
+.incbin "baserom.gba", 0x9B4C80, 0x200
+sKoffingSprites5:
+ax_sprite sKoffingGfx5, 0x200
+ax_sprite_terminator
+sKoffingGfx6:
+.incbin "baserom.gba", 0x9B4E90, 0x200
+sKoffingSprites6:
+ax_sprite sKoffingGfx6, 0x200
+ax_sprite_terminator
+sKoffingGfx7:
+.incbin "baserom.gba", 0x9B50A0, 0x200
+sKoffingSprites7:
+ax_sprite sKoffingGfx7, 0x200
+ax_sprite_terminator
+sKoffingGfx8:
+.incbin "baserom.gba", 0x9B52B0, 0x200
+sKoffingSprites8:
+ax_sprite sKoffingGfx8, 0x200
+ax_sprite_terminator
+sKoffingGfx9:
+.incbin "baserom.gba", 0x9B54C0, 0x200
+sKoffingSprites9:
+ax_sprite sKoffingGfx9, 0x200
+ax_sprite_terminator
+sKoffingGfx10:
+.incbin "baserom.gba", 0x9B56D0, 0x200
+sKoffingSprites10:
+ax_sprite sKoffingGfx10, 0x200
+ax_sprite_terminator
+sKoffingGfx11:
+.incbin "baserom.gba", 0x9B58E0, 0x200
+sKoffingSprites11:
+ax_sprite sKoffingGfx11, 0x200
+ax_sprite_terminator
+sKoffingGfx12:
+.incbin "baserom.gba", 0x9B5AF0, 0x200
+sKoffingSprites12:
+ax_sprite sKoffingGfx12, 0x200
+ax_sprite_terminator
+sKoffingGfx13:
+.incbin "baserom.gba", 0x9B5D00, 0x200
+sKoffingSprites13:
+ax_sprite sKoffingGfx13, 0x200
+ax_sprite_terminator
+sKoffingGfx14:
+.incbin "baserom.gba", 0x9B5F10, 0x200
+sKoffingSprites14:
+ax_sprite sKoffingGfx14, 0x200
+ax_sprite_terminator
+sKoffingGfx15:
+.incbin "baserom.gba", 0x9B6120, 0x200
+sKoffingSprites15:
+ax_sprite sKoffingGfx15, 0x200
+ax_sprite_terminator
+sKoffingGfx16:
+.incbin "baserom.gba", 0x9B6330, 0x100
+sKoffingGfx16_1:
+.incbin "baserom.gba", 0x9B6430, 0x40
+sKoffingSprites16:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx17:
+.incbin "baserom.gba", 0x9B64A0, 0x40
+sKoffingGfx17_1:
+.incbin "baserom.gba", 0x9B64E0, 0x180
+sKoffingSprites17:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx17_1, 0x180
+ax_sprite_terminator
+sKoffingGfx18:
+.incbin "baserom.gba", 0x9B6688, 0x100
+sKoffingSprites18:
+ax_sprite sKoffingGfx18, 0x100
+ax_sprite_terminator
+sKoffingGfx19:
+.incbin "baserom.gba", 0x9B6798, 0x40
+sKoffingGfx19_1:
+.incbin "baserom.gba", 0x9B67D8, 0x100
+sKoffingSprites19:
+ax_sprite 0, 0xa0
+ax_sprite sKoffingGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx19_1, 0x100
+ax_sprite_terminator
+sKoffingGfx20:
+.incbin "baserom.gba", 0x9B6900, 0x80
+sKoffingSprites20:
+ax_sprite sKoffingGfx20, 0x80
+ax_sprite_terminator
+sKoffingGfx21:
+.incbin "baserom.gba", 0x9B6990, 0x80
+sKoffingSprites21:
+ax_sprite sKoffingGfx21, 0x80
+ax_sprite_terminator
+sKoffingGfx22:
+.incbin "baserom.gba", 0x9B6A20, 0x80
+sKoffingSprites22:
+ax_sprite sKoffingGfx22, 0x80
+ax_sprite_terminator
+sKoffingGfx23:
+.incbin "baserom.gba", 0x9B6AB0, 0x80
+sKoffingSprites23:
+ax_sprite sKoffingGfx23, 0x80
+ax_sprite_terminator
+sKoffingGfx24:
+.incbin "baserom.gba", 0x9B6B40, 0x80
+sKoffingSprites24:
+ax_sprite sKoffingGfx24, 0x80
+ax_sprite_terminator
+sKoffingGfx25:
+.incbin "baserom.gba", 0x9B6BD0, 0x80
+sKoffingSprites25:
+ax_sprite sKoffingGfx25, 0x80
+ax_sprite_terminator
+sKoffingGfx26:
+.incbin "baserom.gba", 0x9B6C60, 0x20
+sKoffingGfx26_1:
+.incbin "baserom.gba", 0x9B6C80, 0x100
+sKoffingGfx26_2:
+.incbin "baserom.gba", 0x9B6D80, 0x40
+sKoffingSprites26:
+ax_sprite 0, 0x40
+ax_sprite sKoffingGfx26, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx27:
+.incbin "baserom.gba", 0x9B6E00, 0x40
+sKoffingGfx27_1:
+.incbin "baserom.gba", 0x9B6E40, 0x180
+sKoffingSprites27:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx27_1, 0x180
+ax_sprite_terminator
+sKoffingGfx28:
+.incbin "baserom.gba", 0x9B6FE8, 0x80
+sKoffingGfx28_1:
+.incbin "baserom.gba", 0x9B7068, 0x20
+sKoffingSprites28:
+ax_sprite sKoffingGfx28, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx28_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKoffingGfx29:
+.incbin "baserom.gba", 0x9B70B0, 0x60
+sKoffingGfx29_1:
+.incbin "baserom.gba", 0x9B7110, 0xE0
+sKoffingSprites29:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx29_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx30:
+.incbin "baserom.gba", 0x9B7220, 0x20
+sKoffingGfx30_1:
+.incbin "baserom.gba", 0x9B7240, 0x100
+sKoffingGfx30_2:
+.incbin "baserom.gba", 0x9B7340, 0x40
+sKoffingSprites30:
+ax_sprite 0, 0x40
+ax_sprite sKoffingGfx30, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx31:
+.incbin "baserom.gba", 0x9B73C0, 0x40
+sKoffingGfx31_1:
+.incbin "baserom.gba", 0x9B7400, 0x180
+sKoffingSprites31:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx31_1, 0x180
+ax_sprite_terminator
+sKoffingGfx32:
+.incbin "baserom.gba", 0x9B75A8, 0x80
+sKoffingGfx32_1:
+.incbin "baserom.gba", 0x9B7628, 0x20
+sKoffingSprites32:
+ax_sprite sKoffingGfx32, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx32_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKoffingGfx33:
+.incbin "baserom.gba", 0x9B7670, 0x60
+sKoffingGfx33_1:
+.incbin "baserom.gba", 0x9B76D0, 0x60
+sKoffingGfx33_2:
+.incbin "baserom.gba", 0x9B7730, 0x60
+sKoffingSprites33:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx34:
+.incbin "baserom.gba", 0x9B77D0, 0x40
+sKoffingGfx34_1:
+.incbin "baserom.gba", 0x9B7810, 0x100
+sKoffingGfx34_2:
+.incbin "baserom.gba", 0x9B7910, 0x40
+sKoffingSprites34:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx35:
+.incbin "baserom.gba", 0x9B7990, 0x40
+sKoffingGfx35_1:
+.incbin "baserom.gba", 0x9B79D0, 0x180
+sKoffingSprites35:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx35_1, 0x180
+ax_sprite_terminator
+sKoffingGfx36:
+.incbin "baserom.gba", 0x9B7B78, 0x60
+sKoffingGfx36_1:
+.incbin "baserom.gba", 0x9B7BD8, 0x60
+sKoffingSprites36:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx36_1, 0x60
+ax_sprite_terminator
+sKoffingGfx37:
+.incbin "baserom.gba", 0x9B7C60, 0xE0
+sKoffingGfx37_1:
+.incbin "baserom.gba", 0x9B7D40, 0x40
+sKoffingSprites37:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx37, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sKoffingGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx38:
+.incbin "baserom.gba", 0x9B7DB0, 0x40
+sKoffingGfx38_1:
+.incbin "baserom.gba", 0x9B7DF0, 0x100
+sKoffingGfx38_2:
+.incbin "baserom.gba", 0x9B7EF0, 0x40
+sKoffingSprites38:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx39:
+.incbin "baserom.gba", 0x9B7F70, 0x40
+sKoffingGfx39_1:
+.incbin "baserom.gba", 0x9B7FB0, 0x180
+sKoffingSprites39:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx39_1, 0x180
+ax_sprite_terminator
+sKoffingGfx40:
+.incbin "baserom.gba", 0x9B8158, 0x100
+sKoffingSprites40:
+ax_sprite sKoffingGfx40, 0x100
+ax_sprite_terminator
+sKoffingGfx41:
+.incbin "baserom.gba", 0x9B8268, 0x60
+sKoffingGfx41_1:
+.incbin "baserom.gba", 0x9B82C8, 0x80
+sKoffingGfx41_2:
+.incbin "baserom.gba", 0x9B8348, 0x40
+sKoffingSprites41:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx41_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx41_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx42:
+.incbin "baserom.gba", 0x9B83C8, 0x40
+sKoffingGfx42_1:
+.incbin "baserom.gba", 0x9B8408, 0x60
+sKoffingGfx42_2:
+.incbin "baserom.gba", 0x9B8468, 0x40
+sKoffingSprites42:
+ax_sprite 0, 0xa0
+ax_sprite sKoffingGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx42_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKoffingGfx42_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx43:
+.incbin "baserom.gba", 0x9B84E8, 0x60
+sKoffingGfx43_1:
+.incbin "baserom.gba", 0x9B8548, 0x60
+sKoffingGfx43_2:
+.incbin "baserom.gba", 0x9B85A8, 0x40
+sKoffingSprites43:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx43_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKoffingGfx43_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx44:
+.incbin "baserom.gba", 0x9B8628, 0x60
+sKoffingGfx44_1:
+.incbin "baserom.gba", 0x9B8688, 0xE0
+sKoffingSprites44:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx44_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx45:
+.incbin "baserom.gba", 0x9B8798, 0xE0
+sKoffingGfx45_1:
+.incbin "baserom.gba", 0x9B8878, 0x40
+sKoffingSprites45:
+ax_sprite 0, 0x80
+ax_sprite sKoffingGfx45, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sKoffingGfx45_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx46:
+.incbin "baserom.gba", 0x9B88E8, 0x40
+sKoffingGfx46_1:
+.incbin "baserom.gba", 0x9B8928, 0x60
+sKoffingGfx46_2:
+.incbin "baserom.gba", 0x9B8988, 0x80
+sKoffingGfx46_3:
+.incbin "baserom.gba", 0x9B8A08, 0x40
+sKoffingSprites46:
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx46_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKoffingGfx46_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKoffingGfx47:
+.incbin "baserom.gba", 0x9B8A98, 0x200
+sKoffingSprites47:
+ax_sprite sKoffingGfx47, 0x200
+ax_sprite_terminator
+sKoffingGfx48:
+.incbin "baserom.gba", 0x9B8CA8, 0x200
+sKoffingSprites48:
+ax_sprite sKoffingGfx48, 0x200
+ax_sprite_terminator
+sKoffingGfx49:
+.incbin "baserom.gba", 0x9B8EB8, 0x200
+sKoffingSprites49:
+ax_sprite sKoffingGfx49, 0x200
+ax_sprite_terminator
+sKoffingGfx50:
+.incbin "baserom.gba", 0x9B90C8, 0x200
+sKoffingSprites50:
+ax_sprite sKoffingGfx50, 0x200
+ax_sprite_terminator
+sKoffingGfx51:
+.incbin "baserom.gba", 0x9B92D8, 0x200
+sKoffingSprites51:
+ax_sprite sKoffingGfx51, 0x200
+ax_sprite_terminator
+sKoffingGfx52:
+.incbin "baserom.gba", 0x9B94E8, 0x200
+sKoffingSprites52:
+ax_sprite sKoffingGfx52, 0x200
+ax_sprite_terminator
+sKoffingGfx53:
+.incbin "baserom.gba", 0x9B96F8, 0x200
+sKoffingSprites53:
+ax_sprite sKoffingGfx53, 0x200
+ax_sprite_terminator
+sAxPosesKoffing:
+.4byte sKoffingPose1
+.4byte sKoffingPose2
+.4byte sKoffingPose3
+.4byte sKoffingPose4
+.4byte sKoffingPose5
+.4byte sKoffingPose6
+.4byte sKoffingPose7
+.4byte sKoffingPose8
+.4byte sKoffingPose9
+.4byte sKoffingPose10
+.4byte sKoffingPose11
+.4byte sKoffingPose12
+.4byte sKoffingPose13
+.4byte sKoffingPose14
+.4byte sKoffingPose15
+.4byte sKoffingPose16
+.4byte sKoffingPose17
+.4byte sKoffingPose18
+.4byte sKoffingPose19
+.4byte sKoffingPose20
+.4byte sKoffingPose21
+.4byte sKoffingPose22
+.4byte sKoffingPose23
+.4byte sKoffingPose24
+.4byte sKoffingPose25
+.4byte sKoffingPose26
+.4byte sKoffingPose27
+.4byte sKoffingPose28
+.4byte sKoffingPose29
+.4byte sKoffingPose30
+.4byte sKoffingPose31
+.4byte sKoffingPose32
+.4byte sKoffingPose33
+.4byte sKoffingPose34
+.4byte sKoffingPose35
+.4byte sKoffingPose36
+.4byte sKoffingPose37
+.4byte sKoffingPose38
+.4byte sKoffingPose39
+.4byte sKoffingPose40
+.4byte sKoffingPose41
+.4byte sKoffingPose42
+.4byte sKoffingPose43
+.4byte sKoffingPose44
+.4byte sKoffingPose45
+.4byte sKoffingPose46
+.4byte sKoffingPose47
+.4byte sKoffingPose48
+.4byte sKoffingPose49
+.4byte sKoffingPose50
+.4byte sKoffingPose51
+.4byte sKoffingPose52
+.4byte sKoffingPose53
+.4byte sKoffingPose54
+.4byte sKoffingPose55
+.4byte sKoffingPose56
+.4byte sKoffingPose57
+.4byte sKoffingPose58
+.4byte sKoffingPose59
+.4byte sKoffingPose60
+.4byte sKoffingPose61
+.4byte sKoffingPose62
+.4byte sKoffingPose63
+.4byte sKoffingPose64
+.4byte sKoffingPose65
+.4byte sKoffingPose66
+.4byte sKoffingPose67
+.4byte sKoffingPose68
+.4byte sKoffingPose69
+.4byte sKoffingPose70
+.4byte sKoffingPose71
+.4byte sKoffingPose72
+.4byte sKoffingPose73
+.4byte sKoffingPose74
+.4byte sKoffingPose75
+.4byte sKoffingPose76
+.4byte sKoffingPose77
+.4byte sKoffingPose78
+.4byte sKoffingPose79
+.4byte sKoffingPose80
+.4byte sKoffingPose81
+.4byte sKoffingPose82
+.4byte sKoffingPose83
+.4byte sKoffingPose84
+.4byte sKoffingPose85
+.4byte sKoffingPose86
+.4byte sKoffingPose87
+.4byte sKoffingPose88
+.4byte sKoffingPose89
+.4byte sKoffingPose90
+.4byte sKoffingPose91
+.4byte sKoffingPose92
+.4byte sKoffingPose93
+.4byte sKoffingPose94
+.4byte sKoffingPose95
+.4byte sKoffingPose96
+.4byte sKoffingPose97
+.4byte sKoffingPose98
+.4byte sKoffingPose99
+.4byte sKoffingPose100
+.4byte sKoffingPose101
+.4byte sKoffingPose102
+.4byte sKoffingPose103
+.4byte sKoffingPose104
+.4byte sKoffingPose105
+.4byte sKoffingPose106
+.4byte sKoffingPose107
+.4byte sKoffingPose108
+.4byte sKoffingPose109
+.4byte sKoffingPose110
+.4byte sKoffingPose111
+.4byte sKoffingPose112
+.4byte sKoffingPose113
+.4byte sKoffingPose114
+.4byte sKoffingPose115
+.4byte sKoffingPose116
+.4byte sKoffingPose117
+.4byte sKoffingPose118
+.4byte sKoffingPose119
+.4byte sKoffingPose120
+.4byte sKoffingPose121
+.4byte sKoffingPose122
+.4byte sKoffingPose123
+.4byte sKoffingPose124
+.4byte sKoffingPose125
+.4byte sKoffingPose126
+.4byte sKoffingPose127
+.4byte sKoffingPose128
+.4byte sKoffingPose129
+.4byte sKoffingPose130
+.4byte sKoffingPose131
+.4byte sKoffingPose132
+.4byte sKoffingPose133
+.4byte sKoffingPose134
+.4byte sKoffingPose135
+.4byte sKoffingPose136
+.4byte sKoffingPose137
+.4byte sKoffingPose138
+.4byte sKoffingPose139
+.4byte sKoffingPose140
+.4byte sKoffingPose141
+.4byte sKoffingPose142
+.4byte sKoffingPose143
+.4byte sKoffingPose144
+.4byte sKoffingPose145
+.4byte sKoffingPose146
+.4byte sKoffingPose147
+.4byte sKoffingPose148
+.4byte sKoffingPose149
+.4byte sKoffingPose150
+.4byte sKoffingPose151
+.4byte sKoffingPose152
+.4byte sKoffingPose153
+.4byte sKoffingPose154
+.4byte sKoffingPose155
+.4byte sKoffingPose156
+.4byte sKoffingPose157
+.4byte sKoffingPose158
+.4byte sKoffingPose159
+.4byte sKoffingPose160
+.4byte sKoffingPose161
+.4byte sKoffingPose162
+.4byte sKoffingPose163
+.4byte sKoffingPose164
+.4byte sKoffingPose165
+.4byte sKoffingPose166
+.4byte sKoffingPose167
+.4byte sKoffingPose168
+.4byte sKoffingPose169
+.4byte sKoffingPose170
+.4byte sKoffingPose171
+.4byte sKoffingPose172
+.4byte sKoffingPose173
+.4byte sKoffingPose174
+.4byte sKoffingPose175
+.4byte sKoffingPose176
+.4byte sKoffingPose177
+.4byte sKoffingPose178
+.4byte sKoffingPose179
+.4byte sKoffingPose180
+.4byte sKoffingPose181
+.4byte sKoffingPose182
+.4byte sKoffingPose183
+.4byte sKoffingPose184
+.4byte sKoffingPose185
+.4byte sKoffingPose186
+.4byte sKoffingPose187
+.4byte sKoffingPose188
+.4byte sKoffingPose189
+.4byte sKoffingPose190
+.4byte sKoffingPose191
+.4byte sKoffingPose192
+.4byte sKoffingPose193
+.4byte sKoffingPose194
+.4byte sKoffingPose195
+.4byte sKoffingPose196
+.4byte sKoffingPose197
+.4byte sKoffingPose198
+.4byte sKoffingPose199
+.4byte sKoffingPose200
+.4byte sKoffingPose201
+.4byte sKoffingPose202
+.4byte sKoffingPose203
+.4byte sKoffingPose204
+.4byte sKoffingPose205
+.4byte sKoffingPose206
+.4byte sKoffingPose207
+.4byte sKoffingPose208
+.4byte sKoffingPose209
+.4byte sKoffingPose210
+.4byte sKoffingPose211
+.4byte sKoffingPose212
+.4byte sKoffingPose213
+.4byte sKoffingPose214
+.4byte sKoffingPose215
+.4byte sKoffingPose216
+.4byte sKoffingPose217
+.4byte sKoffingPose218
+.4byte sKoffingPose219
+.4byte sKoffingPose220
+.4byte sKoffingPose221
+.4byte sKoffingPose222
+.4byte sKoffingPose223
+.4byte sKoffingPose224
+.4byte sKoffingPose225
+.4byte sKoffingPose226
+.4byte sKoffingPose227
+.4byte sKoffingPose228
+.4byte sKoffingPose229
+.4byte sKoffingPose230
+.4byte sKoffingPose231
+.4byte sKoffingPose232
+.4byte sKoffingPose233
+.4byte sKoffingPose234
+.4byte sKoffingPose235
+.4byte sKoffingPose236
+.4byte sKoffingPose237
+.4byte sKoffingPose238
+.4byte sKoffingPose239
+.4byte sKoffingPose240
+.4byte sKoffingPose241
+.4byte sKoffingPose242
+.4byte sKoffingPose243
+.4byte sKoffingPose244
+.4byte sKoffingPose245
+.4byte sKoffingPose246
+.4byte sKoffingPose247
+.4byte sKoffingPose248
+.4byte sKoffingPose249
+.4byte sKoffingPose250
+.4byte sKoffingPose251
+.4byte sKoffingPose252
+.4byte sKoffingPose253
+.4byte sKoffingPose254
+.4byte sKoffingPose255
+.4byte sKoffingPose256
+.4byte sKoffingPose257
+.4byte sKoffingPose258
+.4byte sKoffingPose259
+.4byte sKoffingPose260
+.4byte sKoffingPose261
+.4byte sKoffingPose262
+.4byte sKoffingPose263
+.4byte sKoffingPose264
+.4byte sKoffingPose265
+.4byte sKoffingPose266
+.4byte sKoffingPose267
+.4byte sKoffingPose268
+.4byte sKoffingPose269
+.4byte sKoffingPose270
+.4byte sKoffingPose271
+.4byte sKoffingPose272
+.4byte sKoffingPose273
+.4byte sKoffingPose274
+.4byte sKoffingPose275
+.4byte sKoffingPose276
+.4byte sKoffingPose277
+.4byte sKoffingPose278
+.4byte sKoffingPose279
+.4byte sKoffingPose280
+.4byte sKoffingPose281
+.4byte sKoffingPose282
+.4byte sKoffingPose283
+.4byte sKoffingPose284
+.4byte sKoffingPose285
+.4byte sKoffingPose286
+.4byte sKoffingPose287
+.4byte sKoffingPose288
+.4byte sKoffingPose289
+.4byte sKoffingPose290
+.4byte sKoffingPose291
+.4byte sKoffingPose292
+.4byte sKoffingPose293
+.4byte sKoffingPose294
+.4byte sKoffingPose295
+.4byte sKoffingPose296
+.4byte sKoffingPose297
+.4byte sKoffingPose298
+.4byte sKoffingPose299
+.4byte sKoffingPose300
+.4byte sKoffingPose301
+.4byte sKoffingPose302
+.4byte sKoffingPose303
+.4byte sKoffingPose304
+.4byte sKoffingPose305
+.4byte sKoffingPose306
+.4byte sKoffingPose307
+.4byte sKoffingPose308
+.4byte sKoffingPose309
+.4byte sKoffingPose310
+.4byte sKoffingPose311
+.4byte sKoffingPose312
+.4byte sKoffingPose313
+.4byte sKoffingPose314
+.4byte sKoffingPose315
+.4byte sKoffingPose316
+.4byte sKoffingPose317
+.4byte sKoffingPose318
+.4byte sKoffingPose319
+.4byte sKoffingPose320
+.4byte sKoffingPose321
+.4byte sKoffingPose322
+.4byte sKoffingPose323
+.4byte sKoffingPose324
+.4byte sKoffingPose325
+.4byte sKoffingPose326
+.4byte sKoffingPose327
+.4byte sKoffingPose328
+.4byte sKoffingPose329
+.4byte sKoffingPose330
+.4byte sKoffingPose331
+.4byte sKoffingPose332
+.4byte sKoffingPose333
+.4byte sKoffingPose334
+.4byte sKoffingPose335
+.4byte sKoffingPose336
+.4byte sKoffingPose337
+.4byte sKoffingPose338
+.4byte sKoffingPose339
+.4byte sKoffingPose340
+.4byte sKoffingPose341
+.4byte sKoffingPose342
+.4byte sKoffingPose343
+.4byte sKoffingPose344
+.4byte sKoffingPose345
+.4byte sKoffingPose346
+sAxPositionsKoffing:
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -18, 	   1,  -10, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    3,  -12, 	  -4,  -18, 	   5,  -13, 	  -1,  -12
+.2byte    3,  -10, 	  -3,  -18, 	   5,  -13, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -14, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -15, 	  -7,  -15, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -5,  -12, 	   2,  -18, 	  -7,  -13, 	  -1,  -12
+.2byte   -5,  -10, 	   1,  -18, 	  -7,  -13, 	  -1,  -13
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -18, 	  -3,  -10, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -15, 	  -8,  -14, 	   8,  -14, 	   0,  -13
+.2byte    0,  -17, 	  -9,  -17, 	  10,  -16, 	   0,  -14
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -16, 	   4,  -17, 	  -7,  -13, 	  -1,  -12
+.2byte    4,  -17, 	   5,  -18, 	  -8,  -14, 	  -2,  -12
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -17, 	   0,  -19, 	   1,  -15, 	  -2,  -12
+.2byte    6,  -18, 	   0,  -20, 	   1,  -15, 	  -1,  -12
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    2,  -18, 	  -5,  -20, 	   5,  -16, 	  -2,  -13
+.2byte    3,  -19, 	  -5,  -21, 	   6,  -16, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -20, 	   8,  -15, 	  -9,  -15, 	   0,  -14
+.2byte    0,  -21, 	  10,  -15, 	 -10,  -15, 	   0,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -3,  -13, 	   3,  -17, 	  -6,  -13, 	   1,  -13
+.2byte   -3,  -18, 	   4,  -20, 	  -6,  -16, 	   1,  -13
+.2byte   -4,  -19, 	   4,  -21, 	  -7,  -16, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -6,  -11, 	  -3,  -17, 	  -1,  -10, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -19, 	  -2,  -15, 	   1,  -12
+.2byte   -7,  -18, 	  -1,  -20, 	  -2,  -15, 	   0,  -12
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -3,   -9, 	  -5,  -16, 	   4,   -9, 	   0,  -12
+.2byte   -3,  -16, 	  -5,  -17, 	   6,  -13, 	   0,  -12
+.2byte   -5,  -17, 	  -6,  -18, 	   7,  -14, 	   1,  -12
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -15, 	  -8,  -14, 	   8,  -14, 	   0,  -13
+.2byte    0,  -17, 	  -9,  -17, 	  10,  -16, 	   0,  -14
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -16, 	   4,  -17, 	  -7,  -13, 	  -1,  -12
+.2byte    4,  -17, 	   5,  -18, 	  -8,  -14, 	  -2,  -12
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -12, 	  -3,   -8, 	  -1,  -11
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -17, 	   0,  -19, 	   1,  -15, 	  -2,  -12
+.2byte    6,  -18, 	   0,  -20, 	   1,  -15, 	  -1,  -12
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    6,   -9, 	   4,  -14, 	   3,  -11, 	   0,  -13
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    2,  -18, 	  -5,  -20, 	   5,  -16, 	  -2,  -13
+.2byte    3,  -19, 	  -5,  -21, 	   6,  -16, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte    1,  -11, 	  -4,  -17, 	   2,  -13, 	  -2,  -12
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -20, 	   8,  -15, 	  -9,  -15, 	   0,  -14
+.2byte    0,  -21, 	  10,  -15, 	 -10,  -15, 	   0,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -1,  -13, 	   5,  -13, 	  -7,  -13, 	  -2,  -13
+.2byte   -3,  -13, 	   3,  -17, 	  -6,  -13, 	   1,  -13
+.2byte   -3,  -18, 	   4,  -20, 	  -6,  -16, 	   1,  -13
+.2byte   -4,  -19, 	   4,  -21, 	  -7,  -16, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -2,  -11, 	   3,  -17, 	  -3,  -13, 	   1,  -12
+.2byte   -6,  -11, 	  -3,  -17, 	  -1,  -10, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -19, 	  -2,  -15, 	   1,  -12
+.2byte   -7,  -18, 	  -1,  -20, 	  -2,  -15, 	   0,  -12
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -7,   -9, 	  -5,  -14, 	  -4,  -11, 	  -1,  -13
+.2byte   -3,   -9, 	  -5,  -16, 	   4,   -9, 	   0,  -12
+.2byte   -3,  -16, 	  -5,  -17, 	   6,  -13, 	   0,  -12
+.2byte   -5,  -17, 	  -6,  -18, 	   7,  -14, 	   1,  -12
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -4,   -7, 	  -6,  -12, 	   2,   -8, 	   0,  -11
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -15, 	  -8,  -14, 	   8,  -14, 	   0,  -13
+.2byte    0,  -17, 	  -9,  -17, 	  10,  -16, 	   0,  -14
+.2byte   -1,   -7, 	  -7,  -11, 	   5,  -11, 	  -1,  -11
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -16, 	   4,  -17, 	  -7,  -13, 	  -1,  -12
+.2byte    4,  -17, 	   5,  -18, 	  -8,  -14, 	  -2,  -12
+.2byte    4,   -8, 	   5,  -13, 	  -3,   -8, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -17, 	   0,  -19, 	   1,  -15, 	  -2,  -12
+.2byte    6,  -18, 	   0,  -20, 	   1,  -15, 	  -1,  -12
+.2byte    5,   -9, 	   4,  -15, 	   3,  -11, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    2,  -18, 	  -5,  -20, 	   5,  -16, 	  -2,  -13
+.2byte    3,  -19, 	  -5,  -21, 	   6,  -16, 	  -2,  -12
+.2byte    3,  -10, 	  -2,  -18, 	   4,  -14, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -20, 	   8,  -15, 	  -9,  -15, 	   0,  -14
+.2byte    0,  -21, 	  10,  -15, 	 -10,  -15, 	   0,  -13
+.2byte   -1,  -11, 	   6,  -14, 	  -7,  -14, 	  -1,  -13
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -4,  -18, 	   3,  -20, 	  -7,  -16, 	   0,  -13
+.2byte   -5,  -19, 	   3,  -21, 	  -8,  -16, 	   0,  -12
+.2byte   -5,  -10, 	   0,  -18, 	  -6,  -14, 	  -1,  -13
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -17, 	  -2,  -19, 	  -3,  -15, 	   0,  -12
+.2byte   -8,  -18, 	  -2,  -20, 	  -3,  -15, 	  -1,  -12
+.2byte   -7,   -9, 	  -6,  -15, 	  -5,  -11, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,  -16, 	  -6,  -17, 	   5,  -13, 	  -1,  -12
+.2byte   -6,  -17, 	  -7,  -18, 	   6,  -14, 	   0,  -12
+.2byte   -6,   -8, 	  -7,  -13, 	   1,   -8, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte   -1,   -8, 	  -8,  -13, 	   5,  -13, 	  -1,  -12
+.2byte   -1,   -7, 	  -8,  -13, 	   5,  -13, 	  -1,  -11
+.2byte   -1,  -13, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte    0,  -12, 	   2,  -17, 	  -6,   -9, 	  -2,  -13
+.2byte    3,  -12, 	   0,  -17, 	  -1,  -10, 	  -3,  -11
+.2byte    3,  -11, 	  -4,  -17, 	   5,  -13, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -12, 	  -7,  -12, 	  -1,  -12
+.2byte   -3,  -11, 	   4,  -17, 	  -5,  -13, 	   1,  -12
+.2byte   -4,  -12, 	  -1,  -17, 	   0,  -10, 	   2,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   4,   -9, 	   0,  -13
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -18, 	   1,  -10, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    3,  -12, 	  -4,  -18, 	   5,  -13, 	  -1,  -12
+.2byte    3,  -10, 	  -3,  -18, 	   5,  -13, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -14, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -15, 	  -7,  -15, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -5,  -12, 	   2,  -18, 	  -7,  -13, 	  -1,  -12
+.2byte   -5,  -10, 	   1,  -18, 	  -7,  -13, 	  -1,  -13
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -18, 	  -3,  -10, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    0,  -15, 	  -8,  -14, 	   8,  -14, 	   0,  -13
+.2byte    3,  -15, 	   5,  -16, 	  -6,  -12, 	   0,  -11
+.2byte    6,  -16, 	   1,  -18, 	   2,  -14, 	  -1,  -11
+.2byte    3,  -17, 	  -4,  -19, 	   6,  -15, 	  -1,  -12
+.2byte   -1,  -18, 	   8,  -13, 	  -9,  -13, 	   0,  -12
+.2byte   -4,  -17, 	   3,  -19, 	  -7,  -15, 	   0,  -12
+.2byte   -7,  -16, 	  -2,  -18, 	  -3,  -14, 	   0,  -11
+.2byte   -4,  -15, 	  -6,  -16, 	   5,  -12, 	  -1,  -11
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -18, 	   1,  -10, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    3,  -12, 	  -4,  -18, 	   5,  -13, 	  -1,  -12
+.2byte    3,  -10, 	  -3,  -18, 	   5,  -13, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -14, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -15, 	  -7,  -15, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -5,  -12, 	   2,  -18, 	  -7,  -13, 	  -1,  -12
+.2byte   -5,  -10, 	   1,  -18, 	  -7,  -13, 	  -1,  -13
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -18, 	  -3,  -10, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   5,  -12, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    5,  -11, 	   2,  -18, 	   1,  -10, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    3,  -12, 	  -4,  -18, 	   5,  -13, 	  -1,  -12
+.2byte    3,  -10, 	  -3,  -18, 	   5,  -13, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -14, 	  -1,  -13
+.2byte   -1,  -11, 	   5,  -15, 	  -7,  -15, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -5,  -12, 	   2,  -18, 	  -7,  -13, 	  -1,  -12
+.2byte   -5,  -10, 	   1,  -18, 	  -7,  -13, 	  -1,  -13
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -18, 	  -3,  -10, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -12, 	   6,  -13, 	  -1,  -12
+.2byte   -4,   -9, 	  -6,  -16, 	   3,   -9, 	  -1,  -12
+.2byte   -7,  -11, 	  -4,  -17, 	  -2,  -10, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -17, 	  -7,  -13, 	   0,  -13
+.2byte   -1,  -11, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -17, 	   5,  -13, 	  -2,  -13
+.2byte    5,  -11, 	   2,  -17, 	   0,  -10, 	  -1,  -12
+.2byte    2,   -9, 	   4,  -16, 	  -5,   -9, 	  -1,  -12
+sKoffingAnimTable1:
+.4byte sKoffingAnims_1_1
+.4byte sKoffingAnims_1_2
+.4byte sKoffingAnims_1_3
+.4byte sKoffingAnims_1_4
+.4byte sKoffingAnims_1_5
+.4byte sKoffingAnims_1_6
+.4byte sKoffingAnims_1_7
+.4byte sKoffingAnims_1_8
+sKoffingAnimTable2:
+.4byte sKoffingAnims_2_1
+.4byte sKoffingAnims_2_2
+.4byte sKoffingAnims_2_3
+.4byte sKoffingAnims_2_4
+.4byte sKoffingAnims_2_5
+.4byte sKoffingAnims_2_6
+.4byte sKoffingAnims_2_7
+.4byte sKoffingAnims_2_8
+sKoffingAnimTable3:
+.4byte sKoffingAnims_3_1
+.4byte sKoffingAnims_3_2
+.4byte sKoffingAnims_3_3
+.4byte sKoffingAnims_3_4
+.4byte sKoffingAnims_3_5
+.4byte sKoffingAnims_3_6
+.4byte sKoffingAnims_3_7
+.4byte sKoffingAnims_3_8
+sKoffingAnimTable4:
+.4byte sKoffingAnims_4_1
+.4byte sKoffingAnims_4_2
+.4byte sKoffingAnims_4_3
+.4byte sKoffingAnims_4_4
+.4byte sKoffingAnims_4_5
+.4byte sKoffingAnims_4_6
+.4byte sKoffingAnims_4_7
+.4byte sKoffingAnims_4_8
+sKoffingAnimTable5:
+.4byte sKoffingAnims_5_1
+.4byte sKoffingAnims_5_2
+.4byte sKoffingAnims_5_3
+.4byte sKoffingAnims_5_4
+.4byte sKoffingAnims_5_5
+.4byte sKoffingAnims_5_6
+.4byte sKoffingAnims_5_7
+.4byte sKoffingAnims_5_8
+sKoffingAnimTable6:
+.4byte sKoffingAnims_6_1
+.4byte sKoffingAnims_6_1
+.4byte sKoffingAnims_6_1
+.4byte sKoffingAnims_6_1
+.4byte sKoffingAnims_6_1
+.4byte sKoffingAnims_6_1
+.4byte sKoffingAnims_6_1
+.4byte sKoffingAnims_6_1
+sKoffingAnimTable7:
+.4byte sKoffingAnims_7_1
+.4byte sKoffingAnims_7_2
+.4byte sKoffingAnims_7_3
+.4byte sKoffingAnims_7_4
+.4byte sKoffingAnims_7_5
+.4byte sKoffingAnims_7_6
+.4byte sKoffingAnims_7_7
+.4byte sKoffingAnims_7_8
+sKoffingAnimTable8:
+.4byte sKoffingAnims_8_1
+.4byte sKoffingAnims_8_2
+.4byte sKoffingAnims_8_3
+.4byte sKoffingAnims_8_4
+.4byte sKoffingAnims_8_5
+.4byte sKoffingAnims_8_6
+.4byte sKoffingAnims_8_7
+.4byte sKoffingAnims_8_8
+sKoffingAnimTable9:
+.4byte sKoffingAnims_9_1
+.4byte sKoffingAnims_9_2
+.4byte sKoffingAnims_9_3
+.4byte sKoffingAnims_9_4
+.4byte sKoffingAnims_9_5
+.4byte sKoffingAnims_9_6
+.4byte sKoffingAnims_9_7
+.4byte sKoffingAnims_9_8
+sKoffingAnimTable10:
+.4byte sKoffingAnims_10_1
+.4byte sKoffingAnims_10_2
+.4byte sKoffingAnims_10_3
+.4byte sKoffingAnims_10_4
+.4byte sKoffingAnims_10_5
+.4byte sKoffingAnims_10_6
+.4byte sKoffingAnims_10_7
+.4byte sKoffingAnims_10_8
+sKoffingAnimTable11:
+.4byte sKoffingAnims_11_1
+.4byte sKoffingAnims_11_2
+.4byte sKoffingAnims_11_3
+.4byte sKoffingAnims_11_4
+.4byte sKoffingAnims_11_5
+.4byte sKoffingAnims_11_6
+.4byte sKoffingAnims_11_7
+.4byte sKoffingAnims_11_8
+sKoffingAnimTable12:
+.4byte sKoffingAnims_12_1
+.4byte sKoffingAnims_12_2
+.4byte sKoffingAnims_12_3
+.4byte sKoffingAnims_12_4
+.4byte sKoffingAnims_12_5
+.4byte sKoffingAnims_12_6
+.4byte sKoffingAnims_12_7
+.4byte sKoffingAnims_12_8
+sKoffingAnimTable13:
+.4byte sKoffingAnims_13_1
+.4byte sKoffingAnims_13_2
+.4byte sKoffingAnims_13_3
+.4byte sKoffingAnims_13_4
+.4byte sKoffingAnims_13_5
+.4byte sKoffingAnims_13_6
+.4byte sKoffingAnims_13_7
+.4byte sKoffingAnims_13_8
+sAxAnimationsKoffing:
+.4byte sKoffingAnimTable1
+.4byte sKoffingAnimTable2
+.4byte sKoffingAnimTable3
+.4byte sKoffingAnimTable4
+.4byte sKoffingAnimTable5
+.4byte sKoffingAnimTable6
+.4byte sKoffingAnimTable7
+.4byte sKoffingAnimTable8
+.4byte sKoffingAnimTable9
+.4byte sKoffingAnimTable10
+.4byte sKoffingAnimTable11
+.4byte sKoffingAnimTable12
+.4byte sKoffingAnimTable13
+sAxSpritesKoffing:
+.4byte sKoffingSprites1
+.4byte sKoffingSprites2
+.4byte sKoffingSprites3
+.4byte sKoffingSprites4
+.4byte sKoffingSprites5
+.4byte sKoffingSprites6
+.4byte sKoffingSprites7
+.4byte sKoffingSprites8
+.4byte sKoffingSprites9
+.4byte sKoffingSprites10
+.4byte sKoffingSprites11
+.4byte sKoffingSprites12
+.4byte sKoffingSprites13
+.4byte sKoffingSprites14
+.4byte sKoffingSprites15
+.4byte sKoffingSprites16
+.4byte sKoffingSprites17
+.4byte sKoffingSprites18
+.4byte sKoffingSprites19
+.4byte sKoffingSprites20
+.4byte sKoffingSprites21
+.4byte sKoffingSprites22
+.4byte sKoffingSprites23
+.4byte sKoffingSprites24
+.4byte sKoffingSprites25
+.4byte sKoffingSprites26
+.4byte sKoffingSprites27
+.4byte sKoffingSprites28
+.4byte sKoffingSprites29
+.4byte sKoffingSprites30
+.4byte sKoffingSprites31
+.4byte sKoffingSprites32
+.4byte sKoffingSprites33
+.4byte sKoffingSprites34
+.4byte sKoffingSprites35
+.4byte sKoffingSprites36
+.4byte sKoffingSprites37
+.4byte sKoffingSprites38
+.4byte sKoffingSprites39
+.4byte sKoffingSprites40
+.4byte sKoffingSprites41
+.4byte sKoffingSprites42
+.4byte sKoffingSprites43
+.4byte sKoffingSprites44
+.4byte sKoffingSprites45
+.4byte sKoffingSprites46
+.4byte sKoffingSprites47
+.4byte sKoffingSprites48
+.4byte sKoffingSprites49
+.4byte sKoffingSprites50
+.4byte sKoffingSprites51
+.4byte sKoffingSprites52
+.4byte sKoffingSprites53
+sAxMainKoffing:
+ax_main sAxPosesKoffing, sAxAnimationsKoffing, 13, sAxSpritesKoffing, sAxPositionsKoffing

--- a/data/ax/krabby.inc
+++ b/data/ax/krabby.inc
@@ -1,0 +1,3416 @@
+.global gAxKrabby
+gAxKrabby:
+ax_siro sAxMainKrabby
+sKrabbyPose1:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose2:
+ax_pose 1, 0x81f2, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose3:
+ax_pose 2, 0x01f0, 0x90e9, 0x0c00
+ax_pose_terminator
+sKrabbyPose4:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose5:
+ax_pose 4, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose6:
+ax_pose 5, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose7:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose8:
+ax_pose 7, 0x41f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose9:
+ax_pose 8, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose10:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose11:
+ax_pose 4, 0x01f0, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose12:
+ax_pose 5, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose13:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose14:
+ax_pose 1, 0x81f2, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose15:
+ax_pose 2, 0x01f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose16:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose17:
+ax_pose 10, 0x01f1, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose18:
+ax_pose 11, 0x41f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sKrabbyPose19:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose20:
+ax_pose 13, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose21:
+ax_pose 14, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose22:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose23:
+ax_pose 10, 0x01f1, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose24:
+ax_pose 11, 0x41f3, 0x90eb, 0x0c00
+ax_pose_terminator
+sKrabbyPose25:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose26:
+ax_pose 1, 0x81f2, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose27:
+ax_pose 2, 0x01f0, 0x90e9, 0x0c00
+ax_pose_terminator
+sKrabbyPose28:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose29:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose30:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose31:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose32:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose33:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose34:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose35:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose36:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose37:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose38:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose39:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose40:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose41:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose42:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose43:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose44:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose45:
+ax_pose 4, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose46:
+ax_pose 5, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose47:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose48:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose49:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose50:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose51:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose52:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose53:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose54:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose55:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose56:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose57:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose58:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose59:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose60:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose61:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose62:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose63:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose64:
+ax_pose 7, 0x41f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose65:
+ax_pose 8, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose66:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose67:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose68:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose69:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose70:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose71:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose72:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose73:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose74:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose75:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose76:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose77:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose78:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose79:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose80:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose81:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose82:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose83:
+ax_pose 4, 0x01f0, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose84:
+ax_pose 5, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose85:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose86:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose87:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose88:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose89:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose90:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose91:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose92:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose93:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose94:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose95:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose96:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose97:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose98:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose99:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose100:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose101:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose102:
+ax_pose 1, 0x81f2, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose103:
+ax_pose 2, 0x01f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose104:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose105:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose106:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose107:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose108:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose109:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose110:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose111:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose112:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose113:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose114:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose115:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose116:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose117:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose118:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose119:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose120:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose121:
+ax_pose 10, 0x01f1, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose122:
+ax_pose 11, 0x41f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sKrabbyPose123:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose124:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose125:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose126:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose127:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose128:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose129:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose130:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose131:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose132:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose133:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose134:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose135:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose136:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose137:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose138:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose139:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose140:
+ax_pose 13, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose141:
+ax_pose 14, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose142:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose143:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose144:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose145:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose146:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose147:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose148:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose149:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose150:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose151:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose152:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose153:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose154:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose155:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose156:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose157:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose158:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose159:
+ax_pose 10, 0x01f1, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose160:
+ax_pose 11, 0x41f3, 0x90eb, 0x0c00
+ax_pose_terminator
+sKrabbyPose161:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose162:
+ax_pose 16, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose163:
+ax_pose 17, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose164:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose165:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose166:
+ax_pose 18, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose167:
+ax_pose 17, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose168:
+ax_pose 16, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose169:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose170:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose171:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose172:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose173:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose174:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose175:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose176:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose177:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose178:
+ax_pose 20, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose179:
+ax_pose 21, 0x01ed, 0x80f0, 0x0c00
+ax_pose 22, 0x01ed, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose180:
+ax_pose 22, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose181:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose182:
+ax_pose 23, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose183:
+ax_pose 24, 0x01ea, 0x90ee, 0x0c00
+ax_pose 25, 0x01ea, 0x90ee, 0x0c10
+ax_pose_terminator
+sKrabbyPose184:
+ax_pose 25, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose185:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose186:
+ax_pose 26, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose187:
+ax_pose 27, 0x01ec, 0x90f4, 0x0c00
+ax_pose 28, 0x01ec, 0x90f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose188:
+ax_pose 28, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose189:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose190:
+ax_pose 29, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose191:
+ax_pose 30, 0x01ec, 0x90f0, 0x0c00
+ax_pose 31, 0x01ec, 0x90f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose192:
+ax_pose 31, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose193:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose194:
+ax_pose 32, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose195:
+ax_pose 33, 0x01e6, 0x80f0, 0x0c00
+ax_pose 34, 0x01eb, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose196:
+ax_pose 34, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose197:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose198:
+ax_pose 29, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose199:
+ax_pose 30, 0x01ec, 0x80f0, 0x0c00
+ax_pose 31, 0x01ec, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose200:
+ax_pose 31, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose201:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose202:
+ax_pose 26, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose203:
+ax_pose 27, 0x01ec, 0x80eb, 0x0c00
+ax_pose 28, 0x01ec, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose204:
+ax_pose 28, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose205:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose206:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose207:
+ax_pose 24, 0x01ea, 0x80f2, 0x0c00
+ax_pose 25, 0x01ea, 0x80f2, 0x0c10
+ax_pose_terminator
+sKrabbyPose208:
+ax_pose 25, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose209:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose210:
+ax_pose 20, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose211:
+ax_pose 35, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose212:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose213:
+ax_pose 23, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose214:
+ax_pose 36, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose215:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose216:
+ax_pose 26, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose217:
+ax_pose 37, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose218:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose219:
+ax_pose 29, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose220:
+ax_pose 38, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose221:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose222:
+ax_pose 32, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose223:
+ax_pose 39, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose224:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose225:
+ax_pose 29, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose226:
+ax_pose 38, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose227:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose228:
+ax_pose 26, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose229:
+ax_pose 37, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose230:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose231:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose232:
+ax_pose 36, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose233:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose234:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose235:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose236:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose237:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose238:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose239:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose240:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose241:
+ax_pose 40, 0x41f5, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose242:
+ax_pose 41, 0x41f5, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose243:
+ax_pose 42, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose244:
+ax_pose 43, 0x01ed, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose245:
+ax_pose 44, 0x01ec, 0x90f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose246:
+ax_pose 45, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose247:
+ax_pose 46, 0x01e6, 0x80ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose248:
+ax_pose 45, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sKrabbyPose249:
+ax_pose 44, 0x01ec, 0x80ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose250:
+ax_pose 43, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sKrabbyPose251:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose252:
+ax_pose 20, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose253:
+ax_pose 21, 0x01ed, 0x80f0, 0x0c00
+ax_pose 22, 0x01ed, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose254:
+ax_pose 22, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose255:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose256:
+ax_pose 23, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose257:
+ax_pose 24, 0x01ea, 0x90ee, 0x0c00
+ax_pose 25, 0x01ea, 0x90ee, 0x0c10
+ax_pose_terminator
+sKrabbyPose258:
+ax_pose 25, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose259:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose260:
+ax_pose 26, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose261:
+ax_pose 27, 0x01ec, 0x90f4, 0x0c00
+ax_pose 28, 0x01ec, 0x90f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose262:
+ax_pose 28, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose263:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose264:
+ax_pose 29, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose265:
+ax_pose 30, 0x01ec, 0x90f0, 0x0c00
+ax_pose 31, 0x01ec, 0x90f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose266:
+ax_pose 31, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose267:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose268:
+ax_pose 32, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose269:
+ax_pose 33, 0x01e6, 0x80f0, 0x0c00
+ax_pose 34, 0x01eb, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose270:
+ax_pose 34, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose271:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose272:
+ax_pose 29, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose273:
+ax_pose 30, 0x01ec, 0x80f0, 0x0c00
+ax_pose 31, 0x01ec, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose274:
+ax_pose 31, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose275:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose276:
+ax_pose 26, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose277:
+ax_pose 27, 0x01ec, 0x80eb, 0x0c00
+ax_pose 28, 0x01ec, 0x80f0, 0x0c10
+ax_pose_terminator
+sKrabbyPose278:
+ax_pose 28, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose279:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose280:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose281:
+ax_pose 24, 0x01ea, 0x80f2, 0x0c00
+ax_pose 25, 0x01ea, 0x80f2, 0x0c10
+ax_pose_terminator
+sKrabbyPose282:
+ax_pose 25, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose283:
+ax_pose 35, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose284:
+ax_pose 36, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose285:
+ax_pose 37, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sKrabbyPose286:
+ax_pose 38, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose287:
+ax_pose 39, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose288:
+ax_pose 38, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose289:
+ax_pose 37, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose290:
+ax_pose 36, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose291:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose292:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose293:
+ax_pose 17, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sKrabbyPose294:
+ax_pose 18, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose295:
+ax_pose 19, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose296:
+ax_pose 18, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose297:
+ax_pose 17, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sKrabbyPose298:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose299:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose300:
+ax_pose 20, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose301:
+ax_pose 35, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose302:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+sKrabbyPose303:
+ax_pose 23, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose304:
+ax_pose 36, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose305:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose306:
+ax_pose 26, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose307:
+ax_pose 37, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose308:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose309:
+ax_pose 29, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose310:
+ax_pose 38, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose311:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose312:
+ax_pose 32, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose313:
+ax_pose 39, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose314:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose315:
+ax_pose 29, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose316:
+ax_pose 38, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose317:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose318:
+ax_pose 26, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose319:
+ax_pose 37, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose320:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose321:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose322:
+ax_pose 36, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sKrabbyPose323:
+ax_pose 35, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose324:
+ax_pose 36, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose325:
+ax_pose 37, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sKrabbyPose326:
+ax_pose 38, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sKrabbyPose327:
+ax_pose 39, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sKrabbyPose328:
+ax_pose 38, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose329:
+ax_pose 37, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sKrabbyPose330:
+ax_pose 36, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sKrabbyPose331:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose332:
+ax_pose 9, 0x01f1, 0x80f6, 0x0c00
+ax_pose_terminator
+sKrabbyPose333:
+ax_pose 0, 0x81f0, 0x80f7, 0x0c00
+ax_pose_terminator
+sKrabbyPose334:
+ax_pose 3, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose335:
+ax_pose 6, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sKrabbyPose336:
+ax_pose 3, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sKrabbyPose337:
+ax_pose 0, 0x81f0, 0x90f9, 0x0c00
+ax_pose_terminator
+sKrabbyPose338:
+ax_pose 9, 0x01f1, 0x90ea, 0x0c00
+ax_pose_terminator
+.align 2
+sKrabbyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_2_1:
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, -3, 0, 0,
+ax_anim 3, 0, 34, 0, -4, 0, 0,
+ax_anim 2, 0, 33, 0, -4, 0, 0,
+ax_anim 1, 0, 33, 0, -2, 0, 0,
+ax_anim 3, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 2, 0, 2,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 34, 0, 2, 0, 5,
+ax_anim 2, 0, 27, 0, -2, 0, 2,
+ax_anim 1, 0, 27, 0, -1, 0, 1,
+ax_anim_terminator
+sKrabbyAnims_2_2:
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, -3, 0, 0,
+ax_anim 3, 0, 52, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 1, 0, 51, 0, -3, 0, 0,
+ax_anim 3, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 2, 44, 4, 4, 4, 4,
+ax_anim 1, 0, 45, 10, 10, 10, 10,
+ax_anim 2, 0, 44, 18, 18, 18, 18,
+ax_anim 2, 1, 44, 19, 17, 19, 17,
+ax_anim 2, 0, 44, 18, 18, 18, 18,
+ax_anim 2, 0, 44, 19, 17, 19, 17,
+ax_anim 4, 0, 32, 12, 8, 12, 12,
+ax_anim 2, 0, 33, 8, 3, 6, 6,
+ax_anim 1, 0, 34, 3, 1, 3, 3,
+ax_anim_terminator
+sKrabbyAnims_2_3:
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -3, 0, 0,
+ax_anim 3, 0, 70, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 1, 0, 69, 0, -2, 0, 0,
+ax_anim 3, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 2, 0, 2, 0,
+ax_anim 1, 2, 63, 4, 0, 4, 0,
+ax_anim 1, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 63, 19, 0, 19, 0,
+ax_anim 2, 1, 63, 19, 1, 19, 1,
+ax_anim 2, 0, 63, 19, 0, 19, 0,
+ax_anim 2, 0, 63, 19, 1, 19, 1,
+ax_anim 4, 0, 31, 14, -4, 14, 0,
+ax_anim 2, 0, 32, 10, -5, 10, 0,
+ax_anim 1, 0, 33, 4, -1, 4, 0,
+ax_anim_terminator
+sKrabbyAnims_2_4:
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 3, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 3, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 2, -2, 2, -2,
+ax_anim 1, 2, 82, 5, -5, 5, -5,
+ax_anim 1, 0, 83, 12, -12, 12, -12,
+ax_anim 2, 0, 82, 22, -22, 22, -22,
+ax_anim 2, 1, 82, 21, -23, 21, -23,
+ax_anim 2, 0, 82, 22, -22, 22, -22,
+ax_anim 2, 0, 82, 21, -23, 21, -23,
+ax_anim 4, 0, 30, 14, -18, 14, -14,
+ax_anim 2, 0, 31, 10, -12, 10, -10,
+ax_anim 1, 0, 32, 4, -5, 4, -4,
+ax_anim_terminator
+sKrabbyAnims_2_5:
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 3, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 105, -1, -4, 0, 0,
+ax_anim 1, 0, 105, -1, -2, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 1, 2, 101, 0, -5, 0, -5,
+ax_anim 1, 0, 102, 0, -12, 0, -12,
+ax_anim 2, 0, 101, 0, -22, 0, -22,
+ax_anim 2, 1, 101, 0, -23, 0, -23,
+ax_anim 2, 0, 101, 0, -22, 0, -22,
+ax_anim 2, 0, 101, 0, -23, 0, -23,
+ax_anim 4, 0, 48, 0, -14, 0, -14,
+ax_anim 2, 0, 49, 2, -10, 0, -10,
+ax_anim 1, 0, 50, 0, -3, 0, -4,
+ax_anim_terminator
+sKrabbyAnims_2_6:
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 3, 0, 124, -1, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 1, 0, 123, 0, -1, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, -2, -2, -2, -2,
+ax_anim 1, 2, 120, -5, -5, -4, -5,
+ax_anim 1, 0, 121, -14, -14, -14, -14,
+ax_anim 2, 0, 120, -20, -20, -20, -20,
+ax_anim 2, 1, 120, -19, -21, -19, -21,
+ax_anim 2, 0, 120, -20, -20, -20, -20,
+ax_anim 2, 0, 120, -19, -21, -19, -21,
+ax_anim 4, 0, 47, -13, -13, -13, -13,
+ax_anim 2, 0, 48, -9, -10, -9, -9,
+ax_anim 1, 0, 49, -3, -3, -3, -3,
+ax_anim_terminator
+sKrabbyAnims_2_7:
+ax_anim 1, 0, 143, -1, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -3, 0, 0,
+ax_anim 3, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 1, 0, 141, 0, -2, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -2, 0, -2, 0,
+ax_anim 1, 2, 139, -4, 0, -4, 0,
+ax_anim 1, 0, 140, -10, 0, -10, 0,
+ax_anim 2, 0, 139, -19, 0, -19, 0,
+ax_anim 2, 1, 139, -19, -1, -19, -1,
+ax_anim 2, 0, 139, -19, 0, -19, 0,
+ax_anim 2, 0, 139, -19, -1, -19, -1,
+ax_anim 4, 0, 46, -14, -3, -14, 0,
+ax_anim 2, 0, 47, -10, -3, -10, 0,
+ax_anim 1, 0, 48, -6, -1, -6, 0,
+ax_anim_terminator
+sKrabbyAnims_2_8:
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 1, 0, 167, 0, -2, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -2, 2, -2, 2,
+ax_anim 1, 2, 158, -4, 4, -4, 4,
+ax_anim 1, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 158, -18, 18, -18, 18,
+ax_anim 2, 1, 158, -19, 17, -19, 17,
+ax_anim 2, 0, 158, -18, 18, -18, 18,
+ax_anim 2, 0, 158, -19, 17, -19, 17,
+ax_anim 4, 0, 53, -12, 8, -12, 12,
+ax_anim 2, 0, 46, -8, 2, -8, 8,
+ax_anim 1, 0, 47, -4, 2, -4, 4,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_3_1:
+ax_anim 2, 0, 176, 0, -2, 0, -2,
+ax_anim 2, 0, 177, 0, -3, 0, -3,
+ax_anim 4, 0, 177, 0, -4, 0, -4,
+ax_anim 1, 1, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 6, 0, 6,
+ax_anim 2, 0, 178, 0, 11, 0, 11,
+ax_anim 2, 2, 179, 1, 11, 1, 11,
+ax_anim 2, 0, 179, 0, 11, 0, 11,
+ax_anim 2, 0, 179, 1, 11, 1, 11,
+ax_anim 2, 0, 179, 0, 11, 0, 11,
+ax_anim 2, 0, 179, 1, 11, 1, 11,
+ax_anim 2, 0, 176, 0, 5, 0, 5,
+ax_anim_terminator
+sKrabbyAnims_3_2:
+ax_anim 2, 0, 180, -2, -2, -2, -2,
+ax_anim 2, 0, 181, -3, -3, -3, -3,
+ax_anim 4, 0, 181, -4, -4, -4, -4,
+ax_anim 1, 1, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 6, 3, 6, 3,
+ax_anim 2, 0, 182, 17, 14, 17, 14,
+ax_anim 2, 2, 183, 18, 13, 18, 13,
+ax_anim 2, 0, 183, 17, 14, 17, 14,
+ax_anim 2, 0, 183, 18, 13, 18, 13,
+ax_anim 2, 0, 183, 17, 14, 17, 14,
+ax_anim 2, 0, 183, 18, 13, 18, 13,
+ax_anim 2, 0, 180, 5, 4, 5, 4,
+ax_anim_terminator
+sKrabbyAnims_3_3:
+ax_anim 2, 0, 184, -2, 0, -2, 0,
+ax_anim 2, 0, 185, -3, 0, -3, 0,
+ax_anim 4, 0, 185, -4, 0, -4, 0,
+ax_anim 1, 1, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 5, 0, 5, 0,
+ax_anim 2, 0, 186, 15, 0, 15, 0,
+ax_anim 2, 2, 187, 15, -1, 15, -1,
+ax_anim 2, 0, 187, 15, 0, 15, 0,
+ax_anim 2, 0, 187, 15, -1, 15, -1,
+ax_anim 2, 0, 187, 15, 0, 15, 0,
+ax_anim 2, 0, 187, 15, -1, 15, -1,
+ax_anim 2, 0, 184, 5, 0, 5, 4,
+ax_anim_terminator
+sKrabbyAnims_3_4:
+ax_anim 2, 0, 188, -2, 2, -2, 2,
+ax_anim 2, 0, 189, -3, 3, -3, 3,
+ax_anim 4, 0, 189, -4, 4, -4, 4,
+ax_anim 1, 1, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 5, -7, 5, -7,
+ax_anim 2, 0, 190, 15, -20, 15, -20,
+ax_anim 2, 2, 191, 14, -21, 14, -21,
+ax_anim 2, 0, 191, 15, -20, 15, -20,
+ax_anim 2, 0, 191, 14, -21, 14, -21,
+ax_anim 2, 0, 191, 15, -20, 15, -20,
+ax_anim 2, 0, 191, 14, -21, 14, -21,
+ax_anim 2, 0, 188, 5, -7, 5, -7,
+ax_anim_terminator
+sKrabbyAnims_3_5:
+ax_anim 2, 0, 192, 0, 2, 0, 2,
+ax_anim 2, 0, 193, 0, 3, 0, 3,
+ax_anim 4, 0, 193, 0, 4, 0, 4,
+ax_anim 1, 1, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, -12,
+ax_anim 2, 0, 194, 0, -20, 0, -20,
+ax_anim 2, 2, 195, 1, -20, 1, -20,
+ax_anim 2, 0, 195, 0, -20, 0, -20,
+ax_anim 2, 0, 195, 1, -20, 1, -20,
+ax_anim 2, 0, 195, 0, -20, 0, -20,
+ax_anim 2, 0, 195, 1, -20, 1, -20,
+ax_anim 2, 0, 192, 0, -7, 0, -7,
+ax_anim_terminator
+sKrabbyAnims_3_6:
+ax_anim 2, 0, 196, 2, 2, 2, 2,
+ax_anim 2, 0, 197, 3, 3, 3, 3,
+ax_anim 4, 0, 197, 4, 4, 4, 4,
+ax_anim 1, 1, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 197, -5, -7, -5, -7,
+ax_anim 2, 0, 198, -15, -20, -15, -20,
+ax_anim 2, 2, 199, -14, -21, -14, -21,
+ax_anim 2, 0, 199, -15, -20, -15, -20,
+ax_anim 2, 0, 199, -14, -21, -14, -21,
+ax_anim 2, 0, 199, -15, -20, -15, -20,
+ax_anim 2, 0, 199, -14, -21, -14, -21,
+ax_anim 2, 0, 196, -5, -7, -5, -7,
+ax_anim_terminator
+sKrabbyAnims_3_7:
+ax_anim 2, 0, 200, 2, 0, 2, 0,
+ax_anim 2, 0, 201, 3, 0, 3, 0,
+ax_anim 4, 0, 201, 4, 0, 4, 0,
+ax_anim 1, 1, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, -5, 0, -5, 0,
+ax_anim 2, 0, 202, -15, 0, -15, 0,
+ax_anim 2, 2, 203, -15, -1, -15, -1,
+ax_anim 2, 0, 203, -15, 0, -15, 0,
+ax_anim 2, 0, 203, -15, -1, -15, -1,
+ax_anim 2, 0, 203, -15, 0, -15, 0,
+ax_anim 2, 0, 203, -15, -1, -15, -1,
+ax_anim 2, 0, 200, -5, 0, -5, 4,
+ax_anim_terminator
+sKrabbyAnims_3_8:
+ax_anim 2, 0, 204, 2, -2, 2, -2,
+ax_anim 2, 0, 205, 3, -3, 3, -3,
+ax_anim 4, 0, 205, 4, -4, 4, -4,
+ax_anim 1, 1, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 205, -6, 3, -6, 3,
+ax_anim 2, 0, 206, -17, 14, -17, 14,
+ax_anim 2, 2, 207, -18, 13, -18, 13,
+ax_anim 2, 0, 207, -17, 14, -17, 14,
+ax_anim 2, 0, 207, -18, 13, -18, 13,
+ax_anim 2, 0, 207, -17, 14, -17, 14,
+ax_anim 2, 0, 207, -18, 13, -18, 13,
+ax_anim 2, 0, 204, -5, 4, -5, 4,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_4_1:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 2, 0, 2,
+ax_anim 2, 0, 210, 0, 3, 0, 3,
+ax_anim 2, 0, 210, 1, 3, 1, 3,
+ax_anim 2, 0, 210, 0, 3, 0, 3,
+ax_anim 2, 1, 210, 1, 3, 1, 3,
+ax_anim 2, 0, 210, 0, 3, 0, 3,
+ax_anim 1, 0, 209, 0, -2, 0, -2,
+ax_anim 2, 0, 209, 0, -4, 0, -4,
+ax_anim 4, 0, 209, 0, -5, 0, -5,
+ax_anim 2, 0, 209, 0, -4, 0, -4,
+ax_anim 1, 0, 208, 0, -2, 0, -2,
+ax_anim_terminator
+sKrabbyAnims_4_2:
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 2, 2, 2, 2,
+ax_anim 2, 0, 213, 3, 3, 3, 3,
+ax_anim 2, 0, 213, 4, 2, 4, 2,
+ax_anim 2, 0, 213, 3, 3, 3, 3,
+ax_anim 2, 1, 213, 4, 2, 4, 2,
+ax_anim 2, 0, 213, 3, 3, 3, 3,
+ax_anim 1, 0, 212, -2, -2, -2, -2,
+ax_anim 2, 0, 212, -4, -4, -4, -4,
+ax_anim 4, 0, 212, -5, -5, -5, -5,
+ax_anim 2, 0, 212, -4, -4, -4, -4,
+ax_anim 1, 0, 211, -2, -2, -2, -2,
+ax_anim_terminator
+sKrabbyAnims_4_3:
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 2, 0, 2, 0,
+ax_anim 2, 0, 216, 3, 0, 3, 0,
+ax_anim 2, 0, 216, 3, -1, 3, -1,
+ax_anim 2, 0, 216, 3, 0, 3, 0,
+ax_anim 2, 1, 216, 3, -1, 3, -1,
+ax_anim 2, 0, 216, 3, 0, 3, 0,
+ax_anim 1, 0, 215, -2, 0, -2, 0,
+ax_anim 2, 0, 215, -4, 0, -4, 0,
+ax_anim 4, 0, 215, -5, 0, -5, 0,
+ax_anim 2, 0, 215, -4, 0, -4, 0,
+ax_anim 1, 0, 214, -2, 0, -2, 0,
+ax_anim_terminator
+sKrabbyAnims_4_4:
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 2, -2, 2, -2,
+ax_anim 2, 0, 219, 3, -3, 3, -3,
+ax_anim 2, 0, 219, 2, -4, 2, -4,
+ax_anim 2, 0, 219, 3, -3, 3, -3,
+ax_anim 2, 1, 219, 2, -4, 2, -4,
+ax_anim 2, 0, 219, 3, -3, 3, -3,
+ax_anim 1, 0, 218, -2, 2, -2, 2,
+ax_anim 2, 0, 218, -4, 4, -4, 4,
+ax_anim 4, 0, 218, -5, 5, -5, 5,
+ax_anim 2, 0, 218, -4, 4, -4, 4,
+ax_anim 1, 0, 217, -2, 2, -2, 2,
+ax_anim_terminator
+sKrabbyAnims_4_5:
+ax_anim 4, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, -3, 0, -3,
+ax_anim 2, 0, 222, 0, -4, 0, -4,
+ax_anim 2, 0, 222, 1, -4, 1, -4,
+ax_anim 2, 0, 222, 0, -4, 0, -4,
+ax_anim 2, 1, 222, 1, -4, 1, -4,
+ax_anim 2, 0, 222, 0, -4, 0, -4,
+ax_anim 1, 0, 221, 0, 2, 0, 2,
+ax_anim 2, 0, 221, 0, 4, 0, 4,
+ax_anim 4, 0, 221, 0, 5, 0, 5,
+ax_anim 2, 0, 221, 0, 4, 0, 4,
+ax_anim 1, 0, 220, 0, 2, 0, 2,
+ax_anim_terminator
+sKrabbyAnims_4_6:
+ax_anim 4, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 225, -2, -2, -2, -2,
+ax_anim 2, 0, 225, -3, -3, -3, -3,
+ax_anim 2, 0, 225, -2, -4, -2, -4,
+ax_anim 2, 0, 225, -3, -3, -3, -3,
+ax_anim 2, 1, 225, -2, -4, -2, -4,
+ax_anim 2, 0, 225, -3, -3, -3, -3,
+ax_anim 1, 0, 224, 2, 2, 2, 2,
+ax_anim 2, 0, 224, 4, 4, 4, 4,
+ax_anim 4, 0, 224, 5, 5, 5, 5,
+ax_anim 2, 0, 224, 4, 4, 4, 4,
+ax_anim 1, 0, 223, 2, 2, 2, 2,
+ax_anim_terminator
+sKrabbyAnims_4_7:
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 228, -2, 0, -2, 0,
+ax_anim 2, 0, 228, -3, 0, -3, 0,
+ax_anim 2, 0, 228, -3, -1, -3, -1,
+ax_anim 2, 0, 228, -3, 0, -3, 0,
+ax_anim 2, 1, 228, -3, -1, -3, -1,
+ax_anim 2, 0, 228, -3, 0, -3, 0,
+ax_anim 1, 0, 227, 2, 0, 2, 0,
+ax_anim 2, 0, 227, 4, 0, 4, 0,
+ax_anim 4, 0, 227, 5, 0, 5, 0,
+ax_anim 2, 0, 227, 4, 0, 4, 0,
+ax_anim 1, 0, 226, 2, 0, 2, 0,
+ax_anim_terminator
+sKrabbyAnims_4_8:
+ax_anim 4, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 231, -2, 2, -2, 2,
+ax_anim 2, 0, 231, -3, 3, -3, 3,
+ax_anim 2, 0, 231, -4, 2, -4, 2,
+ax_anim 2, 0, 231, -3, 3, -3, 3,
+ax_anim 2, 1, 231, -4, 2, -4, 2,
+ax_anim 2, 0, 231, -3, 3, -3, 3,
+ax_anim 1, 0, 230, 2, -2, 2, -2,
+ax_anim 2, 0, 230, 4, -4, 4, -4,
+ax_anim 4, 0, 230, 5, -5, 5, -5,
+ax_anim 2, 0, 230, 4, -4, 4, -4,
+ax_anim 1, 0, 229, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_5_1:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_5_2:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_5_3:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_5_4:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_5_5:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_5_6:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_5_7:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_5_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_6_1:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 35, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_7_1:
+ax_anim 2, 0, 242, 0, -4, 0, -4,
+ax_anim 8, 0, 242, 0, -5, 0, -5,
+ax_anim_terminator
+sKrabbyAnims_7_2:
+ax_anim 2, 0, 243, -4, -4, -4, -4,
+ax_anim 8, 0, 243, -5, -5, -5, -5,
+ax_anim_terminator
+sKrabbyAnims_7_3:
+ax_anim 2, 0, 244, -4, 0, -4, 0,
+ax_anim 8, 0, 244, -5, 0, -5, 0,
+ax_anim_terminator
+sKrabbyAnims_7_4:
+ax_anim 2, 0, 245, -4, 4, -4, 4,
+ax_anim 8, 0, 245, -5, 5, -5, 5,
+ax_anim_terminator
+sKrabbyAnims_7_5:
+ax_anim 2, 0, 246, 0, 4, 0, 4,
+ax_anim 8, 0, 246, 0, 5, 0, 5,
+ax_anim_terminator
+sKrabbyAnims_7_6:
+ax_anim 2, 0, 247, 4, 4, 4, 4,
+ax_anim 8, 0, 247, 5, 5, 5, 5,
+ax_anim_terminator
+sKrabbyAnims_7_7:
+ax_anim 2, 0, 248, 4, 0, 4, 0,
+ax_anim 8, 0, 248, 5, 0, 5, 0,
+ax_anim_terminator
+sKrabbyAnims_7_8:
+ax_anim 2, 0, 249, 4, -4, 4, -4,
+ax_anim 8, 0, 249, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_8_1:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_8_2:
+ax_anim 30, 0, 254, 0, 0, 0, 0,
+ax_anim 30, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_8_3:
+ax_anim 30, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_8_4:
+ax_anim 30, 0, 262, 0, 0, 0, 0,
+ax_anim 30, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_8_5:
+ax_anim 30, 0, 266, 0, 0, 0, 0,
+ax_anim 30, 0, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_8_6:
+ax_anim 30, 0, 270, 0, 0, 0, 0,
+ax_anim 30, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_8_7:
+ax_anim 30, 0, 274, 0, 0, 0, 0,
+ax_anim 30, 0, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_8_8:
+ax_anim 30, 0, 278, 0, 0, 0, 0,
+ax_anim 30, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_9_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 1, 0, 283, 6, 3, 6, 3,
+ax_anim 2, 0, 284, 8, 9, 8, 9,
+ax_anim 2, 0, 285, 7, 16, 7, 16,
+ax_anim 3, 0, 286, 0, 20, 0, 20,
+ax_anim 2, 3, 287, -7, 16, -7, 16,
+ax_anim 2, 0, 288, -8, 9, -8, 9,
+ax_anim 1, 0, 289, -6, 3, -6, 3,
+ax_anim 1, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_9_2:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 1, 0, 282, 8, 0, 8, 0,
+ax_anim 2, 0, 283, 17, 3, 17, 3,
+ax_anim 2, 0, 284, 21, 10, 21, 10,
+ax_anim 3, 0, 285, 22, 18, 22, 18,
+ax_anim 2, 3, 286, 13, 21, 13, 21,
+ax_anim 2, 0, 287, 3, 15, 3, 15,
+ax_anim 1, 0, 288, 0, 7, 0, 7,
+ax_anim 1, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_9_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 1, 0, 289, 3, -5, 3, -5,
+ax_anim 2, 0, 282, 11, -6, 11, -6,
+ax_anim 2, 0, 283, 18, -5, 18, -5,
+ax_anim 3, 0, 284, 23, -2, 23, -2,
+ax_anim 2, 3, 285, 20, 3, 20, 3,
+ax_anim 2, 0, 286, 12, 7, 12, 7,
+ax_anim 1, 0, 287, 4, 5, 4, 5,
+ax_anim 1, 0, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_9_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 1, 0, 288, -1, -8, -1, -8,
+ax_anim 2, 0, 289, 4, -16, 4, -16,
+ax_anim 2, 0, 282, 12, -24, 12, -24,
+ax_anim 3, 0, 283, 21, -26, 21, -26,
+ax_anim 2, 3, 284, 23, -15, 23, -15,
+ax_anim 2, 0, 285, 18, -6, 18, -6,
+ax_anim 1, 0, 286, 8, 1, 8, 1,
+ax_anim 1, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_9_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 1, 0, 287, -8, -4, -8, -4,
+ax_anim 2, 0, 288, -9, -12, -9, -12,
+ax_anim 2, 0, 289, -7, -23, -7, -23,
+ax_anim 3, 0, 282, 0, -27, 0, -27,
+ax_anim 2, 3, 283, 7, -23, 7, -23,
+ax_anim 2, 0, 284, 9, -10, 9, -10,
+ax_anim 1, 0, 285, 8, -4, 8, -4,
+ax_anim 1, 0, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_9_6:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 1, 0, 284, 1, -8, 1, -8,
+ax_anim 2, 0, 283, -4, -16, -4, -16,
+ax_anim 2, 0, 282, -12, -24, -12, -24,
+ax_anim 3, 0, 289, -21, -26, -21, -26,
+ax_anim 2, 3, 288, -23, -15, -23, -15,
+ax_anim 2, 0, 287, -18, -6, -18, -6,
+ax_anim 1, 0, 286, -8, -1, -8, -1,
+ax_anim 1, 0, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_9_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 1, 0, 283, -3, -5, -3, -5,
+ax_anim 2, 0, 282, -11, -6, -11, -6,
+ax_anim 2, 0, 289, -18, -5, -18, -5,
+ax_anim 3, 0, 288, -23, -2, -23, -2,
+ax_anim 2, 3, 287, -20, 3, -20, 3,
+ax_anim 2, 0, 286, -12, 7, -12, 7,
+ax_anim 1, 0, 285, -4, 5, -4, 5,
+ax_anim 1, 0, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_9_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 1, 0, 282, -8, 0, -8, 0,
+ax_anim 2, 0, 289, -17, 3, -17, 3,
+ax_anim 2, 0, 288, -21, 10, -21, 10,
+ax_anim 3, 0, 287, -22, 18, -22, 18,
+ax_anim 2, 3, 286, -13, 21, -13, 21,
+ax_anim 2, 0, 285, -3, 15, -3, 15,
+ax_anim 1, 0, 284, 0, 7, 0, 7,
+ax_anim 1, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_10_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 6, 0, 6, 0,
+ax_anim 2, 0, 290, -6, 0, -6, 0,
+ax_anim 2, 0, 290, 10, 0, 10, 0,
+ax_anim 2, 0, 290, -10, 0, -10, 0,
+ax_anim 2, 0, 290, 12, 0, 12, 0,
+ax_anim 3, 0, 290, -12, 0, -12, 0,
+ax_anim 3, 0, 290, 13, 0, 13, 0,
+ax_anim 3, 0, 290, -13, 0, -13, 0,
+ax_anim 2, 0, 290, 12, 0, 12, 0,
+ax_anim 3, 0, 290, -12, 0, -12, 0,
+ax_anim 2, 0, 290, 10, 0, 10, 0,
+ax_anim 2, 0, 290, -10, 0, -10, 0,
+ax_anim 2, 0, 290, 6, 0, 6, 0,
+ax_anim 2, 0, 290, -6, 0, -6, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_10_2:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 6, -6, 6, -6,
+ax_anim 2, 0, 291, -6, 6, -6, 6,
+ax_anim 2, 0, 291, 10, -10, 10, -10,
+ax_anim 2, 0, 291, -10, 10, -10, 10,
+ax_anim 2, 0, 291, 12, -12, 12, -12,
+ax_anim 3, 0, 291, -12, 12, -12, 12,
+ax_anim 3, 0, 291, 13, -13, 13, -13,
+ax_anim 3, 0, 291, -13, 13, -13, 13,
+ax_anim 2, 0, 291, 12, -12, 12, -12,
+ax_anim 3, 0, 291, -12, 12, -12, 12,
+ax_anim 2, 0, 291, 10, -10, 10, -10,
+ax_anim 2, 0, 291, -10, 10, -10, 10,
+ax_anim 2, 0, 291, 6, -6, 6, -6,
+ax_anim 2, 0, 291, -6, 6, -6, 6,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_10_3:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, -6, 0, -6,
+ax_anim 2, 0, 292, 0, 6, 0, 6,
+ax_anim 2, 0, 292, 0, -10, 0, -10,
+ax_anim 2, 0, 292, 0, 10, 0, 10,
+ax_anim 2, 0, 292, 0, -12, 0, -12,
+ax_anim 3, 0, 292, 0, 12, 0, 12,
+ax_anim 3, 0, 292, 0, -13, 0, -13,
+ax_anim 3, 0, 292, 0, 13, 0, 13,
+ax_anim 2, 0, 292, 0, -12, 0, -12,
+ax_anim 3, 0, 292, 0, 12, 0, 12,
+ax_anim 2, 0, 292, 0, -10, 0, -10,
+ax_anim 2, 0, 292, 0, 10, 0, 10,
+ax_anim 2, 0, 292, 0, -6, 0, -6,
+ax_anim 2, 0, 292, 0, 6, 0, 6,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_10_4:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 293, -6, -6, -6, -6,
+ax_anim 2, 0, 293, 6, 6, 6, 6,
+ax_anim 2, 0, 293, -10, -10, -10, -10,
+ax_anim 2, 0, 293, 10, 10, 10, 10,
+ax_anim 2, 0, 293, -12, -12, -12, -12,
+ax_anim 3, 0, 293, 12, 12, 12, 12,
+ax_anim 3, 0, 293, -13, -13, -13, -13,
+ax_anim 3, 0, 293, 13, 13, 13, 13,
+ax_anim 2, 0, 293, -12, -12, -12, -12,
+ax_anim 3, 0, 293, 12, 12, 12, 12,
+ax_anim 2, 0, 293, -10, -10, -10, -10,
+ax_anim 2, 0, 293, 10, 10, 10, 10,
+ax_anim 2, 0, 293, -6, -6, -6, -6,
+ax_anim 2, 0, 293, 6, 6, 6, 6,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_10_5:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 6, 0, 6, 0,
+ax_anim 2, 0, 294, -6, 0, -6, 0,
+ax_anim 2, 0, 294, 10, 0, 10, 0,
+ax_anim 2, 0, 294, -10, 0, -10, 0,
+ax_anim 2, 0, 294, 12, 0, 12, 0,
+ax_anim 3, 0, 294, -12, 0, -12, 0,
+ax_anim 3, 0, 294, 13, 0, 13, 0,
+ax_anim 3, 0, 294, -13, 0, -13, 0,
+ax_anim 2, 0, 294, 12, 0, 12, 0,
+ax_anim 3, 0, 294, -12, 0, -12, 0,
+ax_anim 2, 0, 294, 10, 0, 10, 0,
+ax_anim 2, 0, 294, -10, 0, -10, 0,
+ax_anim 2, 0, 294, 6, 0, 6, 0,
+ax_anim 2, 0, 294, -6, 0, -6, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_10_6:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 6, -6, 6, -6,
+ax_anim 2, 0, 295, -6, 6, -6, 6,
+ax_anim 2, 0, 295, 10, -10, 10, -10,
+ax_anim 2, 0, 295, -10, 10, -10, 10,
+ax_anim 2, 0, 295, 12, -12, 12, -12,
+ax_anim 3, 0, 295, -12, 12, -12, 12,
+ax_anim 3, 0, 295, 13, -13, 13, -13,
+ax_anim 3, 0, 295, -13, 13, -13, 13,
+ax_anim 2, 0, 295, 12, -12, 12, -12,
+ax_anim 3, 0, 295, -12, 12, -12, 12,
+ax_anim 2, 0, 295, 10, -10, 10, -10,
+ax_anim 2, 0, 295, -10, 10, -10, 10,
+ax_anim 2, 0, 295, 6, -6, 6, -6,
+ax_anim 2, 0, 295, -6, 6, -6, 6,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_10_7:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, -6, 0, -6,
+ax_anim 2, 0, 296, 0, 6, 0, 6,
+ax_anim 2, 0, 296, 0, -10, 0, -10,
+ax_anim 2, 0, 296, 0, 10, 0, 10,
+ax_anim 2, 0, 296, 0, -12, 0, -12,
+ax_anim 3, 0, 296, 0, 12, 0, 12,
+ax_anim 3, 0, 296, 0, -13, 0, -13,
+ax_anim 3, 0, 296, 0, 13, 0, 13,
+ax_anim 2, 0, 296, 0, -12, 0, -12,
+ax_anim 3, 0, 296, 0, 12, 0, 12,
+ax_anim 2, 0, 296, 0, -10, 0, -10,
+ax_anim 2, 0, 296, 0, 10, 0, 10,
+ax_anim 2, 0, 296, 0, -6, 0, -6,
+ax_anim 2, 0, 296, 0, 6, 0, 6,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_10_8:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 297, -6, -6, -6, -6,
+ax_anim 2, 0, 297, 6, 6, 6, 6,
+ax_anim 2, 0, 297, -10, -10, -10, -10,
+ax_anim 2, 0, 297, 10, 10, 10, 10,
+ax_anim 2, 0, 297, -12, -12, -12, -12,
+ax_anim 3, 0, 297, 12, 12, 12, 12,
+ax_anim 3, 0, 297, -13, -13, -13, -13,
+ax_anim 3, 0, 297, 13, 13, 13, 13,
+ax_anim 2, 0, 297, -12, -12, -12, -12,
+ax_anim 3, 0, 297, 12, 12, 12, 12,
+ax_anim 2, 0, 297, -10, -10, -10, -10,
+ax_anim 2, 0, 297, 10, 10, 10, 10,
+ax_anim 2, 0, 297, -6, -6, -6, -6,
+ax_anim 2, 0, 297, 6, 6, 6, 6,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_11_1:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 1, 0, 299, 0, -10, 0, 0,
+ax_anim 2, 0, 299, 0, -16, 0, 0,
+ax_anim 3, 0, 299, 0, -20, 0, 0,
+ax_anim 4, 0, 299, 0, -21, 0, 0,
+ax_anim 4, 0, 300, 0, -25, 0, 0,
+ax_anim 3, 0, 300, 0, -24, 0, 0,
+ax_anim 2, 0, 300, 0, -18, 0, 0,
+ax_anim 1, 0, 300, 0, -12, 0, 0,
+ax_anim 2, 2, 298, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_11_2:
+ax_anim 2, 0, 301, 0, 0, 0, 0,
+ax_anim 1, 0, 302, 0, -10, 0, 0,
+ax_anim 2, 0, 302, 0, -16, 0, 0,
+ax_anim 3, 0, 302, 0, -20, 0, 0,
+ax_anim 4, 0, 302, 0, -21, 0, 0,
+ax_anim 4, 0, 303, 0, -27, 0, 0,
+ax_anim 3, 0, 303, 0, -26, 0, 0,
+ax_anim 2, 0, 303, 0, -18, 0, 0,
+ax_anim 1, 0, 303, 0, -12, 0, 0,
+ax_anim 2, 2, 301, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_11_3:
+ax_anim 2, 0, 304, 0, 0, 0, 0,
+ax_anim 1, 0, 305, 0, -10, 0, 0,
+ax_anim 2, 0, 305, 0, -16, 0, 0,
+ax_anim 3, 0, 305, 0, -20, 0, 0,
+ax_anim 4, 0, 305, 0, -21, 0, 0,
+ax_anim 4, 0, 306, 0, -23, 0, 0,
+ax_anim 3, 0, 306, 0, -22, 0, 0,
+ax_anim 2, 0, 306, 0, -18, 0, 0,
+ax_anim 1, 0, 306, 0, -12, 0, 0,
+ax_anim 2, 2, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_11_4:
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 1, 0, 308, 0, -10, 0, 0,
+ax_anim 2, 0, 308, 0, -16, 0, 0,
+ax_anim 3, 0, 308, 0, -20, 0, 0,
+ax_anim 4, 0, 308, 0, -21, 0, 0,
+ax_anim 4, 0, 309, 0, -22, 0, 0,
+ax_anim 3, 0, 309, 0, -21, 0, 0,
+ax_anim 2, 0, 309, 0, -17, 0, 0,
+ax_anim 1, 0, 309, 0, -11, 0, 0,
+ax_anim 2, 2, 307, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_11_5:
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 1, 0, 311, 0, -10, 0, 0,
+ax_anim 2, 0, 311, 0, -16, 0, 0,
+ax_anim 3, 0, 311, 0, -20, 0, 0,
+ax_anim 4, 0, 311, 0, -21, 0, 0,
+ax_anim 4, 0, 312, 0, -25, 0, 0,
+ax_anim 3, 0, 312, 0, -24, 0, 0,
+ax_anim 2, 0, 312, 0, -18, 0, 0,
+ax_anim 1, 0, 312, 0, -12, 0, 0,
+ax_anim 2, 2, 310, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_11_6:
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 1, 0, 314, 0, -10, 0, 0,
+ax_anim 2, 0, 314, 0, -16, 0, 0,
+ax_anim 3, 0, 314, 0, -20, 0, 0,
+ax_anim 4, 0, 314, 0, -21, 0, 0,
+ax_anim 4, 0, 315, 0, -22, 0, 0,
+ax_anim 3, 0, 315, 0, -21, 0, 0,
+ax_anim 2, 0, 315, 0, -17, 0, 0,
+ax_anim 1, 0, 315, 0, -11, 0, 0,
+ax_anim 2, 2, 313, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_11_7:
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 1, 0, 317, 0, -10, 0, 0,
+ax_anim 2, 0, 317, 0, -16, 0, 0,
+ax_anim 3, 0, 317, 0, -20, 0, 0,
+ax_anim 4, 0, 317, 0, -21, 0, 0,
+ax_anim 4, 0, 318, 0, -23, 0, 0,
+ax_anim 3, 0, 318, 0, -22, 0, 0,
+ax_anim 2, 0, 318, 0, -18, 0, 0,
+ax_anim 1, 0, 318, 0, -12, 0, 0,
+ax_anim 2, 2, 316, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_11_8:
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 1, 0, 320, 0, -10, 0, 0,
+ax_anim 2, 0, 320, 0, -16, 0, 0,
+ax_anim 3, 0, 320, 0, -20, 0, 0,
+ax_anim 4, 0, 320, 0, -21, 0, 0,
+ax_anim 4, 0, 321, 0, -27, 0, 0,
+ax_anim 3, 0, 321, 0, -26, 0, 0,
+ax_anim 2, 0, 321, 0, -18, 0, 0,
+ax_anim 1, 0, 321, 0, -12, 0, 0,
+ax_anim 2, 2, 319, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_12_1:
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 2, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, 0, 1, 0,
+ax_anim 2, 1, 322, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_12_2:
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 2, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 0, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 329, 1, -1, 1, -1,
+ax_anim 2, 1, 329, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_12_3:
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 2, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 328, 0, -1, 0, -1,
+ax_anim 2, 1, 328, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_12_4:
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 2, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 1, 327, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_12_5:
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 2, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 0, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 1, 0, 1, 0,
+ax_anim 2, 1, 326, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_12_6:
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 2, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 1, -1, 1, -1,
+ax_anim 2, 1, 325, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_12_7:
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 2, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 1, 324, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_12_8:
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 2, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 0, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 323, -1, -1, -1, -1,
+ax_anim 2, 1, 323, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKrabbyAnims_13_1:
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 2, 330, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_13_2:
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 2, 337, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_13_3:
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 2, 336, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_13_4:
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 2, 335, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_13_5:
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 2, 334, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_13_6:
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 2, 333, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_13_7:
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 2, 332, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyAnims_13_8:
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 2, 331, 0, 0, 0, 0,
+ax_anim_terminator
+sKrabbyGfx1:
+.incbin "baserom.gba", 0x9301F4, 0x100
+sKrabbySprites1:
+ax_sprite sKrabbyGfx1, 0x100
+ax_sprite_terminator
+sKrabbyGfx2:
+.incbin "baserom.gba", 0x930304, 0x100
+sKrabbySprites2:
+ax_sprite sKrabbyGfx2, 0x100
+ax_sprite_terminator
+sKrabbyGfx3:
+.incbin "baserom.gba", 0x930414, 0x200
+sKrabbySprites3:
+ax_sprite sKrabbyGfx3, 0x200
+ax_sprite_terminator
+sKrabbyGfx4:
+.incbin "baserom.gba", 0x930624, 0x200
+sKrabbySprites4:
+ax_sprite sKrabbyGfx4, 0x200
+ax_sprite_terminator
+sKrabbyGfx5:
+.incbin "baserom.gba", 0x930834, 0x200
+sKrabbySprites5:
+ax_sprite sKrabbyGfx5, 0x200
+ax_sprite_terminator
+sKrabbyGfx6:
+.incbin "baserom.gba", 0x930A44, 0x200
+sKrabbySprites6:
+ax_sprite sKrabbyGfx6, 0x200
+ax_sprite_terminator
+sKrabbyGfx7:
+.incbin "baserom.gba", 0x930C54, 0x200
+sKrabbySprites7:
+ax_sprite sKrabbyGfx7, 0x200
+ax_sprite_terminator
+sKrabbyGfx8:
+.incbin "baserom.gba", 0x930E64, 0x100
+sKrabbySprites8:
+ax_sprite sKrabbyGfx8, 0x100
+ax_sprite_terminator
+sKrabbyGfx9:
+.incbin "baserom.gba", 0x930F74, 0x100
+sKrabbySprites9:
+ax_sprite sKrabbyGfx9, 0x100
+ax_sprite_terminator
+sKrabbyGfx10:
+.incbin "baserom.gba", 0x931084, 0x200
+sKrabbySprites10:
+ax_sprite sKrabbyGfx10, 0x200
+ax_sprite_terminator
+sKrabbyGfx11:
+.incbin "baserom.gba", 0x931294, 0x200
+sKrabbySprites11:
+ax_sprite sKrabbyGfx11, 0x200
+ax_sprite_terminator
+sKrabbyGfx12:
+.incbin "baserom.gba", 0x9314A4, 0x100
+sKrabbySprites12:
+ax_sprite sKrabbyGfx12, 0x100
+ax_sprite_terminator
+sKrabbyGfx13:
+.incbin "baserom.gba", 0x9315B4, 0x100
+sKrabbySprites13:
+ax_sprite sKrabbyGfx13, 0x100
+ax_sprite_terminator
+sKrabbyGfx14:
+.incbin "baserom.gba", 0x9316C4, 0x100
+sKrabbySprites14:
+ax_sprite sKrabbyGfx14, 0x100
+ax_sprite_terminator
+sKrabbyGfx15:
+.incbin "baserom.gba", 0x9317D4, 0x100
+sKrabbySprites15:
+ax_sprite sKrabbyGfx15, 0x100
+ax_sprite_terminator
+sKrabbyGfx16:
+.incbin "baserom.gba", 0x9318E4, 0x80
+sKrabbyGfx16_1:
+.incbin "baserom.gba", 0x931964, 0x40
+sKrabbyGfx16_2:
+.incbin "baserom.gba", 0x9319A4, 0x80
+sKrabbySprites16:
+ax_sprite sKrabbyGfx16, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx16_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKrabbyGfx17:
+.incbin "baserom.gba", 0x931A5C, 0x60
+sKrabbyGfx17_1:
+.incbin "baserom.gba", 0x931ABC, 0x60
+sKrabbyGfx17_2:
+.incbin "baserom.gba", 0x931B1C, 0x80
+sKrabbySprites17:
+ax_sprite sKrabbyGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx17_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKrabbyGfx18:
+.incbin "baserom.gba", 0x931BD4, 0x40
+sKrabbyGfx18_1:
+.incbin "baserom.gba", 0x931C14, 0x60
+sKrabbyGfx18_2:
+.incbin "baserom.gba", 0x931C74, 0x40
+sKrabbyGfx18_3:
+.incbin "baserom.gba", 0x931CB4, 0x40
+sKrabbySprites18:
+ax_sprite sKrabbyGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx18_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx19:
+.incbin "baserom.gba", 0x931D3C, 0x60
+sKrabbyGfx19_1:
+.incbin "baserom.gba", 0x931D9C, 0x60
+sKrabbyGfx19_2:
+.incbin "baserom.gba", 0x931DFC, 0xA0
+sKrabbySprites19:
+ax_sprite sKrabbyGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx19_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKrabbyGfx20:
+.incbin "baserom.gba", 0x931ED4, 0x80
+sKrabbyGfx20_1:
+.incbin "baserom.gba", 0x931F54, 0x40
+sKrabbyGfx20_2:
+.incbin "baserom.gba", 0x931F94, 0x80
+sKrabbyGfx20_3:
+.incbin "baserom.gba", 0x932014, 0x40
+sKrabbySprites20:
+ax_sprite sKrabbyGfx20, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx20_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx21:
+.incbin "baserom.gba", 0x93209C, 0x180
+sKrabbySprites21:
+ax_sprite sKrabbyGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKrabbyGfx22:
+.incbin "baserom.gba", 0x932234, 0x20
+sKrabbyGfx22_1:
+.incbin "baserom.gba", 0x932254, 0x1A0
+sKrabbySprites22:
+ax_sprite sKrabbyGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx22_1, 0x1a0
+ax_sprite_terminator
+sKrabbyGfx23:
+.incbin "baserom.gba", 0x932414, 0x100
+sKrabbyGfx23_1:
+.incbin "baserom.gba", 0x932514, 0x40
+sKrabbySprites23:
+ax_sprite 0, 0x80
+ax_sprite sKrabbyGfx23, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx24:
+.incbin "baserom.gba", 0x932584, 0x60
+sKrabbyGfx24_1:
+.incbin "baserom.gba", 0x9325E4, 0x60
+sKrabbyGfx24_2:
+.incbin "baserom.gba", 0x932644, 0x80
+sKrabbyGfx24_3:
+.incbin "baserom.gba", 0x9326C4, 0x20
+sKrabbySprites24:
+ax_sprite sKrabbyGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx24_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx24_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx25:
+.incbin "baserom.gba", 0x93272C, 0xE0
+sKrabbyGfx25_1:
+.incbin "baserom.gba", 0x93280C, 0x60
+sKrabbyGfx25_2:
+.incbin "baserom.gba", 0x93286C, 0x60
+sKrabbySprites25:
+ax_sprite sKrabbyGfx25, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx26:
+.incbin "baserom.gba", 0x932904, 0x40
+sKrabbyGfx26_1:
+.incbin "baserom.gba", 0x932944, 0xE0
+sKrabbySprites26:
+ax_sprite 0, 0xa0
+ax_sprite sKrabbyGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx26_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx27:
+.incbin "baserom.gba", 0x932A54, 0x40
+sKrabbyGfx27_1:
+.incbin "baserom.gba", 0x932A94, 0x40
+sKrabbyGfx27_2:
+.incbin "baserom.gba", 0x932AD4, 0x40
+sKrabbyGfx27_3:
+.incbin "baserom.gba", 0x932B14, 0x40
+sKrabbySprites27:
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx27_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx28:
+.incbin "baserom.gba", 0x932BA4, 0xE0
+sKrabbyGfx28_1:
+.incbin "baserom.gba", 0x932C84, 0x40
+sKrabbyGfx28_2:
+.incbin "baserom.gba", 0x932CC4, 0x40
+sKrabbySprites28:
+ax_sprite sKrabbyGfx28, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx28_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKrabbyGfx29:
+.incbin "baserom.gba", 0x932D3C, 0x60
+sKrabbyGfx29_1:
+.incbin "baserom.gba", 0x932D9C, 0x60
+sKrabbySprites29:
+ax_sprite 0, 0x80
+ax_sprite sKrabbyGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx29_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKrabbyGfx30:
+.incbin "baserom.gba", 0x932E2C, 0xE0
+sKrabbyGfx30_1:
+.incbin "baserom.gba", 0x932F0C, 0x80
+sKrabbyGfx30_2:
+.incbin "baserom.gba", 0x932F8C, 0x20
+sKrabbySprites30:
+ax_sprite sKrabbyGfx30, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx30_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx30_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKrabbyGfx31:
+.incbin "baserom.gba", 0x932FE4, 0x100
+sKrabbyGfx31_1:
+.incbin "baserom.gba", 0x9330E4, 0x40
+sKrabbySprites31:
+ax_sprite sKrabbyGfx31, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx31_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKrabbyGfx32:
+.incbin "baserom.gba", 0x93314C, 0x40
+sKrabbyGfx32_1:
+.incbin "baserom.gba", 0x93318C, 0x60
+sKrabbyGfx32_2:
+.incbin "baserom.gba", 0x9331EC, 0x80
+sKrabbyGfx32_3:
+.incbin "baserom.gba", 0x93326C, 0x20
+sKrabbySprites32:
+ax_sprite sKrabbyGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx32_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx32_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKrabbyGfx33:
+.incbin "baserom.gba", 0x9332D4, 0x180
+sKrabbySprites33:
+ax_sprite sKrabbyGfx33, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKrabbyGfx34:
+.incbin "baserom.gba", 0x93346C, 0x1A0
+sKrabbyGfx34_1:
+.incbin "baserom.gba", 0x93360C, 0x20
+sKrabbySprites34:
+ax_sprite sKrabbyGfx34, 0x1a0
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx34_1, 0x20
+ax_sprite_terminator
+sKrabbyGfx35:
+.incbin "baserom.gba", 0x93364C, 0x100
+sKrabbySprites35:
+ax_sprite 0, 0x80
+ax_sprite sKrabbyGfx35, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKrabbyGfx36:
+.incbin "baserom.gba", 0x93376C, 0x100
+sKrabbyGfx36_1:
+.incbin "baserom.gba", 0x93386C, 0x40
+sKrabbySprites36:
+ax_sprite 0, 0x80
+ax_sprite sKrabbyGfx36, 0x100
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx36_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx37:
+.incbin "baserom.gba", 0x9338DC, 0x40
+sKrabbyGfx37_1:
+.incbin "baserom.gba", 0x93391C, 0xE0
+sKrabbySprites37:
+ax_sprite 0, 0xa0
+ax_sprite sKrabbyGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx37_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKrabbyGfx38:
+.incbin "baserom.gba", 0x933A2C, 0x60
+sKrabbyGfx38_1:
+.incbin "baserom.gba", 0x933A8C, 0x60
+sKrabbySprites38:
+ax_sprite 0, 0x80
+ax_sprite sKrabbyGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx38_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sKrabbyGfx39:
+.incbin "baserom.gba", 0x933B1C, 0x40
+sKrabbyGfx39_1:
+.incbin "baserom.gba", 0x933B5C, 0x60
+sKrabbyGfx39_2:
+.incbin "baserom.gba", 0x933BBC, 0x80
+sKrabbyGfx39_3:
+.incbin "baserom.gba", 0x933C3C, 0x20
+sKrabbySprites39:
+ax_sprite sKrabbyGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sKrabbyGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx39_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx39_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKrabbyGfx40:
+.incbin "baserom.gba", 0x933CA4, 0x40
+sKrabbyGfx40_1:
+.incbin "baserom.gba", 0x933CE4, 0x100
+sKrabbySprites40:
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKrabbyGfx40_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKrabbyGfx41:
+.incbin "baserom.gba", 0x933E14, 0x100
+sKrabbySprites41:
+ax_sprite sKrabbyGfx41, 0x100
+ax_sprite_terminator
+sKrabbyGfx42:
+.incbin "baserom.gba", 0x933F24, 0x100
+sKrabbySprites42:
+ax_sprite sKrabbyGfx42, 0x100
+ax_sprite_terminator
+sKrabbyGfx43:
+.incbin "baserom.gba", 0x934034, 0x200
+sKrabbySprites43:
+ax_sprite sKrabbyGfx43, 0x200
+ax_sprite_terminator
+sKrabbyGfx44:
+.incbin "baserom.gba", 0x934244, 0x200
+sKrabbySprites44:
+ax_sprite sKrabbyGfx44, 0x200
+ax_sprite_terminator
+sKrabbyGfx45:
+.incbin "baserom.gba", 0x934454, 0x200
+sKrabbySprites45:
+ax_sprite sKrabbyGfx45, 0x200
+ax_sprite_terminator
+sKrabbyGfx46:
+.incbin "baserom.gba", 0x934664, 0x200
+sKrabbySprites46:
+ax_sprite sKrabbyGfx46, 0x200
+ax_sprite_terminator
+sKrabbyGfx47:
+.incbin "baserom.gba", 0x934874, 0x200
+sKrabbySprites47:
+ax_sprite sKrabbyGfx47, 0x200
+ax_sprite_terminator
+sAxPosesKrabby:
+.4byte sKrabbyPose1
+.4byte sKrabbyPose2
+.4byte sKrabbyPose3
+.4byte sKrabbyPose4
+.4byte sKrabbyPose5
+.4byte sKrabbyPose6
+.4byte sKrabbyPose7
+.4byte sKrabbyPose8
+.4byte sKrabbyPose9
+.4byte sKrabbyPose10
+.4byte sKrabbyPose11
+.4byte sKrabbyPose12
+.4byte sKrabbyPose13
+.4byte sKrabbyPose14
+.4byte sKrabbyPose15
+.4byte sKrabbyPose16
+.4byte sKrabbyPose17
+.4byte sKrabbyPose18
+.4byte sKrabbyPose19
+.4byte sKrabbyPose20
+.4byte sKrabbyPose21
+.4byte sKrabbyPose22
+.4byte sKrabbyPose23
+.4byte sKrabbyPose24
+.4byte sKrabbyPose25
+.4byte sKrabbyPose26
+.4byte sKrabbyPose27
+.4byte sKrabbyPose28
+.4byte sKrabbyPose29
+.4byte sKrabbyPose30
+.4byte sKrabbyPose31
+.4byte sKrabbyPose32
+.4byte sKrabbyPose33
+.4byte sKrabbyPose34
+.4byte sKrabbyPose35
+.4byte sKrabbyPose36
+.4byte sKrabbyPose37
+.4byte sKrabbyPose38
+.4byte sKrabbyPose39
+.4byte sKrabbyPose40
+.4byte sKrabbyPose41
+.4byte sKrabbyPose42
+.4byte sKrabbyPose43
+.4byte sKrabbyPose44
+.4byte sKrabbyPose45
+.4byte sKrabbyPose46
+.4byte sKrabbyPose47
+.4byte sKrabbyPose48
+.4byte sKrabbyPose49
+.4byte sKrabbyPose50
+.4byte sKrabbyPose51
+.4byte sKrabbyPose52
+.4byte sKrabbyPose53
+.4byte sKrabbyPose54
+.4byte sKrabbyPose55
+.4byte sKrabbyPose56
+.4byte sKrabbyPose57
+.4byte sKrabbyPose58
+.4byte sKrabbyPose59
+.4byte sKrabbyPose60
+.4byte sKrabbyPose61
+.4byte sKrabbyPose62
+.4byte sKrabbyPose63
+.4byte sKrabbyPose64
+.4byte sKrabbyPose65
+.4byte sKrabbyPose66
+.4byte sKrabbyPose67
+.4byte sKrabbyPose68
+.4byte sKrabbyPose69
+.4byte sKrabbyPose70
+.4byte sKrabbyPose71
+.4byte sKrabbyPose72
+.4byte sKrabbyPose73
+.4byte sKrabbyPose74
+.4byte sKrabbyPose75
+.4byte sKrabbyPose76
+.4byte sKrabbyPose77
+.4byte sKrabbyPose78
+.4byte sKrabbyPose79
+.4byte sKrabbyPose80
+.4byte sKrabbyPose81
+.4byte sKrabbyPose82
+.4byte sKrabbyPose83
+.4byte sKrabbyPose84
+.4byte sKrabbyPose85
+.4byte sKrabbyPose86
+.4byte sKrabbyPose87
+.4byte sKrabbyPose88
+.4byte sKrabbyPose89
+.4byte sKrabbyPose90
+.4byte sKrabbyPose91
+.4byte sKrabbyPose92
+.4byte sKrabbyPose93
+.4byte sKrabbyPose94
+.4byte sKrabbyPose95
+.4byte sKrabbyPose96
+.4byte sKrabbyPose97
+.4byte sKrabbyPose98
+.4byte sKrabbyPose99
+.4byte sKrabbyPose100
+.4byte sKrabbyPose101
+.4byte sKrabbyPose102
+.4byte sKrabbyPose103
+.4byte sKrabbyPose104
+.4byte sKrabbyPose105
+.4byte sKrabbyPose106
+.4byte sKrabbyPose107
+.4byte sKrabbyPose108
+.4byte sKrabbyPose109
+.4byte sKrabbyPose110
+.4byte sKrabbyPose111
+.4byte sKrabbyPose112
+.4byte sKrabbyPose113
+.4byte sKrabbyPose114
+.4byte sKrabbyPose115
+.4byte sKrabbyPose116
+.4byte sKrabbyPose117
+.4byte sKrabbyPose118
+.4byte sKrabbyPose119
+.4byte sKrabbyPose120
+.4byte sKrabbyPose121
+.4byte sKrabbyPose122
+.4byte sKrabbyPose123
+.4byte sKrabbyPose124
+.4byte sKrabbyPose125
+.4byte sKrabbyPose126
+.4byte sKrabbyPose127
+.4byte sKrabbyPose128
+.4byte sKrabbyPose129
+.4byte sKrabbyPose130
+.4byte sKrabbyPose131
+.4byte sKrabbyPose132
+.4byte sKrabbyPose133
+.4byte sKrabbyPose134
+.4byte sKrabbyPose135
+.4byte sKrabbyPose136
+.4byte sKrabbyPose137
+.4byte sKrabbyPose138
+.4byte sKrabbyPose139
+.4byte sKrabbyPose140
+.4byte sKrabbyPose141
+.4byte sKrabbyPose142
+.4byte sKrabbyPose143
+.4byte sKrabbyPose144
+.4byte sKrabbyPose145
+.4byte sKrabbyPose146
+.4byte sKrabbyPose147
+.4byte sKrabbyPose148
+.4byte sKrabbyPose149
+.4byte sKrabbyPose150
+.4byte sKrabbyPose151
+.4byte sKrabbyPose152
+.4byte sKrabbyPose153
+.4byte sKrabbyPose154
+.4byte sKrabbyPose155
+.4byte sKrabbyPose156
+.4byte sKrabbyPose157
+.4byte sKrabbyPose158
+.4byte sKrabbyPose159
+.4byte sKrabbyPose160
+.4byte sKrabbyPose161
+.4byte sKrabbyPose162
+.4byte sKrabbyPose163
+.4byte sKrabbyPose164
+.4byte sKrabbyPose165
+.4byte sKrabbyPose166
+.4byte sKrabbyPose167
+.4byte sKrabbyPose168
+.4byte sKrabbyPose169
+.4byte sKrabbyPose170
+.4byte sKrabbyPose171
+.4byte sKrabbyPose172
+.4byte sKrabbyPose173
+.4byte sKrabbyPose174
+.4byte sKrabbyPose175
+.4byte sKrabbyPose176
+.4byte sKrabbyPose177
+.4byte sKrabbyPose178
+.4byte sKrabbyPose179
+.4byte sKrabbyPose180
+.4byte sKrabbyPose181
+.4byte sKrabbyPose182
+.4byte sKrabbyPose183
+.4byte sKrabbyPose184
+.4byte sKrabbyPose185
+.4byte sKrabbyPose186
+.4byte sKrabbyPose187
+.4byte sKrabbyPose188
+.4byte sKrabbyPose189
+.4byte sKrabbyPose190
+.4byte sKrabbyPose191
+.4byte sKrabbyPose192
+.4byte sKrabbyPose193
+.4byte sKrabbyPose194
+.4byte sKrabbyPose195
+.4byte sKrabbyPose196
+.4byte sKrabbyPose197
+.4byte sKrabbyPose198
+.4byte sKrabbyPose199
+.4byte sKrabbyPose200
+.4byte sKrabbyPose201
+.4byte sKrabbyPose202
+.4byte sKrabbyPose203
+.4byte sKrabbyPose204
+.4byte sKrabbyPose205
+.4byte sKrabbyPose206
+.4byte sKrabbyPose207
+.4byte sKrabbyPose208
+.4byte sKrabbyPose209
+.4byte sKrabbyPose210
+.4byte sKrabbyPose211
+.4byte sKrabbyPose212
+.4byte sKrabbyPose213
+.4byte sKrabbyPose214
+.4byte sKrabbyPose215
+.4byte sKrabbyPose216
+.4byte sKrabbyPose217
+.4byte sKrabbyPose218
+.4byte sKrabbyPose219
+.4byte sKrabbyPose220
+.4byte sKrabbyPose221
+.4byte sKrabbyPose222
+.4byte sKrabbyPose223
+.4byte sKrabbyPose224
+.4byte sKrabbyPose225
+.4byte sKrabbyPose226
+.4byte sKrabbyPose227
+.4byte sKrabbyPose228
+.4byte sKrabbyPose229
+.4byte sKrabbyPose230
+.4byte sKrabbyPose231
+.4byte sKrabbyPose232
+.4byte sKrabbyPose233
+.4byte sKrabbyPose234
+.4byte sKrabbyPose235
+.4byte sKrabbyPose236
+.4byte sKrabbyPose237
+.4byte sKrabbyPose238
+.4byte sKrabbyPose239
+.4byte sKrabbyPose240
+.4byte sKrabbyPose241
+.4byte sKrabbyPose242
+.4byte sKrabbyPose243
+.4byte sKrabbyPose244
+.4byte sKrabbyPose245
+.4byte sKrabbyPose246
+.4byte sKrabbyPose247
+.4byte sKrabbyPose248
+.4byte sKrabbyPose249
+.4byte sKrabbyPose250
+.4byte sKrabbyPose251
+.4byte sKrabbyPose252
+.4byte sKrabbyPose253
+.4byte sKrabbyPose254
+.4byte sKrabbyPose255
+.4byte sKrabbyPose256
+.4byte sKrabbyPose257
+.4byte sKrabbyPose258
+.4byte sKrabbyPose259
+.4byte sKrabbyPose260
+.4byte sKrabbyPose261
+.4byte sKrabbyPose262
+.4byte sKrabbyPose263
+.4byte sKrabbyPose264
+.4byte sKrabbyPose265
+.4byte sKrabbyPose266
+.4byte sKrabbyPose267
+.4byte sKrabbyPose268
+.4byte sKrabbyPose269
+.4byte sKrabbyPose270
+.4byte sKrabbyPose271
+.4byte sKrabbyPose272
+.4byte sKrabbyPose273
+.4byte sKrabbyPose274
+.4byte sKrabbyPose275
+.4byte sKrabbyPose276
+.4byte sKrabbyPose277
+.4byte sKrabbyPose278
+.4byte sKrabbyPose279
+.4byte sKrabbyPose280
+.4byte sKrabbyPose281
+.4byte sKrabbyPose282
+.4byte sKrabbyPose283
+.4byte sKrabbyPose284
+.4byte sKrabbyPose285
+.4byte sKrabbyPose286
+.4byte sKrabbyPose287
+.4byte sKrabbyPose288
+.4byte sKrabbyPose289
+.4byte sKrabbyPose290
+.4byte sKrabbyPose291
+.4byte sKrabbyPose292
+.4byte sKrabbyPose293
+.4byte sKrabbyPose294
+.4byte sKrabbyPose295
+.4byte sKrabbyPose296
+.4byte sKrabbyPose297
+.4byte sKrabbyPose298
+.4byte sKrabbyPose299
+.4byte sKrabbyPose300
+.4byte sKrabbyPose301
+.4byte sKrabbyPose302
+.4byte sKrabbyPose303
+.4byte sKrabbyPose304
+.4byte sKrabbyPose305
+.4byte sKrabbyPose306
+.4byte sKrabbyPose307
+.4byte sKrabbyPose308
+.4byte sKrabbyPose309
+.4byte sKrabbyPose310
+.4byte sKrabbyPose311
+.4byte sKrabbyPose312
+.4byte sKrabbyPose313
+.4byte sKrabbyPose314
+.4byte sKrabbyPose315
+.4byte sKrabbyPose316
+.4byte sKrabbyPose317
+.4byte sKrabbyPose318
+.4byte sKrabbyPose319
+.4byte sKrabbyPose320
+.4byte sKrabbyPose321
+.4byte sKrabbyPose322
+.4byte sKrabbyPose323
+.4byte sKrabbyPose324
+.4byte sKrabbyPose325
+.4byte sKrabbyPose326
+.4byte sKrabbyPose327
+.4byte sKrabbyPose328
+.4byte sKrabbyPose329
+.4byte sKrabbyPose330
+.4byte sKrabbyPose331
+.4byte sKrabbyPose332
+.4byte sKrabbyPose333
+.4byte sKrabbyPose334
+.4byte sKrabbyPose335
+.4byte sKrabbyPose336
+.4byte sKrabbyPose337
+.4byte sKrabbyPose338
+sAxPositionsKrabby:
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    4,   -5, 	   4,  -12, 	   6,   -4, 	  -1,   -4
+.2byte    4,   -5, 	   4,  -12, 	   6,   -3, 	  -1,   -4
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    2,   -6, 	   0,  -13, 	   7,   -8, 	   0,   -4
+.2byte    3,   -6, 	   1,  -12, 	   8,   -7, 	   0,   -4
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    0,   -7, 	   7,  -13, 	  -7,  -13, 	   0,   -5
+.2byte    0,   -7, 	   6,  -12, 	  -8,  -12, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte   -3,   -6, 	  -1,  -13, 	  -8,   -8, 	  -1,   -4
+.2byte   -4,   -6, 	  -2,  -12, 	  -9,   -7, 	  -1,   -4
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -5,   -5, 	  -5,  -12, 	  -7,   -4, 	   0,   -4
+.2byte   -5,   -5, 	  -5,  -12, 	  -7,   -3, 	   0,   -4
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -2,   -2, 	  -7,  -11, 	   2,   -8, 	   0,   -4
+.2byte   -2,   -2, 	  -6,  -11, 	   4,   -7, 	   0,   -3
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte    0,   -2, 	  -7,  -10, 	   6,  -10, 	   0,   -5
+.2byte    0,   -2, 	  -6,  -11, 	   6,  -11, 	   0,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    1,   -2, 	   6,  -11, 	  -3,   -8, 	  -1,   -4
+.2byte    1,   -2, 	   5,  -11, 	  -5,   -7, 	  -1,   -3
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    4,   -5, 	   4,  -12, 	   6,   -4, 	  -1,   -4
+.2byte    4,   -5, 	   4,  -12, 	   6,   -3, 	  -1,   -4
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    2,   -6, 	   0,  -13, 	   7,   -8, 	   0,   -4
+.2byte    3,   -6, 	   1,  -12, 	   8,   -7, 	   0,   -4
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    0,   -7, 	   7,  -13, 	  -7,  -13, 	   0,   -5
+.2byte    0,   -7, 	   6,  -12, 	  -8,  -12, 	   0,   -5
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte   -3,   -6, 	  -1,  -13, 	  -8,   -8, 	  -1,   -4
+.2byte   -4,   -6, 	  -2,  -12, 	  -9,   -7, 	  -1,   -4
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -5,   -5, 	  -5,  -12, 	  -7,   -4, 	   0,   -4
+.2byte   -5,   -5, 	  -5,  -12, 	  -7,   -3, 	   0,   -4
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -2,   -2, 	  -7,  -11, 	   2,   -8, 	   0,   -4
+.2byte   -2,   -2, 	  -6,  -11, 	   4,   -7, 	   0,   -3
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte    0,   -2, 	  -7,  -10, 	   6,  -10, 	   0,   -5
+.2byte    0,   -2, 	  -6,  -11, 	   6,  -11, 	   0,   -5
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    1,   -2, 	   6,  -11, 	  -3,   -8, 	  -1,   -4
+.2byte    1,   -2, 	   5,  -11, 	  -5,   -7, 	  -1,   -3
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte   -2,   -9, 	  -6,  -19, 	   4,  -15, 	  -1,   -9
+.2byte   -3,  -14, 	  -3,  -22, 	  -7,  -15, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -21, 	  -9,  -16, 	  -1,   -9
+.2byte    0,  -13, 	   7,  -21, 	  -7,  -20, 	  -1,  -10
+.2byte    3,  -11, 	  -1,  -21, 	   7,  -16, 	  -1,   -9
+.2byte    2,  -14, 	   2,  -22, 	   6,  -15, 	  -1,  -10
+.2byte    1,   -9, 	   5,  -19, 	  -5,  -15, 	   0,   -9
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -1,   -9, 	  -7,  -17, 	   6,  -17, 	   0,  -10
+.2byte    0,    1, 	  -5,    6, 	   4,    6, 	   0,   -1
+.2byte    0,    1, 	  -5,    6, 	   4,    6, 	   0,   -1
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    1,  -10, 	   3,  -19, 	  -8,  -14, 	  -1,  -10
+.2byte    1,   -1, 	   8,    2, 	   2,    5, 	  -1,   -3
+.2byte    1,   -1, 	   8,    2, 	   2,    5, 	  -1,   -3
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    0,  -10, 	  -1,  -18, 	  -4,  -14, 	  -2,   -7
+.2byte    6,   -4, 	  13,   -5, 	  12,   -1, 	   0,   -4
+.2byte    6,   -4, 	  13,   -5, 	  12,   -1, 	   0,   -4
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    3,   -9, 	  -8,  -17, 	   5,  -14, 	  -1,   -7
+.2byte    4,   -7, 	   4,  -14, 	   9,  -11, 	   0,   -5
+.2byte    4,   -7, 	   4,  -14, 	   9,  -11, 	   0,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    0,  -14, 	   8,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    0,   -9, 	   2,  -12, 	  -3,  -11, 	   0,   -7
+.2byte    0,   -9, 	   2,  -12, 	  -3,  -11, 	   0,   -7
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte   -4,   -9, 	   7,  -17, 	  -6,  -14, 	   0,   -7
+.2byte   -5,   -7, 	  -5,  -14, 	 -10,  -11, 	  -1,   -5
+.2byte   -5,   -7, 	  -5,  -14, 	 -10,  -11, 	  -1,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -10, 	   0,  -18, 	   3,  -14, 	   1,   -7
+.2byte   -7,   -4, 	 -14,   -5, 	 -13,   -1, 	  -1,   -4
+.2byte   -7,   -4, 	 -14,   -5, 	 -13,   -1, 	  -1,   -4
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -2,  -10, 	  -4,  -19, 	   7,  -14, 	   0,  -10
+.2byte   -2,   -1, 	  -9,    2, 	  -3,    5, 	   0,   -3
+.2byte   -2,   -1, 	  -9,    2, 	  -3,    5, 	   0,   -3
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -1,   -9, 	  -7,  -17, 	   6,  -17, 	   0,  -10
+.2byte    0,   -2, 	  -8,    2, 	   7,    2, 	   0,   -3
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    1,  -10, 	   3,  -19, 	  -8,  -14, 	  -1,  -10
+.2byte    1,   -2, 	  10,   -4, 	  -1,    1, 	   0,   -4
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    0,  -10, 	  -1,  -18, 	  -4,  -14, 	  -2,   -7
+.2byte    6,   -4, 	  12,   -8, 	  12,   -2, 	   0,   -4
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    3,   -9, 	  -8,  -17, 	   5,  -14, 	  -1,   -7
+.2byte    4,   -7, 	   3,  -15, 	  10,  -11, 	   0,   -6
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    0,  -13, 	   8,  -17, 	  -8,  -17, 	  -1,   -9
+.2byte    0,   -9, 	   6,  -12, 	  -7,  -12, 	  -1,   -6
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte   -4,   -9, 	   7,  -17, 	  -6,  -14, 	   0,   -7
+.2byte   -5,   -7, 	  -4,  -15, 	 -11,  -11, 	  -1,   -6
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -10, 	   0,  -18, 	   3,  -14, 	   1,   -7
+.2byte   -7,   -4, 	 -13,   -8, 	 -13,   -2, 	  -1,   -4
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -2,  -10, 	  -4,  -19, 	   7,  -14, 	   0,  -10
+.2byte   -2,   -2, 	 -11,   -4, 	   0,    1, 	  -1,   -4
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte   -2,   -3, 	  -7,   -3, 	   2,    0, 	   0,   -5
+.2byte   -2,   -2, 	  -7,   -2, 	   1,    1, 	   0,   -3
+.2byte    0,   -1, 	  -6,    5, 	   5,    5, 	   0,   -4
+.2byte    1,   -1, 	   9,    4, 	   1,    9, 	   0,   -4
+.2byte    2,   -4, 	   8,   -6, 	   8,    3, 	  -1,   -4
+.2byte    2,   -4, 	   4,  -11, 	  10,   -5, 	  -2,   -3
+.2byte    0,   -5, 	   5,  -14, 	  -6,  -14, 	   0,   -3
+.2byte   -3,   -4, 	  -5,  -11, 	 -11,   -5, 	   1,   -3
+.2byte   -3,   -4, 	  -9,   -6, 	  -9,    3, 	   0,   -4
+.2byte   -2,   -1, 	 -10,    4, 	  -2,    9, 	  -1,   -4
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -1,   -9, 	  -7,  -17, 	   6,  -17, 	   0,  -10
+.2byte    0,    1, 	  -5,    6, 	   4,    6, 	   0,   -1
+.2byte    0,    1, 	  -5,    6, 	   4,    6, 	   0,   -1
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    1,  -10, 	   3,  -19, 	  -8,  -14, 	  -1,  -10
+.2byte    1,   -1, 	   8,    2, 	   2,    5, 	  -1,   -3
+.2byte    1,   -1, 	   8,    2, 	   2,    5, 	  -1,   -3
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    0,  -10, 	  -1,  -18, 	  -4,  -14, 	  -2,   -7
+.2byte    6,   -4, 	  13,   -5, 	  12,   -1, 	   0,   -4
+.2byte    6,   -4, 	  13,   -5, 	  12,   -1, 	   0,   -4
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    3,   -9, 	  -8,  -17, 	   5,  -14, 	  -1,   -7
+.2byte    4,   -7, 	   4,  -14, 	   9,  -11, 	   0,   -5
+.2byte    4,   -7, 	   4,  -14, 	   9,  -11, 	   0,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    0,  -14, 	   8,  -18, 	  -8,  -18, 	  -1,  -10
+.2byte    0,   -9, 	   2,  -12, 	  -3,  -11, 	   0,   -7
+.2byte    0,   -9, 	   2,  -12, 	  -3,  -11, 	   0,   -7
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte   -4,   -9, 	   7,  -17, 	  -6,  -14, 	   0,   -7
+.2byte   -5,   -7, 	  -5,  -14, 	 -10,  -11, 	  -1,   -5
+.2byte   -5,   -7, 	  -5,  -14, 	 -10,  -11, 	  -1,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -10, 	   0,  -18, 	   3,  -14, 	   1,   -7
+.2byte   -7,   -4, 	 -14,   -5, 	 -13,   -1, 	  -1,   -4
+.2byte   -7,   -4, 	 -14,   -5, 	 -13,   -1, 	  -1,   -4
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -2,  -10, 	  -4,  -19, 	   7,  -14, 	   0,  -10
+.2byte   -2,   -1, 	  -9,    2, 	  -3,    5, 	   0,   -3
+.2byte   -2,   -1, 	  -9,    2, 	  -3,    5, 	   0,   -3
+.2byte    0,   -2, 	  -8,    2, 	   7,    2, 	   0,   -3
+.2byte   -2,   -2, 	 -11,   -4, 	   0,    1, 	  -1,   -4
+.2byte   -6,   -4, 	 -12,   -8, 	 -12,   -2, 	   0,   -4
+.2byte   -3,   -6, 	  -2,  -14, 	  -9,  -10, 	   1,   -5
+.2byte    0,   -8, 	   6,  -11, 	  -7,  -11, 	  -1,   -5
+.2byte    2,   -6, 	   1,  -14, 	   8,  -10, 	  -2,   -5
+.2byte    5,   -4, 	  11,   -8, 	  11,   -2, 	  -1,   -4
+.2byte    1,   -2, 	  10,   -4, 	  -1,    1, 	   0,   -4
+.2byte   -1,   -8, 	  -7,  -18, 	   5,  -17, 	   0,   -9
+.2byte    1,   -8, 	   5,  -18, 	  -5,  -14, 	   0,   -8
+.2byte    2,  -12, 	   2,  -20, 	   6,  -13, 	  -1,   -8
+.2byte    3,   -9, 	  -1,  -19, 	   7,  -14, 	  -1,   -7
+.2byte    0,  -11, 	   7,  -19, 	  -7,  -18, 	  -1,   -8
+.2byte   -5,   -9, 	  -1,  -19, 	  -9,  -14, 	  -1,   -7
+.2byte   -3,  -12, 	  -3,  -20, 	  -7,  -13, 	   0,   -8
+.2byte   -2,   -8, 	  -6,  -18, 	   4,  -14, 	  -1,   -8
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -1,   -9, 	  -7,  -17, 	   6,  -17, 	   0,  -10
+.2byte    0,   -2, 	  -8,    2, 	   7,    2, 	   0,   -3
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+.2byte    1,  -10, 	   3,  -19, 	  -8,  -14, 	  -1,  -10
+.2byte    2,   -2, 	  11,   -4, 	   0,    1, 	   1,   -4
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    0,  -10, 	  -1,  -18, 	  -4,  -14, 	  -2,   -7
+.2byte    4,   -4, 	  10,   -8, 	  10,   -2, 	  -2,   -4
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    3,   -9, 	  -8,  -17, 	   5,  -14, 	  -1,   -7
+.2byte    4,   -7, 	   3,  -15, 	  10,  -11, 	   0,   -6
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    0,  -13, 	   8,  -17, 	  -8,  -17, 	  -1,   -9
+.2byte    0,   -9, 	   6,  -12, 	  -7,  -12, 	  -1,   -6
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte   -4,   -9, 	   7,  -17, 	  -6,  -14, 	   0,   -7
+.2byte   -5,   -7, 	  -4,  -15, 	 -11,  -11, 	  -1,   -6
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -10, 	   0,  -18, 	   3,  -14, 	   1,   -7
+.2byte   -5,   -4, 	 -11,   -8, 	 -11,   -2, 	   1,   -4
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -2,  -10, 	  -4,  -19, 	   7,  -14, 	   0,  -10
+.2byte   -3,   -2, 	 -12,   -4, 	  -1,    1, 	  -2,   -4
+.2byte    0,   -2, 	  -8,    2, 	   7,    2, 	   0,   -3
+.2byte   -2,   -2, 	 -11,   -4, 	   0,    1, 	  -1,   -4
+.2byte   -6,   -4, 	 -12,   -8, 	 -12,   -2, 	   0,   -4
+.2byte   -3,   -6, 	  -2,  -14, 	  -9,  -10, 	   1,   -5
+.2byte    0,   -8, 	   6,  -11, 	  -7,  -11, 	  -1,   -5
+.2byte    2,   -6, 	   1,  -14, 	   8,  -10, 	  -2,   -5
+.2byte    5,   -4, 	  11,   -8, 	  11,   -2, 	  -1,   -4
+.2byte    1,   -2, 	  10,   -4, 	  -1,    1, 	   0,   -4
+.2byte    0,   -3, 	  -7,  -12, 	   6,  -12, 	   0,   -6
+.2byte   -2,   -3, 	  -6,  -13, 	   3,   -9, 	   0,   -5
+.2byte   -5,   -6, 	  -6,  -14, 	  -7,   -6, 	   0,   -5
+.2byte   -3,   -7, 	  -1,  -13, 	  -9,   -9, 	  -1,   -5
+.2byte    0,   -8, 	   6,  -14, 	  -7,  -14, 	   0,   -5
+.2byte    2,   -7, 	   0,  -13, 	   8,   -9, 	   0,   -5
+.2byte    4,   -6, 	   5,  -14, 	   6,   -6, 	  -1,   -5
+.2byte    1,   -3, 	   5,  -13, 	  -4,   -9, 	  -1,   -5
+sKrabbyAnimTable1:
+.4byte sKrabbyAnims_1_1
+.4byte sKrabbyAnims_1_2
+.4byte sKrabbyAnims_1_3
+.4byte sKrabbyAnims_1_4
+.4byte sKrabbyAnims_1_5
+.4byte sKrabbyAnims_1_6
+.4byte sKrabbyAnims_1_7
+.4byte sKrabbyAnims_1_8
+sKrabbyAnimTable2:
+.4byte sKrabbyAnims_2_1
+.4byte sKrabbyAnims_2_2
+.4byte sKrabbyAnims_2_3
+.4byte sKrabbyAnims_2_4
+.4byte sKrabbyAnims_2_5
+.4byte sKrabbyAnims_2_6
+.4byte sKrabbyAnims_2_7
+.4byte sKrabbyAnims_2_8
+sKrabbyAnimTable3:
+.4byte sKrabbyAnims_3_1
+.4byte sKrabbyAnims_3_2
+.4byte sKrabbyAnims_3_3
+.4byte sKrabbyAnims_3_4
+.4byte sKrabbyAnims_3_5
+.4byte sKrabbyAnims_3_6
+.4byte sKrabbyAnims_3_7
+.4byte sKrabbyAnims_3_8
+sKrabbyAnimTable4:
+.4byte sKrabbyAnims_4_1
+.4byte sKrabbyAnims_4_2
+.4byte sKrabbyAnims_4_3
+.4byte sKrabbyAnims_4_4
+.4byte sKrabbyAnims_4_5
+.4byte sKrabbyAnims_4_6
+.4byte sKrabbyAnims_4_7
+.4byte sKrabbyAnims_4_8
+sKrabbyAnimTable5:
+.4byte sKrabbyAnims_5_1
+.4byte sKrabbyAnims_5_2
+.4byte sKrabbyAnims_5_3
+.4byte sKrabbyAnims_5_4
+.4byte sKrabbyAnims_5_5
+.4byte sKrabbyAnims_5_6
+.4byte sKrabbyAnims_5_7
+.4byte sKrabbyAnims_5_8
+sKrabbyAnimTable6:
+.4byte sKrabbyAnims_6_1
+.4byte sKrabbyAnims_6_1
+.4byte sKrabbyAnims_6_1
+.4byte sKrabbyAnims_6_1
+.4byte sKrabbyAnims_6_1
+.4byte sKrabbyAnims_6_1
+.4byte sKrabbyAnims_6_1
+.4byte sKrabbyAnims_6_1
+sKrabbyAnimTable7:
+.4byte sKrabbyAnims_7_1
+.4byte sKrabbyAnims_7_2
+.4byte sKrabbyAnims_7_3
+.4byte sKrabbyAnims_7_4
+.4byte sKrabbyAnims_7_5
+.4byte sKrabbyAnims_7_6
+.4byte sKrabbyAnims_7_7
+.4byte sKrabbyAnims_7_8
+sKrabbyAnimTable8:
+.4byte sKrabbyAnims_8_1
+.4byte sKrabbyAnims_8_2
+.4byte sKrabbyAnims_8_3
+.4byte sKrabbyAnims_8_4
+.4byte sKrabbyAnims_8_5
+.4byte sKrabbyAnims_8_6
+.4byte sKrabbyAnims_8_7
+.4byte sKrabbyAnims_8_8
+sKrabbyAnimTable9:
+.4byte sKrabbyAnims_9_1
+.4byte sKrabbyAnims_9_2
+.4byte sKrabbyAnims_9_3
+.4byte sKrabbyAnims_9_4
+.4byte sKrabbyAnims_9_5
+.4byte sKrabbyAnims_9_6
+.4byte sKrabbyAnims_9_7
+.4byte sKrabbyAnims_9_8
+sKrabbyAnimTable10:
+.4byte sKrabbyAnims_10_1
+.4byte sKrabbyAnims_10_2
+.4byte sKrabbyAnims_10_3
+.4byte sKrabbyAnims_10_4
+.4byte sKrabbyAnims_10_5
+.4byte sKrabbyAnims_10_6
+.4byte sKrabbyAnims_10_7
+.4byte sKrabbyAnims_10_8
+sKrabbyAnimTable11:
+.4byte sKrabbyAnims_11_1
+.4byte sKrabbyAnims_11_2
+.4byte sKrabbyAnims_11_3
+.4byte sKrabbyAnims_11_4
+.4byte sKrabbyAnims_11_5
+.4byte sKrabbyAnims_11_6
+.4byte sKrabbyAnims_11_7
+.4byte sKrabbyAnims_11_8
+sKrabbyAnimTable12:
+.4byte sKrabbyAnims_12_1
+.4byte sKrabbyAnims_12_2
+.4byte sKrabbyAnims_12_3
+.4byte sKrabbyAnims_12_4
+.4byte sKrabbyAnims_12_5
+.4byte sKrabbyAnims_12_6
+.4byte sKrabbyAnims_12_7
+.4byte sKrabbyAnims_12_8
+sKrabbyAnimTable13:
+.4byte sKrabbyAnims_13_1
+.4byte sKrabbyAnims_13_2
+.4byte sKrabbyAnims_13_3
+.4byte sKrabbyAnims_13_4
+.4byte sKrabbyAnims_13_5
+.4byte sKrabbyAnims_13_6
+.4byte sKrabbyAnims_13_7
+.4byte sKrabbyAnims_13_8
+sAxAnimationsKrabby:
+.4byte sKrabbyAnimTable1
+.4byte sKrabbyAnimTable2
+.4byte sKrabbyAnimTable3
+.4byte sKrabbyAnimTable4
+.4byte sKrabbyAnimTable5
+.4byte sKrabbyAnimTable6
+.4byte sKrabbyAnimTable7
+.4byte sKrabbyAnimTable8
+.4byte sKrabbyAnimTable9
+.4byte sKrabbyAnimTable10
+.4byte sKrabbyAnimTable11
+.4byte sKrabbyAnimTable12
+.4byte sKrabbyAnimTable13
+sAxSpritesKrabby:
+.4byte sKrabbySprites1
+.4byte sKrabbySprites2
+.4byte sKrabbySprites3
+.4byte sKrabbySprites4
+.4byte sKrabbySprites5
+.4byte sKrabbySprites6
+.4byte sKrabbySprites7
+.4byte sKrabbySprites8
+.4byte sKrabbySprites9
+.4byte sKrabbySprites10
+.4byte sKrabbySprites11
+.4byte sKrabbySprites12
+.4byte sKrabbySprites13
+.4byte sKrabbySprites14
+.4byte sKrabbySprites15
+.4byte sKrabbySprites16
+.4byte sKrabbySprites17
+.4byte sKrabbySprites18
+.4byte sKrabbySprites19
+.4byte sKrabbySprites20
+.4byte sKrabbySprites21
+.4byte sKrabbySprites22
+.4byte sKrabbySprites23
+.4byte sKrabbySprites24
+.4byte sKrabbySprites25
+.4byte sKrabbySprites26
+.4byte sKrabbySprites27
+.4byte sKrabbySprites28
+.4byte sKrabbySprites29
+.4byte sKrabbySprites30
+.4byte sKrabbySprites31
+.4byte sKrabbySprites32
+.4byte sKrabbySprites33
+.4byte sKrabbySprites34
+.4byte sKrabbySprites35
+.4byte sKrabbySprites36
+.4byte sKrabbySprites37
+.4byte sKrabbySprites38
+.4byte sKrabbySprites39
+.4byte sKrabbySprites40
+.4byte sKrabbySprites41
+.4byte sKrabbySprites42
+.4byte sKrabbySprites43
+.4byte sKrabbySprites44
+.4byte sKrabbySprites45
+.4byte sKrabbySprites46
+.4byte sKrabbySprites47
+sAxMainKrabby:
+ax_main sAxPosesKrabby, sAxAnimationsKrabby, 13, sAxSpritesKrabby, sAxPositionsKrabby

--- a/data/ax/kyogre.inc
+++ b/data/ax/kyogre.inc
@@ -1,0 +1,3543 @@
+.global gAxKyogre
+gAxKyogre:
+ax_siro sAxMainKyogre
+sKyogrePose1:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose2:
+ax_pose 1, 0x01e0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose3:
+ax_pose 2, 0x01e6, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose4:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose5:
+ax_pose 4, 0x01de, 0xd0de, 0x5c00
+ax_pose_terminator
+sKyogrePose6:
+ax_pose 5, 0x01e4, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose7:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose8:
+ax_pose 7, 0x01e1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose9:
+ax_pose 8, 0x01e7, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose10:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose11:
+ax_pose 10, 0x01e0, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose12:
+ax_pose 11, 0x01e8, 0xd0da, 0x5c00
+ax_pose_terminator
+sKyogrePose13:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose14:
+ax_pose 13, 0x01e4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose15:
+ax_pose 14, 0x01e6, 0xc0e5, 0x5c00
+ax_pose_terminator
+sKyogrePose16:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose17:
+ax_pose 10, 0x01e0, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose18:
+ax_pose 11, 0x01e8, 0xc0e6, 0x5c00
+ax_pose_terminator
+sKyogrePose19:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose20:
+ax_pose 7, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose21:
+ax_pose 8, 0x01e7, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose22:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose23:
+ax_pose 4, 0x01de, 0xc0e2, 0x5c00
+ax_pose_terminator
+sKyogrePose24:
+ax_pose 5, 0x01e4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose25:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose26:
+ax_pose 1, 0x01e0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose27:
+ax_pose 2, 0x01e6, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose28:
+ax_pose 15, 0x41e3, 0xc0e0, 0x5c00
+ax_pose 16, 0x4203, 0x00f6, 0x5c20
+ax_pose_terminator
+sKyogrePose29:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose30:
+ax_pose 4, 0x01de, 0xd0de, 0x5c00
+ax_pose_terminator
+sKyogrePose31:
+ax_pose 5, 0x01e4, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose32:
+ax_pose 17, 0x01e1, 0x90f9, 0x5c00
+ax_pose 18, 0x81e1, 0x90e9, 0x5c10
+ax_pose 19, 0x81e4, 0x50e1, 0x5c18
+ax_pose 20, 0x4201, 0x50f9, 0x5c1c
+ax_pose 21, 0x4201, 0x10e9, 0x5c20
+ax_pose_terminator
+sKyogrePose33:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose34:
+ax_pose 7, 0x01e1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose35:
+ax_pose 8, 0x01e7, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose36:
+ax_pose 22, 0x01e4, 0x90f4, 0x5c00
+ax_pose 23, 0x81e4, 0x90e4, 0x5c10
+ax_pose 24, 0x0204, 0x50f6, 0x5c18
+ax_pose 25, 0x8204, 0x10ee, 0x5c1c
+ax_pose_terminator
+sKyogrePose37:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose38:
+ax_pose 10, 0x01e0, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose39:
+ax_pose 11, 0x01e8, 0xd0da, 0x5c00
+ax_pose_terminator
+sKyogrePose40:
+ax_pose 26, 0x01e7, 0x90f2, 0x5c00
+ax_pose 27, 0x81e7, 0x90e2, 0x5c10
+ax_pose 28, 0x4207, 0x10f2, 0x5c18
+ax_pose 29, 0x4207, 0x1102, 0x5c1a
+ax_pose_terminator
+sKyogrePose41:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose42:
+ax_pose 13, 0x01e4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose43:
+ax_pose 14, 0x01e6, 0xc0e5, 0x5c00
+ax_pose_terminator
+sKyogrePose44:
+ax_pose 30, 0x01e3, 0x80f0, 0x5c00
+ax_pose 31, 0x4203, 0x00f0, 0x5c10
+ax_pose 32, 0x4203, 0x0100, 0x5c12
+ax_pose 33, 0x01f3, 0x40e0, 0x5c14
+ax_pose 34, 0x01f4, 0x4110, 0x5c18
+ax_pose_terminator
+sKyogrePose45:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose46:
+ax_pose 10, 0x01e0, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose47:
+ax_pose 11, 0x01e8, 0xc0e6, 0x5c00
+ax_pose_terminator
+sKyogrePose48:
+ax_pose 26, 0x01e7, 0x80ee, 0x5c00
+ax_pose 27, 0x81e7, 0x810e, 0x5c10
+ax_pose 28, 0x4207, 0x00fe, 0x5c18
+ax_pose 29, 0x4207, 0x00ee, 0x5c1a
+ax_pose_terminator
+sKyogrePose49:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose50:
+ax_pose 7, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose51:
+ax_pose 8, 0x01e7, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose52:
+ax_pose 22, 0x01e4, 0x80ec, 0x5c00
+ax_pose 23, 0x81e4, 0x810c, 0x5c10
+ax_pose 24, 0x0204, 0x40fa, 0x5c18
+ax_pose 25, 0x8204, 0x010a, 0x5c1c
+ax_pose_terminator
+sKyogrePose53:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose54:
+ax_pose 4, 0x01de, 0xc0e2, 0x5c00
+ax_pose_terminator
+sKyogrePose55:
+ax_pose 5, 0x01e4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose56:
+ax_pose 17, 0x01e1, 0x80e7, 0x5c00
+ax_pose 18, 0x81e1, 0x8107, 0x5c10
+ax_pose 19, 0x81e4, 0x4117, 0x5c18
+ax_pose 20, 0x4201, 0x40e7, 0x5c1c
+ax_pose 21, 0x4201, 0x0107, 0x5c20
+ax_pose_terminator
+sKyogrePose57:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose58:
+ax_pose 1, 0x01e0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose59:
+ax_pose 2, 0x01e6, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose60:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose61:
+ax_pose 4, 0x01de, 0xd0de, 0x5c00
+ax_pose_terminator
+sKyogrePose62:
+ax_pose 5, 0x01e4, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose63:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose64:
+ax_pose 7, 0x01e1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose65:
+ax_pose 8, 0x01e7, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose66:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose67:
+ax_pose 10, 0x01e0, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose68:
+ax_pose 11, 0x01e8, 0xd0da, 0x5c00
+ax_pose_terminator
+sKyogrePose69:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose70:
+ax_pose 13, 0x01e4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose71:
+ax_pose 14, 0x01e6, 0xc0e5, 0x5c00
+ax_pose_terminator
+sKyogrePose72:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose73:
+ax_pose 10, 0x01e0, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose74:
+ax_pose 11, 0x01e8, 0xc0e6, 0x5c00
+ax_pose_terminator
+sKyogrePose75:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose76:
+ax_pose 7, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose77:
+ax_pose 8, 0x01e7, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose78:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose79:
+ax_pose 4, 0x01de, 0xc0e2, 0x5c00
+ax_pose_terminator
+sKyogrePose80:
+ax_pose 5, 0x01e4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose81:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose82:
+ax_pose 1, 0x01e0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose83:
+ax_pose 35, 0x41e5, 0xc0e0, 0x5c00
+ax_pose 36, 0x0205, 0x00fb, 0x5c20
+ax_pose_terminator
+sKyogrePose84:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose85:
+ax_pose 4, 0x01de, 0xd0de, 0x5c00
+ax_pose_terminator
+sKyogrePose86:
+ax_pose 37, 0x41e1, 0xd0e1, 0x5c00
+ax_pose 38, 0x4201, 0x50e1, 0x5c20
+ax_pose 39, 0x4201, 0x1101, 0x5c24
+ax_pose_terminator
+sKyogrePose87:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose88:
+ax_pose 7, 0x01e1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose89:
+ax_pose 40, 0x01e3, 0x90f6, 0x5c00
+ax_pose 41, 0x0203, 0x50fa, 0x5c10
+ax_pose 42, 0x81e6, 0x90e6, 0x5c14
+ax_pose_terminator
+sKyogrePose90:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose91:
+ax_pose 10, 0x01e0, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose92:
+ax_pose 43, 0x41e4, 0xd0de, 0x5c00
+ax_pose 44, 0x4204, 0x110c, 0x5c20
+ax_pose 45, 0x0204, 0x50f3, 0x5c22
+ax_pose 46, 0x0204, 0x10eb, 0x5c26
+ax_pose_terminator
+sKyogrePose93:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose94:
+ax_pose 13, 0x01e4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose95:
+ax_pose 47, 0x41e2, 0xc0e1, 0x5c00
+ax_pose 48, 0x4202, 0x40f1, 0x5c20
+ax_pose_terminator
+sKyogrePose96:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose97:
+ax_pose 10, 0x01e0, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose98:
+ax_pose 43, 0x41e4, 0xc0e2, 0x5c00
+ax_pose 44, 0x4204, 0x00e4, 0x5c20
+ax_pose 45, 0x0204, 0x40fd, 0x5c22
+ax_pose 46, 0x0204, 0x010d, 0x5c26
+ax_pose_terminator
+sKyogrePose99:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose100:
+ax_pose 7, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose101:
+ax_pose 40, 0x01e3, 0x80ea, 0x5c00
+ax_pose 41, 0x0203, 0x40f6, 0x5c10
+ax_pose 42, 0x81e6, 0x810a, 0x5c14
+ax_pose_terminator
+sKyogrePose102:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose103:
+ax_pose 4, 0x01de, 0xc0e2, 0x5c00
+ax_pose_terminator
+sKyogrePose104:
+ax_pose 37, 0x41e1, 0xc0df, 0x5c00
+ax_pose 38, 0x4201, 0x40ff, 0x5c20
+ax_pose 39, 0x4201, 0x00ef, 0x5c24
+ax_pose_terminator
+sKyogrePose105:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose106:
+ax_pose 49, 0x41de, 0xc0dc, 0x5c00
+ax_pose 50, 0x41fe, 0x80dc, 0x5c20
+ax_pose 51, 0x41fe, 0x80fc, 0x5c28
+ax_pose 52, 0x81ee, 0x011c, 0x5c30
+ax_pose 53, 0x01fe, 0x011c, 0x5c32
+ax_pose_terminator
+sKyogrePose107:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose108:
+ax_pose 54, 0x41dc, 0xd0e4, 0x5c00
+ax_pose 55, 0x41fc, 0x90e4, 0x5c20
+ax_pose 56, 0x41fc, 0x1104, 0x5c28
+ax_pose 57, 0x020c, 0x10ed, 0x5c2a
+ax_pose_terminator
+sKyogrePose109:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose110:
+ax_pose 58, 0x01e0, 0x90f7, 0x5c00
+ax_pose 59, 0x4200, 0x90f8, 0x5c10
+ax_pose 60, 0x01e1, 0x90d9, 0x5c18
+ax_pose_terminator
+sKyogrePose111:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose112:
+ax_pose 61, 0x41e2, 0xd0e0, 0x5c00
+ax_pose 62, 0x4202, 0x9100, 0x5c20
+ax_pose 63, 0x4202, 0x90e0, 0x5c28
+ax_pose_terminator
+sKyogrePose113:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose114:
+ax_pose 64, 0x41e1, 0xc0dd, 0x5c00
+ax_pose 65, 0x4201, 0x40ed, 0x5c20
+ax_pose 66, 0x0201, 0x010d, 0x5c24
+ax_pose 67, 0x01e9, 0x011d, 0x5c25
+ax_pose 68, 0x81f1, 0x011d, 0x5c26
+ax_pose_terminator
+sKyogrePose115:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose116:
+ax_pose 61, 0x41e2, 0xc0e0, 0x5c00
+ax_pose 62, 0x4202, 0x80e0, 0x5c20
+ax_pose 63, 0x4202, 0x8100, 0x5c28
+ax_pose_terminator
+sKyogrePose117:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose118:
+ax_pose 58, 0x01e0, 0x80e9, 0x5c00
+ax_pose 59, 0x4200, 0x80e8, 0x5c10
+ax_pose 60, 0x01e1, 0x8107, 0x5c18
+ax_pose_terminator
+sKyogrePose119:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose120:
+ax_pose 54, 0x41dc, 0xc0dc, 0x5c00
+ax_pose 55, 0x41fc, 0x80fc, 0x5c20
+ax_pose 56, 0x41fc, 0x00ec, 0x5c28
+ax_pose 57, 0x020c, 0x010b, 0x5c2a
+ax_pose_terminator
+sKyogrePose121:
+ax_pose 69, 0x41dc, 0xc0e1, 0x5c00
+ax_pose 70, 0x41fc, 0x8101, 0x5c20
+ax_pose 71, 0x41fc, 0x00f1, 0x5c28
+ax_pose_terminator
+sKyogrePose122:
+ax_pose 72, 0x41d9, 0xc0e2, 0x5c00
+ax_pose 73, 0x41f9, 0x8102, 0x5c20
+ax_pose 74, 0x41f9, 0x00f2, 0x5c28
+ax_pose_terminator
+sKyogrePose123:
+ax_pose 75, 0x41e5, 0xc0e0, 0x5c00
+ax_pose 76, 0x41d5, 0x80f0, 0x5c20
+ax_pose_terminator
+sKyogrePose124:
+ax_pose 77, 0x41d8, 0xd0de, 0x5c00
+ax_pose 78, 0x41f8, 0x90ee, 0x5c20
+ax_pose 79, 0x01f8, 0x10e6, 0x5c28
+ax_pose_terminator
+sKyogrePose125:
+ax_pose 80, 0x41d5, 0xd0da, 0x5c00
+ax_pose 81, 0x41f5, 0x90f2, 0x5c20
+ax_pose 82, 0x41f5, 0x10e2, 0x5c28
+ax_pose_terminator
+sKyogrePose126:
+ax_pose 83, 0x41de, 0xd0dc, 0x5c00
+ax_pose 84, 0x41fe, 0x1104, 0x5c20
+ax_pose 85, 0x01fe, 0x10f4, 0x5c22
+ax_pose_terminator
+sKyogrePose127:
+ax_pose 86, 0x41e3, 0xc0e1, 0x5c00
+ax_pose_terminator
+sKyogrePose128:
+ax_pose 83, 0x41de, 0xc0e4, 0x5c00
+ax_pose 84, 0x41fe, 0x00ec, 0x5c20
+ax_pose 85, 0x01fe, 0x0104, 0x5c22
+ax_pose_terminator
+sKyogrePose129:
+ax_pose 80, 0x41d5, 0xc0e6, 0x5c00
+ax_pose 81, 0x41f5, 0x80ee, 0x5c20
+ax_pose 82, 0x41f5, 0x010e, 0x5c28
+ax_pose_terminator
+sKyogrePose130:
+ax_pose 77, 0x41d8, 0xc0e2, 0x5c00
+ax_pose 78, 0x41f8, 0x80f2, 0x5c20
+ax_pose 79, 0x01f8, 0x0112, 0x5c28
+ax_pose_terminator
+sKyogrePose131:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose132:
+ax_pose 1, 0x01e0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose133:
+ax_pose 2, 0x01e6, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose134:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose135:
+ax_pose 4, 0x01de, 0xd0de, 0x5c00
+ax_pose_terminator
+sKyogrePose136:
+ax_pose 5, 0x01e4, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose137:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose138:
+ax_pose 7, 0x01e1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose139:
+ax_pose 8, 0x01e7, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose140:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose141:
+ax_pose 10, 0x01e0, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose142:
+ax_pose 11, 0x01e8, 0xd0da, 0x5c00
+ax_pose_terminator
+sKyogrePose143:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose144:
+ax_pose 13, 0x01e4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose145:
+ax_pose 14, 0x01e6, 0xc0e5, 0x5c00
+ax_pose_terminator
+sKyogrePose146:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose147:
+ax_pose 10, 0x01e0, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose148:
+ax_pose 11, 0x01e8, 0xc0e6, 0x5c00
+ax_pose_terminator
+sKyogrePose149:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose150:
+ax_pose 7, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose151:
+ax_pose 8, 0x01e7, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose152:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose153:
+ax_pose 4, 0x01de, 0xc0e2, 0x5c00
+ax_pose_terminator
+sKyogrePose154:
+ax_pose 5, 0x01e4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose155:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose156:
+ax_pose 3, 0x01e1, 0xc0e1, 0x5c00
+ax_pose_terminator
+sKyogrePose157:
+ax_pose 6, 0x01e4, 0xc0ed, 0x5c00
+ax_pose_terminator
+sKyogrePose158:
+ax_pose 9, 0x01e5, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose159:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose160:
+ax_pose 9, 0x01e5, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose161:
+ax_pose 6, 0x01e4, 0xd0d3, 0x5c00
+ax_pose_terminator
+sKyogrePose162:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose163:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose164:
+ax_pose 6, 0x01e4, 0xd0d3, 0x5c00
+ax_pose_terminator
+sKyogrePose165:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose166:
+ax_pose 9, 0x01e5, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose167:
+ax_pose 6, 0x01e4, 0xd0d3, 0x5c00
+ax_pose_terminator
+sKyogrePose168:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose169:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose170:
+ax_pose 9, 0x01e5, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose171:
+ax_pose 6, 0x01e4, 0xd0d3, 0x5c00
+ax_pose_terminator
+sKyogrePose172:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose173:
+ax_pose 9, 0x01e5, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose174:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose175:
+ax_pose 9, 0x01e5, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose176:
+ax_pose 6, 0x01e4, 0xd0d3, 0x5c00
+ax_pose_terminator
+sKyogrePose177:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose178:
+ax_pose 6, 0x01e4, 0xc0ed, 0x5c00
+ax_pose_terminator
+sKyogrePose179:
+ax_pose 9, 0x01e5, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose180:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose181:
+ax_pose 9, 0x01e5, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose182:
+ax_pose 6, 0x01e4, 0xd0d3, 0x5c00
+ax_pose_terminator
+sKyogrePose183:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose184:
+ax_pose 3, 0x01e1, 0xc0e1, 0x5c00
+ax_pose_terminator
+sKyogrePose185:
+ax_pose 6, 0x01e4, 0xc0ed, 0x5c00
+ax_pose_terminator
+sKyogrePose186:
+ax_pose 9, 0x01e5, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose187:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose188:
+ax_pose 9, 0x01e5, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose189:
+ax_pose 6, 0x01e4, 0xd0d3, 0x5c00
+ax_pose_terminator
+sKyogrePose190:
+ax_pose 3, 0x01e1, 0xd0df, 0x5c00
+ax_pose_terminator
+sKyogrePose191:
+ax_pose 35, 0x41e5, 0xc0e0, 0x5c00
+ax_pose 36, 0x0205, 0x00fb, 0x5c20
+ax_pose_terminator
+sKyogrePose192:
+ax_pose 37, 0x41e1, 0xd0e1, 0x5c00
+ax_pose 38, 0x4201, 0x50e1, 0x5c20
+ax_pose 39, 0x4201, 0x1101, 0x5c24
+ax_pose_terminator
+sKyogrePose193:
+ax_pose 40, 0x01e3, 0x90f6, 0x5c00
+ax_pose 41, 0x0203, 0x50fa, 0x5c10
+ax_pose 42, 0x81e6, 0x90e6, 0x5c14
+ax_pose_terminator
+sKyogrePose194:
+ax_pose 43, 0x41e6, 0xd0de, 0x5c00
+ax_pose 44, 0x4206, 0x110c, 0x5c20
+ax_pose 45, 0x0206, 0x50f3, 0x5c22
+ax_pose 46, 0x0206, 0x10eb, 0x5c26
+ax_pose_terminator
+sKyogrePose195:
+ax_pose 47, 0x41e5, 0xc0e1, 0x5c00
+ax_pose 48, 0x4205, 0x40f1, 0x5c20
+ax_pose_terminator
+sKyogrePose196:
+ax_pose 43, 0x41e6, 0xc0e2, 0x5c00
+ax_pose 44, 0x4206, 0x00e4, 0x5c20
+ax_pose 45, 0x0206, 0x40fd, 0x5c22
+ax_pose 46, 0x0206, 0x010d, 0x5c26
+ax_pose_terminator
+sKyogrePose197:
+ax_pose 40, 0x01e3, 0x80ea, 0x5c00
+ax_pose 41, 0x0203, 0x40f6, 0x5c10
+ax_pose 42, 0x81e6, 0x810a, 0x5c14
+ax_pose_terminator
+sKyogrePose198:
+ax_pose 37, 0x41e1, 0xc0df, 0x5c00
+ax_pose 38, 0x4201, 0x40ff, 0x5c20
+ax_pose 39, 0x4201, 0x00ef, 0x5c24
+ax_pose_terminator
+sKyogrePose199:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose200:
+ax_pose 1, 0x01e0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose201:
+ax_pose 2, 0x01e6, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose202:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose203:
+ax_pose 4, 0x01de, 0xd0de, 0x5c00
+ax_pose_terminator
+sKyogrePose204:
+ax_pose 5, 0x01e4, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose205:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose206:
+ax_pose 7, 0x01e1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose207:
+ax_pose 8, 0x01e7, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose208:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose209:
+ax_pose 10, 0x01e0, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose210:
+ax_pose 11, 0x01e8, 0xd0da, 0x5c00
+ax_pose_terminator
+sKyogrePose211:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose212:
+ax_pose 13, 0x01e4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose213:
+ax_pose 14, 0x01e6, 0xc0e5, 0x5c00
+ax_pose_terminator
+sKyogrePose214:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose215:
+ax_pose 10, 0x01e0, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose216:
+ax_pose 11, 0x01e8, 0xc0e6, 0x5c00
+ax_pose_terminator
+sKyogrePose217:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose218:
+ax_pose 7, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose219:
+ax_pose 8, 0x01e7, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose220:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose221:
+ax_pose 4, 0x01de, 0xc0e2, 0x5c00
+ax_pose_terminator
+sKyogrePose222:
+ax_pose 5, 0x01e4, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose223:
+ax_pose 1, 0x01e0, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose224:
+ax_pose 4, 0x01de, 0xc0e2, 0x5c00
+ax_pose_terminator
+sKyogrePose225:
+ax_pose 7, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose226:
+ax_pose 10, 0x01e0, 0xc0e4, 0x5c00
+ax_pose_terminator
+sKyogrePose227:
+ax_pose 13, 0x01e4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose228:
+ax_pose 10, 0x01e0, 0xd0dc, 0x5c00
+ax_pose_terminator
+sKyogrePose229:
+ax_pose 7, 0x01e1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose230:
+ax_pose 4, 0x01de, 0xd0de, 0x5c00
+ax_pose_terminator
+sKyogrePose231:
+ax_pose 0, 0x01e3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose232:
+ax_pose 3, 0x01e1, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose233:
+ax_pose 6, 0x01e4, 0xc0ec, 0x5c00
+ax_pose_terminator
+sKyogrePose234:
+ax_pose 9, 0x01e5, 0xc0e3, 0x5c00
+ax_pose_terminator
+sKyogrePose235:
+ax_pose 12, 0x01e5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sKyogrePose236:
+ax_pose 9, 0x01e5, 0xd0dd, 0x5c00
+ax_pose_terminator
+sKyogrePose237:
+ax_pose 6, 0x01e4, 0xd0d4, 0x5c00
+ax_pose_terminator
+sKyogrePose238:
+ax_pose 3, 0x01e1, 0xd0e0, 0x5c00
+ax_pose_terminator
+.align 2
+sKyogreAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -4, 0, 0,
+ax_anim 8, 0, 0, 0, -4, 0, 0,
+ax_anim 8, 0, 1, 0, -4, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -4, 0, 0,
+ax_anim 8, 0, 3, 0, -4, 0, 0,
+ax_anim 8, 0, 4, 0, -4, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -4, 0, 0,
+ax_anim 8, 0, 6, 0, -4, 0, 0,
+ax_anim 8, 0, 7, 0, -4, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -4, 0, 0,
+ax_anim 8, 0, 9, 0, -4, 0, 0,
+ax_anim 8, 0, 10, 0, -4, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -4, 0, 0,
+ax_anim 8, 0, 12, 0, -4, 0, 0,
+ax_anim 8, 0, 13, 0, -4, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -3, 0, 0,
+ax_anim 8, 0, 17, 0, -4, 0, 0,
+ax_anim 8, 0, 15, 0, -4, 0, 0,
+ax_anim 8, 0, 16, 0, -4, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -3, 0, 0,
+ax_anim 8, 0, 20, 0, -4, 0, 0,
+ax_anim 8, 0, 18, 0, -4, 0, 0,
+ax_anim 8, 0, 19, 0, -4, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -3, 0, 0,
+ax_anim 8, 0, 23, 0, -4, 0, 0,
+ax_anim 8, 0, 21, 0, -4, 0, 0,
+ax_anim 8, 0, 22, 0, -4, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 4, 0, 4,
+ax_anim 2, 2, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 1, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sKyogreAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 6, 0, 30, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 3, 5, 3, 5,
+ax_anim 2, 2, 31, 8, 12, 8, 12,
+ax_anim 2, 0, 31, 13, 18, 13, 18,
+ax_anim 2, 1, 31, 14, 17, 14, 17,
+ax_anim 2, 0, 31, 13, 18, 13, 18,
+ax_anim 2, 0, 31, 14, 17, 14, 17,
+ax_anim 2, 0, 28, 4, 6, 4, 6,
+ax_anim_terminator
+sKyogreAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 6, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 4, 1, 4, 0,
+ax_anim 2, 2, 35, 10, 2, 10, 0,
+ax_anim 2, 0, 35, 15, 3, 15, 0,
+ax_anim 2, 1, 35, 15, 4, 15, 1,
+ax_anim 2, 0, 35, 15, 3, 15, 0,
+ax_anim 2, 0, 35, 15, 4, 15, 1,
+ax_anim 2, 0, 32, 6, 1, 6, 0,
+ax_anim_terminator
+sKyogreAnims_2_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 6, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 0, 39, 5, -4, 5, -4,
+ax_anim 2, 2, 39, 11, -9, 11, -9,
+ax_anim 2, 0, 39, 18, -13, 18, -13,
+ax_anim 2, 1, 39, 19, -12, 19, -12,
+ax_anim 2, 0, 39, 18, -13, 18, -13,
+ax_anim 2, 0, 39, 19, -12, 19, -12,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sKyogreAnims_2_5:
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 6, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, -2, 0, -2,
+ax_anim 2, 2, 43, 0, -8, 0, -8,
+ax_anim 2, 0, 43, 0, -13, 0, -13,
+ax_anim 2, 1, 43, 1, -13, 1, -13,
+ax_anim 2, 0, 43, 0, -13, 0, -13,
+ax_anim 2, 0, 43, 1, -13, 1, -13,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sKyogreAnims_2_6:
+ax_anim 2, 0, 46, 1, 1, 1, 1,
+ax_anim 6, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 0, 47, -5, -4, -5, -4,
+ax_anim 2, 2, 47, -11, -9, -11, -9,
+ax_anim 2, 0, 47, -18, -13, -18, -13,
+ax_anim 2, 1, 47, -19, -12, -19, -12,
+ax_anim 2, 0, 47, -18, -13, -18, -13,
+ax_anim 2, 0, 47, -19, -12, -19, -12,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sKyogreAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 6, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 51, -4, 1, -4, 0,
+ax_anim 2, 2, 51, -10, 2, -10, 0,
+ax_anim 2, 0, 51, -15, 3, -15, 0,
+ax_anim 2, 1, 51, -15, 4, -15, 1,
+ax_anim 2, 0, 51, -15, 3, -15, 0,
+ax_anim 2, 0, 51, -15, 4, -15, 1,
+ax_anim 2, 0, 48, -6, 1, -6, 0,
+ax_anim_terminator
+sKyogreAnims_2_8:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 6, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 55, -3, 5, -3, 5,
+ax_anim 2, 2, 55, -8, 12, -8, 12,
+ax_anim 2, 0, 55, -13, 18, -13, 18,
+ax_anim 2, 1, 55, -14, 17, -14, 17,
+ax_anim 2, 0, 55, -13, 18, -13, 18,
+ax_anim 2, 0, 55, -14, 17, -14, 17,
+ax_anim 2, 0, 52, -4, 6, -4, 6,
+ax_anim_terminator
+.align 2
+sKyogreAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 4, 0, 56, 0, -3, 0, -3,
+ax_anim 3, 2, 58, 0, -9, 0, 2,
+ax_anim 1, 0, 58, 0, -7, 0, 8,
+ax_anim 2, 0, 57, 0, 3, 0, 12,
+ax_anim 4, 1, 57, 0, 16, 0, 16,
+ax_anim 3, 0, 56, 0, 12, 0, 16,
+ax_anim 4, 0, 56, 0, 16, 0, 16,
+ax_anim 3, 0, 56, 0, 15, 0, 16,
+ax_anim 2, 0, 56, 0, 16, 0, 16,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sKyogreAnims_3_2:
+ax_anim 2, 0, 59, -2, -2, -2, -2,
+ax_anim 4, 0, 59, -3, -3, -3, -3,
+ax_anim 3, 2, 61, -1, -5, -1, -1,
+ax_anim 1, 0, 61, 6, -4, 6, 6,
+ax_anim 2, 0, 60, 12, 6, 12, 12,
+ax_anim 4, 1, 60, 15, 19, 15, 15,
+ax_anim 3, 0, 59, 15, 15, 15, 15,
+ax_anim 4, 0, 59, 15, 19, 15, 15,
+ax_anim 3, 0, 59, 15, 18, 15, 15,
+ax_anim 2, 0, 59, 15, 19, 15, 15,
+ax_anim 2, 0, 59, 6, 8, 6, 6,
+ax_anim_terminator
+sKyogreAnims_3_3:
+ax_anim 2, 0, 62, -2, 0, -2, 0,
+ax_anim 4, 0, 62, -3, 0, -3, 0,
+ax_anim 3, 2, 64, -1, -4, -1, 0,
+ax_anim 1, 0, 64, 6, -7, 6, 0,
+ax_anim 2, 0, 63, 10, -2, 10, 0,
+ax_anim 4, 1, 63, 13, 5, 13, 0,
+ax_anim 3, 0, 62, 13, 1, 13, 0,
+ax_anim 4, 0, 62, 13, 5, 13, 0,
+ax_anim 3, 0, 62, 13, 3, 13, 0,
+ax_anim 2, 0, 62, 13, 5, 13, 0,
+ax_anim 2, 0, 62, 6, 2, 6, 0,
+ax_anim_terminator
+sKyogreAnims_3_4:
+ax_anim 2, 0, 65, -2, 2, -2, 2,
+ax_anim 4, 0, 65, -3, 3, -3, 3,
+ax_anim 3, 2, 67, 0, -3, 0, 0,
+ax_anim 1, 0, 67, 6, -15, 6, -6,
+ax_anim 2, 0, 66, 9, -17, 10, -10,
+ax_anim 4, 1, 66, 14, -12, 14, -17,
+ax_anim 3, 0, 65, 14, -16, 14, -17,
+ax_anim 4, 0, 65, 14, -12, 14, -17,
+ax_anim 3, 0, 65, 14, -14, 14, -17,
+ax_anim 2, 0, 65, 14, -12, 14, -17,
+ax_anim 2, 0, 65, 7, -6, 7, -6,
+ax_anim_terminator
+sKyogreAnims_3_5:
+ax_anim 2, 0, 68, 0, 2, 0, 2,
+ax_anim 4, 0, 68, 0, 3, 0, 3,
+ax_anim 3, 2, 70, 0, -6, 0, -1,
+ax_anim 1, 0, 70, 0, -15, 0, -5,
+ax_anim 2, 0, 69, 0, -14, 0, -15,
+ax_anim 4, 1, 69, 0, -11, 0, -17,
+ax_anim 3, 0, 68, 0, -15, 0, -17,
+ax_anim 4, 0, 68, 0, -11, 0, -17,
+ax_anim 3, 0, 68, 0, -12, 0, -17,
+ax_anim 2, 0, 68, 0, -11, 0, -17,
+ax_anim 2, 0, 68, 0, -6, 0, -8,
+ax_anim_terminator
+sKyogreAnims_3_6:
+ax_anim 2, 0, 71, 2, 2, 2, 2,
+ax_anim 4, 0, 71, 3, 3, 3, 3,
+ax_anim 3, 2, 73, 0, -3, 0, 0,
+ax_anim 1, 0, 73, -6, -15, -6, -6,
+ax_anim 2, 0, 72, -9, -17, -9, -9,
+ax_anim 4, 1, 72, -14, -12, -14, -17,
+ax_anim 3, 0, 71, -14, -16, -14, -17,
+ax_anim 4, 0, 71, -14, -12, -14, -17,
+ax_anim 3, 0, 71, -14, -14, -14, -17,
+ax_anim 2, 0, 71, -14, -12, -14, -17,
+ax_anim 2, 0, 71, -7, -6, -7, -6,
+ax_anim_terminator
+sKyogreAnims_3_7:
+ax_anim 2, 0, 74, 2, 0, 2, 0,
+ax_anim 4, 0, 74, 3, 0, 3, 0,
+ax_anim 3, 2, 76, 1, -4, 1, 0,
+ax_anim 1, 0, 76, -6, -7, -6, 0,
+ax_anim 2, 0, 75, -10, -2, -10, 0,
+ax_anim 4, 1, 75, -13, 5, -13, 0,
+ax_anim 3, 0, 74, -13, 1, -13, 0,
+ax_anim 4, 0, 74, -13, 5, -13, 0,
+ax_anim 3, 0, 74, -13, 3, -13, 0,
+ax_anim 2, 0, 74, -13, 5, -13, 0,
+ax_anim 2, 0, 74, -6, 2, -6, 0,
+ax_anim_terminator
+sKyogreAnims_3_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 4, 0, 77, 3, -3, 3, -3,
+ax_anim 3, 2, 79, 1, -5, 1, -1,
+ax_anim 1, 0, 79, -6, -4, -6, 6,
+ax_anim 2, 0, 78, -12, 6, -12, 16,
+ax_anim 4, 1, 78, -15, 19, -15, 17,
+ax_anim 3, 0, 77, -15, 15, -15, 17,
+ax_anim 4, 0, 77, -15, 19, -15, 17,
+ax_anim 3, 0, 77, -15, 18, -15, 17,
+ax_anim 2, 0, 77, -15, 19, -15, 17,
+ax_anim 2, 0, 77, -6, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sKyogreAnims_4_1:
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 6, 2, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim_terminator
+sKyogreAnims_4_2:
+ax_anim 2, 0, 84, -2, -2, -2, -2,
+ax_anim 6, 2, 84, -3, -3, -3, -3,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 3, 1, 3, 1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 3, 1, 3, 1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 3, 1, 3, 1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim_terminator
+sKyogreAnims_4_3:
+ax_anim 2, 0, 87, -2, 0, -2, 0,
+ax_anim 6, 2, 87, -3, 0, -3, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 1, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim_terminator
+sKyogreAnims_4_4:
+ax_anim 2, 0, 90, -2, 2, -2, 2,
+ax_anim 6, 2, 90, -3, 3, -3, 3,
+ax_anim 2, 0, 89, -1, 1, -1, 1,
+ax_anim 2, 1, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim_terminator
+sKyogreAnims_4_5:
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 6, 2, 93, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 2, 1, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 1, -3, 1, -3,
+ax_anim 2, 0, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim_terminator
+sKyogreAnims_4_6:
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 6, 2, 96, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 1, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -1, -3, -1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -1, -3, -1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -1, -3, -1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim_terminator
+sKyogreAnims_4_7:
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 6, 2, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 1, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, 1, -3, 1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, 1, -3, 1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, 1, -3, 1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim_terminator
+sKyogreAnims_4_8:
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 6, 2, 102, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sKyogreAnims_5_1:
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 2, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_5_2:
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 2, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_5_3:
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 2, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_5_4:
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 2, 110, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_5_5:
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 2, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_5_6:
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 2, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_5_7:
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 2, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_5_8:
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 2, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_6_1:
+ax_anim 16, 0, 120, 0, 0, 0, 0,
+ax_anim 12, 0, 120, 0, -1, 0, 0,
+ax_anim 16, 0, 120, 0, -2, 0, 0,
+ax_anim 16, 0, 121, 0, -2, 0, 0,
+ax_anim 12, 0, 121, 0, -1, 0, 0,
+ax_anim 16, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sKyogreAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sKyogreAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sKyogreAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sKyogreAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sKyogreAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sKyogreAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sKyogreAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sKyogreAnims_8_1:
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 14, 0, 132, 0, -1, 0, 0,
+ax_anim 14, 0, 132, 0, -2, 0, 0,
+ax_anim 14, 0, 132, 0, -3, 0, 0,
+ax_anim 14, 0, 132, 0, -4, 0, 0,
+ax_anim 10, 0, 130, 0, -4, 0, 0,
+ax_anim 14, 0, 131, 0, -4, 0, 0,
+ax_anim 14, 0, 131, 0, -3, 0, 0,
+ax_anim 14, 0, 131, 0, -2, 0, 0,
+ax_anim 14, 0, 131, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_8_2:
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, -1, 0, 0,
+ax_anim 14, 0, 135, 0, -2, 0, 0,
+ax_anim 14, 0, 135, 0, -3, 0, 0,
+ax_anim 14, 0, 135, 0, -4, 0, 0,
+ax_anim 10, 0, 133, 0, -4, 0, 0,
+ax_anim 14, 0, 134, 0, -4, 0, 0,
+ax_anim 14, 0, 134, 0, -3, 0, 0,
+ax_anim 14, 0, 134, 0, -2, 0, 0,
+ax_anim 14, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_8_3:
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 14, 0, 138, 0, -1, 0, 0,
+ax_anim 14, 0, 138, 0, -2, 0, 0,
+ax_anim 14, 0, 138, 0, -3, 0, 0,
+ax_anim 14, 0, 138, 0, -4, 0, 0,
+ax_anim 10, 0, 136, 0, -4, 0, 0,
+ax_anim 14, 0, 137, 0, -4, 0, 0,
+ax_anim 14, 0, 137, 0, -3, 0, 0,
+ax_anim 14, 0, 137, 0, -2, 0, 0,
+ax_anim 14, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_8_4:
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 14, 0, 141, 0, -1, 0, 0,
+ax_anim 14, 0, 141, 0, -2, 0, 0,
+ax_anim 14, 0, 141, 0, -3, 0, 0,
+ax_anim 14, 0, 141, 0, -4, 0, 0,
+ax_anim 10, 0, 139, 0, -4, 0, 0,
+ax_anim 14, 0, 140, 0, -4, 0, 0,
+ax_anim 14, 0, 140, 0, -3, 0, 0,
+ax_anim 14, 0, 140, 0, -2, 0, 0,
+ax_anim 14, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_8_5:
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim 14, 0, 144, 0, -1, 0, 0,
+ax_anim 14, 0, 144, 0, -2, 0, 0,
+ax_anim 14, 0, 144, 0, -3, 0, 0,
+ax_anim 14, 0, 144, 0, -4, 0, 0,
+ax_anim 10, 0, 142, 0, -4, 0, 0,
+ax_anim 14, 0, 143, 0, -4, 0, 0,
+ax_anim 14, 0, 143, 0, -3, 0, 0,
+ax_anim 14, 0, 143, 0, -2, 0, 0,
+ax_anim 14, 0, 143, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_8_6:
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 14, 0, 147, 0, -1, 0, 0,
+ax_anim 14, 0, 147, 0, -2, 0, 0,
+ax_anim 14, 0, 147, 0, -3, 0, 0,
+ax_anim 14, 0, 147, 0, -4, 0, 0,
+ax_anim 10, 0, 145, 0, -4, 0, 0,
+ax_anim 14, 0, 146, 0, -4, 0, 0,
+ax_anim 14, 0, 146, 0, -3, 0, 0,
+ax_anim 14, 0, 146, 0, -2, 0, 0,
+ax_anim 14, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_8_7:
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim 14, 0, 150, 0, -1, 0, 0,
+ax_anim 14, 0, 150, 0, -2, 0, 0,
+ax_anim 14, 0, 150, 0, -3, 0, 0,
+ax_anim 14, 0, 150, 0, -4, 0, 0,
+ax_anim 10, 0, 148, 0, -4, 0, 0,
+ax_anim 14, 0, 149, 0, -4, 0, 0,
+ax_anim 14, 0, 149, 0, -3, 0, 0,
+ax_anim 14, 0, 149, 0, -2, 0, 0,
+ax_anim 14, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sKyogreAnims_8_8:
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 14, 0, 153, 0, -1, 0, 0,
+ax_anim 14, 0, 153, 0, -2, 0, 0,
+ax_anim 14, 0, 153, 0, -3, 0, 0,
+ax_anim 14, 0, 153, 0, -4, 0, 0,
+ax_anim 10, 0, 151, 0, -4, 0, 0,
+ax_anim 14, 0, 152, 0, -4, 0, 0,
+ax_anim 14, 0, 152, 0, -3, 0, 0,
+ax_anim 14, 0, 152, 0, -2, 0, 0,
+ax_anim 14, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 5, 3, 5, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 6, 14, 6, 14,
+ax_anim 3, 0, 158, 0, 15, 0, 15,
+ax_anim 2, 3, 159, -6, 14, -6, 14,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -5, 3, -5, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 5, 2, 5, 2,
+ax_anim 2, 0, 155, 11, 6, 11, 5,
+ax_anim 2, 0, 156, 13, 10, 13, 7,
+ax_anim 3, 0, 157, 10, 12, 10, 9,
+ax_anim 2, 3, 158, 7, 11, 7, 9,
+ax_anim 2, 0, 159, 3, 8, 3, 8,
+ax_anim 1, 0, 160, 1, 5, 1, 5,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 1, -4, 1, -4,
+ax_anim 2, 0, 154, 3, -6, 3, -6,
+ax_anim 2, 0, 155, 6, -4, 6, -4,
+ax_anim 3, 0, 156, 7, 2, 9, 1,
+ax_anim 2, 3, 157, 5, 4, 5, 4,
+ax_anim 2, 0, 158, 2, 5, 2, 5,
+ax_anim 1, 0, 159, 1, 4, 1, 4,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 1, -5, 1, -5,
+ax_anim 2, 0, 161, 4, -10, 4, -10,
+ax_anim 2, 0, 154, 10, -13, 10, -17,
+ax_anim 3, 0, 155, 12, -11, 12, -17,
+ax_anim 2, 3, 156, 11, -8, 11, -12,
+ax_anim 2, 0, 157, 8, -6, 8, -6,
+ax_anim 1, 0, 158, 5, -3, 5, -3,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -4, -2, -4, -2,
+ax_anim 2, 0, 160, -5, -6, -5, -6,
+ax_anim 2, 0, 161, -4, -11, -4, -11,
+ax_anim 3, 0, 154, 0, -12, 0, -13,
+ax_anim 2, 3, 155, 4, -11, 4, -11,
+ax_anim 2, 0, 156, 5, -6, 5, -6,
+ax_anim 1, 0, 157, 4, -2, 4, -2,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, -1, -5, -1, -5,
+ax_anim 2, 0, 155, -4, -10, -4, -10,
+ax_anim 2, 0, 154, -10, -13, -10, -17,
+ax_anim 3, 0, 161, -12, -11, -12, -17,
+ax_anim 2, 3, 160, -11, -8, -11, -12,
+ax_anim 2, 0, 159, -8, -6, -8, -6,
+ax_anim 1, 0, 158, -5, -3, -5, -3,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -1, -4, -1, -4,
+ax_anim 2, 0, 154, -3, -6, -3, -6,
+ax_anim 2, 0, 161, -6, -4, -6, -4,
+ax_anim 3, 0, 160, -7, 2, -9, 1,
+ax_anim 2, 3, 159, -5, 4, -5, 4,
+ax_anim 2, 0, 158, -2, 5, -2, 5,
+ax_anim 1, 0, 157, -1, 4, -1, 4,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -5, 2, -5, 2,
+ax_anim 2, 0, 161, -11, 6, -11, 5,
+ax_anim 2, 0, 160, -13, 10, -13, 7,
+ax_anim 3, 0, 159, -10, 12, -10, 9,
+ax_anim 2, 3, 158, -7, 11, -7, 9,
+ax_anim 2, 0, 157, -3, 8, -3, 8,
+ax_anim 1, 0, 156, -1, 5, -1, 5,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_10_1:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_10_2:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_10_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_10_4:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_10_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_10_6:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_10_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_10_8:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_11_1:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -22, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -17, 0, 0,
+ax_anim 1, 0, 199, 0, -11, 0, 0,
+ax_anim 2, 2, 198, 0, 6, 0, 0,
+ax_anim_terminator
+sKyogreAnims_11_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 6, 0, 0,
+ax_anim_terminator
+sKyogreAnims_11_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -22, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 204, 0, 6, 0, 0,
+ax_anim_terminator
+sKyogreAnims_11_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 2, 207, 0, 6, 0, 0,
+ax_anim_terminator
+sKyogreAnims_11_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -22, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 210, 0, 8, 0, 0,
+ax_anim_terminator
+sKyogreAnims_11_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 2, 213, 0, 6, 0, 0,
+ax_anim_terminator
+sKyogreAnims_11_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -17, 0, 0,
+ax_anim 1, 0, 217, 0, -11, 0, 0,
+ax_anim 2, 2, 216, 0, 6, 0, 0,
+ax_anim_terminator
+sKyogreAnims_11_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 4, 0, 219, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -21, 0, 0,
+ax_anim 2, 0, 220, 0, -17, 0, 0,
+ax_anim 1, 0, 220, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 6, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_12_1:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_12_2:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_12_3:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_12_4:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_12_5:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_12_6:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_12_7:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_12_8:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sKyogreAnims_13_1:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_13_2:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_13_3:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_13_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_13_5:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_13_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_13_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreAnims_13_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sKyogreGfx1:
+.incbin "baserom.gba", 0x15C8DC8, 0x80
+sKyogreGfx1_1:
+.incbin "baserom.gba", 0x15C8E48, 0x300
+sKyogreGfx1_2:
+.incbin "baserom.gba", 0x15C9148, 0x40
+sKyogreSprites1:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx1_1, 0x300
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx1_2, 0x40
+ax_sprite 0, 0x360
+ax_sprite_terminator
+sKyogreGfx2:
+.incbin "baserom.gba", 0x15C91C8, 0x80
+sKyogreGfx2_1:
+.incbin "baserom.gba", 0x15C9248, 0x300
+sKyogreGfx2_2:
+.incbin "baserom.gba", 0x15C9548, 0x40
+sKyogreSprites2:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx2_1, 0x300
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx2_2, 0x40
+ax_sprite 0, 0x360
+ax_sprite_terminator
+sKyogreGfx3:
+.incbin "baserom.gba", 0x15C95C8, 0xA0
+sKyogreGfx3_1:
+.incbin "baserom.gba", 0x15C9668, 0xA0
+sKyogreGfx3_2:
+.incbin "baserom.gba", 0x15C9708, 0xE0
+sKyogreGfx3_3:
+.incbin "baserom.gba", 0x15C97E8, 0xE0
+sKyogreGfx3_4:
+.incbin "baserom.gba", 0x15C98C8, 0x20
+sKyogreGfx3_5:
+.incbin "baserom.gba", 0x15C98E8, 0x20
+sKyogreGfx3_6:
+.incbin "baserom.gba", 0x15C9908, 0x20
+sKyogreSprites3:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx3_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx3_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx3_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx3_4, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx3_5, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx3_6, 0x20
+ax_sprite 0, 0x320
+ax_sprite_terminator
+sKyogreGfx4:
+.incbin "baserom.gba", 0x15C99A8, 0x60
+sKyogreGfx4_1:
+.incbin "baserom.gba", 0x15C9A08, 0x1E0
+sKyogreGfx4_2:
+.incbin "baserom.gba", 0x15C9BE8, 0xC0
+sKyogreGfx4_3:
+.incbin "baserom.gba", 0x15C9CA8, 0xC0
+sKyogreGfx4_4:
+.incbin "baserom.gba", 0x15C9D68, 0x40
+sKyogreSprites4:
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx4, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx4_1, 0x1e0
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx4_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx4_3, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sKyogreGfx4_4, 0x40
+ax_sprite 0, 0x220
+ax_sprite_terminator
+sKyogreGfx5:
+.incbin "baserom.gba", 0x15C9E08, 0x40
+sKyogreGfx5_1:
+.incbin "baserom.gba", 0x15C9E48, 0x40
+sKyogreGfx5_2:
+.incbin "baserom.gba", 0x15C9E88, 0xE0
+sKyogreGfx5_3:
+.incbin "baserom.gba", 0x15C9F68, 0xE0
+sKyogreGfx5_4:
+.incbin "baserom.gba", 0x15CA048, 0xC0
+sKyogreGfx5_5:
+.incbin "baserom.gba", 0x15CA108, 0xC0
+sKyogreSprites5:
+ax_sprite sKyogreGfx5, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx5_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx5_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx5_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx5_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx5_5, 0xc0
+ax_sprite 0, 0x320
+ax_sprite_terminator
+sKyogreGfx6:
+.incbin "baserom.gba", 0x15CA230, 0x60
+sKyogreGfx6_1:
+.incbin "baserom.gba", 0x15CA290, 0xE0
+sKyogreGfx6_2:
+.incbin "baserom.gba", 0x15CA370, 0xC0
+sKyogreGfx6_3:
+.incbin "baserom.gba", 0x15CA430, 0xE0
+sKyogreGfx6_4:
+.incbin "baserom.gba", 0x15CA510, 0x80
+sKyogreGfx6_5:
+.incbin "baserom.gba", 0x15CA590, 0x40
+sKyogreSprites6:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx6, 0x60
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx6_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx6_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx6_3, 0xe0
+ax_sprite 0, 0x80
+ax_sprite sKyogreGfx6_4, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sKyogreGfx6_5, 0x40
+ax_sprite 0, 0x240
+ax_sprite_terminator
+sKyogreGfx7:
+.incbin "baserom.gba", 0x15CA640, 0xA0
+sKyogreGfx7_1:
+.incbin "baserom.gba", 0x15CA6E0, 0xC0
+sKyogreGfx7_2:
+.incbin "baserom.gba", 0x15CA7A0, 0xC0
+sKyogreGfx7_3:
+.incbin "baserom.gba", 0x15CA860, 0xA0
+sKyogreGfx7_4:
+.incbin "baserom.gba", 0x15CA900, 0x80
+sKyogreGfx7_5:
+.incbin "baserom.gba", 0x15CA980, 0x80
+sKyogreSprites7:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx7, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx7_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx7_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx7_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx7_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sKyogreGfx7_5, 0x80
+ax_sprite 0, 0x280
+ax_sprite_terminator
+sKyogreGfx8:
+.incbin "baserom.gba", 0x15CAA70, 0x60
+sKyogreGfx8_1:
+.incbin "baserom.gba", 0x15CAAD0, 0x20
+sKyogreGfx8_2:
+.incbin "baserom.gba", 0x15CAAF0, 0xC0
+sKyogreGfx8_3:
+.incbin "baserom.gba", 0x15CABB0, 0xC0
+sKyogreGfx8_4:
+.incbin "baserom.gba", 0x15CAC70, 0xC0
+sKyogreGfx8_5:
+.incbin "baserom.gba", 0x15CAD30, 0x80
+sKyogreSprites8:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx8, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx8_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx8_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx8_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx8_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx8_5, 0x80
+ax_sprite 0, 0x380
+ax_sprite_terminator
+sKyogreGfx9:
+.incbin "baserom.gba", 0x15CAE20, 0xA0
+sKyogreGfx9_1:
+.incbin "baserom.gba", 0x15CAEC0, 0xC0
+sKyogreGfx9_2:
+.incbin "baserom.gba", 0x15CAF80, 0xC0
+sKyogreGfx9_3:
+.incbin "baserom.gba", 0x15CB040, 0xA0
+sKyogreGfx9_4:
+.incbin "baserom.gba", 0x15CB0E0, 0x80
+sKyogreGfx9_5:
+.incbin "baserom.gba", 0x15CB160, 0x80
+sKyogreSprites9:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx9, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx9_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx9_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx9_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx9_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sKyogreGfx9_5, 0x80
+ax_sprite 0, 0x280
+ax_sprite_terminator
+sKyogreGfx10:
+.incbin "baserom.gba", 0x15CB250, 0xC0
+sKyogreGfx10_1:
+.incbin "baserom.gba", 0x15CB310, 0xC0
+sKyogreGfx10_2:
+.incbin "baserom.gba", 0x15CB3D0, 0xE0
+sKyogreGfx10_3:
+.incbin "baserom.gba", 0x15CB4B0, 0xE0
+sKyogreGfx10_4:
+.incbin "baserom.gba", 0x15CB590, 0xC0
+sKyogreSprites10:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx10, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx10_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx10_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx10_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx10_4, 0xc0
+ax_sprite 0, 0x340
+ax_sprite_terminator
+sKyogreGfx11:
+.incbin "baserom.gba", 0x15CB6B0, 0xA0
+sKyogreGfx11_1:
+.incbin "baserom.gba", 0x15CB750, 0xC0
+sKyogreGfx11_2:
+.incbin "baserom.gba", 0x15CB810, 0xE0
+sKyogreGfx11_3:
+.incbin "baserom.gba", 0x15CB8F0, 0xE0
+sKyogreGfx11_4:
+.incbin "baserom.gba", 0x15CB9D0, 0x80
+sKyogreSprites11:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx11, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx11_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx11_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx11_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx11_4, 0x80
+ax_sprite 0, 0x360
+ax_sprite_terminator
+sKyogreGfx12:
+.incbin "baserom.gba", 0x15CBAB0, 0xA0
+sKyogreGfx12_1:
+.incbin "baserom.gba", 0x15CBB50, 0xC0
+sKyogreGfx12_2:
+.incbin "baserom.gba", 0x15CBC10, 0xE0
+sKyogreGfx12_3:
+.incbin "baserom.gba", 0x15CBCF0, 0xE0
+sKyogreGfx12_4:
+.incbin "baserom.gba", 0x15CBDD0, 0x40
+sKyogreGfx12_5:
+.incbin "baserom.gba", 0x15CBE10, 0x40
+sKyogreSprites12:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx12, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx12_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx12_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx12_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx12_4, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx12_5, 0x40
+ax_sprite 0, 0x360
+ax_sprite_terminator
+sKyogreGfx13:
+.incbin "baserom.gba", 0x15CBEC0, 0x40
+sKyogreGfx13_1:
+.incbin "baserom.gba", 0x15CBF00, 0x40
+sKyogreGfx13_2:
+.incbin "baserom.gba", 0x15CBF40, 0x240
+sKyogreGfx13_3:
+.incbin "baserom.gba", 0x15CC180, 0x80
+sKyogreGfx13_4:
+.incbin "baserom.gba", 0x15CC200, 0x80
+sKyogreSprites13:
+ax_sprite sKyogreGfx13, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx13_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx13_2, 0x240
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx13_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sKyogreGfx13_4, 0x80
+ax_sprite 0, 0x340
+ax_sprite_terminator
+sKyogreGfx14:
+.incbin "baserom.gba", 0x15CC2D8, 0x300
+sKyogreGfx14_1:
+.incbin "baserom.gba", 0x15CC5D8, 0x80
+sKyogreGfx14_2:
+.incbin "baserom.gba", 0x15CC658, 0x80
+sKyogreSprites14:
+ax_sprite sKyogreGfx14, 0x300
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx14_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sKyogreGfx14_2, 0x80
+ax_sprite 0, 0x340
+ax_sprite_terminator
+sKyogreGfx15:
+.incbin "baserom.gba", 0x15CC710, 0x60
+sKyogreGfx15_1:
+.incbin "baserom.gba", 0x15CC770, 0xE0
+sKyogreGfx15_2:
+.incbin "baserom.gba", 0x15CC850, 0xE0
+sKyogreGfx15_3:
+.incbin "baserom.gba", 0x15CC930, 0xE0
+sKyogreGfx15_4:
+.incbin "baserom.gba", 0x15CCA10, 0xA0
+sKyogreSprites15:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx15, 0x60
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx15_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx15_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx15_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx15_4, 0xa0
+ax_sprite 0, 0x340
+ax_sprite_terminator
+sKyogreGfx16:
+.incbin "baserom.gba", 0x15CCB10, 0x80
+sKyogreGfx16_1:
+.incbin "baserom.gba", 0x15CCB90, 0x2E0
+sKyogreSprites16:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx16, 0x80
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx16_1, 0x2e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx17:
+.incbin "baserom.gba", 0x15CCEA0, 0x40
+sKyogreSprites17:
+ax_sprite sKyogreGfx17, 0x40
+ax_sprite_terminator
+sKyogreGfx18:
+.incbin "baserom.gba", 0x15CCEF0, 0x180
+sKyogreGfx18_1:
+.incbin "baserom.gba", 0x15CD070, 0x60
+sKyogreSprites18:
+ax_sprite sKyogreGfx18, 0x180
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx18_1, 0x60
+ax_sprite_terminator
+sKyogreGfx19:
+.incbin "baserom.gba", 0x15CD0F0, 0x20
+sKyogreGfx19_1:
+.incbin "baserom.gba", 0x15CD110, 0xC0
+sKyogreSprites19:
+ax_sprite sKyogreGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx19_1, 0xc0
+ax_sprite_terminator
+sKyogreGfx20:
+.incbin "baserom.gba", 0x15CD1F0, 0x80
+sKyogreSprites20:
+ax_sprite sKyogreGfx20, 0x80
+ax_sprite_terminator
+sKyogreGfx21:
+.incbin "baserom.gba", 0x15CD280, 0x60
+sKyogreSprites21:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx21, 0x60
+ax_sprite_terminator
+sKyogreGfx22:
+.incbin "baserom.gba", 0x15CD2F8, 0x40
+sKyogreSprites22:
+ax_sprite sKyogreGfx22, 0x40
+ax_sprite_terminator
+sKyogreGfx23:
+.incbin "baserom.gba", 0x15CD348, 0x160
+sKyogreGfx23_1:
+.incbin "baserom.gba", 0x15CD4A8, 0x60
+sKyogreSprites23:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx23, 0x160
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx23_1, 0x60
+ax_sprite_terminator
+sKyogreGfx24:
+.incbin "baserom.gba", 0x15CD530, 0x100
+sKyogreSprites24:
+ax_sprite sKyogreGfx24, 0x100
+ax_sprite_terminator
+sKyogreGfx25:
+.incbin "baserom.gba", 0x15CD640, 0x80
+sKyogreSprites25:
+ax_sprite sKyogreGfx25, 0x80
+ax_sprite_terminator
+sKyogreGfx26:
+.incbin "baserom.gba", 0x15CD6D0, 0x40
+sKyogreSprites26:
+ax_sprite sKyogreGfx26, 0x40
+ax_sprite_terminator
+sKyogreGfx27:
+.incbin "baserom.gba", 0x15CD720, 0x200
+sKyogreSprites27:
+ax_sprite sKyogreGfx27, 0x200
+ax_sprite_terminator
+sKyogreGfx28:
+.incbin "baserom.gba", 0x15CD930, 0x20
+sKyogreGfx28_1:
+.incbin "baserom.gba", 0x15CD950, 0xC0
+sKyogreSprites28:
+ax_sprite sKyogreGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx28_1, 0xc0
+ax_sprite_terminator
+sKyogreGfx29:
+.incbin "baserom.gba", 0x15CDA30, 0x40
+sKyogreSprites29:
+ax_sprite sKyogreGfx29, 0x40
+ax_sprite_terminator
+sKyogreGfx30:
+.incbin "baserom.gba", 0x15CDA80, 0x40
+sKyogreSprites30:
+ax_sprite sKyogreGfx30, 0x40
+ax_sprite_terminator
+sKyogreGfx31:
+.incbin "baserom.gba", 0x15CDAD0, 0x40
+sKyogreGfx31_1:
+.incbin "baserom.gba", 0x15CDB10, 0x180
+sKyogreSprites31:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx31_1, 0x180
+ax_sprite_terminator
+sKyogreGfx32:
+.incbin "baserom.gba", 0x15CDCB8, 0x40
+sKyogreSprites32:
+ax_sprite sKyogreGfx32, 0x40
+ax_sprite_terminator
+sKyogreGfx33:
+.incbin "baserom.gba", 0x15CDD08, 0x40
+sKyogreSprites33:
+ax_sprite sKyogreGfx33, 0x40
+ax_sprite_terminator
+sKyogreGfx34:
+.incbin "baserom.gba", 0x15CDD58, 0x80
+sKyogreSprites34:
+ax_sprite sKyogreGfx34, 0x80
+ax_sprite_terminator
+sKyogreGfx35:
+.incbin "baserom.gba", 0x15CDDE8, 0x80
+sKyogreSprites35:
+ax_sprite sKyogreGfx35, 0x80
+ax_sprite_terminator
+sKyogreGfx36:
+.incbin "baserom.gba", 0x15CDE78, 0x80
+sKyogreGfx36_1:
+.incbin "baserom.gba", 0x15CDEF8, 0x300
+sKyogreSprites36:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx36, 0x80
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx36_1, 0x300
+ax_sprite_terminator
+sKyogreGfx37:
+.incbin "baserom.gba", 0x15CE220, 0x20
+sKyogreSprites37:
+ax_sprite sKyogreGfx37, 0x20
+ax_sprite_terminator
+sKyogreGfx38:
+.incbin "baserom.gba", 0x15CE250, 0x60
+sKyogreGfx38_1:
+.incbin "baserom.gba", 0x15CE2B0, 0x200
+sKyogreGfx38_2:
+.incbin "baserom.gba", 0x15CE4B0, 0xC0
+sKyogreSprites38:
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx38, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx38_1, 0x200
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx38_2, 0xc0
+ax_sprite_terminator
+sKyogreGfx39:
+.incbin "baserom.gba", 0x15CE5A8, 0x80
+sKyogreSprites39:
+ax_sprite sKyogreGfx39, 0x80
+ax_sprite_terminator
+sKyogreGfx40:
+.incbin "baserom.gba", 0x15CE638, 0x40
+sKyogreSprites40:
+ax_sprite sKyogreGfx40, 0x40
+ax_sprite_terminator
+sKyogreGfx41:
+.incbin "baserom.gba", 0x15CE688, 0x1E0
+sKyogreSprites41:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx41, 0x1e0
+ax_sprite_terminator
+sKyogreGfx42:
+.incbin "baserom.gba", 0x15CE880, 0x80
+sKyogreSprites42:
+ax_sprite sKyogreGfx42, 0x80
+ax_sprite_terminator
+sKyogreGfx43:
+.incbin "baserom.gba", 0x15CE910, 0xC0
+sKyogreSprites43:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx43, 0xc0
+ax_sprite_terminator
+sKyogreGfx44:
+.incbin "baserom.gba", 0x15CE9E8, 0xC0
+sKyogreGfx44_1:
+.incbin "baserom.gba", 0x15CEAA8, 0xC0
+sKyogreGfx44_2:
+.incbin "baserom.gba", 0x15CEB68, 0xE0
+sKyogreGfx44_3:
+.incbin "baserom.gba", 0x15CEC48, 0xE0
+sKyogreSprites44:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx44, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx44_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx44_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx44_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx45:
+.incbin "baserom.gba", 0x15CED78, 0x40
+sKyogreSprites45:
+ax_sprite sKyogreGfx45, 0x40
+ax_sprite_terminator
+sKyogreGfx46:
+.incbin "baserom.gba", 0x15CEDC8, 0x60
+sKyogreSprites46:
+ax_sprite sKyogreGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx47:
+.incbin "baserom.gba", 0x15CEE40, 0x20
+sKyogreSprites47:
+ax_sprite sKyogreGfx47, 0x20
+ax_sprite_terminator
+sKyogreGfx48:
+.incbin "baserom.gba", 0x15CEE70, 0xA0
+sKyogreGfx48_1:
+.incbin "baserom.gba", 0x15CEF10, 0x340
+sKyogreSprites48:
+ax_sprite sKyogreGfx48, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx48_1, 0x340
+ax_sprite_terminator
+sKyogreGfx49:
+.incbin "baserom.gba", 0x15CF270, 0x80
+sKyogreSprites49:
+ax_sprite sKyogreGfx49, 0x80
+ax_sprite_terminator
+sKyogreGfx50:
+.incbin "baserom.gba", 0x15CF300, 0xA0
+sKyogreGfx50_1:
+.incbin "baserom.gba", 0x15CF3A0, 0xA0
+sKyogreGfx50_2:
+.incbin "baserom.gba", 0x15CF440, 0x200
+sKyogreSprites50:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx50, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx50_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx50_2, 0x200
+ax_sprite_terminator
+sKyogreGfx51:
+.incbin "baserom.gba", 0x15CF678, 0x80
+sKyogreSprites51:
+ax_sprite sKyogreGfx51, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sKyogreGfx52:
+.incbin "baserom.gba", 0x15CF710, 0xA0
+sKyogreSprites52:
+ax_sprite sKyogreGfx52, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sKyogreGfx53:
+.incbin "baserom.gba", 0x15CF7C8, 0x40
+sKyogreSprites53:
+ax_sprite sKyogreGfx53, 0x40
+ax_sprite_terminator
+sKyogreGfx54:
+.incbin "baserom.gba", 0x15CF818, 0x20
+sKyogreSprites54:
+ax_sprite sKyogreGfx54, 0x20
+ax_sprite_terminator
+sKyogreGfx55:
+.incbin "baserom.gba", 0x15CF848, 0x60
+sKyogreGfx55_1:
+.incbin "baserom.gba", 0x15CF8A8, 0x300
+sKyogreSprites55:
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx55, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx55_1, 0x300
+ax_sprite_terminator
+sKyogreGfx56:
+.incbin "baserom.gba", 0x15CFBD0, 0x80
+sKyogreGfx56_1:
+.incbin "baserom.gba", 0x15CFC50, 0x60
+sKyogreSprites56:
+ax_sprite sKyogreGfx56, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx56_1, 0x60
+ax_sprite_terminator
+sKyogreGfx57:
+.incbin "baserom.gba", 0x15CFCD0, 0x40
+sKyogreSprites57:
+ax_sprite sKyogreGfx57, 0x40
+ax_sprite_terminator
+sKyogreGfx58:
+.incbin "baserom.gba", 0x15CFD20, 0x20
+sKyogreSprites58:
+ax_sprite sKyogreGfx58, 0x20
+ax_sprite_terminator
+sKyogreGfx59:
+.incbin "baserom.gba", 0x15CFD50, 0x1E0
+sKyogreSprites59:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx59, 0x1e0
+ax_sprite_terminator
+sKyogreGfx60:
+.incbin "baserom.gba", 0x15CFF48, 0x100
+sKyogreSprites60:
+ax_sprite sKyogreGfx60, 0x100
+ax_sprite_terminator
+sKyogreGfx61:
+.incbin "baserom.gba", 0x15D0058, 0x60
+sKyogreGfx61_1:
+.incbin "baserom.gba", 0x15D00B8, 0x60
+sKyogreGfx61_2:
+.incbin "baserom.gba", 0x15D0118, 0x60
+sKyogreGfx61_3:
+.incbin "baserom.gba", 0x15D0178, 0x60
+sKyogreSprites61:
+ax_sprite sKyogreGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx61_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx61_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx61_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx62:
+.incbin "baserom.gba", 0x15D0220, 0xE0
+sKyogreGfx62_1:
+.incbin "baserom.gba", 0x15D0300, 0x2E0
+sKyogreSprites62:
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx62, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx62_1, 0x2e0
+ax_sprite_terminator
+sKyogreGfx63:
+.incbin "baserom.gba", 0x15D0608, 0x80
+sKyogreGfx63_1:
+.incbin "baserom.gba", 0x15D0688, 0x20
+sKyogreSprites63:
+ax_sprite sKyogreGfx63, 0x80
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx63_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sKyogreGfx64:
+.incbin "baserom.gba", 0x15D06D0, 0x60
+sKyogreGfx64_1:
+.incbin "baserom.gba", 0x15D0730, 0x20
+sKyogreSprites64:
+ax_sprite sKyogreGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx64_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sKyogreGfx65:
+.incbin "baserom.gba", 0x15D0778, 0x60
+sKyogreGfx65_1:
+.incbin "baserom.gba", 0x15D07D8, 0x300
+sKyogreSprites65:
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx65, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx65_1, 0x300
+ax_sprite_terminator
+sKyogreGfx66:
+.incbin "baserom.gba", 0x15D0B00, 0x80
+sKyogreSprites66:
+ax_sprite sKyogreGfx66, 0x80
+ax_sprite_terminator
+sKyogreGfx67:
+.incbin "baserom.gba", 0x15D0B90, 0x20
+sKyogreSprites67:
+ax_sprite sKyogreGfx67, 0x20
+ax_sprite_terminator
+sKyogreGfx68:
+.incbin "baserom.gba", 0x15D0BC0, 0x20
+sKyogreSprites68:
+ax_sprite sKyogreGfx68, 0x20
+ax_sprite_terminator
+sKyogreGfx69:
+.incbin "baserom.gba", 0x15D0BF0, 0x40
+sKyogreSprites69:
+ax_sprite sKyogreGfx69, 0x40
+ax_sprite_terminator
+sKyogreGfx70:
+.incbin "baserom.gba", 0x15D0C40, 0x60
+sKyogreGfx70_1:
+.incbin "baserom.gba", 0x15D0CA0, 0x2E0
+sKyogreSprites70:
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx70, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx70_1, 0x2e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx71:
+.incbin "baserom.gba", 0x15D0FB0, 0xE0
+sKyogreSprites71:
+ax_sprite sKyogreGfx71, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx72:
+.incbin "baserom.gba", 0x15D10A8, 0x40
+sKyogreSprites72:
+ax_sprite sKyogreGfx72, 0x40
+ax_sprite_terminator
+sKyogreGfx73:
+.incbin "baserom.gba", 0x15D10F8, 0x40
+sKyogreGfx73_1:
+.incbin "baserom.gba", 0x15D1138, 0xE0
+sKyogreGfx73_2:
+.incbin "baserom.gba", 0x15D1218, 0xE0
+sKyogreGfx73_3:
+.incbin "baserom.gba", 0x15D12F8, 0xE0
+sKyogreSprites73:
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx73, 0x40
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx73_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx73_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx73_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx74:
+.incbin "baserom.gba", 0x15D1428, 0xE0
+sKyogreSprites74:
+ax_sprite sKyogreGfx74, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx75:
+.incbin "baserom.gba", 0x15D1520, 0x40
+sKyogreSprites75:
+ax_sprite sKyogreGfx75, 0x40
+ax_sprite_terminator
+sKyogreGfx76:
+.incbin "baserom.gba", 0x15D1570, 0xE0
+sKyogreGfx76_1:
+.incbin "baserom.gba", 0x15D1650, 0x200
+sKyogreGfx76_2:
+.incbin "baserom.gba", 0x15D1850, 0xC0
+sKyogreSprites76:
+ax_sprite sKyogreGfx76, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx76_1, 0x200
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx76_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx77:
+.incbin "baserom.gba", 0x15D1948, 0x100
+sKyogreSprites77:
+ax_sprite sKyogreGfx77, 0x100
+ax_sprite_terminator
+sKyogreGfx78:
+.incbin "baserom.gba", 0x15D1A58, 0x60
+sKyogreGfx78_1:
+.incbin "baserom.gba", 0x15D1AB8, 0xC0
+sKyogreGfx78_2:
+.incbin "baserom.gba", 0x15D1B78, 0xE0
+sKyogreGfx78_3:
+.incbin "baserom.gba", 0x15D1C58, 0xE0
+sKyogreSprites78:
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx78, 0x60
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx78_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx78_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx78_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx79:
+.incbin "baserom.gba", 0x15D1D88, 0x100
+sKyogreSprites79:
+ax_sprite sKyogreGfx79, 0x100
+ax_sprite_terminator
+sKyogreGfx80:
+.incbin "baserom.gba", 0x15D1E98, 0x20
+sKyogreSprites80:
+ax_sprite sKyogreGfx80, 0x20
+ax_sprite_terminator
+sKyogreGfx81:
+.incbin "baserom.gba", 0x15D1EC8, 0x60
+sKyogreGfx81_1:
+.incbin "baserom.gba", 0x15D1F28, 0xC0
+sKyogreGfx81_2:
+.incbin "baserom.gba", 0x15D1FE8, 0xC0
+sKyogreGfx81_3:
+.incbin "baserom.gba", 0x15D20A8, 0xC0
+sKyogreSprites81:
+ax_sprite 0, 0x80
+ax_sprite sKyogreGfx81, 0x60
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx81_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx81_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx81_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx82:
+.incbin "baserom.gba", 0x15D21B8, 0x100
+sKyogreSprites82:
+ax_sprite sKyogreGfx82, 0x100
+ax_sprite_terminator
+sKyogreGfx83:
+.incbin "baserom.gba", 0x15D22C8, 0x40
+sKyogreSprites83:
+ax_sprite sKyogreGfx83, 0x40
+ax_sprite_terminator
+sKyogreGfx84:
+.incbin "baserom.gba", 0x15D2318, 0xA0
+sKyogreGfx84_1:
+.incbin "baserom.gba", 0x15D23B8, 0xA0
+sKyogreGfx84_2:
+.incbin "baserom.gba", 0x15D2458, 0xE0
+sKyogreGfx84_3:
+.incbin "baserom.gba", 0x15D2538, 0xE0
+sKyogreSprites84:
+ax_sprite 0, 0x40
+ax_sprite sKyogreGfx84, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sKyogreGfx84_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx84_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx84_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sKyogreGfx85:
+.incbin "baserom.gba", 0x15D2668, 0x40
+sKyogreSprites85:
+ax_sprite sKyogreGfx85, 0x40
+ax_sprite_terminator
+sKyogreGfx86:
+.incbin "baserom.gba", 0x15D26B8, 0x20
+sKyogreSprites86:
+ax_sprite sKyogreGfx86, 0x20
+ax_sprite_terminator
+sKyogreGfx87:
+.incbin "baserom.gba", 0x15D26E8, 0x300
+sKyogreGfx87_1:
+.incbin "baserom.gba", 0x15D29E8, 0xC0
+sKyogreSprites87:
+ax_sprite sKyogreGfx87, 0x300
+ax_sprite 0, 0x20
+ax_sprite sKyogreGfx87_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAxPosesKyogre:
+.4byte sKyogrePose1
+.4byte sKyogrePose2
+.4byte sKyogrePose3
+.4byte sKyogrePose4
+.4byte sKyogrePose5
+.4byte sKyogrePose6
+.4byte sKyogrePose7
+.4byte sKyogrePose8
+.4byte sKyogrePose9
+.4byte sKyogrePose10
+.4byte sKyogrePose11
+.4byte sKyogrePose12
+.4byte sKyogrePose13
+.4byte sKyogrePose14
+.4byte sKyogrePose15
+.4byte sKyogrePose16
+.4byte sKyogrePose17
+.4byte sKyogrePose18
+.4byte sKyogrePose19
+.4byte sKyogrePose20
+.4byte sKyogrePose21
+.4byte sKyogrePose22
+.4byte sKyogrePose23
+.4byte sKyogrePose24
+.4byte sKyogrePose25
+.4byte sKyogrePose26
+.4byte sKyogrePose27
+.4byte sKyogrePose28
+.4byte sKyogrePose29
+.4byte sKyogrePose30
+.4byte sKyogrePose31
+.4byte sKyogrePose32
+.4byte sKyogrePose33
+.4byte sKyogrePose34
+.4byte sKyogrePose35
+.4byte sKyogrePose36
+.4byte sKyogrePose37
+.4byte sKyogrePose38
+.4byte sKyogrePose39
+.4byte sKyogrePose40
+.4byte sKyogrePose41
+.4byte sKyogrePose42
+.4byte sKyogrePose43
+.4byte sKyogrePose44
+.4byte sKyogrePose45
+.4byte sKyogrePose46
+.4byte sKyogrePose47
+.4byte sKyogrePose48
+.4byte sKyogrePose49
+.4byte sKyogrePose50
+.4byte sKyogrePose51
+.4byte sKyogrePose52
+.4byte sKyogrePose53
+.4byte sKyogrePose54
+.4byte sKyogrePose55
+.4byte sKyogrePose56
+.4byte sKyogrePose57
+.4byte sKyogrePose58
+.4byte sKyogrePose59
+.4byte sKyogrePose60
+.4byte sKyogrePose61
+.4byte sKyogrePose62
+.4byte sKyogrePose63
+.4byte sKyogrePose64
+.4byte sKyogrePose65
+.4byte sKyogrePose66
+.4byte sKyogrePose67
+.4byte sKyogrePose68
+.4byte sKyogrePose69
+.4byte sKyogrePose70
+.4byte sKyogrePose71
+.4byte sKyogrePose72
+.4byte sKyogrePose73
+.4byte sKyogrePose74
+.4byte sKyogrePose75
+.4byte sKyogrePose76
+.4byte sKyogrePose77
+.4byte sKyogrePose78
+.4byte sKyogrePose79
+.4byte sKyogrePose80
+.4byte sKyogrePose81
+.4byte sKyogrePose82
+.4byte sKyogrePose83
+.4byte sKyogrePose84
+.4byte sKyogrePose85
+.4byte sKyogrePose86
+.4byte sKyogrePose87
+.4byte sKyogrePose88
+.4byte sKyogrePose89
+.4byte sKyogrePose90
+.4byte sKyogrePose91
+.4byte sKyogrePose92
+.4byte sKyogrePose93
+.4byte sKyogrePose94
+.4byte sKyogrePose95
+.4byte sKyogrePose96
+.4byte sKyogrePose97
+.4byte sKyogrePose98
+.4byte sKyogrePose99
+.4byte sKyogrePose100
+.4byte sKyogrePose101
+.4byte sKyogrePose102
+.4byte sKyogrePose103
+.4byte sKyogrePose104
+.4byte sKyogrePose105
+.4byte sKyogrePose106
+.4byte sKyogrePose107
+.4byte sKyogrePose108
+.4byte sKyogrePose109
+.4byte sKyogrePose110
+.4byte sKyogrePose111
+.4byte sKyogrePose112
+.4byte sKyogrePose113
+.4byte sKyogrePose114
+.4byte sKyogrePose115
+.4byte sKyogrePose116
+.4byte sKyogrePose117
+.4byte sKyogrePose118
+.4byte sKyogrePose119
+.4byte sKyogrePose120
+.4byte sKyogrePose121
+.4byte sKyogrePose122
+.4byte sKyogrePose123
+.4byte sKyogrePose124
+.4byte sKyogrePose125
+.4byte sKyogrePose126
+.4byte sKyogrePose127
+.4byte sKyogrePose128
+.4byte sKyogrePose129
+.4byte sKyogrePose130
+.4byte sKyogrePose131
+.4byte sKyogrePose132
+.4byte sKyogrePose133
+.4byte sKyogrePose134
+.4byte sKyogrePose135
+.4byte sKyogrePose136
+.4byte sKyogrePose137
+.4byte sKyogrePose138
+.4byte sKyogrePose139
+.4byte sKyogrePose140
+.4byte sKyogrePose141
+.4byte sKyogrePose142
+.4byte sKyogrePose143
+.4byte sKyogrePose144
+.4byte sKyogrePose145
+.4byte sKyogrePose146
+.4byte sKyogrePose147
+.4byte sKyogrePose148
+.4byte sKyogrePose149
+.4byte sKyogrePose150
+.4byte sKyogrePose151
+.4byte sKyogrePose152
+.4byte sKyogrePose153
+.4byte sKyogrePose154
+.4byte sKyogrePose155
+.4byte sKyogrePose156
+.4byte sKyogrePose157
+.4byte sKyogrePose158
+.4byte sKyogrePose159
+.4byte sKyogrePose160
+.4byte sKyogrePose161
+.4byte sKyogrePose162
+.4byte sKyogrePose163
+.4byte sKyogrePose164
+.4byte sKyogrePose165
+.4byte sKyogrePose166
+.4byte sKyogrePose167
+.4byte sKyogrePose168
+.4byte sKyogrePose169
+.4byte sKyogrePose170
+.4byte sKyogrePose171
+.4byte sKyogrePose172
+.4byte sKyogrePose173
+.4byte sKyogrePose174
+.4byte sKyogrePose175
+.4byte sKyogrePose176
+.4byte sKyogrePose177
+.4byte sKyogrePose178
+.4byte sKyogrePose179
+.4byte sKyogrePose180
+.4byte sKyogrePose181
+.4byte sKyogrePose182
+.4byte sKyogrePose183
+.4byte sKyogrePose184
+.4byte sKyogrePose185
+.4byte sKyogrePose186
+.4byte sKyogrePose187
+.4byte sKyogrePose188
+.4byte sKyogrePose189
+.4byte sKyogrePose190
+.4byte sKyogrePose191
+.4byte sKyogrePose192
+.4byte sKyogrePose193
+.4byte sKyogrePose194
+.4byte sKyogrePose195
+.4byte sKyogrePose196
+.4byte sKyogrePose197
+.4byte sKyogrePose198
+.4byte sKyogrePose199
+.4byte sKyogrePose200
+.4byte sKyogrePose201
+.4byte sKyogrePose202
+.4byte sKyogrePose203
+.4byte sKyogrePose204
+.4byte sKyogrePose205
+.4byte sKyogrePose206
+.4byte sKyogrePose207
+.4byte sKyogrePose208
+.4byte sKyogrePose209
+.4byte sKyogrePose210
+.4byte sKyogrePose211
+.4byte sKyogrePose212
+.4byte sKyogrePose213
+.4byte sKyogrePose214
+.4byte sKyogrePose215
+.4byte sKyogrePose216
+.4byte sKyogrePose217
+.4byte sKyogrePose218
+.4byte sKyogrePose219
+.4byte sKyogrePose220
+.4byte sKyogrePose221
+.4byte sKyogrePose222
+.4byte sKyogrePose223
+.4byte sKyogrePose224
+.4byte sKyogrePose225
+.4byte sKyogrePose226
+.4byte sKyogrePose227
+.4byte sKyogrePose228
+.4byte sKyogrePose229
+.4byte sKyogrePose230
+.4byte sKyogrePose231
+.4byte sKyogrePose232
+.4byte sKyogrePose233
+.4byte sKyogrePose234
+.4byte sKyogrePose235
+.4byte sKyogrePose236
+.4byte sKyogrePose237
+.4byte sKyogrePose238
+sAxPositionsKyogre:
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -11
+.2byte   -1,    4, 	 -22,   -3, 	  20,   -3, 	  -1,  -10
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+.2byte   12,   -1, 	  19,  -20, 	 -14,   -2, 	   3,  -12
+.2byte   12,    1, 	  19,  -12, 	 -13,    5, 	   2,  -11
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   18,  -11, 	   2,  -25, 	   2,    0, 	   1,  -13
+.2byte   18,   -9, 	   5,  -20, 	   2,    8, 	   1,  -13
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   11,  -22, 	 -16,  -23, 	  17,   -7, 	   1,  -17
+.2byte   11,  -20, 	 -17,  -16, 	  17,    1, 	   2,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   -1,  -25, 	  21,  -19, 	 -21,  -18, 	  -1,  -15
+.2byte   -1,  -22, 	  19,  -10, 	 -21,   -9, 	  -1,  -13
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte  -12,  -22, 	  15,  -23, 	 -18,   -7, 	  -2,  -17
+.2byte  -12,  -20, 	  16,  -16, 	 -18,    1, 	  -3,  -16
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -19,  -11, 	  -3,  -25, 	  -3,    0, 	  -2,  -13
+.2byte  -19,   -9, 	  -6,  -20, 	  -3,    8, 	  -2,  -13
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -13,   -1, 	 -20,  -20, 	  13,   -2, 	  -4,  -12
+.2byte  -13,    1, 	 -20,  -12, 	  12,    5, 	  -3,  -11
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -11
+.2byte   -1,    4, 	 -22,   -3, 	  20,   -3, 	  -1,  -10
+.2byte   -1,    3, 	 -21,  -11, 	  19,  -12, 	   0,   -9
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+.2byte   12,   -1, 	  19,  -20, 	 -14,   -2, 	   3,  -12
+.2byte   12,    1, 	  19,  -12, 	 -13,    5, 	   2,  -11
+.2byte   12,    1, 	  17,  -19, 	 -19,   -2, 	   1,  -11
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   18,  -11, 	   2,  -25, 	   2,    0, 	   1,  -13
+.2byte   18,   -9, 	   5,  -20, 	   2,    8, 	   1,  -13
+.2byte   18,  -10, 	   0,  -21, 	  -6,    7, 	  -1,  -11
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   11,  -22, 	 -16,  -23, 	  17,   -7, 	   1,  -17
+.2byte   11,  -20, 	 -17,  -16, 	  17,    1, 	   2,  -16
+.2byte   11,  -21, 	 -18,  -14, 	  13,    3, 	  -1,  -13
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   -1,  -25, 	  21,  -19, 	 -21,  -18, 	  -1,  -15
+.2byte   -1,  -22, 	  19,  -10, 	 -21,   -9, 	  -1,  -13
+.2byte   -1,  -24, 	  22,   -4, 	 -24,   -6, 	  -1,  -12
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte  -12,  -22, 	  15,  -23, 	 -18,   -7, 	  -2,  -17
+.2byte  -12,  -20, 	  16,  -16, 	 -18,    1, 	  -3,  -16
+.2byte  -12,  -21, 	  17,  -14, 	 -14,    3, 	   0,  -13
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -19,  -11, 	  -3,  -25, 	  -3,    0, 	  -2,  -13
+.2byte  -19,   -9, 	  -6,  -20, 	  -3,    8, 	  -2,  -13
+.2byte  -19,  -10, 	  -1,  -21, 	   5,    7, 	   0,  -11
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -13,   -1, 	 -20,  -20, 	  13,   -2, 	  -4,  -12
+.2byte  -13,    1, 	 -20,  -12, 	  12,    5, 	  -3,  -11
+.2byte  -13,    1, 	 -18,  -19, 	  18,   -2, 	  -2,  -11
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -11
+.2byte   -1,    4, 	 -22,   -3, 	  20,   -3, 	  -1,  -10
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+.2byte   12,   -1, 	  19,  -20, 	 -14,   -2, 	   3,  -12
+.2byte   12,    1, 	  19,  -12, 	 -13,    5, 	   2,  -11
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   18,  -11, 	   2,  -25, 	   2,    0, 	   1,  -13
+.2byte   18,   -9, 	   5,  -20, 	   2,    8, 	   1,  -13
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   11,  -22, 	 -16,  -23, 	  17,   -7, 	   1,  -17
+.2byte   11,  -20, 	 -17,  -16, 	  17,    1, 	   2,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   -1,  -25, 	  21,  -19, 	 -21,  -18, 	  -1,  -15
+.2byte   -1,  -22, 	  19,  -10, 	 -21,   -9, 	  -1,  -13
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte  -12,  -22, 	  15,  -23, 	 -18,   -7, 	  -2,  -17
+.2byte  -12,  -20, 	  16,  -16, 	 -18,    1, 	  -3,  -16
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -19,  -11, 	  -3,  -25, 	  -3,    0, 	  -2,  -13
+.2byte  -19,   -9, 	  -6,  -20, 	  -3,    8, 	  -2,  -13
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -13,   -1, 	 -20,  -20, 	  13,   -2, 	  -4,  -12
+.2byte  -13,    1, 	 -20,  -12, 	  12,    5, 	  -3,  -11
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -11
+.2byte   -1,    2, 	 -23,   -9, 	  23,   -9, 	  -1,  -10
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+.2byte   12,   -1, 	  19,  -20, 	 -14,   -2, 	   3,  -12
+.2byte   11,    0, 	  22,  -18, 	 -15,   -1, 	   2,  -13
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   18,  -11, 	   2,  -25, 	   2,    0, 	   1,  -13
+.2byte   17,   -8, 	   3,  -22, 	   2,    5, 	   0,  -11
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   11,  -22, 	 -16,  -23, 	  17,   -7, 	   1,  -17
+.2byte   12,  -17, 	 -18,  -20, 	  18,   -2, 	   0,  -15
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   -1,  -25, 	  21,  -19, 	 -21,  -18, 	  -1,  -15
+.2byte   -1,  -26, 	  23,  -13, 	 -23,  -14, 	  -1,  -15
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte  -12,  -22, 	  15,  -23, 	 -18,   -7, 	  -2,  -17
+.2byte  -13,  -17, 	  17,  -20, 	 -19,   -2, 	  -1,  -15
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -19,  -11, 	  -3,  -25, 	  -3,    0, 	  -2,  -13
+.2byte  -18,   -8, 	  -4,  -22, 	  -3,    5, 	  -1,  -11
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -13,   -1, 	 -20,  -20, 	  13,   -2, 	  -4,  -12
+.2byte  -12,    0, 	 -23,  -18, 	  14,   -1, 	  -3,  -13
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte   -1,    3, 	 -28,  -10, 	  25,  -10, 	  -1,  -12
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+.2byte   14,    0, 	  24,  -19, 	 -17,    3, 	   3,  -13
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   21,  -11, 	   4,  -26, 	   4,    7, 	   3,  -13
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   13,  -24, 	 -19,  -23, 	  20,   -1, 	  -1,  -15
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   -1,  -28, 	  27,  -15, 	 -25,  -15, 	  -1,  -15
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte  -14,  -24, 	  18,  -23, 	 -21,   -1, 	   0,  -15
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -22,  -11, 	  -5,  -26, 	  -5,    7, 	  -4,  -13
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -15,    0, 	 -25,  -19, 	  16,    3, 	  -4,  -13
+.2byte  -11,   -1, 	 -21,  -17, 	  17,    1, 	  -2,  -12
+.2byte  -11,   -2, 	 -18,  -21, 	  17,   -2, 	  -3,  -13
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -12
+.2byte    7,    1, 	  16,  -19, 	 -15,   -5, 	   2,  -12
+.2byte   16,   -6, 	   2,  -27, 	   0,   -2, 	   0,  -12
+.2byte   10,  -12, 	 -15,  -24, 	  14,   -6, 	   0,  -13
+.2byte    0,  -17, 	  20,  -14, 	 -19,  -14, 	   0,  -10
+.2byte  -11,  -12, 	  14,  -24, 	 -15,   -6, 	  -1,  -13
+.2byte  -17,   -6, 	  -3,  -27, 	  -1,   -2, 	  -1,  -12
+.2byte   -8,    1, 	 -17,  -19, 	  14,   -5, 	  -3,  -12
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -11
+.2byte   -1,    4, 	 -22,   -3, 	  20,   -3, 	  -1,  -10
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+.2byte   12,   -1, 	  19,  -20, 	 -14,   -2, 	   3,  -12
+.2byte   12,    1, 	  19,  -12, 	 -13,    5, 	   2,  -11
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   18,  -11, 	   2,  -25, 	   2,    0, 	   1,  -13
+.2byte   18,   -9, 	   5,  -20, 	   2,    8, 	   1,  -13
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   11,  -22, 	 -16,  -23, 	  17,   -7, 	   1,  -17
+.2byte   11,  -20, 	 -17,  -16, 	  17,    1, 	   2,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   -1,  -25, 	  21,  -19, 	 -21,  -18, 	  -1,  -15
+.2byte   -1,  -22, 	  19,  -10, 	 -21,   -9, 	  -1,  -13
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte  -12,  -22, 	  15,  -23, 	 -18,   -7, 	  -2,  -17
+.2byte  -12,  -20, 	  16,  -16, 	 -18,    1, 	  -3,  -16
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -19,  -11, 	  -3,  -25, 	  -3,    0, 	  -2,  -13
+.2byte  -19,   -9, 	  -6,  -20, 	  -3,    8, 	  -2,  -13
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -13,   -1, 	 -20,  -20, 	  13,   -2, 	  -4,  -12
+.2byte  -13,    1, 	 -20,  -12, 	  12,    5, 	  -3,  -11
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte  -12,    0, 	 -21,  -16, 	  15,    2, 	  -3,  -11
+.2byte  -18,  -10, 	  -2,  -23, 	  -2,    5, 	  -2,  -12
+.2byte  -11,  -21, 	  17,  -20, 	 -18,   -1, 	   0,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   10,  -21, 	 -18,  -20, 	  17,   -1, 	  -1,  -16
+.2byte   17,  -10, 	   1,  -23, 	   1,    5, 	   1,  -12
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte   17,  -10, 	   1,  -23, 	   1,    5, 	   1,  -12
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte   10,  -21, 	 -18,  -20, 	  17,   -1, 	  -1,  -16
+.2byte   17,  -10, 	   1,  -23, 	   1,    5, 	   1,  -12
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   10,  -21, 	 -18,  -20, 	  17,   -1, 	  -1,  -16
+.2byte   17,  -10, 	   1,  -23, 	   1,    5, 	   1,  -12
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte  -11,  -21, 	  17,  -20, 	 -18,   -1, 	   0,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   10,  -21, 	 -18,  -20, 	  17,   -1, 	  -1,  -16
+.2byte   17,  -10, 	   1,  -23, 	   1,    5, 	   1,  -12
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte  -18,  -10, 	  -2,  -23, 	  -2,    5, 	  -2,  -12
+.2byte  -11,  -21, 	  17,  -20, 	 -18,   -1, 	   0,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   10,  -21, 	 -18,  -20, 	  17,   -1, 	  -1,  -16
+.2byte   17,  -10, 	   1,  -23, 	   1,    5, 	   1,  -12
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte  -12,    0, 	 -21,  -16, 	  15,    2, 	  -3,  -11
+.2byte  -18,  -10, 	  -2,  -23, 	  -2,    5, 	  -2,  -12
+.2byte  -11,  -21, 	  17,  -20, 	 -18,   -1, 	   0,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   10,  -21, 	 -18,  -20, 	  17,   -1, 	  -1,  -16
+.2byte   17,  -10, 	   1,  -23, 	   1,    5, 	   1,  -12
+.2byte   11,    0, 	  20,  -16, 	 -16,    2, 	   2,  -11
+.2byte   -1,    2, 	 -23,   -9, 	  23,   -9, 	  -1,  -10
+.2byte   11,    0, 	  22,  -18, 	 -15,   -1, 	   2,  -13
+.2byte   17,   -8, 	   3,  -22, 	   2,    5, 	   0,  -11
+.2byte   12,  -15, 	 -18,  -18, 	  18,    0, 	   0,  -13
+.2byte   -1,  -23, 	  23,  -10, 	 -23,  -11, 	  -1,  -12
+.2byte  -13,  -15, 	  17,  -18, 	 -19,    0, 	  -1,  -13
+.2byte  -18,   -8, 	  -4,  -22, 	  -3,    5, 	  -1,  -11
+.2byte  -12,    0, 	 -23,  -18, 	  14,   -1, 	  -3,  -13
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -11
+.2byte   -1,    4, 	 -22,   -3, 	  20,   -3, 	  -1,  -10
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+.2byte   12,   -1, 	  19,  -20, 	 -14,   -2, 	   3,  -12
+.2byte   12,    1, 	  19,  -12, 	 -13,    5, 	   2,  -11
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   18,  -11, 	   2,  -25, 	   2,    0, 	   1,  -13
+.2byte   18,   -9, 	   5,  -20, 	   2,    8, 	   1,  -13
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   11,  -22, 	 -16,  -23, 	  17,   -7, 	   1,  -17
+.2byte   11,  -20, 	 -17,  -16, 	  17,    1, 	   2,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   -1,  -25, 	  21,  -19, 	 -21,  -18, 	  -1,  -15
+.2byte   -1,  -22, 	  19,  -10, 	 -21,   -9, 	  -1,  -13
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte  -12,  -22, 	  15,  -23, 	 -18,   -7, 	  -2,  -17
+.2byte  -12,  -20, 	  16,  -16, 	 -18,    1, 	  -3,  -16
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -19,  -11, 	  -3,  -25, 	  -3,    0, 	  -2,  -13
+.2byte  -19,   -9, 	  -6,  -20, 	  -3,    8, 	  -2,  -13
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -13,   -1, 	 -20,  -20, 	  13,   -2, 	  -4,  -12
+.2byte  -13,    1, 	 -20,  -12, 	  12,    5, 	  -3,  -11
+.2byte   -1,    2, 	 -21,  -12, 	  20,  -12, 	  -1,  -11
+.2byte  -13,   -1, 	 -20,  -20, 	  13,   -2, 	  -4,  -12
+.2byte  -19,  -11, 	  -3,  -25, 	  -3,    0, 	  -2,  -13
+.2byte  -12,  -22, 	  15,  -23, 	 -18,   -7, 	  -2,  -17
+.2byte   -1,  -25, 	  21,  -19, 	 -21,  -18, 	  -1,  -15
+.2byte   11,  -22, 	 -16,  -23, 	  17,   -7, 	   1,  -17
+.2byte   18,  -11, 	   2,  -25, 	   2,    0, 	   1,  -13
+.2byte   12,   -1, 	  19,  -20, 	 -14,   -2, 	   3,  -12
+.2byte   -1,    3, 	 -25,   -8, 	  23,   -8, 	  -1,  -11
+.2byte  -13,    0, 	 -22,  -16, 	  14,    2, 	  -4,  -11
+.2byte  -19,  -10, 	  -3,  -23, 	  -3,    5, 	  -3,  -12
+.2byte  -12,  -21, 	  16,  -20, 	 -19,   -1, 	  -1,  -16
+.2byte   -1,  -24, 	  23,  -13, 	 -23,  -13, 	  -1,  -14
+.2byte   11,  -21, 	 -17,  -20, 	  18,   -1, 	   0,  -16
+.2byte   18,  -10, 	   2,  -23, 	   2,    5, 	   2,  -12
+.2byte   12,    0, 	  21,  -16, 	 -15,    2, 	   3,  -11
+sKyogreAnimTable1:
+.4byte sKyogreAnims_1_1
+.4byte sKyogreAnims_1_2
+.4byte sKyogreAnims_1_3
+.4byte sKyogreAnims_1_4
+.4byte sKyogreAnims_1_5
+.4byte sKyogreAnims_1_6
+.4byte sKyogreAnims_1_7
+.4byte sKyogreAnims_1_8
+sKyogreAnimTable2:
+.4byte sKyogreAnims_2_1
+.4byte sKyogreAnims_2_2
+.4byte sKyogreAnims_2_3
+.4byte sKyogreAnims_2_4
+.4byte sKyogreAnims_2_5
+.4byte sKyogreAnims_2_6
+.4byte sKyogreAnims_2_7
+.4byte sKyogreAnims_2_8
+sKyogreAnimTable3:
+.4byte sKyogreAnims_3_1
+.4byte sKyogreAnims_3_2
+.4byte sKyogreAnims_3_3
+.4byte sKyogreAnims_3_4
+.4byte sKyogreAnims_3_5
+.4byte sKyogreAnims_3_6
+.4byte sKyogreAnims_3_7
+.4byte sKyogreAnims_3_8
+sKyogreAnimTable4:
+.4byte sKyogreAnims_4_1
+.4byte sKyogreAnims_4_2
+.4byte sKyogreAnims_4_3
+.4byte sKyogreAnims_4_4
+.4byte sKyogreAnims_4_5
+.4byte sKyogreAnims_4_6
+.4byte sKyogreAnims_4_7
+.4byte sKyogreAnims_4_8
+sKyogreAnimTable5:
+.4byte sKyogreAnims_5_1
+.4byte sKyogreAnims_5_2
+.4byte sKyogreAnims_5_3
+.4byte sKyogreAnims_5_4
+.4byte sKyogreAnims_5_5
+.4byte sKyogreAnims_5_6
+.4byte sKyogreAnims_5_7
+.4byte sKyogreAnims_5_8
+sKyogreAnimTable6:
+.4byte sKyogreAnims_6_1
+.4byte sKyogreAnims_6_1
+.4byte sKyogreAnims_6_1
+.4byte sKyogreAnims_6_1
+.4byte sKyogreAnims_6_1
+.4byte sKyogreAnims_6_1
+.4byte sKyogreAnims_6_1
+.4byte sKyogreAnims_6_1
+sKyogreAnimTable7:
+.4byte sKyogreAnims_7_1
+.4byte sKyogreAnims_7_2
+.4byte sKyogreAnims_7_3
+.4byte sKyogreAnims_7_4
+.4byte sKyogreAnims_7_5
+.4byte sKyogreAnims_7_6
+.4byte sKyogreAnims_7_7
+.4byte sKyogreAnims_7_8
+sKyogreAnimTable8:
+.4byte sKyogreAnims_8_1
+.4byte sKyogreAnims_8_2
+.4byte sKyogreAnims_8_3
+.4byte sKyogreAnims_8_4
+.4byte sKyogreAnims_8_5
+.4byte sKyogreAnims_8_6
+.4byte sKyogreAnims_8_7
+.4byte sKyogreAnims_8_8
+sKyogreAnimTable9:
+.4byte sKyogreAnims_9_1
+.4byte sKyogreAnims_9_2
+.4byte sKyogreAnims_9_3
+.4byte sKyogreAnims_9_4
+.4byte sKyogreAnims_9_5
+.4byte sKyogreAnims_9_6
+.4byte sKyogreAnims_9_7
+.4byte sKyogreAnims_9_8
+sKyogreAnimTable10:
+.4byte sKyogreAnims_10_1
+.4byte sKyogreAnims_10_2
+.4byte sKyogreAnims_10_3
+.4byte sKyogreAnims_10_4
+.4byte sKyogreAnims_10_5
+.4byte sKyogreAnims_10_6
+.4byte sKyogreAnims_10_7
+.4byte sKyogreAnims_10_8
+sKyogreAnimTable11:
+.4byte sKyogreAnims_11_1
+.4byte sKyogreAnims_11_2
+.4byte sKyogreAnims_11_3
+.4byte sKyogreAnims_11_4
+.4byte sKyogreAnims_11_5
+.4byte sKyogreAnims_11_6
+.4byte sKyogreAnims_11_7
+.4byte sKyogreAnims_11_8
+sKyogreAnimTable12:
+.4byte sKyogreAnims_12_1
+.4byte sKyogreAnims_12_2
+.4byte sKyogreAnims_12_3
+.4byte sKyogreAnims_12_4
+.4byte sKyogreAnims_12_5
+.4byte sKyogreAnims_12_6
+.4byte sKyogreAnims_12_7
+.4byte sKyogreAnims_12_8
+sKyogreAnimTable13:
+.4byte sKyogreAnims_13_1
+.4byte sKyogreAnims_13_2
+.4byte sKyogreAnims_13_3
+.4byte sKyogreAnims_13_4
+.4byte sKyogreAnims_13_5
+.4byte sKyogreAnims_13_6
+.4byte sKyogreAnims_13_7
+.4byte sKyogreAnims_13_8
+sAxAnimationsKyogre:
+.4byte sKyogreAnimTable1
+.4byte sKyogreAnimTable2
+.4byte sKyogreAnimTable3
+.4byte sKyogreAnimTable4
+.4byte sKyogreAnimTable5
+.4byte sKyogreAnimTable6
+.4byte sKyogreAnimTable7
+.4byte sKyogreAnimTable8
+.4byte sKyogreAnimTable9
+.4byte sKyogreAnimTable10
+.4byte sKyogreAnimTable11
+.4byte sKyogreAnimTable12
+.4byte sKyogreAnimTable13
+sAxSpritesKyogre:
+.4byte sKyogreSprites1
+.4byte sKyogreSprites2
+.4byte sKyogreSprites3
+.4byte sKyogreSprites4
+.4byte sKyogreSprites5
+.4byte sKyogreSprites6
+.4byte sKyogreSprites7
+.4byte sKyogreSprites8
+.4byte sKyogreSprites9
+.4byte sKyogreSprites10
+.4byte sKyogreSprites11
+.4byte sKyogreSprites12
+.4byte sKyogreSprites13
+.4byte sKyogreSprites14
+.4byte sKyogreSprites15
+.4byte sKyogreSprites16
+.4byte sKyogreSprites17
+.4byte sKyogreSprites18
+.4byte sKyogreSprites19
+.4byte sKyogreSprites20
+.4byte sKyogreSprites21
+.4byte sKyogreSprites22
+.4byte sKyogreSprites23
+.4byte sKyogreSprites24
+.4byte sKyogreSprites25
+.4byte sKyogreSprites26
+.4byte sKyogreSprites27
+.4byte sKyogreSprites28
+.4byte sKyogreSprites29
+.4byte sKyogreSprites30
+.4byte sKyogreSprites31
+.4byte sKyogreSprites32
+.4byte sKyogreSprites33
+.4byte sKyogreSprites34
+.4byte sKyogreSprites35
+.4byte sKyogreSprites36
+.4byte sKyogreSprites37
+.4byte sKyogreSprites38
+.4byte sKyogreSprites39
+.4byte sKyogreSprites40
+.4byte sKyogreSprites41
+.4byte sKyogreSprites42
+.4byte sKyogreSprites43
+.4byte sKyogreSprites44
+.4byte sKyogreSprites45
+.4byte sKyogreSprites46
+.4byte sKyogreSprites47
+.4byte sKyogreSprites48
+.4byte sKyogreSprites49
+.4byte sKyogreSprites50
+.4byte sKyogreSprites51
+.4byte sKyogreSprites52
+.4byte sKyogreSprites53
+.4byte sKyogreSprites54
+.4byte sKyogreSprites55
+.4byte sKyogreSprites56
+.4byte sKyogreSprites57
+.4byte sKyogreSprites58
+.4byte sKyogreSprites59
+.4byte sKyogreSprites60
+.4byte sKyogreSprites61
+.4byte sKyogreSprites62
+.4byte sKyogreSprites63
+.4byte sKyogreSprites64
+.4byte sKyogreSprites65
+.4byte sKyogreSprites66
+.4byte sKyogreSprites67
+.4byte sKyogreSprites68
+.4byte sKyogreSprites69
+.4byte sKyogreSprites70
+.4byte sKyogreSprites71
+.4byte sKyogreSprites72
+.4byte sKyogreSprites73
+.4byte sKyogreSprites74
+.4byte sKyogreSprites75
+.4byte sKyogreSprites76
+.4byte sKyogreSprites77
+.4byte sKyogreSprites78
+.4byte sKyogreSprites79
+.4byte sKyogreSprites80
+.4byte sKyogreSprites81
+.4byte sKyogreSprites82
+.4byte sKyogreSprites83
+.4byte sKyogreSprites84
+.4byte sKyogreSprites85
+.4byte sKyogreSprites86
+.4byte sKyogreSprites87
+sAxMainKyogre:
+ax_main sAxPosesKyogre, sAxAnimationsKyogre, 13, sAxSpritesKyogre, sAxPositionsKyogre

--- a/data/ax/lairon.inc
+++ b/data/ax/lairon.inc
@@ -1,0 +1,2622 @@
+.global gAxLairon
+gAxLairon:
+ax_siro sAxMainLairon
+sLaironPose1:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose2:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose4:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose5:
+ax_pose 4, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose6:
+ax_pose 5, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose7:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose8:
+ax_pose 7, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose9:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose10:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose11:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose12:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose16:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose17:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose18:
+ax_pose 11, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose22:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose23:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose24:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose25:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose26:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose27:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose28:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose29:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose30:
+ax_pose 4, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose31:
+ax_pose 5, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose32:
+ax_pose 16, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose33:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose34:
+ax_pose 7, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose35:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose36:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose37:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose38:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose39:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose40:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose41:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose42:
+ax_pose 13, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose43:
+ax_pose 14, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose44:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose45:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose46:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose47:
+ax_pose 11, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose48:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose49:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose50:
+ax_pose 7, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose51:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose52:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose53:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose54:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose55:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose56:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose57:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose58:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose59:
+ax_pose 2, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose60:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose61:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose62:
+ax_pose 4, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose63:
+ax_pose 5, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose64:
+ax_pose 16, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose65:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose66:
+ax_pose 7, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose67:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose68:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose69:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose70:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose71:
+ax_pose 11, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose72:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose73:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose74:
+ax_pose 13, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose75:
+ax_pose 14, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose76:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose77:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose78:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose79:
+ax_pose 11, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose80:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose81:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose82:
+ax_pose 7, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose83:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose84:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose85:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose86:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose87:
+ax_pose 5, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose88:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose89:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose90:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose91:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose92:
+ax_pose 16, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose93:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose94:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose95:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose96:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose97:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose98:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose99:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose100:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose101:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose102:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose103:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose104:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose105:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose106:
+ax_pose 20, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose107:
+ax_pose 21, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose108:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose109:
+ax_pose 22, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose110:
+ax_pose 23, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose111:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose112:
+ax_pose 24, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose113:
+ax_pose 25, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose114:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose115:
+ax_pose 26, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose116:
+ax_pose 27, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose117:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose118:
+ax_pose 28, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose119:
+ax_pose 29, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose120:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose121:
+ax_pose 26, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose122:
+ax_pose 27, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose123:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose124:
+ax_pose 24, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose125:
+ax_pose 25, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose126:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose127:
+ax_pose 22, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose128:
+ax_pose 23, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose129:
+ax_pose 30, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose130:
+ax_pose 31, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose131:
+ax_pose 32, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose132:
+ax_pose 33, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sLaironPose133:
+ax_pose 34, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sLaironPose134:
+ax_pose 35, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sLaironPose135:
+ax_pose 36, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose136:
+ax_pose 35, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sLaironPose137:
+ax_pose 34, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sLaironPose138:
+ax_pose 33, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sLaironPose139:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose140:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose141:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose142:
+ax_pose 16, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose143:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose144:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose145:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose146:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose147:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose148:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose149:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose150:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose151:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose152:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose153:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose154:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose155:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose156:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose157:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose158:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose159:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose160:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose161:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose162:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose163:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose164:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose165:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose166:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose167:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose168:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose169:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose170:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose171:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose172:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose173:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose174:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose175:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose176:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose177:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose178:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose179:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose180:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose181:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose182:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose183:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose184:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose185:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose186:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose187:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose188:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose189:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose190:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose191:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose192:
+ax_pose 16, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose193:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose194:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose195:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose196:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose197:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose198:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose199:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose200:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose201:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose202:
+ax_pose 16, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose203:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose204:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose205:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose206:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose207:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose208:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose209:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose210:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose211:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose212:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose213:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose214:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose215:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose216:
+ax_pose 16, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose217:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose218:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose219:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose220:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose221:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose222:
+ax_pose 16, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose223:
+ax_pose 0, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose224:
+ax_pose 3, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose225:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose226:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose227:
+ax_pose 12, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sLaironPose228:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose229:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sLaironPose230:
+ax_pose 3, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sLaironAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLaironAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 20, 19, 20, 19,
+ax_anim 2, 1, 31, 21, 18, 21, 18,
+ax_anim 2, 0, 31, 20, 19, 20, 19,
+ax_anim 2, 0, 31, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sLaironAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 1, 35, 17, 1, 17, 1,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 35, 17, 1, 17, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sLaironAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -6, 6, -6,
+ax_anim 1, 0, 38, 12, -11, 12, -11,
+ax_anim 2, 0, 39, 19, -17, 19, -17,
+ax_anim 2, 1, 39, 20, -16, 20, -16,
+ax_anim 2, 0, 39, 19, -17, 19, -17,
+ax_anim 2, 0, 39, 20, -16, 20, -16,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sLaironAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sLaironAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -6, -6, -6,
+ax_anim 1, 0, 46, -12, -11, -12, -11,
+ax_anim 2, 0, 47, -19, -17, -19, -17,
+ax_anim 2, 1, 47, -20, -16, -20, -16,
+ax_anim 2, 0, 47, -19, -17, -19, -17,
+ax_anim 2, 0, 47, -20, -16, -20, -16,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sLaironAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 1, 51, -17, 1, -17, 1,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 51, -17, 1, -17, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sLaironAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -20, 19, -20, 19,
+ax_anim 2, 1, 55, -21, 18, -21, 18,
+ax_anim 2, 0, 55, -20, 19, -20, 19,
+ax_anim 2, 0, 55, -21, 18, -21, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLaironAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sLaironAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 20, 19, 20, 19,
+ax_anim 2, 1, 63, 21, 18, 21, 18,
+ax_anim 2, 0, 63, 20, 19, 20, 19,
+ax_anim 2, 0, 63, 21, 18, 21, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sLaironAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 1, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sLaironAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 6, -6, 6, -6,
+ax_anim 1, 0, 70, 12, -11, 12, -11,
+ax_anim 2, 0, 71, 19, -17, 19, -17,
+ax_anim 2, 1, 71, 20, -16, 20, -16,
+ax_anim 2, 0, 71, 19, -17, 19, -17,
+ax_anim 2, 0, 71, 20, -16, 20, -16,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sLaironAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -9, 0, -9,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sLaironAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -6, -6, -6, -6,
+ax_anim 1, 0, 78, -12, -11, -12, -11,
+ax_anim 2, 0, 79, -19, -17, -19, -17,
+ax_anim 2, 1, 79, -20, -16, -20, -16,
+ax_anim 2, 0, 79, -19, -17, -19, -17,
+ax_anim 2, 0, 79, -20, -16, -20, -16,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sLaironAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 1, 83, -17, 1, -17, 1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, 1, -17, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sLaironAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -20, 19, -20, 19,
+ax_anim 2, 1, 87, -21, 18, -21, 18,
+ax_anim 2, 0, 87, -20, 19, -20, 19,
+ax_anim 2, 0, 87, -21, 18, -21, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLaironAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 6, 2, 88, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 1, 89, 0, 3, 0, 2,
+ax_anim 2, 0, 89, 1, 3, 1, 2,
+ax_anim 2, 0, 89, 0, 3, 0, 2,
+ax_anim 2, 0, 89, 1, 3, 1, 2,
+ax_anim 2, 0, 89, 0, 3, 0, 2,
+ax_anim 2, 0, 89, 1, 3, 1, 2,
+ax_anim 2, 0, 89, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sLaironAnims_4_2:
+ax_anim 2, 0, 90, -2, -2, -2, -2,
+ax_anim 6, 2, 90, -3, -3, -3, -3,
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 1, 91, 2, 2, 1, 1,
+ax_anim 2, 0, 91, 3, 1, 2, 0,
+ax_anim 2, 0, 91, 2, 2, 1, 1,
+ax_anim 2, 0, 91, 3, 1, 2, 0,
+ax_anim 2, 0, 91, 2, 2, 1, 1,
+ax_anim 2, 0, 91, 3, 1, 2, 0,
+ax_anim 2, 0, 91, 2, 2, 1, 1,
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim_terminator
+sLaironAnims_4_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 6, 2, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 2, 1, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim_terminator
+sLaironAnims_4_4:
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 6, 2, 94, -3, 3, -3, 3,
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 1, 95, 2, -2, 1, -1,
+ax_anim 2, 0, 95, 3, -1, 2, 0,
+ax_anim 2, 0, 95, 2, -2, 1, -1,
+ax_anim 2, 0, 95, 3, -1, 2, 0,
+ax_anim 2, 0, 95, 2, -2, 1, -1,
+ax_anim 2, 0, 95, 3, -1, 2, 0,
+ax_anim 2, 0, 95, 2, -2, 1, -1,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim_terminator
+sLaironAnims_4_5:
+ax_anim 2, 0, 96, 0, 2, 0, 2,
+ax_anim 6, 2, 96, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 2, 1, 97, 0, -3, 0, -2,
+ax_anim 2, 0, 97, 1, -3, 1, -2,
+ax_anim 2, 0, 97, 0, -3, 0, -2,
+ax_anim 2, 0, 97, 1, -3, 1, -2,
+ax_anim 2, 0, 97, 0, -3, 0, -2,
+ax_anim 2, 0, 97, 1, -3, 1, -2,
+ax_anim 2, 0, 97, 0, -3, 0, -2,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim_terminator
+sLaironAnims_4_6:
+ax_anim 2, 0, 98, 2, 2, 2, 2,
+ax_anim 6, 2, 98, 3, 3, 3, 3,
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 2, 1, 99, -2, -2, -1, -1,
+ax_anim 2, 0, 99, -3, -1, -2, 0,
+ax_anim 2, 0, 99, -2, -2, -1, -1,
+ax_anim 2, 0, 99, -3, -1, -2, 0,
+ax_anim 2, 0, 99, -2, -2, -1, -1,
+ax_anim 2, 0, 99, -3, -1, -2, 0,
+ax_anim 2, 0, 99, -2, -2, -1, -1,
+ax_anim 2, 0, 98, -1, -1, -1, -1,
+ax_anim_terminator
+sLaironAnims_4_7:
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 6, 2, 100, 3, 0, 3, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 1, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim_terminator
+sLaironAnims_4_8:
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 6, 2, 102, 3, -3, 3, -3,
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLaironAnims_5_1:
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 1, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_5_2:
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 1, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_5_3:
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 1, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_5_4:
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 1, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_5_5:
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 1, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_5_6:
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 1, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_5_7:
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 1, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_5_8:
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 1, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sLaironAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sLaironAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sLaironAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sLaironAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sLaironAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sLaironAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sLaironAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLaironAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_8_2:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_8_3:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 16, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 16, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_8_4:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_8_5:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_8_6:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 16, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim 16, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_8_7:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_8_8:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 7, 4, 7, 4,
+ax_anim 2, 0, 156, 12, 11, 12, 11,
+ax_anim 2, 0, 157, 8, 19, 8, 19,
+ax_anim 3, 0, 158, 0, 20, 0, 20,
+ax_anim 2, 3, 159, -8, 19, -8, 19,
+ax_anim 2, 0, 160, -12, 11, -12, 11,
+ax_anim 1, 0, 161, -7, 4, -7, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 9, 1, 9, 1,
+ax_anim 2, 0, 155, 16, 6, 16, 6,
+ax_anim 2, 0, 156, 21, 14, 21, 14,
+ax_anim 3, 0, 157, 19, 21, 19, 21,
+ax_anim 2, 3, 158, 11, 20, 11, 20,
+ax_anim 2, 0, 159, 3, 16, 3, 16,
+ax_anim 1, 0, 160, 0, 8, 0, 8,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 9, -6, 9, -6,
+ax_anim 2, 0, 155, 15, -4, 15, -4,
+ax_anim 3, 0, 156, 18, 0, 18, 0,
+ax_anim 2, 3, 157, 16, 5, 16, 5,
+ax_anim 2, 0, 158, 10, 7, 10, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -9, -1, -9,
+ax_anim 2, 0, 161, 5, -18, 5, -18,
+ax_anim 2, 0, 154, 11, -23, 11, -23,
+ax_anim 3, 0, 155, 18, -22, 18, -22,
+ax_anim 2, 3, 156, 22, -15, 22, -15,
+ax_anim 2, 0, 157, 20, -6, 20, -6,
+ax_anim 1, 0, 158, 9, -2, 9, -2,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -10, -3, -10, -3,
+ax_anim 2, 0, 160, -13, -10, -13, -10,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 13, -10, 13, -10,
+ax_anim 1, 0, 157, 10, -3, 10, -3,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -9, 1, -9,
+ax_anim 2, 0, 155, -5, -18, -5, -18,
+ax_anim 2, 0, 154, -11, -23, -11, -23,
+ax_anim 3, 0, 161, -18, -22, -18, -22,
+ax_anim 2, 3, 160, -22, -15, -22, -15,
+ax_anim 2, 0, 159, -20, -6, -20, -6,
+ax_anim 1, 0, 158, -9, -2, -9, -2,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -9, -6, -9, -6,
+ax_anim 2, 0, 161, -15, -4, -15, -4,
+ax_anim 3, 0, 160, -18, 0, -18, 0,
+ax_anim 2, 3, 159, -16, 5, -16, 5,
+ax_anim 2, 0, 158, -10, 7, -10, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -9, 1, -9, 1,
+ax_anim 2, 0, 161, -16, 6, -16, 6,
+ax_anim 2, 0, 160, -21, 14, -21, 14,
+ax_anim 3, 0, 159, -19, 21, -19, 21,
+ax_anim 2, 3, 158, -11, 20, -11, 20,
+ax_anim 2, 0, 157, -3, 16, -3, 16,
+ax_anim 1, 0, 156, 0, 8, 0, 8,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_10_1:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_10_2:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_10_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_10_4:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_10_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_10_6:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_10_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_10_8:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_11_1:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_11_2:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_11_3:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_11_4:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -22, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 1, 0, 204, 0, -11, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -24, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_11_6:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -17, 0, 0,
+ax_anim 1, 0, 208, 0, -11, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_11_7:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_11_8:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_12_1:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_12_2:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_12_3:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_12_4:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_12_5:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_12_6:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_12_7:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_12_8:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaironAnims_13_1:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_13_2:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_13_3:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_13_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_13_5:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_13_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_13_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironAnims_13_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLaironGfx1:
+.incbin "baserom.gba", 0x1269158, 0x200
+sLaironSprites1:
+ax_sprite sLaironGfx1, 0x200
+ax_sprite_terminator
+sLaironGfx2:
+.incbin "baserom.gba", 0x1269368, 0x200
+sLaironSprites2:
+ax_sprite sLaironGfx2, 0x200
+ax_sprite_terminator
+sLaironGfx3:
+.incbin "baserom.gba", 0x1269578, 0x200
+sLaironSprites3:
+ax_sprite sLaironGfx3, 0x200
+ax_sprite_terminator
+sLaironGfx4:
+.incbin "baserom.gba", 0x1269788, 0x200
+sLaironSprites4:
+ax_sprite sLaironGfx4, 0x200
+ax_sprite_terminator
+sLaironGfx5:
+.incbin "baserom.gba", 0x1269998, 0x200
+sLaironSprites5:
+ax_sprite sLaironGfx5, 0x200
+ax_sprite_terminator
+sLaironGfx6:
+.incbin "baserom.gba", 0x1269BA8, 0x200
+sLaironSprites6:
+ax_sprite sLaironGfx6, 0x200
+ax_sprite_terminator
+sLaironGfx7:
+.incbin "baserom.gba", 0x1269DB8, 0x200
+sLaironSprites7:
+ax_sprite sLaironGfx7, 0x200
+ax_sprite_terminator
+sLaironGfx8:
+.incbin "baserom.gba", 0x1269FC8, 0x200
+sLaironSprites8:
+ax_sprite sLaironGfx8, 0x200
+ax_sprite_terminator
+sLaironGfx9:
+.incbin "baserom.gba", 0x126A1D8, 0x200
+sLaironSprites9:
+ax_sprite sLaironGfx9, 0x200
+ax_sprite_terminator
+sLaironGfx10:
+.incbin "baserom.gba", 0x126A3E8, 0x200
+sLaironSprites10:
+ax_sprite sLaironGfx10, 0x200
+ax_sprite_terminator
+sLaironGfx11:
+.incbin "baserom.gba", 0x126A5F8, 0x200
+sLaironSprites11:
+ax_sprite sLaironGfx11, 0x200
+ax_sprite_terminator
+sLaironGfx12:
+.incbin "baserom.gba", 0x126A808, 0x200
+sLaironSprites12:
+ax_sprite sLaironGfx12, 0x200
+ax_sprite_terminator
+sLaironGfx13:
+.incbin "baserom.gba", 0x126AA18, 0x200
+sLaironSprites13:
+ax_sprite sLaironGfx13, 0x200
+ax_sprite_terminator
+sLaironGfx14:
+.incbin "baserom.gba", 0x126AC28, 0x200
+sLaironSprites14:
+ax_sprite sLaironGfx14, 0x200
+ax_sprite_terminator
+sLaironGfx15:
+.incbin "baserom.gba", 0x126AE38, 0x200
+sLaironSprites15:
+ax_sprite sLaironGfx15, 0x200
+ax_sprite_terminator
+sLaironGfx16:
+.incbin "baserom.gba", 0x126B048, 0x40
+sLaironGfx16_1:
+.incbin "baserom.gba", 0x126B088, 0x100
+sLaironSprites16:
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx16_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx17:
+.incbin "baserom.gba", 0x126B1B8, 0x180
+sLaironSprites17:
+ax_sprite sLaironGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx18:
+.incbin "baserom.gba", 0x126B350, 0x180
+sLaironSprites18:
+ax_sprite sLaironGfx18, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx19:
+.incbin "baserom.gba", 0x126B4E8, 0x60
+sLaironGfx19_1:
+.incbin "baserom.gba", 0x126B548, 0x100
+sLaironSprites19:
+ax_sprite sLaironGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx19_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx20:
+.incbin "baserom.gba", 0x126B670, 0x40
+sLaironGfx20_1:
+.incbin "baserom.gba", 0x126B6B0, 0x100
+sLaironGfx20_2:
+.incbin "baserom.gba", 0x126B7B0, 0x20
+sLaironSprites20:
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx20_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sLaironGfx20_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLaironGfx21:
+.incbin "baserom.gba", 0x126B810, 0x40
+sLaironGfx21_1:
+.incbin "baserom.gba", 0x126B850, 0x100
+sLaironSprites21:
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx22:
+.incbin "baserom.gba", 0x126B980, 0x40
+sLaironGfx22_1:
+.incbin "baserom.gba", 0x126B9C0, 0x100
+sLaironSprites22:
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx22_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx23:
+.incbin "baserom.gba", 0x126BAF0, 0x60
+sLaironGfx23_1:
+.incbin "baserom.gba", 0x126BB50, 0x100
+sLaironSprites23:
+ax_sprite sLaironGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx23_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx24:
+.incbin "baserom.gba", 0x126BC78, 0x160
+sLaironSprites24:
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx24, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx25:
+.incbin "baserom.gba", 0x126BDF8, 0x180
+sLaironSprites25:
+ax_sprite sLaironGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx26:
+.incbin "baserom.gba", 0x126BF90, 0x60
+sLaironGfx26_1:
+.incbin "baserom.gba", 0x126BFF0, 0x100
+sLaironSprites26:
+ax_sprite sLaironGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx26_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx27:
+.incbin "baserom.gba", 0x126C118, 0x160
+sLaironSprites27:
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx27, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx28:
+.incbin "baserom.gba", 0x126C298, 0x60
+sLaironGfx28_1:
+.incbin "baserom.gba", 0x126C2F8, 0x100
+sLaironSprites28:
+ax_sprite sLaironGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx28_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx29:
+.incbin "baserom.gba", 0x126C420, 0x160
+sLaironSprites29:
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx29, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx30:
+.incbin "baserom.gba", 0x126C5A0, 0x60
+sLaironGfx30_1:
+.incbin "baserom.gba", 0x126C600, 0x100
+sLaironSprites30:
+ax_sprite sLaironGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaironGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLaironGfx31:
+.incbin "baserom.gba", 0x126C728, 0x200
+sLaironSprites31:
+ax_sprite sLaironGfx31, 0x200
+ax_sprite_terminator
+sLaironGfx32:
+.incbin "baserom.gba", 0x126C938, 0x200
+sLaironSprites32:
+ax_sprite sLaironGfx32, 0x200
+ax_sprite_terminator
+sLaironGfx33:
+.incbin "baserom.gba", 0x126CB48, 0x200
+sLaironSprites33:
+ax_sprite sLaironGfx33, 0x200
+ax_sprite_terminator
+sLaironGfx34:
+.incbin "baserom.gba", 0x126CD58, 0x200
+sLaironSprites34:
+ax_sprite sLaironGfx34, 0x200
+ax_sprite_terminator
+sLaironGfx35:
+.incbin "baserom.gba", 0x126CF68, 0x200
+sLaironSprites35:
+ax_sprite sLaironGfx35, 0x200
+ax_sprite_terminator
+sLaironGfx36:
+.incbin "baserom.gba", 0x126D178, 0x200
+sLaironSprites36:
+ax_sprite sLaironGfx36, 0x200
+ax_sprite_terminator
+sLaironGfx37:
+.incbin "baserom.gba", 0x126D388, 0x200
+sLaironSprites37:
+ax_sprite sLaironGfx37, 0x200
+ax_sprite_terminator
+sAxPosesLairon:
+.4byte sLaironPose1
+.4byte sLaironPose2
+.4byte sLaironPose3
+.4byte sLaironPose4
+.4byte sLaironPose5
+.4byte sLaironPose6
+.4byte sLaironPose7
+.4byte sLaironPose8
+.4byte sLaironPose9
+.4byte sLaironPose10
+.4byte sLaironPose11
+.4byte sLaironPose12
+.4byte sLaironPose13
+.4byte sLaironPose14
+.4byte sLaironPose15
+.4byte sLaironPose16
+.4byte sLaironPose17
+.4byte sLaironPose18
+.4byte sLaironPose19
+.4byte sLaironPose20
+.4byte sLaironPose21
+.4byte sLaironPose22
+.4byte sLaironPose23
+.4byte sLaironPose24
+.4byte sLaironPose25
+.4byte sLaironPose26
+.4byte sLaironPose27
+.4byte sLaironPose28
+.4byte sLaironPose29
+.4byte sLaironPose30
+.4byte sLaironPose31
+.4byte sLaironPose32
+.4byte sLaironPose33
+.4byte sLaironPose34
+.4byte sLaironPose35
+.4byte sLaironPose36
+.4byte sLaironPose37
+.4byte sLaironPose38
+.4byte sLaironPose39
+.4byte sLaironPose40
+.4byte sLaironPose41
+.4byte sLaironPose42
+.4byte sLaironPose43
+.4byte sLaironPose44
+.4byte sLaironPose45
+.4byte sLaironPose46
+.4byte sLaironPose47
+.4byte sLaironPose48
+.4byte sLaironPose49
+.4byte sLaironPose50
+.4byte sLaironPose51
+.4byte sLaironPose52
+.4byte sLaironPose53
+.4byte sLaironPose54
+.4byte sLaironPose55
+.4byte sLaironPose56
+.4byte sLaironPose57
+.4byte sLaironPose58
+.4byte sLaironPose59
+.4byte sLaironPose60
+.4byte sLaironPose61
+.4byte sLaironPose62
+.4byte sLaironPose63
+.4byte sLaironPose64
+.4byte sLaironPose65
+.4byte sLaironPose66
+.4byte sLaironPose67
+.4byte sLaironPose68
+.4byte sLaironPose69
+.4byte sLaironPose70
+.4byte sLaironPose71
+.4byte sLaironPose72
+.4byte sLaironPose73
+.4byte sLaironPose74
+.4byte sLaironPose75
+.4byte sLaironPose76
+.4byte sLaironPose77
+.4byte sLaironPose78
+.4byte sLaironPose79
+.4byte sLaironPose80
+.4byte sLaironPose81
+.4byte sLaironPose82
+.4byte sLaironPose83
+.4byte sLaironPose84
+.4byte sLaironPose85
+.4byte sLaironPose86
+.4byte sLaironPose87
+.4byte sLaironPose88
+.4byte sLaironPose89
+.4byte sLaironPose90
+.4byte sLaironPose91
+.4byte sLaironPose92
+.4byte sLaironPose93
+.4byte sLaironPose94
+.4byte sLaironPose95
+.4byte sLaironPose96
+.4byte sLaironPose97
+.4byte sLaironPose98
+.4byte sLaironPose99
+.4byte sLaironPose100
+.4byte sLaironPose101
+.4byte sLaironPose102
+.4byte sLaironPose103
+.4byte sLaironPose104
+.4byte sLaironPose105
+.4byte sLaironPose106
+.4byte sLaironPose107
+.4byte sLaironPose108
+.4byte sLaironPose109
+.4byte sLaironPose110
+.4byte sLaironPose111
+.4byte sLaironPose112
+.4byte sLaironPose113
+.4byte sLaironPose114
+.4byte sLaironPose115
+.4byte sLaironPose116
+.4byte sLaironPose117
+.4byte sLaironPose118
+.4byte sLaironPose119
+.4byte sLaironPose120
+.4byte sLaironPose121
+.4byte sLaironPose122
+.4byte sLaironPose123
+.4byte sLaironPose124
+.4byte sLaironPose125
+.4byte sLaironPose126
+.4byte sLaironPose127
+.4byte sLaironPose128
+.4byte sLaironPose129
+.4byte sLaironPose130
+.4byte sLaironPose131
+.4byte sLaironPose132
+.4byte sLaironPose133
+.4byte sLaironPose134
+.4byte sLaironPose135
+.4byte sLaironPose136
+.4byte sLaironPose137
+.4byte sLaironPose138
+.4byte sLaironPose139
+.4byte sLaironPose140
+.4byte sLaironPose141
+.4byte sLaironPose142
+.4byte sLaironPose143
+.4byte sLaironPose144
+.4byte sLaironPose145
+.4byte sLaironPose146
+.4byte sLaironPose147
+.4byte sLaironPose148
+.4byte sLaironPose149
+.4byte sLaironPose150
+.4byte sLaironPose151
+.4byte sLaironPose152
+.4byte sLaironPose153
+.4byte sLaironPose154
+.4byte sLaironPose155
+.4byte sLaironPose156
+.4byte sLaironPose157
+.4byte sLaironPose158
+.4byte sLaironPose159
+.4byte sLaironPose160
+.4byte sLaironPose161
+.4byte sLaironPose162
+.4byte sLaironPose163
+.4byte sLaironPose164
+.4byte sLaironPose165
+.4byte sLaironPose166
+.4byte sLaironPose167
+.4byte sLaironPose168
+.4byte sLaironPose169
+.4byte sLaironPose170
+.4byte sLaironPose171
+.4byte sLaironPose172
+.4byte sLaironPose173
+.4byte sLaironPose174
+.4byte sLaironPose175
+.4byte sLaironPose176
+.4byte sLaironPose177
+.4byte sLaironPose178
+.4byte sLaironPose179
+.4byte sLaironPose180
+.4byte sLaironPose181
+.4byte sLaironPose182
+.4byte sLaironPose183
+.4byte sLaironPose184
+.4byte sLaironPose185
+.4byte sLaironPose186
+.4byte sLaironPose187
+.4byte sLaironPose188
+.4byte sLaironPose189
+.4byte sLaironPose190
+.4byte sLaironPose191
+.4byte sLaironPose192
+.4byte sLaironPose193
+.4byte sLaironPose194
+.4byte sLaironPose195
+.4byte sLaironPose196
+.4byte sLaironPose197
+.4byte sLaironPose198
+.4byte sLaironPose199
+.4byte sLaironPose200
+.4byte sLaironPose201
+.4byte sLaironPose202
+.4byte sLaironPose203
+.4byte sLaironPose204
+.4byte sLaironPose205
+.4byte sLaironPose206
+.4byte sLaironPose207
+.4byte sLaironPose208
+.4byte sLaironPose209
+.4byte sLaironPose210
+.4byte sLaironPose211
+.4byte sLaironPose212
+.4byte sLaironPose213
+.4byte sLaironPose214
+.4byte sLaironPose215
+.4byte sLaironPose216
+.4byte sLaironPose217
+.4byte sLaironPose218
+.4byte sLaironPose219
+.4byte sLaironPose220
+.4byte sLaironPose221
+.4byte sLaironPose222
+.4byte sLaironPose223
+.4byte sLaironPose224
+.4byte sLaironPose225
+.4byte sLaironPose226
+.4byte sLaironPose227
+.4byte sLaironPose228
+.4byte sLaironPose229
+.4byte sLaironPose230
+sAxPositionsLairon:
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -2,    2, 	 -10,    2, 	   8,   -2, 	  -2,   -6
+.2byte    0,    2, 	  -9,   -2, 	   9,    2, 	   0,   -6
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    9,    1, 	   9,   -3, 	  -7,    0, 	   0,   -9
+.2byte    7,    2, 	   3,   -6, 	  -4,    2, 	  -2,   -7
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte   10,   -1, 	   5,   -4, 	   0,    0, 	  -2,   -7
+.2byte    9,    0, 	   0,   -4, 	   5,    0, 	  -2,   -7
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    4,   -8, 	   2,  -10, 	   8,   -2, 	   0,   -7
+.2byte    5,   -8, 	  -1,   -8, 	  11,   -4, 	   0,   -7
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    1,  -10, 	   7,  -10, 	  -8,   -7, 	   0,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,  -10, 	  -1,   -9
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -5,   -8, 	  -3,  -10, 	  -9,   -2, 	  -1,   -7
+.2byte   -6,   -8, 	   0,   -8, 	 -12,   -4, 	  -1,   -7
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte  -11,   -1, 	  -6,   -4, 	  -1,    0, 	   1,   -7
+.2byte  -10,    0, 	  -1,   -4, 	  -6,    0, 	   1,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte  -10,    1, 	 -10,   -3, 	   6,    0, 	  -1,   -9
+.2byte   -8,    2, 	  -4,   -6, 	   3,    2, 	   1,   -7
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -2,    2, 	 -10,    2, 	   8,   -2, 	  -2,   -6
+.2byte    0,    2, 	  -9,   -2, 	   9,    2, 	   0,   -6
+.2byte   -1,   -1, 	  -9,    0, 	   8,    0, 	  -1,   -7
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    9,    1, 	   9,   -3, 	  -7,    0, 	   0,   -9
+.2byte    7,    2, 	   3,   -6, 	  -4,    2, 	  -2,   -7
+.2byte    3,   -2, 	   5,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte   10,   -1, 	   5,   -4, 	   0,    0, 	  -2,   -7
+.2byte    9,    0, 	   0,   -4, 	   5,    0, 	  -2,   -7
+.2byte    7,   -5, 	   2,   -5, 	   2,    0, 	  -3,   -8
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    4,   -8, 	   2,  -10, 	   8,   -2, 	   0,   -7
+.2byte    5,   -8, 	  -1,   -8, 	  11,   -4, 	   0,   -7
+.2byte    4,  -10, 	  -3,   -9, 	   9,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    1,  -10, 	   7,  -10, 	  -8,   -7, 	   0,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -5,   -8, 	  -3,  -10, 	  -9,   -2, 	  -1,   -7
+.2byte   -6,   -8, 	   0,   -8, 	 -12,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	   2,   -9, 	 -10,   -4, 	   0,   -9
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte  -11,   -1, 	  -6,   -4, 	  -1,    0, 	   1,   -7
+.2byte  -10,    0, 	  -1,   -4, 	  -6,    0, 	   1,   -7
+.2byte   -8,   -5, 	  -3,   -5, 	  -3,    0, 	   2,   -8
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte  -10,    1, 	 -10,   -3, 	   6,    0, 	  -1,   -9
+.2byte   -8,    2, 	  -4,   -6, 	   3,    2, 	   1,   -7
+.2byte   -4,   -2, 	  -6,   -5, 	   4,    0, 	   1,   -8
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -2,    2, 	 -10,    2, 	   8,   -2, 	  -2,   -6
+.2byte    0,    2, 	  -9,   -2, 	   9,    2, 	   0,   -6
+.2byte   -1,   -1, 	  -9,    0, 	   8,    0, 	  -1,   -7
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    9,    1, 	   9,   -3, 	  -7,    0, 	   0,   -9
+.2byte    7,    2, 	   3,   -6, 	  -4,    2, 	  -2,   -7
+.2byte    3,   -2, 	   5,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte   10,   -1, 	   5,   -4, 	   0,    0, 	  -2,   -7
+.2byte    9,    0, 	   0,   -4, 	   5,    0, 	  -2,   -7
+.2byte    7,   -5, 	   2,   -5, 	   2,    0, 	  -3,   -8
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    4,   -8, 	   2,  -10, 	   8,   -2, 	   0,   -7
+.2byte    5,   -8, 	  -1,   -8, 	  11,   -4, 	   0,   -7
+.2byte    4,  -10, 	  -3,   -9, 	   9,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    1,  -10, 	   7,  -10, 	  -8,   -7, 	   0,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -5,   -8, 	  -3,  -10, 	  -9,   -2, 	  -1,   -7
+.2byte   -6,   -8, 	   0,   -8, 	 -12,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	   2,   -9, 	 -10,   -4, 	   0,   -9
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte  -11,   -1, 	  -6,   -4, 	  -1,    0, 	   1,   -7
+.2byte  -10,    0, 	  -1,   -4, 	  -6,    0, 	   1,   -7
+.2byte   -8,   -5, 	  -3,   -5, 	  -3,    0, 	   2,   -8
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte  -10,    1, 	 -10,   -3, 	   6,    0, 	  -1,   -9
+.2byte   -8,    2, 	  -4,   -6, 	   3,    2, 	   1,   -7
+.2byte   -4,   -2, 	  -6,   -5, 	   4,    0, 	   1,   -8
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -1,   -1, 	  -9,    0, 	   8,    0, 	  -1,   -7
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    3,   -2, 	   5,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    7,   -5, 	   2,   -5, 	   2,    0, 	  -3,   -8
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    4,  -10, 	  -3,   -9, 	   9,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -5,  -10, 	   2,   -9, 	 -10,   -4, 	   0,   -9
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -8,   -5, 	  -3,   -5, 	  -3,    0, 	   2,   -8
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte   -4,   -2, 	  -6,   -5, 	   4,    0, 	   1,   -8
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -4,    1, 	  -9,   -1, 	   8,   -1, 	  -3,   -6
+.2byte    3,    1, 	  -9,   -1, 	   8,   -1, 	   2,   -5
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    5,   -2, 	   4,   -7, 	  -5,    0, 	   0,   -9
+.2byte    2,    0, 	   5,   -4, 	  -5,    0, 	  -4,   -8
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte   11,   -4, 	   0,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   3,   -5, 	   2,    0, 	  -3,   -7
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    4,  -11, 	  -4,   -8, 	   9,   -4, 	  -1,   -9
+.2byte   10,   -9, 	   1,  -10, 	   9,   -4, 	   1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    1,  -12, 	   8,   -7, 	  -6,   -7, 	   1,   -9
+.2byte   -3,  -12, 	   5,   -7, 	  -8,   -7, 	  -2,   -9
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -5,  -11, 	   3,   -8, 	 -10,   -4, 	   0,   -9
+.2byte  -11,   -9, 	  -2,  -10, 	 -10,   -4, 	  -2,   -9
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte  -12,   -4, 	  -1,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -9,    0, 	  -4,   -5, 	  -3,    0, 	   2,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte   -6,   -2, 	  -5,   -7, 	   4,    0, 	  -1,   -9
+.2byte   -3,    0, 	  -6,   -4, 	   4,    0, 	   3,   -8
+.2byte   -9,    3, 	  -9,   -1, 	   1,    3, 	   0,   -6
+.2byte   -9,    3, 	  -9,   -1, 	   1,    3, 	   0,   -5
+.2byte   -1,    1, 	  -6,   -9, 	   5,   -9, 	  -1,   -6
+.2byte    8,    1, 	   8,  -11, 	   0,   -7, 	  -1,   -8
+.2byte    7,    0, 	   6,  -10, 	   5,   -6, 	  -2,   -6
+.2byte    3,   -6, 	  -1,  -11, 	   8,   -8, 	   0,   -6
+.2byte   -1,   -7, 	   6,  -11, 	  -7,  -11, 	  -1,   -6
+.2byte   -4,   -6, 	   0,  -11, 	  -9,   -8, 	  -1,   -6
+.2byte   -8,    0, 	  -7,  -10, 	  -6,   -6, 	   1,   -6
+.2byte   -9,    1, 	  -9,  -11, 	  -1,   -7, 	   0,   -8
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -1,   -1, 	  -9,    0, 	   8,    0, 	  -1,   -7
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    3,   -2, 	   5,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    7,   -5, 	   2,   -5, 	   2,    0, 	  -3,   -8
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    4,  -10, 	  -3,   -9, 	   9,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -5,  -10, 	   2,   -9, 	 -10,   -4, 	   0,   -9
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -8,   -5, 	  -3,   -5, 	  -3,    0, 	   2,   -8
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte   -4,   -2, 	  -6,   -5, 	   4,    0, 	   1,   -8
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte   -1,   -1, 	  -9,    0, 	   8,    0, 	  -1,   -7
+.2byte    3,   -2, 	   5,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    7,   -5, 	   2,   -5, 	   2,    0, 	  -3,   -8
+.2byte    4,  -10, 	  -3,   -9, 	   9,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte   -5,  -10, 	   2,   -9, 	 -10,   -4, 	   0,   -9
+.2byte   -8,   -5, 	  -3,   -5, 	  -3,    0, 	   2,   -8
+.2byte   -4,   -2, 	  -6,   -5, 	   4,    0, 	   1,   -8
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -1,   -1, 	  -9,    0, 	   8,    0, 	  -1,   -7
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+.2byte    3,   -2, 	   5,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    7,   -5, 	   2,   -5, 	   2,    0, 	  -3,   -8
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    4,  -10, 	  -3,   -9, 	   9,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -5,  -10, 	   2,   -9, 	 -10,   -4, 	   0,   -9
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -8,   -5, 	  -3,   -5, 	  -3,    0, 	   2,   -8
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte   -4,   -2, 	  -6,   -5, 	   4,    0, 	   1,   -8
+.2byte   -1,   -1, 	  -9,    0, 	   8,    0, 	  -1,   -7
+.2byte   -4,   -2, 	  -6,   -5, 	   4,    0, 	   1,   -8
+.2byte   -8,   -5, 	  -3,   -5, 	  -3,    0, 	   2,   -8
+.2byte   -5,  -10, 	   2,   -9, 	 -10,   -4, 	   0,   -9
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -8
+.2byte    4,  -10, 	  -3,   -9, 	   9,   -4, 	  -1,   -9
+.2byte    7,   -5, 	   2,   -5, 	   2,    0, 	  -3,   -8
+.2byte    3,   -2, 	   5,   -5, 	  -5,    0, 	  -2,   -8
+.2byte   -1,    1, 	  -9,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   4,    0, 	   0,  -10
+.2byte  -10,   -2, 	  -3,   -5, 	  -3,    0, 	   1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   7,   -8, 	  -8,   -8, 	  -1,  -10
+.2byte    5,   -8, 	   0,   -8, 	   9,   -4, 	   0,   -9
+.2byte    9,   -2, 	   2,   -5, 	   2,    0, 	  -2,   -8
+.2byte    8,    0, 	   7,   -5, 	  -5,    0, 	  -1,  -10
+sLaironAnimTable1:
+.4byte sLaironAnims_1_1
+.4byte sLaironAnims_1_2
+.4byte sLaironAnims_1_3
+.4byte sLaironAnims_1_4
+.4byte sLaironAnims_1_5
+.4byte sLaironAnims_1_6
+.4byte sLaironAnims_1_7
+.4byte sLaironAnims_1_8
+sLaironAnimTable2:
+.4byte sLaironAnims_2_1
+.4byte sLaironAnims_2_2
+.4byte sLaironAnims_2_3
+.4byte sLaironAnims_2_4
+.4byte sLaironAnims_2_5
+.4byte sLaironAnims_2_6
+.4byte sLaironAnims_2_7
+.4byte sLaironAnims_2_8
+sLaironAnimTable3:
+.4byte sLaironAnims_3_1
+.4byte sLaironAnims_3_2
+.4byte sLaironAnims_3_3
+.4byte sLaironAnims_3_4
+.4byte sLaironAnims_3_5
+.4byte sLaironAnims_3_6
+.4byte sLaironAnims_3_7
+.4byte sLaironAnims_3_8
+sLaironAnimTable4:
+.4byte sLaironAnims_4_1
+.4byte sLaironAnims_4_2
+.4byte sLaironAnims_4_3
+.4byte sLaironAnims_4_4
+.4byte sLaironAnims_4_5
+.4byte sLaironAnims_4_6
+.4byte sLaironAnims_4_7
+.4byte sLaironAnims_4_8
+sLaironAnimTable5:
+.4byte sLaironAnims_5_1
+.4byte sLaironAnims_5_2
+.4byte sLaironAnims_5_3
+.4byte sLaironAnims_5_4
+.4byte sLaironAnims_5_5
+.4byte sLaironAnims_5_6
+.4byte sLaironAnims_5_7
+.4byte sLaironAnims_5_8
+sLaironAnimTable6:
+.4byte sLaironAnims_6_1
+.4byte sLaironAnims_6_1
+.4byte sLaironAnims_6_1
+.4byte sLaironAnims_6_1
+.4byte sLaironAnims_6_1
+.4byte sLaironAnims_6_1
+.4byte sLaironAnims_6_1
+.4byte sLaironAnims_6_1
+sLaironAnimTable7:
+.4byte sLaironAnims_7_1
+.4byte sLaironAnims_7_2
+.4byte sLaironAnims_7_3
+.4byte sLaironAnims_7_4
+.4byte sLaironAnims_7_5
+.4byte sLaironAnims_7_6
+.4byte sLaironAnims_7_7
+.4byte sLaironAnims_7_8
+sLaironAnimTable8:
+.4byte sLaironAnims_8_1
+.4byte sLaironAnims_8_2
+.4byte sLaironAnims_8_3
+.4byte sLaironAnims_8_4
+.4byte sLaironAnims_8_5
+.4byte sLaironAnims_8_6
+.4byte sLaironAnims_8_7
+.4byte sLaironAnims_8_8
+sLaironAnimTable9:
+.4byte sLaironAnims_9_1
+.4byte sLaironAnims_9_2
+.4byte sLaironAnims_9_3
+.4byte sLaironAnims_9_4
+.4byte sLaironAnims_9_5
+.4byte sLaironAnims_9_6
+.4byte sLaironAnims_9_7
+.4byte sLaironAnims_9_8
+sLaironAnimTable10:
+.4byte sLaironAnims_10_1
+.4byte sLaironAnims_10_2
+.4byte sLaironAnims_10_3
+.4byte sLaironAnims_10_4
+.4byte sLaironAnims_10_5
+.4byte sLaironAnims_10_6
+.4byte sLaironAnims_10_7
+.4byte sLaironAnims_10_8
+sLaironAnimTable11:
+.4byte sLaironAnims_11_1
+.4byte sLaironAnims_11_2
+.4byte sLaironAnims_11_3
+.4byte sLaironAnims_11_4
+.4byte sLaironAnims_11_5
+.4byte sLaironAnims_11_6
+.4byte sLaironAnims_11_7
+.4byte sLaironAnims_11_8
+sLaironAnimTable12:
+.4byte sLaironAnims_12_1
+.4byte sLaironAnims_12_2
+.4byte sLaironAnims_12_3
+.4byte sLaironAnims_12_4
+.4byte sLaironAnims_12_5
+.4byte sLaironAnims_12_6
+.4byte sLaironAnims_12_7
+.4byte sLaironAnims_12_8
+sLaironAnimTable13:
+.4byte sLaironAnims_13_1
+.4byte sLaironAnims_13_2
+.4byte sLaironAnims_13_3
+.4byte sLaironAnims_13_4
+.4byte sLaironAnims_13_5
+.4byte sLaironAnims_13_6
+.4byte sLaironAnims_13_7
+.4byte sLaironAnims_13_8
+sAxAnimationsLairon:
+.4byte sLaironAnimTable1
+.4byte sLaironAnimTable2
+.4byte sLaironAnimTable3
+.4byte sLaironAnimTable4
+.4byte sLaironAnimTable5
+.4byte sLaironAnimTable6
+.4byte sLaironAnimTable7
+.4byte sLaironAnimTable8
+.4byte sLaironAnimTable9
+.4byte sLaironAnimTable10
+.4byte sLaironAnimTable11
+.4byte sLaironAnimTable12
+.4byte sLaironAnimTable13
+sAxSpritesLairon:
+.4byte sLaironSprites1
+.4byte sLaironSprites2
+.4byte sLaironSprites3
+.4byte sLaironSprites4
+.4byte sLaironSprites5
+.4byte sLaironSprites6
+.4byte sLaironSprites7
+.4byte sLaironSprites8
+.4byte sLaironSprites9
+.4byte sLaironSprites10
+.4byte sLaironSprites11
+.4byte sLaironSprites12
+.4byte sLaironSprites13
+.4byte sLaironSprites14
+.4byte sLaironSprites15
+.4byte sLaironSprites16
+.4byte sLaironSprites17
+.4byte sLaironSprites18
+.4byte sLaironSprites19
+.4byte sLaironSprites20
+.4byte sLaironSprites21
+.4byte sLaironSprites22
+.4byte sLaironSprites23
+.4byte sLaironSprites24
+.4byte sLaironSprites25
+.4byte sLaironSprites26
+.4byte sLaironSprites27
+.4byte sLaironSprites28
+.4byte sLaironSprites29
+.4byte sLaironSprites30
+.4byte sLaironSprites31
+.4byte sLaironSprites32
+.4byte sLaironSprites33
+.4byte sLaironSprites34
+.4byte sLaironSprites35
+.4byte sLaironSprites36
+.4byte sLaironSprites37
+sAxMainLairon:
+ax_main sAxPosesLairon, sAxAnimationsLairon, 13, sAxSpritesLairon, sAxPositionsLairon

--- a/data/ax/lanturn.inc
+++ b/data/ax/lanturn.inc
@@ -1,0 +1,2636 @@
+.global gAxLanturn
+gAxLanturn:
+ax_siro sAxMainLanturn
+sLanturnPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose2:
+ax_pose 1, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose4:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose5:
+ax_pose 4, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose6:
+ax_pose 5, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose7:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose8:
+ax_pose 7, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose9:
+ax_pose 8, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose10:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose11:
+ax_pose 10, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose12:
+ax_pose 11, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose14:
+ax_pose 13, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose15:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose16:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose17:
+ax_pose 10, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose18:
+ax_pose 11, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose19:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose20:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose21:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose22:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose23:
+ax_pose 4, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose24:
+ax_pose 5, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose26:
+ax_pose 1, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose27:
+ax_pose 2, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose28:
+ax_pose 15, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose29:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose30:
+ax_pose 4, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose31:
+ax_pose 5, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose32:
+ax_pose 16, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose33:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose34:
+ax_pose 7, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose35:
+ax_pose 8, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose36:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sLanturnPose37:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose38:
+ax_pose 10, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose39:
+ax_pose 11, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose40:
+ax_pose 18, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose41:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose42:
+ax_pose 13, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose43:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose44:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose45:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose46:
+ax_pose 10, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose47:
+ax_pose 11, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose48:
+ax_pose 18, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose49:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose50:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose51:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose52:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose53:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose54:
+ax_pose 4, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose55:
+ax_pose 5, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose56:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose58:
+ax_pose 1, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose59:
+ax_pose 2, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose60:
+ax_pose 15, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose61:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose62:
+ax_pose 4, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose63:
+ax_pose 5, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose64:
+ax_pose 16, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose65:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose66:
+ax_pose 7, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose67:
+ax_pose 8, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose68:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sLanturnPose69:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose70:
+ax_pose 10, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose71:
+ax_pose 11, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose72:
+ax_pose 18, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose73:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose74:
+ax_pose 13, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose75:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose76:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose77:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose78:
+ax_pose 10, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose79:
+ax_pose 11, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose80:
+ax_pose 18, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose81:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose82:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose83:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose84:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose85:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose86:
+ax_pose 4, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose87:
+ax_pose 5, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose88:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose90:
+ax_pose 1, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose91:
+ax_pose 2, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose92:
+ax_pose 20, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose93:
+ax_pose 15, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose94:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose95:
+ax_pose 4, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose96:
+ax_pose 5, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose97:
+ax_pose 21, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose98:
+ax_pose 16, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose99:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose100:
+ax_pose 7, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose101:
+ax_pose 8, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose102:
+ax_pose 22, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose103:
+ax_pose 17, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose104:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose105:
+ax_pose 10, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose106:
+ax_pose 11, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose107:
+ax_pose 23, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose108:
+ax_pose 18, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose109:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose110:
+ax_pose 13, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose111:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose112:
+ax_pose 24, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose113:
+ax_pose 19, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose114:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose115:
+ax_pose 10, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose116:
+ax_pose 11, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose117:
+ax_pose 23, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose118:
+ax_pose 18, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose119:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose120:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose121:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose122:
+ax_pose 22, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose123:
+ax_pose 17, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose124:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose125:
+ax_pose 4, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose126:
+ax_pose 5, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose127:
+ax_pose 21, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose128:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose129:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose130:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose131:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose132:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose133:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose134:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose135:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose136:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose137:
+ax_pose 25, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose138:
+ax_pose 26, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose139:
+ax_pose 27, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose140:
+ax_pose 28, 0x01e2, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose141:
+ax_pose 29, 0x01e3, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose142:
+ax_pose 30, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose143:
+ax_pose 31, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose144:
+ax_pose 30, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose145:
+ax_pose 29, 0x01e3, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose146:
+ax_pose 28, 0x01e2, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose147:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose148:
+ax_pose 1, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose149:
+ax_pose 2, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose150:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose151:
+ax_pose 4, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose152:
+ax_pose 5, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose153:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose154:
+ax_pose 7, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose155:
+ax_pose 8, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose156:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose157:
+ax_pose 10, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose158:
+ax_pose 11, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose159:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose160:
+ax_pose 13, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLanturnPose161:
+ax_pose 14, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose162:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose163:
+ax_pose 10, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose164:
+ax_pose 11, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose165:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose166:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose167:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose168:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose169:
+ax_pose 4, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose170:
+ax_pose 5, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose171:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose172:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose173:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose174:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose175:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose176:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose177:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose178:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose179:
+ax_pose 20, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose180:
+ax_pose 21, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose181:
+ax_pose 22, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose182:
+ax_pose 23, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose183:
+ax_pose 24, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose184:
+ax_pose 23, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose185:
+ax_pose 22, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose186:
+ax_pose 21, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose187:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose188:
+ax_pose 20, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose189:
+ax_pose 15, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose190:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose191:
+ax_pose 21, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose192:
+ax_pose 16, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose193:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose194:
+ax_pose 22, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose195:
+ax_pose 17, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose196:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose197:
+ax_pose 23, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sLanturnPose198:
+ax_pose 18, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose199:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose200:
+ax_pose 24, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose201:
+ax_pose 19, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose202:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose203:
+ax_pose 23, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose204:
+ax_pose 18, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose205:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose206:
+ax_pose 22, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose207:
+ax_pose 17, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose208:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose209:
+ax_pose 21, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose210:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose211:
+ax_pose 15, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose212:
+ax_pose 16, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose213:
+ax_pose 17, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sLanturnPose214:
+ax_pose 18, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sLanturnPose215:
+ax_pose 19, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose216:
+ax_pose 18, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose217:
+ax_pose 17, 0x01e8, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose218:
+ax_pose 16, 0x01e8, 0x90ee, 0x0c00
+ax_pose_terminator
+sLanturnPose219:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose220:
+ax_pose 3, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose221:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose222:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sLanturnPose223:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sLanturnPose224:
+ax_pose 9, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sLanturnPose225:
+ax_pose 6, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sLanturnPose226:
+ax_pose 3, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+.align 2
+sLanturnAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLanturnAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 21, 21, 21, 21,
+ax_anim 2, 1, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 31, 21, 21, 21, 21,
+ax_anim 2, 0, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sLanturnAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sLanturnAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 1, 39, 21, -21, 21, -21,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 21, -21, 21, -21,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sLanturnAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sLanturnAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -20, -22, -20, -22,
+ax_anim 2, 1, 47, -21, -21, -21, -21,
+ax_anim 2, 0, 47, -20, -22, -20, -22,
+ax_anim 2, 0, 47, -21, -21, -21, -21,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sLanturnAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sLanturnAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -21, 21, -21, 21,
+ax_anim 2, 1, 55, -22, 20, -22, 20,
+ax_anim 2, 0, 55, -21, 21, -21, 21,
+ax_anim 2, 0, 55, -22, 20, -22, 20,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLanturnAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sLanturnAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 21, 21, 21, 21,
+ax_anim 2, 1, 63, 22, 20, 22, 20,
+ax_anim 2, 0, 63, 21, 21, 21, 21,
+ax_anim 2, 0, 63, 22, 20, 22, 20,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sLanturnAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sLanturnAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 20, -22, 20, -22,
+ax_anim 2, 1, 71, 21, -21, 21, -21,
+ax_anim 2, 0, 71, 20, -22, 20, -22,
+ax_anim 2, 0, 71, 21, -21, 21, -21,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sLanturnAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 1, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sLanturnAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -20, -22, -20, -22,
+ax_anim 2, 1, 79, -21, -21, -21, -21,
+ax_anim 2, 0, 79, -20, -22, -20, -22,
+ax_anim 2, 0, 79, -21, -21, -21, -21,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sLanturnAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sLanturnAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -21, 21, -21, 21,
+ax_anim 2, 1, 87, -22, 20, -22, 20,
+ax_anim 2, 0, 87, -21, 21, -21, 21,
+ax_anim 2, 0, 87, -22, 20, -22, 20,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLanturnAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 4, 2, 91, 0, -4, 0, 0,
+ax_anim 1, 0, 91, 0, -1, 0, 0,
+ax_anim 1, 0, 92, 0, 4, 0, 0,
+ax_anim 2, 0, 92, 0, 5, 0, 0,
+ax_anim 2, 1, 92, 1, 5, 0, 0,
+ax_anim 2, 0, 92, 0, 5, 0, 0,
+ax_anim 2, 0, 92, 1, 5, 0, 0,
+ax_anim 2, 0, 92, 0, 5, 0, 0,
+ax_anim 2, 0, 92, 1, 5, 0, 0,
+ax_anim 2, 0, 88, 0, 2, 0, 0,
+ax_anim_terminator
+sLanturnAnims_4_2:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 96, -3, -3, -3, -3,
+ax_anim 4, 2, 96, -4, -4, -4, -4,
+ax_anim 1, 0, 96, -1, -1, -1, -1,
+ax_anim 1, 0, 97, 4, 4, 4, 4,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 1, 97, 6, 4, 6, 4,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 6, 4, 6, 4,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 6, 4, 6, 4,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sLanturnAnims_4_3:
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 4, 2, 101, -4, 0, -4, 0,
+ax_anim 1, 0, 101, -1, 0, -1, 0,
+ax_anim 1, 0, 102, 4, 0, 4, 0,
+ax_anim 2, 0, 102, 5, -1, 5, -1,
+ax_anim 2, 1, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, -1, 5, -1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, -1, 5, -1,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sLanturnAnims_4_4:
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 106, -3, 3, -3, 3,
+ax_anim 4, 2, 106, -4, 4, -4, 4,
+ax_anim 1, 0, 106, -1, 1, -1, 1,
+ax_anim 1, 0, 107, 4, -4, 4, -4,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 1, 107, 6, -4, 6, -4,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 6, -4, 6, -4,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 6, -4, 6, -4,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sLanturnAnims_4_5:
+ax_anim 2, 0, 108, 0, 1, 0, 0,
+ax_anim 2, 0, 111, 0, 3, 0, 0,
+ax_anim 4, 2, 111, 0, 4, 0, 0,
+ax_anim 1, 0, 111, 0, 1, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 1, 112, 1, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 1, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 1, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim_terminator
+sLanturnAnims_4_6:
+ax_anim 2, 0, 113, 1, 1, 1, 1,
+ax_anim 2, 0, 116, 3, 3, 3, 3,
+ax_anim 4, 2, 116, 4, 4, 4, 4,
+ax_anim 1, 0, 116, 1, 1, 1, 1,
+ax_anim 1, 0, 117, -4, -4, -4, -4,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 1, 117, -6, -4, -6, -4,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -6, -4, -6, -4,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -6, -4, -6, -4,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sLanturnAnims_4_7:
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 3, 0, 3, 0,
+ax_anim 4, 2, 121, 4, 0, 4, 0,
+ax_anim 1, 0, 121, 1, 0, 1, 0,
+ax_anim 1, 0, 122, -4, 0, -4, 0,
+ax_anim 2, 0, 122, -5, -1, -5, -1,
+ax_anim 2, 1, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, -1, -5, -1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, -1, -5, -1,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sLanturnAnims_4_8:
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 126, 3, -3, 3, -3,
+ax_anim 4, 2, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 126, 1, -1, 1, -1,
+ax_anim 1, 0, 127, -4, 4, -4, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 1, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sLanturnAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_6_1:
+ax_anim 20, 0, 136, 0, 0, 0, 0,
+ax_anim 14, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 137, 0, 1, 0, 0,
+ax_anim 20, 0, 137, 0, 2, 0, 0,
+ax_anim 14, 0, 136, 0, 2, 0, 0,
+ax_anim 14, 0, 136, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sLanturnAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sLanturnAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sLanturnAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sLanturnAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sLanturnAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sLanturnAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sLanturnAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLanturnAnims_8_1:
+ax_anim 20, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, -1, 0, 0,
+ax_anim 6, 0, 146, 0, -1, 0, 0,
+ax_anim 6, 0, 148, 0, -1, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim 8, 0, 146, 0, -2, 0, 0,
+ax_anim 20, 0, 146, 0, -3, 0, 0,
+ax_anim 8, 0, 146, 0, -2, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sLanturnAnims_8_2:
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, -1, 0, 0,
+ax_anim 6, 0, 149, 0, -1, 0, 0,
+ax_anim 6, 0, 151, 0, -1, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 8, 0, 149, 0, -2, 0, 0,
+ax_anim 20, 0, 149, 0, -3, 0, 0,
+ax_anim 8, 0, 149, 0, -2, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sLanturnAnims_8_3:
+ax_anim 20, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, -1, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, 0,
+ax_anim 6, 0, 154, 0, -1, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 8, 0, 152, 0, -2, 0, 0,
+ax_anim 20, 0, 152, 0, -3, 0, 0,
+ax_anim 8, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+sLanturnAnims_8_4:
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, -1, 0, 0,
+ax_anim 6, 0, 155, 0, -1, 0, 0,
+ax_anim 6, 0, 157, 0, -1, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim 8, 0, 155, 0, -2, 0, 0,
+ax_anim 20, 0, 155, 0, -3, 0, 0,
+ax_anim 8, 0, 155, 0, -2, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim_terminator
+sLanturnAnims_8_5:
+ax_anim 20, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, -1, 0, 0,
+ax_anim 6, 0, 158, 0, -1, 0, 0,
+ax_anim 6, 0, 160, 0, -1, 0, 0,
+ax_anim 8, 0, 158, 0, -1, 0, 0,
+ax_anim 8, 0, 158, 0, -2, 0, 0,
+ax_anim 20, 0, 158, 0, -3, 0, 0,
+ax_anim 8, 0, 158, 0, -2, 0, 0,
+ax_anim 8, 0, 158, 0, -1, 0, 0,
+ax_anim_terminator
+sLanturnAnims_8_6:
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 0, -1, 0, 0,
+ax_anim 6, 0, 161, 0, -1, 0, 0,
+ax_anim 6, 0, 163, 0, -1, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim 8, 0, 161, 0, -2, 0, 0,
+ax_anim 20, 0, 161, 0, -3, 0, 0,
+ax_anim 8, 0, 161, 0, -2, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim_terminator
+sLanturnAnims_8_7:
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, -1, 0, 0,
+ax_anim 6, 0, 164, 0, -1, 0, 0,
+ax_anim 6, 0, 166, 0, -1, 0, 0,
+ax_anim 8, 0, 164, 0, -1, 0, 0,
+ax_anim 8, 0, 164, 0, -2, 0, 0,
+ax_anim 20, 0, 164, 0, -3, 0, 0,
+ax_anim 8, 0, 164, 0, -2, 0, 0,
+ax_anim 8, 0, 164, 0, -1, 0, 0,
+ax_anim_terminator
+sLanturnAnims_8_8:
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 168, 0, -1, 0, 0,
+ax_anim 6, 0, 167, 0, -1, 0, 0,
+ax_anim 6, 0, 169, 0, -1, 0, 0,
+ax_anim 8, 0, 167, 0, -1, 0, 0,
+ax_anim 8, 0, 167, 0, -2, 0, 0,
+ax_anim 20, 0, 167, 0, -3, 0, 0,
+ax_anim 8, 0, 167, 0, -2, 0, 0,
+ax_anim 8, 0, 167, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 3, 7, 3,
+ax_anim 2, 0, 172, 9, 10, 9, 10,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -9, 10, -9, 10,
+ax_anim 1, 0, 177, -7, 3, -7, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 10, 3, 10, 3,
+ax_anim 2, 0, 171, 20, 7, 20, 7,
+ax_anim 2, 0, 172, 23, 12, 23, 12,
+ax_anim 3, 0, 173, 18, 19, 18, 19,
+ax_anim 2, 3, 174, 11, 18, 11, 18,
+ax_anim 2, 0, 175, 3, 14, 3, 14,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 2, -3, 2, -3,
+ax_anim 2, 0, 170, 9, -3, 9, -3,
+ax_anim 2, 0, 171, 16, -2, 16, -2,
+ax_anim 3, 0, 172, 17, 2, 17, 0,
+ax_anim 2, 3, 173, 15, 6, 15, 5,
+ax_anim 2, 0, 174, 11, 7, 11, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -7, -1, -7,
+ax_anim 2, 0, 177, 3, -14, 3, -14,
+ax_anim 2, 0, 170, 13, -18, 13, -20,
+ax_anim 3, 0, 171, 21, -15, 21, -20,
+ax_anim 2, 3, 172, 22, -10, 22, -10,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 9, 0, 9, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -3, -8, -3,
+ax_anim 2, 0, 176, -11, -8, -11, -8,
+ax_anim 2, 0, 177, -7, -13, -7, -15,
+ax_anim 3, 0, 170, 0, -14, 0, -19,
+ax_anim 2, 3, 171, 7, -13, 7, -15,
+ax_anim 2, 0, 172, 11, -8, 11, -8,
+ax_anim 1, 0, 173, 8, -3, 8, -3,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -7, 1, -7,
+ax_anim 2, 0, 171, -3, -14, -3, -14,
+ax_anim 2, 0, 170, -13, -18, -13, -20,
+ax_anim 3, 0, 177, -21, -15, -21, -20,
+ax_anim 2, 3, 176, -22, -10, -22, -10,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -9, 0, -9, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -2, -3, -2, -3,
+ax_anim 2, 0, 170, -9, -3, -9, -3,
+ax_anim 2, 0, 177, -16, -2, -16, -2,
+ax_anim 3, 0, 176, -17, 2, -17, 0,
+ax_anim 2, 3, 175, -15, 6, -15, 5,
+ax_anim 2, 0, 174, -11, 7, -11, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -10, 3, -10, 3,
+ax_anim 2, 0, 177, -20, 7, -20, 7,
+ax_anim 2, 0, 176, -23, 12, -23, 12,
+ax_anim 3, 0, 175, -18, 19, -18, 19,
+ax_anim 2, 3, 174, -11, 18, -11, 18,
+ax_anim 2, 0, 173, -3, 14, -3, 14,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 2, 186, 0, 5, 0, 0,
+ax_anim_terminator
+sLanturnAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 2, 189, 0, 3, 0, 0,
+ax_anim_terminator
+sLanturnAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 2, 192, 0, 4, 0, 0,
+ax_anim_terminator
+sLanturnAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 2, 195, 0, 4, 0, 0,
+ax_anim_terminator
+sLanturnAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 2, 198, 0, 4, 0, 0,
+ax_anim_terminator
+sLanturnAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 2, 201, 0, 4, 0, 0,
+ax_anim_terminator
+sLanturnAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 2, 204, 0, 4, 0, 0,
+ax_anim_terminator
+sLanturnAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 2, 207, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLanturnAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sLanturnGfx1:
+.incbin "baserom.gba", 0xC7A7B4, 0x200
+sLanturnSprites1:
+ax_sprite sLanturnGfx1, 0x200
+ax_sprite_terminator
+sLanturnGfx2:
+.incbin "baserom.gba", 0xC7A9C4, 0x200
+sLanturnSprites2:
+ax_sprite sLanturnGfx2, 0x200
+ax_sprite_terminator
+sLanturnGfx3:
+.incbin "baserom.gba", 0xC7ABD4, 0x200
+sLanturnSprites3:
+ax_sprite sLanturnGfx3, 0x200
+ax_sprite_terminator
+sLanturnGfx4:
+.incbin "baserom.gba", 0xC7ADE4, 0x200
+sLanturnSprites4:
+ax_sprite sLanturnGfx4, 0x200
+ax_sprite_terminator
+sLanturnGfx5:
+.incbin "baserom.gba", 0xC7AFF4, 0x200
+sLanturnSprites5:
+ax_sprite sLanturnGfx5, 0x200
+ax_sprite_terminator
+sLanturnGfx6:
+.incbin "baserom.gba", 0xC7B204, 0x200
+sLanturnSprites6:
+ax_sprite sLanturnGfx6, 0x200
+ax_sprite_terminator
+sLanturnGfx7:
+.incbin "baserom.gba", 0xC7B414, 0x200
+sLanturnSprites7:
+ax_sprite sLanturnGfx7, 0x200
+ax_sprite_terminator
+sLanturnGfx8:
+.incbin "baserom.gba", 0xC7B624, 0x200
+sLanturnSprites8:
+ax_sprite sLanturnGfx8, 0x200
+ax_sprite_terminator
+sLanturnGfx9:
+.incbin "baserom.gba", 0xC7B834, 0x200
+sLanturnSprites9:
+ax_sprite sLanturnGfx9, 0x200
+ax_sprite_terminator
+sLanturnGfx10:
+.incbin "baserom.gba", 0xC7BA44, 0x200
+sLanturnSprites10:
+ax_sprite sLanturnGfx10, 0x200
+ax_sprite_terminator
+sLanturnGfx11:
+.incbin "baserom.gba", 0xC7BC54, 0x200
+sLanturnSprites11:
+ax_sprite sLanturnGfx11, 0x200
+ax_sprite_terminator
+sLanturnGfx12:
+.incbin "baserom.gba", 0xC7BE64, 0x200
+sLanturnSprites12:
+ax_sprite sLanturnGfx12, 0x200
+ax_sprite_terminator
+sLanturnGfx13:
+.incbin "baserom.gba", 0xC7C074, 0x200
+sLanturnSprites13:
+ax_sprite sLanturnGfx13, 0x200
+ax_sprite_terminator
+sLanturnGfx14:
+.incbin "baserom.gba", 0xC7C284, 0x200
+sLanturnSprites14:
+ax_sprite sLanturnGfx14, 0x200
+ax_sprite_terminator
+sLanturnGfx15:
+.incbin "baserom.gba", 0xC7C494, 0x200
+sLanturnSprites15:
+ax_sprite sLanturnGfx15, 0x200
+ax_sprite_terminator
+sLanturnGfx16:
+.incbin "baserom.gba", 0xC7C6A4, 0x40
+sLanturnGfx16_1:
+.incbin "baserom.gba", 0xC7C6E4, 0x40
+sLanturnGfx16_2:
+.incbin "baserom.gba", 0xC7C724, 0x80
+sLanturnSprites16:
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLanturnGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx16_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLanturnGfx17:
+.incbin "baserom.gba", 0xC7C7E4, 0x100
+sLanturnSprites17:
+ax_sprite 0, 0x80
+ax_sprite sLanturnGfx17, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLanturnGfx18:
+.incbin "baserom.gba", 0xC7C904, 0x20
+sLanturnGfx18_1:
+.incbin "baserom.gba", 0xC7C924, 0x100
+sLanturnGfx18_2:
+.incbin "baserom.gba", 0xC7CA24, 0x20
+sLanturnSprites18:
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLanturnGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx18_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLanturnGfx19:
+.incbin "baserom.gba", 0xC7CA84, 0x40
+sLanturnGfx19_1:
+.incbin "baserom.gba", 0xC7CAC4, 0x100
+sLanturnGfx19_2:
+.incbin "baserom.gba", 0xC7CBC4, 0x20
+sLanturnSprites19:
+ax_sprite sLanturnGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLanturnGfx19_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sLanturnGfx19_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLanturnGfx20:
+.incbin "baserom.gba", 0xC7CC1C, 0x40
+sLanturnGfx20_1:
+.incbin "baserom.gba", 0xC7CC5C, 0x60
+sLanturnGfx20_2:
+.incbin "baserom.gba", 0xC7CCBC, 0x80
+sLanturnGfx20_3:
+.incbin "baserom.gba", 0xC7CD3C, 0x40
+sLanturnSprites20:
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx20_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLanturnGfx21:
+.incbin "baserom.gba", 0xC7CDCC, 0x40
+sLanturnGfx21_1:
+.incbin "baserom.gba", 0xC7CE0C, 0x40
+sLanturnGfx21_2:
+.incbin "baserom.gba", 0xC7CE4C, 0x80
+sLanturnSprites21:
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLanturnGfx21_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx21_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLanturnGfx22:
+.incbin "baserom.gba", 0xC7CF0C, 0x40
+sLanturnGfx22_1:
+.incbin "baserom.gba", 0xC7CF4C, 0x100
+sLanturnSprites22:
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx22_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLanturnGfx23:
+.incbin "baserom.gba", 0xC7D07C, 0x40
+sLanturnGfx23_1:
+.incbin "baserom.gba", 0xC7D0BC, 0x100
+sLanturnSprites23:
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx23_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLanturnGfx24:
+.incbin "baserom.gba", 0xC7D1EC, 0x60
+sLanturnGfx24_1:
+.incbin "baserom.gba", 0xC7D24C, 0x100
+sLanturnSprites24:
+ax_sprite sLanturnGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx24_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLanturnGfx25:
+.incbin "baserom.gba", 0xC7D374, 0x40
+sLanturnGfx25_1:
+.incbin "baserom.gba", 0xC7D3B4, 0x40
+sLanturnGfx25_2:
+.incbin "baserom.gba", 0xC7D3F4, 0x80
+sLanturnSprites25:
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLanturnGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLanturnGfx25_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLanturnGfx26:
+.incbin "baserom.gba", 0xC7D4B4, 0x200
+sLanturnSprites26:
+ax_sprite sLanturnGfx26, 0x200
+ax_sprite_terminator
+sLanturnGfx27:
+.incbin "baserom.gba", 0xC7D6C4, 0x200
+sLanturnSprites27:
+ax_sprite sLanturnGfx27, 0x200
+ax_sprite_terminator
+sLanturnGfx28:
+.incbin "baserom.gba", 0xC7D8D4, 0x200
+sLanturnSprites28:
+ax_sprite sLanturnGfx28, 0x200
+ax_sprite_terminator
+sLanturnGfx29:
+.incbin "baserom.gba", 0xC7DAE4, 0x200
+sLanturnSprites29:
+ax_sprite sLanturnGfx29, 0x200
+ax_sprite_terminator
+sLanturnGfx30:
+.incbin "baserom.gba", 0xC7DCF4, 0x200
+sLanturnSprites30:
+ax_sprite sLanturnGfx30, 0x200
+ax_sprite_terminator
+sLanturnGfx31:
+.incbin "baserom.gba", 0xC7DF04, 0x200
+sLanturnSprites31:
+ax_sprite sLanturnGfx31, 0x200
+ax_sprite_terminator
+sLanturnGfx32:
+.incbin "baserom.gba", 0xC7E114, 0x200
+sLanturnSprites32:
+ax_sprite sLanturnGfx32, 0x200
+ax_sprite_terminator
+sAxPosesLanturn:
+.4byte sLanturnPose1
+.4byte sLanturnPose2
+.4byte sLanturnPose3
+.4byte sLanturnPose4
+.4byte sLanturnPose5
+.4byte sLanturnPose6
+.4byte sLanturnPose7
+.4byte sLanturnPose8
+.4byte sLanturnPose9
+.4byte sLanturnPose10
+.4byte sLanturnPose11
+.4byte sLanturnPose12
+.4byte sLanturnPose13
+.4byte sLanturnPose14
+.4byte sLanturnPose15
+.4byte sLanturnPose16
+.4byte sLanturnPose17
+.4byte sLanturnPose18
+.4byte sLanturnPose19
+.4byte sLanturnPose20
+.4byte sLanturnPose21
+.4byte sLanturnPose22
+.4byte sLanturnPose23
+.4byte sLanturnPose24
+.4byte sLanturnPose25
+.4byte sLanturnPose26
+.4byte sLanturnPose27
+.4byte sLanturnPose28
+.4byte sLanturnPose29
+.4byte sLanturnPose30
+.4byte sLanturnPose31
+.4byte sLanturnPose32
+.4byte sLanturnPose33
+.4byte sLanturnPose34
+.4byte sLanturnPose35
+.4byte sLanturnPose36
+.4byte sLanturnPose37
+.4byte sLanturnPose38
+.4byte sLanturnPose39
+.4byte sLanturnPose40
+.4byte sLanturnPose41
+.4byte sLanturnPose42
+.4byte sLanturnPose43
+.4byte sLanturnPose44
+.4byte sLanturnPose45
+.4byte sLanturnPose46
+.4byte sLanturnPose47
+.4byte sLanturnPose48
+.4byte sLanturnPose49
+.4byte sLanturnPose50
+.4byte sLanturnPose51
+.4byte sLanturnPose52
+.4byte sLanturnPose53
+.4byte sLanturnPose54
+.4byte sLanturnPose55
+.4byte sLanturnPose56
+.4byte sLanturnPose57
+.4byte sLanturnPose58
+.4byte sLanturnPose59
+.4byte sLanturnPose60
+.4byte sLanturnPose61
+.4byte sLanturnPose62
+.4byte sLanturnPose63
+.4byte sLanturnPose64
+.4byte sLanturnPose65
+.4byte sLanturnPose66
+.4byte sLanturnPose67
+.4byte sLanturnPose68
+.4byte sLanturnPose69
+.4byte sLanturnPose70
+.4byte sLanturnPose71
+.4byte sLanturnPose72
+.4byte sLanturnPose73
+.4byte sLanturnPose74
+.4byte sLanturnPose75
+.4byte sLanturnPose76
+.4byte sLanturnPose77
+.4byte sLanturnPose78
+.4byte sLanturnPose79
+.4byte sLanturnPose80
+.4byte sLanturnPose81
+.4byte sLanturnPose82
+.4byte sLanturnPose83
+.4byte sLanturnPose84
+.4byte sLanturnPose85
+.4byte sLanturnPose86
+.4byte sLanturnPose87
+.4byte sLanturnPose88
+.4byte sLanturnPose89
+.4byte sLanturnPose90
+.4byte sLanturnPose91
+.4byte sLanturnPose92
+.4byte sLanturnPose93
+.4byte sLanturnPose94
+.4byte sLanturnPose95
+.4byte sLanturnPose96
+.4byte sLanturnPose97
+.4byte sLanturnPose98
+.4byte sLanturnPose99
+.4byte sLanturnPose100
+.4byte sLanturnPose101
+.4byte sLanturnPose102
+.4byte sLanturnPose103
+.4byte sLanturnPose104
+.4byte sLanturnPose105
+.4byte sLanturnPose106
+.4byte sLanturnPose107
+.4byte sLanturnPose108
+.4byte sLanturnPose109
+.4byte sLanturnPose110
+.4byte sLanturnPose111
+.4byte sLanturnPose112
+.4byte sLanturnPose113
+.4byte sLanturnPose114
+.4byte sLanturnPose115
+.4byte sLanturnPose116
+.4byte sLanturnPose117
+.4byte sLanturnPose118
+.4byte sLanturnPose119
+.4byte sLanturnPose120
+.4byte sLanturnPose121
+.4byte sLanturnPose122
+.4byte sLanturnPose123
+.4byte sLanturnPose124
+.4byte sLanturnPose125
+.4byte sLanturnPose126
+.4byte sLanturnPose127
+.4byte sLanturnPose128
+.4byte sLanturnPose129
+.4byte sLanturnPose130
+.4byte sLanturnPose131
+.4byte sLanturnPose132
+.4byte sLanturnPose133
+.4byte sLanturnPose134
+.4byte sLanturnPose135
+.4byte sLanturnPose136
+.4byte sLanturnPose137
+.4byte sLanturnPose138
+.4byte sLanturnPose139
+.4byte sLanturnPose140
+.4byte sLanturnPose141
+.4byte sLanturnPose142
+.4byte sLanturnPose143
+.4byte sLanturnPose144
+.4byte sLanturnPose145
+.4byte sLanturnPose146
+.4byte sLanturnPose147
+.4byte sLanturnPose148
+.4byte sLanturnPose149
+.4byte sLanturnPose150
+.4byte sLanturnPose151
+.4byte sLanturnPose152
+.4byte sLanturnPose153
+.4byte sLanturnPose154
+.4byte sLanturnPose155
+.4byte sLanturnPose156
+.4byte sLanturnPose157
+.4byte sLanturnPose158
+.4byte sLanturnPose159
+.4byte sLanturnPose160
+.4byte sLanturnPose161
+.4byte sLanturnPose162
+.4byte sLanturnPose163
+.4byte sLanturnPose164
+.4byte sLanturnPose165
+.4byte sLanturnPose166
+.4byte sLanturnPose167
+.4byte sLanturnPose168
+.4byte sLanturnPose169
+.4byte sLanturnPose170
+.4byte sLanturnPose171
+.4byte sLanturnPose172
+.4byte sLanturnPose173
+.4byte sLanturnPose174
+.4byte sLanturnPose175
+.4byte sLanturnPose176
+.4byte sLanturnPose177
+.4byte sLanturnPose178
+.4byte sLanturnPose179
+.4byte sLanturnPose180
+.4byte sLanturnPose181
+.4byte sLanturnPose182
+.4byte sLanturnPose183
+.4byte sLanturnPose184
+.4byte sLanturnPose185
+.4byte sLanturnPose186
+.4byte sLanturnPose187
+.4byte sLanturnPose188
+.4byte sLanturnPose189
+.4byte sLanturnPose190
+.4byte sLanturnPose191
+.4byte sLanturnPose192
+.4byte sLanturnPose193
+.4byte sLanturnPose194
+.4byte sLanturnPose195
+.4byte sLanturnPose196
+.4byte sLanturnPose197
+.4byte sLanturnPose198
+.4byte sLanturnPose199
+.4byte sLanturnPose200
+.4byte sLanturnPose201
+.4byte sLanturnPose202
+.4byte sLanturnPose203
+.4byte sLanturnPose204
+.4byte sLanturnPose205
+.4byte sLanturnPose206
+.4byte sLanturnPose207
+.4byte sLanturnPose208
+.4byte sLanturnPose209
+.4byte sLanturnPose210
+.4byte sLanturnPose211
+.4byte sLanturnPose212
+.4byte sLanturnPose213
+.4byte sLanturnPose214
+.4byte sLanturnPose215
+.4byte sLanturnPose216
+.4byte sLanturnPose217
+.4byte sLanturnPose218
+.4byte sLanturnPose219
+.4byte sLanturnPose220
+.4byte sLanturnPose221
+.4byte sLanturnPose222
+.4byte sLanturnPose223
+.4byte sLanturnPose224
+.4byte sLanturnPose225
+.4byte sLanturnPose226
+sAxPositionsLanturn:
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte   -2,   -2, 	 -11,   -8, 	   8,   -6, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -6, 	   9,   -8, 	   0,  -10
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte    9,   -4, 	   8,  -13, 	  -4,   -2, 	   1,   -9
+.2byte    6,   -3, 	   9,   -9, 	  -7,   -3, 	   1,   -9
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    9,   -7, 	   3,   -6, 	   3,   -2, 	   1,   -9
+.2byte    8,   -7, 	   1,   -5, 	   0,   -1, 	   1,   -9
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    3,  -16, 	 -10,  -11, 	   8,   -6, 	  -1,  -11
+.2byte    6,  -14, 	  -7,  -14, 	   7,   -4, 	   1,  -11
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   9,   -8, 	 -10,   -9, 	   0,  -11
+.2byte    0,  -10, 	   8,   -9, 	 -11,   -8, 	  -1,  -11
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -5,  -16, 	   8,  -11, 	 -10,   -6, 	  -1,  -11
+.2byte   -8,  -14, 	   5,  -14, 	  -9,   -4, 	  -3,  -11
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte  -11,   -7, 	  -5,   -6, 	  -5,   -2, 	  -3,   -9
+.2byte  -10,   -7, 	  -3,   -5, 	  -2,   -1, 	  -3,   -9
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -11,   -4, 	 -10,  -13, 	   2,   -2, 	  -3,   -9
+.2byte   -8,   -3, 	 -11,   -9, 	   5,   -3, 	  -3,   -9
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte   -2,   -2, 	 -11,   -8, 	   8,   -6, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -6, 	   9,   -8, 	   0,  -10
+.2byte   -1,    1, 	 -11,   -1, 	   9,   -1, 	  -1,   -5
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte    9,   -4, 	   8,  -13, 	  -4,   -2, 	   1,   -9
+.2byte    6,   -3, 	   9,   -9, 	  -7,   -3, 	   1,   -9
+.2byte    3,   -2, 	   7,   -6, 	  -6,    0, 	   0,   -7
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    9,   -7, 	   3,   -6, 	   3,   -2, 	   1,   -9
+.2byte    8,   -7, 	   1,   -5, 	   0,   -1, 	   1,   -9
+.2byte    5,   -5, 	   4,   -8, 	   1,   -1, 	   1,   -9
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    3,  -16, 	 -10,  -11, 	   8,   -6, 	  -1,  -11
+.2byte    6,  -14, 	  -7,  -14, 	   7,   -4, 	   1,  -11
+.2byte    3,   -7, 	  -3,  -10, 	   3,   -2, 	  -1,   -9
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   9,   -8, 	 -10,   -9, 	   0,  -11
+.2byte    0,  -10, 	   8,   -9, 	 -11,   -8, 	  -1,  -11
+.2byte   -1,  -11, 	   9,   -7, 	 -11,   -7, 	  -1,  -13
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -5,  -16, 	   8,  -11, 	 -10,   -6, 	  -1,  -11
+.2byte   -8,  -14, 	   5,  -14, 	  -9,   -4, 	  -3,  -11
+.2byte   -4,   -9, 	   2,  -12, 	  -4,   -4, 	   0,  -11
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte  -11,   -7, 	  -5,   -6, 	  -5,   -2, 	  -3,   -9
+.2byte  -10,   -7, 	  -3,   -5, 	  -2,   -1, 	  -3,   -9
+.2byte   -6,   -5, 	  -5,   -8, 	  -2,   -1, 	  -2,   -9
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -11,   -4, 	 -10,  -13, 	   2,   -2, 	  -3,   -9
+.2byte   -8,   -3, 	 -11,   -9, 	   5,   -3, 	  -3,   -9
+.2byte   -5,   -2, 	  -9,   -6, 	   4,    0, 	  -2,   -7
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte   -2,   -2, 	 -11,   -8, 	   8,   -6, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -6, 	   9,   -8, 	   0,  -10
+.2byte   -1,    1, 	 -11,   -1, 	   9,   -1, 	  -1,   -5
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte    9,   -4, 	   8,  -13, 	  -4,   -2, 	   1,   -9
+.2byte    6,   -3, 	   9,   -9, 	  -7,   -3, 	   1,   -9
+.2byte    3,   -2, 	   7,   -6, 	  -6,    0, 	   0,   -7
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    9,   -7, 	   3,   -6, 	   3,   -2, 	   1,   -9
+.2byte    8,   -7, 	   1,   -5, 	   0,   -1, 	   1,   -9
+.2byte    5,   -5, 	   4,   -8, 	   1,   -1, 	   1,   -9
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    3,  -16, 	 -10,  -11, 	   8,   -6, 	  -1,  -11
+.2byte    6,  -14, 	  -7,  -14, 	   7,   -4, 	   1,  -11
+.2byte    3,   -7, 	  -3,  -10, 	   3,   -2, 	  -1,   -9
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   9,   -8, 	 -10,   -9, 	   0,  -11
+.2byte    0,  -10, 	   8,   -9, 	 -11,   -8, 	  -1,  -11
+.2byte   -1,  -11, 	   9,   -7, 	 -11,   -7, 	  -1,  -13
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -5,  -16, 	   8,  -11, 	 -10,   -6, 	  -1,  -11
+.2byte   -8,  -14, 	   5,  -14, 	  -9,   -4, 	  -3,  -11
+.2byte   -4,   -9, 	   2,  -12, 	  -4,   -4, 	   0,  -11
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte  -11,   -7, 	  -5,   -6, 	  -5,   -2, 	  -3,   -9
+.2byte  -10,   -7, 	  -3,   -5, 	  -2,   -1, 	  -3,   -9
+.2byte   -6,   -5, 	  -5,   -8, 	  -2,   -1, 	  -2,   -9
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -11,   -4, 	 -10,  -13, 	   2,   -2, 	  -3,   -9
+.2byte   -8,   -3, 	 -11,   -9, 	   5,   -3, 	  -3,   -9
+.2byte   -5,   -2, 	  -9,   -6, 	   4,    0, 	  -2,   -7
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte   -2,   -2, 	 -11,   -8, 	   8,   -6, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -6, 	   9,   -8, 	   0,  -10
+.2byte   -1,  -17, 	  -8,   -5, 	   6,   -5, 	  -1,  -10
+.2byte   -1,   -2, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte    9,   -4, 	   8,  -13, 	  -4,   -2, 	   1,   -9
+.2byte    6,   -3, 	   9,   -9, 	  -7,   -3, 	   1,   -9
+.2byte    3,  -14, 	   8,   -5, 	   1,   -3, 	   0,   -8
+.2byte    4,   -2, 	   8,   -6, 	  -5,    0, 	   1,   -7
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    9,   -7, 	   3,   -6, 	   3,   -2, 	   1,   -9
+.2byte    8,   -7, 	   1,   -5, 	   0,   -1, 	   1,   -9
+.2byte    4,  -16, 	   4,  -11, 	   6,   -4, 	  -1,   -9
+.2byte    4,   -4, 	   3,   -7, 	   0,    0, 	   0,   -8
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    3,  -16, 	 -10,  -11, 	   8,   -6, 	  -1,  -11
+.2byte    6,  -14, 	  -7,  -14, 	   7,   -4, 	   1,  -11
+.2byte    3,  -16, 	  -7,   -9, 	   6,   -4, 	   0,  -10
+.2byte    4,   -8, 	  -2,  -11, 	   4,   -3, 	   0,  -10
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   9,   -8, 	 -10,   -9, 	   0,  -11
+.2byte    0,  -10, 	   8,   -9, 	 -11,   -8, 	  -1,  -11
+.2byte   -1,  -18, 	   7,   -5, 	  -9,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -5,  -16, 	   8,  -11, 	 -10,   -6, 	  -1,  -11
+.2byte   -8,  -14, 	   5,  -14, 	  -9,   -4, 	  -3,  -11
+.2byte   -4,  -16, 	   6,   -9, 	  -7,   -4, 	  -1,  -10
+.2byte   -5,   -8, 	   1,  -11, 	  -5,   -3, 	  -1,  -10
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte  -11,   -7, 	  -5,   -6, 	  -5,   -2, 	  -3,   -9
+.2byte  -10,   -7, 	  -3,   -5, 	  -2,   -1, 	  -3,   -9
+.2byte   -6,  -16, 	  -6,  -11, 	  -8,   -4, 	  -1,   -9
+.2byte   -6,   -4, 	  -5,   -7, 	  -2,    0, 	  -2,   -8
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -11,   -4, 	 -10,  -13, 	   2,   -2, 	  -3,   -9
+.2byte   -8,   -3, 	 -11,   -9, 	   5,   -3, 	  -3,   -9
+.2byte   -4,  -14, 	  -9,   -5, 	  -2,   -3, 	  -1,   -8
+.2byte   -5,   -2, 	  -9,   -6, 	   4,    0, 	  -2,   -7
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte   -6,   -3, 	  -4,  -12, 	   4,   -6, 	  -3,   -8
+.2byte   -5,   -3, 	  -4,  -12, 	   4,   -6, 	  -3,   -8
+.2byte    0,   -3, 	 -10,  -14, 	  10,  -14, 	   0,  -12
+.2byte    4,   -3, 	   8,  -13, 	  -8,   -9, 	   0,  -10
+.2byte    5,   -7, 	  -2,  -12, 	  -3,   -6, 	  -1,  -11
+.2byte    4,  -12, 	  -7,  -12, 	   2,   -4, 	  -1,  -11
+.2byte    0,   -9, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -5,  -12, 	   6,  -12, 	  -3,   -4, 	   0,  -11
+.2byte   -6,   -7, 	   1,  -12, 	   2,   -6, 	   0,  -11
+.2byte   -5,   -3, 	  -9,  -13, 	   7,   -9, 	  -1,  -10
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte   -2,   -2, 	 -11,   -8, 	   8,   -6, 	  -1,  -10
+.2byte    0,   -2, 	 -10,   -6, 	   9,   -8, 	   0,  -10
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte    9,   -4, 	   8,  -13, 	  -4,   -2, 	   1,   -9
+.2byte    6,   -3, 	   9,   -9, 	  -7,   -3, 	   1,   -9
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    9,   -7, 	   3,   -6, 	   3,   -2, 	   1,   -9
+.2byte    8,   -7, 	   1,   -5, 	   0,   -1, 	   1,   -9
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    3,  -16, 	 -10,  -11, 	   8,   -6, 	  -1,  -11
+.2byte    6,  -14, 	  -7,  -14, 	   7,   -4, 	   1,  -11
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   9,   -8, 	 -10,   -9, 	   0,  -11
+.2byte    0,  -10, 	   8,   -9, 	 -11,   -8, 	  -1,  -11
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -5,  -16, 	   8,  -11, 	 -10,   -6, 	  -1,  -11
+.2byte   -8,  -14, 	   5,  -14, 	  -9,   -4, 	  -3,  -11
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte  -11,   -7, 	  -5,   -6, 	  -5,   -2, 	  -3,   -9
+.2byte  -10,   -7, 	  -3,   -5, 	  -2,   -1, 	  -3,   -9
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -11,   -4, 	 -10,  -13, 	   2,   -2, 	  -3,   -9
+.2byte   -8,   -3, 	 -11,   -9, 	   5,   -3, 	  -3,   -9
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte   -1,  -16, 	  -8,   -4, 	   6,   -4, 	  -1,   -9
+.2byte    3,  -15, 	   8,   -6, 	   1,   -4, 	   0,   -9
+.2byte    5,  -16, 	   5,  -11, 	   7,   -4, 	   0,   -9
+.2byte    3,  -16, 	  -7,   -9, 	   6,   -4, 	   0,  -10
+.2byte   -1,  -17, 	   7,   -4, 	  -9,   -4, 	  -1,  -10
+.2byte   -4,  -16, 	   6,   -9, 	  -7,   -4, 	  -1,  -10
+.2byte   -7,  -16, 	  -7,  -11, 	  -9,   -4, 	  -2,   -9
+.2byte   -4,  -15, 	  -9,   -6, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte   -1,  -17, 	  -8,   -5, 	   6,   -5, 	  -1,  -10
+.2byte   -1,   -2, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+.2byte    3,  -14, 	   8,   -5, 	   1,   -3, 	   0,   -8
+.2byte    4,   -2, 	   8,   -6, 	  -5,    0, 	   1,   -7
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    4,  -16, 	   4,  -11, 	   6,   -4, 	  -1,   -9
+.2byte    4,   -4, 	   3,   -7, 	   0,    0, 	   0,   -8
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    3,  -16, 	  -7,   -9, 	   6,   -4, 	   0,  -10
+.2byte    4,   -8, 	  -2,  -11, 	   4,   -3, 	   0,  -10
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -18, 	   7,   -5, 	  -9,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,  -12
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -4,  -16, 	   6,   -9, 	  -7,   -4, 	  -1,  -10
+.2byte   -5,   -8, 	   1,  -11, 	  -5,   -3, 	  -1,  -10
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte   -6,  -16, 	  -6,  -11, 	  -8,   -4, 	  -1,   -9
+.2byte   -6,   -4, 	  -5,   -7, 	  -2,    0, 	  -2,   -8
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte   -4,  -14, 	  -9,   -5, 	  -2,   -3, 	  -1,   -8
+.2byte   -5,   -2, 	  -9,   -6, 	   4,    0, 	  -2,   -7
+.2byte   -1,   -2, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte   -4,   -4, 	  -8,   -8, 	   5,   -2, 	  -1,   -9
+.2byte   -5,   -5, 	  -4,   -8, 	  -1,   -1, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -4,   -2, 	   0,   -9
+.2byte   -1,   -8, 	   9,   -4, 	 -11,   -4, 	  -1,  -10
+.2byte    3,   -7, 	  -3,  -10, 	   3,   -2, 	  -1,   -9
+.2byte    3,   -5, 	   2,   -8, 	  -1,   -1, 	  -1,   -9
+.2byte    3,   -4, 	   7,   -8, 	  -6,   -2, 	   0,   -9
+.2byte   -1,   -2, 	 -12,   -7, 	  10,   -7, 	  -1,  -10
+.2byte  -10,   -4, 	 -12,  -12, 	   5,   -2, 	  -2,   -9
+.2byte  -10,   -7, 	  -5,   -6, 	  -3,   -1, 	  -3,   -9
+.2byte   -7,  -15, 	   7,  -13, 	 -11,   -4, 	  -2,  -10
+.2byte   -1,   -9, 	  10,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte    5,  -15, 	  -9,  -13, 	   9,   -4, 	   0,  -10
+.2byte    8,   -7, 	   3,   -6, 	   1,   -1, 	   1,   -9
+.2byte    8,   -4, 	  10,  -12, 	  -7,   -2, 	   0,   -9
+sLanturnAnimTable1:
+.4byte sLanturnAnims_1_1
+.4byte sLanturnAnims_1_2
+.4byte sLanturnAnims_1_3
+.4byte sLanturnAnims_1_4
+.4byte sLanturnAnims_1_5
+.4byte sLanturnAnims_1_6
+.4byte sLanturnAnims_1_7
+.4byte sLanturnAnims_1_8
+sLanturnAnimTable2:
+.4byte sLanturnAnims_2_1
+.4byte sLanturnAnims_2_2
+.4byte sLanturnAnims_2_3
+.4byte sLanturnAnims_2_4
+.4byte sLanturnAnims_2_5
+.4byte sLanturnAnims_2_6
+.4byte sLanturnAnims_2_7
+.4byte sLanturnAnims_2_8
+sLanturnAnimTable3:
+.4byte sLanturnAnims_3_1
+.4byte sLanturnAnims_3_2
+.4byte sLanturnAnims_3_3
+.4byte sLanturnAnims_3_4
+.4byte sLanturnAnims_3_5
+.4byte sLanturnAnims_3_6
+.4byte sLanturnAnims_3_7
+.4byte sLanturnAnims_3_8
+sLanturnAnimTable4:
+.4byte sLanturnAnims_4_1
+.4byte sLanturnAnims_4_2
+.4byte sLanturnAnims_4_3
+.4byte sLanturnAnims_4_4
+.4byte sLanturnAnims_4_5
+.4byte sLanturnAnims_4_6
+.4byte sLanturnAnims_4_7
+.4byte sLanturnAnims_4_8
+sLanturnAnimTable5:
+.4byte sLanturnAnims_5_1
+.4byte sLanturnAnims_5_2
+.4byte sLanturnAnims_5_3
+.4byte sLanturnAnims_5_4
+.4byte sLanturnAnims_5_5
+.4byte sLanturnAnims_5_6
+.4byte sLanturnAnims_5_7
+.4byte sLanturnAnims_5_8
+sLanturnAnimTable6:
+.4byte sLanturnAnims_6_1
+.4byte sLanturnAnims_6_1
+.4byte sLanturnAnims_6_1
+.4byte sLanturnAnims_6_1
+.4byte sLanturnAnims_6_1
+.4byte sLanturnAnims_6_1
+.4byte sLanturnAnims_6_1
+.4byte sLanturnAnims_6_1
+sLanturnAnimTable7:
+.4byte sLanturnAnims_7_1
+.4byte sLanturnAnims_7_2
+.4byte sLanturnAnims_7_3
+.4byte sLanturnAnims_7_4
+.4byte sLanturnAnims_7_5
+.4byte sLanturnAnims_7_6
+.4byte sLanturnAnims_7_7
+.4byte sLanturnAnims_7_8
+sLanturnAnimTable8:
+.4byte sLanturnAnims_8_1
+.4byte sLanturnAnims_8_2
+.4byte sLanturnAnims_8_3
+.4byte sLanturnAnims_8_4
+.4byte sLanturnAnims_8_5
+.4byte sLanturnAnims_8_6
+.4byte sLanturnAnims_8_7
+.4byte sLanturnAnims_8_8
+sLanturnAnimTable9:
+.4byte sLanturnAnims_9_1
+.4byte sLanturnAnims_9_2
+.4byte sLanturnAnims_9_3
+.4byte sLanturnAnims_9_4
+.4byte sLanturnAnims_9_5
+.4byte sLanturnAnims_9_6
+.4byte sLanturnAnims_9_7
+.4byte sLanturnAnims_9_8
+sLanturnAnimTable10:
+.4byte sLanturnAnims_10_1
+.4byte sLanturnAnims_10_2
+.4byte sLanturnAnims_10_3
+.4byte sLanturnAnims_10_4
+.4byte sLanturnAnims_10_5
+.4byte sLanturnAnims_10_6
+.4byte sLanturnAnims_10_7
+.4byte sLanturnAnims_10_8
+sLanturnAnimTable11:
+.4byte sLanturnAnims_11_1
+.4byte sLanturnAnims_11_2
+.4byte sLanturnAnims_11_3
+.4byte sLanturnAnims_11_4
+.4byte sLanturnAnims_11_5
+.4byte sLanturnAnims_11_6
+.4byte sLanturnAnims_11_7
+.4byte sLanturnAnims_11_8
+sLanturnAnimTable12:
+.4byte sLanturnAnims_12_1
+.4byte sLanturnAnims_12_2
+.4byte sLanturnAnims_12_3
+.4byte sLanturnAnims_12_4
+.4byte sLanturnAnims_12_5
+.4byte sLanturnAnims_12_6
+.4byte sLanturnAnims_12_7
+.4byte sLanturnAnims_12_8
+sLanturnAnimTable13:
+.4byte sLanturnAnims_13_1
+.4byte sLanturnAnims_13_2
+.4byte sLanturnAnims_13_3
+.4byte sLanturnAnims_13_4
+.4byte sLanturnAnims_13_5
+.4byte sLanturnAnims_13_6
+.4byte sLanturnAnims_13_7
+.4byte sLanturnAnims_13_8
+sAxAnimationsLanturn:
+.4byte sLanturnAnimTable1
+.4byte sLanturnAnimTable2
+.4byte sLanturnAnimTable3
+.4byte sLanturnAnimTable4
+.4byte sLanturnAnimTable5
+.4byte sLanturnAnimTable6
+.4byte sLanturnAnimTable7
+.4byte sLanturnAnimTable8
+.4byte sLanturnAnimTable9
+.4byte sLanturnAnimTable10
+.4byte sLanturnAnimTable11
+.4byte sLanturnAnimTable12
+.4byte sLanturnAnimTable13
+sAxSpritesLanturn:
+.4byte sLanturnSprites1
+.4byte sLanturnSprites2
+.4byte sLanturnSprites3
+.4byte sLanturnSprites4
+.4byte sLanturnSprites5
+.4byte sLanturnSprites6
+.4byte sLanturnSprites7
+.4byte sLanturnSprites8
+.4byte sLanturnSprites9
+.4byte sLanturnSprites10
+.4byte sLanturnSprites11
+.4byte sLanturnSprites12
+.4byte sLanturnSprites13
+.4byte sLanturnSprites14
+.4byte sLanturnSprites15
+.4byte sLanturnSprites16
+.4byte sLanturnSprites17
+.4byte sLanturnSprites18
+.4byte sLanturnSprites19
+.4byte sLanturnSprites20
+.4byte sLanturnSprites21
+.4byte sLanturnSprites22
+.4byte sLanturnSprites23
+.4byte sLanturnSprites24
+.4byte sLanturnSprites25
+.4byte sLanturnSprites26
+.4byte sLanturnSprites27
+.4byte sLanturnSprites28
+.4byte sLanturnSprites29
+.4byte sLanturnSprites30
+.4byte sLanturnSprites31
+.4byte sLanturnSprites32
+sAxMainLanturn:
+ax_main sAxPosesLanturn, sAxAnimationsLanturn, 13, sAxSpritesLanturn, sAxPositionsLanturn

--- a/data/ax/lapras.inc
+++ b/data/ax/lapras.inc
@@ -1,0 +1,3321 @@
+.global gAxLapras
+gAxLapras:
+ax_siro sAxMainLapras
+sLaprasPose1:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose2:
+ax_pose 1, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose3:
+ax_pose 2, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose4:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose5:
+ax_pose 4, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose6:
+ax_pose 5, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose7:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose8:
+ax_pose 7, 0x01e1, 0xd0ce, 0x5c00
+ax_pose_terminator
+sLaprasPose9:
+ax_pose 8, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose10:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose11:
+ax_pose 10, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose12:
+ax_pose 11, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose13:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose14:
+ax_pose 13, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose15:
+ax_pose 14, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose16:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose17:
+ax_pose 10, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose18:
+ax_pose 11, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose19:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose20:
+ax_pose 7, 0x01e1, 0xc0f1, 0x5c00
+ax_pose_terminator
+sLaprasPose21:
+ax_pose 8, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose22:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose23:
+ax_pose 4, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose24:
+ax_pose 5, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose25:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose26:
+ax_pose 1, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose27:
+ax_pose 2, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose28:
+ax_pose 15, 0x01dd, 0x80ed, 0x5c00
+ax_pose 16, 0x41fd, 0x80ed, 0x5c10
+ax_pose 17, 0x81fd, 0x010d, 0x5c18
+ax_pose_terminator
+sLaprasPose29:
+ax_pose 18, 0x01e7, 0x80ec, 0x5c00
+ax_pose 19, 0x81f7, 0x010c, 0x5c10
+ax_pose_terminator
+sLaprasPose30:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose31:
+ax_pose 4, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose32:
+ax_pose 5, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose33:
+ax_pose 20, 0x01de, 0x90f4, 0x5c00
+ax_pose 21, 0x41fe, 0x90f4, 0x5c10
+ax_pose 22, 0x81f6, 0x10ec, 0x5c18
+ax_pose_terminator
+sLaprasPose34:
+ax_pose 23, 0x01e9, 0x90f4, 0x5c00
+ax_pose 24, 0x81f9, 0x10ec, 0x5c10
+ax_pose_terminator
+sLaprasPose35:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose36:
+ax_pose 7, 0x01e1, 0xd0ce, 0x5c00
+ax_pose_terminator
+sLaprasPose37:
+ax_pose 8, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose38:
+ax_pose 25, 0x01db, 0x90ec, 0x5c00
+ax_pose 26, 0x41fb, 0x90ec, 0x5c10
+ax_pose_terminator
+sLaprasPose39:
+ax_pose 27, 0x01e4, 0x90fd, 0x5c00
+ax_pose 28, 0x81ec, 0x90ed, 0x5c10
+ax_pose 29, 0x0204, 0x10fd, 0x5c18
+ax_pose_terminator
+sLaprasPose40:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose41:
+ax_pose 10, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose42:
+ax_pose 11, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose43:
+ax_pose 30, 0x01dd, 0x90f1, 0x5c00
+ax_pose 31, 0x41fd, 0x50f1, 0x5c10
+ax_pose 32, 0x01fd, 0x10e9, 0x5c14
+ax_pose 33, 0x0205, 0x10f9, 0x5c15
+ax_pose_terminator
+sLaprasPose44:
+ax_pose 34, 0x01df, 0x90f9, 0x5c00
+ax_pose 35, 0x41ff, 0x90f1, 0x5c10
+ax_pose 36, 0x01ff, 0x10e9, 0x5c18
+ax_pose 37, 0x81ef, 0x10f1, 0x5c19
+ax_pose_terminator
+sLaprasPose45:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose46:
+ax_pose 13, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose47:
+ax_pose 14, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose48:
+ax_pose 38, 0x01de, 0x80ea, 0x5c00
+ax_pose 39, 0x41fe, 0x40ea, 0x5c10
+ax_pose 40, 0x4206, 0x40f2, 0x5c14
+ax_pose 41, 0x01f6, 0x410a, 0x5c18
+ax_pose_terminator
+sLaprasPose49:
+ax_pose 42, 0x01e2, 0x80ec, 0x5c00
+ax_pose 43, 0x4202, 0x40ec, 0x5c10
+ax_pose 44, 0x81f7, 0x010c, 0x5c14
+ax_pose_terminator
+sLaprasPose50:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose51:
+ax_pose 10, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose52:
+ax_pose 11, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose53:
+ax_pose 30, 0x01dd, 0x80ee, 0x5c00
+ax_pose 31, 0x41fd, 0x40ee, 0x5c10
+ax_pose 32, 0x01fd, 0x010e, 0x5c14
+ax_pose 33, 0x0205, 0x00fe, 0x5c15
+ax_pose_terminator
+sLaprasPose54:
+ax_pose 34, 0x01df, 0x80e6, 0x5c00
+ax_pose 35, 0x41ff, 0x80ee, 0x5c10
+ax_pose 36, 0x01ff, 0x010e, 0x5c18
+ax_pose 37, 0x81ef, 0x0106, 0x5c19
+ax_pose_terminator
+sLaprasPose55:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose56:
+ax_pose 7, 0x01e1, 0xc0f1, 0x5c00
+ax_pose_terminator
+sLaprasPose57:
+ax_pose 8, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose58:
+ax_pose 25, 0x01db, 0x80f3, 0x5c00
+ax_pose 26, 0x41fb, 0x80f3, 0x5c10
+ax_pose_terminator
+sLaprasPose59:
+ax_pose 27, 0x01e4, 0x80e2, 0x5c00
+ax_pose 28, 0x81ec, 0x8102, 0x5c10
+ax_pose 29, 0x0204, 0x00fa, 0x5c18
+ax_pose_terminator
+sLaprasPose60:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose61:
+ax_pose 4, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose62:
+ax_pose 5, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose63:
+ax_pose 20, 0x01de, 0x80eb, 0x5c00
+ax_pose 21, 0x41fe, 0x80eb, 0x5c10
+ax_pose 22, 0x81f6, 0x010b, 0x5c18
+ax_pose_terminator
+sLaprasPose64:
+ax_pose 23, 0x01e9, 0x80eb, 0x5c00
+ax_pose 24, 0x81f9, 0x010b, 0x5c10
+ax_pose_terminator
+sLaprasPose65:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose66:
+ax_pose 1, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose67:
+ax_pose 2, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose68:
+ax_pose 15, 0x01dd, 0x80ed, 0x5c00
+ax_pose 16, 0x41fd, 0x80ed, 0x5c10
+ax_pose 17, 0x81fd, 0x010d, 0x5c18
+ax_pose_terminator
+sLaprasPose69:
+ax_pose 18, 0x01e7, 0x80ec, 0x5c00
+ax_pose 19, 0x81f7, 0x010c, 0x5c10
+ax_pose_terminator
+sLaprasPose70:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose71:
+ax_pose 4, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose72:
+ax_pose 5, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose73:
+ax_pose 20, 0x01de, 0x90f4, 0x5c00
+ax_pose 21, 0x41fe, 0x90f4, 0x5c10
+ax_pose 22, 0x81f6, 0x10ec, 0x5c18
+ax_pose_terminator
+sLaprasPose74:
+ax_pose 23, 0x01e9, 0x90f4, 0x5c00
+ax_pose 24, 0x81f9, 0x10ec, 0x5c10
+ax_pose_terminator
+sLaprasPose75:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose76:
+ax_pose 7, 0x01e1, 0xd0ce, 0x5c00
+ax_pose_terminator
+sLaprasPose77:
+ax_pose 8, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose78:
+ax_pose 25, 0x01db, 0x90ec, 0x5c00
+ax_pose 26, 0x41fb, 0x90ec, 0x5c10
+ax_pose_terminator
+sLaprasPose79:
+ax_pose 27, 0x01e4, 0x90fd, 0x5c00
+ax_pose 28, 0x81ec, 0x90ed, 0x5c10
+ax_pose 29, 0x0204, 0x10fd, 0x5c18
+ax_pose_terminator
+sLaprasPose80:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose81:
+ax_pose 10, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose82:
+ax_pose 11, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose83:
+ax_pose 30, 0x01dd, 0x90f1, 0x5c00
+ax_pose 31, 0x41fd, 0x50f1, 0x5c10
+ax_pose 32, 0x01fd, 0x10e9, 0x5c14
+ax_pose 33, 0x0205, 0x10f9, 0x5c15
+ax_pose_terminator
+sLaprasPose84:
+ax_pose 34, 0x01df, 0x90f9, 0x5c00
+ax_pose 35, 0x41ff, 0x90f1, 0x5c10
+ax_pose 36, 0x01ff, 0x10e9, 0x5c18
+ax_pose 37, 0x81ef, 0x10f1, 0x5c19
+ax_pose_terminator
+sLaprasPose85:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose86:
+ax_pose 13, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose87:
+ax_pose 14, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose88:
+ax_pose 38, 0x01de, 0x80ea, 0x5c00
+ax_pose 39, 0x41fe, 0x40ea, 0x5c10
+ax_pose 40, 0x4206, 0x40f2, 0x5c14
+ax_pose 41, 0x01f6, 0x410a, 0x5c18
+ax_pose_terminator
+sLaprasPose89:
+ax_pose 42, 0x01e2, 0x80ec, 0x5c00
+ax_pose 43, 0x4202, 0x40ec, 0x5c10
+ax_pose 44, 0x81f7, 0x010c, 0x5c14
+ax_pose_terminator
+sLaprasPose90:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose91:
+ax_pose 10, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose92:
+ax_pose 11, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose93:
+ax_pose 30, 0x01dd, 0x80ee, 0x5c00
+ax_pose 31, 0x41fd, 0x40ee, 0x5c10
+ax_pose 32, 0x01fd, 0x010e, 0x5c14
+ax_pose 33, 0x0205, 0x00fe, 0x5c15
+ax_pose_terminator
+sLaprasPose94:
+ax_pose 34, 0x01df, 0x80e6, 0x5c00
+ax_pose 35, 0x41ff, 0x80ee, 0x5c10
+ax_pose 36, 0x01ff, 0x010e, 0x5c18
+ax_pose 37, 0x81ef, 0x0106, 0x5c19
+ax_pose_terminator
+sLaprasPose95:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose96:
+ax_pose 7, 0x01e1, 0xc0f1, 0x5c00
+ax_pose_terminator
+sLaprasPose97:
+ax_pose 8, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose98:
+ax_pose 25, 0x01db, 0x80f3, 0x5c00
+ax_pose 26, 0x41fb, 0x80f3, 0x5c10
+ax_pose_terminator
+sLaprasPose99:
+ax_pose 27, 0x01e4, 0x80e2, 0x5c00
+ax_pose 28, 0x81ec, 0x8102, 0x5c10
+ax_pose 29, 0x0204, 0x00fa, 0x5c18
+ax_pose_terminator
+sLaprasPose100:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose101:
+ax_pose 4, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose102:
+ax_pose 5, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose103:
+ax_pose 20, 0x01de, 0x80eb, 0x5c00
+ax_pose 21, 0x41fe, 0x80eb, 0x5c10
+ax_pose 22, 0x81f6, 0x010b, 0x5c18
+ax_pose_terminator
+sLaprasPose104:
+ax_pose 23, 0x01e9, 0x80eb, 0x5c00
+ax_pose 24, 0x81f9, 0x010b, 0x5c10
+ax_pose_terminator
+sLaprasPose105:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose106:
+ax_pose 1, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose107:
+ax_pose 2, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose108:
+ax_pose 15, 0x01dd, 0x80ed, 0x5c00
+ax_pose 16, 0x41fd, 0x80ed, 0x5c10
+ax_pose 17, 0x81fd, 0x010d, 0x5c18
+ax_pose_terminator
+sLaprasPose109:
+ax_pose 18, 0x01e7, 0x80ec, 0x5c00
+ax_pose 19, 0x81f7, 0x010c, 0x5c10
+ax_pose_terminator
+sLaprasPose110:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose111:
+ax_pose 4, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose112:
+ax_pose 5, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose113:
+ax_pose 20, 0x01de, 0x90f4, 0x5c00
+ax_pose 21, 0x41fe, 0x90f4, 0x5c10
+ax_pose 22, 0x81f6, 0x10ec, 0x5c18
+ax_pose_terminator
+sLaprasPose114:
+ax_pose 23, 0x01e9, 0x90f4, 0x5c00
+ax_pose 24, 0x81f9, 0x10ec, 0x5c10
+ax_pose_terminator
+sLaprasPose115:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose116:
+ax_pose 7, 0x01e1, 0xd0ce, 0x5c00
+ax_pose_terminator
+sLaprasPose117:
+ax_pose 8, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose118:
+ax_pose 25, 0x01db, 0x90ec, 0x5c00
+ax_pose 26, 0x41fb, 0x90ec, 0x5c10
+ax_pose_terminator
+sLaprasPose119:
+ax_pose 27, 0x01e4, 0x90fd, 0x5c00
+ax_pose 28, 0x81ec, 0x90ed, 0x5c10
+ax_pose 29, 0x0204, 0x10fd, 0x5c18
+ax_pose_terminator
+sLaprasPose120:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose121:
+ax_pose 10, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose122:
+ax_pose 11, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose123:
+ax_pose 30, 0x01dd, 0x90f1, 0x5c00
+ax_pose 31, 0x41fd, 0x50f1, 0x5c10
+ax_pose 32, 0x01fd, 0x10e9, 0x5c14
+ax_pose 33, 0x0205, 0x10f9, 0x5c15
+ax_pose_terminator
+sLaprasPose124:
+ax_pose 34, 0x01df, 0x90f9, 0x5c00
+ax_pose 35, 0x41ff, 0x90f1, 0x5c10
+ax_pose 36, 0x01ff, 0x10e9, 0x5c18
+ax_pose 37, 0x81ef, 0x10f1, 0x5c19
+ax_pose_terminator
+sLaprasPose125:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose126:
+ax_pose 13, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose127:
+ax_pose 14, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose128:
+ax_pose 38, 0x01de, 0x80ea, 0x5c00
+ax_pose 39, 0x41fe, 0x40ea, 0x5c10
+ax_pose 40, 0x4206, 0x40f2, 0x5c14
+ax_pose 41, 0x01f6, 0x410a, 0x5c18
+ax_pose_terminator
+sLaprasPose129:
+ax_pose 42, 0x01e2, 0x80ec, 0x5c00
+ax_pose 43, 0x4202, 0x40ec, 0x5c10
+ax_pose 44, 0x81f7, 0x010c, 0x5c14
+ax_pose_terminator
+sLaprasPose130:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose131:
+ax_pose 10, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose132:
+ax_pose 11, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose133:
+ax_pose 30, 0x01dd, 0x80ee, 0x5c00
+ax_pose 31, 0x41fd, 0x40ee, 0x5c10
+ax_pose 32, 0x01fd, 0x010e, 0x5c14
+ax_pose 33, 0x0205, 0x00fe, 0x5c15
+ax_pose_terminator
+sLaprasPose134:
+ax_pose 34, 0x01df, 0x80e6, 0x5c00
+ax_pose 35, 0x41ff, 0x80ee, 0x5c10
+ax_pose 36, 0x01ff, 0x010e, 0x5c18
+ax_pose 37, 0x81ef, 0x0106, 0x5c19
+ax_pose_terminator
+sLaprasPose135:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose136:
+ax_pose 7, 0x01e1, 0xc0f1, 0x5c00
+ax_pose_terminator
+sLaprasPose137:
+ax_pose 8, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose138:
+ax_pose 25, 0x01db, 0x80f3, 0x5c00
+ax_pose 26, 0x41fb, 0x80f3, 0x5c10
+ax_pose_terminator
+sLaprasPose139:
+ax_pose 27, 0x01e4, 0x80e2, 0x5c00
+ax_pose 28, 0x81ec, 0x8102, 0x5c10
+ax_pose 29, 0x0204, 0x00fa, 0x5c18
+ax_pose_terminator
+sLaprasPose140:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose141:
+ax_pose 4, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose142:
+ax_pose 5, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose143:
+ax_pose 20, 0x01de, 0x80eb, 0x5c00
+ax_pose 21, 0x41fe, 0x80eb, 0x5c10
+ax_pose 22, 0x81f6, 0x010b, 0x5c18
+ax_pose_terminator
+sLaprasPose144:
+ax_pose 23, 0x01e9, 0x80eb, 0x5c00
+ax_pose 24, 0x81f9, 0x010b, 0x5c10
+ax_pose_terminator
+sLaprasPose145:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose146:
+ax_pose 1, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose147:
+ax_pose 2, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose148:
+ax_pose 45, 0x01e0, 0x80f0, 0x5c00
+ax_pose 46, 0x4200, 0x40e8, 0x5c10
+ax_pose 47, 0x4200, 0x0108, 0x5c14
+ax_pose_terminator
+sLaprasPose149:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose150:
+ax_pose 4, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose151:
+ax_pose 5, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose152:
+ax_pose 48, 0x01df, 0x90f3, 0x5c00
+ax_pose 49, 0x41ff, 0x50f3, 0x5c10
+ax_pose 50, 0x0207, 0x10f3, 0x5c14
+ax_pose 51, 0x01f8, 0x10eb, 0x5c15
+ax_pose_terminator
+sLaprasPose153:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose154:
+ax_pose 7, 0x01e1, 0xd0ce, 0x5c00
+ax_pose_terminator
+sLaprasPose155:
+ax_pose 8, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose156:
+ax_pose 52, 0x01e0, 0x90ee, 0x5c00
+ax_pose 53, 0x4200, 0x90ee, 0x5c10
+ax_pose 54, 0x01f8, 0x10e6, 0x5c18
+ax_pose_terminator
+sLaprasPose157:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose158:
+ax_pose 10, 0x01e1, 0xd0d7, 0x5c00
+ax_pose_terminator
+sLaprasPose159:
+ax_pose 11, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose160:
+ax_pose 55, 0x01de, 0x90f3, 0x5c00
+ax_pose 56, 0x81f6, 0x10eb, 0x5c10
+ax_pose 57, 0x41fe, 0x50f3, 0x5c12
+ax_pose 58, 0x0206, 0x10fa, 0x5c16
+ax_pose_terminator
+sLaprasPose161:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose162:
+ax_pose 13, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose163:
+ax_pose 14, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose164:
+ax_pose 59, 0x01dd, 0x80eb, 0x5c00
+ax_pose 60, 0x41fd, 0x80eb, 0x5c10
+ax_pose 61, 0x81f5, 0x010b, 0x5c18
+ax_pose 62, 0x0205, 0x010b, 0x5c1a
+ax_pose_terminator
+sLaprasPose165:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose166:
+ax_pose 10, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose167:
+ax_pose 11, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose168:
+ax_pose 55, 0x01de, 0x80ec, 0x5c00
+ax_pose 56, 0x81f6, 0x010c, 0x5c10
+ax_pose 57, 0x41fe, 0x40ec, 0x5c12
+ax_pose 58, 0x0206, 0x00fd, 0x5c16
+ax_pose_terminator
+sLaprasPose169:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose170:
+ax_pose 7, 0x01e1, 0xc0f1, 0x5c00
+ax_pose_terminator
+sLaprasPose171:
+ax_pose 8, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose172:
+ax_pose 52, 0x01e0, 0x80f1, 0x5c00
+ax_pose 53, 0x4200, 0x80f1, 0x5c10
+ax_pose 54, 0x01f8, 0x0111, 0x5c18
+ax_pose_terminator
+sLaprasPose173:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose174:
+ax_pose 4, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose175:
+ax_pose 5, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose176:
+ax_pose 48, 0x01df, 0x80ec, 0x5c00
+ax_pose 49, 0x41ff, 0x40ec, 0x5c10
+ax_pose 50, 0x0207, 0x0104, 0x5c14
+ax_pose 51, 0x01f8, 0x010c, 0x5c15
+ax_pose_terminator
+sLaprasPose177:
+ax_pose 63, 0x01ec, 0x80ed, 0x5c00
+ax_pose 64, 0x81ec, 0x410d, 0x5c10
+ax_pose_terminator
+sLaprasPose178:
+ax_pose 65, 0x01ec, 0x80ed, 0x5c00
+ax_pose 66, 0x81ec, 0x410d, 0x5c10
+ax_pose_terminator
+sLaprasPose179:
+ax_pose 67, 0x81d3, 0xc0ee, 0x5c00
+ax_pose 68, 0x81eb, 0x010e, 0x5c20
+ax_pose_terminator
+sLaprasPose180:
+ax_pose 69, 0x81d0, 0xd0ee, 0x5c00
+ax_pose 70, 0x81d0, 0x50e6, 0x5c20
+ax_pose_terminator
+sLaprasPose181:
+ax_pose 71, 0x81d4, 0xd0eb, 0x5c00
+ax_pose_terminator
+sLaprasPose182:
+ax_pose 72, 0x81d9, 0xd0ef, 0x5c00
+ax_pose 73, 0x81d9, 0x10e7, 0x5c20
+ax_pose_terminator
+sLaprasPose183:
+ax_pose 74, 0x81e6, 0x010f, 0x5c00
+ax_pose 75, 0x81d6, 0xc0ef, 0x5c02
+ax_pose_terminator
+sLaprasPose184:
+ax_pose 72, 0x81d9, 0xc0f1, 0x5c00
+ax_pose 73, 0x81d9, 0x0111, 0x5c20
+ax_pose_terminator
+sLaprasPose185:
+ax_pose 71, 0x81d4, 0xc0f5, 0x5c00
+ax_pose_terminator
+sLaprasPose186:
+ax_pose 69, 0x81d0, 0xc0f2, 0x5c00
+ax_pose 70, 0x81d0, 0x4112, 0x5c20
+ax_pose_terminator
+sLaprasPose187:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose188:
+ax_pose 2, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose189:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose190:
+ax_pose 5, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose191:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose192:
+ax_pose 8, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose193:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose194:
+ax_pose 11, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose195:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose196:
+ax_pose 14, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose197:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose198:
+ax_pose 11, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose199:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose200:
+ax_pose 8, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose201:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose202:
+ax_pose 5, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose203:
+ax_pose 18, 0x01e7, 0x80ec, 0x5c00
+ax_pose 19, 0x81f7, 0x010c, 0x5c10
+ax_pose_terminator
+sLaprasPose204:
+ax_pose 23, 0x01e9, 0x80ee, 0x5c00
+ax_pose 24, 0x81f9, 0x010e, 0x5c10
+ax_pose_terminator
+sLaprasPose205:
+ax_pose 27, 0x01e4, 0x80e5, 0x5c00
+ax_pose 28, 0x81ec, 0x8105, 0x5c10
+ax_pose 29, 0x0204, 0x00fd, 0x5c18
+ax_pose_terminator
+sLaprasPose206:
+ax_pose 34, 0x01df, 0x80ea, 0x5c00
+ax_pose 35, 0x41ff, 0x80f2, 0x5c10
+ax_pose 36, 0x01ff, 0x0112, 0x5c18
+ax_pose 37, 0x81ef, 0x010a, 0x5c19
+ax_pose_terminator
+sLaprasPose207:
+ax_pose 42, 0x01e2, 0x80ec, 0x5c00
+ax_pose 43, 0x4202, 0x40ec, 0x5c10
+ax_pose 44, 0x81f7, 0x010c, 0x5c14
+ax_pose_terminator
+sLaprasPose208:
+ax_pose 34, 0x01df, 0x90f6, 0x5c00
+ax_pose 35, 0x41ff, 0x90ee, 0x5c10
+ax_pose 36, 0x01ff, 0x10e6, 0x5c18
+ax_pose 37, 0x81ef, 0x10ee, 0x5c19
+ax_pose_terminator
+sLaprasPose209:
+ax_pose 27, 0x01e4, 0x90fb, 0x5c00
+ax_pose 28, 0x81ec, 0x90eb, 0x5c10
+ax_pose 29, 0x0204, 0x10fb, 0x5c18
+ax_pose_terminator
+sLaprasPose210:
+ax_pose 23, 0x01e9, 0x90f2, 0x5c00
+ax_pose 24, 0x81f9, 0x10ea, 0x5c10
+ax_pose_terminator
+sLaprasPose211:
+ax_pose 45, 0x01df, 0x80f0, 0x5c00
+ax_pose 46, 0x41ff, 0x40e8, 0x5c10
+ax_pose 47, 0x41ff, 0x0108, 0x5c14
+ax_pose_terminator
+sLaprasPose212:
+ax_pose 48, 0x01df, 0x90f3, 0x5c00
+ax_pose 49, 0x41ff, 0x50f3, 0x5c10
+ax_pose 50, 0x0207, 0x10f3, 0x5c14
+ax_pose 51, 0x01f8, 0x10eb, 0x5c15
+ax_pose_terminator
+sLaprasPose213:
+ax_pose 52, 0x01df, 0x90f0, 0x5c00
+ax_pose 53, 0x41ff, 0x90f0, 0x5c10
+ax_pose 54, 0x01f7, 0x10e8, 0x5c18
+ax_pose_terminator
+sLaprasPose214:
+ax_pose 55, 0x01de, 0x90f3, 0x5c00
+ax_pose 56, 0x81f6, 0x10eb, 0x5c10
+ax_pose 57, 0x41fe, 0x50f3, 0x5c12
+ax_pose 58, 0x0206, 0x10fa, 0x5c16
+ax_pose_terminator
+sLaprasPose215:
+ax_pose 59, 0x01dd, 0x80eb, 0x5c00
+ax_pose 60, 0x41fd, 0x80eb, 0x5c10
+ax_pose 61, 0x81f5, 0x010b, 0x5c18
+ax_pose 62, 0x0205, 0x010b, 0x5c1a
+ax_pose_terminator
+sLaprasPose216:
+ax_pose 55, 0x01de, 0x80ec, 0x5c00
+ax_pose 56, 0x81f6, 0x010c, 0x5c10
+ax_pose 57, 0x41fe, 0x40ec, 0x5c12
+ax_pose 58, 0x0206, 0x00fd, 0x5c16
+ax_pose_terminator
+sLaprasPose217:
+ax_pose 52, 0x01df, 0x80ef, 0x5c00
+ax_pose 53, 0x41ff, 0x80ef, 0x5c10
+ax_pose 54, 0x01f7, 0x010f, 0x5c18
+ax_pose_terminator
+sLaprasPose218:
+ax_pose 48, 0x01df, 0x80ec, 0x5c00
+ax_pose 49, 0x41ff, 0x40ec, 0x5c10
+ax_pose 50, 0x0207, 0x0104, 0x5c14
+ax_pose 51, 0x01f8, 0x010c, 0x5c15
+ax_pose_terminator
+sLaprasPose219:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose220:
+ax_pose 15, 0x01dd, 0x80ed, 0x5c00
+ax_pose 16, 0x41fd, 0x80ed, 0x5c10
+ax_pose 17, 0x81fd, 0x010d, 0x5c18
+ax_pose_terminator
+sLaprasPose221:
+ax_pose 18, 0x01e7, 0x80ec, 0x5c00
+ax_pose 19, 0x81f7, 0x010c, 0x5c10
+ax_pose_terminator
+sLaprasPose222:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose223:
+ax_pose 20, 0x01de, 0x90f4, 0x5c00
+ax_pose 21, 0x41fe, 0x90f4, 0x5c10
+ax_pose 22, 0x81f6, 0x10ec, 0x5c18
+ax_pose_terminator
+sLaprasPose224:
+ax_pose 23, 0x01e9, 0x90f2, 0x5c00
+ax_pose 24, 0x81f9, 0x10ea, 0x5c10
+ax_pose_terminator
+sLaprasPose225:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose226:
+ax_pose 25, 0x01db, 0x90ec, 0x5c00
+ax_pose 26, 0x41fb, 0x90ec, 0x5c10
+ax_pose_terminator
+sLaprasPose227:
+ax_pose 27, 0x01e4, 0x90fb, 0x5c00
+ax_pose 28, 0x81ec, 0x90eb, 0x5c10
+ax_pose 29, 0x0204, 0x10fb, 0x5c18
+ax_pose_terminator
+sLaprasPose228:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose229:
+ax_pose 30, 0x01dd, 0x90f1, 0x5c00
+ax_pose 31, 0x41fd, 0x50f1, 0x5c10
+ax_pose 32, 0x01fd, 0x10e9, 0x5c14
+ax_pose 33, 0x0205, 0x10f9, 0x5c15
+ax_pose_terminator
+sLaprasPose230:
+ax_pose 34, 0x01df, 0x90f9, 0x5c00
+ax_pose 35, 0x41ff, 0x90f1, 0x5c10
+ax_pose 36, 0x01ff, 0x10e9, 0x5c18
+ax_pose 37, 0x81ef, 0x10f1, 0x5c19
+ax_pose_terminator
+sLaprasPose231:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose232:
+ax_pose 38, 0x01de, 0x80ea, 0x5c00
+ax_pose 39, 0x41fe, 0x40ea, 0x5c10
+ax_pose 40, 0x4206, 0x40f2, 0x5c14
+ax_pose 41, 0x01f6, 0x410a, 0x5c18
+ax_pose_terminator
+sLaprasPose233:
+ax_pose 42, 0x01e2, 0x80ec, 0x5c00
+ax_pose 43, 0x4202, 0x40ec, 0x5c10
+ax_pose 44, 0x81f7, 0x010c, 0x5c14
+ax_pose_terminator
+sLaprasPose234:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose235:
+ax_pose 30, 0x01dd, 0x80ee, 0x5c00
+ax_pose 31, 0x41fd, 0x40ee, 0x5c10
+ax_pose 32, 0x01fd, 0x010e, 0x5c14
+ax_pose 33, 0x0205, 0x00fe, 0x5c15
+ax_pose_terminator
+sLaprasPose236:
+ax_pose 34, 0x01df, 0x80e6, 0x5c00
+ax_pose 35, 0x41ff, 0x80ee, 0x5c10
+ax_pose 36, 0x01ff, 0x010e, 0x5c18
+ax_pose 37, 0x81ef, 0x0106, 0x5c19
+ax_pose_terminator
+sLaprasPose237:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose238:
+ax_pose 25, 0x01db, 0x80f3, 0x5c00
+ax_pose 26, 0x41fb, 0x80f3, 0x5c10
+ax_pose_terminator
+sLaprasPose239:
+ax_pose 27, 0x01e4, 0x80e4, 0x5c00
+ax_pose 28, 0x81ec, 0x8104, 0x5c10
+ax_pose 29, 0x0204, 0x00fc, 0x5c18
+ax_pose_terminator
+sLaprasPose240:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose241:
+ax_pose 20, 0x01de, 0x80eb, 0x5c00
+ax_pose 21, 0x41fe, 0x80eb, 0x5c10
+ax_pose 22, 0x81f6, 0x010b, 0x5c18
+ax_pose_terminator
+sLaprasPose242:
+ax_pose 23, 0x01e9, 0x80ed, 0x5c00
+ax_pose 24, 0x81f9, 0x010d, 0x5c10
+ax_pose_terminator
+sLaprasPose243:
+ax_pose 15, 0x01dd, 0x80ed, 0x5c00
+ax_pose 16, 0x41fd, 0x80ed, 0x5c10
+ax_pose 17, 0x81fd, 0x010d, 0x5c18
+ax_pose_terminator
+sLaprasPose244:
+ax_pose 20, 0x01dd, 0x80eb, 0x5c00
+ax_pose 21, 0x41fd, 0x80eb, 0x5c10
+ax_pose 22, 0x81f5, 0x010b, 0x5c18
+ax_pose_terminator
+sLaprasPose245:
+ax_pose 25, 0x01db, 0x80f1, 0x5c00
+ax_pose 26, 0x41fb, 0x80f1, 0x5c10
+ax_pose_terminator
+sLaprasPose246:
+ax_pose 30, 0x01dd, 0x80ec, 0x5c00
+ax_pose 31, 0x41fd, 0x40ec, 0x5c10
+ax_pose 32, 0x01fd, 0x010c, 0x5c14
+ax_pose 33, 0x0205, 0x00fc, 0x5c15
+ax_pose_terminator
+sLaprasPose247:
+ax_pose 38, 0x01de, 0x80ea, 0x5c00
+ax_pose 39, 0x41fe, 0x40ea, 0x5c10
+ax_pose 40, 0x4206, 0x40f2, 0x5c14
+ax_pose 41, 0x01f6, 0x410a, 0x5c18
+ax_pose_terminator
+sLaprasPose248:
+ax_pose 30, 0x01dd, 0x90f3, 0x5c00
+ax_pose 31, 0x41fd, 0x50f3, 0x5c10
+ax_pose 32, 0x01fd, 0x10eb, 0x5c14
+ax_pose 33, 0x0205, 0x10fb, 0x5c15
+ax_pose_terminator
+sLaprasPose249:
+ax_pose 25, 0x01db, 0x90ee, 0x5c00
+ax_pose 26, 0x41fb, 0x90ee, 0x5c10
+ax_pose_terminator
+sLaprasPose250:
+ax_pose 20, 0x01dd, 0x90f5, 0x5c00
+ax_pose 21, 0x41fd, 0x90f5, 0x5c10
+ax_pose 22, 0x81f5, 0x10ed, 0x5c18
+ax_pose_terminator
+sLaprasPose251:
+ax_pose 0, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose252:
+ax_pose 3, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose253:
+ax_pose 6, 0x01e1, 0xc0f0, 0x5c00
+ax_pose_terminator
+sLaprasPose254:
+ax_pose 9, 0x01e1, 0xc0ec, 0x5c00
+ax_pose_terminator
+sLaprasPose255:
+ax_pose 12, 0x01e1, 0xc0e8, 0x5c00
+ax_pose_terminator
+sLaprasPose256:
+ax_pose 9, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+sLaprasPose257:
+ax_pose 6, 0x01e1, 0xd0cf, 0x5c00
+ax_pose_terminator
+sLaprasPose258:
+ax_pose 3, 0x01e1, 0xd0d3, 0x5c00
+ax_pose_terminator
+.align 2
+sLaprasAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 27, 0, -3, 0, -3,
+ax_anim 6, 0, 27, 0, -5, 0, -5,
+ax_anim 1, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 2, 28, 0, 5, 0, 5,
+ax_anim 1, 0, 28, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 16, 0, 16,
+ax_anim 2, 1, 28, 1, 16, 1, 16,
+ax_anim 2, 0, 28, 0, 16, 0, 16,
+ax_anim 2, 0, 28, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sLaprasAnims_2_2:
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 2, 0, 32, -3, -3, -3, -3,
+ax_anim 6, 0, 32, -5, -5, -5, -5,
+ax_anim 1, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 2, 33, 5, 5, 5, 5,
+ax_anim 1, 0, 33, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 17, 16, 17, 16,
+ax_anim 2, 1, 33, 18, 15, 18, 15,
+ax_anim 2, 0, 33, 17, 16, 17, 16,
+ax_anim 2, 0, 33, 18, 15, 18, 15,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sLaprasAnims_2_3:
+ax_anim 2, 0, 35, -2, 0, -2, 0,
+ax_anim 2, 0, 37, -3, 0, -3, 0,
+ax_anim 6, 0, 37, -5, 0, -5, 0,
+ax_anim 1, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 2, 38, 5, 0, 5, 0,
+ax_anim 1, 0, 38, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 15, 0, 15, 0,
+ax_anim 2, 1, 38, 15, -1, 15, -1,
+ax_anim 2, 0, 38, 15, 0, 15, 0,
+ax_anim 2, 0, 38, 15, -1, 15, -1,
+ax_anim 2, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sLaprasAnims_2_4:
+ax_anim 2, 0, 40, -2, 2, -2, 2,
+ax_anim 2, 0, 42, -3, 3, -3, 3,
+ax_anim 6, 0, 42, -5, 5, -5, 5,
+ax_anim 1, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 2, 43, 5, -5, 5, -5,
+ax_anim 1, 0, 43, 10, -10, 10, -10,
+ax_anim 2, 0, 43, 17, -16, 17, -16,
+ax_anim 2, 1, 43, 18, -15, 18, -15,
+ax_anim 2, 0, 43, 17, -16, 17, -16,
+ax_anim 2, 0, 43, 18, -15, 18, -15,
+ax_anim 2, 0, 39, 8, -8, 8, -8,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sLaprasAnims_2_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 2, 0, 47, 0, 3, 0, 3,
+ax_anim 6, 0, 47, 0, 5, 0, 5,
+ax_anim 1, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 2, 48, 0, -5, 0, -5,
+ax_anim 1, 0, 48, 0, -10, 0, -10,
+ax_anim 2, 0, 48, 1, -15, 1, -15,
+ax_anim 2, 1, 48, 0, -15, 0, -15,
+ax_anim 2, 0, 48, 1, -15, 1, -15,
+ax_anim 2, 0, 48, 0, -15, 0, -15,
+ax_anim 2, 0, 44, 0, -8, 0, -8,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sLaprasAnims_2_6:
+ax_anim 2, 0, 50, 2, 2, 2, 2,
+ax_anim 2, 0, 52, 3, 3, 3, 3,
+ax_anim 6, 0, 52, 5, 5, 5, 5,
+ax_anim 1, 0, 49, 2, 2, 2, 2,
+ax_anim 1, 2, 53, -5, -5, -5, -5,
+ax_anim 1, 0, 53, -10, -10, -10, -10,
+ax_anim 2, 0, 53, -17, -16, -17, -16,
+ax_anim 2, 1, 53, -18, -15, -18, -15,
+ax_anim 2, 0, 53, -17, -16, -17, -16,
+ax_anim 2, 0, 53, -18, -15, -18, -15,
+ax_anim 2, 0, 49, -8, -8, -8, -8,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sLaprasAnims_2_7:
+ax_anim 2, 0, 55, 2, 0, 2, 0,
+ax_anim 2, 0, 57, 3, 0, 3, 0,
+ax_anim 6, 0, 57, 5, 0, 5, 0,
+ax_anim 1, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 2, 58, -5, 0, -5, 0,
+ax_anim 1, 0, 58, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -15, 0, -15, 0,
+ax_anim 2, 1, 58, -15, -1, -15, -1,
+ax_anim 2, 0, 58, -15, 0, -15, 0,
+ax_anim 2, 0, 58, -15, -1, -15, -1,
+ax_anim 2, 0, 54, -8, 0, -8, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sLaprasAnims_2_8:
+ax_anim 2, 0, 60, 2, -2, 2, -2,
+ax_anim 2, 0, 62, 3, -3, 3, -3,
+ax_anim 6, 0, 62, 5, -5, 5, -5,
+ax_anim 1, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 2, 63, -5, 5, -5, 5,
+ax_anim 1, 0, 63, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -17, 16, -17, 16,
+ax_anim 2, 1, 63, -18, 15, -18, 15,
+ax_anim 2, 0, 63, -17, 16, -17, 16,
+ax_anim 2, 0, 63, -18, 15, -18, 15,
+ax_anim 2, 0, 59, -8, 8, -8, 8,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sLaprasAnims_3_1:
+ax_anim 2, 0, 65, 0, -2, 0, -2,
+ax_anim 2, 0, 67, 0, -3, 0, -3,
+ax_anim 6, 0, 67, 0, -5, 0, -5,
+ax_anim 1, 0, 64, 0, -2, 0, -2,
+ax_anim 1, 2, 68, 0, 5, 0, 5,
+ax_anim 1, 0, 68, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 1, 68, 1, 16, 1, 16,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 0, 68, 1, 16, 1, 16,
+ax_anim 2, 0, 64, 0, 8, 0, 8,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sLaprasAnims_3_2:
+ax_anim 2, 0, 70, -2, -2, -2, -2,
+ax_anim 2, 0, 72, -3, -3, -3, -3,
+ax_anim 6, 0, 72, -5, -5, -5, -5,
+ax_anim 1, 0, 69, -2, -2, -2, -2,
+ax_anim 1, 2, 73, 5, 5, 5, 5,
+ax_anim 1, 0, 73, 10, 10, 10, 10,
+ax_anim 2, 0, 73, 17, 16, 17, 16,
+ax_anim 2, 1, 73, 18, 15, 18, 15,
+ax_anim 2, 0, 73, 17, 16, 17, 16,
+ax_anim 2, 0, 73, 18, 15, 18, 15,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sLaprasAnims_3_3:
+ax_anim 2, 0, 75, -2, 0, -2, 0,
+ax_anim 2, 0, 77, -3, 0, -3, 0,
+ax_anim 6, 0, 77, -5, 0, -5, 0,
+ax_anim 1, 0, 74, -2, 0, -2, 0,
+ax_anim 1, 2, 78, 5, 0, 5, 0,
+ax_anim 1, 0, 78, 10, 0, 10, 0,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 1, 78, 15, -1, 15, -1,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 0, 78, 15, -1, 15, -1,
+ax_anim 2, 0, 74, 8, 0, 8, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sLaprasAnims_3_4:
+ax_anim 2, 0, 80, -2, 2, -2, 2,
+ax_anim 2, 0, 82, -3, 3, -3, 3,
+ax_anim 6, 0, 82, -5, 5, -5, 5,
+ax_anim 1, 0, 79, -2, 2, -2, 2,
+ax_anim 1, 2, 83, 5, -5, 5, -5,
+ax_anim 1, 0, 83, 10, -10, 10, -10,
+ax_anim 2, 0, 83, 17, -16, 17, -16,
+ax_anim 2, 1, 83, 18, -15, 18, -15,
+ax_anim 2, 0, 83, 17, -16, 17, -16,
+ax_anim 2, 0, 83, 18, -15, 18, -15,
+ax_anim 2, 0, 79, 8, -8, 8, -8,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sLaprasAnims_3_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 2, 0, 87, 0, 3, 0, 3,
+ax_anim 6, 0, 87, 0, 5, 0, 5,
+ax_anim 1, 0, 84, 0, 2, 0, 2,
+ax_anim 1, 2, 88, 0, -5, 0, -5,
+ax_anim 1, 0, 88, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 1, -15, 1, -15,
+ax_anim 2, 1, 88, 0, -15, 0, -15,
+ax_anim 2, 0, 88, 1, -15, 1, -15,
+ax_anim 2, 0, 88, 0, -15, 0, -15,
+ax_anim 2, 0, 84, 0, -8, 0, -8,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sLaprasAnims_3_6:
+ax_anim 2, 0, 90, 2, 2, 2, 2,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim 6, 0, 92, 5, 5, 5, 5,
+ax_anim 1, 0, 89, 2, 2, 2, 2,
+ax_anim 1, 2, 93, -5, -5, -5, -5,
+ax_anim 1, 0, 93, -10, -10, -10, -10,
+ax_anim 2, 0, 93, -17, -16, -17, -16,
+ax_anim 2, 1, 93, -18, -15, -18, -15,
+ax_anim 2, 0, 93, -17, -16, -17, -16,
+ax_anim 2, 0, 93, -18, -15, -18, -15,
+ax_anim 2, 0, 89, -8, -8, -8, -8,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sLaprasAnims_3_7:
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 6, 0, 97, 5, 0, 5, 0,
+ax_anim 1, 0, 94, 2, 0, 2, 0,
+ax_anim 1, 2, 98, -5, 0, -5, 0,
+ax_anim 1, 0, 98, -10, 0, -10, 0,
+ax_anim 2, 0, 98, -15, 0, -15, 0,
+ax_anim 2, 1, 98, -15, -1, -15, -1,
+ax_anim 2, 0, 98, -15, 0, -15, 0,
+ax_anim 2, 0, 98, -15, -1, -15, -1,
+ax_anim 2, 0, 94, -8, 0, -8, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sLaprasAnims_3_8:
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 3, -3, 3, -3,
+ax_anim 6, 0, 102, 5, -5, 5, -5,
+ax_anim 1, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 2, 103, -5, 5, -5, 5,
+ax_anim 1, 0, 103, -10, 10, -10, 10,
+ax_anim 2, 0, 103, -17, 16, -17, 16,
+ax_anim 2, 1, 103, -18, 15, -18, 15,
+ax_anim 2, 0, 103, -17, 16, -17, 16,
+ax_anim 2, 0, 103, -18, 15, -18, 15,
+ax_anim 2, 0, 99, -8, 8, -8, 8,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sLaprasAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -4, 0, -4,
+ax_anim 6, 2, 107, 0, -5, 0, -5,
+ax_anim 1, 0, 108, 0, -2, 0, -2,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 1, 108, 1, 3, 1, 3,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 1, 3, 1, 3,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 1, 3, 1, 3,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sLaprasAnims_4_2:
+ax_anim 2, 0, 110, -2, -2, -2, -2,
+ax_anim 2, 0, 112, -4, -4, -4, -4,
+ax_anim 6, 2, 112, -5, -5, -5, -5,
+ax_anim 1, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 1, 113, 4, 2, 4, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 113, 4, 2, 4, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 113, 4, 2, 4, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim_terminator
+sLaprasAnims_4_3:
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 117, -4, 0, -4, 0,
+ax_anim 6, 2, 117, -5, 0, -5, 0,
+ax_anim 1, 0, 118, -2, 0, -2, 0,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 1, 118, 3, -1, 3, -1,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 118, 3, -1, 3, -1,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 118, 3, -1, 3, -1,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sLaprasAnims_4_4:
+ax_anim 2, 0, 120, -2, 2, -2, 2,
+ax_anim 2, 0, 122, -4, 4, -4, 4,
+ax_anim 6, 2, 122, -5, 5, -5, 5,
+ax_anim 1, 0, 123, -2, 2, -2, 2,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 1, 123, 4, -2, 4, -2,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 4, -2, 4, -2,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 4, -2, 4, -2,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim_terminator
+sLaprasAnims_4_5:
+ax_anim 2, 0, 125, 0, 2, 0, 2,
+ax_anim 2, 0, 127, 0, 4, 0, 4,
+ax_anim 6, 2, 127, 0, 5, 0, 5,
+ax_anim 1, 0, 128, 0, 2, 0, 2,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 1, 128, 1, -3, 1, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 1, -3, 1, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 1, -3, 1, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sLaprasAnims_4_6:
+ax_anim 2, 0, 130, 2, 2, 2, 2,
+ax_anim 2, 0, 132, 4, 4, 4, 4,
+ax_anim 6, 2, 132, 5, 5, 5, 5,
+ax_anim 1, 0, 133, 2, 2, 2, 2,
+ax_anim 2, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 1, 133, -4, -2, -4, -2,
+ax_anim 2, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 133, -4, -2, -4, -2,
+ax_anim 2, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 133, -4, -2, -4, -2,
+ax_anim 2, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim_terminator
+sLaprasAnims_4_7:
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim 2, 0, 137, 4, 0, 4, 0,
+ax_anim 6, 2, 137, 5, 0, 5, 0,
+ax_anim 1, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 1, 138, -3, -1, -3, -1,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 138, -3, -1, -3, -1,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 138, -3, -1, -3, -1,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim_terminator
+sLaprasAnims_4_8:
+ax_anim 2, 0, 140, 2, -2, 2, -2,
+ax_anim 2, 0, 142, 4, -4, 4, -4,
+ax_anim 6, 2, 142, 5, -5, 5, -5,
+ax_anim 1, 0, 143, 2, -2, 2, -2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 1, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLaprasAnims_5_1:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 2, 147, 1, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 1, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 1, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 1, 147, 1, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, 0,
+ax_anim_terminator
+sLaprasAnims_5_2:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 151, -1, -2, 0, 0,
+ax_anim 4, 0, 151, -2, -3, 0, 0,
+ax_anim 2, 2, 151, -1, -3, 0, 0,
+ax_anim 2, 0, 151, -2, -3, 0, 0,
+ax_anim 2, 0, 151, -1, -3, 0, 0,
+ax_anim 2, 0, 151, -2, -3, 0, 0,
+ax_anim 2, 0, 151, -1, -3, 0, 0,
+ax_anim 2, 0, 151, -2, -3, 0, 0,
+ax_anim 2, 1, 151, -1, -3, 0, 0,
+ax_anim 2, 0, 148, -1, -1, 0, 0,
+ax_anim_terminator
+sLaprasAnims_5_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, -2, -3, 0, 0,
+ax_anim 2, 2, 155, -1, -3, 0, 0,
+ax_anim 2, 0, 155, -2, -3, 0, 0,
+ax_anim 2, 0, 155, -1, -3, 0, 0,
+ax_anim 2, 0, 155, -2, -3, 0, 0,
+ax_anim 2, 0, 155, -1, -3, 0, 0,
+ax_anim 2, 0, 155, -2, -3, 0, 0,
+ax_anim 2, 1, 155, -1, -3, 0, 0,
+ax_anim 2, 0, 152, -1, -1, 0, 0,
+ax_anim_terminator
+sLaprasAnims_5_4:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 159, -1, -2, 0, 0,
+ax_anim 4, 0, 159, -2, -2, 0, 0,
+ax_anim 2, 2, 159, -2, -3, 0, 0,
+ax_anim 2, 0, 159, -3, -3, 0, 0,
+ax_anim 2, 0, 159, -2, -3, 0, 0,
+ax_anim 2, 0, 159, -3, -3, 0, 0,
+ax_anim 2, 0, 159, -2, -3, 0, 0,
+ax_anim 2, 0, 159, -3, -3, 0, 0,
+ax_anim 2, 1, 159, -2, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, 0,
+ax_anim_terminator
+sLaprasAnims_5_5:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 163, 0, -1, 0, 0,
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 2, 163, 1, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 1, 163, 1, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_5_6:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 1, -2, 0, 0,
+ax_anim 4, 0, 167, 2, -2, 0, 0,
+ax_anim 2, 2, 167, 2, -3, 0, 0,
+ax_anim 2, 0, 167, 3, -3, 0, 0,
+ax_anim 2, 0, 167, 2, -3, 0, 0,
+ax_anim 2, 0, 167, 3, -3, 0, 0,
+ax_anim 2, 0, 167, 2, -3, 0, 0,
+ax_anim 2, 0, 167, 3, -3, 0, 0,
+ax_anim 2, 1, 167, 2, -3, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, 0,
+ax_anim_terminator
+sLaprasAnims_5_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, -2, 0, 0,
+ax_anim 4, 0, 171, 2, -3, 0, 0,
+ax_anim 2, 2, 171, 1, -3, 0, 0,
+ax_anim 2, 0, 171, 2, -3, 0, 0,
+ax_anim 2, 0, 171, 1, -3, 0, 0,
+ax_anim 2, 0, 171, 2, -3, 0, 0,
+ax_anim 2, 0, 171, 1, -3, 0, 0,
+ax_anim 2, 0, 171, 2, -3, 0, 0,
+ax_anim 2, 1, 171, 1, -3, 0, 0,
+ax_anim 2, 0, 168, 1, -1, 0, 0,
+ax_anim_terminator
+sLaprasAnims_5_8:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 1, -2, 0, 0,
+ax_anim 4, 0, 175, 2, -3, 0, 0,
+ax_anim 2, 2, 175, 1, -3, 0, 0,
+ax_anim 2, 0, 175, 2, -3, 0, 0,
+ax_anim 2, 0, 175, 1, -3, 0, 0,
+ax_anim 2, 0, 175, 2, -3, 0, 0,
+ax_anim 2, 0, 175, 1, -3, 0, 0,
+ax_anim 2, 0, 175, 2, -3, 0, 0,
+ax_anim 2, 1, 175, 1, -3, 0, 0,
+ax_anim 2, 0, 172, 1, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sLaprasAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sLaprasAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sLaprasAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sLaprasAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sLaprasAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sLaprasAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sLaprasAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLaprasAnims_8_1:
+ax_anim 40, 0, 186, 0, 0, 0, 0,
+ax_anim 12, 0, 187, 0, 0, 0, 0,
+ax_anim 16, 0, 186, 0, 0, 0, 0,
+ax_anim 12, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_8_2:
+ax_anim 40, 0, 188, 0, 0, 0, 0,
+ax_anim 12, 0, 189, 0, 0, 0, 0,
+ax_anim 16, 0, 188, 0, 0, 0, 0,
+ax_anim 12, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_8_3:
+ax_anim 40, 0, 190, 0, 0, 0, 0,
+ax_anim 12, 0, 191, 0, 0, 0, 0,
+ax_anim 16, 0, 190, 0, 0, 0, 0,
+ax_anim 12, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_8_4:
+ax_anim 40, 0, 192, 0, 0, 0, 0,
+ax_anim 12, 0, 193, 0, 0, 0, 0,
+ax_anim 16, 0, 192, 0, 0, 0, 0,
+ax_anim 12, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_8_5:
+ax_anim 40, 0, 194, 0, 0, 0, 0,
+ax_anim 12, 0, 195, 0, 0, 0, 0,
+ax_anim 16, 0, 194, 0, 0, 0, 0,
+ax_anim 12, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_8_6:
+ax_anim 40, 0, 196, 0, 0, 0, 0,
+ax_anim 12, 0, 197, 0, 0, 0, 0,
+ax_anim 16, 0, 196, 0, 0, 0, 0,
+ax_anim 12, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_8_7:
+ax_anim 40, 0, 198, 0, 0, 0, 0,
+ax_anim 12, 0, 199, 0, 0, 0, 0,
+ax_anim 16, 0, 198, 0, 0, 0, 0,
+ax_anim 12, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_8_8:
+ax_anim 40, 0, 200, 0, 0, 0, 0,
+ax_anim 12, 0, 201, 0, 0, 0, 0,
+ax_anim 16, 0, 200, 0, 0, 0, 0,
+ax_anim 12, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 3, 6, 3,
+ax_anim 2, 0, 204, 8, 9, 8, 9,
+ax_anim 2, 0, 205, 7, 15, 7, 15,
+ax_anim 3, 0, 206, 0, 18, 0, 18,
+ax_anim 2, 3, 207, -7, 15, -7, 15,
+ax_anim 2, 0, 208, -8, 9, -8, 9,
+ax_anim 1, 0, 209, -6, 3, -6, 3,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 17, 3, 17, 3,
+ax_anim 2, 0, 204, 19, 10, 19, 10,
+ax_anim 3, 0, 205, 17, 19, 17, 19,
+ax_anim 2, 3, 206, 11, 19, 11, 19,
+ax_anim 2, 0, 207, 3, 15, 3, 15,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -5, 3, -5,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 16, -5, 16, -5,
+ax_anim 3, 0, 204, 18, -2, 18, -2,
+ax_anim 2, 3, 205, 16, 2, 16, 2,
+ax_anim 2, 0, 206, 12, 5, 12, 5,
+ax_anim 1, 0, 207, 4, 3, 4, 3,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -8, -1, -8,
+ax_anim 2, 0, 209, 4, -16, 4, -16,
+ax_anim 2, 0, 202, 12, -22, 12, -22,
+ax_anim 3, 0, 203, 18, -22, 18, -22,
+ax_anim 2, 3, 204, 20, -15, 20, -15,
+ax_anim 2, 0, 205, 17, -4, 17, -4,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -4, -8, -4,
+ax_anim 2, 0, 208, -9, -12, -9, -12,
+ax_anim 2, 0, 209, -7, -18, -7, -18,
+ax_anim 3, 0, 202, 0, -22, 0, -22,
+ax_anim 2, 3, 203, 7, -18, 7, -18,
+ax_anim 2, 0, 204, 9, -12, 9, -12,
+ax_anim 1, 0, 205, 8, -4, 8, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -6, 1, -6,
+ax_anim 2, 0, 203, -4, -16, -4, -16,
+ax_anim 2, 0, 202, -12, -22, -12, -22,
+ax_anim 3, 0, 209, -18, -22, -18, -22,
+ax_anim 2, 3, 208, -20, -15, -20, -15,
+ax_anim 2, 0, 207, -17, -4, -17, -4,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -5, -3, -5,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -16, -5, -16, -5,
+ax_anim 3, 0, 208, -18, -2, -18, -2,
+ax_anim 2, 3, 207, -16, 2, -16, 2,
+ax_anim 2, 0, 206, -12, 5, -12, 5,
+ax_anim 1, 0, 205, -4, 3, -4, 3,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -17, 3, -17, 3,
+ax_anim 2, 0, 208, -19, 10, -19, 10,
+ax_anim 3, 0, 207, -17, 19, -17, 19,
+ax_anim 2, 3, 206, -11, 19, -11, 19,
+ax_anim 2, 0, 205, -3, 15, -3, 15,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLaprasAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sLaprasGfx1:
+.incbin "baserom.gba", 0xAA66D0, 0x800
+sLaprasSprites1:
+ax_sprite sLaprasGfx1, 0x800
+ax_sprite_terminator
+sLaprasGfx2:
+.incbin "baserom.gba", 0xAA6EE0, 0x800
+sLaprasSprites2:
+ax_sprite sLaprasGfx2, 0x800
+ax_sprite_terminator
+sLaprasGfx3:
+.incbin "baserom.gba", 0xAA76F0, 0x800
+sLaprasSprites3:
+ax_sprite sLaprasGfx3, 0x800
+ax_sprite_terminator
+sLaprasGfx4:
+.incbin "baserom.gba", 0xAA7F00, 0x800
+sLaprasSprites4:
+ax_sprite sLaprasGfx4, 0x800
+ax_sprite_terminator
+sLaprasGfx5:
+.incbin "baserom.gba", 0xAA8710, 0x800
+sLaprasSprites5:
+ax_sprite sLaprasGfx5, 0x800
+ax_sprite_terminator
+sLaprasGfx6:
+.incbin "baserom.gba", 0xAA8F20, 0x800
+sLaprasSprites6:
+ax_sprite sLaprasGfx6, 0x800
+ax_sprite_terminator
+sLaprasGfx7:
+.incbin "baserom.gba", 0xAA9730, 0x800
+sLaprasSprites7:
+ax_sprite sLaprasGfx7, 0x800
+ax_sprite_terminator
+sLaprasGfx8:
+.incbin "baserom.gba", 0xAA9F40, 0x800
+sLaprasSprites8:
+ax_sprite sLaprasGfx8, 0x800
+ax_sprite_terminator
+sLaprasGfx9:
+.incbin "baserom.gba", 0xAAA750, 0x800
+sLaprasSprites9:
+ax_sprite sLaprasGfx9, 0x800
+ax_sprite_terminator
+sLaprasGfx10:
+.incbin "baserom.gba", 0xAAAF60, 0x800
+sLaprasSprites10:
+ax_sprite sLaprasGfx10, 0x800
+ax_sprite_terminator
+sLaprasGfx11:
+.incbin "baserom.gba", 0xAAB770, 0x800
+sLaprasSprites11:
+ax_sprite sLaprasGfx11, 0x800
+ax_sprite_terminator
+sLaprasGfx12:
+.incbin "baserom.gba", 0xAABF80, 0x800
+sLaprasSprites12:
+ax_sprite sLaprasGfx12, 0x800
+ax_sprite_terminator
+sLaprasGfx13:
+.incbin "baserom.gba", 0xAAC790, 0x800
+sLaprasSprites13:
+ax_sprite sLaprasGfx13, 0x800
+ax_sprite_terminator
+sLaprasGfx14:
+.incbin "baserom.gba", 0xAACFA0, 0x800
+sLaprasSprites14:
+ax_sprite sLaprasGfx14, 0x800
+ax_sprite_terminator
+sLaprasGfx15:
+.incbin "baserom.gba", 0xAAD7B0, 0x800
+sLaprasSprites15:
+ax_sprite sLaprasGfx15, 0x800
+ax_sprite_terminator
+sLaprasGfx16:
+.incbin "baserom.gba", 0xAADFC0, 0x60
+sLaprasGfx16_1:
+.incbin "baserom.gba", 0xAAE020, 0x60
+sLaprasGfx16_2:
+.incbin "baserom.gba", 0xAAE080, 0xE0
+sLaprasSprites16:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx16_2, 0xe0
+ax_sprite_terminator
+sLaprasGfx17:
+.incbin "baserom.gba", 0xAAE198, 0xA0
+sLaprasGfx17_1:
+.incbin "baserom.gba", 0xAAE238, 0x40
+sLaprasSprites17:
+ax_sprite sLaprasGfx17, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx17_1, 0x40
+ax_sprite_terminator
+sLaprasGfx18:
+.incbin "baserom.gba", 0xAAE298, 0x40
+sLaprasSprites18:
+ax_sprite sLaprasGfx18, 0x40
+ax_sprite_terminator
+sLaprasGfx19:
+.incbin "baserom.gba", 0xAAE2E8, 0x1E0
+sLaprasSprites19:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx19, 0x1e0
+ax_sprite_terminator
+sLaprasGfx20:
+.incbin "baserom.gba", 0xAAE4E0, 0x40
+sLaprasSprites20:
+ax_sprite sLaprasGfx20, 0x40
+ax_sprite_terminator
+sLaprasGfx21:
+.incbin "baserom.gba", 0xAAE530, 0x60
+sLaprasGfx21_1:
+.incbin "baserom.gba", 0xAAE590, 0x60
+sLaprasGfx21_2:
+.incbin "baserom.gba", 0xAAE5F0, 0xE0
+sLaprasSprites21:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx21_2, 0xe0
+ax_sprite_terminator
+sLaprasGfx22:
+.incbin "baserom.gba", 0xAAE708, 0x80
+sLaprasGfx22_1:
+.incbin "baserom.gba", 0xAAE788, 0x40
+sLaprasSprites22:
+ax_sprite sLaprasGfx22, 0x80
+ax_sprite 0, 0x40
+ax_sprite sLaprasGfx22_1, 0x40
+ax_sprite_terminator
+sLaprasGfx23:
+.incbin "baserom.gba", 0xAAE7E8, 0x40
+sLaprasSprites23:
+ax_sprite sLaprasGfx23, 0x40
+ax_sprite_terminator
+sLaprasGfx24:
+.incbin "baserom.gba", 0xAAE838, 0x60
+sLaprasGfx24_1:
+.incbin "baserom.gba", 0xAAE898, 0x100
+sLaprasGfx24_2:
+.incbin "baserom.gba", 0xAAE998, 0x60
+sLaprasSprites24:
+ax_sprite sLaprasGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx24_2, 0x60
+ax_sprite_terminator
+sLaprasGfx25:
+.incbin "baserom.gba", 0xAAEA28, 0x40
+sLaprasSprites25:
+ax_sprite sLaprasGfx25, 0x40
+ax_sprite_terminator
+sLaprasGfx26:
+.incbin "baserom.gba", 0xAAEA78, 0x60
+sLaprasGfx26_1:
+.incbin "baserom.gba", 0xAAEAD8, 0x60
+sLaprasGfx26_2:
+.incbin "baserom.gba", 0xAAEB38, 0x60
+sLaprasGfx26_3:
+.incbin "baserom.gba", 0xAAEB98, 0x80
+sLaprasSprites26:
+ax_sprite sLaprasGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx26_3, 0x80
+ax_sprite_terminator
+sLaprasGfx27:
+.incbin "baserom.gba", 0xAAEC58, 0x100
+sLaprasSprites27:
+ax_sprite sLaprasGfx27, 0x100
+ax_sprite_terminator
+sLaprasGfx28:
+.incbin "baserom.gba", 0xAAED68, 0x60
+sLaprasGfx28_1:
+.incbin "baserom.gba", 0xAAEDC8, 0x100
+sLaprasGfx28_2:
+.incbin "baserom.gba", 0xAAEEC8, 0x40
+sLaprasSprites28:
+ax_sprite sLaprasGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx28_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sLaprasGfx28_2, 0x40
+ax_sprite_terminator
+sLaprasGfx29:
+.incbin "baserom.gba", 0xAAEF38, 0x20
+sLaprasGfx29_1:
+.incbin "baserom.gba", 0xAAEF58, 0xA0
+sLaprasSprites29:
+ax_sprite sLaprasGfx29, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx29_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLaprasGfx30:
+.incbin "baserom.gba", 0xAAF020, 0x20
+sLaprasSprites30:
+ax_sprite sLaprasGfx30, 0x20
+ax_sprite_terminator
+sLaprasGfx31:
+.incbin "baserom.gba", 0xAAF050, 0x60
+sLaprasGfx31_1:
+.incbin "baserom.gba", 0xAAF0B0, 0x60
+sLaprasGfx31_2:
+.incbin "baserom.gba", 0xAAF110, 0xE0
+sLaprasSprites31:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx31_2, 0xe0
+ax_sprite_terminator
+sLaprasGfx32:
+.incbin "baserom.gba", 0xAAF228, 0x80
+sLaprasSprites32:
+ax_sprite sLaprasGfx32, 0x80
+ax_sprite_terminator
+sLaprasGfx33:
+.incbin "baserom.gba", 0xAAF2B8, 0x20
+sLaprasSprites33:
+ax_sprite sLaprasGfx33, 0x20
+ax_sprite_terminator
+sLaprasGfx34:
+.incbin "baserom.gba", 0xAAF2E8, 0x20
+sLaprasSprites34:
+ax_sprite sLaprasGfx34, 0x20
+ax_sprite_terminator
+sLaprasGfx35:
+.incbin "baserom.gba", 0xAAF318, 0x60
+sLaprasGfx35_1:
+.incbin "baserom.gba", 0xAAF378, 0x60
+sLaprasGfx35_2:
+.incbin "baserom.gba", 0xAAF3D8, 0x80
+sLaprasGfx35_3:
+.incbin "baserom.gba", 0xAAF458, 0x60
+sLaprasSprites35:
+ax_sprite sLaprasGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx35_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx35_3, 0x60
+ax_sprite_terminator
+sLaprasGfx36:
+.incbin "baserom.gba", 0xAAF4F8, 0x100
+sLaprasSprites36:
+ax_sprite sLaprasGfx36, 0x100
+ax_sprite_terminator
+sLaprasGfx37:
+.incbin "baserom.gba", 0xAAF608, 0x20
+sLaprasSprites37:
+ax_sprite sLaprasGfx37, 0x20
+ax_sprite_terminator
+sLaprasGfx38:
+.incbin "baserom.gba", 0xAAF638, 0x40
+sLaprasSprites38:
+ax_sprite sLaprasGfx38, 0x40
+ax_sprite_terminator
+sLaprasGfx39:
+.incbin "baserom.gba", 0xAAF688, 0x60
+sLaprasGfx39_1:
+.incbin "baserom.gba", 0xAAF6E8, 0x60
+sLaprasGfx39_2:
+.incbin "baserom.gba", 0xAAF748, 0xE0
+sLaprasSprites39:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx39_2, 0xe0
+ax_sprite_terminator
+sLaprasGfx40:
+.incbin "baserom.gba", 0xAAF860, 0x80
+sLaprasSprites40:
+ax_sprite sLaprasGfx40, 0x80
+ax_sprite_terminator
+sLaprasGfx41:
+.incbin "baserom.gba", 0xAAF8F0, 0x80
+sLaprasSprites41:
+ax_sprite sLaprasGfx41, 0x80
+ax_sprite_terminator
+sLaprasGfx42:
+.incbin "baserom.gba", 0xAAF980, 0x60
+sLaprasSprites42:
+ax_sprite sLaprasGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLaprasGfx43:
+.incbin "baserom.gba", 0xAAF9F8, 0x60
+sLaprasGfx43_1:
+.incbin "baserom.gba", 0xAAFA58, 0x160
+sLaprasSprites43:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx43_1, 0x160
+ax_sprite_terminator
+sLaprasGfx44:
+.incbin "baserom.gba", 0xAAFBE0, 0x80
+sLaprasSprites44:
+ax_sprite sLaprasGfx44, 0x80
+ax_sprite_terminator
+sLaprasGfx45:
+.incbin "baserom.gba", 0xAAFC70, 0x40
+sLaprasSprites45:
+ax_sprite sLaprasGfx45, 0x40
+ax_sprite_terminator
+sLaprasGfx46:
+.incbin "baserom.gba", 0xAAFCC0, 0x200
+sLaprasSprites46:
+ax_sprite sLaprasGfx46, 0x200
+ax_sprite_terminator
+sLaprasGfx47:
+.incbin "baserom.gba", 0xAAFED0, 0x80
+sLaprasSprites47:
+ax_sprite sLaprasGfx47, 0x80
+ax_sprite_terminator
+sLaprasGfx48:
+.incbin "baserom.gba", 0xAAFF60, 0x40
+sLaprasSprites48:
+ax_sprite sLaprasGfx48, 0x40
+ax_sprite_terminator
+sLaprasGfx49:
+.incbin "baserom.gba", 0xAAFFB0, 0x60
+sLaprasGfx49_1:
+.incbin "baserom.gba", 0xAB0010, 0x60
+sLaprasGfx49_2:
+.incbin "baserom.gba", 0xAB0070, 0xE0
+sLaprasSprites49:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx49_2, 0xe0
+ax_sprite_terminator
+sLaprasGfx50:
+.incbin "baserom.gba", 0xAB0188, 0x80
+sLaprasSprites50:
+ax_sprite sLaprasGfx50, 0x80
+ax_sprite_terminator
+sLaprasGfx51:
+.incbin "baserom.gba", 0xAB0218, 0x20
+sLaprasSprites51:
+ax_sprite sLaprasGfx51, 0x20
+ax_sprite_terminator
+sLaprasGfx52:
+.incbin "baserom.gba", 0xAB0248, 0x20
+sLaprasSprites52:
+ax_sprite sLaprasGfx52, 0x20
+ax_sprite_terminator
+sLaprasGfx53:
+.incbin "baserom.gba", 0xAB0278, 0x1E0
+sLaprasSprites53:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx53, 0x1e0
+ax_sprite_terminator
+sLaprasGfx54:
+.incbin "baserom.gba", 0xAB0470, 0x80
+sLaprasGfx54_1:
+.incbin "baserom.gba", 0xAB04F0, 0x40
+sLaprasSprites54:
+ax_sprite sLaprasGfx54, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx54_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLaprasGfx55:
+.incbin "baserom.gba", 0xAB0558, 0x20
+sLaprasSprites55:
+ax_sprite sLaprasGfx55, 0x20
+ax_sprite_terminator
+sLaprasGfx56:
+.incbin "baserom.gba", 0xAB0588, 0x60
+sLaprasGfx56_1:
+.incbin "baserom.gba", 0xAB05E8, 0x60
+sLaprasGfx56_2:
+.incbin "baserom.gba", 0xAB0648, 0xE0
+sLaprasSprites56:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx56_2, 0xe0
+ax_sprite_terminator
+sLaprasGfx57:
+.incbin "baserom.gba", 0xAB0760, 0x40
+sLaprasSprites57:
+ax_sprite sLaprasGfx57, 0x40
+ax_sprite_terminator
+sLaprasGfx58:
+.incbin "baserom.gba", 0xAB07B0, 0x80
+sLaprasSprites58:
+ax_sprite sLaprasGfx58, 0x80
+ax_sprite_terminator
+sLaprasGfx59:
+.incbin "baserom.gba", 0xAB0840, 0x20
+sLaprasSprites59:
+ax_sprite sLaprasGfx59, 0x20
+ax_sprite_terminator
+sLaprasGfx60:
+.incbin "baserom.gba", 0xAB0870, 0x60
+sLaprasGfx60_1:
+.incbin "baserom.gba", 0xAB08D0, 0x60
+sLaprasGfx60_2:
+.incbin "baserom.gba", 0xAB0930, 0xE0
+sLaprasSprites60:
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx60, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLaprasGfx60_2, 0xe0
+ax_sprite_terminator
+sLaprasGfx61:
+.incbin "baserom.gba", 0xAB0A48, 0x100
+sLaprasSprites61:
+ax_sprite sLaprasGfx61, 0x100
+ax_sprite_terminator
+sLaprasGfx62:
+.incbin "baserom.gba", 0xAB0B58, 0x40
+sLaprasSprites62:
+ax_sprite sLaprasGfx62, 0x40
+ax_sprite_terminator
+sLaprasGfx63:
+.incbin "baserom.gba", 0xAB0BA8, 0x20
+sLaprasSprites63:
+ax_sprite sLaprasGfx63, 0x20
+ax_sprite_terminator
+sLaprasGfx64:
+.incbin "baserom.gba", 0xAB0BD8, 0x200
+sLaprasSprites64:
+ax_sprite sLaprasGfx64, 0x200
+ax_sprite_terminator
+sLaprasGfx65:
+.incbin "baserom.gba", 0xAB0DE8, 0x80
+sLaprasSprites65:
+ax_sprite sLaprasGfx65, 0x80
+ax_sprite_terminator
+sLaprasGfx66:
+.incbin "baserom.gba", 0xAB0E78, 0x200
+sLaprasSprites66:
+ax_sprite sLaprasGfx66, 0x200
+ax_sprite_terminator
+sLaprasGfx67:
+.incbin "baserom.gba", 0xAB1088, 0x80
+sLaprasSprites67:
+ax_sprite sLaprasGfx67, 0x80
+ax_sprite_terminator
+sLaprasGfx68:
+.incbin "baserom.gba", 0xAB1118, 0x400
+sLaprasSprites68:
+ax_sprite sLaprasGfx68, 0x400
+ax_sprite_terminator
+sLaprasGfx69:
+.incbin "baserom.gba", 0xAB1528, 0x40
+sLaprasSprites69:
+ax_sprite sLaprasGfx69, 0x40
+ax_sprite_terminator
+sLaprasGfx70:
+.incbin "baserom.gba", 0xAB1578, 0x400
+sLaprasSprites70:
+ax_sprite sLaprasGfx70, 0x400
+ax_sprite_terminator
+sLaprasGfx71:
+.incbin "baserom.gba", 0xAB1988, 0x80
+sLaprasSprites71:
+ax_sprite sLaprasGfx71, 0x80
+ax_sprite_terminator
+sLaprasGfx72:
+.incbin "baserom.gba", 0xAB1A18, 0x400
+sLaprasSprites72:
+ax_sprite sLaprasGfx72, 0x400
+ax_sprite_terminator
+sLaprasGfx73:
+.incbin "baserom.gba", 0xAB1E28, 0x400
+sLaprasSprites73:
+ax_sprite sLaprasGfx73, 0x400
+ax_sprite_terminator
+sLaprasGfx74:
+.incbin "baserom.gba", 0xAB2238, 0x40
+sLaprasSprites74:
+ax_sprite sLaprasGfx74, 0x40
+ax_sprite_terminator
+sLaprasGfx75:
+.incbin "baserom.gba", 0xAB2288, 0x40
+sLaprasSprites75:
+ax_sprite sLaprasGfx75, 0x40
+ax_sprite_terminator
+sLaprasGfx76:
+.incbin "baserom.gba", 0xAB22D8, 0x400
+sLaprasSprites76:
+ax_sprite sLaprasGfx76, 0x400
+ax_sprite_terminator
+sAxPosesLapras:
+.4byte sLaprasPose1
+.4byte sLaprasPose2
+.4byte sLaprasPose3
+.4byte sLaprasPose4
+.4byte sLaprasPose5
+.4byte sLaprasPose6
+.4byte sLaprasPose7
+.4byte sLaprasPose8
+.4byte sLaprasPose9
+.4byte sLaprasPose10
+.4byte sLaprasPose11
+.4byte sLaprasPose12
+.4byte sLaprasPose13
+.4byte sLaprasPose14
+.4byte sLaprasPose15
+.4byte sLaprasPose16
+.4byte sLaprasPose17
+.4byte sLaprasPose18
+.4byte sLaprasPose19
+.4byte sLaprasPose20
+.4byte sLaprasPose21
+.4byte sLaprasPose22
+.4byte sLaprasPose23
+.4byte sLaprasPose24
+.4byte sLaprasPose25
+.4byte sLaprasPose26
+.4byte sLaprasPose27
+.4byte sLaprasPose28
+.4byte sLaprasPose29
+.4byte sLaprasPose30
+.4byte sLaprasPose31
+.4byte sLaprasPose32
+.4byte sLaprasPose33
+.4byte sLaprasPose34
+.4byte sLaprasPose35
+.4byte sLaprasPose36
+.4byte sLaprasPose37
+.4byte sLaprasPose38
+.4byte sLaprasPose39
+.4byte sLaprasPose40
+.4byte sLaprasPose41
+.4byte sLaprasPose42
+.4byte sLaprasPose43
+.4byte sLaprasPose44
+.4byte sLaprasPose45
+.4byte sLaprasPose46
+.4byte sLaprasPose47
+.4byte sLaprasPose48
+.4byte sLaprasPose49
+.4byte sLaprasPose50
+.4byte sLaprasPose51
+.4byte sLaprasPose52
+.4byte sLaprasPose53
+.4byte sLaprasPose54
+.4byte sLaprasPose55
+.4byte sLaprasPose56
+.4byte sLaprasPose57
+.4byte sLaprasPose58
+.4byte sLaprasPose59
+.4byte sLaprasPose60
+.4byte sLaprasPose61
+.4byte sLaprasPose62
+.4byte sLaprasPose63
+.4byte sLaprasPose64
+.4byte sLaprasPose65
+.4byte sLaprasPose66
+.4byte sLaprasPose67
+.4byte sLaprasPose68
+.4byte sLaprasPose69
+.4byte sLaprasPose70
+.4byte sLaprasPose71
+.4byte sLaprasPose72
+.4byte sLaprasPose73
+.4byte sLaprasPose74
+.4byte sLaprasPose75
+.4byte sLaprasPose76
+.4byte sLaprasPose77
+.4byte sLaprasPose78
+.4byte sLaprasPose79
+.4byte sLaprasPose80
+.4byte sLaprasPose81
+.4byte sLaprasPose82
+.4byte sLaprasPose83
+.4byte sLaprasPose84
+.4byte sLaprasPose85
+.4byte sLaprasPose86
+.4byte sLaprasPose87
+.4byte sLaprasPose88
+.4byte sLaprasPose89
+.4byte sLaprasPose90
+.4byte sLaprasPose91
+.4byte sLaprasPose92
+.4byte sLaprasPose93
+.4byte sLaprasPose94
+.4byte sLaprasPose95
+.4byte sLaprasPose96
+.4byte sLaprasPose97
+.4byte sLaprasPose98
+.4byte sLaprasPose99
+.4byte sLaprasPose100
+.4byte sLaprasPose101
+.4byte sLaprasPose102
+.4byte sLaprasPose103
+.4byte sLaprasPose104
+.4byte sLaprasPose105
+.4byte sLaprasPose106
+.4byte sLaprasPose107
+.4byte sLaprasPose108
+.4byte sLaprasPose109
+.4byte sLaprasPose110
+.4byte sLaprasPose111
+.4byte sLaprasPose112
+.4byte sLaprasPose113
+.4byte sLaprasPose114
+.4byte sLaprasPose115
+.4byte sLaprasPose116
+.4byte sLaprasPose117
+.4byte sLaprasPose118
+.4byte sLaprasPose119
+.4byte sLaprasPose120
+.4byte sLaprasPose121
+.4byte sLaprasPose122
+.4byte sLaprasPose123
+.4byte sLaprasPose124
+.4byte sLaprasPose125
+.4byte sLaprasPose126
+.4byte sLaprasPose127
+.4byte sLaprasPose128
+.4byte sLaprasPose129
+.4byte sLaprasPose130
+.4byte sLaprasPose131
+.4byte sLaprasPose132
+.4byte sLaprasPose133
+.4byte sLaprasPose134
+.4byte sLaprasPose135
+.4byte sLaprasPose136
+.4byte sLaprasPose137
+.4byte sLaprasPose138
+.4byte sLaprasPose139
+.4byte sLaprasPose140
+.4byte sLaprasPose141
+.4byte sLaprasPose142
+.4byte sLaprasPose143
+.4byte sLaprasPose144
+.4byte sLaprasPose145
+.4byte sLaprasPose146
+.4byte sLaprasPose147
+.4byte sLaprasPose148
+.4byte sLaprasPose149
+.4byte sLaprasPose150
+.4byte sLaprasPose151
+.4byte sLaprasPose152
+.4byte sLaprasPose153
+.4byte sLaprasPose154
+.4byte sLaprasPose155
+.4byte sLaprasPose156
+.4byte sLaprasPose157
+.4byte sLaprasPose158
+.4byte sLaprasPose159
+.4byte sLaprasPose160
+.4byte sLaprasPose161
+.4byte sLaprasPose162
+.4byte sLaprasPose163
+.4byte sLaprasPose164
+.4byte sLaprasPose165
+.4byte sLaprasPose166
+.4byte sLaprasPose167
+.4byte sLaprasPose168
+.4byte sLaprasPose169
+.4byte sLaprasPose170
+.4byte sLaprasPose171
+.4byte sLaprasPose172
+.4byte sLaprasPose173
+.4byte sLaprasPose174
+.4byte sLaprasPose175
+.4byte sLaprasPose176
+.4byte sLaprasPose177
+.4byte sLaprasPose178
+.4byte sLaprasPose179
+.4byte sLaprasPose180
+.4byte sLaprasPose181
+.4byte sLaprasPose182
+.4byte sLaprasPose183
+.4byte sLaprasPose184
+.4byte sLaprasPose185
+.4byte sLaprasPose186
+.4byte sLaprasPose187
+.4byte sLaprasPose188
+.4byte sLaprasPose189
+.4byte sLaprasPose190
+.4byte sLaprasPose191
+.4byte sLaprasPose192
+.4byte sLaprasPose193
+.4byte sLaprasPose194
+.4byte sLaprasPose195
+.4byte sLaprasPose196
+.4byte sLaprasPose197
+.4byte sLaprasPose198
+.4byte sLaprasPose199
+.4byte sLaprasPose200
+.4byte sLaprasPose201
+.4byte sLaprasPose202
+.4byte sLaprasPose203
+.4byte sLaprasPose204
+.4byte sLaprasPose205
+.4byte sLaprasPose206
+.4byte sLaprasPose207
+.4byte sLaprasPose208
+.4byte sLaprasPose209
+.4byte sLaprasPose210
+.4byte sLaprasPose211
+.4byte sLaprasPose212
+.4byte sLaprasPose213
+.4byte sLaprasPose214
+.4byte sLaprasPose215
+.4byte sLaprasPose216
+.4byte sLaprasPose217
+.4byte sLaprasPose218
+.4byte sLaprasPose219
+.4byte sLaprasPose220
+.4byte sLaprasPose221
+.4byte sLaprasPose222
+.4byte sLaprasPose223
+.4byte sLaprasPose224
+.4byte sLaprasPose225
+.4byte sLaprasPose226
+.4byte sLaprasPose227
+.4byte sLaprasPose228
+.4byte sLaprasPose229
+.4byte sLaprasPose230
+.4byte sLaprasPose231
+.4byte sLaprasPose232
+.4byte sLaprasPose233
+.4byte sLaprasPose234
+.4byte sLaprasPose235
+.4byte sLaprasPose236
+.4byte sLaprasPose237
+.4byte sLaprasPose238
+.4byte sLaprasPose239
+.4byte sLaprasPose240
+.4byte sLaprasPose241
+.4byte sLaprasPose242
+.4byte sLaprasPose243
+.4byte sLaprasPose244
+.4byte sLaprasPose245
+.4byte sLaprasPose246
+.4byte sLaprasPose247
+.4byte sLaprasPose248
+.4byte sLaprasPose249
+.4byte sLaprasPose250
+.4byte sLaprasPose251
+.4byte sLaprasPose252
+.4byte sLaprasPose253
+.4byte sLaprasPose254
+.4byte sLaprasPose255
+.4byte sLaprasPose256
+.4byte sLaprasPose257
+.4byte sLaprasPose258
+sAxPositionsLapras:
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -1,  -13, 	 -17,    4, 	  15,    4, 	  -1,  -11
+.2byte   -1,  -11, 	 -17,   -3, 	  15,   -3, 	  -1,   -7
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+.2byte    4,  -17, 	  15,   -4, 	 -10,    4, 	  -3,   -9
+.2byte    6,  -15, 	  13,   -3, 	 -14,    3, 	   0,   -7
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte    9,  -18, 	   2,   -8, 	   2,    4, 	   0,   -9
+.2byte   12,  -16, 	  -3,   -6, 	  -5,    6, 	   1,   -7
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte    7,  -20, 	  -9,  -12, 	  14,   -3, 	   0,  -11
+.2byte    9,  -18, 	 -13,   -6, 	  10,    4, 	  -1,   -7
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte   -1,  -21, 	  16,   -8, 	 -18,   -8, 	  -1,  -10
+.2byte   -1,  -19, 	  15,    0, 	 -17,    0, 	  -1,  -10
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte   -9,  -20, 	   7,  -12, 	 -16,   -3, 	  -2,  -11
+.2byte  -11,  -18, 	  11,   -6, 	 -12,    4, 	  -1,   -7
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte  -11,  -18, 	  -4,   -8, 	  -4,    4, 	  -2,   -9
+.2byte  -14,  -16, 	   1,   -6, 	   3,    6, 	  -3,   -7
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte   -6,  -17, 	 -17,   -4, 	   8,    4, 	   1,   -9
+.2byte   -8,  -15, 	 -15,   -3, 	  12,    3, 	  -2,   -7
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -1,  -13, 	 -17,    4, 	  15,    4, 	  -1,  -11
+.2byte   -1,  -11, 	 -17,   -3, 	  15,   -3, 	  -1,   -7
+.2byte   -1,  -19, 	 -15,    3, 	  13,    3, 	  -1,  -10
+.2byte   -1,  -10, 	 -18,   -3, 	  16,   -3, 	  -1,   -5
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+.2byte    4,  -17, 	  15,   -4, 	 -10,    4, 	  -3,   -9
+.2byte    6,  -15, 	  13,   -3, 	 -14,    3, 	   0,   -7
+.2byte    3,  -19, 	  15,   -1, 	  -8,    8, 	  -2,   -6
+.2byte   13,  -11, 	  15,   -5, 	 -12,    4, 	   2,   -7
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte    9,  -18, 	   2,   -8, 	   2,    4, 	   0,   -9
+.2byte   12,  -16, 	  -3,   -6, 	  -5,    6, 	   1,   -7
+.2byte    4,  -23, 	   5,   -6, 	   7,    5, 	  -3,   -8
+.2byte   19,  -14, 	  -1,   -9, 	  -4,    3, 	   2,   -8
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte    7,  -20, 	  -9,  -12, 	  14,   -3, 	   0,  -11
+.2byte    9,  -18, 	 -13,   -6, 	  10,    4, 	  -1,   -7
+.2byte    3,  -24, 	  -9,   -9, 	  12,    0, 	  -2,  -10
+.2byte   18,  -19, 	 -12,   -8, 	   8,    6, 	   2,   -9
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte   -1,  -21, 	  16,   -8, 	 -18,   -8, 	  -1,  -10
+.2byte   -1,  -19, 	  15,    0, 	 -17,    0, 	  -1,  -10
+.2byte   -1,  -29, 	  15,   -5, 	 -17,   -5, 	  -1,  -11
+.2byte   -1,  -21, 	  14,    0, 	 -16,    0, 	  -1,  -10
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte   -9,  -20, 	   7,  -12, 	 -16,   -3, 	  -2,  -11
+.2byte  -11,  -18, 	  11,   -6, 	 -12,    4, 	  -1,   -7
+.2byte   -5,  -24, 	   7,   -9, 	 -14,    0, 	   0,  -10
+.2byte  -20,  -19, 	  10,   -8, 	 -10,    6, 	  -4,   -9
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte  -11,  -18, 	  -4,   -8, 	  -4,    4, 	  -2,   -9
+.2byte  -14,  -16, 	   1,   -6, 	   3,    6, 	  -3,   -7
+.2byte   -6,  -23, 	  -7,   -6, 	  -9,    5, 	   1,   -8
+.2byte  -21,  -14, 	  -1,   -9, 	   2,    3, 	  -4,   -8
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte   -6,  -17, 	 -17,   -4, 	   8,    4, 	   1,   -9
+.2byte   -8,  -15, 	 -15,   -3, 	  12,    3, 	  -2,   -7
+.2byte   -5,  -19, 	 -17,   -1, 	   6,    8, 	   0,   -6
+.2byte  -15,  -11, 	 -17,   -5, 	  10,    4, 	  -4,   -7
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -1,  -13, 	 -17,    4, 	  15,    4, 	  -1,  -11
+.2byte   -1,  -11, 	 -17,   -3, 	  15,   -3, 	  -1,   -7
+.2byte   -1,  -19, 	 -15,    3, 	  13,    3, 	  -1,  -10
+.2byte   -1,  -10, 	 -18,   -3, 	  16,   -3, 	  -1,   -5
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+.2byte    4,  -17, 	  15,   -4, 	 -10,    4, 	  -3,   -9
+.2byte    6,  -15, 	  13,   -3, 	 -14,    3, 	   0,   -7
+.2byte    3,  -19, 	  15,   -1, 	  -8,    8, 	  -2,   -6
+.2byte   13,  -11, 	  15,   -5, 	 -12,    4, 	   2,   -7
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte    9,  -18, 	   2,   -8, 	   2,    4, 	   0,   -9
+.2byte   12,  -16, 	  -3,   -6, 	  -5,    6, 	   1,   -7
+.2byte    4,  -23, 	   5,   -6, 	   7,    5, 	  -3,   -8
+.2byte   19,  -14, 	  -1,   -9, 	  -4,    3, 	   2,   -8
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte    7,  -20, 	  -9,  -12, 	  14,   -3, 	   0,  -11
+.2byte    9,  -18, 	 -13,   -6, 	  10,    4, 	  -1,   -7
+.2byte    3,  -24, 	  -9,   -9, 	  12,    0, 	  -2,  -10
+.2byte   18,  -19, 	 -12,   -8, 	   8,    6, 	   2,   -9
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte   -1,  -21, 	  16,   -8, 	 -18,   -8, 	  -1,  -10
+.2byte   -1,  -19, 	  15,    0, 	 -17,    0, 	  -1,  -10
+.2byte   -1,  -29, 	  15,   -5, 	 -17,   -5, 	  -1,  -11
+.2byte   -1,  -21, 	  14,    0, 	 -16,    0, 	  -1,  -10
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte   -9,  -20, 	   7,  -12, 	 -16,   -3, 	  -2,  -11
+.2byte  -11,  -18, 	  11,   -6, 	 -12,    4, 	  -1,   -7
+.2byte   -5,  -24, 	   7,   -9, 	 -14,    0, 	   0,  -10
+.2byte  -20,  -19, 	  10,   -8, 	 -10,    6, 	  -4,   -9
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte  -11,  -18, 	  -4,   -8, 	  -4,    4, 	  -2,   -9
+.2byte  -14,  -16, 	   1,   -6, 	   3,    6, 	  -3,   -7
+.2byte   -6,  -23, 	  -7,   -6, 	  -9,    5, 	   1,   -8
+.2byte  -21,  -14, 	  -1,   -9, 	   2,    3, 	  -4,   -8
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte   -6,  -17, 	 -17,   -4, 	   8,    4, 	   1,   -9
+.2byte   -8,  -15, 	 -15,   -3, 	  12,    3, 	  -2,   -7
+.2byte   -5,  -19, 	 -17,   -1, 	   6,    8, 	   0,   -6
+.2byte  -15,  -11, 	 -17,   -5, 	  10,    4, 	  -4,   -7
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -1,  -13, 	 -17,    4, 	  15,    4, 	  -1,  -11
+.2byte   -1,  -11, 	 -17,   -3, 	  15,   -3, 	  -1,   -7
+.2byte   -1,  -19, 	 -15,    3, 	  13,    3, 	  -1,  -10
+.2byte   -1,  -10, 	 -18,   -3, 	  16,   -3, 	  -1,   -5
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+.2byte    4,  -17, 	  15,   -4, 	 -10,    4, 	  -3,   -9
+.2byte    6,  -15, 	  13,   -3, 	 -14,    3, 	   0,   -7
+.2byte    3,  -19, 	  15,   -1, 	  -8,    8, 	  -2,   -6
+.2byte   13,  -11, 	  15,   -5, 	 -12,    4, 	   2,   -7
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte    9,  -18, 	   2,   -8, 	   2,    4, 	   0,   -9
+.2byte   12,  -16, 	  -3,   -6, 	  -5,    6, 	   1,   -7
+.2byte    4,  -23, 	   5,   -6, 	   7,    5, 	  -3,   -8
+.2byte   19,  -14, 	  -1,   -9, 	  -4,    3, 	   2,   -8
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte    7,  -20, 	  -9,  -12, 	  14,   -3, 	   0,  -11
+.2byte    9,  -18, 	 -13,   -6, 	  10,    4, 	  -1,   -7
+.2byte    3,  -24, 	  -9,   -9, 	  12,    0, 	  -2,  -10
+.2byte   18,  -19, 	 -12,   -8, 	   8,    6, 	   2,   -9
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte   -1,  -21, 	  16,   -8, 	 -18,   -8, 	  -1,  -10
+.2byte   -1,  -19, 	  15,    0, 	 -17,    0, 	  -1,  -10
+.2byte   -1,  -29, 	  15,   -5, 	 -17,   -5, 	  -1,  -11
+.2byte   -1,  -21, 	  14,    0, 	 -16,    0, 	  -1,  -10
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte   -9,  -20, 	   7,  -12, 	 -16,   -3, 	  -2,  -11
+.2byte  -11,  -18, 	  11,   -6, 	 -12,    4, 	  -1,   -7
+.2byte   -5,  -24, 	   7,   -9, 	 -14,    0, 	   0,  -10
+.2byte  -20,  -19, 	  10,   -8, 	 -10,    6, 	  -4,   -9
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte  -11,  -18, 	  -4,   -8, 	  -4,    4, 	  -2,   -9
+.2byte  -14,  -16, 	   1,   -6, 	   3,    6, 	  -3,   -7
+.2byte   -6,  -23, 	  -7,   -6, 	  -9,    5, 	   1,   -8
+.2byte  -21,  -14, 	  -1,   -9, 	   2,    3, 	  -4,   -8
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte   -6,  -17, 	 -17,   -4, 	   8,    4, 	   1,   -9
+.2byte   -8,  -15, 	 -15,   -3, 	  12,    3, 	  -2,   -7
+.2byte   -5,  -19, 	 -17,   -1, 	   6,    8, 	   0,   -6
+.2byte  -15,  -11, 	 -17,   -5, 	  10,    4, 	  -4,   -7
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -1,  -13, 	 -17,    4, 	  15,    4, 	  -1,  -11
+.2byte   -1,  -11, 	 -17,   -3, 	  15,   -3, 	  -1,   -7
+.2byte   -1,  -24, 	 -18,    3, 	  16,    2, 	  -1,   -6
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+.2byte    4,  -17, 	  15,   -4, 	 -10,    4, 	  -3,   -9
+.2byte    6,  -15, 	  13,   -3, 	 -14,    3, 	   0,   -7
+.2byte    0,  -25, 	  14,   -5, 	  -9,    5, 	  -3,   -9
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte    9,  -18, 	   2,   -8, 	   2,    4, 	   0,   -9
+.2byte   12,  -16, 	  -3,   -6, 	  -5,    6, 	   1,   -7
+.2byte    1,  -23, 	  -5,   -4, 	  -3,    8, 	  -3,   -6
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte    7,  -20, 	  -9,  -12, 	  14,   -3, 	   0,  -11
+.2byte    9,  -18, 	 -13,   -6, 	  10,    4, 	  -1,   -7
+.2byte    3,  -25, 	 -12,   -8, 	  13,    2, 	  -2,  -10
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte   -1,  -21, 	  16,   -8, 	 -18,   -8, 	  -1,  -10
+.2byte   -1,  -19, 	  15,    0, 	 -17,    0, 	  -1,  -10
+.2byte   -1,  -28, 	  15,   -2, 	 -17,   -2, 	  -1,  -11
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte   -9,  -20, 	   7,  -12, 	 -16,   -3, 	  -2,  -11
+.2byte  -11,  -18, 	  11,   -6, 	 -12,    4, 	  -1,   -7
+.2byte   -5,  -25, 	  10,   -8, 	 -15,    2, 	   0,  -10
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte  -11,  -18, 	  -4,   -8, 	  -4,    4, 	  -2,   -9
+.2byte  -14,  -16, 	   1,   -6, 	   3,    6, 	  -3,   -7
+.2byte   -3,  -23, 	   3,   -4, 	   1,    8, 	   1,   -6
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte   -6,  -17, 	 -17,   -4, 	   8,    4, 	   1,   -9
+.2byte   -8,  -15, 	 -15,   -3, 	  12,    3, 	  -2,   -7
+.2byte   -2,  -25, 	 -16,   -5, 	   7,    5, 	   1,   -9
+.2byte   -7,    9, 	 -16,   -5, 	  11,    5, 	   0,   -9
+.2byte   -7,    9, 	 -17,   -4, 	  12,    6, 	   0,   -9
+.2byte   -1,  -33, 	 -15,  -17, 	  13,  -17, 	  -1,  -14
+.2byte    0,  -32, 	   9,  -24, 	 -12,  -18, 	  -2,  -13
+.2byte   -1,  -30, 	   7,  -23, 	  -7,  -15, 	   0,  -15
+.2byte    3,  -31, 	  -9,  -21, 	  12,  -18, 	  -3,  -14
+.2byte   -1,  -31, 	  13,  -18, 	 -15,  -18, 	  -1,  -12
+.2byte   -4,  -31, 	   8,  -21, 	 -13,  -18, 	   2,  -14
+.2byte    0,  -30, 	  -8,  -23, 	   6,  -15, 	  -1,  -15
+.2byte   -1,  -32, 	 -10,  -24, 	  11,  -18, 	   1,  -13
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -1,  -11, 	 -17,   -3, 	  15,   -3, 	  -1,   -7
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+.2byte    6,  -15, 	  13,   -3, 	 -14,    3, 	   0,   -7
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte   12,  -16, 	  -3,   -6, 	  -5,    6, 	   1,   -7
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte    9,  -18, 	 -13,   -6, 	  10,    4, 	  -1,   -7
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte   -1,  -19, 	  15,    0, 	 -17,    0, 	  -1,  -10
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte  -11,  -18, 	  11,   -6, 	 -12,    4, 	  -1,   -7
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte  -14,  -16, 	   1,   -6, 	   3,    6, 	  -3,   -7
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte   -8,  -15, 	 -15,   -3, 	  12,    3, 	  -2,   -7
+.2byte   -1,  -10, 	 -18,   -3, 	  16,   -3, 	  -1,   -5
+.2byte  -12,  -11, 	 -14,   -5, 	  13,    4, 	  -1,   -7
+.2byte  -18,  -14, 	   2,   -9, 	   5,    3, 	  -1,   -8
+.2byte  -16,  -19, 	  14,   -8, 	  -6,    6, 	   0,   -9
+.2byte   -1,  -21, 	  14,    0, 	 -16,    0, 	  -1,  -10
+.2byte   15,  -19, 	 -15,   -8, 	   5,    6, 	  -1,   -9
+.2byte   17,  -14, 	  -3,   -9, 	  -6,    3, 	   0,   -8
+.2byte   11,  -11, 	  13,   -5, 	 -14,    4, 	   0,   -7
+.2byte   -1,  -25, 	 -18,    2, 	  16,    1, 	  -1,   -7
+.2byte    0,  -25, 	  14,   -5, 	  -9,    5, 	  -3,   -9
+.2byte    3,  -24, 	  -3,   -5, 	  -1,    7, 	  -1,   -7
+.2byte    3,  -25, 	 -12,   -8, 	  13,    2, 	  -2,  -10
+.2byte   -1,  -28, 	  15,   -2, 	 -17,   -2, 	  -1,  -11
+.2byte   -5,  -25, 	  10,   -8, 	 -15,    2, 	   0,  -10
+.2byte   -5,  -24, 	   1,   -5, 	  -1,    7, 	  -1,   -7
+.2byte   -2,  -25, 	 -16,   -5, 	   7,    5, 	   1,   -9
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -1,  -19, 	 -15,    3, 	  13,    3, 	  -1,  -10
+.2byte   -1,  -10, 	 -18,   -3, 	  16,   -3, 	  -1,   -5
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+.2byte    3,  -19, 	  15,   -1, 	  -8,    8, 	  -2,   -6
+.2byte   11,  -11, 	  13,   -5, 	 -14,    4, 	   0,   -7
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte    4,  -23, 	   5,   -6, 	   7,    5, 	  -3,   -8
+.2byte   17,  -14, 	  -3,   -9, 	  -6,    3, 	   0,   -8
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte    3,  -24, 	  -9,   -9, 	  12,    0, 	  -2,  -10
+.2byte   18,  -19, 	 -12,   -8, 	   8,    6, 	   2,   -9
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte   -1,  -29, 	  15,   -5, 	 -17,   -5, 	  -1,  -11
+.2byte   -1,  -21, 	  14,    0, 	 -16,    0, 	  -1,  -10
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte   -5,  -24, 	   7,   -9, 	 -14,    0, 	   0,  -10
+.2byte  -20,  -19, 	  10,   -8, 	 -10,    6, 	  -4,   -9
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte   -6,  -23, 	  -7,   -6, 	  -9,    5, 	   1,   -8
+.2byte  -19,  -14, 	   1,   -9, 	   4,    3, 	  -2,   -8
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte   -5,  -19, 	 -17,   -1, 	   6,    8, 	   0,   -6
+.2byte  -13,  -11, 	 -15,   -5, 	  12,    4, 	  -2,   -7
+.2byte   -1,  -19, 	 -15,    3, 	  13,    3, 	  -1,  -10
+.2byte   -5,  -20, 	 -17,   -2, 	   6,    7, 	   0,   -7
+.2byte   -8,  -23, 	  -9,   -6, 	 -11,    5, 	  -1,   -8
+.2byte   -7,  -24, 	   5,   -9, 	 -16,    0, 	  -2,  -10
+.2byte   -1,  -29, 	  15,   -5, 	 -17,   -5, 	  -1,  -11
+.2byte    5,  -24, 	  -7,   -9, 	  14,    0, 	   0,  -10
+.2byte    6,  -23, 	   7,   -6, 	   9,    5, 	  -1,   -8
+.2byte    4,  -20, 	  16,   -2, 	  -7,    7, 	  -1,   -7
+.2byte   -1,  -12, 	 -18,    2, 	  16,    2, 	  -1,  -10
+.2byte   -7,  -16, 	 -16,   -3, 	  10,    6, 	   0,   -9
+.2byte  -12,  -17, 	  -5,   -7, 	   0,    6, 	  -2,   -8
+.2byte  -10,  -19, 	   9,   -9, 	 -14,    2, 	  -2,   -9
+.2byte   -1,  -21, 	  16,   -2, 	 -18,   -2, 	  -1,  -10
+.2byte    8,  -19, 	 -11,   -9, 	  12,    2, 	   0,   -9
+.2byte   10,  -17, 	   3,   -7, 	  -2,    6, 	   0,   -8
+.2byte    5,  -16, 	  14,   -3, 	 -12,    6, 	  -2,   -9
+sLaprasAnimTable1:
+.4byte sLaprasAnims_1_1
+.4byte sLaprasAnims_1_2
+.4byte sLaprasAnims_1_3
+.4byte sLaprasAnims_1_4
+.4byte sLaprasAnims_1_5
+.4byte sLaprasAnims_1_6
+.4byte sLaprasAnims_1_7
+.4byte sLaprasAnims_1_8
+sLaprasAnimTable2:
+.4byte sLaprasAnims_2_1
+.4byte sLaprasAnims_2_2
+.4byte sLaprasAnims_2_3
+.4byte sLaprasAnims_2_4
+.4byte sLaprasAnims_2_5
+.4byte sLaprasAnims_2_6
+.4byte sLaprasAnims_2_7
+.4byte sLaprasAnims_2_8
+sLaprasAnimTable3:
+.4byte sLaprasAnims_3_1
+.4byte sLaprasAnims_3_2
+.4byte sLaprasAnims_3_3
+.4byte sLaprasAnims_3_4
+.4byte sLaprasAnims_3_5
+.4byte sLaprasAnims_3_6
+.4byte sLaprasAnims_3_7
+.4byte sLaprasAnims_3_8
+sLaprasAnimTable4:
+.4byte sLaprasAnims_4_1
+.4byte sLaprasAnims_4_2
+.4byte sLaprasAnims_4_3
+.4byte sLaprasAnims_4_4
+.4byte sLaprasAnims_4_5
+.4byte sLaprasAnims_4_6
+.4byte sLaprasAnims_4_7
+.4byte sLaprasAnims_4_8
+sLaprasAnimTable5:
+.4byte sLaprasAnims_5_1
+.4byte sLaprasAnims_5_2
+.4byte sLaprasAnims_5_3
+.4byte sLaprasAnims_5_4
+.4byte sLaprasAnims_5_5
+.4byte sLaprasAnims_5_6
+.4byte sLaprasAnims_5_7
+.4byte sLaprasAnims_5_8
+sLaprasAnimTable6:
+.4byte sLaprasAnims_6_1
+.4byte sLaprasAnims_6_1
+.4byte sLaprasAnims_6_1
+.4byte sLaprasAnims_6_1
+.4byte sLaprasAnims_6_1
+.4byte sLaprasAnims_6_1
+.4byte sLaprasAnims_6_1
+.4byte sLaprasAnims_6_1
+sLaprasAnimTable7:
+.4byte sLaprasAnims_7_1
+.4byte sLaprasAnims_7_2
+.4byte sLaprasAnims_7_3
+.4byte sLaprasAnims_7_4
+.4byte sLaprasAnims_7_5
+.4byte sLaprasAnims_7_6
+.4byte sLaprasAnims_7_7
+.4byte sLaprasAnims_7_8
+sLaprasAnimTable8:
+.4byte sLaprasAnims_8_1
+.4byte sLaprasAnims_8_2
+.4byte sLaprasAnims_8_3
+.4byte sLaprasAnims_8_4
+.4byte sLaprasAnims_8_5
+.4byte sLaprasAnims_8_6
+.4byte sLaprasAnims_8_7
+.4byte sLaprasAnims_8_8
+sLaprasAnimTable9:
+.4byte sLaprasAnims_9_1
+.4byte sLaprasAnims_9_2
+.4byte sLaprasAnims_9_3
+.4byte sLaprasAnims_9_4
+.4byte sLaprasAnims_9_5
+.4byte sLaprasAnims_9_6
+.4byte sLaprasAnims_9_7
+.4byte sLaprasAnims_9_8
+sLaprasAnimTable10:
+.4byte sLaprasAnims_10_1
+.4byte sLaprasAnims_10_2
+.4byte sLaprasAnims_10_3
+.4byte sLaprasAnims_10_4
+.4byte sLaprasAnims_10_5
+.4byte sLaprasAnims_10_6
+.4byte sLaprasAnims_10_7
+.4byte sLaprasAnims_10_8
+sLaprasAnimTable11:
+.4byte sLaprasAnims_11_1
+.4byte sLaprasAnims_11_2
+.4byte sLaprasAnims_11_3
+.4byte sLaprasAnims_11_4
+.4byte sLaprasAnims_11_5
+.4byte sLaprasAnims_11_6
+.4byte sLaprasAnims_11_7
+.4byte sLaprasAnims_11_8
+sLaprasAnimTable12:
+.4byte sLaprasAnims_12_1
+.4byte sLaprasAnims_12_2
+.4byte sLaprasAnims_12_3
+.4byte sLaprasAnims_12_4
+.4byte sLaprasAnims_12_5
+.4byte sLaprasAnims_12_6
+.4byte sLaprasAnims_12_7
+.4byte sLaprasAnims_12_8
+sLaprasAnimTable13:
+.4byte sLaprasAnims_13_1
+.4byte sLaprasAnims_13_2
+.4byte sLaprasAnims_13_3
+.4byte sLaprasAnims_13_4
+.4byte sLaprasAnims_13_5
+.4byte sLaprasAnims_13_6
+.4byte sLaprasAnims_13_7
+.4byte sLaprasAnims_13_8
+sAxAnimationsLapras:
+.4byte sLaprasAnimTable1
+.4byte sLaprasAnimTable2
+.4byte sLaprasAnimTable3
+.4byte sLaprasAnimTable4
+.4byte sLaprasAnimTable5
+.4byte sLaprasAnimTable6
+.4byte sLaprasAnimTable7
+.4byte sLaprasAnimTable8
+.4byte sLaprasAnimTable9
+.4byte sLaprasAnimTable10
+.4byte sLaprasAnimTable11
+.4byte sLaprasAnimTable12
+.4byte sLaprasAnimTable13
+sAxSpritesLapras:
+.4byte sLaprasSprites1
+.4byte sLaprasSprites2
+.4byte sLaprasSprites3
+.4byte sLaprasSprites4
+.4byte sLaprasSprites5
+.4byte sLaprasSprites6
+.4byte sLaprasSprites7
+.4byte sLaprasSprites8
+.4byte sLaprasSprites9
+.4byte sLaprasSprites10
+.4byte sLaprasSprites11
+.4byte sLaprasSprites12
+.4byte sLaprasSprites13
+.4byte sLaprasSprites14
+.4byte sLaprasSprites15
+.4byte sLaprasSprites16
+.4byte sLaprasSprites17
+.4byte sLaprasSprites18
+.4byte sLaprasSprites19
+.4byte sLaprasSprites20
+.4byte sLaprasSprites21
+.4byte sLaprasSprites22
+.4byte sLaprasSprites23
+.4byte sLaprasSprites24
+.4byte sLaprasSprites25
+.4byte sLaprasSprites26
+.4byte sLaprasSprites27
+.4byte sLaprasSprites28
+.4byte sLaprasSprites29
+.4byte sLaprasSprites30
+.4byte sLaprasSprites31
+.4byte sLaprasSprites32
+.4byte sLaprasSprites33
+.4byte sLaprasSprites34
+.4byte sLaprasSprites35
+.4byte sLaprasSprites36
+.4byte sLaprasSprites37
+.4byte sLaprasSprites38
+.4byte sLaprasSprites39
+.4byte sLaprasSprites40
+.4byte sLaprasSprites41
+.4byte sLaprasSprites42
+.4byte sLaprasSprites43
+.4byte sLaprasSprites44
+.4byte sLaprasSprites45
+.4byte sLaprasSprites46
+.4byte sLaprasSprites47
+.4byte sLaprasSprites48
+.4byte sLaprasSprites49
+.4byte sLaprasSprites50
+.4byte sLaprasSprites51
+.4byte sLaprasSprites52
+.4byte sLaprasSprites53
+.4byte sLaprasSprites54
+.4byte sLaprasSprites55
+.4byte sLaprasSprites56
+.4byte sLaprasSprites57
+.4byte sLaprasSprites58
+.4byte sLaprasSprites59
+.4byte sLaprasSprites60
+.4byte sLaprasSprites61
+.4byte sLaprasSprites62
+.4byte sLaprasSprites63
+.4byte sLaprasSprites64
+.4byte sLaprasSprites65
+.4byte sLaprasSprites66
+.4byte sLaprasSprites67
+.4byte sLaprasSprites68
+.4byte sLaprasSprites69
+.4byte sLaprasSprites70
+.4byte sLaprasSprites71
+.4byte sLaprasSprites72
+.4byte sLaprasSprites73
+.4byte sLaprasSprites74
+.4byte sLaprasSprites75
+.4byte sLaprasSprites76
+sAxMainLapras:
+ax_main sAxPosesLapras, sAxAnimationsLapras, 13, sAxSpritesLapras, sAxPositionsLapras

--- a/data/ax/larvitar.inc
+++ b/data/ax/larvitar.inc
@@ -1,0 +1,2488 @@
+.global gAxLarvitar
+gAxLarvitar:
+ax_siro sAxMainLarvitar
+sLarvitarPose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose3:
+ax_pose 2, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose4:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose5:
+ax_pose 4, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose6:
+ax_pose 5, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose7:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose8:
+ax_pose 7, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose9:
+ax_pose 8, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose10:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose11:
+ax_pose 10, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose12:
+ax_pose 11, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose14:
+ax_pose 13, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose15:
+ax_pose 14, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose19:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose20:
+ax_pose 7, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose21:
+ax_pose 8, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose25:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose26:
+ax_pose 1, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose27:
+ax_pose 2, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose28:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose29:
+ax_pose 4, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose30:
+ax_pose 5, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose31:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose32:
+ax_pose 7, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose33:
+ax_pose 8, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose34:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose35:
+ax_pose 10, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose36:
+ax_pose 11, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose37:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose38:
+ax_pose 13, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose39:
+ax_pose 14, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose41:
+ax_pose 10, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose43:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose44:
+ax_pose 7, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose45:
+ax_pose 8, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose47:
+ax_pose 4, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose48:
+ax_pose 5, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose49:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose50:
+ax_pose 1, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose51:
+ax_pose 2, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose52:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose53:
+ax_pose 4, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose54:
+ax_pose 5, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose55:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose56:
+ax_pose 7, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose57:
+ax_pose 8, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose58:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose59:
+ax_pose 10, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose60:
+ax_pose 11, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose61:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose62:
+ax_pose 13, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose63:
+ax_pose 14, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose64:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose65:
+ax_pose 10, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose66:
+ax_pose 11, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose67:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose68:
+ax_pose 7, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose69:
+ax_pose 8, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose71:
+ax_pose 4, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose72:
+ax_pose 5, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose73:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose74:
+ax_pose 15, 0x81e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sLarvitarPose75:
+ax_pose 16, 0x81e8, 0x80f7, 0x3c00
+ax_pose 17, 0x01f8, 0x0107, 0x3c08
+ax_pose_terminator
+sLarvitarPose76:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose77:
+ax_pose 18, 0x81ec, 0x90f5, 0x3c00
+ax_pose 19, 0x01fc, 0x10ed, 0x3c08
+ax_pose_terminator
+sLarvitarPose78:
+ax_pose 20, 0x81ec, 0x90f9, 0x3c00
+ax_pose 21, 0x01f4, 0x10f1, 0x3c08
+ax_pose_terminator
+sLarvitarPose79:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose80:
+ax_pose 22, 0x81e9, 0x90f9, 0x3c00
+ax_pose 23, 0x01f9, 0x10f1, 0x3c08
+ax_pose_terminator
+sLarvitarPose81:
+ax_pose 24, 0x81eb, 0x90fa, 0x3c00
+ax_pose 25, 0x81f3, 0x10f2, 0x3c08
+ax_pose_terminator
+sLarvitarPose82:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose83:
+ax_pose 26, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sLarvitarPose84:
+ax_pose 27, 0x81ea, 0x90f9, 0x3c00
+ax_pose 28, 0x01fa, 0x10f1, 0x3c08
+ax_pose_terminator
+sLarvitarPose85:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose86:
+ax_pose 29, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sLarvitarPose87:
+ax_pose 30, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sLarvitarPose88:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose89:
+ax_pose 26, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sLarvitarPose90:
+ax_pose 27, 0x81ea, 0x80f6, 0x3c00
+ax_pose 28, 0x01fa, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose91:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose92:
+ax_pose 22, 0x81e9, 0x80f6, 0x3c00
+ax_pose 23, 0x01f9, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose93:
+ax_pose 24, 0x81eb, 0x80f5, 0x3c00
+ax_pose 25, 0x81f3, 0x0105, 0x3c08
+ax_pose_terminator
+sLarvitarPose94:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose95:
+ax_pose 18, 0x81ec, 0x80fa, 0x3c00
+ax_pose 19, 0x01fc, 0x010a, 0x3c08
+ax_pose_terminator
+sLarvitarPose96:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose 21, 0x01f4, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose97:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose98:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose99:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose100:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose101:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose102:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose103:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose104:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose105:
+ax_pose 31, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose106:
+ax_pose 32, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose107:
+ax_pose 33, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sLarvitarPose108:
+ax_pose 34, 0x01e3, 0x90ea, 0x3c00
+ax_pose_terminator
+sLarvitarPose109:
+ax_pose 35, 0x01e4, 0x90ea, 0x3c00
+ax_pose_terminator
+sLarvitarPose110:
+ax_pose 36, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sLarvitarPose111:
+ax_pose 37, 0x01e8, 0x80f1, 0x3c00
+ax_pose_terminator
+sLarvitarPose112:
+ax_pose 36, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sLarvitarPose113:
+ax_pose 35, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sLarvitarPose114:
+ax_pose 34, 0x01e3, 0x80f6, 0x3c00
+ax_pose_terminator
+sLarvitarPose115:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose116:
+ax_pose 1, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose117:
+ax_pose 2, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose118:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose119:
+ax_pose 4, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose120:
+ax_pose 5, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose121:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose122:
+ax_pose 7, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose123:
+ax_pose 8, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose124:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose125:
+ax_pose 10, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose126:
+ax_pose 11, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose127:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose128:
+ax_pose 13, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose129:
+ax_pose 14, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose130:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose131:
+ax_pose 10, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose132:
+ax_pose 11, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose133:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose134:
+ax_pose 7, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose135:
+ax_pose 8, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose136:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose137:
+ax_pose 4, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose138:
+ax_pose 5, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose139:
+ax_pose 16, 0x81e8, 0x80f7, 0x3c00
+ax_pose 17, 0x01f8, 0x0107, 0x3c08
+ax_pose_terminator
+sLarvitarPose140:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose 21, 0x01f4, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose141:
+ax_pose 24, 0x81eb, 0x80f5, 0x3c00
+ax_pose 25, 0x81f3, 0x0105, 0x3c08
+ax_pose_terminator
+sLarvitarPose142:
+ax_pose 27, 0x81e9, 0x80f6, 0x3c00
+ax_pose 28, 0x01f9, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose143:
+ax_pose 30, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sLarvitarPose144:
+ax_pose 27, 0x81e9, 0x90f9, 0x3c00
+ax_pose 28, 0x01f9, 0x10f1, 0x3c08
+ax_pose_terminator
+sLarvitarPose145:
+ax_pose 24, 0x81eb, 0x90fa, 0x3c00
+ax_pose 25, 0x81f3, 0x10f2, 0x3c08
+ax_pose_terminator
+sLarvitarPose146:
+ax_pose 20, 0x81ec, 0x90f9, 0x3c00
+ax_pose 21, 0x01f4, 0x10f1, 0x3c08
+ax_pose_terminator
+sLarvitarPose147:
+ax_pose 15, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sLarvitarPose148:
+ax_pose 18, 0x81eb, 0x90f8, 0x3c00
+ax_pose 19, 0x01fb, 0x10f0, 0x3c08
+ax_pose_terminator
+sLarvitarPose149:
+ax_pose 22, 0x81e9, 0x90fb, 0x3c00
+ax_pose 23, 0x01f9, 0x10f3, 0x3c08
+ax_pose_terminator
+sLarvitarPose150:
+ax_pose 26, 0x81ec, 0x90f7, 0x3c00
+ax_pose_terminator
+sLarvitarPose151:
+ax_pose 29, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sLarvitarPose152:
+ax_pose 26, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sLarvitarPose153:
+ax_pose 22, 0x81e9, 0x80f6, 0x3c00
+ax_pose 23, 0x01f9, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose154:
+ax_pose 18, 0x81eb, 0x80f9, 0x3c00
+ax_pose 19, 0x01fb, 0x0109, 0x3c08
+ax_pose_terminator
+sLarvitarPose155:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose156:
+ax_pose 15, 0x81e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sLarvitarPose157:
+ax_pose 16, 0x81e8, 0x80f7, 0x3c00
+ax_pose 17, 0x01f8, 0x0107, 0x3c08
+ax_pose_terminator
+sLarvitarPose158:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose159:
+ax_pose 18, 0x81ec, 0x90f7, 0x3c00
+ax_pose 19, 0x01fc, 0x10ef, 0x3c08
+ax_pose_terminator
+sLarvitarPose160:
+ax_pose 20, 0x81ec, 0x90fa, 0x3c00
+ax_pose 21, 0x01f4, 0x10f2, 0x3c08
+ax_pose_terminator
+sLarvitarPose161:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose162:
+ax_pose 22, 0x81e9, 0x90fa, 0x3c00
+ax_pose 23, 0x01f9, 0x10f2, 0x3c08
+ax_pose_terminator
+sLarvitarPose163:
+ax_pose 24, 0x81eb, 0x90fb, 0x3c00
+ax_pose 25, 0x81f3, 0x10f3, 0x3c08
+ax_pose_terminator
+sLarvitarPose164:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose165:
+ax_pose 26, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sLarvitarPose166:
+ax_pose 27, 0x81e8, 0x90f9, 0x3c00
+ax_pose 28, 0x01f8, 0x10f1, 0x3c08
+ax_pose_terminator
+sLarvitarPose167:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose168:
+ax_pose 29, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sLarvitarPose169:
+ax_pose 30, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sLarvitarPose170:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose171:
+ax_pose 26, 0x81ec, 0x80f9, 0x3c00
+ax_pose_terminator
+sLarvitarPose172:
+ax_pose 27, 0x81e8, 0x80f6, 0x3c00
+ax_pose 28, 0x01f8, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose173:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose174:
+ax_pose 22, 0x81e9, 0x80f5, 0x3c00
+ax_pose 23, 0x01f9, 0x0105, 0x3c08
+ax_pose_terminator
+sLarvitarPose175:
+ax_pose 24, 0x81eb, 0x80f5, 0x3c00
+ax_pose 25, 0x81f3, 0x0105, 0x3c08
+ax_pose_terminator
+sLarvitarPose176:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose177:
+ax_pose 18, 0x81ec, 0x80f9, 0x3c00
+ax_pose 19, 0x01fc, 0x0109, 0x3c08
+ax_pose_terminator
+sLarvitarPose178:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose 21, 0x01f4, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose179:
+ax_pose 16, 0x81e8, 0x80f7, 0x3c00
+ax_pose 17, 0x01f8, 0x0107, 0x3c08
+ax_pose_terminator
+sLarvitarPose180:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose 21, 0x01f4, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose181:
+ax_pose 24, 0x81eb, 0x80f5, 0x3c00
+ax_pose 25, 0x81f3, 0x0105, 0x3c08
+ax_pose_terminator
+sLarvitarPose182:
+ax_pose 27, 0x81e8, 0x80f6, 0x3c00
+ax_pose 28, 0x01f8, 0x0106, 0x3c08
+ax_pose_terminator
+sLarvitarPose183:
+ax_pose 30, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sLarvitarPose184:
+ax_pose 27, 0x81e8, 0x90f9, 0x3c00
+ax_pose 28, 0x01f8, 0x10f1, 0x3c08
+ax_pose_terminator
+sLarvitarPose185:
+ax_pose 24, 0x81eb, 0x90fb, 0x3c00
+ax_pose 25, 0x81f3, 0x10f3, 0x3c08
+ax_pose_terminator
+sLarvitarPose186:
+ax_pose 20, 0x81ec, 0x90fa, 0x3c00
+ax_pose 21, 0x01f4, 0x10f2, 0x3c08
+ax_pose_terminator
+sLarvitarPose187:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose188:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose189:
+ax_pose 6, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sLarvitarPose190:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sLarvitarPose191:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sLarvitarPose192:
+ax_pose 9, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sLarvitarPose193:
+ax_pose 6, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sLarvitarPose194:
+ax_pose 3, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+.align 2
+sLarvitarAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_2_1:
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 6, 0, 45, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLarvitarAnims_2_2:
+ax_anim 2, 0, 24, -1, -1, -1, -1,
+ax_anim 6, 0, 24, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 1, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 0, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sLarvitarAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 6, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 22, 0, 22, 0,
+ax_anim 2, 1, 34, 22, 1, 22, 1,
+ax_anim 2, 0, 34, 22, 0, 22, 0,
+ax_anim 2, 0, 34, 22, 1, 22, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sLarvitarAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 6, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 37, 22, -22, 22, -22,
+ax_anim 2, 1, 37, 23, -21, 23, -21,
+ax_anim 2, 0, 37, 22, -22, 22, -22,
+ax_anim 2, 0, 37, 23, -21, 23, -21,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sLarvitarAnims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 6, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -22, 0, -22,
+ax_anim 2, 1, 40, 1, -22, 1, -22,
+ax_anim 2, 0, 40, 0, -22, 0, -22,
+ax_anim 2, 0, 40, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sLarvitarAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 6, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -9, -10, -9, -10,
+ax_anim 2, 0, 43, -20, -22, -20, -22,
+ax_anim 2, 1, 43, -21, -21, -21, -21,
+ax_anim 2, 0, 43, -20, -22, -20, -22,
+ax_anim 2, 0, 43, -21, -21, -21, -21,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sLarvitarAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 6, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 46, -22, 0, -22, 0,
+ax_anim 2, 1, 46, -22, 1, -22, 1,
+ax_anim 2, 0, 46, -22, 0, -22, 0,
+ax_anim 2, 0, 46, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sLarvitarAnims_2_8:
+ax_anim 2, 0, 42, 1, -1, 1, -1,
+ax_anim 6, 0, 42, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -11, 9, -11, 9,
+ax_anim 2, 0, 25, -21, 18, -21, 18,
+ax_anim 2, 1, 25, -22, 17, -22, 17,
+ax_anim 2, 0, 25, -21, 18, -21, 18,
+ax_anim 2, 0, 25, -22, 17, -22, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_3_1:
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim 6, 0, 69, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 52, 0, 18, 0, 18,
+ax_anim 2, 1, 52, 1, 18, 1, 18,
+ax_anim 2, 0, 52, 0, 18, 0, 18,
+ax_anim 2, 0, 52, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sLarvitarAnims_3_2:
+ax_anim 2, 0, 48, -1, -1, -1, -1,
+ax_anim 6, 0, 48, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 55, 21, 20, 21, 20,
+ax_anim 2, 1, 55, 22, 19, 22, 19,
+ax_anim 2, 0, 55, 21, 20, 21, 20,
+ax_anim 2, 0, 55, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sLarvitarAnims_3_3:
+ax_anim 2, 0, 51, -1, 0, -1, 0,
+ax_anim 6, 0, 51, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 58, 22, 0, 22, 0,
+ax_anim 2, 1, 58, 22, 1, 22, 1,
+ax_anim 2, 0, 58, 22, 0, 22, 0,
+ax_anim 2, 0, 58, 22, 1, 22, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sLarvitarAnims_3_4:
+ax_anim 2, 0, 54, -1, 1, -1, 1,
+ax_anim 6, 0, 54, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -4, 4, -4,
+ax_anim 1, 0, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 61, 22, -22, 22, -22,
+ax_anim 2, 1, 61, 23, -21, 23, -21,
+ax_anim 2, 0, 61, 22, -22, 22, -22,
+ax_anim 2, 0, 61, 23, -21, 23, -21,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sLarvitarAnims_3_5:
+ax_anim 2, 0, 57, 0, 1, 0, 1,
+ax_anim 6, 0, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 64, 0, -22, 0, -22,
+ax_anim 2, 1, 64, 1, -22, 1, -22,
+ax_anim 2, 0, 64, 0, -22, 0, -22,
+ax_anim 2, 0, 64, 1, -22, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sLarvitarAnims_3_6:
+ax_anim 2, 0, 60, 1, 1, 1, 1,
+ax_anim 6, 0, 60, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -4, -4, -4,
+ax_anim 1, 0, 65, -9, -10, -9, -10,
+ax_anim 2, 0, 67, -20, -22, -20, -22,
+ax_anim 2, 1, 67, -21, -21, -21, -21,
+ax_anim 2, 0, 67, -20, -22, -20, -22,
+ax_anim 2, 0, 67, -21, -21, -21, -21,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sLarvitarAnims_3_7:
+ax_anim 2, 0, 63, 1, 0, 1, 0,
+ax_anim 6, 0, 63, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 70, -22, 0, -22, 0,
+ax_anim 2, 1, 70, -22, 1, -22, 1,
+ax_anim 2, 0, 70, -22, 0, -22, 0,
+ax_anim 2, 0, 70, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sLarvitarAnims_3_8:
+ax_anim 2, 0, 66, 1, -1, 1, -1,
+ax_anim 6, 0, 66, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -11, 9, -11, 9,
+ax_anim 2, 0, 49, -21, 18, -21, 18,
+ax_anim 2, 1, 49, -22, 17, -22, 17,
+ax_anim 2, 0, 49, -21, 18, -21, 18,
+ax_anim 2, 0, 49, -22, 17, -22, 17,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 1, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sLarvitarAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 1, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sLarvitarAnims_4_3:
+ax_anim 2, 0, 79, -1, 0, -1, 0,
+ax_anim 6, 2, 79, -2, 0, -2, 0,
+ax_anim 2, 0, 78, -1, 0, 0, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 1, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sLarvitarAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 1, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sLarvitarAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 1, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sLarvitarAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 1, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sLarvitarAnims_4_7:
+ax_anim 2, 0, 91, 1, 0, 1, 0,
+ax_anim 6, 2, 91, 2, 0, 2, 0,
+ax_anim 2, 0, 90, 1, 0, 0, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 1, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sLarvitarAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 1, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sLarvitarAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sLarvitarAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sLarvitarAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sLarvitarAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sLarvitarAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sLarvitarAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sLarvitarAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_8_1:
+ax_anim 30, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 4, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 0, 115, 0, -3, 0, 0,
+ax_anim 16, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 4, 0, 116, 0, -6, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 1, 0, 116, 0, -3, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_8_2:
+ax_anim 30, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 4, 0, 118, 0, -6, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 118, 0, -3, 0, 0,
+ax_anim 16, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 4, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -3, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_8_3:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 4, 0, 121, 0, -6, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 16, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 4, 0, 122, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_8_4:
+ax_anim 30, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 4, 0, 124, 0, -6, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 16, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 4, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_8_5:
+ax_anim 30, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 4, 0, 127, 0, -6, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 16, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 128, 0, -5, 0, 0,
+ax_anim 4, 0, 128, 0, -6, 0, 0,
+ax_anim 2, 0, 128, 0, -5, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_8_6:
+ax_anim 30, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 4, 0, 130, 0, -6, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim 16, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_8_7:
+ax_anim 30, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 4, 0, 133, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 16, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 4, 0, 134, 0, -6, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_8_8:
+ax_anim 30, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 4, 0, 136, 0, -6, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 1, 0, 136, 0, -3, 0, 0,
+ax_anim 16, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 9, 9, 9, 9,
+ax_anim 2, 0, 141, 7, 18, 7, 18,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -7, 18, -7, 18,
+ax_anim 2, 0, 144, -9, 9, -9, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 19, 4, 19, 4,
+ax_anim 2, 0, 140, 24, 12, 24, 12,
+ax_anim 3, 0, 141, 22, 19, 22, 19,
+ax_anim 2, 3, 142, 12, 19, 12, 19,
+ax_anim 2, 0, 143, 4, 17, 4, 17,
+ax_anim 1, 0, 144, -1, 10, -1, 10,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -8, 11, -8,
+ax_anim 2, 0, 139, 18, -6, 18, -6,
+ax_anim 3, 0, 140, 22, -2, 22, -2,
+ax_anim 2, 3, 141, 20, 4, 20, 4,
+ax_anim 2, 0, 142, 13, 6, 13, 6,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -8, 0, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 13, -22, 13, -22,
+ax_anim 3, 0, 139, 22, -24, 22, -24,
+ax_anim 2, 3, 140, 24, -15, 24, -15,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -10, -12, -10, -12,
+ax_anim 2, 0, 145, -6, -21, -6, -21,
+ax_anim 3, 0, 138, 0, -24, 0, -24,
+ax_anim 2, 3, 139, 8, -21, 8, -21,
+ax_anim 2, 0, 140, 10, -10, 10, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -8, 0, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -13, -22, -13, -22,
+ax_anim 3, 0, 145, -22, -24, -22, -24,
+ax_anim 2, 3, 144, -24, -15, -24, -15,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -8, -11, -8,
+ax_anim 2, 0, 145, -18, -6, -18, -6,
+ax_anim 3, 0, 144, -22, -2, -22, -2,
+ax_anim 2, 3, 143, -20, 4, -20, 4,
+ax_anim 2, 0, 142, -13, 6, -13, 6,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -19, 4, -19, 4,
+ax_anim 2, 0, 144, -24, 12, -24, 12,
+ax_anim 3, 0, 143, -22, 19, -22, 19,
+ax_anim 2, 3, 142, -12, 19, -12, 19,
+ax_anim 2, 0, 141, -4, 17, -4, 17,
+ax_anim 1, 0, 140, 1, 10, 1, 10,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -18, 0, 0,
+ax_anim 4, 0, 155, 0, -19, 0, 0,
+ax_anim 4, 0, 154, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLarvitarAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sLarvitarGfx1:
+.incbin "baserom.gba", 0x1002B80, 0x200
+sLarvitarSprites1:
+ax_sprite sLarvitarGfx1, 0x200
+ax_sprite_terminator
+sLarvitarGfx2:
+.incbin "baserom.gba", 0x1002D90, 0x200
+sLarvitarSprites2:
+ax_sprite sLarvitarGfx2, 0x200
+ax_sprite_terminator
+sLarvitarGfx3:
+.incbin "baserom.gba", 0x1002FA0, 0x200
+sLarvitarSprites3:
+ax_sprite sLarvitarGfx3, 0x200
+ax_sprite_terminator
+sLarvitarGfx4:
+.incbin "baserom.gba", 0x10031B0, 0x200
+sLarvitarSprites4:
+ax_sprite sLarvitarGfx4, 0x200
+ax_sprite_terminator
+sLarvitarGfx5:
+.incbin "baserom.gba", 0x10033C0, 0x200
+sLarvitarSprites5:
+ax_sprite sLarvitarGfx5, 0x200
+ax_sprite_terminator
+sLarvitarGfx6:
+.incbin "baserom.gba", 0x10035D0, 0x200
+sLarvitarSprites6:
+ax_sprite sLarvitarGfx6, 0x200
+ax_sprite_terminator
+sLarvitarGfx7:
+.incbin "baserom.gba", 0x10037E0, 0x200
+sLarvitarSprites7:
+ax_sprite sLarvitarGfx7, 0x200
+ax_sprite_terminator
+sLarvitarGfx8:
+.incbin "baserom.gba", 0x10039F0, 0x200
+sLarvitarSprites8:
+ax_sprite sLarvitarGfx8, 0x200
+ax_sprite_terminator
+sLarvitarGfx9:
+.incbin "baserom.gba", 0x1003C00, 0x200
+sLarvitarSprites9:
+ax_sprite sLarvitarGfx9, 0x200
+ax_sprite_terminator
+sLarvitarGfx10:
+.incbin "baserom.gba", 0x1003E10, 0x200
+sLarvitarSprites10:
+ax_sprite sLarvitarGfx10, 0x200
+ax_sprite_terminator
+sLarvitarGfx11:
+.incbin "baserom.gba", 0x1004020, 0x200
+sLarvitarSprites11:
+ax_sprite sLarvitarGfx11, 0x200
+ax_sprite_terminator
+sLarvitarGfx12:
+.incbin "baserom.gba", 0x1004230, 0x200
+sLarvitarSprites12:
+ax_sprite sLarvitarGfx12, 0x200
+ax_sprite_terminator
+sLarvitarGfx13:
+.incbin "baserom.gba", 0x1004440, 0x200
+sLarvitarSprites13:
+ax_sprite sLarvitarGfx13, 0x200
+ax_sprite_terminator
+sLarvitarGfx14:
+.incbin "baserom.gba", 0x1004650, 0x200
+sLarvitarSprites14:
+ax_sprite sLarvitarGfx14, 0x200
+ax_sprite_terminator
+sLarvitarGfx15:
+.incbin "baserom.gba", 0x1004860, 0x200
+sLarvitarSprites15:
+ax_sprite sLarvitarGfx15, 0x200
+ax_sprite_terminator
+sLarvitarGfx16:
+.incbin "baserom.gba", 0x1004A70, 0x100
+sLarvitarSprites16:
+ax_sprite sLarvitarGfx16, 0x100
+ax_sprite_terminator
+sLarvitarGfx17:
+.incbin "baserom.gba", 0x1004B80, 0xE0
+sLarvitarSprites17:
+ax_sprite 0, 0x20
+ax_sprite sLarvitarGfx17, 0xe0
+ax_sprite_terminator
+sLarvitarGfx18:
+.incbin "baserom.gba", 0x1004C78, 0x20
+sLarvitarSprites18:
+ax_sprite sLarvitarGfx18, 0x20
+ax_sprite_terminator
+sLarvitarGfx19:
+.incbin "baserom.gba", 0x1004CA8, 0xC0
+sLarvitarSprites19:
+ax_sprite sLarvitarGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLarvitarGfx20:
+.incbin "baserom.gba", 0x1004D80, 0x20
+sLarvitarSprites20:
+ax_sprite sLarvitarGfx20, 0x20
+ax_sprite_terminator
+sLarvitarGfx21:
+.incbin "baserom.gba", 0x1004DB0, 0xC0
+sLarvitarSprites21:
+ax_sprite sLarvitarGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLarvitarGfx22:
+.incbin "baserom.gba", 0x1004E88, 0x20
+sLarvitarSprites22:
+ax_sprite sLarvitarGfx22, 0x20
+ax_sprite_terminator
+sLarvitarGfx23:
+.incbin "baserom.gba", 0x1004EB8, 0x100
+sLarvitarSprites23:
+ax_sprite sLarvitarGfx23, 0x100
+ax_sprite_terminator
+sLarvitarGfx24:
+.incbin "baserom.gba", 0x1004FC8, 0x20
+sLarvitarSprites24:
+ax_sprite sLarvitarGfx24, 0x20
+ax_sprite_terminator
+sLarvitarGfx25:
+.incbin "baserom.gba", 0x1004FF8, 0xC0
+sLarvitarSprites25:
+ax_sprite sLarvitarGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLarvitarGfx26:
+.incbin "baserom.gba", 0x10050D0, 0x40
+sLarvitarSprites26:
+ax_sprite sLarvitarGfx26, 0x40
+ax_sprite_terminator
+sLarvitarGfx27:
+.incbin "baserom.gba", 0x1005120, 0xC0
+sLarvitarSprites27:
+ax_sprite sLarvitarGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLarvitarGfx28:
+.incbin "baserom.gba", 0x10051F8, 0x100
+sLarvitarSprites28:
+ax_sprite sLarvitarGfx28, 0x100
+ax_sprite_terminator
+sLarvitarGfx29:
+.incbin "baserom.gba", 0x1005308, 0x20
+sLarvitarSprites29:
+ax_sprite sLarvitarGfx29, 0x20
+ax_sprite_terminator
+sLarvitarGfx30:
+.incbin "baserom.gba", 0x1005338, 0x100
+sLarvitarSprites30:
+ax_sprite sLarvitarGfx30, 0x100
+ax_sprite_terminator
+sLarvitarGfx31:
+.incbin "baserom.gba", 0x1005448, 0xC0
+sLarvitarSprites31:
+ax_sprite sLarvitarGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLarvitarGfx32:
+.incbin "baserom.gba", 0x1005520, 0x200
+sLarvitarSprites32:
+ax_sprite sLarvitarGfx32, 0x200
+ax_sprite_terminator
+sLarvitarGfx33:
+.incbin "baserom.gba", 0x1005730, 0x200
+sLarvitarSprites33:
+ax_sprite sLarvitarGfx33, 0x200
+ax_sprite_terminator
+sLarvitarGfx34:
+.incbin "baserom.gba", 0x1005940, 0x200
+sLarvitarSprites34:
+ax_sprite sLarvitarGfx34, 0x200
+ax_sprite_terminator
+sLarvitarGfx35:
+.incbin "baserom.gba", 0x1005B50, 0x200
+sLarvitarSprites35:
+ax_sprite sLarvitarGfx35, 0x200
+ax_sprite_terminator
+sLarvitarGfx36:
+.incbin "baserom.gba", 0x1005D60, 0x200
+sLarvitarSprites36:
+ax_sprite sLarvitarGfx36, 0x200
+ax_sprite_terminator
+sLarvitarGfx37:
+.incbin "baserom.gba", 0x1005F70, 0x200
+sLarvitarSprites37:
+ax_sprite sLarvitarGfx37, 0x200
+ax_sprite_terminator
+sLarvitarGfx38:
+.incbin "baserom.gba", 0x1006180, 0x200
+sLarvitarSprites38:
+ax_sprite sLarvitarGfx38, 0x200
+ax_sprite_terminator
+sAxPosesLarvitar:
+.4byte sLarvitarPose1
+.4byte sLarvitarPose2
+.4byte sLarvitarPose3
+.4byte sLarvitarPose4
+.4byte sLarvitarPose5
+.4byte sLarvitarPose6
+.4byte sLarvitarPose7
+.4byte sLarvitarPose8
+.4byte sLarvitarPose9
+.4byte sLarvitarPose10
+.4byte sLarvitarPose11
+.4byte sLarvitarPose12
+.4byte sLarvitarPose13
+.4byte sLarvitarPose14
+.4byte sLarvitarPose15
+.4byte sLarvitarPose16
+.4byte sLarvitarPose17
+.4byte sLarvitarPose18
+.4byte sLarvitarPose19
+.4byte sLarvitarPose20
+.4byte sLarvitarPose21
+.4byte sLarvitarPose22
+.4byte sLarvitarPose23
+.4byte sLarvitarPose24
+.4byte sLarvitarPose25
+.4byte sLarvitarPose26
+.4byte sLarvitarPose27
+.4byte sLarvitarPose28
+.4byte sLarvitarPose29
+.4byte sLarvitarPose30
+.4byte sLarvitarPose31
+.4byte sLarvitarPose32
+.4byte sLarvitarPose33
+.4byte sLarvitarPose34
+.4byte sLarvitarPose35
+.4byte sLarvitarPose36
+.4byte sLarvitarPose37
+.4byte sLarvitarPose38
+.4byte sLarvitarPose39
+.4byte sLarvitarPose40
+.4byte sLarvitarPose41
+.4byte sLarvitarPose42
+.4byte sLarvitarPose43
+.4byte sLarvitarPose44
+.4byte sLarvitarPose45
+.4byte sLarvitarPose46
+.4byte sLarvitarPose47
+.4byte sLarvitarPose48
+.4byte sLarvitarPose49
+.4byte sLarvitarPose50
+.4byte sLarvitarPose51
+.4byte sLarvitarPose52
+.4byte sLarvitarPose53
+.4byte sLarvitarPose54
+.4byte sLarvitarPose55
+.4byte sLarvitarPose56
+.4byte sLarvitarPose57
+.4byte sLarvitarPose58
+.4byte sLarvitarPose59
+.4byte sLarvitarPose60
+.4byte sLarvitarPose61
+.4byte sLarvitarPose62
+.4byte sLarvitarPose63
+.4byte sLarvitarPose64
+.4byte sLarvitarPose65
+.4byte sLarvitarPose66
+.4byte sLarvitarPose67
+.4byte sLarvitarPose68
+.4byte sLarvitarPose69
+.4byte sLarvitarPose70
+.4byte sLarvitarPose71
+.4byte sLarvitarPose72
+.4byte sLarvitarPose73
+.4byte sLarvitarPose74
+.4byte sLarvitarPose75
+.4byte sLarvitarPose76
+.4byte sLarvitarPose77
+.4byte sLarvitarPose78
+.4byte sLarvitarPose79
+.4byte sLarvitarPose80
+.4byte sLarvitarPose81
+.4byte sLarvitarPose82
+.4byte sLarvitarPose83
+.4byte sLarvitarPose84
+.4byte sLarvitarPose85
+.4byte sLarvitarPose86
+.4byte sLarvitarPose87
+.4byte sLarvitarPose88
+.4byte sLarvitarPose89
+.4byte sLarvitarPose90
+.4byte sLarvitarPose91
+.4byte sLarvitarPose92
+.4byte sLarvitarPose93
+.4byte sLarvitarPose94
+.4byte sLarvitarPose95
+.4byte sLarvitarPose96
+.4byte sLarvitarPose97
+.4byte sLarvitarPose98
+.4byte sLarvitarPose99
+.4byte sLarvitarPose100
+.4byte sLarvitarPose101
+.4byte sLarvitarPose102
+.4byte sLarvitarPose103
+.4byte sLarvitarPose104
+.4byte sLarvitarPose105
+.4byte sLarvitarPose106
+.4byte sLarvitarPose107
+.4byte sLarvitarPose108
+.4byte sLarvitarPose109
+.4byte sLarvitarPose110
+.4byte sLarvitarPose111
+.4byte sLarvitarPose112
+.4byte sLarvitarPose113
+.4byte sLarvitarPose114
+.4byte sLarvitarPose115
+.4byte sLarvitarPose116
+.4byte sLarvitarPose117
+.4byte sLarvitarPose118
+.4byte sLarvitarPose119
+.4byte sLarvitarPose120
+.4byte sLarvitarPose121
+.4byte sLarvitarPose122
+.4byte sLarvitarPose123
+.4byte sLarvitarPose124
+.4byte sLarvitarPose125
+.4byte sLarvitarPose126
+.4byte sLarvitarPose127
+.4byte sLarvitarPose128
+.4byte sLarvitarPose129
+.4byte sLarvitarPose130
+.4byte sLarvitarPose131
+.4byte sLarvitarPose132
+.4byte sLarvitarPose133
+.4byte sLarvitarPose134
+.4byte sLarvitarPose135
+.4byte sLarvitarPose136
+.4byte sLarvitarPose137
+.4byte sLarvitarPose138
+.4byte sLarvitarPose139
+.4byte sLarvitarPose140
+.4byte sLarvitarPose141
+.4byte sLarvitarPose142
+.4byte sLarvitarPose143
+.4byte sLarvitarPose144
+.4byte sLarvitarPose145
+.4byte sLarvitarPose146
+.4byte sLarvitarPose147
+.4byte sLarvitarPose148
+.4byte sLarvitarPose149
+.4byte sLarvitarPose150
+.4byte sLarvitarPose151
+.4byte sLarvitarPose152
+.4byte sLarvitarPose153
+.4byte sLarvitarPose154
+.4byte sLarvitarPose155
+.4byte sLarvitarPose156
+.4byte sLarvitarPose157
+.4byte sLarvitarPose158
+.4byte sLarvitarPose159
+.4byte sLarvitarPose160
+.4byte sLarvitarPose161
+.4byte sLarvitarPose162
+.4byte sLarvitarPose163
+.4byte sLarvitarPose164
+.4byte sLarvitarPose165
+.4byte sLarvitarPose166
+.4byte sLarvitarPose167
+.4byte sLarvitarPose168
+.4byte sLarvitarPose169
+.4byte sLarvitarPose170
+.4byte sLarvitarPose171
+.4byte sLarvitarPose172
+.4byte sLarvitarPose173
+.4byte sLarvitarPose174
+.4byte sLarvitarPose175
+.4byte sLarvitarPose176
+.4byte sLarvitarPose177
+.4byte sLarvitarPose178
+.4byte sLarvitarPose179
+.4byte sLarvitarPose180
+.4byte sLarvitarPose181
+.4byte sLarvitarPose182
+.4byte sLarvitarPose183
+.4byte sLarvitarPose184
+.4byte sLarvitarPose185
+.4byte sLarvitarPose186
+.4byte sLarvitarPose187
+.4byte sLarvitarPose188
+.4byte sLarvitarPose189
+.4byte sLarvitarPose190
+.4byte sLarvitarPose191
+.4byte sLarvitarPose192
+.4byte sLarvitarPose193
+.4byte sLarvitarPose194
+sAxPositionsLarvitar:
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -6, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -6, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+.2byte    3,   -5, 	   2,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte    3,   -5, 	   6,   -6, 	  -6,   -3, 	  -1,   -6
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    5,   -7, 	  -2,   -6, 	   3,   -5, 	   0,   -7
+.2byte    5,   -7, 	   4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    4,   -8, 	  -5,   -5, 	   5,   -6, 	  -1,   -6
+.2byte    4,   -8, 	   1,   -8, 	   3,   -3, 	  -1,   -7
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	   5,   -4, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -7, 	  -7,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	   3,   -5, 	  -7,   -6, 	  -1,   -6
+.2byte   -6,   -8, 	  -3,   -8, 	  -5,   -3, 	  -1,   -7
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -7,   -7, 	   0,   -6, 	  -5,   -5, 	  -2,   -7
+.2byte   -7,   -7, 	  -6,   -6, 	   0,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -5,   -5, 	  -4,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte   -5,   -5, 	  -8,   -6, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -6, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -6, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+.2byte    3,   -5, 	   2,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte    3,   -5, 	   6,   -6, 	  -6,   -3, 	  -1,   -6
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    5,   -7, 	  -2,   -6, 	   3,   -5, 	   0,   -7
+.2byte    5,   -7, 	   4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    4,   -8, 	  -5,   -5, 	   5,   -6, 	  -1,   -6
+.2byte    4,   -8, 	   1,   -8, 	   3,   -3, 	  -1,   -7
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	   5,   -4, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -7, 	  -7,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	   3,   -5, 	  -7,   -6, 	  -1,   -6
+.2byte   -6,   -8, 	  -3,   -8, 	  -5,   -3, 	  -1,   -7
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -7,   -7, 	   0,   -6, 	  -5,   -5, 	  -2,   -7
+.2byte   -7,   -7, 	  -6,   -6, 	   0,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -5,   -5, 	  -4,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte   -5,   -5, 	  -8,   -6, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -6, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -6, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+.2byte    3,   -5, 	   2,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte    3,   -5, 	   6,   -6, 	  -6,   -3, 	  -1,   -6
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    5,   -7, 	  -2,   -6, 	   3,   -5, 	   0,   -7
+.2byte    5,   -7, 	   4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    4,   -8, 	  -5,   -5, 	   5,   -6, 	  -1,   -6
+.2byte    4,   -8, 	   1,   -8, 	   3,   -3, 	  -1,   -7
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	   5,   -4, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -7, 	  -7,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	   3,   -5, 	  -7,   -6, 	  -1,   -6
+.2byte   -6,   -8, 	  -3,   -8, 	  -5,   -3, 	  -1,   -7
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -7,   -7, 	   0,   -6, 	  -5,   -5, 	  -2,   -7
+.2byte   -7,   -7, 	  -6,   -6, 	   0,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -5,   -5, 	  -4,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte   -5,   -5, 	  -8,   -6, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,  -11, 	  -5,   -9, 	   3,   -9, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+.2byte    0,  -11, 	   2,   -9, 	  -4,   -8, 	  -3,   -7
+.2byte    5,   -4, 	   4,   -8, 	  -5,   -6, 	  -1,   -5
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    2,  -11, 	   0,  -11, 	  -2,   -9, 	  -2,   -7
+.2byte    7,   -6, 	  -2,   -9, 	  -3,   -6, 	  -1,   -6
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    2,  -11, 	  -5,  -10, 	   2,   -9, 	  -3,   -7
+.2byte    6,   -5, 	  -3,   -8, 	   1,   -5, 	  -1,   -5
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	   4,   -7, 	  -6,   -7, 	  -1,   -4
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -4,  -11, 	   3,  -10, 	  -4,   -9, 	   1,   -7
+.2byte   -8,   -5, 	   1,   -8, 	  -3,   -5, 	  -1,   -5
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -4,  -11, 	  -2,  -11, 	   0,   -9, 	   0,   -7
+.2byte   -9,   -6, 	   0,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -2,  -11, 	  -4,   -9, 	   2,   -8, 	   1,   -7
+.2byte   -7,   -4, 	  -6,   -8, 	   3,   -6, 	  -1,   -5
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+.2byte   -3,   -7, 	  -3,   -5, 	   3,   -2, 	   0,   -4
+.2byte   -2,   -7, 	  -3,   -5, 	   3,   -2, 	   1,   -4
+.2byte    0,   -7, 	  -5,  -10, 	   5,  -10, 	   0,   -8
+.2byte   -1,  -10, 	  -3,  -12, 	  -6,  -10, 	  -4,   -7
+.2byte    0,  -10, 	  -1,  -12, 	  -4,  -10, 	  -4,   -6
+.2byte    2,   -8, 	  -5,   -9, 	   0,   -8, 	  -3,   -4
+.2byte    0,   -7, 	   6,   -8, 	  -6,   -8, 	   0,   -5
+.2byte   -3,   -8, 	   4,   -9, 	  -1,   -8, 	   2,   -4
+.2byte   -1,  -10, 	   0,  -12, 	   3,  -10, 	   3,   -6
+.2byte    0,  -10, 	   2,  -12, 	   5,  -10, 	   3,   -7
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -4, 	   6,   -6, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -6, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+.2byte    3,   -5, 	   2,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte    3,   -5, 	   6,   -6, 	  -6,   -3, 	  -1,   -6
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    5,   -7, 	  -2,   -6, 	   3,   -5, 	   0,   -7
+.2byte    5,   -7, 	   4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    4,   -8, 	  -5,   -5, 	   5,   -6, 	  -1,   -6
+.2byte    4,   -8, 	   1,   -8, 	   3,   -3, 	  -1,   -7
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	   5,   -4, 	  -8,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -7, 	  -7,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -6,   -8, 	   3,   -5, 	  -7,   -6, 	  -1,   -6
+.2byte   -6,   -8, 	  -3,   -8, 	  -5,   -3, 	  -1,   -7
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -7,   -7, 	   0,   -6, 	  -5,   -5, 	  -2,   -7
+.2byte   -7,   -7, 	  -6,   -6, 	   0,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -5,   -5, 	  -4,   -3, 	  -1,   -5, 	  -1,   -6
+.2byte   -5,   -5, 	  -8,   -6, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte   -7,   -4, 	  -6,   -8, 	   3,   -6, 	  -1,   -5
+.2byte   -9,   -6, 	   0,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -8,   -6, 	   1,   -9, 	  -3,   -6, 	  -1,   -6
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte    6,   -6, 	  -3,   -9, 	   1,   -6, 	  -1,   -6
+.2byte    7,   -6, 	  -2,   -9, 	  -3,   -6, 	  -1,   -6
+.2byte    5,   -4, 	   4,   -8, 	  -5,   -6, 	  -1,   -5
+.2byte    0,  -11, 	  -4,   -9, 	   4,   -9, 	   0,   -8
+.2byte    3,  -12, 	   5,  -10, 	  -1,   -9, 	   0,   -8
+.2byte    4,  -11, 	   2,  -11, 	   0,   -9, 	   0,   -7
+.2byte    3,  -11, 	  -4,  -10, 	   3,   -9, 	  -2,   -7
+.2byte   -1,   -8, 	   4,   -9, 	  -6,   -9, 	  -1,   -6
+.2byte   -4,  -11, 	   3,  -10, 	  -4,   -9, 	   1,   -7
+.2byte   -4,  -11, 	  -2,  -11, 	   0,   -9, 	   0,   -7
+.2byte   -3,  -12, 	  -5,  -10, 	   1,   -9, 	   0,   -8
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,  -11, 	  -5,   -9, 	   3,   -9, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+.2byte    2,  -11, 	   4,   -9, 	  -2,   -8, 	  -1,   -7
+.2byte    6,   -4, 	   5,   -8, 	  -4,   -6, 	   0,   -5
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    3,  -11, 	   1,  -11, 	  -1,   -9, 	  -1,   -7
+.2byte    8,   -6, 	  -1,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    2,  -11, 	  -5,  -10, 	   2,   -9, 	  -3,   -7
+.2byte    6,   -7, 	  -3,  -10, 	   1,   -7, 	  -1,   -7
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	   4,   -7, 	  -6,   -7, 	  -1,   -4
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -4,  -11, 	   3,  -10, 	  -4,   -9, 	   1,   -7
+.2byte   -8,   -7, 	   1,  -10, 	  -3,   -7, 	  -1,   -7
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -5,  -11, 	  -3,  -11, 	  -1,   -9, 	  -1,   -7
+.2byte   -9,   -6, 	   0,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -3,  -11, 	  -5,   -9, 	   1,   -8, 	   0,   -7
+.2byte   -7,   -4, 	  -6,   -8, 	   3,   -6, 	  -1,   -5
+.2byte   -1,   -5, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte   -7,   -4, 	  -6,   -8, 	   3,   -6, 	  -1,   -5
+.2byte   -9,   -6, 	   0,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -8,   -7, 	   1,  -10, 	  -3,   -7, 	  -1,   -7
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte    6,   -7, 	  -3,  -10, 	   1,   -7, 	  -1,   -7
+.2byte    8,   -6, 	  -1,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    6,   -4, 	   5,   -8, 	  -4,   -6, 	   0,   -5
+.2byte   -1,   -6, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -5,   -6, 	  -7,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -7,   -8, 	  -4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte   -6,   -9, 	  -1,   -7, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -10, 	   6,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte    4,   -9, 	  -1,   -7, 	   5,   -5, 	  -1,   -8
+.2byte    5,   -8, 	   2,   -5, 	   0,   -4, 	   0,   -7
+.2byte    3,   -6, 	   5,   -6, 	  -4,   -4, 	  -1,   -7
+sLarvitarAnimTable1:
+.4byte sLarvitarAnims_1_1
+.4byte sLarvitarAnims_1_2
+.4byte sLarvitarAnims_1_3
+.4byte sLarvitarAnims_1_4
+.4byte sLarvitarAnims_1_5
+.4byte sLarvitarAnims_1_6
+.4byte sLarvitarAnims_1_7
+.4byte sLarvitarAnims_1_8
+sLarvitarAnimTable2:
+.4byte sLarvitarAnims_2_1
+.4byte sLarvitarAnims_2_2
+.4byte sLarvitarAnims_2_3
+.4byte sLarvitarAnims_2_4
+.4byte sLarvitarAnims_2_5
+.4byte sLarvitarAnims_2_6
+.4byte sLarvitarAnims_2_7
+.4byte sLarvitarAnims_2_8
+sLarvitarAnimTable3:
+.4byte sLarvitarAnims_3_1
+.4byte sLarvitarAnims_3_2
+.4byte sLarvitarAnims_3_3
+.4byte sLarvitarAnims_3_4
+.4byte sLarvitarAnims_3_5
+.4byte sLarvitarAnims_3_6
+.4byte sLarvitarAnims_3_7
+.4byte sLarvitarAnims_3_8
+sLarvitarAnimTable4:
+.4byte sLarvitarAnims_4_1
+.4byte sLarvitarAnims_4_2
+.4byte sLarvitarAnims_4_3
+.4byte sLarvitarAnims_4_4
+.4byte sLarvitarAnims_4_5
+.4byte sLarvitarAnims_4_6
+.4byte sLarvitarAnims_4_7
+.4byte sLarvitarAnims_4_8
+sLarvitarAnimTable5:
+.4byte sLarvitarAnims_5_1
+.4byte sLarvitarAnims_5_2
+.4byte sLarvitarAnims_5_3
+.4byte sLarvitarAnims_5_4
+.4byte sLarvitarAnims_5_5
+.4byte sLarvitarAnims_5_6
+.4byte sLarvitarAnims_5_7
+.4byte sLarvitarAnims_5_8
+sLarvitarAnimTable6:
+.4byte sLarvitarAnims_6_1
+.4byte sLarvitarAnims_6_1
+.4byte sLarvitarAnims_6_1
+.4byte sLarvitarAnims_6_1
+.4byte sLarvitarAnims_6_1
+.4byte sLarvitarAnims_6_1
+.4byte sLarvitarAnims_6_1
+.4byte sLarvitarAnims_6_1
+sLarvitarAnimTable7:
+.4byte sLarvitarAnims_7_1
+.4byte sLarvitarAnims_7_2
+.4byte sLarvitarAnims_7_3
+.4byte sLarvitarAnims_7_4
+.4byte sLarvitarAnims_7_5
+.4byte sLarvitarAnims_7_6
+.4byte sLarvitarAnims_7_7
+.4byte sLarvitarAnims_7_8
+sLarvitarAnimTable8:
+.4byte sLarvitarAnims_8_1
+.4byte sLarvitarAnims_8_2
+.4byte sLarvitarAnims_8_3
+.4byte sLarvitarAnims_8_4
+.4byte sLarvitarAnims_8_5
+.4byte sLarvitarAnims_8_6
+.4byte sLarvitarAnims_8_7
+.4byte sLarvitarAnims_8_8
+sLarvitarAnimTable9:
+.4byte sLarvitarAnims_9_1
+.4byte sLarvitarAnims_9_2
+.4byte sLarvitarAnims_9_3
+.4byte sLarvitarAnims_9_4
+.4byte sLarvitarAnims_9_5
+.4byte sLarvitarAnims_9_6
+.4byte sLarvitarAnims_9_7
+.4byte sLarvitarAnims_9_8
+sLarvitarAnimTable10:
+.4byte sLarvitarAnims_10_1
+.4byte sLarvitarAnims_10_2
+.4byte sLarvitarAnims_10_3
+.4byte sLarvitarAnims_10_4
+.4byte sLarvitarAnims_10_5
+.4byte sLarvitarAnims_10_6
+.4byte sLarvitarAnims_10_7
+.4byte sLarvitarAnims_10_8
+sLarvitarAnimTable11:
+.4byte sLarvitarAnims_11_1
+.4byte sLarvitarAnims_11_2
+.4byte sLarvitarAnims_11_3
+.4byte sLarvitarAnims_11_4
+.4byte sLarvitarAnims_11_5
+.4byte sLarvitarAnims_11_6
+.4byte sLarvitarAnims_11_7
+.4byte sLarvitarAnims_11_8
+sLarvitarAnimTable12:
+.4byte sLarvitarAnims_12_1
+.4byte sLarvitarAnims_12_2
+.4byte sLarvitarAnims_12_3
+.4byte sLarvitarAnims_12_4
+.4byte sLarvitarAnims_12_5
+.4byte sLarvitarAnims_12_6
+.4byte sLarvitarAnims_12_7
+.4byte sLarvitarAnims_12_8
+sLarvitarAnimTable13:
+.4byte sLarvitarAnims_13_1
+.4byte sLarvitarAnims_13_2
+.4byte sLarvitarAnims_13_3
+.4byte sLarvitarAnims_13_4
+.4byte sLarvitarAnims_13_5
+.4byte sLarvitarAnims_13_6
+.4byte sLarvitarAnims_13_7
+.4byte sLarvitarAnims_13_8
+sAxAnimationsLarvitar:
+.4byte sLarvitarAnimTable1
+.4byte sLarvitarAnimTable2
+.4byte sLarvitarAnimTable3
+.4byte sLarvitarAnimTable4
+.4byte sLarvitarAnimTable5
+.4byte sLarvitarAnimTable6
+.4byte sLarvitarAnimTable7
+.4byte sLarvitarAnimTable8
+.4byte sLarvitarAnimTable9
+.4byte sLarvitarAnimTable10
+.4byte sLarvitarAnimTable11
+.4byte sLarvitarAnimTable12
+.4byte sLarvitarAnimTable13
+sAxSpritesLarvitar:
+.4byte sLarvitarSprites1
+.4byte sLarvitarSprites2
+.4byte sLarvitarSprites3
+.4byte sLarvitarSprites4
+.4byte sLarvitarSprites5
+.4byte sLarvitarSprites6
+.4byte sLarvitarSprites7
+.4byte sLarvitarSprites8
+.4byte sLarvitarSprites9
+.4byte sLarvitarSprites10
+.4byte sLarvitarSprites11
+.4byte sLarvitarSprites12
+.4byte sLarvitarSprites13
+.4byte sLarvitarSprites14
+.4byte sLarvitarSprites15
+.4byte sLarvitarSprites16
+.4byte sLarvitarSprites17
+.4byte sLarvitarSprites18
+.4byte sLarvitarSprites19
+.4byte sLarvitarSprites20
+.4byte sLarvitarSprites21
+.4byte sLarvitarSprites22
+.4byte sLarvitarSprites23
+.4byte sLarvitarSprites24
+.4byte sLarvitarSprites25
+.4byte sLarvitarSprites26
+.4byte sLarvitarSprites27
+.4byte sLarvitarSprites28
+.4byte sLarvitarSprites29
+.4byte sLarvitarSprites30
+.4byte sLarvitarSprites31
+.4byte sLarvitarSprites32
+.4byte sLarvitarSprites33
+.4byte sLarvitarSprites34
+.4byte sLarvitarSprites35
+.4byte sLarvitarSprites36
+.4byte sLarvitarSprites37
+.4byte sLarvitarSprites38
+sAxMainLarvitar:
+ax_main sAxPosesLarvitar, sAxAnimationsLarvitar, 13, sAxSpritesLarvitar, sAxPositionsLarvitar

--- a/data/ax/latias.inc
+++ b/data/ax/latias.inc
@@ -1,0 +1,5225 @@
+.global gAxLatias
+gAxLatias:
+ax_siro sAxMainLatias
+sLatiasPose1:
+ax_pose 0, 0x81e9, 0x80fb, 0x5c00
+ax_pose 1, 0x01e9, 0x0113, 0x5c08
+ax_pose 2, 0x01e9, 0x010b, 0x5c09
+ax_pose 3, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 4, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose2:
+ax_pose 5, 0x81e9, 0x80fb, 0x5c00
+ax_pose 6, 0x01e9, 0x0113, 0x5c08
+ax_pose 7, 0x01e9, 0x010b, 0x5c09
+ax_pose 8, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 9, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose3:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose4:
+ax_pose 15, 0x41f1, 0x90f5, 0x5c00
+ax_pose 16, 0x81e9, 0x10ed, 0x5c08
+ax_pose 17, 0x41e1, 0x10fd, 0x5c0a
+ax_pose 18, 0x01e9, 0x10f5, 0x5c0c
+ax_pose 19, 0x41e9, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose5:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose6:
+ax_pose 27, 0x41ef, 0x90ef, 0x5c00
+ax_pose 28, 0x01ef, 0x110f, 0x5c08
+ax_pose 29, 0x01e7, 0x110f, 0x5c09
+ax_pose 30, 0x01ef, 0x1117, 0x5c0a
+ax_pose 31, 0x41df, 0x10ef, 0x5c0b
+ax_pose 32, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 33, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose7:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose8:
+ax_pose 42, 0x01f3, 0x50f5, 0x5c00
+ax_pose 43, 0x81e3, 0x10ed, 0x5c04
+ax_pose 44, 0x41e3, 0x1105, 0x5c06
+ax_pose 45, 0x01e3, 0x10f5, 0x5c08
+ax_pose 46, 0x41eb, 0x50f5, 0x5c09
+ax_pose 47, 0x01f3, 0x1105, 0x5c0d
+ax_pose 48, 0x01f5, 0x10ed, 0x5c0e
+ax_pose_terminator
+sLatiasPose9:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose10:
+ax_pose 55, 0x01f2, 0x40fb, 0x5c00
+ax_pose 56, 0x41ea, 0x010b, 0x5c04
+ax_pose 57, 0x01da, 0x00fc, 0x5c06
+ax_pose 58, 0x41e2, 0x00f6, 0x5c07
+ax_pose 59, 0x41ea, 0x40eb, 0x5c09
+ax_pose 60, 0x81f2, 0x00f3, 0x5c0d
+ax_pose_terminator
+sLatiasPose11:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose12:
+ax_pose 61, 0x41e3, 0x80eb, 0x5c00
+ax_pose 48, 0x01f5, 0x010b, 0x5c08
+ax_pose 43, 0x81e3, 0x010b, 0x5c09
+ax_pose 47, 0x01f3, 0x00f3, 0x5c0b
+ax_pose 42, 0x01f3, 0x40fb, 0x5c0c
+ax_pose_terminator
+sLatiasPose13:
+ax_pose 20, 0x41ef, 0x80f1, 0x5c00
+ax_pose 24, 0x41df, 0x0101, 0x5c08
+ax_pose 23, 0x01ef, 0x00e1, 0x5c0a
+ax_pose 21, 0x01e7, 0x00e9, 0x5c0b
+ax_pose 22, 0x01ef, 0x00e9, 0x5c0c
+ax_pose 26, 0x01e7, 0x00f1, 0x5c0d
+ax_pose 25, 0x41e7, 0x00fb, 0x5c0e
+ax_pose_terminator
+sLatiasPose14:
+ax_pose 27, 0x41ef, 0x80f1, 0x5c00
+ax_pose 31, 0x41df, 0x0101, 0x5c08
+ax_pose 32, 0x41e7, 0x00fb, 0x5c0a
+ax_pose 30, 0x01ef, 0x00e1, 0x5c0c
+ax_pose 28, 0x01ef, 0x00e9, 0x5c0d
+ax_pose 29, 0x01e7, 0x00e9, 0x5c0e
+ax_pose 33, 0x01e7, 0x00f1, 0x5c0f
+ax_pose_terminator
+sLatiasPose15:
+ax_pose 62, 0x81f1, 0x00eb, 0x5c00
+ax_pose 13, 0x81e9, 0x010b, 0x5c02
+ax_pose 63, 0x01f9, 0x0103, 0x5c04
+ax_pose 64, 0x81e9, 0x0103, 0x5c05
+ax_pose 65, 0x81e1, 0x80f3, 0x5c07
+ax_pose_terminator
+sLatiasPose16:
+ax_pose 66, 0x81e1, 0x80f3, 0x5c00
+ax_pose 16, 0x81e9, 0x010b, 0x5c08
+ax_pose 67, 0x81f1, 0x00eb, 0x5c0a
+ax_pose 18, 0x01e9, 0x0103, 0x5c0c
+ax_pose 68, 0x81f1, 0x0103, 0x5c0d
+ax_pose_terminator
+sLatiasPose17:
+ax_pose 69, 0x81e9, 0x80fb, 0x5c00
+ax_pose 70, 0x01e9, 0x0113, 0x5c08
+ax_pose 71, 0x01e9, 0x010b, 0x5c09
+ax_pose 72, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 73, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose18:
+ax_pose 0, 0x81e9, 0x80fb, 0x5c00
+ax_pose 1, 0x01e9, 0x0113, 0x5c08
+ax_pose 2, 0x01e9, 0x010b, 0x5c09
+ax_pose 3, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 4, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose19:
+ax_pose 5, 0x81e9, 0x80fb, 0x5c00
+ax_pose 6, 0x01e9, 0x0113, 0x5c08
+ax_pose 7, 0x01e9, 0x010b, 0x5c09
+ax_pose 8, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 9, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose20:
+ax_pose 74, 0x41f0, 0x90f3, 0x5c00
+ax_pose 75, 0x0200, 0x10f5, 0x5c08
+ax_pose 76, 0x01e9, 0x10eb, 0x5c09
+ax_pose 77, 0x01f1, 0x10eb, 0x5c0a
+ax_pose 78, 0x01e0, 0x1104, 0x5c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x5c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x5c0d
+ax_pose_terminator
+sLatiasPose21:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose22:
+ax_pose 15, 0x41f1, 0x90f5, 0x5c00
+ax_pose 16, 0x81e9, 0x10ed, 0x5c08
+ax_pose 17, 0x41e1, 0x10fd, 0x5c0a
+ax_pose 18, 0x01e9, 0x10f5, 0x5c0c
+ax_pose 19, 0x41e9, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose23:
+ax_pose 81, 0x01ee, 0x50f0, 0x5c00
+ax_pose 82, 0x01de, 0x10f4, 0x5c04
+ax_pose 83, 0x41e6, 0x10f5, 0x5c05
+ax_pose 84, 0x01e5, 0x110c, 0x5c07
+ax_pose 85, 0x41ed, 0x1108, 0x5c08
+ax_pose 86, 0x01f5, 0x1108, 0x5c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x5c0b
+ax_pose 88, 0x01fe, 0x1100, 0x5c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x5c0d
+ax_pose 90, 0x81ee, 0x1100, 0x5c0e
+ax_pose_terminator
+sLatiasPose24:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose25:
+ax_pose 27, 0x41ef, 0x90ef, 0x5c00
+ax_pose 28, 0x01ef, 0x110f, 0x5c08
+ax_pose 29, 0x01e7, 0x110f, 0x5c09
+ax_pose 30, 0x01ef, 0x1117, 0x5c0a
+ax_pose 31, 0x41df, 0x10ef, 0x5c0b
+ax_pose 32, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 33, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose26:
+ax_pose 91, 0x81e2, 0x110d, 0x5c00
+ax_pose 92, 0x01ea, 0x10ed, 0x5c02
+ax_pose 93, 0x01e2, 0x10ed, 0x5c03
+ax_pose 94, 0x0200, 0x10f9, 0x5c04
+ax_pose 95, 0x01f6, 0x10ed, 0x5c05
+ax_pose 96, 0x41e8, 0x10f5, 0x5c06
+ax_pose 97, 0x01f0, 0x50f5, 0x5c08
+ax_pose 98, 0x81e2, 0x5105, 0x5c0c
+ax_pose_terminator
+sLatiasPose27:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose28:
+ax_pose 42, 0x01f3, 0x50f5, 0x5c00
+ax_pose 43, 0x81e3, 0x10ed, 0x5c04
+ax_pose 44, 0x41e3, 0x1105, 0x5c06
+ax_pose 45, 0x01e3, 0x10f5, 0x5c08
+ax_pose 46, 0x41eb, 0x50f5, 0x5c09
+ax_pose 47, 0x01f3, 0x1105, 0x5c0d
+ax_pose 48, 0x01f5, 0x10ed, 0x5c0e
+ax_pose_terminator
+sLatiasPose29:
+ax_pose 99, 0x01f3, 0x40fb, 0x5c00
+ax_pose 100, 0x41db, 0x00fb, 0x5c04
+ax_pose 101, 0x41e3, 0x00f6, 0x5c06
+ax_pose 102, 0x01eb, 0x0113, 0x5c08
+ax_pose 103, 0x01eb, 0x010b, 0x5c09
+ax_pose 104, 0x41eb, 0x40eb, 0x5c0a
+ax_pose 105, 0x81f3, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose30:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose31:
+ax_pose 55, 0x01f2, 0x40fb, 0x5c00
+ax_pose 56, 0x41ea, 0x010b, 0x5c04
+ax_pose 57, 0x01da, 0x00fb, 0x5c06
+ax_pose 58, 0x41e2, 0x00f6, 0x5c07
+ax_pose 59, 0x41ea, 0x40eb, 0x5c09
+ax_pose 60, 0x81f2, 0x00f3, 0x5c0d
+ax_pose_terminator
+sLatiasPose32:
+ax_pose 106, 0x01e2, 0x40eb, 0x5c00
+ax_pose 95, 0x01f6, 0x010b, 0x5c04
+ax_pose 94, 0x0200, 0x00ff, 0x5c05
+ax_pose 92, 0x01ea, 0x010b, 0x5c06
+ax_pose 93, 0x01e2, 0x010b, 0x5c07
+ax_pose 96, 0x41e8, 0x00fb, 0x5c08
+ax_pose 97, 0x01f0, 0x40fb, 0x5c0a
+ax_pose 107, 0x81f2, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose33:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose34:
+ax_pose 61, 0x41e3, 0x80eb, 0x5c00
+ax_pose 48, 0x01f5, 0x010b, 0x5c08
+ax_pose 43, 0x81e3, 0x010b, 0x5c09
+ax_pose 47, 0x01f3, 0x00f3, 0x5c0b
+ax_pose 42, 0x01f3, 0x40fb, 0x5c0c
+ax_pose_terminator
+sLatiasPose35:
+ax_pose 81, 0x01ee, 0x4100, 0x5c00
+ax_pose 82, 0x01de, 0x0104, 0x5c04
+ax_pose 83, 0x41e6, 0x00fb, 0x5c05
+ax_pose 84, 0x01e5, 0x00ec, 0x5c07
+ax_pose 85, 0x41ed, 0x00e8, 0x5c08
+ax_pose 89, 0x01fe, 0x0108, 0x5c0a
+ax_pose 88, 0x01fe, 0x00f8, 0x5c0b
+ax_pose 86, 0x01f5, 0x00f0, 0x5c0c
+ax_pose 87, 0x01ee, 0x0110, 0x5c0d
+ax_pose 90, 0x81ee, 0x00f8, 0x5c0e
+ax_pose_terminator
+sLatiasPose36:
+ax_pose 20, 0x41ef, 0x80f1, 0x5c00
+ax_pose 24, 0x41df, 0x0101, 0x5c08
+ax_pose 23, 0x01ef, 0x00e1, 0x5c0a
+ax_pose 21, 0x01e7, 0x00e9, 0x5c0b
+ax_pose 22, 0x01ef, 0x00e9, 0x5c0c
+ax_pose 26, 0x01e7, 0x00f1, 0x5c0d
+ax_pose 25, 0x41e7, 0x00fb, 0x5c0e
+ax_pose_terminator
+sLatiasPose37:
+ax_pose 27, 0x41ef, 0x80f1, 0x5c00
+ax_pose 31, 0x41df, 0x0101, 0x5c08
+ax_pose 32, 0x41e7, 0x00fb, 0x5c0a
+ax_pose 30, 0x01ef, 0x00e1, 0x5c0c
+ax_pose 28, 0x01ef, 0x00e9, 0x5c0d
+ax_pose 29, 0x01e7, 0x00e9, 0x5c0e
+ax_pose 33, 0x01e7, 0x00f1, 0x5c0f
+ax_pose_terminator
+sLatiasPose38:
+ax_pose 74, 0x41f0, 0x80ed, 0x5c00
+ax_pose 76, 0x01e9, 0x010d, 0x5c08
+ax_pose 75, 0x0200, 0x0103, 0x5c09
+ax_pose 77, 0x01f1, 0x010d, 0x5c0a
+ax_pose 78, 0x01e0, 0x00f4, 0x5c0b
+ax_pose 79, 0x01e8, 0x0105, 0x5c0c
+ax_pose 80, 0x41e8, 0x00f5, 0x5c0d
+ax_pose_terminator
+sLatiasPose39:
+ax_pose 62, 0x81f1, 0x00eb, 0x5c00
+ax_pose 13, 0x81e9, 0x010b, 0x5c02
+ax_pose 63, 0x01f9, 0x0103, 0x5c04
+ax_pose 64, 0x81e9, 0x0103, 0x5c05
+ax_pose 65, 0x81e1, 0x80f3, 0x5c07
+ax_pose_terminator
+sLatiasPose40:
+ax_pose 66, 0x81e1, 0x80f3, 0x5c00
+ax_pose 16, 0x81e9, 0x010b, 0x5c08
+ax_pose 67, 0x81f1, 0x00eb, 0x5c0a
+ax_pose 18, 0x01e9, 0x0103, 0x5c0c
+ax_pose 68, 0x81f1, 0x0103, 0x5c0d
+ax_pose_terminator
+sLatiasPose41:
+ax_pose 69, 0x81e9, 0x80fb, 0x5c00
+ax_pose 70, 0x01e9, 0x0113, 0x5c08
+ax_pose 71, 0x01e9, 0x010b, 0x5c09
+ax_pose 72, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 73, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose42:
+ax_pose 0, 0x81e9, 0x80fb, 0x5c00
+ax_pose 1, 0x01e9, 0x0113, 0x5c08
+ax_pose 2, 0x01e9, 0x010b, 0x5c09
+ax_pose 3, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 4, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose43:
+ax_pose 5, 0x81e9, 0x80fb, 0x5c00
+ax_pose 6, 0x01e9, 0x0113, 0x5c08
+ax_pose 7, 0x01e9, 0x010b, 0x5c09
+ax_pose 8, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 9, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose44:
+ax_pose 74, 0x41f0, 0x90f3, 0x5c00
+ax_pose 75, 0x0200, 0x10f5, 0x5c08
+ax_pose 76, 0x01e9, 0x10eb, 0x5c09
+ax_pose 77, 0x01f1, 0x10eb, 0x5c0a
+ax_pose 78, 0x01e0, 0x1104, 0x5c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x5c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x5c0d
+ax_pose_terminator
+sLatiasPose45:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose46:
+ax_pose 15, 0x41f1, 0x90f5, 0x5c00
+ax_pose 16, 0x81e9, 0x10ed, 0x5c08
+ax_pose 17, 0x41e1, 0x10fd, 0x5c0a
+ax_pose 18, 0x01e9, 0x10f5, 0x5c0c
+ax_pose 19, 0x41e9, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose47:
+ax_pose 81, 0x01ee, 0x50f0, 0x5c00
+ax_pose 82, 0x01de, 0x10f4, 0x5c04
+ax_pose 83, 0x41e6, 0x10f5, 0x5c05
+ax_pose 84, 0x01e5, 0x110c, 0x5c07
+ax_pose 85, 0x41ed, 0x1108, 0x5c08
+ax_pose 86, 0x01f5, 0x1108, 0x5c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x5c0b
+ax_pose 88, 0x01fe, 0x1100, 0x5c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x5c0d
+ax_pose 90, 0x81ee, 0x1100, 0x5c0e
+ax_pose_terminator
+sLatiasPose48:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose49:
+ax_pose 27, 0x41ef, 0x90ef, 0x5c00
+ax_pose 28, 0x01ef, 0x110f, 0x5c08
+ax_pose 29, 0x01e7, 0x110f, 0x5c09
+ax_pose 30, 0x01ef, 0x1117, 0x5c0a
+ax_pose 31, 0x41df, 0x10ef, 0x5c0b
+ax_pose 32, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 33, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose50:
+ax_pose 91, 0x81e2, 0x110d, 0x5c00
+ax_pose 92, 0x01ea, 0x10ed, 0x5c02
+ax_pose 93, 0x01e2, 0x10ed, 0x5c03
+ax_pose 94, 0x0200, 0x10f9, 0x5c04
+ax_pose 95, 0x01f6, 0x10ed, 0x5c05
+ax_pose 96, 0x41e8, 0x10f5, 0x5c06
+ax_pose 97, 0x01f0, 0x50f5, 0x5c08
+ax_pose 98, 0x81e2, 0x5105, 0x5c0c
+ax_pose_terminator
+sLatiasPose51:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose52:
+ax_pose 42, 0x01f3, 0x50f5, 0x5c00
+ax_pose 43, 0x81e3, 0x10ed, 0x5c04
+ax_pose 44, 0x41e3, 0x1105, 0x5c06
+ax_pose 45, 0x01e3, 0x10f5, 0x5c08
+ax_pose 46, 0x41eb, 0x50f5, 0x5c09
+ax_pose 47, 0x01f3, 0x1105, 0x5c0d
+ax_pose 48, 0x01f5, 0x10ed, 0x5c0e
+ax_pose_terminator
+sLatiasPose53:
+ax_pose 99, 0x01f3, 0x40fb, 0x5c00
+ax_pose 100, 0x41db, 0x00fb, 0x5c04
+ax_pose 101, 0x41e3, 0x00f6, 0x5c06
+ax_pose 102, 0x01eb, 0x0113, 0x5c08
+ax_pose 103, 0x01eb, 0x010b, 0x5c09
+ax_pose 104, 0x41eb, 0x40eb, 0x5c0a
+ax_pose 105, 0x81f3, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose54:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose55:
+ax_pose 55, 0x01f2, 0x40fb, 0x5c00
+ax_pose 56, 0x41ea, 0x010b, 0x5c04
+ax_pose 57, 0x01da, 0x00fb, 0x5c06
+ax_pose 58, 0x41e2, 0x00f6, 0x5c07
+ax_pose 59, 0x41ea, 0x40eb, 0x5c09
+ax_pose 60, 0x81f2, 0x00f3, 0x5c0d
+ax_pose_terminator
+sLatiasPose56:
+ax_pose 106, 0x01e2, 0x40eb, 0x5c00
+ax_pose 95, 0x01f6, 0x010b, 0x5c04
+ax_pose 94, 0x0200, 0x00ff, 0x5c05
+ax_pose 92, 0x01ea, 0x010b, 0x5c06
+ax_pose 93, 0x01e2, 0x010b, 0x5c07
+ax_pose 96, 0x41e8, 0x00fb, 0x5c08
+ax_pose 97, 0x01f0, 0x40fb, 0x5c0a
+ax_pose 107, 0x81f2, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose57:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose58:
+ax_pose 61, 0x41e3, 0x80eb, 0x5c00
+ax_pose 48, 0x01f5, 0x010b, 0x5c08
+ax_pose 43, 0x81e3, 0x010b, 0x5c09
+ax_pose 47, 0x01f3, 0x00f3, 0x5c0b
+ax_pose 42, 0x01f3, 0x40fb, 0x5c0c
+ax_pose_terminator
+sLatiasPose59:
+ax_pose 81, 0x01ee, 0x4100, 0x5c00
+ax_pose 82, 0x01de, 0x0104, 0x5c04
+ax_pose 83, 0x41e6, 0x00fb, 0x5c05
+ax_pose 84, 0x01e5, 0x00ec, 0x5c07
+ax_pose 85, 0x41ed, 0x00e8, 0x5c08
+ax_pose 89, 0x01fe, 0x0108, 0x5c0a
+ax_pose 88, 0x01fe, 0x00f8, 0x5c0b
+ax_pose 86, 0x01f5, 0x00f0, 0x5c0c
+ax_pose 87, 0x01ee, 0x0110, 0x5c0d
+ax_pose 90, 0x81ee, 0x00f8, 0x5c0e
+ax_pose_terminator
+sLatiasPose60:
+ax_pose 20, 0x41ef, 0x80f1, 0x5c00
+ax_pose 24, 0x41df, 0x0101, 0x5c08
+ax_pose 23, 0x01ef, 0x00e1, 0x5c0a
+ax_pose 21, 0x01e7, 0x00e9, 0x5c0b
+ax_pose 22, 0x01ef, 0x00e9, 0x5c0c
+ax_pose 26, 0x01e7, 0x00f1, 0x5c0d
+ax_pose 25, 0x41e7, 0x00fb, 0x5c0e
+ax_pose_terminator
+sLatiasPose61:
+ax_pose 27, 0x41ef, 0x80f1, 0x5c00
+ax_pose 31, 0x41df, 0x0101, 0x5c08
+ax_pose 32, 0x41e7, 0x00fb, 0x5c0a
+ax_pose 30, 0x01ef, 0x00e1, 0x5c0c
+ax_pose 28, 0x01ef, 0x00e9, 0x5c0d
+ax_pose 29, 0x01e7, 0x00e9, 0x5c0e
+ax_pose 33, 0x01e7, 0x00f1, 0x5c0f
+ax_pose_terminator
+sLatiasPose62:
+ax_pose 74, 0x41f0, 0x80ed, 0x5c00
+ax_pose 76, 0x01e9, 0x010d, 0x5c08
+ax_pose 75, 0x0200, 0x0103, 0x5c09
+ax_pose 77, 0x01f1, 0x010d, 0x5c0a
+ax_pose 78, 0x01e0, 0x00f4, 0x5c0b
+ax_pose 79, 0x01e8, 0x0105, 0x5c0c
+ax_pose 80, 0x41e8, 0x00f5, 0x5c0d
+ax_pose_terminator
+sLatiasPose63:
+ax_pose 62, 0x81f1, 0x00eb, 0x5c00
+ax_pose 13, 0x81e9, 0x010b, 0x5c02
+ax_pose 63, 0x01f9, 0x0103, 0x5c04
+ax_pose 64, 0x81e9, 0x0103, 0x5c05
+ax_pose 65, 0x81e1, 0x80f3, 0x5c07
+ax_pose_terminator
+sLatiasPose64:
+ax_pose 66, 0x81e1, 0x80f3, 0x5c00
+ax_pose 16, 0x81e9, 0x010b, 0x5c08
+ax_pose 67, 0x81f1, 0x00eb, 0x5c0a
+ax_pose 18, 0x01e9, 0x0103, 0x5c0c
+ax_pose 68, 0x81f1, 0x0103, 0x5c0d
+ax_pose_terminator
+sLatiasPose65:
+ax_pose 69, 0x81e9, 0x80fb, 0x5c00
+ax_pose 70, 0x01e9, 0x0113, 0x5c08
+ax_pose 71, 0x01e9, 0x010b, 0x5c09
+ax_pose 72, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 73, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose66:
+ax_pose 108, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sLatiasPose67:
+ax_pose 109, 0x41ee, 0x80f0, 0x5c00
+ax_pose 110, 0x41e6, 0x40f0, 0x5c08
+ax_pose 111, 0x01de, 0x00f0, 0x5c0c
+ax_pose 112, 0x01de, 0x0108, 0x5c0d
+ax_pose 113, 0x01e4, 0x00e8, 0x5c0e
+ax_pose 114, 0x01e4, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose68:
+ax_pose 74, 0x41f0, 0x90f3, 0x5c00
+ax_pose 75, 0x0200, 0x10f5, 0x5c08
+ax_pose 76, 0x01e9, 0x10eb, 0x5c09
+ax_pose 77, 0x01f1, 0x10eb, 0x5c0a
+ax_pose 78, 0x01e0, 0x1104, 0x5c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x5c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x5c0d
+ax_pose_terminator
+sLatiasPose69:
+ax_pose 115, 0x81e6, 0x90fb, 0x5c00
+ax_pose 116, 0x81e6, 0x50f3, 0x5c08
+ax_pose 117, 0x01de, 0x1103, 0x5c0c
+ax_pose 118, 0x01de, 0x10fb, 0x5c0d
+ax_pose 119, 0x01e5, 0x110b, 0x5c0e
+ax_pose 120, 0x01e6, 0x10eb, 0x5c0f
+ax_pose_terminator
+sLatiasPose70:
+ax_pose 121, 0x81e1, 0x9102, 0x5c00
+ax_pose 122, 0x01f1, 0x50f2, 0x5c08
+ax_pose 123, 0x41e9, 0x10f2, 0x5c0c
+ax_pose 124, 0x01e9, 0x10ea, 0x5c0e
+ax_pose_terminator
+sLatiasPose71:
+ax_pose 81, 0x01ee, 0x50f0, 0x5c00
+ax_pose 82, 0x01de, 0x10f4, 0x5c04
+ax_pose 83, 0x41e6, 0x10f5, 0x5c05
+ax_pose 84, 0x01e5, 0x110c, 0x5c07
+ax_pose 85, 0x41ed, 0x1108, 0x5c08
+ax_pose 86, 0x01f5, 0x1108, 0x5c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x5c0b
+ax_pose 88, 0x01fe, 0x1100, 0x5c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x5c0d
+ax_pose 90, 0x81ee, 0x1100, 0x5c0e
+ax_pose_terminator
+sLatiasPose72:
+ax_pose 125, 0x81e0, 0x50f2, 0x5c00
+ax_pose 126, 0x01f0, 0x50fa, 0x5c04
+ax_pose 127, 0x01e0, 0x5102, 0x5c08
+ax_pose 128, 0x01e8, 0x10fa, 0x5c0c
+ax_pose 129, 0x01e4, 0x10ea, 0x5c0d
+ax_pose 130, 0x01f0, 0x10ea, 0x5c0e
+ax_pose 131, 0x0200, 0x10f7, 0x5c0f
+ax_pose_terminator
+sLatiasPose73:
+ax_pose 132, 0x81e6, 0x90f2, 0x5c00
+ax_pose 133, 0x81e6, 0x5102, 0x5c08
+ax_pose 134, 0x81e6, 0x110a, 0x5c0c
+ax_pose 135, 0x01ee, 0x1112, 0x5c0e
+ax_pose 136, 0x01de, 0x10f2, 0x5c0f
+ax_pose_terminator
+sLatiasPose74:
+ax_pose 91, 0x81e2, 0x110d, 0x5c00
+ax_pose 92, 0x01ea, 0x10ed, 0x5c02
+ax_pose 93, 0x01e2, 0x10ed, 0x5c03
+ax_pose 94, 0x0200, 0x10f9, 0x5c04
+ax_pose 95, 0x01f6, 0x10ed, 0x5c05
+ax_pose 96, 0x41e8, 0x10f5, 0x5c06
+ax_pose 97, 0x01f0, 0x50f5, 0x5c08
+ax_pose 98, 0x81e2, 0x5105, 0x5c0c
+ax_pose_terminator
+sLatiasPose75:
+ax_pose 137, 0x81e5, 0x90fc, 0x5c00
+ax_pose 138, 0x41dd, 0x10fc, 0x5c08
+ax_pose 139, 0x01ed, 0x50ec, 0x5c0a
+ax_pose 140, 0x01fd, 0x10f4, 0x5c0e
+ax_pose 141, 0x01ed, 0x10e4, 0x5c0f
+ax_pose_terminator
+sLatiasPose76:
+ax_pose 142, 0x41e9, 0x90f0, 0x5c00
+ax_pose 143, 0x41e1, 0x1100, 0x5c08
+ax_pose 144, 0x41f9, 0x10f0, 0x5c0a
+ax_pose 145, 0x01f9, 0x1100, 0x5c0c
+ax_pose 146, 0x01f1, 0x1110, 0x5c0d
+ax_pose 147, 0x0201, 0x10f9, 0x5c0e
+ax_pose 148, 0x01e8, 0x10e8, 0x5c0f
+ax_pose_terminator
+sLatiasPose77:
+ax_pose 99, 0x01f3, 0x40fb, 0x5c00
+ax_pose 100, 0x41db, 0x00fb, 0x5c04
+ax_pose 101, 0x41e3, 0x00f6, 0x5c06
+ax_pose 102, 0x01eb, 0x0113, 0x5c08
+ax_pose 103, 0x01eb, 0x010b, 0x5c09
+ax_pose 104, 0x41eb, 0x40eb, 0x5c0a
+ax_pose 105, 0x81f3, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose78:
+ax_pose 149, 0x81de, 0x80f8, 0x5c00
+ax_pose 150, 0x81ee, 0x00f0, 0x5c08
+ax_pose -1, 0x81ee, 0x1108, 0x5c08
+ax_pose 151, 0x01e6, 0x00f0, 0x5c0a
+ax_pose -1, 0x01e6, 0x1108, 0x5c0a
+ax_pose 152, 0x01ef, 0x00e8, 0x5c0b
+ax_pose -1, 0x01ef, 0x1110, 0x5c0b
+ax_pose 153, 0x41d6, 0x00f8, 0x5c0c
+ax_pose_terminator
+sLatiasPose79:
+ax_pose 154, 0x81df, 0x80f8, 0x5c00
+ax_pose 155, 0x81ef, 0x00f0, 0x5c08
+ax_pose -1, 0x81ef, 0x1108, 0x5c08
+ax_pose 156, 0x01e7, 0x00f0, 0x5c0a
+ax_pose -1, 0x01e7, 0x1108, 0x5c0a
+ax_pose 157, 0x01ed, 0x00e8, 0x5c0b
+ax_pose -1, 0x01ed, 0x1110, 0x5c0b
+ax_pose 158, 0x41d7, 0x00f8, 0x5c0c
+ax_pose_terminator
+sLatiasPose80:
+ax_pose 106, 0x01e2, 0x40eb, 0x5c00
+ax_pose 95, 0x01f6, 0x010b, 0x5c04
+ax_pose 94, 0x0200, 0x00ff, 0x5c05
+ax_pose 92, 0x01ea, 0x010b, 0x5c06
+ax_pose 93, 0x01e2, 0x010b, 0x5c07
+ax_pose 96, 0x41e8, 0x00fb, 0x5c08
+ax_pose 97, 0x01f0, 0x40fb, 0x5c0a
+ax_pose 107, 0x81f2, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose81:
+ax_pose 137, 0x81e5, 0x80f4, 0x5c00
+ax_pose 138, 0x41dd, 0x00f4, 0x5c08
+ax_pose 139, 0x01ed, 0x4104, 0x5c0a
+ax_pose 140, 0x01fd, 0x0104, 0x5c0e
+ax_pose 141, 0x01ed, 0x0114, 0x5c0f
+ax_pose_terminator
+sLatiasPose82:
+ax_pose 142, 0x41e9, 0x80f0, 0x5c00
+ax_pose 143, 0x41e1, 0x00f0, 0x5c08
+ax_pose 144, 0x41f9, 0x0100, 0x5c0a
+ax_pose 145, 0x01f9, 0x00f8, 0x5c0c
+ax_pose 146, 0x01f1, 0x00e8, 0x5c0d
+ax_pose 147, 0x0201, 0x00ff, 0x5c0e
+ax_pose 148, 0x01e8, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose83:
+ax_pose 81, 0x01ee, 0x4100, 0x5c00
+ax_pose 82, 0x01de, 0x0104, 0x5c04
+ax_pose 83, 0x41e6, 0x00fb, 0x5c05
+ax_pose 84, 0x01e5, 0x00ec, 0x5c07
+ax_pose 85, 0x41ed, 0x00e8, 0x5c08
+ax_pose 89, 0x01fe, 0x0108, 0x5c0a
+ax_pose 88, 0x01fe, 0x00f8, 0x5c0b
+ax_pose 86, 0x01f5, 0x00f0, 0x5c0c
+ax_pose 87, 0x01ee, 0x0110, 0x5c0d
+ax_pose 90, 0x81ee, 0x00f8, 0x5c0e
+ax_pose_terminator
+sLatiasPose84:
+ax_pose 125, 0x81e0, 0x4106, 0x5c00
+ax_pose 126, 0x01f0, 0x40f6, 0x5c04
+ax_pose 127, 0x01e0, 0x40ee, 0x5c08
+ax_pose 128, 0x01e8, 0x00fe, 0x5c0c
+ax_pose 129, 0x01e4, 0x010e, 0x5c0d
+ax_pose 130, 0x01f0, 0x010e, 0x5c0e
+ax_pose 131, 0x0200, 0x0101, 0x5c0f
+ax_pose_terminator
+sLatiasPose85:
+ax_pose 132, 0x81e6, 0x80fe, 0x5c00
+ax_pose 133, 0x81e6, 0x40f6, 0x5c08
+ax_pose 134, 0x81e6, 0x00ee, 0x5c0c
+ax_pose 135, 0x01ee, 0x00e6, 0x5c0e
+ax_pose 136, 0x01de, 0x0106, 0x5c0f
+ax_pose_terminator
+sLatiasPose86:
+ax_pose 74, 0x41f0, 0x80ed, 0x5c00
+ax_pose 76, 0x01e9, 0x010d, 0x5c08
+ax_pose 75, 0x0200, 0x0103, 0x5c09
+ax_pose 77, 0x01f1, 0x010d, 0x5c0a
+ax_pose 78, 0x01e0, 0x00f4, 0x5c0b
+ax_pose 79, 0x01e8, 0x0105, 0x5c0c
+ax_pose 80, 0x41e8, 0x00f5, 0x5c0d
+ax_pose_terminator
+sLatiasPose87:
+ax_pose 115, 0x81e6, 0x80f5, 0x5c00
+ax_pose 116, 0x81e6, 0x4105, 0x5c08
+ax_pose 117, 0x01de, 0x00f5, 0x5c0c
+ax_pose 118, 0x01de, 0x00fd, 0x5c0d
+ax_pose 119, 0x01e5, 0x00ed, 0x5c0e
+ax_pose 120, 0x01e6, 0x010d, 0x5c0f
+ax_pose_terminator
+sLatiasPose88:
+ax_pose 121, 0x81e1, 0x80ee, 0x5c00
+ax_pose 122, 0x01f1, 0x40fe, 0x5c08
+ax_pose 123, 0x41e9, 0x00fe, 0x5c0c
+ax_pose 124, 0x01e9, 0x010e, 0x5c0e
+ax_pose_terminator
+sLatiasPose89:
+ax_pose 69, 0x81e9, 0x80fb, 0x5c00
+ax_pose 70, 0x01e9, 0x0113, 0x5c08
+ax_pose 71, 0x01e9, 0x010b, 0x5c09
+ax_pose 72, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 73, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose90:
+ax_pose 109, 0x41f0, 0x80f0, 0x5c00
+ax_pose 110, 0x41e8, 0x40f0, 0x5c08
+ax_pose 111, 0x01e0, 0x00f0, 0x5c0c
+ax_pose 112, 0x01e0, 0x0108, 0x5c0d
+ax_pose 113, 0x01e6, 0x00e8, 0x5c0e
+ax_pose 114, 0x01e6, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose91:
+ax_pose 159, 0x41e5, 0x80ee, 0x5c00
+ax_pose 160, 0x41f5, 0x40ee, 0x5c08
+ax_pose 161, 0x41fd, 0x00fe, 0x5c0c
+ax_pose 162, 0x01fd, 0x00f6, 0x5c0e
+ax_pose 163, 0x01e5, 0x010e, 0x5c0f
+ax_pose_terminator
+sLatiasPose92:
+ax_pose 74, 0x41f0, 0x90f3, 0x5c00
+ax_pose 75, 0x0200, 0x10f5, 0x5c08
+ax_pose 76, 0x01e9, 0x10eb, 0x5c09
+ax_pose 77, 0x01f1, 0x10eb, 0x5c0a
+ax_pose 78, 0x01e0, 0x1104, 0x5c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x5c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x5c0d
+ax_pose_terminator
+sLatiasPose93:
+ax_pose 121, 0x81e1, 0x9101, 0x5c00
+ax_pose 122, 0x01f1, 0x50f1, 0x5c08
+ax_pose 123, 0x41e9, 0x10f1, 0x5c0c
+ax_pose 124, 0x01e9, 0x10e9, 0x5c0e
+ax_pose_terminator
+sLatiasPose94:
+ax_pose 164, 0x81e1, 0x90f8, 0x5c00
+ax_pose 165, 0x81e1, 0x1108, 0x5c08
+ax_pose 166, 0x01f1, 0x1108, 0x5c0a
+ax_pose 167, 0x0201, 0x10f2, 0x5c0b
+ax_pose 168, 0x81f1, 0x10f0, 0x5c0c
+ax_pose 169, 0x01e9, 0x10f0, 0x5c0e
+ax_pose 170, 0x01e9, 0x10e8, 0x5c0f
+ax_pose_terminator
+sLatiasPose95:
+ax_pose 81, 0x01ee, 0x50f0, 0x5c00
+ax_pose 82, 0x01de, 0x10f4, 0x5c04
+ax_pose 83, 0x41e6, 0x10f5, 0x5c05
+ax_pose 84, 0x01e5, 0x110c, 0x5c07
+ax_pose 85, 0x41ed, 0x1108, 0x5c08
+ax_pose 86, 0x01f5, 0x1108, 0x5c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x5c0b
+ax_pose 88, 0x01fe, 0x1100, 0x5c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x5c0d
+ax_pose 90, 0x81ee, 0x1100, 0x5c0e
+ax_pose_terminator
+sLatiasPose96:
+ax_pose 132, 0x81e6, 0x90f1, 0x5c00
+ax_pose 133, 0x81e6, 0x5101, 0x5c08
+ax_pose 134, 0x81e6, 0x1109, 0x5c0c
+ax_pose 135, 0x01ee, 0x1111, 0x5c0e
+ax_pose 136, 0x01de, 0x10f1, 0x5c0f
+ax_pose_terminator
+sLatiasPose97:
+ax_pose 171, 0x81e2, 0x90ed, 0x5c00
+ax_pose 172, 0x81e2, 0x50fd, 0x5c08
+ax_pose 173, 0x81e2, 0x1105, 0x5c0c
+ax_pose 174, 0x01f2, 0x1105, 0x5c0e
+ax_pose 175, 0x0202, 0x10f5, 0x5c0f
+ax_pose_terminator
+sLatiasPose98:
+ax_pose 91, 0x81e2, 0x110d, 0x5c00
+ax_pose 92, 0x01ea, 0x10ed, 0x5c02
+ax_pose 93, 0x01e2, 0x10ed, 0x5c03
+ax_pose 94, 0x0200, 0x10f9, 0x5c04
+ax_pose 95, 0x01f6, 0x10ed, 0x5c05
+ax_pose 96, 0x41e8, 0x10f5, 0x5c06
+ax_pose 97, 0x01f0, 0x50f5, 0x5c08
+ax_pose 98, 0x81e2, 0x5105, 0x5c0c
+ax_pose_terminator
+sLatiasPose99:
+ax_pose 142, 0x41e8, 0x90f0, 0x5c00
+ax_pose 143, 0x41e0, 0x1100, 0x5c08
+ax_pose 144, 0x41f8, 0x10f0, 0x5c0a
+ax_pose 145, 0x01f8, 0x1100, 0x5c0c
+ax_pose 146, 0x01f0, 0x1110, 0x5c0d
+ax_pose 147, 0x0200, 0x10f9, 0x5c0e
+ax_pose 148, 0x01e7, 0x10e8, 0x5c0f
+ax_pose_terminator
+sLatiasPose100:
+ax_pose 176, 0x81e1, 0x90fa, 0x5c00
+ax_pose 177, 0x41e9, 0x10ea, 0x5c08
+ax_pose 178, 0x81f1, 0x10f2, 0x5c0a
+ax_pose 179, 0x41d9, 0x10fa, 0x5c0c
+ax_pose 180, 0x01ec, 0x110a, 0x5c0e
+ax_pose 181, 0x0201, 0x10fc, 0x5c0f
+ax_pose_terminator
+sLatiasPose101:
+ax_pose 99, 0x01f3, 0x40fb, 0x5c00
+ax_pose 100, 0x41db, 0x00fb, 0x5c04
+ax_pose 101, 0x41e3, 0x00f6, 0x5c06
+ax_pose 102, 0x01eb, 0x0113, 0x5c08
+ax_pose 103, 0x01eb, 0x010b, 0x5c09
+ax_pose 104, 0x41eb, 0x40eb, 0x5c0a
+ax_pose 105, 0x81f3, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose102:
+ax_pose 154, 0x81df, 0x80f8, 0x5c00
+ax_pose 155, 0x81ef, 0x00f0, 0x5c08
+ax_pose -1, 0x81ef, 0x1108, 0x5c08
+ax_pose 156, 0x01e7, 0x00f0, 0x5c0a
+ax_pose -1, 0x01e7, 0x1108, 0x5c0a
+ax_pose 157, 0x01ed, 0x00e8, 0x5c0b
+ax_pose -1, 0x01ed, 0x1110, 0x5c0b
+ax_pose 158, 0x41d7, 0x00f8, 0x5c0c
+ax_pose_terminator
+sLatiasPose103:
+ax_pose 182, 0x01d6, 0x40f8, 0x5c00
+ax_pose 183, 0x41e6, 0x80ec, 0x5c04
+ax_pose 184, 0x41f6, 0x40ec, 0x5c0c
+ax_pose 185, 0x81e6, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiasPose104:
+ax_pose 106, 0x01e2, 0x40eb, 0x5c00
+ax_pose 95, 0x01f6, 0x010b, 0x5c04
+ax_pose 94, 0x0200, 0x00ff, 0x5c05
+ax_pose 92, 0x01ea, 0x010b, 0x5c06
+ax_pose 93, 0x01e2, 0x010b, 0x5c07
+ax_pose 96, 0x41e8, 0x00fb, 0x5c08
+ax_pose 97, 0x01f0, 0x40fb, 0x5c0a
+ax_pose 107, 0x81f2, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose105:
+ax_pose 142, 0x41e8, 0x80f0, 0x5c00
+ax_pose 143, 0x41e0, 0x00f0, 0x5c08
+ax_pose 144, 0x41f8, 0x0100, 0x5c0a
+ax_pose 145, 0x01f8, 0x00f8, 0x5c0c
+ax_pose 146, 0x01f0, 0x00e8, 0x5c0d
+ax_pose 147, 0x0200, 0x00ff, 0x5c0e
+ax_pose 148, 0x01e7, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose106:
+ax_pose 176, 0x81e1, 0x80f6, 0x5c00
+ax_pose 177, 0x41e9, 0x0106, 0x5c08
+ax_pose 178, 0x81f1, 0x0106, 0x5c0a
+ax_pose 179, 0x41d9, 0x00f6, 0x5c0c
+ax_pose 180, 0x01ec, 0x00ee, 0x5c0e
+ax_pose 181, 0x0201, 0x00fc, 0x5c0f
+ax_pose_terminator
+sLatiasPose107:
+ax_pose 81, 0x01ee, 0x4100, 0x5c00
+ax_pose 82, 0x01de, 0x0104, 0x5c04
+ax_pose 83, 0x41e6, 0x00fb, 0x5c05
+ax_pose 84, 0x01e5, 0x00ec, 0x5c07
+ax_pose 85, 0x41ed, 0x00e8, 0x5c08
+ax_pose 89, 0x01fe, 0x0108, 0x5c0a
+ax_pose 88, 0x01fe, 0x00f8, 0x5c0b
+ax_pose 86, 0x01f5, 0x00f0, 0x5c0c
+ax_pose 87, 0x01ee, 0x0110, 0x5c0d
+ax_pose 90, 0x81ee, 0x00f8, 0x5c0e
+ax_pose_terminator
+sLatiasPose108:
+ax_pose 132, 0x81e6, 0x80ff, 0x5c00
+ax_pose 133, 0x81e6, 0x40f7, 0x5c08
+ax_pose 134, 0x81e6, 0x00ef, 0x5c0c
+ax_pose 135, 0x01ee, 0x00e7, 0x5c0e
+ax_pose 136, 0x01de, 0x0107, 0x5c0f
+ax_pose_terminator
+sLatiasPose109:
+ax_pose 171, 0x81e2, 0x8103, 0x5c00
+ax_pose 172, 0x81e2, 0x40fb, 0x5c08
+ax_pose 173, 0x81e2, 0x00f3, 0x5c0c
+ax_pose 174, 0x01f2, 0x00f3, 0x5c0e
+ax_pose 175, 0x0202, 0x0103, 0x5c0f
+ax_pose_terminator
+sLatiasPose110:
+ax_pose 74, 0x41f0, 0x80ed, 0x5c00
+ax_pose 76, 0x01e9, 0x010d, 0x5c08
+ax_pose 75, 0x0200, 0x0103, 0x5c09
+ax_pose 77, 0x01f1, 0x010d, 0x5c0a
+ax_pose 78, 0x01e0, 0x00f4, 0x5c0b
+ax_pose 79, 0x01e8, 0x0105, 0x5c0c
+ax_pose 80, 0x41e8, 0x00f5, 0x5c0d
+ax_pose_terminator
+sLatiasPose111:
+ax_pose 121, 0x81e1, 0x80ef, 0x5c00
+ax_pose 122, 0x01f1, 0x40ff, 0x5c08
+ax_pose 123, 0x41e9, 0x00ff, 0x5c0c
+ax_pose 124, 0x01e9, 0x010f, 0x5c0e
+ax_pose_terminator
+sLatiasPose112:
+ax_pose 164, 0x81e1, 0x80f8, 0x5c00
+ax_pose 165, 0x81e1, 0x00f0, 0x5c08
+ax_pose 166, 0x01f1, 0x00f0, 0x5c0a
+ax_pose 167, 0x0201, 0x0106, 0x5c0b
+ax_pose 168, 0x81f1, 0x0108, 0x5c0c
+ax_pose 169, 0x01e9, 0x0108, 0x5c0e
+ax_pose 170, 0x01e9, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose113:
+ax_pose 186, 0x41f3, 0x80ec, 0x6c00
+ax_pose 187, 0x4203, 0x00ec, 0x6c08
+ax_pose 188, 0x0203, 0x00fc, 0x6c0a
+ax_pose 189, 0x81f6, 0x010c, 0x6c0b
+ax_pose_terminator
+sLatiasPose114:
+ax_pose 190, 0x41f3, 0x80ec, 0x6c00
+ax_pose 191, 0x4203, 0x00ec, 0x6c08
+ax_pose 192, 0x0203, 0x00fc, 0x6c0a
+ax_pose 193, 0x81f6, 0x010c, 0x6c0b
+ax_pose_terminator
+sLatiasPose115:
+ax_pose 194, 0x41ec, 0x40f0, 0x5c00
+ax_pose 195, 0x41fc, 0x00f8, 0x5c04
+ax_pose 196, 0x41f4, 0x00f8, 0x5c06
+ax_pose 197, 0x41dc, 0x80f0, 0x5c08
+ax_pose_terminator
+sLatiasPose116:
+ax_pose 198, 0x41e1, 0x90f0, 0x5c00
+ax_pose 199, 0x41f1, 0x1100, 0x5c08
+ax_pose 200, 0x01f1, 0x10f8, 0x5c0a
+ax_pose 201, 0x01d9, 0x1108, 0x5c0b
+ax_pose 202, 0x41f9, 0x10f8, 0x5c0c
+ax_pose 203, 0x01f9, 0x10f0, 0x5c0e
+ax_pose 204, 0x01d9, 0x10f8, 0x5c0f
+ax_pose_terminator
+sLatiasPose117:
+ax_pose 205, 0x81e0, 0x90fd, 0x5c00
+ax_pose 206, 0x01d8, 0x10ed, 0x5c08
+ax_pose 207, 0x01d8, 0x10f5, 0x5c09
+ax_pose 208, 0x81e3, 0x10ed, 0x5c0a
+ax_pose 209, 0x81e3, 0x50f5, 0x5c0c
+ax_pose_terminator
+sLatiasPose118:
+ax_pose 210, 0x01f7, 0x50f8, 0x5c00
+ax_pose 211, 0x01e7, 0x110b, 0x5c04
+ax_pose 212, 0x01d8, 0x10f8, 0x5c05
+ax_pose 213, 0x41df, 0x1100, 0x5c06
+ax_pose 214, 0x41e7, 0x90eb, 0x5c08
+ax_pose_terminator
+sLatiasPose119:
+ax_pose 215, 0x41e2, 0x80ef, 0x5c00
+ax_pose 216, 0x41da, 0x00f7, 0x5c08
+ax_pose 217, 0x41fa, 0x00f7, 0x5c0a
+ax_pose 218, 0x41f2, 0x40ef, 0x5c0c
+ax_pose_terminator
+sLatiasPose120:
+ax_pose 210, 0x01f7, 0x40f8, 0x5c00
+ax_pose 211, 0x01e7, 0x00ed, 0x5c04
+ax_pose 212, 0x01d8, 0x0100, 0x5c05
+ax_pose 213, 0x41df, 0x00f0, 0x5c06
+ax_pose 214, 0x41e7, 0x80f5, 0x5c08
+ax_pose_terminator
+sLatiasPose121:
+ax_pose 205, 0x81e0, 0x80f3, 0x5c00
+ax_pose 206, 0x01d8, 0x010b, 0x5c08
+ax_pose 207, 0x01d8, 0x0103, 0x5c09
+ax_pose 208, 0x81e3, 0x010b, 0x5c0a
+ax_pose 209, 0x81e3, 0x4103, 0x5c0c
+ax_pose_terminator
+sLatiasPose122:
+ax_pose 198, 0x41e1, 0x80f0, 0x5c00
+ax_pose 199, 0x41f1, 0x00f0, 0x5c08
+ax_pose 200, 0x01f1, 0x0100, 0x5c0a
+ax_pose 201, 0x01d9, 0x00f0, 0x5c0b
+ax_pose 202, 0x41f9, 0x00f8, 0x5c0c
+ax_pose 203, 0x01f9, 0x0108, 0x5c0e
+ax_pose 204, 0x01d9, 0x0100, 0x5c0f
+ax_pose_terminator
+sLatiasPose123:
+ax_pose 69, 0x81e9, 0x80fb, 0x6c00
+ax_pose 70, 0x01e9, 0x0113, 0x6c08
+ax_pose 71, 0x01e9, 0x010b, 0x6c09
+ax_pose 72, 0x01e9, 0x00eb, 0x6c0a
+ax_pose 73, 0x81e9, 0x40f3, 0x6c0b
+ax_pose_terminator
+sLatiasPose124:
+ax_pose 74, 0x41f0, 0x90f3, 0x6c00
+ax_pose 75, 0x0200, 0x10f5, 0x6c08
+ax_pose 76, 0x01e9, 0x10eb, 0x6c09
+ax_pose 77, 0x01f1, 0x10eb, 0x6c0a
+ax_pose 78, 0x01e0, 0x1104, 0x6c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x6c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x6c0d
+ax_pose_terminator
+sLatiasPose125:
+ax_pose 81, 0x01ee, 0x50f0, 0x6c00
+ax_pose 82, 0x01de, 0x10f4, 0x6c04
+ax_pose 83, 0x41e6, 0x10f5, 0x6c05
+ax_pose 84, 0x01e5, 0x110c, 0x6c07
+ax_pose 85, 0x41ed, 0x1108, 0x6c08
+ax_pose 86, 0x01f5, 0x1108, 0x6c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x6c0b
+ax_pose 88, 0x01fe, 0x1100, 0x6c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x6c0d
+ax_pose 90, 0x81ee, 0x1100, 0x6c0e
+ax_pose_terminator
+sLatiasPose126:
+ax_pose 91, 0x81e2, 0x110d, 0x6c00
+ax_pose 92, 0x01ea, 0x10ed, 0x6c02
+ax_pose 93, 0x01e2, 0x10ed, 0x6c03
+ax_pose 94, 0x0200, 0x10f9, 0x6c04
+ax_pose 95, 0x01f6, 0x10ed, 0x6c05
+ax_pose 96, 0x41e8, 0x10f5, 0x6c06
+ax_pose 97, 0x01f0, 0x50f5, 0x6c08
+ax_pose 98, 0x81e2, 0x5105, 0x6c0c
+ax_pose_terminator
+sLatiasPose127:
+ax_pose 99, 0x01f3, 0x40fb, 0x6c00
+ax_pose 100, 0x41db, 0x00fb, 0x6c04
+ax_pose 101, 0x41e3, 0x00f6, 0x6c06
+ax_pose 102, 0x01eb, 0x0113, 0x6c08
+ax_pose 103, 0x01eb, 0x010b, 0x6c09
+ax_pose 104, 0x41eb, 0x40eb, 0x6c0a
+ax_pose 105, 0x81f3, 0x00f3, 0x6c0e
+ax_pose_terminator
+sLatiasPose128:
+ax_pose 106, 0x01e2, 0x40eb, 0x6c00
+ax_pose 95, 0x01f6, 0x010b, 0x6c04
+ax_pose 94, 0x0200, 0x00ff, 0x6c05
+ax_pose 92, 0x01ea, 0x010b, 0x6c06
+ax_pose 93, 0x01e2, 0x010b, 0x6c07
+ax_pose 96, 0x41e8, 0x00fb, 0x6c08
+ax_pose 97, 0x01f0, 0x40fb, 0x6c0a
+ax_pose 107, 0x81f2, 0x00f3, 0x6c0e
+ax_pose_terminator
+sLatiasPose129:
+ax_pose 81, 0x01ee, 0x4100, 0x6c00
+ax_pose 82, 0x01de, 0x0104, 0x6c04
+ax_pose 83, 0x41e6, 0x00fb, 0x6c05
+ax_pose 84, 0x01e5, 0x00ec, 0x6c07
+ax_pose 85, 0x41ed, 0x00e8, 0x6c08
+ax_pose 89, 0x01fe, 0x0108, 0x6c0a
+ax_pose 88, 0x01fe, 0x00f8, 0x6c0b
+ax_pose 86, 0x01f5, 0x00f0, 0x6c0c
+ax_pose 87, 0x01ee, 0x0110, 0x6c0d
+ax_pose 90, 0x81ee, 0x00f8, 0x6c0e
+ax_pose_terminator
+sLatiasPose130:
+ax_pose 74, 0x41f0, 0x80ed, 0x6c00
+ax_pose 76, 0x01e9, 0x010d, 0x6c08
+ax_pose 75, 0x0200, 0x0103, 0x6c09
+ax_pose 77, 0x01f1, 0x010d, 0x6c0a
+ax_pose 78, 0x01e0, 0x00f4, 0x6c0b
+ax_pose 79, 0x01e8, 0x0105, 0x6c0c
+ax_pose 80, 0x41e8, 0x00f5, 0x6c0d
+ax_pose_terminator
+sLatiasPose131:
+ax_pose 0, 0x81e9, 0x80fb, 0x5c00
+ax_pose 1, 0x01e9, 0x0113, 0x5c08
+ax_pose 2, 0x01e9, 0x010b, 0x5c09
+ax_pose 3, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 4, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose132:
+ax_pose 62, 0x81f1, 0x00eb, 0x5c00
+ax_pose 13, 0x81e9, 0x010b, 0x5c02
+ax_pose 63, 0x01f9, 0x0103, 0x5c04
+ax_pose 64, 0x81e9, 0x0103, 0x5c05
+ax_pose 65, 0x81e1, 0x80f3, 0x5c07
+ax_pose_terminator
+sLatiasPose133:
+ax_pose 20, 0x41ef, 0x80f1, 0x5c00
+ax_pose 24, 0x41df, 0x0101, 0x5c08
+ax_pose 23, 0x01ef, 0x00e1, 0x5c0a
+ax_pose 21, 0x01e7, 0x00e9, 0x5c0b
+ax_pose 22, 0x01ef, 0x00e9, 0x5c0c
+ax_pose 26, 0x01e7, 0x00f1, 0x5c0d
+ax_pose 25, 0x41e7, 0x00fb, 0x5c0e
+ax_pose_terminator
+sLatiasPose134:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose135:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose136:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose137:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose138:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose139:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose140:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose141:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose142:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose143:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose144:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose145:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose146:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose147:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose148:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose149:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose150:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose151:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose152:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose153:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose154:
+ax_pose 20, 0x41ef, 0x80f1, 0x5c00
+ax_pose 24, 0x41df, 0x0101, 0x5c08
+ax_pose 23, 0x01ef, 0x00e1, 0x5c0a
+ax_pose 21, 0x01e7, 0x00e9, 0x5c0b
+ax_pose 22, 0x01ef, 0x00e9, 0x5c0c
+ax_pose 26, 0x01e7, 0x00f1, 0x5c0d
+ax_pose 25, 0x41e7, 0x00fb, 0x5c0e
+ax_pose_terminator
+sLatiasPose155:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose156:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose157:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose158:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose159:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose160:
+ax_pose 62, 0x81f1, 0x00eb, 0x5c00
+ax_pose 13, 0x81e9, 0x010b, 0x5c02
+ax_pose 63, 0x01f9, 0x0103, 0x5c04
+ax_pose 64, 0x81e9, 0x0103, 0x5c05
+ax_pose 65, 0x81e1, 0x80f3, 0x5c07
+ax_pose_terminator
+sLatiasPose161:
+ax_pose 20, 0x41ef, 0x80f1, 0x5c00
+ax_pose 24, 0x41df, 0x0101, 0x5c08
+ax_pose 23, 0x01ef, 0x00e1, 0x5c0a
+ax_pose 21, 0x01e7, 0x00e9, 0x5c0b
+ax_pose 22, 0x01ef, 0x00e9, 0x5c0c
+ax_pose 26, 0x01e7, 0x00f1, 0x5c0d
+ax_pose 25, 0x41e7, 0x00fb, 0x5c0e
+ax_pose_terminator
+sLatiasPose162:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose163:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose164:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose165:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose166:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose167:
+ax_pose 109, 0x41ee, 0x80f0, 0x5c00
+ax_pose 110, 0x41e6, 0x40f0, 0x5c08
+ax_pose 111, 0x01de, 0x00f0, 0x5c0c
+ax_pose 112, 0x01de, 0x0108, 0x5c0d
+ax_pose 113, 0x01e4, 0x00e8, 0x5c0e
+ax_pose 114, 0x01e4, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose168:
+ax_pose 121, 0x81e1, 0x9102, 0x5c00
+ax_pose 122, 0x01f1, 0x50f2, 0x5c08
+ax_pose 123, 0x41e9, 0x10f2, 0x5c0c
+ax_pose 124, 0x01e9, 0x10ea, 0x5c0e
+ax_pose_terminator
+sLatiasPose169:
+ax_pose 132, 0x81e6, 0x90f2, 0x5c00
+ax_pose 133, 0x81e6, 0x5102, 0x5c08
+ax_pose 134, 0x81e6, 0x110a, 0x5c0c
+ax_pose 135, 0x01ee, 0x1112, 0x5c0e
+ax_pose 136, 0x01de, 0x10f2, 0x5c0f
+ax_pose_terminator
+sLatiasPose170:
+ax_pose 142, 0x41ec, 0x90ef, 0x5c00
+ax_pose 143, 0x41e4, 0x10ff, 0x5c08
+ax_pose 144, 0x41fc, 0x10ef, 0x5c0a
+ax_pose 145, 0x01fc, 0x10ff, 0x5c0c
+ax_pose 146, 0x01f4, 0x110f, 0x5c0d
+ax_pose 147, 0x0204, 0x10f8, 0x5c0e
+ax_pose 148, 0x01eb, 0x10e7, 0x5c0f
+ax_pose_terminator
+sLatiasPose171:
+ax_pose 154, 0x81e5, 0x80f8, 0x5c00
+ax_pose 155, 0x81f5, 0x00f0, 0x5c08
+ax_pose -1, 0x81f5, 0x1108, 0x5c08
+ax_pose 156, 0x01ed, 0x00f0, 0x5c0a
+ax_pose -1, 0x01ed, 0x1108, 0x5c0a
+ax_pose 157, 0x01f3, 0x00e8, 0x5c0b
+ax_pose -1, 0x01f3, 0x1110, 0x5c0b
+ax_pose 158, 0x41dd, 0x00f8, 0x5c0c
+ax_pose_terminator
+sLatiasPose172:
+ax_pose 142, 0x41ec, 0x80f1, 0x5c00
+ax_pose 143, 0x41e4, 0x00f1, 0x5c08
+ax_pose 144, 0x41fc, 0x0101, 0x5c0a
+ax_pose 145, 0x01fc, 0x00f9, 0x5c0c
+ax_pose 146, 0x01f4, 0x00e9, 0x5c0d
+ax_pose 147, 0x0204, 0x0100, 0x5c0e
+ax_pose 148, 0x01eb, 0x0111, 0x5c0f
+ax_pose_terminator
+sLatiasPose173:
+ax_pose 132, 0x81e6, 0x80fe, 0x5c00
+ax_pose 133, 0x81e6, 0x40f6, 0x5c08
+ax_pose 134, 0x81e6, 0x00ee, 0x5c0c
+ax_pose 135, 0x01ee, 0x00e6, 0x5c0e
+ax_pose 136, 0x01de, 0x0106, 0x5c0f
+ax_pose_terminator
+sLatiasPose174:
+ax_pose 121, 0x81e1, 0x80ee, 0x5c00
+ax_pose 122, 0x01f1, 0x40fe, 0x5c08
+ax_pose 123, 0x41e9, 0x00fe, 0x5c0c
+ax_pose 124, 0x01e9, 0x010e, 0x5c0e
+ax_pose_terminator
+sLatiasPose175:
+ax_pose 69, 0x81e9, 0x80fb, 0x5c00
+ax_pose 70, 0x01e9, 0x0113, 0x5c08
+ax_pose 71, 0x01e9, 0x010b, 0x5c09
+ax_pose 72, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 73, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose176:
+ax_pose 0, 0x81e9, 0x80fb, 0x5c00
+ax_pose 1, 0x01e9, 0x0113, 0x5c08
+ax_pose 2, 0x01e9, 0x010b, 0x5c09
+ax_pose 3, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 4, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose177:
+ax_pose 5, 0x81e9, 0x80fb, 0x5c00
+ax_pose 6, 0x01e9, 0x0113, 0x5c08
+ax_pose 7, 0x01e9, 0x010b, 0x5c09
+ax_pose 8, 0x01e9, 0x00eb, 0x5c0a
+ax_pose 9, 0x81e9, 0x40f3, 0x5c0b
+ax_pose_terminator
+sLatiasPose178:
+ax_pose 108, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sLatiasPose179:
+ax_pose 109, 0x41ee, 0x80f0, 0x5c00
+ax_pose 110, 0x41e6, 0x40f0, 0x5c08
+ax_pose 111, 0x01de, 0x00f0, 0x5c0c
+ax_pose 112, 0x01de, 0x0108, 0x5c0d
+ax_pose 113, 0x01e4, 0x00e8, 0x5c0e
+ax_pose 114, 0x01e4, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose180:
+ax_pose 74, 0x41f0, 0x90f3, 0x5c00
+ax_pose 75, 0x0200, 0x10f5, 0x5c08
+ax_pose 76, 0x01e9, 0x10eb, 0x5c09
+ax_pose 77, 0x01f1, 0x10eb, 0x5c0a
+ax_pose 78, 0x01e0, 0x1104, 0x5c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x5c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x5c0d
+ax_pose_terminator
+sLatiasPose181:
+ax_pose 10, 0x41f1, 0x90f5, 0x5c00
+ax_pose 11, 0x01e9, 0x10f5, 0x5c08
+ax_pose 12, 0x41e9, 0x10fd, 0x5c09
+ax_pose 13, 0x81e9, 0x10ed, 0x5c0b
+ax_pose 14, 0x41e1, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose182:
+ax_pose 15, 0x41f1, 0x90f5, 0x5c00
+ax_pose 16, 0x81e9, 0x10ed, 0x5c08
+ax_pose 17, 0x41e1, 0x10fd, 0x5c0a
+ax_pose 18, 0x01e9, 0x10f5, 0x5c0c
+ax_pose 19, 0x41e9, 0x10fd, 0x5c0d
+ax_pose_terminator
+sLatiasPose183:
+ax_pose 115, 0x81e6, 0x90fb, 0x5c00
+ax_pose 116, 0x81e6, 0x50f3, 0x5c08
+ax_pose 117, 0x01de, 0x1103, 0x5c0c
+ax_pose 118, 0x01de, 0x10fb, 0x5c0d
+ax_pose 119, 0x01e5, 0x110b, 0x5c0e
+ax_pose 120, 0x01e6, 0x10eb, 0x5c0f
+ax_pose_terminator
+sLatiasPose184:
+ax_pose 121, 0x81e1, 0x9102, 0x5c00
+ax_pose 122, 0x01f1, 0x50f2, 0x5c08
+ax_pose 123, 0x41e9, 0x10f2, 0x5c0c
+ax_pose 124, 0x01e9, 0x10ea, 0x5c0e
+ax_pose_terminator
+sLatiasPose185:
+ax_pose 81, 0x01ee, 0x50f0, 0x5c00
+ax_pose 82, 0x01de, 0x10f4, 0x5c04
+ax_pose 83, 0x41e6, 0x10f5, 0x5c05
+ax_pose 84, 0x01e5, 0x110c, 0x5c07
+ax_pose 85, 0x41ed, 0x1108, 0x5c08
+ax_pose 86, 0x01f5, 0x1108, 0x5c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x5c0b
+ax_pose 88, 0x01fe, 0x1100, 0x5c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x5c0d
+ax_pose 90, 0x81ee, 0x1100, 0x5c0e
+ax_pose_terminator
+sLatiasPose186:
+ax_pose 20, 0x41ef, 0x90ef, 0x5c00
+ax_pose 21, 0x01e7, 0x110f, 0x5c08
+ax_pose 22, 0x01ef, 0x110f, 0x5c09
+ax_pose 23, 0x01ef, 0x1117, 0x5c0a
+ax_pose 24, 0x41df, 0x10ef, 0x5c0b
+ax_pose 25, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 26, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose187:
+ax_pose 27, 0x41ef, 0x90ef, 0x5c00
+ax_pose 28, 0x01ef, 0x110f, 0x5c08
+ax_pose 29, 0x01e7, 0x110f, 0x5c09
+ax_pose 30, 0x01ef, 0x1117, 0x5c0a
+ax_pose 31, 0x41df, 0x10ef, 0x5c0b
+ax_pose 32, 0x41e7, 0x10f5, 0x5c0d
+ax_pose 33, 0x01e7, 0x1107, 0x5c0f
+ax_pose_terminator
+sLatiasPose188:
+ax_pose 125, 0x81e0, 0x50f2, 0x5c00
+ax_pose 126, 0x01f0, 0x50fa, 0x5c04
+ax_pose 127, 0x01e0, 0x5102, 0x5c08
+ax_pose 128, 0x01e8, 0x10fa, 0x5c0c
+ax_pose 129, 0x01e4, 0x10ea, 0x5c0d
+ax_pose 130, 0x01f0, 0x10ea, 0x5c0e
+ax_pose 131, 0x0200, 0x10f7, 0x5c0f
+ax_pose_terminator
+sLatiasPose189:
+ax_pose 132, 0x81e6, 0x90f2, 0x5c00
+ax_pose 133, 0x81e6, 0x5102, 0x5c08
+ax_pose 134, 0x81e6, 0x110a, 0x5c0c
+ax_pose 135, 0x01ee, 0x1112, 0x5c0e
+ax_pose 136, 0x01de, 0x10f2, 0x5c0f
+ax_pose_terminator
+sLatiasPose190:
+ax_pose 91, 0x81e2, 0x110d, 0x5c00
+ax_pose 92, 0x01ea, 0x10ed, 0x5c02
+ax_pose 93, 0x01e2, 0x10ed, 0x5c03
+ax_pose 94, 0x0200, 0x10f9, 0x5c04
+ax_pose 95, 0x01f6, 0x10ed, 0x5c05
+ax_pose 96, 0x41e8, 0x10f5, 0x5c06
+ax_pose 97, 0x01f0, 0x50f5, 0x5c08
+ax_pose 98, 0x81e2, 0x5105, 0x5c0c
+ax_pose_terminator
+sLatiasPose191:
+ax_pose 34, 0x41e9, 0x50f7, 0x5c00
+ax_pose 35, 0x0201, 0x10f7, 0x5c04
+ax_pose 36, 0x01f5, 0x10ef, 0x5c05
+ax_pose 37, 0x01e3, 0x10e7, 0x5c06
+ax_pose 38, 0x81e1, 0x10ef, 0x5c07
+ax_pose 39, 0x01f1, 0x1107, 0x5c09
+ax_pose 40, 0x41e1, 0x1107, 0x5c0a
+ax_pose 41, 0x01f1, 0x50f7, 0x5c0c
+ax_pose_terminator
+sLatiasPose192:
+ax_pose 42, 0x01f3, 0x50f5, 0x5c00
+ax_pose 43, 0x81e3, 0x10ed, 0x5c04
+ax_pose 44, 0x41e3, 0x1105, 0x5c06
+ax_pose 45, 0x01e3, 0x10f5, 0x5c08
+ax_pose 46, 0x41eb, 0x50f5, 0x5c09
+ax_pose 47, 0x01f3, 0x1105, 0x5c0d
+ax_pose 48, 0x01f5, 0x10ed, 0x5c0e
+ax_pose_terminator
+sLatiasPose193:
+ax_pose 137, 0x81e5, 0x90fc, 0x5c00
+ax_pose 138, 0x41dd, 0x10fc, 0x5c08
+ax_pose 139, 0x01ed, 0x50ec, 0x5c0a
+ax_pose 140, 0x01fd, 0x10f4, 0x5c0e
+ax_pose 141, 0x01ed, 0x10e4, 0x5c0f
+ax_pose_terminator
+sLatiasPose194:
+ax_pose 142, 0x41e9, 0x90f0, 0x5c00
+ax_pose 143, 0x41e1, 0x1100, 0x5c08
+ax_pose 144, 0x41f9, 0x10f0, 0x5c0a
+ax_pose 145, 0x01f9, 0x1100, 0x5c0c
+ax_pose 146, 0x01f1, 0x1110, 0x5c0d
+ax_pose 147, 0x0201, 0x10f9, 0x5c0e
+ax_pose 148, 0x01e8, 0x10e8, 0x5c0f
+ax_pose_terminator
+sLatiasPose195:
+ax_pose 99, 0x01f3, 0x40fb, 0x5c00
+ax_pose 100, 0x41db, 0x00fb, 0x5c04
+ax_pose 101, 0x41e3, 0x00f6, 0x5c06
+ax_pose 102, 0x01eb, 0x0113, 0x5c08
+ax_pose 103, 0x01eb, 0x010b, 0x5c09
+ax_pose 104, 0x41eb, 0x40eb, 0x5c0a
+ax_pose 105, 0x81f3, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose196:
+ax_pose 49, 0x41ea, 0x40eb, 0x5c00
+ax_pose 50, 0x01da, 0x00fc, 0x5c04
+ax_pose 51, 0x41e2, 0x00f6, 0x5c05
+ax_pose 52, 0x41ea, 0x010b, 0x5c07
+ax_pose 53, 0x81f2, 0x00f3, 0x5c09
+ax_pose 54, 0x01f2, 0x40fb, 0x5c0b
+ax_pose_terminator
+sLatiasPose197:
+ax_pose 55, 0x01f2, 0x40fb, 0x5c00
+ax_pose 56, 0x41ea, 0x010b, 0x5c04
+ax_pose 57, 0x01da, 0x00fc, 0x5c06
+ax_pose 58, 0x41e2, 0x00f6, 0x5c07
+ax_pose 59, 0x41ea, 0x40eb, 0x5c09
+ax_pose 60, 0x81f2, 0x00f3, 0x5c0d
+ax_pose_terminator
+sLatiasPose198:
+ax_pose 149, 0x81de, 0x80f8, 0x5c00
+ax_pose 150, 0x81ee, 0x00f0, 0x5c08
+ax_pose -1, 0x81ee, 0x1108, 0x5c08
+ax_pose 151, 0x01e6, 0x00f0, 0x5c0a
+ax_pose -1, 0x01e6, 0x1108, 0x5c0a
+ax_pose 219, 0x01e6, 0x0108, 0x5c0b
+ax_pose 152, 0x01ef, 0x00e8, 0x5c0c
+ax_pose -1, 0x01ef, 0x1110, 0x5c0c
+ax_pose 153, 0x41d6, 0x00f8, 0x5c0d
+ax_pose_terminator
+sLatiasPose199:
+ax_pose 154, 0x81df, 0x80f8, 0x5c00
+ax_pose 155, 0x81ef, 0x00f0, 0x5c08
+ax_pose -1, 0x81ef, 0x1108, 0x5c08
+ax_pose 156, 0x01e7, 0x00f0, 0x5c0a
+ax_pose -1, 0x01e7, 0x1108, 0x5c0a
+ax_pose 157, 0x01ed, 0x00e8, 0x5c0b
+ax_pose -1, 0x01ed, 0x1110, 0x5c0b
+ax_pose 158, 0x41d7, 0x00f8, 0x5c0c
+ax_pose_terminator
+sLatiasPose200:
+ax_pose 106, 0x01e2, 0x40eb, 0x5c00
+ax_pose 95, 0x01f6, 0x010b, 0x5c04
+ax_pose 94, 0x0200, 0x00ff, 0x5c05
+ax_pose 92, 0x01ea, 0x010b, 0x5c06
+ax_pose 93, 0x01e2, 0x010b, 0x5c07
+ax_pose 96, 0x41e8, 0x00fb, 0x5c08
+ax_pose 97, 0x01f0, 0x40fb, 0x5c0a
+ax_pose 107, 0x81f2, 0x00f3, 0x5c0e
+ax_pose_terminator
+sLatiasPose201:
+ax_pose 34, 0x41e9, 0x40e9, 0x5c00
+ax_pose 37, 0x01e3, 0x0111, 0x5c04
+ax_pose 38, 0x81e1, 0x0109, 0x5c05
+ax_pose 35, 0x0201, 0x0101, 0x5c07
+ax_pose 36, 0x01f5, 0x0109, 0x5c08
+ax_pose 40, 0x41e1, 0x00e9, 0x5c09
+ax_pose 39, 0x01f1, 0x00f1, 0x5c0b
+ax_pose 41, 0x01f1, 0x40f9, 0x5c0c
+ax_pose_terminator
+sLatiasPose202:
+ax_pose 61, 0x41e3, 0x80eb, 0x5c00
+ax_pose 48, 0x01f5, 0x010b, 0x5c08
+ax_pose 43, 0x81e3, 0x010b, 0x5c09
+ax_pose 47, 0x01f3, 0x00f3, 0x5c0b
+ax_pose 42, 0x01f3, 0x40fb, 0x5c0c
+ax_pose_terminator
+sLatiasPose203:
+ax_pose 137, 0x81e5, 0x80f4, 0x5c00
+ax_pose 138, 0x41dd, 0x00f4, 0x5c08
+ax_pose 139, 0x01ed, 0x4104, 0x5c0a
+ax_pose 140, 0x01fd, 0x0104, 0x5c0e
+ax_pose 141, 0x01ed, 0x0114, 0x5c0f
+ax_pose_terminator
+sLatiasPose204:
+ax_pose 142, 0x41e9, 0x80f0, 0x5c00
+ax_pose 143, 0x41e1, 0x00f0, 0x5c08
+ax_pose 144, 0x41f9, 0x0100, 0x5c0a
+ax_pose 145, 0x01f9, 0x00f8, 0x5c0c
+ax_pose 146, 0x01f1, 0x00e8, 0x5c0d
+ax_pose 147, 0x0201, 0x00ff, 0x5c0e
+ax_pose 148, 0x01e8, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose205:
+ax_pose 81, 0x01ee, 0x4100, 0x5c00
+ax_pose 82, 0x01de, 0x0104, 0x5c04
+ax_pose 83, 0x41e6, 0x00fb, 0x5c05
+ax_pose 84, 0x01e5, 0x00ec, 0x5c07
+ax_pose 85, 0x41ed, 0x00e8, 0x5c08
+ax_pose 89, 0x01fe, 0x0108, 0x5c0a
+ax_pose 88, 0x01fe, 0x00f8, 0x5c0b
+ax_pose 86, 0x01f5, 0x00f0, 0x5c0c
+ax_pose 87, 0x01ee, 0x0110, 0x5c0d
+ax_pose 90, 0x81ee, 0x00f8, 0x5c0e
+ax_pose_terminator
+sLatiasPose206:
+ax_pose 20, 0x41ef, 0x80f1, 0x5c00
+ax_pose 24, 0x41df, 0x0101, 0x5c08
+ax_pose 23, 0x01ef, 0x00e1, 0x5c0a
+ax_pose 21, 0x01e7, 0x00e9, 0x5c0b
+ax_pose 22, 0x01ef, 0x00e9, 0x5c0c
+ax_pose 26, 0x01e7, 0x00f1, 0x5c0d
+ax_pose 25, 0x41e7, 0x00fb, 0x5c0e
+ax_pose_terminator
+sLatiasPose207:
+ax_pose 27, 0x41ef, 0x80f1, 0x5c00
+ax_pose 31, 0x41df, 0x0101, 0x5c08
+ax_pose 32, 0x41e7, 0x00fb, 0x5c0a
+ax_pose 30, 0x01ef, 0x00e1, 0x5c0c
+ax_pose 28, 0x01ef, 0x00e9, 0x5c0d
+ax_pose 29, 0x01e7, 0x00e9, 0x5c0e
+ax_pose 33, 0x01e7, 0x00f1, 0x5c0f
+ax_pose_terminator
+sLatiasPose208:
+ax_pose 125, 0x81e0, 0x4106, 0x5c00
+ax_pose 126, 0x01f0, 0x40f6, 0x5c04
+ax_pose 127, 0x01e0, 0x40ee, 0x5c08
+ax_pose 128, 0x01e8, 0x00fe, 0x5c0c
+ax_pose 129, 0x01e4, 0x010e, 0x5c0d
+ax_pose 130, 0x01f0, 0x010e, 0x5c0e
+ax_pose 131, 0x0200, 0x0101, 0x5c0f
+ax_pose_terminator
+sLatiasPose209:
+ax_pose 132, 0x81e6, 0x80fe, 0x5c00
+ax_pose 133, 0x81e6, 0x40f6, 0x5c08
+ax_pose 134, 0x81e6, 0x00ee, 0x5c0c
+ax_pose 135, 0x01ee, 0x00e6, 0x5c0e
+ax_pose 136, 0x01de, 0x0106, 0x5c0f
+ax_pose_terminator
+sLatiasPose210:
+ax_pose 74, 0x41f0, 0x80ed, 0x5c00
+ax_pose 76, 0x01e9, 0x010d, 0x5c08
+ax_pose 75, 0x0200, 0x0103, 0x5c09
+ax_pose 77, 0x01f1, 0x010d, 0x5c0a
+ax_pose 78, 0x01e0, 0x00f4, 0x5c0b
+ax_pose 79, 0x01e8, 0x0105, 0x5c0c
+ax_pose 80, 0x41e8, 0x00f5, 0x5c0d
+ax_pose_terminator
+sLatiasPose211:
+ax_pose 62, 0x81f1, 0x00eb, 0x5c00
+ax_pose 13, 0x81e9, 0x010b, 0x5c02
+ax_pose 63, 0x01f9, 0x0103, 0x5c04
+ax_pose 64, 0x81e9, 0x0103, 0x5c05
+ax_pose 65, 0x81e1, 0x80f3, 0x5c07
+ax_pose_terminator
+sLatiasPose212:
+ax_pose 66, 0x81e1, 0x80f3, 0x5c00
+ax_pose 16, 0x81e9, 0x010b, 0x5c08
+ax_pose 67, 0x81f1, 0x00eb, 0x5c0a
+ax_pose 18, 0x01e9, 0x0103, 0x5c0c
+ax_pose 68, 0x81f1, 0x0103, 0x5c0d
+ax_pose_terminator
+sLatiasPose213:
+ax_pose 115, 0x81e6, 0x80f5, 0x5c00
+ax_pose 116, 0x81e6, 0x4105, 0x5c08
+ax_pose 117, 0x01de, 0x00f5, 0x5c0c
+ax_pose 118, 0x01de, 0x00fd, 0x5c0d
+ax_pose 119, 0x01e5, 0x00ed, 0x5c0e
+ax_pose 120, 0x01e6, 0x010d, 0x5c0f
+ax_pose_terminator
+sLatiasPose214:
+ax_pose 121, 0x81e1, 0x80ee, 0x5c00
+ax_pose 122, 0x01f1, 0x40fe, 0x5c08
+ax_pose 123, 0x41e9, 0x00fe, 0x5c0c
+ax_pose 124, 0x01e9, 0x010e, 0x5c0e
+ax_pose_terminator
+sLatiasPose215:
+ax_pose 109, 0x41ee, 0x80f0, 0x5c00
+ax_pose 110, 0x41e6, 0x40f0, 0x5c08
+ax_pose 111, 0x01de, 0x00f0, 0x5c0c
+ax_pose 112, 0x01de, 0x0108, 0x5c0d
+ax_pose 113, 0x01e4, 0x00e8, 0x5c0e
+ax_pose 114, 0x01e4, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiasPose216:
+ax_pose 121, 0x81e1, 0x9102, 0x5c00
+ax_pose 122, 0x01f1, 0x50f2, 0x5c08
+ax_pose 123, 0x41e9, 0x10f2, 0x5c0c
+ax_pose 124, 0x01e9, 0x10ea, 0x5c0e
+ax_pose_terminator
+sLatiasPose217:
+ax_pose 132, 0x81e6, 0x90f2, 0x5c00
+ax_pose 133, 0x81e6, 0x5102, 0x5c08
+ax_pose 134, 0x81e6, 0x110a, 0x5c0c
+ax_pose 135, 0x01ee, 0x1112, 0x5c0e
+ax_pose 136, 0x01de, 0x10f2, 0x5c0f
+ax_pose_terminator
+sLatiasPose218:
+ax_pose 142, 0x41ec, 0x90ef, 0x5c00
+ax_pose 143, 0x41e4, 0x10ff, 0x5c08
+ax_pose 144, 0x41fc, 0x10ef, 0x5c0a
+ax_pose 145, 0x01fc, 0x10ff, 0x5c0c
+ax_pose 146, 0x01f4, 0x110f, 0x5c0d
+ax_pose 147, 0x0204, 0x10f8, 0x5c0e
+ax_pose 148, 0x01eb, 0x10e7, 0x5c0f
+ax_pose_terminator
+sLatiasPose219:
+ax_pose 154, 0x81e5, 0x80f8, 0x5c00
+ax_pose 155, 0x81f5, 0x00f0, 0x5c08
+ax_pose -1, 0x81f5, 0x1108, 0x5c08
+ax_pose 156, 0x01ed, 0x00f0, 0x5c0a
+ax_pose -1, 0x01ed, 0x1108, 0x5c0a
+ax_pose 157, 0x01f3, 0x00e8, 0x5c0b
+ax_pose -1, 0x01f3, 0x1110, 0x5c0b
+ax_pose 158, 0x41dd, 0x00f8, 0x5c0c
+ax_pose_terminator
+sLatiasPose220:
+ax_pose 142, 0x41ec, 0x80f1, 0x5c00
+ax_pose 143, 0x41e4, 0x00f1, 0x5c08
+ax_pose 144, 0x41fc, 0x0101, 0x5c0a
+ax_pose 145, 0x01fc, 0x00f9, 0x5c0c
+ax_pose 146, 0x01f4, 0x00e9, 0x5c0d
+ax_pose 147, 0x0204, 0x0100, 0x5c0e
+ax_pose 148, 0x01eb, 0x0111, 0x5c0f
+ax_pose_terminator
+sLatiasPose221:
+ax_pose 132, 0x81e6, 0x80fe, 0x5c00
+ax_pose 133, 0x81e6, 0x40f6, 0x5c08
+ax_pose 134, 0x81e6, 0x00ee, 0x5c0c
+ax_pose 135, 0x01ee, 0x00e6, 0x5c0e
+ax_pose 136, 0x01de, 0x0106, 0x5c0f
+ax_pose_terminator
+sLatiasPose222:
+ax_pose 121, 0x81e1, 0x80ee, 0x5c00
+ax_pose 122, 0x01f1, 0x40fe, 0x5c08
+ax_pose 123, 0x41e9, 0x00fe, 0x5c0c
+ax_pose 124, 0x01e9, 0x010e, 0x5c0e
+ax_pose_terminator
+sLatiasPose223:
+ax_pose 69, 0x81e9, 0x80fb, 0x6c00
+ax_pose 70, 0x01e9, 0x0113, 0x6c08
+ax_pose 71, 0x01e9, 0x010b, 0x6c09
+ax_pose 72, 0x01e9, 0x00eb, 0x6c0a
+ax_pose 73, 0x81e9, 0x40f3, 0x6c0b
+ax_pose_terminator
+sLatiasPose224:
+ax_pose 74, 0x41f0, 0x80ed, 0x6c00
+ax_pose 76, 0x01e9, 0x010d, 0x6c08
+ax_pose 75, 0x0200, 0x0103, 0x6c09
+ax_pose 77, 0x01f1, 0x010d, 0x6c0a
+ax_pose 78, 0x01e0, 0x00f4, 0x6c0b
+ax_pose 79, 0x01e8, 0x0105, 0x6c0c
+ax_pose 80, 0x41e8, 0x00f5, 0x6c0d
+ax_pose_terminator
+sLatiasPose225:
+ax_pose 81, 0x01ee, 0x4100, 0x6c00
+ax_pose 82, 0x01de, 0x0104, 0x6c04
+ax_pose 83, 0x41e6, 0x00fb, 0x6c05
+ax_pose 84, 0x01e5, 0x00ec, 0x6c07
+ax_pose 85, 0x41ed, 0x00e8, 0x6c08
+ax_pose 89, 0x01fe, 0x0108, 0x6c0a
+ax_pose 88, 0x01fe, 0x00f8, 0x6c0b
+ax_pose 86, 0x01f5, 0x00f0, 0x6c0c
+ax_pose 87, 0x01ee, 0x0110, 0x6c0d
+ax_pose 90, 0x81ee, 0x00f8, 0x6c0e
+ax_pose_terminator
+sLatiasPose226:
+ax_pose 106, 0x01e2, 0x40eb, 0x6c00
+ax_pose 95, 0x01f6, 0x010b, 0x6c04
+ax_pose 94, 0x0200, 0x00ff, 0x6c05
+ax_pose 92, 0x01ea, 0x010b, 0x6c06
+ax_pose 93, 0x01e2, 0x010b, 0x6c07
+ax_pose 96, 0x41e8, 0x00fb, 0x6c08
+ax_pose 97, 0x01f0, 0x40fb, 0x6c0a
+ax_pose 107, 0x81f2, 0x00f3, 0x6c0e
+ax_pose_terminator
+sLatiasPose227:
+ax_pose 99, 0x01f3, 0x40fb, 0x6c00
+ax_pose 100, 0x41db, 0x00fb, 0x6c04
+ax_pose 101, 0x41e3, 0x00f6, 0x6c06
+ax_pose 102, 0x01eb, 0x0113, 0x6c08
+ax_pose 103, 0x01eb, 0x010b, 0x6c09
+ax_pose 104, 0x41eb, 0x40eb, 0x6c0a
+ax_pose 105, 0x81f3, 0x00f3, 0x6c0e
+ax_pose_terminator
+sLatiasPose228:
+ax_pose 91, 0x81e2, 0x110d, 0x6c00
+ax_pose 92, 0x01ea, 0x10ed, 0x6c02
+ax_pose 93, 0x01e2, 0x10ed, 0x6c03
+ax_pose 94, 0x0200, 0x10f9, 0x6c04
+ax_pose 95, 0x01f6, 0x10ed, 0x6c05
+ax_pose 96, 0x41e8, 0x10f5, 0x6c06
+ax_pose 97, 0x01f0, 0x50f5, 0x6c08
+ax_pose 98, 0x81e2, 0x5105, 0x6c0c
+ax_pose_terminator
+sLatiasPose229:
+ax_pose 81, 0x01ee, 0x50f0, 0x6c00
+ax_pose 82, 0x01de, 0x10f4, 0x6c04
+ax_pose 83, 0x41e6, 0x10f5, 0x6c05
+ax_pose 84, 0x01e5, 0x110c, 0x6c07
+ax_pose 85, 0x41ed, 0x1108, 0x6c08
+ax_pose 86, 0x01f5, 0x1108, 0x6c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x6c0b
+ax_pose 88, 0x01fe, 0x1100, 0x6c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x6c0d
+ax_pose 90, 0x81ee, 0x1100, 0x6c0e
+ax_pose_terminator
+sLatiasPose230:
+ax_pose 74, 0x41f0, 0x90f3, 0x6c00
+ax_pose 75, 0x0200, 0x10f5, 0x6c08
+ax_pose 76, 0x01e9, 0x10eb, 0x6c09
+ax_pose 77, 0x01f1, 0x10eb, 0x6c0a
+ax_pose 78, 0x01e0, 0x1104, 0x6c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x6c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x6c0d
+ax_pose_terminator
+sLatiasPose231:
+ax_pose 74, 0x41f0, 0x90f3, 0x6c00
+ax_pose 75, 0x0200, 0x10f5, 0x6c08
+ax_pose 76, 0x01e9, 0x10eb, 0x6c09
+ax_pose 77, 0x01f1, 0x10eb, 0x6c0a
+ax_pose 78, 0x01e0, 0x1104, 0x6c0b
+ax_pose 79, 0x01e8, 0x10f3, 0x6c0c
+ax_pose 80, 0x41e8, 0x10fb, 0x6c0d
+ax_pose_terminator
+sLatiasPose232:
+ax_pose 81, 0x01ee, 0x50f0, 0x6c00
+ax_pose 82, 0x01de, 0x10f4, 0x6c04
+ax_pose 83, 0x41e6, 0x10f5, 0x6c05
+ax_pose 84, 0x01e5, 0x110c, 0x6c07
+ax_pose 85, 0x41ed, 0x1108, 0x6c08
+ax_pose 86, 0x01f5, 0x1108, 0x6c0a
+ax_pose 87, 0x01ee, 0x10e8, 0x6c0b
+ax_pose 88, 0x01fe, 0x1100, 0x6c0c
+ax_pose 89, 0x01fe, 0x10f0, 0x6c0d
+ax_pose 90, 0x81ee, 0x1100, 0x6c0e
+ax_pose_terminator
+sLatiasPose233:
+ax_pose 125, 0x81e0, 0x50f2, 0x5c00
+ax_pose 126, 0x01f0, 0x50fa, 0x5c04
+ax_pose 127, 0x01e0, 0x5102, 0x5c08
+ax_pose 128, 0x01e8, 0x10fa, 0x5c0c
+ax_pose 129, 0x01e4, 0x10ea, 0x5c0d
+ax_pose 130, 0x01f0, 0x10ea, 0x5c0e
+ax_pose 131, 0x0200, 0x10f7, 0x5c0f
+ax_pose_terminator
+sLatiasPose234:
+ax_pose 220, 0x01e1, 0x00ea, 0x5c00
+ax_pose 221, 0x01ec, 0x00e9, 0x5c01
+ax_pose 222, 0x01e0, 0x4101, 0x5c02
+ax_pose 223, 0x81e3, 0x40f1, 0x5c06
+ax_pose 224, 0x81e8, 0x40f9, 0x5c0a
+ax_pose 225, 0x41f0, 0x0101, 0x5c0e
+ax_pose_terminator
+sLatiasPose235:
+ax_pose 226, 0x41f4, 0x40ea, 0x5c00
+ax_pose 227, 0x41ec, 0x40ea, 0x5c04
+ax_pose 228, 0x41fc, 0x00f1, 0x5c08
+ax_pose 229, 0x41e4, 0x00ea, 0x5c0a
+ax_pose 230, 0x41e4, 0x0101, 0x5c0c
+ax_pose 231, 0x01ec, 0x010a, 0x5c0e
+ax_pose 232, 0x01dc, 0x0101, 0x5c0f
+ax_pose_terminator
+.align 2
+sLatiasAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 2, 0, 16, 0, -2, 0, -2,
+ax_anim 6, 0, 17, 0, -4, 0, -4,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 0, 4, 0, 4,
+ax_anim 1, 0, 18, 0, 10, 0, 10,
+ax_anim 2, 0, 17, 0, 17, 0, 17,
+ax_anim 2, 1, 17, 1, 17, 1, 17,
+ax_anim 2, 0, 17, 0, 17, 0, 17,
+ax_anim 2, 0, 17, 1, 17, 1, 17,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sLatiasAnims_2_2:
+ax_anim 2, 0, 19, -1, -1, -1, -1,
+ax_anim 2, 0, 19, -2, -2, -2, -2,
+ax_anim 6, 0, 20, -4, -4, -4, -4,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 4, 6, 4, 6,
+ax_anim 1, 0, 21, 9, 14, 9, 13,
+ax_anim 2, 0, 20, 13, 22, 13, 20,
+ax_anim 2, 1, 20, 14, 21, 14, 19,
+ax_anim 2, 0, 20, 13, 22, 13, 20,
+ax_anim 2, 0, 20, 14, 21, 14, 19,
+ax_anim 2, 0, 19, 5, 8, 5, 8,
+ax_anim_terminator
+sLatiasAnims_2_3:
+ax_anim 2, 0, 22, -1, 0, -1, 0,
+ax_anim 2, 0, 22, -2, 0, -2, 0,
+ax_anim 6, 0, 23, -4, 0, -4, 0,
+ax_anim 1, 0, 24, -2, 0, -2, 0,
+ax_anim 1, 2, 23, 1, 1, 1, 0,
+ax_anim 1, 0, 24, 5, 2, 5, 0,
+ax_anim 2, 0, 23, 12, 3, 12, 0,
+ax_anim 2, 1, 23, 12, 4, 12, 1,
+ax_anim 2, 0, 23, 12, 3, 12, 0,
+ax_anim 2, 0, 23, 12, 4, 12, 1,
+ax_anim 2, 0, 22, 6, 1, 6, 0,
+ax_anim_terminator
+sLatiasAnims_2_4:
+ax_anim 2, 0, 25, -1, 1, -1, 1,
+ax_anim 2, 0, 25, -2, 2, -2, 2,
+ax_anim 6, 0, 26, -4, 4, -4, 4,
+ax_anim 1, 0, 27, -1, 1, -1, 1,
+ax_anim 1, 2, 26, 4, -3, 7, -6,
+ax_anim 1, 0, 27, 9, -7, 13, -11,
+ax_anim 2, 0, 26, 14, -11, 19, -16,
+ax_anim 2, 1, 26, 15, -10, 20, -15,
+ax_anim 2, 0, 26, 14, -11, 19, -16,
+ax_anim 2, 0, 26, 15, -10, 20, -15,
+ax_anim 2, 0, 25, 6, -5, 8, -7,
+ax_anim_terminator
+sLatiasAnims_2_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 2, 0, 28, 0, 2, 0, 2,
+ax_anim 6, 0, 29, 0, 4, 0, 4,
+ax_anim 1, 0, 30, 0, 2, 0, 1,
+ax_anim 1, 2, 29, 0, 0, 0, -5,
+ax_anim 1, 0, 30, 0, -4, 0, -12,
+ax_anim 2, 0, 29, 0, -9, 0, -19,
+ax_anim 2, 1, 29, 1, -9, 1, -19,
+ax_anim 2, 0, 29, 0, -9, 0, -19,
+ax_anim 2, 0, 29, 1, -9, 1, -19,
+ax_anim 2, 0, 28, 0, -6, 0, -9,
+ax_anim_terminator
+sLatiasAnims_2_6:
+ax_anim 2, 0, 31, 1, 1, 1, 1,
+ax_anim 2, 0, 31, 2, 2, 2, 2,
+ax_anim 6, 0, 32, 4, 4, 4, 4,
+ax_anim 1, 0, 33, 1, 1, 1, 1,
+ax_anim 1, 2, 32, -4, -3, -7, -6,
+ax_anim 1, 0, 33, -9, -7, -13, -11,
+ax_anim 2, 0, 32, -14, -11, -19, -16,
+ax_anim 2, 1, 32, -15, -10, -20, -15,
+ax_anim 2, 0, 32, -14, -11, -19, -16,
+ax_anim 2, 0, 32, -15, -10, -20, -15,
+ax_anim 2, 0, 31, -6, -5, -8, -7,
+ax_anim_terminator
+sLatiasAnims_2_7:
+ax_anim 2, 0, 34, 1, 0, 1, 0,
+ax_anim 2, 0, 34, 2, 0, 2, 0,
+ax_anim 6, 0, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 2, 0, 2, 0,
+ax_anim 1, 2, 35, -1, 1, -1, 0,
+ax_anim 1, 0, 36, -5, 2, -5, 0,
+ax_anim 2, 0, 35, -12, 3, -12, 0,
+ax_anim 2, 1, 35, -12, 4, -12, 1,
+ax_anim 2, 0, 35, -12, 3, -12, 0,
+ax_anim 2, 0, 35, -12, 4, -12, 1,
+ax_anim 2, 0, 34, -6, 1, -6, 0,
+ax_anim_terminator
+sLatiasAnims_2_8:
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 2, 0, 37, 2, -2, 2, -2,
+ax_anim 6, 0, 38, 4, -4, 4, -4,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 38, -4, 6, -4, 6,
+ax_anim 1, 0, 39, -9, 14, -9, 13,
+ax_anim 2, 0, 38, -13, 22, -13, 20,
+ax_anim 2, 1, 38, -14, 21, -14, 19,
+ax_anim 2, 0, 38, -13, 22, -13, 20,
+ax_anim 2, 0, 38, -14, 21, -14, 19,
+ax_anim 2, 0, 37, -5, 8, -5, 8,
+ax_anim_terminator
+.align 2
+sLatiasAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 2, 0, 40, 0, -2, 0, -2,
+ax_anim 6, 0, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 42, 0, 10, 0, 10,
+ax_anim 2, 0, 41, 0, 17, 0, 17,
+ax_anim 2, 1, 41, 1, 17, 1, 17,
+ax_anim 2, 0, 41, 0, 17, 0, 17,
+ax_anim 2, 0, 41, 1, 17, 1, 17,
+ax_anim 2, 0, 40, 0, 6, 0, 6,
+ax_anim_terminator
+sLatiasAnims_3_2:
+ax_anim 2, 0, 43, -1, -1, -1, -1,
+ax_anim 2, 0, 43, -2, -2, -2, -2,
+ax_anim 6, 0, 44, -4, -4, -4, -4,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 4, 6, 4, 6,
+ax_anim 1, 0, 45, 9, 14, 9, 13,
+ax_anim 2, 0, 44, 13, 22, 13, 20,
+ax_anim 2, 1, 44, 14, 21, 14, 19,
+ax_anim 2, 0, 44, 13, 22, 13, 20,
+ax_anim 2, 0, 44, 14, 21, 14, 19,
+ax_anim 2, 0, 43, 5, 8, 5, 8,
+ax_anim_terminator
+sLatiasAnims_3_3:
+ax_anim 2, 0, 46, -1, 0, -1, 0,
+ax_anim 2, 0, 46, -2, 0, -2, 0,
+ax_anim 6, 0, 47, -4, 0, -4, 0,
+ax_anim 1, 0, 48, -2, 0, -2, 0,
+ax_anim 1, 2, 47, 1, 1, 1, 0,
+ax_anim 1, 0, 48, 5, 2, 5, 0,
+ax_anim 2, 0, 47, 12, 3, 12, 0,
+ax_anim 2, 1, 47, 12, 4, 12, 1,
+ax_anim 2, 0, 47, 12, 3, 12, 0,
+ax_anim 2, 0, 47, 12, 4, 12, 1,
+ax_anim 2, 0, 46, 6, 1, 6, 0,
+ax_anim_terminator
+sLatiasAnims_3_4:
+ax_anim 2, 0, 49, -1, 1, -1, 1,
+ax_anim 2, 0, 49, -2, 2, -2, 2,
+ax_anim 6, 0, 50, -4, 4, -4, 4,
+ax_anim 1, 0, 51, -1, 1, -1, 1,
+ax_anim 1, 2, 50, 4, -3, 7, -6,
+ax_anim 1, 0, 51, 9, -7, 13, -11,
+ax_anim 2, 0, 50, 14, -11, 19, -16,
+ax_anim 2, 1, 50, 15, -10, 20, -15,
+ax_anim 2, 0, 50, 14, -11, 19, -16,
+ax_anim 2, 0, 50, 15, -10, 20, -15,
+ax_anim 2, 0, 49, 6, -5, 8, -7,
+ax_anim_terminator
+sLatiasAnims_3_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 2, 0, 52, 0, 2, 0, 2,
+ax_anim 6, 0, 53, 0, 4, 0, 4,
+ax_anim 1, 0, 54, 0, 2, 0, 1,
+ax_anim 1, 2, 53, 0, 0, 0, -5,
+ax_anim 1, 0, 54, 0, -4, 0, -12,
+ax_anim 2, 0, 53, 0, -9, 0, -19,
+ax_anim 2, 1, 53, 1, -9, 1, -19,
+ax_anim 2, 0, 53, 0, -9, 0, -19,
+ax_anim 2, 0, 53, 1, -9, 1, -19,
+ax_anim 2, 0, 52, 0, -6, 0, -9,
+ax_anim_terminator
+sLatiasAnims_3_6:
+ax_anim 2, 0, 55, 1, 1, 1, 1,
+ax_anim 2, 0, 55, 2, 2, 2, 2,
+ax_anim 6, 0, 56, 4, 4, 4, 4,
+ax_anim 1, 0, 57, 1, 1, 1, 1,
+ax_anim 1, 2, 56, -4, -3, -7, -6,
+ax_anim 1, 0, 57, -9, -7, -13, -11,
+ax_anim 2, 0, 56, -14, -11, -19, -16,
+ax_anim 2, 1, 56, -15, -10, -20, -15,
+ax_anim 2, 0, 56, -14, -11, -19, -16,
+ax_anim 2, 0, 56, -15, -10, -20, -15,
+ax_anim 2, 0, 55, -6, -5, -8, -7,
+ax_anim_terminator
+sLatiasAnims_3_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 2, 0, 58, 2, 0, 2, 0,
+ax_anim 6, 0, 59, 4, 0, 4, 0,
+ax_anim 1, 0, 60, 2, 0, 2, 0,
+ax_anim 1, 2, 59, -1, 1, -1, 0,
+ax_anim 1, 0, 60, -5, 2, -5, 0,
+ax_anim 2, 0, 59, -12, 3, -12, 0,
+ax_anim 2, 1, 59, -12, 4, -12, 1,
+ax_anim 2, 0, 59, -12, 3, -12, 0,
+ax_anim 2, 0, 59, -12, 4, -12, 1,
+ax_anim 2, 0, 58, -6, 1, -6, 0,
+ax_anim_terminator
+sLatiasAnims_3_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 2, 0, 61, 2, -2, 2, -2,
+ax_anim 6, 0, 62, 4, -4, 4, -4,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 62, -4, 6, -4, 6,
+ax_anim 1, 0, 63, -9, 14, -9, 13,
+ax_anim 2, 0, 62, -13, 22, -13, 20,
+ax_anim 2, 1, 62, -14, 21, -14, 19,
+ax_anim 2, 0, 62, -13, 22, -13, 20,
+ax_anim 2, 0, 62, -14, 21, -14, 19,
+ax_anim 2, 0, 61, -5, 8, -5, 8,
+ax_anim_terminator
+.align 2
+sLatiasAnims_4_1:
+ax_anim 2, 0, 65, 0, -2, 0, -2,
+ax_anim 6, 2, 65, 0, -3, 0, -3,
+ax_anim 1, 0, 65, 0, 2, 0, 2,
+ax_anim 1, 0, 65, 0, 8, 0, 8,
+ax_anim 2, 1, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 1, 10, 1, 10,
+ax_anim 2, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 1, 10, 1, 10,
+ax_anim 2, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 1, 10, 1, 10,
+ax_anim 2, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 2, 0, 2,
+ax_anim_terminator
+sLatiasAnims_4_2:
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim 6, 2, 68, -3, -3, -3, -3,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 4, 4, 4, 4,
+ax_anim 2, 1, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 69, 9, 7, 9, 7,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 69, 9, 7, 9, 7,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 69, 9, 7, 9, 7,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 67, 2, 2, 2, 2,
+ax_anim_terminator
+sLatiasAnims_4_3:
+ax_anim 2, 0, 71, -2, 0, -2, 0,
+ax_anim 6, 2, 71, -3, 0, -3, 0,
+ax_anim 1, 0, 71, 0, -2, 0, 0,
+ax_anim 1, 0, 71, 4, -1, 2, 0,
+ax_anim 2, 1, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 72, 8, 1, 6, 1,
+ax_anim 2, 0, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 72, 8, 1, 6, 1,
+ax_anim 2, 0, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 72, 8, 1, 6, 1,
+ax_anim 2, 0, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 70, 2, 0, 2, 0,
+ax_anim_terminator
+sLatiasAnims_4_4:
+ax_anim 2, 0, 74, -2, 2, -2, 2,
+ax_anim 6, 2, 74, -3, 3, -3, 3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 2, -2, 2, -2,
+ax_anim 2, 1, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, 7, -5, 7, -5,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, 7, -5, 7, -5,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, 7, -5, 7, -5,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 73, 3, -3, 3, -3,
+ax_anim_terminator
+sLatiasAnims_4_5:
+ax_anim 2, 0, 77, 0, 2, 0, 2,
+ax_anim 6, 2, 77, 0, 3, 0, 3,
+ax_anim 1, 0, 77, 0, -2, 0, -2,
+ax_anim 1, 0, 77, 0, -4, 0, -4,
+ax_anim 2, 1, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 78, 1, -6, 1, -6,
+ax_anim 2, 0, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 78, 1, -6, 1, -6,
+ax_anim 2, 0, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 78, 1, -6, 1, -6,
+ax_anim 2, 0, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 76, 0, -2, 0, -2,
+ax_anim_terminator
+sLatiasAnims_4_6:
+ax_anim 2, 0, 80, 2, 2, 2, 2,
+ax_anim 6, 2, 80, 3, 3, 3, 3,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, -2, -2, -2, -2,
+ax_anim 2, 1, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, -7, -5, -7, -5,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, -7, -5, -7, -5,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, -7, -5, -7, -5,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 79, -3, -3, -3, -3,
+ax_anim_terminator
+sLatiasAnims_4_7:
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 6, 2, 83, 3, 0, 3, 0,
+ax_anim 1, 0, 83, 0, -2, 0, 0,
+ax_anim 1, 0, 83, -4, -1, -2, 0,
+ax_anim 2, 1, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 84, -8, 1, -6, 1,
+ax_anim 2, 0, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 84, -8, 1, -6, 1,
+ax_anim 2, 0, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 84, -8, 1, -6, 1,
+ax_anim 2, 0, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 82, -2, 0, -2, 0,
+ax_anim_terminator
+sLatiasAnims_4_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 6, 2, 86, 3, -3, 3, -3,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 86, -4, 4, -4, 4,
+ax_anim 2, 1, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -9, 7, -9, 7,
+ax_anim 2, 0, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -9, 7, -9, 7,
+ax_anim 2, 0, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -9, 7, -9, 7,
+ax_anim 2, 0, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sLatiasAnims_5_1:
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -6, 0, 0,
+ax_anim 6, 2, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 90, -1, -7, -1, 0,
+ax_anim 2, 0, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 90, -1, -7, -1, 0,
+ax_anim 2, 0, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 90, -1, -7, -1, 0,
+ax_anim 2, 0, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim_terminator
+sLatiasAnims_5_2:
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -6, 0, 0,
+ax_anim 6, 2, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 93, -1, -6, -1, 1,
+ax_anim 2, 0, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 93, -1, -6, -1, 1,
+ax_anim 2, 0, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 93, -1, -6, -1, 1,
+ax_anim 2, 0, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiasAnims_5_3:
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -6, 0, 0,
+ax_anim 6, 2, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, -1,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, -1,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, -1,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiasAnims_5_4:
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -6, 0, 0,
+ax_anim 6, 2, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 99, -1, -8, -1, -1,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 99, -1, -8, -1, -1,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 99, -1, -8, -1, -1,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiasAnims_5_5:
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -6, 0, 0,
+ax_anim 6, 2, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 102, -1, -7, -1, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 102, -1, -7, -1, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 102, -1, -7, -1, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim_terminator
+sLatiasAnims_5_6:
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 6, 2, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 1, -8, 1, -1,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 1, -8, 1, -1,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 1, -8, 1, -1,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiasAnims_5_7:
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -6, 0, 0,
+ax_anim 6, 2, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, -1,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, -1,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, -1,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiasAnims_5_8:
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 6, 2, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 111, 1, -6, 1, 1,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 111, 1, -6, 1, 1,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 111, 1, -6, 1, 1,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sLatiasAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sLatiasAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sLatiasAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sLatiasAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sLatiasAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sLatiasAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sLatiasAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLatiasAnims_8_1:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, -2, 0, 0,
+ax_anim 8, 0, 122, 0, -2, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_8_2:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, -1, 0, 0,
+ax_anim 8, 0, 123, 0, -2, 0, 0,
+ax_anim 8, 0, 123, 0, -2, 0, 0,
+ax_anim 8, 0, 123, 0, -1, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_8_3:
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_8_4:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 125, 0, -1, 0, 0,
+ax_anim 8, 0, 125, 0, -2, 0, 0,
+ax_anim 8, 0, 125, 0, -2, 0, 0,
+ax_anim 8, 0, 125, 0, -1, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_8_5:
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim 8, 0, 126, 0, -2, 0, 0,
+ax_anim 8, 0, 126, 0, -2, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_8_6:
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim 8, 0, 127, 0, -2, 0, 0,
+ax_anim 8, 0, 127, 0, -2, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_8_7:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, -2, 0, 0,
+ax_anim 8, 0, 128, 0, -2, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_8_8:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, -1, 0, 0,
+ax_anim 8, 0, 129, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -1, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 9, 4, 9, 4,
+ax_anim 2, 0, 132, 14, 12, 14, 12,
+ax_anim 2, 0, 133, 12, 19, 12, 19,
+ax_anim 3, 0, 134, 0, 23, 0, 23,
+ax_anim 2, 3, 135, -12, 19, -12, 19,
+ax_anim 2, 0, 136, -14, 12, -14, 12,
+ax_anim 1, 0, 137, -9, 4, -9, 4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 12, -2, 12, -2,
+ax_anim 2, 0, 131, 23, 3, 23, 3,
+ax_anim 2, 0, 132, 27, 14, 27, 14,
+ax_anim 3, 0, 133, 22, 21, 22, 21,
+ax_anim 2, 3, 134, 8, 22, 8, 22,
+ax_anim 2, 0, 135, -5, 19, -5, 19,
+ax_anim 1, 0, 136, -6, 9, -6, 9,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 4, -8, 4, -8,
+ax_anim 2, 0, 130, 15, -11, 15, -11,
+ax_anim 2, 0, 131, 25, -7, 25, -7,
+ax_anim 3, 0, 132, 28, 2, 28, 2,
+ax_anim 2, 3, 133, 23, 8, 23, 8,
+ax_anim 2, 0, 134, 13, 11, 13, 11,
+ax_anim 1, 0, 135, 3, 7, 3, 7,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 2, -16, 2, -16,
+ax_anim 2, 0, 130, 15, -21, 15, -21,
+ax_anim 3, 0, 131, 28, -19, 28, -19,
+ax_anim 2, 3, 132, 31, -9, 31, -9,
+ax_anim 2, 0, 133, 26, -1, 26, -1,
+ax_anim 1, 0, 134, 11, 1, 11, 1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -10, -4, -7, -4,
+ax_anim 2, 0, 136, -11, -13, -8, -10,
+ax_anim 2, 0, 137, -7, -20, -5, -16,
+ax_anim 3, 0, 130, 0, -24, 0, -18,
+ax_anim 2, 3, 131, 7, -20, 5, -16,
+ax_anim 2, 0, 132, 11, -13, 8, -10,
+ax_anim 1, 0, 133, 10, -4, 7, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -8, 1, -8,
+ax_anim 2, 0, 131, -2, -16, -2, -16,
+ax_anim 2, 0, 130, -15, -21, -15, -21,
+ax_anim 3, 0, 137, -28, -19, -28, -19,
+ax_anim 2, 3, 136, -31, -9, -31, -9,
+ax_anim 2, 0, 135, -26, -1, -26, -1,
+ax_anim 1, 0, 134, -11, 1, -11, 1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -4, -8, -4, -8,
+ax_anim 2, 0, 130, -15, -11, -15, -11,
+ax_anim 2, 0, 137, -25, -7, -25, -7,
+ax_anim 3, 0, 136, -28, 2, -28, 2,
+ax_anim 2, 3, 135, -23, 8, -23, 8,
+ax_anim 2, 0, 134, -13, 11, -13, 11,
+ax_anim 1, 0, 133, -3, 7, -3, 7,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -12, -2, -12, -2,
+ax_anim 2, 0, 137, -23, 3, -23, 3,
+ax_anim 2, 0, 136, -27, 14, -27, 14,
+ax_anim 3, 0, 135, -22, 21, -22, 21,
+ax_anim 2, 3, 134, -8, 22, -8, 22,
+ax_anim 2, 0, 133, 5, 19, 5, 19,
+ax_anim 1, 0, 132, 6, 9, 6, 9,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_10_1:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_10_2:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_10_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_10_4:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_10_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_10_6:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_10_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_10_8:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_11_1:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -17, 0, 0,
+ax_anim 1, 0, 177, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 2, 0, 0,
+ax_anim_terminator
+sLatiasAnims_11_2:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -17, 0, 0,
+ax_anim 1, 0, 182, 0, -11, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_11_3:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_11_4:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_11_5:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 3, 0, 0,
+ax_anim_terminator
+sLatiasAnims_11_6:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_11_7:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 207, 0, -17, 0, 0,
+ax_anim 1, 0, 207, 0, -11, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_11_8:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -17, 0, 0,
+ax_anim 1, 0, 212, 0, -11, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_12_1:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_12_2:
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_12_4:
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_12_5:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_12_6:
+ax_anim 2, 0, 219, 1, -1, 1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 1, -1, 1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 1, -1, 1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 1, -1, 1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 1, -1, 1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_12_8:
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -1, -1, -1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_13_1:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_13_2:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_13_3:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_13_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_13_5:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_13_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_13_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiasAnims_13_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_14_1:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 232, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_15_1:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 12, 0, 233, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiasAnims_16_1:
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiasGfx1:
+.incbin "baserom.gba", 0x15AC0DC, 0x100
+sLatiasSprites1:
+ax_sprite sLatiasGfx1, 0x100
+ax_sprite_terminator
+sLatiasGfx2:
+.incbin "baserom.gba", 0x15AC1EC, 0x20
+sLatiasSprites2:
+ax_sprite sLatiasGfx2, 0x20
+ax_sprite_terminator
+sLatiasGfx3:
+.incbin "baserom.gba", 0x15AC21C, 0x20
+sLatiasSprites3:
+ax_sprite sLatiasGfx3, 0x20
+ax_sprite_terminator
+sLatiasGfx4:
+.incbin "baserom.gba", 0x15AC24C, 0x20
+sLatiasSprites4:
+ax_sprite sLatiasGfx4, 0x20
+ax_sprite_terminator
+sLatiasGfx5:
+.incbin "baserom.gba", 0x15AC27C, 0x80
+sLatiasSprites5:
+ax_sprite sLatiasGfx5, 0x80
+ax_sprite_terminator
+sLatiasGfx6:
+.incbin "baserom.gba", 0x15AC30C, 0x100
+sLatiasSprites6:
+ax_sprite sLatiasGfx6, 0x100
+ax_sprite_terminator
+sLatiasGfx7:
+.incbin "baserom.gba", 0x15AC41C, 0x20
+sLatiasSprites7:
+ax_sprite sLatiasGfx7, 0x20
+ax_sprite_terminator
+sLatiasGfx8:
+.incbin "baserom.gba", 0x15AC44C, 0x20
+sLatiasSprites8:
+ax_sprite sLatiasGfx8, 0x20
+ax_sprite_terminator
+sLatiasGfx9:
+.incbin "baserom.gba", 0x15AC47C, 0x20
+sLatiasSprites9:
+ax_sprite sLatiasGfx9, 0x20
+ax_sprite_terminator
+sLatiasGfx10:
+.incbin "baserom.gba", 0x15AC4AC, 0x80
+sLatiasSprites10:
+ax_sprite sLatiasGfx10, 0x80
+ax_sprite_terminator
+sLatiasGfx11:
+.incbin "baserom.gba", 0x15AC53C, 0x100
+sLatiasSprites11:
+ax_sprite sLatiasGfx11, 0x100
+ax_sprite_terminator
+sLatiasGfx12:
+.incbin "baserom.gba", 0x15AC64C, 0x20
+sLatiasSprites12:
+ax_sprite sLatiasGfx12, 0x20
+ax_sprite_terminator
+sLatiasGfx13:
+.incbin "baserom.gba", 0x15AC67C, 0x40
+sLatiasSprites13:
+ax_sprite sLatiasGfx13, 0x40
+ax_sprite_terminator
+sLatiasGfx14:
+.incbin "baserom.gba", 0x15AC6CC, 0x40
+sLatiasSprites14:
+ax_sprite sLatiasGfx14, 0x40
+ax_sprite_terminator
+sLatiasGfx15:
+.incbin "baserom.gba", 0x15AC71C, 0x40
+sLatiasSprites15:
+ax_sprite sLatiasGfx15, 0x40
+ax_sprite_terminator
+sLatiasGfx16:
+.incbin "baserom.gba", 0x15AC76C, 0x100
+sLatiasSprites16:
+ax_sprite sLatiasGfx16, 0x100
+ax_sprite_terminator
+sLatiasGfx17:
+.incbin "baserom.gba", 0x15AC87C, 0x40
+sLatiasSprites17:
+ax_sprite sLatiasGfx17, 0x40
+ax_sprite_terminator
+sLatiasGfx18:
+.incbin "baserom.gba", 0x15AC8CC, 0x40
+sLatiasSprites18:
+ax_sprite sLatiasGfx18, 0x40
+ax_sprite_terminator
+sLatiasGfx19:
+.incbin "baserom.gba", 0x15AC91C, 0x20
+sLatiasSprites19:
+ax_sprite sLatiasGfx19, 0x20
+ax_sprite_terminator
+sLatiasGfx20:
+.incbin "baserom.gba", 0x15AC94C, 0x40
+sLatiasSprites20:
+ax_sprite sLatiasGfx20, 0x40
+ax_sprite_terminator
+sLatiasGfx21:
+.incbin "baserom.gba", 0x15AC99C, 0x100
+sLatiasSprites21:
+ax_sprite sLatiasGfx21, 0x100
+ax_sprite_terminator
+sLatiasGfx22:
+.incbin "baserom.gba", 0x15ACAAC, 0x20
+sLatiasSprites22:
+ax_sprite sLatiasGfx22, 0x20
+ax_sprite_terminator
+sLatiasGfx23:
+.incbin "baserom.gba", 0x15ACADC, 0x20
+sLatiasSprites23:
+ax_sprite sLatiasGfx23, 0x20
+ax_sprite_terminator
+sLatiasGfx24:
+.incbin "baserom.gba", 0x15ACB0C, 0x20
+sLatiasSprites24:
+ax_sprite sLatiasGfx24, 0x20
+ax_sprite_terminator
+sLatiasGfx25:
+.incbin "baserom.gba", 0x15ACB3C, 0x40
+sLatiasSprites25:
+ax_sprite sLatiasGfx25, 0x40
+ax_sprite_terminator
+sLatiasGfx26:
+.incbin "baserom.gba", 0x15ACB8C, 0x40
+sLatiasSprites26:
+ax_sprite sLatiasGfx26, 0x40
+ax_sprite_terminator
+sLatiasGfx27:
+.incbin "baserom.gba", 0x15ACBDC, 0x20
+sLatiasSprites27:
+ax_sprite sLatiasGfx27, 0x20
+ax_sprite_terminator
+sLatiasGfx28:
+.incbin "baserom.gba", 0x15ACC0C, 0x100
+sLatiasSprites28:
+ax_sprite sLatiasGfx28, 0x100
+ax_sprite_terminator
+sLatiasGfx29:
+.incbin "baserom.gba", 0x15ACD1C, 0x20
+sLatiasSprites29:
+ax_sprite sLatiasGfx29, 0x20
+ax_sprite_terminator
+sLatiasGfx30:
+.incbin "baserom.gba", 0x15ACD4C, 0x20
+sLatiasSprites30:
+ax_sprite sLatiasGfx30, 0x20
+ax_sprite_terminator
+sLatiasGfx31:
+.incbin "baserom.gba", 0x15ACD7C, 0x20
+sLatiasSprites31:
+ax_sprite sLatiasGfx31, 0x20
+ax_sprite_terminator
+sLatiasGfx32:
+.incbin "baserom.gba", 0x15ACDAC, 0x40
+sLatiasSprites32:
+ax_sprite sLatiasGfx32, 0x40
+ax_sprite_terminator
+sLatiasGfx33:
+.incbin "baserom.gba", 0x15ACDFC, 0x40
+sLatiasSprites33:
+ax_sprite sLatiasGfx33, 0x40
+ax_sprite_terminator
+sLatiasGfx34:
+.incbin "baserom.gba", 0x15ACE4C, 0x20
+sLatiasSprites34:
+ax_sprite sLatiasGfx34, 0x20
+ax_sprite_terminator
+sLatiasGfx35:
+.incbin "baserom.gba", 0x15ACE7C, 0x80
+sLatiasSprites35:
+ax_sprite sLatiasGfx35, 0x80
+ax_sprite_terminator
+sLatiasGfx36:
+.incbin "baserom.gba", 0x15ACF0C, 0x20
+sLatiasSprites36:
+ax_sprite sLatiasGfx36, 0x20
+ax_sprite_terminator
+sLatiasGfx37:
+.incbin "baserom.gba", 0x15ACF3C, 0x20
+sLatiasSprites37:
+ax_sprite sLatiasGfx37, 0x20
+ax_sprite_terminator
+sLatiasGfx38:
+.incbin "baserom.gba", 0x15ACF6C, 0x20
+sLatiasSprites38:
+ax_sprite sLatiasGfx38, 0x20
+ax_sprite_terminator
+sLatiasGfx39:
+.incbin "baserom.gba", 0x15ACF9C, 0x40
+sLatiasSprites39:
+ax_sprite sLatiasGfx39, 0x40
+ax_sprite_terminator
+sLatiasGfx40:
+.incbin "baserom.gba", 0x15ACFEC, 0x20
+sLatiasSprites40:
+ax_sprite sLatiasGfx40, 0x20
+ax_sprite_terminator
+sLatiasGfx41:
+.incbin "baserom.gba", 0x15AD01C, 0x40
+sLatiasSprites41:
+ax_sprite sLatiasGfx41, 0x40
+ax_sprite_terminator
+sLatiasGfx42:
+.incbin "baserom.gba", 0x15AD06C, 0x80
+sLatiasSprites42:
+ax_sprite sLatiasGfx42, 0x80
+ax_sprite_terminator
+sLatiasGfx43:
+.incbin "baserom.gba", 0x15AD0FC, 0x80
+sLatiasSprites43:
+ax_sprite sLatiasGfx43, 0x80
+ax_sprite_terminator
+sLatiasGfx44:
+.incbin "baserom.gba", 0x15AD18C, 0x40
+sLatiasSprites44:
+ax_sprite sLatiasGfx44, 0x40
+ax_sprite_terminator
+sLatiasGfx45:
+.incbin "baserom.gba", 0x15AD1DC, 0x40
+sLatiasSprites45:
+ax_sprite sLatiasGfx45, 0x40
+ax_sprite_terminator
+sLatiasGfx46:
+.incbin "baserom.gba", 0x15AD22C, 0x20
+sLatiasSprites46:
+ax_sprite sLatiasGfx46, 0x20
+ax_sprite_terminator
+sLatiasGfx47:
+.incbin "baserom.gba", 0x15AD25C, 0x80
+sLatiasSprites47:
+ax_sprite sLatiasGfx47, 0x80
+ax_sprite_terminator
+sLatiasGfx48:
+.incbin "baserom.gba", 0x15AD2EC, 0x20
+sLatiasSprites48:
+ax_sprite sLatiasGfx48, 0x20
+ax_sprite_terminator
+sLatiasGfx49:
+.incbin "baserom.gba", 0x15AD31C, 0x20
+sLatiasSprites49:
+ax_sprite sLatiasGfx49, 0x20
+ax_sprite_terminator
+sLatiasGfx50:
+.incbin "baserom.gba", 0x15AD34C, 0x80
+sLatiasSprites50:
+ax_sprite sLatiasGfx50, 0x80
+ax_sprite_terminator
+sLatiasGfx51:
+.incbin "baserom.gba", 0x15AD3DC, 0x20
+sLatiasSprites51:
+ax_sprite sLatiasGfx51, 0x20
+ax_sprite_terminator
+sLatiasGfx52:
+.incbin "baserom.gba", 0x15AD40C, 0x40
+sLatiasSprites52:
+ax_sprite sLatiasGfx52, 0x40
+ax_sprite_terminator
+sLatiasGfx53:
+.incbin "baserom.gba", 0x15AD45C, 0x40
+sLatiasSprites53:
+ax_sprite sLatiasGfx53, 0x40
+ax_sprite_terminator
+sLatiasGfx54:
+.incbin "baserom.gba", 0x15AD4AC, 0x40
+sLatiasSprites54:
+ax_sprite sLatiasGfx54, 0x40
+ax_sprite_terminator
+sLatiasGfx55:
+.incbin "baserom.gba", 0x15AD4FC, 0x80
+sLatiasSprites55:
+ax_sprite sLatiasGfx55, 0x80
+ax_sprite_terminator
+sLatiasGfx56:
+.incbin "baserom.gba", 0x15AD58C, 0x80
+sLatiasSprites56:
+ax_sprite sLatiasGfx56, 0x80
+ax_sprite_terminator
+sLatiasGfx57:
+.incbin "baserom.gba", 0x15AD61C, 0x40
+sLatiasSprites57:
+ax_sprite sLatiasGfx57, 0x40
+ax_sprite_terminator
+sLatiasGfx58:
+.incbin "baserom.gba", 0x15AD66C, 0x20
+sLatiasSprites58:
+ax_sprite sLatiasGfx58, 0x20
+ax_sprite_terminator
+sLatiasGfx59:
+.incbin "baserom.gba", 0x15AD69C, 0x40
+sLatiasSprites59:
+ax_sprite sLatiasGfx59, 0x40
+ax_sprite_terminator
+sLatiasGfx60:
+.incbin "baserom.gba", 0x15AD6EC, 0x80
+sLatiasSprites60:
+ax_sprite sLatiasGfx60, 0x80
+ax_sprite_terminator
+sLatiasGfx61:
+.incbin "baserom.gba", 0x15AD77C, 0x40
+sLatiasSprites61:
+ax_sprite sLatiasGfx61, 0x40
+ax_sprite_terminator
+sLatiasGfx62:
+.incbin "baserom.gba", 0x15AD7CC, 0x100
+sLatiasSprites62:
+ax_sprite sLatiasGfx62, 0x100
+ax_sprite_terminator
+sLatiasGfx63:
+.incbin "baserom.gba", 0x15AD8DC, 0x40
+sLatiasSprites63:
+ax_sprite sLatiasGfx63, 0x40
+ax_sprite_terminator
+sLatiasGfx64:
+.incbin "baserom.gba", 0x15AD92C, 0x20
+sLatiasSprites64:
+ax_sprite sLatiasGfx64, 0x20
+ax_sprite_terminator
+sLatiasGfx65:
+.incbin "baserom.gba", 0x15AD95C, 0x40
+sLatiasSprites65:
+ax_sprite sLatiasGfx65, 0x40
+ax_sprite_terminator
+sLatiasGfx66:
+.incbin "baserom.gba", 0x15AD9AC, 0x100
+sLatiasSprites66:
+ax_sprite sLatiasGfx66, 0x100
+ax_sprite_terminator
+sLatiasGfx67:
+.incbin "baserom.gba", 0x15ADABC, 0x100
+sLatiasSprites67:
+ax_sprite sLatiasGfx67, 0x100
+ax_sprite_terminator
+sLatiasGfx68:
+.incbin "baserom.gba", 0x15ADBCC, 0x40
+sLatiasSprites68:
+ax_sprite sLatiasGfx68, 0x40
+ax_sprite_terminator
+sLatiasGfx69:
+.incbin "baserom.gba", 0x15ADC1C, 0x40
+sLatiasSprites69:
+ax_sprite sLatiasGfx69, 0x40
+ax_sprite_terminator
+sLatiasGfx70:
+.incbin "baserom.gba", 0x15ADC6C, 0x100
+sLatiasSprites70:
+ax_sprite sLatiasGfx70, 0x100
+ax_sprite_terminator
+sLatiasGfx71:
+.incbin "baserom.gba", 0x15ADD7C, 0x20
+sLatiasSprites71:
+ax_sprite sLatiasGfx71, 0x20
+ax_sprite_terminator
+sLatiasGfx72:
+.incbin "baserom.gba", 0x15ADDAC, 0x20
+sLatiasSprites72:
+ax_sprite sLatiasGfx72, 0x20
+ax_sprite_terminator
+sLatiasGfx73:
+.incbin "baserom.gba", 0x15ADDDC, 0x20
+sLatiasSprites73:
+ax_sprite sLatiasGfx73, 0x20
+ax_sprite_terminator
+sLatiasGfx74:
+.incbin "baserom.gba", 0x15ADE0C, 0x60
+sLatiasSprites74:
+ax_sprite sLatiasGfx74, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLatiasGfx75:
+.incbin "baserom.gba", 0x15ADE84, 0x100
+sLatiasSprites75:
+ax_sprite sLatiasGfx75, 0x100
+ax_sprite_terminator
+sLatiasGfx76:
+.incbin "baserom.gba", 0x15ADF94, 0x20
+sLatiasSprites76:
+ax_sprite sLatiasGfx76, 0x20
+ax_sprite_terminator
+sLatiasGfx77:
+.incbin "baserom.gba", 0x15ADFC4, 0x20
+sLatiasSprites77:
+ax_sprite sLatiasGfx77, 0x20
+ax_sprite_terminator
+sLatiasGfx78:
+.incbin "baserom.gba", 0x15ADFF4, 0x20
+sLatiasSprites78:
+ax_sprite sLatiasGfx78, 0x20
+ax_sprite_terminator
+sLatiasGfx79:
+.incbin "baserom.gba", 0x15AE024, 0x20
+sLatiasSprites79:
+ax_sprite sLatiasGfx79, 0x20
+ax_sprite_terminator
+sLatiasGfx80:
+.incbin "baserom.gba", 0x15AE054, 0x20
+sLatiasSprites80:
+ax_sprite sLatiasGfx80, 0x20
+ax_sprite_terminator
+sLatiasGfx81:
+.incbin "baserom.gba", 0x15AE084, 0x40
+sLatiasSprites81:
+ax_sprite sLatiasGfx81, 0x40
+ax_sprite_terminator
+sLatiasGfx82:
+.incbin "baserom.gba", 0x15AE0D4, 0x80
+sLatiasSprites82:
+ax_sprite sLatiasGfx82, 0x80
+ax_sprite_terminator
+sLatiasGfx83:
+.incbin "baserom.gba", 0x15AE164, 0x20
+sLatiasSprites83:
+ax_sprite sLatiasGfx83, 0x20
+ax_sprite_terminator
+sLatiasGfx84:
+.incbin "baserom.gba", 0x15AE194, 0x40
+sLatiasSprites84:
+ax_sprite sLatiasGfx84, 0x40
+ax_sprite_terminator
+sLatiasGfx85:
+.incbin "baserom.gba", 0x15AE1E4, 0x20
+sLatiasSprites85:
+ax_sprite sLatiasGfx85, 0x20
+ax_sprite_terminator
+sLatiasGfx86:
+.incbin "baserom.gba", 0x15AE214, 0x40
+sLatiasSprites86:
+ax_sprite sLatiasGfx86, 0x40
+ax_sprite_terminator
+sLatiasGfx87:
+.incbin "baserom.gba", 0x15AE264, 0x20
+sLatiasSprites87:
+ax_sprite sLatiasGfx87, 0x20
+ax_sprite_terminator
+sLatiasGfx88:
+.incbin "baserom.gba", 0x15AE294, 0x20
+sLatiasSprites88:
+ax_sprite sLatiasGfx88, 0x20
+ax_sprite_terminator
+sLatiasGfx89:
+.incbin "baserom.gba", 0x15AE2C4, 0x20
+sLatiasSprites89:
+ax_sprite sLatiasGfx89, 0x20
+ax_sprite_terminator
+sLatiasGfx90:
+.incbin "baserom.gba", 0x15AE2F4, 0x20
+sLatiasSprites90:
+ax_sprite sLatiasGfx90, 0x20
+ax_sprite_terminator
+sLatiasGfx91:
+.incbin "baserom.gba", 0x15AE324, 0x40
+sLatiasSprites91:
+ax_sprite sLatiasGfx91, 0x40
+ax_sprite_terminator
+sLatiasGfx92:
+.incbin "baserom.gba", 0x15AE374, 0x40
+sLatiasSprites92:
+ax_sprite sLatiasGfx92, 0x40
+ax_sprite_terminator
+sLatiasGfx93:
+.incbin "baserom.gba", 0x15AE3C4, 0x20
+sLatiasSprites93:
+ax_sprite sLatiasGfx93, 0x20
+ax_sprite_terminator
+sLatiasGfx94:
+.incbin "baserom.gba", 0x15AE3F4, 0x20
+sLatiasSprites94:
+ax_sprite sLatiasGfx94, 0x20
+ax_sprite_terminator
+sLatiasGfx95:
+.incbin "baserom.gba", 0x15AE424, 0x20
+sLatiasSprites95:
+ax_sprite sLatiasGfx95, 0x20
+ax_sprite_terminator
+sLatiasGfx96:
+.incbin "baserom.gba", 0x15AE454, 0x20
+sLatiasSprites96:
+ax_sprite sLatiasGfx96, 0x20
+ax_sprite_terminator
+sLatiasGfx97:
+.incbin "baserom.gba", 0x15AE484, 0x40
+sLatiasSprites97:
+ax_sprite sLatiasGfx97, 0x40
+ax_sprite_terminator
+sLatiasGfx98:
+.incbin "baserom.gba", 0x15AE4D4, 0x80
+sLatiasSprites98:
+ax_sprite sLatiasGfx98, 0x80
+ax_sprite_terminator
+sLatiasGfx99:
+.incbin "baserom.gba", 0x15AE564, 0x80
+sLatiasSprites99:
+ax_sprite sLatiasGfx99, 0x80
+ax_sprite_terminator
+sLatiasGfx100:
+.incbin "baserom.gba", 0x15AE5F4, 0x80
+sLatiasSprites100:
+ax_sprite sLatiasGfx100, 0x80
+ax_sprite_terminator
+sLatiasGfx101:
+.incbin "baserom.gba", 0x15AE684, 0x40
+sLatiasSprites101:
+ax_sprite sLatiasGfx101, 0x40
+ax_sprite_terminator
+sLatiasGfx102:
+.incbin "baserom.gba", 0x15AE6D4, 0x40
+sLatiasSprites102:
+ax_sprite sLatiasGfx102, 0x40
+ax_sprite_terminator
+sLatiasGfx103:
+.incbin "baserom.gba", 0x15AE724, 0x20
+sLatiasSprites103:
+ax_sprite sLatiasGfx103, 0x20
+ax_sprite_terminator
+sLatiasGfx104:
+.incbin "baserom.gba", 0x15AE754, 0x20
+sLatiasSprites104:
+ax_sprite sLatiasGfx104, 0x20
+ax_sprite_terminator
+sLatiasGfx105:
+.incbin "baserom.gba", 0x15AE784, 0x80
+sLatiasSprites105:
+ax_sprite sLatiasGfx105, 0x80
+ax_sprite_terminator
+sLatiasGfx106:
+.incbin "baserom.gba", 0x15AE814, 0x40
+sLatiasSprites106:
+ax_sprite sLatiasGfx106, 0x40
+ax_sprite_terminator
+sLatiasGfx107:
+.incbin "baserom.gba", 0x15AE864, 0x80
+sLatiasSprites107:
+ax_sprite sLatiasGfx107, 0x80
+ax_sprite_terminator
+sLatiasGfx108:
+.incbin "baserom.gba", 0x15AE8F4, 0x40
+sLatiasSprites108:
+ax_sprite sLatiasGfx108, 0x40
+ax_sprite_terminator
+sLatiasGfx109:
+.incbin "baserom.gba", 0x15AE944, 0x200
+sLatiasSprites109:
+ax_sprite sLatiasGfx109, 0x200
+ax_sprite_terminator
+sLatiasGfx110:
+.incbin "baserom.gba", 0x15AEB54, 0x100
+sLatiasSprites110:
+ax_sprite sLatiasGfx110, 0x100
+ax_sprite_terminator
+sLatiasGfx111:
+.incbin "baserom.gba", 0x15AEC64, 0x80
+sLatiasSprites111:
+ax_sprite sLatiasGfx111, 0x80
+ax_sprite_terminator
+sLatiasGfx112:
+.incbin "baserom.gba", 0x15AECF4, 0x20
+sLatiasSprites112:
+ax_sprite sLatiasGfx112, 0x20
+ax_sprite_terminator
+sLatiasGfx113:
+.incbin "baserom.gba", 0x15AED24, 0x20
+sLatiasSprites113:
+ax_sprite sLatiasGfx113, 0x20
+ax_sprite_terminator
+sLatiasGfx114:
+.incbin "baserom.gba", 0x15AED54, 0x20
+sLatiasSprites114:
+ax_sprite sLatiasGfx114, 0x20
+ax_sprite_terminator
+sLatiasGfx115:
+.incbin "baserom.gba", 0x15AED84, 0x20
+sLatiasSprites115:
+ax_sprite sLatiasGfx115, 0x20
+ax_sprite_terminator
+sLatiasGfx116:
+.incbin "baserom.gba", 0x15AEDB4, 0x100
+sLatiasSprites116:
+ax_sprite sLatiasGfx116, 0x100
+ax_sprite_terminator
+sLatiasGfx117:
+.incbin "baserom.gba", 0x15AEEC4, 0x80
+sLatiasSprites117:
+ax_sprite sLatiasGfx117, 0x80
+ax_sprite_terminator
+sLatiasGfx118:
+.incbin "baserom.gba", 0x15AEF54, 0x20
+sLatiasSprites118:
+ax_sprite sLatiasGfx118, 0x20
+ax_sprite_terminator
+sLatiasGfx119:
+.incbin "baserom.gba", 0x15AEF84, 0x20
+sLatiasSprites119:
+ax_sprite sLatiasGfx119, 0x20
+ax_sprite_terminator
+sLatiasGfx120:
+.incbin "baserom.gba", 0x15AEFB4, 0x20
+sLatiasSprites120:
+ax_sprite sLatiasGfx120, 0x20
+ax_sprite_terminator
+sLatiasGfx121:
+.incbin "baserom.gba", 0x15AEFE4, 0x20
+sLatiasSprites121:
+ax_sprite sLatiasGfx121, 0x20
+ax_sprite_terminator
+sLatiasGfx122:
+.incbin "baserom.gba", 0x15AF014, 0x100
+sLatiasSprites122:
+ax_sprite sLatiasGfx122, 0x100
+ax_sprite_terminator
+sLatiasGfx123:
+.incbin "baserom.gba", 0x15AF124, 0x80
+sLatiasSprites123:
+ax_sprite sLatiasGfx123, 0x80
+ax_sprite_terminator
+sLatiasGfx124:
+.incbin "baserom.gba", 0x15AF1B4, 0x40
+sLatiasSprites124:
+ax_sprite sLatiasGfx124, 0x40
+ax_sprite_terminator
+sLatiasGfx125:
+.incbin "baserom.gba", 0x15AF204, 0x20
+sLatiasSprites125:
+ax_sprite sLatiasGfx125, 0x20
+ax_sprite_terminator
+sLatiasGfx126:
+.incbin "baserom.gba", 0x15AF234, 0x80
+sLatiasSprites126:
+ax_sprite sLatiasGfx126, 0x80
+ax_sprite_terminator
+sLatiasGfx127:
+.incbin "baserom.gba", 0x15AF2C4, 0x80
+sLatiasSprites127:
+ax_sprite sLatiasGfx127, 0x80
+ax_sprite_terminator
+sLatiasGfx128:
+.incbin "baserom.gba", 0x15AF354, 0x80
+sLatiasSprites128:
+ax_sprite sLatiasGfx128, 0x80
+ax_sprite_terminator
+sLatiasGfx129:
+.incbin "baserom.gba", 0x15AF3E4, 0x20
+sLatiasSprites129:
+ax_sprite sLatiasGfx129, 0x20
+ax_sprite_terminator
+sLatiasGfx130:
+.incbin "baserom.gba", 0x15AF414, 0x20
+sLatiasSprites130:
+ax_sprite sLatiasGfx130, 0x20
+ax_sprite_terminator
+sLatiasGfx131:
+.incbin "baserom.gba", 0x15AF444, 0x20
+sLatiasSprites131:
+ax_sprite sLatiasGfx131, 0x20
+ax_sprite_terminator
+sLatiasGfx132:
+.incbin "baserom.gba", 0x15AF474, 0x20
+sLatiasSprites132:
+ax_sprite sLatiasGfx132, 0x20
+ax_sprite_terminator
+sLatiasGfx133:
+.incbin "baserom.gba", 0x15AF4A4, 0x100
+sLatiasSprites133:
+ax_sprite sLatiasGfx133, 0x100
+ax_sprite_terminator
+sLatiasGfx134:
+.incbin "baserom.gba", 0x15AF5B4, 0x60
+sLatiasSprites134:
+ax_sprite sLatiasGfx134, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLatiasGfx135:
+.incbin "baserom.gba", 0x15AF62C, 0x40
+sLatiasSprites135:
+ax_sprite sLatiasGfx135, 0x40
+ax_sprite_terminator
+sLatiasGfx136:
+.incbin "baserom.gba", 0x15AF67C, 0x20
+sLatiasSprites136:
+ax_sprite sLatiasGfx136, 0x20
+ax_sprite_terminator
+sLatiasGfx137:
+.incbin "baserom.gba", 0x15AF6AC, 0x20
+sLatiasSprites137:
+ax_sprite sLatiasGfx137, 0x20
+ax_sprite_terminator
+sLatiasGfx138:
+.incbin "baserom.gba", 0x15AF6DC, 0x100
+sLatiasSprites138:
+ax_sprite sLatiasGfx138, 0x100
+ax_sprite_terminator
+sLatiasGfx139:
+.incbin "baserom.gba", 0x15AF7EC, 0x40
+sLatiasSprites139:
+ax_sprite sLatiasGfx139, 0x40
+ax_sprite_terminator
+sLatiasGfx140:
+.incbin "baserom.gba", 0x15AF83C, 0x60
+sLatiasSprites140:
+ax_sprite sLatiasGfx140, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLatiasGfx141:
+.incbin "baserom.gba", 0x15AF8B4, 0x20
+sLatiasSprites141:
+ax_sprite sLatiasGfx141, 0x20
+ax_sprite_terminator
+sLatiasGfx142:
+.incbin "baserom.gba", 0x15AF8E4, 0x20
+sLatiasSprites142:
+ax_sprite sLatiasGfx142, 0x20
+ax_sprite_terminator
+sLatiasGfx143:
+.incbin "baserom.gba", 0x15AF914, 0x100
+sLatiasSprites143:
+ax_sprite sLatiasGfx143, 0x100
+ax_sprite_terminator
+sLatiasGfx144:
+.incbin "baserom.gba", 0x15AFA24, 0x40
+sLatiasSprites144:
+ax_sprite sLatiasGfx144, 0x40
+ax_sprite_terminator
+sLatiasGfx145:
+.incbin "baserom.gba", 0x15AFA74, 0x40
+sLatiasSprites145:
+ax_sprite sLatiasGfx145, 0x40
+ax_sprite_terminator
+sLatiasGfx146:
+.incbin "baserom.gba", 0x15AFAC4, 0x20
+sLatiasSprites146:
+ax_sprite sLatiasGfx146, 0x20
+ax_sprite_terminator
+sLatiasGfx147:
+.incbin "baserom.gba", 0x15AFAF4, 0x20
+sLatiasSprites147:
+ax_sprite sLatiasGfx147, 0x20
+ax_sprite_terminator
+sLatiasGfx148:
+.incbin "baserom.gba", 0x15AFB24, 0x20
+sLatiasSprites148:
+ax_sprite sLatiasGfx148, 0x20
+ax_sprite_terminator
+sLatiasGfx149:
+.incbin "baserom.gba", 0x15AFB54, 0x20
+sLatiasSprites149:
+ax_sprite sLatiasGfx149, 0x20
+ax_sprite_terminator
+sLatiasGfx150:
+.incbin "baserom.gba", 0x15AFB84, 0x100
+sLatiasSprites150:
+ax_sprite sLatiasGfx150, 0x100
+ax_sprite_terminator
+sLatiasGfx151:
+.incbin "baserom.gba", 0x15AFC94, 0x40
+sLatiasSprites151:
+ax_sprite sLatiasGfx151, 0x40
+ax_sprite_terminator
+sLatiasGfx152:
+.incbin "baserom.gba", 0x15AFCE4, 0x20
+sLatiasSprites152:
+ax_sprite sLatiasGfx152, 0x20
+ax_sprite_terminator
+sLatiasGfx153:
+.incbin "baserom.gba", 0x15AFD14, 0x20
+sLatiasSprites153:
+ax_sprite sLatiasGfx153, 0x20
+ax_sprite_terminator
+sLatiasGfx154:
+.incbin "baserom.gba", 0x15AFD44, 0x40
+sLatiasSprites154:
+ax_sprite sLatiasGfx154, 0x40
+ax_sprite_terminator
+sLatiasGfx155:
+.incbin "baserom.gba", 0x15AFD94, 0x100
+sLatiasSprites155:
+ax_sprite sLatiasGfx155, 0x100
+ax_sprite_terminator
+sLatiasGfx156:
+.incbin "baserom.gba", 0x15AFEA4, 0x40
+sLatiasSprites156:
+ax_sprite sLatiasGfx156, 0x40
+ax_sprite_terminator
+sLatiasGfx157:
+.incbin "baserom.gba", 0x15AFEF4, 0x20
+sLatiasSprites157:
+ax_sprite sLatiasGfx157, 0x20
+ax_sprite_terminator
+sLatiasGfx158:
+.incbin "baserom.gba", 0x15AFF24, 0x20
+sLatiasSprites158:
+ax_sprite sLatiasGfx158, 0x20
+ax_sprite_terminator
+sLatiasGfx159:
+.incbin "baserom.gba", 0x15AFF54, 0x40
+sLatiasSprites159:
+ax_sprite sLatiasGfx159, 0x40
+ax_sprite_terminator
+sLatiasGfx160:
+.incbin "baserom.gba", 0x15AFFA4, 0x100
+sLatiasSprites160:
+ax_sprite sLatiasGfx160, 0x100
+ax_sprite_terminator
+sLatiasGfx161:
+.incbin "baserom.gba", 0x15B00B4, 0x80
+sLatiasSprites161:
+ax_sprite sLatiasGfx161, 0x80
+ax_sprite_terminator
+sLatiasGfx162:
+.incbin "baserom.gba", 0x15B0144, 0x40
+sLatiasSprites162:
+ax_sprite sLatiasGfx162, 0x40
+ax_sprite_terminator
+sLatiasGfx163:
+.incbin "baserom.gba", 0x15B0194, 0x20
+sLatiasSprites163:
+ax_sprite sLatiasGfx163, 0x20
+ax_sprite_terminator
+sLatiasGfx164:
+.incbin "baserom.gba", 0x15B01C4, 0x20
+sLatiasSprites164:
+ax_sprite sLatiasGfx164, 0x20
+ax_sprite_terminator
+sLatiasGfx165:
+.incbin "baserom.gba", 0x15B01F4, 0x100
+sLatiasSprites165:
+ax_sprite sLatiasGfx165, 0x100
+ax_sprite_terminator
+sLatiasGfx166:
+.incbin "baserom.gba", 0x15B0304, 0x40
+sLatiasSprites166:
+ax_sprite sLatiasGfx166, 0x40
+ax_sprite_terminator
+sLatiasGfx167:
+.incbin "baserom.gba", 0x15B0354, 0x20
+sLatiasSprites167:
+ax_sprite sLatiasGfx167, 0x20
+ax_sprite_terminator
+sLatiasGfx168:
+.incbin "baserom.gba", 0x15B0384, 0x20
+sLatiasSprites168:
+ax_sprite sLatiasGfx168, 0x20
+ax_sprite_terminator
+sLatiasGfx169:
+.incbin "baserom.gba", 0x15B03B4, 0x40
+sLatiasSprites169:
+ax_sprite sLatiasGfx169, 0x40
+ax_sprite_terminator
+sLatiasGfx170:
+.incbin "baserom.gba", 0x15B0404, 0x20
+sLatiasSprites170:
+ax_sprite sLatiasGfx170, 0x20
+ax_sprite_terminator
+sLatiasGfx171:
+.incbin "baserom.gba", 0x15B0434, 0x20
+sLatiasSprites171:
+ax_sprite sLatiasGfx171, 0x20
+ax_sprite_terminator
+sLatiasGfx172:
+.incbin "baserom.gba", 0x15B0464, 0x100
+sLatiasSprites172:
+ax_sprite sLatiasGfx172, 0x100
+ax_sprite_terminator
+sLatiasGfx173:
+.incbin "baserom.gba", 0x15B0574, 0x80
+sLatiasSprites173:
+ax_sprite sLatiasGfx173, 0x80
+ax_sprite_terminator
+sLatiasGfx174:
+.incbin "baserom.gba", 0x15B0604, 0x40
+sLatiasSprites174:
+ax_sprite sLatiasGfx174, 0x40
+ax_sprite_terminator
+sLatiasGfx175:
+.incbin "baserom.gba", 0x15B0654, 0x20
+sLatiasSprites175:
+ax_sprite sLatiasGfx175, 0x20
+ax_sprite_terminator
+sLatiasGfx176:
+.incbin "baserom.gba", 0x15B0684, 0x20
+sLatiasSprites176:
+ax_sprite sLatiasGfx176, 0x20
+ax_sprite_terminator
+sLatiasGfx177:
+.incbin "baserom.gba", 0x15B06B4, 0x100
+sLatiasSprites177:
+ax_sprite sLatiasGfx177, 0x100
+ax_sprite_terminator
+sLatiasGfx178:
+.incbin "baserom.gba", 0x15B07C4, 0x40
+sLatiasSprites178:
+ax_sprite sLatiasGfx178, 0x40
+ax_sprite_terminator
+sLatiasGfx179:
+.incbin "baserom.gba", 0x15B0814, 0x40
+sLatiasSprites179:
+ax_sprite sLatiasGfx179, 0x40
+ax_sprite_terminator
+sLatiasGfx180:
+.incbin "baserom.gba", 0x15B0864, 0x40
+sLatiasSprites180:
+ax_sprite sLatiasGfx180, 0x40
+ax_sprite_terminator
+sLatiasGfx181:
+.incbin "baserom.gba", 0x15B08B4, 0x20
+sLatiasSprites181:
+ax_sprite sLatiasGfx181, 0x20
+ax_sprite_terminator
+sLatiasGfx182:
+.incbin "baserom.gba", 0x15B08E4, 0x20
+sLatiasSprites182:
+ax_sprite sLatiasGfx182, 0x20
+ax_sprite_terminator
+sLatiasGfx183:
+.incbin "baserom.gba", 0x15B0914, 0x80
+sLatiasSprites183:
+ax_sprite sLatiasGfx183, 0x80
+ax_sprite_terminator
+sLatiasGfx184:
+.incbin "baserom.gba", 0x15B09A4, 0x100
+sLatiasSprites184:
+ax_sprite sLatiasGfx184, 0x100
+ax_sprite_terminator
+sLatiasGfx185:
+.incbin "baserom.gba", 0x15B0AB4, 0x60
+sLatiasSprites185:
+ax_sprite 0, 0x20
+ax_sprite sLatiasGfx185, 0x60
+ax_sprite_terminator
+sLatiasGfx186:
+.incbin "baserom.gba", 0x15B0B2C, 0x40
+sLatiasSprites186:
+ax_sprite sLatiasGfx186, 0x40
+ax_sprite_terminator
+sLatiasGfx187:
+.incbin "baserom.gba", 0x15B0B7C, 0x100
+sLatiasSprites187:
+ax_sprite sLatiasGfx187, 0x100
+ax_sprite_terminator
+sLatiasGfx188:
+.incbin "baserom.gba", 0x15B0C8C, 0x40
+sLatiasSprites188:
+ax_sprite sLatiasGfx188, 0x40
+ax_sprite_terminator
+sLatiasGfx189:
+.incbin "baserom.gba", 0x15B0CDC, 0x20
+sLatiasSprites189:
+ax_sprite sLatiasGfx189, 0x20
+ax_sprite_terminator
+sLatiasGfx190:
+.incbin "baserom.gba", 0x15B0D0C, 0x40
+sLatiasSprites190:
+ax_sprite sLatiasGfx190, 0x40
+ax_sprite_terminator
+sLatiasGfx191:
+.incbin "baserom.gba", 0x15B0D5C, 0x100
+sLatiasSprites191:
+ax_sprite sLatiasGfx191, 0x100
+ax_sprite_terminator
+sLatiasGfx192:
+.incbin "baserom.gba", 0x15B0E6C, 0x40
+sLatiasSprites192:
+ax_sprite sLatiasGfx192, 0x40
+ax_sprite_terminator
+sLatiasGfx193:
+.incbin "baserom.gba", 0x15B0EBC, 0x20
+sLatiasSprites193:
+ax_sprite sLatiasGfx193, 0x20
+ax_sprite_terminator
+sLatiasGfx194:
+.incbin "baserom.gba", 0x15B0EEC, 0x40
+sLatiasSprites194:
+ax_sprite sLatiasGfx194, 0x40
+ax_sprite_terminator
+sLatiasGfx195:
+.incbin "baserom.gba", 0x15B0F3C, 0x80
+sLatiasSprites195:
+ax_sprite sLatiasGfx195, 0x80
+ax_sprite_terminator
+sLatiasGfx196:
+.incbin "baserom.gba", 0x15B0FCC, 0x40
+sLatiasSprites196:
+ax_sprite sLatiasGfx196, 0x40
+ax_sprite_terminator
+sLatiasGfx197:
+.incbin "baserom.gba", 0x15B101C, 0x40
+sLatiasSprites197:
+ax_sprite sLatiasGfx197, 0x40
+ax_sprite_terminator
+sLatiasGfx198:
+.incbin "baserom.gba", 0x15B106C, 0x100
+sLatiasSprites198:
+ax_sprite sLatiasGfx198, 0x100
+ax_sprite_terminator
+sLatiasGfx199:
+.incbin "baserom.gba", 0x15B117C, 0x100
+sLatiasSprites199:
+ax_sprite sLatiasGfx199, 0x100
+ax_sprite_terminator
+sLatiasGfx200:
+.incbin "baserom.gba", 0x15B128C, 0x40
+sLatiasSprites200:
+ax_sprite sLatiasGfx200, 0x40
+ax_sprite_terminator
+sLatiasGfx201:
+.incbin "baserom.gba", 0x15B12DC, 0x20
+sLatiasSprites201:
+ax_sprite sLatiasGfx201, 0x20
+ax_sprite_terminator
+sLatiasGfx202:
+.incbin "baserom.gba", 0x15B130C, 0x20
+sLatiasSprites202:
+ax_sprite sLatiasGfx202, 0x20
+ax_sprite_terminator
+sLatiasGfx203:
+.incbin "baserom.gba", 0x15B133C, 0x40
+sLatiasSprites203:
+ax_sprite sLatiasGfx203, 0x40
+ax_sprite_terminator
+sLatiasGfx204:
+.incbin "baserom.gba", 0x15B138C, 0x20
+sLatiasSprites204:
+ax_sprite sLatiasGfx204, 0x20
+ax_sprite_terminator
+sLatiasGfx205:
+.incbin "baserom.gba", 0x15B13BC, 0x20
+sLatiasSprites205:
+ax_sprite sLatiasGfx205, 0x20
+ax_sprite_terminator
+sLatiasGfx206:
+.incbin "baserom.gba", 0x15B13EC, 0x100
+sLatiasSprites206:
+ax_sprite sLatiasGfx206, 0x100
+ax_sprite_terminator
+sLatiasGfx207:
+.incbin "baserom.gba", 0x15B14FC, 0x20
+sLatiasSprites207:
+ax_sprite sLatiasGfx207, 0x20
+ax_sprite_terminator
+sLatiasGfx208:
+.incbin "baserom.gba", 0x15B152C, 0x20
+sLatiasSprites208:
+ax_sprite sLatiasGfx208, 0x20
+ax_sprite_terminator
+sLatiasGfx209:
+.incbin "baserom.gba", 0x15B155C, 0x40
+sLatiasSprites209:
+ax_sprite sLatiasGfx209, 0x40
+ax_sprite_terminator
+sLatiasGfx210:
+.incbin "baserom.gba", 0x15B15AC, 0x80
+sLatiasSprites210:
+ax_sprite sLatiasGfx210, 0x80
+ax_sprite_terminator
+sLatiasGfx211:
+.incbin "baserom.gba", 0x15B163C, 0x80
+sLatiasSprites211:
+ax_sprite sLatiasGfx211, 0x80
+ax_sprite_terminator
+sLatiasGfx212:
+.incbin "baserom.gba", 0x15B16CC, 0x20
+sLatiasSprites212:
+ax_sprite sLatiasGfx212, 0x20
+ax_sprite_terminator
+sLatiasGfx213:
+.incbin "baserom.gba", 0x15B16FC, 0x20
+sLatiasSprites213:
+ax_sprite sLatiasGfx213, 0x20
+ax_sprite_terminator
+sLatiasGfx214:
+.incbin "baserom.gba", 0x15B172C, 0x40
+sLatiasSprites214:
+ax_sprite sLatiasGfx214, 0x40
+ax_sprite_terminator
+sLatiasGfx215:
+.incbin "baserom.gba", 0x15B177C, 0x100
+sLatiasSprites215:
+ax_sprite sLatiasGfx215, 0x100
+ax_sprite_terminator
+sLatiasGfx216:
+.incbin "baserom.gba", 0x15B188C, 0x100
+sLatiasSprites216:
+ax_sprite sLatiasGfx216, 0x100
+ax_sprite_terminator
+sLatiasGfx217:
+.incbin "baserom.gba", 0x15B199C, 0x40
+sLatiasSprites217:
+ax_sprite sLatiasGfx217, 0x40
+ax_sprite_terminator
+sLatiasGfx218:
+.incbin "baserom.gba", 0x15B19EC, 0x40
+sLatiasSprites218:
+ax_sprite sLatiasGfx218, 0x40
+ax_sprite_terminator
+sLatiasGfx219:
+.incbin "baserom.gba", 0x15B1A3C, 0x80
+sLatiasSprites219:
+ax_sprite sLatiasGfx219, 0x80
+ax_sprite_terminator
+sLatiasGfx220:
+.incbin "baserom.gba", 0x15B1ACC, 0x20
+sLatiasSprites220:
+ax_sprite sLatiasGfx220, 0x20
+ax_sprite_terminator
+sLatiasGfx221:
+.incbin "baserom.gba", 0x15B1AFC, 0x20
+sLatiasSprites221:
+ax_sprite sLatiasGfx221, 0x20
+ax_sprite_terminator
+sLatiasGfx222:
+.incbin "baserom.gba", 0x15B1B2C, 0x20
+sLatiasSprites222:
+ax_sprite sLatiasGfx222, 0x20
+ax_sprite_terminator
+sLatiasGfx223:
+.incbin "baserom.gba", 0x15B1B5C, 0x80
+sLatiasSprites223:
+ax_sprite sLatiasGfx223, 0x80
+ax_sprite_terminator
+sLatiasGfx224:
+.incbin "baserom.gba", 0x15B1BEC, 0x80
+sLatiasSprites224:
+ax_sprite sLatiasGfx224, 0x80
+ax_sprite_terminator
+sLatiasGfx225:
+.incbin "baserom.gba", 0x15B1C7C, 0x80
+sLatiasSprites225:
+ax_sprite sLatiasGfx225, 0x80
+ax_sprite_terminator
+sLatiasGfx226:
+.incbin "baserom.gba", 0x15B1D0C, 0x40
+sLatiasSprites226:
+ax_sprite sLatiasGfx226, 0x40
+ax_sprite_terminator
+sLatiasGfx227:
+.incbin "baserom.gba", 0x15B1D5C, 0x80
+sLatiasSprites227:
+ax_sprite sLatiasGfx227, 0x80
+ax_sprite_terminator
+sLatiasGfx228:
+.incbin "baserom.gba", 0x15B1DEC, 0x80
+sLatiasSprites228:
+ax_sprite sLatiasGfx228, 0x80
+ax_sprite_terminator
+sLatiasGfx229:
+.incbin "baserom.gba", 0x15B1E7C, 0x40
+sLatiasSprites229:
+ax_sprite sLatiasGfx229, 0x40
+ax_sprite_terminator
+sLatiasGfx230:
+.incbin "baserom.gba", 0x15B1ECC, 0x40
+sLatiasSprites230:
+ax_sprite sLatiasGfx230, 0x40
+ax_sprite_terminator
+sLatiasGfx231:
+.incbin "baserom.gba", 0x15B1F1C, 0x40
+sLatiasSprites231:
+ax_sprite sLatiasGfx231, 0x40
+ax_sprite_terminator
+sLatiasGfx232:
+.incbin "baserom.gba", 0x15B1F6C, 0x20
+sLatiasSprites232:
+ax_sprite sLatiasGfx232, 0x20
+ax_sprite_terminator
+sLatiasGfx233:
+.incbin "baserom.gba", 0x15B1F9C, 0x20
+sLatiasSprites233:
+ax_sprite sLatiasGfx233, 0x20
+ax_sprite_terminator
+sAxPosesLatias:
+.4byte sLatiasPose1
+.4byte sLatiasPose2
+.4byte sLatiasPose3
+.4byte sLatiasPose4
+.4byte sLatiasPose5
+.4byte sLatiasPose6
+.4byte sLatiasPose7
+.4byte sLatiasPose8
+.4byte sLatiasPose9
+.4byte sLatiasPose10
+.4byte sLatiasPose11
+.4byte sLatiasPose12
+.4byte sLatiasPose13
+.4byte sLatiasPose14
+.4byte sLatiasPose15
+.4byte sLatiasPose16
+.4byte sLatiasPose17
+.4byte sLatiasPose18
+.4byte sLatiasPose19
+.4byte sLatiasPose20
+.4byte sLatiasPose21
+.4byte sLatiasPose22
+.4byte sLatiasPose23
+.4byte sLatiasPose24
+.4byte sLatiasPose25
+.4byte sLatiasPose26
+.4byte sLatiasPose27
+.4byte sLatiasPose28
+.4byte sLatiasPose29
+.4byte sLatiasPose30
+.4byte sLatiasPose31
+.4byte sLatiasPose32
+.4byte sLatiasPose33
+.4byte sLatiasPose34
+.4byte sLatiasPose35
+.4byte sLatiasPose36
+.4byte sLatiasPose37
+.4byte sLatiasPose38
+.4byte sLatiasPose39
+.4byte sLatiasPose40
+.4byte sLatiasPose41
+.4byte sLatiasPose42
+.4byte sLatiasPose43
+.4byte sLatiasPose44
+.4byte sLatiasPose45
+.4byte sLatiasPose46
+.4byte sLatiasPose47
+.4byte sLatiasPose48
+.4byte sLatiasPose49
+.4byte sLatiasPose50
+.4byte sLatiasPose51
+.4byte sLatiasPose52
+.4byte sLatiasPose53
+.4byte sLatiasPose54
+.4byte sLatiasPose55
+.4byte sLatiasPose56
+.4byte sLatiasPose57
+.4byte sLatiasPose58
+.4byte sLatiasPose59
+.4byte sLatiasPose60
+.4byte sLatiasPose61
+.4byte sLatiasPose62
+.4byte sLatiasPose63
+.4byte sLatiasPose64
+.4byte sLatiasPose65
+.4byte sLatiasPose66
+.4byte sLatiasPose67
+.4byte sLatiasPose68
+.4byte sLatiasPose69
+.4byte sLatiasPose70
+.4byte sLatiasPose71
+.4byte sLatiasPose72
+.4byte sLatiasPose73
+.4byte sLatiasPose74
+.4byte sLatiasPose75
+.4byte sLatiasPose76
+.4byte sLatiasPose77
+.4byte sLatiasPose78
+.4byte sLatiasPose79
+.4byte sLatiasPose80
+.4byte sLatiasPose81
+.4byte sLatiasPose82
+.4byte sLatiasPose83
+.4byte sLatiasPose84
+.4byte sLatiasPose85
+.4byte sLatiasPose86
+.4byte sLatiasPose87
+.4byte sLatiasPose88
+.4byte sLatiasPose89
+.4byte sLatiasPose90
+.4byte sLatiasPose91
+.4byte sLatiasPose92
+.4byte sLatiasPose93
+.4byte sLatiasPose94
+.4byte sLatiasPose95
+.4byte sLatiasPose96
+.4byte sLatiasPose97
+.4byte sLatiasPose98
+.4byte sLatiasPose99
+.4byte sLatiasPose100
+.4byte sLatiasPose101
+.4byte sLatiasPose102
+.4byte sLatiasPose103
+.4byte sLatiasPose104
+.4byte sLatiasPose105
+.4byte sLatiasPose106
+.4byte sLatiasPose107
+.4byte sLatiasPose108
+.4byte sLatiasPose109
+.4byte sLatiasPose110
+.4byte sLatiasPose111
+.4byte sLatiasPose112
+.4byte sLatiasPose113
+.4byte sLatiasPose114
+.4byte sLatiasPose115
+.4byte sLatiasPose116
+.4byte sLatiasPose117
+.4byte sLatiasPose118
+.4byte sLatiasPose119
+.4byte sLatiasPose120
+.4byte sLatiasPose121
+.4byte sLatiasPose122
+.4byte sLatiasPose123
+.4byte sLatiasPose124
+.4byte sLatiasPose125
+.4byte sLatiasPose126
+.4byte sLatiasPose127
+.4byte sLatiasPose128
+.4byte sLatiasPose129
+.4byte sLatiasPose130
+.4byte sLatiasPose131
+.4byte sLatiasPose132
+.4byte sLatiasPose133
+.4byte sLatiasPose134
+.4byte sLatiasPose135
+.4byte sLatiasPose136
+.4byte sLatiasPose137
+.4byte sLatiasPose138
+.4byte sLatiasPose139
+.4byte sLatiasPose140
+.4byte sLatiasPose141
+.4byte sLatiasPose142
+.4byte sLatiasPose143
+.4byte sLatiasPose144
+.4byte sLatiasPose145
+.4byte sLatiasPose146
+.4byte sLatiasPose147
+.4byte sLatiasPose148
+.4byte sLatiasPose149
+.4byte sLatiasPose150
+.4byte sLatiasPose151
+.4byte sLatiasPose152
+.4byte sLatiasPose153
+.4byte sLatiasPose154
+.4byte sLatiasPose155
+.4byte sLatiasPose156
+.4byte sLatiasPose157
+.4byte sLatiasPose158
+.4byte sLatiasPose159
+.4byte sLatiasPose160
+.4byte sLatiasPose161
+.4byte sLatiasPose162
+.4byte sLatiasPose163
+.4byte sLatiasPose164
+.4byte sLatiasPose165
+.4byte sLatiasPose166
+.4byte sLatiasPose167
+.4byte sLatiasPose168
+.4byte sLatiasPose169
+.4byte sLatiasPose170
+.4byte sLatiasPose171
+.4byte sLatiasPose172
+.4byte sLatiasPose173
+.4byte sLatiasPose174
+.4byte sLatiasPose175
+.4byte sLatiasPose176
+.4byte sLatiasPose177
+.4byte sLatiasPose178
+.4byte sLatiasPose179
+.4byte sLatiasPose180
+.4byte sLatiasPose181
+.4byte sLatiasPose182
+.4byte sLatiasPose183
+.4byte sLatiasPose184
+.4byte sLatiasPose185
+.4byte sLatiasPose186
+.4byte sLatiasPose187
+.4byte sLatiasPose188
+.4byte sLatiasPose189
+.4byte sLatiasPose190
+.4byte sLatiasPose191
+.4byte sLatiasPose192
+.4byte sLatiasPose193
+.4byte sLatiasPose194
+.4byte sLatiasPose195
+.4byte sLatiasPose196
+.4byte sLatiasPose197
+.4byte sLatiasPose198
+.4byte sLatiasPose199
+.4byte sLatiasPose200
+.4byte sLatiasPose201
+.4byte sLatiasPose202
+.4byte sLatiasPose203
+.4byte sLatiasPose204
+.4byte sLatiasPose205
+.4byte sLatiasPose206
+.4byte sLatiasPose207
+.4byte sLatiasPose208
+.4byte sLatiasPose209
+.4byte sLatiasPose210
+.4byte sLatiasPose211
+.4byte sLatiasPose212
+.4byte sLatiasPose213
+.4byte sLatiasPose214
+.4byte sLatiasPose215
+.4byte sLatiasPose216
+.4byte sLatiasPose217
+.4byte sLatiasPose218
+.4byte sLatiasPose219
+.4byte sLatiasPose220
+.4byte sLatiasPose221
+.4byte sLatiasPose222
+.4byte sLatiasPose223
+.4byte sLatiasPose224
+.4byte sLatiasPose225
+.4byte sLatiasPose226
+.4byte sLatiasPose227
+.4byte sLatiasPose228
+.4byte sLatiasPose229
+.4byte sLatiasPose230
+.4byte sLatiasPose231
+.4byte sLatiasPose232
+.4byte sLatiasPose233
+.4byte sLatiasPose234
+.4byte sLatiasPose235
+sAxPositionsLatias:
+.2byte    0,    3, 	  -7,   -8, 	   6,   -8, 	   0,  -10
+.2byte    0,    3, 	  -6,   -8, 	   5,   -8, 	   0,  -10
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   2,  -10, 	   0,  -12
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -16,   -2, 	  -4,  -10, 	   2,   -5, 	  -1,  -12
+.2byte  -16,   -2, 	  -3,  -10, 	   2,   -5, 	  -1,  -12
+.2byte    0,    2, 	  -9,   -6, 	   8,   -6, 	  -1,  -10
+.2byte    0,    3, 	  -7,   -8, 	   6,   -8, 	   0,  -10
+.2byte    0,    3, 	  -6,   -8, 	   5,   -8, 	   0,  -10
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   2,  -10, 	   0,  -12
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   16,  -22, 	   8,   -5, 	  -1,  -16, 	   2,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte    0,  -28, 	   8,  -10, 	  -9,  -10, 	   0,  -15
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte  -17,  -22, 	   0,  -16, 	  -9,   -5, 	  -3,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -21,  -13, 	  -4,  -10, 	  -4,   -2, 	  -5,  -13
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -16,   -3, 	  -5,  -10, 	   5,   -1, 	   0,  -12
+.2byte  -16,   -2, 	  -4,  -10, 	   2,   -5, 	  -1,  -12
+.2byte  -16,   -2, 	  -3,  -10, 	   2,   -5, 	  -1,  -12
+.2byte    0,    2, 	  -9,   -6, 	   8,   -6, 	  -1,  -10
+.2byte    0,    3, 	  -7,   -8, 	   6,   -8, 	   0,  -10
+.2byte    0,    3, 	  -6,   -8, 	   5,   -8, 	   0,  -10
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   2,  -10, 	   0,  -12
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   16,  -22, 	   8,   -5, 	  -1,  -16, 	   2,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte    0,  -28, 	   8,  -10, 	  -9,  -10, 	   0,  -15
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte  -17,  -22, 	   0,  -16, 	  -9,   -5, 	  -3,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -21,  -13, 	  -4,  -10, 	  -4,   -2, 	  -5,  -13
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -16,   -3, 	  -5,  -10, 	   5,   -1, 	   0,  -12
+.2byte  -16,   -2, 	  -4,  -10, 	   2,   -5, 	  -1,  -12
+.2byte  -16,   -2, 	  -3,  -10, 	   2,   -5, 	  -1,  -12
+.2byte    0,    2, 	  -9,   -6, 	   8,   -6, 	  -1,  -10
+.2byte    0,  -16, 	  -5,   -9, 	   4,   -9, 	   0,  -10
+.2byte    0,   -5, 	 -10,  -13, 	   9,  -13, 	   0,  -11
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte    8,  -20, 	  -2,  -11, 	   7,  -12, 	   1,  -12
+.2byte   12,   -8, 	  -6,   -8, 	   3,  -12, 	   0,  -10
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   14,  -21, 	   7,  -11, 	   6,  -15, 	  -1,  -13
+.2byte   18,  -12, 	   4,   -6, 	   6,  -13, 	   1,  -11
+.2byte   16,  -22, 	   8,   -5, 	  -1,  -16, 	   2,  -16
+.2byte    9,  -27, 	   9,  -16, 	   0,  -20, 	  -1,  -15
+.2byte   13,  -23, 	  15,  -12, 	   2,  -19, 	   1,  -15
+.2byte    0,  -28, 	   8,  -10, 	  -9,  -10, 	   0,  -15
+.2byte    0,  -32, 	   3,  -22, 	  -4,  -22, 	   0,  -18
+.2byte    0,  -31, 	 -10,  -21, 	   9,  -21, 	   0,  -17
+.2byte  -17,  -22, 	   0,  -16, 	  -9,   -5, 	  -3,  -16
+.2byte  -10,  -27, 	  -1,  -20, 	 -10,  -16, 	   0,  -15
+.2byte  -14,  -23, 	  -3,  -19, 	 -16,  -12, 	  -2,  -15
+.2byte  -21,  -13, 	  -4,  -10, 	  -4,   -2, 	  -5,  -13
+.2byte  -15,  -21, 	  -7,  -15, 	  -8,  -11, 	   0,  -13
+.2byte  -19,  -12, 	  -7,  -13, 	  -5,   -6, 	  -2,  -11
+.2byte  -16,   -3, 	  -5,  -10, 	   5,   -1, 	   0,  -12
+.2byte   -9,  -20, 	  -8,  -12, 	   1,  -11, 	  -2,  -12
+.2byte  -13,   -8, 	  -4,  -12, 	   5,   -8, 	  -1,  -10
+.2byte    0,    2, 	  -9,   -6, 	   8,   -6, 	  -1,  -10
+.2byte    0,   -3, 	 -10,  -11, 	   9,  -11, 	   0,   -9
+.2byte   -1,  -20, 	 -11,  -13, 	  10,  -13, 	   0,  -11
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte   11,   -8, 	  -7,   -8, 	   2,  -12, 	  -1,  -10
+.2byte    6,  -25, 	  -8,  -11, 	  13,  -16, 	   0,  -11
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   17,  -12, 	   3,   -6, 	   5,  -13, 	   0,  -11
+.2byte   10,  -25, 	   2,   -9, 	   2,  -16, 	   0,  -12
+.2byte   16,  -22, 	   8,   -5, 	  -1,  -16, 	   2,  -16
+.2byte   13,  -24, 	  15,  -13, 	   2,  -20, 	   1,  -16
+.2byte    8,  -32, 	  12,  -15, 	   0,  -21, 	  -2,  -15
+.2byte    0,  -28, 	   8,  -10, 	  -9,  -10, 	   0,  -15
+.2byte    0,  -31, 	 -10,  -21, 	   9,  -21, 	   0,  -17
+.2byte    0,  -39, 	  11,  -24, 	 -11,  -23, 	   0,  -19
+.2byte  -17,  -22, 	   0,  -16, 	  -9,   -5, 	  -3,  -16
+.2byte  -14,  -24, 	  -3,  -20, 	 -16,  -13, 	  -2,  -16
+.2byte   -9,  -32, 	  -1,  -21, 	 -13,  -15, 	   1,  -15
+.2byte  -21,  -13, 	  -4,  -10, 	  -4,   -2, 	  -5,  -13
+.2byte  -18,  -12, 	  -6,  -13, 	  -4,   -6, 	  -1,  -11
+.2byte  -11,  -25, 	  -3,  -16, 	  -3,   -9, 	  -1,  -12
+.2byte  -16,   -3, 	  -5,  -10, 	   5,   -1, 	   0,  -12
+.2byte  -12,   -8, 	  -3,  -12, 	   6,   -8, 	   0,  -10
+.2byte   -7,  -25, 	 -14,  -16, 	   7,  -11, 	  -1,  -11
+.2byte  -10,    5, 	  -5,   -2, 	  -1,    2, 	   0,   -6
+.2byte  -10,    6, 	  -5,   -2, 	   0,    2, 	   0,   -6
+.2byte    5,  -24, 	  -8,  -15, 	   6,  -15, 	  -1,  -15
+.2byte   -3,  -22, 	  -1,  -13, 	  10,  -14, 	   2,  -11
+.2byte    0,  -22, 	   6,  -11, 	   9,  -17, 	   1,  -13
+.2byte   11,  -25, 	   8,  -15, 	   1,  -19, 	  -1,  -12
+.2byte   -8,  -26, 	   7,  -20, 	  -9,  -20, 	  -1,  -15
+.2byte  -12,  -25, 	  -2,  -19, 	  -9,  -15, 	   0,  -12
+.2byte   -1,  -22, 	 -10,  -17, 	  -7,  -11, 	  -2,  -13
+.2byte    2,  -22, 	 -11,  -14, 	   0,  -13, 	  -3,  -11
+.2byte    0,    2, 	  -9,   -6, 	   8,   -6, 	  -1,  -10
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   16,  -22, 	   8,   -5, 	  -1,  -16, 	   2,  -16
+.2byte    0,  -28, 	   8,  -10, 	  -9,  -10, 	   0,  -15
+.2byte  -17,  -22, 	   0,  -16, 	  -9,   -5, 	  -3,  -16
+.2byte  -21,  -13, 	  -4,  -10, 	  -4,   -2, 	  -5,  -13
+.2byte  -16,   -3, 	  -5,  -10, 	   5,   -1, 	   0,  -12
+.2byte    0,    3, 	  -7,   -8, 	   6,   -8, 	   0,  -10
+.2byte  -16,   -2, 	  -4,  -10, 	   2,   -5, 	  -1,  -12
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte  -16,   -2, 	  -4,  -10, 	   2,   -5, 	  -1,  -12
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte    0,   -5, 	 -10,  -13, 	   9,  -13, 	   0,  -11
+.2byte   12,   -8, 	  -6,   -8, 	   3,  -12, 	   0,  -10
+.2byte   18,  -12, 	   4,   -6, 	   6,  -13, 	   1,  -11
+.2byte   12,  -20, 	  14,   -9, 	   1,  -16, 	   0,  -12
+.2byte    0,  -25, 	 -10,  -15, 	   9,  -15, 	   0,  -11
+.2byte  -13,  -20, 	  -2,  -16, 	 -15,   -9, 	  -1,  -12
+.2byte  -19,  -12, 	  -7,  -13, 	  -5,   -6, 	  -2,  -11
+.2byte  -13,   -8, 	  -4,  -12, 	   5,   -8, 	  -1,  -10
+.2byte    0,    2, 	  -9,   -6, 	   8,   -6, 	  -1,  -10
+.2byte    0,    3, 	  -7,   -8, 	   6,   -8, 	   0,  -10
+.2byte    0,    3, 	  -6,   -8, 	   5,   -8, 	   0,  -10
+.2byte    0,  -16, 	  -5,   -9, 	   4,   -9, 	   0,  -10
+.2byte    0,   -5, 	 -10,  -13, 	   9,  -13, 	   0,  -11
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   3,  -10, 	   0,  -12
+.2byte   15,   -2, 	  -3,   -5, 	   2,  -10, 	   0,  -12
+.2byte    8,  -20, 	  -2,  -11, 	   7,  -12, 	   1,  -12
+.2byte   12,   -8, 	  -6,   -8, 	   3,  -12, 	   0,  -10
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   20,  -12, 	   5,   -7, 	   4,  -13, 	   3,  -15
+.2byte   14,  -21, 	   7,  -11, 	   6,  -15, 	  -1,  -13
+.2byte   18,  -12, 	   4,   -6, 	   6,  -13, 	   1,  -11
+.2byte   16,  -22, 	   8,   -5, 	  -1,  -16, 	   2,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte   16,  -21, 	  10,  -11, 	   2,  -17, 	   2,  -16
+.2byte    9,  -27, 	   9,  -16, 	   0,  -20, 	  -1,  -15
+.2byte   13,  -23, 	  15,  -12, 	   2,  -19, 	   1,  -15
+.2byte    0,  -28, 	   8,  -10, 	  -9,  -10, 	   0,  -15
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte    0,  -27, 	   7,  -11, 	  -8,  -11, 	   0,  -16
+.2byte    0,  -32, 	   3,  -22, 	  -4,  -22, 	   0,  -18
+.2byte    0,  -31, 	 -10,  -21, 	   9,  -21, 	   0,  -17
+.2byte  -17,  -22, 	   0,  -16, 	  -9,   -5, 	  -3,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -17,  -21, 	  -3,  -17, 	 -11,  -11, 	  -3,  -16
+.2byte  -10,  -27, 	  -1,  -20, 	 -10,  -16, 	   0,  -15
+.2byte  -14,  -23, 	  -3,  -19, 	 -16,  -12, 	  -2,  -15
+.2byte  -21,  -13, 	  -4,  -10, 	  -4,   -2, 	  -5,  -13
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -21,  -12, 	  -5,  -13, 	  -6,   -7, 	  -4,  -15
+.2byte  -15,  -21, 	  -7,  -15, 	  -8,  -11, 	   0,  -13
+.2byte  -19,  -12, 	  -7,  -13, 	  -5,   -6, 	  -2,  -11
+.2byte  -16,   -3, 	  -5,  -10, 	   5,   -1, 	   0,  -12
+.2byte  -16,   -2, 	  -4,  -10, 	   2,   -5, 	  -1,  -12
+.2byte  -16,   -2, 	  -3,  -10, 	   2,   -5, 	  -1,  -12
+.2byte   -9,  -20, 	  -8,  -12, 	   1,  -11, 	  -2,  -12
+.2byte  -13,   -8, 	  -4,  -12, 	   5,   -8, 	  -1,  -10
+.2byte    0,   -5, 	 -10,  -13, 	   9,  -13, 	   0,  -11
+.2byte   12,   -8, 	  -6,   -8, 	   3,  -12, 	   0,  -10
+.2byte   18,  -12, 	   4,   -6, 	   6,  -13, 	   1,  -11
+.2byte   12,  -20, 	  14,   -9, 	   1,  -16, 	   0,  -12
+.2byte    0,  -25, 	 -10,  -15, 	   9,  -15, 	   0,  -11
+.2byte  -13,  -20, 	  -2,  -16, 	 -15,   -9, 	  -1,  -12
+.2byte  -19,  -12, 	  -7,  -13, 	  -5,   -6, 	  -2,  -11
+.2byte  -13,   -8, 	  -4,  -12, 	   5,   -8, 	  -1,  -10
+.2byte    0,    2, 	  -9,   -6, 	   8,   -6, 	  -1,  -10
+.2byte  -16,   -3, 	  -5,  -10, 	   5,   -1, 	   0,  -12
+.2byte  -21,  -13, 	  -4,  -10, 	  -4,   -2, 	  -5,  -13
+.2byte  -17,  -22, 	   0,  -16, 	  -9,   -5, 	  -3,  -16
+.2byte    0,  -28, 	   8,  -10, 	  -9,  -10, 	   0,  -15
+.2byte   16,  -22, 	   8,   -5, 	  -1,  -16, 	   2,  -16
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte   15,   -3, 	  -6,   -1, 	   4,  -10, 	  -1,  -12
+.2byte   20,  -13, 	   3,   -2, 	   3,  -10, 	   4,  -13
+.2byte   14,  -21, 	   7,  -11, 	   6,  -15, 	  -1,  -13
+.2byte   12,  -25, 	   8,  -13, 	   6,  -17, 	  -1,  -15
+.2byte   11,  -18, 	   5,  -12, 	   2,  -15, 	  -3,  -12
+sLatiasAnimTable1:
+.4byte sLatiasAnims_1_1
+.4byte sLatiasAnims_1_2
+.4byte sLatiasAnims_1_3
+.4byte sLatiasAnims_1_4
+.4byte sLatiasAnims_1_5
+.4byte sLatiasAnims_1_6
+.4byte sLatiasAnims_1_7
+.4byte sLatiasAnims_1_8
+sLatiasAnimTable2:
+.4byte sLatiasAnims_2_1
+.4byte sLatiasAnims_2_2
+.4byte sLatiasAnims_2_3
+.4byte sLatiasAnims_2_4
+.4byte sLatiasAnims_2_5
+.4byte sLatiasAnims_2_6
+.4byte sLatiasAnims_2_7
+.4byte sLatiasAnims_2_8
+sLatiasAnimTable3:
+.4byte sLatiasAnims_3_1
+.4byte sLatiasAnims_3_2
+.4byte sLatiasAnims_3_3
+.4byte sLatiasAnims_3_4
+.4byte sLatiasAnims_3_5
+.4byte sLatiasAnims_3_6
+.4byte sLatiasAnims_3_7
+.4byte sLatiasAnims_3_8
+sLatiasAnimTable4:
+.4byte sLatiasAnims_4_1
+.4byte sLatiasAnims_4_2
+.4byte sLatiasAnims_4_3
+.4byte sLatiasAnims_4_4
+.4byte sLatiasAnims_4_5
+.4byte sLatiasAnims_4_6
+.4byte sLatiasAnims_4_7
+.4byte sLatiasAnims_4_8
+sLatiasAnimTable5:
+.4byte sLatiasAnims_5_1
+.4byte sLatiasAnims_5_2
+.4byte sLatiasAnims_5_3
+.4byte sLatiasAnims_5_4
+.4byte sLatiasAnims_5_5
+.4byte sLatiasAnims_5_6
+.4byte sLatiasAnims_5_7
+.4byte sLatiasAnims_5_8
+sLatiasAnimTable6:
+.4byte sLatiasAnims_6_1
+.4byte sLatiasAnims_6_1
+.4byte sLatiasAnims_6_1
+.4byte sLatiasAnims_6_1
+.4byte sLatiasAnims_6_1
+.4byte sLatiasAnims_6_1
+.4byte sLatiasAnims_6_1
+.4byte sLatiasAnims_6_1
+sLatiasAnimTable7:
+.4byte sLatiasAnims_7_1
+.4byte sLatiasAnims_7_2
+.4byte sLatiasAnims_7_3
+.4byte sLatiasAnims_7_4
+.4byte sLatiasAnims_7_5
+.4byte sLatiasAnims_7_6
+.4byte sLatiasAnims_7_7
+.4byte sLatiasAnims_7_8
+sLatiasAnimTable8:
+.4byte sLatiasAnims_8_1
+.4byte sLatiasAnims_8_2
+.4byte sLatiasAnims_8_3
+.4byte sLatiasAnims_8_4
+.4byte sLatiasAnims_8_5
+.4byte sLatiasAnims_8_6
+.4byte sLatiasAnims_8_7
+.4byte sLatiasAnims_8_8
+sLatiasAnimTable9:
+.4byte sLatiasAnims_9_1
+.4byte sLatiasAnims_9_2
+.4byte sLatiasAnims_9_3
+.4byte sLatiasAnims_9_4
+.4byte sLatiasAnims_9_5
+.4byte sLatiasAnims_9_6
+.4byte sLatiasAnims_9_7
+.4byte sLatiasAnims_9_8
+sLatiasAnimTable10:
+.4byte sLatiasAnims_10_1
+.4byte sLatiasAnims_10_2
+.4byte sLatiasAnims_10_3
+.4byte sLatiasAnims_10_4
+.4byte sLatiasAnims_10_5
+.4byte sLatiasAnims_10_6
+.4byte sLatiasAnims_10_7
+.4byte sLatiasAnims_10_8
+sLatiasAnimTable11:
+.4byte sLatiasAnims_11_1
+.4byte sLatiasAnims_11_2
+.4byte sLatiasAnims_11_3
+.4byte sLatiasAnims_11_4
+.4byte sLatiasAnims_11_5
+.4byte sLatiasAnims_11_6
+.4byte sLatiasAnims_11_7
+.4byte sLatiasAnims_11_8
+sLatiasAnimTable12:
+.4byte sLatiasAnims_12_1
+.4byte sLatiasAnims_12_2
+.4byte sLatiasAnims_12_3
+.4byte sLatiasAnims_12_4
+.4byte sLatiasAnims_12_5
+.4byte sLatiasAnims_12_6
+.4byte sLatiasAnims_12_7
+.4byte sLatiasAnims_12_8
+sLatiasAnimTable13:
+.4byte sLatiasAnims_13_1
+.4byte sLatiasAnims_13_2
+.4byte sLatiasAnims_13_3
+.4byte sLatiasAnims_13_4
+.4byte sLatiasAnims_13_5
+.4byte sLatiasAnims_13_6
+.4byte sLatiasAnims_13_7
+.4byte sLatiasAnims_13_8
+sLatiasAnimTable14:
+.4byte sLatiasAnims_14_1
+.4byte sLatiasAnims_14_1
+.4byte sLatiasAnims_14_1
+.4byte sLatiasAnims_14_1
+.4byte sLatiasAnims_14_1
+.4byte sLatiasAnims_14_1
+.4byte sLatiasAnims_14_1
+.4byte sLatiasAnims_14_1
+sLatiasAnimTable15:
+.4byte sLatiasAnims_15_1
+.4byte sLatiasAnims_15_1
+.4byte sLatiasAnims_15_1
+.4byte sLatiasAnims_15_1
+.4byte sLatiasAnims_15_1
+.4byte sLatiasAnims_15_1
+.4byte sLatiasAnims_15_1
+.4byte sLatiasAnims_15_1
+sLatiasAnimTable16:
+.4byte sLatiasAnims_16_1
+.4byte sLatiasAnims_16_1
+.4byte sLatiasAnims_16_1
+.4byte sLatiasAnims_16_1
+.4byte sLatiasAnims_16_1
+.4byte sLatiasAnims_16_1
+.4byte sLatiasAnims_16_1
+.4byte sLatiasAnims_16_1
+sAxAnimationsLatias:
+.4byte sLatiasAnimTable1
+.4byte sLatiasAnimTable2
+.4byte sLatiasAnimTable3
+.4byte sLatiasAnimTable4
+.4byte sLatiasAnimTable5
+.4byte sLatiasAnimTable6
+.4byte sLatiasAnimTable7
+.4byte sLatiasAnimTable8
+.4byte sLatiasAnimTable9
+.4byte sLatiasAnimTable10
+.4byte sLatiasAnimTable11
+.4byte sLatiasAnimTable12
+.4byte sLatiasAnimTable13
+.4byte sLatiasAnimTable14
+.4byte sLatiasAnimTable15
+.4byte sLatiasAnimTable16
+sAxSpritesLatias:
+.4byte sLatiasSprites1
+.4byte sLatiasSprites2
+.4byte sLatiasSprites3
+.4byte sLatiasSprites4
+.4byte sLatiasSprites5
+.4byte sLatiasSprites6
+.4byte sLatiasSprites7
+.4byte sLatiasSprites8
+.4byte sLatiasSprites9
+.4byte sLatiasSprites10
+.4byte sLatiasSprites11
+.4byte sLatiasSprites12
+.4byte sLatiasSprites13
+.4byte sLatiasSprites14
+.4byte sLatiasSprites15
+.4byte sLatiasSprites16
+.4byte sLatiasSprites17
+.4byte sLatiasSprites18
+.4byte sLatiasSprites19
+.4byte sLatiasSprites20
+.4byte sLatiasSprites21
+.4byte sLatiasSprites22
+.4byte sLatiasSprites23
+.4byte sLatiasSprites24
+.4byte sLatiasSprites25
+.4byte sLatiasSprites26
+.4byte sLatiasSprites27
+.4byte sLatiasSprites28
+.4byte sLatiasSprites29
+.4byte sLatiasSprites30
+.4byte sLatiasSprites31
+.4byte sLatiasSprites32
+.4byte sLatiasSprites33
+.4byte sLatiasSprites34
+.4byte sLatiasSprites35
+.4byte sLatiasSprites36
+.4byte sLatiasSprites37
+.4byte sLatiasSprites38
+.4byte sLatiasSprites39
+.4byte sLatiasSprites40
+.4byte sLatiasSprites41
+.4byte sLatiasSprites42
+.4byte sLatiasSprites43
+.4byte sLatiasSprites44
+.4byte sLatiasSprites45
+.4byte sLatiasSprites46
+.4byte sLatiasSprites47
+.4byte sLatiasSprites48
+.4byte sLatiasSprites49
+.4byte sLatiasSprites50
+.4byte sLatiasSprites51
+.4byte sLatiasSprites52
+.4byte sLatiasSprites53
+.4byte sLatiasSprites54
+.4byte sLatiasSprites55
+.4byte sLatiasSprites56
+.4byte sLatiasSprites57
+.4byte sLatiasSprites58
+.4byte sLatiasSprites59
+.4byte sLatiasSprites60
+.4byte sLatiasSprites61
+.4byte sLatiasSprites62
+.4byte sLatiasSprites63
+.4byte sLatiasSprites64
+.4byte sLatiasSprites65
+.4byte sLatiasSprites66
+.4byte sLatiasSprites67
+.4byte sLatiasSprites68
+.4byte sLatiasSprites69
+.4byte sLatiasSprites70
+.4byte sLatiasSprites71
+.4byte sLatiasSprites72
+.4byte sLatiasSprites73
+.4byte sLatiasSprites74
+.4byte sLatiasSprites75
+.4byte sLatiasSprites76
+.4byte sLatiasSprites77
+.4byte sLatiasSprites78
+.4byte sLatiasSprites79
+.4byte sLatiasSprites80
+.4byte sLatiasSprites81
+.4byte sLatiasSprites82
+.4byte sLatiasSprites83
+.4byte sLatiasSprites84
+.4byte sLatiasSprites85
+.4byte sLatiasSprites86
+.4byte sLatiasSprites87
+.4byte sLatiasSprites88
+.4byte sLatiasSprites89
+.4byte sLatiasSprites90
+.4byte sLatiasSprites91
+.4byte sLatiasSprites92
+.4byte sLatiasSprites93
+.4byte sLatiasSprites94
+.4byte sLatiasSprites95
+.4byte sLatiasSprites96
+.4byte sLatiasSprites97
+.4byte sLatiasSprites98
+.4byte sLatiasSprites99
+.4byte sLatiasSprites100
+.4byte sLatiasSprites101
+.4byte sLatiasSprites102
+.4byte sLatiasSprites103
+.4byte sLatiasSprites104
+.4byte sLatiasSprites105
+.4byte sLatiasSprites106
+.4byte sLatiasSprites107
+.4byte sLatiasSprites108
+.4byte sLatiasSprites109
+.4byte sLatiasSprites110
+.4byte sLatiasSprites111
+.4byte sLatiasSprites112
+.4byte sLatiasSprites113
+.4byte sLatiasSprites114
+.4byte sLatiasSprites115
+.4byte sLatiasSprites116
+.4byte sLatiasSprites117
+.4byte sLatiasSprites118
+.4byte sLatiasSprites119
+.4byte sLatiasSprites120
+.4byte sLatiasSprites121
+.4byte sLatiasSprites122
+.4byte sLatiasSprites123
+.4byte sLatiasSprites124
+.4byte sLatiasSprites125
+.4byte sLatiasSprites126
+.4byte sLatiasSprites127
+.4byte sLatiasSprites128
+.4byte sLatiasSprites129
+.4byte sLatiasSprites130
+.4byte sLatiasSprites131
+.4byte sLatiasSprites132
+.4byte sLatiasSprites133
+.4byte sLatiasSprites134
+.4byte sLatiasSprites135
+.4byte sLatiasSprites136
+.4byte sLatiasSprites137
+.4byte sLatiasSprites138
+.4byte sLatiasSprites139
+.4byte sLatiasSprites140
+.4byte sLatiasSprites141
+.4byte sLatiasSprites142
+.4byte sLatiasSprites143
+.4byte sLatiasSprites144
+.4byte sLatiasSprites145
+.4byte sLatiasSprites146
+.4byte sLatiasSprites147
+.4byte sLatiasSprites148
+.4byte sLatiasSprites149
+.4byte sLatiasSprites150
+.4byte sLatiasSprites151
+.4byte sLatiasSprites152
+.4byte sLatiasSprites153
+.4byte sLatiasSprites154
+.4byte sLatiasSprites155
+.4byte sLatiasSprites156
+.4byte sLatiasSprites157
+.4byte sLatiasSprites158
+.4byte sLatiasSprites159
+.4byte sLatiasSprites160
+.4byte sLatiasSprites161
+.4byte sLatiasSprites162
+.4byte sLatiasSprites163
+.4byte sLatiasSprites164
+.4byte sLatiasSprites165
+.4byte sLatiasSprites166
+.4byte sLatiasSprites167
+.4byte sLatiasSprites168
+.4byte sLatiasSprites169
+.4byte sLatiasSprites170
+.4byte sLatiasSprites171
+.4byte sLatiasSprites172
+.4byte sLatiasSprites173
+.4byte sLatiasSprites174
+.4byte sLatiasSprites175
+.4byte sLatiasSprites176
+.4byte sLatiasSprites177
+.4byte sLatiasSprites178
+.4byte sLatiasSprites179
+.4byte sLatiasSprites180
+.4byte sLatiasSprites181
+.4byte sLatiasSprites182
+.4byte sLatiasSprites183
+.4byte sLatiasSprites184
+.4byte sLatiasSprites185
+.4byte sLatiasSprites186
+.4byte sLatiasSprites187
+.4byte sLatiasSprites188
+.4byte sLatiasSprites189
+.4byte sLatiasSprites190
+.4byte sLatiasSprites191
+.4byte sLatiasSprites192
+.4byte sLatiasSprites193
+.4byte sLatiasSprites194
+.4byte sLatiasSprites195
+.4byte sLatiasSprites196
+.4byte sLatiasSprites197
+.4byte sLatiasSprites198
+.4byte sLatiasSprites199
+.4byte sLatiasSprites200
+.4byte sLatiasSprites201
+.4byte sLatiasSprites202
+.4byte sLatiasSprites203
+.4byte sLatiasSprites204
+.4byte sLatiasSprites205
+.4byte sLatiasSprites206
+.4byte sLatiasSprites207
+.4byte sLatiasSprites208
+.4byte sLatiasSprites209
+.4byte sLatiasSprites210
+.4byte sLatiasSprites211
+.4byte sLatiasSprites212
+.4byte sLatiasSprites213
+.4byte sLatiasSprites214
+.4byte sLatiasSprites215
+.4byte sLatiasSprites216
+.4byte sLatiasSprites217
+.4byte sLatiasSprites218
+.4byte sLatiasSprites219
+.4byte sLatiasSprites220
+.4byte sLatiasSprites221
+.4byte sLatiasSprites222
+.4byte sLatiasSprites223
+.4byte sLatiasSprites224
+.4byte sLatiasSprites225
+.4byte sLatiasSprites226
+.4byte sLatiasSprites227
+.4byte sLatiasSprites228
+.4byte sLatiasSprites229
+.4byte sLatiasSprites230
+.4byte sLatiasSprites231
+.4byte sLatiasSprites232
+.4byte sLatiasSprites233
+sAxMainLatias:
+ax_main sAxPosesLatias, sAxAnimationsLatias, 16, sAxSpritesLatias, sAxPositionsLatias

--- a/data/ax/latios.inc
+++ b/data/ax/latios.inc
@@ -1,0 +1,4762 @@
+.global gAxLatios
+gAxLatios:
+ax_siro sAxMainLatios
+sLatiosPose1:
+ax_pose 0, 0x81e2, 0x80f5, 0x5c00
+ax_pose 1, 0x81e2, 0x4105, 0x5c08
+ax_pose 2, 0x01e2, 0x40e5, 0x5c0c
+ax_pose 3, 0x01e2, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose2:
+ax_pose 4, 0x81e2, 0x80f5, 0x5c00
+ax_pose 5, 0x81e2, 0x4105, 0x5c08
+ax_pose 6, 0x01e2, 0x40e5, 0x5c0c
+ax_pose 7, 0x01e2, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose3:
+ax_pose 8, 0x01d9, 0x90f6, 0x5c00
+ax_pose 9, 0x41f9, 0x1106, 0x5c10
+ax_pose 10, 0x01e6, 0x50e6, 0x5c12
+ax_pose_terminator
+sLatiosPose4:
+ax_pose 11, 0x01d9, 0x90f6, 0x5c00
+ax_pose 12, 0x41f9, 0x1106, 0x5c10
+ax_pose 13, 0x01e6, 0x50e6, 0x5c12
+ax_pose_terminator
+sLatiosPose5:
+ax_pose 14, 0x01e3, 0x510e, 0x5c00
+ax_pose 15, 0x01e3, 0x90ee, 0x5c04
+ax_pose 16, 0x81eb, 0x10e6, 0x5c14
+ax_pose 17, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose6:
+ax_pose 18, 0x01e3, 0x510e, 0x5c00
+ax_pose 19, 0x01e3, 0x90ee, 0x5c04
+ax_pose 20, 0x81eb, 0x10e6, 0x5c14
+ax_pose 21, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose7:
+ax_pose 22, 0x01de, 0x90f6, 0x5c00
+ax_pose 23, 0x81de, 0x50ee, 0x5c10
+ax_pose 24, 0x81de, 0x10e6, 0x5c14
+ax_pose 25, 0x01fe, 0x10f6, 0x5c16
+ax_pose_terminator
+sLatiosPose8:
+ax_pose 26, 0x01de, 0x90f6, 0x5c00
+ax_pose 27, 0x81de, 0x50ee, 0x5c10
+ax_pose 28, 0x81de, 0x10e6, 0x5c14
+ax_pose 29, 0x01fe, 0x10f6, 0x5c16
+ax_pose_terminator
+sLatiosPose9:
+ax_pose 30, 0x81dc, 0x80f4, 0x5c00
+ax_pose 31, 0x81dc, 0x4104, 0x5c08
+ax_pose 32, 0x41fc, 0x00f9, 0x5c0c
+ax_pose 33, 0x41e7, 0x00e4, 0x5c0e
+ax_pose 34, 0x41e7, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiosPose10:
+ax_pose 35, 0x81dc, 0x80f4, 0x5c00
+ax_pose 36, 0x81dc, 0x4104, 0x5c08
+ax_pose 37, 0x41fc, 0x00f9, 0x5c0c
+ax_pose 38, 0x41e7, 0x00e4, 0x5c0e
+ax_pose 39, 0x41e7, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiosPose11:
+ax_pose 22, 0x01de, 0x80eb, 0x5c00
+ax_pose 23, 0x81de, 0x410b, 0x5c10
+ax_pose 24, 0x81de, 0x0113, 0x5c14
+ax_pose 25, 0x01fe, 0x0103, 0x5c16
+ax_pose_terminator
+sLatiosPose12:
+ax_pose 26, 0x01de, 0x80eb, 0x5c00
+ax_pose 27, 0x81de, 0x410b, 0x5c10
+ax_pose 28, 0x81de, 0x0113, 0x5c14
+ax_pose 29, 0x01fe, 0x0103, 0x5c16
+ax_pose_terminator
+sLatiosPose13:
+ax_pose 14, 0x01e3, 0x40e3, 0x5c00
+ax_pose 15, 0x01e3, 0x80f3, 0x5c04
+ax_pose 16, 0x81eb, 0x0113, 0x5c14
+ax_pose 17, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose14:
+ax_pose 18, 0x01e3, 0x40e3, 0x5c00
+ax_pose 19, 0x01e3, 0x80f3, 0x5c04
+ax_pose 20, 0x81eb, 0x0113, 0x5c14
+ax_pose 21, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose15:
+ax_pose 8, 0x01d9, 0x80eb, 0x5c00
+ax_pose 9, 0x41f9, 0x00eb, 0x5c10
+ax_pose 10, 0x01e6, 0x410b, 0x5c12
+ax_pose_terminator
+sLatiosPose16:
+ax_pose 11, 0x01d9, 0x80eb, 0x5c00
+ax_pose 12, 0x41f9, 0x00eb, 0x5c10
+ax_pose 13, 0x01e6, 0x410b, 0x5c12
+ax_pose_terminator
+sLatiosPose17:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose18:
+ax_pose 0, 0x81e2, 0x80f5, 0x5c00
+ax_pose 1, 0x81e2, 0x4105, 0x5c08
+ax_pose 2, 0x01e2, 0x40e5, 0x5c0c
+ax_pose 3, 0x01e2, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose19:
+ax_pose 4, 0x81e2, 0x80f5, 0x5c00
+ax_pose 5, 0x81e2, 0x4105, 0x5c08
+ax_pose 6, 0x01e2, 0x40e5, 0x5c0c
+ax_pose 7, 0x01e2, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose20:
+ax_pose 44, 0x01d9, 0x90f6, 0x5c00
+ax_pose 45, 0x01e7, 0x50e6, 0x5c10
+ax_pose 46, 0x41f9, 0x50f6, 0x5c14
+ax_pose_terminator
+sLatiosPose21:
+ax_pose 8, 0x01d9, 0x90f6, 0x5c00
+ax_pose 9, 0x41f9, 0x1106, 0x5c10
+ax_pose 10, 0x01e6, 0x50e6, 0x5c12
+ax_pose_terminator
+sLatiosPose22:
+ax_pose 11, 0x01d9, 0x90f6, 0x5c00
+ax_pose 12, 0x41f9, 0x1106, 0x5c10
+ax_pose 13, 0x01e6, 0x50e6, 0x5c12
+ax_pose_terminator
+sLatiosPose23:
+ax_pose 47, 0x01e3, 0x510e, 0x5c00
+ax_pose 48, 0x01e3, 0x90ee, 0x5c04
+ax_pose 49, 0x81eb, 0x10e6, 0x5c14
+ax_pose 50, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose24:
+ax_pose 14, 0x01e3, 0x510e, 0x5c00
+ax_pose 15, 0x01e3, 0x90ee, 0x5c04
+ax_pose 16, 0x81eb, 0x10e6, 0x5c14
+ax_pose 17, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose25:
+ax_pose 18, 0x01e3, 0x510e, 0x5c00
+ax_pose 19, 0x01e3, 0x90ee, 0x5c04
+ax_pose 20, 0x81eb, 0x10e6, 0x5c14
+ax_pose 21, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose26:
+ax_pose 51, 0x01dd, 0x90f6, 0x5c00
+ax_pose 52, 0x81dd, 0x50ee, 0x5c10
+ax_pose 53, 0x01df, 0x10e6, 0x5c14
+ax_pose 54, 0x01fd, 0x10f7, 0x5c15
+ax_pose_terminator
+sLatiosPose27:
+ax_pose 22, 0x01de, 0x90f6, 0x5c00
+ax_pose 23, 0x81de, 0x50ee, 0x5c10
+ax_pose 24, 0x81de, 0x10e6, 0x5c14
+ax_pose 25, 0x01fe, 0x10f6, 0x5c16
+ax_pose_terminator
+sLatiosPose28:
+ax_pose 26, 0x01de, 0x90f6, 0x5c00
+ax_pose 27, 0x81de, 0x50ee, 0x5c10
+ax_pose 28, 0x81de, 0x10e6, 0x5c14
+ax_pose 29, 0x01fe, 0x10f6, 0x5c16
+ax_pose_terminator
+sLatiosPose29:
+ax_pose 55, 0x81db, 0x80f5, 0x5c00
+ax_pose 56, 0x81db, 0x4105, 0x5c08
+ax_pose 57, 0x41fb, 0x00f8, 0x5c0c
+ax_pose 58, 0x41e7, 0x00e5, 0x5c0e
+ax_pose 59, 0x41e7, 0x010d, 0x5c10
+ax_pose_terminator
+sLatiosPose30:
+ax_pose 30, 0x81dc, 0x80f4, 0x5c00
+ax_pose 31, 0x81dc, 0x4104, 0x5c08
+ax_pose 32, 0x41fc, 0x00f9, 0x5c0c
+ax_pose 33, 0x41e7, 0x00e4, 0x5c0e
+ax_pose 34, 0x41e7, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiosPose31:
+ax_pose 35, 0x81dc, 0x80f4, 0x5c00
+ax_pose 36, 0x81dc, 0x4104, 0x5c08
+ax_pose 37, 0x41fc, 0x00f9, 0x5c0c
+ax_pose 38, 0x41e7, 0x00e4, 0x5c0e
+ax_pose 39, 0x41e7, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiosPose32:
+ax_pose 51, 0x01dd, 0x80eb, 0x5c00
+ax_pose 52, 0x81dd, 0x410b, 0x5c10
+ax_pose 53, 0x01df, 0x0113, 0x5c14
+ax_pose 54, 0x01fd, 0x0102, 0x5c15
+ax_pose_terminator
+sLatiosPose33:
+ax_pose 22, 0x01de, 0x80eb, 0x5c00
+ax_pose 23, 0x81de, 0x410b, 0x5c10
+ax_pose 24, 0x81de, 0x0113, 0x5c14
+ax_pose 25, 0x01fe, 0x0103, 0x5c16
+ax_pose_terminator
+sLatiosPose34:
+ax_pose 26, 0x01de, 0x80eb, 0x5c00
+ax_pose 27, 0x81de, 0x410b, 0x5c10
+ax_pose 28, 0x81de, 0x0113, 0x5c14
+ax_pose 29, 0x01fe, 0x0103, 0x5c16
+ax_pose_terminator
+sLatiosPose35:
+ax_pose 47, 0x01e3, 0x40e3, 0x5c00
+ax_pose 48, 0x01e3, 0x80f3, 0x5c04
+ax_pose 49, 0x81eb, 0x0113, 0x5c14
+ax_pose 50, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose36:
+ax_pose 14, 0x01e3, 0x40e3, 0x5c00
+ax_pose 15, 0x01e3, 0x80f3, 0x5c04
+ax_pose 16, 0x81eb, 0x0113, 0x5c14
+ax_pose 17, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose37:
+ax_pose 18, 0x01e3, 0x40e3, 0x5c00
+ax_pose 19, 0x01e3, 0x80f3, 0x5c04
+ax_pose 20, 0x81eb, 0x0113, 0x5c14
+ax_pose 21, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose38:
+ax_pose 44, 0x01d9, 0x80eb, 0x5c00
+ax_pose 45, 0x01e7, 0x410b, 0x5c10
+ax_pose 46, 0x41f9, 0x40eb, 0x5c14
+ax_pose_terminator
+sLatiosPose39:
+ax_pose 8, 0x01d9, 0x80eb, 0x5c00
+ax_pose 9, 0x41f9, 0x00eb, 0x5c10
+ax_pose 10, 0x01e6, 0x410b, 0x5c12
+ax_pose_terminator
+sLatiosPose40:
+ax_pose 11, 0x01d9, 0x80eb, 0x5c00
+ax_pose 12, 0x41f9, 0x00eb, 0x5c10
+ax_pose 13, 0x01e6, 0x410b, 0x5c12
+ax_pose_terminator
+sLatiosPose41:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose42:
+ax_pose 0, 0x81e2, 0x80f5, 0x5c00
+ax_pose 1, 0x81e2, 0x4105, 0x5c08
+ax_pose 2, 0x01e2, 0x40e5, 0x5c0c
+ax_pose 3, 0x01e2, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose43:
+ax_pose 4, 0x81e2, 0x80f5, 0x5c00
+ax_pose 5, 0x81e2, 0x4105, 0x5c08
+ax_pose 6, 0x01e2, 0x40e5, 0x5c0c
+ax_pose 7, 0x01e2, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose44:
+ax_pose 44, 0x01d9, 0x90f6, 0x5c00
+ax_pose 45, 0x01e7, 0x50e6, 0x5c10
+ax_pose 46, 0x41f9, 0x50f6, 0x5c14
+ax_pose_terminator
+sLatiosPose45:
+ax_pose 8, 0x01d9, 0x90f6, 0x5c00
+ax_pose 9, 0x41f9, 0x1106, 0x5c10
+ax_pose 10, 0x01e6, 0x50e6, 0x5c12
+ax_pose_terminator
+sLatiosPose46:
+ax_pose 11, 0x01d9, 0x90f6, 0x5c00
+ax_pose 12, 0x41f9, 0x1106, 0x5c10
+ax_pose 13, 0x01e6, 0x50e6, 0x5c12
+ax_pose_terminator
+sLatiosPose47:
+ax_pose 47, 0x01e3, 0x510e, 0x5c00
+ax_pose 48, 0x01e3, 0x90ee, 0x5c04
+ax_pose 49, 0x81eb, 0x10e6, 0x5c14
+ax_pose 50, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose48:
+ax_pose 14, 0x01e3, 0x510e, 0x5c00
+ax_pose 15, 0x01e3, 0x90ee, 0x5c04
+ax_pose 16, 0x81eb, 0x10e6, 0x5c14
+ax_pose 17, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose49:
+ax_pose 18, 0x01e3, 0x510e, 0x5c00
+ax_pose 19, 0x01e3, 0x90ee, 0x5c04
+ax_pose 20, 0x81eb, 0x10e6, 0x5c14
+ax_pose 21, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose50:
+ax_pose 51, 0x01dd, 0x90f6, 0x5c00
+ax_pose 52, 0x81dd, 0x50ee, 0x5c10
+ax_pose 53, 0x01df, 0x10e6, 0x5c14
+ax_pose 54, 0x01fd, 0x10f7, 0x5c15
+ax_pose_terminator
+sLatiosPose51:
+ax_pose 22, 0x01de, 0x90f6, 0x5c00
+ax_pose 23, 0x81de, 0x50ee, 0x5c10
+ax_pose 24, 0x81de, 0x10e6, 0x5c14
+ax_pose 25, 0x01fe, 0x10f6, 0x5c16
+ax_pose_terminator
+sLatiosPose52:
+ax_pose 26, 0x01de, 0x90f6, 0x5c00
+ax_pose 27, 0x81de, 0x50ee, 0x5c10
+ax_pose 28, 0x81de, 0x10e6, 0x5c14
+ax_pose 29, 0x01fe, 0x10f6, 0x5c16
+ax_pose_terminator
+sLatiosPose53:
+ax_pose 55, 0x81db, 0x80f5, 0x5c00
+ax_pose 56, 0x81db, 0x4105, 0x5c08
+ax_pose 57, 0x41fb, 0x00f8, 0x5c0c
+ax_pose 58, 0x41e7, 0x00e5, 0x5c0e
+ax_pose 59, 0x41e7, 0x010d, 0x5c10
+ax_pose_terminator
+sLatiosPose54:
+ax_pose 30, 0x81dc, 0x80f4, 0x5c00
+ax_pose 31, 0x81dc, 0x4104, 0x5c08
+ax_pose 32, 0x41fc, 0x00f9, 0x5c0c
+ax_pose 33, 0x41e7, 0x00e4, 0x5c0e
+ax_pose 34, 0x41e7, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiosPose55:
+ax_pose 35, 0x81dc, 0x80f4, 0x5c00
+ax_pose 36, 0x81dc, 0x4104, 0x5c08
+ax_pose 37, 0x41fc, 0x00f9, 0x5c0c
+ax_pose 38, 0x41e7, 0x00e4, 0x5c0e
+ax_pose 39, 0x41e7, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiosPose56:
+ax_pose 51, 0x01dd, 0x80eb, 0x5c00
+ax_pose 52, 0x81dd, 0x410b, 0x5c10
+ax_pose 53, 0x01df, 0x0113, 0x5c14
+ax_pose 54, 0x01fd, 0x0102, 0x5c15
+ax_pose_terminator
+sLatiosPose57:
+ax_pose 22, 0x01de, 0x80eb, 0x5c00
+ax_pose 23, 0x81de, 0x410b, 0x5c10
+ax_pose 24, 0x81de, 0x0113, 0x5c14
+ax_pose 25, 0x01fe, 0x0103, 0x5c16
+ax_pose_terminator
+sLatiosPose58:
+ax_pose 26, 0x01de, 0x80eb, 0x5c00
+ax_pose 27, 0x81de, 0x410b, 0x5c10
+ax_pose 28, 0x81de, 0x0113, 0x5c14
+ax_pose 29, 0x01fe, 0x0103, 0x5c16
+ax_pose_terminator
+sLatiosPose59:
+ax_pose 47, 0x01e3, 0x40e3, 0x5c00
+ax_pose 48, 0x01e3, 0x80f3, 0x5c04
+ax_pose 49, 0x81eb, 0x0113, 0x5c14
+ax_pose 50, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose60:
+ax_pose 14, 0x01e3, 0x40e3, 0x5c00
+ax_pose 15, 0x01e3, 0x80f3, 0x5c04
+ax_pose 16, 0x81eb, 0x0113, 0x5c14
+ax_pose 17, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose61:
+ax_pose 18, 0x01e3, 0x40e3, 0x5c00
+ax_pose 19, 0x01e3, 0x80f3, 0x5c04
+ax_pose 20, 0x81eb, 0x0113, 0x5c14
+ax_pose 21, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose62:
+ax_pose 44, 0x01d9, 0x80eb, 0x5c00
+ax_pose 45, 0x01e7, 0x410b, 0x5c10
+ax_pose 46, 0x41f9, 0x40eb, 0x5c14
+ax_pose_terminator
+sLatiosPose63:
+ax_pose 8, 0x01d9, 0x80eb, 0x5c00
+ax_pose 9, 0x41f9, 0x00eb, 0x5c10
+ax_pose 10, 0x01e6, 0x410b, 0x5c12
+ax_pose_terminator
+sLatiosPose64:
+ax_pose 11, 0x01d9, 0x80eb, 0x5c00
+ax_pose 12, 0x41f9, 0x00eb, 0x5c10
+ax_pose 13, 0x01e6, 0x410b, 0x5c12
+ax_pose_terminator
+sLatiosPose65:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose66:
+ax_pose 60, 0x41e0, 0x80f0, 0x5c00
+ax_pose 61, 0x41f0, 0x40f0, 0x5c08
+ax_pose 62, 0x41f8, 0x00f8, 0x5c0c
+ax_pose 63, 0x01d8, 0x010d, 0x5c0e
+ax_pose 64, 0x01d8, 0x00ec, 0x5c0f
+ax_pose_terminator
+sLatiosPose67:
+ax_pose 65, 0x41ef, 0x80f0, 0x5c00
+ax_pose 66, 0x41e7, 0x40f0, 0x5c08
+ax_pose 67, 0x01df, 0x00f0, 0x5c0c
+ax_pose 68, 0x01df, 0x0108, 0x5c0d
+ax_pose 69, 0x01df, 0x00e8, 0x5c0e
+ax_pose 70, 0x01df, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiosPose68:
+ax_pose 44, 0x01d9, 0x90f6, 0x5c00
+ax_pose 45, 0x01e7, 0x50e6, 0x5c10
+ax_pose 46, 0x41f9, 0x50f6, 0x5c14
+ax_pose_terminator
+sLatiosPose69:
+ax_pose 71, 0x41e0, 0x90f0, 0x5c00
+ax_pose 72, 0x01f0, 0x50f0, 0x5c08
+ax_pose 73, 0x41f0, 0x1100, 0x5c0c
+ax_pose 74, 0x01f8, 0x1100, 0x5c0e
+ax_pose 75, 0x01de, 0x10e8, 0x5c0f
+ax_pose 76, 0x01d0, 0x5100, 0x5c10
+ax_pose_terminator
+sLatiosPose70:
+ax_pose 77, 0x41eb, 0x90f2, 0x5c00
+ax_pose 78, 0x41e3, 0x50f2, 0x5c08
+ax_pose 79, 0x41db, 0x1102, 0x5c0c
+ax_pose 80, 0x41e3, 0x10e2, 0x5c0e
+ax_pose 81, 0x81eb, 0x10ea, 0x5c10
+ax_pose_terminator
+sLatiosPose71:
+ax_pose 47, 0x01e3, 0x510e, 0x5c00
+ax_pose 48, 0x01e3, 0x90ee, 0x5c04
+ax_pose 49, 0x81eb, 0x10e6, 0x5c14
+ax_pose 50, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose72:
+ax_pose 82, 0x81d8, 0x9109, 0x5c00
+ax_pose 83, 0x81e0, 0x1101, 0x5c08
+ax_pose 84, 0x01f0, 0x1101, 0x5c0a
+ax_pose 85, 0x81e0, 0x90f1, 0x5c0b
+ax_pose 86, 0x81e0, 0x50e9, 0x5c13
+ax_pose 87, 0x01d8, 0x10e9, 0x5c17
+ax_pose_terminator
+sLatiosPose73:
+ax_pose 88, 0x41f0, 0x90ed, 0x5c00
+ax_pose 89, 0x41e8, 0x50ed, 0x5c08
+ax_pose 90, 0x01e0, 0x1105, 0x5c0c
+ax_pose 91, 0x41e0, 0x10ed, 0x5c0d
+ax_pose 92, 0x01d8, 0x10f5, 0x5c0f
+ax_pose 93, 0x01f5, 0x110d, 0x5c10
+ax_pose 94, 0x01e0, 0x510d, 0x5c11
+ax_pose_terminator
+sLatiosPose74:
+ax_pose 51, 0x01dd, 0x90f6, 0x5c00
+ax_pose 52, 0x81dd, 0x50ee, 0x5c10
+ax_pose 53, 0x01df, 0x10e6, 0x5c14
+ax_pose 54, 0x01fd, 0x10f7, 0x5c15
+ax_pose_terminator
+sLatiosPose75:
+ax_pose 95, 0x41e1, 0x90f2, 0x5c00
+ax_pose 96, 0x01f1, 0x50f2, 0x5c08
+ax_pose 97, 0x01f1, 0x1102, 0x5c0c
+ax_pose 98, 0x41e4, 0x10e2, 0x5c0d
+ax_pose 99, 0x01ec, 0x10ea, 0x5c0f
+ax_pose 100, 0x01d1, 0x5102, 0x5c10
+ax_pose_terminator
+sLatiosPose76:
+ax_pose 101, 0x41df, 0x90f3, 0x5c00
+ax_pose 102, 0x41ef, 0x1103, 0x5c08
+ax_pose 103, 0x01ef, 0x50f3, 0x5c0a
+ax_pose 104, 0x41d7, 0x1103, 0x5c0e
+ax_pose 105, 0x81d7, 0x10eb, 0x5c10
+ax_pose 106, 0x81ef, 0x10eb, 0x5c12
+ax_pose 107, 0x01d7, 0x10f3, 0x5c14
+ax_pose_terminator
+sLatiosPose77:
+ax_pose 55, 0x81db, 0x80f5, 0x5c00
+ax_pose 56, 0x81db, 0x4105, 0x5c08
+ax_pose 57, 0x41fb, 0x00f8, 0x5c0c
+ax_pose 58, 0x41e7, 0x00e5, 0x5c0e
+ax_pose 59, 0x41e7, 0x010d, 0x5c10
+ax_pose_terminator
+sLatiosPose78:
+ax_pose 108, 0x81e1, 0x80f8, 0x5c00
+ax_pose 109, 0x81e9, 0x00f0, 0x5c08
+ax_pose 110, 0x81e9, 0x0108, 0x5c0a
+ax_pose 111, 0x01ee, 0x00e8, 0x5c0c
+ax_pose 112, 0x01ee, 0x0110, 0x5c0d
+ax_pose 113, 0x01d9, 0x00f8, 0x5c0e
+ax_pose 114, 0x01d9, 0x0100, 0x5c0f
+ax_pose 115, 0x41d1, 0x00f8, 0x5c10
+ax_pose_terminator
+sLatiosPose79:
+ax_pose 116, 0x41e0, 0x80f0, 0x5c00
+ax_pose 117, 0x41f0, 0x40f0, 0x5c08
+ax_pose 118, 0x01f8, 0x40f8, 0x5c0c
+ax_pose 119, 0x01e9, 0x00e8, 0x5c10
+ax_pose 120, 0x01e9, 0x0110, 0x5c11
+ax_pose 121, 0x41d8, 0x00f8, 0x5c12
+ax_pose_terminator
+sLatiosPose80:
+ax_pose 51, 0x01dd, 0x80eb, 0x5c00
+ax_pose 52, 0x81dd, 0x410b, 0x5c10
+ax_pose 53, 0x01df, 0x0113, 0x5c14
+ax_pose 54, 0x01fd, 0x0102, 0x5c15
+ax_pose_terminator
+sLatiosPose81:
+ax_pose 95, 0x41e1, 0x80ef, 0x5c00
+ax_pose 96, 0x01f1, 0x40ff, 0x5c08
+ax_pose 97, 0x01f1, 0x00f7, 0x5c0c
+ax_pose 98, 0x41e4, 0x010f, 0x5c0d
+ax_pose 99, 0x01ec, 0x010f, 0x5c0f
+ax_pose 100, 0x01d1, 0x40ef, 0x5c10
+ax_pose_terminator
+sLatiosPose82:
+ax_pose 101, 0x41df, 0x80ee, 0x5c00
+ax_pose 102, 0x41ef, 0x00ee, 0x5c08
+ax_pose 103, 0x01ef, 0x40fe, 0x5c0a
+ax_pose 104, 0x41d7, 0x00ee, 0x5c0e
+ax_pose 105, 0x81d7, 0x010e, 0x5c10
+ax_pose 106, 0x81ef, 0x010e, 0x5c12
+ax_pose 107, 0x01d7, 0x0106, 0x5c14
+ax_pose_terminator
+sLatiosPose83:
+ax_pose 47, 0x01e3, 0x40e3, 0x5c00
+ax_pose 48, 0x01e3, 0x80f3, 0x5c04
+ax_pose 49, 0x81eb, 0x0113, 0x5c14
+ax_pose 50, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose84:
+ax_pose 82, 0x81d8, 0x80e8, 0x5c00
+ax_pose 83, 0x81e0, 0x00f8, 0x5c08
+ax_pose 84, 0x01f0, 0x00f8, 0x5c0a
+ax_pose 85, 0x81e0, 0x8100, 0x5c0b
+ax_pose 86, 0x81e0, 0x4110, 0x5c13
+ax_pose 87, 0x01d8, 0x0110, 0x5c17
+ax_pose_terminator
+sLatiosPose85:
+ax_pose 88, 0x41f0, 0x80f4, 0x5c00
+ax_pose 89, 0x41e8, 0x40f4, 0x5c08
+ax_pose 90, 0x01e0, 0x00f4, 0x5c0c
+ax_pose 91, 0x41e0, 0x0104, 0x5c0d
+ax_pose 92, 0x01d8, 0x0104, 0x5c0f
+ax_pose 93, 0x01f5, 0x00ec, 0x5c10
+ax_pose 94, 0x01e0, 0x40e4, 0x5c11
+ax_pose_terminator
+sLatiosPose86:
+ax_pose 44, 0x01d9, 0x80eb, 0x5c00
+ax_pose 45, 0x01e7, 0x410b, 0x5c10
+ax_pose 46, 0x41f9, 0x40eb, 0x5c14
+ax_pose_terminator
+sLatiosPose87:
+ax_pose 71, 0x41e0, 0x80f0, 0x5c00
+ax_pose 72, 0x01f0, 0x4100, 0x5c08
+ax_pose 73, 0x41f0, 0x00f0, 0x5c0c
+ax_pose 74, 0x01f8, 0x00f8, 0x5c0e
+ax_pose 75, 0x01de, 0x0110, 0x5c0f
+ax_pose 76, 0x01d0, 0x40f0, 0x5c10
+ax_pose_terminator
+sLatiosPose88:
+ax_pose 77, 0x41eb, 0x80ee, 0x5c00
+ax_pose 78, 0x41e3, 0x40ee, 0x5c08
+ax_pose 79, 0x41db, 0x00ee, 0x5c0c
+ax_pose 80, 0x41e3, 0x010e, 0x5c0e
+ax_pose 81, 0x81eb, 0x010e, 0x5c10
+ax_pose_terminator
+sLatiosPose89:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose90:
+ax_pose 65, 0x41ef, 0x80f0, 0x5c00
+ax_pose 66, 0x41e7, 0x40f0, 0x5c08
+ax_pose 67, 0x01df, 0x00f0, 0x5c0c
+ax_pose 68, 0x01df, 0x0108, 0x5c0d
+ax_pose 69, 0x01df, 0x00e8, 0x5c0e
+ax_pose 70, 0x01df, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiosPose91:
+ax_pose 122, 0x01dd, 0x80e9, 0x5c00
+ax_pose 123, 0x81dd, 0x4109, 0x5c10
+ax_pose 124, 0x81dd, 0x0111, 0x5c14
+ax_pose_terminator
+sLatiosPose92:
+ax_pose 44, 0x01d9, 0x90f6, 0x5c00
+ax_pose 45, 0x01e7, 0x50e6, 0x5c10
+ax_pose 46, 0x41f9, 0x50f6, 0x5c14
+ax_pose_terminator
+sLatiosPose93:
+ax_pose 77, 0x41ea, 0x90f2, 0x5c00
+ax_pose 78, 0x41e2, 0x50f2, 0x5c08
+ax_pose 79, 0x41da, 0x1102, 0x5c0c
+ax_pose 80, 0x41e2, 0x10e2, 0x5c0e
+ax_pose 81, 0x81ea, 0x10ea, 0x5c10
+ax_pose_terminator
+sLatiosPose94:
+ax_pose 125, 0x01de, 0x90ed, 0x5c00
+ax_pose 126, 0x01d6, 0x1104, 0x5c10
+ax_pose 127, 0x81de, 0x10e5, 0x5c11
+ax_pose_terminator
+sLatiosPose95:
+ax_pose 47, 0x01e3, 0x510e, 0x5c00
+ax_pose 48, 0x01e3, 0x90ee, 0x5c04
+ax_pose 49, 0x81eb, 0x10e6, 0x5c14
+ax_pose 50, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose96:
+ax_pose 88, 0x41f0, 0x90ee, 0x5c00
+ax_pose 89, 0x41e8, 0x50ee, 0x5c08
+ax_pose 90, 0x01e0, 0x1106, 0x5c0c
+ax_pose 91, 0x41e0, 0x10ee, 0x5c0d
+ax_pose 92, 0x01d8, 0x10f6, 0x5c0f
+ax_pose 93, 0x01f5, 0x110e, 0x5c10
+ax_pose 94, 0x01e0, 0x510e, 0x5c11
+ax_pose_terminator
+sLatiosPose97:
+ax_pose 128, 0x41e1, 0x90ef, 0x5c00
+ax_pose 129, 0x41f1, 0x50ef, 0x5c08
+ax_pose 130, 0x41f9, 0x10ef, 0x5c0c
+ax_pose 131, 0x01f9, 0x10ff, 0x5c0e
+ax_pose 132, 0x01e8, 0x110f, 0x5c0f
+ax_pose 133, 0x01d1, 0x50ff, 0x5c10
+ax_pose_terminator
+sLatiosPose98:
+ax_pose 51, 0x01dd, 0x90f6, 0x5c00
+ax_pose 52, 0x81dd, 0x50ee, 0x5c10
+ax_pose 53, 0x01df, 0x10e6, 0x5c14
+ax_pose 54, 0x01fd, 0x10f7, 0x5c15
+ax_pose_terminator
+sLatiosPose99:
+ax_pose 101, 0x41e0, 0x90f3, 0x5c00
+ax_pose 102, 0x41f0, 0x1103, 0x5c08
+ax_pose 103, 0x01f0, 0x50f3, 0x5c0a
+ax_pose 104, 0x41d8, 0x1103, 0x5c0e
+ax_pose 105, 0x81d8, 0x10eb, 0x5c10
+ax_pose 106, 0x81f0, 0x10eb, 0x5c12
+ax_pose 107, 0x01d8, 0x10f3, 0x5c14
+ax_pose_terminator
+sLatiosPose100:
+ax_pose 134, 0x41e1, 0x90f1, 0x5c00
+ax_pose 135, 0x41f1, 0x50f1, 0x5c08
+ax_pose 136, 0x41f9, 0x10f1, 0x5c0c
+ax_pose 137, 0x01f9, 0x1101, 0x5c0e
+ax_pose 138, 0x01e1, 0x10e9, 0x5c0f
+ax_pose 139, 0x01d1, 0x50fe, 0x5c10
+ax_pose_terminator
+sLatiosPose101:
+ax_pose 55, 0x81db, 0x80f5, 0x5c00
+ax_pose 56, 0x81db, 0x4105, 0x5c08
+ax_pose 57, 0x41fb, 0x00f8, 0x5c0c
+ax_pose 58, 0x41e7, 0x00e5, 0x5c0e
+ax_pose 59, 0x41e7, 0x010d, 0x5c10
+ax_pose_terminator
+sLatiosPose102:
+ax_pose 116, 0x41de, 0x80f0, 0x5c00
+ax_pose 117, 0x41ee, 0x40f0, 0x5c08
+ax_pose 118, 0x01f6, 0x40f8, 0x5c0c
+ax_pose 119, 0x01e7, 0x00e8, 0x5c10
+ax_pose 120, 0x01e7, 0x0110, 0x5c11
+ax_pose 121, 0x41d6, 0x00f8, 0x5c12
+ax_pose_terminator
+sLatiosPose103:
+ax_pose 140, 0x01d2, 0x80e9, 0x5c00
+ax_pose 141, 0x41f2, 0x80e9, 0x5c10
+ax_pose 142, 0x01e2, 0x0109, 0x5c18
+ax_pose 143, 0x01ea, 0x4109, 0x5c19
+ax_pose_terminator
+sLatiosPose104:
+ax_pose 51, 0x01dd, 0x80eb, 0x5c00
+ax_pose 52, 0x81dd, 0x410b, 0x5c10
+ax_pose 53, 0x01df, 0x0113, 0x5c14
+ax_pose 54, 0x01fd, 0x0102, 0x5c15
+ax_pose_terminator
+sLatiosPose105:
+ax_pose 101, 0x41e0, 0x80ee, 0x5c00
+ax_pose 102, 0x41f0, 0x00ee, 0x5c08
+ax_pose 103, 0x01f0, 0x40fe, 0x5c0a
+ax_pose 104, 0x41d8, 0x00ee, 0x5c0e
+ax_pose 105, 0x81d8, 0x010e, 0x5c10
+ax_pose 106, 0x81f0, 0x010e, 0x5c12
+ax_pose 107, 0x01d8, 0x0106, 0x5c14
+ax_pose_terminator
+sLatiosPose106:
+ax_pose 134, 0x41e1, 0x80f0, 0x5c00
+ax_pose 135, 0x41f1, 0x40f0, 0x5c08
+ax_pose 136, 0x41f9, 0x0100, 0x5c0c
+ax_pose 137, 0x01f9, 0x00f8, 0x5c0e
+ax_pose 138, 0x01e1, 0x0110, 0x5c0f
+ax_pose 139, 0x01d1, 0x40f3, 0x5c10
+ax_pose_terminator
+sLatiosPose107:
+ax_pose 47, 0x01e3, 0x40e3, 0x5c00
+ax_pose 48, 0x01e3, 0x80f3, 0x5c04
+ax_pose 49, 0x81eb, 0x0113, 0x5c14
+ax_pose 50, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose108:
+ax_pose 88, 0x41f0, 0x80f3, 0x5c00
+ax_pose 89, 0x41e8, 0x40f3, 0x5c08
+ax_pose 90, 0x01e0, 0x00f3, 0x5c0c
+ax_pose 91, 0x41e0, 0x0103, 0x5c0d
+ax_pose 92, 0x01d8, 0x0103, 0x5c0f
+ax_pose 93, 0x01f5, 0x00eb, 0x5c10
+ax_pose 94, 0x01e0, 0x40e3, 0x5c11
+ax_pose_terminator
+sLatiosPose109:
+ax_pose 128, 0x41e1, 0x80f2, 0x5c00
+ax_pose 129, 0x41f1, 0x40f2, 0x5c08
+ax_pose 130, 0x41f9, 0x0102, 0x5c0c
+ax_pose 131, 0x01f9, 0x00fa, 0x5c0e
+ax_pose 132, 0x01e8, 0x00ea, 0x5c0f
+ax_pose 133, 0x01d1, 0x40f2, 0x5c10
+ax_pose_terminator
+sLatiosPose110:
+ax_pose 44, 0x01d9, 0x80eb, 0x5c00
+ax_pose 45, 0x01e7, 0x410b, 0x5c10
+ax_pose 46, 0x41f9, 0x40eb, 0x5c14
+ax_pose_terminator
+sLatiosPose111:
+ax_pose 77, 0x41ea, 0x80ee, 0x5c00
+ax_pose 78, 0x41e2, 0x40ee, 0x5c08
+ax_pose 79, 0x41da, 0x00ee, 0x5c0c
+ax_pose 80, 0x41e2, 0x010e, 0x5c0e
+ax_pose 81, 0x81ea, 0x010e, 0x5c10
+ax_pose_terminator
+sLatiosPose112:
+ax_pose 125, 0x01de, 0x80f3, 0x5c00
+ax_pose 126, 0x01d6, 0x00f4, 0x5c10
+ax_pose 127, 0x81de, 0x0113, 0x5c11
+ax_pose_terminator
+sLatiosPose113:
+ax_pose 144, 0x01ed, 0x80eb, 0x5c00
+ax_pose 145, 0x81ed, 0x810b, 0x5c10
+ax_pose_terminator
+sLatiosPose114:
+ax_pose 146, 0x01ed, 0x80eb, 0x5c00
+ax_pose 147, 0x81ed, 0x810b, 0x5c10
+ax_pose_terminator
+sLatiosPose115:
+ax_pose 148, 0x81d2, 0x010e, 0x5c00
+ax_pose 149, 0x81f2, 0x0106, 0x5c02
+ax_pose 150, 0x01f2, 0x40f6, 0x5c04
+ax_pose 151, 0x01d2, 0x80ee, 0x5c08
+ax_pose_terminator
+sLatiosPose116:
+ax_pose 152, 0x01d1, 0x90f2, 0x5c00
+ax_pose 153, 0x81d5, 0x10ea, 0x5c10
+ax_pose 154, 0x01f1, 0x50fa, 0x5c12
+ax_pose 155, 0x81f1, 0x10f2, 0x5c16
+ax_pose_terminator
+sLatiosPose117:
+ax_pose 156, 0x01e1, 0x50e1, 0x5c00
+ax_pose 157, 0x01c9, 0x10f5, 0x5c04
+ax_pose 158, 0x41d1, 0x90e9, 0x5c05
+ax_pose 159, 0x01e1, 0x90f1, 0x5c0d
+ax_pose_terminator
+sLatiosPose118:
+ax_pose 160, 0x81d8, 0x10e5, 0x5c00
+ax_pose 161, 0x01c8, 0x10f8, 0x5c02
+ax_pose 162, 0x81f0, 0x10f5, 0x5c03
+ax_pose 163, 0x01f0, 0x50fd, 0x5c05
+ax_pose 164, 0x01d0, 0x90ed, 0x5c09
+ax_pose_terminator
+sLatiosPose119:
+ax_pose 165, 0x01e9, 0x010f, 0x5c00
+ax_pose 166, 0x41f0, 0x80ef, 0x5c01
+ax_pose 167, 0x01d0, 0x80ef, 0x5c09
+ax_pose_terminator
+sLatiosPose120:
+ax_pose 160, 0x81d8, 0x0113, 0x5c00
+ax_pose 161, 0x01c8, 0x0100, 0x5c02
+ax_pose 162, 0x81f0, 0x0103, 0x5c03
+ax_pose 163, 0x01f0, 0x40f3, 0x5c05
+ax_pose 164, 0x01d0, 0x80f3, 0x5c09
+ax_pose_terminator
+sLatiosPose121:
+ax_pose 156, 0x01e1, 0x410f, 0x5c00
+ax_pose 157, 0x01c9, 0x0103, 0x5c04
+ax_pose 158, 0x41d1, 0x80f7, 0x5c05
+ax_pose 159, 0x01e1, 0x80ef, 0x5c0d
+ax_pose_terminator
+sLatiosPose122:
+ax_pose 152, 0x01d1, 0x80ee, 0x5c00
+ax_pose 153, 0x81d5, 0x010e, 0x5c10
+ax_pose 154, 0x01f1, 0x40f6, 0x5c12
+ax_pose 155, 0x81f1, 0x0106, 0x5c16
+ax_pose_terminator
+sLatiosPose123:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose124:
+ax_pose 44, 0x01d9, 0x80eb, 0x5c00
+ax_pose 45, 0x01e7, 0x410b, 0x5c10
+ax_pose 46, 0x41f9, 0x40eb, 0x5c14
+ax_pose_terminator
+sLatiosPose125:
+ax_pose 47, 0x01e3, 0x40e3, 0x5c00
+ax_pose 48, 0x01e3, 0x80f3, 0x5c04
+ax_pose 49, 0x81eb, 0x0113, 0x5c14
+ax_pose 50, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose126:
+ax_pose 51, 0x01dd, 0x80eb, 0x5c00
+ax_pose 52, 0x81dd, 0x410b, 0x5c10
+ax_pose 53, 0x01df, 0x0113, 0x5c14
+ax_pose 54, 0x01fd, 0x0102, 0x5c15
+ax_pose_terminator
+sLatiosPose127:
+ax_pose 55, 0x81db, 0x80f5, 0x5c00
+ax_pose 56, 0x81db, 0x4105, 0x5c08
+ax_pose 57, 0x41fb, 0x00f8, 0x5c0c
+ax_pose 58, 0x41e7, 0x00e5, 0x5c0e
+ax_pose 59, 0x41e7, 0x010d, 0x5c10
+ax_pose_terminator
+sLatiosPose128:
+ax_pose 51, 0x01dd, 0x90f6, 0x5c00
+ax_pose 52, 0x81dd, 0x50ee, 0x5c10
+ax_pose 53, 0x01df, 0x10e6, 0x5c14
+ax_pose 54, 0x01fd, 0x10f7, 0x5c15
+ax_pose_terminator
+sLatiosPose129:
+ax_pose 47, 0x01e3, 0x510e, 0x5c00
+ax_pose 48, 0x01e3, 0x90ee, 0x5c04
+ax_pose 49, 0x81eb, 0x10e6, 0x5c14
+ax_pose 50, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose130:
+ax_pose 44, 0x01d9, 0x90f6, 0x5c00
+ax_pose 45, 0x01e7, 0x50e6, 0x5c10
+ax_pose 46, 0x41f9, 0x50f6, 0x5c14
+ax_pose_terminator
+sLatiosPose131:
+ax_pose 0, 0x81e2, 0x80f5, 0x5c00
+ax_pose 1, 0x81e2, 0x4105, 0x5c08
+ax_pose 2, 0x01e2, 0x40e5, 0x5c0c
+ax_pose 3, 0x01e2, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose132:
+ax_pose 8, 0x01d9, 0x80eb, 0x5c00
+ax_pose 9, 0x41f9, 0x00eb, 0x5c10
+ax_pose 10, 0x01e6, 0x410b, 0x5c12
+ax_pose_terminator
+sLatiosPose133:
+ax_pose 14, 0x01e3, 0x40e3, 0x5c00
+ax_pose 15, 0x01e3, 0x80f3, 0x5c04
+ax_pose 16, 0x81eb, 0x0113, 0x5c14
+ax_pose 17, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose134:
+ax_pose 22, 0x01de, 0x80eb, 0x5c00
+ax_pose 23, 0x81de, 0x410b, 0x5c10
+ax_pose 24, 0x81de, 0x0113, 0x5c14
+ax_pose 25, 0x01fe, 0x0103, 0x5c16
+ax_pose_terminator
+sLatiosPose135:
+ax_pose 30, 0x81dc, 0x80f4, 0x5c00
+ax_pose 31, 0x81dc, 0x4104, 0x5c08
+ax_pose 32, 0x41fc, 0x00f9, 0x5c0c
+ax_pose 33, 0x41e7, 0x00e4, 0x5c0e
+ax_pose 34, 0x41e7, 0x010c, 0x5c10
+ax_pose_terminator
+sLatiosPose136:
+ax_pose 22, 0x01de, 0x90f6, 0x5c00
+ax_pose 23, 0x81de, 0x50ee, 0x5c10
+ax_pose 24, 0x81de, 0x10e6, 0x5c14
+ax_pose 25, 0x01fe, 0x10f6, 0x5c16
+ax_pose_terminator
+sLatiosPose137:
+ax_pose 14, 0x01e3, 0x510e, 0x5c00
+ax_pose 15, 0x01e3, 0x90ee, 0x5c04
+ax_pose 16, 0x81eb, 0x10e6, 0x5c14
+ax_pose 17, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose138:
+ax_pose 8, 0x01d9, 0x90f6, 0x5c00
+ax_pose 9, 0x41f9, 0x1106, 0x5c10
+ax_pose 10, 0x01e6, 0x50e6, 0x5c12
+ax_pose_terminator
+sLatiosPose139:
+ax_pose 65, 0x41ef, 0x80f0, 0x5c00
+ax_pose 66, 0x41e7, 0x40f0, 0x5c08
+ax_pose 67, 0x01df, 0x00f0, 0x5c0c
+ax_pose 68, 0x01df, 0x0108, 0x5c0d
+ax_pose 69, 0x01df, 0x00e8, 0x5c0e
+ax_pose 70, 0x01df, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiosPose140:
+ax_pose 77, 0x41eb, 0x90f2, 0x5c00
+ax_pose 78, 0x41e3, 0x50f2, 0x5c08
+ax_pose 79, 0x41db, 0x1102, 0x5c0c
+ax_pose 80, 0x41e3, 0x10e2, 0x5c0e
+ax_pose 81, 0x81eb, 0x10ea, 0x5c10
+ax_pose_terminator
+sLatiosPose141:
+ax_pose 88, 0x41f0, 0x90ed, 0x5c00
+ax_pose 89, 0x41e8, 0x50ed, 0x5c08
+ax_pose 90, 0x01e0, 0x1105, 0x5c0c
+ax_pose 91, 0x41e0, 0x10ed, 0x5c0d
+ax_pose 92, 0x01d8, 0x10f5, 0x5c0f
+ax_pose 93, 0x01f5, 0x110d, 0x5c10
+ax_pose 94, 0x01e0, 0x510d, 0x5c11
+ax_pose_terminator
+sLatiosPose142:
+ax_pose 101, 0x41e2, 0x90f2, 0x5c00
+ax_pose 102, 0x41f2, 0x1102, 0x5c08
+ax_pose 103, 0x01f2, 0x50f2, 0x5c0a
+ax_pose 104, 0x41da, 0x1102, 0x5c0e
+ax_pose 105, 0x81da, 0x10ea, 0x5c10
+ax_pose 106, 0x81f2, 0x10ea, 0x5c12
+ax_pose 107, 0x01da, 0x10f2, 0x5c14
+ax_pose_terminator
+sLatiosPose143:
+ax_pose 116, 0x41e0, 0x80f0, 0x5c00
+ax_pose 117, 0x41f0, 0x40f0, 0x5c08
+ax_pose 168, 0x41f8, 0x00f8, 0x5c0c
+ax_pose 119, 0x01e9, 0x00e8, 0x5c0e
+ax_pose 120, 0x01e9, 0x0110, 0x5c0f
+ax_pose 121, 0x41d8, 0x00f8, 0x5c10
+ax_pose_terminator
+sLatiosPose144:
+ax_pose 101, 0x41e2, 0x80ef, 0x5c00
+ax_pose 102, 0x41f2, 0x00ef, 0x5c08
+ax_pose 103, 0x01f2, 0x40ff, 0x5c0a
+ax_pose 104, 0x41da, 0x00ef, 0x5c0e
+ax_pose 105, 0x81da, 0x010f, 0x5c10
+ax_pose 106, 0x81f2, 0x010f, 0x5c12
+ax_pose 107, 0x01da, 0x0107, 0x5c14
+ax_pose_terminator
+sLatiosPose145:
+ax_pose 88, 0x41f0, 0x80f4, 0x5c00
+ax_pose 89, 0x41e8, 0x40f4, 0x5c08
+ax_pose 90, 0x01e0, 0x00f4, 0x5c0c
+ax_pose 91, 0x41e0, 0x0104, 0x5c0d
+ax_pose 92, 0x01d8, 0x0104, 0x5c0f
+ax_pose 93, 0x01f5, 0x00ec, 0x5c10
+ax_pose 94, 0x01e0, 0x40e4, 0x5c11
+ax_pose_terminator
+sLatiosPose146:
+ax_pose 77, 0x41eb, 0x80ee, 0x5c00
+ax_pose 78, 0x41e3, 0x40ee, 0x5c08
+ax_pose 79, 0x41db, 0x00ee, 0x5c0c
+ax_pose 80, 0x41e3, 0x010e, 0x5c0e
+ax_pose 81, 0x81eb, 0x010e, 0x5c10
+ax_pose_terminator
+sLatiosPose147:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose148:
+ax_pose 65, 0x41ec, 0x80f0, 0x5c00
+ax_pose 66, 0x41e4, 0x40f0, 0x5c08
+ax_pose 67, 0x01dc, 0x00f0, 0x5c0c
+ax_pose 68, 0x01dc, 0x0108, 0x5c0d
+ax_pose 69, 0x01dc, 0x00e8, 0x5c0e
+ax_pose 70, 0x01dc, 0x0110, 0x5c0f
+ax_pose_terminator
+sLatiosPose149:
+ax_pose 122, 0x01d9, 0x80e9, 0x5c00
+ax_pose 123, 0x81d9, 0x4109, 0x5c10
+ax_pose 124, 0x81d9, 0x0111, 0x5c14
+ax_pose_terminator
+sLatiosPose150:
+ax_pose 44, 0x01d9, 0x90f6, 0x5c00
+ax_pose 45, 0x01e7, 0x50e6, 0x5c10
+ax_pose 46, 0x41f9, 0x50f6, 0x5c14
+ax_pose_terminator
+sLatiosPose151:
+ax_pose 77, 0x41ea, 0x90f5, 0x5c00
+ax_pose 78, 0x41e2, 0x50f5, 0x5c08
+ax_pose 79, 0x41da, 0x1105, 0x5c0c
+ax_pose 80, 0x41e2, 0x10e5, 0x5c0e
+ax_pose 81, 0x81ea, 0x10ed, 0x5c10
+ax_pose_terminator
+sLatiosPose152:
+ax_pose 125, 0x01dd, 0x90f0, 0x5c00
+ax_pose 126, 0x01d5, 0x1107, 0x5c10
+ax_pose 127, 0x81dd, 0x10e8, 0x5c11
+ax_pose_terminator
+sLatiosPose153:
+ax_pose 47, 0x01e3, 0x510e, 0x5c00
+ax_pose 48, 0x01e3, 0x90ee, 0x5c04
+ax_pose 49, 0x81eb, 0x10e6, 0x5c14
+ax_pose 50, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose154:
+ax_pose 88, 0x41f0, 0x90ef, 0x5c00
+ax_pose 89, 0x41e8, 0x50ef, 0x5c08
+ax_pose 90, 0x01e0, 0x1107, 0x5c0c
+ax_pose 91, 0x41e0, 0x10ef, 0x5c0d
+ax_pose 92, 0x01d8, 0x10f7, 0x5c0f
+ax_pose 93, 0x01f5, 0x110f, 0x5c10
+ax_pose 94, 0x01e0, 0x510f, 0x5c11
+ax_pose_terminator
+sLatiosPose155:
+ax_pose 128, 0x41e1, 0x90ef, 0x5c00
+ax_pose 129, 0x41f1, 0x50ef, 0x5c08
+ax_pose 130, 0x41f9, 0x10ef, 0x5c0c
+ax_pose 131, 0x01f9, 0x10ff, 0x5c0e
+ax_pose 132, 0x01e8, 0x110f, 0x5c0f
+ax_pose 133, 0x01d1, 0x50ff, 0x5c10
+ax_pose_terminator
+sLatiosPose156:
+ax_pose 51, 0x01dd, 0x90f6, 0x5c00
+ax_pose 52, 0x81dd, 0x50ee, 0x5c10
+ax_pose 53, 0x01df, 0x10e6, 0x5c14
+ax_pose 54, 0x01fd, 0x10f7, 0x5c15
+ax_pose_terminator
+sLatiosPose157:
+ax_pose 101, 0x41e1, 0x90f3, 0x5c00
+ax_pose 102, 0x41f1, 0x1103, 0x5c08
+ax_pose 103, 0x01f1, 0x50f3, 0x5c0a
+ax_pose 104, 0x41d9, 0x1103, 0x5c0e
+ax_pose 105, 0x81d9, 0x10eb, 0x5c10
+ax_pose 106, 0x81f1, 0x10eb, 0x5c12
+ax_pose 107, 0x01d9, 0x10f3, 0x5c14
+ax_pose_terminator
+sLatiosPose158:
+ax_pose 134, 0x41e1, 0x90f1, 0x5c00
+ax_pose 135, 0x41f1, 0x50f1, 0x5c08
+ax_pose 136, 0x41f9, 0x10f1, 0x5c0c
+ax_pose 137, 0x01f9, 0x1101, 0x5c0e
+ax_pose 138, 0x01e1, 0x10e9, 0x5c0f
+ax_pose 139, 0x01d1, 0x50fe, 0x5c10
+ax_pose_terminator
+sLatiosPose159:
+ax_pose 55, 0x81db, 0x80f5, 0x5c00
+ax_pose 56, 0x81db, 0x4105, 0x5c08
+ax_pose 57, 0x41fb, 0x00f8, 0x5c0c
+ax_pose 58, 0x41e7, 0x00e5, 0x5c0e
+ax_pose 59, 0x41e7, 0x010d, 0x5c10
+ax_pose_terminator
+sLatiosPose160:
+ax_pose 116, 0x41de, 0x80f0, 0x5c00
+ax_pose 117, 0x41ee, 0x40f0, 0x5c08
+ax_pose 118, 0x01f6, 0x40f8, 0x5c0c
+ax_pose 119, 0x01e7, 0x00e8, 0x5c10
+ax_pose 120, 0x01e7, 0x0110, 0x5c11
+ax_pose 121, 0x41d6, 0x00f8, 0x5c12
+ax_pose_terminator
+sLatiosPose161:
+ax_pose 140, 0x01d2, 0x80e9, 0x5c00
+ax_pose 141, 0x41f2, 0x80e9, 0x5c10
+ax_pose 142, 0x01e2, 0x0109, 0x5c18
+ax_pose 143, 0x01ea, 0x4109, 0x5c19
+ax_pose_terminator
+sLatiosPose162:
+ax_pose 51, 0x01dd, 0x80eb, 0x5c00
+ax_pose 52, 0x81dd, 0x410b, 0x5c10
+ax_pose 53, 0x01df, 0x0113, 0x5c14
+ax_pose 54, 0x01fd, 0x0102, 0x5c15
+ax_pose_terminator
+sLatiosPose163:
+ax_pose 101, 0x41e1, 0x80ee, 0x5c00
+ax_pose 102, 0x41f1, 0x00ee, 0x5c08
+ax_pose 103, 0x01f1, 0x40fe, 0x5c0a
+ax_pose 104, 0x41d9, 0x00ee, 0x5c0e
+ax_pose 105, 0x81d9, 0x010e, 0x5c10
+ax_pose 106, 0x81f1, 0x010e, 0x5c12
+ax_pose 107, 0x01d9, 0x0106, 0x5c14
+ax_pose_terminator
+sLatiosPose164:
+ax_pose 134, 0x41e1, 0x80f0, 0x5c00
+ax_pose 135, 0x41f1, 0x40f0, 0x5c08
+ax_pose 136, 0x41f9, 0x0100, 0x5c0c
+ax_pose 137, 0x01f9, 0x00f8, 0x5c0e
+ax_pose 138, 0x01e1, 0x0110, 0x5c0f
+ax_pose 139, 0x01d1, 0x40f3, 0x5c10
+ax_pose_terminator
+sLatiosPose165:
+ax_pose 47, 0x01e3, 0x40e3, 0x5c00
+ax_pose 48, 0x01e3, 0x80f3, 0x5c04
+ax_pose 49, 0x81eb, 0x0113, 0x5c14
+ax_pose 50, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose166:
+ax_pose 88, 0x41f0, 0x80f2, 0x5c00
+ax_pose 89, 0x41e8, 0x40f2, 0x5c08
+ax_pose 90, 0x01e0, 0x00f2, 0x5c0c
+ax_pose 91, 0x41e0, 0x0102, 0x5c0d
+ax_pose 92, 0x01d8, 0x0102, 0x5c0f
+ax_pose 93, 0x01f5, 0x00ea, 0x5c10
+ax_pose 94, 0x01e0, 0x40e2, 0x5c11
+ax_pose_terminator
+sLatiosPose167:
+ax_pose 128, 0x41e1, 0x80f2, 0x5c00
+ax_pose 129, 0x41f1, 0x40f2, 0x5c08
+ax_pose 130, 0x41f9, 0x0102, 0x5c0c
+ax_pose 131, 0x01f9, 0x00fa, 0x5c0e
+ax_pose 132, 0x01e8, 0x00ea, 0x5c0f
+ax_pose 133, 0x01d1, 0x40f2, 0x5c10
+ax_pose_terminator
+sLatiosPose168:
+ax_pose 44, 0x01d9, 0x80eb, 0x5c00
+ax_pose 45, 0x01e7, 0x410b, 0x5c10
+ax_pose 46, 0x41f9, 0x40eb, 0x5c14
+ax_pose_terminator
+sLatiosPose169:
+ax_pose 77, 0x41ea, 0x80eb, 0x5c00
+ax_pose 78, 0x41e2, 0x40eb, 0x5c08
+ax_pose 79, 0x41da, 0x00eb, 0x5c0c
+ax_pose 80, 0x41e2, 0x010b, 0x5c0e
+ax_pose 81, 0x81ea, 0x010b, 0x5c10
+ax_pose_terminator
+sLatiosPose170:
+ax_pose 125, 0x01dd, 0x80f0, 0x5c00
+ax_pose 126, 0x01d5, 0x00f1, 0x5c10
+ax_pose 127, 0x81dd, 0x0110, 0x5c11
+ax_pose_terminator
+sLatiosPose171:
+ax_pose 60, 0x41e0, 0x80f0, 0x5c00
+ax_pose 61, 0x41f0, 0x40f0, 0x5c08
+ax_pose 62, 0x41f8, 0x00f8, 0x5c0c
+ax_pose 63, 0x01d8, 0x010d, 0x5c0e
+ax_pose 64, 0x01d8, 0x00ec, 0x5c0f
+ax_pose_terminator
+sLatiosPose172:
+ax_pose 71, 0x41e0, 0x80ef, 0x5c00
+ax_pose 72, 0x01f0, 0x40ff, 0x5c08
+ax_pose 73, 0x41f0, 0x00ef, 0x5c0c
+ax_pose 74, 0x01f8, 0x00f7, 0x5c0e
+ax_pose 75, 0x01de, 0x010f, 0x5c0f
+ax_pose 76, 0x01d0, 0x40ef, 0x5c10
+ax_pose_terminator
+sLatiosPose173:
+ax_pose 82, 0x81d9, 0x80e7, 0x5c00
+ax_pose 83, 0x81e1, 0x00f7, 0x5c08
+ax_pose 84, 0x01f1, 0x00f7, 0x5c0a
+ax_pose 85, 0x81e1, 0x80ff, 0x5c0b
+ax_pose 86, 0x81e1, 0x410f, 0x5c13
+ax_pose 87, 0x01d9, 0x010f, 0x5c17
+ax_pose_terminator
+sLatiosPose174:
+ax_pose 95, 0x41e4, 0x80ef, 0x5c00
+ax_pose 96, 0x01f4, 0x40ff, 0x5c08
+ax_pose 97, 0x01f4, 0x00f7, 0x5c0c
+ax_pose 98, 0x41e7, 0x010f, 0x5c0d
+ax_pose 99, 0x01ef, 0x010f, 0x5c0f
+ax_pose 100, 0x01d4, 0x40ef, 0x5c10
+ax_pose_terminator
+sLatiosPose175:
+ax_pose 108, 0x81e3, 0x80f8, 0x5c00
+ax_pose 109, 0x81eb, 0x00f0, 0x5c08
+ax_pose 110, 0x81eb, 0x0108, 0x5c0a
+ax_pose 111, 0x01f0, 0x00e8, 0x5c0c
+ax_pose 112, 0x01f0, 0x0110, 0x5c0d
+ax_pose 113, 0x01db, 0x00f8, 0x5c0e
+ax_pose 114, 0x01db, 0x0100, 0x5c0f
+ax_pose 115, 0x41d3, 0x00f8, 0x5c10
+ax_pose_terminator
+sLatiosPose176:
+ax_pose 95, 0x41e4, 0x90f2, 0x5c00
+ax_pose 96, 0x01f4, 0x50f2, 0x5c08
+ax_pose 97, 0x01f4, 0x1102, 0x5c0c
+ax_pose 98, 0x41e7, 0x10e2, 0x5c0d
+ax_pose 99, 0x01ef, 0x10ea, 0x5c0f
+ax_pose 100, 0x01d4, 0x5102, 0x5c10
+ax_pose_terminator
+sLatiosPose177:
+ax_pose 82, 0x81d9, 0x910a, 0x5c00
+ax_pose 83, 0x81e1, 0x1102, 0x5c08
+ax_pose 84, 0x01f1, 0x1102, 0x5c0a
+ax_pose 85, 0x81e1, 0x90f2, 0x5c0b
+ax_pose 86, 0x81e1, 0x50ea, 0x5c13
+ax_pose 87, 0x01d9, 0x10ea, 0x5c17
+ax_pose_terminator
+sLatiosPose178:
+ax_pose 71, 0x41e0, 0x90f0, 0x5c00
+ax_pose 72, 0x01f0, 0x50f0, 0x5c08
+ax_pose 73, 0x41f0, 0x1100, 0x5c0c
+ax_pose 74, 0x01f8, 0x1100, 0x5c0e
+ax_pose 75, 0x01de, 0x10e8, 0x5c0f
+ax_pose 76, 0x01d0, 0x5100, 0x5c10
+ax_pose_terminator
+sLatiosPose179:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose180:
+ax_pose 44, 0x01d9, 0x80eb, 0x5c00
+ax_pose 45, 0x01e7, 0x410b, 0x5c10
+ax_pose 46, 0x41f9, 0x40eb, 0x5c14
+ax_pose_terminator
+sLatiosPose181:
+ax_pose 47, 0x01e3, 0x40e3, 0x5c00
+ax_pose 48, 0x01e3, 0x80f3, 0x5c04
+ax_pose 49, 0x81eb, 0x0113, 0x5c14
+ax_pose 50, 0x01d3, 0x4103, 0x5c16
+ax_pose_terminator
+sLatiosPose182:
+ax_pose 51, 0x01dd, 0x80eb, 0x5c00
+ax_pose 52, 0x81dd, 0x410b, 0x5c10
+ax_pose 53, 0x01df, 0x0113, 0x5c14
+ax_pose 54, 0x01fd, 0x0102, 0x5c15
+ax_pose_terminator
+sLatiosPose183:
+ax_pose 55, 0x81db, 0x80f5, 0x5c00
+ax_pose 56, 0x81db, 0x4105, 0x5c08
+ax_pose 57, 0x41fb, 0x00f8, 0x5c0c
+ax_pose 58, 0x41e7, 0x00e5, 0x5c0e
+ax_pose 59, 0x41e7, 0x010d, 0x5c10
+ax_pose_terminator
+sLatiosPose184:
+ax_pose 51, 0x01dd, 0x90f6, 0x5c00
+ax_pose 52, 0x81dd, 0x50ee, 0x5c10
+ax_pose 53, 0x01df, 0x10e6, 0x5c14
+ax_pose 54, 0x01fd, 0x10f7, 0x5c15
+ax_pose_terminator
+sLatiosPose185:
+ax_pose 47, 0x01e3, 0x510e, 0x5c00
+ax_pose 48, 0x01e3, 0x90ee, 0x5c04
+ax_pose 49, 0x81eb, 0x10e6, 0x5c14
+ax_pose 50, 0x01d3, 0x50ee, 0x5c16
+ax_pose_terminator
+sLatiosPose186:
+ax_pose 44, 0x01d9, 0x90f6, 0x5c00
+ax_pose 45, 0x01e7, 0x50e6, 0x5c10
+ax_pose 46, 0x41f9, 0x50f6, 0x5c14
+ax_pose_terminator
+sLatiosPose187:
+ax_pose 169, 0x01e6, 0x80f8, 0x5c00
+ax_pose 170, 0x41de, 0x0108, 0x5c10
+ax_pose 171, 0x81de, 0x80e8, 0x5c12
+ax_pose_terminator
+sLatiosPose188:
+ax_pose 172, 0x01d7, 0x80f0, 0x5c00
+ax_pose 173, 0x41f7, 0x80f0, 0x5c10
+ax_pose 174, 0x81df, 0x4110, 0x5c18
+ax_pose_terminator
+sLatiosPose189:
+ax_pose_full 175, 0x0, 0x5, 0x01ec, 0x40ef, 0x5c00
+ax_pose_full 176, 0x0, -0x5, 0x01e4, 0x80ef, 0x5c04
+ax_pose_full 177, 0x0, -0x5, 0x41dc, 0x00e7, 0x5c14
+ax_pose_full 178, 0x0, -0x5, 0x01e4, 0x00e7, 0x5c16
+ax_pose_full 179, 0x0, -0x5, 0x01ec, 0x00e7, 0x5c17
+ax_pose_terminator
+sLatiosPose190:
+ax_pose 180, 0x41ef, 0x80eb, 0x5c00
+ax_pose 181, 0x41ff, 0x40eb, 0x5c08
+ax_pose 182, 0x01ef, 0x410b, 0x5c0c
+ax_pose_terminator
+sLatiosPose191:
+ax_pose 183, 0x41ef, 0x80eb, 0x5c00
+ax_pose 184, 0x41ff, 0x40eb, 0x5c08
+ax_pose 185, 0x01f7, 0x410b, 0x5c0c
+ax_pose_terminator
+sLatiosPose192:
+ax_pose 40, 0x81e1, 0x80f5, 0x5c00
+ax_pose 41, 0x81e1, 0x4105, 0x5c08
+ax_pose 42, 0x01e1, 0x40e5, 0x5c0c
+ax_pose 43, 0x01e1, 0x410d, 0x5c10
+ax_pose_terminator
+sLatiosPose193:
+ax_pose 186, 0x01d6, 0x80ec, 0x5c00
+ax_pose 187, 0x81d6, 0x010c, 0x5c10
+ax_pose 188, 0x01f6, 0x00fd, 0x5c12
+ax_pose_terminator
+sLatiosPose194:
+ax_pose 189, 0x01ea, 0x80ea, 0x5c00
+ax_pose 190, 0x81ea, 0x410a, 0x5c10
+ax_pose 191, 0x420a, 0x00f7, 0x5c14
+ax_pose 192, 0x01f2, 0x00e2, 0x5c16
+ax_pose_terminator
+sLatiosPose195:
+ax_pose 193, 0x01df, 0x80ed, 0x5c00
+ax_pose 194, 0x81df, 0x010d, 0x5c10
+ax_pose 195, 0x01ff, 0x00f5, 0x5c12
+ax_pose -1, 0x01ff, 0x1104, 0x5c12
+ax_pose_terminator
+sLatiosPose196:
+ax_pose 196, 0x01dd, 0x80ec, 0x5c00
+ax_pose 197, 0x81dd, 0x010c, 0x5c10
+ax_pose 198, 0x41fd, 0x40ec, 0x5c12
+ax_pose_terminator
+sLatiosPose197:
+ax_pose 196, 0x01dd, 0x90f4, 0x5c00
+ax_pose 197, 0x81dd, 0x10ec, 0x5c10
+ax_pose 198, 0x41fd, 0x50f4, 0x5c12
+ax_pose_terminator
+sLatiosPose198:
+ax_pose 199, 0x01dd, 0x80ed, 0x5c00
+ax_pose 200, 0x41fd, 0x40ed, 0x5c10
+ax_pose 201, 0x81dd, 0x010d, 0x5c14
+ax_pose_terminator
+sLatiosPose199:
+ax_pose 199, 0x01dd, 0x90f3, 0x5c00
+ax_pose 200, 0x41fd, 0x50f3, 0x5c10
+ax_pose 201, 0x81dd, 0x10eb, 0x5c14
+ax_pose_terminator
+sLatiosPose200:
+ax_pose 193, 0x01df, 0x80ed, 0x5c00
+ax_pose 194, 0x81df, 0x010d, 0x5c10
+ax_pose 195, 0x01ff, 0x00f5, 0x5c12
+ax_pose -1, 0x01ff, 0x1104, 0x5c12
+ax_pose_terminator
+sLatiosPose201:
+ax_pose 199, 0x01dd, 0x80ed, 0x5c00
+ax_pose 200, 0x41fd, 0x40ed, 0x5c10
+ax_pose 201, 0x81dd, 0x010d, 0x5c14
+ax_pose_terminator
+sLatiosPose202:
+ax_pose 202, 0x01e3, 0x80ec, 0x5c00
+ax_pose 203, 0x01e3, 0x00e4, 0x5c10
+ax_pose 204, 0x81e3, 0x010c, 0x5c11
+ax_pose_terminator
+sLatiosPose203:
+ax_pose 205, 0x41f3, 0x80e8, 0x5c00
+ax_pose 206, 0x41eb, 0x00f8, 0x5c08
+ax_pose 207, 0x01f3, 0x4108, 0x5c0a
+ax_pose_terminator
+.align 2
+sLatiosAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -4, 0, 0,
+ax_anim 4, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -4, 0, 0,
+ax_anim 4, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -4, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 9, 0, -4, 0, 0,
+ax_anim 4, 0, 8, 0, -4, 0, 0,
+ax_anim 4, 0, 9, 0, -4, 0, 0,
+ax_anim 4, 0, 8, 0, -4, 0, 0,
+ax_anim 4, 0, 9, 0, -4, 0, 0,
+ax_anim 4, 0, 8, 0, -4, 0, 0,
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim 4, 0, 10, 0, -4, 0, 0,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim 4, 0, 10, 0, -4, 0, 0,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim 4, 0, 10, 0, -4, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -4, 0, 0,
+ax_anim 4, 0, 12, 0, -4, 0, 0,
+ax_anim 4, 0, 13, 0, -4, 0, 0,
+ax_anim 4, 0, 12, 0, -4, 0, 0,
+ax_anim 4, 0, 13, 0, -4, 0, 0,
+ax_anim 4, 0, 12, 0, -4, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 15, 0, -4, 0, 0,
+ax_anim 4, 0, 14, 0, -4, 0, 0,
+ax_anim 4, 0, 15, 0, -4, 0, 0,
+ax_anim 4, 0, 14, 0, -4, 0, 0,
+ax_anim 4, 0, 15, 0, -4, 0, 0,
+ax_anim 4, 0, 14, 0, -4, 0, 0,
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 2, 0, 16, 0, -2, 0, -2,
+ax_anim 6, 0, 17, 0, -4, 0, -4,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 0, 4, 0, 2,
+ax_anim 1, 0, 18, 0, 10, 0, 6,
+ax_anim 2, 0, 17, 0, 20, 0, 11,
+ax_anim 2, 1, 17, 1, 20, 1, 11,
+ax_anim 2, 0, 17, 0, 20, 0, 11,
+ax_anim 2, 0, 17, 1, 20, 1, 11,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sLatiosAnims_2_2:
+ax_anim 2, 0, 19, -1, -1, -1, -1,
+ax_anim 2, 0, 19, -2, -2, -2, -2,
+ax_anim 6, 0, 20, -4, -4, -4, -4,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 4, 7, 4, 6,
+ax_anim 1, 0, 21, 7, 14, 7, 11,
+ax_anim 2, 0, 20, 12, 24, 12, 18,
+ax_anim 2, 1, 20, 13, 23, 13, 17,
+ax_anim 2, 0, 20, 12, 24, 12, 18,
+ax_anim 2, 0, 20, 13, 23, 13, 17,
+ax_anim 2, 0, 19, 4, 8, 4, 7,
+ax_anim_terminator
+sLatiosAnims_2_3:
+ax_anim 2, 0, 22, -1, 0, -1, 0,
+ax_anim 2, 0, 22, -2, 0, -2, 0,
+ax_anim 6, 0, 23, -4, 0, -4, 0,
+ax_anim 1, 0, 24, -2, 0, -2, 0,
+ax_anim 1, 2, 23, 1, 2, 1, 0,
+ax_anim 1, 0, 24, 4, 4, 4, 0,
+ax_anim 2, 0, 23, 7, 7, 12, 0,
+ax_anim 2, 1, 23, 7, 8, 12, 1,
+ax_anim 2, 0, 23, 7, 7, 12, 0,
+ax_anim 2, 0, 23, 7, 8, 12, 1,
+ax_anim 2, 0, 22, 4, 2, 4, 0,
+ax_anim_terminator
+sLatiosAnims_2_4:
+ax_anim 2, 0, 25, -1, 1, -1, 1,
+ax_anim 2, 0, 25, -2, 2, -2, 2,
+ax_anim 6, 0, 26, -4, 4, -4, 4,
+ax_anim 1, 0, 27, -1, 1, -1, 1,
+ax_anim 1, 2, 26, 3, -1, 6, -5,
+ax_anim 1, 0, 27, 8, -4, 12, -9,
+ax_anim 2, 0, 26, 13, -7, 19, -15,
+ax_anim 2, 1, 26, 14, -6, 20, -14,
+ax_anim 2, 0, 26, 13, -7, 19, -15,
+ax_anim 2, 0, 26, 14, -6, 20, -14,
+ax_anim 2, 0, 25, 5, -3, 8, -7,
+ax_anim_terminator
+sLatiosAnims_2_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 2, 0, 28, 0, 2, 0, 2,
+ax_anim 6, 0, 29, 0, 4, 0, 4,
+ax_anim 1, 0, 30, 0, 2, 0, 1,
+ax_anim 1, 2, 29, 0, 0, 0, -5,
+ax_anim 1, 0, 30, 0, -2, 0, -12,
+ax_anim 2, 0, 29, 0, -6, 0, -16,
+ax_anim 2, 1, 29, 1, -6, 1, -16,
+ax_anim 2, 0, 29, 0, -6, 0, -16,
+ax_anim 2, 0, 29, 1, -6, 1, -16,
+ax_anim 2, 0, 28, 0, -6, 0, -9,
+ax_anim_terminator
+sLatiosAnims_2_6:
+ax_anim 2, 0, 31, 1, 1, 1, 1,
+ax_anim 2, 0, 31, 2, 2, 2, 2,
+ax_anim 6, 0, 32, 4, 4, 4, 4,
+ax_anim 1, 0, 33, 1, 1, 1, 1,
+ax_anim 1, 2, 32, -3, -1, -6, -5,
+ax_anim 1, 0, 33, -8, -4, -12, -9,
+ax_anim 2, 0, 32, -13, -7, -19, -15,
+ax_anim 2, 1, 32, -14, -6, -20, -14,
+ax_anim 2, 0, 32, -13, -7, -19, -15,
+ax_anim 2, 0, 32, -14, -6, -20, -14,
+ax_anim 2, 0, 31, -5, -3, -8, -7,
+ax_anim_terminator
+sLatiosAnims_2_7:
+ax_anim 2, 0, 34, 1, 0, 1, 0,
+ax_anim 2, 0, 34, 2, 0, 2, 0,
+ax_anim 6, 0, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 2, 0, 2, 0,
+ax_anim 1, 2, 35, -1, 2, -1, 0,
+ax_anim 1, 0, 36, -4, 4, -4, 0,
+ax_anim 2, 0, 35, -7, 7, -12, 0,
+ax_anim 2, 1, 35, -7, 8, -12, 1,
+ax_anim 2, 0, 35, -7, 7, -12, 0,
+ax_anim 2, 0, 35, -7, 8, -12, 1,
+ax_anim 2, 0, 34, -4, 2, -4, 0,
+ax_anim_terminator
+sLatiosAnims_2_8:
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 2, 0, 37, 2, -2, 2, -2,
+ax_anim 6, 0, 38, 4, -4, 4, -4,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 38, -4, 7, -4, 6,
+ax_anim 1, 0, 39, -7, 14, -7, 11,
+ax_anim 2, 0, 38, -12, 24, -12, 18,
+ax_anim 2, 1, 38, -13, 23, -13, 17,
+ax_anim 2, 0, 38, -12, 24, -12, 18,
+ax_anim 2, 0, 38, -13, 23, -13, 17,
+ax_anim 2, 0, 37, -4, 8, -4, 7,
+ax_anim_terminator
+.align 2
+sLatiosAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 2, 0, 40, 0, -2, 0, -2,
+ax_anim 6, 0, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, 4, 0, 2,
+ax_anim 1, 0, 42, 0, 10, 0, 6,
+ax_anim 2, 0, 41, 0, 20, 0, 11,
+ax_anim 2, 1, 41, 1, 20, 1, 11,
+ax_anim 2, 0, 41, 0, 20, 0, 11,
+ax_anim 2, 0, 41, 1, 20, 1, 11,
+ax_anim 2, 0, 40, 0, 6, 0, 6,
+ax_anim_terminator
+sLatiosAnims_3_2:
+ax_anim 2, 0, 43, -1, -1, -1, -1,
+ax_anim 2, 0, 43, -2, -2, -2, -2,
+ax_anim 6, 0, 44, -4, -4, -4, -4,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 4, 7, 4, 6,
+ax_anim 1, 0, 45, 7, 14, 7, 11,
+ax_anim 2, 0, 44, 12, 24, 12, 18,
+ax_anim 2, 1, 44, 13, 23, 13, 17,
+ax_anim 2, 0, 44, 12, 24, 12, 18,
+ax_anim 2, 0, 44, 13, 23, 13, 17,
+ax_anim 2, 0, 43, 4, 8, 4, 7,
+ax_anim_terminator
+sLatiosAnims_3_3:
+ax_anim 2, 0, 46, -1, 0, -1, 0,
+ax_anim 2, 0, 46, -2, 0, -2, 0,
+ax_anim 6, 0, 47, -4, 0, -4, 0,
+ax_anim 1, 0, 48, -2, 0, -2, 0,
+ax_anim 1, 2, 47, 1, 2, 1, 0,
+ax_anim 1, 0, 48, 4, 4, 4, 0,
+ax_anim 2, 0, 47, 7, 7, 12, 0,
+ax_anim 2, 1, 47, 7, 8, 12, 1,
+ax_anim 2, 0, 47, 7, 7, 12, 0,
+ax_anim 2, 0, 47, 7, 8, 12, 1,
+ax_anim 2, 0, 46, 4, 2, 4, 0,
+ax_anim_terminator
+sLatiosAnims_3_4:
+ax_anim 2, 0, 49, -1, 1, -1, 1,
+ax_anim 2, 0, 49, -2, 2, -2, 2,
+ax_anim 6, 0, 50, -4, 4, -4, 4,
+ax_anim 1, 0, 51, -1, 1, -1, 1,
+ax_anim 1, 2, 50, 3, -1, 6, -5,
+ax_anim 1, 0, 51, 8, -4, 12, -9,
+ax_anim 2, 0, 50, 13, -7, 19, -15,
+ax_anim 2, 1, 50, 14, -6, 20, -14,
+ax_anim 2, 0, 50, 13, -7, 19, -15,
+ax_anim 2, 0, 50, 14, -6, 20, -14,
+ax_anim 2, 0, 49, 5, -3, 8, -7,
+ax_anim_terminator
+sLatiosAnims_3_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 2, 0, 52, 0, 2, 0, 2,
+ax_anim 6, 0, 53, 0, 4, 0, 4,
+ax_anim 1, 0, 54, 0, 2, 0, 1,
+ax_anim 1, 2, 53, 0, 0, 0, -5,
+ax_anim 1, 0, 54, 0, -2, 0, -12,
+ax_anim 2, 0, 53, 0, -6, 0, -16,
+ax_anim 2, 1, 53, 1, -6, 1, -16,
+ax_anim 2, 0, 53, 0, -6, 0, -16,
+ax_anim 2, 0, 53, 1, -6, 1, -16,
+ax_anim 2, 0, 52, 0, -6, 0, -9,
+ax_anim_terminator
+sLatiosAnims_3_6:
+ax_anim 2, 0, 55, 1, 1, 1, 1,
+ax_anim 2, 0, 55, 2, 2, 2, 2,
+ax_anim 6, 0, 56, 4, 4, 4, 4,
+ax_anim 1, 0, 57, 1, 1, 1, 1,
+ax_anim 1, 2, 56, -3, -1, -6, -5,
+ax_anim 1, 0, 57, -8, -4, -12, -9,
+ax_anim 2, 0, 56, -13, -7, -19, -15,
+ax_anim 2, 1, 56, -14, -6, -20, -14,
+ax_anim 2, 0, 56, -13, -7, -19, -15,
+ax_anim 2, 0, 56, -14, -6, -20, -14,
+ax_anim 2, 0, 55, -5, -3, -8, -7,
+ax_anim_terminator
+sLatiosAnims_3_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 2, 0, 58, 2, 0, 2, 0,
+ax_anim 6, 0, 59, 4, 0, 4, 0,
+ax_anim 1, 0, 60, 2, 0, 2, 0,
+ax_anim 1, 2, 59, -1, 2, -1, 0,
+ax_anim 1, 0, 60, -4, 4, -4, 0,
+ax_anim 2, 0, 59, -7, 7, -12, 0,
+ax_anim 2, 1, 59, -7, 8, -12, 1,
+ax_anim 2, 0, 59, -7, 7, -12, 0,
+ax_anim 2, 0, 59, -7, 8, -12, 1,
+ax_anim 2, 0, 58, -4, 2, -4, 0,
+ax_anim_terminator
+sLatiosAnims_3_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 2, 0, 61, 2, -2, 2, -2,
+ax_anim 6, 0, 62, 4, -4, 4, -4,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 62, -4, 7, -4, 6,
+ax_anim 1, 0, 63, -7, 14, -7, 11,
+ax_anim 2, 0, 62, -12, 24, -12, 18,
+ax_anim 2, 1, 62, -13, 23, -13, 17,
+ax_anim 2, 0, 62, -12, 24, -12, 18,
+ax_anim 2, 0, 62, -13, 23, -13, 17,
+ax_anim 2, 0, 61, -4, 8, -4, 7,
+ax_anim_terminator
+.align 2
+sLatiosAnims_4_1:
+ax_anim 2, 0, 65, 0, -2, 0, -2,
+ax_anim 6, 2, 65, 0, -3, 0, -3,
+ax_anim 1, 0, 65, 0, 2, 0, 2,
+ax_anim 1, 0, 66, 0, 8, 0, 8,
+ax_anim 2, 1, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 1, 10, 1, 10,
+ax_anim 2, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 1, 10, 1, 10,
+ax_anim 2, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 1, 10, 1, 10,
+ax_anim 2, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 2, 0, 2,
+ax_anim_terminator
+sLatiosAnims_4_2:
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim 6, 2, 68, -3, -3, -3, -3,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 69, 4, 4, 4, 4,
+ax_anim 2, 1, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 69, 9, 7, 9, 7,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 69, 9, 7, 9, 7,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 69, 9, 7, 9, 7,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim 2, 0, 67, 2, 2, 2, 2,
+ax_anim_terminator
+sLatiosAnims_4_3:
+ax_anim 2, 0, 71, -2, 0, -2, 0,
+ax_anim 6, 2, 71, -3, 0, -3, 0,
+ax_anim 1, 0, 71, 0, -2, 0, 0,
+ax_anim 1, 0, 72, 4, -1, 2, 0,
+ax_anim 2, 1, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 72, 8, 1, 6, 1,
+ax_anim 2, 0, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 72, 8, 1, 6, 1,
+ax_anim 2, 0, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 72, 8, 1, 6, 1,
+ax_anim 2, 0, 72, 8, 0, 6, 0,
+ax_anim 2, 0, 70, 2, 0, 2, 0,
+ax_anim_terminator
+sLatiosAnims_4_4:
+ax_anim 2, 0, 74, -2, 2, -2, 2,
+ax_anim 6, 2, 74, -3, 3, -3, 3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 2, -2, 2, -2,
+ax_anim 2, 1, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, 7, -5, 7, -5,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, 7, -5, 7, -5,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, 7, -5, 7, -5,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 73, 3, -3, 3, -3,
+ax_anim_terminator
+sLatiosAnims_4_5:
+ax_anim 2, 0, 77, 0, 2, 0, 2,
+ax_anim 6, 2, 77, 0, 3, 0, 3,
+ax_anim 1, 0, 77, 0, -2, 0, -2,
+ax_anim 1, 0, 78, 0, -4, 0, -4,
+ax_anim 2, 1, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 78, 1, -6, 1, -6,
+ax_anim 2, 0, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 78, 1, -6, 1, -6,
+ax_anim 2, 0, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 78, 1, -6, 1, -6,
+ax_anim 2, 0, 78, 0, -6, 0, -6,
+ax_anim 2, 0, 76, 0, -2, 0, -2,
+ax_anim_terminator
+sLatiosAnims_4_6:
+ax_anim 2, 0, 80, 2, 2, 2, 2,
+ax_anim 6, 2, 80, 3, 3, 3, 3,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 81, -2, -2, -2, -2,
+ax_anim 2, 1, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, -7, -5, -7, -5,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, -7, -5, -7, -5,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, -7, -5, -7, -5,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 79, -3, -3, -3, -3,
+ax_anim_terminator
+sLatiosAnims_4_7:
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 6, 2, 83, 3, 0, 3, 0,
+ax_anim 1, 0, 83, 0, -2, 0, 0,
+ax_anim 1, 0, 84, -4, -1, -2, 0,
+ax_anim 2, 1, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 84, -8, 1, -6, 1,
+ax_anim 2, 0, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 84, -8, 1, -6, 1,
+ax_anim 2, 0, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 84, -8, 1, -6, 1,
+ax_anim 2, 0, 84, -8, 0, -6, 0,
+ax_anim 2, 0, 82, -2, 0, -2, 0,
+ax_anim_terminator
+sLatiosAnims_4_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 6, 2, 86, 3, -3, 3, -3,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, -4, 4, -4, 4,
+ax_anim 2, 1, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -9, 7, -9, 7,
+ax_anim 2, 0, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -9, 7, -9, 7,
+ax_anim 2, 0, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 87, -9, 7, -9, 7,
+ax_anim 2, 0, 87, -8, 8, -8, 8,
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sLatiosAnims_5_1:
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -6, 0, 0,
+ax_anim 6, 0, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 90, -1, -7, -1, 0,
+ax_anim 2, 2, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 90, -1, -7, -1, 0,
+ax_anim 2, 0, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 90, -1, -7, -1, 0,
+ax_anim 2, 0, 90, 0, -7, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim_terminator
+sLatiosAnims_5_2:
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -6, 0, 0,
+ax_anim 6, 0, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 93, -1, -6, -1, 1,
+ax_anim 2, 2, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 93, -1, -6, -1, 1,
+ax_anim 2, 0, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 93, -1, -6, -1, 1,
+ax_anim 2, 0, 93, 0, -7, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiosAnims_5_3:
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -6, 0, 0,
+ax_anim 6, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, -1,
+ax_anim 2, 2, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, -1,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, -1,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiosAnims_5_4:
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -6, 0, 0,
+ax_anim 6, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 99, -1, -8, -1, -1,
+ax_anim 2, 2, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 99, -1, -8, -1, -1,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 99, -1, -8, -1, -1,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiosAnims_5_5:
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -6, 0, 0,
+ax_anim 6, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 102, -1, -7, -1, 0,
+ax_anim 2, 2, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 102, -1, -7, -1, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 102, -1, -7, -1, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim_terminator
+sLatiosAnims_5_6:
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 6, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 1, -8, 1, -1,
+ax_anim 2, 2, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 1, -8, 1, -1,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 105, 1, -8, 1, -1,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiosAnims_5_7:
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -6, 0, 0,
+ax_anim 6, 0, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, -1,
+ax_anim 2, 2, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, -1,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, -1,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim_terminator
+sLatiosAnims_5_8:
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 6, 0, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 111, 1, -6, 1, 1,
+ax_anim 2, 2, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 111, 1, -6, 1, 1,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 111, 1, -6, 1, 1,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sLatiosAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sLatiosAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sLatiosAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sLatiosAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sLatiosAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sLatiosAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sLatiosAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLatiosAnims_8_1:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, -2, 0, 0,
+ax_anim 8, 0, 122, 0, -2, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_8_2:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, -1, 0, 0,
+ax_anim 8, 0, 129, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -1, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_8_3:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, -2, 0, 0,
+ax_anim 8, 0, 128, 0, -2, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_8_4:
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim 8, 0, 127, 0, -2, 0, 0,
+ax_anim 8, 0, 127, 0, -2, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_8_5:
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim 8, 0, 126, 0, -2, 0, 0,
+ax_anim 8, 0, 126, 0, -2, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_8_6:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 125, 0, -1, 0, 0,
+ax_anim 8, 0, 125, 0, -2, 0, 0,
+ax_anim 8, 0, 125, 0, -2, 0, 0,
+ax_anim 8, 0, 125, 0, -1, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_8_7:
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_8_8:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, -1, 0, 0,
+ax_anim 8, 0, 123, 0, -2, 0, 0,
+ax_anim 8, 0, 123, 0, -2, 0, 0,
+ax_anim 8, 0, 123, 0, -1, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 9, 4, 9, 4,
+ax_anim 2, 0, 132, 14, 12, 14, 12,
+ax_anim 2, 0, 133, 12, 19, 12, 19,
+ax_anim 3, 0, 134, 0, 23, 0, 23,
+ax_anim 2, 3, 135, -12, 19, -12, 19,
+ax_anim 2, 0, 136, -14, 12, -14, 12,
+ax_anim 1, 0, 137, -9, 4, -9, 4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 12, -2, 12, -2,
+ax_anim 2, 0, 131, 23, 3, 23, 3,
+ax_anim 2, 0, 132, 27, 14, 27, 14,
+ax_anim 3, 0, 133, 22, 21, 22, 21,
+ax_anim 2, 3, 134, 8, 22, 8, 22,
+ax_anim 2, 0, 135, -5, 19, -5, 19,
+ax_anim 1, 0, 136, -6, 9, -6, 9,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 4, -8, 4, -8,
+ax_anim 2, 0, 130, 15, -11, 15, -11,
+ax_anim 2, 0, 131, 25, -7, 25, -7,
+ax_anim 3, 0, 132, 28, 2, 28, 2,
+ax_anim 2, 3, 133, 23, 8, 23, 8,
+ax_anim 2, 0, 134, 13, 11, 13, 11,
+ax_anim 1, 0, 135, 3, 7, 3, 7,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 2, -16, 2, -16,
+ax_anim 2, 0, 130, 15, -21, 15, -21,
+ax_anim 3, 0, 131, 28, -19, 28, -19,
+ax_anim 2, 3, 132, 31, -9, 31, -9,
+ax_anim 2, 0, 133, 26, -1, 26, -1,
+ax_anim 1, 0, 134, 11, 1, 11, 1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -10, -4, -7, -4,
+ax_anim 2, 0, 136, -11, -13, -8, -10,
+ax_anim 2, 0, 137, -7, -20, -5, -16,
+ax_anim 3, 0, 130, 0, -24, 0, -18,
+ax_anim 2, 3, 131, 7, -20, 5, -16,
+ax_anim 2, 0, 132, 11, -13, 8, -10,
+ax_anim 1, 0, 133, 10, -4, 7, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -8, 1, -8,
+ax_anim 2, 0, 131, -2, -16, -2, -16,
+ax_anim 2, 0, 130, -15, -21, -15, -21,
+ax_anim 3, 0, 137, -28, -19, -28, -19,
+ax_anim 2, 3, 136, -31, -9, -31, -9,
+ax_anim 2, 0, 135, -26, -1, -26, -1,
+ax_anim 1, 0, 134, -11, 1, -11, 1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -4, -8, -4, -8,
+ax_anim 2, 0, 130, -15, -11, -15, -11,
+ax_anim 2, 0, 137, -25, -7, -25, -7,
+ax_anim 3, 0, 136, -28, 2, -28, 2,
+ax_anim 2, 3, 135, -23, 8, -23, 8,
+ax_anim 2, 0, 134, -13, 11, -13, 11,
+ax_anim 1, 0, 133, -3, 7, -3, 7,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -12, -2, -12, -2,
+ax_anim 2, 0, 137, -23, 3, -23, 3,
+ax_anim 2, 0, 136, -27, 14, -27, 14,
+ax_anim 3, 0, 135, -22, 21, -22, 21,
+ax_anim 2, 3, 134, -8, 22, -8, 22,
+ax_anim 2, 0, 133, 5, 19, 5, 19,
+ax_anim 1, 0, 132, 6, 9, 6, 9,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -7, 0, 0,
+ax_anim 2, 0, 146, 0, -13, 0, 0,
+ax_anim 3, 0, 146, 0, -17, 0, 0,
+ax_anim 4, 0, 146, 0, -18, 0, 0,
+ax_anim 4, 0, 147, 0, -20, 0, 0,
+ax_anim 3, 0, 148, 0, -18, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 1, 0, 148, 0, -6, 0, 0,
+ax_anim 2, 2, 148, 0, 9, 0, 0,
+ax_anim_terminator
+sLatiosAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -22, 0, 0,
+ax_anim 3, 0, 151, 0, -22, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 2, 151, 0, 5, 0, 0,
+ax_anim_terminator
+sLatiosAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -22, 0, 0,
+ax_anim 3, 0, 154, 0, -22, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 3, 0, 0,
+ax_anim_terminator
+sLatiosAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -21, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 4, 0, 0,
+ax_anim_terminator
+sLatiosAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 2, 0, 0,
+ax_anim_terminator
+sLatiosAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -21, 0, 0,
+ax_anim 2, 0, 163, 0, -17, 0, 0,
+ax_anim 1, 0, 163, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 3, 0, 0,
+ax_anim_terminator
+sLatiosAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 166, 0, -22, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 3, 0, 0,
+ax_anim_terminator
+sLatiosAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -22, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 2, 169, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_14_1:
+ax_anim 12, 0, 186, 0, 0, 0, 0,
+ax_anim 12, 0, 186, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_15_1:
+ax_anim 12, 0, 187, 0, 0, 0, 0,
+ax_anim 12, 0, 187, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_16_1:
+ax_anim 12, 0, 188, 0, 0, 0, 0,
+ax_anim 12, 0, 188, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_17_1:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_17_2:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_17_3:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_17_4:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_17_5:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_17_6:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_17_7:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_17_8:
+ax_anim 24, 0, 189, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_18_1:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_18_2:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_18_3:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_18_4:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_18_5:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_18_6:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_18_7:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_18_8:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 1, 0, 0,
+ax_anim 2, 0, 192, 0, 2, 0, 0,
+ax_anim 2, 0, 192, 0, 3, 0, 0,
+ax_anim 2, 0, 192, 0, 5, 0, 0,
+ax_anim 2, 0, 192, 0, 7, 0, 0,
+ax_anim 2, 0, 192, 0, 10, 0, 0,
+ax_anim 4, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -2, 0, 0,
+ax_anim 6, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_19_1:
+ax_anim 20, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 14, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 6, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 12, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 3, 0, 194, 0, 0, 0, 0,
+ax_anim 3, 0, 198, 0, 0, 0, 0,
+ax_anim 16, 0, 196, 0, 0, 0, 0,
+ax_anim 4, 0, 198, 0, 0, 0, 0,
+ax_anim 20, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_20_1:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 1, 0, 0,
+ax_anim 1, 0, 201, 1, 1, 1, 0,
+ax_anim 2, 0, 201, 0, 1, 0, 0,
+ax_anim 1, 0, 201, 1, 1, 1, 0,
+ax_anim 2, 0, 201, 0, 1, 0, 0,
+ax_anim 1, 0, 201, 1, 1, 1, 0,
+ax_anim 2, 0, 201, 0, 1, 0, 0,
+ax_anim_terminator
+sLatiosAnims_20_2:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_20_3:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_20_4:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_20_5:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_20_6:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_20_7:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_20_8:
+ax_anim 20, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLatiosAnims_21_1:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_21_2:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_21_3:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_21_4:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_21_5:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_21_6:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_21_7:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosAnims_21_8:
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLatiosGfx1:
+.incbin "baserom.gba", 0x15BA2F0, 0x100
+sLatiosSprites1:
+ax_sprite sLatiosGfx1, 0x100
+ax_sprite_terminator
+sLatiosGfx2:
+.incbin "baserom.gba", 0x15BA400, 0x80
+sLatiosSprites2:
+ax_sprite sLatiosGfx2, 0x80
+ax_sprite_terminator
+sLatiosGfx3:
+.incbin "baserom.gba", 0x15BA490, 0x80
+sLatiosSprites3:
+ax_sprite sLatiosGfx3, 0x80
+ax_sprite_terminator
+sLatiosGfx4:
+.incbin "baserom.gba", 0x15BA520, 0x80
+sLatiosSprites4:
+ax_sprite sLatiosGfx4, 0x80
+ax_sprite_terminator
+sLatiosGfx5:
+.incbin "baserom.gba", 0x15BA5B0, 0x100
+sLatiosSprites5:
+ax_sprite sLatiosGfx5, 0x100
+ax_sprite_terminator
+sLatiosGfx6:
+.incbin "baserom.gba", 0x15BA6C0, 0x80
+sLatiosSprites6:
+ax_sprite sLatiosGfx6, 0x80
+ax_sprite_terminator
+sLatiosGfx7:
+.incbin "baserom.gba", 0x15BA750, 0x80
+sLatiosSprites7:
+ax_sprite sLatiosGfx7, 0x80
+ax_sprite_terminator
+sLatiosGfx8:
+.incbin "baserom.gba", 0x15BA7E0, 0x80
+sLatiosSprites8:
+ax_sprite sLatiosGfx8, 0x80
+ax_sprite_terminator
+sLatiosGfx9:
+.incbin "baserom.gba", 0x15BA870, 0x200
+sLatiosSprites9:
+ax_sprite sLatiosGfx9, 0x200
+ax_sprite_terminator
+sLatiosGfx10:
+.incbin "baserom.gba", 0x15BAA80, 0x40
+sLatiosSprites10:
+ax_sprite sLatiosGfx10, 0x40
+ax_sprite_terminator
+sLatiosGfx11:
+.incbin "baserom.gba", 0x15BAAD0, 0x80
+sLatiosSprites11:
+ax_sprite sLatiosGfx11, 0x80
+ax_sprite_terminator
+sLatiosGfx12:
+.incbin "baserom.gba", 0x15BAB60, 0x200
+sLatiosSprites12:
+ax_sprite sLatiosGfx12, 0x200
+ax_sprite_terminator
+sLatiosGfx13:
+.incbin "baserom.gba", 0x15BAD70, 0x40
+sLatiosSprites13:
+ax_sprite sLatiosGfx13, 0x40
+ax_sprite_terminator
+sLatiosGfx14:
+.incbin "baserom.gba", 0x15BADC0, 0x80
+sLatiosSprites14:
+ax_sprite sLatiosGfx14, 0x80
+ax_sprite_terminator
+sLatiosGfx15:
+.incbin "baserom.gba", 0x15BAE50, 0x80
+sLatiosSprites15:
+ax_sprite sLatiosGfx15, 0x80
+ax_sprite_terminator
+sLatiosGfx16:
+.incbin "baserom.gba", 0x15BAEE0, 0x200
+sLatiosSprites16:
+ax_sprite sLatiosGfx16, 0x200
+ax_sprite_terminator
+sLatiosGfx17:
+.incbin "baserom.gba", 0x15BB0F0, 0x40
+sLatiosSprites17:
+ax_sprite sLatiosGfx17, 0x40
+ax_sprite_terminator
+sLatiosGfx18:
+.incbin "baserom.gba", 0x15BB140, 0x80
+sLatiosSprites18:
+ax_sprite sLatiosGfx18, 0x80
+ax_sprite_terminator
+sLatiosGfx19:
+.incbin "baserom.gba", 0x15BB1D0, 0x80
+sLatiosSprites19:
+ax_sprite sLatiosGfx19, 0x80
+ax_sprite_terminator
+sLatiosGfx20:
+.incbin "baserom.gba", 0x15BB260, 0x200
+sLatiosSprites20:
+ax_sprite sLatiosGfx20, 0x200
+ax_sprite_terminator
+sLatiosGfx21:
+.incbin "baserom.gba", 0x15BB470, 0x40
+sLatiosSprites21:
+ax_sprite sLatiosGfx21, 0x40
+ax_sprite_terminator
+sLatiosGfx22:
+.incbin "baserom.gba", 0x15BB4C0, 0x80
+sLatiosSprites22:
+ax_sprite sLatiosGfx22, 0x80
+ax_sprite_terminator
+sLatiosGfx23:
+.incbin "baserom.gba", 0x15BB550, 0x200
+sLatiosSprites23:
+ax_sprite sLatiosGfx23, 0x200
+ax_sprite_terminator
+sLatiosGfx24:
+.incbin "baserom.gba", 0x15BB760, 0x80
+sLatiosSprites24:
+ax_sprite sLatiosGfx24, 0x80
+ax_sprite_terminator
+sLatiosGfx25:
+.incbin "baserom.gba", 0x15BB7F0, 0x40
+sLatiosSprites25:
+ax_sprite sLatiosGfx25, 0x40
+ax_sprite_terminator
+sLatiosGfx26:
+.incbin "baserom.gba", 0x15BB840, 0x20
+sLatiosSprites26:
+ax_sprite sLatiosGfx26, 0x20
+ax_sprite_terminator
+sLatiosGfx27:
+.incbin "baserom.gba", 0x15BB870, 0x200
+sLatiosSprites27:
+ax_sprite sLatiosGfx27, 0x200
+ax_sprite_terminator
+sLatiosGfx28:
+.incbin "baserom.gba", 0x15BBA80, 0x80
+sLatiosSprites28:
+ax_sprite sLatiosGfx28, 0x80
+ax_sprite_terminator
+sLatiosGfx29:
+.incbin "baserom.gba", 0x15BBB10, 0x40
+sLatiosSprites29:
+ax_sprite sLatiosGfx29, 0x40
+ax_sprite_terminator
+sLatiosGfx30:
+.incbin "baserom.gba", 0x15BBB60, 0x20
+sLatiosSprites30:
+ax_sprite sLatiosGfx30, 0x20
+ax_sprite_terminator
+sLatiosGfx31:
+.incbin "baserom.gba", 0x15BBB90, 0x100
+sLatiosSprites31:
+ax_sprite sLatiosGfx31, 0x100
+ax_sprite_terminator
+sLatiosGfx32:
+.incbin "baserom.gba", 0x15BBCA0, 0x80
+sLatiosSprites32:
+ax_sprite sLatiosGfx32, 0x80
+ax_sprite_terminator
+sLatiosGfx33:
+.incbin "baserom.gba", 0x15BBD30, 0x40
+sLatiosSprites33:
+ax_sprite sLatiosGfx33, 0x40
+ax_sprite_terminator
+sLatiosGfx34:
+.incbin "baserom.gba", 0x15BBD80, 0x40
+sLatiosSprites34:
+ax_sprite sLatiosGfx34, 0x40
+ax_sprite_terminator
+sLatiosGfx35:
+.incbin "baserom.gba", 0x15BBDD0, 0x40
+sLatiosSprites35:
+ax_sprite sLatiosGfx35, 0x40
+ax_sprite_terminator
+sLatiosGfx36:
+.incbin "baserom.gba", 0x15BBE20, 0x100
+sLatiosSprites36:
+ax_sprite sLatiosGfx36, 0x100
+ax_sprite_terminator
+sLatiosGfx37:
+.incbin "baserom.gba", 0x15BBF30, 0x80
+sLatiosSprites37:
+ax_sprite sLatiosGfx37, 0x80
+ax_sprite_terminator
+sLatiosGfx38:
+.incbin "baserom.gba", 0x15BBFC0, 0x40
+sLatiosSprites38:
+ax_sprite sLatiosGfx38, 0x40
+ax_sprite_terminator
+sLatiosGfx39:
+.incbin "baserom.gba", 0x15BC010, 0x40
+sLatiosSprites39:
+ax_sprite sLatiosGfx39, 0x40
+ax_sprite_terminator
+sLatiosGfx40:
+.incbin "baserom.gba", 0x15BC060, 0x40
+sLatiosSprites40:
+ax_sprite sLatiosGfx40, 0x40
+ax_sprite_terminator
+sLatiosGfx41:
+.incbin "baserom.gba", 0x15BC0B0, 0x100
+sLatiosSprites41:
+ax_sprite sLatiosGfx41, 0x100
+ax_sprite_terminator
+sLatiosGfx42:
+.incbin "baserom.gba", 0x15BC1C0, 0x80
+sLatiosSprites42:
+ax_sprite sLatiosGfx42, 0x80
+ax_sprite_terminator
+sLatiosGfx43:
+.incbin "baserom.gba", 0x15BC250, 0x40
+sLatiosGfx43_1:
+.incbin "baserom.gba", 0x15BC290, 0x20
+sLatiosSprites43:
+ax_sprite sLatiosGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx43_1, 0x20
+ax_sprite_terminator
+sLatiosGfx44:
+.incbin "baserom.gba", 0x15BC2D0, 0x60
+sLatiosSprites44:
+ax_sprite sLatiosGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLatiosGfx45:
+.incbin "baserom.gba", 0x15BC348, 0x40
+sLatiosGfx45_1:
+.incbin "baserom.gba", 0x15BC388, 0x160
+sLatiosSprites45:
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLatiosGfx45_1, 0x160
+ax_sprite_terminator
+sLatiosGfx46:
+.incbin "baserom.gba", 0x15BC510, 0x80
+sLatiosSprites46:
+ax_sprite sLatiosGfx46, 0x80
+ax_sprite_terminator
+sLatiosGfx47:
+.incbin "baserom.gba", 0x15BC5A0, 0x80
+sLatiosSprites47:
+ax_sprite sLatiosGfx47, 0x80
+ax_sprite_terminator
+sLatiosGfx48:
+.incbin "baserom.gba", 0x15BC630, 0x80
+sLatiosSprites48:
+ax_sprite sLatiosGfx48, 0x80
+ax_sprite_terminator
+sLatiosGfx49:
+.incbin "baserom.gba", 0x15BC6C0, 0x1C0
+sLatiosGfx49_1:
+.incbin "baserom.gba", 0x15BC880, 0x20
+sLatiosSprites49:
+ax_sprite sLatiosGfx49, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx49_1, 0x20
+ax_sprite_terminator
+sLatiosGfx50:
+.incbin "baserom.gba", 0x15BC8C0, 0x40
+sLatiosSprites50:
+ax_sprite sLatiosGfx50, 0x40
+ax_sprite_terminator
+sLatiosGfx51:
+.incbin "baserom.gba", 0x15BC910, 0x80
+sLatiosSprites51:
+ax_sprite sLatiosGfx51, 0x80
+ax_sprite_terminator
+sLatiosGfx52:
+.incbin "baserom.gba", 0x15BC9A0, 0x40
+sLatiosGfx52_1:
+.incbin "baserom.gba", 0x15BC9E0, 0x100
+sLatiosGfx52_2:
+.incbin "baserom.gba", 0x15BCAE0, 0x60
+sLatiosSprites52:
+ax_sprite sLatiosGfx52, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLatiosGfx52_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx52_2, 0x60
+ax_sprite_terminator
+sLatiosGfx53:
+.incbin "baserom.gba", 0x15BCB70, 0x80
+sLatiosSprites53:
+ax_sprite sLatiosGfx53, 0x80
+ax_sprite_terminator
+sLatiosGfx54:
+.incbin "baserom.gba", 0x15BCC00, 0x20
+sLatiosSprites54:
+ax_sprite sLatiosGfx54, 0x20
+ax_sprite_terminator
+sLatiosGfx55:
+.incbin "baserom.gba", 0x15BCC30, 0x20
+sLatiosSprites55:
+ax_sprite sLatiosGfx55, 0x20
+ax_sprite_terminator
+sLatiosGfx56:
+.incbin "baserom.gba", 0x15BCC60, 0x100
+sLatiosSprites56:
+ax_sprite sLatiosGfx56, 0x100
+ax_sprite_terminator
+sLatiosGfx57:
+.incbin "baserom.gba", 0x15BCD70, 0x80
+sLatiosSprites57:
+ax_sprite sLatiosGfx57, 0x80
+ax_sprite_terminator
+sLatiosGfx58:
+.incbin "baserom.gba", 0x15BCE00, 0x40
+sLatiosSprites58:
+ax_sprite sLatiosGfx58, 0x40
+ax_sprite_terminator
+sLatiosGfx59:
+.incbin "baserom.gba", 0x15BCE50, 0x40
+sLatiosSprites59:
+ax_sprite sLatiosGfx59, 0x40
+ax_sprite_terminator
+sLatiosGfx60:
+.incbin "baserom.gba", 0x15BCEA0, 0x40
+sLatiosSprites60:
+ax_sprite sLatiosGfx60, 0x40
+ax_sprite_terminator
+sLatiosGfx61:
+.incbin "baserom.gba", 0x15BCEF0, 0x100
+sLatiosSprites61:
+ax_sprite sLatiosGfx61, 0x100
+ax_sprite_terminator
+sLatiosGfx62:
+.incbin "baserom.gba", 0x15BD000, 0x60
+sLatiosSprites62:
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx62, 0x60
+ax_sprite_terminator
+sLatiosGfx63:
+.incbin "baserom.gba", 0x15BD078, 0x40
+sLatiosSprites63:
+ax_sprite sLatiosGfx63, 0x40
+ax_sprite_terminator
+sLatiosGfx64:
+.incbin "baserom.gba", 0x15BD0C8, 0x20
+sLatiosSprites64:
+ax_sprite sLatiosGfx64, 0x20
+ax_sprite_terminator
+sLatiosGfx65:
+.incbin "baserom.gba", 0x15BD0F8, 0x20
+sLatiosSprites65:
+ax_sprite sLatiosGfx65, 0x20
+ax_sprite_terminator
+sLatiosGfx66:
+.incbin "baserom.gba", 0x15BD128, 0x100
+sLatiosSprites66:
+ax_sprite sLatiosGfx66, 0x100
+ax_sprite_terminator
+sLatiosGfx67:
+.incbin "baserom.gba", 0x15BD238, 0x80
+sLatiosSprites67:
+ax_sprite sLatiosGfx67, 0x80
+ax_sprite_terminator
+sLatiosGfx68:
+.incbin "baserom.gba", 0x15BD2C8, 0x20
+sLatiosSprites68:
+ax_sprite sLatiosGfx68, 0x20
+ax_sprite_terminator
+sLatiosGfx69:
+.incbin "baserom.gba", 0x15BD2F8, 0x20
+sLatiosSprites69:
+ax_sprite sLatiosGfx69, 0x20
+ax_sprite_terminator
+sLatiosGfx70:
+.incbin "baserom.gba", 0x15BD328, 0x20
+sLatiosSprites70:
+ax_sprite sLatiosGfx70, 0x20
+ax_sprite_terminator
+sLatiosGfx71:
+.incbin "baserom.gba", 0x15BD358, 0x20
+sLatiosSprites71:
+ax_sprite sLatiosGfx71, 0x20
+ax_sprite_terminator
+sLatiosGfx72:
+.incbin "baserom.gba", 0x15BD388, 0x100
+sLatiosSprites72:
+ax_sprite sLatiosGfx72, 0x100
+ax_sprite_terminator
+sLatiosGfx73:
+.incbin "baserom.gba", 0x15BD498, 0x80
+sLatiosSprites73:
+ax_sprite sLatiosGfx73, 0x80
+ax_sprite_terminator
+sLatiosGfx74:
+.incbin "baserom.gba", 0x15BD528, 0x40
+sLatiosSprites74:
+ax_sprite sLatiosGfx74, 0x40
+ax_sprite_terminator
+sLatiosGfx75:
+.incbin "baserom.gba", 0x15BD578, 0x20
+sLatiosSprites75:
+ax_sprite sLatiosGfx75, 0x20
+ax_sprite_terminator
+sLatiosGfx76:
+.incbin "baserom.gba", 0x15BD5A8, 0x20
+sLatiosSprites76:
+ax_sprite sLatiosGfx76, 0x20
+ax_sprite_terminator
+sLatiosGfx77:
+.incbin "baserom.gba", 0x15BD5D8, 0x60
+sLatiosSprites77:
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx77, 0x60
+ax_sprite_terminator
+sLatiosGfx78:
+.incbin "baserom.gba", 0x15BD650, 0x100
+sLatiosSprites78:
+ax_sprite sLatiosGfx78, 0x100
+ax_sprite_terminator
+sLatiosGfx79:
+.incbin "baserom.gba", 0x15BD760, 0x80
+sLatiosSprites79:
+ax_sprite sLatiosGfx79, 0x80
+ax_sprite_terminator
+sLatiosGfx80:
+.incbin "baserom.gba", 0x15BD7F0, 0x40
+sLatiosSprites80:
+ax_sprite sLatiosGfx80, 0x40
+ax_sprite_terminator
+sLatiosGfx81:
+.incbin "baserom.gba", 0x15BD840, 0x40
+sLatiosSprites81:
+ax_sprite sLatiosGfx81, 0x40
+ax_sprite_terminator
+sLatiosGfx82:
+.incbin "baserom.gba", 0x15BD890, 0x40
+sLatiosSprites82:
+ax_sprite sLatiosGfx82, 0x40
+ax_sprite_terminator
+sLatiosGfx83:
+.incbin "baserom.gba", 0x15BD8E0, 0x80
+sLatiosGfx83_1:
+.incbin "baserom.gba", 0x15BD960, 0x20
+sLatiosGfx83_2:
+.incbin "baserom.gba", 0x15BD980, 0x20
+sLatiosSprites83:
+ax_sprite sLatiosGfx83, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx83_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx83_2, 0x20
+ax_sprite_terminator
+sLatiosGfx84:
+.incbin "baserom.gba", 0x15BD9D0, 0x40
+sLatiosSprites84:
+ax_sprite sLatiosGfx84, 0x40
+ax_sprite_terminator
+sLatiosGfx85:
+.incbin "baserom.gba", 0x15BDA20, 0x20
+sLatiosSprites85:
+ax_sprite sLatiosGfx85, 0x20
+ax_sprite_terminator
+sLatiosGfx86:
+.incbin "baserom.gba", 0x15BDA50, 0x100
+sLatiosSprites86:
+ax_sprite sLatiosGfx86, 0x100
+ax_sprite_terminator
+sLatiosGfx87:
+.incbin "baserom.gba", 0x15BDB60, 0x80
+sLatiosSprites87:
+ax_sprite sLatiosGfx87, 0x80
+ax_sprite_terminator
+sLatiosGfx88:
+.incbin "baserom.gba", 0x15BDBF0, 0x20
+sLatiosSprites88:
+ax_sprite sLatiosGfx88, 0x20
+ax_sprite_terminator
+sLatiosGfx89:
+.incbin "baserom.gba", 0x15BDC20, 0x100
+sLatiosSprites89:
+ax_sprite sLatiosGfx89, 0x100
+ax_sprite_terminator
+sLatiosGfx90:
+.incbin "baserom.gba", 0x15BDD30, 0x80
+sLatiosSprites90:
+ax_sprite sLatiosGfx90, 0x80
+ax_sprite_terminator
+sLatiosGfx91:
+.incbin "baserom.gba", 0x15BDDC0, 0x20
+sLatiosSprites91:
+ax_sprite sLatiosGfx91, 0x20
+ax_sprite_terminator
+sLatiosGfx92:
+.incbin "baserom.gba", 0x15BDDF0, 0x40
+sLatiosSprites92:
+ax_sprite sLatiosGfx92, 0x40
+ax_sprite_terminator
+sLatiosGfx93:
+.incbin "baserom.gba", 0x15BDE40, 0x20
+sLatiosSprites93:
+ax_sprite sLatiosGfx93, 0x20
+ax_sprite_terminator
+sLatiosGfx94:
+.incbin "baserom.gba", 0x15BDE70, 0x20
+sLatiosSprites94:
+ax_sprite sLatiosGfx94, 0x20
+ax_sprite_terminator
+sLatiosGfx95:
+.incbin "baserom.gba", 0x15BDEA0, 0x80
+sLatiosSprites95:
+ax_sprite sLatiosGfx95, 0x80
+ax_sprite_terminator
+sLatiosGfx96:
+.incbin "baserom.gba", 0x15BDF30, 0x100
+sLatiosSprites96:
+ax_sprite sLatiosGfx96, 0x100
+ax_sprite_terminator
+sLatiosGfx97:
+.incbin "baserom.gba", 0x15BE040, 0x80
+sLatiosSprites97:
+ax_sprite sLatiosGfx97, 0x80
+ax_sprite_terminator
+sLatiosGfx98:
+.incbin "baserom.gba", 0x15BE0D0, 0x20
+sLatiosSprites98:
+ax_sprite sLatiosGfx98, 0x20
+ax_sprite_terminator
+sLatiosGfx99:
+.incbin "baserom.gba", 0x15BE100, 0x40
+sLatiosSprites99:
+ax_sprite sLatiosGfx99, 0x40
+ax_sprite_terminator
+sLatiosGfx100:
+.incbin "baserom.gba", 0x15BE150, 0x20
+sLatiosSprites100:
+ax_sprite sLatiosGfx100, 0x20
+ax_sprite_terminator
+sLatiosGfx101:
+.incbin "baserom.gba", 0x15BE180, 0x80
+sLatiosSprites101:
+ax_sprite sLatiosGfx101, 0x80
+ax_sprite_terminator
+sLatiosGfx102:
+.incbin "baserom.gba", 0x15BE210, 0x100
+sLatiosSprites102:
+ax_sprite sLatiosGfx102, 0x100
+ax_sprite_terminator
+sLatiosGfx103:
+.incbin "baserom.gba", 0x15BE320, 0x40
+sLatiosSprites103:
+ax_sprite sLatiosGfx103, 0x40
+ax_sprite_terminator
+sLatiosGfx104:
+.incbin "baserom.gba", 0x15BE370, 0x80
+sLatiosSprites104:
+ax_sprite sLatiosGfx104, 0x80
+ax_sprite_terminator
+sLatiosGfx105:
+.incbin "baserom.gba", 0x15BE400, 0x40
+sLatiosSprites105:
+ax_sprite sLatiosGfx105, 0x40
+ax_sprite_terminator
+sLatiosGfx106:
+.incbin "baserom.gba", 0x15BE450, 0x40
+sLatiosSprites106:
+ax_sprite sLatiosGfx106, 0x40
+ax_sprite_terminator
+sLatiosGfx107:
+.incbin "baserom.gba", 0x15BE4A0, 0x40
+sLatiosSprites107:
+ax_sprite sLatiosGfx107, 0x40
+ax_sprite_terminator
+sLatiosGfx108:
+.incbin "baserom.gba", 0x15BE4F0, 0x20
+sLatiosSprites108:
+ax_sprite sLatiosGfx108, 0x20
+ax_sprite_terminator
+sLatiosGfx109:
+.incbin "baserom.gba", 0x15BE520, 0x100
+sLatiosSprites109:
+ax_sprite sLatiosGfx109, 0x100
+ax_sprite_terminator
+sLatiosGfx110:
+.incbin "baserom.gba", 0x15BE630, 0x40
+sLatiosSprites110:
+ax_sprite sLatiosGfx110, 0x40
+ax_sprite_terminator
+sLatiosGfx111:
+.incbin "baserom.gba", 0x15BE680, 0x40
+sLatiosSprites111:
+ax_sprite sLatiosGfx111, 0x40
+ax_sprite_terminator
+sLatiosGfx112:
+.incbin "baserom.gba", 0x15BE6D0, 0x20
+sLatiosSprites112:
+ax_sprite sLatiosGfx112, 0x20
+ax_sprite_terminator
+sLatiosGfx113:
+.incbin "baserom.gba", 0x15BE700, 0x20
+sLatiosSprites113:
+ax_sprite sLatiosGfx113, 0x20
+ax_sprite_terminator
+sLatiosGfx114:
+.incbin "baserom.gba", 0x15BE730, 0x20
+sLatiosSprites114:
+ax_sprite sLatiosGfx114, 0x20
+ax_sprite_terminator
+sLatiosGfx115:
+.incbin "baserom.gba", 0x15BE760, 0x20
+sLatiosSprites115:
+ax_sprite sLatiosGfx115, 0x20
+ax_sprite_terminator
+sLatiosGfx116:
+.incbin "baserom.gba", 0x15BE790, 0x40
+sLatiosSprites116:
+ax_sprite sLatiosGfx116, 0x40
+ax_sprite_terminator
+sLatiosGfx117:
+.incbin "baserom.gba", 0x15BE7E0, 0x40
+sLatiosGfx117_1:
+.incbin "baserom.gba", 0x15BE820, 0x80
+sLatiosSprites117:
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx117, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx117_1, 0x80
+ax_sprite_terminator
+sLatiosGfx118:
+.incbin "baserom.gba", 0x15BE8C8, 0x80
+sLatiosSprites118:
+ax_sprite sLatiosGfx118, 0x80
+ax_sprite_terminator
+sLatiosGfx119:
+.incbin "baserom.gba", 0x15BE958, 0x80
+sLatiosSprites119:
+ax_sprite sLatiosGfx119, 0x80
+ax_sprite_terminator
+sLatiosGfx120:
+.incbin "baserom.gba", 0x15BE9E8, 0x20
+sLatiosSprites120:
+ax_sprite sLatiosGfx120, 0x20
+ax_sprite_terminator
+sLatiosGfx121:
+.incbin "baserom.gba", 0x15BEA18, 0x20
+sLatiosSprites121:
+ax_sprite sLatiosGfx121, 0x20
+ax_sprite_terminator
+sLatiosGfx122:
+.incbin "baserom.gba", 0x15BEA48, 0x40
+sLatiosSprites122:
+ax_sprite sLatiosGfx122, 0x40
+ax_sprite_terminator
+sLatiosGfx123:
+.incbin "baserom.gba", 0x15BEA98, 0x100
+sLatiosGfx123_1:
+.incbin "baserom.gba", 0x15BEB98, 0x60
+sLatiosGfx123_2:
+.incbin "baserom.gba", 0x15BEBF8, 0x60
+sLatiosSprites123:
+ax_sprite sLatiosGfx123, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx123_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx123_2, 0x60
+ax_sprite_terminator
+sLatiosGfx124:
+.incbin "baserom.gba", 0x15BEC88, 0x60
+sLatiosSprites124:
+ax_sprite sLatiosGfx124, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLatiosGfx125:
+.incbin "baserom.gba", 0x15BED00, 0x40
+sLatiosSprites125:
+ax_sprite sLatiosGfx125, 0x40
+ax_sprite_terminator
+sLatiosGfx126:
+.incbin "baserom.gba", 0x15BED50, 0x40
+sLatiosGfx126_1:
+.incbin "baserom.gba", 0x15BED90, 0x100
+sLatiosGfx126_2:
+.incbin "baserom.gba", 0x15BEE90, 0x60
+sLatiosSprites126:
+ax_sprite sLatiosGfx126, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLatiosGfx126_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx126_2, 0x60
+ax_sprite_terminator
+sLatiosGfx127:
+.incbin "baserom.gba", 0x15BEF20, 0x20
+sLatiosSprites127:
+ax_sprite sLatiosGfx127, 0x20
+ax_sprite_terminator
+sLatiosGfx128:
+.incbin "baserom.gba", 0x15BEF50, 0x40
+sLatiosSprites128:
+ax_sprite sLatiosGfx128, 0x40
+ax_sprite_terminator
+sLatiosGfx129:
+.incbin "baserom.gba", 0x15BEFA0, 0x100
+sLatiosSprites129:
+ax_sprite sLatiosGfx129, 0x100
+ax_sprite_terminator
+sLatiosGfx130:
+.incbin "baserom.gba", 0x15BF0B0, 0x80
+sLatiosSprites130:
+ax_sprite sLatiosGfx130, 0x80
+ax_sprite_terminator
+sLatiosGfx131:
+.incbin "baserom.gba", 0x15BF140, 0x40
+sLatiosSprites131:
+ax_sprite sLatiosGfx131, 0x40
+ax_sprite_terminator
+sLatiosGfx132:
+.incbin "baserom.gba", 0x15BF190, 0x20
+sLatiosSprites132:
+ax_sprite sLatiosGfx132, 0x20
+ax_sprite_terminator
+sLatiosGfx133:
+.incbin "baserom.gba", 0x15BF1C0, 0x20
+sLatiosSprites133:
+ax_sprite sLatiosGfx133, 0x20
+ax_sprite_terminator
+sLatiosGfx134:
+.incbin "baserom.gba", 0x15BF1F0, 0x20
+sLatiosGfx134_1:
+.incbin "baserom.gba", 0x15BF210, 0x40
+sLatiosSprites134:
+ax_sprite sLatiosGfx134, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx134_1, 0x40
+ax_sprite_terminator
+sLatiosGfx135:
+.incbin "baserom.gba", 0x15BF270, 0x100
+sLatiosSprites135:
+ax_sprite sLatiosGfx135, 0x100
+ax_sprite_terminator
+sLatiosGfx136:
+.incbin "baserom.gba", 0x15BF380, 0x80
+sLatiosSprites136:
+ax_sprite sLatiosGfx136, 0x80
+ax_sprite_terminator
+sLatiosGfx137:
+.incbin "baserom.gba", 0x15BF410, 0x40
+sLatiosSprites137:
+ax_sprite sLatiosGfx137, 0x40
+ax_sprite_terminator
+sLatiosGfx138:
+.incbin "baserom.gba", 0x15BF460, 0x20
+sLatiosSprites138:
+ax_sprite sLatiosGfx138, 0x20
+ax_sprite_terminator
+sLatiosGfx139:
+.incbin "baserom.gba", 0x15BF490, 0x20
+sLatiosSprites139:
+ax_sprite sLatiosGfx139, 0x20
+ax_sprite_terminator
+sLatiosGfx140:
+.incbin "baserom.gba", 0x15BF4C0, 0x80
+sLatiosSprites140:
+ax_sprite sLatiosGfx140, 0x80
+ax_sprite_terminator
+sLatiosGfx141:
+.incbin "baserom.gba", 0x15BF550, 0x40
+sLatiosGfx141_1:
+.incbin "baserom.gba", 0x15BF590, 0x40
+sLatiosGfx141_2:
+.incbin "baserom.gba", 0x15BF5D0, 0xE0
+sLatiosSprites141:
+ax_sprite 0, 0x40
+ax_sprite sLatiosGfx141, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLatiosGfx141_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLatiosGfx141_2, 0xe0
+ax_sprite_terminator
+sLatiosGfx142:
+.incbin "baserom.gba", 0x15BF6E8, 0x80
+sLatiosGfx142_1:
+.incbin "baserom.gba", 0x15BF768, 0x40
+sLatiosSprites142:
+ax_sprite sLatiosGfx142, 0x80
+ax_sprite 0, 0x40
+ax_sprite sLatiosGfx142_1, 0x40
+ax_sprite_terminator
+sLatiosGfx143:
+.incbin "baserom.gba", 0x15BF7C8, 0x20
+sLatiosSprites143:
+ax_sprite sLatiosGfx143, 0x20
+ax_sprite_terminator
+sLatiosGfx144:
+.incbin "baserom.gba", 0x15BF7F8, 0x80
+sLatiosSprites144:
+ax_sprite sLatiosGfx144, 0x80
+ax_sprite_terminator
+sLatiosGfx145:
+.incbin "baserom.gba", 0x15BF888, 0x200
+sLatiosSprites145:
+ax_sprite sLatiosGfx145, 0x200
+ax_sprite_terminator
+sLatiosGfx146:
+.incbin "baserom.gba", 0x15BFA98, 0x100
+sLatiosSprites146:
+ax_sprite sLatiosGfx146, 0x100
+ax_sprite_terminator
+sLatiosGfx147:
+.incbin "baserom.gba", 0x15BFBA8, 0x200
+sLatiosSprites147:
+ax_sprite sLatiosGfx147, 0x200
+ax_sprite_terminator
+sLatiosGfx148:
+.incbin "baserom.gba", 0x15BFDB8, 0x100
+sLatiosSprites148:
+ax_sprite sLatiosGfx148, 0x100
+ax_sprite_terminator
+sLatiosGfx149:
+.incbin "baserom.gba", 0x15BFEC8, 0x40
+sLatiosSprites149:
+ax_sprite sLatiosGfx149, 0x40
+ax_sprite_terminator
+sLatiosGfx150:
+.incbin "baserom.gba", 0x15BFF18, 0x40
+sLatiosSprites150:
+ax_sprite sLatiosGfx150, 0x40
+ax_sprite_terminator
+sLatiosGfx151:
+.incbin "baserom.gba", 0x15BFF68, 0x80
+sLatiosSprites151:
+ax_sprite sLatiosGfx151, 0x80
+ax_sprite_terminator
+sLatiosGfx152:
+.incbin "baserom.gba", 0x15BFFF8, 0x200
+sLatiosSprites152:
+ax_sprite sLatiosGfx152, 0x200
+ax_sprite_terminator
+sLatiosGfx153:
+.incbin "baserom.gba", 0x15C0208, 0x200
+sLatiosSprites153:
+ax_sprite sLatiosGfx153, 0x200
+ax_sprite_terminator
+sLatiosGfx154:
+.incbin "baserom.gba", 0x15C0418, 0x40
+sLatiosSprites154:
+ax_sprite sLatiosGfx154, 0x40
+ax_sprite_terminator
+sLatiosGfx155:
+.incbin "baserom.gba", 0x15C0468, 0x80
+sLatiosSprites155:
+ax_sprite sLatiosGfx155, 0x80
+ax_sprite_terminator
+sLatiosGfx156:
+.incbin "baserom.gba", 0x15C04F8, 0x40
+sLatiosSprites156:
+ax_sprite sLatiosGfx156, 0x40
+ax_sprite_terminator
+sLatiosGfx157:
+.incbin "baserom.gba", 0x15C0548, 0x80
+sLatiosSprites157:
+ax_sprite sLatiosGfx157, 0x80
+ax_sprite_terminator
+sLatiosGfx158:
+.incbin "baserom.gba", 0x15C05D8, 0x20
+sLatiosSprites158:
+ax_sprite sLatiosGfx158, 0x20
+ax_sprite_terminator
+sLatiosGfx159:
+.incbin "baserom.gba", 0x15C0608, 0x100
+sLatiosSprites159:
+ax_sprite sLatiosGfx159, 0x100
+ax_sprite_terminator
+sLatiosGfx160:
+.incbin "baserom.gba", 0x15C0718, 0x200
+sLatiosSprites160:
+ax_sprite sLatiosGfx160, 0x200
+ax_sprite_terminator
+sLatiosGfx161:
+.incbin "baserom.gba", 0x15C0928, 0x40
+sLatiosSprites161:
+ax_sprite sLatiosGfx161, 0x40
+ax_sprite_terminator
+sLatiosGfx162:
+.incbin "baserom.gba", 0x15C0978, 0x20
+sLatiosSprites162:
+ax_sprite sLatiosGfx162, 0x20
+ax_sprite_terminator
+sLatiosGfx163:
+.incbin "baserom.gba", 0x15C09A8, 0x40
+sLatiosSprites163:
+ax_sprite sLatiosGfx163, 0x40
+ax_sprite_terminator
+sLatiosGfx164:
+.incbin "baserom.gba", 0x15C09F8, 0x80
+sLatiosSprites164:
+ax_sprite sLatiosGfx164, 0x80
+ax_sprite_terminator
+sLatiosGfx165:
+.incbin "baserom.gba", 0x15C0A88, 0x200
+sLatiosSprites165:
+ax_sprite sLatiosGfx165, 0x200
+ax_sprite_terminator
+sLatiosGfx166:
+.incbin "baserom.gba", 0x15C0C98, 0x20
+sLatiosSprites166:
+ax_sprite sLatiosGfx166, 0x20
+ax_sprite_terminator
+sLatiosGfx167:
+.incbin "baserom.gba", 0x15C0CC8, 0x100
+sLatiosSprites167:
+ax_sprite sLatiosGfx167, 0x100
+ax_sprite_terminator
+sLatiosGfx168:
+.incbin "baserom.gba", 0x15C0DD8, 0x200
+sLatiosSprites168:
+ax_sprite sLatiosGfx168, 0x200
+ax_sprite_terminator
+sLatiosGfx169:
+.incbin "baserom.gba", 0x15C0FE8, 0x40
+sLatiosSprites169:
+ax_sprite sLatiosGfx169, 0x40
+ax_sprite_terminator
+sLatiosGfx170:
+.incbin "baserom.gba", 0x15C1038, 0x200
+sLatiosSprites170:
+ax_sprite sLatiosGfx170, 0x200
+ax_sprite_terminator
+sLatiosGfx171:
+.incbin "baserom.gba", 0x15C1248, 0x40
+sLatiosSprites171:
+ax_sprite sLatiosGfx171, 0x40
+ax_sprite_terminator
+sLatiosGfx172:
+.incbin "baserom.gba", 0x15C1298, 0x100
+sLatiosSprites172:
+ax_sprite sLatiosGfx172, 0x100
+ax_sprite_terminator
+sLatiosGfx173:
+.incbin "baserom.gba", 0x15C13A8, 0x200
+sLatiosSprites173:
+ax_sprite sLatiosGfx173, 0x200
+ax_sprite_terminator
+sLatiosGfx174:
+.incbin "baserom.gba", 0x15C15B8, 0x100
+sLatiosSprites174:
+ax_sprite sLatiosGfx174, 0x100
+ax_sprite_terminator
+sLatiosGfx175:
+.incbin "baserom.gba", 0x15C16C8, 0x80
+sLatiosSprites175:
+ax_sprite sLatiosGfx175, 0x80
+ax_sprite_terminator
+sLatiosGfx176:
+.incbin "baserom.gba", 0x15C1758, 0x80
+sLatiosSprites176:
+ax_sprite sLatiosGfx176, 0x80
+ax_sprite_terminator
+sLatiosGfx177:
+.incbin "baserom.gba", 0x15C17E8, 0x200
+sLatiosSprites177:
+ax_sprite sLatiosGfx177, 0x200
+ax_sprite_terminator
+sLatiosGfx178:
+.incbin "baserom.gba", 0x15C19F8, 0x40
+sLatiosSprites178:
+ax_sprite sLatiosGfx178, 0x40
+ax_sprite_terminator
+sLatiosGfx179:
+.incbin "baserom.gba", 0x15C1A48, 0x20
+sLatiosSprites179:
+ax_sprite sLatiosGfx179, 0x20
+ax_sprite_terminator
+sLatiosGfx180:
+.incbin "baserom.gba", 0x15C1A78, 0x20
+sLatiosSprites180:
+ax_sprite sLatiosGfx180, 0x20
+ax_sprite_terminator
+sLatiosGfx181:
+.incbin "baserom.gba", 0x15C1AA8, 0x100
+sLatiosSprites181:
+ax_sprite sLatiosGfx181, 0x100
+ax_sprite_terminator
+sLatiosGfx182:
+.incbin "baserom.gba", 0x15C1BB8, 0x80
+sLatiosSprites182:
+ax_sprite sLatiosGfx182, 0x80
+ax_sprite_terminator
+sLatiosGfx183:
+.incbin "baserom.gba", 0x15C1C48, 0x80
+sLatiosSprites183:
+ax_sprite sLatiosGfx183, 0x80
+ax_sprite_terminator
+sLatiosGfx184:
+.incbin "baserom.gba", 0x15C1CD8, 0x100
+sLatiosSprites184:
+ax_sprite sLatiosGfx184, 0x100
+ax_sprite_terminator
+sLatiosGfx185:
+.incbin "baserom.gba", 0x15C1DE8, 0x80
+sLatiosSprites185:
+ax_sprite sLatiosGfx185, 0x80
+ax_sprite_terminator
+sLatiosGfx186:
+.incbin "baserom.gba", 0x15C1E78, 0x80
+sLatiosSprites186:
+ax_sprite sLatiosGfx186, 0x80
+ax_sprite_terminator
+sLatiosGfx187:
+.incbin "baserom.gba", 0x15C1F08, 0x200
+sLatiosSprites187:
+ax_sprite sLatiosGfx187, 0x200
+ax_sprite_terminator
+sLatiosGfx188:
+.incbin "baserom.gba", 0x15C2118, 0x40
+sLatiosSprites188:
+ax_sprite sLatiosGfx188, 0x40
+ax_sprite_terminator
+sLatiosGfx189:
+.incbin "baserom.gba", 0x15C2168, 0x20
+sLatiosSprites189:
+ax_sprite sLatiosGfx189, 0x20
+ax_sprite_terminator
+sLatiosGfx190:
+.incbin "baserom.gba", 0x15C2198, 0x200
+sLatiosSprites190:
+ax_sprite sLatiosGfx190, 0x200
+ax_sprite_terminator
+sLatiosGfx191:
+.incbin "baserom.gba", 0x15C23A8, 0x80
+sLatiosSprites191:
+ax_sprite sLatiosGfx191, 0x80
+ax_sprite_terminator
+sLatiosGfx192:
+.incbin "baserom.gba", 0x15C2438, 0x40
+sLatiosSprites192:
+ax_sprite sLatiosGfx192, 0x40
+ax_sprite_terminator
+sLatiosGfx193:
+.incbin "baserom.gba", 0x15C2488, 0x20
+sLatiosSprites193:
+ax_sprite sLatiosGfx193, 0x20
+ax_sprite_terminator
+sLatiosGfx194:
+.incbin "baserom.gba", 0x15C24B8, 0x200
+sLatiosSprites194:
+ax_sprite sLatiosGfx194, 0x200
+ax_sprite_terminator
+sLatiosGfx195:
+.incbin "baserom.gba", 0x15C26C8, 0x40
+sLatiosSprites195:
+ax_sprite sLatiosGfx195, 0x40
+ax_sprite_terminator
+sLatiosGfx196:
+.incbin "baserom.gba", 0x15C2718, 0x20
+sLatiosSprites196:
+ax_sprite sLatiosGfx196, 0x20
+ax_sprite_terminator
+sLatiosGfx197:
+.incbin "baserom.gba", 0x15C2748, 0x200
+sLatiosSprites197:
+ax_sprite sLatiosGfx197, 0x200
+ax_sprite_terminator
+sLatiosGfx198:
+.incbin "baserom.gba", 0x15C2958, 0x40
+sLatiosSprites198:
+ax_sprite sLatiosGfx198, 0x40
+ax_sprite_terminator
+sLatiosGfx199:
+.incbin "baserom.gba", 0x15C29A8, 0x80
+sLatiosSprites199:
+ax_sprite sLatiosGfx199, 0x80
+ax_sprite_terminator
+sLatiosGfx200:
+.incbin "baserom.gba", 0x15C2A38, 0x200
+sLatiosSprites200:
+ax_sprite sLatiosGfx200, 0x200
+ax_sprite_terminator
+sLatiosGfx201:
+.incbin "baserom.gba", 0x15C2C48, 0x80
+sLatiosSprites201:
+ax_sprite sLatiosGfx201, 0x80
+ax_sprite_terminator
+sLatiosGfx202:
+.incbin "baserom.gba", 0x15C2CD8, 0x40
+sLatiosSprites202:
+ax_sprite sLatiosGfx202, 0x40
+ax_sprite_terminator
+sLatiosGfx203:
+.incbin "baserom.gba", 0x15C2D28, 0x200
+sLatiosSprites203:
+ax_sprite sLatiosGfx203, 0x200
+ax_sprite_terminator
+sLatiosGfx204:
+.incbin "baserom.gba", 0x15C2F38, 0x20
+sLatiosSprites204:
+ax_sprite sLatiosGfx204, 0x20
+ax_sprite_terminator
+sLatiosGfx205:
+.incbin "baserom.gba", 0x15C2F68, 0x40
+sLatiosSprites205:
+ax_sprite sLatiosGfx205, 0x40
+ax_sprite_terminator
+sLatiosGfx206:
+.incbin "baserom.gba", 0x15C2FB8, 0x100
+sLatiosSprites206:
+ax_sprite sLatiosGfx206, 0x100
+ax_sprite_terminator
+sLatiosGfx207:
+.incbin "baserom.gba", 0x15C30C8, 0x40
+sLatiosSprites207:
+ax_sprite sLatiosGfx207, 0x40
+ax_sprite_terminator
+sLatiosGfx208:
+.incbin "baserom.gba", 0x15C3118, 0x80
+sLatiosSprites208:
+ax_sprite sLatiosGfx208, 0x80
+ax_sprite_terminator
+sAxPosesLatios:
+.4byte sLatiosPose1
+.4byte sLatiosPose2
+.4byte sLatiosPose3
+.4byte sLatiosPose4
+.4byte sLatiosPose5
+.4byte sLatiosPose6
+.4byte sLatiosPose7
+.4byte sLatiosPose8
+.4byte sLatiosPose9
+.4byte sLatiosPose10
+.4byte sLatiosPose11
+.4byte sLatiosPose12
+.4byte sLatiosPose13
+.4byte sLatiosPose14
+.4byte sLatiosPose15
+.4byte sLatiosPose16
+.4byte sLatiosPose17
+.4byte sLatiosPose18
+.4byte sLatiosPose19
+.4byte sLatiosPose20
+.4byte sLatiosPose21
+.4byte sLatiosPose22
+.4byte sLatiosPose23
+.4byte sLatiosPose24
+.4byte sLatiosPose25
+.4byte sLatiosPose26
+.4byte sLatiosPose27
+.4byte sLatiosPose28
+.4byte sLatiosPose29
+.4byte sLatiosPose30
+.4byte sLatiosPose31
+.4byte sLatiosPose32
+.4byte sLatiosPose33
+.4byte sLatiosPose34
+.4byte sLatiosPose35
+.4byte sLatiosPose36
+.4byte sLatiosPose37
+.4byte sLatiosPose38
+.4byte sLatiosPose39
+.4byte sLatiosPose40
+.4byte sLatiosPose41
+.4byte sLatiosPose42
+.4byte sLatiosPose43
+.4byte sLatiosPose44
+.4byte sLatiosPose45
+.4byte sLatiosPose46
+.4byte sLatiosPose47
+.4byte sLatiosPose48
+.4byte sLatiosPose49
+.4byte sLatiosPose50
+.4byte sLatiosPose51
+.4byte sLatiosPose52
+.4byte sLatiosPose53
+.4byte sLatiosPose54
+.4byte sLatiosPose55
+.4byte sLatiosPose56
+.4byte sLatiosPose57
+.4byte sLatiosPose58
+.4byte sLatiosPose59
+.4byte sLatiosPose60
+.4byte sLatiosPose61
+.4byte sLatiosPose62
+.4byte sLatiosPose63
+.4byte sLatiosPose64
+.4byte sLatiosPose65
+.4byte sLatiosPose66
+.4byte sLatiosPose67
+.4byte sLatiosPose68
+.4byte sLatiosPose69
+.4byte sLatiosPose70
+.4byte sLatiosPose71
+.4byte sLatiosPose72
+.4byte sLatiosPose73
+.4byte sLatiosPose74
+.4byte sLatiosPose75
+.4byte sLatiosPose76
+.4byte sLatiosPose77
+.4byte sLatiosPose78
+.4byte sLatiosPose79
+.4byte sLatiosPose80
+.4byte sLatiosPose81
+.4byte sLatiosPose82
+.4byte sLatiosPose83
+.4byte sLatiosPose84
+.4byte sLatiosPose85
+.4byte sLatiosPose86
+.4byte sLatiosPose87
+.4byte sLatiosPose88
+.4byte sLatiosPose89
+.4byte sLatiosPose90
+.4byte sLatiosPose91
+.4byte sLatiosPose92
+.4byte sLatiosPose93
+.4byte sLatiosPose94
+.4byte sLatiosPose95
+.4byte sLatiosPose96
+.4byte sLatiosPose97
+.4byte sLatiosPose98
+.4byte sLatiosPose99
+.4byte sLatiosPose100
+.4byte sLatiosPose101
+.4byte sLatiosPose102
+.4byte sLatiosPose103
+.4byte sLatiosPose104
+.4byte sLatiosPose105
+.4byte sLatiosPose106
+.4byte sLatiosPose107
+.4byte sLatiosPose108
+.4byte sLatiosPose109
+.4byte sLatiosPose110
+.4byte sLatiosPose111
+.4byte sLatiosPose112
+.4byte sLatiosPose113
+.4byte sLatiosPose114
+.4byte sLatiosPose115
+.4byte sLatiosPose116
+.4byte sLatiosPose117
+.4byte sLatiosPose118
+.4byte sLatiosPose119
+.4byte sLatiosPose120
+.4byte sLatiosPose121
+.4byte sLatiosPose122
+.4byte sLatiosPose123
+.4byte sLatiosPose124
+.4byte sLatiosPose125
+.4byte sLatiosPose126
+.4byte sLatiosPose127
+.4byte sLatiosPose128
+.4byte sLatiosPose129
+.4byte sLatiosPose130
+.4byte sLatiosPose131
+.4byte sLatiosPose132
+.4byte sLatiosPose133
+.4byte sLatiosPose134
+.4byte sLatiosPose135
+.4byte sLatiosPose136
+.4byte sLatiosPose137
+.4byte sLatiosPose138
+.4byte sLatiosPose139
+.4byte sLatiosPose140
+.4byte sLatiosPose141
+.4byte sLatiosPose142
+.4byte sLatiosPose143
+.4byte sLatiosPose144
+.4byte sLatiosPose145
+.4byte sLatiosPose146
+.4byte sLatiosPose147
+.4byte sLatiosPose148
+.4byte sLatiosPose149
+.4byte sLatiosPose150
+.4byte sLatiosPose151
+.4byte sLatiosPose152
+.4byte sLatiosPose153
+.4byte sLatiosPose154
+.4byte sLatiosPose155
+.4byte sLatiosPose156
+.4byte sLatiosPose157
+.4byte sLatiosPose158
+.4byte sLatiosPose159
+.4byte sLatiosPose160
+.4byte sLatiosPose161
+.4byte sLatiosPose162
+.4byte sLatiosPose163
+.4byte sLatiosPose164
+.4byte sLatiosPose165
+.4byte sLatiosPose166
+.4byte sLatiosPose167
+.4byte sLatiosPose168
+.4byte sLatiosPose169
+.4byte sLatiosPose170
+.4byte sLatiosPose171
+.4byte sLatiosPose172
+.4byte sLatiosPose173
+.4byte sLatiosPose174
+.4byte sLatiosPose175
+.4byte sLatiosPose176
+.4byte sLatiosPose177
+.4byte sLatiosPose178
+.4byte sLatiosPose179
+.4byte sLatiosPose180
+.4byte sLatiosPose181
+.4byte sLatiosPose182
+.4byte sLatiosPose183
+.4byte sLatiosPose184
+.4byte sLatiosPose185
+.4byte sLatiosPose186
+.4byte sLatiosPose187
+.4byte sLatiosPose188
+.4byte sLatiosPose189
+.4byte sLatiosPose190
+.4byte sLatiosPose191
+.4byte sLatiosPose192
+.4byte sLatiosPose193
+.4byte sLatiosPose194
+.4byte sLatiosPose195
+.4byte sLatiosPose196
+.4byte sLatiosPose197
+.4byte sLatiosPose198
+.4byte sLatiosPose199
+.4byte sLatiosPose200
+.4byte sLatiosPose201
+.4byte sLatiosPose202
+.4byte sLatiosPose203
+sAxPositionsLatios:
+.2byte    0,    0, 	  -6,  -16, 	   6,  -16, 	   0,  -18
+.2byte    0,    0, 	  -6,  -16, 	   6,  -16, 	   0,  -18
+.2byte   17,   -3, 	   7,  -14, 	  -1,  -10, 	   0,  -16
+.2byte   15,   -4, 	   6,  -14, 	  -2,  -10, 	  -2,  -16
+.2byte   26,  -16, 	   3,  -16, 	   5,  -11, 	   0,  -16
+.2byte   26,  -16, 	   4,  -17, 	   5,  -11, 	   1,  -16
+.2byte   19,  -26, 	   1,  -20, 	   9,  -14, 	   0,  -18
+.2byte   19,  -26, 	   0,  -19, 	   9,  -14, 	   0,  -18
+.2byte    0,  -31, 	   8,  -14, 	  -8,  -14, 	   0,  -18
+.2byte    0,  -30, 	   8,  -14, 	  -8,  -14, 	   0,  -18
+.2byte  -19,  -26, 	  -1,  -20, 	  -9,  -14, 	   0,  -18
+.2byte  -19,  -26, 	   0,  -19, 	  -9,  -14, 	   0,  -18
+.2byte  -26,  -16, 	  -3,  -16, 	  -5,  -11, 	   0,  -16
+.2byte  -26,  -16, 	  -4,  -17, 	  -5,  -11, 	  -1,  -16
+.2byte  -17,   -3, 	  -7,  -14, 	   1,  -10, 	   0,  -16
+.2byte  -15,   -4, 	  -6,  -14, 	   2,  -10, 	   2,  -16
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte    0,    0, 	  -6,  -16, 	   6,  -16, 	   0,  -18
+.2byte    0,    0, 	  -6,  -16, 	   6,  -16, 	   0,  -18
+.2byte   18,   -4, 	   6,  -15, 	  -5,   -4, 	  -2,  -16
+.2byte   17,   -3, 	   7,  -14, 	  -1,  -10, 	   0,  -16
+.2byte   15,   -4, 	   6,  -14, 	  -2,  -10, 	  -2,  -16
+.2byte   27,  -18, 	   0,  -14, 	   2,   -4, 	   2,  -15
+.2byte   26,  -16, 	   3,  -16, 	   5,  -11, 	   0,  -16
+.2byte   26,  -16, 	   4,  -17, 	   5,  -11, 	   1,  -16
+.2byte   19,  -28, 	  -3,  -17, 	  11,   -8, 	   0,  -17
+.2byte   19,  -26, 	   1,  -20, 	   9,  -14, 	   0,  -18
+.2byte   19,  -26, 	   0,  -19, 	   9,  -14, 	   0,  -18
+.2byte    0,  -33, 	   9,  -12, 	  -9,  -12, 	   0,  -16
+.2byte    0,  -31, 	   8,  -14, 	  -8,  -14, 	   0,  -18
+.2byte    0,  -30, 	   8,  -14, 	  -8,  -14, 	   0,  -18
+.2byte  -19,  -28, 	   3,  -17, 	 -11,   -8, 	   0,  -17
+.2byte  -19,  -26, 	  -1,  -20, 	  -9,  -14, 	   0,  -18
+.2byte  -19,  -26, 	   0,  -19, 	  -9,  -14, 	   0,  -18
+.2byte  -27,  -18, 	   0,  -14, 	  -2,   -4, 	  -2,  -15
+.2byte  -26,  -16, 	  -3,  -16, 	  -5,  -11, 	   0,  -16
+.2byte  -26,  -16, 	  -4,  -17, 	  -5,  -11, 	  -1,  -16
+.2byte  -18,   -4, 	  -6,  -15, 	   5,   -4, 	   2,  -16
+.2byte  -17,   -3, 	  -7,  -14, 	   1,  -10, 	   0,  -16
+.2byte  -15,   -4, 	  -6,  -14, 	   2,  -10, 	   2,  -16
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte    0,    0, 	  -6,  -16, 	   6,  -16, 	   0,  -18
+.2byte    0,    0, 	  -6,  -16, 	   6,  -16, 	   0,  -18
+.2byte   18,   -4, 	   6,  -15, 	  -5,   -4, 	  -2,  -16
+.2byte   17,   -3, 	   7,  -14, 	  -1,  -10, 	   0,  -16
+.2byte   15,   -4, 	   6,  -14, 	  -2,  -10, 	  -2,  -16
+.2byte   27,  -18, 	   0,  -14, 	   2,   -4, 	   2,  -15
+.2byte   26,  -16, 	   3,  -16, 	   5,  -11, 	   0,  -16
+.2byte   26,  -16, 	   4,  -17, 	   5,  -11, 	   1,  -16
+.2byte   19,  -28, 	  -3,  -17, 	  11,   -8, 	   0,  -17
+.2byte   19,  -26, 	   1,  -20, 	   9,  -14, 	   0,  -18
+.2byte   19,  -26, 	   0,  -19, 	   9,  -14, 	   0,  -18
+.2byte    0,  -33, 	   9,  -12, 	  -9,  -12, 	   0,  -16
+.2byte    0,  -31, 	   8,  -14, 	  -8,  -14, 	   0,  -18
+.2byte    0,  -30, 	   8,  -14, 	  -8,  -14, 	   0,  -18
+.2byte  -19,  -28, 	   3,  -17, 	 -11,   -8, 	   0,  -17
+.2byte  -19,  -26, 	  -1,  -20, 	  -9,  -14, 	   0,  -18
+.2byte  -19,  -26, 	   0,  -19, 	  -9,  -14, 	   0,  -18
+.2byte  -27,  -18, 	   0,  -14, 	  -2,   -4, 	  -2,  -15
+.2byte  -26,  -16, 	  -3,  -16, 	  -5,  -11, 	   0,  -16
+.2byte  -26,  -16, 	  -4,  -17, 	  -5,  -11, 	  -1,  -16
+.2byte  -18,   -4, 	  -6,  -15, 	   5,   -4, 	   2,  -16
+.2byte  -17,   -3, 	  -7,  -14, 	   1,  -10, 	   0,  -16
+.2byte  -15,   -4, 	  -6,  -14, 	   2,  -10, 	   2,  -16
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte    0,  -20, 	  -5,  -11, 	   5,  -11, 	   0,  -15
+.2byte    0,   -7, 	  -9,  -10, 	  10,  -10, 	   0,  -15
+.2byte   18,   -4, 	   6,  -15, 	  -5,   -4, 	  -2,  -16
+.2byte   13,  -22, 	  11,  -12, 	   4,  -10, 	  -1,  -16
+.2byte   15,  -10, 	   4,  -14, 	  -3,   -8, 	  -3,  -15
+.2byte   27,  -18, 	   0,  -14, 	   2,   -4, 	   2,  -15
+.2byte   19,  -30, 	  12,  -18, 	  11,  -14, 	  -4,  -14
+.2byte   20,  -21, 	  12,  -19, 	   9,   -9, 	  -4,  -15
+.2byte   19,  -28, 	  -3,  -17, 	  11,   -8, 	   0,  -17
+.2byte   13,  -40, 	   9,  -27, 	  14,  -23, 	  -3,  -19
+.2byte   16,  -31, 	   3,  -27, 	  16,  -17, 	  -2,  -21
+.2byte    0,  -33, 	   9,  -12, 	  -9,  -12, 	   0,  -16
+.2byte    0,  -40, 	   5,  -25, 	  -5,  -25, 	   0,  -17
+.2byte    0,  -33, 	   8,  -21, 	  -8,  -21, 	   0,  -16
+.2byte  -19,  -28, 	   3,  -17, 	 -11,   -8, 	   0,  -17
+.2byte  -13,  -40, 	  -9,  -27, 	 -14,  -23, 	   3,  -19
+.2byte  -16,  -31, 	  -3,  -27, 	 -16,  -17, 	   2,  -21
+.2byte  -27,  -18, 	   0,  -14, 	  -2,   -4, 	  -2,  -15
+.2byte  -19,  -30, 	 -12,  -18, 	 -11,  -14, 	   4,  -14
+.2byte  -20,  -21, 	 -12,  -19, 	  -9,   -9, 	   4,  -15
+.2byte  -18,   -4, 	  -6,  -15, 	   5,   -4, 	   2,  -16
+.2byte  -14,  -22, 	 -12,  -12, 	  -5,  -10, 	   0,  -16
+.2byte  -16,  -10, 	  -5,  -14, 	   2,   -8, 	   2,  -15
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte    0,   -7, 	  -9,  -10, 	  10,  -10, 	   0,  -15
+.2byte    0,  -28, 	 -11,  -16, 	  11,  -16, 	   0,  -16
+.2byte   18,   -4, 	   6,  -15, 	  -5,   -4, 	  -2,  -16
+.2byte   15,  -11, 	   4,  -15, 	  -3,   -9, 	  -3,  -16
+.2byte    9,  -32, 	  10,  -17, 	  -5,  -14, 	  -1,  -16
+.2byte   27,  -18, 	   0,  -14, 	   2,   -4, 	   2,  -15
+.2byte   21,  -21, 	  13,  -19, 	  10,   -9, 	  -3,  -15
+.2byte   12,  -36, 	  13,  -21, 	   9,  -12, 	  -2,  -14
+.2byte   19,  -28, 	  -3,  -17, 	  11,   -8, 	   0,  -17
+.2byte   16,  -30, 	   3,  -26, 	  16,  -16, 	  -2,  -20
+.2byte    8,  -43, 	  -3,  -26, 	  13,  -21, 	  -4,  -18
+.2byte    0,  -33, 	   9,  -12, 	  -9,  -12, 	   0,  -16
+.2byte    0,  -35, 	   8,  -23, 	  -8,  -23, 	   0,  -18
+.2byte    0,  -44, 	  10,  -24, 	 -10,  -24, 	   0,  -16
+.2byte  -19,  -28, 	   3,  -17, 	 -11,   -8, 	   0,  -17
+.2byte  -16,  -30, 	  -3,  -26, 	 -16,  -16, 	   2,  -20
+.2byte   -8,  -43, 	   3,  -26, 	 -13,  -21, 	   4,  -18
+.2byte  -27,  -18, 	   0,  -14, 	  -2,   -4, 	  -2,  -15
+.2byte  -21,  -21, 	 -13,  -19, 	 -10,   -9, 	   3,  -15
+.2byte  -12,  -36, 	 -13,  -21, 	  -9,  -12, 	   2,  -14
+.2byte  -18,   -4, 	  -6,  -15, 	   5,   -4, 	   2,  -16
+.2byte  -16,  -11, 	  -5,  -15, 	   2,   -9, 	   2,  -16
+.2byte  -10,  -32, 	 -11,  -17, 	   4,  -14, 	   0,  -16
+.2byte  -14,    6, 	  -7,   -5, 	  -2,    1, 	   1,   -9
+.2byte  -14,    7, 	  -7,   -4, 	  -2,    1, 	   2,   -9
+.2byte    9,  -33, 	  -4,  -20, 	   6,  -18, 	   0,  -16
+.2byte   -3,  -30, 	  11,  -22, 	   8,  -19, 	   3,  -14
+.2byte   -1,  -31, 	  12,  -25, 	  12,  -19, 	   0,  -14
+.2byte    8,  -35, 	  -1,  -29, 	   8,  -24, 	  -6,  -19
+.2byte   -7,  -34, 	   5,  -24, 	  -5,  -24, 	   0,  -18
+.2byte   -9,  -35, 	   0,  -29, 	  -9,  -24, 	   5,  -19
+.2byte    0,  -31, 	 -13,  -25, 	 -13,  -19, 	  -1,  -14
+.2byte    2,  -30, 	 -12,  -22, 	  -9,  -19, 	  -4,  -14
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte  -18,   -4, 	  -6,  -15, 	   5,   -4, 	   2,  -16
+.2byte  -27,  -18, 	   0,  -14, 	  -2,   -4, 	  -2,  -15
+.2byte  -19,  -28, 	   3,  -17, 	 -11,   -8, 	   0,  -17
+.2byte    0,  -33, 	   9,  -12, 	  -9,  -12, 	   0,  -16
+.2byte   19,  -28, 	  -3,  -17, 	  11,   -8, 	   0,  -17
+.2byte   27,  -18, 	   0,  -14, 	   2,   -4, 	   2,  -15
+.2byte   18,   -4, 	   6,  -15, 	  -5,   -4, 	  -2,  -16
+.2byte    0,    0, 	  -6,  -16, 	   6,  -16, 	   0,  -18
+.2byte  -17,   -3, 	  -7,  -14, 	   1,  -10, 	   0,  -16
+.2byte  -26,  -16, 	  -3,  -16, 	  -5,  -11, 	   0,  -16
+.2byte  -19,  -26, 	  -1,  -20, 	  -9,  -14, 	   0,  -18
+.2byte    0,  -31, 	   8,  -14, 	  -8,  -14, 	   0,  -18
+.2byte   19,  -26, 	   1,  -20, 	   9,  -14, 	   0,  -18
+.2byte   26,  -16, 	   3,  -16, 	   5,  -11, 	   0,  -16
+.2byte   17,   -3, 	   7,  -14, 	  -1,  -10, 	   0,  -16
+.2byte    0,   -7, 	  -9,  -10, 	  10,  -10, 	   0,  -15
+.2byte   15,  -10, 	   4,  -14, 	  -3,   -8, 	  -3,  -15
+.2byte   20,  -21, 	  12,  -19, 	   9,   -9, 	  -4,  -15
+.2byte   15,  -28, 	   2,  -24, 	  15,  -14, 	  -3,  -18
+.2byte    0,  -33, 	   8,  -21, 	  -8,  -21, 	   0,  -16
+.2byte  -15,  -28, 	  -2,  -24, 	 -15,  -14, 	   3,  -18
+.2byte  -20,  -21, 	 -12,  -19, 	  -9,   -9, 	   4,  -15
+.2byte  -16,  -10, 	  -5,  -14, 	   2,   -8, 	   2,  -15
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte    0,  -10, 	  -9,  -13, 	  10,  -13, 	   0,  -18
+.2byte    0,  -32, 	 -11,  -20, 	  11,  -20, 	   0,  -20
+.2byte   18,   -4, 	   6,  -15, 	  -5,   -4, 	  -2,  -16
+.2byte   18,  -11, 	   7,  -15, 	   0,   -9, 	   0,  -16
+.2byte   12,  -33, 	  13,  -18, 	  -2,  -15, 	   2,  -17
+.2byte   27,  -18, 	   0,  -14, 	   2,   -4, 	   2,  -15
+.2byte   22,  -21, 	  14,  -19, 	  11,   -9, 	  -2,  -15
+.2byte   12,  -36, 	  13,  -21, 	   9,  -12, 	  -2,  -14
+.2byte   19,  -28, 	  -3,  -17, 	  11,   -8, 	   0,  -17
+.2byte   16,  -29, 	   3,  -25, 	  16,  -15, 	  -2,  -19
+.2byte    8,  -43, 	  -3,  -26, 	  13,  -21, 	  -4,  -18
+.2byte    0,  -33, 	   9,  -12, 	  -9,  -12, 	   0,  -16
+.2byte    0,  -35, 	   8,  -23, 	  -8,  -23, 	   0,  -18
+.2byte    0,  -44, 	  10,  -24, 	 -10,  -24, 	   0,  -16
+.2byte  -19,  -28, 	   3,  -17, 	 -11,   -8, 	   0,  -17
+.2byte  -16,  -29, 	  -3,  -25, 	 -16,  -15, 	   2,  -19
+.2byte   -8,  -43, 	   3,  -26, 	 -13,  -21, 	   4,  -18
+.2byte  -27,  -18, 	   0,  -14, 	  -2,   -4, 	  -2,  -15
+.2byte  -22,  -21, 	 -14,  -19, 	 -11,   -9, 	   2,  -15
+.2byte  -12,  -36, 	 -13,  -21, 	  -9,  -12, 	   2,  -14
+.2byte  -18,   -4, 	  -6,  -15, 	   5,   -4, 	   2,  -16
+.2byte  -19,  -11, 	  -8,  -15, 	  -1,   -9, 	  -1,  -16
+.2byte  -13,  -33, 	 -14,  -18, 	   1,  -15, 	  -3,  -17
+.2byte    0,  -20, 	  -5,  -11, 	   5,  -11, 	   0,  -15
+.2byte  -15,  -22, 	 -13,  -12, 	  -6,  -10, 	  -1,  -16
+.2byte  -20,  -29, 	 -13,  -17, 	 -12,  -13, 	   3,  -13
+.2byte  -13,  -37, 	  -9,  -24, 	 -14,  -20, 	   3,  -16
+.2byte    0,  -38, 	   5,  -23, 	  -5,  -23, 	   0,  -15
+.2byte   13,  -37, 	   9,  -24, 	  14,  -20, 	  -3,  -16
+.2byte   20,  -29, 	  13,  -17, 	  12,  -13, 	  -3,  -13
+.2byte   13,  -22, 	  11,  -12, 	   4,  -10, 	  -1,  -16
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte  -18,   -4, 	  -6,  -15, 	   5,   -4, 	   2,  -16
+.2byte  -27,  -18, 	   0,  -14, 	  -2,   -4, 	  -2,  -15
+.2byte  -19,  -28, 	   3,  -17, 	 -11,   -8, 	   0,  -17
+.2byte    0,  -33, 	   9,  -12, 	  -9,  -12, 	   0,  -16
+.2byte   19,  -28, 	  -3,  -17, 	  11,   -8, 	   0,  -17
+.2byte   27,  -18, 	   0,  -14, 	   2,   -4, 	   2,  -15
+.2byte   18,   -4, 	   6,  -15, 	  -5,   -4, 	  -2,  -16
+.2byte  -20,  -25, 	 -14,  -14, 	 -14,  -10, 	   1,  -11
+.2byte  -12,  -29, 	 -13,  -19, 	 -12,  -12, 	   1,  -13
+.2byte  -15,  -22, 	  -9,  -18, 	  -9,  -12, 	  -1,  -11
+.2byte   -3,    1, 	 -10,   -1, 	   7,    0, 	   0,   -8
+.2byte   -3,    4, 	 -10,   -1, 	   6,    1, 	   1,   -5
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -15
+.2byte   -7,  -36, 	 -12,  -19, 	   7,  -28, 	  -1,  -22
+.2byte    5,    8, 	 -10,    5, 	   9,    4, 	   0,   -6
+.2byte    0,  -15, 	  -9,   -6, 	   9,   -6, 	   0,   -8
+.2byte  -16,  -16, 	 -14,   -7, 	   0,   -4, 	  -4,   -9
+.2byte   15,  -16, 	  13,   -7, 	  -1,   -4, 	   3,   -9
+.2byte  -10,  -16, 	 -11,   -6, 	   4,   -4, 	  -2,   -9
+.2byte    9,  -16, 	  10,   -6, 	  -5,   -4, 	   1,   -9
+.2byte    0,  -15, 	  -9,   -6, 	   9,   -6, 	   0,   -8
+.2byte  -10,  -16, 	 -11,   -6, 	   4,   -4, 	  -2,   -9
+.2byte  -16,  -17, 	 -12,   -4, 	  -2,   -5, 	  -4,  -10
+.2byte    0,  -10, 	  -7,   -2, 	   7,   -3, 	   0,   -6
+sLatiosAnimTable1:
+.4byte sLatiosAnims_1_1
+.4byte sLatiosAnims_1_2
+.4byte sLatiosAnims_1_3
+.4byte sLatiosAnims_1_4
+.4byte sLatiosAnims_1_5
+.4byte sLatiosAnims_1_6
+.4byte sLatiosAnims_1_7
+.4byte sLatiosAnims_1_8
+sLatiosAnimTable2:
+.4byte sLatiosAnims_2_1
+.4byte sLatiosAnims_2_2
+.4byte sLatiosAnims_2_3
+.4byte sLatiosAnims_2_4
+.4byte sLatiosAnims_2_5
+.4byte sLatiosAnims_2_6
+.4byte sLatiosAnims_2_7
+.4byte sLatiosAnims_2_8
+sLatiosAnimTable3:
+.4byte sLatiosAnims_3_1
+.4byte sLatiosAnims_3_2
+.4byte sLatiosAnims_3_3
+.4byte sLatiosAnims_3_4
+.4byte sLatiosAnims_3_5
+.4byte sLatiosAnims_3_6
+.4byte sLatiosAnims_3_7
+.4byte sLatiosAnims_3_8
+sLatiosAnimTable4:
+.4byte sLatiosAnims_4_1
+.4byte sLatiosAnims_4_2
+.4byte sLatiosAnims_4_3
+.4byte sLatiosAnims_4_4
+.4byte sLatiosAnims_4_5
+.4byte sLatiosAnims_4_6
+.4byte sLatiosAnims_4_7
+.4byte sLatiosAnims_4_8
+sLatiosAnimTable5:
+.4byte sLatiosAnims_5_1
+.4byte sLatiosAnims_5_2
+.4byte sLatiosAnims_5_3
+.4byte sLatiosAnims_5_4
+.4byte sLatiosAnims_5_5
+.4byte sLatiosAnims_5_6
+.4byte sLatiosAnims_5_7
+.4byte sLatiosAnims_5_8
+sLatiosAnimTable6:
+.4byte sLatiosAnims_6_1
+.4byte sLatiosAnims_6_1
+.4byte sLatiosAnims_6_1
+.4byte sLatiosAnims_6_1
+.4byte sLatiosAnims_6_1
+.4byte sLatiosAnims_6_1
+.4byte sLatiosAnims_6_1
+.4byte sLatiosAnims_6_1
+sLatiosAnimTable7:
+.4byte sLatiosAnims_7_1
+.4byte sLatiosAnims_7_2
+.4byte sLatiosAnims_7_3
+.4byte sLatiosAnims_7_4
+.4byte sLatiosAnims_7_5
+.4byte sLatiosAnims_7_6
+.4byte sLatiosAnims_7_7
+.4byte sLatiosAnims_7_8
+sLatiosAnimTable8:
+.4byte sLatiosAnims_8_1
+.4byte sLatiosAnims_8_2
+.4byte sLatiosAnims_8_3
+.4byte sLatiosAnims_8_4
+.4byte sLatiosAnims_8_5
+.4byte sLatiosAnims_8_6
+.4byte sLatiosAnims_8_7
+.4byte sLatiosAnims_8_8
+sLatiosAnimTable9:
+.4byte sLatiosAnims_9_1
+.4byte sLatiosAnims_9_2
+.4byte sLatiosAnims_9_3
+.4byte sLatiosAnims_9_4
+.4byte sLatiosAnims_9_5
+.4byte sLatiosAnims_9_6
+.4byte sLatiosAnims_9_7
+.4byte sLatiosAnims_9_8
+sLatiosAnimTable10:
+.4byte sLatiosAnims_10_1
+.4byte sLatiosAnims_10_2
+.4byte sLatiosAnims_10_3
+.4byte sLatiosAnims_10_4
+.4byte sLatiosAnims_10_5
+.4byte sLatiosAnims_10_6
+.4byte sLatiosAnims_10_7
+.4byte sLatiosAnims_10_8
+sLatiosAnimTable11:
+.4byte sLatiosAnims_11_1
+.4byte sLatiosAnims_11_2
+.4byte sLatiosAnims_11_3
+.4byte sLatiosAnims_11_4
+.4byte sLatiosAnims_11_5
+.4byte sLatiosAnims_11_6
+.4byte sLatiosAnims_11_7
+.4byte sLatiosAnims_11_8
+sLatiosAnimTable12:
+.4byte sLatiosAnims_12_1
+.4byte sLatiosAnims_12_2
+.4byte sLatiosAnims_12_3
+.4byte sLatiosAnims_12_4
+.4byte sLatiosAnims_12_5
+.4byte sLatiosAnims_12_6
+.4byte sLatiosAnims_12_7
+.4byte sLatiosAnims_12_8
+sLatiosAnimTable13:
+.4byte sLatiosAnims_13_1
+.4byte sLatiosAnims_13_2
+.4byte sLatiosAnims_13_3
+.4byte sLatiosAnims_13_4
+.4byte sLatiosAnims_13_5
+.4byte sLatiosAnims_13_6
+.4byte sLatiosAnims_13_7
+.4byte sLatiosAnims_13_8
+sLatiosAnimTable14:
+.4byte sLatiosAnims_14_1
+.4byte sLatiosAnims_14_1
+.4byte sLatiosAnims_14_1
+.4byte sLatiosAnims_14_1
+.4byte sLatiosAnims_14_1
+.4byte sLatiosAnims_14_1
+.4byte sLatiosAnims_14_1
+.4byte sLatiosAnims_14_1
+sLatiosAnimTable15:
+.4byte sLatiosAnims_15_1
+.4byte sLatiosAnims_15_1
+.4byte sLatiosAnims_15_1
+.4byte sLatiosAnims_15_1
+.4byte sLatiosAnims_15_1
+.4byte sLatiosAnims_15_1
+.4byte sLatiosAnims_15_1
+.4byte sLatiosAnims_15_1
+sLatiosAnimTable16:
+.4byte sLatiosAnims_16_1
+.4byte sLatiosAnims_16_1
+.4byte sLatiosAnims_16_1
+.4byte sLatiosAnims_16_1
+.4byte sLatiosAnims_16_1
+.4byte sLatiosAnims_16_1
+.4byte sLatiosAnims_16_1
+.4byte sLatiosAnims_16_1
+sLatiosAnimTable17:
+.4byte sLatiosAnims_17_1
+.4byte sLatiosAnims_17_2
+.4byte sLatiosAnims_17_3
+.4byte sLatiosAnims_17_4
+.4byte sLatiosAnims_17_5
+.4byte sLatiosAnims_17_6
+.4byte sLatiosAnims_17_7
+.4byte sLatiosAnims_17_8
+sLatiosAnimTable18:
+.4byte sLatiosAnims_18_1
+.4byte sLatiosAnims_18_2
+.4byte sLatiosAnims_18_3
+.4byte sLatiosAnims_18_4
+.4byte sLatiosAnims_18_5
+.4byte sLatiosAnims_18_6
+.4byte sLatiosAnims_18_7
+.4byte sLatiosAnims_18_8
+sLatiosAnimTable19:
+.4byte sLatiosAnims_19_1
+.4byte sLatiosAnims_19_1
+.4byte sLatiosAnims_19_1
+.4byte sLatiosAnims_19_1
+.4byte sLatiosAnims_19_1
+.4byte sLatiosAnims_19_1
+.4byte sLatiosAnims_19_1
+.4byte sLatiosAnims_19_1
+sLatiosAnimTable20:
+.4byte sLatiosAnims_20_1
+.4byte sLatiosAnims_20_2
+.4byte sLatiosAnims_20_3
+.4byte sLatiosAnims_20_4
+.4byte sLatiosAnims_20_5
+.4byte sLatiosAnims_20_6
+.4byte sLatiosAnims_20_7
+.4byte sLatiosAnims_20_8
+sLatiosAnimTable21:
+.4byte sLatiosAnims_21_1
+.4byte sLatiosAnims_21_2
+.4byte sLatiosAnims_21_3
+.4byte sLatiosAnims_21_4
+.4byte sLatiosAnims_21_5
+.4byte sLatiosAnims_21_6
+.4byte sLatiosAnims_21_7
+.4byte sLatiosAnims_21_8
+sAxAnimationsLatios:
+.4byte sLatiosAnimTable1
+.4byte sLatiosAnimTable2
+.4byte sLatiosAnimTable3
+.4byte sLatiosAnimTable4
+.4byte sLatiosAnimTable5
+.4byte sLatiosAnimTable6
+.4byte sLatiosAnimTable7
+.4byte sLatiosAnimTable8
+.4byte sLatiosAnimTable9
+.4byte sLatiosAnimTable10
+.4byte sLatiosAnimTable11
+.4byte sLatiosAnimTable12
+.4byte sLatiosAnimTable13
+.4byte sLatiosAnimTable14
+.4byte sLatiosAnimTable15
+.4byte sLatiosAnimTable16
+.4byte sLatiosAnimTable17
+.4byte sLatiosAnimTable18
+.4byte sLatiosAnimTable19
+.4byte sLatiosAnimTable20
+.4byte sLatiosAnimTable21
+sAxSpritesLatios:
+.4byte sLatiosSprites1
+.4byte sLatiosSprites2
+.4byte sLatiosSprites3
+.4byte sLatiosSprites4
+.4byte sLatiosSprites5
+.4byte sLatiosSprites6
+.4byte sLatiosSprites7
+.4byte sLatiosSprites8
+.4byte sLatiosSprites9
+.4byte sLatiosSprites10
+.4byte sLatiosSprites11
+.4byte sLatiosSprites12
+.4byte sLatiosSprites13
+.4byte sLatiosSprites14
+.4byte sLatiosSprites15
+.4byte sLatiosSprites16
+.4byte sLatiosSprites17
+.4byte sLatiosSprites18
+.4byte sLatiosSprites19
+.4byte sLatiosSprites20
+.4byte sLatiosSprites21
+.4byte sLatiosSprites22
+.4byte sLatiosSprites23
+.4byte sLatiosSprites24
+.4byte sLatiosSprites25
+.4byte sLatiosSprites26
+.4byte sLatiosSprites27
+.4byte sLatiosSprites28
+.4byte sLatiosSprites29
+.4byte sLatiosSprites30
+.4byte sLatiosSprites31
+.4byte sLatiosSprites32
+.4byte sLatiosSprites33
+.4byte sLatiosSprites34
+.4byte sLatiosSprites35
+.4byte sLatiosSprites36
+.4byte sLatiosSprites37
+.4byte sLatiosSprites38
+.4byte sLatiosSprites39
+.4byte sLatiosSprites40
+.4byte sLatiosSprites41
+.4byte sLatiosSprites42
+.4byte sLatiosSprites43
+.4byte sLatiosSprites44
+.4byte sLatiosSprites45
+.4byte sLatiosSprites46
+.4byte sLatiosSprites47
+.4byte sLatiosSprites48
+.4byte sLatiosSprites49
+.4byte sLatiosSprites50
+.4byte sLatiosSprites51
+.4byte sLatiosSprites52
+.4byte sLatiosSprites53
+.4byte sLatiosSprites54
+.4byte sLatiosSprites55
+.4byte sLatiosSprites56
+.4byte sLatiosSprites57
+.4byte sLatiosSprites58
+.4byte sLatiosSprites59
+.4byte sLatiosSprites60
+.4byte sLatiosSprites61
+.4byte sLatiosSprites62
+.4byte sLatiosSprites63
+.4byte sLatiosSprites64
+.4byte sLatiosSprites65
+.4byte sLatiosSprites66
+.4byte sLatiosSprites67
+.4byte sLatiosSprites68
+.4byte sLatiosSprites69
+.4byte sLatiosSprites70
+.4byte sLatiosSprites71
+.4byte sLatiosSprites72
+.4byte sLatiosSprites73
+.4byte sLatiosSprites74
+.4byte sLatiosSprites75
+.4byte sLatiosSprites76
+.4byte sLatiosSprites77
+.4byte sLatiosSprites78
+.4byte sLatiosSprites79
+.4byte sLatiosSprites80
+.4byte sLatiosSprites81
+.4byte sLatiosSprites82
+.4byte sLatiosSprites83
+.4byte sLatiosSprites84
+.4byte sLatiosSprites85
+.4byte sLatiosSprites86
+.4byte sLatiosSprites87
+.4byte sLatiosSprites88
+.4byte sLatiosSprites89
+.4byte sLatiosSprites90
+.4byte sLatiosSprites91
+.4byte sLatiosSprites92
+.4byte sLatiosSprites93
+.4byte sLatiosSprites94
+.4byte sLatiosSprites95
+.4byte sLatiosSprites96
+.4byte sLatiosSprites97
+.4byte sLatiosSprites98
+.4byte sLatiosSprites99
+.4byte sLatiosSprites100
+.4byte sLatiosSprites101
+.4byte sLatiosSprites102
+.4byte sLatiosSprites103
+.4byte sLatiosSprites104
+.4byte sLatiosSprites105
+.4byte sLatiosSprites106
+.4byte sLatiosSprites107
+.4byte sLatiosSprites108
+.4byte sLatiosSprites109
+.4byte sLatiosSprites110
+.4byte sLatiosSprites111
+.4byte sLatiosSprites112
+.4byte sLatiosSprites113
+.4byte sLatiosSprites114
+.4byte sLatiosSprites115
+.4byte sLatiosSprites116
+.4byte sLatiosSprites117
+.4byte sLatiosSprites118
+.4byte sLatiosSprites119
+.4byte sLatiosSprites120
+.4byte sLatiosSprites121
+.4byte sLatiosSprites122
+.4byte sLatiosSprites123
+.4byte sLatiosSprites124
+.4byte sLatiosSprites125
+.4byte sLatiosSprites126
+.4byte sLatiosSprites127
+.4byte sLatiosSprites128
+.4byte sLatiosSprites129
+.4byte sLatiosSprites130
+.4byte sLatiosSprites131
+.4byte sLatiosSprites132
+.4byte sLatiosSprites133
+.4byte sLatiosSprites134
+.4byte sLatiosSprites135
+.4byte sLatiosSprites136
+.4byte sLatiosSprites137
+.4byte sLatiosSprites138
+.4byte sLatiosSprites139
+.4byte sLatiosSprites140
+.4byte sLatiosSprites141
+.4byte sLatiosSprites142
+.4byte sLatiosSprites143
+.4byte sLatiosSprites144
+.4byte sLatiosSprites145
+.4byte sLatiosSprites146
+.4byte sLatiosSprites147
+.4byte sLatiosSprites148
+.4byte sLatiosSprites149
+.4byte sLatiosSprites150
+.4byte sLatiosSprites151
+.4byte sLatiosSprites152
+.4byte sLatiosSprites153
+.4byte sLatiosSprites154
+.4byte sLatiosSprites155
+.4byte sLatiosSprites156
+.4byte sLatiosSprites157
+.4byte sLatiosSprites158
+.4byte sLatiosSprites159
+.4byte sLatiosSprites160
+.4byte sLatiosSprites161
+.4byte sLatiosSprites162
+.4byte sLatiosSprites163
+.4byte sLatiosSprites164
+.4byte sLatiosSprites165
+.4byte sLatiosSprites166
+.4byte sLatiosSprites167
+.4byte sLatiosSprites168
+.4byte sLatiosSprites169
+.4byte sLatiosSprites170
+.4byte sLatiosSprites171
+.4byte sLatiosSprites172
+.4byte sLatiosSprites173
+.4byte sLatiosSprites174
+.4byte sLatiosSprites175
+.4byte sLatiosSprites176
+.4byte sLatiosSprites177
+.4byte sLatiosSprites178
+.4byte sLatiosSprites179
+.4byte sLatiosSprites180
+.4byte sLatiosSprites181
+.4byte sLatiosSprites182
+.4byte sLatiosSprites183
+.4byte sLatiosSprites184
+.4byte sLatiosSprites185
+.4byte sLatiosSprites186
+.4byte sLatiosSprites187
+.4byte sLatiosSprites188
+.4byte sLatiosSprites189
+.4byte sLatiosSprites190
+.4byte sLatiosSprites191
+.4byte sLatiosSprites192
+.4byte sLatiosSprites193
+.4byte sLatiosSprites194
+.4byte sLatiosSprites195
+.4byte sLatiosSprites196
+.4byte sLatiosSprites197
+.4byte sLatiosSprites198
+.4byte sLatiosSprites199
+.4byte sLatiosSprites200
+.4byte sLatiosSprites201
+.4byte sLatiosSprites202
+.4byte sLatiosSprites203
+.4byte sLatiosSprites204
+.4byte sLatiosSprites205
+.4byte sLatiosSprites206
+.4byte sLatiosSprites207
+.4byte sLatiosSprites208
+sAxMainLatios:
+ax_main sAxPosesLatios, sAxAnimationsLatios, 21, sAxSpritesLatios, sAxPositionsLatios

--- a/data/ax/ledian.inc
+++ b/data/ax/ledian.inc
@@ -1,0 +1,3098 @@
+.global gAxLedian
+gAxLedian:
+ax_siro sAxMainLedian
+sLedianPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose3:
+ax_pose 2, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose4:
+ax_pose 3, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose5:
+ax_pose 4, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose6:
+ax_pose 5, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose7:
+ax_pose 6, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose8:
+ax_pose 7, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose9:
+ax_pose 8, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose10:
+ax_pose 9, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose11:
+ax_pose 6, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose12:
+ax_pose 7, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose13:
+ax_pose 4, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose14:
+ax_pose 5, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose15:
+ax_pose 2, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose16:
+ax_pose 3, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose17:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose18:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose19:
+ax_pose 10, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose20:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose21:
+ax_pose 2, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose22:
+ax_pose 3, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose23:
+ax_pose 12, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose24:
+ax_pose 13, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose25:
+ax_pose 4, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose26:
+ax_pose 5, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose27:
+ax_pose 14, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose28:
+ax_pose 15, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose29:
+ax_pose 6, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose30:
+ax_pose 7, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose31:
+ax_pose 16, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose32:
+ax_pose 17, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose33:
+ax_pose 8, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose34:
+ax_pose 9, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose35:
+ax_pose 18, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose36:
+ax_pose 19, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose37:
+ax_pose 6, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose38:
+ax_pose 7, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose39:
+ax_pose 16, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose40:
+ax_pose 17, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose41:
+ax_pose 4, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose42:
+ax_pose 5, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose43:
+ax_pose 14, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose44:
+ax_pose 15, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose45:
+ax_pose 2, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose46:
+ax_pose 3, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose47:
+ax_pose 12, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose48:
+ax_pose 13, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose50:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose51:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose 21, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedianPose52:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose53:
+ax_pose 20, 0x01e5, 0x90f0, 0x2c00
+ax_pose 21, 0x01e5, 0x90f0, 0x2c10
+ax_pose_terminator
+sLedianPose54:
+ax_pose 21, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sLedianPose55:
+ax_pose 2, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose56:
+ax_pose 3, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose57:
+ax_pose 22, 0x01e3, 0x90f1, 0x2c00
+ax_pose 23, 0x01e1, 0x90eb, 0x2c10
+ax_pose_terminator
+sLedianPose58:
+ax_pose 23, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose59:
+ax_pose 24, 0x01e5, 0x90ed, 0x2c00
+ax_pose 25, 0x01e1, 0x90eb, 0x2c10
+ax_pose_terminator
+sLedianPose60:
+ax_pose 25, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose61:
+ax_pose 4, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose62:
+ax_pose 5, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose63:
+ax_pose 26, 0x01e0, 0x90f0, 0x2c00
+ax_pose 27, 0x01e0, 0x90ea, 0x2c10
+ax_pose_terminator
+sLedianPose64:
+ax_pose 27, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose65:
+ax_pose 28, 0x01e0, 0x90ef, 0x2c00
+ax_pose 29, 0x01e0, 0x90ea, 0x2c10
+ax_pose_terminator
+sLedianPose66:
+ax_pose 29, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose67:
+ax_pose 6, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose68:
+ax_pose 7, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose69:
+ax_pose 30, 0x01e1, 0x90ee, 0x2c00
+ax_pose 31, 0x01e1, 0x90ea, 0x2c10
+ax_pose_terminator
+sLedianPose70:
+ax_pose 31, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose71:
+ax_pose 32, 0x01e1, 0x90f0, 0x2c00
+ax_pose 33, 0x01e1, 0x90ea, 0x2c10
+ax_pose_terminator
+sLedianPose72:
+ax_pose 33, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose73:
+ax_pose 8, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose74:
+ax_pose 9, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose75:
+ax_pose 34, 0x01e0, 0x80f0, 0x2c00
+ax_pose 35, 0x01e1, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedianPose76:
+ax_pose 35, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose77:
+ax_pose 34, 0x01e0, 0x90f0, 0x2c00
+ax_pose 35, 0x01e1, 0x90f0, 0x2c10
+ax_pose_terminator
+sLedianPose78:
+ax_pose 35, 0x01e1, 0x90f0, 0x2c00
+ax_pose_terminator
+sLedianPose79:
+ax_pose 6, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose80:
+ax_pose 7, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose81:
+ax_pose 30, 0x01e1, 0x80f1, 0x2c00
+ax_pose 31, 0x01e1, 0x80f5, 0x2c10
+ax_pose_terminator
+sLedianPose82:
+ax_pose 31, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose83:
+ax_pose 32, 0x01e1, 0x80ef, 0x2c00
+ax_pose 33, 0x01e1, 0x80f5, 0x2c10
+ax_pose_terminator
+sLedianPose84:
+ax_pose 33, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose85:
+ax_pose 4, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose86:
+ax_pose 5, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose87:
+ax_pose 26, 0x01e0, 0x80ef, 0x2c00
+ax_pose 27, 0x01e0, 0x80f5, 0x2c10
+ax_pose_terminator
+sLedianPose88:
+ax_pose 27, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose89:
+ax_pose 28, 0x01e0, 0x80f0, 0x2c00
+ax_pose 29, 0x01e0, 0x80f5, 0x2c10
+ax_pose_terminator
+sLedianPose90:
+ax_pose 29, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose91:
+ax_pose 2, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose92:
+ax_pose 3, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose93:
+ax_pose 22, 0x01e3, 0x80ee, 0x2c00
+ax_pose 23, 0x01e1, 0x80f4, 0x2c10
+ax_pose_terminator
+sLedianPose94:
+ax_pose 23, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose95:
+ax_pose 24, 0x01e5, 0x80f2, 0x2c00
+ax_pose 25, 0x01e1, 0x80f4, 0x2c10
+ax_pose_terminator
+sLedianPose96:
+ax_pose 25, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose97:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose98:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose99:
+ax_pose 10, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose100:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose101:
+ax_pose 2, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose102:
+ax_pose 3, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose103:
+ax_pose 12, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose104:
+ax_pose 13, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose105:
+ax_pose 4, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose106:
+ax_pose 5, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose107:
+ax_pose 14, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose108:
+ax_pose 15, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose109:
+ax_pose 6, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose110:
+ax_pose 7, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose111:
+ax_pose 16, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose112:
+ax_pose 17, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose113:
+ax_pose 8, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose114:
+ax_pose 9, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose115:
+ax_pose 18, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose116:
+ax_pose 19, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose117:
+ax_pose 6, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose118:
+ax_pose 7, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose119:
+ax_pose 16, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose120:
+ax_pose 17, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose121:
+ax_pose 4, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose122:
+ax_pose 5, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose123:
+ax_pose 14, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose124:
+ax_pose 15, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose125:
+ax_pose 2, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose126:
+ax_pose 3, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose127:
+ax_pose 12, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose128:
+ax_pose 13, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose129:
+ax_pose 36, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose130:
+ax_pose 37, 0x01e5, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose131:
+ax_pose 38, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose132:
+ax_pose 39, 0x01e3, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose133:
+ax_pose 40, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose134:
+ax_pose 39, 0x01e3, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose135:
+ax_pose 38, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose136:
+ax_pose 37, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose137:
+ax_pose 41, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose138:
+ax_pose 42, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose139:
+ax_pose 43, 0x01e0, 0x80f1, 0x2c00
+ax_pose_terminator
+sLedianPose140:
+ax_pose 44, 0x01e1, 0x90e9, 0x2c00
+ax_pose_terminator
+sLedianPose141:
+ax_pose 45, 0x01e2, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose142:
+ax_pose 46, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose143:
+ax_pose 47, 0x01e1, 0x80f1, 0x2c00
+ax_pose_terminator
+sLedianPose144:
+ax_pose 46, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose145:
+ax_pose 45, 0x01e2, 0x80f6, 0x2c00
+ax_pose_terminator
+sLedianPose146:
+ax_pose 44, 0x01e1, 0x80f7, 0x2c00
+ax_pose_terminator
+sLedianPose147:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose148:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose149:
+ax_pose 2, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose150:
+ax_pose 3, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose151:
+ax_pose 4, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose152:
+ax_pose 5, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose153:
+ax_pose 6, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose154:
+ax_pose 7, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose155:
+ax_pose 8, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose156:
+ax_pose 9, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose157:
+ax_pose 6, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose158:
+ax_pose 7, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose159:
+ax_pose 4, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose160:
+ax_pose 5, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose161:
+ax_pose 2, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose162:
+ax_pose 3, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose163:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose164:
+ax_pose 23, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose165:
+ax_pose 27, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose166:
+ax_pose 31, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose167:
+ax_pose 35, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sLedianPose168:
+ax_pose 31, 0x01e2, 0x90ec, 0x2c00
+ax_pose_terminator
+sLedianPose169:
+ax_pose 27, 0x01e1, 0x90ed, 0x2c00
+ax_pose_terminator
+sLedianPose170:
+ax_pose 23, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sLedianPose171:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose172:
+ax_pose 2, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose173:
+ax_pose 4, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose174:
+ax_pose 6, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose175:
+ax_pose 8, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose176:
+ax_pose 6, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose177:
+ax_pose 4, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose178:
+ax_pose 2, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose179:
+ax_pose 48, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose180:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose181:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose182:
+ax_pose 49, 0x01e5, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose183:
+ax_pose 2, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose184:
+ax_pose 3, 0x01e1, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose185:
+ax_pose 50, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose186:
+ax_pose 4, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose187:
+ax_pose 5, 0x01e0, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose188:
+ax_pose 51, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose189:
+ax_pose 6, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose190:
+ax_pose 7, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose191:
+ax_pose 52, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose192:
+ax_pose 8, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose193:
+ax_pose 9, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose194:
+ax_pose 51, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose195:
+ax_pose 6, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose196:
+ax_pose 7, 0x01e1, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose197:
+ax_pose 50, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose198:
+ax_pose 4, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose199:
+ax_pose 5, 0x01e0, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose200:
+ax_pose 49, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose201:
+ax_pose 2, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose202:
+ax_pose 3, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose203:
+ax_pose 36, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose204:
+ax_pose 37, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose205:
+ax_pose 38, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose206:
+ax_pose 39, 0x01e3, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose207:
+ax_pose 40, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose208:
+ax_pose 39, 0x01e3, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose209:
+ax_pose 38, 0x01e4, 0x90ec, 0x2c00
+ax_pose_terminator
+sLedianPose210:
+ax_pose 37, 0x01e5, 0x90eb, 0x2c00
+ax_pose_terminator
+sLedianPose211:
+ax_pose 48, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose212:
+ax_pose 49, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedianPose213:
+ax_pose 50, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose214:
+ax_pose 51, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sLedianPose215:
+ax_pose 52, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedianPose216:
+ax_pose 51, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose217:
+ax_pose 50, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sLedianPose218:
+ax_pose 49, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+.align 2
+sLedianAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 9, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 4, 0, 12, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 15, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 2, 17, 0, 0, 0, 0,
+ax_anim 1, 0, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 17, 0, 10, 0, 10,
+ax_anim 1, 0, 16, 0, 23, 0, 23,
+ax_anim 1, 1, 17, 0, 23, 0, 23,
+ax_anim 1, 0, 16, 1, 23, 1, 23,
+ax_anim 1, 0, 17, 1, 23, 1, 23,
+ax_anim 1, 0, 16, 0, 23, 0, 23,
+ax_anim 1, 0, 17, 0, 23, 0, 23,
+ax_anim 1, 0, 16, 1, 23, 1, 23,
+ax_anim 1, 0, 17, 1, 23, 1, 23,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sLedianAnims_2_2:
+ax_anim 2, 0, 20, -1, -1, -1, -1,
+ax_anim 6, 0, 20, -2, -2, -2, -2,
+ax_anim 1, 2, 21, 0, 0, 0, 0,
+ax_anim 1, 0, 20, 4, 4, 4, 4,
+ax_anim 1, 0, 21, 9, 11, 9, 11,
+ax_anim 1, 0, 20, 19, 22, 19, 22,
+ax_anim 1, 1, 21, 19, 22, 19, 22,
+ax_anim 1, 0, 20, 20, 21, 20, 21,
+ax_anim 1, 0, 21, 20, 21, 20, 21,
+ax_anim 1, 0, 20, 19, 22, 19, 22,
+ax_anim 1, 0, 21, 19, 22, 19, 22,
+ax_anim 1, 0, 20, 20, 21, 20, 21,
+ax_anim 1, 0, 21, 20, 21, 20, 21,
+ax_anim 2, 0, 20, 5, 7, 5, 7,
+ax_anim_terminator
+sLedianAnims_2_3:
+ax_anim 2, 0, 24, -1, 0, -1, 0,
+ax_anim 6, 0, 24, -2, 0, -2, 0,
+ax_anim 1, 2, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 4, 0, 4, 0,
+ax_anim 1, 0, 25, 9, 0, 9, 0,
+ax_anim 1, 0, 24, 19, 0, 19, 0,
+ax_anim 1, 1, 25, 19, 0, 19, 0,
+ax_anim 1, 0, 24, 19, 1, 19, 1,
+ax_anim 1, 0, 25, 19, 1, 19, 1,
+ax_anim 1, 0, 24, 19, 0, 19, 0,
+ax_anim 1, 0, 25, 19, 0, 19, 0,
+ax_anim 1, 0, 24, 19, 1, 19, 1,
+ax_anim 1, 0, 25, 19, 1, 19, 1,
+ax_anim 2, 0, 24, 5, 0, 5, 0,
+ax_anim_terminator
+sLedianAnims_2_4:
+ax_anim 2, 0, 28, -1, 1, -1, 1,
+ax_anim 6, 0, 28, -2, 2, -2, 2,
+ax_anim 1, 2, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 5, -4, 5, -4,
+ax_anim 1, 0, 29, 12, -10, 12, -10,
+ax_anim 1, 0, 28, 19, -15, 19, -15,
+ax_anim 1, 1, 29, 19, -15, 19, -15,
+ax_anim 1, 0, 28, 20, -14, 20, -14,
+ax_anim 1, 0, 29, 20, -14, 20, -14,
+ax_anim 1, 0, 28, 19, -15, 19, -15,
+ax_anim 1, 0, 29, 19, -15, 19, -15,
+ax_anim 1, 0, 28, 20, -14, 20, -14,
+ax_anim 1, 0, 29, 20, -14, 20, -14,
+ax_anim 2, 0, 28, 7, -6, 7, -6,
+ax_anim_terminator
+sLedianAnims_2_5:
+ax_anim 2, 0, 32, 0, 1, 0, 1,
+ax_anim 6, 0, 32, 0, 2, 0, 2,
+ax_anim 1, 2, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 32, 0, -4, 0, -4,
+ax_anim 1, 0, 33, 0, -10, 0, -10,
+ax_anim 1, 0, 32, 0, -15, 0, -15,
+ax_anim 1, 1, 33, 0, -15, 0, -15,
+ax_anim 1, 0, 32, 1, -15, 1, -15,
+ax_anim 1, 0, 33, 1, -15, 1, -15,
+ax_anim 1, 0, 32, 0, -15, 0, -15,
+ax_anim 1, 0, 33, 0, -15, 0, -15,
+ax_anim 1, 0, 32, 1, -15, 1, -15,
+ax_anim 1, 0, 33, 1, -15, 1, -15,
+ax_anim 2, 0, 32, 0, -4, 0, -4,
+ax_anim_terminator
+sLedianAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 6, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 2, 37, 0, 0, 0, 0,
+ax_anim 1, 0, 36, -5, -4, -5, -4,
+ax_anim 1, 0, 37, -12, -10, -12, -10,
+ax_anim 1, 0, 36, -19, -15, -19, -15,
+ax_anim 1, 1, 37, -19, -15, -19, -15,
+ax_anim 1, 0, 36, -20, -14, -20, -14,
+ax_anim 1, 0, 37, -20, -14, -20, -14,
+ax_anim 1, 0, 36, -19, -15, -19, -15,
+ax_anim 1, 0, 37, -19, -15, -19, -15,
+ax_anim 1, 0, 36, -20, -14, -20, -14,
+ax_anim 1, 0, 37, -20, -14, -20, -14,
+ax_anim 2, 0, 36, -7, -6, -7, -6,
+ax_anim_terminator
+sLedianAnims_2_7:
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 6, 0, 40, 2, 0, 2, 0,
+ax_anim 1, 2, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 40, -4, 0, -4, 0,
+ax_anim 1, 0, 41, -9, 0, -9, 0,
+ax_anim 1, 0, 40, -19, 0, -19, 0,
+ax_anim 1, 1, 41, -19, 0, -19, 0,
+ax_anim 1, 0, 40, -19, 1, -19, 1,
+ax_anim 1, 0, 41, -19, 1, -19, 1,
+ax_anim 1, 0, 40, -19, 0, -19, 0,
+ax_anim 1, 0, 41, -19, 0, -19, 0,
+ax_anim 1, 0, 40, -19, 1, -19, 1,
+ax_anim 1, 0, 41, -19, 1, -19, 1,
+ax_anim 2, 0, 40, -5, 0, -5, 0,
+ax_anim_terminator
+sLedianAnims_2_8:
+ax_anim 2, 0, 44, 1, -1, 1, -1,
+ax_anim 6, 0, 44, 2, -2, 2, -2,
+ax_anim 1, 2, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 44, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -9, 11, -9, 11,
+ax_anim 1, 0, 44, -19, 22, -19, 22,
+ax_anim 1, 1, 45, -19, 22, -19, 22,
+ax_anim 1, 0, 44, -20, 21, -20, 21,
+ax_anim 1, 0, 45, -20, 21, -20, 21,
+ax_anim 1, 0, 44, -19, 22, -19, 22,
+ax_anim 1, 0, 45, -19, 22, -19, 22,
+ax_anim 1, 0, 44, -20, 21, -20, 21,
+ax_anim 1, 0, 45, -20, 21, -20, 21,
+ax_anim 2, 0, 44, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sLedianAnims_3_1:
+ax_anim 1, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, -4, 0, -4,
+ax_anim 6, 0, 95, 0, -6, 0, -6,
+ax_anim 1, 2, 95, 0, -3, 0, -3,
+ax_anim 1, 0, 53, 0, 3, 0, 3,
+ax_anim 1, 0, 50, 4, 19, 4, 19,
+ax_anim 1, 1, 59, 5, 20, 5, 20,
+ax_anim 2, 0, 59, 6, 16, 6, 16,
+ax_anim 6, 0, 59, 6, 14, 6, 14,
+ax_anim 2, 0, 52, -2, 19, -2, 19,
+ax_anim 2, 0, 95, -3, 20, -3, 20,
+ax_anim 2, 0, 53, -1, 16, -1, 16,
+ax_anim 1, 0, 49, 0, 11, 0, 11,
+ax_anim 1, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sLedianAnims_3_2:
+ax_anim 1, 0, 54, -2, -2, -2, -2,
+ax_anim 2, 0, 48, -4, -4, -4, -4,
+ax_anim 6, 0, 53, -6, -6, -6, -6,
+ax_anim 1, 2, 53, -3, -3, -3, -3,
+ax_anim 1, 0, 57, 6, 6, 6, 6,
+ax_anim 1, 0, 58, 18, 19, 18, 19,
+ax_anim 1, 1, 65, 19, 20, 19, 20,
+ax_anim 2, 0, 65, 17, 18, 17, 18,
+ax_anim 6, 0, 65, 15, 14, 15, 14,
+ax_anim 2, 0, 56, 15, 20, 15, 20,
+ax_anim 2, 0, 53, 15, 20, 15, 20,
+ax_anim 2, 0, 57, 16, 17, 16, 17,
+ax_anim 1, 0, 55, 11, 11, 11, 11,
+ax_anim 1, 0, 54, 3, 3, 3, 3,
+ax_anim_terminator
+sLedianAnims_3_3:
+ax_anim 1, 0, 60, -2, 0, -2, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim 6, 0, 57, -6, 1, -6, 1,
+ax_anim 1, 2, 57, -3, 1, -3, 1,
+ax_anim 1, 0, 63, 6, 1, 6, 1,
+ax_anim 1, 0, 64, 14, 0, 14, 0,
+ax_anim 1, 1, 71, 17, -1, 17, -1,
+ax_anim 2, 0, 71, 15, -1, 15, -1,
+ax_anim 6, 0, 71, 14, -1, 14, -1,
+ax_anim 2, 0, 62, 17, 1, 17, 1,
+ax_anim 2, 0, 57, 18, 2, 18, 2,
+ax_anim 2, 0, 63, 13, -1, 13, -1,
+ax_anim 1, 0, 61, 6, -1, 6, -1,
+ax_anim 1, 0, 60, 3, 0, 3, 0,
+ax_anim_terminator
+sLedianAnims_3_4:
+ax_anim 1, 0, 66, -2, 2, -2, 2,
+ax_anim 2, 0, 60, -4, 4, -4, 4,
+ax_anim 6, 0, 63, -6, 6, -6, 6,
+ax_anim 1, 2, 63, -3, 3, -3, 3,
+ax_anim 1, 0, 69, 6, -6, 6, -6,
+ax_anim 1, 0, 70, 13, -15, 13, -15,
+ax_anim 1, 1, 75, 15, -15, 15, -15,
+ax_anim 2, 0, 75, 14, -14, 14, -14,
+ax_anim 6, 0, 75, 12, -11, 12, -11,
+ax_anim 2, 0, 68, 20, -15, 20, -15,
+ax_anim 2, 0, 63, 22, -13, 22, -13,
+ax_anim 2, 0, 69, 15, -12, 15, -12,
+ax_anim 1, 0, 67, 7, -7, 7, -7,
+ax_anim 1, 0, 66, 3, -3, 3, -3,
+ax_anim_terminator
+sLedianAnims_3_5:
+ax_anim 1, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 66, 1, 4, 1, 4,
+ax_anim 6, 0, 69, 1, 6, 1, 6,
+ax_anim 1, 2, 69, 1, 3, 1, 3,
+ax_anim 1, 0, 77, 0, -6, 0, -6,
+ax_anim 1, 0, 74, 0, -12, 0, -12,
+ax_anim 1, 1, 81, -2, -16, -2, -16,
+ax_anim 2, 0, 81, -3, -15, -3, -15,
+ax_anim 6, 0, 81, -3, -12, -3, -12,
+ax_anim 2, 0, 76, 2, -18, 2, -18,
+ax_anim 2, 0, 69, 5, -20, 5, -20,
+ax_anim 2, 0, 77, 0, -13, 0, -13,
+ax_anim 1, 0, 73, 0, -5, 0, -5,
+ax_anim 1, 0, 72, 0, -1, 0, -1,
+ax_anim_terminator
+sLedianAnims_3_6:
+ax_anim 1, 0, 78, 2, 2, 2, 2,
+ax_anim 2, 0, 72, 4, 4, 4, 4,
+ax_anim 6, 0, 77, 6, 6, 6, 6,
+ax_anim 1, 2, 77, 3, 3, 3, 3,
+ax_anim 1, 0, 83, -6, -7, -6, -7,
+ax_anim 1, 0, 80, -15, -15, -15, -15,
+ax_anim 1, 1, 87, -18, -13, -18, -13,
+ax_anim 2, 0, 87, -13, -11, -13, -11,
+ax_anim 6, 0, 87, -9, -9, -9, -9,
+ax_anim 2, 0, 82, -11, -14, -11, -14,
+ax_anim 2, 0, 77, -12, -15, -12, -15,
+ax_anim 2, 0, 83, -10, -13, -10, -13,
+ax_anim 1, 0, 79, -7, -7, -7, -7,
+ax_anim 1, 0, 78, -3, -3, -3, -3,
+ax_anim_terminator
+sLedianAnims_3_7:
+ax_anim 1, 0, 84, 2, 0, 2, 0,
+ax_anim 2, 0, 78, 4, 0, 4, 0,
+ax_anim 6, 0, 83, 6, 0, 6, 0,
+ax_anim 1, 2, 83, 3, 0, 3, 0,
+ax_anim 1, 0, 89, -3, 0, -3, 0,
+ax_anim 1, 0, 86, -9, 0, -9, 0,
+ax_anim 1, 1, 93, -11, 2, -11, 2,
+ax_anim 2, 0, 93, -10, 2, -10, 2,
+ax_anim 6, 0, 93, -9, 2, -9, 2,
+ax_anim 2, 0, 88, -14, 2, -14, 2,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 89, -10, -1, -10, -1,
+ax_anim 1, 0, 85, -7, -1, -7, -1,
+ax_anim 1, 0, 84, -3, 0, -3, 0,
+ax_anim_terminator
+sLedianAnims_3_8:
+ax_anim 1, 0, 90, 2, -2, 2, -2,
+ax_anim 2, 0, 84, 4, -4, 4, -4,
+ax_anim 6, 0, 89, 6, -6, 6, -6,
+ax_anim 1, 2, 89, 3, -3, 3, -3,
+ax_anim 1, 0, 95, -8, 6, -8, 6,
+ax_anim 1, 0, 92, -14, 19, -14, 19,
+ax_anim 1, 1, 51, -14, 21, -14, 21,
+ax_anim 2, 0, 51, -13, 20, -13, 20,
+ax_anim 6, 0, 51, -11, 16, -11, 16,
+ax_anim 2, 0, 94, -19, 17, -19, 17,
+ax_anim 2, 0, 89, -20, 19, -20, 19,
+ax_anim 2, 0, 95, -16, 15, -16, 15,
+ax_anim 1, 0, 91, -11, 11, -11, 11,
+ax_anim 1, 0, 90, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sLedianAnims_4_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 2, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 1, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_4_2:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 2, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 1, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_4_3:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 2, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 1, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_4_4:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 2, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 1, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_4_5:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 2, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 1, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_4_6:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 2, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 1, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_4_7:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 2, 2, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 1, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_4_8:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 2, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 1, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_5_1:
+ax_anim 1, 0, 128, 0, -2, 0, -2,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 4, 0, 128, 0, -4, 0, -4,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 1, 0, 128, 0, -2, 0, -2,
+ax_anim 6, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim_terminator
+sLedianAnims_5_2:
+ax_anim 1, 0, 129, 0, -2, 0, -2,
+ax_anim 2, 0, 129, 0, -3, 0, -3,
+ax_anim 4, 0, 129, 0, -4, 0, -4,
+ax_anim 2, 0, 129, 0, -3, 0, -3,
+ax_anim 1, 0, 129, 0, -2, 0, -2,
+ax_anim 6, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim_terminator
+sLedianAnims_5_3:
+ax_anim 1, 0, 130, 0, -2, 0, -2,
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 4, 0, 130, 0, -4, 0, -4,
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 1, 0, 130, 0, -2, 0, -2,
+ax_anim 6, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim_terminator
+sLedianAnims_5_4:
+ax_anim 1, 0, 131, 0, -2, 0, -2,
+ax_anim 2, 0, 131, 0, -3, 0, -3,
+ax_anim 4, 0, 131, 0, -4, 0, -4,
+ax_anim 2, 0, 131, 0, -3, 0, -3,
+ax_anim 1, 0, 131, 0, -2, 0, -2,
+ax_anim 6, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim_terminator
+sLedianAnims_5_5:
+ax_anim 1, 0, 132, 0, -2, 0, -2,
+ax_anim 2, 0, 132, 0, -3, 0, -3,
+ax_anim 4, 0, 132, 0, -4, 0, -4,
+ax_anim 2, 0, 132, 0, -3, 0, -3,
+ax_anim 1, 0, 132, 0, -2, 0, -2,
+ax_anim 6, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim_terminator
+sLedianAnims_5_6:
+ax_anim 1, 0, 133, 0, -2, 0, -2,
+ax_anim 2, 0, 133, 0, -3, 0, -3,
+ax_anim 4, 0, 133, 0, -4, 0, -4,
+ax_anim 2, 0, 133, 0, -3, 0, -3,
+ax_anim 1, 0, 133, 0, -2, 0, -2,
+ax_anim 6, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 1, -1, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 1, -1, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 1, -1, 1,
+ax_anim_terminator
+sLedianAnims_5_7:
+ax_anim 1, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 4, 0, 134, 0, -4, 0, -4,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 1, 0, 134, 0, -2, 0, -2,
+ax_anim 6, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim_terminator
+sLedianAnims_5_8:
+ax_anim 1, 0, 135, 0, -2, 0, -2,
+ax_anim 2, 0, 135, 0, -3, 0, -3,
+ax_anim 4, 0, 135, 0, -4, 0, -4,
+ax_anim 2, 0, 135, 0, -3, 0, -3,
+ax_anim 1, 0, 135, 0, -2, 0, -2,
+ax_anim 6, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sLedianAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sLedianAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sLedianAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sLedianAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sLedianAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sLedianAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sLedianAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sLedianAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLedianAnims_8_1:
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, -1, 0, 0,
+ax_anim 4, 0, 147, 0, -1, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -1, 0, 0,
+ax_anim 4, 0, 147, 0, -1, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_8_2:
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -1, 0, 0,
+ax_anim 4, 0, 149, 0, -1, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -1, 0, 0,
+ax_anim 4, 0, 149, 0, -1, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_8_3:
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, -1, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, 0,
+ax_anim 4, 0, 150, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 150, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 150, 0, -1, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_8_4:
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, -1, 0, 0,
+ax_anim 4, 0, 153, 0, -1, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 153, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 153, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -1, 0, 0,
+ax_anim 4, 0, 153, 0, -1, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_8_5:
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -1, 0, 0,
+ax_anim 4, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -1, 0, 0,
+ax_anim 4, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_8_6:
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, -1, 0, 0,
+ax_anim 4, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 156, 0, -1, 0, 0,
+ax_anim 4, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_8_7:
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, 0,
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_8_8:
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -1, 0, 0,
+ax_anim 4, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -1, 0, 0,
+ax_anim 4, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 9, 6, 9, 6,
+ax_anim 2, 0, 164, 13, 12, 13, 12,
+ax_anim 2, 0, 165, 9, 19, 9, 19,
+ax_anim 3, 0, 166, 0, 22, 0, 22,
+ax_anim 2, 3, 167, -9, 19, -9, 19,
+ax_anim 2, 0, 168, -13, 12, -13, 12,
+ax_anim 1, 0, 169, -9, 6, -9, 6,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 12, 1, 12, 1,
+ax_anim 2, 0, 163, 18, 8, 18, 8,
+ax_anim 2, 0, 164, 22, 17, 22, 17,
+ax_anim 3, 0, 165, 19, 24, 19, 24,
+ax_anim 2, 3, 166, 9, 22, 9, 22,
+ax_anim 2, 0, 167, 1, 17, 1, 17,
+ax_anim 1, 0, 168, -4, 8, -4, 8,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 8, -4, 8, -4,
+ax_anim 2, 0, 162, 16, -5, 16, -5,
+ax_anim 2, 0, 163, 20, -2, 20, -2,
+ax_anim 3, 0, 164, 21, 2, 21, 2,
+ax_anim 2, 3, 165, 17, 8, 17, 8,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -2, -6, -2, -6,
+ax_anim 2, 0, 169, 4, -14, 4, -14,
+ax_anim 2, 0, 162, 11, -21, 11, -21,
+ax_anim 3, 0, 163, 19, -17, 19, -17,
+ax_anim 2, 3, 164, 22, -11, 22, -11,
+ax_anim 2, 0, 165, 20, -3, 20, -3,
+ax_anim 1, 0, 166, 13, 0, 13, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -9, -3, -9, -3,
+ax_anim 2, 0, 168, -12, -7, -12, -7,
+ax_anim 2, 0, 169, -7, -15, -7, -15,
+ax_anim 3, 0, 162, 0, -18, 0, -18,
+ax_anim 2, 3, 163, 7, -15, 7, -15,
+ax_anim 2, 0, 164, 11, -8, 11, -8,
+ax_anim 1, 0, 165, 9, -3, 9, -3,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 2, -6, 2, -6,
+ax_anim 2, 0, 163, -4, -14, -4, -14,
+ax_anim 2, 0, 162, -11, -21, -11, -21,
+ax_anim 3, 0, 169, -19, -17, -19, -17,
+ax_anim 2, 3, 168, -22, -11, -22, -11,
+ax_anim 2, 0, 167, -20, -3, -20, -3,
+ax_anim 1, 0, 166, -13, 0, -13, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -8, -4, -8, -4,
+ax_anim 2, 0, 162, -16, -5, -16, -5,
+ax_anim 2, 0, 169, -20, -2, -20, -2,
+ax_anim 3, 0, 168, -21, 2, -21, 2,
+ax_anim 2, 3, 167, -16, 7, -16, 7,
+ax_anim 2, 0, 166, -12, 6, -12, 6,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -12, 1, -12, 1,
+ax_anim 2, 0, 169, -18, 8, -18, 8,
+ax_anim 2, 0, 168, -22, 17, -22, 17,
+ax_anim 3, 0, 167, -19, 24, -19, 24,
+ax_anim 2, 3, 166, -9, 22, -9, 22,
+ax_anim 2, 0, 165, -1, 17, -1, 17,
+ax_anim 1, 0, 164, 4, 8, 4, 8,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedianAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sLedianGfx1:
+.incbin "baserom.gba", 0xC48AAC, 0x200
+sLedianSprites1:
+ax_sprite sLedianGfx1, 0x200
+ax_sprite_terminator
+sLedianGfx2:
+.incbin "baserom.gba", 0xC48CBC, 0x200
+sLedianSprites2:
+ax_sprite sLedianGfx2, 0x200
+ax_sprite_terminator
+sLedianGfx3:
+.incbin "baserom.gba", 0xC48ECC, 0x200
+sLedianSprites3:
+ax_sprite sLedianGfx3, 0x200
+ax_sprite_terminator
+sLedianGfx4:
+.incbin "baserom.gba", 0xC490DC, 0x200
+sLedianSprites4:
+ax_sprite sLedianGfx4, 0x200
+ax_sprite_terminator
+sLedianGfx5:
+.incbin "baserom.gba", 0xC492EC, 0x200
+sLedianSprites5:
+ax_sprite sLedianGfx5, 0x200
+ax_sprite_terminator
+sLedianGfx6:
+.incbin "baserom.gba", 0xC494FC, 0x200
+sLedianSprites6:
+ax_sprite sLedianGfx6, 0x200
+ax_sprite_terminator
+sLedianGfx7:
+.incbin "baserom.gba", 0xC4970C, 0x200
+sLedianSprites7:
+ax_sprite sLedianGfx7, 0x200
+ax_sprite_terminator
+sLedianGfx8:
+.incbin "baserom.gba", 0xC4991C, 0x200
+sLedianSprites8:
+ax_sprite sLedianGfx8, 0x200
+ax_sprite_terminator
+sLedianGfx9:
+.incbin "baserom.gba", 0xC49B2C, 0x200
+sLedianSprites9:
+ax_sprite sLedianGfx9, 0x200
+ax_sprite_terminator
+sLedianGfx10:
+.incbin "baserom.gba", 0xC49D3C, 0x200
+sLedianSprites10:
+ax_sprite sLedianGfx10, 0x200
+ax_sprite_terminator
+sLedianGfx11:
+.incbin "baserom.gba", 0xC49F4C, 0x40
+sLedianGfx11_1:
+.incbin "baserom.gba", 0xC49F8C, 0x100
+sLedianGfx11_2:
+.incbin "baserom.gba", 0xC4A08C, 0x40
+sLedianSprites11:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx11, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx11_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx11_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx12:
+.incbin "baserom.gba", 0xC4A10C, 0x40
+sLedianGfx12_1:
+.incbin "baserom.gba", 0xC4A14C, 0x100
+sLedianGfx12_2:
+.incbin "baserom.gba", 0xC4A24C, 0x60
+sLedianSprites12:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx12, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx12_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx12_2, 0x60
+ax_sprite_terminator
+sLedianGfx13:
+.incbin "baserom.gba", 0xC4A2E4, 0x40
+sLedianGfx13_1:
+.incbin "baserom.gba", 0xC4A324, 0x60
+sLedianGfx13_2:
+.incbin "baserom.gba", 0xC4A384, 0xE0
+sLedianSprites13:
+ax_sprite sLedianGfx13, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx13_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx13_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx14:
+.incbin "baserom.gba", 0xC4A49C, 0x40
+sLedianGfx14_1:
+.incbin "baserom.gba", 0xC4A4DC, 0x40
+sLedianGfx14_2:
+.incbin "baserom.gba", 0xC4A51C, 0x60
+sLedianGfx14_3:
+.incbin "baserom.gba", 0xC4A57C, 0x60
+sLedianSprites14:
+ax_sprite sLedianGfx14, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx14_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx14_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx14_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx15:
+.incbin "baserom.gba", 0xC4A624, 0x40
+sLedianGfx15_1:
+.incbin "baserom.gba", 0xC4A664, 0x60
+sLedianGfx15_2:
+.incbin "baserom.gba", 0xC4A6C4, 0x60
+sLedianGfx15_3:
+.incbin "baserom.gba", 0xC4A724, 0x60
+sLedianSprites15:
+ax_sprite sLedianGfx15, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx15_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx15_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx15_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx16:
+.incbin "baserom.gba", 0xC4A7CC, 0x40
+sLedianGfx16_1:
+.incbin "baserom.gba", 0xC4A80C, 0x60
+sLedianGfx16_2:
+.incbin "baserom.gba", 0xC4A86C, 0x60
+sLedianGfx16_3:
+.incbin "baserom.gba", 0xC4A8CC, 0x40
+sLedianSprites16:
+ax_sprite sLedianGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx17:
+.incbin "baserom.gba", 0xC4A954, 0x40
+sLedianGfx17_1:
+.incbin "baserom.gba", 0xC4A994, 0x60
+sLedianGfx17_2:
+.incbin "baserom.gba", 0xC4A9F4, 0x60
+sLedianGfx17_3:
+.incbin "baserom.gba", 0xC4AA54, 0x60
+sLedianSprites17:
+ax_sprite sLedianGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx18:
+.incbin "baserom.gba", 0xC4AAFC, 0x40
+sLedianGfx18_1:
+.incbin "baserom.gba", 0xC4AB3C, 0x60
+sLedianGfx18_2:
+.incbin "baserom.gba", 0xC4AB9C, 0x60
+sLedianGfx18_3:
+.incbin "baserom.gba", 0xC4ABFC, 0x60
+sLedianSprites18:
+ax_sprite sLedianGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx19:
+.incbin "baserom.gba", 0xC4ACA4, 0x40
+sLedianGfx19_1:
+.incbin "baserom.gba", 0xC4ACE4, 0x180
+sLedianSprites19:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx19_1, 0x180
+ax_sprite_terminator
+sLedianGfx20:
+.incbin "baserom.gba", 0xC4AE8C, 0x40
+sLedianGfx20_1:
+.incbin "baserom.gba", 0xC4AECC, 0x180
+sLedianSprites20:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx20_1, 0x180
+ax_sprite_terminator
+sLedianGfx21:
+.incbin "baserom.gba", 0xC4B074, 0x20
+sLedianGfx21_1:
+.incbin "baserom.gba", 0xC4B094, 0x20
+sLedianGfx21_2:
+.incbin "baserom.gba", 0xC4B0B4, 0x20
+sLedianGfx21_3:
+.incbin "baserom.gba", 0xC4B0D4, 0xE0
+sLedianSprites21:
+ax_sprite sLedianGfx21, 0x20
+ax_sprite 0, 0x60
+ax_sprite sLedianGfx21_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx21_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx21_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx22:
+.incbin "baserom.gba", 0xC4B1FC, 0x40
+sLedianGfx22_1:
+.incbin "baserom.gba", 0xC4B23C, 0x100
+sLedianGfx22_2:
+.incbin "baserom.gba", 0xC4B33C, 0x40
+sLedianSprites22:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx23:
+.incbin "baserom.gba", 0xC4B3BC, 0x20
+sLedianGfx23_1:
+.incbin "baserom.gba", 0xC4B3DC, 0x20
+sLedianGfx23_2:
+.incbin "baserom.gba", 0xC4B3FC, 0x60
+sLedianGfx23_3:
+.incbin "baserom.gba", 0xC4B45C, 0x60
+sLedianSprites23:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx23_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sLedianGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx24:
+.incbin "baserom.gba", 0xC4B50C, 0x40
+sLedianGfx24_1:
+.incbin "baserom.gba", 0xC4B54C, 0x180
+sLedianSprites24:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx24_1, 0x180
+ax_sprite_terminator
+sLedianGfx25:
+.incbin "baserom.gba", 0xC4B6F4, 0x20
+sLedianGfx25_1:
+.incbin "baserom.gba", 0xC4B714, 0x40
+sLedianGfx25_2:
+.incbin "baserom.gba", 0xC4B754, 0xA0
+sLedianSprites25:
+ax_sprite 0, 0x80
+ax_sprite sLedianGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx25_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx26:
+.incbin "baserom.gba", 0xC4B834, 0x20
+sLedianGfx26_1:
+.incbin "baserom.gba", 0xC4B854, 0x60
+sLedianGfx26_2:
+.incbin "baserom.gba", 0xC4B8B4, 0x60
+sLedianGfx26_3:
+.incbin "baserom.gba", 0xC4B914, 0x60
+sLedianSprites26:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx26, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx27:
+.incbin "baserom.gba", 0xC4B9C4, 0x20
+sLedianGfx27_1:
+.incbin "baserom.gba", 0xC4B9E4, 0x40
+sLedianGfx27_2:
+.incbin "baserom.gba", 0xC4BA24, 0x60
+sLedianGfx27_3:
+.incbin "baserom.gba", 0xC4BA84, 0x60
+sLedianSprites27:
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx28:
+.incbin "baserom.gba", 0xC4BB34, 0x40
+sLedianGfx28_1:
+.incbin "baserom.gba", 0xC4BB74, 0x60
+sLedianGfx28_2:
+.incbin "baserom.gba", 0xC4BBD4, 0x60
+sLedianGfx28_3:
+.incbin "baserom.gba", 0xC4BC34, 0x80
+sLedianSprites28:
+ax_sprite sLedianGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx28_3, 0x80
+ax_sprite_terminator
+sLedianGfx29:
+.incbin "baserom.gba", 0xC4BCF4, 0x40
+sLedianGfx29_1:
+.incbin "baserom.gba", 0xC4BD34, 0x100
+sLedianSprites29:
+ax_sprite 0, 0x80
+ax_sprite sLedianGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx29_1, 0x100
+ax_sprite_terminator
+sLedianGfx30:
+.incbin "baserom.gba", 0xC4BE5C, 0x40
+sLedianGfx30_1:
+.incbin "baserom.gba", 0xC4BE9C, 0x60
+sLedianGfx30_2:
+.incbin "baserom.gba", 0xC4BEFC, 0xE0
+sLedianSprites30:
+ax_sprite sLedianGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx30_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx31:
+.incbin "baserom.gba", 0xC4C014, 0x60
+sLedianGfx31_1:
+.incbin "baserom.gba", 0xC4C074, 0xC0
+sLedianGfx31_2:
+.incbin "baserom.gba", 0xC4C134, 0x40
+sLedianSprites31:
+ax_sprite sLedianGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx31_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLedianGfx32:
+.incbin "baserom.gba", 0xC4C1AC, 0x40
+sLedianGfx32_1:
+.incbin "baserom.gba", 0xC4C1EC, 0x60
+sLedianGfx32_2:
+.incbin "baserom.gba", 0xC4C24C, 0x60
+sLedianGfx32_3:
+.incbin "baserom.gba", 0xC4C2AC, 0x60
+sLedianSprites32:
+ax_sprite sLedianGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx33:
+.incbin "baserom.gba", 0xC4C354, 0x60
+sLedianGfx33_1:
+.incbin "baserom.gba", 0xC4C3B4, 0x60
+sLedianGfx33_2:
+.incbin "baserom.gba", 0xC4C414, 0x40
+sLedianGfx33_3:
+.incbin "baserom.gba", 0xC4C454, 0x40
+sLedianSprites33:
+ax_sprite sLedianGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx33_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLedianGfx34:
+.incbin "baserom.gba", 0xC4C4DC, 0x40
+sLedianGfx34_1:
+.incbin "baserom.gba", 0xC4C51C, 0x60
+sLedianGfx34_2:
+.incbin "baserom.gba", 0xC4C57C, 0xE0
+sLedianSprites34:
+ax_sprite sLedianGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx34_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx35:
+.incbin "baserom.gba", 0xC4C694, 0x120
+sLedianGfx35_1:
+.incbin "baserom.gba", 0xC4C7B4, 0x20
+sLedianSprites35:
+ax_sprite sLedianGfx35, 0x120
+ax_sprite 0, 0x40
+ax_sprite sLedianGfx35_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLedianGfx36:
+.incbin "baserom.gba", 0xC4C7FC, 0x40
+sLedianGfx36_1:
+.incbin "baserom.gba", 0xC4C83C, 0x100
+sLedianGfx36_2:
+.incbin "baserom.gba", 0xC4C93C, 0x40
+sLedianSprites36:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx36_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx37:
+.incbin "baserom.gba", 0xC4C9BC, 0x40
+sLedianGfx37_1:
+.incbin "baserom.gba", 0xC4C9FC, 0x160
+sLedianSprites37:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx37_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx38:
+.incbin "baserom.gba", 0xC4CB8C, 0x60
+sLedianGfx38_1:
+.incbin "baserom.gba", 0xC4CBEC, 0x60
+sLedianGfx38_2:
+.incbin "baserom.gba", 0xC4CC4C, 0x60
+sLedianGfx38_3:
+.incbin "baserom.gba", 0xC4CCAC, 0x60
+sLedianSprites38:
+ax_sprite sLedianGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx39:
+.incbin "baserom.gba", 0xC4CD54, 0x60
+sLedianGfx39_1:
+.incbin "baserom.gba", 0xC4CDB4, 0x60
+sLedianGfx39_2:
+.incbin "baserom.gba", 0xC4CE14, 0x60
+sLedianGfx39_3:
+.incbin "baserom.gba", 0xC4CE74, 0x60
+sLedianSprites39:
+ax_sprite sLedianGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx40:
+.incbin "baserom.gba", 0xC4CF1C, 0x60
+sLedianGfx40_1:
+.incbin "baserom.gba", 0xC4CF7C, 0x60
+sLedianGfx40_2:
+.incbin "baserom.gba", 0xC4CFDC, 0x60
+sLedianGfx40_3:
+.incbin "baserom.gba", 0xC4D03C, 0x60
+sLedianSprites40:
+ax_sprite sLedianGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx40_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedianGfx41:
+.incbin "baserom.gba", 0xC4D0E4, 0x40
+sLedianGfx41_1:
+.incbin "baserom.gba", 0xC4D124, 0x180
+sLedianSprites41:
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedianGfx41_1, 0x180
+ax_sprite_terminator
+sLedianGfx42:
+.incbin "baserom.gba", 0xC4D2CC, 0x200
+sLedianSprites42:
+ax_sprite sLedianGfx42, 0x200
+ax_sprite_terminator
+sLedianGfx43:
+.incbin "baserom.gba", 0xC4D4DC, 0x200
+sLedianSprites43:
+ax_sprite sLedianGfx43, 0x200
+ax_sprite_terminator
+sLedianGfx44:
+.incbin "baserom.gba", 0xC4D6EC, 0x200
+sLedianSprites44:
+ax_sprite sLedianGfx44, 0x200
+ax_sprite_terminator
+sLedianGfx45:
+.incbin "baserom.gba", 0xC4D8FC, 0x200
+sLedianSprites45:
+ax_sprite sLedianGfx45, 0x200
+ax_sprite_terminator
+sLedianGfx46:
+.incbin "baserom.gba", 0xC4DB0C, 0x200
+sLedianSprites46:
+ax_sprite sLedianGfx46, 0x200
+ax_sprite_terminator
+sLedianGfx47:
+.incbin "baserom.gba", 0xC4DD1C, 0x200
+sLedianSprites47:
+ax_sprite sLedianGfx47, 0x200
+ax_sprite_terminator
+sLedianGfx48:
+.incbin "baserom.gba", 0xC4DF2C, 0x200
+sLedianSprites48:
+ax_sprite sLedianGfx48, 0x200
+ax_sprite_terminator
+sLedianGfx49:
+.incbin "baserom.gba", 0xC4E13C, 0x200
+sLedianSprites49:
+ax_sprite sLedianGfx49, 0x200
+ax_sprite_terminator
+sLedianGfx50:
+.incbin "baserom.gba", 0xC4E34C, 0x200
+sLedianSprites50:
+ax_sprite sLedianGfx50, 0x200
+ax_sprite_terminator
+sLedianGfx51:
+.incbin "baserom.gba", 0xC4E55C, 0x200
+sLedianSprites51:
+ax_sprite sLedianGfx51, 0x200
+ax_sprite_terminator
+sLedianGfx52:
+.incbin "baserom.gba", 0xC4E76C, 0x200
+sLedianSprites52:
+ax_sprite sLedianGfx52, 0x200
+ax_sprite_terminator
+sLedianGfx53:
+.incbin "baserom.gba", 0xC4E97C, 0x200
+sLedianSprites53:
+ax_sprite sLedianGfx53, 0x200
+ax_sprite_terminator
+sAxPosesLedian:
+.4byte sLedianPose1
+.4byte sLedianPose2
+.4byte sLedianPose3
+.4byte sLedianPose4
+.4byte sLedianPose5
+.4byte sLedianPose6
+.4byte sLedianPose7
+.4byte sLedianPose8
+.4byte sLedianPose9
+.4byte sLedianPose10
+.4byte sLedianPose11
+.4byte sLedianPose12
+.4byte sLedianPose13
+.4byte sLedianPose14
+.4byte sLedianPose15
+.4byte sLedianPose16
+.4byte sLedianPose17
+.4byte sLedianPose18
+.4byte sLedianPose19
+.4byte sLedianPose20
+.4byte sLedianPose21
+.4byte sLedianPose22
+.4byte sLedianPose23
+.4byte sLedianPose24
+.4byte sLedianPose25
+.4byte sLedianPose26
+.4byte sLedianPose27
+.4byte sLedianPose28
+.4byte sLedianPose29
+.4byte sLedianPose30
+.4byte sLedianPose31
+.4byte sLedianPose32
+.4byte sLedianPose33
+.4byte sLedianPose34
+.4byte sLedianPose35
+.4byte sLedianPose36
+.4byte sLedianPose37
+.4byte sLedianPose38
+.4byte sLedianPose39
+.4byte sLedianPose40
+.4byte sLedianPose41
+.4byte sLedianPose42
+.4byte sLedianPose43
+.4byte sLedianPose44
+.4byte sLedianPose45
+.4byte sLedianPose46
+.4byte sLedianPose47
+.4byte sLedianPose48
+.4byte sLedianPose49
+.4byte sLedianPose50
+.4byte sLedianPose51
+.4byte sLedianPose52
+.4byte sLedianPose53
+.4byte sLedianPose54
+.4byte sLedianPose55
+.4byte sLedianPose56
+.4byte sLedianPose57
+.4byte sLedianPose58
+.4byte sLedianPose59
+.4byte sLedianPose60
+.4byte sLedianPose61
+.4byte sLedianPose62
+.4byte sLedianPose63
+.4byte sLedianPose64
+.4byte sLedianPose65
+.4byte sLedianPose66
+.4byte sLedianPose67
+.4byte sLedianPose68
+.4byte sLedianPose69
+.4byte sLedianPose70
+.4byte sLedianPose71
+.4byte sLedianPose72
+.4byte sLedianPose73
+.4byte sLedianPose74
+.4byte sLedianPose75
+.4byte sLedianPose76
+.4byte sLedianPose77
+.4byte sLedianPose78
+.4byte sLedianPose79
+.4byte sLedianPose80
+.4byte sLedianPose81
+.4byte sLedianPose82
+.4byte sLedianPose83
+.4byte sLedianPose84
+.4byte sLedianPose85
+.4byte sLedianPose86
+.4byte sLedianPose87
+.4byte sLedianPose88
+.4byte sLedianPose89
+.4byte sLedianPose90
+.4byte sLedianPose91
+.4byte sLedianPose92
+.4byte sLedianPose93
+.4byte sLedianPose94
+.4byte sLedianPose95
+.4byte sLedianPose96
+.4byte sLedianPose97
+.4byte sLedianPose98
+.4byte sLedianPose99
+.4byte sLedianPose100
+.4byte sLedianPose101
+.4byte sLedianPose102
+.4byte sLedianPose103
+.4byte sLedianPose104
+.4byte sLedianPose105
+.4byte sLedianPose106
+.4byte sLedianPose107
+.4byte sLedianPose108
+.4byte sLedianPose109
+.4byte sLedianPose110
+.4byte sLedianPose111
+.4byte sLedianPose112
+.4byte sLedianPose113
+.4byte sLedianPose114
+.4byte sLedianPose115
+.4byte sLedianPose116
+.4byte sLedianPose117
+.4byte sLedianPose118
+.4byte sLedianPose119
+.4byte sLedianPose120
+.4byte sLedianPose121
+.4byte sLedianPose122
+.4byte sLedianPose123
+.4byte sLedianPose124
+.4byte sLedianPose125
+.4byte sLedianPose126
+.4byte sLedianPose127
+.4byte sLedianPose128
+.4byte sLedianPose129
+.4byte sLedianPose130
+.4byte sLedianPose131
+.4byte sLedianPose132
+.4byte sLedianPose133
+.4byte sLedianPose134
+.4byte sLedianPose135
+.4byte sLedianPose136
+.4byte sLedianPose137
+.4byte sLedianPose138
+.4byte sLedianPose139
+.4byte sLedianPose140
+.4byte sLedianPose141
+.4byte sLedianPose142
+.4byte sLedianPose143
+.4byte sLedianPose144
+.4byte sLedianPose145
+.4byte sLedianPose146
+.4byte sLedianPose147
+.4byte sLedianPose148
+.4byte sLedianPose149
+.4byte sLedianPose150
+.4byte sLedianPose151
+.4byte sLedianPose152
+.4byte sLedianPose153
+.4byte sLedianPose154
+.4byte sLedianPose155
+.4byte sLedianPose156
+.4byte sLedianPose157
+.4byte sLedianPose158
+.4byte sLedianPose159
+.4byte sLedianPose160
+.4byte sLedianPose161
+.4byte sLedianPose162
+.4byte sLedianPose163
+.4byte sLedianPose164
+.4byte sLedianPose165
+.4byte sLedianPose166
+.4byte sLedianPose167
+.4byte sLedianPose168
+.4byte sLedianPose169
+.4byte sLedianPose170
+.4byte sLedianPose171
+.4byte sLedianPose172
+.4byte sLedianPose173
+.4byte sLedianPose174
+.4byte sLedianPose175
+.4byte sLedianPose176
+.4byte sLedianPose177
+.4byte sLedianPose178
+.4byte sLedianPose179
+.4byte sLedianPose180
+.4byte sLedianPose181
+.4byte sLedianPose182
+.4byte sLedianPose183
+.4byte sLedianPose184
+.4byte sLedianPose185
+.4byte sLedianPose186
+.4byte sLedianPose187
+.4byte sLedianPose188
+.4byte sLedianPose189
+.4byte sLedianPose190
+.4byte sLedianPose191
+.4byte sLedianPose192
+.4byte sLedianPose193
+.4byte sLedianPose194
+.4byte sLedianPose195
+.4byte sLedianPose196
+.4byte sLedianPose197
+.4byte sLedianPose198
+.4byte sLedianPose199
+.4byte sLedianPose200
+.4byte sLedianPose201
+.4byte sLedianPose202
+.4byte sLedianPose203
+.4byte sLedianPose204
+.4byte sLedianPose205
+.4byte sLedianPose206
+.4byte sLedianPose207
+.4byte sLedianPose208
+.4byte sLedianPose209
+.4byte sLedianPose210
+.4byte sLedianPose211
+.4byte sLedianPose212
+.4byte sLedianPose213
+.4byte sLedianPose214
+.4byte sLedianPose215
+.4byte sLedianPose216
+.4byte sLedianPose217
+.4byte sLedianPose218
+sAxPositionsLedian:
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   0,  -12
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   1,  -12
+.2byte    6,  -14, 	   2,  -20, 	   2,  -11, 	  -1,  -13
+.2byte    6,  -14, 	   3,  -21, 	   2,  -11, 	  -1,  -13
+.2byte    2,  -15, 	  -6,  -19, 	   6,  -11, 	  -1,  -13
+.2byte    2,  -16, 	  -6,  -19, 	   6,  -11, 	   0,  -13
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -4,  -15, 	   4,  -19, 	  -8,  -11, 	  -1,  -13
+.2byte   -4,  -16, 	   4,  -19, 	  -8,  -11, 	  -2,  -13
+.2byte   -8,  -14, 	  -4,  -20, 	  -4,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	  -5,  -21, 	  -4,  -11, 	  -1,  -13
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -2,  -12
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -3,  -12
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -5,   -9, 	  -9,  -16, 	  -6,   -7, 	  -1,   -8
+.2byte   -5,   -9, 	  -9,  -16, 	  -6,   -7, 	  -1,   -8
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   0,  -12
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   1,  -12
+.2byte    6,  -12, 	   3,  -18, 	   5,   -8, 	  -3,  -10
+.2byte    6,  -12, 	   3,  -18, 	   5,   -8, 	  -4,  -11
+.2byte    6,  -14, 	   2,  -20, 	   2,  -11, 	  -1,  -13
+.2byte    6,  -14, 	   3,  -21, 	   2,  -11, 	  -1,  -13
+.2byte    3,  -16, 	  -7,  -22, 	   7,  -15, 	  -1,  -15
+.2byte    3,  -17, 	  -7,  -22, 	   7,  -15, 	  -2,  -15
+.2byte    2,  -15, 	  -6,  -19, 	   6,  -11, 	  -1,  -13
+.2byte    2,  -16, 	  -6,  -19, 	   6,  -11, 	   0,  -13
+.2byte    0,  -19, 	  -9,  -21, 	   0,  -16, 	  -2,  -15
+.2byte    0,  -19, 	  -9,  -21, 	  -1,  -17, 	  -2,  -15
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte    3,  -17, 	   9,  -15, 	   0,  -12, 	  -2,  -13
+.2byte    3,  -17, 	   9,  -15, 	   1,  -13, 	  -2,  -13
+.2byte   -4,  -15, 	   4,  -19, 	  -8,  -11, 	  -1,  -13
+.2byte   -4,  -16, 	   4,  -19, 	  -8,  -11, 	  -2,  -13
+.2byte   -2,  -19, 	   7,  -21, 	  -2,  -16, 	   0,  -15
+.2byte   -2,  -19, 	   7,  -21, 	  -1,  -17, 	   0,  -15
+.2byte   -8,  -14, 	  -4,  -20, 	  -4,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	  -5,  -21, 	  -4,  -11, 	  -1,  -13
+.2byte   -5,  -16, 	   5,  -22, 	  -9,  -15, 	  -1,  -15
+.2byte   -5,  -17, 	   5,  -22, 	  -9,  -15, 	   0,  -15
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -2,  -12
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -3,  -12
+.2byte   -8,  -12, 	  -5,  -18, 	  -7,   -8, 	   1,  -10
+.2byte   -8,  -12, 	  -5,  -18, 	  -7,   -8, 	   2,  -11
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte    5,  -12, 	   6,  -10, 	   7,  -18, 	   0,  -10
+.2byte    5,  -12, 	   6,  -10, 	   7,  -18, 	   0,  -10
+.2byte   -6,  -12, 	  -7,  -10, 	  -8,  -18, 	  -1,  -10
+.2byte   -6,  -12, 	  -7,  -10, 	  -8,  -18, 	  -1,  -10
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   0,  -12
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   1,  -12
+.2byte   -3,  -10, 	  -5,   -6, 	 -12,  -18, 	  -3,  -13
+.2byte   -3,  -10, 	  -5,   -6, 	 -12,  -18, 	  -3,  -13
+.2byte    6,  -13, 	   5,  -20, 	   8,  -11, 	  -2,  -10
+.2byte    6,  -13, 	   5,  -20, 	   8,  -11, 	  -2,  -10
+.2byte    6,  -14, 	   2,  -20, 	   2,  -11, 	  -1,  -13
+.2byte    6,  -14, 	   3,  -21, 	   2,  -11, 	  -1,  -13
+.2byte    2,  -10, 	  -3,   -8, 	 -10,  -12, 	  -3,  -12
+.2byte    2,  -10, 	  -3,   -8, 	 -10,  -12, 	  -3,  -12
+.2byte    1,  -16, 	 -10,  -21, 	   7,  -17, 	  -4,  -14
+.2byte    1,  -16, 	 -10,  -21, 	   7,  -17, 	  -4,  -14
+.2byte    2,  -15, 	  -6,  -19, 	   6,  -11, 	  -1,  -13
+.2byte    2,  -16, 	  -6,  -19, 	   6,  -11, 	   0,  -13
+.2byte    3,  -14, 	   6,   -9, 	   1,  -11, 	  -3,  -13
+.2byte    3,  -14, 	   6,   -9, 	   1,  -11, 	  -3,  -13
+.2byte   -2,  -17, 	 -10,  -18, 	  -6,  -18, 	  -2,  -12
+.2byte   -2,  -17, 	 -10,  -18, 	  -6,  -18, 	  -2,  -12
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -5,  -17, 	 -10,  -17, 	  -9,  -14, 	   0,  -14
+.2byte   -5,  -17, 	 -10,  -17, 	  -9,  -14, 	   0,  -14
+.2byte    4,  -17, 	   9,  -17, 	   8,  -14, 	  -1,  -14
+.2byte    4,  -17, 	   9,  -17, 	   8,  -14, 	  -1,  -14
+.2byte   -4,  -15, 	   4,  -19, 	  -8,  -11, 	  -1,  -13
+.2byte   -4,  -16, 	   4,  -19, 	  -8,  -11, 	  -2,  -13
+.2byte   -5,  -14, 	  -8,   -9, 	  -3,  -11, 	   1,  -13
+.2byte   -5,  -14, 	  -8,   -9, 	  -3,  -11, 	   1,  -13
+.2byte    0,  -17, 	   8,  -18, 	   4,  -18, 	   0,  -12
+.2byte    0,  -17, 	   8,  -18, 	   4,  -18, 	   0,  -12
+.2byte   -8,  -14, 	  -4,  -20, 	  -4,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	  -5,  -21, 	  -4,  -11, 	  -1,  -13
+.2byte   -4,  -10, 	   1,   -8, 	   8,  -12, 	   1,  -12
+.2byte   -4,  -10, 	   1,   -8, 	   8,  -12, 	   1,  -12
+.2byte   -3,  -16, 	   8,  -21, 	  -9,  -17, 	   2,  -14
+.2byte   -3,  -16, 	   8,  -21, 	  -9,  -17, 	   2,  -14
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -2,  -12
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -3,  -12
+.2byte    1,  -10, 	   3,   -6, 	  10,  -18, 	   1,  -13
+.2byte    1,  -10, 	   3,   -6, 	  10,  -18, 	   1,  -13
+.2byte   -8,  -13, 	  -7,  -20, 	 -10,  -11, 	   0,  -10
+.2byte   -8,  -13, 	  -7,  -20, 	 -10,  -11, 	   0,  -10
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -5,   -9, 	  -9,  -16, 	  -6,   -7, 	  -1,   -8
+.2byte   -5,   -9, 	  -9,  -16, 	  -6,   -7, 	  -1,   -8
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   0,  -12
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   1,  -12
+.2byte    6,  -12, 	   3,  -18, 	   5,   -8, 	  -3,  -10
+.2byte    6,  -12, 	   3,  -18, 	   5,   -8, 	  -4,  -11
+.2byte    6,  -14, 	   2,  -20, 	   2,  -11, 	  -1,  -13
+.2byte    6,  -14, 	   3,  -21, 	   2,  -11, 	  -1,  -13
+.2byte    3,  -16, 	  -7,  -22, 	   7,  -15, 	  -1,  -15
+.2byte    3,  -17, 	  -7,  -22, 	   7,  -15, 	  -2,  -15
+.2byte    2,  -15, 	  -6,  -19, 	   6,  -11, 	  -1,  -13
+.2byte    2,  -16, 	  -6,  -19, 	   6,  -11, 	   0,  -13
+.2byte    0,  -19, 	  -9,  -21, 	   0,  -16, 	  -2,  -15
+.2byte    0,  -19, 	  -9,  -21, 	  -1,  -17, 	  -2,  -15
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte    3,  -17, 	   9,  -15, 	   0,  -12, 	  -2,  -13
+.2byte    3,  -17, 	   9,  -15, 	   1,  -13, 	  -2,  -13
+.2byte   -4,  -15, 	   4,  -19, 	  -8,  -11, 	  -1,  -13
+.2byte   -4,  -16, 	   4,  -19, 	  -8,  -11, 	  -2,  -13
+.2byte   -2,  -19, 	   7,  -21, 	  -2,  -16, 	   0,  -15
+.2byte   -2,  -19, 	   7,  -21, 	  -1,  -17, 	   0,  -15
+.2byte   -8,  -14, 	  -4,  -20, 	  -4,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	  -5,  -21, 	  -4,  -11, 	  -1,  -13
+.2byte   -5,  -16, 	   5,  -22, 	  -9,  -15, 	  -1,  -15
+.2byte   -5,  -17, 	   5,  -22, 	  -9,  -15, 	   0,  -15
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -2,  -12
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -3,  -12
+.2byte   -8,  -12, 	  -5,  -18, 	  -7,   -8, 	   1,  -10
+.2byte   -8,  -12, 	  -5,  -18, 	  -7,   -8, 	   2,  -11
+.2byte   -1,  -12, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte    2,  -12, 	   7,  -13, 	  -6,   -6, 	  -1,   -8
+.2byte    4,  -15, 	  -2,  -17, 	  -2,   -6, 	  -1,  -10
+.2byte    0,  -16, 	  -6,  -16, 	   6,   -8, 	  -3,  -10
+.2byte   -1,  -17, 	   8,  -13, 	 -10,  -13, 	  -1,  -11
+.2byte   -2,  -16, 	   4,  -16, 	  -8,   -8, 	   1,  -10
+.2byte   -6,  -15, 	   0,  -17, 	   0,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	  -9,  -13, 	   4,   -6, 	  -1,   -8
+.2byte   -4,   -8, 	  -7,   -9, 	   4,   -3, 	  -1,   -6
+.2byte   -4,   -6, 	  -7,   -8, 	   4,   -2, 	  -1,   -6
+.2byte    0,  -11, 	 -10,  -14, 	  10,  -14, 	   0,   -9
+.2byte    2,  -14, 	   6,  -15, 	  -7,   -9, 	   0,  -10
+.2byte    3,  -14, 	   0,  -20, 	   0,  -10, 	   0,  -11
+.2byte    3,  -17, 	  -7,  -19, 	   8,  -11, 	   0,  -12
+.2byte    0,  -19, 	  10,  -15, 	 -10,  -15, 	   0,  -11
+.2byte   -4,  -17, 	   6,  -19, 	  -9,  -11, 	  -1,  -12
+.2byte   -4,  -14, 	  -1,  -20, 	  -1,  -10, 	  -1,  -11
+.2byte   -3,  -14, 	  -7,  -15, 	   6,   -9, 	  -1,  -10
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   0,  -12
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   1,  -12
+.2byte    6,  -14, 	   2,  -20, 	   2,  -11, 	  -1,  -13
+.2byte    6,  -14, 	   3,  -21, 	   2,  -11, 	  -1,  -13
+.2byte    2,  -15, 	  -6,  -19, 	   6,  -11, 	  -1,  -13
+.2byte    2,  -16, 	  -6,  -19, 	   6,  -11, 	   0,  -13
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -4,  -15, 	   4,  -19, 	  -8,  -11, 	  -1,  -13
+.2byte   -4,  -16, 	   4,  -19, 	  -8,  -11, 	  -2,  -13
+.2byte   -8,  -14, 	  -4,  -20, 	  -4,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	  -5,  -21, 	  -4,  -11, 	  -1,  -13
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -2,  -12
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -3,  -12
+.2byte    5,  -12, 	   6,  -10, 	   7,  -18, 	   0,  -10
+.2byte    1,   -9, 	   3,   -5, 	  10,  -17, 	   1,  -12
+.2byte   -5,   -9, 	   0,   -7, 	   7,  -11, 	   0,  -11
+.2byte   -5,  -14, 	  -8,   -9, 	  -3,  -11, 	   1,  -13
+.2byte   -3,  -14, 	  -8,  -14, 	  -7,  -11, 	   2,  -11
+.2byte    5,  -13, 	   8,   -8, 	   3,  -10, 	  -1,  -12
+.2byte    5,   -9, 	   0,   -7, 	  -7,  -11, 	   0,  -11
+.2byte   -1,   -9, 	  -3,   -5, 	 -10,  -17, 	  -1,  -12
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   0,  -12
+.2byte    6,  -14, 	   2,  -20, 	   2,  -11, 	  -1,  -13
+.2byte    2,  -15, 	  -6,  -19, 	   6,  -11, 	  -1,  -13
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -4,  -15, 	   4,  -19, 	  -8,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	  -4,  -20, 	  -4,  -11, 	  -1,  -13
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -2,  -12
+.2byte   -1,   -9, 	 -11,  -12, 	   9,  -12, 	  -1,   -8
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte   -1,  -12, 	 -11,  -14, 	   9,  -14, 	  -1,  -13
+.2byte    3,  -10, 	   7,  -15, 	  -6,   -7, 	   0,   -9
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   0,  -12
+.2byte    4,  -13, 	   8,  -17, 	  -4,  -10, 	   1,  -12
+.2byte    4,  -12, 	  -1,  -17, 	  -1,   -8, 	  -1,   -9
+.2byte    6,  -14, 	   2,  -20, 	   2,  -11, 	  -1,  -13
+.2byte    6,  -14, 	   3,  -21, 	   2,  -11, 	  -1,  -13
+.2byte    1,  -13, 	  -8,  -17, 	   6,   -9, 	  -1,  -10
+.2byte    2,  -15, 	  -6,  -19, 	   6,  -11, 	  -1,  -13
+.2byte    2,  -16, 	  -6,  -19, 	   6,  -11, 	   0,  -13
+.2byte   -1,  -17, 	   9,  -14, 	 -11,  -13, 	  -1,   -9
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -1,  -19, 	   9,  -15, 	 -11,  -15, 	  -1,  -12
+.2byte   -3,  -13, 	   6,  -17, 	  -8,   -9, 	  -1,  -10
+.2byte   -4,  -15, 	   4,  -19, 	  -8,  -11, 	  -1,  -13
+.2byte   -4,  -16, 	   4,  -19, 	  -8,  -11, 	  -2,  -13
+.2byte   -6,  -12, 	  -1,  -17, 	  -1,   -8, 	  -1,   -9
+.2byte   -8,  -14, 	  -4,  -20, 	  -4,  -11, 	  -1,  -13
+.2byte   -8,  -14, 	  -5,  -21, 	  -4,  -11, 	  -1,  -13
+.2byte   -5,  -10, 	  -9,  -15, 	   4,   -7, 	  -2,   -9
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -2,  -12
+.2byte   -6,  -13, 	 -10,  -17, 	   2,  -10, 	  -3,  -12
+.2byte   -1,  -12, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -4,  -12, 	  -9,  -13, 	   4,   -6, 	  -1,   -8
+.2byte   -7,  -15, 	  -1,  -17, 	  -1,   -6, 	  -2,  -10
+.2byte   -2,  -16, 	   4,  -16, 	  -8,   -8, 	   1,  -10
+.2byte   -1,  -17, 	   8,  -13, 	 -10,  -13, 	  -1,  -11
+.2byte    0,  -16, 	  -6,  -16, 	   6,   -8, 	  -3,  -10
+.2byte    6,  -15, 	   0,  -17, 	   0,   -6, 	   1,  -10
+.2byte    2,  -12, 	   7,  -13, 	  -6,   -6, 	  -1,   -8
+.2byte   -1,  -10, 	 -11,  -13, 	   9,  -13, 	  -1,   -9
+.2byte   -5,  -11, 	  -9,  -16, 	   4,   -8, 	  -2,  -10
+.2byte   -6,  -12, 	  -1,  -17, 	  -1,   -8, 	  -1,   -9
+.2byte   -3,  -13, 	   6,  -17, 	  -8,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   9,  -14, 	 -11,  -13, 	  -1,   -9
+.2byte    1,  -13, 	  -8,  -17, 	   6,   -9, 	  -1,  -10
+.2byte    4,  -12, 	  -1,  -17, 	  -1,   -8, 	  -1,   -9
+.2byte    3,  -11, 	   7,  -16, 	  -6,   -8, 	   0,  -10
+sLedianAnimTable1:
+.4byte sLedianAnims_1_1
+.4byte sLedianAnims_1_2
+.4byte sLedianAnims_1_3
+.4byte sLedianAnims_1_4
+.4byte sLedianAnims_1_5
+.4byte sLedianAnims_1_6
+.4byte sLedianAnims_1_7
+.4byte sLedianAnims_1_8
+sLedianAnimTable2:
+.4byte sLedianAnims_2_1
+.4byte sLedianAnims_2_2
+.4byte sLedianAnims_2_3
+.4byte sLedianAnims_2_4
+.4byte sLedianAnims_2_5
+.4byte sLedianAnims_2_6
+.4byte sLedianAnims_2_7
+.4byte sLedianAnims_2_8
+sLedianAnimTable3:
+.4byte sLedianAnims_3_1
+.4byte sLedianAnims_3_2
+.4byte sLedianAnims_3_3
+.4byte sLedianAnims_3_4
+.4byte sLedianAnims_3_5
+.4byte sLedianAnims_3_6
+.4byte sLedianAnims_3_7
+.4byte sLedianAnims_3_8
+sLedianAnimTable4:
+.4byte sLedianAnims_4_1
+.4byte sLedianAnims_4_2
+.4byte sLedianAnims_4_3
+.4byte sLedianAnims_4_4
+.4byte sLedianAnims_4_5
+.4byte sLedianAnims_4_6
+.4byte sLedianAnims_4_7
+.4byte sLedianAnims_4_8
+sLedianAnimTable5:
+.4byte sLedianAnims_5_1
+.4byte sLedianAnims_5_2
+.4byte sLedianAnims_5_3
+.4byte sLedianAnims_5_4
+.4byte sLedianAnims_5_5
+.4byte sLedianAnims_5_6
+.4byte sLedianAnims_5_7
+.4byte sLedianAnims_5_8
+sLedianAnimTable6:
+.4byte sLedianAnims_6_1
+.4byte sLedianAnims_6_1
+.4byte sLedianAnims_6_1
+.4byte sLedianAnims_6_1
+.4byte sLedianAnims_6_1
+.4byte sLedianAnims_6_1
+.4byte sLedianAnims_6_1
+.4byte sLedianAnims_6_1
+sLedianAnimTable7:
+.4byte sLedianAnims_7_1
+.4byte sLedianAnims_7_2
+.4byte sLedianAnims_7_3
+.4byte sLedianAnims_7_4
+.4byte sLedianAnims_7_5
+.4byte sLedianAnims_7_6
+.4byte sLedianAnims_7_7
+.4byte sLedianAnims_7_8
+sLedianAnimTable8:
+.4byte sLedianAnims_8_1
+.4byte sLedianAnims_8_2
+.4byte sLedianAnims_8_3
+.4byte sLedianAnims_8_4
+.4byte sLedianAnims_8_5
+.4byte sLedianAnims_8_6
+.4byte sLedianAnims_8_7
+.4byte sLedianAnims_8_8
+sLedianAnimTable9:
+.4byte sLedianAnims_9_1
+.4byte sLedianAnims_9_2
+.4byte sLedianAnims_9_3
+.4byte sLedianAnims_9_4
+.4byte sLedianAnims_9_5
+.4byte sLedianAnims_9_6
+.4byte sLedianAnims_9_7
+.4byte sLedianAnims_9_8
+sLedianAnimTable10:
+.4byte sLedianAnims_10_1
+.4byte sLedianAnims_10_2
+.4byte sLedianAnims_10_3
+.4byte sLedianAnims_10_4
+.4byte sLedianAnims_10_5
+.4byte sLedianAnims_10_6
+.4byte sLedianAnims_10_7
+.4byte sLedianAnims_10_8
+sLedianAnimTable11:
+.4byte sLedianAnims_11_1
+.4byte sLedianAnims_11_2
+.4byte sLedianAnims_11_3
+.4byte sLedianAnims_11_4
+.4byte sLedianAnims_11_5
+.4byte sLedianAnims_11_6
+.4byte sLedianAnims_11_7
+.4byte sLedianAnims_11_8
+sLedianAnimTable12:
+.4byte sLedianAnims_12_1
+.4byte sLedianAnims_12_2
+.4byte sLedianAnims_12_3
+.4byte sLedianAnims_12_4
+.4byte sLedianAnims_12_5
+.4byte sLedianAnims_12_6
+.4byte sLedianAnims_12_7
+.4byte sLedianAnims_12_8
+sLedianAnimTable13:
+.4byte sLedianAnims_13_1
+.4byte sLedianAnims_13_2
+.4byte sLedianAnims_13_3
+.4byte sLedianAnims_13_4
+.4byte sLedianAnims_13_5
+.4byte sLedianAnims_13_6
+.4byte sLedianAnims_13_7
+.4byte sLedianAnims_13_8
+sAxAnimationsLedian:
+.4byte sLedianAnimTable1
+.4byte sLedianAnimTable2
+.4byte sLedianAnimTable3
+.4byte sLedianAnimTable4
+.4byte sLedianAnimTable5
+.4byte sLedianAnimTable6
+.4byte sLedianAnimTable7
+.4byte sLedianAnimTable8
+.4byte sLedianAnimTable9
+.4byte sLedianAnimTable10
+.4byte sLedianAnimTable11
+.4byte sLedianAnimTable12
+.4byte sLedianAnimTable13
+sAxSpritesLedian:
+.4byte sLedianSprites1
+.4byte sLedianSprites2
+.4byte sLedianSprites3
+.4byte sLedianSprites4
+.4byte sLedianSprites5
+.4byte sLedianSprites6
+.4byte sLedianSprites7
+.4byte sLedianSprites8
+.4byte sLedianSprites9
+.4byte sLedianSprites10
+.4byte sLedianSprites11
+.4byte sLedianSprites12
+.4byte sLedianSprites13
+.4byte sLedianSprites14
+.4byte sLedianSprites15
+.4byte sLedianSprites16
+.4byte sLedianSprites17
+.4byte sLedianSprites18
+.4byte sLedianSprites19
+.4byte sLedianSprites20
+.4byte sLedianSprites21
+.4byte sLedianSprites22
+.4byte sLedianSprites23
+.4byte sLedianSprites24
+.4byte sLedianSprites25
+.4byte sLedianSprites26
+.4byte sLedianSprites27
+.4byte sLedianSprites28
+.4byte sLedianSprites29
+.4byte sLedianSprites30
+.4byte sLedianSprites31
+.4byte sLedianSprites32
+.4byte sLedianSprites33
+.4byte sLedianSprites34
+.4byte sLedianSprites35
+.4byte sLedianSprites36
+.4byte sLedianSprites37
+.4byte sLedianSprites38
+.4byte sLedianSprites39
+.4byte sLedianSprites40
+.4byte sLedianSprites41
+.4byte sLedianSprites42
+.4byte sLedianSprites43
+.4byte sLedianSprites44
+.4byte sLedianSprites45
+.4byte sLedianSprites46
+.4byte sLedianSprites47
+.4byte sLedianSprites48
+.4byte sLedianSprites49
+.4byte sLedianSprites50
+.4byte sLedianSprites51
+.4byte sLedianSprites52
+.4byte sLedianSprites53
+sAxMainLedian:
+ax_main sAxPosesLedian, sAxAnimationsLedian, 13, sAxSpritesLedian, sAxPositionsLedian

--- a/data/ax/ledyba.inc
+++ b/data/ax/ledyba.inc
@@ -1,0 +1,2782 @@
+.global gAxLedyba
+gAxLedyba:
+ax_siro sAxMainLedyba
+sLedybaPose1:
+ax_pose 0, 0x41f0, 0x80f0, 0x2c00
+ax_pose 1, 0x41e8, 0x40f0, 0x2c08
+ax_pose 2, 0x01e8, 0x00e8, 0x2c0c
+ax_pose 3, 0x01e8, 0x0110, 0x2c0d
+ax_pose_terminator
+sLedybaPose2:
+ax_pose 4, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose3:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose4:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose5:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose6:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose7:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose8:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose9:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose10:
+ax_pose 12, 0x41f2, 0x80f0, 0x2c00
+ax_pose 13, 0x41ea, 0x40f0, 0x2c08
+ax_pose 14, 0x41e2, 0x00f8, 0x2c0c
+ax_pose 15, 0x01f2, 0x00e8, 0x2c0e
+ax_pose_terminator
+sLedybaPose11:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose12:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose13:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose14:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose15:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose16:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose17:
+ax_pose 0, 0x41f0, 0x80f0, 0x2c00
+ax_pose 1, 0x41e8, 0x40f0, 0x2c08
+ax_pose 2, 0x01e8, 0x00e8, 0x2c0c
+ax_pose 3, 0x01e8, 0x0110, 0x2c0d
+ax_pose_terminator
+sLedybaPose18:
+ax_pose 4, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose19:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose20:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose21:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose22:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose23:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose24:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose25:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose26:
+ax_pose 12, 0x41f2, 0x80f0, 0x2c00
+ax_pose 13, 0x41ea, 0x40f0, 0x2c08
+ax_pose 14, 0x41e2, 0x00f8, 0x2c0c
+ax_pose 15, 0x01f2, 0x00e8, 0x2c0e
+ax_pose_terminator
+sLedybaPose27:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose28:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose29:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose30:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose31:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose32:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose33:
+ax_pose 0, 0x41f0, 0x80f0, 0x2c00
+ax_pose 1, 0x41e8, 0x40f0, 0x2c08
+ax_pose 2, 0x01e8, 0x00e8, 0x2c0c
+ax_pose 3, 0x01e8, 0x0110, 0x2c0d
+ax_pose_terminator
+sLedybaPose34:
+ax_pose 4, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose35:
+ax_pose 16, 0x01e5, 0x80ec, 0x2c00
+ax_pose 17, 0x01e0, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose36:
+ax_pose 17, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose37:
+ax_pose 16, 0x01e5, 0x90f4, 0x2c00
+ax_pose 17, 0x01e0, 0x90f0, 0x2c10
+ax_pose_terminator
+sLedybaPose38:
+ax_pose 17, 0x01e0, 0x90f0, 0x2c00
+ax_pose_terminator
+sLedybaPose39:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose40:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose41:
+ax_pose 18, 0x01e4, 0x90f6, 0x2c00
+ax_pose 19, 0x01e2, 0x90ef, 0x2c10
+ax_pose_terminator
+sLedybaPose42:
+ax_pose 19, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose43:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose 21, 0x01e2, 0x90ef, 0x2c10
+ax_pose_terminator
+sLedybaPose44:
+ax_pose 21, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose45:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose46:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose47:
+ax_pose 22, 0x01e3, 0x90f6, 0x2c00
+ax_pose 23, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sLedybaPose48:
+ax_pose 23, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose49:
+ax_pose 24, 0x01e3, 0x90f4, 0x2c00
+ax_pose 25, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sLedybaPose50:
+ax_pose 25, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose51:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose52:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose53:
+ax_pose 26, 0x01e3, 0x90ef, 0x2c00
+ax_pose 27, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sLedybaPose54:
+ax_pose 27, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose55:
+ax_pose 28, 0x01e3, 0x90f2, 0x2c00
+ax_pose 29, 0x01e3, 0x90ef, 0x2c10
+ax_pose_terminator
+sLedybaPose56:
+ax_pose 29, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose57:
+ax_pose 12, 0x41f2, 0x80f0, 0x2c00
+ax_pose 13, 0x41ea, 0x40f0, 0x2c08
+ax_pose 14, 0x41e2, 0x00f8, 0x2c0c
+ax_pose 15, 0x01f2, 0x00e8, 0x2c0e
+ax_pose_terminator
+sLedybaPose58:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose59:
+ax_pose 30, 0x01e2, 0x80f0, 0x2c00
+ax_pose 31, 0x01e2, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose60:
+ax_pose 31, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose61:
+ax_pose 30, 0x01e2, 0x90f0, 0x2c00
+ax_pose 31, 0x01e2, 0x90f0, 0x2c10
+ax_pose_terminator
+sLedybaPose62:
+ax_pose 31, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sLedybaPose63:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose64:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose65:
+ax_pose 26, 0x01e3, 0x80f0, 0x2c00
+ax_pose 27, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose66:
+ax_pose 27, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose67:
+ax_pose 28, 0x01e3, 0x80ed, 0x2c00
+ax_pose 29, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose68:
+ax_pose 29, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose69:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose70:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose71:
+ax_pose 22, 0x01e3, 0x80e9, 0x2c00
+ax_pose 23, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose72:
+ax_pose 23, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose73:
+ax_pose 24, 0x01e3, 0x80eb, 0x2c00
+ax_pose 25, 0x01e3, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose74:
+ax_pose 25, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose75:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose76:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose77:
+ax_pose 18, 0x01e4, 0x80ea, 0x2c00
+ax_pose 19, 0x01e2, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose78:
+ax_pose 19, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose79:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose 21, 0x01e2, 0x80f0, 0x2c10
+ax_pose_terminator
+sLedybaPose80:
+ax_pose 21, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose81:
+ax_pose 0, 0x41f0, 0x80f0, 0x2c00
+ax_pose 1, 0x41e8, 0x40f0, 0x2c08
+ax_pose 2, 0x01e8, 0x00e8, 0x2c0c
+ax_pose 3, 0x01e8, 0x0110, 0x2c0d
+ax_pose_terminator
+sLedybaPose82:
+ax_pose 4, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose83:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose84:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose85:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose86:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose87:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose88:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose89:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose90:
+ax_pose 12, 0x41f2, 0x80f0, 0x2c00
+ax_pose 13, 0x41ea, 0x40f0, 0x2c08
+ax_pose 14, 0x41e2, 0x00f8, 0x2c0c
+ax_pose 15, 0x01f2, 0x00e8, 0x2c0e
+ax_pose_terminator
+sLedybaPose91:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose92:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose93:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose94:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose95:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose96:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose97:
+ax_pose 32, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose98:
+ax_pose 33, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sLedybaPose99:
+ax_pose 34, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose100:
+ax_pose 35, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sLedybaPose101:
+ax_pose 36, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose102:
+ax_pose 35, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sLedybaPose103:
+ax_pose 34, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose104:
+ax_pose 33, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedybaPose105:
+ax_pose 37, 0x01ef, 0x80f1, 0x2c00
+ax_pose_terminator
+sLedybaPose106:
+ax_pose 38, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sLedybaPose107:
+ax_pose 39, 0x01e0, 0x80f1, 0x2c00
+ax_pose_terminator
+sLedybaPose108:
+ax_pose 40, 0x01e1, 0x90ec, 0x2c00
+ax_pose_terminator
+sLedybaPose109:
+ax_pose 41, 0x01e1, 0x90ee, 0x2c00
+ax_pose_terminator
+sLedybaPose110:
+ax_pose 42, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sLedybaPose111:
+ax_pose 43, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sLedybaPose112:
+ax_pose 42, 0x01e2, 0x80f2, 0x2c00
+ax_pose_terminator
+sLedybaPose113:
+ax_pose 41, 0x01e1, 0x80f2, 0x2c00
+ax_pose_terminator
+sLedybaPose114:
+ax_pose 40, 0x01e1, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedybaPose115:
+ax_pose 0, 0x41f0, 0x80f0, 0x2c00
+ax_pose 1, 0x41e8, 0x40f0, 0x2c08
+ax_pose 2, 0x01e8, 0x00e8, 0x2c0c
+ax_pose 3, 0x01e8, 0x0110, 0x2c0d
+ax_pose_terminator
+sLedybaPose116:
+ax_pose 4, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose117:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose118:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose119:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose120:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose121:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose122:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose123:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose124:
+ax_pose 12, 0x41f2, 0x80f0, 0x2c00
+ax_pose 13, 0x41ea, 0x40f0, 0x2c08
+ax_pose 14, 0x41e2, 0x00f8, 0x2c0c
+ax_pose 15, 0x01f2, 0x00e8, 0x2c0e
+ax_pose_terminator
+sLedybaPose125:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose126:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose127:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose128:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose129:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose130:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose131:
+ax_pose 0, 0x41f0, 0x80f0, 0x2c00
+ax_pose 1, 0x41e8, 0x40f0, 0x2c08
+ax_pose 2, 0x01e8, 0x00e8, 0x2c0c
+ax_pose 3, 0x01e8, 0x0110, 0x2c0d
+ax_pose_terminator
+sLedybaPose132:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose133:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose134:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose135:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose136:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose137:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose138:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose139:
+ax_pose 17, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose140:
+ax_pose 19, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose141:
+ax_pose 23, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sLedybaPose142:
+ax_pose 27, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose143:
+ax_pose 31, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sLedybaPose144:
+ax_pose 27, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sLedybaPose145:
+ax_pose 23, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sLedybaPose146:
+ax_pose 19, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sLedybaPose147:
+ax_pose 32, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose148:
+ax_pose 0, 0x41f0, 0x80f0, 0x2c00
+ax_pose 1, 0x41e8, 0x40f0, 0x2c08
+ax_pose 2, 0x01e8, 0x00e8, 0x2c0c
+ax_pose 3, 0x01e8, 0x0110, 0x2c0d
+ax_pose_terminator
+sLedybaPose149:
+ax_pose 4, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose150:
+ax_pose 33, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sLedybaPose151:
+ax_pose 5, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose152:
+ax_pose 6, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose153:
+ax_pose 34, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose154:
+ax_pose 7, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose155:
+ax_pose 8, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose156:
+ax_pose 35, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sLedybaPose157:
+ax_pose 9, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose158:
+ax_pose 10, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose159:
+ax_pose 36, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose160:
+ax_pose 11, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose161:
+ax_pose 12, 0x41f2, 0x80f0, 0x2c00
+ax_pose 13, 0x41ea, 0x40f0, 0x2c08
+ax_pose 14, 0x41e2, 0x00f8, 0x2c0c
+ax_pose 15, 0x01f2, 0x00e8, 0x2c0e
+ax_pose_terminator
+sLedybaPose162:
+ax_pose 35, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sLedybaPose163:
+ax_pose 9, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose164:
+ax_pose 10, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose165:
+ax_pose 34, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose166:
+ax_pose 7, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose167:
+ax_pose 8, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose168:
+ax_pose 33, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedybaPose169:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose170:
+ax_pose 6, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose171:
+ax_pose 32, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose172:
+ax_pose 33, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sLedybaPose173:
+ax_pose 34, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose174:
+ax_pose 35, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sLedybaPose175:
+ax_pose 36, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose176:
+ax_pose 35, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sLedybaPose177:
+ax_pose 34, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose178:
+ax_pose 33, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sLedybaPose179:
+ax_pose 44, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose180:
+ax_pose 45, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sLedybaPose181:
+ax_pose 46, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sLedybaPose182:
+ax_pose 47, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose183:
+ax_pose 48, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sLedybaPose184:
+ax_pose 47, 0x01e3, 0x90ef, 0x2c00
+ax_pose_terminator
+sLedybaPose185:
+ax_pose 46, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sLedybaPose186:
+ax_pose 45, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sLedybaAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 9, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 4, 0, 12, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 15, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 2, 17, 0, 0, 0, 0,
+ax_anim 1, 0, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 17, 0, 10, 0, 10,
+ax_anim 1, 0, 16, 0, 23, 0, 23,
+ax_anim 1, 1, 17, 0, 23, 0, 23,
+ax_anim 1, 0, 16, 1, 23, 1, 23,
+ax_anim 1, 0, 17, 1, 23, 1, 23,
+ax_anim 1, 0, 16, 0, 23, 0, 23,
+ax_anim 1, 0, 17, 0, 23, 0, 23,
+ax_anim 1, 0, 16, 1, 23, 1, 23,
+ax_anim 1, 0, 17, 1, 23, 1, 23,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sLedybaAnims_2_2:
+ax_anim 2, 0, 18, -1, -1, -1, -1,
+ax_anim 6, 0, 18, -2, -2, -2, -2,
+ax_anim 1, 2, 19, 0, 0, 0, 0,
+ax_anim 1, 0, 18, 4, 4, 4, 4,
+ax_anim 1, 0, 19, 9, 11, 9, 11,
+ax_anim 1, 0, 18, 19, 22, 19, 22,
+ax_anim 1, 1, 19, 19, 22, 19, 22,
+ax_anim 1, 0, 18, 20, 21, 20, 21,
+ax_anim 1, 0, 19, 20, 21, 20, 21,
+ax_anim 1, 0, 18, 19, 22, 19, 22,
+ax_anim 1, 0, 19, 19, 22, 19, 22,
+ax_anim 1, 0, 18, 20, 21, 20, 21,
+ax_anim 1, 0, 19, 20, 21, 20, 21,
+ax_anim 2, 0, 18, 5, 7, 5, 7,
+ax_anim_terminator
+sLedybaAnims_2_3:
+ax_anim 2, 0, 20, -1, 0, -1, 0,
+ax_anim 6, 0, 20, -2, 0, -2, 0,
+ax_anim 1, 2, 21, 0, 0, 0, 0,
+ax_anim 1, 0, 20, 4, 0, 4, 0,
+ax_anim 1, 0, 21, 9, 0, 9, 0,
+ax_anim 1, 0, 20, 19, 0, 19, 0,
+ax_anim 1, 1, 21, 19, 0, 19, 0,
+ax_anim 1, 0, 20, 19, 1, 19, 1,
+ax_anim 1, 0, 21, 19, 1, 19, 1,
+ax_anim 1, 0, 20, 19, 0, 19, 0,
+ax_anim 1, 0, 21, 19, 0, 19, 0,
+ax_anim 1, 0, 20, 19, 1, 19, 1,
+ax_anim 1, 0, 21, 19, 1, 19, 1,
+ax_anim 2, 0, 20, 5, 0, 5, 0,
+ax_anim_terminator
+sLedybaAnims_2_4:
+ax_anim 2, 0, 22, -1, 1, -1, 1,
+ax_anim 6, 0, 22, -2, 2, -2, 2,
+ax_anim 1, 2, 23, 0, 0, 0, 0,
+ax_anim 1, 0, 22, 5, -4, 5, -4,
+ax_anim 1, 0, 23, 12, -10, 12, -10,
+ax_anim 1, 0, 22, 19, -15, 19, -15,
+ax_anim 1, 1, 23, 19, -15, 19, -15,
+ax_anim 1, 0, 22, 20, -14, 20, -14,
+ax_anim 1, 0, 23, 20, -14, 20, -14,
+ax_anim 1, 0, 22, 19, -15, 19, -15,
+ax_anim 1, 0, 23, 19, -15, 19, -15,
+ax_anim 1, 0, 22, 20, -14, 20, -14,
+ax_anim 1, 0, 23, 20, -14, 20, -14,
+ax_anim 2, 0, 22, 7, -6, 7, -6,
+ax_anim_terminator
+sLedybaAnims_2_5:
+ax_anim 2, 0, 24, 0, 1, 0, 1,
+ax_anim 6, 0, 24, 0, 2, 0, 2,
+ax_anim 1, 2, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, -4, 0, -4,
+ax_anim 1, 0, 25, 0, -10, 0, -10,
+ax_anim 1, 0, 24, 0, -15, 0, -15,
+ax_anim 1, 1, 25, 0, -15, 0, -15,
+ax_anim 1, 0, 24, 1, -15, 1, -15,
+ax_anim 1, 0, 25, 1, -15, 1, -15,
+ax_anim 1, 0, 24, 0, -15, 0, -15,
+ax_anim 1, 0, 25, 0, -15, 0, -15,
+ax_anim 1, 0, 24, 1, -15, 1, -15,
+ax_anim 1, 0, 25, 1, -15, 1, -15,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim_terminator
+sLedybaAnims_2_6:
+ax_anim 2, 0, 26, 1, 1, 1, 1,
+ax_anim 6, 0, 26, 2, 2, 2, 2,
+ax_anim 1, 2, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 26, -5, -4, -5, -4,
+ax_anim 1, 0, 27, -12, -10, -12, -10,
+ax_anim 1, 0, 26, -19, -15, -19, -15,
+ax_anim 1, 1, 27, -19, -15, -19, -15,
+ax_anim 1, 0, 26, -20, -14, -20, -14,
+ax_anim 1, 0, 27, -20, -14, -20, -14,
+ax_anim 1, 0, 26, -19, -15, -19, -15,
+ax_anim 1, 0, 27, -19, -15, -19, -15,
+ax_anim 1, 0, 26, -20, -14, -20, -14,
+ax_anim 1, 0, 27, -20, -14, -20, -14,
+ax_anim 2, 0, 26, -7, -6, -7, -6,
+ax_anim_terminator
+sLedybaAnims_2_7:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 6, 0, 28, 2, 0, 2, 0,
+ax_anim 1, 2, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 28, -4, 0, -4, 0,
+ax_anim 1, 0, 29, -9, 0, -9, 0,
+ax_anim 1, 0, 28, -19, 0, -19, 0,
+ax_anim 1, 1, 29, -19, 0, -19, 0,
+ax_anim 1, 0, 28, -19, 1, -19, 1,
+ax_anim 1, 0, 29, -19, 1, -19, 1,
+ax_anim 1, 0, 28, -19, 0, -19, 0,
+ax_anim 1, 0, 29, -19, 0, -19, 0,
+ax_anim 1, 0, 28, -19, 1, -19, 1,
+ax_anim 1, 0, 29, -19, 1, -19, 1,
+ax_anim 2, 0, 28, -5, 0, -5, 0,
+ax_anim_terminator
+sLedybaAnims_2_8:
+ax_anim 2, 0, 30, 1, -1, 1, -1,
+ax_anim 6, 0, 30, 2, -2, 2, -2,
+ax_anim 1, 2, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 30, -4, 4, -4, 4,
+ax_anim 1, 0, 31, -9, 11, -9, 11,
+ax_anim 1, 0, 30, -19, 22, -19, 22,
+ax_anim 1, 1, 31, -19, 22, -19, 22,
+ax_anim 1, 0, 30, -20, 21, -20, 21,
+ax_anim 1, 0, 31, -20, 21, -20, 21,
+ax_anim 1, 0, 30, -19, 22, -19, 22,
+ax_anim 1, 0, 31, -19, 22, -19, 22,
+ax_anim 1, 0, 30, -20, 21, -20, 21,
+ax_anim 1, 0, 31, -20, 21, -20, 21,
+ax_anim 2, 0, 30, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sLedybaAnims_3_1:
+ax_anim 1, 0, 32, 0, -2, 0, -2,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim 6, 0, 79, 0, -6, 0, -6,
+ax_anim 1, 2, 79, 0, -3, 0, -3,
+ax_anim 1, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 34, 4, 19, 4, 19,
+ax_anim 1, 1, 43, 5, 20, 5, 20,
+ax_anim 2, 0, 43, 6, 16, 6, 16,
+ax_anim 6, 0, 43, 6, 14, 6, 14,
+ax_anim 2, 0, 36, -2, 19, -2, 19,
+ax_anim 2, 0, 79, -3, 20, -3, 20,
+ax_anim 2, 0, 37, -1, 16, -1, 16,
+ax_anim 1, 0, 33, 0, 11, 0, 11,
+ax_anim 1, 0, 32, 0, 3, 0, 3,
+ax_anim_terminator
+sLedybaAnims_3_2:
+ax_anim 1, 0, 38, -2, -2, -2, -2,
+ax_anim 2, 0, 32, -4, -4, -4, -4,
+ax_anim 6, 0, 37, -6, -6, -6, -6,
+ax_anim 1, 2, 37, -3, -3, -3, -3,
+ax_anim 1, 0, 41, 6, 6, 6, 6,
+ax_anim 1, 0, 42, 18, 19, 18, 19,
+ax_anim 1, 1, 49, 17, 20, 17, 20,
+ax_anim 2, 0, 49, 17, 18, 17, 18,
+ax_anim 6, 0, 49, 15, 14, 15, 14,
+ax_anim 2, 0, 40, 15, 20, 15, 20,
+ax_anim 2, 0, 37, 15, 20, 15, 20,
+ax_anim 2, 0, 41, 15, 14, 15, 14,
+ax_anim 1, 0, 39, 11, 11, 11, 11,
+ax_anim 1, 0, 38, 3, 3, 3, 3,
+ax_anim_terminator
+sLedybaAnims_3_3:
+ax_anim 1, 0, 44, -2, 0, -2, 0,
+ax_anim 2, 0, 38, -4, 0, -4, 0,
+ax_anim 6, 0, 41, -6, 1, -6, 1,
+ax_anim 1, 2, 41, -3, 1, -3, 1,
+ax_anim 1, 0, 47, 6, 1, 6, 1,
+ax_anim 1, 0, 48, 14, 0, 14, 0,
+ax_anim 1, 1, 55, 17, 0, 17, 0,
+ax_anim 2, 0, 55, 15, 0, 15, 0,
+ax_anim 6, 0, 55, 14, 0, 14, 0,
+ax_anim 2, 0, 46, 16, 0, 16, 0,
+ax_anim 2, 0, 41, 17, 1, 17, 1,
+ax_anim 2, 0, 47, 11, 0, 11, 0,
+ax_anim 1, 0, 45, 6, -1, 6, -1,
+ax_anim 1, 0, 44, 3, 0, 3, 0,
+ax_anim_terminator
+sLedybaAnims_3_4:
+ax_anim 1, 0, 50, -2, 2, -2, 2,
+ax_anim 2, 0, 44, -4, 4, -4, 4,
+ax_anim 6, 0, 47, -6, 6, -6, 6,
+ax_anim 1, 2, 47, -3, 3, -3, 3,
+ax_anim 1, 0, 53, 6, -6, 6, -6,
+ax_anim 1, 0, 54, 13, -15, 13, -15,
+ax_anim 1, 1, 59, 15, -15, 15, -15,
+ax_anim 2, 0, 59, 14, -14, 14, -14,
+ax_anim 6, 0, 59, 13, -11, 13, -11,
+ax_anim 2, 0, 52, 20, -15, 20, -15,
+ax_anim 2, 0, 47, 19, -15, 19, -15,
+ax_anim 2, 0, 53, 15, -13, 15, -13,
+ax_anim 1, 0, 51, 7, -7, 7, -7,
+ax_anim 1, 0, 50, 3, -3, 3, -3,
+ax_anim_terminator
+sLedybaAnims_3_5:
+ax_anim 1, 0, 56, 0, 2, 0, 2,
+ax_anim 2, 0, 50, 0, 4, 0, 4,
+ax_anim 6, 0, 53, 0, 6, 0, 6,
+ax_anim 1, 2, 53, 0, 3, 0, 3,
+ax_anim 1, 0, 61, 0, -6, 0, -6,
+ax_anim 1, 0, 58, 0, -12, 0, -12,
+ax_anim 1, 1, 65, -1, -15, -1, -15,
+ax_anim 2, 0, 65, -2, -16, -2, -16,
+ax_anim 6, 0, 59, -3, -13, -3, -13,
+ax_anim 2, 0, 60, 2, -18, 2, -18,
+ax_anim 2, 0, 53, 5, -19, 5, -19,
+ax_anim 2, 0, 61, 1, -13, 1, -13,
+ax_anim 1, 0, 57, 0, -5, 0, -5,
+ax_anim 1, 0, 56, 0, -1, 0, -1,
+ax_anim_terminator
+sLedybaAnims_3_6:
+ax_anim 1, 0, 62, 2, 2, 2, 2,
+ax_anim 2, 0, 56, 4, 4, 4, 4,
+ax_anim 6, 0, 61, 6, 6, 6, 6,
+ax_anim 1, 2, 61, 3, 3, 3, 3,
+ax_anim 1, 0, 67, -6, -7, -6, -7,
+ax_anim 1, 0, 64, -15, -15, -15, -15,
+ax_anim 1, 1, 71, -17, -15, -17, -15,
+ax_anim 2, 0, 71, -13, -11, -13, -11,
+ax_anim 6, 0, 71, -9, -9, -9, -9,
+ax_anim 2, 0, 66, -11, -14, -11, -14,
+ax_anim 2, 0, 61, -12, -18, -12, -18,
+ax_anim 2, 0, 67, -10, -13, -10, -13,
+ax_anim 1, 0, 63, -7, -7, -7, -7,
+ax_anim 1, 0, 62, -3, -3, -3, -3,
+ax_anim_terminator
+sLedybaAnims_3_7:
+ax_anim 1, 0, 68, 2, 0, 2, 0,
+ax_anim 2, 0, 62, 4, 0, 4, 0,
+ax_anim 6, 0, 67, 6, 0, 6, 0,
+ax_anim 1, 2, 67, 3, 0, 3, 0,
+ax_anim 1, 0, 73, -3, -2, -3, -2,
+ax_anim 1, 0, 70, -7, 0, -7, 0,
+ax_anim 1, 1, 77, -11, 2, -11, 2,
+ax_anim 2, 0, 77, -10, 2, -10, 2,
+ax_anim 6, 0, 77, -9, 2, -9, 2,
+ax_anim 2, 0, 72, -14, 0, -14, 0,
+ax_anim 2, 0, 67, -15, 0, -15, 0,
+ax_anim 2, 0, 73, -9, -2, -9, -2,
+ax_anim 1, 0, 69, -6, -1, -6, -1,
+ax_anim 1, 0, 68, -3, 0, -3, 0,
+ax_anim_terminator
+sLedybaAnims_3_8:
+ax_anim 1, 0, 74, 2, -2, 2, -2,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim 6, 0, 73, 6, -6, 6, -6,
+ax_anim 1, 2, 73, 3, -3, 3, -3,
+ax_anim 1, 0, 79, -8, 6, -8, 6,
+ax_anim 1, 0, 76, -14, 19, -14, 19,
+ax_anim 1, 1, 35, -15, 23, -15, 23,
+ax_anim 2, 0, 35, -13, 21, -13, 21,
+ax_anim 6, 0, 35, -11, 16, -11, 16,
+ax_anim 2, 0, 78, -19, 17, -19, 17,
+ax_anim 2, 0, 73, -18, 17, -18, 17,
+ax_anim 2, 0, 79, -16, 15, -16, 15,
+ax_anim 1, 0, 75, -11, 11, -11, 11,
+ax_anim 1, 0, 74, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sLedybaAnims_4_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 2, 81, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 0, 81, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 1, 81, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 0, 81, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_4_2:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 2, 83, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 1, 83, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_4_3:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 2, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 1, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_4_4:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 2, 87, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 0, 87, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 1, 87, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 0, 87, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_4_5:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 2, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 1, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_4_6:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 2, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 1, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_4_7:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 2, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 1, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_4_8:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 2, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 1, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_5_1:
+ax_anim 1, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 4, 0, 96, 0, -4, 0, -4,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 1, 0, 96, 0, -2, 0, -2,
+ax_anim 6, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sLedybaAnims_5_2:
+ax_anim 1, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 4, 0, 97, 0, -4, 0, -4,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 1, 0, 97, 0, -2, 0, -2,
+ax_anim 6, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sLedybaAnims_5_3:
+ax_anim 1, 0, 98, 0, -2, 0, -2,
+ax_anim 2, 0, 98, 0, -3, 0, -3,
+ax_anim 4, 0, 98, 0, -4, 0, -4,
+ax_anim 2, 0, 98, 0, -3, 0, -3,
+ax_anim 1, 0, 98, 0, -2, 0, -2,
+ax_anim 6, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim_terminator
+sLedybaAnims_5_4:
+ax_anim 1, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 4, 0, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 1, 0, 99, 0, -2, 0, -2,
+ax_anim 6, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sLedybaAnims_5_5:
+ax_anim 1, 0, 100, 0, -2, 0, -2,
+ax_anim 2, 0, 100, 0, -3, 0, -3,
+ax_anim 4, 0, 100, 0, -4, 0, -4,
+ax_anim 2, 0, 100, 0, -3, 0, -3,
+ax_anim 1, 0, 100, 0, -2, 0, -2,
+ax_anim 6, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim_terminator
+sLedybaAnims_5_6:
+ax_anim 1, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 4, 0, 101, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 1, 0, 101, 0, -2, 0, -2,
+ax_anim 6, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim_terminator
+sLedybaAnims_5_7:
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 4, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 6, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim_terminator
+sLedybaAnims_5_8:
+ax_anim 1, 0, 103, 0, -2, 0, -2,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 4, 0, 103, 0, -4, 0, -4,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 1, 0, 103, 0, -2, 0, -2,
+ax_anim 6, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sLedybaAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sLedybaAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sLedybaAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sLedybaAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sLedybaAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sLedybaAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sLedybaAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sLedybaAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLedybaAnims_8_1:
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, -1, 0, 0,
+ax_anim 4, 0, 115, 0, -1, 0, 0,
+ax_anim 4, 0, 114, 0, -2, 0, 0,
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 0, 114, 0, -2, 0, 0,
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 0, 114, 0, -1, 0, 0,
+ax_anim 4, 0, 115, 0, -1, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_8_2:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, -1, 0, 0,
+ax_anim 4, 0, 117, 0, -1, 0, 0,
+ax_anim 4, 0, 116, 0, -2, 0, 0,
+ax_anim 4, 0, 117, 0, -2, 0, 0,
+ax_anim 4, 0, 116, 0, -2, 0, 0,
+ax_anim 4, 0, 117, 0, -2, 0, 0,
+ax_anim 4, 0, 116, 0, -1, 0, 0,
+ax_anim 4, 0, 117, 0, -1, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_8_3:
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, -1, 0, 0,
+ax_anim 4, 0, 119, 0, -1, 0, 0,
+ax_anim 4, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 119, 0, -2, 0, 0,
+ax_anim 4, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 119, 0, -2, 0, 0,
+ax_anim 4, 0, 118, 0, -1, 0, 0,
+ax_anim 4, 0, 119, 0, -1, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_8_4:
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, -1, 0, 0,
+ax_anim 4, 0, 121, 0, -1, 0, 0,
+ax_anim 4, 0, 120, 0, -2, 0, 0,
+ax_anim 4, 0, 121, 0, -2, 0, 0,
+ax_anim 4, 0, 120, 0, -2, 0, 0,
+ax_anim 4, 0, 121, 0, -2, 0, 0,
+ax_anim 4, 0, 120, 0, -1, 0, 0,
+ax_anim 4, 0, 121, 0, -1, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_8_5:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 123, 0, -1, 0, 0,
+ax_anim 4, 0, 122, 0, -2, 0, 0,
+ax_anim 4, 0, 123, 0, -2, 0, 0,
+ax_anim 4, 0, 122, 0, -2, 0, 0,
+ax_anim 4, 0, 123, 0, -2, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 123, 0, -1, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_8_6:
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 124, 0, -2, 0, 0,
+ax_anim 4, 0, 125, 0, -2, 0, 0,
+ax_anim 4, 0, 124, 0, -2, 0, 0,
+ax_anim 4, 0, 125, 0, -2, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_8_7:
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, -1, 0, 0,
+ax_anim 4, 0, 126, 0, -2, 0, 0,
+ax_anim 4, 0, 127, 0, -2, 0, 0,
+ax_anim 4, 0, 126, 0, -2, 0, 0,
+ax_anim 4, 0, 127, 0, -2, 0, 0,
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, -1, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_8_8:
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 129, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, -2, 0, 0,
+ax_anim 4, 0, 129, 0, -2, 0, 0,
+ax_anim 4, 0, 128, 0, -2, 0, 0,
+ax_anim 4, 0, 129, 0, -2, 0, 0,
+ax_anim 4, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 129, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 3, 6, 3,
+ax_anim 2, 0, 132, 8, 11, 8, 11,
+ax_anim 2, 0, 133, 7, 18, 7, 18,
+ax_anim 3, 0, 134, 0, 22, 0, 22,
+ax_anim 2, 3, 135, -7, 18, -7, 18,
+ax_anim 2, 0, 136, -8, 11, -8, 11,
+ax_anim 1, 0, 137, -6, 3, -6, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 8, 0, 8, 0,
+ax_anim 2, 0, 131, 17, 5, 17, 5,
+ax_anim 2, 0, 132, 19, 13, 19, 13,
+ax_anim 3, 0, 133, 20, 22, 20, 22,
+ax_anim 2, 3, 134, 11, 23, 11, 23,
+ax_anim 2, 0, 135, 2, 16, 2, 16,
+ax_anim 1, 0, 136, -1, 7, -1, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -5, 3, -5,
+ax_anim 2, 0, 130, 11, -6, 11, -6,
+ax_anim 2, 0, 131, 17, -4, 17, -4,
+ax_anim 3, 0, 132, 20, 1, 20, 1,
+ax_anim 2, 3, 133, 18, 4, 18, 4,
+ax_anim 2, 0, 134, 12, 6, 12, 6,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 4, -16, 4, -16,
+ax_anim 2, 0, 130, 12, -20, 12, -20,
+ax_anim 3, 0, 131, 20, -17, 20, -17,
+ax_anim 2, 3, 132, 20, -13, 20, -13,
+ax_anim 2, 0, 133, 17, -4, 17, -4,
+ax_anim 1, 0, 134, 9, 0, 9, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -8, -3, -8, -3,
+ax_anim 2, 0, 136, -9, -10, -9, -10,
+ax_anim 2, 0, 137, -7, -15, -7, -15,
+ax_anim 3, 0, 130, 0, -18, 0, -18,
+ax_anim 2, 3, 131, 7, -15, 7, -15,
+ax_anim 2, 0, 132, 9, -10, 9, -10,
+ax_anim 1, 0, 133, 8, -3, 8, -3,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -8, 1, -8,
+ax_anim 2, 0, 131, -4, -16, -4, -16,
+ax_anim 2, 0, 130, -12, -20, -12, -20,
+ax_anim 3, 0, 137, -20, -17, -20, -17,
+ax_anim 2, 3, 136, -20, -13, -20, -13,
+ax_anim 2, 0, 135, -17, -4, -17, -4,
+ax_anim 1, 0, 134, -9, 0, -9, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -5, -3, -5,
+ax_anim 2, 0, 130, -11, -6, -11, -6,
+ax_anim 2, 0, 137, -17, -4, -17, -4,
+ax_anim 3, 0, 136, -20, 1, -20, 1,
+ax_anim 2, 3, 135, -18, 4, -18, 4,
+ax_anim 2, 0, 134, -12, 6, -12, 6,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -8, 0, -8, 0,
+ax_anim 2, 0, 137, -17, 5, -17, 5,
+ax_anim 2, 0, 136, -19, 13, -19, 13,
+ax_anim 3, 0, 135, -20, 22, -20, 22,
+ax_anim 2, 3, 134, -11, 23, -11, 23,
+ax_anim 2, 0, 133, -2, 16, -2, 16,
+ax_anim 1, 0, 132, 1, 7, 1, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -23, 0, 0,
+ax_anim 3, 0, 147, 0, -22, 0, 0,
+ax_anim 2, 0, 147, 0, -18, 0, 0,
+ax_anim 1, 0, 147, 0, -12, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -23, 0, 0,
+ax_anim 3, 0, 150, 0, -22, 0, 0,
+ax_anim 2, 0, 150, 0, -18, 0, 0,
+ax_anim 1, 0, 150, 0, -12, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -23, 0, 0,
+ax_anim 3, 0, 153, 0, -22, 0, 0,
+ax_anim 2, 0, 153, 0, -18, 0, 0,
+ax_anim 1, 0, 153, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -22, 0, 0,
+ax_anim 3, 0, 156, 0, -21, 0, 0,
+ax_anim 2, 0, 156, 0, -17, 0, 0,
+ax_anim 1, 0, 156, 0, -11, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 162, 0, -21, 0, 0,
+ax_anim 2, 0, 162, 0, -17, 0, 0,
+ax_anim 1, 0, 162, 0, -11, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLedybaAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sLedybaGfx1:
+.incbin "baserom.gba", 0xC3E464, 0x100
+sLedybaSprites1:
+ax_sprite sLedybaGfx1, 0x100
+ax_sprite_terminator
+sLedybaGfx2:
+.incbin "baserom.gba", 0xC3E574, 0x80
+sLedybaSprites2:
+ax_sprite sLedybaGfx2, 0x80
+ax_sprite_terminator
+sLedybaGfx3:
+.incbin "baserom.gba", 0xC3E604, 0x20
+sLedybaSprites3:
+ax_sprite sLedybaGfx3, 0x20
+ax_sprite_terminator
+sLedybaGfx4:
+.incbin "baserom.gba", 0xC3E634, 0x20
+sLedybaSprites4:
+ax_sprite sLedybaGfx4, 0x20
+ax_sprite_terminator
+sLedybaGfx5:
+.incbin "baserom.gba", 0xC3E664, 0x200
+sLedybaSprites5:
+ax_sprite sLedybaGfx5, 0x200
+ax_sprite_terminator
+sLedybaGfx6:
+.incbin "baserom.gba", 0xC3E874, 0x200
+sLedybaSprites6:
+ax_sprite sLedybaGfx6, 0x200
+ax_sprite_terminator
+sLedybaGfx7:
+.incbin "baserom.gba", 0xC3EA84, 0x200
+sLedybaSprites7:
+ax_sprite sLedybaGfx7, 0x200
+ax_sprite_terminator
+sLedybaGfx8:
+.incbin "baserom.gba", 0xC3EC94, 0x200
+sLedybaSprites8:
+ax_sprite sLedybaGfx8, 0x200
+ax_sprite_terminator
+sLedybaGfx9:
+.incbin "baserom.gba", 0xC3EEA4, 0x200
+sLedybaSprites9:
+ax_sprite sLedybaGfx9, 0x200
+ax_sprite_terminator
+sLedybaGfx10:
+.incbin "baserom.gba", 0xC3F0B4, 0x200
+sLedybaSprites10:
+ax_sprite sLedybaGfx10, 0x200
+ax_sprite_terminator
+sLedybaGfx11:
+.incbin "baserom.gba", 0xC3F2C4, 0x200
+sLedybaSprites11:
+ax_sprite sLedybaGfx11, 0x200
+ax_sprite_terminator
+sLedybaGfx12:
+.incbin "baserom.gba", 0xC3F4D4, 0x200
+sLedybaSprites12:
+ax_sprite sLedybaGfx12, 0x200
+ax_sprite_terminator
+sLedybaGfx13:
+.incbin "baserom.gba", 0xC3F6E4, 0x100
+sLedybaSprites13:
+ax_sprite sLedybaGfx13, 0x100
+ax_sprite_terminator
+sLedybaGfx14:
+.incbin "baserom.gba", 0xC3F7F4, 0x80
+sLedybaSprites14:
+ax_sprite sLedybaGfx14, 0x80
+ax_sprite_terminator
+sLedybaGfx15:
+.incbin "baserom.gba", 0xC3F884, 0x40
+sLedybaSprites15:
+ax_sprite sLedybaGfx15, 0x40
+ax_sprite_terminator
+sLedybaGfx16:
+.incbin "baserom.gba", 0xC3F8D4, 0x20
+sLedybaSprites16:
+ax_sprite sLedybaGfx16, 0x20
+ax_sprite_terminator
+sLedybaGfx17:
+.incbin "baserom.gba", 0xC3F904, 0x20
+sLedybaGfx17_1:
+.incbin "baserom.gba", 0xC3F924, 0x20
+sLedybaGfx17_2:
+.incbin "baserom.gba", 0xC3F944, 0x20
+sLedybaGfx17_3:
+.incbin "baserom.gba", 0xC3F964, 0xC0
+sLedybaSprites17:
+ax_sprite sLedybaGfx17, 0x20
+ax_sprite 0, 0x60
+ax_sprite sLedybaGfx17_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sLedybaGfx17_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx17_3, 0xc0
+ax_sprite_terminator
+sLedybaGfx18:
+.incbin "baserom.gba", 0xC3FA64, 0x40
+sLedybaGfx18_1:
+.incbin "baserom.gba", 0xC3FAA4, 0x180
+sLedybaSprites18:
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx18_1, 0x180
+ax_sprite_terminator
+sLedybaGfx19:
+.incbin "baserom.gba", 0xC3FC4C, 0x20
+sLedybaGfx19_1:
+.incbin "baserom.gba", 0xC3FC6C, 0x40
+sLedybaGfx19_2:
+.incbin "baserom.gba", 0xC3FCAC, 0x60
+sLedybaGfx19_3:
+.incbin "baserom.gba", 0xC3FD0C, 0x60
+sLedybaSprites19:
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx19_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx20:
+.incbin "baserom.gba", 0xC3FDBC, 0x60
+sLedybaGfx20_1:
+.incbin "baserom.gba", 0xC3FE1C, 0x180
+sLedybaSprites20:
+ax_sprite sLedybaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx20_1, 0x180
+ax_sprite_terminator
+sLedybaGfx21:
+.incbin "baserom.gba", 0xC3FFBC, 0x20
+sLedybaGfx21_1:
+.incbin "baserom.gba", 0xC3FFDC, 0x120
+sLedybaSprites21:
+ax_sprite 0, 0x80
+ax_sprite sLedybaGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx21_1, 0x120
+ax_sprite_terminator
+sLedybaGfx22:
+.incbin "baserom.gba", 0xC40124, 0x60
+sLedybaGfx22_1:
+.incbin "baserom.gba", 0xC40184, 0x180
+sLedybaSprites22:
+ax_sprite sLedybaGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx22_1, 0x180
+ax_sprite_terminator
+sLedybaGfx23:
+.incbin "baserom.gba", 0xC40324, 0x60
+sLedybaGfx23_1:
+.incbin "baserom.gba", 0xC40384, 0x40
+sLedybaGfx23_2:
+.incbin "baserom.gba", 0xC403C4, 0x60
+sLedybaGfx23_3:
+.incbin "baserom.gba", 0xC40424, 0x60
+sLedybaSprites23:
+ax_sprite sLedybaGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx24:
+.incbin "baserom.gba", 0xC404CC, 0x1E0
+sLedybaSprites24:
+ax_sprite sLedybaGfx24, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx25:
+.incbin "baserom.gba", 0xC406C4, 0x40
+sLedybaGfx25_1:
+.incbin "baserom.gba", 0xC40704, 0xE0
+sLedybaSprites25:
+ax_sprite 0, 0x80
+ax_sprite sLedybaGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx25_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx26:
+.incbin "baserom.gba", 0xC40814, 0x40
+sLedybaGfx26_1:
+.incbin "baserom.gba", 0xC40854, 0x100
+sLedybaGfx26_2:
+.incbin "baserom.gba", 0xC40954, 0x40
+sLedybaSprites26:
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx27:
+.incbin "baserom.gba", 0xC409D4, 0x120
+sLedybaSprites27:
+ax_sprite sLedybaGfx27, 0x120
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sLedybaGfx28:
+.incbin "baserom.gba", 0xC40B0C, 0x20
+sLedybaGfx28_1:
+.incbin "baserom.gba", 0xC40B2C, 0x100
+sLedybaGfx28_2:
+.incbin "baserom.gba", 0xC40C2C, 0x40
+sLedybaSprites28:
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx28_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx29:
+.incbin "baserom.gba", 0xC40CAC, 0x40
+sLedybaGfx29_1:
+.incbin "baserom.gba", 0xC40CEC, 0x40
+sLedybaGfx29_2:
+.incbin "baserom.gba", 0xC40D2C, 0x40
+sLedybaGfx29_3:
+.incbin "baserom.gba", 0xC40D6C, 0x20
+sLedybaSprites29:
+ax_sprite sLedybaGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx29_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx29_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sLedybaGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLedybaGfx30:
+.incbin "baserom.gba", 0xC40DD4, 0x200
+sLedybaSprites30:
+ax_sprite sLedybaGfx30, 0x200
+ax_sprite_terminator
+sLedybaGfx31:
+.incbin "baserom.gba", 0xC40FE4, 0x100
+sLedybaGfx31_1:
+.incbin "baserom.gba", 0xC410E4, 0x20
+sLedybaSprites31:
+ax_sprite sLedybaGfx31, 0x100
+ax_sprite 0, 0x60
+ax_sprite sLedybaGfx31_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLedybaGfx32:
+.incbin "baserom.gba", 0xC4112C, 0x40
+sLedybaGfx32_1:
+.incbin "baserom.gba", 0xC4116C, 0x160
+sLedybaSprites32:
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx32_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx33:
+.incbin "baserom.gba", 0xC412FC, 0x180
+sLedybaSprites33:
+ax_sprite sLedybaGfx33, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLedybaGfx34:
+.incbin "baserom.gba", 0xC41494, 0x60
+sLedybaGfx34_1:
+.incbin "baserom.gba", 0xC414F4, 0x60
+sLedybaGfx34_2:
+.incbin "baserom.gba", 0xC41554, 0x60
+sLedybaGfx34_3:
+.incbin "baserom.gba", 0xC415B4, 0x20
+sLedybaSprites34:
+ax_sprite sLedybaGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx34_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sLedybaGfx34_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx35:
+.incbin "baserom.gba", 0xC4161C, 0x60
+sLedybaGfx35_1:
+.incbin "baserom.gba", 0xC4167C, 0x80
+sLedybaGfx35_2:
+.incbin "baserom.gba", 0xC416FC, 0x60
+sLedybaGfx35_3:
+.incbin "baserom.gba", 0xC4175C, 0x20
+sLedybaSprites35:
+ax_sprite sLedybaGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx35_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLedybaGfx35_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx36:
+.incbin "baserom.gba", 0xC417C4, 0x40
+sLedybaGfx36_1:
+.incbin "baserom.gba", 0xC41804, 0x100
+sLedybaGfx36_2:
+.incbin "baserom.gba", 0xC41904, 0x40
+sLedybaSprites36:
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx36_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLedybaGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLedybaGfx37:
+.incbin "baserom.gba", 0xC41984, 0x180
+sLedybaSprites37:
+ax_sprite sLedybaGfx37, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLedybaGfx38:
+.incbin "baserom.gba", 0xC41B1C, 0x200
+sLedybaSprites38:
+ax_sprite sLedybaGfx38, 0x200
+ax_sprite_terminator
+sLedybaGfx39:
+.incbin "baserom.gba", 0xC41D2C, 0x200
+sLedybaSprites39:
+ax_sprite sLedybaGfx39, 0x200
+ax_sprite_terminator
+sLedybaGfx40:
+.incbin "baserom.gba", 0xC41F3C, 0x200
+sLedybaSprites40:
+ax_sprite sLedybaGfx40, 0x200
+ax_sprite_terminator
+sLedybaGfx41:
+.incbin "baserom.gba", 0xC4214C, 0x200
+sLedybaSprites41:
+ax_sprite sLedybaGfx41, 0x200
+ax_sprite_terminator
+sLedybaGfx42:
+.incbin "baserom.gba", 0xC4235C, 0x200
+sLedybaSprites42:
+ax_sprite sLedybaGfx42, 0x200
+ax_sprite_terminator
+sLedybaGfx43:
+.incbin "baserom.gba", 0xC4256C, 0x200
+sLedybaSprites43:
+ax_sprite sLedybaGfx43, 0x200
+ax_sprite_terminator
+sLedybaGfx44:
+.incbin "baserom.gba", 0xC4277C, 0x200
+sLedybaSprites44:
+ax_sprite sLedybaGfx44, 0x200
+ax_sprite_terminator
+sLedybaGfx45:
+.incbin "baserom.gba", 0xC4298C, 0x200
+sLedybaSprites45:
+ax_sprite sLedybaGfx45, 0x200
+ax_sprite_terminator
+sLedybaGfx46:
+.incbin "baserom.gba", 0xC42B9C, 0x200
+sLedybaSprites46:
+ax_sprite sLedybaGfx46, 0x200
+ax_sprite_terminator
+sLedybaGfx47:
+.incbin "baserom.gba", 0xC42DAC, 0x200
+sLedybaSprites47:
+ax_sprite sLedybaGfx47, 0x200
+ax_sprite_terminator
+sLedybaGfx48:
+.incbin "baserom.gba", 0xC42FBC, 0x200
+sLedybaSprites48:
+ax_sprite sLedybaGfx48, 0x200
+ax_sprite_terminator
+sLedybaGfx49:
+.incbin "baserom.gba", 0xC431CC, 0x200
+sLedybaSprites49:
+ax_sprite sLedybaGfx49, 0x200
+ax_sprite_terminator
+sAxPosesLedyba:
+.4byte sLedybaPose1
+.4byte sLedybaPose2
+.4byte sLedybaPose3
+.4byte sLedybaPose4
+.4byte sLedybaPose5
+.4byte sLedybaPose6
+.4byte sLedybaPose7
+.4byte sLedybaPose8
+.4byte sLedybaPose9
+.4byte sLedybaPose10
+.4byte sLedybaPose11
+.4byte sLedybaPose12
+.4byte sLedybaPose13
+.4byte sLedybaPose14
+.4byte sLedybaPose15
+.4byte sLedybaPose16
+.4byte sLedybaPose17
+.4byte sLedybaPose18
+.4byte sLedybaPose19
+.4byte sLedybaPose20
+.4byte sLedybaPose21
+.4byte sLedybaPose22
+.4byte sLedybaPose23
+.4byte sLedybaPose24
+.4byte sLedybaPose25
+.4byte sLedybaPose26
+.4byte sLedybaPose27
+.4byte sLedybaPose28
+.4byte sLedybaPose29
+.4byte sLedybaPose30
+.4byte sLedybaPose31
+.4byte sLedybaPose32
+.4byte sLedybaPose33
+.4byte sLedybaPose34
+.4byte sLedybaPose35
+.4byte sLedybaPose36
+.4byte sLedybaPose37
+.4byte sLedybaPose38
+.4byte sLedybaPose39
+.4byte sLedybaPose40
+.4byte sLedybaPose41
+.4byte sLedybaPose42
+.4byte sLedybaPose43
+.4byte sLedybaPose44
+.4byte sLedybaPose45
+.4byte sLedybaPose46
+.4byte sLedybaPose47
+.4byte sLedybaPose48
+.4byte sLedybaPose49
+.4byte sLedybaPose50
+.4byte sLedybaPose51
+.4byte sLedybaPose52
+.4byte sLedybaPose53
+.4byte sLedybaPose54
+.4byte sLedybaPose55
+.4byte sLedybaPose56
+.4byte sLedybaPose57
+.4byte sLedybaPose58
+.4byte sLedybaPose59
+.4byte sLedybaPose60
+.4byte sLedybaPose61
+.4byte sLedybaPose62
+.4byte sLedybaPose63
+.4byte sLedybaPose64
+.4byte sLedybaPose65
+.4byte sLedybaPose66
+.4byte sLedybaPose67
+.4byte sLedybaPose68
+.4byte sLedybaPose69
+.4byte sLedybaPose70
+.4byte sLedybaPose71
+.4byte sLedybaPose72
+.4byte sLedybaPose73
+.4byte sLedybaPose74
+.4byte sLedybaPose75
+.4byte sLedybaPose76
+.4byte sLedybaPose77
+.4byte sLedybaPose78
+.4byte sLedybaPose79
+.4byte sLedybaPose80
+.4byte sLedybaPose81
+.4byte sLedybaPose82
+.4byte sLedybaPose83
+.4byte sLedybaPose84
+.4byte sLedybaPose85
+.4byte sLedybaPose86
+.4byte sLedybaPose87
+.4byte sLedybaPose88
+.4byte sLedybaPose89
+.4byte sLedybaPose90
+.4byte sLedybaPose91
+.4byte sLedybaPose92
+.4byte sLedybaPose93
+.4byte sLedybaPose94
+.4byte sLedybaPose95
+.4byte sLedybaPose96
+.4byte sLedybaPose97
+.4byte sLedybaPose98
+.4byte sLedybaPose99
+.4byte sLedybaPose100
+.4byte sLedybaPose101
+.4byte sLedybaPose102
+.4byte sLedybaPose103
+.4byte sLedybaPose104
+.4byte sLedybaPose105
+.4byte sLedybaPose106
+.4byte sLedybaPose107
+.4byte sLedybaPose108
+.4byte sLedybaPose109
+.4byte sLedybaPose110
+.4byte sLedybaPose111
+.4byte sLedybaPose112
+.4byte sLedybaPose113
+.4byte sLedybaPose114
+.4byte sLedybaPose115
+.4byte sLedybaPose116
+.4byte sLedybaPose117
+.4byte sLedybaPose118
+.4byte sLedybaPose119
+.4byte sLedybaPose120
+.4byte sLedybaPose121
+.4byte sLedybaPose122
+.4byte sLedybaPose123
+.4byte sLedybaPose124
+.4byte sLedybaPose125
+.4byte sLedybaPose126
+.4byte sLedybaPose127
+.4byte sLedybaPose128
+.4byte sLedybaPose129
+.4byte sLedybaPose130
+.4byte sLedybaPose131
+.4byte sLedybaPose132
+.4byte sLedybaPose133
+.4byte sLedybaPose134
+.4byte sLedybaPose135
+.4byte sLedybaPose136
+.4byte sLedybaPose137
+.4byte sLedybaPose138
+.4byte sLedybaPose139
+.4byte sLedybaPose140
+.4byte sLedybaPose141
+.4byte sLedybaPose142
+.4byte sLedybaPose143
+.4byte sLedybaPose144
+.4byte sLedybaPose145
+.4byte sLedybaPose146
+.4byte sLedybaPose147
+.4byte sLedybaPose148
+.4byte sLedybaPose149
+.4byte sLedybaPose150
+.4byte sLedybaPose151
+.4byte sLedybaPose152
+.4byte sLedybaPose153
+.4byte sLedybaPose154
+.4byte sLedybaPose155
+.4byte sLedybaPose156
+.4byte sLedybaPose157
+.4byte sLedybaPose158
+.4byte sLedybaPose159
+.4byte sLedybaPose160
+.4byte sLedybaPose161
+.4byte sLedybaPose162
+.4byte sLedybaPose163
+.4byte sLedybaPose164
+.4byte sLedybaPose165
+.4byte sLedybaPose166
+.4byte sLedybaPose167
+.4byte sLedybaPose168
+.4byte sLedybaPose169
+.4byte sLedybaPose170
+.4byte sLedybaPose171
+.4byte sLedybaPose172
+.4byte sLedybaPose173
+.4byte sLedybaPose174
+.4byte sLedybaPose175
+.4byte sLedybaPose176
+.4byte sLedybaPose177
+.4byte sLedybaPose178
+.4byte sLedybaPose179
+.4byte sLedybaPose180
+.4byte sLedybaPose181
+.4byte sLedybaPose182
+.4byte sLedybaPose183
+.4byte sLedybaPose184
+.4byte sLedybaPose185
+.4byte sLedybaPose186
+sAxPositionsLedyba:
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -11
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -10
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -11
+.2byte    4,  -18, 	  -1,  -18, 	  10,  -11, 	  -2,  -12
+.2byte    4,  -17, 	  -1,  -16, 	  10,  -11, 	  -1,  -13
+.2byte   -1,  -19, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -19, 	   8,  -16, 	 -10,  -16, 	  -1,  -13
+.2byte   -6,  -18, 	  -1,  -18, 	 -12,  -11, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -16, 	 -12,  -11, 	  -1,  -13
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -10
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -12
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -11
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -10
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -11
+.2byte    4,  -18, 	  -1,  -18, 	  10,  -11, 	  -2,  -12
+.2byte    4,  -17, 	  -1,  -16, 	  10,  -11, 	  -1,  -13
+.2byte   -1,  -19, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -19, 	   8,  -16, 	 -10,  -16, 	  -1,  -13
+.2byte   -6,  -18, 	  -1,  -18, 	 -12,  -11, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -16, 	 -12,  -11, 	  -1,  -13
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -10
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -12
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    3,  -10, 	   1,   -3, 	  10,  -14, 	   0,  -11
+.2byte    3,  -10, 	   1,   -3, 	  10,  -14, 	   0,  -11
+.2byte   -4,  -10, 	  -2,   -3, 	 -11,  -14, 	  -1,  -11
+.2byte   -4,  -10, 	  -2,   -3, 	 -11,  -14, 	  -1,  -11
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -11
+.2byte    3,  -10, 	   4,   -4, 	  -7,  -15, 	  -1,   -9
+.2byte    3,  -10, 	   4,   -4, 	  -7,  -15, 	  -1,   -9
+.2byte    6,  -13, 	   7,  -22, 	   8,   -9, 	  -3,  -10
+.2byte    6,  -13, 	   7,  -22, 	   8,   -9, 	  -3,  -10
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -10
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -11
+.2byte    7,  -11, 	   9,   -5, 	  -3,  -15, 	   1,  -10
+.2byte    7,  -11, 	   9,   -5, 	  -3,  -15, 	   1,  -10
+.2byte    8,  -18, 	   1,  -23, 	  11,  -14, 	   0,   -9
+.2byte    8,  -18, 	   1,  -23, 	  11,  -14, 	   0,   -9
+.2byte    4,  -18, 	  -1,  -18, 	  10,  -11, 	  -2,  -12
+.2byte    4,  -17, 	  -1,  -16, 	  10,  -11, 	  -1,  -13
+.2byte    6,  -16, 	  11,  -13, 	   8,  -14, 	  -1,  -12
+.2byte    6,  -16, 	  11,  -13, 	   8,  -14, 	  -1,  -12
+.2byte    0,  -18, 	  -9,  -21, 	   2,  -17, 	  -1,  -12
+.2byte    0,  -18, 	  -9,  -21, 	   2,  -17, 	  -1,  -12
+.2byte   -1,  -19, 	   8,  -16, 	 -10,  -16, 	  -1,  -13
+.2byte   -1,  -19, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -3,  -19, 	 -10,  -18, 	 -11,  -12, 	  -1,  -13
+.2byte   -3,  -19, 	 -10,  -18, 	 -11,  -12, 	  -1,  -13
+.2byte    2,  -19, 	   9,  -18, 	  10,  -12, 	   0,  -13
+.2byte    2,  -19, 	   9,  -18, 	  10,  -12, 	   0,  -13
+.2byte   -6,  -18, 	  -1,  -18, 	 -12,  -11, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -16, 	 -12,  -11, 	  -1,  -13
+.2byte   -8,  -16, 	 -13,  -13, 	 -10,  -14, 	  -1,  -12
+.2byte   -8,  -16, 	 -13,  -13, 	 -10,  -14, 	  -1,  -12
+.2byte   -2,  -18, 	   7,  -21, 	  -4,  -17, 	  -1,  -12
+.2byte   -2,  -18, 	   7,  -21, 	  -4,  -17, 	  -1,  -12
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -10
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -11
+.2byte   -9,  -11, 	 -11,   -5, 	   1,  -15, 	  -3,  -10
+.2byte   -9,  -11, 	 -11,   -5, 	   1,  -15, 	  -3,  -10
+.2byte  -10,  -18, 	  -3,  -23, 	 -13,  -14, 	  -2,   -9
+.2byte  -10,  -18, 	  -3,  -23, 	 -13,  -14, 	  -2,   -9
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -12
+.2byte   -5,  -10, 	  -6,   -4, 	   5,  -15, 	  -1,   -9
+.2byte   -5,  -10, 	  -6,   -4, 	   5,  -15, 	  -1,   -9
+.2byte   -8,  -13, 	  -9,  -22, 	 -10,   -9, 	   1,  -10
+.2byte   -8,  -13, 	  -9,  -22, 	 -10,   -9, 	   1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -11
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -10
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -11
+.2byte    4,  -18, 	  -1,  -18, 	  10,  -11, 	  -2,  -12
+.2byte    4,  -17, 	  -1,  -16, 	  10,  -11, 	  -1,  -13
+.2byte   -1,  -19, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -19, 	   8,  -16, 	 -10,  -16, 	  -1,  -13
+.2byte   -6,  -18, 	  -1,  -18, 	 -12,  -11, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -16, 	 -12,  -11, 	  -1,  -13
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -10
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -13, 	   9,  -13, 	  -1,   -6
+.2byte    5,  -10, 	   7,  -17, 	  -7,   -9, 	   0,   -7
+.2byte    7,  -14, 	   2,  -15, 	   2,  -11, 	  -2,   -8
+.2byte    2,  -17, 	  -6,  -19, 	   9,  -14, 	  -2,  -10
+.2byte   -1,  -18, 	   8,  -17, 	 -11,  -17, 	  -1,   -9
+.2byte   -4,  -17, 	   4,  -19, 	 -11,  -14, 	   0,  -10
+.2byte   -9,  -15, 	  -4,  -16, 	  -4,  -12, 	   0,   -9
+.2byte   -6,  -10, 	  -8,  -17, 	   6,   -9, 	  -1,   -7
+.2byte   -1,    0, 	 -10,    0, 	   8,    0, 	  -1,   -7
+.2byte   -1,    0, 	  -9,    0, 	   7,    0, 	  -1,   -8
+.2byte    0,   -4, 	 -11,   -3, 	  11,   -3, 	   0,   -8
+.2byte    8,   -3, 	   9,   -9, 	  -3,   -2, 	   1,  -11
+.2byte   11,   -5, 	   6,   -6, 	   3,   -2, 	   2,   -8
+.2byte    7,  -10, 	  -3,  -10, 	  11,   -6, 	   0,   -9
+.2byte    0,   -9, 	   8,   -9, 	  -8,   -9, 	   0,   -7
+.2byte   -8,  -10, 	   2,  -10, 	 -12,   -6, 	  -1,   -9
+.2byte  -12,   -5, 	  -7,   -6, 	  -4,   -2, 	  -3,   -8
+.2byte   -9,   -3, 	 -10,   -9, 	   2,   -2, 	  -2,  -11
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -11
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -10
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -11
+.2byte    4,  -18, 	  -1,  -18, 	  10,  -11, 	  -2,  -12
+.2byte    4,  -17, 	  -1,  -16, 	  10,  -11, 	  -1,  -13
+.2byte   -1,  -19, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -19, 	   8,  -16, 	 -10,  -16, 	  -1,  -13
+.2byte   -6,  -18, 	  -1,  -18, 	 -12,  -11, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -16, 	 -12,  -11, 	  -1,  -13
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -10
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -12
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -11
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -10
+.2byte   -6,  -18, 	  -1,  -18, 	 -12,  -11, 	   0,  -12
+.2byte   -1,  -19, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte    4,  -18, 	  -1,  -18, 	  10,  -11, 	  -2,  -12
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte    3,  -10, 	   1,   -3, 	  10,  -14, 	   0,  -11
+.2byte    3,  -10, 	   4,   -4, 	  -7,  -15, 	  -1,   -9
+.2byte    5,  -11, 	   7,   -5, 	  -5,  -15, 	  -1,  -10
+.2byte    6,  -15, 	  11,  -12, 	   8,  -13, 	  -1,  -11
+.2byte   -1,  -18, 	  -8,  -17, 	  -9,  -11, 	   1,  -12
+.2byte   -6,  -15, 	 -11,  -12, 	  -8,  -13, 	   1,  -11
+.2byte   -6,  -11, 	  -8,   -5, 	   4,  -15, 	   0,  -10
+.2byte   -4,  -10, 	  -5,   -4, 	   6,  -15, 	   0,   -9
+.2byte   -1,   -7, 	 -11,  -12, 	   9,  -12, 	  -1,   -5
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    5,  -10, 	   7,  -17, 	  -7,   -9, 	   0,   -7
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte    6,  -12, 	  10,  -12, 	  -2,   -7, 	  -1,  -11
+.2byte    7,  -14, 	   2,  -15, 	   2,  -11, 	  -2,   -8
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -10
+.2byte    8,  -14, 	   5,  -14, 	   5,   -8, 	   0,  -11
+.2byte    2,  -17, 	  -6,  -19, 	   9,  -14, 	  -2,  -10
+.2byte    4,  -18, 	  -1,  -18, 	  10,  -11, 	  -2,  -12
+.2byte    4,  -17, 	  -1,  -16, 	  10,  -11, 	  -1,  -13
+.2byte   -1,  -18, 	   8,  -17, 	 -11,  -17, 	  -1,   -9
+.2byte   -1,  -19, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -1,  -19, 	   8,  -16, 	 -10,  -16, 	  -1,  -13
+.2byte   -4,  -17, 	   4,  -19, 	 -11,  -14, 	   0,  -10
+.2byte   -6,  -18, 	  -1,  -18, 	 -12,  -11, 	   0,  -12
+.2byte   -6,  -17, 	  -1,  -16, 	 -12,  -11, 	  -1,  -13
+.2byte   -9,  -15, 	  -4,  -16, 	  -4,  -12, 	   0,   -9
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -10
+.2byte  -10,  -14, 	  -7,  -14, 	  -7,   -8, 	  -2,  -11
+.2byte   -6,  -10, 	  -8,  -17, 	   6,   -9, 	  -1,   -7
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -11
+.2byte   -8,  -13, 	 -12,  -13, 	   0,   -8, 	  -1,  -12
+.2byte   -1,   -7, 	 -11,  -12, 	   9,  -12, 	  -1,   -5
+.2byte   -6,   -9, 	  -8,  -16, 	   6,   -8, 	  -1,   -6
+.2byte   -9,  -14, 	  -4,  -15, 	  -4,  -11, 	   0,   -8
+.2byte   -4,  -16, 	   4,  -18, 	 -11,  -13, 	   0,   -9
+.2byte   -1,  -18, 	   8,  -17, 	 -11,  -17, 	  -1,   -9
+.2byte    2,  -16, 	  -6,  -18, 	   9,  -13, 	  -2,   -9
+.2byte    7,  -14, 	   2,  -15, 	   2,  -11, 	  -2,   -8
+.2byte    5,  -10, 	   7,  -17, 	  -7,   -9, 	   0,   -7
+.2byte   -1,  -11, 	 -12,  -12, 	  10,  -12, 	  -1,  -12
+.2byte   -8,  -12, 	 -11,  -16, 	   3,   -9, 	   0,  -11
+.2byte  -10,  -14, 	  -5,  -15, 	  -5,  -10, 	   0,  -11
+.2byte   -5,  -19, 	   1,  -20, 	 -13,  -14, 	   0,  -13
+.2byte   -1,  -19, 	   9,  -18, 	 -11,  -18, 	  -1,  -13
+.2byte    3,  -19, 	  -3,  -20, 	  11,  -14, 	  -2,  -13
+.2byte    8,  -14, 	   3,  -15, 	   3,  -10, 	  -2,  -11
+.2byte    6,  -12, 	   9,  -16, 	  -5,   -9, 	  -2,  -11
+sLedybaAnimTable1:
+.4byte sLedybaAnims_1_1
+.4byte sLedybaAnims_1_2
+.4byte sLedybaAnims_1_3
+.4byte sLedybaAnims_1_4
+.4byte sLedybaAnims_1_5
+.4byte sLedybaAnims_1_6
+.4byte sLedybaAnims_1_7
+.4byte sLedybaAnims_1_8
+sLedybaAnimTable2:
+.4byte sLedybaAnims_2_1
+.4byte sLedybaAnims_2_2
+.4byte sLedybaAnims_2_3
+.4byte sLedybaAnims_2_4
+.4byte sLedybaAnims_2_5
+.4byte sLedybaAnims_2_6
+.4byte sLedybaAnims_2_7
+.4byte sLedybaAnims_2_8
+sLedybaAnimTable3:
+.4byte sLedybaAnims_3_1
+.4byte sLedybaAnims_3_2
+.4byte sLedybaAnims_3_3
+.4byte sLedybaAnims_3_4
+.4byte sLedybaAnims_3_5
+.4byte sLedybaAnims_3_6
+.4byte sLedybaAnims_3_7
+.4byte sLedybaAnims_3_8
+sLedybaAnimTable4:
+.4byte sLedybaAnims_4_1
+.4byte sLedybaAnims_4_2
+.4byte sLedybaAnims_4_3
+.4byte sLedybaAnims_4_4
+.4byte sLedybaAnims_4_5
+.4byte sLedybaAnims_4_6
+.4byte sLedybaAnims_4_7
+.4byte sLedybaAnims_4_8
+sLedybaAnimTable5:
+.4byte sLedybaAnims_5_1
+.4byte sLedybaAnims_5_2
+.4byte sLedybaAnims_5_3
+.4byte sLedybaAnims_5_4
+.4byte sLedybaAnims_5_5
+.4byte sLedybaAnims_5_6
+.4byte sLedybaAnims_5_7
+.4byte sLedybaAnims_5_8
+sLedybaAnimTable6:
+.4byte sLedybaAnims_6_1
+.4byte sLedybaAnims_6_1
+.4byte sLedybaAnims_6_1
+.4byte sLedybaAnims_6_1
+.4byte sLedybaAnims_6_1
+.4byte sLedybaAnims_6_1
+.4byte sLedybaAnims_6_1
+.4byte sLedybaAnims_6_1
+sLedybaAnimTable7:
+.4byte sLedybaAnims_7_1
+.4byte sLedybaAnims_7_2
+.4byte sLedybaAnims_7_3
+.4byte sLedybaAnims_7_4
+.4byte sLedybaAnims_7_5
+.4byte sLedybaAnims_7_6
+.4byte sLedybaAnims_7_7
+.4byte sLedybaAnims_7_8
+sLedybaAnimTable8:
+.4byte sLedybaAnims_8_1
+.4byte sLedybaAnims_8_2
+.4byte sLedybaAnims_8_3
+.4byte sLedybaAnims_8_4
+.4byte sLedybaAnims_8_5
+.4byte sLedybaAnims_8_6
+.4byte sLedybaAnims_8_7
+.4byte sLedybaAnims_8_8
+sLedybaAnimTable9:
+.4byte sLedybaAnims_9_1
+.4byte sLedybaAnims_9_2
+.4byte sLedybaAnims_9_3
+.4byte sLedybaAnims_9_4
+.4byte sLedybaAnims_9_5
+.4byte sLedybaAnims_9_6
+.4byte sLedybaAnims_9_7
+.4byte sLedybaAnims_9_8
+sLedybaAnimTable10:
+.4byte sLedybaAnims_10_1
+.4byte sLedybaAnims_10_2
+.4byte sLedybaAnims_10_3
+.4byte sLedybaAnims_10_4
+.4byte sLedybaAnims_10_5
+.4byte sLedybaAnims_10_6
+.4byte sLedybaAnims_10_7
+.4byte sLedybaAnims_10_8
+sLedybaAnimTable11:
+.4byte sLedybaAnims_11_1
+.4byte sLedybaAnims_11_2
+.4byte sLedybaAnims_11_3
+.4byte sLedybaAnims_11_4
+.4byte sLedybaAnims_11_5
+.4byte sLedybaAnims_11_6
+.4byte sLedybaAnims_11_7
+.4byte sLedybaAnims_11_8
+sLedybaAnimTable12:
+.4byte sLedybaAnims_12_1
+.4byte sLedybaAnims_12_2
+.4byte sLedybaAnims_12_3
+.4byte sLedybaAnims_12_4
+.4byte sLedybaAnims_12_5
+.4byte sLedybaAnims_12_6
+.4byte sLedybaAnims_12_7
+.4byte sLedybaAnims_12_8
+sLedybaAnimTable13:
+.4byte sLedybaAnims_13_1
+.4byte sLedybaAnims_13_2
+.4byte sLedybaAnims_13_3
+.4byte sLedybaAnims_13_4
+.4byte sLedybaAnims_13_5
+.4byte sLedybaAnims_13_6
+.4byte sLedybaAnims_13_7
+.4byte sLedybaAnims_13_8
+sAxAnimationsLedyba:
+.4byte sLedybaAnimTable1
+.4byte sLedybaAnimTable2
+.4byte sLedybaAnimTable3
+.4byte sLedybaAnimTable4
+.4byte sLedybaAnimTable5
+.4byte sLedybaAnimTable6
+.4byte sLedybaAnimTable7
+.4byte sLedybaAnimTable8
+.4byte sLedybaAnimTable9
+.4byte sLedybaAnimTable10
+.4byte sLedybaAnimTable11
+.4byte sLedybaAnimTable12
+.4byte sLedybaAnimTable13
+sAxSpritesLedyba:
+.4byte sLedybaSprites1
+.4byte sLedybaSprites2
+.4byte sLedybaSprites3
+.4byte sLedybaSprites4
+.4byte sLedybaSprites5
+.4byte sLedybaSprites6
+.4byte sLedybaSprites7
+.4byte sLedybaSprites8
+.4byte sLedybaSprites9
+.4byte sLedybaSprites10
+.4byte sLedybaSprites11
+.4byte sLedybaSprites12
+.4byte sLedybaSprites13
+.4byte sLedybaSprites14
+.4byte sLedybaSprites15
+.4byte sLedybaSprites16
+.4byte sLedybaSprites17
+.4byte sLedybaSprites18
+.4byte sLedybaSprites19
+.4byte sLedybaSprites20
+.4byte sLedybaSprites21
+.4byte sLedybaSprites22
+.4byte sLedybaSprites23
+.4byte sLedybaSprites24
+.4byte sLedybaSprites25
+.4byte sLedybaSprites26
+.4byte sLedybaSprites27
+.4byte sLedybaSprites28
+.4byte sLedybaSprites29
+.4byte sLedybaSprites30
+.4byte sLedybaSprites31
+.4byte sLedybaSprites32
+.4byte sLedybaSprites33
+.4byte sLedybaSprites34
+.4byte sLedybaSprites35
+.4byte sLedybaSprites36
+.4byte sLedybaSprites37
+.4byte sLedybaSprites38
+.4byte sLedybaSprites39
+.4byte sLedybaSprites40
+.4byte sLedybaSprites41
+.4byte sLedybaSprites42
+.4byte sLedybaSprites43
+.4byte sLedybaSprites44
+.4byte sLedybaSprites45
+.4byte sLedybaSprites46
+.4byte sLedybaSprites47
+.4byte sLedybaSprites48
+.4byte sLedybaSprites49
+sAxMainLedyba:
+ax_main sAxPosesLedyba, sAxAnimationsLedyba, 13, sAxSpritesLedyba, sAxPositionsLedyba

--- a/data/ax/lickitung.inc
+++ b/data/ax/lickitung.inc
@@ -1,0 +1,3126 @@
+.global gAxLickitung
+gAxLickitung:
+ax_siro sAxMainLickitung
+sLickitungPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose4:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose5:
+ax_pose 4, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose6:
+ax_pose 5, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose7:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose8:
+ax_pose 7, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose9:
+ax_pose 8, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose10:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose11:
+ax_pose 10, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose12:
+ax_pose 11, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose19:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose28:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose29:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose30:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose31:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose32:
+ax_pose 4, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose33:
+ax_pose 5, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose34:
+ax_pose 18, 0x81e2, 0x90fe, 0x4c00
+ax_pose 19, 0x01ea, 0x50ee, 0x4c08
+ax_pose 20, 0x41fa, 0x10ee, 0x4c0c
+ax_pose 21, 0x0202, 0x10f6, 0x4c0e
+ax_pose_terminator
+sLickitungPose35:
+ax_pose 22, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose36:
+ax_pose 23, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose37:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose38:
+ax_pose 7, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose39:
+ax_pose 8, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose40:
+ax_pose 24, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose41:
+ax_pose 25, 0x01ec, 0x50ff, 0x4c00
+ax_pose 26, 0x01ec, 0x50ef, 0x4c04
+ax_pose 27, 0x41fc, 0x50ef, 0x4c08
+ax_pose 28, 0x01f4, 0x110f, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e7, 0x4c0d
+ax_pose_terminator
+sLickitungPose42:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose43:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose44:
+ax_pose 10, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose45:
+ax_pose 11, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose46:
+ax_pose 31, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sLickitungPose47:
+ax_pose 32, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose48:
+ax_pose 33, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose49:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose50:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose51:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose52:
+ax_pose 34, 0x41e9, 0x80f1, 0x4c00
+ax_pose 35, 0x41f9, 0x40f1, 0x4c08
+ax_pose 36, 0x01e9, 0x0111, 0x4c0c
+ax_pose 37, 0x01f1, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose53:
+ax_pose 38, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose54:
+ax_pose 39, 0x41e9, 0x80ef, 0x4c00
+ax_pose 40, 0x01e9, 0x00e7, 0x4c08
+ax_pose 41, 0x01f1, 0x00e7, 0x4c09
+ax_pose 42, 0x41f9, 0x40ef, 0x4c0a
+ax_pose_terminator
+sLickitungPose55:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose56:
+ax_pose 10, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose57:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose58:
+ax_pose 31, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sLickitungPose59:
+ax_pose 32, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose60:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose61:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose62:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose63:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose64:
+ax_pose 24, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose65:
+ax_pose 25, 0x01ec, 0x40f1, 0x4c00
+ax_pose 26, 0x01ec, 0x4101, 0x4c04
+ax_pose 27, 0x41fc, 0x40f1, 0x4c08
+ax_pose 28, 0x01f4, 0x00e9, 0x4c0c
+ax_pose 29, 0x01ec, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose66:
+ax_pose 30, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose67:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose68:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose69:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose70:
+ax_pose 18, 0x81e2, 0x80f2, 0x4c00
+ax_pose 19, 0x01ea, 0x4102, 0x4c08
+ax_pose 20, 0x41fa, 0x0102, 0x4c0c
+ax_pose 21, 0x0202, 0x0102, 0x4c0e
+ax_pose_terminator
+sLickitungPose71:
+ax_pose 22, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose72:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose73:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose74:
+ax_pose 1, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose75:
+ax_pose 2, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose76:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose77:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose78:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose79:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose80:
+ax_pose 4, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose81:
+ax_pose 5, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose82:
+ax_pose 18, 0x81e2, 0x90fe, 0x4c00
+ax_pose 19, 0x01ea, 0x50ee, 0x4c08
+ax_pose 20, 0x41fa, 0x10ee, 0x4c0c
+ax_pose 21, 0x0202, 0x10f6, 0x4c0e
+ax_pose_terminator
+sLickitungPose83:
+ax_pose 22, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose84:
+ax_pose 23, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose85:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose86:
+ax_pose 7, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose87:
+ax_pose 8, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose88:
+ax_pose 24, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose89:
+ax_pose 25, 0x01ec, 0x50ff, 0x4c00
+ax_pose 26, 0x01ec, 0x50ef, 0x4c04
+ax_pose 27, 0x41fc, 0x50ef, 0x4c08
+ax_pose 28, 0x01f4, 0x110f, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e7, 0x4c0d
+ax_pose_terminator
+sLickitungPose90:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose91:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose92:
+ax_pose 10, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose93:
+ax_pose 11, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose94:
+ax_pose 31, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sLickitungPose95:
+ax_pose 32, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose96:
+ax_pose 33, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose97:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose98:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose99:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose100:
+ax_pose 34, 0x41e9, 0x80f1, 0x4c00
+ax_pose 35, 0x41f9, 0x40f1, 0x4c08
+ax_pose 36, 0x01e9, 0x0111, 0x4c0c
+ax_pose 37, 0x01f1, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose101:
+ax_pose 38, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose102:
+ax_pose 39, 0x41e9, 0x80ef, 0x4c00
+ax_pose 40, 0x01e9, 0x00e7, 0x4c08
+ax_pose 41, 0x01f1, 0x00e7, 0x4c09
+ax_pose 42, 0x41f9, 0x40ef, 0x4c0a
+ax_pose_terminator
+sLickitungPose103:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose104:
+ax_pose 10, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose105:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose106:
+ax_pose 31, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sLickitungPose107:
+ax_pose 32, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose108:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose109:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose110:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose111:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose112:
+ax_pose 24, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose113:
+ax_pose 25, 0x01ec, 0x40f1, 0x4c00
+ax_pose 26, 0x01ec, 0x4101, 0x4c04
+ax_pose 27, 0x41fc, 0x40f1, 0x4c08
+ax_pose 28, 0x01f4, 0x00e9, 0x4c0c
+ax_pose 29, 0x01ec, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose114:
+ax_pose 30, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose115:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose116:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose117:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose118:
+ax_pose 18, 0x81e2, 0x80f2, 0x4c00
+ax_pose 19, 0x01ea, 0x4102, 0x4c08
+ax_pose 20, 0x41fa, 0x0102, 0x4c0c
+ax_pose 21, 0x0202, 0x0102, 0x4c0e
+ax_pose_terminator
+sLickitungPose119:
+ax_pose 22, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose120:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose121:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose122:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose123:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose124:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose125:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose126:
+ax_pose 18, 0x81e2, 0x90fe, 0x4c00
+ax_pose 19, 0x01ea, 0x50ee, 0x4c08
+ax_pose 20, 0x41fa, 0x10ee, 0x4c0c
+ax_pose 21, 0x0202, 0x10f6, 0x4c0e
+ax_pose_terminator
+sLickitungPose127:
+ax_pose 22, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose128:
+ax_pose 23, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose129:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose130:
+ax_pose 24, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose131:
+ax_pose 25, 0x01ec, 0x50ff, 0x4c00
+ax_pose 26, 0x01ec, 0x50ef, 0x4c04
+ax_pose 27, 0x41fc, 0x50ef, 0x4c08
+ax_pose 28, 0x01f4, 0x110f, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e7, 0x4c0d
+ax_pose_terminator
+sLickitungPose132:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose133:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose134:
+ax_pose 31, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sLickitungPose135:
+ax_pose 32, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose136:
+ax_pose 33, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose137:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose138:
+ax_pose 34, 0x41e9, 0x80f1, 0x4c00
+ax_pose 35, 0x41f9, 0x40f1, 0x4c08
+ax_pose 36, 0x01e9, 0x0111, 0x4c0c
+ax_pose 37, 0x01f1, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose139:
+ax_pose 38, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose140:
+ax_pose 39, 0x41e9, 0x80ef, 0x4c00
+ax_pose 40, 0x01e9, 0x00e7, 0x4c08
+ax_pose 41, 0x01f1, 0x00e7, 0x4c09
+ax_pose 42, 0x41f9, 0x40ef, 0x4c0a
+ax_pose_terminator
+sLickitungPose141:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose142:
+ax_pose 31, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sLickitungPose143:
+ax_pose 32, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose144:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose145:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose146:
+ax_pose 24, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose147:
+ax_pose 25, 0x01ec, 0x40f1, 0x4c00
+ax_pose 26, 0x01ec, 0x4101, 0x4c04
+ax_pose 27, 0x41fc, 0x40f1, 0x4c08
+ax_pose 28, 0x01f4, 0x00e9, 0x4c0c
+ax_pose 29, 0x01ec, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose148:
+ax_pose 30, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose149:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose150:
+ax_pose 18, 0x81e2, 0x80f2, 0x4c00
+ax_pose 19, 0x01ea, 0x4102, 0x4c08
+ax_pose 20, 0x41fa, 0x0102, 0x4c0c
+ax_pose 21, 0x0202, 0x0102, 0x4c0e
+ax_pose_terminator
+sLickitungPose151:
+ax_pose 22, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose152:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose153:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose154:
+ax_pose 1, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose155:
+ax_pose 2, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose156:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose 43, 0x01de, 0x34f4, 0x0c10
+ax_pose_terminator
+sLickitungPose157:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose158:
+ax_pose 17, 0x01e5, 0x80f0, 0x4c00
+ax_pose 43, 0x01de, 0x2504, 0x0c10
+ax_pose_terminator
+sLickitungPose159:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose160:
+ax_pose 4, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose161:
+ax_pose 5, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose162:
+ax_pose 23, 0x01e6, 0x90f0, 0x4c00
+ax_pose 43, 0x01e0, 0x34ec, 0x0c10
+ax_pose_terminator
+sLickitungPose163:
+ax_pose 22, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose164:
+ax_pose 18, 0x81e2, 0x90fe, 0x4c00
+ax_pose 19, 0x01ea, 0x50ee, 0x4c08
+ax_pose 20, 0x41fa, 0x10ee, 0x4c0c
+ax_pose 21, 0x0202, 0x10f6, 0x4c0e
+ax_pose 43, 0x01db, 0x24f9, 0x0c0f
+ax_pose_terminator
+sLickitungPose165:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose166:
+ax_pose 7, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose167:
+ax_pose 8, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose168:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose 43, 0x01e7, 0x34ed, 0x0c10
+ax_pose_terminator
+sLickitungPose169:
+ax_pose 25, 0x01ec, 0x50ff, 0x4c00
+ax_pose 26, 0x01ec, 0x50ef, 0x4c04
+ax_pose 27, 0x41fc, 0x50ef, 0x4c08
+ax_pose 28, 0x01f4, 0x110f, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e7, 0x4c0d
+ax_pose_terminator
+sLickitungPose170:
+ax_pose 24, 0x01e4, 0x90f0, 0x4c00
+ax_pose 43, 0x01dc, 0x34f1, 0x0c10
+ax_pose_terminator
+sLickitungPose171:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose172:
+ax_pose 10, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose173:
+ax_pose 11, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose174:
+ax_pose 43, 0x01f5, 0x24fe, 0x0c00
+ax_pose 33, 0x01e6, 0x90f0, 0x4c01
+ax_pose_terminator
+sLickitungPose175:
+ax_pose 32, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose176:
+ax_pose 31, 0x01e6, 0x90ef, 0x4c00
+ax_pose 43, 0x01e7, 0x24e9, 0x0c10
+ax_pose_terminator
+sLickitungPose177:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose178:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose179:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose180:
+ax_pose 43, 0x01ef, 0x350f, 0x0c00
+ax_pose 34, 0x41e9, 0x80f1, 0x4c01
+ax_pose 35, 0x41f9, 0x40f1, 0x4c09
+ax_pose 36, 0x01e9, 0x0111, 0x4c0d
+ax_pose 37, 0x01f1, 0x0111, 0x4c0e
+ax_pose_terminator
+sLickitungPose181:
+ax_pose 38, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose182:
+ax_pose 43, 0x01ee, 0x04e9, 0x0c00
+ax_pose 39, 0x41e9, 0x80ef, 0x4c01
+ax_pose 40, 0x01e9, 0x00e7, 0x4c09
+ax_pose 41, 0x01f1, 0x00e7, 0x4c0a
+ax_pose 42, 0x41f9, 0x40ef, 0x4c0b
+ax_pose_terminator
+sLickitungPose183:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose184:
+ax_pose 10, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose185:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose186:
+ax_pose 31, 0x01e6, 0x80f1, 0x4c00
+ax_pose 43, 0x01e9, 0x150f, 0x0c10
+ax_pose_terminator
+sLickitungPose187:
+ax_pose 32, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose188:
+ax_pose 43, 0x01f7, 0x24f7, 0x0c00
+ax_pose 33, 0x01e6, 0x80f0, 0x4c01
+ax_pose_terminator
+sLickitungPose189:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose190:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose191:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose192:
+ax_pose 43, 0x01e1, 0x3506, 0x0c00
+ax_pose 24, 0x01e4, 0x80f0, 0x4c01
+ax_pose_terminator
+sLickitungPose193:
+ax_pose 25, 0x01ec, 0x40f1, 0x4c00
+ax_pose 26, 0x01ec, 0x4101, 0x4c04
+ax_pose 27, 0x41fc, 0x40f1, 0x4c08
+ax_pose 28, 0x01f4, 0x00e9, 0x4c0c
+ax_pose 29, 0x01ec, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose194:
+ax_pose 43, 0x01ed, 0x3505, 0x0c00
+ax_pose 30, 0x01e6, 0x80f0, 0x4c01
+ax_pose_terminator
+sLickitungPose195:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose196:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose197:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose198:
+ax_pose 18, 0x81e2, 0x80f2, 0x4c00
+ax_pose 19, 0x01ea, 0x4102, 0x4c08
+ax_pose 20, 0x41fa, 0x0102, 0x4c0c
+ax_pose 21, 0x0202, 0x0102, 0x4c0e
+ax_pose 43, 0x01da, 0x34fb, 0x0c0f
+ax_pose_terminator
+sLickitungPose199:
+ax_pose 22, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose200:
+ax_pose 43, 0x01e4, 0x350a, 0x0c00
+ax_pose 23, 0x01e6, 0x80f0, 0x4c01
+ax_pose_terminator
+sLickitungPose201:
+ax_pose 44, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sLickitungPose202:
+ax_pose 45, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sLickitungPose203:
+ax_pose 46, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose204:
+ax_pose 47, 0x01e2, 0x90ef, 0x4c00
+ax_pose_terminator
+sLickitungPose205:
+ax_pose 48, 0x01e2, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose206:
+ax_pose 49, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose207:
+ax_pose 50, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose208:
+ax_pose 49, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose209:
+ax_pose 48, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose210:
+ax_pose 47, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sLickitungPose211:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose212:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose213:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose214:
+ax_pose 22, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose215:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose216:
+ax_pose 25, 0x01ec, 0x50ff, 0x4c00
+ax_pose 26, 0x01ec, 0x50ef, 0x4c04
+ax_pose 27, 0x41fc, 0x50ef, 0x4c08
+ax_pose 28, 0x01f4, 0x110f, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e7, 0x4c0d
+ax_pose_terminator
+sLickitungPose217:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose218:
+ax_pose 32, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose219:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose220:
+ax_pose 38, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose221:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose222:
+ax_pose 32, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose223:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose224:
+ax_pose 25, 0x01ec, 0x40f1, 0x4c00
+ax_pose 26, 0x01ec, 0x4101, 0x4c04
+ax_pose 27, 0x41fc, 0x40f1, 0x4c08
+ax_pose 28, 0x01f4, 0x00e9, 0x4c0c
+ax_pose 29, 0x01ec, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose225:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose226:
+ax_pose 22, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose227:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose228:
+ax_pose 22, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose229:
+ax_pose 25, 0x01ec, 0x40f1, 0x4c00
+ax_pose 26, 0x01ec, 0x4101, 0x4c04
+ax_pose 27, 0x41fc, 0x40f1, 0x4c08
+ax_pose 28, 0x01f4, 0x00e9, 0x4c0c
+ax_pose 29, 0x01ec, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose230:
+ax_pose 32, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose231:
+ax_pose 38, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose232:
+ax_pose 32, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose233:
+ax_pose 25, 0x01ec, 0x50ff, 0x4c00
+ax_pose 26, 0x01ec, 0x50ef, 0x4c04
+ax_pose 27, 0x41fc, 0x50ef, 0x4c08
+ax_pose 28, 0x01f4, 0x110f, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e7, 0x4c0d
+ax_pose_terminator
+sLickitungPose234:
+ax_pose 22, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose235:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose236:
+ax_pose 22, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose237:
+ax_pose 25, 0x01ec, 0x50ff, 0x4c00
+ax_pose 26, 0x01ec, 0x50ef, 0x4c04
+ax_pose 27, 0x41fc, 0x50ef, 0x4c08
+ax_pose 28, 0x01f4, 0x110f, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e7, 0x4c0d
+ax_pose_terminator
+sLickitungPose238:
+ax_pose 32, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sLickitungPose239:
+ax_pose 38, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose240:
+ax_pose 32, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose241:
+ax_pose 25, 0x01ec, 0x40f1, 0x4c00
+ax_pose 26, 0x01ec, 0x4101, 0x4c04
+ax_pose 27, 0x41fc, 0x40f1, 0x4c08
+ax_pose 28, 0x01f4, 0x00e9, 0x4c0c
+ax_pose 29, 0x01ec, 0x0111, 0x4c0d
+ax_pose_terminator
+sLickitungPose242:
+ax_pose 22, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sLickitungPose243:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose244:
+ax_pose 1, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose245:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose246:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose247:
+ax_pose 4, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose248:
+ax_pose 22, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose249:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose250:
+ax_pose 7, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose251:
+ax_pose 25, 0x01ec, 0x50fd, 0x4c00
+ax_pose 26, 0x01ec, 0x50ed, 0x4c04
+ax_pose 27, 0x41fc, 0x50ed, 0x4c08
+ax_pose 28, 0x01f4, 0x110d, 0x4c0c
+ax_pose 29, 0x01ec, 0x10e5, 0x4c0d
+ax_pose_terminator
+sLickitungPose252:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose253:
+ax_pose 10, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose254:
+ax_pose 32, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose255:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose256:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose257:
+ax_pose 38, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose258:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose259:
+ax_pose 10, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose260:
+ax_pose 32, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose261:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose262:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose263:
+ax_pose 25, 0x01ec, 0x40f3, 0x4c00
+ax_pose 26, 0x01ec, 0x4103, 0x4c04
+ax_pose 27, 0x41fc, 0x40f3, 0x4c08
+ax_pose 28, 0x01f4, 0x00eb, 0x4c0c
+ax_pose 29, 0x01ec, 0x0113, 0x4c0d
+ax_pose_terminator
+sLickitungPose264:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose265:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose266:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose267:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose268:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose269:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose270:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose271:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose272:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose273:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose274:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose275:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose276:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose277:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose278:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose279:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sLickitungPose280:
+ax_pose 9, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose281:
+ax_pose 6, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sLickitungPose282:
+ax_pose 3, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+.align 2
+sLickitungAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLickitungAnims_2_1:
+ax_anim 2, 0, 67, 0, -1, 0, -1,
+ax_anim 6, 0, 61, 0, -2, 0, -2,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 12, 0, 12,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLickitungAnims_2_2:
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 6, 0, 67, -2, -2, -2, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 34, 15, 20, 19, 20,
+ax_anim 2, 1, 34, 16, 19, 20, 19,
+ax_anim 2, 0, 34, 15, 20, 19, 20,
+ax_anim 2, 0, 34, 16, 19, 20, 19,
+ax_anim 2, 0, 30, 6, 6, 6, 6,
+ax_anim_terminator
+sLickitungAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 6, 0, 25, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 37, 10, 0, 10, 0,
+ax_anim 2, 0, 40, 18, 0, 18, 0,
+ax_anim 2, 1, 40, 18, 1, 18, 1,
+ax_anim 2, 0, 40, 18, 0, 18, 0,
+ax_anim 2, 0, 40, 18, 1, 18, 1,
+ax_anim 2, 0, 36, 6, 0, 6, 0,
+ax_anim_terminator
+sLickitungAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 6, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -1, 0, -1,
+ax_anim 1, 2, 36, 4, -6, 4, -6,
+ax_anim 1, 0, 43, 10, -13, 10, -13,
+ax_anim 2, 0, 46, 18, -16, 18, -16,
+ax_anim 2, 1, 46, 19, -15, 19, -15,
+ax_anim 2, 0, 46, 18, -16, 18, -16,
+ax_anim 2, 0, 46, 19, -15, 19, -15,
+ax_anim 2, 0, 42, 6, -6, 6, -6,
+ax_anim_terminator
+sLickitungAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 49, 0, -11, 0, -11,
+ax_anim 2, 0, 52, 0, -15, 0, -15,
+ax_anim 2, 1, 52, 1, -15, 1, -15,
+ax_anim 2, 0, 52, 0, -15, 0, -15,
+ax_anim 2, 0, 52, 1, -15, 1, -15,
+ax_anim 2, 0, 48, 0, -6, 0, -6,
+ax_anim_terminator
+sLickitungAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 6, 0, 43, 2, 2, 2, 2,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 2, 48, -4, -6, -4, -6,
+ax_anim 1, 0, 55, -10, -13, -10, -13,
+ax_anim 2, 0, 58, -18, -16, -18, -16,
+ax_anim 2, 1, 58, -19, -15, -19, -15,
+ax_anim 2, 0, 58, -18, -16, -18, -16,
+ax_anim 2, 0, 58, -19, -15, -19, -15,
+ax_anim 2, 0, 54, -6, -6, -6, -6,
+ax_anim_terminator
+sLickitungAnims_2_7:
+ax_anim 2, 0, 55, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 0, -4, 0,
+ax_anim 1, 0, 61, -10, 0, -10, 0,
+ax_anim 2, 0, 64, -18, 0, -18, 0,
+ax_anim 2, 1, 64, -18, 1, -18, 1,
+ax_anim 2, 0, 64, -18, 0, -18, 0,
+ax_anim 2, 0, 64, -18, 1, -18, 1,
+ax_anim 2, 0, 60, -6, 0, -6, 0,
+ax_anim_terminator
+sLickitungAnims_2_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 6, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 67, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -15, 20, -19, 20,
+ax_anim 2, 1, 70, -16, 19, -20, 19,
+ax_anim 2, 0, 70, -15, 20, -19, 20,
+ax_anim 2, 0, 70, -16, 19, -20, 19,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLickitungAnims_3_1:
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 6, 0, 109, 0, -2, 0, -2,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 2, 114, 0, 4, 0, 4,
+ax_anim 1, 0, 73, 0, 12, 0, 12,
+ax_anim 2, 0, 76, 0, 20, 0, 20,
+ax_anim 2, 1, 76, 1, 20, 1, 20,
+ax_anim 2, 0, 76, 0, 20, 0, 20,
+ax_anim 2, 0, 76, 1, 20, 1, 20,
+ax_anim 2, 0, 72, 0, 6, 0, 6,
+ax_anim_terminator
+sLickitungAnims_3_2:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 6, 0, 115, -2, -2, -2, -2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 72, 4, 4, 4, 4,
+ax_anim 1, 0, 79, 12, 12, 12, 12,
+ax_anim 2, 0, 82, 15, 20, 19, 20,
+ax_anim 2, 1, 82, 16, 19, 20, 19,
+ax_anim 2, 0, 82, 15, 20, 19, 20,
+ax_anim 2, 0, 82, 16, 19, 20, 19,
+ax_anim 2, 0, 78, 6, 6, 6, 6,
+ax_anim_terminator
+sLickitungAnims_3_3:
+ax_anim 2, 0, 79, -1, 0, -1, 0,
+ax_anim 6, 0, 73, -2, 0, -2, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 2, 78, 4, 0, 4, 0,
+ax_anim 1, 0, 85, 10, 0, 10, 0,
+ax_anim 2, 0, 88, 18, 0, 18, 0,
+ax_anim 2, 1, 88, 18, 1, 18, 1,
+ax_anim 2, 0, 88, 18, 0, 18, 0,
+ax_anim 2, 0, 88, 18, 1, 18, 1,
+ax_anim 2, 0, 84, 6, 0, 6, 0,
+ax_anim_terminator
+sLickitungAnims_3_4:
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 6, 0, 79, -2, 2, -2, 2,
+ax_anim 1, 0, 85, 0, -1, 0, -1,
+ax_anim 1, 2, 84, 4, -6, 4, -6,
+ax_anim 1, 0, 91, 10, -13, 10, -13,
+ax_anim 2, 0, 94, 18, -16, 18, -16,
+ax_anim 2, 1, 94, 19, -15, 19, -15,
+ax_anim 2, 0, 94, 18, -16, 18, -16,
+ax_anim 2, 0, 94, 19, -15, 19, -15,
+ax_anim 2, 0, 90, 6, -6, 6, -6,
+ax_anim_terminator
+sLickitungAnims_3_5:
+ax_anim 2, 0, 91, 0, 1, 0, 1,
+ax_anim 6, 0, 85, 0, 2, 0, 2,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 2, 90, 0, -4, 0, -4,
+ax_anim 1, 0, 97, 0, -11, 0, -11,
+ax_anim 2, 0, 100, 0, -15, 0, -15,
+ax_anim 2, 1, 100, 1, -15, 1, -15,
+ax_anim 2, 0, 100, 0, -15, 0, -15,
+ax_anim 2, 0, 100, 1, -15, 1, -15,
+ax_anim 2, 0, 96, 0, -6, 0, -6,
+ax_anim_terminator
+sLickitungAnims_3_6:
+ax_anim 2, 0, 97, 1, 1, 1, 1,
+ax_anim 6, 0, 91, 2, 2, 2, 2,
+ax_anim 1, 0, 97, 0, -1, 0, -1,
+ax_anim 1, 2, 96, -4, -6, -4, -6,
+ax_anim 1, 0, 103, -10, -13, -10, -13,
+ax_anim 2, 0, 106, -18, -16, -18, -16,
+ax_anim 2, 1, 106, -19, -15, -19, -15,
+ax_anim 2, 0, 106, -18, -16, -18, -16,
+ax_anim 2, 0, 106, -19, -15, -19, -15,
+ax_anim 2, 0, 102, -6, -6, -6, -6,
+ax_anim_terminator
+sLickitungAnims_3_7:
+ax_anim 2, 0, 103, 1, 0, 1, 0,
+ax_anim 6, 0, 97, 2, 0, 2, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 2, 102, -4, 0, -4, 0,
+ax_anim 1, 0, 109, -10, 0, -10, 0,
+ax_anim 2, 0, 112, -18, 0, -18, 0,
+ax_anim 2, 1, 112, -18, 1, -18, 1,
+ax_anim 2, 0, 112, -18, 0, -18, 0,
+ax_anim 2, 0, 112, -18, 1, -18, 1,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim_terminator
+sLickitungAnims_3_8:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 6, 0, 103, 2, -2, 2, -2,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 2, 108, -4, 4, -4, 4,
+ax_anim 1, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 118, -15, 20, -19, 20,
+ax_anim 2, 1, 118, -16, 19, -20, 19,
+ax_anim 2, 0, 118, -15, 20, -19, 20,
+ax_anim 2, 0, 118, -16, 19, -20, 19,
+ax_anim 2, 0, 114, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLickitungAnims_4_1:
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim 6, 2, 121, 0, -3, 0, -3,
+ax_anim 2, 0, 121, 0, -1, 0, -1,
+ax_anim 2, 1, 122, 0, 3, 0, 2,
+ax_anim 2, 0, 122, 1, 3, 1, 2,
+ax_anim 2, 0, 122, 0, 3, 0, 2,
+ax_anim 2, 0, 122, 1, 3, 1, 2,
+ax_anim 2, 0, 122, 0, 3, 0, 2,
+ax_anim 2, 0, 122, 1, 3, 1, 2,
+ax_anim 2, 0, 122, 0, 3, 0, 2,
+ax_anim 2, 0, 120, 0, 2, 0, 2,
+ax_anim_terminator
+sLickitungAnims_4_2:
+ax_anim 2, 0, 124, -2, -2, -2, -2,
+ax_anim 6, 2, 125, -3, -3, -3, -3,
+ax_anim 2, 0, 125, -1, -1, -1, -1,
+ax_anim 2, 1, 126, 2, 2, 1, 1,
+ax_anim 2, 0, 126, 3, 1, 2, 0,
+ax_anim 2, 0, 126, 2, 2, 1, 1,
+ax_anim 2, 0, 126, 3, 1, 2, 0,
+ax_anim 2, 0, 126, 2, 2, 1, 1,
+ax_anim 2, 0, 126, 3, 1, 2, 0,
+ax_anim 2, 0, 126, 2, 2, 1, 1,
+ax_anim 2, 0, 124, 1, 1, 1, 1,
+ax_anim_terminator
+sLickitungAnims_4_3:
+ax_anim 2, 0, 128, -2, 0, -2, 0,
+ax_anim 6, 2, 129, -3, 0, -3, 0,
+ax_anim 2, 0, 129, -1, 0, -1, 0,
+ax_anim 2, 1, 130, 3, 0, 3, 0,
+ax_anim 2, 0, 130, 3, 1, 3, 1,
+ax_anim 2, 0, 130, 3, 0, 3, 0,
+ax_anim 2, 0, 130, 3, 1, 3, 1,
+ax_anim 2, 0, 130, 3, 0, 3, 0,
+ax_anim 2, 0, 130, 3, 1, 3, 1,
+ax_anim 2, 0, 130, 3, 0, 3, 0,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim_terminator
+sLickitungAnims_4_4:
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim 6, 2, 133, -3, 3, -3, 3,
+ax_anim 2, 0, 133, -1, 1, -1, 1,
+ax_anim 2, 1, 134, 2, -2, 1, -1,
+ax_anim 2, 0, 134, 3, -1, 2, 0,
+ax_anim 2, 0, 134, 2, -2, 1, -1,
+ax_anim 2, 0, 134, 3, -1, 2, 0,
+ax_anim 2, 0, 134, 2, -2, 1, -1,
+ax_anim 2, 0, 134, 3, -1, 2, 0,
+ax_anim 2, 0, 134, 2, -2, 1, -1,
+ax_anim 2, 0, 132, 1, -1, 1, -1,
+ax_anim_terminator
+sLickitungAnims_4_5:
+ax_anim 2, 0, 136, 0, 2, 0, 2,
+ax_anim 6, 2, 137, 0, 3, 0, 3,
+ax_anim 2, 0, 137, 0, 1, 0, 1,
+ax_anim 2, 1, 138, 0, -3, 0, -2,
+ax_anim 2, 0, 138, 1, -3, 1, -2,
+ax_anim 2, 0, 138, 0, -3, 0, -2,
+ax_anim 2, 0, 138, 1, -3, 1, -2,
+ax_anim 2, 0, 138, 0, -3, 0, -2,
+ax_anim 2, 0, 138, 1, -3, 1, -2,
+ax_anim 2, 0, 138, 0, -3, 0, -2,
+ax_anim 2, 0, 136, 0, -2, 0, -2,
+ax_anim_terminator
+sLickitungAnims_4_6:
+ax_anim 2, 0, 140, 2, 2, 2, 2,
+ax_anim 6, 2, 141, 3, 3, 3, 3,
+ax_anim 2, 0, 141, 1, 1, 1, 1,
+ax_anim 2, 1, 142, -2, -2, -1, -1,
+ax_anim 2, 0, 142, -3, -1, -2, 0,
+ax_anim 2, 0, 142, -2, -2, -1, -1,
+ax_anim 2, 0, 142, -3, -1, -2, 0,
+ax_anim 2, 0, 142, -2, -2, -1, -1,
+ax_anim 2, 0, 142, -3, -1, -2, 0,
+ax_anim 2, 0, 142, -2, -2, -1, -1,
+ax_anim 2, 0, 140, -1, -1, -1, -1,
+ax_anim_terminator
+sLickitungAnims_4_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 6, 2, 145, 3, 0, 3, 0,
+ax_anim 2, 0, 145, 1, 0, 1, 0,
+ax_anim 2, 1, 146, -3, 0, -3, 0,
+ax_anim 2, 0, 146, -3, 1, -3, 1,
+ax_anim 2, 0, 146, -3, 0, -3, 0,
+ax_anim 2, 0, 146, -3, 1, -3, 1,
+ax_anim 2, 0, 146, -3, 0, -3, 0,
+ax_anim 2, 0, 146, -3, 1, -3, 1,
+ax_anim 2, 0, 146, -3, 0, -3, 0,
+ax_anim 2, 0, 144, -2, 0, -2, 0,
+ax_anim_terminator
+sLickitungAnims_4_8:
+ax_anim 2, 0, 148, 2, -2, 2, -2,
+ax_anim 6, 2, 149, 3, -3, 3, -3,
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 1, 150, -2, 2, -1, 1,
+ax_anim 2, 0, 150, -3, 1, -2, 0,
+ax_anim 2, 0, 150, -2, 2, -1, 1,
+ax_anim 2, 0, 150, -3, 1, -2, 0,
+ax_anim 2, 0, 150, -2, 2, -1, 1,
+ax_anim 2, 0, 150, -3, 1, -2, 0,
+ax_anim 2, 0, 150, -2, 2, -1, 1,
+ax_anim 2, 0, 148, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLickitungAnims_5_1:
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 6, 0, 197, 2, -1, 2, -1,
+ax_anim 2, 0, 155, 0, 7, 0, 7,
+ax_anim 1, 0, 198, 0, 9, 0, 9,
+ax_anim 1, 0, 156, 0, 12, 0, 12,
+ax_anim 1, 0, 162, 0, 14, 0, 14,
+ax_anim 2, 0, 157, 0, 15, 0, 15,
+ax_anim 6, 2, 161, -2, 16, -2, 16,
+ax_anim 2, 0, 157, 0, 18, 0, 18,
+ax_anim 1, 0, 162, 0, 20, 0, 20,
+ax_anim 1, 1, 156, 0, 20, 0, 20,
+ax_anim 1, 0, 198, 0, 20, 0, 20,
+ax_anim 2, 0, 155, 0, 20, 0, 20,
+ax_anim 2, 0, 197, 0, 18, 0, 18,
+ax_anim_terminator
+sLickitungAnims_5_2:
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 6, 0, 155, -2, -2, -2, -2,
+ax_anim 2, 0, 161, 7, 7, 7, 7,
+ax_anim 1, 0, 156, 10, 10, 10, 10,
+ax_anim 1, 0, 162, 16, 12, 16, 12,
+ax_anim 1, 0, 168, 19, 11, 19, 11,
+ax_anim 2, 0, 163, 22, 12, 22, 12,
+ax_anim 6, 2, 169, 23, 12, 23, 12,
+ax_anim 2, 0, 163, 24, 17, 24, 17,
+ax_anim 1, 0, 168, 24, 19, 24, 19,
+ax_anim 1, 1, 162, 23, 21, 23, 21,
+ax_anim 1, 0, 156, 22, 21, 22, 21,
+ax_anim 2, 0, 161, 19, 20, 19, 20,
+ax_anim 2, 0, 155, 16, 17, 16, 17,
+ax_anim_terminator
+sLickitungAnims_5_3:
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 6, 0, 161, -2, 0, -2, 0,
+ax_anim 2, 0, 167, 5, 0, 5, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 1, 0, 168, 14, 0, 14, 0,
+ax_anim 1, 0, 174, 15, 0, 15, 0,
+ax_anim 2, 0, 169, 18, 0, 18, 0,
+ax_anim 6, 2, 175, 17, 0, 17, 0,
+ax_anim 2, 0, 169, 18, 0, 18, 0,
+ax_anim 1, 0, 174, 18, 0, 18, 0,
+ax_anim 1, 1, 168, 18, 0, 18, 0,
+ax_anim 1, 0, 162, 18, 1, 18, 1,
+ax_anim 2, 0, 167, 14, 1, 14, 1,
+ax_anim 2, 0, 161, 12, 1, 12, 1,
+ax_anim_terminator
+sLickitungAnims_5_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 167, -1, 1, -1, 1,
+ax_anim 2, 0, 173, 5, -5, 5, -5,
+ax_anim 1, 0, 168, 10, -10, 10, -10,
+ax_anim 1, 0, 174, 13, -13, 13, -13,
+ax_anim 1, 0, 180, 14, -14, 14, -14,
+ax_anim 2, 0, 175, 16, -16, 16, -16,
+ax_anim 6, 2, 181, 14, -16, 14, -16,
+ax_anim 2, 0, 175, 18, -18, 18, -18,
+ax_anim 1, 0, 180, 19, -17, 19, -17,
+ax_anim 1, 1, 174, 21, -17, 21, -17,
+ax_anim 1, 0, 168, 22, -18, 22, -18,
+ax_anim 2, 0, 173, 19, -18, 19, -18,
+ax_anim 2, 0, 167, 16, -16, 16, -16,
+ax_anim_terminator
+sLickitungAnims_5_5:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 173, 1, 1, 1, 1,
+ax_anim 2, 0, 179, 0, -3, 0, -3,
+ax_anim 1, 0, 174, 0, -10, 0, -10,
+ax_anim 1, 0, 180, 0, -13, 0, -13,
+ax_anim 1, 0, 186, 0, -14, 0, -14,
+ax_anim 2, 0, 181, 0, -14, 0, -14,
+ax_anim 6, 2, 187, 0, -16, 0, -16,
+ax_anim 2, 0, 181, 0, -18, 0, -18,
+ax_anim 1, 0, 186, 0, -19, 0, -19,
+ax_anim 1, 1, 180, 0, -18, 0, -18,
+ax_anim 1, 0, 174, 0, -19, 0, -19,
+ax_anim 2, 0, 179, 0, -18, 0, -18,
+ax_anim 2, 0, 173, 0, -16, 0, -16,
+ax_anim_terminator
+sLickitungAnims_5_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 179, 1, 1, 1, 1,
+ax_anim 2, 0, 185, -5, -5, -5, -5,
+ax_anim 1, 0, 180, -10, -10, -10, -10,
+ax_anim 1, 0, 186, -13, -13, -13, -13,
+ax_anim 1, 0, 192, -14, -14, -14, -14,
+ax_anim 2, 0, 187, -16, -16, -16, -16,
+ax_anim 6, 2, 193, -14, -16, -14, -16,
+ax_anim 2, 0, 187, -18, -18, -18, -18,
+ax_anim 1, 0, 192, -19, -20, -19, -20,
+ax_anim 1, 1, 186, -18, -20, -18, -20,
+ax_anim 1, 0, 180, -18, -18, -18, -18,
+ax_anim 2, 0, 185, -17, -19, -17, -19,
+ax_anim 2, 0, 179, -14, -17, -14, -17,
+ax_anim_terminator
+sLickitungAnims_5_7:
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 6, 0, 185, 2, 0, 2, 0,
+ax_anim 2, 0, 191, -5, 0, -5, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 1, 0, 192, -11, 0, -11, 0,
+ax_anim 1, 0, 198, -14, 2, -14, 2,
+ax_anim 2, 0, 193, -16, 1, -16, 1,
+ax_anim 6, 2, 199, -16, 1, -16, 1,
+ax_anim 2, 0, 193, -18, 0, -18, 0,
+ax_anim 1, 0, 198, -18, 0, -18, 0,
+ax_anim 1, 1, 192, -18, -1, -18, -1,
+ax_anim 1, 0, 186, -18, 0, -18, 0,
+ax_anim 2, 0, 191, -17, 0, -17, 0,
+ax_anim 2, 0, 185, -15, 0, -15, 0,
+ax_anim_terminator
+sLickitungAnims_5_8:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 191, 2, 0, 2, 0,
+ax_anim 2, 0, 197, -7, 7, -7, 7,
+ax_anim 1, 0, 192, -10, 10, -10, 10,
+ax_anim 1, 0, 198, -13, 12, -13, 12,
+ax_anim 1, 0, 156, -14, 14, -14, 14,
+ax_anim 2, 0, 199, -12, 15, -12, 15,
+ax_anim 6, 2, 157, -12, 13, -12, 13,
+ax_anim 2, 0, 199, -20, 19, -20, 19,
+ax_anim 1, 0, 156, -22, 18, -22, 18,
+ax_anim 1, 1, 198, -22, 18, -22, 18,
+ax_anim 1, 0, 192, -21, 15, -21, 15,
+ax_anim 2, 0, 197, -22, 16, -22, 16,
+ax_anim 2, 0, 191, -18, 13, -18, 13,
+ax_anim_terminator
+.align 2
+sLickitungAnims_6_1:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 35, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLickitungAnims_7_1:
+ax_anim 2, 0, 202, 0, -4, 0, -4,
+ax_anim 8, 0, 202, 0, -5, 0, -5,
+ax_anim_terminator
+sLickitungAnims_7_2:
+ax_anim 2, 0, 203, -4, -4, -4, -4,
+ax_anim 8, 0, 203, -5, -5, -5, -5,
+ax_anim_terminator
+sLickitungAnims_7_3:
+ax_anim 2, 0, 204, -4, 0, -4, 0,
+ax_anim 8, 0, 204, -5, 0, -5, 0,
+ax_anim_terminator
+sLickitungAnims_7_4:
+ax_anim 2, 0, 205, -4, 4, -4, 4,
+ax_anim 8, 0, 205, -5, 5, -5, 5,
+ax_anim_terminator
+sLickitungAnims_7_5:
+ax_anim 2, 0, 206, 0, 4, 0, 4,
+ax_anim 8, 0, 206, 0, 5, 0, 5,
+ax_anim_terminator
+sLickitungAnims_7_6:
+ax_anim 2, 0, 207, 4, 4, 4, 4,
+ax_anim 8, 0, 207, 5, 5, 5, 5,
+ax_anim_terminator
+sLickitungAnims_7_7:
+ax_anim 2, 0, 208, 4, 0, 4, 0,
+ax_anim 8, 0, 208, 5, 0, 5, 0,
+ax_anim_terminator
+sLickitungAnims_7_8:
+ax_anim 2, 0, 209, 4, -4, 4, -4,
+ax_anim 8, 0, 209, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLickitungAnims_8_1:
+ax_anim 36, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_8_2:
+ax_anim 36, 0, 212, 0, 0, 0, 0,
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim 10, 0, 212, 0, 0, 0, 0,
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_8_3:
+ax_anim 36, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_8_4:
+ax_anim 36, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_8_5:
+ax_anim 36, 0, 218, 0, 0, 0, 0,
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_8_6:
+ax_anim 36, 0, 220, 0, 0, 0, 0,
+ax_anim 12, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 220, 0, 0, 0, 0,
+ax_anim 12, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_8_7:
+ax_anim 36, 0, 222, 0, 0, 0, 0,
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_8_8:
+ax_anim 36, 0, 224, 0, 0, 0, 0,
+ax_anim 12, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim 12, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLickitungAnims_9_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 6, 3, 6, 3,
+ax_anim 2, 0, 228, 8, 9, 8, 9,
+ax_anim 2, 0, 229, 7, 17, 7, 17,
+ax_anim 3, 0, 230, 0, 20, 0, 20,
+ax_anim 2, 3, 231, -7, 17, -7, 17,
+ax_anim 2, 0, 232, -8, 9, -8, 9,
+ax_anim 1, 0, 233, -6, 3, -6, 3,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_9_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 8, 0, 8, 0,
+ax_anim 2, 0, 227, 17, 3, 17, 3,
+ax_anim 2, 0, 228, 19, 10, 19, 10,
+ax_anim 3, 0, 229, 19, 19, 19, 19,
+ax_anim 2, 3, 230, 11, 19, 11, 19,
+ax_anim 2, 0, 231, 3, 15, 3, 15,
+ax_anim 1, 0, 232, 0, 7, 0, 7,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_9_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 3, -5, 3, -5,
+ax_anim 2, 0, 226, 11, -6, 11, -6,
+ax_anim 2, 0, 227, 16, -5, 16, -5,
+ax_anim 3, 0, 228, 18, -2, 18, -2,
+ax_anim 2, 3, 229, 16, 4, 16, 4,
+ax_anim 2, 0, 230, 12, 5, 12, 5,
+ax_anim 1, 0, 231, 4, 5, 4, 5,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_9_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, -1, -8, -1, -8,
+ax_anim 2, 0, 233, 4, -16, 4, -16,
+ax_anim 2, 0, 226, 10, -20, 10, -20,
+ax_anim 3, 0, 227, 18, -19, 18, -19,
+ax_anim 2, 3, 228, 20, -13, 20, -13,
+ax_anim 2, 0, 229, 16, -5, 16, -5,
+ax_anim 1, 0, 230, 7, -1, 7, -1,
+ax_anim 1, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_9_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, -8, -4, -8, -4,
+ax_anim 2, 0, 232, -9, -12, -9, -12,
+ax_anim 2, 0, 233, -7, -18, -7, -18,
+ax_anim 3, 0, 226, 0, -22, 0, -22,
+ax_anim 2, 3, 227, 7, -18, 7, -18,
+ax_anim 2, 0, 228, 9, -10, 9, -10,
+ax_anim 1, 0, 229, 8, -4, 8, -4,
+ax_anim 1, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_9_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 1, -8, 1, -8,
+ax_anim 2, 0, 227, -4, -16, -4, -16,
+ax_anim 2, 0, 226, -10, -20, -10, -20,
+ax_anim 3, 0, 233, -18, -19, -18, -19,
+ax_anim 2, 3, 232, -20, -13, -20, -13,
+ax_anim 2, 0, 231, -16, -5, -16, -5,
+ax_anim 1, 0, 230, -7, -1, -7, -1,
+ax_anim 1, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_9_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 227, -3, -5, -3, -5,
+ax_anim 2, 0, 226, -11, -6, -11, -6,
+ax_anim 2, 0, 233, -16, -5, -16, -5,
+ax_anim 3, 0, 232, -18, -2, -18, -2,
+ax_anim 2, 3, 231, -16, 4, -16, 4,
+ax_anim 2, 0, 230, -12, 5, -12, 5,
+ax_anim 1, 0, 229, -4, 5, -4, 5,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_9_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 226, -8, 0, -8, 0,
+ax_anim 2, 0, 233, -17, 3, -17, 3,
+ax_anim 2, 0, 232, -19, 10, -19, 10,
+ax_anim 3, 0, 231, -19, 19, -19, 19,
+ax_anim 2, 3, 230, -11, 19, -11, 19,
+ax_anim 2, 0, 229, -3, 15, -3, 15,
+ax_anim 1, 0, 228, 0, 7, 0, 7,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLickitungAnims_10_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 3, 0, 234, 13, 0, 13, 0,
+ax_anim 3, 0, 234, -13, 0, -13, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_10_2:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 3, 0, 235, 13, -13, 13, -13,
+ax_anim 3, 0, 235, -13, 13, -13, 13,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_10_3:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 3, 0, 236, 0, -13, 0, -13,
+ax_anim 3, 0, 236, 0, 13, 0, 13,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_10_4:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 3, 0, 237, -13, -13, -13, -13,
+ax_anim 3, 0, 237, 13, 13, 13, 13,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_10_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 3, 0, 238, 13, 0, 13, 0,
+ax_anim 3, 0, 238, -13, 0, -13, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_10_6:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 3, 0, 239, 13, -13, 13, -13,
+ax_anim 3, 0, 239, -13, 13, -13, 13,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_10_7:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 3, 0, 240, 0, -13, 0, -13,
+ax_anim 3, 0, 240, 0, 13, 0, 13,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_10_8:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 3, 0, 241, -13, -13, -13, -13,
+ax_anim 3, 0, 241, 13, 13, 13, 13,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLickitungAnims_11_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 243, 0, -20, 0, 0,
+ax_anim 4, 0, 243, 0, -21, 0, 0,
+ax_anim 4, 0, 244, 0, -23, 0, 0,
+ax_anim 3, 0, 244, 0, -22, 0, 0,
+ax_anim 2, 0, 244, 0, -18, 0, 0,
+ax_anim 1, 0, 244, 0, -12, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_11_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 246, 0, -20, 0, 0,
+ax_anim 4, 0, 246, 0, -21, 0, 0,
+ax_anim 4, 0, 247, 0, -23, 0, 0,
+ax_anim 3, 0, 247, 0, -22, 0, 0,
+ax_anim 2, 0, 247, 0, -18, 0, 0,
+ax_anim 1, 0, 247, 0, -12, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_11_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 0, -10, 0, 0,
+ax_anim 2, 0, 249, 0, -16, 0, 0,
+ax_anim 3, 0, 249, 0, -20, 0, 0,
+ax_anim 4, 0, 249, 0, -21, 0, 0,
+ax_anim 4, 0, 250, 0, -23, 0, 0,
+ax_anim 3, 0, 250, 0, -22, 0, 0,
+ax_anim 2, 0, 250, 0, -18, 0, 0,
+ax_anim 1, 0, 250, 0, -12, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_11_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -10, 0, 0,
+ax_anim 2, 0, 252, 0, -16, 0, 0,
+ax_anim 3, 0, 252, 0, -20, 0, 0,
+ax_anim 4, 0, 252, 0, -21, 0, 0,
+ax_anim 4, 0, 253, 0, -22, 0, 0,
+ax_anim 3, 0, 253, 0, -21, 0, 0,
+ax_anim 2, 0, 253, 0, -17, 0, 0,
+ax_anim 1, 0, 253, 0, -11, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_11_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, -10, 0, 0,
+ax_anim 2, 0, 255, 0, -16, 0, 0,
+ax_anim 3, 0, 255, 0, -20, 0, 0,
+ax_anim 4, 0, 255, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 256, 0, -22, 0, 0,
+ax_anim 2, 0, 256, 0, -18, 0, 0,
+ax_anim 1, 0, 256, 0, -12, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_11_6:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -16, 0, 0,
+ax_anim 3, 0, 258, 0, -20, 0, 0,
+ax_anim 4, 0, 258, 0, -21, 0, 0,
+ax_anim 4, 0, 259, 0, -22, 0, 0,
+ax_anim 3, 0, 259, 0, -21, 0, 0,
+ax_anim 2, 0, 259, 0, -17, 0, 0,
+ax_anim 1, 0, 259, 0, -11, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_11_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 261, 0, -10, 0, 0,
+ax_anim 2, 0, 261, 0, -16, 0, 0,
+ax_anim 3, 0, 261, 0, -20, 0, 0,
+ax_anim 4, 0, 261, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -23, 0, 0,
+ax_anim 3, 0, 262, 0, -22, 0, 0,
+ax_anim 2, 0, 262, 0, -18, 0, 0,
+ax_anim 1, 0, 262, 0, -12, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_11_8:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 264, 0, -10, 0, 0,
+ax_anim 2, 0, 264, 0, -16, 0, 0,
+ax_anim 3, 0, 264, 0, -20, 0, 0,
+ax_anim 4, 0, 264, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -23, 0, 0,
+ax_anim 3, 0, 265, 0, -22, 0, 0,
+ax_anim 2, 0, 265, 0, -18, 0, 0,
+ax_anim 1, 0, 265, 0, -12, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLickitungAnims_12_1:
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 1, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_12_2:
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 1, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_12_3:
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 1, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_12_4:
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 1, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_12_5:
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 1, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_12_6:
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 1, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_12_7:
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 1, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_12_8:
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 1, 267, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLickitungAnims_13_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_13_2:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_13_3:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_13_4:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_13_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_13_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_13_7:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungAnims_13_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sLickitungGfx1:
+.incbin "baserom.gba", 0x9A8748, 0x200
+sLickitungSprites1:
+ax_sprite sLickitungGfx1, 0x200
+ax_sprite_terminator
+sLickitungGfx2:
+.incbin "baserom.gba", 0x9A8958, 0x200
+sLickitungSprites2:
+ax_sprite sLickitungGfx2, 0x200
+ax_sprite_terminator
+sLickitungGfx3:
+.incbin "baserom.gba", 0x9A8B68, 0x200
+sLickitungSprites3:
+ax_sprite sLickitungGfx3, 0x200
+ax_sprite_terminator
+sLickitungGfx4:
+.incbin "baserom.gba", 0x9A8D78, 0x200
+sLickitungSprites4:
+ax_sprite sLickitungGfx4, 0x200
+ax_sprite_terminator
+sLickitungGfx5:
+.incbin "baserom.gba", 0x9A8F88, 0x200
+sLickitungSprites5:
+ax_sprite sLickitungGfx5, 0x200
+ax_sprite_terminator
+sLickitungGfx6:
+.incbin "baserom.gba", 0x9A9198, 0x200
+sLickitungSprites6:
+ax_sprite sLickitungGfx6, 0x200
+ax_sprite_terminator
+sLickitungGfx7:
+.incbin "baserom.gba", 0x9A93A8, 0x200
+sLickitungSprites7:
+ax_sprite sLickitungGfx7, 0x200
+ax_sprite_terminator
+sLickitungGfx8:
+.incbin "baserom.gba", 0x9A95B8, 0x200
+sLickitungSprites8:
+ax_sprite sLickitungGfx8, 0x200
+ax_sprite_terminator
+sLickitungGfx9:
+.incbin "baserom.gba", 0x9A97C8, 0x200
+sLickitungSprites9:
+ax_sprite sLickitungGfx9, 0x200
+ax_sprite_terminator
+sLickitungGfx10:
+.incbin "baserom.gba", 0x9A99D8, 0x200
+sLickitungSprites10:
+ax_sprite sLickitungGfx10, 0x200
+ax_sprite_terminator
+sLickitungGfx11:
+.incbin "baserom.gba", 0x9A9BE8, 0x200
+sLickitungSprites11:
+ax_sprite sLickitungGfx11, 0x200
+ax_sprite_terminator
+sLickitungGfx12:
+.incbin "baserom.gba", 0x9A9DF8, 0x200
+sLickitungSprites12:
+ax_sprite sLickitungGfx12, 0x200
+ax_sprite_terminator
+sLickitungGfx13:
+.incbin "baserom.gba", 0x9AA008, 0x200
+sLickitungSprites13:
+ax_sprite sLickitungGfx13, 0x200
+ax_sprite_terminator
+sLickitungGfx14:
+.incbin "baserom.gba", 0x9AA218, 0x200
+sLickitungSprites14:
+ax_sprite sLickitungGfx14, 0x200
+ax_sprite_terminator
+sLickitungGfx15:
+.incbin "baserom.gba", 0x9AA428, 0x200
+sLickitungSprites15:
+ax_sprite sLickitungGfx15, 0x200
+ax_sprite_terminator
+sLickitungGfx16:
+.incbin "baserom.gba", 0x9AA638, 0x60
+sLickitungGfx16_1:
+.incbin "baserom.gba", 0x9AA698, 0x180
+sLickitungSprites16:
+ax_sprite sLickitungGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx16_1, 0x180
+ax_sprite_terminator
+sLickitungGfx17:
+.incbin "baserom.gba", 0x9AA838, 0x40
+sLickitungGfx17_1:
+.incbin "baserom.gba", 0x9AA878, 0x180
+sLickitungSprites17:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx17_1, 0x180
+ax_sprite_terminator
+sLickitungGfx18:
+.incbin "baserom.gba", 0x9AAA20, 0x1E0
+sLickitungSprites18:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx18, 0x1e0
+ax_sprite_terminator
+sLickitungGfx19:
+.incbin "baserom.gba", 0x9AAC18, 0x100
+sLickitungSprites19:
+ax_sprite sLickitungGfx19, 0x100
+ax_sprite_terminator
+sLickitungGfx20:
+.incbin "baserom.gba", 0x9AAD28, 0x20
+sLickitungGfx20_1:
+.incbin "baserom.gba", 0x9AAD48, 0x40
+sLickitungSprites20:
+ax_sprite sLickitungGfx20, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx20_1, 0x40
+ax_sprite_terminator
+sLickitungGfx21:
+.incbin "baserom.gba", 0x9AADA8, 0x40
+sLickitungSprites21:
+ax_sprite sLickitungGfx21, 0x40
+ax_sprite_terminator
+sLickitungGfx22:
+.incbin "baserom.gba", 0x9AADF8, 0x20
+sLickitungSprites22:
+ax_sprite sLickitungGfx22, 0x20
+ax_sprite_terminator
+sLickitungGfx23:
+.incbin "baserom.gba", 0x9AAE28, 0x1E0
+sLickitungSprites23:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx23, 0x1e0
+ax_sprite_terminator
+sLickitungGfx24:
+.incbin "baserom.gba", 0x9AB020, 0x200
+sLickitungSprites24:
+ax_sprite sLickitungGfx24, 0x200
+ax_sprite_terminator
+sLickitungGfx25:
+.incbin "baserom.gba", 0x9AB230, 0x60
+sLickitungGfx25_1:
+.incbin "baserom.gba", 0x9AB290, 0xE0
+sLickitungGfx25_2:
+.incbin "baserom.gba", 0x9AB370, 0x60
+sLickitungSprites25:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx25_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx25_2, 0x60
+ax_sprite_terminator
+sLickitungGfx26:
+.incbin "baserom.gba", 0x9AB408, 0x80
+sLickitungSprites26:
+ax_sprite sLickitungGfx26, 0x80
+ax_sprite_terminator
+sLickitungGfx27:
+.incbin "baserom.gba", 0x9AB498, 0x80
+sLickitungSprites27:
+ax_sprite sLickitungGfx27, 0x80
+ax_sprite_terminator
+sLickitungGfx28:
+.incbin "baserom.gba", 0x9AB528, 0x80
+sLickitungSprites28:
+ax_sprite sLickitungGfx28, 0x80
+ax_sprite_terminator
+sLickitungGfx29:
+.incbin "baserom.gba", 0x9AB5B8, 0x20
+sLickitungSprites29:
+ax_sprite sLickitungGfx29, 0x20
+ax_sprite_terminator
+sLickitungGfx30:
+.incbin "baserom.gba", 0x9AB5E8, 0x20
+sLickitungSprites30:
+ax_sprite sLickitungGfx30, 0x20
+ax_sprite_terminator
+sLickitungGfx31:
+.incbin "baserom.gba", 0x9AB618, 0x60
+sLickitungGfx31_1:
+.incbin "baserom.gba", 0x9AB678, 0xE0
+sLickitungGfx31_2:
+.incbin "baserom.gba", 0x9AB758, 0x40
+sLickitungSprites31:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx31_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLickitungGfx32:
+.incbin "baserom.gba", 0x9AB7D8, 0x140
+sLickitungGfx32_1:
+.incbin "baserom.gba", 0x9AB918, 0x60
+sLickitungSprites32:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx32, 0x140
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLickitungGfx33:
+.incbin "baserom.gba", 0x9AB9A8, 0x60
+sLickitungGfx33_1:
+.incbin "baserom.gba", 0x9ABA08, 0x100
+sLickitungGfx33_2:
+.incbin "baserom.gba", 0x9ABB08, 0x60
+sLickitungSprites33:
+ax_sprite sLickitungGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx33_2, 0x60
+ax_sprite_terminator
+sLickitungGfx34:
+.incbin "baserom.gba", 0x9ABB98, 0x40
+sLickitungGfx34_1:
+.incbin "baserom.gba", 0x9ABBD8, 0x100
+sLickitungGfx34_2:
+.incbin "baserom.gba", 0x9ABCD8, 0x60
+sLickitungSprites34:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx34_2, 0x60
+ax_sprite_terminator
+sLickitungGfx35:
+.incbin "baserom.gba", 0x9ABD70, 0x100
+sLickitungSprites35:
+ax_sprite sLickitungGfx35, 0x100
+ax_sprite_terminator
+sLickitungGfx36:
+.incbin "baserom.gba", 0x9ABE80, 0x80
+sLickitungSprites36:
+ax_sprite sLickitungGfx36, 0x80
+ax_sprite_terminator
+sLickitungGfx37:
+.incbin "baserom.gba", 0x9ABF10, 0x20
+sLickitungSprites37:
+ax_sprite sLickitungGfx37, 0x20
+ax_sprite_terminator
+sLickitungGfx38:
+.incbin "baserom.gba", 0x9ABF40, 0x20
+sLickitungSprites38:
+ax_sprite sLickitungGfx38, 0x20
+ax_sprite_terminator
+sLickitungGfx39:
+.incbin "baserom.gba", 0x9ABF70, 0x40
+sLickitungGfx39_1:
+.incbin "baserom.gba", 0x9ABFB0, 0x180
+sLickitungSprites39:
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLickitungGfx39_1, 0x180
+ax_sprite_terminator
+sLickitungGfx40:
+.incbin "baserom.gba", 0x9AC158, 0x100
+sLickitungSprites40:
+ax_sprite sLickitungGfx40, 0x100
+ax_sprite_terminator
+sLickitungGfx41:
+.incbin "baserom.gba", 0x9AC268, 0x20
+sLickitungSprites41:
+ax_sprite sLickitungGfx41, 0x20
+ax_sprite_terminator
+sLickitungGfx42:
+.incbin "baserom.gba", 0x9AC298, 0x20
+sLickitungSprites42:
+ax_sprite sLickitungGfx42, 0x20
+ax_sprite_terminator
+sLickitungGfx43:
+.incbin "baserom.gba", 0x9AC2C8, 0x80
+sLickitungSprites43:
+ax_sprite sLickitungGfx43, 0x80
+ax_sprite_terminator
+sLickitungGfx44:
+.incbin "baserom.gba", 0x9AC358, 0x20
+sLickitungSprites44:
+ax_sprite sLickitungGfx44, 0x20
+ax_sprite_terminator
+sLickitungGfx45:
+.incbin "baserom.gba", 0x9AC388, 0x200
+sLickitungSprites45:
+ax_sprite sLickitungGfx45, 0x200
+ax_sprite_terminator
+sLickitungGfx46:
+.incbin "baserom.gba", 0x9AC598, 0x200
+sLickitungSprites46:
+ax_sprite sLickitungGfx46, 0x200
+ax_sprite_terminator
+sLickitungGfx47:
+.incbin "baserom.gba", 0x9AC7A8, 0x200
+sLickitungSprites47:
+ax_sprite sLickitungGfx47, 0x200
+ax_sprite_terminator
+sLickitungGfx48:
+.incbin "baserom.gba", 0x9AC9B8, 0x200
+sLickitungSprites48:
+ax_sprite sLickitungGfx48, 0x200
+ax_sprite_terminator
+sLickitungGfx49:
+.incbin "baserom.gba", 0x9ACBC8, 0x200
+sLickitungSprites49:
+ax_sprite sLickitungGfx49, 0x200
+ax_sprite_terminator
+sLickitungGfx50:
+.incbin "baserom.gba", 0x9ACDD8, 0x200
+sLickitungSprites50:
+ax_sprite sLickitungGfx50, 0x200
+ax_sprite_terminator
+sLickitungGfx51:
+.incbin "baserom.gba", 0x9ACFE8, 0x200
+sLickitungSprites51:
+ax_sprite sLickitungGfx51, 0x200
+ax_sprite_terminator
+sAxPosesLickitung:
+.4byte sLickitungPose1
+.4byte sLickitungPose2
+.4byte sLickitungPose3
+.4byte sLickitungPose4
+.4byte sLickitungPose5
+.4byte sLickitungPose6
+.4byte sLickitungPose7
+.4byte sLickitungPose8
+.4byte sLickitungPose9
+.4byte sLickitungPose10
+.4byte sLickitungPose11
+.4byte sLickitungPose12
+.4byte sLickitungPose13
+.4byte sLickitungPose14
+.4byte sLickitungPose15
+.4byte sLickitungPose16
+.4byte sLickitungPose17
+.4byte sLickitungPose18
+.4byte sLickitungPose19
+.4byte sLickitungPose20
+.4byte sLickitungPose21
+.4byte sLickitungPose22
+.4byte sLickitungPose23
+.4byte sLickitungPose24
+.4byte sLickitungPose25
+.4byte sLickitungPose26
+.4byte sLickitungPose27
+.4byte sLickitungPose28
+.4byte sLickitungPose29
+.4byte sLickitungPose30
+.4byte sLickitungPose31
+.4byte sLickitungPose32
+.4byte sLickitungPose33
+.4byte sLickitungPose34
+.4byte sLickitungPose35
+.4byte sLickitungPose36
+.4byte sLickitungPose37
+.4byte sLickitungPose38
+.4byte sLickitungPose39
+.4byte sLickitungPose40
+.4byte sLickitungPose41
+.4byte sLickitungPose42
+.4byte sLickitungPose43
+.4byte sLickitungPose44
+.4byte sLickitungPose45
+.4byte sLickitungPose46
+.4byte sLickitungPose47
+.4byte sLickitungPose48
+.4byte sLickitungPose49
+.4byte sLickitungPose50
+.4byte sLickitungPose51
+.4byte sLickitungPose52
+.4byte sLickitungPose53
+.4byte sLickitungPose54
+.4byte sLickitungPose55
+.4byte sLickitungPose56
+.4byte sLickitungPose57
+.4byte sLickitungPose58
+.4byte sLickitungPose59
+.4byte sLickitungPose60
+.4byte sLickitungPose61
+.4byte sLickitungPose62
+.4byte sLickitungPose63
+.4byte sLickitungPose64
+.4byte sLickitungPose65
+.4byte sLickitungPose66
+.4byte sLickitungPose67
+.4byte sLickitungPose68
+.4byte sLickitungPose69
+.4byte sLickitungPose70
+.4byte sLickitungPose71
+.4byte sLickitungPose72
+.4byte sLickitungPose73
+.4byte sLickitungPose74
+.4byte sLickitungPose75
+.4byte sLickitungPose76
+.4byte sLickitungPose77
+.4byte sLickitungPose78
+.4byte sLickitungPose79
+.4byte sLickitungPose80
+.4byte sLickitungPose81
+.4byte sLickitungPose82
+.4byte sLickitungPose83
+.4byte sLickitungPose84
+.4byte sLickitungPose85
+.4byte sLickitungPose86
+.4byte sLickitungPose87
+.4byte sLickitungPose88
+.4byte sLickitungPose89
+.4byte sLickitungPose90
+.4byte sLickitungPose91
+.4byte sLickitungPose92
+.4byte sLickitungPose93
+.4byte sLickitungPose94
+.4byte sLickitungPose95
+.4byte sLickitungPose96
+.4byte sLickitungPose97
+.4byte sLickitungPose98
+.4byte sLickitungPose99
+.4byte sLickitungPose100
+.4byte sLickitungPose101
+.4byte sLickitungPose102
+.4byte sLickitungPose103
+.4byte sLickitungPose104
+.4byte sLickitungPose105
+.4byte sLickitungPose106
+.4byte sLickitungPose107
+.4byte sLickitungPose108
+.4byte sLickitungPose109
+.4byte sLickitungPose110
+.4byte sLickitungPose111
+.4byte sLickitungPose112
+.4byte sLickitungPose113
+.4byte sLickitungPose114
+.4byte sLickitungPose115
+.4byte sLickitungPose116
+.4byte sLickitungPose117
+.4byte sLickitungPose118
+.4byte sLickitungPose119
+.4byte sLickitungPose120
+.4byte sLickitungPose121
+.4byte sLickitungPose122
+.4byte sLickitungPose123
+.4byte sLickitungPose124
+.4byte sLickitungPose125
+.4byte sLickitungPose126
+.4byte sLickitungPose127
+.4byte sLickitungPose128
+.4byte sLickitungPose129
+.4byte sLickitungPose130
+.4byte sLickitungPose131
+.4byte sLickitungPose132
+.4byte sLickitungPose133
+.4byte sLickitungPose134
+.4byte sLickitungPose135
+.4byte sLickitungPose136
+.4byte sLickitungPose137
+.4byte sLickitungPose138
+.4byte sLickitungPose139
+.4byte sLickitungPose140
+.4byte sLickitungPose141
+.4byte sLickitungPose142
+.4byte sLickitungPose143
+.4byte sLickitungPose144
+.4byte sLickitungPose145
+.4byte sLickitungPose146
+.4byte sLickitungPose147
+.4byte sLickitungPose148
+.4byte sLickitungPose149
+.4byte sLickitungPose150
+.4byte sLickitungPose151
+.4byte sLickitungPose152
+.4byte sLickitungPose153
+.4byte sLickitungPose154
+.4byte sLickitungPose155
+.4byte sLickitungPose156
+.4byte sLickitungPose157
+.4byte sLickitungPose158
+.4byte sLickitungPose159
+.4byte sLickitungPose160
+.4byte sLickitungPose161
+.4byte sLickitungPose162
+.4byte sLickitungPose163
+.4byte sLickitungPose164
+.4byte sLickitungPose165
+.4byte sLickitungPose166
+.4byte sLickitungPose167
+.4byte sLickitungPose168
+.4byte sLickitungPose169
+.4byte sLickitungPose170
+.4byte sLickitungPose171
+.4byte sLickitungPose172
+.4byte sLickitungPose173
+.4byte sLickitungPose174
+.4byte sLickitungPose175
+.4byte sLickitungPose176
+.4byte sLickitungPose177
+.4byte sLickitungPose178
+.4byte sLickitungPose179
+.4byte sLickitungPose180
+.4byte sLickitungPose181
+.4byte sLickitungPose182
+.4byte sLickitungPose183
+.4byte sLickitungPose184
+.4byte sLickitungPose185
+.4byte sLickitungPose186
+.4byte sLickitungPose187
+.4byte sLickitungPose188
+.4byte sLickitungPose189
+.4byte sLickitungPose190
+.4byte sLickitungPose191
+.4byte sLickitungPose192
+.4byte sLickitungPose193
+.4byte sLickitungPose194
+.4byte sLickitungPose195
+.4byte sLickitungPose196
+.4byte sLickitungPose197
+.4byte sLickitungPose198
+.4byte sLickitungPose199
+.4byte sLickitungPose200
+.4byte sLickitungPose201
+.4byte sLickitungPose202
+.4byte sLickitungPose203
+.4byte sLickitungPose204
+.4byte sLickitungPose205
+.4byte sLickitungPose206
+.4byte sLickitungPose207
+.4byte sLickitungPose208
+.4byte sLickitungPose209
+.4byte sLickitungPose210
+.4byte sLickitungPose211
+.4byte sLickitungPose212
+.4byte sLickitungPose213
+.4byte sLickitungPose214
+.4byte sLickitungPose215
+.4byte sLickitungPose216
+.4byte sLickitungPose217
+.4byte sLickitungPose218
+.4byte sLickitungPose219
+.4byte sLickitungPose220
+.4byte sLickitungPose221
+.4byte sLickitungPose222
+.4byte sLickitungPose223
+.4byte sLickitungPose224
+.4byte sLickitungPose225
+.4byte sLickitungPose226
+.4byte sLickitungPose227
+.4byte sLickitungPose228
+.4byte sLickitungPose229
+.4byte sLickitungPose230
+.4byte sLickitungPose231
+.4byte sLickitungPose232
+.4byte sLickitungPose233
+.4byte sLickitungPose234
+.4byte sLickitungPose235
+.4byte sLickitungPose236
+.4byte sLickitungPose237
+.4byte sLickitungPose238
+.4byte sLickitungPose239
+.4byte sLickitungPose240
+.4byte sLickitungPose241
+.4byte sLickitungPose242
+.4byte sLickitungPose243
+.4byte sLickitungPose244
+.4byte sLickitungPose245
+.4byte sLickitungPose246
+.4byte sLickitungPose247
+.4byte sLickitungPose248
+.4byte sLickitungPose249
+.4byte sLickitungPose250
+.4byte sLickitungPose251
+.4byte sLickitungPose252
+.4byte sLickitungPose253
+.4byte sLickitungPose254
+.4byte sLickitungPose255
+.4byte sLickitungPose256
+.4byte sLickitungPose257
+.4byte sLickitungPose258
+.4byte sLickitungPose259
+.4byte sLickitungPose260
+.4byte sLickitungPose261
+.4byte sLickitungPose262
+.4byte sLickitungPose263
+.4byte sLickitungPose264
+.4byte sLickitungPose265
+.4byte sLickitungPose266
+.4byte sLickitungPose267
+.4byte sLickitungPose268
+.4byte sLickitungPose269
+.4byte sLickitungPose270
+.4byte sLickitungPose271
+.4byte sLickitungPose272
+.4byte sLickitungPose273
+.4byte sLickitungPose274
+.4byte sLickitungPose275
+.4byte sLickitungPose276
+.4byte sLickitungPose277
+.4byte sLickitungPose278
+.4byte sLickitungPose279
+.4byte sLickitungPose280
+.4byte sLickitungPose281
+.4byte sLickitungPose282
+sAxPositionsLickitung:
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte    0,  -11, 	  -7,  -20, 	  11,  -15, 	   1,  -10
+.2byte    0,  -11, 	 -12,  -15, 	   6,  -20, 	  -1,  -10
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    4,  -11, 	   5,  -20, 	  -7,  -13, 	   0,   -9
+.2byte    6,  -12, 	   9,  -17, 	  -4,  -19, 	   0,  -11
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    7,  -11, 	  -1,  -21, 	  -1,  -11, 	   0,   -9
+.2byte    6,  -14, 	   4,  -18, 	  -4,  -17, 	  -1,  -11
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    4,  -13, 	  -5,  -18, 	   7,  -12, 	  -1,   -9
+.2byte    3,  -15, 	  -8,  -17, 	   6,  -18, 	  -1,  -10
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte   -1,  -16, 	   6,  -19, 	 -11,  -13, 	  -1,   -8
+.2byte    0,  -16, 	  10,  -13, 	  -7,  -19, 	   0,   -8
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte   -5,  -13, 	   4,  -18, 	  -8,  -12, 	   0,   -9
+.2byte   -4,  -15, 	   7,  -17, 	  -7,  -18, 	   0,  -10
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -8,  -11, 	   0,  -21, 	   0,  -11, 	  -1,   -9
+.2byte   -7,  -14, 	  -5,  -18, 	   3,  -17, 	   0,  -11
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -5,  -11, 	  -6,  -20, 	   6,  -13, 	  -1,   -9
+.2byte   -7,  -12, 	 -10,  -17, 	   3,  -19, 	  -1,  -11
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte    0,  -11, 	  -7,  -20, 	  11,  -15, 	   1,  -10
+.2byte    0,  -11, 	 -12,  -15, 	   6,  -20, 	  -1,  -10
+.2byte   -7,  -18, 	   3,  -22, 	  -2,   -6, 	   2,  -10
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte    7,  -17, 	   2,   -6, 	  -3,  -22, 	  -1,  -10
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    4,  -11, 	   5,  -20, 	  -7,  -13, 	   0,   -9
+.2byte    6,  -12, 	   9,  -17, 	  -4,  -19, 	   0,  -11
+.2byte    5,  -20, 	  -8,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    5,  -12, 	  10,  -14, 	  -8,   -9, 	   0,   -9
+.2byte   -5,  -16, 	  -2,   -8, 	  -5,  -22, 	   0,  -11
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    7,  -11, 	  -1,  -21, 	  -1,  -11, 	   0,   -9
+.2byte    6,  -14, 	   4,  -18, 	  -4,  -17, 	  -1,  -11
+.2byte    0,  -20, 	  -8,  -18, 	   5,   -8, 	  -3,  -10
+.2byte    9,  -12, 	   0,  -11, 	  -3,   -7, 	  -2,   -8
+.2byte   -1,  -13, 	   6,   -8, 	  -5,  -19, 	  -2,   -9
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    4,  -13, 	  -5,  -18, 	   7,  -12, 	  -1,   -9
+.2byte    3,  -15, 	  -8,  -17, 	   6,  -18, 	  -1,  -10
+.2byte   -5,  -21, 	  -8,  -16, 	   3,  -11, 	   0,  -10
+.2byte    5,  -16, 	  -8,  -14, 	   8,   -9, 	  -1,  -10
+.2byte    5,  -13, 	   8,  -10, 	  -4,  -17, 	   0,   -9
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte   -1,  -16, 	   6,  -19, 	 -11,  -13, 	  -1,   -8
+.2byte    0,  -16, 	  10,  -13, 	  -7,  -19, 	   0,   -8
+.2byte    8,  -18, 	  -1,  -16, 	   0,  -21, 	   0,  -10
+.2byte    0,  -20, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -9,  -18, 	  -2,  -20, 	   0,  -16, 	   0,   -8
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte   -5,  -13, 	   4,  -18, 	  -8,  -12, 	   0,   -9
+.2byte   -4,  -15, 	   7,  -17, 	  -7,  -18, 	   0,  -10
+.2byte    4,  -21, 	   7,  -16, 	  -4,  -11, 	  -1,  -10
+.2byte   -6,  -16, 	   7,  -14, 	  -9,   -9, 	   0,  -10
+.2byte   -6,  -13, 	  -9,  -10, 	   3,  -17, 	  -1,   -9
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -8,  -11, 	   0,  -21, 	   0,  -11, 	  -1,   -9
+.2byte   -7,  -14, 	  -5,  -18, 	   3,  -17, 	   0,  -11
+.2byte   -1,  -20, 	   7,  -18, 	  -6,   -8, 	   2,  -10
+.2byte  -10,  -12, 	  -1,  -11, 	   2,   -7, 	   1,   -8
+.2byte    0,  -13, 	  -7,   -8, 	   4,  -19, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -5,  -11, 	  -6,  -20, 	   6,  -13, 	  -1,   -9
+.2byte   -7,  -12, 	 -10,  -17, 	   3,  -19, 	  -1,  -11
+.2byte   -6,  -20, 	   7,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -6,  -12, 	 -11,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    4,  -16, 	   1,   -8, 	   4,  -22, 	  -1,  -11
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte    0,  -11, 	  -7,  -20, 	  11,  -15, 	   1,  -10
+.2byte    0,  -11, 	 -12,  -15, 	   6,  -20, 	  -1,  -10
+.2byte   -7,  -18, 	   3,  -22, 	  -2,   -6, 	   2,  -10
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte    7,  -17, 	   2,   -6, 	  -3,  -22, 	  -1,  -10
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    4,  -11, 	   5,  -20, 	  -7,  -13, 	   0,   -9
+.2byte    6,  -12, 	   9,  -17, 	  -4,  -19, 	   0,  -11
+.2byte    5,  -20, 	  -8,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    5,  -12, 	  10,  -14, 	  -8,   -9, 	   0,   -9
+.2byte   -5,  -16, 	  -2,   -8, 	  -5,  -22, 	   0,  -11
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    7,  -11, 	  -1,  -21, 	  -1,  -11, 	   0,   -9
+.2byte    6,  -14, 	   4,  -18, 	  -4,  -17, 	  -1,  -11
+.2byte    0,  -20, 	  -8,  -18, 	   5,   -8, 	  -3,  -10
+.2byte    9,  -12, 	   0,  -11, 	  -3,   -7, 	  -2,   -8
+.2byte   -1,  -13, 	   6,   -8, 	  -5,  -19, 	  -2,   -9
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    4,  -13, 	  -5,  -18, 	   7,  -12, 	  -1,   -9
+.2byte    3,  -15, 	  -8,  -17, 	   6,  -18, 	  -1,  -10
+.2byte   -5,  -21, 	  -8,  -16, 	   3,  -11, 	   0,  -10
+.2byte    5,  -16, 	  -8,  -14, 	   8,   -9, 	  -1,  -10
+.2byte    5,  -13, 	   8,  -10, 	  -4,  -17, 	   0,   -9
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte   -1,  -16, 	   6,  -19, 	 -11,  -13, 	  -1,   -8
+.2byte    0,  -16, 	  10,  -13, 	  -7,  -19, 	   0,   -8
+.2byte    8,  -18, 	  -1,  -16, 	   0,  -21, 	   0,  -10
+.2byte    0,  -20, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -9,  -18, 	  -2,  -20, 	   0,  -16, 	   0,   -8
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte   -5,  -13, 	   4,  -18, 	  -8,  -12, 	   0,   -9
+.2byte   -4,  -15, 	   7,  -17, 	  -7,  -18, 	   0,  -10
+.2byte    4,  -21, 	   7,  -16, 	  -4,  -11, 	  -1,  -10
+.2byte   -6,  -16, 	   7,  -14, 	  -9,   -9, 	   0,  -10
+.2byte   -6,  -13, 	  -9,  -10, 	   3,  -17, 	  -1,   -9
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -8,  -11, 	   0,  -21, 	   0,  -11, 	  -1,   -9
+.2byte   -7,  -14, 	  -5,  -18, 	   3,  -17, 	   0,  -11
+.2byte   -1,  -20, 	   7,  -18, 	  -6,   -8, 	   2,  -10
+.2byte  -10,  -12, 	  -1,  -11, 	   2,   -7, 	   1,   -8
+.2byte    0,  -13, 	  -7,   -8, 	   4,  -19, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -5,  -11, 	  -6,  -20, 	   6,  -13, 	  -1,   -9
+.2byte   -7,  -12, 	 -10,  -17, 	   3,  -19, 	  -1,  -11
+.2byte   -6,  -20, 	   7,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -6,  -12, 	 -11,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    4,  -16, 	   1,   -8, 	   4,  -22, 	  -1,  -11
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte   -7,  -18, 	   3,  -22, 	  -2,   -6, 	   2,  -10
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte    7,  -17, 	   2,   -6, 	  -3,  -22, 	  -1,  -10
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    5,  -20, 	  -8,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    5,  -12, 	  10,  -14, 	  -8,   -9, 	   0,   -9
+.2byte   -5,  -16, 	  -2,   -8, 	  -5,  -22, 	   0,  -11
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    0,  -20, 	  -8,  -18, 	   5,   -8, 	  -3,  -10
+.2byte    9,  -12, 	   0,  -11, 	  -3,   -7, 	  -2,   -8
+.2byte   -1,  -13, 	   6,   -8, 	  -5,  -19, 	  -2,   -9
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte   -5,  -21, 	  -8,  -16, 	   3,  -11, 	   0,  -10
+.2byte    5,  -16, 	  -8,  -14, 	   8,   -9, 	  -1,  -10
+.2byte    5,  -13, 	   8,  -10, 	  -4,  -17, 	   0,   -9
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte    8,  -18, 	  -1,  -16, 	   0,  -21, 	   0,  -10
+.2byte    0,  -20, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -9,  -18, 	  -2,  -20, 	   0,  -16, 	   0,   -8
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte    4,  -21, 	   7,  -16, 	  -4,  -11, 	  -1,  -10
+.2byte   -6,  -16, 	   7,  -14, 	  -9,   -9, 	   0,  -10
+.2byte   -6,  -13, 	  -9,  -10, 	   3,  -17, 	  -1,   -9
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -1,  -20, 	   7,  -18, 	  -6,   -8, 	   2,  -10
+.2byte  -10,  -12, 	  -1,  -11, 	   2,   -7, 	   1,   -8
+.2byte    0,  -13, 	  -7,   -8, 	   4,  -19, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -6,  -20, 	   7,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -6,  -12, 	 -11,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    4,  -16, 	   1,   -8, 	   4,  -22, 	  -1,  -11
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte    0,  -11, 	  -7,  -20, 	  11,  -15, 	   1,  -10
+.2byte    0,  -11, 	 -12,  -15, 	   6,  -20, 	  -1,  -10
+.2byte   -7,  -18, 	   3,  -22, 	  -2,   -6, 	   2,  -10
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte    7,  -17, 	   2,   -6, 	  -3,  -22, 	  -1,  -10
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    4,  -11, 	   5,  -20, 	  -7,  -13, 	   0,   -9
+.2byte    6,  -12, 	   9,  -17, 	  -4,  -19, 	   0,  -11
+.2byte   -5,  -16, 	  -2,   -8, 	  -5,  -22, 	   0,  -11
+.2byte    5,  -12, 	  10,  -14, 	  -8,   -9, 	   0,   -9
+.2byte    5,  -20, 	  -8,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    7,  -11, 	  -1,  -21, 	  -1,  -11, 	   0,   -9
+.2byte    6,  -14, 	   4,  -18, 	  -4,  -17, 	  -1,  -11
+.2byte   -1,  -13, 	   6,   -8, 	  -5,  -19, 	  -2,   -9
+.2byte    9,  -12, 	   0,  -11, 	  -3,   -7, 	  -2,   -8
+.2byte    0,  -20, 	  -8,  -18, 	   5,   -8, 	  -3,  -10
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    4,  -13, 	  -5,  -18, 	   7,  -12, 	  -1,   -9
+.2byte    3,  -15, 	  -8,  -17, 	   6,  -18, 	  -1,  -10
+.2byte    5,  -13, 	   8,  -10, 	  -4,  -17, 	   0,   -9
+.2byte    5,  -16, 	  -8,  -14, 	   8,   -9, 	  -1,  -10
+.2byte   -5,  -21, 	  -8,  -16, 	   3,  -11, 	   0,  -10
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte   -1,  -16, 	   6,  -19, 	 -11,  -13, 	  -1,   -8
+.2byte    0,  -16, 	  10,  -13, 	  -7,  -19, 	   0,   -8
+.2byte    8,  -18, 	  -1,  -16, 	   0,  -21, 	   0,  -10
+.2byte    0,  -20, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -9,  -18, 	  -2,  -20, 	   0,  -16, 	   0,   -8
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte   -5,  -13, 	   4,  -18, 	  -8,  -12, 	   0,   -9
+.2byte   -4,  -15, 	   7,  -17, 	  -7,  -18, 	   0,  -10
+.2byte    4,  -21, 	   7,  -16, 	  -4,  -11, 	  -1,  -10
+.2byte   -6,  -16, 	   7,  -14, 	  -9,   -9, 	   0,  -10
+.2byte   -6,  -13, 	  -9,  -10, 	   3,  -17, 	  -1,   -9
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -8,  -11, 	   0,  -21, 	   0,  -11, 	  -1,   -9
+.2byte   -7,  -14, 	  -5,  -18, 	   3,  -17, 	   0,  -11
+.2byte   -1,  -20, 	   7,  -18, 	  -6,   -8, 	   2,  -10
+.2byte  -10,  -12, 	  -1,  -11, 	   2,   -7, 	   1,   -8
+.2byte    0,  -13, 	  -7,   -8, 	   4,  -19, 	   1,   -9
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -5,  -11, 	  -6,  -20, 	   6,  -13, 	  -1,   -9
+.2byte   -7,  -12, 	 -10,  -17, 	   3,  -19, 	  -1,  -11
+.2byte   -6,  -20, 	   7,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -6,  -12, 	 -11,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    4,  -16, 	   1,   -8, 	   4,  -22, 	  -1,  -11
+.2byte   -6,   -9, 	  -8,   -7, 	   8,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -8,   -5, 	   8,   -3, 	   0,   -6
+.2byte    0,  -17, 	 -10,  -18, 	   9,  -18, 	   0,  -13
+.2byte    1,  -21, 	   2,  -22, 	  -7,  -17, 	   0,  -11
+.2byte    5,  -18, 	  -1,  -20, 	  -6,  -14, 	   0,  -11
+.2byte    4,  -20, 	  -9,  -18, 	   5,  -13, 	  -2,   -9
+.2byte    0,  -18, 	   8,  -15, 	  -9,  -15, 	   0,   -9
+.2byte   -5,  -20, 	   8,  -18, 	  -6,  -13, 	   1,   -9
+.2byte   -6,  -18, 	   0,  -20, 	   5,  -14, 	  -1,  -11
+.2byte   -2,  -21, 	  -3,  -22, 	   6,  -17, 	  -1,  -11
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    5,  -12, 	  10,  -14, 	  -8,   -9, 	   0,   -9
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    9,  -12, 	   0,  -11, 	  -3,   -7, 	  -2,   -8
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    5,  -16, 	  -8,  -14, 	   8,   -9, 	  -1,  -10
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte    0,  -20, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte   -6,  -16, 	   7,  -14, 	  -9,   -9, 	   0,  -10
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte  -10,  -12, 	  -1,  -11, 	   2,   -7, 	   1,   -8
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -6,  -12, 	 -11,  -14, 	   7,   -9, 	  -1,   -9
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte   -6,  -11, 	 -11,  -13, 	   7,   -8, 	  -1,   -8
+.2byte  -10,  -12, 	  -1,  -11, 	   2,   -7, 	   1,   -8
+.2byte   -6,  -15, 	   7,  -13, 	  -9,   -8, 	   0,   -9
+.2byte    0,  -19, 	  10,  -10, 	 -11,  -10, 	  -1,  -10
+.2byte    5,  -15, 	  -8,  -13, 	   8,   -8, 	  -1,   -9
+.2byte    9,  -12, 	   0,  -11, 	  -3,   -7, 	  -2,   -8
+.2byte    5,  -11, 	  10,  -13, 	  -8,   -8, 	   0,   -8
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte    5,  -11, 	  10,  -13, 	  -8,   -8, 	   0,   -8
+.2byte    9,  -12, 	   0,  -11, 	  -3,   -7, 	  -2,   -8
+.2byte    5,  -15, 	  -8,  -13, 	   8,   -8, 	  -1,   -9
+.2byte    0,  -19, 	  10,  -10, 	 -11,  -10, 	  -1,  -10
+.2byte   -6,  -15, 	   7,  -13, 	  -9,   -8, 	   0,   -9
+.2byte  -10,  -12, 	  -1,  -11, 	   2,   -7, 	   1,   -8
+.2byte   -6,  -11, 	 -11,  -13, 	   7,   -8, 	  -1,   -8
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte    0,  -11, 	  -7,  -20, 	  11,  -15, 	   1,  -10
+.2byte    0,   -9, 	 -12,  -11, 	  10,  -12, 	   0,   -8
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    4,  -11, 	   5,  -20, 	  -7,  -13, 	   0,   -9
+.2byte    4,  -12, 	   9,  -14, 	  -9,   -9, 	  -1,   -9
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    7,  -11, 	  -1,  -21, 	  -1,  -11, 	   0,   -9
+.2byte    7,  -12, 	  -2,  -11, 	  -5,   -7, 	  -4,   -8
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    4,  -13, 	  -5,  -18, 	   7,  -12, 	  -1,   -9
+.2byte    4,  -16, 	  -9,  -14, 	   7,   -9, 	  -2,  -10
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte   -1,  -16, 	   6,  -19, 	 -11,  -13, 	  -1,   -8
+.2byte    0,  -20, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte   -5,  -13, 	   4,  -18, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -16, 	   8,  -14, 	  -8,   -9, 	   1,  -10
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -8,  -11, 	   0,  -21, 	   0,  -11, 	  -1,   -9
+.2byte   -8,  -12, 	   1,  -11, 	   4,   -7, 	   3,   -8
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -5,  -11, 	  -6,  -20, 	   6,  -13, 	  -1,   -9
+.2byte   -5,  -12, 	 -10,  -14, 	   8,   -9, 	   0,   -9
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+.2byte    0,  -11, 	 -10,  -17, 	   9,  -17, 	   0,   -9
+.2byte   -5,  -12, 	  -8,  -19, 	   6,  -15, 	   0,   -9
+.2byte   -7,  -12, 	  -2,  -19, 	   2,  -13, 	  -1,   -9
+.2byte   -6,  -15, 	   6,  -19, 	  -7,  -14, 	   0,  -10
+.2byte    0,  -17, 	   8,  -17, 	  -9,  -17, 	  -1,   -9
+.2byte    5,  -15, 	  -7,  -19, 	   6,  -14, 	  -1,  -10
+.2byte    6,  -12, 	   1,  -19, 	  -3,  -13, 	   0,   -9
+.2byte    4,  -12, 	   7,  -19, 	  -7,  -15, 	  -1,   -9
+sLickitungAnimTable1:
+.4byte sLickitungAnims_1_1
+.4byte sLickitungAnims_1_2
+.4byte sLickitungAnims_1_3
+.4byte sLickitungAnims_1_4
+.4byte sLickitungAnims_1_5
+.4byte sLickitungAnims_1_6
+.4byte sLickitungAnims_1_7
+.4byte sLickitungAnims_1_8
+sLickitungAnimTable2:
+.4byte sLickitungAnims_2_1
+.4byte sLickitungAnims_2_2
+.4byte sLickitungAnims_2_3
+.4byte sLickitungAnims_2_4
+.4byte sLickitungAnims_2_5
+.4byte sLickitungAnims_2_6
+.4byte sLickitungAnims_2_7
+.4byte sLickitungAnims_2_8
+sLickitungAnimTable3:
+.4byte sLickitungAnims_3_1
+.4byte sLickitungAnims_3_2
+.4byte sLickitungAnims_3_3
+.4byte sLickitungAnims_3_4
+.4byte sLickitungAnims_3_5
+.4byte sLickitungAnims_3_6
+.4byte sLickitungAnims_3_7
+.4byte sLickitungAnims_3_8
+sLickitungAnimTable4:
+.4byte sLickitungAnims_4_1
+.4byte sLickitungAnims_4_2
+.4byte sLickitungAnims_4_3
+.4byte sLickitungAnims_4_4
+.4byte sLickitungAnims_4_5
+.4byte sLickitungAnims_4_6
+.4byte sLickitungAnims_4_7
+.4byte sLickitungAnims_4_8
+sLickitungAnimTable5:
+.4byte sLickitungAnims_5_1
+.4byte sLickitungAnims_5_2
+.4byte sLickitungAnims_5_3
+.4byte sLickitungAnims_5_4
+.4byte sLickitungAnims_5_5
+.4byte sLickitungAnims_5_6
+.4byte sLickitungAnims_5_7
+.4byte sLickitungAnims_5_8
+sLickitungAnimTable6:
+.4byte sLickitungAnims_6_1
+.4byte sLickitungAnims_6_1
+.4byte sLickitungAnims_6_1
+.4byte sLickitungAnims_6_1
+.4byte sLickitungAnims_6_1
+.4byte sLickitungAnims_6_1
+.4byte sLickitungAnims_6_1
+.4byte sLickitungAnims_6_1
+sLickitungAnimTable7:
+.4byte sLickitungAnims_7_1
+.4byte sLickitungAnims_7_2
+.4byte sLickitungAnims_7_3
+.4byte sLickitungAnims_7_4
+.4byte sLickitungAnims_7_5
+.4byte sLickitungAnims_7_6
+.4byte sLickitungAnims_7_7
+.4byte sLickitungAnims_7_8
+sLickitungAnimTable8:
+.4byte sLickitungAnims_8_1
+.4byte sLickitungAnims_8_2
+.4byte sLickitungAnims_8_3
+.4byte sLickitungAnims_8_4
+.4byte sLickitungAnims_8_5
+.4byte sLickitungAnims_8_6
+.4byte sLickitungAnims_8_7
+.4byte sLickitungAnims_8_8
+sLickitungAnimTable9:
+.4byte sLickitungAnims_9_1
+.4byte sLickitungAnims_9_2
+.4byte sLickitungAnims_9_3
+.4byte sLickitungAnims_9_4
+.4byte sLickitungAnims_9_5
+.4byte sLickitungAnims_9_6
+.4byte sLickitungAnims_9_7
+.4byte sLickitungAnims_9_8
+sLickitungAnimTable10:
+.4byte sLickitungAnims_10_1
+.4byte sLickitungAnims_10_2
+.4byte sLickitungAnims_10_3
+.4byte sLickitungAnims_10_4
+.4byte sLickitungAnims_10_5
+.4byte sLickitungAnims_10_6
+.4byte sLickitungAnims_10_7
+.4byte sLickitungAnims_10_8
+sLickitungAnimTable11:
+.4byte sLickitungAnims_11_1
+.4byte sLickitungAnims_11_2
+.4byte sLickitungAnims_11_3
+.4byte sLickitungAnims_11_4
+.4byte sLickitungAnims_11_5
+.4byte sLickitungAnims_11_6
+.4byte sLickitungAnims_11_7
+.4byte sLickitungAnims_11_8
+sLickitungAnimTable12:
+.4byte sLickitungAnims_12_1
+.4byte sLickitungAnims_12_2
+.4byte sLickitungAnims_12_3
+.4byte sLickitungAnims_12_4
+.4byte sLickitungAnims_12_5
+.4byte sLickitungAnims_12_6
+.4byte sLickitungAnims_12_7
+.4byte sLickitungAnims_12_8
+sLickitungAnimTable13:
+.4byte sLickitungAnims_13_1
+.4byte sLickitungAnims_13_2
+.4byte sLickitungAnims_13_3
+.4byte sLickitungAnims_13_4
+.4byte sLickitungAnims_13_5
+.4byte sLickitungAnims_13_6
+.4byte sLickitungAnims_13_7
+.4byte sLickitungAnims_13_8
+sAxAnimationsLickitung:
+.4byte sLickitungAnimTable1
+.4byte sLickitungAnimTable2
+.4byte sLickitungAnimTable3
+.4byte sLickitungAnimTable4
+.4byte sLickitungAnimTable5
+.4byte sLickitungAnimTable6
+.4byte sLickitungAnimTable7
+.4byte sLickitungAnimTable8
+.4byte sLickitungAnimTable9
+.4byte sLickitungAnimTable10
+.4byte sLickitungAnimTable11
+.4byte sLickitungAnimTable12
+.4byte sLickitungAnimTable13
+sAxSpritesLickitung:
+.4byte sLickitungSprites1
+.4byte sLickitungSprites2
+.4byte sLickitungSprites3
+.4byte sLickitungSprites4
+.4byte sLickitungSprites5
+.4byte sLickitungSprites6
+.4byte sLickitungSprites7
+.4byte sLickitungSprites8
+.4byte sLickitungSprites9
+.4byte sLickitungSprites10
+.4byte sLickitungSprites11
+.4byte sLickitungSprites12
+.4byte sLickitungSprites13
+.4byte sLickitungSprites14
+.4byte sLickitungSprites15
+.4byte sLickitungSprites16
+.4byte sLickitungSprites17
+.4byte sLickitungSprites18
+.4byte sLickitungSprites19
+.4byte sLickitungSprites20
+.4byte sLickitungSprites21
+.4byte sLickitungSprites22
+.4byte sLickitungSprites23
+.4byte sLickitungSprites24
+.4byte sLickitungSprites25
+.4byte sLickitungSprites26
+.4byte sLickitungSprites27
+.4byte sLickitungSprites28
+.4byte sLickitungSprites29
+.4byte sLickitungSprites30
+.4byte sLickitungSprites31
+.4byte sLickitungSprites32
+.4byte sLickitungSprites33
+.4byte sLickitungSprites34
+.4byte sLickitungSprites35
+.4byte sLickitungSprites36
+.4byte sLickitungSprites37
+.4byte sLickitungSprites38
+.4byte sLickitungSprites39
+.4byte sLickitungSprites40
+.4byte sLickitungSprites41
+.4byte sLickitungSprites42
+.4byte sLickitungSprites43
+.4byte sLickitungSprites44
+.4byte sLickitungSprites45
+.4byte sLickitungSprites46
+.4byte sLickitungSprites47
+.4byte sLickitungSprites48
+.4byte sLickitungSprites49
+.4byte sLickitungSprites50
+.4byte sLickitungSprites51
+sAxMainLickitung:
+ax_main sAxPosesLickitung, sAxAnimationsLickitung, 13, sAxSpritesLickitung, sAxPositionsLickitung

--- a/data/ax/lileep.inc
+++ b/data/ax/lileep.inc
@@ -1,0 +1,3987 @@
+.global gAxLileep
+gAxLileep:
+ax_siro sAxMainLileep
+sLileepPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose6:
+ax_pose 5, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose7:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose8:
+ax_pose 7, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose9:
+ax_pose 8, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose10:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose11:
+ax_pose 10, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose26:
+ax_pose 15, 0x81e9, 0x80f4, 0xac00
+ax_pose 16, 0x81e9, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose27:
+ax_pose 17, 0x41f5, 0x80f1, 0xac00
+ax_pose 18, 0x41ed, 0x00f9, 0xac08
+ax_pose_terminator
+sLileepPose28:
+ax_pose 19, 0x01f6, 0x80f1, 0xac00
+ax_pose 20, 0x01f5, 0x40f8, 0xac10
+ax_pose_terminator
+sLileepPose29:
+ax_pose 19, 0x0202, 0x80f1, 0xac00
+ax_pose 21, 0x0204, 0x40f8, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose30:
+ax_pose 19, 0x0202, 0x80f3, 0xac00
+ax_pose 21, 0x0204, 0x40f9, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose31:
+ax_pose 19, 0x0202, 0x80ef, 0xac00
+ax_pose 21, 0x0204, 0x40f7, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose32:
+ax_pose 19, 0x0200, 0x80f1, 0xac00
+ax_pose 21, 0x0200, 0x40f8, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose33:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose34:
+ax_pose 22, 0x41ee, 0x90e8, 0xac00
+ax_pose 23, 0x41e6, 0x10f0, 0xac08
+ax_pose 24, 0x41fe, 0x10f8, 0xac0a
+ax_pose_terminator
+sLileepPose35:
+ax_pose 25, 0x41f5, 0x90f4, 0xac00
+ax_pose 26, 0x41ed, 0x1104, 0xac08
+ax_pose_terminator
+sLileepPose36:
+ax_pose 27, 0x01f2, 0x90f8, 0xac00
+ax_pose 28, 0x01f5, 0x50f8, 0xac10
+ax_pose_terminator
+sLileepPose37:
+ax_pose 27, 0x01fe, 0x9101, 0xac00
+ax_pose 29, 0x81f5, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose38:
+ax_pose 27, 0x01ff, 0x9100, 0xac00
+ax_pose 29, 0x81f6, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose39:
+ax_pose 27, 0x01fb, 0x9102, 0xac00
+ax_pose 29, 0x81f5, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose40:
+ax_pose 27, 0x01fc, 0x90ff, 0xac00
+ax_pose 29, 0x81f5, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose41:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose42:
+ax_pose 30, 0x41f4, 0x90e7, 0xac00
+ax_pose 31, 0x01ec, 0x10ef, 0xac08
+ax_pose_terminator
+sLileepPose43:
+ax_pose 32, 0x41f3, 0x90f8, 0xac00
+ax_pose 33, 0x01eb, 0x1108, 0xac08
+ax_pose_terminator
+sLileepPose44:
+ax_pose 34, 0x01ed, 0x90fc, 0xac00
+ax_pose 35, 0x01f3, 0x50f9, 0xac10
+ax_pose_terminator
+sLileepPose45:
+ax_pose 34, 0x01ed, 0x9104, 0xac00
+ax_pose 36, 0x81f3, 0x1109, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose46:
+ax_pose 34, 0x01eb, 0x9104, 0xac00
+ax_pose 36, 0x81f2, 0x1109, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose47:
+ax_pose 34, 0x01ef, 0x9104, 0xac00
+ax_pose 36, 0x81f4, 0x1109, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose48:
+ax_pose 34, 0x01ed, 0x9102, 0xac00
+ax_pose 36, 0x81f3, 0x1107, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose49:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose50:
+ax_pose 37, 0x41f5, 0x90ec, 0xac00
+ax_pose 38, 0x41ed, 0x10ec, 0xac08
+ax_pose_terminator
+sLileepPose51:
+ax_pose 39, 0x41ea, 0x90f3, 0xac00
+ax_pose 40, 0x41fa, 0x50f3, 0xac08
+ax_pose 41, 0x0202, 0x10fb, 0xac0c
+ax_pose_terminator
+sLileepPose52:
+ax_pose 42, 0x01e6, 0x90f7, 0xac00
+ax_pose 43, 0x81e4, 0x90fa, 0xac10
+ax_pose_terminator
+sLileepPose53:
+ax_pose 42, 0x01dc, 0x9101, 0xac00
+ax_pose 44, 0x81e4, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose54:
+ax_pose 42, 0x01db, 0x9100, 0xac00
+ax_pose 44, 0x81e3, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose55:
+ax_pose 42, 0x01dd, 0x9102, 0xac00
+ax_pose 44, 0x81e5, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose56:
+ax_pose 42, 0x01de, 0x90ff, 0xac00
+ax_pose 44, 0x81e4, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose57:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose58:
+ax_pose 45, 0x41ed, 0x80f0, 0xac00
+ax_pose 46, 0x41fd, 0x00f8, 0xac08
+ax_pose_terminator
+sLileepPose59:
+ax_pose 47, 0x81e7, 0x80f4, 0xac00
+ax_pose 48, 0x81e7, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose60:
+ax_pose 49, 0x01e3, 0x80f4, 0xac00
+ax_pose 50, 0x01f3, 0x40f8, 0xac10
+ax_pose_terminator
+sLileepPose61:
+ax_pose 49, 0x01da, 0x80f4, 0xac00
+ax_pose 51, 0x01e3, 0x40f8, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose62:
+ax_pose 49, 0x01da, 0x80f2, 0xac00
+ax_pose 51, 0x01e3, 0x40f7, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose63:
+ax_pose 49, 0x01da, 0x80f6, 0xac00
+ax_pose 51, 0x01e3, 0x40f9, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose64:
+ax_pose 49, 0x01dc, 0x80f4, 0xac00
+ax_pose 51, 0x01ef, 0x40f8, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose65:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose66:
+ax_pose 37, 0x41f5, 0x80f4, 0xac00
+ax_pose 38, 0x41ed, 0x0104, 0xac08
+ax_pose_terminator
+sLileepPose67:
+ax_pose 39, 0x41ea, 0x80ed, 0xac00
+ax_pose 40, 0x41fa, 0x40ed, 0xac08
+ax_pose 41, 0x0202, 0x00fd, 0xac0c
+ax_pose_terminator
+sLileepPose68:
+ax_pose 42, 0x01e6, 0x80e9, 0xac00
+ax_pose 43, 0x81e4, 0x80f6, 0xac10
+ax_pose_terminator
+sLileepPose69:
+ax_pose 42, 0x01dc, 0x80df, 0xac00
+ax_pose 44, 0x81e4, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose70:
+ax_pose 42, 0x01db, 0x80e0, 0xac00
+ax_pose 44, 0x81e3, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose71:
+ax_pose 42, 0x01dd, 0x80de, 0xac00
+ax_pose 44, 0x81e5, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose72:
+ax_pose 42, 0x01de, 0x80e1, 0xac00
+ax_pose 44, 0x81e4, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose73:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose74:
+ax_pose 30, 0x41f4, 0x80f9, 0xac00
+ax_pose 31, 0x01ec, 0x0109, 0xac08
+ax_pose_terminator
+sLileepPose75:
+ax_pose 32, 0x41f3, 0x80e8, 0xac00
+ax_pose 33, 0x01eb, 0x00f0, 0xac08
+ax_pose_terminator
+sLileepPose76:
+ax_pose 34, 0x01ed, 0x80e4, 0xac00
+ax_pose 35, 0x01f3, 0x40f7, 0xac10
+ax_pose_terminator
+sLileepPose77:
+ax_pose 34, 0x01ed, 0x80dc, 0xac00
+ax_pose 36, 0x81f3, 0x00ef, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose78:
+ax_pose 34, 0x01eb, 0x80dc, 0xac00
+ax_pose 36, 0x81f2, 0x00ef, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose79:
+ax_pose 34, 0x01ef, 0x80dc, 0xac00
+ax_pose 36, 0x81f4, 0x00ef, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose80:
+ax_pose 34, 0x01ed, 0x80de, 0xac00
+ax_pose 36, 0x81f3, 0x00f1, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose81:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose82:
+ax_pose 22, 0x41ee, 0x80f8, 0xac00
+ax_pose 23, 0x41e6, 0x0100, 0xac08
+ax_pose 24, 0x41fe, 0x00f8, 0xac0a
+ax_pose_terminator
+sLileepPose83:
+ax_pose 25, 0x41f5, 0x80ec, 0xac00
+ax_pose 26, 0x41ed, 0x00ec, 0xac08
+ax_pose_terminator
+sLileepPose84:
+ax_pose 27, 0x01f2, 0x80e8, 0xac00
+ax_pose 28, 0x01f5, 0x40f8, 0xac10
+ax_pose_terminator
+sLileepPose85:
+ax_pose 27, 0x01fe, 0x80df, 0xac00
+ax_pose 29, 0x81f5, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose86:
+ax_pose 27, 0x01ff, 0x80e0, 0xac00
+ax_pose 29, 0x81f6, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose87:
+ax_pose 27, 0x01fb, 0x80de, 0xac00
+ax_pose 29, 0x81f5, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose88:
+ax_pose 27, 0x01fc, 0x80e1, 0xac00
+ax_pose 29, 0x81f5, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose89:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose90:
+ax_pose 15, 0x81e9, 0x80f4, 0xac00
+ax_pose 16, 0x81e9, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose91:
+ax_pose 17, 0x41f5, 0x80f1, 0xac00
+ax_pose 18, 0x41ed, 0x00f9, 0xac08
+ax_pose_terminator
+sLileepPose92:
+ax_pose 19, 0x01f6, 0x80f1, 0xac00
+ax_pose 20, 0x01f5, 0x40f8, 0xac10
+ax_pose_terminator
+sLileepPose93:
+ax_pose 19, 0x0202, 0x80f1, 0xac00
+ax_pose 21, 0x0204, 0x40f8, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose94:
+ax_pose 19, 0x0202, 0x80f3, 0xac00
+ax_pose 21, 0x0204, 0x40f9, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose95:
+ax_pose 19, 0x0202, 0x80ef, 0xac00
+ax_pose 21, 0x0204, 0x40f7, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose96:
+ax_pose 19, 0x0200, 0x80f1, 0xac00
+ax_pose 21, 0x0200, 0x40f8, 0xac10
+ax_pose 20, 0x01f5, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose97:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose98:
+ax_pose 22, 0x41ee, 0x90e8, 0xac00
+ax_pose 23, 0x41e6, 0x10f0, 0xac08
+ax_pose 24, 0x41fe, 0x10f8, 0xac0a
+ax_pose_terminator
+sLileepPose99:
+ax_pose 25, 0x41f5, 0x90f4, 0xac00
+ax_pose 26, 0x41ed, 0x1104, 0xac08
+ax_pose_terminator
+sLileepPose100:
+ax_pose 27, 0x01f2, 0x90f8, 0xac00
+ax_pose 28, 0x01f5, 0x50f8, 0xac10
+ax_pose_terminator
+sLileepPose101:
+ax_pose 27, 0x01fe, 0x9101, 0xac00
+ax_pose 29, 0x81f5, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose102:
+ax_pose 27, 0x01ff, 0x9100, 0xac00
+ax_pose 29, 0x81f6, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose103:
+ax_pose 27, 0x01fb, 0x9102, 0xac00
+ax_pose 29, 0x81f5, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose104:
+ax_pose 27, 0x01fc, 0x90ff, 0xac00
+ax_pose 29, 0x81f5, 0x9108, 0xac10
+ax_pose 28, 0x01f5, 0x50f8, 0xac18
+ax_pose_terminator
+sLileepPose105:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose106:
+ax_pose 30, 0x41f4, 0x90e7, 0xac00
+ax_pose 31, 0x01ec, 0x10ef, 0xac08
+ax_pose_terminator
+sLileepPose107:
+ax_pose 32, 0x41f3, 0x90f8, 0xac00
+ax_pose 33, 0x01eb, 0x1108, 0xac08
+ax_pose_terminator
+sLileepPose108:
+ax_pose 34, 0x01ed, 0x90fc, 0xac00
+ax_pose 35, 0x01f3, 0x50f9, 0xac10
+ax_pose_terminator
+sLileepPose109:
+ax_pose 34, 0x01ed, 0x9104, 0xac00
+ax_pose 36, 0x81f3, 0x1109, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose110:
+ax_pose 34, 0x01eb, 0x9104, 0xac00
+ax_pose 36, 0x81f2, 0x1109, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose111:
+ax_pose 34, 0x01ef, 0x9104, 0xac00
+ax_pose 36, 0x81f4, 0x1109, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose112:
+ax_pose 34, 0x01ed, 0x9102, 0xac00
+ax_pose 36, 0x81f3, 0x1107, 0xac10
+ax_pose 35, 0x01f3, 0x50f9, 0xac12
+ax_pose_terminator
+sLileepPose113:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose114:
+ax_pose 37, 0x41f5, 0x90ec, 0xac00
+ax_pose 38, 0x41ed, 0x10ec, 0xac08
+ax_pose_terminator
+sLileepPose115:
+ax_pose 39, 0x41ea, 0x90f3, 0xac00
+ax_pose 40, 0x41fa, 0x50f3, 0xac08
+ax_pose 41, 0x0202, 0x10fb, 0xac0c
+ax_pose_terminator
+sLileepPose116:
+ax_pose 42, 0x01e6, 0x90f7, 0xac00
+ax_pose 43, 0x81e4, 0x90fa, 0xac10
+ax_pose_terminator
+sLileepPose117:
+ax_pose 42, 0x01dc, 0x9101, 0xac00
+ax_pose 44, 0x81e4, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose118:
+ax_pose 42, 0x01db, 0x9100, 0xac00
+ax_pose 44, 0x81e3, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose119:
+ax_pose 42, 0x01dd, 0x9102, 0xac00
+ax_pose 44, 0x81e5, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose120:
+ax_pose 42, 0x01de, 0x90ff, 0xac00
+ax_pose 44, 0x81e4, 0x910a, 0xac10
+ax_pose 43, 0x81e4, 0x90fa, 0xac18
+ax_pose_terminator
+sLileepPose121:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose122:
+ax_pose 45, 0x41ed, 0x80f0, 0xac00
+ax_pose 46, 0x41fd, 0x00f8, 0xac08
+ax_pose_terminator
+sLileepPose123:
+ax_pose 47, 0x81e7, 0x80f4, 0xac00
+ax_pose 48, 0x81e7, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose124:
+ax_pose 49, 0x01e3, 0x80f4, 0xac00
+ax_pose 50, 0x01f3, 0x40f8, 0xac10
+ax_pose_terminator
+sLileepPose125:
+ax_pose 49, 0x01da, 0x80f4, 0xac00
+ax_pose 51, 0x01e3, 0x40f8, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose126:
+ax_pose 49, 0x01da, 0x80f2, 0xac00
+ax_pose 51, 0x01e3, 0x40f7, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose127:
+ax_pose 49, 0x01da, 0x80f6, 0xac00
+ax_pose 51, 0x01e3, 0x40f9, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose128:
+ax_pose 49, 0x01dc, 0x80f4, 0xac00
+ax_pose 51, 0x01ef, 0x40f8, 0xac10
+ax_pose 50, 0x01f3, 0x40f8, 0xac14
+ax_pose_terminator
+sLileepPose129:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose130:
+ax_pose 37, 0x41f5, 0x80f4, 0xac00
+ax_pose 38, 0x41ed, 0x0104, 0xac08
+ax_pose_terminator
+sLileepPose131:
+ax_pose 39, 0x41ea, 0x80ed, 0xac00
+ax_pose 40, 0x41fa, 0x40ed, 0xac08
+ax_pose 41, 0x0202, 0x00fd, 0xac0c
+ax_pose_terminator
+sLileepPose132:
+ax_pose 42, 0x01e6, 0x80e9, 0xac00
+ax_pose 43, 0x81e4, 0x80f6, 0xac10
+ax_pose_terminator
+sLileepPose133:
+ax_pose 42, 0x01dc, 0x80df, 0xac00
+ax_pose 44, 0x81e4, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose134:
+ax_pose 42, 0x01db, 0x80e0, 0xac00
+ax_pose 44, 0x81e3, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose135:
+ax_pose 42, 0x01dd, 0x80de, 0xac00
+ax_pose 44, 0x81e5, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose136:
+ax_pose 42, 0x01de, 0x80e1, 0xac00
+ax_pose 44, 0x81e4, 0x80e6, 0xac10
+ax_pose 43, 0x81e4, 0x80f6, 0xac18
+ax_pose_terminator
+sLileepPose137:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose138:
+ax_pose 30, 0x41f4, 0x80f9, 0xac00
+ax_pose 31, 0x01ec, 0x0109, 0xac08
+ax_pose_terminator
+sLileepPose139:
+ax_pose 32, 0x41f3, 0x80e8, 0xac00
+ax_pose 33, 0x01eb, 0x00f0, 0xac08
+ax_pose_terminator
+sLileepPose140:
+ax_pose 34, 0x01ed, 0x80e4, 0xac00
+ax_pose 35, 0x01f3, 0x40f7, 0xac10
+ax_pose_terminator
+sLileepPose141:
+ax_pose 34, 0x01ed, 0x80dc, 0xac00
+ax_pose 36, 0x81f3, 0x00ef, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose142:
+ax_pose 34, 0x01eb, 0x80dc, 0xac00
+ax_pose 36, 0x81f2, 0x00ef, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose143:
+ax_pose 34, 0x01ef, 0x80dc, 0xac00
+ax_pose 36, 0x81f4, 0x00ef, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose144:
+ax_pose 34, 0x01ed, 0x80de, 0xac00
+ax_pose 36, 0x81f3, 0x00f1, 0xac10
+ax_pose 35, 0x01f3, 0x40f7, 0xac12
+ax_pose_terminator
+sLileepPose145:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose146:
+ax_pose 22, 0x41ee, 0x80f8, 0xac00
+ax_pose 23, 0x41e6, 0x0100, 0xac08
+ax_pose 24, 0x41fe, 0x00f8, 0xac0a
+ax_pose_terminator
+sLileepPose147:
+ax_pose 25, 0x41f5, 0x80ec, 0xac00
+ax_pose 26, 0x41ed, 0x00ec, 0xac08
+ax_pose_terminator
+sLileepPose148:
+ax_pose 27, 0x01f2, 0x80e8, 0xac00
+ax_pose 28, 0x01f5, 0x40f8, 0xac10
+ax_pose_terminator
+sLileepPose149:
+ax_pose 27, 0x01fe, 0x80df, 0xac00
+ax_pose 29, 0x81f5, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose150:
+ax_pose 27, 0x01ff, 0x80e0, 0xac00
+ax_pose 29, 0x81f6, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose151:
+ax_pose 27, 0x01fb, 0x80de, 0xac00
+ax_pose 29, 0x81f5, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose152:
+ax_pose 27, 0x01fc, 0x80e1, 0xac00
+ax_pose 29, 0x81f5, 0x80e8, 0xac10
+ax_pose 28, 0x01f5, 0x40f8, 0xac18
+ax_pose_terminator
+sLileepPose153:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose154:
+ax_pose 52, 0x81eb, 0x40f6, 0xac00
+ax_pose 53, 0x01f3, 0x40fe, 0xac04
+ax_pose_terminator
+sLileepPose155:
+ax_pose 54, 0x41f6, 0x80f6, 0xac00
+ax_pose 55, 0x41ee, 0x00f6, 0xac08
+ax_pose_terminator
+sLileepPose156:
+ax_pose 15, 0x81e9, 0x80f4, 0xac00
+ax_pose 16, 0x81e9, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose157:
+ax_pose 17, 0x41f5, 0x80f1, 0xac00
+ax_pose 18, 0x41ed, 0x00f9, 0xac08
+ax_pose_terminator
+sLileepPose158:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose159:
+ax_pose 56, 0x41f5, 0x90f5, 0xac00
+ax_pose 57, 0x41ed, 0x1105, 0xac08
+ax_pose_terminator
+sLileepPose160:
+ax_pose 58, 0x41f6, 0x90f5, 0xac00
+ax_pose 59, 0x41ee, 0x1105, 0xac08
+ax_pose_terminator
+sLileepPose161:
+ax_pose 22, 0x41ee, 0x90e8, 0xac00
+ax_pose 23, 0x41e6, 0x10f0, 0xac08
+ax_pose 24, 0x41fe, 0x10f8, 0xac0a
+ax_pose_terminator
+sLileepPose162:
+ax_pose 25, 0x41f5, 0x90f4, 0xac00
+ax_pose 26, 0x41ed, 0x1104, 0xac08
+ax_pose_terminator
+sLileepPose163:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose164:
+ax_pose 60, 0x41f3, 0x90f6, 0xac00
+ax_pose 61, 0x41eb, 0x1106, 0xac08
+ax_pose_terminator
+sLileepPose165:
+ax_pose 62, 0x41f3, 0x90f6, 0xac00
+ax_pose 63, 0x41eb, 0x1106, 0xac08
+ax_pose_terminator
+sLileepPose166:
+ax_pose 30, 0x41f4, 0x90e7, 0xac00
+ax_pose 31, 0x01ec, 0x10ef, 0xac08
+ax_pose_terminator
+sLileepPose167:
+ax_pose 32, 0x41f3, 0x90f8, 0xac00
+ax_pose 33, 0x01eb, 0x1108, 0xac08
+ax_pose_terminator
+sLileepPose168:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose169:
+ax_pose 64, 0x81ea, 0x90fd, 0xac00
+ax_pose 65, 0x81ea, 0x110d, 0xac08
+ax_pose 66, 0x01fa, 0x10f5, 0xac0a
+ax_pose_terminator
+sLileepPose170:
+ax_pose 67, 0x41ec, 0x90f3, 0xac00
+ax_pose 68, 0x41fc, 0x50f3, 0xac08
+ax_pose_terminator
+sLileepPose171:
+ax_pose 37, 0x41f5, 0x90ec, 0xac00
+ax_pose 38, 0x41ed, 0x10ec, 0xac08
+ax_pose_terminator
+sLileepPose172:
+ax_pose 39, 0x41ea, 0x90f3, 0xac00
+ax_pose 40, 0x41fa, 0x50f3, 0xac08
+ax_pose 41, 0x0202, 0x10fb, 0xac0c
+ax_pose_terminator
+sLileepPose173:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose174:
+ax_pose 69, 0x81e7, 0x80f4, 0xac00
+ax_pose 70, 0x81e7, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose175:
+ax_pose 71, 0x41e9, 0x80f0, 0xac00
+ax_pose 72, 0x01f9, 0x40f8, 0xac08
+ax_pose_terminator
+sLileepPose176:
+ax_pose 45, 0x41ed, 0x80f0, 0xac00
+ax_pose 46, 0x41fd, 0x00f8, 0xac08
+ax_pose_terminator
+sLileepPose177:
+ax_pose 47, 0x81e7, 0x80f4, 0xac00
+ax_pose 48, 0x81e7, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose178:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose179:
+ax_pose 64, 0x81ea, 0x80f3, 0xac00
+ax_pose 65, 0x81ea, 0x00eb, 0xac08
+ax_pose 66, 0x01fa, 0x0103, 0xac0a
+ax_pose_terminator
+sLileepPose180:
+ax_pose 67, 0x41ec, 0x80ed, 0xac00
+ax_pose 68, 0x41fc, 0x40ed, 0xac08
+ax_pose_terminator
+sLileepPose181:
+ax_pose 37, 0x41f5, 0x80f4, 0xac00
+ax_pose 38, 0x41ed, 0x0104, 0xac08
+ax_pose_terminator
+sLileepPose182:
+ax_pose 39, 0x41ea, 0x80ed, 0xac00
+ax_pose 40, 0x41fa, 0x40ed, 0xac08
+ax_pose 41, 0x0202, 0x00fd, 0xac0c
+ax_pose_terminator
+sLileepPose183:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose184:
+ax_pose 60, 0x41f3, 0x80ea, 0xac00
+ax_pose 61, 0x41eb, 0x00ea, 0xac08
+ax_pose_terminator
+sLileepPose185:
+ax_pose 62, 0x41f3, 0x80ea, 0xac00
+ax_pose 63, 0x41eb, 0x00ea, 0xac08
+ax_pose_terminator
+sLileepPose186:
+ax_pose 30, 0x41f4, 0x80f9, 0xac00
+ax_pose 31, 0x01ec, 0x0109, 0xac08
+ax_pose_terminator
+sLileepPose187:
+ax_pose 32, 0x41f3, 0x80e8, 0xac00
+ax_pose 33, 0x01eb, 0x00f0, 0xac08
+ax_pose_terminator
+sLileepPose188:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose189:
+ax_pose 56, 0x41f5, 0x80eb, 0xac00
+ax_pose 57, 0x41ed, 0x00eb, 0xac08
+ax_pose_terminator
+sLileepPose190:
+ax_pose 58, 0x41f6, 0x80eb, 0xac00
+ax_pose 59, 0x41ee, 0x00eb, 0xac08
+ax_pose_terminator
+sLileepPose191:
+ax_pose 22, 0x41ee, 0x80f8, 0xac00
+ax_pose 23, 0x41e6, 0x0100, 0xac08
+ax_pose 24, 0x41fe, 0x00f8, 0xac0a
+ax_pose_terminator
+sLileepPose192:
+ax_pose 25, 0x41f5, 0x80ec, 0xac00
+ax_pose 26, 0x41ed, 0x00ec, 0xac08
+ax_pose_terminator
+sLileepPose193:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose194:
+ax_pose 15, 0x81e9, 0x80f4, 0xac00
+ax_pose 16, 0x81e9, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose195:
+ax_pose 17, 0x41f5, 0x80f1, 0xac00
+ax_pose 18, 0x41ed, 0x00f9, 0xac08
+ax_pose_terminator
+sLileepPose196:
+ax_pose 73, 0x41e9, 0x80f1, 0xac00
+ax_pose 74, 0x01f9, 0x40f9, 0xac08
+ax_pose_terminator
+sLileepPose197:
+ax_pose 75, 0x01ec, 0x00f9, 0xac00
+ax_pose -1, 0x01ec, 0x00fe, 0xac00
+ax_pose 73, 0x41e9, 0x80f1, 0xac01
+ax_pose 74, 0x01f9, 0x40f9, 0xac09
+ax_pose_terminator
+sLileepPose198:
+ax_pose 76, 0x01ec, 0x00f9, 0xac00
+ax_pose -1, 0x01ec, 0x00fe, 0xac00
+ax_pose 73, 0x41e9, 0x80f1, 0xac01
+ax_pose 74, 0x01f9, 0x40f9, 0xac09
+ax_pose_terminator
+sLileepPose199:
+ax_pose 77, 0x01e8, 0x40f5, 0xac00
+ax_pose -1, 0x01e8, 0x40fa, 0xac00
+ax_pose 73, 0x41e9, 0x80f1, 0xac04
+ax_pose 74, 0x01f9, 0x40f9, 0xac0c
+ax_pose_terminator
+sLileepPose200:
+ax_pose 78, 0x01e8, 0x40f5, 0xac00
+ax_pose -1, 0x01e8, 0x40fa, 0xac00
+ax_pose 73, 0x41e9, 0x80f1, 0xac04
+ax_pose 74, 0x01f9, 0x40f9, 0xac0c
+ax_pose_terminator
+sLileepPose201:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose202:
+ax_pose 22, 0x41ee, 0x90e8, 0xac00
+ax_pose 23, 0x41e6, 0x10f0, 0xac08
+ax_pose 24, 0x41fe, 0x10f8, 0xac0a
+ax_pose_terminator
+sLileepPose203:
+ax_pose 25, 0x41f5, 0x90f4, 0xac00
+ax_pose 26, 0x41ed, 0x1104, 0xac08
+ax_pose_terminator
+sLileepPose204:
+ax_pose 79, 0x01e8, 0x90ed, 0xac00
+ax_pose_terminator
+sLileepPose205:
+ax_pose 75, 0x01ed, 0x00fb, 0xac00
+ax_pose -1, 0x01ea, 0x00fd, 0xac00
+ax_pose 79, 0x01e8, 0x90ed, 0xac01
+ax_pose_terminator
+sLileepPose206:
+ax_pose 76, 0x01ed, 0x00fb, 0xac00
+ax_pose -1, 0x01ea, 0x00fd, 0xac00
+ax_pose 79, 0x01e8, 0x90ed, 0xac01
+ax_pose_terminator
+sLileepPose207:
+ax_pose 77, 0x01e9, 0x40f7, 0xac00
+ax_pose -1, 0x01e6, 0x40f9, 0xac00
+ax_pose 79, 0x01e8, 0x90ed, 0xac04
+ax_pose_terminator
+sLileepPose208:
+ax_pose 78, 0x01e9, 0x40f7, 0xac00
+ax_pose -1, 0x01e6, 0x40f9, 0xac00
+ax_pose 79, 0x01e8, 0x90ed, 0xac04
+ax_pose_terminator
+sLileepPose209:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose210:
+ax_pose 30, 0x41f4, 0x90e7, 0xac00
+ax_pose 31, 0x01ec, 0x10ef, 0xac08
+ax_pose_terminator
+sLileepPose211:
+ax_pose 32, 0x41f3, 0x90f8, 0xac00
+ax_pose 33, 0x01eb, 0x1108, 0xac08
+ax_pose_terminator
+sLileepPose212:
+ax_pose 80, 0x41ea, 0x90ef, 0xac00
+ax_pose 81, 0x01fa, 0x50f7, 0xac08
+ax_pose_terminator
+sLileepPose213:
+ax_pose 75, 0x01ed, 0x00fc, 0xac00
+ax_pose -1, 0x01ea, 0x00fc, 0xac00
+ax_pose 80, 0x41ea, 0x90ef, 0xac01
+ax_pose 81, 0x01fa, 0x50f7, 0xac09
+ax_pose_terminator
+sLileepPose214:
+ax_pose 76, 0x01ed, 0x00fc, 0xac00
+ax_pose -1, 0x01ea, 0x00fc, 0xac00
+ax_pose 80, 0x41ea, 0x90ef, 0xac01
+ax_pose 81, 0x01fa, 0x50f7, 0xac09
+ax_pose_terminator
+sLileepPose215:
+ax_pose 77, 0x01e9, 0x40f8, 0xac00
+ax_pose -1, 0x01e6, 0x40f8, 0xac00
+ax_pose 80, 0x41ea, 0x90ef, 0xac04
+ax_pose 81, 0x01fa, 0x50f7, 0xac0c
+ax_pose_terminator
+sLileepPose216:
+ax_pose 78, 0x01e9, 0x40f8, 0xac00
+ax_pose -1, 0x01e6, 0x40f8, 0xac00
+ax_pose 80, 0x41ea, 0x90ef, 0xac04
+ax_pose 81, 0x01fa, 0x50f7, 0xac0c
+ax_pose_terminator
+sLileepPose217:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose218:
+ax_pose 37, 0x41f5, 0x90ec, 0xac00
+ax_pose 38, 0x41ed, 0x10ec, 0xac08
+ax_pose_terminator
+sLileepPose219:
+ax_pose 39, 0x41ea, 0x90f3, 0xac00
+ax_pose 40, 0x41fa, 0x50f3, 0xac08
+ax_pose 41, 0x0202, 0x10fb, 0xac0c
+ax_pose_terminator
+sLileepPose220:
+ax_pose 82, 0x01e8, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose221:
+ax_pose 75, 0x01ed, 0x00fc, 0xac00
+ax_pose -1, 0x01ea, 0x00fa, 0xac00
+ax_pose 82, 0x01e8, 0x90ec, 0xac01
+ax_pose_terminator
+sLileepPose222:
+ax_pose 76, 0x01ed, 0x00fc, 0xac00
+ax_pose -1, 0x01ea, 0x00fa, 0xac00
+ax_pose 82, 0x01e8, 0x90ec, 0xac01
+ax_pose_terminator
+sLileepPose223:
+ax_pose 77, 0x01e9, 0x40f8, 0xac00
+ax_pose -1, 0x01e6, 0x40f6, 0xac00
+ax_pose 82, 0x01e8, 0x90ec, 0xac04
+ax_pose_terminator
+sLileepPose224:
+ax_pose 78, 0x01e9, 0x40f8, 0xac00
+ax_pose -1, 0x01e6, 0x40f6, 0xac00
+ax_pose 82, 0x01e8, 0x90ec, 0xac04
+ax_pose_terminator
+sLileepPose225:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose226:
+ax_pose 45, 0x41ed, 0x80f0, 0xac00
+ax_pose 46, 0x41fd, 0x00f8, 0xac08
+ax_pose_terminator
+sLileepPose227:
+ax_pose 47, 0x81e7, 0x80f4, 0xac00
+ax_pose 48, 0x81e7, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose228:
+ax_pose 83, 0x41e9, 0x80f0, 0xac00
+ax_pose 84, 0x01f9, 0x40f8, 0xac08
+ax_pose_terminator
+sLileepPose229:
+ax_pose 75, 0x01ec, 0x00fe, 0xac00
+ax_pose -1, 0x01ec, 0x00f9, 0xac00
+ax_pose 83, 0x41e9, 0x80f0, 0xac01
+ax_pose 84, 0x01f9, 0x40f8, 0xac09
+ax_pose_terminator
+sLileepPose230:
+ax_pose 76, 0x01ec, 0x00fe, 0xac00
+ax_pose -1, 0x01ec, 0x00f9, 0xac00
+ax_pose 83, 0x41e9, 0x80f0, 0xac01
+ax_pose 84, 0x01f9, 0x40f8, 0xac09
+ax_pose_terminator
+sLileepPose231:
+ax_pose 77, 0x01e8, 0x40fa, 0xac00
+ax_pose -1, 0x01e8, 0x40f5, 0xac00
+ax_pose 83, 0x41e9, 0x80f0, 0xac04
+ax_pose 84, 0x01f9, 0x40f8, 0xac0c
+ax_pose_terminator
+sLileepPose232:
+ax_pose 75, 0x01ec, 0x00fe, 0xac00
+ax_pose -1, 0x01ec, 0x00f9, 0xac00
+ax_pose 83, 0x41e9, 0x80f0, 0xac01
+ax_pose 84, 0x01f9, 0x40f8, 0xac09
+ax_pose_terminator
+sLileepPose233:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose234:
+ax_pose 37, 0x41f5, 0x80f4, 0xac00
+ax_pose 38, 0x41ed, 0x0104, 0xac08
+ax_pose_terminator
+sLileepPose235:
+ax_pose 39, 0x41ea, 0x80ed, 0xac00
+ax_pose 40, 0x41fa, 0x40ed, 0xac08
+ax_pose 41, 0x0202, 0x00fd, 0xac0c
+ax_pose_terminator
+sLileepPose236:
+ax_pose 82, 0x01e8, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose237:
+ax_pose 75, 0x01ed, 0x00fb, 0xac00
+ax_pose -1, 0x01eb, 0x00fc, 0xac00
+ax_pose 82, 0x01e8, 0x80f4, 0xac01
+ax_pose_terminator
+sLileepPose238:
+ax_pose 76, 0x01ed, 0x00fb, 0xac00
+ax_pose -1, 0x01eb, 0x00fc, 0xac00
+ax_pose 82, 0x01e8, 0x80f4, 0xac01
+ax_pose_terminator
+sLileepPose239:
+ax_pose 77, 0x01e9, 0x40f7, 0xac00
+ax_pose -1, 0x01e7, 0x40f8, 0xac00
+ax_pose 82, 0x01e8, 0x80f4, 0xac04
+ax_pose_terminator
+sLileepPose240:
+ax_pose 78, 0x01e9, 0x40f7, 0xac00
+ax_pose -1, 0x01e7, 0x40f8, 0xac00
+ax_pose 82, 0x01e8, 0x80f4, 0xac04
+ax_pose_terminator
+sLileepPose241:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose242:
+ax_pose 30, 0x41f4, 0x80f9, 0xac00
+ax_pose 31, 0x01ec, 0x0109, 0xac08
+ax_pose_terminator
+sLileepPose243:
+ax_pose 32, 0x41f3, 0x80e8, 0xac00
+ax_pose 33, 0x01eb, 0x00f0, 0xac08
+ax_pose_terminator
+sLileepPose244:
+ax_pose 80, 0x41ea, 0x80f1, 0xac00
+ax_pose 81, 0x01fa, 0x40f9, 0xac08
+ax_pose_terminator
+sLileepPose245:
+ax_pose 75, 0x01ed, 0x10fc, 0xac00
+ax_pose -1, 0x01ea, 0x10fc, 0xac00
+ax_pose 80, 0x41ea, 0x80f1, 0xac01
+ax_pose 81, 0x01fa, 0x40f9, 0xac09
+ax_pose_terminator
+sLileepPose246:
+ax_pose 76, 0x01ed, 0x10fc, 0xac00
+ax_pose -1, 0x01ea, 0x10fc, 0xac00
+ax_pose 80, 0x41ea, 0x80f1, 0xac01
+ax_pose 81, 0x01fa, 0x40f9, 0xac09
+ax_pose_terminator
+sLileepPose247:
+ax_pose 77, 0x01e9, 0x50f8, 0xac00
+ax_pose -1, 0x01e6, 0x50f8, 0xac00
+ax_pose 80, 0x41ea, 0x80f1, 0xac04
+ax_pose 81, 0x01fa, 0x40f9, 0xac0c
+ax_pose_terminator
+sLileepPose248:
+ax_pose 78, 0x01e9, 0x50f8, 0xac00
+ax_pose -1, 0x01e6, 0x50f8, 0xac00
+ax_pose 80, 0x41ea, 0x80f1, 0xac04
+ax_pose 81, 0x01fa, 0x40f9, 0xac0c
+ax_pose_terminator
+sLileepPose249:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose250:
+ax_pose 22, 0x41ee, 0x80f8, 0xac00
+ax_pose 23, 0x41e6, 0x0100, 0xac08
+ax_pose 24, 0x41fe, 0x00f8, 0xac0a
+ax_pose_terminator
+sLileepPose251:
+ax_pose 25, 0x41f5, 0x80ec, 0xac00
+ax_pose 26, 0x41ed, 0x00ec, 0xac08
+ax_pose_terminator
+sLileepPose252:
+ax_pose 79, 0x01e8, 0x80f3, 0xac00
+ax_pose_terminator
+sLileepPose253:
+ax_pose 75, 0x01ed, 0x10fd, 0xac00
+ax_pose -1, 0x01ea, 0x10fb, 0xac00
+ax_pose 79, 0x01e8, 0x80f3, 0xac01
+ax_pose_terminator
+sLileepPose254:
+ax_pose 76, 0x01ed, 0x10fd, 0xac00
+ax_pose -1, 0x01ea, 0x10fb, 0xac00
+ax_pose 79, 0x01e8, 0x80f3, 0xac01
+ax_pose_terminator
+sLileepPose255:
+ax_pose 77, 0x01e9, 0x50f9, 0xac00
+ax_pose -1, 0x01e6, 0x50f7, 0xac00
+ax_pose 79, 0x01e8, 0x80f3, 0xac04
+ax_pose_terminator
+sLileepPose256:
+ax_pose 78, 0x01e9, 0x50f9, 0xac00
+ax_pose -1, 0x01e6, 0x50f7, 0xac00
+ax_pose 79, 0x01e8, 0x80f3, 0xac04
+ax_pose_terminator
+sLileepPose257:
+ax_pose 85, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose258:
+ax_pose 86, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose259:
+ax_pose 87, 0x01e1, 0x80f0, 0xac00
+ax_pose_terminator
+sLileepPose260:
+ax_pose 88, 0x01e3, 0x90ed, 0xac00
+ax_pose_terminator
+sLileepPose261:
+ax_pose 89, 0x01e5, 0x90ed, 0xac00
+ax_pose_terminator
+sLileepPose262:
+ax_pose 90, 0x01e7, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose263:
+ax_pose 91, 0x01e6, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose264:
+ax_pose 90, 0x01e7, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose265:
+ax_pose 89, 0x01e5, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose266:
+ax_pose 88, 0x01e3, 0x80f3, 0xac00
+ax_pose_terminator
+sLileepPose267:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose268:
+ax_pose 1, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose269:
+ax_pose 2, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose270:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose271:
+ax_pose 4, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose272:
+ax_pose 5, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose273:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose274:
+ax_pose 7, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose275:
+ax_pose 8, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose276:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose277:
+ax_pose 10, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose278:
+ax_pose 11, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose279:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose280:
+ax_pose 13, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose281:
+ax_pose 14, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose282:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose283:
+ax_pose 10, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose284:
+ax_pose 11, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose285:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose286:
+ax_pose 7, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose287:
+ax_pose 8, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose288:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose289:
+ax_pose 4, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose290:
+ax_pose 5, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose291:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose292:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose293:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose294:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose295:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose296:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose297:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose298:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose299:
+ax_pose 17, 0x41f5, 0x80f1, 0xac00
+ax_pose 18, 0x41ed, 0x00f9, 0xac08
+ax_pose_terminator
+sLileepPose300:
+ax_pose 25, 0x41f3, 0x90f2, 0xac00
+ax_pose 26, 0x41eb, 0x1102, 0xac08
+ax_pose_terminator
+sLileepPose301:
+ax_pose 32, 0x41f3, 0x90f5, 0xac00
+ax_pose 33, 0x01eb, 0x1105, 0xac08
+ax_pose_terminator
+sLileepPose302:
+ax_pose 39, 0x41ec, 0x90f1, 0xac00
+ax_pose 40, 0x41fc, 0x50f1, 0xac08
+ax_pose 41, 0x0204, 0x10f9, 0xac0c
+ax_pose_terminator
+sLileepPose303:
+ax_pose 47, 0x81e9, 0x80f4, 0xac00
+ax_pose 48, 0x81e9, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose304:
+ax_pose 39, 0x41ec, 0x80ef, 0xac00
+ax_pose 40, 0x41fc, 0x40ef, 0xac08
+ax_pose 41, 0x0204, 0x00ff, 0xac0c
+ax_pose_terminator
+sLileepPose305:
+ax_pose 32, 0x41f3, 0x80eb, 0xac00
+ax_pose 33, 0x01eb, 0x00f3, 0xac08
+ax_pose_terminator
+sLileepPose306:
+ax_pose 25, 0x41f3, 0x80ee, 0xac00
+ax_pose 26, 0x41eb, 0x00ee, 0xac08
+ax_pose_terminator
+sLileepPose307:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose308:
+ax_pose 15, 0x81e9, 0x80f4, 0xac00
+ax_pose 16, 0x81e9, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose309:
+ax_pose 17, 0x41f5, 0x80f1, 0xac00
+ax_pose 18, 0x41ed, 0x00f9, 0xac08
+ax_pose_terminator
+sLileepPose310:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose311:
+ax_pose 22, 0x41ee, 0x90eb, 0xac00
+ax_pose 23, 0x41e6, 0x10f3, 0xac08
+ax_pose 24, 0x41fe, 0x10fb, 0xac0a
+ax_pose_terminator
+sLileepPose312:
+ax_pose 25, 0x41f5, 0x90f1, 0xac00
+ax_pose 26, 0x41ed, 0x1101, 0xac08
+ax_pose_terminator
+sLileepPose313:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose314:
+ax_pose 30, 0x41f4, 0x90ea, 0xac00
+ax_pose 31, 0x01ec, 0x10f2, 0xac08
+ax_pose_terminator
+sLileepPose315:
+ax_pose 32, 0x41f3, 0x90f5, 0xac00
+ax_pose 33, 0x01eb, 0x1105, 0xac08
+ax_pose_terminator
+sLileepPose316:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose317:
+ax_pose 37, 0x41f5, 0x90ee, 0xac00
+ax_pose 38, 0x41ed, 0x10ee, 0xac08
+ax_pose_terminator
+sLileepPose318:
+ax_pose 39, 0x41ea, 0x90f0, 0xac00
+ax_pose 40, 0x41fa, 0x50f0, 0xac08
+ax_pose 41, 0x0202, 0x10f8, 0xac0c
+ax_pose_terminator
+sLileepPose319:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose320:
+ax_pose 45, 0x41ed, 0x80f0, 0xac00
+ax_pose 46, 0x41fd, 0x00f8, 0xac08
+ax_pose_terminator
+sLileepPose321:
+ax_pose 47, 0x81e7, 0x80f4, 0xac00
+ax_pose 48, 0x81e7, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose322:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose323:
+ax_pose 37, 0x41f5, 0x80f2, 0xac00
+ax_pose 38, 0x41ed, 0x0102, 0xac08
+ax_pose_terminator
+sLileepPose324:
+ax_pose 39, 0x41ea, 0x80f0, 0xac00
+ax_pose 40, 0x41fa, 0x40f0, 0xac08
+ax_pose 41, 0x0202, 0x0100, 0xac0c
+ax_pose_terminator
+sLileepPose325:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose326:
+ax_pose 30, 0x41f4, 0x80f6, 0xac00
+ax_pose 31, 0x01ec, 0x0106, 0xac08
+ax_pose_terminator
+sLileepPose327:
+ax_pose 32, 0x41f3, 0x80eb, 0xac00
+ax_pose 33, 0x01eb, 0x00f3, 0xac08
+ax_pose_terminator
+sLileepPose328:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose329:
+ax_pose 22, 0x41ee, 0x80f5, 0xac00
+ax_pose 23, 0x41e6, 0x00fd, 0xac08
+ax_pose 24, 0x41fe, 0x00f5, 0xac0a
+ax_pose_terminator
+sLileepPose330:
+ax_pose 25, 0x41f5, 0x80ef, 0xac00
+ax_pose 26, 0x41ed, 0x00ef, 0xac08
+ax_pose_terminator
+sLileepPose331:
+ax_pose 15, 0x81e9, 0x80f4, 0xac00
+ax_pose 16, 0x81e9, 0x4104, 0xac08
+ax_pose_terminator
+sLileepPose332:
+ax_pose 22, 0x41ee, 0x80f6, 0xac00
+ax_pose 23, 0x41e6, 0x00fe, 0xac08
+ax_pose 24, 0x41fe, 0x00f6, 0xac0a
+ax_pose_terminator
+sLileepPose333:
+ax_pose 30, 0x41f4, 0x80f7, 0xac00
+ax_pose 31, 0x01ec, 0x0107, 0xac08
+ax_pose_terminator
+sLileepPose334:
+ax_pose 37, 0x41f5, 0x80f2, 0xac00
+ax_pose 38, 0x41ed, 0x0102, 0xac08
+ax_pose_terminator
+sLileepPose335:
+ax_pose 45, 0x41ed, 0x80f0, 0xac00
+ax_pose 46, 0x41fd, 0x00f8, 0xac08
+ax_pose_terminator
+sLileepPose336:
+ax_pose 37, 0x41f5, 0x90ee, 0xac00
+ax_pose 38, 0x41ed, 0x10ee, 0xac08
+ax_pose_terminator
+sLileepPose337:
+ax_pose 30, 0x41f4, 0x90e9, 0xac00
+ax_pose 31, 0x01ec, 0x10f1, 0xac08
+ax_pose_terminator
+sLileepPose338:
+ax_pose 22, 0x41ee, 0x90ea, 0xac00
+ax_pose 23, 0x41e6, 0x10f2, 0xac08
+ax_pose 24, 0x41fe, 0x10fa, 0xac0a
+ax_pose_terminator
+sLileepPose339:
+ax_pose 0, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose340:
+ax_pose 3, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose341:
+ax_pose 6, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose342:
+ax_pose 9, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose343:
+ax_pose 12, 0x01eb, 0x80f4, 0xac00
+ax_pose_terminator
+sLileepPose344:
+ax_pose 9, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose345:
+ax_pose 6, 0x01eb, 0x90ec, 0xac00
+ax_pose_terminator
+sLileepPose346:
+ax_pose 3, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+.align 2
+sLileepAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_2_1:
+ax_anim 8, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 1, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_2_2:
+ax_anim 8, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 1, 37, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_2_3:
+ax_anim 8, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 1, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_2_4:
+ax_anim 8, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 1, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_2_5:
+ax_anim 8, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 1, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_2_6:
+ax_anim 8, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 1, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_2_7:
+ax_anim 8, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 1, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_2_8:
+ax_anim 8, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 2, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 1, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_3_1:
+ax_anim 8, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 2, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 1, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_3_2:
+ax_anim 8, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 2, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 1, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_3_3:
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 2, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 1, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_3_4:
+ax_anim 8, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 2, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 1, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_3_5:
+ax_anim 8, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 2, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 1, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_3_6:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 2, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 1, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_3_7:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 2, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 1, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_3_8:
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 2, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 1, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_4_1:
+ax_anim 8, 2, 155, 0, 0, 0, 0,
+ax_anim 2, 1, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_4_2:
+ax_anim 8, 2, 160, 0, 0, 0, 0,
+ax_anim 2, 1, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_4_3:
+ax_anim 8, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_4_4:
+ax_anim 8, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_4_5:
+ax_anim 8, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_4_6:
+ax_anim 8, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_4_7:
+ax_anim 8, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_4_8:
+ax_anim 8, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_5_1:
+ax_anim 6, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 4, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 6, 2, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_5_2:
+ax_anim 6, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 4, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 6, 2, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 4, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_5_3:
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 2, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_5_4:
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 2, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_5_5:
+ax_anim 6, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 6, 2, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_5_6:
+ax_anim 6, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 6, 2, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_5_7:
+ax_anim 6, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 6, 2, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_5_8:
+ax_anim 6, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 6, 2, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_6_1:
+ax_anim 30, 0, 256, 0, 0, 0, 0,
+ax_anim 35, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_7_1:
+ax_anim 2, 0, 258, 0, -2, 0, -2,
+ax_anim 8, 0, 258, 0, -3, 0, -3,
+ax_anim_terminator
+sLileepAnims_7_2:
+ax_anim 2, 0, 259, -2, -2, -2, -2,
+ax_anim 8, 0, 259, -3, -3, -3, -3,
+ax_anim_terminator
+sLileepAnims_7_3:
+ax_anim 2, 0, 260, -2, 0, -2, 0,
+ax_anim 8, 0, 260, -3, 0, -3, 0,
+ax_anim_terminator
+sLileepAnims_7_4:
+ax_anim 2, 0, 261, -2, 2, -2, 2,
+ax_anim 8, 0, 261, -3, 3, -3, 3,
+ax_anim_terminator
+sLileepAnims_7_5:
+ax_anim 2, 0, 262, 0, 2, 0, 2,
+ax_anim 8, 0, 262, 0, 3, 0, 3,
+ax_anim_terminator
+sLileepAnims_7_6:
+ax_anim 2, 0, 263, 2, 2, 2, 2,
+ax_anim 8, 0, 263, 3, 3, 3, 3,
+ax_anim_terminator
+sLileepAnims_7_7:
+ax_anim 2, 0, 264, 2, 0, 2, 0,
+ax_anim 8, 0, 264, 3, 0, 3, 0,
+ax_anim_terminator
+sLileepAnims_7_8:
+ax_anim 2, 0, 265, 2, -2, 2, -2,
+ax_anim 8, 0, 265, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLileepAnims_8_1:
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim 10, 0, 267, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim 10, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_8_2:
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_8_3:
+ax_anim 8, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 273, 0, 0, 0, 0,
+ax_anim 8, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_8_4:
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 10, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 10, 0, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_8_5:
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim 10, 0, 279, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim 10, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_8_6:
+ax_anim 8, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 281, 0, 0, 0, 0,
+ax_anim 10, 0, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_8_7:
+ax_anim 8, 0, 284, 0, 0, 0, 0,
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 284, 0, 0, 0, 0,
+ax_anim 10, 0, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_8_8:
+ax_anim 8, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 288, 0, 0, 0, 0,
+ax_anim 8, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_9_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 1, 0, 291, 6, 3, 6, 3,
+ax_anim 2, 0, 292, 8, 9, 8, 9,
+ax_anim 2, 0, 293, 7, 15, 7, 15,
+ax_anim 3, 0, 294, 0, 18, 0, 18,
+ax_anim 2, 3, 295, -7, 15, -7, 15,
+ax_anim 2, 0, 296, -8, 9, -8, 9,
+ax_anim 1, 0, 297, -6, 3, -6, 3,
+ax_anim 1, 0, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_9_2:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 1, 0, 290, 8, 0, 8, 0,
+ax_anim 2, 0, 291, 17, 3, 17, 3,
+ax_anim 2, 0, 292, 24, 10, 24, 10,
+ax_anim 3, 0, 293, 22, 17, 22, 17,
+ax_anim 2, 3, 294, 13, 19, 13, 19,
+ax_anim 2, 0, 295, 3, 15, 3, 15,
+ax_anim 1, 0, 296, 0, 7, 0, 7,
+ax_anim 1, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_9_3:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 1, 0, 297, 3, -5, 3, -5,
+ax_anim 2, 0, 290, 11, -6, 11, -6,
+ax_anim 2, 0, 291, 19, -5, 19, -5,
+ax_anim 3, 0, 292, 22, -2, 22, -2,
+ax_anim 2, 3, 293, 19, 4, 19, 4,
+ax_anim 2, 0, 294, 12, 5, 12, 5,
+ax_anim 1, 0, 295, 4, 5, 4, 5,
+ax_anim 1, 0, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_9_4:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 1, 0, 296, -1, -8, -1, -8,
+ax_anim 2, 0, 297, 5, -18, 5, -18,
+ax_anim 2, 0, 290, 13, -22, 13, -22,
+ax_anim 3, 0, 291, 20, -22, 20, -22,
+ax_anim 2, 3, 292, 24, -14, 24, -14,
+ax_anim 2, 0, 293, 17, -4, 17, -4,
+ax_anim 1, 0, 294, 7, -1, 7, -1,
+ax_anim 1, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_9_5:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 1, 0, 295, -8, -4, -8, -4,
+ax_anim 2, 0, 296, -9, -12, -9, -12,
+ax_anim 2, 0, 297, -7, -18, -7, -18,
+ax_anim 3, 0, 290, 0, -22, 0, -22,
+ax_anim 2, 3, 291, 7, -18, 7, -18,
+ax_anim 2, 0, 292, 9, -10, 9, -10,
+ax_anim 1, 0, 293, 8, -4, 8, -4,
+ax_anim 1, 0, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_9_6:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 1, 0, 292, 1, -8, 1, -8,
+ax_anim 2, 0, 291, -5, -18, -5, -18,
+ax_anim 2, 0, 290, -13, -22, -13, -22,
+ax_anim 3, 0, 297, -20, -22, -20, -22,
+ax_anim 2, 3, 296, -24, -14, -24, -14,
+ax_anim 2, 0, 295, -17, -4, -17, -4,
+ax_anim 1, 0, 294, -7, -1, -7, -1,
+ax_anim 1, 0, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_9_7:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 1, 0, 291, -3, -5, -3, -5,
+ax_anim 2, 0, 290, -11, -6, -11, -6,
+ax_anim 2, 0, 297, -19, -5, -19, -5,
+ax_anim 3, 0, 296, -22, -2, -22, -2,
+ax_anim 2, 3, 295, -19, 4, -19, 4,
+ax_anim 2, 0, 294, -12, 5, -12, 5,
+ax_anim 1, 0, 293, -4, 5, -4, 5,
+ax_anim 1, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_9_8:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 1, 0, 290, -8, 0, -8, 0,
+ax_anim 2, 0, 297, -17, 3, -17, 3,
+ax_anim 2, 0, 296, -24, 10, -24, 10,
+ax_anim 3, 0, 295, -22, 17, -22, 17,
+ax_anim 2, 3, 294, -13, 19, -13, 19,
+ax_anim 2, 0, 293, -3, 15, -3, 15,
+ax_anim 1, 0, 292, 0, 7, 0, 7,
+ax_anim 1, 0, 291, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_10_1:
+ax_anim 2, 0, 298, 0, 2, 0, 2,
+ax_anim 2, 0, 298, 6, 2, 6, 2,
+ax_anim 2, 0, 298, -6, 2, -6, 2,
+ax_anim 2, 0, 298, 10, 2, 10, 2,
+ax_anim 2, 0, 298, -10, 2, -10, 2,
+ax_anim 2, 0, 298, 12, 2, 12, 2,
+ax_anim 3, 0, 298, -12, 2, -12, 2,
+ax_anim 3, 0, 298, 13, 2, 13, 2,
+ax_anim 3, 0, 298, -13, 2, -13, 2,
+ax_anim 2, 0, 298, 12, 2, 12, 2,
+ax_anim 3, 0, 298, -12, 2, -12, 2,
+ax_anim 2, 0, 298, 10, 2, 10, 2,
+ax_anim 2, 0, 298, -10, 2, -10, 2,
+ax_anim 2, 0, 298, 6, 2, 6, 2,
+ax_anim 2, 0, 298, -6, 2, -6, 2,
+ax_anim 2, 0, 298, 0, 2, 0, 2,
+ax_anim_terminator
+sLileepAnims_10_2:
+ax_anim 2, 0, 299, 2, 2, 2, 2,
+ax_anim 2, 0, 299, 8, -4, 8, -4,
+ax_anim 2, 0, 299, -4, 8, -4, 8,
+ax_anim 2, 0, 299, 12, -8, 12, -8,
+ax_anim 2, 0, 299, -8, 12, -8, 12,
+ax_anim 2, 0, 299, 14, -10, 14, -10,
+ax_anim 3, 0, 299, -10, 14, -10, 14,
+ax_anim 3, 0, 299, 15, -11, 15, -11,
+ax_anim 3, 0, 299, -11, 15, -11, 15,
+ax_anim 2, 0, 299, 14, -10, 14, -10,
+ax_anim 3, 0, 299, -10, 14, -10, 14,
+ax_anim 2, 0, 299, 12, -8, 12, -8,
+ax_anim 2, 0, 299, -8, 12, -8, 12,
+ax_anim 2, 0, 299, 8, -4, 8, -4,
+ax_anim 2, 0, 299, -4, 8, -4, 8,
+ax_anim 2, 0, 299, 2, 2, 2, 2,
+ax_anim_terminator
+sLileepAnims_10_3:
+ax_anim 2, 0, 300, 3, 0, 3, 0,
+ax_anim 2, 0, 300, 3, -6, 3, -6,
+ax_anim 2, 0, 300, 3, 6, 3, 6,
+ax_anim 2, 0, 300, 3, -10, 3, -10,
+ax_anim 2, 0, 300, 3, 10, 3, 10,
+ax_anim 2, 0, 300, 3, -12, 3, -12,
+ax_anim 3, 0, 300, 3, 12, 3, 12,
+ax_anim 3, 0, 300, 3, -13, 3, -13,
+ax_anim 3, 0, 300, 3, 13, 3, 13,
+ax_anim 2, 0, 300, 3, -12, 3, -12,
+ax_anim 3, 0, 300, 3, 12, 3, 12,
+ax_anim 2, 0, 300, 3, -10, 3, -10,
+ax_anim 2, 0, 300, 3, 10, 3, 10,
+ax_anim 2, 0, 300, 3, -6, 3, -6,
+ax_anim 2, 0, 300, 3, 6, 3, 6,
+ax_anim 2, 0, 300, 3, 0, 3, 0,
+ax_anim_terminator
+sLileepAnims_10_4:
+ax_anim 2, 0, 301, 2, -2, 2, -2,
+ax_anim 2, 0, 301, -4, -8, -4, -8,
+ax_anim 2, 0, 301, 8, 4, 8, 4,
+ax_anim 2, 0, 301, -8, -12, -8, -12,
+ax_anim 2, 0, 301, 12, 8, 12, 8,
+ax_anim 2, 0, 301, -10, -14, -10, -14,
+ax_anim 3, 0, 301, 14, 10, 14, 10,
+ax_anim 3, 0, 301, -11, -15, -11, -15,
+ax_anim 3, 0, 301, 15, 11, 15, 11,
+ax_anim 2, 0, 301, -10, -14, -10, -14,
+ax_anim 3, 0, 301, 14, 10, 14, 10,
+ax_anim 2, 0, 301, -8, -12, -8, -12,
+ax_anim 2, 0, 301, 12, 8, 12, 8,
+ax_anim 2, 0, 301, -4, -8, -4, -8,
+ax_anim 2, 0, 301, 8, 4, 8, 4,
+ax_anim 2, 0, 301, 2, -2, 2, -2,
+ax_anim_terminator
+sLileepAnims_10_5:
+ax_anim 2, 0, 302, 0, -3, 0, -3,
+ax_anim 2, 0, 302, 6, -3, 6, -3,
+ax_anim 2, 0, 302, -6, -3, -6, -3,
+ax_anim 2, 0, 302, 10, -3, 10, -3,
+ax_anim 2, 0, 302, -10, -3, -10, -3,
+ax_anim 2, 0, 302, 12, -3, 12, -3,
+ax_anim 3, 0, 302, -12, -3, -12, -3,
+ax_anim 3, 0, 302, 13, -3, 13, -3,
+ax_anim 3, 0, 302, -13, -3, -13, -3,
+ax_anim 2, 0, 302, 12, -3, 12, -3,
+ax_anim 3, 0, 302, -12, -3, -12, -3,
+ax_anim 2, 0, 302, 10, -3, 10, -3,
+ax_anim 2, 0, 302, -10, -3, -10, -3,
+ax_anim 2, 0, 302, 6, -3, 6, -3,
+ax_anim 2, 0, 302, -6, -3, -6, -3,
+ax_anim 2, 0, 302, 0, -3, 0, -3,
+ax_anim_terminator
+sLileepAnims_10_6:
+ax_anim 2, 0, 303, -2, -2, -2, -2,
+ax_anim 2, 0, 303, 4, -8, 4, -8,
+ax_anim 2, 0, 303, -8, 4, -8, 4,
+ax_anim 2, 0, 303, 8, -12, 8, -12,
+ax_anim 2, 0, 303, -12, 8, -12, 8,
+ax_anim 2, 0, 303, 10, -14, 10, -14,
+ax_anim 3, 0, 303, -14, 10, -14, 10,
+ax_anim 3, 0, 303, 11, -15, 11, -15,
+ax_anim 3, 0, 303, -15, 11, -15, 11,
+ax_anim 2, 0, 303, 10, -14, 10, -14,
+ax_anim 3, 0, 303, -14, 10, -14, 10,
+ax_anim 2, 0, 303, 8, -12, 8, -12,
+ax_anim 2, 0, 303, -12, 8, -12, 8,
+ax_anim 2, 0, 303, 4, -8, 4, -8,
+ax_anim 2, 0, 303, -8, 4, -8, 4,
+ax_anim 2, 0, 303, -2, -2, -2, -2,
+ax_anim_terminator
+sLileepAnims_10_7:
+ax_anim 2, 0, 304, -2, 0, -2, 0,
+ax_anim 2, 0, 304, -2, -6, -2, -6,
+ax_anim 2, 0, 304, -2, 6, -2, 6,
+ax_anim 2, 0, 304, -2, -10, -2, -10,
+ax_anim 2, 0, 304, -2, 10, -2, 10,
+ax_anim 2, 0, 304, -2, -12, -2, -12,
+ax_anim 3, 0, 304, -2, 12, -2, 12,
+ax_anim 3, 0, 304, -2, -13, -2, -13,
+ax_anim 3, 0, 304, -2, 13, -2, 13,
+ax_anim 2, 0, 304, -2, -12, -2, -12,
+ax_anim 3, 0, 304, -2, 12, -2, 12,
+ax_anim 2, 0, 304, -2, -10, -2, -10,
+ax_anim 2, 0, 304, -2, 10, -2, 10,
+ax_anim 2, 0, 304, -2, -6, -2, -6,
+ax_anim 2, 0, 304, -2, 6, -2, 6,
+ax_anim 2, 0, 304, -2, 0, -2, 0,
+ax_anim_terminator
+sLileepAnims_10_8:
+ax_anim 2, 0, 305, -2, 2, -2, 2,
+ax_anim 2, 0, 305, -8, -4, -8, -4,
+ax_anim 2, 0, 305, 4, 8, 4, 8,
+ax_anim 2, 0, 305, -12, -8, -12, -8,
+ax_anim 2, 0, 305, 8, 12, 8, 12,
+ax_anim 2, 0, 305, -14, -10, -14, -10,
+ax_anim 3, 0, 305, 10, 14, 10, 14,
+ax_anim 3, 0, 305, -15, -11, -15, -11,
+ax_anim 3, 0, 305, 11, 15, 11, 15,
+ax_anim 2, 0, 305, -14, -10, -14, -10,
+ax_anim 3, 0, 305, 10, 14, 10, 14,
+ax_anim 2, 0, 305, -12, -8, -12, -8,
+ax_anim 2, 0, 305, 8, 12, 8, 12,
+ax_anim 2, 0, 305, -8, -4, -8, -4,
+ax_anim 2, 0, 305, 4, 8, 4, 8,
+ax_anim 2, 0, 305, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sLileepAnims_11_1:
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 1, 0, 307, 0, -10, 0, 0,
+ax_anim 2, 0, 307, 0, -16, 0, 0,
+ax_anim 3, 0, 307, 0, -20, 0, 0,
+ax_anim 4, 0, 307, 0, -21, 0, 0,
+ax_anim 4, 0, 306, 0, -24, 0, 0,
+ax_anim 3, 0, 308, 0, -22, 0, 0,
+ax_anim 2, 0, 308, 0, -18, 0, 0,
+ax_anim 1, 0, 308, 0, -12, 0, 0,
+ax_anim 2, 2, 306, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_11_2:
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 1, 0, 310, 0, -10, 0, 0,
+ax_anim 2, 0, 310, 0, -16, 0, 0,
+ax_anim 3, 0, 310, 0, -20, 0, 0,
+ax_anim 4, 0, 310, 0, -21, 0, 0,
+ax_anim 4, 0, 309, 0, -24, 0, 0,
+ax_anim 3, 0, 311, 0, -22, 0, 0,
+ax_anim 2, 0, 311, 0, -18, 0, 0,
+ax_anim 1, 0, 311, 0, -12, 0, 0,
+ax_anim 2, 2, 309, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_11_3:
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 1, 0, 313, 0, -10, 0, 0,
+ax_anim 2, 0, 313, 0, -16, 0, 0,
+ax_anim 3, 0, 313, 0, -20, 0, 0,
+ax_anim 4, 0, 313, 0, -21, 0, 0,
+ax_anim 4, 0, 312, 0, -22, 0, 0,
+ax_anim 3, 0, 314, 0, -22, 0, 0,
+ax_anim 2, 0, 314, 0, -18, 0, 0,
+ax_anim 1, 0, 314, 0, -12, 0, 0,
+ax_anim 2, 2, 312, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_11_4:
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 1, 0, 316, 0, -10, 0, 0,
+ax_anim 2, 0, 316, 0, -16, 0, 0,
+ax_anim 3, 0, 316, 0, -20, 0, 0,
+ax_anim 4, 0, 316, 0, -21, 0, 0,
+ax_anim 4, 0, 315, 0, -22, 0, 0,
+ax_anim 3, 0, 317, 0, -21, 0, 0,
+ax_anim 2, 0, 317, 0, -17, 0, 0,
+ax_anim 1, 0, 317, 0, -11, 0, 0,
+ax_anim 2, 2, 315, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_11_5:
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 1, 0, 319, 0, -10, 0, 0,
+ax_anim 2, 0, 319, 0, -16, 0, 0,
+ax_anim 3, 0, 319, 0, -20, 0, 0,
+ax_anim 4, 0, 319, 0, -21, 0, 0,
+ax_anim 4, 0, 318, 0, -24, 0, 0,
+ax_anim 3, 0, 320, 0, -19, 0, 0,
+ax_anim 2, 0, 320, 0, -18, 0, 0,
+ax_anim 1, 0, 320, 0, -12, 0, 0,
+ax_anim 2, 2, 318, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_11_6:
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 1, 0, 322, 0, -10, 0, 0,
+ax_anim 2, 0, 322, 0, -16, 0, 0,
+ax_anim 3, 0, 322, 0, -20, 0, 0,
+ax_anim 4, 0, 322, 0, -21, 0, 0,
+ax_anim 4, 0, 321, 0, -22, 0, 0,
+ax_anim 3, 0, 323, 0, -21, 0, 0,
+ax_anim 2, 0, 323, 0, -17, 0, 0,
+ax_anim 1, 0, 323, 0, -11, 0, 0,
+ax_anim 2, 2, 321, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_11_7:
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 1, 0, 325, 0, -10, 0, 0,
+ax_anim 2, 0, 325, 0, -16, 0, 0,
+ax_anim 3, 0, 325, 0, -20, 0, 0,
+ax_anim 4, 0, 325, 0, -21, 0, 0,
+ax_anim 4, 0, 324, 0, -22, 0, 0,
+ax_anim 3, 0, 326, 0, -22, 0, 0,
+ax_anim 2, 0, 326, 0, -18, 0, 0,
+ax_anim 1, 0, 326, 0, -12, 0, 0,
+ax_anim 2, 2, 324, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_11_8:
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 1, 0, 328, 0, -10, 0, 0,
+ax_anim 2, 0, 328, 0, -16, 0, 0,
+ax_anim 3, 0, 328, 0, -20, 0, 0,
+ax_anim 4, 0, 328, 0, -21, 0, 0,
+ax_anim 4, 0, 327, 0, -24, 0, 0,
+ax_anim 3, 0, 329, 0, -22, 0, 0,
+ax_anim 2, 0, 329, 0, -18, 0, 0,
+ax_anim 1, 0, 329, 0, -12, 0, 0,
+ax_anim 2, 2, 327, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLileepAnims_12_1:
+ax_anim 2, 0, 330, 1, 0, 1, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 1, 0, 1, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 1, 0, 1, 0,
+ax_anim 2, 2, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 1, 0, 1, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 1, 0, 1, 0,
+ax_anim 2, 1, 330, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_12_2:
+ax_anim 2, 0, 337, -1, -1, -1, -1,
+ax_anim 2, 0, 337, -2, 0, -2, 0,
+ax_anim 2, 0, 337, -1, -1, -1, -1,
+ax_anim 2, 0, 337, -2, 0, -2, 0,
+ax_anim 2, 0, 337, -1, -1, -1, -1,
+ax_anim 2, 2, 337, -2, 0, -2, 0,
+ax_anim 2, 0, 337, -1, -1, -1, -1,
+ax_anim 2, 0, 337, -2, 0, -2, 0,
+ax_anim 2, 0, 337, -1, -1, -1, -1,
+ax_anim 2, 1, 337, -2, 0, -2, 0,
+ax_anim_terminator
+sLileepAnims_12_3:
+ax_anim 2, 0, 336, -2, -1, -2, -1,
+ax_anim 2, 0, 336, -2, 0, -2, 0,
+ax_anim 2, 0, 336, -2, -1, -2, -1,
+ax_anim 2, 0, 336, -2, 0, -2, 0,
+ax_anim 2, 0, 336, -2, -1, -2, -1,
+ax_anim 2, 2, 336, -2, 0, -2, 0,
+ax_anim 2, 0, 336, -2, -1, -2, -1,
+ax_anim 2, 0, 336, -2, 0, -2, 0,
+ax_anim 2, 0, 336, -2, -1, -2, -1,
+ax_anim 2, 1, 336, -2, 0, -2, 0,
+ax_anim_terminator
+sLileepAnims_12_4:
+ax_anim 2, 0, 335, -2, 0, -2, 0,
+ax_anim 2, 0, 335, -1, 1, -1, 1,
+ax_anim 2, 0, 335, -2, 0, -2, 0,
+ax_anim 2, 0, 335, -1, 1, -1, 1,
+ax_anim 2, 0, 335, -2, 0, -2, 0,
+ax_anim 2, 2, 335, -1, 1, -1, 1,
+ax_anim 2, 0, 335, -2, 0, -2, 0,
+ax_anim 2, 0, 335, -1, 1, -1, 1,
+ax_anim 2, 0, 335, -2, 0, -2, 0,
+ax_anim 2, 1, 335, -1, 1, -1, 1,
+ax_anim_terminator
+sLileepAnims_12_5:
+ax_anim 2, 0, 334, 1, -1, 1, -1,
+ax_anim 2, 0, 334, 0, -1, 0, -1,
+ax_anim 2, 0, 334, 1, -1, 1, -1,
+ax_anim 2, 0, 334, 0, -1, 0, -1,
+ax_anim 2, 0, 334, 1, -1, 1, -1,
+ax_anim 2, 2, 334, 0, -1, 0, -1,
+ax_anim 2, 0, 334, 1, -1, 1, -1,
+ax_anim 2, 0, 334, 0, -1, 0, -1,
+ax_anim 2, 0, 334, 1, -1, 1, -1,
+ax_anim 2, 1, 334, 0, -1, 0, -1,
+ax_anim_terminator
+sLileepAnims_12_6:
+ax_anim 2, 0, 333, 2, 0, 2, 0,
+ax_anim 2, 0, 333, 1, 1, 1, 1,
+ax_anim 2, 0, 333, 2, 0, 2, 0,
+ax_anim 2, 0, 333, 1, 1, 1, 1,
+ax_anim 2, 0, 333, 2, 0, 2, 0,
+ax_anim 2, 2, 333, 1, 1, 1, 1,
+ax_anim 2, 0, 333, 2, 0, 2, 0,
+ax_anim 2, 0, 333, 1, 1, 1, 1,
+ax_anim 2, 0, 333, 2, 0, 2, 0,
+ax_anim 2, 1, 333, 1, 1, 1, 1,
+ax_anim_terminator
+sLileepAnims_12_7:
+ax_anim 2, 0, 332, 2, -1, 2, -1,
+ax_anim 2, 0, 332, 2, 0, 2, 0,
+ax_anim 2, 0, 332, 2, -1, 2, -1,
+ax_anim 2, 0, 332, 2, 0, 2, 0,
+ax_anim 2, 0, 332, 2, -1, 2, -1,
+ax_anim 2, 2, 332, 2, 0, 2, 0,
+ax_anim 2, 0, 332, 2, -1, 2, -1,
+ax_anim 2, 0, 332, 2, 0, 2, 0,
+ax_anim 2, 0, 332, 2, -1, 2, -1,
+ax_anim 2, 1, 332, 2, 0, 2, 0,
+ax_anim_terminator
+sLileepAnims_12_8:
+ax_anim 2, 0, 331, 1, 0, 1, 0,
+ax_anim 2, 0, 331, 2, 1, 2, 1,
+ax_anim 2, 0, 331, 1, 0, 1, 0,
+ax_anim 2, 0, 331, 2, 1, 2, 1,
+ax_anim 2, 0, 331, 1, 0, 1, 0,
+ax_anim 2, 2, 331, 2, 1, 2, 1,
+ax_anim 2, 0, 331, 1, 0, 1, 0,
+ax_anim 2, 0, 331, 2, 1, 2, 1,
+ax_anim 2, 0, 331, 1, 0, 1, 0,
+ax_anim 2, 1, 331, 2, 1, 2, 1,
+ax_anim_terminator
+.align 2
+sLileepAnims_13_1:
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 2, 338, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_13_2:
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 2, 345, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_13_3:
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 2, 344, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_13_4:
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 2, 343, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_13_5:
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 2, 342, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_13_6:
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 2, 341, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_13_7:
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 2, 340, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepAnims_13_8:
+ax_anim 2, 0, 339, 0, 0, 0, 0,
+ax_anim 2, 0, 340, 0, 0, 0, 0,
+ax_anim 2, 0, 341, 0, 0, 0, 0,
+ax_anim 2, 0, 342, 0, 0, 0, 0,
+ax_anim 2, 0, 343, 0, 0, 0, 0,
+ax_anim 2, 0, 344, 0, 0, 0, 0,
+ax_anim 2, 0, 345, 0, 0, 0, 0,
+ax_anim 2, 0, 338, 0, 0, 0, 0,
+ax_anim 2, 2, 339, 0, 0, 0, 0,
+ax_anim_terminator
+sLileepGfx1:
+.incbin "baserom.gba", 0x14110D4, 0x200
+sLileepSprites1:
+ax_sprite sLileepGfx1, 0x200
+ax_sprite_terminator
+sLileepGfx2:
+.incbin "baserom.gba", 0x14112E4, 0x200
+sLileepSprites2:
+ax_sprite sLileepGfx2, 0x200
+ax_sprite_terminator
+sLileepGfx3:
+.incbin "baserom.gba", 0x14114F4, 0x200
+sLileepSprites3:
+ax_sprite sLileepGfx3, 0x200
+ax_sprite_terminator
+sLileepGfx4:
+.incbin "baserom.gba", 0x1411704, 0x200
+sLileepSprites4:
+ax_sprite sLileepGfx4, 0x200
+ax_sprite_terminator
+sLileepGfx5:
+.incbin "baserom.gba", 0x1411914, 0x200
+sLileepSprites5:
+ax_sprite sLileepGfx5, 0x200
+ax_sprite_terminator
+sLileepGfx6:
+.incbin "baserom.gba", 0x1411B24, 0x200
+sLileepSprites6:
+ax_sprite sLileepGfx6, 0x200
+ax_sprite_terminator
+sLileepGfx7:
+.incbin "baserom.gba", 0x1411D34, 0x200
+sLileepSprites7:
+ax_sprite sLileepGfx7, 0x200
+ax_sprite_terminator
+sLileepGfx8:
+.incbin "baserom.gba", 0x1411F44, 0x200
+sLileepSprites8:
+ax_sprite sLileepGfx8, 0x200
+ax_sprite_terminator
+sLileepGfx9:
+.incbin "baserom.gba", 0x1412154, 0x200
+sLileepSprites9:
+ax_sprite sLileepGfx9, 0x200
+ax_sprite_terminator
+sLileepGfx10:
+.incbin "baserom.gba", 0x1412364, 0x200
+sLileepSprites10:
+ax_sprite sLileepGfx10, 0x200
+ax_sprite_terminator
+sLileepGfx11:
+.incbin "baserom.gba", 0x1412574, 0x200
+sLileepSprites11:
+ax_sprite sLileepGfx11, 0x200
+ax_sprite_terminator
+sLileepGfx12:
+.incbin "baserom.gba", 0x1412784, 0x200
+sLileepSprites12:
+ax_sprite sLileepGfx12, 0x200
+ax_sprite_terminator
+sLileepGfx13:
+.incbin "baserom.gba", 0x1412994, 0x200
+sLileepSprites13:
+ax_sprite sLileepGfx13, 0x200
+ax_sprite_terminator
+sLileepGfx14:
+.incbin "baserom.gba", 0x1412BA4, 0x200
+sLileepSprites14:
+ax_sprite sLileepGfx14, 0x200
+ax_sprite_terminator
+sLileepGfx15:
+.incbin "baserom.gba", 0x1412DB4, 0x200
+sLileepSprites15:
+ax_sprite sLileepGfx15, 0x200
+ax_sprite_terminator
+sLileepGfx16:
+.incbin "baserom.gba", 0x1412FC4, 0x100
+sLileepSprites16:
+ax_sprite sLileepGfx16, 0x100
+ax_sprite_terminator
+sLileepGfx17:
+.incbin "baserom.gba", 0x14130D4, 0x80
+sLileepSprites17:
+ax_sprite sLileepGfx17, 0x80
+ax_sprite_terminator
+sLileepGfx18:
+.incbin "baserom.gba", 0x1413164, 0x100
+sLileepSprites18:
+ax_sprite sLileepGfx18, 0x100
+ax_sprite_terminator
+sLileepGfx19:
+.incbin "baserom.gba", 0x1413274, 0x40
+sLileepSprites19:
+ax_sprite sLileepGfx19, 0x40
+ax_sprite_terminator
+sLileepGfx20:
+.incbin "baserom.gba", 0x14132C4, 0x40
+sLileepGfx20_1:
+.incbin "baserom.gba", 0x1413304, 0x100
+sLileepSprites20:
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLileepGfx21:
+.incbin "baserom.gba", 0x1413434, 0x80
+sLileepSprites21:
+ax_sprite sLileepGfx21, 0x80
+ax_sprite_terminator
+sLileepGfx22:
+.incbin "baserom.gba", 0x14134C4, 0x80
+sLileepSprites22:
+ax_sprite sLileepGfx22, 0x80
+ax_sprite_terminator
+sLileepGfx23:
+.incbin "baserom.gba", 0x1413554, 0xE0
+sLileepSprites23:
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx23, 0xe0
+ax_sprite_terminator
+sLileepGfx24:
+.incbin "baserom.gba", 0x141364C, 0x40
+sLileepSprites24:
+ax_sprite sLileepGfx24, 0x40
+ax_sprite_terminator
+sLileepGfx25:
+.incbin "baserom.gba", 0x141369C, 0x40
+sLileepSprites25:
+ax_sprite sLileepGfx25, 0x40
+ax_sprite_terminator
+sLileepGfx26:
+.incbin "baserom.gba", 0x14136EC, 0x60
+sLileepGfx26_1:
+.incbin "baserom.gba", 0x141374C, 0x80
+sLileepSprites26:
+ax_sprite sLileepGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx26_1, 0x80
+ax_sprite_terminator
+sLileepGfx27:
+.incbin "baserom.gba", 0x14137EC, 0x40
+sLileepSprites27:
+ax_sprite sLileepGfx27, 0x40
+ax_sprite_terminator
+sLileepGfx28:
+.incbin "baserom.gba", 0x141383C, 0x40
+sLileepGfx28_1:
+.incbin "baserom.gba", 0x141387C, 0x60
+sLileepGfx28_2:
+.incbin "baserom.gba", 0x14138DC, 0x60
+sLileepSprites28:
+ax_sprite sLileepGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLileepGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLileepGfx29:
+.incbin "baserom.gba", 0x1413974, 0x80
+sLileepSprites29:
+ax_sprite sLileepGfx29, 0x80
+ax_sprite_terminator
+sLileepGfx30:
+.incbin "baserom.gba", 0x1413A04, 0xC0
+sLileepSprites30:
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx30, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLileepGfx31:
+.incbin "baserom.gba", 0x1413AE4, 0x60
+sLileepGfx31_1:
+.incbin "baserom.gba", 0x1413B44, 0x60
+sLileepSprites31:
+ax_sprite sLileepGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLileepGfx32:
+.incbin "baserom.gba", 0x1413BCC, 0x20
+sLileepSprites32:
+ax_sprite sLileepGfx32, 0x20
+ax_sprite_terminator
+sLileepGfx33:
+.incbin "baserom.gba", 0x1413BFC, 0x100
+sLileepSprites33:
+ax_sprite sLileepGfx33, 0x100
+ax_sprite_terminator
+sLileepGfx34:
+.incbin "baserom.gba", 0x1413D0C, 0x20
+sLileepSprites34:
+ax_sprite sLileepGfx34, 0x20
+ax_sprite_terminator
+sLileepGfx35:
+.incbin "baserom.gba", 0x1413D3C, 0x20
+sLileepGfx35_1:
+.incbin "baserom.gba", 0x1413D5C, 0x60
+sLileepGfx35_2:
+.incbin "baserom.gba", 0x1413DBC, 0x60
+sLileepSprites35:
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx35, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLileepGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLileepGfx36:
+.incbin "baserom.gba", 0x1413E5C, 0x80
+sLileepSprites36:
+ax_sprite sLileepGfx36, 0x80
+ax_sprite_terminator
+sLileepGfx37:
+.incbin "baserom.gba", 0x1413EEC, 0x40
+sLileepSprites37:
+ax_sprite sLileepGfx37, 0x40
+ax_sprite_terminator
+sLileepGfx38:
+.incbin "baserom.gba", 0x1413F3C, 0xE0
+sLileepSprites38:
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx38, 0xe0
+ax_sprite_terminator
+sLileepGfx39:
+.incbin "baserom.gba", 0x1414034, 0x40
+sLileepSprites39:
+ax_sprite sLileepGfx39, 0x40
+ax_sprite_terminator
+sLileepGfx40:
+.incbin "baserom.gba", 0x1414084, 0x60
+sLileepGfx40_1:
+.incbin "baserom.gba", 0x14140E4, 0x60
+sLileepSprites40:
+ax_sprite sLileepGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLileepGfx41:
+.incbin "baserom.gba", 0x141416C, 0x80
+sLileepSprites41:
+ax_sprite sLileepGfx41, 0x80
+ax_sprite_terminator
+sLileepGfx42:
+.incbin "baserom.gba", 0x14141FC, 0x20
+sLileepSprites42:
+ax_sprite sLileepGfx42, 0x20
+ax_sprite_terminator
+sLileepGfx43:
+.incbin "baserom.gba", 0x141422C, 0x60
+sLileepGfx43_1:
+.incbin "baserom.gba", 0x141428C, 0x60
+sLileepGfx43_2:
+.incbin "baserom.gba", 0x14142EC, 0x60
+sLileepSprites43:
+ax_sprite sLileepGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx43_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLileepGfx44:
+.incbin "baserom.gba", 0x1414384, 0x20
+sLileepGfx44_1:
+.incbin "baserom.gba", 0x14143A4, 0x80
+sLileepSprites44:
+ax_sprite 0, 0x40
+ax_sprite sLileepGfx44, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx44_1, 0x80
+ax_sprite_terminator
+sLileepGfx45:
+.incbin "baserom.gba", 0x141444C, 0x40
+sLileepGfx45_1:
+.incbin "baserom.gba", 0x141448C, 0x20
+sLileepSprites45:
+ax_sprite sLileepGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx45_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLileepGfx46:
+.incbin "baserom.gba", 0x14144D4, 0x100
+sLileepSprites46:
+ax_sprite sLileepGfx46, 0x100
+ax_sprite_terminator
+sLileepGfx47:
+.incbin "baserom.gba", 0x14145E4, 0x40
+sLileepSprites47:
+ax_sprite sLileepGfx47, 0x40
+ax_sprite_terminator
+sLileepGfx48:
+.incbin "baserom.gba", 0x1414634, 0x100
+sLileepSprites48:
+ax_sprite sLileepGfx48, 0x100
+ax_sprite_terminator
+sLileepGfx49:
+.incbin "baserom.gba", 0x1414744, 0x80
+sLileepSprites49:
+ax_sprite sLileepGfx49, 0x80
+ax_sprite_terminator
+sLileepGfx50:
+.incbin "baserom.gba", 0x14147D4, 0x60
+sLileepGfx50_1:
+.incbin "baserom.gba", 0x1414834, 0x60
+sLileepGfx50_2:
+.incbin "baserom.gba", 0x1414894, 0x60
+sLileepSprites50:
+ax_sprite sLileepGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx50_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLileepGfx51:
+.incbin "baserom.gba", 0x141492C, 0x80
+sLileepSprites51:
+ax_sprite sLileepGfx51, 0x80
+ax_sprite_terminator
+sLileepGfx52:
+.incbin "baserom.gba", 0x14149BC, 0x80
+sLileepSprites52:
+ax_sprite sLileepGfx52, 0x80
+ax_sprite_terminator
+sLileepGfx53:
+.incbin "baserom.gba", 0x1414A4C, 0x80
+sLileepSprites53:
+ax_sprite sLileepGfx53, 0x80
+ax_sprite_terminator
+sLileepGfx54:
+.incbin "baserom.gba", 0x1414ADC, 0x80
+sLileepSprites54:
+ax_sprite sLileepGfx54, 0x80
+ax_sprite_terminator
+sLileepGfx55:
+.incbin "baserom.gba", 0x1414B6C, 0x60
+sLileepGfx55_1:
+.incbin "baserom.gba", 0x1414BCC, 0x60
+sLileepSprites55:
+ax_sprite sLileepGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLileepGfx56:
+.incbin "baserom.gba", 0x1414C54, 0x40
+sLileepSprites56:
+ax_sprite sLileepGfx56, 0x40
+ax_sprite_terminator
+sLileepGfx57:
+.incbin "baserom.gba", 0x1414CA4, 0x100
+sLileepSprites57:
+ax_sprite sLileepGfx57, 0x100
+ax_sprite_terminator
+sLileepGfx58:
+.incbin "baserom.gba", 0x1414DB4, 0x40
+sLileepSprites58:
+ax_sprite sLileepGfx58, 0x40
+ax_sprite_terminator
+sLileepGfx59:
+.incbin "baserom.gba", 0x1414E04, 0x100
+sLileepSprites59:
+ax_sprite sLileepGfx59, 0x100
+ax_sprite_terminator
+sLileepGfx60:
+.incbin "baserom.gba", 0x1414F14, 0x40
+sLileepSprites60:
+ax_sprite sLileepGfx60, 0x40
+ax_sprite_terminator
+sLileepGfx61:
+.incbin "baserom.gba", 0x1414F64, 0x60
+sLileepGfx61_1:
+.incbin "baserom.gba", 0x1414FC4, 0x80
+sLileepSprites61:
+ax_sprite sLileepGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx61_1, 0x80
+ax_sprite_terminator
+sLileepGfx62:
+.incbin "baserom.gba", 0x1415064, 0x40
+sLileepSprites62:
+ax_sprite sLileepGfx62, 0x40
+ax_sprite_terminator
+sLileepGfx63:
+.incbin "baserom.gba", 0x14150B4, 0x60
+sLileepGfx63_1:
+.incbin "baserom.gba", 0x1415114, 0x80
+sLileepSprites63:
+ax_sprite sLileepGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx63_1, 0x80
+ax_sprite_terminator
+sLileepGfx64:
+.incbin "baserom.gba", 0x14151B4, 0x40
+sLileepSprites64:
+ax_sprite sLileepGfx64, 0x40
+ax_sprite_terminator
+sLileepGfx65:
+.incbin "baserom.gba", 0x1415204, 0xC0
+sLileepGfx65_1:
+.incbin "baserom.gba", 0x14152C4, 0x20
+sLileepSprites65:
+ax_sprite sLileepGfx65, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx65_1, 0x20
+ax_sprite_terminator
+sLileepGfx66:
+.incbin "baserom.gba", 0x1415304, 0x40
+sLileepSprites66:
+ax_sprite sLileepGfx66, 0x40
+ax_sprite_terminator
+sLileepGfx67:
+.incbin "baserom.gba", 0x1415354, 0x20
+sLileepSprites67:
+ax_sprite sLileepGfx67, 0x20
+ax_sprite_terminator
+sLileepGfx68:
+.incbin "baserom.gba", 0x1415384, 0x60
+sLileepGfx68_1:
+.incbin "baserom.gba", 0x14153E4, 0x60
+sLileepSprites68:
+ax_sprite sLileepGfx68, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx68_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLileepGfx69:
+.incbin "baserom.gba", 0x141546C, 0x80
+sLileepSprites69:
+ax_sprite sLileepGfx69, 0x80
+ax_sprite_terminator
+sLileepGfx70:
+.incbin "baserom.gba", 0x14154FC, 0x100
+sLileepSprites70:
+ax_sprite sLileepGfx70, 0x100
+ax_sprite_terminator
+sLileepGfx71:
+.incbin "baserom.gba", 0x141560C, 0x80
+sLileepSprites71:
+ax_sprite sLileepGfx71, 0x80
+ax_sprite_terminator
+sLileepGfx72:
+.incbin "baserom.gba", 0x141569C, 0x100
+sLileepSprites72:
+ax_sprite sLileepGfx72, 0x100
+ax_sprite_terminator
+sLileepGfx73:
+.incbin "baserom.gba", 0x14157AC, 0x80
+sLileepSprites73:
+ax_sprite sLileepGfx73, 0x80
+ax_sprite_terminator
+sLileepGfx74:
+.incbin "baserom.gba", 0x141583C, 0x100
+sLileepSprites74:
+ax_sprite sLileepGfx74, 0x100
+ax_sprite_terminator
+sLileepGfx75:
+.incbin "baserom.gba", 0x141594C, 0x80
+sLileepSprites75:
+ax_sprite sLileepGfx75, 0x80
+ax_sprite_terminator
+sLileepGfx76:
+.incbin "baserom.gba", 0x14159DC, 0x20
+sLileepSprites76:
+ax_sprite sLileepGfx76, 0x20
+ax_sprite_terminator
+sLileepGfx77:
+.incbin "baserom.gba", 0x1415A0C, 0x20
+sLileepSprites77:
+ax_sprite sLileepGfx77, 0x20
+ax_sprite_terminator
+sLileepGfx78:
+.incbin "baserom.gba", 0x1415A3C, 0x80
+sLileepSprites78:
+ax_sprite sLileepGfx78, 0x80
+ax_sprite_terminator
+sLileepGfx79:
+.incbin "baserom.gba", 0x1415ACC, 0x80
+sLileepSprites79:
+ax_sprite sLileepGfx79, 0x80
+ax_sprite_terminator
+sLileepGfx80:
+.incbin "baserom.gba", 0x1415B5C, 0x60
+sLileepGfx80_1:
+.incbin "baserom.gba", 0x1415BBC, 0xE0
+sLileepGfx80_2:
+.incbin "baserom.gba", 0x1415C9C, 0x40
+sLileepSprites80:
+ax_sprite sLileepGfx80, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx80_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sLileepGfx80_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLileepGfx81:
+.incbin "baserom.gba", 0x1415D14, 0x100
+sLileepSprites81:
+ax_sprite sLileepGfx81, 0x100
+ax_sprite_terminator
+sLileepGfx82:
+.incbin "baserom.gba", 0x1415E24, 0x80
+sLileepSprites82:
+ax_sprite sLileepGfx82, 0x80
+ax_sprite_terminator
+sLileepGfx83:
+.incbin "baserom.gba", 0x1415EB4, 0x60
+sLileepGfx83_1:
+.incbin "baserom.gba", 0x1415F14, 0xE0
+sLileepGfx83_2:
+.incbin "baserom.gba", 0x1415FF4, 0x60
+sLileepSprites83:
+ax_sprite sLileepGfx83, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx83_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLileepGfx83_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLileepGfx84:
+.incbin "baserom.gba", 0x141608C, 0x100
+sLileepSprites84:
+ax_sprite sLileepGfx84, 0x100
+ax_sprite_terminator
+sLileepGfx85:
+.incbin "baserom.gba", 0x141619C, 0x80
+sLileepSprites85:
+ax_sprite sLileepGfx85, 0x80
+ax_sprite_terminator
+sLileepGfx86:
+.incbin "baserom.gba", 0x141622C, 0x200
+sLileepSprites86:
+ax_sprite sLileepGfx86, 0x200
+ax_sprite_terminator
+sLileepGfx87:
+.incbin "baserom.gba", 0x141643C, 0x200
+sLileepSprites87:
+ax_sprite sLileepGfx87, 0x200
+ax_sprite_terminator
+sLileepGfx88:
+.incbin "baserom.gba", 0x141664C, 0x200
+sLileepSprites88:
+ax_sprite sLileepGfx88, 0x200
+ax_sprite_terminator
+sLileepGfx89:
+.incbin "baserom.gba", 0x141685C, 0x200
+sLileepSprites89:
+ax_sprite sLileepGfx89, 0x200
+ax_sprite_terminator
+sLileepGfx90:
+.incbin "baserom.gba", 0x1416A6C, 0x200
+sLileepSprites90:
+ax_sprite sLileepGfx90, 0x200
+ax_sprite_terminator
+sLileepGfx91:
+.incbin "baserom.gba", 0x1416C7C, 0x200
+sLileepSprites91:
+ax_sprite sLileepGfx91, 0x200
+ax_sprite_terminator
+sLileepGfx92:
+.incbin "baserom.gba", 0x1416E8C, 0x200
+sLileepSprites92:
+ax_sprite sLileepGfx92, 0x200
+ax_sprite_terminator
+sAxPosesLileep:
+.4byte sLileepPose1
+.4byte sLileepPose2
+.4byte sLileepPose3
+.4byte sLileepPose4
+.4byte sLileepPose5
+.4byte sLileepPose6
+.4byte sLileepPose7
+.4byte sLileepPose8
+.4byte sLileepPose9
+.4byte sLileepPose10
+.4byte sLileepPose11
+.4byte sLileepPose12
+.4byte sLileepPose13
+.4byte sLileepPose14
+.4byte sLileepPose15
+.4byte sLileepPose16
+.4byte sLileepPose17
+.4byte sLileepPose18
+.4byte sLileepPose19
+.4byte sLileepPose20
+.4byte sLileepPose21
+.4byte sLileepPose22
+.4byte sLileepPose23
+.4byte sLileepPose24
+.4byte sLileepPose25
+.4byte sLileepPose26
+.4byte sLileepPose27
+.4byte sLileepPose28
+.4byte sLileepPose29
+.4byte sLileepPose30
+.4byte sLileepPose31
+.4byte sLileepPose32
+.4byte sLileepPose33
+.4byte sLileepPose34
+.4byte sLileepPose35
+.4byte sLileepPose36
+.4byte sLileepPose37
+.4byte sLileepPose38
+.4byte sLileepPose39
+.4byte sLileepPose40
+.4byte sLileepPose41
+.4byte sLileepPose42
+.4byte sLileepPose43
+.4byte sLileepPose44
+.4byte sLileepPose45
+.4byte sLileepPose46
+.4byte sLileepPose47
+.4byte sLileepPose48
+.4byte sLileepPose49
+.4byte sLileepPose50
+.4byte sLileepPose51
+.4byte sLileepPose52
+.4byte sLileepPose53
+.4byte sLileepPose54
+.4byte sLileepPose55
+.4byte sLileepPose56
+.4byte sLileepPose57
+.4byte sLileepPose58
+.4byte sLileepPose59
+.4byte sLileepPose60
+.4byte sLileepPose61
+.4byte sLileepPose62
+.4byte sLileepPose63
+.4byte sLileepPose64
+.4byte sLileepPose65
+.4byte sLileepPose66
+.4byte sLileepPose67
+.4byte sLileepPose68
+.4byte sLileepPose69
+.4byte sLileepPose70
+.4byte sLileepPose71
+.4byte sLileepPose72
+.4byte sLileepPose73
+.4byte sLileepPose74
+.4byte sLileepPose75
+.4byte sLileepPose76
+.4byte sLileepPose77
+.4byte sLileepPose78
+.4byte sLileepPose79
+.4byte sLileepPose80
+.4byte sLileepPose81
+.4byte sLileepPose82
+.4byte sLileepPose83
+.4byte sLileepPose84
+.4byte sLileepPose85
+.4byte sLileepPose86
+.4byte sLileepPose87
+.4byte sLileepPose88
+.4byte sLileepPose89
+.4byte sLileepPose90
+.4byte sLileepPose91
+.4byte sLileepPose92
+.4byte sLileepPose93
+.4byte sLileepPose94
+.4byte sLileepPose95
+.4byte sLileepPose96
+.4byte sLileepPose97
+.4byte sLileepPose98
+.4byte sLileepPose99
+.4byte sLileepPose100
+.4byte sLileepPose101
+.4byte sLileepPose102
+.4byte sLileepPose103
+.4byte sLileepPose104
+.4byte sLileepPose105
+.4byte sLileepPose106
+.4byte sLileepPose107
+.4byte sLileepPose108
+.4byte sLileepPose109
+.4byte sLileepPose110
+.4byte sLileepPose111
+.4byte sLileepPose112
+.4byte sLileepPose113
+.4byte sLileepPose114
+.4byte sLileepPose115
+.4byte sLileepPose116
+.4byte sLileepPose117
+.4byte sLileepPose118
+.4byte sLileepPose119
+.4byte sLileepPose120
+.4byte sLileepPose121
+.4byte sLileepPose122
+.4byte sLileepPose123
+.4byte sLileepPose124
+.4byte sLileepPose125
+.4byte sLileepPose126
+.4byte sLileepPose127
+.4byte sLileepPose128
+.4byte sLileepPose129
+.4byte sLileepPose130
+.4byte sLileepPose131
+.4byte sLileepPose132
+.4byte sLileepPose133
+.4byte sLileepPose134
+.4byte sLileepPose135
+.4byte sLileepPose136
+.4byte sLileepPose137
+.4byte sLileepPose138
+.4byte sLileepPose139
+.4byte sLileepPose140
+.4byte sLileepPose141
+.4byte sLileepPose142
+.4byte sLileepPose143
+.4byte sLileepPose144
+.4byte sLileepPose145
+.4byte sLileepPose146
+.4byte sLileepPose147
+.4byte sLileepPose148
+.4byte sLileepPose149
+.4byte sLileepPose150
+.4byte sLileepPose151
+.4byte sLileepPose152
+.4byte sLileepPose153
+.4byte sLileepPose154
+.4byte sLileepPose155
+.4byte sLileepPose156
+.4byte sLileepPose157
+.4byte sLileepPose158
+.4byte sLileepPose159
+.4byte sLileepPose160
+.4byte sLileepPose161
+.4byte sLileepPose162
+.4byte sLileepPose163
+.4byte sLileepPose164
+.4byte sLileepPose165
+.4byte sLileepPose166
+.4byte sLileepPose167
+.4byte sLileepPose168
+.4byte sLileepPose169
+.4byte sLileepPose170
+.4byte sLileepPose171
+.4byte sLileepPose172
+.4byte sLileepPose173
+.4byte sLileepPose174
+.4byte sLileepPose175
+.4byte sLileepPose176
+.4byte sLileepPose177
+.4byte sLileepPose178
+.4byte sLileepPose179
+.4byte sLileepPose180
+.4byte sLileepPose181
+.4byte sLileepPose182
+.4byte sLileepPose183
+.4byte sLileepPose184
+.4byte sLileepPose185
+.4byte sLileepPose186
+.4byte sLileepPose187
+.4byte sLileepPose188
+.4byte sLileepPose189
+.4byte sLileepPose190
+.4byte sLileepPose191
+.4byte sLileepPose192
+.4byte sLileepPose193
+.4byte sLileepPose194
+.4byte sLileepPose195
+.4byte sLileepPose196
+.4byte sLileepPose197
+.4byte sLileepPose198
+.4byte sLileepPose199
+.4byte sLileepPose200
+.4byte sLileepPose201
+.4byte sLileepPose202
+.4byte sLileepPose203
+.4byte sLileepPose204
+.4byte sLileepPose205
+.4byte sLileepPose206
+.4byte sLileepPose207
+.4byte sLileepPose208
+.4byte sLileepPose209
+.4byte sLileepPose210
+.4byte sLileepPose211
+.4byte sLileepPose212
+.4byte sLileepPose213
+.4byte sLileepPose214
+.4byte sLileepPose215
+.4byte sLileepPose216
+.4byte sLileepPose217
+.4byte sLileepPose218
+.4byte sLileepPose219
+.4byte sLileepPose220
+.4byte sLileepPose221
+.4byte sLileepPose222
+.4byte sLileepPose223
+.4byte sLileepPose224
+.4byte sLileepPose225
+.4byte sLileepPose226
+.4byte sLileepPose227
+.4byte sLileepPose228
+.4byte sLileepPose229
+.4byte sLileepPose230
+.4byte sLileepPose231
+.4byte sLileepPose232
+.4byte sLileepPose233
+.4byte sLileepPose234
+.4byte sLileepPose235
+.4byte sLileepPose236
+.4byte sLileepPose237
+.4byte sLileepPose238
+.4byte sLileepPose239
+.4byte sLileepPose240
+.4byte sLileepPose241
+.4byte sLileepPose242
+.4byte sLileepPose243
+.4byte sLileepPose244
+.4byte sLileepPose245
+.4byte sLileepPose246
+.4byte sLileepPose247
+.4byte sLileepPose248
+.4byte sLileepPose249
+.4byte sLileepPose250
+.4byte sLileepPose251
+.4byte sLileepPose252
+.4byte sLileepPose253
+.4byte sLileepPose254
+.4byte sLileepPose255
+.4byte sLileepPose256
+.4byte sLileepPose257
+.4byte sLileepPose258
+.4byte sLileepPose259
+.4byte sLileepPose260
+.4byte sLileepPose261
+.4byte sLileepPose262
+.4byte sLileepPose263
+.4byte sLileepPose264
+.4byte sLileepPose265
+.4byte sLileepPose266
+.4byte sLileepPose267
+.4byte sLileepPose268
+.4byte sLileepPose269
+.4byte sLileepPose270
+.4byte sLileepPose271
+.4byte sLileepPose272
+.4byte sLileepPose273
+.4byte sLileepPose274
+.4byte sLileepPose275
+.4byte sLileepPose276
+.4byte sLileepPose277
+.4byte sLileepPose278
+.4byte sLileepPose279
+.4byte sLileepPose280
+.4byte sLileepPose281
+.4byte sLileepPose282
+.4byte sLileepPose283
+.4byte sLileepPose284
+.4byte sLileepPose285
+.4byte sLileepPose286
+.4byte sLileepPose287
+.4byte sLileepPose288
+.4byte sLileepPose289
+.4byte sLileepPose290
+.4byte sLileepPose291
+.4byte sLileepPose292
+.4byte sLileepPose293
+.4byte sLileepPose294
+.4byte sLileepPose295
+.4byte sLileepPose296
+.4byte sLileepPose297
+.4byte sLileepPose298
+.4byte sLileepPose299
+.4byte sLileepPose300
+.4byte sLileepPose301
+.4byte sLileepPose302
+.4byte sLileepPose303
+.4byte sLileepPose304
+.4byte sLileepPose305
+.4byte sLileepPose306
+.4byte sLileepPose307
+.4byte sLileepPose308
+.4byte sLileepPose309
+.4byte sLileepPose310
+.4byte sLileepPose311
+.4byte sLileepPose312
+.4byte sLileepPose313
+.4byte sLileepPose314
+.4byte sLileepPose315
+.4byte sLileepPose316
+.4byte sLileepPose317
+.4byte sLileepPose318
+.4byte sLileepPose319
+.4byte sLileepPose320
+.4byte sLileepPose321
+.4byte sLileepPose322
+.4byte sLileepPose323
+.4byte sLileepPose324
+.4byte sLileepPose325
+.4byte sLileepPose326
+.4byte sLileepPose327
+.4byte sLileepPose328
+.4byte sLileepPose329
+.4byte sLileepPose330
+.4byte sLileepPose331
+.4byte sLileepPose332
+.4byte sLileepPose333
+.4byte sLileepPose334
+.4byte sLileepPose335
+.4byte sLileepPose336
+.4byte sLileepPose337
+.4byte sLileepPose338
+.4byte sLileepPose339
+.4byte sLileepPose340
+.4byte sLileepPose341
+.4byte sLileepPose342
+.4byte sLileepPose343
+.4byte sLileepPose344
+.4byte sLileepPose345
+.4byte sLileepPose346
+sAxPositionsLileep:
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte   -2,  -14, 	  -5,    0, 	   5,    1, 	  -1,   -3
+.2byte    1,  -14, 	  -5,    0, 	   5,    1, 	   0,   -4
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte    2,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte   -2,  -13, 	   3,   -1, 	  -1,    2, 	  -1,   -2
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte    0,  -14, 	   4,   -2, 	   4,    1, 	   0,   -4
+.2byte    0,  -11, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte   -4,  -15, 	  -1,   -4, 	   5,   -1, 	   0,   -4
+.2byte    1,  -13, 	  -1,   -4, 	   5,   -1, 	   0,   -3
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    2,  -14, 	   5,   -2, 	  -6,   -2, 	   0,   -5
+.2byte   -2,  -14, 	   5,   -2, 	  -6,   -2, 	  -2,   -4
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte    3,  -15, 	   0,   -4, 	  -6,   -1, 	  -1,   -4
+.2byte   -2,  -13, 	   0,   -4, 	  -6,   -1, 	  -1,   -3
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   -1,  -14, 	  -5,   -2, 	  -5,    1, 	  -1,   -4
+.2byte   -1,  -11, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte   -3,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte    1,  -13, 	  -4,   -1, 	   0,    2, 	   0,   -2
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte    0,  -15, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -4,    0, 	   3,    0, 	   0,   -3
+.2byte    0,    3, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    0,   15, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    2,   15, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte   -2,   15, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    0,   13, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte   -9,  -13, 	   4,   -2, 	  -1,    2, 	  -4,   -8
+.2byte   12,   -6, 	   4,   -1, 	  -1,    2, 	   3,   -4
+.2byte   16,   -1, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   25,   11, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   24,   12, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   26,    8, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   23,    9, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte  -14,   -7, 	   4,   -2, 	   3,    1, 	  -3,   -4
+.2byte   13,   -7, 	   4,   -2, 	   3,    1, 	   1,   -5
+.2byte   17,   -5, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   25,   -5, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   25,   -7, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   25,   -3, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   23,   -5, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte  -13,   -5, 	  -1,   -4, 	   5,   -1, 	  -5,   -5
+.2byte    8,  -12, 	   0,   -4, 	   5,   -1, 	   3,   -7
+.2byte   13,  -16, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   23,  -26, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   22,  -27, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   24,  -25, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   21,  -24, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,   -9, 	  -6,    1, 	   4,    1, 	  -1,   -4
+.2byte    0,  -15, 	   5,   -2, 	  -5,   -2, 	   0,   -6
+.2byte   -1,  -20, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte   -1,  -29, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte   -3,  -29, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte    1,  -29, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte   -1,  -27, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte   12,   -5, 	   0,   -4, 	  -6,   -1, 	   4,   -5
+.2byte   -9,  -12, 	  -1,   -4, 	  -6,   -1, 	  -4,   -7
+.2byte  -14,  -16, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -24,  -26, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -23,  -27, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -25,  -25, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -22,  -24, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   13,   -7, 	  -5,   -2, 	  -4,    1, 	   2,   -4
+.2byte  -14,   -7, 	  -5,   -2, 	  -4,    1, 	  -2,   -5
+.2byte  -18,   -5, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -26,   -5, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -26,   -7, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -26,   -3, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -24,   -5, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte    8,  -13, 	  -5,   -2, 	   0,    2, 	   3,   -8
+.2byte  -13,   -6, 	  -5,   -1, 	   0,    2, 	  -4,   -4
+.2byte  -17,   -1, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -26,   11, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -25,   12, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -27,    8, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -24,    9, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte    0,  -15, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -4,    0, 	   3,    0, 	   0,   -3
+.2byte    0,    3, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    0,   15, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    2,   15, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte   -2,   15, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    0,   13, 	  -6,   -1, 	   4,   -1, 	  -1,   -2
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte   -9,  -13, 	   4,   -2, 	  -1,    2, 	  -4,   -8
+.2byte   12,   -6, 	   4,   -1, 	  -1,    2, 	   3,   -4
+.2byte   16,   -1, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   25,   11, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   24,   12, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   26,    8, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte   23,    9, 	   2,    0, 	  -1,    2, 	   2,   -5
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte  -14,   -7, 	   4,   -2, 	   3,    1, 	  -3,   -4
+.2byte   13,   -7, 	   4,   -2, 	   3,    1, 	   1,   -5
+.2byte   17,   -5, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   25,   -5, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   25,   -7, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   25,   -3, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   23,   -5, 	   4,   -3, 	   4,    1, 	   1,   -5
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte  -13,   -5, 	  -1,   -4, 	   5,   -1, 	  -5,   -5
+.2byte    8,  -12, 	   0,   -4, 	   5,   -1, 	   3,   -7
+.2byte   13,  -16, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   23,  -26, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   22,  -27, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   24,  -25, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte   21,  -24, 	   0,   -5, 	   5,   -1, 	   1,   -6
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,   -9, 	  -6,    1, 	   4,    1, 	  -1,   -4
+.2byte    0,  -15, 	   5,   -2, 	  -5,   -2, 	   0,   -6
+.2byte   -1,  -20, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte   -1,  -29, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte   -3,  -29, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte    1,  -29, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte   -1,  -27, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte   12,   -5, 	   0,   -4, 	  -6,   -1, 	   4,   -5
+.2byte   -9,  -12, 	  -1,   -4, 	  -6,   -1, 	  -4,   -7
+.2byte  -14,  -16, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -24,  -26, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -23,  -27, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -25,  -25, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte  -22,  -24, 	  -1,   -5, 	  -6,   -1, 	  -2,   -6
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   13,   -7, 	  -5,   -2, 	  -4,    1, 	   2,   -4
+.2byte  -14,   -7, 	  -5,   -2, 	  -4,    1, 	  -2,   -5
+.2byte  -18,   -5, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -26,   -5, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -26,   -7, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -26,   -3, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -24,   -5, 	  -5,   -3, 	  -5,    1, 	  -2,   -5
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte    8,  -13, 	  -5,   -2, 	   0,    2, 	   3,   -8
+.2byte  -13,   -6, 	  -5,   -1, 	   0,    2, 	  -4,   -4
+.2byte  -17,   -1, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -26,   11, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -25,   12, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -27,    8, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte  -24,    9, 	  -3,    0, 	   0,    2, 	  -3,   -5
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte    0,   -6, 	  -4,    0, 	   3,    0, 	   0,   -3
+.2byte    0,   -5, 	  -3,    0, 	   2,    0, 	  -1,   -2
+.2byte    0,  -15, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -4,    0, 	   3,    0, 	   0,   -3
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte   12,   -6, 	   3,   -1, 	  -1,    2, 	   3,   -3
+.2byte   12,   -5, 	   4,   -1, 	  -1,    2, 	   4,   -3
+.2byte   -9,  -13, 	   4,   -2, 	  -1,    2, 	  -4,   -8
+.2byte   12,   -6, 	   4,   -1, 	  -1,    2, 	   3,   -4
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte   13,   -7, 	   4,   -2, 	   4,    1, 	   1,   -5
+.2byte   14,   -6, 	   4,   -2, 	   4,    1, 	   2,   -4
+.2byte  -14,   -7, 	   4,   -2, 	   3,    1, 	  -3,   -4
+.2byte   13,   -7, 	   4,   -2, 	   3,    1, 	   1,   -5
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte    9,  -12, 	  -1,   -4, 	   5,   -1, 	   2,   -6
+.2byte    9,   -9, 	   0,   -4, 	   5,   -1, 	   2,   -6
+.2byte  -13,   -5, 	  -1,   -4, 	   5,   -1, 	  -5,   -5
+.2byte    8,  -12, 	   0,   -4, 	   5,   -1, 	   3,   -7
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	   0,   -6
+.2byte   -1,  -14, 	   5,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    0,   -9, 	  -6,    1, 	   4,    1, 	  -1,   -4
+.2byte    0,  -15, 	   5,   -2, 	  -5,   -2, 	   0,   -6
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte  -10,  -12, 	   0,   -4, 	  -6,   -1, 	  -3,   -6
+.2byte  -10,   -9, 	  -1,   -4, 	  -6,   -1, 	  -3,   -6
+.2byte   12,   -5, 	   0,   -4, 	  -6,   -1, 	   4,   -5
+.2byte   -9,  -12, 	  -1,   -4, 	  -6,   -1, 	  -4,   -7
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte  -14,   -7, 	  -5,   -2, 	  -5,    1, 	  -2,   -5
+.2byte  -15,   -6, 	  -5,   -2, 	  -5,    1, 	  -3,   -4
+.2byte   13,   -7, 	  -5,   -2, 	  -4,    1, 	   2,   -4
+.2byte  -14,   -7, 	  -5,   -2, 	  -4,    1, 	  -2,   -5
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte  -13,   -6, 	  -4,   -1, 	   0,    2, 	  -4,   -3
+.2byte  -13,   -5, 	  -5,   -1, 	   0,    2, 	  -5,   -3
+.2byte    8,  -13, 	  -5,   -2, 	   0,    2, 	   3,   -8
+.2byte  -13,   -6, 	  -5,   -1, 	   0,    2, 	  -4,   -4
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte    0,  -15, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -4,    0, 	   3,    0, 	   0,   -3
+.2byte   -1,  -17, 	  -5,    1, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	  -5,    1, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	  -5,    1, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	  -5,    1, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	  -5,    1, 	   4,    1, 	   0,   -6
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte   -9,  -13, 	   4,   -2, 	  -1,    2, 	  -4,   -8
+.2byte   12,   -6, 	   4,   -1, 	  -1,    2, 	   3,   -4
+.2byte    0,  -17, 	   4,   -1, 	  -1,    2, 	   0,   -5
+.2byte    0,  -17, 	   4,   -1, 	  -1,    2, 	   0,   -5
+.2byte    0,  -17, 	   4,   -1, 	  -1,    2, 	   0,   -5
+.2byte    0,  -17, 	   4,   -1, 	  -1,    2, 	   0,   -5
+.2byte    0,  -17, 	   4,   -1, 	  -1,    2, 	   0,   -5
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte  -14,   -7, 	   4,   -2, 	   3,    1, 	  -3,   -4
+.2byte   13,   -7, 	   4,   -2, 	   3,    1, 	   1,   -5
+.2byte   -1,  -17, 	   4,   -2, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	   4,   -2, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	   4,   -2, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	   4,   -2, 	   4,    1, 	   0,   -6
+.2byte   -1,  -17, 	   4,   -2, 	   4,    1, 	   0,   -6
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte  -13,   -5, 	  -1,   -4, 	   5,   -1, 	  -5,   -5
+.2byte    8,  -12, 	   0,   -4, 	   5,   -1, 	   3,   -7
+.2byte   -1,  -17, 	  -1,   -5, 	   5,   -1, 	  -1,   -6
+.2byte   -1,  -17, 	  -1,   -5, 	   5,   -1, 	  -1,   -6
+.2byte   -1,  -17, 	  -1,   -5, 	   5,   -1, 	  -1,   -6
+.2byte   -1,  -17, 	  -1,   -5, 	   5,   -1, 	  -1,   -6
+.2byte   -1,  -17, 	  -1,   -5, 	   5,   -1, 	  -1,   -6
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,   -9, 	  -6,    1, 	   4,    1, 	  -1,   -4
+.2byte    0,  -15, 	   5,   -2, 	  -5,   -2, 	   0,   -6
+.2byte    0,  -17, 	   5,   -2, 	  -6,   -2, 	   0,   -6
+.2byte    0,  -17, 	   5,   -2, 	  -6,   -2, 	   0,   -6
+.2byte    0,  -17, 	   5,   -2, 	  -6,   -2, 	   0,   -6
+.2byte    0,  -17, 	   5,   -2, 	  -6,   -2, 	   0,   -6
+.2byte    0,  -17, 	   5,   -2, 	  -6,   -2, 	   0,   -6
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte   12,   -5, 	   0,   -4, 	  -6,   -1, 	   4,   -5
+.2byte   -9,  -12, 	  -1,   -4, 	  -6,   -1, 	  -4,   -7
+.2byte    0,  -17, 	   0,   -5, 	  -6,   -1, 	   0,   -6
+.2byte    0,  -17, 	   0,   -5, 	  -6,   -1, 	   0,   -6
+.2byte    0,  -17, 	   0,   -5, 	  -6,   -1, 	   0,   -6
+.2byte    0,  -17, 	   0,   -5, 	  -6,   -1, 	   0,   -6
+.2byte    0,  -17, 	   0,   -5, 	  -6,   -1, 	   0,   -6
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   13,   -7, 	  -5,   -2, 	  -4,    1, 	   2,   -4
+.2byte  -14,   -7, 	  -5,   -2, 	  -4,    1, 	  -2,   -5
+.2byte    0,  -17, 	  -5,   -2, 	  -5,    1, 	  -1,   -6
+.2byte    0,  -17, 	  -5,   -2, 	  -5,    1, 	  -1,   -6
+.2byte    0,  -17, 	  -5,   -2, 	  -5,    1, 	  -1,   -6
+.2byte    0,  -17, 	  -5,   -2, 	  -5,    1, 	  -1,   -6
+.2byte    0,  -17, 	  -5,   -2, 	  -5,    1, 	  -1,   -6
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte    8,  -13, 	  -5,   -2, 	   0,    2, 	   3,   -8
+.2byte  -13,   -6, 	  -5,   -1, 	   0,    2, 	  -4,   -4
+.2byte   -1,  -17, 	  -5,   -1, 	   0,    2, 	  -1,   -5
+.2byte   -1,  -17, 	  -5,   -1, 	   0,    2, 	  -1,   -5
+.2byte   -1,  -17, 	  -5,   -1, 	   0,    2, 	  -1,   -5
+.2byte   -1,  -17, 	  -5,   -1, 	   0,    2, 	  -1,   -5
+.2byte   -1,  -17, 	  -5,   -1, 	   0,    2, 	  -1,   -5
+.2byte    0,  -13, 	  -6,    0, 	   5,    0, 	  -1,   -3
+.2byte    0,  -15, 	  -6,    0, 	   5,    0, 	  -1,   -4
+.2byte    0,  -17, 	  -5,   -1, 	   5,   -1, 	  -1,   -6
+.2byte   -8,  -15, 	   6,   -6, 	   0,   -4, 	  -1,   -8
+.2byte   -7,  -13, 	   4,   -7, 	   6,   -5, 	   0,   -7
+.2byte   -6,  -11, 	   2,   -5, 	   6,   -5, 	   0,   -6
+.2byte    0,  -12, 	   4,   -2, 	  -3,   -2, 	   0,   -4
+.2byte    5,  -11, 	  -3,   -5, 	  -7,   -5, 	  -1,   -6
+.2byte    7,  -13, 	  -4,   -7, 	  -6,   -5, 	   0,   -7
+.2byte    7,  -15, 	  -7,   -6, 	  -1,   -4, 	   0,   -8
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte   -2,  -14, 	  -5,    0, 	   5,    1, 	  -1,   -3
+.2byte    1,  -14, 	  -5,    0, 	   5,    1, 	   0,   -4
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte    2,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte   -2,  -13, 	   3,   -1, 	  -1,    2, 	  -1,   -2
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte    0,  -14, 	   4,   -2, 	   4,    1, 	   0,   -4
+.2byte    0,  -11, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte   -4,  -15, 	  -1,   -4, 	   5,   -1, 	   0,   -4
+.2byte    1,  -13, 	  -1,   -4, 	   5,   -1, 	   0,   -3
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    2,  -14, 	   5,   -2, 	  -6,   -2, 	   0,   -5
+.2byte   -2,  -14, 	   5,   -2, 	  -6,   -2, 	  -2,   -4
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte    3,  -15, 	   0,   -4, 	  -6,   -1, 	  -1,   -4
+.2byte   -2,  -13, 	   0,   -4, 	  -6,   -1, 	  -1,   -3
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   -1,  -14, 	  -5,   -2, 	  -5,    1, 	  -1,   -4
+.2byte   -1,  -11, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte   -3,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte    1,  -13, 	  -4,   -1, 	   0,    2, 	   0,   -2
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte    0,   -6, 	  -4,    0, 	   3,    0, 	   0,   -3
+.2byte   10,   -8, 	   2,   -3, 	  -3,    0, 	   1,   -6
+.2byte   10,   -7, 	   1,   -2, 	   0,    1, 	  -2,   -5
+.2byte    6,  -10, 	  -2,   -2, 	   3,    1, 	   1,   -5
+.2byte    0,  -13, 	   5,    0, 	  -5,    0, 	   0,   -4
+.2byte   -7,  -10, 	   1,   -2, 	  -4,    1, 	  -2,   -5
+.2byte  -11,   -7, 	  -2,   -2, 	  -1,    1, 	   1,   -5
+.2byte  -11,   -8, 	  -3,   -3, 	   2,    0, 	  -2,   -6
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte    0,  -15, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -4,    0, 	   3,    0, 	   0,   -3
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+.2byte   -6,  -13, 	   7,   -2, 	   2,    2, 	  -1,   -8
+.2byte    9,   -6, 	   1,   -1, 	  -4,    2, 	   0,   -4
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte  -11,   -7, 	   7,   -2, 	   6,    1, 	   0,   -4
+.2byte   10,   -7, 	   1,   -2, 	   0,    1, 	  -2,   -5
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte  -11,   -5, 	   1,   -4, 	   7,   -1, 	  -3,   -5
+.2byte    5,  -12, 	  -3,   -4, 	   2,   -1, 	   0,   -7
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,   -9, 	  -6,    1, 	   4,    1, 	  -1,   -4
+.2byte    0,  -15, 	   5,   -2, 	  -5,   -2, 	   0,   -6
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte   10,   -5, 	  -2,   -4, 	  -8,   -1, 	   2,   -5
+.2byte   -6,  -12, 	   2,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte   10,   -7, 	  -8,   -2, 	  -7,    1, 	  -1,   -4
+.2byte  -11,   -7, 	  -2,   -2, 	  -1,    1, 	   1,   -5
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte    5,  -13, 	  -8,   -2, 	  -3,    2, 	   0,   -8
+.2byte  -10,   -6, 	  -2,   -1, 	   3,    2, 	  -1,   -4
+.2byte    0,  -15, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    6,  -13, 	  -7,   -2, 	  -2,    2, 	   1,   -8
+.2byte   11,   -7, 	  -7,   -2, 	  -6,    1, 	   0,   -4
+.2byte   10,   -5, 	  -2,   -4, 	  -8,   -1, 	   2,   -5
+.2byte    0,   -9, 	  -6,    1, 	   4,    1, 	  -1,   -4
+.2byte  -11,   -5, 	   1,   -4, 	   7,   -1, 	  -3,   -5
+.2byte  -12,   -7, 	   6,   -2, 	   5,    1, 	  -1,   -4
+.2byte   -7,  -13, 	   6,   -2, 	   1,    2, 	  -2,   -8
+.2byte   -1,  -14, 	  -5,    0, 	   4,    1, 	  -1,   -3
+.2byte   -1,  -15, 	  -5,   -1, 	   0,    2, 	  -1,   -4
+.2byte   -1,  -15, 	  -5,   -2, 	  -5,    1, 	  -1,   -3
+.2byte    0,  -15, 	  -1,   -5, 	  -6,   -1, 	  -1,   -3
+.2byte    0,  -15, 	   5,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,  -15, 	   0,   -5, 	   5,   -1, 	   0,   -3
+.2byte    0,  -15, 	   4,   -2, 	   4,    1, 	   0,   -3
+.2byte    0,  -15, 	   4,   -1, 	  -1,    2, 	   0,   -4
+sLileepAnimTable1:
+.4byte sLileepAnims_1_1
+.4byte sLileepAnims_1_2
+.4byte sLileepAnims_1_3
+.4byte sLileepAnims_1_4
+.4byte sLileepAnims_1_5
+.4byte sLileepAnims_1_6
+.4byte sLileepAnims_1_7
+.4byte sLileepAnims_1_8
+sLileepAnimTable2:
+.4byte sLileepAnims_2_1
+.4byte sLileepAnims_2_2
+.4byte sLileepAnims_2_3
+.4byte sLileepAnims_2_4
+.4byte sLileepAnims_2_5
+.4byte sLileepAnims_2_6
+.4byte sLileepAnims_2_7
+.4byte sLileepAnims_2_8
+sLileepAnimTable3:
+.4byte sLileepAnims_3_1
+.4byte sLileepAnims_3_2
+.4byte sLileepAnims_3_3
+.4byte sLileepAnims_3_4
+.4byte sLileepAnims_3_5
+.4byte sLileepAnims_3_6
+.4byte sLileepAnims_3_7
+.4byte sLileepAnims_3_8
+sLileepAnimTable4:
+.4byte sLileepAnims_4_1
+.4byte sLileepAnims_4_2
+.4byte sLileepAnims_4_3
+.4byte sLileepAnims_4_4
+.4byte sLileepAnims_4_5
+.4byte sLileepAnims_4_6
+.4byte sLileepAnims_4_7
+.4byte sLileepAnims_4_8
+sLileepAnimTable5:
+.4byte sLileepAnims_5_1
+.4byte sLileepAnims_5_2
+.4byte sLileepAnims_5_3
+.4byte sLileepAnims_5_4
+.4byte sLileepAnims_5_5
+.4byte sLileepAnims_5_6
+.4byte sLileepAnims_5_7
+.4byte sLileepAnims_5_8
+sLileepAnimTable6:
+.4byte sLileepAnims_6_1
+.4byte sLileepAnims_6_1
+.4byte sLileepAnims_6_1
+.4byte sLileepAnims_6_1
+.4byte sLileepAnims_6_1
+.4byte sLileepAnims_6_1
+.4byte sLileepAnims_6_1
+.4byte sLileepAnims_6_1
+sLileepAnimTable7:
+.4byte sLileepAnims_7_1
+.4byte sLileepAnims_7_2
+.4byte sLileepAnims_7_3
+.4byte sLileepAnims_7_4
+.4byte sLileepAnims_7_5
+.4byte sLileepAnims_7_6
+.4byte sLileepAnims_7_7
+.4byte sLileepAnims_7_8
+sLileepAnimTable8:
+.4byte sLileepAnims_8_1
+.4byte sLileepAnims_8_2
+.4byte sLileepAnims_8_3
+.4byte sLileepAnims_8_4
+.4byte sLileepAnims_8_5
+.4byte sLileepAnims_8_6
+.4byte sLileepAnims_8_7
+.4byte sLileepAnims_8_8
+sLileepAnimTable9:
+.4byte sLileepAnims_9_1
+.4byte sLileepAnims_9_2
+.4byte sLileepAnims_9_3
+.4byte sLileepAnims_9_4
+.4byte sLileepAnims_9_5
+.4byte sLileepAnims_9_6
+.4byte sLileepAnims_9_7
+.4byte sLileepAnims_9_8
+sLileepAnimTable10:
+.4byte sLileepAnims_10_1
+.4byte sLileepAnims_10_2
+.4byte sLileepAnims_10_3
+.4byte sLileepAnims_10_4
+.4byte sLileepAnims_10_5
+.4byte sLileepAnims_10_6
+.4byte sLileepAnims_10_7
+.4byte sLileepAnims_10_8
+sLileepAnimTable11:
+.4byte sLileepAnims_11_1
+.4byte sLileepAnims_11_2
+.4byte sLileepAnims_11_3
+.4byte sLileepAnims_11_4
+.4byte sLileepAnims_11_5
+.4byte sLileepAnims_11_6
+.4byte sLileepAnims_11_7
+.4byte sLileepAnims_11_8
+sLileepAnimTable12:
+.4byte sLileepAnims_12_1
+.4byte sLileepAnims_12_2
+.4byte sLileepAnims_12_3
+.4byte sLileepAnims_12_4
+.4byte sLileepAnims_12_5
+.4byte sLileepAnims_12_6
+.4byte sLileepAnims_12_7
+.4byte sLileepAnims_12_8
+sLileepAnimTable13:
+.4byte sLileepAnims_13_1
+.4byte sLileepAnims_13_2
+.4byte sLileepAnims_13_3
+.4byte sLileepAnims_13_4
+.4byte sLileepAnims_13_5
+.4byte sLileepAnims_13_6
+.4byte sLileepAnims_13_7
+.4byte sLileepAnims_13_8
+sAxAnimationsLileep:
+.4byte sLileepAnimTable1
+.4byte sLileepAnimTable2
+.4byte sLileepAnimTable3
+.4byte sLileepAnimTable4
+.4byte sLileepAnimTable5
+.4byte sLileepAnimTable6
+.4byte sLileepAnimTable7
+.4byte sLileepAnimTable8
+.4byte sLileepAnimTable9
+.4byte sLileepAnimTable10
+.4byte sLileepAnimTable11
+.4byte sLileepAnimTable12
+.4byte sLileepAnimTable13
+sAxSpritesLileep:
+.4byte sLileepSprites1
+.4byte sLileepSprites2
+.4byte sLileepSprites3
+.4byte sLileepSprites4
+.4byte sLileepSprites5
+.4byte sLileepSprites6
+.4byte sLileepSprites7
+.4byte sLileepSprites8
+.4byte sLileepSprites9
+.4byte sLileepSprites10
+.4byte sLileepSprites11
+.4byte sLileepSprites12
+.4byte sLileepSprites13
+.4byte sLileepSprites14
+.4byte sLileepSprites15
+.4byte sLileepSprites16
+.4byte sLileepSprites17
+.4byte sLileepSprites18
+.4byte sLileepSprites19
+.4byte sLileepSprites20
+.4byte sLileepSprites21
+.4byte sLileepSprites22
+.4byte sLileepSprites23
+.4byte sLileepSprites24
+.4byte sLileepSprites25
+.4byte sLileepSprites26
+.4byte sLileepSprites27
+.4byte sLileepSprites28
+.4byte sLileepSprites29
+.4byte sLileepSprites30
+.4byte sLileepSprites31
+.4byte sLileepSprites32
+.4byte sLileepSprites33
+.4byte sLileepSprites34
+.4byte sLileepSprites35
+.4byte sLileepSprites36
+.4byte sLileepSprites37
+.4byte sLileepSprites38
+.4byte sLileepSprites39
+.4byte sLileepSprites40
+.4byte sLileepSprites41
+.4byte sLileepSprites42
+.4byte sLileepSprites43
+.4byte sLileepSprites44
+.4byte sLileepSprites45
+.4byte sLileepSprites46
+.4byte sLileepSprites47
+.4byte sLileepSprites48
+.4byte sLileepSprites49
+.4byte sLileepSprites50
+.4byte sLileepSprites51
+.4byte sLileepSprites52
+.4byte sLileepSprites53
+.4byte sLileepSprites54
+.4byte sLileepSprites55
+.4byte sLileepSprites56
+.4byte sLileepSprites57
+.4byte sLileepSprites58
+.4byte sLileepSprites59
+.4byte sLileepSprites60
+.4byte sLileepSprites61
+.4byte sLileepSprites62
+.4byte sLileepSprites63
+.4byte sLileepSprites64
+.4byte sLileepSprites65
+.4byte sLileepSprites66
+.4byte sLileepSprites67
+.4byte sLileepSprites68
+.4byte sLileepSprites69
+.4byte sLileepSprites70
+.4byte sLileepSprites71
+.4byte sLileepSprites72
+.4byte sLileepSprites73
+.4byte sLileepSprites74
+.4byte sLileepSprites75
+.4byte sLileepSprites76
+.4byte sLileepSprites77
+.4byte sLileepSprites78
+.4byte sLileepSprites79
+.4byte sLileepSprites80
+.4byte sLileepSprites81
+.4byte sLileepSprites82
+.4byte sLileepSprites83
+.4byte sLileepSprites84
+.4byte sLileepSprites85
+.4byte sLileepSprites86
+.4byte sLileepSprites87
+.4byte sLileepSprites88
+.4byte sLileepSprites89
+.4byte sLileepSprites90
+.4byte sLileepSprites91
+.4byte sLileepSprites92
+sAxMainLileep:
+ax_main sAxPosesLileep, sAxAnimationsLileep, 13, sAxSpritesLileep, sAxPositionsLileep

--- a/data/ax/linoone.inc
+++ b/data/ax/linoone.inc
@@ -1,0 +1,2975 @@
+.global gAxLinoone
+gAxLinoone:
+ax_siro sAxMainLinoone
+sLinoonePose1:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose2:
+ax_pose 1, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose3:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose4:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose5:
+ax_pose 4, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose6:
+ax_pose 5, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose7:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose8:
+ax_pose 7, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose9:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose10:
+ax_pose 9, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose11:
+ax_pose 10, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose12:
+ax_pose 11, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose13:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose14:
+ax_pose 13, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose15:
+ax_pose 14, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose16:
+ax_pose 9, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose17:
+ax_pose 10, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose18:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose19:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose20:
+ax_pose 7, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose22:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose23:
+ax_pose 4, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose24:
+ax_pose 5, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose25:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose26:
+ax_pose 1, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose27:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose28:
+ax_pose 15, 0x01e3, 0x80f6, 0x9c00
+ax_pose_terminator
+sLinoonePose29:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose30:
+ax_pose 4, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose31:
+ax_pose 5, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose32:
+ax_pose 16, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sLinoonePose33:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose34:
+ax_pose 7, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose35:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose36:
+ax_pose 17, 0x01e5, 0x90ec, 0x9c00
+ax_pose_terminator
+sLinoonePose37:
+ax_pose 9, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose38:
+ax_pose 10, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose39:
+ax_pose 11, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose40:
+ax_pose 18, 0x01e6, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose41:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose42:
+ax_pose 13, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose43:
+ax_pose 14, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose44:
+ax_pose 19, 0x01e9, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose45:
+ax_pose 9, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose46:
+ax_pose 10, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose47:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose48:
+ax_pose 18, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose49:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose50:
+ax_pose 7, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose51:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose52:
+ax_pose 17, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sLinoonePose53:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose54:
+ax_pose 4, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose55:
+ax_pose 5, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose56:
+ax_pose 16, 0x01e2, 0x80f3, 0x9c00
+ax_pose_terminator
+sLinoonePose57:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose58:
+ax_pose 1, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose59:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose60:
+ax_pose 15, 0x01e3, 0x80f6, 0x9c00
+ax_pose_terminator
+sLinoonePose61:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose62:
+ax_pose 4, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose63:
+ax_pose 5, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose64:
+ax_pose 16, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sLinoonePose65:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose66:
+ax_pose 7, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose67:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose68:
+ax_pose 17, 0x01e5, 0x90ec, 0x9c00
+ax_pose_terminator
+sLinoonePose69:
+ax_pose 9, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose70:
+ax_pose 10, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose71:
+ax_pose 11, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose72:
+ax_pose 18, 0x01e6, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose73:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose74:
+ax_pose 13, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose75:
+ax_pose 14, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose76:
+ax_pose 19, 0x01e9, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose77:
+ax_pose 9, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose78:
+ax_pose 10, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose79:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose80:
+ax_pose 18, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose81:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose82:
+ax_pose 7, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose83:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose84:
+ax_pose 17, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sLinoonePose85:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose86:
+ax_pose 4, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose87:
+ax_pose 5, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose88:
+ax_pose 16, 0x01e2, 0x80f3, 0x9c00
+ax_pose_terminator
+sLinoonePose89:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose90:
+ax_pose 1, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose91:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose92:
+ax_pose 20, 0x01ee, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose93:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose94:
+ax_pose 4, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose95:
+ax_pose 5, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose96:
+ax_pose 21, 0x01e9, 0x90f1, 0x9c00
+ax_pose_terminator
+sLinoonePose97:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose98:
+ax_pose 7, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose99:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose100:
+ax_pose 22, 0x01e6, 0x90f5, 0x9c00
+ax_pose_terminator
+sLinoonePose101:
+ax_pose 9, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose102:
+ax_pose 10, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose103:
+ax_pose 11, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose104:
+ax_pose 23, 0x01e6, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose105:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose106:
+ax_pose 13, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose107:
+ax_pose 14, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose108:
+ax_pose 24, 0x01e9, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose109:
+ax_pose 9, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose110:
+ax_pose 10, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose111:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose112:
+ax_pose 23, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose113:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose114:
+ax_pose 7, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose115:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose116:
+ax_pose 22, 0x01e6, 0x80eb, 0x9c00
+ax_pose_terminator
+sLinoonePose117:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose118:
+ax_pose 4, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose119:
+ax_pose 5, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose120:
+ax_pose 21, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sLinoonePose121:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose122:
+ax_pose 1, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose123:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose124:
+ax_pose 15, 0x01e6, 0x80f6, 0x9c00
+ax_pose_terminator
+sLinoonePose125:
+ax_pose 25, 0x01e5, 0x80f6, 0x9c00
+ax_pose_terminator
+sLinoonePose126:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose127:
+ax_pose 4, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose128:
+ax_pose 5, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose129:
+ax_pose 16, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sLinoonePose130:
+ax_pose 26, 0x01e5, 0x90ee, 0x9c00
+ax_pose_terminator
+sLinoonePose131:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose132:
+ax_pose 7, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose133:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose134:
+ax_pose 17, 0x01e5, 0x90ed, 0x9c00
+ax_pose_terminator
+sLinoonePose135:
+ax_pose 27, 0x01e3, 0x90f3, 0x9c00
+ax_pose_terminator
+sLinoonePose136:
+ax_pose 9, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose137:
+ax_pose 10, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose138:
+ax_pose 11, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose139:
+ax_pose 18, 0x01e6, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose140:
+ax_pose 28, 0x01e5, 0x90f2, 0x9c00
+ax_pose_terminator
+sLinoonePose141:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose142:
+ax_pose 13, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose143:
+ax_pose 14, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose144:
+ax_pose 19, 0x01e7, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose145:
+ax_pose 29, 0x01e5, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose146:
+ax_pose 9, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose147:
+ax_pose 10, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose148:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose149:
+ax_pose 18, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose150:
+ax_pose 28, 0x01e5, 0x80ee, 0x9c00
+ax_pose_terminator
+sLinoonePose151:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose152:
+ax_pose 7, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose153:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose154:
+ax_pose 17, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sLinoonePose155:
+ax_pose 27, 0x01e3, 0x80ed, 0x9c00
+ax_pose_terminator
+sLinoonePose156:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose157:
+ax_pose 4, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose158:
+ax_pose 5, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose159:
+ax_pose 16, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sLinoonePose160:
+ax_pose 26, 0x01e5, 0x80f2, 0x9c00
+ax_pose_terminator
+sLinoonePose161:
+ax_pose 30, 0x01ea, 0x80f2, 0x9c00
+ax_pose_terminator
+sLinoonePose162:
+ax_pose 31, 0x01ea, 0x80f2, 0x9c00
+ax_pose_terminator
+sLinoonePose163:
+ax_pose 32, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose164:
+ax_pose 33, 0x01ea, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose165:
+ax_pose 34, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose166:
+ax_pose 35, 0x01ea, 0x90ee, 0x9c00
+ax_pose_terminator
+sLinoonePose167:
+ax_pose 36, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose168:
+ax_pose 35, 0x01ea, 0x80f2, 0x9c00
+ax_pose_terminator
+sLinoonePose169:
+ax_pose 34, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose170:
+ax_pose 33, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose171:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose172:
+ax_pose 1, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose173:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose174:
+ax_pose 20, 0x01ee, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose175:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose176:
+ax_pose 4, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose177:
+ax_pose 5, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose178:
+ax_pose 21, 0x01e9, 0x90f1, 0x9c00
+ax_pose_terminator
+sLinoonePose179:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose180:
+ax_pose 7, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose181:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose182:
+ax_pose 22, 0x01e6, 0x90f5, 0x9c00
+ax_pose_terminator
+sLinoonePose183:
+ax_pose 9, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose184:
+ax_pose 10, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose185:
+ax_pose 11, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose186:
+ax_pose 23, 0x01e6, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose187:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose188:
+ax_pose 13, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose189:
+ax_pose 14, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose190:
+ax_pose 24, 0x01e9, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose191:
+ax_pose 9, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose192:
+ax_pose 10, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose193:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose194:
+ax_pose 23, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose195:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose196:
+ax_pose 7, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose197:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose198:
+ax_pose 22, 0x01e6, 0x80eb, 0x9c00
+ax_pose_terminator
+sLinoonePose199:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose200:
+ax_pose 4, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose201:
+ax_pose 5, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose202:
+ax_pose 21, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sLinoonePose203:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose204:
+ax_pose 5, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose205:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose206:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose207:
+ax_pose 14, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose208:
+ax_pose 11, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose209:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose210:
+ax_pose 5, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose211:
+ax_pose 25, 0x01e5, 0x80f6, 0x9c00
+ax_pose_terminator
+sLinoonePose212:
+ax_pose 26, 0x01e5, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose213:
+ax_pose 27, 0x01e3, 0x90f5, 0x9c00
+ax_pose_terminator
+sLinoonePose214:
+ax_pose 28, 0x01e5, 0x90f3, 0x9c00
+ax_pose_terminator
+sLinoonePose215:
+ax_pose 29, 0x01e4, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose216:
+ax_pose 28, 0x01e5, 0x80ec, 0x9c00
+ax_pose_terminator
+sLinoonePose217:
+ax_pose 27, 0x01e3, 0x80eb, 0x9c00
+ax_pose_terminator
+sLinoonePose218:
+ax_pose 26, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose219:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose220:
+ax_pose 1, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose221:
+ax_pose 2, 0x81e9, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose222:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose223:
+ax_pose 4, 0x41f1, 0x90ee, 0x9c00
+ax_pose_terminator
+sLinoonePose224:
+ax_pose 5, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sLinoonePose225:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose226:
+ax_pose 7, 0x41f1, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose227:
+ax_pose 8, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose228:
+ax_pose 9, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose229:
+ax_pose 10, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose230:
+ax_pose 11, 0x01ec, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose231:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose232:
+ax_pose 13, 0x81ea, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose233:
+ax_pose 14, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose234:
+ax_pose 9, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose235:
+ax_pose 10, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose236:
+ax_pose 11, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose237:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose238:
+ax_pose 7, 0x41f1, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose239:
+ax_pose 8, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose240:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose241:
+ax_pose 4, 0x41f1, 0x80f2, 0x9c00
+ax_pose_terminator
+sLinoonePose242:
+ax_pose 5, 0x01ea, 0x80f1, 0x9c00
+ax_pose_terminator
+sLinoonePose243:
+ax_pose 15, 0x01e4, 0x80f6, 0x9c00
+ax_pose_terminator
+sLinoonePose244:
+ax_pose 16, 0x01e5, 0x80f1, 0x9c00
+ax_pose_terminator
+sLinoonePose245:
+ax_pose 17, 0x01e5, 0x80f1, 0x9c00
+ax_pose_terminator
+sLinoonePose246:
+ax_pose 18, 0x01e5, 0x80ef, 0x9c00
+ax_pose_terminator
+sLinoonePose247:
+ax_pose 19, 0x01e4, 0x80f7, 0x9c00
+ax_pose_terminator
+sLinoonePose248:
+ax_pose 18, 0x01e5, 0x90f1, 0x9c00
+ax_pose_terminator
+sLinoonePose249:
+ax_pose 17, 0x01e5, 0x90ee, 0x9c00
+ax_pose_terminator
+sLinoonePose250:
+ax_pose 16, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sLinoonePose251:
+ax_pose 0, 0x81eb, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose252:
+ax_pose 3, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose253:
+ax_pose 6, 0x41f3, 0x80f0, 0x9c00
+ax_pose_terminator
+sLinoonePose254:
+ax_pose 9, 0x01ed, 0x80f1, 0x9c00
+ax_pose_terminator
+sLinoonePose255:
+ax_pose 12, 0x81ef, 0x80f8, 0x9c00
+ax_pose_terminator
+sLinoonePose256:
+ax_pose 9, 0x01ed, 0x90ef, 0x9c00
+ax_pose_terminator
+sLinoonePose257:
+ax_pose 6, 0x41f3, 0x90f0, 0x9c00
+ax_pose_terminator
+sLinoonePose258:
+ax_pose 3, 0x01eb, 0x90f0, 0x9c00
+ax_pose_terminator
+.align 2
+sLinooneAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 3, 0, 1,
+ax_anim 6, 0, 2, 0, 0, 0, 3,
+ax_anim 6, 0, 2, 0, 2, 0, 4,
+ax_anim 6, 0, 0, 0, 2, 0, 2,
+ax_anim_terminator
+sLinooneAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 2, -1, 1, 1,
+ax_anim 6, 0, 5, 2, -2, 2, 2,
+ax_anim 6, 0, 5, 3, 0, 3, 3,
+ax_anim 6, 0, 3, 1, 1, 1, 1,
+ax_anim_terminator
+sLinooneAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, -1, 0, 0,
+ax_anim 6, 0, 7, 2, -2, 1, 0,
+ax_anim 6, 0, 8, 3, -3, 2, 0,
+ax_anim 6, 0, 8, 3, 0, 3, 0,
+ax_anim 6, 0, 6, 1, 0, 1, 0,
+ax_anim_terminator
+sLinooneAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 2, -3, 2, -2,
+ax_anim 6, 0, 11, 4, -6, 3, -3,
+ax_anim 6, 0, 11, 4, -4, 3, -3,
+ax_anim 6, 0, 9, 1, -1, 1, -1,
+ax_anim_terminator
+sLinooneAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, -1,
+ax_anim 6, 0, 14, 0, -6, 0, -2,
+ax_anim 6, 0, 14, 0, -4, 0, -3,
+ax_anim 6, 0, 12, 0, -2, 0, -1,
+ax_anim_terminator
+sLinooneAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -2, -3, -2, -2,
+ax_anim 6, 0, 17, -4, -6, -3, -3,
+ax_anim 6, 0, 17, -4, -4, -3, -3,
+ax_anim 6, 0, 15, -1, -1, -1, -1,
+ax_anim_terminator
+sLinooneAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, -1, 0, 0,
+ax_anim 6, 0, 19, -2, -2, -1, 0,
+ax_anim 6, 0, 20, -3, -3, -2, 0,
+ax_anim 6, 0, 20, -3, 0, -3, 0,
+ax_anim 6, 0, 18, -1, 0, -1, 0,
+ax_anim_terminator
+sLinooneAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -2, -1, -1, 1,
+ax_anim 6, 0, 23, -2, -2, -2, 2,
+ax_anim 6, 0, 23, -3, 0, -3, 3,
+ax_anim 6, 0, 21, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLinooneAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLinooneAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, -1,
+ax_anim 1, 2, 29, 6, 2, 6, 6,
+ax_anim 1, 0, 29, 12, 8, 12, 12,
+ax_anim 2, 0, 31, 23, 22, 22, 22,
+ax_anim 2, 1, 31, 24, 21, 23, 21,
+ax_anim 2, 0, 31, 23, 22, 22, 22,
+ax_anim 2, 0, 31, 24, 21, 23, 21,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sLinooneAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 2, -2, 2, 0,
+ax_anim 1, 2, 33, 6, -5, 6, 0,
+ax_anim 1, 0, 33, 10, -5, 10, 0,
+ax_anim 2, 0, 35, 22, -1, 22, -1,
+ax_anim 2, 1, 35, 22, 0, 22, 0,
+ax_anim 2, 0, 35, 22, -1, 22, -1,
+ax_anim 2, 0, 35, 22, 0, 22, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sLinooneAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -4, 1, -1,
+ax_anim 1, 2, 37, 4, -10, 4, -4,
+ax_anim 1, 0, 37, 10, -17, 10, -10,
+ax_anim 2, 0, 39, 22, -23, 22, -23,
+ax_anim 2, 1, 39, 23, -22, 23, -22,
+ax_anim 2, 0, 39, 22, -23, 22, -23,
+ax_anim 2, 0, 39, 23, -22, 23, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sLinooneAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, -4, 0, -1,
+ax_anim 1, 2, 41, 0, -11, 0, -6,
+ax_anim 1, 0, 41, 0, -15, 0, -13,
+ax_anim 2, 0, 43, 0, -25, 0, -25,
+ax_anim 2, 1, 43, 1, -25, 1, -25,
+ax_anim 2, 0, 43, 0, -25, 0, -25,
+ax_anim 2, 0, 43, 1, -25, 1, -25,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sLinooneAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -4, -1, -1,
+ax_anim 1, 2, 45, -4, -10, -4, -4,
+ax_anim 1, 0, 45, -10, -17, -10, -10,
+ax_anim 2, 0, 47, -22, -23, -22, -23,
+ax_anim 2, 1, 47, -23, -22, -23, -22,
+ax_anim 2, 0, 47, -22, -23, -22, -23,
+ax_anim 2, 0, 47, -23, -22, -23, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sLinooneAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, -2, -2, -2, 0,
+ax_anim 1, 2, 49, -6, -5, -6, 0,
+ax_anim 1, 0, 49, -10, -5, -10, 0,
+ax_anim 2, 0, 51, -22, -1, -22, -1,
+ax_anim 2, 1, 51, -22, 0, -22, 0,
+ax_anim 2, 0, 51, -22, -1, -22, -1,
+ax_anim 2, 0, 51, -22, 0, -22, 0,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sLinooneAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, -1,
+ax_anim 1, 2, 53, -6, 2, -6, 6,
+ax_anim 1, 0, 53, -12, 8, -12, 12,
+ax_anim 2, 0, 55, -23, 22, -22, 22,
+ax_anim 2, 1, 55, -24, 21, -23, 21,
+ax_anim 2, 0, 55, -23, 22, -22, 22,
+ax_anim 2, 0, 55, -24, 21, -23, 21,
+ax_anim 2, 0, 52, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sLinooneAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 1, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 0, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sLinooneAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, -1, 0, -1,
+ax_anim 1, 2, 61, 6, 2, 6, 6,
+ax_anim 1, 0, 61, 12, 8, 12, 12,
+ax_anim 2, 0, 63, 23, 22, 22, 22,
+ax_anim 2, 1, 63, 24, 21, 23, 21,
+ax_anim 2, 0, 63, 23, 22, 22, 22,
+ax_anim 2, 0, 63, 24, 21, 23, 21,
+ax_anim 2, 0, 60, 8, 8, 8, 8,
+ax_anim_terminator
+sLinooneAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 2, -2, 2, 0,
+ax_anim 1, 2, 65, 6, -5, 6, 0,
+ax_anim 1, 0, 65, 10, -5, 10, 0,
+ax_anim 2, 0, 67, 22, -1, 22, -1,
+ax_anim 2, 1, 67, 22, 0, 22, 0,
+ax_anim 2, 0, 67, 22, -1, 22, -1,
+ax_anim 2, 0, 67, 22, 0, 22, 0,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sLinooneAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -4, 1, -1,
+ax_anim 1, 2, 69, 4, -10, 4, -4,
+ax_anim 1, 0, 69, 10, -17, 10, -10,
+ax_anim 2, 0, 71, 22, -23, 22, -23,
+ax_anim 2, 1, 71, 23, -22, 23, -22,
+ax_anim 2, 0, 71, 22, -23, 22, -23,
+ax_anim 2, 0, 71, 23, -22, 23, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sLinooneAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, -4, 0, -1,
+ax_anim 1, 2, 73, 0, -11, 0, -6,
+ax_anim 1, 0, 73, 0, -15, 0, -13,
+ax_anim 2, 0, 75, 0, -25, 0, -25,
+ax_anim 2, 1, 75, 1, -25, 1, -25,
+ax_anim 2, 0, 75, 0, -25, 0, -25,
+ax_anim 2, 0, 75, 1, -25, 1, -25,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sLinooneAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -4, -1, -1,
+ax_anim 1, 2, 77, -4, -10, -4, -4,
+ax_anim 1, 0, 77, -10, -17, -10, -10,
+ax_anim 2, 0, 79, -22, -23, -22, -23,
+ax_anim 2, 1, 79, -23, -22, -23, -22,
+ax_anim 2, 0, 79, -22, -23, -22, -23,
+ax_anim 2, 0, 79, -23, -22, -23, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sLinooneAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, -2, -2, -2, 0,
+ax_anim 1, 2, 81, -6, -5, -6, 0,
+ax_anim 1, 0, 81, -10, -5, -10, 0,
+ax_anim 2, 0, 83, -22, -1, -22, -1,
+ax_anim 2, 1, 83, -22, 0, -22, 0,
+ax_anim 2, 0, 83, -22, -1, -22, -1,
+ax_anim 2, 0, 83, -22, 0, -22, 0,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sLinooneAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, -1, 0, -1,
+ax_anim 1, 2, 85, -6, 2, -6, 6,
+ax_anim 1, 0, 85, -12, 8, -12, 12,
+ax_anim 2, 0, 87, -23, 22, -22, 22,
+ax_anim 2, 1, 87, -24, 21, -23, 21,
+ax_anim 2, 0, 87, -23, 22, -22, 22,
+ax_anim 2, 0, 87, -24, 21, -23, 21,
+ax_anim 2, 0, 84, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sLinooneAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 6, 2, 88, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 3, 0, 2,
+ax_anim_terminator
+sLinooneAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 1, 95, 2, 2, 1, 1,
+ax_anim 2, 0, 95, 3, 1, 2, 0,
+ax_anim 2, 0, 95, 2, 2, 1, 1,
+ax_anim 2, 0, 95, 3, 1, 2, 0,
+ax_anim 2, 0, 95, 2, 2, 1, 1,
+ax_anim 2, 0, 95, 3, 1, 2, 0,
+ax_anim 2, 0, 95, 2, 2, 1, 1,
+ax_anim 2, 0, 92, 2, 2, 1, 1,
+ax_anim_terminator
+sLinooneAnims_4_3:
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim 6, 2, 96, -3, 0, -3, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 1, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 99, 2, 1, 2, 1,
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 99, 2, 1, 2, 1,
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 99, 2, 1, 2, 1,
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sLinooneAnims_4_4:
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim 6, 2, 100, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 1, 103, 2, -2, 1, -1,
+ax_anim 2, 0, 103, 3, -1, 2, 0,
+ax_anim 2, 0, 103, 2, -2, 1, -1,
+ax_anim 2, 0, 103, 3, -1, 2, 0,
+ax_anim 2, 0, 103, 2, -2, 1, -1,
+ax_anim 2, 0, 103, 3, -1, 2, 0,
+ax_anim 2, 0, 103, 2, -2, 1, -1,
+ax_anim 2, 0, 100, 2, -2, 1, -1,
+ax_anim_terminator
+sLinooneAnims_4_5:
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim 6, 2, 104, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 1, 107, 0, -3, 0, -2,
+ax_anim 2, 0, 107, 1, -3, 1, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -2,
+ax_anim 2, 0, 107, 1, -3, 1, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -2,
+ax_anim 2, 0, 107, 1, -3, 1, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -2,
+ax_anim 2, 0, 104, 0, -3, 0, -2,
+ax_anim_terminator
+sLinooneAnims_4_6:
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim 6, 2, 108, 3, 3, 3, 3,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 1, 111, -2, -2, -1, -1,
+ax_anim 2, 0, 111, -3, -1, -2, 0,
+ax_anim 2, 0, 111, -2, -2, -1, -1,
+ax_anim 2, 0, 111, -3, -1, -2, 0,
+ax_anim 2, 0, 111, -2, -2, -1, -1,
+ax_anim 2, 0, 111, -3, -1, -2, 0,
+ax_anim 2, 0, 111, -2, -2, -1, -1,
+ax_anim 2, 0, 108, -2, -2, -1, -1,
+ax_anim_terminator
+sLinooneAnims_4_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 6, 2, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -2, 1, -2, 1,
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -2, 1, -2, 1,
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -2, 1, -2, 1,
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sLinooneAnims_4_8:
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim 6, 2, 116, 3, -3, 3, -3,
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -1, 1,
+ax_anim 2, 0, 119, -3, 1, -2, 0,
+ax_anim 2, 0, 119, -2, 2, -1, 1,
+ax_anim 2, 0, 119, -3, 1, -2, 0,
+ax_anim 2, 0, 119, -2, 2, -1, 1,
+ax_anim 2, 0, 119, -3, 1, -2, 0,
+ax_anim 2, 0, 119, -2, 2, -1, 1,
+ax_anim 2, 0, 116, -2, 2, -1, 1,
+ax_anim_terminator
+.align 2
+sLinooneAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -1, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 6, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 2, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_5_2:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 6, 0, 129, 0, -5, 0, 0,
+ax_anim 2, 2, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_5_3:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 6, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 2, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_5_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 6, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 2, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -4, 0, 0,
+ax_anim 6, 0, 144, 0, -5, 0, 0,
+ax_anim 2, 2, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_5_6:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, 0,
+ax_anim 2, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 0, 148, 0, -4, 0, 0,
+ax_anim 6, 0, 149, 0, -5, 0, 0,
+ax_anim 2, 2, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_5_7:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, -1, 0, 0,
+ax_anim 2, 0, 153, 0, -3, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 6, 0, 154, 0, -5, 0, 0,
+ax_anim 2, 2, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, -1,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, -1,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_5_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 2, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 0, 158, 0, -4, 0, 0,
+ax_anim 6, 0, 159, 0, -5, 0, 0,
+ax_anim 2, 2, 159, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLinooneAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLinooneAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sLinooneAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sLinooneAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sLinooneAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sLinooneAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sLinooneAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sLinooneAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sLinooneAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLinooneAnims_8_1:
+ax_anim 60, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_8_2:
+ax_anim 60, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_8_3:
+ax_anim 60, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_8_4:
+ax_anim 60, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_8_5:
+ax_anim 60, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_8_6:
+ax_anim 60, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_8_7:
+ax_anim 60, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_8_8:
+ax_anim 60, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLinooneAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 8, 2, 8, 2,
+ax_anim 2, 0, 204, 10, 11, 10, 11,
+ax_anim 2, 0, 205, 8, 18, 8, 18,
+ax_anim 3, 0, 206, 0, 21, 0, 21,
+ax_anim 2, 3, 207, -8, 18, -8, 18,
+ax_anim 2, 0, 208, -10, 11, -10, 11,
+ax_anim 1, 0, 209, -8, 3, -8, 3,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 14, 0, 14, 0,
+ax_anim 2, 0, 203, 23, 4, 23, 4,
+ax_anim 2, 0, 204, 23, 12, 23, 12,
+ax_anim 3, 0, 205, 19, 20, 19, 20,
+ax_anim 2, 3, 206, 9, 23, 9, 23,
+ax_anim 2, 0, 207, 1, 18, 1, 18,
+ax_anim 1, 0, 208, 0, 10, 0, 10,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 2, -6, 2, -6,
+ax_anim 2, 0, 202, 11, -7, 11, -7,
+ax_anim 2, 0, 203, 18, -6, 18, -6,
+ax_anim 3, 0, 204, 18, -1, 20, -1,
+ax_anim 2, 3, 205, 18, 5, 18, 5,
+ax_anim 2, 0, 206, 12, 8, 12, 8,
+ax_anim 1, 0, 207, 3, 6, 3, 6,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -10, -1, -10,
+ax_anim 2, 0, 209, 1, -19, 1, -19,
+ax_anim 2, 0, 202, 11, -21, 11, -23,
+ax_anim 3, 0, 203, 21, -21, 21, -21,
+ax_anim 2, 3, 204, 22, -13, 22, -13,
+ax_anim 2, 0, 205, 19, -2, 19, -2,
+ax_anim 1, 0, 206, 9, 4, 9, 4,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -7, -4, -7, -4,
+ax_anim 2, 0, 208, -9, -13, -9, -13,
+ax_anim 2, 0, 209, -8, -19, -8, -19,
+ax_anim 3, 0, 202, 0, -21, 0, -23,
+ax_anim 2, 3, 203, 8, -19, 8, -19,
+ax_anim 2, 0, 204, 9, -11, 9, -11,
+ax_anim 1, 0, 205, 7, -4, 7, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -10, 1, -10,
+ax_anim 2, 0, 203, -1, -19, -1, -19,
+ax_anim 2, 0, 202, -11, -21, -11, -23,
+ax_anim 3, 0, 209, -21, -21, -21, -21,
+ax_anim 2, 3, 208, -22, -13, -22, -13,
+ax_anim 2, 0, 207, -19, -2, -19, -2,
+ax_anim 1, 0, 206, -9, 4, -9, 4,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -2, -6, -2, -6,
+ax_anim 2, 0, 202, -11, -7, -11, -7,
+ax_anim 2, 0, 209, -18, -6, -18, -6,
+ax_anim 3, 0, 208, -18, -1, -20, -1,
+ax_anim 2, 3, 207, -18, 5, -18, 5,
+ax_anim 2, 0, 206, -12, 8, -12, 8,
+ax_anim 1, 0, 205, -3, 6, -3, 6,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -14, 0, -14, 0,
+ax_anim 2, 0, 209, -23, 4, -23, 4,
+ax_anim 2, 0, 208, -23, 12, -23, 12,
+ax_anim 3, 0, 207, -19, 20, -19, 20,
+ax_anim 2, 3, 206, -9, 23, -9, 23,
+ax_anim 2, 0, 205, -1, 18, -1, 18,
+ax_anim 1, 0, 204, 0, 10, 0, 10,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLinooneAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLinooneAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -24, 0, 0,
+ax_anim 3, 0, 226, 0, -21, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -23, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -24, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -24, 0, 0,
+ax_anim 3, 0, 238, 0, -21, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLinooneAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLinooneAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sLinooneGfx1:
+.incbin "baserom.gba", 0x10D8BC0, 0x100
+sLinooneSprites1:
+ax_sprite sLinooneGfx1, 0x100
+ax_sprite_terminator
+sLinooneGfx2:
+.incbin "baserom.gba", 0x10D8CD0, 0x100
+sLinooneSprites2:
+ax_sprite sLinooneGfx2, 0x100
+ax_sprite_terminator
+sLinooneGfx3:
+.incbin "baserom.gba", 0x10D8DE0, 0x100
+sLinooneSprites3:
+ax_sprite sLinooneGfx3, 0x100
+ax_sprite_terminator
+sLinooneGfx4:
+.incbin "baserom.gba", 0x10D8EF0, 0x200
+sLinooneSprites4:
+ax_sprite sLinooneGfx4, 0x200
+ax_sprite_terminator
+sLinooneGfx5:
+.incbin "baserom.gba", 0x10D9100, 0x100
+sLinooneSprites5:
+ax_sprite sLinooneGfx5, 0x100
+ax_sprite_terminator
+sLinooneGfx6:
+.incbin "baserom.gba", 0x10D9210, 0x200
+sLinooneSprites6:
+ax_sprite sLinooneGfx6, 0x200
+ax_sprite_terminator
+sLinooneGfx7:
+.incbin "baserom.gba", 0x10D9420, 0x100
+sLinooneSprites7:
+ax_sprite sLinooneGfx7, 0x100
+ax_sprite_terminator
+sLinooneGfx8:
+.incbin "baserom.gba", 0x10D9530, 0x100
+sLinooneSprites8:
+ax_sprite sLinooneGfx8, 0x100
+ax_sprite_terminator
+sLinooneGfx9:
+.incbin "baserom.gba", 0x10D9640, 0x200
+sLinooneSprites9:
+ax_sprite sLinooneGfx9, 0x200
+ax_sprite_terminator
+sLinooneGfx10:
+.incbin "baserom.gba", 0x10D9850, 0x200
+sLinooneSprites10:
+ax_sprite sLinooneGfx10, 0x200
+ax_sprite_terminator
+sLinooneGfx11:
+.incbin "baserom.gba", 0x10D9A60, 0x200
+sLinooneSprites11:
+ax_sprite sLinooneGfx11, 0x200
+ax_sprite_terminator
+sLinooneGfx12:
+.incbin "baserom.gba", 0x10D9C70, 0x200
+sLinooneSprites12:
+ax_sprite sLinooneGfx12, 0x200
+ax_sprite_terminator
+sLinooneGfx13:
+.incbin "baserom.gba", 0x10D9E80, 0x100
+sLinooneSprites13:
+ax_sprite sLinooneGfx13, 0x100
+ax_sprite_terminator
+sLinooneGfx14:
+.incbin "baserom.gba", 0x10D9F90, 0x100
+sLinooneSprites14:
+ax_sprite sLinooneGfx14, 0x100
+ax_sprite_terminator
+sLinooneGfx15:
+.incbin "baserom.gba", 0x10DA0A0, 0x100
+sLinooneSprites15:
+ax_sprite sLinooneGfx15, 0x100
+ax_sprite_terminator
+sLinooneGfx16:
+.incbin "baserom.gba", 0x10DA1B0, 0x40
+sLinooneGfx16_1:
+.incbin "baserom.gba", 0x10DA1F0, 0x60
+sLinooneGfx16_2:
+.incbin "baserom.gba", 0x10DA250, 0x60
+sLinooneSprites16:
+ax_sprite 0, 0x80
+ax_sprite sLinooneGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLinooneGfx17:
+.incbin "baserom.gba", 0x10DA2F0, 0x60
+sLinooneGfx17_1:
+.incbin "baserom.gba", 0x10DA350, 0xE0
+sLinooneSprites17:
+ax_sprite 0, 0x80
+ax_sprite sLinooneGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx17_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLinooneGfx18:
+.incbin "baserom.gba", 0x10DA460, 0x60
+sLinooneGfx18_1:
+.incbin "baserom.gba", 0x10DA4C0, 0x100
+sLinooneSprites18:
+ax_sprite 0, 0x80
+ax_sprite sLinooneGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx18_1, 0x100
+ax_sprite_terminator
+sLinooneGfx19:
+.incbin "baserom.gba", 0x10DA5E8, 0x40
+sLinooneGfx19_1:
+.incbin "baserom.gba", 0x10DA628, 0x60
+sLinooneGfx19_2:
+.incbin "baserom.gba", 0x10DA688, 0x60
+sLinooneSprites19:
+ax_sprite 0, 0xa0
+ax_sprite sLinooneGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx19_2, 0x60
+ax_sprite_terminator
+sLinooneGfx20:
+.incbin "baserom.gba", 0x10DA720, 0x40
+sLinooneGfx20_1:
+.incbin "baserom.gba", 0x10DA760, 0x40
+sLinooneGfx20_2:
+.incbin "baserom.gba", 0x10DA7A0, 0x40
+sLinooneSprites20:
+ax_sprite 0, 0x80
+ax_sprite sLinooneGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx20_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLinooneGfx21:
+.incbin "baserom.gba", 0x10DA820, 0x40
+sLinooneGfx21_1:
+.incbin "baserom.gba", 0x10DA860, 0x40
+sLinooneGfx21_2:
+.incbin "baserom.gba", 0x10DA8A0, 0x60
+sLinooneGfx21_3:
+.incbin "baserom.gba", 0x10DA900, 0x40
+sLinooneSprites21:
+ax_sprite sLinooneGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx21_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLinooneGfx22:
+.incbin "baserom.gba", 0x10DA988, 0x40
+sLinooneGfx22_1:
+.incbin "baserom.gba", 0x10DA9C8, 0x40
+sLinooneGfx22_2:
+.incbin "baserom.gba", 0x10DAA08, 0xE0
+sLinooneSprites22:
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx22_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLinooneGfx23:
+.incbin "baserom.gba", 0x10DAB28, 0x1C0
+sLinooneSprites23:
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx23, 0x1c0
+ax_sprite_terminator
+sLinooneGfx24:
+.incbin "baserom.gba", 0x10DAD00, 0x40
+sLinooneGfx24_1:
+.incbin "baserom.gba", 0x10DAD40, 0x60
+sLinooneGfx24_2:
+.incbin "baserom.gba", 0x10DADA0, 0x80
+sLinooneGfx24_3:
+.incbin "baserom.gba", 0x10DAE20, 0x60
+sLinooneSprites24:
+ax_sprite sLinooneGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx24_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx24_3, 0x60
+ax_sprite_terminator
+sLinooneGfx25:
+.incbin "baserom.gba", 0x10DAEC0, 0x40
+sLinooneGfx25_1:
+.incbin "baserom.gba", 0x10DAF00, 0x40
+sLinooneGfx25_2:
+.incbin "baserom.gba", 0x10DAF40, 0x40
+sLinooneGfx25_3:
+.incbin "baserom.gba", 0x10DAF80, 0x40
+sLinooneSprites25:
+ax_sprite sLinooneGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx25_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx25_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLinooneGfx26:
+.incbin "baserom.gba", 0x10DB008, 0x40
+sLinooneGfx26_1:
+.incbin "baserom.gba", 0x10DB048, 0x40
+sLinooneGfx26_2:
+.incbin "baserom.gba", 0x10DB088, 0x60
+sLinooneGfx26_3:
+.incbin "baserom.gba", 0x10DB0E8, 0x60
+sLinooneSprites26:
+ax_sprite sLinooneGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLinooneGfx27:
+.incbin "baserom.gba", 0x10DB190, 0x40
+sLinooneGfx27_1:
+.incbin "baserom.gba", 0x10DB1D0, 0x40
+sLinooneGfx27_2:
+.incbin "baserom.gba", 0x10DB210, 0x60
+sLinooneGfx27_3:
+.incbin "baserom.gba", 0x10DB270, 0x40
+sLinooneSprites27:
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLinooneGfx28:
+.incbin "baserom.gba", 0x10DB300, 0x40
+sLinooneGfx28_1:
+.incbin "baserom.gba", 0x10DB340, 0x60
+sLinooneGfx28_2:
+.incbin "baserom.gba", 0x10DB3A0, 0x60
+sLinooneGfx28_3:
+.incbin "baserom.gba", 0x10DB400, 0x60
+sLinooneSprites28:
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx28_3, 0x60
+ax_sprite_terminator
+sLinooneGfx29:
+.incbin "baserom.gba", 0x10DB4A8, 0x60
+sLinooneGfx29_1:
+.incbin "baserom.gba", 0x10DB508, 0x60
+sLinooneGfx29_2:
+.incbin "baserom.gba", 0x10DB568, 0x60
+sLinooneGfx29_3:
+.incbin "baserom.gba", 0x10DB5C8, 0x60
+sLinooneSprites29:
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLinooneGfx29_3, 0x60
+ax_sprite_terminator
+sLinooneGfx30:
+.incbin "baserom.gba", 0x10DB670, 0x40
+sLinooneGfx30_1:
+.incbin "baserom.gba", 0x10DB6B0, 0x40
+sLinooneGfx30_2:
+.incbin "baserom.gba", 0x10DB6F0, 0x40
+sLinooneGfx30_3:
+.incbin "baserom.gba", 0x10DB730, 0x40
+sLinooneSprites30:
+ax_sprite sLinooneGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx30_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLinooneGfx30_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLinooneGfx31:
+.incbin "baserom.gba", 0x10DB7B8, 0x200
+sLinooneSprites31:
+ax_sprite sLinooneGfx31, 0x200
+ax_sprite_terminator
+sLinooneGfx32:
+.incbin "baserom.gba", 0x10DB9C8, 0x200
+sLinooneSprites32:
+ax_sprite sLinooneGfx32, 0x200
+ax_sprite_terminator
+sLinooneGfx33:
+.incbin "baserom.gba", 0x10DBBD8, 0x200
+sLinooneSprites33:
+ax_sprite sLinooneGfx33, 0x200
+ax_sprite_terminator
+sLinooneGfx34:
+.incbin "baserom.gba", 0x10DBDE8, 0x200
+sLinooneSprites34:
+ax_sprite sLinooneGfx34, 0x200
+ax_sprite_terminator
+sLinooneGfx35:
+.incbin "baserom.gba", 0x10DBFF8, 0x200
+sLinooneSprites35:
+ax_sprite sLinooneGfx35, 0x200
+ax_sprite_terminator
+sLinooneGfx36:
+.incbin "baserom.gba", 0x10DC208, 0x200
+sLinooneSprites36:
+ax_sprite sLinooneGfx36, 0x200
+ax_sprite_terminator
+sLinooneGfx37:
+.incbin "baserom.gba", 0x10DC418, 0x200
+sLinooneSprites37:
+ax_sprite sLinooneGfx37, 0x200
+ax_sprite_terminator
+sAxPosesLinoone:
+.4byte sLinoonePose1
+.4byte sLinoonePose2
+.4byte sLinoonePose3
+.4byte sLinoonePose4
+.4byte sLinoonePose5
+.4byte sLinoonePose6
+.4byte sLinoonePose7
+.4byte sLinoonePose8
+.4byte sLinoonePose9
+.4byte sLinoonePose10
+.4byte sLinoonePose11
+.4byte sLinoonePose12
+.4byte sLinoonePose13
+.4byte sLinoonePose14
+.4byte sLinoonePose15
+.4byte sLinoonePose16
+.4byte sLinoonePose17
+.4byte sLinoonePose18
+.4byte sLinoonePose19
+.4byte sLinoonePose20
+.4byte sLinoonePose21
+.4byte sLinoonePose22
+.4byte sLinoonePose23
+.4byte sLinoonePose24
+.4byte sLinoonePose25
+.4byte sLinoonePose26
+.4byte sLinoonePose27
+.4byte sLinoonePose28
+.4byte sLinoonePose29
+.4byte sLinoonePose30
+.4byte sLinoonePose31
+.4byte sLinoonePose32
+.4byte sLinoonePose33
+.4byte sLinoonePose34
+.4byte sLinoonePose35
+.4byte sLinoonePose36
+.4byte sLinoonePose37
+.4byte sLinoonePose38
+.4byte sLinoonePose39
+.4byte sLinoonePose40
+.4byte sLinoonePose41
+.4byte sLinoonePose42
+.4byte sLinoonePose43
+.4byte sLinoonePose44
+.4byte sLinoonePose45
+.4byte sLinoonePose46
+.4byte sLinoonePose47
+.4byte sLinoonePose48
+.4byte sLinoonePose49
+.4byte sLinoonePose50
+.4byte sLinoonePose51
+.4byte sLinoonePose52
+.4byte sLinoonePose53
+.4byte sLinoonePose54
+.4byte sLinoonePose55
+.4byte sLinoonePose56
+.4byte sLinoonePose57
+.4byte sLinoonePose58
+.4byte sLinoonePose59
+.4byte sLinoonePose60
+.4byte sLinoonePose61
+.4byte sLinoonePose62
+.4byte sLinoonePose63
+.4byte sLinoonePose64
+.4byte sLinoonePose65
+.4byte sLinoonePose66
+.4byte sLinoonePose67
+.4byte sLinoonePose68
+.4byte sLinoonePose69
+.4byte sLinoonePose70
+.4byte sLinoonePose71
+.4byte sLinoonePose72
+.4byte sLinoonePose73
+.4byte sLinoonePose74
+.4byte sLinoonePose75
+.4byte sLinoonePose76
+.4byte sLinoonePose77
+.4byte sLinoonePose78
+.4byte sLinoonePose79
+.4byte sLinoonePose80
+.4byte sLinoonePose81
+.4byte sLinoonePose82
+.4byte sLinoonePose83
+.4byte sLinoonePose84
+.4byte sLinoonePose85
+.4byte sLinoonePose86
+.4byte sLinoonePose87
+.4byte sLinoonePose88
+.4byte sLinoonePose89
+.4byte sLinoonePose90
+.4byte sLinoonePose91
+.4byte sLinoonePose92
+.4byte sLinoonePose93
+.4byte sLinoonePose94
+.4byte sLinoonePose95
+.4byte sLinoonePose96
+.4byte sLinoonePose97
+.4byte sLinoonePose98
+.4byte sLinoonePose99
+.4byte sLinoonePose100
+.4byte sLinoonePose101
+.4byte sLinoonePose102
+.4byte sLinoonePose103
+.4byte sLinoonePose104
+.4byte sLinoonePose105
+.4byte sLinoonePose106
+.4byte sLinoonePose107
+.4byte sLinoonePose108
+.4byte sLinoonePose109
+.4byte sLinoonePose110
+.4byte sLinoonePose111
+.4byte sLinoonePose112
+.4byte sLinoonePose113
+.4byte sLinoonePose114
+.4byte sLinoonePose115
+.4byte sLinoonePose116
+.4byte sLinoonePose117
+.4byte sLinoonePose118
+.4byte sLinoonePose119
+.4byte sLinoonePose120
+.4byte sLinoonePose121
+.4byte sLinoonePose122
+.4byte sLinoonePose123
+.4byte sLinoonePose124
+.4byte sLinoonePose125
+.4byte sLinoonePose126
+.4byte sLinoonePose127
+.4byte sLinoonePose128
+.4byte sLinoonePose129
+.4byte sLinoonePose130
+.4byte sLinoonePose131
+.4byte sLinoonePose132
+.4byte sLinoonePose133
+.4byte sLinoonePose134
+.4byte sLinoonePose135
+.4byte sLinoonePose136
+.4byte sLinoonePose137
+.4byte sLinoonePose138
+.4byte sLinoonePose139
+.4byte sLinoonePose140
+.4byte sLinoonePose141
+.4byte sLinoonePose142
+.4byte sLinoonePose143
+.4byte sLinoonePose144
+.4byte sLinoonePose145
+.4byte sLinoonePose146
+.4byte sLinoonePose147
+.4byte sLinoonePose148
+.4byte sLinoonePose149
+.4byte sLinoonePose150
+.4byte sLinoonePose151
+.4byte sLinoonePose152
+.4byte sLinoonePose153
+.4byte sLinoonePose154
+.4byte sLinoonePose155
+.4byte sLinoonePose156
+.4byte sLinoonePose157
+.4byte sLinoonePose158
+.4byte sLinoonePose159
+.4byte sLinoonePose160
+.4byte sLinoonePose161
+.4byte sLinoonePose162
+.4byte sLinoonePose163
+.4byte sLinoonePose164
+.4byte sLinoonePose165
+.4byte sLinoonePose166
+.4byte sLinoonePose167
+.4byte sLinoonePose168
+.4byte sLinoonePose169
+.4byte sLinoonePose170
+.4byte sLinoonePose171
+.4byte sLinoonePose172
+.4byte sLinoonePose173
+.4byte sLinoonePose174
+.4byte sLinoonePose175
+.4byte sLinoonePose176
+.4byte sLinoonePose177
+.4byte sLinoonePose178
+.4byte sLinoonePose179
+.4byte sLinoonePose180
+.4byte sLinoonePose181
+.4byte sLinoonePose182
+.4byte sLinoonePose183
+.4byte sLinoonePose184
+.4byte sLinoonePose185
+.4byte sLinoonePose186
+.4byte sLinoonePose187
+.4byte sLinoonePose188
+.4byte sLinoonePose189
+.4byte sLinoonePose190
+.4byte sLinoonePose191
+.4byte sLinoonePose192
+.4byte sLinoonePose193
+.4byte sLinoonePose194
+.4byte sLinoonePose195
+.4byte sLinoonePose196
+.4byte sLinoonePose197
+.4byte sLinoonePose198
+.4byte sLinoonePose199
+.4byte sLinoonePose200
+.4byte sLinoonePose201
+.4byte sLinoonePose202
+.4byte sLinoonePose203
+.4byte sLinoonePose204
+.4byte sLinoonePose205
+.4byte sLinoonePose206
+.4byte sLinoonePose207
+.4byte sLinoonePose208
+.4byte sLinoonePose209
+.4byte sLinoonePose210
+.4byte sLinoonePose211
+.4byte sLinoonePose212
+.4byte sLinoonePose213
+.4byte sLinoonePose214
+.4byte sLinoonePose215
+.4byte sLinoonePose216
+.4byte sLinoonePose217
+.4byte sLinoonePose218
+.4byte sLinoonePose219
+.4byte sLinoonePose220
+.4byte sLinoonePose221
+.4byte sLinoonePose222
+.4byte sLinoonePose223
+.4byte sLinoonePose224
+.4byte sLinoonePose225
+.4byte sLinoonePose226
+.4byte sLinoonePose227
+.4byte sLinoonePose228
+.4byte sLinoonePose229
+.4byte sLinoonePose230
+.4byte sLinoonePose231
+.4byte sLinoonePose232
+.4byte sLinoonePose233
+.4byte sLinoonePose234
+.4byte sLinoonePose235
+.4byte sLinoonePose236
+.4byte sLinoonePose237
+.4byte sLinoonePose238
+.4byte sLinoonePose239
+.4byte sLinoonePose240
+.4byte sLinoonePose241
+.4byte sLinoonePose242
+.4byte sLinoonePose243
+.4byte sLinoonePose244
+.4byte sLinoonePose245
+.4byte sLinoonePose246
+.4byte sLinoonePose247
+.4byte sLinoonePose248
+.4byte sLinoonePose249
+.4byte sLinoonePose250
+.4byte sLinoonePose251
+.4byte sLinoonePose252
+.4byte sLinoonePose253
+.4byte sLinoonePose254
+.4byte sLinoonePose255
+.4byte sLinoonePose256
+.4byte sLinoonePose257
+.4byte sLinoonePose258
+sAxPositionsLinoone:
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -9
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+.2byte   11,   -1, 	   4,   -3, 	  -1,   -2, 	   0,  -10
+.2byte   10,    6, 	  13,    5, 	   4,    6, 	   2,   -4
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte   13,   -8, 	   2,   -6, 	   2,   -3, 	  -2,   -9
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte   10,  -11, 	   3,   -9, 	  10,   -6, 	  -2,   -7
+.2byte   10,  -16, 	  -4,  -11, 	   4,   -6, 	  -2,  -11
+.2byte   11,   -9, 	   4,   -8, 	  11,   -6, 	   0,  -10
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,  -10
+.2byte  -11,  -11, 	  -4,   -9, 	 -11,   -6, 	   1,   -7
+.2byte  -11,  -16, 	   3,  -11, 	  -5,   -6, 	   1,  -11
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -14,   -8, 	  -3,   -6, 	  -3,   -3, 	   1,   -9
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -12,   -1, 	  -5,   -3, 	   0,   -2, 	  -1,  -10
+.2byte  -11,    6, 	 -14,    5, 	  -5,    6, 	  -3,   -4
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -9
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,   -1, 	   2,   -1, 	  -1,   -9
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+.2byte   11,   -1, 	   4,   -3, 	  -1,   -2, 	   0,  -10
+.2byte   10,    6, 	  13,    5, 	   4,    6, 	   2,   -4
+.2byte    3,   -6, 	   5,   -6, 	  -1,   -4, 	  -5,  -12
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte   13,   -8, 	   2,   -6, 	   2,   -3, 	  -2,   -9
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte    8,   -8, 	   5,   -8, 	   4,   -4, 	  -4,  -11
+.2byte   10,  -11, 	   3,   -9, 	  10,   -6, 	  -2,   -7
+.2byte   10,  -16, 	  -4,  -11, 	   4,   -6, 	  -2,  -11
+.2byte   11,   -9, 	   4,   -8, 	  11,   -6, 	   0,  -10
+.2byte    5,   -7, 	  -2,   -8, 	   5,   -5, 	  -3,   -8
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,  -10
+.2byte   -1,   -7, 	   3,   -5, 	  -5,   -5, 	  -1,   -1
+.2byte  -11,  -11, 	  -4,   -9, 	 -11,   -6, 	   1,   -7
+.2byte  -11,  -16, 	   3,  -11, 	  -5,   -6, 	   1,  -11
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte   -6,   -7, 	   1,   -8, 	  -6,   -5, 	   2,   -8
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -14,   -8, 	  -3,   -6, 	  -3,   -3, 	   1,   -9
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte   -9,   -8, 	  -6,   -8, 	  -5,   -4, 	   3,  -11
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -12,   -1, 	  -5,   -3, 	   0,   -2, 	  -1,  -10
+.2byte  -11,    6, 	 -14,    5, 	  -5,    6, 	  -3,   -4
+.2byte   -4,   -6, 	  -6,   -6, 	   0,   -4, 	   4,  -12
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -9
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,   -1, 	   2,   -1, 	  -1,   -9
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+.2byte   11,   -1, 	   4,   -3, 	  -1,   -2, 	   0,  -10
+.2byte   10,    6, 	  13,    5, 	   4,    6, 	   2,   -4
+.2byte    3,   -6, 	   5,   -6, 	  -1,   -4, 	  -5,  -12
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte   13,   -8, 	   2,   -6, 	   2,   -3, 	  -2,   -9
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte    8,   -8, 	   5,   -8, 	   4,   -4, 	  -4,  -11
+.2byte   10,  -11, 	   3,   -9, 	  10,   -6, 	  -2,   -7
+.2byte   10,  -16, 	  -4,  -11, 	   4,   -6, 	  -2,  -11
+.2byte   11,   -9, 	   4,   -8, 	  11,   -6, 	   0,  -10
+.2byte    5,   -7, 	  -2,   -8, 	   5,   -5, 	  -3,   -8
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,  -10
+.2byte   -1,   -7, 	   3,   -5, 	  -5,   -5, 	  -1,   -1
+.2byte  -11,  -11, 	  -4,   -9, 	 -11,   -6, 	   1,   -7
+.2byte  -11,  -16, 	   3,  -11, 	  -5,   -6, 	   1,  -11
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte   -6,   -7, 	   1,   -8, 	  -6,   -5, 	   2,   -8
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -14,   -8, 	  -3,   -6, 	  -3,   -3, 	   1,   -9
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte   -9,   -8, 	  -6,   -8, 	  -5,   -4, 	   3,  -11
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -12,   -1, 	  -5,   -3, 	   0,   -2, 	  -1,  -10
+.2byte  -11,    6, 	 -14,    5, 	  -5,    6, 	  -3,   -4
+.2byte   -4,   -6, 	  -6,   -6, 	   0,   -4, 	   4,  -12
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -9
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte   -1,    9, 	  -6,    8, 	   5,    7, 	  -1,   -2
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+.2byte   11,   -1, 	   4,   -3, 	  -1,   -2, 	   0,  -10
+.2byte   10,    6, 	  13,    5, 	   4,    6, 	   2,   -4
+.2byte   12,    2, 	   6,    2, 	   3,    5, 	   3,   -6
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte   13,   -8, 	   2,   -6, 	   2,   -3, 	  -2,   -9
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte   17,   -7, 	  11,   -3, 	  10,    1, 	   5,   -7
+.2byte   10,  -11, 	   3,   -9, 	  10,   -6, 	  -2,   -7
+.2byte   10,  -16, 	  -4,  -11, 	   4,   -6, 	  -2,  -11
+.2byte   11,   -9, 	   4,   -8, 	  11,   -6, 	   0,  -10
+.2byte   10,  -12, 	   4,  -10, 	  10,   -6, 	   2,  -10
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,  -10
+.2byte   -1,  -19, 	   3,  -10, 	  -5,  -10, 	  -1,   -9
+.2byte  -11,  -11, 	  -4,   -9, 	 -11,   -6, 	   1,   -7
+.2byte  -11,  -16, 	   3,  -11, 	  -5,   -6, 	   1,  -11
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte  -11,  -12, 	  -5,  -10, 	 -11,   -6, 	  -3,  -10
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -14,   -8, 	  -3,   -6, 	  -3,   -3, 	   1,   -9
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte  -18,   -7, 	 -12,   -3, 	 -11,    1, 	  -6,   -7
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -12,   -1, 	  -5,   -3, 	   0,   -2, 	  -1,  -10
+.2byte  -11,    6, 	 -14,    5, 	  -5,    6, 	  -3,   -4
+.2byte  -13,    2, 	  -7,    2, 	  -4,    5, 	  -4,   -6
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -9
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte   -1,    1, 	  -4,    2, 	   2,    2, 	  -1,   -6
+.2byte   -1,  -25, 	  -5,  -19, 	   3,  -19, 	  -1,  -13
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+.2byte   11,   -1, 	   4,   -3, 	  -1,   -2, 	   0,  -10
+.2byte   10,    6, 	  13,    5, 	   4,    6, 	   2,   -4
+.2byte    5,   -4, 	   7,   -4, 	   1,   -2, 	  -3,  -10
+.2byte   -4,  -25, 	   2,  -21, 	  -4,  -18, 	  -2,  -12
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte   13,   -8, 	   2,   -6, 	   2,   -3, 	  -2,   -9
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte    9,   -8, 	   6,   -8, 	   5,   -4, 	  -3,  -11
+.2byte    0,  -24, 	   3,  -20, 	   1,  -17, 	  -1,  -10
+.2byte   10,  -11, 	   3,   -9, 	  10,   -6, 	  -2,   -7
+.2byte   10,  -16, 	  -4,  -11, 	   4,   -6, 	  -2,  -11
+.2byte   11,   -9, 	   4,   -8, 	  11,   -6, 	   0,  -10
+.2byte    5,   -7, 	  -2,   -8, 	   5,   -5, 	  -3,   -8
+.2byte    0,  -24, 	  -3,  -22, 	   3,  -19, 	  -3,  -11
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,  -10
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -3
+.2byte   -1,  -20, 	   4,  -17, 	  -6,  -17, 	  -1,  -10
+.2byte  -11,  -11, 	  -4,   -9, 	 -11,   -6, 	   1,   -7
+.2byte  -11,  -16, 	   3,  -11, 	  -5,   -6, 	   1,  -11
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte   -6,   -7, 	   1,   -8, 	  -6,   -5, 	   2,   -8
+.2byte   -1,  -24, 	   2,  -22, 	  -4,  -19, 	   2,  -11
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -14,   -8, 	  -3,   -6, 	  -3,   -3, 	   1,   -9
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte  -10,   -8, 	  -7,   -8, 	  -6,   -4, 	   2,  -11
+.2byte   -1,  -24, 	  -4,  -20, 	  -2,  -17, 	   0,  -10
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -12,   -1, 	  -5,   -3, 	   0,   -2, 	  -1,  -10
+.2byte  -11,    6, 	 -14,    5, 	  -5,    6, 	  -3,   -4
+.2byte   -6,   -4, 	  -8,   -4, 	  -2,   -2, 	   2,  -10
+.2byte    3,  -25, 	  -3,  -21, 	   3,  -18, 	   1,  -12
+.2byte  -10,    4, 	 -13,    2, 	  -5,    6, 	   1,   -5
+.2byte  -10,    4, 	 -13,    2, 	  -5,    6, 	   1,   -6
+.2byte    0,    6, 	  -8,    3, 	   8,    3, 	   0,   -6
+.2byte   10,    4, 	  13,   -2, 	  -3,    5, 	  -1,   -5
+.2byte   13,   -1, 	   9,   -9, 	   7,    5, 	  -1,   -4
+.2byte   11,   -8, 	   0,  -10, 	  10,   -2, 	  -1,   -5
+.2byte    0,   -8, 	   9,   -7, 	  -8,   -8, 	   0,   -4
+.2byte  -12,   -8, 	  -1,  -10, 	 -11,   -2, 	   0,   -5
+.2byte  -14,   -1, 	 -10,   -9, 	  -8,    5, 	   0,   -4
+.2byte  -11,    4, 	 -14,   -2, 	   2,    5, 	   0,   -5
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -9
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte   -1,    9, 	  -6,    8, 	   5,    7, 	  -1,   -2
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+.2byte   11,   -1, 	   4,   -3, 	  -1,   -2, 	   0,  -10
+.2byte   10,    6, 	  13,    5, 	   4,    6, 	   2,   -4
+.2byte   12,    2, 	   6,    2, 	   3,    5, 	   3,   -6
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte   13,   -8, 	   2,   -6, 	   2,   -3, 	  -2,   -9
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte   17,   -7, 	  11,   -3, 	  10,    1, 	   5,   -7
+.2byte   10,  -11, 	   3,   -9, 	  10,   -6, 	  -2,   -7
+.2byte   10,  -16, 	  -4,  -11, 	   4,   -6, 	  -2,  -11
+.2byte   11,   -9, 	   4,   -8, 	  11,   -6, 	   0,  -10
+.2byte   10,  -12, 	   4,  -10, 	  10,   -6, 	   2,  -10
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,  -10
+.2byte   -1,  -19, 	   3,  -10, 	  -5,  -10, 	  -1,   -9
+.2byte  -11,  -11, 	  -4,   -9, 	 -11,   -6, 	   1,   -7
+.2byte  -11,  -16, 	   3,  -11, 	  -5,   -6, 	   1,  -11
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte  -11,  -12, 	  -5,  -10, 	 -11,   -6, 	  -3,  -10
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -14,   -8, 	  -3,   -6, 	  -3,   -3, 	   1,   -9
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte  -18,   -7, 	 -12,   -3, 	 -11,    1, 	  -6,   -7
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -12,   -1, 	  -5,   -3, 	   0,   -2, 	  -1,  -10
+.2byte  -11,    6, 	 -14,    5, 	  -5,    6, 	  -3,   -4
+.2byte  -13,    2, 	  -7,    2, 	  -4,    5, 	  -4,   -6
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte  -11,    6, 	 -14,    5, 	  -5,    6, 	  -3,   -4
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte   -1,  -13, 	   4,  -10, 	  -6,  -10, 	  -1,  -10
+.2byte   11,   -9, 	   4,   -8, 	  11,   -6, 	   0,  -10
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte   10,    6, 	  13,    5, 	   4,    6, 	   2,   -4
+.2byte   -1,  -25, 	  -5,  -19, 	   3,  -19, 	  -1,  -13
+.2byte   -2,  -25, 	   4,  -21, 	  -2,  -18, 	   0,  -12
+.2byte    2,  -24, 	   5,  -20, 	   3,  -17, 	   1,  -10
+.2byte    1,  -24, 	  -2,  -22, 	   4,  -19, 	  -2,  -11
+.2byte   -1,  -21, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -3,  -24, 	   0,  -22, 	  -6,  -19, 	   0,  -11
+.2byte   -3,  -24, 	  -6,  -20, 	  -4,  -17, 	  -2,  -10
+.2byte    1,  -25, 	  -5,  -21, 	   1,  -18, 	  -1,  -12
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -9
+.2byte   -1,    6, 	  -6,    6, 	   4,    6, 	  -1,   -5
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+.2byte    9,   -1, 	   2,   -3, 	  -3,   -2, 	  -2,  -10
+.2byte    9,    5, 	  12,    4, 	   3,    5, 	   1,   -5
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte   13,   -8, 	   2,   -6, 	   2,   -3, 	  -2,   -9
+.2byte   13,   -2, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte   10,  -11, 	   3,   -9, 	  10,   -6, 	  -2,   -7
+.2byte   10,  -16, 	  -4,  -11, 	   4,   -6, 	  -2,  -11
+.2byte   11,   -8, 	   4,   -7, 	  11,   -5, 	   0,   -9
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,  -10
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,   -9
+.2byte  -11,  -12, 	  -4,  -10, 	 -11,   -7, 	   1,   -8
+.2byte  -11,  -15, 	   3,  -10, 	  -5,   -5, 	   1,  -10
+.2byte  -12,   -9, 	  -5,   -8, 	 -12,   -6, 	  -1,  -10
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -14,   -8, 	  -3,   -6, 	  -3,   -3, 	   1,   -9
+.2byte  -14,   -2, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -10,   -1, 	  -3,   -3, 	   2,   -2, 	   1,  -10
+.2byte  -10,    5, 	 -13,    4, 	  -4,    5, 	  -2,   -5
+.2byte   -1,   -1, 	  -4,    0, 	   2,    0, 	  -1,   -8
+.2byte   -6,   -3, 	  -8,   -3, 	  -2,   -1, 	   2,   -9
+.2byte  -12,   -8, 	  -9,   -8, 	  -8,   -4, 	   0,  -11
+.2byte   -7,   -8, 	   0,   -9, 	  -7,   -6, 	   1,   -9
+.2byte   -1,  -12, 	   3,  -10, 	  -5,  -10, 	  -1,   -6
+.2byte    6,   -8, 	  -1,   -9, 	   6,   -6, 	  -2,   -9
+.2byte   10,   -8, 	   7,   -8, 	   6,   -4, 	  -2,  -11
+.2byte    5,   -3, 	   7,   -3, 	   1,   -1, 	  -3,   -9
+.2byte   -1,    5, 	  -5,    5, 	   4,    4, 	  -1,   -5
+.2byte  -10,    4, 	 -12,    0, 	  -4,    5, 	  -1,   -7
+.2byte  -14,   -3, 	 -12,   -4, 	 -11,    1, 	   0,   -5
+.2byte  -10,  -10, 	  -3,   -8, 	 -10,   -5, 	   2,   -6
+.2byte   -1,  -11, 	   4,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte    9,  -10, 	   2,   -8, 	   9,   -5, 	  -3,   -6
+.2byte   13,   -3, 	  11,   -4, 	  10,    1, 	  -1,   -5
+.2byte    9,    4, 	  11,    0, 	   3,    5, 	   0,   -7
+sLinooneAnimTable1:
+.4byte sLinooneAnims_1_1
+.4byte sLinooneAnims_1_2
+.4byte sLinooneAnims_1_3
+.4byte sLinooneAnims_1_4
+.4byte sLinooneAnims_1_5
+.4byte sLinooneAnims_1_6
+.4byte sLinooneAnims_1_7
+.4byte sLinooneAnims_1_8
+sLinooneAnimTable2:
+.4byte sLinooneAnims_2_1
+.4byte sLinooneAnims_2_2
+.4byte sLinooneAnims_2_3
+.4byte sLinooneAnims_2_4
+.4byte sLinooneAnims_2_5
+.4byte sLinooneAnims_2_6
+.4byte sLinooneAnims_2_7
+.4byte sLinooneAnims_2_8
+sLinooneAnimTable3:
+.4byte sLinooneAnims_3_1
+.4byte sLinooneAnims_3_2
+.4byte sLinooneAnims_3_3
+.4byte sLinooneAnims_3_4
+.4byte sLinooneAnims_3_5
+.4byte sLinooneAnims_3_6
+.4byte sLinooneAnims_3_7
+.4byte sLinooneAnims_3_8
+sLinooneAnimTable4:
+.4byte sLinooneAnims_4_1
+.4byte sLinooneAnims_4_2
+.4byte sLinooneAnims_4_3
+.4byte sLinooneAnims_4_4
+.4byte sLinooneAnims_4_5
+.4byte sLinooneAnims_4_6
+.4byte sLinooneAnims_4_7
+.4byte sLinooneAnims_4_8
+sLinooneAnimTable5:
+.4byte sLinooneAnims_5_1
+.4byte sLinooneAnims_5_2
+.4byte sLinooneAnims_5_3
+.4byte sLinooneAnims_5_4
+.4byte sLinooneAnims_5_5
+.4byte sLinooneAnims_5_6
+.4byte sLinooneAnims_5_7
+.4byte sLinooneAnims_5_8
+sLinooneAnimTable6:
+.4byte sLinooneAnims_6_1
+.4byte sLinooneAnims_6_1
+.4byte sLinooneAnims_6_1
+.4byte sLinooneAnims_6_1
+.4byte sLinooneAnims_6_1
+.4byte sLinooneAnims_6_1
+.4byte sLinooneAnims_6_1
+.4byte sLinooneAnims_6_1
+sLinooneAnimTable7:
+.4byte sLinooneAnims_7_1
+.4byte sLinooneAnims_7_2
+.4byte sLinooneAnims_7_3
+.4byte sLinooneAnims_7_4
+.4byte sLinooneAnims_7_5
+.4byte sLinooneAnims_7_6
+.4byte sLinooneAnims_7_7
+.4byte sLinooneAnims_7_8
+sLinooneAnimTable8:
+.4byte sLinooneAnims_8_1
+.4byte sLinooneAnims_8_2
+.4byte sLinooneAnims_8_3
+.4byte sLinooneAnims_8_4
+.4byte sLinooneAnims_8_5
+.4byte sLinooneAnims_8_6
+.4byte sLinooneAnims_8_7
+.4byte sLinooneAnims_8_8
+sLinooneAnimTable9:
+.4byte sLinooneAnims_9_1
+.4byte sLinooneAnims_9_2
+.4byte sLinooneAnims_9_3
+.4byte sLinooneAnims_9_4
+.4byte sLinooneAnims_9_5
+.4byte sLinooneAnims_9_6
+.4byte sLinooneAnims_9_7
+.4byte sLinooneAnims_9_8
+sLinooneAnimTable10:
+.4byte sLinooneAnims_10_1
+.4byte sLinooneAnims_10_2
+.4byte sLinooneAnims_10_3
+.4byte sLinooneAnims_10_4
+.4byte sLinooneAnims_10_5
+.4byte sLinooneAnims_10_6
+.4byte sLinooneAnims_10_7
+.4byte sLinooneAnims_10_8
+sLinooneAnimTable11:
+.4byte sLinooneAnims_11_1
+.4byte sLinooneAnims_11_2
+.4byte sLinooneAnims_11_3
+.4byte sLinooneAnims_11_4
+.4byte sLinooneAnims_11_5
+.4byte sLinooneAnims_11_6
+.4byte sLinooneAnims_11_7
+.4byte sLinooneAnims_11_8
+sLinooneAnimTable12:
+.4byte sLinooneAnims_12_1
+.4byte sLinooneAnims_12_2
+.4byte sLinooneAnims_12_3
+.4byte sLinooneAnims_12_4
+.4byte sLinooneAnims_12_5
+.4byte sLinooneAnims_12_6
+.4byte sLinooneAnims_12_7
+.4byte sLinooneAnims_12_8
+sLinooneAnimTable13:
+.4byte sLinooneAnims_13_1
+.4byte sLinooneAnims_13_2
+.4byte sLinooneAnims_13_3
+.4byte sLinooneAnims_13_4
+.4byte sLinooneAnims_13_5
+.4byte sLinooneAnims_13_6
+.4byte sLinooneAnims_13_7
+.4byte sLinooneAnims_13_8
+sAxAnimationsLinoone:
+.4byte sLinooneAnimTable1
+.4byte sLinooneAnimTable2
+.4byte sLinooneAnimTable3
+.4byte sLinooneAnimTable4
+.4byte sLinooneAnimTable5
+.4byte sLinooneAnimTable6
+.4byte sLinooneAnimTable7
+.4byte sLinooneAnimTable8
+.4byte sLinooneAnimTable9
+.4byte sLinooneAnimTable10
+.4byte sLinooneAnimTable11
+.4byte sLinooneAnimTable12
+.4byte sLinooneAnimTable13
+sAxSpritesLinoone:
+.4byte sLinooneSprites1
+.4byte sLinooneSprites2
+.4byte sLinooneSprites3
+.4byte sLinooneSprites4
+.4byte sLinooneSprites5
+.4byte sLinooneSprites6
+.4byte sLinooneSprites7
+.4byte sLinooneSprites8
+.4byte sLinooneSprites9
+.4byte sLinooneSprites10
+.4byte sLinooneSprites11
+.4byte sLinooneSprites12
+.4byte sLinooneSprites13
+.4byte sLinooneSprites14
+.4byte sLinooneSprites15
+.4byte sLinooneSprites16
+.4byte sLinooneSprites17
+.4byte sLinooneSprites18
+.4byte sLinooneSprites19
+.4byte sLinooneSprites20
+.4byte sLinooneSprites21
+.4byte sLinooneSprites22
+.4byte sLinooneSprites23
+.4byte sLinooneSprites24
+.4byte sLinooneSprites25
+.4byte sLinooneSprites26
+.4byte sLinooneSprites27
+.4byte sLinooneSprites28
+.4byte sLinooneSprites29
+.4byte sLinooneSprites30
+.4byte sLinooneSprites31
+.4byte sLinooneSprites32
+.4byte sLinooneSprites33
+.4byte sLinooneSprites34
+.4byte sLinooneSprites35
+.4byte sLinooneSprites36
+.4byte sLinooneSprites37
+sAxMainLinoone:
+ax_main sAxPosesLinoone, sAxAnimationsLinoone, 13, sAxSpritesLinoone, sAxPositionsLinoone

--- a/data/ax/lombre.inc
+++ b/data/ax/lombre.inc
@@ -1,0 +1,3345 @@
+.global gAxLombre
+gAxLombre:
+ax_siro sAxMainLombre
+sLombrePose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose4:
+ax_pose 3, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose5:
+ax_pose 4, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose6:
+ax_pose 5, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose7:
+ax_pose 6, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose8:
+ax_pose 7, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose9:
+ax_pose 8, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose10:
+ax_pose 9, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose11:
+ax_pose 10, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose12:
+ax_pose 11, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose16:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose17:
+ax_pose 16, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose18:
+ax_pose 17, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose19:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose20:
+ax_pose 19, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose21:
+ax_pose 20, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose22:
+ax_pose 21, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose23:
+ax_pose 22, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose24:
+ax_pose 23, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose25:
+ax_pose 24, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose28:
+ax_pose 25, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose29:
+ax_pose 4, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose30:
+ax_pose 5, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose31:
+ax_pose 26, 0x01e6, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose32:
+ax_pose 7, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose33:
+ax_pose 8, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose34:
+ax_pose 27, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose35:
+ax_pose 10, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose36:
+ax_pose 11, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose37:
+ax_pose 28, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose39:
+ax_pose 14, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose40:
+ax_pose 29, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose41:
+ax_pose 16, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose42:
+ax_pose 17, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose43:
+ax_pose 30, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sLombrePose44:
+ax_pose 19, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose45:
+ax_pose 20, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose46:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose47:
+ax_pose 22, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose48:
+ax_pose 23, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose49:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose50:
+ax_pose 32, 0x41f6, 0x80f0, 0x3c00
+ax_pose 24, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose51:
+ax_pose 24, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose52:
+ax_pose 33, 0x41f6, 0x80f0, 0x3c00
+ax_pose 34, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose53:
+ax_pose 34, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose54:
+ax_pose 3, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose55:
+ax_pose 35, 0x41f6, 0x90ef, 0x3c00
+ax_pose 25, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose56:
+ax_pose 25, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose57:
+ax_pose 36, 0x41f6, 0x90ef, 0x3c00
+ax_pose 37, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose58:
+ax_pose 37, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose59:
+ax_pose 6, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose60:
+ax_pose 38, 0x41f6, 0x90f1, 0x3c00
+ax_pose 26, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose61:
+ax_pose 26, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose62:
+ax_pose 39, 0x41f6, 0x90f1, 0x3c00
+ax_pose 40, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose63:
+ax_pose 40, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose64:
+ax_pose 9, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose65:
+ax_pose 41, 0x41ee, 0x90ef, 0x3c00
+ax_pose 27, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose66:
+ax_pose 27, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose67:
+ax_pose 42, 0x01ee, 0x50ff, 0x3c00
+ax_pose 43, 0x01e6, 0x80ef, 0x3c04
+ax_pose_terminator
+sLombrePose68:
+ax_pose 43, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose69:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose70:
+ax_pose 44, 0x41ee, 0x80f0, 0x3c00
+ax_pose 28, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose71:
+ax_pose 28, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose72:
+ax_pose 45, 0x41ee, 0x80f0, 0x3c00
+ax_pose 46, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose73:
+ax_pose 46, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose74:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose75:
+ax_pose 41, 0x41ee, 0x80f0, 0x3c00
+ax_pose 29, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose76:
+ax_pose 29, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose77:
+ax_pose 42, 0x01ee, 0x40f0, 0x3c00
+ax_pose 47, 0x01e6, 0x80f0, 0x3c04
+ax_pose_terminator
+sLombrePose78:
+ax_pose 47, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose79:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose80:
+ax_pose 38, 0x41f6, 0x80ee, 0x3c00
+ax_pose 30, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose81:
+ax_pose 30, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose82:
+ax_pose 39, 0x41f6, 0x80ee, 0x3c00
+ax_pose 48, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose83:
+ax_pose 48, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose84:
+ax_pose 21, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose85:
+ax_pose 35, 0x41f6, 0x80f0, 0x3c00
+ax_pose 31, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose86:
+ax_pose 31, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose87:
+ax_pose 36, 0x41f6, 0x80f0, 0x3c00
+ax_pose 49, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose88:
+ax_pose 49, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose90:
+ax_pose 50, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose91:
+ax_pose 3, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose92:
+ax_pose 51, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose93:
+ax_pose 6, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose94:
+ax_pose 52, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose95:
+ax_pose 9, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose96:
+ax_pose 53, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose97:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose98:
+ax_pose 54, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose99:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose100:
+ax_pose 55, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose101:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose102:
+ax_pose 56, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose103:
+ax_pose 21, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose104:
+ax_pose 57, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose105:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose106:
+ax_pose 32, 0x41f6, 0x80f0, 0x3c00
+ax_pose 24, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose107:
+ax_pose 24, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose108:
+ax_pose 33, 0x41f6, 0x80f0, 0x3c00
+ax_pose 34, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose109:
+ax_pose 34, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose110:
+ax_pose 3, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose111:
+ax_pose 35, 0x41f6, 0x90ef, 0x3c00
+ax_pose 25, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose112:
+ax_pose 25, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose113:
+ax_pose 36, 0x41f6, 0x90ef, 0x3c00
+ax_pose 37, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose114:
+ax_pose 37, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose115:
+ax_pose 6, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose116:
+ax_pose 38, 0x41f6, 0x90f1, 0x3c00
+ax_pose 26, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose117:
+ax_pose 26, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose118:
+ax_pose 39, 0x41f6, 0x90f1, 0x3c00
+ax_pose 40, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose119:
+ax_pose 40, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose120:
+ax_pose 9, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose121:
+ax_pose 41, 0x41ee, 0x90ef, 0x3c00
+ax_pose 27, 0x01e6, 0x80ef, 0x3c08
+ax_pose_terminator
+sLombrePose122:
+ax_pose 27, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose123:
+ax_pose 42, 0x01ee, 0x50ff, 0x3c00
+ax_pose 43, 0x01e6, 0x80ef, 0x3c04
+ax_pose_terminator
+sLombrePose124:
+ax_pose 43, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose125:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose126:
+ax_pose 44, 0x41ee, 0x80f0, 0x3c00
+ax_pose 28, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose127:
+ax_pose 28, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose128:
+ax_pose 45, 0x41ee, 0x80f0, 0x3c00
+ax_pose 46, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose129:
+ax_pose 46, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose130:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose131:
+ax_pose 41, 0x41ee, 0x80f0, 0x3c00
+ax_pose 29, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose132:
+ax_pose 29, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose133:
+ax_pose 42, 0x01ee, 0x40f0, 0x3c00
+ax_pose 47, 0x01e6, 0x80f0, 0x3c04
+ax_pose_terminator
+sLombrePose134:
+ax_pose 47, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose135:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose136:
+ax_pose 38, 0x41f6, 0x80ee, 0x3c00
+ax_pose 30, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose137:
+ax_pose 30, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose138:
+ax_pose 39, 0x41f6, 0x80ee, 0x3c00
+ax_pose 48, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose139:
+ax_pose 48, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose140:
+ax_pose 21, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose141:
+ax_pose 35, 0x41f6, 0x80f0, 0x3c00
+ax_pose 31, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose142:
+ax_pose 31, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose143:
+ax_pose 36, 0x41f6, 0x80f0, 0x3c00
+ax_pose 49, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose144:
+ax_pose 49, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose145:
+ax_pose 58, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose146:
+ax_pose 59, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose147:
+ax_pose 60, 0x01e0, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose148:
+ax_pose 61, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose149:
+ax_pose 62, 0x01e3, 0x80ec, 0x3c00
+ax_pose_terminator
+sLombrePose150:
+ax_pose 63, 0x01e3, 0x80eb, 0x3c00
+ax_pose_terminator
+sLombrePose151:
+ax_pose 64, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose152:
+ax_pose 65, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sLombrePose153:
+ax_pose 66, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sLombrePose154:
+ax_pose 67, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLombrePose155:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose156:
+ax_pose 50, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose157:
+ax_pose 3, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose158:
+ax_pose 51, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose159:
+ax_pose 6, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose160:
+ax_pose 52, 0x01e6, 0x80ee, 0x3c00
+ax_pose_terminator
+sLombrePose161:
+ax_pose 9, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose162:
+ax_pose 53, 0x01e6, 0x80ee, 0x3c00
+ax_pose_terminator
+sLombrePose163:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose164:
+ax_pose 54, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose165:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose166:
+ax_pose 55, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose167:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose168:
+ax_pose 56, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sLombrePose169:
+ax_pose 21, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose170:
+ax_pose 57, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose171:
+ax_pose 50, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose172:
+ax_pose 57, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose173:
+ax_pose 56, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose174:
+ax_pose 55, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose175:
+ax_pose 54, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose176:
+ax_pose 53, 0x01e7, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose177:
+ax_pose 52, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose178:
+ax_pose 51, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose179:
+ax_pose 50, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose180:
+ax_pose 51, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose181:
+ax_pose 52, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose182:
+ax_pose 53, 0x01e7, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose183:
+ax_pose 54, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose184:
+ax_pose 55, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose185:
+ax_pose 56, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose186:
+ax_pose 57, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose187:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose188:
+ax_pose 50, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose189:
+ax_pose 3, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose190:
+ax_pose 51, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose191:
+ax_pose 6, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose192:
+ax_pose 52, 0x01e6, 0x80ec, 0x3c00
+ax_pose_terminator
+sLombrePose193:
+ax_pose 9, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose194:
+ax_pose 53, 0x01e6, 0x80ec, 0x3c00
+ax_pose_terminator
+sLombrePose195:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose196:
+ax_pose 54, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose197:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose198:
+ax_pose 55, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sLombrePose199:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose200:
+ax_pose 56, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sLombrePose201:
+ax_pose 21, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose202:
+ax_pose 57, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose203:
+ax_pose 50, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose204:
+ax_pose 57, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose205:
+ax_pose 56, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose206:
+ax_pose 55, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sLombrePose207:
+ax_pose 54, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose208:
+ax_pose 53, 0x01e7, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose209:
+ax_pose 52, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose210:
+ax_pose 51, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sLombrePose211:
+ax_pose 0, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose212:
+ax_pose 21, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose213:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose214:
+ax_pose 15, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose215:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sLombrePose216:
+ax_pose 9, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose217:
+ax_pose 6, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose218:
+ax_pose 3, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sLombrePose219:
+ax_pose 68, 0x41ea, 0x40f0, 0x3c00
+ax_pose 69, 0x41f2, 0x80f0, 0x3c04
+ax_pose 70, 0x01fe, 0x44f8, 0x5c0c
+ax_pose_terminator
+sLombrePose220:
+ax_pose 71, 0x41ee, 0x40f0, 0x3c00
+ax_pose 72, 0x41f6, 0x80f0, 0x3c04
+ax_pose 70, 0x01fe, 0x44f8, 0x5c0c
+ax_pose_terminator
+sLombrePose221:
+ax_pose 73, 0x41ed, 0x80f0, 0x3c00
+ax_pose 74, 0x41fd, 0x40f0, 0x3c08
+ax_pose 70, 0x01fe, 0x44f8, 0x5c0c
+ax_pose_terminator
+sLombrePose222:
+ax_pose 75, 0x01fc, 0x44f8, 0x5c00
+ax_pose 76, 0x41ee, 0x40f0, 0x3c04
+ax_pose 77, 0x41f6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose223:
+ax_pose 78, 0x01f5, 0x44f8, 0x5c00
+ax_pose 79, 0x41ea, 0x40f0, 0x3c04
+ax_pose 80, 0x41f2, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose224:
+ax_pose 68, 0x41ea, 0x40f0, 0x3c00
+ax_pose 69, 0x41f2, 0x80f0, 0x3c04
+ax_pose 70, 0x01fe, 0x44f8, 0x5c0c
+ax_pose_terminator
+sLombrePose225:
+ax_pose 71, 0x41ee, 0x40f0, 0x3c00
+ax_pose 72, 0x41f6, 0x80f0, 0x3c04
+ax_pose 70, 0x01fe, 0x44f8, 0x5c0c
+ax_pose_terminator
+sLombrePose226:
+ax_pose 73, 0x41ed, 0x80f0, 0x3c00
+ax_pose 74, 0x41fd, 0x40f0, 0x3c08
+ax_pose 70, 0x01fe, 0x44f8, 0x5c0c
+ax_pose_terminator
+sLombrePose227:
+ax_pose 75, 0x01fc, 0x44f8, 0x5c00
+ax_pose 76, 0x41ee, 0x40f0, 0x3c04
+ax_pose 77, 0x41f6, 0x80f0, 0x3c08
+ax_pose_terminator
+sLombrePose228:
+ax_pose 78, 0x01f5, 0x44f8, 0x5c00
+ax_pose 79, 0x41ea, 0x40f0, 0x3c04
+ax_pose 80, 0x41f2, 0x80f0, 0x3c08
+ax_pose_terminator
+.align 2
+sLombreAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 1, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim 2, 0, 25, 0, 3, 0, 3,
+ax_anim_terminator
+sLombreAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 19, 19, 19, 19,
+ax_anim 2, 1, 27, 20, 18, 20, 18,
+ax_anim 2, 0, 27, 19, 19, 19, 19,
+ax_anim 2, 0, 27, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sLombreAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 6, 0, 6, 0,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim_terminator
+sLombreAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 4, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 4, -4, 4, -4,
+ax_anim 1, 0, 33, 10, -12, 10, -12,
+ax_anim 2, 0, 33, 18, -20, 18, -20,
+ax_anim 2, 1, 33, 19, -19, 19, -19,
+ax_anim 2, 0, 33, 18, -20, 18, -20,
+ax_anim 2, 0, 33, 19, -19, 19, -19,
+ax_anim 2, 0, 34, 6, -6, 6, -6,
+ax_anim 2, 0, 35, 3, -3, 3, -3,
+ax_anim_terminator
+sLombreAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 1, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 0, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -6, 0, -6,
+ax_anim 2, 0, 38, 0, -3, 0, -3,
+ax_anim_terminator
+sLombreAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 4, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -4, -4, -4, -4,
+ax_anim 1, 0, 39, -10, -12, -10, -12,
+ax_anim 2, 0, 39, -18, -20, -18, -20,
+ax_anim 2, 1, 39, -19, -19, -19, -19,
+ax_anim 2, 0, 39, -18, -20, -18, -20,
+ax_anim 2, 0, 39, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -6, -6, -6, -6,
+ax_anim 2, 0, 41, -3, -3, -3, -3,
+ax_anim_terminator
+sLombreAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim 2, 0, 44, -3, 0, -3, 0,
+ax_anim_terminator
+sLombreAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -19, 19, -19, 19,
+ax_anim 2, 1, 45, -20, 18, -20, 18,
+ax_anim 2, 0, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -20, 18, -20, 18,
+ax_anim 2, 0, 46, -8, 8, -8, 8,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sLombreAnims_3_1:
+ax_anim 2, 0, 52, 0, -2, 0, -2,
+ax_anim 4, 0, 52, 0, -3, 0, -3,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 2, 52, 0, 5, 0, 5,
+ax_anim 3, 0, 49, 0, 17, 0, 17,
+ax_anim 4, 1, 50, 1, 17, 0, 17,
+ax_anim 2, 0, 50, 1, 16, 0, 16,
+ax_anim 3, 0, 51, 0, 17, 0, 17,
+ax_anim 4, 0, 52, -1, 17, 0, 17,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sLombreAnims_3_2:
+ax_anim 2, 0, 57, -2, -2, -2, -2,
+ax_anim 4, 0, 57, -3, -3, -3, -3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 2, 57, 5, 5, 5, 5,
+ax_anim 3, 0, 54, 18, 18, 18, 18,
+ax_anim 4, 1, 55, 17, 19, 17, 19,
+ax_anim 2, 0, 55, 16, 17, 16, 17,
+ax_anim 3, 0, 56, 18, 18, 18, 18,
+ax_anim 4, 0, 57, 19, 18, 19, 18,
+ax_anim 2, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 4, 4, 4, 4,
+ax_anim_terminator
+sLombreAnims_3_3:
+ax_anim 2, 0, 62, -2, 0, -2, 0,
+ax_anim 4, 0, 62, -3, 0, -3, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 2, 62, 5, 0, 5, 0,
+ax_anim 3, 0, 59, 12, 0, 12, 0,
+ax_anim 4, 1, 60, 12, 1, 12, 1,
+ax_anim 2, 0, 60, 11, 1, 11, 0,
+ax_anim 3, 0, 61, 12, 0, 12, 0,
+ax_anim 4, 0, 62, 13, -1, 13, -1,
+ax_anim 2, 0, 58, 8, 0, 8, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim_terminator
+sLombreAnims_3_4:
+ax_anim 2, 0, 67, -2, 2, -2, 2,
+ax_anim 4, 0, 67, -3, 3, -3, 3,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 2, 67, 5, -7, 5, -7,
+ax_anim 3, 0, 64, 16, -21, 16, -21,
+ax_anim 4, 1, 65, 17, -21, 17, -21,
+ax_anim 2, 0, 65, 15, -20, 15, -20,
+ax_anim 3, 0, 66, 16, -21, 16, -21,
+ax_anim 4, 0, 67, 15, -22, 15, -22,
+ax_anim 2, 0, 63, 10, -13, 10, -13,
+ax_anim 2, 0, 63, 4, -6, 4, -6,
+ax_anim_terminator
+sLombreAnims_3_5:
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 4, 0, 72, 0, 3, 0, 3,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 72, 0, -7, 0, -7,
+ax_anim 3, 0, 69, 0, -19, 0, -19,
+ax_anim 4, 1, 70, -1, -19, -1, -19,
+ax_anim 2, 0, 70, -1, -18, -1, -18,
+ax_anim 3, 0, 71, 0, -19, 0, -19,
+ax_anim 4, 0, 72, 1, -19, 1, -19,
+ax_anim 2, 0, 68, 0, -13, 0, -13,
+ax_anim 2, 0, 68, 0, -4, 0, -4,
+ax_anim_terminator
+sLombreAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 4, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 77, -5, -7, -5, -7,
+ax_anim 3, 0, 74, -16, -21, -16, -21,
+ax_anim 4, 1, 75, -17, -21, -17, -21,
+ax_anim 2, 0, 75, -16, -20, -16, -20,
+ax_anim 3, 0, 76, -16, -21, -16, -21,
+ax_anim 4, 0, 77, -15, -22, -15, -22,
+ax_anim 2, 0, 73, -10, -13, -10, -13,
+ax_anim 2, 0, 73, -4, -6, -4, -6,
+ax_anim_terminator
+sLombreAnims_3_7:
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim 4, 0, 82, 3, 0, 3, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 82, -5, 0, -5, 0,
+ax_anim 3, 0, 79, -12, 0, -12, 0,
+ax_anim 4, 1, 80, -13, 1, -13, 1,
+ax_anim 2, 0, 80, -11, 1, -11, 1,
+ax_anim 3, 0, 81, -12, 0, -12, 0,
+ax_anim 4, 0, 82, -13, -1, -13, -1,
+ax_anim 2, 0, 78, -8, 0, -8, 0,
+ax_anim 2, 0, 78, -4, 0, -4, 0,
+ax_anim_terminator
+sLombreAnims_3_8:
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 4, 0, 87, 3, -3, 3, -3,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 87, -7, 5, -7, 5,
+ax_anim 3, 0, 84, -18, 18, -18, 18,
+ax_anim 4, 1, 85, -17, 19, -17, 19,
+ax_anim 2, 0, 85, -15, 17, -15, 17,
+ax_anim 3, 0, 86, -18, 18, -18, 18,
+ax_anim 4, 0, 87, -19, 18, -19, 18,
+ax_anim 2, 0, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sLombreAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 4, 0, 88, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 2, 2, 89, 0, 4, 0, 4,
+ax_anim 2, 0, 89, 1, 4, 1, 4,
+ax_anim 2, 0, 89, 0, 4, 0, 4,
+ax_anim 2, 0, 89, 1, 4, 1, 4,
+ax_anim 2, 1, 89, 0, 4, 0, 4,
+ax_anim 2, 0, 89, 1, 4, 1, 4,
+ax_anim 2, 0, 89, 0, 4, 0, 4,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim_terminator
+sLombreAnims_4_2:
+ax_anim 2, 0, 90, -2, -2, -2, -2,
+ax_anim 4, 0, 90, -3, -3, -3, -3,
+ax_anim 2, 0, 90, -2, -2, -2, -2,
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim 2, 2, 91, 4, 4, 4, 4,
+ax_anim 2, 0, 91, 5, 3, 5, 3,
+ax_anim 2, 0, 91, 4, 4, 4, 4,
+ax_anim 2, 0, 91, 5, 3, 5, 3,
+ax_anim 2, 1, 91, 4, 4, 4, 4,
+ax_anim 2, 0, 91, 5, 3, 5, 3,
+ax_anim 2, 0, 91, 4, 4, 4, 4,
+ax_anim 2, 0, 90, 3, 3, 3, 3,
+ax_anim_terminator
+sLombreAnims_4_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 4, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 2, 93, 4, 0, 4, 0,
+ax_anim 2, 0, 93, 4, -1, 4, -1,
+ax_anim 2, 0, 93, 4, 0, 4, 0,
+ax_anim 2, 0, 93, 4, -1, 4, -1,
+ax_anim 2, 1, 93, 4, 0, 4, 0,
+ax_anim 2, 0, 93, 4, -1, 4, -1,
+ax_anim 2, 0, 93, 4, 0, 4, 0,
+ax_anim 2, 0, 92, 3, 0, 3, 0,
+ax_anim_terminator
+sLombreAnims_4_4:
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 4, 0, 94, -3, 3, -3, 3,
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim 2, 2, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 1, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 94, 3, -3, 3, -3,
+ax_anim_terminator
+sLombreAnims_4_5:
+ax_anim 2, 0, 96, 0, 2, 0, 2,
+ax_anim 4, 0, 96, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 2, 0, 2,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 2, 97, 0, -4, 0, -4,
+ax_anim 2, 0, 97, 1, -4, 1, -4,
+ax_anim 2, 0, 97, 0, -4, 0, -4,
+ax_anim 2, 0, 97, 1, -4, 1, -4,
+ax_anim 2, 1, 97, 0, -4, 0, -4,
+ax_anim 2, 0, 97, 1, -4, 1, -4,
+ax_anim 2, 0, 97, 0, -4, 0, -4,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim_terminator
+sLombreAnims_4_6:
+ax_anim 2, 0, 98, 2, 2, 2, 2,
+ax_anim 4, 0, 98, 3, 3, 3, 3,
+ax_anim 2, 0, 98, 2, 2, 2, 2,
+ax_anim 2, 0, 98, -1, -1, -1, -1,
+ax_anim 2, 2, 99, -4, -4, -4, -4,
+ax_anim 2, 0, 99, -5, -3, -5, -3,
+ax_anim 2, 0, 99, -4, -4, -4, -4,
+ax_anim 2, 0, 99, -5, -3, -5, -3,
+ax_anim 2, 1, 99, -4, -4, -4, -4,
+ax_anim 2, 0, 99, -5, -3, -5, -3,
+ax_anim 2, 0, 99, -4, -4, -4, -4,
+ax_anim 2, 0, 98, -3, -3, -3, -3,
+ax_anim_terminator
+sLombreAnims_4_7:
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 4, 0, 100, 3, 0, 3, 0,
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 2, 101, -4, 0, -4, 0,
+ax_anim 2, 0, 101, -4, -1, -4, -1,
+ax_anim 2, 0, 101, -4, 0, -4, 0,
+ax_anim 2, 0, 101, -4, -1, -4, -1,
+ax_anim 2, 1, 101, -4, 0, -4, 0,
+ax_anim 2, 0, 101, -4, -1, -4, -1,
+ax_anim 2, 0, 101, -4, 0, -4, 0,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sLombreAnims_4_8:
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 4, 0, 102, 3, -3, 3, -3,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim 2, 2, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 1, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sLombreAnims_5_1:
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim 4, 0, 108, 0, -3, 0, -3,
+ax_anim 1, 0, 108, 0, 8, 0, 8,
+ax_anim 2, 2, 108, 0, 21, 0, 21,
+ax_anim 3, 0, 105, 0, 41, 0, 41,
+ax_anim 4, 1, 106, 1, 41, 1, 41,
+ax_anim 2, 0, 106, 1, 40, 1, 40,
+ax_anim 3, 0, 107, 0, 41, 0, 41,
+ax_anim 4, 0, 108, -1, 41, -1, 41,
+ax_anim 2, 0, 104, 0, 10, 0, 10,
+ax_anim 2, 0, 104, 0, 4, 0, 4,
+ax_anim_terminator
+sLombreAnims_5_2:
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 4, 0, 113, -3, -3, -3, -3,
+ax_anim 1, 0, 113, 8, 8, 8, 8,
+ax_anim 2, 2, 113, 21, 21, 21, 21,
+ax_anim 3, 0, 110, 42, 42, 42, 42,
+ax_anim 4, 1, 111, 41, 43, 41, 43,
+ax_anim 2, 0, 111, 40, 41, 40, 41,
+ax_anim 3, 0, 112, 42, 42, 42, 42,
+ax_anim 4, 0, 113, 43, 42, 43, 42,
+ax_anim 2, 0, 109, 10, 10, 10, 10,
+ax_anim 2, 0, 109, 4, 4, 4, 4,
+ax_anim_terminator
+sLombreAnims_5_3:
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim 4, 0, 118, -3, 0, -3, 0,
+ax_anim 1, 0, 118, 8, 0, 8, 0,
+ax_anim 2, 2, 118, 21, 0, 21, 0,
+ax_anim 3, 0, 115, 36, 0, 36, 0,
+ax_anim 4, 1, 116, 36, 1, 36, 1,
+ax_anim 2, 0, 116, 35, 1, 35, 1,
+ax_anim 3, 0, 117, 36, 0, 36, 0,
+ax_anim 4, 0, 118, 37, -1, 37, -1,
+ax_anim 2, 0, 114, 8, 0, 8, 0,
+ax_anim 2, 0, 114, 4, 0, 4, 0,
+ax_anim_terminator
+sLombreAnims_5_4:
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim 4, 0, 123, -3, 3, -3, 3,
+ax_anim 1, 0, 123, 8, -8, 8, -8,
+ax_anim 2, 2, 123, 21, -23, 21, -23,
+ax_anim 3, 0, 120, 40, -45, 40, -45,
+ax_anim 4, 1, 121, 41, -45, 41, -45,
+ax_anim 2, 0, 121, 39, -44, 39, -44,
+ax_anim 3, 0, 122, 40, -45, 40, -45,
+ax_anim 4, 0, 123, 39, -46, 39, -46,
+ax_anim 2, 0, 119, 10, -13, 10, -13,
+ax_anim 2, 0, 119, 4, -6, 4, -6,
+ax_anim_terminator
+sLombreAnims_5_5:
+ax_anim 2, 0, 128, 0, 2, 0, 2,
+ax_anim 4, 0, 128, 0, 3, 0, 3,
+ax_anim 1, 0, 128, 0, -8, 0, -8,
+ax_anim 2, 2, 128, 0, -23, 0, -23,
+ax_anim 3, 0, 125, 0, -43, 0, -43,
+ax_anim 4, 1, 126, -1, -43, -1, -43,
+ax_anim 2, 0, 126, -1, -42, -1, -42,
+ax_anim 3, 0, 127, 0, -43, 0, -43,
+ax_anim 4, 0, 128, 1, -43, 1, -43,
+ax_anim 2, 0, 124, 0, -13, 0, -13,
+ax_anim 2, 0, 124, 0, -4, 0, -4,
+ax_anim_terminator
+sLombreAnims_5_6:
+ax_anim 2, 0, 133, 2, 2, 2, 2,
+ax_anim 4, 0, 133, 3, 3, 3, 3,
+ax_anim 1, 0, 133, -8, -8, -8, -8,
+ax_anim 2, 2, 133, -21, -23, -21, -23,
+ax_anim 3, 0, 130, -40, -45, -40, -45,
+ax_anim 4, 1, 131, -41, -45, -41, -45,
+ax_anim 2, 0, 131, -40, -44, -40, -44,
+ax_anim 3, 0, 132, -40, -45, -40, -45,
+ax_anim 4, 0, 133, -39, -46, -39, -46,
+ax_anim 2, 0, 129, -10, -13, -10, -13,
+ax_anim 2, 0, 129, -4, -6, -4, -6,
+ax_anim_terminator
+sLombreAnims_5_7:
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim 4, 0, 138, 3, 0, 3, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 2, 138, -21, 0, -21, 0,
+ax_anim 3, 0, 135, -36, 0, -36, 0,
+ax_anim 4, 1, 136, -37, 1, -37, 1,
+ax_anim 2, 0, 136, -35, 1, -35, 1,
+ax_anim 3, 0, 137, -36, 0, -36, 0,
+ax_anim 4, 0, 138, -37, -1, -37, -1,
+ax_anim 2, 0, 134, -8, 0, -8, 0,
+ax_anim 2, 0, 134, -4, 0, -4, 0,
+ax_anim_terminator
+sLombreAnims_5_8:
+ax_anim 2, 0, 143, 2, -2, 2, -2,
+ax_anim 4, 0, 143, 3, -3, 3, -3,
+ax_anim 1, 0, 143, -8, 8, -8, 8,
+ax_anim 2, 2, 143, -23, 21, -23, 21,
+ax_anim 3, 0, 140, -42, 42, -42, 42,
+ax_anim 4, 1, 141, -41, 43, -41, 43,
+ax_anim 2, 0, 141, -39, 41, -39, 41,
+ax_anim 3, 0, 142, -42, 42, -42, 42,
+ax_anim 4, 0, 143, -43, 42, -43, 42,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sLombreAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sLombreAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sLombreAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sLombreAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sLombreAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sLombreAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sLombreAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sLombreAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLombreAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -4, 0, 0,
+ax_anim 3, 0, 154, 0, -5, 0, 0,
+ax_anim 4, 0, 155, 0, -6, 0, 0,
+ax_anim 2, 0, 155, 0, -4, 0, 0,
+ax_anim 1, 0, 155, 0, -2, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_8_2:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, -4, 0, 0,
+ax_anim 3, 0, 156, 0, -5, 0, 0,
+ax_anim 4, 0, 157, 1, -7, 0, 0,
+ax_anim 2, 0, 157, 1, -5, 0, 0,
+ax_anim 1, 0, 157, 1, -3, 0, 0,
+ax_anim 10, 0, 157, 1, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_8_3:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, -4, 0, 0,
+ax_anim 3, 0, 158, 0, -5, 0, 0,
+ax_anim 4, 0, 159, -1, -7, 0, 0,
+ax_anim 2, 0, 159, 0, -5, 0, 0,
+ax_anim 1, 0, 159, 0, -3, 0, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_8_4:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, -4, 0, 0,
+ax_anim 3, 0, 160, 0, -5, 0, 0,
+ax_anim 4, 0, 161, -1, -5, 0, 0,
+ax_anim 2, 0, 161, 0, -4, 0, 0,
+ax_anim 1, 0, 161, 0, -2, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_8_5:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -2, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 3, 0, 162, 0, -5, 0, 0,
+ax_anim 4, 0, 163, 0, -6, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_8_6:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -2, 0, 0,
+ax_anim 2, 0, 164, 0, -4, 0, 0,
+ax_anim 3, 0, 164, 0, -5, 0, 0,
+ax_anim 4, 0, 165, 1, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim 1, 0, 165, 0, -2, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_8_7:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -2, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -5, 0, 0,
+ax_anim 4, 0, 167, 1, -7, 0, 0,
+ax_anim 2, 0, 167, 0, -5, 0, 0,
+ax_anim 1, 0, 167, 0, -3, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_8_8:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -2, 0, 0,
+ax_anim 2, 0, 168, 0, -4, 0, 0,
+ax_anim 3, 0, 168, 0, -5, 0, 0,
+ax_anim 4, 0, 169, -1, -7, 0, 0,
+ax_anim 2, 0, 169, -1, -5, 0, 0,
+ax_anim 1, 0, 169, -1, -3, 0, 0,
+ax_anim 10, 0, 169, -1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 18, 7, 18,
+ax_anim 3, 0, 174, 0, 22, 0, 22,
+ax_anim 2, 3, 175, -7, 18, -7, 18,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 24, 9, 24, 9,
+ax_anim 3, 0, 173, 23, 19, 23, 19,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 2, 14, 2, 14,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 22, 1, 22, 1,
+ax_anim 2, 3, 173, 17, 5, 17, 5,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -23, 11, -23,
+ax_anim 3, 0, 171, 20, -25, 20, -25,
+ax_anim 2, 3, 172, 22, -14, 22, -14,
+ax_anim 2, 0, 173, 18, -6, 18, -6,
+ax_anim 1, 0, 174, 8, 0, 8, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -6, -4, -6, -4,
+ax_anim 2, 0, 176, -8, -10, -8, -10,
+ax_anim 2, 0, 177, -7, -20, -7, -20,
+ax_anim 3, 0, 170, 0, -25, 0, -25,
+ax_anim 2, 3, 171, 7, -20, 7, -20,
+ax_anim 2, 0, 172, 8, -8, 8, -8,
+ax_anim 1, 0, 173, 6, -4, 6, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -23, -11, -23,
+ax_anim 3, 0, 177, -20, -25, -20, -25,
+ax_anim 2, 3, 176, -22, -14, -22, -14,
+ax_anim 2, 0, 175, -18, -6, -18, -6,
+ax_anim 1, 0, 174, -8, 0, -8, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -22, 1, -22, 1,
+ax_anim 2, 3, 175, -17, 5, -17, 5,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -24, 9, -24, 9,
+ax_anim 3, 0, 175, -23, 19, -23, 19,
+ax_anim 2, 3, 174, -11, 21, -11, 21,
+ax_anim 2, 0, 173, -2, 14, -2, 14,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_11_2:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_11_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_11_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_11_6:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_11_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_14_1:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_14_2:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_14_3:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_14_4:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_14_5:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_14_6:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_14_7:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_14_8:
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim 4, 0, 219, 0, 0, 0, 0,
+ax_anim 18, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLombreAnims_15_1:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_15_2:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_15_3:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_15_4:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_15_5:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_15_6:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_15_7:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreAnims_15_8:
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLombreGfx1:
+.incbin "baserom.gba", 0x1113774, 0x200
+sLombreSprites1:
+ax_sprite sLombreGfx1, 0x200
+ax_sprite_terminator
+sLombreGfx2:
+.incbin "baserom.gba", 0x1113984, 0x200
+sLombreSprites2:
+ax_sprite sLombreGfx2, 0x200
+ax_sprite_terminator
+sLombreGfx3:
+.incbin "baserom.gba", 0x1113B94, 0x200
+sLombreSprites3:
+ax_sprite sLombreGfx3, 0x200
+ax_sprite_terminator
+sLombreGfx4:
+.incbin "baserom.gba", 0x1113DA4, 0x200
+sLombreSprites4:
+ax_sprite sLombreGfx4, 0x200
+ax_sprite_terminator
+sLombreGfx5:
+.incbin "baserom.gba", 0x1113FB4, 0x200
+sLombreSprites5:
+ax_sprite sLombreGfx5, 0x200
+ax_sprite_terminator
+sLombreGfx6:
+.incbin "baserom.gba", 0x11141C4, 0x200
+sLombreSprites6:
+ax_sprite sLombreGfx6, 0x200
+ax_sprite_terminator
+sLombreGfx7:
+.incbin "baserom.gba", 0x11143D4, 0x200
+sLombreSprites7:
+ax_sprite sLombreGfx7, 0x200
+ax_sprite_terminator
+sLombreGfx8:
+.incbin "baserom.gba", 0x11145E4, 0x200
+sLombreSprites8:
+ax_sprite sLombreGfx8, 0x200
+ax_sprite_terminator
+sLombreGfx9:
+.incbin "baserom.gba", 0x11147F4, 0x200
+sLombreSprites9:
+ax_sprite sLombreGfx9, 0x200
+ax_sprite_terminator
+sLombreGfx10:
+.incbin "baserom.gba", 0x1114A04, 0x200
+sLombreSprites10:
+ax_sprite sLombreGfx10, 0x200
+ax_sprite_terminator
+sLombreGfx11:
+.incbin "baserom.gba", 0x1114C14, 0x200
+sLombreSprites11:
+ax_sprite sLombreGfx11, 0x200
+ax_sprite_terminator
+sLombreGfx12:
+.incbin "baserom.gba", 0x1114E24, 0x200
+sLombreSprites12:
+ax_sprite sLombreGfx12, 0x200
+ax_sprite_terminator
+sLombreGfx13:
+.incbin "baserom.gba", 0x1115034, 0x200
+sLombreSprites13:
+ax_sprite sLombreGfx13, 0x200
+ax_sprite_terminator
+sLombreGfx14:
+.incbin "baserom.gba", 0x1115244, 0x200
+sLombreSprites14:
+ax_sprite sLombreGfx14, 0x200
+ax_sprite_terminator
+sLombreGfx15:
+.incbin "baserom.gba", 0x1115454, 0x200
+sLombreSprites15:
+ax_sprite sLombreGfx15, 0x200
+ax_sprite_terminator
+sLombreGfx16:
+.incbin "baserom.gba", 0x1115664, 0x200
+sLombreSprites16:
+ax_sprite sLombreGfx16, 0x200
+ax_sprite_terminator
+sLombreGfx17:
+.incbin "baserom.gba", 0x1115874, 0x200
+sLombreSprites17:
+ax_sprite sLombreGfx17, 0x200
+ax_sprite_terminator
+sLombreGfx18:
+.incbin "baserom.gba", 0x1115A84, 0x200
+sLombreSprites18:
+ax_sprite sLombreGfx18, 0x200
+ax_sprite_terminator
+sLombreGfx19:
+.incbin "baserom.gba", 0x1115C94, 0x200
+sLombreSprites19:
+ax_sprite sLombreGfx19, 0x200
+ax_sprite_terminator
+sLombreGfx20:
+.incbin "baserom.gba", 0x1115EA4, 0x200
+sLombreSprites20:
+ax_sprite sLombreGfx20, 0x200
+ax_sprite_terminator
+sLombreGfx21:
+.incbin "baserom.gba", 0x11160B4, 0x200
+sLombreSprites21:
+ax_sprite sLombreGfx21, 0x200
+ax_sprite_terminator
+sLombreGfx22:
+.incbin "baserom.gba", 0x11162C4, 0x200
+sLombreSprites22:
+ax_sprite sLombreGfx22, 0x200
+ax_sprite_terminator
+sLombreGfx23:
+.incbin "baserom.gba", 0x11164D4, 0x200
+sLombreSprites23:
+ax_sprite sLombreGfx23, 0x200
+ax_sprite_terminator
+sLombreGfx24:
+.incbin "baserom.gba", 0x11166E4, 0x200
+sLombreSprites24:
+ax_sprite sLombreGfx24, 0x200
+ax_sprite_terminator
+sLombreGfx25:
+.incbin "baserom.gba", 0x11168F4, 0x60
+sLombreGfx25_1:
+.incbin "baserom.gba", 0x1116954, 0x60
+sLombreGfx25_2:
+.incbin "baserom.gba", 0x11169B4, 0x60
+sLombreGfx25_3:
+.incbin "baserom.gba", 0x1116A14, 0x60
+sLombreSprites25:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx25_3, 0x60
+ax_sprite_terminator
+sLombreGfx26:
+.incbin "baserom.gba", 0x1116ABC, 0x40
+sLombreGfx26_1:
+.incbin "baserom.gba", 0x1116AFC, 0x100
+sLombreGfx26_2:
+.incbin "baserom.gba", 0x1116BFC, 0x40
+sLombreSprites26:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx27:
+.incbin "baserom.gba", 0x1116C7C, 0x60
+sLombreGfx27_1:
+.incbin "baserom.gba", 0x1116CDC, 0x60
+sLombreGfx27_2:
+.incbin "baserom.gba", 0x1116D3C, 0x60
+sLombreGfx27_3:
+.incbin "baserom.gba", 0x1116D9C, 0x60
+sLombreSprites27:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx27_3, 0x60
+ax_sprite_terminator
+sLombreGfx28:
+.incbin "baserom.gba", 0x1116E44, 0x60
+sLombreGfx28_1:
+.incbin "baserom.gba", 0x1116EA4, 0x60
+sLombreGfx28_2:
+.incbin "baserom.gba", 0x1116F04, 0x60
+sLombreGfx28_3:
+.incbin "baserom.gba", 0x1116F64, 0x40
+sLombreSprites28:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx29:
+.incbin "baserom.gba", 0x1116FF4, 0x160
+sLombreGfx29_1:
+.incbin "baserom.gba", 0x1117154, 0x20
+sLombreSprites29:
+ax_sprite sLombreGfx29, 0x160
+ax_sprite 0, 0x60
+ax_sprite sLombreGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx30:
+.incbin "baserom.gba", 0x111719C, 0x60
+sLombreGfx30_1:
+.incbin "baserom.gba", 0x11171FC, 0x60
+sLombreGfx30_2:
+.incbin "baserom.gba", 0x111725C, 0x60
+sLombreGfx30_3:
+.incbin "baserom.gba", 0x11172BC, 0x40
+sLombreSprites30:
+ax_sprite sLombreGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx31:
+.incbin "baserom.gba", 0x1117344, 0x60
+sLombreGfx31_1:
+.incbin "baserom.gba", 0x11173A4, 0x60
+sLombreGfx31_2:
+.incbin "baserom.gba", 0x1117404, 0x60
+sLombreGfx31_3:
+.incbin "baserom.gba", 0x1117464, 0x60
+sLombreSprites31:
+ax_sprite sLombreGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx32:
+.incbin "baserom.gba", 0x111750C, 0x40
+sLombreGfx32_1:
+.incbin "baserom.gba", 0x111754C, 0x100
+sLombreGfx32_2:
+.incbin "baserom.gba", 0x111764C, 0x40
+sLombreSprites32:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx33:
+.incbin "baserom.gba", 0x11176CC, 0x100
+sLombreSprites33:
+ax_sprite sLombreGfx33, 0x100
+ax_sprite_terminator
+sLombreGfx34:
+.incbin "baserom.gba", 0x11177DC, 0x100
+sLombreSprites34:
+ax_sprite sLombreGfx34, 0x100
+ax_sprite_terminator
+sLombreGfx35:
+.incbin "baserom.gba", 0x11178EC, 0x60
+sLombreGfx35_1:
+.incbin "baserom.gba", 0x111794C, 0x60
+sLombreGfx35_2:
+.incbin "baserom.gba", 0x11179AC, 0x60
+sLombreGfx35_3:
+.incbin "baserom.gba", 0x1117A0C, 0x60
+sLombreSprites35:
+ax_sprite sLombreGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx36:
+.incbin "baserom.gba", 0x1117AB4, 0x60
+sLombreGfx36_1:
+.incbin "baserom.gba", 0x1117B14, 0x60
+sLombreSprites36:
+ax_sprite sLombreGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx37:
+.incbin "baserom.gba", 0x1117B9C, 0xE0
+sLombreSprites37:
+ax_sprite sLombreGfx37, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx38:
+.incbin "baserom.gba", 0x1117C94, 0x20
+sLombreGfx38_1:
+.incbin "baserom.gba", 0x1117CB4, 0x60
+sLombreGfx38_2:
+.incbin "baserom.gba", 0x1117D14, 0xC0
+sLombreSprites38:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx38, 0x20
+ax_sprite 0, 0x60
+ax_sprite sLombreGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx38_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx39:
+.incbin "baserom.gba", 0x1117E14, 0x20
+sLombreGfx39_1:
+.incbin "baserom.gba", 0x1117E34, 0x60
+sLombreSprites39:
+ax_sprite sLombreGfx39, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx39_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sLombreGfx40:
+.incbin "baserom.gba", 0x1117EBC, 0x60
+sLombreGfx40_1:
+.incbin "baserom.gba", 0x1117F1C, 0x60
+sLombreSprites40:
+ax_sprite sLombreGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx41:
+.incbin "baserom.gba", 0x1117FA4, 0x20
+sLombreGfx41_1:
+.incbin "baserom.gba", 0x1117FC4, 0x60
+sLombreGfx41_2:
+.incbin "baserom.gba", 0x1118024, 0x60
+sLombreGfx41_3:
+.incbin "baserom.gba", 0x1118084, 0x60
+sLombreSprites41:
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx41, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx41_3, 0x60
+ax_sprite_terminator
+sLombreGfx42:
+.incbin "baserom.gba", 0x111812C, 0x20
+sLombreGfx42_1:
+.incbin "baserom.gba", 0x111814C, 0x20
+sLombreGfx42_2:
+.incbin "baserom.gba", 0x111816C, 0x40
+sLombreSprites42:
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx42, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx42_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx42_2, 0x40
+ax_sprite_terminator
+sLombreGfx43:
+.incbin "baserom.gba", 0x11181E4, 0x20
+sLombreGfx43_1:
+.incbin "baserom.gba", 0x1118204, 0x40
+sLombreSprites43:
+ax_sprite sLombreGfx43, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx43_1, 0x40
+ax_sprite_terminator
+sLombreGfx44:
+.incbin "baserom.gba", 0x1118264, 0x140
+sLombreGfx44_1:
+.incbin "baserom.gba", 0x11183A4, 0x20
+sLombreSprites44:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx44, 0x140
+ax_sprite 0, 0x60
+ax_sprite sLombreGfx44_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx45:
+.incbin "baserom.gba", 0x11183F4, 0x20
+sLombreGfx45_1:
+.incbin "baserom.gba", 0x1118414, 0x60
+sLombreGfx45_2:
+.incbin "baserom.gba", 0x1118474, 0x40
+sLombreSprites45:
+ax_sprite sLombreGfx45, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx45_2, 0x40
+ax_sprite_terminator
+sLombreGfx46:
+.incbin "baserom.gba", 0x11184E4, 0x40
+sLombreGfx46_1:
+.incbin "baserom.gba", 0x1118524, 0x60
+sLombreGfx46_2:
+.incbin "baserom.gba", 0x1118584, 0x20
+sLombreSprites46:
+ax_sprite sLombreGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx46_2, 0x20
+ax_sprite_terminator
+sLombreGfx47:
+.incbin "baserom.gba", 0x11185D4, 0x100
+sLombreGfx47_1:
+.incbin "baserom.gba", 0x11186D4, 0x60
+sLombreGfx47_2:
+.incbin "baserom.gba", 0x1118734, 0x20
+sLombreSprites47:
+ax_sprite sLombreGfx47, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx47_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLombreGfx48:
+.incbin "baserom.gba", 0x111878C, 0x60
+sLombreGfx48_1:
+.incbin "baserom.gba", 0x11187EC, 0x80
+sLombreGfx48_2:
+.incbin "baserom.gba", 0x111886C, 0x60
+sLombreGfx48_3:
+.incbin "baserom.gba", 0x11188CC, 0x20
+sLombreSprites48:
+ax_sprite sLombreGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx48_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx48_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLombreGfx49:
+.incbin "baserom.gba", 0x1118934, 0x20
+sLombreGfx49_1:
+.incbin "baserom.gba", 0x1118954, 0x60
+sLombreGfx49_2:
+.incbin "baserom.gba", 0x11189B4, 0x60
+sLombreGfx49_3:
+.incbin "baserom.gba", 0x1118A14, 0x60
+sLombreSprites49:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx49, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx49_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx50:
+.incbin "baserom.gba", 0x1118AC4, 0x20
+sLombreGfx50_1:
+.incbin "baserom.gba", 0x1118AE4, 0x60
+sLombreGfx50_2:
+.incbin "baserom.gba", 0x1118B44, 0x60
+sLombreGfx50_3:
+.incbin "baserom.gba", 0x1118BA4, 0x60
+sLombreSprites50:
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx50, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx50_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx50_3, 0x60
+ax_sprite_terminator
+sLombreGfx51:
+.incbin "baserom.gba", 0x1118C4C, 0x40
+sLombreGfx51_1:
+.incbin "baserom.gba", 0x1118C8C, 0xE0
+sLombreGfx51_2:
+.incbin "baserom.gba", 0x1118D6C, 0x80
+sLombreSprites51:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx51, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx51_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx51_2, 0x80
+ax_sprite_terminator
+sLombreGfx52:
+.incbin "baserom.gba", 0x1118E24, 0x60
+sLombreGfx52_1:
+.incbin "baserom.gba", 0x1118E84, 0x60
+sLombreGfx52_2:
+.incbin "baserom.gba", 0x1118EE4, 0x60
+sLombreSprites52:
+ax_sprite 0, 0xa0
+ax_sprite sLombreGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx52_2, 0x60
+ax_sprite_terminator
+sLombreGfx53:
+.incbin "baserom.gba", 0x1118F7C, 0x20
+sLombreGfx53_1:
+.incbin "baserom.gba", 0x1118F9C, 0x60
+sLombreGfx53_2:
+.incbin "baserom.gba", 0x1118FFC, 0x60
+sLombreGfx53_3:
+.incbin "baserom.gba", 0x111905C, 0x60
+sLombreSprites53:
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx53, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx53_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx53_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx53_3, 0x60
+ax_sprite_terminator
+sLombreGfx54:
+.incbin "baserom.gba", 0x1119104, 0x60
+sLombreGfx54_1:
+.incbin "baserom.gba", 0x1119164, 0x60
+sLombreGfx54_2:
+.incbin "baserom.gba", 0x11191C4, 0x60
+sLombreGfx54_3:
+.incbin "baserom.gba", 0x1119224, 0x60
+sLombreSprites54:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx54_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx54_3, 0x60
+ax_sprite_terminator
+sLombreGfx55:
+.incbin "baserom.gba", 0x11192CC, 0x180
+sLombreGfx55_1:
+.incbin "baserom.gba", 0x111944C, 0x40
+sLombreSprites55:
+ax_sprite sLombreGfx55, 0x180
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx55_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx56:
+.incbin "baserom.gba", 0x11194B4, 0x60
+sLombreGfx56_1:
+.incbin "baserom.gba", 0x1119514, 0x60
+sLombreGfx56_2:
+.incbin "baserom.gba", 0x1119574, 0x60
+sLombreGfx56_3:
+.incbin "baserom.gba", 0x11195D4, 0x60
+sLombreSprites56:
+ax_sprite sLombreGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx56_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx56_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx57:
+.incbin "baserom.gba", 0x111967C, 0x20
+sLombreGfx57_1:
+.incbin "baserom.gba", 0x111969C, 0x60
+sLombreGfx57_2:
+.incbin "baserom.gba", 0x11196FC, 0x60
+sLombreGfx57_3:
+.incbin "baserom.gba", 0x111975C, 0x60
+sLombreSprites57:
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx57, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLombreGfx57_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx57_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx57_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx58:
+.incbin "baserom.gba", 0x111980C, 0x60
+sLombreGfx58_1:
+.incbin "baserom.gba", 0x111986C, 0x60
+sLombreGfx58_2:
+.incbin "baserom.gba", 0x11198CC, 0x60
+sLombreSprites58:
+ax_sprite 0, 0x80
+ax_sprite sLombreGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx58_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLombreGfx58_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLombreGfx59:
+.incbin "baserom.gba", 0x111996C, 0x200
+sLombreSprites59:
+ax_sprite sLombreGfx59, 0x200
+ax_sprite_terminator
+sLombreGfx60:
+.incbin "baserom.gba", 0x1119B7C, 0x200
+sLombreSprites60:
+ax_sprite sLombreGfx60, 0x200
+ax_sprite_terminator
+sLombreGfx61:
+.incbin "baserom.gba", 0x1119D8C, 0x200
+sLombreSprites61:
+ax_sprite sLombreGfx61, 0x200
+ax_sprite_terminator
+sLombreGfx62:
+.incbin "baserom.gba", 0x1119F9C, 0x200
+sLombreSprites62:
+ax_sprite sLombreGfx62, 0x200
+ax_sprite_terminator
+sLombreGfx63:
+.incbin "baserom.gba", 0x111A1AC, 0x200
+sLombreSprites63:
+ax_sprite sLombreGfx63, 0x200
+ax_sprite_terminator
+sLombreGfx64:
+.incbin "baserom.gba", 0x111A3BC, 0x200
+sLombreSprites64:
+ax_sprite sLombreGfx64, 0x200
+ax_sprite_terminator
+sLombreGfx65:
+.incbin "baserom.gba", 0x111A5CC, 0x200
+sLombreSprites65:
+ax_sprite sLombreGfx65, 0x200
+ax_sprite_terminator
+sLombreGfx66:
+.incbin "baserom.gba", 0x111A7DC, 0x200
+sLombreSprites66:
+ax_sprite sLombreGfx66, 0x200
+ax_sprite_terminator
+sLombreGfx67:
+.incbin "baserom.gba", 0x111A9EC, 0x200
+sLombreSprites67:
+ax_sprite sLombreGfx67, 0x200
+ax_sprite_terminator
+sLombreGfx68:
+.incbin "baserom.gba", 0x111ABFC, 0x200
+sLombreSprites68:
+ax_sprite sLombreGfx68, 0x200
+ax_sprite_terminator
+sLombreGfx69:
+.incbin "baserom.gba", 0x111AE0C, 0x80
+sLombreSprites69:
+ax_sprite sLombreGfx69, 0x80
+ax_sprite_terminator
+sLombreGfx70:
+.incbin "baserom.gba", 0x111AE9C, 0x100
+sLombreSprites70:
+ax_sprite sLombreGfx70, 0x100
+ax_sprite_terminator
+sLombreGfx71:
+.incbin "baserom.gba", 0x111AFAC, 0x80
+sLombreSprites71:
+ax_sprite sLombreGfx71, 0x80
+ax_sprite_terminator
+sLombreGfx72:
+.incbin "baserom.gba", 0x111B03C, 0x80
+sLombreSprites72:
+ax_sprite sLombreGfx72, 0x80
+ax_sprite_terminator
+sLombreGfx73:
+.incbin "baserom.gba", 0x111B0CC, 0x100
+sLombreSprites73:
+ax_sprite sLombreGfx73, 0x100
+ax_sprite_terminator
+sLombreGfx74:
+.incbin "baserom.gba", 0x111B1DC, 0x100
+sLombreSprites74:
+ax_sprite sLombreGfx74, 0x100
+ax_sprite_terminator
+sLombreGfx75:
+.incbin "baserom.gba", 0x111B2EC, 0x80
+sLombreSprites75:
+ax_sprite sLombreGfx75, 0x80
+ax_sprite_terminator
+sLombreGfx76:
+.incbin "baserom.gba", 0x111B37C, 0x80
+sLombreSprites76:
+ax_sprite sLombreGfx76, 0x80
+ax_sprite_terminator
+sLombreGfx77:
+.incbin "baserom.gba", 0x111B40C, 0x80
+sLombreSprites77:
+ax_sprite sLombreGfx77, 0x80
+ax_sprite_terminator
+sLombreGfx78:
+.incbin "baserom.gba", 0x111B49C, 0x100
+sLombreSprites78:
+ax_sprite sLombreGfx78, 0x100
+ax_sprite_terminator
+sLombreGfx79:
+.incbin "baserom.gba", 0x111B5AC, 0x80
+sLombreSprites79:
+ax_sprite sLombreGfx79, 0x80
+ax_sprite_terminator
+sLombreGfx80:
+.incbin "baserom.gba", 0x111B63C, 0x80
+sLombreSprites80:
+ax_sprite sLombreGfx80, 0x80
+ax_sprite_terminator
+sLombreGfx81:
+.incbin "baserom.gba", 0x111B6CC, 0x100
+sLombreSprites81:
+ax_sprite sLombreGfx81, 0x100
+ax_sprite_terminator
+sAxPosesLombre:
+.4byte sLombrePose1
+.4byte sLombrePose2
+.4byte sLombrePose3
+.4byte sLombrePose4
+.4byte sLombrePose5
+.4byte sLombrePose6
+.4byte sLombrePose7
+.4byte sLombrePose8
+.4byte sLombrePose9
+.4byte sLombrePose10
+.4byte sLombrePose11
+.4byte sLombrePose12
+.4byte sLombrePose13
+.4byte sLombrePose14
+.4byte sLombrePose15
+.4byte sLombrePose16
+.4byte sLombrePose17
+.4byte sLombrePose18
+.4byte sLombrePose19
+.4byte sLombrePose20
+.4byte sLombrePose21
+.4byte sLombrePose22
+.4byte sLombrePose23
+.4byte sLombrePose24
+.4byte sLombrePose25
+.4byte sLombrePose26
+.4byte sLombrePose27
+.4byte sLombrePose28
+.4byte sLombrePose29
+.4byte sLombrePose30
+.4byte sLombrePose31
+.4byte sLombrePose32
+.4byte sLombrePose33
+.4byte sLombrePose34
+.4byte sLombrePose35
+.4byte sLombrePose36
+.4byte sLombrePose37
+.4byte sLombrePose38
+.4byte sLombrePose39
+.4byte sLombrePose40
+.4byte sLombrePose41
+.4byte sLombrePose42
+.4byte sLombrePose43
+.4byte sLombrePose44
+.4byte sLombrePose45
+.4byte sLombrePose46
+.4byte sLombrePose47
+.4byte sLombrePose48
+.4byte sLombrePose49
+.4byte sLombrePose50
+.4byte sLombrePose51
+.4byte sLombrePose52
+.4byte sLombrePose53
+.4byte sLombrePose54
+.4byte sLombrePose55
+.4byte sLombrePose56
+.4byte sLombrePose57
+.4byte sLombrePose58
+.4byte sLombrePose59
+.4byte sLombrePose60
+.4byte sLombrePose61
+.4byte sLombrePose62
+.4byte sLombrePose63
+.4byte sLombrePose64
+.4byte sLombrePose65
+.4byte sLombrePose66
+.4byte sLombrePose67
+.4byte sLombrePose68
+.4byte sLombrePose69
+.4byte sLombrePose70
+.4byte sLombrePose71
+.4byte sLombrePose72
+.4byte sLombrePose73
+.4byte sLombrePose74
+.4byte sLombrePose75
+.4byte sLombrePose76
+.4byte sLombrePose77
+.4byte sLombrePose78
+.4byte sLombrePose79
+.4byte sLombrePose80
+.4byte sLombrePose81
+.4byte sLombrePose82
+.4byte sLombrePose83
+.4byte sLombrePose84
+.4byte sLombrePose85
+.4byte sLombrePose86
+.4byte sLombrePose87
+.4byte sLombrePose88
+.4byte sLombrePose89
+.4byte sLombrePose90
+.4byte sLombrePose91
+.4byte sLombrePose92
+.4byte sLombrePose93
+.4byte sLombrePose94
+.4byte sLombrePose95
+.4byte sLombrePose96
+.4byte sLombrePose97
+.4byte sLombrePose98
+.4byte sLombrePose99
+.4byte sLombrePose100
+.4byte sLombrePose101
+.4byte sLombrePose102
+.4byte sLombrePose103
+.4byte sLombrePose104
+.4byte sLombrePose105
+.4byte sLombrePose106
+.4byte sLombrePose107
+.4byte sLombrePose108
+.4byte sLombrePose109
+.4byte sLombrePose110
+.4byte sLombrePose111
+.4byte sLombrePose112
+.4byte sLombrePose113
+.4byte sLombrePose114
+.4byte sLombrePose115
+.4byte sLombrePose116
+.4byte sLombrePose117
+.4byte sLombrePose118
+.4byte sLombrePose119
+.4byte sLombrePose120
+.4byte sLombrePose121
+.4byte sLombrePose122
+.4byte sLombrePose123
+.4byte sLombrePose124
+.4byte sLombrePose125
+.4byte sLombrePose126
+.4byte sLombrePose127
+.4byte sLombrePose128
+.4byte sLombrePose129
+.4byte sLombrePose130
+.4byte sLombrePose131
+.4byte sLombrePose132
+.4byte sLombrePose133
+.4byte sLombrePose134
+.4byte sLombrePose135
+.4byte sLombrePose136
+.4byte sLombrePose137
+.4byte sLombrePose138
+.4byte sLombrePose139
+.4byte sLombrePose140
+.4byte sLombrePose141
+.4byte sLombrePose142
+.4byte sLombrePose143
+.4byte sLombrePose144
+.4byte sLombrePose145
+.4byte sLombrePose146
+.4byte sLombrePose147
+.4byte sLombrePose148
+.4byte sLombrePose149
+.4byte sLombrePose150
+.4byte sLombrePose151
+.4byte sLombrePose152
+.4byte sLombrePose153
+.4byte sLombrePose154
+.4byte sLombrePose155
+.4byte sLombrePose156
+.4byte sLombrePose157
+.4byte sLombrePose158
+.4byte sLombrePose159
+.4byte sLombrePose160
+.4byte sLombrePose161
+.4byte sLombrePose162
+.4byte sLombrePose163
+.4byte sLombrePose164
+.4byte sLombrePose165
+.4byte sLombrePose166
+.4byte sLombrePose167
+.4byte sLombrePose168
+.4byte sLombrePose169
+.4byte sLombrePose170
+.4byte sLombrePose171
+.4byte sLombrePose172
+.4byte sLombrePose173
+.4byte sLombrePose174
+.4byte sLombrePose175
+.4byte sLombrePose176
+.4byte sLombrePose177
+.4byte sLombrePose178
+.4byte sLombrePose179
+.4byte sLombrePose180
+.4byte sLombrePose181
+.4byte sLombrePose182
+.4byte sLombrePose183
+.4byte sLombrePose184
+.4byte sLombrePose185
+.4byte sLombrePose186
+.4byte sLombrePose187
+.4byte sLombrePose188
+.4byte sLombrePose189
+.4byte sLombrePose190
+.4byte sLombrePose191
+.4byte sLombrePose192
+.4byte sLombrePose193
+.4byte sLombrePose194
+.4byte sLombrePose195
+.4byte sLombrePose196
+.4byte sLombrePose197
+.4byte sLombrePose198
+.4byte sLombrePose199
+.4byte sLombrePose200
+.4byte sLombrePose201
+.4byte sLombrePose202
+.4byte sLombrePose203
+.4byte sLombrePose204
+.4byte sLombrePose205
+.4byte sLombrePose206
+.4byte sLombrePose207
+.4byte sLombrePose208
+.4byte sLombrePose209
+.4byte sLombrePose210
+.4byte sLombrePose211
+.4byte sLombrePose212
+.4byte sLombrePose213
+.4byte sLombrePose214
+.4byte sLombrePose215
+.4byte sLombrePose216
+.4byte sLombrePose217
+.4byte sLombrePose218
+.4byte sLombrePose219
+.4byte sLombrePose220
+.4byte sLombrePose221
+.4byte sLombrePose222
+.4byte sLombrePose223
+.4byte sLombrePose224
+.4byte sLombrePose225
+.4byte sLombrePose226
+.4byte sLombrePose227
+.4byte sLombrePose228
+sAxPositionsLombre:
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte   -2,   -6, 	 -11,   -1, 	   7,    0, 	  -2,   -8
+.2byte    0,   -6, 	  -8,    0, 	  10,   -1, 	   0,   -8
+.2byte    2,   -7, 	  -7,   -1, 	   7,   -4, 	  -1,   -7
+.2byte    3,   -6, 	  -4,    0, 	   8,   -4, 	   0,   -6
+.2byte    1,   -5, 	  -8,    0, 	   6,   -2, 	  -2,   -5
+.2byte    4,   -7, 	   1,   -1, 	   3,   -4, 	  -2,   -7
+.2byte    5,   -6, 	   2,   -1, 	  -3,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   0,    1, 	   4,   -2, 	  -2,   -5
+.2byte    5,   -8, 	   6,   -2, 	  -6,   -4, 	  -1,   -7
+.2byte    4,   -7, 	   5,   -2, 	  -7,   -4, 	  -2,   -6
+.2byte    6,   -7, 	   6,   -1, 	  -2,   -4, 	   0,   -6
+.2byte   -1,  -12, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte    1,  -12, 	   9,   -3, 	  -9,   -4, 	  -1,   -7
+.2byte   -3,  -12, 	   7,   -4, 	 -11,   -3, 	  -1,   -7
+.2byte   -6,   -8, 	   5,   -4, 	  -8,   -2, 	   0,   -7
+.2byte   -5,   -7, 	   6,   -4, 	  -7,   -2, 	   0,   -6
+.2byte   -7,   -7, 	   1,   -5, 	  -8,   -1, 	  -1,   -6
+.2byte   -6,   -7, 	  -5,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte   -7,   -6, 	   1,   -2, 	  -4,   -1, 	  -2,   -6
+.2byte   -6,   -5, 	  -5,   -2, 	  -2,    1, 	  -1,   -5
+.2byte   -4,   -7, 	  -9,   -4, 	   5,   -1, 	  -1,   -7
+.2byte   -5,   -6, 	 -10,   -4, 	   2,    0, 	  -2,   -6
+.2byte   -3,   -5, 	  -8,   -2, 	   6,    0, 	   0,   -5
+.2byte    0,   -5, 	   4,   -4, 	   8,   -6, 	   0,   -7
+.2byte   -2,   -6, 	 -11,   -1, 	   7,    0, 	  -2,   -8
+.2byte    0,   -6, 	  -8,    0, 	  10,   -1, 	   0,   -8
+.2byte    3,   -5, 	 -10,   -8, 	  -3,   -3, 	  -2,   -6
+.2byte    4,   -7, 	  -3,   -1, 	   9,   -5, 	   1,   -7
+.2byte    2,   -5, 	  -7,    0, 	   7,   -2, 	  -1,   -5
+.2byte    5,   -5, 	  -8,   -5, 	   8,   -3, 	  -1,   -7
+.2byte    5,   -6, 	   2,   -1, 	  -3,   -3, 	  -1,   -6
+.2byte    4,   -5, 	   0,    1, 	   4,   -2, 	  -2,   -5
+.2byte    6,  -10, 	   4,   -5, 	   8,   -6, 	   1,   -8
+.2byte    4,   -7, 	   5,   -2, 	  -7,   -4, 	  -2,   -6
+.2byte    6,   -7, 	   6,   -1, 	  -2,   -4, 	   0,   -6
+.2byte   -3,   -9, 	  -6,   -7, 	  -7,   -3, 	   0,   -7
+.2byte    1,  -12, 	   9,   -3, 	  -9,   -4, 	  -1,   -7
+.2byte   -2,  -12, 	   8,   -4, 	 -10,   -3, 	   0,   -7
+.2byte   -5,   -9, 	  -9,   -6, 	  -6,   -5, 	  -1,   -9
+.2byte   -4,   -7, 	   7,   -4, 	  -6,   -2, 	   1,   -6
+.2byte   -6,   -7, 	   2,   -5, 	  -7,   -1, 	   0,   -6
+.2byte   -5,   -5, 	  -9,   -3, 	   6,   -6, 	   0,   -6
+.2byte   -6,   -6, 	   2,   -2, 	  -3,   -1, 	  -1,   -6
+.2byte   -5,   -5, 	  -4,   -2, 	  -1,    1, 	   0,   -5
+.2byte   -4,   -5, 	   2,   -3, 	   9,   -8, 	   0,   -7
+.2byte   -5,   -7, 	 -10,   -5, 	   2,   -1, 	  -2,   -7
+.2byte   -3,   -5, 	  -8,   -2, 	   6,    0, 	   0,   -5
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte    3,   -4, 	   7,   -3, 	  11,   -5, 	   3,   -6
+.2byte    3,   -4, 	   7,   -3, 	  11,   -5, 	   3,   -6
+.2byte   -4,   -4, 	 -12,   -5, 	  -9,   -3, 	  -4,   -6
+.2byte   -4,   -4, 	 -12,   -5, 	  -9,   -3, 	  -4,   -6
+.2byte    2,   -7, 	  -7,   -1, 	   7,   -4, 	  -1,   -7
+.2byte    2,   -4, 	 -11,   -7, 	  -4,   -2, 	  -3,   -5
+.2byte    2,   -4, 	 -11,   -7, 	  -4,   -2, 	  -3,   -5
+.2byte    4,   -5, 	   8,   -5, 	   3,   -3, 	   0,   -6
+.2byte    4,   -5, 	   8,   -5, 	   3,   -3, 	   0,   -6
+.2byte    4,   -7, 	   1,   -1, 	   3,   -4, 	  -2,   -7
+.2byte    7,   -5, 	  -6,   -5, 	  10,   -3, 	   1,   -7
+.2byte    7,   -5, 	  -6,   -5, 	  10,   -3, 	   1,   -7
+.2byte    7,   -7, 	  10,   -7, 	  -1,   -6, 	   2,   -7
+.2byte    7,   -7, 	  10,   -7, 	  -1,   -6, 	   2,   -7
+.2byte    5,   -8, 	   6,   -2, 	  -6,   -4, 	  -1,   -7
+.2byte    6,  -10, 	   4,   -5, 	   8,   -6, 	   1,   -8
+.2byte    6,  -10, 	   4,   -5, 	   8,   -6, 	   1,   -8
+.2byte    3,  -13, 	  -9,  -10, 	  -4,   -6, 	   0,   -8
+.2byte    3,  -13, 	  -9,  -10, 	  -4,   -6, 	   0,   -8
+.2byte   -1,  -12, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	  -2,  -10
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	  -2,  -10
+.2byte    4,  -12, 	   8,   -6, 	   7,  -10, 	   1,  -10
+.2byte    4,  -12, 	   8,   -6, 	   7,  -10, 	   1,  -10
+.2byte   -6,   -8, 	   5,   -4, 	  -8,   -2, 	   0,   -7
+.2byte   -6,   -9, 	 -10,   -6, 	  -7,   -5, 	  -2,   -9
+.2byte   -6,   -9, 	 -10,   -6, 	  -7,   -5, 	  -2,   -9
+.2byte    0,  -10, 	   2,   -8, 	   7,  -10, 	  -2,   -9
+.2byte    0,  -10, 	   2,   -8, 	   7,  -10, 	  -2,   -9
+.2byte   -6,   -7, 	  -5,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte   -8,   -5, 	 -12,   -3, 	   3,   -6, 	  -3,   -6
+.2byte   -8,   -5, 	 -12,   -3, 	   3,   -6, 	  -3,   -6
+.2byte   -9,   -7, 	  -2,   -8, 	 -13,   -6, 	  -4,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	 -13,   -6, 	  -4,   -7
+.2byte   -4,   -7, 	  -9,   -4, 	   5,   -1, 	  -1,   -7
+.2byte   -4,   -4, 	   2,   -2, 	   9,   -7, 	   0,   -6
+.2byte   -4,   -4, 	   2,   -2, 	   9,   -7, 	   0,   -6
+.2byte   -6,   -5, 	  -6,   -6, 	 -10,   -5, 	  -2,   -6
+.2byte   -6,   -5, 	  -6,   -6, 	 -10,   -5, 	  -2,   -6
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte   -1,   -3, 	  -9,    1, 	   7,    1, 	  -1,   -6
+.2byte    2,   -7, 	  -7,   -1, 	   7,   -4, 	  -1,   -7
+.2byte    3,   -3, 	  -3,    1, 	   9,   -1, 	  -1,   -4
+.2byte    4,   -7, 	   1,   -1, 	   3,   -4, 	  -2,   -7
+.2byte    8,   -5, 	   5,    1, 	   8,   -1, 	   1,   -5
+.2byte    5,   -8, 	   6,   -2, 	  -6,   -4, 	  -1,   -7
+.2byte    7,   -9, 	   8,   -2, 	   1,   -4, 	   0,   -7
+.2byte   -1,  -12, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte   -1,  -13, 	   7,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,   -8, 	   5,   -4, 	  -8,   -2, 	   0,   -7
+.2byte   -9,   -9, 	  -2,   -6, 	 -10,   -2, 	  -3,   -8
+.2byte   -6,   -7, 	  -5,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte  -10,   -5, 	 -10,   -1, 	  -7,    2, 	  -3,   -5
+.2byte   -4,   -7, 	  -9,   -4, 	   5,   -1, 	  -1,   -7
+.2byte   -5,   -3, 	 -11,   -1, 	   1,    2, 	  -1,   -5
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte    3,   -4, 	   7,   -3, 	  11,   -5, 	   3,   -6
+.2byte    3,   -4, 	   7,   -3, 	  11,   -5, 	   3,   -6
+.2byte   -4,   -4, 	 -12,   -5, 	  -9,   -3, 	  -4,   -6
+.2byte   -4,   -4, 	 -12,   -5, 	  -9,   -3, 	  -4,   -6
+.2byte    2,   -7, 	  -7,   -1, 	   7,   -4, 	  -1,   -7
+.2byte    2,   -4, 	 -11,   -7, 	  -4,   -2, 	  -3,   -5
+.2byte    2,   -4, 	 -11,   -7, 	  -4,   -2, 	  -3,   -5
+.2byte    4,   -5, 	   8,   -5, 	   3,   -3, 	   0,   -6
+.2byte    4,   -5, 	   8,   -5, 	   3,   -3, 	   0,   -6
+.2byte    4,   -7, 	   1,   -1, 	   3,   -4, 	  -2,   -7
+.2byte    7,   -5, 	  -6,   -5, 	  10,   -3, 	   1,   -7
+.2byte    7,   -5, 	  -6,   -5, 	  10,   -3, 	   1,   -7
+.2byte    7,   -7, 	  10,   -7, 	  -1,   -6, 	   2,   -7
+.2byte    7,   -7, 	  10,   -7, 	  -1,   -6, 	   2,   -7
+.2byte    5,   -8, 	   6,   -2, 	  -6,   -4, 	  -1,   -7
+.2byte    6,  -10, 	   4,   -5, 	   8,   -6, 	   1,   -8
+.2byte    6,  -10, 	   4,   -5, 	   8,   -6, 	   1,   -8
+.2byte    3,  -13, 	  -9,  -10, 	  -4,   -6, 	   0,   -8
+.2byte    3,  -13, 	  -9,  -10, 	  -4,   -6, 	   0,   -8
+.2byte   -1,  -12, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	  -2,  -10
+.2byte   -5,  -12, 	  -8,  -10, 	  -9,   -6, 	  -2,  -10
+.2byte    4,  -12, 	   8,   -6, 	   7,  -10, 	   1,  -10
+.2byte    4,  -12, 	   8,   -6, 	   7,  -10, 	   1,  -10
+.2byte   -6,   -8, 	   5,   -4, 	  -8,   -2, 	   0,   -7
+.2byte   -6,   -9, 	 -10,   -6, 	  -7,   -5, 	  -2,   -9
+.2byte   -6,   -9, 	 -10,   -6, 	  -7,   -5, 	  -2,   -9
+.2byte    0,  -10, 	   2,   -8, 	   7,  -10, 	  -2,   -9
+.2byte    0,  -10, 	   2,   -8, 	   7,  -10, 	  -2,   -9
+.2byte   -6,   -7, 	  -5,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte   -8,   -5, 	 -12,   -3, 	   3,   -6, 	  -3,   -6
+.2byte   -8,   -5, 	 -12,   -3, 	   3,   -6, 	  -3,   -6
+.2byte   -9,   -7, 	  -2,   -8, 	 -13,   -6, 	  -4,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	 -13,   -6, 	  -4,   -7
+.2byte   -4,   -7, 	  -9,   -4, 	   5,   -1, 	  -1,   -7
+.2byte   -4,   -4, 	   2,   -2, 	   9,   -7, 	   0,   -6
+.2byte   -4,   -4, 	   2,   -2, 	   9,   -7, 	   0,   -6
+.2byte   -6,   -5, 	  -6,   -6, 	 -10,   -5, 	  -2,   -6
+.2byte   -6,   -5, 	  -6,   -6, 	 -10,   -5, 	  -2,   -6
+.2byte   -1,   -8, 	  -6,   -8, 	  10,    1, 	  -1,   -4
+.2byte    0,   -9, 	  -6,   -8, 	  10,    1, 	  -1,   -5
+.2byte    0,  -10, 	 -12,  -11, 	  12,  -11, 	   0,  -12
+.2byte    3,  -10, 	  -7,    1, 	  10,  -18, 	   1,   -8
+.2byte    5,  -10, 	  -5,   -2, 	  -5,   -8, 	   1,   -7
+.2byte    1,  -13, 	   8,   -4, 	  -9,  -12, 	  -3,  -11
+.2byte   -1,  -14, 	  11,  -10, 	 -13,  -10, 	  -1,  -10
+.2byte   -3,  -14, 	   8,  -10, 	  -9,   -4, 	   1,  -12
+.2byte   -6,   -9, 	   4,   -8, 	   4,   -2, 	  -2,   -7
+.2byte   -4,  -10, 	 -11,  -18, 	   6,    1, 	  -2,   -8
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte   -1,   -3, 	  -9,    1, 	   7,    1, 	  -1,   -6
+.2byte    2,   -7, 	  -7,   -1, 	   7,   -4, 	  -1,   -7
+.2byte    1,   -3, 	  -5,    1, 	   7,   -1, 	  -3,   -4
+.2byte    4,   -7, 	   1,   -1, 	   3,   -4, 	  -2,   -7
+.2byte    7,   -5, 	   4,    1, 	   7,   -1, 	   0,   -5
+.2byte    5,   -8, 	   6,   -2, 	  -6,   -4, 	  -1,   -7
+.2byte    6,   -9, 	   7,   -2, 	   0,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte   -1,  -13, 	   7,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,   -8, 	   5,   -4, 	  -8,   -2, 	   0,   -7
+.2byte   -8,   -9, 	  -1,   -6, 	  -9,   -2, 	  -2,   -8
+.2byte   -6,   -7, 	  -5,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte   -9,   -5, 	  -9,   -1, 	  -6,    2, 	  -2,   -5
+.2byte   -4,   -7, 	  -9,   -4, 	   5,   -1, 	  -1,   -7
+.2byte   -3,   -3, 	  -9,   -1, 	   3,    2, 	   1,   -5
+.2byte   -1,   -4, 	  -9,    0, 	   7,    0, 	  -1,   -7
+.2byte   -3,   -3, 	  -9,   -1, 	   3,    2, 	   1,   -5
+.2byte   -8,   -6, 	  -8,   -2, 	  -5,    1, 	  -1,   -6
+.2byte   -7,   -8, 	   0,   -5, 	  -8,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -1, 	  -1,   -3, 	  -2,   -6
+.2byte    6,   -6, 	   3,    0, 	   6,   -2, 	  -1,   -6
+.2byte    1,   -3, 	  -5,    1, 	   7,   -1, 	  -3,   -4
+.2byte   -1,   -4, 	  -9,    0, 	   7,    0, 	  -1,   -7
+.2byte    1,   -3, 	  -5,    1, 	   7,   -1, 	  -3,   -4
+.2byte    6,   -6, 	   3,    0, 	   6,   -2, 	  -1,   -6
+.2byte    5,   -8, 	   6,   -1, 	  -1,   -3, 	  -2,   -6
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -7,   -8, 	   0,   -5, 	  -8,   -1, 	  -1,   -7
+.2byte   -8,   -6, 	  -8,   -2, 	  -5,    1, 	  -1,   -6
+.2byte   -3,   -3, 	  -9,   -1, 	   3,    2, 	   1,   -5
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte   -1,   -2, 	  -9,    2, 	   7,    2, 	  -1,   -5
+.2byte    2,   -7, 	  -7,   -1, 	   7,   -4, 	  -1,   -7
+.2byte    1,   -3, 	  -5,    1, 	   7,   -1, 	  -3,   -4
+.2byte    4,   -7, 	   1,   -1, 	   3,   -4, 	  -2,   -7
+.2byte    5,   -5, 	   2,    1, 	   5,   -1, 	  -2,   -5
+.2byte    5,   -8, 	   6,   -2, 	  -6,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   5,   -2, 	  -2,   -4, 	  -3,   -7
+.2byte   -1,  -12, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   7,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte   -6,   -8, 	   5,   -4, 	  -8,   -2, 	   0,   -7
+.2byte   -6,   -9, 	   1,   -6, 	  -7,   -2, 	   0,   -8
+.2byte   -6,   -7, 	  -5,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte   -7,   -5, 	  -7,   -1, 	  -4,    2, 	   0,   -5
+.2byte   -4,   -7, 	  -9,   -4, 	   5,   -1, 	  -1,   -7
+.2byte   -3,   -3, 	  -9,   -1, 	   3,    2, 	   1,   -5
+.2byte   -1,   -4, 	  -9,    0, 	   7,    0, 	  -1,   -7
+.2byte   -3,   -3, 	  -9,   -1, 	   3,    2, 	   1,   -5
+.2byte   -8,   -6, 	  -8,   -2, 	  -5,    1, 	  -1,   -6
+.2byte   -7,   -8, 	   0,   -5, 	  -8,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -1, 	  -1,   -3, 	  -2,   -6
+.2byte    6,   -6, 	   3,    0, 	   6,   -2, 	  -1,   -6
+.2byte    1,   -3, 	  -5,    1, 	   7,   -1, 	  -3,   -4
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte   -4,   -7, 	  -9,   -4, 	   5,   -1, 	  -1,   -7
+.2byte   -6,   -7, 	  -5,   -4, 	  -3,   -1, 	  -1,   -7
+.2byte   -6,   -8, 	   5,   -4, 	  -8,   -2, 	   0,   -7
+.2byte   -1,  -12, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte    5,   -8, 	   6,   -2, 	  -6,   -4, 	  -1,   -7
+.2byte    4,   -7, 	   1,   -1, 	   3,   -4, 	  -2,   -7
+.2byte    2,   -7, 	  -7,   -1, 	   7,   -4, 	  -1,   -7
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte   -1,   -6, 	  -9,    0, 	  11,   -3, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,    1, 	  12,   -5, 	  -1,   -9
+.2byte   -1,   -6, 	  -7,   -1, 	  10,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	  -5,   -1, 	   0,    0, 	  -1,   -5
+.2byte   -1,   -7, 	 -10,   -1, 	   9,   -1, 	  -1,   -9
+.2byte   -1,   -6, 	  -9,    0, 	  11,   -3, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,    1, 	  12,   -5, 	  -1,   -9
+.2byte   -1,   -6, 	  -7,   -1, 	  10,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	  -5,   -1, 	   0,    0, 	  -1,   -5
+sLombreAnimTable1:
+.4byte sLombreAnims_1_1
+.4byte sLombreAnims_1_2
+.4byte sLombreAnims_1_3
+.4byte sLombreAnims_1_4
+.4byte sLombreAnims_1_5
+.4byte sLombreAnims_1_6
+.4byte sLombreAnims_1_7
+.4byte sLombreAnims_1_8
+sLombreAnimTable2:
+.4byte sLombreAnims_2_1
+.4byte sLombreAnims_2_2
+.4byte sLombreAnims_2_3
+.4byte sLombreAnims_2_4
+.4byte sLombreAnims_2_5
+.4byte sLombreAnims_2_6
+.4byte sLombreAnims_2_7
+.4byte sLombreAnims_2_8
+sLombreAnimTable3:
+.4byte sLombreAnims_3_1
+.4byte sLombreAnims_3_2
+.4byte sLombreAnims_3_3
+.4byte sLombreAnims_3_4
+.4byte sLombreAnims_3_5
+.4byte sLombreAnims_3_6
+.4byte sLombreAnims_3_7
+.4byte sLombreAnims_3_8
+sLombreAnimTable4:
+.4byte sLombreAnims_4_1
+.4byte sLombreAnims_4_2
+.4byte sLombreAnims_4_3
+.4byte sLombreAnims_4_4
+.4byte sLombreAnims_4_5
+.4byte sLombreAnims_4_6
+.4byte sLombreAnims_4_7
+.4byte sLombreAnims_4_8
+sLombreAnimTable5:
+.4byte sLombreAnims_5_1
+.4byte sLombreAnims_5_2
+.4byte sLombreAnims_5_3
+.4byte sLombreAnims_5_4
+.4byte sLombreAnims_5_5
+.4byte sLombreAnims_5_6
+.4byte sLombreAnims_5_7
+.4byte sLombreAnims_5_8
+sLombreAnimTable6:
+.4byte sLombreAnims_6_1
+.4byte sLombreAnims_6_1
+.4byte sLombreAnims_6_1
+.4byte sLombreAnims_6_1
+.4byte sLombreAnims_6_1
+.4byte sLombreAnims_6_1
+.4byte sLombreAnims_6_1
+.4byte sLombreAnims_6_1
+sLombreAnimTable7:
+.4byte sLombreAnims_7_1
+.4byte sLombreAnims_7_2
+.4byte sLombreAnims_7_3
+.4byte sLombreAnims_7_4
+.4byte sLombreAnims_7_5
+.4byte sLombreAnims_7_6
+.4byte sLombreAnims_7_7
+.4byte sLombreAnims_7_8
+sLombreAnimTable8:
+.4byte sLombreAnims_8_1
+.4byte sLombreAnims_8_2
+.4byte sLombreAnims_8_3
+.4byte sLombreAnims_8_4
+.4byte sLombreAnims_8_5
+.4byte sLombreAnims_8_6
+.4byte sLombreAnims_8_7
+.4byte sLombreAnims_8_8
+sLombreAnimTable9:
+.4byte sLombreAnims_9_1
+.4byte sLombreAnims_9_2
+.4byte sLombreAnims_9_3
+.4byte sLombreAnims_9_4
+.4byte sLombreAnims_9_5
+.4byte sLombreAnims_9_6
+.4byte sLombreAnims_9_7
+.4byte sLombreAnims_9_8
+sLombreAnimTable10:
+.4byte sLombreAnims_10_1
+.4byte sLombreAnims_10_2
+.4byte sLombreAnims_10_3
+.4byte sLombreAnims_10_4
+.4byte sLombreAnims_10_5
+.4byte sLombreAnims_10_6
+.4byte sLombreAnims_10_7
+.4byte sLombreAnims_10_8
+sLombreAnimTable11:
+.4byte sLombreAnims_11_1
+.4byte sLombreAnims_11_2
+.4byte sLombreAnims_11_3
+.4byte sLombreAnims_11_4
+.4byte sLombreAnims_11_5
+.4byte sLombreAnims_11_6
+.4byte sLombreAnims_11_7
+.4byte sLombreAnims_11_8
+sLombreAnimTable12:
+.4byte sLombreAnims_12_1
+.4byte sLombreAnims_12_2
+.4byte sLombreAnims_12_3
+.4byte sLombreAnims_12_4
+.4byte sLombreAnims_12_5
+.4byte sLombreAnims_12_6
+.4byte sLombreAnims_12_7
+.4byte sLombreAnims_12_8
+sLombreAnimTable13:
+.4byte sLombreAnims_13_1
+.4byte sLombreAnims_13_2
+.4byte sLombreAnims_13_3
+.4byte sLombreAnims_13_4
+.4byte sLombreAnims_13_5
+.4byte sLombreAnims_13_6
+.4byte sLombreAnims_13_7
+.4byte sLombreAnims_13_8
+sLombreAnimTable14:
+.4byte sLombreAnims_14_1
+.4byte sLombreAnims_14_2
+.4byte sLombreAnims_14_3
+.4byte sLombreAnims_14_4
+.4byte sLombreAnims_14_5
+.4byte sLombreAnims_14_6
+.4byte sLombreAnims_14_7
+.4byte sLombreAnims_14_8
+sLombreAnimTable15:
+.4byte sLombreAnims_15_1
+.4byte sLombreAnims_15_2
+.4byte sLombreAnims_15_3
+.4byte sLombreAnims_15_4
+.4byte sLombreAnims_15_5
+.4byte sLombreAnims_15_6
+.4byte sLombreAnims_15_7
+.4byte sLombreAnims_15_8
+sAxAnimationsLombre:
+.4byte sLombreAnimTable1
+.4byte sLombreAnimTable2
+.4byte sLombreAnimTable3
+.4byte sLombreAnimTable4
+.4byte sLombreAnimTable5
+.4byte sLombreAnimTable6
+.4byte sLombreAnimTable7
+.4byte sLombreAnimTable8
+.4byte sLombreAnimTable9
+.4byte sLombreAnimTable10
+.4byte sLombreAnimTable11
+.4byte sLombreAnimTable12
+.4byte sLombreAnimTable13
+.4byte sLombreAnimTable14
+.4byte sLombreAnimTable15
+sAxSpritesLombre:
+.4byte sLombreSprites1
+.4byte sLombreSprites2
+.4byte sLombreSprites3
+.4byte sLombreSprites4
+.4byte sLombreSprites5
+.4byte sLombreSprites6
+.4byte sLombreSprites7
+.4byte sLombreSprites8
+.4byte sLombreSprites9
+.4byte sLombreSprites10
+.4byte sLombreSprites11
+.4byte sLombreSprites12
+.4byte sLombreSprites13
+.4byte sLombreSprites14
+.4byte sLombreSprites15
+.4byte sLombreSprites16
+.4byte sLombreSprites17
+.4byte sLombreSprites18
+.4byte sLombreSprites19
+.4byte sLombreSprites20
+.4byte sLombreSprites21
+.4byte sLombreSprites22
+.4byte sLombreSprites23
+.4byte sLombreSprites24
+.4byte sLombreSprites25
+.4byte sLombreSprites26
+.4byte sLombreSprites27
+.4byte sLombreSprites28
+.4byte sLombreSprites29
+.4byte sLombreSprites30
+.4byte sLombreSprites31
+.4byte sLombreSprites32
+.4byte sLombreSprites33
+.4byte sLombreSprites34
+.4byte sLombreSprites35
+.4byte sLombreSprites36
+.4byte sLombreSprites37
+.4byte sLombreSprites38
+.4byte sLombreSprites39
+.4byte sLombreSprites40
+.4byte sLombreSprites41
+.4byte sLombreSprites42
+.4byte sLombreSprites43
+.4byte sLombreSprites44
+.4byte sLombreSprites45
+.4byte sLombreSprites46
+.4byte sLombreSprites47
+.4byte sLombreSprites48
+.4byte sLombreSprites49
+.4byte sLombreSprites50
+.4byte sLombreSprites51
+.4byte sLombreSprites52
+.4byte sLombreSprites53
+.4byte sLombreSprites54
+.4byte sLombreSprites55
+.4byte sLombreSprites56
+.4byte sLombreSprites57
+.4byte sLombreSprites58
+.4byte sLombreSprites59
+.4byte sLombreSprites60
+.4byte sLombreSprites61
+.4byte sLombreSprites62
+.4byte sLombreSprites63
+.4byte sLombreSprites64
+.4byte sLombreSprites65
+.4byte sLombreSprites66
+.4byte sLombreSprites67
+.4byte sLombreSprites68
+.4byte sLombreSprites69
+.4byte sLombreSprites70
+.4byte sLombreSprites71
+.4byte sLombreSprites72
+.4byte sLombreSprites73
+.4byte sLombreSprites74
+.4byte sLombreSprites75
+.4byte sLombreSprites76
+.4byte sLombreSprites77
+.4byte sLombreSprites78
+.4byte sLombreSprites79
+.4byte sLombreSprites80
+.4byte sLombreSprites81
+sAxMainLombre:
+ax_main sAxPosesLombre, sAxAnimationsLombre, 15, sAxSpritesLombre, sAxPositionsLombre

--- a/data/ax/lotad.inc
+++ b/data/ax/lotad.inc
@@ -1,0 +1,2870 @@
+.global gAxLotad
+gAxLotad:
+ax_siro sAxMainLotad
+sLotadPose1:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose2:
+ax_pose 1, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose3:
+ax_pose 2, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose4:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose5:
+ax_pose 4, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose6:
+ax_pose 5, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose7:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose8:
+ax_pose 7, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose9:
+ax_pose 8, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose10:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose11:
+ax_pose 10, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose12:
+ax_pose 11, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose13:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose14:
+ax_pose 13, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose15:
+ax_pose 14, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose16:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose17:
+ax_pose 10, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose18:
+ax_pose 11, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose19:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose20:
+ax_pose 7, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose21:
+ax_pose 8, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose22:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose23:
+ax_pose 4, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose24:
+ax_pose 5, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose25:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose26:
+ax_pose 1, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose27:
+ax_pose 2, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose28:
+ax_pose 15, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose29:
+ax_pose 16, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose30:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose31:
+ax_pose 4, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose32:
+ax_pose 5, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose33:
+ax_pose 17, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose34:
+ax_pose 18, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose35:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose36:
+ax_pose 7, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose37:
+ax_pose 8, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose38:
+ax_pose 19, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose39:
+ax_pose 20, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose40:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose41:
+ax_pose 10, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose42:
+ax_pose 11, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose43:
+ax_pose 21, 0x81f0, 0x90f6, 0x3c00
+ax_pose_terminator
+sLotadPose44:
+ax_pose 22, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sLotadPose45:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose46:
+ax_pose 13, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose47:
+ax_pose 14, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose48:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose49:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose50:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose51:
+ax_pose 10, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose52:
+ax_pose 11, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose53:
+ax_pose 21, 0x81f0, 0x80f7, 0x3c00
+ax_pose_terminator
+sLotadPose54:
+ax_pose 22, 0x01ef, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose55:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose56:
+ax_pose 7, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose57:
+ax_pose 8, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose58:
+ax_pose 19, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose59:
+ax_pose 20, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose60:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose61:
+ax_pose 4, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose62:
+ax_pose 5, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose63:
+ax_pose 17, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose64:
+ax_pose 18, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose65:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose66:
+ax_pose 1, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose67:
+ax_pose 2, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose68:
+ax_pose 15, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose69:
+ax_pose 16, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose70:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose71:
+ax_pose 4, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose72:
+ax_pose 5, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose73:
+ax_pose 17, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose74:
+ax_pose 18, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose75:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose76:
+ax_pose 7, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose77:
+ax_pose 8, 0x41f4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose78:
+ax_pose 19, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose79:
+ax_pose 20, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose80:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose81:
+ax_pose 10, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose82:
+ax_pose 11, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose83:
+ax_pose 21, 0x81f0, 0x90f6, 0x3c00
+ax_pose_terminator
+sLotadPose84:
+ax_pose 22, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sLotadPose85:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose86:
+ax_pose 13, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose87:
+ax_pose 14, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose88:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose89:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose90:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose91:
+ax_pose 10, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose92:
+ax_pose 11, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose93:
+ax_pose 21, 0x81f0, 0x80f7, 0x3c00
+ax_pose_terminator
+sLotadPose94:
+ax_pose 22, 0x01ef, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose95:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose96:
+ax_pose 7, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose97:
+ax_pose 8, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose98:
+ax_pose 19, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose99:
+ax_pose 20, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose100:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose101:
+ax_pose 4, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose102:
+ax_pose 5, 0x41f4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose103:
+ax_pose 17, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose104:
+ax_pose 18, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose105:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose106:
+ax_pose 15, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose107:
+ax_pose 16, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose108:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose109:
+ax_pose 17, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose110:
+ax_pose 18, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose111:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose112:
+ax_pose 19, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose113:
+ax_pose 20, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose114:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose115:
+ax_pose 21, 0x81f0, 0x90f7, 0x3c00
+ax_pose_terminator
+sLotadPose116:
+ax_pose 22, 0x01f1, 0x90ec, 0x3c00
+ax_pose_terminator
+sLotadPose117:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose118:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose119:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose120:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose121:
+ax_pose 21, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sLotadPose122:
+ax_pose 22, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose123:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose124:
+ax_pose 19, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose125:
+ax_pose 20, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose126:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose127:
+ax_pose 17, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose128:
+ax_pose 18, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose129:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose130:
+ax_pose 15, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose131:
+ax_pose 16, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose132:
+ax_pose 25, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose133:
+ax_pose 26, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose134:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose135:
+ax_pose 17, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose136:
+ax_pose 18, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose137:
+ax_pose 27, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sLotadPose138:
+ax_pose 28, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sLotadPose139:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose140:
+ax_pose 19, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose141:
+ax_pose 20, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose142:
+ax_pose 29, 0x01f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose143:
+ax_pose 30, 0x01f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose144:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose145:
+ax_pose 21, 0x81f0, 0x90f6, 0x3c00
+ax_pose_terminator
+sLotadPose146:
+ax_pose 22, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sLotadPose147:
+ax_pose 31, 0x81ef, 0x90f7, 0x3c00
+ax_pose_terminator
+sLotadPose148:
+ax_pose 32, 0x01ef, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose149:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose150:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose151:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose152:
+ax_pose 33, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sLotadPose153:
+ax_pose 34, 0x01f0, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose154:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose155:
+ax_pose 21, 0x81f0, 0x80f7, 0x3c00
+ax_pose_terminator
+sLotadPose156:
+ax_pose 22, 0x01f0, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose157:
+ax_pose 31, 0x81ef, 0x80f9, 0x3c00
+ax_pose_terminator
+sLotadPose158:
+ax_pose 32, 0x01ef, 0x80f5, 0x3c00
+ax_pose_terminator
+sLotadPose159:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose160:
+ax_pose 19, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose161:
+ax_pose 20, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose162:
+ax_pose 29, 0x01f1, 0x80f5, 0x3c00
+ax_pose_terminator
+sLotadPose163:
+ax_pose 30, 0x01f1, 0x80f5, 0x3c00
+ax_pose_terminator
+sLotadPose164:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose165:
+ax_pose 17, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose166:
+ax_pose 18, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose167:
+ax_pose 27, 0x01f1, 0x80f2, 0x3c00
+ax_pose_terminator
+sLotadPose168:
+ax_pose 28, 0x01f1, 0x80f2, 0x3c00
+ax_pose_terminator
+sLotadPose169:
+ax_pose 35, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose170:
+ax_pose 36, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose171:
+ax_pose 37, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sLotadPose172:
+ax_pose 38, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sLotadPose173:
+ax_pose 39, 0x01e4, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose174:
+ax_pose 40, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sLotadPose175:
+ax_pose 41, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sLotadPose176:
+ax_pose 40, 0x01e6, 0x80f5, 0x3c00
+ax_pose_terminator
+sLotadPose177:
+ax_pose 39, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sLotadPose178:
+ax_pose 38, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose179:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose180:
+ax_pose 15, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose181:
+ax_pose 16, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose182:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose183:
+ax_pose 17, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose184:
+ax_pose 18, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose185:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose186:
+ax_pose 19, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose187:
+ax_pose 20, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose188:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose189:
+ax_pose 21, 0x81f0, 0x90f7, 0x3c00
+ax_pose_terminator
+sLotadPose190:
+ax_pose 22, 0x01f1, 0x90ec, 0x3c00
+ax_pose_terminator
+sLotadPose191:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose192:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose193:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose194:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose195:
+ax_pose 21, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sLotadPose196:
+ax_pose 22, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose197:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose198:
+ax_pose 19, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose199:
+ax_pose 20, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose200:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose201:
+ax_pose 17, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose202:
+ax_pose 18, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose203:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose204:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose205:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose206:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose207:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose208:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose209:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose210:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose211:
+ax_pose 15, 0x41f2, 0x80f5, 0x3c00
+ax_pose_terminator
+sLotadPose212:
+ax_pose 17, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose213:
+ax_pose 19, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sLotadPose214:
+ax_pose 21, 0x81f0, 0x90f7, 0x3c00
+ax_pose_terminator
+sLotadPose215:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose216:
+ax_pose 21, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sLotadPose217:
+ax_pose 19, 0x01f0, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose218:
+ax_pose 17, 0x41f1, 0x80f5, 0x3c00
+ax_pose_terminator
+sLotadPose219:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose220:
+ax_pose 15, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose221:
+ax_pose 16, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose222:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose223:
+ax_pose 17, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose224:
+ax_pose 18, 0x41f1, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose225:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose226:
+ax_pose 19, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose227:
+ax_pose 20, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose228:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose229:
+ax_pose 21, 0x81f0, 0x90f7, 0x3c00
+ax_pose_terminator
+sLotadPose230:
+ax_pose 22, 0x01f1, 0x90ec, 0x3c00
+ax_pose_terminator
+sLotadPose231:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose232:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose233:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose234:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose235:
+ax_pose 21, 0x81f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sLotadPose236:
+ax_pose 22, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sLotadPose237:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose238:
+ax_pose 19, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose239:
+ax_pose 20, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose240:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose241:
+ax_pose 17, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose242:
+ax_pose 18, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose243:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose244:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose245:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose246:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose247:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose248:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose249:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose250:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose251:
+ax_pose 0, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose252:
+ax_pose 3, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose253:
+ax_pose 6, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose254:
+ax_pose 9, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose255:
+ax_pose 12, 0x41f2, 0x80f4, 0x3c00
+ax_pose_terminator
+sLotadPose256:
+ax_pose 9, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose257:
+ax_pose 6, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+sLotadPose258:
+ax_pose 3, 0x41f2, 0x90eb, 0x3c00
+ax_pose_terminator
+.align 2
+sLotadAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLotadAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 21, 21, 21, 21,
+ax_anim 2, 1, 33, 22, 20, 22, 20,
+ax_anim 2, 0, 33, 21, 21, 21, 21,
+ax_anim 2, 0, 33, 22, 20, 22, 20,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sLotadAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 23, 0, 23, 0,
+ax_anim 2, 1, 37, 23, 1, 23, 1,
+ax_anim 2, 0, 37, 23, 0, 23, 0,
+ax_anim 2, 0, 37, 23, 1, 23, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sLotadAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, 4, -6, 4, -6,
+ax_anim 1, 0, 41, 13, -12, 13, -12,
+ax_anim 2, 0, 43, 22, -20, 22, -20,
+ax_anim 2, 1, 43, 23, -19, 23, -19,
+ax_anim 2, 0, 43, 22, -20, 22, -20,
+ax_anim 2, 0, 43, 23, -19, 23, -19,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sLotadAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, -4,
+ax_anim 1, 0, 46, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 1, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 0, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sLotadAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 4, 0, 49, 2, 2, 2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 50, -4, -6, -4, -6,
+ax_anim 1, 0, 51, -13, -12, -13, -12,
+ax_anim 2, 0, 53, -22, -20, -22, -20,
+ax_anim 2, 1, 53, -23, -19, -23, -19,
+ax_anim 2, 0, 53, -22, -20, -22, -20,
+ax_anim 2, 0, 53, -23, -19, -23, -19,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sLotadAnims_2_7:
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 4, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 56, -10, 0, -10, 0,
+ax_anim 2, 0, 57, -23, 0, -23, 0,
+ax_anim 2, 1, 57, -23, 1, -23, 1,
+ax_anim 2, 0, 57, -23, 0, -23, 0,
+ax_anim 2, 0, 57, -23, 1, -23, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sLotadAnims_2_8:
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 4, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 61, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -21, 21, -21, 21,
+ax_anim 2, 1, 63, -22, 20, -22, 20,
+ax_anim 2, 0, 63, -21, 21, -21, 21,
+ax_anim 2, 0, 63, -22, 20, -22, 20,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLotadAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 64, 0, -2, 0, -2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 2, 1, 67, 1, 20, 1, 20,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 2, 0, 67, 1, 20, 1, 20,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sLotadAnims_3_2:
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 4, 0, 69, -2, -2, -2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, 4, 4, 4,
+ax_anim 1, 0, 71, 10, 10, 10, 10,
+ax_anim 2, 0, 73, 21, 21, 21, 21,
+ax_anim 2, 1, 73, 22, 20, 22, 20,
+ax_anim 2, 0, 73, 21, 21, 21, 21,
+ax_anim 2, 0, 73, 22, 20, 22, 20,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sLotadAnims_3_3:
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 4, 0, 74, -2, 0, -2, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 4, 0, 4, 0,
+ax_anim 1, 0, 76, 10, 0, 10, 0,
+ax_anim 2, 0, 77, 23, 0, 23, 0,
+ax_anim 2, 1, 77, 23, 1, 23, 1,
+ax_anim 2, 0, 77, 23, 0, 23, 0,
+ax_anim 2, 0, 77, 23, 1, 23, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sLotadAnims_3_4:
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 4, 0, 79, -2, 2, -2, 2,
+ax_anim 1, 0, 81, 0, -1, 0, -1,
+ax_anim 1, 2, 80, 4, -6, 4, -6,
+ax_anim 1, 0, 81, 13, -12, 13, -12,
+ax_anim 2, 0, 83, 22, -20, 22, -20,
+ax_anim 2, 1, 83, 23, -19, 23, -19,
+ax_anim 2, 0, 83, 22, -20, 22, -20,
+ax_anim 2, 0, 83, 23, -19, 23, -19,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sLotadAnims_3_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 4, 0, 84, 0, 2, 0, 2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, 0, -4, 0, -4,
+ax_anim 1, 0, 86, 0, -11, 0, -11,
+ax_anim 2, 0, 88, 0, -21, 0, -21,
+ax_anim 2, 1, 88, 1, -21, 1, -21,
+ax_anim 2, 0, 88, 0, -21, 0, -21,
+ax_anim 2, 0, 88, 1, -21, 1, -21,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sLotadAnims_3_6:
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 4, 0, 89, 2, 2, 2, 2,
+ax_anim 1, 0, 91, 0, -1, 0, -1,
+ax_anim 1, 2, 90, -4, -6, -4, -6,
+ax_anim 1, 0, 91, -13, -12, -13, -12,
+ax_anim 2, 0, 93, -22, -20, -22, -20,
+ax_anim 2, 1, 93, -23, -19, -23, -19,
+ax_anim 2, 0, 93, -22, -20, -22, -20,
+ax_anim 2, 0, 93, -23, -19, -23, -19,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sLotadAnims_3_7:
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 4, 0, 94, 2, 0, 2, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 95, -4, 0, -4, 0,
+ax_anim 1, 0, 96, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -23, 0, -23, 0,
+ax_anim 2, 1, 97, -23, 1, -23, 1,
+ax_anim 2, 0, 97, -23, 0, -23, 0,
+ax_anim 2, 0, 97, -23, 1, -23, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sLotadAnims_3_8:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 100, -4, 4, -4, 4,
+ax_anim 1, 0, 101, -10, 10, -10, 10,
+ax_anim 2, 0, 103, -21, 21, -21, 21,
+ax_anim 2, 1, 103, -22, 20, -22, 20,
+ax_anim 2, 0, 103, -21, 21, -21, 21,
+ax_anim 2, 0, 103, -22, 20, -22, 20,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLotadAnims_4_1:
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 6, 2, 104, 0, -3, 0, -3,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim 3, 1, 106, 0, 2, 0, 2,
+ax_anim 3, 0, 105, 0, 2, 0, 2,
+ax_anim 3, 0, 106, 0, 2, 0, 2,
+ax_anim 3, 0, 105, 0, 2, 0, 2,
+ax_anim 3, 0, 106, 0, 2, 0, 2,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sLotadAnims_4_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 6, 2, 107, -3, -3, -3, -3,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim 3, 1, 109, 2, 2, 2, 2,
+ax_anim 3, 0, 108, 2, 2, 2, 2,
+ax_anim 3, 0, 109, 2, 2, 2, 2,
+ax_anim 3, 0, 108, 2, 2, 2, 2,
+ax_anim 3, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sLotadAnims_4_3:
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 6, 2, 110, -3, 0, -3, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 3, 0, 3, 0,
+ax_anim 3, 1, 112, 3, 0, 3, 0,
+ax_anim 3, 0, 111, 3, 0, 3, 0,
+ax_anim 3, 0, 112, 3, 0, 3, 0,
+ax_anim 3, 0, 111, 3, 0, 3, 0,
+ax_anim 3, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sLotadAnims_4_4:
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 6, 2, 113, -3, 3, -3, 3,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 2, -2, 2, -2,
+ax_anim 3, 1, 115, 2, -2, 2, -2,
+ax_anim 3, 0, 114, 2, -2, 2, -2,
+ax_anim 3, 0, 115, 2, -2, 2, -2,
+ax_anim 3, 0, 114, 2, -2, 2, -2,
+ax_anim 3, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sLotadAnims_4_5:
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim 6, 2, 116, 0, 3, 0, 3,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -2, 0, -2,
+ax_anim 3, 1, 118, 0, -2, 0, -2,
+ax_anim 3, 0, 117, 0, -2, 0, -2,
+ax_anim 3, 0, 118, 0, -2, 0, -2,
+ax_anim 3, 0, 117, 0, -2, 0, -2,
+ax_anim 3, 0, 118, 0, -2, 0, -2,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sLotadAnims_4_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 6, 2, 119, 3, 3, 3, 3,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, -2, -2, -2, -2,
+ax_anim 3, 1, 121, -2, -2, -2, -2,
+ax_anim 3, 0, 120, -2, -2, -2, -2,
+ax_anim 3, 0, 121, -2, -2, -2, -2,
+ax_anim 3, 0, 120, -2, -2, -2, -2,
+ax_anim 3, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sLotadAnims_4_7:
+ax_anim 2, 0, 122, 2, 0, 2, 0,
+ax_anim 6, 2, 122, 3, 0, 3, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -3, 0, -3, 0,
+ax_anim 3, 1, 124, -3, 0, -3, 0,
+ax_anim 3, 0, 123, -3, 0, -3, 0,
+ax_anim 3, 0, 124, -3, 0, -3, 0,
+ax_anim 3, 0, 123, -3, 0, -3, 0,
+ax_anim 3, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sLotadAnims_4_8:
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 6, 2, 125, 3, -3, 3, -3,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim 3, 1, 127, -2, 2, -2, 2,
+ax_anim 3, 0, 126, -2, 2, -2, 2,
+ax_anim 3, 0, 127, -2, 2, -2, 2,
+ax_anim 3, 0, 126, -2, 2, -2, 2,
+ax_anim 3, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLotadAnims_5_1:
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, -1, 0, 0,
+ax_anim 3, 0, 132, 0, -2, 0, 0,
+ax_anim 3, 0, 131, 0, -3, 0, 0,
+ax_anim 3, 0, 132, 0, -4, 0, 0,
+ax_anim 3, 0, 131, 0, -4, 0, 0,
+ax_anim 3, 2, 132, 0, -3, 0, 0,
+ax_anim 3, 0, 131, 0, -2, 0, 0,
+ax_anim 3, 0, 132, 0, -1, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_5_2:
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, -2, 0, 0,
+ax_anim 3, 0, 137, 0, -3, 0, 0,
+ax_anim 3, 0, 136, 0, -4, 0, 0,
+ax_anim 3, 0, 137, 0, -5, 0, 0,
+ax_anim 3, 0, 136, 0, -5, 0, 0,
+ax_anim 3, 2, 137, 0, -4, 0, 0,
+ax_anim 3, 0, 136, 0, -3, 0, 0,
+ax_anim 3, 0, 137, 0, -2, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_5_3:
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, -1, 0, 0,
+ax_anim 3, 0, 142, 0, -2, 0, 0,
+ax_anim 3, 0, 141, 0, -4, 0, 0,
+ax_anim 3, 0, 142, 0, -4, 0, 0,
+ax_anim 3, 0, 141, 0, -4, 0, 0,
+ax_anim 3, 2, 142, 0, -4, 0, 0,
+ax_anim 3, 0, 141, 0, -2, 0, 0,
+ax_anim 3, 0, 142, 0, -1, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_5_4:
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, -1, 0, 0,
+ax_anim 3, 0, 147, 0, -2, 0, 0,
+ax_anim 3, 0, 146, 0, -3, 0, 0,
+ax_anim 3, 0, 147, 0, -4, 0, 0,
+ax_anim 3, 0, 146, 0, -4, 0, 0,
+ax_anim 3, 2, 147, 0, -3, 0, 0,
+ax_anim 3, 0, 146, 0, -2, 0, 0,
+ax_anim 3, 0, 147, 0, -1, 0, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_5_5:
+ax_anim 3, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim 3, 0, 152, 0, -2, 0, 0,
+ax_anim 3, 0, 151, 0, -3, 0, 0,
+ax_anim 3, 0, 152, 0, -4, 0, 0,
+ax_anim 3, 0, 151, 0, -4, 0, 0,
+ax_anim 3, 2, 152, 0, -3, 0, 0,
+ax_anim 3, 0, 151, 0, -2, 0, 0,
+ax_anim 3, 0, 152, 0, -1, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_5_6:
+ax_anim 3, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, -1, 0, 0,
+ax_anim 3, 0, 157, 0, -2, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 3, 0, 157, 0, -4, 0, 0,
+ax_anim 3, 0, 156, 0, -4, 0, 0,
+ax_anim 3, 2, 157, 0, -3, 0, 0,
+ax_anim 3, 0, 156, 0, -2, 0, 0,
+ax_anim 3, 0, 157, 0, -1, 0, 0,
+ax_anim 3, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_5_7:
+ax_anim 3, 0, 160, 0, 0, 0, 0,
+ax_anim 3, 0, 161, 0, -1, 0, 0,
+ax_anim 3, 0, 162, 0, -2, 0, 0,
+ax_anim 3, 0, 161, 0, -4, 0, 0,
+ax_anim 3, 0, 162, 0, -4, 0, 0,
+ax_anim 3, 0, 161, 0, -4, 0, 0,
+ax_anim 3, 2, 162, 0, -4, 0, 0,
+ax_anim 3, 0, 161, 0, -2, 0, 0,
+ax_anim 3, 0, 162, 0, -1, 0, 0,
+ax_anim 3, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_5_8:
+ax_anim 3, 0, 165, 0, 0, 0, 0,
+ax_anim 3, 0, 166, 0, -2, 0, 0,
+ax_anim 3, 0, 167, 0, -3, 0, 0,
+ax_anim 3, 0, 166, 0, -4, 0, 0,
+ax_anim 3, 0, 167, 0, -5, 0, 0,
+ax_anim 3, 0, 166, 0, -5, 0, 0,
+ax_anim 3, 2, 167, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -3, 0, 0,
+ax_anim 3, 0, 167, 0, -2, 0, 0,
+ax_anim 3, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_7_1:
+ax_anim 2, 0, 170, 0, -4, 0, -4,
+ax_anim 8, 0, 170, 0, -5, 0, -5,
+ax_anim_terminator
+sLotadAnims_7_2:
+ax_anim 2, 0, 171, -4, -4, -4, -4,
+ax_anim 8, 0, 171, -5, -5, -5, -5,
+ax_anim_terminator
+sLotadAnims_7_3:
+ax_anim 2, 0, 172, -4, 0, -4, 0,
+ax_anim 8, 0, 172, -5, 0, -5, 0,
+ax_anim_terminator
+sLotadAnims_7_4:
+ax_anim 2, 0, 173, -4, 4, -4, 4,
+ax_anim 8, 0, 173, -5, 5, -5, 5,
+ax_anim_terminator
+sLotadAnims_7_5:
+ax_anim 2, 0, 174, 0, 4, 0, 4,
+ax_anim 8, 0, 174, 0, 5, 0, 5,
+ax_anim_terminator
+sLotadAnims_7_6:
+ax_anim 2, 0, 175, 4, 4, 4, 4,
+ax_anim 8, 0, 175, 5, 5, 5, 5,
+ax_anim_terminator
+sLotadAnims_7_7:
+ax_anim 2, 0, 176, 4, 0, 4, 0,
+ax_anim 8, 0, 176, 5, 0, 5, 0,
+ax_anim_terminator
+sLotadAnims_7_8:
+ax_anim 2, 0, 177, 4, -4, 4, -4,
+ax_anim 8, 0, 177, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLotadAnims_8_1:
+ax_anim 24, 0, 178, 0, 0, 0, 0,
+ax_anim 18, 0, 179, 0, 0, 0, 0,
+ax_anim 24, 0, 178, 0, 0, 0, 0,
+ax_anim 18, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_8_2:
+ax_anim 24, 0, 181, 0, 0, 0, 0,
+ax_anim 18, 0, 182, 0, 0, 0, 0,
+ax_anim 24, 0, 181, 0, 0, 0, 0,
+ax_anim 18, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_8_3:
+ax_anim 24, 0, 184, 0, 0, 0, 0,
+ax_anim 18, 0, 185, 0, 0, 0, 0,
+ax_anim 24, 0, 184, 0, 0, 0, 0,
+ax_anim 18, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_8_4:
+ax_anim 24, 0, 187, 0, 0, 0, 0,
+ax_anim 18, 0, 188, 0, 0, 0, 0,
+ax_anim 24, 0, 187, 0, 0, 0, 0,
+ax_anim 18, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_8_5:
+ax_anim 24, 0, 190, 0, 0, 0, 0,
+ax_anim 18, 0, 191, 0, 0, 0, 0,
+ax_anim 24, 0, 190, 0, 0, 0, 0,
+ax_anim 18, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_8_6:
+ax_anim 24, 0, 193, 0, 0, 0, 0,
+ax_anim 18, 0, 194, 0, 0, 0, 0,
+ax_anim 24, 0, 193, 0, 0, 0, 0,
+ax_anim 18, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_8_7:
+ax_anim 24, 0, 196, 0, 0, 0, 0,
+ax_anim 18, 0, 197, 0, 0, 0, 0,
+ax_anim 24, 0, 196, 0, 0, 0, 0,
+ax_anim 18, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_8_8:
+ax_anim 24, 0, 199, 0, 0, 0, 0,
+ax_anim 18, 0, 200, 0, 0, 0, 0,
+ax_anim 24, 0, 199, 0, 0, 0, 0,
+ax_anim 18, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 3, 6, 3,
+ax_anim 2, 0, 204, 8, 10, 8, 10,
+ax_anim 2, 0, 205, 7, 17, 7, 17,
+ax_anim 3, 0, 206, 0, 20, 0, 20,
+ax_anim 2, 3, 207, -7, 17, -7, 17,
+ax_anim 2, 0, 208, -8, 10, -8, 10,
+ax_anim 1, 0, 209, -6, 3, -6, 3,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 17, 3, 17, 3,
+ax_anim 2, 0, 204, 19, 10, 19, 10,
+ax_anim 3, 0, 205, 21, 20, 21, 20,
+ax_anim 2, 3, 206, 12, 21, 12, 21,
+ax_anim 2, 0, 207, 3, 15, 3, 15,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -5, 3, -5,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 17, -5, 17, -5,
+ax_anim 3, 0, 204, 21, -2, 21, -2,
+ax_anim 2, 3, 205, 19, 3, 19, 3,
+ax_anim 2, 0, 206, 12, 5, 12, 5,
+ax_anim 1, 0, 207, 4, 4, 4, 4,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -8, -1, -8,
+ax_anim 2, 0, 209, 4, -16, 4, -16,
+ax_anim 2, 0, 202, 12, -23, 12, -23,
+ax_anim 3, 0, 203, 21, -24, 21, -24,
+ax_anim 2, 3, 204, 22, -15, 22, -15,
+ax_anim 2, 0, 205, 17, -6, 17, -6,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -4, -8, -4,
+ax_anim 2, 0, 208, -9, -14, -9, -14,
+ax_anim 2, 0, 209, -7, -22, -7, -22,
+ax_anim 3, 0, 202, 0, -24, 0, -24,
+ax_anim 2, 3, 203, 7, -22, 7, -22,
+ax_anim 2, 0, 204, 9, -14, 9, -14,
+ax_anim 1, 0, 205, 8, -4, 8, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -8, 1, -8,
+ax_anim 2, 0, 203, -4, -16, -4, -16,
+ax_anim 2, 0, 202, -12, -23, -12, -23,
+ax_anim 3, 0, 209, -21, -24, -21, -24,
+ax_anim 2, 3, 208, -22, -15, -22, -15,
+ax_anim 2, 0, 207, -17, -6, -17, -6,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -5, -3, -5,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -17, -5, -17, -5,
+ax_anim 3, 0, 208, -21, -2, -21, -2,
+ax_anim 2, 3, 207, -19, 3, -19, 3,
+ax_anim 2, 0, 206, -12, 5, -12, 5,
+ax_anim 1, 0, 205, -4, 4, -4, 4,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -17, 3, -17, 3,
+ax_anim 2, 0, 208, -19, 10, -19, 10,
+ax_anim 3, 0, 207, -21, 20, -21, 20,
+ax_anim 2, 3, 206, -12, 21, -12, 21,
+ax_anim 2, 0, 205, -3, 15, -3, 15,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLotadAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sLotadGfx1:
+.incbin "baserom.gba", 0x110A7D0, 0x100
+sLotadSprites1:
+ax_sprite sLotadGfx1, 0x100
+ax_sprite_terminator
+sLotadGfx2:
+.incbin "baserom.gba", 0x110A8E0, 0x100
+sLotadSprites2:
+ax_sprite sLotadGfx2, 0x100
+ax_sprite_terminator
+sLotadGfx3:
+.incbin "baserom.gba", 0x110A9F0, 0x100
+sLotadSprites3:
+ax_sprite sLotadGfx3, 0x100
+ax_sprite_terminator
+sLotadGfx4:
+.incbin "baserom.gba", 0x110AB00, 0x100
+sLotadSprites4:
+ax_sprite sLotadGfx4, 0x100
+ax_sprite_terminator
+sLotadGfx5:
+.incbin "baserom.gba", 0x110AC10, 0x100
+sLotadSprites5:
+ax_sprite sLotadGfx5, 0x100
+ax_sprite_terminator
+sLotadGfx6:
+.incbin "baserom.gba", 0x110AD20, 0x100
+sLotadSprites6:
+ax_sprite sLotadGfx6, 0x100
+ax_sprite_terminator
+sLotadGfx7:
+.incbin "baserom.gba", 0x110AE30, 0x100
+sLotadSprites7:
+ax_sprite sLotadGfx7, 0x100
+ax_sprite_terminator
+sLotadGfx8:
+.incbin "baserom.gba", 0x110AF40, 0x100
+sLotadSprites8:
+ax_sprite sLotadGfx8, 0x100
+ax_sprite_terminator
+sLotadGfx9:
+.incbin "baserom.gba", 0x110B050, 0x100
+sLotadSprites9:
+ax_sprite sLotadGfx9, 0x100
+ax_sprite_terminator
+sLotadGfx10:
+.incbin "baserom.gba", 0x110B160, 0x100
+sLotadSprites10:
+ax_sprite sLotadGfx10, 0x100
+ax_sprite_terminator
+sLotadGfx11:
+.incbin "baserom.gba", 0x110B270, 0x100
+sLotadSprites11:
+ax_sprite sLotadGfx11, 0x100
+ax_sprite_terminator
+sLotadGfx12:
+.incbin "baserom.gba", 0x110B380, 0x100
+sLotadSprites12:
+ax_sprite sLotadGfx12, 0x100
+ax_sprite_terminator
+sLotadGfx13:
+.incbin "baserom.gba", 0x110B490, 0x100
+sLotadSprites13:
+ax_sprite sLotadGfx13, 0x100
+ax_sprite_terminator
+sLotadGfx14:
+.incbin "baserom.gba", 0x110B5A0, 0x100
+sLotadSprites14:
+ax_sprite sLotadGfx14, 0x100
+ax_sprite_terminator
+sLotadGfx15:
+.incbin "baserom.gba", 0x110B6B0, 0x100
+sLotadSprites15:
+ax_sprite sLotadGfx15, 0x100
+ax_sprite_terminator
+sLotadGfx16:
+.incbin "baserom.gba", 0x110B7C0, 0x60
+sLotadGfx16_1:
+.incbin "baserom.gba", 0x110B820, 0x60
+sLotadSprites16:
+ax_sprite sLotadGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLotadGfx17:
+.incbin "baserom.gba", 0x110B8A8, 0x60
+sLotadGfx17_1:
+.incbin "baserom.gba", 0x110B908, 0x60
+sLotadSprites17:
+ax_sprite sLotadGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLotadGfx18:
+.incbin "baserom.gba", 0x110B990, 0x60
+sLotadGfx18_1:
+.incbin "baserom.gba", 0x110B9F0, 0x60
+sLotadSprites18:
+ax_sprite sLotadGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLotadGfx19:
+.incbin "baserom.gba", 0x110BA78, 0x60
+sLotadGfx19_1:
+.incbin "baserom.gba", 0x110BAD8, 0x60
+sLotadSprites19:
+ax_sprite sLotadGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLotadGfx20:
+.incbin "baserom.gba", 0x110BB60, 0x60
+sLotadGfx20_1:
+.incbin "baserom.gba", 0x110BBC0, 0x60
+sLotadGfx20_2:
+.incbin "baserom.gba", 0x110BC20, 0x40
+sLotadSprites20:
+ax_sprite sLotadGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx20_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx21:
+.incbin "baserom.gba", 0x110BC98, 0x60
+sLotadGfx21_1:
+.incbin "baserom.gba", 0x110BCF8, 0x60
+sLotadGfx21_2:
+.incbin "baserom.gba", 0x110BD58, 0x40
+sLotadSprites21:
+ax_sprite sLotadGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx21_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx22:
+.incbin "baserom.gba", 0x110BDD0, 0xC0
+sLotadSprites22:
+ax_sprite sLotadGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLotadGfx23:
+.incbin "baserom.gba", 0x110BEA8, 0x60
+sLotadGfx23_1:
+.incbin "baserom.gba", 0x110BF08, 0x60
+sLotadGfx23_2:
+.incbin "baserom.gba", 0x110BF68, 0x20
+sLotadSprites23:
+ax_sprite sLotadGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx23_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sLotadGfx24:
+.incbin "baserom.gba", 0x110BFC0, 0x60
+sLotadGfx24_1:
+.incbin "baserom.gba", 0x110C020, 0x60
+sLotadGfx24_2:
+.incbin "baserom.gba", 0x110C080, 0x60
+sLotadSprites24:
+ax_sprite sLotadGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx25:
+.incbin "baserom.gba", 0x110C118, 0x60
+sLotadGfx25_1:
+.incbin "baserom.gba", 0x110C178, 0x60
+sLotadGfx25_2:
+.incbin "baserom.gba", 0x110C1D8, 0x60
+sLotadSprites25:
+ax_sprite sLotadGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx26:
+.incbin "baserom.gba", 0x110C270, 0x60
+sLotadGfx26_1:
+.incbin "baserom.gba", 0x110C2D0, 0x60
+sLotadGfx26_2:
+.incbin "baserom.gba", 0x110C330, 0x40
+sLotadSprites26:
+ax_sprite sLotadGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx26_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sLotadGfx27:
+.incbin "baserom.gba", 0x110C3A8, 0x60
+sLotadGfx27_1:
+.incbin "baserom.gba", 0x110C408, 0x60
+sLotadGfx27_2:
+.incbin "baserom.gba", 0x110C468, 0x40
+sLotadSprites27:
+ax_sprite sLotadGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx28:
+.incbin "baserom.gba", 0x110C4E0, 0x60
+sLotadGfx28_1:
+.incbin "baserom.gba", 0x110C540, 0x60
+sLotadGfx28_2:
+.incbin "baserom.gba", 0x110C5A0, 0x20
+sLotadSprites28:
+ax_sprite sLotadGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx28_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sLotadGfx29:
+.incbin "baserom.gba", 0x110C5F8, 0x60
+sLotadGfx29_1:
+.incbin "baserom.gba", 0x110C658, 0x60
+sLotadGfx29_2:
+.incbin "baserom.gba", 0x110C6B8, 0x40
+sLotadSprites29:
+ax_sprite sLotadGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx29_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx30:
+.incbin "baserom.gba", 0x110C730, 0x60
+sLotadGfx30_1:
+.incbin "baserom.gba", 0x110C790, 0x60
+sLotadGfx30_2:
+.incbin "baserom.gba", 0x110C7F0, 0x20
+sLotadSprites30:
+ax_sprite sLotadGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx30_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sLotadGfx31:
+.incbin "baserom.gba", 0x110C848, 0x60
+sLotadGfx31_1:
+.incbin "baserom.gba", 0x110C8A8, 0x60
+sLotadGfx31_2:
+.incbin "baserom.gba", 0x110C908, 0x40
+sLotadSprites31:
+ax_sprite sLotadGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLotadGfx31_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx32:
+.incbin "baserom.gba", 0x110C980, 0xC0
+sLotadSprites32:
+ax_sprite sLotadGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLotadGfx33:
+.incbin "baserom.gba", 0x110CA58, 0x60
+sLotadGfx33_1:
+.incbin "baserom.gba", 0x110CAB8, 0x60
+sLotadGfx33_2:
+.incbin "baserom.gba", 0x110CB18, 0x60
+sLotadSprites33:
+ax_sprite sLotadGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx34:
+.incbin "baserom.gba", 0x110CBB0, 0x60
+sLotadGfx34_1:
+.incbin "baserom.gba", 0x110CC10, 0x60
+sLotadGfx34_2:
+.incbin "baserom.gba", 0x110CC70, 0x60
+sLotadSprites34:
+ax_sprite sLotadGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx35:
+.incbin "baserom.gba", 0x110CD08, 0x60
+sLotadGfx35_1:
+.incbin "baserom.gba", 0x110CD68, 0x60
+sLotadGfx35_2:
+.incbin "baserom.gba", 0x110CDC8, 0x60
+sLotadSprites35:
+ax_sprite sLotadGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLotadGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sLotadGfx36:
+.incbin "baserom.gba", 0x110CE60, 0x100
+sLotadSprites36:
+ax_sprite sLotadGfx36, 0x100
+ax_sprite_terminator
+sLotadGfx37:
+.incbin "baserom.gba", 0x110CF70, 0x100
+sLotadSprites37:
+ax_sprite sLotadGfx37, 0x100
+ax_sprite_terminator
+sLotadGfx38:
+.incbin "baserom.gba", 0x110D080, 0x200
+sLotadSprites38:
+ax_sprite sLotadGfx38, 0x200
+ax_sprite_terminator
+sLotadGfx39:
+.incbin "baserom.gba", 0x110D290, 0x200
+sLotadSprites39:
+ax_sprite sLotadGfx39, 0x200
+ax_sprite_terminator
+sLotadGfx40:
+.incbin "baserom.gba", 0x110D4A0, 0x200
+sLotadSprites40:
+ax_sprite sLotadGfx40, 0x200
+ax_sprite_terminator
+sLotadGfx41:
+.incbin "baserom.gba", 0x110D6B0, 0x200
+sLotadSprites41:
+ax_sprite sLotadGfx41, 0x200
+ax_sprite_terminator
+sLotadGfx42:
+.incbin "baserom.gba", 0x110D8C0, 0x200
+sLotadSprites42:
+ax_sprite sLotadGfx42, 0x200
+ax_sprite_terminator
+sAxPosesLotad:
+.4byte sLotadPose1
+.4byte sLotadPose2
+.4byte sLotadPose3
+.4byte sLotadPose4
+.4byte sLotadPose5
+.4byte sLotadPose6
+.4byte sLotadPose7
+.4byte sLotadPose8
+.4byte sLotadPose9
+.4byte sLotadPose10
+.4byte sLotadPose11
+.4byte sLotadPose12
+.4byte sLotadPose13
+.4byte sLotadPose14
+.4byte sLotadPose15
+.4byte sLotadPose16
+.4byte sLotadPose17
+.4byte sLotadPose18
+.4byte sLotadPose19
+.4byte sLotadPose20
+.4byte sLotadPose21
+.4byte sLotadPose22
+.4byte sLotadPose23
+.4byte sLotadPose24
+.4byte sLotadPose25
+.4byte sLotadPose26
+.4byte sLotadPose27
+.4byte sLotadPose28
+.4byte sLotadPose29
+.4byte sLotadPose30
+.4byte sLotadPose31
+.4byte sLotadPose32
+.4byte sLotadPose33
+.4byte sLotadPose34
+.4byte sLotadPose35
+.4byte sLotadPose36
+.4byte sLotadPose37
+.4byte sLotadPose38
+.4byte sLotadPose39
+.4byte sLotadPose40
+.4byte sLotadPose41
+.4byte sLotadPose42
+.4byte sLotadPose43
+.4byte sLotadPose44
+.4byte sLotadPose45
+.4byte sLotadPose46
+.4byte sLotadPose47
+.4byte sLotadPose48
+.4byte sLotadPose49
+.4byte sLotadPose50
+.4byte sLotadPose51
+.4byte sLotadPose52
+.4byte sLotadPose53
+.4byte sLotadPose54
+.4byte sLotadPose55
+.4byte sLotadPose56
+.4byte sLotadPose57
+.4byte sLotadPose58
+.4byte sLotadPose59
+.4byte sLotadPose60
+.4byte sLotadPose61
+.4byte sLotadPose62
+.4byte sLotadPose63
+.4byte sLotadPose64
+.4byte sLotadPose65
+.4byte sLotadPose66
+.4byte sLotadPose67
+.4byte sLotadPose68
+.4byte sLotadPose69
+.4byte sLotadPose70
+.4byte sLotadPose71
+.4byte sLotadPose72
+.4byte sLotadPose73
+.4byte sLotadPose74
+.4byte sLotadPose75
+.4byte sLotadPose76
+.4byte sLotadPose77
+.4byte sLotadPose78
+.4byte sLotadPose79
+.4byte sLotadPose80
+.4byte sLotadPose81
+.4byte sLotadPose82
+.4byte sLotadPose83
+.4byte sLotadPose84
+.4byte sLotadPose85
+.4byte sLotadPose86
+.4byte sLotadPose87
+.4byte sLotadPose88
+.4byte sLotadPose89
+.4byte sLotadPose90
+.4byte sLotadPose91
+.4byte sLotadPose92
+.4byte sLotadPose93
+.4byte sLotadPose94
+.4byte sLotadPose95
+.4byte sLotadPose96
+.4byte sLotadPose97
+.4byte sLotadPose98
+.4byte sLotadPose99
+.4byte sLotadPose100
+.4byte sLotadPose101
+.4byte sLotadPose102
+.4byte sLotadPose103
+.4byte sLotadPose104
+.4byte sLotadPose105
+.4byte sLotadPose106
+.4byte sLotadPose107
+.4byte sLotadPose108
+.4byte sLotadPose109
+.4byte sLotadPose110
+.4byte sLotadPose111
+.4byte sLotadPose112
+.4byte sLotadPose113
+.4byte sLotadPose114
+.4byte sLotadPose115
+.4byte sLotadPose116
+.4byte sLotadPose117
+.4byte sLotadPose118
+.4byte sLotadPose119
+.4byte sLotadPose120
+.4byte sLotadPose121
+.4byte sLotadPose122
+.4byte sLotadPose123
+.4byte sLotadPose124
+.4byte sLotadPose125
+.4byte sLotadPose126
+.4byte sLotadPose127
+.4byte sLotadPose128
+.4byte sLotadPose129
+.4byte sLotadPose130
+.4byte sLotadPose131
+.4byte sLotadPose132
+.4byte sLotadPose133
+.4byte sLotadPose134
+.4byte sLotadPose135
+.4byte sLotadPose136
+.4byte sLotadPose137
+.4byte sLotadPose138
+.4byte sLotadPose139
+.4byte sLotadPose140
+.4byte sLotadPose141
+.4byte sLotadPose142
+.4byte sLotadPose143
+.4byte sLotadPose144
+.4byte sLotadPose145
+.4byte sLotadPose146
+.4byte sLotadPose147
+.4byte sLotadPose148
+.4byte sLotadPose149
+.4byte sLotadPose150
+.4byte sLotadPose151
+.4byte sLotadPose152
+.4byte sLotadPose153
+.4byte sLotadPose154
+.4byte sLotadPose155
+.4byte sLotadPose156
+.4byte sLotadPose157
+.4byte sLotadPose158
+.4byte sLotadPose159
+.4byte sLotadPose160
+.4byte sLotadPose161
+.4byte sLotadPose162
+.4byte sLotadPose163
+.4byte sLotadPose164
+.4byte sLotadPose165
+.4byte sLotadPose166
+.4byte sLotadPose167
+.4byte sLotadPose168
+.4byte sLotadPose169
+.4byte sLotadPose170
+.4byte sLotadPose171
+.4byte sLotadPose172
+.4byte sLotadPose173
+.4byte sLotadPose174
+.4byte sLotadPose175
+.4byte sLotadPose176
+.4byte sLotadPose177
+.4byte sLotadPose178
+.4byte sLotadPose179
+.4byte sLotadPose180
+.4byte sLotadPose181
+.4byte sLotadPose182
+.4byte sLotadPose183
+.4byte sLotadPose184
+.4byte sLotadPose185
+.4byte sLotadPose186
+.4byte sLotadPose187
+.4byte sLotadPose188
+.4byte sLotadPose189
+.4byte sLotadPose190
+.4byte sLotadPose191
+.4byte sLotadPose192
+.4byte sLotadPose193
+.4byte sLotadPose194
+.4byte sLotadPose195
+.4byte sLotadPose196
+.4byte sLotadPose197
+.4byte sLotadPose198
+.4byte sLotadPose199
+.4byte sLotadPose200
+.4byte sLotadPose201
+.4byte sLotadPose202
+.4byte sLotadPose203
+.4byte sLotadPose204
+.4byte sLotadPose205
+.4byte sLotadPose206
+.4byte sLotadPose207
+.4byte sLotadPose208
+.4byte sLotadPose209
+.4byte sLotadPose210
+.4byte sLotadPose211
+.4byte sLotadPose212
+.4byte sLotadPose213
+.4byte sLotadPose214
+.4byte sLotadPose215
+.4byte sLotadPose216
+.4byte sLotadPose217
+.4byte sLotadPose218
+.4byte sLotadPose219
+.4byte sLotadPose220
+.4byte sLotadPose221
+.4byte sLotadPose222
+.4byte sLotadPose223
+.4byte sLotadPose224
+.4byte sLotadPose225
+.4byte sLotadPose226
+.4byte sLotadPose227
+.4byte sLotadPose228
+.4byte sLotadPose229
+.4byte sLotadPose230
+.4byte sLotadPose231
+.4byte sLotadPose232
+.4byte sLotadPose233
+.4byte sLotadPose234
+.4byte sLotadPose235
+.4byte sLotadPose236
+.4byte sLotadPose237
+.4byte sLotadPose238
+.4byte sLotadPose239
+.4byte sLotadPose240
+.4byte sLotadPose241
+.4byte sLotadPose242
+.4byte sLotadPose243
+.4byte sLotadPose244
+.4byte sLotadPose245
+.4byte sLotadPose246
+.4byte sLotadPose247
+.4byte sLotadPose248
+.4byte sLotadPose249
+.4byte sLotadPose250
+.4byte sLotadPose251
+.4byte sLotadPose252
+.4byte sLotadPose253
+.4byte sLotadPose254
+.4byte sLotadPose255
+.4byte sLotadPose256
+.4byte sLotadPose257
+.4byte sLotadPose258
+sAxPositionsLotad:
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -1,    1, 	  -7,    0, 	   3,    2, 	  -1,   -3
+.2byte   -1,    1, 	  -6,    2, 	   5,    0, 	  -1,   -3
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte    5,    0, 	   0,    0, 	   1,    2, 	  -1,   -3
+.2byte    5,    0, 	   6,    1, 	  -3,    1, 	  -1,   -3
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    5,   -2, 	   1,   -3, 	   5,    1, 	  -1,   -4
+.2byte    5,   -2, 	   6,   -3, 	   1,    1, 	  -1,   -4
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    4,   -3, 	  -2,   -2, 	   5,   -1, 	   0,   -5
+.2byte    4,   -3, 	   1,   -3, 	   3,    0, 	   0,   -5
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    0,   -2, 	   6,   -4, 	  -6,   -1, 	  -1,   -4
+.2byte   -2,   -2, 	   4,   -1, 	  -8,   -4, 	  -1,   -4
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -6,   -3, 	   0,   -2, 	  -7,   -1, 	  -2,   -5
+.2byte   -6,   -3, 	  -3,   -3, 	  -5,    0, 	  -2,   -5
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -7,   -2, 	  -3,   -3, 	  -7,    1, 	  -1,   -4
+.2byte   -7,   -2, 	  -8,   -3, 	  -3,    1, 	  -1,   -4
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -7,    0, 	  -2,    0, 	  -3,    2, 	  -1,   -3
+.2byte   -7,    0, 	  -8,    1, 	   1,    1, 	  -1,   -3
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -1,    1, 	  -7,    0, 	   3,    2, 	  -1,   -3
+.2byte   -1,    1, 	  -6,    2, 	   5,    0, 	  -1,   -3
+.2byte   -2,   -3, 	  -7,    0, 	   5,   -3, 	  -2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   5,    0, 	   1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte    5,    0, 	   0,    0, 	   1,    2, 	  -1,   -3
+.2byte    5,    0, 	   6,    1, 	  -3,    1, 	  -1,   -3
+.2byte    3,   -5, 	   5,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    3,   -5, 	   6,   -5, 	   0,   -1, 	  -1,   -5
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    5,   -2, 	   1,   -3, 	   5,    1, 	  -1,   -4
+.2byte    5,   -2, 	   6,   -3, 	   1,    1, 	  -1,   -4
+.2byte    4,   -7, 	   3,   -6, 	   1,   -4, 	  -3,   -5
+.2byte    5,   -7, 	   2,  -10, 	   1,   -2, 	  -3,   -8
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    4,   -3, 	  -2,   -2, 	   5,   -1, 	   0,   -5
+.2byte    4,   -3, 	   1,   -3, 	   3,    0, 	   0,   -5
+.2byte    1,  -10, 	  -3,  -10, 	   4,   -6, 	  -3,   -6
+.2byte    2,  -11, 	  -2,  -12, 	   4,   -6, 	  -2,   -9
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    0,   -2, 	   6,   -4, 	  -6,   -1, 	  -1,   -4
+.2byte   -2,   -2, 	   4,   -1, 	  -8,   -4, 	  -1,   -4
+.2byte    1,  -11, 	   4,   -3, 	  -8,   -6, 	   1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -6,   -3, 	  -3,   -6
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -6,   -3, 	   0,   -2, 	  -7,   -1, 	  -2,   -5
+.2byte   -6,   -3, 	  -3,   -3, 	  -5,    0, 	  -2,   -5
+.2byte   -5,  -10, 	  -1,  -10, 	  -8,   -6, 	  -1,   -6
+.2byte   -4,  -11, 	   0,  -12, 	  -6,   -6, 	   0,   -9
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -7,   -2, 	  -3,   -3, 	  -7,    1, 	  -1,   -4
+.2byte   -7,   -2, 	  -8,   -3, 	  -3,    1, 	  -1,   -4
+.2byte   -6,   -7, 	  -5,   -6, 	  -3,   -4, 	   1,   -5
+.2byte   -7,   -7, 	  -4,  -10, 	  -3,   -2, 	   1,   -8
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -7,    0, 	  -2,    0, 	  -3,    2, 	  -1,   -3
+.2byte   -7,    0, 	  -8,    1, 	   1,    1, 	  -1,   -3
+.2byte   -5,   -5, 	  -7,   -2, 	  -1,   -4, 	  -2,   -5
+.2byte   -5,   -5, 	  -8,   -5, 	  -2,   -1, 	  -1,   -5
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -1,    1, 	  -7,    0, 	   3,    2, 	  -1,   -3
+.2byte   -1,    1, 	  -6,    2, 	   5,    0, 	  -1,   -3
+.2byte   -2,   -3, 	  -7,    0, 	   5,   -3, 	  -2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   5,    0, 	   1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte    5,    0, 	   0,    0, 	   1,    2, 	  -1,   -3
+.2byte    5,    0, 	   6,    1, 	  -3,    1, 	  -1,   -3
+.2byte    3,   -5, 	   5,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    3,   -5, 	   6,   -5, 	   0,   -1, 	  -1,   -5
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    5,   -2, 	   1,   -3, 	   5,    1, 	  -1,   -4
+.2byte    5,   -2, 	   6,   -3, 	   1,    1, 	  -1,   -4
+.2byte    4,   -7, 	   3,   -6, 	   1,   -4, 	  -3,   -5
+.2byte    5,   -7, 	   2,  -10, 	   1,   -2, 	  -3,   -8
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    4,   -3, 	  -2,   -2, 	   5,   -1, 	   0,   -5
+.2byte    4,   -3, 	   1,   -3, 	   3,    0, 	   0,   -5
+.2byte    1,  -10, 	  -3,  -10, 	   4,   -6, 	  -3,   -6
+.2byte    2,  -11, 	  -2,  -12, 	   4,   -6, 	  -2,   -9
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    0,   -2, 	   6,   -4, 	  -6,   -1, 	  -1,   -4
+.2byte   -2,   -2, 	   4,   -1, 	  -8,   -4, 	  -1,   -4
+.2byte    1,  -11, 	   4,   -3, 	  -8,   -6, 	   1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -6,   -3, 	  -3,   -6
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -6,   -3, 	   0,   -2, 	  -7,   -1, 	  -2,   -5
+.2byte   -6,   -3, 	  -3,   -3, 	  -5,    0, 	  -2,   -5
+.2byte   -5,  -10, 	  -1,  -10, 	  -8,   -6, 	  -1,   -6
+.2byte   -4,  -11, 	   0,  -12, 	  -6,   -6, 	   0,   -9
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -7,   -2, 	  -3,   -3, 	  -7,    1, 	  -1,   -4
+.2byte   -7,   -2, 	  -8,   -3, 	  -3,    1, 	  -1,   -4
+.2byte   -6,   -7, 	  -5,   -6, 	  -3,   -4, 	   1,   -5
+.2byte   -7,   -7, 	  -4,  -10, 	  -3,   -2, 	   1,   -8
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -7,    0, 	  -2,    0, 	  -3,    2, 	  -1,   -3
+.2byte   -7,    0, 	  -8,    1, 	   1,    1, 	  -1,   -3
+.2byte   -5,   -5, 	  -7,   -2, 	  -1,   -4, 	  -2,   -5
+.2byte   -5,   -5, 	  -8,   -5, 	  -2,   -1, 	  -1,   -5
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -2,   -3, 	  -7,    0, 	   5,   -3, 	  -2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   5,    0, 	   1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte    3,   -5, 	   5,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    3,   -5, 	   6,   -5, 	   0,   -1, 	  -1,   -5
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    4,   -7, 	   3,   -6, 	   1,   -4, 	  -3,   -5
+.2byte    5,   -7, 	   2,  -10, 	   1,   -2, 	  -3,   -8
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    2,  -10, 	  -2,  -10, 	   5,   -6, 	  -2,   -6
+.2byte    2,   -9, 	  -2,  -10, 	   4,   -4, 	  -2,   -7
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    1,  -11, 	   4,   -3, 	  -8,   -6, 	   1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -6,   -3, 	  -3,   -6
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -7,   -6, 	   0,   -6
+.2byte   -4,   -9, 	   0,  -10, 	  -6,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -6,   -7, 	  -5,   -6, 	  -3,   -4, 	   1,   -5
+.2byte   -7,   -7, 	  -4,  -10, 	  -3,   -2, 	   1,   -8
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -5,   -5, 	  -7,   -2, 	  -1,   -4, 	  -2,   -5
+.2byte   -5,   -5, 	  -8,   -5, 	  -2,   -1, 	  -1,   -5
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -2,   -3, 	  -7,    0, 	   5,   -3, 	  -2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   5,    0, 	   1,   -5
+.2byte    0,   -4, 	  -6,   -2, 	   6,   -7, 	  -1,   -6
+.2byte    0,   -6, 	  -8,   -8, 	   4,   -2, 	   0,   -7
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte    3,   -5, 	   5,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    3,   -5, 	   6,   -5, 	   0,   -1, 	  -1,   -5
+.2byte    3,   -5, 	   6,   -2, 	  -2,   -4, 	  -1,   -6
+.2byte    3,   -6, 	   7,   -8, 	  -2,   -1, 	   1,   -5
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    4,   -7, 	   3,   -6, 	   1,   -4, 	  -3,   -5
+.2byte    5,   -7, 	   2,  -10, 	   1,   -2, 	  -3,   -8
+.2byte    4,   -5, 	   4,   -2, 	   1,   -5, 	  -1,   -3
+.2byte    1,   -8, 	  -1,   -9, 	   4,   -1, 	  -1,   -7
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    1,  -10, 	  -3,  -10, 	   4,   -6, 	  -3,   -6
+.2byte    2,  -10, 	  -2,  -11, 	   4,   -5, 	  -2,   -8
+.2byte    4,  -10, 	   4,   -2, 	   5,   -6, 	   0,   -6
+.2byte    0,  -11, 	  -2,  -11, 	   5,   -2, 	  -2,   -8
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    1,  -11, 	   4,   -3, 	  -8,   -6, 	   1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -6,   -3, 	  -3,   -6
+.2byte    1,  -10, 	   4,   -6, 	  -6,   -8, 	   2,   -6
+.2byte   -4,  -10, 	   4,   -8, 	  -7,   -6, 	  -5,   -6
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -5,  -10, 	  -1,  -10, 	  -8,   -6, 	  -1,   -6
+.2byte   -4,  -10, 	   0,  -11, 	  -6,   -5, 	   0,   -8
+.2byte   -5,  -10, 	  -5,   -2, 	  -6,   -6, 	  -1,   -6
+.2byte   -1,  -11, 	   1,  -11, 	  -6,   -2, 	   1,   -8
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -6,   -7, 	  -5,   -6, 	  -3,   -4, 	   1,   -5
+.2byte   -7,   -7, 	  -4,  -10, 	  -3,   -2, 	   1,   -8
+.2byte   -5,   -5, 	  -5,   -2, 	  -2,   -5, 	   0,   -3
+.2byte   -2,   -8, 	   0,   -9, 	  -5,   -1, 	   0,   -7
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -5,   -5, 	  -7,   -2, 	  -1,   -4, 	  -2,   -5
+.2byte   -5,   -5, 	  -8,   -5, 	  -2,   -1, 	  -1,   -5
+.2byte   -5,   -4, 	  -8,   -1, 	   0,   -3, 	  -1,   -5
+.2byte   -5,   -5, 	  -9,   -7, 	   0,    0, 	  -3,   -4
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -6
+.2byte   -7,    0, 	  -5,    0, 	  -1,    0, 	  -1,   -5
+.2byte    0,   -7, 	  -6,   -7, 	   6,   -7, 	   0,   -9
+.2byte    4,   -8, 	   7,   -7, 	  -1,   -4, 	  -1,   -7
+.2byte    6,  -10, 	   4,  -11, 	   6,   -7, 	  -1,   -8
+.2byte    3,  -11, 	   0,  -11, 	   7,   -7, 	  -1,  -10
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -8
+.2byte   -3,  -11, 	   0,  -11, 	  -7,   -7, 	   1,  -10
+.2byte   -6,  -10, 	  -4,  -11, 	  -6,   -7, 	   1,   -8
+.2byte   -4,   -8, 	  -7,   -7, 	   1,   -4, 	   1,   -7
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -2,   -3, 	  -7,    0, 	   5,   -3, 	  -2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   5,    0, 	   1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte    3,   -5, 	   5,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    3,   -5, 	   6,   -5, 	   0,   -1, 	  -1,   -5
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    4,   -7, 	   3,   -6, 	   1,   -4, 	  -3,   -5
+.2byte    5,   -7, 	   2,  -10, 	   1,   -2, 	  -3,   -8
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    2,  -10, 	  -2,  -10, 	   5,   -6, 	  -2,   -6
+.2byte    2,   -9, 	  -2,  -10, 	   4,   -4, 	  -2,   -7
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    1,  -11, 	   4,   -3, 	  -8,   -6, 	   1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -6,   -3, 	  -3,   -6
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -7,   -6, 	   0,   -6
+.2byte   -4,   -9, 	   0,  -10, 	  -6,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -6,   -7, 	  -5,   -6, 	  -3,   -4, 	   1,   -5
+.2byte   -7,   -7, 	  -4,  -10, 	  -3,   -2, 	   1,   -8
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -5,   -5, 	  -7,   -2, 	  -1,   -4, 	  -2,   -5
+.2byte   -5,   -5, 	  -8,   -5, 	  -2,   -1, 	  -1,   -5
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte   -1,   -3, 	  -6,    0, 	   6,   -3, 	  -1,   -5
+.2byte    3,   -5, 	   5,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    6,   -7, 	   5,   -6, 	   3,   -4, 	  -1,   -5
+.2byte    2,  -10, 	  -2,  -10, 	   5,   -6, 	  -2,   -6
+.2byte    1,  -11, 	   4,   -3, 	  -8,   -6, 	   1,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -7,   -6, 	   0,   -6
+.2byte   -7,   -7, 	  -6,   -6, 	  -4,   -4, 	   0,   -5
+.2byte   -4,   -5, 	  -6,   -2, 	   0,   -4, 	  -1,   -5
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -2,   -3, 	  -7,    0, 	   5,   -3, 	  -2,   -5
+.2byte    0,   -3, 	  -7,   -3, 	   5,    0, 	   1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte    3,   -5, 	   5,   -2, 	  -1,   -4, 	   0,   -5
+.2byte    3,   -5, 	   6,   -5, 	   0,   -1, 	  -1,   -5
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    4,   -7, 	   3,   -6, 	   1,   -4, 	  -3,   -5
+.2byte    5,   -7, 	   2,  -10, 	   1,   -2, 	  -3,   -8
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    2,  -10, 	  -2,  -10, 	   5,   -6, 	  -2,   -6
+.2byte    2,   -9, 	  -2,  -10, 	   4,   -4, 	  -2,   -7
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    1,  -11, 	   4,   -3, 	  -8,   -6, 	   1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -6,   -3, 	  -3,   -6
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -4,  -10, 	   0,  -10, 	  -7,   -6, 	   0,   -6
+.2byte   -4,   -9, 	   0,  -10, 	  -6,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -6,   -7, 	  -5,   -6, 	  -3,   -4, 	   1,   -5
+.2byte   -7,   -7, 	  -4,  -10, 	  -3,   -2, 	   1,   -8
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -5,   -5, 	  -7,   -2, 	  -1,   -4, 	  -2,   -5
+.2byte   -5,   -5, 	  -8,   -5, 	  -2,   -1, 	  -1,   -5
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+.2byte   -1,    0, 	  -7,    0, 	   5,    0, 	  -1,   -4
+.2byte   -7,   -1, 	  -6,   -1, 	  -2,    0, 	  -1,   -4
+.2byte   -7,   -3, 	  -5,   -4, 	  -5,    0, 	  -1,   -5
+.2byte   -6,   -4, 	   0,   -2, 	  -6,   -1, 	  -2,   -6
+.2byte   -1,   -3, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    4,   -4, 	  -2,   -2, 	   4,   -1, 	   0,   -6
+.2byte    5,   -3, 	   3,   -4, 	   3,    0, 	  -1,   -5
+.2byte    5,   -1, 	   4,   -1, 	   0,    0, 	  -1,   -4
+sLotadAnimTable1:
+.4byte sLotadAnims_1_1
+.4byte sLotadAnims_1_2
+.4byte sLotadAnims_1_3
+.4byte sLotadAnims_1_4
+.4byte sLotadAnims_1_5
+.4byte sLotadAnims_1_6
+.4byte sLotadAnims_1_7
+.4byte sLotadAnims_1_8
+sLotadAnimTable2:
+.4byte sLotadAnims_2_1
+.4byte sLotadAnims_2_2
+.4byte sLotadAnims_2_3
+.4byte sLotadAnims_2_4
+.4byte sLotadAnims_2_5
+.4byte sLotadAnims_2_6
+.4byte sLotadAnims_2_7
+.4byte sLotadAnims_2_8
+sLotadAnimTable3:
+.4byte sLotadAnims_3_1
+.4byte sLotadAnims_3_2
+.4byte sLotadAnims_3_3
+.4byte sLotadAnims_3_4
+.4byte sLotadAnims_3_5
+.4byte sLotadAnims_3_6
+.4byte sLotadAnims_3_7
+.4byte sLotadAnims_3_8
+sLotadAnimTable4:
+.4byte sLotadAnims_4_1
+.4byte sLotadAnims_4_2
+.4byte sLotadAnims_4_3
+.4byte sLotadAnims_4_4
+.4byte sLotadAnims_4_5
+.4byte sLotadAnims_4_6
+.4byte sLotadAnims_4_7
+.4byte sLotadAnims_4_8
+sLotadAnimTable5:
+.4byte sLotadAnims_5_1
+.4byte sLotadAnims_5_2
+.4byte sLotadAnims_5_3
+.4byte sLotadAnims_5_4
+.4byte sLotadAnims_5_5
+.4byte sLotadAnims_5_6
+.4byte sLotadAnims_5_7
+.4byte sLotadAnims_5_8
+sLotadAnimTable6:
+.4byte sLotadAnims_6_1
+.4byte sLotadAnims_6_1
+.4byte sLotadAnims_6_1
+.4byte sLotadAnims_6_1
+.4byte sLotadAnims_6_1
+.4byte sLotadAnims_6_1
+.4byte sLotadAnims_6_1
+.4byte sLotadAnims_6_1
+sLotadAnimTable7:
+.4byte sLotadAnims_7_1
+.4byte sLotadAnims_7_2
+.4byte sLotadAnims_7_3
+.4byte sLotadAnims_7_4
+.4byte sLotadAnims_7_5
+.4byte sLotadAnims_7_6
+.4byte sLotadAnims_7_7
+.4byte sLotadAnims_7_8
+sLotadAnimTable8:
+.4byte sLotadAnims_8_1
+.4byte sLotadAnims_8_2
+.4byte sLotadAnims_8_3
+.4byte sLotadAnims_8_4
+.4byte sLotadAnims_8_5
+.4byte sLotadAnims_8_6
+.4byte sLotadAnims_8_7
+.4byte sLotadAnims_8_8
+sLotadAnimTable9:
+.4byte sLotadAnims_9_1
+.4byte sLotadAnims_9_2
+.4byte sLotadAnims_9_3
+.4byte sLotadAnims_9_4
+.4byte sLotadAnims_9_5
+.4byte sLotadAnims_9_6
+.4byte sLotadAnims_9_7
+.4byte sLotadAnims_9_8
+sLotadAnimTable10:
+.4byte sLotadAnims_10_1
+.4byte sLotadAnims_10_2
+.4byte sLotadAnims_10_3
+.4byte sLotadAnims_10_4
+.4byte sLotadAnims_10_5
+.4byte sLotadAnims_10_6
+.4byte sLotadAnims_10_7
+.4byte sLotadAnims_10_8
+sLotadAnimTable11:
+.4byte sLotadAnims_11_1
+.4byte sLotadAnims_11_2
+.4byte sLotadAnims_11_3
+.4byte sLotadAnims_11_4
+.4byte sLotadAnims_11_5
+.4byte sLotadAnims_11_6
+.4byte sLotadAnims_11_7
+.4byte sLotadAnims_11_8
+sLotadAnimTable12:
+.4byte sLotadAnims_12_1
+.4byte sLotadAnims_12_2
+.4byte sLotadAnims_12_3
+.4byte sLotadAnims_12_4
+.4byte sLotadAnims_12_5
+.4byte sLotadAnims_12_6
+.4byte sLotadAnims_12_7
+.4byte sLotadAnims_12_8
+sLotadAnimTable13:
+.4byte sLotadAnims_13_1
+.4byte sLotadAnims_13_2
+.4byte sLotadAnims_13_3
+.4byte sLotadAnims_13_4
+.4byte sLotadAnims_13_5
+.4byte sLotadAnims_13_6
+.4byte sLotadAnims_13_7
+.4byte sLotadAnims_13_8
+sAxAnimationsLotad:
+.4byte sLotadAnimTable1
+.4byte sLotadAnimTable2
+.4byte sLotadAnimTable3
+.4byte sLotadAnimTable4
+.4byte sLotadAnimTable5
+.4byte sLotadAnimTable6
+.4byte sLotadAnimTable7
+.4byte sLotadAnimTable8
+.4byte sLotadAnimTable9
+.4byte sLotadAnimTable10
+.4byte sLotadAnimTable11
+.4byte sLotadAnimTable12
+.4byte sLotadAnimTable13
+sAxSpritesLotad:
+.4byte sLotadSprites1
+.4byte sLotadSprites2
+.4byte sLotadSprites3
+.4byte sLotadSprites4
+.4byte sLotadSprites5
+.4byte sLotadSprites6
+.4byte sLotadSprites7
+.4byte sLotadSprites8
+.4byte sLotadSprites9
+.4byte sLotadSprites10
+.4byte sLotadSprites11
+.4byte sLotadSprites12
+.4byte sLotadSprites13
+.4byte sLotadSprites14
+.4byte sLotadSprites15
+.4byte sLotadSprites16
+.4byte sLotadSprites17
+.4byte sLotadSprites18
+.4byte sLotadSprites19
+.4byte sLotadSprites20
+.4byte sLotadSprites21
+.4byte sLotadSprites22
+.4byte sLotadSprites23
+.4byte sLotadSprites24
+.4byte sLotadSprites25
+.4byte sLotadSprites26
+.4byte sLotadSprites27
+.4byte sLotadSprites28
+.4byte sLotadSprites29
+.4byte sLotadSprites30
+.4byte sLotadSprites31
+.4byte sLotadSprites32
+.4byte sLotadSprites33
+.4byte sLotadSprites34
+.4byte sLotadSprites35
+.4byte sLotadSprites36
+.4byte sLotadSprites37
+.4byte sLotadSprites38
+.4byte sLotadSprites39
+.4byte sLotadSprites40
+.4byte sLotadSprites41
+.4byte sLotadSprites42
+sAxMainLotad:
+ax_main sAxPosesLotad, sAxAnimationsLotad, 13, sAxSpritesLotad, sAxPositionsLotad

--- a/data/ax/loudred.inc
+++ b/data/ax/loudred.inc
@@ -1,0 +1,2950 @@
+.global gAxLoudred
+gAxLoudred:
+ax_siro sAxMainLoudred
+sLoudredPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose4:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose5:
+ax_pose 4, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose7:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose8:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose9:
+ax_pose 8, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose10:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose11:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose12:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose13:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose14:
+ax_pose 13, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose15:
+ax_pose 14, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose16:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose17:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose18:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose20:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose21:
+ax_pose 8, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose28:
+ax_pose 15, 0x81e6, 0x80f3, 0x3c00
+ax_pose 16, 0x81e6, 0x4103, 0x3c08
+ax_pose 17, 0x01f6, 0x010b, 0x3c0c
+ax_pose_terminator
+sLoudredPose29:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose30:
+ax_pose 4, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose31:
+ax_pose 5, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose32:
+ax_pose 18, 0x81e5, 0x90fa, 0x3c00
+ax_pose 19, 0x81e5, 0x50f2, 0x3c08
+ax_pose_terminator
+sLoudredPose33:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose34:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose35:
+ax_pose 8, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose36:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose37:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose38:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose39:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose40:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose41:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose42:
+ax_pose 13, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose43:
+ax_pose 14, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose44:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose45:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose46:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose47:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose48:
+ax_pose 22, 0x81e5, 0x80f3, 0x3c00
+ax_pose 23, 0x81e5, 0x4103, 0x3c08
+ax_pose_terminator
+sLoudredPose49:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose50:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose51:
+ax_pose 8, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose52:
+ax_pose 20, 0x81e5, 0x80f9, 0x3c00
+ax_pose 21, 0x01f5, 0x00f1, 0x3c08
+ax_pose_terminator
+sLoudredPose53:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose54:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose55:
+ax_pose 5, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose56:
+ax_pose 18, 0x81e5, 0x80f6, 0x3c00
+ax_pose 19, 0x81e5, 0x4106, 0x3c08
+ax_pose_terminator
+sLoudredPose57:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose58:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose59:
+ax_pose 2, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose60:
+ax_pose 15, 0x81e6, 0x80f3, 0x3c00
+ax_pose 16, 0x81e6, 0x4103, 0x3c08
+ax_pose 17, 0x01f6, 0x010b, 0x3c0c
+ax_pose_terminator
+sLoudredPose61:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose62:
+ax_pose 4, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose63:
+ax_pose 5, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose64:
+ax_pose 18, 0x81e5, 0x90fa, 0x3c00
+ax_pose 19, 0x81e5, 0x50f2, 0x3c08
+ax_pose_terminator
+sLoudredPose65:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose66:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose67:
+ax_pose 8, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose68:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose69:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose70:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose71:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose72:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose73:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose74:
+ax_pose 13, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose75:
+ax_pose 14, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose76:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose77:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose78:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose79:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose80:
+ax_pose 22, 0x81e5, 0x80f3, 0x3c00
+ax_pose 23, 0x81e5, 0x4103, 0x3c08
+ax_pose_terminator
+sLoudredPose81:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose82:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose83:
+ax_pose 8, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose84:
+ax_pose 20, 0x81e5, 0x80f9, 0x3c00
+ax_pose 21, 0x01f5, 0x00f1, 0x3c08
+ax_pose_terminator
+sLoudredPose85:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose86:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose87:
+ax_pose 5, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose88:
+ax_pose 18, 0x81e5, 0x80f6, 0x3c00
+ax_pose 19, 0x81e5, 0x4106, 0x3c08
+ax_pose_terminator
+sLoudredPose89:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose90:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose91:
+ax_pose 2, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose92:
+ax_pose 15, 0x81e6, 0x80f3, 0x3c00
+ax_pose 16, 0x81e6, 0x4103, 0x3c08
+ax_pose 17, 0x01f6, 0x010b, 0x3c0c
+ax_pose_terminator
+sLoudredPose93:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose94:
+ax_pose 4, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose95:
+ax_pose 5, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose96:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose97:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose98:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose99:
+ax_pose 8, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose100:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose101:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose102:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose103:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose104:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose105:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose106:
+ax_pose 13, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose107:
+ax_pose 14, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose108:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose109:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose110:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose111:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose112:
+ax_pose 22, 0x81e5, 0x80f3, 0x3c00
+ax_pose 23, 0x81e5, 0x4103, 0x3c08
+ax_pose_terminator
+sLoudredPose113:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose114:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose115:
+ax_pose 8, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose116:
+ax_pose 20, 0x81e5, 0x80f9, 0x3c00
+ax_pose 21, 0x01f5, 0x00f1, 0x3c08
+ax_pose_terminator
+sLoudredPose117:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose118:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose119:
+ax_pose 5, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose120:
+ax_pose 18, 0x81e5, 0x80f5, 0x3c00
+ax_pose 19, 0x81e5, 0x4105, 0x3c08
+ax_pose_terminator
+sLoudredPose121:
+ax_pose 0, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose122:
+ax_pose 1, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose123:
+ax_pose 2, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose124:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose125:
+ax_pose 4, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose126:
+ax_pose 5, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose127:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose128:
+ax_pose 7, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose129:
+ax_pose 8, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose130:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose131:
+ax_pose 10, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose132:
+ax_pose 11, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose133:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose134:
+ax_pose 13, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose135:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose136:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose137:
+ax_pose 10, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose138:
+ax_pose 11, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose139:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose140:
+ax_pose 7, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose141:
+ax_pose 8, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose142:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose143:
+ax_pose 4, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose144:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose145:
+ax_pose 26, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose146:
+ax_pose 27, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose147:
+ax_pose 28, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose148:
+ax_pose 29, 0x01e4, 0x90ea, 0x3c00
+ax_pose_terminator
+sLoudredPose149:
+ax_pose 30, 0x01e7, 0x90e6, 0x3c00
+ax_pose_terminator
+sLoudredPose150:
+ax_pose 31, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sLoudredPose151:
+ax_pose 32, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose152:
+ax_pose 31, 0x01e8, 0x80f7, 0x3c00
+ax_pose_terminator
+sLoudredPose153:
+ax_pose 30, 0x01e7, 0x80fa, 0x3c00
+ax_pose_terminator
+sLoudredPose154:
+ax_pose 29, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sLoudredPose155:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose156:
+ax_pose 15, 0x81e6, 0x80f3, 0x3c00
+ax_pose 16, 0x81e6, 0x4103, 0x3c08
+ax_pose 17, 0x01f6, 0x010b, 0x3c0c
+ax_pose_terminator
+sLoudredPose157:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose158:
+ax_pose 18, 0x81e5, 0x90fa, 0x3c00
+ax_pose 19, 0x81e5, 0x50f2, 0x3c08
+ax_pose_terminator
+sLoudredPose159:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose160:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose161:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose162:
+ax_pose 22, 0x81e4, 0x90fc, 0x3c00
+ax_pose 23, 0x81e4, 0x50f4, 0x3c08
+ax_pose_terminator
+sLoudredPose163:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose164:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose165:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose166:
+ax_pose 22, 0x81e4, 0x80f4, 0x3c00
+ax_pose 23, 0x81e4, 0x4104, 0x3c08
+ax_pose_terminator
+sLoudredPose167:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose168:
+ax_pose 20, 0x81e5, 0x80f9, 0x3c00
+ax_pose 21, 0x01f5, 0x00f1, 0x3c08
+ax_pose_terminator
+sLoudredPose169:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose170:
+ax_pose 18, 0x81e5, 0x80f6, 0x3c00
+ax_pose 19, 0x81e5, 0x4106, 0x3c08
+ax_pose_terminator
+sLoudredPose171:
+ax_pose 15, 0x81e6, 0x80f3, 0x3c00
+ax_pose 16, 0x81e6, 0x4103, 0x3c08
+ax_pose 17, 0x01f6, 0x010b, 0x3c0c
+ax_pose_terminator
+sLoudredPose172:
+ax_pose 18, 0x81e5, 0x80f5, 0x3c00
+ax_pose 19, 0x81e5, 0x4105, 0x3c08
+ax_pose_terminator
+sLoudredPose173:
+ax_pose 20, 0x81e5, 0x80f9, 0x3c00
+ax_pose 21, 0x01f5, 0x00f1, 0x3c08
+ax_pose_terminator
+sLoudredPose174:
+ax_pose 22, 0x81e5, 0x80f3, 0x3c00
+ax_pose 23, 0x81e5, 0x4103, 0x3c08
+ax_pose_terminator
+sLoudredPose175:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose176:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose177:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose178:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose179:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose180:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose181:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose182:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose183:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose184:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose185:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose186:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose187:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose188:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose189:
+ax_pose 22, 0x81e5, 0x80f3, 0x3c00
+ax_pose 23, 0x81e5, 0x4103, 0x3c08
+ax_pose_terminator
+sLoudredPose190:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose191:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose192:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose193:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose194:
+ax_pose 20, 0x81e5, 0x80f9, 0x3c00
+ax_pose 21, 0x01f5, 0x00f1, 0x3c08
+ax_pose_terminator
+sLoudredPose195:
+ax_pose 22, 0x81e5, 0x80f3, 0x3c00
+ax_pose 23, 0x81e5, 0x4103, 0x3c08
+ax_pose_terminator
+sLoudredPose196:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose197:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose198:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose199:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose200:
+ax_pose 18, 0x81e5, 0x80f5, 0x3c00
+ax_pose 19, 0x81e5, 0x4105, 0x3c08
+ax_pose_terminator
+sLoudredPose201:
+ax_pose 20, 0x81e5, 0x80f9, 0x3c00
+ax_pose 21, 0x01f5, 0x00f1, 0x3c08
+ax_pose_terminator
+sLoudredPose202:
+ax_pose 22, 0x81e5, 0x80f3, 0x3c00
+ax_pose 23, 0x81e5, 0x4103, 0x3c08
+ax_pose_terminator
+sLoudredPose203:
+ax_pose 24, 0x41ea, 0x80f0, 0x3c00
+ax_pose 25, 0x41fa, 0x40f0, 0x3c08
+ax_pose_terminator
+sLoudredPose204:
+ax_pose 22, 0x81e5, 0x90fd, 0x3c00
+ax_pose 23, 0x81e5, 0x50f5, 0x3c08
+ax_pose_terminator
+sLoudredPose205:
+ax_pose 20, 0x81e5, 0x90f7, 0x3c00
+ax_pose 21, 0x01f5, 0x1107, 0x3c08
+ax_pose_terminator
+sLoudredPose206:
+ax_pose 18, 0x81e5, 0x90fb, 0x3c00
+ax_pose 19, 0x81e5, 0x50f3, 0x3c08
+ax_pose_terminator
+sLoudredPose207:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose208:
+ax_pose 5, 0x01e6, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose209:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose210:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose211:
+ax_pose 13, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose212:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose213:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose214:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose215:
+ax_pose 0, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose216:
+ax_pose 1, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sLoudredPose217:
+ax_pose 2, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sLoudredPose218:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose219:
+ax_pose 4, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sLoudredPose220:
+ax_pose 5, 0x01e6, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose221:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose222:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose223:
+ax_pose 8, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sLoudredPose224:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose225:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose226:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose227:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose228:
+ax_pose 13, 0x01ea, 0x80ef, 0x3c00
+ax_pose_terminator
+sLoudredPose229:
+ax_pose 14, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sLoudredPose230:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose231:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose232:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose233:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose234:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose235:
+ax_pose 8, 0x01e5, 0x80f5, 0x3c00
+ax_pose_terminator
+sLoudredPose236:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose237:
+ax_pose 4, 0x01e5, 0x80f5, 0x3c00
+ax_pose_terminator
+sLoudredPose238:
+ax_pose 5, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose239:
+ax_pose 0, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose240:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose241:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose242:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose243:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose244:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose245:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose246:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose247:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose248:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose249:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose250:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose251:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose252:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose253:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose254:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose255:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose256:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose257:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose258:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose259:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose260:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose261:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose262:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose263:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose264:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose265:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose266:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose267:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose268:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose269:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose270:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose271:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose272:
+ax_pose 9, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose273:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose274:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose275:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose276:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose277:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sLoudredPose278:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sLoudredPose279:
+ax_pose 12, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sLoudredPose280:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sLoudredPose281:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sLoudredPose282:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+.align 2
+sLoudredAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLoudredAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 1, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 0, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sLoudredAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 1, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sLoudredAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 12, -13, 12, -13,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 2, 1, 39, 20, -18, 20, -18,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 2, 0, 39, 20, -18, 20, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sLoudredAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 1, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 0, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sLoudredAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -12, -13, -12, -13,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 1, 47, -20, -18, -20, -18,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 0, 47, -20, -18, -20, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sLoudredAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 1, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sLoudredAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 1, 55, -21, 19, -21, 19,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 0, 55, -21, 19, -21, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLoudredAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sLoudredAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 20, 20, 20, 20,
+ax_anim 2, 1, 63, 21, 19, 21, 19,
+ax_anim 2, 0, 63, 20, 20, 20, 20,
+ax_anim 2, 0, 63, 21, 19, 21, 19,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sLoudredAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 1, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 0, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sLoudredAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 5, -6, 5, -6,
+ax_anim 1, 0, 70, 12, -13, 12, -13,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 1, 71, 20, -18, 20, -18,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 71, 20, -18, 20, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sLoudredAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -19, 0, -19,
+ax_anim 2, 1, 75, 1, -19, 1, -19,
+ax_anim 2, 0, 75, 0, -19, 0, -19,
+ax_anim 2, 0, 75, 1, -19, 1, -19,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sLoudredAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -5, -6, -5, -6,
+ax_anim 1, 0, 78, -12, -13, -12, -13,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 2, 1, 79, -20, -18, -20, -18,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 2, 0, 79, -20, -18, -20, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sLoudredAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 1, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 0, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sLoudredAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -20, 20, -20, 20,
+ax_anim 2, 1, 87, -21, 19, -21, 19,
+ax_anim 2, 0, 87, -20, 20, -20, 20,
+ax_anim 2, 0, 87, -21, 19, -21, 19,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLoudredAnims_4_1:
+ax_anim 3, 0, 89, 0, 0, 0, 0,
+ax_anim 3, 0, 90, 0, 0, 0, 0,
+ax_anim 3, 0, 89, 0, 0, 0, 0,
+ax_anim 3, 0, 90, 0, 0, 0, 0,
+ax_anim 3, 0, 89, 0, 0, 0, 0,
+ax_anim 3, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 1, 2, 91, 0, -4, 0, 0,
+ax_anim 4, 0, 91, 0, -5, 0, 0,
+ax_anim 3, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 1, 91, 0, -2, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_4_2:
+ax_anim 3, 0, 93, 0, 0, 0, 0,
+ax_anim 3, 0, 94, 0, 0, 0, 0,
+ax_anim 3, 0, 93, 0, 0, 0, 0,
+ax_anim 3, 0, 94, 0, 0, 0, 0,
+ax_anim 3, 0, 93, 0, 0, 0, 0,
+ax_anim 3, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 1, 2, 95, 0, -4, 0, 0,
+ax_anim 4, 0, 95, 0, -5, 0, 0,
+ax_anim 3, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 1, 95, 0, -2, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_4_3:
+ax_anim 3, 0, 97, 0, 0, 0, 0,
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim 3, 0, 97, 0, 0, 0, 0,
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim 3, 0, 97, 0, 0, 0, 0,
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 1, 2, 99, 0, -4, 0, 0,
+ax_anim 4, 0, 99, 0, -5, 0, 0,
+ax_anim 3, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 1, 99, 0, -2, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_4_4:
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 1, 2, 103, 0, -4, 0, 0,
+ax_anim 4, 0, 103, 0, -5, 0, 0,
+ax_anim 3, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 1, 103, 0, -2, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_4_5:
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 1, 2, 107, 0, -4, 0, 0,
+ax_anim 4, 0, 107, 0, -5, 0, 0,
+ax_anim 3, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 1, 107, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_4_6:
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 1, 2, 111, 0, -4, 0, 0,
+ax_anim 4, 0, 111, 0, -5, 0, 0,
+ax_anim 3, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 1, 111, 0, -2, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_4_7:
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 1, 2, 115, 0, -4, 0, 0,
+ax_anim 4, 0, 115, 0, -5, 0, 0,
+ax_anim 3, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 1, 115, 0, -2, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_4_8:
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 1, 2, 119, 0, -4, 0, 0,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 3, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 1, 119, 0, -2, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_5_1:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 2, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 2, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_5_3:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 2, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 2, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_5_5:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 2, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 2, 137, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_5_7:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 2, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 2, 143, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sLoudredAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sLoudredAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sLoudredAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sLoudredAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sLoudredAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sLoudredAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sLoudredAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLoudredAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -3, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 4, 0, 155, 0, -6, 0, 0,
+ax_anim 4, 0, 155, 0, -5, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_8_2:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -3, 0, 0,
+ax_anim 1, 0, 157, 0, -5, 0, 0,
+ax_anim 4, 0, 157, 0, -6, 0, 0,
+ax_anim 4, 0, 157, 0, -5, 0, 0,
+ax_anim 2, 0, 157, 0, -2, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_8_3:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -3, 0, 0,
+ax_anim 1, 0, 159, 0, -5, 0, 0,
+ax_anim 4, 0, 159, 0, -6, 0, 0,
+ax_anim 4, 0, 159, 0, -5, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_8_4:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -3, 0, 0,
+ax_anim 1, 0, 161, 0, -5, 0, 0,
+ax_anim 4, 0, 161, 0, -6, 0, 0,
+ax_anim 4, 0, 161, 0, -5, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_8_5:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -3, 0, 0,
+ax_anim 1, 0, 163, 0, -5, 0, 0,
+ax_anim 4, 0, 163, 0, -6, 0, 0,
+ax_anim 4, 0, 163, 0, -5, 0, 0,
+ax_anim 2, 0, 163, 0, -2, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_8_6:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -3, 0, 0,
+ax_anim 1, 0, 165, 0, -5, 0, 0,
+ax_anim 4, 0, 165, 0, -6, 0, 0,
+ax_anim 4, 0, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -2, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_8_7:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -3, 0, 0,
+ax_anim 1, 0, 167, 0, -5, 0, 0,
+ax_anim 4, 0, 167, 0, -6, 0, 0,
+ax_anim 4, 0, 167, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_8_8:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -3, 0, 0,
+ax_anim 1, 0, 169, 0, -5, 0, 0,
+ax_anim 4, 0, 169, 0, -6, 0, 0,
+ax_anim 4, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -2, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 9, 9, 9, 9,
+ax_anim 2, 0, 173, 9, 18, 9, 18,
+ax_anim 3, 0, 174, 0, 20, 0, 21,
+ax_anim 2, 3, 175, -9, 18, -9, 18,
+ax_anim 2, 0, 176, -9, 9, -9, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 4, 19, 4,
+ax_anim 2, 0, 172, 23, 15, 23, 15,
+ax_anim 3, 0, 173, 21, 20, 21, 20,
+ax_anim 2, 3, 174, 11, 22, 11, 22,
+ax_anim 2, 0, 175, 4, 15, 4, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -7, 17, -7,
+ax_anim 3, 0, 172, 21, 0, 21, 0,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -7, 0, -7,
+ax_anim 2, 0, 177, 5, -16, 5, -16,
+ax_anim 2, 0, 170, 11, -19, 11, -19,
+ax_anim 3, 0, 171, 21, -20, 21, -20,
+ax_anim 2, 3, 172, 24, -14, 24, -14,
+ax_anim 2, 0, 173, 20, -5, 20, -5,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -7, -4, -7, -4,
+ax_anim 2, 0, 176, -10, -12, -10, -12,
+ax_anim 2, 0, 177, -8, -18, -8, -18,
+ax_anim 3, 0, 170, 0, -18, 0, -18,
+ax_anim 2, 3, 171, 8, -18, 8, -18,
+ax_anim 2, 0, 172, 10, -10, 10, -10,
+ax_anim 1, 0, 173, 7, -4, 7, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -7, 0, -7,
+ax_anim 2, 0, 171, -5, -16, -5, -16,
+ax_anim 2, 0, 170, -11, -19, -11, -19,
+ax_anim 3, 0, 177, -21, -20, -21, -20,
+ax_anim 2, 3, 176, -24, -14, -24, -14,
+ax_anim 2, 0, 175, -20, -5, -20, -5,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -7, -17, -7,
+ax_anim 3, 0, 176, -21, 0, -21, 0,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 4, -19, 4,
+ax_anim 2, 0, 176, -23, 15, -23, 15,
+ax_anim 3, 0, 175, -21, 20, -21, 20,
+ax_anim 2, 3, 174, -11, 22, -11, 22,
+ax_anim 2, 0, 173, -4, 15, -4, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_10_1:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_10_2:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_10_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_10_4:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_10_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_10_6:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_10_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_10_8:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_11_1:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -20, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_11_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_11_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -20, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_11_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -20, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 2, 0, 225, 0, -17, 0, 0,
+ax_anim 1, 0, 225, 0, -11, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_11_5:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 3, 0, 228, 0, -21, 0, 0,
+ax_anim 2, 0, 228, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_11_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 230, 0, -16, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -20, 0, 0,
+ax_anim 3, 0, 231, 0, -21, 0, 0,
+ax_anim 2, 0, 231, 0, -17, 0, 0,
+ax_anim 1, 0, 231, 0, -11, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_11_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -20, 0, 0,
+ax_anim 3, 0, 234, 0, -21, 0, 0,
+ax_anim 2, 0, 234, 0, -18, 0, 0,
+ax_anim 1, 0, 234, 0, -12, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_11_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 236, 0, -16, 0, 0,
+ax_anim 3, 0, 236, 0, -20, 0, 0,
+ax_anim 4, 0, 236, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 3, 0, 237, 0, -22, 0, 0,
+ax_anim 2, 0, 237, 0, -18, 0, 0,
+ax_anim 1, 0, 237, 0, -12, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_12_1:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_12_2:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_12_3:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_12_4:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_12_5:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_12_6:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_12_7:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_12_8:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLoudredAnims_13_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_13_2:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_13_3:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_13_4:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_13_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_13_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_13_7:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredAnims_13_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sLoudredGfx1:
+.incbin "baserom.gba", 0x11F6FA8, 0x200
+sLoudredSprites1:
+ax_sprite sLoudredGfx1, 0x200
+ax_sprite_terminator
+sLoudredGfx2:
+.incbin "baserom.gba", 0x11F71B8, 0x200
+sLoudredSprites2:
+ax_sprite sLoudredGfx2, 0x200
+ax_sprite_terminator
+sLoudredGfx3:
+.incbin "baserom.gba", 0x11F73C8, 0x200
+sLoudredSprites3:
+ax_sprite sLoudredGfx3, 0x200
+ax_sprite_terminator
+sLoudredGfx4:
+.incbin "baserom.gba", 0x11F75D8, 0x200
+sLoudredSprites4:
+ax_sprite sLoudredGfx4, 0x200
+ax_sprite_terminator
+sLoudredGfx5:
+.incbin "baserom.gba", 0x11F77E8, 0x200
+sLoudredSprites5:
+ax_sprite sLoudredGfx5, 0x200
+ax_sprite_terminator
+sLoudredGfx6:
+.incbin "baserom.gba", 0x11F79F8, 0x200
+sLoudredSprites6:
+ax_sprite sLoudredGfx6, 0x200
+ax_sprite_terminator
+sLoudredGfx7:
+.incbin "baserom.gba", 0x11F7C08, 0x200
+sLoudredSprites7:
+ax_sprite sLoudredGfx7, 0x200
+ax_sprite_terminator
+sLoudredGfx8:
+.incbin "baserom.gba", 0x11F7E18, 0x200
+sLoudredSprites8:
+ax_sprite sLoudredGfx8, 0x200
+ax_sprite_terminator
+sLoudredGfx9:
+.incbin "baserom.gba", 0x11F8028, 0x200
+sLoudredSprites9:
+ax_sprite sLoudredGfx9, 0x200
+ax_sprite_terminator
+sLoudredGfx10:
+.incbin "baserom.gba", 0x11F8238, 0x200
+sLoudredSprites10:
+ax_sprite sLoudredGfx10, 0x200
+ax_sprite_terminator
+sLoudredGfx11:
+.incbin "baserom.gba", 0x11F8448, 0x200
+sLoudredSprites11:
+ax_sprite sLoudredGfx11, 0x200
+ax_sprite_terminator
+sLoudredGfx12:
+.incbin "baserom.gba", 0x11F8658, 0x200
+sLoudredSprites12:
+ax_sprite sLoudredGfx12, 0x200
+ax_sprite_terminator
+sLoudredGfx13:
+.incbin "baserom.gba", 0x11F8868, 0x200
+sLoudredSprites13:
+ax_sprite sLoudredGfx13, 0x200
+ax_sprite_terminator
+sLoudredGfx14:
+.incbin "baserom.gba", 0x11F8A78, 0x200
+sLoudredSprites14:
+ax_sprite sLoudredGfx14, 0x200
+ax_sprite_terminator
+sLoudredGfx15:
+.incbin "baserom.gba", 0x11F8C88, 0x200
+sLoudredSprites15:
+ax_sprite sLoudredGfx15, 0x200
+ax_sprite_terminator
+sLoudredGfx16:
+.incbin "baserom.gba", 0x11F8E98, 0x100
+sLoudredSprites16:
+ax_sprite sLoudredGfx16, 0x100
+ax_sprite_terminator
+sLoudredGfx17:
+.incbin "baserom.gba", 0x11F8FA8, 0x80
+sLoudredSprites17:
+ax_sprite sLoudredGfx17, 0x80
+ax_sprite_terminator
+sLoudredGfx18:
+.incbin "baserom.gba", 0x11F9038, 0x20
+sLoudredSprites18:
+ax_sprite sLoudredGfx18, 0x20
+ax_sprite_terminator
+sLoudredGfx19:
+.incbin "baserom.gba", 0x11F9068, 0x100
+sLoudredSprites19:
+ax_sprite sLoudredGfx19, 0x100
+ax_sprite_terminator
+sLoudredGfx20:
+.incbin "baserom.gba", 0x11F9178, 0x80
+sLoudredSprites20:
+ax_sprite sLoudredGfx20, 0x80
+ax_sprite_terminator
+sLoudredGfx21:
+.incbin "baserom.gba", 0x11F9208, 0x100
+sLoudredSprites21:
+ax_sprite sLoudredGfx21, 0x100
+ax_sprite_terminator
+sLoudredGfx22:
+.incbin "baserom.gba", 0x11F9318, 0x20
+sLoudredSprites22:
+ax_sprite sLoudredGfx22, 0x20
+ax_sprite_terminator
+sLoudredGfx23:
+.incbin "baserom.gba", 0x11F9348, 0xC0
+sLoudredSprites23:
+ax_sprite 0, 0x40
+ax_sprite sLoudredGfx23, 0xc0
+ax_sprite_terminator
+sLoudredGfx24:
+.incbin "baserom.gba", 0x11F9420, 0x80
+sLoudredSprites24:
+ax_sprite sLoudredGfx24, 0x80
+ax_sprite_terminator
+sLoudredGfx25:
+.incbin "baserom.gba", 0x11F94B0, 0x100
+sLoudredSprites25:
+ax_sprite sLoudredGfx25, 0x100
+ax_sprite_terminator
+sLoudredGfx26:
+.incbin "baserom.gba", 0x11F95C0, 0x80
+sLoudredSprites26:
+ax_sprite sLoudredGfx26, 0x80
+ax_sprite_terminator
+sLoudredGfx27:
+.incbin "baserom.gba", 0x11F9650, 0x200
+sLoudredSprites27:
+ax_sprite sLoudredGfx27, 0x200
+ax_sprite_terminator
+sLoudredGfx28:
+.incbin "baserom.gba", 0x11F9860, 0x200
+sLoudredSprites28:
+ax_sprite sLoudredGfx28, 0x200
+ax_sprite_terminator
+sLoudredGfx29:
+.incbin "baserom.gba", 0x11F9A70, 0x200
+sLoudredSprites29:
+ax_sprite sLoudredGfx29, 0x200
+ax_sprite_terminator
+sLoudredGfx30:
+.incbin "baserom.gba", 0x11F9C80, 0x200
+sLoudredSprites30:
+ax_sprite sLoudredGfx30, 0x200
+ax_sprite_terminator
+sLoudredGfx31:
+.incbin "baserom.gba", 0x11F9E90, 0x200
+sLoudredSprites31:
+ax_sprite sLoudredGfx31, 0x200
+ax_sprite_terminator
+sLoudredGfx32:
+.incbin "baserom.gba", 0x11FA0A0, 0x200
+sLoudredSprites32:
+ax_sprite sLoudredGfx32, 0x200
+ax_sprite_terminator
+sLoudredGfx33:
+.incbin "baserom.gba", 0x11FA2B0, 0x200
+sLoudredSprites33:
+ax_sprite sLoudredGfx33, 0x200
+ax_sprite_terminator
+sAxPosesLoudred:
+.4byte sLoudredPose1
+.4byte sLoudredPose2
+.4byte sLoudredPose3
+.4byte sLoudredPose4
+.4byte sLoudredPose5
+.4byte sLoudredPose6
+.4byte sLoudredPose7
+.4byte sLoudredPose8
+.4byte sLoudredPose9
+.4byte sLoudredPose10
+.4byte sLoudredPose11
+.4byte sLoudredPose12
+.4byte sLoudredPose13
+.4byte sLoudredPose14
+.4byte sLoudredPose15
+.4byte sLoudredPose16
+.4byte sLoudredPose17
+.4byte sLoudredPose18
+.4byte sLoudredPose19
+.4byte sLoudredPose20
+.4byte sLoudredPose21
+.4byte sLoudredPose22
+.4byte sLoudredPose23
+.4byte sLoudredPose24
+.4byte sLoudredPose25
+.4byte sLoudredPose26
+.4byte sLoudredPose27
+.4byte sLoudredPose28
+.4byte sLoudredPose29
+.4byte sLoudredPose30
+.4byte sLoudredPose31
+.4byte sLoudredPose32
+.4byte sLoudredPose33
+.4byte sLoudredPose34
+.4byte sLoudredPose35
+.4byte sLoudredPose36
+.4byte sLoudredPose37
+.4byte sLoudredPose38
+.4byte sLoudredPose39
+.4byte sLoudredPose40
+.4byte sLoudredPose41
+.4byte sLoudredPose42
+.4byte sLoudredPose43
+.4byte sLoudredPose44
+.4byte sLoudredPose45
+.4byte sLoudredPose46
+.4byte sLoudredPose47
+.4byte sLoudredPose48
+.4byte sLoudredPose49
+.4byte sLoudredPose50
+.4byte sLoudredPose51
+.4byte sLoudredPose52
+.4byte sLoudredPose53
+.4byte sLoudredPose54
+.4byte sLoudredPose55
+.4byte sLoudredPose56
+.4byte sLoudredPose57
+.4byte sLoudredPose58
+.4byte sLoudredPose59
+.4byte sLoudredPose60
+.4byte sLoudredPose61
+.4byte sLoudredPose62
+.4byte sLoudredPose63
+.4byte sLoudredPose64
+.4byte sLoudredPose65
+.4byte sLoudredPose66
+.4byte sLoudredPose67
+.4byte sLoudredPose68
+.4byte sLoudredPose69
+.4byte sLoudredPose70
+.4byte sLoudredPose71
+.4byte sLoudredPose72
+.4byte sLoudredPose73
+.4byte sLoudredPose74
+.4byte sLoudredPose75
+.4byte sLoudredPose76
+.4byte sLoudredPose77
+.4byte sLoudredPose78
+.4byte sLoudredPose79
+.4byte sLoudredPose80
+.4byte sLoudredPose81
+.4byte sLoudredPose82
+.4byte sLoudredPose83
+.4byte sLoudredPose84
+.4byte sLoudredPose85
+.4byte sLoudredPose86
+.4byte sLoudredPose87
+.4byte sLoudredPose88
+.4byte sLoudredPose89
+.4byte sLoudredPose90
+.4byte sLoudredPose91
+.4byte sLoudredPose92
+.4byte sLoudredPose93
+.4byte sLoudredPose94
+.4byte sLoudredPose95
+.4byte sLoudredPose96
+.4byte sLoudredPose97
+.4byte sLoudredPose98
+.4byte sLoudredPose99
+.4byte sLoudredPose100
+.4byte sLoudredPose101
+.4byte sLoudredPose102
+.4byte sLoudredPose103
+.4byte sLoudredPose104
+.4byte sLoudredPose105
+.4byte sLoudredPose106
+.4byte sLoudredPose107
+.4byte sLoudredPose108
+.4byte sLoudredPose109
+.4byte sLoudredPose110
+.4byte sLoudredPose111
+.4byte sLoudredPose112
+.4byte sLoudredPose113
+.4byte sLoudredPose114
+.4byte sLoudredPose115
+.4byte sLoudredPose116
+.4byte sLoudredPose117
+.4byte sLoudredPose118
+.4byte sLoudredPose119
+.4byte sLoudredPose120
+.4byte sLoudredPose121
+.4byte sLoudredPose122
+.4byte sLoudredPose123
+.4byte sLoudredPose124
+.4byte sLoudredPose125
+.4byte sLoudredPose126
+.4byte sLoudredPose127
+.4byte sLoudredPose128
+.4byte sLoudredPose129
+.4byte sLoudredPose130
+.4byte sLoudredPose131
+.4byte sLoudredPose132
+.4byte sLoudredPose133
+.4byte sLoudredPose134
+.4byte sLoudredPose135
+.4byte sLoudredPose136
+.4byte sLoudredPose137
+.4byte sLoudredPose138
+.4byte sLoudredPose139
+.4byte sLoudredPose140
+.4byte sLoudredPose141
+.4byte sLoudredPose142
+.4byte sLoudredPose143
+.4byte sLoudredPose144
+.4byte sLoudredPose145
+.4byte sLoudredPose146
+.4byte sLoudredPose147
+.4byte sLoudredPose148
+.4byte sLoudredPose149
+.4byte sLoudredPose150
+.4byte sLoudredPose151
+.4byte sLoudredPose152
+.4byte sLoudredPose153
+.4byte sLoudredPose154
+.4byte sLoudredPose155
+.4byte sLoudredPose156
+.4byte sLoudredPose157
+.4byte sLoudredPose158
+.4byte sLoudredPose159
+.4byte sLoudredPose160
+.4byte sLoudredPose161
+.4byte sLoudredPose162
+.4byte sLoudredPose163
+.4byte sLoudredPose164
+.4byte sLoudredPose165
+.4byte sLoudredPose166
+.4byte sLoudredPose167
+.4byte sLoudredPose168
+.4byte sLoudredPose169
+.4byte sLoudredPose170
+.4byte sLoudredPose171
+.4byte sLoudredPose172
+.4byte sLoudredPose173
+.4byte sLoudredPose174
+.4byte sLoudredPose175
+.4byte sLoudredPose176
+.4byte sLoudredPose177
+.4byte sLoudredPose178
+.4byte sLoudredPose179
+.4byte sLoudredPose180
+.4byte sLoudredPose181
+.4byte sLoudredPose182
+.4byte sLoudredPose183
+.4byte sLoudredPose184
+.4byte sLoudredPose185
+.4byte sLoudredPose186
+.4byte sLoudredPose187
+.4byte sLoudredPose188
+.4byte sLoudredPose189
+.4byte sLoudredPose190
+.4byte sLoudredPose191
+.4byte sLoudredPose192
+.4byte sLoudredPose193
+.4byte sLoudredPose194
+.4byte sLoudredPose195
+.4byte sLoudredPose196
+.4byte sLoudredPose197
+.4byte sLoudredPose198
+.4byte sLoudredPose199
+.4byte sLoudredPose200
+.4byte sLoudredPose201
+.4byte sLoudredPose202
+.4byte sLoudredPose203
+.4byte sLoudredPose204
+.4byte sLoudredPose205
+.4byte sLoudredPose206
+.4byte sLoudredPose207
+.4byte sLoudredPose208
+.4byte sLoudredPose209
+.4byte sLoudredPose210
+.4byte sLoudredPose211
+.4byte sLoudredPose212
+.4byte sLoudredPose213
+.4byte sLoudredPose214
+.4byte sLoudredPose215
+.4byte sLoudredPose216
+.4byte sLoudredPose217
+.4byte sLoudredPose218
+.4byte sLoudredPose219
+.4byte sLoudredPose220
+.4byte sLoudredPose221
+.4byte sLoudredPose222
+.4byte sLoudredPose223
+.4byte sLoudredPose224
+.4byte sLoudredPose225
+.4byte sLoudredPose226
+.4byte sLoudredPose227
+.4byte sLoudredPose228
+.4byte sLoudredPose229
+.4byte sLoudredPose230
+.4byte sLoudredPose231
+.4byte sLoudredPose232
+.4byte sLoudredPose233
+.4byte sLoudredPose234
+.4byte sLoudredPose235
+.4byte sLoudredPose236
+.4byte sLoudredPose237
+.4byte sLoudredPose238
+.4byte sLoudredPose239
+.4byte sLoudredPose240
+.4byte sLoudredPose241
+.4byte sLoudredPose242
+.4byte sLoudredPose243
+.4byte sLoudredPose244
+.4byte sLoudredPose245
+.4byte sLoudredPose246
+.4byte sLoudredPose247
+.4byte sLoudredPose248
+.4byte sLoudredPose249
+.4byte sLoudredPose250
+.4byte sLoudredPose251
+.4byte sLoudredPose252
+.4byte sLoudredPose253
+.4byte sLoudredPose254
+.4byte sLoudredPose255
+.4byte sLoudredPose256
+.4byte sLoudredPose257
+.4byte sLoudredPose258
+.4byte sLoudredPose259
+.4byte sLoudredPose260
+.4byte sLoudredPose261
+.4byte sLoudredPose262
+.4byte sLoudredPose263
+.4byte sLoudredPose264
+.4byte sLoudredPose265
+.4byte sLoudredPose266
+.4byte sLoudredPose267
+.4byte sLoudredPose268
+.4byte sLoudredPose269
+.4byte sLoudredPose270
+.4byte sLoudredPose271
+.4byte sLoudredPose272
+.4byte sLoudredPose273
+.4byte sLoudredPose274
+.4byte sLoudredPose275
+.4byte sLoudredPose276
+.4byte sLoudredPose277
+.4byte sLoudredPose278
+.4byte sLoudredPose279
+.4byte sLoudredPose280
+.4byte sLoudredPose281
+.4byte sLoudredPose282
+sAxPositionsLoudred:
+.2byte   -1,   -8, 	  -9,  -13, 	   9,  -13, 	  -1,  -11
+.2byte   -2,   -6, 	 -12,   -9, 	   9,  -13, 	  -2,   -9
+.2byte    1,   -6, 	  -9,  -13, 	  12,   -9, 	   1,   -9
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    3,   -5, 	   7,  -10, 	  -8,  -11, 	   3,   -8
+.2byte    1,   -5, 	   7,  -14, 	  -9,   -6, 	   1,   -8
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -9, 	  -1,  -11, 	   2,   -8
+.2byte    5,   -5, 	   0,  -15, 	   0,   -5, 	   2,   -7
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte   -2,  -10, 	  -8,   -9, 	   8,  -11, 	  -2,   -8
+.2byte    1,   -8, 	  -7,  -15, 	   8,   -7, 	  -1,   -8
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    2,  -10, 	  11,   -9, 	  -9,  -14, 	   1,  -10
+.2byte   -3,  -10, 	   8,  -14, 	 -11,   -9, 	  -2,  -10
+.2byte   -3,  -10, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte    1,  -10, 	   7,   -9, 	  -9,  -11, 	   1,   -8
+.2byte   -2,   -8, 	   6,  -15, 	  -9,   -7, 	   0,   -8
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -6,   -7, 	   0,   -9, 	   0,  -11, 	  -3,   -8
+.2byte   -6,   -5, 	  -1,  -15, 	  -1,   -5, 	  -3,   -7
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -4,   -5, 	  -8,  -10, 	   7,  -11, 	  -4,   -8
+.2byte   -2,   -5, 	  -8,  -14, 	   8,   -6, 	  -2,   -8
+.2byte   -1,   -7, 	  -9,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -2,   -6, 	 -12,   -9, 	   9,  -13, 	  -2,   -9
+.2byte    1,   -6, 	  -9,  -13, 	  12,   -9, 	   1,   -9
+.2byte   -1,  -10, 	 -10,   -5, 	   9,   -5, 	  -1,  -11
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    3,   -5, 	   7,  -10, 	  -8,  -11, 	   3,   -8
+.2byte    1,   -5, 	   7,  -14, 	  -9,   -6, 	   1,   -8
+.2byte    1,   -8, 	   6,   -6, 	 -10,   -1, 	  -1,   -9
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -9, 	  -1,  -11, 	   2,   -8
+.2byte    5,   -5, 	   0,  -15, 	   0,   -5, 	   2,   -7
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -9, 	  -7,  -14, 	   7,  -10, 	  -1,   -9
+.2byte   -2,  -10, 	  -8,   -9, 	   8,  -11, 	  -2,   -8
+.2byte    1,   -8, 	  -7,  -15, 	   8,   -7, 	  -1,   -8
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte   -2,  -10, 	   8,  -12, 	  -9,  -12, 	  -1,  -10
+.2byte    2,  -10, 	  11,   -9, 	  -9,  -14, 	   1,  -10
+.2byte   -3,  -10, 	   8,  -14, 	 -11,   -9, 	  -2,  -10
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	   6,  -14, 	  -8,  -10, 	   0,   -9
+.2byte    1,  -10, 	   7,   -9, 	  -9,  -11, 	   1,   -8
+.2byte   -2,   -8, 	   6,  -15, 	  -9,   -7, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -4, 	  -9,   -3, 	   1,   -8
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -6,   -7, 	   0,   -9, 	   0,  -11, 	  -3,   -8
+.2byte   -6,   -5, 	  -1,  -15, 	  -1,   -5, 	  -3,   -7
+.2byte   -4,  -10, 	   2,   -7, 	   2,   -4, 	   0,  -11
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -4,   -5, 	  -8,  -10, 	   7,  -11, 	  -4,   -8
+.2byte   -2,   -5, 	  -8,  -14, 	   8,   -6, 	  -2,   -8
+.2byte   -2,   -8, 	  -7,   -6, 	   9,   -1, 	   0,   -9
+.2byte   -1,   -7, 	  -9,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -2,   -6, 	 -12,   -9, 	   9,  -13, 	  -2,   -9
+.2byte    1,   -6, 	  -9,  -13, 	  12,   -9, 	   1,   -9
+.2byte   -1,  -10, 	 -10,   -5, 	   9,   -5, 	  -1,  -11
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    3,   -5, 	   7,  -10, 	  -8,  -11, 	   3,   -8
+.2byte    1,   -5, 	   7,  -14, 	  -9,   -6, 	   1,   -8
+.2byte    1,   -8, 	   6,   -6, 	 -10,   -1, 	  -1,   -9
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -9, 	  -1,  -11, 	   2,   -8
+.2byte    5,   -5, 	   0,  -15, 	   0,   -5, 	   2,   -7
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -9, 	  -7,  -14, 	   7,  -10, 	  -1,   -9
+.2byte   -2,  -10, 	  -8,   -9, 	   8,  -11, 	  -2,   -8
+.2byte    1,   -8, 	  -7,  -15, 	   8,   -7, 	  -1,   -8
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte   -2,  -10, 	   8,  -12, 	  -9,  -12, 	  -1,  -10
+.2byte    2,  -10, 	  11,   -9, 	  -9,  -14, 	   1,  -10
+.2byte   -3,  -10, 	   8,  -14, 	 -11,   -9, 	  -2,  -10
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	   6,  -14, 	  -8,  -10, 	   0,   -9
+.2byte    1,  -10, 	   7,   -9, 	  -9,  -11, 	   1,   -8
+.2byte   -2,   -8, 	   6,  -15, 	  -9,   -7, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -4, 	  -9,   -3, 	   1,   -8
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -6,   -7, 	   0,   -9, 	   0,  -11, 	  -3,   -8
+.2byte   -6,   -5, 	  -1,  -15, 	  -1,   -5, 	  -3,   -7
+.2byte   -4,  -10, 	   2,   -7, 	   2,   -4, 	   0,  -11
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -4,   -5, 	  -8,  -10, 	   7,  -11, 	  -4,   -8
+.2byte   -2,   -5, 	  -8,  -14, 	   8,   -6, 	  -2,   -8
+.2byte   -2,   -8, 	  -7,   -6, 	   9,   -1, 	   0,   -9
+.2byte   -1,   -7, 	  -9,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -2,   -6, 	 -12,   -9, 	   9,  -13, 	  -2,   -9
+.2byte    1,   -6, 	  -9,  -13, 	  12,   -9, 	   1,   -9
+.2byte   -1,  -10, 	 -10,   -5, 	   9,   -5, 	  -1,  -11
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    3,   -5, 	   7,  -10, 	  -8,  -11, 	   3,   -8
+.2byte    1,   -5, 	   7,  -14, 	  -9,   -6, 	   1,   -8
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -9, 	  -1,  -11, 	   2,   -8
+.2byte    5,   -5, 	   0,  -15, 	   0,   -5, 	   2,   -7
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -9, 	  -7,  -14, 	   7,  -10, 	  -1,   -9
+.2byte   -2,  -10, 	  -8,   -9, 	   8,  -11, 	  -2,   -8
+.2byte    1,   -8, 	  -7,  -15, 	   8,   -7, 	  -1,   -8
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte   -2,  -10, 	   8,  -12, 	  -9,  -12, 	  -1,  -10
+.2byte    2,  -10, 	  11,   -9, 	  -9,  -14, 	   1,  -10
+.2byte   -3,  -10, 	   8,  -14, 	 -11,   -9, 	  -2,  -10
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	   6,  -14, 	  -8,  -10, 	   0,   -9
+.2byte    1,  -10, 	   7,   -9, 	  -9,  -11, 	   1,   -8
+.2byte   -2,   -8, 	   6,  -15, 	  -9,   -7, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -4, 	  -9,   -3, 	   1,   -8
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -6,   -7, 	   0,   -9, 	   0,  -11, 	  -3,   -8
+.2byte   -6,   -5, 	  -1,  -15, 	  -1,   -5, 	  -3,   -7
+.2byte   -4,  -10, 	   2,   -7, 	   2,   -4, 	   0,  -11
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -4,   -5, 	  -8,  -10, 	   7,  -11, 	  -4,   -8
+.2byte   -2,   -5, 	  -8,  -14, 	   8,   -6, 	  -2,   -8
+.2byte   -3,   -8, 	  -8,   -6, 	   8,   -1, 	  -1,   -9
+.2byte   -1,   -8, 	  -9,  -13, 	   9,  -13, 	  -1,  -11
+.2byte   -2,   -8, 	 -12,  -11, 	   9,  -15, 	  -2,  -11
+.2byte    1,   -8, 	  -9,  -15, 	  12,  -11, 	   1,  -11
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    3,   -6, 	   7,  -11, 	  -8,  -12, 	   3,   -9
+.2byte    1,   -7, 	   7,  -16, 	  -9,   -8, 	   1,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    5,   -8, 	  -1,  -10, 	  -1,  -12, 	   2,   -9
+.2byte    5,   -6, 	   0,  -16, 	   0,   -6, 	   2,   -8
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte   -2,  -11, 	  -8,  -10, 	   8,  -12, 	  -2,   -9
+.2byte    1,   -9, 	  -7,  -16, 	   8,   -8, 	  -1,   -9
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    2,  -11, 	  11,  -10, 	  -9,  -15, 	   1,  -11
+.2byte   -3,  -11, 	   8,  -15, 	 -11,  -10, 	  -2,  -11
+.2byte   -3,  -10, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte    1,  -11, 	   7,  -10, 	  -9,  -12, 	   1,   -9
+.2byte   -2,   -9, 	   6,  -16, 	  -9,   -8, 	   0,   -9
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -6,   -8, 	   0,  -10, 	   0,  -12, 	  -3,   -9
+.2byte   -6,   -6, 	  -1,  -16, 	  -1,   -6, 	  -3,   -8
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -4,   -6, 	  -8,  -11, 	   7,  -12, 	  -4,   -9
+.2byte   -2,   -7, 	  -8,  -16, 	   8,   -8, 	  -2,  -10
+.2byte   -4,   -4, 	  -8,   -4, 	   8,    0, 	  -2,   -7
+.2byte   -4,   -5, 	  -8,   -4, 	   8,    0, 	  -2,   -8
+.2byte   -1,  -12, 	 -13,  -13, 	  11,  -13, 	  -1,  -14
+.2byte   -2,  -10, 	   5,  -19, 	 -13,  -12, 	  -2,  -12
+.2byte   -1,   -8, 	  -7,  -16, 	 -12,   -3, 	  -5,   -8
+.2byte    2,   -5, 	  -7,  -14, 	   3,   -5, 	  -4,   -6
+.2byte   -1,   -8, 	  10,   -7, 	 -11,   -7, 	  -1,   -6
+.2byte   -3,   -5, 	   6,  -14, 	  -4,   -5, 	   3,   -6
+.2byte    0,   -8, 	   6,  -16, 	  11,   -3, 	   4,   -8
+.2byte    1,  -10, 	  -6,  -19, 	  12,  -12, 	   1,  -12
+.2byte   -1,   -7, 	  -9,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -1,  -10, 	 -10,   -5, 	   9,   -5, 	  -1,  -11
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    1,   -8, 	   6,   -6, 	 -10,   -1, 	  -1,   -9
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -9, 	  -7,  -14, 	   7,  -10, 	  -1,   -9
+.2byte   -1,   -9, 	  -8,   -5, 	   7,   -4, 	  -3,   -9
+.2byte   -2,  -10, 	   8,  -12, 	  -9,  -12, 	  -1,  -10
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	   6,  -14, 	  -8,  -10, 	   0,   -9
+.2byte    0,   -9, 	   7,   -5, 	  -8,   -4, 	   2,   -9
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -4,  -10, 	   2,   -7, 	   2,   -4, 	   0,  -11
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -2,   -8, 	  -7,   -6, 	   9,   -1, 	   0,   -9
+.2byte   -1,  -10, 	 -10,   -5, 	   9,   -5, 	  -1,  -11
+.2byte   -3,   -8, 	  -8,   -6, 	   8,   -1, 	  -1,   -9
+.2byte   -4,  -10, 	   2,   -7, 	   2,   -4, 	   0,  -11
+.2byte   -1,   -8, 	   6,   -4, 	  -9,   -3, 	   1,   -8
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte   -1,   -8, 	   6,   -4, 	  -9,   -3, 	   1,   -8
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte   -4,  -10, 	   2,   -7, 	   2,   -4, 	   0,  -11
+.2byte   -1,   -8, 	   6,   -4, 	  -9,   -3, 	   1,   -8
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte   -3,   -8, 	  -8,   -6, 	   8,   -1, 	  -1,   -9
+.2byte   -4,  -10, 	   2,   -7, 	   2,   -4, 	   0,  -11
+.2byte   -1,   -8, 	   6,   -4, 	  -9,   -3, 	   1,   -8
+.2byte   -1,   -8, 	   8,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,   -8, 	  -7,   -4, 	   8,   -3, 	  -2,   -8
+.2byte    3,  -10, 	  -3,   -7, 	  -3,   -4, 	  -1,  -11
+.2byte    2,   -8, 	   7,   -6, 	  -9,   -1, 	   0,   -9
+.2byte   -2,   -6, 	 -12,   -9, 	   9,  -13, 	  -2,   -9
+.2byte    1,   -5, 	   7,  -14, 	  -9,   -6, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -9, 	  -1,  -11, 	   2,   -8
+.2byte   -2,  -10, 	  -8,   -9, 	   8,  -11, 	  -2,   -8
+.2byte    2,  -10, 	  11,   -9, 	  -9,  -14, 	   1,  -10
+.2byte    1,  -10, 	   7,   -9, 	  -9,  -11, 	   1,   -8
+.2byte   -6,   -7, 	   0,   -9, 	   0,  -11, 	  -3,   -8
+.2byte   -4,   -5, 	  -8,  -10, 	   7,  -11, 	  -4,   -8
+.2byte   -1,   -8, 	  -9,  -13, 	   9,  -13, 	  -1,  -11
+.2byte   -1,   -6, 	 -11,   -9, 	  10,  -13, 	  -1,   -9
+.2byte    0,   -6, 	 -10,  -13, 	  11,   -9, 	   0,   -9
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    2,   -5, 	   6,  -10, 	  -9,  -11, 	   2,   -8
+.2byte    2,   -5, 	   8,  -14, 	  -8,   -6, 	   2,   -8
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -9, 	  -1,  -11, 	   2,   -8
+.2byte    4,   -5, 	  -1,  -15, 	  -1,   -5, 	   1,   -7
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte   -2,  -10, 	  -8,   -9, 	   8,  -11, 	  -2,   -8
+.2byte    1,   -8, 	  -7,  -15, 	   8,   -7, 	  -1,   -8
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    1,  -10, 	  10,   -9, 	 -10,  -14, 	   0,  -10
+.2byte   -2,  -10, 	   9,  -14, 	 -10,   -9, 	  -1,  -10
+.2byte   -3,  -10, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte    1,  -10, 	   7,   -9, 	  -9,  -11, 	   1,   -8
+.2byte   -2,   -8, 	   6,  -15, 	  -9,   -7, 	   0,   -8
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -6,   -7, 	   0,   -9, 	   0,  -11, 	  -3,   -8
+.2byte   -5,   -5, 	   0,  -15, 	   0,   -5, 	  -2,   -7
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -3,   -5, 	  -7,  -10, 	   8,  -11, 	  -3,   -8
+.2byte   -3,   -5, 	  -9,  -14, 	   7,   -6, 	  -3,   -8
+.2byte   -1,   -8, 	  -9,  -13, 	   9,  -13, 	  -1,  -11
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -3,  -10, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte   -3,  -10, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -3,  -10, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -3,  -10, 	   6,  -15, 	  -8,  -11, 	   0,  -10
+.2byte   -2,  -11, 	   8,  -13, 	  -9,  -13, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -15, 	   7,  -11, 	  -1,  -10
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+.2byte   -1,   -7, 	  -9,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -3,   -7, 	  -7,  -14, 	   6,  -10, 	  -3,  -10
+.2byte   -5,   -7, 	   0,  -13, 	   0,   -9, 	  -2,   -8
+.2byte   -3,   -9, 	   6,  -14, 	  -8,  -10, 	   0,   -9
+.2byte   -2,  -10, 	   8,  -12, 	  -9,  -12, 	  -1,  -10
+.2byte    2,   -9, 	  -7,  -14, 	   7,  -10, 	  -1,   -9
+.2byte    4,   -7, 	  -1,  -13, 	  -1,   -9, 	   1,   -8
+.2byte    2,   -7, 	   6,  -14, 	  -7,  -10, 	   2,  -10
+sLoudredAnimTable1:
+.4byte sLoudredAnims_1_1
+.4byte sLoudredAnims_1_2
+.4byte sLoudredAnims_1_3
+.4byte sLoudredAnims_1_4
+.4byte sLoudredAnims_1_5
+.4byte sLoudredAnims_1_6
+.4byte sLoudredAnims_1_7
+.4byte sLoudredAnims_1_8
+sLoudredAnimTable2:
+.4byte sLoudredAnims_2_1
+.4byte sLoudredAnims_2_2
+.4byte sLoudredAnims_2_3
+.4byte sLoudredAnims_2_4
+.4byte sLoudredAnims_2_5
+.4byte sLoudredAnims_2_6
+.4byte sLoudredAnims_2_7
+.4byte sLoudredAnims_2_8
+sLoudredAnimTable3:
+.4byte sLoudredAnims_3_1
+.4byte sLoudredAnims_3_2
+.4byte sLoudredAnims_3_3
+.4byte sLoudredAnims_3_4
+.4byte sLoudredAnims_3_5
+.4byte sLoudredAnims_3_6
+.4byte sLoudredAnims_3_7
+.4byte sLoudredAnims_3_8
+sLoudredAnimTable4:
+.4byte sLoudredAnims_4_1
+.4byte sLoudredAnims_4_2
+.4byte sLoudredAnims_4_3
+.4byte sLoudredAnims_4_4
+.4byte sLoudredAnims_4_5
+.4byte sLoudredAnims_4_6
+.4byte sLoudredAnims_4_7
+.4byte sLoudredAnims_4_8
+sLoudredAnimTable5:
+.4byte sLoudredAnims_5_1
+.4byte sLoudredAnims_5_2
+.4byte sLoudredAnims_5_3
+.4byte sLoudredAnims_5_4
+.4byte sLoudredAnims_5_5
+.4byte sLoudredAnims_5_6
+.4byte sLoudredAnims_5_7
+.4byte sLoudredAnims_5_8
+sLoudredAnimTable6:
+.4byte sLoudredAnims_6_1
+.4byte sLoudredAnims_6_1
+.4byte sLoudredAnims_6_1
+.4byte sLoudredAnims_6_1
+.4byte sLoudredAnims_6_1
+.4byte sLoudredAnims_6_1
+.4byte sLoudredAnims_6_1
+.4byte sLoudredAnims_6_1
+sLoudredAnimTable7:
+.4byte sLoudredAnims_7_1
+.4byte sLoudredAnims_7_2
+.4byte sLoudredAnims_7_3
+.4byte sLoudredAnims_7_4
+.4byte sLoudredAnims_7_5
+.4byte sLoudredAnims_7_6
+.4byte sLoudredAnims_7_7
+.4byte sLoudredAnims_7_8
+sLoudredAnimTable8:
+.4byte sLoudredAnims_8_1
+.4byte sLoudredAnims_8_2
+.4byte sLoudredAnims_8_3
+.4byte sLoudredAnims_8_4
+.4byte sLoudredAnims_8_5
+.4byte sLoudredAnims_8_6
+.4byte sLoudredAnims_8_7
+.4byte sLoudredAnims_8_8
+sLoudredAnimTable9:
+.4byte sLoudredAnims_9_1
+.4byte sLoudredAnims_9_2
+.4byte sLoudredAnims_9_3
+.4byte sLoudredAnims_9_4
+.4byte sLoudredAnims_9_5
+.4byte sLoudredAnims_9_6
+.4byte sLoudredAnims_9_7
+.4byte sLoudredAnims_9_8
+sLoudredAnimTable10:
+.4byte sLoudredAnims_10_1
+.4byte sLoudredAnims_10_2
+.4byte sLoudredAnims_10_3
+.4byte sLoudredAnims_10_4
+.4byte sLoudredAnims_10_5
+.4byte sLoudredAnims_10_6
+.4byte sLoudredAnims_10_7
+.4byte sLoudredAnims_10_8
+sLoudredAnimTable11:
+.4byte sLoudredAnims_11_1
+.4byte sLoudredAnims_11_2
+.4byte sLoudredAnims_11_3
+.4byte sLoudredAnims_11_4
+.4byte sLoudredAnims_11_5
+.4byte sLoudredAnims_11_6
+.4byte sLoudredAnims_11_7
+.4byte sLoudredAnims_11_8
+sLoudredAnimTable12:
+.4byte sLoudredAnims_12_1
+.4byte sLoudredAnims_12_2
+.4byte sLoudredAnims_12_3
+.4byte sLoudredAnims_12_4
+.4byte sLoudredAnims_12_5
+.4byte sLoudredAnims_12_6
+.4byte sLoudredAnims_12_7
+.4byte sLoudredAnims_12_8
+sLoudredAnimTable13:
+.4byte sLoudredAnims_13_1
+.4byte sLoudredAnims_13_2
+.4byte sLoudredAnims_13_3
+.4byte sLoudredAnims_13_4
+.4byte sLoudredAnims_13_5
+.4byte sLoudredAnims_13_6
+.4byte sLoudredAnims_13_7
+.4byte sLoudredAnims_13_8
+sAxAnimationsLoudred:
+.4byte sLoudredAnimTable1
+.4byte sLoudredAnimTable2
+.4byte sLoudredAnimTable3
+.4byte sLoudredAnimTable4
+.4byte sLoudredAnimTable5
+.4byte sLoudredAnimTable6
+.4byte sLoudredAnimTable7
+.4byte sLoudredAnimTable8
+.4byte sLoudredAnimTable9
+.4byte sLoudredAnimTable10
+.4byte sLoudredAnimTable11
+.4byte sLoudredAnimTable12
+.4byte sLoudredAnimTable13
+sAxSpritesLoudred:
+.4byte sLoudredSprites1
+.4byte sLoudredSprites2
+.4byte sLoudredSprites3
+.4byte sLoudredSprites4
+.4byte sLoudredSprites5
+.4byte sLoudredSprites6
+.4byte sLoudredSprites7
+.4byte sLoudredSprites8
+.4byte sLoudredSprites9
+.4byte sLoudredSprites10
+.4byte sLoudredSprites11
+.4byte sLoudredSprites12
+.4byte sLoudredSprites13
+.4byte sLoudredSprites14
+.4byte sLoudredSprites15
+.4byte sLoudredSprites16
+.4byte sLoudredSprites17
+.4byte sLoudredSprites18
+.4byte sLoudredSprites19
+.4byte sLoudredSprites20
+.4byte sLoudredSprites21
+.4byte sLoudredSprites22
+.4byte sLoudredSprites23
+.4byte sLoudredSprites24
+.4byte sLoudredSprites25
+.4byte sLoudredSprites26
+.4byte sLoudredSprites27
+.4byte sLoudredSprites28
+.4byte sLoudredSprites29
+.4byte sLoudredSprites30
+.4byte sLoudredSprites31
+.4byte sLoudredSprites32
+.4byte sLoudredSprites33
+sAxMainLoudred:
+ax_main sAxPosesLoudred, sAxAnimationsLoudred, 13, sAxSpritesLoudred, sAxPositionsLoudred

--- a/data/ax/ludicolo.inc
+++ b/data/ax/ludicolo.inc
@@ -1,0 +1,2675 @@
+.global gAxLudicolo
+gAxLudicolo:
+ax_siro sAxMainLudicolo
+sLudicoloPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose4:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose5:
+ax_pose 4, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose6:
+ax_pose 5, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose7:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose8:
+ax_pose 7, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose9:
+ax_pose 8, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose10:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose11:
+ax_pose 10, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose12:
+ax_pose 11, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose16:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose17:
+ax_pose 10, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose18:
+ax_pose 11, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose19:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose20:
+ax_pose 7, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose21:
+ax_pose 8, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose28:
+ax_pose 15, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose29:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose30:
+ax_pose 4, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose31:
+ax_pose 5, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose32:
+ax_pose 16, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose33:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose34:
+ax_pose 7, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose35:
+ax_pose 8, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose36:
+ax_pose 17, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose37:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose38:
+ax_pose 10, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose39:
+ax_pose 11, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose40:
+ax_pose 18, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose41:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose42:
+ax_pose 13, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose43:
+ax_pose 14, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose44:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose45:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose46:
+ax_pose 10, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose47:
+ax_pose 11, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose48:
+ax_pose 18, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose49:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose50:
+ax_pose 7, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose51:
+ax_pose 8, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose52:
+ax_pose 17, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose53:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose54:
+ax_pose 4, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose55:
+ax_pose 5, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose56:
+ax_pose 16, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose58:
+ax_pose 1, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose59:
+ax_pose 2, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose60:
+ax_pose 15, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose61:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose62:
+ax_pose 4, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose63:
+ax_pose 5, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose64:
+ax_pose 16, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose65:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose66:
+ax_pose 7, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose67:
+ax_pose 8, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose68:
+ax_pose 17, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose69:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose70:
+ax_pose 10, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose71:
+ax_pose 11, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose72:
+ax_pose 18, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose73:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose74:
+ax_pose 13, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose75:
+ax_pose 14, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose76:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose77:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose78:
+ax_pose 10, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose79:
+ax_pose 11, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose80:
+ax_pose 18, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose81:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose82:
+ax_pose 7, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose83:
+ax_pose 8, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose84:
+ax_pose 17, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose85:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose86:
+ax_pose 4, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose87:
+ax_pose 5, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose88:
+ax_pose 16, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose90:
+ax_pose 20, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose91:
+ax_pose 15, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose92:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose93:
+ax_pose 21, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose94:
+ax_pose 16, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose95:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose96:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose97:
+ax_pose 17, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose98:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose99:
+ax_pose 23, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose100:
+ax_pose 18, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose101:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose102:
+ax_pose 24, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose103:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose104:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose105:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose106:
+ax_pose 18, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose107:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose108:
+ax_pose 22, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose109:
+ax_pose 17, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose110:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose111:
+ax_pose 21, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose112:
+ax_pose 16, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose113:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose114:
+ax_pose 1, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose115:
+ax_pose 2, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose116:
+ax_pose 20, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose117:
+ax_pose 15, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose118:
+ax_pose 25, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose119:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose120:
+ax_pose 4, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose121:
+ax_pose 5, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose122:
+ax_pose 21, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose123:
+ax_pose 16, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose124:
+ax_pose 26, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose125:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose126:
+ax_pose 7, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose127:
+ax_pose 8, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose128:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose129:
+ax_pose 17, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose130:
+ax_pose 27, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose131:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose132:
+ax_pose 10, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose133:
+ax_pose 11, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose134:
+ax_pose 23, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose135:
+ax_pose 18, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose136:
+ax_pose 28, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose137:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose138:
+ax_pose 13, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose139:
+ax_pose 14, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose140:
+ax_pose 24, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose141:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose142:
+ax_pose 29, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose143:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose144:
+ax_pose 10, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose145:
+ax_pose 11, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose146:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose147:
+ax_pose 18, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose148:
+ax_pose 28, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose149:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose150:
+ax_pose 7, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose151:
+ax_pose 8, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose152:
+ax_pose 22, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose153:
+ax_pose 17, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose154:
+ax_pose 27, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose155:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose156:
+ax_pose 4, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose157:
+ax_pose 5, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose158:
+ax_pose 21, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose159:
+ax_pose 16, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose160:
+ax_pose 26, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose161:
+ax_pose 30, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose162:
+ax_pose 31, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose163:
+ax_pose 32, 0x01e1, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose164:
+ax_pose 33, 0x01e3, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose165:
+ax_pose 34, 0x01e3, 0x90eb, 0x8c00
+ax_pose_terminator
+sLudicoloPose166:
+ax_pose 35, 0x01e3, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose167:
+ax_pose 36, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose168:
+ax_pose 35, 0x01e3, 0x80f3, 0x8c00
+ax_pose_terminator
+sLudicoloPose169:
+ax_pose 34, 0x01e3, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose170:
+ax_pose 33, 0x01e3, 0x80f3, 0x8c00
+ax_pose_terminator
+sLudicoloPose171:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose172:
+ax_pose 25, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose173:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose174:
+ax_pose 26, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose175:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose176:
+ax_pose 27, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose177:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose178:
+ax_pose 28, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose179:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose180:
+ax_pose 29, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose181:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose182:
+ax_pose 28, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose183:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose184:
+ax_pose 27, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose185:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose186:
+ax_pose 26, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose187:
+ax_pose 15, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose188:
+ax_pose 16, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose189:
+ax_pose 17, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose190:
+ax_pose 18, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose191:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose192:
+ax_pose 18, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose193:
+ax_pose 17, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose194:
+ax_pose 16, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose195:
+ax_pose 25, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose196:
+ax_pose 26, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose197:
+ax_pose 27, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose198:
+ax_pose 28, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose199:
+ax_pose 29, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose200:
+ax_pose 28, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose201:
+ax_pose 27, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose202:
+ax_pose 26, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose203:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose204:
+ax_pose 25, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose205:
+ax_pose 20, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose206:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose207:
+ax_pose 26, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose208:
+ax_pose 21, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose209:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose210:
+ax_pose 27, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose211:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose212:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose213:
+ax_pose 28, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose214:
+ax_pose 23, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose215:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose216:
+ax_pose 29, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose217:
+ax_pose 24, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose218:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose219:
+ax_pose 28, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose220:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose221:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose222:
+ax_pose 27, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose223:
+ax_pose 22, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sLudicoloPose224:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose225:
+ax_pose 26, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose226:
+ax_pose 21, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose227:
+ax_pose 20, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose228:
+ax_pose 21, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose229:
+ax_pose 22, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose230:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose231:
+ax_pose 24, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose232:
+ax_pose 23, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose233:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sLudicoloPose234:
+ax_pose 21, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sLudicoloPose235:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose236:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose237:
+ax_pose 6, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sLudicoloPose238:
+ax_pose 9, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sLudicoloPose239:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sLudicoloPose240:
+ax_pose 9, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sLudicoloPose241:
+ax_pose 6, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sLudicoloPose242:
+ax_pose 3, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+.align 2
+sLudicoloAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLudicoloAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 1, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sLudicoloAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sLudicoloAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -4, 6, -4,
+ax_anim 1, 0, 38, 12, -10, 12, -10,
+ax_anim 2, 0, 39, 18, -16, 18, -16,
+ax_anim 2, 1, 39, 19, -15, 19, -15,
+ax_anim 2, 0, 39, 18, -16, 18, -16,
+ax_anim 2, 0, 39, 19, -15, 19, -15,
+ax_anim 2, 0, 36, 8, -6, 8, -6,
+ax_anim_terminator
+sLudicoloAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sLudicoloAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -4, -6, -4,
+ax_anim 1, 0, 46, -12, -10, -12, -10,
+ax_anim 2, 0, 47, -18, -16, -18, -16,
+ax_anim 2, 1, 47, -19, -15, -19, -15,
+ax_anim 2, 0, 47, -18, -16, -18, -16,
+ax_anim 2, 0, 47, -19, -15, -19, -15,
+ax_anim 2, 0, 44, -8, -6, -8, -6,
+ax_anim_terminator
+sLudicoloAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sLudicoloAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 1, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 0, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 12, 0, 12,
+ax_anim 1, 0, 58, 0, 26, 0, 26,
+ax_anim 2, 0, 59, 0, 43, 0, 43,
+ax_anim 2, 1, 59, 1, 43, 1, 43,
+ax_anim 2, 0, 59, 0, 43, 0, 43,
+ax_anim 2, 0, 59, 1, 43, 1, 43,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sLudicoloAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 12, 12, 12, 12,
+ax_anim 1, 0, 62, 26, 26, 26, 26,
+ax_anim 2, 0, 63, 42, 43, 42, 43,
+ax_anim 2, 1, 63, 43, 42, 43, 42,
+ax_anim 2, 0, 63, 42, 43, 42, 43,
+ax_anim 2, 0, 63, 43, 42, 43, 42,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sLudicoloAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 12, 0, 12, 0,
+ax_anim 1, 0, 66, 26, 0, 26, 0,
+ax_anim 2, 0, 67, 44, 0, 44, 0,
+ax_anim 2, 1, 67, 44, 1, 44, 1,
+ax_anim 2, 0, 67, 44, 0, 44, 0,
+ax_anim 2, 0, 67, 44, 1, 44, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sLudicoloAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 14, -12, 14, -12,
+ax_anim 1, 0, 70, 28, -26, 28, -26,
+ax_anim 2, 0, 71, 42, -40, 42, -40,
+ax_anim 2, 1, 71, 43, -39, 43, -39,
+ax_anim 2, 0, 71, 42, -40, 42, -40,
+ax_anim 2, 0, 71, 43, -39, 43, -39,
+ax_anim 2, 0, 68, 8, -6, 8, -6,
+ax_anim_terminator
+sLudicoloAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -12, 0, -12,
+ax_anim 1, 0, 74, 0, -27, 0, -27,
+ax_anim 2, 0, 75, 0, -39, 0, -39,
+ax_anim 2, 1, 75, 1, -39, 1, -39,
+ax_anim 2, 0, 75, 0, -39, 0, -39,
+ax_anim 2, 0, 75, 1, -39, 1, -39,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sLudicoloAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -14, -12, -14, -12,
+ax_anim 1, 0, 78, -28, -26, -28, -26,
+ax_anim 2, 0, 79, -42, -40, -42, -40,
+ax_anim 2, 1, 79, -43, -39, -43, -39,
+ax_anim 2, 0, 79, -42, -40, -42, -40,
+ax_anim 2, 0, 79, -43, -39, -43, -39,
+ax_anim 2, 0, 76, -8, -6, -8, -6,
+ax_anim_terminator
+sLudicoloAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -12, 0, -12, 0,
+ax_anim 1, 0, 82, -26, 0, -26, 0,
+ax_anim 2, 0, 83, -44, 0, -44, 0,
+ax_anim 2, 1, 83, -44, 1, -44, 1,
+ax_anim 2, 0, 83, -44, 0, -44, 0,
+ax_anim 2, 0, 83, -44, 1, -44, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sLudicoloAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -12, 12, -12, 12,
+ax_anim 1, 0, 86, -26, 26, -26, 26,
+ax_anim 2, 0, 87, -42, 43, -42, 43,
+ax_anim 2, 1, 87, -43, 42, -43, 42,
+ax_anim 2, 0, 87, -42, 43, -42, 43,
+ax_anim 2, 0, 87, -43, 42, -43, 42,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sLudicoloAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sLudicoloAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sLudicoloAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sLudicoloAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sLudicoloAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sLudicoloAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sLudicoloAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_5_1:
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 4, 0, 117, 0, -7, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim_terminator
+sLudicoloAnims_5_2:
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -6, 0, 0,
+ax_anim 4, 0, 123, 0, -7, 0, 0,
+ax_anim 2, 0, 123, 0, -6, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim_terminator
+sLudicoloAnims_5_3:
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -6, 0, 0,
+ax_anim 4, 0, 129, 0, -7, 0, 0,
+ax_anim 2, 0, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 1, 0, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 1, 0, 1,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 1, 0, 1,
+ax_anim_terminator
+sLudicoloAnims_5_4:
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -6, 0, 0,
+ax_anim 4, 0, 135, 0, -7, 0, 0,
+ax_anim 2, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+sLudicoloAnims_5_5:
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -4, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, 0,
+ax_anim 4, 0, 141, 0, -7, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim_terminator
+sLudicoloAnims_5_6:
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -6, 0, 0,
+ax_anim 4, 0, 147, 0, -7, 0, 0,
+ax_anim 2, 0, 147, 0, -6, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim 2, 1, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, -1, 1, -1,
+ax_anim_terminator
+sLudicoloAnims_5_7:
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -6, 0, 0,
+ax_anim 4, 0, 153, 0, -7, 0, 0,
+ax_anim 2, 0, 153, 0, -6, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 1, 0, 1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 1, 0, 1,
+ax_anim 2, 1, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 1, 0, 1,
+ax_anim_terminator
+sLudicoloAnims_5_8:
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -6, 0, 0,
+ax_anim 4, 0, 159, 0, -7, 0, 0,
+ax_anim 2, 0, 159, 0, -6, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 1, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sLudicoloAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sLudicoloAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sLudicoloAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sLudicoloAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sLudicoloAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sLudicoloAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sLudicoloAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_8_1:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 20, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_8_2:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 20, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_8_3:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_8_4:
+ax_anim 40, 0, 176, 0, 0, 0, 0,
+ax_anim 20, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_8_5:
+ax_anim 40, 0, 178, 0, 0, 0, 0,
+ax_anim 20, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_8_6:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 20, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_8_7:
+ax_anim 40, 0, 182, 0, 0, 0, 0,
+ax_anim 20, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_8_8:
+ax_anim 40, 0, 184, 0, 0, 0, 0,
+ax_anim 20, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 3, 7, 3,
+ax_anim 2, 0, 188, 11, 9, 11, 9,
+ax_anim 2, 0, 189, 10, 18, 10, 18,
+ax_anim 3, 0, 190, 0, 22, 0, 22,
+ax_anim 2, 3, 191, -10, 18, -10, 18,
+ax_anim 2, 0, 192, -11, 9, -11, 9,
+ax_anim 1, 0, 193, -7, 3, -7, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 4, 17, 4,
+ax_anim 2, 0, 188, 22, 11, 22, 11,
+ax_anim 3, 0, 189, 22, 21, 22, 21,
+ax_anim 2, 3, 190, 10, 22, 10, 22,
+ax_anim 2, 0, 191, 2, 17, 2, 17,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 10, -7, 10, -7,
+ax_anim 2, 0, 187, 17, -5, 17, -5,
+ax_anim 3, 0, 188, 22, 0, 22, 0,
+ax_anim 2, 3, 189, 18, 5, 18, 5,
+ax_anim 2, 0, 190, 12, 7, 12, 7,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -2, -8, -2, -8,
+ax_anim 2, 0, 193, 2, -16, 2, -16,
+ax_anim 2, 0, 186, 12, -20, 12, -20,
+ax_anim 3, 0, 187, 21, -18, 21, -18,
+ax_anim 2, 3, 188, 24, -12, 24, -12,
+ax_anim 2, 0, 189, 20, -3, 20, -3,
+ax_anim 1, 0, 190, 11, 1, 11, 1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -11, -12, -11, -12,
+ax_anim 2, 0, 193, -8, -17, -8, -17,
+ax_anim 3, 0, 186, 0, -19, 0, -19,
+ax_anim 2, 3, 187, 8, -17, 8, -17,
+ax_anim 2, 0, 188, 11, -12, 11, -12,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 2, -8, 2, -8,
+ax_anim 2, 0, 187, -2, -16, -2, -16,
+ax_anim 2, 0, 186, -12, -20, -12, -20,
+ax_anim 3, 0, 193, -21, -18, -21, -18,
+ax_anim 2, 3, 192, -24, -12, -24, -12,
+ax_anim 2, 0, 191, -20, -3, -20, -3,
+ax_anim 1, 0, 190, -11, -1, -11, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -10, -7, -10, -7,
+ax_anim 2, 0, 193, -17, -5, -17, -5,
+ax_anim 3, 0, 192, -22, 0, -22, 0,
+ax_anim 2, 3, 191, -18, 5, -18, 5,
+ax_anim 2, 0, 190, -12, 7, -12, 7,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 4, -17, 4,
+ax_anim 2, 0, 192, -22, 11, -22, 11,
+ax_anim 3, 0, 191, -22, 21, -22, 21,
+ax_anim 2, 3, 190, -10, 22, -10, 22,
+ax_anim 2, 0, 189, -2, 17, -2, 17,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -25, 0, 0,
+ax_anim 2, 0, 204, 0, -21, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -23, 0, 0,
+ax_anim 2, 0, 207, 0, -20, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -23, 0, 0,
+ax_anim 2, 0, 225, 0, -20, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLudicoloAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sLudicoloGfx1:
+.incbin "baserom.gba", 0x1120C7C, 0x200
+sLudicoloSprites1:
+ax_sprite sLudicoloGfx1, 0x200
+ax_sprite_terminator
+sLudicoloGfx2:
+.incbin "baserom.gba", 0x1120E8C, 0x200
+sLudicoloSprites2:
+ax_sprite sLudicoloGfx2, 0x200
+ax_sprite_terminator
+sLudicoloGfx3:
+.incbin "baserom.gba", 0x112109C, 0x200
+sLudicoloSprites3:
+ax_sprite sLudicoloGfx3, 0x200
+ax_sprite_terminator
+sLudicoloGfx4:
+.incbin "baserom.gba", 0x11212AC, 0x200
+sLudicoloSprites4:
+ax_sprite sLudicoloGfx4, 0x200
+ax_sprite_terminator
+sLudicoloGfx5:
+.incbin "baserom.gba", 0x11214BC, 0x200
+sLudicoloSprites5:
+ax_sprite sLudicoloGfx5, 0x200
+ax_sprite_terminator
+sLudicoloGfx6:
+.incbin "baserom.gba", 0x11216CC, 0x200
+sLudicoloSprites6:
+ax_sprite sLudicoloGfx6, 0x200
+ax_sprite_terminator
+sLudicoloGfx7:
+.incbin "baserom.gba", 0x11218DC, 0x200
+sLudicoloSprites7:
+ax_sprite sLudicoloGfx7, 0x200
+ax_sprite_terminator
+sLudicoloGfx8:
+.incbin "baserom.gba", 0x1121AEC, 0x200
+sLudicoloSprites8:
+ax_sprite sLudicoloGfx8, 0x200
+ax_sprite_terminator
+sLudicoloGfx9:
+.incbin "baserom.gba", 0x1121CFC, 0x200
+sLudicoloSprites9:
+ax_sprite sLudicoloGfx9, 0x200
+ax_sprite_terminator
+sLudicoloGfx10:
+.incbin "baserom.gba", 0x1121F0C, 0x200
+sLudicoloSprites10:
+ax_sprite sLudicoloGfx10, 0x200
+ax_sprite_terminator
+sLudicoloGfx11:
+.incbin "baserom.gba", 0x112211C, 0x200
+sLudicoloSprites11:
+ax_sprite sLudicoloGfx11, 0x200
+ax_sprite_terminator
+sLudicoloGfx12:
+.incbin "baserom.gba", 0x112232C, 0x200
+sLudicoloSprites12:
+ax_sprite sLudicoloGfx12, 0x200
+ax_sprite_terminator
+sLudicoloGfx13:
+.incbin "baserom.gba", 0x112253C, 0x200
+sLudicoloSprites13:
+ax_sprite sLudicoloGfx13, 0x200
+ax_sprite_terminator
+sLudicoloGfx14:
+.incbin "baserom.gba", 0x112274C, 0x200
+sLudicoloSprites14:
+ax_sprite sLudicoloGfx14, 0x200
+ax_sprite_terminator
+sLudicoloGfx15:
+.incbin "baserom.gba", 0x112295C, 0x200
+sLudicoloSprites15:
+ax_sprite sLudicoloGfx15, 0x200
+ax_sprite_terminator
+sLudicoloGfx16:
+.incbin "baserom.gba", 0x1122B6C, 0x200
+sLudicoloSprites16:
+ax_sprite sLudicoloGfx16, 0x200
+ax_sprite_terminator
+sLudicoloGfx17:
+.incbin "baserom.gba", 0x1122D7C, 0x1E0
+sLudicoloSprites17:
+ax_sprite sLudicoloGfx17, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLudicoloGfx18:
+.incbin "baserom.gba", 0x1122F74, 0x60
+sLudicoloGfx18_1:
+.incbin "baserom.gba", 0x1122FD4, 0x100
+sLudicoloGfx18_2:
+.incbin "baserom.gba", 0x11230D4, 0x40
+sLudicoloSprites18:
+ax_sprite sLudicoloGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLudicoloGfx19:
+.incbin "baserom.gba", 0x112314C, 0x180
+sLudicoloGfx19_1:
+.incbin "baserom.gba", 0x11232CC, 0x40
+sLudicoloSprites19:
+ax_sprite sLudicoloGfx19, 0x180
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLudicoloGfx20:
+.incbin "baserom.gba", 0x1123334, 0x200
+sLudicoloSprites20:
+ax_sprite sLudicoloGfx20, 0x200
+ax_sprite_terminator
+sLudicoloGfx21:
+.incbin "baserom.gba", 0x1123544, 0x1E0
+sLudicoloSprites21:
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx21, 0x1e0
+ax_sprite_terminator
+sLudicoloGfx22:
+.incbin "baserom.gba", 0x112373C, 0x200
+sLudicoloSprites22:
+ax_sprite sLudicoloGfx22, 0x200
+ax_sprite_terminator
+sLudicoloGfx23:
+.incbin "baserom.gba", 0x112394C, 0x60
+sLudicoloGfx23_1:
+.incbin "baserom.gba", 0x11239AC, 0x60
+sLudicoloGfx23_2:
+.incbin "baserom.gba", 0x1123A0C, 0xE0
+sLudicoloSprites23:
+ax_sprite sLudicoloGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx23_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLudicoloGfx24:
+.incbin "baserom.gba", 0x1123B24, 0x180
+sLudicoloGfx24_1:
+.incbin "baserom.gba", 0x1123CA4, 0x40
+sLudicoloSprites24:
+ax_sprite sLudicoloGfx24, 0x180
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLudicoloGfx25:
+.incbin "baserom.gba", 0x1123D0C, 0x200
+sLudicoloSprites25:
+ax_sprite sLudicoloGfx25, 0x200
+ax_sprite_terminator
+sLudicoloGfx26:
+.incbin "baserom.gba", 0x1123F1C, 0x200
+sLudicoloSprites26:
+ax_sprite sLudicoloGfx26, 0x200
+ax_sprite_terminator
+sLudicoloGfx27:
+.incbin "baserom.gba", 0x112412C, 0x100
+sLudicoloGfx27_1:
+.incbin "baserom.gba", 0x112422C, 0x60
+sLudicoloGfx27_2:
+.incbin "baserom.gba", 0x112428C, 0x60
+sLudicoloSprites27:
+ax_sprite sLudicoloGfx27, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx27_2, 0x60
+ax_sprite_terminator
+sLudicoloGfx28:
+.incbin "baserom.gba", 0x112431C, 0x180
+sLudicoloGfx28_1:
+.incbin "baserom.gba", 0x112449C, 0x40
+sLudicoloSprites28:
+ax_sprite sLudicoloGfx28, 0x180
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLudicoloGfx29:
+.incbin "baserom.gba", 0x1124504, 0x180
+sLudicoloGfx29_1:
+.incbin "baserom.gba", 0x1124684, 0x60
+sLudicoloSprites29:
+ax_sprite sLudicoloGfx29, 0x180
+ax_sprite 0, 0x20
+ax_sprite sLudicoloGfx29_1, 0x60
+ax_sprite_terminator
+sLudicoloGfx30:
+.incbin "baserom.gba", 0x1124704, 0x200
+sLudicoloSprites30:
+ax_sprite sLudicoloGfx30, 0x200
+ax_sprite_terminator
+sLudicoloGfx31:
+.incbin "baserom.gba", 0x1124914, 0x200
+sLudicoloSprites31:
+ax_sprite sLudicoloGfx31, 0x200
+ax_sprite_terminator
+sLudicoloGfx32:
+.incbin "baserom.gba", 0x1124B24, 0x200
+sLudicoloSprites32:
+ax_sprite sLudicoloGfx32, 0x200
+ax_sprite_terminator
+sLudicoloGfx33:
+.incbin "baserom.gba", 0x1124D34, 0x200
+sLudicoloSprites33:
+ax_sprite sLudicoloGfx33, 0x200
+ax_sprite_terminator
+sLudicoloGfx34:
+.incbin "baserom.gba", 0x1124F44, 0x200
+sLudicoloSprites34:
+ax_sprite sLudicoloGfx34, 0x200
+ax_sprite_terminator
+sLudicoloGfx35:
+.incbin "baserom.gba", 0x1125154, 0x200
+sLudicoloSprites35:
+ax_sprite sLudicoloGfx35, 0x200
+ax_sprite_terminator
+sLudicoloGfx36:
+.incbin "baserom.gba", 0x1125364, 0x200
+sLudicoloSprites36:
+ax_sprite sLudicoloGfx36, 0x200
+ax_sprite_terminator
+sLudicoloGfx37:
+.incbin "baserom.gba", 0x1125574, 0x200
+sLudicoloSprites37:
+ax_sprite sLudicoloGfx37, 0x200
+ax_sprite_terminator
+sAxPosesLudicolo:
+.4byte sLudicoloPose1
+.4byte sLudicoloPose2
+.4byte sLudicoloPose3
+.4byte sLudicoloPose4
+.4byte sLudicoloPose5
+.4byte sLudicoloPose6
+.4byte sLudicoloPose7
+.4byte sLudicoloPose8
+.4byte sLudicoloPose9
+.4byte sLudicoloPose10
+.4byte sLudicoloPose11
+.4byte sLudicoloPose12
+.4byte sLudicoloPose13
+.4byte sLudicoloPose14
+.4byte sLudicoloPose15
+.4byte sLudicoloPose16
+.4byte sLudicoloPose17
+.4byte sLudicoloPose18
+.4byte sLudicoloPose19
+.4byte sLudicoloPose20
+.4byte sLudicoloPose21
+.4byte sLudicoloPose22
+.4byte sLudicoloPose23
+.4byte sLudicoloPose24
+.4byte sLudicoloPose25
+.4byte sLudicoloPose26
+.4byte sLudicoloPose27
+.4byte sLudicoloPose28
+.4byte sLudicoloPose29
+.4byte sLudicoloPose30
+.4byte sLudicoloPose31
+.4byte sLudicoloPose32
+.4byte sLudicoloPose33
+.4byte sLudicoloPose34
+.4byte sLudicoloPose35
+.4byte sLudicoloPose36
+.4byte sLudicoloPose37
+.4byte sLudicoloPose38
+.4byte sLudicoloPose39
+.4byte sLudicoloPose40
+.4byte sLudicoloPose41
+.4byte sLudicoloPose42
+.4byte sLudicoloPose43
+.4byte sLudicoloPose44
+.4byte sLudicoloPose45
+.4byte sLudicoloPose46
+.4byte sLudicoloPose47
+.4byte sLudicoloPose48
+.4byte sLudicoloPose49
+.4byte sLudicoloPose50
+.4byte sLudicoloPose51
+.4byte sLudicoloPose52
+.4byte sLudicoloPose53
+.4byte sLudicoloPose54
+.4byte sLudicoloPose55
+.4byte sLudicoloPose56
+.4byte sLudicoloPose57
+.4byte sLudicoloPose58
+.4byte sLudicoloPose59
+.4byte sLudicoloPose60
+.4byte sLudicoloPose61
+.4byte sLudicoloPose62
+.4byte sLudicoloPose63
+.4byte sLudicoloPose64
+.4byte sLudicoloPose65
+.4byte sLudicoloPose66
+.4byte sLudicoloPose67
+.4byte sLudicoloPose68
+.4byte sLudicoloPose69
+.4byte sLudicoloPose70
+.4byte sLudicoloPose71
+.4byte sLudicoloPose72
+.4byte sLudicoloPose73
+.4byte sLudicoloPose74
+.4byte sLudicoloPose75
+.4byte sLudicoloPose76
+.4byte sLudicoloPose77
+.4byte sLudicoloPose78
+.4byte sLudicoloPose79
+.4byte sLudicoloPose80
+.4byte sLudicoloPose81
+.4byte sLudicoloPose82
+.4byte sLudicoloPose83
+.4byte sLudicoloPose84
+.4byte sLudicoloPose85
+.4byte sLudicoloPose86
+.4byte sLudicoloPose87
+.4byte sLudicoloPose88
+.4byte sLudicoloPose89
+.4byte sLudicoloPose90
+.4byte sLudicoloPose91
+.4byte sLudicoloPose92
+.4byte sLudicoloPose93
+.4byte sLudicoloPose94
+.4byte sLudicoloPose95
+.4byte sLudicoloPose96
+.4byte sLudicoloPose97
+.4byte sLudicoloPose98
+.4byte sLudicoloPose99
+.4byte sLudicoloPose100
+.4byte sLudicoloPose101
+.4byte sLudicoloPose102
+.4byte sLudicoloPose103
+.4byte sLudicoloPose104
+.4byte sLudicoloPose105
+.4byte sLudicoloPose106
+.4byte sLudicoloPose107
+.4byte sLudicoloPose108
+.4byte sLudicoloPose109
+.4byte sLudicoloPose110
+.4byte sLudicoloPose111
+.4byte sLudicoloPose112
+.4byte sLudicoloPose113
+.4byte sLudicoloPose114
+.4byte sLudicoloPose115
+.4byte sLudicoloPose116
+.4byte sLudicoloPose117
+.4byte sLudicoloPose118
+.4byte sLudicoloPose119
+.4byte sLudicoloPose120
+.4byte sLudicoloPose121
+.4byte sLudicoloPose122
+.4byte sLudicoloPose123
+.4byte sLudicoloPose124
+.4byte sLudicoloPose125
+.4byte sLudicoloPose126
+.4byte sLudicoloPose127
+.4byte sLudicoloPose128
+.4byte sLudicoloPose129
+.4byte sLudicoloPose130
+.4byte sLudicoloPose131
+.4byte sLudicoloPose132
+.4byte sLudicoloPose133
+.4byte sLudicoloPose134
+.4byte sLudicoloPose135
+.4byte sLudicoloPose136
+.4byte sLudicoloPose137
+.4byte sLudicoloPose138
+.4byte sLudicoloPose139
+.4byte sLudicoloPose140
+.4byte sLudicoloPose141
+.4byte sLudicoloPose142
+.4byte sLudicoloPose143
+.4byte sLudicoloPose144
+.4byte sLudicoloPose145
+.4byte sLudicoloPose146
+.4byte sLudicoloPose147
+.4byte sLudicoloPose148
+.4byte sLudicoloPose149
+.4byte sLudicoloPose150
+.4byte sLudicoloPose151
+.4byte sLudicoloPose152
+.4byte sLudicoloPose153
+.4byte sLudicoloPose154
+.4byte sLudicoloPose155
+.4byte sLudicoloPose156
+.4byte sLudicoloPose157
+.4byte sLudicoloPose158
+.4byte sLudicoloPose159
+.4byte sLudicoloPose160
+.4byte sLudicoloPose161
+.4byte sLudicoloPose162
+.4byte sLudicoloPose163
+.4byte sLudicoloPose164
+.4byte sLudicoloPose165
+.4byte sLudicoloPose166
+.4byte sLudicoloPose167
+.4byte sLudicoloPose168
+.4byte sLudicoloPose169
+.4byte sLudicoloPose170
+.4byte sLudicoloPose171
+.4byte sLudicoloPose172
+.4byte sLudicoloPose173
+.4byte sLudicoloPose174
+.4byte sLudicoloPose175
+.4byte sLudicoloPose176
+.4byte sLudicoloPose177
+.4byte sLudicoloPose178
+.4byte sLudicoloPose179
+.4byte sLudicoloPose180
+.4byte sLudicoloPose181
+.4byte sLudicoloPose182
+.4byte sLudicoloPose183
+.4byte sLudicoloPose184
+.4byte sLudicoloPose185
+.4byte sLudicoloPose186
+.4byte sLudicoloPose187
+.4byte sLudicoloPose188
+.4byte sLudicoloPose189
+.4byte sLudicoloPose190
+.4byte sLudicoloPose191
+.4byte sLudicoloPose192
+.4byte sLudicoloPose193
+.4byte sLudicoloPose194
+.4byte sLudicoloPose195
+.4byte sLudicoloPose196
+.4byte sLudicoloPose197
+.4byte sLudicoloPose198
+.4byte sLudicoloPose199
+.4byte sLudicoloPose200
+.4byte sLudicoloPose201
+.4byte sLudicoloPose202
+.4byte sLudicoloPose203
+.4byte sLudicoloPose204
+.4byte sLudicoloPose205
+.4byte sLudicoloPose206
+.4byte sLudicoloPose207
+.4byte sLudicoloPose208
+.4byte sLudicoloPose209
+.4byte sLudicoloPose210
+.4byte sLudicoloPose211
+.4byte sLudicoloPose212
+.4byte sLudicoloPose213
+.4byte sLudicoloPose214
+.4byte sLudicoloPose215
+.4byte sLudicoloPose216
+.4byte sLudicoloPose217
+.4byte sLudicoloPose218
+.4byte sLudicoloPose219
+.4byte sLudicoloPose220
+.4byte sLudicoloPose221
+.4byte sLudicoloPose222
+.4byte sLudicoloPose223
+.4byte sLudicoloPose224
+.4byte sLudicoloPose225
+.4byte sLudicoloPose226
+.4byte sLudicoloPose227
+.4byte sLudicoloPose228
+.4byte sLudicoloPose229
+.4byte sLudicoloPose230
+.4byte sLudicoloPose231
+.4byte sLudicoloPose232
+.4byte sLudicoloPose233
+.4byte sLudicoloPose234
+.4byte sLudicoloPose235
+.4byte sLudicoloPose236
+.4byte sLudicoloPose237
+.4byte sLudicoloPose238
+.4byte sLudicoloPose239
+.4byte sLudicoloPose240
+.4byte sLudicoloPose241
+.4byte sLudicoloPose242
+sAxPositionsLudicolo:
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -1,   -8, 	 -13,   -6, 	  10,  -10, 	  -1,   -9
+.2byte    0,   -8, 	 -11,  -10, 	  12,   -6, 	   0,   -9
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+.2byte    4,   -8, 	  13,   -7, 	  -5,  -12, 	   1,   -8
+.2byte    3,   -8, 	  11,  -14, 	  -6,   -4, 	  -1,   -7
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    7,  -10, 	   4,   -9, 	   4,  -12, 	  -1,  -10
+.2byte    6,   -6, 	   3,  -15, 	   2,   -5, 	  -1,   -6
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    4,  -11, 	  -6,   -8, 	  10,  -15, 	  -2,  -10
+.2byte    4,   -6, 	  -4,  -15, 	   8,   -3, 	   0,   -7
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	  11,   -8, 	 -10,  -16, 	  -2,   -9
+.2byte   -1,  -10, 	   9,  -16, 	 -12,   -9, 	   0,   -9
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -8, 	 -10,  -15, 	   2,  -10
+.2byte   -4,   -6, 	   4,  -15, 	  -8,   -3, 	   0,   -7
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -7,  -10, 	  -4,   -9, 	  -4,  -12, 	   1,  -10
+.2byte   -6,   -6, 	  -3,  -15, 	  -2,   -5, 	   1,   -6
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -4,   -8, 	 -13,   -7, 	   5,  -12, 	  -1,   -8
+.2byte   -3,   -8, 	 -11,  -14, 	   6,   -4, 	   1,   -7
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -1,   -8, 	 -13,   -6, 	  10,  -10, 	  -1,   -9
+.2byte    0,   -8, 	 -11,  -10, 	  12,   -6, 	   0,   -9
+.2byte   -1,   -7, 	 -13,  -12, 	  12,  -12, 	   0,   -8
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+.2byte    4,   -8, 	  13,   -7, 	  -5,  -12, 	   1,   -8
+.2byte    3,   -8, 	  11,  -14, 	  -6,   -4, 	  -1,   -7
+.2byte    5,   -8, 	  13,  -14, 	  -7,   -8, 	   2,   -8
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    7,  -10, 	   4,   -9, 	   4,  -12, 	  -1,  -10
+.2byte    6,   -6, 	   3,  -15, 	   2,   -5, 	  -1,   -6
+.2byte    6,   -8, 	   0,  -12, 	  -1,   -7, 	   0,   -8
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    4,  -11, 	  -6,   -8, 	  10,  -15, 	  -2,  -10
+.2byte    4,   -6, 	  -4,  -15, 	   8,   -3, 	   0,   -7
+.2byte    5,  -10, 	  -3,  -14, 	  10,   -8, 	   0,   -9
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	  11,   -8, 	 -10,  -16, 	  -2,   -9
+.2byte   -1,  -10, 	   9,  -16, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -10, 	  13,  -13, 	 -14,  -13, 	   0,   -9
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -8, 	 -10,  -15, 	   2,  -10
+.2byte   -4,   -6, 	   4,  -15, 	  -8,   -3, 	   0,   -7
+.2byte   -5,  -10, 	   3,  -14, 	 -10,   -8, 	   0,   -9
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -7,  -10, 	  -4,   -9, 	  -4,  -12, 	   1,  -10
+.2byte   -6,   -6, 	  -3,  -15, 	  -2,   -5, 	   1,   -6
+.2byte   -6,   -8, 	   0,  -12, 	   1,   -7, 	   0,   -8
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -4,   -8, 	 -13,   -7, 	   5,  -12, 	  -1,   -8
+.2byte   -3,   -8, 	 -11,  -14, 	   6,   -4, 	   1,   -7
+.2byte   -5,   -8, 	 -13,  -14, 	   7,   -8, 	  -2,   -8
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -1,   -8, 	 -13,   -6, 	  10,  -10, 	  -1,   -9
+.2byte    0,   -8, 	 -11,  -10, 	  12,   -6, 	   0,   -9
+.2byte   -1,   -7, 	 -13,  -12, 	  12,  -12, 	   0,   -8
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+.2byte    4,   -8, 	  13,   -7, 	  -5,  -12, 	   1,   -8
+.2byte    3,   -8, 	  11,  -14, 	  -6,   -4, 	  -1,   -7
+.2byte    5,   -8, 	  13,  -14, 	  -7,   -8, 	   2,   -8
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    7,  -10, 	   4,   -9, 	   4,  -12, 	  -1,  -10
+.2byte    6,   -6, 	   3,  -15, 	   2,   -5, 	  -1,   -6
+.2byte    6,   -8, 	   0,  -12, 	  -1,   -7, 	   0,   -8
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    4,  -11, 	  -6,   -8, 	  10,  -15, 	  -2,  -10
+.2byte    4,   -6, 	  -4,  -15, 	   8,   -3, 	   0,   -7
+.2byte    5,  -10, 	  -3,  -14, 	  10,   -8, 	   0,   -9
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	  11,   -8, 	 -10,  -16, 	  -2,   -9
+.2byte   -1,  -10, 	   9,  -16, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -10, 	  13,  -13, 	 -14,  -13, 	   0,   -9
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -8, 	 -10,  -15, 	   2,  -10
+.2byte   -4,   -6, 	   4,  -15, 	  -8,   -3, 	   0,   -7
+.2byte   -5,  -10, 	   3,  -14, 	 -10,   -8, 	   0,   -9
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -7,  -10, 	  -4,   -9, 	  -4,  -12, 	   1,  -10
+.2byte   -6,   -6, 	  -3,  -15, 	  -2,   -5, 	   1,   -6
+.2byte   -6,   -8, 	   0,  -12, 	   1,   -7, 	   0,   -8
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -4,   -8, 	 -13,   -7, 	   5,  -12, 	  -1,   -8
+.2byte   -3,   -8, 	 -11,  -14, 	   6,   -4, 	   1,   -7
+.2byte   -5,   -8, 	 -13,  -14, 	   7,   -8, 	  -2,   -8
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -1,   -3, 	 -10,    1, 	   9,    1, 	  -1,   -7
+.2byte   -1,   -7, 	 -13,  -12, 	  12,  -12, 	   0,   -8
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+.2byte    4,   -5, 	  13,   -4, 	   0,    1, 	   0,   -6
+.2byte    5,   -8, 	  13,  -14, 	  -7,   -8, 	   2,   -8
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    6,   -6, 	   8,   -7, 	   7,   -2, 	  -1,   -8
+.2byte    6,   -8, 	   0,  -12, 	  -1,   -7, 	   0,   -8
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    4,   -8, 	   0,  -12, 	  13,   -6, 	   0,   -9
+.2byte    5,  -10, 	  -3,  -14, 	  10,   -8, 	   0,   -9
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,   -9, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    0,  -10, 	  13,  -13, 	 -14,  -13, 	   0,   -9
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -4,   -8, 	   0,  -12, 	 -13,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   3,  -14, 	 -10,   -8, 	   0,   -9
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -6,   -6, 	  -8,   -7, 	  -7,   -2, 	   1,   -8
+.2byte   -6,   -8, 	   0,  -12, 	   1,   -7, 	   0,   -8
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -4,   -5, 	 -13,   -4, 	   0,    1, 	   0,   -6
+.2byte   -5,   -8, 	 -13,  -14, 	   7,   -8, 	  -2,   -8
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -1,   -8, 	 -13,   -6, 	  10,  -10, 	  -1,   -9
+.2byte    0,   -8, 	 -11,  -10, 	  12,   -6, 	   0,   -9
+.2byte   -1,   -3, 	 -10,    1, 	   9,    1, 	  -1,   -7
+.2byte   -1,   -7, 	 -13,  -12, 	  12,  -12, 	   0,   -8
+.2byte   -1,   -9, 	 -12,  -15, 	  12,  -15, 	   0,   -8
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+.2byte    4,   -8, 	  13,   -7, 	  -5,  -12, 	   1,   -8
+.2byte    3,   -8, 	  11,  -14, 	  -6,   -4, 	  -1,   -7
+.2byte    4,   -5, 	  13,   -4, 	   0,    1, 	   0,   -6
+.2byte    5,   -8, 	  13,  -14, 	  -7,   -8, 	   2,   -8
+.2byte    3,   -9, 	   9,  -15, 	  -7,  -13, 	   1,   -7
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    7,  -10, 	   4,   -9, 	   4,  -12, 	  -1,  -10
+.2byte    6,   -6, 	   3,  -15, 	   2,   -5, 	  -1,   -6
+.2byte    6,   -6, 	   8,   -7, 	   7,   -2, 	  -1,   -8
+.2byte    6,   -8, 	   0,  -12, 	  -1,   -7, 	   0,   -8
+.2byte    6,  -10, 	   0,  -16, 	   0,  -12, 	  -1,   -8
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    4,  -11, 	  -6,   -8, 	  10,  -15, 	  -2,  -10
+.2byte    4,   -6, 	  -4,  -15, 	   8,   -3, 	   0,   -7
+.2byte    4,   -8, 	   0,  -12, 	  13,   -6, 	   0,   -9
+.2byte    5,  -10, 	  -3,  -14, 	  10,   -8, 	   0,   -9
+.2byte    3,  -10, 	  -6,  -16, 	   8,  -13, 	  -2,   -8
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	  11,   -8, 	 -10,  -16, 	  -2,   -9
+.2byte   -1,  -10, 	   9,  -16, 	 -12,   -9, 	   0,   -9
+.2byte   -1,   -9, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    0,  -10, 	  13,  -13, 	 -14,  -13, 	   0,   -9
+.2byte   -1,  -11, 	  12,  -15, 	 -13,  -15, 	  -1,   -8
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -8, 	 -10,  -15, 	   2,  -10
+.2byte   -4,   -6, 	   4,  -15, 	  -8,   -3, 	   0,   -7
+.2byte   -4,   -8, 	   0,  -12, 	 -13,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   3,  -14, 	 -10,   -8, 	   0,   -9
+.2byte   -3,  -10, 	   6,  -16, 	  -8,  -13, 	   2,   -8
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -7,  -10, 	  -4,   -9, 	  -4,  -12, 	   1,  -10
+.2byte   -6,   -6, 	  -3,  -15, 	  -2,   -5, 	   1,   -6
+.2byte   -6,   -6, 	  -8,   -7, 	  -7,   -2, 	   1,   -8
+.2byte   -6,   -8, 	   0,  -12, 	   1,   -7, 	   0,   -8
+.2byte   -6,  -10, 	   0,  -16, 	   0,  -12, 	   1,   -8
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -4,   -8, 	 -13,   -7, 	   5,  -12, 	  -1,   -8
+.2byte   -3,   -8, 	 -11,  -14, 	   6,   -4, 	   1,   -7
+.2byte   -4,   -5, 	 -13,   -4, 	   0,    1, 	   0,   -6
+.2byte   -5,   -8, 	 -13,  -14, 	   7,   -8, 	  -2,   -8
+.2byte   -3,   -9, 	  -9,  -15, 	   7,  -13, 	  -1,   -7
+.2byte   -3,   -9, 	  -9,   -5, 	   9,   -2, 	   1,   -7
+.2byte   -2,   -7, 	  -7,   -8, 	   9,    1, 	   2,   -7
+.2byte    0,   -8, 	 -10,  -12, 	  10,  -12, 	   0,   -9
+.2byte    2,   -8, 	   8,  -15, 	  -6,  -11, 	  -1,   -8
+.2byte    5,   -9, 	   5,  -18, 	   0,   -8, 	  -2,   -7
+.2byte    4,  -12, 	  -5,  -16, 	   9,  -13, 	  -1,   -8
+.2byte    0,   -9, 	  11,  -17, 	 -11,  -17, 	   0,  -10
+.2byte   -5,  -12, 	   4,  -16, 	 -10,  -13, 	   0,   -8
+.2byte   -6,   -9, 	  -6,  -18, 	  -1,   -8, 	   1,   -7
+.2byte   -3,   -8, 	  -9,  -15, 	   5,  -11, 	   0,   -8
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	 -12,  -15, 	  12,  -15, 	   0,   -8
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+.2byte    3,   -9, 	   9,  -15, 	  -7,  -13, 	   1,   -7
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    6,  -10, 	   0,  -16, 	   0,  -12, 	  -1,   -8
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    3,  -10, 	  -6,  -16, 	   8,  -13, 	  -2,   -8
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -11, 	  12,  -15, 	 -13,  -15, 	  -1,   -8
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -3,  -10, 	   6,  -16, 	  -8,  -13, 	   2,   -8
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -6,  -10, 	   0,  -16, 	   0,  -12, 	   1,   -8
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -3,   -9, 	  -9,  -15, 	   7,  -13, 	  -1,   -7
+.2byte   -1,   -7, 	 -13,  -12, 	  12,  -12, 	   0,   -8
+.2byte   -4,   -8, 	 -12,  -14, 	   8,   -8, 	  -1,   -8
+.2byte   -7,   -8, 	  -1,  -12, 	   0,   -7, 	  -1,   -8
+.2byte   -5,  -10, 	   3,  -14, 	 -10,   -8, 	   0,   -9
+.2byte    0,  -10, 	  13,  -13, 	 -14,  -13, 	   0,   -9
+.2byte    5,  -10, 	  -3,  -14, 	  10,   -8, 	   0,   -9
+.2byte    7,   -8, 	   1,  -12, 	   0,   -7, 	   1,   -8
+.2byte    4,   -8, 	  12,  -14, 	  -8,   -8, 	   1,   -8
+.2byte   -1,   -9, 	 -12,  -15, 	  12,  -15, 	   0,   -8
+.2byte    3,   -9, 	   9,  -15, 	  -7,  -13, 	   1,   -7
+.2byte    6,  -10, 	   0,  -16, 	   0,  -12, 	  -1,   -8
+.2byte    3,  -10, 	  -6,  -16, 	   8,  -13, 	  -2,   -8
+.2byte   -1,  -11, 	  12,  -15, 	 -13,  -15, 	  -1,   -8
+.2byte   -3,  -10, 	   6,  -16, 	  -8,  -13, 	   2,   -8
+.2byte   -6,  -10, 	   0,  -16, 	   0,  -12, 	   1,   -8
+.2byte   -3,   -9, 	  -9,  -15, 	   7,  -13, 	  -1,   -7
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	 -12,  -15, 	  12,  -15, 	   0,   -8
+.2byte   -1,   -3, 	 -10,    1, 	   9,    1, 	  -1,   -7
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+.2byte    3,   -9, 	   9,  -15, 	  -7,  -13, 	   1,   -7
+.2byte    4,   -5, 	  13,   -4, 	   0,    1, 	   0,   -6
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    6,  -10, 	   0,  -16, 	   0,  -12, 	  -1,   -8
+.2byte    6,   -6, 	   8,   -7, 	   7,   -2, 	  -1,   -8
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    3,  -10, 	  -6,  -16, 	   8,  -13, 	  -2,   -8
+.2byte    4,   -8, 	   0,  -12, 	  13,   -6, 	   0,   -9
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -11, 	  12,  -15, 	 -13,  -15, 	  -1,   -8
+.2byte   -1,   -9, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -3,  -10, 	   6,  -16, 	  -8,  -13, 	   2,   -8
+.2byte   -4,   -8, 	   0,  -12, 	 -13,   -6, 	   0,   -9
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -6,  -10, 	   0,  -16, 	   0,  -12, 	   1,   -8
+.2byte   -6,   -6, 	  -8,   -7, 	  -7,   -2, 	   1,   -8
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -3,   -9, 	  -9,  -15, 	   7,  -13, 	  -1,   -7
+.2byte   -4,   -5, 	 -13,   -4, 	   0,    1, 	   0,   -6
+.2byte   -1,   -3, 	 -10,    1, 	   9,    1, 	  -1,   -7
+.2byte   -4,   -5, 	 -13,   -4, 	   0,    1, 	   0,   -6
+.2byte   -7,   -6, 	  -9,   -7, 	  -8,   -2, 	   0,   -8
+.2byte   -4,   -8, 	   0,  -12, 	 -13,   -6, 	   0,   -9
+.2byte   -1,   -9, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    4,   -8, 	   0,  -12, 	  13,   -6, 	   0,   -9
+.2byte    6,   -6, 	   8,   -7, 	   7,   -2, 	  -1,   -8
+.2byte    4,   -5, 	  13,   -4, 	   0,    1, 	   0,   -6
+.2byte    0,   -7, 	 -10,   -7, 	   9,   -7, 	  -1,   -7
+.2byte   -4,   -7, 	 -11,  -10, 	   3,   -6, 	   0,   -8
+.2byte   -6,   -8, 	  -4,  -11, 	  -4,   -7, 	   1,   -8
+.2byte   -6,   -8, 	   5,  -11, 	  -9,   -9, 	   1,   -8
+.2byte   -1,  -10, 	   9,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte    6,   -8, 	  -5,  -11, 	   9,   -9, 	  -1,   -8
+.2byte    6,   -8, 	   4,  -11, 	   4,   -7, 	  -1,   -8
+.2byte    4,   -7, 	  11,  -10, 	  -3,   -6, 	   0,   -8
+sLudicoloAnimTable1:
+.4byte sLudicoloAnims_1_1
+.4byte sLudicoloAnims_1_2
+.4byte sLudicoloAnims_1_3
+.4byte sLudicoloAnims_1_4
+.4byte sLudicoloAnims_1_5
+.4byte sLudicoloAnims_1_6
+.4byte sLudicoloAnims_1_7
+.4byte sLudicoloAnims_1_8
+sLudicoloAnimTable2:
+.4byte sLudicoloAnims_2_1
+.4byte sLudicoloAnims_2_2
+.4byte sLudicoloAnims_2_3
+.4byte sLudicoloAnims_2_4
+.4byte sLudicoloAnims_2_5
+.4byte sLudicoloAnims_2_6
+.4byte sLudicoloAnims_2_7
+.4byte sLudicoloAnims_2_8
+sLudicoloAnimTable3:
+.4byte sLudicoloAnims_3_1
+.4byte sLudicoloAnims_3_2
+.4byte sLudicoloAnims_3_3
+.4byte sLudicoloAnims_3_4
+.4byte sLudicoloAnims_3_5
+.4byte sLudicoloAnims_3_6
+.4byte sLudicoloAnims_3_7
+.4byte sLudicoloAnims_3_8
+sLudicoloAnimTable4:
+.4byte sLudicoloAnims_4_1
+.4byte sLudicoloAnims_4_2
+.4byte sLudicoloAnims_4_3
+.4byte sLudicoloAnims_4_4
+.4byte sLudicoloAnims_4_5
+.4byte sLudicoloAnims_4_6
+.4byte sLudicoloAnims_4_7
+.4byte sLudicoloAnims_4_8
+sLudicoloAnimTable5:
+.4byte sLudicoloAnims_5_1
+.4byte sLudicoloAnims_5_2
+.4byte sLudicoloAnims_5_3
+.4byte sLudicoloAnims_5_4
+.4byte sLudicoloAnims_5_5
+.4byte sLudicoloAnims_5_6
+.4byte sLudicoloAnims_5_7
+.4byte sLudicoloAnims_5_8
+sLudicoloAnimTable6:
+.4byte sLudicoloAnims_6_1
+.4byte sLudicoloAnims_6_1
+.4byte sLudicoloAnims_6_1
+.4byte sLudicoloAnims_6_1
+.4byte sLudicoloAnims_6_1
+.4byte sLudicoloAnims_6_1
+.4byte sLudicoloAnims_6_1
+.4byte sLudicoloAnims_6_1
+sLudicoloAnimTable7:
+.4byte sLudicoloAnims_7_1
+.4byte sLudicoloAnims_7_2
+.4byte sLudicoloAnims_7_3
+.4byte sLudicoloAnims_7_4
+.4byte sLudicoloAnims_7_5
+.4byte sLudicoloAnims_7_6
+.4byte sLudicoloAnims_7_7
+.4byte sLudicoloAnims_7_8
+sLudicoloAnimTable8:
+.4byte sLudicoloAnims_8_1
+.4byte sLudicoloAnims_8_2
+.4byte sLudicoloAnims_8_3
+.4byte sLudicoloAnims_8_4
+.4byte sLudicoloAnims_8_5
+.4byte sLudicoloAnims_8_6
+.4byte sLudicoloAnims_8_7
+.4byte sLudicoloAnims_8_8
+sLudicoloAnimTable9:
+.4byte sLudicoloAnims_9_1
+.4byte sLudicoloAnims_9_2
+.4byte sLudicoloAnims_9_3
+.4byte sLudicoloAnims_9_4
+.4byte sLudicoloAnims_9_5
+.4byte sLudicoloAnims_9_6
+.4byte sLudicoloAnims_9_7
+.4byte sLudicoloAnims_9_8
+sLudicoloAnimTable10:
+.4byte sLudicoloAnims_10_1
+.4byte sLudicoloAnims_10_2
+.4byte sLudicoloAnims_10_3
+.4byte sLudicoloAnims_10_4
+.4byte sLudicoloAnims_10_5
+.4byte sLudicoloAnims_10_6
+.4byte sLudicoloAnims_10_7
+.4byte sLudicoloAnims_10_8
+sLudicoloAnimTable11:
+.4byte sLudicoloAnims_11_1
+.4byte sLudicoloAnims_11_2
+.4byte sLudicoloAnims_11_3
+.4byte sLudicoloAnims_11_4
+.4byte sLudicoloAnims_11_5
+.4byte sLudicoloAnims_11_6
+.4byte sLudicoloAnims_11_7
+.4byte sLudicoloAnims_11_8
+sLudicoloAnimTable12:
+.4byte sLudicoloAnims_12_1
+.4byte sLudicoloAnims_12_2
+.4byte sLudicoloAnims_12_3
+.4byte sLudicoloAnims_12_4
+.4byte sLudicoloAnims_12_5
+.4byte sLudicoloAnims_12_6
+.4byte sLudicoloAnims_12_7
+.4byte sLudicoloAnims_12_8
+sLudicoloAnimTable13:
+.4byte sLudicoloAnims_13_1
+.4byte sLudicoloAnims_13_2
+.4byte sLudicoloAnims_13_3
+.4byte sLudicoloAnims_13_4
+.4byte sLudicoloAnims_13_5
+.4byte sLudicoloAnims_13_6
+.4byte sLudicoloAnims_13_7
+.4byte sLudicoloAnims_13_8
+sAxAnimationsLudicolo:
+.4byte sLudicoloAnimTable1
+.4byte sLudicoloAnimTable2
+.4byte sLudicoloAnimTable3
+.4byte sLudicoloAnimTable4
+.4byte sLudicoloAnimTable5
+.4byte sLudicoloAnimTable6
+.4byte sLudicoloAnimTable7
+.4byte sLudicoloAnimTable8
+.4byte sLudicoloAnimTable9
+.4byte sLudicoloAnimTable10
+.4byte sLudicoloAnimTable11
+.4byte sLudicoloAnimTable12
+.4byte sLudicoloAnimTable13
+sAxSpritesLudicolo:
+.4byte sLudicoloSprites1
+.4byte sLudicoloSprites2
+.4byte sLudicoloSprites3
+.4byte sLudicoloSprites4
+.4byte sLudicoloSprites5
+.4byte sLudicoloSprites6
+.4byte sLudicoloSprites7
+.4byte sLudicoloSprites8
+.4byte sLudicoloSprites9
+.4byte sLudicoloSprites10
+.4byte sLudicoloSprites11
+.4byte sLudicoloSprites12
+.4byte sLudicoloSprites13
+.4byte sLudicoloSprites14
+.4byte sLudicoloSprites15
+.4byte sLudicoloSprites16
+.4byte sLudicoloSprites17
+.4byte sLudicoloSprites18
+.4byte sLudicoloSprites19
+.4byte sLudicoloSprites20
+.4byte sLudicoloSprites21
+.4byte sLudicoloSprites22
+.4byte sLudicoloSprites23
+.4byte sLudicoloSprites24
+.4byte sLudicoloSprites25
+.4byte sLudicoloSprites26
+.4byte sLudicoloSprites27
+.4byte sLudicoloSprites28
+.4byte sLudicoloSprites29
+.4byte sLudicoloSprites30
+.4byte sLudicoloSprites31
+.4byte sLudicoloSprites32
+.4byte sLudicoloSprites33
+.4byte sLudicoloSprites34
+.4byte sLudicoloSprites35
+.4byte sLudicoloSprites36
+.4byte sLudicoloSprites37
+sAxMainLudicolo:
+ax_main sAxPosesLudicolo, sAxAnimationsLudicolo, 13, sAxSpritesLudicolo, sAxPositionsLudicolo

--- a/data/ax/lugia.inc
+++ b/data/ax/lugia.inc
@@ -1,0 +1,4545 @@
+.global gAxLugia
+gAxLugia:
+ax_siro sAxMainLugia
+sLugiaPose1:
+ax_pose 0, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 1, 0x41f5, 0x80f0, 0x9c20
+ax_pose 2, 0x01db, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose2:
+ax_pose 3, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 4, 0x41f5, 0x80f0, 0x9c20
+ax_pose 5, 0x01dd, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose3:
+ax_pose 6, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose4:
+ax_pose 8, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose5:
+ax_pose 10, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x1100, 0x9c20
+ax_pose 12, 0x41f1, 0x90e0, 0x9c22
+ax_pose 13, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose6:
+ax_pose 14, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x1100, 0x9c20
+ax_pose 16, 0x41f1, 0x90e0, 0x9c22
+ax_pose 17, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose7:
+ax_pose 18, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 19, 0x01ef, 0x90e8, 0x9c20
+ax_pose 20, 0x41ef, 0x9108, 0x9c30
+ax_pose 21, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose8:
+ax_pose 22, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 23, 0x01ef, 0x90e8, 0x9c20
+ax_pose 24, 0x41ef, 0x9108, 0x9c30
+ax_pose 25, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose9:
+ax_pose 26, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 27, 0x01ed, 0x80f0, 0x9c20
+ax_pose 28, 0x01fd, 0x00e8, 0x9c30
+ax_pose 29, 0x01d5, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose10:
+ax_pose 30, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 31, 0x01ed, 0x80f0, 0x9c20
+ax_pose 32, 0x01fd, 0x00e8, 0x9c30
+ax_pose 33, 0x01d6, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose11:
+ax_pose 18, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 19, 0x01ef, 0x80f8, 0x9c20
+ax_pose 20, 0x41ef, 0x80d8, 0x9c30
+ax_pose 21, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose12:
+ax_pose 22, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 23, 0x01ef, 0x80f8, 0x9c20
+ax_pose 24, 0x41ef, 0x80d8, 0x9c30
+ax_pose 25, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose13:
+ax_pose 10, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x00f0, 0x9c20
+ax_pose 12, 0x41f1, 0x8100, 0x9c22
+ax_pose 13, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose14:
+ax_pose 14, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x00f0, 0x9c20
+ax_pose 16, 0x41f1, 0x8100, 0x9c22
+ax_pose 17, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose15:
+ax_pose 6, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose16:
+ax_pose 8, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose17:
+ax_pose 0, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 1, 0x41f5, 0x80f0, 0x9c20
+ax_pose 2, 0x01db, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose18:
+ax_pose 3, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 4, 0x41f5, 0x80f0, 0x9c20
+ax_pose 5, 0x01dd, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose19:
+ax_pose 34, 0x41d1, 0xc0d8, 0x9c00
+ax_pose 35, 0x41f1, 0x80f0, 0x9c20
+ax_pose 36, 0x01d1, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose20:
+ax_pose 37, 0x41d4, 0xc0db, 0x9c00
+ax_pose 38, 0x41f4, 0x80db, 0x9c20
+ax_pose 39, 0x41f4, 0x80fb, 0x9c28
+ax_pose_terminator
+sLugiaPose21:
+ax_pose 6, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose22:
+ax_pose 8, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose23:
+ax_pose 40, 0x41d3, 0xd0e0, 0x9c00
+ax_pose 41, 0x41f3, 0x90f0, 0x9c20
+ax_pose_terminator
+sLugiaPose24:
+ax_pose 42, 0x41d4, 0xd0e0, 0x9c00
+ax_pose 43, 0x41f4, 0x9100, 0x9c20
+ax_pose 44, 0x41f4, 0x90e0, 0x9c28
+ax_pose_terminator
+sLugiaPose25:
+ax_pose 10, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x1100, 0x9c20
+ax_pose 12, 0x41f1, 0x90e0, 0x9c22
+ax_pose 13, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose26:
+ax_pose 14, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x1100, 0x9c20
+ax_pose 16, 0x41f1, 0x90e0, 0x9c22
+ax_pose 17, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose27:
+ax_pose 45, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 46, 0x41f1, 0x1100, 0x9c20
+ax_pose 47, 0x41f1, 0x90e0, 0x9c22
+ax_pose 48, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose28:
+ax_pose 49, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 50, 0x81f1, 0x1110, 0x9c20
+ax_pose 51, 0x81f1, 0x9100, 0x9c22
+ax_pose 52, 0x41f1, 0x90e0, 0x9c2a
+ax_pose 53, 0x0201, 0x10f8, 0x9c32
+ax_pose 54, 0x81e9, 0x10d8, 0x9c33
+ax_pose_terminator
+sLugiaPose29:
+ax_pose 18, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 19, 0x01ef, 0x90e8, 0x9c20
+ax_pose 20, 0x41ef, 0x9108, 0x9c30
+ax_pose 21, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose30:
+ax_pose 22, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 23, 0x01ef, 0x90e8, 0x9c20
+ax_pose 24, 0x41ef, 0x9108, 0x9c30
+ax_pose 25, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose31:
+ax_pose 55, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 56, 0x81ef, 0x1108, 0x9c20
+ax_pose 57, 0x01ef, 0x90e8, 0x9c22
+ax_pose 58, 0x81ef, 0x10e0, 0x9c32
+ax_pose_terminator
+sLugiaPose32:
+ax_pose 59, 0x01cf, 0xd0e6, 0x9c00
+ax_pose_terminator
+sLugiaPose33:
+ax_pose 26, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 27, 0x01ed, 0x80f0, 0x9c20
+ax_pose 28, 0x01fd, 0x00e8, 0x9c30
+ax_pose 29, 0x01d5, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose34:
+ax_pose 30, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 31, 0x01ed, 0x80f0, 0x9c20
+ax_pose 32, 0x01fd, 0x00e8, 0x9c30
+ax_pose 33, 0x01d6, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose35:
+ax_pose 60, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 61, 0x81ef, 0x80e8, 0x9c20
+ax_pose 62, 0x01ef, 0x80f8, 0x9c28
+ax_pose 63, 0x81d0, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose36:
+ax_pose 64, 0x41ce, 0xc0d9, 0x9c00
+ax_pose 65, 0x81ee, 0x00e1, 0x9c20
+ax_pose 66, 0x81ee, 0x80e9, 0x9c22
+ax_pose 67, 0x01ee, 0x80f9, 0x9c2a
+ax_pose 68, 0x01c6, 0x00fb, 0x9c3a
+ax_pose_terminator
+sLugiaPose37:
+ax_pose 18, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 19, 0x01ef, 0x80f8, 0x9c20
+ax_pose 20, 0x41ef, 0x80d8, 0x9c30
+ax_pose 21, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose38:
+ax_pose 22, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 23, 0x01ef, 0x80f8, 0x9c20
+ax_pose 24, 0x41ef, 0x80d8, 0x9c30
+ax_pose 25, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose39:
+ax_pose 55, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 56, 0x81ef, 0x00f0, 0x9c20
+ax_pose 57, 0x01ef, 0x80f8, 0x9c22
+ax_pose 58, 0x81ef, 0x0118, 0x9c32
+ax_pose_terminator
+sLugiaPose40:
+ax_pose 59, 0x01cf, 0xc0da, 0x9c00
+ax_pose_terminator
+sLugiaPose41:
+ax_pose 10, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x00f0, 0x9c20
+ax_pose 12, 0x41f1, 0x8100, 0x9c22
+ax_pose 13, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose42:
+ax_pose 14, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x00f0, 0x9c20
+ax_pose 16, 0x41f1, 0x8100, 0x9c22
+ax_pose 17, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose43:
+ax_pose 45, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 46, 0x41f1, 0x00f0, 0x9c20
+ax_pose 47, 0x41f1, 0x8100, 0x9c22
+ax_pose 48, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose44:
+ax_pose 49, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 50, 0x81f1, 0x00e8, 0x9c20
+ax_pose 51, 0x81f1, 0x80f0, 0x9c22
+ax_pose 52, 0x41f1, 0x8100, 0x9c2a
+ax_pose 53, 0x0201, 0x0100, 0x9c32
+ax_pose 54, 0x81e9, 0x0120, 0x9c33
+ax_pose_terminator
+sLugiaPose45:
+ax_pose 6, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose46:
+ax_pose 8, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose47:
+ax_pose 40, 0x41d3, 0xc0e0, 0x9c00
+ax_pose 41, 0x41f3, 0x80f0, 0x9c20
+ax_pose_terminator
+sLugiaPose48:
+ax_pose 42, 0x41d4, 0xc0e0, 0x9c00
+ax_pose 43, 0x41f4, 0x80e0, 0x9c20
+ax_pose 44, 0x41f4, 0x8100, 0x9c28
+ax_pose_terminator
+sLugiaPose49:
+ax_pose 0, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 1, 0x41f5, 0x80f0, 0x9c20
+ax_pose 2, 0x01db, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose50:
+ax_pose 3, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 4, 0x41f5, 0x80f0, 0x9c20
+ax_pose 5, 0x01dd, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose51:
+ax_pose 34, 0x41d1, 0xc0d8, 0x9c00
+ax_pose 35, 0x41f1, 0x80f0, 0x9c20
+ax_pose 36, 0x01d1, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose52:
+ax_pose 37, 0x41d4, 0xc0db, 0x9c00
+ax_pose 38, 0x41f4, 0x80db, 0x9c20
+ax_pose 39, 0x41f4, 0x80fb, 0x9c28
+ax_pose_terminator
+sLugiaPose53:
+ax_pose 6, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose54:
+ax_pose 8, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose55:
+ax_pose 40, 0x41d3, 0xd0e0, 0x9c00
+ax_pose 41, 0x41f3, 0x90f0, 0x9c20
+ax_pose_terminator
+sLugiaPose56:
+ax_pose 42, 0x41d4, 0xd0e0, 0x9c00
+ax_pose 43, 0x41f4, 0x9100, 0x9c20
+ax_pose 44, 0x41f4, 0x90e0, 0x9c28
+ax_pose_terminator
+sLugiaPose57:
+ax_pose 10, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x1100, 0x9c20
+ax_pose 12, 0x41f1, 0x90e0, 0x9c22
+ax_pose 13, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose58:
+ax_pose 14, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x1100, 0x9c20
+ax_pose 16, 0x41f1, 0x90e0, 0x9c22
+ax_pose 17, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose59:
+ax_pose 45, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 46, 0x41f1, 0x1100, 0x9c20
+ax_pose 47, 0x41f1, 0x90e0, 0x9c22
+ax_pose 48, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose60:
+ax_pose 49, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 50, 0x81f1, 0x1110, 0x9c20
+ax_pose 51, 0x81f1, 0x9100, 0x9c22
+ax_pose 52, 0x41f1, 0x90e0, 0x9c2a
+ax_pose 53, 0x0201, 0x10f8, 0x9c32
+ax_pose 54, 0x81e9, 0x10d8, 0x9c33
+ax_pose_terminator
+sLugiaPose61:
+ax_pose 18, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 19, 0x01ef, 0x90e8, 0x9c20
+ax_pose 20, 0x41ef, 0x9108, 0x9c30
+ax_pose 21, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose62:
+ax_pose 22, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 23, 0x01ef, 0x90e8, 0x9c20
+ax_pose 24, 0x41ef, 0x9108, 0x9c30
+ax_pose 25, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose63:
+ax_pose 55, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 56, 0x81ef, 0x1108, 0x9c20
+ax_pose 57, 0x01ef, 0x90e8, 0x9c22
+ax_pose 58, 0x81ef, 0x10e0, 0x9c32
+ax_pose_terminator
+sLugiaPose64:
+ax_pose 59, 0x01cf, 0xd0e6, 0x9c00
+ax_pose_terminator
+sLugiaPose65:
+ax_pose 26, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 27, 0x01ed, 0x80f0, 0x9c20
+ax_pose 28, 0x01fd, 0x00e8, 0x9c30
+ax_pose 29, 0x01d5, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose66:
+ax_pose 30, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 31, 0x01ed, 0x80f0, 0x9c20
+ax_pose 32, 0x01fd, 0x00e8, 0x9c30
+ax_pose 33, 0x01d6, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose67:
+ax_pose 60, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 61, 0x81ef, 0x80e8, 0x9c20
+ax_pose 62, 0x01ef, 0x80f8, 0x9c28
+ax_pose 63, 0x81d0, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose68:
+ax_pose 64, 0x41ce, 0xc0d9, 0x9c00
+ax_pose 65, 0x81ee, 0x00e1, 0x9c20
+ax_pose 66, 0x81ee, 0x80e9, 0x9c22
+ax_pose 67, 0x01ee, 0x80f9, 0x9c2a
+ax_pose 68, 0x01c6, 0x00fb, 0x9c3a
+ax_pose_terminator
+sLugiaPose69:
+ax_pose 18, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 19, 0x01ef, 0x80f8, 0x9c20
+ax_pose 20, 0x41ef, 0x80d8, 0x9c30
+ax_pose 21, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose70:
+ax_pose 22, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 23, 0x01ef, 0x80f8, 0x9c20
+ax_pose 24, 0x41ef, 0x80d8, 0x9c30
+ax_pose 25, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose71:
+ax_pose 55, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 56, 0x81ef, 0x00f0, 0x9c20
+ax_pose 57, 0x01ef, 0x80f8, 0x9c22
+ax_pose 58, 0x81ef, 0x0118, 0x9c32
+ax_pose_terminator
+sLugiaPose72:
+ax_pose 59, 0x01cf, 0xc0da, 0x9c00
+ax_pose_terminator
+sLugiaPose73:
+ax_pose 10, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x00f0, 0x9c20
+ax_pose 12, 0x41f1, 0x8100, 0x9c22
+ax_pose 13, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose74:
+ax_pose 14, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x00f0, 0x9c20
+ax_pose 16, 0x41f1, 0x8100, 0x9c22
+ax_pose 17, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose75:
+ax_pose 45, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 46, 0x41f1, 0x00f0, 0x9c20
+ax_pose 47, 0x41f1, 0x8100, 0x9c22
+ax_pose 48, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose76:
+ax_pose 49, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 50, 0x81f1, 0x00e8, 0x9c20
+ax_pose 51, 0x81f1, 0x80f0, 0x9c22
+ax_pose 52, 0x41f1, 0x8100, 0x9c2a
+ax_pose 53, 0x0201, 0x0100, 0x9c32
+ax_pose 54, 0x81e9, 0x0120, 0x9c33
+ax_pose_terminator
+sLugiaPose77:
+ax_pose 6, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose78:
+ax_pose 8, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose79:
+ax_pose 40, 0x41d3, 0xc0e0, 0x9c00
+ax_pose 41, 0x41f3, 0x80f0, 0x9c20
+ax_pose_terminator
+sLugiaPose80:
+ax_pose 42, 0x41d4, 0xc0e0, 0x9c00
+ax_pose 43, 0x41f4, 0x80e0, 0x9c20
+ax_pose 44, 0x41f4, 0x8100, 0x9c28
+ax_pose_terminator
+sLugiaPose81:
+ax_pose 0, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 1, 0x41f5, 0x80f0, 0x9c20
+ax_pose 2, 0x01db, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose82:
+ax_pose 3, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 4, 0x41f5, 0x80f0, 0x9c20
+ax_pose 5, 0x01dd, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose83:
+ax_pose 69, 0x01d0, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose84:
+ax_pose 70, 0x41d0, 0xc0dd, 0x9c00
+ax_pose 71, 0x41f0, 0x80fd, 0x9c20
+ax_pose 72, 0x01f0, 0x40ed, 0x9c28
+ax_pose 73, 0x81d8, 0x011d, 0x9c2c
+ax_pose_terminator
+sLugiaPose85:
+ax_pose 6, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose86:
+ax_pose 8, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose87:
+ax_pose 74, 0x01c7, 0xd0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose88:
+ax_pose 75, 0x01c9, 0xd0e3, 0x9c00
+ax_pose_terminator
+sLugiaPose89:
+ax_pose 10, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x1100, 0x9c20
+ax_pose 12, 0x41f1, 0x90e0, 0x9c22
+ax_pose 13, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose90:
+ax_pose 14, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x1100, 0x9c20
+ax_pose 16, 0x41f1, 0x90e0, 0x9c22
+ax_pose 17, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose91:
+ax_pose 76, 0x01c7, 0xd0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose92:
+ax_pose 77, 0x41cc, 0xd0e0, 0x9c00
+ax_pose 78, 0x01ec, 0x90e0, 0x9c20
+ax_pose 79, 0x81ec, 0x9100, 0x9c30
+ax_pose 80, 0x81dd, 0x10d8, 0x9c38
+ax_pose_terminator
+sLugiaPose93:
+ax_pose 18, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 19, 0x01ef, 0x90e8, 0x9c20
+ax_pose 20, 0x41ef, 0x9108, 0x9c30
+ax_pose 21, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose94:
+ax_pose 22, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 23, 0x01ef, 0x90e8, 0x9c20
+ax_pose 24, 0x41ef, 0x9108, 0x9c30
+ax_pose 25, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose95:
+ax_pose 81, 0x01c8, 0xd0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose96:
+ax_pose 82, 0x41cb, 0xd0e8, 0x9c00
+ax_pose 83, 0x41eb, 0x1118, 0x9c20
+ax_pose 84, 0x81eb, 0x9108, 0x9c22
+ax_pose 85, 0x41eb, 0x90e8, 0x9c2a
+ax_pose 86, 0x81eb, 0x10e0, 0x9c32
+ax_pose_terminator
+sLugiaPose97:
+ax_pose 26, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 27, 0x01ed, 0x80f0, 0x9c20
+ax_pose 28, 0x01fd, 0x00e8, 0x9c30
+ax_pose 29, 0x01d5, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose98:
+ax_pose 30, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 31, 0x01ed, 0x80f0, 0x9c20
+ax_pose 32, 0x01fd, 0x00e8, 0x9c30
+ax_pose 33, 0x01d6, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose99:
+ax_pose 87, 0x01ce, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose100:
+ax_pose 88, 0x41cd, 0xc0dd, 0x9c00
+ax_pose 89, 0x81ed, 0x80ed, 0x9c20
+ax_pose 90, 0x81ed, 0x80fd, 0x9c28
+ax_pose 91, 0x01ed, 0x010d, 0x9c30
+ax_pose 92, 0x81d0, 0x011d, 0x9c31
+ax_pose_terminator
+sLugiaPose101:
+ax_pose 18, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 19, 0x01ef, 0x80f8, 0x9c20
+ax_pose 20, 0x41ef, 0x80d8, 0x9c30
+ax_pose 21, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose102:
+ax_pose 22, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 23, 0x01ef, 0x80f8, 0x9c20
+ax_pose 24, 0x41ef, 0x80d8, 0x9c30
+ax_pose 25, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose103:
+ax_pose 81, 0x01c8, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose104:
+ax_pose 82, 0x41cb, 0xc0d8, 0x9c00
+ax_pose 83, 0x41eb, 0x00d8, 0x9c20
+ax_pose 84, 0x81eb, 0x80e8, 0x9c22
+ax_pose 85, 0x41eb, 0x80f8, 0x9c2a
+ax_pose 86, 0x81eb, 0x0118, 0x9c32
+ax_pose_terminator
+sLugiaPose105:
+ax_pose 10, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x00f0, 0x9c20
+ax_pose 12, 0x41f1, 0x8100, 0x9c22
+ax_pose 13, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose106:
+ax_pose 14, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 15, 0x41f1, 0x00f0, 0x9c20
+ax_pose 16, 0x41f1, 0x8100, 0x9c22
+ax_pose 17, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose107:
+ax_pose 76, 0x01c7, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose108:
+ax_pose 77, 0x41cc, 0xc0e0, 0x9c00
+ax_pose 78, 0x01ec, 0x8100, 0x9c20
+ax_pose 79, 0x81ec, 0x80f0, 0x9c30
+ax_pose 80, 0x81dd, 0x0120, 0x9c38
+ax_pose_terminator
+sLugiaPose109:
+ax_pose 6, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose110:
+ax_pose 8, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 9, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose111:
+ax_pose 74, 0x01c7, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose112:
+ax_pose 75, 0x01c9, 0xc0dd, 0x9c00
+ax_pose_terminator
+sLugiaPose113:
+ax_pose 0, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 1, 0x41f5, 0x80f0, 0x9c20
+ax_pose 2, 0x01db, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose114:
+ax_pose 34, 0x41d3, 0xc0d8, 0x9c00
+ax_pose 35, 0x41f3, 0x80f0, 0x9c20
+ax_pose 36, 0x01d3, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose115:
+ax_pose 37, 0x41d3, 0xc0db, 0x9c00
+ax_pose 38, 0x41f3, 0x80db, 0x9c20
+ax_pose 39, 0x41f3, 0x80fb, 0x9c28
+ax_pose_terminator
+sLugiaPose116:
+ax_pose 6, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose117:
+ax_pose 40, 0x41d3, 0xd0e0, 0x9c00
+ax_pose 41, 0x41f3, 0x90f0, 0x9c20
+ax_pose_terminator
+sLugiaPose118:
+ax_pose 42, 0x41d4, 0xd0e0, 0x9c00
+ax_pose 43, 0x41f4, 0x9100, 0x9c20
+ax_pose 44, 0x41f4, 0x90e0, 0x9c28
+ax_pose_terminator
+sLugiaPose119:
+ax_pose 10, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x1100, 0x9c20
+ax_pose 12, 0x41f1, 0x90e0, 0x9c22
+ax_pose 13, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose120:
+ax_pose 45, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 46, 0x41f1, 0x1100, 0x9c20
+ax_pose 47, 0x41f1, 0x90e0, 0x9c22
+ax_pose 48, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose121:
+ax_pose 49, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 50, 0x81f1, 0x1110, 0x9c20
+ax_pose 51, 0x81f1, 0x9100, 0x9c22
+ax_pose 52, 0x41f1, 0x90e0, 0x9c2a
+ax_pose 53, 0x0201, 0x10f8, 0x9c32
+ax_pose 54, 0x81e9, 0x10d8, 0x9c33
+ax_pose_terminator
+sLugiaPose122:
+ax_pose 18, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 19, 0x01ef, 0x90e8, 0x9c20
+ax_pose 20, 0x41ef, 0x9108, 0x9c30
+ax_pose 21, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose123:
+ax_pose 55, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 56, 0x81ef, 0x1108, 0x9c20
+ax_pose 57, 0x01ef, 0x90e8, 0x9c22
+ax_pose 58, 0x81ef, 0x10e0, 0x9c32
+ax_pose_terminator
+sLugiaPose124:
+ax_pose 59, 0x01cf, 0xd0e6, 0x9c00
+ax_pose_terminator
+sLugiaPose125:
+ax_pose 26, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 27, 0x01ed, 0x80f0, 0x9c20
+ax_pose 28, 0x01fd, 0x00e8, 0x9c30
+ax_pose 29, 0x01d5, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose126:
+ax_pose 60, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 61, 0x81ef, 0x80e8, 0x9c20
+ax_pose 62, 0x01ef, 0x80f8, 0x9c28
+ax_pose 63, 0x81d0, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose127:
+ax_pose 64, 0x41ce, 0xc0d9, 0x9c00
+ax_pose 65, 0x81ee, 0x00e1, 0x9c20
+ax_pose 66, 0x81ee, 0x80e9, 0x9c22
+ax_pose 67, 0x01ee, 0x80f9, 0x9c2a
+ax_pose 68, 0x01c6, 0x00fb, 0x9c3a
+ax_pose_terminator
+sLugiaPose128:
+ax_pose 18, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 19, 0x01ef, 0x80f8, 0x9c20
+ax_pose 20, 0x41ef, 0x80d8, 0x9c30
+ax_pose 21, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose129:
+ax_pose 55, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 56, 0x81ef, 0x00f0, 0x9c20
+ax_pose 57, 0x01ef, 0x80f8, 0x9c22
+ax_pose 58, 0x81ef, 0x0118, 0x9c32
+ax_pose_terminator
+sLugiaPose130:
+ax_pose 59, 0x01cf, 0xc0da, 0x9c00
+ax_pose_terminator
+sLugiaPose131:
+ax_pose 10, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x00f0, 0x9c20
+ax_pose 12, 0x41f1, 0x8100, 0x9c22
+ax_pose 13, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose132:
+ax_pose 45, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 46, 0x41f1, 0x00f0, 0x9c20
+ax_pose 47, 0x41f1, 0x8100, 0x9c22
+ax_pose 48, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose133:
+ax_pose 49, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 50, 0x81f1, 0x00e8, 0x9c20
+ax_pose 51, 0x81f1, 0x80f0, 0x9c22
+ax_pose 52, 0x41f1, 0x8100, 0x9c2a
+ax_pose 53, 0x0201, 0x0100, 0x9c32
+ax_pose 54, 0x81e9, 0x0120, 0x9c33
+ax_pose_terminator
+sLugiaPose134:
+ax_pose 6, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose135:
+ax_pose 40, 0x41d3, 0xc0e0, 0x9c00
+ax_pose 41, 0x41f3, 0x80f0, 0x9c20
+ax_pose_terminator
+sLugiaPose136:
+ax_pose 42, 0x41d4, 0xc0e0, 0x9c00
+ax_pose 43, 0x41f4, 0x80e0, 0x9c20
+ax_pose 44, 0x41f4, 0x8100, 0x9c28
+ax_pose_terminator
+sLugiaPose137:
+ax_pose 93, 0x01d4, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose138:
+ax_pose 94, 0x01d4, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose139:
+ax_pose 95, 0x81f1, 0x010d, 0x9c00
+ax_pose 96, 0x81d6, 0x011d, 0x9c02
+ax_pose 97, 0x01ec, 0x80ed, 0x9c04
+ax_pose 98, 0x41cc, 0xc0dd, 0x9c14
+ax_pose_terminator
+sLugiaPose140:
+ax_pose 99, 0x81c7, 0xd0fc, 0x9c00
+ax_pose 100, 0x01f2, 0x1115, 0x9c20
+ax_pose 101, 0x01f7, 0x50ec, 0x9c21
+ax_pose 102, 0x41e7, 0x90dc, 0x9c25
+ax_pose 103, 0x01c7, 0x90dc, 0x9c2d
+ax_pose_terminator
+sLugiaPose141:
+ax_pose 104, 0x01cb, 0xd0d9, 0x9c00
+ax_pose_terminator
+sLugiaPose142:
+ax_pose 105, 0x01cd, 0xd0df, 0x9c00
+ax_pose_terminator
+sLugiaPose143:
+ax_pose 106, 0x41cf, 0xc0e0, 0x9c00
+ax_pose 107, 0x01d3, 0x00d8, 0x9c20
+ax_pose 108, 0x01ef, 0x80f0, 0x9c21
+ax_pose_terminator
+sLugiaPose144:
+ax_pose 105, 0x01cd, 0xc0e1, 0x9c00
+ax_pose_terminator
+sLugiaPose145:
+ax_pose 104, 0x01cb, 0xc0e7, 0x9c00
+ax_pose_terminator
+sLugiaPose146:
+ax_pose 99, 0x81c7, 0xc0e4, 0x9c00
+ax_pose 100, 0x01f2, 0x00e3, 0x9c20
+ax_pose 101, 0x01f7, 0x4104, 0x9c21
+ax_pose 102, 0x41e7, 0x8104, 0x9c25
+ax_pose 103, 0x01c7, 0x8104, 0x9c2d
+ax_pose_terminator
+sLugiaPose147:
+ax_pose 109, 0x01cb, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose148:
+ax_pose 110, 0x01cb, 0xc0e1, 0x9c00
+ax_pose_terminator
+sLugiaPose149:
+ax_pose 111, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose150:
+ax_pose 112, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose151:
+ax_pose 113, 0x01cc, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose152:
+ax_pose 112, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose153:
+ax_pose 111, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose154:
+ax_pose 110, 0x01cb, 0xd0df, 0x9c00
+ax_pose_terminator
+sLugiaPose155:
+ax_pose 114, 0x01cc, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose156:
+ax_pose 115, 0x01cc, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose157:
+ax_pose 116, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose158:
+ax_pose 117, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose159:
+ax_pose 118, 0x01cc, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose160:
+ax_pose 117, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose161:
+ax_pose 116, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose162:
+ax_pose 115, 0x01cb, 0xd0df, 0x9c00
+ax_pose_terminator
+sLugiaPose163:
+ax_pose 70, 0x41d0, 0xc0dd, 0x9c00
+ax_pose 71, 0x41f0, 0x80fd, 0x9c20
+ax_pose 72, 0x01f0, 0x40ed, 0x9c28
+ax_pose 73, 0x81d8, 0x011d, 0x9c2c
+ax_pose_terminator
+sLugiaPose164:
+ax_pose 75, 0x01c9, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose165:
+ax_pose 77, 0x41cc, 0xc0e2, 0x9c00
+ax_pose 78, 0x01ec, 0x8102, 0x9c20
+ax_pose 79, 0x81ec, 0x80f2, 0x9c30
+ax_pose 80, 0x81dd, 0x0122, 0x9c38
+ax_pose_terminator
+sLugiaPose166:
+ax_pose 82, 0x41cf, 0xc0dc, 0x9c00
+ax_pose 83, 0x41ef, 0x00dc, 0x9c20
+ax_pose 84, 0x81ef, 0x80ec, 0x9c22
+ax_pose 85, 0x41ef, 0x80fc, 0x9c2a
+ax_pose 86, 0x81ef, 0x011c, 0x9c32
+ax_pose_terminator
+sLugiaPose167:
+ax_pose 88, 0x41d5, 0xc0dd, 0x9c00
+ax_pose 89, 0x81f5, 0x80ed, 0x9c20
+ax_pose 90, 0x81f5, 0x80fd, 0x9c28
+ax_pose 91, 0x01f5, 0x010d, 0x9c30
+ax_pose 92, 0x81d8, 0x011d, 0x9c31
+ax_pose_terminator
+sLugiaPose168:
+ax_pose 82, 0x41cf, 0xd0e4, 0x9c00
+ax_pose 83, 0x41ef, 0x1114, 0x9c20
+ax_pose 84, 0x81ef, 0x9104, 0x9c22
+ax_pose 85, 0x41ef, 0x90e4, 0x9c2a
+ax_pose 86, 0x81ef, 0x10dc, 0x9c32
+ax_pose_terminator
+sLugiaPose169:
+ax_pose 77, 0x41cc, 0xd0de, 0x9c00
+ax_pose 78, 0x01ec, 0x90de, 0x9c20
+ax_pose 79, 0x81ec, 0x90fe, 0x9c30
+ax_pose 80, 0x81dd, 0x10d6, 0x9c38
+ax_pose_terminator
+sLugiaPose170:
+ax_pose 75, 0x01c9, 0xd0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose171:
+ax_pose 70, 0x41d0, 0xc0dd, 0x9c00
+ax_pose 71, 0x41f0, 0x80fd, 0x9c20
+ax_pose 72, 0x01f0, 0x40ed, 0x9c28
+ax_pose 73, 0x81d8, 0x011d, 0x9c2c
+ax_pose_terminator
+sLugiaPose172:
+ax_pose 70, 0x41d0, 0xc0dd, 0x9c00
+ax_pose 71, 0x41f0, 0x80fd, 0x9c20
+ax_pose 72, 0x01f0, 0x40ed, 0x9c28
+ax_pose 73, 0x81d8, 0x011d, 0x9c2c
+ax_pose_terminator
+sLugiaPose173:
+ax_pose 75, 0x01c9, 0xd0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose174:
+ax_pose 77, 0x41cc, 0xd0de, 0x9c00
+ax_pose 78, 0x01ec, 0x90de, 0x9c20
+ax_pose 79, 0x81ec, 0x90fe, 0x9c30
+ax_pose 80, 0x81dd, 0x10d6, 0x9c38
+ax_pose_terminator
+sLugiaPose175:
+ax_pose 82, 0x41cf, 0xd0e4, 0x9c00
+ax_pose 83, 0x41ef, 0x1114, 0x9c20
+ax_pose 84, 0x81ef, 0x9104, 0x9c22
+ax_pose 85, 0x41ef, 0x90e4, 0x9c2a
+ax_pose 86, 0x81ef, 0x10dc, 0x9c32
+ax_pose_terminator
+sLugiaPose176:
+ax_pose 88, 0x41d5, 0xc0dd, 0x9c00
+ax_pose 89, 0x81f5, 0x80ed, 0x9c20
+ax_pose 90, 0x81f5, 0x80fd, 0x9c28
+ax_pose 91, 0x01f5, 0x010d, 0x9c30
+ax_pose 92, 0x81d8, 0x011d, 0x9c31
+ax_pose_terminator
+sLugiaPose177:
+ax_pose 82, 0x41cf, 0xc0dc, 0x9c00
+ax_pose 83, 0x41ef, 0x00dc, 0x9c20
+ax_pose 84, 0x81ef, 0x80ec, 0x9c22
+ax_pose 85, 0x41ef, 0x80fc, 0x9c2a
+ax_pose 86, 0x81ef, 0x011c, 0x9c32
+ax_pose_terminator
+sLugiaPose178:
+ax_pose 77, 0x41cc, 0xc0e2, 0x9c00
+ax_pose 78, 0x01ec, 0x8102, 0x9c20
+ax_pose 79, 0x81ec, 0x80f2, 0x9c30
+ax_pose 80, 0x81dd, 0x0122, 0x9c38
+ax_pose_terminator
+sLugiaPose179:
+ax_pose 75, 0x01c9, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose180:
+ax_pose 70, 0x41d0, 0xc0dd, 0x9c00
+ax_pose 71, 0x41f0, 0x80fd, 0x9c20
+ax_pose 72, 0x01f0, 0x40ed, 0x9c28
+ax_pose 73, 0x81d8, 0x011d, 0x9c2c
+ax_pose_terminator
+sLugiaPose181:
+ax_pose 109, 0x01cb, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose182:
+ax_pose 0, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 1, 0x41f5, 0x80f0, 0x9c20
+ax_pose 2, 0x01db, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose183:
+ax_pose 70, 0x41d0, 0xc0dd, 0x9c00
+ax_pose 71, 0x41f0, 0x80fd, 0x9c20
+ax_pose 72, 0x01f0, 0x40ed, 0x9c28
+ax_pose 73, 0x81d8, 0x011d, 0x9c2c
+ax_pose_terminator
+sLugiaPose184:
+ax_pose 110, 0x01cb, 0xd0df, 0x9c00
+ax_pose_terminator
+sLugiaPose185:
+ax_pose 6, 0x41d7, 0xd0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x50e8, 0x9c20
+ax_pose_terminator
+sLugiaPose186:
+ax_pose 75, 0x01c9, 0xd0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose187:
+ax_pose 111, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose188:
+ax_pose 10, 0x41d1, 0xd0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x1100, 0x9c20
+ax_pose 12, 0x41f1, 0x90e0, 0x9c22
+ax_pose 13, 0x81e1, 0x10d8, 0x9c2a
+ax_pose_terminator
+sLugiaPose189:
+ax_pose 77, 0x41cc, 0xd0e0, 0x9c00
+ax_pose 78, 0x01ec, 0x90e0, 0x9c20
+ax_pose 79, 0x81ec, 0x9100, 0x9c30
+ax_pose 80, 0x81dd, 0x10d8, 0x9c38
+ax_pose_terminator
+sLugiaPose190:
+ax_pose 112, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose191:
+ax_pose 18, 0x41cf, 0xd0e8, 0x9c00
+ax_pose 19, 0x01ef, 0x90e8, 0x9c20
+ax_pose 20, 0x41ef, 0x9108, 0x9c30
+ax_pose 21, 0x81f7, 0x10e0, 0x9c38
+ax_pose_terminator
+sLugiaPose192:
+ax_pose 82, 0x41cb, 0xd0e8, 0x9c00
+ax_pose 83, 0x41eb, 0x1118, 0x9c20
+ax_pose 84, 0x81eb, 0x9108, 0x9c22
+ax_pose 85, 0x41eb, 0x90e8, 0x9c2a
+ax_pose 86, 0x81eb, 0x10e0, 0x9c32
+ax_pose_terminator
+sLugiaPose193:
+ax_pose 113, 0x01cc, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose194:
+ax_pose 26, 0x41cd, 0xc0d8, 0x9c00
+ax_pose 27, 0x01ed, 0x80f0, 0x9c20
+ax_pose 28, 0x01fd, 0x00e8, 0x9c30
+ax_pose 29, 0x01d5, 0x4118, 0x9c31
+ax_pose_terminator
+sLugiaPose195:
+ax_pose 88, 0x41d0, 0xc0dd, 0x9c00
+ax_pose 89, 0x81f0, 0x80ed, 0x9c20
+ax_pose 90, 0x81f0, 0x80fd, 0x9c28
+ax_pose 91, 0x01f0, 0x010d, 0x9c30
+ax_pose 92, 0x81d3, 0x011d, 0x9c31
+ax_pose_terminator
+sLugiaPose196:
+ax_pose 112, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose197:
+ax_pose 18, 0x41cf, 0xc0d8, 0x9c00
+ax_pose 19, 0x01ef, 0x80f8, 0x9c20
+ax_pose 20, 0x41ef, 0x80d8, 0x9c30
+ax_pose 21, 0x81f7, 0x0118, 0x9c38
+ax_pose_terminator
+sLugiaPose198:
+ax_pose 82, 0x41cb, 0xc0d8, 0x9c00
+ax_pose 83, 0x41eb, 0x00d8, 0x9c20
+ax_pose 84, 0x81eb, 0x80e8, 0x9c22
+ax_pose 85, 0x41eb, 0x80f8, 0x9c2a
+ax_pose 86, 0x81eb, 0x0118, 0x9c32
+ax_pose_terminator
+sLugiaPose199:
+ax_pose 111, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose200:
+ax_pose 10, 0x41d1, 0xc0e0, 0x9c00
+ax_pose 11, 0x41f1, 0x00f0, 0x9c20
+ax_pose 12, 0x41f1, 0x8100, 0x9c22
+ax_pose 13, 0x81e1, 0x0120, 0x9c2a
+ax_pose_terminator
+sLugiaPose201:
+ax_pose 77, 0x41cc, 0xc0e0, 0x9c00
+ax_pose 78, 0x01ec, 0x8100, 0x9c20
+ax_pose 79, 0x81ec, 0x80f0, 0x9c30
+ax_pose 80, 0x81dd, 0x0120, 0x9c38
+ax_pose_terminator
+sLugiaPose202:
+ax_pose 110, 0x01cb, 0xc0e1, 0x9c00
+ax_pose_terminator
+sLugiaPose203:
+ax_pose 6, 0x41d7, 0xc0e0, 0x9c00
+ax_pose 7, 0x41f7, 0x40f8, 0x9c20
+ax_pose_terminator
+sLugiaPose204:
+ax_pose 75, 0x01c9, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose205:
+ax_pose 109, 0x01cb, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose206:
+ax_pose 110, 0x01cb, 0xc0e1, 0x9c00
+ax_pose_terminator
+sLugiaPose207:
+ax_pose 111, 0x01cb, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose208:
+ax_pose 112, 0x01cc, 0xc0e1, 0x9c00
+ax_pose_terminator
+sLugiaPose209:
+ax_pose 113, 0x01cc, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose210:
+ax_pose 112, 0x01cc, 0xd0df, 0x9c00
+ax_pose_terminator
+sLugiaPose211:
+ax_pose 111, 0x01cb, 0xd0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose212:
+ax_pose 110, 0x01cb, 0xd0df, 0x9c00
+ax_pose_terminator
+sLugiaPose213:
+ax_pose 109, 0x01cb, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose214:
+ax_pose 110, 0x01cb, 0xc0e1, 0x9c00
+ax_pose_terminator
+sLugiaPose215:
+ax_pose 111, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose216:
+ax_pose 112, 0x01cb, 0xc0e2, 0x9c00
+ax_pose_terminator
+sLugiaPose217:
+ax_pose 113, 0x01cc, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose218:
+ax_pose 112, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose219:
+ax_pose 111, 0x01cb, 0xd0de, 0x9c00
+ax_pose_terminator
+sLugiaPose220:
+ax_pose 110, 0x01cb, 0xd0df, 0x9c00
+ax_pose_terminator
+sLugiaPose221:
+ax_pose 109, 0x01cb, 0xc0e0, 0x9c00
+ax_pose_terminator
+sLugiaPose222:
+ax_pose 0, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 1, 0x41f5, 0x80f0, 0x9c20
+ax_pose 2, 0x01db, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose223:
+ax_pose 3, 0x41d5, 0xc0d8, 0x9c00
+ax_pose 4, 0x41f5, 0x80f0, 0x9c20
+ax_pose 5, 0x01dd, 0x4118, 0x9c28
+ax_pose_terminator
+sLugiaPose224:
+ax_pose 69, 0x01d0, 0xc0e0, 0x9c00
+ax_pose_terminator
+.align 2
+sLugiaAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_2_1:
+ax_anim 2, 0, 19, 0, -1, 0, -1,
+ax_anim 4, 0, 19, 0, -2, 0, -2,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 0, 4, 0, 4,
+ax_anim 1, 0, 18, 0, 10, 0, 10,
+ax_anim 2, 0, 16, 0, 23, 0, 23,
+ax_anim 2, 1, 17, 0, 23, 0, 23,
+ax_anim 2, 0, 16, 0, 23, 0, 23,
+ax_anim 2, 0, 17, 0, 23, 0, 23,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sLugiaAnims_2_2:
+ax_anim 2, 0, 23, -1, -1, -1, -1,
+ax_anim 4, 0, 23, -2, -2, -2, -2,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, 3, 5, 3, 5,
+ax_anim 1, 0, 22, 9, 12, 9, 12,
+ax_anim 2, 0, 20, 19, 26, 19, 26,
+ax_anim 2, 1, 21, 19, 26, 19, 26,
+ax_anim 2, 0, 20, 19, 26, 19, 26,
+ax_anim 2, 0, 21, 19, 26, 19, 26,
+ax_anim 2, 0, 20, 5, 7, 5, 7,
+ax_anim_terminator
+sLugiaAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 4, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 4, 0, 4, 0,
+ax_anim 1, 0, 26, 10, 2, 10, 0,
+ax_anim 2, 0, 24, 17, 5, 17, 0,
+ax_anim 2, 1, 25, 17, 5, 17, 0,
+ax_anim 2, 0, 24, 17, 5, 17, 0,
+ax_anim 2, 0, 25, 17, 5, 17, 0,
+ax_anim 2, 0, 24, 6, 2, 6, 0,
+ax_anim_terminator
+sLugiaAnims_2_4:
+ax_anim 2, 0, 31, -1, 1, -1, 1,
+ax_anim 4, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 0, 30, 0, -1, 0, -1,
+ax_anim 1, 2, 30, 5, -3, 5, -3,
+ax_anim 1, 0, 30, 8, -5, 8, -5,
+ax_anim 2, 0, 28, 12, -8, 12, -8,
+ax_anim 2, 1, 29, 12, -8, 12, -8,
+ax_anim 2, 0, 28, 12, -8, 12, -8,
+ax_anim 2, 0, 29, 12, -8, 12, -8,
+ax_anim 2, 0, 28, 6, -4, 6, -4,
+ax_anim_terminator
+sLugiaAnims_2_5:
+ax_anim 2, 0, 35, 0, 3, 0, 3,
+ax_anim 4, 0, 35, 0, 6, 0, 6,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 0, -1, 0, -1,
+ax_anim 1, 0, 34, 0, -3, 0, -3,
+ax_anim 2, 0, 32, 0, -8, 0, -8,
+ax_anim 2, 1, 33, 0, -8, 0, -8,
+ax_anim 2, 0, 32, 0, -8, 0, -8,
+ax_anim 2, 0, 33, 0, -8, 0, -8,
+ax_anim 2, 0, 32, 0, -2, 0, -2,
+ax_anim_terminator
+sLugiaAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 38, -5, -3, -5, -3,
+ax_anim 1, 0, 38, -8, -5, -8, -5,
+ax_anim 2, 0, 36, -12, -8, -12, -8,
+ax_anim 2, 1, 37, -12, -8, -12, -8,
+ax_anim 2, 0, 36, -12, -8, -12, -8,
+ax_anim 2, 0, 37, -12, -8, -12, -8,
+ax_anim 2, 0, 36, -6, -4, -6, -4,
+ax_anim_terminator
+sLugiaAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 2, -10, 0,
+ax_anim 2, 0, 40, -17, 5, -17, 0,
+ax_anim 2, 1, 41, -17, 5, -17, 0,
+ax_anim 2, 0, 40, -17, 5, -17, 0,
+ax_anim 2, 0, 41, -17, 5, -17, 0,
+ax_anim 2, 0, 40, -6, 2, -6, 0,
+ax_anim_terminator
+sLugiaAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -3, 5, -3, 5,
+ax_anim 1, 0, 46, -9, 12, -9, 12,
+ax_anim 2, 0, 44, -19, 26, -19, 26,
+ax_anim 2, 1, 45, -19, 26, -19, 26,
+ax_anim 2, 0, 44, -19, 26, -19, 26,
+ax_anim 2, 0, 45, -19, 26, -19, 26,
+ax_anim 2, 0, 44, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sLugiaAnims_3_1:
+ax_anim 2, 0, 51, 0, -1, 0, -1,
+ax_anim 4, 0, 51, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 23, 0, 23,
+ax_anim 2, 1, 49, 0, 23, 0, 23,
+ax_anim 2, 0, 48, 0, 23, 0, 23,
+ax_anim 2, 0, 49, 0, 23, 0, 23,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sLugiaAnims_3_2:
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 4, 0, 55, -2, -2, -2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 3, 5, 3, 5,
+ax_anim 1, 0, 54, 9, 12, 9, 12,
+ax_anim 2, 0, 52, 19, 26, 19, 26,
+ax_anim 2, 1, 53, 19, 26, 19, 26,
+ax_anim 2, 0, 52, 19, 26, 19, 26,
+ax_anim 2, 0, 53, 19, 26, 19, 26,
+ax_anim 2, 0, 52, 5, 7, 5, 7,
+ax_anim_terminator
+sLugiaAnims_3_3:
+ax_anim 2, 0, 59, -1, 0, -1, 0,
+ax_anim 4, 0, 59, -2, 0, -2, 0,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 4, 0, 4, 0,
+ax_anim 1, 0, 58, 10, 2, 10, 0,
+ax_anim 2, 0, 56, 17, 5, 17, 0,
+ax_anim 2, 1, 57, 17, 5, 17, 0,
+ax_anim 2, 0, 56, 17, 5, 17, 0,
+ax_anim 2, 0, 57, 17, 5, 17, 0,
+ax_anim 2, 0, 56, 6, 2, 6, 0,
+ax_anim_terminator
+sLugiaAnims_3_4:
+ax_anim 2, 0, 63, -1, 1, -1, 1,
+ax_anim 4, 0, 63, -2, 2, -2, 2,
+ax_anim 1, 0, 62, 0, -1, 0, -1,
+ax_anim 1, 2, 62, 5, -3, 5, -3,
+ax_anim 1, 0, 62, 8, -5, 8, -5,
+ax_anim 2, 0, 60, 12, -8, 12, -8,
+ax_anim 2, 1, 61, 12, -8, 12, -8,
+ax_anim 2, 0, 60, 12, -8, 12, -8,
+ax_anim 2, 0, 61, 12, -8, 12, -8,
+ax_anim 2, 0, 60, 6, -4, 6, -4,
+ax_anim_terminator
+sLugiaAnims_3_5:
+ax_anim 2, 0, 67, 0, 3, 0, 3,
+ax_anim 4, 0, 67, 0, 6, 0, 6,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 0, -1, 0, -1,
+ax_anim 1, 0, 66, 0, -3, 0, -3,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 1, 65, 0, -8, 0, -8,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 65, 0, -8, 0, -8,
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim_terminator
+sLugiaAnims_3_6:
+ax_anim 2, 0, 71, 1, 1, 1, 1,
+ax_anim 4, 0, 71, 2, 2, 2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 70, -5, -3, -5, -3,
+ax_anim 1, 0, 70, -8, -5, -8, -5,
+ax_anim 2, 0, 68, -12, -8, -12, -8,
+ax_anim 2, 1, 69, -12, -8, -12, -8,
+ax_anim 2, 0, 68, -12, -8, -12, -8,
+ax_anim 2, 0, 69, -12, -8, -12, -8,
+ax_anim 2, 0, 68, -6, -4, -6, -4,
+ax_anim_terminator
+sLugiaAnims_3_7:
+ax_anim 2, 0, 75, 1, 0, 1, 0,
+ax_anim 4, 0, 75, 2, 0, 2, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 74, -4, 0, -4, 0,
+ax_anim 1, 0, 74, -10, 2, -10, 0,
+ax_anim 2, 0, 72, -17, 5, -17, 0,
+ax_anim 2, 1, 73, -17, 5, -17, 0,
+ax_anim 2, 0, 72, -17, 5, -17, 0,
+ax_anim 2, 0, 73, -17, 5, -17, 0,
+ax_anim 2, 0, 72, -6, 2, -6, 0,
+ax_anim_terminator
+sLugiaAnims_3_8:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 4, 0, 79, 2, -2, 2, -2,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 2, 78, -3, 5, -3, 5,
+ax_anim 1, 0, 78, -9, 12, -9, 12,
+ax_anim 2, 0, 76, -19, 26, -19, 26,
+ax_anim 2, 1, 77, -19, 26, -19, 26,
+ax_anim 2, 0, 76, -19, 26, -19, 26,
+ax_anim 2, 0, 77, -19, 26, -19, 26,
+ax_anim 2, 0, 76, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sLugiaAnims_4_1:
+ax_anim 2, 0, 82, 0, -11, 0, -11,
+ax_anim 6, 2, 82, 0, -14, 0, -14,
+ax_anim 1, 0, 83, 0, -6, 0, -6,
+ax_anim 1, 0, 83, 0, 1, 0, 1,
+ax_anim 2, 1, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sLugiaAnims_4_2:
+ax_anim 2, 0, 86, -8, -8, -8, -8,
+ax_anim 6, 2, 86, -10, -10, -10, -10,
+ax_anim 1, 0, 87, -6, -6, -6, -6,
+ax_anim 1, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 5, 3, 5, 3,
+ax_anim 2, 0, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 5, 3, 5, 3,
+ax_anim 2, 0, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 5, 3, 5, 3,
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim_terminator
+sLugiaAnims_4_3:
+ax_anim 2, 0, 90, -8, 0, -8, 0,
+ax_anim 6, 2, 90, -10, 0, -10, 0,
+ax_anim 1, 0, 91, -6, 0, -6, 0,
+ax_anim 1, 0, 91, 1, 0, 1, 0,
+ax_anim 2, 1, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 91, 4, 1, 4, 1,
+ax_anim 2, 0, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 91, 4, 1, 4, 1,
+ax_anim 2, 0, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 91, 4, 1, 4, 1,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim_terminator
+sLugiaAnims_4_4:
+ax_anim 2, 0, 94, -8, 8, -8, 8,
+ax_anim 6, 2, 94, -10, 10, -10, 10,
+ax_anim 1, 0, 95, -6, 6, -6, 6,
+ax_anim 1, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 95, 4, -4, 4, -4,
+ax_anim 2, 0, 95, 5, -3, 5, -3,
+ax_anim 2, 0, 92, 2, -2, 2, -2,
+ax_anim_terminator
+sLugiaAnims_4_5:
+ax_anim 2, 0, 98, 0, 11, 0, 11,
+ax_anim 6, 2, 98, 0, 14, 0, 14,
+ax_anim 1, 0, 99, 0, 6, 0, 6,
+ax_anim 1, 0, 99, 0, -1, 0, -1,
+ax_anim 2, 1, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 1, -4, 1, -4,
+ax_anim 2, 0, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 1, -4, 1, -4,
+ax_anim 2, 0, 99, 0, -4, 0, -4,
+ax_anim 2, 0, 99, 1, -4, 1, -4,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim_terminator
+sLugiaAnims_4_6:
+ax_anim 2, 0, 102, 8, 8, 8, 8,
+ax_anim 6, 2, 102, 10, 10, 10, 10,
+ax_anim 1, 0, 103, 6, 6, 6, 6,
+ax_anim 1, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 1, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -5, -3, -5, -3,
+ax_anim 2, 0, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -5, -3, -5, -3,
+ax_anim 2, 0, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -5, -3, -5, -3,
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim_terminator
+sLugiaAnims_4_7:
+ax_anim 2, 0, 106, 8, 0, 8, 0,
+ax_anim 6, 2, 106, 10, 0, 10, 0,
+ax_anim 1, 0, 107, 6, 0, 6, 0,
+ax_anim 1, 0, 107, -1, 0, -1, 0,
+ax_anim 2, 1, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -4, 1, -4, 1,
+ax_anim 2, 0, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -4, 1, -4, 1,
+ax_anim 2, 0, 107, -4, 0, -4, 0,
+ax_anim 2, 0, 107, -4, 1, -4, 1,
+ax_anim 2, 0, 104, -2, 0, -2, 0,
+ax_anim_terminator
+sLugiaAnims_4_8:
+ax_anim 2, 0, 110, 8, -8, 8, -8,
+ax_anim 6, 2, 110, 10, -10, 10, -10,
+ax_anim 1, 0, 111, 6, -6, 6, -6,
+ax_anim 1, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 1, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 108, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sLugiaAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_5_2:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_5_4:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_5_6:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_5_8:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sLugiaAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sLugiaAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sLugiaAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sLugiaAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sLugiaAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sLugiaAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sLugiaAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLugiaAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_8_2:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 30, 0, 161, 1, 1, 0, 0,
+ax_anim_terminator
+sLugiaAnims_8_3:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_8_4:
+ax_anim 30, 0, 151, 0, 0, 0, 0,
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_8_6:
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim 30, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_8_7:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_8_8:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 15, 7, 15,
+ax_anim 3, 0, 166, 0, 18, 0, 18,
+ax_anim 2, 3, 167, -7, 15, -7, 15,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 12, 19, 12,
+ax_anim 3, 0, 165, 17, 22, 17, 22,
+ax_anim 2, 3, 166, 11, 19, 11, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -3, 3, -3,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 14, -5, 14, -5,
+ax_anim 3, 0, 164, 16, 2, 16, 2,
+ax_anim 2, 3, 165, 14, 8, 14, 5,
+ax_anim 2, 0, 166, 10, 8, 10, 6,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -5, -1, -5,
+ax_anim 2, 0, 169, 4, -10, 4, -10,
+ax_anim 2, 0, 162, 12, -13, 12, -13,
+ax_anim 3, 0, 163, 18, -9, 18, -9,
+ax_anim 2, 3, 164, 20, -4, 20, -7,
+ax_anim 2, 0, 165, 17, 0, 17, -2,
+ax_anim 1, 0, 166, 7, 0, 7, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -6, -9, -6,
+ax_anim 2, 0, 169, -7, -10, -7, -10,
+ax_anim 3, 0, 162, 0, -12, 0, -12,
+ax_anim 2, 3, 163, 7, -10, 7, -10,
+ax_anim 2, 0, 164, 9, -6, 9, -6,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -5, 1, -5,
+ax_anim 2, 0, 163, -4, -10, -4, -10,
+ax_anim 2, 0, 162, -12, -13, -12, -13,
+ax_anim 3, 0, 169, -18, -9, -18, -9,
+ax_anim 2, 3, 168, -20, -4, -20, -7,
+ax_anim 2, 0, 167, -17, 0, -17, -2,
+ax_anim 1, 0, 166, -7, 0, -7, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -3, -3, -3,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -14, -5, -14, -5,
+ax_anim 3, 0, 168, -16, 2, -16, 2,
+ax_anim 2, 3, 167, -14, 8, -14, 5,
+ax_anim 2, 0, 166, -10, 8, -10, 6,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 12, -19, 12,
+ax_anim 3, 0, 167, -17, 22, -17, 22,
+ax_anim 2, 3, 166, -11, 19, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_10_1:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, 0, 6, 0,
+ax_anim 2, 0, 171, -6, 0, -6, 0,
+ax_anim 2, 0, 171, 10, 0, 10, 0,
+ax_anim 2, 0, 171, -10, 0, -10, 0,
+ax_anim 2, 0, 171, 12, 0, 12, 0,
+ax_anim 3, 0, 171, -12, 0, -12, 0,
+ax_anim 3, 0, 171, 13, 0, 13, 0,
+ax_anim 3, 0, 171, -13, 0, -13, 0,
+ax_anim 2, 0, 171, 12, 0, 12, 0,
+ax_anim 3, 0, 171, -12, 0, -12, 0,
+ax_anim 2, 0, 171, 10, 0, 10, 0,
+ax_anim 2, 0, 171, -10, 0, -10, 0,
+ax_anim 2, 0, 171, 6, 0, 6, 0,
+ax_anim 2, 0, 171, -6, 0, -6, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_10_2:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 6, -6, 6, -6,
+ax_anim 2, 0, 172, -6, 6, -6, 6,
+ax_anim 2, 0, 172, 10, -10, 10, -10,
+ax_anim 2, 0, 172, -10, 10, -10, 10,
+ax_anim 2, 0, 172, 12, -12, 12, -12,
+ax_anim 3, 0, 172, -12, 12, -12, 12,
+ax_anim 3, 0, 172, 13, -13, 13, -13,
+ax_anim 3, 0, 172, -13, 13, -13, 13,
+ax_anim 2, 0, 172, 12, -12, 12, -12,
+ax_anim 3, 0, 172, -12, 12, -12, 12,
+ax_anim 2, 0, 172, 10, -10, 10, -10,
+ax_anim 2, 0, 172, -10, 10, -10, 10,
+ax_anim 2, 0, 172, 6, -6, 6, -6,
+ax_anim 2, 0, 172, -6, 6, -6, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_10_3:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 3, 0, 173, 0, -13, 0, -13,
+ax_anim 3, 0, 173, 0, 13, 0, 13,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_10_4:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, -6, -6, -6, -6,
+ax_anim 2, 0, 174, 6, 6, 6, 6,
+ax_anim 2, 0, 174, -10, -10, -10, -10,
+ax_anim 2, 0, 174, 10, 10, 10, 10,
+ax_anim 2, 0, 174, -12, -12, -12, -12,
+ax_anim 3, 0, 174, 12, 12, 12, 12,
+ax_anim 3, 0, 174, -13, -13, -13, -13,
+ax_anim 3, 0, 174, 13, 13, 13, 13,
+ax_anim 2, 0, 174, -12, -12, -12, -12,
+ax_anim 3, 0, 174, 12, 12, 12, 12,
+ax_anim 2, 0, 174, -10, -10, -10, -10,
+ax_anim 2, 0, 174, 10, 10, 10, 10,
+ax_anim 2, 0, 174, -6, -6, -6, -6,
+ax_anim 2, 0, 174, 6, 6, 6, 6,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_10_5:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, 0, 6, 0,
+ax_anim 2, 0, 175, -6, 0, -6, 0,
+ax_anim 2, 0, 175, 10, 0, 10, 0,
+ax_anim 2, 0, 175, -10, 0, -10, 0,
+ax_anim 2, 0, 175, 12, 0, 12, 0,
+ax_anim 3, 0, 175, -12, 0, -12, 0,
+ax_anim 3, 0, 175, 13, 0, 13, 0,
+ax_anim 3, 0, 175, -13, 0, -13, 0,
+ax_anim 2, 0, 175, 12, 0, 12, 0,
+ax_anim 3, 0, 175, -12, 0, -12, 0,
+ax_anim 2, 0, 175, 10, 0, 10, 0,
+ax_anim 2, 0, 175, -10, 0, -10, 0,
+ax_anim 2, 0, 175, 6, 0, 6, 0,
+ax_anim 2, 0, 175, -6, 0, -6, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_10_6:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 6, -6, 6, -6,
+ax_anim 2, 0, 176, -6, 6, -6, 6,
+ax_anim 2, 0, 176, 10, -10, 10, -10,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 2, 0, 176, 12, -12, 12, -12,
+ax_anim 3, 0, 176, -12, 12, -12, 12,
+ax_anim 3, 0, 176, 13, -13, 13, -13,
+ax_anim 3, 0, 176, -13, 13, -13, 13,
+ax_anim 2, 0, 176, 12, -12, 12, -12,
+ax_anim 3, 0, 176, -12, 12, -12, 12,
+ax_anim 2, 0, 176, 10, -10, 10, -10,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 2, 0, 176, 6, -6, 6, -6,
+ax_anim 2, 0, 176, -6, 6, -6, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_10_7:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, -6, 0, -6,
+ax_anim 2, 0, 177, 0, 6, 0, 6,
+ax_anim 2, 0, 177, 0, -10, 0, -10,
+ax_anim 2, 0, 177, 0, 10, 0, 10,
+ax_anim 2, 0, 177, 0, -12, 0, -12,
+ax_anim 3, 0, 177, 0, 12, 0, 12,
+ax_anim 3, 0, 177, 0, -13, 0, -13,
+ax_anim 3, 0, 177, 0, 13, 0, 13,
+ax_anim 2, 0, 177, 0, -12, 0, -12,
+ax_anim 3, 0, 177, 0, 12, 0, 12,
+ax_anim 2, 0, 177, 0, -10, 0, -10,
+ax_anim 2, 0, 177, 0, 10, 0, 10,
+ax_anim 2, 0, 177, 0, -6, 0, -6,
+ax_anim 2, 0, 177, 0, 6, 0, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_10_8:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -6, -6, -6, -6,
+ax_anim 2, 0, 178, 6, 6, 6, 6,
+ax_anim 2, 0, 178, -10, -10, -10, -10,
+ax_anim 2, 0, 178, 10, 10, 10, 10,
+ax_anim 2, 0, 178, -12, -12, -12, -12,
+ax_anim 3, 0, 178, 12, 12, 12, 12,
+ax_anim 3, 0, 178, -13, -13, -13, -13,
+ax_anim 3, 0, 178, 13, 13, 13, 13,
+ax_anim 2, 0, 178, -12, -12, -12, -12,
+ax_anim 3, 0, 178, 12, 12, 12, 12,
+ax_anim 2, 0, 178, -10, -10, -10, -10,
+ax_anim 2, 0, 178, 10, 10, 10, 10,
+ax_anim 2, 0, 178, -6, -6, -6, -6,
+ax_anim 2, 0, 178, 6, 6, 6, 6,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_11_1:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 3, 0, 0,
+ax_anim_terminator
+sLugiaAnims_11_2:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -24, 0, 0,
+ax_anim 3, 0, 185, 0, -23, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 3, 0, 0,
+ax_anim_terminator
+sLugiaAnims_11_3:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 5, 0, 0,
+ax_anim_terminator
+sLugiaAnims_11_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -17, 0, 0,
+ax_anim 1, 0, 191, 0, -8, 0, 0,
+ax_anim 2, 2, 191, 0, 8, 0, 0,
+ax_anim_terminator
+sLugiaAnims_11_5:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -5, 0, 0,
+ax_anim 2, 2, 194, 0, 11, 0, 0,
+ax_anim_terminator
+sLugiaAnims_11_6:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -8, 0, 0,
+ax_anim 2, 2, 197, 0, 8, 0, 0,
+ax_anim_terminator
+sLugiaAnims_11_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 5, 0, 0,
+ax_anim_terminator
+sLugiaAnims_11_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -24, 0, 0,
+ax_anim 3, 0, 203, 0, -23, 0, 0,
+ax_anim 2, 0, 203, 0, -18, 0, 0,
+ax_anim 1, 0, 203, 0, -12, 0, 0,
+ax_anim 2, 2, 203, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_12_1:
+ax_anim 2, 0, 204, 1, 0, 1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, 0, 1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, 0, 1, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, 0, 1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, 0, 1, 0,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_12_2:
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_12_3:
+ax_anim 2, 0, 210, 0, -1, 0, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, -1, 0, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, -1, 0, -1,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, -1, 0, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, -1, 0, -1,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_12_4:
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, -1, -1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_12_5:
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_12_6:
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, -1, 1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_12_7:
+ax_anim 2, 0, 206, 0, -1, 0, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, -1, 0, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, -1, 0, -1,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, -1, 0, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, -1, 0, -1,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_12_8:
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, -1, -1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_13_1:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_13_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_13_3:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_13_4:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_13_5:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_13_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_13_7:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaAnims_13_8:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLugiaAnims_14_1:
+ax_anim 8, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -8, 0, 0,
+ax_anim 3, 0, 223, 0, -16, 0, 0,
+ax_anim 4, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -14, 0, 0,
+ax_anim 3, 0, 222, 0, -8, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sLugiaGfx1:
+.incbin "baserom.gba", 0x101F6B4, 0x20
+sLugiaGfx1_1:
+.incbin "baserom.gba", 0x101F6D4, 0x60
+sLugiaGfx1_2:
+.incbin "baserom.gba", 0x101F734, 0x200
+sLugiaGfx1_3:
+.incbin "baserom.gba", 0x101F934, 0x80
+sLugiaSprites1:
+ax_sprite sLugiaGfx1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx1_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx1_2, 0x200
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx1_3, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx2:
+.incbin "baserom.gba", 0x101F9FC, 0x100
+sLugiaSprites2:
+ax_sprite sLugiaGfx2, 0x100
+ax_sprite_terminator
+sLugiaGfx3:
+.incbin "baserom.gba", 0x101FB0C, 0x80
+sLugiaSprites3:
+ax_sprite sLugiaGfx3, 0x80
+ax_sprite_terminator
+sLugiaGfx4:
+.incbin "baserom.gba", 0x101FB9C, 0x60
+sLugiaGfx4_1:
+.incbin "baserom.gba", 0x101FBFC, 0x200
+sLugiaGfx4_2:
+.incbin "baserom.gba", 0x101FDFC, 0x80
+sLugiaSprites4:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx4, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx4_1, 0x200
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx4_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx5:
+.incbin "baserom.gba", 0x101FEBC, 0x100
+sLugiaSprites5:
+ax_sprite sLugiaGfx5, 0x100
+ax_sprite_terminator
+sLugiaGfx6:
+.incbin "baserom.gba", 0x101FFCC, 0x80
+sLugiaSprites6:
+ax_sprite sLugiaGfx6, 0x80
+ax_sprite_terminator
+sLugiaGfx7:
+.incbin "baserom.gba", 0x102005C, 0x80
+sLugiaGfx7_1:
+.incbin "baserom.gba", 0x10200DC, 0x160
+sLugiaGfx7_2:
+.incbin "baserom.gba", 0x102023C, 0xE0
+sLugiaGfx7_3:
+.incbin "baserom.gba", 0x102031C, 0xA0
+sLugiaSprites7:
+ax_sprite sLugiaGfx7, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx7_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx7_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx7_3, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx8:
+.incbin "baserom.gba", 0x1020404, 0x60
+sLugiaSprites8:
+ax_sprite sLugiaGfx8, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx9:
+.incbin "baserom.gba", 0x102047C, 0x80
+sLugiaGfx9_1:
+.incbin "baserom.gba", 0x10204FC, 0x160
+sLugiaGfx9_2:
+.incbin "baserom.gba", 0x102065C, 0xE0
+sLugiaGfx9_3:
+.incbin "baserom.gba", 0x102073C, 0xA0
+sLugiaSprites9:
+ax_sprite sLugiaGfx9, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx9_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx9_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx9_3, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx10:
+.incbin "baserom.gba", 0x1020824, 0x60
+sLugiaSprites10:
+ax_sprite sLugiaGfx10, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx11:
+.incbin "baserom.gba", 0x102089C, 0x80
+sLugiaGfx11_1:
+.incbin "baserom.gba", 0x102091C, 0xA0
+sLugiaGfx11_2:
+.incbin "baserom.gba", 0x10209BC, 0xC0
+sLugiaGfx11_3:
+.incbin "baserom.gba", 0x1020A7C, 0x20
+sLugiaGfx11_4:
+.incbin "baserom.gba", 0x1020A9C, 0xC0
+sLugiaSprites11:
+ax_sprite sLugiaGfx11, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx11_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx11_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx11_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx11_4, 0xc0
+ax_sprite_terminator
+sLugiaGfx12:
+.incbin "baserom.gba", 0x1020BAC, 0x40
+sLugiaSprites12:
+ax_sprite sLugiaGfx12, 0x40
+ax_sprite_terminator
+sLugiaGfx13:
+.incbin "baserom.gba", 0x1020BFC, 0xE0
+sLugiaSprites13:
+ax_sprite sLugiaGfx13, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx14:
+.incbin "baserom.gba", 0x1020CF4, 0x40
+sLugiaSprites14:
+ax_sprite sLugiaGfx14, 0x40
+ax_sprite_terminator
+sLugiaGfx15:
+.incbin "baserom.gba", 0x1020D44, 0x40
+sLugiaGfx15_1:
+.incbin "baserom.gba", 0x1020D84, 0x20
+sLugiaGfx15_2:
+.incbin "baserom.gba", 0x1020DA4, 0xA0
+sLugiaGfx15_3:
+.incbin "baserom.gba", 0x1020E44, 0xC0
+sLugiaGfx15_4:
+.incbin "baserom.gba", 0x1020F04, 0x20
+sLugiaGfx15_5:
+.incbin "baserom.gba", 0x1020F24, 0xC0
+sLugiaSprites15:
+ax_sprite sLugiaGfx15, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx15_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx15_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx15_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx15_4, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx15_5, 0xc0
+ax_sprite_terminator
+sLugiaGfx16:
+.incbin "baserom.gba", 0x1021044, 0x40
+sLugiaSprites16:
+ax_sprite sLugiaGfx16, 0x40
+ax_sprite_terminator
+sLugiaGfx17:
+.incbin "baserom.gba", 0x1021094, 0xE0
+sLugiaSprites17:
+ax_sprite sLugiaGfx17, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx18:
+.incbin "baserom.gba", 0x102118C, 0x40
+sLugiaSprites18:
+ax_sprite sLugiaGfx18, 0x40
+ax_sprite_terminator
+sLugiaGfx19:
+.incbin "baserom.gba", 0x10211DC, 0x40
+sLugiaGfx19_1:
+.incbin "baserom.gba", 0x102121C, 0x40
+sLugiaGfx19_2:
+.incbin "baserom.gba", 0x102125C, 0xE0
+sLugiaGfx19_3:
+.incbin "baserom.gba", 0x102133C, 0x1C0
+sLugiaSprites19:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx19_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx19_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx19_3, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx20:
+.incbin "baserom.gba", 0x102154C, 0x60
+sLugiaGfx20_1:
+.incbin "baserom.gba", 0x10215AC, 0x100
+sLugiaSprites20:
+ax_sprite sLugiaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLugiaGfx21:
+.incbin "baserom.gba", 0x10216D4, 0x80
+sLugiaGfx21_1:
+.incbin "baserom.gba", 0x1021754, 0x20
+sLugiaSprites21:
+ax_sprite sLugiaGfx21, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx21_1, 0x20
+ax_sprite_terminator
+sLugiaGfx22:
+.incbin "baserom.gba", 0x1021794, 0x40
+sLugiaSprites22:
+ax_sprite sLugiaGfx22, 0x40
+ax_sprite_terminator
+sLugiaGfx23:
+.incbin "baserom.gba", 0x10217E4, 0x40
+sLugiaGfx23_1:
+.incbin "baserom.gba", 0x1021824, 0x20
+sLugiaGfx23_2:
+.incbin "baserom.gba", 0x1021844, 0xE0
+sLugiaGfx23_3:
+.incbin "baserom.gba", 0x1021924, 0x1A0
+sLugiaSprites23:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx23_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx23_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx23_3, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx24:
+.incbin "baserom.gba", 0x1021B14, 0x60
+sLugiaGfx24_1:
+.incbin "baserom.gba", 0x1021B74, 0xC0
+sLugiaGfx24_2:
+.incbin "baserom.gba", 0x1021C34, 0x20
+sLugiaSprites24:
+ax_sprite sLugiaGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx24_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx24_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLugiaGfx25:
+.incbin "baserom.gba", 0x1021C8C, 0x80
+sLugiaGfx25_1:
+.incbin "baserom.gba", 0x1021D0C, 0x20
+sLugiaSprites25:
+ax_sprite sLugiaGfx25, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx25_1, 0x20
+ax_sprite_terminator
+sLugiaGfx26:
+.incbin "baserom.gba", 0x1021D4C, 0x40
+sLugiaSprites26:
+ax_sprite sLugiaGfx26, 0x40
+ax_sprite_terminator
+sLugiaGfx27:
+.incbin "baserom.gba", 0x1021D9C, 0x60
+sLugiaGfx27_1:
+.incbin "baserom.gba", 0x1021DFC, 0x60
+sLugiaGfx27_2:
+.incbin "baserom.gba", 0x1021E5C, 0x40
+sLugiaGfx27_3:
+.incbin "baserom.gba", 0x1021E9C, 0x120
+sLugiaGfx27_4:
+.incbin "baserom.gba", 0x1021FBC, 0xC0
+sLugiaSprites27:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx27, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx27_3, 0x120
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx27_4, 0xc0
+ax_sprite_terminator
+sLugiaGfx28:
+.incbin "baserom.gba", 0x10220D4, 0x1E0
+sLugiaSprites28:
+ax_sprite sLugiaGfx28, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx29:
+.incbin "baserom.gba", 0x10222CC, 0x20
+sLugiaSprites29:
+ax_sprite sLugiaGfx29, 0x20
+ax_sprite_terminator
+sLugiaGfx30:
+.incbin "baserom.gba", 0x10222FC, 0x80
+sLugiaSprites30:
+ax_sprite sLugiaGfx30, 0x80
+ax_sprite_terminator
+sLugiaGfx31:
+.incbin "baserom.gba", 0x102238C, 0x60
+sLugiaGfx31_1:
+.incbin "baserom.gba", 0x10223EC, 0x60
+sLugiaGfx31_2:
+.incbin "baserom.gba", 0x102244C, 0x40
+sLugiaGfx31_3:
+.incbin "baserom.gba", 0x102248C, 0x220
+sLugiaSprites31:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx31, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx31_3, 0x220
+ax_sprite_terminator
+sLugiaGfx32:
+.incbin "baserom.gba", 0x10226F4, 0x180
+sLugiaGfx32_1:
+.incbin "baserom.gba", 0x1022874, 0x40
+sLugiaSprites32:
+ax_sprite sLugiaGfx32, 0x180
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx32_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx33:
+.incbin "baserom.gba", 0x10228DC, 0x20
+sLugiaSprites33:
+ax_sprite sLugiaGfx33, 0x20
+ax_sprite_terminator
+sLugiaGfx34:
+.incbin "baserom.gba", 0x102290C, 0x80
+sLugiaSprites34:
+ax_sprite sLugiaGfx34, 0x80
+ax_sprite_terminator
+sLugiaGfx35:
+.incbin "baserom.gba", 0x102299C, 0x60
+sLugiaGfx35_1:
+.incbin "baserom.gba", 0x10229FC, 0x40
+sLugiaGfx35_2:
+.incbin "baserom.gba", 0x1022A3C, 0x120
+sLugiaGfx35_3:
+.incbin "baserom.gba", 0x1022B5C, 0xC0
+sLugiaGfx35_4:
+.incbin "baserom.gba", 0x1022C1C, 0x80
+sLugiaSprites35:
+ax_sprite sLugiaGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx35_2, 0x120
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx35_3, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx35_4, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx36:
+.incbin "baserom.gba", 0x1022CF4, 0x100
+sLugiaSprites36:
+ax_sprite sLugiaGfx36, 0x100
+ax_sprite_terminator
+sLugiaGfx37:
+.incbin "baserom.gba", 0x1022E04, 0x80
+sLugiaSprites37:
+ax_sprite sLugiaGfx37, 0x80
+ax_sprite_terminator
+sLugiaGfx38:
+.incbin "baserom.gba", 0x1022E94, 0x60
+sLugiaGfx38_1:
+.incbin "baserom.gba", 0x1022EF4, 0x60
+sLugiaGfx38_2:
+.incbin "baserom.gba", 0x1022F54, 0xA0
+sLugiaGfx38_3:
+.incbin "baserom.gba", 0x1022FF4, 0xE0
+sLugiaSprites38:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx38, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx38_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx38_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx38_3, 0xe0
+ax_sprite_terminator
+sLugiaGfx39:
+.incbin "baserom.gba", 0x102311C, 0x60
+sLugiaGfx39_1:
+.incbin "baserom.gba", 0x102317C, 0x60
+sLugiaSprites39:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx39_1, 0x60
+ax_sprite_terminator
+sLugiaGfx40:
+.incbin "baserom.gba", 0x1023204, 0x80
+sLugiaGfx40_1:
+.incbin "baserom.gba", 0x1023284, 0x60
+sLugiaSprites40:
+ax_sprite sLugiaGfx40, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx40_1, 0x60
+ax_sprite_terminator
+sLugiaGfx41:
+.incbin "baserom.gba", 0x1023304, 0x60
+sLugiaGfx41_1:
+.incbin "baserom.gba", 0x1023364, 0x160
+sLugiaGfx41_2:
+.incbin "baserom.gba", 0x10234C4, 0xE0
+sLugiaGfx41_3:
+.incbin "baserom.gba", 0x10235A4, 0xC0
+sLugiaSprites41:
+ax_sprite sLugiaGfx41, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx41_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx41_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx41_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx42:
+.incbin "baserom.gba", 0x10236AC, 0x80
+sLugiaGfx42_1:
+.incbin "baserom.gba", 0x102372C, 0x60
+sLugiaSprites42:
+ax_sprite sLugiaGfx42, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx42_1, 0x60
+ax_sprite_terminator
+sLugiaGfx43:
+.incbin "baserom.gba", 0x10237AC, 0x60
+sLugiaGfx43_1:
+.incbin "baserom.gba", 0x102380C, 0x80
+sLugiaGfx43_2:
+.incbin "baserom.gba", 0x102388C, 0xA0
+sLugiaGfx43_3:
+.incbin "baserom.gba", 0x102392C, 0xE0
+sLugiaSprites43:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx43, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx43_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx43_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx43_3, 0xe0
+ax_sprite_terminator
+sLugiaGfx44:
+.incbin "baserom.gba", 0x1023A54, 0x80
+sLugiaGfx44_1:
+.incbin "baserom.gba", 0x1023AD4, 0x20
+sLugiaSprites44:
+ax_sprite sLugiaGfx44, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx44_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx45:
+.incbin "baserom.gba", 0x1023B1C, 0x60
+sLugiaGfx45_1:
+.incbin "baserom.gba", 0x1023B7C, 0x60
+sLugiaSprites45:
+ax_sprite sLugiaGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx46:
+.incbin "baserom.gba", 0x1023C04, 0x80
+sLugiaGfx46_1:
+.incbin "baserom.gba", 0x1023C84, 0xC0
+sLugiaGfx46_2:
+.incbin "baserom.gba", 0x1023D44, 0x200
+sLugiaSprites46:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx46, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx46_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx46_2, 0x200
+ax_sprite_terminator
+sLugiaGfx47:
+.incbin "baserom.gba", 0x1023F7C, 0x40
+sLugiaSprites47:
+ax_sprite sLugiaGfx47, 0x40
+ax_sprite_terminator
+sLugiaGfx48:
+.incbin "baserom.gba", 0x1023FCC, 0xE0
+sLugiaSprites48:
+ax_sprite sLugiaGfx48, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx49:
+.incbin "baserom.gba", 0x10240C4, 0x40
+sLugiaSprites49:
+ax_sprite sLugiaGfx49, 0x40
+ax_sprite_terminator
+sLugiaGfx50:
+.incbin "baserom.gba", 0x1024114, 0x60
+sLugiaGfx50_1:
+.incbin "baserom.gba", 0x1024174, 0x80
+sLugiaGfx50_2:
+.incbin "baserom.gba", 0x10241F4, 0xA0
+sLugiaGfx50_3:
+.incbin "baserom.gba", 0x1024294, 0xC0
+sLugiaSprites50:
+ax_sprite sLugiaGfx50, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx50_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx50_2, 0xa0
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx50_3, 0xc0
+ax_sprite_terminator
+sLugiaGfx51:
+.incbin "baserom.gba", 0x1024394, 0x40
+sLugiaSprites51:
+ax_sprite sLugiaGfx51, 0x40
+ax_sprite_terminator
+sLugiaGfx52:
+.incbin "baserom.gba", 0x10243E4, 0x80
+sLugiaGfx52_1:
+.incbin "baserom.gba", 0x1024464, 0x20
+sLugiaSprites52:
+ax_sprite sLugiaGfx52, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx52_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx53:
+.incbin "baserom.gba", 0x10244AC, 0xE0
+sLugiaSprites53:
+ax_sprite sLugiaGfx53, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx54:
+.incbin "baserom.gba", 0x10245A4, 0x20
+sLugiaSprites54:
+ax_sprite sLugiaGfx54, 0x20
+ax_sprite_terminator
+sLugiaGfx55:
+.incbin "baserom.gba", 0x10245D4, 0x40
+sLugiaSprites55:
+ax_sprite sLugiaGfx55, 0x40
+ax_sprite_terminator
+sLugiaGfx56:
+.incbin "baserom.gba", 0x1024624, 0xC0
+sLugiaGfx56_1:
+.incbin "baserom.gba", 0x10246E4, 0xC0
+sLugiaGfx56_2:
+.incbin "baserom.gba", 0x10247A4, 0xC0
+sLugiaGfx56_3:
+.incbin "baserom.gba", 0x1024864, 0xE0
+sLugiaSprites56:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx56, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx56_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx56_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx56_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx57:
+.incbin "baserom.gba", 0x1024994, 0x40
+sLugiaSprites57:
+ax_sprite sLugiaGfx57, 0x40
+ax_sprite_terminator
+sLugiaGfx58:
+.incbin "baserom.gba", 0x10249E4, 0x60
+sLugiaGfx58_1:
+.incbin "baserom.gba", 0x1024A44, 0xC0
+sLugiaGfx58_2:
+.incbin "baserom.gba", 0x1024B04, 0x20
+sLugiaSprites58:
+ax_sprite sLugiaGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx58_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx58_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLugiaGfx59:
+.incbin "baserom.gba", 0x1024B5C, 0x20
+sLugiaSprites59:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx59, 0x20
+ax_sprite_terminator
+sLugiaGfx60:
+.incbin "baserom.gba", 0x1024B94, 0x60
+sLugiaGfx60_1:
+.incbin "baserom.gba", 0x1024BF4, 0x60
+sLugiaGfx60_2:
+.incbin "baserom.gba", 0x1024C54, 0xA0
+sLugiaGfx60_3:
+.incbin "baserom.gba", 0x1024CF4, 0xC0
+sLugiaGfx60_4:
+.incbin "baserom.gba", 0x1024DB4, 0xC0
+sLugiaGfx60_5:
+.incbin "baserom.gba", 0x1024E74, 0xE0
+sLugiaGfx60_6:
+.incbin "baserom.gba", 0x1024F54, 0x20
+sLugiaGfx60_7:
+.incbin "baserom.gba", 0x1024F74, 0x80
+sLugiaSprites60:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx60, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx60_1, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx60_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx60_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx60_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx60_5, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx60_6, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx60_7, 0x80
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sLugiaGfx61:
+.incbin "baserom.gba", 0x1025084, 0xA0
+sLugiaGfx61_1:
+.incbin "baserom.gba", 0x1025124, 0x120
+sLugiaGfx61_2:
+.incbin "baserom.gba", 0x1025244, 0xE0
+sLugiaGfx61_3:
+.incbin "baserom.gba", 0x1025324, 0x80
+sLugiaSprites61:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx61, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx61_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx61_2, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx61_3, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx62:
+.incbin "baserom.gba", 0x10253F4, 0x20
+sLugiaGfx62_1:
+.incbin "baserom.gba", 0x1025414, 0x60
+sLugiaSprites62:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx62, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx62_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx63:
+.incbin "baserom.gba", 0x10254A4, 0x60
+sLugiaGfx63_1:
+.incbin "baserom.gba", 0x1025504, 0x60
+sLugiaGfx63_2:
+.incbin "baserom.gba", 0x1025564, 0x60
+sLugiaGfx63_3:
+.incbin "baserom.gba", 0x10255C4, 0x40
+sLugiaSprites63:
+ax_sprite sLugiaGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx63_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx63_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx63_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx64:
+.incbin "baserom.gba", 0x102564C, 0x40
+sLugiaSprites64:
+ax_sprite sLugiaGfx64, 0x40
+ax_sprite_terminator
+sLugiaGfx65:
+.incbin "baserom.gba", 0x102569C, 0x60
+sLugiaGfx65_1:
+.incbin "baserom.gba", 0x10256FC, 0x40
+sLugiaGfx65_2:
+.incbin "baserom.gba", 0x102573C, 0xA0
+sLugiaGfx65_3:
+.incbin "baserom.gba", 0x10257DC, 0xC0
+sLugiaSprites65:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx65, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx65_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx65_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx65_3, 0xc0
+ax_sprite_terminator
+sLugiaGfx66:
+.incbin "baserom.gba", 0x10258E4, 0x40
+sLugiaSprites66:
+ax_sprite sLugiaGfx66, 0x40
+ax_sprite_terminator
+sLugiaGfx67:
+.incbin "baserom.gba", 0x1025934, 0xC0
+sLugiaGfx67_1:
+.incbin "baserom.gba", 0x10259F4, 0x20
+sLugiaSprites67:
+ax_sprite sLugiaGfx67, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx67_1, 0x20
+ax_sprite_terminator
+sLugiaGfx68:
+.incbin "baserom.gba", 0x1025A34, 0x160
+sLugiaGfx68_1:
+.incbin "baserom.gba", 0x1025B94, 0x40
+sLugiaSprites68:
+ax_sprite sLugiaGfx68, 0x160
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx68_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx69:
+.incbin "baserom.gba", 0x1025BFC, 0x20
+sLugiaSprites69:
+ax_sprite sLugiaGfx69, 0x20
+ax_sprite_terminator
+sLugiaGfx70:
+.incbin "baserom.gba", 0x1025C2C, 0x60
+sLugiaGfx70_1:
+.incbin "baserom.gba", 0x1025C8C, 0x60
+sLugiaGfx70_2:
+.incbin "baserom.gba", 0x1025CEC, 0xA0
+sLugiaGfx70_3:
+.incbin "baserom.gba", 0x1025D8C, 0xA0
+sLugiaGfx70_4:
+.incbin "baserom.gba", 0x1025E2C, 0x80
+sLugiaGfx70_5:
+.incbin "baserom.gba", 0x1025EAC, 0x80
+sLugiaGfx70_6:
+.incbin "baserom.gba", 0x1025F2C, 0x80
+sLugiaGfx70_7:
+.incbin "baserom.gba", 0x1025FAC, 0x80
+sLugiaSprites70:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx70, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx70_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx70_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx70_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx70_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx70_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx70_6, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx70_7, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx71:
+.incbin "baserom.gba", 0x10260BC, 0x60
+sLugiaGfx71_1:
+.incbin "baserom.gba", 0x102611C, 0x200
+sLugiaGfx71_2:
+.incbin "baserom.gba", 0x102631C, 0x80
+sLugiaSprites71:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx71, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx71_1, 0x200
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx71_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx72:
+.incbin "baserom.gba", 0x10263DC, 0x40
+sLugiaGfx72_1:
+.incbin "baserom.gba", 0x102641C, 0x60
+sLugiaSprites72:
+ax_sprite sLugiaGfx72, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx72_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx73:
+.incbin "baserom.gba", 0x10264A4, 0x80
+sLugiaSprites73:
+ax_sprite sLugiaGfx73, 0x80
+ax_sprite_terminator
+sLugiaGfx74:
+.incbin "baserom.gba", 0x1026534, 0x40
+sLugiaSprites74:
+ax_sprite sLugiaGfx74, 0x40
+ax_sprite_terminator
+sLugiaGfx75:
+.incbin "baserom.gba", 0x1026584, 0x60
+sLugiaGfx75_1:
+.incbin "baserom.gba", 0x10265E4, 0x80
+sLugiaGfx75_2:
+.incbin "baserom.gba", 0x1026664, 0x80
+sLugiaGfx75_3:
+.incbin "baserom.gba", 0x10266E4, 0x60
+sLugiaGfx75_4:
+.incbin "baserom.gba", 0x1026744, 0xA0
+sLugiaGfx75_5:
+.incbin "baserom.gba", 0x10267E4, 0xA0
+sLugiaGfx75_6:
+.incbin "baserom.gba", 0x1026884, 0x80
+sLugiaGfx75_7:
+.incbin "baserom.gba", 0x1026904, 0x60
+sLugiaSprites75:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx75, 0x60
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx75_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx75_2, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx75_3, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx75_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx75_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx75_6, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx75_7, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sLugiaGfx76:
+.incbin "baserom.gba", 0x10269F4, 0x60
+sLugiaGfx76_1:
+.incbin "baserom.gba", 0x1026A54, 0x100
+sLugiaGfx76_2:
+.incbin "baserom.gba", 0x1026B54, 0xE0
+sLugiaGfx76_3:
+.incbin "baserom.gba", 0x1026C34, 0xA0
+sLugiaGfx76_4:
+.incbin "baserom.gba", 0x1026CD4, 0x20
+sLugiaGfx76_5:
+.incbin "baserom.gba", 0x1026CF4, 0xA0
+sLugiaGfx76_6:
+.incbin "baserom.gba", 0x1026D94, 0xA0
+sLugiaGfx76_7:
+.incbin "baserom.gba", 0x1026E34, 0x40
+sLugiaSprites76:
+ax_sprite 0, 0x100
+ax_sprite sLugiaGfx76, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx76_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx76_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx76_3, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx76_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx76_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx76_6, 0xa0
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx76_7, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx77:
+.incbin "baserom.gba", 0x1026F04, 0x40
+sLugiaGfx77_1:
+.incbin "baserom.gba", 0x1026F44, 0x80
+sLugiaGfx77_2:
+.incbin "baserom.gba", 0x1026FC4, 0xA0
+sLugiaGfx77_3:
+.incbin "baserom.gba", 0x1027064, 0xA0
+sLugiaGfx77_4:
+.incbin "baserom.gba", 0x1027104, 0x80
+sLugiaGfx77_5:
+.incbin "baserom.gba", 0x1027184, 0xC0
+sLugiaGfx77_6:
+.incbin "baserom.gba", 0x1027244, 0xA0
+sLugiaGfx77_7:
+.incbin "baserom.gba", 0x10272E4, 0x40
+sLugiaSprites77:
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx77, 0x40
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx77_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx77_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx77_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx77_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx77_5, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx77_6, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx77_7, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLugiaGfx78:
+.incbin "baserom.gba", 0x10273B4, 0x60
+sLugiaGfx78_1:
+.incbin "baserom.gba", 0x1027414, 0xC0
+sLugiaGfx78_2:
+.incbin "baserom.gba", 0x10274D4, 0x120
+sLugiaSprites78:
+ax_sprite 0, 0x140
+ax_sprite sLugiaGfx78, 0x60
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx78_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx78_2, 0x120
+ax_sprite_terminator
+sLugiaGfx79:
+.incbin "baserom.gba", 0x102762C, 0xE0
+sLugiaGfx79_1:
+.incbin "baserom.gba", 0x102770C, 0x20
+sLugiaSprites79:
+ax_sprite sLugiaGfx79, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx79_1, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sLugiaGfx80:
+.incbin "baserom.gba", 0x1027754, 0xC0
+sLugiaGfx80_1:
+.incbin "baserom.gba", 0x1027814, 0x20
+sLugiaSprites80:
+ax_sprite sLugiaGfx80, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx80_1, 0x20
+ax_sprite_terminator
+sLugiaGfx81:
+.incbin "baserom.gba", 0x1027854, 0x20
+sLugiaSprites81:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx81, 0x20
+ax_sprite_terminator
+sLugiaGfx82:
+.incbin "baserom.gba", 0x102788C, 0x40
+sLugiaGfx82_1:
+.incbin "baserom.gba", 0x10278CC, 0xA0
+sLugiaGfx82_2:
+.incbin "baserom.gba", 0x102796C, 0xA0
+sLugiaGfx82_3:
+.incbin "baserom.gba", 0x1027A0C, 0x80
+sLugiaGfx82_4:
+.incbin "baserom.gba", 0x1027A8C, 0x80
+sLugiaGfx82_5:
+.incbin "baserom.gba", 0x1027B0C, 0x80
+sLugiaGfx82_6:
+.incbin "baserom.gba", 0x1027B8C, 0xA0
+sLugiaGfx82_7:
+.incbin "baserom.gba", 0x1027C2C, 0x20
+sLugiaGfx82_8:
+.incbin "baserom.gba", 0x1027C4C, 0x60
+sLugiaSprites82:
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx82, 0x40
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx82_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx82_2, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx82_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx82_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx82_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx82_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx82_7, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx82_8, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx83:
+.incbin "baserom.gba", 0x1027D4C, 0x20
+sLugiaGfx83_1:
+.incbin "baserom.gba", 0x1027D6C, 0x60
+sLugiaGfx83_2:
+.incbin "baserom.gba", 0x1027DCC, 0x60
+sLugiaGfx83_3:
+.incbin "baserom.gba", 0x1027E2C, 0x1A0
+sLugiaSprites83:
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx83, 0x20
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx83_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx83_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx83_3, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx84:
+.incbin "baserom.gba", 0x102801C, 0x40
+sLugiaSprites84:
+ax_sprite sLugiaGfx84, 0x40
+ax_sprite_terminator
+sLugiaGfx85:
+.incbin "baserom.gba", 0x102806C, 0x80
+sLugiaGfx85_1:
+.incbin "baserom.gba", 0x10280EC, 0x20
+sLugiaSprites85:
+ax_sprite sLugiaGfx85, 0x80
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx85_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx86:
+.incbin "baserom.gba", 0x1028134, 0x100
+sLugiaSprites86:
+ax_sprite sLugiaGfx86, 0x100
+ax_sprite_terminator
+sLugiaGfx87:
+.incbin "baserom.gba", 0x1028244, 0x40
+sLugiaSprites87:
+ax_sprite sLugiaGfx87, 0x40
+ax_sprite_terminator
+sLugiaGfx88:
+.incbin "baserom.gba", 0x1028294, 0x80
+sLugiaGfx88_1:
+.incbin "baserom.gba", 0x1028314, 0x80
+sLugiaGfx88_2:
+.incbin "baserom.gba", 0x1028394, 0x80
+sLugiaGfx88_3:
+.incbin "baserom.gba", 0x1028414, 0x80
+sLugiaGfx88_4:
+.incbin "baserom.gba", 0x1028494, 0x80
+sLugiaGfx88_5:
+.incbin "baserom.gba", 0x1028514, 0x80
+sLugiaGfx88_6:
+.incbin "baserom.gba", 0x1028594, 0x40
+sLugiaGfx88_7:
+.incbin "baserom.gba", 0x10285D4, 0x60
+sLugiaSprites88:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx88, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx88_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx88_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx88_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx88_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx88_5, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx88_6, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx88_7, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sLugiaGfx89:
+.incbin "baserom.gba", 0x10286C4, 0x40
+sLugiaGfx89_1:
+.incbin "baserom.gba", 0x1028704, 0x60
+sLugiaGfx89_2:
+.incbin "baserom.gba", 0x1028764, 0x220
+sLugiaGfx89_3:
+.incbin "baserom.gba", 0x1028984, 0xA0
+sLugiaSprites89:
+ax_sprite sLugiaGfx89, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx89_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx89_2, 0x220
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx89_3, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx90:
+.incbin "baserom.gba", 0x1028A6C, 0x40
+sLugiaGfx90_1:
+.incbin "baserom.gba", 0x1028AAC, 0x20
+sLugiaGfx90_2:
+.incbin "baserom.gba", 0x1028ACC, 0x20
+sLugiaSprites90:
+ax_sprite sLugiaGfx90, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx90_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx90_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx91:
+.incbin "baserom.gba", 0x1028B24, 0x60
+sLugiaGfx91_1:
+.incbin "baserom.gba", 0x1028B84, 0x60
+sLugiaSprites91:
+ax_sprite sLugiaGfx91, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx91_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx92:
+.incbin "baserom.gba", 0x1028C0C, 0x20
+sLugiaSprites92:
+ax_sprite sLugiaGfx92, 0x20
+ax_sprite_terminator
+sLugiaGfx93:
+.incbin "baserom.gba", 0x1028C3C, 0x40
+sLugiaSprites93:
+ax_sprite sLugiaGfx93, 0x40
+ax_sprite_terminator
+sLugiaGfx94:
+.incbin "baserom.gba", 0x1028C8C, 0x40
+sLugiaGfx94_1:
+.incbin "baserom.gba", 0x1028CCC, 0x60
+sLugiaGfx94_2:
+.incbin "baserom.gba", 0x1028D2C, 0x60
+sLugiaGfx94_3:
+.incbin "baserom.gba", 0x1028D8C, 0x80
+sLugiaGfx94_4:
+.incbin "baserom.gba", 0x1028E0C, 0xC0
+sLugiaGfx94_5:
+.incbin "baserom.gba", 0x1028ECC, 0xE0
+sLugiaGfx94_6:
+.incbin "baserom.gba", 0x1028FAC, 0xA0
+sLugiaSprites94:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx94, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx94_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx94_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx94_3, 0x80
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx94_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx94_5, 0xe0
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx94_6, 0xa0
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sLugiaGfx95:
+.incbin "baserom.gba", 0x10290CC, 0x40
+sLugiaGfx95_1:
+.incbin "baserom.gba", 0x102910C, 0x80
+sLugiaGfx95_2:
+.incbin "baserom.gba", 0x102918C, 0x80
+sLugiaGfx95_3:
+.incbin "baserom.gba", 0x102920C, 0x80
+sLugiaGfx95_4:
+.incbin "baserom.gba", 0x102928C, 0xC0
+sLugiaGfx95_5:
+.incbin "baserom.gba", 0x102934C, 0xE0
+sLugiaGfx95_6:
+.incbin "baserom.gba", 0x102942C, 0xA0
+sLugiaSprites95:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx95, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx95_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx95_2, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx95_3, 0x80
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx95_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx95_5, 0xe0
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx95_6, 0xa0
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sLugiaGfx96:
+.incbin "baserom.gba", 0x102954C, 0x40
+sLugiaSprites96:
+ax_sprite sLugiaGfx96, 0x40
+ax_sprite_terminator
+sLugiaGfx97:
+.incbin "baserom.gba", 0x102959C, 0x40
+sLugiaSprites97:
+ax_sprite sLugiaGfx97, 0x40
+ax_sprite_terminator
+sLugiaGfx98:
+.incbin "baserom.gba", 0x10295EC, 0x140
+sLugiaGfx98_1:
+.incbin "baserom.gba", 0x102972C, 0x20
+sLugiaSprites98:
+ax_sprite sLugiaGfx98, 0x140
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx98_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sLugiaGfx99:
+.incbin "baserom.gba", 0x1029774, 0x60
+sLugiaGfx99_1:
+.incbin "baserom.gba", 0x10297D4, 0x300
+sLugiaSprites99:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx99, 0x60
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx99_1, 0x300
+ax_sprite_terminator
+sLugiaGfx100:
+.incbin "baserom.gba", 0x1029AFC, 0x40
+sLugiaGfx100_1:
+.incbin "baserom.gba", 0x1029B3C, 0x40
+sLugiaGfx100_2:
+.incbin "baserom.gba", 0x1029B7C, 0x120
+sLugiaGfx100_3:
+.incbin "baserom.gba", 0x1029C9C, 0x160
+sLugiaGfx100_4:
+.incbin "baserom.gba", 0x1029DFC, 0x40
+sLugiaSprites100:
+ax_sprite sLugiaGfx100, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx100_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx100_2, 0x120
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx100_3, 0x160
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx100_4, 0x40
+ax_sprite_terminator
+sLugiaGfx101:
+.incbin "baserom.gba", 0x1029E8C, 0x20
+sLugiaSprites101:
+ax_sprite sLugiaGfx101, 0x20
+ax_sprite_terminator
+sLugiaGfx102:
+.incbin "baserom.gba", 0x1029EBC, 0x40
+sLugiaSprites102:
+ax_sprite sLugiaGfx102, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx103:
+.incbin "baserom.gba", 0x1029F14, 0xE0
+sLugiaSprites103:
+ax_sprite sLugiaGfx103, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx104:
+.incbin "baserom.gba", 0x102A00C, 0x40
+sLugiaGfx104_1:
+.incbin "baserom.gba", 0x102A04C, 0x100
+sLugiaSprites104:
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx104, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx104_1, 0x100
+ax_sprite_terminator
+sLugiaGfx105:
+.incbin "baserom.gba", 0x102A174, 0x60
+sLugiaGfx105_1:
+.incbin "baserom.gba", 0x102A1D4, 0xC0
+sLugiaGfx105_2:
+.incbin "baserom.gba", 0x102A294, 0xA0
+sLugiaGfx105_3:
+.incbin "baserom.gba", 0x102A334, 0x280
+sLugiaGfx105_4:
+.incbin "baserom.gba", 0x102A5B4, 0x40
+sLugiaGfx105_5:
+.incbin "baserom.gba", 0x102A5F4, 0xC0
+sLugiaGfx105_6:
+.incbin "baserom.gba", 0x102A6B4, 0x40
+sLugiaSprites105:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx105, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx105_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx105_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx105_3, 0x280
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx105_4, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx105_5, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx105_6, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx106:
+.incbin "baserom.gba", 0x102A774, 0x280
+sLugiaGfx106_1:
+.incbin "baserom.gba", 0x102A9F4, 0xE0
+sLugiaGfx106_2:
+.incbin "baserom.gba", 0x102AAD4, 0xC0
+sLugiaGfx106_3:
+.incbin "baserom.gba", 0x102AB94, 0xC0
+sLugiaGfx106_4:
+.incbin "baserom.gba", 0x102AC54, 0x80
+sLugiaSprites106:
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx106, 0x280
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx106_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx106_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx106_3, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx106_4, 0x80
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sLugiaGfx107:
+.incbin "baserom.gba", 0x102AD34, 0x40
+sLugiaGfx107_1:
+.incbin "baserom.gba", 0x102AD74, 0x40
+sLugiaGfx107_2:
+.incbin "baserom.gba", 0x102ADB4, 0x240
+sLugiaGfx107_3:
+.incbin "baserom.gba", 0x102AFF4, 0xC0
+sLugiaSprites107:
+ax_sprite sLugiaGfx107, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx107_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx107_2, 0x240
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx107_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx108:
+.incbin "baserom.gba", 0x102B0FC, 0x20
+sLugiaSprites108:
+ax_sprite sLugiaGfx108, 0x20
+ax_sprite_terminator
+sLugiaGfx109:
+.incbin "baserom.gba", 0x102B12C, 0x100
+sLugiaGfx109_1:
+.incbin "baserom.gba", 0x102B22C, 0x40
+sLugiaGfx109_2:
+.incbin "baserom.gba", 0x102B26C, 0x40
+sLugiaSprites109:
+ax_sprite sLugiaGfx109, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx109_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx109_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx110:
+.incbin "baserom.gba", 0x102B2E4, 0x60
+sLugiaGfx110_1:
+.incbin "baserom.gba", 0x102B344, 0x60
+sLugiaGfx110_2:
+.incbin "baserom.gba", 0x102B3A4, 0x40
+sLugiaGfx110_3:
+.incbin "baserom.gba", 0x102B3E4, 0x80
+sLugiaGfx110_4:
+.incbin "baserom.gba", 0x102B464, 0xC0
+sLugiaGfx110_5:
+.incbin "baserom.gba", 0x102B524, 0xE0
+sLugiaGfx110_6:
+.incbin "baserom.gba", 0x102B604, 0x100
+sLugiaGfx110_7:
+.incbin "baserom.gba", 0x102B704, 0x40
+sLugiaGfx110_8:
+.incbin "baserom.gba", 0x102B744, 0x40
+sLugiaSprites110:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx110, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx110_1, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx110_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx110_3, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx110_4, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx110_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx110_6, 0x100
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx110_7, 0x40
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx110_8, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx111:
+.incbin "baserom.gba", 0x102B824, 0x40
+sLugiaGfx111_1:
+.incbin "baserom.gba", 0x102B864, 0x40
+sLugiaGfx111_2:
+.incbin "baserom.gba", 0x102B8A4, 0x60
+sLugiaGfx111_3:
+.incbin "baserom.gba", 0x102B904, 0x80
+sLugiaGfx111_4:
+.incbin "baserom.gba", 0x102B984, 0xA0
+sLugiaGfx111_5:
+.incbin "baserom.gba", 0x102BA24, 0xC0
+sLugiaGfx111_6:
+.incbin "baserom.gba", 0x102BAE4, 0xC0
+sLugiaGfx111_7:
+.incbin "baserom.gba", 0x102BBA4, 0x60
+sLugiaSprites111:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx111, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx111_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx111_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx111_3, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx111_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx111_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx111_6, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx111_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx112:
+.incbin "baserom.gba", 0x102BC94, 0x40
+sLugiaGfx112_1:
+.incbin "baserom.gba", 0x102BCD4, 0x60
+sLugiaGfx112_2:
+.incbin "baserom.gba", 0x102BD34, 0x60
+sLugiaGfx112_3:
+.incbin "baserom.gba", 0x102BD94, 0x80
+sLugiaGfx112_4:
+.incbin "baserom.gba", 0x102BE14, 0xA0
+sLugiaGfx112_5:
+.incbin "baserom.gba", 0x102BEB4, 0xC0
+sLugiaGfx112_6:
+.incbin "baserom.gba", 0x102BF74, 0xA0
+sLugiaGfx112_7:
+.incbin "baserom.gba", 0x102C014, 0x60
+sLugiaSprites112:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx112, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx112_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx112_2, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx112_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx112_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx112_5, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx112_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx112_7, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx113:
+.incbin "baserom.gba", 0x102C104, 0x40
+sLugiaGfx113_1:
+.incbin "baserom.gba", 0x102C144, 0x60
+sLugiaGfx113_2:
+.incbin "baserom.gba", 0x102C1A4, 0x80
+sLugiaGfx113_3:
+.incbin "baserom.gba", 0x102C224, 0x80
+sLugiaGfx113_4:
+.incbin "baserom.gba", 0x102C2A4, 0xA0
+sLugiaGfx113_5:
+.incbin "baserom.gba", 0x102C344, 0xE0
+sLugiaGfx113_6:
+.incbin "baserom.gba", 0x102C424, 0xE0
+sLugiaGfx113_7:
+.incbin "baserom.gba", 0x102C504, 0x40
+sLugiaGfx113_8:
+.incbin "baserom.gba", 0x102C544, 0x40
+sLugiaSprites113:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx113, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx113_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx113_2, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx113_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx113_4, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx113_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx113_6, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx113_7, 0x40
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx113_8, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx114:
+.incbin "baserom.gba", 0x102C624, 0x60
+sLugiaGfx114_1:
+.incbin "baserom.gba", 0x102C684, 0x40
+sLugiaGfx114_2:
+.incbin "baserom.gba", 0x102C6C4, 0x40
+sLugiaGfx114_3:
+.incbin "baserom.gba", 0x102C704, 0x80
+sLugiaGfx114_4:
+.incbin "baserom.gba", 0x102C784, 0xC0
+sLugiaGfx114_5:
+.incbin "baserom.gba", 0x102C844, 0x200
+sLugiaGfx114_6:
+.incbin "baserom.gba", 0x102CA44, 0x80
+sLugiaSprites114:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx114, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx114_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx114_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx114_3, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx114_4, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx114_5, 0x200
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx114_6, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx115:
+.incbin "baserom.gba", 0x102CB44, 0x60
+sLugiaGfx115_1:
+.incbin "baserom.gba", 0x102CBA4, 0x60
+sLugiaGfx115_2:
+.incbin "baserom.gba", 0x102CC04, 0x40
+sLugiaGfx115_3:
+.incbin "baserom.gba", 0x102CC44, 0x80
+sLugiaGfx115_4:
+.incbin "baserom.gba", 0x102CCC4, 0xC0
+sLugiaGfx115_5:
+.incbin "baserom.gba", 0x102CD84, 0x200
+sLugiaSprites115:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx115, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx115_1, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx115_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx115_3, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx115_4, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx115_5, 0x200
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sLugiaGfx116:
+.incbin "baserom.gba", 0x102CFF4, 0x40
+sLugiaGfx116_1:
+.incbin "baserom.gba", 0x102D034, 0x40
+sLugiaGfx116_2:
+.incbin "baserom.gba", 0x102D074, 0x60
+sLugiaGfx116_3:
+.incbin "baserom.gba", 0x102D0D4, 0x80
+sLugiaGfx116_4:
+.incbin "baserom.gba", 0x102D154, 0xA0
+sLugiaGfx116_5:
+.incbin "baserom.gba", 0x102D1F4, 0xC0
+sLugiaGfx116_6:
+.incbin "baserom.gba", 0x102D2B4, 0xC0
+sLugiaGfx116_7:
+.incbin "baserom.gba", 0x102D374, 0x60
+sLugiaSprites116:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx116, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx116_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx116_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx116_3, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx116_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx116_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx116_6, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx116_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx117:
+.incbin "baserom.gba", 0x102D464, 0x60
+sLugiaGfx117_1:
+.incbin "baserom.gba", 0x102D4C4, 0x60
+sLugiaGfx117_2:
+.incbin "baserom.gba", 0x102D524, 0x60
+sLugiaGfx117_3:
+.incbin "baserom.gba", 0x102D584, 0x80
+sLugiaGfx117_4:
+.incbin "baserom.gba", 0x102D604, 0xA0
+sLugiaGfx117_5:
+.incbin "baserom.gba", 0x102D6A4, 0xC0
+sLugiaGfx117_6:
+.incbin "baserom.gba", 0x102D764, 0xA0
+sLugiaGfx117_7:
+.incbin "baserom.gba", 0x102D804, 0x60
+sLugiaSprites117:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx117, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx117_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx117_2, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx117_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx117_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx117_5, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx117_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx117_7, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLugiaGfx118:
+.incbin "baserom.gba", 0x102D8F4, 0x60
+sLugiaGfx118_1:
+.incbin "baserom.gba", 0x102D954, 0x60
+sLugiaGfx118_2:
+.incbin "baserom.gba", 0x102D9B4, 0x80
+sLugiaGfx118_3:
+.incbin "baserom.gba", 0x102DA34, 0x80
+sLugiaGfx118_4:
+.incbin "baserom.gba", 0x102DAB4, 0xA0
+sLugiaGfx118_5:
+.incbin "baserom.gba", 0x102DB54, 0xE0
+sLugiaGfx118_6:
+.incbin "baserom.gba", 0x102DC34, 0xE0
+sLugiaGfx118_7:
+.incbin "baserom.gba", 0x102DD14, 0x60
+sLugiaGfx118_8:
+.incbin "baserom.gba", 0x102DD74, 0x40
+sLugiaSprites118:
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx118, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx118_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx118_2, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx118_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sLugiaGfx118_4, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx118_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx118_6, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx118_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx118_8, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLugiaGfx119:
+.incbin "baserom.gba", 0x102DE54, 0x60
+sLugiaGfx119_1:
+.incbin "baserom.gba", 0x102DEB4, 0x60
+sLugiaGfx119_2:
+.incbin "baserom.gba", 0x102DF14, 0x40
+sLugiaGfx119_3:
+.incbin "baserom.gba", 0x102DF54, 0x80
+sLugiaGfx119_4:
+.incbin "baserom.gba", 0x102DFD4, 0xC0
+sLugiaGfx119_5:
+.incbin "baserom.gba", 0x102E094, 0x200
+sLugiaGfx119_6:
+.incbin "baserom.gba", 0x102E294, 0x80
+sLugiaSprites119:
+ax_sprite 0, 0x40
+ax_sprite sLugiaGfx119, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx119_1, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sLugiaGfx119_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sLugiaGfx119_3, 0x80
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx119_4, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sLugiaGfx119_5, 0x200
+ax_sprite 0, 0x60
+ax_sprite sLugiaGfx119_6, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAxPosesLugia:
+.4byte sLugiaPose1
+.4byte sLugiaPose2
+.4byte sLugiaPose3
+.4byte sLugiaPose4
+.4byte sLugiaPose5
+.4byte sLugiaPose6
+.4byte sLugiaPose7
+.4byte sLugiaPose8
+.4byte sLugiaPose9
+.4byte sLugiaPose10
+.4byte sLugiaPose11
+.4byte sLugiaPose12
+.4byte sLugiaPose13
+.4byte sLugiaPose14
+.4byte sLugiaPose15
+.4byte sLugiaPose16
+.4byte sLugiaPose17
+.4byte sLugiaPose18
+.4byte sLugiaPose19
+.4byte sLugiaPose20
+.4byte sLugiaPose21
+.4byte sLugiaPose22
+.4byte sLugiaPose23
+.4byte sLugiaPose24
+.4byte sLugiaPose25
+.4byte sLugiaPose26
+.4byte sLugiaPose27
+.4byte sLugiaPose28
+.4byte sLugiaPose29
+.4byte sLugiaPose30
+.4byte sLugiaPose31
+.4byte sLugiaPose32
+.4byte sLugiaPose33
+.4byte sLugiaPose34
+.4byte sLugiaPose35
+.4byte sLugiaPose36
+.4byte sLugiaPose37
+.4byte sLugiaPose38
+.4byte sLugiaPose39
+.4byte sLugiaPose40
+.4byte sLugiaPose41
+.4byte sLugiaPose42
+.4byte sLugiaPose43
+.4byte sLugiaPose44
+.4byte sLugiaPose45
+.4byte sLugiaPose46
+.4byte sLugiaPose47
+.4byte sLugiaPose48
+.4byte sLugiaPose49
+.4byte sLugiaPose50
+.4byte sLugiaPose51
+.4byte sLugiaPose52
+.4byte sLugiaPose53
+.4byte sLugiaPose54
+.4byte sLugiaPose55
+.4byte sLugiaPose56
+.4byte sLugiaPose57
+.4byte sLugiaPose58
+.4byte sLugiaPose59
+.4byte sLugiaPose60
+.4byte sLugiaPose61
+.4byte sLugiaPose62
+.4byte sLugiaPose63
+.4byte sLugiaPose64
+.4byte sLugiaPose65
+.4byte sLugiaPose66
+.4byte sLugiaPose67
+.4byte sLugiaPose68
+.4byte sLugiaPose69
+.4byte sLugiaPose70
+.4byte sLugiaPose71
+.4byte sLugiaPose72
+.4byte sLugiaPose73
+.4byte sLugiaPose74
+.4byte sLugiaPose75
+.4byte sLugiaPose76
+.4byte sLugiaPose77
+.4byte sLugiaPose78
+.4byte sLugiaPose79
+.4byte sLugiaPose80
+.4byte sLugiaPose81
+.4byte sLugiaPose82
+.4byte sLugiaPose83
+.4byte sLugiaPose84
+.4byte sLugiaPose85
+.4byte sLugiaPose86
+.4byte sLugiaPose87
+.4byte sLugiaPose88
+.4byte sLugiaPose89
+.4byte sLugiaPose90
+.4byte sLugiaPose91
+.4byte sLugiaPose92
+.4byte sLugiaPose93
+.4byte sLugiaPose94
+.4byte sLugiaPose95
+.4byte sLugiaPose96
+.4byte sLugiaPose97
+.4byte sLugiaPose98
+.4byte sLugiaPose99
+.4byte sLugiaPose100
+.4byte sLugiaPose101
+.4byte sLugiaPose102
+.4byte sLugiaPose103
+.4byte sLugiaPose104
+.4byte sLugiaPose105
+.4byte sLugiaPose106
+.4byte sLugiaPose107
+.4byte sLugiaPose108
+.4byte sLugiaPose109
+.4byte sLugiaPose110
+.4byte sLugiaPose111
+.4byte sLugiaPose112
+.4byte sLugiaPose113
+.4byte sLugiaPose114
+.4byte sLugiaPose115
+.4byte sLugiaPose116
+.4byte sLugiaPose117
+.4byte sLugiaPose118
+.4byte sLugiaPose119
+.4byte sLugiaPose120
+.4byte sLugiaPose121
+.4byte sLugiaPose122
+.4byte sLugiaPose123
+.4byte sLugiaPose124
+.4byte sLugiaPose125
+.4byte sLugiaPose126
+.4byte sLugiaPose127
+.4byte sLugiaPose128
+.4byte sLugiaPose129
+.4byte sLugiaPose130
+.4byte sLugiaPose131
+.4byte sLugiaPose132
+.4byte sLugiaPose133
+.4byte sLugiaPose134
+.4byte sLugiaPose135
+.4byte sLugiaPose136
+.4byte sLugiaPose137
+.4byte sLugiaPose138
+.4byte sLugiaPose139
+.4byte sLugiaPose140
+.4byte sLugiaPose141
+.4byte sLugiaPose142
+.4byte sLugiaPose143
+.4byte sLugiaPose144
+.4byte sLugiaPose145
+.4byte sLugiaPose146
+.4byte sLugiaPose147
+.4byte sLugiaPose148
+.4byte sLugiaPose149
+.4byte sLugiaPose150
+.4byte sLugiaPose151
+.4byte sLugiaPose152
+.4byte sLugiaPose153
+.4byte sLugiaPose154
+.4byte sLugiaPose155
+.4byte sLugiaPose156
+.4byte sLugiaPose157
+.4byte sLugiaPose158
+.4byte sLugiaPose159
+.4byte sLugiaPose160
+.4byte sLugiaPose161
+.4byte sLugiaPose162
+.4byte sLugiaPose163
+.4byte sLugiaPose164
+.4byte sLugiaPose165
+.4byte sLugiaPose166
+.4byte sLugiaPose167
+.4byte sLugiaPose168
+.4byte sLugiaPose169
+.4byte sLugiaPose170
+.4byte sLugiaPose171
+.4byte sLugiaPose172
+.4byte sLugiaPose173
+.4byte sLugiaPose174
+.4byte sLugiaPose175
+.4byte sLugiaPose176
+.4byte sLugiaPose177
+.4byte sLugiaPose178
+.4byte sLugiaPose179
+.4byte sLugiaPose180
+.4byte sLugiaPose181
+.4byte sLugiaPose182
+.4byte sLugiaPose183
+.4byte sLugiaPose184
+.4byte sLugiaPose185
+.4byte sLugiaPose186
+.4byte sLugiaPose187
+.4byte sLugiaPose188
+.4byte sLugiaPose189
+.4byte sLugiaPose190
+.4byte sLugiaPose191
+.4byte sLugiaPose192
+.4byte sLugiaPose193
+.4byte sLugiaPose194
+.4byte sLugiaPose195
+.4byte sLugiaPose196
+.4byte sLugiaPose197
+.4byte sLugiaPose198
+.4byte sLugiaPose199
+.4byte sLugiaPose200
+.4byte sLugiaPose201
+.4byte sLugiaPose202
+.4byte sLugiaPose203
+.4byte sLugiaPose204
+.4byte sLugiaPose205
+.4byte sLugiaPose206
+.4byte sLugiaPose207
+.4byte sLugiaPose208
+.4byte sLugiaPose209
+.4byte sLugiaPose210
+.4byte sLugiaPose211
+.4byte sLugiaPose212
+.4byte sLugiaPose213
+.4byte sLugiaPose214
+.4byte sLugiaPose215
+.4byte sLugiaPose216
+.4byte sLugiaPose217
+.4byte sLugiaPose218
+.4byte sLugiaPose219
+.4byte sLugiaPose220
+.4byte sLugiaPose221
+.4byte sLugiaPose222
+.4byte sLugiaPose223
+.4byte sLugiaPose224
+sAxPositionsLugia:
+.2byte   -1,  -25, 	 -32,  -29, 	  30,  -29, 	  -1,  -17
+.2byte   -1,  -25, 	 -32,  -28, 	  30,  -28, 	  -1,  -17
+.2byte   17,  -25, 	  25,  -33, 	 -23,  -29, 	   2,  -18
+.2byte   17,  -25, 	  25,  -32, 	 -24,  -29, 	   2,  -18
+.2byte   28,  -28, 	   5,  -36, 	  -7,  -25, 	   0,  -17
+.2byte   28,  -28, 	   5,  -35, 	  -7,  -24, 	   0,  -17
+.2byte   23,  -37, 	 -14,  -38, 	  30,  -18, 	   0,  -23
+.2byte   23,  -37, 	 -14,  -36, 	  30,  -17, 	   0,  -23
+.2byte   -1,  -40, 	  28,  -35, 	 -30,  -35, 	  -1,  -20
+.2byte   -1,  -39, 	  28,  -33, 	 -30,  -33, 	  -1,  -20
+.2byte  -24,  -37, 	  13,  -38, 	 -31,  -18, 	  -1,  -23
+.2byte  -24,  -37, 	  13,  -36, 	 -31,  -17, 	  -1,  -23
+.2byte  -29,  -28, 	  -6,  -36, 	   6,  -25, 	  -1,  -17
+.2byte  -29,  -28, 	  -6,  -35, 	   6,  -24, 	  -1,  -17
+.2byte  -18,  -25, 	 -26,  -33, 	  22,  -29, 	  -3,  -18
+.2byte  -18,  -25, 	 -26,  -32, 	  23,  -29, 	  -3,  -18
+.2byte   -1,  -25, 	 -32,  -29, 	  30,  -29, 	  -1,  -17
+.2byte   -1,  -25, 	 -32,  -28, 	  30,  -28, 	  -1,  -17
+.2byte   -1,  -24, 	 -29,  -38, 	  27,  -38, 	  -1,  -18
+.2byte   -1,  -26, 	 -23,   -2, 	  22,   -2, 	  -1,  -17
+.2byte   17,  -25, 	  25,  -33, 	 -23,  -29, 	   2,  -18
+.2byte   17,  -25, 	  25,  -32, 	 -24,  -29, 	   2,  -18
+.2byte   17,  -22, 	  23,  -37, 	 -21,  -35, 	   1,  -17
+.2byte   15,  -28, 	  18,   -8, 	 -15,   -3, 	   1,  -19
+.2byte   28,  -28, 	   5,  -36, 	  -7,  -25, 	   0,  -17
+.2byte   28,  -28, 	   5,  -35, 	  -7,  -24, 	   0,  -17
+.2byte   28,  -25, 	   5,  -38, 	  -9,  -29, 	  -2,  -16
+.2byte   27,  -30, 	  12,  -10, 	  -2,   -3, 	  -2,  -17
+.2byte   23,  -37, 	 -14,  -38, 	  30,  -18, 	   0,  -23
+.2byte   23,  -37, 	 -14,  -36, 	  30,  -17, 	   0,  -23
+.2byte   24,  -33, 	 -10,  -45, 	  28,  -26, 	   2,  -21
+.2byte   23,  -40, 	 -10,  -24, 	  23,   -8, 	   1,  -23
+.2byte   -1,  -40, 	  28,  -35, 	 -30,  -35, 	  -1,  -20
+.2byte   -1,  -39, 	  28,  -33, 	 -30,  -33, 	  -1,  -20
+.2byte   -1,  -37, 	  24,  -39, 	 -26,  -39, 	  -1,  -20
+.2byte   -1,  -43, 	  21,  -14, 	 -23,  -14, 	  -1,  -22
+.2byte  -24,  -37, 	  13,  -38, 	 -31,  -18, 	  -1,  -23
+.2byte  -24,  -37, 	  13,  -36, 	 -31,  -17, 	  -1,  -23
+.2byte  -25,  -33, 	   9,  -45, 	 -29,  -26, 	  -3,  -21
+.2byte  -24,  -40, 	   9,  -24, 	 -24,   -8, 	  -2,  -23
+.2byte  -29,  -28, 	  -6,  -36, 	   6,  -25, 	  -1,  -17
+.2byte  -29,  -28, 	  -6,  -35, 	   6,  -24, 	  -1,  -17
+.2byte  -29,  -25, 	  -6,  -38, 	   8,  -29, 	   1,  -16
+.2byte  -28,  -30, 	 -13,  -10, 	   1,   -3, 	   1,  -17
+.2byte  -18,  -25, 	 -26,  -33, 	  22,  -29, 	  -3,  -18
+.2byte  -18,  -25, 	 -26,  -32, 	  23,  -29, 	  -3,  -18
+.2byte  -18,  -22, 	 -24,  -37, 	  20,  -35, 	  -2,  -17
+.2byte  -16,  -28, 	 -19,   -8, 	  14,   -3, 	  -2,  -19
+.2byte   -1,  -25, 	 -32,  -29, 	  30,  -29, 	  -1,  -17
+.2byte   -1,  -25, 	 -32,  -28, 	  30,  -28, 	  -1,  -17
+.2byte   -1,  -24, 	 -29,  -38, 	  27,  -38, 	  -1,  -18
+.2byte   -1,  -26, 	 -23,   -2, 	  22,   -2, 	  -1,  -17
+.2byte   17,  -25, 	  25,  -33, 	 -23,  -29, 	   2,  -18
+.2byte   17,  -25, 	  25,  -32, 	 -24,  -29, 	   2,  -18
+.2byte   17,  -22, 	  23,  -37, 	 -21,  -35, 	   1,  -17
+.2byte   15,  -28, 	  18,   -8, 	 -15,   -3, 	   1,  -19
+.2byte   28,  -28, 	   5,  -36, 	  -7,  -25, 	   0,  -17
+.2byte   28,  -28, 	   5,  -35, 	  -7,  -24, 	   0,  -17
+.2byte   28,  -25, 	   5,  -38, 	  -9,  -29, 	  -2,  -16
+.2byte   27,  -30, 	  12,  -10, 	  -2,   -3, 	  -2,  -17
+.2byte   23,  -37, 	 -14,  -38, 	  30,  -18, 	   0,  -23
+.2byte   23,  -37, 	 -14,  -36, 	  30,  -17, 	   0,  -23
+.2byte   24,  -33, 	 -10,  -45, 	  28,  -26, 	   2,  -21
+.2byte   23,  -40, 	 -10,  -24, 	  23,   -8, 	   1,  -23
+.2byte   -1,  -40, 	  28,  -35, 	 -30,  -35, 	  -1,  -20
+.2byte   -1,  -39, 	  28,  -33, 	 -30,  -33, 	  -1,  -20
+.2byte   -1,  -37, 	  24,  -39, 	 -26,  -39, 	  -1,  -20
+.2byte   -1,  -43, 	  21,  -14, 	 -23,  -14, 	  -1,  -22
+.2byte  -24,  -37, 	  13,  -38, 	 -31,  -18, 	  -1,  -23
+.2byte  -24,  -37, 	  13,  -36, 	 -31,  -17, 	  -1,  -23
+.2byte  -25,  -33, 	   9,  -45, 	 -29,  -26, 	  -3,  -21
+.2byte  -24,  -40, 	   9,  -24, 	 -24,   -8, 	  -2,  -23
+.2byte  -29,  -28, 	  -6,  -36, 	   6,  -25, 	  -1,  -17
+.2byte  -29,  -28, 	  -6,  -35, 	   6,  -24, 	  -1,  -17
+.2byte  -29,  -25, 	  -6,  -38, 	   8,  -29, 	   1,  -16
+.2byte  -28,  -30, 	 -13,  -10, 	   1,   -3, 	   1,  -17
+.2byte  -18,  -25, 	 -26,  -33, 	  22,  -29, 	  -3,  -18
+.2byte  -18,  -25, 	 -26,  -32, 	  23,  -29, 	  -3,  -18
+.2byte  -18,  -22, 	 -24,  -37, 	  20,  -35, 	  -2,  -17
+.2byte  -16,  -28, 	 -19,   -8, 	  14,   -3, 	  -2,  -19
+.2byte   -1,  -25, 	 -32,  -29, 	  30,  -29, 	  -1,  -17
+.2byte   -1,  -25, 	 -32,  -28, 	  30,  -28, 	  -1,  -17
+.2byte   -1,  -31, 	   6,  -17, 	 -11,  -24, 	  -1,  -14
+.2byte   -1,  -14, 	 -27,  -33, 	  25,  -33, 	  -1,  -17
+.2byte   17,  -25, 	  25,  -33, 	 -23,  -29, 	   2,  -18
+.2byte   17,  -25, 	  25,  -32, 	 -24,  -29, 	   2,  -18
+.2byte   -1,  -41, 	   8,  -30, 	  10,  -38, 	   2,  -20
+.2byte   16,  -20, 	  25,  -36, 	 -20,  -27, 	   3,  -15
+.2byte   28,  -28, 	   5,  -36, 	  -7,  -25, 	   0,  -17
+.2byte   28,  -28, 	   5,  -35, 	  -7,  -24, 	   0,  -17
+.2byte   -2,  -39, 	  14,  -31, 	   9,  -40, 	  -1,  -18
+.2byte   25,  -24, 	   2,  -36, 	  -8,  -26, 	  -1,  -16
+.2byte   23,  -37, 	 -14,  -38, 	  30,  -18, 	   0,  -23
+.2byte   23,  -37, 	 -14,  -36, 	  30,  -17, 	   0,  -23
+.2byte   -1,  -41, 	  11,  -39, 	   3,  -41, 	  -3,  -20
+.2byte   20,  -35, 	 -14,  -40, 	  29,  -20, 	   1,  -21
+.2byte   -1,  -40, 	  28,  -35, 	 -30,  -35, 	  -1,  -20
+.2byte   -1,  -39, 	  28,  -33, 	 -30,  -33, 	  -1,  -20
+.2byte   -1,  -41, 	  -9,  -37, 	   4,  -40, 	  -1,  -18
+.2byte   -1,  -46, 	  26,  -39, 	 -28,  -39, 	  -1,  -25
+.2byte  -24,  -37, 	  13,  -38, 	 -31,  -18, 	  -1,  -23
+.2byte  -24,  -37, 	  13,  -36, 	 -31,  -17, 	  -1,  -23
+.2byte    0,  -41, 	 -12,  -39, 	  -4,  -41, 	   2,  -20
+.2byte  -21,  -35, 	  13,  -40, 	 -30,  -20, 	  -2,  -21
+.2byte  -29,  -28, 	  -6,  -36, 	   6,  -25, 	  -1,  -17
+.2byte  -29,  -28, 	  -6,  -35, 	   6,  -24, 	  -1,  -17
+.2byte    1,  -39, 	 -15,  -31, 	 -10,  -40, 	   0,  -18
+.2byte  -26,  -24, 	  -3,  -36, 	   7,  -26, 	   0,  -16
+.2byte  -18,  -25, 	 -26,  -33, 	  22,  -29, 	  -3,  -18
+.2byte  -18,  -25, 	 -26,  -32, 	  23,  -29, 	  -3,  -18
+.2byte    0,  -41, 	  -9,  -30, 	 -11,  -38, 	  -3,  -20
+.2byte  -17,  -20, 	 -26,  -36, 	  19,  -27, 	  -4,  -15
+.2byte   -1,  -25, 	 -32,  -29, 	  30,  -29, 	  -1,  -17
+.2byte   -1,  -22, 	 -29,  -36, 	  27,  -36, 	  -1,  -16
+.2byte   -1,  -27, 	 -23,   -3, 	  22,   -3, 	  -1,  -18
+.2byte   17,  -25, 	  25,  -33, 	 -23,  -29, 	   2,  -18
+.2byte   17,  -22, 	  23,  -37, 	 -21,  -35, 	   1,  -17
+.2byte   15,  -28, 	  18,   -8, 	 -15,   -3, 	   1,  -19
+.2byte   28,  -28, 	   5,  -36, 	  -7,  -25, 	   0,  -17
+.2byte   28,  -25, 	   5,  -38, 	  -9,  -29, 	  -2,  -16
+.2byte   27,  -30, 	  12,  -10, 	  -2,   -3, 	  -2,  -17
+.2byte   23,  -37, 	 -14,  -38, 	  30,  -18, 	   0,  -23
+.2byte   24,  -33, 	 -10,  -45, 	  28,  -26, 	   2,  -21
+.2byte   23,  -40, 	 -10,  -24, 	  23,   -8, 	   1,  -23
+.2byte   -1,  -40, 	  28,  -35, 	 -30,  -35, 	  -1,  -20
+.2byte   -1,  -37, 	  24,  -39, 	 -26,  -39, 	  -1,  -20
+.2byte   -1,  -43, 	  21,  -14, 	 -23,  -14, 	  -1,  -22
+.2byte  -24,  -37, 	  13,  -38, 	 -31,  -18, 	  -1,  -23
+.2byte  -25,  -33, 	   9,  -45, 	 -29,  -26, 	  -3,  -21
+.2byte  -24,  -40, 	   9,  -24, 	 -24,   -8, 	  -2,  -23
+.2byte  -29,  -28, 	  -6,  -36, 	   6,  -25, 	  -1,  -17
+.2byte  -29,  -25, 	  -6,  -38, 	   8,  -29, 	   1,  -16
+.2byte  -28,  -30, 	 -13,  -10, 	   1,   -3, 	   1,  -17
+.2byte  -18,  -25, 	 -26,  -33, 	  22,  -29, 	  -3,  -18
+.2byte  -18,  -22, 	 -24,  -37, 	  20,  -35, 	  -2,  -17
+.2byte  -16,  -28, 	 -19,   -8, 	  14,   -3, 	  -2,  -19
+.2byte   -8,  -26, 	 -19,   -6, 	  19,    2, 	  -1,  -12
+.2byte   -9,  -25, 	 -19,   -6, 	  19,    2, 	  -1,  -11
+.2byte   -1,  -37, 	 -27,  -37, 	  26,  -37, 	  -1,  -20
+.2byte   -3,  -42, 	  21,  -42, 	 -29,  -30, 	   1,  -21
+.2byte   -3,  -41, 	  -2,  -46, 	 -30,  -28, 	  -1,  -13
+.2byte    0,  -43, 	 -22,  -42, 	  18,  -33, 	  -2,  -14
+.2byte   -1,  -42, 	  21,  -37, 	 -23,  -37, 	  -1,  -17
+.2byte   -1,  -43, 	  21,  -42, 	 -19,  -33, 	   1,  -14
+.2byte    2,  -41, 	   1,  -46, 	  29,  -28, 	   0,  -13
+.2byte    2,  -42, 	 -22,  -42, 	  28,  -30, 	  -2,  -21
+.2byte   -1,  -32, 	 -21,   -3, 	  19,   -3, 	  -1,  -17
+.2byte  -11,  -34, 	 -16,   -9, 	  18,   -2, 	  -3,  -15
+.2byte  -16,  -35, 	   4,  -15, 	  13,   -3, 	  -2,  -17
+.2byte  -13,  -38, 	  17,  -13, 	 -10,   -5, 	   2,  -15
+.2byte   -1,  -42, 	  20,   -7, 	 -22,   -7, 	  -1,  -17
+.2byte   12,  -38, 	 -18,  -13, 	   9,   -5, 	  -3,  -15
+.2byte   15,  -35, 	  -5,  -15, 	 -14,   -3, 	   1,  -17
+.2byte   10,  -34, 	  15,   -9, 	 -19,   -2, 	   2,  -15
+.2byte   -1,  -30, 	 -22,   -3, 	  21,   -4, 	  -1,  -16
+.2byte  -13,  -32, 	 -18,  -10, 	  16,   -4, 	  -3,  -15
+.2byte  -18,  -34, 	   8,  -14, 	  14,   -5, 	   3,  -16
+.2byte  -15,  -37, 	  15,  -15, 	 -12,   -5, 	   6,  -16
+.2byte   -1,  -40, 	  22,   -8, 	 -24,   -8, 	  -1,  -18
+.2byte   14,  -37, 	 -16,  -15, 	  11,   -5, 	  -7,  -16
+.2byte   17,  -34, 	  -9,  -14, 	 -15,   -5, 	  -4,  -16
+.2byte   11,  -33, 	  16,  -11, 	 -18,   -5, 	   1,  -16
+.2byte   -1,  -14, 	 -27,  -33, 	  25,  -33, 	  -1,  -17
+.2byte  -14,  -20, 	 -23,  -36, 	  22,  -27, 	  -1,  -15
+.2byte  -24,  -24, 	  -1,  -36, 	   9,  -26, 	   2,  -16
+.2byte  -17,  -31, 	  17,  -36, 	 -26,  -16, 	   2,  -17
+.2byte   -1,  -38, 	  26,  -31, 	 -28,  -31, 	  -1,  -17
+.2byte   16,  -31, 	 -18,  -36, 	  25,  -16, 	  -3,  -17
+.2byte   23,  -24, 	   0,  -36, 	 -10,  -26, 	  -3,  -16
+.2byte   13,  -20, 	  22,  -36, 	 -23,  -27, 	   0,  -15
+.2byte   -1,  -14, 	 -27,  -33, 	  25,  -33, 	  -1,  -17
+.2byte   -1,  -14, 	 -27,  -33, 	  25,  -33, 	  -1,  -17
+.2byte   13,  -20, 	  22,  -36, 	 -23,  -27, 	   0,  -15
+.2byte   23,  -24, 	   0,  -36, 	 -10,  -26, 	  -3,  -16
+.2byte   16,  -31, 	 -18,  -36, 	  25,  -16, 	  -3,  -17
+.2byte   -1,  -38, 	  26,  -31, 	 -28,  -31, 	  -1,  -17
+.2byte  -17,  -31, 	  17,  -36, 	 -26,  -16, 	   2,  -17
+.2byte  -24,  -24, 	  -1,  -36, 	   9,  -26, 	   2,  -16
+.2byte  -14,  -20, 	 -23,  -36, 	  22,  -27, 	  -1,  -15
+.2byte   -1,  -14, 	 -27,  -33, 	  25,  -33, 	  -1,  -17
+.2byte   -1,  -32, 	 -21,   -3, 	  19,   -3, 	  -1,  -17
+.2byte   -1,  -25, 	 -32,  -29, 	  30,  -29, 	  -1,  -17
+.2byte   -1,  -14, 	 -27,  -33, 	  25,  -33, 	  -1,  -17
+.2byte   10,  -34, 	  15,   -9, 	 -19,   -2, 	   2,  -15
+.2byte   17,  -25, 	  25,  -33, 	 -23,  -29, 	   2,  -18
+.2byte   13,  -20, 	  22,  -36, 	 -23,  -27, 	   0,  -15
+.2byte   15,  -35, 	  -5,  -15, 	 -14,   -3, 	   1,  -17
+.2byte   28,  -28, 	   5,  -36, 	  -7,  -25, 	   0,  -17
+.2byte   25,  -24, 	   2,  -36, 	  -8,  -26, 	  -1,  -16
+.2byte   12,  -38, 	 -18,  -13, 	   9,   -5, 	  -3,  -15
+.2byte   23,  -37, 	 -14,  -38, 	  30,  -18, 	   0,  -23
+.2byte   20,  -35, 	 -14,  -40, 	  29,  -20, 	   1,  -21
+.2byte   -1,  -42, 	  20,   -7, 	 -22,   -7, 	  -1,  -17
+.2byte   -1,  -40, 	  28,  -35, 	 -30,  -35, 	  -1,  -20
+.2byte   -1,  -43, 	  26,  -36, 	 -28,  -36, 	  -1,  -22
+.2byte  -13,  -38, 	  17,  -13, 	 -10,   -5, 	   2,  -15
+.2byte  -24,  -37, 	  13,  -38, 	 -31,  -18, 	  -1,  -23
+.2byte  -21,  -35, 	  13,  -40, 	 -30,  -20, 	  -2,  -21
+.2byte  -16,  -35, 	   4,  -15, 	  13,   -3, 	  -2,  -17
+.2byte  -29,  -28, 	  -6,  -36, 	   6,  -25, 	  -1,  -17
+.2byte  -26,  -24, 	  -3,  -36, 	   7,  -26, 	   0,  -16
+.2byte  -11,  -34, 	 -16,   -9, 	  18,   -2, 	  -3,  -15
+.2byte  -18,  -25, 	 -26,  -33, 	  22,  -29, 	  -3,  -18
+.2byte  -14,  -20, 	 -23,  -36, 	  22,  -27, 	  -1,  -15
+.2byte   -1,  -32, 	 -21,   -3, 	  19,   -3, 	  -1,  -17
+.2byte  -11,  -34, 	 -16,   -9, 	  18,   -2, 	  -3,  -15
+.2byte  -18,  -35, 	   2,  -15, 	  11,   -3, 	  -4,  -17
+.2byte  -14,  -37, 	  16,  -12, 	 -11,   -4, 	   1,  -14
+.2byte   -1,  -42, 	  20,   -7, 	 -22,   -7, 	  -1,  -17
+.2byte   13,  -37, 	 -17,  -12, 	  10,   -4, 	  -2,  -14
+.2byte   17,  -35, 	  -3,  -15, 	 -12,   -3, 	   3,  -17
+.2byte   10,  -34, 	  15,   -9, 	 -19,   -2, 	   2,  -15
+.2byte   -1,  -32, 	 -21,   -3, 	  19,   -3, 	  -1,  -17
+.2byte  -11,  -34, 	 -16,   -9, 	  18,   -2, 	  -3,  -15
+.2byte  -16,  -35, 	   4,  -15, 	  13,   -3, 	  -2,  -17
+.2byte  -13,  -38, 	  17,  -13, 	 -10,   -5, 	   2,  -15
+.2byte   -1,  -42, 	  20,   -7, 	 -22,   -7, 	  -1,  -17
+.2byte   12,  -38, 	 -18,  -13, 	   9,   -5, 	  -3,  -15
+.2byte   15,  -35, 	  -5,  -15, 	 -14,   -3, 	   1,  -17
+.2byte   10,  -34, 	  15,   -9, 	 -19,   -2, 	   2,  -15
+.2byte   -1,  -32, 	 -21,   -3, 	  19,   -3, 	  -1,  -17
+.2byte   -1,  -25, 	 -32,  -29, 	  30,  -29, 	  -1,  -17
+.2byte   -1,  -25, 	 -32,  -28, 	  30,  -28, 	  -1,  -17
+.2byte   -1,  -31, 	   6,  -17, 	 -11,  -24, 	  -1,  -14
+sLugiaAnimTable1:
+.4byte sLugiaAnims_1_1
+.4byte sLugiaAnims_1_2
+.4byte sLugiaAnims_1_3
+.4byte sLugiaAnims_1_4
+.4byte sLugiaAnims_1_5
+.4byte sLugiaAnims_1_6
+.4byte sLugiaAnims_1_7
+.4byte sLugiaAnims_1_8
+sLugiaAnimTable2:
+.4byte sLugiaAnims_2_1
+.4byte sLugiaAnims_2_2
+.4byte sLugiaAnims_2_3
+.4byte sLugiaAnims_2_4
+.4byte sLugiaAnims_2_5
+.4byte sLugiaAnims_2_6
+.4byte sLugiaAnims_2_7
+.4byte sLugiaAnims_2_8
+sLugiaAnimTable3:
+.4byte sLugiaAnims_3_1
+.4byte sLugiaAnims_3_2
+.4byte sLugiaAnims_3_3
+.4byte sLugiaAnims_3_4
+.4byte sLugiaAnims_3_5
+.4byte sLugiaAnims_3_6
+.4byte sLugiaAnims_3_7
+.4byte sLugiaAnims_3_8
+sLugiaAnimTable4:
+.4byte sLugiaAnims_4_1
+.4byte sLugiaAnims_4_2
+.4byte sLugiaAnims_4_3
+.4byte sLugiaAnims_4_4
+.4byte sLugiaAnims_4_5
+.4byte sLugiaAnims_4_6
+.4byte sLugiaAnims_4_7
+.4byte sLugiaAnims_4_8
+sLugiaAnimTable5:
+.4byte sLugiaAnims_5_1
+.4byte sLugiaAnims_5_2
+.4byte sLugiaAnims_5_3
+.4byte sLugiaAnims_5_4
+.4byte sLugiaAnims_5_5
+.4byte sLugiaAnims_5_6
+.4byte sLugiaAnims_5_7
+.4byte sLugiaAnims_5_8
+sLugiaAnimTable6:
+.4byte sLugiaAnims_6_1
+.4byte sLugiaAnims_6_1
+.4byte sLugiaAnims_6_1
+.4byte sLugiaAnims_6_1
+.4byte sLugiaAnims_6_1
+.4byte sLugiaAnims_6_1
+.4byte sLugiaAnims_6_1
+.4byte sLugiaAnims_6_1
+sLugiaAnimTable7:
+.4byte sLugiaAnims_7_1
+.4byte sLugiaAnims_7_2
+.4byte sLugiaAnims_7_3
+.4byte sLugiaAnims_7_4
+.4byte sLugiaAnims_7_5
+.4byte sLugiaAnims_7_6
+.4byte sLugiaAnims_7_7
+.4byte sLugiaAnims_7_8
+sLugiaAnimTable8:
+.4byte sLugiaAnims_8_1
+.4byte sLugiaAnims_8_2
+.4byte sLugiaAnims_8_3
+.4byte sLugiaAnims_8_4
+.4byte sLugiaAnims_8_5
+.4byte sLugiaAnims_8_6
+.4byte sLugiaAnims_8_7
+.4byte sLugiaAnims_8_8
+sLugiaAnimTable9:
+.4byte sLugiaAnims_9_1
+.4byte sLugiaAnims_9_2
+.4byte sLugiaAnims_9_3
+.4byte sLugiaAnims_9_4
+.4byte sLugiaAnims_9_5
+.4byte sLugiaAnims_9_6
+.4byte sLugiaAnims_9_7
+.4byte sLugiaAnims_9_8
+sLugiaAnimTable10:
+.4byte sLugiaAnims_10_1
+.4byte sLugiaAnims_10_2
+.4byte sLugiaAnims_10_3
+.4byte sLugiaAnims_10_4
+.4byte sLugiaAnims_10_5
+.4byte sLugiaAnims_10_6
+.4byte sLugiaAnims_10_7
+.4byte sLugiaAnims_10_8
+sLugiaAnimTable11:
+.4byte sLugiaAnims_11_1
+.4byte sLugiaAnims_11_2
+.4byte sLugiaAnims_11_3
+.4byte sLugiaAnims_11_4
+.4byte sLugiaAnims_11_5
+.4byte sLugiaAnims_11_6
+.4byte sLugiaAnims_11_7
+.4byte sLugiaAnims_11_8
+sLugiaAnimTable12:
+.4byte sLugiaAnims_12_1
+.4byte sLugiaAnims_12_2
+.4byte sLugiaAnims_12_3
+.4byte sLugiaAnims_12_4
+.4byte sLugiaAnims_12_5
+.4byte sLugiaAnims_12_6
+.4byte sLugiaAnims_12_7
+.4byte sLugiaAnims_12_8
+sLugiaAnimTable13:
+.4byte sLugiaAnims_13_1
+.4byte sLugiaAnims_13_2
+.4byte sLugiaAnims_13_3
+.4byte sLugiaAnims_13_4
+.4byte sLugiaAnims_13_5
+.4byte sLugiaAnims_13_6
+.4byte sLugiaAnims_13_7
+.4byte sLugiaAnims_13_8
+sLugiaAnimTable14:
+.4byte sLugiaAnims_14_1
+.4byte sLugiaAnims_14_1
+.4byte sLugiaAnims_14_1
+.4byte sLugiaAnims_14_1
+.4byte sLugiaAnims_14_1
+.4byte sLugiaAnims_14_1
+.4byte sLugiaAnims_14_1
+.4byte sLugiaAnims_14_1
+sAxAnimationsLugia:
+.4byte sLugiaAnimTable1
+.4byte sLugiaAnimTable2
+.4byte sLugiaAnimTable3
+.4byte sLugiaAnimTable4
+.4byte sLugiaAnimTable5
+.4byte sLugiaAnimTable6
+.4byte sLugiaAnimTable7
+.4byte sLugiaAnimTable8
+.4byte sLugiaAnimTable9
+.4byte sLugiaAnimTable10
+.4byte sLugiaAnimTable11
+.4byte sLugiaAnimTable12
+.4byte sLugiaAnimTable13
+.4byte sLugiaAnimTable14
+sAxSpritesLugia:
+.4byte sLugiaSprites1
+.4byte sLugiaSprites2
+.4byte sLugiaSprites3
+.4byte sLugiaSprites4
+.4byte sLugiaSprites5
+.4byte sLugiaSprites6
+.4byte sLugiaSprites7
+.4byte sLugiaSprites8
+.4byte sLugiaSprites9
+.4byte sLugiaSprites10
+.4byte sLugiaSprites11
+.4byte sLugiaSprites12
+.4byte sLugiaSprites13
+.4byte sLugiaSprites14
+.4byte sLugiaSprites15
+.4byte sLugiaSprites16
+.4byte sLugiaSprites17
+.4byte sLugiaSprites18
+.4byte sLugiaSprites19
+.4byte sLugiaSprites20
+.4byte sLugiaSprites21
+.4byte sLugiaSprites22
+.4byte sLugiaSprites23
+.4byte sLugiaSprites24
+.4byte sLugiaSprites25
+.4byte sLugiaSprites26
+.4byte sLugiaSprites27
+.4byte sLugiaSprites28
+.4byte sLugiaSprites29
+.4byte sLugiaSprites30
+.4byte sLugiaSprites31
+.4byte sLugiaSprites32
+.4byte sLugiaSprites33
+.4byte sLugiaSprites34
+.4byte sLugiaSprites35
+.4byte sLugiaSprites36
+.4byte sLugiaSprites37
+.4byte sLugiaSprites38
+.4byte sLugiaSprites39
+.4byte sLugiaSprites40
+.4byte sLugiaSprites41
+.4byte sLugiaSprites42
+.4byte sLugiaSprites43
+.4byte sLugiaSprites44
+.4byte sLugiaSprites45
+.4byte sLugiaSprites46
+.4byte sLugiaSprites47
+.4byte sLugiaSprites48
+.4byte sLugiaSprites49
+.4byte sLugiaSprites50
+.4byte sLugiaSprites51
+.4byte sLugiaSprites52
+.4byte sLugiaSprites53
+.4byte sLugiaSprites54
+.4byte sLugiaSprites55
+.4byte sLugiaSprites56
+.4byte sLugiaSprites57
+.4byte sLugiaSprites58
+.4byte sLugiaSprites59
+.4byte sLugiaSprites60
+.4byte sLugiaSprites61
+.4byte sLugiaSprites62
+.4byte sLugiaSprites63
+.4byte sLugiaSprites64
+.4byte sLugiaSprites65
+.4byte sLugiaSprites66
+.4byte sLugiaSprites67
+.4byte sLugiaSprites68
+.4byte sLugiaSprites69
+.4byte sLugiaSprites70
+.4byte sLugiaSprites71
+.4byte sLugiaSprites72
+.4byte sLugiaSprites73
+.4byte sLugiaSprites74
+.4byte sLugiaSprites75
+.4byte sLugiaSprites76
+.4byte sLugiaSprites77
+.4byte sLugiaSprites78
+.4byte sLugiaSprites79
+.4byte sLugiaSprites80
+.4byte sLugiaSprites81
+.4byte sLugiaSprites82
+.4byte sLugiaSprites83
+.4byte sLugiaSprites84
+.4byte sLugiaSprites85
+.4byte sLugiaSprites86
+.4byte sLugiaSprites87
+.4byte sLugiaSprites88
+.4byte sLugiaSprites89
+.4byte sLugiaSprites90
+.4byte sLugiaSprites91
+.4byte sLugiaSprites92
+.4byte sLugiaSprites93
+.4byte sLugiaSprites94
+.4byte sLugiaSprites95
+.4byte sLugiaSprites96
+.4byte sLugiaSprites97
+.4byte sLugiaSprites98
+.4byte sLugiaSprites99
+.4byte sLugiaSprites100
+.4byte sLugiaSprites101
+.4byte sLugiaSprites102
+.4byte sLugiaSprites103
+.4byte sLugiaSprites104
+.4byte sLugiaSprites105
+.4byte sLugiaSprites106
+.4byte sLugiaSprites107
+.4byte sLugiaSprites108
+.4byte sLugiaSprites109
+.4byte sLugiaSprites110
+.4byte sLugiaSprites111
+.4byte sLugiaSprites112
+.4byte sLugiaSprites113
+.4byte sLugiaSprites114
+.4byte sLugiaSprites115
+.4byte sLugiaSprites116
+.4byte sLugiaSprites117
+.4byte sLugiaSprites118
+.4byte sLugiaSprites119
+sAxMainLugia:
+ax_main sAxPosesLugia, sAxAnimationsLugia, 14, sAxSpritesLugia, sAxPositionsLugia

--- a/data/ax/lunatone.inc
+++ b/data/ax/lunatone.inc
@@ -1,0 +1,2235 @@
+.global gAxLunatone
+gAxLunatone:
+ax_siro sAxMainLunatone
+sLunatonePose1:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose2:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose3:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose4:
+ax_pose 3, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose5:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose6:
+ax_pose 5, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose7:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose8:
+ax_pose 7, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose9:
+ax_pose 8, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose10:
+ax_pose 9, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose11:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose12:
+ax_pose 7, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose13:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose14:
+ax_pose 5, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose15:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose16:
+ax_pose 3, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose17:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose18:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose19:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose20:
+ax_pose 3, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose21:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose22:
+ax_pose 5, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose23:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose24:
+ax_pose 7, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose25:
+ax_pose 8, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose26:
+ax_pose 9, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose27:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose28:
+ax_pose 7, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose29:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose30:
+ax_pose 5, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose31:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose32:
+ax_pose 3, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose33:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose34:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose35:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose36:
+ax_pose 3, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose37:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose38:
+ax_pose 5, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose39:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose40:
+ax_pose 7, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose41:
+ax_pose 8, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose42:
+ax_pose 9, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose43:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose44:
+ax_pose 7, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose45:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose46:
+ax_pose 5, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose47:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose48:
+ax_pose 3, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose49:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose50:
+ax_pose 10, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose51:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose52:
+ax_pose 11, 0x81e7, 0x90f7, 0x0c00
+ax_pose 12, 0x01ef, 0x10ef, 0x0c08
+ax_pose_terminator
+sLunatonePose53:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose54:
+ax_pose 13, 0x81e7, 0x90fc, 0x0c00
+ax_pose 14, 0x81e7, 0x50f4, 0x0c08
+ax_pose_terminator
+sLunatonePose55:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose56:
+ax_pose 15, 0x81e2, 0x90f5, 0x0c00
+ax_pose 16, 0x01f2, 0x1105, 0x0c08
+ax_pose_terminator
+sLunatonePose57:
+ax_pose 8, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose58:
+ax_pose 17, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose59:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose60:
+ax_pose 15, 0x81e2, 0x80fa, 0x0c00
+ax_pose 16, 0x01f2, 0x00f2, 0x0c08
+ax_pose_terminator
+sLunatonePose61:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose62:
+ax_pose 13, 0x81e7, 0x80f3, 0x0c00
+ax_pose 14, 0x81e7, 0x4103, 0x0c08
+ax_pose_terminator
+sLunatonePose63:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose64:
+ax_pose 11, 0x81e7, 0x80f8, 0x0c00
+ax_pose 12, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sLunatonePose65:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose66:
+ax_pose 10, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose67:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose68:
+ax_pose 11, 0x81e7, 0x90f7, 0x0c00
+ax_pose 12, 0x01ef, 0x10ef, 0x0c08
+ax_pose_terminator
+sLunatonePose69:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose70:
+ax_pose 13, 0x81e7, 0x90fc, 0x0c00
+ax_pose 14, 0x81e7, 0x50f4, 0x0c08
+ax_pose_terminator
+sLunatonePose71:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose72:
+ax_pose 15, 0x81e2, 0x90f5, 0x0c00
+ax_pose 16, 0x01f2, 0x1105, 0x0c08
+ax_pose_terminator
+sLunatonePose73:
+ax_pose 8, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose74:
+ax_pose 17, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose75:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose76:
+ax_pose 15, 0x81e2, 0x80fa, 0x0c00
+ax_pose 16, 0x01f2, 0x00f2, 0x0c08
+ax_pose_terminator
+sLunatonePose77:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose78:
+ax_pose 13, 0x81e7, 0x80f3, 0x0c00
+ax_pose 14, 0x81e7, 0x4103, 0x0c08
+ax_pose_terminator
+sLunatonePose79:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose80:
+ax_pose 11, 0x81e7, 0x80f8, 0x0c00
+ax_pose 12, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sLunatonePose81:
+ax_pose 18, 0x01e6, 0x80f6, 0x0c00
+ax_pose_terminator
+sLunatonePose82:
+ax_pose 19, 0x01e6, 0x80f6, 0x0c00
+ax_pose_terminator
+sLunatonePose83:
+ax_pose 20, 0x01e0, 0x80f5, 0x0c00
+ax_pose_terminator
+sLunatonePose84:
+ax_pose 21, 0x01e0, 0x90ed, 0x0c00
+ax_pose_terminator
+sLunatonePose85:
+ax_pose 22, 0x01e3, 0x90ee, 0x0c00
+ax_pose_terminator
+sLunatonePose86:
+ax_pose 23, 0x01e4, 0x90ee, 0x0c00
+ax_pose_terminator
+sLunatonePose87:
+ax_pose 24, 0x01e0, 0x80f5, 0x0c00
+ax_pose_terminator
+sLunatonePose88:
+ax_pose 23, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sLunatonePose89:
+ax_pose 22, 0x01e3, 0x80f2, 0x0c00
+ax_pose_terminator
+sLunatonePose90:
+ax_pose 21, 0x01e0, 0x80f3, 0x0c00
+ax_pose_terminator
+sLunatonePose91:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose92:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose93:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose94:
+ax_pose 3, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose95:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose96:
+ax_pose 5, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose97:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose98:
+ax_pose 7, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose99:
+ax_pose 8, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose100:
+ax_pose 9, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose101:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose102:
+ax_pose 7, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose103:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose104:
+ax_pose 5, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose105:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose106:
+ax_pose 3, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose107:
+ax_pose 10, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose108:
+ax_pose 11, 0x81e8, 0x80f8, 0x0c00
+ax_pose 12, 0x01f0, 0x0108, 0x0c08
+ax_pose_terminator
+sLunatonePose109:
+ax_pose 13, 0x81e7, 0x80f2, 0x0c00
+ax_pose 14, 0x81e7, 0x4102, 0x0c08
+ax_pose_terminator
+sLunatonePose110:
+ax_pose 15, 0x81e1, 0x80f9, 0x0c00
+ax_pose 16, 0x01f1, 0x00f1, 0x0c08
+ax_pose_terminator
+sLunatonePose111:
+ax_pose 17, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose112:
+ax_pose 15, 0x81e1, 0x90f7, 0x0c00
+ax_pose 16, 0x01f1, 0x1107, 0x0c08
+ax_pose_terminator
+sLunatonePose113:
+ax_pose 13, 0x81e7, 0x90fe, 0x0c00
+ax_pose 14, 0x81e7, 0x50f6, 0x0c08
+ax_pose_terminator
+sLunatonePose114:
+ax_pose 11, 0x81e8, 0x90f8, 0x0c00
+ax_pose 12, 0x01f0, 0x10f0, 0x0c08
+ax_pose_terminator
+sLunatonePose115:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose116:
+ax_pose 3, 0x81e6, 0x90f8, 0x0c00
+ax_pose_terminator
+sLunatonePose117:
+ax_pose 5, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose118:
+ax_pose 7, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose119:
+ax_pose 9, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose120:
+ax_pose 7, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose121:
+ax_pose 5, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose122:
+ax_pose 3, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose123:
+ax_pose 0, 0x81e6, 0x80f9, 0x0c00
+ax_pose_terminator
+sLunatonePose124:
+ax_pose 10, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sLunatonePose125:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+sLunatonePose126:
+ax_pose 11, 0x81e7, 0x90f7, 0x0c00
+ax_pose 12, 0x01ef, 0x10ef, 0x0c08
+ax_pose_terminator
+sLunatonePose127:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose128:
+ax_pose 13, 0x81e7, 0x90fc, 0x0c00
+ax_pose 14, 0x81e7, 0x50f4, 0x0c08
+ax_pose_terminator
+sLunatonePose129:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose130:
+ax_pose 15, 0x81e2, 0x90f6, 0x0c00
+ax_pose 16, 0x01f2, 0x1106, 0x0c08
+ax_pose_terminator
+sLunatonePose131:
+ax_pose 8, 0x81e6, 0x80f9, 0x0c00
+ax_pose_terminator
+sLunatonePose132:
+ax_pose 17, 0x81e5, 0x80f9, 0x0c00
+ax_pose_terminator
+sLunatonePose133:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose134:
+ax_pose 15, 0x81e2, 0x80f9, 0x0c00
+ax_pose 16, 0x01f2, 0x00f1, 0x0c08
+ax_pose_terminator
+sLunatonePose135:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose136:
+ax_pose 13, 0x81e7, 0x80f3, 0x0c00
+ax_pose 14, 0x81e7, 0x4103, 0x0c08
+ax_pose_terminator
+sLunatonePose137:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose138:
+ax_pose 11, 0x81e7, 0x80f8, 0x0c00
+ax_pose 12, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sLunatonePose139:
+ax_pose 10, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose140:
+ax_pose 11, 0x81e8, 0x80f8, 0x0c00
+ax_pose 12, 0x01f0, 0x0108, 0x0c08
+ax_pose_terminator
+sLunatonePose141:
+ax_pose 13, 0x81e7, 0x80f2, 0x0c00
+ax_pose 14, 0x81e7, 0x4102, 0x0c08
+ax_pose_terminator
+sLunatonePose142:
+ax_pose 15, 0x81e1, 0x80f9, 0x0c00
+ax_pose 16, 0x01f1, 0x00f1, 0x0c08
+ax_pose_terminator
+sLunatonePose143:
+ax_pose 17, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose144:
+ax_pose 15, 0x81e1, 0x90f7, 0x0c00
+ax_pose 16, 0x01f1, 0x1107, 0x0c08
+ax_pose_terminator
+sLunatonePose145:
+ax_pose 13, 0x81e7, 0x90fe, 0x0c00
+ax_pose 14, 0x81e7, 0x50f6, 0x0c08
+ax_pose_terminator
+sLunatonePose146:
+ax_pose 11, 0x81e8, 0x90f8, 0x0c00
+ax_pose 12, 0x01f0, 0x10f0, 0x0c08
+ax_pose_terminator
+sLunatonePose147:
+ax_pose 0, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose148:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose149:
+ax_pose 4, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose150:
+ax_pose 6, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sLunatonePose151:
+ax_pose 8, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sLunatonePose152:
+ax_pose 6, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose153:
+ax_pose 4, 0x01e6, 0x90eb, 0x0c00
+ax_pose_terminator
+sLunatonePose154:
+ax_pose 2, 0x81e6, 0x90f7, 0x0c00
+ax_pose_terminator
+.align 2
+sLunatoneAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_1_2:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_1_3:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_1_4:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_1_5:
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_1_6:
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_1_7:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_1_8:
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 17, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 9,
+ax_anim 2, 0, 17, 0, 24, 0, 21,
+ax_anim 2, 1, 18, 0, 24, 0, 21,
+ax_anim 2, 0, 17, 0, 24, 0, 21,
+ax_anim 2, 0, 30, 0, 24, 0, 21,
+ax_anim 2, 0, 17, 0, 24, 0, 21,
+ax_anim 2, 0, 17, 0, 12, 0, 12,
+ax_anim 2, 0, 17, 0, 4, 0, 4,
+ax_anim_terminator
+sLunatoneAnims_2_2:
+ax_anim 2, 0, 18, -1, -1, -1, -1,
+ax_anim 6, 0, 19, -2, -2, -2, -2,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 4, 4, 4, 4,
+ax_anim 1, 0, 18, 10, 11, 10, 10,
+ax_anim 2, 0, 19, 22, 24, 22, 22,
+ax_anim 2, 1, 20, 22, 24, 22, 22,
+ax_anim 2, 0, 19, 22, 24, 22, 22,
+ax_anim 2, 0, 16, 22, 24, 22, 22,
+ax_anim 2, 0, 19, 22, 24, 22, 22,
+ax_anim 2, 0, 19, 12, 13, 12, 12,
+ax_anim 2, 0, 19, 4, 4, 4, 4,
+ax_anim_terminator
+sLunatoneAnims_2_3:
+ax_anim 2, 0, 20, -1, 0, -1, 0,
+ax_anim 6, 0, 21, -2, 0, -2, 0,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 21, 4, 0, 4, 0,
+ax_anim 1, 0, 20, 10, 1, 10, 0,
+ax_anim 2, 0, 21, 20, 2, 20, 0,
+ax_anim 2, 1, 22, 20, 2, 20, 0,
+ax_anim 2, 0, 21, 20, 2, 20, 0,
+ax_anim 2, 0, 18, 20, 2, 20, 0,
+ax_anim 2, 0, 21, 20, 2, 20, 0,
+ax_anim 2, 0, 21, 12, 1, 12, 0,
+ax_anim 2, 0, 21, 4, 0, 4, 0,
+ax_anim_terminator
+sLunatoneAnims_2_4:
+ax_anim 2, 0, 22, -1, 1, -1, 1,
+ax_anim 6, 0, 23, -2, 2, -2, 2,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 23, 5, -3, 5, -4,
+ax_anim 1, 0, 22, 12, -8, 12, -9,
+ax_anim 2, 0, 23, 21, -14, 21, -16,
+ax_anim 2, 1, 24, 21, -14, 21, -16,
+ax_anim 2, 0, 23, 21, -14, 21, -16,
+ax_anim 2, 0, 20, 21, -14, 21, -16,
+ax_anim 2, 0, 23, 21, -14, 21, -16,
+ax_anim 2, 0, 23, 13, -9, 13, -10,
+ax_anim 2, 0, 23, 5, -3, 5, -4,
+ax_anim_terminator
+sLunatoneAnims_2_5:
+ax_anim 2, 0, 24, 0, 1, 0, 1,
+ax_anim 6, 0, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 24, 0, -12, 0, -13,
+ax_anim 2, 0, 25, 0, -15, 0, -18,
+ax_anim 2, 1, 26, 0, -15, 0, -18,
+ax_anim 2, 0, 25, 0, -15, 0, -18,
+ax_anim 2, 0, 22, 0, -15, 0, -18,
+ax_anim 2, 0, 25, 0, -15, 0, -18,
+ax_anim 2, 0, 25, 0, -10, 0, -11,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim_terminator
+sLunatoneAnims_2_6:
+ax_anim 2, 0, 26, 1, 1, 1, 1,
+ax_anim 6, 0, 27, 2, 2, 2, 2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 27, -5, -3, -5, -4,
+ax_anim 1, 0, 26, -12, -8, -12, -9,
+ax_anim 2, 0, 27, -21, -14, -21, -16,
+ax_anim 2, 1, 28, -21, -14, -21, -16,
+ax_anim 2, 0, 27, -21, -14, -21, -16,
+ax_anim 2, 0, 24, -21, -14, -21, -16,
+ax_anim 2, 0, 27, -21, -14, -21, -16,
+ax_anim 2, 0, 27, -13, -9, -13, -10,
+ax_anim 2, 0, 27, -5, -3, -5, -4,
+ax_anim_terminator
+sLunatoneAnims_2_7:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 6, 0, 29, 2, 0, 2, 0,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, -4, 0, -4, 0,
+ax_anim 1, 0, 28, -10, 1, -10, 0,
+ax_anim 2, 0, 29, -20, 2, -20, 0,
+ax_anim 2, 1, 30, -20, 2, -20, 0,
+ax_anim 2, 0, 29, -20, 2, -20, 0,
+ax_anim 2, 0, 26, -20, 2, -20, 0,
+ax_anim 2, 0, 29, -20, 2, -20, 0,
+ax_anim 2, 0, 29, -12, 1, -12, 0,
+ax_anim 2, 0, 29, -4, 0, -4, 0,
+ax_anim_terminator
+sLunatoneAnims_2_8:
+ax_anim 2, 0, 30, 1, -1, 1, -1,
+ax_anim 6, 0, 31, 2, -2, 2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, -4, 4, -4, 4,
+ax_anim 1, 0, 30, -10, 11, -10, 10,
+ax_anim 2, 0, 31, -22, 24, -22, 22,
+ax_anim 2, 1, 16, -22, 24, -22, 22,
+ax_anim 2, 0, 31, -22, 24, -22, 22,
+ax_anim 2, 0, 28, -22, 24, -22, 22,
+ax_anim 2, 0, 31, -22, 24, -22, 22,
+ax_anim 2, 0, 31, -12, 13, -12, 12,
+ax_anim 2, 0, 31, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_3_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 6, 0, 33, 0, -2, 0, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, 4, 0, 4,
+ax_anim 1, 0, 32, 0, 10, 0, 9,
+ax_anim 2, 0, 33, 0, 24, 0, 21,
+ax_anim 2, 1, 34, 0, 24, 0, 21,
+ax_anim 2, 0, 33, 0, 24, 0, 21,
+ax_anim 2, 0, 46, 0, 24, 0, 21,
+ax_anim 2, 0, 33, 0, 24, 0, 21,
+ax_anim 2, 0, 33, 0, 12, 0, 12,
+ax_anim 2, 0, 33, 0, 4, 0, 4,
+ax_anim_terminator
+sLunatoneAnims_3_2:
+ax_anim 2, 0, 34, -1, -1, -1, -1,
+ax_anim 6, 0, 35, -2, -2, -2, -2,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 4, 4, 4,
+ax_anim 1, 0, 34, 10, 11, 10, 10,
+ax_anim 2, 0, 35, 22, 24, 22, 22,
+ax_anim 2, 1, 36, 22, 24, 22, 22,
+ax_anim 2, 0, 35, 22, 24, 22, 22,
+ax_anim 2, 0, 32, 22, 24, 22, 22,
+ax_anim 2, 0, 35, 22, 24, 22, 22,
+ax_anim 2, 0, 35, 12, 13, 12, 12,
+ax_anim 2, 0, 35, 4, 4, 4, 4,
+ax_anim_terminator
+sLunatoneAnims_3_3:
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 6, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 1, 10, 0,
+ax_anim 2, 0, 37, 20, 2, 20, 0,
+ax_anim 2, 1, 38, 20, 2, 20, 0,
+ax_anim 2, 0, 37, 20, 2, 20, 0,
+ax_anim 2, 0, 34, 20, 2, 20, 0,
+ax_anim 2, 0, 37, 20, 2, 20, 0,
+ax_anim 2, 0, 37, 12, 1, 12, 0,
+ax_anim 2, 0, 37, 4, 0, 4, 0,
+ax_anim_terminator
+sLunatoneAnims_3_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 5, -3, 5, -4,
+ax_anim 1, 0, 38, 12, -8, 12, -9,
+ax_anim 2, 0, 39, 21, -14, 21, -16,
+ax_anim 2, 1, 40, 21, -14, 21, -16,
+ax_anim 2, 0, 39, 21, -14, 21, -16,
+ax_anim 2, 0, 36, 21, -14, 21, -16,
+ax_anim 2, 0, 39, 21, -14, 21, -16,
+ax_anim 2, 0, 39, 13, -9, 13, -10,
+ax_anim 2, 0, 39, 5, -3, 5, -4,
+ax_anim_terminator
+sLunatoneAnims_3_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 40, 0, -12, 0, -13,
+ax_anim 2, 0, 41, 0, -15, 0, -18,
+ax_anim 2, 1, 42, 0, -15, 0, -18,
+ax_anim 2, 0, 41, 0, -15, 0, -18,
+ax_anim 2, 0, 38, 0, -15, 0, -18,
+ax_anim 2, 0, 41, 0, -15, 0, -18,
+ax_anim 2, 0, 41, 0, -10, 0, -11,
+ax_anim 2, 0, 41, 0, -4, 0, -4,
+ax_anim_terminator
+sLunatoneAnims_3_6:
+ax_anim 2, 0, 42, 1, 1, 1, 1,
+ax_anim 6, 0, 43, 2, 2, 2, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -5, -3, -5, -4,
+ax_anim 1, 0, 42, -12, -8, -12, -9,
+ax_anim 2, 0, 43, -21, -14, -21, -16,
+ax_anim 2, 1, 44, -21, -14, -21, -16,
+ax_anim 2, 0, 43, -21, -14, -21, -16,
+ax_anim 2, 0, 40, -21, -14, -21, -16,
+ax_anim 2, 0, 43, -21, -14, -21, -16,
+ax_anim 2, 0, 43, -13, -9, -13, -10,
+ax_anim 2, 0, 43, -5, -3, -5, -4,
+ax_anim_terminator
+sLunatoneAnims_3_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 45, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 1, -10, 0,
+ax_anim 2, 0, 45, -20, 2, -20, 0,
+ax_anim 2, 1, 46, -20, 2, -20, 0,
+ax_anim 2, 0, 45, -20, 2, -20, 0,
+ax_anim 2, 0, 42, -20, 2, -20, 0,
+ax_anim 2, 0, 45, -20, 2, -20, 0,
+ax_anim 2, 0, 45, -12, 1, -12, 0,
+ax_anim 2, 0, 45, -4, 0, -4, 0,
+ax_anim_terminator
+sLunatoneAnims_3_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 11, -10, 10,
+ax_anim 2, 0, 47, -22, 24, -22, 22,
+ax_anim 2, 1, 32, -22, 24, -22, 22,
+ax_anim 2, 0, 47, -22, 24, -22, 22,
+ax_anim 2, 0, 44, -22, 24, -22, 22,
+ax_anim 2, 0, 47, -22, 24, -22, 22,
+ax_anim 2, 0, 47, -12, 13, -12, 12,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_4_1:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 2, 2, 48, 0, 3, 0, 3,
+ax_anim 6, 0, 48, 0, 4, 0, 4,
+ax_anim 1, 1, 49, 0, -5, 0, -5,
+ax_anim 1, 0, 49, 0, -8, 0, -8,
+ax_anim 4, 0, 49, 0, -9, 0, -9,
+ax_anim 2, 0, 48, 0, -7, 0, -7,
+ax_anim 2, 0, 48, 0, -4, 0, -4,
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim_terminator
+sLunatoneAnims_4_2:
+ax_anim 2, 0, 50, 1, 1, 1, 1,
+ax_anim 2, 2, 50, 3, 3, 3, 3,
+ax_anim 6, 0, 50, 4, 4, 4, 4,
+ax_anim 1, 1, 51, -5, -5, -5, -5,
+ax_anim 1, 0, 51, -8, -8, -8, -8,
+ax_anim 4, 0, 51, -9, -9, -9, -9,
+ax_anim 2, 0, 50, -7, -7, -7, -7,
+ax_anim 2, 0, 50, -4, -4, -4, -4,
+ax_anim 2, 0, 50, -2, -2, -2, -2,
+ax_anim_terminator
+sLunatoneAnims_4_3:
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 2, 2, 52, 3, 0, 3, 0,
+ax_anim 6, 0, 52, 4, 0, 4, 0,
+ax_anim 1, 1, 53, -5, 0, -5, 0,
+ax_anim 1, 0, 53, -8, 0, -8, 0,
+ax_anim 4, 0, 53, -9, 0, -9, 0,
+ax_anim 2, 0, 52, -7, 0, -7, 0,
+ax_anim 2, 0, 52, -4, 0, -4, 0,
+ax_anim 2, 0, 52, -2, 0, -2, 0,
+ax_anim_terminator
+sLunatoneAnims_4_4:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 2, 2, 54, 3, -3, 3, -3,
+ax_anim 6, 0, 54, 4, -4, 4, -4,
+ax_anim 1, 1, 55, -5, 5, -5, 5,
+ax_anim 1, 0, 55, -8, 8, -8, 8,
+ax_anim 4, 0, 55, -9, 9, -9, 9,
+ax_anim 2, 0, 54, -7, 7, -7, 7,
+ax_anim 2, 0, 54, -4, 4, -4, 4,
+ax_anim 2, 0, 54, -2, 2, -2, 2,
+ax_anim_terminator
+sLunatoneAnims_4_5:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 2, 2, 56, 0, -3, 0, -3,
+ax_anim 6, 0, 56, 0, -4, 0, -4,
+ax_anim 1, 1, 57, 0, 5, 0, 5,
+ax_anim 1, 0, 57, 0, 8, 0, 8,
+ax_anim 4, 0, 57, 0, 9, 0, 9,
+ax_anim 2, 0, 56, 0, 7, 0, 7,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim 2, 0, 56, 0, 2, 0, 2,
+ax_anim_terminator
+sLunatoneAnims_4_6:
+ax_anim 2, 0, 58, -1, -1, -1, -1,
+ax_anim 2, 2, 58, -3, -3, -3, -3,
+ax_anim 6, 0, 58, -4, -4, -4, -4,
+ax_anim 1, 1, 59, 5, 5, 5, 5,
+ax_anim 1, 0, 59, 8, 8, 8, 8,
+ax_anim 4, 0, 59, 9, 9, 9, 9,
+ax_anim 2, 0, 58, 7, 7, 7, 7,
+ax_anim 2, 0, 58, 4, 4, 4, 4,
+ax_anim 2, 0, 58, 2, 2, 2, 2,
+ax_anim_terminator
+sLunatoneAnims_4_7:
+ax_anim 2, 0, 60, -1, 0, -1, 0,
+ax_anim 2, 2, 60, -3, 0, -3, 0,
+ax_anim 6, 0, 60, -4, 0, -4, 0,
+ax_anim 1, 1, 61, 5, 0, 5, 0,
+ax_anim 1, 0, 61, 8, 0, 8, 0,
+ax_anim 4, 0, 61, 9, 0, 9, 0,
+ax_anim 2, 0, 60, 7, 0, 7, 0,
+ax_anim 2, 0, 60, 4, 0, 4, 0,
+ax_anim 2, 0, 60, 2, 0, 2, 0,
+ax_anim_terminator
+sLunatoneAnims_4_8:
+ax_anim 2, 0, 62, -1, 1, -1, 1,
+ax_anim 2, 2, 62, -3, 3, -3, 3,
+ax_anim 6, 0, 62, -4, 4, -4, 4,
+ax_anim 1, 1, 63, 5, -5, 5, -5,
+ax_anim 1, 0, 63, 8, -8, 8, -8,
+ax_anim 4, 0, 63, 9, -9, 9, -9,
+ax_anim 2, 0, 62, 7, -7, 7, -7,
+ax_anim 2, 0, 62, 4, -4, 4, -4,
+ax_anim 2, 0, 62, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_5_1:
+ax_anim 2, 0, 64, 0, -2, 0, 0,
+ax_anim 2, 0, 65, 0, -4, 0, 0,
+ax_anim 8, 2, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 1, -5, 1, 0,
+ax_anim 2, 0, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 1, -5, 1, 0,
+ax_anim 2, 0, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 1, -5, 1, 0,
+ax_anim 2, 0, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 0, -3, 0, 0,
+ax_anim 2, 0, 64, 0, -1, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_5_2:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 8, 2, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 1, -6, 1, -1,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 1, -6, 1, -1,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 1, -6, 1, -1,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 0, -3, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_5_3:
+ax_anim 2, 0, 68, 0, -2, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 8, 2, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, -1,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, -1,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, -1,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -3, 0, 0,
+ax_anim 2, 0, 68, 0, -1, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_5_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 8, 2, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, -1, -6, -1, -1,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, -1, -6, -1, -1,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, -1, -6, -1, -1,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, 0, -3, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_5_5:
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -4, 0, 0,
+ax_anim 8, 2, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 1, -5, 1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 1, -5, 1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 1, -5, 1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_5_6:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 8, 2, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 1, -6, 1, -1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 1, -6, 1, -1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 1, -6, 1, -1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_5_7:
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -4, 0, 0,
+ax_anim 8, 2, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_5_8:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 8, 2, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_6_1:
+ax_anim 16, 0, 80, 0, 0, 0, 0,
+ax_anim 12, 0, 80, 0, -1, 0, 0,
+ax_anim 16, 0, 80, 0, -2, 0, 0,
+ax_anim 16, 0, 81, 0, -2, 0, 0,
+ax_anim 12, 0, 81, 0, -1, 0, 0,
+ax_anim 16, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_7_1:
+ax_anim 2, 0, 82, 0, -4, 0, -4,
+ax_anim 8, 0, 82, 0, -5, 0, -5,
+ax_anim_terminator
+sLunatoneAnims_7_2:
+ax_anim 2, 0, 83, -4, -4, -4, -4,
+ax_anim 8, 0, 83, -5, -5, -5, -5,
+ax_anim_terminator
+sLunatoneAnims_7_3:
+ax_anim 2, 0, 84, -4, 0, -4, 0,
+ax_anim 8, 0, 84, -5, 0, -5, 0,
+ax_anim_terminator
+sLunatoneAnims_7_4:
+ax_anim 2, 0, 85, -4, 4, -4, 4,
+ax_anim 8, 0, 85, -5, 5, -5, 5,
+ax_anim_terminator
+sLunatoneAnims_7_5:
+ax_anim 2, 0, 86, 0, 4, 0, 4,
+ax_anim 8, 0, 86, 0, 5, 0, 5,
+ax_anim_terminator
+sLunatoneAnims_7_6:
+ax_anim 2, 0, 87, 4, 4, 4, 4,
+ax_anim 8, 0, 87, 5, 5, 5, 5,
+ax_anim_terminator
+sLunatoneAnims_7_7:
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim 8, 0, 88, 5, 0, 5, 0,
+ax_anim_terminator
+sLunatoneAnims_7_8:
+ax_anim 2, 0, 89, 4, -4, 4, -4,
+ax_anim 8, 0, 89, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_8_1:
+ax_anim 8, 0, 90, 0, 0, 0, 0,
+ax_anim 8, 0, 91, 0, -1, 0, 0,
+ax_anim 8, 0, 90, 0, -2, 0, 0,
+ax_anim 8, 0, 91, 0, -2, 0, 0,
+ax_anim 8, 0, 90, 0, -1, 0, 0,
+ax_anim 8, 0, 91, 0, 0, 0, 0,
+ax_anim 8, 0, 90, 0, 0, 0, 0,
+ax_anim 8, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_8_2:
+ax_anim 8, 0, 92, 0, 0, 0, 0,
+ax_anim 8, 0, 93, 0, -1, 0, 0,
+ax_anim 8, 0, 92, 0, -2, 0, 0,
+ax_anim 8, 0, 93, 0, -2, 0, 0,
+ax_anim 8, 0, 92, 0, -1, 0, 0,
+ax_anim 8, 0, 93, 0, 0, 0, 0,
+ax_anim 8, 0, 92, 0, 0, 0, 0,
+ax_anim 8, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_8_3:
+ax_anim 8, 0, 94, 0, 0, 0, 0,
+ax_anim 8, 0, 95, 0, -1, 0, 0,
+ax_anim 8, 0, 94, 0, -2, 0, 0,
+ax_anim 8, 0, 95, 0, -2, 0, 0,
+ax_anim 8, 0, 94, 0, -1, 0, 0,
+ax_anim 8, 0, 95, 0, 0, 0, 0,
+ax_anim 8, 0, 94, 0, 0, 0, 0,
+ax_anim 8, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_8_4:
+ax_anim 8, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 0, 97, 0, -1, 0, 0,
+ax_anim 8, 0, 96, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -2, 0, 0,
+ax_anim 8, 0, 96, 0, -1, 0, 0,
+ax_anim 8, 0, 97, 0, 0, 0, 0,
+ax_anim 8, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_8_5:
+ax_anim 8, 0, 98, 0, 0, 0, 0,
+ax_anim 8, 0, 99, 0, -1, 0, 0,
+ax_anim 8, 0, 98, 0, -2, 0, 0,
+ax_anim 8, 0, 99, 0, -2, 0, 0,
+ax_anim 8, 0, 98, 0, -1, 0, 0,
+ax_anim 8, 0, 99, 0, 0, 0, 0,
+ax_anim 8, 0, 98, 0, 0, 0, 0,
+ax_anim 8, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_8_6:
+ax_anim 8, 0, 100, 0, 0, 0, 0,
+ax_anim 8, 0, 101, 0, -1, 0, 0,
+ax_anim 8, 0, 100, 0, -2, 0, 0,
+ax_anim 8, 0, 101, 0, -2, 0, 0,
+ax_anim 8, 0, 100, 0, -1, 0, 0,
+ax_anim 8, 0, 101, 0, 0, 0, 0,
+ax_anim 8, 0, 100, 0, 0, 0, 0,
+ax_anim 8, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_8_7:
+ax_anim 8, 0, 102, 0, 0, 0, 0,
+ax_anim 8, 0, 103, 0, -1, 0, 0,
+ax_anim 8, 0, 102, 0, -2, 0, 0,
+ax_anim 8, 0, 103, 0, -2, 0, 0,
+ax_anim 8, 0, 102, 0, -1, 0, 0,
+ax_anim 8, 0, 103, 0, 0, 0, 0,
+ax_anim 8, 0, 102, 0, 0, 0, 0,
+ax_anim 8, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_8_8:
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim 8, 0, 105, 0, -1, 0, 0,
+ax_anim 8, 0, 104, 0, -2, 0, 0,
+ax_anim 8, 0, 105, 0, -2, 0, 0,
+ax_anim 8, 0, 104, 0, -1, 0, 0,
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_9_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 9, 5, 9, 5,
+ax_anim 2, 0, 108, 12, 12, 12, 12,
+ax_anim 2, 0, 109, 10, 21, 10, 19,
+ax_anim 3, 0, 110, 0, 25, 0, 23,
+ax_anim 2, 3, 111, -10, 21, -10, 19,
+ax_anim 2, 0, 112, -12, 12, -12, 12,
+ax_anim 1, 0, 113, -9, 5, -9, 5,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_9_2:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 8, 0, 8, 0,
+ax_anim 2, 0, 107, 18, 4, 18, 4,
+ax_anim 2, 0, 108, 24, 14, 24, 14,
+ax_anim 3, 0, 109, 22, 25, 22, 23,
+ax_anim 2, 3, 110, 14, 24, 13, 23,
+ax_anim 2, 0, 111, 6, 19, 6, 19,
+ax_anim 1, 0, 112, 1, 10, 1, 10,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_9_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 7, -4, 7, -4,
+ax_anim 2, 0, 106, 13, -5, 13, -5,
+ax_anim 2, 0, 107, 18, -3, 18, -3,
+ax_anim 3, 0, 108, 22, 3, 22, 1,
+ax_anim 2, 3, 109, 18, 6, 18, 6,
+ax_anim 2, 0, 110, 11, 7, 11, 7,
+ax_anim 1, 0, 111, 4, 5, 4, 5,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_9_4:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 1, -7, 1, -7,
+ax_anim 2, 0, 113, 7, -13, 7, -13,
+ax_anim 2, 0, 106, 15, -16, 15, -16,
+ax_anim 3, 0, 107, 22, -16, 22, -18,
+ax_anim 2, 3, 108, 23, -9, 23, -9,
+ax_anim 2, 0, 109, 17, -3, 17, -3,
+ax_anim 1, 0, 110, 7, 0, 7, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_9_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, -10, -3, -10, -3,
+ax_anim 2, 0, 112, -11, -11, -11, -11,
+ax_anim 2, 0, 113, -6, -15, -6, -16,
+ax_anim 3, 0, 106, 0, -16, 0, -18,
+ax_anim 2, 3, 107, 6, -15, 6, -16,
+ax_anim 2, 0, 108, 11, -11, 11, -11,
+ax_anim 1, 0, 109, 10, -3, 10, -3,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_9_6:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, -1, -7, -1, -7,
+ax_anim 2, 0, 107, -7, -13, -7, -13,
+ax_anim 2, 0, 106, -15, -16, -15, -16,
+ax_anim 3, 0, 113, -22, -16, -22, -18,
+ax_anim 2, 3, 112, -23, -9, -23, -9,
+ax_anim 2, 0, 111, -17, -3, -17, -3,
+ax_anim 1, 0, 110, -7, 0, -7, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_9_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, -7, -4, -7, -4,
+ax_anim 2, 0, 106, -13, -5, -13, -5,
+ax_anim 2, 0, 113, -18, -3, -18, -3,
+ax_anim 3, 0, 112, -22, 3, -22, 1,
+ax_anim 2, 3, 111, -18, 6, -18, 6,
+ax_anim 2, 0, 110, -11, 7, -11, 7,
+ax_anim 1, 0, 109, -4, 5, -4, 5,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_9_8:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, -8, 0, -8, 0,
+ax_anim 2, 0, 113, -18, 4, -18, 4,
+ax_anim 2, 0, 112, -24, 14, -24, 14,
+ax_anim 3, 0, 111, -22, 25, -22, 23,
+ax_anim 2, 3, 110, -14, 24, -13, 23,
+ax_anim 2, 0, 109, -6, 19, -6, 19,
+ax_anim 1, 0, 108, -1, 10, -1, 10,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_10_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 3, 0, 114, 13, 0, 13, 0,
+ax_anim 3, 0, 114, -13, 0, -13, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_10_2:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 3, 0, 115, 13, -13, 13, -13,
+ax_anim 3, 0, 115, -13, 13, -13, 13,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_10_3:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 3, 0, 116, 0, -13, 0, -13,
+ax_anim 3, 0, 116, 0, 13, 0, 13,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_10_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 3, 0, 117, -13, -13, -13, -13,
+ax_anim 3, 0, 117, 13, 13, 13, 13,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_10_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 3, 0, 118, 13, 0, 13, 0,
+ax_anim 3, 0, 118, -13, 0, -13, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_10_6:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 3, 0, 119, 13, -13, 13, -13,
+ax_anim 3, 0, 119, -13, 13, -13, 13,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_10_7:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 3, 0, 120, 0, -13, 0, -13,
+ax_anim 3, 0, 120, 0, 13, 0, 13,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_10_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 3, 0, 121, -13, -13, -13, -13,
+ax_anim 3, 0, 121, 13, 13, 13, 13,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_11_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, -10, 0, 0,
+ax_anim 2, 0, 123, 0, -16, 0, 0,
+ax_anim 3, 0, 123, 0, -20, 0, 0,
+ax_anim 4, 0, 123, 0, -21, 0, 0,
+ax_anim 4, 0, 122, 0, -22, 0, 0,
+ax_anim 3, 0, 122, 0, -21, 0, 0,
+ax_anim 2, 0, 122, 0, -16, 0, 0,
+ax_anim 1, 0, 122, 0, -10, 0, 0,
+ax_anim 2, 2, 122, 0, 4, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_11_2:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -10, 0, 0,
+ax_anim 2, 0, 125, 0, -16, 0, 0,
+ax_anim 3, 0, 125, 0, -20, 0, 0,
+ax_anim 4, 0, 125, 0, -21, 0, 0,
+ax_anim 4, 0, 124, 0, -23, 0, 0,
+ax_anim 3, 0, 124, 0, -22, 0, 0,
+ax_anim 2, 0, 124, 0, -16, 0, 0,
+ax_anim 1, 0, 124, 0, -10, 0, 0,
+ax_anim 2, 2, 124, 0, 4, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_11_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -10, 0, 0,
+ax_anim 2, 0, 127, 0, -16, 0, 0,
+ax_anim 3, 0, 127, 0, -20, 0, 0,
+ax_anim 4, 0, 127, 0, -21, 0, 0,
+ax_anim 4, 0, 126, 0, -22, 0, 0,
+ax_anim 3, 0, 126, 0, -21, 0, 0,
+ax_anim 2, 0, 126, 0, -16, 0, 0,
+ax_anim 1, 0, 126, 0, -10, 0, 0,
+ax_anim 2, 2, 126, 0, 4, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_11_4:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 2, 0, 129, 0, -16, 0, 0,
+ax_anim 3, 0, 129, 0, -20, 0, 0,
+ax_anim 4, 0, 129, 0, -21, 0, 0,
+ax_anim 4, 0, 128, 0, -21, 0, 0,
+ax_anim 3, 0, 128, 0, -20, 0, 0,
+ax_anim 2, 0, 128, 0, -15, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 2, 2, 128, 0, 4, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_11_5:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 2, 0, 131, 0, -16, 0, 0,
+ax_anim 3, 0, 131, 0, -20, 0, 0,
+ax_anim 4, 0, 131, 0, -21, 0, 0,
+ax_anim 4, 0, 130, 0, -21, 0, 0,
+ax_anim 3, 0, 130, 0, -20, 0, 0,
+ax_anim 2, 0, 130, 0, -16, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 2, 2, 130, 0, 4, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_11_6:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 2, 0, 133, 0, -16, 0, 0,
+ax_anim 3, 0, 133, 0, -20, 0, 0,
+ax_anim 4, 0, 133, 0, -21, 0, 0,
+ax_anim 4, 0, 132, 0, -21, 0, 0,
+ax_anim 3, 0, 132, 0, -20, 0, 0,
+ax_anim 2, 0, 132, 0, -15, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 2, 2, 132, 0, 4, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_11_7:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 2, 0, 135, 0, -16, 0, 0,
+ax_anim 3, 0, 135, 0, -20, 0, 0,
+ax_anim 4, 0, 135, 0, -21, 0, 0,
+ax_anim 4, 0, 134, 0, -22, 0, 0,
+ax_anim 3, 0, 134, 0, -21, 0, 0,
+ax_anim 2, 0, 134, 0, -16, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 2, 2, 134, 0, 4, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_11_8:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -10, 0, 0,
+ax_anim 2, 0, 137, 0, -16, 0, 0,
+ax_anim 3, 0, 137, 0, -20, 0, 0,
+ax_anim 4, 0, 137, 0, -21, 0, 0,
+ax_anim 4, 0, 136, 0, -23, 0, 0,
+ax_anim 3, 0, 136, 0, -22, 0, 0,
+ax_anim 2, 0, 136, 0, -16, 0, 0,
+ax_anim 1, 0, 136, 0, -10, 0, 0,
+ax_anim 2, 2, 136, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_12_1:
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_12_2:
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 1, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_12_3:
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_12_4:
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_12_5:
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_12_6:
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_12_7:
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 1, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_12_8:
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLunatoneAnims_13_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_13_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_13_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_13_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_13_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_13_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_13_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneAnims_13_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sLunatoneGfx1:
+.incbin "baserom.gba", 0x13C91FC, 0x100
+sLunatoneSprites1:
+ax_sprite sLunatoneGfx1, 0x100
+ax_sprite_terminator
+sLunatoneGfx2:
+.incbin "baserom.gba", 0x13C930C, 0x100
+sLunatoneSprites2:
+ax_sprite sLunatoneGfx2, 0x100
+ax_sprite_terminator
+sLunatoneGfx3:
+.incbin "baserom.gba", 0x13C941C, 0x100
+sLunatoneSprites3:
+ax_sprite sLunatoneGfx3, 0x100
+ax_sprite_terminator
+sLunatoneGfx4:
+.incbin "baserom.gba", 0x13C952C, 0x100
+sLunatoneSprites4:
+ax_sprite sLunatoneGfx4, 0x100
+ax_sprite_terminator
+sLunatoneGfx5:
+.incbin "baserom.gba", 0x13C963C, 0x200
+sLunatoneSprites5:
+ax_sprite sLunatoneGfx5, 0x200
+ax_sprite_terminator
+sLunatoneGfx6:
+.incbin "baserom.gba", 0x13C984C, 0x200
+sLunatoneSprites6:
+ax_sprite sLunatoneGfx6, 0x200
+ax_sprite_terminator
+sLunatoneGfx7:
+.incbin "baserom.gba", 0x13C9A5C, 0x200
+sLunatoneSprites7:
+ax_sprite sLunatoneGfx7, 0x200
+ax_sprite_terminator
+sLunatoneGfx8:
+.incbin "baserom.gba", 0x13C9C6C, 0x200
+sLunatoneSprites8:
+ax_sprite sLunatoneGfx8, 0x200
+ax_sprite_terminator
+sLunatoneGfx9:
+.incbin "baserom.gba", 0x13C9E7C, 0x100
+sLunatoneSprites9:
+ax_sprite sLunatoneGfx9, 0x100
+ax_sprite_terminator
+sLunatoneGfx10:
+.incbin "baserom.gba", 0x13C9F8C, 0x100
+sLunatoneSprites10:
+ax_sprite sLunatoneGfx10, 0x100
+ax_sprite_terminator
+sLunatoneGfx11:
+.incbin "baserom.gba", 0x13CA09C, 0xC0
+sLunatoneSprites11:
+ax_sprite sLunatoneGfx11, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLunatoneGfx12:
+.incbin "baserom.gba", 0x13CA174, 0xC0
+sLunatoneSprites12:
+ax_sprite sLunatoneGfx12, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLunatoneGfx13:
+.incbin "baserom.gba", 0x13CA24C, 0x20
+sLunatoneSprites13:
+ax_sprite sLunatoneGfx13, 0x20
+ax_sprite_terminator
+sLunatoneGfx14:
+.incbin "baserom.gba", 0x13CA27C, 0xC0
+sLunatoneSprites14:
+ax_sprite sLunatoneGfx14, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLunatoneGfx15:
+.incbin "baserom.gba", 0x13CA354, 0x60
+sLunatoneSprites15:
+ax_sprite sLunatoneGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sLunatoneGfx16:
+.incbin "baserom.gba", 0x13CA3CC, 0x100
+sLunatoneSprites16:
+ax_sprite sLunatoneGfx16, 0x100
+ax_sprite_terminator
+sLunatoneGfx17:
+.incbin "baserom.gba", 0x13CA4DC, 0x20
+sLunatoneSprites17:
+ax_sprite sLunatoneGfx17, 0x20
+ax_sprite_terminator
+sLunatoneGfx18:
+.incbin "baserom.gba", 0x13CA50C, 0xC0
+sLunatoneSprites18:
+ax_sprite sLunatoneGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLunatoneGfx19:
+.incbin "baserom.gba", 0x13CA5E4, 0x200
+sLunatoneSprites19:
+ax_sprite sLunatoneGfx19, 0x200
+ax_sprite_terminator
+sLunatoneGfx20:
+.incbin "baserom.gba", 0x13CA7F4, 0x200
+sLunatoneSprites20:
+ax_sprite sLunatoneGfx20, 0x200
+ax_sprite_terminator
+sLunatoneGfx21:
+.incbin "baserom.gba", 0x13CAA04, 0x200
+sLunatoneSprites21:
+ax_sprite sLunatoneGfx21, 0x200
+ax_sprite_terminator
+sLunatoneGfx22:
+.incbin "baserom.gba", 0x13CAC14, 0x200
+sLunatoneSprites22:
+ax_sprite sLunatoneGfx22, 0x200
+ax_sprite_terminator
+sLunatoneGfx23:
+.incbin "baserom.gba", 0x13CAE24, 0x200
+sLunatoneSprites23:
+ax_sprite sLunatoneGfx23, 0x200
+ax_sprite_terminator
+sLunatoneGfx24:
+.incbin "baserom.gba", 0x13CB034, 0x200
+sLunatoneSprites24:
+ax_sprite sLunatoneGfx24, 0x200
+ax_sprite_terminator
+sLunatoneGfx25:
+.incbin "baserom.gba", 0x13CB244, 0x200
+sLunatoneSprites25:
+ax_sprite sLunatoneGfx25, 0x200
+ax_sprite_terminator
+sAxPosesLunatone:
+.4byte sLunatonePose1
+.4byte sLunatonePose2
+.4byte sLunatonePose3
+.4byte sLunatonePose4
+.4byte sLunatonePose5
+.4byte sLunatonePose6
+.4byte sLunatonePose7
+.4byte sLunatonePose8
+.4byte sLunatonePose9
+.4byte sLunatonePose10
+.4byte sLunatonePose11
+.4byte sLunatonePose12
+.4byte sLunatonePose13
+.4byte sLunatonePose14
+.4byte sLunatonePose15
+.4byte sLunatonePose16
+.4byte sLunatonePose17
+.4byte sLunatonePose18
+.4byte sLunatonePose19
+.4byte sLunatonePose20
+.4byte sLunatonePose21
+.4byte sLunatonePose22
+.4byte sLunatonePose23
+.4byte sLunatonePose24
+.4byte sLunatonePose25
+.4byte sLunatonePose26
+.4byte sLunatonePose27
+.4byte sLunatonePose28
+.4byte sLunatonePose29
+.4byte sLunatonePose30
+.4byte sLunatonePose31
+.4byte sLunatonePose32
+.4byte sLunatonePose33
+.4byte sLunatonePose34
+.4byte sLunatonePose35
+.4byte sLunatonePose36
+.4byte sLunatonePose37
+.4byte sLunatonePose38
+.4byte sLunatonePose39
+.4byte sLunatonePose40
+.4byte sLunatonePose41
+.4byte sLunatonePose42
+.4byte sLunatonePose43
+.4byte sLunatonePose44
+.4byte sLunatonePose45
+.4byte sLunatonePose46
+.4byte sLunatonePose47
+.4byte sLunatonePose48
+.4byte sLunatonePose49
+.4byte sLunatonePose50
+.4byte sLunatonePose51
+.4byte sLunatonePose52
+.4byte sLunatonePose53
+.4byte sLunatonePose54
+.4byte sLunatonePose55
+.4byte sLunatonePose56
+.4byte sLunatonePose57
+.4byte sLunatonePose58
+.4byte sLunatonePose59
+.4byte sLunatonePose60
+.4byte sLunatonePose61
+.4byte sLunatonePose62
+.4byte sLunatonePose63
+.4byte sLunatonePose64
+.4byte sLunatonePose65
+.4byte sLunatonePose66
+.4byte sLunatonePose67
+.4byte sLunatonePose68
+.4byte sLunatonePose69
+.4byte sLunatonePose70
+.4byte sLunatonePose71
+.4byte sLunatonePose72
+.4byte sLunatonePose73
+.4byte sLunatonePose74
+.4byte sLunatonePose75
+.4byte sLunatonePose76
+.4byte sLunatonePose77
+.4byte sLunatonePose78
+.4byte sLunatonePose79
+.4byte sLunatonePose80
+.4byte sLunatonePose81
+.4byte sLunatonePose82
+.4byte sLunatonePose83
+.4byte sLunatonePose84
+.4byte sLunatonePose85
+.4byte sLunatonePose86
+.4byte sLunatonePose87
+.4byte sLunatonePose88
+.4byte sLunatonePose89
+.4byte sLunatonePose90
+.4byte sLunatonePose91
+.4byte sLunatonePose92
+.4byte sLunatonePose93
+.4byte sLunatonePose94
+.4byte sLunatonePose95
+.4byte sLunatonePose96
+.4byte sLunatonePose97
+.4byte sLunatonePose98
+.4byte sLunatonePose99
+.4byte sLunatonePose100
+.4byte sLunatonePose101
+.4byte sLunatonePose102
+.4byte sLunatonePose103
+.4byte sLunatonePose104
+.4byte sLunatonePose105
+.4byte sLunatonePose106
+.4byte sLunatonePose107
+.4byte sLunatonePose108
+.4byte sLunatonePose109
+.4byte sLunatonePose110
+.4byte sLunatonePose111
+.4byte sLunatonePose112
+.4byte sLunatonePose113
+.4byte sLunatonePose114
+.4byte sLunatonePose115
+.4byte sLunatonePose116
+.4byte sLunatonePose117
+.4byte sLunatonePose118
+.4byte sLunatonePose119
+.4byte sLunatonePose120
+.4byte sLunatonePose121
+.4byte sLunatonePose122
+.4byte sLunatonePose123
+.4byte sLunatonePose124
+.4byte sLunatonePose125
+.4byte sLunatonePose126
+.4byte sLunatonePose127
+.4byte sLunatonePose128
+.4byte sLunatonePose129
+.4byte sLunatonePose130
+.4byte sLunatonePose131
+.4byte sLunatonePose132
+.4byte sLunatonePose133
+.4byte sLunatonePose134
+.4byte sLunatonePose135
+.4byte sLunatonePose136
+.4byte sLunatonePose137
+.4byte sLunatonePose138
+.4byte sLunatonePose139
+.4byte sLunatonePose140
+.4byte sLunatonePose141
+.4byte sLunatonePose142
+.4byte sLunatonePose143
+.4byte sLunatonePose144
+.4byte sLunatonePose145
+.4byte sLunatonePose146
+.4byte sLunatonePose147
+.4byte sLunatonePose148
+.4byte sLunatonePose149
+.4byte sLunatonePose150
+.4byte sLunatonePose151
+.4byte sLunatonePose152
+.4byte sLunatonePose153
+.4byte sLunatonePose154
+sAxPositionsLunatone:
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+.2byte    0,  -11, 	  -1,   -9, 	  -5,   -9, 	  -4,  -12
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    2,  -12, 	   0,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    2,  -14, 	  -3,  -11, 	  -1,   -8, 	  -4,  -10
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -4,  -14, 	   1,  -11, 	  -1,   -8, 	   2,  -10
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -12, 	  -2,  -10, 	   2,   -8, 	   1,  -10
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -2,  -11, 	  -1,   -9, 	   3,   -9, 	   2,  -12
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+.2byte    0,  -11, 	  -1,   -9, 	  -5,   -9, 	  -4,  -12
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    2,  -12, 	   0,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    2,  -14, 	  -3,  -11, 	  -1,   -8, 	  -4,  -10
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -4,  -14, 	   1,  -11, 	  -1,   -8, 	   2,  -10
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -12, 	  -2,  -10, 	   2,   -8, 	   1,  -10
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -2,  -11, 	  -1,   -9, 	   3,   -9, 	   2,  -12
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+.2byte    0,  -11, 	  -1,   -9, 	  -5,   -9, 	  -4,  -12
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    2,  -12, 	   0,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    2,  -14, 	  -3,  -11, 	  -1,   -8, 	  -4,  -10
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -4,  -14, 	   1,  -11, 	  -1,   -8, 	   2,  -10
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -12, 	  -2,  -10, 	   2,   -8, 	   1,  -10
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -2,  -11, 	  -1,   -9, 	   3,   -9, 	   2,  -12
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte   -1,  -14, 	  -5,  -11, 	   2,  -11, 	  -1,  -12
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+.2byte    1,  -14, 	  -1,  -10, 	  -3,   -9, 	  -5,  -13
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    2,  -14, 	  -1,   -9, 	  -2,   -7, 	  -6,  -12
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    1,  -14, 	  -4,   -9, 	  -1,   -7, 	  -6,   -9
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -3,  -14, 	   2,   -9, 	  -1,   -7, 	   4,   -9
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -14, 	  -1,   -9, 	   0,   -7, 	   4,  -12
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -3,  -14, 	  -1,  -10, 	   1,   -9, 	   3,  -13
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte   -1,  -14, 	  -5,  -11, 	   2,  -11, 	  -1,  -12
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+.2byte    1,  -14, 	  -1,  -10, 	  -3,   -9, 	  -5,  -13
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    2,  -14, 	  -1,   -9, 	  -2,   -7, 	  -6,  -12
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    1,  -14, 	  -4,   -9, 	  -1,   -7, 	  -6,   -9
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -3,  -14, 	   2,   -9, 	  -1,   -7, 	   4,   -9
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -14, 	  -1,   -9, 	   0,   -7, 	   4,  -12
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -3,  -14, 	  -1,  -10, 	   1,   -9, 	   3,  -13
+.2byte   -2,  -13, 	  -2,  -10, 	   1,   -8, 	   2,  -12
+.2byte   -2,  -13, 	  -1,  -10, 	   1,   -8, 	   2,  -12
+.2byte   -1,  -17, 	  -5,  -13, 	   2,  -13, 	  -1,  -14
+.2byte    2,  -15, 	   2,  -12, 	  -1,  -10, 	  -2,  -12
+.2byte    3,  -16, 	   1,  -12, 	   0,   -9, 	  -2,  -12
+.2byte    2,  -15, 	  -4,  -12, 	   1,  -10, 	  -1,  -11
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -13
+.2byte   -3,  -15, 	   3,  -12, 	  -2,  -10, 	   0,  -11
+.2byte   -4,  -16, 	  -2,  -12, 	  -1,   -9, 	   1,  -12
+.2byte   -3,  -15, 	  -3,  -12, 	   0,  -10, 	   1,  -12
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+.2byte    0,  -11, 	  -1,   -9, 	  -5,   -9, 	  -4,  -12
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    2,  -12, 	   0,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    2,  -14, 	  -3,  -11, 	  -1,   -8, 	  -4,  -10
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -4,  -14, 	   1,  -11, 	  -1,   -8, 	   2,  -10
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -12, 	  -2,  -10, 	   2,   -8, 	   1,  -10
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -2,  -11, 	  -1,   -9, 	   3,   -9, 	   2,  -12
+.2byte   -1,  -14, 	  -5,  -11, 	   2,  -11, 	  -1,  -12
+.2byte   -3,  -13, 	  -1,   -9, 	   1,   -8, 	   3,  -12
+.2byte   -5,  -14, 	  -2,   -9, 	  -1,   -7, 	   3,  -12
+.2byte   -4,  -15, 	   1,  -10, 	  -2,   -8, 	   3,  -10
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte    3,  -15, 	  -2,  -10, 	   1,   -8, 	  -4,  -10
+.2byte    4,  -14, 	   1,   -9, 	   0,   -7, 	  -4,  -12
+.2byte    2,  -13, 	   0,   -9, 	  -2,   -8, 	  -4,  -12
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte    1,  -11, 	   0,   -9, 	  -4,   -9, 	  -3,  -12
+.2byte    2,  -12, 	   0,  -10, 	  -4,   -8, 	  -3,  -10
+.2byte    2,  -14, 	  -3,  -11, 	  -1,   -8, 	  -4,  -10
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -4,  -14, 	   1,  -11, 	  -1,   -8, 	   2,  -10
+.2byte   -4,  -12, 	  -2,  -10, 	   2,   -8, 	   1,  -10
+.2byte   -2,  -11, 	  -1,   -9, 	   3,   -9, 	   2,  -12
+.2byte    0,  -12, 	  -3,  -11, 	   4,  -11, 	   0,  -13
+.2byte    0,  -14, 	  -4,  -11, 	   3,  -11, 	   0,  -12
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+.2byte    1,  -14, 	  -1,  -10, 	  -3,   -9, 	  -5,  -13
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    2,  -14, 	  -1,   -9, 	  -2,   -7, 	  -6,  -12
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    2,  -14, 	  -3,   -9, 	   0,   -7, 	  -5,   -9
+.2byte    0,  -14, 	   4,  -11, 	  -3,  -11, 	   0,  -12
+.2byte    0,  -14, 	   4,  -10, 	  -3,  -10, 	   0,  -10
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -4,  -14, 	   1,   -9, 	  -2,   -7, 	   3,   -9
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -14, 	  -1,   -9, 	   0,   -7, 	   4,  -12
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -3,  -14, 	  -1,  -10, 	   1,   -9, 	   3,  -13
+.2byte   -1,  -14, 	  -5,  -11, 	   2,  -11, 	  -1,  -12
+.2byte   -3,  -13, 	  -1,   -9, 	   1,   -8, 	   3,  -12
+.2byte   -5,  -14, 	  -2,   -9, 	  -1,   -7, 	   3,  -12
+.2byte   -4,  -15, 	   1,  -10, 	  -2,   -8, 	   3,  -10
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte    3,  -15, 	  -2,  -10, 	   1,   -8, 	  -4,  -10
+.2byte    4,  -14, 	   1,   -9, 	   0,   -7, 	  -4,  -12
+.2byte    2,  -13, 	   0,   -9, 	  -2,   -8, 	  -4,  -12
+.2byte   -1,  -12, 	  -4,  -11, 	   3,  -11, 	  -1,  -13
+.2byte   -2,  -12, 	  -1,  -10, 	   3,   -9, 	   2,  -12
+.2byte   -4,  -12, 	  -2,  -10, 	   0,   -8, 	   1,  -11
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -9, 	   1,  -10
+.2byte   -1,  -14, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte    2,  -14, 	  -4,  -11, 	   0,   -9, 	  -3,  -10
+.2byte    2,  -12, 	   0,  -10, 	  -2,   -8, 	  -3,  -11
+.2byte    0,  -12, 	  -1,  -10, 	  -5,   -9, 	  -4,  -12
+sLunatoneAnimTable1:
+.4byte sLunatoneAnims_1_1
+.4byte sLunatoneAnims_1_2
+.4byte sLunatoneAnims_1_3
+.4byte sLunatoneAnims_1_4
+.4byte sLunatoneAnims_1_5
+.4byte sLunatoneAnims_1_6
+.4byte sLunatoneAnims_1_7
+.4byte sLunatoneAnims_1_8
+sLunatoneAnimTable2:
+.4byte sLunatoneAnims_2_1
+.4byte sLunatoneAnims_2_2
+.4byte sLunatoneAnims_2_3
+.4byte sLunatoneAnims_2_4
+.4byte sLunatoneAnims_2_5
+.4byte sLunatoneAnims_2_6
+.4byte sLunatoneAnims_2_7
+.4byte sLunatoneAnims_2_8
+sLunatoneAnimTable3:
+.4byte sLunatoneAnims_3_1
+.4byte sLunatoneAnims_3_2
+.4byte sLunatoneAnims_3_3
+.4byte sLunatoneAnims_3_4
+.4byte sLunatoneAnims_3_5
+.4byte sLunatoneAnims_3_6
+.4byte sLunatoneAnims_3_7
+.4byte sLunatoneAnims_3_8
+sLunatoneAnimTable4:
+.4byte sLunatoneAnims_4_1
+.4byte sLunatoneAnims_4_2
+.4byte sLunatoneAnims_4_3
+.4byte sLunatoneAnims_4_4
+.4byte sLunatoneAnims_4_5
+.4byte sLunatoneAnims_4_6
+.4byte sLunatoneAnims_4_7
+.4byte sLunatoneAnims_4_8
+sLunatoneAnimTable5:
+.4byte sLunatoneAnims_5_1
+.4byte sLunatoneAnims_5_2
+.4byte sLunatoneAnims_5_3
+.4byte sLunatoneAnims_5_4
+.4byte sLunatoneAnims_5_5
+.4byte sLunatoneAnims_5_6
+.4byte sLunatoneAnims_5_7
+.4byte sLunatoneAnims_5_8
+sLunatoneAnimTable6:
+.4byte sLunatoneAnims_6_1
+.4byte sLunatoneAnims_6_1
+.4byte sLunatoneAnims_6_1
+.4byte sLunatoneAnims_6_1
+.4byte sLunatoneAnims_6_1
+.4byte sLunatoneAnims_6_1
+.4byte sLunatoneAnims_6_1
+.4byte sLunatoneAnims_6_1
+sLunatoneAnimTable7:
+.4byte sLunatoneAnims_7_1
+.4byte sLunatoneAnims_7_2
+.4byte sLunatoneAnims_7_3
+.4byte sLunatoneAnims_7_4
+.4byte sLunatoneAnims_7_5
+.4byte sLunatoneAnims_7_6
+.4byte sLunatoneAnims_7_7
+.4byte sLunatoneAnims_7_8
+sLunatoneAnimTable8:
+.4byte sLunatoneAnims_8_1
+.4byte sLunatoneAnims_8_2
+.4byte sLunatoneAnims_8_3
+.4byte sLunatoneAnims_8_4
+.4byte sLunatoneAnims_8_5
+.4byte sLunatoneAnims_8_6
+.4byte sLunatoneAnims_8_7
+.4byte sLunatoneAnims_8_8
+sLunatoneAnimTable9:
+.4byte sLunatoneAnims_9_1
+.4byte sLunatoneAnims_9_2
+.4byte sLunatoneAnims_9_3
+.4byte sLunatoneAnims_9_4
+.4byte sLunatoneAnims_9_5
+.4byte sLunatoneAnims_9_6
+.4byte sLunatoneAnims_9_7
+.4byte sLunatoneAnims_9_8
+sLunatoneAnimTable10:
+.4byte sLunatoneAnims_10_1
+.4byte sLunatoneAnims_10_2
+.4byte sLunatoneAnims_10_3
+.4byte sLunatoneAnims_10_4
+.4byte sLunatoneAnims_10_5
+.4byte sLunatoneAnims_10_6
+.4byte sLunatoneAnims_10_7
+.4byte sLunatoneAnims_10_8
+sLunatoneAnimTable11:
+.4byte sLunatoneAnims_11_1
+.4byte sLunatoneAnims_11_2
+.4byte sLunatoneAnims_11_3
+.4byte sLunatoneAnims_11_4
+.4byte sLunatoneAnims_11_5
+.4byte sLunatoneAnims_11_6
+.4byte sLunatoneAnims_11_7
+.4byte sLunatoneAnims_11_8
+sLunatoneAnimTable12:
+.4byte sLunatoneAnims_12_1
+.4byte sLunatoneAnims_12_2
+.4byte sLunatoneAnims_12_3
+.4byte sLunatoneAnims_12_4
+.4byte sLunatoneAnims_12_5
+.4byte sLunatoneAnims_12_6
+.4byte sLunatoneAnims_12_7
+.4byte sLunatoneAnims_12_8
+sLunatoneAnimTable13:
+.4byte sLunatoneAnims_13_1
+.4byte sLunatoneAnims_13_2
+.4byte sLunatoneAnims_13_3
+.4byte sLunatoneAnims_13_4
+.4byte sLunatoneAnims_13_5
+.4byte sLunatoneAnims_13_6
+.4byte sLunatoneAnims_13_7
+.4byte sLunatoneAnims_13_8
+sAxAnimationsLunatone:
+.4byte sLunatoneAnimTable1
+.4byte sLunatoneAnimTable2
+.4byte sLunatoneAnimTable3
+.4byte sLunatoneAnimTable4
+.4byte sLunatoneAnimTable5
+.4byte sLunatoneAnimTable6
+.4byte sLunatoneAnimTable7
+.4byte sLunatoneAnimTable8
+.4byte sLunatoneAnimTable9
+.4byte sLunatoneAnimTable10
+.4byte sLunatoneAnimTable11
+.4byte sLunatoneAnimTable12
+.4byte sLunatoneAnimTable13
+sAxSpritesLunatone:
+.4byte sLunatoneSprites1
+.4byte sLunatoneSprites2
+.4byte sLunatoneSprites3
+.4byte sLunatoneSprites4
+.4byte sLunatoneSprites5
+.4byte sLunatoneSprites6
+.4byte sLunatoneSprites7
+.4byte sLunatoneSprites8
+.4byte sLunatoneSprites9
+.4byte sLunatoneSprites10
+.4byte sLunatoneSprites11
+.4byte sLunatoneSprites12
+.4byte sLunatoneSprites13
+.4byte sLunatoneSprites14
+.4byte sLunatoneSprites15
+.4byte sLunatoneSprites16
+.4byte sLunatoneSprites17
+.4byte sLunatoneSprites18
+.4byte sLunatoneSprites19
+.4byte sLunatoneSprites20
+.4byte sLunatoneSprites21
+.4byte sLunatoneSprites22
+.4byte sLunatoneSprites23
+.4byte sLunatoneSprites24
+.4byte sLunatoneSprites25
+sAxMainLunatone:
+ax_main sAxPosesLunatone, sAxAnimationsLunatone, 13, sAxSpritesLunatone, sAxPositionsLunatone

--- a/data/ax/luvdisc.inc
+++ b/data/ax/luvdisc.inc
@@ -1,0 +1,2568 @@
+.global gAxLuvdisc
+gAxLuvdisc:
+ax_siro sAxMainLuvdisc
+sLuvdiscPose1:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose2:
+ax_pose 1, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose3:
+ax_pose 2, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose4:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose5:
+ax_pose 4, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose6:
+ax_pose 5, 0x81e7, 0x90f9, 0xac00
+ax_pose_terminator
+sLuvdiscPose7:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose8:
+ax_pose 7, 0x01e7, 0x90f1, 0xac00
+ax_pose_terminator
+sLuvdiscPose9:
+ax_pose 8, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose10:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose11:
+ax_pose 10, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose12:
+ax_pose 11, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose13:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose14:
+ax_pose 13, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose15:
+ax_pose 14, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose16:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose17:
+ax_pose 10, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose18:
+ax_pose 11, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose19:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose20:
+ax_pose 7, 0x01e7, 0x80ef, 0xac00
+ax_pose_terminator
+sLuvdiscPose21:
+ax_pose 8, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose22:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose23:
+ax_pose 4, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose24:
+ax_pose 5, 0x81e7, 0x80f7, 0xac00
+ax_pose_terminator
+sLuvdiscPose25:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose26:
+ax_pose 1, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose27:
+ax_pose 2, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose28:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose29:
+ax_pose 4, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose30:
+ax_pose 5, 0x81e7, 0x90f9, 0xac00
+ax_pose_terminator
+sLuvdiscPose31:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose32:
+ax_pose 7, 0x01e7, 0x90f1, 0xac00
+ax_pose_terminator
+sLuvdiscPose33:
+ax_pose 8, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose34:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose35:
+ax_pose 10, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose36:
+ax_pose 11, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose37:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose38:
+ax_pose 13, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose39:
+ax_pose 14, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose40:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose41:
+ax_pose 10, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose42:
+ax_pose 11, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose43:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose44:
+ax_pose 7, 0x01e7, 0x80ef, 0xac00
+ax_pose_terminator
+sLuvdiscPose45:
+ax_pose 8, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose46:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose47:
+ax_pose 4, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose48:
+ax_pose 5, 0x81e7, 0x80f7, 0xac00
+ax_pose_terminator
+sLuvdiscPose49:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose50:
+ax_pose 1, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose51:
+ax_pose 2, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose52:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose53:
+ax_pose 4, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose54:
+ax_pose 5, 0x81e7, 0x90f9, 0xac00
+ax_pose_terminator
+sLuvdiscPose55:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose56:
+ax_pose 7, 0x01e7, 0x90f1, 0xac00
+ax_pose_terminator
+sLuvdiscPose57:
+ax_pose 8, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose58:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose59:
+ax_pose 10, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose60:
+ax_pose 11, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose61:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose62:
+ax_pose 13, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose63:
+ax_pose 14, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose64:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose65:
+ax_pose 10, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose66:
+ax_pose 11, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose67:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose68:
+ax_pose 7, 0x01e7, 0x80ef, 0xac00
+ax_pose_terminator
+sLuvdiscPose69:
+ax_pose 8, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose70:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose71:
+ax_pose 4, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose72:
+ax_pose 5, 0x81e7, 0x80f7, 0xac00
+ax_pose_terminator
+sLuvdiscPose73:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose74:
+ax_pose 15, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose75:
+ax_pose 16, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose76:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose77:
+ax_pose 17, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose78:
+ax_pose 18, 0x01ed, 0x50f9, 0xac00
+ax_pose 19, 0x01e5, 0x10f9, 0xac04
+ax_pose_terminator
+sLuvdiscPose79:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose80:
+ax_pose 20, 0x81e7, 0x90f7, 0xac00
+ax_pose 21, 0x01ef, 0x10ef, 0xac08
+ax_pose_terminator
+sLuvdiscPose81:
+ax_pose 22, 0x81e8, 0x90f8, 0xac00
+ax_pose 23, 0x01f0, 0x1108, 0xac08
+ax_pose_terminator
+sLuvdiscPose82:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose83:
+ax_pose 24, 0x81e9, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose84:
+ax_pose 25, 0x01eb, 0x50f9, 0xac00
+ax_pose 26, 0x01fb, 0x10f9, 0xac04
+ax_pose_terminator
+sLuvdiscPose85:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose86:
+ax_pose 27, 0x81e8, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose87:
+ax_pose 28, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose88:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose89:
+ax_pose 24, 0x81e9, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose90:
+ax_pose 25, 0x01eb, 0x40f7, 0xac00
+ax_pose 26, 0x01fb, 0x00ff, 0xac04
+ax_pose_terminator
+sLuvdiscPose91:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose92:
+ax_pose 20, 0x81e7, 0x80f9, 0xac00
+ax_pose 21, 0x01ef, 0x0109, 0xac08
+ax_pose_terminator
+sLuvdiscPose93:
+ax_pose 22, 0x81e8, 0x80f8, 0xac00
+ax_pose 23, 0x01f0, 0x00f0, 0xac08
+ax_pose_terminator
+sLuvdiscPose94:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose95:
+ax_pose 17, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose96:
+ax_pose 18, 0x01ed, 0x40f7, 0xac00
+ax_pose 19, 0x01e5, 0x00ff, 0xac04
+ax_pose_terminator
+sLuvdiscPose97:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose98:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose99:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose100:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose101:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose102:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose103:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose104:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose105:
+ax_pose 29, 0x41ef, 0x80f1, 0xac00
+ax_pose_terminator
+sLuvdiscPose106:
+ax_pose 30, 0x41ee, 0x80f1, 0xac00
+ax_pose_terminator
+sLuvdiscPose107:
+ax_pose 31, 0x01e0, 0x80ef, 0xac00
+ax_pose_terminator
+sLuvdiscPose108:
+ax_pose 32, 0x01e4, 0x90ea, 0xac00
+ax_pose_terminator
+sLuvdiscPose109:
+ax_pose 33, 0x01e2, 0x90ee, 0xac00
+ax_pose_terminator
+sLuvdiscPose110:
+ax_pose 34, 0x01e3, 0x90ef, 0xac00
+ax_pose_terminator
+sLuvdiscPose111:
+ax_pose 35, 0x01e3, 0x80f5, 0xac00
+ax_pose_terminator
+sLuvdiscPose112:
+ax_pose 34, 0x01e3, 0x80f1, 0xac00
+ax_pose_terminator
+sLuvdiscPose113:
+ax_pose 33, 0x01e2, 0x80f2, 0xac00
+ax_pose_terminator
+sLuvdiscPose114:
+ax_pose 32, 0x01e4, 0x80f6, 0xac00
+ax_pose_terminator
+sLuvdiscPose115:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose116:
+ax_pose 1, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose117:
+ax_pose 2, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose118:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose119:
+ax_pose 4, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose120:
+ax_pose 5, 0x81e7, 0x90f9, 0xac00
+ax_pose_terminator
+sLuvdiscPose121:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose122:
+ax_pose 7, 0x01e7, 0x90f1, 0xac00
+ax_pose_terminator
+sLuvdiscPose123:
+ax_pose 8, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose124:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose125:
+ax_pose 10, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose126:
+ax_pose 11, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose127:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose128:
+ax_pose 13, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose129:
+ax_pose 14, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose130:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose131:
+ax_pose 10, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose132:
+ax_pose 11, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose133:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose134:
+ax_pose 7, 0x01e7, 0x80ef, 0xac00
+ax_pose_terminator
+sLuvdiscPose135:
+ax_pose 8, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose136:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose137:
+ax_pose 4, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose138:
+ax_pose 5, 0x81e7, 0x80f7, 0xac00
+ax_pose_terminator
+sLuvdiscPose139:
+ax_pose 16, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose140:
+ax_pose 18, 0x01ec, 0x40f7, 0xac00
+ax_pose 19, 0x01e4, 0x00ff, 0xac04
+ax_pose_terminator
+sLuvdiscPose141:
+ax_pose 22, 0x81e8, 0x80f8, 0xac00
+ax_pose 23, 0x01f0, 0x00f0, 0xac08
+ax_pose_terminator
+sLuvdiscPose142:
+ax_pose 25, 0x01eb, 0x40f7, 0xac00
+ax_pose 26, 0x01fb, 0x00ff, 0xac04
+ax_pose_terminator
+sLuvdiscPose143:
+ax_pose 28, 0x81e8, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose144:
+ax_pose 25, 0x01eb, 0x50f9, 0xac00
+ax_pose 26, 0x01fb, 0x10f9, 0xac04
+ax_pose_terminator
+sLuvdiscPose145:
+ax_pose 22, 0x81e8, 0x90f8, 0xac00
+ax_pose 23, 0x01f0, 0x1108, 0xac08
+ax_pose_terminator
+sLuvdiscPose146:
+ax_pose 18, 0x01ec, 0x50f9, 0xac00
+ax_pose 19, 0x01e4, 0x10f9, 0xac04
+ax_pose_terminator
+sLuvdiscPose147:
+ax_pose 15, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose148:
+ax_pose 17, 0x81e7, 0x90f9, 0xac00
+ax_pose_terminator
+sLuvdiscPose149:
+ax_pose 20, 0x81e7, 0x90f8, 0xac00
+ax_pose 21, 0x01ef, 0x10f0, 0xac08
+ax_pose_terminator
+sLuvdiscPose150:
+ax_pose 24, 0x81e8, 0x90f9, 0xac00
+ax_pose_terminator
+sLuvdiscPose151:
+ax_pose 27, 0x81e9, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose152:
+ax_pose 24, 0x81e8, 0x80f7, 0xac00
+ax_pose_terminator
+sLuvdiscPose153:
+ax_pose 20, 0x81e7, 0x80f8, 0xac00
+ax_pose 21, 0x01ef, 0x0108, 0xac08
+ax_pose_terminator
+sLuvdiscPose154:
+ax_pose 17, 0x81e7, 0x80f7, 0xac00
+ax_pose_terminator
+sLuvdiscPose155:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose156:
+ax_pose 15, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose157:
+ax_pose 16, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose158:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose159:
+ax_pose 17, 0x81e9, 0x90f9, 0xac00
+ax_pose_terminator
+sLuvdiscPose160:
+ax_pose 18, 0x01ed, 0x50f9, 0xac00
+ax_pose 19, 0x01e5, 0x10f9, 0xac04
+ax_pose_terminator
+sLuvdiscPose161:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose162:
+ax_pose 20, 0x81e7, 0x90f8, 0xac00
+ax_pose 21, 0x01ef, 0x10f0, 0xac08
+ax_pose_terminator
+sLuvdiscPose163:
+ax_pose 22, 0x81e8, 0x90f8, 0xac00
+ax_pose 23, 0x01f0, 0x1108, 0xac08
+ax_pose_terminator
+sLuvdiscPose164:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose165:
+ax_pose 24, 0x81e9, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose166:
+ax_pose 25, 0x01eb, 0x50fa, 0xac00
+ax_pose 26, 0x01fb, 0x10fa, 0xac04
+ax_pose_terminator
+sLuvdiscPose167:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose168:
+ax_pose 27, 0x81e8, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose169:
+ax_pose 28, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose170:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose171:
+ax_pose 24, 0x81e9, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose172:
+ax_pose 25, 0x01eb, 0x40f6, 0xac00
+ax_pose 26, 0x01fb, 0x00fe, 0xac04
+ax_pose_terminator
+sLuvdiscPose173:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose174:
+ax_pose 20, 0x81e7, 0x80f8, 0xac00
+ax_pose 21, 0x01ef, 0x0108, 0xac08
+ax_pose_terminator
+sLuvdiscPose175:
+ax_pose 22, 0x81e8, 0x80f8, 0xac00
+ax_pose 23, 0x01f0, 0x00f0, 0xac08
+ax_pose_terminator
+sLuvdiscPose176:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose177:
+ax_pose 17, 0x81e9, 0x80f7, 0xac00
+ax_pose_terminator
+sLuvdiscPose178:
+ax_pose 18, 0x01ed, 0x40f7, 0xac00
+ax_pose 19, 0x01e5, 0x00ff, 0xac04
+ax_pose_terminator
+sLuvdiscPose179:
+ax_pose 16, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose180:
+ax_pose 18, 0x01ec, 0x40f7, 0xac00
+ax_pose 19, 0x01e4, 0x00ff, 0xac04
+ax_pose_terminator
+sLuvdiscPose181:
+ax_pose 22, 0x81e8, 0x80f8, 0xac00
+ax_pose 23, 0x01f0, 0x00f0, 0xac08
+ax_pose_terminator
+sLuvdiscPose182:
+ax_pose 25, 0x01eb, 0x40f7, 0xac00
+ax_pose 26, 0x01fb, 0x00ff, 0xac04
+ax_pose_terminator
+sLuvdiscPose183:
+ax_pose 28, 0x81e8, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose184:
+ax_pose 25, 0x01eb, 0x50f9, 0xac00
+ax_pose 26, 0x01fb, 0x10f9, 0xac04
+ax_pose_terminator
+sLuvdiscPose185:
+ax_pose 22, 0x81e8, 0x90f8, 0xac00
+ax_pose 23, 0x01f0, 0x1108, 0xac08
+ax_pose_terminator
+sLuvdiscPose186:
+ax_pose 18, 0x01ec, 0x50f9, 0xac00
+ax_pose 19, 0x01e4, 0x10f9, 0xac04
+ax_pose_terminator
+sLuvdiscPose187:
+ax_pose 0, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose188:
+ax_pose 3, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose189:
+ax_pose 6, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose190:
+ax_pose 9, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose191:
+ax_pose 12, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose192:
+ax_pose 9, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+sLuvdiscPose193:
+ax_pose 6, 0x01e7, 0x90f0, 0xac00
+ax_pose_terminator
+sLuvdiscPose194:
+ax_pose 3, 0x81e7, 0x90f8, 0xac00
+ax_pose_terminator
+.align 2
+sLuvdiscAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 6, 0, 24, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 2, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 24, 0, 22,
+ax_anim 2, 1, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 24, 0, 24, 0, 22,
+ax_anim 2, 0, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sLuvdiscAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 6, 0, 27, -3, -3, -3, -3,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 2, 0, 29, 10, 11, 10, 10,
+ax_anim 2, 0, 27, 22, 25, 22, 22,
+ax_anim 2, 1, 27, 23, 24, 23, 21,
+ax_anim 2, 0, 27, 22, 25, 22, 22,
+ax_anim 2, 0, 27, 23, 24, 23, 21,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sLuvdiscAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 6, 0, 30, -3, 0, -3, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 2, 0, 32, 10, 1, 10, 0,
+ax_anim 2, 0, 30, 22, 3, 22, 0,
+ax_anim 2, 1, 30, 22, 4, 22, 1,
+ax_anim 2, 0, 30, 22, 3, 22, 0,
+ax_anim 2, 0, 30, 22, 4, 22, 1,
+ax_anim 2, 0, 30, 6, 1, 6, 0,
+ax_anim_terminator
+sLuvdiscAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 6, 0, 33, -3, 3, -3, 3,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -5, 5, -5,
+ax_anim 2, 0, 35, 12, -11, 12, -12,
+ax_anim 2, 0, 33, 23, -19, 23, -22,
+ax_anim 2, 1, 33, 24, -18, 24, -21,
+ax_anim 2, 0, 33, 23, -19, 23, -22,
+ax_anim 2, 0, 33, 24, -18, 24, -21,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sLuvdiscAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 6, 0, 36, 0, 3, 0, 3,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 2, 0, 38, 0, -11, 0, -12,
+ax_anim 2, 0, 36, 0, -19, 0, -24,
+ax_anim 2, 1, 36, 1, -19, 1, -24,
+ax_anim 2, 0, 36, 0, -19, 0, -24,
+ax_anim 2, 0, 36, 1, -19, 1, -24,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sLuvdiscAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 6, 0, 39, 3, 3, 3, 3,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -5, -5, -5,
+ax_anim 2, 0, 41, -12, -11, -12, -12,
+ax_anim 2, 0, 39, -23, -19, -23, -22,
+ax_anim 2, 1, 39, -24, -18, -24, -21,
+ax_anim 2, 0, 39, -23, -19, -23, -22,
+ax_anim 2, 0, 39, -24, -18, -24, -21,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sLuvdiscAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 6, 0, 42, 3, 0, 3, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 2, 0, 44, -10, 1, -10, 0,
+ax_anim 2, 0, 42, -22, 3, -22, 0,
+ax_anim 2, 1, 42, -22, 4, -22, 1,
+ax_anim 2, 0, 42, -22, 3, -22, 0,
+ax_anim 2, 0, 42, -22, 4, -22, 1,
+ax_anim 2, 0, 42, -6, 1, -6, 0,
+ax_anim_terminator
+sLuvdiscAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 6, 0, 45, 3, -3, 3, -3,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 2, 0, 47, -10, 11, -10, 10,
+ax_anim 2, 0, 45, -22, 25, -22, 22,
+ax_anim 2, 1, 45, -23, 24, -23, 21,
+ax_anim 2, 0, 45, -22, 25, -22, 22,
+ax_anim 2, 0, 45, -23, 24, -23, 21,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 6, 0, 48, 0, -3, 0, -3,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 8, 0, 8,
+ax_anim 2, 0, 50, 0, 24, 0, 24,
+ax_anim 2, 0, 48, 0, 48, 0, 45,
+ax_anim 2, 1, 48, 1, 48, 1, 45,
+ax_anim 2, 0, 48, 0, 48, 0, 45,
+ax_anim 2, 0, 48, 1, 48, 1, 45,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sLuvdiscAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 51, -2, -2, -2, -2,
+ax_anim 6, 0, 51, -3, -3, -3, -3,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 8, 8, 8, 8,
+ax_anim 2, 0, 53, 24, 24, 24, 24,
+ax_anim 2, 0, 51, 46, 49, 46, 46,
+ax_anim 2, 1, 51, 47, 48, 47, 45,
+ax_anim 2, 0, 51, 46, 49, 46, 46,
+ax_anim 2, 0, 51, 47, 48, 47, 45,
+ax_anim 2, 0, 51, 20, 20, 20, 20,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sLuvdiscAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 2, 0, 54, -2, 0, -2, 0,
+ax_anim 6, 0, 54, -3, 0, -3, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 8, 0, 8, 0,
+ax_anim 2, 0, 56, 24, 1, 24, 0,
+ax_anim 2, 0, 54, 46, 3, 46, 0,
+ax_anim 2, 1, 54, 46, 4, 46, 1,
+ax_anim 2, 0, 54, 46, 3, 46, 0,
+ax_anim 2, 0, 54, 46, 4, 46, 1,
+ax_anim 2, 0, 54, 20, 1, 20, 0,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sLuvdiscAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 2, 0, 57, -2, 2, -2, 2,
+ax_anim 6, 0, 57, -3, 3, -3, 3,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 10, -10, 10, -10,
+ax_anim 2, 0, 59, 25, -23, 25, -25,
+ax_anim 2, 0, 57, 47, -43, 47, -46,
+ax_anim 2, 1, 57, 48, -42, 48, -45,
+ax_anim 2, 0, 57, 47, -43, 47, -46,
+ax_anim 2, 0, 57, 48, -42, 48, -45,
+ax_anim 2, 0, 57, 21, -19, 21, -21,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sLuvdiscAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 60, 0, 2, 0, 2,
+ax_anim 6, 0, 60, 0, 3, 0, 3,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -8, 0, -8,
+ax_anim 2, 0, 62, 0, -22, 0, -23,
+ax_anim 2, 0, 60, 0, -43, 0, -48,
+ax_anim 2, 1, 60, 1, -43, 1, -48,
+ax_anim 2, 0, 60, 0, -43, 0, -48,
+ax_anim 2, 0, 60, 1, -43, 1, -48,
+ax_anim 2, 0, 60, 0, -16, 0, -16,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sLuvdiscAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 6, 0, 63, 3, 3, 3, 3,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -10, -10, -10, -10,
+ax_anim 2, 0, 65, -25, -23, -25, -25,
+ax_anim 2, 0, 63, -47, -43, -47, -46,
+ax_anim 2, 1, 63, -48, -42, -48, -45,
+ax_anim 2, 0, 63, -47, -43, -47, -46,
+ax_anim 2, 0, 63, -48, -42, -48, -45,
+ax_anim 2, 0, 63, -21, -19, -21, -21,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sLuvdiscAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 2, 0, 66, 2, 0, 2, 0,
+ax_anim 6, 0, 66, 3, 0, 3, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -8, 0, -8, 0,
+ax_anim 2, 0, 68, -24, 1, -24, 0,
+ax_anim 2, 0, 66, -46, 3, -46, 0,
+ax_anim 2, 1, 66, -46, 4, -46, 1,
+ax_anim 2, 0, 66, -46, 3, -46, 0,
+ax_anim 2, 0, 66, -46, 4, -46, 1,
+ax_anim 2, 0, 66, -20, 1, -20, 0,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sLuvdiscAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 2, 0, 69, 2, -2, 2, -2,
+ax_anim 6, 0, 69, 3, -3, 3, -3,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -8, 8, -8, 8,
+ax_anim 2, 0, 71, -24, 24, -24, 24,
+ax_anim 2, 0, 69, -46, 49, -46, 46,
+ax_anim 2, 1, 69, -47, 48, -47, 45,
+ax_anim 2, 0, 69, -46, 49, -46, 46,
+ax_anim 2, 0, 69, -47, 48, -47, 45,
+ax_anim 2, 0, 69, -20, 20, -20, 20,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sLuvdiscAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sLuvdiscAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sLuvdiscAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sLuvdiscAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sLuvdiscAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sLuvdiscAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sLuvdiscAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_5_1:
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -1, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 6, 2, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 1, -5, 1, 0,
+ax_anim 2, 1, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 1, -5, 1, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_5_2:
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 6, 2, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 103, -1, -4, -1, 1,
+ax_anim 2, 1, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 103, -1, -4, -1, 1,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_5_3:
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -1, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -3, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 6, 2, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -6, 0, -1,
+ax_anim 2, 1, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -6, 0, -1,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_5_4:
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 6, 2, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, -1, -6, -1, -1,
+ax_anim 2, 1, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, -1, -6, -1, -1,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_5_5:
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -1, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 6, 2, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 1, -5, 1, 0,
+ax_anim 2, 1, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 1, -5, 1, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_5_6:
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 6, 2, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 1, -6, 1, -1,
+ax_anim 2, 1, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 1, -6, 1, -1,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 99, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_5_7:
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, -1, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 6, 2, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -6, 0, -1,
+ax_anim 2, 1, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -6, 0, -1,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_5_8:
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -1, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 6, 2, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 1, -4, 1, 1,
+ax_anim 2, 1, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 1, -4, 1, 1,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_6_1:
+ax_anim 16, 0, 104, 0, 0, 0, 0,
+ax_anim 12, 0, 104, 0, -1, 0, 0,
+ax_anim 16, 0, 104, 0, -2, 0, 0,
+ax_anim 16, 0, 105, 0, -1, 0, 0,
+ax_anim 12, 0, 105, 0, 0, 0, 0,
+ax_anim 16, 0, 105, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sLuvdiscAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sLuvdiscAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sLuvdiscAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sLuvdiscAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sLuvdiscAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sLuvdiscAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sLuvdiscAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_8_1:
+ax_anim 34, 0, 114, 0, 0, 0, 0,
+ax_anim 8, 0, 115, 0, -1, 0, 0,
+ax_anim 8, 0, 114, 0, -1, 0, 0,
+ax_anim 8, 0, 116, 0, -2, 0, 0,
+ax_anim 8, 0, 114, 0, -2, 0, 0,
+ax_anim 8, 0, 115, 0, -2, 0, 0,
+ax_anim 8, 0, 114, 0, -1, 0, 0,
+ax_anim 8, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_8_2:
+ax_anim 34, 0, 117, 0, 0, 0, 0,
+ax_anim 8, 0, 118, 1, -1, 0, 0,
+ax_anim 8, 0, 117, 1, -1, 0, 0,
+ax_anim 8, 0, 119, 0, -2, 0, 0,
+ax_anim 8, 0, 117, 0, -2, 0, 0,
+ax_anim 8, 0, 118, 0, -2, 0, 0,
+ax_anim 8, 0, 117, 0, -1, 0, 0,
+ax_anim 8, 0, 119, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_8_3:
+ax_anim 34, 0, 120, 0, 0, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim 8, 0, 120, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, -2, 0, 0,
+ax_anim 8, 0, 120, 0, -2, 0, 0,
+ax_anim 8, 0, 121, 0, -2, 0, 0,
+ax_anim 8, 0, 120, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_8_4:
+ax_anim 34, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 1, -1, 0, 0,
+ax_anim 8, 0, 123, 1, -1, 0, 0,
+ax_anim 8, 0, 125, 0, -2, 0, 0,
+ax_anim 8, 0, 123, 0, -2, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 8, 0, 123, 0, -1, 0, 0,
+ax_anim 8, 0, 125, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_8_5:
+ax_anim 34, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, -2, 0, 0,
+ax_anim 8, 0, 126, 0, -2, 0, 0,
+ax_anim 8, 0, 127, 0, -2, 0, 0,
+ax_anim 8, 0, 126, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_8_6:
+ax_anim 34, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 130, -1, -1, 0, 0,
+ax_anim 8, 0, 129, -1, -1, 0, 0,
+ax_anim 8, 0, 131, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -2, 0, 0,
+ax_anim 8, 0, 130, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -1, 0, 0,
+ax_anim 8, 0, 131, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_8_7:
+ax_anim 34, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, -1, 0, 0,
+ax_anim 8, 0, 132, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, -2, 0, 0,
+ax_anim 8, 0, 132, 0, -2, 0, 0,
+ax_anim 8, 0, 133, 0, -2, 0, 0,
+ax_anim 8, 0, 132, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_8_8:
+ax_anim 34, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 136, -1, -1, 0, 0,
+ax_anim 8, 0, 135, -1, -1, 0, 0,
+ax_anim 8, 0, 137, 0, -2, 0, 0,
+ax_anim 8, 0, 135, 0, -2, 0, 0,
+ax_anim 8, 0, 136, 0, -2, 0, 0,
+ax_anim 8, 0, 135, 0, -1, 0, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 8, 4, 8, 4,
+ax_anim 2, 0, 140, 11, 12, 11, 12,
+ax_anim 2, 0, 141, 8, 19, 8, 19,
+ax_anim 3, 0, 142, 0, 23, 0, 23,
+ax_anim 2, 3, 143, -8, 19, -8, 19,
+ax_anim 2, 0, 144, -11, 12, -11, 12,
+ax_anim 1, 0, 145, -8, 4, -8, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 10, 1, 10, 1,
+ax_anim 2, 0, 139, 19, 6, 19, 6,
+ax_anim 2, 0, 140, 23, 16, 23, 15,
+ax_anim 3, 0, 141, 23, 24, 23, 22,
+ax_anim 2, 3, 142, 13, 25, 13, 25,
+ax_anim 2, 0, 143, 5, 17, 5, 17,
+ax_anim 1, 0, 144, 1, 8, 1, 8,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 5, -4, 5, -4,
+ax_anim 2, 0, 138, 12, -4, 12, -4,
+ax_anim 2, 0, 139, 20, -2, 20, -3,
+ax_anim 3, 0, 140, 24, 3, 24, 1,
+ax_anim 2, 3, 141, 17, 8, 17, 7,
+ax_anim 2, 0, 142, 11, 8, 11, 8,
+ax_anim 1, 0, 143, 4, 6, 4, 6,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 1, -8, 1, -8,
+ax_anim 2, 0, 145, 6, -15, 6, -15,
+ax_anim 2, 0, 138, 14, -19, 14, -21,
+ax_anim 3, 0, 139, 22, -19, 22, -22,
+ax_anim 2, 3, 140, 22, -12, 22, -14,
+ax_anim 2, 0, 141, 18, -7, 18, -7,
+ax_anim 1, 0, 142, 12, -1, 12, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -9, -4, -9, -4,
+ax_anim 2, 0, 144, -10, -11, -10, -11,
+ax_anim 2, 0, 145, -6, -17, -6, -19,
+ax_anim 3, 0, 138, 0, -20, 0, -22,
+ax_anim 2, 3, 139, 6, -17, 6, -19,
+ax_anim 2, 0, 140, 10, -11, 10, -11,
+ax_anim 1, 0, 141, 9, -4, 9, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -1, -8, -1, -8,
+ax_anim 2, 0, 139, -6, -15, -6, -15,
+ax_anim 2, 0, 138, -14, -19, -14, -21,
+ax_anim 3, 0, 145, -22, -19, -22, -22,
+ax_anim 2, 3, 144, -22, -12, -22, -14,
+ax_anim 2, 0, 143, -18, -7, -18, -7,
+ax_anim 1, 0, 142, -12, -1, -12, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -5, -4, -5, -4,
+ax_anim 2, 0, 138, -12, -4, -12, -4,
+ax_anim 2, 0, 145, -20, -2, -20, -3,
+ax_anim 3, 0, 144, -24, 3, -24, 1,
+ax_anim 2, 3, 143, -17, 8, -17, 7,
+ax_anim 2, 0, 142, -11, 8, -11, 8,
+ax_anim 1, 0, 141, -4, 6, -4, 6,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -10, 1, -10, 1,
+ax_anim 2, 0, 145, -19, 6, -19, 6,
+ax_anim 2, 0, 144, -23, 16, -23, 15,
+ax_anim 3, 0, 143, -23, 24, -23, 22,
+ax_anim 2, 3, 142, -13, 25, -13, 25,
+ax_anim 2, 0, 141, -5, 17, -5, 17,
+ax_anim 1, 0, 140, -1, 8, -1, 8,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 156, 0, -21, 0, 0,
+ax_anim 2, 0, 156, 0, -15, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 2, 156, 0, 3, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -23, 0, 0,
+ax_anim 2, 0, 159, 0, -15, 0, 0,
+ax_anim 1, 0, 159, 0, -9, 0, 0,
+ax_anim 2, 2, 159, 0, 4, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 2, 162, 0, 4, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -15, 0, 0,
+ax_anim 1, 0, 165, 0, -9, 0, 0,
+ax_anim 2, 2, 165, 0, 3, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -15, 0, 0,
+ax_anim 1, 0, 168, 0, -9, 0, 0,
+ax_anim 2, 2, 168, 0, 3, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -9, 0, 0,
+ax_anim 2, 2, 171, 0, 3, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 2, 174, 0, 4, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -23, 0, 0,
+ax_anim 2, 0, 177, 0, -15, 0, 0,
+ax_anim 1, 0, 177, 0, -9, 0, 0,
+ax_anim 2, 2, 177, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sLuvdiscAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sLuvdiscGfx1:
+.incbin "baserom.gba", 0x15405F8, 0x100
+sLuvdiscSprites1:
+ax_sprite sLuvdiscGfx1, 0x100
+ax_sprite_terminator
+sLuvdiscGfx2:
+.incbin "baserom.gba", 0x1540708, 0x100
+sLuvdiscSprites2:
+ax_sprite sLuvdiscGfx2, 0x100
+ax_sprite_terminator
+sLuvdiscGfx3:
+.incbin "baserom.gba", 0x1540818, 0x100
+sLuvdiscSprites3:
+ax_sprite sLuvdiscGfx3, 0x100
+ax_sprite_terminator
+sLuvdiscGfx4:
+.incbin "baserom.gba", 0x1540928, 0x100
+sLuvdiscSprites4:
+ax_sprite sLuvdiscGfx4, 0x100
+ax_sprite_terminator
+sLuvdiscGfx5:
+.incbin "baserom.gba", 0x1540A38, 0x100
+sLuvdiscSprites5:
+ax_sprite sLuvdiscGfx5, 0x100
+ax_sprite_terminator
+sLuvdiscGfx6:
+.incbin "baserom.gba", 0x1540B48, 0x100
+sLuvdiscSprites6:
+ax_sprite sLuvdiscGfx6, 0x100
+ax_sprite_terminator
+sLuvdiscGfx7:
+.incbin "baserom.gba", 0x1540C58, 0x200
+sLuvdiscSprites7:
+ax_sprite sLuvdiscGfx7, 0x200
+ax_sprite_terminator
+sLuvdiscGfx8:
+.incbin "baserom.gba", 0x1540E68, 0x200
+sLuvdiscSprites8:
+ax_sprite sLuvdiscGfx8, 0x200
+ax_sprite_terminator
+sLuvdiscGfx9:
+.incbin "baserom.gba", 0x1541078, 0x200
+sLuvdiscSprites9:
+ax_sprite sLuvdiscGfx9, 0x200
+ax_sprite_terminator
+sLuvdiscGfx10:
+.incbin "baserom.gba", 0x1541288, 0x100
+sLuvdiscSprites10:
+ax_sprite sLuvdiscGfx10, 0x100
+ax_sprite_terminator
+sLuvdiscGfx11:
+.incbin "baserom.gba", 0x1541398, 0x100
+sLuvdiscSprites11:
+ax_sprite sLuvdiscGfx11, 0x100
+ax_sprite_terminator
+sLuvdiscGfx12:
+.incbin "baserom.gba", 0x15414A8, 0x100
+sLuvdiscSprites12:
+ax_sprite sLuvdiscGfx12, 0x100
+ax_sprite_terminator
+sLuvdiscGfx13:
+.incbin "baserom.gba", 0x15415B8, 0x100
+sLuvdiscSprites13:
+ax_sprite sLuvdiscGfx13, 0x100
+ax_sprite_terminator
+sLuvdiscGfx14:
+.incbin "baserom.gba", 0x15416C8, 0x100
+sLuvdiscSprites14:
+ax_sprite sLuvdiscGfx14, 0x100
+ax_sprite_terminator
+sLuvdiscGfx15:
+.incbin "baserom.gba", 0x15417D8, 0x100
+sLuvdiscSprites15:
+ax_sprite sLuvdiscGfx15, 0x100
+ax_sprite_terminator
+sLuvdiscGfx16:
+.incbin "baserom.gba", 0x15418E8, 0xC0
+sLuvdiscSprites16:
+ax_sprite sLuvdiscGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx17:
+.incbin "baserom.gba", 0x15419C0, 0xC0
+sLuvdiscSprites17:
+ax_sprite sLuvdiscGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx18:
+.incbin "baserom.gba", 0x1541A98, 0xC0
+sLuvdiscSprites18:
+ax_sprite sLuvdiscGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx19:
+.incbin "baserom.gba", 0x1541B70, 0x80
+sLuvdiscSprites19:
+ax_sprite sLuvdiscGfx19, 0x80
+ax_sprite_terminator
+sLuvdiscGfx20:
+.incbin "baserom.gba", 0x1541C00, 0x20
+sLuvdiscSprites20:
+ax_sprite sLuvdiscGfx20, 0x20
+ax_sprite_terminator
+sLuvdiscGfx21:
+.incbin "baserom.gba", 0x1541C30, 0xC0
+sLuvdiscSprites21:
+ax_sprite sLuvdiscGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx22:
+.incbin "baserom.gba", 0x1541D08, 0x20
+sLuvdiscSprites22:
+ax_sprite sLuvdiscGfx22, 0x20
+ax_sprite_terminator
+sLuvdiscGfx23:
+.incbin "baserom.gba", 0x1541D38, 0xC0
+sLuvdiscSprites23:
+ax_sprite sLuvdiscGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx24:
+.incbin "baserom.gba", 0x1541E10, 0x20
+sLuvdiscSprites24:
+ax_sprite sLuvdiscGfx24, 0x20
+ax_sprite_terminator
+sLuvdiscGfx25:
+.incbin "baserom.gba", 0x1541E40, 0xC0
+sLuvdiscSprites25:
+ax_sprite sLuvdiscGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx26:
+.incbin "baserom.gba", 0x1541F18, 0x80
+sLuvdiscSprites26:
+ax_sprite sLuvdiscGfx26, 0x80
+ax_sprite_terminator
+sLuvdiscGfx27:
+.incbin "baserom.gba", 0x1541FA8, 0x20
+sLuvdiscSprites27:
+ax_sprite sLuvdiscGfx27, 0x20
+ax_sprite_terminator
+sLuvdiscGfx28:
+.incbin "baserom.gba", 0x1541FD8, 0xC0
+sLuvdiscSprites28:
+ax_sprite sLuvdiscGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx29:
+.incbin "baserom.gba", 0x15420B0, 0xC0
+sLuvdiscSprites29:
+ax_sprite sLuvdiscGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sLuvdiscGfx30:
+.incbin "baserom.gba", 0x1542188, 0x100
+sLuvdiscSprites30:
+ax_sprite sLuvdiscGfx30, 0x100
+ax_sprite_terminator
+sLuvdiscGfx31:
+.incbin "baserom.gba", 0x1542298, 0x100
+sLuvdiscSprites31:
+ax_sprite sLuvdiscGfx31, 0x100
+ax_sprite_terminator
+sLuvdiscGfx32:
+.incbin "baserom.gba", 0x15423A8, 0x200
+sLuvdiscSprites32:
+ax_sprite sLuvdiscGfx32, 0x200
+ax_sprite_terminator
+sLuvdiscGfx33:
+.incbin "baserom.gba", 0x15425B8, 0x200
+sLuvdiscSprites33:
+ax_sprite sLuvdiscGfx33, 0x200
+ax_sprite_terminator
+sLuvdiscGfx34:
+.incbin "baserom.gba", 0x15427C8, 0x200
+sLuvdiscSprites34:
+ax_sprite sLuvdiscGfx34, 0x200
+ax_sprite_terminator
+sLuvdiscGfx35:
+.incbin "baserom.gba", 0x15429D8, 0x200
+sLuvdiscSprites35:
+ax_sprite sLuvdiscGfx35, 0x200
+ax_sprite_terminator
+sLuvdiscGfx36:
+.incbin "baserom.gba", 0x1542BE8, 0x200
+sLuvdiscSprites36:
+ax_sprite sLuvdiscGfx36, 0x200
+ax_sprite_terminator
+sAxPosesLuvdisc:
+.4byte sLuvdiscPose1
+.4byte sLuvdiscPose2
+.4byte sLuvdiscPose3
+.4byte sLuvdiscPose4
+.4byte sLuvdiscPose5
+.4byte sLuvdiscPose6
+.4byte sLuvdiscPose7
+.4byte sLuvdiscPose8
+.4byte sLuvdiscPose9
+.4byte sLuvdiscPose10
+.4byte sLuvdiscPose11
+.4byte sLuvdiscPose12
+.4byte sLuvdiscPose13
+.4byte sLuvdiscPose14
+.4byte sLuvdiscPose15
+.4byte sLuvdiscPose16
+.4byte sLuvdiscPose17
+.4byte sLuvdiscPose18
+.4byte sLuvdiscPose19
+.4byte sLuvdiscPose20
+.4byte sLuvdiscPose21
+.4byte sLuvdiscPose22
+.4byte sLuvdiscPose23
+.4byte sLuvdiscPose24
+.4byte sLuvdiscPose25
+.4byte sLuvdiscPose26
+.4byte sLuvdiscPose27
+.4byte sLuvdiscPose28
+.4byte sLuvdiscPose29
+.4byte sLuvdiscPose30
+.4byte sLuvdiscPose31
+.4byte sLuvdiscPose32
+.4byte sLuvdiscPose33
+.4byte sLuvdiscPose34
+.4byte sLuvdiscPose35
+.4byte sLuvdiscPose36
+.4byte sLuvdiscPose37
+.4byte sLuvdiscPose38
+.4byte sLuvdiscPose39
+.4byte sLuvdiscPose40
+.4byte sLuvdiscPose41
+.4byte sLuvdiscPose42
+.4byte sLuvdiscPose43
+.4byte sLuvdiscPose44
+.4byte sLuvdiscPose45
+.4byte sLuvdiscPose46
+.4byte sLuvdiscPose47
+.4byte sLuvdiscPose48
+.4byte sLuvdiscPose49
+.4byte sLuvdiscPose50
+.4byte sLuvdiscPose51
+.4byte sLuvdiscPose52
+.4byte sLuvdiscPose53
+.4byte sLuvdiscPose54
+.4byte sLuvdiscPose55
+.4byte sLuvdiscPose56
+.4byte sLuvdiscPose57
+.4byte sLuvdiscPose58
+.4byte sLuvdiscPose59
+.4byte sLuvdiscPose60
+.4byte sLuvdiscPose61
+.4byte sLuvdiscPose62
+.4byte sLuvdiscPose63
+.4byte sLuvdiscPose64
+.4byte sLuvdiscPose65
+.4byte sLuvdiscPose66
+.4byte sLuvdiscPose67
+.4byte sLuvdiscPose68
+.4byte sLuvdiscPose69
+.4byte sLuvdiscPose70
+.4byte sLuvdiscPose71
+.4byte sLuvdiscPose72
+.4byte sLuvdiscPose73
+.4byte sLuvdiscPose74
+.4byte sLuvdiscPose75
+.4byte sLuvdiscPose76
+.4byte sLuvdiscPose77
+.4byte sLuvdiscPose78
+.4byte sLuvdiscPose79
+.4byte sLuvdiscPose80
+.4byte sLuvdiscPose81
+.4byte sLuvdiscPose82
+.4byte sLuvdiscPose83
+.4byte sLuvdiscPose84
+.4byte sLuvdiscPose85
+.4byte sLuvdiscPose86
+.4byte sLuvdiscPose87
+.4byte sLuvdiscPose88
+.4byte sLuvdiscPose89
+.4byte sLuvdiscPose90
+.4byte sLuvdiscPose91
+.4byte sLuvdiscPose92
+.4byte sLuvdiscPose93
+.4byte sLuvdiscPose94
+.4byte sLuvdiscPose95
+.4byte sLuvdiscPose96
+.4byte sLuvdiscPose97
+.4byte sLuvdiscPose98
+.4byte sLuvdiscPose99
+.4byte sLuvdiscPose100
+.4byte sLuvdiscPose101
+.4byte sLuvdiscPose102
+.4byte sLuvdiscPose103
+.4byte sLuvdiscPose104
+.4byte sLuvdiscPose105
+.4byte sLuvdiscPose106
+.4byte sLuvdiscPose107
+.4byte sLuvdiscPose108
+.4byte sLuvdiscPose109
+.4byte sLuvdiscPose110
+.4byte sLuvdiscPose111
+.4byte sLuvdiscPose112
+.4byte sLuvdiscPose113
+.4byte sLuvdiscPose114
+.4byte sLuvdiscPose115
+.4byte sLuvdiscPose116
+.4byte sLuvdiscPose117
+.4byte sLuvdiscPose118
+.4byte sLuvdiscPose119
+.4byte sLuvdiscPose120
+.4byte sLuvdiscPose121
+.4byte sLuvdiscPose122
+.4byte sLuvdiscPose123
+.4byte sLuvdiscPose124
+.4byte sLuvdiscPose125
+.4byte sLuvdiscPose126
+.4byte sLuvdiscPose127
+.4byte sLuvdiscPose128
+.4byte sLuvdiscPose129
+.4byte sLuvdiscPose130
+.4byte sLuvdiscPose131
+.4byte sLuvdiscPose132
+.4byte sLuvdiscPose133
+.4byte sLuvdiscPose134
+.4byte sLuvdiscPose135
+.4byte sLuvdiscPose136
+.4byte sLuvdiscPose137
+.4byte sLuvdiscPose138
+.4byte sLuvdiscPose139
+.4byte sLuvdiscPose140
+.4byte sLuvdiscPose141
+.4byte sLuvdiscPose142
+.4byte sLuvdiscPose143
+.4byte sLuvdiscPose144
+.4byte sLuvdiscPose145
+.4byte sLuvdiscPose146
+.4byte sLuvdiscPose147
+.4byte sLuvdiscPose148
+.4byte sLuvdiscPose149
+.4byte sLuvdiscPose150
+.4byte sLuvdiscPose151
+.4byte sLuvdiscPose152
+.4byte sLuvdiscPose153
+.4byte sLuvdiscPose154
+.4byte sLuvdiscPose155
+.4byte sLuvdiscPose156
+.4byte sLuvdiscPose157
+.4byte sLuvdiscPose158
+.4byte sLuvdiscPose159
+.4byte sLuvdiscPose160
+.4byte sLuvdiscPose161
+.4byte sLuvdiscPose162
+.4byte sLuvdiscPose163
+.4byte sLuvdiscPose164
+.4byte sLuvdiscPose165
+.4byte sLuvdiscPose166
+.4byte sLuvdiscPose167
+.4byte sLuvdiscPose168
+.4byte sLuvdiscPose169
+.4byte sLuvdiscPose170
+.4byte sLuvdiscPose171
+.4byte sLuvdiscPose172
+.4byte sLuvdiscPose173
+.4byte sLuvdiscPose174
+.4byte sLuvdiscPose175
+.4byte sLuvdiscPose176
+.4byte sLuvdiscPose177
+.4byte sLuvdiscPose178
+.4byte sLuvdiscPose179
+.4byte sLuvdiscPose180
+.4byte sLuvdiscPose181
+.4byte sLuvdiscPose182
+.4byte sLuvdiscPose183
+.4byte sLuvdiscPose184
+.4byte sLuvdiscPose185
+.4byte sLuvdiscPose186
+.4byte sLuvdiscPose187
+.4byte sLuvdiscPose188
+.4byte sLuvdiscPose189
+.4byte sLuvdiscPose190
+.4byte sLuvdiscPose191
+.4byte sLuvdiscPose192
+.4byte sLuvdiscPose193
+.4byte sLuvdiscPose194
+sAxPositionsLuvdisc:
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte    1,   -8, 	  -3,  -13, 	   2,  -15, 	  -1,  -13
+.2byte   -2,   -8, 	  -3,  -14, 	   3,  -13, 	   0,  -13
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+.2byte    5,  -10, 	   2,  -16, 	  -1,  -13, 	  -1,  -12
+.2byte    7,  -10, 	   3,  -17, 	   2,  -14, 	   1,  -12
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    8,  -11, 	   3,  -16, 	   1,  -14, 	   0,  -12
+.2byte    8,  -11, 	   1,  -16, 	   2,  -14, 	   1,  -12
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   1,  -15, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   2,  -16, 	   1,  -12
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    0,  -13, 	   4,  -15, 	  -3,  -15, 	   0,  -12
+.2byte   -1,  -13, 	   2,  -15, 	  -5,  -16, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -2,  -15, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -3,  -16, 	  -2,  -12
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -4,  -16, 	  -2,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -2,  -16, 	  -3,  -14, 	  -2,  -12
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -6,  -10, 	  -3,  -16, 	   0,  -13, 	   0,  -12
+.2byte   -8,  -10, 	  -4,  -17, 	  -3,  -14, 	  -2,  -12
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte    1,   -8, 	  -3,  -13, 	   2,  -15, 	  -1,  -13
+.2byte   -2,   -8, 	  -3,  -14, 	   3,  -13, 	   0,  -13
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+.2byte    5,  -10, 	   2,  -16, 	  -1,  -13, 	  -1,  -12
+.2byte    7,  -10, 	   3,  -17, 	   2,  -14, 	   1,  -12
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    8,  -11, 	   3,  -16, 	   1,  -14, 	   0,  -12
+.2byte    8,  -11, 	   1,  -16, 	   2,  -14, 	   1,  -12
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   1,  -15, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   2,  -16, 	   1,  -12
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    0,  -13, 	   4,  -15, 	  -3,  -15, 	   0,  -12
+.2byte   -1,  -13, 	   2,  -15, 	  -5,  -16, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -2,  -15, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -3,  -16, 	  -2,  -12
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -4,  -16, 	  -2,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -2,  -16, 	  -3,  -14, 	  -2,  -12
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -6,  -10, 	  -3,  -16, 	   0,  -13, 	   0,  -12
+.2byte   -8,  -10, 	  -4,  -17, 	  -3,  -14, 	  -2,  -12
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte    1,   -8, 	  -3,  -13, 	   2,  -15, 	  -1,  -13
+.2byte   -2,   -8, 	  -3,  -14, 	   3,  -13, 	   0,  -13
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+.2byte    5,  -10, 	   2,  -16, 	  -1,  -13, 	  -1,  -12
+.2byte    7,  -10, 	   3,  -17, 	   2,  -14, 	   1,  -12
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    8,  -11, 	   3,  -16, 	   1,  -14, 	   0,  -12
+.2byte    8,  -11, 	   1,  -16, 	   2,  -14, 	   1,  -12
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   1,  -15, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   2,  -16, 	   1,  -12
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    0,  -13, 	   4,  -15, 	  -3,  -15, 	   0,  -12
+.2byte   -1,  -13, 	   2,  -15, 	  -5,  -16, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -2,  -15, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -3,  -16, 	  -2,  -12
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -4,  -16, 	  -2,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -2,  -16, 	  -3,  -14, 	  -2,  -12
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -6,  -10, 	  -3,  -16, 	   0,  -13, 	   0,  -12
+.2byte   -8,  -10, 	  -4,  -17, 	  -3,  -14, 	  -2,  -12
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte   -1,  -16, 	  -4,  -16, 	   3,  -16, 	  -1,  -12
+.2byte   -1,   -5, 	  -4,  -12, 	   3,  -12, 	  -1,  -12
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+.2byte    3,  -17, 	   1,  -19, 	  -2,  -16, 	   0,  -12
+.2byte    7,   -9, 	   4,  -13, 	   2,  -11, 	   0,  -10
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    4,  -19, 	  -2,  -18, 	  -2,  -16, 	   0,  -13
+.2byte    9,  -11, 	   2,  -16, 	   1,  -14, 	   0,  -11
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    3,  -17, 	  -3,  -16, 	   0,  -15, 	   0,  -11
+.2byte    6,  -14, 	   1,  -16, 	   3,  -14, 	   0,  -11
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    0,  -22, 	   3,  -16, 	  -4,  -16, 	  -1,  -14
+.2byte   -1,  -17, 	   3,  -16, 	  -4,  -16, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -4,  -17, 	   2,  -16, 	  -1,  -15, 	  -1,  -11
+.2byte   -7,  -14, 	  -2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -5,  -19, 	   1,  -18, 	   1,  -16, 	  -1,  -13
+.2byte  -10,  -11, 	  -3,  -16, 	  -2,  -14, 	  -1,  -11
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -4,  -17, 	  -2,  -19, 	   1,  -16, 	  -1,  -12
+.2byte   -8,   -9, 	  -5,  -13, 	  -3,  -11, 	  -1,  -10
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+.2byte   -9,   -7, 	  -4,   -8, 	  -4,  -12, 	   0,  -10
+.2byte   -9,   -8, 	  -4,   -9, 	  -4,  -13, 	   0,  -12
+.2byte   -8,  -14, 	  -4,  -17, 	  -2,  -15, 	  -1,  -14
+.2byte    6,  -14, 	  -1,  -17, 	   2,  -17, 	   1,  -13
+.2byte    1,  -16, 	  -3,  -16, 	   3,  -16, 	   0,  -12
+.2byte   -6,  -14, 	  -1,  -15, 	   2,  -16, 	  -1,  -13
+.2byte    8,  -16, 	   0,  -15, 	  -1,  -17, 	  -1,  -12
+.2byte    5,  -14, 	   0,  -15, 	  -3,  -16, 	   0,  -13
+.2byte   -2,  -16, 	   2,  -16, 	  -4,  -16, 	  -1,  -12
+.2byte   -7,  -14, 	   0,  -17, 	  -3,  -17, 	  -2,  -13
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte    1,   -8, 	  -3,  -13, 	   2,  -15, 	  -1,  -13
+.2byte   -2,   -8, 	  -3,  -14, 	   3,  -13, 	   0,  -13
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+.2byte    5,  -10, 	   2,  -16, 	  -1,  -13, 	  -1,  -12
+.2byte    7,  -10, 	   3,  -17, 	   2,  -14, 	   1,  -12
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    8,  -11, 	   3,  -16, 	   1,  -14, 	   0,  -12
+.2byte    8,  -11, 	   1,  -16, 	   2,  -14, 	   1,  -12
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   1,  -15, 	   0,  -12
+.2byte    4,  -14, 	  -1,  -16, 	   2,  -16, 	   1,  -12
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    0,  -13, 	   4,  -15, 	  -3,  -15, 	   0,  -12
+.2byte   -1,  -13, 	   2,  -15, 	  -5,  -16, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -2,  -15, 	  -1,  -12
+.2byte   -5,  -14, 	   0,  -16, 	  -3,  -16, 	  -2,  -12
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -4,  -16, 	  -2,  -14, 	  -1,  -12
+.2byte   -9,  -11, 	  -2,  -16, 	  -3,  -14, 	  -2,  -12
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -6,  -10, 	  -3,  -16, 	   0,  -13, 	   0,  -12
+.2byte   -8,  -10, 	  -4,  -17, 	  -3,  -14, 	  -2,  -12
+.2byte   -1,   -5, 	  -4,  -12, 	   3,  -12, 	  -1,  -12
+.2byte   -8,  -10, 	  -5,  -14, 	  -3,  -12, 	  -1,  -11
+.2byte  -10,  -11, 	  -3,  -16, 	  -2,  -14, 	  -1,  -11
+.2byte   -7,  -14, 	  -2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	   3,  -15, 	  -4,  -15, 	  -1,  -11
+.2byte    6,  -14, 	   1,  -16, 	   3,  -14, 	   0,  -11
+.2byte    9,  -11, 	   2,  -16, 	   1,  -14, 	   0,  -11
+.2byte    7,  -10, 	   4,  -14, 	   2,  -12, 	   0,  -11
+.2byte   -1,  -16, 	  -4,  -16, 	   3,  -16, 	  -1,  -12
+.2byte    4,  -17, 	   2,  -19, 	  -1,  -16, 	   1,  -12
+.2byte    5,  -19, 	  -1,  -18, 	  -1,  -16, 	   1,  -13
+.2byte    4,  -18, 	  -2,  -17, 	   1,  -16, 	   1,  -12
+.2byte    0,  -21, 	   3,  -15, 	  -4,  -15, 	  -1,  -13
+.2byte   -5,  -18, 	   1,  -17, 	  -2,  -16, 	  -2,  -12
+.2byte   -6,  -19, 	   0,  -18, 	   0,  -16, 	  -2,  -13
+.2byte   -5,  -17, 	  -3,  -19, 	   0,  -16, 	  -2,  -12
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte   -1,  -16, 	  -4,  -16, 	   3,  -16, 	  -1,  -12
+.2byte   -1,   -5, 	  -4,  -12, 	   3,  -12, 	  -1,  -12
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+.2byte    4,  -15, 	   2,  -17, 	  -1,  -14, 	   1,  -10
+.2byte    7,   -9, 	   4,  -13, 	   2,  -11, 	   0,  -10
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    5,  -19, 	  -1,  -18, 	  -1,  -16, 	   1,  -13
+.2byte    9,  -11, 	   2,  -16, 	   1,  -14, 	   0,  -11
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    3,  -17, 	  -3,  -16, 	   0,  -15, 	   0,  -11
+.2byte    7,  -14, 	   2,  -16, 	   4,  -14, 	   1,  -11
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    0,  -22, 	   3,  -16, 	  -4,  -16, 	  -1,  -14
+.2byte   -1,  -17, 	   3,  -16, 	  -4,  -16, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -4,  -17, 	   2,  -16, 	  -1,  -15, 	  -1,  -11
+.2byte   -8,  -14, 	  -3,  -16, 	  -5,  -14, 	  -2,  -11
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -6,  -19, 	   0,  -18, 	   0,  -16, 	  -2,  -13
+.2byte  -10,  -11, 	  -3,  -16, 	  -2,  -14, 	  -1,  -11
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -5,  -15, 	  -3,  -17, 	   0,  -14, 	  -2,  -10
+.2byte   -8,   -9, 	  -5,  -13, 	  -3,  -11, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,  -12, 	   3,  -12, 	  -1,  -12
+.2byte   -8,  -10, 	  -5,  -14, 	  -3,  -12, 	  -1,  -11
+.2byte  -10,  -11, 	  -3,  -16, 	  -2,  -14, 	  -1,  -11
+.2byte   -7,  -14, 	  -2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	   3,  -15, 	  -4,  -15, 	  -1,  -11
+.2byte    6,  -14, 	   1,  -16, 	   3,  -14, 	   0,  -11
+.2byte    9,  -11, 	   2,  -16, 	   1,  -14, 	   0,  -11
+.2byte    7,  -10, 	   4,  -14, 	   2,  -12, 	   0,  -11
+.2byte    0,   -8, 	  -4,  -13, 	   3,  -13, 	  -1,  -13
+.2byte   -7,  -10, 	  -4,  -15, 	  -1,  -13, 	  -1,  -12
+.2byte   -9,  -11, 	  -3,  -15, 	  -1,  -14, 	  -1,  -12
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -14, 	  -1,  -12
+.2byte   -1,  -13, 	   3,  -15, 	  -4,  -15, 	   0,  -12
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -14, 	   0,  -12
+.2byte    8,  -11, 	   2,  -15, 	   0,  -14, 	   0,  -12
+.2byte    6,  -10, 	   3,  -15, 	   0,  -13, 	   0,  -12
+sLuvdiscAnimTable1:
+.4byte sLuvdiscAnims_1_1
+.4byte sLuvdiscAnims_1_2
+.4byte sLuvdiscAnims_1_3
+.4byte sLuvdiscAnims_1_4
+.4byte sLuvdiscAnims_1_5
+.4byte sLuvdiscAnims_1_6
+.4byte sLuvdiscAnims_1_7
+.4byte sLuvdiscAnims_1_8
+sLuvdiscAnimTable2:
+.4byte sLuvdiscAnims_2_1
+.4byte sLuvdiscAnims_2_2
+.4byte sLuvdiscAnims_2_3
+.4byte sLuvdiscAnims_2_4
+.4byte sLuvdiscAnims_2_5
+.4byte sLuvdiscAnims_2_6
+.4byte sLuvdiscAnims_2_7
+.4byte sLuvdiscAnims_2_8
+sLuvdiscAnimTable3:
+.4byte sLuvdiscAnims_3_1
+.4byte sLuvdiscAnims_3_2
+.4byte sLuvdiscAnims_3_3
+.4byte sLuvdiscAnims_3_4
+.4byte sLuvdiscAnims_3_5
+.4byte sLuvdiscAnims_3_6
+.4byte sLuvdiscAnims_3_7
+.4byte sLuvdiscAnims_3_8
+sLuvdiscAnimTable4:
+.4byte sLuvdiscAnims_4_1
+.4byte sLuvdiscAnims_4_2
+.4byte sLuvdiscAnims_4_3
+.4byte sLuvdiscAnims_4_4
+.4byte sLuvdiscAnims_4_5
+.4byte sLuvdiscAnims_4_6
+.4byte sLuvdiscAnims_4_7
+.4byte sLuvdiscAnims_4_8
+sLuvdiscAnimTable5:
+.4byte sLuvdiscAnims_5_1
+.4byte sLuvdiscAnims_5_2
+.4byte sLuvdiscAnims_5_3
+.4byte sLuvdiscAnims_5_4
+.4byte sLuvdiscAnims_5_5
+.4byte sLuvdiscAnims_5_6
+.4byte sLuvdiscAnims_5_7
+.4byte sLuvdiscAnims_5_8
+sLuvdiscAnimTable6:
+.4byte sLuvdiscAnims_6_1
+.4byte sLuvdiscAnims_6_1
+.4byte sLuvdiscAnims_6_1
+.4byte sLuvdiscAnims_6_1
+.4byte sLuvdiscAnims_6_1
+.4byte sLuvdiscAnims_6_1
+.4byte sLuvdiscAnims_6_1
+.4byte sLuvdiscAnims_6_1
+sLuvdiscAnimTable7:
+.4byte sLuvdiscAnims_7_1
+.4byte sLuvdiscAnims_7_2
+.4byte sLuvdiscAnims_7_3
+.4byte sLuvdiscAnims_7_4
+.4byte sLuvdiscAnims_7_5
+.4byte sLuvdiscAnims_7_6
+.4byte sLuvdiscAnims_7_7
+.4byte sLuvdiscAnims_7_8
+sLuvdiscAnimTable8:
+.4byte sLuvdiscAnims_8_1
+.4byte sLuvdiscAnims_8_2
+.4byte sLuvdiscAnims_8_3
+.4byte sLuvdiscAnims_8_4
+.4byte sLuvdiscAnims_8_5
+.4byte sLuvdiscAnims_8_6
+.4byte sLuvdiscAnims_8_7
+.4byte sLuvdiscAnims_8_8
+sLuvdiscAnimTable9:
+.4byte sLuvdiscAnims_9_1
+.4byte sLuvdiscAnims_9_2
+.4byte sLuvdiscAnims_9_3
+.4byte sLuvdiscAnims_9_4
+.4byte sLuvdiscAnims_9_5
+.4byte sLuvdiscAnims_9_6
+.4byte sLuvdiscAnims_9_7
+.4byte sLuvdiscAnims_9_8
+sLuvdiscAnimTable10:
+.4byte sLuvdiscAnims_10_1
+.4byte sLuvdiscAnims_10_2
+.4byte sLuvdiscAnims_10_3
+.4byte sLuvdiscAnims_10_4
+.4byte sLuvdiscAnims_10_5
+.4byte sLuvdiscAnims_10_6
+.4byte sLuvdiscAnims_10_7
+.4byte sLuvdiscAnims_10_8
+sLuvdiscAnimTable11:
+.4byte sLuvdiscAnims_11_1
+.4byte sLuvdiscAnims_11_2
+.4byte sLuvdiscAnims_11_3
+.4byte sLuvdiscAnims_11_4
+.4byte sLuvdiscAnims_11_5
+.4byte sLuvdiscAnims_11_6
+.4byte sLuvdiscAnims_11_7
+.4byte sLuvdiscAnims_11_8
+sLuvdiscAnimTable12:
+.4byte sLuvdiscAnims_12_1
+.4byte sLuvdiscAnims_12_2
+.4byte sLuvdiscAnims_12_3
+.4byte sLuvdiscAnims_12_4
+.4byte sLuvdiscAnims_12_5
+.4byte sLuvdiscAnims_12_6
+.4byte sLuvdiscAnims_12_7
+.4byte sLuvdiscAnims_12_8
+sLuvdiscAnimTable13:
+.4byte sLuvdiscAnims_13_1
+.4byte sLuvdiscAnims_13_2
+.4byte sLuvdiscAnims_13_3
+.4byte sLuvdiscAnims_13_4
+.4byte sLuvdiscAnims_13_5
+.4byte sLuvdiscAnims_13_6
+.4byte sLuvdiscAnims_13_7
+.4byte sLuvdiscAnims_13_8
+sAxAnimationsLuvdisc:
+.4byte sLuvdiscAnimTable1
+.4byte sLuvdiscAnimTable2
+.4byte sLuvdiscAnimTable3
+.4byte sLuvdiscAnimTable4
+.4byte sLuvdiscAnimTable5
+.4byte sLuvdiscAnimTable6
+.4byte sLuvdiscAnimTable7
+.4byte sLuvdiscAnimTable8
+.4byte sLuvdiscAnimTable9
+.4byte sLuvdiscAnimTable10
+.4byte sLuvdiscAnimTable11
+.4byte sLuvdiscAnimTable12
+.4byte sLuvdiscAnimTable13
+sAxSpritesLuvdisc:
+.4byte sLuvdiscSprites1
+.4byte sLuvdiscSprites2
+.4byte sLuvdiscSprites3
+.4byte sLuvdiscSprites4
+.4byte sLuvdiscSprites5
+.4byte sLuvdiscSprites6
+.4byte sLuvdiscSprites7
+.4byte sLuvdiscSprites8
+.4byte sLuvdiscSprites9
+.4byte sLuvdiscSprites10
+.4byte sLuvdiscSprites11
+.4byte sLuvdiscSprites12
+.4byte sLuvdiscSprites13
+.4byte sLuvdiscSprites14
+.4byte sLuvdiscSprites15
+.4byte sLuvdiscSprites16
+.4byte sLuvdiscSprites17
+.4byte sLuvdiscSprites18
+.4byte sLuvdiscSprites19
+.4byte sLuvdiscSprites20
+.4byte sLuvdiscSprites21
+.4byte sLuvdiscSprites22
+.4byte sLuvdiscSprites23
+.4byte sLuvdiscSprites24
+.4byte sLuvdiscSprites25
+.4byte sLuvdiscSprites26
+.4byte sLuvdiscSprites27
+.4byte sLuvdiscSprites28
+.4byte sLuvdiscSprites29
+.4byte sLuvdiscSprites30
+.4byte sLuvdiscSprites31
+.4byte sLuvdiscSprites32
+.4byte sLuvdiscSprites33
+.4byte sLuvdiscSprites34
+.4byte sLuvdiscSprites35
+.4byte sLuvdiscSprites36
+sAxMainLuvdisc:
+ax_main sAxPosesLuvdisc, sAxAnimationsLuvdisc, 13, sAxSpritesLuvdisc, sAxPositionsLuvdisc

--- a/data/ax/machamp.inc
+++ b/data/ax/machamp.inc
@@ -1,0 +1,3014 @@
+.global gAxMachamp
+gAxMachamp:
+ax_siro sAxMainMachamp
+sMachampPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose4:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose5:
+ax_pose 4, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose7:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose8:
+ax_pose 7, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose9:
+ax_pose 8, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose10:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose11:
+ax_pose 10, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose12:
+ax_pose 11, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose22:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose23:
+ax_pose 4, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose28:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose29:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose30:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose31:
+ax_pose 4, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose32:
+ax_pose 5, 0x01e5, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose33:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose34:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose35:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose36:
+ax_pose 7, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose37:
+ax_pose 8, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose38:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose39:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose40:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose41:
+ax_pose 10, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose42:
+ax_pose 11, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose43:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose44:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose45:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose46:
+ax_pose 13, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose47:
+ax_pose 14, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose48:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose49:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose50:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose51:
+ax_pose 10, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose52:
+ax_pose 11, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose53:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose54:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose55:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose56:
+ax_pose 7, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose57:
+ax_pose 8, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose58:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose59:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose60:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose61:
+ax_pose 4, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose62:
+ax_pose 5, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose63:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose64:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose65:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose66:
+ax_pose 15, 0x01e6, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose67:
+ax_pose 16, 0x01e8, 0x80ed, 0xcc00
+ax_pose 17, 0x01e6, 0x80f4, 0xcc10
+ax_pose_terminator
+sMachampPose68:
+ax_pose 17, 0x01e6, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachampPose69:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose70:
+ax_pose 18, 0x01e5, 0x90ec, 0xcc00
+ax_pose_terminator
+sMachampPose71:
+ax_pose 19, 0x81e5, 0x9100, 0xcc00
+ax_pose 20, 0x01eb, 0x90ec, 0xcc08
+ax_pose_terminator
+sMachampPose72:
+ax_pose 20, 0x01eb, 0x90ec, 0xcc00
+ax_pose_terminator
+sMachampPose73:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose74:
+ax_pose 21, 0x01e5, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose75:
+ax_pose 22, 0x01e3, 0x90f6, 0xcc00
+ax_pose 23, 0x01e5, 0x90ef, 0xcc10
+ax_pose_terminator
+sMachampPose76:
+ax_pose 23, 0x01e5, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose77:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose78:
+ax_pose 24, 0x01e3, 0x90ec, 0xcc00
+ax_pose_terminator
+sMachampPose79:
+ax_pose 25, 0x01e2, 0x90ee, 0xcc00
+ax_pose 26, 0x01e5, 0x90ec, 0xcc10
+ax_pose_terminator
+sMachampPose80:
+ax_pose 26, 0x01e5, 0x90ec, 0xcc00
+ax_pose_terminator
+sMachampPose81:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose82:
+ax_pose 27, 0x81e4, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachampPose83:
+ax_pose 28, 0x01df, 0x80f6, 0xcc00
+ax_pose 29, 0x01e4, 0x80f0, 0xcc10
+ax_pose_terminator
+sMachampPose84:
+ax_pose 29, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose85:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose86:
+ax_pose 24, 0x01e3, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachampPose87:
+ax_pose 25, 0x01e2, 0x80f1, 0xcc00
+ax_pose 26, 0x01e5, 0x80f3, 0xcc10
+ax_pose_terminator
+sMachampPose88:
+ax_pose 26, 0x01e5, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachampPose89:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose90:
+ax_pose 21, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose91:
+ax_pose 22, 0x01e3, 0x80e9, 0xcc00
+ax_pose 23, 0x01e5, 0x80f0, 0xcc10
+ax_pose_terminator
+sMachampPose92:
+ax_pose 23, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose93:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose94:
+ax_pose 18, 0x01e5, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachampPose95:
+ax_pose 19, 0x81e5, 0x80ef, 0xcc00
+ax_pose 20, 0x01eb, 0x80f3, 0xcc08
+ax_pose_terminator
+sMachampPose96:
+ax_pose 20, 0x01eb, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachampPose97:
+ax_pose 30, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose98:
+ax_pose 31, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sMachampPose99:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose100:
+ax_pose 33, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sMachampPose101:
+ax_pose 34, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose102:
+ax_pose 33, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sMachampPose103:
+ax_pose 32, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose104:
+ax_pose 31, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose105:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose106:
+ax_pose 30, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose107:
+ax_pose 35, 0x01e7, 0x80f1, 0xcc00
+ax_pose 36, 0x41de, 0x00f4, 0xcc10
+ax_pose 37, 0x01e6, 0x80f0, 0xcc12
+ax_pose_terminator
+sMachampPose108:
+ax_pose 36, 0x41de, 0x00f4, 0xcc00
+ax_pose 37, 0x01e6, 0x80f0, 0xcc02
+ax_pose_terminator
+sMachampPose109:
+ax_pose 15, 0x01e0, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose110:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose111:
+ax_pose 31, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose112:
+ax_pose 38, 0x01e0, 0x90f2, 0xcc00
+ax_pose 39, 0x41d7, 0x10fc, 0xcc10
+ax_pose 40, 0x01df, 0x90f0, 0xcc12
+ax_pose_terminator
+sMachampPose113:
+ax_pose 39, 0x41d7, 0x10fc, 0xcc00
+ax_pose 40, 0x01df, 0x90f0, 0xcc02
+ax_pose_terminator
+sMachampPose114:
+ax_pose 41, 0x01db, 0x80eb, 0xcc00
+ax_pose 42, 0x41fb, 0x00fb, 0xcc10
+ax_pose_terminator
+sMachampPose115:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose116:
+ax_pose 32, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose117:
+ax_pose 43, 0x01e5, 0x90f5, 0xcc00
+ax_pose 44, 0x81f2, 0x110f, 0xcc10
+ax_pose 45, 0x01e2, 0x90ef, 0xcc12
+ax_pose_terminator
+sMachampPose118:
+ax_pose 45, 0x01e2, 0x90ef, 0xcc00
+ax_pose 44, 0x81f2, 0x110f, 0xcc10
+ax_pose_terminator
+sMachampPose119:
+ax_pose 46, 0x01e1, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose120:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose121:
+ax_pose 33, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sMachampPose122:
+ax_pose 47, 0x01de, 0x90f1, 0xcc00
+ax_pose 48, 0x81e3, 0x110b, 0xcc10
+ax_pose 49, 0x01e3, 0x90eb, 0xcc12
+ax_pose_terminator
+sMachampPose123:
+ax_pose 49, 0x01e3, 0x90eb, 0xcc00
+ax_pose 48, 0x81e3, 0x110b, 0xcc10
+ax_pose_terminator
+sMachampPose124:
+ax_pose 50, 0x01e1, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachampPose125:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose126:
+ax_pose 34, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose127:
+ax_pose 51, 0x01da, 0x80f0, 0xcc00
+ax_pose 52, 0x4200, 0x40f8, 0xcc10
+ax_pose 53, 0x01e0, 0x80f8, 0xcc14
+ax_pose_terminator
+sMachampPose128:
+ax_pose 53, 0x01e0, 0x80f8, 0xcc00
+ax_pose 52, 0x4200, 0x40f8, 0xcc10
+ax_pose_terminator
+sMachampPose129:
+ax_pose 29, 0x01e1, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachampPose130:
+ax_pose 9, 0x01e4, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose131:
+ax_pose 33, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sMachampPose132:
+ax_pose 47, 0x01db, 0x80ec, 0xcc00
+ax_pose 48, 0x81e0, 0x00ea, 0xcc10
+ax_pose 49, 0x01e0, 0x80f2, 0xcc12
+ax_pose_terminator
+sMachampPose133:
+ax_pose 49, 0x01e0, 0x80f2, 0xcc00
+ax_pose 48, 0x81e0, 0x00ea, 0xcc10
+ax_pose_terminator
+sMachampPose134:
+ax_pose 50, 0x01e1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachampPose135:
+ax_pose 6, 0x01e4, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose136:
+ax_pose 32, 0x01e4, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose137:
+ax_pose 43, 0x01e5, 0x80eb, 0xcc00
+ax_pose 44, 0x81f2, 0x00e9, 0xcc10
+ax_pose 45, 0x01e2, 0x80f1, 0xcc12
+ax_pose_terminator
+sMachampPose138:
+ax_pose 45, 0x01e2, 0x80f1, 0xcc00
+ax_pose 44, 0x81f2, 0x00e9, 0xcc10
+ax_pose_terminator
+sMachampPose139:
+ax_pose 46, 0x01e1, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose140:
+ax_pose 3, 0x01e4, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose141:
+ax_pose 31, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose142:
+ax_pose 38, 0x01e0, 0x80ee, 0xcc00
+ax_pose 39, 0x41d7, 0x00f4, 0xcc10
+ax_pose 40, 0x01df, 0x80f0, 0xcc12
+ax_pose_terminator
+sMachampPose143:
+ax_pose 39, 0x41d7, 0x00f4, 0xcc00
+ax_pose 40, 0x01df, 0x80f0, 0xcc02
+ax_pose_terminator
+sMachampPose144:
+ax_pose 41, 0x01db, 0x90f5, 0xcc00
+ax_pose 42, 0x41fb, 0x10f5, 0xcc10
+ax_pose_terminator
+sMachampPose145:
+ax_pose 54, 0x01e6, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose146:
+ax_pose 55, 0x01e6, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose147:
+ax_pose 56, 0x01e1, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose148:
+ax_pose 57, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose149:
+ax_pose 58, 0x01e3, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose150:
+ax_pose 59, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose151:
+ax_pose 60, 0x01e1, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose152:
+ax_pose 59, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose153:
+ax_pose 58, 0x01e3, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose154:
+ax_pose 57, 0x01e3, 0x80f1, 0xcc00
+ax_pose_terminator
+sMachampPose155:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose156:
+ax_pose 30, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose157:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose158:
+ax_pose 31, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose159:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose160:
+ax_pose 32, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose161:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose162:
+ax_pose 33, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sMachampPose163:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose164:
+ax_pose 34, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose165:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose166:
+ax_pose 33, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sMachampPose167:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose168:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose169:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose170:
+ax_pose 31, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sMachampPose171:
+ax_pose 30, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose172:
+ax_pose 31, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sMachampPose173:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose174:
+ax_pose 33, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sMachampPose175:
+ax_pose 34, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose176:
+ax_pose 33, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sMachampPose177:
+ax_pose 32, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose178:
+ax_pose 31, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose179:
+ax_pose 30, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose180:
+ax_pose 31, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose181:
+ax_pose 32, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose182:
+ax_pose 33, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sMachampPose183:
+ax_pose 34, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose184:
+ax_pose 33, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sMachampPose185:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose186:
+ax_pose 31, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sMachampPose187:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose188:
+ax_pose 30, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose189:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose190:
+ax_pose 31, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose191:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose192:
+ax_pose 32, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose193:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose194:
+ax_pose 33, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sMachampPose195:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose196:
+ax_pose 34, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose197:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose198:
+ax_pose 33, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sMachampPose199:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose200:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose201:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose202:
+ax_pose 31, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sMachampPose203:
+ax_pose 30, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose204:
+ax_pose 31, 0x01e4, 0x80ef, 0xcc00
+ax_pose_terminator
+sMachampPose205:
+ax_pose 32, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose206:
+ax_pose 33, 0x01e4, 0x80ee, 0xcc00
+ax_pose_terminator
+sMachampPose207:
+ax_pose 34, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose208:
+ax_pose 33, 0x01e4, 0x90f1, 0xcc00
+ax_pose_terminator
+sMachampPose209:
+ax_pose 32, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose210:
+ax_pose 31, 0x01e4, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachampPose211:
+ax_pose 0, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose212:
+ax_pose 3, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose213:
+ax_pose 6, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose214:
+ax_pose 9, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose215:
+ax_pose 12, 0x01e4, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachampPose216:
+ax_pose 9, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose217:
+ax_pose 6, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachampPose218:
+ax_pose 3, 0x01e4, 0x90ef, 0xcc00
+ax_pose_terminator
+.align 2
+sMachampAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_2_1:
+ax_anim 2, 0, 59, 1, -2, 1, -2,
+ax_anim 2, 0, 59, 1, -3, 1, -3,
+ax_anim 2, 0, 59, 0, -3, 0, -3,
+ax_anim 2, 0, 59, 1, -3, 1, -3,
+ax_anim 1, 0, 59, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 0, 4, 0, 4,
+ax_anim 1, 0, 32, 0, 10, 0, 10,
+ax_anim 2, 0, 33, 0, 20, 0, 20,
+ax_anim 2, 1, 33, 0, 21, 0, 21,
+ax_anim 2, 0, 33, 0, 20, 0, 20,
+ax_anim 2, 0, 33, 0, 21, 0, 21,
+ax_anim 2, 0, 34, 0, 10, 0, 10,
+ax_anim_terminator
+sMachampAnims_2_2:
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 2, 0, 59, -1, -3, -1, -3,
+ax_anim 2, 0, 59, 0, -4, 0, -4,
+ax_anim 2, 0, 59, -1, -3, -1, -3,
+ax_anim 1, 0, 59, 0, -4, 0, -4,
+ax_anim 1, 0, 31, 2, -2, 2, -2,
+ax_anim 1, 2, 35, 4, 4, 4, 4,
+ax_anim 1, 0, 37, 10, 10, 10, 10,
+ax_anim 2, 0, 46, 19, 19, 19, 19,
+ax_anim 2, 1, 46, 20, 18, 20, 18,
+ax_anim 2, 0, 46, 19, 19, 19, 19,
+ax_anim 2, 0, 46, 20, 18, 20, 18,
+ax_anim 2, 0, 39, 9, 9, 9, 9,
+ax_anim_terminator
+sMachampAnims_2_3:
+ax_anim 2, 0, 29, -2, 0, -2, 0,
+ax_anim 2, 0, 29, -3, 0, -3, 0,
+ax_anim 2, 0, 29, -3, -1, -3, -1,
+ax_anim 2, 0, 29, -3, 0, -3, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 0, 40, 4, 0, 4, 0,
+ax_anim 1, 2, 44, 6, 1, 6, 1,
+ax_anim 1, 0, 51, 12, 0, 12, 0,
+ax_anim 2, 0, 51, 18, 0, 18, 0,
+ax_anim 2, 1, 51, 19, 0, 19, 0,
+ax_anim 2, 0, 51, 18, 0, 18, 0,
+ax_anim 2, 0, 51, 19, 0, 19, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sMachampAnims_2_4:
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 2, 0, 34, -4, 1, -4, 1,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 2, 0, 34, -4, 1, -4, 1,
+ax_anim 1, 0, 39, -1, 2, -1, 2,
+ax_anim 1, 0, 46, 1, 0, 1, 0,
+ax_anim 1, 2, 51, 4, -4, 4, -4,
+ax_anim 1, 0, 56, 10, -10, 10, -10,
+ax_anim 2, 0, 56, 16, -16, 16, -16,
+ax_anim 2, 1, 56, 17, -17, 17, -17,
+ax_anim 2, 0, 56, 16, -16, 16, -16,
+ax_anim 2, 0, 56, 17, -17, 17, -17,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sMachampAnims_2_5:
+ax_anim 2, 0, 39, 0, 2, 0, 2,
+ax_anim 2, 0, 39, -1, 3, -1, 3,
+ax_anim 2, 0, 39, 0, 3, 0, 3,
+ax_anim 2, 0, 39, -1, 3, -1, 3,
+ax_anim 1, 0, 44, 0, 3, 0, 3,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -10, 0, -10,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 1, 61, -1, -18, -1, -18,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 0, 61, -1, -18, -1, -18,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sMachampAnims_2_6:
+ax_anim 2, 0, 54, 3, 1, 3, 1,
+ax_anim 2, 0, 54, 3, 4, 3, 4,
+ax_anim 2, 0, 54, 3, 3, 3, 3,
+ax_anim 2, 0, 54, 3, 4, 3, 4,
+ax_anim 1, 0, 49, 1, 3, 1, 3,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -4, -5, -4, -5,
+ax_anim 1, 0, 36, -10, -10, -10, -10,
+ax_anim 2, 0, 36, -16, -16, -16, -16,
+ax_anim 2, 1, 36, -17, -17, -17, -17,
+ax_anim 2, 0, 36, -16, -16, -16, -16,
+ax_anim 2, 0, 36, -17, -17, -17, -17,
+ax_anim 2, 0, 39, -6, -4, -6, -4,
+ax_anim_terminator
+sMachampAnims_2_7:
+ax_anim 2, 0, 59, 3, 0, 3, 0,
+ax_anim 2, 0, 59, 4, 0, 4, 0,
+ax_anim 2, 0, 59, 3, 0, 3, 0,
+ax_anim 2, 0, 59, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 3, 0, 3, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -3, 0, -3, 0,
+ax_anim 1, 0, 41, -9, 0, -9, 0,
+ax_anim 2, 0, 41, -17, 0, -17, 0,
+ax_anim 2, 1, 41, -18, 0, -18, 0,
+ax_anim 2, 0, 41, -17, 0, -17, 0,
+ax_anim 2, 0, 41, -18, 0, -18, 0,
+ax_anim 2, 0, 46, -7, 1, -7, 1,
+ax_anim_terminator
+sMachampAnims_2_8:
+ax_anim 2, 0, 24, 3, -2, 3, -2,
+ax_anim 2, 0, 24, 4, -3, 4, -3,
+ax_anim 2, 0, 24, 3, -2, 3, -2,
+ax_anim 2, 0, 24, 4, -3, 4, -3,
+ax_anim 1, 0, 59, 2, -1, 2, -1,
+ax_anim 1, 0, 56, 0, 3, 0, 3,
+ax_anim 1, 2, 50, -4, 5, -4, 5,
+ax_anim 1, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -18, 18, -18, 18,
+ax_anim 2, 1, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -18, 18, -18, 18,
+ax_anim 2, 0, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 50, -8, 11, -8, 11,
+ax_anim_terminator
+.align 2
+sMachampAnims_3_1:
+ax_anim 2, 0, 92, 0, -2, 0, -2,
+ax_anim 6, 0, 65, 0, -4, 0, -4,
+ax_anim 2, 0, 65, 0, 1, 0, 1,
+ax_anim 2, 2, 65, 1, 6, 1, 6,
+ax_anim 2, 0, 66, 3, 15, 3, 15,
+ax_anim 2, 1, 67, 3, 16, 3, 16,
+ax_anim 2, 0, 67, 3, 15, 3, 15,
+ax_anim 2, 0, 67, 3, 16, 3, 16,
+ax_anim 2, 0, 67, 3, 15, 3, 15,
+ax_anim 2, 0, 67, 3, 16, 3, 16,
+ax_anim 4, 0, 68, 1, 6, 1, 6,
+ax_anim_terminator
+sMachampAnims_3_2:
+ax_anim 2, 0, 72, -2, -2, -2, -2,
+ax_anim 6, 0, 69, -4, -4, -4, -4,
+ax_anim 2, 0, 69, 1, 1, 1, 1,
+ax_anim 2, 2, 69, 6, 6, 6, 6,
+ax_anim 2, 0, 70, 17, 17, 17, 17,
+ax_anim 2, 1, 71, 18, 18, 18, 18,
+ax_anim 2, 0, 71, 17, 17, 17, 17,
+ax_anim 2, 0, 71, 18, 18, 18, 18,
+ax_anim 2, 0, 71, 17, 17, 17, 17,
+ax_anim 2, 0, 71, 18, 18, 18, 18,
+ax_anim 4, 0, 64, 13, 10, 13, 10,
+ax_anim_terminator
+sMachampAnims_3_3:
+ax_anim 2, 0, 76, -4, 1, -4, 1,
+ax_anim 6, 0, 73, -7, -2, -7, -2,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 4, 0, 4, 0,
+ax_anim 2, 0, 74, 11, 0, 11, 0,
+ax_anim 2, 1, 75, 12, 0, 12, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 75, 12, 0, 12, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 75, 12, 0, 12, 0,
+ax_anim 4, 0, 68, 7, 0, 7, 0,
+ax_anim_terminator
+sMachampAnims_3_4:
+ax_anim 2, 0, 80, -2, 2, -2, 2,
+ax_anim 6, 0, 77, -5, 4, -5, 4,
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim 2, 2, 77, 6, -6, 6, -6,
+ax_anim 2, 0, 78, 17, -17, 17, -17,
+ax_anim 2, 1, 79, 18, -18, 18, -18,
+ax_anim 2, 0, 79, 17, -17, 17, -17,
+ax_anim 2, 0, 79, 18, -18, 18, -18,
+ax_anim 2, 0, 79, 17, -17, 17, -17,
+ax_anim 2, 0, 79, 18, -18, 18, -18,
+ax_anim 4, 0, 72, 10, -9, 10, -9,
+ax_anim_terminator
+sMachampAnims_3_5:
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 6, 0, 81, 0, 4, 0, 4,
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 2, 81, 0, -6, 0, -6,
+ax_anim 2, 0, 82, 0, -15, 0, -15,
+ax_anim 2, 1, 83, 0, -16, 0, -16,
+ax_anim 2, 0, 83, 0, -15, 0, -15,
+ax_anim 2, 0, 83, 0, -16, 0, -16,
+ax_anim 2, 0, 83, 0, -15, 0, -15,
+ax_anim 2, 0, 83, 0, -16, 0, -16,
+ax_anim 4, 0, 84, 0, -8, 0, -8,
+ax_anim_terminator
+sMachampAnims_3_6:
+ax_anim 2, 0, 80, 3, 2, 3, 2,
+ax_anim 6, 0, 85, 6, 4, 6, 4,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 2, 85, -6, -6, -6, -6,
+ax_anim 2, 0, 86, -17, -17, -17, -17,
+ax_anim 2, 1, 87, -18, -18, -18, -18,
+ax_anim 2, 0, 87, -17, -17, -17, -17,
+ax_anim 2, 0, 87, -18, -18, -18, -18,
+ax_anim 2, 0, 87, -17, -17, -17, -17,
+ax_anim 2, 0, 87, -18, -18, -18, -18,
+ax_anim 4, 0, 88, -9, -12, -9, -12,
+ax_anim_terminator
+sMachampAnims_3_7:
+ax_anim 2, 0, 84, 4, 1, 4, 1,
+ax_anim 6, 0, 89, 8, -3, 8, -3,
+ax_anim 2, 0, 89, 1, -2, 1, -2,
+ax_anim 2, 2, 89, -4, -1, -4, -1,
+ax_anim 2, 0, 90, -11, 0, -11, 0,
+ax_anim 2, 1, 91, -12, 0, -12, 0,
+ax_anim 2, 0, 91, -11, 0, -11, 0,
+ax_anim 2, 0, 91, -12, 0, -12, 0,
+ax_anim 2, 0, 91, -11, 0, -11, 0,
+ax_anim 2, 0, 91, -12, 0, -12, 0,
+ax_anim 4, 0, 92, -6, -1, -6, -1,
+ax_anim_terminator
+sMachampAnims_3_8:
+ax_anim 2, 0, 88, 3, -1, 3, -1,
+ax_anim 6, 0, 93, 4, -4, 4, -4,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 2, 93, -6, 6, -6, 6,
+ax_anim 2, 0, 94, -17, 17, -17, 17,
+ax_anim 2, 1, 95, -18, 18, -18, 18,
+ax_anim 2, 0, 95, -17, 17, -17, 17,
+ax_anim 2, 0, 95, -18, 18, -18, 18,
+ax_anim 2, 0, 95, -17, 17, -17, 17,
+ax_anim 2, 0, 95, -18, 18, -18, 18,
+ax_anim 4, 0, 64, -10, 11, -10, 11,
+ax_anim_terminator
+.align 2
+sMachampAnims_4_1:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_4_2:
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_4_3:
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 1, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_4_4:
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_4_5:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 1, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_4_6:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_4_7:
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_4_8:
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 1, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_5_1:
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 2, 0, 1,
+ax_anim 4, 0, 108, 0, 0, 0, 2,
+ax_anim 2, 2, 107, 1, 4, 0, 4,
+ax_anim 2, 0, 106, 0, 17, 0, 17,
+ax_anim 2, 1, 107, 1, 17, 1, 17,
+ax_anim 2, 0, 107, 0, 17, 0, 17,
+ax_anim 2, 0, 107, 1, 17, 1, 17,
+ax_anim 2, 0, 107, 0, 17, 0, 17,
+ax_anim 2, 0, 107, 1, 17, 1, 17,
+ax_anim 2, 0, 108, 0, 9, 1, 12,
+ax_anim 2, 0, 108, 0, 1, 0, 6,
+ax_anim 2, 0, 108, 0, 0, 0, 3,
+ax_anim_terminator
+sMachampAnims_5_2:
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, -1, 1, 1,
+ax_anim 4, 0, 113, 1, -2, 2, 2,
+ax_anim 2, 2, 112, 4, 4, 4, 4,
+ax_anim 2, 0, 111, 16, 21, 16, 18,
+ax_anim 2, 1, 112, 17, 20, 17, 17,
+ax_anim 2, 0, 112, 16, 21, 16, 18,
+ax_anim 2, 0, 112, 17, 20, 17, 17,
+ax_anim 2, 0, 112, 16, 21, 16, 18,
+ax_anim 2, 0, 112, 17, 20, 17, 17,
+ax_anim 2, 0, 113, 9, 3, 9, 9,
+ax_anim 2, 0, 113, 5, -3, 5, 5,
+ax_anim 2, 0, 113, 4, -4, 4, 4,
+ax_anim_terminator
+sMachampAnims_5_3:
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 118, 1, -3, 1, 0,
+ax_anim 2, 2, 117, 6, -3, 6, 0,
+ax_anim 2, 0, 116, 13, -3, 13, 0,
+ax_anim 2, 1, 117, 14, -3, 14, 0,
+ax_anim 2, 0, 117, 14, -2, 14, 0,
+ax_anim 2, 0, 117, 14, -3, 14, 0,
+ax_anim 2, 0, 117, 14, -2, 14, 0,
+ax_anim 2, 0, 117, 14, -3, 14, 0,
+ax_anim 2, 0, 118, 11, -6, 12, 0,
+ax_anim 2, 0, 118, 9, -7, 10, 0,
+ax_anim 2, 0, 118, 6, -5, 6, 0,
+ax_anim_terminator
+sMachampAnims_5_4:
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 1, -1, 1, -1,
+ax_anim 4, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 2, 122, 7, -7, 7, -7,
+ax_anim 2, 0, 121, 14, -14, 14, -14,
+ax_anim 2, 1, 122, 15, -15, 15, -15,
+ax_anim 2, 0, 122, 16, -14, 16, -14,
+ax_anim 2, 0, 122, 15, -15, 15, -15,
+ax_anim 2, 0, 122, 16, -14, 16, -14,
+ax_anim 2, 0, 122, 15, -15, 15, -15,
+ax_anim 2, 0, 123, 6, -7, 6, -6,
+ax_anim 2, 0, 123, 4, -5, 4, -4,
+ax_anim 2, 0, 123, 2, -1, 2, -2,
+ax_anim_terminator
+sMachampAnims_5_5:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 1, 0, 0, -1,
+ax_anim 4, 0, 128, 1, -1, 0, -2,
+ax_anim 2, 2, 127, 1, -6, 1, -6,
+ax_anim 2, 0, 126, 0, -9, 0, -9,
+ax_anim 2, 1, 127, 1, -9, 1, -13,
+ax_anim 2, 0, 127, 0, -9, 0, -13,
+ax_anim 2, 0, 127, 1, -9, 1, -13,
+ax_anim 2, 0, 127, 0, -9, 0, -13,
+ax_anim 2, 0, 127, 1, -9, 1, -13,
+ax_anim 2, 0, 128, 0, -7, 0, -5,
+ax_anim 2, 0, 128, 0, -6, 0, -4,
+ax_anim 2, 0, 128, 0, -4, 0, -2,
+ax_anim_terminator
+sMachampAnims_5_6:
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 133, -1, -1, -1, -1,
+ax_anim 4, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 2, 132, -7, -7, -7, -7,
+ax_anim 2, 0, 131, -14, -14, -14, -14,
+ax_anim 2, 1, 132, -15, -15, -15, -15,
+ax_anim 2, 0, 132, -16, -14, -16, -14,
+ax_anim 2, 0, 132, -15, -15, -15, -15,
+ax_anim 2, 0, 132, -16, -14, -16, -14,
+ax_anim 2, 0, 132, -15, -15, -15, -15,
+ax_anim 2, 0, 133, -6, -7, -6, -6,
+ax_anim 2, 0, 133, -4, -5, -4, -4,
+ax_anim 2, 0, 133, -2, -1, -2, -2,
+ax_anim_terminator
+sMachampAnims_5_7:
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 138, -1, -3, -1, 0,
+ax_anim 2, 2, 137, -6, -3, -6, 0,
+ax_anim 2, 0, 136, -13, -3, -13, 0,
+ax_anim 2, 1, 137, -14, -3, -14, 0,
+ax_anim 2, 0, 137, -14, -2, -14, 0,
+ax_anim 2, 0, 137, -14, -3, -14, 0,
+ax_anim 2, 0, 137, -14, -2, -14, 0,
+ax_anim 2, 0, 137, -14, -3, -14, 0,
+ax_anim 2, 0, 138, -11, -6, -12, 0,
+ax_anim 2, 0, 138, -9, -7, -10, 0,
+ax_anim 2, 0, 138, -6, -5, -6, 0,
+ax_anim_terminator
+sMachampAnims_5_8:
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, -1, -1, 1,
+ax_anim 4, 0, 143, -1, -2, -2, 2,
+ax_anim 2, 2, 142, -4, 4, -4, 4,
+ax_anim 2, 0, 141, -16, 21, -16, 18,
+ax_anim 2, 1, 142, -17, 20, -17, 17,
+ax_anim 2, 0, 142, -16, 21, -16, 18,
+ax_anim 2, 0, 142, -17, 20, -17, 17,
+ax_anim 2, 0, 142, -16, 21, -16, 18,
+ax_anim 2, 0, 142, -17, 20, -17, 17,
+ax_anim 2, 0, 143, -9, 3, -9, 9,
+ax_anim 2, 0, 143, -5, -3, -5, 5,
+ax_anim 2, 0, 143, -4, -4, -4, 4,
+ax_anim_terminator
+.align 2
+sMachampAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_7_1:
+ax_anim 2, 0, 146, 0, -3, 0, -3,
+ax_anim 8, 0, 146, 0, -4, 0, -4,
+ax_anim_terminator
+sMachampAnims_7_2:
+ax_anim 2, 0, 147, -3, -3, -3, -3,
+ax_anim 8, 0, 147, -4, -4, -4, -4,
+ax_anim_terminator
+sMachampAnims_7_3:
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim 8, 0, 148, -4, 0, -4, 0,
+ax_anim_terminator
+sMachampAnims_7_4:
+ax_anim 2, 0, 149, -3, 3, -3, 3,
+ax_anim 8, 0, 149, -4, 4, -4, 4,
+ax_anim_terminator
+sMachampAnims_7_5:
+ax_anim 2, 0, 150, 0, 3, 0, 3,
+ax_anim 8, 0, 150, 0, 4, 0, 4,
+ax_anim_terminator
+sMachampAnims_7_6:
+ax_anim 2, 0, 151, 3, 3, 3, 3,
+ax_anim 8, 0, 151, 4, 4, 4, 4,
+ax_anim_terminator
+sMachampAnims_7_7:
+ax_anim 2, 0, 152, 3, 0, 3, 0,
+ax_anim 8, 0, 152, 4, 0, 4, 0,
+ax_anim_terminator
+sMachampAnims_7_8:
+ax_anim 2, 0, 153, 3, -3, 3, -3,
+ax_anim 8, 0, 153, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sMachampAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, 0, 1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, 0, 1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, 0, 1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, 0, 1, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_8_2:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, 0, 1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, 0, 1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, 0, 1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, 0, 1, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_8_3:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 0, 1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 0, 1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 0, 1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 0, 1, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_8_4:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, 0, 1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, 0, 1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, 0, 1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, 0, 1, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_8_5:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_8_6:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, 0, 1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, 0, 1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, 0, 1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, 0, 1, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_8_7:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, 0, 1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, 0, 1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, 0, 1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, 0, 1, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_8_8:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, 0, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, 0, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, 0, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, 0, 1, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 19, 7, 19,
+ax_anim 3, 0, 174, 1, 22, 1, 24,
+ax_anim 2, 3, 175, -6, 19, -6, 19,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 24, 9, 24, 9,
+ax_anim 3, 0, 173, 23, 21, 23, 21,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 2, 12, 2, 12,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 20, 1, 20, 1,
+ax_anim 2, 3, 173, 17, 5, 17, 5,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -22, 11, -22,
+ax_anim 3, 0, 171, 19, -22, 19, -22,
+ax_anim 2, 3, 172, 20, -10, 20, -10,
+ax_anim 2, 0, 173, 16, -4, 16, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -6, -4, -6, -4,
+ax_anim 2, 0, 176, -8, -10, -8, -9,
+ax_anim 2, 0, 177, -7, -18, -7, -15,
+ax_anim 3, 0, 170, -1, -22, -1, -18,
+ax_anim 2, 3, 171, 4, -19, 4, -16,
+ax_anim 2, 0, 172, 5, -9, 5, -8,
+ax_anim 1, 0, 173, 4, -4, 4, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -22, -11, -22,
+ax_anim 3, 0, 177, -19, -22, -19, -22,
+ax_anim 2, 3, 176, -20, -10, -20, -10,
+ax_anim 2, 0, 175, -16, -4, -16, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -20, 1, -20, 1,
+ax_anim 2, 3, 175, -17, 5, -17, 5,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -24, 9, -24, 9,
+ax_anim 3, 0, 175, -23, 21, -23, 16,
+ax_anim 2, 3, 174, -11, 21, -11, 16,
+ax_anim 2, 0, 173, -2, 12, -4, 12,
+ax_anim 1, 0, 172, 0, 7, -3, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_11_2:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_11_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_11_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_11_6:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_11_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachampAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMachampGfx1:
+.incbin "baserom.gba", 0x7F6C40, 0x200
+sMachampSprites1:
+ax_sprite sMachampGfx1, 0x200
+ax_sprite_terminator
+sMachampGfx2:
+.incbin "baserom.gba", 0x7F6E50, 0x200
+sMachampSprites2:
+ax_sprite sMachampGfx2, 0x200
+ax_sprite_terminator
+sMachampGfx3:
+.incbin "baserom.gba", 0x7F7060, 0x200
+sMachampSprites3:
+ax_sprite sMachampGfx3, 0x200
+ax_sprite_terminator
+sMachampGfx4:
+.incbin "baserom.gba", 0x7F7270, 0x200
+sMachampSprites4:
+ax_sprite sMachampGfx4, 0x200
+ax_sprite_terminator
+sMachampGfx5:
+.incbin "baserom.gba", 0x7F7480, 0x200
+sMachampSprites5:
+ax_sprite sMachampGfx5, 0x200
+ax_sprite_terminator
+sMachampGfx6:
+.incbin "baserom.gba", 0x7F7690, 0x200
+sMachampSprites6:
+ax_sprite sMachampGfx6, 0x200
+ax_sprite_terminator
+sMachampGfx7:
+.incbin "baserom.gba", 0x7F78A0, 0x200
+sMachampSprites7:
+ax_sprite sMachampGfx7, 0x200
+ax_sprite_terminator
+sMachampGfx8:
+.incbin "baserom.gba", 0x7F7AB0, 0x200
+sMachampSprites8:
+ax_sprite sMachampGfx8, 0x200
+ax_sprite_terminator
+sMachampGfx9:
+.incbin "baserom.gba", 0x7F7CC0, 0x200
+sMachampSprites9:
+ax_sprite sMachampGfx9, 0x200
+ax_sprite_terminator
+sMachampGfx10:
+.incbin "baserom.gba", 0x7F7ED0, 0x200
+sMachampSprites10:
+ax_sprite sMachampGfx10, 0x200
+ax_sprite_terminator
+sMachampGfx11:
+.incbin "baserom.gba", 0x7F80E0, 0x200
+sMachampSprites11:
+ax_sprite sMachampGfx11, 0x200
+ax_sprite_terminator
+sMachampGfx12:
+.incbin "baserom.gba", 0x7F82F0, 0x200
+sMachampSprites12:
+ax_sprite sMachampGfx12, 0x200
+ax_sprite_terminator
+sMachampGfx13:
+.incbin "baserom.gba", 0x7F8500, 0x200
+sMachampSprites13:
+ax_sprite sMachampGfx13, 0x200
+ax_sprite_terminator
+sMachampGfx14:
+.incbin "baserom.gba", 0x7F8710, 0x200
+sMachampSprites14:
+ax_sprite sMachampGfx14, 0x200
+ax_sprite_terminator
+sMachampGfx15:
+.incbin "baserom.gba", 0x7F8920, 0x200
+sMachampSprites15:
+ax_sprite sMachampGfx15, 0x200
+ax_sprite_terminator
+sMachampGfx16:
+.incbin "baserom.gba", 0x7F8B30, 0x40
+sMachampGfx16_1:
+.incbin "baserom.gba", 0x7F8B70, 0x80
+sMachampGfx16_2:
+.incbin "baserom.gba", 0x7F8BF0, 0x40
+sMachampGfx16_3:
+.incbin "baserom.gba", 0x7F8C30, 0x40
+sMachampSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx16_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx17:
+.incbin "baserom.gba", 0x7F8CC0, 0x40
+sMachampGfx17_1:
+.incbin "baserom.gba", 0x7F8D00, 0x40
+sMachampGfx17_2:
+.incbin "baserom.gba", 0x7F8D40, 0x60
+sMachampGfx17_3:
+.incbin "baserom.gba", 0x7F8DA0, 0x60
+sMachampSprites17:
+ax_sprite sMachampGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx18:
+.incbin "baserom.gba", 0x7F8E48, 0x60
+sMachampGfx18_1:
+.incbin "baserom.gba", 0x7F8EA8, 0x60
+sMachampGfx18_2:
+.incbin "baserom.gba", 0x7F8F08, 0x60
+sMachampGfx18_3:
+.incbin "baserom.gba", 0x7F8F68, 0x40
+sMachampSprites18:
+ax_sprite sMachampGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx18_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachampGfx19:
+.incbin "baserom.gba", 0x7F8FF0, 0x60
+sMachampGfx19_1:
+.incbin "baserom.gba", 0x7F9050, 0x60
+sMachampGfx19_2:
+.incbin "baserom.gba", 0x7F90B0, 0x60
+sMachampGfx19_3:
+.incbin "baserom.gba", 0x7F9110, 0x60
+sMachampSprites19:
+ax_sprite sMachampGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx20:
+.incbin "baserom.gba", 0x7F91B8, 0x100
+sMachampSprites20:
+ax_sprite sMachampGfx20, 0x100
+ax_sprite_terminator
+sMachampGfx21:
+.incbin "baserom.gba", 0x7F92C8, 0x160
+sMachampGfx21_1:
+.incbin "baserom.gba", 0x7F9428, 0x40
+sMachampSprites21:
+ax_sprite sMachampGfx21, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachampGfx22:
+.incbin "baserom.gba", 0x7F9490, 0x80
+sMachampGfx22_1:
+.incbin "baserom.gba", 0x7F9510, 0xE0
+sMachampGfx22_2:
+.incbin "baserom.gba", 0x7F95F0, 0x40
+sMachampSprites22:
+ax_sprite sMachampGfx22, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx23:
+.incbin "baserom.gba", 0x7F9668, 0xC0
+sMachampGfx23_1:
+.incbin "baserom.gba", 0x7F9728, 0x40
+sMachampGfx23_2:
+.incbin "baserom.gba", 0x7F9768, 0x40
+sMachampSprites23:
+ax_sprite sMachampGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx23_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachampGfx24:
+.incbin "baserom.gba", 0x7F97E0, 0x1E0
+sMachampSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx24, 0x1e0
+ax_sprite_terminator
+sMachampGfx25:
+.incbin "baserom.gba", 0x7F99D8, 0x60
+sMachampGfx25_1:
+.incbin "baserom.gba", 0x7F9A38, 0x100
+sMachampGfx25_2:
+.incbin "baserom.gba", 0x7F9B38, 0x40
+sMachampSprites25:
+ax_sprite sMachampGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx26:
+.incbin "baserom.gba", 0x7F9BB0, 0x140
+sMachampGfx26_1:
+.incbin "baserom.gba", 0x7F9CF0, 0x60
+sMachampSprites26:
+ax_sprite sMachampGfx26, 0x140
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachampGfx27:
+.incbin "baserom.gba", 0x7F9D78, 0x40
+sMachampGfx27_1:
+.incbin "baserom.gba", 0x7F9DB8, 0x60
+sMachampGfx27_2:
+.incbin "baserom.gba", 0x7F9E18, 0x60
+sMachampGfx27_3:
+.incbin "baserom.gba", 0x7F9E78, 0x40
+sMachampSprites27:
+ax_sprite sMachampGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx28:
+.incbin "baserom.gba", 0x7F9F00, 0x100
+sMachampSprites28:
+ax_sprite sMachampGfx28, 0x100
+ax_sprite_terminator
+sMachampGfx29:
+.incbin "baserom.gba", 0x7FA010, 0x60
+sMachampGfx29_1:
+.incbin "baserom.gba", 0x7FA070, 0x60
+sMachampGfx29_2:
+.incbin "baserom.gba", 0x7FA0D0, 0x40
+sMachampGfx29_3:
+.incbin "baserom.gba", 0x7FA110, 0x20
+sMachampSprites29:
+ax_sprite sMachampGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx29_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMachampGfx29_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx30:
+.incbin "baserom.gba", 0x7FA178, 0x60
+sMachampGfx30_1:
+.incbin "baserom.gba", 0x7FA1D8, 0x60
+sMachampGfx30_2:
+.incbin "baserom.gba", 0x7FA238, 0x60
+sMachampGfx30_3:
+.incbin "baserom.gba", 0x7FA298, 0x40
+sMachampSprites30:
+ax_sprite sMachampGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx31:
+.incbin "baserom.gba", 0x7FA320, 0x180
+sMachampSprites31:
+ax_sprite sMachampGfx31, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMachampGfx32:
+.incbin "baserom.gba", 0x7FA4B8, 0x60
+sMachampGfx32_1:
+.incbin "baserom.gba", 0x7FA518, 0x100
+sMachampGfx32_2:
+.incbin "baserom.gba", 0x7FA618, 0x60
+sMachampSprites32:
+ax_sprite sMachampGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx32_2, 0x60
+ax_sprite_terminator
+sMachampGfx33:
+.incbin "baserom.gba", 0x7FA6A8, 0x60
+sMachampGfx33_1:
+.incbin "baserom.gba", 0x7FA708, 0x60
+sMachampGfx33_2:
+.incbin "baserom.gba", 0x7FA768, 0x60
+sMachampGfx33_3:
+.incbin "baserom.gba", 0x7FA7C8, 0x40
+sMachampSprites33:
+ax_sprite sMachampGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx34:
+.incbin "baserom.gba", 0x7FA850, 0x200
+sMachampSprites34:
+ax_sprite sMachampGfx34, 0x200
+ax_sprite_terminator
+sMachampGfx35:
+.incbin "baserom.gba", 0x7FAA60, 0x200
+sMachampSprites35:
+ax_sprite sMachampGfx35, 0x200
+ax_sprite_terminator
+sMachampGfx36:
+.incbin "baserom.gba", 0x7FAC70, 0x1E0
+sMachampSprites36:
+ax_sprite sMachampGfx36, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx37:
+.incbin "baserom.gba", 0x7FAE68, 0x40
+sMachampSprites37:
+ax_sprite sMachampGfx37, 0x40
+ax_sprite_terminator
+sMachampGfx38:
+.incbin "baserom.gba", 0x7FAEB8, 0x60
+sMachampGfx38_1:
+.incbin "baserom.gba", 0x7FAF18, 0x40
+sMachampGfx38_2:
+.incbin "baserom.gba", 0x7FAF58, 0x40
+sMachampGfx38_3:
+.incbin "baserom.gba", 0x7FAF98, 0x40
+sMachampSprites38:
+ax_sprite sMachampGfx38, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx39:
+.incbin "baserom.gba", 0x7FB020, 0x40
+sMachampGfx39_1:
+.incbin "baserom.gba", 0x7FB060, 0x180
+sMachampSprites39:
+ax_sprite sMachampGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx39_1, 0x180
+ax_sprite_terminator
+sMachampGfx40:
+.incbin "baserom.gba", 0x7FB200, 0x40
+sMachampSprites40:
+ax_sprite sMachampGfx40, 0x40
+ax_sprite_terminator
+sMachampGfx41:
+.incbin "baserom.gba", 0x7FB250, 0x80
+sMachampGfx41_1:
+.incbin "baserom.gba", 0x7FB2D0, 0xC0
+sMachampGfx41_2:
+.incbin "baserom.gba", 0x7FB390, 0x40
+sMachampSprites41:
+ax_sprite sMachampGfx41, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx41_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx41_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachampGfx42:
+.incbin "baserom.gba", 0x7FB408, 0x60
+sMachampGfx42_1:
+.incbin "baserom.gba", 0x7FB468, 0xE0
+sMachampGfx42_2:
+.incbin "baserom.gba", 0x7FB548, 0x60
+sMachampSprites42:
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx42_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx42_2, 0x60
+ax_sprite_terminator
+sMachampGfx43:
+.incbin "baserom.gba", 0x7FB5E0, 0x40
+sMachampSprites43:
+ax_sprite sMachampGfx43, 0x40
+ax_sprite_terminator
+sMachampGfx44:
+.incbin "baserom.gba", 0x7FB630, 0x40
+sMachampGfx44_1:
+.incbin "baserom.gba", 0x7FB670, 0x180
+sMachampSprites44:
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx44_1, 0x180
+ax_sprite_terminator
+sMachampGfx45:
+.incbin "baserom.gba", 0x7FB818, 0x40
+sMachampSprites45:
+ax_sprite sMachampGfx45, 0x40
+ax_sprite_terminator
+sMachampGfx46:
+.incbin "baserom.gba", 0x7FB868, 0x1E0
+sMachampSprites46:
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx46, 0x1e0
+ax_sprite_terminator
+sMachampGfx47:
+.incbin "baserom.gba", 0x7FBA60, 0x1C0
+sMachampSprites47:
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx47, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx48:
+.incbin "baserom.gba", 0x7FBC40, 0x60
+sMachampGfx48_1:
+.incbin "baserom.gba", 0x7FBCA0, 0x60
+sMachampGfx48_2:
+.incbin "baserom.gba", 0x7FBD00, 0x40
+sMachampGfx48_3:
+.incbin "baserom.gba", 0x7FBD40, 0x40
+sMachampSprites48:
+ax_sprite sMachampGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx48_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx48_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachampGfx49:
+.incbin "baserom.gba", 0x7FBDC8, 0x40
+sMachampSprites49:
+ax_sprite sMachampGfx49, 0x40
+ax_sprite_terminator
+sMachampGfx50:
+.incbin "baserom.gba", 0x7FBE18, 0x100
+sMachampGfx50_1:
+.incbin "baserom.gba", 0x7FBF18, 0x60
+sMachampGfx50_2:
+.incbin "baserom.gba", 0x7FBF78, 0x60
+sMachampSprites50:
+ax_sprite sMachampGfx50, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx50_2, 0x60
+ax_sprite_terminator
+sMachampGfx51:
+.incbin "baserom.gba", 0x7FC008, 0x60
+sMachampGfx51_1:
+.incbin "baserom.gba", 0x7FC068, 0x100
+sMachampGfx51_2:
+.incbin "baserom.gba", 0x7FC168, 0x40
+sMachampSprites51:
+ax_sprite sMachampGfx51, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx51_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx51_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx52:
+.incbin "baserom.gba", 0x7FC1E0, 0x200
+sMachampSprites52:
+ax_sprite sMachampGfx52, 0x200
+ax_sprite_terminator
+sMachampGfx53:
+.incbin "baserom.gba", 0x7FC3F0, 0x60
+sMachampSprites53:
+ax_sprite sMachampGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx54:
+.incbin "baserom.gba", 0x7FC468, 0x40
+sMachampGfx54_1:
+.incbin "baserom.gba", 0x7FC4A8, 0x60
+sMachampGfx54_2:
+.incbin "baserom.gba", 0x7FC508, 0x40
+sMachampGfx54_3:
+.incbin "baserom.gba", 0x7FC548, 0x60
+sMachampSprites54:
+ax_sprite sMachampGfx54, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachampGfx54_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachampGfx54_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachampGfx55:
+.incbin "baserom.gba", 0x7FC5F0, 0x200
+sMachampSprites55:
+ax_sprite sMachampGfx55, 0x200
+ax_sprite_terminator
+sMachampGfx56:
+.incbin "baserom.gba", 0x7FC800, 0x200
+sMachampSprites56:
+ax_sprite sMachampGfx56, 0x200
+ax_sprite_terminator
+sMachampGfx57:
+.incbin "baserom.gba", 0x7FCA10, 0x200
+sMachampSprites57:
+ax_sprite sMachampGfx57, 0x200
+ax_sprite_terminator
+sMachampGfx58:
+.incbin "baserom.gba", 0x7FCC20, 0x200
+sMachampSprites58:
+ax_sprite sMachampGfx58, 0x200
+ax_sprite_terminator
+sMachampGfx59:
+.incbin "baserom.gba", 0x7FCE30, 0x200
+sMachampSprites59:
+ax_sprite sMachampGfx59, 0x200
+ax_sprite_terminator
+sMachampGfx60:
+.incbin "baserom.gba", 0x7FD040, 0x200
+sMachampSprites60:
+ax_sprite sMachampGfx60, 0x200
+ax_sprite_terminator
+sMachampGfx61:
+.incbin "baserom.gba", 0x7FD250, 0x200
+sMachampSprites61:
+ax_sprite sMachampGfx61, 0x200
+ax_sprite_terminator
+sAxPosesMachamp:
+.4byte sMachampPose1
+.4byte sMachampPose2
+.4byte sMachampPose3
+.4byte sMachampPose4
+.4byte sMachampPose5
+.4byte sMachampPose6
+.4byte sMachampPose7
+.4byte sMachampPose8
+.4byte sMachampPose9
+.4byte sMachampPose10
+.4byte sMachampPose11
+.4byte sMachampPose12
+.4byte sMachampPose13
+.4byte sMachampPose14
+.4byte sMachampPose15
+.4byte sMachampPose16
+.4byte sMachampPose17
+.4byte sMachampPose18
+.4byte sMachampPose19
+.4byte sMachampPose20
+.4byte sMachampPose21
+.4byte sMachampPose22
+.4byte sMachampPose23
+.4byte sMachampPose24
+.4byte sMachampPose25
+.4byte sMachampPose26
+.4byte sMachampPose27
+.4byte sMachampPose28
+.4byte sMachampPose29
+.4byte sMachampPose30
+.4byte sMachampPose31
+.4byte sMachampPose32
+.4byte sMachampPose33
+.4byte sMachampPose34
+.4byte sMachampPose35
+.4byte sMachampPose36
+.4byte sMachampPose37
+.4byte sMachampPose38
+.4byte sMachampPose39
+.4byte sMachampPose40
+.4byte sMachampPose41
+.4byte sMachampPose42
+.4byte sMachampPose43
+.4byte sMachampPose44
+.4byte sMachampPose45
+.4byte sMachampPose46
+.4byte sMachampPose47
+.4byte sMachampPose48
+.4byte sMachampPose49
+.4byte sMachampPose50
+.4byte sMachampPose51
+.4byte sMachampPose52
+.4byte sMachampPose53
+.4byte sMachampPose54
+.4byte sMachampPose55
+.4byte sMachampPose56
+.4byte sMachampPose57
+.4byte sMachampPose58
+.4byte sMachampPose59
+.4byte sMachampPose60
+.4byte sMachampPose61
+.4byte sMachampPose62
+.4byte sMachampPose63
+.4byte sMachampPose64
+.4byte sMachampPose65
+.4byte sMachampPose66
+.4byte sMachampPose67
+.4byte sMachampPose68
+.4byte sMachampPose69
+.4byte sMachampPose70
+.4byte sMachampPose71
+.4byte sMachampPose72
+.4byte sMachampPose73
+.4byte sMachampPose74
+.4byte sMachampPose75
+.4byte sMachampPose76
+.4byte sMachampPose77
+.4byte sMachampPose78
+.4byte sMachampPose79
+.4byte sMachampPose80
+.4byte sMachampPose81
+.4byte sMachampPose82
+.4byte sMachampPose83
+.4byte sMachampPose84
+.4byte sMachampPose85
+.4byte sMachampPose86
+.4byte sMachampPose87
+.4byte sMachampPose88
+.4byte sMachampPose89
+.4byte sMachampPose90
+.4byte sMachampPose91
+.4byte sMachampPose92
+.4byte sMachampPose93
+.4byte sMachampPose94
+.4byte sMachampPose95
+.4byte sMachampPose96
+.4byte sMachampPose97
+.4byte sMachampPose98
+.4byte sMachampPose99
+.4byte sMachampPose100
+.4byte sMachampPose101
+.4byte sMachampPose102
+.4byte sMachampPose103
+.4byte sMachampPose104
+.4byte sMachampPose105
+.4byte sMachampPose106
+.4byte sMachampPose107
+.4byte sMachampPose108
+.4byte sMachampPose109
+.4byte sMachampPose110
+.4byte sMachampPose111
+.4byte sMachampPose112
+.4byte sMachampPose113
+.4byte sMachampPose114
+.4byte sMachampPose115
+.4byte sMachampPose116
+.4byte sMachampPose117
+.4byte sMachampPose118
+.4byte sMachampPose119
+.4byte sMachampPose120
+.4byte sMachampPose121
+.4byte sMachampPose122
+.4byte sMachampPose123
+.4byte sMachampPose124
+.4byte sMachampPose125
+.4byte sMachampPose126
+.4byte sMachampPose127
+.4byte sMachampPose128
+.4byte sMachampPose129
+.4byte sMachampPose130
+.4byte sMachampPose131
+.4byte sMachampPose132
+.4byte sMachampPose133
+.4byte sMachampPose134
+.4byte sMachampPose135
+.4byte sMachampPose136
+.4byte sMachampPose137
+.4byte sMachampPose138
+.4byte sMachampPose139
+.4byte sMachampPose140
+.4byte sMachampPose141
+.4byte sMachampPose142
+.4byte sMachampPose143
+.4byte sMachampPose144
+.4byte sMachampPose145
+.4byte sMachampPose146
+.4byte sMachampPose147
+.4byte sMachampPose148
+.4byte sMachampPose149
+.4byte sMachampPose150
+.4byte sMachampPose151
+.4byte sMachampPose152
+.4byte sMachampPose153
+.4byte sMachampPose154
+.4byte sMachampPose155
+.4byte sMachampPose156
+.4byte sMachampPose157
+.4byte sMachampPose158
+.4byte sMachampPose159
+.4byte sMachampPose160
+.4byte sMachampPose161
+.4byte sMachampPose162
+.4byte sMachampPose163
+.4byte sMachampPose164
+.4byte sMachampPose165
+.4byte sMachampPose166
+.4byte sMachampPose167
+.4byte sMachampPose168
+.4byte sMachampPose169
+.4byte sMachampPose170
+.4byte sMachampPose171
+.4byte sMachampPose172
+.4byte sMachampPose173
+.4byte sMachampPose174
+.4byte sMachampPose175
+.4byte sMachampPose176
+.4byte sMachampPose177
+.4byte sMachampPose178
+.4byte sMachampPose179
+.4byte sMachampPose180
+.4byte sMachampPose181
+.4byte sMachampPose182
+.4byte sMachampPose183
+.4byte sMachampPose184
+.4byte sMachampPose185
+.4byte sMachampPose186
+.4byte sMachampPose187
+.4byte sMachampPose188
+.4byte sMachampPose189
+.4byte sMachampPose190
+.4byte sMachampPose191
+.4byte sMachampPose192
+.4byte sMachampPose193
+.4byte sMachampPose194
+.4byte sMachampPose195
+.4byte sMachampPose196
+.4byte sMachampPose197
+.4byte sMachampPose198
+.4byte sMachampPose199
+.4byte sMachampPose200
+.4byte sMachampPose201
+.4byte sMachampPose202
+.4byte sMachampPose203
+.4byte sMachampPose204
+.4byte sMachampPose205
+.4byte sMachampPose206
+.4byte sMachampPose207
+.4byte sMachampPose208
+.4byte sMachampPose209
+.4byte sMachampPose210
+.4byte sMachampPose211
+.4byte sMachampPose212
+.4byte sMachampPose213
+.4byte sMachampPose214
+.4byte sMachampPose215
+.4byte sMachampPose216
+.4byte sMachampPose217
+.4byte sMachampPose218
+sAxPositionsMachamp:
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	 -12,   -9, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -15, 	  -9,   -6, 	  10,   -9, 	  -1,  -11
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte    0,  -15, 	   8,  -10, 	  -2,   -8, 	  -1,  -12
+.2byte    0,  -15, 	   9,  -10, 	  -9,   -8, 	  -2,  -12
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,  -12
+.2byte    4,  -16, 	   9,  -11, 	  -2,   -6, 	   0,  -12
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte    2,  -18, 	  -8,  -12, 	  10,  -10, 	  -2,  -14
+.2byte    3,  -17, 	  -3,  -13, 	   6,   -8, 	  -2,  -14
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte   -1,  -19, 	   8,   -7, 	 -11,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	   9,  -12, 	 -10,   -7, 	  -1,  -13
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte   -4,  -18, 	   6,  -12, 	 -12,  -10, 	   0,  -14
+.2byte   -5,  -17, 	   1,  -13, 	  -8,   -8, 	   0,  -14
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte   -6,  -16, 	  -1,  -11, 	  -8,   -9, 	  -2,  -12
+.2byte   -6,  -16, 	 -11,  -11, 	   0,   -6, 	  -2,  -12
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte   -2,  -15, 	 -10,  -10, 	   0,   -8, 	  -1,  -12
+.2byte   -2,  -15, 	 -11,  -10, 	   7,   -8, 	   0,  -12
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -1,  -15, 	 -12,   -9, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -15, 	  -9,   -6, 	  10,   -9, 	  -1,  -11
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte    0,  -15, 	   8,  -10, 	  -2,   -8, 	  -1,  -12
+.2byte    0,  -15, 	   9,  -10, 	  -9,   -8, 	  -2,  -12
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    4,  -16, 	  -1,  -11, 	   6,   -9, 	   0,  -12
+.2byte    4,  -16, 	   9,  -11, 	  -2,   -6, 	   0,  -12
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte    2,  -18, 	  -8,  -12, 	  10,  -10, 	  -2,  -14
+.2byte    3,  -17, 	  -3,  -13, 	   6,   -8, 	  -2,  -14
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte   -1,  -19, 	   8,   -7, 	 -11,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	   9,  -12, 	 -10,   -7, 	  -1,  -13
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte   -4,  -18, 	   6,  -12, 	 -12,  -10, 	   0,  -14
+.2byte   -5,  -17, 	   1,  -13, 	  -8,   -8, 	   0,  -14
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte   -6,  -16, 	  -1,  -11, 	  -8,   -9, 	  -2,  -12
+.2byte   -6,  -16, 	 -11,  -11, 	   0,   -6, 	  -2,  -12
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte   -2,  -15, 	 -10,  -10, 	   0,   -8, 	  -1,  -12
+.2byte   -2,  -15, 	 -11,  -10, 	   7,   -8, 	   0,  -12
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -3,  -18, 	  -3,  -14, 	  -9,  -14, 	   0,  -12
+.2byte    3,   -9, 	   1,    1, 	   6,  -17, 	  -2,  -12
+.2byte    3,   -9, 	   1,    1, 	   6,  -17, 	  -2,  -12
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte    0,  -18, 	  -6,  -16, 	   7,  -15, 	  -3,  -14
+.2byte   -3,   -8, 	   2,    1, 	 -13,  -11, 	  -1,  -10
+.2byte   -3,   -8, 	   2,    1, 	 -13,  -11, 	  -1,  -10
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte   -5,  -18, 	 -13,  -10, 	   4,  -19, 	  -5,  -13
+.2byte    3,  -10, 	   7,   -2, 	  -9,  -10, 	   1,  -11
+.2byte    3,  -10, 	   7,   -2, 	  -9,  -10, 	   1,  -11
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte   -8,  -17, 	 -14,  -12, 	   0,  -27, 	  -4,  -14
+.2byte    1,  -11, 	   7,   -9, 	  -5,   -2, 	  -2,  -13
+.2byte    1,  -11, 	   7,   -9, 	  -5,   -2, 	  -2,  -13
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte    5,  -17, 	   5,   -3, 	   4,  -20, 	  -1,  -10
+.2byte   -7,  -16, 	  -2,  -25, 	 -10,   -9, 	  -2,  -12
+.2byte   -7,  -16, 	  -2,  -25, 	 -10,   -9, 	  -2,  -12
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte    6,  -17, 	  12,  -12, 	  -2,  -27, 	   2,  -14
+.2byte   -3,  -11, 	  -9,   -9, 	   3,   -2, 	   0,  -13
+.2byte   -3,  -11, 	  -9,   -9, 	   3,   -2, 	   0,  -13
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte    3,  -18, 	  11,  -10, 	  -6,  -19, 	   3,  -13
+.2byte   -5,  -10, 	  -9,   -2, 	   7,  -10, 	  -3,  -11
+.2byte   -5,  -10, 	  -9,   -2, 	   7,  -10, 	  -3,  -11
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte    0,  -18, 	   6,  -16, 	  -7,  -15, 	   3,  -14
+.2byte    1,   -8, 	  -4,    1, 	  11,  -11, 	  -1,  -10
+.2byte    1,   -8, 	  -4,    1, 	  11,  -11, 	  -1,  -10
+.2byte   -1,  -12, 	 -13,   -7, 	  11,   -7, 	  -1,  -11
+.2byte   -3,  -12, 	 -14,   -8, 	   5,   -4, 	  -1,  -11
+.2byte   -8,  -14, 	  -6,   -9, 	  -2,   -5, 	  -2,  -10
+.2byte   -6,  -17, 	   3,  -10, 	 -11,   -7, 	  -1,  -13
+.2byte   -1,  -18, 	  10,   -8, 	 -12,   -8, 	  -1,  -12
+.2byte    4,  -17, 	  -5,  -10, 	   9,   -7, 	  -1,  -13
+.2byte    6,  -14, 	   4,   -9, 	   0,   -5, 	   0,  -10
+.2byte    1,  -12, 	  12,   -8, 	  -7,   -4, 	  -1,  -11
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -1,  -12, 	 -13,   -7, 	  11,   -7, 	  -1,  -11
+.2byte    3,  -21, 	   0,  -28, 	   0,  -22, 	  -1,  -15
+.2byte    3,  -21, 	   0,  -28, 	   0,  -22, 	  -1,  -15
+.2byte    3,  -24, 	   3,  -20, 	   9,  -20, 	   0,  -18
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte    1,  -12, 	  12,   -8, 	  -7,   -4, 	  -1,  -11
+.2byte   -4,  -26, 	   0,  -35, 	 -11,  -26, 	  -1,  -20
+.2byte   -4,  -26, 	   0,  -35, 	 -11,  -26, 	  -1,  -20
+.2byte   -5,  -28, 	  -8,  -13, 	   3,  -25, 	  -2,  -22
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    6,  -14, 	   4,   -9, 	   0,   -5, 	   0,  -10
+.2byte  -10,  -15, 	 -12,  -27, 	 -14,  -13, 	  -3,  -12
+.2byte  -10,  -15, 	 -12,  -27, 	 -14,  -13, 	  -3,  -12
+.2byte   -6,  -20, 	   6,  -19, 	 -13,  -12, 	  -3,  -15
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte    4,  -17, 	  -5,  -10, 	   9,   -7, 	  -1,  -13
+.2byte   -7,  -12, 	 -18,  -23, 	 -10,   -2, 	  -3,  -15
+.2byte   -7,  -12, 	 -18,  -23, 	 -10,   -2, 	  -3,  -15
+.2byte   -1,  -19, 	  10,  -23, 	  -5,  -10, 	  -1,  -16
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte   -1,  -18, 	  10,   -8, 	 -12,   -8, 	  -1,  -12
+.2byte    2,  -14, 	   8,   -2, 	   6,  -22, 	   0,  -14
+.2byte    2,  -14, 	   8,   -2, 	   6,  -22, 	   0,  -14
+.2byte    4,  -19, 	  -1,  -28, 	   7,  -12, 	  -1,  -15
+.2byte   -3,  -19, 	   5,  -14, 	  -9,   -9, 	   1,  -15
+.2byte   -5,  -17, 	   4,  -10, 	 -10,   -7, 	   0,  -13
+.2byte    3,  -15, 	  14,  -26, 	   6,   -5, 	  -1,  -18
+.2byte    3,  -15, 	  14,  -26, 	   6,   -5, 	  -1,  -18
+.2byte    0,  -19, 	 -11,  -23, 	   4,  -10, 	   0,  -16
+.2byte   -5,  -17, 	  -5,  -11, 	  -2,   -7, 	  -1,  -12
+.2byte   -7,  -14, 	  -5,   -9, 	  -1,   -5, 	  -1,  -10
+.2byte    9,  -15, 	  11,  -27, 	  13,  -13, 	   2,  -12
+.2byte    9,  -15, 	  11,  -27, 	  13,  -13, 	   2,  -12
+.2byte    5,  -20, 	  -7,  -19, 	  12,  -12, 	   2,  -15
+.2byte   -1,  -16, 	 -11,  -11, 	   5,   -7, 	   1,  -13
+.2byte   -2,  -12, 	 -13,   -8, 	   6,   -4, 	   0,  -11
+.2byte    3,  -26, 	  -1,  -35, 	  10,  -26, 	   0,  -20
+.2byte    3,  -26, 	  -1,  -35, 	  10,  -26, 	   0,  -20
+.2byte    4,  -28, 	   7,  -13, 	  -4,  -25, 	   1,  -22
+.2byte   -2,  -13, 	  -8,   -5, 	   7,   -3, 	   0,   -9
+.2byte   -3,  -12, 	  -8,   -5, 	   7,   -2, 	   0,   -8
+.2byte    0,  -16, 	  -1,  -21, 	   1,  -20, 	   0,  -12
+.2byte    1,  -16, 	   0,  -24, 	   1,  -22, 	  -2,  -13
+.2byte    2,  -17, 	   2,  -23, 	   4,  -22, 	  -3,  -13
+.2byte    0,  -16, 	  -1,  -19, 	   2,  -19, 	  -3,  -13
+.2byte    0,  -17, 	   3,  -20, 	  -3,  -20, 	   0,  -13
+.2byte   -1,  -16, 	   0,  -19, 	  -3,  -19, 	   2,  -13
+.2byte   -4,  -17, 	  -4,  -23, 	  -6,  -22, 	   1,  -13
+.2byte   -2,  -16, 	  -1,  -24, 	  -2,  -22, 	   1,  -13
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -1,  -12, 	 -13,   -7, 	  11,   -7, 	  -1,  -11
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte    1,  -12, 	  12,   -8, 	  -7,   -4, 	  -1,  -11
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    6,  -14, 	   4,   -9, 	   0,   -5, 	   0,  -10
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte    4,  -17, 	  -5,  -10, 	   9,   -7, 	  -1,  -13
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte   -1,  -18, 	  10,   -8, 	 -12,   -8, 	  -1,  -12
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte   -6,  -17, 	   3,  -10, 	 -11,   -7, 	  -1,  -13
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte   -8,  -14, 	  -6,   -9, 	  -2,   -5, 	  -2,  -10
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte   -3,  -12, 	 -14,   -8, 	   5,   -4, 	  -1,  -11
+.2byte   -1,  -12, 	 -13,   -7, 	  11,   -7, 	  -1,  -11
+.2byte   -3,  -12, 	 -14,   -8, 	   5,   -4, 	  -1,  -11
+.2byte   -8,  -14, 	  -6,   -9, 	  -2,   -5, 	  -2,  -10
+.2byte   -6,  -17, 	   3,  -10, 	 -11,   -7, 	  -1,  -13
+.2byte   -1,  -18, 	  10,   -8, 	 -12,   -8, 	  -1,  -12
+.2byte    4,  -17, 	  -5,  -10, 	   9,   -7, 	  -1,  -13
+.2byte    6,  -14, 	   4,   -9, 	   0,   -5, 	   0,  -10
+.2byte    1,  -12, 	  12,   -8, 	  -7,   -4, 	  -1,  -11
+.2byte   -1,  -12, 	 -13,   -7, 	  11,   -7, 	  -1,  -11
+.2byte    1,  -12, 	  12,   -8, 	  -7,   -4, 	  -1,  -11
+.2byte    6,  -14, 	   4,   -9, 	   0,   -5, 	   0,  -10
+.2byte    4,  -17, 	  -5,  -10, 	   9,   -7, 	  -1,  -13
+.2byte   -1,  -18, 	  10,   -8, 	 -12,   -8, 	  -1,  -12
+.2byte   -6,  -17, 	   3,  -10, 	 -11,   -7, 	  -1,  -13
+.2byte   -8,  -14, 	  -6,   -9, 	  -2,   -5, 	  -2,  -10
+.2byte   -3,  -12, 	 -14,   -8, 	   5,   -4, 	  -1,  -11
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -1,  -12, 	 -13,   -7, 	  11,   -7, 	  -1,  -11
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+.2byte    1,  -12, 	  12,   -8, 	  -7,   -4, 	  -1,  -11
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    6,  -14, 	   4,   -9, 	   0,   -5, 	   0,  -10
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte    4,  -17, 	  -5,  -10, 	   9,   -7, 	  -1,  -13
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte   -1,  -18, 	  10,   -8, 	 -12,   -8, 	  -1,  -12
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte   -6,  -17, 	   3,  -10, 	 -11,   -7, 	  -1,  -13
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte   -8,  -14, 	  -6,   -9, 	  -2,   -5, 	  -2,  -10
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte   -3,  -12, 	 -14,   -8, 	   5,   -4, 	  -1,  -11
+.2byte   -1,  -12, 	 -13,   -7, 	  11,   -7, 	  -1,  -11
+.2byte   -3,  -12, 	 -14,   -8, 	   5,   -4, 	  -1,  -11
+.2byte   -8,  -14, 	  -6,   -9, 	  -2,   -5, 	  -2,  -10
+.2byte   -6,  -17, 	   3,  -10, 	 -11,   -7, 	  -1,  -13
+.2byte   -1,  -18, 	  10,   -8, 	 -12,   -8, 	  -1,  -12
+.2byte    4,  -17, 	  -5,  -10, 	   9,   -7, 	  -1,  -13
+.2byte    6,  -14, 	   4,   -9, 	   0,   -5, 	   0,  -10
+.2byte    1,  -12, 	  12,   -8, 	  -7,   -4, 	  -1,  -11
+.2byte   -1,  -16, 	 -11,   -8, 	   9,   -8, 	  -1,  -12
+.2byte   -2,  -16, 	 -12,  -11, 	   4,   -7, 	   0,  -13
+.2byte   -6,  -17, 	  -6,  -11, 	  -3,   -7, 	  -2,  -12
+.2byte   -4,  -19, 	   4,  -14, 	 -10,   -9, 	   0,  -15
+.2byte   -1,  -20, 	   8,  -10, 	 -10,  -10, 	  -1,  -14
+.2byte    2,  -19, 	  -6,  -14, 	   8,   -9, 	  -2,  -15
+.2byte    4,  -17, 	   4,  -11, 	   1,   -7, 	   0,  -12
+.2byte    0,  -16, 	  10,  -11, 	  -6,   -7, 	  -2,  -13
+sMachampAnimTable1:
+.4byte sMachampAnims_1_1
+.4byte sMachampAnims_1_2
+.4byte sMachampAnims_1_3
+.4byte sMachampAnims_1_4
+.4byte sMachampAnims_1_5
+.4byte sMachampAnims_1_6
+.4byte sMachampAnims_1_7
+.4byte sMachampAnims_1_8
+sMachampAnimTable2:
+.4byte sMachampAnims_2_1
+.4byte sMachampAnims_2_2
+.4byte sMachampAnims_2_3
+.4byte sMachampAnims_2_4
+.4byte sMachampAnims_2_5
+.4byte sMachampAnims_2_6
+.4byte sMachampAnims_2_7
+.4byte sMachampAnims_2_8
+sMachampAnimTable3:
+.4byte sMachampAnims_3_1
+.4byte sMachampAnims_3_2
+.4byte sMachampAnims_3_3
+.4byte sMachampAnims_3_4
+.4byte sMachampAnims_3_5
+.4byte sMachampAnims_3_6
+.4byte sMachampAnims_3_7
+.4byte sMachampAnims_3_8
+sMachampAnimTable4:
+.4byte sMachampAnims_4_1
+.4byte sMachampAnims_4_2
+.4byte sMachampAnims_4_3
+.4byte sMachampAnims_4_4
+.4byte sMachampAnims_4_5
+.4byte sMachampAnims_4_6
+.4byte sMachampAnims_4_7
+.4byte sMachampAnims_4_8
+sMachampAnimTable5:
+.4byte sMachampAnims_5_1
+.4byte sMachampAnims_5_2
+.4byte sMachampAnims_5_3
+.4byte sMachampAnims_5_4
+.4byte sMachampAnims_5_5
+.4byte sMachampAnims_5_6
+.4byte sMachampAnims_5_7
+.4byte sMachampAnims_5_8
+sMachampAnimTable6:
+.4byte sMachampAnims_6_1
+.4byte sMachampAnims_6_1
+.4byte sMachampAnims_6_1
+.4byte sMachampAnims_6_1
+.4byte sMachampAnims_6_1
+.4byte sMachampAnims_6_1
+.4byte sMachampAnims_6_1
+.4byte sMachampAnims_6_1
+sMachampAnimTable7:
+.4byte sMachampAnims_7_1
+.4byte sMachampAnims_7_2
+.4byte sMachampAnims_7_3
+.4byte sMachampAnims_7_4
+.4byte sMachampAnims_7_5
+.4byte sMachampAnims_7_6
+.4byte sMachampAnims_7_7
+.4byte sMachampAnims_7_8
+sMachampAnimTable8:
+.4byte sMachampAnims_8_1
+.4byte sMachampAnims_8_2
+.4byte sMachampAnims_8_3
+.4byte sMachampAnims_8_4
+.4byte sMachampAnims_8_5
+.4byte sMachampAnims_8_6
+.4byte sMachampAnims_8_7
+.4byte sMachampAnims_8_8
+sMachampAnimTable9:
+.4byte sMachampAnims_9_1
+.4byte sMachampAnims_9_2
+.4byte sMachampAnims_9_3
+.4byte sMachampAnims_9_4
+.4byte sMachampAnims_9_5
+.4byte sMachampAnims_9_6
+.4byte sMachampAnims_9_7
+.4byte sMachampAnims_9_8
+sMachampAnimTable10:
+.4byte sMachampAnims_10_1
+.4byte sMachampAnims_10_2
+.4byte sMachampAnims_10_3
+.4byte sMachampAnims_10_4
+.4byte sMachampAnims_10_5
+.4byte sMachampAnims_10_6
+.4byte sMachampAnims_10_7
+.4byte sMachampAnims_10_8
+sMachampAnimTable11:
+.4byte sMachampAnims_11_1
+.4byte sMachampAnims_11_2
+.4byte sMachampAnims_11_3
+.4byte sMachampAnims_11_4
+.4byte sMachampAnims_11_5
+.4byte sMachampAnims_11_6
+.4byte sMachampAnims_11_7
+.4byte sMachampAnims_11_8
+sMachampAnimTable12:
+.4byte sMachampAnims_12_1
+.4byte sMachampAnims_12_2
+.4byte sMachampAnims_12_3
+.4byte sMachampAnims_12_4
+.4byte sMachampAnims_12_5
+.4byte sMachampAnims_12_6
+.4byte sMachampAnims_12_7
+.4byte sMachampAnims_12_8
+sMachampAnimTable13:
+.4byte sMachampAnims_13_1
+.4byte sMachampAnims_13_2
+.4byte sMachampAnims_13_3
+.4byte sMachampAnims_13_4
+.4byte sMachampAnims_13_5
+.4byte sMachampAnims_13_6
+.4byte sMachampAnims_13_7
+.4byte sMachampAnims_13_8
+sAxAnimationsMachamp:
+.4byte sMachampAnimTable1
+.4byte sMachampAnimTable2
+.4byte sMachampAnimTable3
+.4byte sMachampAnimTable4
+.4byte sMachampAnimTable5
+.4byte sMachampAnimTable6
+.4byte sMachampAnimTable7
+.4byte sMachampAnimTable8
+.4byte sMachampAnimTable9
+.4byte sMachampAnimTable10
+.4byte sMachampAnimTable11
+.4byte sMachampAnimTable12
+.4byte sMachampAnimTable13
+sAxSpritesMachamp:
+.4byte sMachampSprites1
+.4byte sMachampSprites2
+.4byte sMachampSprites3
+.4byte sMachampSprites4
+.4byte sMachampSprites5
+.4byte sMachampSprites6
+.4byte sMachampSprites7
+.4byte sMachampSprites8
+.4byte sMachampSprites9
+.4byte sMachampSprites10
+.4byte sMachampSprites11
+.4byte sMachampSprites12
+.4byte sMachampSprites13
+.4byte sMachampSprites14
+.4byte sMachampSprites15
+.4byte sMachampSprites16
+.4byte sMachampSprites17
+.4byte sMachampSprites18
+.4byte sMachampSprites19
+.4byte sMachampSprites20
+.4byte sMachampSprites21
+.4byte sMachampSprites22
+.4byte sMachampSprites23
+.4byte sMachampSprites24
+.4byte sMachampSprites25
+.4byte sMachampSprites26
+.4byte sMachampSprites27
+.4byte sMachampSprites28
+.4byte sMachampSprites29
+.4byte sMachampSprites30
+.4byte sMachampSprites31
+.4byte sMachampSprites32
+.4byte sMachampSprites33
+.4byte sMachampSprites34
+.4byte sMachampSprites35
+.4byte sMachampSprites36
+.4byte sMachampSprites37
+.4byte sMachampSprites38
+.4byte sMachampSprites39
+.4byte sMachampSprites40
+.4byte sMachampSprites41
+.4byte sMachampSprites42
+.4byte sMachampSprites43
+.4byte sMachampSprites44
+.4byte sMachampSprites45
+.4byte sMachampSprites46
+.4byte sMachampSprites47
+.4byte sMachampSprites48
+.4byte sMachampSprites49
+.4byte sMachampSprites50
+.4byte sMachampSprites51
+.4byte sMachampSprites52
+.4byte sMachampSprites53
+.4byte sMachampSprites54
+.4byte sMachampSprites55
+.4byte sMachampSprites56
+.4byte sMachampSprites57
+.4byte sMachampSprites58
+.4byte sMachampSprites59
+.4byte sMachampSprites60
+.4byte sMachampSprites61
+sAxMainMachamp:
+ax_main sAxPosesMachamp, sAxAnimationsMachamp, 13, sAxSpritesMachamp, sAxPositionsMachamp

--- a/data/ax/machoke.inc
+++ b/data/ax/machoke.inc
@@ -1,0 +1,2913 @@
+.global gAxMachoke
+gAxMachoke:
+ax_siro sAxMainMachoke
+sMachokePose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose4:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose5:
+ax_pose 4, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose6:
+ax_pose 5, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sMachokePose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose8:
+ax_pose 7, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose9:
+ax_pose 8, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose10:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose11:
+ax_pose 10, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose12:
+ax_pose 11, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose14:
+ax_pose 13, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose15:
+ax_pose 14, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose16:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose17:
+ax_pose 10, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose20:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose21:
+ax_pose 8, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose22:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose23:
+ax_pose 4, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose28:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose29:
+ax_pose 4, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose30:
+ax_pose 5, 0x01e6, 0x90eb, 0x2c00
+ax_pose_terminator
+sMachokePose31:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose32:
+ax_pose 7, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose33:
+ax_pose 8, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose34:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose35:
+ax_pose 10, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose36:
+ax_pose 11, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose37:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose38:
+ax_pose 13, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose39:
+ax_pose 14, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose40:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose41:
+ax_pose 10, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose42:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose43:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose44:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose45:
+ax_pose 8, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose46:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose47:
+ax_pose 4, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose48:
+ax_pose 5, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose50:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose51:
+ax_pose 16, 0x01e7, 0x80e7, 0x2c00
+ax_pose 17, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sMachokePose52:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose53:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose54:
+ax_pose 18, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose55:
+ax_pose 19, 0x01e7, 0x90fa, 0x2c00
+ax_pose 20, 0x01e7, 0x90f1, 0x2c10
+ax_pose_terminator
+sMachokePose56:
+ax_pose 20, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sMachokePose57:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose58:
+ax_pose 21, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose59:
+ax_pose 22, 0x01e5, 0x90f4, 0x2c00
+ax_pose 23, 0x01e5, 0x90f3, 0x2c10
+ax_pose_terminator
+sMachokePose60:
+ax_pose 23, 0x01e5, 0x90f3, 0x2c00
+ax_pose_terminator
+sMachokePose61:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose62:
+ax_pose 24, 0x01e4, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose63:
+ax_pose 25, 0x01e3, 0x90ee, 0x2c00
+ax_pose 26, 0x01e4, 0x90ed, 0x2c10
+ax_pose_terminator
+sMachokePose64:
+ax_pose 26, 0x01e4, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose65:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose66:
+ax_pose 27, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sMachokePose67:
+ax_pose 28, 0x01e5, 0x80f8, 0x2c00
+ax_pose 29, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sMachokePose68:
+ax_pose 29, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose69:
+ax_pose 9, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose70:
+ax_pose 24, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose71:
+ax_pose 25, 0x01e3, 0x80f2, 0x2c00
+ax_pose 26, 0x01e4, 0x80f3, 0x2c10
+ax_pose_terminator
+sMachokePose72:
+ax_pose 26, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose73:
+ax_pose 6, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMachokePose74:
+ax_pose 21, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose75:
+ax_pose 22, 0x01e5, 0x80ec, 0x2c00
+ax_pose 23, 0x01e5, 0x80ed, 0x2c10
+ax_pose_terminator
+sMachokePose76:
+ax_pose 23, 0x01e5, 0x80ed, 0x2c00
+ax_pose_terminator
+sMachokePose77:
+ax_pose 3, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose78:
+ax_pose 18, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose79:
+ax_pose 19, 0x01e7, 0x80e6, 0x2c00
+ax_pose 20, 0x01e7, 0x80ef, 0x2c10
+ax_pose_terminator
+sMachokePose80:
+ax_pose 20, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sMachokePose81:
+ax_pose 17, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose82:
+ax_pose 20, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sMachokePose83:
+ax_pose 23, 0x01e4, 0x80ec, 0x2c00
+ax_pose_terminator
+sMachokePose84:
+ax_pose 26, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose85:
+ax_pose 29, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sMachokePose86:
+ax_pose 26, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose87:
+ax_pose 23, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sMachokePose88:
+ax_pose 20, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sMachokePose89:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose90:
+ax_pose 30, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose91:
+ax_pose 31, 0x01e5, 0x80f0, 0x2c00
+ax_pose 32, 0x01e5, 0x80f1, 0x2c10
+ax_pose_terminator
+sMachokePose92:
+ax_pose 32, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMachokePose93:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose94:
+ax_pose 33, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose95:
+ax_pose 34, 0x01e8, 0x90f1, 0x2c00
+ax_pose 35, 0x01e6, 0x90ef, 0x2c10
+ax_pose_terminator
+sMachokePose96:
+ax_pose 35, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose97:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose98:
+ax_pose 36, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose99:
+ax_pose 37, 0x81e5, 0x9102, 0x2c00
+ax_pose 38, 0x01e6, 0x90f2, 0x2c08
+ax_pose_terminator
+sMachokePose100:
+ax_pose 38, 0x01e6, 0x90f2, 0x2c00
+ax_pose_terminator
+sMachokePose101:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose102:
+ax_pose 39, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose103:
+ax_pose 40, 0x01e2, 0x90f3, 0x2c00
+ax_pose 41, 0x01e9, 0x90f0, 0x2c10
+ax_pose_terminator
+sMachokePose104:
+ax_pose 41, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sMachokePose105:
+ax_pose 42, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sMachokePose106:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose107:
+ax_pose 42, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose108:
+ax_pose 43, 0x01e4, 0x80f1, 0x2c00
+ax_pose 44, 0x01e5, 0x80f2, 0x2c10
+ax_pose_terminator
+sMachokePose109:
+ax_pose 44, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose110:
+ax_pose 39, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose111:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose112:
+ax_pose 39, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose113:
+ax_pose 40, 0x01e2, 0x80ec, 0x2c00
+ax_pose 41, 0x01e9, 0x80ef, 0x2c10
+ax_pose_terminator
+sMachokePose114:
+ax_pose 41, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sMachokePose115:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose116:
+ax_pose 36, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose117:
+ax_pose 37, 0x81e5, 0x80ed, 0x2c00
+ax_pose 38, 0x01e6, 0x80ed, 0x2c08
+ax_pose_terminator
+sMachokePose118:
+ax_pose 38, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sMachokePose119:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose120:
+ax_pose 33, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose121:
+ax_pose 34, 0x01e8, 0x80ee, 0x2c00
+ax_pose 35, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sMachokePose122:
+ax_pose 35, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose123:
+ax_pose 45, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose124:
+ax_pose 46, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose125:
+ax_pose 47, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose126:
+ax_pose 48, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sMachokePose127:
+ax_pose 49, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sMachokePose128:
+ax_pose 50, 0x01e2, 0x90f4, 0x2c00
+ax_pose_terminator
+sMachokePose129:
+ax_pose 51, 0x01e1, 0x80ef, 0x2c00
+ax_pose_terminator
+sMachokePose130:
+ax_pose 50, 0x01e2, 0x80ec, 0x2c00
+ax_pose_terminator
+sMachokePose131:
+ax_pose 49, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose132:
+ax_pose 48, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose133:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose134:
+ax_pose 30, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose135:
+ax_pose 31, 0x01e5, 0x80f0, 0x2c00
+ax_pose 32, 0x01e5, 0x80f1, 0x2c10
+ax_pose_terminator
+sMachokePose136:
+ax_pose 32, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMachokePose137:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose138:
+ax_pose 33, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose139:
+ax_pose 34, 0x01ea, 0x90f3, 0x2c00
+ax_pose 35, 0x01e6, 0x90ef, 0x2c10
+ax_pose_terminator
+sMachokePose140:
+ax_pose 35, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose141:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose142:
+ax_pose 36, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose143:
+ax_pose 37, 0x81e5, 0x9102, 0x2c00
+ax_pose 38, 0x01e6, 0x90f2, 0x2c08
+ax_pose_terminator
+sMachokePose144:
+ax_pose 38, 0x01e6, 0x90f2, 0x2c00
+ax_pose_terminator
+sMachokePose145:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose146:
+ax_pose 39, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose147:
+ax_pose 40, 0x01e2, 0x90f3, 0x2c00
+ax_pose 41, 0x01e9, 0x90f0, 0x2c10
+ax_pose_terminator
+sMachokePose148:
+ax_pose 41, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sMachokePose149:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose150:
+ax_pose 42, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose151:
+ax_pose 43, 0x01e4, 0x80f1, 0x2c00
+ax_pose 44, 0x01e5, 0x80f2, 0x2c10
+ax_pose_terminator
+sMachokePose152:
+ax_pose 44, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose153:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose154:
+ax_pose 39, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose155:
+ax_pose 40, 0x01e2, 0x80ec, 0x2c00
+ax_pose 41, 0x01e9, 0x80ef, 0x2c10
+ax_pose_terminator
+sMachokePose156:
+ax_pose 41, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sMachokePose157:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose158:
+ax_pose 36, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose159:
+ax_pose 37, 0x81e5, 0x80ed, 0x2c00
+ax_pose 38, 0x01e6, 0x80ed, 0x2c08
+ax_pose_terminator
+sMachokePose160:
+ax_pose 38, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sMachokePose161:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose162:
+ax_pose 33, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose163:
+ax_pose 34, 0x01ea, 0x80ec, 0x2c00
+ax_pose 35, 0x01e6, 0x80f0, 0x2c10
+ax_pose_terminator
+sMachokePose164:
+ax_pose 35, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose165:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose166:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose167:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose168:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose169:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose170:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose171:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose172:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose173:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose174:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose175:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose176:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose177:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose178:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose179:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose180:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose181:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose182:
+ax_pose 30, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose183:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMachokePose184:
+ax_pose 33, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose185:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose186:
+ax_pose 36, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose187:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose188:
+ax_pose 39, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose189:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose190:
+ax_pose 42, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose191:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose192:
+ax_pose 39, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose193:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose194:
+ax_pose 36, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose195:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose196:
+ax_pose 33, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose197:
+ax_pose 17, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose198:
+ax_pose 20, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sMachokePose199:
+ax_pose 23, 0x01e4, 0x80ec, 0x2c00
+ax_pose_terminator
+sMachokePose200:
+ax_pose 26, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sMachokePose201:
+ax_pose 29, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sMachokePose202:
+ax_pose 26, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose203:
+ax_pose 23, 0x01e4, 0x90f3, 0x2c00
+ax_pose_terminator
+sMachokePose204:
+ax_pose 20, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sMachokePose205:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose206:
+ax_pose 3, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMachokePose207:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose208:
+ax_pose 9, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMachokePose209:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMachokePose210:
+ax_pose 9, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMachokePose211:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMachokePose212:
+ax_pose 3, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sMachokeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 25, 1, -4, 1, -4,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 25, 1, -4, 1, -4,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 3, 2, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 8, 0, 8,
+ax_anim 1, 0, 26, 0, 15, 0, 15,
+ax_anim 2, 1, 26, 1, 15, 1, 15,
+ax_anim 2, 0, 26, 0, 15, 0, 15,
+ax_anim 2, 0, 25, 0, 7, 0, 10,
+ax_anim 2, 0, 25, 0, 2, 0, 6,
+ax_anim_terminator
+sMachokeAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -3, -3, -3, -3,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 2, 0, 28, -3, -5, -3, -5,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 2, 0, 28, -3, -5, -3, -5,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 3, 2, 29, 0, -1, 0, -1,
+ax_anim 1, 0, 29, 8, 8, 8, 8,
+ax_anim 1, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 10, 6, 10, 10,
+ax_anim 2, 0, 28, 5, 1, 5, 5,
+ax_anim_terminator
+sMachokeAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -5, 0, -5, 0,
+ax_anim 2, 0, 31, -6, 0, -6, 0,
+ax_anim 2, 0, 31, -6, -1, -6, 0,
+ax_anim 2, 0, 31, -6, 0, -6, 0,
+ax_anim 2, 0, 31, -6, -1, -6, 0,
+ax_anim 2, 0, 31, -6, 0, -6, 0,
+ax_anim 3, 2, 32, 5, 0, 5, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 1, 0, 32, 22, 0, 22, 0,
+ax_anim 2, 1, 32, 22, -1, 22, -1,
+ax_anim 2, 0, 32, 22, 0, 22, 0,
+ax_anim 2, 0, 31, 9, -2, 9, 0,
+ax_anim 2, 0, 31, 4, -1, 4, 0,
+ax_anim_terminator
+sMachokeAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -3, 3, -3, 3,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 2, 0, 34, -3, 5, -3, 5,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 2, 0, 34, -3, 5, -3, 5,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 3, 2, 35, 0, 1, 0, 0,
+ax_anim 1, 0, 35, 8, -8, 8, -8,
+ax_anim 1, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 1, 35, 19, -17, 19, -17,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 9, -11, 9, -9,
+ax_anim 2, 0, 34, 3, -5, 3, -3,
+ax_anim_terminator
+sMachokeAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 3, 0, 3,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 5, 0, 5,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 5, 0, 5,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 3, 2, 38, 0, -3, 0, -3,
+ax_anim 1, 0, 38, 0, -10, 0, -10,
+ax_anim 1, 0, 38, 0, -17, 0, -17,
+ax_anim 2, 1, 38, -1, -17, 0, -17,
+ax_anim 2, 0, 38, 0, -17, 0, -17,
+ax_anim 2, 0, 37, 0, -7, 0, -3,
+ax_anim 2, 0, 37, 0, -5, 0, -2,
+ax_anim_terminator
+sMachokeAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 3, 3, 3, 3,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 2, 0, 40, 3, 5, 3, 5,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 2, 0, 40, 3, 5, 3, 5,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 3, 2, 41, 0, 1, 0, 0,
+ax_anim 1, 0, 41, -8, -8, -8, -8,
+ax_anim 1, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 1, 41, -19, -17, -19, -17,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -9, -11, -9, -9,
+ax_anim 2, 0, 40, -3, -5, -3, -3,
+ax_anim_terminator
+sMachokeAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 5, 0, 5, 0,
+ax_anim 2, 0, 43, 6, 0, 6, 0,
+ax_anim 2, 0, 43, 6, -1, 6, 0,
+ax_anim 2, 0, 43, 6, 0, 6, 0,
+ax_anim 2, 0, 43, 6, -1, 6, 0,
+ax_anim 2, 0, 43, 6, 0, 6, 0,
+ax_anim 3, 2, 44, -5, 0, -5, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 1, 0, 44, -22, 0, -22, 0,
+ax_anim 2, 1, 44, -22, -1, -22, -1,
+ax_anim 2, 0, 44, -22, 0, -22, 0,
+ax_anim 2, 0, 43, -9, -2, -9, 0,
+ax_anim 2, 0, 43, -4, -1, -4, 0,
+ax_anim_terminator
+sMachokeAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 3, -3, 3, -3,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 2, 0, 46, 3, -5, 3, -5,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 2, 0, 46, 3, -5, 3, -5,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 3, 2, 47, 0, -1, 0, -1,
+ax_anim 1, 0, 47, -8, 8, -8, 8,
+ax_anim 1, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 1, 47, -19, 17, -19, 17,
+ax_anim 2, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -10, 6, -10, 10,
+ax_anim 2, 0, 46, -5, 1, -5, 5,
+ax_anim_terminator
+.align 2
+sMachokeAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 2, 49, 0, 0, 0, 3,
+ax_anim 2, 0, 49, 1, 6, 0, 6,
+ax_anim 2, 1, 50, 4, 15, 0, 15,
+ax_anim 2, 0, 51, 3, 15, 0, 15,
+ax_anim 2, 0, 51, 4, 15, 0, 15,
+ax_anim 2, 0, 51, 3, 15, 0, 15,
+ax_anim 4, 0, 48, 1, 6, 0, 6,
+ax_anim_terminator
+sMachokeAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 2, 2, 53, 1, 1, 3, 3,
+ax_anim 2, 0, 53, 6, 2, 6, 6,
+ax_anim 2, 1, 54, 10, 14, 10, 14,
+ax_anim 2, 0, 55, 11, 13, 11, 13,
+ax_anim 2, 0, 55, 10, 14, 10, 14,
+ax_anim 2, 0, 55, 11, 13, 11, 13,
+ax_anim 4, 0, 52, 6, 6, 6, 6,
+ax_anim_terminator
+sMachokeAnims_3_3:
+ax_anim 2, 0, 57, -1, 0, -1, 0,
+ax_anim 6, 0, 57, -2, 0, -2, 0,
+ax_anim 2, 2, 57, 0, -2, -3, 0,
+ax_anim 2, 0, 57, 4, 0, 4, 0,
+ax_anim 2, 1, 58, 10, 0, 10, 0,
+ax_anim 2, 0, 59, 10, -1, 10, -1,
+ax_anim 2, 0, 59, 10, 0, 10, 0,
+ax_anim 2, 0, 59, 10, -1, 10, -1,
+ax_anim 4, 0, 56, 4, 0, 4, 0,
+ax_anim_terminator
+sMachokeAnims_3_4:
+ax_anim 2, 0, 61, -1, 1, -1, 1,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 2, 2, 61, 0, -3, 3, -3,
+ax_anim 2, 0, 61, 6, -6, 6, -6,
+ax_anim 2, 1, 62, 11, -11, 11, -11,
+ax_anim 2, 0, 63, 12, -10, 12, -10,
+ax_anim 2, 0, 63, 11, -11, 11, -11,
+ax_anim 2, 0, 63, 12, -10, 12, -10,
+ax_anim 4, 0, 60, 6, -6, 6, -6,
+ax_anim_terminator
+sMachokeAnims_3_5:
+ax_anim 2, 0, 65, 0, 1, 0, 1,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 2, 65, 0, -4, 0, -3,
+ax_anim 2, 0, 65, 0, -6, 0, -6,
+ax_anim 2, 1, 66, 0, -17, 0, -17,
+ax_anim 2, 0, 67, 1, -17, 1, -17,
+ax_anim 2, 0, 67, 0, -17, 0, -17,
+ax_anim 2, 0, 67, 1, -17, 1, -17,
+ax_anim 4, 0, 64, 0, -6, 0, -6,
+ax_anim_terminator
+sMachokeAnims_3_6:
+ax_anim 2, 0, 69, 1, 1, 1, 1,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 2, 2, 69, 0, -3, -3, -3,
+ax_anim 2, 0, 69, -6, -6, -6, -6,
+ax_anim 2, 1, 70, -11, -11, -11, -11,
+ax_anim 2, 0, 71, -12, -10, -12, -10,
+ax_anim 2, 0, 71, -11, -11, -11, -11,
+ax_anim 2, 0, 71, -12, -10, -12, -10,
+ax_anim 4, 0, 68, -6, -6, -6, -6,
+ax_anim_terminator
+sMachokeAnims_3_7:
+ax_anim 2, 0, 73, 1, 0, 1, 0,
+ax_anim 6, 0, 73, 2, 0, 2, 0,
+ax_anim 2, 2, 73, 0, -2, 3, 0,
+ax_anim 2, 0, 73, -4, 0, -4, 0,
+ax_anim 2, 1, 74, -10, 0, -10, 0,
+ax_anim 2, 0, 75, -10, -1, -10, -1,
+ax_anim 2, 0, 75, -10, 0, -10, 0,
+ax_anim 2, 0, 75, -10, -1, -10, -1,
+ax_anim 4, 0, 72, -4, 0, -4, 0,
+ax_anim_terminator
+sMachokeAnims_3_8:
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 2, 2, 77, -1, 1, -3, 3,
+ax_anim 2, 0, 77, -6, 2, -6, 6,
+ax_anim 2, 1, 78, -10, 14, -10, 14,
+ax_anim 2, 0, 79, -11, 13, -11, 13,
+ax_anim 2, 0, 79, -10, 14, -10, 14,
+ax_anim 2, 0, 79, -11, 13, -11, 13,
+ax_anim 4, 0, 76, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMachokeAnims_4_1:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_4_2:
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_4_3:
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_4_4:
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_4_5:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_4_6:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_4_7:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_4_8:
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_5_1:
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 2, -3, 2, -3,
+ax_anim 2, 0, 114, 1, -3, 0, -3,
+ax_anim 2, 0, 114, 2, -3, 1, -3,
+ax_anim 6, 0, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 2, 89, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 0, 15, 0, 15,
+ax_anim 2, 1, 91, 1, 15, 1, 15,
+ax_anim 2, 0, 91, 0, 15, 0, 15,
+ax_anim 4, 0, 91, 1, 15, 1, 15,
+ax_anim 2, 0, 89, 0, 6, 0, 6,
+ax_anim_terminator
+sMachokeAnims_5_2:
+ax_anim 2, 0, 96, -1, -1, -1, -1,
+ax_anim 2, 0, 100, -4, -2, -4, -2,
+ax_anim 2, 0, 100, -5, -2, -5, -2,
+ax_anim 2, 0, 100, -4, -2, -4, -2,
+ax_anim 6, 0, 97, 0, -4, 0, -4,
+ax_anim 2, 0, 93, 2, -2, 2, -2,
+ax_anim 2, 2, 93, 5, 1, 5, 1,
+ax_anim 2, 0, 94, 15, 15, 15, 15,
+ax_anim 2, 1, 95, 16, 14, 16, 14,
+ax_anim 2, 0, 95, 15, 15, 15, 15,
+ax_anim 4, 0, 95, 16, 14, 16, 14,
+ax_anim 2, 0, 93, 8, 4, 8, 4,
+ax_anim_terminator
+sMachokeAnims_5_3:
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 0, 105, -3, 1, -3, 1,
+ax_anim 2, 0, 105, -3, 0, -3, 0,
+ax_anim 6, 0, 101, -2, 0, -3, 0,
+ax_anim 2, 0, 97, 2, -1, 2, 0,
+ax_anim 2, 2, 97, 4, -1, 4, 0,
+ax_anim 2, 0, 98, 12, 0, 12, 0,
+ax_anim 2, 1, 99, 12, -1, 12, -1,
+ax_anim 2, 0, 99, 12, 0, 12, 0,
+ax_anim 4, 0, 99, 12, -1, 12, -1,
+ax_anim 2, 0, 97, 6, 0, 6, 0,
+ax_anim_terminator
+sMachokeAnims_5_4:
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 110, -2, 4, -2, 4,
+ax_anim 2, 0, 110, -3, 5, -3, 3,
+ax_anim 2, 0, 110, -2, 4, -2, 4,
+ax_anim 6, 0, 104, -1, 1, -3, 3,
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 2, 101, 5, -5, 5, -8,
+ax_anim 2, 0, 102, 13, -13, 13, -18,
+ax_anim 2, 1, 103, 14, -12, 14, -17,
+ax_anim 2, 0, 103, 13, -13, 13, -18,
+ax_anim 4, 0, 103, 14, -12, 14, -17,
+ax_anim 2, 0, 101, 6, -6, 6, -6,
+ax_anim_terminator
+sMachokeAnims_5_5:
+ax_anim 2, 0, 100, 0, 2, 0, 2,
+ax_anim 2, 0, 96, -2, 3, -2, 3,
+ax_anim 2, 0, 96, -2, 4, -2, 4,
+ax_anim 2, 0, 96, -2, 3, -2, 3,
+ax_anim 6, 0, 97, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, -6, 0, -6,
+ax_anim 2, 0, 107, 0, -12, 0, -12,
+ax_anim 2, 1, 108, 1, -12, 1, -12,
+ax_anim 2, 0, 108, 0, -12, 0, -12,
+ax_anim 4, 0, 108, 1, -12, 1, -12,
+ax_anim 2, 0, 106, 0, -6, 0, -6,
+ax_anim_terminator
+sMachokeAnims_5_6:
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 2, 0, 100, 1, 2, 1, 2,
+ax_anim 2, 0, 100, 2, 3, 2, 3,
+ax_anim 2, 0, 100, 1, 3, 1, 3,
+ax_anim 6, 0, 106, 1, 1, 1, 1,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 2, 111, -3, -4, -3, -4,
+ax_anim 2, 0, 112, -12, -12, -12, -12,
+ax_anim 2, 1, 113, -13, -11, -13, -11,
+ax_anim 2, 0, 113, -12, -12, -12, -12,
+ax_anim 4, 0, 113, -13, -11, -13, -11,
+ax_anim 2, 0, 111, -6, -6, -6, -6,
+ax_anim_terminator
+sMachokeAnims_5_7:
+ax_anim 2, 0, 110, 4, 1, 4, 1,
+ax_anim 2, 0, 105, 5, 2, 5, 2,
+ax_anim 2, 0, 105, 6, 2, 6, 2,
+ax_anim 2, 0, 105, 5, 2, 5, 2,
+ax_anim 6, 0, 111, 3, 1, 3, 1,
+ax_anim 2, 0, 115, -1, -1, -1, 0,
+ax_anim 2, 2, 115, -3, -1, -3, 0,
+ax_anim 2, 0, 116, -9, 0, -9, 0,
+ax_anim 2, 1, 117, -9, -1, -9, 0,
+ax_anim 2, 0, 117, -9, 0, -9, 0,
+ax_anim 4, 0, 117, -9, -1, -9, 0,
+ax_anim 2, 0, 115, -6, -1, -6, 0,
+ax_anim_terminator
+sMachokeAnims_5_8:
+ax_anim 2, 0, 114, 1, 1, 1, 1,
+ax_anim 2, 0, 110, 6, 1, 6, 1,
+ax_anim 2, 0, 110, 7, 0, 7, 0,
+ax_anim 2, 0, 110, 6, 1, 6, 1,
+ax_anim 6, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 119, -2, 1, -2, 1,
+ax_anim 2, 2, 119, -5, 4, -5, 4,
+ax_anim 2, 0, 120, -15, 15, -11, 11,
+ax_anim 2, 1, 121, -16, 14, -12, 10,
+ax_anim 2, 0, 121, -15, 15, -11, 11,
+ax_anim 4, 0, 121, -16, 14, -12, 10,
+ax_anim 2, 0, 119, -9, 6, -9, 6,
+ax_anim_terminator
+.align 2
+sMachokeAnims_6_1:
+ax_anim 30, 0, 122, 0, 0, 0, 0,
+ax_anim 35, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_7_1:
+ax_anim 2, 0, 124, 0, -4, 0, -4,
+ax_anim 8, 0, 124, 0, -5, 0, -5,
+ax_anim_terminator
+sMachokeAnims_7_2:
+ax_anim 2, 0, 125, -4, -4, -4, -4,
+ax_anim 8, 0, 125, -5, -5, -5, -5,
+ax_anim_terminator
+sMachokeAnims_7_3:
+ax_anim 2, 0, 126, -4, 0, -4, 0,
+ax_anim 8, 0, 126, -5, 0, -5, 0,
+ax_anim_terminator
+sMachokeAnims_7_4:
+ax_anim 2, 0, 127, -4, 4, -4, 4,
+ax_anim 8, 0, 127, -5, 5, -5, 5,
+ax_anim_terminator
+sMachokeAnims_7_5:
+ax_anim 2, 0, 128, 0, 4, 0, 4,
+ax_anim 8, 0, 128, 0, 5, 0, 5,
+ax_anim_terminator
+sMachokeAnims_7_6:
+ax_anim 2, 0, 129, 4, 4, 4, 4,
+ax_anim 8, 0, 129, 5, 5, 5, 5,
+ax_anim_terminator
+sMachokeAnims_7_7:
+ax_anim 2, 0, 130, 4, 0, 4, 0,
+ax_anim 8, 0, 130, 5, 0, 5, 0,
+ax_anim_terminator
+sMachokeAnims_7_8:
+ax_anim 2, 0, 131, 4, -4, 4, -4,
+ax_anim 8, 0, 131, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMachokeAnims_8_1:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 0, 133, 0, -2, 0, 0,
+ax_anim_terminator
+sMachokeAnims_8_2:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 137, 0, -2, 0, 0,
+ax_anim_terminator
+sMachokeAnims_8_3:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, -3, 0, 0,
+ax_anim 4, 0, 141, 0, -4, 0, 0,
+ax_anim 4, 0, 141, 0, -3, 0, 0,
+ax_anim_terminator
+sMachokeAnims_8_4:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim_terminator
+sMachokeAnims_8_5:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, -1, -3, 0, 0,
+ax_anim 4, 0, 149, -1, -4, 0, 0,
+ax_anim 4, 0, 149, -1, -3, 0, 0,
+ax_anim_terminator
+sMachokeAnims_8_6:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, -2, 0, 0,
+ax_anim 4, 0, 153, 0, -3, 0, 0,
+ax_anim 4, 0, 153, 0, -2, 0, 0,
+ax_anim_terminator
+sMachokeAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 157, 0, -4, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim_terminator
+sMachokeAnims_8_8:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_9_1:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 6, 4, 6, 4,
+ax_anim 2, 0, 166, 8, 9, 8, 9,
+ax_anim 2, 0, 167, 7, 17, 7, 17,
+ax_anim 3, 0, 168, 1, 20, 1, 20,
+ax_anim 2, 3, 169, -6, 17, -6, 17,
+ax_anim 2, 0, 170, -8, 9, -8, 9,
+ax_anim 1, 0, 171, -6, 4, -6, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_9_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 6, 0, 6, 0,
+ax_anim 2, 0, 165, 17, 3, 17, 3,
+ax_anim 2, 0, 166, 22, 9, 22, 9,
+ax_anim 3, 0, 167, 23, 18, 23, 18,
+ax_anim 2, 3, 168, 11, 19, 11, 19,
+ax_anim 2, 0, 169, 2, 12, 2, 12,
+ax_anim 1, 0, 170, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_9_3:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 3, -4, 3, -4,
+ax_anim 2, 0, 164, 11, -6, 11, -6,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 3, 0, 166, 20, 1, 20, 1,
+ax_anim 2, 3, 167, 17, 5, 17, 5,
+ax_anim 2, 0, 168, 12, 7, 12, 7,
+ax_anim 1, 0, 169, 4, 5, 4, 5,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_9_4:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -1, -6, -1, -6,
+ax_anim 2, 0, 171, 4, -16, 4, -16,
+ax_anim 2, 0, 164, 11, -20, 11, -20,
+ax_anim 3, 0, 165, 17, -21, 17, -21,
+ax_anim 2, 3, 166, 18, -12, 18, -12,
+ax_anim 2, 0, 167, 16, -6, 16, -6,
+ax_anim 1, 0, 168, 7, -1, 7, -1,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_9_5:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, -6, -4, -6, -4,
+ax_anim 2, 0, 170, -8, -10, -8, -10,
+ax_anim 2, 0, 171, -7, -18, -7, -18,
+ax_anim 3, 0, 164, 0, -22, 0, -22,
+ax_anim 2, 3, 165, 7, -19, 7, -19,
+ax_anim 2, 0, 166, 8, -10, 8, -10,
+ax_anim 1, 0, 167, 6, -4, 6, -4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_9_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 1, -6, 1, -6,
+ax_anim 2, 0, 165, -4, -16, -4, -16,
+ax_anim 2, 0, 164, -11, -20, -11, -20,
+ax_anim 3, 0, 171, -17, -21, -17, -21,
+ax_anim 2, 3, 170, -18, -12, -18, -12,
+ax_anim 2, 0, 169, -16, -6, -16, -6,
+ax_anim 1, 0, 168, -7, -1, -7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_9_7:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 165, -3, -4, -3, -4,
+ax_anim 2, 0, 164, -11, -6, -11, -6,
+ax_anim 2, 0, 171, -17, -4, -17, -4,
+ax_anim 3, 0, 170, -20, 1, -20, 1,
+ax_anim 2, 3, 169, -17, 5, -17, 5,
+ax_anim 2, 0, 168, -12, 7, -12, 7,
+ax_anim 1, 0, 167, -4, 5, -4, 5,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_9_8:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, -6, 0, -6, 0,
+ax_anim 2, 0, 171, -17, 3, -17, 3,
+ax_anim 2, 0, 170, -22, 9, -22, 9,
+ax_anim 3, 0, 169, -23, 18, -23, 18,
+ax_anim 2, 3, 168, -11, 19, -11, 19,
+ax_anim 2, 0, 167, -2, 12, -2, 12,
+ax_anim 1, 0, 166, 0, 7, 0, 7,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_10_1:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 6, 0, 6, 0,
+ax_anim 2, 0, 172, -6, 0, -6, 0,
+ax_anim 2, 0, 172, 10, 0, 10, 0,
+ax_anim 2, 0, 172, -10, 0, -10, 0,
+ax_anim 2, 0, 172, 12, 0, 12, 0,
+ax_anim 3, 0, 172, -12, 0, -12, 0,
+ax_anim 3, 0, 172, 13, 0, 13, 0,
+ax_anim 3, 0, 172, -13, 0, -13, 0,
+ax_anim 2, 0, 172, 12, 0, 12, 0,
+ax_anim 3, 0, 172, -12, 0, -12, 0,
+ax_anim 2, 0, 172, 10, 0, 10, 0,
+ax_anim 2, 0, 172, -10, 0, -10, 0,
+ax_anim 2, 0, 172, 6, 0, 6, 0,
+ax_anim 2, 0, 172, -6, 0, -6, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_10_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 6, -6, 6, -6,
+ax_anim 2, 0, 173, -6, 6, -6, 6,
+ax_anim 2, 0, 173, 10, -10, 10, -10,
+ax_anim 2, 0, 173, -10, 10, -10, 10,
+ax_anim 2, 0, 173, 12, -12, 12, -12,
+ax_anim 3, 0, 173, -12, 12, -12, 12,
+ax_anim 3, 0, 173, 13, -13, 13, -13,
+ax_anim 3, 0, 173, -13, 13, -13, 13,
+ax_anim 2, 0, 173, 12, -12, 12, -12,
+ax_anim 3, 0, 173, -12, 12, -12, 12,
+ax_anim 2, 0, 173, 10, -10, 10, -10,
+ax_anim 2, 0, 173, -10, 10, -10, 10,
+ax_anim 2, 0, 173, 6, -6, 6, -6,
+ax_anim 2, 0, 173, -6, 6, -6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_10_3:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, -6, 0, -6,
+ax_anim 2, 0, 174, 0, 6, 0, 6,
+ax_anim 2, 0, 174, 0, -10, 0, -10,
+ax_anim 2, 0, 174, 0, 10, 0, 10,
+ax_anim 2, 0, 174, 0, -12, 0, -12,
+ax_anim 3, 0, 174, 0, 12, 0, 12,
+ax_anim 3, 0, 174, 0, -13, 0, -13,
+ax_anim 3, 0, 174, 0, 13, 0, 13,
+ax_anim 2, 0, 174, 0, -12, 0, -12,
+ax_anim 3, 0, 174, 0, 12, 0, 12,
+ax_anim 2, 0, 174, 0, -10, 0, -10,
+ax_anim 2, 0, 174, 0, 10, 0, 10,
+ax_anim 2, 0, 174, 0, -6, 0, -6,
+ax_anim 2, 0, 174, 0, 6, 0, 6,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_10_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -6, -6, -6, -6,
+ax_anim 2, 0, 175, 6, 6, 6, 6,
+ax_anim 2, 0, 175, -10, -10, -10, -10,
+ax_anim 2, 0, 175, 10, 10, 10, 10,
+ax_anim 2, 0, 175, -12, -12, -12, -12,
+ax_anim 3, 0, 175, 12, 12, 12, 12,
+ax_anim 3, 0, 175, -13, -13, -13, -13,
+ax_anim 3, 0, 175, 13, 13, 13, 13,
+ax_anim 2, 0, 175, -12, -12, -12, -12,
+ax_anim 3, 0, 175, 12, 12, 12, 12,
+ax_anim 2, 0, 175, -10, -10, -10, -10,
+ax_anim 2, 0, 175, 10, 10, 10, 10,
+ax_anim 2, 0, 175, -6, -6, -6, -6,
+ax_anim 2, 0, 175, 6, 6, 6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_10_5:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 6, 0, 6, 0,
+ax_anim 2, 0, 176, -6, 0, -6, 0,
+ax_anim 2, 0, 176, 10, 0, 10, 0,
+ax_anim 2, 0, 176, -10, 0, -10, 0,
+ax_anim 2, 0, 176, 12, 0, 12, 0,
+ax_anim 3, 0, 176, -12, 0, -12, 0,
+ax_anim 3, 0, 176, 13, 0, 13, 0,
+ax_anim 3, 0, 176, -13, 0, -13, 0,
+ax_anim 2, 0, 176, 12, 0, 12, 0,
+ax_anim 3, 0, 176, -12, 0, -12, 0,
+ax_anim 2, 0, 176, 10, 0, 10, 0,
+ax_anim 2, 0, 176, -10, 0, -10, 0,
+ax_anim 2, 0, 176, 6, 0, 6, 0,
+ax_anim 2, 0, 176, -6, 0, -6, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_10_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 6, -6, 6, -6,
+ax_anim 2, 0, 177, -6, 6, -6, 6,
+ax_anim 2, 0, 177, 10, -10, 10, -10,
+ax_anim 2, 0, 177, -10, 10, -10, 10,
+ax_anim 2, 0, 177, 12, -12, 12, -12,
+ax_anim 3, 0, 177, -12, 12, -12, 12,
+ax_anim 3, 0, 177, 13, -13, 13, -13,
+ax_anim 3, 0, 177, -13, 13, -13, 13,
+ax_anim 2, 0, 177, 12, -12, 12, -12,
+ax_anim 3, 0, 177, -12, 12, -12, 12,
+ax_anim 2, 0, 177, 10, -10, 10, -10,
+ax_anim 2, 0, 177, -10, 10, -10, 10,
+ax_anim 2, 0, 177, 6, -6, 6, -6,
+ax_anim 2, 0, 177, -6, 6, -6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_10_7:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, -6, 0, -6,
+ax_anim 2, 0, 178, 0, 6, 0, 6,
+ax_anim 2, 0, 178, 0, -10, 0, -10,
+ax_anim 2, 0, 178, 0, 10, 0, 10,
+ax_anim 2, 0, 178, 0, -12, 0, -12,
+ax_anim 3, 0, 178, 0, 12, 0, 12,
+ax_anim 3, 0, 178, 0, -13, 0, -13,
+ax_anim 3, 0, 178, 0, 13, 0, 13,
+ax_anim 2, 0, 178, 0, -12, 0, -12,
+ax_anim 3, 0, 178, 0, 12, 0, 12,
+ax_anim 2, 0, 178, 0, -10, 0, -10,
+ax_anim 2, 0, 178, 0, 10, 0, 10,
+ax_anim 2, 0, 178, 0, -6, 0, -6,
+ax_anim 2, 0, 178, 0, 6, 0, 6,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_10_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 3, 0, 179, -13, -13, -13, -13,
+ax_anim 3, 0, 179, 13, 13, 13, 13,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_11_1:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_11_2:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_11_4:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_11_5:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_11_6:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -17, 0, 0,
+ax_anim 1, 0, 191, 0, -11, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_11_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_11_8:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_12_1:
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_12_2:
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, 0,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_12_3:
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_12_4:
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_12_5:
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_12_6:
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_12_7:
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_12_8:
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachokeAnims_13_1:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_13_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_13_3:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_13_4:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_13_5:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_13_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_13_7:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeAnims_13_8:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMachokeGfx1:
+.incbin "baserom.gba", 0x7EB910, 0x200
+sMachokeSprites1:
+ax_sprite sMachokeGfx1, 0x200
+ax_sprite_terminator
+sMachokeGfx2:
+.incbin "baserom.gba", 0x7EBB20, 0x200
+sMachokeSprites2:
+ax_sprite sMachokeGfx2, 0x200
+ax_sprite_terminator
+sMachokeGfx3:
+.incbin "baserom.gba", 0x7EBD30, 0x200
+sMachokeSprites3:
+ax_sprite sMachokeGfx3, 0x200
+ax_sprite_terminator
+sMachokeGfx4:
+.incbin "baserom.gba", 0x7EBF40, 0x200
+sMachokeSprites4:
+ax_sprite sMachokeGfx4, 0x200
+ax_sprite_terminator
+sMachokeGfx5:
+.incbin "baserom.gba", 0x7EC150, 0x200
+sMachokeSprites5:
+ax_sprite sMachokeGfx5, 0x200
+ax_sprite_terminator
+sMachokeGfx6:
+.incbin "baserom.gba", 0x7EC360, 0x200
+sMachokeSprites6:
+ax_sprite sMachokeGfx6, 0x200
+ax_sprite_terminator
+sMachokeGfx7:
+.incbin "baserom.gba", 0x7EC570, 0x200
+sMachokeSprites7:
+ax_sprite sMachokeGfx7, 0x200
+ax_sprite_terminator
+sMachokeGfx8:
+.incbin "baserom.gba", 0x7EC780, 0x200
+sMachokeSprites8:
+ax_sprite sMachokeGfx8, 0x200
+ax_sprite_terminator
+sMachokeGfx9:
+.incbin "baserom.gba", 0x7EC990, 0x200
+sMachokeSprites9:
+ax_sprite sMachokeGfx9, 0x200
+ax_sprite_terminator
+sMachokeGfx10:
+.incbin "baserom.gba", 0x7ECBA0, 0x200
+sMachokeSprites10:
+ax_sprite sMachokeGfx10, 0x200
+ax_sprite_terminator
+sMachokeGfx11:
+.incbin "baserom.gba", 0x7ECDB0, 0x200
+sMachokeSprites11:
+ax_sprite sMachokeGfx11, 0x200
+ax_sprite_terminator
+sMachokeGfx12:
+.incbin "baserom.gba", 0x7ECFC0, 0x200
+sMachokeSprites12:
+ax_sprite sMachokeGfx12, 0x200
+ax_sprite_terminator
+sMachokeGfx13:
+.incbin "baserom.gba", 0x7ED1D0, 0x200
+sMachokeSprites13:
+ax_sprite sMachokeGfx13, 0x200
+ax_sprite_terminator
+sMachokeGfx14:
+.incbin "baserom.gba", 0x7ED3E0, 0x200
+sMachokeSprites14:
+ax_sprite sMachokeGfx14, 0x200
+ax_sprite_terminator
+sMachokeGfx15:
+.incbin "baserom.gba", 0x7ED5F0, 0x200
+sMachokeSprites15:
+ax_sprite sMachokeGfx15, 0x200
+ax_sprite_terminator
+sMachokeGfx16:
+.incbin "baserom.gba", 0x7ED800, 0x40
+sMachokeGfx16_1:
+.incbin "baserom.gba", 0x7ED840, 0x60
+sMachokeGfx16_2:
+.incbin "baserom.gba", 0x7ED8A0, 0x60
+sMachokeGfx16_3:
+.incbin "baserom.gba", 0x7ED900, 0x40
+sMachokeSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx17:
+.incbin "baserom.gba", 0x7ED990, 0x20
+sMachokeGfx17_1:
+.incbin "baserom.gba", 0x7ED9B0, 0x60
+sMachokeGfx17_2:
+.incbin "baserom.gba", 0x7EDA10, 0x60
+sMachokeGfx17_3:
+.incbin "baserom.gba", 0x7EDA70, 0x40
+sMachokeSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx18:
+.incbin "baserom.gba", 0x7EDB00, 0x40
+sMachokeGfx18_1:
+.incbin "baserom.gba", 0x7EDB40, 0x160
+sMachokeSprites18:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx18_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx19:
+.incbin "baserom.gba", 0x7EDCD0, 0x60
+sMachokeGfx19_1:
+.incbin "baserom.gba", 0x7EDD30, 0x60
+sMachokeGfx19_2:
+.incbin "baserom.gba", 0x7EDD90, 0x60
+sMachokeGfx19_3:
+.incbin "baserom.gba", 0x7EDDF0, 0x60
+sMachokeSprites19:
+ax_sprite sMachokeGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx20:
+.incbin "baserom.gba", 0x7EDE98, 0x40
+sMachokeGfx20_1:
+.incbin "baserom.gba", 0x7EDED8, 0x40
+sMachokeGfx20_2:
+.incbin "baserom.gba", 0x7EDF18, 0x60
+sMachokeGfx20_3:
+.incbin "baserom.gba", 0x7EDF78, 0x40
+sMachokeSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx21:
+.incbin "baserom.gba", 0x7EE008, 0x40
+sMachokeGfx21_1:
+.incbin "baserom.gba", 0x7EE048, 0x160
+sMachokeSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx22:
+.incbin "baserom.gba", 0x7EE1D8, 0x60
+sMachokeGfx22_1:
+.incbin "baserom.gba", 0x7EE238, 0x60
+sMachokeGfx22_2:
+.incbin "baserom.gba", 0x7EE298, 0x60
+sMachokeGfx22_3:
+.incbin "baserom.gba", 0x7EE2F8, 0x60
+sMachokeSprites22:
+ax_sprite sMachokeGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx23:
+.incbin "baserom.gba", 0x7EE3A0, 0x60
+sMachokeGfx23_1:
+.incbin "baserom.gba", 0x7EE400, 0xC0
+sMachokeGfx23_2:
+.incbin "baserom.gba", 0x7EE4C0, 0x20
+sMachokeSprites23:
+ax_sprite sMachokeGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx23_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sMachokeGfx23_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachokeGfx24:
+.incbin "baserom.gba", 0x7EE518, 0x40
+sMachokeGfx24_1:
+.incbin "baserom.gba", 0x7EE558, 0x100
+sMachokeGfx24_2:
+.incbin "baserom.gba", 0x7EE658, 0x60
+sMachokeSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx24_2, 0x60
+ax_sprite_terminator
+sMachokeGfx25:
+.incbin "baserom.gba", 0x7EE6F0, 0x40
+sMachokeGfx25_1:
+.incbin "baserom.gba", 0x7EE730, 0x100
+sMachokeGfx25_2:
+.incbin "baserom.gba", 0x7EE830, 0x40
+sMachokeSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx26:
+.incbin "baserom.gba", 0x7EE8B0, 0x60
+sMachokeGfx26_1:
+.incbin "baserom.gba", 0x7EE910, 0x60
+sMachokeGfx26_2:
+.incbin "baserom.gba", 0x7EE970, 0x20
+sMachokeGfx26_3:
+.incbin "baserom.gba", 0x7EE990, 0x40
+sMachokeSprites26:
+ax_sprite sMachokeGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx26_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx26_3, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMachokeGfx27:
+.incbin "baserom.gba", 0x7EEA18, 0x40
+sMachokeGfx27_1:
+.incbin "baserom.gba", 0x7EEA58, 0x60
+sMachokeGfx27_2:
+.incbin "baserom.gba", 0x7EEAB8, 0x60
+sMachokeGfx27_3:
+.incbin "baserom.gba", 0x7EEB18, 0x60
+sMachokeSprites27:
+ax_sprite sMachokeGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx28:
+.incbin "baserom.gba", 0x7EEBC0, 0x100
+sMachokeSprites28:
+ax_sprite sMachokeGfx28, 0x100
+ax_sprite_terminator
+sMachokeGfx29:
+.incbin "baserom.gba", 0x7EECD0, 0x60
+sMachokeGfx29_1:
+.incbin "baserom.gba", 0x7EED30, 0x40
+sMachokeGfx29_2:
+.incbin "baserom.gba", 0x7EED70, 0x40
+sMachokeGfx29_3:
+.incbin "baserom.gba", 0x7EEDB0, 0x20
+sMachokeSprites29:
+ax_sprite sMachokeGfx29, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx29_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx29_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMachokeGfx29_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx30:
+.incbin "baserom.gba", 0x7EEE18, 0x40
+sMachokeGfx30_1:
+.incbin "baserom.gba", 0x7EEE58, 0x60
+sMachokeGfx30_2:
+.incbin "baserom.gba", 0x7EEEB8, 0x60
+sMachokeGfx30_3:
+.incbin "baserom.gba", 0x7EEF18, 0x40
+sMachokeSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx31:
+.incbin "baserom.gba", 0x7EEFA8, 0x60
+sMachokeGfx31_1:
+.incbin "baserom.gba", 0x7EF008, 0x60
+sMachokeGfx31_2:
+.incbin "baserom.gba", 0x7EF068, 0x60
+sMachokeGfx31_3:
+.incbin "baserom.gba", 0x7EF0C8, 0x60
+sMachokeSprites31:
+ax_sprite sMachokeGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx32:
+.incbin "baserom.gba", 0x7EF170, 0x20
+sMachokeGfx32_1:
+.incbin "baserom.gba", 0x7EF190, 0x60
+sMachokeGfx32_2:
+.incbin "baserom.gba", 0x7EF1F0, 0x100
+sMachokeSprites32:
+ax_sprite sMachokeGfx32, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMachokeGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx32_2, 0x100
+ax_sprite_terminator
+sMachokeGfx33:
+.incbin "baserom.gba", 0x7EF320, 0x40
+sMachokeGfx33_1:
+.incbin "baserom.gba", 0x7EF360, 0x100
+sMachokeGfx33_2:
+.incbin "baserom.gba", 0x7EF460, 0x40
+sMachokeSprites33:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx34:
+.incbin "baserom.gba", 0x7EF4E0, 0x40
+sMachokeGfx34_1:
+.incbin "baserom.gba", 0x7EF520, 0x60
+sMachokeGfx34_2:
+.incbin "baserom.gba", 0x7EF580, 0x60
+sMachokeGfx34_3:
+.incbin "baserom.gba", 0x7EF5E0, 0x40
+sMachokeSprites34:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx35:
+.incbin "baserom.gba", 0x7EF670, 0x40
+sMachokeGfx35_1:
+.incbin "baserom.gba", 0x7EF6B0, 0x60
+sMachokeGfx35_2:
+.incbin "baserom.gba", 0x7EF710, 0x60
+sMachokeGfx35_3:
+.incbin "baserom.gba", 0x7EF770, 0x80
+sMachokeSprites35:
+ax_sprite sMachokeGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx35_3, 0x80
+ax_sprite_terminator
+sMachokeGfx36:
+.incbin "baserom.gba", 0x7EF830, 0x1E0
+sMachokeSprites36:
+ax_sprite sMachokeGfx36, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx37:
+.incbin "baserom.gba", 0x7EFA28, 0x40
+sMachokeGfx37_1:
+.incbin "baserom.gba", 0x7EFA68, 0x60
+sMachokeGfx37_2:
+.incbin "baserom.gba", 0x7EFAC8, 0x60
+sMachokeGfx37_3:
+.incbin "baserom.gba", 0x7EFB28, 0x40
+sMachokeSprites37:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx37_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx38:
+.incbin "baserom.gba", 0x7EFBB8, 0x100
+sMachokeSprites38:
+ax_sprite sMachokeGfx38, 0x100
+ax_sprite_terminator
+sMachokeGfx39:
+.incbin "baserom.gba", 0x7EFCC8, 0x160
+sMachokeGfx39_1:
+.incbin "baserom.gba", 0x7EFE28, 0x20
+sMachokeSprites39:
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx39, 0x160
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx39_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx40:
+.incbin "baserom.gba", 0x7EFE78, 0x60
+sMachokeGfx40_1:
+.incbin "baserom.gba", 0x7EFED8, 0x60
+sMachokeGfx40_2:
+.incbin "baserom.gba", 0x7EFF38, 0x60
+sMachokeSprites40:
+ax_sprite sMachokeGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachokeGfx41:
+.incbin "baserom.gba", 0x7EFFD0, 0xE0
+sMachokeGfx41_1:
+.incbin "baserom.gba", 0x7F00B0, 0x40
+sMachokeGfx41_2:
+.incbin "baserom.gba", 0x7F00F0, 0x40
+sMachokeSprites41:
+ax_sprite sMachokeGfx41, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx41_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx41_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachokeGfx42:
+.incbin "baserom.gba", 0x7F0168, 0x60
+sMachokeGfx42_1:
+.incbin "baserom.gba", 0x7F01C8, 0x80
+sMachokeGfx42_2:
+.incbin "baserom.gba", 0x7F0248, 0x40
+sMachokeSprites42:
+ax_sprite sMachokeGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx42_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx42_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachokeGfx43:
+.incbin "baserom.gba", 0x7F02C0, 0x60
+sMachokeGfx43_1:
+.incbin "baserom.gba", 0x7F0320, 0x60
+sMachokeGfx43_2:
+.incbin "baserom.gba", 0x7F0380, 0x40
+sMachokeGfx43_3:
+.incbin "baserom.gba", 0x7F03C0, 0x60
+sMachokeSprites43:
+ax_sprite sMachokeGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx43_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx43_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx43_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx44:
+.incbin "baserom.gba", 0x7F0468, 0x100
+sMachokeGfx44_1:
+.incbin "baserom.gba", 0x7F0568, 0x20
+sMachokeGfx44_2:
+.incbin "baserom.gba", 0x7F0588, 0x20
+sMachokeSprites44:
+ax_sprite sMachokeGfx44, 0x100
+ax_sprite 0, 0x40
+ax_sprite sMachokeGfx44_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMachokeGfx44_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachokeGfx45:
+.incbin "baserom.gba", 0x7F05E0, 0x60
+sMachokeGfx45_1:
+.incbin "baserom.gba", 0x7F0640, 0xE0
+sMachokeGfx45_2:
+.incbin "baserom.gba", 0x7F0720, 0x40
+sMachokeSprites45:
+ax_sprite sMachokeGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx45_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMachokeGfx45_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachokeGfx46:
+.incbin "baserom.gba", 0x7F0798, 0x200
+sMachokeSprites46:
+ax_sprite sMachokeGfx46, 0x200
+ax_sprite_terminator
+sMachokeGfx47:
+.incbin "baserom.gba", 0x7F09A8, 0x200
+sMachokeSprites47:
+ax_sprite sMachokeGfx47, 0x200
+ax_sprite_terminator
+sMachokeGfx48:
+.incbin "baserom.gba", 0x7F0BB8, 0x200
+sMachokeSprites48:
+ax_sprite sMachokeGfx48, 0x200
+ax_sprite_terminator
+sMachokeGfx49:
+.incbin "baserom.gba", 0x7F0DC8, 0x200
+sMachokeSprites49:
+ax_sprite sMachokeGfx49, 0x200
+ax_sprite_terminator
+sMachokeGfx50:
+.incbin "baserom.gba", 0x7F0FD8, 0x200
+sMachokeSprites50:
+ax_sprite sMachokeGfx50, 0x200
+ax_sprite_terminator
+sMachokeGfx51:
+.incbin "baserom.gba", 0x7F11E8, 0x200
+sMachokeSprites51:
+ax_sprite sMachokeGfx51, 0x200
+ax_sprite_terminator
+sMachokeGfx52:
+.incbin "baserom.gba", 0x7F13F8, 0x200
+sMachokeSprites52:
+ax_sprite sMachokeGfx52, 0x200
+ax_sprite_terminator
+sAxPosesMachoke:
+.4byte sMachokePose1
+.4byte sMachokePose2
+.4byte sMachokePose3
+.4byte sMachokePose4
+.4byte sMachokePose5
+.4byte sMachokePose6
+.4byte sMachokePose7
+.4byte sMachokePose8
+.4byte sMachokePose9
+.4byte sMachokePose10
+.4byte sMachokePose11
+.4byte sMachokePose12
+.4byte sMachokePose13
+.4byte sMachokePose14
+.4byte sMachokePose15
+.4byte sMachokePose16
+.4byte sMachokePose17
+.4byte sMachokePose18
+.4byte sMachokePose19
+.4byte sMachokePose20
+.4byte sMachokePose21
+.4byte sMachokePose22
+.4byte sMachokePose23
+.4byte sMachokePose24
+.4byte sMachokePose25
+.4byte sMachokePose26
+.4byte sMachokePose27
+.4byte sMachokePose28
+.4byte sMachokePose29
+.4byte sMachokePose30
+.4byte sMachokePose31
+.4byte sMachokePose32
+.4byte sMachokePose33
+.4byte sMachokePose34
+.4byte sMachokePose35
+.4byte sMachokePose36
+.4byte sMachokePose37
+.4byte sMachokePose38
+.4byte sMachokePose39
+.4byte sMachokePose40
+.4byte sMachokePose41
+.4byte sMachokePose42
+.4byte sMachokePose43
+.4byte sMachokePose44
+.4byte sMachokePose45
+.4byte sMachokePose46
+.4byte sMachokePose47
+.4byte sMachokePose48
+.4byte sMachokePose49
+.4byte sMachokePose50
+.4byte sMachokePose51
+.4byte sMachokePose52
+.4byte sMachokePose53
+.4byte sMachokePose54
+.4byte sMachokePose55
+.4byte sMachokePose56
+.4byte sMachokePose57
+.4byte sMachokePose58
+.4byte sMachokePose59
+.4byte sMachokePose60
+.4byte sMachokePose61
+.4byte sMachokePose62
+.4byte sMachokePose63
+.4byte sMachokePose64
+.4byte sMachokePose65
+.4byte sMachokePose66
+.4byte sMachokePose67
+.4byte sMachokePose68
+.4byte sMachokePose69
+.4byte sMachokePose70
+.4byte sMachokePose71
+.4byte sMachokePose72
+.4byte sMachokePose73
+.4byte sMachokePose74
+.4byte sMachokePose75
+.4byte sMachokePose76
+.4byte sMachokePose77
+.4byte sMachokePose78
+.4byte sMachokePose79
+.4byte sMachokePose80
+.4byte sMachokePose81
+.4byte sMachokePose82
+.4byte sMachokePose83
+.4byte sMachokePose84
+.4byte sMachokePose85
+.4byte sMachokePose86
+.4byte sMachokePose87
+.4byte sMachokePose88
+.4byte sMachokePose89
+.4byte sMachokePose90
+.4byte sMachokePose91
+.4byte sMachokePose92
+.4byte sMachokePose93
+.4byte sMachokePose94
+.4byte sMachokePose95
+.4byte sMachokePose96
+.4byte sMachokePose97
+.4byte sMachokePose98
+.4byte sMachokePose99
+.4byte sMachokePose100
+.4byte sMachokePose101
+.4byte sMachokePose102
+.4byte sMachokePose103
+.4byte sMachokePose104
+.4byte sMachokePose105
+.4byte sMachokePose106
+.4byte sMachokePose107
+.4byte sMachokePose108
+.4byte sMachokePose109
+.4byte sMachokePose110
+.4byte sMachokePose111
+.4byte sMachokePose112
+.4byte sMachokePose113
+.4byte sMachokePose114
+.4byte sMachokePose115
+.4byte sMachokePose116
+.4byte sMachokePose117
+.4byte sMachokePose118
+.4byte sMachokePose119
+.4byte sMachokePose120
+.4byte sMachokePose121
+.4byte sMachokePose122
+.4byte sMachokePose123
+.4byte sMachokePose124
+.4byte sMachokePose125
+.4byte sMachokePose126
+.4byte sMachokePose127
+.4byte sMachokePose128
+.4byte sMachokePose129
+.4byte sMachokePose130
+.4byte sMachokePose131
+.4byte sMachokePose132
+.4byte sMachokePose133
+.4byte sMachokePose134
+.4byte sMachokePose135
+.4byte sMachokePose136
+.4byte sMachokePose137
+.4byte sMachokePose138
+.4byte sMachokePose139
+.4byte sMachokePose140
+.4byte sMachokePose141
+.4byte sMachokePose142
+.4byte sMachokePose143
+.4byte sMachokePose144
+.4byte sMachokePose145
+.4byte sMachokePose146
+.4byte sMachokePose147
+.4byte sMachokePose148
+.4byte sMachokePose149
+.4byte sMachokePose150
+.4byte sMachokePose151
+.4byte sMachokePose152
+.4byte sMachokePose153
+.4byte sMachokePose154
+.4byte sMachokePose155
+.4byte sMachokePose156
+.4byte sMachokePose157
+.4byte sMachokePose158
+.4byte sMachokePose159
+.4byte sMachokePose160
+.4byte sMachokePose161
+.4byte sMachokePose162
+.4byte sMachokePose163
+.4byte sMachokePose164
+.4byte sMachokePose165
+.4byte sMachokePose166
+.4byte sMachokePose167
+.4byte sMachokePose168
+.4byte sMachokePose169
+.4byte sMachokePose170
+.4byte sMachokePose171
+.4byte sMachokePose172
+.4byte sMachokePose173
+.4byte sMachokePose174
+.4byte sMachokePose175
+.4byte sMachokePose176
+.4byte sMachokePose177
+.4byte sMachokePose178
+.4byte sMachokePose179
+.4byte sMachokePose180
+.4byte sMachokePose181
+.4byte sMachokePose182
+.4byte sMachokePose183
+.4byte sMachokePose184
+.4byte sMachokePose185
+.4byte sMachokePose186
+.4byte sMachokePose187
+.4byte sMachokePose188
+.4byte sMachokePose189
+.4byte sMachokePose190
+.4byte sMachokePose191
+.4byte sMachokePose192
+.4byte sMachokePose193
+.4byte sMachokePose194
+.4byte sMachokePose195
+.4byte sMachokePose196
+.4byte sMachokePose197
+.4byte sMachokePose198
+.4byte sMachokePose199
+.4byte sMachokePose200
+.4byte sMachokePose201
+.4byte sMachokePose202
+.4byte sMachokePose203
+.4byte sMachokePose204
+.4byte sMachokePose205
+.4byte sMachokePose206
+.4byte sMachokePose207
+.4byte sMachokePose208
+.4byte sMachokePose209
+.4byte sMachokePose210
+.4byte sMachokePose211
+.4byte sMachokePose212
+sAxPositionsMachoke:
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -12, 	 -11,   -7, 	   4,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	  -6,   -4, 	   9,   -7, 	  -1,  -10
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte    2,  -12, 	   7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    2,  -12, 	   7,   -5, 	  -9,   -4, 	  -1,  -10
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    3,  -13, 	  -2,   -9, 	   2,   -6, 	   0,  -11
+.2byte    3,  -13, 	   7,   -9, 	  -6,   -4, 	  -2,  -11
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte    5,  -17, 	  -7,  -10, 	  10,  -10, 	  -1,  -13
+.2byte    5,  -16, 	  -1,  -13, 	   6,   -6, 	   0,  -13
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    0,  -18, 	   7,   -7, 	  -7,  -11, 	  -2,  -13
+.2byte   -2,  -18, 	   5,  -11, 	  -9,   -7, 	   0,  -13
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -7,  -17, 	   5,  -10, 	 -12,  -10, 	  -1,  -13
+.2byte   -7,  -16, 	  -1,  -13, 	  -8,   -6, 	  -2,  -13
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -5,  -13, 	   0,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte   -5,  -13, 	  -9,   -9, 	   4,   -4, 	   0,  -11
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -4,  -12, 	  -9,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,  -12, 	  -9,   -5, 	   7,   -4, 	  -1,  -10
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -12, 	 -11,   -7, 	   4,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	  -6,   -4, 	   9,   -7, 	  -1,  -10
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte    2,  -12, 	   7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    2,  -12, 	   7,   -5, 	  -9,   -4, 	  -1,  -10
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    3,  -13, 	  -2,   -9, 	   2,   -6, 	   0,  -11
+.2byte    3,  -13, 	   7,   -9, 	  -6,   -4, 	  -2,  -11
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte    5,  -17, 	  -7,  -10, 	  10,  -10, 	  -1,  -13
+.2byte    5,  -16, 	  -1,  -13, 	   6,   -6, 	   0,  -13
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    0,  -18, 	   7,   -7, 	  -7,  -11, 	  -2,  -13
+.2byte   -2,  -18, 	   5,  -11, 	  -9,   -7, 	   0,  -13
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -7,  -17, 	   5,  -10, 	 -12,  -10, 	  -1,  -13
+.2byte   -7,  -16, 	  -1,  -13, 	  -8,   -6, 	  -2,  -13
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -5,  -13, 	   0,   -9, 	  -4,   -6, 	  -2,  -11
+.2byte   -5,  -13, 	  -9,   -9, 	   4,   -4, 	   0,  -11
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -4,  -12, 	  -9,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,  -12, 	  -9,   -5, 	   7,   -4, 	  -1,  -10
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -2,  -16, 	  -7,  -10, 	  -7,  -16, 	  -1,  -12
+.2byte    0,  -11, 	  -9,    2, 	  12,  -13, 	  -1,   -9
+.2byte    0,  -11, 	  -9,    2, 	  12,  -13, 	  -1,   -9
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte    0,  -17, 	  -4,  -12, 	   9,  -18, 	  -2,  -12
+.2byte    0,  -10, 	  13,   -3, 	 -13,  -10, 	   0,   -9
+.2byte    0,  -10, 	  13,   -3, 	 -13,  -10, 	   0,   -9
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte   -4,  -17, 	  -6,   -9, 	   4,  -20, 	  -4,  -12
+.2byte    3,  -12, 	  16,  -14, 	 -11,   -7, 	   0,  -11
+.2byte    3,  -12, 	  16,  -14, 	 -11,   -7, 	   0,  -11
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte   -8,  -19, 	 -16,   -9, 	  -3,  -23, 	  -6,  -14
+.2byte    5,  -11, 	   9,  -24, 	   1,    0, 	   2,  -12
+.2byte    5,  -11, 	   9,  -24, 	   1,    0, 	   2,  -12
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    2,  -14, 	   3,   -3, 	   5,  -20, 	  -2,  -10
+.2byte   -4,  -16, 	   3,  -25, 	 -13,   -8, 	  -2,  -11
+.2byte   -4,  -16, 	   3,  -25, 	 -13,   -8, 	  -2,  -11
+.2byte   -6,  -17, 	   3,  -13, 	 -10,   -8, 	   0,  -14
+.2byte    7,  -19, 	  15,   -9, 	   2,  -23, 	   5,  -14
+.2byte   -6,  -11, 	 -10,  -24, 	  -2,    0, 	  -3,  -12
+.2byte   -6,  -11, 	 -10,  -24, 	  -2,    0, 	  -3,  -12
+.2byte   -4,  -14, 	  -5,   -9, 	   2,   -5, 	   0,  -11
+.2byte    3,  -17, 	   5,   -9, 	  -5,  -20, 	   3,  -12
+.2byte   -4,  -12, 	 -17,  -14, 	  10,   -7, 	  -1,  -11
+.2byte   -4,  -12, 	 -17,  -14, 	  10,   -7, 	  -1,  -11
+.2byte   -3,  -13, 	 -10,   -7, 	   5,   -4, 	   0,  -11
+.2byte   -1,  -17, 	   3,  -12, 	 -10,  -18, 	   1,  -12
+.2byte   -1,  -10, 	 -14,   -3, 	  12,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	 -14,   -3, 	  12,  -10, 	  -1,   -9
+.2byte    0,  -12, 	  -9,    1, 	  12,  -14, 	  -1,  -10
+.2byte   -1,  -11, 	 -14,   -4, 	  12,  -11, 	  -1,  -10
+.2byte   -5,  -13, 	 -18,  -15, 	   9,   -8, 	  -2,  -12
+.2byte   -5,  -12, 	  -9,  -25, 	  -1,   -1, 	  -2,  -13
+.2byte   -3,  -17, 	   4,  -26, 	 -12,   -9, 	  -1,  -12
+.2byte    5,  -12, 	   9,  -25, 	   1,   -1, 	   2,  -13
+.2byte    3,  -13, 	  16,  -15, 	 -11,   -8, 	   0,  -12
+.2byte    0,  -10, 	  13,   -3, 	 -13,  -10, 	   0,   -9
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	  -9,  -11, 	   2,  -12, 	   0,  -12
+.2byte    0,  -16, 	 -13,   -8, 	   7,  -12, 	  -1,  -11
+.2byte    0,  -16, 	 -13,   -8, 	   7,  -12, 	  -1,  -11
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte    1,  -15, 	   2,  -10, 	   1,  -13, 	  -2,  -12
+.2byte   -5,  -16, 	  12,  -17, 	  -6,  -11, 	  -2,  -12
+.2byte   -5,  -16, 	  12,  -17, 	  -6,  -11, 	  -2,  -12
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    0,  -15, 	  -5,   -9, 	   6,  -17, 	  -4,  -12
+.2byte   -5,  -14, 	   7,  -20, 	  -6,   -9, 	  -2,  -11
+.2byte   -5,  -14, 	   7,  -20, 	  -6,   -9, 	  -2,  -11
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte   -1,  -17, 	  -8,   -9, 	   5,  -19, 	  -2,  -14
+.2byte    0,  -13, 	  -3,  -21, 	   6,  -11, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -21, 	   6,  -11, 	   0,  -11
+.2byte   -5,  -14, 	  -8,   -2, 	   3,  -21, 	   0,   -9
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    4,  -14, 	   7,   -2, 	  -4,  -21, 	  -1,   -9
+.2byte   -7,  -17, 	  10,  -15, 	 -11,  -15, 	  -2,  -10
+.2byte   -7,  -17, 	  10,  -15, 	 -11,  -15, 	  -2,  -10
+.2byte    0,  -17, 	   7,   -9, 	  -6,  -19, 	   1,  -14
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -1,  -17, 	   6,   -9, 	  -7,  -19, 	   0,  -14
+.2byte   -2,  -13, 	   1,  -21, 	  -8,  -11, 	  -2,  -11
+.2byte   -2,  -13, 	   1,  -21, 	  -8,  -11, 	  -2,  -11
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	   3,   -9, 	  -8,  -17, 	   2,  -12
+.2byte    3,  -14, 	  -9,  -20, 	   4,   -9, 	   0,  -11
+.2byte    3,  -14, 	  -9,  -20, 	   4,   -9, 	   0,  -11
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -3,  -15, 	  -4,  -10, 	  -3,  -13, 	   0,  -12
+.2byte    3,  -16, 	 -14,  -17, 	   4,  -11, 	   0,  -12
+.2byte    3,  -16, 	 -14,  -17, 	   4,  -11, 	   0,  -12
+.2byte   -3,  -10, 	  -3,   -1, 	  -3,    0, 	   0,   -8
+.2byte   -4,   -9, 	  -3,    0, 	  -3,    1, 	   0,   -7
+.2byte    0,  -20, 	 -12,  -19, 	  13,  -22, 	   0,  -13
+.2byte   -5,  -16, 	   4,  -20, 	 -14,  -11, 	  -2,  -11
+.2byte   -2,  -18, 	   4,  -20, 	 -12,  -10, 	   0,  -10
+.2byte    0,  -20, 	  -3,  -21, 	   9,  -16, 	  -1,  -12
+.2byte   -1,  -23, 	  11,  -20, 	 -13,  -23, 	  -1,  -13
+.2byte   -1,  -20, 	   2,  -21, 	 -10,  -16, 	   0,  -12
+.2byte    1,  -18, 	  -5,  -20, 	  11,  -10, 	  -1,  -10
+.2byte    4,  -16, 	  -5,  -20, 	  13,  -11, 	   1,  -11
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	  -9,  -11, 	   2,  -12, 	   0,  -12
+.2byte    0,  -16, 	 -13,   -8, 	   7,  -12, 	  -1,  -11
+.2byte    0,  -16, 	 -13,   -8, 	   7,  -12, 	  -1,  -11
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte    1,  -15, 	   2,  -10, 	   1,  -13, 	  -2,  -12
+.2byte   -5,  -16, 	  12,  -17, 	  -6,  -11, 	  -2,  -12
+.2byte   -5,  -16, 	  12,  -17, 	  -6,  -11, 	  -2,  -12
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    0,  -15, 	  -5,   -9, 	   6,  -17, 	  -4,  -12
+.2byte   -5,  -14, 	   7,  -20, 	  -6,   -9, 	  -2,  -11
+.2byte   -5,  -14, 	   7,  -20, 	  -6,   -9, 	  -2,  -11
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte   -1,  -17, 	  -8,   -9, 	   5,  -19, 	  -2,  -14
+.2byte    0,  -13, 	  -3,  -21, 	   6,  -11, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -21, 	   6,  -11, 	   0,  -11
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    4,  -14, 	   7,   -2, 	  -4,  -21, 	  -1,   -9
+.2byte   -7,  -17, 	  10,  -15, 	 -11,  -15, 	  -2,  -10
+.2byte   -7,  -17, 	  10,  -15, 	 -11,  -15, 	  -2,  -10
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -1,  -17, 	   6,   -9, 	  -7,  -19, 	   0,  -14
+.2byte   -2,  -13, 	   1,  -21, 	  -8,  -11, 	  -2,  -11
+.2byte   -2,  -13, 	   1,  -21, 	  -8,  -11, 	  -2,  -11
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	   3,   -9, 	  -8,  -17, 	   2,  -12
+.2byte    3,  -14, 	  -9,  -20, 	   4,   -9, 	   0,  -11
+.2byte    3,  -14, 	  -9,  -20, 	   4,   -9, 	   0,  -11
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -3,  -15, 	  -4,  -10, 	  -3,  -13, 	   0,  -12
+.2byte    3,  -16, 	 -14,  -17, 	   4,  -11, 	   0,  -12
+.2byte    3,  -16, 	 -14,  -17, 	   4,  -11, 	   0,  -12
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	  -9,  -11, 	   2,  -12, 	   0,  -12
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+.2byte    1,  -15, 	   2,  -10, 	   1,  -13, 	  -2,  -12
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    0,  -15, 	  -5,   -9, 	   6,  -17, 	  -4,  -12
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte   -1,  -17, 	  -8,   -9, 	   5,  -19, 	  -2,  -14
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    4,  -14, 	   7,   -2, 	  -4,  -21, 	  -1,   -9
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -1,  -17, 	   6,   -9, 	  -7,  -19, 	   0,  -14
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	   3,   -9, 	  -8,  -17, 	   2,  -12
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -3,  -15, 	  -4,  -10, 	  -3,  -13, 	   0,  -12
+.2byte    0,  -12, 	  -9,    1, 	  12,  -14, 	  -1,  -10
+.2byte   -1,  -11, 	 -14,   -4, 	  12,  -11, 	  -1,  -10
+.2byte   -5,  -13, 	 -18,  -15, 	   9,   -8, 	  -2,  -12
+.2byte   -5,  -12, 	  -9,  -25, 	  -1,   -1, 	  -2,  -13
+.2byte   -3,  -17, 	   4,  -26, 	 -12,   -9, 	  -1,  -12
+.2byte    5,  -12, 	   9,  -25, 	   1,   -1, 	   2,  -13
+.2byte    3,  -13, 	  16,  -15, 	 -11,   -8, 	   0,  -12
+.2byte    0,  -10, 	  13,   -3, 	 -13,  -10, 	   0,   -9
+.2byte   -1,  -13, 	  -9,   -6, 	   7,   -6, 	  -1,  -11
+.2byte   -4,  -13, 	 -11,   -7, 	   4,   -4, 	  -1,  -11
+.2byte   -5,  -14, 	  -6,   -9, 	   1,   -5, 	  -1,  -11
+.2byte   -7,  -17, 	   2,  -13, 	 -11,   -8, 	  -1,  -14
+.2byte   -1,  -19, 	   7,  -10, 	  -9,  -10, 	  -1,  -14
+.2byte    5,  -17, 	  -4,  -13, 	   9,   -8, 	  -1,  -14
+.2byte    3,  -14, 	   4,   -9, 	  -3,   -5, 	  -1,  -11
+.2byte    2,  -13, 	   9,   -7, 	  -6,   -4, 	  -1,  -11
+sMachokeAnimTable1:
+.4byte sMachokeAnims_1_1
+.4byte sMachokeAnims_1_2
+.4byte sMachokeAnims_1_3
+.4byte sMachokeAnims_1_4
+.4byte sMachokeAnims_1_5
+.4byte sMachokeAnims_1_6
+.4byte sMachokeAnims_1_7
+.4byte sMachokeAnims_1_8
+sMachokeAnimTable2:
+.4byte sMachokeAnims_2_1
+.4byte sMachokeAnims_2_2
+.4byte sMachokeAnims_2_3
+.4byte sMachokeAnims_2_4
+.4byte sMachokeAnims_2_5
+.4byte sMachokeAnims_2_6
+.4byte sMachokeAnims_2_7
+.4byte sMachokeAnims_2_8
+sMachokeAnimTable3:
+.4byte sMachokeAnims_3_1
+.4byte sMachokeAnims_3_2
+.4byte sMachokeAnims_3_3
+.4byte sMachokeAnims_3_4
+.4byte sMachokeAnims_3_5
+.4byte sMachokeAnims_3_6
+.4byte sMachokeAnims_3_7
+.4byte sMachokeAnims_3_8
+sMachokeAnimTable4:
+.4byte sMachokeAnims_4_1
+.4byte sMachokeAnims_4_2
+.4byte sMachokeAnims_4_3
+.4byte sMachokeAnims_4_4
+.4byte sMachokeAnims_4_5
+.4byte sMachokeAnims_4_6
+.4byte sMachokeAnims_4_7
+.4byte sMachokeAnims_4_8
+sMachokeAnimTable5:
+.4byte sMachokeAnims_5_1
+.4byte sMachokeAnims_5_2
+.4byte sMachokeAnims_5_3
+.4byte sMachokeAnims_5_4
+.4byte sMachokeAnims_5_5
+.4byte sMachokeAnims_5_6
+.4byte sMachokeAnims_5_7
+.4byte sMachokeAnims_5_8
+sMachokeAnimTable6:
+.4byte sMachokeAnims_6_1
+.4byte sMachokeAnims_6_1
+.4byte sMachokeAnims_6_1
+.4byte sMachokeAnims_6_1
+.4byte sMachokeAnims_6_1
+.4byte sMachokeAnims_6_1
+.4byte sMachokeAnims_6_1
+.4byte sMachokeAnims_6_1
+sMachokeAnimTable7:
+.4byte sMachokeAnims_7_1
+.4byte sMachokeAnims_7_2
+.4byte sMachokeAnims_7_3
+.4byte sMachokeAnims_7_4
+.4byte sMachokeAnims_7_5
+.4byte sMachokeAnims_7_6
+.4byte sMachokeAnims_7_7
+.4byte sMachokeAnims_7_8
+sMachokeAnimTable8:
+.4byte sMachokeAnims_8_1
+.4byte sMachokeAnims_8_2
+.4byte sMachokeAnims_8_3
+.4byte sMachokeAnims_8_4
+.4byte sMachokeAnims_8_5
+.4byte sMachokeAnims_8_6
+.4byte sMachokeAnims_8_7
+.4byte sMachokeAnims_8_8
+sMachokeAnimTable9:
+.4byte sMachokeAnims_9_1
+.4byte sMachokeAnims_9_2
+.4byte sMachokeAnims_9_3
+.4byte sMachokeAnims_9_4
+.4byte sMachokeAnims_9_5
+.4byte sMachokeAnims_9_6
+.4byte sMachokeAnims_9_7
+.4byte sMachokeAnims_9_8
+sMachokeAnimTable10:
+.4byte sMachokeAnims_10_1
+.4byte sMachokeAnims_10_2
+.4byte sMachokeAnims_10_3
+.4byte sMachokeAnims_10_4
+.4byte sMachokeAnims_10_5
+.4byte sMachokeAnims_10_6
+.4byte sMachokeAnims_10_7
+.4byte sMachokeAnims_10_8
+sMachokeAnimTable11:
+.4byte sMachokeAnims_11_1
+.4byte sMachokeAnims_11_2
+.4byte sMachokeAnims_11_3
+.4byte sMachokeAnims_11_4
+.4byte sMachokeAnims_11_5
+.4byte sMachokeAnims_11_6
+.4byte sMachokeAnims_11_7
+.4byte sMachokeAnims_11_8
+sMachokeAnimTable12:
+.4byte sMachokeAnims_12_1
+.4byte sMachokeAnims_12_2
+.4byte sMachokeAnims_12_3
+.4byte sMachokeAnims_12_4
+.4byte sMachokeAnims_12_5
+.4byte sMachokeAnims_12_6
+.4byte sMachokeAnims_12_7
+.4byte sMachokeAnims_12_8
+sMachokeAnimTable13:
+.4byte sMachokeAnims_13_1
+.4byte sMachokeAnims_13_2
+.4byte sMachokeAnims_13_3
+.4byte sMachokeAnims_13_4
+.4byte sMachokeAnims_13_5
+.4byte sMachokeAnims_13_6
+.4byte sMachokeAnims_13_7
+.4byte sMachokeAnims_13_8
+sAxAnimationsMachoke:
+.4byte sMachokeAnimTable1
+.4byte sMachokeAnimTable2
+.4byte sMachokeAnimTable3
+.4byte sMachokeAnimTable4
+.4byte sMachokeAnimTable5
+.4byte sMachokeAnimTable6
+.4byte sMachokeAnimTable7
+.4byte sMachokeAnimTable8
+.4byte sMachokeAnimTable9
+.4byte sMachokeAnimTable10
+.4byte sMachokeAnimTable11
+.4byte sMachokeAnimTable12
+.4byte sMachokeAnimTable13
+sAxSpritesMachoke:
+.4byte sMachokeSprites1
+.4byte sMachokeSprites2
+.4byte sMachokeSprites3
+.4byte sMachokeSprites4
+.4byte sMachokeSprites5
+.4byte sMachokeSprites6
+.4byte sMachokeSprites7
+.4byte sMachokeSprites8
+.4byte sMachokeSprites9
+.4byte sMachokeSprites10
+.4byte sMachokeSprites11
+.4byte sMachokeSprites12
+.4byte sMachokeSprites13
+.4byte sMachokeSprites14
+.4byte sMachokeSprites15
+.4byte sMachokeSprites16
+.4byte sMachokeSprites17
+.4byte sMachokeSprites18
+.4byte sMachokeSprites19
+.4byte sMachokeSprites20
+.4byte sMachokeSprites21
+.4byte sMachokeSprites22
+.4byte sMachokeSprites23
+.4byte sMachokeSprites24
+.4byte sMachokeSprites25
+.4byte sMachokeSprites26
+.4byte sMachokeSprites27
+.4byte sMachokeSprites28
+.4byte sMachokeSprites29
+.4byte sMachokeSprites30
+.4byte sMachokeSprites31
+.4byte sMachokeSprites32
+.4byte sMachokeSprites33
+.4byte sMachokeSprites34
+.4byte sMachokeSprites35
+.4byte sMachokeSprites36
+.4byte sMachokeSprites37
+.4byte sMachokeSprites38
+.4byte sMachokeSprites39
+.4byte sMachokeSprites40
+.4byte sMachokeSprites41
+.4byte sMachokeSprites42
+.4byte sMachokeSprites43
+.4byte sMachokeSprites44
+.4byte sMachokeSprites45
+.4byte sMachokeSprites46
+.4byte sMachokeSprites47
+.4byte sMachokeSprites48
+.4byte sMachokeSprites49
+.4byte sMachokeSprites50
+.4byte sMachokeSprites51
+.4byte sMachokeSprites52
+sAxMainMachoke:
+ax_main sAxPosesMachoke, sAxAnimationsMachoke, 13, sAxSpritesMachoke, sAxPositionsMachoke

--- a/data/ax/machop.inc
+++ b/data/ax/machop.inc
@@ -1,0 +1,4269 @@
+.global gAxMachop
+gAxMachop:
+ax_siro sAxMainMachop
+sMachopPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose4:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose5:
+ax_pose 4, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose6:
+ax_pose 5, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose7:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose8:
+ax_pose 7, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose9:
+ax_pose 8, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose10:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose11:
+ax_pose 10, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose12:
+ax_pose 11, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose13:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose14:
+ax_pose 13, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose15:
+ax_pose 14, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose16:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose17:
+ax_pose 10, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose18:
+ax_pose 11, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose19:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose20:
+ax_pose 7, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose21:
+ax_pose 8, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose27:
+ax_pose 2, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose28:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose29:
+ax_pose 4, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose30:
+ax_pose 5, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose31:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose32:
+ax_pose 7, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose33:
+ax_pose 8, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose34:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose35:
+ax_pose 10, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose36:
+ax_pose 11, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose37:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose38:
+ax_pose 13, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose39:
+ax_pose 14, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose40:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose41:
+ax_pose 10, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose42:
+ax_pose 11, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose43:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose44:
+ax_pose 7, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose45:
+ax_pose 8, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose47:
+ax_pose 4, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose48:
+ax_pose 5, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose49:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose50:
+ax_pose 15, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose51:
+ax_pose 16, 0x01ec, 0x80f5, 0xcc00
+ax_pose 17, 0x01ec, 0x80f4, 0xcc10
+ax_pose_terminator
+sMachopPose52:
+ax_pose 17, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose53:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose54:
+ax_pose 18, 0x01ec, 0x90f2, 0xcc00
+ax_pose_terminator
+sMachopPose55:
+ax_pose 19, 0x01ec, 0x90eb, 0xcc00
+ax_pose 20, 0x01ec, 0x90eb, 0xcc10
+ax_pose_terminator
+sMachopPose56:
+ax_pose 20, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose57:
+ax_pose 15, 0x01ec, 0x90ec, 0xcc00
+ax_pose_terminator
+sMachopPose58:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose59:
+ax_pose 21, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose60:
+ax_pose 22, 0x01ee, 0x90ef, 0xcc00
+ax_pose 23, 0x01ec, 0x90ef, 0xcc10
+ax_pose_terminator
+sMachopPose61:
+ax_pose 23, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose62:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose63:
+ax_pose 24, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose64:
+ax_pose 25, 0x81ec, 0x90ff, 0xcc00
+ax_pose 26, 0x01ec, 0x90ef, 0xcc08
+ax_pose_terminator
+sMachopPose65:
+ax_pose 26, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose66:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose67:
+ax_pose 27, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose68:
+ax_pose 28, 0x81eb, 0x80f3, 0xcc00
+ax_pose 29, 0x01ec, 0x80f3, 0xcc08
+ax_pose_terminator
+sMachopPose69:
+ax_pose 29, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose70:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose71:
+ax_pose 24, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose72:
+ax_pose 25, 0x81ec, 0x80f0, 0xcc00
+ax_pose 26, 0x01ec, 0x80f0, 0xcc08
+ax_pose_terminator
+sMachopPose73:
+ax_pose 26, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose74:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose75:
+ax_pose 21, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose76:
+ax_pose 22, 0x01ed, 0x80ef, 0xcc00
+ax_pose 23, 0x01ec, 0x80f0, 0xcc10
+ax_pose_terminator
+sMachopPose77:
+ax_pose 23, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose78:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose79:
+ax_pose 18, 0x01ec, 0x80ed, 0xcc00
+ax_pose_terminator
+sMachopPose80:
+ax_pose 19, 0x01ec, 0x80f4, 0xcc00
+ax_pose 20, 0x01ec, 0x80f4, 0xcc10
+ax_pose_terminator
+sMachopPose81:
+ax_pose 20, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose82:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose83:
+ax_pose 30, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose84:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose85:
+ax_pose 31, 0x01ec, 0x90e9, 0xcc00
+ax_pose_terminator
+sMachopPose86:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose87:
+ax_pose 32, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose88:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose89:
+ax_pose 33, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose90:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose91:
+ax_pose 34, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose92:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose93:
+ax_pose 33, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose94:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose95:
+ax_pose 32, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose96:
+ax_pose 3, 0x01ec, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachopPose97:
+ax_pose 31, 0x01ec, 0x80f6, 0xcc00
+ax_pose_terminator
+sMachopPose98:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose99:
+ax_pose 1, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose100:
+ax_pose 2, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose101:
+ax_pose 35, 0x01ec, 0x80f4, 0xcc00
+ax_pose 36, 0x01ec, 0x80f4, 0xcc10
+ax_pose_terminator
+sMachopPose102:
+ax_pose 36, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose103:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose104:
+ax_pose 4, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose105:
+ax_pose 5, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose106:
+ax_pose 37, 0x01ec, 0x90ed, 0xcc00
+ax_pose 38, 0x01ec, 0x90ed, 0xcc10
+ax_pose_terminator
+sMachopPose107:
+ax_pose 38, 0x01ec, 0x90ed, 0xcc00
+ax_pose_terminator
+sMachopPose108:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose109:
+ax_pose 7, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose110:
+ax_pose 8, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose111:
+ax_pose 39, 0x81ec, 0x90fe, 0xcc00
+ax_pose 40, 0x01ec, 0x90ed, 0xcc08
+ax_pose_terminator
+sMachopPose112:
+ax_pose 40, 0x01ec, 0x90ed, 0xcc00
+ax_pose_terminator
+sMachopPose113:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose114:
+ax_pose 10, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose115:
+ax_pose 11, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose116:
+ax_pose 41, 0x01ec, 0x90ed, 0xcc00
+ax_pose 42, 0x01ec, 0x90ed, 0xcc10
+ax_pose_terminator
+sMachopPose117:
+ax_pose 42, 0x01ec, 0x90ed, 0xcc00
+ax_pose_terminator
+sMachopPose118:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose119:
+ax_pose 13, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose120:
+ax_pose 14, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose121:
+ax_pose 43, 0x01ec, 0x80f3, 0xcc00
+ax_pose 44, 0x01ec, 0x80f3, 0xcc10
+ax_pose_terminator
+sMachopPose122:
+ax_pose 44, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose123:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose124:
+ax_pose 10, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose125:
+ax_pose 11, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose126:
+ax_pose 41, 0x01ec, 0x80f3, 0xcc00
+ax_pose 42, 0x01ec, 0x80f3, 0xcc10
+ax_pose_terminator
+sMachopPose127:
+ax_pose 42, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose128:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose129:
+ax_pose 7, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose130:
+ax_pose 8, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose131:
+ax_pose 39, 0x81ec, 0x80f2, 0xcc00
+ax_pose 40, 0x01ec, 0x80f2, 0xcc08
+ax_pose_terminator
+sMachopPose132:
+ax_pose 40, 0x01ec, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose133:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose134:
+ax_pose 4, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose135:
+ax_pose 5, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose136:
+ax_pose 37, 0x01ec, 0x80f2, 0xcc00
+ax_pose 38, 0x01ec, 0x80f2, 0xcc10
+ax_pose_terminator
+sMachopPose137:
+ax_pose 38, 0x01ec, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose138:
+ax_pose 45, 0x01ed, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose139:
+ax_pose 46, 0x01ed, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose140:
+ax_pose 47, 0x01e5, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose141:
+ax_pose 48, 0x01e3, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose142:
+ax_pose 49, 0x01e2, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose143:
+ax_pose 50, 0x01e4, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose144:
+ax_pose 51, 0x01e3, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose145:
+ax_pose 50, 0x01e4, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose146:
+ax_pose 49, 0x01e2, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose147:
+ax_pose 48, 0x01e3, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose148:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose149:
+ax_pose 1, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose150:
+ax_pose 2, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose151:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose152:
+ax_pose 4, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose153:
+ax_pose 5, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose154:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose155:
+ax_pose 7, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose156:
+ax_pose 8, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose157:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose158:
+ax_pose 10, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose159:
+ax_pose 11, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose160:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose161:
+ax_pose 13, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose162:
+ax_pose 14, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose163:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose164:
+ax_pose 10, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose165:
+ax_pose 11, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose166:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose167:
+ax_pose 7, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose168:
+ax_pose 8, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose169:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose170:
+ax_pose 4, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose171:
+ax_pose 5, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose172:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose173:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose174:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose175:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose176:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose177:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose178:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose179:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose180:
+ax_pose 30, 0x01ed, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose181:
+ax_pose 31, 0x01ec, 0x90e9, 0xcc00
+ax_pose_terminator
+sMachopPose182:
+ax_pose 32, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose183:
+ax_pose 33, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose184:
+ax_pose 34, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose185:
+ax_pose 33, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose186:
+ax_pose 32, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose187:
+ax_pose 31, 0x01ec, 0x80f6, 0xcc00
+ax_pose_terminator
+sMachopPose188:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose189:
+ax_pose 15, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose190:
+ax_pose 30, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose191:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose192:
+ax_pose 18, 0x01ec, 0x90f4, 0xcc00
+ax_pose_terminator
+sMachopPose193:
+ax_pose 31, 0x01eb, 0x90e9, 0xcc00
+ax_pose_terminator
+sMachopPose194:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose195:
+ax_pose 21, 0x01ec, 0x90f2, 0xcc00
+ax_pose_terminator
+sMachopPose196:
+ax_pose 32, 0x81eb, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose197:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose198:
+ax_pose 24, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose199:
+ax_pose 33, 0x01eb, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose200:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose201:
+ax_pose 27, 0x01ec, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachopPose202:
+ax_pose 34, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose203:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose204:
+ax_pose 24, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose205:
+ax_pose 33, 0x01eb, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose206:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose207:
+ax_pose 21, 0x01ec, 0x80ed, 0xcc00
+ax_pose_terminator
+sMachopPose208:
+ax_pose 32, 0x81eb, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose209:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose210:
+ax_pose 18, 0x01ec, 0x80eb, 0xcc00
+ax_pose_terminator
+sMachopPose211:
+ax_pose 31, 0x01eb, 0x80f7, 0xcc00
+ax_pose_terminator
+sMachopPose212:
+ax_pose 30, 0x01ed, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose213:
+ax_pose 31, 0x01ec, 0x80f6, 0xcc00
+ax_pose_terminator
+sMachopPose214:
+ax_pose 32, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose215:
+ax_pose 33, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose216:
+ax_pose 34, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose217:
+ax_pose 33, 0x01ec, 0x90f0, 0xcc00
+ax_pose_terminator
+sMachopPose218:
+ax_pose 32, 0x81ec, 0x90f8, 0xcc00
+ax_pose_terminator
+sMachopPose219:
+ax_pose 31, 0x01ec, 0x90e9, 0xcc00
+ax_pose_terminator
+sMachopPose220:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose221:
+ax_pose 3, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose222:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose223:
+ax_pose 9, 0x01ec, 0x80f0, 0xcc00
+ax_pose_terminator
+sMachopPose224:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose225:
+ax_pose 9, 0x01ec, 0x90ef, 0xcc00
+ax_pose_terminator
+sMachopPose226:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose227:
+ax_pose 3, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose228:
+ax_pose 52, 0x01f1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose229:
+ax_pose 53, 0x01f1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose230:
+ax_pose 52, 0x01f1, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose231:
+ax_pose 53, 0x01f1, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose232:
+ax_pose 52, 0x01f1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose233:
+ax_pose 54, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose234:
+ax_pose 55, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose235:
+ax_pose 56, 0x81ec, 0x80f9, 0xcc00
+ax_pose_terminator
+sMachopPose236:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose237:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose238:
+ax_pose 57, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose239:
+ax_pose 58, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose240:
+ax_pose 59, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose241:
+ax_pose 60, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose242:
+ax_pose 61, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose243:
+ax_pose 62, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose244:
+ax_pose 63, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose245:
+ax_pose 64, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose246:
+ax_pose 65, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose247:
+ax_pose 65, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose248:
+ax_pose 66, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose249:
+ax_pose 67, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose250:
+ax_pose 68, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose251:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose252:
+ax_pose 69, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose253:
+ax_pose 70, 0x01ec, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose254:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose255:
+ax_pose 71, 0x01ed, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose256:
+ax_pose 72, 0x01ed, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose257:
+ax_pose 0, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose258:
+ax_pose 60, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMachopPose259:
+ax_pose 73, 0x81eb, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose260:
+ax_pose 6, 0x81ec, 0x80f8, 0xcc00
+ax_pose_terminator
+sMachopPose261:
+ax_pose 74, 0x41f3, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose262:
+ax_pose 6, 0x81ec, 0x90f7, 0xcc00
+ax_pose_terminator
+sMachopPose263:
+ax_pose 74, 0x41f3, 0x90ec, 0xcc00
+ax_pose_terminator
+sMachopPose264:
+ax_pose 12, 0x01ec, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose265:
+ax_pose 75, 0x01ef, 0x80f3, 0xcc00
+ax_pose_terminator
+sMachopPose266:
+ax_pose 76, 0x01ec, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachopPose267:
+ax_pose 77, 0x01ec, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachopPose268:
+ax_pose 78, 0x01ec, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachopPose269:
+ax_pose 79, 0x01ec, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachopPose270:
+ax_pose 80, 0x01ec, 0x80f5, 0xcc00
+ax_pose_terminator
+sMachopPose271:
+ax_pose 76, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose272:
+ax_pose 77, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose273:
+ax_pose 78, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose274:
+ax_pose 79, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose275:
+ax_pose 80, 0x01ec, 0x90eb, 0xcc00
+ax_pose_terminator
+sMachopPose276:
+ax_pose 81, 0x01ed, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose277:
+ax_pose 52, 0x01f1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose278:
+ax_pose 53, 0x01f1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose279:
+ax_pose 52, 0x01f1, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose280:
+ax_pose 53, 0x01f1, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose281:
+ax_pose 52, 0x01f1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose282:
+ax_pose 53, 0x01f1, 0x80f2, 0xcc00
+ax_pose_terminator
+sMachopPose283:
+ax_pose 52, 0x01f1, 0x90ee, 0xcc00
+ax_pose_terminator
+sMachopPose284:
+ax_pose 53, 0x01f1, 0x90ee, 0xcc00
+ax_pose_terminator
+.align 2
+sMachopAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -1,
+ax_anim 4, 0, 26, 0, -3, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMachopAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sMachopAnims_2_3:
+ax_anim 2, 0, 31, -2, 0, -1, 0,
+ax_anim 4, 0, 32, -3, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sMachopAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 4, 0, 35, -3, 3, -3, 3,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, -5, 4, -5,
+ax_anim 1, 0, 34, 10, -12, 10, -12,
+ax_anim 2, 0, 34, 20, -22, 20, -22,
+ax_anim 2, 1, 34, 19, -23, 19, -23,
+ax_anim 2, 0, 34, 20, -22, 20, -22,
+ax_anim 2, 0, 34, 19, -23, 19, -23,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMachopAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 4, 0, 38, 0, 3, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -12, 0, -10,
+ax_anim 2, 0, 37, 0, -22, 0, -18,
+ax_anim 2, 1, 37, 1, -22, 1, -18,
+ax_anim 2, 0, 37, 0, -22, 0, -18,
+ax_anim 2, 0, 37, 1, -22, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMachopAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 4, 0, 41, 3, 3, 3, 3,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -4, -5, -4, -5,
+ax_anim 1, 0, 40, -10, -12, -10, -12,
+ax_anim 2, 0, 40, -20, -22, -20, -22,
+ax_anim 2, 1, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 40, -20, -22, -20, -22,
+ax_anim 2, 0, 40, -19, -23, -19, -23,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMachopAnims_2_7:
+ax_anim 2, 0, 43, 2, 0, 1, 0,
+ax_anim 4, 0, 44, 3, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sMachopAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMachopAnims_3_1:
+ax_anim 4, 0, 49, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 49, 0, 3, 0, 3,
+ax_anim 2, 0, 50, 0, 14, 0, 14,
+ax_anim 2, 1, 51, 1, 14, 1, 14,
+ax_anim 2, 0, 51, 0, 14, 0, 14,
+ax_anim 2, 0, 51, 1, 14, 1, 14,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sMachopAnims_3_2:
+ax_anim 4, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 56, -3, -3, -3, -3,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 2, 53, 8, 8, 8, 8,
+ax_anim 2, 0, 54, 17, 12, 17, 12,
+ax_anim 2, 1, 55, 18, 11, 18, 11,
+ax_anim 2, 0, 55, 17, 12, 17, 12,
+ax_anim 2, 0, 55, 18, 11, 18, 11,
+ax_anim 2, 0, 52, 6, 6, 6, 6,
+ax_anim_terminator
+sMachopAnims_3_3:
+ax_anim 4, 0, 58, -1, 0, -1, 0,
+ax_anim 6, 0, 53, -3, 0, -3, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim 2, 2, 58, 8, 0, 8, 0,
+ax_anim 2, 0, 59, 13, 0, 13, 0,
+ax_anim 2, 1, 60, 13, 1, 13, 1,
+ax_anim 2, 0, 60, 13, 0, 13, 0,
+ax_anim 2, 0, 60, 13, 1, 13, 1,
+ax_anim 2, 0, 57, 6, 0, 6, 0,
+ax_anim_terminator
+sMachopAnims_3_4:
+ax_anim 4, 0, 62, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -3, 3, -3, 3,
+ax_anim 2, 0, 62, 2, -2, 2, -2,
+ax_anim 2, 2, 62, 11, -12, 11, -12,
+ax_anim 2, 0, 63, 14, -23, 14, -23,
+ax_anim 2, 1, 64, 13, -24, 13, -24,
+ax_anim 2, 0, 64, 14, -23, 14, -23,
+ax_anim 2, 0, 64, 13, -24, 13, -24,
+ax_anim 2, 0, 61, 6, -6, 6, -6,
+ax_anim_terminator
+sMachopAnims_3_5:
+ax_anim 4, 0, 66, 0, 1, 0, 1,
+ax_anim 6, 0, 70, -1, 3, -1, 3,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 2, 66, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, -17, 0, -17,
+ax_anim 2, 1, 68, 1, -17, 1, -17,
+ax_anim 2, 0, 68, 0, -17, 0, -17,
+ax_anim 2, 0, 68, 1, -17, 1, -17,
+ax_anim 2, 0, 65, 0, -6, 0, -6,
+ax_anim_terminator
+sMachopAnims_3_6:
+ax_anim 4, 0, 69, 1, 1, 1, 1,
+ax_anim 6, 0, 74, 3, 3, 3, 3,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 2, 70, -11, -12, -11, -12,
+ax_anim 2, 0, 71, -14, -23, -14, -23,
+ax_anim 2, 1, 72, -13, -24, -13, -24,
+ax_anim 2, 0, 72, -14, -23, -14, -23,
+ax_anim 2, 0, 72, -13, -24, -13, -24,
+ax_anim 2, 0, 69, -6, -6, -6, -6,
+ax_anim_terminator
+sMachopAnims_3_7:
+ax_anim 4, 0, 74, 1, 0, 1, 0,
+ax_anim 6, 0, 78, 5, 0, 5, 0,
+ax_anim 2, 0, 74, -3, 0, -3, 0,
+ax_anim 2, 2, 74, -7, 0, -7, 0,
+ax_anim 2, 0, 75, -13, 0, -13, 0,
+ax_anim 2, 1, 76, -13, 1, -13, 1,
+ax_anim 2, 0, 76, -13, 0, -13, 0,
+ax_anim 2, 0, 76, -13, 1, -13, 1,
+ax_anim 2, 0, 73, -6, 0, -6, 0,
+ax_anim_terminator
+sMachopAnims_3_8:
+ax_anim 4, 0, 78, 1, -1, 1, -1,
+ax_anim 6, 0, 49, 3, -3, 3, -3,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 78, -6, 6, -6, 6,
+ax_anim 2, 0, 79, -17, 12, -17, 12,
+ax_anim 2, 1, 80, -18, 11, -18, 11,
+ax_anim 2, 0, 80, -17, 12, -17, 12,
+ax_anim 2, 0, 80, -18, 11, -18, 11,
+ax_anim 2, 0, 77, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMachopAnims_4_1:
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 3, 0, 81, 0, -3, 0, -3,
+ax_anim 6, 2, 81, 0, -4, 0, -4,
+ax_anim 2, 0, 81, 0, -3, 0, -3,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_4_2:
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 0, 83, 0, -3, 0, 0,
+ax_anim 6, 2, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim_terminator
+sMachopAnims_4_3:
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 0, 85, 0, -3, 0, 0,
+ax_anim 6, 2, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim_terminator
+sMachopAnims_4_4:
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 0, 87, 0, -3, 0, 0,
+ax_anim 6, 2, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -3, 0, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 1, 1, 1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 1, 1, 1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_4_5:
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim 3, 0, 89, 0, -3, 0, -3,
+ax_anim 6, 2, 89, 0, -4, 0, -4,
+ax_anim 2, 0, 89, 0, -3, 0, -3,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_4_6:
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 3, 0, 91, 0, -3, 0, 0,
+ax_anim 6, 2, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -1, 1, -1, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -1, 1, -1, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -1, 1, -1, 1,
+ax_anim_terminator
+sMachopAnims_4_7:
+ax_anim 2, 0, 93, 0, -1, 0, 0,
+ax_anim 3, 0, 93, 0, -3, 0, 0,
+ax_anim 6, 2, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_4_8:
+ax_anim 2, 0, 95, 0, -1, 0, 0,
+ax_anim 3, 0, 95, 0, -3, 0, 0,
+ax_anim 6, 2, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 1, 1, 1,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 1, 1, 1,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sMachopAnims_5_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 2, 0, 98, 0, -3, 0, -3,
+ax_anim 6, 0, 98, 0, -4, 0, -4,
+ax_anim 2, 0, 98, 0, -2, 0, -1,
+ax_anim 2, 0, 101, 0, 1, 0, 4,
+ax_anim 2, 2, 100, 0, 7, 0, 12,
+ax_anim 2, 0, 100, 0, 16, 0, 14,
+ax_anim 2, 1, 101, 1, 16, 1, 14,
+ax_anim 2, 0, 101, 0, 16, 0, 14,
+ax_anim 2, 0, 101, 1, 16, 1, 14,
+ax_anim 4, 0, 97, 0, 6, 0, 6,
+ax_anim_terminator
+sMachopAnims_5_2:
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -3, -3, -3, -3,
+ax_anim 6, 0, 103, -4, -4, -4, -4,
+ax_anim 2, 0, 103, -2, -6, -2, -2,
+ax_anim 2, 0, 106, 7, -2, 7, 5,
+ax_anim 2, 2, 105, 10, 4, 10, 8,
+ax_anim 2, 0, 105, 18, 16, 18, 16,
+ax_anim 2, 1, 106, 19, 15, 19, 15,
+ax_anim 2, 0, 106, 18, 16, 18, 16,
+ax_anim 2, 0, 106, 19, 15, 19, 15,
+ax_anim 4, 0, 102, 6, 4, 6, 4,
+ax_anim_terminator
+sMachopAnims_5_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 6, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 108, -2, -6, -2, 0,
+ax_anim 2, 0, 111, 7, -8, 7, 0,
+ax_anim 2, 2, 110, 10, -6, 10, 0,
+ax_anim 2, 0, 110, 18, -2, 18, 0,
+ax_anim 2, 1, 111, 18, -3, 18, -1,
+ax_anim 2, 0, 111, 18, -2, 18, 0,
+ax_anim 2, 0, 111, 18, -3, 18, -1,
+ax_anim 4, 0, 107, 6, 0, 6, 0,
+ax_anim_terminator
+sMachopAnims_5_4:
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 113, -3, 3, -3, 3,
+ax_anim 6, 0, 113, -4, 4, -4, 4,
+ax_anim 2, 0, 113, -2, -4, -2, 2,
+ax_anim 2, 0, 116, 3, -14, 3, -6,
+ax_anim 2, 2, 115, 9, -19, 10, -12,
+ax_anim 2, 0, 115, 17, -23, 17, -21,
+ax_anim 2, 1, 116, 18, -22, 18, -20,
+ax_anim 2, 0, 116, 17, -23, 17, -21,
+ax_anim 2, 0, 116, 18, -22, 18, -20,
+ax_anim 4, 0, 112, 6, -6, 6, -6,
+ax_anim_terminator
+sMachopAnims_5_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 2, 0, 118, 0, 3, 0, 3,
+ax_anim 6, 0, 118, 0, 4, 0, 4,
+ax_anim 2, 0, 118, 0, -4, 0, -1,
+ax_anim 2, 0, 121, 0, -10, 0, -6,
+ax_anim 2, 2, 120, 0, -16, 0, -12,
+ax_anim 2, 0, 120, 0, -19, 0, -17,
+ax_anim 2, 1, 121, 1, -19, 1, -17,
+ax_anim 2, 0, 121, 0, -19, 0, -17,
+ax_anim 2, 0, 121, 1, -19, 1, -17,
+ax_anim 4, 0, 117, 0, -6, 0, -6,
+ax_anim_terminator
+sMachopAnims_5_6:
+ax_anim 2, 0, 123, 2, 2, 2, 2,
+ax_anim 2, 0, 123, 3, 3, 3, 3,
+ax_anim 6, 0, 123, 4, 4, 4, 4,
+ax_anim 2, 0, 123, 2, -4, 2, 2,
+ax_anim 2, 0, 126, -3, -14, -3, -6,
+ax_anim 2, 2, 125, -9, -19, -10, -12,
+ax_anim 2, 0, 125, -17, -23, -17, -21,
+ax_anim 2, 1, 126, -18, -22, -18, -20,
+ax_anim 2, 0, 126, -17, -23, -17, -21,
+ax_anim 2, 0, 126, -18, -22, -18, -20,
+ax_anim 4, 0, 122, -6, -6, -6, -6,
+ax_anim_terminator
+sMachopAnims_5_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 2, 0, 128, 3, 0, 3, 0,
+ax_anim 6, 0, 128, 4, 0, 4, 0,
+ax_anim 2, 0, 128, 2, -6, 2, 0,
+ax_anim 2, 0, 131, -7, -8, -7, 0,
+ax_anim 2, 2, 130, -10, -6, -10, 0,
+ax_anim 2, 0, 130, -18, -2, -18, 0,
+ax_anim 2, 1, 131, -18, -3, -18, -1,
+ax_anim 2, 0, 131, -18, -2, -18, 0,
+ax_anim 2, 0, 131, -18, -3, -18, -1,
+ax_anim 4, 0, 127, -6, 0, -6, 0,
+ax_anim_terminator
+sMachopAnims_5_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 133, 3, -3, 3, -3,
+ax_anim 6, 0, 133, 4, -4, 4, -4,
+ax_anim 2, 0, 133, 2, -6, 2, -2,
+ax_anim 2, 0, 136, -7, -2, -7, 5,
+ax_anim 2, 2, 135, -10, 4, -10, 8,
+ax_anim 2, 0, 135, -18, 16, -18, 16,
+ax_anim 2, 1, 136, -19, 15, -19, 15,
+ax_anim 2, 0, 136, -18, 16, -18, 16,
+ax_anim 2, 0, 136, -19, 15, -19, 15,
+ax_anim 4, 0, 132, -6, 4, -6, 4,
+ax_anim_terminator
+.align 2
+sMachopAnims_6_1:
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim 35, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_7_1:
+ax_anim 2, 0, 139, 0, -2, 0, -2,
+ax_anim 8, 0, 139, 0, -3, 0, -3,
+ax_anim_terminator
+sMachopAnims_7_2:
+ax_anim 2, 0, 140, -2, -2, -2, -2,
+ax_anim 8, 0, 140, -3, -3, -3, -3,
+ax_anim_terminator
+sMachopAnims_7_3:
+ax_anim 2, 0, 141, -2, 0, -2, 0,
+ax_anim 8, 0, 141, -3, 0, -3, 0,
+ax_anim_terminator
+sMachopAnims_7_4:
+ax_anim 2, 0, 142, -2, 2, -2, 2,
+ax_anim 8, 0, 142, -3, 3, -3, 3,
+ax_anim_terminator
+sMachopAnims_7_5:
+ax_anim 2, 0, 143, 0, 2, 0, 2,
+ax_anim 8, 0, 143, 0, 3, 0, 3,
+ax_anim_terminator
+sMachopAnims_7_6:
+ax_anim 2, 0, 144, 2, 2, 2, 2,
+ax_anim 8, 0, 144, 3, 3, 3, 3,
+ax_anim_terminator
+sMachopAnims_7_7:
+ax_anim 2, 0, 145, 2, 0, 2, 0,
+ax_anim 8, 0, 145, 3, 0, 3, 0,
+ax_anim_terminator
+sMachopAnims_7_8:
+ax_anim 2, 0, 146, 2, -2, 2, -2,
+ax_anim 8, 0, 146, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMachopAnims_8_1:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 1, -3, 0, 0,
+ax_anim 4, 0, 148, 1, -4, 0, 0,
+ax_anim 4, 0, 148, 1, -3, 0, 0,
+ax_anim_terminator
+sMachopAnims_8_2:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, -1, -3, 0, 0,
+ax_anim 4, 0, 151, -1, -4, 0, 0,
+ax_anim 4, 0, 151, -1, -3, 0, 0,
+ax_anim_terminator
+sMachopAnims_8_3:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, -1, -3, 0, 0,
+ax_anim 4, 0, 154, -1, -4, 0, 0,
+ax_anim 4, 0, 154, -1, -3, 0, 0,
+ax_anim_terminator
+sMachopAnims_8_4:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 1, -3, 0, 0,
+ax_anim 4, 0, 157, 1, -4, 0, 0,
+ax_anim 4, 0, 157, 1, -3, 0, 0,
+ax_anim_terminator
+sMachopAnims_8_5:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 4, 0, 160, 0, -4, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim_terminator
+sMachopAnims_8_6:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 163, -1, -3, 0, 0,
+ax_anim 4, 0, 163, -1, -4, 0, 0,
+ax_anim 4, 0, 163, -1, -3, 0, 0,
+ax_anim_terminator
+sMachopAnims_8_7:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 1, -3, 0, 0,
+ax_anim 4, 0, 166, 1, -4, 0, 0,
+ax_anim 4, 0, 166, 1, -3, 0, 0,
+ax_anim_terminator
+sMachopAnims_8_8:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 1, -3, 0, 0,
+ax_anim 4, 0, 169, 1, -4, 0, 0,
+ax_anim 4, 0, 169, 1, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_9_1:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 6, 4, 6, 4,
+ax_anim 2, 0, 173, 8, 9, 8, 9,
+ax_anim 2, 0, 174, 7, 17, 7, 17,
+ax_anim 3, 0, 175, 0, 23, 0, 23,
+ax_anim 2, 3, 176, -7, 17, -7, 17,
+ax_anim 2, 0, 177, -8, 10, -8, 10,
+ax_anim 1, 0, 178, -6, 4, -6, 4,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_9_2:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 0, 6, 0,
+ax_anim 2, 0, 172, 17, 3, 17, 3,
+ax_anim 2, 0, 173, 24, 9, 24, 9,
+ax_anim 3, 0, 174, 23, 21, 23, 21,
+ax_anim 2, 3, 175, 11, 21, 11, 21,
+ax_anim 2, 0, 176, 2, 14, 2, 14,
+ax_anim 1, 0, 177, 0, 7, 0, 7,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_9_3:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 3, -4, 3, -4,
+ax_anim 2, 0, 171, 11, -6, 11, -6,
+ax_anim 2, 0, 172, 17, -4, 17, -4,
+ax_anim 3, 0, 173, 24, 1, 24, 1,
+ax_anim 2, 3, 174, 18, 6, 18, 6,
+ax_anim 2, 0, 175, 12, 7, 12, 7,
+ax_anim 1, 0, 176, 4, 5, 4, 5,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_9_4:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, -1, -6, -1, -6,
+ax_anim 2, 0, 178, 4, -16, 4, -16,
+ax_anim 2, 0, 171, 11, -21, 11, -21,
+ax_anim 3, 0, 172, 21, -23, 21, -23,
+ax_anim 2, 3, 173, 21, -14, 21, -14,
+ax_anim 2, 0, 174, 16, -6, 16, -6,
+ax_anim 1, 0, 175, 7, -1, 7, -1,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_9_5:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -6, -4, -6, -4,
+ax_anim 2, 0, 177, -8, -10, -8, -10,
+ax_anim 2, 0, 178, -7, -19, -7, -19,
+ax_anim 3, 0, 171, 0, -24, 0, -24,
+ax_anim 2, 3, 172, 7, -19, 7, -19,
+ax_anim 2, 0, 173, 8, -8, 8, -8,
+ax_anim 1, 0, 174, 6, -4, 6, -4,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_9_6:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 1, -6, 1, -6,
+ax_anim 2, 0, 172, -4, -16, -4, -16,
+ax_anim 2, 0, 171, -11, -21, -11, -21,
+ax_anim 3, 0, 178, -21, -23, -21, -23,
+ax_anim 2, 3, 177, -21, -14, -21, -14,
+ax_anim 2, 0, 176, -16, -6, -16, -6,
+ax_anim 1, 0, 175, -7, -1, -7, -1,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_9_7:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, -3, -4, -3, -4,
+ax_anim 2, 0, 171, -11, -6, -11, -6,
+ax_anim 2, 0, 178, -17, -4, -17, -4,
+ax_anim 3, 0, 177, -24, 1, -24, 1,
+ax_anim 2, 3, 176, -18, 6, -18, 6,
+ax_anim 2, 0, 175, -12, 7, -12, 7,
+ax_anim 1, 0, 174, -4, 5, -4, 5,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_9_8:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -6, 0, -6, 0,
+ax_anim 2, 0, 178, -17, 3, -17, 3,
+ax_anim 2, 0, 177, -24, 9, -24, 9,
+ax_anim 3, 0, 176, -23, 21, -23, 21,
+ax_anim 2, 3, 175, -11, 21, -11, 21,
+ax_anim 2, 0, 174, -2, 14, -2, 14,
+ax_anim 1, 0, 173, 0, 7, 0, 7,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_10_1:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, 0, 6, 0,
+ax_anim 2, 0, 179, -6, 0, -6, 0,
+ax_anim 2, 0, 179, 10, 0, 10, 0,
+ax_anim 2, 0, 179, -10, 0, -10, 0,
+ax_anim 2, 0, 179, 12, 0, 12, 0,
+ax_anim 3, 0, 179, -12, 0, -12, 0,
+ax_anim 3, 0, 179, 13, 0, 13, 0,
+ax_anim 3, 0, 179, -13, 0, -13, 0,
+ax_anim 2, 0, 179, 12, 0, 12, 0,
+ax_anim 3, 0, 179, -12, 0, -12, 0,
+ax_anim 2, 0, 179, 10, 0, 10, 0,
+ax_anim 2, 0, 179, -10, 0, -10, 0,
+ax_anim 2, 0, 179, 6, 0, 6, 0,
+ax_anim 2, 0, 179, -6, 0, -6, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_10_2:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 6, -6, 6, -6,
+ax_anim 2, 0, 180, -6, 6, -6, 6,
+ax_anim 2, 0, 180, 10, -10, 10, -10,
+ax_anim 2, 0, 180, -10, 10, -10, 10,
+ax_anim 2, 0, 180, 12, -12, 12, -12,
+ax_anim 3, 0, 180, -12, 12, -12, 12,
+ax_anim 3, 0, 180, 13, -13, 13, -13,
+ax_anim 3, 0, 180, -13, 13, -13, 13,
+ax_anim 2, 0, 180, 12, -12, 12, -12,
+ax_anim 3, 0, 180, -12, 12, -12, 12,
+ax_anim 2, 0, 180, 10, -10, 10, -10,
+ax_anim 2, 0, 180, -10, 10, -10, 10,
+ax_anim 2, 0, 180, 6, -6, 6, -6,
+ax_anim 2, 0, 180, -6, 6, -6, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_10_3:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, -6, 0, -6,
+ax_anim 2, 0, 181, 0, 6, 0, 6,
+ax_anim 2, 0, 181, 0, -10, 0, -10,
+ax_anim 2, 0, 181, 0, 10, 0, 10,
+ax_anim 2, 0, 181, 0, -12, 0, -12,
+ax_anim 3, 0, 181, 0, 12, 0, 12,
+ax_anim 3, 0, 181, 0, -13, 0, -13,
+ax_anim 3, 0, 181, 0, 13, 0, 13,
+ax_anim 2, 0, 181, 0, -12, 0, -12,
+ax_anim 3, 0, 181, 0, 12, 0, 12,
+ax_anim 2, 0, 181, 0, -10, 0, -10,
+ax_anim 2, 0, 181, 0, 10, 0, 10,
+ax_anim 2, 0, 181, 0, -6, 0, -6,
+ax_anim 2, 0, 181, 0, 6, 0, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_10_4:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -6, -6, -6, -6,
+ax_anim 2, 0, 182, 6, 6, 6, 6,
+ax_anim 2, 0, 182, -10, -10, -10, -10,
+ax_anim 2, 0, 182, 10, 10, 10, 10,
+ax_anim 2, 0, 182, -12, -12, -12, -12,
+ax_anim 3, 0, 182, 12, 12, 12, 12,
+ax_anim 3, 0, 182, -13, -13, -13, -13,
+ax_anim 3, 0, 182, 13, 13, 13, 13,
+ax_anim 2, 0, 182, -12, -12, -12, -12,
+ax_anim 3, 0, 182, 12, 12, 12, 12,
+ax_anim 2, 0, 182, -10, -10, -10, -10,
+ax_anim 2, 0, 182, 10, 10, 10, 10,
+ax_anim 2, 0, 182, -6, -6, -6, -6,
+ax_anim 2, 0, 182, 6, 6, 6, 6,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_10_5:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, 0, 6, 0,
+ax_anim 2, 0, 183, -6, 0, -6, 0,
+ax_anim 2, 0, 183, 10, 0, 10, 0,
+ax_anim 2, 0, 183, -10, 0, -10, 0,
+ax_anim 2, 0, 183, 12, 0, 12, 0,
+ax_anim 3, 0, 183, -12, 0, -12, 0,
+ax_anim 3, 0, 183, 13, 0, 13, 0,
+ax_anim 3, 0, 183, -13, 0, -13, 0,
+ax_anim 2, 0, 183, 12, 0, 12, 0,
+ax_anim 3, 0, 183, -12, 0, -12, 0,
+ax_anim 2, 0, 183, 10, 0, 10, 0,
+ax_anim 2, 0, 183, -10, 0, -10, 0,
+ax_anim 2, 0, 183, 6, 0, 6, 0,
+ax_anim 2, 0, 183, -6, 0, -6, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_10_6:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 6, -6, 6, -6,
+ax_anim 2, 0, 184, -6, 6, -6, 6,
+ax_anim 2, 0, 184, 10, -10, 10, -10,
+ax_anim 2, 0, 184, -10, 10, -10, 10,
+ax_anim 2, 0, 184, 12, -12, 12, -12,
+ax_anim 3, 0, 184, -12, 12, -12, 12,
+ax_anim 3, 0, 184, 13, -13, 13, -13,
+ax_anim 3, 0, 184, -13, 13, -13, 13,
+ax_anim 2, 0, 184, 12, -12, 12, -12,
+ax_anim 3, 0, 184, -12, 12, -12, 12,
+ax_anim 2, 0, 184, 10, -10, 10, -10,
+ax_anim 2, 0, 184, -10, 10, -10, 10,
+ax_anim 2, 0, 184, 6, -6, 6, -6,
+ax_anim 2, 0, 184, -6, 6, -6, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_10_7:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -6, 0, -6,
+ax_anim 2, 0, 185, 0, 6, 0, 6,
+ax_anim 2, 0, 185, 0, -10, 0, -10,
+ax_anim 2, 0, 185, 0, 10, 0, 10,
+ax_anim 2, 0, 185, 0, -12, 0, -12,
+ax_anim 3, 0, 185, 0, 12, 0, 12,
+ax_anim 3, 0, 185, 0, -13, 0, -13,
+ax_anim 3, 0, 185, 0, 13, 0, 13,
+ax_anim 2, 0, 185, 0, -12, 0, -12,
+ax_anim 3, 0, 185, 0, 12, 0, 12,
+ax_anim 2, 0, 185, 0, -10, 0, -10,
+ax_anim 2, 0, 185, 0, 10, 0, 10,
+ax_anim 2, 0, 185, 0, -6, 0, -6,
+ax_anim 2, 0, 185, 0, 6, 0, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_10_8:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, -6, -6, -6, -6,
+ax_anim 2, 0, 186, 6, 6, 6, 6,
+ax_anim 2, 0, 186, -10, -10, -10, -10,
+ax_anim 2, 0, 186, 10, 10, 10, 10,
+ax_anim 2, 0, 186, -12, -12, -12, -12,
+ax_anim 3, 0, 186, 12, 12, 12, 12,
+ax_anim 3, 0, 186, -13, -13, -13, -13,
+ax_anim 3, 0, 186, 13, 13, 13, 13,
+ax_anim 2, 0, 186, -12, -12, -12, -12,
+ax_anim 3, 0, 186, 12, 12, 12, 12,
+ax_anim 2, 0, 186, -10, -10, -10, -10,
+ax_anim 2, 0, 186, 10, 10, 10, 10,
+ax_anim 2, 0, 186, -6, -6, -6, -6,
+ax_anim 2, 0, 186, 6, 6, 6, 6,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_11_1:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_11_2:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_11_3:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_11_4:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -17, 0, 0,
+ax_anim 1, 0, 198, 0, -11, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_11_5:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_11_6:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -22, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 1, 0, 204, 0, -11, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_11_7:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_11_8:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_12_1:
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, 0, 1, 0,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_12_2:
+ax_anim 2, 0, 218, 1, -1, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_12_3:
+ax_anim 2, 0, 217, 0, -1, 0, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, -1, 0, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, -1, 0, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, -1, 0, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, -1, 0, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_12_4:
+ax_anim 2, 0, 216, -1, -1, -1, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, -1, -1, -1, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, -1, -1, -1, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, -1, -1, -1, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, -1, -1, -1, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_12_5:
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_12_6:
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, -1, 1, -1,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_12_7:
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, -1, 0, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_12_8:
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_13_1:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_13_2:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_13_3:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_13_4:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_13_5:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_13_6:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_13_7:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_13_8:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_14_1:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_14_2:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_14_3:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_14_4:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_14_5:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_14_6:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_14_7:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_14_8:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 35, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_15_1:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_15_2:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_15_3:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_15_4:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_15_5:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_15_6:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_15_7:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_15_8:
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 232, 0, 0, 0, 0,
+ax_anim 14, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_16_1:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_16_2:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_16_3:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_16_4:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_16_5:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_16_6:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_16_7:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_16_8:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 3, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_17_1:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_17_2:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_17_3:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_17_4:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_17_5:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_17_6:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_17_7:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+sMachopAnims_17_8:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_18_1:
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 8, 0, 243, 0, 1, 0, 1,
+ax_anim_terminator
+sMachopAnims_18_2:
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 8, 0, 243, 0, 1, 0, 1,
+ax_anim_terminator
+sMachopAnims_18_3:
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 8, 0, 243, 0, 1, 0, 1,
+ax_anim_terminator
+sMachopAnims_18_4:
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 8, 0, 243, 0, 1, 0, 1,
+ax_anim_terminator
+sMachopAnims_18_5:
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 1, 0, 1,
+ax_anim 8, 0, 246, 0, 1, 0, 1,
+ax_anim_terminator
+sMachopAnims_18_6:
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 8, 0, 243, 0, 1, 0, 1,
+ax_anim_terminator
+sMachopAnims_18_7:
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 8, 0, 243, 0, 1, 0, 1,
+ax_anim_terminator
+sMachopAnims_18_8:
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 1, 0, 1,
+ax_anim 8, 0, 243, 0, 1, 0, 1,
+ax_anim_terminator
+.align 2
+sMachopAnims_19_1:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_19_2:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_19_3:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_19_4:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_19_5:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_19_6:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_19_7:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_19_8:
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_20_1:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 1, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 0,
+ax_anim 2, 0, 252, 0, 1, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 0,
+ax_anim 2, 0, 252, 0, 1, 0, 0,
+ax_anim 2, 0, 252, 1, 1, 1, 0,
+ax_anim_terminator
+sMachopAnims_20_2:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim_terminator
+sMachopAnims_20_3:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim_terminator
+sMachopAnims_20_4:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim_terminator
+sMachopAnims_20_5:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim_terminator
+sMachopAnims_20_6:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim_terminator
+sMachopAnims_20_7:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim_terminator
+sMachopAnims_20_8:
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -2, 0, 0,
+ax_anim 1, 0, 251, 0, -4, 0, 0,
+ax_anim 2, 0, 252, 0, -4, 0, 0,
+ax_anim 1, 0, 252, 0, -2, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_21_1:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_21_2:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_21_3:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_21_4:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_21_5:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_21_6:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_21_7:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_21_8:
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_22_1:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_22_2:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_22_3:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_22_4:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_22_5:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_22_6:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_22_7:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_22_8:
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 30, 0, 257, 0, 0, 0, 0,
+ax_anim 34, 0, 258, 0, 0, 0, 0,
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_23_1:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_23_2:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_23_3:
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 4, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_23_4:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_23_5:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_23_6:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_23_7:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_23_8:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 4, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_24_1:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_24_2:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_24_3:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_24_4:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_24_5:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_24_6:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_24_7:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_24_8:
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_25_1:
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 273, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_25_2:
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 273, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_25_3:
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 273, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_25_4:
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 273, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_25_5:
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 273, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_25_6:
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim 10, 0, 270, 0, 0, 0, 0,
+ax_anim 12, 0, 273, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_25_7:
+ax_anim 10, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim 12, 0, 267, 0, 0, 0, 0,
+ax_anim 10, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_25_8:
+ax_anim 10, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim 12, 0, 267, 0, 0, 0, 0,
+ax_anim 10, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_26_1:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_26_2:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_26_3:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_26_4:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_26_5:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_26_6:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_26_7:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+sMachopAnims_26_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sMachopAnims_27_1:
+ax_anim 12, 0, 276, 0, 0, 0, 0,
+ax_anim 12, 0, 276, 0, 0, 0, 0,
+ax_anim 16, 0, 276, -1, 0, 0, 0,
+ax_anim 12, 0, 276, 0, 0, 0, 0,
+ax_anim 12, 0, 276, 1, 0, 0, 0,
+ax_anim 16, 0, 276, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMachopAnims_28_1:
+ax_anim 12, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_28_2:
+ax_anim 12, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_28_3:
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_28_4:
+ax_anim 12, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_28_5:
+ax_anim 12, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_28_6:
+ax_anim 12, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_28_7:
+ax_anim 12, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopAnims_28_8:
+ax_anim 12, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sMachopGfx1:
+.incbin "baserom.gba", 0x7DD6D0, 0x200
+sMachopSprites1:
+ax_sprite sMachopGfx1, 0x200
+ax_sprite_terminator
+sMachopGfx2:
+.incbin "baserom.gba", 0x7DD8E0, 0x200
+sMachopSprites2:
+ax_sprite sMachopGfx2, 0x200
+ax_sprite_terminator
+sMachopGfx3:
+.incbin "baserom.gba", 0x7DDAF0, 0x200
+sMachopSprites3:
+ax_sprite sMachopGfx3, 0x200
+ax_sprite_terminator
+sMachopGfx4:
+.incbin "baserom.gba", 0x7DDD00, 0x200
+sMachopSprites4:
+ax_sprite sMachopGfx4, 0x200
+ax_sprite_terminator
+sMachopGfx5:
+.incbin "baserom.gba", 0x7DDF10, 0x200
+sMachopSprites5:
+ax_sprite sMachopGfx5, 0x200
+ax_sprite_terminator
+sMachopGfx6:
+.incbin "baserom.gba", 0x7DE120, 0x200
+sMachopSprites6:
+ax_sprite sMachopGfx6, 0x200
+ax_sprite_terminator
+sMachopGfx7:
+.incbin "baserom.gba", 0x7DE330, 0x100
+sMachopSprites7:
+ax_sprite sMachopGfx7, 0x100
+ax_sprite_terminator
+sMachopGfx8:
+.incbin "baserom.gba", 0x7DE440, 0x100
+sMachopSprites8:
+ax_sprite sMachopGfx8, 0x100
+ax_sprite_terminator
+sMachopGfx9:
+.incbin "baserom.gba", 0x7DE550, 0x100
+sMachopSprites9:
+ax_sprite sMachopGfx9, 0x100
+ax_sprite_terminator
+sMachopGfx10:
+.incbin "baserom.gba", 0x7DE660, 0x200
+sMachopSprites10:
+ax_sprite sMachopGfx10, 0x200
+ax_sprite_terminator
+sMachopGfx11:
+.incbin "baserom.gba", 0x7DE870, 0x200
+sMachopSprites11:
+ax_sprite sMachopGfx11, 0x200
+ax_sprite_terminator
+sMachopGfx12:
+.incbin "baserom.gba", 0x7DEA80, 0x200
+sMachopSprites12:
+ax_sprite sMachopGfx12, 0x200
+ax_sprite_terminator
+sMachopGfx13:
+.incbin "baserom.gba", 0x7DEC90, 0x200
+sMachopSprites13:
+ax_sprite sMachopGfx13, 0x200
+ax_sprite_terminator
+sMachopGfx14:
+.incbin "baserom.gba", 0x7DEEA0, 0x200
+sMachopSprites14:
+ax_sprite sMachopGfx14, 0x200
+ax_sprite_terminator
+sMachopGfx15:
+.incbin "baserom.gba", 0x7DF0B0, 0x200
+sMachopSprites15:
+ax_sprite sMachopGfx15, 0x200
+ax_sprite_terminator
+sMachopGfx16:
+.incbin "baserom.gba", 0x7DF2C0, 0x60
+sMachopGfx16_1:
+.incbin "baserom.gba", 0x7DF320, 0x60
+sMachopGfx16_2:
+.incbin "baserom.gba", 0x7DF380, 0x60
+sMachopSprites16:
+ax_sprite sMachopGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx17:
+.incbin "baserom.gba", 0x7DF418, 0x40
+sMachopGfx17_1:
+.incbin "baserom.gba", 0x7DF458, 0x40
+sMachopGfx17_2:
+.incbin "baserom.gba", 0x7DF498, 0x60
+sMachopGfx17_3:
+.incbin "baserom.gba", 0x7DF4F8, 0x40
+sMachopSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx17_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachopGfx18:
+.incbin "baserom.gba", 0x7DF588, 0x40
+sMachopGfx18_1:
+.incbin "baserom.gba", 0x7DF5C8, 0x60
+sMachopGfx18_2:
+.incbin "baserom.gba", 0x7DF628, 0x40
+sMachopSprites18:
+ax_sprite sMachopGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx18_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMachopGfx19:
+.incbin "baserom.gba", 0x7DF6A0, 0xE0
+sMachopGfx19_1:
+.incbin "baserom.gba", 0x7DF780, 0x40
+sMachopSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx19, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx19_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx20:
+.incbin "baserom.gba", 0x7DF7F0, 0x40
+sMachopGfx20_1:
+.incbin "baserom.gba", 0x7DF830, 0x60
+sMachopGfx20_2:
+.incbin "baserom.gba", 0x7DF890, 0x40
+sMachopGfx20_3:
+.incbin "baserom.gba", 0x7DF8D0, 0x40
+sMachopSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx20_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx20_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachopGfx21:
+.incbin "baserom.gba", 0x7DF960, 0x20
+sMachopGfx21_1:
+.incbin "baserom.gba", 0x7DF980, 0x60
+sMachopGfx21_2:
+.incbin "baserom.gba", 0x7DF9E0, 0x60
+sMachopGfx21_3:
+.incbin "baserom.gba", 0x7DFA40, 0x20
+sMachopSprites21:
+ax_sprite sMachopGfx21, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMachopGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachopGfx22:
+.incbin "baserom.gba", 0x7DFAA8, 0x60
+sMachopGfx22_1:
+.incbin "baserom.gba", 0x7DFB08, 0x60
+sMachopGfx22_2:
+.incbin "baserom.gba", 0x7DFB68, 0x40
+sMachopSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx22_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx23:
+.incbin "baserom.gba", 0x7DFBE8, 0x40
+sMachopGfx23_1:
+.incbin "baserom.gba", 0x7DFC28, 0x40
+sMachopGfx23_2:
+.incbin "baserom.gba", 0x7DFC68, 0x40
+sMachopSprites23:
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx23_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMachopGfx24:
+.incbin "baserom.gba", 0x7DFCE8, 0x40
+sMachopGfx24_1:
+.incbin "baserom.gba", 0x7DFD28, 0x60
+sMachopGfx24_2:
+.incbin "baserom.gba", 0x7DFD88, 0x60
+sMachopSprites24:
+ax_sprite sMachopGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx25:
+.incbin "baserom.gba", 0x7DFE20, 0x40
+sMachopGfx25_1:
+.incbin "baserom.gba", 0x7DFE60, 0x40
+sMachopGfx25_2:
+.incbin "baserom.gba", 0x7DFEA0, 0x60
+sMachopGfx25_3:
+.incbin "baserom.gba", 0x7DFF00, 0x40
+sMachopSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMachopGfx26:
+.incbin "baserom.gba", 0x7DFF90, 0xC0
+sMachopSprites26:
+ax_sprite sMachopGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachopGfx27:
+.incbin "baserom.gba", 0x7E0068, 0x40
+sMachopGfx27_1:
+.incbin "baserom.gba", 0x7E00A8, 0x60
+sMachopGfx27_2:
+.incbin "baserom.gba", 0x7E0108, 0x60
+sMachopSprites27:
+ax_sprite sMachopGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx28:
+.incbin "baserom.gba", 0x7E01A0, 0x40
+sMachopGfx28_1:
+.incbin "baserom.gba", 0x7E01E0, 0x60
+sMachopGfx28_2:
+.incbin "baserom.gba", 0x7E0240, 0x60
+sMachopSprites28:
+ax_sprite sMachopGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx29:
+.incbin "baserom.gba", 0x7E02D8, 0x60
+sMachopGfx29_1:
+.incbin "baserom.gba", 0x7E0338, 0x20
+sMachopSprites29:
+ax_sprite sMachopGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx29_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMachopGfx30:
+.incbin "baserom.gba", 0x7E0380, 0x60
+sMachopGfx30_1:
+.incbin "baserom.gba", 0x7E03E0, 0x60
+sMachopGfx30_2:
+.incbin "baserom.gba", 0x7E0440, 0x60
+sMachopSprites30:
+ax_sprite sMachopGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx31:
+.incbin "baserom.gba", 0x7E04D8, 0x60
+sMachopGfx31_1:
+.incbin "baserom.gba", 0x7E0538, 0x60
+sMachopGfx31_2:
+.incbin "baserom.gba", 0x7E0598, 0x60
+sMachopSprites31:
+ax_sprite sMachopGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx32:
+.incbin "baserom.gba", 0x7E0630, 0x40
+sMachopGfx32_1:
+.incbin "baserom.gba", 0x7E0670, 0x60
+sMachopGfx32_2:
+.incbin "baserom.gba", 0x7E06D0, 0x60
+sMachopSprites32:
+ax_sprite sMachopGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx33:
+.incbin "baserom.gba", 0x7E0768, 0xC0
+sMachopSprites33:
+ax_sprite sMachopGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachopGfx34:
+.incbin "baserom.gba", 0x7E0840, 0x40
+sMachopGfx34_1:
+.incbin "baserom.gba", 0x7E0880, 0x60
+sMachopGfx34_2:
+.incbin "baserom.gba", 0x7E08E0, 0x60
+sMachopSprites34:
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx35:
+.incbin "baserom.gba", 0x7E0980, 0x60
+sMachopGfx35_1:
+.incbin "baserom.gba", 0x7E09E0, 0x60
+sMachopGfx35_2:
+.incbin "baserom.gba", 0x7E0A40, 0x60
+sMachopSprites35:
+ax_sprite sMachopGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx36:
+.incbin "baserom.gba", 0x7E0AD8, 0x60
+sMachopGfx36_1:
+.incbin "baserom.gba", 0x7E0B38, 0x60
+sMachopSprites36:
+ax_sprite 0, 0x80
+ax_sprite sMachopGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx36_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx37:
+.incbin "baserom.gba", 0x7E0BC8, 0x40
+sMachopGfx37_1:
+.incbin "baserom.gba", 0x7E0C08, 0x60
+sMachopGfx37_2:
+.incbin "baserom.gba", 0x7E0C68, 0x60
+sMachopSprites37:
+ax_sprite sMachopGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx38:
+.incbin "baserom.gba", 0x7E0D00, 0x60
+sMachopGfx38_1:
+.incbin "baserom.gba", 0x7E0D60, 0x60
+sMachopSprites38:
+ax_sprite 0, 0x80
+ax_sprite sMachopGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx38_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx39:
+.incbin "baserom.gba", 0x7E0DF0, 0x60
+sMachopGfx39_1:
+.incbin "baserom.gba", 0x7E0E50, 0x60
+sMachopGfx39_2:
+.incbin "baserom.gba", 0x7E0EB0, 0x60
+sMachopSprites39:
+ax_sprite sMachopGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx39_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx40:
+.incbin "baserom.gba", 0x7E0F48, 0x20
+sMachopGfx40_1:
+.incbin "baserom.gba", 0x7E0F68, 0x40
+sMachopSprites40:
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx40, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx40_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMachopGfx41:
+.incbin "baserom.gba", 0x7E0FD8, 0x60
+sMachopGfx41_1:
+.incbin "baserom.gba", 0x7E1038, 0x60
+sMachopGfx41_2:
+.incbin "baserom.gba", 0x7E1098, 0x60
+sMachopSprites41:
+ax_sprite sMachopGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx41_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx42:
+.incbin "baserom.gba", 0x7E1130, 0x20
+sMachopGfx42_1:
+.incbin "baserom.gba", 0x7E1150, 0x20
+sMachopGfx42_2:
+.incbin "baserom.gba", 0x7E1170, 0x20
+sMachopGfx42_3:
+.incbin "baserom.gba", 0x7E1190, 0x40
+sMachopGfx42_4:
+.incbin "baserom.gba", 0x7E11D0, 0x20
+sMachopSprites42:
+ax_sprite sMachopGfx42, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMachopGfx42_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx42_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx42_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMachopGfx42_4, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMachopGfx43:
+.incbin "baserom.gba", 0x7E1248, 0x60
+sMachopGfx43_1:
+.incbin "baserom.gba", 0x7E12A8, 0x60
+sMachopGfx43_2:
+.incbin "baserom.gba", 0x7E1308, 0x60
+sMachopSprites43:
+ax_sprite sMachopGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx43_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx44:
+.incbin "baserom.gba", 0x7E13A0, 0x60
+sMachopGfx44_1:
+.incbin "baserom.gba", 0x7E1400, 0x20
+sMachopGfx44_2:
+.incbin "baserom.gba", 0x7E1420, 0x20
+sMachopGfx44_3:
+.incbin "baserom.gba", 0x7E1440, 0x20
+sMachopGfx44_4:
+.incbin "baserom.gba", 0x7E1460, 0x20
+sMachopSprites44:
+ax_sprite sMachopGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx44_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx44_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx44_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx44_4, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx45:
+.incbin "baserom.gba", 0x7E14D8, 0x60
+sMachopGfx45_1:
+.incbin "baserom.gba", 0x7E1538, 0x60
+sMachopGfx45_2:
+.incbin "baserom.gba", 0x7E1598, 0x60
+sMachopSprites45:
+ax_sprite sMachopGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMachopGfx45_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMachopGfx46:
+.incbin "baserom.gba", 0x7E1630, 0x200
+sMachopSprites46:
+ax_sprite sMachopGfx46, 0x200
+ax_sprite_terminator
+sMachopGfx47:
+.incbin "baserom.gba", 0x7E1840, 0x200
+sMachopSprites47:
+ax_sprite sMachopGfx47, 0x200
+ax_sprite_terminator
+sMachopGfx48:
+.incbin "baserom.gba", 0x7E1A50, 0x200
+sMachopSprites48:
+ax_sprite sMachopGfx48, 0x200
+ax_sprite_terminator
+sMachopGfx49:
+.incbin "baserom.gba", 0x7E1C60, 0x200
+sMachopSprites49:
+ax_sprite sMachopGfx49, 0x200
+ax_sprite_terminator
+sMachopGfx50:
+.incbin "baserom.gba", 0x7E1E70, 0x200
+sMachopSprites50:
+ax_sprite sMachopGfx50, 0x200
+ax_sprite_terminator
+sMachopGfx51:
+.incbin "baserom.gba", 0x7E2080, 0x200
+sMachopSprites51:
+ax_sprite sMachopGfx51, 0x200
+ax_sprite_terminator
+sMachopGfx52:
+.incbin "baserom.gba", 0x7E2290, 0x200
+sMachopSprites52:
+ax_sprite sMachopGfx52, 0x200
+ax_sprite_terminator
+sMachopGfx53:
+.incbin "baserom.gba", 0x7E24A0, 0x200
+sMachopSprites53:
+ax_sprite sMachopGfx53, 0x200
+ax_sprite_terminator
+sMachopGfx54:
+.incbin "baserom.gba", 0x7E26B0, 0x200
+sMachopSprites54:
+ax_sprite sMachopGfx54, 0x200
+ax_sprite_terminator
+sMachopGfx55:
+.incbin "baserom.gba", 0x7E28C0, 0x100
+sMachopSprites55:
+ax_sprite sMachopGfx55, 0x100
+ax_sprite_terminator
+sMachopGfx56:
+.incbin "baserom.gba", 0x7E29D0, 0x200
+sMachopSprites56:
+ax_sprite sMachopGfx56, 0x200
+ax_sprite_terminator
+sMachopGfx57:
+.incbin "baserom.gba", 0x7E2BE0, 0x100
+sMachopSprites57:
+ax_sprite sMachopGfx57, 0x100
+ax_sprite_terminator
+sMachopGfx58:
+.incbin "baserom.gba", 0x7E2CF0, 0x200
+sMachopSprites58:
+ax_sprite sMachopGfx58, 0x200
+ax_sprite_terminator
+sMachopGfx59:
+.incbin "baserom.gba", 0x7E2F00, 0x200
+sMachopSprites59:
+ax_sprite sMachopGfx59, 0x200
+ax_sprite_terminator
+sMachopGfx60:
+.incbin "baserom.gba", 0x7E3110, 0x200
+sMachopSprites60:
+ax_sprite sMachopGfx60, 0x200
+ax_sprite_terminator
+sMachopGfx61:
+.incbin "baserom.gba", 0x7E3320, 0x200
+sMachopSprites61:
+ax_sprite sMachopGfx61, 0x200
+ax_sprite_terminator
+sMachopGfx62:
+.incbin "baserom.gba", 0x7E3530, 0x200
+sMachopSprites62:
+ax_sprite sMachopGfx62, 0x200
+ax_sprite_terminator
+sMachopGfx63:
+.incbin "baserom.gba", 0x7E3740, 0x200
+sMachopSprites63:
+ax_sprite sMachopGfx63, 0x200
+ax_sprite_terminator
+sMachopGfx64:
+.incbin "baserom.gba", 0x7E3950, 0x200
+sMachopSprites64:
+ax_sprite sMachopGfx64, 0x200
+ax_sprite_terminator
+sMachopGfx65:
+.incbin "baserom.gba", 0x7E3B60, 0x200
+sMachopSprites65:
+ax_sprite sMachopGfx65, 0x200
+ax_sprite_terminator
+sMachopGfx66:
+.incbin "baserom.gba", 0x7E3D70, 0x200
+sMachopSprites66:
+ax_sprite sMachopGfx66, 0x200
+ax_sprite_terminator
+sMachopGfx67:
+.incbin "baserom.gba", 0x7E3F80, 0x200
+sMachopSprites67:
+ax_sprite sMachopGfx67, 0x200
+ax_sprite_terminator
+sMachopGfx68:
+.incbin "baserom.gba", 0x7E4190, 0x200
+sMachopSprites68:
+ax_sprite sMachopGfx68, 0x200
+ax_sprite_terminator
+sMachopGfx69:
+.incbin "baserom.gba", 0x7E43A0, 0x200
+sMachopSprites69:
+ax_sprite sMachopGfx69, 0x200
+ax_sprite_terminator
+sMachopGfx70:
+.incbin "baserom.gba", 0x7E45B0, 0x200
+sMachopSprites70:
+ax_sprite sMachopGfx70, 0x200
+ax_sprite_terminator
+sMachopGfx71:
+.incbin "baserom.gba", 0x7E47C0, 0x200
+sMachopSprites71:
+ax_sprite sMachopGfx71, 0x200
+ax_sprite_terminator
+sMachopGfx72:
+.incbin "baserom.gba", 0x7E49D0, 0x200
+sMachopSprites72:
+ax_sprite sMachopGfx72, 0x200
+ax_sprite_terminator
+sMachopGfx73:
+.incbin "baserom.gba", 0x7E4BE0, 0x200
+sMachopSprites73:
+ax_sprite sMachopGfx73, 0x200
+ax_sprite_terminator
+sMachopGfx74:
+.incbin "baserom.gba", 0x7E4DF0, 0x100
+sMachopSprites74:
+ax_sprite sMachopGfx74, 0x100
+ax_sprite_terminator
+sMachopGfx75:
+.incbin "baserom.gba", 0x7E4F00, 0x100
+sMachopSprites75:
+ax_sprite sMachopGfx75, 0x100
+ax_sprite_terminator
+sMachopGfx76:
+.incbin "baserom.gba", 0x7E5010, 0x200
+sMachopSprites76:
+ax_sprite sMachopGfx76, 0x200
+ax_sprite_terminator
+sMachopGfx77:
+.incbin "baserom.gba", 0x7E5220, 0x200
+sMachopSprites77:
+ax_sprite sMachopGfx77, 0x200
+ax_sprite_terminator
+sMachopGfx78:
+.incbin "baserom.gba", 0x7E5430, 0x200
+sMachopSprites78:
+ax_sprite sMachopGfx78, 0x200
+ax_sprite_terminator
+sMachopGfx79:
+.incbin "baserom.gba", 0x7E5640, 0x200
+sMachopSprites79:
+ax_sprite sMachopGfx79, 0x200
+ax_sprite_terminator
+sMachopGfx80:
+.incbin "baserom.gba", 0x7E5850, 0x200
+sMachopSprites80:
+ax_sprite sMachopGfx80, 0x200
+ax_sprite_terminator
+sMachopGfx81:
+.incbin "baserom.gba", 0x7E5A60, 0x200
+sMachopSprites81:
+ax_sprite sMachopGfx81, 0x200
+ax_sprite_terminator
+sMachopGfx82:
+.incbin "baserom.gba", 0x7E5C70, 0x200
+sMachopSprites82:
+ax_sprite sMachopGfx82, 0x200
+ax_sprite_terminator
+sAxPosesMachop:
+.4byte sMachopPose1
+.4byte sMachopPose2
+.4byte sMachopPose3
+.4byte sMachopPose4
+.4byte sMachopPose5
+.4byte sMachopPose6
+.4byte sMachopPose7
+.4byte sMachopPose8
+.4byte sMachopPose9
+.4byte sMachopPose10
+.4byte sMachopPose11
+.4byte sMachopPose12
+.4byte sMachopPose13
+.4byte sMachopPose14
+.4byte sMachopPose15
+.4byte sMachopPose16
+.4byte sMachopPose17
+.4byte sMachopPose18
+.4byte sMachopPose19
+.4byte sMachopPose20
+.4byte sMachopPose21
+.4byte sMachopPose22
+.4byte sMachopPose23
+.4byte sMachopPose24
+.4byte sMachopPose25
+.4byte sMachopPose26
+.4byte sMachopPose27
+.4byte sMachopPose28
+.4byte sMachopPose29
+.4byte sMachopPose30
+.4byte sMachopPose31
+.4byte sMachopPose32
+.4byte sMachopPose33
+.4byte sMachopPose34
+.4byte sMachopPose35
+.4byte sMachopPose36
+.4byte sMachopPose37
+.4byte sMachopPose38
+.4byte sMachopPose39
+.4byte sMachopPose40
+.4byte sMachopPose41
+.4byte sMachopPose42
+.4byte sMachopPose43
+.4byte sMachopPose44
+.4byte sMachopPose45
+.4byte sMachopPose46
+.4byte sMachopPose47
+.4byte sMachopPose48
+.4byte sMachopPose49
+.4byte sMachopPose50
+.4byte sMachopPose51
+.4byte sMachopPose52
+.4byte sMachopPose53
+.4byte sMachopPose54
+.4byte sMachopPose55
+.4byte sMachopPose56
+.4byte sMachopPose57
+.4byte sMachopPose58
+.4byte sMachopPose59
+.4byte sMachopPose60
+.4byte sMachopPose61
+.4byte sMachopPose62
+.4byte sMachopPose63
+.4byte sMachopPose64
+.4byte sMachopPose65
+.4byte sMachopPose66
+.4byte sMachopPose67
+.4byte sMachopPose68
+.4byte sMachopPose69
+.4byte sMachopPose70
+.4byte sMachopPose71
+.4byte sMachopPose72
+.4byte sMachopPose73
+.4byte sMachopPose74
+.4byte sMachopPose75
+.4byte sMachopPose76
+.4byte sMachopPose77
+.4byte sMachopPose78
+.4byte sMachopPose79
+.4byte sMachopPose80
+.4byte sMachopPose81
+.4byte sMachopPose82
+.4byte sMachopPose83
+.4byte sMachopPose84
+.4byte sMachopPose85
+.4byte sMachopPose86
+.4byte sMachopPose87
+.4byte sMachopPose88
+.4byte sMachopPose89
+.4byte sMachopPose90
+.4byte sMachopPose91
+.4byte sMachopPose92
+.4byte sMachopPose93
+.4byte sMachopPose94
+.4byte sMachopPose95
+.4byte sMachopPose96
+.4byte sMachopPose97
+.4byte sMachopPose98
+.4byte sMachopPose99
+.4byte sMachopPose100
+.4byte sMachopPose101
+.4byte sMachopPose102
+.4byte sMachopPose103
+.4byte sMachopPose104
+.4byte sMachopPose105
+.4byte sMachopPose106
+.4byte sMachopPose107
+.4byte sMachopPose108
+.4byte sMachopPose109
+.4byte sMachopPose110
+.4byte sMachopPose111
+.4byte sMachopPose112
+.4byte sMachopPose113
+.4byte sMachopPose114
+.4byte sMachopPose115
+.4byte sMachopPose116
+.4byte sMachopPose117
+.4byte sMachopPose118
+.4byte sMachopPose119
+.4byte sMachopPose120
+.4byte sMachopPose121
+.4byte sMachopPose122
+.4byte sMachopPose123
+.4byte sMachopPose124
+.4byte sMachopPose125
+.4byte sMachopPose126
+.4byte sMachopPose127
+.4byte sMachopPose128
+.4byte sMachopPose129
+.4byte sMachopPose130
+.4byte sMachopPose131
+.4byte sMachopPose132
+.4byte sMachopPose133
+.4byte sMachopPose134
+.4byte sMachopPose135
+.4byte sMachopPose136
+.4byte sMachopPose137
+.4byte sMachopPose138
+.4byte sMachopPose139
+.4byte sMachopPose140
+.4byte sMachopPose141
+.4byte sMachopPose142
+.4byte sMachopPose143
+.4byte sMachopPose144
+.4byte sMachopPose145
+.4byte sMachopPose146
+.4byte sMachopPose147
+.4byte sMachopPose148
+.4byte sMachopPose149
+.4byte sMachopPose150
+.4byte sMachopPose151
+.4byte sMachopPose152
+.4byte sMachopPose153
+.4byte sMachopPose154
+.4byte sMachopPose155
+.4byte sMachopPose156
+.4byte sMachopPose157
+.4byte sMachopPose158
+.4byte sMachopPose159
+.4byte sMachopPose160
+.4byte sMachopPose161
+.4byte sMachopPose162
+.4byte sMachopPose163
+.4byte sMachopPose164
+.4byte sMachopPose165
+.4byte sMachopPose166
+.4byte sMachopPose167
+.4byte sMachopPose168
+.4byte sMachopPose169
+.4byte sMachopPose170
+.4byte sMachopPose171
+.4byte sMachopPose172
+.4byte sMachopPose173
+.4byte sMachopPose174
+.4byte sMachopPose175
+.4byte sMachopPose176
+.4byte sMachopPose177
+.4byte sMachopPose178
+.4byte sMachopPose179
+.4byte sMachopPose180
+.4byte sMachopPose181
+.4byte sMachopPose182
+.4byte sMachopPose183
+.4byte sMachopPose184
+.4byte sMachopPose185
+.4byte sMachopPose186
+.4byte sMachopPose187
+.4byte sMachopPose188
+.4byte sMachopPose189
+.4byte sMachopPose190
+.4byte sMachopPose191
+.4byte sMachopPose192
+.4byte sMachopPose193
+.4byte sMachopPose194
+.4byte sMachopPose195
+.4byte sMachopPose196
+.4byte sMachopPose197
+.4byte sMachopPose198
+.4byte sMachopPose199
+.4byte sMachopPose200
+.4byte sMachopPose201
+.4byte sMachopPose202
+.4byte sMachopPose203
+.4byte sMachopPose204
+.4byte sMachopPose205
+.4byte sMachopPose206
+.4byte sMachopPose207
+.4byte sMachopPose208
+.4byte sMachopPose209
+.4byte sMachopPose210
+.4byte sMachopPose211
+.4byte sMachopPose212
+.4byte sMachopPose213
+.4byte sMachopPose214
+.4byte sMachopPose215
+.4byte sMachopPose216
+.4byte sMachopPose217
+.4byte sMachopPose218
+.4byte sMachopPose219
+.4byte sMachopPose220
+.4byte sMachopPose221
+.4byte sMachopPose222
+.4byte sMachopPose223
+.4byte sMachopPose224
+.4byte sMachopPose225
+.4byte sMachopPose226
+.4byte sMachopPose227
+.4byte sMachopPose228
+.4byte sMachopPose229
+.4byte sMachopPose230
+.4byte sMachopPose231
+.4byte sMachopPose232
+.4byte sMachopPose233
+.4byte sMachopPose234
+.4byte sMachopPose235
+.4byte sMachopPose236
+.4byte sMachopPose237
+.4byte sMachopPose238
+.4byte sMachopPose239
+.4byte sMachopPose240
+.4byte sMachopPose241
+.4byte sMachopPose242
+.4byte sMachopPose243
+.4byte sMachopPose244
+.4byte sMachopPose245
+.4byte sMachopPose246
+.4byte sMachopPose247
+.4byte sMachopPose248
+.4byte sMachopPose249
+.4byte sMachopPose250
+.4byte sMachopPose251
+.4byte sMachopPose252
+.4byte sMachopPose253
+.4byte sMachopPose254
+.4byte sMachopPose255
+.4byte sMachopPose256
+.4byte sMachopPose257
+.4byte sMachopPose258
+.4byte sMachopPose259
+.4byte sMachopPose260
+.4byte sMachopPose261
+.4byte sMachopPose262
+.4byte sMachopPose263
+.4byte sMachopPose264
+.4byte sMachopPose265
+.4byte sMachopPose266
+.4byte sMachopPose267
+.4byte sMachopPose268
+.4byte sMachopPose269
+.4byte sMachopPose270
+.4byte sMachopPose271
+.4byte sMachopPose272
+.4byte sMachopPose273
+.4byte sMachopPose274
+.4byte sMachopPose275
+.4byte sMachopPose276
+.4byte sMachopPose277
+.4byte sMachopPose278
+.4byte sMachopPose279
+.4byte sMachopPose280
+.4byte sMachopPose281
+.4byte sMachopPose282
+.4byte sMachopPose283
+.4byte sMachopPose284
+sAxPositionsMachop:
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte   -2,   -7, 	  -9,   -5, 	   2,   -2, 	  -2,   -6
+.2byte    0,   -7, 	  -4,   -2, 	   7,   -5, 	  -1,   -7
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte    4,   -7, 	   3,   -6, 	   0,   -3, 	   0,   -6
+.2byte    3,   -6, 	   7,   -3, 	  -7,   -2, 	  -1,   -5
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    5,   -8, 	  -3,   -5, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -7, 	   4,   -5, 	  -4,   -1, 	  -2,   -5
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    2,  -10, 	  -7,   -4, 	   7,   -5, 	  -1,   -5
+.2byte    4,  -11, 	  -1,   -7, 	   1,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -2, 	  -8,   -8, 	   0,   -6
+.2byte   -2,  -11, 	   6,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,  -10, 	   5,   -4, 	  -9,   -5, 	  -1,   -5
+.2byte   -6,  -11, 	  -1,   -7, 	  -3,   -1, 	  -2,   -6
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -7,   -8, 	   1,   -5, 	  -6,   -4, 	  -1,   -6
+.2byte   -6,   -7, 	  -6,   -5, 	   2,   -1, 	   0,   -5
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -6,   -7, 	  -5,   -6, 	  -2,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -9,   -3, 	   5,   -2, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte   -2,   -7, 	  -9,   -5, 	   2,   -2, 	  -2,   -6
+.2byte    0,   -7, 	  -4,   -2, 	   7,   -5, 	  -1,   -7
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte    4,   -7, 	   3,   -6, 	   0,   -3, 	   0,   -6
+.2byte    3,   -6, 	   7,   -3, 	  -7,   -2, 	  -1,   -5
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    5,   -8, 	  -3,   -5, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -7, 	   4,   -5, 	  -4,   -1, 	  -2,   -5
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    2,  -10, 	  -7,   -4, 	   7,   -5, 	  -1,   -5
+.2byte    4,  -11, 	  -1,   -7, 	   1,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -2, 	  -8,   -8, 	   0,   -6
+.2byte   -2,  -11, 	   6,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,  -10, 	   5,   -4, 	  -9,   -5, 	  -1,   -5
+.2byte   -6,  -11, 	  -1,   -7, 	  -3,   -1, 	  -2,   -6
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -7,   -8, 	   1,   -5, 	  -6,   -4, 	  -1,   -6
+.2byte   -6,   -7, 	  -6,   -5, 	   2,   -1, 	   0,   -5
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -6,   -7, 	  -5,   -6, 	  -2,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -9,   -3, 	   5,   -2, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte    1,   -8, 	  -5,   -8, 	   8,  -15, 	   0,   -8
+.2byte   -7,   -4, 	  -5,  -11, 	  -4,    0, 	  -3,   -6
+.2byte   -7,   -4, 	  -5,  -11, 	  -4,    0, 	  -3,   -6
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte    3,   -8, 	   8,   -6, 	  -9,  -11, 	  -1,   -6
+.2byte    3,   -1, 	  -5,  -10, 	   0,    2, 	  -1,   -3
+.2byte    3,   -1, 	  -5,  -10, 	   0,    2, 	  -1,   -3
+.2byte   -2,   -8, 	   4,   -8, 	  -9,  -15, 	  -1,   -8
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte   -3,   -7, 	   1,   -8, 	 -11,   -7, 	  -5,   -6
+.2byte    6,   -6, 	  -5,   -9, 	   6,    0, 	   2,   -6
+.2byte    6,   -6, 	  -5,   -9, 	   6,    0, 	   2,   -6
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    1,   -6, 	   2,   -5, 	  -3,   -6, 	  -3,   -5
+.2byte    4,   -6, 	  -7,   -4, 	   3,   -3, 	   1,   -5
+.2byte    4,   -6, 	  -7,   -4, 	   3,   -3, 	   1,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -3,  -10, 	   2,   -7, 	  -9,   -8, 	  -2,   -5
+.2byte    2,  -13, 	   8,   -7, 	  -2,   -7, 	   0,   -9
+.2byte    2,  -13, 	   8,   -7, 	  -2,   -7, 	   0,   -9
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -3,   -6, 	  -4,   -5, 	   1,   -6, 	   1,   -5
+.2byte   -6,   -6, 	   5,   -4, 	  -5,   -3, 	  -3,   -5
+.2byte   -6,   -6, 	   5,   -4, 	  -5,   -3, 	  -3,   -5
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte    1,   -7, 	  -3,   -8, 	   9,   -7, 	   3,   -6
+.2byte   -8,   -6, 	   3,   -9, 	  -8,    0, 	  -4,   -6
+.2byte   -8,   -6, 	   3,   -9, 	  -8,    0, 	  -4,   -6
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -5,   -8, 	 -10,   -6, 	   7,  -11, 	  -1,   -6
+.2byte   -5,   -1, 	   3,  -10, 	  -2,    2, 	  -1,   -3
+.2byte   -5,   -1, 	   3,  -10, 	  -2,    2, 	  -1,   -3
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte    0,   -6, 	  -7,  -11, 	   6,   -4, 	   1,   -6
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte    0,   -6, 	   5,  -11, 	  -6,   -2, 	  -2,   -6
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    1,   -6, 	  -1,   -7, 	  -4,   -7, 	  -1,   -5
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    3,   -9, 	  -7,   -4, 	   5,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,  -11, 	   6,  -11, 	  -6,   -3, 	   0,   -6
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -5,   -9, 	   5,   -4, 	  -7,   -7, 	  -1,   -5
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -3,   -6, 	  -1,   -7, 	   2,   -7, 	  -1,   -5
+.2byte   -4,   -8, 	  -7,   -4, 	   4,   -2, 	   0,   -6
+.2byte   -2,   -6, 	  -7,  -11, 	   4,   -2, 	   0,   -6
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte   -2,   -7, 	  -9,   -5, 	   2,   -2, 	  -2,   -6
+.2byte    0,   -7, 	  -4,   -2, 	   7,   -5, 	  -1,   -7
+.2byte   -2,   -5, 	   1,   -3, 	   7,   -5, 	  -1,   -6
+.2byte   -2,   -5, 	   1,   -3, 	   7,   -5, 	  -1,   -6
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte    4,   -7, 	   3,   -6, 	   0,   -3, 	   0,   -6
+.2byte    3,   -6, 	   7,   -3, 	  -7,   -2, 	  -1,   -5
+.2byte    2,   -5, 	  -2,   -2, 	  -9,   -3, 	  -1,   -6
+.2byte    2,   -5, 	  -2,   -2, 	  -9,   -3, 	  -1,   -6
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    5,   -8, 	  -3,   -5, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -7, 	   4,   -5, 	  -4,   -1, 	  -2,   -5
+.2byte    3,   -6, 	   5,   -4, 	  -4,   -1, 	   0,   -7
+.2byte    3,   -6, 	   5,   -4, 	  -4,   -1, 	   0,   -7
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    2,  -10, 	  -7,   -4, 	   7,   -5, 	  -1,   -5
+.2byte    4,  -11, 	  -1,   -7, 	   1,   -1, 	   0,   -6
+.2byte    3,   -8, 	   4,   -6, 	   4,   -1, 	   0,   -7
+.2byte    3,   -8, 	   4,   -6, 	   4,   -1, 	   0,   -7
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -2, 	  -8,   -8, 	   0,   -6
+.2byte   -2,  -11, 	   6,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte    1,  -11, 	   3,   -9, 	  -8,   -4, 	   0,   -8
+.2byte    1,  -11, 	   3,   -9, 	  -8,   -4, 	   0,   -8
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,  -10, 	   5,   -4, 	  -9,   -5, 	  -1,   -5
+.2byte   -6,  -11, 	  -1,   -7, 	  -3,   -1, 	  -2,   -6
+.2byte   -4,   -8, 	  -5,   -6, 	  -5,   -1, 	  -1,   -7
+.2byte   -4,   -8, 	  -5,   -6, 	  -5,   -1, 	  -1,   -7
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -7,   -8, 	   1,   -5, 	  -6,   -4, 	  -1,   -6
+.2byte   -6,   -7, 	  -6,   -5, 	   2,   -1, 	   0,   -5
+.2byte   -5,   -6, 	  -7,   -4, 	   2,   -1, 	  -2,   -7
+.2byte   -5,   -6, 	  -7,   -4, 	   2,   -1, 	  -2,   -7
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -6,   -7, 	  -5,   -6, 	  -2,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -9,   -3, 	   5,   -2, 	  -1,   -5
+.2byte   -4,   -5, 	   0,   -2, 	   7,   -3, 	  -1,   -6
+.2byte   -4,   -5, 	   0,   -2, 	   7,   -3, 	  -1,   -6
+.2byte   -4,   -6, 	  -5,   -3, 	   4,    0, 	  -1,   -4
+.2byte   -4,   -5, 	  -5,   -3, 	   4,    1, 	  -1,   -4
+.2byte   -1,   -9, 	  -3,  -16, 	   1,  -16, 	  -1,  -10
+.2byte    2,   -9, 	   2,  -17, 	  -2,  -15, 	  -1,   -7
+.2byte    3,  -10, 	  -1,  -18, 	   0,  -16, 	  -2,   -6
+.2byte    2,  -12, 	  -3,  -17, 	   4,  -15, 	  -1,   -7
+.2byte   -1,  -12, 	   6,  -12, 	  -8,  -12, 	  -1,   -7
+.2byte   -3,  -12, 	   2,  -17, 	  -5,  -15, 	   0,   -7
+.2byte   -5,  -10, 	  -1,  -18, 	  -2,  -16, 	   0,   -6
+.2byte   -3,   -9, 	  -3,  -17, 	   1,  -15, 	   0,   -7
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte   -2,   -7, 	  -9,   -5, 	   2,   -2, 	  -2,   -6
+.2byte    0,   -7, 	  -4,   -2, 	   7,   -5, 	  -1,   -7
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte    4,   -7, 	   3,   -6, 	   0,   -3, 	   0,   -6
+.2byte    3,   -6, 	   7,   -3, 	  -7,   -2, 	  -1,   -5
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    5,   -8, 	  -3,   -5, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -7, 	   4,   -5, 	  -4,   -1, 	  -2,   -5
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    2,  -10, 	  -7,   -4, 	   7,   -5, 	  -1,   -5
+.2byte    4,  -11, 	  -1,   -7, 	   1,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -2, 	  -8,   -8, 	   0,   -6
+.2byte   -2,  -11, 	   6,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -4,  -10, 	   5,   -4, 	  -9,   -5, 	  -1,   -5
+.2byte   -6,  -11, 	  -1,   -7, 	  -3,   -1, 	  -2,   -6
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -7,   -8, 	   1,   -5, 	  -6,   -4, 	  -1,   -6
+.2byte   -6,   -7, 	  -6,   -5, 	   2,   -1, 	   0,   -5
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -6,   -7, 	  -5,   -6, 	  -2,   -3, 	  -2,   -6
+.2byte   -5,   -6, 	  -9,   -3, 	   5,   -2, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,  -10, 	   5,   -3, 	   0,   -5
+.2byte    0,   -6, 	   5,  -11, 	  -6,   -2, 	  -2,   -6
+.2byte    1,   -6, 	  -1,   -7, 	  -4,   -7, 	  -1,   -5
+.2byte    3,   -9, 	  -7,   -4, 	   5,   -7, 	  -1,   -5
+.2byte   -2,  -10, 	   5,  -10, 	  -7,   -2, 	  -1,   -5
+.2byte   -5,   -9, 	   5,   -4, 	  -7,   -7, 	  -1,   -5
+.2byte   -3,   -6, 	  -1,   -7, 	   2,   -7, 	  -1,   -5
+.2byte   -2,   -6, 	  -7,  -11, 	   4,   -2, 	   0,   -6
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte    0,   -8, 	  -6,   -8, 	   7,  -15, 	  -1,   -8
+.2byte    0,   -6, 	  -7,  -11, 	   6,   -4, 	   1,   -6
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte    5,   -8, 	  10,   -6, 	  -7,  -11, 	   1,   -6
+.2byte    0,   -7, 	   5,  -12, 	  -6,   -3, 	  -2,   -7
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    0,   -7, 	   4,   -8, 	  -8,   -7, 	  -2,   -6
+.2byte    1,   -7, 	  -1,   -8, 	  -4,   -8, 	  -1,   -6
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    1,   -6, 	   2,   -5, 	  -3,   -6, 	  -3,   -5
+.2byte    3,  -10, 	  -7,   -5, 	   5,   -8, 	  -1,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,  -10, 	   4,   -7, 	  -7,   -8, 	   0,   -5
+.2byte   -1,  -11, 	   6,  -11, 	  -6,   -3, 	   0,   -6
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -3,   -6, 	  -4,   -5, 	   1,   -6, 	   1,   -5
+.2byte   -5,  -10, 	   5,   -5, 	  -7,   -8, 	  -1,   -6
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -2,   -7, 	  -6,   -8, 	   6,   -7, 	   0,   -6
+.2byte   -3,   -7, 	  -1,   -8, 	   2,   -8, 	  -1,   -6
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -7,   -8, 	 -12,   -6, 	   5,  -11, 	  -3,   -6
+.2byte   -1,   -7, 	  -6,  -12, 	   5,   -3, 	   1,   -7
+.2byte   -1,   -5, 	  -8,  -10, 	   5,   -3, 	   0,   -5
+.2byte   -2,   -6, 	  -7,  -11, 	   4,   -2, 	   0,   -6
+.2byte   -3,   -6, 	  -1,   -7, 	   2,   -7, 	  -1,   -5
+.2byte   -5,   -9, 	   5,   -4, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -10, 	   6,  -10, 	  -6,   -2, 	   0,   -5
+.2byte    4,   -9, 	  -6,   -4, 	   6,   -7, 	   0,   -5
+.2byte    2,   -6, 	   0,   -7, 	  -3,   -7, 	   0,   -5
+.2byte    0,   -6, 	   5,  -11, 	  -6,   -2, 	  -2,   -6
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte   -5,   -8, 	  -8,   -4, 	   3,   -2, 	  -1,   -6
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -5,  -12, 	   4,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte    3,  -12, 	  -6,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -2, 	  -1,   -6
+.2byte   -4,   -6, 	  -3,    2, 	   0,   -9, 	  -1,   -4
+.2byte   -4,   -6, 	  -3,    2, 	   1,   -8, 	  -1,   -4
+.2byte    3,   -6, 	   2,    2, 	  -1,   -9, 	   0,   -4
+.2byte    3,   -6, 	   2,    2, 	  -2,   -8, 	   0,   -4
+.2byte   -4,   -6, 	  -3,    2, 	   0,   -9, 	  -1,   -4
+.2byte    0,   -8, 	   3,   -6, 	   5,   -9, 	   1,   -5
+.2byte    5,   -4, 	   0,   -2, 	   2,   -4, 	   1,   -5
+.2byte    4,   -6, 	   0,   -2, 	   2,   -3, 	   1,   -5
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -6, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	   8,   -9, 	 -10,   -9, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -11, 	  -9,  -14, 	   7,  -14, 	  -1,   -8
+.2byte   -3,   -5, 	  -7,   -5, 	  -2,   -2, 	  -1,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -9, 	  -8,  -16, 	   8,   -4, 	   0,   -7
+.2byte    3,   -9, 	   5,   -3, 	  -2,   -7, 	   0,   -6
+.2byte   -4,  -12, 	   5,  -16, 	  -9,   -6, 	  -1,   -7
+.2byte   -4,  -12, 	   5,  -16, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,   -4, 	  -7,   -3, 	   5,   -3, 	  -1,   -6
+.2byte   -1,   -4, 	  -7,   -3, 	   5,   -3, 	  -1,   -6
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte    1,   -9, 	  -7,  -11, 	   0,   -5, 	   1,   -7
+.2byte    1,   -8, 	  -4,  -14, 	  -2,   -7, 	   1,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -2, 	  -9,   -2, 	  -1,   -6
+.2byte   -1,   -6, 	   6,   -1, 	  -8,   -1, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -2, 	   7,   -2, 	  -1,   -7
+.2byte   -1,  -11, 	  -9,  -14, 	   7,  -14, 	  -1,   -8
+.2byte   -1,   -5, 	  -4,   -3, 	   2,   -3, 	  -1,   -8
+.2byte   -6,   -9, 	  -2,   -6, 	  -1,   -1, 	   0,   -5
+.2byte   -6,   -2, 	   0,   -2, 	   1,   -1, 	  -2,   -4
+.2byte    4,   -9, 	   0,   -6, 	  -1,   -1, 	  -2,   -5
+.2byte    4,   -2, 	  -2,   -2, 	  -3,   -1, 	   0,   -4
+.2byte   -1,  -12, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,   -7, 	   7,   -8, 	  -9,   -8, 	  -1,   -5
+.2byte   -3,   -6, 	   2,   -4, 	   5,   -2, 	   0,   -5
+.2byte   -1,   -7, 	  -2,   -5, 	   7,   -3, 	   1,   -6
+.2byte   -5,   -5, 	  -4,   -3, 	   3,   -1, 	  -2,   -4
+.2byte   -1,   -7, 	   3,   -5, 	   7,   -3, 	   1,   -6
+.2byte   -4,   -5, 	   1,   -2, 	   3,   -1, 	   0,   -4
+.2byte    2,   -6, 	  -3,   -4, 	  -6,   -2, 	  -1,   -5
+.2byte    0,   -7, 	   1,   -5, 	  -8,   -3, 	  -2,   -6
+.2byte    4,   -5, 	   3,   -3, 	  -4,   -1, 	   1,   -4
+.2byte    0,   -7, 	  -4,   -5, 	  -8,   -3, 	  -2,   -6
+.2byte    3,   -5, 	  -2,   -2, 	  -4,   -1, 	  -1,   -4
+.2byte    1,   -7, 	  -4,  -12, 	   6,   -7, 	  -2,   -6
+.2byte   -4,   -6, 	  -3,    2, 	   0,   -9, 	  -1,   -4
+.2byte   -4,   -6, 	  -3,    2, 	   1,   -8, 	  -1,   -4
+.2byte    3,   -6, 	   2,    2, 	  -1,   -9, 	   0,   -4
+.2byte    3,   -6, 	   2,    2, 	  -2,   -8, 	   0,   -4
+.2byte   -4,   -6, 	  -3,    2, 	   0,   -9, 	  -1,   -4
+.2byte   -4,   -6, 	  -3,    2, 	   1,   -8, 	  -1,   -4
+.2byte    3,   -6, 	   2,    2, 	  -1,   -9, 	   0,   -4
+.2byte    3,   -6, 	   2,    2, 	  -2,   -8, 	   0,   -4
+sMachopAnimTable1:
+.4byte sMachopAnims_1_1
+.4byte sMachopAnims_1_2
+.4byte sMachopAnims_1_3
+.4byte sMachopAnims_1_4
+.4byte sMachopAnims_1_5
+.4byte sMachopAnims_1_6
+.4byte sMachopAnims_1_7
+.4byte sMachopAnims_1_8
+sMachopAnimTable2:
+.4byte sMachopAnims_2_1
+.4byte sMachopAnims_2_2
+.4byte sMachopAnims_2_3
+.4byte sMachopAnims_2_4
+.4byte sMachopAnims_2_5
+.4byte sMachopAnims_2_6
+.4byte sMachopAnims_2_7
+.4byte sMachopAnims_2_8
+sMachopAnimTable3:
+.4byte sMachopAnims_3_1
+.4byte sMachopAnims_3_2
+.4byte sMachopAnims_3_3
+.4byte sMachopAnims_3_4
+.4byte sMachopAnims_3_5
+.4byte sMachopAnims_3_6
+.4byte sMachopAnims_3_7
+.4byte sMachopAnims_3_8
+sMachopAnimTable4:
+.4byte sMachopAnims_4_1
+.4byte sMachopAnims_4_2
+.4byte sMachopAnims_4_3
+.4byte sMachopAnims_4_4
+.4byte sMachopAnims_4_5
+.4byte sMachopAnims_4_6
+.4byte sMachopAnims_4_7
+.4byte sMachopAnims_4_8
+sMachopAnimTable5:
+.4byte sMachopAnims_5_1
+.4byte sMachopAnims_5_2
+.4byte sMachopAnims_5_3
+.4byte sMachopAnims_5_4
+.4byte sMachopAnims_5_5
+.4byte sMachopAnims_5_6
+.4byte sMachopAnims_5_7
+.4byte sMachopAnims_5_8
+sMachopAnimTable6:
+.4byte sMachopAnims_6_1
+.4byte sMachopAnims_6_1
+.4byte sMachopAnims_6_1
+.4byte sMachopAnims_6_1
+.4byte sMachopAnims_6_1
+.4byte sMachopAnims_6_1
+.4byte sMachopAnims_6_1
+.4byte sMachopAnims_6_1
+sMachopAnimTable7:
+.4byte sMachopAnims_7_1
+.4byte sMachopAnims_7_2
+.4byte sMachopAnims_7_3
+.4byte sMachopAnims_7_4
+.4byte sMachopAnims_7_5
+.4byte sMachopAnims_7_6
+.4byte sMachopAnims_7_7
+.4byte sMachopAnims_7_8
+sMachopAnimTable8:
+.4byte sMachopAnims_8_1
+.4byte sMachopAnims_8_2
+.4byte sMachopAnims_8_3
+.4byte sMachopAnims_8_4
+.4byte sMachopAnims_8_5
+.4byte sMachopAnims_8_6
+.4byte sMachopAnims_8_7
+.4byte sMachopAnims_8_8
+sMachopAnimTable9:
+.4byte sMachopAnims_9_1
+.4byte sMachopAnims_9_2
+.4byte sMachopAnims_9_3
+.4byte sMachopAnims_9_4
+.4byte sMachopAnims_9_5
+.4byte sMachopAnims_9_6
+.4byte sMachopAnims_9_7
+.4byte sMachopAnims_9_8
+sMachopAnimTable10:
+.4byte sMachopAnims_10_1
+.4byte sMachopAnims_10_2
+.4byte sMachopAnims_10_3
+.4byte sMachopAnims_10_4
+.4byte sMachopAnims_10_5
+.4byte sMachopAnims_10_6
+.4byte sMachopAnims_10_7
+.4byte sMachopAnims_10_8
+sMachopAnimTable11:
+.4byte sMachopAnims_11_1
+.4byte sMachopAnims_11_2
+.4byte sMachopAnims_11_3
+.4byte sMachopAnims_11_4
+.4byte sMachopAnims_11_5
+.4byte sMachopAnims_11_6
+.4byte sMachopAnims_11_7
+.4byte sMachopAnims_11_8
+sMachopAnimTable12:
+.4byte sMachopAnims_12_1
+.4byte sMachopAnims_12_2
+.4byte sMachopAnims_12_3
+.4byte sMachopAnims_12_4
+.4byte sMachopAnims_12_5
+.4byte sMachopAnims_12_6
+.4byte sMachopAnims_12_7
+.4byte sMachopAnims_12_8
+sMachopAnimTable13:
+.4byte sMachopAnims_13_1
+.4byte sMachopAnims_13_2
+.4byte sMachopAnims_13_3
+.4byte sMachopAnims_13_4
+.4byte sMachopAnims_13_5
+.4byte sMachopAnims_13_6
+.4byte sMachopAnims_13_7
+.4byte sMachopAnims_13_8
+sMachopAnimTable14:
+.4byte sMachopAnims_14_1
+.4byte sMachopAnims_14_2
+.4byte sMachopAnims_14_3
+.4byte sMachopAnims_14_4
+.4byte sMachopAnims_14_5
+.4byte sMachopAnims_14_6
+.4byte sMachopAnims_14_7
+.4byte sMachopAnims_14_8
+sMachopAnimTable15:
+.4byte sMachopAnims_15_1
+.4byte sMachopAnims_15_2
+.4byte sMachopAnims_15_3
+.4byte sMachopAnims_15_4
+.4byte sMachopAnims_15_5
+.4byte sMachopAnims_15_6
+.4byte sMachopAnims_15_7
+.4byte sMachopAnims_15_8
+sMachopAnimTable16:
+.4byte sMachopAnims_16_1
+.4byte sMachopAnims_16_2
+.4byte sMachopAnims_16_3
+.4byte sMachopAnims_16_4
+.4byte sMachopAnims_16_5
+.4byte sMachopAnims_16_6
+.4byte sMachopAnims_16_7
+.4byte sMachopAnims_16_8
+sMachopAnimTable17:
+.4byte sMachopAnims_17_1
+.4byte sMachopAnims_17_2
+.4byte sMachopAnims_17_3
+.4byte sMachopAnims_17_4
+.4byte sMachopAnims_17_5
+.4byte sMachopAnims_17_6
+.4byte sMachopAnims_17_7
+.4byte sMachopAnims_17_8
+sMachopAnimTable18:
+.4byte sMachopAnims_18_1
+.4byte sMachopAnims_18_2
+.4byte sMachopAnims_18_3
+.4byte sMachopAnims_18_4
+.4byte sMachopAnims_18_5
+.4byte sMachopAnims_18_6
+.4byte sMachopAnims_18_7
+.4byte sMachopAnims_18_8
+sMachopAnimTable19:
+.4byte sMachopAnims_19_1
+.4byte sMachopAnims_19_2
+.4byte sMachopAnims_19_3
+.4byte sMachopAnims_19_4
+.4byte sMachopAnims_19_5
+.4byte sMachopAnims_19_6
+.4byte sMachopAnims_19_7
+.4byte sMachopAnims_19_8
+sMachopAnimTable20:
+.4byte sMachopAnims_20_1
+.4byte sMachopAnims_20_2
+.4byte sMachopAnims_20_3
+.4byte sMachopAnims_20_4
+.4byte sMachopAnims_20_5
+.4byte sMachopAnims_20_6
+.4byte sMachopAnims_20_7
+.4byte sMachopAnims_20_8
+sMachopAnimTable21:
+.4byte sMachopAnims_21_1
+.4byte sMachopAnims_21_2
+.4byte sMachopAnims_21_3
+.4byte sMachopAnims_21_4
+.4byte sMachopAnims_21_5
+.4byte sMachopAnims_21_6
+.4byte sMachopAnims_21_7
+.4byte sMachopAnims_21_8
+sMachopAnimTable22:
+.4byte sMachopAnims_22_1
+.4byte sMachopAnims_22_2
+.4byte sMachopAnims_22_3
+.4byte sMachopAnims_22_4
+.4byte sMachopAnims_22_5
+.4byte sMachopAnims_22_6
+.4byte sMachopAnims_22_7
+.4byte sMachopAnims_22_8
+sMachopAnimTable23:
+.4byte sMachopAnims_23_1
+.4byte sMachopAnims_23_2
+.4byte sMachopAnims_23_3
+.4byte sMachopAnims_23_4
+.4byte sMachopAnims_23_5
+.4byte sMachopAnims_23_6
+.4byte sMachopAnims_23_7
+.4byte sMachopAnims_23_8
+sMachopAnimTable24:
+.4byte sMachopAnims_24_1
+.4byte sMachopAnims_24_2
+.4byte sMachopAnims_24_3
+.4byte sMachopAnims_24_4
+.4byte sMachopAnims_24_5
+.4byte sMachopAnims_24_6
+.4byte sMachopAnims_24_7
+.4byte sMachopAnims_24_8
+sMachopAnimTable25:
+.4byte sMachopAnims_25_1
+.4byte sMachopAnims_25_2
+.4byte sMachopAnims_25_3
+.4byte sMachopAnims_25_4
+.4byte sMachopAnims_25_5
+.4byte sMachopAnims_25_6
+.4byte sMachopAnims_25_7
+.4byte sMachopAnims_25_8
+sMachopAnimTable26:
+.4byte sMachopAnims_26_1
+.4byte sMachopAnims_26_2
+.4byte sMachopAnims_26_3
+.4byte sMachopAnims_26_4
+.4byte sMachopAnims_26_5
+.4byte sMachopAnims_26_6
+.4byte sMachopAnims_26_7
+.4byte sMachopAnims_26_8
+sMachopAnimTable27:
+.4byte sMachopAnims_27_1
+.4byte sMachopAnims_27_1
+.4byte sMachopAnims_27_1
+.4byte sMachopAnims_27_1
+.4byte sMachopAnims_27_1
+.4byte sMachopAnims_27_1
+.4byte sMachopAnims_27_1
+.4byte sMachopAnims_27_1
+sMachopAnimTable28:
+.4byte sMachopAnims_28_1
+.4byte sMachopAnims_28_2
+.4byte sMachopAnims_28_3
+.4byte sMachopAnims_28_4
+.4byte sMachopAnims_28_5
+.4byte sMachopAnims_28_6
+.4byte sMachopAnims_28_7
+.4byte sMachopAnims_28_8
+sAxAnimationsMachop:
+.4byte sMachopAnimTable1
+.4byte sMachopAnimTable2
+.4byte sMachopAnimTable3
+.4byte sMachopAnimTable4
+.4byte sMachopAnimTable5
+.4byte sMachopAnimTable6
+.4byte sMachopAnimTable7
+.4byte sMachopAnimTable8
+.4byte sMachopAnimTable9
+.4byte sMachopAnimTable10
+.4byte sMachopAnimTable11
+.4byte sMachopAnimTable12
+.4byte sMachopAnimTable13
+.4byte sMachopAnimTable14
+.4byte sMachopAnimTable15
+.4byte sMachopAnimTable16
+.4byte sMachopAnimTable17
+.4byte sMachopAnimTable18
+.4byte sMachopAnimTable19
+.4byte sMachopAnimTable20
+.4byte sMachopAnimTable21
+.4byte sMachopAnimTable22
+.4byte sMachopAnimTable23
+.4byte sMachopAnimTable24
+.4byte sMachopAnimTable25
+.4byte sMachopAnimTable26
+.4byte sMachopAnimTable27
+.4byte sMachopAnimTable28
+sAxSpritesMachop:
+.4byte sMachopSprites1
+.4byte sMachopSprites2
+.4byte sMachopSprites3
+.4byte sMachopSprites4
+.4byte sMachopSprites5
+.4byte sMachopSprites6
+.4byte sMachopSprites7
+.4byte sMachopSprites8
+.4byte sMachopSprites9
+.4byte sMachopSprites10
+.4byte sMachopSprites11
+.4byte sMachopSprites12
+.4byte sMachopSprites13
+.4byte sMachopSprites14
+.4byte sMachopSprites15
+.4byte sMachopSprites16
+.4byte sMachopSprites17
+.4byte sMachopSprites18
+.4byte sMachopSprites19
+.4byte sMachopSprites20
+.4byte sMachopSprites21
+.4byte sMachopSprites22
+.4byte sMachopSprites23
+.4byte sMachopSprites24
+.4byte sMachopSprites25
+.4byte sMachopSprites26
+.4byte sMachopSprites27
+.4byte sMachopSprites28
+.4byte sMachopSprites29
+.4byte sMachopSprites30
+.4byte sMachopSprites31
+.4byte sMachopSprites32
+.4byte sMachopSprites33
+.4byte sMachopSprites34
+.4byte sMachopSprites35
+.4byte sMachopSprites36
+.4byte sMachopSprites37
+.4byte sMachopSprites38
+.4byte sMachopSprites39
+.4byte sMachopSprites40
+.4byte sMachopSprites41
+.4byte sMachopSprites42
+.4byte sMachopSprites43
+.4byte sMachopSprites44
+.4byte sMachopSprites45
+.4byte sMachopSprites46
+.4byte sMachopSprites47
+.4byte sMachopSprites48
+.4byte sMachopSprites49
+.4byte sMachopSprites50
+.4byte sMachopSprites51
+.4byte sMachopSprites52
+.4byte sMachopSprites53
+.4byte sMachopSprites54
+.4byte sMachopSprites55
+.4byte sMachopSprites56
+.4byte sMachopSprites57
+.4byte sMachopSprites58
+.4byte sMachopSprites59
+.4byte sMachopSprites60
+.4byte sMachopSprites61
+.4byte sMachopSprites62
+.4byte sMachopSprites63
+.4byte sMachopSprites64
+.4byte sMachopSprites65
+.4byte sMachopSprites66
+.4byte sMachopSprites67
+.4byte sMachopSprites68
+.4byte sMachopSprites69
+.4byte sMachopSprites70
+.4byte sMachopSprites71
+.4byte sMachopSprites72
+.4byte sMachopSprites73
+.4byte sMachopSprites74
+.4byte sMachopSprites75
+.4byte sMachopSprites76
+.4byte sMachopSprites77
+.4byte sMachopSprites78
+.4byte sMachopSprites79
+.4byte sMachopSprites80
+.4byte sMachopSprites81
+.4byte sMachopSprites82
+sAxMainMachop:
+ax_main sAxPosesMachop, sAxAnimationsMachop, 28, sAxSpritesMachop, sAxPositionsMachop

--- a/data/ax/magby.inc
+++ b/data/ax/magby.inc
@@ -1,0 +1,2808 @@
+.global gAxMagby
+gAxMagby:
+ax_siro sAxMainMagby
+sMagbyPose1:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose2:
+ax_pose 1, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose3:
+ax_pose 2, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose4:
+ax_pose 3, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose5:
+ax_pose 4, 0x81eb, 0x90f9, 0x0c00
+ax_pose_terminator
+sMagbyPose6:
+ax_pose 5, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose8:
+ax_pose 7, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose13:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose14:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose15:
+ax_pose 14, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose16:
+ax_pose 9, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose17:
+ax_pose 10, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose18:
+ax_pose 11, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose19:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose20:
+ax_pose 7, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose21:
+ax_pose 8, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose22:
+ax_pose 3, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose23:
+ax_pose 4, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sMagbyPose24:
+ax_pose 5, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose25:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose26:
+ax_pose 1, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose27:
+ax_pose 2, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose28:
+ax_pose 15, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose29:
+ax_pose 3, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose30:
+ax_pose 4, 0x81eb, 0x90f9, 0x0c00
+ax_pose_terminator
+sMagbyPose31:
+ax_pose 5, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose32:
+ax_pose 16, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sMagbyPose33:
+ax_pose 6, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose34:
+ax_pose 7, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose35:
+ax_pose 8, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose36:
+ax_pose 17, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sMagbyPose37:
+ax_pose 9, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose38:
+ax_pose 10, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose39:
+ax_pose 11, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose40:
+ax_pose 18, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose41:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose42:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose43:
+ax_pose 14, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose44:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose45:
+ax_pose 9, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose46:
+ax_pose 10, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose47:
+ax_pose 11, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose48:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose49:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose50:
+ax_pose 7, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose51:
+ax_pose 8, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose52:
+ax_pose 17, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagbyPose53:
+ax_pose 3, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose54:
+ax_pose 4, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sMagbyPose55:
+ax_pose 5, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose56:
+ax_pose 16, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagbyPose57:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose58:
+ax_pose 15, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose59:
+ax_pose 20, 0x81e6, 0x80f8, 0x0c00
+ax_pose 21, 0x01e6, 0x80f0, 0x0c08
+ax_pose_terminator
+sMagbyPose60:
+ax_pose 21, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose61:
+ax_pose 3, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose62:
+ax_pose 16, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sMagbyPose63:
+ax_pose 22, 0x01e9, 0x90f0, 0x0c00
+ax_pose 23, 0x01e5, 0x90f0, 0x0c10
+ax_pose_terminator
+sMagbyPose64:
+ax_pose 23, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose65:
+ax_pose 6, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose66:
+ax_pose 17, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sMagbyPose67:
+ax_pose 24, 0x01e6, 0x90ef, 0x0c00
+ax_pose 25, 0x41ee, 0x90ef, 0x0c10
+ax_pose_terminator
+sMagbyPose68:
+ax_pose 24, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sMagbyPose69:
+ax_pose 9, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose70:
+ax_pose 18, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose71:
+ax_pose 26, 0x01e7, 0x90f1, 0x0c00
+ax_pose 27, 0x01e6, 0x90f2, 0x0c10
+ax_pose_terminator
+sMagbyPose72:
+ax_pose 26, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose73:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose74:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose75:
+ax_pose 28, 0x81e6, 0x80fd, 0x0c00
+ax_pose 29, 0x01e6, 0x80f0, 0x0c08
+ax_pose_terminator
+sMagbyPose76:
+ax_pose 29, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose77:
+ax_pose 19, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose78:
+ax_pose 9, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose79:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose80:
+ax_pose 26, 0x01e7, 0x80f0, 0x0c00
+ax_pose 27, 0x01e6, 0x80ef, 0x0c10
+ax_pose_terminator
+sMagbyPose81:
+ax_pose 26, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose82:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose83:
+ax_pose 17, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagbyPose84:
+ax_pose 24, 0x01e6, 0x80f2, 0x0c00
+ax_pose 25, 0x41ee, 0x80f2, 0x0c10
+ax_pose_terminator
+sMagbyPose85:
+ax_pose 24, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagbyPose86:
+ax_pose 3, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose87:
+ax_pose 16, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagbyPose88:
+ax_pose 22, 0x01e9, 0x80f1, 0x0c00
+ax_pose 23, 0x01e5, 0x80f1, 0x0c10
+ax_pose_terminator
+sMagbyPose89:
+ax_pose 23, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagbyPose90:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose91:
+ax_pose 30, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose92:
+ax_pose 31, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose93:
+ax_pose 3, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose94:
+ax_pose 32, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose95:
+ax_pose 33, 0x01e3, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose96:
+ax_pose 6, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose97:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose98:
+ax_pose 35, 0x01e3, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose99:
+ax_pose 9, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose100:
+ax_pose 36, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose101:
+ax_pose 37, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose102:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose103:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose104:
+ax_pose 39, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose105:
+ax_pose 9, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose106:
+ax_pose 36, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose107:
+ax_pose 37, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose108:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose109:
+ax_pose 34, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose110:
+ax_pose 35, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose111:
+ax_pose 3, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose112:
+ax_pose 32, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose113:
+ax_pose 33, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose114:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose115:
+ax_pose 3, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose116:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose117:
+ax_pose 9, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose118:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose119:
+ax_pose 9, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose120:
+ax_pose 6, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose121:
+ax_pose 3, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose122:
+ax_pose 40, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagbyPose123:
+ax_pose 41, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagbyPose124:
+ax_pose 42, 0x01e3, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagbyPose125:
+ax_pose 43, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sMagbyPose126:
+ax_pose 44, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose127:
+ax_pose 45, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sMagbyPose128:
+ax_pose 46, 0x01e3, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagbyPose129:
+ax_pose 45, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagbyPose130:
+ax_pose 44, 0x01e4, 0x80f5, 0x0c00
+ax_pose_terminator
+sMagbyPose131:
+ax_pose 43, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sMagbyPose132:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose133:
+ax_pose 30, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose134:
+ax_pose 3, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose135:
+ax_pose 32, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose136:
+ax_pose 6, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose137:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose138:
+ax_pose 9, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose139:
+ax_pose 36, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose140:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose141:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose142:
+ax_pose 9, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose143:
+ax_pose 36, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagbyPose144:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose145:
+ax_pose 34, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose146:
+ax_pose 3, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose147:
+ax_pose 32, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose148:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose149:
+ax_pose 33, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose150:
+ax_pose 35, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sMagbyPose151:
+ax_pose 37, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagbyPose152:
+ax_pose 39, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose153:
+ax_pose 37, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose154:
+ax_pose 35, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose155:
+ax_pose 33, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose156:
+ax_pose 30, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose157:
+ax_pose 32, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose158:
+ax_pose 34, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose159:
+ax_pose 36, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose160:
+ax_pose 38, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose161:
+ax_pose 36, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagbyPose162:
+ax_pose 34, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose163:
+ax_pose 32, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose164:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose165:
+ax_pose 30, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose166:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose167:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose168:
+ax_pose 32, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose169:
+ax_pose 33, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose170:
+ax_pose 6, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sMagbyPose171:
+ax_pose 34, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose172:
+ax_pose 35, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose173:
+ax_pose 9, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sMagbyPose174:
+ax_pose 36, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose175:
+ax_pose 37, 0x01e9, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose176:
+ax_pose 12, 0x01ec, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose177:
+ax_pose 38, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose178:
+ax_pose 39, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose179:
+ax_pose 9, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sMagbyPose180:
+ax_pose 36, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagbyPose181:
+ax_pose 37, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose182:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose183:
+ax_pose 34, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose184:
+ax_pose 35, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose185:
+ax_pose 3, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sMagbyPose186:
+ax_pose 32, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagbyPose187:
+ax_pose 33, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose188:
+ax_pose 31, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose189:
+ax_pose 33, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagbyPose190:
+ax_pose 35, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose191:
+ax_pose 37, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose192:
+ax_pose 39, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagbyPose193:
+ax_pose 37, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose194:
+ax_pose 35, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sMagbyPose195:
+ax_pose 33, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sMagbyPose196:
+ax_pose 0, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose197:
+ax_pose 3, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose198:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose199:
+ax_pose 9, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose200:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagbyPose201:
+ax_pose 9, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose202:
+ax_pose 6, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagbyPose203:
+ax_pose 3, 0x01eb, 0x90eb, 0x0c00
+ax_pose_terminator
+.align 2
+sMagbyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 29, 0, 19, 0, 19,
+ax_anim 2, 1, 29, 1, 19, 1, 19,
+ax_anim 2, 0, 29, 0, 19, 0, 19,
+ax_anim 2, 0, 29, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMagbyAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 6, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 25, 20, 19, 20, 19,
+ax_anim 2, 1, 25, 21, 18, 21, 18,
+ax_anim 2, 0, 25, 20, 19, 20, 19,
+ax_anim 2, 0, 25, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sMagbyAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 6, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, -2, 0, 0,
+ax_anim 1, 2, 34, 4, -2, 4, 0,
+ax_anim 1, 0, 34, 10, -1, 10, 0,
+ax_anim 2, 0, 30, 20, 0, 20, 0,
+ax_anim 2, 1, 30, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 20, 0, 20, 0,
+ax_anim 2, 0, 30, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMagbyAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 38, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 2, 0, 33, 20, -23, 20, -23,
+ax_anim 2, 1, 33, 21, -22, 21, -22,
+ax_anim 2, 0, 33, 20, -23, 20, -23,
+ax_anim 2, 0, 33, 21, -22, 21, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sMagbyAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 6, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 46, 0, -21, 0, -21,
+ax_anim 2, 1, 46, 1, -21, 1, -21,
+ax_anim 2, 0, 46, 0, -21, 0, -21,
+ax_anim 2, 0, 46, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sMagbyAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 6, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 46, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 2, 0, 50, -20, -23, -20, -23,
+ax_anim 2, 1, 50, -21, -22, -21, -22,
+ax_anim 2, 0, 50, -20, -23, -20, -23,
+ax_anim 2, 0, 50, -21, -22, -21, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sMagbyAnims_2_7:
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 6, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, -2, 0, 0,
+ax_anim 1, 2, 50, -4, -2, -4, 0,
+ax_anim 1, 0, 50, -10, -1, -10, 0,
+ax_anim 2, 0, 54, -20, 0, -20, 0,
+ax_anim 2, 1, 54, -20, 1, -20, 1,
+ax_anim 2, 0, 54, -20, 0, -20, 0,
+ax_anim 2, 0, 54, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sMagbyAnims_2_8:
+ax_anim 2, 0, 55, 3, -1, 3, -1,
+ax_anim 6, 0, 55, 4, -2, 4, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 26, -20, 20, -20, 19,
+ax_anim 2, 1, 26, -21, 19, -21, 18,
+ax_anim 2, 0, 26, -20, 20, -20, 19,
+ax_anim 2, 0, 26, -21, 19, -21, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMagbyAnims_3_1:
+ax_anim 2, 0, 86, 0, -2, 0, -2,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 6, 0, 86, 0, -5, 0, -5,
+ax_anim 1, 2, 57, 0, -1, 0, -1,
+ax_anim 1, 0, 57, 0, 7, 0, 7,
+ax_anim 2, 0, 58, 0, 19, 0, 19,
+ax_anim 2, 1, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sMagbyAnims_3_2:
+ax_anim 2, 0, 65, -2, -2, -2, -2,
+ax_anim 2, 0, 65, -4, -4, -4, -4,
+ax_anim 6, 0, 65, -5, -5, -5, -5,
+ax_anim 1, 2, 61, -1, -1, -1, -1,
+ax_anim 1, 0, 61, 7, 7, 7, 7,
+ax_anim 2, 0, 62, 16, 19, 16, 19,
+ax_anim 2, 1, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 63, 16, 19, 16, 19,
+ax_anim 2, 0, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 63, 16, 19, 16, 19,
+ax_anim 2, 0, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 63, 16, 19, 16, 19,
+ax_anim 2, 0, 60, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sMagbyAnims_3_3:
+ax_anim 2, 0, 69, -2, 0, -2, 0,
+ax_anim 2, 0, 69, -4, 0, -4, 0,
+ax_anim 6, 0, 69, -5, 0, -5, 0,
+ax_anim 1, 2, 65, -1, 0, -1, 0,
+ax_anim 1, 0, 65, 7, 0, 7, 0,
+ax_anim 2, 0, 66, 16, 0, 16, 0,
+ax_anim 2, 1, 67, 16, 1, 16, 1,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 0, 67, 16, 1, 16, 1,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 0, 67, 16, 1, 16, 1,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sMagbyAnims_3_4:
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 2, 0, 76, -4, 4, -4, 4,
+ax_anim 6, 0, 76, -5, 5, -5, 5,
+ax_anim 1, 2, 69, -1, 1, -1, 1,
+ax_anim 1, 0, 69, 7, -7, 7, -7,
+ax_anim 2, 0, 70, 13, -14, 13, -14,
+ax_anim 2, 1, 71, 14, -13, 14, -13,
+ax_anim 2, 0, 71, 13, -14, 13, -14,
+ax_anim 2, 0, 71, 14, -13, 14, -13,
+ax_anim 2, 0, 71, 13, -14, 13, -14,
+ax_anim 2, 0, 71, 14, -13, 14, -13,
+ax_anim 2, 0, 71, 13, -14, 13, -14,
+ax_anim 2, 0, 68, 10, -10, 10, -10,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sMagbyAnims_3_5:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 6, 0, 73, 0, 5, 0, 5,
+ax_anim 1, 2, 73, 0, 1, 0, 1,
+ax_anim 1, 0, 73, 0, -5, 0, -5,
+ax_anim 2, 0, 74, 0, -13, 0, -13,
+ax_anim 2, 1, 75, 1, -13, 1, -13,
+ax_anim 2, 0, 75, 0, -13, 0, -13,
+ax_anim 2, 0, 75, 1, -13, 1, -13,
+ax_anim 2, 0, 75, 0, -13, 0, -13,
+ax_anim 2, 0, 75, 1, -13, 1, -13,
+ax_anim 2, 0, 75, 0, -13, 0, -13,
+ax_anim 2, 0, 72, 0, -8, 0, -8,
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim_terminator
+sMagbyAnims_3_6:
+ax_anim 2, 0, 73, 2, 2, 2, 2,
+ax_anim 2, 0, 73, 4, 4, 4, 4,
+ax_anim 6, 0, 73, 5, 5, 5, 5,
+ax_anim 1, 2, 78, 1, 1, 1, 1,
+ax_anim 1, 0, 78, -7, -7, -7, -7,
+ax_anim 2, 0, 79, -13, -14, -13, -14,
+ax_anim 2, 1, 80, -14, -13, -14, -13,
+ax_anim 2, 0, 80, -13, -14, -13, -14,
+ax_anim 2, 0, 80, -14, -13, -14, -13,
+ax_anim 2, 0, 80, -13, -14, -13, -14,
+ax_anim 2, 0, 80, -14, -13, -14, -13,
+ax_anim 2, 0, 80, -13, -14, -13, -14,
+ax_anim 2, 0, 77, -10, -10, -10, -10,
+ax_anim 2, 0, 77, -4, -4, -4, -4,
+ax_anim_terminator
+sMagbyAnims_3_7:
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim 2, 0, 78, 4, 0, 4, 0,
+ax_anim 6, 0, 78, 5, 0, 5, 0,
+ax_anim 1, 2, 82, 1, 0, 1, 0,
+ax_anim 1, 0, 82, -7, 0, -7, 0,
+ax_anim 2, 0, 83, -16, 0, -16, 0,
+ax_anim 2, 1, 84, -16, 1, -16, 1,
+ax_anim 2, 0, 84, -16, 0, -16, 0,
+ax_anim 2, 0, 84, -16, 1, -16, 1,
+ax_anim 2, 0, 84, -16, 0, -16, 0,
+ax_anim 2, 0, 84, -16, 1, -16, 1,
+ax_anim 2, 0, 84, -16, 0, -16, 0,
+ax_anim 2, 0, 81, -10, 0, -10, 0,
+ax_anim 2, 0, 81, -4, 0, -4, 0,
+ax_anim_terminator
+sMagbyAnims_3_8:
+ax_anim 2, 0, 82, 2, -2, 2, -2,
+ax_anim 2, 0, 82, 4, -4, 4, -4,
+ax_anim 6, 0, 82, 5, -5, 5, -5,
+ax_anim 1, 2, 86, 1, -1, 1, -1,
+ax_anim 1, 0, 86, -7, 7, -7, 7,
+ax_anim 2, 0, 87, -16, 19, -16, 19,
+ax_anim 2, 1, 88, -17, 18, -17, 18,
+ax_anim 2, 0, 88, -16, 19, -16, 19,
+ax_anim 2, 0, 88, -17, 18, -17, 18,
+ax_anim 2, 0, 88, -16, 19, -16, 19,
+ax_anim 2, 0, 88, -17, 18, -17, 18,
+ax_anim 2, 0, 88, -16, 19, -16, 19,
+ax_anim 2, 0, 85, -10, 10, -10, 10,
+ax_anim 2, 0, 85, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMagbyAnims_4_1:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 6, 2, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim 2, 1, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim_terminator
+sMagbyAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 2, 93, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 1, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sMagbyAnims_4_3:
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim 6, 2, 96, -3, 0, -3, 0,
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 2, 1, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 3, 1, 3, 1,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 3, 1, 3, 1,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 3, 1, 3, 1,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim_terminator
+sMagbyAnims_4_4:
+ax_anim 2, 0, 99, -2, 2, -2, 2,
+ax_anim 6, 2, 99, -3, 3, -3, 3,
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 2, 1, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -1, 3, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -1, 3, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -1, 3, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim_terminator
+sMagbyAnims_4_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 6, 2, 102, 0, 3, 0, 3,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 2, 1, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 1, -3, 1, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 1, -3, 1, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 103, 1, -3, 1, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim_terminator
+sMagbyAnims_4_6:
+ax_anim 2, 0, 105, 2, 2, 2, 2,
+ax_anim 6, 2, 105, 3, 3, 3, 3,
+ax_anim 2, 0, 104, 1, 1, 1, 1,
+ax_anim 2, 1, 106, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -3, -1, -3, -1,
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -3, -1, -3, -1,
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -3, -1, -3, -1,
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim 2, 0, 104, -1, -1, -1, -1,
+ax_anim_terminator
+sMagbyAnims_4_7:
+ax_anim 2, 0, 108, 2, 0, 2, 0,
+ax_anim 6, 2, 108, 3, 0, 3, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 1, 109, -3, 0, -3, 0,
+ax_anim 2, 0, 109, -3, 1, -3, 1,
+ax_anim 2, 0, 109, -3, 0, -3, 0,
+ax_anim 2, 0, 109, -3, 1, -3, 1,
+ax_anim 2, 0, 109, -3, 0, -3, 0,
+ax_anim 2, 0, 109, -3, 1, -3, 1,
+ax_anim 2, 0, 109, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -1, 0, -1, 0,
+ax_anim_terminator
+sMagbyAnims_4_8:
+ax_anim 2, 0, 111, 2, -2, 2, -2,
+ax_anim 6, 2, 111, 3, -3, 3, -3,
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 1, 112, -2, 2, -2, 2,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 112, -2, 2, -2, 2,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 112, -2, 2, -2, 2,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 112, -2, 2, -2, 2,
+ax_anim 2, 0, 110, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMagbyAnims_5_1:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_5_2:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_5_3:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_5_4:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_5_5:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_5_6:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_5_7:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_5_8:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_6_1:
+ax_anim 30, 0, 121, 0, 0, 0, 0,
+ax_anim 35, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_7_1:
+ax_anim 2, 0, 123, 0, -2, 0, -2,
+ax_anim 8, 0, 123, 0, -3, 0, -3,
+ax_anim_terminator
+sMagbyAnims_7_2:
+ax_anim 2, 0, 124, -2, -2, -2, -2,
+ax_anim 8, 0, 124, -3, -3, -3, -3,
+ax_anim_terminator
+sMagbyAnims_7_3:
+ax_anim 2, 0, 125, -2, 0, -2, 0,
+ax_anim 8, 0, 125, -3, 0, -3, 0,
+ax_anim_terminator
+sMagbyAnims_7_4:
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim 8, 0, 126, -3, 3, -3, 3,
+ax_anim_terminator
+sMagbyAnims_7_5:
+ax_anim 2, 0, 127, 0, 2, 0, 2,
+ax_anim 8, 0, 127, 0, 3, 0, 3,
+ax_anim_terminator
+sMagbyAnims_7_6:
+ax_anim 2, 0, 128, 2, 2, 2, 2,
+ax_anim 8, 0, 128, 3, 3, 3, 3,
+ax_anim_terminator
+sMagbyAnims_7_7:
+ax_anim 2, 0, 129, 2, 0, 2, 0,
+ax_anim 8, 0, 129, 3, 0, 3, 0,
+ax_anim_terminator
+sMagbyAnims_7_8:
+ax_anim 2, 0, 130, 2, -2, 2, -2,
+ax_anim 8, 0, 130, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMagbyAnims_8_1:
+ax_anim 30, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 3, 0, 132, 0, -3, 0, 0,
+ax_anim 4, 0, 132, 0, -4, 0, 0,
+ax_anim 3, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sMagbyAnims_8_2:
+ax_anim 30, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, 0,
+ax_anim 3, 0, 134, 0, -3, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 3, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sMagbyAnims_8_3:
+ax_anim 30, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 3, 0, 136, 0, -4, 0, 0,
+ax_anim 4, 0, 136, 0, -5, 0, 0,
+ax_anim 3, 0, 136, 0, -4, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim_terminator
+sMagbyAnims_8_4:
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 3, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 138, 0, -5, 0, 0,
+ax_anim 3, 0, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sMagbyAnims_8_5:
+ax_anim 30, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 3, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -5, 0, 0,
+ax_anim 3, 0, 140, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sMagbyAnims_8_6:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 3, 0, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -5, 0, 0,
+ax_anim 3, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim_terminator
+sMagbyAnims_8_7:
+ax_anim 30, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 3, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 144, 0, -5, 0, 0,
+ax_anim 3, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sMagbyAnims_8_8:
+ax_anim 30, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim 3, 0, 146, 0, -3, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 3, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_9_1:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 6, 3, 6, 3,
+ax_anim 2, 0, 149, 8, 9, 8, 9,
+ax_anim 2, 0, 150, 7, 15, 7, 15,
+ax_anim 3, 0, 151, 0, 18, 0, 18,
+ax_anim 2, 3, 152, -7, 15, -7, 15,
+ax_anim 2, 0, 153, -8, 9, -8, 9,
+ax_anim 1, 0, 154, -6, 3, -6, 3,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_9_2:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 8, 0, 8, 0,
+ax_anim 2, 0, 148, 17, 3, 17, 3,
+ax_anim 2, 0, 149, 19, 12, 19, 12,
+ax_anim 3, 0, 150, 17, 19, 17, 19,
+ax_anim 2, 3, 151, 11, 19, 11, 19,
+ax_anim 2, 0, 152, 3, 15, 3, 15,
+ax_anim 1, 0, 153, 0, 7, 0, 7,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_9_3:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 3, -5, 3, -5,
+ax_anim 2, 0, 147, 11, -6, 11, -6,
+ax_anim 2, 0, 148, 16, -5, 16, -5,
+ax_anim 3, 0, 149, 18, -2, 18, -2,
+ax_anim 2, 3, 150, 16, 4, 16, 4,
+ax_anim 2, 0, 151, 12, 5, 12, 5,
+ax_anim 1, 0, 152, 4, 5, 4, 5,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_9_4:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, -1, -8, -1, -8,
+ax_anim 2, 0, 154, 4, -16, 4, -16,
+ax_anim 2, 0, 147, 13, -22, 13, -22,
+ax_anim 3, 0, 148, 20, -22, 20, -22,
+ax_anim 2, 3, 149, 20, -15, 20, -15,
+ax_anim 2, 0, 150, 17, -4, 17, -4,
+ax_anim 1, 0, 151, 7, -1, 7, -1,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_9_5:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -8, -4, -8, -4,
+ax_anim 2, 0, 153, -9, -12, -9, -12,
+ax_anim 2, 0, 154, -7, -20, -7, -20,
+ax_anim 3, 0, 147, 0, -22, 0, -22,
+ax_anim 2, 3, 148, 7, -20, 7, -20,
+ax_anim 2, 0, 149, 9, -10, 9, -10,
+ax_anim 1, 0, 150, 8, -4, 8, -4,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_9_6:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 1, -8, 1, -8,
+ax_anim 2, 0, 148, -4, -16, -4, -16,
+ax_anim 2, 0, 147, -13, -22, -13, -22,
+ax_anim 3, 0, 154, -20, -22, -20, -22,
+ax_anim 2, 3, 153, -20, -15, -20, -15,
+ax_anim 2, 0, 152, -17, -4, -17, -4,
+ax_anim 1, 0, 151, -7, -1, -7, -1,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_9_7:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, -3, -5, -3, -5,
+ax_anim 2, 0, 147, -11, -6, -11, -6,
+ax_anim 2, 0, 154, -16, -5, -16, -5,
+ax_anim 3, 0, 153, -18, -2, -18, -2,
+ax_anim 2, 3, 152, -16, 4, -16, 4,
+ax_anim 2, 0, 151, -12, 5, -12, 5,
+ax_anim 1, 0, 150, -4, 5, -4, 5,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_9_8:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -8, 0, -8, 0,
+ax_anim 2, 0, 154, -17, 3, -17, 3,
+ax_anim 2, 0, 153, -19, 12, -19, 12,
+ax_anim 3, 0, 152, -17, 19, -17, 19,
+ax_anim 2, 3, 151, -11, 19, -11, 19,
+ax_anim 2, 0, 150, -3, 15, -3, 15,
+ax_anim 1, 0, 149, 0, 7, 0, 7,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_10_1:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, 0, 6, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, 10, 0, 10, 0,
+ax_anim 2, 0, 155, -10, 0, -10, 0,
+ax_anim 2, 0, 155, 12, 0, 12, 0,
+ax_anim 3, 0, 155, -12, 0, -12, 0,
+ax_anim 3, 0, 155, 13, 0, 13, 0,
+ax_anim 3, 0, 155, -13, 0, -13, 0,
+ax_anim 2, 0, 155, 12, 0, 12, 0,
+ax_anim 3, 0, 155, -12, 0, -12, 0,
+ax_anim 2, 0, 155, 10, 0, 10, 0,
+ax_anim 2, 0, 155, -10, 0, -10, 0,
+ax_anim 2, 0, 155, 6, 0, 6, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_10_2:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 6, -6, 6, -6,
+ax_anim 2, 0, 156, -6, 6, -6, 6,
+ax_anim 2, 0, 156, 10, -10, 10, -10,
+ax_anim 2, 0, 156, -10, 10, -10, 10,
+ax_anim 2, 0, 156, 12, -12, 12, -12,
+ax_anim 3, 0, 156, -12, 12, -12, 12,
+ax_anim 3, 0, 156, 13, -13, 13, -13,
+ax_anim 3, 0, 156, -13, 13, -13, 13,
+ax_anim 2, 0, 156, 12, -12, 12, -12,
+ax_anim 3, 0, 156, -12, 12, -12, 12,
+ax_anim 2, 0, 156, 10, -10, 10, -10,
+ax_anim 2, 0, 156, -10, 10, -10, 10,
+ax_anim 2, 0, 156, 6, -6, 6, -6,
+ax_anim 2, 0, 156, -6, 6, -6, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_10_3:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, -6, 0, -6,
+ax_anim 2, 0, 157, 0, 6, 0, 6,
+ax_anim 2, 0, 157, 0, -10, 0, -10,
+ax_anim 2, 0, 157, 0, 10, 0, 10,
+ax_anim 2, 0, 157, 0, -12, 0, -12,
+ax_anim 3, 0, 157, 0, 12, 0, 12,
+ax_anim 3, 0, 157, 0, -13, 0, -13,
+ax_anim 3, 0, 157, 0, 13, 0, 13,
+ax_anim 2, 0, 157, 0, -12, 0, -12,
+ax_anim 3, 0, 157, 0, 12, 0, 12,
+ax_anim 2, 0, 157, 0, -10, 0, -10,
+ax_anim 2, 0, 157, 0, 10, 0, 10,
+ax_anim 2, 0, 157, 0, -6, 0, -6,
+ax_anim 2, 0, 157, 0, 6, 0, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_10_4:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -6, -6, -6, -6,
+ax_anim 2, 0, 158, 6, 6, 6, 6,
+ax_anim 2, 0, 158, -10, -10, -10, -10,
+ax_anim 2, 0, 158, 10, 10, 10, 10,
+ax_anim 2, 0, 158, -12, -12, -12, -12,
+ax_anim 3, 0, 158, 12, 12, 12, 12,
+ax_anim 3, 0, 158, -13, -13, -13, -13,
+ax_anim 3, 0, 158, 13, 13, 13, 13,
+ax_anim 2, 0, 158, -12, -12, -12, -12,
+ax_anim 3, 0, 158, 12, 12, 12, 12,
+ax_anim 2, 0, 158, -10, -10, -10, -10,
+ax_anim 2, 0, 158, 10, 10, 10, 10,
+ax_anim 2, 0, 158, -6, -6, -6, -6,
+ax_anim 2, 0, 158, 6, 6, 6, 6,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_10_5:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, 0, 6, 0,
+ax_anim 2, 0, 159, -6, 0, -6, 0,
+ax_anim 2, 0, 159, 10, 0, 10, 0,
+ax_anim 2, 0, 159, -10, 0, -10, 0,
+ax_anim 2, 0, 159, 12, 0, 12, 0,
+ax_anim 3, 0, 159, -12, 0, -12, 0,
+ax_anim 3, 0, 159, 13, 0, 13, 0,
+ax_anim 3, 0, 159, -13, 0, -13, 0,
+ax_anim 2, 0, 159, 12, 0, 12, 0,
+ax_anim 3, 0, 159, -12, 0, -12, 0,
+ax_anim 2, 0, 159, 10, 0, 10, 0,
+ax_anim 2, 0, 159, -10, 0, -10, 0,
+ax_anim 2, 0, 159, 6, 0, 6, 0,
+ax_anim 2, 0, 159, -6, 0, -6, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_10_6:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 6, -6, 6, -6,
+ax_anim 2, 0, 160, -6, 6, -6, 6,
+ax_anim 2, 0, 160, 10, -10, 10, -10,
+ax_anim 2, 0, 160, -10, 10, -10, 10,
+ax_anim 2, 0, 160, 12, -12, 12, -12,
+ax_anim 3, 0, 160, -12, 12, -12, 12,
+ax_anim 3, 0, 160, 13, -13, 13, -13,
+ax_anim 3, 0, 160, -13, 13, -13, 13,
+ax_anim 2, 0, 160, 12, -12, 12, -12,
+ax_anim 3, 0, 160, -12, 12, -12, 12,
+ax_anim 2, 0, 160, 10, -10, 10, -10,
+ax_anim 2, 0, 160, -10, 10, -10, 10,
+ax_anim 2, 0, 160, 6, -6, 6, -6,
+ax_anim 2, 0, 160, -6, 6, -6, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_10_7:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 3, 0, 161, 0, -13, 0, -13,
+ax_anim 3, 0, 161, 0, 13, 0, 13,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_10_8:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -6, -6, -6, -6,
+ax_anim 2, 0, 162, 6, 6, 6, 6,
+ax_anim 2, 0, 162, -10, -10, -10, -10,
+ax_anim 2, 0, 162, 10, 10, 10, 10,
+ax_anim 2, 0, 162, -12, -12, -12, -12,
+ax_anim 3, 0, 162, 12, 12, 12, 12,
+ax_anim 3, 0, 162, -13, -13, -13, -13,
+ax_anim 3, 0, 162, 13, 13, 13, 13,
+ax_anim 2, 0, 162, -12, -12, -12, -12,
+ax_anim 3, 0, 162, 12, 12, 12, 12,
+ax_anim 2, 0, 162, -10, -10, -10, -10,
+ax_anim 2, 0, 162, 10, 10, 10, 10,
+ax_anim 2, 0, 162, -6, -6, -6, -6,
+ax_anim 2, 0, 162, 6, 6, 6, 6,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_11_1:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_11_2:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_11_3:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_11_4:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 174, 0, -21, 0, 0,
+ax_anim 2, 0, 174, 0, -17, 0, 0,
+ax_anim 1, 0, 174, 0, -11, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_11_5:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -23, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_11_6:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -17, 0, 0,
+ax_anim 1, 0, 180, 0, -11, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_11_7:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_11_8:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_12_1:
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_12_2:
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_12_3:
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_12_4:
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_12_5:
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_12_6:
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_12_7:
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_12_8:
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagbyAnims_13_1:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_13_2:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_13_3:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_13_4:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_13_5:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_13_6:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_13_7:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyAnims_13_8:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMagbyGfx1:
+.incbin "baserom.gba", 0xFBAD2C, 0x200
+sMagbySprites1:
+ax_sprite sMagbyGfx1, 0x200
+ax_sprite_terminator
+sMagbyGfx2:
+.incbin "baserom.gba", 0xFBAF3C, 0x200
+sMagbySprites2:
+ax_sprite sMagbyGfx2, 0x200
+ax_sprite_terminator
+sMagbyGfx3:
+.incbin "baserom.gba", 0xFBB14C, 0x200
+sMagbySprites3:
+ax_sprite sMagbyGfx3, 0x200
+ax_sprite_terminator
+sMagbyGfx4:
+.incbin "baserom.gba", 0xFBB35C, 0x200
+sMagbySprites4:
+ax_sprite sMagbyGfx4, 0x200
+ax_sprite_terminator
+sMagbyGfx5:
+.incbin "baserom.gba", 0xFBB56C, 0x100
+sMagbySprites5:
+ax_sprite sMagbyGfx5, 0x100
+ax_sprite_terminator
+sMagbyGfx6:
+.incbin "baserom.gba", 0xFBB67C, 0x200
+sMagbySprites6:
+ax_sprite sMagbyGfx6, 0x200
+ax_sprite_terminator
+sMagbyGfx7:
+.incbin "baserom.gba", 0xFBB88C, 0x200
+sMagbySprites7:
+ax_sprite sMagbyGfx7, 0x200
+ax_sprite_terminator
+sMagbyGfx8:
+.incbin "baserom.gba", 0xFBBA9C, 0x200
+sMagbySprites8:
+ax_sprite sMagbyGfx8, 0x200
+ax_sprite_terminator
+sMagbyGfx9:
+.incbin "baserom.gba", 0xFBBCAC, 0x200
+sMagbySprites9:
+ax_sprite sMagbyGfx9, 0x200
+ax_sprite_terminator
+sMagbyGfx10:
+.incbin "baserom.gba", 0xFBBEBC, 0x200
+sMagbySprites10:
+ax_sprite sMagbyGfx10, 0x200
+ax_sprite_terminator
+sMagbyGfx11:
+.incbin "baserom.gba", 0xFBC0CC, 0x200
+sMagbySprites11:
+ax_sprite sMagbyGfx11, 0x200
+ax_sprite_terminator
+sMagbyGfx12:
+.incbin "baserom.gba", 0xFBC2DC, 0x200
+sMagbySprites12:
+ax_sprite sMagbyGfx12, 0x200
+ax_sprite_terminator
+sMagbyGfx13:
+.incbin "baserom.gba", 0xFBC4EC, 0x200
+sMagbySprites13:
+ax_sprite sMagbyGfx13, 0x200
+ax_sprite_terminator
+sMagbyGfx14:
+.incbin "baserom.gba", 0xFBC6FC, 0x200
+sMagbySprites14:
+ax_sprite sMagbyGfx14, 0x200
+ax_sprite_terminator
+sMagbyGfx15:
+.incbin "baserom.gba", 0xFBC90C, 0x200
+sMagbySprites15:
+ax_sprite sMagbyGfx15, 0x200
+ax_sprite_terminator
+sMagbyGfx16:
+.incbin "baserom.gba", 0xFBCB1C, 0x40
+sMagbyGfx16_1:
+.incbin "baserom.gba", 0xFBCB5C, 0x60
+sMagbyGfx16_2:
+.incbin "baserom.gba", 0xFBCBBC, 0x60
+sMagbyGfx16_3:
+.incbin "baserom.gba", 0xFBCC1C, 0x40
+sMagbySprites16:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx17:
+.incbin "baserom.gba", 0xFBCCAC, 0x60
+sMagbyGfx17_1:
+.incbin "baserom.gba", 0xFBCD0C, 0x60
+sMagbyGfx17_2:
+.incbin "baserom.gba", 0xFBCD6C, 0x60
+sMagbyGfx17_3:
+.incbin "baserom.gba", 0xFBCDCC, 0x40
+sMagbySprites17:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx18:
+.incbin "baserom.gba", 0xFBCE5C, 0x40
+sMagbyGfx18_1:
+.incbin "baserom.gba", 0xFBCE9C, 0xC0
+sMagbyGfx18_2:
+.incbin "baserom.gba", 0xFBCF5C, 0x60
+sMagbySprites18:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx18_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx19:
+.incbin "baserom.gba", 0xFBCFFC, 0x60
+sMagbyGfx19_1:
+.incbin "baserom.gba", 0xFBD05C, 0x60
+sMagbyGfx19_2:
+.incbin "baserom.gba", 0xFBD0BC, 0x60
+sMagbyGfx19_3:
+.incbin "baserom.gba", 0xFBD11C, 0x40
+sMagbySprites19:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx20:
+.incbin "baserom.gba", 0xFBD1AC, 0x40
+sMagbyGfx20_1:
+.incbin "baserom.gba", 0xFBD1EC, 0x40
+sMagbyGfx20_2:
+.incbin "baserom.gba", 0xFBD22C, 0x60
+sMagbyGfx20_3:
+.incbin "baserom.gba", 0xFBD28C, 0x40
+sMagbySprites20:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx21:
+.incbin "baserom.gba", 0xFBD31C, 0x20
+sMagbyGfx21_1:
+.incbin "baserom.gba", 0xFBD33C, 0x20
+sMagbyGfx21_2:
+.incbin "baserom.gba", 0xFBD35C, 0x20
+sMagbyGfx21_3:
+.incbin "baserom.gba", 0xFBD37C, 0x40
+sMagbySprites21:
+ax_sprite sMagbyGfx21, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx21_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx21_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx21_3, 0x40
+ax_sprite_terminator
+sMagbyGfx22:
+.incbin "baserom.gba", 0xFBD3FC, 0x60
+sMagbyGfx22_1:
+.incbin "baserom.gba", 0xFBD45C, 0xC0
+sMagbySprites22:
+ax_sprite 0, 0xa0
+ax_sprite sMagbyGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx22_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx23:
+.incbin "baserom.gba", 0xFBD54C, 0x60
+sMagbyGfx23_1:
+.incbin "baserom.gba", 0xFBD5AC, 0x20
+sMagbySprites23:
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx23, 0x60
+ax_sprite 0, 0x60
+ax_sprite sMagbyGfx23_1, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sMagbyGfx24:
+.incbin "baserom.gba", 0xFBD5FC, 0x60
+sMagbyGfx24_1:
+.incbin "baserom.gba", 0xFBD65C, 0x60
+sMagbyGfx24_2:
+.incbin "baserom.gba", 0xFBD6BC, 0x60
+sMagbySprites24:
+ax_sprite 0, 0x80
+ax_sprite sMagbyGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx25:
+.incbin "baserom.gba", 0xFBD75C, 0x40
+sMagbyGfx25_1:
+.incbin "baserom.gba", 0xFBD79C, 0xE0
+sMagbyGfx25_2:
+.incbin "baserom.gba", 0xFBD87C, 0x40
+sMagbySprites25:
+ax_sprite sMagbyGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx25_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx26:
+.incbin "baserom.gba", 0xFBD8F4, 0xC0
+sMagbySprites26:
+ax_sprite sMagbyGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagbyGfx27:
+.incbin "baserom.gba", 0xFBD9CC, 0x60
+sMagbyGfx27_1:
+.incbin "baserom.gba", 0xFBDA2C, 0x60
+sMagbyGfx27_2:
+.incbin "baserom.gba", 0xFBDA8C, 0x80
+sMagbyGfx27_3:
+.incbin "baserom.gba", 0xFBDB0C, 0x40
+sMagbySprites27:
+ax_sprite sMagbyGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx27_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx28:
+.incbin "baserom.gba", 0xFBDB94, 0x60
+sMagbyGfx28_1:
+.incbin "baserom.gba", 0xFBDBF4, 0x60
+sMagbyGfx28_2:
+.incbin "baserom.gba", 0xFBDC54, 0x20
+sMagbySprites28:
+ax_sprite sMagbyGfx28, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx28_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sMagbyGfx28_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMagbyGfx29:
+.incbin "baserom.gba", 0xFBDCAC, 0x80
+sMagbyGfx29_1:
+.incbin "baserom.gba", 0xFBDD2C, 0x20
+sMagbySprites29:
+ax_sprite sMagbyGfx29, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx29_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagbyGfx30:
+.incbin "baserom.gba", 0xFBDD74, 0x60
+sMagbyGfx30_1:
+.incbin "baserom.gba", 0xFBDDD4, 0x60
+sMagbyGfx30_2:
+.incbin "baserom.gba", 0xFBDE34, 0x80
+sMagbyGfx30_3:
+.incbin "baserom.gba", 0xFBDEB4, 0x60
+sMagbySprites30:
+ax_sprite sMagbyGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx30_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx30_3, 0x60
+ax_sprite_terminator
+sMagbyGfx31:
+.incbin "baserom.gba", 0xFBDF54, 0x40
+sMagbyGfx31_1:
+.incbin "baserom.gba", 0xFBDF94, 0x40
+sMagbyGfx31_2:
+.incbin "baserom.gba", 0xFBDFD4, 0x60
+sMagbyGfx31_3:
+.incbin "baserom.gba", 0xFBE034, 0x40
+sMagbySprites31:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx32:
+.incbin "baserom.gba", 0xFBE0C4, 0x40
+sMagbyGfx32_1:
+.incbin "baserom.gba", 0xFBE104, 0x100
+sMagbyGfx32_2:
+.incbin "baserom.gba", 0xFBE204, 0x60
+sMagbySprites32:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx32_2, 0x60
+ax_sprite_terminator
+sMagbyGfx33:
+.incbin "baserom.gba", 0xFBE29C, 0x40
+sMagbyGfx33_1:
+.incbin "baserom.gba", 0xFBE2DC, 0x60
+sMagbyGfx33_2:
+.incbin "baserom.gba", 0xFBE33C, 0x60
+sMagbyGfx33_3:
+.incbin "baserom.gba", 0xFBE39C, 0x40
+sMagbySprites33:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx34:
+.incbin "baserom.gba", 0xFBE42C, 0x40
+sMagbyGfx34_1:
+.incbin "baserom.gba", 0xFBE46C, 0x80
+sMagbyGfx34_2:
+.incbin "baserom.gba", 0xFBE4EC, 0x60
+sMagbyGfx34_3:
+.incbin "baserom.gba", 0xFBE54C, 0x20
+sMagbySprites34:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx34_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx34_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx35:
+.incbin "baserom.gba", 0xFBE5BC, 0x60
+sMagbyGfx35_1:
+.incbin "baserom.gba", 0xFBE61C, 0x60
+sMagbyGfx35_2:
+.incbin "baserom.gba", 0xFBE67C, 0x60
+sMagbyGfx35_3:
+.incbin "baserom.gba", 0xFBE6DC, 0x40
+sMagbySprites35:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx36:
+.incbin "baserom.gba", 0xFBE76C, 0x40
+sMagbyGfx36_1:
+.incbin "baserom.gba", 0xFBE7AC, 0x100
+sMagbyGfx36_2:
+.incbin "baserom.gba", 0xFBE8AC, 0x40
+sMagbySprites36:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx36_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx37:
+.incbin "baserom.gba", 0xFBE92C, 0x40
+sMagbyGfx37_1:
+.incbin "baserom.gba", 0xFBE96C, 0x60
+sMagbyGfx37_2:
+.incbin "baserom.gba", 0xFBE9CC, 0x60
+sMagbyGfx37_3:
+.incbin "baserom.gba", 0xFBEA2C, 0x40
+sMagbySprites37:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx38:
+.incbin "baserom.gba", 0xFBEABC, 0x60
+sMagbyGfx38_1:
+.incbin "baserom.gba", 0xFBEB1C, 0x80
+sMagbyGfx38_2:
+.incbin "baserom.gba", 0xFBEB9C, 0x60
+sMagbyGfx38_3:
+.incbin "baserom.gba", 0xFBEBFC, 0x40
+sMagbySprites38:
+ax_sprite sMagbyGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx38_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx39:
+.incbin "baserom.gba", 0xFBEC84, 0x40
+sMagbyGfx39_1:
+.incbin "baserom.gba", 0xFBECC4, 0x40
+sMagbyGfx39_2:
+.incbin "baserom.gba", 0xFBED04, 0x40
+sMagbyGfx39_3:
+.incbin "baserom.gba", 0xFBED44, 0x40
+sMagbySprites39:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx39_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagbyGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagbyGfx40:
+.incbin "baserom.gba", 0xFBEDD4, 0x40
+sMagbyGfx40_1:
+.incbin "baserom.gba", 0xFBEE14, 0x80
+sMagbyGfx40_2:
+.incbin "baserom.gba", 0xFBEE94, 0x60
+sMagbySprites40:
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx40_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagbyGfx40_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMagbyGfx41:
+.incbin "baserom.gba", 0xFBEF34, 0x200
+sMagbySprites41:
+ax_sprite sMagbyGfx41, 0x200
+ax_sprite_terminator
+sMagbyGfx42:
+.incbin "baserom.gba", 0xFBF144, 0x200
+sMagbySprites42:
+ax_sprite sMagbyGfx42, 0x200
+ax_sprite_terminator
+sMagbyGfx43:
+.incbin "baserom.gba", 0xFBF354, 0x200
+sMagbySprites43:
+ax_sprite sMagbyGfx43, 0x200
+ax_sprite_terminator
+sMagbyGfx44:
+.incbin "baserom.gba", 0xFBF564, 0x200
+sMagbySprites44:
+ax_sprite sMagbyGfx44, 0x200
+ax_sprite_terminator
+sMagbyGfx45:
+.incbin "baserom.gba", 0xFBF774, 0x200
+sMagbySprites45:
+ax_sprite sMagbyGfx45, 0x200
+ax_sprite_terminator
+sMagbyGfx46:
+.incbin "baserom.gba", 0xFBF984, 0x200
+sMagbySprites46:
+ax_sprite sMagbyGfx46, 0x200
+ax_sprite_terminator
+sMagbyGfx47:
+.incbin "baserom.gba", 0xFBFB94, 0x200
+sMagbySprites47:
+ax_sprite sMagbyGfx47, 0x200
+ax_sprite_terminator
+sAxPosesMagby:
+.4byte sMagbyPose1
+.4byte sMagbyPose2
+.4byte sMagbyPose3
+.4byte sMagbyPose4
+.4byte sMagbyPose5
+.4byte sMagbyPose6
+.4byte sMagbyPose7
+.4byte sMagbyPose8
+.4byte sMagbyPose9
+.4byte sMagbyPose10
+.4byte sMagbyPose11
+.4byte sMagbyPose12
+.4byte sMagbyPose13
+.4byte sMagbyPose14
+.4byte sMagbyPose15
+.4byte sMagbyPose16
+.4byte sMagbyPose17
+.4byte sMagbyPose18
+.4byte sMagbyPose19
+.4byte sMagbyPose20
+.4byte sMagbyPose21
+.4byte sMagbyPose22
+.4byte sMagbyPose23
+.4byte sMagbyPose24
+.4byte sMagbyPose25
+.4byte sMagbyPose26
+.4byte sMagbyPose27
+.4byte sMagbyPose28
+.4byte sMagbyPose29
+.4byte sMagbyPose30
+.4byte sMagbyPose31
+.4byte sMagbyPose32
+.4byte sMagbyPose33
+.4byte sMagbyPose34
+.4byte sMagbyPose35
+.4byte sMagbyPose36
+.4byte sMagbyPose37
+.4byte sMagbyPose38
+.4byte sMagbyPose39
+.4byte sMagbyPose40
+.4byte sMagbyPose41
+.4byte sMagbyPose42
+.4byte sMagbyPose43
+.4byte sMagbyPose44
+.4byte sMagbyPose45
+.4byte sMagbyPose46
+.4byte sMagbyPose47
+.4byte sMagbyPose48
+.4byte sMagbyPose49
+.4byte sMagbyPose50
+.4byte sMagbyPose51
+.4byte sMagbyPose52
+.4byte sMagbyPose53
+.4byte sMagbyPose54
+.4byte sMagbyPose55
+.4byte sMagbyPose56
+.4byte sMagbyPose57
+.4byte sMagbyPose58
+.4byte sMagbyPose59
+.4byte sMagbyPose60
+.4byte sMagbyPose61
+.4byte sMagbyPose62
+.4byte sMagbyPose63
+.4byte sMagbyPose64
+.4byte sMagbyPose65
+.4byte sMagbyPose66
+.4byte sMagbyPose67
+.4byte sMagbyPose68
+.4byte sMagbyPose69
+.4byte sMagbyPose70
+.4byte sMagbyPose71
+.4byte sMagbyPose72
+.4byte sMagbyPose73
+.4byte sMagbyPose74
+.4byte sMagbyPose75
+.4byte sMagbyPose76
+.4byte sMagbyPose77
+.4byte sMagbyPose78
+.4byte sMagbyPose79
+.4byte sMagbyPose80
+.4byte sMagbyPose81
+.4byte sMagbyPose82
+.4byte sMagbyPose83
+.4byte sMagbyPose84
+.4byte sMagbyPose85
+.4byte sMagbyPose86
+.4byte sMagbyPose87
+.4byte sMagbyPose88
+.4byte sMagbyPose89
+.4byte sMagbyPose90
+.4byte sMagbyPose91
+.4byte sMagbyPose92
+.4byte sMagbyPose93
+.4byte sMagbyPose94
+.4byte sMagbyPose95
+.4byte sMagbyPose96
+.4byte sMagbyPose97
+.4byte sMagbyPose98
+.4byte sMagbyPose99
+.4byte sMagbyPose100
+.4byte sMagbyPose101
+.4byte sMagbyPose102
+.4byte sMagbyPose103
+.4byte sMagbyPose104
+.4byte sMagbyPose105
+.4byte sMagbyPose106
+.4byte sMagbyPose107
+.4byte sMagbyPose108
+.4byte sMagbyPose109
+.4byte sMagbyPose110
+.4byte sMagbyPose111
+.4byte sMagbyPose112
+.4byte sMagbyPose113
+.4byte sMagbyPose114
+.4byte sMagbyPose115
+.4byte sMagbyPose116
+.4byte sMagbyPose117
+.4byte sMagbyPose118
+.4byte sMagbyPose119
+.4byte sMagbyPose120
+.4byte sMagbyPose121
+.4byte sMagbyPose122
+.4byte sMagbyPose123
+.4byte sMagbyPose124
+.4byte sMagbyPose125
+.4byte sMagbyPose126
+.4byte sMagbyPose127
+.4byte sMagbyPose128
+.4byte sMagbyPose129
+.4byte sMagbyPose130
+.4byte sMagbyPose131
+.4byte sMagbyPose132
+.4byte sMagbyPose133
+.4byte sMagbyPose134
+.4byte sMagbyPose135
+.4byte sMagbyPose136
+.4byte sMagbyPose137
+.4byte sMagbyPose138
+.4byte sMagbyPose139
+.4byte sMagbyPose140
+.4byte sMagbyPose141
+.4byte sMagbyPose142
+.4byte sMagbyPose143
+.4byte sMagbyPose144
+.4byte sMagbyPose145
+.4byte sMagbyPose146
+.4byte sMagbyPose147
+.4byte sMagbyPose148
+.4byte sMagbyPose149
+.4byte sMagbyPose150
+.4byte sMagbyPose151
+.4byte sMagbyPose152
+.4byte sMagbyPose153
+.4byte sMagbyPose154
+.4byte sMagbyPose155
+.4byte sMagbyPose156
+.4byte sMagbyPose157
+.4byte sMagbyPose158
+.4byte sMagbyPose159
+.4byte sMagbyPose160
+.4byte sMagbyPose161
+.4byte sMagbyPose162
+.4byte sMagbyPose163
+.4byte sMagbyPose164
+.4byte sMagbyPose165
+.4byte sMagbyPose166
+.4byte sMagbyPose167
+.4byte sMagbyPose168
+.4byte sMagbyPose169
+.4byte sMagbyPose170
+.4byte sMagbyPose171
+.4byte sMagbyPose172
+.4byte sMagbyPose173
+.4byte sMagbyPose174
+.4byte sMagbyPose175
+.4byte sMagbyPose176
+.4byte sMagbyPose177
+.4byte sMagbyPose178
+.4byte sMagbyPose179
+.4byte sMagbyPose180
+.4byte sMagbyPose181
+.4byte sMagbyPose182
+.4byte sMagbyPose183
+.4byte sMagbyPose184
+.4byte sMagbyPose185
+.4byte sMagbyPose186
+.4byte sMagbyPose187
+.4byte sMagbyPose188
+.4byte sMagbyPose189
+.4byte sMagbyPose190
+.4byte sMagbyPose191
+.4byte sMagbyPose192
+.4byte sMagbyPose193
+.4byte sMagbyPose194
+.4byte sMagbyPose195
+.4byte sMagbyPose196
+.4byte sMagbyPose197
+.4byte sMagbyPose198
+.4byte sMagbyPose199
+.4byte sMagbyPose200
+.4byte sMagbyPose201
+.4byte sMagbyPose202
+.4byte sMagbyPose203
+sAxPositionsMagby:
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -5, 	   6,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -3, 	   7,   -5, 	   0,   -7
+.2byte    3,   -7, 	   6,   -6, 	  -5,   -3, 	  -1,   -8
+.2byte    3,   -6, 	   5,   -6, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -6, 	   7,   -4, 	  -6,   -3, 	   0,   -7
+.2byte    5,   -9, 	   3,   -4, 	   1,   -3, 	   0,   -8
+.2byte    5,   -8, 	  -3,   -5, 	   3,   -3, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -5, 	  -1,   -2, 	   0,   -7
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    3,   -9, 	  -7,   -5, 	   6,   -6, 	   0,   -7
+.2byte    3,   -9, 	  -2,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -12, 	   7,   -3, 	  -7,   -7, 	   0,   -6
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -3, 	   0,   -6
+.2byte   -3,  -10, 	   6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte   -3,   -9, 	   7,   -5, 	  -6,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   2,   -9, 	  -5,   -3, 	   1,   -7
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -5,   -8, 	   3,   -5, 	  -3,   -3, 	   1,   -7
+.2byte   -5,   -8, 	  -6,   -5, 	   1,   -2, 	   0,   -7
+.2byte   -3,   -7, 	  -6,   -6, 	   5,   -3, 	   1,   -8
+.2byte   -3,   -6, 	  -5,   -6, 	   1,   -2, 	   1,   -7
+.2byte   -3,   -6, 	  -7,   -4, 	   6,   -3, 	   0,   -7
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -5, 	   6,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -3, 	   7,   -5, 	   0,   -7
+.2byte   -3,   -8, 	  -1,   -5, 	   1,   -8, 	  -1,   -9
+.2byte    3,   -7, 	   6,   -6, 	  -5,   -3, 	  -1,   -8
+.2byte    3,   -6, 	   5,   -6, 	  -1,   -2, 	  -1,   -7
+.2byte    3,   -6, 	   7,   -4, 	  -6,   -3, 	   0,   -7
+.2byte    4,  -10, 	  -3,   -7, 	   4,   -8, 	   0,  -10
+.2byte    5,   -9, 	   3,   -4, 	   1,   -3, 	   0,   -8
+.2byte    5,   -8, 	  -3,   -5, 	   3,   -3, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -5, 	  -1,   -2, 	   0,   -7
+.2byte    2,  -13, 	  -8,   -8, 	   6,  -10, 	  -1,   -9
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    3,   -9, 	  -7,   -5, 	   6,   -6, 	   0,   -7
+.2byte    3,   -9, 	  -2,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    0,  -11, 	  -8,   -5, 	   4,  -11, 	  -2,   -8
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -12, 	   7,   -3, 	  -7,   -7, 	   0,   -6
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -3, 	   0,   -6
+.2byte    2,  -11, 	   6,   -4, 	  -4,   -5, 	  -1,   -8
+.2byte   -3,  -10, 	   6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte   -3,   -9, 	   7,   -5, 	  -6,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   2,   -9, 	  -5,   -3, 	   1,   -7
+.2byte    0,  -11, 	   8,   -5, 	  -4,  -11, 	   2,   -8
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -5,   -8, 	   3,   -5, 	  -3,   -3, 	   1,   -7
+.2byte   -5,   -8, 	  -6,   -5, 	   1,   -2, 	   0,   -7
+.2byte   -2,  -13, 	   8,   -8, 	  -6,  -10, 	   1,   -9
+.2byte   -3,   -7, 	  -6,   -6, 	   5,   -3, 	   1,   -8
+.2byte   -3,   -6, 	  -5,   -6, 	   1,   -2, 	   1,   -7
+.2byte   -3,   -6, 	  -7,   -4, 	   6,   -3, 	   0,   -7
+.2byte   -4,  -10, 	   3,   -7, 	  -4,   -8, 	   0,  -10
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -3,   -8, 	  -1,   -5, 	   1,   -8, 	  -1,   -9
+.2byte    2,   -3, 	  -2,   -1, 	   4,   -5, 	   2,   -6
+.2byte    2,   -3, 	  -2,   -1, 	   4,   -5, 	   2,   -6
+.2byte    3,   -7, 	   6,   -6, 	  -5,   -3, 	  -1,   -8
+.2byte    4,  -10, 	  -3,   -7, 	   4,   -8, 	   0,  -10
+.2byte    7,   -6, 	  10,   -5, 	  -6,   -8, 	   0,   -7
+.2byte    7,   -6, 	  10,   -5, 	  -6,   -8, 	   0,   -7
+.2byte    5,   -9, 	   3,   -4, 	   1,   -3, 	   0,   -8
+.2byte    2,  -13, 	  -8,   -8, 	   6,  -10, 	  -1,   -9
+.2byte    7,   -7, 	   6,   -5, 	  -1,   -6, 	   2,   -9
+.2byte    7,   -7, 	   6,   -5, 	  -1,   -6, 	   2,   -9
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    0,  -11, 	  -8,   -5, 	   4,  -11, 	  -2,   -8
+.2byte    8,   -9, 	   7,   -9, 	   6,   -5, 	   3,   -9
+.2byte    8,   -9, 	   7,   -9, 	   6,   -5, 	   3,   -9
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    2,  -11, 	   6,   -4, 	  -4,   -5, 	  -1,   -8
+.2byte   -3,  -13, 	   3,  -16, 	  -8,   -9, 	   0,  -11
+.2byte   -3,  -13, 	   3,  -16, 	  -8,   -9, 	   0,  -11
+.2byte   -3,  -11, 	  -7,   -4, 	   3,   -5, 	   0,   -8
+.2byte   -3,  -10, 	   6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -4,  -11, 	   2,   -8
+.2byte   -8,   -9, 	  -7,   -9, 	  -6,   -5, 	  -3,   -9
+.2byte   -8,   -9, 	  -7,   -9, 	  -6,   -5, 	  -3,   -9
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -2,  -13, 	   8,   -8, 	  -6,  -10, 	   1,   -9
+.2byte   -7,   -7, 	  -6,   -5, 	   1,   -6, 	  -2,   -9
+.2byte   -7,   -7, 	  -6,   -5, 	   1,   -6, 	  -2,   -9
+.2byte   -3,   -7, 	  -6,   -6, 	   5,   -3, 	   1,   -8
+.2byte   -4,  -10, 	   3,   -7, 	  -4,   -8, 	   0,  -10
+.2byte   -7,   -6, 	 -10,   -5, 	   6,   -8, 	   0,   -7
+.2byte   -7,   -6, 	 -10,   -5, 	   6,   -8, 	   0,   -7
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,  -14, 	  -7,   -6, 	   7,   -6, 	   0,  -10
+.2byte    0,   -8, 	  -9,  -13, 	   9,  -13, 	   0,  -11
+.2byte    3,   -7, 	   6,   -6, 	  -5,   -3, 	  -1,   -8
+.2byte    5,  -15, 	   6,   -6, 	  -1,   -5, 	   0,  -10
+.2byte    7,  -10, 	   5,   -7, 	  -7,  -12, 	   0,  -13
+.2byte    5,   -9, 	   3,   -4, 	   1,   -3, 	   0,   -8
+.2byte    3,  -14, 	   6,  -10, 	   4,   -5, 	  -1,   -7
+.2byte    9,  -12, 	   0,  -10, 	  -2,  -10, 	   1,  -12
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    2,  -12, 	  -2,  -11, 	   6,   -9, 	   0,   -8
+.2byte    4,  -13, 	  -8,  -14, 	   4,  -11, 	  -1,  -13
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -12, 	   5,  -10, 	  -6,  -10, 	   0,   -7
+.2byte    0,  -13, 	   8,  -13, 	  -8,  -13, 	   0,  -12
+.2byte   -3,  -10, 	   6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte   -2,  -12, 	   2,  -11, 	  -6,   -9, 	   0,   -8
+.2byte   -4,  -13, 	   8,  -14, 	  -4,  -11, 	   1,  -13
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -3,  -14, 	  -6,  -10, 	  -4,   -5, 	   1,   -7
+.2byte   -9,  -12, 	   0,  -10, 	   2,  -10, 	  -1,  -12
+.2byte   -3,   -7, 	  -6,   -6, 	   5,   -3, 	   1,   -8
+.2byte   -5,  -15, 	  -6,   -6, 	   1,   -5, 	   0,  -10
+.2byte   -7,  -10, 	  -5,   -7, 	   7,  -12, 	   0,  -13
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -3,   -7, 	  -6,   -6, 	   5,   -3, 	   1,   -8
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -3,  -10, 	   6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    5,   -9, 	   3,   -4, 	   1,   -3, 	   0,   -8
+.2byte    3,   -7, 	   6,   -6, 	  -5,   -3, 	  -1,   -8
+.2byte   -5,   -5, 	  -5,   -2, 	   4,    0, 	   0,   -5
+.2byte   -5,   -4, 	  -4,   -1, 	   4,    1, 	   0,   -4
+.2byte   -1,   -8, 	  -9,  -11, 	   6,   -5, 	  -1,   -9
+.2byte    2,  -15, 	   3,  -10, 	  -7,   -5, 	  -2,   -9
+.2byte    1,  -16, 	   3,  -13, 	  -5,   -6, 	  -3,  -10
+.2byte    3,  -12, 	  -7,   -8, 	   3,   -4, 	  -2,   -8
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -5, 	   0,   -8
+.2byte   -4,  -12, 	   6,   -8, 	  -4,   -4, 	   1,   -8
+.2byte   -2,  -16, 	  -4,  -13, 	   4,   -6, 	   2,  -10
+.2byte   -3,  -15, 	  -4,  -10, 	   6,   -5, 	   1,   -9
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,  -14, 	  -7,   -6, 	   7,   -6, 	   0,  -10
+.2byte    3,   -7, 	   6,   -6, 	  -5,   -3, 	  -1,   -8
+.2byte    5,  -15, 	   6,   -6, 	  -1,   -5, 	   0,  -10
+.2byte    5,   -9, 	   3,   -4, 	   1,   -3, 	   0,   -8
+.2byte    3,  -14, 	   6,  -10, 	   4,   -5, 	  -1,   -7
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    1,  -11, 	  -3,  -10, 	   5,   -8, 	  -1,   -7
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -12, 	   5,  -10, 	  -6,  -10, 	   0,   -7
+.2byte   -3,  -10, 	   6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte   -1,  -11, 	   3,  -10, 	  -5,   -8, 	   1,   -7
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -3,  -14, 	  -6,  -10, 	  -4,   -5, 	   1,   -7
+.2byte   -3,   -7, 	  -6,   -6, 	   5,   -3, 	   1,   -8
+.2byte   -5,  -15, 	  -6,   -6, 	   1,   -5, 	   0,  -10
+.2byte    0,   -5, 	  -9,  -10, 	   9,  -10, 	   0,   -8
+.2byte   -7,   -5, 	  -5,   -2, 	   7,   -7, 	   0,   -8
+.2byte   -6,   -6, 	   3,   -4, 	   5,   -4, 	   2,   -6
+.2byte   -2,   -7, 	  10,   -8, 	  -2,   -5, 	   3,   -7
+.2byte    0,   -7, 	   8,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    3,   -7, 	  -9,   -8, 	   3,   -5, 	  -2,   -7
+.2byte    8,   -7, 	  -1,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    6,   -5, 	   4,   -2, 	  -8,   -7, 	  -1,   -8
+.2byte    0,  -14, 	  -7,   -6, 	   7,   -6, 	   0,  -10
+.2byte    5,  -14, 	   6,   -5, 	  -1,   -4, 	   0,   -9
+.2byte    3,  -14, 	   6,  -10, 	   4,   -5, 	  -1,   -7
+.2byte    1,  -11, 	  -3,  -10, 	   5,   -8, 	  -1,   -7
+.2byte    0,  -12, 	   5,  -10, 	  -6,  -10, 	   0,   -7
+.2byte   -1,  -11, 	   3,  -10, 	  -5,   -8, 	   1,   -7
+.2byte   -3,  -14, 	  -6,  -10, 	  -4,   -5, 	   1,   -7
+.2byte   -5,  -14, 	  -6,   -5, 	   1,   -4, 	   0,   -9
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte    0,  -14, 	  -7,   -6, 	   7,   -6, 	   0,  -10
+.2byte    0,   -5, 	  -9,  -10, 	   9,  -10, 	   0,   -8
+.2byte    3,   -8, 	   6,   -7, 	  -5,   -4, 	  -1,   -9
+.2byte    5,  -15, 	   6,   -6, 	  -1,   -5, 	   0,  -10
+.2byte    6,   -6, 	   4,   -3, 	  -8,   -8, 	  -1,   -9
+.2byte    4,   -9, 	   2,   -4, 	   0,   -3, 	  -1,   -8
+.2byte    2,  -14, 	   5,  -10, 	   3,   -5, 	  -2,   -7
+.2byte    8,   -8, 	  -1,   -6, 	  -3,   -6, 	   0,   -8
+.2byte    2,  -10, 	  -7,   -8, 	   5,   -5, 	  -1,   -8
+.2byte    1,  -13, 	  -3,  -12, 	   5,  -10, 	  -1,   -9
+.2byte    3,   -8, 	  -9,   -9, 	   3,   -6, 	  -2,   -8
+.2byte    0,  -12, 	   8,   -5, 	  -8,   -5, 	   0,   -6
+.2byte    0,  -11, 	   5,   -9, 	  -6,   -9, 	   0,   -6
+.2byte    0,   -8, 	   8,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -5, 	  -1,   -8
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -9, 	  -1,   -8
+.2byte   -4,   -9, 	   8,  -10, 	  -4,   -7, 	   1,   -9
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -3,  -14, 	  -6,  -10, 	  -4,   -5, 	   1,   -7
+.2byte   -9,   -8, 	   0,   -6, 	   2,   -6, 	  -1,   -8
+.2byte   -4,   -7, 	  -7,   -6, 	   4,   -3, 	   0,   -8
+.2byte   -6,  -15, 	  -7,   -6, 	   0,   -5, 	  -1,  -10
+.2byte   -7,   -6, 	  -5,   -3, 	   7,   -8, 	   0,   -9
+.2byte    0,   -5, 	  -9,  -10, 	   9,  -10, 	   0,   -8
+.2byte   -8,   -6, 	  -6,   -3, 	   6,   -8, 	  -1,   -9
+.2byte   -9,   -7, 	   0,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	   8,   -9, 	  -4,   -6, 	   1,   -8
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    4,   -8, 	  -8,   -9, 	   4,   -6, 	  -1,   -8
+.2byte    8,   -7, 	  -1,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    7,   -6, 	   5,   -3, 	  -7,   -8, 	   0,   -9
+.2byte    0,   -7, 	  -8,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -3,   -7, 	  -6,   -6, 	   5,   -3, 	   1,   -8
+.2byte   -5,   -9, 	  -3,   -4, 	  -1,   -3, 	   0,   -8
+.2byte   -3,  -10, 	   6,   -8, 	  -6,   -5, 	   0,   -8
+.2byte    0,  -13, 	   8,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -5, 	   0,   -8
+.2byte    5,   -9, 	   3,   -4, 	   1,   -3, 	   0,   -8
+.2byte    3,   -7, 	   6,   -6, 	  -5,   -3, 	  -1,   -8
+sMagbyAnimTable1:
+.4byte sMagbyAnims_1_1
+.4byte sMagbyAnims_1_2
+.4byte sMagbyAnims_1_3
+.4byte sMagbyAnims_1_4
+.4byte sMagbyAnims_1_5
+.4byte sMagbyAnims_1_6
+.4byte sMagbyAnims_1_7
+.4byte sMagbyAnims_1_8
+sMagbyAnimTable2:
+.4byte sMagbyAnims_2_1
+.4byte sMagbyAnims_2_2
+.4byte sMagbyAnims_2_3
+.4byte sMagbyAnims_2_4
+.4byte sMagbyAnims_2_5
+.4byte sMagbyAnims_2_6
+.4byte sMagbyAnims_2_7
+.4byte sMagbyAnims_2_8
+sMagbyAnimTable3:
+.4byte sMagbyAnims_3_1
+.4byte sMagbyAnims_3_2
+.4byte sMagbyAnims_3_3
+.4byte sMagbyAnims_3_4
+.4byte sMagbyAnims_3_5
+.4byte sMagbyAnims_3_6
+.4byte sMagbyAnims_3_7
+.4byte sMagbyAnims_3_8
+sMagbyAnimTable4:
+.4byte sMagbyAnims_4_1
+.4byte sMagbyAnims_4_2
+.4byte sMagbyAnims_4_3
+.4byte sMagbyAnims_4_4
+.4byte sMagbyAnims_4_5
+.4byte sMagbyAnims_4_6
+.4byte sMagbyAnims_4_7
+.4byte sMagbyAnims_4_8
+sMagbyAnimTable5:
+.4byte sMagbyAnims_5_1
+.4byte sMagbyAnims_5_2
+.4byte sMagbyAnims_5_3
+.4byte sMagbyAnims_5_4
+.4byte sMagbyAnims_5_5
+.4byte sMagbyAnims_5_6
+.4byte sMagbyAnims_5_7
+.4byte sMagbyAnims_5_8
+sMagbyAnimTable6:
+.4byte sMagbyAnims_6_1
+.4byte sMagbyAnims_6_1
+.4byte sMagbyAnims_6_1
+.4byte sMagbyAnims_6_1
+.4byte sMagbyAnims_6_1
+.4byte sMagbyAnims_6_1
+.4byte sMagbyAnims_6_1
+.4byte sMagbyAnims_6_1
+sMagbyAnimTable7:
+.4byte sMagbyAnims_7_1
+.4byte sMagbyAnims_7_2
+.4byte sMagbyAnims_7_3
+.4byte sMagbyAnims_7_4
+.4byte sMagbyAnims_7_5
+.4byte sMagbyAnims_7_6
+.4byte sMagbyAnims_7_7
+.4byte sMagbyAnims_7_8
+sMagbyAnimTable8:
+.4byte sMagbyAnims_8_1
+.4byte sMagbyAnims_8_2
+.4byte sMagbyAnims_8_3
+.4byte sMagbyAnims_8_4
+.4byte sMagbyAnims_8_5
+.4byte sMagbyAnims_8_6
+.4byte sMagbyAnims_8_7
+.4byte sMagbyAnims_8_8
+sMagbyAnimTable9:
+.4byte sMagbyAnims_9_1
+.4byte sMagbyAnims_9_2
+.4byte sMagbyAnims_9_3
+.4byte sMagbyAnims_9_4
+.4byte sMagbyAnims_9_5
+.4byte sMagbyAnims_9_6
+.4byte sMagbyAnims_9_7
+.4byte sMagbyAnims_9_8
+sMagbyAnimTable10:
+.4byte sMagbyAnims_10_1
+.4byte sMagbyAnims_10_2
+.4byte sMagbyAnims_10_3
+.4byte sMagbyAnims_10_4
+.4byte sMagbyAnims_10_5
+.4byte sMagbyAnims_10_6
+.4byte sMagbyAnims_10_7
+.4byte sMagbyAnims_10_8
+sMagbyAnimTable11:
+.4byte sMagbyAnims_11_1
+.4byte sMagbyAnims_11_2
+.4byte sMagbyAnims_11_3
+.4byte sMagbyAnims_11_4
+.4byte sMagbyAnims_11_5
+.4byte sMagbyAnims_11_6
+.4byte sMagbyAnims_11_7
+.4byte sMagbyAnims_11_8
+sMagbyAnimTable12:
+.4byte sMagbyAnims_12_1
+.4byte sMagbyAnims_12_2
+.4byte sMagbyAnims_12_3
+.4byte sMagbyAnims_12_4
+.4byte sMagbyAnims_12_5
+.4byte sMagbyAnims_12_6
+.4byte sMagbyAnims_12_7
+.4byte sMagbyAnims_12_8
+sMagbyAnimTable13:
+.4byte sMagbyAnims_13_1
+.4byte sMagbyAnims_13_2
+.4byte sMagbyAnims_13_3
+.4byte sMagbyAnims_13_4
+.4byte sMagbyAnims_13_5
+.4byte sMagbyAnims_13_6
+.4byte sMagbyAnims_13_7
+.4byte sMagbyAnims_13_8
+sAxAnimationsMagby:
+.4byte sMagbyAnimTable1
+.4byte sMagbyAnimTable2
+.4byte sMagbyAnimTable3
+.4byte sMagbyAnimTable4
+.4byte sMagbyAnimTable5
+.4byte sMagbyAnimTable6
+.4byte sMagbyAnimTable7
+.4byte sMagbyAnimTable8
+.4byte sMagbyAnimTable9
+.4byte sMagbyAnimTable10
+.4byte sMagbyAnimTable11
+.4byte sMagbyAnimTable12
+.4byte sMagbyAnimTable13
+sAxSpritesMagby:
+.4byte sMagbySprites1
+.4byte sMagbySprites2
+.4byte sMagbySprites3
+.4byte sMagbySprites4
+.4byte sMagbySprites5
+.4byte sMagbySprites6
+.4byte sMagbySprites7
+.4byte sMagbySprites8
+.4byte sMagbySprites9
+.4byte sMagbySprites10
+.4byte sMagbySprites11
+.4byte sMagbySprites12
+.4byte sMagbySprites13
+.4byte sMagbySprites14
+.4byte sMagbySprites15
+.4byte sMagbySprites16
+.4byte sMagbySprites17
+.4byte sMagbySprites18
+.4byte sMagbySprites19
+.4byte sMagbySprites20
+.4byte sMagbySprites21
+.4byte sMagbySprites22
+.4byte sMagbySprites23
+.4byte sMagbySprites24
+.4byte sMagbySprites25
+.4byte sMagbySprites26
+.4byte sMagbySprites27
+.4byte sMagbySprites28
+.4byte sMagbySprites29
+.4byte sMagbySprites30
+.4byte sMagbySprites31
+.4byte sMagbySprites32
+.4byte sMagbySprites33
+.4byte sMagbySprites34
+.4byte sMagbySprites35
+.4byte sMagbySprites36
+.4byte sMagbySprites37
+.4byte sMagbySprites38
+.4byte sMagbySprites39
+.4byte sMagbySprites40
+.4byte sMagbySprites41
+.4byte sMagbySprites42
+.4byte sMagbySprites43
+.4byte sMagbySprites44
+.4byte sMagbySprites45
+.4byte sMagbySprites46
+.4byte sMagbySprites47
+sAxMainMagby:
+ax_main sAxPosesMagby, sAxAnimationsMagby, 13, sAxSpritesMagby, sAxPositionsMagby

--- a/data/ax/magcargo.inc
+++ b/data/ax/magcargo.inc
@@ -1,0 +1,2828 @@
+.global gAxMagcargo
+gAxMagcargo:
+ax_siro sAxMainMagcargo
+sMagcargoPose1:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose2:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose3:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose4:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose5:
+ax_pose 4, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose6:
+ax_pose 5, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose7:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose8:
+ax_pose 7, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose9:
+ax_pose 8, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose10:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose11:
+ax_pose 10, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose12:
+ax_pose 11, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose13:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose14:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose15:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose16:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose17:
+ax_pose 16, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose18:
+ax_pose 17, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose19:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose20:
+ax_pose 19, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose21:
+ax_pose 20, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose22:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose23:
+ax_pose 22, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose24:
+ax_pose 23, 0x01ea, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose25:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose26:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose27:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose28:
+ax_pose 24, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose29:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose30:
+ax_pose 4, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose31:
+ax_pose 5, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose32:
+ax_pose 25, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose33:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose34:
+ax_pose 7, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose35:
+ax_pose 8, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose36:
+ax_pose 26, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose37:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose38:
+ax_pose 10, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose39:
+ax_pose 11, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose40:
+ax_pose 27, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose41:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose42:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose43:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose44:
+ax_pose 28, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose45:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose46:
+ax_pose 16, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose47:
+ax_pose 17, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose48:
+ax_pose 29, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose49:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose50:
+ax_pose 19, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose51:
+ax_pose 20, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose52:
+ax_pose 30, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose53:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose54:
+ax_pose 22, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose55:
+ax_pose 23, 0x01ea, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose56:
+ax_pose 31, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose57:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose58:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose59:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose60:
+ax_pose 24, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose61:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose62:
+ax_pose 4, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose63:
+ax_pose 5, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose64:
+ax_pose 25, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose65:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose66:
+ax_pose 7, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose67:
+ax_pose 8, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose68:
+ax_pose 26, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose69:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose70:
+ax_pose 10, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose71:
+ax_pose 11, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose72:
+ax_pose 27, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose73:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose74:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose75:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose76:
+ax_pose 28, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose77:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose78:
+ax_pose 16, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose79:
+ax_pose 17, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose80:
+ax_pose 29, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose81:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose82:
+ax_pose 19, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose83:
+ax_pose 20, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose84:
+ax_pose 30, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose85:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose86:
+ax_pose 22, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose87:
+ax_pose 23, 0x01ea, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose88:
+ax_pose 31, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose89:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose90:
+ax_pose 24, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose91:
+ax_pose 32, 0x01e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose92:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose93:
+ax_pose 25, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose94:
+ax_pose 33, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose95:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose96:
+ax_pose 26, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose97:
+ax_pose 34, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose98:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose99:
+ax_pose 27, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose100:
+ax_pose 35, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose101:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose102:
+ax_pose 28, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose103:
+ax_pose 36, 0x81e8, 0x80f7, 0x2c00
+ax_pose 37, 0x01f8, 0x0107, 0x2c08
+ax_pose_terminator
+sMagcargoPose104:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose105:
+ax_pose 29, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose106:
+ax_pose 38, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose107:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose108:
+ax_pose 30, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose109:
+ax_pose 39, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose110:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose111:
+ax_pose 31, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose112:
+ax_pose 40, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose113:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose114:
+ax_pose 41, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose115:
+ax_pose 42, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose116:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose117:
+ax_pose 43, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose118:
+ax_pose 44, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose119:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose120:
+ax_pose 45, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose121:
+ax_pose 46, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose122:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose123:
+ax_pose 47, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose124:
+ax_pose 48, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose125:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose126:
+ax_pose 49, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose127:
+ax_pose 50, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose128:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose129:
+ax_pose 51, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose130:
+ax_pose 52, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose131:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose132:
+ax_pose 53, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose133:
+ax_pose 54, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose134:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose135:
+ax_pose 55, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose136:
+ax_pose 56, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose137:
+ax_pose 57, 0x01ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sMagcargoPose138:
+ax_pose 58, 0x01ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sMagcargoPose139:
+ax_pose 59, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sMagcargoPose140:
+ax_pose 60, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose141:
+ax_pose 61, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose142:
+ax_pose 62, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose143:
+ax_pose 63, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMagcargoPose144:
+ax_pose 64, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose145:
+ax_pose 65, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose146:
+ax_pose 66, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose147:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose148:
+ax_pose 42, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose149:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose150:
+ax_pose 44, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose151:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose152:
+ax_pose 46, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose153:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose154:
+ax_pose 48, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose155:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose156:
+ax_pose 50, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose157:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose158:
+ax_pose 52, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose159:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose160:
+ax_pose 54, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose161:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose162:
+ax_pose 56, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose163:
+ax_pose 41, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose164:
+ax_pose 55, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose165:
+ax_pose 53, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose166:
+ax_pose 51, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose167:
+ax_pose 49, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose168:
+ax_pose 47, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose169:
+ax_pose 45, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose170:
+ax_pose 43, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose171:
+ax_pose 24, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose172:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose173:
+ax_pose 26, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose174:
+ax_pose 27, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose175:
+ax_pose 28, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose176:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose177:
+ax_pose 30, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose178:
+ax_pose 31, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose179:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose180:
+ax_pose 24, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose181:
+ax_pose 32, 0x01e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose182:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose183:
+ax_pose 25, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose184:
+ax_pose 33, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose185:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose186:
+ax_pose 26, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose187:
+ax_pose 34, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose188:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose189:
+ax_pose 27, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose190:
+ax_pose 35, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose191:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose192:
+ax_pose 28, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose193:
+ax_pose 36, 0x81e8, 0x80f7, 0x2c00
+ax_pose 37, 0x01f8, 0x0107, 0x2c08
+ax_pose_terminator
+sMagcargoPose194:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose195:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose196:
+ax_pose 38, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose197:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose198:
+ax_pose 30, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagcargoPose199:
+ax_pose 39, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose200:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose201:
+ax_pose 31, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose202:
+ax_pose 40, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagcargoPose203:
+ax_pose 42, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose204:
+ax_pose 56, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose205:
+ax_pose 54, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose206:
+ax_pose 52, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagcargoPose207:
+ax_pose 50, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose208:
+ax_pose 48, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose209:
+ax_pose 46, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagcargoPose210:
+ax_pose 44, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose211:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose212:
+ax_pose 21, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose213:
+ax_pose 18, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose214:
+ax_pose 15, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose215:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sMagcargoPose216:
+ax_pose 9, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose217:
+ax_pose 6, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagcargoPose218:
+ax_pose 3, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+.align 2
+sMagcargoAnims_1_1:
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 12, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_1_2:
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 12, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_1_3:
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 12, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_1_4:
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 12, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_1_5:
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 12, 0, 12, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_1_6:
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 12, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_1_7:
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 12, 0, 18, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_1_8:
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 12, 0, 21, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 16, 0, 17,
+ax_anim 2, 1, 24, -1, 16, -1, 17,
+ax_anim 2, 0, 24, 0, 16, 0, 17,
+ax_anim 2, 0, 24, -1, 16, -1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMagcargoAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 4, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 16, 15, 16, 15,
+ax_anim 2, 1, 28, 17, 14, 17, 14,
+ax_anim 2, 0, 28, 16, 15, 16, 15,
+ax_anim 2, 0, 28, 17, 14, 17, 14,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sMagcargoAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 4, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 8, 0, 8, 0,
+ax_anim 2, 0, 32, 14, 0, 14, 0,
+ax_anim 2, 1, 32, 14, 1, 14, 1,
+ax_anim 2, 0, 32, 14, 0, 14, 0,
+ax_anim 2, 0, 32, 14, 1, 14, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMagcargoAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, -5, 4, -5,
+ax_anim 1, 0, 37, 11, -11, 11, -11,
+ax_anim 2, 0, 36, 18, -19, 18, -19,
+ax_anim 2, 1, 36, 19, -18, 19, -18,
+ax_anim 2, 0, 36, 18, -19, 18, -19,
+ax_anim 2, 0, 36, 19, -18, 19, -18,
+ax_anim 2, 0, 36, 7, -7, 7, -7,
+ax_anim_terminator
+sMagcargoAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 4, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 41, 0, -10, 0, -10,
+ax_anim 2, 0, 40, 0, -20, 0, -20,
+ax_anim 2, 1, 40, -1, -20, -1, -20,
+ax_anim 2, 0, 40, 0, -20, 0, -20,
+ax_anim 2, 0, 40, -1, -20, -1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sMagcargoAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 4, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, -5, -4, -5,
+ax_anim 1, 0, 45, -11, -11, -11, -11,
+ax_anim 2, 0, 44, -18, -19, -18, -19,
+ax_anim 2, 1, 44, -19, -18, -19, -18,
+ax_anim 2, 0, 44, -18, -19, -18, -19,
+ax_anim 2, 0, 44, -19, -18, -19, -18,
+ax_anim 2, 0, 44, -7, -7, -7, -7,
+ax_anim_terminator
+sMagcargoAnims_2_7:
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 4, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 49, -8, 0, -8, 0,
+ax_anim 2, 0, 48, -14, 0, -14, 0,
+ax_anim 2, 1, 48, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -14, 0, -14, 0,
+ax_anim 2, 0, 48, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sMagcargoAnims_2_8:
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 4, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 53, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -16, 15, -16, 15,
+ax_anim 2, 1, 52, -17, 14, -17, 14,
+ax_anim 2, 0, 52, -16, 15, -16, 15,
+ax_anim 2, 0, 52, -17, 14, -17, 14,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_3_1:
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 4, 0, 59, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 16, 0, 17,
+ax_anim 2, 1, 56, -1, 16, -1, 17,
+ax_anim 2, 0, 56, 0, 16, 0, 17,
+ax_anim 2, 0, 56, -1, 16, -1, 17,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sMagcargoAnims_3_2:
+ax_anim 2, 0, 63, -1, -1, -1, -1,
+ax_anim 4, 0, 63, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 4, 4, 4, 4,
+ax_anim 1, 0, 61, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 16, 15, 16, 15,
+ax_anim 2, 1, 60, 17, 14, 17, 14,
+ax_anim 2, 0, 60, 16, 15, 16, 15,
+ax_anim 2, 0, 60, 17, 14, 17, 14,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sMagcargoAnims_3_3:
+ax_anim 2, 0, 67, -1, 0, -1, 0,
+ax_anim 4, 0, 67, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 4, 0, 4, 0,
+ax_anim 1, 0, 65, 8, 0, 8, 0,
+ax_anim 2, 0, 64, 14, 0, 14, 0,
+ax_anim 2, 1, 64, 14, 1, 14, 1,
+ax_anim 2, 0, 64, 14, 0, 14, 0,
+ax_anim 2, 0, 64, 14, 1, 14, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sMagcargoAnims_3_4:
+ax_anim 2, 0, 71, -1, 1, -1, 1,
+ax_anim 4, 0, 71, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, -5, 4, -5,
+ax_anim 1, 0, 69, 11, -11, 11, -11,
+ax_anim 2, 0, 68, 18, -19, 18, -19,
+ax_anim 2, 1, 68, 19, -18, 19, -18,
+ax_anim 2, 0, 68, 18, -19, 18, -19,
+ax_anim 2, 0, 68, 19, -18, 19, -18,
+ax_anim 2, 0, 68, 7, -7, 7, -7,
+ax_anim_terminator
+sMagcargoAnims_3_5:
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 4, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, -4, 0, -4,
+ax_anim 1, 0, 73, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -20, 0, -20,
+ax_anim 2, 1, 72, -1, -20, -1, -20,
+ax_anim 2, 0, 72, 0, -20, 0, -20,
+ax_anim 2, 0, 72, -1, -20, -1, -20,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sMagcargoAnims_3_6:
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 4, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 2, 78, -4, -5, -4, -5,
+ax_anim 1, 0, 77, -11, -11, -11, -11,
+ax_anim 2, 0, 76, -18, -19, -18, -19,
+ax_anim 2, 1, 76, -19, -18, -19, -18,
+ax_anim 2, 0, 76, -18, -19, -18, -19,
+ax_anim 2, 0, 76, -19, -18, -19, -18,
+ax_anim 2, 0, 76, -7, -7, -7, -7,
+ax_anim_terminator
+sMagcargoAnims_3_7:
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 4, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 81, -8, 0, -8, 0,
+ax_anim 2, 0, 80, -14, 0, -14, 0,
+ax_anim 2, 1, 80, -14, 1, -14, 1,
+ax_anim 2, 0, 80, -14, 0, -14, 0,
+ax_anim 2, 0, 80, -14, 1, -14, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sMagcargoAnims_3_8:
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 4, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 86, -4, 4, -4, 4,
+ax_anim 1, 0, 85, -10, 10, -10, 10,
+ax_anim 2, 0, 84, -16, 15, -16, 15,
+ax_anim 2, 1, 84, -17, 14, -17, 14,
+ax_anim 2, 0, 84, -16, 15, -16, 15,
+ax_anim 2, 0, 84, -17, 14, -17, 14,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_4_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 1, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sMagcargoAnims_4_2:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 1, 0, 93, -1, -1, -1, -1,
+ax_anim 1, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 1, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 6, 4, 6, 4,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 6, 4, 6, 4,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 6, 4, 6, 4,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim_terminator
+sMagcargoAnims_4_3:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 1, 0, 96, -1, 0, -1, 0,
+ax_anim 1, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 1, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, 1, 5, 1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, 1, 5, 1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, 1, 5, 1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim_terminator
+sMagcargoAnims_4_4:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 1, 0, 99, -1, 1, -1, 1,
+ax_anim 1, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 1, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim_terminator
+sMagcargoAnims_4_5:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 1, 0, 102, 0, 1, 0, 1,
+ax_anim 1, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 1, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 1, -5, 1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 1, -5, 1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 1, -5, 1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sMagcargoAnims_4_6:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 1, 0, 105, 1, 1, 1, 1,
+ax_anim 1, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 1, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -6, -4, -6, -4,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -6, -4, -6, -4,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -6, -4, -6, -4,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim_terminator
+sMagcargoAnims_4_7:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 108, 1, 0, 1, 0,
+ax_anim 1, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 1, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, 1, -5, 1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, 1, -5, 1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, 1, -5, 1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim_terminator
+sMagcargoAnims_4_8:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 111, 1, -1, 1, -1,
+ax_anim 1, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 1, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_5_1:
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_5_2:
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_5_3:
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_5_4:
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_5_5:
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_5_6:
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_5_7:
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_5_8:
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sMagcargoAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sMagcargoAnims_7_3:
+ax_anim 2, 0, 140, -6, 0, -6, 0,
+ax_anim 8, 0, 140, -7, 0, -7, 0,
+ax_anim_terminator
+sMagcargoAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sMagcargoAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sMagcargoAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sMagcargoAnims_7_7:
+ax_anim 2, 0, 144, 6, 0, 6, 0,
+ax_anim 8, 0, 144, 7, 0, 7, 0,
+ax_anim_terminator
+sMagcargoAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_8_2:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_8_3:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_8_4:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_8_5:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_8_6:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_8_7:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_8_8:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 7, 3, 7, 3,
+ax_anim 2, 0, 164, 10, 9, 10, 9,
+ax_anim 2, 0, 165, 7, 14, 7, 14,
+ax_anim 3, 0, 166, 0, 16, 0, 16,
+ax_anim 2, 3, 167, -7, 14, -7, 14,
+ax_anim 2, 0, 168, -10, 9, -10, 9,
+ax_anim 1, 0, 169, -7, 3, -7, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 21, 10, 21, 10,
+ax_anim 3, 0, 165, 19, 17, 19, 17,
+ax_anim 2, 3, 166, 11, 19, 11, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, -1, 8, -1, 8,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -5, 17, -5,
+ax_anim 3, 0, 164, 20, -2, 20, -2,
+ax_anim 2, 3, 165, 17, 4, 17, 4,
+ax_anim 2, 0, 166, 11, 5, 11, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -18, 4, -18,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 22, -23, 22, -23,
+ax_anim 2, 3, 164, 22, -14, 22, -14,
+ax_anim 2, 0, 165, 15, -5, 15, -5,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -11, -12, -11, -12,
+ax_anim 2, 0, 169, -7, -20, -7, -20,
+ax_anim 3, 0, 162, 0, -24, 0, -24,
+ax_anim 2, 3, 163, 7, -20, 7, -20,
+ax_anim 2, 0, 164, 11, -12, 11, -12,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -18, -4, -18,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -22, -23, -22, -23,
+ax_anim 2, 3, 168, -22, -14, -22, -14,
+ax_anim 2, 0, 167, -15, -5, -15, -5,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -5, -17, -5,
+ax_anim 3, 0, 168, -20, -2, -20, -2,
+ax_anim 2, 3, 167, -17, 4, -17, 4,
+ax_anim 2, 0, 166, -11, 5, -11, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -21, 10, -21, 10,
+ax_anim 3, 0, 167, -19, 17, -19, 17,
+ax_anim 2, 3, 166, -11, 19, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, -1, 8, -1, 8,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagcargoAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMagcargoGfx1:
+.incbin "baserom.gba", 0xEE2BA8, 0x100
+sMagcargoSprites1:
+ax_sprite sMagcargoGfx1, 0x100
+ax_sprite_terminator
+sMagcargoGfx2:
+.incbin "baserom.gba", 0xEE2CB8, 0x100
+sMagcargoSprites2:
+ax_sprite sMagcargoGfx2, 0x100
+ax_sprite_terminator
+sMagcargoGfx3:
+.incbin "baserom.gba", 0xEE2DC8, 0x100
+sMagcargoSprites3:
+ax_sprite sMagcargoGfx3, 0x100
+ax_sprite_terminator
+sMagcargoGfx4:
+.incbin "baserom.gba", 0xEE2ED8, 0x200
+sMagcargoSprites4:
+ax_sprite sMagcargoGfx4, 0x200
+ax_sprite_terminator
+sMagcargoGfx5:
+.incbin "baserom.gba", 0xEE30E8, 0x200
+sMagcargoSprites5:
+ax_sprite sMagcargoGfx5, 0x200
+ax_sprite_terminator
+sMagcargoGfx6:
+.incbin "baserom.gba", 0xEE32F8, 0x200
+sMagcargoSprites6:
+ax_sprite sMagcargoGfx6, 0x200
+ax_sprite_terminator
+sMagcargoGfx7:
+.incbin "baserom.gba", 0xEE3508, 0x200
+sMagcargoSprites7:
+ax_sprite sMagcargoGfx7, 0x200
+ax_sprite_terminator
+sMagcargoGfx8:
+.incbin "baserom.gba", 0xEE3718, 0x200
+sMagcargoSprites8:
+ax_sprite sMagcargoGfx8, 0x200
+ax_sprite_terminator
+sMagcargoGfx9:
+.incbin "baserom.gba", 0xEE3928, 0x200
+sMagcargoSprites9:
+ax_sprite sMagcargoGfx9, 0x200
+ax_sprite_terminator
+sMagcargoGfx10:
+.incbin "baserom.gba", 0xEE3B38, 0x200
+sMagcargoSprites10:
+ax_sprite sMagcargoGfx10, 0x200
+ax_sprite_terminator
+sMagcargoGfx11:
+.incbin "baserom.gba", 0xEE3D48, 0x200
+sMagcargoSprites11:
+ax_sprite sMagcargoGfx11, 0x200
+ax_sprite_terminator
+sMagcargoGfx12:
+.incbin "baserom.gba", 0xEE3F58, 0x200
+sMagcargoSprites12:
+ax_sprite sMagcargoGfx12, 0x200
+ax_sprite_terminator
+sMagcargoGfx13:
+.incbin "baserom.gba", 0xEE4168, 0x100
+sMagcargoSprites13:
+ax_sprite sMagcargoGfx13, 0x100
+ax_sprite_terminator
+sMagcargoGfx14:
+.incbin "baserom.gba", 0xEE4278, 0x100
+sMagcargoSprites14:
+ax_sprite sMagcargoGfx14, 0x100
+ax_sprite_terminator
+sMagcargoGfx15:
+.incbin "baserom.gba", 0xEE4388, 0x100
+sMagcargoSprites15:
+ax_sprite sMagcargoGfx15, 0x100
+ax_sprite_terminator
+sMagcargoGfx16:
+.incbin "baserom.gba", 0xEE4498, 0x200
+sMagcargoSprites16:
+ax_sprite sMagcargoGfx16, 0x200
+ax_sprite_terminator
+sMagcargoGfx17:
+.incbin "baserom.gba", 0xEE46A8, 0x200
+sMagcargoSprites17:
+ax_sprite sMagcargoGfx17, 0x200
+ax_sprite_terminator
+sMagcargoGfx18:
+.incbin "baserom.gba", 0xEE48B8, 0x200
+sMagcargoSprites18:
+ax_sprite sMagcargoGfx18, 0x200
+ax_sprite_terminator
+sMagcargoGfx19:
+.incbin "baserom.gba", 0xEE4AC8, 0x200
+sMagcargoSprites19:
+ax_sprite sMagcargoGfx19, 0x200
+ax_sprite_terminator
+sMagcargoGfx20:
+.incbin "baserom.gba", 0xEE4CD8, 0x200
+sMagcargoSprites20:
+ax_sprite sMagcargoGfx20, 0x200
+ax_sprite_terminator
+sMagcargoGfx21:
+.incbin "baserom.gba", 0xEE4EE8, 0x200
+sMagcargoSprites21:
+ax_sprite sMagcargoGfx21, 0x200
+ax_sprite_terminator
+sMagcargoGfx22:
+.incbin "baserom.gba", 0xEE50F8, 0x200
+sMagcargoSprites22:
+ax_sprite sMagcargoGfx22, 0x200
+ax_sprite_terminator
+sMagcargoGfx23:
+.incbin "baserom.gba", 0xEE5308, 0x200
+sMagcargoSprites23:
+ax_sprite sMagcargoGfx23, 0x200
+ax_sprite_terminator
+sMagcargoGfx24:
+.incbin "baserom.gba", 0xEE5518, 0x200
+sMagcargoSprites24:
+ax_sprite sMagcargoGfx24, 0x200
+ax_sprite_terminator
+sMagcargoGfx25:
+.incbin "baserom.gba", 0xEE5728, 0x100
+sMagcargoSprites25:
+ax_sprite sMagcargoGfx25, 0x100
+ax_sprite_terminator
+sMagcargoGfx26:
+.incbin "baserom.gba", 0xEE5838, 0x40
+sMagcargoGfx26_1:
+.incbin "baserom.gba", 0xEE5878, 0x180
+sMagcargoSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx26_1, 0x180
+ax_sprite_terminator
+sMagcargoGfx27:
+.incbin "baserom.gba", 0xEE5A20, 0x200
+sMagcargoSprites27:
+ax_sprite sMagcargoGfx27, 0x200
+ax_sprite_terminator
+sMagcargoGfx28:
+.incbin "baserom.gba", 0xEE5C30, 0x1E0
+sMagcargoSprites28:
+ax_sprite sMagcargoGfx28, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagcargoGfx29:
+.incbin "baserom.gba", 0xEE5E28, 0x100
+sMagcargoSprites29:
+ax_sprite sMagcargoGfx29, 0x100
+ax_sprite_terminator
+sMagcargoGfx30:
+.incbin "baserom.gba", 0xEE5F38, 0x60
+sMagcargoGfx30_1:
+.incbin "baserom.gba", 0xEE5F98, 0x100
+sMagcargoGfx30_2:
+.incbin "baserom.gba", 0xEE6098, 0x60
+sMagcargoSprites30:
+ax_sprite sMagcargoGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx30_2, 0x60
+ax_sprite_terminator
+sMagcargoGfx31:
+.incbin "baserom.gba", 0xEE6128, 0x200
+sMagcargoSprites31:
+ax_sprite sMagcargoGfx31, 0x200
+ax_sprite_terminator
+sMagcargoGfx32:
+.incbin "baserom.gba", 0xEE6338, 0x20
+sMagcargoGfx32_1:
+.incbin "baserom.gba", 0xEE6358, 0x180
+sMagcargoSprites32:
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx32, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx32_1, 0x180
+ax_sprite_terminator
+sMagcargoGfx33:
+.incbin "baserom.gba", 0xEE6500, 0x60
+sMagcargoGfx33_1:
+.incbin "baserom.gba", 0xEE6560, 0x60
+sMagcargoGfx33_2:
+.incbin "baserom.gba", 0xEE65C0, 0x40
+sMagcargoGfx33_3:
+.incbin "baserom.gba", 0xEE6600, 0x40
+sMagcargoSprites33:
+ax_sprite sMagcargoGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx33_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagcargoGfx34:
+.incbin "baserom.gba", 0xEE6688, 0x60
+sMagcargoGfx34_1:
+.incbin "baserom.gba", 0xEE66E8, 0xE0
+sMagcargoGfx34_2:
+.incbin "baserom.gba", 0xEE67C8, 0x60
+sMagcargoSprites34:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx34_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx34_2, 0x60
+ax_sprite_terminator
+sMagcargoGfx35:
+.incbin "baserom.gba", 0xEE6860, 0x40
+sMagcargoGfx35_1:
+.incbin "baserom.gba", 0xEE68A0, 0x180
+sMagcargoSprites35:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx35_1, 0x180
+ax_sprite_terminator
+sMagcargoGfx36:
+.incbin "baserom.gba", 0xEE6A48, 0x1C0
+sMagcargoSprites36:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx36, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagcargoGfx37:
+.incbin "baserom.gba", 0xEE6C28, 0x100
+sMagcargoSprites37:
+ax_sprite sMagcargoGfx37, 0x100
+ax_sprite_terminator
+sMagcargoGfx38:
+.incbin "baserom.gba", 0xEE6D38, 0x20
+sMagcargoSprites38:
+ax_sprite sMagcargoGfx38, 0x20
+ax_sprite_terminator
+sMagcargoGfx39:
+.incbin "baserom.gba", 0xEE6D68, 0x40
+sMagcargoGfx39_1:
+.incbin "baserom.gba", 0xEE6DA8, 0x100
+sMagcargoGfx39_2:
+.incbin "baserom.gba", 0xEE6EA8, 0x60
+sMagcargoSprites39:
+ax_sprite sMagcargoGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx39_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx39_2, 0x60
+ax_sprite_terminator
+sMagcargoGfx40:
+.incbin "baserom.gba", 0xEE6F38, 0x20
+sMagcargoGfx40_1:
+.incbin "baserom.gba", 0xEE6F58, 0x180
+sMagcargoSprites40:
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx40, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx40_1, 0x180
+ax_sprite_terminator
+sMagcargoGfx41:
+.incbin "baserom.gba", 0xEE7100, 0x40
+sMagcargoGfx41_1:
+.incbin "baserom.gba", 0xEE7140, 0x60
+sMagcargoGfx41_2:
+.incbin "baserom.gba", 0xEE71A0, 0xE0
+sMagcargoSprites41:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx41_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagcargoGfx42:
+.incbin "baserom.gba", 0xEE72C0, 0x100
+sMagcargoSprites42:
+ax_sprite sMagcargoGfx42, 0x100
+ax_sprite_terminator
+sMagcargoGfx43:
+.incbin "baserom.gba", 0xEE73D0, 0x100
+sMagcargoSprites43:
+ax_sprite sMagcargoGfx43, 0x100
+ax_sprite_terminator
+sMagcargoGfx44:
+.incbin "baserom.gba", 0xEE74E0, 0x160
+sMagcargoGfx44_1:
+.incbin "baserom.gba", 0xEE7640, 0x60
+sMagcargoSprites44:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx44, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx44_1, 0x60
+ax_sprite_terminator
+sMagcargoGfx45:
+.incbin "baserom.gba", 0xEE76C8, 0x40
+sMagcargoGfx45_1:
+.incbin "baserom.gba", 0xEE7708, 0x60
+sMagcargoGfx45_2:
+.incbin "baserom.gba", 0xEE7768, 0x80
+sMagcargoGfx45_3:
+.incbin "baserom.gba", 0xEE77E8, 0x60
+sMagcargoSprites45:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx45_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx45_3, 0x60
+ax_sprite_terminator
+sMagcargoGfx46:
+.incbin "baserom.gba", 0xEE7890, 0x200
+sMagcargoSprites46:
+ax_sprite sMagcargoGfx46, 0x200
+ax_sprite_terminator
+sMagcargoGfx47:
+.incbin "baserom.gba", 0xEE7AA0, 0x40
+sMagcargoGfx47_1:
+.incbin "baserom.gba", 0xEE7AE0, 0x180
+sMagcargoSprites47:
+ax_sprite sMagcargoGfx47, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx47_1, 0x180
+ax_sprite_terminator
+sMagcargoGfx48:
+.incbin "baserom.gba", 0xEE7C80, 0x140
+sMagcargoGfx48_1:
+.incbin "baserom.gba", 0xEE7DC0, 0x60
+sMagcargoSprites48:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx48, 0x140
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagcargoGfx49:
+.incbin "baserom.gba", 0xEE7E50, 0x40
+sMagcargoGfx49_1:
+.incbin "baserom.gba", 0xEE7E90, 0x160
+sMagcargoSprites49:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx49_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagcargoGfx50:
+.incbin "baserom.gba", 0xEE8020, 0x100
+sMagcargoSprites50:
+ax_sprite sMagcargoGfx50, 0x100
+ax_sprite_terminator
+sMagcargoGfx51:
+.incbin "baserom.gba", 0xEE8130, 0x100
+sMagcargoSprites51:
+ax_sprite sMagcargoGfx51, 0x100
+ax_sprite_terminator
+sMagcargoGfx52:
+.incbin "baserom.gba", 0xEE8240, 0x60
+sMagcargoGfx52_1:
+.incbin "baserom.gba", 0xEE82A0, 0x80
+sMagcargoGfx52_2:
+.incbin "baserom.gba", 0xEE8320, 0x60
+sMagcargoGfx52_3:
+.incbin "baserom.gba", 0xEE8380, 0x60
+sMagcargoSprites52:
+ax_sprite sMagcargoGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx52_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx52_3, 0x60
+ax_sprite_terminator
+sMagcargoGfx53:
+.incbin "baserom.gba", 0xEE8420, 0x20
+sMagcargoGfx53_1:
+.incbin "baserom.gba", 0xEE8440, 0x100
+sMagcargoGfx53_2:
+.incbin "baserom.gba", 0xEE8540, 0x60
+sMagcargoSprites53:
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx53, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx53_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx53_2, 0x60
+ax_sprite_terminator
+sMagcargoGfx54:
+.incbin "baserom.gba", 0xEE85D8, 0x200
+sMagcargoSprites54:
+ax_sprite sMagcargoGfx54, 0x200
+ax_sprite_terminator
+sMagcargoGfx55:
+.incbin "baserom.gba", 0xEE87E8, 0x1C0
+sMagcargoSprites55:
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx55, 0x1c0
+ax_sprite_terminator
+sMagcargoGfx56:
+.incbin "baserom.gba", 0xEE89C0, 0x60
+sMagcargoGfx56_1:
+.incbin "baserom.gba", 0xEE8A20, 0x160
+sMagcargoSprites56:
+ax_sprite sMagcargoGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagcargoGfx56_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagcargoGfx57:
+.incbin "baserom.gba", 0xEE8BA8, 0x20
+sMagcargoGfx57_1:
+.incbin "baserom.gba", 0xEE8BC8, 0x140
+sMagcargoSprites57:
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx57, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMagcargoGfx57_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagcargoGfx58:
+.incbin "baserom.gba", 0xEE8D38, 0x200
+sMagcargoSprites58:
+ax_sprite sMagcargoGfx58, 0x200
+ax_sprite_terminator
+sMagcargoGfx59:
+.incbin "baserom.gba", 0xEE8F48, 0x200
+sMagcargoSprites59:
+ax_sprite sMagcargoGfx59, 0x200
+ax_sprite_terminator
+sMagcargoGfx60:
+.incbin "baserom.gba", 0xEE9158, 0x200
+sMagcargoSprites60:
+ax_sprite sMagcargoGfx60, 0x200
+ax_sprite_terminator
+sMagcargoGfx61:
+.incbin "baserom.gba", 0xEE9368, 0x200
+sMagcargoSprites61:
+ax_sprite sMagcargoGfx61, 0x200
+ax_sprite_terminator
+sMagcargoGfx62:
+.incbin "baserom.gba", 0xEE9578, 0x200
+sMagcargoSprites62:
+ax_sprite sMagcargoGfx62, 0x200
+ax_sprite_terminator
+sMagcargoGfx63:
+.incbin "baserom.gba", 0xEE9788, 0x200
+sMagcargoSprites63:
+ax_sprite sMagcargoGfx63, 0x200
+ax_sprite_terminator
+sMagcargoGfx64:
+.incbin "baserom.gba", 0xEE9998, 0x200
+sMagcargoSprites64:
+ax_sprite sMagcargoGfx64, 0x200
+ax_sprite_terminator
+sMagcargoGfx65:
+.incbin "baserom.gba", 0xEE9BA8, 0x200
+sMagcargoSprites65:
+ax_sprite sMagcargoGfx65, 0x200
+ax_sprite_terminator
+sMagcargoGfx66:
+.incbin "baserom.gba", 0xEE9DB8, 0x200
+sMagcargoSprites66:
+ax_sprite sMagcargoGfx66, 0x200
+ax_sprite_terminator
+sMagcargoGfx67:
+.incbin "baserom.gba", 0xEE9FC8, 0x200
+sMagcargoSprites67:
+ax_sprite sMagcargoGfx67, 0x200
+ax_sprite_terminator
+sAxPosesMagcargo:
+.4byte sMagcargoPose1
+.4byte sMagcargoPose2
+.4byte sMagcargoPose3
+.4byte sMagcargoPose4
+.4byte sMagcargoPose5
+.4byte sMagcargoPose6
+.4byte sMagcargoPose7
+.4byte sMagcargoPose8
+.4byte sMagcargoPose9
+.4byte sMagcargoPose10
+.4byte sMagcargoPose11
+.4byte sMagcargoPose12
+.4byte sMagcargoPose13
+.4byte sMagcargoPose14
+.4byte sMagcargoPose15
+.4byte sMagcargoPose16
+.4byte sMagcargoPose17
+.4byte sMagcargoPose18
+.4byte sMagcargoPose19
+.4byte sMagcargoPose20
+.4byte sMagcargoPose21
+.4byte sMagcargoPose22
+.4byte sMagcargoPose23
+.4byte sMagcargoPose24
+.4byte sMagcargoPose25
+.4byte sMagcargoPose26
+.4byte sMagcargoPose27
+.4byte sMagcargoPose28
+.4byte sMagcargoPose29
+.4byte sMagcargoPose30
+.4byte sMagcargoPose31
+.4byte sMagcargoPose32
+.4byte sMagcargoPose33
+.4byte sMagcargoPose34
+.4byte sMagcargoPose35
+.4byte sMagcargoPose36
+.4byte sMagcargoPose37
+.4byte sMagcargoPose38
+.4byte sMagcargoPose39
+.4byte sMagcargoPose40
+.4byte sMagcargoPose41
+.4byte sMagcargoPose42
+.4byte sMagcargoPose43
+.4byte sMagcargoPose44
+.4byte sMagcargoPose45
+.4byte sMagcargoPose46
+.4byte sMagcargoPose47
+.4byte sMagcargoPose48
+.4byte sMagcargoPose49
+.4byte sMagcargoPose50
+.4byte sMagcargoPose51
+.4byte sMagcargoPose52
+.4byte sMagcargoPose53
+.4byte sMagcargoPose54
+.4byte sMagcargoPose55
+.4byte sMagcargoPose56
+.4byte sMagcargoPose57
+.4byte sMagcargoPose58
+.4byte sMagcargoPose59
+.4byte sMagcargoPose60
+.4byte sMagcargoPose61
+.4byte sMagcargoPose62
+.4byte sMagcargoPose63
+.4byte sMagcargoPose64
+.4byte sMagcargoPose65
+.4byte sMagcargoPose66
+.4byte sMagcargoPose67
+.4byte sMagcargoPose68
+.4byte sMagcargoPose69
+.4byte sMagcargoPose70
+.4byte sMagcargoPose71
+.4byte sMagcargoPose72
+.4byte sMagcargoPose73
+.4byte sMagcargoPose74
+.4byte sMagcargoPose75
+.4byte sMagcargoPose76
+.4byte sMagcargoPose77
+.4byte sMagcargoPose78
+.4byte sMagcargoPose79
+.4byte sMagcargoPose80
+.4byte sMagcargoPose81
+.4byte sMagcargoPose82
+.4byte sMagcargoPose83
+.4byte sMagcargoPose84
+.4byte sMagcargoPose85
+.4byte sMagcargoPose86
+.4byte sMagcargoPose87
+.4byte sMagcargoPose88
+.4byte sMagcargoPose89
+.4byte sMagcargoPose90
+.4byte sMagcargoPose91
+.4byte sMagcargoPose92
+.4byte sMagcargoPose93
+.4byte sMagcargoPose94
+.4byte sMagcargoPose95
+.4byte sMagcargoPose96
+.4byte sMagcargoPose97
+.4byte sMagcargoPose98
+.4byte sMagcargoPose99
+.4byte sMagcargoPose100
+.4byte sMagcargoPose101
+.4byte sMagcargoPose102
+.4byte sMagcargoPose103
+.4byte sMagcargoPose104
+.4byte sMagcargoPose105
+.4byte sMagcargoPose106
+.4byte sMagcargoPose107
+.4byte sMagcargoPose108
+.4byte sMagcargoPose109
+.4byte sMagcargoPose110
+.4byte sMagcargoPose111
+.4byte sMagcargoPose112
+.4byte sMagcargoPose113
+.4byte sMagcargoPose114
+.4byte sMagcargoPose115
+.4byte sMagcargoPose116
+.4byte sMagcargoPose117
+.4byte sMagcargoPose118
+.4byte sMagcargoPose119
+.4byte sMagcargoPose120
+.4byte sMagcargoPose121
+.4byte sMagcargoPose122
+.4byte sMagcargoPose123
+.4byte sMagcargoPose124
+.4byte sMagcargoPose125
+.4byte sMagcargoPose126
+.4byte sMagcargoPose127
+.4byte sMagcargoPose128
+.4byte sMagcargoPose129
+.4byte sMagcargoPose130
+.4byte sMagcargoPose131
+.4byte sMagcargoPose132
+.4byte sMagcargoPose133
+.4byte sMagcargoPose134
+.4byte sMagcargoPose135
+.4byte sMagcargoPose136
+.4byte sMagcargoPose137
+.4byte sMagcargoPose138
+.4byte sMagcargoPose139
+.4byte sMagcargoPose140
+.4byte sMagcargoPose141
+.4byte sMagcargoPose142
+.4byte sMagcargoPose143
+.4byte sMagcargoPose144
+.4byte sMagcargoPose145
+.4byte sMagcargoPose146
+.4byte sMagcargoPose147
+.4byte sMagcargoPose148
+.4byte sMagcargoPose149
+.4byte sMagcargoPose150
+.4byte sMagcargoPose151
+.4byte sMagcargoPose152
+.4byte sMagcargoPose153
+.4byte sMagcargoPose154
+.4byte sMagcargoPose155
+.4byte sMagcargoPose156
+.4byte sMagcargoPose157
+.4byte sMagcargoPose158
+.4byte sMagcargoPose159
+.4byte sMagcargoPose160
+.4byte sMagcargoPose161
+.4byte sMagcargoPose162
+.4byte sMagcargoPose163
+.4byte sMagcargoPose164
+.4byte sMagcargoPose165
+.4byte sMagcargoPose166
+.4byte sMagcargoPose167
+.4byte sMagcargoPose168
+.4byte sMagcargoPose169
+.4byte sMagcargoPose170
+.4byte sMagcargoPose171
+.4byte sMagcargoPose172
+.4byte sMagcargoPose173
+.4byte sMagcargoPose174
+.4byte sMagcargoPose175
+.4byte sMagcargoPose176
+.4byte sMagcargoPose177
+.4byte sMagcargoPose178
+.4byte sMagcargoPose179
+.4byte sMagcargoPose180
+.4byte sMagcargoPose181
+.4byte sMagcargoPose182
+.4byte sMagcargoPose183
+.4byte sMagcargoPose184
+.4byte sMagcargoPose185
+.4byte sMagcargoPose186
+.4byte sMagcargoPose187
+.4byte sMagcargoPose188
+.4byte sMagcargoPose189
+.4byte sMagcargoPose190
+.4byte sMagcargoPose191
+.4byte sMagcargoPose192
+.4byte sMagcargoPose193
+.4byte sMagcargoPose194
+.4byte sMagcargoPose195
+.4byte sMagcargoPose196
+.4byte sMagcargoPose197
+.4byte sMagcargoPose198
+.4byte sMagcargoPose199
+.4byte sMagcargoPose200
+.4byte sMagcargoPose201
+.4byte sMagcargoPose202
+.4byte sMagcargoPose203
+.4byte sMagcargoPose204
+.4byte sMagcargoPose205
+.4byte sMagcargoPose206
+.4byte sMagcargoPose207
+.4byte sMagcargoPose208
+.4byte sMagcargoPose209
+.4byte sMagcargoPose210
+.4byte sMagcargoPose211
+.4byte sMagcargoPose212
+.4byte sMagcargoPose213
+.4byte sMagcargoPose214
+.4byte sMagcargoPose215
+.4byte sMagcargoPose216
+.4byte sMagcargoPose217
+.4byte sMagcargoPose218
+sAxPositionsMagcargo:
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    0,   -5, 	  -5,   -1, 	   4,   -1, 	   0,   -7
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+.2byte   10,   -1, 	   2,    2, 	   8,    0, 	   0,   -2
+.2byte   13,    0, 	   4,    5, 	   9,    3, 	   1,   -1
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte   13,   -7, 	   8,    0, 	   7,   -5, 	   2,   -2
+.2byte   15,  -11, 	   9,    0, 	   8,   -5, 	   2,   -3
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte    9,  -14, 	   8,   -6, 	   2,   -8, 	   2,   -5
+.2byte   11,  -17, 	   9,   -7, 	   3,  -10, 	   3,   -5
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    0,  -13, 	   5,   -6, 	  -5,   -7, 	   0,   -6
+.2byte    0,  -16, 	   5,   -7, 	  -5,   -7, 	   0,   -7
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -9,  -13, 	  -3,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte  -11,  -16, 	  -4,   -9, 	 -10,   -7, 	  -3,   -6
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte  -14,   -7, 	  -8,   -4, 	  -5,    1, 	  -2,   -3
+.2byte  -15,  -10, 	 -11,   -4, 	 -10,    1, 	  -3,   -3
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte  -12,   -1, 	  -9,    0, 	  -1,    2, 	  -1,   -2
+.2byte  -14,    0, 	 -10,    2, 	  -3,    4, 	  -2,   -1
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    0,   -5, 	  -5,   -1, 	   4,   -1, 	   0,   -7
+.2byte    0,   -6, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+.2byte   10,   -1, 	   2,    2, 	   8,    0, 	   0,   -2
+.2byte   13,    0, 	   4,    5, 	   9,    3, 	   1,   -1
+.2byte    5,   -5, 	   0,    3, 	   6,    1, 	  -2,   -2
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte   13,   -7, 	   8,    0, 	   7,   -5, 	   2,   -2
+.2byte   15,  -11, 	   9,    0, 	   8,   -5, 	   2,   -3
+.2byte    9,  -11, 	   5,    1, 	   6,   -3, 	  -3,   -3
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte    9,  -14, 	   8,   -6, 	   2,   -8, 	   2,   -5
+.2byte   11,  -17, 	   9,   -7, 	   3,  -10, 	   3,   -5
+.2byte    5,  -15, 	   6,   -4, 	  -1,   -5, 	  -3,   -1
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    0,  -13, 	   5,   -6, 	  -5,   -7, 	   0,   -6
+.2byte    0,  -16, 	   5,   -7, 	  -5,   -7, 	   0,   -7
+.2byte    0,  -13, 	   5,   -4, 	  -6,   -4, 	   0,   -3
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -9,  -13, 	  -3,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte  -11,  -16, 	  -4,   -9, 	 -10,   -7, 	  -3,   -6
+.2byte   -5,  -15, 	  -1,   -6, 	  -7,   -4, 	   1,   -6
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte  -14,   -7, 	  -8,   -4, 	  -5,    1, 	  -2,   -3
+.2byte  -15,  -10, 	 -11,   -4, 	 -10,    1, 	  -3,   -3
+.2byte  -10,  -11, 	  -7,   -3, 	  -7,    1, 	   2,   -3
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte  -12,   -1, 	  -9,    0, 	  -1,    2, 	  -1,   -2
+.2byte  -14,    0, 	 -10,    2, 	  -3,    4, 	  -2,   -1
+.2byte   -7,   -6, 	  -8,    1, 	  -1,    3, 	   1,   -2
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte   -1,   -3, 	  -6,    0, 	   5,    0, 	   0,   -6
+.2byte    0,   -5, 	  -5,   -1, 	   4,   -1, 	   0,   -7
+.2byte    0,   -6, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+.2byte   10,   -1, 	   2,    2, 	   8,    0, 	   0,   -2
+.2byte   13,    0, 	   4,    5, 	   9,    3, 	   1,   -1
+.2byte    5,   -5, 	   0,    3, 	   6,    1, 	  -2,   -2
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte   13,   -7, 	   8,    0, 	   7,   -5, 	   2,   -2
+.2byte   15,  -11, 	   9,    0, 	   8,   -5, 	   2,   -3
+.2byte    9,  -11, 	   5,    1, 	   6,   -3, 	  -3,   -3
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte    9,  -14, 	   8,   -6, 	   2,   -8, 	   2,   -5
+.2byte   11,  -17, 	   9,   -7, 	   3,  -10, 	   3,   -5
+.2byte    5,  -15, 	   6,   -4, 	  -1,   -5, 	  -3,   -1
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    0,  -13, 	   5,   -6, 	  -5,   -7, 	   0,   -6
+.2byte    0,  -16, 	   5,   -7, 	  -5,   -7, 	   0,   -7
+.2byte    0,  -13, 	   5,   -4, 	  -6,   -4, 	   0,   -3
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -9,  -13, 	  -3,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte  -11,  -16, 	  -4,   -9, 	 -10,   -7, 	  -3,   -6
+.2byte   -5,  -15, 	  -1,   -6, 	  -7,   -4, 	   1,   -6
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte  -14,   -7, 	  -8,   -4, 	  -5,    1, 	  -2,   -3
+.2byte  -15,  -10, 	 -11,   -4, 	 -10,    1, 	  -3,   -3
+.2byte  -10,  -11, 	  -7,   -3, 	  -7,    1, 	   2,   -3
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte  -12,   -1, 	  -9,    0, 	  -1,    2, 	  -1,   -2
+.2byte  -14,    0, 	 -10,    2, 	  -3,    4, 	  -2,   -1
+.2byte   -7,   -6, 	  -8,    1, 	  -1,    3, 	   1,   -2
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte    0,   -6, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    0,    0, 	  -5,    2, 	   5,    2, 	   0,   -4
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+.2byte    5,   -5, 	   0,    3, 	   6,    1, 	  -2,   -2
+.2byte   10,   -1, 	   4,    3, 	   8,    1, 	   1,   -2
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte    9,  -11, 	   5,    1, 	   6,   -3, 	  -3,   -3
+.2byte   14,   -5, 	   8,    1, 	   7,   -3, 	   0,   -3
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte    5,  -15, 	   6,   -4, 	  -1,   -5, 	  -3,   -1
+.2byte    9,  -13, 	   8,   -5, 	   2,   -7, 	  -1,   -2
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    0,  -13, 	   5,   -4, 	  -6,   -4, 	   0,   -3
+.2byte    0,  -13, 	   5,   -7, 	  -6,   -6, 	   0,   -4
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -5,  -15, 	  -1,   -6, 	  -7,   -4, 	   1,   -6
+.2byte   -9,  -12, 	  -3,   -7, 	  -8,   -4, 	  -1,   -5
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte  -10,  -11, 	  -7,   -3, 	  -7,    1, 	   2,   -3
+.2byte  -14,   -5, 	  -8,   -3, 	  -7,    2, 	  -3,   -2
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte   -7,   -6, 	  -8,    1, 	  -1,    3, 	   1,   -2
+.2byte  -11,   -1, 	  -9,    1, 	  -2,    3, 	  -1,   -1
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte   -1,   -5, 	  -5,    1, 	   4,    0, 	   0,   -3
+.2byte    0,    0, 	  -5,    3, 	   5,    2, 	   0,   -3
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+.2byte    8,   -7, 	   1,    3, 	   6,   -1, 	   0,   -3
+.2byte    7,   -1, 	   1,    3, 	   6,    0, 	  -1,   -2
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte   13,  -11, 	   7,    0, 	   7,   -4, 	  -1,   -3
+.2byte    9,   -6, 	   6,    1, 	   6,   -3, 	  -2,   -3
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte    8,  -17, 	   5,   -4, 	  -1,   -6, 	  -3,   -2
+.2byte    6,  -12, 	   6,   -3, 	  -1,   -6, 	  -2,   -3
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    0,  -15, 	   5,   -6, 	  -6,   -6, 	   0,   -6
+.2byte    0,   -9, 	   5,   -4, 	  -6,   -4, 	   0,   -3
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -8,  -16, 	   0,   -7, 	  -6,   -4, 	   1,   -5
+.2byte   -6,  -11, 	  -1,   -6, 	  -7,   -3, 	   1,   -3
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte  -14,  -11, 	  -7,   -4, 	  -8,    1, 	  -2,   -3
+.2byte  -10,   -6, 	  -7,   -3, 	  -6,    2, 	   0,   -2
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte  -11,   -7, 	  -8,    0, 	   0,    2, 	   0,   -3
+.2byte   -8,   -1, 	  -8,    0, 	   0,    3, 	   2,   -2
+.2byte   -8,   -1, 	  -7,   -1, 	   0,    2, 	  -1,   -2
+.2byte   -9,    1, 	  -8,    1, 	  -2,    3, 	  -1,    0
+.2byte   -1,   -5, 	  -6,   -1, 	   5,   -1, 	   0,   -8
+.2byte    6,   -7, 	   0,    0, 	   5,   -4, 	   0,   -3
+.2byte    9,  -10, 	   3,   -1, 	   7,   -7, 	   2,   -5
+.2byte    5,  -14, 	   7,   -7, 	   1,   -9, 	   2,   -6
+.2byte    0,  -14, 	   5,   -8, 	  -5,   -8, 	   0,   -7
+.2byte   -7,  -15, 	  -1,  -10, 	  -8,   -7, 	  -1,   -5
+.2byte  -10,  -10, 	  -9,   -7, 	 -10,   -3, 	  -1,   -4
+.2byte   -6,   -7, 	  -7,   -5, 	  -1,   -1, 	   1,   -5
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte    0,    0, 	  -5,    3, 	   5,    2, 	   0,   -3
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+.2byte    7,   -1, 	   1,    3, 	   6,    0, 	  -1,   -2
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte    9,   -6, 	   6,    1, 	   6,   -3, 	  -2,   -3
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte    6,  -12, 	   6,   -3, 	  -1,   -6, 	  -2,   -3
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    0,   -9, 	   5,   -4, 	  -6,   -4, 	   0,   -3
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -6,  -11, 	  -1,   -6, 	  -7,   -3, 	   1,   -3
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte  -10,   -6, 	  -7,   -3, 	  -6,    2, 	   0,   -2
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte   -8,   -1, 	  -8,    0, 	   0,    3, 	   2,   -2
+.2byte   -1,   -5, 	  -5,    1, 	   4,    0, 	   0,   -3
+.2byte  -11,   -7, 	  -8,    0, 	   0,    2, 	   0,   -3
+.2byte  -14,  -11, 	  -7,   -4, 	  -8,    1, 	  -2,   -3
+.2byte   -8,  -16, 	   0,   -7, 	  -6,   -4, 	   1,   -5
+.2byte    0,  -15, 	   5,   -6, 	  -6,   -6, 	   0,   -6
+.2byte    8,  -17, 	   5,   -4, 	  -1,   -6, 	  -3,   -2
+.2byte   13,  -11, 	   7,    0, 	   7,   -4, 	  -1,   -3
+.2byte    8,   -7, 	   1,    3, 	   6,   -1, 	   0,   -3
+.2byte    0,   -6, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    5,   -6, 	   0,    2, 	   6,    0, 	  -2,   -3
+.2byte   10,  -11, 	   6,    1, 	   7,   -3, 	  -2,   -3
+.2byte    6,  -15, 	   7,   -4, 	   0,   -5, 	  -2,   -1
+.2byte    0,  -14, 	   5,   -5, 	  -6,   -5, 	   0,   -4
+.2byte   -6,  -15, 	  -2,   -6, 	  -8,   -4, 	   0,   -6
+.2byte  -11,  -11, 	  -8,   -3, 	  -8,    1, 	   1,   -3
+.2byte   -7,   -7, 	  -8,    0, 	  -1,    2, 	   1,   -3
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte    0,   -6, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    0,    0, 	  -5,    2, 	   5,    2, 	   0,   -4
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+.2byte    5,   -5, 	   0,    3, 	   6,    1, 	  -2,   -2
+.2byte    8,   -1, 	   2,    3, 	   6,    1, 	  -1,   -2
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte   10,  -11, 	   6,    1, 	   7,   -3, 	  -2,   -3
+.2byte   13,   -5, 	   7,    1, 	   6,   -3, 	  -1,   -3
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte    6,  -15, 	   7,   -4, 	   0,   -5, 	  -2,   -1
+.2byte    8,  -13, 	   7,   -5, 	   1,   -7, 	  -2,   -2
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    0,  -13, 	   5,   -4, 	  -6,   -4, 	   0,   -3
+.2byte    0,  -13, 	   5,   -7, 	  -6,   -6, 	   0,   -4
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -6,  -15, 	  -2,   -6, 	  -8,   -4, 	   0,   -6
+.2byte   -8,  -12, 	  -2,   -7, 	  -7,   -4, 	   0,   -5
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte  -11,  -11, 	  -8,   -3, 	  -8,    1, 	   1,   -3
+.2byte  -13,   -5, 	  -7,   -3, 	  -6,    2, 	  -2,   -2
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte   -7,   -6, 	  -8,    1, 	  -1,    3, 	   1,   -2
+.2byte   -9,   -1, 	  -7,    1, 	   0,    3, 	   1,   -1
+.2byte    0,    0, 	  -5,    3, 	   5,    2, 	   0,   -3
+.2byte   -8,   -1, 	  -8,    0, 	   0,    3, 	   2,   -2
+.2byte  -10,   -6, 	  -7,   -3, 	  -6,    2, 	   0,   -2
+.2byte   -7,  -11, 	  -2,   -6, 	  -8,   -3, 	   0,   -3
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -4
+.2byte    7,  -12, 	   7,   -3, 	   0,   -6, 	  -1,   -3
+.2byte    9,   -6, 	   6,    1, 	   6,   -3, 	  -2,   -3
+.2byte    7,   -1, 	   1,    3, 	   6,    0, 	  -1,   -2
+.2byte   -1,   -1, 	  -6,    1, 	   5,    1, 	   0,   -5
+.2byte   -9,   -1, 	  -8,    1, 	   0,    2, 	   0,   -2
+.2byte  -12,   -6, 	  -8,   -4, 	  -7,    1, 	   0,   -2
+.2byte   -8,  -12, 	  -1,   -7, 	  -7,   -4, 	   0,   -4
+.2byte    0,  -12, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte    6,  -13, 	   6,   -4, 	  -1,   -7, 	   1,   -4
+.2byte   12,   -7, 	   6,    1, 	   6,   -4, 	   0,   -2
+.2byte    8,   -2, 	   1,    3, 	   7,    0, 	   0,   -2
+sMagcargoAnimTable1:
+.4byte sMagcargoAnims_1_1
+.4byte sMagcargoAnims_1_2
+.4byte sMagcargoAnims_1_3
+.4byte sMagcargoAnims_1_4
+.4byte sMagcargoAnims_1_5
+.4byte sMagcargoAnims_1_6
+.4byte sMagcargoAnims_1_7
+.4byte sMagcargoAnims_1_8
+sMagcargoAnimTable2:
+.4byte sMagcargoAnims_2_1
+.4byte sMagcargoAnims_2_2
+.4byte sMagcargoAnims_2_3
+.4byte sMagcargoAnims_2_4
+.4byte sMagcargoAnims_2_5
+.4byte sMagcargoAnims_2_6
+.4byte sMagcargoAnims_2_7
+.4byte sMagcargoAnims_2_8
+sMagcargoAnimTable3:
+.4byte sMagcargoAnims_3_1
+.4byte sMagcargoAnims_3_2
+.4byte sMagcargoAnims_3_3
+.4byte sMagcargoAnims_3_4
+.4byte sMagcargoAnims_3_5
+.4byte sMagcargoAnims_3_6
+.4byte sMagcargoAnims_3_7
+.4byte sMagcargoAnims_3_8
+sMagcargoAnimTable4:
+.4byte sMagcargoAnims_4_1
+.4byte sMagcargoAnims_4_2
+.4byte sMagcargoAnims_4_3
+.4byte sMagcargoAnims_4_4
+.4byte sMagcargoAnims_4_5
+.4byte sMagcargoAnims_4_6
+.4byte sMagcargoAnims_4_7
+.4byte sMagcargoAnims_4_8
+sMagcargoAnimTable5:
+.4byte sMagcargoAnims_5_1
+.4byte sMagcargoAnims_5_2
+.4byte sMagcargoAnims_5_3
+.4byte sMagcargoAnims_5_4
+.4byte sMagcargoAnims_5_5
+.4byte sMagcargoAnims_5_6
+.4byte sMagcargoAnims_5_7
+.4byte sMagcargoAnims_5_8
+sMagcargoAnimTable6:
+.4byte sMagcargoAnims_6_1
+.4byte sMagcargoAnims_6_1
+.4byte sMagcargoAnims_6_1
+.4byte sMagcargoAnims_6_1
+.4byte sMagcargoAnims_6_1
+.4byte sMagcargoAnims_6_1
+.4byte sMagcargoAnims_6_1
+.4byte sMagcargoAnims_6_1
+sMagcargoAnimTable7:
+.4byte sMagcargoAnims_7_1
+.4byte sMagcargoAnims_7_2
+.4byte sMagcargoAnims_7_3
+.4byte sMagcargoAnims_7_4
+.4byte sMagcargoAnims_7_5
+.4byte sMagcargoAnims_7_6
+.4byte sMagcargoAnims_7_7
+.4byte sMagcargoAnims_7_8
+sMagcargoAnimTable8:
+.4byte sMagcargoAnims_8_1
+.4byte sMagcargoAnims_8_2
+.4byte sMagcargoAnims_8_3
+.4byte sMagcargoAnims_8_4
+.4byte sMagcargoAnims_8_5
+.4byte sMagcargoAnims_8_6
+.4byte sMagcargoAnims_8_7
+.4byte sMagcargoAnims_8_8
+sMagcargoAnimTable9:
+.4byte sMagcargoAnims_9_1
+.4byte sMagcargoAnims_9_2
+.4byte sMagcargoAnims_9_3
+.4byte sMagcargoAnims_9_4
+.4byte sMagcargoAnims_9_5
+.4byte sMagcargoAnims_9_6
+.4byte sMagcargoAnims_9_7
+.4byte sMagcargoAnims_9_8
+sMagcargoAnimTable10:
+.4byte sMagcargoAnims_10_1
+.4byte sMagcargoAnims_10_2
+.4byte sMagcargoAnims_10_3
+.4byte sMagcargoAnims_10_4
+.4byte sMagcargoAnims_10_5
+.4byte sMagcargoAnims_10_6
+.4byte sMagcargoAnims_10_7
+.4byte sMagcargoAnims_10_8
+sMagcargoAnimTable11:
+.4byte sMagcargoAnims_11_1
+.4byte sMagcargoAnims_11_2
+.4byte sMagcargoAnims_11_3
+.4byte sMagcargoAnims_11_4
+.4byte sMagcargoAnims_11_5
+.4byte sMagcargoAnims_11_6
+.4byte sMagcargoAnims_11_7
+.4byte sMagcargoAnims_11_8
+sMagcargoAnimTable12:
+.4byte sMagcargoAnims_12_1
+.4byte sMagcargoAnims_12_2
+.4byte sMagcargoAnims_12_3
+.4byte sMagcargoAnims_12_4
+.4byte sMagcargoAnims_12_5
+.4byte sMagcargoAnims_12_6
+.4byte sMagcargoAnims_12_7
+.4byte sMagcargoAnims_12_8
+sMagcargoAnimTable13:
+.4byte sMagcargoAnims_13_1
+.4byte sMagcargoAnims_13_2
+.4byte sMagcargoAnims_13_3
+.4byte sMagcargoAnims_13_4
+.4byte sMagcargoAnims_13_5
+.4byte sMagcargoAnims_13_6
+.4byte sMagcargoAnims_13_7
+.4byte sMagcargoAnims_13_8
+sAxAnimationsMagcargo:
+.4byte sMagcargoAnimTable1
+.4byte sMagcargoAnimTable2
+.4byte sMagcargoAnimTable3
+.4byte sMagcargoAnimTable4
+.4byte sMagcargoAnimTable5
+.4byte sMagcargoAnimTable6
+.4byte sMagcargoAnimTable7
+.4byte sMagcargoAnimTable8
+.4byte sMagcargoAnimTable9
+.4byte sMagcargoAnimTable10
+.4byte sMagcargoAnimTable11
+.4byte sMagcargoAnimTable12
+.4byte sMagcargoAnimTable13
+sAxSpritesMagcargo:
+.4byte sMagcargoSprites1
+.4byte sMagcargoSprites2
+.4byte sMagcargoSprites3
+.4byte sMagcargoSprites4
+.4byte sMagcargoSprites5
+.4byte sMagcargoSprites6
+.4byte sMagcargoSprites7
+.4byte sMagcargoSprites8
+.4byte sMagcargoSprites9
+.4byte sMagcargoSprites10
+.4byte sMagcargoSprites11
+.4byte sMagcargoSprites12
+.4byte sMagcargoSprites13
+.4byte sMagcargoSprites14
+.4byte sMagcargoSprites15
+.4byte sMagcargoSprites16
+.4byte sMagcargoSprites17
+.4byte sMagcargoSprites18
+.4byte sMagcargoSprites19
+.4byte sMagcargoSprites20
+.4byte sMagcargoSprites21
+.4byte sMagcargoSprites22
+.4byte sMagcargoSprites23
+.4byte sMagcargoSprites24
+.4byte sMagcargoSprites25
+.4byte sMagcargoSprites26
+.4byte sMagcargoSprites27
+.4byte sMagcargoSprites28
+.4byte sMagcargoSprites29
+.4byte sMagcargoSprites30
+.4byte sMagcargoSprites31
+.4byte sMagcargoSprites32
+.4byte sMagcargoSprites33
+.4byte sMagcargoSprites34
+.4byte sMagcargoSprites35
+.4byte sMagcargoSprites36
+.4byte sMagcargoSprites37
+.4byte sMagcargoSprites38
+.4byte sMagcargoSprites39
+.4byte sMagcargoSprites40
+.4byte sMagcargoSprites41
+.4byte sMagcargoSprites42
+.4byte sMagcargoSprites43
+.4byte sMagcargoSprites44
+.4byte sMagcargoSprites45
+.4byte sMagcargoSprites46
+.4byte sMagcargoSprites47
+.4byte sMagcargoSprites48
+.4byte sMagcargoSprites49
+.4byte sMagcargoSprites50
+.4byte sMagcargoSprites51
+.4byte sMagcargoSprites52
+.4byte sMagcargoSprites53
+.4byte sMagcargoSprites54
+.4byte sMagcargoSprites55
+.4byte sMagcargoSprites56
+.4byte sMagcargoSprites57
+.4byte sMagcargoSprites58
+.4byte sMagcargoSprites59
+.4byte sMagcargoSprites60
+.4byte sMagcargoSprites61
+.4byte sMagcargoSprites62
+.4byte sMagcargoSprites63
+.4byte sMagcargoSprites64
+.4byte sMagcargoSprites65
+.4byte sMagcargoSprites66
+.4byte sMagcargoSprites67
+sAxMainMagcargo:
+ax_main sAxPosesMagcargo, sAxAnimationsMagcargo, 13, sAxSpritesMagcargo, sAxPositionsMagcargo

--- a/data/ax/magikarp.inc
+++ b/data/ax/magikarp.inc
@@ -1,0 +1,2600 @@
+.global gAxMagikarp
+gAxMagikarp:
+ax_siro sAxMainMagikarp
+sMagikarpPose1:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose2:
+ax_pose 1, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose3:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose4:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose5:
+ax_pose 4, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose6:
+ax_pose 5, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose7:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose8:
+ax_pose 7, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose9:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose10:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose11:
+ax_pose 10, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose12:
+ax_pose 11, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose13:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose14:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose15:
+ax_pose 14, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose16:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose17:
+ax_pose 16, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose18:
+ax_pose 17, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose19:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose20:
+ax_pose 19, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose21:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose22:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose23:
+ax_pose 22, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose24:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose25:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose26:
+ax_pose 1, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose27:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose28:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose29:
+ax_pose 4, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose30:
+ax_pose 5, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose31:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose32:
+ax_pose 7, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose33:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose34:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose35:
+ax_pose 10, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose36:
+ax_pose 11, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose37:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose38:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose39:
+ax_pose 14, 0x01ec, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose40:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose41:
+ax_pose 16, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose42:
+ax_pose 17, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose43:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose44:
+ax_pose 19, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose45:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose46:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose47:
+ax_pose 22, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose48:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose49:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose50:
+ax_pose 1, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose51:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose52:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose53:
+ax_pose 4, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose54:
+ax_pose 5, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose55:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose56:
+ax_pose 7, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose57:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose58:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose59:
+ax_pose 10, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose60:
+ax_pose 11, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose61:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose62:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose63:
+ax_pose 14, 0x01ec, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose64:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose65:
+ax_pose 16, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose66:
+ax_pose 17, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose67:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose68:
+ax_pose 19, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose69:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose70:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose71:
+ax_pose 22, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose72:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose73:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose74:
+ax_pose 1, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose75:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose76:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose77:
+ax_pose 4, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose78:
+ax_pose 5, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose79:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose80:
+ax_pose 7, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose81:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose82:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose83:
+ax_pose 10, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose84:
+ax_pose 11, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose85:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose86:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose87:
+ax_pose 14, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose88:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose89:
+ax_pose 16, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose90:
+ax_pose 17, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose91:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose92:
+ax_pose 19, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose93:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose94:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose95:
+ax_pose 22, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose96:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose97:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose98:
+ax_pose 1, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose99:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose100:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose101:
+ax_pose 4, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose102:
+ax_pose 5, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose103:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose104:
+ax_pose 7, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose105:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose106:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose107:
+ax_pose 10, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose108:
+ax_pose 11, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose109:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose110:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose111:
+ax_pose 14, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose112:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose113:
+ax_pose 16, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose114:
+ax_pose 17, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose115:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose116:
+ax_pose 19, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose117:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose118:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose119:
+ax_pose 22, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose120:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose121:
+ax_pose 24, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose122:
+ax_pose 25, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose123:
+ax_pose 26, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose124:
+ax_pose 27, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sMagikarpPose125:
+ax_pose 28, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sMagikarpPose126:
+ax_pose 29, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sMagikarpPose127:
+ax_pose 30, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagikarpPose128:
+ax_pose 29, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose129:
+ax_pose 28, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose130:
+ax_pose 27, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sMagikarpPose131:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose132:
+ax_pose 1, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose133:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose134:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose135:
+ax_pose 4, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose136:
+ax_pose 5, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose137:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose138:
+ax_pose 7, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose139:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose140:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose141:
+ax_pose 10, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose142:
+ax_pose 11, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose143:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose144:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose145:
+ax_pose 14, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose146:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose147:
+ax_pose 16, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose148:
+ax_pose 17, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose149:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose150:
+ax_pose 19, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose151:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose152:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose153:
+ax_pose 22, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose154:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose155:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose156:
+ax_pose 23, 0x01f0, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose157:
+ax_pose 20, 0x01f0, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagikarpPose158:
+ax_pose 17, 0x01f4, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose159:
+ax_pose 14, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose160:
+ax_pose 11, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose161:
+ax_pose 8, 0x01f1, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagikarpPose162:
+ax_pose 5, 0x01f0, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagikarpPose163:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose164:
+ax_pose 5, 0x01f0, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagikarpPose165:
+ax_pose 8, 0x01f1, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagikarpPose166:
+ax_pose 11, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose167:
+ax_pose 14, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose168:
+ax_pose 17, 0x01f4, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose169:
+ax_pose 20, 0x01f0, 0x80f2, 0x0c00
+ax_pose_terminator
+sMagikarpPose170:
+ax_pose 23, 0x01f0, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose171:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose172:
+ax_pose 1, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose173:
+ax_pose 2, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose174:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose175:
+ax_pose 4, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose176:
+ax_pose 5, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose177:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose178:
+ax_pose 7, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose179:
+ax_pose 8, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose180:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose181:
+ax_pose 10, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose182:
+ax_pose 11, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose183:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose184:
+ax_pose 13, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose185:
+ax_pose 14, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose186:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose187:
+ax_pose 16, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose188:
+ax_pose 17, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose189:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose190:
+ax_pose 19, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose191:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose192:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose193:
+ax_pose 22, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose194:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose195:
+ax_pose 0, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose196:
+ax_pose 21, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose197:
+ax_pose 18, 0x01f1, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose198:
+ax_pose 15, 0x01f5, 0x80f1, 0x0c00
+ax_pose_terminator
+sMagikarpPose199:
+ax_pose 12, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose200:
+ax_pose 9, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sMagikarpPose201:
+ax_pose 6, 0x01f2, 0x80ef, 0x0c00
+ax_pose_terminator
+sMagikarpPose202:
+ax_pose 3, 0x01f0, 0x80ee, 0x0c00
+ax_pose_terminator
+sMagikarpPose203:
+ax_pose 0, 0x01ef, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose204:
+ax_pose 21, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose205:
+ax_pose 18, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose206:
+ax_pose 15, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose207:
+ax_pose 12, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sMagikarpPose208:
+ax_pose 9, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMagikarpPose209:
+ax_pose 6, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sMagikarpPose210:
+ax_pose 3, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+.align 2
+sMagikarpAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 2, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 2, 0, -7, 0, 0,
+ax_anim 4, 0, 1, 0, -5, 0, 0,
+ax_anim 2, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 2, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 5, 0, -7, 0, 0,
+ax_anim 4, 0, 4, 0, -5, 0, 0,
+ax_anim 2, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 2, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 8, 0, -7, 0, 0,
+ax_anim 4, 0, 7, 0, -5, 0, 0,
+ax_anim 2, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, -4, 0, 0,
+ax_anim 4, 0, 9, 0, -5, 0, 0,
+ax_anim 6, 0, 11, 0, -7, 0, 0,
+ax_anim 4, 0, 10, 0, -5, 0, 0,
+ax_anim 2, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, -4, 0, 0,
+ax_anim 4, 0, 12, 0, -5, 0, 0,
+ax_anim 6, 0, 14, 0, -7, 0, 0,
+ax_anim 4, 0, 13, 0, -5, 0, 0,
+ax_anim 2, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, -4, 0, 0,
+ax_anim 4, 0, 15, 0, -5, 0, 0,
+ax_anim 6, 0, 17, 0, -7, 0, 0,
+ax_anim 4, 0, 16, 0, -5, 0, 0,
+ax_anim 2, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, -4, 0, 0,
+ax_anim 4, 0, 18, 0, -5, 0, 0,
+ax_anim 6, 0, 20, 0, -7, 0, 0,
+ax_anim 4, 0, 19, 0, -5, 0, 0,
+ax_anim 2, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, -4, 0, 0,
+ax_anim 4, 0, 21, 0, -5, 0, 0,
+ax_anim 6, 0, 23, 0, -7, 0, 0,
+ax_anim 4, 0, 22, 0, -5, 0, 0,
+ax_anim 2, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_2_1:
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -1, 0, 2,
+ax_anim 2, 0, 25, 0, -3, 0, 4,
+ax_anim 2, 0, 26, 0, 3, 0, 6,
+ax_anim 2, 0, 26, 0, 8, 0, 8,
+ax_anim 2, 0, 25, 0, 8, 0, 10,
+ax_anim 2, 0, 25, 0, 6, 0, 12,
+ax_anim 2, 2, 25, 0, 7, 0, 14,
+ax_anim 2, 0, 26, 0, 10, 0, 16,
+ax_anim 2, 1, 26, 0, 17, 0, 17,
+ax_anim 2, 0, 25, 0, 16, 0, 17,
+ax_anim 2, 0, 25, 0, 14, 0, 17,
+ax_anim 2, 0, 24, 0, 15, 0, 17,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 0, 25, 0, -4, 0, 6,
+ax_anim_terminator
+sMagikarpAnims_2_2:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 2, -1, 2, 2,
+ax_anim 2, 0, 28, 4, -3, 4, 4,
+ax_anim 2, 0, 29, 6, 3, 6, 6,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim 2, 0, 28, 10, 8, 10, 10,
+ax_anim 2, 0, 28, 12, 6, 12, 12,
+ax_anim 2, 2, 28, 14, 7, 14, 14,
+ax_anim 2, 0, 29, 16, 10, 16, 16,
+ax_anim 2, 1, 29, 17, 17, 17, 17,
+ax_anim 2, 0, 28, 17, 16, 17, 17,
+ax_anim 2, 0, 28, 17, 14, 17, 17,
+ax_anim 2, 0, 27, 17, 15, 17, 17,
+ax_anim 2, 0, 29, 17, 17, 17, 17,
+ax_anim 2, 0, 28, 6, -4, 6, 6,
+ax_anim_terminator
+sMagikarpAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 2, -3, 2, 0,
+ax_anim 2, 0, 31, 4, -6, 4, 0,
+ax_anim 2, 0, 32, 6, -3, 6, 0,
+ax_anim 2, 0, 32, 8, 0, 8, 0,
+ax_anim 2, 0, 31, 10, -2, 10, 0,
+ax_anim 2, 0, 31, 12, -6, 12, 0,
+ax_anim 2, 2, 31, 14, -8, 14, 0,
+ax_anim 2, 0, 32, 16, -6, 16, 0,
+ax_anim 2, 1, 32, 17, 0, 17, 0,
+ax_anim 2, 0, 31, 17, -1, 17, 0,
+ax_anim 2, 0, 31, 17, -3, 17, 0,
+ax_anim 2, 0, 30, 17, -2, 17, 0,
+ax_anim 2, 0, 32, 17, 0, 17, 0,
+ax_anim 2, 0, 31, 6, -4, 6, 0,
+ax_anim_terminator
+sMagikarpAnims_2_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 2, -5, 2, -2,
+ax_anim 2, 0, 34, 4, -10, 4, -4,
+ax_anim 2, 0, 35, 6, -9, 6, -6,
+ax_anim 2, 0, 35, 8, -8, 8, -8,
+ax_anim 2, 0, 34, 10, -12, 10, -10,
+ax_anim 2, 0, 34, 12, -18, 12, -12,
+ax_anim 2, 2, 34, 14, -22, 14, -14,
+ax_anim 2, 0, 35, 16, -22, 16, -16,
+ax_anim 2, 1, 35, 17, -19, 17, -17,
+ax_anim 2, 0, 34, 17, -20, 17, -17,
+ax_anim 2, 0, 34, 17, -22, 17, -17,
+ax_anim 2, 0, 33, 17, -21, 17, -17,
+ax_anim 2, 0, 35, 17, -19, 17, -17,
+ax_anim 2, 0, 34, 6, -10, 6, -6,
+ax_anim_terminator
+sMagikarpAnims_2_5:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -5, 0, -2,
+ax_anim 2, 0, 37, 0, -10, 0, -4,
+ax_anim 2, 0, 38, 0, -9, 0, -6,
+ax_anim 2, 0, 38, 0, -8, 0, -8,
+ax_anim 2, 0, 37, 0, -12, 0, -10,
+ax_anim 2, 0, 37, 0, -18, 0, -12,
+ax_anim 2, 2, 37, 0, -22, 0, -14,
+ax_anim 2, 0, 38, 0, -22, 0, -16,
+ax_anim 2, 1, 38, 0, -19, 0, -17,
+ax_anim 2, 0, 37, 0, -20, 0, -17,
+ax_anim 2, 0, 37, 0, -22, 0, -17,
+ax_anim 2, 0, 36, 0, -21, 0, -17,
+ax_anim 2, 0, 38, 0, -19, 0, -17,
+ax_anim 2, 0, 37, 0, -10, 0, -6,
+ax_anim_terminator
+sMagikarpAnims_2_6:
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 40, -2, -5, -2, -2,
+ax_anim 2, 0, 40, -4, -10, -4, -4,
+ax_anim 2, 0, 41, -6, -9, -6, -6,
+ax_anim 2, 0, 41, -8, -8, -8, -8,
+ax_anim 2, 0, 40, -10, -12, -10, -10,
+ax_anim 2, 0, 40, -12, -18, -12, -12,
+ax_anim 2, 2, 40, -14, -22, -14, -14,
+ax_anim 2, 0, 41, -16, -22, -16, -16,
+ax_anim 2, 1, 41, -17, -19, -17, -17,
+ax_anim 2, 0, 40, -17, -20, -17, -17,
+ax_anim 2, 0, 40, -17, -22, -17, -17,
+ax_anim 2, 0, 39, -17, -21, -17, -17,
+ax_anim 2, 0, 41, -17, -19, -17, -17,
+ax_anim 2, 0, 40, -6, -10, -6, -6,
+ax_anim_terminator
+sMagikarpAnims_2_7:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -2, -3, -2, 0,
+ax_anim 2, 0, 43, -4, -6, -4, 0,
+ax_anim 2, 0, 44, -6, -3, -6, 0,
+ax_anim 2, 0, 44, -8, 0, -8, 0,
+ax_anim 2, 0, 43, -10, -2, -10, 0,
+ax_anim 2, 0, 43, -12, -6, -12, 0,
+ax_anim 2, 2, 43, -14, -8, -14, 0,
+ax_anim 2, 0, 44, -16, -6, -16, 0,
+ax_anim 2, 1, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 43, -17, -1, -17, 0,
+ax_anim 2, 0, 43, -17, -3, -17, 0,
+ax_anim 2, 0, 42, -17, -2, -17, 0,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 43, -6, -4, -6, 0,
+ax_anim_terminator
+sMagikarpAnims_2_8:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 46, -2, -1, -2, 2,
+ax_anim 2, 0, 46, -4, -3, -4, 4,
+ax_anim 2, 0, 47, -6, 3, -6, 6,
+ax_anim 2, 0, 47, -8, 8, -8, 8,
+ax_anim 2, 0, 46, -10, 8, -10, 10,
+ax_anim 2, 0, 46, -12, 6, -12, 12,
+ax_anim 2, 2, 46, -14, 7, -14, 14,
+ax_anim 2, 0, 47, -16, 10, -16, 16,
+ax_anim 2, 1, 47, -17, 17, -17, 17,
+ax_anim 2, 0, 46, -17, 16, -17, 17,
+ax_anim 2, 0, 46, -17, 14, -17, 17,
+ax_anim 2, 0, 45, -17, 15, -17, 17,
+ax_anim 2, 0, 47, -17, 17, -17, 17,
+ax_anim 2, 0, 46, -6, -4, -6, 6,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_3_1:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, -1, 0, 2,
+ax_anim 2, 0, 49, 0, -3, 0, 4,
+ax_anim 2, 0, 50, 0, 3, 0, 6,
+ax_anim 2, 0, 50, 0, 8, 0, 8,
+ax_anim 2, 0, 49, 0, 8, 0, 10,
+ax_anim 2, 0, 49, 0, 6, 0, 12,
+ax_anim 2, 2, 49, 0, 7, 0, 14,
+ax_anim 2, 0, 50, 0, 10, 0, 16,
+ax_anim 2, 1, 50, 0, 17, 0, 17,
+ax_anim 2, 0, 49, 0, 16, 0, 17,
+ax_anim 2, 0, 49, 0, 14, 0, 17,
+ax_anim 2, 0, 48, 0, 15, 0, 17,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 0, 49, 0, -4, 0, 6,
+ax_anim_terminator
+sMagikarpAnims_3_2:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 2, -1, 2, 2,
+ax_anim 2, 0, 52, 4, -3, 4, 4,
+ax_anim 2, 0, 53, 6, 3, 6, 6,
+ax_anim 2, 0, 53, 8, 8, 8, 8,
+ax_anim 2, 0, 52, 10, 8, 10, 10,
+ax_anim 2, 0, 52, 12, 6, 12, 12,
+ax_anim 2, 2, 52, 14, 7, 14, 14,
+ax_anim 2, 0, 53, 16, 10, 16, 16,
+ax_anim 2, 1, 53, 17, 17, 17, 17,
+ax_anim 2, 0, 52, 17, 16, 17, 17,
+ax_anim 2, 0, 52, 17, 14, 17, 17,
+ax_anim 2, 0, 51, 17, 15, 17, 17,
+ax_anim 2, 0, 53, 17, 17, 17, 17,
+ax_anim 2, 0, 52, 6, -4, 6, 6,
+ax_anim_terminator
+sMagikarpAnims_3_3:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 2, -3, 2, 0,
+ax_anim 2, 0, 55, 4, -6, 4, 0,
+ax_anim 2, 0, 56, 6, -3, 6, 0,
+ax_anim 2, 0, 56, 8, 0, 8, 0,
+ax_anim 2, 0, 55, 10, -2, 10, 0,
+ax_anim 2, 0, 55, 12, -6, 12, 0,
+ax_anim 2, 2, 55, 14, -8, 14, 0,
+ax_anim 2, 0, 56, 16, -6, 16, 0,
+ax_anim 2, 1, 56, 17, 0, 17, 0,
+ax_anim 2, 0, 55, 17, -1, 17, 0,
+ax_anim 2, 0, 55, 17, -3, 17, 0,
+ax_anim 2, 0, 54, 17, -2, 17, 0,
+ax_anim 2, 0, 56, 17, 0, 17, 0,
+ax_anim 2, 0, 55, 6, -4, 6, 0,
+ax_anim_terminator
+sMagikarpAnims_3_4:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 2, -5, 2, -2,
+ax_anim 2, 0, 58, 4, -10, 4, -4,
+ax_anim 2, 0, 59, 6, -9, 6, -6,
+ax_anim 2, 0, 59, 8, -8, 8, -8,
+ax_anim 2, 0, 58, 10, -12, 10, -10,
+ax_anim 2, 0, 58, 12, -18, 12, -12,
+ax_anim 2, 2, 58, 14, -22, 14, -14,
+ax_anim 2, 0, 59, 16, -22, 16, -16,
+ax_anim 2, 1, 59, 17, -19, 17, -17,
+ax_anim 2, 0, 58, 17, -20, 17, -17,
+ax_anim 2, 0, 58, 17, -22, 17, -17,
+ax_anim 2, 0, 57, 17, -21, 17, -17,
+ax_anim 2, 0, 59, 17, -19, 17, -17,
+ax_anim 2, 0, 58, 6, -10, 6, -6,
+ax_anim_terminator
+sMagikarpAnims_3_5:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -5, 0, -2,
+ax_anim 2, 0, 61, 0, -10, 0, -4,
+ax_anim 2, 0, 62, 0, -9, 0, -6,
+ax_anim 2, 0, 62, 0, -8, 0, -8,
+ax_anim 2, 0, 61, 0, -12, 0, -10,
+ax_anim 2, 0, 61, 0, -18, 0, -12,
+ax_anim 2, 2, 61, 0, -22, 0, -14,
+ax_anim 2, 0, 62, 0, -22, 0, -16,
+ax_anim 2, 1, 62, 0, -19, 0, -17,
+ax_anim 2, 0, 61, 0, -20, 0, -17,
+ax_anim 2, 0, 61, 0, -22, 0, -17,
+ax_anim 2, 0, 60, 0, -21, 0, -17,
+ax_anim 2, 0, 62, 0, -19, 0, -17,
+ax_anim 2, 0, 61, 0, -10, 0, -6,
+ax_anim_terminator
+sMagikarpAnims_3_6:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -2, -5, -2, -2,
+ax_anim 2, 0, 64, -4, -10, -4, -4,
+ax_anim 2, 0, 65, -6, -9, -6, -6,
+ax_anim 2, 0, 65, -8, -8, -8, -8,
+ax_anim 2, 0, 64, -10, -12, -10, -10,
+ax_anim 2, 0, 64, -12, -18, -12, -12,
+ax_anim 2, 2, 64, -14, -22, -14, -14,
+ax_anim 2, 0, 65, -16, -22, -16, -16,
+ax_anim 2, 1, 65, -17, -19, -17, -17,
+ax_anim 2, 0, 64, -17, -20, -17, -17,
+ax_anim 2, 0, 64, -17, -22, -17, -17,
+ax_anim 2, 0, 63, -17, -21, -17, -17,
+ax_anim 2, 0, 65, -17, -19, -17, -17,
+ax_anim 2, 0, 64, -6, -10, -6, -6,
+ax_anim_terminator
+sMagikarpAnims_3_7:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -2, -3, -2, 0,
+ax_anim 2, 0, 67, -4, -6, -4, 0,
+ax_anim 2, 0, 68, -6, -3, -6, 0,
+ax_anim 2, 0, 68, -8, 0, -8, 0,
+ax_anim 2, 0, 67, -10, -2, -10, 0,
+ax_anim 2, 0, 67, -12, -6, -12, 0,
+ax_anim 2, 2, 67, -14, -8, -14, 0,
+ax_anim 2, 0, 68, -16, -6, -16, 0,
+ax_anim 2, 1, 68, -17, 0, -17, 0,
+ax_anim 2, 0, 67, -17, -1, -17, 0,
+ax_anim 2, 0, 67, -17, -3, -17, 0,
+ax_anim 2, 0, 66, -17, -2, -17, 0,
+ax_anim 2, 0, 68, -17, 0, -17, 0,
+ax_anim 2, 0, 67, -6, -4, -6, 0,
+ax_anim_terminator
+sMagikarpAnims_3_8:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 70, -2, -1, -2, 2,
+ax_anim 2, 0, 70, -4, -3, -4, 4,
+ax_anim 2, 0, 71, -6, 3, -6, 6,
+ax_anim 2, 0, 71, -8, 8, -8, 8,
+ax_anim 2, 0, 70, -10, 8, -10, 10,
+ax_anim 2, 0, 70, -12, 6, -12, 12,
+ax_anim 2, 2, 70, -14, 7, -14, 14,
+ax_anim 2, 0, 71, -16, 10, -16, 16,
+ax_anim 2, 1, 71, -17, 17, -17, 17,
+ax_anim 2, 0, 70, -17, 16, -17, 17,
+ax_anim 2, 0, 70, -17, 14, -17, 17,
+ax_anim 2, 0, 69, -17, 15, -17, 17,
+ax_anim 2, 0, 71, -17, 17, -17, 17,
+ax_anim 2, 0, 70, -6, -4, -6, 6,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -1, 0, -1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -1, 0, -1, 0,
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -4, 0, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 1, 0, 74, 0, -5, 0, 0,
+ax_anim 3, 0, 74, 0, -4, 0, 0,
+ax_anim 3, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 0, -5, 0, 0,
+ax_anim 1, 0, 77, 0, -5, 0, 0,
+ax_anim 3, 0, 77, 0, -4, 0, 0,
+ax_anim 3, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 0, 80, 0, -5, 0, 0,
+ax_anim 3, 0, 80, 0, -4, 0, 0,
+ax_anim 3, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 1, 0, 83, 0, -5, 0, 0,
+ax_anim 3, 0, 83, 0, -4, 0, 0,
+ax_anim 3, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 1, 0, 86, 0, -5, 0, 0,
+ax_anim 3, 0, 86, 0, -4, 0, 0,
+ax_anim 3, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, 0, -1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, 0, -1, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -5, 0, 0,
+ax_anim 3, 0, 89, 0, -4, 0, 0,
+ax_anim 3, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -5, 0, 0,
+ax_anim 3, 0, 92, 0, -4, 0, 0,
+ax_anim 3, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 0, -1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 0, -1, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -5, 0, 0,
+ax_anim 3, 0, 95, 0, -4, 0, 0,
+ax_anim 3, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -5, 0, 0,
+ax_anim 3, 0, 98, 0, -4, 0, 0,
+ax_anim 3, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_5_2:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -5, 0, 0,
+ax_anim 3, 0, 101, 0, -4, 0, 0,
+ax_anim 3, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -5, 0, 0,
+ax_anim 3, 0, 104, 0, -4, 0, 0,
+ax_anim 3, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_5_4:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -5, 0, 0,
+ax_anim 3, 0, 107, 0, -4, 0, 0,
+ax_anim 3, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 1, 0, 110, 0, -5, 0, 0,
+ax_anim 3, 0, 110, 0, -4, 0, 0,
+ax_anim 3, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_5_6:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 1, 0, 113, 0, -5, 0, 0,
+ax_anim 3, 0, 113, 0, -4, 0, 0,
+ax_anim 3, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 0, 116, 0, -5, 0, 0,
+ax_anim 3, 0, 116, 0, -4, 0, 0,
+ax_anim 3, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_5_8:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -5, 0, 0,
+ax_anim 3, 0, 119, 0, -4, 0, 0,
+ax_anim 3, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sMagikarpAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sMagikarpAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sMagikarpAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sMagikarpAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sMagikarpAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sMagikarpAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sMagikarpAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_8_1:
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_8_2:
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_8_3:
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_8_4:
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_8_5:
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_8_6:
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_8_7:
+ax_anim 8, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_8_8:
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 15, 7, 15,
+ax_anim 3, 0, 158, 0, 18, 0, 18,
+ax_anim 2, 3, 159, -7, 15, -7, 15,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 19, 10, 19, 10,
+ax_anim 3, 0, 157, 19, 19, 19, 19,
+ax_anim 2, 3, 158, 11, 18, 11, 18,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -5, 16, -5,
+ax_anim 3, 0, 156, 18, -2, 18, -2,
+ax_anim 2, 3, 157, 16, 4, 16, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -22, 12, -22,
+ax_anim 3, 0, 155, 18, -22, 18, -22,
+ax_anim 2, 3, 156, 20, -15, 20, -15,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -13, -22, -13, -22,
+ax_anim 3, 0, 161, -20, -22, -20, -22,
+ax_anim 2, 3, 160, -21, -15, -21, -15,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -5, -16, -5,
+ax_anim 3, 0, 160, -18, -2, -18, -2,
+ax_anim 2, 3, 159, -16, 4, -16, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -19, 10, -19, 10,
+ax_anim 3, 0, 159, -19, 19, -19, 19,
+ax_anim 2, 3, 158, -11, 18, -11, 18,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagikarpAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMagikarpGfx1:
+.incbin "baserom.gba", 0xA898D8, 0x200
+sMagikarpSprites1:
+ax_sprite sMagikarpGfx1, 0x200
+ax_sprite_terminator
+sMagikarpGfx2:
+.incbin "baserom.gba", 0xA89AE8, 0x200
+sMagikarpSprites2:
+ax_sprite sMagikarpGfx2, 0x200
+ax_sprite_terminator
+sMagikarpGfx3:
+.incbin "baserom.gba", 0xA89CF8, 0x200
+sMagikarpSprites3:
+ax_sprite sMagikarpGfx3, 0x200
+ax_sprite_terminator
+sMagikarpGfx4:
+.incbin "baserom.gba", 0xA89F08, 0x200
+sMagikarpSprites4:
+ax_sprite sMagikarpGfx4, 0x200
+ax_sprite_terminator
+sMagikarpGfx5:
+.incbin "baserom.gba", 0xA8A118, 0x200
+sMagikarpSprites5:
+ax_sprite sMagikarpGfx5, 0x200
+ax_sprite_terminator
+sMagikarpGfx6:
+.incbin "baserom.gba", 0xA8A328, 0x200
+sMagikarpSprites6:
+ax_sprite sMagikarpGfx6, 0x200
+ax_sprite_terminator
+sMagikarpGfx7:
+.incbin "baserom.gba", 0xA8A538, 0x200
+sMagikarpSprites7:
+ax_sprite sMagikarpGfx7, 0x200
+ax_sprite_terminator
+sMagikarpGfx8:
+.incbin "baserom.gba", 0xA8A748, 0x200
+sMagikarpSprites8:
+ax_sprite sMagikarpGfx8, 0x200
+ax_sprite_terminator
+sMagikarpGfx9:
+.incbin "baserom.gba", 0xA8A958, 0x200
+sMagikarpSprites9:
+ax_sprite sMagikarpGfx9, 0x200
+ax_sprite_terminator
+sMagikarpGfx10:
+.incbin "baserom.gba", 0xA8AB68, 0x200
+sMagikarpSprites10:
+ax_sprite sMagikarpGfx10, 0x200
+ax_sprite_terminator
+sMagikarpGfx11:
+.incbin "baserom.gba", 0xA8AD78, 0x200
+sMagikarpSprites11:
+ax_sprite sMagikarpGfx11, 0x200
+ax_sprite_terminator
+sMagikarpGfx12:
+.incbin "baserom.gba", 0xA8AF88, 0x200
+sMagikarpSprites12:
+ax_sprite sMagikarpGfx12, 0x200
+ax_sprite_terminator
+sMagikarpGfx13:
+.incbin "baserom.gba", 0xA8B198, 0x200
+sMagikarpSprites13:
+ax_sprite sMagikarpGfx13, 0x200
+ax_sprite_terminator
+sMagikarpGfx14:
+.incbin "baserom.gba", 0xA8B3A8, 0x200
+sMagikarpSprites14:
+ax_sprite sMagikarpGfx14, 0x200
+ax_sprite_terminator
+sMagikarpGfx15:
+.incbin "baserom.gba", 0xA8B5B8, 0x200
+sMagikarpSprites15:
+ax_sprite sMagikarpGfx15, 0x200
+ax_sprite_terminator
+sMagikarpGfx16:
+.incbin "baserom.gba", 0xA8B7C8, 0x200
+sMagikarpSprites16:
+ax_sprite sMagikarpGfx16, 0x200
+ax_sprite_terminator
+sMagikarpGfx17:
+.incbin "baserom.gba", 0xA8B9D8, 0x200
+sMagikarpSprites17:
+ax_sprite sMagikarpGfx17, 0x200
+ax_sprite_terminator
+sMagikarpGfx18:
+.incbin "baserom.gba", 0xA8BBE8, 0x200
+sMagikarpSprites18:
+ax_sprite sMagikarpGfx18, 0x200
+ax_sprite_terminator
+sMagikarpGfx19:
+.incbin "baserom.gba", 0xA8BDF8, 0x200
+sMagikarpSprites19:
+ax_sprite sMagikarpGfx19, 0x200
+ax_sprite_terminator
+sMagikarpGfx20:
+.incbin "baserom.gba", 0xA8C008, 0x200
+sMagikarpSprites20:
+ax_sprite sMagikarpGfx20, 0x200
+ax_sprite_terminator
+sMagikarpGfx21:
+.incbin "baserom.gba", 0xA8C218, 0x200
+sMagikarpSprites21:
+ax_sprite sMagikarpGfx21, 0x200
+ax_sprite_terminator
+sMagikarpGfx22:
+.incbin "baserom.gba", 0xA8C428, 0x200
+sMagikarpSprites22:
+ax_sprite sMagikarpGfx22, 0x200
+ax_sprite_terminator
+sMagikarpGfx23:
+.incbin "baserom.gba", 0xA8C638, 0x200
+sMagikarpSprites23:
+ax_sprite sMagikarpGfx23, 0x200
+ax_sprite_terminator
+sMagikarpGfx24:
+.incbin "baserom.gba", 0xA8C848, 0x200
+sMagikarpSprites24:
+ax_sprite sMagikarpGfx24, 0x200
+ax_sprite_terminator
+sMagikarpGfx25:
+.incbin "baserom.gba", 0xA8CA58, 0x200
+sMagikarpSprites25:
+ax_sprite sMagikarpGfx25, 0x200
+ax_sprite_terminator
+sMagikarpGfx26:
+.incbin "baserom.gba", 0xA8CC68, 0x200
+sMagikarpSprites26:
+ax_sprite sMagikarpGfx26, 0x200
+ax_sprite_terminator
+sMagikarpGfx27:
+.incbin "baserom.gba", 0xA8CE78, 0x200
+sMagikarpSprites27:
+ax_sprite sMagikarpGfx27, 0x200
+ax_sprite_terminator
+sMagikarpGfx28:
+.incbin "baserom.gba", 0xA8D088, 0x200
+sMagikarpSprites28:
+ax_sprite sMagikarpGfx28, 0x200
+ax_sprite_terminator
+sMagikarpGfx29:
+.incbin "baserom.gba", 0xA8D298, 0x200
+sMagikarpSprites29:
+ax_sprite sMagikarpGfx29, 0x200
+ax_sprite_terminator
+sMagikarpGfx30:
+.incbin "baserom.gba", 0xA8D4A8, 0x200
+sMagikarpSprites30:
+ax_sprite sMagikarpGfx30, 0x200
+ax_sprite_terminator
+sMagikarpGfx31:
+.incbin "baserom.gba", 0xA8D6B8, 0x200
+sMagikarpSprites31:
+ax_sprite sMagikarpGfx31, 0x200
+ax_sprite_terminator
+sAxPosesMagikarp:
+.4byte sMagikarpPose1
+.4byte sMagikarpPose2
+.4byte sMagikarpPose3
+.4byte sMagikarpPose4
+.4byte sMagikarpPose5
+.4byte sMagikarpPose6
+.4byte sMagikarpPose7
+.4byte sMagikarpPose8
+.4byte sMagikarpPose9
+.4byte sMagikarpPose10
+.4byte sMagikarpPose11
+.4byte sMagikarpPose12
+.4byte sMagikarpPose13
+.4byte sMagikarpPose14
+.4byte sMagikarpPose15
+.4byte sMagikarpPose16
+.4byte sMagikarpPose17
+.4byte sMagikarpPose18
+.4byte sMagikarpPose19
+.4byte sMagikarpPose20
+.4byte sMagikarpPose21
+.4byte sMagikarpPose22
+.4byte sMagikarpPose23
+.4byte sMagikarpPose24
+.4byte sMagikarpPose25
+.4byte sMagikarpPose26
+.4byte sMagikarpPose27
+.4byte sMagikarpPose28
+.4byte sMagikarpPose29
+.4byte sMagikarpPose30
+.4byte sMagikarpPose31
+.4byte sMagikarpPose32
+.4byte sMagikarpPose33
+.4byte sMagikarpPose34
+.4byte sMagikarpPose35
+.4byte sMagikarpPose36
+.4byte sMagikarpPose37
+.4byte sMagikarpPose38
+.4byte sMagikarpPose39
+.4byte sMagikarpPose40
+.4byte sMagikarpPose41
+.4byte sMagikarpPose42
+.4byte sMagikarpPose43
+.4byte sMagikarpPose44
+.4byte sMagikarpPose45
+.4byte sMagikarpPose46
+.4byte sMagikarpPose47
+.4byte sMagikarpPose48
+.4byte sMagikarpPose49
+.4byte sMagikarpPose50
+.4byte sMagikarpPose51
+.4byte sMagikarpPose52
+.4byte sMagikarpPose53
+.4byte sMagikarpPose54
+.4byte sMagikarpPose55
+.4byte sMagikarpPose56
+.4byte sMagikarpPose57
+.4byte sMagikarpPose58
+.4byte sMagikarpPose59
+.4byte sMagikarpPose60
+.4byte sMagikarpPose61
+.4byte sMagikarpPose62
+.4byte sMagikarpPose63
+.4byte sMagikarpPose64
+.4byte sMagikarpPose65
+.4byte sMagikarpPose66
+.4byte sMagikarpPose67
+.4byte sMagikarpPose68
+.4byte sMagikarpPose69
+.4byte sMagikarpPose70
+.4byte sMagikarpPose71
+.4byte sMagikarpPose72
+.4byte sMagikarpPose73
+.4byte sMagikarpPose74
+.4byte sMagikarpPose75
+.4byte sMagikarpPose76
+.4byte sMagikarpPose77
+.4byte sMagikarpPose78
+.4byte sMagikarpPose79
+.4byte sMagikarpPose80
+.4byte sMagikarpPose81
+.4byte sMagikarpPose82
+.4byte sMagikarpPose83
+.4byte sMagikarpPose84
+.4byte sMagikarpPose85
+.4byte sMagikarpPose86
+.4byte sMagikarpPose87
+.4byte sMagikarpPose88
+.4byte sMagikarpPose89
+.4byte sMagikarpPose90
+.4byte sMagikarpPose91
+.4byte sMagikarpPose92
+.4byte sMagikarpPose93
+.4byte sMagikarpPose94
+.4byte sMagikarpPose95
+.4byte sMagikarpPose96
+.4byte sMagikarpPose97
+.4byte sMagikarpPose98
+.4byte sMagikarpPose99
+.4byte sMagikarpPose100
+.4byte sMagikarpPose101
+.4byte sMagikarpPose102
+.4byte sMagikarpPose103
+.4byte sMagikarpPose104
+.4byte sMagikarpPose105
+.4byte sMagikarpPose106
+.4byte sMagikarpPose107
+.4byte sMagikarpPose108
+.4byte sMagikarpPose109
+.4byte sMagikarpPose110
+.4byte sMagikarpPose111
+.4byte sMagikarpPose112
+.4byte sMagikarpPose113
+.4byte sMagikarpPose114
+.4byte sMagikarpPose115
+.4byte sMagikarpPose116
+.4byte sMagikarpPose117
+.4byte sMagikarpPose118
+.4byte sMagikarpPose119
+.4byte sMagikarpPose120
+.4byte sMagikarpPose121
+.4byte sMagikarpPose122
+.4byte sMagikarpPose123
+.4byte sMagikarpPose124
+.4byte sMagikarpPose125
+.4byte sMagikarpPose126
+.4byte sMagikarpPose127
+.4byte sMagikarpPose128
+.4byte sMagikarpPose129
+.4byte sMagikarpPose130
+.4byte sMagikarpPose131
+.4byte sMagikarpPose132
+.4byte sMagikarpPose133
+.4byte sMagikarpPose134
+.4byte sMagikarpPose135
+.4byte sMagikarpPose136
+.4byte sMagikarpPose137
+.4byte sMagikarpPose138
+.4byte sMagikarpPose139
+.4byte sMagikarpPose140
+.4byte sMagikarpPose141
+.4byte sMagikarpPose142
+.4byte sMagikarpPose143
+.4byte sMagikarpPose144
+.4byte sMagikarpPose145
+.4byte sMagikarpPose146
+.4byte sMagikarpPose147
+.4byte sMagikarpPose148
+.4byte sMagikarpPose149
+.4byte sMagikarpPose150
+.4byte sMagikarpPose151
+.4byte sMagikarpPose152
+.4byte sMagikarpPose153
+.4byte sMagikarpPose154
+.4byte sMagikarpPose155
+.4byte sMagikarpPose156
+.4byte sMagikarpPose157
+.4byte sMagikarpPose158
+.4byte sMagikarpPose159
+.4byte sMagikarpPose160
+.4byte sMagikarpPose161
+.4byte sMagikarpPose162
+.4byte sMagikarpPose163
+.4byte sMagikarpPose164
+.4byte sMagikarpPose165
+.4byte sMagikarpPose166
+.4byte sMagikarpPose167
+.4byte sMagikarpPose168
+.4byte sMagikarpPose169
+.4byte sMagikarpPose170
+.4byte sMagikarpPose171
+.4byte sMagikarpPose172
+.4byte sMagikarpPose173
+.4byte sMagikarpPose174
+.4byte sMagikarpPose175
+.4byte sMagikarpPose176
+.4byte sMagikarpPose177
+.4byte sMagikarpPose178
+.4byte sMagikarpPose179
+.4byte sMagikarpPose180
+.4byte sMagikarpPose181
+.4byte sMagikarpPose182
+.4byte sMagikarpPose183
+.4byte sMagikarpPose184
+.4byte sMagikarpPose185
+.4byte sMagikarpPose186
+.4byte sMagikarpPose187
+.4byte sMagikarpPose188
+.4byte sMagikarpPose189
+.4byte sMagikarpPose190
+.4byte sMagikarpPose191
+.4byte sMagikarpPose192
+.4byte sMagikarpPose193
+.4byte sMagikarpPose194
+.4byte sMagikarpPose195
+.4byte sMagikarpPose196
+.4byte sMagikarpPose197
+.4byte sMagikarpPose198
+.4byte sMagikarpPose199
+.4byte sMagikarpPose200
+.4byte sMagikarpPose201
+.4byte sMagikarpPose202
+.4byte sMagikarpPose203
+.4byte sMagikarpPose204
+.4byte sMagikarpPose205
+.4byte sMagikarpPose206
+.4byte sMagikarpPose207
+.4byte sMagikarpPose208
+.4byte sMagikarpPose209
+.4byte sMagikarpPose210
+sAxPositionsMagikarp:
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -1,    4, 	   2,   -6, 	   4,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+.2byte    7,    2, 	   0,   -3, 	   3,  -11, 	   2,   -5
+.2byte    8,   -1, 	   0,   -3, 	   3,  -10, 	   2,   -6
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte   12,   -4, 	  -2,   -2, 	   0,  -10, 	   2,   -5
+.2byte   11,   -8, 	  -2,   -3, 	  -1,   -9, 	   3,   -6
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte    8,  -12, 	   2,   -4, 	   0,   -9, 	   3,   -8
+.2byte    8,  -13, 	   1,   -4, 	   0,   -8, 	   2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    0,  -13, 	  -1,   -4, 	  -1,   -9, 	   1,   -8
+.2byte   -1,  -15, 	  -1,   -4, 	  -3,   -9, 	   0,   -8
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	   1,   -1, 	   0,   -7, 	  -2,   -6
+.2byte   -8,  -11, 	   0,   -2, 	  -3,   -5, 	  -1,   -7
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte  -11,   -3, 	   0,    0, 	  -1,   -6, 	  -1,   -5
+.2byte  -11,   -7, 	  -2,    0, 	  -1,   -3, 	  -2,   -6
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte   -9,    1, 	   3,   -1, 	   2,   -5, 	  -2,   -3
+.2byte   -9,   -3, 	   3,   -1, 	   4,   -3, 	  -1,   -5
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -1,    4, 	   2,   -6, 	   4,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+.2byte    7,    2, 	   0,   -3, 	   3,  -11, 	   2,   -5
+.2byte    8,   -1, 	   0,   -3, 	   3,  -10, 	   2,   -6
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte   12,   -4, 	  -2,   -2, 	   0,  -10, 	   2,   -5
+.2byte   11,   -8, 	  -2,   -3, 	  -1,   -9, 	   3,   -6
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte    8,  -12, 	   2,   -4, 	   0,   -9, 	   3,   -8
+.2byte    8,  -13, 	   1,   -4, 	   0,   -8, 	   2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    0,  -13, 	  -1,   -4, 	  -1,   -9, 	   1,   -8
+.2byte   -1,  -14, 	  -1,   -3, 	  -3,   -8, 	   0,   -7
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	   1,   -1, 	   0,   -7, 	  -2,   -6
+.2byte   -8,  -11, 	   0,   -2, 	  -3,   -5, 	  -1,   -7
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte  -11,   -3, 	   0,    0, 	  -1,   -6, 	  -1,   -5
+.2byte  -11,   -7, 	  -2,    0, 	  -1,   -3, 	  -2,   -6
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte   -9,    1, 	   3,   -1, 	   2,   -5, 	  -2,   -3
+.2byte   -9,   -3, 	   3,   -1, 	   4,   -3, 	  -1,   -5
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -1,    4, 	   2,   -6, 	   4,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+.2byte    7,    2, 	   0,   -3, 	   3,  -11, 	   2,   -5
+.2byte    8,   -1, 	   0,   -3, 	   3,  -10, 	   2,   -6
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte   12,   -4, 	  -2,   -2, 	   0,  -10, 	   2,   -5
+.2byte   11,   -8, 	  -2,   -3, 	  -1,   -9, 	   3,   -6
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte    8,  -12, 	   2,   -4, 	   0,   -9, 	   3,   -8
+.2byte    8,  -13, 	   1,   -4, 	   0,   -8, 	   2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    0,  -13, 	  -1,   -4, 	  -1,   -9, 	   1,   -8
+.2byte   -1,  -14, 	  -1,   -3, 	  -3,   -8, 	   0,   -7
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	   1,   -1, 	   0,   -7, 	  -2,   -6
+.2byte   -8,  -11, 	   0,   -2, 	  -3,   -5, 	  -1,   -7
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte  -11,   -3, 	   0,    0, 	  -1,   -6, 	  -1,   -5
+.2byte  -11,   -7, 	  -2,    0, 	  -1,   -3, 	  -2,   -6
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte   -9,    1, 	   3,   -1, 	   2,   -5, 	  -2,   -3
+.2byte   -9,   -3, 	   3,   -1, 	   4,   -3, 	  -1,   -5
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -1,    4, 	   2,   -6, 	   4,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+.2byte    7,    2, 	   0,   -3, 	   3,  -11, 	   2,   -5
+.2byte    8,   -1, 	   0,   -3, 	   3,  -10, 	   2,   -6
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte   12,   -4, 	  -2,   -2, 	   0,  -10, 	   2,   -5
+.2byte   11,   -8, 	  -2,   -3, 	  -1,   -9, 	   3,   -6
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte    8,  -12, 	   2,   -4, 	   0,   -9, 	   3,   -8
+.2byte    8,  -13, 	   1,   -4, 	   0,   -8, 	   2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    0,  -13, 	  -1,   -4, 	  -1,   -9, 	   1,   -8
+.2byte   -1,  -15, 	  -1,   -4, 	  -3,   -9, 	   0,   -8
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	   1,   -1, 	   0,   -7, 	  -2,   -6
+.2byte   -8,  -11, 	   0,   -2, 	  -3,   -5, 	  -1,   -7
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte  -11,   -3, 	   0,    0, 	  -1,   -6, 	  -1,   -5
+.2byte  -11,   -7, 	  -2,    0, 	  -1,   -3, 	  -2,   -6
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte   -9,    1, 	   3,   -1, 	   2,   -5, 	  -2,   -3
+.2byte   -9,   -3, 	   3,   -1, 	   4,   -3, 	  -1,   -5
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -1,    4, 	   2,   -6, 	   4,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+.2byte    7,    2, 	   0,   -3, 	   3,  -11, 	   2,   -5
+.2byte    8,   -1, 	   0,   -3, 	   3,  -10, 	   2,   -6
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte   12,   -4, 	  -2,   -2, 	   0,  -10, 	   2,   -5
+.2byte   11,   -8, 	  -2,   -3, 	  -1,   -9, 	   3,   -6
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte    8,  -12, 	   2,   -4, 	   0,   -9, 	   3,   -8
+.2byte    8,  -13, 	   1,   -4, 	   0,   -8, 	   2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    0,  -13, 	  -1,   -4, 	  -1,   -9, 	   1,   -8
+.2byte   -1,  -15, 	  -1,   -4, 	  -3,   -9, 	   0,   -8
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	   1,   -1, 	   0,   -7, 	  -2,   -6
+.2byte   -8,  -11, 	   0,   -2, 	  -3,   -5, 	  -1,   -7
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte  -11,   -3, 	   0,    0, 	  -1,   -6, 	  -1,   -5
+.2byte  -11,   -7, 	  -2,    0, 	  -1,   -3, 	  -2,   -6
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte   -9,    1, 	   3,   -1, 	   2,   -5, 	  -2,   -3
+.2byte   -9,   -3, 	   3,   -1, 	   4,   -3, 	  -1,   -5
+.2byte  -11,   -4, 	   2,   -1, 	   2,   -4, 	  -2,   -5
+.2byte  -11,   -4, 	   2,   -1, 	   2,   -4, 	  -2,   -6
+.2byte   -3,    0, 	   0,   -7, 	   3,  -11, 	  -1,   -7
+.2byte    5,   -3, 	  -5,    0, 	  -5,   -6, 	  -3,   -4
+.2byte    6,   -4, 	  -4,    1, 	  -5,   -4, 	  -3,   -4
+.2byte    6,   -8, 	  -4,    0, 	  -3,   -7, 	  -1,   -5
+.2byte   -1,  -11, 	  -1,   -1, 	  -1,   -4, 	   0,   -5
+.2byte   -7,   -8, 	   3,    0, 	   2,   -7, 	   0,   -5
+.2byte   -7,   -4, 	   3,    1, 	   4,   -4, 	   2,   -4
+.2byte   -6,   -3, 	   4,    0, 	   4,   -6, 	   2,   -4
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -1,    4, 	   2,   -6, 	   4,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+.2byte    7,    2, 	   0,   -3, 	   3,  -11, 	   2,   -5
+.2byte    8,   -1, 	   0,   -3, 	   3,  -10, 	   2,   -6
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte   12,   -4, 	  -2,   -2, 	   0,  -10, 	   2,   -5
+.2byte   11,   -8, 	  -2,   -3, 	  -1,   -9, 	   3,   -6
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte    8,  -12, 	   2,   -4, 	   0,   -9, 	   3,   -8
+.2byte    8,  -13, 	   1,   -4, 	   0,   -8, 	   2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    0,  -13, 	  -1,   -4, 	  -1,   -9, 	   1,   -8
+.2byte   -1,  -15, 	  -1,   -4, 	  -3,   -9, 	   0,   -8
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	   1,   -1, 	   0,   -7, 	  -2,   -6
+.2byte   -8,  -11, 	   0,   -2, 	  -3,   -5, 	  -1,   -7
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte  -11,   -3, 	   0,    0, 	  -1,   -6, 	  -1,   -5
+.2byte  -11,   -7, 	  -2,    0, 	  -1,   -3, 	  -2,   -6
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte   -9,    1, 	   3,   -1, 	   2,   -5, 	  -2,   -3
+.2byte   -9,   -3, 	   3,   -1, 	   4,   -3, 	  -1,   -5
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte   -8,   -3, 	   4,   -1, 	   5,   -3, 	   0,   -5
+.2byte   -9,   -6, 	   0,    1, 	   1,   -2, 	   0,   -5
+.2byte   -7,   -9, 	   1,    0, 	  -2,   -3, 	   0,   -5
+.2byte   -1,  -12, 	  -1,   -1, 	  -3,   -6, 	   0,   -5
+.2byte    8,  -10, 	   1,   -1, 	   0,   -5, 	   2,   -5
+.2byte   10,   -6, 	  -3,   -1, 	  -2,   -7, 	   2,   -4
+.2byte    7,    1, 	  -1,   -1, 	   2,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    1, 	  -1,   -1, 	   2,   -8, 	   1,   -4
+.2byte   10,   -6, 	  -3,   -1, 	  -2,   -7, 	   2,   -4
+.2byte    8,  -10, 	   1,   -1, 	   0,   -5, 	   2,   -5
+.2byte   -1,  -12, 	  -1,   -1, 	  -3,   -6, 	   0,   -5
+.2byte   -7,   -9, 	   1,    0, 	  -2,   -3, 	   0,   -5
+.2byte   -9,   -6, 	   0,    1, 	   1,   -2, 	   0,   -5
+.2byte   -8,   -3, 	   4,   -1, 	   5,   -3, 	   0,   -5
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -1,    4, 	   2,   -6, 	   4,   -8, 	   1,   -4
+.2byte    0,    1, 	   3,   -6, 	   8,   -5, 	   1,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+.2byte    7,    2, 	   0,   -3, 	   3,  -11, 	   2,   -5
+.2byte    8,   -1, 	   0,   -3, 	   3,  -10, 	   2,   -6
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte   12,   -4, 	  -2,   -2, 	   0,  -10, 	   2,   -5
+.2byte   11,   -8, 	  -2,   -3, 	  -1,   -9, 	   3,   -6
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte    8,  -12, 	   2,   -4, 	   0,   -9, 	   3,   -8
+.2byte    8,  -13, 	   1,   -4, 	   0,   -8, 	   2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    0,  -13, 	  -1,   -4, 	  -1,   -9, 	   1,   -8
+.2byte   -1,  -15, 	  -1,   -4, 	  -3,   -9, 	   0,   -8
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	   1,   -1, 	   0,   -7, 	  -2,   -6
+.2byte   -8,  -11, 	   0,   -2, 	  -3,   -5, 	  -1,   -7
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte  -11,   -3, 	   0,    0, 	  -1,   -6, 	  -1,   -5
+.2byte  -11,   -7, 	  -2,    0, 	  -1,   -3, 	  -2,   -6
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte   -9,    1, 	   3,   -1, 	   2,   -5, 	  -2,   -3
+.2byte   -9,   -3, 	   3,   -1, 	   4,   -3, 	  -1,   -5
+.2byte    0,    4, 	   3,   -5, 	   6,   -7, 	   1,   -4
+.2byte   -8,    1, 	   3,    0, 	   4,   -3, 	  -1,   -3
+.2byte  -10,   -3, 	   1,    2, 	   2,   -2, 	  -1,   -3
+.2byte   -8,   -7, 	   1,    2, 	   0,   -2, 	  -1,   -5
+.2byte   -1,  -11, 	  -1,    1, 	  -2,   -3, 	   0,   -4
+.2byte    7,   -8, 	   0,    2, 	  -1,   -4, 	   1,   -4
+.2byte   10,   -4, 	  -3,    1, 	  -2,   -4, 	   1,   -3
+.2byte    5,    2, 	  -1,   -2, 	  -1,   -7, 	   0,   -3
+.2byte    0,    3, 	   3,   -6, 	   6,   -8, 	   1,   -5
+.2byte   -8,    0, 	   3,   -1, 	   4,   -4, 	  -1,   -4
+.2byte  -11,   -5, 	   0,    0, 	   1,   -4, 	  -2,   -5
+.2byte   -9,  -10, 	   0,   -1, 	  -1,   -5, 	  -2,   -8
+.2byte   -1,  -15, 	  -1,   -3, 	  -2,   -7, 	   0,   -8
+.2byte    8,  -12, 	   1,   -2, 	   0,   -8, 	   2,   -8
+.2byte   11,   -7, 	  -2,   -2, 	  -1,   -7, 	   2,   -6
+.2byte    7,    0, 	   1,   -4, 	   1,   -9, 	   2,   -5
+sMagikarpAnimTable1:
+.4byte sMagikarpAnims_1_1
+.4byte sMagikarpAnims_1_2
+.4byte sMagikarpAnims_1_3
+.4byte sMagikarpAnims_1_4
+.4byte sMagikarpAnims_1_5
+.4byte sMagikarpAnims_1_6
+.4byte sMagikarpAnims_1_7
+.4byte sMagikarpAnims_1_8
+sMagikarpAnimTable2:
+.4byte sMagikarpAnims_2_1
+.4byte sMagikarpAnims_2_2
+.4byte sMagikarpAnims_2_3
+.4byte sMagikarpAnims_2_4
+.4byte sMagikarpAnims_2_5
+.4byte sMagikarpAnims_2_6
+.4byte sMagikarpAnims_2_7
+.4byte sMagikarpAnims_2_8
+sMagikarpAnimTable3:
+.4byte sMagikarpAnims_3_1
+.4byte sMagikarpAnims_3_2
+.4byte sMagikarpAnims_3_3
+.4byte sMagikarpAnims_3_4
+.4byte sMagikarpAnims_3_5
+.4byte sMagikarpAnims_3_6
+.4byte sMagikarpAnims_3_7
+.4byte sMagikarpAnims_3_8
+sMagikarpAnimTable4:
+.4byte sMagikarpAnims_4_1
+.4byte sMagikarpAnims_4_2
+.4byte sMagikarpAnims_4_3
+.4byte sMagikarpAnims_4_4
+.4byte sMagikarpAnims_4_5
+.4byte sMagikarpAnims_4_6
+.4byte sMagikarpAnims_4_7
+.4byte sMagikarpAnims_4_8
+sMagikarpAnimTable5:
+.4byte sMagikarpAnims_5_1
+.4byte sMagikarpAnims_5_2
+.4byte sMagikarpAnims_5_3
+.4byte sMagikarpAnims_5_4
+.4byte sMagikarpAnims_5_5
+.4byte sMagikarpAnims_5_6
+.4byte sMagikarpAnims_5_7
+.4byte sMagikarpAnims_5_8
+sMagikarpAnimTable6:
+.4byte sMagikarpAnims_6_1
+.4byte sMagikarpAnims_6_1
+.4byte sMagikarpAnims_6_1
+.4byte sMagikarpAnims_6_1
+.4byte sMagikarpAnims_6_1
+.4byte sMagikarpAnims_6_1
+.4byte sMagikarpAnims_6_1
+.4byte sMagikarpAnims_6_1
+sMagikarpAnimTable7:
+.4byte sMagikarpAnims_7_1
+.4byte sMagikarpAnims_7_2
+.4byte sMagikarpAnims_7_3
+.4byte sMagikarpAnims_7_4
+.4byte sMagikarpAnims_7_5
+.4byte sMagikarpAnims_7_6
+.4byte sMagikarpAnims_7_7
+.4byte sMagikarpAnims_7_8
+sMagikarpAnimTable8:
+.4byte sMagikarpAnims_8_1
+.4byte sMagikarpAnims_8_2
+.4byte sMagikarpAnims_8_3
+.4byte sMagikarpAnims_8_4
+.4byte sMagikarpAnims_8_5
+.4byte sMagikarpAnims_8_6
+.4byte sMagikarpAnims_8_7
+.4byte sMagikarpAnims_8_8
+sMagikarpAnimTable9:
+.4byte sMagikarpAnims_9_1
+.4byte sMagikarpAnims_9_2
+.4byte sMagikarpAnims_9_3
+.4byte sMagikarpAnims_9_4
+.4byte sMagikarpAnims_9_5
+.4byte sMagikarpAnims_9_6
+.4byte sMagikarpAnims_9_7
+.4byte sMagikarpAnims_9_8
+sMagikarpAnimTable10:
+.4byte sMagikarpAnims_10_1
+.4byte sMagikarpAnims_10_2
+.4byte sMagikarpAnims_10_3
+.4byte sMagikarpAnims_10_4
+.4byte sMagikarpAnims_10_5
+.4byte sMagikarpAnims_10_6
+.4byte sMagikarpAnims_10_7
+.4byte sMagikarpAnims_10_8
+sMagikarpAnimTable11:
+.4byte sMagikarpAnims_11_1
+.4byte sMagikarpAnims_11_2
+.4byte sMagikarpAnims_11_3
+.4byte sMagikarpAnims_11_4
+.4byte sMagikarpAnims_11_5
+.4byte sMagikarpAnims_11_6
+.4byte sMagikarpAnims_11_7
+.4byte sMagikarpAnims_11_8
+sMagikarpAnimTable12:
+.4byte sMagikarpAnims_12_1
+.4byte sMagikarpAnims_12_2
+.4byte sMagikarpAnims_12_3
+.4byte sMagikarpAnims_12_4
+.4byte sMagikarpAnims_12_5
+.4byte sMagikarpAnims_12_6
+.4byte sMagikarpAnims_12_7
+.4byte sMagikarpAnims_12_8
+sMagikarpAnimTable13:
+.4byte sMagikarpAnims_13_1
+.4byte sMagikarpAnims_13_2
+.4byte sMagikarpAnims_13_3
+.4byte sMagikarpAnims_13_4
+.4byte sMagikarpAnims_13_5
+.4byte sMagikarpAnims_13_6
+.4byte sMagikarpAnims_13_7
+.4byte sMagikarpAnims_13_8
+sAxAnimationsMagikarp:
+.4byte sMagikarpAnimTable1
+.4byte sMagikarpAnimTable2
+.4byte sMagikarpAnimTable3
+.4byte sMagikarpAnimTable4
+.4byte sMagikarpAnimTable5
+.4byte sMagikarpAnimTable6
+.4byte sMagikarpAnimTable7
+.4byte sMagikarpAnimTable8
+.4byte sMagikarpAnimTable9
+.4byte sMagikarpAnimTable10
+.4byte sMagikarpAnimTable11
+.4byte sMagikarpAnimTable12
+.4byte sMagikarpAnimTable13
+sAxSpritesMagikarp:
+.4byte sMagikarpSprites1
+.4byte sMagikarpSprites2
+.4byte sMagikarpSprites3
+.4byte sMagikarpSprites4
+.4byte sMagikarpSprites5
+.4byte sMagikarpSprites6
+.4byte sMagikarpSprites7
+.4byte sMagikarpSprites8
+.4byte sMagikarpSprites9
+.4byte sMagikarpSprites10
+.4byte sMagikarpSprites11
+.4byte sMagikarpSprites12
+.4byte sMagikarpSprites13
+.4byte sMagikarpSprites14
+.4byte sMagikarpSprites15
+.4byte sMagikarpSprites16
+.4byte sMagikarpSprites17
+.4byte sMagikarpSprites18
+.4byte sMagikarpSprites19
+.4byte sMagikarpSprites20
+.4byte sMagikarpSprites21
+.4byte sMagikarpSprites22
+.4byte sMagikarpSprites23
+.4byte sMagikarpSprites24
+.4byte sMagikarpSprites25
+.4byte sMagikarpSprites26
+.4byte sMagikarpSprites27
+.4byte sMagikarpSprites28
+.4byte sMagikarpSprites29
+.4byte sMagikarpSprites30
+.4byte sMagikarpSprites31
+sAxMainMagikarp:
+ax_main sAxPosesMagikarp, sAxAnimationsMagikarp, 13, sAxSpritesMagikarp, sAxPositionsMagikarp

--- a/data/ax/magmar.inc
+++ b/data/ax/magmar.inc
@@ -1,0 +1,2641 @@
+.global gAxMagmar
+gAxMagmar:
+ax_siro sAxMainMagmar
+sMagmarPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose5:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose6:
+ax_pose 5, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose8:
+ax_pose 7, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose9:
+ax_pose 8, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose10:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose12:
+ax_pose 11, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose18:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagmarPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose24:
+ax_pose 5, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagmarPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose28:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose29:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose30:
+ax_pose 5, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose31:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose32:
+ax_pose 7, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose33:
+ax_pose 8, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose34:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose35:
+ax_pose 10, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose36:
+ax_pose 11, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose37:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose38:
+ax_pose 13, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose39:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose40:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose41:
+ax_pose 10, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose42:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagmarPose43:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose44:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose45:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose46:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose47:
+ax_pose 4, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose48:
+ax_pose 5, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagmarPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose50:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose51:
+ax_pose 16, 0x81e6, 0x80f0, 0x2c00
+ax_pose 17, 0x01e6, 0x80f0, 0x2c08
+ax_pose_terminator
+sMagmarPose52:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose53:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose54:
+ax_pose 18, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose55:
+ax_pose 19, 0x81e5, 0x90ff, 0x2c00
+ax_pose 20, 0x01e5, 0x90ef, 0x2c08
+ax_pose_terminator
+sMagmarPose56:
+ax_pose 20, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose57:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose58:
+ax_pose 21, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sMagmarPose59:
+ax_pose 22, 0x41ef, 0x90ef, 0x2c00
+ax_pose 23, 0x01e6, 0x90f0, 0x2c08
+ax_pose_terminator
+sMagmarPose60:
+ax_pose 23, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sMagmarPose61:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose62:
+ax_pose 24, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose63:
+ax_pose 25, 0x41e7, 0x90ef, 0x2c00
+ax_pose 26, 0x01e7, 0x90ef, 0x2c08
+ax_pose_terminator
+sMagmarPose64:
+ax_pose 26, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose65:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose66:
+ax_pose 27, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose67:
+ax_pose 28, 0x81e5, 0x8100, 0x2c00
+ax_pose 29, 0x01e5, 0x80f0, 0x2c08
+ax_pose_terminator
+sMagmarPose68:
+ax_pose 29, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose69:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose70:
+ax_pose 24, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose71:
+ax_pose 25, 0x41e7, 0x80f0, 0x2c00
+ax_pose 26, 0x01e7, 0x80f0, 0x2c08
+ax_pose_terminator
+sMagmarPose72:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose73:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose74:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagmarPose75:
+ax_pose 22, 0x41ef, 0x80f0, 0x2c00
+ax_pose 23, 0x01e6, 0x80ef, 0x2c08
+ax_pose_terminator
+sMagmarPose76:
+ax_pose 23, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagmarPose77:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose78:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose79:
+ax_pose 19, 0x81e5, 0x80f0, 0x2c00
+ax_pose 20, 0x01e5, 0x80f0, 0x2c08
+ax_pose_terminator
+sMagmarPose80:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose81:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose82:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose83:
+ax_pose 30, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose84:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose85:
+ax_pose 18, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose86:
+ax_pose 31, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sMagmarPose87:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose88:
+ax_pose 21, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sMagmarPose89:
+ax_pose 32, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sMagmarPose90:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose91:
+ax_pose 24, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose92:
+ax_pose 33, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sMagmarPose93:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose94:
+ax_pose 27, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose95:
+ax_pose 34, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose96:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose97:
+ax_pose 24, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose98:
+ax_pose 33, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagmarPose99:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose100:
+ax_pose 21, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagmarPose101:
+ax_pose 32, 0x01e4, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagmarPose102:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose103:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose104:
+ax_pose 31, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagmarPose105:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose106:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose107:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose108:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose109:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose110:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose111:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose112:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose113:
+ax_pose 35, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose114:
+ax_pose 36, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose115:
+ax_pose 37, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose116:
+ax_pose 38, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose117:
+ax_pose 39, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose118:
+ax_pose 40, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose119:
+ax_pose 41, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose120:
+ax_pose 40, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose121:
+ax_pose 39, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMagmarPose122:
+ax_pose 38, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMagmarPose123:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose124:
+ax_pose 30, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose125:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose126:
+ax_pose 31, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sMagmarPose127:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose128:
+ax_pose 32, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sMagmarPose129:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose130:
+ax_pose 33, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sMagmarPose131:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose132:
+ax_pose 34, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose133:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose134:
+ax_pose 33, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagmarPose135:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose136:
+ax_pose 32, 0x01e4, 0x80ee, 0x2c00
+ax_pose_terminator
+sMagmarPose137:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose138:
+ax_pose 31, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMagmarPose139:
+ax_pose 30, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose140:
+ax_pose 31, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose141:
+ax_pose 32, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose142:
+ax_pose 33, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose143:
+ax_pose 34, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose144:
+ax_pose 33, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose145:
+ax_pose 32, 0x01e4, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose146:
+ax_pose 31, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose147:
+ax_pose 30, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose148:
+ax_pose 31, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose149:
+ax_pose 32, 0x01e4, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose150:
+ax_pose 33, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose151:
+ax_pose 34, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose152:
+ax_pose 33, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose153:
+ax_pose 32, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose154:
+ax_pose 31, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose155:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose156:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose157:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose158:
+ax_pose 30, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose159:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose160:
+ax_pose 4, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose161:
+ax_pose 5, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose162:
+ax_pose 31, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose163:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose164:
+ax_pose 7, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose165:
+ax_pose 8, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose166:
+ax_pose 32, 0x01e4, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose167:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose168:
+ax_pose 10, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose169:
+ax_pose 11, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMagmarPose170:
+ax_pose 33, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMagmarPose171:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose172:
+ax_pose 13, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose173:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose174:
+ax_pose 34, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose175:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose176:
+ax_pose 10, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose177:
+ax_pose 11, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagmarPose178:
+ax_pose 33, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose179:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose180:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose181:
+ax_pose 8, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose182:
+ax_pose 32, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose183:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose184:
+ax_pose 4, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose185:
+ax_pose 5, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sMagmarPose186:
+ax_pose 31, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose187:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose188:
+ax_pose 18, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose189:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose190:
+ax_pose 24, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sMagmarPose191:
+ax_pose 27, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose192:
+ax_pose 24, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose193:
+ax_pose 21, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose194:
+ax_pose 18, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose195:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose196:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose197:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose198:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose199:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMagmarPose200:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose201:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sMagmarPose202:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+.align 2
+sMagmarAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_2_1:
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 4, 0, 46, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 2, 0, 2,
+ax_anim 1, 2, 25, 0, 7, 0, 7,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 8, 0, 8,
+ax_anim_terminator
+sMagmarAnims_2_2:
+ax_anim 2, 0, 26, -1, -1, -1, -1,
+ax_anim 4, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 2, 2, 2, 2,
+ax_anim 1, 2, 28, 6, 6, 6, 6,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 1, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sMagmarAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 4, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 2, 0, 0, 0,
+ax_anim 1, 2, 31, 9, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 10, 0,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 1, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 0, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 31, 6, 0, 6, 0,
+ax_anim_terminator
+sMagmarAnims_2_4:
+ax_anim 2, 0, 32, -1, 1, -1, 1,
+ax_anim 4, 0, 32, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 2, -2, 2, -2,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 35, 10, -11, 10, -11,
+ax_anim 2, 0, 37, 18, -20, 18, -20,
+ax_anim 2, 1, 37, 19, -19, 19, -19,
+ax_anim 2, 0, 37, 18, -20, 18, -20,
+ax_anim 2, 0, 37, 19, -19, 19, -19,
+ax_anim 2, 0, 34, 8, -8, 8, -8,
+ax_anim_terminator
+sMagmarAnims_2_5:
+ax_anim 2, 0, 35, 0, 1, 0, 1,
+ax_anim 4, 0, 35, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, -2, 0, -2,
+ax_anim 1, 2, 38, 0, -6, 0, -6,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -19, 0, -19,
+ax_anim 2, 1, 40, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -19, 0, -19,
+ax_anim 2, 0, 40, 1, -19, 1, -19,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim_terminator
+sMagmarAnims_2_6:
+ax_anim 2, 0, 37, 1, 1, 1, 1,
+ax_anim 4, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -11, -10, -11,
+ax_anim 2, 0, 40, -18, -20, -18, -20,
+ax_anim 2, 1, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -18, -20, -18, -20,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 41, -6, -6, -6, -6,
+ax_anim_terminator
+sMagmarAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 4, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 43, -2, -1, -2, -1,
+ax_anim 1, 2, 44, -5, -1, -5, -1,
+ax_anim 1, 0, 43, -11, -1, -11, -1,
+ax_anim 2, 0, 46, -18, 0, -18, 0,
+ax_anim 2, 1, 46, -18, 1, -18, 1,
+ax_anim 2, 0, 46, -18, 0, -18, 0,
+ax_anim 2, 0, 46, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim_terminator
+sMagmarAnims_2_8:
+ax_anim 2, 0, 44, 3, -3, 3, -3,
+ax_anim 4, 0, 44, 4, -4, 4, -4,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 25, -18, 19, -18, 19,
+ax_anim 2, 1, 25, -19, 18, -19, 18,
+ax_anim 2, 0, 25, -18, 19, -18, 19,
+ax_anim 2, 0, 25, -19, 18, -19, 18,
+ax_anim 2, 0, 47, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMagmarAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 2, 0, 77, 0, -4, 0, -4,
+ax_anim 6, 0, 77, 0, -5, 0, -5,
+ax_anim 1, 0, 77, 0, -3, 0, -3,
+ax_anim 1, 2, 49, 1, 3, 1, 3,
+ax_anim 2, 0, 50, 2, 17, 2, 17,
+ax_anim 2, 0, 51, 3, 17, 3, 17,
+ax_anim 2, 1, 51, 2, 17, 2, 17,
+ax_anim 2, 0, 51, 3, 17, 3, 17,
+ax_anim 2, 0, 51, 2, 17, 2, 17,
+ax_anim 2, 0, 51, 3, 17, 3, 17,
+ax_anim 2, 0, 48, 1, 10, 1, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sMagmarAnims_3_2:
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 2, 0, 57, -4, -4, -4, -4,
+ax_anim 6, 0, 57, -5, -5, -5, -5,
+ax_anim 1, 0, 57, -3, -3, -3, -3,
+ax_anim 1, 2, 53, 3, 3, 3, 3,
+ax_anim 2, 0, 54, 12, 21, 12, 21,
+ax_anim 2, 0, 55, 13, 20, 13, 20,
+ax_anim 2, 1, 55, 12, 21, 12, 21,
+ax_anim 2, 0, 55, 13, 20, 13, 20,
+ax_anim 2, 0, 55, 12, 21, 12, 21,
+ax_anim 2, 0, 55, 13, 20, 13, 20,
+ax_anim 2, 0, 52, 8, 12, 8, 12,
+ax_anim 2, 0, 52, 2, 4, 2, 4,
+ax_anim_terminator
+sMagmarAnims_3_3:
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 2, 0, 61, -4, 0, -4, 0,
+ax_anim 6, 0, 61, -5, 0, -5, 0,
+ax_anim 1, 0, 61, -3, 0, -3, 0,
+ax_anim 1, 2, 57, 3, 0, 3, 0,
+ax_anim 2, 0, 58, 11, 0, 11, 0,
+ax_anim 2, 0, 59, 11, -1, 11, -1,
+ax_anim 2, 1, 59, 11, 0, 11, 0,
+ax_anim 2, 0, 59, 11, -1, 11, -1,
+ax_anim 2, 0, 59, 11, 0, 11, 0,
+ax_anim 2, 0, 59, 11, -1, 11, -1,
+ax_anim 2, 0, 56, 8, 0, 8, 0,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim_terminator
+sMagmarAnims_3_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 2, 0, 65, -4, 4, -4, 4,
+ax_anim 6, 0, 65, -5, 5, -5, 5,
+ax_anim 1, 0, 65, -3, 3, -3, 3,
+ax_anim 1, 2, 61, 3, -3, 3, -3,
+ax_anim 2, 0, 62, 14, -14, 14, -14,
+ax_anim 2, 0, 63, 13, -15, 13, -15,
+ax_anim 2, 1, 63, 14, -14, 14, -14,
+ax_anim 2, 0, 63, 13, -15, 13, -15,
+ax_anim 2, 0, 63, 14, -14, 14, -14,
+ax_anim 2, 0, 63, 13, -15, 13, -15,
+ax_anim 2, 0, 60, 8, -8, 8, -8,
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim_terminator
+sMagmarAnims_3_5:
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 2, 0, 57, 0, 4, 0, 4,
+ax_anim 6, 0, 57, 0, 5, 0, 5,
+ax_anim 1, 0, 57, 0, 3, 0, 3,
+ax_anim 1, 2, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 66, 0, -12, 0, -12,
+ax_anim 2, 0, 67, 0, -13, 0, -13,
+ax_anim 2, 1, 67, 0, -12, 0, -12,
+ax_anim 2, 0, 67, 0, -13, 0, -13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 2, 0, 67, 0, -13, 0, -13,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sMagmarAnims_3_6:
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 2, 0, 65, 4, 4, 4, 4,
+ax_anim 6, 0, 65, 5, 5, 5, 5,
+ax_anim 1, 0, 65, 3, 3, 3, 3,
+ax_anim 1, 2, 69, -3, -3, -3, -3,
+ax_anim 2, 0, 70, -14, -14, -14, -14,
+ax_anim 2, 0, 71, -13, -15, -13, -15,
+ax_anim 2, 1, 71, -14, -14, -14, -14,
+ax_anim 2, 0, 71, -13, -15, -13, -15,
+ax_anim 2, 0, 71, -14, -14, -14, -14,
+ax_anim 2, 0, 71, -13, -15, -13, -15,
+ax_anim 2, 0, 68, -8, -8, -8, -8,
+ax_anim 2, 0, 68, -3, -3, -3, -3,
+ax_anim_terminator
+sMagmarAnims_3_7:
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 2, 0, 69, 4, 0, 4, 0,
+ax_anim 6, 0, 69, 5, 0, 5, 0,
+ax_anim 1, 0, 69, 3, 0, 3, 0,
+ax_anim 1, 2, 73, -3, 0, -3, 0,
+ax_anim 2, 0, 74, -11, 0, -11, 0,
+ax_anim 2, 0, 75, -11, -1, -11, -1,
+ax_anim 2, 1, 75, -11, 0, -11, 0,
+ax_anim 2, 0, 75, -11, -1, -11, -1,
+ax_anim 2, 0, 75, -11, 0, -11, 0,
+ax_anim 2, 0, 75, -11, -1, -11, -1,
+ax_anim 2, 0, 72, -8, 0, -8, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sMagmarAnims_3_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 2, 0, 73, 4, -4, 4, -4,
+ax_anim 6, 0, 73, 5, -5, 5, -5,
+ax_anim 1, 0, 73, 3, -3, 3, -3,
+ax_anim 1, 2, 77, -3, 3, -3, 3,
+ax_anim 2, 0, 78, -12, 21, -12, 21,
+ax_anim 2, 0, 79, -13, 20, -13, 20,
+ax_anim 2, 1, 79, -12, 21, -12, 21,
+ax_anim 2, 0, 79, -13, 20, -13, 20,
+ax_anim 2, 0, 79, -12, 21, -12, 21,
+ax_anim 2, 0, 79, -13, 20, -13, 20,
+ax_anim 2, 0, 76, -8, 12, -8, 12,
+ax_anim 2, 0, 76, -2, 4, -2, 4,
+ax_anim_terminator
+.align 2
+sMagmarAnims_4_1:
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim 6, 0, 80, 0, -4, 0, -4,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 4, 0, 4,
+ax_anim 2, 0, 82, 1, 4, 1, 4,
+ax_anim 2, 0, 82, 0, 4, 0, 4,
+ax_anim 2, 1, 82, 1, 4, 1, 4,
+ax_anim 2, 0, 82, 0, 4, 0, 4,
+ax_anim 2, 0, 82, 1, 4, 1, 4,
+ax_anim 2, 0, 82, 0, 4, 0, 4,
+ax_anim 2, 0, 82, 1, 4, 1, 4,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sMagmarAnims_4_2:
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 6, 0, 83, -4, -4, -4, -4,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 2, 0, 85, 5, 3, 5, 3,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 2, 1, 85, 5, 3, 5, 3,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 2, 0, 85, 5, 3, 5, 3,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 2, 0, 85, 5, 3, 5, 3,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim_terminator
+sMagmarAnims_4_3:
+ax_anim 2, 0, 86, -2, 0, -2, 0,
+ax_anim 6, 0, 86, -4, 0, -4, 0,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim 2, 0, 88, 4, -1, 4, -1,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim 2, 1, 88, 4, -1, 4, -1,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim 2, 0, 88, 4, -1, 4, -1,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim 2, 0, 88, 4, -1, 4, -1,
+ax_anim 2, 0, 86, 2, 0, 2, 0,
+ax_anim_terminator
+sMagmarAnims_4_4:
+ax_anim 2, 0, 89, -2, 2, -2, 2,
+ax_anim 6, 0, 89, -4, 4, -4, 4,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 4, -4, 4, -4,
+ax_anim 2, 0, 91, 5, -3, 5, -3,
+ax_anim 2, 0, 91, 4, -4, 4, -4,
+ax_anim 2, 1, 91, 5, -3, 5, -3,
+ax_anim 2, 0, 91, 4, -4, 4, -4,
+ax_anim 2, 0, 91, 5, -3, 5, -3,
+ax_anim 2, 0, 91, 4, -4, 4, -4,
+ax_anim 2, 0, 91, 5, -3, 5, -3,
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim_terminator
+sMagmarAnims_4_5:
+ax_anim 2, 0, 92, 0, 2, 0, 2,
+ax_anim 6, 0, 92, 0, 4, 0, 4,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, -4,
+ax_anim 2, 0, 94, 1, -4, 1, -4,
+ax_anim 2, 0, 94, 0, -4, 0, -4,
+ax_anim 2, 1, 94, 1, -4, 1, -4,
+ax_anim 2, 0, 94, 0, -4, 0, -4,
+ax_anim 2, 0, 94, 1, -4, 1, -4,
+ax_anim 2, 0, 94, 0, -4, 0, -4,
+ax_anim 2, 0, 94, 1, -4, 1, -4,
+ax_anim 2, 0, 92, 0, -2, 0, -2,
+ax_anim_terminator
+sMagmarAnims_4_6:
+ax_anim 2, 0, 95, 2, 2, 2, 2,
+ax_anim 6, 0, 95, 4, 4, 4, 4,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -4, -4, -4, -4,
+ax_anim 2, 0, 97, -5, -3, -5, -3,
+ax_anim 2, 0, 97, -4, -4, -4, -4,
+ax_anim 2, 1, 97, -5, -3, -5, -3,
+ax_anim 2, 0, 97, -4, -4, -4, -4,
+ax_anim 2, 0, 97, -5, -3, -5, -3,
+ax_anim 2, 0, 97, -4, -4, -4, -4,
+ax_anim 2, 0, 97, -5, -3, -5, -3,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim_terminator
+sMagmarAnims_4_7:
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 6, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim 2, 0, 100, -4, -1, -4, -1,
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim 2, 1, 100, -4, -1, -4, -1,
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim 2, 0, 100, -4, -1, -4, -1,
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim 2, 0, 100, -4, -1, -4, -1,
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim_terminator
+sMagmarAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 6, 0, 101, 4, -4, 4, -4,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 1, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMagmarAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sMagmarAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sMagmarAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sMagmarAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sMagmarAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sMagmarAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sMagmarAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sMagmarAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMagmarAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 12, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_8_2:
+ax_anim 40, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 12, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_8_3:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 12, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_8_4:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_8_5:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_8_6:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_8_7:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_8_8:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 16, 7, 16,
+ax_anim 3, 0, 142, 0, 19, 0, 19,
+ax_anim 2, 3, 143, -7, 16, -7, 16,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, -1, 8, -1,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 19, 10, 19, 10,
+ax_anim 3, 0, 141, 17, 19, 17, 19,
+ax_anim 2, 3, 142, 11, 19, 11, 19,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 16, -5, 16, -5,
+ax_anim 3, 0, 140, 18, -2, 18, -2,
+ax_anim 2, 3, 141, 16, 4, 16, 4,
+ax_anim 2, 0, 142, 12, 5, 12, 5,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -22, 12, -22,
+ax_anim 3, 0, 139, 18, -20, 18, -20,
+ax_anim 2, 3, 140, 20, -15, 20, -15,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -18, -7, -18,
+ax_anim 3, 0, 138, 0, -22, 0, -22,
+ax_anim 2, 3, 139, 7, -18, 7, -18,
+ax_anim 2, 0, 140, 9, -10, 9, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -6, 1, -6,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -22, -12, -22,
+ax_anim 3, 0, 145, -18, -20, -18, -20,
+ax_anim 2, 3, 144, -20, -15, -20, -15,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -16, -5, -16, -5,
+ax_anim 3, 0, 144, -18, -2, -18, -2,
+ax_anim 2, 3, 143, -16, 4, -16, 4,
+ax_anim 2, 0, 142, -12, 5, -12, 5,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, -1, -8, -1,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -19, 10, -19, 10,
+ax_anim 3, 0, 143, -17, 19, -17, 19,
+ax_anim 2, 3, 142, -11, 19, -11, 19,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -23, 0, 0,
+ax_anim 3, 0, 157, 0, -22, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_11_2:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 158, 0, -23, 0, 0,
+ax_anim 3, 0, 161, 0, -22, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_11_3:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_11_4:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -17, 0, 0,
+ax_anim 1, 0, 169, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_11_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_11_6:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -17, 0, 0,
+ax_anim 1, 0, 177, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_11_7:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_11_8:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagmarAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMagmarGfx1:
+.incbin "baserom.gba", 0xA6C118, 0x200
+sMagmarSprites1:
+ax_sprite sMagmarGfx1, 0x200
+ax_sprite_terminator
+sMagmarGfx2:
+.incbin "baserom.gba", 0xA6C328, 0x200
+sMagmarSprites2:
+ax_sprite sMagmarGfx2, 0x200
+ax_sprite_terminator
+sMagmarGfx3:
+.incbin "baserom.gba", 0xA6C538, 0x200
+sMagmarSprites3:
+ax_sprite sMagmarGfx3, 0x200
+ax_sprite_terminator
+sMagmarGfx4:
+.incbin "baserom.gba", 0xA6C748, 0x200
+sMagmarSprites4:
+ax_sprite sMagmarGfx4, 0x200
+ax_sprite_terminator
+sMagmarGfx5:
+.incbin "baserom.gba", 0xA6C958, 0x200
+sMagmarSprites5:
+ax_sprite sMagmarGfx5, 0x200
+ax_sprite_terminator
+sMagmarGfx6:
+.incbin "baserom.gba", 0xA6CB68, 0x200
+sMagmarSprites6:
+ax_sprite sMagmarGfx6, 0x200
+ax_sprite_terminator
+sMagmarGfx7:
+.incbin "baserom.gba", 0xA6CD78, 0x200
+sMagmarSprites7:
+ax_sprite sMagmarGfx7, 0x200
+ax_sprite_terminator
+sMagmarGfx8:
+.incbin "baserom.gba", 0xA6CF88, 0x200
+sMagmarSprites8:
+ax_sprite sMagmarGfx8, 0x200
+ax_sprite_terminator
+sMagmarGfx9:
+.incbin "baserom.gba", 0xA6D198, 0x200
+sMagmarSprites9:
+ax_sprite sMagmarGfx9, 0x200
+ax_sprite_terminator
+sMagmarGfx10:
+.incbin "baserom.gba", 0xA6D3A8, 0x200
+sMagmarSprites10:
+ax_sprite sMagmarGfx10, 0x200
+ax_sprite_terminator
+sMagmarGfx11:
+.incbin "baserom.gba", 0xA6D5B8, 0x200
+sMagmarSprites11:
+ax_sprite sMagmarGfx11, 0x200
+ax_sprite_terminator
+sMagmarGfx12:
+.incbin "baserom.gba", 0xA6D7C8, 0x200
+sMagmarSprites12:
+ax_sprite sMagmarGfx12, 0x200
+ax_sprite_terminator
+sMagmarGfx13:
+.incbin "baserom.gba", 0xA6D9D8, 0x200
+sMagmarSprites13:
+ax_sprite sMagmarGfx13, 0x200
+ax_sprite_terminator
+sMagmarGfx14:
+.incbin "baserom.gba", 0xA6DBE8, 0x200
+sMagmarSprites14:
+ax_sprite sMagmarGfx14, 0x200
+ax_sprite_terminator
+sMagmarGfx15:
+.incbin "baserom.gba", 0xA6DDF8, 0x200
+sMagmarSprites15:
+ax_sprite sMagmarGfx15, 0x200
+ax_sprite_terminator
+sMagmarGfx16:
+.incbin "baserom.gba", 0xA6E008, 0x40
+sMagmarGfx16_1:
+.incbin "baserom.gba", 0xA6E048, 0x60
+sMagmarGfx16_2:
+.incbin "baserom.gba", 0xA6E0A8, 0xE0
+sMagmarSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMagmarGfx16_2, 0xe0
+ax_sprite_terminator
+sMagmarGfx17:
+.incbin "baserom.gba", 0xA6E1C0, 0x60
+sMagmarGfx17_1:
+.incbin "baserom.gba", 0xA6E220, 0x20
+sMagmarGfx17_2:
+.incbin "baserom.gba", 0xA6E240, 0x40
+sMagmarSprites17:
+ax_sprite sMagmarGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx17_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx17_2, 0x40
+ax_sprite_terminator
+sMagmarGfx18:
+.incbin "baserom.gba", 0xA6E2B0, 0x40
+sMagmarGfx18_1:
+.incbin "baserom.gba", 0xA6E2F0, 0x140
+sMagmarSprites18:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagmarGfx18_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx19:
+.incbin "baserom.gba", 0xA6E460, 0x40
+sMagmarGfx19_1:
+.incbin "baserom.gba", 0xA6E4A0, 0x160
+sMagmarSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx20:
+.incbin "baserom.gba", 0xA6E630, 0x80
+sMagmarGfx20_1:
+.incbin "baserom.gba", 0xA6E6B0, 0x20
+sMagmarSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx20, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx20_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx21:
+.incbin "baserom.gba", 0xA6E700, 0x20
+sMagmarGfx21_1:
+.incbin "baserom.gba", 0xA6E720, 0x160
+sMagmarSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMagmarGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx22:
+.incbin "baserom.gba", 0xA6E8B0, 0x40
+sMagmarGfx22_1:
+.incbin "baserom.gba", 0xA6E8F0, 0x100
+sMagmarGfx22_2:
+.incbin "baserom.gba", 0xA6E9F0, 0x60
+sMagmarSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx22_2, 0x60
+ax_sprite_terminator
+sMagmarGfx23:
+.incbin "baserom.gba", 0xA6EA88, 0x20
+sMagmarGfx23_1:
+.incbin "baserom.gba", 0xA6EAA8, 0x60
+sMagmarSprites23:
+ax_sprite sMagmarGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx23_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMagmarGfx24:
+.incbin "baserom.gba", 0xA6EB30, 0x40
+sMagmarGfx24_1:
+.incbin "baserom.gba", 0xA6EB70, 0x100
+sMagmarGfx24_2:
+.incbin "baserom.gba", 0xA6EC70, 0x60
+sMagmarSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx24_2, 0x60
+ax_sprite_terminator
+sMagmarGfx25:
+.incbin "baserom.gba", 0xA6ED08, 0x60
+sMagmarGfx25_1:
+.incbin "baserom.gba", 0xA6ED68, 0x60
+sMagmarGfx25_2:
+.incbin "baserom.gba", 0xA6EDC8, 0x60
+sMagmarGfx25_3:
+.incbin "baserom.gba", 0xA6EE28, 0x60
+sMagmarSprites25:
+ax_sprite sMagmarGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx26:
+.incbin "baserom.gba", 0xA6EED0, 0x60
+sMagmarGfx26_1:
+.incbin "baserom.gba", 0xA6EF30, 0x20
+sMagmarGfx26_2:
+.incbin "baserom.gba", 0xA6EF50, 0x40
+sMagmarSprites26:
+ax_sprite sMagmarGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx26_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx26_2, 0x40
+ax_sprite_terminator
+sMagmarGfx27:
+.incbin "baserom.gba", 0xA6EFC0, 0x60
+sMagmarGfx27_1:
+.incbin "baserom.gba", 0xA6F020, 0x160
+sMagmarSprites27:
+ax_sprite sMagmarGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx28:
+.incbin "baserom.gba", 0xA6F1A8, 0x40
+sMagmarGfx28_1:
+.incbin "baserom.gba", 0xA6F1E8, 0x160
+sMagmarSprites28:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx28_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx29:
+.incbin "baserom.gba", 0xA6F378, 0x80
+sMagmarGfx29_1:
+.incbin "baserom.gba", 0xA6F3F8, 0x20
+sMagmarGfx29_2:
+.incbin "baserom.gba", 0xA6F418, 0x20
+sMagmarSprites29:
+ax_sprite sMagmarGfx29, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx29_2, 0x20
+ax_sprite_terminator
+sMagmarGfx30:
+.incbin "baserom.gba", 0xA6F468, 0x40
+sMagmarGfx30_1:
+.incbin "baserom.gba", 0xA6F4A8, 0x60
+sMagmarGfx30_2:
+.incbin "baserom.gba", 0xA6F508, 0x60
+sMagmarGfx30_3:
+.incbin "baserom.gba", 0xA6F568, 0x40
+sMagmarSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMagmarGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx31:
+.incbin "baserom.gba", 0xA6F5F8, 0x40
+sMagmarGfx31_1:
+.incbin "baserom.gba", 0xA6F638, 0x160
+sMagmarSprites31:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx31_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx32:
+.incbin "baserom.gba", 0xA6F7C8, 0x40
+sMagmarGfx32_1:
+.incbin "baserom.gba", 0xA6F808, 0x180
+sMagmarSprites32:
+ax_sprite sMagmarGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx32_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagmarGfx33:
+.incbin "baserom.gba", 0xA6F9B0, 0x20
+sMagmarGfx33_1:
+.incbin "baserom.gba", 0xA6F9D0, 0x100
+sMagmarGfx33_2:
+.incbin "baserom.gba", 0xA6FAD0, 0x60
+sMagmarSprites33:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx33, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMagmarGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx33_2, 0x60
+ax_sprite_terminator
+sMagmarGfx34:
+.incbin "baserom.gba", 0xA6FB68, 0x40
+sMagmarGfx34_1:
+.incbin "baserom.gba", 0xA6FBA8, 0x60
+sMagmarGfx34_2:
+.incbin "baserom.gba", 0xA6FC08, 0x80
+sMagmarGfx34_3:
+.incbin "baserom.gba", 0xA6FC88, 0x60
+sMagmarSprites34:
+ax_sprite sMagmarGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagmarGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx34_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx34_3, 0x60
+ax_sprite_terminator
+sMagmarGfx35:
+.incbin "baserom.gba", 0xA6FD28, 0x40
+sMagmarGfx35_1:
+.incbin "baserom.gba", 0xA6FD68, 0x40
+sMagmarGfx35_2:
+.incbin "baserom.gba", 0xA6FDA8, 0x100
+sMagmarSprites35:
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagmarGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagmarGfx35_2, 0x100
+ax_sprite_terminator
+sMagmarGfx36:
+.incbin "baserom.gba", 0xA6FEE0, 0x200
+sMagmarSprites36:
+ax_sprite sMagmarGfx36, 0x200
+ax_sprite_terminator
+sMagmarGfx37:
+.incbin "baserom.gba", 0xA700F0, 0x200
+sMagmarSprites37:
+ax_sprite sMagmarGfx37, 0x200
+ax_sprite_terminator
+sMagmarGfx38:
+.incbin "baserom.gba", 0xA70300, 0x200
+sMagmarSprites38:
+ax_sprite sMagmarGfx38, 0x200
+ax_sprite_terminator
+sMagmarGfx39:
+.incbin "baserom.gba", 0xA70510, 0x200
+sMagmarSprites39:
+ax_sprite sMagmarGfx39, 0x200
+ax_sprite_terminator
+sMagmarGfx40:
+.incbin "baserom.gba", 0xA70720, 0x200
+sMagmarSprites40:
+ax_sprite sMagmarGfx40, 0x200
+ax_sprite_terminator
+sMagmarGfx41:
+.incbin "baserom.gba", 0xA70930, 0x200
+sMagmarSprites41:
+ax_sprite sMagmarGfx41, 0x200
+ax_sprite_terminator
+sMagmarGfx42:
+.incbin "baserom.gba", 0xA70B40, 0x200
+sMagmarSprites42:
+ax_sprite sMagmarGfx42, 0x200
+ax_sprite_terminator
+sAxPosesMagmar:
+.4byte sMagmarPose1
+.4byte sMagmarPose2
+.4byte sMagmarPose3
+.4byte sMagmarPose4
+.4byte sMagmarPose5
+.4byte sMagmarPose6
+.4byte sMagmarPose7
+.4byte sMagmarPose8
+.4byte sMagmarPose9
+.4byte sMagmarPose10
+.4byte sMagmarPose11
+.4byte sMagmarPose12
+.4byte sMagmarPose13
+.4byte sMagmarPose14
+.4byte sMagmarPose15
+.4byte sMagmarPose16
+.4byte sMagmarPose17
+.4byte sMagmarPose18
+.4byte sMagmarPose19
+.4byte sMagmarPose20
+.4byte sMagmarPose21
+.4byte sMagmarPose22
+.4byte sMagmarPose23
+.4byte sMagmarPose24
+.4byte sMagmarPose25
+.4byte sMagmarPose26
+.4byte sMagmarPose27
+.4byte sMagmarPose28
+.4byte sMagmarPose29
+.4byte sMagmarPose30
+.4byte sMagmarPose31
+.4byte sMagmarPose32
+.4byte sMagmarPose33
+.4byte sMagmarPose34
+.4byte sMagmarPose35
+.4byte sMagmarPose36
+.4byte sMagmarPose37
+.4byte sMagmarPose38
+.4byte sMagmarPose39
+.4byte sMagmarPose40
+.4byte sMagmarPose41
+.4byte sMagmarPose42
+.4byte sMagmarPose43
+.4byte sMagmarPose44
+.4byte sMagmarPose45
+.4byte sMagmarPose46
+.4byte sMagmarPose47
+.4byte sMagmarPose48
+.4byte sMagmarPose49
+.4byte sMagmarPose50
+.4byte sMagmarPose51
+.4byte sMagmarPose52
+.4byte sMagmarPose53
+.4byte sMagmarPose54
+.4byte sMagmarPose55
+.4byte sMagmarPose56
+.4byte sMagmarPose57
+.4byte sMagmarPose58
+.4byte sMagmarPose59
+.4byte sMagmarPose60
+.4byte sMagmarPose61
+.4byte sMagmarPose62
+.4byte sMagmarPose63
+.4byte sMagmarPose64
+.4byte sMagmarPose65
+.4byte sMagmarPose66
+.4byte sMagmarPose67
+.4byte sMagmarPose68
+.4byte sMagmarPose69
+.4byte sMagmarPose70
+.4byte sMagmarPose71
+.4byte sMagmarPose72
+.4byte sMagmarPose73
+.4byte sMagmarPose74
+.4byte sMagmarPose75
+.4byte sMagmarPose76
+.4byte sMagmarPose77
+.4byte sMagmarPose78
+.4byte sMagmarPose79
+.4byte sMagmarPose80
+.4byte sMagmarPose81
+.4byte sMagmarPose82
+.4byte sMagmarPose83
+.4byte sMagmarPose84
+.4byte sMagmarPose85
+.4byte sMagmarPose86
+.4byte sMagmarPose87
+.4byte sMagmarPose88
+.4byte sMagmarPose89
+.4byte sMagmarPose90
+.4byte sMagmarPose91
+.4byte sMagmarPose92
+.4byte sMagmarPose93
+.4byte sMagmarPose94
+.4byte sMagmarPose95
+.4byte sMagmarPose96
+.4byte sMagmarPose97
+.4byte sMagmarPose98
+.4byte sMagmarPose99
+.4byte sMagmarPose100
+.4byte sMagmarPose101
+.4byte sMagmarPose102
+.4byte sMagmarPose103
+.4byte sMagmarPose104
+.4byte sMagmarPose105
+.4byte sMagmarPose106
+.4byte sMagmarPose107
+.4byte sMagmarPose108
+.4byte sMagmarPose109
+.4byte sMagmarPose110
+.4byte sMagmarPose111
+.4byte sMagmarPose112
+.4byte sMagmarPose113
+.4byte sMagmarPose114
+.4byte sMagmarPose115
+.4byte sMagmarPose116
+.4byte sMagmarPose117
+.4byte sMagmarPose118
+.4byte sMagmarPose119
+.4byte sMagmarPose120
+.4byte sMagmarPose121
+.4byte sMagmarPose122
+.4byte sMagmarPose123
+.4byte sMagmarPose124
+.4byte sMagmarPose125
+.4byte sMagmarPose126
+.4byte sMagmarPose127
+.4byte sMagmarPose128
+.4byte sMagmarPose129
+.4byte sMagmarPose130
+.4byte sMagmarPose131
+.4byte sMagmarPose132
+.4byte sMagmarPose133
+.4byte sMagmarPose134
+.4byte sMagmarPose135
+.4byte sMagmarPose136
+.4byte sMagmarPose137
+.4byte sMagmarPose138
+.4byte sMagmarPose139
+.4byte sMagmarPose140
+.4byte sMagmarPose141
+.4byte sMagmarPose142
+.4byte sMagmarPose143
+.4byte sMagmarPose144
+.4byte sMagmarPose145
+.4byte sMagmarPose146
+.4byte sMagmarPose147
+.4byte sMagmarPose148
+.4byte sMagmarPose149
+.4byte sMagmarPose150
+.4byte sMagmarPose151
+.4byte sMagmarPose152
+.4byte sMagmarPose153
+.4byte sMagmarPose154
+.4byte sMagmarPose155
+.4byte sMagmarPose156
+.4byte sMagmarPose157
+.4byte sMagmarPose158
+.4byte sMagmarPose159
+.4byte sMagmarPose160
+.4byte sMagmarPose161
+.4byte sMagmarPose162
+.4byte sMagmarPose163
+.4byte sMagmarPose164
+.4byte sMagmarPose165
+.4byte sMagmarPose166
+.4byte sMagmarPose167
+.4byte sMagmarPose168
+.4byte sMagmarPose169
+.4byte sMagmarPose170
+.4byte sMagmarPose171
+.4byte sMagmarPose172
+.4byte sMagmarPose173
+.4byte sMagmarPose174
+.4byte sMagmarPose175
+.4byte sMagmarPose176
+.4byte sMagmarPose177
+.4byte sMagmarPose178
+.4byte sMagmarPose179
+.4byte sMagmarPose180
+.4byte sMagmarPose181
+.4byte sMagmarPose182
+.4byte sMagmarPose183
+.4byte sMagmarPose184
+.4byte sMagmarPose185
+.4byte sMagmarPose186
+.4byte sMagmarPose187
+.4byte sMagmarPose188
+.4byte sMagmarPose189
+.4byte sMagmarPose190
+.4byte sMagmarPose191
+.4byte sMagmarPose192
+.4byte sMagmarPose193
+.4byte sMagmarPose194
+.4byte sMagmarPose195
+.4byte sMagmarPose196
+.4byte sMagmarPose197
+.4byte sMagmarPose198
+.4byte sMagmarPose199
+.4byte sMagmarPose200
+.4byte sMagmarPose201
+.4byte sMagmarPose202
+sAxPositionsMagmar:
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -2,   -9, 	  -9,   -5, 	  10,  -11, 	  -1,   -8
+.2byte    0,   -9, 	 -11,  -11, 	   8,   -5, 	  -1,   -8
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+.2byte    4,   -9, 	   9,   -8, 	  -7,   -6, 	  -1,   -8
+.2byte    3,   -9, 	   6,  -11, 	  -2,   -2, 	   0,   -7
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte    5,  -10, 	   5,  -12, 	   7,   -5, 	   0,   -8
+.2byte    7,  -10, 	   8,   -9, 	   0,   -3, 	   2,   -8
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte    7,  -14, 	   3,  -14, 	  13,   -9, 	  -1,  -10
+.2byte    5,  -14, 	  -3,  -12, 	   6,   -4, 	  -2,   -8
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -2,  -20, 	   9,   -7, 	 -11,  -14, 	  -2,  -10
+.2byte    0,  -20, 	   9,  -14, 	 -11,   -7, 	  -1,   -8
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte   -9,  -14, 	  -5,  -14, 	 -15,   -9, 	  -1,  -10
+.2byte   -7,  -14, 	   1,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte   -7,  -10, 	  -7,  -12, 	  -9,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	 -10,   -9, 	  -2,   -3, 	  -4,   -8
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte   -6,   -9, 	 -11,   -8, 	   5,   -6, 	  -1,   -8
+.2byte   -5,   -9, 	  -8,  -11, 	   0,   -2, 	  -2,   -7
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -2,   -9, 	  -9,   -5, 	  10,  -11, 	  -1,   -8
+.2byte    0,   -9, 	 -11,  -11, 	   8,   -5, 	  -1,   -8
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+.2byte    4,   -9, 	   9,   -8, 	  -7,   -6, 	  -1,   -8
+.2byte    3,   -9, 	   6,  -11, 	  -2,   -2, 	   0,   -7
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte    5,  -10, 	   5,  -12, 	   7,   -5, 	   0,   -8
+.2byte    7,  -10, 	   8,   -9, 	   0,   -3, 	   2,   -8
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte    7,  -14, 	   3,  -14, 	  13,   -9, 	  -1,  -10
+.2byte    5,  -14, 	  -3,  -12, 	   6,   -4, 	  -2,   -8
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -2,  -20, 	   9,   -7, 	 -11,  -14, 	  -2,  -10
+.2byte    0,  -20, 	   9,  -14, 	 -11,   -7, 	  -1,   -8
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte   -9,  -14, 	  -5,  -14, 	 -15,   -9, 	  -1,  -10
+.2byte   -7,  -14, 	   1,  -12, 	  -8,   -4, 	   0,   -8
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte   -7,  -10, 	  -7,  -12, 	  -9,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	 -10,   -9, 	  -2,   -3, 	  -4,   -8
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte   -6,   -9, 	 -11,   -8, 	   5,   -6, 	  -1,   -8
+.2byte   -5,   -9, 	  -8,  -11, 	   0,   -2, 	  -2,   -7
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -2,   -8, 	 -10,  -14, 	   0,   -6, 	  -1,   -9
+.2byte   -1,   -3, 	  -5,    2, 	   7,   -7, 	  -1,   -7
+.2byte   -1,   -3, 	  -5,    2, 	   7,   -7, 	  -1,   -7
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+.2byte    5,   -9, 	   6,  -13, 	   2,   -7, 	   0,   -8
+.2byte    7,   -7, 	  12,   -5, 	  -5,   -8, 	   0,   -8
+.2byte    7,   -7, 	  12,   -5, 	  -5,   -8, 	   0,   -8
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte    6,  -10, 	   3,  -14, 	   6,   -7, 	   0,  -10
+.2byte    8,   -8, 	  13,   -9, 	  -2,   -5, 	  -1,   -9
+.2byte    8,   -8, 	  13,   -9, 	  -2,   -5, 	  -1,   -9
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte    5,  -13, 	  -7,  -15, 	   7,  -10, 	   0,  -10
+.2byte    9,  -12, 	  11,  -17, 	   7,   -8, 	   0,   -9
+.2byte    9,  -12, 	  11,  -17, 	   7,   -8, 	   0,   -9
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -1,  -21, 	   8,  -11, 	  -3,  -14, 	   0,   -9
+.2byte   -2,  -23, 	   6,  -20, 	 -10,  -11, 	  -2,  -10
+.2byte   -2,  -23, 	   6,  -20, 	 -10,  -11, 	  -2,  -10
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte   -7,  -13, 	   5,  -15, 	  -9,  -10, 	  -2,  -10
+.2byte  -11,  -12, 	 -13,  -17, 	  -9,   -8, 	  -2,   -9
+.2byte  -11,  -12, 	 -13,  -17, 	  -9,   -8, 	  -2,   -9
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte   -8,  -10, 	  -5,  -14, 	  -8,   -7, 	  -2,  -10
+.2byte  -10,   -8, 	 -15,   -9, 	   0,   -5, 	  -1,   -9
+.2byte  -10,   -8, 	 -15,   -9, 	   0,   -5, 	  -1,   -9
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte   -7,   -9, 	  -8,  -13, 	  -4,   -7, 	  -2,   -8
+.2byte   -9,   -7, 	 -14,   -5, 	   3,   -8, 	  -2,   -8
+.2byte   -9,   -7, 	 -14,   -5, 	   3,   -8, 	  -2,   -8
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -2,   -8, 	 -10,  -14, 	   0,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	 -11,  -11, 	   9,  -11, 	  -1,   -9
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+.2byte    5,   -9, 	   6,  -13, 	   2,   -7, 	   0,   -8
+.2byte    9,   -7, 	   7,  -10, 	  -7,   -7, 	   1,   -7
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte    6,  -10, 	   3,  -14, 	   6,   -7, 	   0,  -10
+.2byte   13,   -9, 	   0,  -11, 	  -1,   -6, 	   3,   -7
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte    5,  -13, 	  -7,  -15, 	   7,  -10, 	   0,  -10
+.2byte   12,  -15, 	  -5,  -11, 	   6,   -4, 	   1,   -9
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -1,  -21, 	   8,  -11, 	  -3,  -14, 	   0,   -9
+.2byte   -1,  -23, 	   8,   -9, 	 -10,   -9, 	  -1,  -11
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte   -7,  -13, 	   5,  -15, 	  -9,  -10, 	  -2,  -10
+.2byte  -14,  -15, 	   3,  -11, 	  -8,   -4, 	  -3,   -9
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte   -8,  -10, 	  -5,  -14, 	  -8,   -7, 	  -2,  -10
+.2byte  -15,   -9, 	  -2,  -11, 	  -1,   -6, 	  -5,   -7
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte   -7,   -9, 	  -8,  -13, 	  -4,   -7, 	  -2,   -8
+.2byte  -11,   -7, 	  -9,  -10, 	   5,   -7, 	  -3,   -7
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -8,   -3, 	   5,   -2, 	  -1,   -6
+.2byte   -7,   -7, 	  -8,   -3, 	   3,    0, 	  -1,   -6
+.2byte   -1,  -13, 	  -6,  -10, 	   3,  -10, 	  -1,   -9
+.2byte    3,  -15, 	   5,  -11, 	  -3,  -10, 	  -1,   -9
+.2byte    5,  -14, 	   3,  -13, 	   1,  -10, 	  -2,   -9
+.2byte    5,  -17, 	   2,  -15, 	   7,  -13, 	  -1,  -10
+.2byte   -1,  -19, 	   3,  -15, 	  -5,  -15, 	  -1,   -9
+.2byte   -6,  -17, 	  -3,  -15, 	  -8,  -13, 	   0,  -10
+.2byte   -6,  -14, 	  -4,  -13, 	  -2,  -10, 	   1,   -9
+.2byte   -4,  -16, 	  -6,  -12, 	   2,  -11, 	   0,  -10
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -1,   -5, 	 -11,  -11, 	   9,  -11, 	  -1,   -9
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+.2byte    9,   -7, 	   7,  -10, 	  -7,   -7, 	   1,   -7
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte   13,   -9, 	   0,  -11, 	  -1,   -6, 	   3,   -7
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte   12,  -15, 	  -5,  -11, 	   6,   -4, 	   1,   -9
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -1,  -23, 	   8,   -9, 	 -10,   -9, 	  -1,  -11
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte  -14,  -15, 	   3,  -11, 	  -8,   -4, 	  -3,   -9
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte  -15,   -9, 	  -2,  -11, 	  -1,   -6, 	  -5,   -7
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte  -11,   -7, 	  -9,  -10, 	   5,   -7, 	  -3,   -7
+.2byte   -1,   -5, 	 -11,  -11, 	   9,  -11, 	  -1,   -9
+.2byte   -9,   -7, 	  -7,  -10, 	   7,   -7, 	  -1,   -7
+.2byte  -12,   -9, 	   1,  -11, 	   2,   -6, 	  -2,   -7
+.2byte  -12,  -15, 	   5,  -11, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,  -22, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte   10,  -15, 	  -7,  -11, 	   4,   -4, 	  -1,   -9
+.2byte   10,   -9, 	  -3,  -11, 	  -4,   -6, 	   0,   -7
+.2byte    7,   -7, 	   5,  -10, 	  -9,   -7, 	  -1,   -7
+.2byte   -1,   -5, 	 -11,  -11, 	   9,  -11, 	  -1,   -9
+.2byte    7,   -7, 	   5,  -10, 	  -9,   -7, 	  -1,   -7
+.2byte   10,   -9, 	  -3,  -11, 	  -4,   -6, 	   0,   -7
+.2byte   10,  -15, 	  -7,  -11, 	   4,   -4, 	  -1,   -9
+.2byte   -1,  -22, 	   8,   -8, 	 -10,   -8, 	  -1,  -10
+.2byte  -12,  -15, 	   5,  -11, 	  -6,   -4, 	  -1,   -9
+.2byte  -12,   -9, 	   1,  -11, 	   2,   -6, 	  -2,   -7
+.2byte   -9,   -7, 	  -7,  -10, 	   7,   -7, 	  -1,   -7
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -2,   -9, 	  -9,   -5, 	  10,  -11, 	  -1,   -8
+.2byte    0,   -9, 	 -11,  -11, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	 -11,  -11, 	   9,  -11, 	  -1,   -9
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+.2byte    4,   -9, 	   9,   -8, 	  -7,   -6, 	  -1,   -8
+.2byte    3,   -9, 	   6,  -11, 	  -2,   -2, 	   0,   -7
+.2byte    7,   -7, 	   5,  -10, 	  -9,   -7, 	  -1,   -7
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte    5,  -10, 	   5,  -12, 	   7,   -5, 	   0,   -8
+.2byte    7,  -10, 	   8,   -9, 	   0,   -3, 	   2,   -8
+.2byte   11,   -9, 	  -2,  -11, 	  -3,   -6, 	   1,   -7
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte    7,  -14, 	   3,  -14, 	  13,   -9, 	  -1,  -10
+.2byte    5,  -14, 	  -3,  -12, 	   6,   -4, 	  -2,   -8
+.2byte   10,  -15, 	  -7,  -11, 	   4,   -4, 	  -1,   -9
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -2,  -20, 	   9,   -7, 	 -11,  -14, 	  -2,  -10
+.2byte    0,  -20, 	   9,  -14, 	 -11,   -7, 	  -1,   -8
+.2byte   -1,  -23, 	   8,   -9, 	 -10,   -9, 	  -1,  -11
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte   -9,  -14, 	  -5,  -14, 	 -15,   -9, 	  -1,  -10
+.2byte   -7,  -14, 	   1,  -12, 	  -8,   -4, 	   0,   -8
+.2byte  -12,  -15, 	   5,  -11, 	  -6,   -4, 	  -1,   -9
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte   -7,  -10, 	  -7,  -12, 	  -9,   -5, 	  -2,   -8
+.2byte   -9,  -10, 	 -10,   -9, 	  -2,   -3, 	  -4,   -8
+.2byte  -13,   -9, 	   0,  -11, 	   1,   -6, 	  -3,   -7
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte   -6,   -9, 	 -11,   -8, 	   5,   -6, 	  -1,   -8
+.2byte   -5,   -9, 	  -8,  -11, 	   0,   -2, 	  -2,   -7
+.2byte   -9,   -7, 	  -7,  -10, 	   7,   -7, 	  -1,   -7
+.2byte   -2,   -8, 	 -10,  -14, 	   0,   -6, 	  -1,   -9
+.2byte   -6,   -9, 	  -7,  -13, 	  -3,   -7, 	  -1,   -8
+.2byte   -7,  -10, 	  -4,  -14, 	  -7,   -7, 	  -1,  -10
+.2byte   -6,  -13, 	   6,  -15, 	  -8,  -10, 	  -1,  -10
+.2byte   -1,  -21, 	   8,  -11, 	  -3,  -14, 	   0,   -9
+.2byte    5,  -13, 	  -7,  -15, 	   7,  -10, 	   0,  -10
+.2byte    5,  -10, 	   2,  -14, 	   5,   -7, 	  -1,  -10
+.2byte    5,   -9, 	   6,  -13, 	   2,   -7, 	   0,   -8
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	 -10,  -11, 	   2,   -5, 	  -2,   -8
+.2byte   -8,  -11, 	  -7,   -8, 	  -6,   -4, 	  -3,   -9
+.2byte   -8,  -15, 	   0,  -10, 	 -13,   -7, 	  -1,  -10
+.2byte   -1,  -20, 	  10,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte    6,  -15, 	  -2,  -10, 	  11,   -7, 	  -1,  -10
+.2byte    6,  -11, 	   5,   -8, 	   4,   -4, 	   1,   -9
+.2byte    4,  -10, 	   8,  -11, 	  -4,   -5, 	   0,   -8
+sMagmarAnimTable1:
+.4byte sMagmarAnims_1_1
+.4byte sMagmarAnims_1_2
+.4byte sMagmarAnims_1_3
+.4byte sMagmarAnims_1_4
+.4byte sMagmarAnims_1_5
+.4byte sMagmarAnims_1_6
+.4byte sMagmarAnims_1_7
+.4byte sMagmarAnims_1_8
+sMagmarAnimTable2:
+.4byte sMagmarAnims_2_1
+.4byte sMagmarAnims_2_2
+.4byte sMagmarAnims_2_3
+.4byte sMagmarAnims_2_4
+.4byte sMagmarAnims_2_5
+.4byte sMagmarAnims_2_6
+.4byte sMagmarAnims_2_7
+.4byte sMagmarAnims_2_8
+sMagmarAnimTable3:
+.4byte sMagmarAnims_3_1
+.4byte sMagmarAnims_3_2
+.4byte sMagmarAnims_3_3
+.4byte sMagmarAnims_3_4
+.4byte sMagmarAnims_3_5
+.4byte sMagmarAnims_3_6
+.4byte sMagmarAnims_3_7
+.4byte sMagmarAnims_3_8
+sMagmarAnimTable4:
+.4byte sMagmarAnims_4_1
+.4byte sMagmarAnims_4_2
+.4byte sMagmarAnims_4_3
+.4byte sMagmarAnims_4_4
+.4byte sMagmarAnims_4_5
+.4byte sMagmarAnims_4_6
+.4byte sMagmarAnims_4_7
+.4byte sMagmarAnims_4_8
+sMagmarAnimTable5:
+.4byte sMagmarAnims_5_1
+.4byte sMagmarAnims_5_2
+.4byte sMagmarAnims_5_3
+.4byte sMagmarAnims_5_4
+.4byte sMagmarAnims_5_5
+.4byte sMagmarAnims_5_6
+.4byte sMagmarAnims_5_7
+.4byte sMagmarAnims_5_8
+sMagmarAnimTable6:
+.4byte sMagmarAnims_6_1
+.4byte sMagmarAnims_6_1
+.4byte sMagmarAnims_6_1
+.4byte sMagmarAnims_6_1
+.4byte sMagmarAnims_6_1
+.4byte sMagmarAnims_6_1
+.4byte sMagmarAnims_6_1
+.4byte sMagmarAnims_6_1
+sMagmarAnimTable7:
+.4byte sMagmarAnims_7_1
+.4byte sMagmarAnims_7_2
+.4byte sMagmarAnims_7_3
+.4byte sMagmarAnims_7_4
+.4byte sMagmarAnims_7_5
+.4byte sMagmarAnims_7_6
+.4byte sMagmarAnims_7_7
+.4byte sMagmarAnims_7_8
+sMagmarAnimTable8:
+.4byte sMagmarAnims_8_1
+.4byte sMagmarAnims_8_2
+.4byte sMagmarAnims_8_3
+.4byte sMagmarAnims_8_4
+.4byte sMagmarAnims_8_5
+.4byte sMagmarAnims_8_6
+.4byte sMagmarAnims_8_7
+.4byte sMagmarAnims_8_8
+sMagmarAnimTable9:
+.4byte sMagmarAnims_9_1
+.4byte sMagmarAnims_9_2
+.4byte sMagmarAnims_9_3
+.4byte sMagmarAnims_9_4
+.4byte sMagmarAnims_9_5
+.4byte sMagmarAnims_9_6
+.4byte sMagmarAnims_9_7
+.4byte sMagmarAnims_9_8
+sMagmarAnimTable10:
+.4byte sMagmarAnims_10_1
+.4byte sMagmarAnims_10_2
+.4byte sMagmarAnims_10_3
+.4byte sMagmarAnims_10_4
+.4byte sMagmarAnims_10_5
+.4byte sMagmarAnims_10_6
+.4byte sMagmarAnims_10_7
+.4byte sMagmarAnims_10_8
+sMagmarAnimTable11:
+.4byte sMagmarAnims_11_1
+.4byte sMagmarAnims_11_2
+.4byte sMagmarAnims_11_3
+.4byte sMagmarAnims_11_4
+.4byte sMagmarAnims_11_5
+.4byte sMagmarAnims_11_6
+.4byte sMagmarAnims_11_7
+.4byte sMagmarAnims_11_8
+sMagmarAnimTable12:
+.4byte sMagmarAnims_12_1
+.4byte sMagmarAnims_12_2
+.4byte sMagmarAnims_12_3
+.4byte sMagmarAnims_12_4
+.4byte sMagmarAnims_12_5
+.4byte sMagmarAnims_12_6
+.4byte sMagmarAnims_12_7
+.4byte sMagmarAnims_12_8
+sMagmarAnimTable13:
+.4byte sMagmarAnims_13_1
+.4byte sMagmarAnims_13_2
+.4byte sMagmarAnims_13_3
+.4byte sMagmarAnims_13_4
+.4byte sMagmarAnims_13_5
+.4byte sMagmarAnims_13_6
+.4byte sMagmarAnims_13_7
+.4byte sMagmarAnims_13_8
+sAxAnimationsMagmar:
+.4byte sMagmarAnimTable1
+.4byte sMagmarAnimTable2
+.4byte sMagmarAnimTable3
+.4byte sMagmarAnimTable4
+.4byte sMagmarAnimTable5
+.4byte sMagmarAnimTable6
+.4byte sMagmarAnimTable7
+.4byte sMagmarAnimTable8
+.4byte sMagmarAnimTable9
+.4byte sMagmarAnimTable10
+.4byte sMagmarAnimTable11
+.4byte sMagmarAnimTable12
+.4byte sMagmarAnimTable13
+sAxSpritesMagmar:
+.4byte sMagmarSprites1
+.4byte sMagmarSprites2
+.4byte sMagmarSprites3
+.4byte sMagmarSprites4
+.4byte sMagmarSprites5
+.4byte sMagmarSprites6
+.4byte sMagmarSprites7
+.4byte sMagmarSprites8
+.4byte sMagmarSprites9
+.4byte sMagmarSprites10
+.4byte sMagmarSprites11
+.4byte sMagmarSprites12
+.4byte sMagmarSprites13
+.4byte sMagmarSprites14
+.4byte sMagmarSprites15
+.4byte sMagmarSprites16
+.4byte sMagmarSprites17
+.4byte sMagmarSprites18
+.4byte sMagmarSprites19
+.4byte sMagmarSprites20
+.4byte sMagmarSprites21
+.4byte sMagmarSprites22
+.4byte sMagmarSprites23
+.4byte sMagmarSprites24
+.4byte sMagmarSprites25
+.4byte sMagmarSprites26
+.4byte sMagmarSprites27
+.4byte sMagmarSprites28
+.4byte sMagmarSprites29
+.4byte sMagmarSprites30
+.4byte sMagmarSprites31
+.4byte sMagmarSprites32
+.4byte sMagmarSprites33
+.4byte sMagmarSprites34
+.4byte sMagmarSprites35
+.4byte sMagmarSprites36
+.4byte sMagmarSprites37
+.4byte sMagmarSprites38
+.4byte sMagmarSprites39
+.4byte sMagmarSprites40
+.4byte sMagmarSprites41
+.4byte sMagmarSprites42
+sAxMainMagmar:
+ax_main sAxPosesMagmar, sAxAnimationsMagmar, 13, sAxSpritesMagmar, sAxPositionsMagmar

--- a/data/ax/magnemite.inc
+++ b/data/ax/magnemite.inc
@@ -1,0 +1,2753 @@
+.global gAxMagnemite
+gAxMagnemite:
+ax_siro sAxMainMagnemite
+sMagnemitePose1:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose2:
+ax_pose 1, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose3:
+ax_pose 2, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose4:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose5:
+ax_pose 4, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose6:
+ax_pose 5, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose7:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose8:
+ax_pose 7, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose9:
+ax_pose 8, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose10:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose11:
+ax_pose 10, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose12:
+ax_pose 11, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose13:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose14:
+ax_pose 13, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose15:
+ax_pose 14, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose16:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose17:
+ax_pose 16, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose18:
+ax_pose 17, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose19:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose20:
+ax_pose 19, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose21:
+ax_pose 20, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose22:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose23:
+ax_pose 22, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose24:
+ax_pose 23, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose25:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose26:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose27:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose28:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose29:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose30:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose31:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose32:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose33:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose34:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose35:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose36:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose37:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose38:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose39:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose40:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose41:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose42:
+ax_pose 24, 0x01f0, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose43:
+ax_pose 25, 0x01f0, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose44:
+ax_pose 26, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose45:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose46:
+ax_pose 27, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose47:
+ax_pose 28, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose48:
+ax_pose 29, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose49:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose50:
+ax_pose 30, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose51:
+ax_pose 31, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose52:
+ax_pose 32, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose53:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose54:
+ax_pose 33, 0x01f0, 0x40f9, 0x5c00
+ax_pose_terminator
+sMagnemitePose55:
+ax_pose 34, 0x01f0, 0x40f9, 0x5c00
+ax_pose_terminator
+sMagnemitePose56:
+ax_pose 35, 0x01f0, 0x40f9, 0x5c00
+ax_pose_terminator
+sMagnemitePose57:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose58:
+ax_pose 36, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose59:
+ax_pose 37, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose60:
+ax_pose 38, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose61:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose62:
+ax_pose 39, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose63:
+ax_pose 40, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose64:
+ax_pose 41, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose65:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose66:
+ax_pose 42, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose67:
+ax_pose 43, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose68:
+ax_pose 44, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose69:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose70:
+ax_pose 45, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose71:
+ax_pose 46, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose72:
+ax_pose 47, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose73:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose74:
+ax_pose 24, 0x01f0, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose75:
+ax_pose 25, 0x01f0, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose76:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose77:
+ax_pose 27, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose78:
+ax_pose 28, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose79:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose80:
+ax_pose 30, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose81:
+ax_pose 31, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose82:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose83:
+ax_pose 33, 0x01f0, 0x40f9, 0x5c00
+ax_pose_terminator
+sMagnemitePose84:
+ax_pose 34, 0x01f0, 0x40f9, 0x5c00
+ax_pose_terminator
+sMagnemitePose85:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose86:
+ax_pose 36, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose87:
+ax_pose 37, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose88:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose89:
+ax_pose 39, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose90:
+ax_pose 40, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose91:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose92:
+ax_pose 42, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose93:
+ax_pose 43, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose94:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose95:
+ax_pose 45, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose96:
+ax_pose 46, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose97:
+ax_pose 48, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose98:
+ax_pose 49, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose99:
+ax_pose 50, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sMagnemitePose100:
+ax_pose 51, 0x01e6, 0x80ec, 0x5c00
+ax_pose_terminator
+sMagnemitePose101:
+ax_pose 52, 0x01e3, 0x80ea, 0x5c00
+ax_pose_terminator
+sMagnemitePose102:
+ax_pose 53, 0x01e4, 0x80ea, 0x5c00
+ax_pose_terminator
+sMagnemitePose103:
+ax_pose 54, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sMagnemitePose104:
+ax_pose 55, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose105:
+ax_pose 56, 0x01e3, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose106:
+ax_pose 57, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sMagnemitePose107:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose108:
+ax_pose 1, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose109:
+ax_pose 2, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose110:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose111:
+ax_pose 4, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose112:
+ax_pose 5, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose113:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose114:
+ax_pose 7, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose115:
+ax_pose 8, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose116:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose117:
+ax_pose 10, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose118:
+ax_pose 11, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose119:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose120:
+ax_pose 13, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose121:
+ax_pose 14, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose122:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose123:
+ax_pose 16, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose124:
+ax_pose 17, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose125:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose126:
+ax_pose 19, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose127:
+ax_pose 20, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose128:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose129:
+ax_pose 22, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose130:
+ax_pose 23, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose131:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose132:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose133:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose134:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose135:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose136:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose137:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose138:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose139:
+ax_pose 1, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose140:
+ax_pose 4, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose141:
+ax_pose 7, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose142:
+ax_pose 10, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose143:
+ax_pose 13, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose144:
+ax_pose 16, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose145:
+ax_pose 19, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose146:
+ax_pose 22, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose147:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose148:
+ax_pose 1, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose149:
+ax_pose 2, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose150:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose151:
+ax_pose 4, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose152:
+ax_pose 5, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose153:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose154:
+ax_pose 7, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose155:
+ax_pose 8, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose156:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose157:
+ax_pose 10, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose158:
+ax_pose 11, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose159:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose160:
+ax_pose 13, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose161:
+ax_pose 14, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose162:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose163:
+ax_pose 16, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose164:
+ax_pose 17, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose165:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose166:
+ax_pose 19, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose167:
+ax_pose 20, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose168:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose169:
+ax_pose 22, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose170:
+ax_pose 23, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose171:
+ax_pose 1, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose172:
+ax_pose 22, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose173:
+ax_pose 19, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose174:
+ax_pose 16, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose175:
+ax_pose 13, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose176:
+ax_pose 10, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose177:
+ax_pose 7, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose178:
+ax_pose 4, 0x81e8, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose179:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose180:
+ax_pose 21, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose181:
+ax_pose 18, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose182:
+ax_pose 15, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose183:
+ax_pose 12, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose184:
+ax_pose 9, 0x01f0, 0x40f8, 0x5c00
+ax_pose_terminator
+sMagnemitePose185:
+ax_pose 6, 0x81ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose186:
+ax_pose 3, 0x01f0, 0x40f7, 0x5c00
+ax_pose_terminator
+sMagnemitePose187:
+ax_pose 0, 0x41ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose188:
+ax_pose 58, 0x41f0, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnemitePose189:
+ax_pose 59, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+.align 2
+sMagnemiteAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 27, 0, -4, 0, -3,
+ax_anim 2, 0, 28, 0, -6, 0, -4,
+ax_anim 1, 0, 29, 0, -8, 0, -5,
+ax_anim 1, 0, 30, 0, -8, 0, -5,
+ax_anim 1, 0, 31, 0, -8, 0, -5,
+ax_anim 1, 0, 25, 0, -8, 0, -5,
+ax_anim 1, 0, 26, 0, -8, 0, -5,
+ax_anim 1, 0, 27, 0, -8, 0, -5,
+ax_anim 1, 0, 28, 0, -8, 0, -5,
+ax_anim 1, 0, 24, 0, -8, 0, -5,
+ax_anim 1, 2, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 9, 0, 9,
+ax_anim 2, 0, 24, 0, 23, 0, 23,
+ax_anim 2, 1, 24, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 23, 0, 23,
+ax_anim 2, 0, 24, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 12, 0, 12,
+ax_anim_terminator
+sMagnemiteAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 24, -2, -2, -2, -2,
+ax_anim 2, 0, 25, -4, -5, -4, -4,
+ax_anim 2, 0, 26, -5, -8, -5, -5,
+ax_anim 1, 0, 27, -6, -12, -6, -6,
+ax_anim 1, 0, 28, -6, -12, -6, -6,
+ax_anim 1, 0, 29, -6, -12, -6, -6,
+ax_anim 1, 0, 30, -6, -12, -6, -6,
+ax_anim 1, 0, 31, -6, -12, -6, -6,
+ax_anim 1, 0, 25, -6, -12, -6, -6,
+ax_anim 1, 0, 27, -6, -12, -6, -6,
+ax_anim 1, 0, 29, -6, -12, -6, -6,
+ax_anim 1, 2, 31, 0, -3, 0, 0,
+ax_anim 1, 0, 31, 9, 9, 9, 9,
+ax_anim 2, 0, 31, 23, 23, 23, 23,
+ax_anim 2, 1, 31, 22, 24, 22, 24,
+ax_anim 2, 0, 31, 23, 23, 23, 23,
+ax_anim 2, 0, 31, 22, 24, 22, 24,
+ax_anim 2, 0, 31, 12, 12, 12, 12,
+ax_anim_terminator
+sMagnemiteAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 2, 0, 24, -4, -1, -4, 0,
+ax_anim 2, 0, 25, -5, -2, -5, 0,
+ax_anim 1, 0, 26, -6, -4, -6, 0,
+ax_anim 1, 0, 27, -6, -4, -6, 0,
+ax_anim 1, 0, 28, -6, -4, -6, 0,
+ax_anim 1, 0, 29, -6, -4, -6, 0,
+ax_anim 1, 0, 30, -6, -4, -6, 0,
+ax_anim 1, 0, 24, -6, -4, -6, 0,
+ax_anim 1, 0, 26, -6, -4, -6, 0,
+ax_anim 1, 0, 28, -6, -4, -6, 0,
+ax_anim 1, 2, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 9, 0, 9, 0,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 1, 30, 23, -1, 23, -1,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 0, 30, 23, -1, 23, -1,
+ax_anim 2, 0, 30, 12, 0, 12, 0,
+ax_anim_terminator
+sMagnemiteAnims_2_4:
+ax_anim 2, 0, 29, -1, 1, -1, 1,
+ax_anim 2, 0, 30, -2, 2, -2, 2,
+ax_anim 2, 0, 31, -4, 1, -4, 4,
+ax_anim 2, 0, 24, -5, 1, -5, 5,
+ax_anim 1, 0, 25, -6, -1, -6, 6,
+ax_anim 1, 0, 26, -6, -1, -6, 6,
+ax_anim 1, 0, 27, -6, -1, -6, 6,
+ax_anim 1, 0, 29, -6, -1, -6, 6,
+ax_anim 1, 0, 31, -6, -1, -6, 6,
+ax_anim 1, 0, 25, -6, -1, -6, 6,
+ax_anim 1, 0, 27, -6, -1, -6, 6,
+ax_anim 1, 0, 29, -6, -1, -6, 6,
+ax_anim 1, 2, 29, 0, -2, 0, 0,
+ax_anim 1, 0, 29, 9, -8, 9, -8,
+ax_anim 2, 0, 29, 22, -20, 22, -20,
+ax_anim 2, 1, 29, 21, -21, 21, -21,
+ax_anim 2, 0, 29, 22, -20, 22, -20,
+ax_anim 2, 0, 29, 21, -21, 21, -21,
+ax_anim 2, 0, 29, 12, -12, 12, -12,
+ax_anim_terminator
+sMagnemiteAnims_2_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 2, 0, 29, 0, 2, 0, 2,
+ax_anim 2, 0, 30, 0, 4, 0, 5,
+ax_anim 2, 0, 31, 0, 5, 0, 7,
+ax_anim 1, 0, 24, 0, 6, 0, 9,
+ax_anim 1, 0, 25, 0, 6, 0, 9,
+ax_anim 1, 0, 26, 0, 6, 0, 9,
+ax_anim 1, 0, 28, 0, 6, 0, 9,
+ax_anim 1, 0, 30, 0, 6, 0, 9,
+ax_anim 1, 0, 24, 0, 6, 0, 9,
+ax_anim 1, 0, 26, 0, 6, 0, 9,
+ax_anim 1, 0, 28, 0, 6, 0, 9,
+ax_anim 1, 2, 28, 0, 0, 0, 2,
+ax_anim 1, 0, 28, 0, -9, 0, -9,
+ax_anim 2, 0, 28, 0, -21, 0, -21,
+ax_anim 2, 1, 28, 1, -21, 1, -21,
+ax_anim 2, 0, 28, 0, -21, 0, -21,
+ax_anim 2, 0, 28, 1, -21, 1, -21,
+ax_anim 2, 0, 28, 0, -12, 0, -12,
+ax_anim_terminator
+sMagnemiteAnims_2_6:
+ax_anim 2, 0, 27, 1, 1, 1, 1,
+ax_anim 2, 0, 28, 2, 2, 2, 2,
+ax_anim 2, 0, 29, 4, 1, 4, 4,
+ax_anim 2, 0, 30, 5, 1, 5, 5,
+ax_anim 1, 0, 31, 6, -1, 6, 6,
+ax_anim 1, 0, 24, 6, -1, 6, 6,
+ax_anim 1, 0, 25, 6, -1, 6, 6,
+ax_anim 1, 0, 27, 6, -1, 6, 6,
+ax_anim 1, 0, 29, 6, -1, 6, 6,
+ax_anim 1, 0, 31, 6, -1, 6, 6,
+ax_anim 1, 0, 25, 6, -1, 6, 6,
+ax_anim 1, 0, 27, 6, -1, 6, 6,
+ax_anim 1, 2, 27, 0, -2, 0, 0,
+ax_anim 1, 0, 27, -9, -8, -9, -8,
+ax_anim 2, 0, 27, -22, -20, -22, -20,
+ax_anim 2, 1, 27, -21, -21, -21, -21,
+ax_anim 2, 0, 27, -22, -20, -22, -20,
+ax_anim 2, 0, 27, -21, -21, -21, -21,
+ax_anim 2, 0, 27, -12, -12, -12, -12,
+ax_anim_terminator
+sMagnemiteAnims_2_7:
+ax_anim 2, 0, 26, 1, 0, 1, 0,
+ax_anim 2, 0, 27, 2, 0, 2, 0,
+ax_anim 2, 0, 28, 4, -1, 4, 0,
+ax_anim 2, 0, 29, 5, -2, 5, 0,
+ax_anim 1, 0, 30, 6, -4, 6, 0,
+ax_anim 1, 0, 31, 6, -4, 6, 0,
+ax_anim 1, 0, 24, 6, -4, 6, 0,
+ax_anim 1, 0, 26, 6, -4, 6, 0,
+ax_anim 1, 0, 28, 6, -4, 6, 0,
+ax_anim 1, 0, 30, 6, -4, 6, 0,
+ax_anim 1, 0, 24, 6, -4, 6, 0,
+ax_anim 1, 0, 26, 6, -4, 6, 0,
+ax_anim 1, 2, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 26, -9, 0, -9, 0,
+ax_anim 2, 0, 26, -23, 0, -23, 0,
+ax_anim 2, 1, 26, -23, -1, -23, -1,
+ax_anim 2, 0, 26, -23, 0, -23, 0,
+ax_anim 2, 0, 26, -23, -1, -23, -1,
+ax_anim 2, 0, 26, -12, 0, -12, 0,
+ax_anim_terminator
+sMagnemiteAnims_2_8:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 26, 2, -2, 2, -2,
+ax_anim 2, 0, 27, 4, -5, 4, -4,
+ax_anim 2, 0, 28, 5, -8, 5, -5,
+ax_anim 1, 0, 29, 6, -12, 6, -6,
+ax_anim 1, 0, 30, 6, -12, 6, -6,
+ax_anim 1, 0, 31, 6, -12, 6, -6,
+ax_anim 1, 0, 25, 6, -12, 6, -6,
+ax_anim 1, 0, 27, 6, -12, 6, -6,
+ax_anim 1, 0, 29, 6, -12, 6, -6,
+ax_anim 1, 0, 31, 6, -12, 6, -6,
+ax_anim 1, 0, 25, 6, -12, 6, -6,
+ax_anim 1, 2, 25, 0, -3, 0, 0,
+ax_anim 1, 0, 25, -9, 9, -9, 9,
+ax_anim 2, 0, 25, -23, 23, -23, 23,
+ax_anim 2, 1, 25, -22, 24, -22, 24,
+ax_anim 2, 0, 25, -23, 23, -23, 23,
+ax_anim 2, 0, 25, -22, 24, -22, 24,
+ax_anim 2, 0, 25, -12, 12, -12, 12,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_3_1:
+ax_anim 2, 0, 33, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 0, -2, 0, -2,
+ax_anim 2, 0, 35, 0, -4, 0, -3,
+ax_anim 2, 0, 36, 0, -6, 0, -4,
+ax_anim 1, 0, 37, 0, -8, 0, -5,
+ax_anim 1, 0, 38, 0, -8, 0, -5,
+ax_anim 1, 0, 39, 0, -8, 0, -5,
+ax_anim 1, 0, 33, 0, -8, 0, -5,
+ax_anim 1, 0, 34, 0, -8, 0, -5,
+ax_anim 1, 0, 35, 0, -8, 0, -5,
+ax_anim 1, 0, 36, 0, -8, 0, -5,
+ax_anim 1, 0, 32, 0, -8, 0, -5,
+ax_anim 1, 2, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 32, 0, 9, 0, 9,
+ax_anim 2, 0, 32, 0, 23, 0, 23,
+ax_anim 2, 1, 32, 1, 23, 1, 23,
+ax_anim 2, 0, 32, 0, 23, 0, 23,
+ax_anim 2, 0, 32, 1, 23, 1, 23,
+ax_anim 2, 0, 32, 0, 12, 0, 12,
+ax_anim_terminator
+sMagnemiteAnims_3_2:
+ax_anim 2, 0, 39, -1, -1, -1, -1,
+ax_anim 2, 0, 32, -2, -2, -2, -2,
+ax_anim 2, 0, 33, -4, -5, -4, -4,
+ax_anim 2, 0, 34, -5, -8, -5, -5,
+ax_anim 1, 0, 35, -6, -12, -6, -6,
+ax_anim 1, 0, 36, -6, -12, -6, -6,
+ax_anim 1, 0, 37, -6, -12, -6, -6,
+ax_anim 1, 0, 38, -6, -12, -6, -6,
+ax_anim 1, 0, 39, -6, -12, -6, -6,
+ax_anim 1, 0, 33, -6, -12, -6, -6,
+ax_anim 1, 0, 35, -6, -12, -6, -6,
+ax_anim 1, 0, 37, -6, -12, -6, -6,
+ax_anim 1, 2, 39, 0, -3, 0, 0,
+ax_anim 1, 0, 39, 9, 9, 9, 9,
+ax_anim 2, 0, 39, 23, 23, 23, 23,
+ax_anim 2, 1, 39, 22, 24, 22, 24,
+ax_anim 2, 0, 39, 23, 23, 23, 23,
+ax_anim 2, 0, 39, 22, 24, 22, 24,
+ax_anim 2, 0, 39, 12, 12, 12, 12,
+ax_anim_terminator
+sMagnemiteAnims_3_3:
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 2, 0, 39, -2, 0, -2, 0,
+ax_anim 2, 0, 32, -4, -1, -4, 0,
+ax_anim 2, 0, 33, -5, -2, -5, 0,
+ax_anim 1, 0, 34, -6, -4, -6, 0,
+ax_anim 1, 0, 35, -6, -4, -6, 0,
+ax_anim 1, 0, 36, -6, -4, -6, 0,
+ax_anim 1, 0, 37, -6, -4, -6, 0,
+ax_anim 1, 0, 38, -6, -4, -6, 0,
+ax_anim 1, 0, 32, -6, -4, -6, 0,
+ax_anim 1, 0, 34, -6, -4, -6, 0,
+ax_anim 1, 0, 36, -6, -4, -6, 0,
+ax_anim 1, 2, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 38, 9, 0, 9, 0,
+ax_anim 2, 0, 38, 23, 0, 23, 0,
+ax_anim 2, 1, 38, 23, -1, 23, -1,
+ax_anim 2, 0, 38, 23, 0, 23, 0,
+ax_anim 2, 0, 38, 23, -1, 23, -1,
+ax_anim 2, 0, 38, 12, 0, 12, 0,
+ax_anim_terminator
+sMagnemiteAnims_3_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 2, 0, 38, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -4, 1, -4, 4,
+ax_anim 2, 0, 32, -5, 1, -5, 5,
+ax_anim 1, 0, 33, -6, -1, -6, 6,
+ax_anim 1, 0, 34, -6, -1, -6, 6,
+ax_anim 1, 0, 35, -6, -1, -6, 6,
+ax_anim 1, 0, 37, -6, -1, -6, 6,
+ax_anim 1, 0, 39, -6, -1, -6, 6,
+ax_anim 1, 0, 33, -6, -1, -6, 6,
+ax_anim 1, 0, 35, -6, -1, -6, 6,
+ax_anim 1, 0, 37, -6, -1, -6, 6,
+ax_anim 1, 2, 37, 0, -2, 0, 0,
+ax_anim 1, 0, 37, 9, -8, 9, -8,
+ax_anim 2, 0, 37, 22, -20, 22, -20,
+ax_anim 2, 1, 37, 21, -21, 21, -21,
+ax_anim 2, 0, 37, 22, -20, 22, -20,
+ax_anim 2, 0, 37, 21, -21, 21, -21,
+ax_anim 2, 0, 37, 12, -12, 12, -12,
+ax_anim_terminator
+sMagnemiteAnims_3_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 4, 0, 5,
+ax_anim 2, 0, 39, 0, 5, 0, 7,
+ax_anim 1, 0, 32, 0, 6, 0, 9,
+ax_anim 1, 0, 33, 0, 6, 0, 9,
+ax_anim 1, 0, 34, 0, 6, 0, 9,
+ax_anim 1, 0, 36, 0, 6, 0, 9,
+ax_anim 1, 0, 38, 0, 6, 0, 9,
+ax_anim 1, 0, 32, 0, 6, 0, 9,
+ax_anim 1, 0, 34, 0, 6, 0, 9,
+ax_anim 1, 0, 36, 0, 6, 0, 9,
+ax_anim 1, 2, 36, 0, 0, 0, 2,
+ax_anim 1, 0, 36, 0, -9, 0, -9,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 1, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 0, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -12, 0, -12,
+ax_anim_terminator
+sMagnemiteAnims_3_6:
+ax_anim 2, 0, 35, 1, 1, 1, 1,
+ax_anim 2, 0, 36, 2, 2, 2, 2,
+ax_anim 2, 0, 37, 4, 1, 4, 4,
+ax_anim 2, 0, 38, 5, 1, 5, 5,
+ax_anim 1, 0, 39, 6, -1, 6, 6,
+ax_anim 1, 0, 32, 6, -1, 6, 6,
+ax_anim 1, 0, 33, 6, -1, 6, 6,
+ax_anim 1, 0, 35, 6, -1, 6, 6,
+ax_anim 1, 0, 37, 6, -1, 6, 6,
+ax_anim 1, 0, 39, 6, -1, 6, 6,
+ax_anim 1, 0, 33, 6, -1, 6, 6,
+ax_anim 1, 0, 35, 6, -1, 6, 6,
+ax_anim 1, 2, 35, 0, -2, 0, 0,
+ax_anim 1, 0, 35, -9, -8, -9, -8,
+ax_anim 2, 0, 35, -22, -20, -22, -20,
+ax_anim 2, 1, 35, -21, -21, -21, -21,
+ax_anim 2, 0, 35, -22, -20, -22, -20,
+ax_anim 2, 0, 35, -21, -21, -21, -21,
+ax_anim 2, 0, 35, -12, -12, -12, -12,
+ax_anim_terminator
+sMagnemiteAnims_3_7:
+ax_anim 2, 0, 34, 1, 0, 1, 0,
+ax_anim 2, 0, 35, 2, 0, 2, 0,
+ax_anim 2, 0, 36, 4, -1, 4, 0,
+ax_anim 2, 0, 37, 5, -2, 5, 0,
+ax_anim 1, 0, 38, 6, -4, 6, 0,
+ax_anim 1, 0, 39, 6, -4, 6, 0,
+ax_anim 1, 0, 32, 6, -4, 6, 0,
+ax_anim 1, 0, 34, 6, -4, 6, 0,
+ax_anim 1, 0, 36, 6, -4, 6, 0,
+ax_anim 1, 0, 38, 6, -4, 6, 0,
+ax_anim 1, 0, 32, 6, -4, 6, 0,
+ax_anim 1, 0, 34, 6, -4, 6, 0,
+ax_anim 1, 2, 34, 0, 0, 0, 0,
+ax_anim 1, 0, 34, -9, 0, -9, 0,
+ax_anim 2, 0, 34, -23, 0, -23, 0,
+ax_anim 2, 1, 34, -23, -1, -23, -1,
+ax_anim 2, 0, 34, -23, 0, -23, 0,
+ax_anim 2, 0, 34, -23, -1, -23, -1,
+ax_anim 2, 0, 34, -12, 0, -12, 0,
+ax_anim_terminator
+sMagnemiteAnims_3_8:
+ax_anim 2, 0, 33, 1, -1, 1, -1,
+ax_anim 2, 0, 34, 2, -2, 2, -2,
+ax_anim 2, 0, 35, 4, -5, 4, -4,
+ax_anim 2, 0, 36, 5, -8, 5, -5,
+ax_anim 1, 0, 37, 6, -12, 6, -6,
+ax_anim 1, 0, 38, 6, -12, 6, -6,
+ax_anim 1, 0, 39, 6, -12, 6, -6,
+ax_anim 1, 0, 33, 6, -12, 6, -6,
+ax_anim 1, 0, 35, 6, -12, 6, -6,
+ax_anim 1, 0, 37, 6, -12, 6, -6,
+ax_anim 1, 0, 39, 6, -12, 6, -6,
+ax_anim 1, 0, 33, 6, -12, 6, -6,
+ax_anim 1, 2, 33, 0, -3, 0, 0,
+ax_anim 1, 0, 33, -9, 9, -9, 9,
+ax_anim 2, 0, 33, -23, 23, -23, 23,
+ax_anim 2, 1, 33, -22, 24, -22, 24,
+ax_anim 2, 0, 33, -23, 23, -23, 23,
+ax_anim 2, 0, 33, -22, 24, -22, 24,
+ax_anim 2, 0, 33, -12, 12, -12, 12,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_4_1:
+ax_anim 2, 2, 40, 0, 1, 0, 1,
+ax_anim 2, 0, 42, 0, 3, 0, 3,
+ax_anim 6, 0, 42, 0, 4, 0, 4,
+ax_anim 1, 1, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, -2, 0, -2,
+ax_anim 4, 0, 41, 0, -3, 0, -3,
+ax_anim 2, 0, 41, 0, -1, 0, -1,
+ax_anim_terminator
+sMagnemiteAnims_4_2:
+ax_anim 2, 2, 44, 1, 1, 1, 1,
+ax_anim 2, 0, 46, 3, 3, 3, 3,
+ax_anim 6, 0, 46, 4, 4, 4, 4,
+ax_anim 1, 1, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -2, -2, -2, -2,
+ax_anim 4, 0, 45, -3, -3, -3, -3,
+ax_anim 2, 0, 45, -1, -1, -1, -1,
+ax_anim_terminator
+sMagnemiteAnims_4_3:
+ax_anim 2, 2, 48, 1, 0, 1, 0,
+ax_anim 2, 0, 50, 3, 0, 3, 0,
+ax_anim 6, 0, 50, 4, 0, 4, 0,
+ax_anim 1, 1, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -2, 0, -2, 0,
+ax_anim 4, 0, 49, -3, 0, -3, 0,
+ax_anim 2, 0, 49, -1, 0, -1, 0,
+ax_anim_terminator
+sMagnemiteAnims_4_4:
+ax_anim 2, 2, 52, 1, -1, 1, -1,
+ax_anim 2, 0, 54, 3, -3, 3, -3,
+ax_anim 6, 0, 54, 4, -4, 4, -4,
+ax_anim 1, 1, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, -2, 2, -2, 2,
+ax_anim 4, 0, 53, -3, 3, -3, 3,
+ax_anim 2, 0, 53, -1, 1, -1, 1,
+ax_anim_terminator
+sMagnemiteAnims_4_5:
+ax_anim 2, 2, 56, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 0, -3, 0, -3,
+ax_anim 6, 0, 58, 0, -4, 0, -4,
+ax_anim 1, 1, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 0, 2, 0, 2,
+ax_anim 4, 0, 57, 0, 3, 0, 3,
+ax_anim 2, 0, 57, 0, 1, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_4_6:
+ax_anim 2, 2, 60, -1, -1, -1, -1,
+ax_anim 2, 0, 62, -3, -3, -3, -3,
+ax_anim 6, 0, 62, -4, -4, -4, -4,
+ax_anim 1, 1, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 4, 0, 61, 3, 3, 3, 3,
+ax_anim 2, 0, 61, 1, 1, 1, 1,
+ax_anim_terminator
+sMagnemiteAnims_4_7:
+ax_anim 2, 2, 64, -1, 0, -1, 0,
+ax_anim 2, 0, 66, -3, 0, -3, 0,
+ax_anim 6, 0, 66, -4, 0, -4, 0,
+ax_anim 1, 1, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 2, 0, 2, 0,
+ax_anim 4, 0, 65, 3, 0, 3, 0,
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim_terminator
+sMagnemiteAnims_4_8:
+ax_anim 2, 2, 68, -1, 1, -1, 1,
+ax_anim 2, 0, 70, -3, 3, -3, 3,
+ax_anim 6, 0, 70, -4, 4, -4, 4,
+ax_anim 1, 1, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 2, -2, 2, -2,
+ax_anim 4, 0, 69, 3, -3, 3, -3,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_5_1:
+ax_anim 2, 0, 72, 0, -2, 0, -1,
+ax_anim 6, 0, 72, 0, -3, 0, -4,
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 2, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 1, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim_terminator
+sMagnemiteAnims_5_2:
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 6, 0, 75, 0, -3, 0, 0,
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 2, 2, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 2, 1, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sMagnemiteAnims_5_3:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 6, 0, 78, 0, -3, 0, 0,
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 1, 0, 1, 0,
+ax_anim 2, 0, 79, 5, 0, 5, 0,
+ax_anim 2, 2, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 79, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 79, 5, 0, 5, 0,
+ax_anim 2, 1, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 79, 2, 0, 2, 0,
+ax_anim_terminator
+sMagnemiteAnims_5_4:
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 6, 0, 81, 0, -3, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 4, -4, 4, -4,
+ax_anim 2, 2, 83, 4, -4, 4, -4,
+ax_anim 2, 0, 82, 4, -4, 4, -4,
+ax_anim 2, 0, 83, 4, -4, 4, -4,
+ax_anim 2, 0, 82, 4, -4, 4, -4,
+ax_anim 2, 1, 83, 4, -4, 4, -4,
+ax_anim 2, 0, 82, 2, -2, 2, -2,
+ax_anim_terminator
+sMagnemiteAnims_5_5:
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 6, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, -1,
+ax_anim 2, 0, 85, 0, -5, 0, -5,
+ax_anim 2, 2, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 85, 0, -5, 0, -5,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 85, 0, -5, 0, -5,
+ax_anim 2, 1, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 85, 0, -2, 0, -2,
+ax_anim_terminator
+sMagnemiteAnims_5_6:
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 6, 0, 87, 0, -3, 0, 0,
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim 2, 2, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim 2, 1, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 88, -2, -2, -2, -2,
+ax_anim_terminator
+sMagnemiteAnims_5_7:
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 6, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, -1, 0, -1, 0,
+ax_anim 2, 0, 91, -5, 0, -5, 0,
+ax_anim 2, 2, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 91, -5, 0, -5, 0,
+ax_anim 2, 0, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 91, -5, 0, -5, 0,
+ax_anim 2, 1, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 91, -2, 0, -2, 0,
+ax_anim_terminator
+sMagnemiteAnims_5_8:
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 6, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 0, 94, -4, 4, -4, 4,
+ax_anim 2, 2, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -4, 4, -4, 4,
+ax_anim 2, 1, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_6_1:
+ax_anim 20, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 0, 96, 0, -1, 0, 0,
+ax_anim 8, 0, 96, 0, -2, 0, 0,
+ax_anim 20, 0, 97, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -1, 0, 0,
+ax_anim 8, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sMagnemiteAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sMagnemiteAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sMagnemiteAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sMagnemiteAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sMagnemiteAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sMagnemiteAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sMagnemiteAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_8_1:
+ax_anim 10, 0, 106, 0, 0, 0, 0,
+ax_anim 14, 0, 108, 0, -1, 0, 0,
+ax_anim 10, 0, 106, 0, 0, 0, 0,
+ax_anim 14, 0, 107, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_8_2:
+ax_anim 10, 0, 109, 0, 0, 0, 0,
+ax_anim 14, 0, 111, 0, -1, 0, 0,
+ax_anim 10, 0, 109, 0, 0, 0, 0,
+ax_anim 14, 0, 110, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_8_3:
+ax_anim 10, 0, 112, 0, 0, 0, 0,
+ax_anim 14, 0, 114, 0, -1, 0, 0,
+ax_anim 10, 0, 112, 0, 0, 0, 0,
+ax_anim 14, 0, 113, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_8_4:
+ax_anim 10, 0, 115, 0, 0, 0, 0,
+ax_anim 14, 0, 117, 0, -1, 0, 0,
+ax_anim 10, 0, 115, 0, 0, 0, 0,
+ax_anim 14, 0, 116, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_8_5:
+ax_anim 10, 0, 118, 0, 0, 0, 0,
+ax_anim 14, 0, 120, 0, -1, 0, 0,
+ax_anim 10, 0, 118, 0, 0, 0, 0,
+ax_anim 14, 0, 119, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_8_6:
+ax_anim 10, 0, 121, 0, 0, 0, 0,
+ax_anim 14, 0, 123, 0, -1, 0, 0,
+ax_anim 10, 0, 121, 0, 0, 0, 0,
+ax_anim 14, 0, 122, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_8_7:
+ax_anim 10, 0, 124, 0, 0, 0, 0,
+ax_anim 14, 0, 126, 0, -1, 0, 0,
+ax_anim 10, 0, 124, 0, 0, 0, 0,
+ax_anim 14, 0, 125, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_8_8:
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim 14, 0, 129, 0, -1, 0, 0,
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim 14, 0, 128, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 4, 6, 4,
+ax_anim 2, 0, 132, 8, 9, 8, 9,
+ax_anim 2, 0, 133, 7, 19, 7, 19,
+ax_anim 3, 0, 134, 0, 24, 0, 24,
+ax_anim 2, 3, 135, -7, 19, -7, 19,
+ax_anim 2, 0, 136, -8, 9, -8, 9,
+ax_anim 1, 0, 137, -6, 4, -6, 4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 131, 17, 3, 17, 3,
+ax_anim 2, 0, 132, 24, 9, 24, 9,
+ax_anim 3, 0, 133, 23, 24, 23, 24,
+ax_anim 2, 3, 134, 11, 23, 11, 23,
+ax_anim 2, 0, 135, 2, 12, 2, 12,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -4, 3, -4,
+ax_anim 2, 0, 130, 11, -6, 11, -6,
+ax_anim 2, 0, 131, 19, -4, 19, -4,
+ax_anim 3, 0, 132, 24, 1, 24, 1,
+ax_anim 2, 3, 133, 19, 6, 19, 6,
+ax_anim 2, 0, 134, 12, 7, 12, 7,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -6, -1, -6,
+ax_anim 2, 0, 137, 4, -16, 4, -16,
+ax_anim 2, 0, 130, 12, -23, 12, -23,
+ax_anim 3, 0, 131, 22, -23, 22, -23,
+ax_anim 2, 3, 132, 23, -13, 23, -13,
+ax_anim 2, 0, 133, 16, -6, 16, -6,
+ax_anim 1, 0, 134, 7, -1, 7, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -6, -4, -6, -4,
+ax_anim 2, 0, 136, -8, -10, -8, -10,
+ax_anim 2, 0, 137, -7, -18, -7, -18,
+ax_anim 3, 0, 130, 0, -22, 0, -22,
+ax_anim 2, 3, 131, 7, -18, 7, -18,
+ax_anim 2, 0, 132, 8, -8, 8, -8,
+ax_anim 1, 0, 133, 6, -4, 6, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -6, 1, -6,
+ax_anim 2, 0, 131, -4, -16, -4, -16,
+ax_anim 2, 0, 130, -12, -23, -12, -23,
+ax_anim 3, 0, 137, -22, -23, -22, -23,
+ax_anim 2, 3, 136, -23, -13, -23, -13,
+ax_anim 2, 0, 135, -16, -6, -16, -6,
+ax_anim 1, 0, 134, -7, -1, -7, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -4, -3, -4,
+ax_anim 2, 0, 130, -11, -6, -11, -6,
+ax_anim 2, 0, 137, -19, -4, -19, -4,
+ax_anim 3, 0, 136, -24, 1, -24, 1,
+ax_anim 2, 3, 135, -19, 5, -19, 5,
+ax_anim 2, 0, 134, -12, 7, -12, 7,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -17, 3, -17, 3,
+ax_anim 2, 0, 136, -24, 9, -24, 9,
+ax_anim 3, 0, 135, -23, 24, -23, 24,
+ax_anim 2, 3, 134, -11, 23, -11, 23,
+ax_anim 2, 0, 133, -2, 12, -2, 12,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -24, 0, 0,
+ax_anim 3, 0, 147, 0, -22, 0, 0,
+ax_anim 2, 0, 147, 0, -18, 0, 0,
+ax_anim 1, 0, 147, 0, -12, 0, 0,
+ax_anim 2, 2, 147, 0, 3, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -24, 0, 0,
+ax_anim 3, 0, 150, 0, -22, 0, 0,
+ax_anim 2, 0, 150, 0, -18, 0, 0,
+ax_anim 1, 0, 150, 0, -12, 0, 0,
+ax_anim 2, 2, 150, 0, 3, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -24, 0, 0,
+ax_anim 3, 0, 153, 0, -22, 0, 0,
+ax_anim 2, 0, 153, 0, -18, 0, 0,
+ax_anim 1, 0, 153, 0, -12, 0, 0,
+ax_anim 2, 2, 153, 0, 3, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -22, 0, 0,
+ax_anim 3, 0, 156, 0, -21, 0, 0,
+ax_anim 2, 0, 156, 0, -17, 0, 0,
+ax_anim 1, 0, 156, 0, -11, 0, 0,
+ax_anim 2, 2, 156, 0, 3, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -24, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 3, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 162, 0, -21, 0, 0,
+ax_anim 2, 0, 162, 0, -17, 0, 0,
+ax_anim 1, 0, 162, 0, -11, 0, 0,
+ax_anim 2, 2, 162, 0, 3, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -24, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 3, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -24, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, 0,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnemiteAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnemiteAnims_14_1:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_14_2:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_14_3:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_14_4:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_14_5:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_14_6:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_14_7:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteAnims_14_8:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 2, 0, 188, 0, 3, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 2, 0, 188, 0, 1, 0, 1,
+ax_anim 1, 0, 188, 0, 2, 0, 1,
+ax_anim 4, 0, 188, 0, 3, 0, 1,
+ax_anim_terminator
+sMagnemiteGfx1:
+.incbin "baserom.gba", 0x87CDE4, 0x100
+sMagnemiteSprites1:
+ax_sprite sMagnemiteGfx1, 0x100
+ax_sprite_terminator
+sMagnemiteGfx2:
+.incbin "baserom.gba", 0x87CEF4, 0x100
+sMagnemiteSprites2:
+ax_sprite sMagnemiteGfx2, 0x100
+ax_sprite_terminator
+sMagnemiteGfx3:
+.incbin "baserom.gba", 0x87D004, 0x100
+sMagnemiteSprites3:
+ax_sprite sMagnemiteGfx3, 0x100
+ax_sprite_terminator
+sMagnemiteGfx4:
+.incbin "baserom.gba", 0x87D114, 0x80
+sMagnemiteSprites4:
+ax_sprite sMagnemiteGfx4, 0x80
+ax_sprite_terminator
+sMagnemiteGfx5:
+.incbin "baserom.gba", 0x87D1A4, 0x100
+sMagnemiteSprites5:
+ax_sprite sMagnemiteGfx5, 0x100
+ax_sprite_terminator
+sMagnemiteGfx6:
+.incbin "baserom.gba", 0x87D2B4, 0x100
+sMagnemiteSprites6:
+ax_sprite sMagnemiteGfx6, 0x100
+ax_sprite_terminator
+sMagnemiteGfx7:
+.incbin "baserom.gba", 0x87D3C4, 0x100
+sMagnemiteSprites7:
+ax_sprite sMagnemiteGfx7, 0x100
+ax_sprite_terminator
+sMagnemiteGfx8:
+.incbin "baserom.gba", 0x87D4D4, 0x100
+sMagnemiteSprites8:
+ax_sprite sMagnemiteGfx8, 0x100
+ax_sprite_terminator
+sMagnemiteGfx9:
+.incbin "baserom.gba", 0x87D5E4, 0x100
+sMagnemiteSprites9:
+ax_sprite sMagnemiteGfx9, 0x100
+ax_sprite_terminator
+sMagnemiteGfx10:
+.incbin "baserom.gba", 0x87D6F4, 0x80
+sMagnemiteSprites10:
+ax_sprite sMagnemiteGfx10, 0x80
+ax_sprite_terminator
+sMagnemiteGfx11:
+.incbin "baserom.gba", 0x87D784, 0x80
+sMagnemiteSprites11:
+ax_sprite sMagnemiteGfx11, 0x80
+ax_sprite_terminator
+sMagnemiteGfx12:
+.incbin "baserom.gba", 0x87D814, 0x100
+sMagnemiteSprites12:
+ax_sprite sMagnemiteGfx12, 0x100
+ax_sprite_terminator
+sMagnemiteGfx13:
+.incbin "baserom.gba", 0x87D924, 0x100
+sMagnemiteSprites13:
+ax_sprite sMagnemiteGfx13, 0x100
+ax_sprite_terminator
+sMagnemiteGfx14:
+.incbin "baserom.gba", 0x87DA34, 0x100
+sMagnemiteSprites14:
+ax_sprite sMagnemiteGfx14, 0x100
+ax_sprite_terminator
+sMagnemiteGfx15:
+.incbin "baserom.gba", 0x87DB44, 0x100
+sMagnemiteSprites15:
+ax_sprite sMagnemiteGfx15, 0x100
+ax_sprite_terminator
+sMagnemiteGfx16:
+.incbin "baserom.gba", 0x87DC54, 0x80
+sMagnemiteSprites16:
+ax_sprite sMagnemiteGfx16, 0x80
+ax_sprite_terminator
+sMagnemiteGfx17:
+.incbin "baserom.gba", 0x87DCE4, 0x80
+sMagnemiteSprites17:
+ax_sprite sMagnemiteGfx17, 0x80
+ax_sprite_terminator
+sMagnemiteGfx18:
+.incbin "baserom.gba", 0x87DD74, 0x100
+sMagnemiteSprites18:
+ax_sprite sMagnemiteGfx18, 0x100
+ax_sprite_terminator
+sMagnemiteGfx19:
+.incbin "baserom.gba", 0x87DE84, 0x100
+sMagnemiteSprites19:
+ax_sprite sMagnemiteGfx19, 0x100
+ax_sprite_terminator
+sMagnemiteGfx20:
+.incbin "baserom.gba", 0x87DF94, 0x100
+sMagnemiteSprites20:
+ax_sprite sMagnemiteGfx20, 0x100
+ax_sprite_terminator
+sMagnemiteGfx21:
+.incbin "baserom.gba", 0x87E0A4, 0x100
+sMagnemiteSprites21:
+ax_sprite sMagnemiteGfx21, 0x100
+ax_sprite_terminator
+sMagnemiteGfx22:
+.incbin "baserom.gba", 0x87E1B4, 0x80
+sMagnemiteSprites22:
+ax_sprite sMagnemiteGfx22, 0x80
+ax_sprite_terminator
+sMagnemiteGfx23:
+.incbin "baserom.gba", 0x87E244, 0x100
+sMagnemiteSprites23:
+ax_sprite sMagnemiteGfx23, 0x100
+ax_sprite_terminator
+sMagnemiteGfx24:
+.incbin "baserom.gba", 0x87E354, 0x100
+sMagnemiteSprites24:
+ax_sprite sMagnemiteGfx24, 0x100
+ax_sprite_terminator
+sMagnemiteGfx25:
+.incbin "baserom.gba", 0x87E464, 0x40
+sMagnemiteGfx25_1:
+.incbin "baserom.gba", 0x87E4A4, 0x40
+sMagnemiteSprites25:
+ax_sprite sMagnemiteGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagnemiteGfx25_1, 0x40
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sMagnemiteGfx26:
+.incbin "baserom.gba", 0x87E50C, 0x40
+sMagnemiteGfx26_1:
+.incbin "baserom.gba", 0x87E54C, 0x40
+sMagnemiteSprites26:
+ax_sprite sMagnemiteGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagnemiteGfx26_1, 0x40
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sMagnemiteGfx27:
+.incbin "baserom.gba", 0x87E5B4, 0x80
+sMagnemiteSprites27:
+ax_sprite sMagnemiteGfx27, 0x80
+ax_sprite_terminator
+sMagnemiteGfx28:
+.incbin "baserom.gba", 0x87E644, 0x80
+sMagnemiteSprites28:
+ax_sprite sMagnemiteGfx28, 0x80
+ax_sprite_terminator
+sMagnemiteGfx29:
+.incbin "baserom.gba", 0x87E6D4, 0x80
+sMagnemiteSprites29:
+ax_sprite sMagnemiteGfx29, 0x80
+ax_sprite_terminator
+sMagnemiteGfx30:
+.incbin "baserom.gba", 0x87E764, 0x80
+sMagnemiteSprites30:
+ax_sprite sMagnemiteGfx30, 0x80
+ax_sprite_terminator
+sMagnemiteGfx31:
+.incbin "baserom.gba", 0x87E7F4, 0xC0
+sMagnemiteSprites31:
+ax_sprite sMagnemiteGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagnemiteGfx32:
+.incbin "baserom.gba", 0x87E8CC, 0xC0
+sMagnemiteSprites32:
+ax_sprite sMagnemiteGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagnemiteGfx33:
+.incbin "baserom.gba", 0x87E9A4, 0x80
+sMagnemiteSprites33:
+ax_sprite sMagnemiteGfx33, 0x80
+ax_sprite_terminator
+sMagnemiteGfx34:
+.incbin "baserom.gba", 0x87EA34, 0x80
+sMagnemiteSprites34:
+ax_sprite sMagnemiteGfx34, 0x80
+ax_sprite_terminator
+sMagnemiteGfx35:
+.incbin "baserom.gba", 0x87EAC4, 0x80
+sMagnemiteSprites35:
+ax_sprite sMagnemiteGfx35, 0x80
+ax_sprite_terminator
+sMagnemiteGfx36:
+.incbin "baserom.gba", 0x87EB54, 0x80
+sMagnemiteSprites36:
+ax_sprite sMagnemiteGfx36, 0x80
+ax_sprite_terminator
+sMagnemiteGfx37:
+.incbin "baserom.gba", 0x87EBE4, 0x60
+sMagnemiteGfx37_1:
+.incbin "baserom.gba", 0x87EC44, 0x60
+sMagnemiteSprites37:
+ax_sprite sMagnemiteGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnemiteGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagnemiteGfx38:
+.incbin "baserom.gba", 0x87ECCC, 0x60
+sMagnemiteGfx38_1:
+.incbin "baserom.gba", 0x87ED2C, 0x60
+sMagnemiteSprites38:
+ax_sprite sMagnemiteGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnemiteGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagnemiteGfx39:
+.incbin "baserom.gba", 0x87EDB4, 0x60
+sMagnemiteGfx39_1:
+.incbin "baserom.gba", 0x87EE14, 0x60
+sMagnemiteSprites39:
+ax_sprite sMagnemiteGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnemiteGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagnemiteGfx40:
+.incbin "baserom.gba", 0x87EE9C, 0x80
+sMagnemiteSprites40:
+ax_sprite sMagnemiteGfx40, 0x80
+ax_sprite_terminator
+sMagnemiteGfx41:
+.incbin "baserom.gba", 0x87EF2C, 0x80
+sMagnemiteSprites41:
+ax_sprite sMagnemiteGfx41, 0x80
+ax_sprite_terminator
+sMagnemiteGfx42:
+.incbin "baserom.gba", 0x87EFBC, 0x80
+sMagnemiteSprites42:
+ax_sprite sMagnemiteGfx42, 0x80
+ax_sprite_terminator
+sMagnemiteGfx43:
+.incbin "baserom.gba", 0x87F04C, 0xC0
+sMagnemiteSprites43:
+ax_sprite sMagnemiteGfx43, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagnemiteGfx44:
+.incbin "baserom.gba", 0x87F124, 0xC0
+sMagnemiteSprites44:
+ax_sprite sMagnemiteGfx44, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagnemiteGfx45:
+.incbin "baserom.gba", 0x87F1FC, 0x80
+sMagnemiteSprites45:
+ax_sprite sMagnemiteGfx45, 0x80
+ax_sprite_terminator
+sMagnemiteGfx46:
+.incbin "baserom.gba", 0x87F28C, 0x80
+sMagnemiteSprites46:
+ax_sprite sMagnemiteGfx46, 0x80
+ax_sprite_terminator
+sMagnemiteGfx47:
+.incbin "baserom.gba", 0x87F31C, 0x80
+sMagnemiteSprites47:
+ax_sprite sMagnemiteGfx47, 0x80
+ax_sprite_terminator
+sMagnemiteGfx48:
+.incbin "baserom.gba", 0x87F3AC, 0x80
+sMagnemiteSprites48:
+ax_sprite sMagnemiteGfx48, 0x80
+ax_sprite_terminator
+sMagnemiteGfx49:
+.incbin "baserom.gba", 0x87F43C, 0x100
+sMagnemiteSprites49:
+ax_sprite sMagnemiteGfx49, 0x100
+ax_sprite_terminator
+sMagnemiteGfx50:
+.incbin "baserom.gba", 0x87F54C, 0x100
+sMagnemiteSprites50:
+ax_sprite sMagnemiteGfx50, 0x100
+ax_sprite_terminator
+sMagnemiteGfx51:
+.incbin "baserom.gba", 0x87F65C, 0x200
+sMagnemiteSprites51:
+ax_sprite sMagnemiteGfx51, 0x200
+ax_sprite_terminator
+sMagnemiteGfx52:
+.incbin "baserom.gba", 0x87F86C, 0x200
+sMagnemiteSprites52:
+ax_sprite sMagnemiteGfx52, 0x200
+ax_sprite_terminator
+sMagnemiteGfx53:
+.incbin "baserom.gba", 0x87FA7C, 0x200
+sMagnemiteSprites53:
+ax_sprite sMagnemiteGfx53, 0x200
+ax_sprite_terminator
+sMagnemiteGfx54:
+.incbin "baserom.gba", 0x87FC8C, 0x200
+sMagnemiteSprites54:
+ax_sprite sMagnemiteGfx54, 0x200
+ax_sprite_terminator
+sMagnemiteGfx55:
+.incbin "baserom.gba", 0x87FE9C, 0x200
+sMagnemiteSprites55:
+ax_sprite sMagnemiteGfx55, 0x200
+ax_sprite_terminator
+sMagnemiteGfx56:
+.incbin "baserom.gba", 0x8800AC, 0x200
+sMagnemiteSprites56:
+ax_sprite sMagnemiteGfx56, 0x200
+ax_sprite_terminator
+sMagnemiteGfx57:
+.incbin "baserom.gba", 0x8802BC, 0x200
+sMagnemiteSprites57:
+ax_sprite sMagnemiteGfx57, 0x200
+ax_sprite_terminator
+sMagnemiteGfx58:
+.incbin "baserom.gba", 0x8804CC, 0x200
+sMagnemiteSprites58:
+ax_sprite sMagnemiteGfx58, 0x200
+ax_sprite_terminator
+sMagnemiteGfx59:
+.incbin "baserom.gba", 0x8806DC, 0x100
+sMagnemiteSprites59:
+ax_sprite sMagnemiteGfx59, 0x100
+ax_sprite_terminator
+sMagnemiteGfx60:
+.incbin "baserom.gba", 0x8807EC, 0x100
+sMagnemiteSprites60:
+ax_sprite sMagnemiteGfx60, 0x100
+ax_sprite_terminator
+sAxPosesMagnemite:
+.4byte sMagnemitePose1
+.4byte sMagnemitePose2
+.4byte sMagnemitePose3
+.4byte sMagnemitePose4
+.4byte sMagnemitePose5
+.4byte sMagnemitePose6
+.4byte sMagnemitePose7
+.4byte sMagnemitePose8
+.4byte sMagnemitePose9
+.4byte sMagnemitePose10
+.4byte sMagnemitePose11
+.4byte sMagnemitePose12
+.4byte sMagnemitePose13
+.4byte sMagnemitePose14
+.4byte sMagnemitePose15
+.4byte sMagnemitePose16
+.4byte sMagnemitePose17
+.4byte sMagnemitePose18
+.4byte sMagnemitePose19
+.4byte sMagnemitePose20
+.4byte sMagnemitePose21
+.4byte sMagnemitePose22
+.4byte sMagnemitePose23
+.4byte sMagnemitePose24
+.4byte sMagnemitePose25
+.4byte sMagnemitePose26
+.4byte sMagnemitePose27
+.4byte sMagnemitePose28
+.4byte sMagnemitePose29
+.4byte sMagnemitePose30
+.4byte sMagnemitePose31
+.4byte sMagnemitePose32
+.4byte sMagnemitePose33
+.4byte sMagnemitePose34
+.4byte sMagnemitePose35
+.4byte sMagnemitePose36
+.4byte sMagnemitePose37
+.4byte sMagnemitePose38
+.4byte sMagnemitePose39
+.4byte sMagnemitePose40
+.4byte sMagnemitePose41
+.4byte sMagnemitePose42
+.4byte sMagnemitePose43
+.4byte sMagnemitePose44
+.4byte sMagnemitePose45
+.4byte sMagnemitePose46
+.4byte sMagnemitePose47
+.4byte sMagnemitePose48
+.4byte sMagnemitePose49
+.4byte sMagnemitePose50
+.4byte sMagnemitePose51
+.4byte sMagnemitePose52
+.4byte sMagnemitePose53
+.4byte sMagnemitePose54
+.4byte sMagnemitePose55
+.4byte sMagnemitePose56
+.4byte sMagnemitePose57
+.4byte sMagnemitePose58
+.4byte sMagnemitePose59
+.4byte sMagnemitePose60
+.4byte sMagnemitePose61
+.4byte sMagnemitePose62
+.4byte sMagnemitePose63
+.4byte sMagnemitePose64
+.4byte sMagnemitePose65
+.4byte sMagnemitePose66
+.4byte sMagnemitePose67
+.4byte sMagnemitePose68
+.4byte sMagnemitePose69
+.4byte sMagnemitePose70
+.4byte sMagnemitePose71
+.4byte sMagnemitePose72
+.4byte sMagnemitePose73
+.4byte sMagnemitePose74
+.4byte sMagnemitePose75
+.4byte sMagnemitePose76
+.4byte sMagnemitePose77
+.4byte sMagnemitePose78
+.4byte sMagnemitePose79
+.4byte sMagnemitePose80
+.4byte sMagnemitePose81
+.4byte sMagnemitePose82
+.4byte sMagnemitePose83
+.4byte sMagnemitePose84
+.4byte sMagnemitePose85
+.4byte sMagnemitePose86
+.4byte sMagnemitePose87
+.4byte sMagnemitePose88
+.4byte sMagnemitePose89
+.4byte sMagnemitePose90
+.4byte sMagnemitePose91
+.4byte sMagnemitePose92
+.4byte sMagnemitePose93
+.4byte sMagnemitePose94
+.4byte sMagnemitePose95
+.4byte sMagnemitePose96
+.4byte sMagnemitePose97
+.4byte sMagnemitePose98
+.4byte sMagnemitePose99
+.4byte sMagnemitePose100
+.4byte sMagnemitePose101
+.4byte sMagnemitePose102
+.4byte sMagnemitePose103
+.4byte sMagnemitePose104
+.4byte sMagnemitePose105
+.4byte sMagnemitePose106
+.4byte sMagnemitePose107
+.4byte sMagnemitePose108
+.4byte sMagnemitePose109
+.4byte sMagnemitePose110
+.4byte sMagnemitePose111
+.4byte sMagnemitePose112
+.4byte sMagnemitePose113
+.4byte sMagnemitePose114
+.4byte sMagnemitePose115
+.4byte sMagnemitePose116
+.4byte sMagnemitePose117
+.4byte sMagnemitePose118
+.4byte sMagnemitePose119
+.4byte sMagnemitePose120
+.4byte sMagnemitePose121
+.4byte sMagnemitePose122
+.4byte sMagnemitePose123
+.4byte sMagnemitePose124
+.4byte sMagnemitePose125
+.4byte sMagnemitePose126
+.4byte sMagnemitePose127
+.4byte sMagnemitePose128
+.4byte sMagnemitePose129
+.4byte sMagnemitePose130
+.4byte sMagnemitePose131
+.4byte sMagnemitePose132
+.4byte sMagnemitePose133
+.4byte sMagnemitePose134
+.4byte sMagnemitePose135
+.4byte sMagnemitePose136
+.4byte sMagnemitePose137
+.4byte sMagnemitePose138
+.4byte sMagnemitePose139
+.4byte sMagnemitePose140
+.4byte sMagnemitePose141
+.4byte sMagnemitePose142
+.4byte sMagnemitePose143
+.4byte sMagnemitePose144
+.4byte sMagnemitePose145
+.4byte sMagnemitePose146
+.4byte sMagnemitePose147
+.4byte sMagnemitePose148
+.4byte sMagnemitePose149
+.4byte sMagnemitePose150
+.4byte sMagnemitePose151
+.4byte sMagnemitePose152
+.4byte sMagnemitePose153
+.4byte sMagnemitePose154
+.4byte sMagnemitePose155
+.4byte sMagnemitePose156
+.4byte sMagnemitePose157
+.4byte sMagnemitePose158
+.4byte sMagnemitePose159
+.4byte sMagnemitePose160
+.4byte sMagnemitePose161
+.4byte sMagnemitePose162
+.4byte sMagnemitePose163
+.4byte sMagnemitePose164
+.4byte sMagnemitePose165
+.4byte sMagnemitePose166
+.4byte sMagnemitePose167
+.4byte sMagnemitePose168
+.4byte sMagnemitePose169
+.4byte sMagnemitePose170
+.4byte sMagnemitePose171
+.4byte sMagnemitePose172
+.4byte sMagnemitePose173
+.4byte sMagnemitePose174
+.4byte sMagnemitePose175
+.4byte sMagnemitePose176
+.4byte sMagnemitePose177
+.4byte sMagnemitePose178
+.4byte sMagnemitePose179
+.4byte sMagnemitePose180
+.4byte sMagnemitePose181
+.4byte sMagnemitePose182
+.4byte sMagnemitePose183
+.4byte sMagnemitePose184
+.4byte sMagnemitePose185
+.4byte sMagnemitePose186
+.4byte sMagnemitePose187
+.4byte sMagnemitePose188
+.4byte sMagnemitePose189
+sAxPositionsMagnemite:
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -1,   -5, 	 -10,   -6, 	   8,   -6, 	  -1,   -8
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte    2,   -6, 	  -7,  -11, 	   2,  -17, 	   0,   -8
+.2byte    2,   -6, 	  -8,   -5, 	   4,  -11, 	   0,   -8
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -7, 	   0,  -17, 	   0,   -7
+.2byte    2,   -6, 	  -2,   -1, 	  -2,  -15, 	   0,   -7
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -8, 	   5,  -11, 	  -5,  -15, 	  -1,   -7
+.2byte    2,   -8, 	   6,   -5, 	  -7,   -9, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,   -7, 	   6,  -12, 	  -8,  -12, 	  -1,   -9
+.2byte   -1,   -7, 	   8,   -6, 	 -10,   -6, 	  -1,   -9
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -3,   -9, 	   3,  -15, 	  -7,  -11, 	  -1,   -8
+.2byte   -3,   -8, 	   5,   -9, 	  -8,   -5, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -17, 	   0,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -12, 	   0,   -1, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -3,   -5, 	  -4,  -17, 	   5,  -11, 	  -1,   -8
+.2byte   -3,   -5, 	  -6,  -11, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -8, 	   5,   -8, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -8, 	   5,   -8, 	  -1,   -8
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte    1,   -5, 	   0,   -7, 	   5,  -11, 	   0,   -8
+.2byte    1,   -5, 	   0,   -4, 	   6,   -8, 	   0,   -7
+.2byte    1,   -5, 	  -2,   -6, 	   4,  -10, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	   2,   -7, 	   4,  -12, 	  -1,   -8
+.2byte    2,   -6, 	   2,   -5, 	   4,  -10, 	  -1,   -8
+.2byte    2,   -6, 	   0,   -6, 	   2,  -11, 	  -1,   -8
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -7, 	   6,  -11, 	   0,  -13, 	  -1,   -7
+.2byte    2,   -7, 	   6,   -9, 	   0,  -12, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -9, 	   0,  -12, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,   -7, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte   -1,   -7, 	   5,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,   -7, 	   5,  -10, 	  -7,  -10, 	  -1,   -9
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -2,   -8, 	   0,  -12, 	  -7,  -11, 	   0,   -8
+.2byte   -2,   -8, 	   2,  -10, 	  -7,   -9, 	   0,   -8
+.2byte   -2,   -8, 	   1,  -11, 	  -5,   -9, 	   0,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -12, 	  -4,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -10, 	  -4,   -5, 	  -1,   -8
+.2byte   -4,   -6, 	  -4,  -11, 	  -2,   -6, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -7,  -11, 	  -2,   -7, 	  -2,   -8
+.2byte   -4,   -6, 	  -8,   -8, 	  -2,   -4, 	  -2,   -8
+.2byte   -4,   -6, 	  -6,  -10, 	   0,   -6, 	  -2,   -7
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -8, 	   5,   -8, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -5, 	   5,   -5, 	  -1,   -8
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte    1,   -5, 	   0,   -7, 	   5,  -11, 	   0,   -8
+.2byte    1,   -5, 	   0,   -4, 	   6,   -8, 	   0,   -7
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	   2,   -7, 	   4,  -12, 	  -1,   -8
+.2byte    2,   -6, 	   2,   -5, 	   4,  -10, 	  -1,   -8
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -7, 	   6,  -11, 	   0,  -13, 	  -1,   -7
+.2byte    2,   -7, 	   6,   -9, 	   0,  -12, 	  -1,   -7
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,   -7, 	   5,  -13, 	  -7,  -13, 	  -1,   -9
+.2byte   -1,   -7, 	   5,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -2,   -8, 	   0,  -12, 	  -7,  -11, 	   0,   -8
+.2byte   -2,   -8, 	   2,  -10, 	  -7,   -9, 	   0,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -12, 	  -4,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -10, 	  -4,   -5, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -7,  -11, 	  -2,   -7, 	  -2,   -8
+.2byte   -4,   -6, 	  -8,   -8, 	  -2,   -4, 	  -2,   -8
+.2byte   -1,   -5, 	 -10,   -7, 	   8,   -7, 	  -1,   -7
+.2byte   -1,   -5, 	 -10,   -7, 	   8,   -7, 	  -1,   -7
+.2byte    0,   -7, 	  -7,  -14, 	   7,  -14, 	   0,  -11
+.2byte    2,   -7, 	  -7,  -11, 	   0,  -16, 	  -1,   -8
+.2byte    2,   -8, 	  -5,   -8, 	  -2,  -16, 	  -1,   -7
+.2byte    2,   -9, 	   4,  -10, 	  -6,  -14, 	   0,   -6
+.2byte    0,   -9, 	   7,  -12, 	  -7,  -12, 	   0,   -6
+.2byte   -2,   -9, 	   6,  -14, 	  -4,  -10, 	   0,   -7
+.2byte   -2,   -8, 	   2,  -16, 	   5,   -8, 	   1,   -7
+.2byte   -2,   -6, 	   0,  -16, 	   7,  -11, 	   1,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -1,   -5, 	 -10,   -6, 	   8,   -6, 	  -1,   -8
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte    2,   -6, 	  -7,  -11, 	   2,  -17, 	   0,   -8
+.2byte    2,   -6, 	  -8,   -5, 	   4,  -11, 	   0,   -8
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -7, 	   0,  -17, 	   0,   -7
+.2byte    2,   -6, 	  -2,   -1, 	  -2,  -15, 	   0,   -7
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -8, 	   5,  -11, 	  -5,  -15, 	  -1,   -7
+.2byte    2,   -8, 	   6,   -5, 	  -7,   -9, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,   -7, 	   6,  -12, 	  -8,  -12, 	  -1,   -9
+.2byte   -1,   -7, 	   8,   -6, 	 -10,   -6, 	  -1,   -9
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -3,   -9, 	   3,  -15, 	  -7,  -11, 	  -1,   -8
+.2byte   -3,   -8, 	   5,   -9, 	  -8,   -5, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -17, 	   0,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -12, 	   0,   -1, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -3,   -5, 	  -4,  -17, 	   5,  -11, 	  -1,   -8
+.2byte   -3,   -5, 	  -6,  -11, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte   -1,   -5, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte    2,   -6, 	  -7,  -11, 	   2,  -17, 	   0,   -8
+.2byte    2,   -6, 	  -2,   -7, 	   0,  -17, 	   0,   -7
+.2byte    2,   -8, 	   5,  -11, 	  -5,  -15, 	  -1,   -7
+.2byte   -1,   -7, 	   6,  -12, 	  -8,  -12, 	  -1,   -9
+.2byte   -3,   -9, 	   3,  -15, 	  -7,  -11, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -17, 	   0,   -7, 	  -1,   -8
+.2byte   -3,   -5, 	  -4,  -17, 	   5,  -11, 	  -1,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -1,   -5, 	 -10,   -6, 	   8,   -6, 	  -1,   -8
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte    2,   -6, 	  -7,  -11, 	   2,  -17, 	   0,   -8
+.2byte    2,   -6, 	  -8,   -5, 	   4,  -11, 	   0,   -8
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -7, 	   0,  -17, 	   0,   -7
+.2byte    2,   -6, 	  -2,   -1, 	  -2,  -15, 	   0,   -7
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -8, 	   5,  -11, 	  -5,  -15, 	  -1,   -7
+.2byte    2,   -8, 	   6,   -5, 	  -7,   -9, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,   -7, 	   6,  -12, 	  -8,  -12, 	  -1,   -9
+.2byte   -1,   -7, 	   8,   -6, 	 -10,   -6, 	  -1,   -9
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -3,   -9, 	   3,  -15, 	  -7,  -11, 	  -1,   -8
+.2byte   -3,   -8, 	   5,   -9, 	  -8,   -5, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -17, 	   0,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -12, 	   0,   -1, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -3,   -5, 	  -4,  -17, 	   5,  -11, 	  -1,   -8
+.2byte   -3,   -5, 	  -6,  -11, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	  -8,  -13, 	   6,  -13, 	  -1,   -8
+.2byte   -3,   -5, 	  -4,  -17, 	   5,  -11, 	  -1,   -8
+.2byte   -4,   -6, 	  -2,  -17, 	   0,   -7, 	  -1,   -8
+.2byte   -3,   -9, 	   3,  -15, 	  -7,  -11, 	  -1,   -8
+.2byte   -1,   -7, 	   6,  -12, 	  -8,  -12, 	  -1,   -9
+.2byte    2,   -8, 	   5,  -11, 	  -5,  -15, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -7, 	   0,  -17, 	   0,   -7
+.2byte    2,   -6, 	  -7,  -11, 	   2,  -17, 	   0,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,  -15, 	   6,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -1,  -16, 	   0,   -3, 	  -1,   -8
+.2byte   -3,   -8, 	   5,  -13, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte    2,   -8, 	   6,   -7, 	  -7,  -13, 	  -1,   -7
+.2byte    2,   -6, 	  -2,   -3, 	  -1,  -16, 	  -1,   -7
+.2byte    2,   -6, 	  -8,   -7, 	   3,  -15, 	   0,   -8
+.2byte   -1,   -5, 	  -9,  -10, 	   7,  -10, 	  -1,   -8
+.2byte   -1,   -3, 	  -9,   -8, 	   7,   -8, 	  -1,   -6
+.2byte   -1,   -3, 	  -9,   -5, 	   7,   -5, 	  -1,   -6
+sMagnemiteAnimTable1:
+.4byte sMagnemiteAnims_1_1
+.4byte sMagnemiteAnims_1_2
+.4byte sMagnemiteAnims_1_3
+.4byte sMagnemiteAnims_1_4
+.4byte sMagnemiteAnims_1_5
+.4byte sMagnemiteAnims_1_6
+.4byte sMagnemiteAnims_1_7
+.4byte sMagnemiteAnims_1_8
+sMagnemiteAnimTable2:
+.4byte sMagnemiteAnims_2_1
+.4byte sMagnemiteAnims_2_2
+.4byte sMagnemiteAnims_2_3
+.4byte sMagnemiteAnims_2_4
+.4byte sMagnemiteAnims_2_5
+.4byte sMagnemiteAnims_2_6
+.4byte sMagnemiteAnims_2_7
+.4byte sMagnemiteAnims_2_8
+sMagnemiteAnimTable3:
+.4byte sMagnemiteAnims_3_1
+.4byte sMagnemiteAnims_3_2
+.4byte sMagnemiteAnims_3_3
+.4byte sMagnemiteAnims_3_4
+.4byte sMagnemiteAnims_3_5
+.4byte sMagnemiteAnims_3_6
+.4byte sMagnemiteAnims_3_7
+.4byte sMagnemiteAnims_3_8
+sMagnemiteAnimTable4:
+.4byte sMagnemiteAnims_4_1
+.4byte sMagnemiteAnims_4_2
+.4byte sMagnemiteAnims_4_3
+.4byte sMagnemiteAnims_4_4
+.4byte sMagnemiteAnims_4_5
+.4byte sMagnemiteAnims_4_6
+.4byte sMagnemiteAnims_4_7
+.4byte sMagnemiteAnims_4_8
+sMagnemiteAnimTable5:
+.4byte sMagnemiteAnims_5_1
+.4byte sMagnemiteAnims_5_2
+.4byte sMagnemiteAnims_5_3
+.4byte sMagnemiteAnims_5_4
+.4byte sMagnemiteAnims_5_5
+.4byte sMagnemiteAnims_5_6
+.4byte sMagnemiteAnims_5_7
+.4byte sMagnemiteAnims_5_8
+sMagnemiteAnimTable6:
+.4byte sMagnemiteAnims_6_1
+.4byte sMagnemiteAnims_6_1
+.4byte sMagnemiteAnims_6_1
+.4byte sMagnemiteAnims_6_1
+.4byte sMagnemiteAnims_6_1
+.4byte sMagnemiteAnims_6_1
+.4byte sMagnemiteAnims_6_1
+.4byte sMagnemiteAnims_6_1
+sMagnemiteAnimTable7:
+.4byte sMagnemiteAnims_7_1
+.4byte sMagnemiteAnims_7_2
+.4byte sMagnemiteAnims_7_3
+.4byte sMagnemiteAnims_7_4
+.4byte sMagnemiteAnims_7_5
+.4byte sMagnemiteAnims_7_6
+.4byte sMagnemiteAnims_7_7
+.4byte sMagnemiteAnims_7_8
+sMagnemiteAnimTable8:
+.4byte sMagnemiteAnims_8_1
+.4byte sMagnemiteAnims_8_2
+.4byte sMagnemiteAnims_8_3
+.4byte sMagnemiteAnims_8_4
+.4byte sMagnemiteAnims_8_5
+.4byte sMagnemiteAnims_8_6
+.4byte sMagnemiteAnims_8_7
+.4byte sMagnemiteAnims_8_8
+sMagnemiteAnimTable9:
+.4byte sMagnemiteAnims_9_1
+.4byte sMagnemiteAnims_9_2
+.4byte sMagnemiteAnims_9_3
+.4byte sMagnemiteAnims_9_4
+.4byte sMagnemiteAnims_9_5
+.4byte sMagnemiteAnims_9_6
+.4byte sMagnemiteAnims_9_7
+.4byte sMagnemiteAnims_9_8
+sMagnemiteAnimTable10:
+.4byte sMagnemiteAnims_10_1
+.4byte sMagnemiteAnims_10_2
+.4byte sMagnemiteAnims_10_3
+.4byte sMagnemiteAnims_10_4
+.4byte sMagnemiteAnims_10_5
+.4byte sMagnemiteAnims_10_6
+.4byte sMagnemiteAnims_10_7
+.4byte sMagnemiteAnims_10_8
+sMagnemiteAnimTable11:
+.4byte sMagnemiteAnims_11_1
+.4byte sMagnemiteAnims_11_2
+.4byte sMagnemiteAnims_11_3
+.4byte sMagnemiteAnims_11_4
+.4byte sMagnemiteAnims_11_5
+.4byte sMagnemiteAnims_11_6
+.4byte sMagnemiteAnims_11_7
+.4byte sMagnemiteAnims_11_8
+sMagnemiteAnimTable12:
+.4byte sMagnemiteAnims_12_1
+.4byte sMagnemiteAnims_12_2
+.4byte sMagnemiteAnims_12_3
+.4byte sMagnemiteAnims_12_4
+.4byte sMagnemiteAnims_12_5
+.4byte sMagnemiteAnims_12_6
+.4byte sMagnemiteAnims_12_7
+.4byte sMagnemiteAnims_12_8
+sMagnemiteAnimTable13:
+.4byte sMagnemiteAnims_13_1
+.4byte sMagnemiteAnims_13_2
+.4byte sMagnemiteAnims_13_3
+.4byte sMagnemiteAnims_13_4
+.4byte sMagnemiteAnims_13_5
+.4byte sMagnemiteAnims_13_6
+.4byte sMagnemiteAnims_13_7
+.4byte sMagnemiteAnims_13_8
+sMagnemiteAnimTable14:
+.4byte sMagnemiteAnims_14_1
+.4byte sMagnemiteAnims_14_2
+.4byte sMagnemiteAnims_14_3
+.4byte sMagnemiteAnims_14_4
+.4byte sMagnemiteAnims_14_5
+.4byte sMagnemiteAnims_14_6
+.4byte sMagnemiteAnims_14_7
+.4byte sMagnemiteAnims_14_8
+sAxAnimationsMagnemite:
+.4byte sMagnemiteAnimTable1
+.4byte sMagnemiteAnimTable2
+.4byte sMagnemiteAnimTable3
+.4byte sMagnemiteAnimTable4
+.4byte sMagnemiteAnimTable5
+.4byte sMagnemiteAnimTable6
+.4byte sMagnemiteAnimTable7
+.4byte sMagnemiteAnimTable8
+.4byte sMagnemiteAnimTable9
+.4byte sMagnemiteAnimTable10
+.4byte sMagnemiteAnimTable11
+.4byte sMagnemiteAnimTable12
+.4byte sMagnemiteAnimTable13
+.4byte sMagnemiteAnimTable14
+sAxSpritesMagnemite:
+.4byte sMagnemiteSprites1
+.4byte sMagnemiteSprites2
+.4byte sMagnemiteSprites3
+.4byte sMagnemiteSprites4
+.4byte sMagnemiteSprites5
+.4byte sMagnemiteSprites6
+.4byte sMagnemiteSprites7
+.4byte sMagnemiteSprites8
+.4byte sMagnemiteSprites9
+.4byte sMagnemiteSprites10
+.4byte sMagnemiteSprites11
+.4byte sMagnemiteSprites12
+.4byte sMagnemiteSprites13
+.4byte sMagnemiteSprites14
+.4byte sMagnemiteSprites15
+.4byte sMagnemiteSprites16
+.4byte sMagnemiteSprites17
+.4byte sMagnemiteSprites18
+.4byte sMagnemiteSprites19
+.4byte sMagnemiteSprites20
+.4byte sMagnemiteSprites21
+.4byte sMagnemiteSprites22
+.4byte sMagnemiteSprites23
+.4byte sMagnemiteSprites24
+.4byte sMagnemiteSprites25
+.4byte sMagnemiteSprites26
+.4byte sMagnemiteSprites27
+.4byte sMagnemiteSprites28
+.4byte sMagnemiteSprites29
+.4byte sMagnemiteSprites30
+.4byte sMagnemiteSprites31
+.4byte sMagnemiteSprites32
+.4byte sMagnemiteSprites33
+.4byte sMagnemiteSprites34
+.4byte sMagnemiteSprites35
+.4byte sMagnemiteSprites36
+.4byte sMagnemiteSprites37
+.4byte sMagnemiteSprites38
+.4byte sMagnemiteSprites39
+.4byte sMagnemiteSprites40
+.4byte sMagnemiteSprites41
+.4byte sMagnemiteSprites42
+.4byte sMagnemiteSprites43
+.4byte sMagnemiteSprites44
+.4byte sMagnemiteSprites45
+.4byte sMagnemiteSprites46
+.4byte sMagnemiteSprites47
+.4byte sMagnemiteSprites48
+.4byte sMagnemiteSprites49
+.4byte sMagnemiteSprites50
+.4byte sMagnemiteSprites51
+.4byte sMagnemiteSprites52
+.4byte sMagnemiteSprites53
+.4byte sMagnemiteSprites54
+.4byte sMagnemiteSprites55
+.4byte sMagnemiteSprites56
+.4byte sMagnemiteSprites57
+.4byte sMagnemiteSprites58
+.4byte sMagnemiteSprites59
+.4byte sMagnemiteSprites60
+sAxMainMagnemite:
+ax_main sAxPosesMagnemite, sAxAnimationsMagnemite, 14, sAxSpritesMagnemite, sAxPositionsMagnemite

--- a/data/ax/magneton.inc
+++ b/data/ax/magneton.inc
@@ -1,0 +1,2533 @@
+.global gAxMagneton
+gAxMagneton:
+ax_siro sAxMainMagneton
+sMagnetonPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose3:
+ax_pose 2, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose4:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose5:
+ax_pose 4, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose6:
+ax_pose 5, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose7:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose8:
+ax_pose 7, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose9:
+ax_pose 8, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose10:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose11:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose12:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose13:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose14:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose15:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose16:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose17:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose18:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose19:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose22:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose23:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose25:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose27:
+ax_pose 2, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose28:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose29:
+ax_pose 4, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose30:
+ax_pose 5, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose31:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose32:
+ax_pose 7, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose33:
+ax_pose 8, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose34:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose35:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose36:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose37:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose38:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose39:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose40:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose41:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose42:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose43:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose44:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose45:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose46:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose47:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose48:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose49:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose50:
+ax_pose 1, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose51:
+ax_pose 2, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose52:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose53:
+ax_pose 4, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose54:
+ax_pose 5, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose55:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose56:
+ax_pose 7, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose57:
+ax_pose 8, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose58:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose59:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose60:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose61:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose62:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose63:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose64:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose65:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose66:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose67:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose68:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose69:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose70:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose71:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose72:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose73:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose74:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose75:
+ax_pose 16, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose76:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose77:
+ax_pose 17, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose78:
+ax_pose 18, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose79:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose80:
+ax_pose 19, 0x01e6, 0x90eb, 0x5c00
+ax_pose_terminator
+sMagnetonPose81:
+ax_pose 20, 0x01e6, 0x90eb, 0x5c00
+ax_pose_terminator
+sMagnetonPose82:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose83:
+ax_pose 21, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose84:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose85:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose86:
+ax_pose 23, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose87:
+ax_pose 24, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose88:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose89:
+ax_pose 21, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose90:
+ax_pose 22, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose91:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose92:
+ax_pose 19, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sMagnetonPose93:
+ax_pose 20, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sMagnetonPose94:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose95:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose96:
+ax_pose 18, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose97:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose98:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose99:
+ax_pose 16, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose100:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose101:
+ax_pose 17, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose102:
+ax_pose 18, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose103:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose104:
+ax_pose 19, 0x01e6, 0x90eb, 0x5c00
+ax_pose_terminator
+sMagnetonPose105:
+ax_pose 20, 0x01e6, 0x90eb, 0x5c00
+ax_pose_terminator
+sMagnetonPose106:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose107:
+ax_pose 21, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose108:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose109:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose110:
+ax_pose 23, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose111:
+ax_pose 24, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose112:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose113:
+ax_pose 21, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose114:
+ax_pose 22, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose115:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose116:
+ax_pose 19, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sMagnetonPose117:
+ax_pose 20, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sMagnetonPose118:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose119:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose120:
+ax_pose 18, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose121:
+ax_pose 25, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose122:
+ax_pose 26, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose123:
+ax_pose 27, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose124:
+ax_pose 28, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sMagnetonPose125:
+ax_pose 29, 0x01e2, 0x90eb, 0x5c00
+ax_pose_terminator
+sMagnetonPose126:
+ax_pose 30, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose127:
+ax_pose 31, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose128:
+ax_pose 30, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose129:
+ax_pose 29, 0x01e2, 0x80f5, 0x5c00
+ax_pose_terminator
+sMagnetonPose130:
+ax_pose 28, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMagnetonPose131:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose132:
+ax_pose 1, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose133:
+ax_pose 2, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose134:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose135:
+ax_pose 4, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose136:
+ax_pose 5, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose137:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose138:
+ax_pose 7, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose139:
+ax_pose 8, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose140:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose141:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose142:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose143:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose144:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose145:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose146:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose147:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose148:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose149:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose150:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose151:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose152:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose153:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose154:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose155:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose156:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose157:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose158:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose159:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose160:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose161:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose162:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose163:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose164:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose165:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose166:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose167:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose168:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose169:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose170:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose171:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose172:
+ax_pose 1, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose173:
+ax_pose 2, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose174:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose175:
+ax_pose 4, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose176:
+ax_pose 5, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose177:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose178:
+ax_pose 7, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose179:
+ax_pose 8, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose180:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose181:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose182:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose183:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose184:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose185:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose186:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose187:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose188:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose189:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose190:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose191:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose192:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose193:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose194:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose195:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose196:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose197:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose198:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose199:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose200:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose201:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose202:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose203:
+ax_pose 0, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose204:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose205:
+ax_pose 6, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sMagnetonPose206:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMagnetonPose207:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMagnetonPose208:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMagnetonPose209:
+ax_pose 6, 0x81e6, 0x90f9, 0x5c00
+ax_pose_terminator
+sMagnetonPose210:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+.align 2
+sMagnetonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -4, 0, 0,
+ax_anim 8, 0, 0, 0, -4, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -4, 0, 0,
+ax_anim 8, 0, 3, 0, -4, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -4, 0, 0,
+ax_anim 8, 0, 6, 0, -4, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -4, 0, 0,
+ax_anim 8, 0, 9, 0, -4, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -4, 0, 0,
+ax_anim 8, 0, 12, 0, -4, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -4, 0, 0,
+ax_anim 8, 0, 15, 0, -4, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -4, 0, 0,
+ax_anim 8, 0, 18, 0, -4, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -4, 0, 0,
+ax_anim 8, 0, 21, 0, -4, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMagnetonAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 21, 20, 21, 20,
+ax_anim 2, 1, 27, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sMagnetonAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 22, 0, 22, 0,
+ax_anim 2, 1, 30, 22, -1, 22, -1,
+ax_anim 2, 0, 30, 22, 0, 22, 0,
+ax_anim 2, 0, 30, 22, -1, 22, -1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sMagnetonAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 5, -5, 5, -5,
+ax_anim 1, 0, 34, 13, -12, 13, -12,
+ax_anim 2, 0, 33, 20, -17, 20, -17,
+ax_anim 2, 1, 33, 21, -16, 21, -16,
+ax_anim 2, 0, 33, 20, -17, 20, -17,
+ax_anim 2, 0, 33, 21, -16, 21, -16,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMagnetonAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -9, 0, -9,
+ax_anim 2, 0, 36, 0, -17, 0, -17,
+ax_anim 2, 1, 36, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -17, 0, -17,
+ax_anim 2, 0, 36, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMagnetonAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -5, -5, -5, -5,
+ax_anim 1, 0, 40, -13, -12, -13, -12,
+ax_anim 2, 0, 39, -20, -17, -20, -17,
+ax_anim 2, 1, 39, -21, -16, -21, -16,
+ax_anim 2, 0, 39, -20, -17, -20, -17,
+ax_anim 2, 0, 39, -21, -16, -21, -16,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMagnetonAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -22, 0, -22, 0,
+ax_anim 2, 1, 42, -22, -1, -22, -1,
+ax_anim 2, 0, 42, -22, 0, -22, 0,
+ax_anim 2, 0, 42, -22, -1, -22, -1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sMagnetonAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -21, 20, -21, 20,
+ax_anim 2, 1, 45, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -21, 20, -21, 20,
+ax_anim 2, 0, 45, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sMagnetonAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 21, 20, 21, 20,
+ax_anim 2, 1, 51, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 21, 20, 21, 20,
+ax_anim 2, 0, 51, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sMagnetonAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 22, 0, 22, 0,
+ax_anim 2, 1, 54, 22, -1, 22, -1,
+ax_anim 2, 0, 54, 22, 0, 22, 0,
+ax_anim 2, 0, 54, 22, -1, 22, -1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sMagnetonAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 59, 5, -5, 5, -5,
+ax_anim 1, 0, 58, 13, -12, 13, -12,
+ax_anim 2, 0, 57, 20, -17, 20, -17,
+ax_anim 2, 1, 57, 21, -16, 21, -16,
+ax_anim 2, 0, 57, 20, -17, 20, -17,
+ax_anim 2, 0, 57, 21, -16, 21, -16,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sMagnetonAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -9, 0, -9,
+ax_anim 2, 0, 60, 0, -17, 0, -17,
+ax_anim 2, 1, 60, 1, -17, 1, -17,
+ax_anim 2, 0, 60, 0, -17, 0, -17,
+ax_anim 2, 0, 60, 1, -17, 1, -17,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sMagnetonAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 65, -5, -5, -5, -5,
+ax_anim 1, 0, 64, -13, -12, -13, -12,
+ax_anim 2, 0, 63, -20, -17, -20, -17,
+ax_anim 2, 1, 63, -21, -16, -21, -16,
+ax_anim 2, 0, 63, -20, -17, -20, -17,
+ax_anim 2, 0, 63, -21, -16, -21, -16,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sMagnetonAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -22, 0, -22, 0,
+ax_anim 2, 1, 66, -22, -1, -22, -1,
+ax_anim 2, 0, 66, -22, 0, -22, 0,
+ax_anim 2, 0, 66, -22, -1, -22, -1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sMagnetonAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -21, 20, -21, 20,
+ax_anim 2, 1, 69, -22, 19, -22, 19,
+ax_anim 2, 0, 69, -21, 20, -21, 20,
+ax_anim 2, 0, 69, -22, 19, -22, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_4_1:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 2, 2, 73, 0, 3, 0, 3,
+ax_anim 6, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 1, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -2, 0, -2,
+ax_anim 4, 0, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim_terminator
+sMagnetonAnims_4_2:
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim 2, 2, 76, 3, 3, 3, 3,
+ax_anim 6, 0, 76, 4, 4, 4, 4,
+ax_anim 1, 1, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 4, 0, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim_terminator
+sMagnetonAnims_4_3:
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim 2, 2, 79, 3, 0, 3, 0,
+ax_anim 6, 0, 79, 4, 0, 4, 0,
+ax_anim 1, 1, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim 4, 0, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 79, -1, 0, -1, 0,
+ax_anim_terminator
+sMagnetonAnims_4_4:
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 3, -3, 3, -3,
+ax_anim 6, 0, 82, 4, -4, 4, -4,
+ax_anim 1, 1, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -2, 2, -2, 2,
+ax_anim 4, 0, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 82, -1, 1, -1, 1,
+ax_anim_terminator
+sMagnetonAnims_4_5:
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim 2, 2, 85, 0, -3, 0, -3,
+ax_anim 6, 0, 85, 0, -4, 0, -4,
+ax_anim 1, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 4, 0, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim_terminator
+sMagnetonAnims_4_6:
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 2, 88, -3, -3, -3, -3,
+ax_anim 6, 0, 88, -4, -4, -4, -4,
+ax_anim 1, 1, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 4, 0, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 88, 1, 1, 1, 1,
+ax_anim_terminator
+sMagnetonAnims_4_7:
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim 2, 2, 91, -3, 0, -3, 0,
+ax_anim 6, 0, 91, -4, 0, -4, 0,
+ax_anim 1, 1, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 4, 0, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 91, 1, 0, 1, 0,
+ax_anim_terminator
+sMagnetonAnims_4_8:
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 2, 94, -3, 3, -3, 3,
+ax_anim 6, 0, 94, -4, 4, -4, 4,
+ax_anim 1, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 4, 0, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_5_1:
+ax_anim 2, 0, 96, 0, -2, 0, -1,
+ax_anim 6, 0, 96, 0, -3, 0, -4,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 97, 0, 1, 0, 1,
+ax_anim 2, 0, 97, 0, 4, 0, 4,
+ax_anim 2, 2, 98, 0, 4, 0, 4,
+ax_anim 2, 0, 97, 0, 4, 0, 4,
+ax_anim 2, 0, 98, 0, 4, 0, 4,
+ax_anim 2, 0, 97, 0, 4, 0, 4,
+ax_anim 2, 1, 98, 0, 4, 0, 4,
+ax_anim 2, 0, 97, 0, 1, 0, 1,
+ax_anim_terminator
+sMagnetonAnims_5_2:
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 6, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 1, 1, 1, 1,
+ax_anim 2, 0, 100, 4, 4, 4, 4,
+ax_anim 2, 2, 101, 4, 4, 4, 4,
+ax_anim 2, 0, 100, 4, 4, 4, 4,
+ax_anim 2, 0, 101, 4, 4, 4, 4,
+ax_anim 2, 0, 100, 4, 4, 4, 4,
+ax_anim 2, 1, 101, 4, 4, 4, 4,
+ax_anim 2, 0, 100, 1, 1, 1, 1,
+ax_anim_terminator
+sMagnetonAnims_5_3:
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 6, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 1, 0, 1, 0,
+ax_anim 2, 0, 103, 5, 0, 5, 0,
+ax_anim 2, 2, 104, 5, 0, 5, 0,
+ax_anim 2, 0, 103, 5, 0, 5, 0,
+ax_anim 2, 0, 104, 5, 0, 5, 0,
+ax_anim 2, 0, 103, 5, 0, 5, 0,
+ax_anim 2, 1, 104, 5, 0, 5, 0,
+ax_anim 2, 0, 103, 1, 0, 1, 0,
+ax_anim_terminator
+sMagnetonAnims_5_4:
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 6, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 1, -1, 1, -1,
+ax_anim 2, 0, 106, 4, -4, 4, -4,
+ax_anim 2, 2, 107, 4, -4, 4, -4,
+ax_anim 2, 0, 106, 4, -4, 4, -4,
+ax_anim 2, 0, 107, 4, -4, 4, -4,
+ax_anim 2, 0, 106, 4, -4, 4, -4,
+ax_anim 2, 1, 107, 4, -4, 4, -4,
+ax_anim 2, 0, 106, 1, -1, 1, -1,
+ax_anim_terminator
+sMagnetonAnims_5_5:
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 6, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, -5, 0, -5,
+ax_anim 2, 2, 110, 0, -5, 0, -5,
+ax_anim 2, 0, 109, 0, -5, 0, -5,
+ax_anim 2, 0, 110, 0, -5, 0, -5,
+ax_anim 2, 0, 109, 0, -5, 0, -5,
+ax_anim 2, 1, 110, 0, -5, 0, -5,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim_terminator
+sMagnetonAnims_5_6:
+ax_anim 2, 0, 111, 0, -2, 0, 0,
+ax_anim 6, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 112, -1, -1, -1, -1,
+ax_anim 2, 0, 112, -4, -4, -4, -4,
+ax_anim 2, 2, 113, -4, -4, -4, -4,
+ax_anim 2, 0, 112, -4, -4, -4, -4,
+ax_anim 2, 0, 113, -4, -4, -4, -4,
+ax_anim 2, 0, 112, -4, -4, -4, -4,
+ax_anim 2, 1, 113, -4, -4, -4, -4,
+ax_anim 2, 0, 112, -1, -1, -1, -1,
+ax_anim_terminator
+sMagnetonAnims_5_7:
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 6, 0, 114, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 115, -1, 0, -1, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 2, 116, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 116, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 1, 116, -5, 0, -5, 0,
+ax_anim 2, 0, 115, -1, 0, -1, 0,
+ax_anim_terminator
+sMagnetonAnims_5_8:
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 6, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 118, -1, 1, -1, 1,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 2, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 1, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 118, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_6_1:
+ax_anim 16, 0, 120, 0, 0, 0, 0,
+ax_anim 12, 0, 120, 0, -1, 0, 0,
+ax_anim 16, 0, 120, 0, -2, 0, 0,
+ax_anim 16, 0, 121, 0, -2, 0, 0,
+ax_anim 12, 0, 121, 0, -1, 0, 0,
+ax_anim 16, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sMagnetonAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sMagnetonAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sMagnetonAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sMagnetonAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sMagnetonAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sMagnetonAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sMagnetonAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_8_1:
+ax_anim 14, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 14, 0, 132, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_8_2:
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_8_3:
+ax_anim 14, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_8_4:
+ax_anim 14, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 14, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_8_5:
+ax_anim 14, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 14, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_8_6:
+ax_anim 14, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_8_7:
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_8_8:
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 18, 7, 18,
+ax_anim 3, 0, 158, 0, 22, 0, 22,
+ax_anim 2, 3, 159, -7, 18, -7, 18,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 21, 10, 21, 10,
+ax_anim 3, 0, 157, 21, 22, 21, 22,
+ax_anim 2, 3, 158, 11, 22, 11, 22,
+ax_anim 2, 0, 159, 3, 17, 3, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 5, -5, 5, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 18, -5, 18, -5,
+ax_anim 3, 0, 156, 22, -2, 22, -2,
+ax_anim 2, 3, 157, 18, 4, 18, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -17, 4, -17,
+ax_anim 2, 0, 154, 12, -20, 12, -20,
+ax_anim 3, 0, 155, 19, -19, 19, -19,
+ax_anim 2, 3, 156, 20, -13, 20, -13,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -16, -7, -16,
+ax_anim 3, 0, 154, 0, -19, 0, -19,
+ax_anim 2, 3, 155, 7, -16, 7, -16,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -17, -4, -17,
+ax_anim 2, 0, 154, -12, -20, -12, -20,
+ax_anim 3, 0, 161, -19, -19, -19, -19,
+ax_anim 2, 3, 160, -20, -13, -20, -13,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -5, -5, -5, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -18, -5, -18, -5,
+ax_anim 3, 0, 160, -22, -2, -22, -2,
+ax_anim 2, 3, 159, -18, 4, -18, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -21, 10, -21, 10,
+ax_anim 3, 0, 159, -21, 22, -21, 22,
+ax_anim 2, 3, 158, -11, 22, -11, 22,
+ax_anim 2, 0, 157, -3, 17, -3, 17,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 2, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 1, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_12_1:
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_12_5:
+ax_anim 2, 0, 198, -1, 0, -1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, 0, -1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, 0, -1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, 0, -1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, 0, -1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMagnetonAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMagnetonGfx1:
+.incbin "baserom.gba", 0x8857C8, 0x200
+sMagnetonSprites1:
+ax_sprite sMagnetonGfx1, 0x200
+ax_sprite_terminator
+sMagnetonGfx2:
+.incbin "baserom.gba", 0x8859D8, 0x200
+sMagnetonSprites2:
+ax_sprite sMagnetonGfx2, 0x200
+ax_sprite_terminator
+sMagnetonGfx3:
+.incbin "baserom.gba", 0x885BE8, 0x200
+sMagnetonSprites3:
+ax_sprite sMagnetonGfx3, 0x200
+ax_sprite_terminator
+sMagnetonGfx4:
+.incbin "baserom.gba", 0x885DF8, 0x200
+sMagnetonSprites4:
+ax_sprite sMagnetonGfx4, 0x200
+ax_sprite_terminator
+sMagnetonGfx5:
+.incbin "baserom.gba", 0x886008, 0x200
+sMagnetonSprites5:
+ax_sprite sMagnetonGfx5, 0x200
+ax_sprite_terminator
+sMagnetonGfx6:
+.incbin "baserom.gba", 0x886218, 0x200
+sMagnetonSprites6:
+ax_sprite sMagnetonGfx6, 0x200
+ax_sprite_terminator
+sMagnetonGfx7:
+.incbin "baserom.gba", 0x886428, 0x100
+sMagnetonSprites7:
+ax_sprite sMagnetonGfx7, 0x100
+ax_sprite_terminator
+sMagnetonGfx8:
+.incbin "baserom.gba", 0x886538, 0x200
+sMagnetonSprites8:
+ax_sprite sMagnetonGfx8, 0x200
+ax_sprite_terminator
+sMagnetonGfx9:
+.incbin "baserom.gba", 0x886748, 0x200
+sMagnetonSprites9:
+ax_sprite sMagnetonGfx9, 0x200
+ax_sprite_terminator
+sMagnetonGfx10:
+.incbin "baserom.gba", 0x886958, 0x200
+sMagnetonSprites10:
+ax_sprite sMagnetonGfx10, 0x200
+ax_sprite_terminator
+sMagnetonGfx11:
+.incbin "baserom.gba", 0x886B68, 0x200
+sMagnetonSprites11:
+ax_sprite sMagnetonGfx11, 0x200
+ax_sprite_terminator
+sMagnetonGfx12:
+.incbin "baserom.gba", 0x886D78, 0x200
+sMagnetonSprites12:
+ax_sprite sMagnetonGfx12, 0x200
+ax_sprite_terminator
+sMagnetonGfx13:
+.incbin "baserom.gba", 0x886F88, 0x200
+sMagnetonSprites13:
+ax_sprite sMagnetonGfx13, 0x200
+ax_sprite_terminator
+sMagnetonGfx14:
+.incbin "baserom.gba", 0x887198, 0x200
+sMagnetonSprites14:
+ax_sprite sMagnetonGfx14, 0x200
+ax_sprite_terminator
+sMagnetonGfx15:
+.incbin "baserom.gba", 0x8873A8, 0x200
+sMagnetonSprites15:
+ax_sprite sMagnetonGfx15, 0x200
+ax_sprite_terminator
+sMagnetonGfx16:
+.incbin "baserom.gba", 0x8875B8, 0x40
+sMagnetonGfx16_1:
+.incbin "baserom.gba", 0x8875F8, 0xE0
+sMagnetonGfx16_2:
+.incbin "baserom.gba", 0x8876D8, 0x40
+sMagnetonSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagnetonGfx16_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMagnetonGfx17:
+.incbin "baserom.gba", 0x887758, 0x40
+sMagnetonGfx17_1:
+.incbin "baserom.gba", 0x887798, 0xE0
+sMagnetonSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagnetonGfx17_1, 0xe0
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMagnetonGfx18:
+.incbin "baserom.gba", 0x8878A8, 0x60
+sMagnetonGfx18_1:
+.incbin "baserom.gba", 0x887908, 0x60
+sMagnetonGfx18_2:
+.incbin "baserom.gba", 0x887968, 0x60
+sMagnetonSprites18:
+ax_sprite sMagnetonGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMagnetonGfx19:
+.incbin "baserom.gba", 0x887A00, 0x60
+sMagnetonGfx19_1:
+.incbin "baserom.gba", 0x887A60, 0x60
+sMagnetonGfx19_2:
+.incbin "baserom.gba", 0x887AC0, 0x60
+sMagnetonSprites19:
+ax_sprite sMagnetonGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMagnetonGfx20:
+.incbin "baserom.gba", 0x887B58, 0x40
+sMagnetonGfx20_1:
+.incbin "baserom.gba", 0x887B98, 0x40
+sMagnetonGfx20_2:
+.incbin "baserom.gba", 0x887BD8, 0x60
+sMagnetonGfx20_3:
+.incbin "baserom.gba", 0x887C38, 0x40
+sMagnetonSprites20:
+ax_sprite sMagnetonGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagnetonGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagnetonGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx20_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagnetonGfx21:
+.incbin "baserom.gba", 0x887CC0, 0x40
+sMagnetonGfx21_1:
+.incbin "baserom.gba", 0x887D00, 0x60
+sMagnetonGfx21_2:
+.incbin "baserom.gba", 0x887D60, 0x60
+sMagnetonGfx21_3:
+.incbin "baserom.gba", 0x887DC0, 0x20
+sMagnetonSprites21:
+ax_sprite sMagnetonGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMagnetonGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMagnetonGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMagnetonGfx22:
+.incbin "baserom.gba", 0x887E28, 0x60
+sMagnetonGfx22_1:
+.incbin "baserom.gba", 0x887E88, 0x60
+sMagnetonGfx22_2:
+.incbin "baserom.gba", 0x887EE8, 0x60
+sMagnetonSprites22:
+ax_sprite sMagnetonGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMagnetonGfx23:
+.incbin "baserom.gba", 0x887F80, 0x40
+sMagnetonGfx23_1:
+.incbin "baserom.gba", 0x887FC0, 0x60
+sMagnetonGfx23_2:
+.incbin "baserom.gba", 0x888020, 0x60
+sMagnetonSprites23:
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMagnetonGfx24:
+.incbin "baserom.gba", 0x8880C0, 0x40
+sMagnetonGfx24_1:
+.incbin "baserom.gba", 0x888100, 0x100
+sMagnetonSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx24_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMagnetonGfx25:
+.incbin "baserom.gba", 0x888230, 0x40
+sMagnetonGfx25_1:
+.incbin "baserom.gba", 0x888270, 0x100
+sMagnetonSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMagnetonGfx25_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMagnetonGfx26:
+.incbin "baserom.gba", 0x8883A0, 0x200
+sMagnetonSprites26:
+ax_sprite sMagnetonGfx26, 0x200
+ax_sprite_terminator
+sMagnetonGfx27:
+.incbin "baserom.gba", 0x8885B0, 0x200
+sMagnetonSprites27:
+ax_sprite sMagnetonGfx27, 0x200
+ax_sprite_terminator
+sMagnetonGfx28:
+.incbin "baserom.gba", 0x8887C0, 0x200
+sMagnetonSprites28:
+ax_sprite sMagnetonGfx28, 0x200
+ax_sprite_terminator
+sMagnetonGfx29:
+.incbin "baserom.gba", 0x8889D0, 0x200
+sMagnetonSprites29:
+ax_sprite sMagnetonGfx29, 0x200
+ax_sprite_terminator
+sMagnetonGfx30:
+.incbin "baserom.gba", 0x888BE0, 0x200
+sMagnetonSprites30:
+ax_sprite sMagnetonGfx30, 0x200
+ax_sprite_terminator
+sMagnetonGfx31:
+.incbin "baserom.gba", 0x888DF0, 0x200
+sMagnetonSprites31:
+ax_sprite sMagnetonGfx31, 0x200
+ax_sprite_terminator
+sMagnetonGfx32:
+.incbin "baserom.gba", 0x889000, 0x200
+sMagnetonSprites32:
+ax_sprite sMagnetonGfx32, 0x200
+ax_sprite_terminator
+sAxPosesMagneton:
+.4byte sMagnetonPose1
+.4byte sMagnetonPose2
+.4byte sMagnetonPose3
+.4byte sMagnetonPose4
+.4byte sMagnetonPose5
+.4byte sMagnetonPose6
+.4byte sMagnetonPose7
+.4byte sMagnetonPose8
+.4byte sMagnetonPose9
+.4byte sMagnetonPose10
+.4byte sMagnetonPose11
+.4byte sMagnetonPose12
+.4byte sMagnetonPose13
+.4byte sMagnetonPose14
+.4byte sMagnetonPose15
+.4byte sMagnetonPose16
+.4byte sMagnetonPose17
+.4byte sMagnetonPose18
+.4byte sMagnetonPose19
+.4byte sMagnetonPose20
+.4byte sMagnetonPose21
+.4byte sMagnetonPose22
+.4byte sMagnetonPose23
+.4byte sMagnetonPose24
+.4byte sMagnetonPose25
+.4byte sMagnetonPose26
+.4byte sMagnetonPose27
+.4byte sMagnetonPose28
+.4byte sMagnetonPose29
+.4byte sMagnetonPose30
+.4byte sMagnetonPose31
+.4byte sMagnetonPose32
+.4byte sMagnetonPose33
+.4byte sMagnetonPose34
+.4byte sMagnetonPose35
+.4byte sMagnetonPose36
+.4byte sMagnetonPose37
+.4byte sMagnetonPose38
+.4byte sMagnetonPose39
+.4byte sMagnetonPose40
+.4byte sMagnetonPose41
+.4byte sMagnetonPose42
+.4byte sMagnetonPose43
+.4byte sMagnetonPose44
+.4byte sMagnetonPose45
+.4byte sMagnetonPose46
+.4byte sMagnetonPose47
+.4byte sMagnetonPose48
+.4byte sMagnetonPose49
+.4byte sMagnetonPose50
+.4byte sMagnetonPose51
+.4byte sMagnetonPose52
+.4byte sMagnetonPose53
+.4byte sMagnetonPose54
+.4byte sMagnetonPose55
+.4byte sMagnetonPose56
+.4byte sMagnetonPose57
+.4byte sMagnetonPose58
+.4byte sMagnetonPose59
+.4byte sMagnetonPose60
+.4byte sMagnetonPose61
+.4byte sMagnetonPose62
+.4byte sMagnetonPose63
+.4byte sMagnetonPose64
+.4byte sMagnetonPose65
+.4byte sMagnetonPose66
+.4byte sMagnetonPose67
+.4byte sMagnetonPose68
+.4byte sMagnetonPose69
+.4byte sMagnetonPose70
+.4byte sMagnetonPose71
+.4byte sMagnetonPose72
+.4byte sMagnetonPose73
+.4byte sMagnetonPose74
+.4byte sMagnetonPose75
+.4byte sMagnetonPose76
+.4byte sMagnetonPose77
+.4byte sMagnetonPose78
+.4byte sMagnetonPose79
+.4byte sMagnetonPose80
+.4byte sMagnetonPose81
+.4byte sMagnetonPose82
+.4byte sMagnetonPose83
+.4byte sMagnetonPose84
+.4byte sMagnetonPose85
+.4byte sMagnetonPose86
+.4byte sMagnetonPose87
+.4byte sMagnetonPose88
+.4byte sMagnetonPose89
+.4byte sMagnetonPose90
+.4byte sMagnetonPose91
+.4byte sMagnetonPose92
+.4byte sMagnetonPose93
+.4byte sMagnetonPose94
+.4byte sMagnetonPose95
+.4byte sMagnetonPose96
+.4byte sMagnetonPose97
+.4byte sMagnetonPose98
+.4byte sMagnetonPose99
+.4byte sMagnetonPose100
+.4byte sMagnetonPose101
+.4byte sMagnetonPose102
+.4byte sMagnetonPose103
+.4byte sMagnetonPose104
+.4byte sMagnetonPose105
+.4byte sMagnetonPose106
+.4byte sMagnetonPose107
+.4byte sMagnetonPose108
+.4byte sMagnetonPose109
+.4byte sMagnetonPose110
+.4byte sMagnetonPose111
+.4byte sMagnetonPose112
+.4byte sMagnetonPose113
+.4byte sMagnetonPose114
+.4byte sMagnetonPose115
+.4byte sMagnetonPose116
+.4byte sMagnetonPose117
+.4byte sMagnetonPose118
+.4byte sMagnetonPose119
+.4byte sMagnetonPose120
+.4byte sMagnetonPose121
+.4byte sMagnetonPose122
+.4byte sMagnetonPose123
+.4byte sMagnetonPose124
+.4byte sMagnetonPose125
+.4byte sMagnetonPose126
+.4byte sMagnetonPose127
+.4byte sMagnetonPose128
+.4byte sMagnetonPose129
+.4byte sMagnetonPose130
+.4byte sMagnetonPose131
+.4byte sMagnetonPose132
+.4byte sMagnetonPose133
+.4byte sMagnetonPose134
+.4byte sMagnetonPose135
+.4byte sMagnetonPose136
+.4byte sMagnetonPose137
+.4byte sMagnetonPose138
+.4byte sMagnetonPose139
+.4byte sMagnetonPose140
+.4byte sMagnetonPose141
+.4byte sMagnetonPose142
+.4byte sMagnetonPose143
+.4byte sMagnetonPose144
+.4byte sMagnetonPose145
+.4byte sMagnetonPose146
+.4byte sMagnetonPose147
+.4byte sMagnetonPose148
+.4byte sMagnetonPose149
+.4byte sMagnetonPose150
+.4byte sMagnetonPose151
+.4byte sMagnetonPose152
+.4byte sMagnetonPose153
+.4byte sMagnetonPose154
+.4byte sMagnetonPose155
+.4byte sMagnetonPose156
+.4byte sMagnetonPose157
+.4byte sMagnetonPose158
+.4byte sMagnetonPose159
+.4byte sMagnetonPose160
+.4byte sMagnetonPose161
+.4byte sMagnetonPose162
+.4byte sMagnetonPose163
+.4byte sMagnetonPose164
+.4byte sMagnetonPose165
+.4byte sMagnetonPose166
+.4byte sMagnetonPose167
+.4byte sMagnetonPose168
+.4byte sMagnetonPose169
+.4byte sMagnetonPose170
+.4byte sMagnetonPose171
+.4byte sMagnetonPose172
+.4byte sMagnetonPose173
+.4byte sMagnetonPose174
+.4byte sMagnetonPose175
+.4byte sMagnetonPose176
+.4byte sMagnetonPose177
+.4byte sMagnetonPose178
+.4byte sMagnetonPose179
+.4byte sMagnetonPose180
+.4byte sMagnetonPose181
+.4byte sMagnetonPose182
+.4byte sMagnetonPose183
+.4byte sMagnetonPose184
+.4byte sMagnetonPose185
+.4byte sMagnetonPose186
+.4byte sMagnetonPose187
+.4byte sMagnetonPose188
+.4byte sMagnetonPose189
+.4byte sMagnetonPose190
+.4byte sMagnetonPose191
+.4byte sMagnetonPose192
+.4byte sMagnetonPose193
+.4byte sMagnetonPose194
+.4byte sMagnetonPose195
+.4byte sMagnetonPose196
+.4byte sMagnetonPose197
+.4byte sMagnetonPose198
+.4byte sMagnetonPose199
+.4byte sMagnetonPose200
+.4byte sMagnetonPose201
+.4byte sMagnetonPose202
+.4byte sMagnetonPose203
+.4byte sMagnetonPose204
+.4byte sMagnetonPose205
+.4byte sMagnetonPose206
+.4byte sMagnetonPose207
+.4byte sMagnetonPose208
+.4byte sMagnetonPose209
+.4byte sMagnetonPose210
+sAxPositionsMagneton:
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    0,  -12, 	  -8,  -16, 	   8,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -8,  -14, 	   8,  -14, 	   0,  -12
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    1,  -11, 	   5,  -19, 	  -7,  -13, 	   1,  -10
+.2byte    1,  -12, 	   5,  -17, 	  -6,  -12, 	   1,  -11
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    2,  -11, 	   5,  -15, 	  -4,  -13, 	   2,  -10
+.2byte    2,  -12, 	   4,  -15, 	  -4,  -12, 	   2,  -11
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -13, 	  -5,  -19, 	   5,  -14, 	  -1,  -11
+.2byte    1,  -13, 	  -5,  -18, 	   4,  -13, 	  -1,  -12
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    0,  -13, 	   8,  -16, 	  -8,  -16, 	   0,  -11
+.2byte    0,  -14, 	   8,  -14, 	  -8,  -14, 	   0,  -12
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -2,  -13, 	   5,  -19, 	  -5,  -14, 	   1,  -11
+.2byte   -1,  -13, 	   5,  -18, 	  -4,  -13, 	   1,  -12
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -11, 	  -5,  -15, 	   4,  -13, 	  -2,  -10
+.2byte   -2,  -12, 	  -4,  -15, 	   4,  -12, 	  -2,  -11
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,  -19, 	   7,  -13, 	  -1,  -10
+.2byte   -1,  -12, 	  -5,  -17, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    0,  -12, 	  -8,  -16, 	   8,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -8,  -14, 	   8,  -14, 	   0,  -12
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    1,  -11, 	   5,  -19, 	  -7,  -13, 	   1,  -10
+.2byte    1,  -12, 	   5,  -17, 	  -6,  -12, 	   1,  -11
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    2,  -11, 	   5,  -15, 	  -4,  -13, 	   2,  -10
+.2byte    2,  -12, 	   4,  -15, 	  -4,  -12, 	   2,  -11
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -13, 	  -5,  -19, 	   5,  -14, 	  -1,  -11
+.2byte    1,  -13, 	  -5,  -18, 	   4,  -13, 	  -1,  -12
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    0,  -13, 	   8,  -16, 	  -8,  -16, 	   0,  -11
+.2byte    0,  -14, 	   8,  -14, 	  -8,  -14, 	   0,  -12
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -2,  -13, 	   5,  -19, 	  -5,  -14, 	   1,  -11
+.2byte   -1,  -13, 	   5,  -18, 	  -4,  -13, 	   1,  -12
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -11, 	  -5,  -15, 	   4,  -13, 	  -2,  -10
+.2byte   -2,  -12, 	  -4,  -15, 	   4,  -12, 	  -2,  -11
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,  -19, 	   7,  -13, 	  -1,  -10
+.2byte   -1,  -12, 	  -5,  -17, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    0,  -12, 	  -8,  -16, 	   8,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -8,  -14, 	   8,  -14, 	   0,  -12
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    1,  -11, 	   5,  -19, 	  -7,  -13, 	   1,  -10
+.2byte    1,  -12, 	   5,  -17, 	  -6,  -12, 	   1,  -11
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    2,  -11, 	   5,  -15, 	  -4,  -13, 	   2,  -10
+.2byte    2,  -12, 	   4,  -15, 	  -4,  -12, 	   2,  -11
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -13, 	  -5,  -19, 	   5,  -14, 	  -1,  -11
+.2byte    1,  -13, 	  -5,  -18, 	   4,  -13, 	  -1,  -12
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    0,  -13, 	   8,  -16, 	  -8,  -16, 	   0,  -11
+.2byte    0,  -14, 	   8,  -14, 	  -8,  -14, 	   0,  -12
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -2,  -13, 	   5,  -19, 	  -5,  -14, 	   1,  -11
+.2byte   -1,  -13, 	   5,  -18, 	  -4,  -13, 	   1,  -12
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -11, 	  -5,  -15, 	   4,  -13, 	  -2,  -10
+.2byte   -2,  -12, 	  -4,  -15, 	   4,  -12, 	  -2,  -11
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,  -19, 	   7,  -13, 	  -1,  -10
+.2byte   -1,  -12, 	  -5,  -17, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    0,  -10, 	  -6,  -11, 	   6,  -11, 	   0,   -8
+.2byte    0,  -10, 	  -6,  -13, 	   6,  -13, 	   0,   -8
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    1,  -10, 	   6,  -13, 	  -2,  -11, 	   1,   -9
+.2byte    1,  -10, 	   6,  -13, 	  -4,  -13, 	   0,   -9
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    1,  -10, 	   6,  -16, 	   0,  -12, 	   1,   -9
+.2byte    1,  -10, 	   5,  -14, 	  -2,  -12, 	   1,   -9
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    1,  -12, 	  -2,  -18, 	   6,  -16, 	   0,  -10
+.2byte    1,  -11, 	  -2,  -18, 	   4,  -14, 	  -1,  -10
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    0,  -12, 	   6,  -19, 	  -6,  -19, 	   0,  -11
+.2byte    0,  -12, 	   6,  -17, 	  -6,  -17, 	   0,  -11
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -1,  -12, 	   2,  -18, 	  -6,  -16, 	   0,  -10
+.2byte   -1,  -11, 	   2,  -18, 	  -4,  -14, 	   1,  -10
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -16, 	   0,  -12, 	  -1,   -9
+.2byte   -1,  -10, 	  -5,  -14, 	   2,  -12, 	  -1,   -9
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -13, 	   2,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -13, 	   4,  -13, 	   0,   -9
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    0,  -10, 	  -6,  -11, 	   6,  -11, 	   0,   -8
+.2byte    0,  -10, 	  -6,  -13, 	   6,  -13, 	   0,   -8
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    1,  -10, 	   6,  -13, 	  -2,  -11, 	   1,   -9
+.2byte    1,  -10, 	   6,  -13, 	  -4,  -13, 	   0,   -9
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    1,  -10, 	   6,  -16, 	   0,  -12, 	   1,   -9
+.2byte    1,  -10, 	   5,  -14, 	  -2,  -12, 	   1,   -9
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    1,  -12, 	  -2,  -18, 	   6,  -16, 	   0,  -10
+.2byte    1,  -11, 	  -2,  -18, 	   4,  -14, 	  -1,  -10
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    0,  -12, 	   6,  -19, 	  -6,  -19, 	   0,  -11
+.2byte    0,  -12, 	   6,  -17, 	  -6,  -17, 	   0,  -11
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -1,  -12, 	   2,  -18, 	  -6,  -16, 	   0,  -10
+.2byte   -1,  -11, 	   2,  -18, 	  -4,  -14, 	   1,  -10
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -16, 	   0,  -12, 	  -1,   -9
+.2byte   -1,  -10, 	  -5,  -14, 	   2,  -12, 	  -1,   -9
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -13, 	   2,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -13, 	   4,  -13, 	   0,   -9
+.2byte    0,  -12, 	  -8,  -13, 	   8,  -13, 	   0,  -11
+.2byte    0,  -12, 	  -8,  -13, 	   8,  -13, 	   0,  -11
+.2byte    0,  -21, 	  -5,  -18, 	   5,  -18, 	   0,  -20
+.2byte    2,  -18, 	   5,  -18, 	  -4,  -17, 	   2,  -17
+.2byte    2,  -18, 	   3,  -19, 	  -3,  -16, 	   0,  -14
+.2byte    1,  -17, 	  -6,  -19, 	   4,  -15, 	  -1,  -14
+.2byte    0,  -18, 	   5,  -15, 	  -5,  -15, 	   0,  -16
+.2byte   -2,  -17, 	   5,  -19, 	  -5,  -15, 	   0,  -14
+.2byte   -3,  -18, 	  -4,  -19, 	   2,  -16, 	  -1,  -14
+.2byte   -3,  -18, 	  -6,  -18, 	   3,  -17, 	  -3,  -17
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    0,  -12, 	  -8,  -16, 	   8,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -8,  -14, 	   8,  -14, 	   0,  -12
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    1,  -11, 	   5,  -19, 	  -7,  -13, 	   1,  -10
+.2byte    1,  -12, 	   5,  -17, 	  -6,  -12, 	   1,  -11
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    2,  -11, 	   5,  -15, 	  -4,  -13, 	   2,  -10
+.2byte    2,  -12, 	   4,  -15, 	  -4,  -12, 	   2,  -11
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -13, 	  -5,  -19, 	   5,  -14, 	  -1,  -11
+.2byte    1,  -13, 	  -5,  -18, 	   4,  -13, 	  -1,  -12
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    0,  -13, 	   8,  -16, 	  -8,  -16, 	   0,  -11
+.2byte    0,  -14, 	   8,  -14, 	  -8,  -14, 	   0,  -12
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -2,  -13, 	   5,  -19, 	  -5,  -14, 	   1,  -11
+.2byte   -1,  -13, 	   5,  -18, 	  -4,  -13, 	   1,  -12
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -11, 	  -5,  -15, 	   4,  -13, 	  -2,  -10
+.2byte   -2,  -12, 	  -4,  -15, 	   4,  -12, 	  -2,  -11
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,  -19, 	   7,  -13, 	  -1,  -10
+.2byte   -1,  -12, 	  -5,  -17, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte    0,  -12, 	  -8,  -16, 	   8,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -8,  -14, 	   8,  -14, 	   0,  -12
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    1,  -11, 	   5,  -19, 	  -7,  -13, 	   1,  -10
+.2byte    1,  -12, 	   5,  -17, 	  -6,  -12, 	   1,  -11
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    2,  -11, 	   5,  -15, 	  -4,  -13, 	   2,  -10
+.2byte    2,  -12, 	   4,  -15, 	  -4,  -12, 	   2,  -11
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -13, 	  -5,  -19, 	   5,  -14, 	  -1,  -11
+.2byte    1,  -13, 	  -5,  -18, 	   4,  -13, 	  -1,  -12
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    0,  -13, 	   8,  -16, 	  -8,  -16, 	   0,  -11
+.2byte    0,  -14, 	   8,  -14, 	  -8,  -14, 	   0,  -12
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte   -2,  -13, 	   5,  -19, 	  -5,  -14, 	   1,  -11
+.2byte   -1,  -13, 	   5,  -18, 	  -4,  -13, 	   1,  -12
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -11, 	  -5,  -15, 	   4,  -13, 	  -2,  -10
+.2byte   -2,  -12, 	  -4,  -15, 	   4,  -12, 	  -2,  -11
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,  -19, 	   7,  -13, 	  -1,  -10
+.2byte   -1,  -12, 	  -5,  -17, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+.2byte    0,  -10, 	  -8,  -18, 	   8,  -18, 	   0,   -9
+.2byte   -1,  -10, 	  -4,  -19, 	   7,  -16, 	  -1,   -9
+.2byte   -2,  -10, 	  -5,  -15, 	   4,  -14, 	  -1,   -9
+.2byte   -2,  -12, 	   4,  -20, 	  -5,  -16, 	   0,  -10
+.2byte    0,  -12, 	   8,  -18, 	  -8,  -18, 	   0,  -10
+.2byte    2,  -12, 	  -4,  -20, 	   5,  -16, 	   0,  -10
+.2byte    2,  -10, 	   5,  -15, 	  -4,  -14, 	   1,   -9
+.2byte    1,  -10, 	   4,  -19, 	  -7,  -16, 	   1,   -9
+sMagnetonAnimTable1:
+.4byte sMagnetonAnims_1_1
+.4byte sMagnetonAnims_1_2
+.4byte sMagnetonAnims_1_3
+.4byte sMagnetonAnims_1_4
+.4byte sMagnetonAnims_1_5
+.4byte sMagnetonAnims_1_6
+.4byte sMagnetonAnims_1_7
+.4byte sMagnetonAnims_1_8
+sMagnetonAnimTable2:
+.4byte sMagnetonAnims_2_1
+.4byte sMagnetonAnims_2_2
+.4byte sMagnetonAnims_2_3
+.4byte sMagnetonAnims_2_4
+.4byte sMagnetonAnims_2_5
+.4byte sMagnetonAnims_2_6
+.4byte sMagnetonAnims_2_7
+.4byte sMagnetonAnims_2_8
+sMagnetonAnimTable3:
+.4byte sMagnetonAnims_3_1
+.4byte sMagnetonAnims_3_2
+.4byte sMagnetonAnims_3_3
+.4byte sMagnetonAnims_3_4
+.4byte sMagnetonAnims_3_5
+.4byte sMagnetonAnims_3_6
+.4byte sMagnetonAnims_3_7
+.4byte sMagnetonAnims_3_8
+sMagnetonAnimTable4:
+.4byte sMagnetonAnims_4_1
+.4byte sMagnetonAnims_4_2
+.4byte sMagnetonAnims_4_3
+.4byte sMagnetonAnims_4_4
+.4byte sMagnetonAnims_4_5
+.4byte sMagnetonAnims_4_6
+.4byte sMagnetonAnims_4_7
+.4byte sMagnetonAnims_4_8
+sMagnetonAnimTable5:
+.4byte sMagnetonAnims_5_1
+.4byte sMagnetonAnims_5_2
+.4byte sMagnetonAnims_5_3
+.4byte sMagnetonAnims_5_4
+.4byte sMagnetonAnims_5_5
+.4byte sMagnetonAnims_5_6
+.4byte sMagnetonAnims_5_7
+.4byte sMagnetonAnims_5_8
+sMagnetonAnimTable6:
+.4byte sMagnetonAnims_6_1
+.4byte sMagnetonAnims_6_1
+.4byte sMagnetonAnims_6_1
+.4byte sMagnetonAnims_6_1
+.4byte sMagnetonAnims_6_1
+.4byte sMagnetonAnims_6_1
+.4byte sMagnetonAnims_6_1
+.4byte sMagnetonAnims_6_1
+sMagnetonAnimTable7:
+.4byte sMagnetonAnims_7_1
+.4byte sMagnetonAnims_7_2
+.4byte sMagnetonAnims_7_3
+.4byte sMagnetonAnims_7_4
+.4byte sMagnetonAnims_7_5
+.4byte sMagnetonAnims_7_6
+.4byte sMagnetonAnims_7_7
+.4byte sMagnetonAnims_7_8
+sMagnetonAnimTable8:
+.4byte sMagnetonAnims_8_1
+.4byte sMagnetonAnims_8_2
+.4byte sMagnetonAnims_8_3
+.4byte sMagnetonAnims_8_4
+.4byte sMagnetonAnims_8_5
+.4byte sMagnetonAnims_8_6
+.4byte sMagnetonAnims_8_7
+.4byte sMagnetonAnims_8_8
+sMagnetonAnimTable9:
+.4byte sMagnetonAnims_9_1
+.4byte sMagnetonAnims_9_2
+.4byte sMagnetonAnims_9_3
+.4byte sMagnetonAnims_9_4
+.4byte sMagnetonAnims_9_5
+.4byte sMagnetonAnims_9_6
+.4byte sMagnetonAnims_9_7
+.4byte sMagnetonAnims_9_8
+sMagnetonAnimTable10:
+.4byte sMagnetonAnims_10_1
+.4byte sMagnetonAnims_10_2
+.4byte sMagnetonAnims_10_3
+.4byte sMagnetonAnims_10_4
+.4byte sMagnetonAnims_10_5
+.4byte sMagnetonAnims_10_6
+.4byte sMagnetonAnims_10_7
+.4byte sMagnetonAnims_10_8
+sMagnetonAnimTable11:
+.4byte sMagnetonAnims_11_1
+.4byte sMagnetonAnims_11_2
+.4byte sMagnetonAnims_11_3
+.4byte sMagnetonAnims_11_4
+.4byte sMagnetonAnims_11_5
+.4byte sMagnetonAnims_11_6
+.4byte sMagnetonAnims_11_7
+.4byte sMagnetonAnims_11_8
+sMagnetonAnimTable12:
+.4byte sMagnetonAnims_12_1
+.4byte sMagnetonAnims_12_2
+.4byte sMagnetonAnims_12_3
+.4byte sMagnetonAnims_12_4
+.4byte sMagnetonAnims_12_5
+.4byte sMagnetonAnims_12_6
+.4byte sMagnetonAnims_12_7
+.4byte sMagnetonAnims_12_8
+sMagnetonAnimTable13:
+.4byte sMagnetonAnims_13_1
+.4byte sMagnetonAnims_13_2
+.4byte sMagnetonAnims_13_3
+.4byte sMagnetonAnims_13_4
+.4byte sMagnetonAnims_13_5
+.4byte sMagnetonAnims_13_6
+.4byte sMagnetonAnims_13_7
+.4byte sMagnetonAnims_13_8
+sAxAnimationsMagneton:
+.4byte sMagnetonAnimTable1
+.4byte sMagnetonAnimTable2
+.4byte sMagnetonAnimTable3
+.4byte sMagnetonAnimTable4
+.4byte sMagnetonAnimTable5
+.4byte sMagnetonAnimTable6
+.4byte sMagnetonAnimTable7
+.4byte sMagnetonAnimTable8
+.4byte sMagnetonAnimTable9
+.4byte sMagnetonAnimTable10
+.4byte sMagnetonAnimTable11
+.4byte sMagnetonAnimTable12
+.4byte sMagnetonAnimTable13
+sAxSpritesMagneton:
+.4byte sMagnetonSprites1
+.4byte sMagnetonSprites2
+.4byte sMagnetonSprites3
+.4byte sMagnetonSprites4
+.4byte sMagnetonSprites5
+.4byte sMagnetonSprites6
+.4byte sMagnetonSprites7
+.4byte sMagnetonSprites8
+.4byte sMagnetonSprites9
+.4byte sMagnetonSprites10
+.4byte sMagnetonSprites11
+.4byte sMagnetonSprites12
+.4byte sMagnetonSprites13
+.4byte sMagnetonSprites14
+.4byte sMagnetonSprites15
+.4byte sMagnetonSprites16
+.4byte sMagnetonSprites17
+.4byte sMagnetonSprites18
+.4byte sMagnetonSprites19
+.4byte sMagnetonSprites20
+.4byte sMagnetonSprites21
+.4byte sMagnetonSprites22
+.4byte sMagnetonSprites23
+.4byte sMagnetonSprites24
+.4byte sMagnetonSprites25
+.4byte sMagnetonSprites26
+.4byte sMagnetonSprites27
+.4byte sMagnetonSprites28
+.4byte sMagnetonSprites29
+.4byte sMagnetonSprites30
+.4byte sMagnetonSprites31
+.4byte sMagnetonSprites32
+sAxMainMagneton:
+ax_main sAxPosesMagneton, sAxAnimationsMagneton, 13, sAxSpritesMagneton, sAxPositionsMagneton

--- a/data/ax/makuhita.inc
+++ b/data/ax/makuhita.inc
@@ -1,0 +1,2635 @@
+.global gAxMakuhita
+gAxMakuhita:
+ax_siro sAxMainMakuhita
+sMakuhitaPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose2:
+ax_pose 1, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose3:
+ax_pose 2, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose4:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose5:
+ax_pose 4, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose6:
+ax_pose 5, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose7:
+ax_pose 6, 0x01e6, 0x90e8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose8:
+ax_pose 7, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose9:
+ax_pose 8, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose10:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose11:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose16:
+ax_pose 9, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose17:
+ax_pose 10, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose19:
+ax_pose 6, 0x01e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose21:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose22:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose23:
+ax_pose 4, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose26:
+ax_pose 15, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose27:
+ax_pose 16, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sMakuhitaPose28:
+ax_pose 17, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose29:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose30:
+ax_pose 18, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose31:
+ax_pose 19, 0x01e9, 0x90ea, 0x2c00
+ax_pose_terminator
+sMakuhitaPose32:
+ax_pose 20, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose33:
+ax_pose 6, 0x01e6, 0x90e8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose34:
+ax_pose 21, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose35:
+ax_pose 22, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose36:
+ax_pose 23, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose37:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose38:
+ax_pose 24, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sMakuhitaPose39:
+ax_pose 25, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose40:
+ax_pose 26, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose42:
+ax_pose 27, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose43:
+ax_pose 28, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose44:
+ax_pose 29, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose45:
+ax_pose 9, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose46:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sMakuhitaPose47:
+ax_pose 25, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose48:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose49:
+ax_pose 6, 0x01e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose50:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose51:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose52:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose53:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose54:
+ax_pose 18, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose55:
+ax_pose 19, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sMakuhitaPose56:
+ax_pose 20, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose57:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose58:
+ax_pose 15, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose59:
+ax_pose 16, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sMakuhitaPose60:
+ax_pose 17, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose61:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose62:
+ax_pose 18, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose63:
+ax_pose 19, 0x01e9, 0x90ea, 0x2c00
+ax_pose_terminator
+sMakuhitaPose64:
+ax_pose 20, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose65:
+ax_pose 6, 0x01e6, 0x90e8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose66:
+ax_pose 21, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose67:
+ax_pose 22, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose68:
+ax_pose 23, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose69:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose70:
+ax_pose 24, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sMakuhitaPose71:
+ax_pose 25, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose72:
+ax_pose 26, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose74:
+ax_pose 27, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose75:
+ax_pose 28, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose76:
+ax_pose 29, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose77:
+ax_pose 9, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose78:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sMakuhitaPose79:
+ax_pose 25, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose80:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose81:
+ax_pose 6, 0x01e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose82:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose83:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose84:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose85:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose86:
+ax_pose 18, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose87:
+ax_pose 19, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sMakuhitaPose88:
+ax_pose 20, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose89:
+ax_pose 17, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose90:
+ax_pose 20, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose91:
+ax_pose 23, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose92:
+ax_pose 26, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose93:
+ax_pose 29, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose94:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose95:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose96:
+ax_pose 20, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose97:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose98:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose99:
+ax_pose 6, 0x01e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose100:
+ax_pose 9, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose102:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose103:
+ax_pose 6, 0x01e6, 0x90e8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose104:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose105:
+ax_pose 30, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose106:
+ax_pose 31, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose107:
+ax_pose 32, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose108:
+ax_pose 33, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sMakuhitaPose109:
+ax_pose 34, 0x01e2, 0x90ea, 0x2c00
+ax_pose_terminator
+sMakuhitaPose110:
+ax_pose 35, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sMakuhitaPose111:
+ax_pose 36, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose112:
+ax_pose 35, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sMakuhitaPose113:
+ax_pose 34, 0x01e2, 0x80f6, 0x2c00
+ax_pose_terminator
+sMakuhitaPose114:
+ax_pose 33, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sMakuhitaPose115:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose116:
+ax_pose 1, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sMakuhitaPose117:
+ax_pose 2, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMakuhitaPose118:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose119:
+ax_pose 4, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose120:
+ax_pose 5, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMakuhitaPose121:
+ax_pose 6, 0x01e6, 0x90e8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose122:
+ax_pose 7, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMakuhitaPose123:
+ax_pose 8, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose124:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose125:
+ax_pose 10, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sMakuhitaPose126:
+ax_pose 11, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose127:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose128:
+ax_pose 13, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sMakuhitaPose129:
+ax_pose 14, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sMakuhitaPose130:
+ax_pose 9, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose131:
+ax_pose 10, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sMakuhitaPose132:
+ax_pose 11, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose133:
+ax_pose 6, 0x01e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose134:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMakuhitaPose135:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose136:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose137:
+ax_pose 4, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose138:
+ax_pose 5, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sMakuhitaPose139:
+ax_pose 17, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose140:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose141:
+ax_pose 23, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose142:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose143:
+ax_pose 29, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose144:
+ax_pose 26, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose145:
+ax_pose 23, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose146:
+ax_pose 20, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose147:
+ax_pose 16, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sMakuhitaPose148:
+ax_pose 18, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose149:
+ax_pose 21, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sMakuhitaPose150:
+ax_pose 24, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sMakuhitaPose151:
+ax_pose 28, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose152:
+ax_pose 25, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose153:
+ax_pose 22, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose154:
+ax_pose 19, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sMakuhitaPose155:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose156:
+ax_pose 17, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose157:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose158:
+ax_pose 20, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose159:
+ax_pose 6, 0x01e6, 0x90e8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose160:
+ax_pose 23, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose161:
+ax_pose 9, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sMakuhitaPose162:
+ax_pose 26, 0x01e9, 0x90eb, 0x2c00
+ax_pose_terminator
+sMakuhitaPose163:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose164:
+ax_pose 29, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose165:
+ax_pose 9, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose166:
+ax_pose 26, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose167:
+ax_pose 6, 0x01e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose168:
+ax_pose 23, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose169:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose170:
+ax_pose 20, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose171:
+ax_pose 17, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose172:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sMakuhitaPose173:
+ax_pose 23, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose174:
+ax_pose 26, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose175:
+ax_pose 29, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose176:
+ax_pose 26, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose177:
+ax_pose 23, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose178:
+ax_pose 20, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sMakuhitaPose179:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose180:
+ax_pose 3, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose181:
+ax_pose 6, 0x01e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose182:
+ax_pose 9, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose183:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMakuhitaPose184:
+ax_pose 9, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sMakuhitaPose185:
+ax_pose 6, 0x01e6, 0x90e8, 0x2c00
+ax_pose_terminator
+sMakuhitaPose186:
+ax_pose 3, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sMakuhitaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_2_1:
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 2, 0, 27, 0, -3, 0, -3,
+ax_anim 6, 0, 27, 0, -4, 0, -4,
+ax_anim 1, 2, 24, 0, 3, 0, 3,
+ax_anim 1, 0, 25, 0, 11, 0, 11,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sMakuhitaAnims_2_2:
+ax_anim 2, 0, 31, -2, -2, -2, -2,
+ax_anim 2, 0, 31, -3, -3, -3, -3,
+ax_anim 6, 0, 31, -4, -4, -4, -4,
+ax_anim 1, 2, 28, 3, 3, 3, 3,
+ax_anim 1, 0, 30, 11, 10, 11, 10,
+ax_anim 2, 0, 30, 21, 18, 21, 18,
+ax_anim 2, 1, 30, 22, 17, 22, 17,
+ax_anim 2, 0, 30, 21, 18, 21, 18,
+ax_anim 2, 0, 30, 22, 17, 22, 17,
+ax_anim 2, 0, 30, 21, 18, 21, 18,
+ax_anim 2, 0, 30, 22, 17, 22, 17,
+ax_anim 2, 0, 28, 10, 9, 10, 9,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sMakuhitaAnims_2_3:
+ax_anim 2, 0, 35, -2, 0, -2, 0,
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 6, 0, 35, -4, 0, -4, 0,
+ax_anim 1, 2, 32, 3, 0, 3, 0,
+ax_anim 1, 0, 34, 11, 0, 11, 0,
+ax_anim 2, 0, 34, 20, 0, 20, 0,
+ax_anim 2, 1, 34, 20, 1, 20, 1,
+ax_anim 2, 0, 34, 20, 0, 20, 0,
+ax_anim 2, 0, 34, 20, 1, 20, 1,
+ax_anim 2, 0, 34, 20, 0, 20, 0,
+ax_anim 2, 0, 34, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sMakuhitaAnims_2_4:
+ax_anim 2, 0, 39, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -3, 3, -3, 3,
+ax_anim 6, 0, 39, -4, 4, -4, 4,
+ax_anim 1, 2, 36, 3, -3, 3, -3,
+ax_anim 1, 0, 38, 10, -10, 10, -10,
+ax_anim 2, 0, 38, 18, -18, 18, -18,
+ax_anim 2, 1, 38, 19, -17, 19, -17,
+ax_anim 2, 0, 38, 18, -18, 18, -18,
+ax_anim 2, 0, 38, 19, -17, 19, -17,
+ax_anim 2, 0, 38, 18, -18, 18, -18,
+ax_anim 2, 0, 38, 19, -17, 19, -17,
+ax_anim 2, 0, 36, 10, -10, 10, -10,
+ax_anim 2, 0, 36, 4, -4, 4, -4,
+ax_anim_terminator
+sMakuhitaAnims_2_5:
+ax_anim 2, 0, 43, 0, 2, 0, 2,
+ax_anim 2, 0, 43, 0, 3, 0, 3,
+ax_anim 6, 0, 43, 0, 4, 0, 4,
+ax_anim 1, 2, 40, 0, -2, 0, -2,
+ax_anim 1, 0, 41, 0, -9, 0, -9,
+ax_anim 2, 0, 41, 0, -17, 0, -17,
+ax_anim 2, 1, 41, 1, -17, 1, -17,
+ax_anim 2, 0, 41, 0, -17, 0, -17,
+ax_anim 2, 0, 41, 1, -17, 1, -17,
+ax_anim 2, 0, 41, 0, -17, 0, -17,
+ax_anim 2, 0, 41, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -8, 0, -8,
+ax_anim 2, 0, 40, 0, -3, 0, -3,
+ax_anim_terminator
+sMakuhitaAnims_2_6:
+ax_anim 2, 0, 47, 2, 2, 2, 2,
+ax_anim 2, 0, 47, 3, 3, 3, 3,
+ax_anim 6, 0, 47, 4, 4, 4, 4,
+ax_anim 1, 2, 44, -3, -3, -3, -3,
+ax_anim 1, 0, 46, -10, -10, -10, -10,
+ax_anim 2, 0, 46, -18, -18, -18, -18,
+ax_anim 2, 1, 46, -19, -17, -19, -17,
+ax_anim 2, 0, 46, -18, -18, -18, -18,
+ax_anim 2, 0, 46, -19, -17, -19, -17,
+ax_anim 2, 0, 46, -18, -18, -18, -18,
+ax_anim 2, 0, 46, -19, -17, -19, -17,
+ax_anim 2, 0, 44, -10, -10, -10, -10,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim_terminator
+sMakuhitaAnims_2_7:
+ax_anim 2, 0, 51, 2, 0, 2, 0,
+ax_anim 2, 0, 51, 3, 0, 3, 0,
+ax_anim 6, 0, 51, 4, 0, 4, 0,
+ax_anim 1, 2, 48, -3, 0, -3, 0,
+ax_anim 1, 0, 50, -11, 0, -11, 0,
+ax_anim 2, 0, 50, -20, 0, -20, 0,
+ax_anim 2, 1, 50, -20, 1, -20, 1,
+ax_anim 2, 0, 50, -20, 0, -20, 0,
+ax_anim 2, 0, 50, -20, 1, -20, 1,
+ax_anim 2, 0, 50, -20, 0, -20, 0,
+ax_anim 2, 0, 50, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sMakuhitaAnims_2_8:
+ax_anim 2, 0, 55, 2, -2, 2, -2,
+ax_anim 2, 0, 55, 3, -3, 3, -3,
+ax_anim 6, 0, 55, 4, -4, 4, -4,
+ax_anim 1, 2, 52, -3, 3, -3, 3,
+ax_anim 1, 0, 54, -11, 10, -11, 10,
+ax_anim 2, 0, 54, -21, 18, -21, 18,
+ax_anim 2, 1, 54, -22, 17, -22, 17,
+ax_anim 2, 0, 54, -21, 18, -21, 18,
+ax_anim 2, 0, 54, -22, 17, -22, 17,
+ax_anim 2, 0, 54, -21, 18, -21, 18,
+ax_anim 2, 0, 54, -22, 17, -22, 17,
+ax_anim 2, 0, 52, -10, 9, -10, 9,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_3_1:
+ax_anim 2, 0, 59, 0, -2, 0, -2,
+ax_anim 2, 0, 59, 0, -3, 0, -3,
+ax_anim 6, 0, 59, 0, -4, 0, -4,
+ax_anim 2, 2, 56, 0, 3, 0, 3,
+ax_anim 1, 0, 58, 1, 11, 1, 11,
+ax_anim 4, 0, 58, 2, 12, 1, 11,
+ax_anim 1, 0, 57, -2, 19, -2, 19,
+ax_anim 4, 1, 57, -3, 20, -3, 20,
+ax_anim 1, 0, 58, 1, 19, 1, 19,
+ax_anim 4, 0, 58, 2, 20, 2, 20,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sMakuhitaAnims_3_2:
+ax_anim 2, 0, 63, -2, -2, -2, -2,
+ax_anim 2, 0, 63, -3, -3, -3, -3,
+ax_anim 6, 0, 63, -4, -4, -4, -4,
+ax_anim 2, 2, 60, 3, 3, 3, 3,
+ax_anim 1, 0, 61, 11, 10, 11, 10,
+ax_anim 4, 0, 61, 12, 10, 12, 10,
+ax_anim 1, 0, 62, 18, 16, 18, 16,
+ax_anim 4, 1, 62, 17, 17, 17, 17,
+ax_anim 1, 0, 61, 20, 18, 20, 18,
+ax_anim 4, 0, 61, 21, 18, 21, 18,
+ax_anim 2, 0, 60, 10, 9, 10, 9,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sMakuhitaAnims_3_3:
+ax_anim 2, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 67, -3, 0, -3, 0,
+ax_anim 6, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 64, 3, 0, 3, 0,
+ax_anim 1, 0, 65, 9, 0, 9, 0,
+ax_anim 4, 0, 65, 10, -1, 10, -1,
+ax_anim 1, 0, 66, 15, 0, 15, 0,
+ax_anim 4, 1, 66, 16, 1, 16, 1,
+ax_anim 1, 0, 65, 18, -1, 18, -1,
+ax_anim 4, 0, 65, 19, -2, 19, -2,
+ax_anim 2, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sMakuhitaAnims_3_4:
+ax_anim 2, 0, 71, -2, 2, -2, 2,
+ax_anim 2, 0, 71, -3, 3, -3, 3,
+ax_anim 6, 0, 71, -4, 4, -4, 4,
+ax_anim 2, 2, 68, 3, -3, 3, -3,
+ax_anim 1, 0, 69, 10, -11, 10, -11,
+ax_anim 4, 0, 69, 10, -12, 10, -11,
+ax_anim 1, 0, 70, 18, -18, 18, -18,
+ax_anim 4, 1, 70, 19, -18, 18, -19,
+ax_anim 1, 0, 69, 18, -19, 18, -18,
+ax_anim 4, 0, 69, 18, -21, 20, -19,
+ax_anim 2, 0, 68, 9, -10, 9, -10,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sMakuhitaAnims_3_5:
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 6, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 2, 72, 0, -2, 0, -2,
+ax_anim 1, 0, 74, 0, -8, 0, -8,
+ax_anim 4, 0, 74, -1, -9, 0, -8,
+ax_anim 1, 0, 73, 0, -16, 0, -16,
+ax_anim 4, 1, 73, 1, -17, -1, -17,
+ax_anim 1, 0, 74, -2, -17, 0, -16,
+ax_anim 4, 0, 74, -3, -18, 1, -17,
+ax_anim 2, 0, 72, 0, -8, 0, -8,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sMakuhitaAnims_3_6:
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 6, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 2, 76, -3, -3, -3, -3,
+ax_anim 1, 0, 77, -10, -11, -10, -11,
+ax_anim 4, 0, 77, -10, -12, -10, -11,
+ax_anim 1, 0, 78, -18, -18, -18, -18,
+ax_anim 4, 1, 78, -19, -18, -18, -19,
+ax_anim 1, 0, 77, -18, -20, -18, -18,
+ax_anim 4, 0, 77, -19, -21, -20, -19,
+ax_anim 2, 0, 76, -9, -10, -9, -10,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim_terminator
+sMakuhitaAnims_3_7:
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 6, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 2, 80, -3, 0, -3, 0,
+ax_anim 1, 0, 81, -9, 0, -9, 0,
+ax_anim 4, 0, 81, -10, -1, -10, -1,
+ax_anim 1, 0, 82, -15, 0, -15, 0,
+ax_anim 4, 1, 82, -16, 1, -16, 1,
+ax_anim 1, 0, 81, -18, -1, -18, -1,
+ax_anim 4, 0, 81, -19, -2, -19, -2,
+ax_anim 2, 0, 80, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sMakuhitaAnims_3_8:
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 6, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 2, 84, -3, 3, -3, 3,
+ax_anim 1, 0, 85, -11, 10, -11, 10,
+ax_anim 4, 0, 85, -12, 10, -12, 10,
+ax_anim 1, 0, 86, -18, 16, -18, 16,
+ax_anim 4, 1, 86, -17, 17, -17, 17,
+ax_anim 1, 0, 85, -20, 18, -20, 18,
+ax_anim 4, 0, 85, -21, 18, -21, 18,
+ax_anim 2, 0, 84, -10, 9, -10, 9,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_4_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 1, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim_terminator
+sMakuhitaAnims_4_2:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 1, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim_terminator
+sMakuhitaAnims_4_3:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim_terminator
+sMakuhitaAnims_4_4:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sMakuhitaAnims_4_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 1, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim_terminator
+sMakuhitaAnims_4_6:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 93, -1, 1, -1, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+sMakuhitaAnims_4_7:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 1, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim_terminator
+sMakuhitaAnims_4_8:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sMakuhitaAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sMakuhitaAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sMakuhitaAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sMakuhitaAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sMakuhitaAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sMakuhitaAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sMakuhitaAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_8_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, 0, 0,
+ax_anim 20, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 115, -1, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, 0, 0,
+ax_anim 20, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 1, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_8_2:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, 0, 0,
+ax_anim 20, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 1, -1, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, 0, 0,
+ax_anim 20, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 119, -1, 1, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_8_3:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, 0,
+ax_anim 20, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, -2, -1, 0, 0,
+ax_anim 4, 0, 121, -2, -2, 0, 0,
+ax_anim 4, 0, 121, -2, -1, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, 0,
+ax_anim 20, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 1, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_8_4:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, 0, 0,
+ax_anim 20, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 1, 1, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, 0, 0,
+ax_anim 20, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 125, -1, -1, 0, 0,
+ax_anim 4, 0, 125, -2, -2, 0, 0,
+ax_anim 4, 0, 125, -1, -1, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_8_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, 0, 0,
+ax_anim 20, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, -1, 0, 0, 0,
+ax_anim 4, 0, 127, -2, 0, 0, 0,
+ax_anim 4, 0, 127, -1, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, 0, 0,
+ax_anim 20, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 1, 0, 0, 0,
+ax_anim 4, 0, 128, 2, 0, 0, 0,
+ax_anim 4, 0, 128, 1, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_8_6:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 0, 0,
+ax_anim 20, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 130, -1, 1, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 0, 0,
+ax_anim 20, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 1, -1, 0, 0,
+ax_anim 4, 0, 131, 2, -2, 0, 0,
+ax_anim 4, 0, 131, 1, -1, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_8_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 20, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 2, -1, 0, 0,
+ax_anim 4, 0, 133, 2, -2, 0, 0,
+ax_anim 4, 0, 133, 2, -1, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 20, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 1, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_8_8:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 0, 0,
+ax_anim 20, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 136, -1, -1, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 0, 0,
+ax_anim 20, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 1, 1, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 7, 3, 7, 3,
+ax_anim 2, 0, 140, 11, 10, 11, 10,
+ax_anim 2, 0, 141, 10, 16, 10, 16,
+ax_anim 3, 0, 142, 0, 19, 0, 19,
+ax_anim 2, 3, 143, -10, 16, -10, 16,
+ax_anim 2, 0, 144, -11, 10, -11, 10,
+ax_anim 1, 0, 145, -7, 3, -7, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 9, 1, 9, 1,
+ax_anim 2, 0, 139, 17, 4, 17, 4,
+ax_anim 2, 0, 140, 21, 11, 21, 11,
+ax_anim 3, 0, 141, 21, 19, 21, 19,
+ax_anim 2, 3, 142, 11, 19, 11, 19,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 13, -6, 13, -6,
+ax_anim 2, 0, 139, 19, -4, 19, -4,
+ax_anim 3, 0, 140, 22, 0, 22, 0,
+ax_anim 2, 3, 141, 17, 5, 17, 5,
+ax_anim 2, 0, 142, 12, 5, 12, 5,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -7, -1, -7,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -24, 12, -24,
+ax_anim 3, 0, 139, 21, -23, 21, -23,
+ax_anim 2, 3, 140, 24, -15, 24, -15,
+ax_anim 2, 0, 141, 17, -5, 17, -5,
+ax_anim 1, 0, 142, 9, -1, 9, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -11, -12, -11, -12,
+ax_anim 2, 0, 145, -7, -19, -7, -19,
+ax_anim 3, 0, 138, 0, -24, 0, -24,
+ax_anim 2, 3, 139, 7, -19, 7, -19,
+ax_anim 2, 0, 140, 11, -12, 11, -12,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -7, 1, -7,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -24, -12, -24,
+ax_anim 3, 0, 145, -21, -23, -21, -23,
+ax_anim 2, 3, 144, -24, -15, -24, -15,
+ax_anim 2, 0, 143, -17, -5, -17, -5,
+ax_anim 1, 0, 142, -9, -1, -9, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -13, -6, -13, -6,
+ax_anim 2, 0, 145, -19, -4, -19, -4,
+ax_anim 3, 0, 144, -22, 0, -22, 0,
+ax_anim 2, 3, 143, -17, 5, -17, 5,
+ax_anim 2, 0, 142, -12, 5, -12, 5,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -9, 1, -9, 1,
+ax_anim 2, 0, 145, -17, 4, -17, 4,
+ax_anim 2, 0, 144, -21, 11, -21, 11,
+ax_anim 3, 0, 143, -21, 19, -21, 19,
+ax_anim 2, 3, 142, -11, 19, -11, 19,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 155, 0, -22, 0, 0,
+ax_anim 3, 0, 155, 0, -21, 0, 0,
+ax_anim 2, 0, 155, 0, -18, 0, 0,
+ax_anim 1, 0, 155, 0, -12, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_11_2:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -26, 0, 0,
+ax_anim 3, 0, 157, 0, -25, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_11_3:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -24, 0, 0,
+ax_anim 3, 0, 159, 0, -23, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_11_4:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -24, 0, 0,
+ax_anim 3, 0, 161, 0, -23, 0, 0,
+ax_anim 2, 0, 161, 0, -17, 0, 0,
+ax_anim 1, 0, 161, 0, -11, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_11_5:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -21, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_11_6:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -24, 0, 0,
+ax_anim 3, 0, 165, 0, -23, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_11_7:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -24, 0, 0,
+ax_anim 3, 0, 167, 0, -23, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_11_8:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -26, 0, 0,
+ax_anim 3, 0, 169, 0, -25, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMakuhitaAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMakuhitaGfx1:
+.incbin "baserom.gba", 0x1208740, 0x200
+sMakuhitaSprites1:
+ax_sprite sMakuhitaGfx1, 0x200
+ax_sprite_terminator
+sMakuhitaGfx2:
+.incbin "baserom.gba", 0x1208950, 0x200
+sMakuhitaSprites2:
+ax_sprite sMakuhitaGfx2, 0x200
+ax_sprite_terminator
+sMakuhitaGfx3:
+.incbin "baserom.gba", 0x1208B60, 0x200
+sMakuhitaSprites3:
+ax_sprite sMakuhitaGfx3, 0x200
+ax_sprite_terminator
+sMakuhitaGfx4:
+.incbin "baserom.gba", 0x1208D70, 0x200
+sMakuhitaSprites4:
+ax_sprite sMakuhitaGfx4, 0x200
+ax_sprite_terminator
+sMakuhitaGfx5:
+.incbin "baserom.gba", 0x1208F80, 0x200
+sMakuhitaSprites5:
+ax_sprite sMakuhitaGfx5, 0x200
+ax_sprite_terminator
+sMakuhitaGfx6:
+.incbin "baserom.gba", 0x1209190, 0x200
+sMakuhitaSprites6:
+ax_sprite sMakuhitaGfx6, 0x200
+ax_sprite_terminator
+sMakuhitaGfx7:
+.incbin "baserom.gba", 0x12093A0, 0x200
+sMakuhitaSprites7:
+ax_sprite sMakuhitaGfx7, 0x200
+ax_sprite_terminator
+sMakuhitaGfx8:
+.incbin "baserom.gba", 0x12095B0, 0x200
+sMakuhitaSprites8:
+ax_sprite sMakuhitaGfx8, 0x200
+ax_sprite_terminator
+sMakuhitaGfx9:
+.incbin "baserom.gba", 0x12097C0, 0x200
+sMakuhitaSprites9:
+ax_sprite sMakuhitaGfx9, 0x200
+ax_sprite_terminator
+sMakuhitaGfx10:
+.incbin "baserom.gba", 0x12099D0, 0x200
+sMakuhitaSprites10:
+ax_sprite sMakuhitaGfx10, 0x200
+ax_sprite_terminator
+sMakuhitaGfx11:
+.incbin "baserom.gba", 0x1209BE0, 0x200
+sMakuhitaSprites11:
+ax_sprite sMakuhitaGfx11, 0x200
+ax_sprite_terminator
+sMakuhitaGfx12:
+.incbin "baserom.gba", 0x1209DF0, 0x200
+sMakuhitaSprites12:
+ax_sprite sMakuhitaGfx12, 0x200
+ax_sprite_terminator
+sMakuhitaGfx13:
+.incbin "baserom.gba", 0x120A000, 0x200
+sMakuhitaSprites13:
+ax_sprite sMakuhitaGfx13, 0x200
+ax_sprite_terminator
+sMakuhitaGfx14:
+.incbin "baserom.gba", 0x120A210, 0x200
+sMakuhitaSprites14:
+ax_sprite sMakuhitaGfx14, 0x200
+ax_sprite_terminator
+sMakuhitaGfx15:
+.incbin "baserom.gba", 0x120A420, 0x200
+sMakuhitaSprites15:
+ax_sprite sMakuhitaGfx15, 0x200
+ax_sprite_terminator
+sMakuhitaGfx16:
+.incbin "baserom.gba", 0x120A630, 0x60
+sMakuhitaGfx16_1:
+.incbin "baserom.gba", 0x120A690, 0x160
+sMakuhitaSprites16:
+ax_sprite sMakuhitaGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx16_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx17:
+.incbin "baserom.gba", 0x120A818, 0x60
+sMakuhitaGfx17_1:
+.incbin "baserom.gba", 0x120A878, 0x60
+sMakuhitaGfx17_2:
+.incbin "baserom.gba", 0x120A8D8, 0x60
+sMakuhitaGfx17_3:
+.incbin "baserom.gba", 0x120A938, 0x40
+sMakuhitaSprites17:
+ax_sprite sMakuhitaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx18:
+.incbin "baserom.gba", 0x120A9C0, 0x60
+sMakuhitaGfx18_1:
+.incbin "baserom.gba", 0x120AA20, 0x60
+sMakuhitaGfx18_2:
+.incbin "baserom.gba", 0x120AA80, 0x60
+sMakuhitaSprites18:
+ax_sprite 0, 0x80
+ax_sprite sMakuhitaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx19:
+.incbin "baserom.gba", 0x120AB20, 0x40
+sMakuhitaGfx19_1:
+.incbin "baserom.gba", 0x120AB60, 0x160
+sMakuhitaSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx20:
+.incbin "baserom.gba", 0x120ACF0, 0x40
+sMakuhitaGfx20_1:
+.incbin "baserom.gba", 0x120AD30, 0x60
+sMakuhitaGfx20_2:
+.incbin "baserom.gba", 0x120AD90, 0x60
+sMakuhitaGfx20_3:
+.incbin "baserom.gba", 0x120ADF0, 0x40
+sMakuhitaSprites20:
+ax_sprite sMakuhitaGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx20_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMakuhitaGfx21:
+.incbin "baserom.gba", 0x120AE78, 0x40
+sMakuhitaGfx21_1:
+.incbin "baserom.gba", 0x120AEB8, 0x60
+sMakuhitaGfx21_2:
+.incbin "baserom.gba", 0x120AF18, 0x60
+sMakuhitaGfx21_3:
+.incbin "baserom.gba", 0x120AF78, 0x60
+sMakuhitaSprites21:
+ax_sprite sMakuhitaGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx22:
+.incbin "baserom.gba", 0x120B020, 0x20
+sMakuhitaGfx22_1:
+.incbin "baserom.gba", 0x120B040, 0x60
+sMakuhitaGfx22_2:
+.incbin "baserom.gba", 0x120B0A0, 0x100
+sMakuhitaSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx22_2, 0x100
+ax_sprite_terminator
+sMakuhitaGfx23:
+.incbin "baserom.gba", 0x120B1D8, 0x20
+sMakuhitaGfx23_1:
+.incbin "baserom.gba", 0x120B1F8, 0x60
+sMakuhitaGfx23_2:
+.incbin "baserom.gba", 0x120B258, 0x60
+sMakuhitaGfx23_3:
+.incbin "baserom.gba", 0x120B2B8, 0x60
+sMakuhitaSprites23:
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx24:
+.incbin "baserom.gba", 0x120B368, 0x60
+sMakuhitaGfx24_1:
+.incbin "baserom.gba", 0x120B3C8, 0x60
+sMakuhitaGfx24_2:
+.incbin "baserom.gba", 0x120B428, 0x60
+sMakuhitaSprites24:
+ax_sprite 0, 0x80
+ax_sprite sMakuhitaGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx25:
+.incbin "baserom.gba", 0x120B4C8, 0x40
+sMakuhitaGfx25_1:
+.incbin "baserom.gba", 0x120B508, 0x60
+sMakuhitaGfx25_2:
+.incbin "baserom.gba", 0x120B568, 0x60
+sMakuhitaGfx25_3:
+.incbin "baserom.gba", 0x120B5C8, 0x40
+sMakuhitaSprites25:
+ax_sprite sMakuhitaGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx25_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMakuhitaGfx26:
+.incbin "baserom.gba", 0x120B650, 0x60
+sMakuhitaGfx26_1:
+.incbin "baserom.gba", 0x120B6B0, 0xE0
+sMakuhitaGfx26_2:
+.incbin "baserom.gba", 0x120B790, 0x20
+sMakuhitaSprites26:
+ax_sprite sMakuhitaGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx26_1, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sMakuhitaGfx26_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx27:
+.incbin "baserom.gba", 0x120B7E8, 0x40
+sMakuhitaGfx27_1:
+.incbin "baserom.gba", 0x120B828, 0x60
+sMakuhitaGfx27_2:
+.incbin "baserom.gba", 0x120B888, 0x60
+sMakuhitaGfx27_3:
+.incbin "baserom.gba", 0x120B8E8, 0x20
+sMakuhitaSprites27:
+ax_sprite sMakuhitaGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx27_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMakuhitaGfx28:
+.incbin "baserom.gba", 0x120B950, 0x60
+sMakuhitaGfx28_1:
+.incbin "baserom.gba", 0x120B9B0, 0xC0
+sMakuhitaGfx28_2:
+.incbin "baserom.gba", 0x120BA70, 0x20
+sMakuhitaSprites28:
+ax_sprite sMakuhitaGfx28, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx28_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sMakuhitaGfx28_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMakuhitaGfx29:
+.incbin "baserom.gba", 0x120BAC8, 0x60
+sMakuhitaGfx29_1:
+.incbin "baserom.gba", 0x120BB28, 0x60
+sMakuhitaGfx29_2:
+.incbin "baserom.gba", 0x120BB88, 0x80
+sMakuhitaGfx29_3:
+.incbin "baserom.gba", 0x120BC08, 0x40
+sMakuhitaSprites29:
+ax_sprite sMakuhitaGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx29_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMakuhitaGfx30:
+.incbin "baserom.gba", 0x120BC90, 0x60
+sMakuhitaGfx30_1:
+.incbin "baserom.gba", 0x120BCF0, 0x60
+sMakuhitaGfx30_2:
+.incbin "baserom.gba", 0x120BD50, 0x60
+sMakuhitaSprites30:
+ax_sprite sMakuhitaGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMakuhitaGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMakuhitaGfx31:
+.incbin "baserom.gba", 0x120BDE8, 0x200
+sMakuhitaSprites31:
+ax_sprite sMakuhitaGfx31, 0x200
+ax_sprite_terminator
+sMakuhitaGfx32:
+.incbin "baserom.gba", 0x120BFF8, 0x200
+sMakuhitaSprites32:
+ax_sprite sMakuhitaGfx32, 0x200
+ax_sprite_terminator
+sMakuhitaGfx33:
+.incbin "baserom.gba", 0x120C208, 0x200
+sMakuhitaSprites33:
+ax_sprite sMakuhitaGfx33, 0x200
+ax_sprite_terminator
+sMakuhitaGfx34:
+.incbin "baserom.gba", 0x120C418, 0x200
+sMakuhitaSprites34:
+ax_sprite sMakuhitaGfx34, 0x200
+ax_sprite_terminator
+sMakuhitaGfx35:
+.incbin "baserom.gba", 0x120C628, 0x200
+sMakuhitaSprites35:
+ax_sprite sMakuhitaGfx35, 0x200
+ax_sprite_terminator
+sMakuhitaGfx36:
+.incbin "baserom.gba", 0x120C838, 0x200
+sMakuhitaSprites36:
+ax_sprite sMakuhitaGfx36, 0x200
+ax_sprite_terminator
+sMakuhitaGfx37:
+.incbin "baserom.gba", 0x120CA48, 0x200
+sMakuhitaSprites37:
+ax_sprite sMakuhitaGfx37, 0x200
+ax_sprite_terminator
+sAxPosesMakuhita:
+.4byte sMakuhitaPose1
+.4byte sMakuhitaPose2
+.4byte sMakuhitaPose3
+.4byte sMakuhitaPose4
+.4byte sMakuhitaPose5
+.4byte sMakuhitaPose6
+.4byte sMakuhitaPose7
+.4byte sMakuhitaPose8
+.4byte sMakuhitaPose9
+.4byte sMakuhitaPose10
+.4byte sMakuhitaPose11
+.4byte sMakuhitaPose12
+.4byte sMakuhitaPose13
+.4byte sMakuhitaPose14
+.4byte sMakuhitaPose15
+.4byte sMakuhitaPose16
+.4byte sMakuhitaPose17
+.4byte sMakuhitaPose18
+.4byte sMakuhitaPose19
+.4byte sMakuhitaPose20
+.4byte sMakuhitaPose21
+.4byte sMakuhitaPose22
+.4byte sMakuhitaPose23
+.4byte sMakuhitaPose24
+.4byte sMakuhitaPose25
+.4byte sMakuhitaPose26
+.4byte sMakuhitaPose27
+.4byte sMakuhitaPose28
+.4byte sMakuhitaPose29
+.4byte sMakuhitaPose30
+.4byte sMakuhitaPose31
+.4byte sMakuhitaPose32
+.4byte sMakuhitaPose33
+.4byte sMakuhitaPose34
+.4byte sMakuhitaPose35
+.4byte sMakuhitaPose36
+.4byte sMakuhitaPose37
+.4byte sMakuhitaPose38
+.4byte sMakuhitaPose39
+.4byte sMakuhitaPose40
+.4byte sMakuhitaPose41
+.4byte sMakuhitaPose42
+.4byte sMakuhitaPose43
+.4byte sMakuhitaPose44
+.4byte sMakuhitaPose45
+.4byte sMakuhitaPose46
+.4byte sMakuhitaPose47
+.4byte sMakuhitaPose48
+.4byte sMakuhitaPose49
+.4byte sMakuhitaPose50
+.4byte sMakuhitaPose51
+.4byte sMakuhitaPose52
+.4byte sMakuhitaPose53
+.4byte sMakuhitaPose54
+.4byte sMakuhitaPose55
+.4byte sMakuhitaPose56
+.4byte sMakuhitaPose57
+.4byte sMakuhitaPose58
+.4byte sMakuhitaPose59
+.4byte sMakuhitaPose60
+.4byte sMakuhitaPose61
+.4byte sMakuhitaPose62
+.4byte sMakuhitaPose63
+.4byte sMakuhitaPose64
+.4byte sMakuhitaPose65
+.4byte sMakuhitaPose66
+.4byte sMakuhitaPose67
+.4byte sMakuhitaPose68
+.4byte sMakuhitaPose69
+.4byte sMakuhitaPose70
+.4byte sMakuhitaPose71
+.4byte sMakuhitaPose72
+.4byte sMakuhitaPose73
+.4byte sMakuhitaPose74
+.4byte sMakuhitaPose75
+.4byte sMakuhitaPose76
+.4byte sMakuhitaPose77
+.4byte sMakuhitaPose78
+.4byte sMakuhitaPose79
+.4byte sMakuhitaPose80
+.4byte sMakuhitaPose81
+.4byte sMakuhitaPose82
+.4byte sMakuhitaPose83
+.4byte sMakuhitaPose84
+.4byte sMakuhitaPose85
+.4byte sMakuhitaPose86
+.4byte sMakuhitaPose87
+.4byte sMakuhitaPose88
+.4byte sMakuhitaPose89
+.4byte sMakuhitaPose90
+.4byte sMakuhitaPose91
+.4byte sMakuhitaPose92
+.4byte sMakuhitaPose93
+.4byte sMakuhitaPose94
+.4byte sMakuhitaPose95
+.4byte sMakuhitaPose96
+.4byte sMakuhitaPose97
+.4byte sMakuhitaPose98
+.4byte sMakuhitaPose99
+.4byte sMakuhitaPose100
+.4byte sMakuhitaPose101
+.4byte sMakuhitaPose102
+.4byte sMakuhitaPose103
+.4byte sMakuhitaPose104
+.4byte sMakuhitaPose105
+.4byte sMakuhitaPose106
+.4byte sMakuhitaPose107
+.4byte sMakuhitaPose108
+.4byte sMakuhitaPose109
+.4byte sMakuhitaPose110
+.4byte sMakuhitaPose111
+.4byte sMakuhitaPose112
+.4byte sMakuhitaPose113
+.4byte sMakuhitaPose114
+.4byte sMakuhitaPose115
+.4byte sMakuhitaPose116
+.4byte sMakuhitaPose117
+.4byte sMakuhitaPose118
+.4byte sMakuhitaPose119
+.4byte sMakuhitaPose120
+.4byte sMakuhitaPose121
+.4byte sMakuhitaPose122
+.4byte sMakuhitaPose123
+.4byte sMakuhitaPose124
+.4byte sMakuhitaPose125
+.4byte sMakuhitaPose126
+.4byte sMakuhitaPose127
+.4byte sMakuhitaPose128
+.4byte sMakuhitaPose129
+.4byte sMakuhitaPose130
+.4byte sMakuhitaPose131
+.4byte sMakuhitaPose132
+.4byte sMakuhitaPose133
+.4byte sMakuhitaPose134
+.4byte sMakuhitaPose135
+.4byte sMakuhitaPose136
+.4byte sMakuhitaPose137
+.4byte sMakuhitaPose138
+.4byte sMakuhitaPose139
+.4byte sMakuhitaPose140
+.4byte sMakuhitaPose141
+.4byte sMakuhitaPose142
+.4byte sMakuhitaPose143
+.4byte sMakuhitaPose144
+.4byte sMakuhitaPose145
+.4byte sMakuhitaPose146
+.4byte sMakuhitaPose147
+.4byte sMakuhitaPose148
+.4byte sMakuhitaPose149
+.4byte sMakuhitaPose150
+.4byte sMakuhitaPose151
+.4byte sMakuhitaPose152
+.4byte sMakuhitaPose153
+.4byte sMakuhitaPose154
+.4byte sMakuhitaPose155
+.4byte sMakuhitaPose156
+.4byte sMakuhitaPose157
+.4byte sMakuhitaPose158
+.4byte sMakuhitaPose159
+.4byte sMakuhitaPose160
+.4byte sMakuhitaPose161
+.4byte sMakuhitaPose162
+.4byte sMakuhitaPose163
+.4byte sMakuhitaPose164
+.4byte sMakuhitaPose165
+.4byte sMakuhitaPose166
+.4byte sMakuhitaPose167
+.4byte sMakuhitaPose168
+.4byte sMakuhitaPose169
+.4byte sMakuhitaPose170
+.4byte sMakuhitaPose171
+.4byte sMakuhitaPose172
+.4byte sMakuhitaPose173
+.4byte sMakuhitaPose174
+.4byte sMakuhitaPose175
+.4byte sMakuhitaPose176
+.4byte sMakuhitaPose177
+.4byte sMakuhitaPose178
+.4byte sMakuhitaPose179
+.4byte sMakuhitaPose180
+.4byte sMakuhitaPose181
+.4byte sMakuhitaPose182
+.4byte sMakuhitaPose183
+.4byte sMakuhitaPose184
+.4byte sMakuhitaPose185
+.4byte sMakuhitaPose186
+sAxPositionsMakuhita:
+.2byte   -1,   -8, 	  -9,   -5, 	   8,   -5, 	  -1,   -7
+.2byte   -3,   -7, 	 -10,   -3, 	   8,   -6, 	  -3,   -6
+.2byte    2,   -7, 	  -9,   -6, 	   9,   -3, 	   2,   -6
+.2byte    2,   -9, 	   8,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    4,   -8, 	  10,   -5, 	  -6,   -4, 	   2,   -6
+.2byte    1,   -7, 	   7,   -8, 	  -5,    0, 	   0,   -5
+.2byte    4,   -9, 	   5,   -9, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -9, 	   7,   -6, 	   1,   -2, 	  -1,   -6
+.2byte    4,   -7, 	   4,  -10, 	   2,    0, 	  -2,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   8,   -6, 	  -2,   -7
+.2byte   -2,  -11, 	  -7,  -10, 	   6,   -6, 	  -2,   -6
+.2byte    2,  -10, 	  -3,  -11, 	   9,   -3, 	   0,   -5
+.2byte   -1,  -11, 	   9,   -8, 	 -10,   -8, 	   0,   -7
+.2byte    1,   -9, 	  11,   -4, 	 -10,   -6, 	   1,   -5
+.2byte   -2,   -9, 	   9,   -6, 	 -12,   -4, 	  -2,   -5
+.2byte   -3,  -12, 	   4,  -12, 	  -9,   -6, 	   1,   -7
+.2byte    1,  -11, 	   6,  -10, 	  -7,   -6, 	   1,   -6
+.2byte   -3,  -10, 	   2,  -11, 	 -10,   -3, 	  -1,   -5
+.2byte   -5,   -9, 	  -6,   -9, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -9, 	  -8,   -6, 	  -2,   -2, 	   0,   -6
+.2byte   -5,   -7, 	  -5,  -10, 	  -3,    0, 	   1,   -5
+.2byte   -3,   -9, 	  -9,   -8, 	   4,   -3, 	  -2,   -7
+.2byte   -5,   -8, 	 -11,   -5, 	   5,   -4, 	  -3,   -6
+.2byte   -2,   -7, 	  -8,   -8, 	   4,    0, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -5, 	   8,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   1,   -6, 	  13,  -11, 	   0,   -7
+.2byte   -2,   -8, 	 -13,  -11, 	   2,   -6, 	  -2,   -7
+.2byte   -1,   -4, 	  -8,    1, 	   7,    1, 	  -1,   -6
+.2byte    2,   -9, 	   8,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    4,   -8, 	  12,   -5, 	 -12,   -7, 	   1,   -6
+.2byte    5,   -8, 	   7,  -15, 	   3,   -4, 	  -2,   -6
+.2byte    2,   -4, 	   8,   -2, 	  -1,    3, 	  -1,   -4
+.2byte    4,   -9, 	   5,   -9, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -9, 	  13,   -9, 	  -5,   -2, 	   0,   -7
+.2byte    6,  -10, 	  -1,   -9, 	  10,   -7, 	   0,   -7
+.2byte    5,   -5, 	   9,   -5, 	   5,    0, 	  -2,   -6
+.2byte    2,  -12, 	  -5,  -12, 	   8,   -6, 	  -2,   -7
+.2byte    4,  -13, 	   8,  -15, 	   5,   -1, 	   0,   -8
+.2byte    4,  -13, 	 -11,  -12, 	  10,  -13, 	   0,   -8
+.2byte    4,  -10, 	   0,  -10, 	  10,   -4, 	   0,   -8
+.2byte   -1,  -11, 	   9,   -8, 	 -10,   -8, 	   0,   -7
+.2byte   -2,  -14, 	   1,  -20, 	 -13,   -4, 	   0,   -9
+.2byte    0,  -15, 	  11,   -4, 	  -5,  -18, 	   0,   -9
+.2byte   -1,  -13, 	   7,  -11, 	  -8,  -11, 	   0,   -9
+.2byte   -3,  -12, 	   4,  -12, 	  -9,   -6, 	   1,   -7
+.2byte   -5,  -13, 	  -9,  -15, 	  -6,   -1, 	  -1,   -8
+.2byte   -5,  -13, 	  10,  -12, 	 -11,  -13, 	  -1,   -8
+.2byte   -5,  -10, 	  -1,  -10, 	 -11,   -4, 	  -1,   -8
+.2byte   -5,   -9, 	  -6,   -9, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -9, 	 -14,   -9, 	   4,   -2, 	  -1,   -7
+.2byte   -7,  -10, 	   0,   -9, 	 -11,   -7, 	  -1,   -7
+.2byte   -6,   -5, 	 -10,   -5, 	  -6,    0, 	   1,   -6
+.2byte   -3,   -9, 	  -9,   -8, 	   4,   -3, 	  -2,   -7
+.2byte   -5,   -8, 	 -13,   -5, 	  11,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	  -8,  -15, 	  -4,   -4, 	   1,   -6
+.2byte   -3,   -4, 	  -9,   -2, 	   0,    3, 	   0,   -4
+.2byte   -1,   -8, 	  -9,   -5, 	   8,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   1,   -6, 	  13,  -11, 	   0,   -7
+.2byte   -2,   -8, 	 -13,  -11, 	   2,   -6, 	  -2,   -7
+.2byte   -1,   -4, 	  -8,    1, 	   7,    1, 	  -1,   -6
+.2byte    2,   -9, 	   8,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    4,   -8, 	  12,   -5, 	 -12,   -7, 	   1,   -6
+.2byte    5,   -8, 	   7,  -15, 	   3,   -4, 	  -2,   -6
+.2byte    2,   -4, 	   8,   -2, 	  -1,    3, 	  -1,   -4
+.2byte    4,   -9, 	   5,   -9, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -9, 	  13,   -9, 	  -5,   -2, 	   0,   -7
+.2byte    6,  -10, 	  -1,   -9, 	  10,   -7, 	   0,   -7
+.2byte    5,   -5, 	   9,   -5, 	   5,    0, 	  -2,   -6
+.2byte    2,  -12, 	  -5,  -12, 	   8,   -6, 	  -2,   -7
+.2byte    4,  -13, 	   8,  -15, 	   5,   -1, 	   0,   -8
+.2byte    4,  -13, 	 -11,  -12, 	  10,  -13, 	   0,   -8
+.2byte    4,  -10, 	   0,  -10, 	  10,   -4, 	   0,   -8
+.2byte   -1,  -11, 	   9,   -8, 	 -10,   -8, 	   0,   -7
+.2byte   -2,  -14, 	   1,  -20, 	 -13,   -4, 	   0,   -9
+.2byte    0,  -15, 	  11,   -4, 	  -5,  -18, 	   0,   -9
+.2byte   -1,  -13, 	   7,  -11, 	  -8,  -11, 	   0,   -9
+.2byte   -3,  -12, 	   4,  -12, 	  -9,   -6, 	   1,   -7
+.2byte   -5,  -13, 	  -9,  -15, 	  -6,   -1, 	  -1,   -8
+.2byte   -5,  -13, 	  10,  -12, 	 -11,  -13, 	  -1,   -8
+.2byte   -5,  -10, 	  -1,  -10, 	 -11,   -4, 	  -1,   -8
+.2byte   -5,   -9, 	  -6,   -9, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -9, 	 -14,   -9, 	   4,   -2, 	  -1,   -7
+.2byte   -7,  -10, 	   0,   -9, 	 -11,   -7, 	  -1,   -7
+.2byte   -6,   -5, 	 -10,   -5, 	  -6,    0, 	   1,   -6
+.2byte   -3,   -9, 	  -9,   -8, 	   4,   -3, 	  -2,   -7
+.2byte   -5,   -8, 	 -13,   -5, 	  11,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	  -8,  -15, 	  -4,   -4, 	   1,   -6
+.2byte   -3,   -4, 	  -9,   -2, 	   0,    3, 	   0,   -4
+.2byte   -1,   -4, 	  -8,    1, 	   7,    1, 	  -1,   -6
+.2byte    3,   -4, 	   9,   -2, 	   0,    3, 	   0,   -4
+.2byte    6,   -5, 	  10,   -5, 	   6,    0, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	  10,   -4, 	   0,   -8
+.2byte   -1,  -13, 	   7,  -11, 	  -8,  -11, 	   0,   -9
+.2byte   -5,  -10, 	  -1,  -10, 	 -11,   -4, 	  -1,   -8
+.2byte   -6,   -5, 	 -10,   -5, 	  -6,    0, 	   1,   -6
+.2byte   -4,   -4, 	 -10,   -2, 	  -1,    3, 	  -1,   -4
+.2byte   -1,   -8, 	  -9,   -5, 	   8,   -5, 	  -1,   -7
+.2byte   -3,   -9, 	  -9,   -8, 	   4,   -3, 	  -2,   -7
+.2byte   -5,   -9, 	  -6,   -9, 	  -3,   -2, 	   1,   -7
+.2byte   -3,  -12, 	   4,  -12, 	  -9,   -6, 	   1,   -7
+.2byte   -1,  -11, 	   9,   -8, 	 -10,   -8, 	   0,   -7
+.2byte    2,  -12, 	  -5,  -12, 	   8,   -6, 	  -2,   -7
+.2byte    4,   -9, 	   5,   -9, 	   2,   -2, 	  -2,   -7
+.2byte    2,   -9, 	   8,   -8, 	  -5,   -3, 	   1,   -7
+.2byte   -1,  -10, 	 -13,   -3, 	  12,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -13,   -3, 	  12,   -3, 	  -1,   -7
+.2byte    0,  -15, 	 -11,  -20, 	  10,  -20, 	  -1,  -12
+.2byte   -1,  -15, 	   2,  -21, 	 -11,  -15, 	   0,  -12
+.2byte    2,  -14, 	   1,  -19, 	  -8,  -11, 	   0,  -11
+.2byte    1,  -15, 	  -9,  -18, 	   2,  -12, 	  -1,   -9
+.2byte   -1,  -15, 	   9,  -13, 	 -10,  -13, 	  -1,   -8
+.2byte   -2,  -15, 	   8,  -18, 	  -3,  -12, 	   0,   -9
+.2byte   -3,  -14, 	  -2,  -19, 	   7,  -11, 	  -1,  -11
+.2byte    0,  -15, 	  -3,  -21, 	  10,  -15, 	  -1,  -12
+.2byte   -1,   -8, 	  -9,   -5, 	   8,   -5, 	  -1,   -7
+.2byte   -4,   -9, 	 -11,   -5, 	   7,   -8, 	  -4,   -8
+.2byte    3,   -9, 	  -8,   -8, 	  10,   -5, 	   3,   -8
+.2byte    2,   -9, 	   8,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    4,  -10, 	  10,   -7, 	  -6,   -6, 	   2,   -8
+.2byte    0,   -9, 	   6,  -10, 	  -6,   -2, 	  -1,   -7
+.2byte    4,   -9, 	   5,   -9, 	   2,   -2, 	  -2,   -7
+.2byte    7,  -10, 	   9,   -7, 	   3,   -3, 	   1,   -7
+.2byte    4,   -7, 	   4,  -10, 	   2,    0, 	  -2,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   8,   -6, 	  -2,   -7
+.2byte    1,  -13, 	  -4,  -12, 	   9,   -8, 	   1,   -8
+.2byte    3,  -12, 	  -2,  -13, 	  10,   -5, 	   1,   -7
+.2byte   -1,  -11, 	   9,   -8, 	 -10,   -8, 	   0,   -7
+.2byte    0,  -11, 	  10,   -6, 	 -11,   -8, 	   0,   -7
+.2byte   -1,  -11, 	  10,   -8, 	 -11,   -6, 	  -1,   -7
+.2byte   -3,  -12, 	   4,  -12, 	  -9,   -6, 	   1,   -7
+.2byte   -2,  -13, 	   3,  -12, 	 -10,   -8, 	  -2,   -8
+.2byte   -4,  -12, 	   1,  -13, 	 -11,   -5, 	  -2,   -7
+.2byte   -5,   -9, 	  -6,   -9, 	  -3,   -2, 	   1,   -7
+.2byte   -8,  -10, 	 -10,   -7, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,   -7, 	  -5,  -10, 	  -3,    0, 	   1,   -5
+.2byte   -3,   -9, 	  -9,   -8, 	   4,   -3, 	  -2,   -7
+.2byte   -5,  -10, 	 -11,   -7, 	   5,   -6, 	  -3,   -8
+.2byte   -1,   -9, 	  -7,  -10, 	   5,   -2, 	   0,   -7
+.2byte   -1,   -4, 	  -8,    1, 	   7,    1, 	  -1,   -6
+.2byte   -4,   -5, 	 -10,   -3, 	  -1,    2, 	  -1,   -5
+.2byte   -7,   -6, 	 -11,   -6, 	  -7,   -1, 	   0,   -7
+.2byte   -5,  -10, 	  -1,  -10, 	 -11,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   7,  -10, 	  -8,  -10, 	   0,   -8
+.2byte    4,  -10, 	   0,  -10, 	  10,   -4, 	   0,   -8
+.2byte    6,   -6, 	  10,   -6, 	   6,   -1, 	  -1,   -7
+.2byte    3,   -5, 	   9,   -3, 	   0,    2, 	   0,   -5
+.2byte   -2,   -8, 	 -13,  -11, 	   2,   -6, 	  -2,   -7
+.2byte    4,   -8, 	  12,   -5, 	 -12,   -7, 	   1,   -6
+.2byte    5,   -9, 	  13,   -9, 	  -5,   -2, 	   0,   -7
+.2byte    4,  -13, 	   8,  -15, 	   5,   -1, 	   0,   -8
+.2byte   -1,  -15, 	  10,   -4, 	  -6,  -18, 	  -1,   -9
+.2byte   -5,  -13, 	  10,  -12, 	 -11,  -13, 	  -1,   -8
+.2byte   -7,  -10, 	   0,   -9, 	 -11,   -7, 	  -1,   -7
+.2byte   -6,   -8, 	  -8,  -15, 	  -4,   -4, 	   1,   -6
+.2byte   -1,   -8, 	  -9,   -5, 	   8,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -8,    0, 	   7,    0, 	  -1,   -7
+.2byte    2,   -9, 	   8,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    2,   -5, 	   8,   -3, 	  -1,    2, 	  -1,   -5
+.2byte    4,   -9, 	   5,   -9, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -5, 	   9,   -5, 	   5,    0, 	  -2,   -6
+.2byte    1,  -12, 	  -6,  -12, 	   7,   -6, 	  -3,   -7
+.2byte    2,  -11, 	  -2,  -11, 	   8,   -5, 	  -2,   -9
+.2byte   -1,  -10, 	   9,   -7, 	 -10,   -7, 	   0,   -6
+.2byte   -1,  -12, 	   7,  -10, 	  -8,  -10, 	   0,   -8
+.2byte   -3,  -12, 	   4,  -12, 	  -9,   -6, 	   1,   -7
+.2byte   -4,  -10, 	   0,  -10, 	 -10,   -4, 	   0,   -8
+.2byte   -5,   -9, 	  -6,   -9, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -5, 	 -10,   -5, 	  -6,    0, 	   1,   -6
+.2byte   -3,   -9, 	  -9,   -8, 	   4,   -3, 	  -2,   -7
+.2byte   -3,   -5, 	  -9,   -3, 	   0,    2, 	   0,   -5
+.2byte   -1,   -4, 	  -8,    1, 	   7,    1, 	  -1,   -6
+.2byte   -4,   -5, 	 -10,   -3, 	  -1,    2, 	  -1,   -5
+.2byte   -6,   -6, 	 -10,   -6, 	  -6,   -1, 	   1,   -7
+.2byte   -4,  -10, 	   0,  -10, 	 -10,   -4, 	   0,   -8
+.2byte   -1,  -12, 	   7,  -10, 	  -8,  -10, 	   0,   -8
+.2byte    3,  -10, 	  -1,  -10, 	   9,   -4, 	  -1,   -8
+.2byte    5,   -6, 	   9,   -6, 	   5,   -1, 	  -2,   -7
+.2byte    3,   -5, 	   9,   -3, 	   0,    2, 	   0,   -5
+.2byte   -1,   -8, 	  -9,   -5, 	   8,   -5, 	  -1,   -7
+.2byte   -3,   -9, 	  -9,   -8, 	   4,   -3, 	  -2,   -7
+.2byte   -5,   -9, 	  -6,   -9, 	  -3,   -2, 	   1,   -7
+.2byte   -3,  -12, 	   4,  -12, 	  -9,   -6, 	   1,   -7
+.2byte   -1,  -11, 	   9,   -8, 	 -10,   -8, 	   0,   -7
+.2byte    2,  -12, 	  -5,  -12, 	   8,   -6, 	  -2,   -7
+.2byte    4,   -9, 	   5,   -9, 	   2,   -2, 	  -2,   -7
+.2byte    2,   -9, 	   8,   -8, 	  -5,   -3, 	   1,   -7
+sMakuhitaAnimTable1:
+.4byte sMakuhitaAnims_1_1
+.4byte sMakuhitaAnims_1_2
+.4byte sMakuhitaAnims_1_3
+.4byte sMakuhitaAnims_1_4
+.4byte sMakuhitaAnims_1_5
+.4byte sMakuhitaAnims_1_6
+.4byte sMakuhitaAnims_1_7
+.4byte sMakuhitaAnims_1_8
+sMakuhitaAnimTable2:
+.4byte sMakuhitaAnims_2_1
+.4byte sMakuhitaAnims_2_2
+.4byte sMakuhitaAnims_2_3
+.4byte sMakuhitaAnims_2_4
+.4byte sMakuhitaAnims_2_5
+.4byte sMakuhitaAnims_2_6
+.4byte sMakuhitaAnims_2_7
+.4byte sMakuhitaAnims_2_8
+sMakuhitaAnimTable3:
+.4byte sMakuhitaAnims_3_1
+.4byte sMakuhitaAnims_3_2
+.4byte sMakuhitaAnims_3_3
+.4byte sMakuhitaAnims_3_4
+.4byte sMakuhitaAnims_3_5
+.4byte sMakuhitaAnims_3_6
+.4byte sMakuhitaAnims_3_7
+.4byte sMakuhitaAnims_3_8
+sMakuhitaAnimTable4:
+.4byte sMakuhitaAnims_4_1
+.4byte sMakuhitaAnims_4_2
+.4byte sMakuhitaAnims_4_3
+.4byte sMakuhitaAnims_4_4
+.4byte sMakuhitaAnims_4_5
+.4byte sMakuhitaAnims_4_6
+.4byte sMakuhitaAnims_4_7
+.4byte sMakuhitaAnims_4_8
+sMakuhitaAnimTable5:
+.4byte sMakuhitaAnims_5_1
+.4byte sMakuhitaAnims_5_2
+.4byte sMakuhitaAnims_5_3
+.4byte sMakuhitaAnims_5_4
+.4byte sMakuhitaAnims_5_5
+.4byte sMakuhitaAnims_5_6
+.4byte sMakuhitaAnims_5_7
+.4byte sMakuhitaAnims_5_8
+sMakuhitaAnimTable6:
+.4byte sMakuhitaAnims_6_1
+.4byte sMakuhitaAnims_6_1
+.4byte sMakuhitaAnims_6_1
+.4byte sMakuhitaAnims_6_1
+.4byte sMakuhitaAnims_6_1
+.4byte sMakuhitaAnims_6_1
+.4byte sMakuhitaAnims_6_1
+.4byte sMakuhitaAnims_6_1
+sMakuhitaAnimTable7:
+.4byte sMakuhitaAnims_7_1
+.4byte sMakuhitaAnims_7_2
+.4byte sMakuhitaAnims_7_3
+.4byte sMakuhitaAnims_7_4
+.4byte sMakuhitaAnims_7_5
+.4byte sMakuhitaAnims_7_6
+.4byte sMakuhitaAnims_7_7
+.4byte sMakuhitaAnims_7_8
+sMakuhitaAnimTable8:
+.4byte sMakuhitaAnims_8_1
+.4byte sMakuhitaAnims_8_2
+.4byte sMakuhitaAnims_8_3
+.4byte sMakuhitaAnims_8_4
+.4byte sMakuhitaAnims_8_5
+.4byte sMakuhitaAnims_8_6
+.4byte sMakuhitaAnims_8_7
+.4byte sMakuhitaAnims_8_8
+sMakuhitaAnimTable9:
+.4byte sMakuhitaAnims_9_1
+.4byte sMakuhitaAnims_9_2
+.4byte sMakuhitaAnims_9_3
+.4byte sMakuhitaAnims_9_4
+.4byte sMakuhitaAnims_9_5
+.4byte sMakuhitaAnims_9_6
+.4byte sMakuhitaAnims_9_7
+.4byte sMakuhitaAnims_9_8
+sMakuhitaAnimTable10:
+.4byte sMakuhitaAnims_10_1
+.4byte sMakuhitaAnims_10_2
+.4byte sMakuhitaAnims_10_3
+.4byte sMakuhitaAnims_10_4
+.4byte sMakuhitaAnims_10_5
+.4byte sMakuhitaAnims_10_6
+.4byte sMakuhitaAnims_10_7
+.4byte sMakuhitaAnims_10_8
+sMakuhitaAnimTable11:
+.4byte sMakuhitaAnims_11_1
+.4byte sMakuhitaAnims_11_2
+.4byte sMakuhitaAnims_11_3
+.4byte sMakuhitaAnims_11_4
+.4byte sMakuhitaAnims_11_5
+.4byte sMakuhitaAnims_11_6
+.4byte sMakuhitaAnims_11_7
+.4byte sMakuhitaAnims_11_8
+sMakuhitaAnimTable12:
+.4byte sMakuhitaAnims_12_1
+.4byte sMakuhitaAnims_12_2
+.4byte sMakuhitaAnims_12_3
+.4byte sMakuhitaAnims_12_4
+.4byte sMakuhitaAnims_12_5
+.4byte sMakuhitaAnims_12_6
+.4byte sMakuhitaAnims_12_7
+.4byte sMakuhitaAnims_12_8
+sMakuhitaAnimTable13:
+.4byte sMakuhitaAnims_13_1
+.4byte sMakuhitaAnims_13_2
+.4byte sMakuhitaAnims_13_3
+.4byte sMakuhitaAnims_13_4
+.4byte sMakuhitaAnims_13_5
+.4byte sMakuhitaAnims_13_6
+.4byte sMakuhitaAnims_13_7
+.4byte sMakuhitaAnims_13_8
+sAxAnimationsMakuhita:
+.4byte sMakuhitaAnimTable1
+.4byte sMakuhitaAnimTable2
+.4byte sMakuhitaAnimTable3
+.4byte sMakuhitaAnimTable4
+.4byte sMakuhitaAnimTable5
+.4byte sMakuhitaAnimTable6
+.4byte sMakuhitaAnimTable7
+.4byte sMakuhitaAnimTable8
+.4byte sMakuhitaAnimTable9
+.4byte sMakuhitaAnimTable10
+.4byte sMakuhitaAnimTable11
+.4byte sMakuhitaAnimTable12
+.4byte sMakuhitaAnimTable13
+sAxSpritesMakuhita:
+.4byte sMakuhitaSprites1
+.4byte sMakuhitaSprites2
+.4byte sMakuhitaSprites3
+.4byte sMakuhitaSprites4
+.4byte sMakuhitaSprites5
+.4byte sMakuhitaSprites6
+.4byte sMakuhitaSprites7
+.4byte sMakuhitaSprites8
+.4byte sMakuhitaSprites9
+.4byte sMakuhitaSprites10
+.4byte sMakuhitaSprites11
+.4byte sMakuhitaSprites12
+.4byte sMakuhitaSprites13
+.4byte sMakuhitaSprites14
+.4byte sMakuhitaSprites15
+.4byte sMakuhitaSprites16
+.4byte sMakuhitaSprites17
+.4byte sMakuhitaSprites18
+.4byte sMakuhitaSprites19
+.4byte sMakuhitaSprites20
+.4byte sMakuhitaSprites21
+.4byte sMakuhitaSprites22
+.4byte sMakuhitaSprites23
+.4byte sMakuhitaSprites24
+.4byte sMakuhitaSprites25
+.4byte sMakuhitaSprites26
+.4byte sMakuhitaSprites27
+.4byte sMakuhitaSprites28
+.4byte sMakuhitaSprites29
+.4byte sMakuhitaSprites30
+.4byte sMakuhitaSprites31
+.4byte sMakuhitaSprites32
+.4byte sMakuhitaSprites33
+.4byte sMakuhitaSprites34
+.4byte sMakuhitaSprites35
+.4byte sMakuhitaSprites36
+.4byte sMakuhitaSprites37
+sAxMainMakuhita:
+ax_main sAxPosesMakuhita, sAxAnimationsMakuhita, 13, sAxSpritesMakuhita, sAxPositionsMakuhita

--- a/data/ax/manectric.inc
+++ b/data/ax/manectric.inc
@@ -1,0 +1,3533 @@
+.global gAxManectric
+gAxManectric:
+ax_siro sAxMainManectric
+sManectricPose1:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose2:
+ax_pose 1, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose3:
+ax_pose 2, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose4:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose5:
+ax_pose 4, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose6:
+ax_pose 5, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose8:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose10:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose11:
+ax_pose 10, 0x0205, 0x10f8, 0x0c00
+ax_pose 11, 0x81e5, 0x50f4, 0x0c01
+ax_pose 12, 0x81e5, 0x90fc, 0x0c05
+ax_pose_terminator
+sManectricPose12:
+ax_pose 13, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sManectricPose13:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose14:
+ax_pose 15, 0x81e5, 0x80f8, 0x0c00
+ax_pose 16, 0x0205, 0x00f8, 0x0c08
+ax_pose_terminator
+sManectricPose15:
+ax_pose 17, 0x81e5, 0x80f8, 0x0c00
+ax_pose 18, 0x0205, 0x0100, 0x0c08
+ax_pose_terminator
+sManectricPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose17:
+ax_pose 10, 0x0205, 0x0100, 0x0c00
+ax_pose 12, 0x81e5, 0x80f4, 0x0c01
+ax_pose 11, 0x81e5, 0x4104, 0x0c09
+ax_pose_terminator
+sManectricPose18:
+ax_pose 13, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sManectricPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose22:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose23:
+ax_pose 4, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose24:
+ax_pose 5, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose25:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose26:
+ax_pose 1, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose27:
+ax_pose 2, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose28:
+ax_pose 19, 0x81e0, 0x80f4, 0x0c00
+ax_pose 20, 0x81e0, 0x4104, 0x0c08
+ax_pose 21, 0x0200, 0x00fc, 0x0c0c
+ax_pose_terminator
+sManectricPose29:
+ax_pose 22, 0x81e3, 0x80f4, 0x0c00
+ax_pose 23, 0x81e3, 0x4104, 0x0c08
+ax_pose 24, 0x0203, 0x00fc, 0x0c0c
+ax_pose_terminator
+sManectricPose30:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose31:
+ax_pose 4, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose32:
+ax_pose 5, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose33:
+ax_pose 25, 0x01e3, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose34:
+ax_pose 26, 0x01e7, 0x90f3, 0x0c00
+ax_pose_terminator
+sManectricPose35:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose36:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose37:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose38:
+ax_pose 27, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose39:
+ax_pose 28, 0x01e3, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose40:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose41:
+ax_pose 10, 0x0205, 0x10f8, 0x0c00
+ax_pose 11, 0x81e5, 0x50f4, 0x0c01
+ax_pose 12, 0x81e5, 0x90fc, 0x0c05
+ax_pose_terminator
+sManectricPose42:
+ax_pose 13, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sManectricPose43:
+ax_pose 29, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose44:
+ax_pose 30, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose45:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose46:
+ax_pose 15, 0x81e5, 0x80f8, 0x0c00
+ax_pose 16, 0x0205, 0x00f8, 0x0c08
+ax_pose_terminator
+sManectricPose47:
+ax_pose 17, 0x81e5, 0x80f8, 0x0c00
+ax_pose 18, 0x0205, 0x0100, 0x0c08
+ax_pose_terminator
+sManectricPose48:
+ax_pose 31, 0x01df, 0x80f3, 0x0c00
+ax_pose_terminator
+sManectricPose49:
+ax_pose 32, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose50:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose51:
+ax_pose 10, 0x0205, 0x0100, 0x0c00
+ax_pose 12, 0x81e5, 0x80f4, 0x0c01
+ax_pose 11, 0x81e5, 0x4104, 0x0c09
+ax_pose_terminator
+sManectricPose52:
+ax_pose 13, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sManectricPose53:
+ax_pose 29, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose54:
+ax_pose 30, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose55:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose56:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose57:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose58:
+ax_pose 27, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose59:
+ax_pose 28, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose60:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose61:
+ax_pose 4, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose62:
+ax_pose 5, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose63:
+ax_pose 25, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose64:
+ax_pose 26, 0x01e7, 0x80ed, 0x0c00
+ax_pose_terminator
+sManectricPose65:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose66:
+ax_pose 1, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose67:
+ax_pose 2, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose68:
+ax_pose 19, 0x81e0, 0x80f4, 0x0c00
+ax_pose 20, 0x81e0, 0x4104, 0x0c08
+ax_pose 21, 0x0200, 0x00fc, 0x0c0c
+ax_pose_terminator
+sManectricPose69:
+ax_pose 22, 0x81e3, 0x80f4, 0x0c00
+ax_pose 23, 0x81e3, 0x4104, 0x0c08
+ax_pose 24, 0x0203, 0x00fc, 0x0c0c
+ax_pose_terminator
+sManectricPose70:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose71:
+ax_pose 4, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose72:
+ax_pose 5, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose73:
+ax_pose 25, 0x01e3, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose74:
+ax_pose 26, 0x01e7, 0x90f3, 0x0c00
+ax_pose_terminator
+sManectricPose75:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose76:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose77:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose78:
+ax_pose 27, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose79:
+ax_pose 28, 0x01e3, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose80:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose81:
+ax_pose 10, 0x0205, 0x10f8, 0x0c00
+ax_pose 11, 0x81e5, 0x50f4, 0x0c01
+ax_pose 12, 0x81e5, 0x90fc, 0x0c05
+ax_pose_terminator
+sManectricPose82:
+ax_pose 13, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sManectricPose83:
+ax_pose 29, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose84:
+ax_pose 30, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose85:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose86:
+ax_pose 15, 0x81e5, 0x80f8, 0x0c00
+ax_pose 16, 0x0205, 0x00f8, 0x0c08
+ax_pose_terminator
+sManectricPose87:
+ax_pose 17, 0x81e5, 0x80f8, 0x0c00
+ax_pose 18, 0x0205, 0x0100, 0x0c08
+ax_pose_terminator
+sManectricPose88:
+ax_pose 31, 0x01df, 0x80f3, 0x0c00
+ax_pose_terminator
+sManectricPose89:
+ax_pose 32, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose90:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose91:
+ax_pose 10, 0x0205, 0x0100, 0x0c00
+ax_pose 12, 0x81e5, 0x80f4, 0x0c01
+ax_pose 11, 0x81e5, 0x4104, 0x0c09
+ax_pose_terminator
+sManectricPose92:
+ax_pose 13, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sManectricPose93:
+ax_pose 29, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose94:
+ax_pose 30, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose95:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose96:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose97:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose98:
+ax_pose 27, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose99:
+ax_pose 28, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose100:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose101:
+ax_pose 4, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose102:
+ax_pose 5, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose103:
+ax_pose 25, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose104:
+ax_pose 26, 0x01e7, 0x80ed, 0x0c00
+ax_pose_terminator
+sManectricPose105:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose106:
+ax_pose 33, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose107:
+ax_pose 34, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose108:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose109:
+ax_pose 35, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose110:
+ax_pose 36, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose111:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose112:
+ax_pose 37, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose113:
+ax_pose 38, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose114:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose115:
+ax_pose 39, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose116:
+ax_pose 40, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose117:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose118:
+ax_pose 41, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose119:
+ax_pose 42, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose120:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose121:
+ax_pose 39, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose122:
+ax_pose 40, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose123:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose124:
+ax_pose 37, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose125:
+ax_pose 38, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose126:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose127:
+ax_pose 35, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose128:
+ax_pose 36, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose129:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose130:
+ax_pose 34, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose131:
+ax_pose 43, 0x81e2, 0x40ed, 0x0c00
+ax_pose 44, 0x41e2, 0x80f5, 0x0c04
+ax_pose 45, 0x01f2, 0x4105, 0x0c0c
+ax_pose 46, 0x01da, 0x00fd, 0x0c10
+ax_pose 47, 0x01e7, 0x80f4, 0x0c11
+ax_pose_terminator
+sManectricPose132:
+ax_pose 48, 0x81dc, 0x80e9, 0x0c00
+ax_pose 49, 0x41fc, 0x00e9, 0x0c08
+ax_pose 50, 0x41dc, 0x80f9, 0x0c0a
+ax_pose 51, 0x01ec, 0x4109, 0x0c12
+ax_pose 52, 0x41fc, 0x0109, 0x0c16
+ax_pose 53, 0x01d4, 0x00f9, 0x0c18
+ax_pose 54, 0x01e7, 0x80f4, 0x0c19
+ax_pose_terminator
+sManectricPose133:
+ax_pose 47, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose134:
+ax_pose 54, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose135:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose136:
+ax_pose 36, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose137:
+ax_pose 55, 0x81e1, 0x510b, 0x0c00
+ax_pose 56, 0x81e1, 0x1103, 0x0c04
+ax_pose 57, 0x81d9, 0x10fb, 0x0c06
+ax_pose 58, 0x81e1, 0x90eb, 0x0c08
+ax_pose 59, 0x4201, 0x10eb, 0x0c10
+ax_pose 60, 0x01e6, 0x90f2, 0x0c12
+ax_pose_terminator
+sManectricPose138:
+ax_pose 61, 0x81d8, 0x9109, 0x0c00
+ax_pose 62, 0x41f8, 0x1109, 0x0c08
+ax_pose 63, 0x41d8, 0x90e9, 0x0c0a
+ax_pose 64, 0x81e8, 0x90e9, 0x0c12
+ax_pose 65, 0x01e8, 0x10f9, 0x0c1a
+ax_pose 66, 0x01e6, 0x90f2, 0x0c1b
+ax_pose_terminator
+sManectricPose139:
+ax_pose 60, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose140:
+ax_pose 66, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose141:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose142:
+ax_pose 38, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose143:
+ax_pose 43, 0x81e0, 0x40ed, 0x0c00
+ax_pose 44, 0x41e0, 0x80f5, 0x0c04
+ax_pose 45, 0x01f0, 0x4105, 0x0c0c
+ax_pose 46, 0x01d8, 0x00fd, 0x0c10
+ax_pose 67, 0x01e4, 0x90f1, 0x0c11
+ax_pose_terminator
+sManectricPose144:
+ax_pose 48, 0x81da, 0x80e9, 0x0c00
+ax_pose 49, 0x41fa, 0x00e9, 0x0c08
+ax_pose 50, 0x41da, 0x80f9, 0x0c0a
+ax_pose 51, 0x01ea, 0x4109, 0x0c12
+ax_pose 52, 0x41fa, 0x0109, 0x0c16
+ax_pose 53, 0x01d2, 0x00f9, 0x0c18
+ax_pose 68, 0x01e4, 0x90f1, 0x0c19
+ax_pose_terminator
+sManectricPose145:
+ax_pose 67, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose146:
+ax_pose 68, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose147:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose148:
+ax_pose 40, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose149:
+ax_pose 55, 0x81e0, 0x40ed, 0x0c00
+ax_pose 56, 0x81e0, 0x00f5, 0x0c04
+ax_pose 57, 0x81d8, 0x00fd, 0x0c06
+ax_pose 58, 0x81e0, 0x8105, 0x0c08
+ax_pose 59, 0x4200, 0x0105, 0x0c10
+ax_pose 69, 0x01e5, 0x90f0, 0x0c12
+ax_pose_terminator
+sManectricPose150:
+ax_pose 61, 0x81d7, 0x80e7, 0x0c00
+ax_pose 62, 0x41f7, 0x00e7, 0x0c08
+ax_pose 63, 0x41d7, 0x80f7, 0x0c0a
+ax_pose 64, 0x81e7, 0x8107, 0x0c12
+ax_pose 65, 0x01e7, 0x00ff, 0x0c1a
+ax_pose 70, 0x01e5, 0x90f0, 0x0c1b
+ax_pose_terminator
+sManectricPose151:
+ax_pose 69, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose152:
+ax_pose 70, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose153:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose154:
+ax_pose 42, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose155:
+ax_pose 43, 0x81e2, 0x40ed, 0x0c00
+ax_pose 44, 0x41e2, 0x80f5, 0x0c04
+ax_pose 45, 0x01f2, 0x4105, 0x0c0c
+ax_pose 46, 0x01da, 0x00fd, 0x0c10
+ax_pose 71, 0x01e5, 0x80f4, 0x0c11
+ax_pose_terminator
+sManectricPose156:
+ax_pose 48, 0x81dc, 0x80e9, 0x0c00
+ax_pose 49, 0x41fc, 0x00e9, 0x0c08
+ax_pose 50, 0x41dc, 0x80f9, 0x0c0a
+ax_pose 51, 0x01ec, 0x4109, 0x0c12
+ax_pose 52, 0x41fc, 0x0109, 0x0c16
+ax_pose 53, 0x01d4, 0x00f9, 0x0c18
+ax_pose 72, 0x01e5, 0x80f4, 0x0c19
+ax_pose_terminator
+sManectricPose157:
+ax_pose 71, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose158:
+ax_pose 72, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose159:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose160:
+ax_pose 40, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose161:
+ax_pose 55, 0x81e0, 0x510b, 0x0c00
+ax_pose 56, 0x81e0, 0x1103, 0x0c04
+ax_pose 57, 0x81d8, 0x10fb, 0x0c06
+ax_pose 58, 0x81e0, 0x90eb, 0x0c08
+ax_pose 59, 0x4200, 0x10eb, 0x0c10
+ax_pose 69, 0x01e5, 0x80f0, 0x0c12
+ax_pose_terminator
+sManectricPose162:
+ax_pose 61, 0x81d7, 0x9109, 0x0c00
+ax_pose 62, 0x41f7, 0x1109, 0x0c08
+ax_pose 63, 0x41d7, 0x90e9, 0x0c0a
+ax_pose 64, 0x81e7, 0x90e9, 0x0c12
+ax_pose 65, 0x01e7, 0x10f9, 0x0c1a
+ax_pose 70, 0x01e5, 0x80f0, 0x0c1b
+ax_pose_terminator
+sManectricPose163:
+ax_pose 69, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose164:
+ax_pose 70, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose165:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose166:
+ax_pose 38, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose167:
+ax_pose 43, 0x81e0, 0x40ed, 0x0c00
+ax_pose 44, 0x41e0, 0x80f5, 0x0c04
+ax_pose 45, 0x01f0, 0x4105, 0x0c0c
+ax_pose 46, 0x01d8, 0x00fd, 0x0c10
+ax_pose 67, 0x01e4, 0x80ef, 0x0c11
+ax_pose_terminator
+sManectricPose168:
+ax_pose 48, 0x81da, 0x80e9, 0x0c00
+ax_pose 49, 0x41fa, 0x00e9, 0x0c08
+ax_pose 50, 0x41da, 0x80f9, 0x0c0a
+ax_pose 51, 0x01ea, 0x4109, 0x0c12
+ax_pose 52, 0x41fa, 0x0109, 0x0c16
+ax_pose 53, 0x01d2, 0x00f9, 0x0c18
+ax_pose 68, 0x01e4, 0x80ef, 0x0c19
+ax_pose_terminator
+sManectricPose169:
+ax_pose 67, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose170:
+ax_pose 68, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose171:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose172:
+ax_pose 36, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose173:
+ax_pose 55, 0x81e1, 0x40ed, 0x0c00
+ax_pose 56, 0x81e1, 0x00f5, 0x0c04
+ax_pose 57, 0x81d9, 0x00fd, 0x0c06
+ax_pose 58, 0x81e1, 0x8105, 0x0c08
+ax_pose 59, 0x4201, 0x0105, 0x0c10
+ax_pose 60, 0x01e6, 0x80ee, 0x0c12
+ax_pose_terminator
+sManectricPose174:
+ax_pose 61, 0x81d8, 0x80e7, 0x0c00
+ax_pose 62, 0x41f8, 0x00e7, 0x0c08
+ax_pose 63, 0x41d8, 0x80f7, 0x0c0a
+ax_pose 64, 0x81e8, 0x8107, 0x0c12
+ax_pose 65, 0x01e8, 0x00ff, 0x0c1a
+ax_pose 66, 0x01e6, 0x80ee, 0x0c1b
+ax_pose_terminator
+sManectricPose175:
+ax_pose 60, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose176:
+ax_pose 66, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose177:
+ax_pose 73, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose178:
+ax_pose 74, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose179:
+ax_pose 75, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose180:
+ax_pose 76, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose181:
+ax_pose 77, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sManectricPose182:
+ax_pose 78, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sManectricPose183:
+ax_pose 79, 0x81e4, 0x4103, 0x0c00
+ax_pose 80, 0x01dc, 0x00fb, 0x0c04
+ax_pose 81, 0x81e4, 0x80f3, 0x0c05
+ax_pose_terminator
+sManectricPose184:
+ax_pose 78, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sManectricPose185:
+ax_pose 77, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sManectricPose186:
+ax_pose 76, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose187:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose188:
+ax_pose 34, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose189:
+ax_pose 47, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose190:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose191:
+ax_pose 36, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose192:
+ax_pose 60, 0x01e6, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose193:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose194:
+ax_pose 38, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose195:
+ax_pose 67, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose196:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose197:
+ax_pose 40, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose198:
+ax_pose 69, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose199:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose200:
+ax_pose 42, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose201:
+ax_pose 71, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose202:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose203:
+ax_pose 40, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose204:
+ax_pose 69, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose205:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose206:
+ax_pose 38, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose207:
+ax_pose 67, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose208:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose209:
+ax_pose 36, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose210:
+ax_pose 60, 0x01e6, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose211:
+ax_pose 19, 0x81e3, 0x80f4, 0x0c00
+ax_pose 20, 0x81e3, 0x4104, 0x0c08
+ax_pose 21, 0x0203, 0x00fc, 0x0c0c
+ax_pose_terminator
+sManectricPose212:
+ax_pose 25, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sManectricPose213:
+ax_pose 27, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose214:
+ax_pose 29, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose215:
+ax_pose 31, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sManectricPose216:
+ax_pose 29, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose217:
+ax_pose 27, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose218:
+ax_pose 25, 0x01e3, 0x90ef, 0x0c00
+ax_pose_terminator
+sManectricPose219:
+ax_pose 33, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose220:
+ax_pose 35, 0x01e7, 0x90f2, 0x0c00
+ax_pose_terminator
+sManectricPose221:
+ax_pose 37, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose222:
+ax_pose 39, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose223:
+ax_pose 41, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose224:
+ax_pose 39, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose225:
+ax_pose 37, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose226:
+ax_pose 35, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sManectricPose227:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose228:
+ax_pose 33, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose229:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose230:
+ax_pose 35, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose231:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose232:
+ax_pose 37, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose233:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose234:
+ax_pose 39, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sManectricPose235:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose236:
+ax_pose 41, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose237:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose238:
+ax_pose 39, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose239:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose240:
+ax_pose 37, 0x01e4, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose241:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose242:
+ax_pose 35, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sManectricPose243:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose244:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose245:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose246:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose247:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose248:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose249:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose250:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sManectricPose251:
+ax_pose 0, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose252:
+ax_pose 3, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sManectricPose253:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sManectricPose254:
+ax_pose 9, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sManectricPose255:
+ax_pose 14, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sManectricPose256:
+ax_pose 9, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sManectricPose257:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sManectricPose258:
+ax_pose 3, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sManectricAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_2_1:
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, -6, 0, -6,
+ax_anim 6, 0, 24, 0, -8, 0, -8,
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 2, 0, 28, 0, 5, 0, 5,
+ax_anim 2, 2, 27, 0, 9, 0, 9,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, -1, 18, -1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, -1, 18, -1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 0, 11, 0, 11,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sManectricAnims_2_2:
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim 6, 0, 29, -8, -8, -8, -8,
+ax_anim 2, 0, 32, -2, -2, -2, -2,
+ax_anim 2, 0, 33, 7, 7, 7, 7,
+ax_anim 2, 2, 32, 11, 12, 11, 12,
+ax_anim 2, 0, 33, 18, 20, 18, 20,
+ax_anim 2, 1, 33, 17, 21, 17, 21,
+ax_anim 2, 0, 33, 18, 20, 18, 20,
+ax_anim 2, 0, 33, 17, 21, 17, 21,
+ax_anim 2, 0, 33, 18, 20, 18, 20,
+ax_anim 2, 0, 30, 10, 12, 10, 12,
+ax_anim 2, 0, 29, 3, 4, 3, 4,
+ax_anim_terminator
+sManectricAnims_2_3:
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 2, 0, 36, -6, 0, -6, 0,
+ax_anim 6, 0, 34, -8, 0, -8, 0,
+ax_anim 2, 0, 37, -2, 0, -2, 0,
+ax_anim 2, 0, 38, 5, 0, 5, 0,
+ax_anim 2, 2, 37, 11, 0, 11, 0,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 1, 38, 16, 1, 16, 1,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 0, 38, 16, 1, 16, 1,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sManectricAnims_2_4:
+ax_anim 2, 0, 40, -3, 3, -3, 3,
+ax_anim 2, 0, 41, -6, 6, -6, 6,
+ax_anim 6, 0, 39, -8, 8, -8, 8,
+ax_anim 2, 0, 42, -2, 2, -2, 2,
+ax_anim 2, 0, 43, 8, -9, 8, -9,
+ax_anim 2, 2, 42, 11, -12, 11, -12,
+ax_anim 2, 0, 43, 17, -18, 17, -18,
+ax_anim 2, 1, 43, 16, -19, 16, -19,
+ax_anim 2, 0, 43, 17, -18, 17, -18,
+ax_anim 2, 0, 43, 16, -19, 16, -19,
+ax_anim 2, 0, 43, 17, -18, 17, -18,
+ax_anim 2, 0, 40, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 4, -5, 4, -5,
+ax_anim_terminator
+sManectricAnims_2_5:
+ax_anim 2, 0, 45, 0, 3, 0, 3,
+ax_anim 2, 0, 46, 0, 6, 0, 6,
+ax_anim 6, 0, 44, 0, 8, 0, 8,
+ax_anim 2, 0, 47, 0, 2, 0, 2,
+ax_anim 2, 0, 48, 0, -7, 0, -7,
+ax_anim 2, 2, 47, 0, -9, 0, -9,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 1, 48, -1, -16, -1, -16,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 0, 48, -1, -16, -1, -16,
+ax_anim 2, 0, 48, 0, -16, 0, -16,
+ax_anim 2, 0, 45, 0, -11, 0, -11,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sManectricAnims_2_6:
+ax_anim 2, 0, 50, 3, 3, 3, 3,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim 6, 0, 49, 8, 8, 8, 8,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim 2, 0, 53, -8, -9, -8, -9,
+ax_anim 2, 2, 52, -11, -12, -11, -12,
+ax_anim 2, 0, 53, -17, -18, -17, -18,
+ax_anim 2, 1, 53, -16, -19, -16, -19,
+ax_anim 2, 0, 53, -17, -18, -17, -18,
+ax_anim 2, 0, 53, -16, -19, -16, -19,
+ax_anim 2, 0, 53, -17, -18, -17, -18,
+ax_anim 2, 0, 50, -11, -13, -11, -13,
+ax_anim 2, 0, 49, -4, -5, -4, -5,
+ax_anim_terminator
+sManectricAnims_2_7:
+ax_anim 2, 0, 55, 3, 0, 3, 0,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim 6, 0, 54, 8, 0, 8, 0,
+ax_anim 2, 0, 57, 2, 0, 2, 0,
+ax_anim 2, 0, 58, -5, 0, -5, 0,
+ax_anim 2, 2, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 1, 58, -16, 1, -16, 1,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 0, 58, -16, 1, -16, 1,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 0, 55, -11, 0, -11, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sManectricAnims_2_8:
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim 2, 0, 61, 6, -6, 6, -6,
+ax_anim 6, 0, 59, 8, -8, 8, -8,
+ax_anim 2, 0, 62, 2, -2, 2, -2,
+ax_anim 2, 0, 63, -7, 7, -7, 7,
+ax_anim 2, 2, 62, -11, 12, -11, 12,
+ax_anim 2, 0, 63, -18, 20, -18, 20,
+ax_anim 2, 1, 63, -17, 21, -17, 21,
+ax_anim 2, 0, 63, -18, 20, -18, 20,
+ax_anim 2, 0, 63, -17, 21, -17, 21,
+ax_anim 2, 0, 63, -18, 20, -18, 20,
+ax_anim 2, 0, 60, -10, 12, -10, 12,
+ax_anim 2, 0, 59, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sManectricAnims_3_1:
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 66, 0, -6, 0, -6,
+ax_anim 6, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 67, 0, -2, 0, -2,
+ax_anim 2, 0, 68, 0, 13, 0, 13,
+ax_anim 2, 2, 67, 0, 25, 0, 25,
+ax_anim 2, 0, 68, 0, 42, 0, 42,
+ax_anim 2, 1, 68, -1, 42, -1, 42,
+ax_anim 2, 0, 68, 0, 42, 0, 42,
+ax_anim 2, 0, 68, -1, 42, -1, 42,
+ax_anim 2, 0, 68, 0, 42, 0, 42,
+ax_anim 2, 0, 65, 0, 11, 0, 11,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sManectricAnims_3_2:
+ax_anim 2, 0, 70, -3, -3, -3, -3,
+ax_anim 2, 0, 71, -6, -6, -6, -6,
+ax_anim 6, 0, 69, -8, -8, -8, -8,
+ax_anim 2, 0, 72, -2, -2, -2, -2,
+ax_anim 2, 0, 73, 7, 7, 7, 7,
+ax_anim 2, 2, 72, 19, 20, 19, 20,
+ax_anim 2, 0, 73, 34, 36, 34, 36,
+ax_anim 2, 1, 73, 41, 45, 41, 45,
+ax_anim 2, 0, 73, 42, 44, 42, 44,
+ax_anim 2, 0, 73, 41, 45, 41, 45,
+ax_anim 2, 0, 73, 42, 44, 42, 44,
+ax_anim 2, 0, 70, 10, 12, 10, 12,
+ax_anim 2, 0, 69, 3, 4, 3, 4,
+ax_anim_terminator
+sManectricAnims_3_3:
+ax_anim 2, 0, 75, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -6, 0, -6, 0,
+ax_anim 6, 0, 74, -8, 0, -8, 0,
+ax_anim 2, 0, 77, -2, 0, -2, 0,
+ax_anim 2, 0, 78, 5, 0, 5, 0,
+ax_anim 2, 2, 77, 19, 0, 19, 0,
+ax_anim 2, 0, 78, 32, 0, 32, 0,
+ax_anim 2, 1, 78, 40, 1, 40, 1,
+ax_anim 2, 0, 78, 40, 0, 40, 0,
+ax_anim 2, 0, 78, 40, 1, 40, 1,
+ax_anim 2, 0, 78, 40, 0, 40, 0,
+ax_anim 2, 0, 75, 11, 0, 11, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sManectricAnims_3_4:
+ax_anim 2, 0, 80, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -6, 6, -6, 6,
+ax_anim 6, 0, 79, -8, 8, -8, 8,
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 2, 0, 83, 8, -9, 8, -9,
+ax_anim 2, 2, 82, 19, -20, 19, -20,
+ax_anim 2, 0, 83, 33, -34, 33, -34,
+ax_anim 2, 1, 83, 40, -43, 40, -43,
+ax_anim 2, 0, 83, 41, -42, 41, -42,
+ax_anim 2, 0, 83, 40, -43, 40, -43,
+ax_anim 2, 0, 83, 41, -42, 41, -42,
+ax_anim 2, 0, 80, 11, -13, 11, -13,
+ax_anim 2, 0, 79, 4, -5, 4, -5,
+ax_anim_terminator
+sManectricAnims_3_5:
+ax_anim 2, 0, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 86, 0, 6, 0, 6,
+ax_anim 6, 0, 84, 0, 8, 0, 8,
+ax_anim 2, 0, 87, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, -7, 0, -7,
+ax_anim 2, 2, 87, 0, -17, 0, -17,
+ax_anim 2, 0, 88, 0, -32, 0, -32,
+ax_anim 2, 1, 88, -1, -40, -1, -40,
+ax_anim 2, 0, 88, 0, -40, 0, -40,
+ax_anim 2, 0, 88, -1, -40, -1, -40,
+ax_anim 2, 0, 88, 0, -40, 0, -40,
+ax_anim 2, 0, 85, 0, -11, 0, -11,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sManectricAnims_3_6:
+ax_anim 2, 0, 90, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 6, 6, 6, 6,
+ax_anim 6, 0, 89, 8, 8, 8, 8,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 0, 93, -8, -9, -8, -9,
+ax_anim 2, 2, 92, -19, -20, -19, -20,
+ax_anim 2, 0, 93, -33, -34, -33, -34,
+ax_anim 2, 1, 93, -40, -43, -40, -43,
+ax_anim 2, 0, 93, -41, -42, -41, -42,
+ax_anim 2, 0, 93, -40, -43, -40, -43,
+ax_anim 2, 0, 93, -41, -42, -41, -42,
+ax_anim 2, 0, 90, -11, -13, -11, -13,
+ax_anim 2, 0, 89, -4, -5, -4, -5,
+ax_anim_terminator
+sManectricAnims_3_7:
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 6, 0, 94, 8, 0, 8, 0,
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 98, -5, 0, -5, 0,
+ax_anim 2, 2, 97, -19, 0, -19, 0,
+ax_anim 2, 0, 98, -32, 0, -32, 0,
+ax_anim 2, 1, 98, -40, 1, -40, 1,
+ax_anim 2, 0, 98, -40, 0, -40, 0,
+ax_anim 2, 0, 98, -40, 1, -40, 1,
+ax_anim 2, 0, 98, -40, 0, -40, 0,
+ax_anim 2, 0, 95, -11, 0, -11, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sManectricAnims_3_8:
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 6, -6, 6, -6,
+ax_anim 6, 0, 99, 8, -8, 8, -8,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 103, -7, 7, -7, 7,
+ax_anim 2, 2, 102, -19, 20, -19, 20,
+ax_anim 2, 0, 103, -34, 36, -34, 36,
+ax_anim 2, 1, 103, -41, 45, -41, 45,
+ax_anim 2, 0, 103, -42, 44, -42, 44,
+ax_anim 2, 0, 103, -41, 45, -41, 45,
+ax_anim 2, 0, 103, -42, 44, -42, 44,
+ax_anim 2, 0, 100, -10, 12, -10, 12,
+ax_anim 2, 0, 99, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sManectricAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sManectricAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sManectricAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sManectricAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sManectricAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sManectricAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sManectricAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sManectricAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sManectricAnims_5_1:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 1, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_5_2:
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 2, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 1, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_5_3:
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 2, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 1, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_5_4:
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 2, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 1, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_5_5:
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 1, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_5_6:
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 2, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 1, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_5_7:
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 2, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 1, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_5_8:
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 2, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 1, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sManectricAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sManectricAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sManectricAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sManectricAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sManectricAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sManectricAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sManectricAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sManectricAnims_8_1:
+ax_anim 60, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, 0, -1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, 0, -1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, 0, -1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, 0, -1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, 0, -1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, 0, -1, 0,
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_8_2:
+ax_anim 60, 0, 189, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 190, -1, 0, -1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, -1, 0, -1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, -1, 0, -1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, -1, 0, -1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, -1, 0, -1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, -1, 0, -1, 0,
+ax_anim 10, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_8_3:
+ax_anim 60, 0, 192, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, 0, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, 0, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, 0, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, 0, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, 0, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 1, 0, 1, 0,
+ax_anim_terminator
+sManectricAnims_8_4:
+ax_anim 60, 0, 195, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, -1, 1, -1,
+ax_anim 2, 0, 196, 2, -1, 2, -1,
+ax_anim 2, 0, 196, 1, -1, 1, -1,
+ax_anim 2, 0, 196, 2, -1, 2, -1,
+ax_anim 2, 0, 196, 1, -1, 1, -1,
+ax_anim 2, 0, 196, 2, -1, 2, -1,
+ax_anim 2, 0, 196, 1, -1, 1, -1,
+ax_anim 2, 0, 196, 2, -1, 2, -1,
+ax_anim 2, 0, 196, 1, -1, 1, -1,
+ax_anim 2, 0, 196, 2, -1, 2, -1,
+ax_anim 2, 0, 196, 1, -1, 1, -1,
+ax_anim 10, 0, 196, 2, -1, 2, -1,
+ax_anim_terminator
+sManectricAnims_8_5:
+ax_anim 60, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, 0, 1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, 0, 1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, 0, 1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, 0, 1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, 0, 1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 10, 0, 199, 1, 0, 1, 0,
+ax_anim_terminator
+sManectricAnims_8_6:
+ax_anim 60, 0, 201, 0, 0, 0, 0,
+ax_anim 10, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 10, 0, 202, 0, -1, 0, -1,
+ax_anim_terminator
+sManectricAnims_8_7:
+ax_anim 60, 0, 204, 0, 0, 0, 0,
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, 0, -1, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, 0, -1, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, 0, -1, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, 0, -1, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, 0, -1, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -1, 0, -1, 0,
+ax_anim 10, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_8_8:
+ax_anim 60, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 1, 0, 1, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 9, 3, 9, 3,
+ax_anim 2, 0, 212, 12, 11, 12, 11,
+ax_anim 2, 0, 213, 8, 17, 8, 17,
+ax_anim 3, 0, 214, 0, 21, 0, 21,
+ax_anim 2, 3, 215, -8, 17, -8, 17,
+ax_anim 2, 0, 216, -12, 11, -12, 11,
+ax_anim 1, 0, 217, -9, 3, -9, 3,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 9, 1, 9, 1,
+ax_anim 2, 0, 211, 19, 6, 19, 6,
+ax_anim 2, 0, 212, 21, 15, 21, 15,
+ax_anim 3, 0, 213, 18, 22, 18, 22,
+ax_anim 2, 3, 214, 9, 22, 9, 22,
+ax_anim 2, 0, 215, 1, 15, 1, 15,
+ax_anim 1, 0, 216, -2, 9, -2, 9,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -4, 0, -4,
+ax_anim 2, 0, 210, 7, -6, 7, -6,
+ax_anim 2, 0, 211, 14, -3, 14, -3,
+ax_anim 3, 0, 212, 16, 3, 16, 3,
+ax_anim 2, 3, 213, 13, 7, 13, 7,
+ax_anim 2, 0, 214, 6, 10, 6, 10,
+ax_anim 1, 0, 215, 2, 5, 2, 5,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, -1, -7, -1, -7,
+ax_anim 2, 0, 217, 2, -14, 2, -14,
+ax_anim 2, 0, 210, 10, -17, 10, -17,
+ax_anim 3, 0, 211, 18, -17, 18, -17,
+ax_anim 2, 3, 212, 20, -10, 20, -10,
+ax_anim 2, 0, 213, 16, -3, 16, -3,
+ax_anim 1, 0, 214, 7, 0, 7, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -8, -4, -8, -4,
+ax_anim 2, 0, 216, -12, -8, -12, -8,
+ax_anim 2, 0, 217, -9, -13, -9, -13,
+ax_anim 3, 0, 210, 0, -16, 0, -16,
+ax_anim 2, 3, 211, 9, -13, 9, -13,
+ax_anim 2, 0, 212, 12, -8, 12, -8,
+ax_anim 1, 0, 213, 8, -4, 8, -4,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 1, -7, 1, -7,
+ax_anim 2, 0, 211, -2, -14, -2, -14,
+ax_anim 2, 0, 210, -10, -17, -10, -17,
+ax_anim 3, 0, 217, -18, -17, -18, -17,
+ax_anim 2, 3, 216, -20, -10, -20, -10,
+ax_anim 2, 0, 215, -16, -3, -16, -3,
+ax_anim 1, 0, 214, -7, 0, -7, 0,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -4, 0, -4,
+ax_anim 2, 0, 210, -7, -6, -7, -6,
+ax_anim 2, 0, 217, -14, -3, -14, -3,
+ax_anim 3, 0, 216, -16, 3, -16, 3,
+ax_anim 2, 3, 215, -13, 7, -13, 7,
+ax_anim 2, 0, 214, -6, 10, -6, 10,
+ax_anim 1, 0, 213, -2, 5, -2, 5,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -9, 1, -9, 1,
+ax_anim 2, 0, 217, -19, 6, -19, 6,
+ax_anim 2, 0, 216, -21, 15, -21, 15,
+ax_anim 3, 0, 215, -18, 22, -18, 22,
+ax_anim 2, 3, 214, -9, 22, -9, 22,
+ax_anim 2, 0, 213, -1, 15, -1, 15,
+ax_anim 1, 0, 212, -2, 9, -2, 9,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -8, 0, 0,
+ax_anim 2, 0, 227, 0, -14, 0, 0,
+ax_anim 3, 0, 227, 0, -18, 0, 0,
+ax_anim 4, 0, 227, 0, -19, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_11_2:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 228, 0, -22, 0, 0,
+ax_anim 2, 0, 228, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_11_3:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_11_4:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -22, 0, 0,
+ax_anim 3, 0, 232, 0, -21, 0, 0,
+ax_anim 2, 0, 232, 0, -17, 0, 0,
+ax_anim 1, 0, 232, 0, -11, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_11_5:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -9, 0, 0,
+ax_anim 2, 0, 235, 0, -15, 0, 0,
+ax_anim 3, 0, 235, 0, -19, 0, 0,
+ax_anim 4, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -23, 0, 0,
+ax_anim 3, 0, 234, 0, -22, 0, 0,
+ax_anim 2, 0, 234, 0, -18, 0, 0,
+ax_anim 1, 0, 234, 0, -12, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_11_6:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -22, 0, 0,
+ax_anim 3, 0, 236, 0, -21, 0, 0,
+ax_anim 2, 0, 236, 0, -17, 0, 0,
+ax_anim 1, 0, 236, 0, -11, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_11_7:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 239, 0, -16, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_11_8:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -23, 0, 0,
+ax_anim 3, 0, 240, 0, -22, 0, 0,
+ax_anim 2, 0, 240, 0, -18, 0, 0,
+ax_anim 1, 0, 240, 0, -12, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sManectricAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sManectricGfx1:
+.incbin "baserom.gba", 0x129EBEC, 0x100
+sManectricSprites1:
+ax_sprite sManectricGfx1, 0x100
+ax_sprite_terminator
+sManectricGfx2:
+.incbin "baserom.gba", 0x129ECFC, 0x100
+sManectricSprites2:
+ax_sprite sManectricGfx2, 0x100
+ax_sprite_terminator
+sManectricGfx3:
+.incbin "baserom.gba", 0x129EE0C, 0x100
+sManectricSprites3:
+ax_sprite sManectricGfx3, 0x100
+ax_sprite_terminator
+sManectricGfx4:
+.incbin "baserom.gba", 0x129EF1C, 0x200
+sManectricSprites4:
+ax_sprite sManectricGfx4, 0x200
+ax_sprite_terminator
+sManectricGfx5:
+.incbin "baserom.gba", 0x129F12C, 0x200
+sManectricSprites5:
+ax_sprite sManectricGfx5, 0x200
+ax_sprite_terminator
+sManectricGfx6:
+.incbin "baserom.gba", 0x129F33C, 0x200
+sManectricSprites6:
+ax_sprite sManectricGfx6, 0x200
+ax_sprite_terminator
+sManectricGfx7:
+.incbin "baserom.gba", 0x129F54C, 0x200
+sManectricSprites7:
+ax_sprite sManectricGfx7, 0x200
+ax_sprite_terminator
+sManectricGfx8:
+.incbin "baserom.gba", 0x129F75C, 0x200
+sManectricSprites8:
+ax_sprite sManectricGfx8, 0x200
+ax_sprite_terminator
+sManectricGfx9:
+.incbin "baserom.gba", 0x129F96C, 0x200
+sManectricSprites9:
+ax_sprite sManectricGfx9, 0x200
+ax_sprite_terminator
+sManectricGfx10:
+.incbin "baserom.gba", 0x129FB7C, 0x200
+sManectricSprites10:
+ax_sprite sManectricGfx10, 0x200
+ax_sprite_terminator
+sManectricGfx11:
+.incbin "baserom.gba", 0x129FD8C, 0x20
+sManectricSprites11:
+ax_sprite sManectricGfx11, 0x20
+ax_sprite_terminator
+sManectricGfx12:
+.incbin "baserom.gba", 0x129FDBC, 0x80
+sManectricSprites12:
+ax_sprite sManectricGfx12, 0x80
+ax_sprite_terminator
+sManectricGfx13:
+.incbin "baserom.gba", 0x129FE4C, 0x100
+sManectricSprites13:
+ax_sprite sManectricGfx13, 0x100
+ax_sprite_terminator
+sManectricGfx14:
+.incbin "baserom.gba", 0x129FF5C, 0x200
+sManectricSprites14:
+ax_sprite sManectricGfx14, 0x200
+ax_sprite_terminator
+sManectricGfx15:
+.incbin "baserom.gba", 0x12A016C, 0x100
+sManectricSprites15:
+ax_sprite sManectricGfx15, 0x100
+ax_sprite_terminator
+sManectricGfx16:
+.incbin "baserom.gba", 0x12A027C, 0x100
+sManectricSprites16:
+ax_sprite sManectricGfx16, 0x100
+ax_sprite_terminator
+sManectricGfx17:
+.incbin "baserom.gba", 0x12A038C, 0x20
+sManectricSprites17:
+ax_sprite sManectricGfx17, 0x20
+ax_sprite_terminator
+sManectricGfx18:
+.incbin "baserom.gba", 0x12A03BC, 0x100
+sManectricSprites18:
+ax_sprite sManectricGfx18, 0x100
+ax_sprite_terminator
+sManectricGfx19:
+.incbin "baserom.gba", 0x12A04CC, 0x20
+sManectricSprites19:
+ax_sprite sManectricGfx19, 0x20
+ax_sprite_terminator
+sManectricGfx20:
+.incbin "baserom.gba", 0x12A04FC, 0x100
+sManectricSprites20:
+ax_sprite sManectricGfx20, 0x100
+ax_sprite_terminator
+sManectricGfx21:
+.incbin "baserom.gba", 0x12A060C, 0x80
+sManectricSprites21:
+ax_sprite sManectricGfx21, 0x80
+ax_sprite_terminator
+sManectricGfx22:
+.incbin "baserom.gba", 0x12A069C, 0x20
+sManectricSprites22:
+ax_sprite sManectricGfx22, 0x20
+ax_sprite_terminator
+sManectricGfx23:
+.incbin "baserom.gba", 0x12A06CC, 0xE0
+sManectricSprites23:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx23, 0xe0
+ax_sprite_terminator
+sManectricGfx24:
+.incbin "baserom.gba", 0x12A07C4, 0x60
+sManectricSprites24:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx24, 0x60
+ax_sprite_terminator
+sManectricGfx25:
+.incbin "baserom.gba", 0x12A083C, 0x20
+sManectricSprites25:
+ax_sprite sManectricGfx25, 0x20
+ax_sprite_terminator
+sManectricGfx26:
+.incbin "baserom.gba", 0x12A086C, 0x60
+sManectricGfx26_1:
+.incbin "baserom.gba", 0x12A08CC, 0x140
+sManectricSprites26:
+ax_sprite sManectricGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx26_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sManectricGfx27:
+.incbin "baserom.gba", 0x12A0A34, 0x160
+sManectricGfx27_1:
+.incbin "baserom.gba", 0x12A0B94, 0x40
+sManectricSprites27:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx27, 0x160
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx28:
+.incbin "baserom.gba", 0x12A0C04, 0x60
+sManectricGfx28_1:
+.incbin "baserom.gba", 0x12A0C64, 0x140
+sManectricGfx28_2:
+.incbin "baserom.gba", 0x12A0DA4, 0x20
+sManectricSprites28:
+ax_sprite sManectricGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx28_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx28_2, 0x20
+ax_sprite_terminator
+sManectricGfx29:
+.incbin "baserom.gba", 0x12A0DF4, 0x40
+sManectricGfx29_1:
+.incbin "baserom.gba", 0x12A0E34, 0x100
+sManectricGfx29_2:
+.incbin "baserom.gba", 0x12A0F34, 0x60
+sManectricSprites29:
+ax_sprite sManectricGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx29_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx29_2, 0x60
+ax_sprite_terminator
+sManectricGfx30:
+.incbin "baserom.gba", 0x12A0FC4, 0x60
+sManectricGfx30_1:
+.incbin "baserom.gba", 0x12A1024, 0x180
+sManectricSprites30:
+ax_sprite sManectricGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx30_1, 0x180
+ax_sprite_terminator
+sManectricGfx31:
+.incbin "baserom.gba", 0x12A11C4, 0x40
+sManectricGfx31_1:
+.incbin "baserom.gba", 0x12A1204, 0x100
+sManectricGfx31_2:
+.incbin "baserom.gba", 0x12A1304, 0x60
+sManectricSprites31:
+ax_sprite sManectricGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx31_2, 0x60
+ax_sprite_terminator
+sManectricGfx32:
+.incbin "baserom.gba", 0x12A1394, 0x60
+sManectricGfx32_1:
+.incbin "baserom.gba", 0x12A13F4, 0x60
+sManectricGfx32_2:
+.incbin "baserom.gba", 0x12A1454, 0x60
+sManectricGfx32_3:
+.incbin "baserom.gba", 0x12A14B4, 0x60
+sManectricSprites32:
+ax_sprite sManectricGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx33:
+.incbin "baserom.gba", 0x12A155C, 0x60
+sManectricGfx33_1:
+.incbin "baserom.gba", 0x12A15BC, 0x60
+sManectricGfx33_2:
+.incbin "baserom.gba", 0x12A161C, 0x60
+sManectricGfx33_3:
+.incbin "baserom.gba", 0x12A167C, 0x60
+sManectricSprites33:
+ax_sprite sManectricGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx33_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx34:
+.incbin "baserom.gba", 0x12A1724, 0x60
+sManectricGfx34_1:
+.incbin "baserom.gba", 0x12A1784, 0x60
+sManectricGfx34_2:
+.incbin "baserom.gba", 0x12A17E4, 0x60
+sManectricGfx34_3:
+.incbin "baserom.gba", 0x12A1844, 0x40
+sManectricSprites34:
+ax_sprite sManectricGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx35:
+.incbin "baserom.gba", 0x12A18CC, 0x20
+sManectricGfx35_1:
+.incbin "baserom.gba", 0x12A18EC, 0x60
+sManectricGfx35_2:
+.incbin "baserom.gba", 0x12A194C, 0x60
+sManectricGfx35_3:
+.incbin "baserom.gba", 0x12A19AC, 0x60
+sManectricSprites35:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx35, 0x20
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx36:
+.incbin "baserom.gba", 0x12A1A5C, 0xE0
+sManectricGfx36_1:
+.incbin "baserom.gba", 0x12A1B3C, 0x60
+sManectricGfx36_2:
+.incbin "baserom.gba", 0x12A1B9C, 0x40
+sManectricSprites36:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx36, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx37:
+.incbin "baserom.gba", 0x12A1C1C, 0x40
+sManectricGfx37_1:
+.incbin "baserom.gba", 0x12A1C5C, 0x160
+sManectricSprites37:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx37_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx38:
+.incbin "baserom.gba", 0x12A1DEC, 0x60
+sManectricGfx38_1:
+.incbin "baserom.gba", 0x12A1E4C, 0x100
+sManectricGfx38_2:
+.incbin "baserom.gba", 0x12A1F4C, 0x60
+sManectricSprites38:
+ax_sprite sManectricGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx38_2, 0x60
+ax_sprite_terminator
+sManectricGfx39:
+.incbin "baserom.gba", 0x12A1FDC, 0x40
+sManectricGfx39_1:
+.incbin "baserom.gba", 0x12A201C, 0x180
+sManectricSprites39:
+ax_sprite sManectricGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx39_1, 0x180
+ax_sprite_terminator
+sManectricGfx40:
+.incbin "baserom.gba", 0x12A21BC, 0x40
+sManectricGfx40_1:
+.incbin "baserom.gba", 0x12A21FC, 0x100
+sManectricGfx40_2:
+.incbin "baserom.gba", 0x12A22FC, 0x60
+sManectricSprites40:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx40_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx40_2, 0x60
+ax_sprite_terminator
+sManectricGfx41:
+.incbin "baserom.gba", 0x12A2394, 0x40
+sManectricGfx41_1:
+.incbin "baserom.gba", 0x12A23D4, 0x180
+sManectricSprites41:
+ax_sprite sManectricGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx41_1, 0x180
+ax_sprite_terminator
+sManectricGfx42:
+.incbin "baserom.gba", 0x12A2574, 0x20
+sManectricGfx42_1:
+.incbin "baserom.gba", 0x12A2594, 0x60
+sManectricGfx42_2:
+.incbin "baserom.gba", 0x12A25F4, 0x60
+sManectricGfx42_3:
+.incbin "baserom.gba", 0x12A2654, 0x60
+sManectricSprites42:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx42, 0x20
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx42_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx43:
+.incbin "baserom.gba", 0x12A2704, 0x60
+sManectricGfx43_1:
+.incbin "baserom.gba", 0x12A2764, 0x60
+sManectricGfx43_2:
+.incbin "baserom.gba", 0x12A27C4, 0x60
+sManectricGfx43_3:
+.incbin "baserom.gba", 0x12A2824, 0x60
+sManectricSprites43:
+ax_sprite sManectricGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx43_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx44:
+.incbin "baserom.gba", 0x12A28CC, 0x80
+sManectricSprites44:
+ax_sprite sManectricGfx44, 0x80
+ax_sprite_terminator
+sManectricGfx45:
+.incbin "baserom.gba", 0x12A295C, 0xA0
+sManectricGfx45_1:
+.incbin "baserom.gba", 0x12A29FC, 0x40
+sManectricSprites45:
+ax_sprite sManectricGfx45, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx45_1, 0x40
+ax_sprite_terminator
+sManectricGfx46:
+.incbin "baserom.gba", 0x12A2A5C, 0x60
+sManectricSprites46:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx46, 0x60
+ax_sprite_terminator
+sManectricGfx47:
+.incbin "baserom.gba", 0x12A2AD4, 0x20
+sManectricSprites47:
+ax_sprite sManectricGfx47, 0x20
+ax_sprite_terminator
+sManectricGfx48:
+.incbin "baserom.gba", 0x12A2B04, 0x60
+sManectricGfx48_1:
+.incbin "baserom.gba", 0x12A2B64, 0x60
+sManectricGfx48_2:
+.incbin "baserom.gba", 0x12A2BC4, 0x60
+sManectricGfx48_3:
+.incbin "baserom.gba", 0x12A2C24, 0x60
+sManectricSprites48:
+ax_sprite sManectricGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx48_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx49:
+.incbin "baserom.gba", 0x12A2CCC, 0xE0
+sManectricSprites49:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx49, 0xe0
+ax_sprite_terminator
+sManectricGfx50:
+.incbin "baserom.gba", 0x12A2DC4, 0x40
+sManectricSprites50:
+ax_sprite sManectricGfx50, 0x40
+ax_sprite_terminator
+sManectricGfx51:
+.incbin "baserom.gba", 0x12A2E14, 0x100
+sManectricSprites51:
+ax_sprite sManectricGfx51, 0x100
+ax_sprite_terminator
+sManectricGfx52:
+.incbin "baserom.gba", 0x12A2F24, 0x80
+sManectricSprites52:
+ax_sprite sManectricGfx52, 0x80
+ax_sprite_terminator
+sManectricGfx53:
+.incbin "baserom.gba", 0x12A2FB4, 0x40
+sManectricSprites53:
+ax_sprite sManectricGfx53, 0x40
+ax_sprite_terminator
+sManectricGfx54:
+.incbin "baserom.gba", 0x12A3004, 0x20
+sManectricSprites54:
+ax_sprite sManectricGfx54, 0x20
+ax_sprite_terminator
+sManectricGfx55:
+.incbin "baserom.gba", 0x12A3034, 0x60
+sManectricGfx55_1:
+.incbin "baserom.gba", 0x12A3094, 0x60
+sManectricGfx55_2:
+.incbin "baserom.gba", 0x12A30F4, 0x60
+sManectricGfx55_3:
+.incbin "baserom.gba", 0x12A3154, 0x60
+sManectricSprites55:
+ax_sprite sManectricGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx55_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx55_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx56:
+.incbin "baserom.gba", 0x12A31FC, 0x80
+sManectricSprites56:
+ax_sprite sManectricGfx56, 0x80
+ax_sprite_terminator
+sManectricGfx57:
+.incbin "baserom.gba", 0x12A328C, 0x40
+sManectricSprites57:
+ax_sprite sManectricGfx57, 0x40
+ax_sprite_terminator
+sManectricGfx58:
+.incbin "baserom.gba", 0x12A32DC, 0x40
+sManectricSprites58:
+ax_sprite sManectricGfx58, 0x40
+ax_sprite_terminator
+sManectricGfx59:
+.incbin "baserom.gba", 0x12A332C, 0x100
+sManectricSprites59:
+ax_sprite sManectricGfx59, 0x100
+ax_sprite_terminator
+sManectricGfx60:
+.incbin "baserom.gba", 0x12A343C, 0x40
+sManectricSprites60:
+ax_sprite sManectricGfx60, 0x40
+ax_sprite_terminator
+sManectricGfx61:
+.incbin "baserom.gba", 0x12A348C, 0xE0
+sManectricGfx61_1:
+.incbin "baserom.gba", 0x12A356C, 0x60
+sManectricGfx61_2:
+.incbin "baserom.gba", 0x12A35CC, 0x40
+sManectricSprites61:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx61, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx61_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx61_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx62:
+.incbin "baserom.gba", 0x12A364C, 0xE0
+sManectricSprites62:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx62, 0xe0
+ax_sprite_terminator
+sManectricGfx63:
+.incbin "baserom.gba", 0x12A3744, 0x40
+sManectricSprites63:
+ax_sprite sManectricGfx63, 0x40
+ax_sprite_terminator
+sManectricGfx64:
+.incbin "baserom.gba", 0x12A3794, 0x20
+sManectricGfx64_1:
+.incbin "baserom.gba", 0x12A37B4, 0x20
+sManectricGfx64_2:
+.incbin "baserom.gba", 0x12A37D4, 0x80
+sManectricSprites64:
+ax_sprite sManectricGfx64, 0x20
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx64_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx64_2, 0x80
+ax_sprite_terminator
+sManectricGfx65:
+.incbin "baserom.gba", 0x12A3884, 0x100
+sManectricSprites65:
+ax_sprite sManectricGfx65, 0x100
+ax_sprite_terminator
+sManectricGfx66:
+.incbin "baserom.gba", 0x12A3994, 0x20
+sManectricSprites66:
+ax_sprite sManectricGfx66, 0x20
+ax_sprite_terminator
+sManectricGfx67:
+.incbin "baserom.gba", 0x12A39C4, 0xE0
+sManectricGfx67_1:
+.incbin "baserom.gba", 0x12A3AA4, 0x60
+sManectricGfx67_2:
+.incbin "baserom.gba", 0x12A3B04, 0x40
+sManectricSprites67:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx67, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx67_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx67_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx68:
+.incbin "baserom.gba", 0x12A3B84, 0x60
+sManectricGfx68_1:
+.incbin "baserom.gba", 0x12A3BE4, 0x100
+sManectricGfx68_2:
+.incbin "baserom.gba", 0x12A3CE4, 0x60
+sManectricSprites68:
+ax_sprite sManectricGfx68, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx68_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx68_2, 0x60
+ax_sprite_terminator
+sManectricGfx69:
+.incbin "baserom.gba", 0x12A3D74, 0x60
+sManectricGfx69_1:
+.incbin "baserom.gba", 0x12A3DD4, 0x100
+sManectricGfx69_2:
+.incbin "baserom.gba", 0x12A3ED4, 0x60
+sManectricSprites69:
+ax_sprite sManectricGfx69, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx69_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx69_2, 0x60
+ax_sprite_terminator
+sManectricGfx70:
+.incbin "baserom.gba", 0x12A3F64, 0x160
+sManectricGfx70_1:
+.incbin "baserom.gba", 0x12A40C4, 0x60
+sManectricSprites70:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx70, 0x160
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx70_1, 0x60
+ax_sprite_terminator
+sManectricGfx71:
+.incbin "baserom.gba", 0x12A414C, 0x160
+sManectricGfx71_1:
+.incbin "baserom.gba", 0x12A42AC, 0x60
+sManectricSprites71:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx71, 0x160
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx71_1, 0x60
+ax_sprite_terminator
+sManectricGfx72:
+.incbin "baserom.gba", 0x12A4334, 0x20
+sManectricGfx72_1:
+.incbin "baserom.gba", 0x12A4354, 0x60
+sManectricGfx72_2:
+.incbin "baserom.gba", 0x12A43B4, 0x60
+sManectricGfx72_3:
+.incbin "baserom.gba", 0x12A4414, 0x60
+sManectricSprites72:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx72, 0x20
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx72_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx72_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx72_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx73:
+.incbin "baserom.gba", 0x12A44C4, 0x20
+sManectricGfx73_1:
+.incbin "baserom.gba", 0x12A44E4, 0x60
+sManectricGfx73_2:
+.incbin "baserom.gba", 0x12A4544, 0x60
+sManectricGfx73_3:
+.incbin "baserom.gba", 0x12A45A4, 0x60
+sManectricSprites73:
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx73, 0x20
+ax_sprite 0, 0x40
+ax_sprite sManectricGfx73_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx73_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sManectricGfx73_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sManectricGfx74:
+.incbin "baserom.gba", 0x12A4654, 0x200
+sManectricSprites74:
+ax_sprite sManectricGfx74, 0x200
+ax_sprite_terminator
+sManectricGfx75:
+.incbin "baserom.gba", 0x12A4864, 0x200
+sManectricSprites75:
+ax_sprite sManectricGfx75, 0x200
+ax_sprite_terminator
+sManectricGfx76:
+.incbin "baserom.gba", 0x12A4A74, 0x200
+sManectricSprites76:
+ax_sprite sManectricGfx76, 0x200
+ax_sprite_terminator
+sManectricGfx77:
+.incbin "baserom.gba", 0x12A4C84, 0x200
+sManectricSprites77:
+ax_sprite sManectricGfx77, 0x200
+ax_sprite_terminator
+sManectricGfx78:
+.incbin "baserom.gba", 0x12A4E94, 0x200
+sManectricSprites78:
+ax_sprite sManectricGfx78, 0x200
+ax_sprite_terminator
+sManectricGfx79:
+.incbin "baserom.gba", 0x12A50A4, 0x200
+sManectricSprites79:
+ax_sprite sManectricGfx79, 0x200
+ax_sprite_terminator
+sManectricGfx80:
+.incbin "baserom.gba", 0x12A52B4, 0x80
+sManectricSprites80:
+ax_sprite sManectricGfx80, 0x80
+ax_sprite_terminator
+sManectricGfx81:
+.incbin "baserom.gba", 0x12A5344, 0x20
+sManectricSprites81:
+ax_sprite sManectricGfx81, 0x20
+ax_sprite_terminator
+sManectricGfx82:
+.incbin "baserom.gba", 0x12A5374, 0x100
+sManectricSprites82:
+ax_sprite sManectricGfx82, 0x100
+ax_sprite_terminator
+sAxPosesManectric:
+.4byte sManectricPose1
+.4byte sManectricPose2
+.4byte sManectricPose3
+.4byte sManectricPose4
+.4byte sManectricPose5
+.4byte sManectricPose6
+.4byte sManectricPose7
+.4byte sManectricPose8
+.4byte sManectricPose9
+.4byte sManectricPose10
+.4byte sManectricPose11
+.4byte sManectricPose12
+.4byte sManectricPose13
+.4byte sManectricPose14
+.4byte sManectricPose15
+.4byte sManectricPose16
+.4byte sManectricPose17
+.4byte sManectricPose18
+.4byte sManectricPose19
+.4byte sManectricPose20
+.4byte sManectricPose21
+.4byte sManectricPose22
+.4byte sManectricPose23
+.4byte sManectricPose24
+.4byte sManectricPose25
+.4byte sManectricPose26
+.4byte sManectricPose27
+.4byte sManectricPose28
+.4byte sManectricPose29
+.4byte sManectricPose30
+.4byte sManectricPose31
+.4byte sManectricPose32
+.4byte sManectricPose33
+.4byte sManectricPose34
+.4byte sManectricPose35
+.4byte sManectricPose36
+.4byte sManectricPose37
+.4byte sManectricPose38
+.4byte sManectricPose39
+.4byte sManectricPose40
+.4byte sManectricPose41
+.4byte sManectricPose42
+.4byte sManectricPose43
+.4byte sManectricPose44
+.4byte sManectricPose45
+.4byte sManectricPose46
+.4byte sManectricPose47
+.4byte sManectricPose48
+.4byte sManectricPose49
+.4byte sManectricPose50
+.4byte sManectricPose51
+.4byte sManectricPose52
+.4byte sManectricPose53
+.4byte sManectricPose54
+.4byte sManectricPose55
+.4byte sManectricPose56
+.4byte sManectricPose57
+.4byte sManectricPose58
+.4byte sManectricPose59
+.4byte sManectricPose60
+.4byte sManectricPose61
+.4byte sManectricPose62
+.4byte sManectricPose63
+.4byte sManectricPose64
+.4byte sManectricPose65
+.4byte sManectricPose66
+.4byte sManectricPose67
+.4byte sManectricPose68
+.4byte sManectricPose69
+.4byte sManectricPose70
+.4byte sManectricPose71
+.4byte sManectricPose72
+.4byte sManectricPose73
+.4byte sManectricPose74
+.4byte sManectricPose75
+.4byte sManectricPose76
+.4byte sManectricPose77
+.4byte sManectricPose78
+.4byte sManectricPose79
+.4byte sManectricPose80
+.4byte sManectricPose81
+.4byte sManectricPose82
+.4byte sManectricPose83
+.4byte sManectricPose84
+.4byte sManectricPose85
+.4byte sManectricPose86
+.4byte sManectricPose87
+.4byte sManectricPose88
+.4byte sManectricPose89
+.4byte sManectricPose90
+.4byte sManectricPose91
+.4byte sManectricPose92
+.4byte sManectricPose93
+.4byte sManectricPose94
+.4byte sManectricPose95
+.4byte sManectricPose96
+.4byte sManectricPose97
+.4byte sManectricPose98
+.4byte sManectricPose99
+.4byte sManectricPose100
+.4byte sManectricPose101
+.4byte sManectricPose102
+.4byte sManectricPose103
+.4byte sManectricPose104
+.4byte sManectricPose105
+.4byte sManectricPose106
+.4byte sManectricPose107
+.4byte sManectricPose108
+.4byte sManectricPose109
+.4byte sManectricPose110
+.4byte sManectricPose111
+.4byte sManectricPose112
+.4byte sManectricPose113
+.4byte sManectricPose114
+.4byte sManectricPose115
+.4byte sManectricPose116
+.4byte sManectricPose117
+.4byte sManectricPose118
+.4byte sManectricPose119
+.4byte sManectricPose120
+.4byte sManectricPose121
+.4byte sManectricPose122
+.4byte sManectricPose123
+.4byte sManectricPose124
+.4byte sManectricPose125
+.4byte sManectricPose126
+.4byte sManectricPose127
+.4byte sManectricPose128
+.4byte sManectricPose129
+.4byte sManectricPose130
+.4byte sManectricPose131
+.4byte sManectricPose132
+.4byte sManectricPose133
+.4byte sManectricPose134
+.4byte sManectricPose135
+.4byte sManectricPose136
+.4byte sManectricPose137
+.4byte sManectricPose138
+.4byte sManectricPose139
+.4byte sManectricPose140
+.4byte sManectricPose141
+.4byte sManectricPose142
+.4byte sManectricPose143
+.4byte sManectricPose144
+.4byte sManectricPose145
+.4byte sManectricPose146
+.4byte sManectricPose147
+.4byte sManectricPose148
+.4byte sManectricPose149
+.4byte sManectricPose150
+.4byte sManectricPose151
+.4byte sManectricPose152
+.4byte sManectricPose153
+.4byte sManectricPose154
+.4byte sManectricPose155
+.4byte sManectricPose156
+.4byte sManectricPose157
+.4byte sManectricPose158
+.4byte sManectricPose159
+.4byte sManectricPose160
+.4byte sManectricPose161
+.4byte sManectricPose162
+.4byte sManectricPose163
+.4byte sManectricPose164
+.4byte sManectricPose165
+.4byte sManectricPose166
+.4byte sManectricPose167
+.4byte sManectricPose168
+.4byte sManectricPose169
+.4byte sManectricPose170
+.4byte sManectricPose171
+.4byte sManectricPose172
+.4byte sManectricPose173
+.4byte sManectricPose174
+.4byte sManectricPose175
+.4byte sManectricPose176
+.4byte sManectricPose177
+.4byte sManectricPose178
+.4byte sManectricPose179
+.4byte sManectricPose180
+.4byte sManectricPose181
+.4byte sManectricPose182
+.4byte sManectricPose183
+.4byte sManectricPose184
+.4byte sManectricPose185
+.4byte sManectricPose186
+.4byte sManectricPose187
+.4byte sManectricPose188
+.4byte sManectricPose189
+.4byte sManectricPose190
+.4byte sManectricPose191
+.4byte sManectricPose192
+.4byte sManectricPose193
+.4byte sManectricPose194
+.4byte sManectricPose195
+.4byte sManectricPose196
+.4byte sManectricPose197
+.4byte sManectricPose198
+.4byte sManectricPose199
+.4byte sManectricPose200
+.4byte sManectricPose201
+.4byte sManectricPose202
+.4byte sManectricPose203
+.4byte sManectricPose204
+.4byte sManectricPose205
+.4byte sManectricPose206
+.4byte sManectricPose207
+.4byte sManectricPose208
+.4byte sManectricPose209
+.4byte sManectricPose210
+.4byte sManectricPose211
+.4byte sManectricPose212
+.4byte sManectricPose213
+.4byte sManectricPose214
+.4byte sManectricPose215
+.4byte sManectricPose216
+.4byte sManectricPose217
+.4byte sManectricPose218
+.4byte sManectricPose219
+.4byte sManectricPose220
+.4byte sManectricPose221
+.4byte sManectricPose222
+.4byte sManectricPose223
+.4byte sManectricPose224
+.4byte sManectricPose225
+.4byte sManectricPose226
+.4byte sManectricPose227
+.4byte sManectricPose228
+.4byte sManectricPose229
+.4byte sManectricPose230
+.4byte sManectricPose231
+.4byte sManectricPose232
+.4byte sManectricPose233
+.4byte sManectricPose234
+.4byte sManectricPose235
+.4byte sManectricPose236
+.4byte sManectricPose237
+.4byte sManectricPose238
+.4byte sManectricPose239
+.4byte sManectricPose240
+.4byte sManectricPose241
+.4byte sManectricPose242
+.4byte sManectricPose243
+.4byte sManectricPose244
+.4byte sManectricPose245
+.4byte sManectricPose246
+.4byte sManectricPose247
+.4byte sManectricPose248
+.4byte sManectricPose249
+.4byte sManectricPose250
+.4byte sManectricPose251
+.4byte sManectricPose252
+.4byte sManectricPose253
+.4byte sManectricPose254
+.4byte sManectricPose255
+.4byte sManectricPose256
+.4byte sManectricPose257
+.4byte sManectricPose258
+sAxPositionsManectric:
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    1,   -3, 	  -4,    3, 	   5,   -1, 	   0,   -8
+.2byte   -2,   -3, 	  -5,   -1, 	   3,    3, 	  -1,   -8
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte    9,   -5, 	   7,   -1, 	   4,    4, 	   0,   -7
+.2byte    8,   -4, 	   9,    3, 	  -1,    1, 	   0,   -5
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte   13,  -11, 	   0,   -3, 	   9,    0, 	  -2,   -9
+.2byte   13,  -10, 	  10,   -3, 	   3,    0, 	  -1,   -7
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte    6,  -15, 	  -4,   -5, 	   9,   -4, 	  -2,   -7
+.2byte    8,  -14, 	   1,   -8, 	   4,    0, 	  -1,   -7
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -11, 	   4,   -4, 	  -4,   -8, 	  -1,   -7
+.2byte    2,  -11, 	   3,   -7, 	  -5,   -4, 	   0,   -7
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte   -7,  -15, 	   3,   -5, 	 -10,   -4, 	   1,   -7
+.2byte   -9,  -14, 	  -2,   -8, 	  -5,    0, 	   0,   -7
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte  -14,  -11, 	  -1,   -3, 	 -10,    0, 	   1,   -9
+.2byte  -14,  -10, 	 -11,   -3, 	  -4,    0, 	   0,   -7
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -10,   -5, 	  -8,   -1, 	  -5,    4, 	  -1,   -7
+.2byte   -9,   -4, 	 -10,    3, 	   0,    1, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    1,   -3, 	  -4,    3, 	   5,   -1, 	   0,   -8
+.2byte   -2,   -3, 	  -5,   -1, 	   3,    3, 	  -1,   -8
+.2byte   -1,   -7, 	  -3,   -1, 	   2,   -2, 	   0,  -16
+.2byte    0,   -1, 	  -2,    1, 	   0,    2, 	  -1,  -11
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte    9,   -5, 	   7,   -1, 	   4,    4, 	   0,   -7
+.2byte    8,   -4, 	   9,    3, 	  -1,    1, 	   0,   -5
+.2byte    9,   -6, 	   9,   -2, 	   8,    0, 	   0,  -13
+.2byte    9,   -4, 	   5,   -2, 	   3,    2, 	  -1,  -10
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte   13,  -11, 	   0,   -3, 	   9,    0, 	  -2,   -9
+.2byte   13,  -10, 	  10,   -3, 	   3,    0, 	  -1,   -7
+.2byte   14,  -12, 	  11,   -6, 	  12,   -4, 	  -2,  -13
+.2byte   14,  -10, 	   3,   -3, 	   2,    0, 	  -1,   -8
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte    6,  -15, 	  -4,   -5, 	   9,   -4, 	  -2,   -7
+.2byte    8,  -14, 	   1,   -8, 	   4,    0, 	  -1,   -7
+.2byte   10,  -17, 	   8,   -9, 	  11,   -8, 	  -1,  -13
+.2byte   11,  -14, 	   0,   -5, 	   2,   -2, 	  -1,   -7
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -11, 	   4,   -4, 	  -4,   -8, 	  -1,   -7
+.2byte    2,  -11, 	   3,   -7, 	  -5,   -4, 	   0,   -7
+.2byte    0,  -19, 	   4,  -20, 	  -4,  -20, 	   0,  -17
+.2byte    0,  -13, 	   4,   -7, 	  -5,   -7, 	   0,  -10
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte   -7,  -15, 	   3,   -5, 	 -10,   -4, 	   1,   -7
+.2byte   -9,  -14, 	  -2,   -8, 	  -5,    0, 	   0,   -7
+.2byte  -11,  -17, 	  -9,   -9, 	 -12,   -8, 	   0,  -13
+.2byte  -12,  -14, 	  -1,   -5, 	  -3,   -2, 	   0,   -7
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte  -14,  -11, 	  -1,   -3, 	 -10,    0, 	   1,   -9
+.2byte  -14,  -10, 	 -11,   -3, 	  -4,    0, 	   0,   -7
+.2byte  -15,  -12, 	 -12,   -6, 	 -13,   -4, 	   1,  -13
+.2byte  -15,  -10, 	  -4,   -3, 	  -3,    0, 	   0,   -8
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -10,   -5, 	  -8,   -1, 	  -5,    4, 	  -1,   -7
+.2byte   -9,   -4, 	 -10,    3, 	   0,    1, 	  -1,   -5
+.2byte  -10,   -6, 	 -10,   -2, 	  -9,    0, 	  -1,  -13
+.2byte  -10,   -4, 	  -6,   -2, 	  -4,    2, 	   0,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    1,   -3, 	  -4,    3, 	   5,   -1, 	   0,   -8
+.2byte   -2,   -3, 	  -5,   -1, 	   3,    3, 	  -1,   -8
+.2byte   -1,   -7, 	  -3,   -1, 	   2,   -2, 	   0,  -16
+.2byte    0,   -1, 	  -2,    1, 	   0,    2, 	  -1,  -11
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte    9,   -5, 	   7,   -1, 	   4,    4, 	   0,   -7
+.2byte    8,   -4, 	   9,    3, 	  -1,    1, 	   0,   -5
+.2byte    9,   -6, 	   9,   -2, 	   8,    0, 	   0,  -13
+.2byte    9,   -4, 	   5,   -2, 	   3,    2, 	  -1,  -10
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte   13,  -11, 	   0,   -3, 	   9,    0, 	  -2,   -9
+.2byte   13,  -10, 	  10,   -3, 	   3,    0, 	  -1,   -7
+.2byte   14,  -12, 	  11,   -6, 	  12,   -4, 	  -2,  -13
+.2byte   14,  -10, 	   3,   -3, 	   2,    0, 	  -1,   -8
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte    6,  -15, 	  -4,   -5, 	   9,   -4, 	  -2,   -7
+.2byte    8,  -14, 	   1,   -8, 	   4,    0, 	  -1,   -7
+.2byte   10,  -17, 	   8,   -9, 	  11,   -8, 	  -1,  -13
+.2byte   11,  -14, 	   0,   -5, 	   2,   -2, 	  -1,   -7
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -11, 	   4,   -4, 	  -4,   -8, 	  -1,   -7
+.2byte    2,  -11, 	   3,   -7, 	  -5,   -4, 	   0,   -7
+.2byte    0,  -19, 	   4,  -20, 	  -4,  -20, 	   0,  -17
+.2byte    0,  -13, 	   4,   -7, 	  -5,   -7, 	   0,  -10
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte   -7,  -15, 	   3,   -5, 	 -10,   -4, 	   1,   -7
+.2byte   -9,  -14, 	  -2,   -8, 	  -5,    0, 	   0,   -7
+.2byte  -11,  -17, 	  -9,   -9, 	 -12,   -8, 	   0,  -13
+.2byte  -12,  -14, 	  -1,   -5, 	  -3,   -2, 	   0,   -7
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte  -14,  -11, 	  -1,   -3, 	 -10,    0, 	   1,   -9
+.2byte  -14,  -10, 	 -11,   -3, 	  -4,    0, 	   0,   -7
+.2byte  -15,  -12, 	 -12,   -6, 	 -13,   -4, 	   1,  -13
+.2byte  -15,  -10, 	  -4,   -3, 	  -3,    0, 	   0,   -8
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -10,   -5, 	  -8,   -1, 	  -5,    4, 	  -1,   -7
+.2byte   -9,   -4, 	 -10,    3, 	   0,    1, 	  -1,   -5
+.2byte  -10,   -6, 	 -10,   -2, 	  -9,    0, 	  -1,  -13
+.2byte  -10,   -4, 	  -6,   -2, 	  -4,    2, 	   0,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    0,  -13, 	  -2,    0, 	   2,    1, 	   0,   -8
+.2byte   -1,    0, 	  -7,    1, 	   6,    1, 	   0,   -9
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   10,  -13, 	   6,    0, 	   4,    2, 	  -2,   -8
+.2byte   10,   -3, 	   8,   -1, 	   2,    4, 	   0,   -8
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte    9,  -19, 	   4,   -6, 	   5,    0, 	  -3,   -8
+.2byte   10,   -8, 	   5,   -4, 	   5,    1, 	  -1,   -8
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte    5,  -21, 	   0,   -7, 	   7,   -4, 	  -2,   -7
+.2byte   11,  -15, 	   1,   -7, 	   9,   -3, 	   0,   -9
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte    0,  -25, 	   5,   -5, 	  -6,   -5, 	   0,   -9
+.2byte    0,  -17, 	   5,   -6, 	  -6,   -6, 	   0,   -9
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte   -6,  -21, 	  -1,   -7, 	  -8,   -4, 	   1,   -7
+.2byte  -12,  -15, 	  -2,   -7, 	 -10,   -3, 	  -1,   -9
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte  -10,  -19, 	  -5,   -6, 	  -6,    0, 	   2,   -8
+.2byte  -11,   -8, 	  -6,   -4, 	  -6,    1, 	   0,   -8
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -11,  -13, 	  -7,    0, 	  -5,    2, 	   1,   -8
+.2byte  -11,   -3, 	  -9,   -1, 	  -3,    4, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte   -1,    0, 	  -7,    1, 	   6,    1, 	   0,   -9
+.2byte   -1,  -13, 	  -6,    1, 	   5,    1, 	  -1,   -7
+.2byte   -1,  -13, 	  -6,    1, 	   5,    1, 	  -1,   -7
+.2byte   -1,  -13, 	  -6,    1, 	   5,    1, 	  -1,   -7
+.2byte   -1,  -13, 	  -6,    1, 	   5,    1, 	  -1,   -7
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   10,   -3, 	   8,   -1, 	   2,    4, 	   0,   -8
+.2byte   10,  -14, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   10,  -14, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   10,  -14, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   10,  -14, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte   10,   -8, 	   5,   -4, 	   5,    1, 	  -1,   -8
+.2byte   10,  -19, 	   7,   -3, 	   6,    0, 	  -1,  -10
+.2byte   10,  -19, 	   7,   -3, 	   6,    0, 	  -1,  -10
+.2byte   10,  -19, 	   7,   -3, 	   6,    0, 	  -1,  -10
+.2byte   10,  -19, 	   7,   -3, 	   6,    0, 	  -1,  -10
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   10,  -14, 	   0,   -6, 	   8,   -2, 	  -1,   -8
+.2byte    5,  -22, 	  -1,   -6, 	   6,   -3, 	  -2,   -7
+.2byte    5,  -22, 	  -1,   -6, 	   6,   -3, 	  -2,   -7
+.2byte    5,  -22, 	  -1,   -6, 	   6,   -3, 	  -2,   -7
+.2byte    5,  -22, 	  -1,   -6, 	   6,   -3, 	  -2,   -7
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte    0,  -17, 	   5,   -6, 	  -6,   -6, 	   0,   -9
+.2byte    0,  -23, 	   5,   -3, 	  -6,   -3, 	   0,   -5
+.2byte    0,  -23, 	   5,   -3, 	  -6,   -3, 	   0,   -5
+.2byte    0,  -23, 	   5,   -3, 	  -6,   -3, 	   0,   -5
+.2byte    0,  -23, 	   5,   -3, 	  -6,   -3, 	   0,   -5
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte  -11,  -14, 	  -1,   -6, 	  -9,   -2, 	   0,   -8
+.2byte   -6,  -22, 	   0,   -6, 	  -7,   -3, 	   1,   -7
+.2byte   -6,  -22, 	   0,   -6, 	  -7,   -3, 	   1,   -7
+.2byte   -6,  -22, 	   0,   -6, 	  -7,   -3, 	   1,   -7
+.2byte   -6,  -22, 	   0,   -6, 	  -7,   -3, 	   1,   -7
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte  -11,   -8, 	  -6,   -4, 	  -6,    1, 	   0,   -8
+.2byte  -11,  -19, 	  -8,   -3, 	  -7,    0, 	   0,  -10
+.2byte  -11,  -19, 	  -8,   -3, 	  -7,    0, 	   0,  -10
+.2byte  -11,  -19, 	  -8,   -3, 	  -7,    0, 	   0,  -10
+.2byte  -11,  -19, 	  -8,   -3, 	  -7,    0, 	   0,  -10
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -11,   -3, 	  -9,   -1, 	  -3,    4, 	  -1,   -8
+.2byte  -11,  -14, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -11,  -14, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -11,  -14, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -11,  -14, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte   -8,   -2, 	  -8,    1, 	  -5,    2, 	   0,   -6
+.2byte   -8,   -1, 	  -8,    1, 	  -5,    2, 	   0,   -5
+.2byte    0,   -3, 	  -6,    1, 	   7,    1, 	   1,   -9
+.2byte    7,   -3, 	  12,   -1, 	   4,    3, 	  -1,   -7
+.2byte    7,   -7, 	  11,   -3, 	   8,    0, 	  -2,   -8
+.2byte    6,  -11, 	   0,   -8, 	   9,   -4, 	  -3,   -6
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -7,  -11, 	  -1,   -8, 	 -10,   -4, 	   2,   -6
+.2byte   -8,   -7, 	 -12,   -3, 	  -9,    0, 	   1,   -8
+.2byte   -8,   -3, 	 -13,   -1, 	  -5,    3, 	   0,   -7
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte   -1,    0, 	  -7,    1, 	   6,    1, 	   0,   -9
+.2byte   -1,  -13, 	  -6,    1, 	   5,    1, 	  -1,   -7
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   10,   -3, 	   8,   -1, 	   2,    4, 	   0,   -8
+.2byte   10,  -14, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte   10,   -8, 	   5,   -4, 	   5,    1, 	  -1,   -8
+.2byte   10,  -19, 	   7,   -3, 	   6,    0, 	  -1,  -10
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   10,  -14, 	   0,   -6, 	   8,   -2, 	  -1,   -8
+.2byte    5,  -22, 	  -1,   -6, 	   6,   -3, 	  -2,   -7
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte    0,  -17, 	   5,   -6, 	  -6,   -6, 	   0,   -9
+.2byte    0,  -23, 	   5,   -3, 	  -6,   -3, 	   0,   -5
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte  -11,  -14, 	  -1,   -6, 	  -9,   -2, 	   0,   -8
+.2byte   -6,  -22, 	   0,   -6, 	  -7,   -3, 	   1,   -7
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte  -11,   -8, 	  -6,   -4, 	  -6,    1, 	   0,   -8
+.2byte  -11,  -19, 	  -8,   -3, 	  -7,    0, 	   0,  -10
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -11,   -3, 	  -9,   -1, 	  -3,    4, 	  -1,   -8
+.2byte  -11,  -14, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte   -1,   -4, 	  -3,    2, 	   2,    1, 	   0,  -13
+.2byte  -10,   -6, 	 -10,   -2, 	  -9,    0, 	  -1,  -13
+.2byte  -15,  -12, 	 -12,   -6, 	 -13,   -4, 	   1,  -13
+.2byte  -11,  -17, 	  -9,   -9, 	 -12,   -8, 	   0,  -13
+.2byte    0,  -16, 	   4,  -17, 	  -4,  -17, 	   0,  -14
+.2byte   10,  -17, 	   8,   -9, 	  11,   -8, 	  -1,  -13
+.2byte   14,  -12, 	  11,   -6, 	  12,   -4, 	  -2,  -13
+.2byte    9,   -6, 	   9,   -2, 	   8,    0, 	   0,  -13
+.2byte    0,  -13, 	  -2,    0, 	   2,    1, 	   0,   -8
+.2byte   10,  -13, 	   6,    0, 	   4,    2, 	  -2,   -8
+.2byte    9,  -19, 	   4,   -6, 	   5,    0, 	  -3,   -8
+.2byte    5,  -21, 	   0,   -7, 	   7,   -4, 	  -2,   -7
+.2byte    0,  -25, 	   5,   -5, 	  -6,   -5, 	   0,   -9
+.2byte   -6,  -21, 	  -1,   -7, 	  -8,   -4, 	   1,   -7
+.2byte  -10,  -19, 	  -5,   -6, 	  -6,    0, 	   2,   -8
+.2byte  -11,  -13, 	  -7,    0, 	  -5,    2, 	   1,   -8
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte    0,  -13, 	  -2,    0, 	   2,    1, 	   0,   -8
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte    9,  -13, 	   5,    0, 	   3,    2, 	  -3,   -8
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte   10,  -19, 	   5,   -6, 	   6,    0, 	  -2,   -8
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte    6,  -21, 	   1,   -7, 	   8,   -4, 	  -1,   -7
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte    0,  -25, 	   5,   -5, 	  -6,   -5, 	   0,   -9
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte   -7,  -21, 	  -2,   -7, 	  -9,   -4, 	   0,   -7
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte  -11,  -19, 	  -6,   -6, 	  -7,    0, 	   1,   -8
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -10,  -13, 	  -6,    0, 	  -4,    2, 	   2,   -8
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+.2byte   -1,   -4, 	  -6,    1, 	   5,    1, 	   0,   -9
+.2byte   -9,   -6, 	  -9,    0, 	  -2,    2, 	   0,   -9
+.2byte  -13,  -11, 	  -8,   -3, 	  -7,    0, 	   0,   -8
+.2byte   -9,  -16, 	   1,   -5, 	  -7,   -3, 	   0,   -8
+.2byte    0,  -12, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte    8,  -16, 	  -2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   12,  -11, 	   7,   -3, 	   6,    0, 	  -1,   -8
+.2byte    8,   -6, 	   8,    0, 	   1,    2, 	  -1,   -9
+sManectricAnimTable1:
+.4byte sManectricAnims_1_1
+.4byte sManectricAnims_1_2
+.4byte sManectricAnims_1_3
+.4byte sManectricAnims_1_4
+.4byte sManectricAnims_1_5
+.4byte sManectricAnims_1_6
+.4byte sManectricAnims_1_7
+.4byte sManectricAnims_1_8
+sManectricAnimTable2:
+.4byte sManectricAnims_2_1
+.4byte sManectricAnims_2_2
+.4byte sManectricAnims_2_3
+.4byte sManectricAnims_2_4
+.4byte sManectricAnims_2_5
+.4byte sManectricAnims_2_6
+.4byte sManectricAnims_2_7
+.4byte sManectricAnims_2_8
+sManectricAnimTable3:
+.4byte sManectricAnims_3_1
+.4byte sManectricAnims_3_2
+.4byte sManectricAnims_3_3
+.4byte sManectricAnims_3_4
+.4byte sManectricAnims_3_5
+.4byte sManectricAnims_3_6
+.4byte sManectricAnims_3_7
+.4byte sManectricAnims_3_8
+sManectricAnimTable4:
+.4byte sManectricAnims_4_1
+.4byte sManectricAnims_4_2
+.4byte sManectricAnims_4_3
+.4byte sManectricAnims_4_4
+.4byte sManectricAnims_4_5
+.4byte sManectricAnims_4_6
+.4byte sManectricAnims_4_7
+.4byte sManectricAnims_4_8
+sManectricAnimTable5:
+.4byte sManectricAnims_5_1
+.4byte sManectricAnims_5_2
+.4byte sManectricAnims_5_3
+.4byte sManectricAnims_5_4
+.4byte sManectricAnims_5_5
+.4byte sManectricAnims_5_6
+.4byte sManectricAnims_5_7
+.4byte sManectricAnims_5_8
+sManectricAnimTable6:
+.4byte sManectricAnims_6_1
+.4byte sManectricAnims_6_1
+.4byte sManectricAnims_6_1
+.4byte sManectricAnims_6_1
+.4byte sManectricAnims_6_1
+.4byte sManectricAnims_6_1
+.4byte sManectricAnims_6_1
+.4byte sManectricAnims_6_1
+sManectricAnimTable7:
+.4byte sManectricAnims_7_1
+.4byte sManectricAnims_7_2
+.4byte sManectricAnims_7_3
+.4byte sManectricAnims_7_4
+.4byte sManectricAnims_7_5
+.4byte sManectricAnims_7_6
+.4byte sManectricAnims_7_7
+.4byte sManectricAnims_7_8
+sManectricAnimTable8:
+.4byte sManectricAnims_8_1
+.4byte sManectricAnims_8_2
+.4byte sManectricAnims_8_3
+.4byte sManectricAnims_8_4
+.4byte sManectricAnims_8_5
+.4byte sManectricAnims_8_6
+.4byte sManectricAnims_8_7
+.4byte sManectricAnims_8_8
+sManectricAnimTable9:
+.4byte sManectricAnims_9_1
+.4byte sManectricAnims_9_2
+.4byte sManectricAnims_9_3
+.4byte sManectricAnims_9_4
+.4byte sManectricAnims_9_5
+.4byte sManectricAnims_9_6
+.4byte sManectricAnims_9_7
+.4byte sManectricAnims_9_8
+sManectricAnimTable10:
+.4byte sManectricAnims_10_1
+.4byte sManectricAnims_10_2
+.4byte sManectricAnims_10_3
+.4byte sManectricAnims_10_4
+.4byte sManectricAnims_10_5
+.4byte sManectricAnims_10_6
+.4byte sManectricAnims_10_7
+.4byte sManectricAnims_10_8
+sManectricAnimTable11:
+.4byte sManectricAnims_11_1
+.4byte sManectricAnims_11_2
+.4byte sManectricAnims_11_3
+.4byte sManectricAnims_11_4
+.4byte sManectricAnims_11_5
+.4byte sManectricAnims_11_6
+.4byte sManectricAnims_11_7
+.4byte sManectricAnims_11_8
+sManectricAnimTable12:
+.4byte sManectricAnims_12_1
+.4byte sManectricAnims_12_2
+.4byte sManectricAnims_12_3
+.4byte sManectricAnims_12_4
+.4byte sManectricAnims_12_5
+.4byte sManectricAnims_12_6
+.4byte sManectricAnims_12_7
+.4byte sManectricAnims_12_8
+sManectricAnimTable13:
+.4byte sManectricAnims_13_1
+.4byte sManectricAnims_13_2
+.4byte sManectricAnims_13_3
+.4byte sManectricAnims_13_4
+.4byte sManectricAnims_13_5
+.4byte sManectricAnims_13_6
+.4byte sManectricAnims_13_7
+.4byte sManectricAnims_13_8
+sAxAnimationsManectric:
+.4byte sManectricAnimTable1
+.4byte sManectricAnimTable2
+.4byte sManectricAnimTable3
+.4byte sManectricAnimTable4
+.4byte sManectricAnimTable5
+.4byte sManectricAnimTable6
+.4byte sManectricAnimTable7
+.4byte sManectricAnimTable8
+.4byte sManectricAnimTable9
+.4byte sManectricAnimTable10
+.4byte sManectricAnimTable11
+.4byte sManectricAnimTable12
+.4byte sManectricAnimTable13
+sAxSpritesManectric:
+.4byte sManectricSprites1
+.4byte sManectricSprites2
+.4byte sManectricSprites3
+.4byte sManectricSprites4
+.4byte sManectricSprites5
+.4byte sManectricSprites6
+.4byte sManectricSprites7
+.4byte sManectricSprites8
+.4byte sManectricSprites9
+.4byte sManectricSprites10
+.4byte sManectricSprites11
+.4byte sManectricSprites12
+.4byte sManectricSprites13
+.4byte sManectricSprites14
+.4byte sManectricSprites15
+.4byte sManectricSprites16
+.4byte sManectricSprites17
+.4byte sManectricSprites18
+.4byte sManectricSprites19
+.4byte sManectricSprites20
+.4byte sManectricSprites21
+.4byte sManectricSprites22
+.4byte sManectricSprites23
+.4byte sManectricSprites24
+.4byte sManectricSprites25
+.4byte sManectricSprites26
+.4byte sManectricSprites27
+.4byte sManectricSprites28
+.4byte sManectricSprites29
+.4byte sManectricSprites30
+.4byte sManectricSprites31
+.4byte sManectricSprites32
+.4byte sManectricSprites33
+.4byte sManectricSprites34
+.4byte sManectricSprites35
+.4byte sManectricSprites36
+.4byte sManectricSprites37
+.4byte sManectricSprites38
+.4byte sManectricSprites39
+.4byte sManectricSprites40
+.4byte sManectricSprites41
+.4byte sManectricSprites42
+.4byte sManectricSprites43
+.4byte sManectricSprites44
+.4byte sManectricSprites45
+.4byte sManectricSprites46
+.4byte sManectricSprites47
+.4byte sManectricSprites48
+.4byte sManectricSprites49
+.4byte sManectricSprites50
+.4byte sManectricSprites51
+.4byte sManectricSprites52
+.4byte sManectricSprites53
+.4byte sManectricSprites54
+.4byte sManectricSprites55
+.4byte sManectricSprites56
+.4byte sManectricSprites57
+.4byte sManectricSprites58
+.4byte sManectricSprites59
+.4byte sManectricSprites60
+.4byte sManectricSprites61
+.4byte sManectricSprites62
+.4byte sManectricSprites63
+.4byte sManectricSprites64
+.4byte sManectricSprites65
+.4byte sManectricSprites66
+.4byte sManectricSprites67
+.4byte sManectricSprites68
+.4byte sManectricSprites69
+.4byte sManectricSprites70
+.4byte sManectricSprites71
+.4byte sManectricSprites72
+.4byte sManectricSprites73
+.4byte sManectricSprites74
+.4byte sManectricSprites75
+.4byte sManectricSprites76
+.4byte sManectricSprites77
+.4byte sManectricSprites78
+.4byte sManectricSprites79
+.4byte sManectricSprites80
+.4byte sManectricSprites81
+.4byte sManectricSprites82
+sAxMainManectric:
+ax_main sAxPosesManectric, sAxAnimationsManectric, 13, sAxSpritesManectric, sAxPositionsManectric

--- a/data/ax/mankey.inc
+++ b/data/ax/mankey.inc
@@ -1,0 +1,2938 @@
+.global gAxMankey
+gAxMankey:
+ax_siro sAxMainMankey
+sMankeyPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose4:
+ax_pose 3, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose5:
+ax_pose 4, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose6:
+ax_pose 5, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose7:
+ax_pose 6, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose8:
+ax_pose 7, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose9:
+ax_pose 8, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose10:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose11:
+ax_pose 10, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose12:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose13:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose14:
+ax_pose 13, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose15:
+ax_pose 14, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose20:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose21:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose22:
+ax_pose 3, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose23:
+ax_pose 4, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose24:
+ax_pose 5, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose25:
+ax_pose 0, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose26:
+ax_pose 1, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose27:
+ax_pose 2, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose28:
+ax_pose 3, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose29:
+ax_pose 4, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose30:
+ax_pose 5, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose31:
+ax_pose 6, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose32:
+ax_pose 7, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose33:
+ax_pose 8, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose34:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose35:
+ax_pose 10, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose36:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose37:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose38:
+ax_pose 13, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose39:
+ax_pose 14, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose40:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose41:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose42:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose43:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose44:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose45:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose46:
+ax_pose 3, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose47:
+ax_pose 4, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose48:
+ax_pose 5, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose49:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose50:
+ax_pose 1, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose51:
+ax_pose 2, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose52:
+ax_pose 15, 0x81e6, 0x80ef, 0x4c00
+ax_pose 16, 0x01e6, 0x80ef, 0x4c08
+ax_pose_terminator
+sMankeyPose53:
+ax_pose 16, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sMankeyPose54:
+ax_pose 17, 0x81e6, 0x80ff, 0x4c00
+ax_pose 18, 0x01e6, 0x80ef, 0x4c08
+ax_pose_terminator
+sMankeyPose55:
+ax_pose 18, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sMankeyPose56:
+ax_pose 3, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose57:
+ax_pose 4, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose58:
+ax_pose 5, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose59:
+ax_pose 19, 0x81e7, 0x9100, 0x4c00
+ax_pose 20, 0x01e6, 0x90ef, 0x4c08
+ax_pose_terminator
+sMankeyPose60:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose61:
+ax_pose 21, 0x81e6, 0x90f3, 0x4c00
+ax_pose 22, 0x01e6, 0x90ef, 0x4c08
+ax_pose_terminator
+sMankeyPose62:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose63:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose64:
+ax_pose 7, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose65:
+ax_pose 8, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose66:
+ax_pose 23, 0x81e6, 0x9101, 0x4c00
+ax_pose 24, 0x01e6, 0x90ee, 0x4c08
+ax_pose_terminator
+sMankeyPose67:
+ax_pose 24, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose68:
+ax_pose 25, 0x81e4, 0x90fb, 0x4c00
+ax_pose 26, 0x01e6, 0x90ee, 0x4c08
+ax_pose_terminator
+sMankeyPose69:
+ax_pose 26, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose70:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose71:
+ax_pose 10, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose72:
+ax_pose 11, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose73:
+ax_pose 27, 0x01e6, 0x50f8, 0x4c00
+ax_pose 28, 0x01e6, 0x90f0, 0x4c04
+ax_pose_terminator
+sMankeyPose74:
+ax_pose 28, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose75:
+ax_pose 29, 0x81e1, 0x9100, 0x4c00
+ax_pose 30, 0x01e6, 0x90f0, 0x4c08
+ax_pose_terminator
+sMankeyPose76:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose77:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose78:
+ax_pose 13, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose79:
+ax_pose 14, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose80:
+ax_pose 31, 0x01e6, 0x80f0, 0x4c00
+ax_pose 32, 0x01e8, 0x4100, 0x4c10
+ax_pose_terminator
+sMankeyPose81:
+ax_pose 31, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose82:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose 32, 0x01e8, 0x50f0, 0x4c10
+ax_pose_terminator
+sMankeyPose83:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose84:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose85:
+ax_pose 10, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose86:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose87:
+ax_pose 27, 0x01e6, 0x40f7, 0x4c00
+ax_pose 28, 0x01e6, 0x80ef, 0x4c04
+ax_pose_terminator
+sMankeyPose88:
+ax_pose 28, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sMankeyPose89:
+ax_pose 29, 0x81e0, 0x80ee, 0x4c00
+ax_pose 30, 0x01e6, 0x80ef, 0x4c08
+ax_pose_terminator
+sMankeyPose90:
+ax_pose 30, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sMankeyPose91:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose92:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose93:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose94:
+ax_pose 23, 0x81e6, 0x80ef, 0x4c00
+ax_pose 24, 0x01e6, 0x80f1, 0x4c08
+ax_pose_terminator
+sMankeyPose95:
+ax_pose 24, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose96:
+ax_pose 25, 0x81e6, 0x80f4, 0x4c00
+ax_pose 26, 0x01e6, 0x80f1, 0x4c08
+ax_pose_terminator
+sMankeyPose97:
+ax_pose 26, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose98:
+ax_pose 3, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose99:
+ax_pose 4, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose100:
+ax_pose 5, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose101:
+ax_pose 19, 0x81e6, 0x80f1, 0x4c00
+ax_pose 20, 0x01e6, 0x80f1, 0x4c08
+ax_pose_terminator
+sMankeyPose102:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose103:
+ax_pose 21, 0x81e6, 0x80fd, 0x4c00
+ax_pose 22, 0x01e6, 0x80f1, 0x4c08
+ax_pose_terminator
+sMankeyPose104:
+ax_pose 22, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose105:
+ax_pose 34, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sMankeyPose106:
+ax_pose 35, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose107:
+ax_pose 36, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose108:
+ax_pose 37, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose109:
+ax_pose 38, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose110:
+ax_pose 37, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose111:
+ax_pose 36, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose112:
+ax_pose 35, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose113:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose114:
+ax_pose 3, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose115:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose116:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose117:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose118:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose119:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose120:
+ax_pose 3, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose121:
+ax_pose 39, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose122:
+ax_pose 40, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose123:
+ax_pose 41, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose124:
+ax_pose 42, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose125:
+ax_pose 43, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose126:
+ax_pose 42, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose127:
+ax_pose 41, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose128:
+ax_pose 40, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose129:
+ax_pose 44, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose130:
+ax_pose 45, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose131:
+ax_pose 46, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose132:
+ax_pose 47, 0x01e2, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose133:
+ax_pose 48, 0x01df, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose134:
+ax_pose 49, 0x01e0, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose135:
+ax_pose 50, 0x01e0, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose136:
+ax_pose 49, 0x01e0, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose137:
+ax_pose 48, 0x01df, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose138:
+ax_pose 47, 0x01e2, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose139:
+ax_pose 0, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose140:
+ax_pose 1, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose141:
+ax_pose 2, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose142:
+ax_pose 3, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sMankeyPose143:
+ax_pose 4, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose144:
+ax_pose 5, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose145:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose146:
+ax_pose 7, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose147:
+ax_pose 8, 0x01e4, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose148:
+ax_pose 9, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose149:
+ax_pose 10, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose150:
+ax_pose 11, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose151:
+ax_pose 12, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose152:
+ax_pose 13, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose153:
+ax_pose 14, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose154:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose155:
+ax_pose 10, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose156:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose157:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose158:
+ax_pose 7, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose159:
+ax_pose 8, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose160:
+ax_pose 3, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose161:
+ax_pose 4, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose162:
+ax_pose 5, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose163:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose164:
+ax_pose 3, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose165:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose166:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose167:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose168:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose169:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose170:
+ax_pose 3, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose171:
+ax_pose 16, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sMankeyPose172:
+ax_pose 20, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose173:
+ax_pose 24, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sMankeyPose174:
+ax_pose 28, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose175:
+ax_pose 31, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose176:
+ax_pose 28, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose177:
+ax_pose 24, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sMankeyPose178:
+ax_pose 20, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose179:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose180:
+ax_pose 1, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose181:
+ax_pose 2, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose182:
+ax_pose 3, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose183:
+ax_pose 4, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose184:
+ax_pose 5, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose185:
+ax_pose 6, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose186:
+ax_pose 7, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose187:
+ax_pose 8, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sMankeyPose188:
+ax_pose 9, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose189:
+ax_pose 10, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose190:
+ax_pose 11, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose191:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose192:
+ax_pose 13, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose193:
+ax_pose 14, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose194:
+ax_pose 9, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose195:
+ax_pose 10, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose196:
+ax_pose 11, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sMankeyPose197:
+ax_pose 6, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose198:
+ax_pose 7, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose199:
+ax_pose 8, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose200:
+ax_pose 3, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sMankeyPose201:
+ax_pose 4, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose202:
+ax_pose 5, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sMankeyPose203:
+ax_pose 34, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sMankeyPose204:
+ax_pose 35, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose205:
+ax_pose 36, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose206:
+ax_pose 37, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose207:
+ax_pose 38, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose208:
+ax_pose 37, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMankeyPose209:
+ax_pose 36, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose210:
+ax_pose 35, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sMankeyPose211:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose212:
+ax_pose 3, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sMankeyPose213:
+ax_pose 6, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMankeyPose214:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sMankeyPose215:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sMankeyPose216:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sMankeyPose217:
+ax_pose 6, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sMankeyPose218:
+ax_pose 3, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+.align 2
+sMankeyAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 4, 0, 16, 0, -3, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 4, 0, 17, 0, -3, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 4, 0, 19, 0, -3, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 4, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 4, 0, 22, 0, -3, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 4, 0, 23, 0, -3, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 4, 0, 24, 0, -5, 0, -5,
+ax_anim 4, 0, 26, 0, -5, 0, -5,
+ax_anim 2, 0, 24, 0, -5, 0, -5,
+ax_anim 2, 0, 25, 0, -5, 0, -5,
+ax_anim 2, 0, 24, 0, -5, 0, -5,
+ax_anim 2, 0, 26, 0, -5, 0, -5,
+ax_anim 1, 2, 25, 0, -2, 0, -1,
+ax_anim 1, 0, 26, 0, -1, 0, 1,
+ax_anim 1, 0, 25, 0, 5, 0, 8,
+ax_anim 1, 0, 26, 0, 14, 0, 14,
+ax_anim 2, 1, 25, 1, 14, 1, 14,
+ax_anim 2, 0, 26, 0, 14, 0, 14,
+ax_anim 2, 0, 25, 1, 14, 1, 14,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMankeyAnims_2_2:
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 4, 0, 27, -5, -5, -5, -5,
+ax_anim 4, 0, 29, -5, -5, -5, -5,
+ax_anim 2, 0, 27, -5, -5, -5, -5,
+ax_anim 2, 0, 28, -5, -5, -5, -5,
+ax_anim 2, 0, 27, -5, -5, -5, -5,
+ax_anim 2, 0, 29, -5, -5, -5, -5,
+ax_anim 1, 2, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 3, 3, 3, 3,
+ax_anim 1, 0, 28, 9, 9, 9, 9,
+ax_anim 1, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sMankeyAnims_2_3:
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 4, 0, 30, -5, 0, -5, 0,
+ax_anim 4, 0, 32, -5, 0, -5, 0,
+ax_anim 2, 0, 30, -5, 0, -5, 0,
+ax_anim 2, 0, 31, -5, 0, -5, 0,
+ax_anim 2, 0, 30, -5, 0, -5, 0,
+ax_anim 2, 0, 32, -5, 0, -5, 0,
+ax_anim 1, 2, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 3, 0, 3, 0,
+ax_anim 1, 0, 31, 9, 0, 9, 0,
+ax_anim 1, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 19, 0, 19, 0,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sMankeyAnims_2_4:
+ax_anim 2, 0, 34, -2, 2, -2, 2,
+ax_anim 4, 0, 33, -5, 5, -5, 5,
+ax_anim 4, 0, 35, -5, 5, -5, 5,
+ax_anim 2, 0, 33, -5, 5, -5, 5,
+ax_anim 2, 0, 34, -5, 5, -5, 5,
+ax_anim 2, 0, 33, -5, 5, -5, 5,
+ax_anim 2, 0, 35, -5, 5, -5, 5,
+ax_anim 1, 2, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 3, -3, 3, -3,
+ax_anim 1, 0, 34, 9, -9, 9, -9,
+ax_anim 1, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 1, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMankeyAnims_2_5:
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 4, 0, 36, 0, 5, 0, 5,
+ax_anim 4, 0, 38, 0, 5, 0, 5,
+ax_anim 2, 0, 36, 0, 5, 0, 5,
+ax_anim 2, 0, 37, 0, 5, 0, 5,
+ax_anim 2, 0, 36, 0, 5, 0, 5,
+ax_anim 2, 0, 38, 0, 5, 0, 5,
+ax_anim 1, 2, 37, 0, 2, 0, 1,
+ax_anim 1, 0, 38, 0, 1, 0, -1,
+ax_anim 1, 0, 37, 0, -5, 0, -8,
+ax_anim 1, 0, 38, 0, -14, 0, -14,
+ax_anim 2, 1, 37, 1, -14, 1, -14,
+ax_anim 2, 0, 38, 0, -14, 0, -14,
+ax_anim 2, 0, 37, 1, -14, 1, -14,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMankeyAnims_2_6:
+ax_anim 2, 0, 40, 2, 2, 2, 2,
+ax_anim 4, 0, 39, 5, 5, 5, 5,
+ax_anim 4, 0, 41, 5, 5, 5, 5,
+ax_anim 2, 0, 39, 5, 5, 5, 5,
+ax_anim 2, 0, 40, 5, 5, 5, 5,
+ax_anim 2, 0, 39, 5, 5, 5, 5,
+ax_anim 2, 0, 41, 5, 5, 5, 5,
+ax_anim 1, 2, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, -3, -3, -3, -3,
+ax_anim 1, 0, 40, -9, -9, -9, -9,
+ax_anim 1, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 1, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMankeyAnims_2_7:
+ax_anim 2, 0, 43, 2, 0, 2, 0,
+ax_anim 4, 0, 42, 5, 0, 5, 0,
+ax_anim 4, 0, 44, 5, 0, 5, 0,
+ax_anim 2, 0, 42, 5, 0, 5, 0,
+ax_anim 2, 0, 43, 5, 0, 5, 0,
+ax_anim 2, 0, 42, 5, 0, 5, 0,
+ax_anim 2, 0, 44, 5, 0, 5, 0,
+ax_anim 1, 2, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 44, -3, 0, -3, 0,
+ax_anim 1, 0, 43, -9, 0, -9, 0,
+ax_anim 1, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -19, 0, -19, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sMankeyAnims_2_8:
+ax_anim 2, 0, 46, 2, -2, 2, -2,
+ax_anim 4, 0, 45, 5, -5, 5, -5,
+ax_anim 4, 0, 47, 5, -5, 5, -5,
+ax_anim 2, 0, 45, 5, -5, 5, -5,
+ax_anim 2, 0, 46, 5, -5, 5, -5,
+ax_anim 2, 0, 45, 5, -5, 5, -5,
+ax_anim 2, 0, 47, 5, -5, 5, -5,
+ax_anim 1, 2, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 47, -3, 3, -3, 3,
+ax_anim 1, 0, 46, -9, 9, -9, 9,
+ax_anim 1, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 1, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMankeyAnims_3_1:
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim 4, 0, 48, 0, -3, 0, -3,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 0, 49, 0, 6, 0, 6,
+ax_anim 2, 0, 49, 0, 15, 0, 15,
+ax_anim 2, 2, 54, 0, 17, 0, 17,
+ax_anim 2, 0, 60, 0, 19, 0, 19,
+ax_anim 2, 1, 61, 1, 20, 1, 20,
+ax_anim 1, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 48, 0, 16, 0, 16,
+ax_anim 1, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 102, 0, 19, 0, 19,
+ax_anim 2, 0, 103, -1, 20, -1, 20,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 0, 50, 0, 8, 0, 8,
+ax_anim 2, 0, 50, 0, 3, 0, 4,
+ax_anim_terminator
+sMankeyAnims_3_2:
+ax_anim 2, 0, 55, -2, -2, -2, -2,
+ax_anim 4, 0, 55, -3, -3, -3, -3,
+ax_anim 1, 0, 56, 0, -1, 0, 0,
+ax_anim 1, 0, 56, 5, 1, 5, 5,
+ax_anim 2, 0, 56, 12, 8, 12, 13,
+ax_anim 2, 2, 61, 17, 17, 17, 18,
+ax_anim 2, 0, 53, 20, 19, 18, 19,
+ax_anim 2, 1, 54, 20, 20, 18, 19,
+ax_anim 1, 0, 55, 17, 18, 17, 18,
+ax_anim 2, 0, 54, 16, 17, 16, 17,
+ax_anim 1, 0, 54, 17, 18, 17, 18,
+ax_anim 2, 0, 67, 20, 21, 18, 19,
+ax_anim 2, 0, 68, 21, 22, 18, 19,
+ax_anim 2, 0, 57, 15, 13, 15, 16,
+ax_anim 2, 0, 57, 8, 2, 8, 8,
+ax_anim 2, 0, 57, 5, 0, 5, 5,
+ax_anim_terminator
+sMankeyAnims_3_3:
+ax_anim 2, 0, 62, -2, 0, -2, 0,
+ax_anim 4, 0, 62, -3, 0, -3, 0,
+ax_anim 1, 0, 63, 0, -2, 0, 0,
+ax_anim 1, 0, 63, 5, -5, 5, 0,
+ax_anim 2, 0, 63, 10, -5, 10, 0,
+ax_anim 2, 2, 68, 17, 0, 17, 0,
+ax_anim 2, 0, 58, 18, 0, 18, 0,
+ax_anim 2, 1, 59, 19, 1, 19, 1,
+ax_anim 1, 0, 62, 17, 0, 17, 0,
+ax_anim 2, 0, 62, 16, 0, 16, 0,
+ax_anim 1, 0, 66, 17, 0, 17, 0,
+ax_anim 2, 0, 74, 18, 0, 18, 0,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 2, 0, 64, 15, -5, 15, 0,
+ax_anim 2, 0, 64, 8, -6, 8, 0,
+ax_anim 2, 0, 64, 4, -3, 4, 0,
+ax_anim_terminator
+sMankeyAnims_3_4:
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 4, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 0, 70, 0, -3, 0, 0,
+ax_anim 1, 0, 70, 5, -11, 5, -5,
+ax_anim 2, 0, 70, 10, -15, 10, -10,
+ax_anim 2, 2, 75, 17, -17, 17, -17,
+ax_anim 2, 0, 65, 18, -18, 18, -18,
+ax_anim 2, 1, 66, 19, -18, 19, -18,
+ax_anim 1, 0, 69, 17, -17, 17, -17,
+ax_anim 2, 0, 69, 16, -16, 16, -16,
+ax_anim 1, 0, 73, 17, -17, 17, -17,
+ax_anim 2, 0, 79, 18, -18, 18, -18,
+ax_anim 2, 0, 80, 19, -19, 19, -19,
+ax_anim 2, 0, 71, 11, -16, 11, -11,
+ax_anim 2, 0, 71, 4, -9, 3, -3,
+ax_anim 2, 0, 71, 1, -5, 1, -1,
+ax_anim_terminator
+sMankeyAnims_3_5:
+ax_anim 2, 0, 76, 0, 2, 0, 2,
+ax_anim 4, 0, 76, 0, 3, 0, 3,
+ax_anim 1, 0, 77, 0, -1, 0, -2,
+ax_anim 1, 0, 77, 0, -9, 0, -9,
+ax_anim 2, 0, 77, 0, -11, 0, -14,
+ax_anim 2, 2, 82, 0, -17, 0, -17,
+ax_anim 2, 0, 86, 0, -19, 0, -18,
+ax_anim 2, 1, 87, -1, -20, -1, -20,
+ax_anim 1, 0, 76, 0, -17, 0, -17,
+ax_anim 2, 0, 76, 0, -16, 0, -16,
+ax_anim 1, 0, 80, 0, -17, 0, -17,
+ax_anim 2, 0, 72, 0, -19, 0, -18,
+ax_anim 2, 0, 75, 1, -20, 1, -20,
+ax_anim 2, 0, 78, 0, -14, 0, -13,
+ax_anim 2, 0, 78, 0, -8, 0, -6,
+ax_anim 2, 0, 78, 0, -4, 0, -3,
+ax_anim_terminator
+sMankeyAnims_3_6:
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 4, 0, 83, 3, 3, 3, 3,
+ax_anim 1, 0, 84, 0, -3, 0, 0,
+ax_anim 1, 0, 84, -5, -11, -5, -5,
+ax_anim 2, 0, 84, -10, -15, -10, -10,
+ax_anim 2, 2, 89, -17, -17, -17, -17,
+ax_anim 2, 0, 93, -18, -18, -18, -18,
+ax_anim 2, 1, 94, -19, -18, -19, -18,
+ax_anim 1, 0, 83, -17, -17, -17, -17,
+ax_anim 2, 0, 83, -16, -16, -16, -16,
+ax_anim 1, 0, 87, -17, -17, -17, -17,
+ax_anim 2, 0, 81, -18, -18, -18, -18,
+ax_anim 2, 0, 82, -18, -19, -18, -19,
+ax_anim 2, 0, 85, -11, -16, -11, -11,
+ax_anim 2, 0, 85, -5, -11, -5, -5,
+ax_anim 2, 0, 85, -3, -7, -3, -3,
+ax_anim_terminator
+sMankeyAnims_3_7:
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim 4, 0, 90, 3, 0, 3, 0,
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 1, 0, 91, -5, -5, -5, 0,
+ax_anim 2, 0, 91, -10, -5, -10, 0,
+ax_anim 2, 2, 90, -17, 0, -17, 0,
+ax_anim 2, 0, 100, -18, 0, -18, 0,
+ax_anim 2, 1, 101, -19, 1, -19, 1,
+ax_anim 1, 0, 90, -17, 0, -17, 0,
+ax_anim 2, 0, 90, -16, 0, -16, 0,
+ax_anim 1, 0, 94, -17, 0, -17, 0,
+ax_anim 2, 0, 88, -18, 0, -18, 0,
+ax_anim 2, 0, 89, -18, 0, -18, 0,
+ax_anim 2, 0, 92, -15, -7, -15, 0,
+ax_anim 2, 0, 92, -8, -6, -8, 0,
+ax_anim 2, 0, 92, -4, -4, -4, 0,
+ax_anim_terminator
+sMankeyAnims_3_8:
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim 4, 0, 97, 3, -3, 3, -3,
+ax_anim 1, 0, 98, 0, -1, 0, 0,
+ax_anim 1, 0, 98, -5, 1, -5, 6,
+ax_anim 2, 0, 98, -12, 8, -12, 13,
+ax_anim 2, 2, 103, -17, 17, -17, 18,
+ax_anim 2, 0, 51, -18, 19, -18, 19,
+ax_anim 2, 1, 52, -18, 20, -18, 20,
+ax_anim 1, 0, 97, -17, 18, -17, 18,
+ax_anim 2, 0, 97, -16, 17, -16, 17,
+ax_anim 1, 0, 101, -17, 18, -17, 18,
+ax_anim 2, 0, 95, -18, 19, -18, 19,
+ax_anim 2, 0, 96, -19, 19, -19, 19,
+ax_anim 2, 0, 99, -15, 13, -15, 16,
+ax_anim 2, 0, 99, -8, 2, -8, 8,
+ax_anim 2, 0, 99, -4, 0, -4, 4,
+ax_anim_terminator
+.align 2
+sMankeyAnims_4_1:
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim 2, 1, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_4_2:
+ax_anim 2, 0, 111, 1, -1, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, 0,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_4_3:
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 1, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_4_4:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_4_5:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_4_6:
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_4_7:
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_4_8:
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 118, 0, -10, 0, 0,
+ax_anim 2, 0, 117, 0, -12, 0, 0,
+ax_anim 2, 0, 116, 0, -13, 0, 0,
+ax_anim 2, 0, 115, 0, -12, 0, 0,
+ax_anim 1, 0, 114, 0, -10, 0, 0,
+ax_anim 1, 0, 113, 0, -5, 0, 0,
+ax_anim 1, 2, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 1, 0, 113, 0, -10, 0, 0,
+ax_anim 2, 0, 114, 0, -12, 0, 0,
+ax_anim 2, 0, 115, 0, -13, 0, 0,
+ax_anim 2, 0, 116, 0, -12, 0, 0,
+ax_anim 1, 0, 117, 0, -10, 0, 0,
+ax_anim 1, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 2, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 112, 0, -10, 0, 0,
+ax_anim 2, 0, 113, 0, -12, 0, 0,
+ax_anim 2, 0, 114, 0, -13, 0, 0,
+ax_anim 2, 0, 115, 0, -12, 0, 0,
+ax_anim 1, 0, 116, 0, -10, 0, 0,
+ax_anim 1, 0, 117, 0, -5, 0, 0,
+ax_anim 1, 2, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -10, 0, 0,
+ax_anim 2, 0, 112, 0, -12, 0, 0,
+ax_anim 2, 0, 113, 0, -13, 0, 0,
+ax_anim 2, 0, 114, 0, -12, 0, 0,
+ax_anim 1, 0, 115, 0, -10, 0, 0,
+ax_anim 1, 0, 116, 0, -5, 0, 0,
+ax_anim 1, 2, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 0, 114, 0, -10, 0, 0,
+ax_anim 2, 0, 113, 0, -12, 0, 0,
+ax_anim 2, 0, 112, 0, -13, 0, 0,
+ax_anim 2, 0, 119, 0, -12, 0, 0,
+ax_anim 1, 0, 118, 0, -10, 0, 0,
+ax_anim 1, 0, 117, 0, -5, 0, 0,
+ax_anim 1, 2, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 1, 0, 113, 0, -10, 0, 0,
+ax_anim 2, 0, 112, 0, -12, 0, 0,
+ax_anim 2, 0, 119, 0, -13, 0, 0,
+ax_anim 2, 0, 118, 0, -12, 0, 0,
+ax_anim 1, 0, 117, 0, -10, 0, 0,
+ax_anim 1, 0, 116, 0, -5, 0, 0,
+ax_anim 1, 2, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -5, 0, 0,
+ax_anim 1, 0, 112, 0, -10, 0, 0,
+ax_anim 2, 0, 119, 0, -12, 0, 0,
+ax_anim 2, 0, 118, 0, -13, 0, 0,
+ax_anim 2, 0, 117, 0, -12, 0, 0,
+ax_anim 1, 0, 116, 0, -10, 0, 0,
+ax_anim 1, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 2, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -10, 0, 0,
+ax_anim 2, 0, 118, 0, -12, 0, 0,
+ax_anim 2, 0, 117, 0, -13, 0, 0,
+ax_anim 2, 0, 116, 0, -12, 0, 0,
+ax_anim 1, 0, 115, 0, -10, 0, 0,
+ax_anim 1, 0, 114, 0, -5, 0, 0,
+ax_anim 1, 2, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sMankeyAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sMankeyAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sMankeyAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sMankeyAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sMankeyAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sMankeyAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sMankeyAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMankeyAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_8_2:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_8_4:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -3, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_8_5:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -3, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_8_6:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 158, 0, -4, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim_terminator
+sMankeyAnims_8_8:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 4, 0, 161, 0, -4, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 19, 7, 19,
+ax_anim 3, 0, 166, 0, 22, 0, 22,
+ax_anim 2, 3, 167, -7, 20, -7, 20,
+ax_anim 2, 0, 168, -8, 10, -8, 10,
+ax_anim 1, 0, 169, -6, 5, -6, 5,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 24, 9, 24, 9,
+ax_anim 3, 0, 165, 23, 21, 23, 21,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 12, 2, 12,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 20, 1, 20, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 11, -20, 11, -20,
+ax_anim 3, 0, 163, 19, -20, 19, -20,
+ax_anim 2, 3, 164, 21, -13, 21, -13,
+ax_anim 2, 0, 165, 16, -2, 16, -2,
+ax_anim 1, 0, 166, 7, 1, 7, 1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -21, 0, -21,
+ax_anim 2, 3, 163, 7, -17, 7, -17,
+ax_anim 2, 0, 164, 8, -7, 8, -7,
+ax_anim 1, 0, 165, 6, -3, 6, -3,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -11, -20, -11, -20,
+ax_anim 3, 0, 169, -19, -20, -19, -20,
+ax_anim 2, 3, 168, -21, -13, -21, -13,
+ax_anim 2, 0, 167, -16, -2, -16, -2,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -20, 1, -20, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -24, 9, -24, 9,
+ax_anim 3, 0, 167, -23, 21, -23, 16,
+ax_anim 2, 3, 166, -11, 21, -11, 16,
+ax_anim 2, 0, 165, -2, 12, -4, 12,
+ax_anim 1, 0, 164, 0, 7, -3, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMankeyAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMankeyGfx1:
+.incbin "baserom.gba", 0x7720D0, 0x200
+sMankeySprites1:
+ax_sprite sMankeyGfx1, 0x200
+ax_sprite_terminator
+sMankeyGfx2:
+.incbin "baserom.gba", 0x7722E0, 0x200
+sMankeySprites2:
+ax_sprite sMankeyGfx2, 0x200
+ax_sprite_terminator
+sMankeyGfx3:
+.incbin "baserom.gba", 0x7724F0, 0x200
+sMankeySprites3:
+ax_sprite sMankeyGfx3, 0x200
+ax_sprite_terminator
+sMankeyGfx4:
+.incbin "baserom.gba", 0x772700, 0x200
+sMankeySprites4:
+ax_sprite sMankeyGfx4, 0x200
+ax_sprite_terminator
+sMankeyGfx5:
+.incbin "baserom.gba", 0x772910, 0x200
+sMankeySprites5:
+ax_sprite sMankeyGfx5, 0x200
+ax_sprite_terminator
+sMankeyGfx6:
+.incbin "baserom.gba", 0x772B20, 0x200
+sMankeySprites6:
+ax_sprite sMankeyGfx6, 0x200
+ax_sprite_terminator
+sMankeyGfx7:
+.incbin "baserom.gba", 0x772D30, 0x200
+sMankeySprites7:
+ax_sprite sMankeyGfx7, 0x200
+ax_sprite_terminator
+sMankeyGfx8:
+.incbin "baserom.gba", 0x772F40, 0x200
+sMankeySprites8:
+ax_sprite sMankeyGfx8, 0x200
+ax_sprite_terminator
+sMankeyGfx9:
+.incbin "baserom.gba", 0x773150, 0x200
+sMankeySprites9:
+ax_sprite sMankeyGfx9, 0x200
+ax_sprite_terminator
+sMankeyGfx10:
+.incbin "baserom.gba", 0x773360, 0x200
+sMankeySprites10:
+ax_sprite sMankeyGfx10, 0x200
+ax_sprite_terminator
+sMankeyGfx11:
+.incbin "baserom.gba", 0x773570, 0x200
+sMankeySprites11:
+ax_sprite sMankeyGfx11, 0x200
+ax_sprite_terminator
+sMankeyGfx12:
+.incbin "baserom.gba", 0x773780, 0x200
+sMankeySprites12:
+ax_sprite sMankeyGfx12, 0x200
+ax_sprite_terminator
+sMankeyGfx13:
+.incbin "baserom.gba", 0x773990, 0x200
+sMankeySprites13:
+ax_sprite sMankeyGfx13, 0x200
+ax_sprite_terminator
+sMankeyGfx14:
+.incbin "baserom.gba", 0x773BA0, 0x200
+sMankeySprites14:
+ax_sprite sMankeyGfx14, 0x200
+ax_sprite_terminator
+sMankeyGfx15:
+.incbin "baserom.gba", 0x773DB0, 0x200
+sMankeySprites15:
+ax_sprite sMankeyGfx15, 0x200
+ax_sprite_terminator
+sMankeyGfx16:
+.incbin "baserom.gba", 0x773FC0, 0xE0
+sMankeySprites16:
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx16, 0xe0
+ax_sprite_terminator
+sMankeyGfx17:
+.incbin "baserom.gba", 0x7740B8, 0x40
+sMankeyGfx17_1:
+.incbin "baserom.gba", 0x7740F8, 0x160
+sMankeySprites17:
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx17_1, 0x160
+ax_sprite_terminator
+sMankeyGfx18:
+.incbin "baserom.gba", 0x774280, 0x80
+sMankeyGfx18_1:
+.incbin "baserom.gba", 0x774300, 0x60
+sMankeySprites18:
+ax_sprite sMankeyGfx18, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx18_1, 0x60
+ax_sprite_terminator
+sMankeyGfx19:
+.incbin "baserom.gba", 0x774380, 0x40
+sMankeyGfx19_1:
+.incbin "baserom.gba", 0x7743C0, 0x80
+sMankeyGfx19_2:
+.incbin "baserom.gba", 0x774440, 0xE0
+sMankeySprites19:
+ax_sprite sMankeyGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx19_2, 0xe0
+ax_sprite_terminator
+sMankeyGfx20:
+.incbin "baserom.gba", 0x774550, 0x60
+sMankeyGfx20_1:
+.incbin "baserom.gba", 0x7745B0, 0x20
+sMankeySprites20:
+ax_sprite sMankeyGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx20_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMankeyGfx21:
+.incbin "baserom.gba", 0x7745F8, 0x20
+sMankeyGfx21_1:
+.incbin "baserom.gba", 0x774618, 0x160
+sMankeySprites21:
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx21, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx22:
+.incbin "baserom.gba", 0x7747A8, 0x20
+sMankeyGfx22_1:
+.incbin "baserom.gba", 0x7747C8, 0xA0
+sMankeySprites22:
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx22, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx22_1, 0xa0
+ax_sprite_terminator
+sMankeyGfx23:
+.incbin "baserom.gba", 0x774890, 0x40
+sMankeyGfx23_1:
+.incbin "baserom.gba", 0x7748D0, 0x160
+sMankeySprites23:
+ax_sprite sMankeyGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx23_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx24:
+.incbin "baserom.gba", 0x774A58, 0xA0
+sMankeyGfx24_1:
+.incbin "baserom.gba", 0x774AF8, 0x20
+sMankeySprites24:
+ax_sprite sMankeyGfx24, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx24_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx25:
+.incbin "baserom.gba", 0x774B40, 0x20
+sMankeyGfx25_1:
+.incbin "baserom.gba", 0x774B60, 0x60
+sMankeyGfx25_2:
+.incbin "baserom.gba", 0x774BC0, 0xE0
+sMankeySprites25:
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx25, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx25_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx26:
+.incbin "baserom.gba", 0x774CE0, 0x20
+sMankeyGfx26_1:
+.incbin "baserom.gba", 0x774D00, 0x80
+sMankeySprites26:
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx26, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx26_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx27:
+.incbin "baserom.gba", 0x774DB0, 0x40
+sMankeyGfx27_1:
+.incbin "baserom.gba", 0x774DF0, 0x60
+sMankeyGfx27_2:
+.incbin "baserom.gba", 0x774E50, 0xE0
+sMankeySprites27:
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx27_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx28:
+.incbin "baserom.gba", 0x774F70, 0x60
+sMankeySprites28:
+ax_sprite sMankeyGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx29:
+.incbin "baserom.gba", 0x774FE8, 0x40
+sMankeyGfx29_1:
+.incbin "baserom.gba", 0x775028, 0x60
+sMankeyGfx29_2:
+.incbin "baserom.gba", 0x775088, 0x60
+sMankeySprites29:
+ax_sprite 0, 0xa0
+ax_sprite sMankeyGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx30:
+.incbin "baserom.gba", 0x775128, 0x60
+sMankeyGfx30_1:
+.incbin "baserom.gba", 0x775188, 0x20
+sMankeySprites30:
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx30_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx31:
+.incbin "baserom.gba", 0x7751D8, 0x40
+sMankeyGfx31_1:
+.incbin "baserom.gba", 0x775218, 0xC0
+sMankeyGfx31_2:
+.incbin "baserom.gba", 0x7752D8, 0x60
+sMankeySprites31:
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx31_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx32:
+.incbin "baserom.gba", 0x775378, 0x40
+sMankeyGfx32_1:
+.incbin "baserom.gba", 0x7753B8, 0x100
+sMankeyGfx32_2:
+.incbin "baserom.gba", 0x7754B8, 0x40
+sMankeySprites32:
+ax_sprite sMankeyGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx33:
+.incbin "baserom.gba", 0x775530, 0x80
+sMankeySprites33:
+ax_sprite sMankeyGfx33, 0x80
+ax_sprite_terminator
+sMankeyGfx34:
+.incbin "baserom.gba", 0x7755C0, 0x140
+sMankeyGfx34_1:
+.incbin "baserom.gba", 0x775700, 0x40
+sMankeySprites34:
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx34, 0x140
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx35:
+.incbin "baserom.gba", 0x775770, 0x160
+sMankeySprites35:
+ax_sprite 0, 0xa0
+ax_sprite sMankeyGfx35, 0x160
+ax_sprite_terminator
+sMankeyGfx36:
+.incbin "baserom.gba", 0x7758E8, 0x160
+sMankeySprites36:
+ax_sprite 0, 0x80
+ax_sprite sMankeyGfx36, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx37:
+.incbin "baserom.gba", 0x775A68, 0x60
+sMankeyGfx37_1:
+.incbin "baserom.gba", 0x775AC8, 0xE0
+sMankeySprites37:
+ax_sprite 0, 0x80
+ax_sprite sMankeyGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx37_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx38:
+.incbin "baserom.gba", 0x775BD8, 0x40
+sMankeyGfx38_1:
+.incbin "baserom.gba", 0x775C18, 0x60
+sMankeyGfx38_2:
+.incbin "baserom.gba", 0x775C78, 0x60
+sMankeySprites38:
+ax_sprite 0, 0xa0
+ax_sprite sMankeyGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx39:
+.incbin "baserom.gba", 0x775D18, 0x100
+sMankeyGfx39_1:
+.incbin "baserom.gba", 0x775E18, 0x40
+sMankeySprites39:
+ax_sprite 0, 0x80
+ax_sprite sMankeyGfx39, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx40:
+.incbin "baserom.gba", 0x775E88, 0x40
+sMankeyGfx40_1:
+.incbin "baserom.gba", 0x775EC8, 0x60
+sMankeyGfx40_2:
+.incbin "baserom.gba", 0x775F28, 0xE0
+sMankeySprites40:
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx40_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx41:
+.incbin "baserom.gba", 0x776048, 0x20
+sMankeyGfx41_1:
+.incbin "baserom.gba", 0x776068, 0x60
+sMankeyGfx41_2:
+.incbin "baserom.gba", 0x7760C8, 0x60
+sMankeyGfx41_3:
+.incbin "baserom.gba", 0x776128, 0x60
+sMankeySprites41:
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx41, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx41_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx42:
+.incbin "baserom.gba", 0x7761D8, 0xE0
+sMankeyGfx42_1:
+.incbin "baserom.gba", 0x7762B8, 0x40
+sMankeySprites42:
+ax_sprite 0, 0x80
+ax_sprite sMankeyGfx42, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx42_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx43:
+.incbin "baserom.gba", 0x776328, 0x20
+sMankeyGfx43_1:
+.incbin "baserom.gba", 0x776348, 0x60
+sMankeyGfx43_2:
+.incbin "baserom.gba", 0x7763A8, 0xE0
+sMankeySprites43:
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx43, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMankeyGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx43_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMankeyGfx44:
+.incbin "baserom.gba", 0x7764C8, 0x40
+sMankeyGfx44_1:
+.incbin "baserom.gba", 0x776508, 0x60
+sMankeyGfx44_2:
+.incbin "baserom.gba", 0x776568, 0x100
+sMankeySprites44:
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMankeyGfx44_2, 0x100
+ax_sprite_terminator
+sMankeyGfx45:
+.incbin "baserom.gba", 0x7766A0, 0x200
+sMankeySprites45:
+ax_sprite sMankeyGfx45, 0x200
+ax_sprite_terminator
+sMankeyGfx46:
+.incbin "baserom.gba", 0x7768B0, 0x200
+sMankeySprites46:
+ax_sprite sMankeyGfx46, 0x200
+ax_sprite_terminator
+sMankeyGfx47:
+.incbin "baserom.gba", 0x776AC0, 0x200
+sMankeySprites47:
+ax_sprite sMankeyGfx47, 0x200
+ax_sprite_terminator
+sMankeyGfx48:
+.incbin "baserom.gba", 0x776CD0, 0x200
+sMankeySprites48:
+ax_sprite sMankeyGfx48, 0x200
+ax_sprite_terminator
+sMankeyGfx49:
+.incbin "baserom.gba", 0x776EE0, 0x200
+sMankeySprites49:
+ax_sprite sMankeyGfx49, 0x200
+ax_sprite_terminator
+sMankeyGfx50:
+.incbin "baserom.gba", 0x7770F0, 0x200
+sMankeySprites50:
+ax_sprite sMankeyGfx50, 0x200
+ax_sprite_terminator
+sMankeyGfx51:
+.incbin "baserom.gba", 0x777300, 0x200
+sMankeySprites51:
+ax_sprite sMankeyGfx51, 0x200
+ax_sprite_terminator
+sAxPosesMankey:
+.4byte sMankeyPose1
+.4byte sMankeyPose2
+.4byte sMankeyPose3
+.4byte sMankeyPose4
+.4byte sMankeyPose5
+.4byte sMankeyPose6
+.4byte sMankeyPose7
+.4byte sMankeyPose8
+.4byte sMankeyPose9
+.4byte sMankeyPose10
+.4byte sMankeyPose11
+.4byte sMankeyPose12
+.4byte sMankeyPose13
+.4byte sMankeyPose14
+.4byte sMankeyPose15
+.4byte sMankeyPose16
+.4byte sMankeyPose17
+.4byte sMankeyPose18
+.4byte sMankeyPose19
+.4byte sMankeyPose20
+.4byte sMankeyPose21
+.4byte sMankeyPose22
+.4byte sMankeyPose23
+.4byte sMankeyPose24
+.4byte sMankeyPose25
+.4byte sMankeyPose26
+.4byte sMankeyPose27
+.4byte sMankeyPose28
+.4byte sMankeyPose29
+.4byte sMankeyPose30
+.4byte sMankeyPose31
+.4byte sMankeyPose32
+.4byte sMankeyPose33
+.4byte sMankeyPose34
+.4byte sMankeyPose35
+.4byte sMankeyPose36
+.4byte sMankeyPose37
+.4byte sMankeyPose38
+.4byte sMankeyPose39
+.4byte sMankeyPose40
+.4byte sMankeyPose41
+.4byte sMankeyPose42
+.4byte sMankeyPose43
+.4byte sMankeyPose44
+.4byte sMankeyPose45
+.4byte sMankeyPose46
+.4byte sMankeyPose47
+.4byte sMankeyPose48
+.4byte sMankeyPose49
+.4byte sMankeyPose50
+.4byte sMankeyPose51
+.4byte sMankeyPose52
+.4byte sMankeyPose53
+.4byte sMankeyPose54
+.4byte sMankeyPose55
+.4byte sMankeyPose56
+.4byte sMankeyPose57
+.4byte sMankeyPose58
+.4byte sMankeyPose59
+.4byte sMankeyPose60
+.4byte sMankeyPose61
+.4byte sMankeyPose62
+.4byte sMankeyPose63
+.4byte sMankeyPose64
+.4byte sMankeyPose65
+.4byte sMankeyPose66
+.4byte sMankeyPose67
+.4byte sMankeyPose68
+.4byte sMankeyPose69
+.4byte sMankeyPose70
+.4byte sMankeyPose71
+.4byte sMankeyPose72
+.4byte sMankeyPose73
+.4byte sMankeyPose74
+.4byte sMankeyPose75
+.4byte sMankeyPose76
+.4byte sMankeyPose77
+.4byte sMankeyPose78
+.4byte sMankeyPose79
+.4byte sMankeyPose80
+.4byte sMankeyPose81
+.4byte sMankeyPose82
+.4byte sMankeyPose83
+.4byte sMankeyPose84
+.4byte sMankeyPose85
+.4byte sMankeyPose86
+.4byte sMankeyPose87
+.4byte sMankeyPose88
+.4byte sMankeyPose89
+.4byte sMankeyPose90
+.4byte sMankeyPose91
+.4byte sMankeyPose92
+.4byte sMankeyPose93
+.4byte sMankeyPose94
+.4byte sMankeyPose95
+.4byte sMankeyPose96
+.4byte sMankeyPose97
+.4byte sMankeyPose98
+.4byte sMankeyPose99
+.4byte sMankeyPose100
+.4byte sMankeyPose101
+.4byte sMankeyPose102
+.4byte sMankeyPose103
+.4byte sMankeyPose104
+.4byte sMankeyPose105
+.4byte sMankeyPose106
+.4byte sMankeyPose107
+.4byte sMankeyPose108
+.4byte sMankeyPose109
+.4byte sMankeyPose110
+.4byte sMankeyPose111
+.4byte sMankeyPose112
+.4byte sMankeyPose113
+.4byte sMankeyPose114
+.4byte sMankeyPose115
+.4byte sMankeyPose116
+.4byte sMankeyPose117
+.4byte sMankeyPose118
+.4byte sMankeyPose119
+.4byte sMankeyPose120
+.4byte sMankeyPose121
+.4byte sMankeyPose122
+.4byte sMankeyPose123
+.4byte sMankeyPose124
+.4byte sMankeyPose125
+.4byte sMankeyPose126
+.4byte sMankeyPose127
+.4byte sMankeyPose128
+.4byte sMankeyPose129
+.4byte sMankeyPose130
+.4byte sMankeyPose131
+.4byte sMankeyPose132
+.4byte sMankeyPose133
+.4byte sMankeyPose134
+.4byte sMankeyPose135
+.4byte sMankeyPose136
+.4byte sMankeyPose137
+.4byte sMankeyPose138
+.4byte sMankeyPose139
+.4byte sMankeyPose140
+.4byte sMankeyPose141
+.4byte sMankeyPose142
+.4byte sMankeyPose143
+.4byte sMankeyPose144
+.4byte sMankeyPose145
+.4byte sMankeyPose146
+.4byte sMankeyPose147
+.4byte sMankeyPose148
+.4byte sMankeyPose149
+.4byte sMankeyPose150
+.4byte sMankeyPose151
+.4byte sMankeyPose152
+.4byte sMankeyPose153
+.4byte sMankeyPose154
+.4byte sMankeyPose155
+.4byte sMankeyPose156
+.4byte sMankeyPose157
+.4byte sMankeyPose158
+.4byte sMankeyPose159
+.4byte sMankeyPose160
+.4byte sMankeyPose161
+.4byte sMankeyPose162
+.4byte sMankeyPose163
+.4byte sMankeyPose164
+.4byte sMankeyPose165
+.4byte sMankeyPose166
+.4byte sMankeyPose167
+.4byte sMankeyPose168
+.4byte sMankeyPose169
+.4byte sMankeyPose170
+.4byte sMankeyPose171
+.4byte sMankeyPose172
+.4byte sMankeyPose173
+.4byte sMankeyPose174
+.4byte sMankeyPose175
+.4byte sMankeyPose176
+.4byte sMankeyPose177
+.4byte sMankeyPose178
+.4byte sMankeyPose179
+.4byte sMankeyPose180
+.4byte sMankeyPose181
+.4byte sMankeyPose182
+.4byte sMankeyPose183
+.4byte sMankeyPose184
+.4byte sMankeyPose185
+.4byte sMankeyPose186
+.4byte sMankeyPose187
+.4byte sMankeyPose188
+.4byte sMankeyPose189
+.4byte sMankeyPose190
+.4byte sMankeyPose191
+.4byte sMankeyPose192
+.4byte sMankeyPose193
+.4byte sMankeyPose194
+.4byte sMankeyPose195
+.4byte sMankeyPose196
+.4byte sMankeyPose197
+.4byte sMankeyPose198
+.4byte sMankeyPose199
+.4byte sMankeyPose200
+.4byte sMankeyPose201
+.4byte sMankeyPose202
+.4byte sMankeyPose203
+.4byte sMankeyPose204
+.4byte sMankeyPose205
+.4byte sMankeyPose206
+.4byte sMankeyPose207
+.4byte sMankeyPose208
+.4byte sMankeyPose209
+.4byte sMankeyPose210
+.4byte sMankeyPose211
+.4byte sMankeyPose212
+.4byte sMankeyPose213
+.4byte sMankeyPose214
+.4byte sMankeyPose215
+.4byte sMankeyPose216
+.4byte sMankeyPose217
+.4byte sMankeyPose218
+sAxPositionsMankey:
+.2byte   -1,   -5, 	  -9,  -18, 	   7,  -18, 	  -1,   -8
+.2byte   -1,   -8, 	  -9,  -23, 	   7,  -23, 	  -1,  -11
+.2byte   -1,   -7, 	 -10,  -20, 	   8,  -20, 	  -1,  -10
+.2byte    3,   -6, 	   5,  -20, 	  -5,  -16, 	   1,   -8
+.2byte    2,   -9, 	   4,  -25, 	  -6,  -21, 	   0,  -11
+.2byte    3,   -8, 	   6,  -22, 	  -6,  -18, 	   1,  -10
+.2byte    6,   -6, 	   1,  -20, 	   0,  -13, 	   1,   -7
+.2byte    6,   -9, 	   1,  -24, 	   0,  -18, 	   0,  -10
+.2byte    6,   -9, 	   2,  -23, 	  -1,  -16, 	   1,  -10
+.2byte    4,   -9, 	  -3,  -20, 	   6,  -16, 	   0,   -8
+.2byte    4,  -12, 	  -3,  -24, 	   6,  -21, 	  -1,  -12
+.2byte    3,  -11, 	  -5,  -22, 	   8,  -18, 	   0,  -10
+.2byte   -1,  -10, 	   6,  -18, 	  -8,  -18, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -23, 	  -8,  -23, 	  -1,  -12
+.2byte   -1,  -12, 	   8,  -20, 	 -10,  -20, 	  -1,  -11
+.2byte   -5,   -9, 	   2,  -20, 	  -7,  -16, 	  -1,   -8
+.2byte   -5,  -12, 	   2,  -24, 	  -7,  -21, 	   0,  -12
+.2byte   -4,  -11, 	   4,  -22, 	  -9,  -18, 	  -1,  -10
+.2byte   -7,   -7, 	  -2,  -21, 	  -1,  -14, 	  -2,   -8
+.2byte   -7,  -10, 	  -2,  -25, 	  -1,  -19, 	  -1,  -11
+.2byte   -7,   -9, 	  -3,  -23, 	   0,  -16, 	  -2,  -10
+.2byte   -4,   -6, 	  -6,  -20, 	   4,  -16, 	  -2,   -8
+.2byte   -4,   -9, 	  -6,  -25, 	   4,  -21, 	  -2,  -11
+.2byte   -4,   -8, 	  -7,  -22, 	   5,  -18, 	  -2,  -10
+.2byte   -1,   -6, 	  -9,  -19, 	   7,  -19, 	  -1,   -9
+.2byte   -1,   -7, 	  -9,  -22, 	   7,  -22, 	  -1,  -10
+.2byte   -1,   -7, 	 -10,  -20, 	   8,  -20, 	  -1,  -10
+.2byte    3,   -6, 	   5,  -20, 	  -5,  -16, 	   1,   -8
+.2byte    3,   -8, 	   5,  -24, 	  -5,  -20, 	   1,  -10
+.2byte    3,   -8, 	   6,  -22, 	  -6,  -18, 	   1,  -10
+.2byte    6,   -6, 	   1,  -20, 	   0,  -13, 	   1,   -7
+.2byte    6,   -9, 	   1,  -24, 	   0,  -18, 	   0,  -10
+.2byte    6,   -9, 	   2,  -23, 	  -1,  -16, 	   1,  -10
+.2byte    4,   -9, 	  -3,  -20, 	   6,  -16, 	   0,   -8
+.2byte    4,  -12, 	  -3,  -24, 	   6,  -21, 	  -1,  -12
+.2byte    3,  -11, 	  -5,  -22, 	   8,  -18, 	   0,  -10
+.2byte   -1,  -10, 	   6,  -18, 	  -8,  -18, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -23, 	  -8,  -23, 	  -1,  -12
+.2byte   -1,  -12, 	   8,  -20, 	 -10,  -20, 	  -1,  -11
+.2byte   -5,   -9, 	   2,  -20, 	  -7,  -16, 	  -1,   -8
+.2byte   -5,  -12, 	   2,  -24, 	  -7,  -21, 	   0,  -12
+.2byte   -4,  -11, 	   4,  -22, 	  -9,  -18, 	  -1,  -10
+.2byte   -7,   -7, 	  -2,  -21, 	  -1,  -14, 	  -2,   -8
+.2byte   -7,  -10, 	  -2,  -25, 	  -1,  -19, 	  -1,  -11
+.2byte   -7,   -9, 	  -3,  -23, 	   0,  -16, 	  -2,  -10
+.2byte   -4,   -6, 	  -6,  -20, 	   4,  -16, 	  -2,   -8
+.2byte   -4,   -9, 	  -6,  -25, 	   4,  -21, 	  -2,  -11
+.2byte   -4,   -8, 	  -7,  -22, 	   5,  -18, 	  -2,  -10
+.2byte   -1,   -5, 	  -9,  -18, 	   7,  -18, 	  -1,   -8
+.2byte   -1,   -8, 	  -9,  -23, 	   7,  -23, 	  -1,  -11
+.2byte   -1,   -7, 	 -10,  -20, 	   8,  -20, 	  -1,  -10
+.2byte   -1,   -4, 	 -10,   -1, 	   6,  -20, 	  -1,   -7
+.2byte   -1,   -4, 	 -10,   -1, 	   6,  -20, 	  -1,   -7
+.2byte   -1,   -4, 	  -8,  -20, 	   8,   -2, 	  -1,   -7
+.2byte   -1,   -4, 	  -8,  -20, 	   8,   -2, 	  -1,   -7
+.2byte    3,   -6, 	   5,  -20, 	  -5,  -16, 	   1,   -8
+.2byte    2,   -9, 	   4,  -25, 	  -6,  -21, 	   0,  -11
+.2byte    3,   -8, 	   6,  -22, 	  -6,  -18, 	   1,  -10
+.2byte    4,   -5, 	  11,   -3, 	  -6,  -19, 	   1,   -7
+.2byte    4,   -5, 	  11,   -3, 	  -6,  -19, 	   1,   -7
+.2byte    4,   -5, 	   4,  -21, 	   1,   -1, 	   1,   -7
+.2byte    4,   -5, 	   4,  -21, 	   1,   -1, 	   1,   -7
+.2byte    5,   -7, 	   0,  -21, 	  -1,  -14, 	   0,   -8
+.2byte    6,  -10, 	   1,  -25, 	   0,  -19, 	   0,  -11
+.2byte    6,   -9, 	   2,  -23, 	  -1,  -16, 	   1,  -10
+.2byte    6,   -7, 	   9,   -2, 	  -3,  -17, 	   0,   -8
+.2byte    6,   -7, 	   9,   -2, 	  -3,  -17, 	   0,   -8
+.2byte    6,   -7, 	  -3,  -22, 	   8,   -3, 	  -1,   -8
+.2byte    6,   -7, 	  -3,  -22, 	   8,   -3, 	  -1,   -8
+.2byte    3,   -9, 	  -4,  -20, 	   5,  -16, 	  -1,   -8
+.2byte    4,  -12, 	  -3,  -24, 	   6,  -21, 	  -1,  -12
+.2byte    3,  -11, 	  -5,  -22, 	   8,  -18, 	   0,  -10
+.2byte    4,   -8, 	   5,   -6, 	   5,  -11, 	  -1,   -8
+.2byte    4,   -8, 	   5,   -6, 	   5,  -11, 	  -1,   -8
+.2byte    4,   -8, 	  -9,  -19, 	  10,   -9, 	  -1,   -8
+.2byte    4,   -8, 	  -9,  -19, 	  10,   -9, 	  -1,   -8
+.2byte   -1,  -10, 	   6,  -18, 	  -8,  -18, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -23, 	  -8,  -23, 	  -1,  -12
+.2byte   -1,  -12, 	   8,  -20, 	 -10,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	   6,   -9, 	  -8,  -22, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -9, 	  -8,  -22, 	  -1,   -8
+.2byte   -1,   -9, 	   7,  -22, 	  -8,  -10, 	  -1,   -8
+.2byte   -1,   -9, 	   7,  -22, 	  -8,  -10, 	  -1,   -8
+.2byte   -5,   -9, 	   2,  -20, 	  -7,  -16, 	  -1,   -8
+.2byte   -5,  -12, 	   2,  -24, 	  -7,  -21, 	   0,  -12
+.2byte   -4,  -11, 	   4,  -22, 	  -9,  -18, 	  -1,  -10
+.2byte   -6,   -8, 	  -7,   -6, 	  -7,  -11, 	  -1,   -8
+.2byte   -6,   -8, 	  -7,   -6, 	  -7,  -11, 	  -1,   -8
+.2byte   -6,   -8, 	   7,  -19, 	 -12,   -9, 	  -1,   -8
+.2byte   -6,   -8, 	   7,  -19, 	 -12,   -9, 	  -1,   -8
+.2byte   -7,   -7, 	  -2,  -21, 	  -1,  -14, 	  -2,   -8
+.2byte   -7,  -10, 	  -2,  -25, 	  -1,  -19, 	  -1,  -11
+.2byte   -7,   -9, 	  -3,  -23, 	   0,  -16, 	  -2,  -10
+.2byte   -8,   -7, 	 -11,   -2, 	   1,  -17, 	  -2,   -8
+.2byte   -8,   -7, 	 -11,   -2, 	   1,  -17, 	  -2,   -8
+.2byte   -8,   -7, 	   1,  -22, 	 -10,   -3, 	  -1,   -8
+.2byte   -8,   -7, 	   1,  -22, 	 -10,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -20, 	   4,  -16, 	  -2,   -8
+.2byte   -4,   -9, 	  -6,  -25, 	   4,  -21, 	  -2,  -11
+.2byte   -4,   -8, 	  -7,  -22, 	   5,  -18, 	  -2,  -10
+.2byte   -5,   -5, 	 -12,   -3, 	   5,  -19, 	  -2,   -7
+.2byte   -5,   -5, 	 -12,   -3, 	   5,  -19, 	  -2,   -7
+.2byte   -5,   -5, 	  -5,  -21, 	  -2,   -1, 	  -2,   -7
+.2byte   -5,   -5, 	  -5,  -21, 	  -2,   -1, 	  -2,   -7
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	  -1,   -7
+.2byte   -3,   -5, 	 -10,   -6, 	   4,   -1, 	   0,   -7
+.2byte   -6,   -5, 	 -11,   -9, 	  -7,   -4, 	   1,   -7
+.2byte   -4,   -8, 	  -4,  -11, 	 -13,   -8, 	  -1,   -7
+.2byte   -1,   -7, 	   6,   -8, 	  -8,   -8, 	  -1,   -6
+.2byte    2,   -8, 	   2,  -11, 	  11,   -8, 	  -1,   -7
+.2byte    5,   -5, 	  10,   -9, 	   6,   -4, 	  -2,   -7
+.2byte    2,   -5, 	   9,   -6, 	  -5,   -1, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,  -18, 	   7,  -18, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -20, 	   4,  -16, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -21, 	  -1,  -14, 	  -2,   -8
+.2byte   -5,   -9, 	   2,  -20, 	  -7,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   6,  -18, 	  -8,  -18, 	  -1,   -9
+.2byte    3,   -9, 	  -4,  -20, 	   5,  -16, 	  -1,   -8
+.2byte    5,   -7, 	   0,  -21, 	  -1,  -14, 	   0,   -8
+.2byte    3,   -6, 	   5,  -20, 	  -5,  -16, 	   1,   -8
+.2byte   -7,   -7, 	   0,  -21, 	  -1,  -14, 	  -1,   -8
+.2byte   -4,   -8, 	   4,  -19, 	  -7,  -16, 	  -1,   -9
+.2byte   -1,   -9, 	   6,  -17, 	  -8,  -17, 	  -1,   -8
+.2byte    1,   -9, 	   5,  -16, 	  -4,  -21, 	  -2,   -9
+.2byte    6,   -8, 	   0,  -15, 	   1,  -22, 	  -1,  -10
+.2byte   -3,   -9, 	  -7,  -16, 	   2,  -21, 	   0,   -9
+.2byte   -1,   -9, 	  -8,  -17, 	   6,  -17, 	  -1,   -8
+.2byte    3,   -8, 	  -5,  -19, 	   6,  -16, 	   0,   -9
+.2byte   -1,   -3, 	  -8,   -2, 	   6,   -2, 	  -1,   -5
+.2byte   -1,   -2, 	  -8,   -1, 	   6,   -1, 	  -1,   -5
+.2byte    0,  -10, 	  -9,  -20, 	   9,  -20, 	   0,  -12
+.2byte    4,  -11, 	   4,  -25, 	 -12,  -18, 	  -1,  -12
+.2byte    5,  -13, 	   0,  -23, 	  -5,  -21, 	  -1,  -13
+.2byte    4,  -14, 	  -6,  -23, 	   6,  -18, 	  -1,  -12
+.2byte    0,  -16, 	   9,  -20, 	  -9,  -20, 	   0,  -11
+.2byte   -4,  -14, 	   6,  -23, 	  -6,  -18, 	   1,  -12
+.2byte   -6,  -13, 	  -1,  -23, 	   4,  -21, 	   0,  -13
+.2byte   -4,  -11, 	  -4,  -25, 	  12,  -18, 	   1,  -12
+.2byte   -1,   -6, 	  -9,  -19, 	   7,  -19, 	  -1,   -9
+.2byte   -1,   -9, 	  -9,  -24, 	   7,  -24, 	  -1,  -12
+.2byte   -1,   -8, 	 -10,  -21, 	   8,  -21, 	  -1,  -11
+.2byte    2,   -6, 	   4,  -20, 	  -6,  -16, 	   0,   -8
+.2byte    2,   -8, 	   4,  -24, 	  -6,  -20, 	   0,  -10
+.2byte    3,   -7, 	   6,  -21, 	  -6,  -17, 	   1,   -9
+.2byte    5,   -7, 	   0,  -21, 	  -1,  -14, 	   0,   -8
+.2byte    5,  -10, 	   0,  -25, 	  -1,  -19, 	  -1,  -11
+.2byte    5,  -10, 	   1,  -24, 	  -2,  -17, 	   0,  -11
+.2byte    3,   -8, 	  -4,  -19, 	   5,  -15, 	  -1,   -7
+.2byte    3,  -11, 	  -4,  -23, 	   5,  -20, 	  -2,  -11
+.2byte    2,  -10, 	  -6,  -21, 	   7,  -17, 	  -1,   -9
+.2byte   -1,   -8, 	   6,  -16, 	  -8,  -16, 	  -1,   -7
+.2byte   -1,  -11, 	   6,  -21, 	  -8,  -21, 	  -1,  -10
+.2byte   -1,  -10, 	   8,  -18, 	 -10,  -18, 	  -1,   -9
+.2byte   -5,   -8, 	   2,  -19, 	  -7,  -15, 	  -1,   -7
+.2byte   -5,  -11, 	   2,  -23, 	  -7,  -20, 	   0,  -11
+.2byte   -4,  -10, 	   4,  -21, 	  -9,  -17, 	  -1,   -9
+.2byte   -7,   -7, 	  -2,  -21, 	  -1,  -14, 	  -2,   -8
+.2byte   -7,  -10, 	  -2,  -25, 	  -1,  -19, 	  -1,  -11
+.2byte   -7,   -9, 	  -3,  -23, 	   0,  -16, 	  -2,  -10
+.2byte   -4,   -6, 	  -6,  -20, 	   4,  -16, 	  -2,   -8
+.2byte   -4,   -9, 	  -6,  -25, 	   4,  -21, 	  -2,  -11
+.2byte   -4,   -8, 	  -7,  -22, 	   5,  -18, 	  -2,  -10
+.2byte   -1,   -5, 	  -9,  -18, 	   7,  -18, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -20, 	   4,  -16, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -21, 	  -1,  -14, 	  -2,   -8
+.2byte   -5,   -9, 	   2,  -20, 	  -7,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   6,  -18, 	  -8,  -18, 	  -1,   -9
+.2byte    3,   -9, 	  -4,  -20, 	   5,  -16, 	  -1,   -8
+.2byte    5,   -7, 	   0,  -21, 	  -1,  -14, 	   0,   -8
+.2byte    3,   -6, 	   5,  -20, 	  -5,  -16, 	   1,   -8
+.2byte   -1,   -4, 	 -10,   -1, 	   6,  -20, 	  -1,   -7
+.2byte    2,   -5, 	   9,   -3, 	  -8,  -19, 	  -1,   -7
+.2byte    6,   -7, 	   9,   -2, 	  -3,  -17, 	   0,   -8
+.2byte    4,   -8, 	   5,   -6, 	   5,  -11, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -9, 	  -8,  -22, 	  -1,   -8
+.2byte   -5,   -8, 	  -6,   -6, 	  -6,  -11, 	   0,   -8
+.2byte   -7,   -7, 	 -10,   -2, 	   2,  -17, 	  -1,   -8
+.2byte   -3,   -5, 	 -10,   -3, 	   7,  -19, 	   0,   -7
+.2byte   -1,   -5, 	  -9,  -18, 	   7,  -18, 	  -1,   -8
+.2byte   -1,   -8, 	  -9,  -23, 	   7,  -23, 	  -1,  -11
+.2byte   -1,   -7, 	 -10,  -20, 	   8,  -20, 	  -1,  -10
+.2byte    3,   -6, 	   5,  -20, 	  -5,  -16, 	   1,   -8
+.2byte    2,   -9, 	   4,  -25, 	  -6,  -21, 	   0,  -11
+.2byte    3,   -8, 	   6,  -22, 	  -6,  -18, 	   1,  -10
+.2byte    5,   -6, 	   0,  -20, 	  -1,  -13, 	   0,   -7
+.2byte    5,   -9, 	   0,  -24, 	  -1,  -18, 	  -1,  -10
+.2byte    5,   -9, 	   1,  -23, 	  -2,  -16, 	   0,  -10
+.2byte    3,   -9, 	  -4,  -20, 	   5,  -16, 	  -1,   -8
+.2byte    3,  -12, 	  -4,  -24, 	   5,  -21, 	  -2,  -12
+.2byte    2,  -11, 	  -6,  -22, 	   7,  -18, 	  -1,  -10
+.2byte   -1,  -10, 	   6,  -18, 	  -8,  -18, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -23, 	  -8,  -23, 	  -1,  -12
+.2byte   -1,  -12, 	   8,  -20, 	 -10,  -20, 	  -1,  -11
+.2byte   -4,   -9, 	   3,  -20, 	  -6,  -16, 	   0,   -8
+.2byte   -4,  -12, 	   3,  -24, 	  -6,  -21, 	   1,  -12
+.2byte   -3,  -11, 	   5,  -22, 	  -8,  -18, 	   0,  -10
+.2byte   -6,   -7, 	  -1,  -21, 	   0,  -14, 	  -1,   -8
+.2byte   -6,  -10, 	  -1,  -25, 	   0,  -19, 	   0,  -11
+.2byte   -6,   -9, 	  -2,  -23, 	   1,  -16, 	  -1,  -10
+.2byte   -3,   -6, 	  -5,  -20, 	   5,  -16, 	  -1,   -8
+.2byte   -3,   -9, 	  -5,  -25, 	   5,  -21, 	  -1,  -11
+.2byte   -3,   -8, 	  -6,  -22, 	   6,  -18, 	  -1,  -10
+.2byte   -1,   -5, 	 -10,   -2, 	   8,   -2, 	  -1,   -7
+.2byte   -3,   -5, 	 -10,   -6, 	   4,   -1, 	   0,   -7
+.2byte   -6,   -5, 	 -11,   -9, 	  -7,   -4, 	   1,   -7
+.2byte   -4,   -8, 	  -4,  -11, 	 -13,   -8, 	  -1,   -7
+.2byte   -1,   -7, 	   6,   -8, 	  -8,   -8, 	  -1,   -6
+.2byte    2,   -8, 	   2,  -11, 	  11,   -8, 	  -1,   -7
+.2byte    5,   -5, 	  10,   -9, 	   6,   -4, 	  -2,   -7
+.2byte    2,   -5, 	   9,   -6, 	  -5,   -1, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,  -18, 	   7,  -18, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,  -20, 	   4,  -16, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -21, 	  -1,  -14, 	  -2,   -8
+.2byte   -5,   -9, 	   2,  -20, 	  -7,  -16, 	  -1,   -8
+.2byte   -1,  -10, 	   6,  -18, 	  -8,  -18, 	  -1,   -9
+.2byte    4,   -9, 	  -3,  -20, 	   6,  -16, 	   0,   -8
+.2byte    6,   -7, 	   1,  -21, 	   0,  -14, 	   1,   -8
+.2byte    3,   -6, 	   5,  -20, 	  -5,  -16, 	   1,   -8
+sMankeyAnimTable1:
+.4byte sMankeyAnims_1_1
+.4byte sMankeyAnims_1_2
+.4byte sMankeyAnims_1_3
+.4byte sMankeyAnims_1_4
+.4byte sMankeyAnims_1_5
+.4byte sMankeyAnims_1_6
+.4byte sMankeyAnims_1_7
+.4byte sMankeyAnims_1_8
+sMankeyAnimTable2:
+.4byte sMankeyAnims_2_1
+.4byte sMankeyAnims_2_2
+.4byte sMankeyAnims_2_3
+.4byte sMankeyAnims_2_4
+.4byte sMankeyAnims_2_5
+.4byte sMankeyAnims_2_6
+.4byte sMankeyAnims_2_7
+.4byte sMankeyAnims_2_8
+sMankeyAnimTable3:
+.4byte sMankeyAnims_3_1
+.4byte sMankeyAnims_3_2
+.4byte sMankeyAnims_3_3
+.4byte sMankeyAnims_3_4
+.4byte sMankeyAnims_3_5
+.4byte sMankeyAnims_3_6
+.4byte sMankeyAnims_3_7
+.4byte sMankeyAnims_3_8
+sMankeyAnimTable4:
+.4byte sMankeyAnims_4_1
+.4byte sMankeyAnims_4_2
+.4byte sMankeyAnims_4_3
+.4byte sMankeyAnims_4_4
+.4byte sMankeyAnims_4_5
+.4byte sMankeyAnims_4_6
+.4byte sMankeyAnims_4_7
+.4byte sMankeyAnims_4_8
+sMankeyAnimTable5:
+.4byte sMankeyAnims_5_1
+.4byte sMankeyAnims_5_2
+.4byte sMankeyAnims_5_3
+.4byte sMankeyAnims_5_4
+.4byte sMankeyAnims_5_5
+.4byte sMankeyAnims_5_6
+.4byte sMankeyAnims_5_7
+.4byte sMankeyAnims_5_8
+sMankeyAnimTable6:
+.4byte sMankeyAnims_6_1
+.4byte sMankeyAnims_6_1
+.4byte sMankeyAnims_6_1
+.4byte sMankeyAnims_6_1
+.4byte sMankeyAnims_6_1
+.4byte sMankeyAnims_6_1
+.4byte sMankeyAnims_6_1
+.4byte sMankeyAnims_6_1
+sMankeyAnimTable7:
+.4byte sMankeyAnims_7_1
+.4byte sMankeyAnims_7_2
+.4byte sMankeyAnims_7_3
+.4byte sMankeyAnims_7_4
+.4byte sMankeyAnims_7_5
+.4byte sMankeyAnims_7_6
+.4byte sMankeyAnims_7_7
+.4byte sMankeyAnims_7_8
+sMankeyAnimTable8:
+.4byte sMankeyAnims_8_1
+.4byte sMankeyAnims_8_2
+.4byte sMankeyAnims_8_3
+.4byte sMankeyAnims_8_4
+.4byte sMankeyAnims_8_5
+.4byte sMankeyAnims_8_6
+.4byte sMankeyAnims_8_7
+.4byte sMankeyAnims_8_8
+sMankeyAnimTable9:
+.4byte sMankeyAnims_9_1
+.4byte sMankeyAnims_9_2
+.4byte sMankeyAnims_9_3
+.4byte sMankeyAnims_9_4
+.4byte sMankeyAnims_9_5
+.4byte sMankeyAnims_9_6
+.4byte sMankeyAnims_9_7
+.4byte sMankeyAnims_9_8
+sMankeyAnimTable10:
+.4byte sMankeyAnims_10_1
+.4byte sMankeyAnims_10_2
+.4byte sMankeyAnims_10_3
+.4byte sMankeyAnims_10_4
+.4byte sMankeyAnims_10_5
+.4byte sMankeyAnims_10_6
+.4byte sMankeyAnims_10_7
+.4byte sMankeyAnims_10_8
+sMankeyAnimTable11:
+.4byte sMankeyAnims_11_1
+.4byte sMankeyAnims_11_2
+.4byte sMankeyAnims_11_3
+.4byte sMankeyAnims_11_4
+.4byte sMankeyAnims_11_5
+.4byte sMankeyAnims_11_6
+.4byte sMankeyAnims_11_7
+.4byte sMankeyAnims_11_8
+sMankeyAnimTable12:
+.4byte sMankeyAnims_12_1
+.4byte sMankeyAnims_12_2
+.4byte sMankeyAnims_12_3
+.4byte sMankeyAnims_12_4
+.4byte sMankeyAnims_12_5
+.4byte sMankeyAnims_12_6
+.4byte sMankeyAnims_12_7
+.4byte sMankeyAnims_12_8
+sMankeyAnimTable13:
+.4byte sMankeyAnims_13_1
+.4byte sMankeyAnims_13_2
+.4byte sMankeyAnims_13_3
+.4byte sMankeyAnims_13_4
+.4byte sMankeyAnims_13_5
+.4byte sMankeyAnims_13_6
+.4byte sMankeyAnims_13_7
+.4byte sMankeyAnims_13_8
+sAxAnimationsMankey:
+.4byte sMankeyAnimTable1
+.4byte sMankeyAnimTable2
+.4byte sMankeyAnimTable3
+.4byte sMankeyAnimTable4
+.4byte sMankeyAnimTable5
+.4byte sMankeyAnimTable6
+.4byte sMankeyAnimTable7
+.4byte sMankeyAnimTable8
+.4byte sMankeyAnimTable9
+.4byte sMankeyAnimTable10
+.4byte sMankeyAnimTable11
+.4byte sMankeyAnimTable12
+.4byte sMankeyAnimTable13
+sAxSpritesMankey:
+.4byte sMankeySprites1
+.4byte sMankeySprites2
+.4byte sMankeySprites3
+.4byte sMankeySprites4
+.4byte sMankeySprites5
+.4byte sMankeySprites6
+.4byte sMankeySprites7
+.4byte sMankeySprites8
+.4byte sMankeySprites9
+.4byte sMankeySprites10
+.4byte sMankeySprites11
+.4byte sMankeySprites12
+.4byte sMankeySprites13
+.4byte sMankeySprites14
+.4byte sMankeySprites15
+.4byte sMankeySprites16
+.4byte sMankeySprites17
+.4byte sMankeySprites18
+.4byte sMankeySprites19
+.4byte sMankeySprites20
+.4byte sMankeySprites21
+.4byte sMankeySprites22
+.4byte sMankeySprites23
+.4byte sMankeySprites24
+.4byte sMankeySprites25
+.4byte sMankeySprites26
+.4byte sMankeySprites27
+.4byte sMankeySprites28
+.4byte sMankeySprites29
+.4byte sMankeySprites30
+.4byte sMankeySprites31
+.4byte sMankeySprites32
+.4byte sMankeySprites33
+.4byte sMankeySprites34
+.4byte sMankeySprites35
+.4byte sMankeySprites36
+.4byte sMankeySprites37
+.4byte sMankeySprites38
+.4byte sMankeySprites39
+.4byte sMankeySprites40
+.4byte sMankeySprites41
+.4byte sMankeySprites42
+.4byte sMankeySprites43
+.4byte sMankeySprites44
+.4byte sMankeySprites45
+.4byte sMankeySprites46
+.4byte sMankeySprites47
+.4byte sMankeySprites48
+.4byte sMankeySprites49
+.4byte sMankeySprites50
+.4byte sMankeySprites51
+sAxMainMankey:
+ax_main sAxPosesMankey, sAxAnimationsMankey, 13, sAxSpritesMankey, sAxPositionsMankey

--- a/data/ax/mantine.inc
+++ b/data/ax/mantine.inc
@@ -1,0 +1,3722 @@
+.global gAxMantine
+gAxMantine:
+ax_siro sAxMainMantine
+sMantinePose1:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose2:
+ax_pose 3, 0x01d9, 0x80e4, 0x7c00
+ax_pose 4, 0x41e9, 0x8104, 0x7c10
+ax_pose 5, 0x01e1, 0x0104, 0x7c18
+ax_pose 6, 0x41f9, 0x40f4, 0x7c19
+ax_pose_terminator
+sMantinePose3:
+ax_pose 7, 0x41e2, 0xc0e4, 0x7c00
+ax_pose_terminator
+sMantinePose4:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+sMantinePose5:
+ax_pose 11, 0x01de, 0x90f6, 0x7c00
+ax_pose 12, 0x81de, 0x50ee, 0x7c10
+ax_pose 13, 0x41fe, 0x10fe, 0x7c14
+ax_pose 14, 0x41fe, 0x10ee, 0x7c16
+ax_pose_terminator
+sMantinePose6:
+ax_pose 15, 0x01e7, 0x90f6, 0x7c00
+ax_pose 16, 0x81e7, 0x90e6, 0x7c10
+ax_pose_terminator
+sMantinePose7:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose8:
+ax_pose 21, 0x41e3, 0xc0e0, 0x7c00
+ax_pose_terminator
+sMantinePose9:
+ax_pose 22, 0x4203, 0x00f8, 0x7c00
+ax_pose 23, 0x01f3, 0x40e0, 0x7c02
+ax_pose 24, 0x01e3, 0x80f0, 0x7c06
+ax_pose 25, 0x81eb, 0x0110, 0x7c16
+ax_pose_terminator
+sMantinePose10:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose11:
+ax_pose 29, 0x01e2, 0x80e8, 0x7c00
+ax_pose 30, 0x81e2, 0x8108, 0x7c10
+ax_pose_terminator
+sMantinePose12:
+ax_pose 31, 0x01e4, 0x80e8, 0x7c00
+ax_pose 32, 0x81e4, 0x8108, 0x7c10
+ax_pose 33, 0x4204, 0x00f0, 0x7c18
+ax_pose_terminator
+sMantinePose13:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose14:
+ax_pose 38, 0x01e2, 0x80e4, 0x7c00
+ax_pose 39, 0x81e2, 0x8104, 0x7c10
+ax_pose 40, 0x81ea, 0x0114, 0x7c18
+ax_pose 41, 0x0202, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose15:
+ax_pose 42, 0x01e2, 0x80e4, 0x7c00
+ax_pose 43, 0x81e2, 0x8104, 0x7c10
+ax_pose 44, 0x81f2, 0x0114, 0x7c18
+ax_pose 45, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose16:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose17:
+ax_pose 49, 0x01e1, 0x80e8, 0x7c00
+ax_pose 50, 0x81e1, 0x8108, 0x7c10
+ax_pose 51, 0x0201, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose18:
+ax_pose 52, 0x01e3, 0x80ec, 0x7c00
+ax_pose 53, 0x81e3, 0x410c, 0x7c10
+ax_pose 54, 0x4203, 0x0104, 0x7c14
+ax_pose_terminator
+sMantinePose19:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose20:
+ax_pose 58, 0x41e2, 0xc0e8, 0x7c00
+ax_pose_terminator
+sMantinePose21:
+ax_pose 59, 0x01e3, 0x80e8, 0x7c00
+ax_pose 60, 0x41f1, 0x8108, 0x7c10
+ax_pose 61, 0x4203, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose22:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose23:
+ax_pose 11, 0x01de, 0x80ea, 0x7c00
+ax_pose 12, 0x81de, 0x410a, 0x7c10
+ax_pose 13, 0x41fe, 0x00f2, 0x7c14
+ax_pose 14, 0x41fe, 0x0102, 0x7c16
+ax_pose_terminator
+sMantinePose24:
+ax_pose 15, 0x01e7, 0x80ea, 0x7c00
+ax_pose 16, 0x81e7, 0x810a, 0x7c10
+ax_pose_terminator
+sMantinePose25:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose26:
+ax_pose 3, 0x01d9, 0x80e4, 0x7c00
+ax_pose 4, 0x41e9, 0x8104, 0x7c10
+ax_pose 5, 0x01e1, 0x0104, 0x7c18
+ax_pose 6, 0x41f9, 0x40f4, 0x7c19
+ax_pose_terminator
+sMantinePose27:
+ax_pose 7, 0x41e2, 0xc0e4, 0x7c00
+ax_pose_terminator
+sMantinePose28:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+sMantinePose29:
+ax_pose 11, 0x01de, 0x90f6, 0x7c00
+ax_pose 12, 0x81de, 0x50ee, 0x7c10
+ax_pose 13, 0x41fe, 0x10fe, 0x7c14
+ax_pose 14, 0x41fe, 0x10ee, 0x7c16
+ax_pose_terminator
+sMantinePose30:
+ax_pose 15, 0x01e7, 0x90f6, 0x7c00
+ax_pose 16, 0x81e7, 0x90e6, 0x7c10
+ax_pose_terminator
+sMantinePose31:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose32:
+ax_pose 21, 0x41e3, 0xc0e0, 0x7c00
+ax_pose_terminator
+sMantinePose33:
+ax_pose 22, 0x4203, 0x00f8, 0x7c00
+ax_pose 23, 0x01f3, 0x40e0, 0x7c02
+ax_pose 24, 0x01e3, 0x80f0, 0x7c06
+ax_pose 25, 0x81eb, 0x0110, 0x7c16
+ax_pose_terminator
+sMantinePose34:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose35:
+ax_pose 29, 0x01e2, 0x80e8, 0x7c00
+ax_pose 30, 0x81e2, 0x8108, 0x7c10
+ax_pose_terminator
+sMantinePose36:
+ax_pose 31, 0x01e4, 0x80e8, 0x7c00
+ax_pose 32, 0x81e4, 0x8108, 0x7c10
+ax_pose 33, 0x4204, 0x00f0, 0x7c18
+ax_pose_terminator
+sMantinePose37:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose38:
+ax_pose 38, 0x01e2, 0x80e4, 0x7c00
+ax_pose 39, 0x81e2, 0x8104, 0x7c10
+ax_pose 40, 0x81ea, 0x0114, 0x7c18
+ax_pose 41, 0x0202, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose39:
+ax_pose 42, 0x01e2, 0x80e4, 0x7c00
+ax_pose 43, 0x81e2, 0x8104, 0x7c10
+ax_pose 44, 0x81f2, 0x0114, 0x7c18
+ax_pose 45, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose40:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose41:
+ax_pose 49, 0x01e1, 0x80e8, 0x7c00
+ax_pose 50, 0x81e1, 0x8108, 0x7c10
+ax_pose 51, 0x0201, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose42:
+ax_pose 52, 0x01e3, 0x80ec, 0x7c00
+ax_pose 53, 0x81e3, 0x410c, 0x7c10
+ax_pose 54, 0x4203, 0x0104, 0x7c14
+ax_pose_terminator
+sMantinePose43:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose44:
+ax_pose 58, 0x41e2, 0xc0e8, 0x7c00
+ax_pose_terminator
+sMantinePose45:
+ax_pose 59, 0x01e3, 0x80e8, 0x7c00
+ax_pose 60, 0x41f1, 0x8108, 0x7c10
+ax_pose 61, 0x4203, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose46:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose47:
+ax_pose 11, 0x01de, 0x80ea, 0x7c00
+ax_pose 12, 0x81de, 0x410a, 0x7c10
+ax_pose 13, 0x41fe, 0x00f2, 0x7c14
+ax_pose 14, 0x41fe, 0x0102, 0x7c16
+ax_pose_terminator
+sMantinePose48:
+ax_pose 15, 0x01e7, 0x80ea, 0x7c00
+ax_pose 16, 0x81e7, 0x810a, 0x7c10
+ax_pose_terminator
+sMantinePose49:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose50:
+ax_pose 3, 0x01d9, 0x80e4, 0x7c00
+ax_pose 4, 0x41e9, 0x8104, 0x7c10
+ax_pose 5, 0x01e1, 0x0104, 0x7c18
+ax_pose 6, 0x41f9, 0x40f4, 0x7c19
+ax_pose_terminator
+sMantinePose51:
+ax_pose 7, 0x41e2, 0xc0e4, 0x7c00
+ax_pose_terminator
+sMantinePose52:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+sMantinePose53:
+ax_pose 11, 0x01de, 0x90f6, 0x7c00
+ax_pose 12, 0x81de, 0x50ee, 0x7c10
+ax_pose 13, 0x41fe, 0x10fe, 0x7c14
+ax_pose 14, 0x41fe, 0x10ee, 0x7c16
+ax_pose_terminator
+sMantinePose54:
+ax_pose 15, 0x01e7, 0x90f6, 0x7c00
+ax_pose 16, 0x81e7, 0x90e6, 0x7c10
+ax_pose_terminator
+sMantinePose55:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose56:
+ax_pose 21, 0x41e3, 0xc0e0, 0x7c00
+ax_pose_terminator
+sMantinePose57:
+ax_pose 22, 0x4203, 0x00f8, 0x7c00
+ax_pose 23, 0x01f3, 0x40e0, 0x7c02
+ax_pose 24, 0x01e3, 0x80f0, 0x7c06
+ax_pose 25, 0x81eb, 0x0110, 0x7c16
+ax_pose_terminator
+sMantinePose58:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose59:
+ax_pose 29, 0x01e2, 0x80e8, 0x7c00
+ax_pose 30, 0x81e2, 0x8108, 0x7c10
+ax_pose_terminator
+sMantinePose60:
+ax_pose 31, 0x01e4, 0x80e8, 0x7c00
+ax_pose 32, 0x81e4, 0x8108, 0x7c10
+ax_pose 33, 0x4204, 0x00f0, 0x7c18
+ax_pose_terminator
+sMantinePose61:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose62:
+ax_pose 38, 0x01e2, 0x80e4, 0x7c00
+ax_pose 39, 0x81e2, 0x8104, 0x7c10
+ax_pose 40, 0x81ea, 0x0114, 0x7c18
+ax_pose 41, 0x0202, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose63:
+ax_pose 42, 0x01e2, 0x80e4, 0x7c00
+ax_pose 43, 0x81e2, 0x8104, 0x7c10
+ax_pose 44, 0x81f2, 0x0114, 0x7c18
+ax_pose 45, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose64:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose65:
+ax_pose 49, 0x01e1, 0x80e8, 0x7c00
+ax_pose 50, 0x81e1, 0x8108, 0x7c10
+ax_pose 51, 0x0201, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose66:
+ax_pose 52, 0x01e3, 0x80ec, 0x7c00
+ax_pose 53, 0x81e3, 0x410c, 0x7c10
+ax_pose 54, 0x4203, 0x0104, 0x7c14
+ax_pose_terminator
+sMantinePose67:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose68:
+ax_pose 58, 0x41e2, 0xc0e8, 0x7c00
+ax_pose_terminator
+sMantinePose69:
+ax_pose 59, 0x01e3, 0x80e8, 0x7c00
+ax_pose 60, 0x41f1, 0x8108, 0x7c10
+ax_pose 61, 0x4203, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose70:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose71:
+ax_pose 11, 0x01de, 0x80ea, 0x7c00
+ax_pose 12, 0x81de, 0x410a, 0x7c10
+ax_pose 13, 0x41fe, 0x00f2, 0x7c14
+ax_pose 14, 0x41fe, 0x0102, 0x7c16
+ax_pose_terminator
+sMantinePose72:
+ax_pose 15, 0x01e7, 0x80ea, 0x7c00
+ax_pose 16, 0x81e7, 0x810a, 0x7c10
+ax_pose_terminator
+sMantinePose73:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose74:
+ax_pose 3, 0x01d9, 0x80e4, 0x7c00
+ax_pose 4, 0x41e9, 0x8104, 0x7c10
+ax_pose 5, 0x01e1, 0x0104, 0x7c18
+ax_pose 6, 0x41f9, 0x40f4, 0x7c19
+ax_pose_terminator
+sMantinePose75:
+ax_pose 7, 0x41e2, 0xc0e4, 0x7c00
+ax_pose_terminator
+sMantinePose76:
+ax_pose 62, 0x01df, 0x80e4, 0x7c00
+ax_pose 63, 0x81df, 0x8104, 0x7c10
+ax_pose 64, 0x81ea, 0x0114, 0x7c18
+ax_pose 65, 0x01ff, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose77:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+sMantinePose78:
+ax_pose 11, 0x01de, 0x90f6, 0x7c00
+ax_pose 12, 0x81de, 0x50ee, 0x7c10
+ax_pose 13, 0x41fe, 0x10fe, 0x7c14
+ax_pose 14, 0x41fe, 0x10ee, 0x7c16
+ax_pose_terminator
+sMantinePose79:
+ax_pose 15, 0x01e7, 0x90f6, 0x7c00
+ax_pose 16, 0x81e7, 0x90e6, 0x7c10
+ax_pose_terminator
+sMantinePose80:
+ax_pose 66, 0x41e6, 0xd0d6, 0x7c00
+ax_pose_terminator
+sMantinePose81:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose82:
+ax_pose 21, 0x41e3, 0xc0e0, 0x7c00
+ax_pose_terminator
+sMantinePose83:
+ax_pose 22, 0x4203, 0x00f8, 0x7c00
+ax_pose 23, 0x01f3, 0x40e0, 0x7c02
+ax_pose 24, 0x01e3, 0x80f0, 0x7c06
+ax_pose 25, 0x81eb, 0x0110, 0x7c16
+ax_pose_terminator
+sMantinePose84:
+ax_pose 67, 0x01e6, 0x80e2, 0x7c00
+ax_pose 68, 0x81e6, 0x8102, 0x7c10
+ax_pose 69, 0x01ee, 0x0112, 0x7c18
+ax_pose 70, 0x0206, 0x0102, 0x7c19
+ax_pose_terminator
+sMantinePose85:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose86:
+ax_pose 29, 0x01e2, 0x80e8, 0x7c00
+ax_pose 30, 0x81e2, 0x8108, 0x7c10
+ax_pose_terminator
+sMantinePose87:
+ax_pose 31, 0x01e4, 0x80e8, 0x7c00
+ax_pose 32, 0x81e4, 0x8108, 0x7c10
+ax_pose 33, 0x4204, 0x00f0, 0x7c18
+ax_pose_terminator
+sMantinePose88:
+ax_pose 71, 0x01e3, 0x80ec, 0x7c00
+ax_pose 72, 0x81e3, 0x810c, 0x7c10
+ax_pose 73, 0x4203, 0x00ec, 0x7c18
+ax_pose 74, 0x41db, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose89:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose90:
+ax_pose 38, 0x01e2, 0x80e4, 0x7c00
+ax_pose 39, 0x81e2, 0x8104, 0x7c10
+ax_pose 40, 0x81ea, 0x0114, 0x7c18
+ax_pose 41, 0x0202, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose91:
+ax_pose 42, 0x01e2, 0x80e4, 0x7c00
+ax_pose 43, 0x81e2, 0x8104, 0x7c10
+ax_pose 44, 0x81f2, 0x0114, 0x7c18
+ax_pose 45, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose92:
+ax_pose 75, 0x01e4, 0x80e4, 0x7c00
+ax_pose 76, 0x81e4, 0x8104, 0x7c10
+ax_pose 77, 0x0204, 0x00f4, 0x7c18
+ax_pose 78, 0x0204, 0x00fc, 0x7c19
+ax_pose 79, 0x81ed, 0x0114, 0x7c1a
+ax_pose_terminator
+sMantinePose93:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose94:
+ax_pose 49, 0x01e1, 0x80e8, 0x7c00
+ax_pose 50, 0x81e1, 0x8108, 0x7c10
+ax_pose 51, 0x0201, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose95:
+ax_pose 52, 0x01e3, 0x80ec, 0x7c00
+ax_pose 53, 0x81e3, 0x410c, 0x7c10
+ax_pose 54, 0x4203, 0x0104, 0x7c14
+ax_pose_terminator
+sMantinePose96:
+ax_pose 80, 0x01e1, 0x80ea, 0x7c00
+ax_pose 81, 0x81e1, 0x810a, 0x7c10
+ax_pose 82, 0x01d9, 0x00fa, 0x7c18
+ax_pose 83, 0x0201, 0x0102, 0x7c19
+ax_pose 84, 0x4201, 0x010a, 0x7c1a
+ax_pose 85, 0x0201, 0x00fa, 0x7c1c
+ax_pose_terminator
+sMantinePose97:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose98:
+ax_pose 58, 0x41e2, 0xc0e8, 0x7c00
+ax_pose_terminator
+sMantinePose99:
+ax_pose 59, 0x01e3, 0x80e8, 0x7c00
+ax_pose 60, 0x41f1, 0x8108, 0x7c10
+ax_pose 61, 0x4203, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose100:
+ax_pose 86, 0x01e5, 0x80ec, 0x7c00
+ax_pose 87, 0x41f5, 0x810c, 0x7c10
+ax_pose 88, 0x4205, 0x00f4, 0x7c18
+ax_pose_terminator
+sMantinePose101:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose102:
+ax_pose 11, 0x01de, 0x80ea, 0x7c00
+ax_pose 12, 0x81de, 0x410a, 0x7c10
+ax_pose 13, 0x41fe, 0x00f2, 0x7c14
+ax_pose 14, 0x41fe, 0x0102, 0x7c16
+ax_pose_terminator
+sMantinePose103:
+ax_pose 15, 0x01e7, 0x80ea, 0x7c00
+ax_pose 16, 0x81e7, 0x810a, 0x7c10
+ax_pose_terminator
+sMantinePose104:
+ax_pose 66, 0x41e6, 0xc0ea, 0x7c00
+ax_pose_terminator
+sMantinePose105:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose106:
+ax_pose 3, 0x01d9, 0x80e4, 0x7c00
+ax_pose 4, 0x41e9, 0x8104, 0x7c10
+ax_pose 5, 0x01e1, 0x0104, 0x7c18
+ax_pose 6, 0x41f9, 0x40f4, 0x7c19
+ax_pose_terminator
+sMantinePose107:
+ax_pose 7, 0x41e2, 0xc0e4, 0x7c00
+ax_pose_terminator
+sMantinePose108:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+sMantinePose109:
+ax_pose 11, 0x01de, 0x90f6, 0x7c00
+ax_pose 12, 0x81de, 0x50ee, 0x7c10
+ax_pose 13, 0x41fe, 0x10fe, 0x7c14
+ax_pose 14, 0x41fe, 0x10ee, 0x7c16
+ax_pose_terminator
+sMantinePose110:
+ax_pose 15, 0x01e7, 0x90f6, 0x7c00
+ax_pose 16, 0x81e7, 0x90e6, 0x7c10
+ax_pose_terminator
+sMantinePose111:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose112:
+ax_pose 21, 0x41e3, 0xc0e0, 0x7c00
+ax_pose_terminator
+sMantinePose113:
+ax_pose 22, 0x4203, 0x00f8, 0x7c00
+ax_pose 23, 0x01f3, 0x40e0, 0x7c02
+ax_pose 24, 0x01e3, 0x80f0, 0x7c06
+ax_pose 25, 0x81eb, 0x0110, 0x7c16
+ax_pose_terminator
+sMantinePose114:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose115:
+ax_pose 29, 0x01e2, 0x80e8, 0x7c00
+ax_pose 30, 0x81e2, 0x8108, 0x7c10
+ax_pose_terminator
+sMantinePose116:
+ax_pose 31, 0x01e4, 0x80e8, 0x7c00
+ax_pose 32, 0x81e4, 0x8108, 0x7c10
+ax_pose 33, 0x4204, 0x00f0, 0x7c18
+ax_pose_terminator
+sMantinePose117:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose118:
+ax_pose 38, 0x01e2, 0x80e4, 0x7c00
+ax_pose 39, 0x81e2, 0x8104, 0x7c10
+ax_pose 40, 0x81ea, 0x0114, 0x7c18
+ax_pose 41, 0x0202, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose119:
+ax_pose 42, 0x01e2, 0x80e4, 0x7c00
+ax_pose 43, 0x81e2, 0x8104, 0x7c10
+ax_pose 44, 0x81f2, 0x0114, 0x7c18
+ax_pose 45, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose120:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose121:
+ax_pose 49, 0x01e1, 0x80e8, 0x7c00
+ax_pose 50, 0x81e1, 0x8108, 0x7c10
+ax_pose 51, 0x0201, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose122:
+ax_pose 52, 0x01e3, 0x80ec, 0x7c00
+ax_pose 53, 0x81e3, 0x410c, 0x7c10
+ax_pose 54, 0x4203, 0x0104, 0x7c14
+ax_pose_terminator
+sMantinePose123:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose124:
+ax_pose 58, 0x41e2, 0xc0e8, 0x7c00
+ax_pose_terminator
+sMantinePose125:
+ax_pose 59, 0x01e3, 0x80e8, 0x7c00
+ax_pose 60, 0x41f1, 0x8108, 0x7c10
+ax_pose 61, 0x4203, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose126:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose127:
+ax_pose 11, 0x01de, 0x80ea, 0x7c00
+ax_pose 12, 0x81de, 0x410a, 0x7c10
+ax_pose 13, 0x41fe, 0x00f2, 0x7c14
+ax_pose 14, 0x41fe, 0x0102, 0x7c16
+ax_pose_terminator
+sMantinePose128:
+ax_pose 15, 0x01e7, 0x80ea, 0x7c00
+ax_pose 16, 0x81e7, 0x810a, 0x7c10
+ax_pose_terminator
+sMantinePose129:
+ax_pose 89, 0x01e8, 0x80eb, 0x7c00
+ax_pose 90, 0x81e8, 0x810b, 0x7c10
+ax_pose_terminator
+sMantinePose130:
+ax_pose 91, 0x01e8, 0x80eb, 0x7c00
+ax_pose 92, 0x81e8, 0x810b, 0x7c10
+ax_pose_terminator
+sMantinePose131:
+ax_pose 93, 0x81d7, 0x80f4, 0x7c00
+ax_pose 94, 0x0207, 0x00fd, 0x7c08
+ax_pose 95, 0x01e7, 0x40e4, 0x7c09
+ax_pose 96, 0x81f7, 0x00fc, 0x7c0d
+ax_pose 97, 0x01d7, 0x8104, 0x7c0f
+ax_pose_terminator
+sMantinePose132:
+ax_pose 98, 0x01e1, 0x5104, 0x7c00
+ax_pose 99, 0x81d1, 0x90f4, 0x7c04
+ax_pose 100, 0x81d1, 0x50ec, 0x7c0c
+ax_pose 101, 0x01f1, 0x50f4, 0x7c10
+ax_pose 102, 0x41f1, 0x10e4, 0x7c14
+ax_pose 103, 0x81f1, 0x1104, 0x7c16
+ax_pose 104, 0x0201, 0x1104, 0x7c18
+ax_pose 105, 0x0201, 0x10fc, 0x7c19
+ax_pose 106, 0x01d1, 0x5101, 0x7c1a
+ax_pose 107, 0x01e9, 0x10e4, 0x7c1e
+ax_pose_terminator
+sMantinePose133:
+ax_pose 108, 0x41f9, 0x90f0, 0x7c00
+ax_pose 109, 0x01d9, 0x90e8, 0x7c08
+ax_pose 110, 0x01d0, 0x50f3, 0x7c18
+ax_pose_terminator
+sMantinePose134:
+ax_pose 111, 0x01d5, 0x50e7, 0x7c00
+ax_pose 112, 0x01ce, 0x10ea, 0x7c04
+ax_pose 113, 0x01d5, 0x90f4, 0x7c05
+ax_pose 114, 0x81e5, 0x10ec, 0x7c15
+ax_pose 115, 0x41f5, 0x90f4, 0x7c17
+ax_pose_terminator
+sMantinePose135:
+ax_pose 116, 0x81d9, 0x8105, 0x7c00
+ax_pose 117, 0x41f9, 0x00f5, 0x7c08
+ax_pose 118, 0x81e9, 0x0115, 0x7c0a
+ax_pose 119, 0x01d9, 0x80e5, 0x7c0c
+ax_pose_terminator
+sMantinePose136:
+ax_pose 111, 0x01df, 0x40ea, 0x7c00
+ax_pose 112, 0x01d8, 0x00ef, 0x7c04
+ax_pose 113, 0x01d5, 0x80ec, 0x7c05
+ax_pose 114, 0x81e5, 0x010c, 0x7c15
+ax_pose 115, 0x41f5, 0x80ec, 0x7c17
+ax_pose_terminator
+sMantinePose137:
+ax_pose 110, 0x01df, 0x410b, 0x7c00
+ax_pose 108, 0x41f9, 0x80f0, 0x7c04
+ax_pose 109, 0x01d9, 0x80f8, 0x7c0c
+ax_pose_terminator
+sMantinePose138:
+ax_pose 98, 0x01e1, 0x40ec, 0x7c00
+ax_pose 99, 0x81d1, 0x80fc, 0x7c04
+ax_pose 100, 0x81d1, 0x410c, 0x7c0c
+ax_pose 101, 0x01f1, 0x40fc, 0x7c10
+ax_pose 102, 0x41f1, 0x010c, 0x7c14
+ax_pose 103, 0x81f1, 0x00f4, 0x7c16
+ax_pose 104, 0x0201, 0x00f4, 0x7c18
+ax_pose 105, 0x0201, 0x00fc, 0x7c19
+ax_pose 106, 0x01d9, 0x4114, 0x7c1a
+ax_pose 107, 0x01e9, 0x0114, 0x7c1e
+ax_pose_terminator
+sMantinePose139:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose140:
+ax_pose 3, 0x01d9, 0x80e4, 0x7c00
+ax_pose 4, 0x41e9, 0x8104, 0x7c10
+ax_pose 5, 0x01e1, 0x0104, 0x7c18
+ax_pose 6, 0x41f9, 0x40f4, 0x7c19
+ax_pose_terminator
+sMantinePose141:
+ax_pose 7, 0x41e2, 0xc0e4, 0x7c00
+ax_pose_terminator
+sMantinePose142:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+sMantinePose143:
+ax_pose 11, 0x01de, 0x90f6, 0x7c00
+ax_pose 12, 0x81de, 0x50ee, 0x7c10
+ax_pose 13, 0x41fe, 0x10fe, 0x7c14
+ax_pose 14, 0x41fe, 0x10ee, 0x7c16
+ax_pose_terminator
+sMantinePose144:
+ax_pose 15, 0x01e7, 0x90f6, 0x7c00
+ax_pose 16, 0x81e7, 0x90e6, 0x7c10
+ax_pose_terminator
+sMantinePose145:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose146:
+ax_pose 21, 0x41e3, 0xc0e0, 0x7c00
+ax_pose_terminator
+sMantinePose147:
+ax_pose 22, 0x4203, 0x00f8, 0x7c00
+ax_pose 23, 0x01f3, 0x40e0, 0x7c02
+ax_pose 24, 0x01e3, 0x80f0, 0x7c06
+ax_pose 25, 0x81eb, 0x0110, 0x7c16
+ax_pose_terminator
+sMantinePose148:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose149:
+ax_pose 29, 0x01e2, 0x80e8, 0x7c00
+ax_pose 30, 0x81e2, 0x8108, 0x7c10
+ax_pose_terminator
+sMantinePose150:
+ax_pose 31, 0x01e4, 0x80e8, 0x7c00
+ax_pose 32, 0x81e4, 0x8108, 0x7c10
+ax_pose 33, 0x4204, 0x00f0, 0x7c18
+ax_pose_terminator
+sMantinePose151:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose152:
+ax_pose 38, 0x01e2, 0x80e4, 0x7c00
+ax_pose 39, 0x81e2, 0x8104, 0x7c10
+ax_pose 40, 0x81ea, 0x0114, 0x7c18
+ax_pose 41, 0x0202, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose153:
+ax_pose 42, 0x01e2, 0x80e4, 0x7c00
+ax_pose 43, 0x81e2, 0x8104, 0x7c10
+ax_pose 44, 0x81f2, 0x0114, 0x7c18
+ax_pose 45, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose154:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose155:
+ax_pose 49, 0x01e1, 0x80e8, 0x7c00
+ax_pose 50, 0x81e1, 0x8108, 0x7c10
+ax_pose 51, 0x0201, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose156:
+ax_pose 52, 0x01e3, 0x80ec, 0x7c00
+ax_pose 53, 0x81e3, 0x410c, 0x7c10
+ax_pose 54, 0x4203, 0x0104, 0x7c14
+ax_pose_terminator
+sMantinePose157:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose158:
+ax_pose 58, 0x41e2, 0xc0e8, 0x7c00
+ax_pose_terminator
+sMantinePose159:
+ax_pose 59, 0x01e3, 0x80e8, 0x7c00
+ax_pose 60, 0x41f1, 0x8108, 0x7c10
+ax_pose 61, 0x4203, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose160:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose161:
+ax_pose 11, 0x01de, 0x80ea, 0x7c00
+ax_pose 12, 0x81de, 0x410a, 0x7c10
+ax_pose 13, 0x41fe, 0x00f2, 0x7c14
+ax_pose 14, 0x41fe, 0x0102, 0x7c16
+ax_pose_terminator
+sMantinePose162:
+ax_pose 15, 0x01e7, 0x80ea, 0x7c00
+ax_pose 16, 0x81e7, 0x810a, 0x7c10
+ax_pose_terminator
+sMantinePose163:
+ax_pose 62, 0x01df, 0x80e4, 0x7c00
+ax_pose 63, 0x81df, 0x8104, 0x7c10
+ax_pose 64, 0x81ea, 0x0114, 0x7c18
+ax_pose 65, 0x01ff, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose164:
+ax_pose 66, 0x41e6, 0xc0ea, 0x7c00
+ax_pose_terminator
+sMantinePose165:
+ax_pose 86, 0x01e5, 0x80ec, 0x7c00
+ax_pose 87, 0x41f5, 0x810c, 0x7c10
+ax_pose 88, 0x4205, 0x00f4, 0x7c18
+ax_pose_terminator
+sMantinePose166:
+ax_pose 80, 0x01e1, 0x80ea, 0x7c00
+ax_pose 81, 0x81e1, 0x810a, 0x7c10
+ax_pose 82, 0x01d9, 0x00fa, 0x7c18
+ax_pose 83, 0x0201, 0x0102, 0x7c19
+ax_pose 84, 0x4201, 0x010a, 0x7c1a
+ax_pose 85, 0x0201, 0x00fa, 0x7c1c
+ax_pose_terminator
+sMantinePose167:
+ax_pose 75, 0x01e4, 0x80e4, 0x7c00
+ax_pose 76, 0x81e4, 0x8104, 0x7c10
+ax_pose 77, 0x0204, 0x00f4, 0x7c18
+ax_pose 78, 0x0204, 0x00fc, 0x7c19
+ax_pose 79, 0x81ed, 0x0114, 0x7c1a
+ax_pose_terminator
+sMantinePose168:
+ax_pose 71, 0x01e3, 0x80ec, 0x7c00
+ax_pose 72, 0x81e3, 0x810c, 0x7c10
+ax_pose 73, 0x4203, 0x00ec, 0x7c18
+ax_pose 74, 0x41db, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose169:
+ax_pose 67, 0x01e6, 0x80e2, 0x7c00
+ax_pose 68, 0x81e6, 0x8102, 0x7c10
+ax_pose 69, 0x01ee, 0x0112, 0x7c18
+ax_pose 70, 0x0206, 0x0102, 0x7c19
+ax_pose_terminator
+sMantinePose170:
+ax_pose 66, 0x41e6, 0xd0d6, 0x7c00
+ax_pose_terminator
+sMantinePose171:
+ax_pose 62, 0x01df, 0x80e4, 0x7c00
+ax_pose 63, 0x81df, 0x8104, 0x7c10
+ax_pose 64, 0x81ea, 0x0114, 0x7c18
+ax_pose 65, 0x01ff, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose172:
+ax_pose 66, 0x41e6, 0xd0d6, 0x7c00
+ax_pose_terminator
+sMantinePose173:
+ax_pose 67, 0x01e6, 0x80e3, 0x7c00
+ax_pose 68, 0x81e6, 0x8103, 0x7c10
+ax_pose 69, 0x01ee, 0x0113, 0x7c18
+ax_pose 70, 0x0206, 0x0103, 0x7c19
+ax_pose_terminator
+sMantinePose174:
+ax_pose 71, 0x01e2, 0x80ed, 0x7c00
+ax_pose 72, 0x81e2, 0x810d, 0x7c10
+ax_pose 73, 0x4202, 0x00ed, 0x7c18
+ax_pose 74, 0x41da, 0x00fd, 0x7c1a
+ax_pose_terminator
+sMantinePose175:
+ax_pose 75, 0x01e3, 0x80e4, 0x7c00
+ax_pose 76, 0x81e3, 0x8104, 0x7c10
+ax_pose 77, 0x0203, 0x00f4, 0x7c18
+ax_pose 78, 0x0203, 0x00fc, 0x7c19
+ax_pose 79, 0x81ec, 0x0114, 0x7c1a
+ax_pose_terminator
+sMantinePose176:
+ax_pose 80, 0x01e2, 0x80e8, 0x7c00
+ax_pose 81, 0x81e2, 0x8108, 0x7c10
+ax_pose 82, 0x01da, 0x00f8, 0x7c18
+ax_pose 83, 0x0202, 0x0100, 0x7c19
+ax_pose 84, 0x4202, 0x0108, 0x7c1a
+ax_pose 85, 0x0202, 0x00f8, 0x7c1c
+ax_pose_terminator
+sMantinePose177:
+ax_pose 86, 0x01e5, 0x80eb, 0x7c00
+ax_pose 87, 0x41f5, 0x810b, 0x7c10
+ax_pose 88, 0x4205, 0x00f3, 0x7c18
+ax_pose_terminator
+sMantinePose178:
+ax_pose 66, 0x41e6, 0xc0ea, 0x7c00
+ax_pose_terminator
+sMantinePose179:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose180:
+ax_pose 3, 0x01d9, 0x80e4, 0x7c00
+ax_pose 4, 0x41e9, 0x8104, 0x7c10
+ax_pose 5, 0x01e1, 0x0104, 0x7c18
+ax_pose 6, 0x41f9, 0x40f4, 0x7c19
+ax_pose_terminator
+sMantinePose181:
+ax_pose 7, 0x41e2, 0xc0e4, 0x7c00
+ax_pose_terminator
+sMantinePose182:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+sMantinePose183:
+ax_pose 11, 0x01de, 0x90f6, 0x7c00
+ax_pose 12, 0x81de, 0x50ee, 0x7c10
+ax_pose 13, 0x41fe, 0x10fe, 0x7c14
+ax_pose 14, 0x41fe, 0x10ee, 0x7c16
+ax_pose_terminator
+sMantinePose184:
+ax_pose 15, 0x01e7, 0x90f6, 0x7c00
+ax_pose 16, 0x81e7, 0x90e6, 0x7c10
+ax_pose_terminator
+sMantinePose185:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose186:
+ax_pose 21, 0x41e3, 0xc0e0, 0x7c00
+ax_pose_terminator
+sMantinePose187:
+ax_pose 22, 0x4203, 0x00f8, 0x7c00
+ax_pose 23, 0x01f3, 0x40e0, 0x7c02
+ax_pose 24, 0x01e3, 0x80f0, 0x7c06
+ax_pose 25, 0x81eb, 0x0110, 0x7c16
+ax_pose_terminator
+sMantinePose188:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose189:
+ax_pose 29, 0x01e2, 0x80e8, 0x7c00
+ax_pose 30, 0x81e2, 0x8108, 0x7c10
+ax_pose_terminator
+sMantinePose190:
+ax_pose 31, 0x01e4, 0x80e8, 0x7c00
+ax_pose 32, 0x81e4, 0x8108, 0x7c10
+ax_pose 33, 0x4204, 0x00f0, 0x7c18
+ax_pose_terminator
+sMantinePose191:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose192:
+ax_pose 38, 0x01e2, 0x80e4, 0x7c00
+ax_pose 39, 0x81e2, 0x8104, 0x7c10
+ax_pose 40, 0x81ea, 0x0114, 0x7c18
+ax_pose 41, 0x0202, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose193:
+ax_pose 42, 0x01e2, 0x80e4, 0x7c00
+ax_pose 43, 0x81e2, 0x8104, 0x7c10
+ax_pose 44, 0x81f2, 0x0114, 0x7c18
+ax_pose 45, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose194:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose195:
+ax_pose 49, 0x01e1, 0x80e8, 0x7c00
+ax_pose 50, 0x81e1, 0x8108, 0x7c10
+ax_pose 51, 0x0201, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose196:
+ax_pose 52, 0x01e3, 0x80ec, 0x7c00
+ax_pose 53, 0x81e3, 0x410c, 0x7c10
+ax_pose 54, 0x4203, 0x0104, 0x7c14
+ax_pose_terminator
+sMantinePose197:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose198:
+ax_pose 58, 0x41e2, 0xc0e8, 0x7c00
+ax_pose_terminator
+sMantinePose199:
+ax_pose 59, 0x01e3, 0x80e8, 0x7c00
+ax_pose 60, 0x41f1, 0x8108, 0x7c10
+ax_pose 61, 0x4203, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose200:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose201:
+ax_pose 11, 0x01de, 0x80ea, 0x7c00
+ax_pose 12, 0x81de, 0x410a, 0x7c10
+ax_pose 13, 0x41fe, 0x00f2, 0x7c14
+ax_pose 14, 0x41fe, 0x0102, 0x7c16
+ax_pose_terminator
+sMantinePose202:
+ax_pose 15, 0x01e7, 0x80ea, 0x7c00
+ax_pose 16, 0x81e7, 0x810a, 0x7c10
+ax_pose_terminator
+sMantinePose203:
+ax_pose 62, 0x01df, 0x80e4, 0x7c00
+ax_pose 63, 0x81df, 0x8104, 0x7c10
+ax_pose 64, 0x81ea, 0x0114, 0x7c18
+ax_pose 65, 0x01ff, 0x00fc, 0x7c1a
+ax_pose_terminator
+sMantinePose204:
+ax_pose 66, 0x41e6, 0xc0ea, 0x7c00
+ax_pose_terminator
+sMantinePose205:
+ax_pose 86, 0x01e5, 0x80eb, 0x7c00
+ax_pose 87, 0x41f5, 0x810b, 0x7c10
+ax_pose 88, 0x4205, 0x00f3, 0x7c18
+ax_pose_terminator
+sMantinePose206:
+ax_pose 80, 0x01e2, 0x80e8, 0x7c00
+ax_pose 81, 0x81e2, 0x8108, 0x7c10
+ax_pose 82, 0x01da, 0x00f8, 0x7c18
+ax_pose 83, 0x0202, 0x0100, 0x7c19
+ax_pose 84, 0x4202, 0x0108, 0x7c1a
+ax_pose 85, 0x0202, 0x00f8, 0x7c1c
+ax_pose_terminator
+sMantinePose207:
+ax_pose 75, 0x01e3, 0x80e4, 0x7c00
+ax_pose 76, 0x81e3, 0x8104, 0x7c10
+ax_pose 77, 0x0203, 0x00f4, 0x7c18
+ax_pose 78, 0x0203, 0x00fc, 0x7c19
+ax_pose 79, 0x81ec, 0x0114, 0x7c1a
+ax_pose_terminator
+sMantinePose208:
+ax_pose 71, 0x01e2, 0x80ed, 0x7c00
+ax_pose 72, 0x81e2, 0x810d, 0x7c10
+ax_pose 73, 0x4202, 0x00ed, 0x7c18
+ax_pose 74, 0x41da, 0x00fd, 0x7c1a
+ax_pose_terminator
+sMantinePose209:
+ax_pose 67, 0x01e6, 0x80e3, 0x7c00
+ax_pose 68, 0x81e6, 0x8103, 0x7c10
+ax_pose 69, 0x01ee, 0x0113, 0x7c18
+ax_pose 70, 0x0206, 0x0103, 0x7c19
+ax_pose_terminator
+sMantinePose210:
+ax_pose 66, 0x41e6, 0xd0d6, 0x7c00
+ax_pose_terminator
+sMantinePose211:
+ax_pose 0, 0x01da, 0x80e4, 0x7c00
+ax_pose 1, 0x41ea, 0x8104, 0x7c10
+ax_pose 2, 0x41fa, 0x40f4, 0x7c18
+ax_pose_terminator
+sMantinePose212:
+ax_pose 8, 0x01e1, 0x80ea, 0x7c00
+ax_pose 9, 0x81e1, 0x810a, 0x7c10
+ax_pose 10, 0x4201, 0x0102, 0x7c18
+ax_pose_terminator
+sMantinePose213:
+ax_pose 55, 0x01e2, 0x80e8, 0x7c00
+ax_pose 56, 0x41f1, 0x8108, 0x7c10
+ax_pose 57, 0x4202, 0x00f8, 0x7c18
+ax_pose_terminator
+sMantinePose214:
+ax_pose 46, 0x01e2, 0x80e8, 0x7c00
+ax_pose 47, 0x81e2, 0x8108, 0x7c10
+ax_pose 48, 0x4202, 0x0108, 0x7c18
+ax_pose_terminator
+sMantinePose215:
+ax_pose 34, 0x01e2, 0x80e4, 0x7c00
+ax_pose 35, 0x81e2, 0x8104, 0x7c10
+ax_pose 36, 0x81ea, 0x0114, 0x7c18
+ax_pose 37, 0x0202, 0x40f4, 0x7c1a
+ax_pose_terminator
+sMantinePose216:
+ax_pose 26, 0x01e2, 0x80e8, 0x7c00
+ax_pose 27, 0x81e2, 0x8108, 0x7c10
+ax_pose 28, 0x4202, 0x00ec, 0x7c18
+ax_pose_terminator
+sMantinePose217:
+ax_pose 17, 0x4203, 0x00f8, 0x7c00
+ax_pose 18, 0x01eb, 0x40e0, 0x7c02
+ax_pose 19, 0x01e3, 0x80f0, 0x7c06
+ax_pose 20, 0x81e3, 0x4110, 0x7c16
+ax_pose_terminator
+sMantinePose218:
+ax_pose 8, 0x01e1, 0x90f6, 0x7c00
+ax_pose 9, 0x81e1, 0x90e6, 0x7c10
+ax_pose 10, 0x4201, 0x10ee, 0x7c18
+ax_pose_terminator
+.align 2
+sMantineAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 2, 0, 0,
+ax_anim 6, 0, 1, 0, 3, 0, 0,
+ax_anim 6, 0, 0, 0, 3, 0, 0,
+ax_anim 6, 0, 2, 0, 3, 0, 0,
+ax_anim 8, 0, 2, 0, 2, 0, 0,
+ax_anim 8, 0, 2, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 2, 0, 0,
+ax_anim 6, 0, 4, 0, 3, 0, 0,
+ax_anim 6, 0, 3, 0, 3, 0, 0,
+ax_anim 6, 0, 5, 0, 3, 0, 0,
+ax_anim 8, 0, 5, 0, 2, 0, 0,
+ax_anim 8, 0, 5, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 2, 0, 0,
+ax_anim 6, 0, 7, 0, 3, 0, 0,
+ax_anim 6, 0, 6, 0, 3, 0, 0,
+ax_anim 6, 0, 8, 0, 3, 0, 0,
+ax_anim 8, 0, 8, 0, 2, 0, 0,
+ax_anim 8, 0, 8, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 2, 0, 0,
+ax_anim 6, 0, 10, 0, 3, 0, 0,
+ax_anim 6, 0, 9, 0, 3, 0, 0,
+ax_anim 6, 0, 11, 0, 3, 0, 0,
+ax_anim 8, 0, 11, 0, 2, 0, 0,
+ax_anim 8, 0, 11, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 2, 0, 0,
+ax_anim 6, 0, 13, 0, 3, 0, 0,
+ax_anim 6, 0, 12, 0, 3, 0, 0,
+ax_anim 6, 0, 14, 0, 3, 0, 0,
+ax_anim 8, 0, 14, 0, 2, 0, 0,
+ax_anim 8, 0, 14, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 16, 0, 2, 0, 0,
+ax_anim 6, 0, 16, 0, 3, 0, 0,
+ax_anim 6, 0, 15, 0, 3, 0, 0,
+ax_anim 6, 0, 17, 0, 3, 0, 0,
+ax_anim 8, 0, 17, 0, 2, 0, 0,
+ax_anim 8, 0, 17, 0, 1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 19, 0, 2, 0, 0,
+ax_anim 6, 0, 19, 0, 3, 0, 0,
+ax_anim 6, 0, 18, 0, 3, 0, 0,
+ax_anim 6, 0, 20, 0, 3, 0, 0,
+ax_anim 8, 0, 20, 0, 2, 0, 0,
+ax_anim 8, 0, 20, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 22, 0, 2, 0, 0,
+ax_anim 6, 0, 22, 0, 3, 0, 0,
+ax_anim 6, 0, 21, 0, 3, 0, 0,
+ax_anim 6, 0, 23, 0, 3, 0, 0,
+ax_anim 8, 0, 23, 0, 2, 0, 0,
+ax_anim 8, 0, 23, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 1, 0, 0,
+ax_anim 2, 0, 25, 0, 2, 0, 0,
+ax_anim 2, 0, 26, 0, 2, 0, 0,
+ax_anim 2, 0, 26, 0, 1, 0, 0,
+ax_anim 4, 2, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 24, 0, 4, 0, 7,
+ax_anim 1, 0, 24, 0, 14, 0, 7,
+ax_anim 2, 1, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sMantineAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 1, 0, 0,
+ax_anim 2, 0, 28, 0, 2, 0, 0,
+ax_anim 2, 0, 29, 0, 2, 0, 0,
+ax_anim 2, 0, 29, 0, 1, 0, 0,
+ax_anim 4, 2, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 2, 4, 2, 4,
+ax_anim 1, 0, 27, 10, 14, 10, 14,
+ax_anim 2, 1, 27, 14, 20, 14, 20,
+ax_anim 2, 0, 27, 15, 19, 15, 19,
+ax_anim 2, 0, 27, 14, 20, 14, 20,
+ax_anim 2, 0, 27, 15, 19, 15, 19,
+ax_anim 2, 0, 27, 14, 20, 14, 20,
+ax_anim 2, 0, 27, 7, 10, 7, 10,
+ax_anim 2, 0, 27, 2, 4, 2, 4,
+ax_anim_terminator
+sMantineAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 1, 0, 0,
+ax_anim 2, 0, 31, 0, 2, 0, 0,
+ax_anim 2, 0, 32, 0, 2, 0, 0,
+ax_anim 2, 0, 32, 0, 1, 0, 0,
+ax_anim 4, 2, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 2, 2, 2, 0,
+ax_anim 1, 0, 30, 10, 3, 10, 0,
+ax_anim 2, 1, 30, 16, 4, 16, 0,
+ax_anim 2, 0, 30, 16, 5, 16, 1,
+ax_anim 2, 0, 30, 16, 4, 16, 0,
+ax_anim 2, 0, 30, 16, 5, 16, 1,
+ax_anim 2, 0, 30, 16, 4, 16, 0,
+ax_anim 2, 0, 30, 7, 3, 7, 0,
+ax_anim 2, 0, 30, 2, 2, 2, 0,
+ax_anim_terminator
+sMantineAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 1, 0, 0,
+ax_anim 2, 0, 34, 0, 2, 0, 0,
+ax_anim 2, 0, 35, 0, 2, 0, 0,
+ax_anim 2, 0, 35, 0, 1, 0, 0,
+ax_anim 4, 2, 35, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 3, -4, 3, -4,
+ax_anim 1, 0, 33, 14, -13, 14, -13,
+ax_anim 2, 1, 33, 15, -13, 15, -13,
+ax_anim 2, 0, 33, 16, -12, 16, -12,
+ax_anim 2, 0, 33, 15, -13, 15, -13,
+ax_anim 2, 0, 33, 16, -12, 16, -12,
+ax_anim 2, 0, 33, 15, -13, 15, -13,
+ax_anim 2, 0, 33, 9, -9, 9, -9,
+ax_anim 2, 0, 33, 3, -4, 3, -4,
+ax_anim_terminator
+sMantineAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 1, 0, 0,
+ax_anim 2, 0, 37, 0, 2, 0, 0,
+ax_anim 2, 0, 38, 0, 2, 0, 0,
+ax_anim 2, 0, 38, 0, 1, 0, 0,
+ax_anim 4, 2, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 36, 0, -4, 0, -7,
+ax_anim 1, 0, 36, 0, -8, 0, -8,
+ax_anim 2, 1, 36, 0, -14, 0, -14,
+ax_anim 2, 0, 36, 1, -14, 1, -14,
+ax_anim 2, 0, 36, 0, -14, 0, -14,
+ax_anim 2, 0, 36, 1, -14, 1, -14,
+ax_anim 2, 0, 36, 0, -14, 0, -14,
+ax_anim 2, 0, 36, 0, -8, 0, -8,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sMantineAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 0,
+ax_anim 2, 0, 40, 0, 2, 0, 0,
+ax_anim 2, 0, 41, 0, 2, 0, 0,
+ax_anim 2, 0, 41, 0, 1, 0, 0,
+ax_anim 4, 2, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 39, -3, -4, -3, -4,
+ax_anim 1, 0, 39, -14, -13, -14, -13,
+ax_anim 2, 1, 39, -15, -13, -15, -13,
+ax_anim 2, 0, 39, -16, -12, -16, -12,
+ax_anim 2, 0, 39, -15, -13, -15, -13,
+ax_anim 2, 0, 39, -16, -12, -16, -12,
+ax_anim 2, 0, 39, -15, -13, -15, -13,
+ax_anim 2, 0, 39, -9, -9, -9, -9,
+ax_anim 2, 0, 39, -3, -4, -3, -4,
+ax_anim_terminator
+sMantineAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 1, 0, 0,
+ax_anim 2, 0, 43, 0, 2, 0, 0,
+ax_anim 2, 0, 44, 0, 2, 0, 0,
+ax_anim 2, 0, 44, 0, 1, 0, 0,
+ax_anim 4, 2, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 42, -2, 2, -2, 0,
+ax_anim 1, 0, 42, -10, 3, -10, 0,
+ax_anim 2, 1, 42, -16, 4, -16, 0,
+ax_anim 2, 0, 42, -16, 5, -16, 1,
+ax_anim 2, 0, 42, -16, 4, -16, 0,
+ax_anim 2, 0, 42, -16, 5, -16, 1,
+ax_anim 2, 0, 42, -16, 4, -16, 0,
+ax_anim 2, 0, 42, -7, 3, -7, 0,
+ax_anim 2, 0, 42, -2, 2, -2, 0,
+ax_anim_terminator
+sMantineAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 1, 0, 0,
+ax_anim 2, 0, 46, 0, 2, 0, 0,
+ax_anim 2, 0, 47, 0, 2, 0, 0,
+ax_anim 2, 0, 47, 0, 1, 0, 0,
+ax_anim 4, 2, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 45, -2, 4, -2, 4,
+ax_anim 1, 0, 45, -10, 14, -10, 14,
+ax_anim 2, 1, 45, -14, 20, -14, 20,
+ax_anim 2, 0, 45, -15, 19, -15, 19,
+ax_anim 2, 0, 45, -14, 20, -14, 20,
+ax_anim 2, 0, 45, -15, 19, -15, 19,
+ax_anim 2, 0, 45, -14, 20, -14, 20,
+ax_anim 2, 0, 45, -7, 10, -7, 10,
+ax_anim 2, 0, 45, -2, 4, -2, 4,
+ax_anim_terminator
+.align 2
+sMantineAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 1, 0, 0,
+ax_anim 2, 0, 49, 0, 2, 0, 0,
+ax_anim 2, 0, 50, 0, 2, 0, 0,
+ax_anim 2, 0, 50, 0, 1, 0, 0,
+ax_anim 4, 2, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, 4, 0, 7,
+ax_anim 1, 0, 48, 0, 14, 0, 7,
+ax_anim 2, 1, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sMantineAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 1, 0, 0,
+ax_anim 2, 0, 52, 0, 2, 0, 0,
+ax_anim 2, 0, 53, 0, 2, 0, 0,
+ax_anim 2, 0, 53, 0, 1, 0, 0,
+ax_anim 4, 2, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 2, 4, 2, 4,
+ax_anim 1, 0, 51, 10, 14, 10, 14,
+ax_anim 2, 1, 51, 14, 20, 14, 20,
+ax_anim 2, 0, 51, 15, 19, 15, 19,
+ax_anim 2, 0, 51, 14, 20, 14, 20,
+ax_anim 2, 0, 51, 15, 19, 15, 19,
+ax_anim 2, 0, 51, 14, 20, 14, 20,
+ax_anim 2, 0, 51, 7, 10, 7, 10,
+ax_anim 2, 0, 51, 2, 4, 2, 4,
+ax_anim_terminator
+sMantineAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 1, 0, 0,
+ax_anim 2, 0, 55, 0, 2, 0, 0,
+ax_anim 2, 0, 56, 0, 2, 0, 0,
+ax_anim 2, 0, 56, 0, 1, 0, 0,
+ax_anim 4, 2, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 2, 2, 2, 0,
+ax_anim 1, 0, 54, 10, 3, 10, 0,
+ax_anim 2, 1, 54, 16, 4, 16, 0,
+ax_anim 2, 0, 54, 16, 5, 16, 1,
+ax_anim 2, 0, 54, 16, 4, 16, 0,
+ax_anim 2, 0, 54, 16, 5, 16, 1,
+ax_anim 2, 0, 54, 16, 4, 16, 0,
+ax_anim 2, 0, 54, 7, 3, 7, 0,
+ax_anim 2, 0, 54, 2, 2, 2, 0,
+ax_anim_terminator
+sMantineAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 0, 1, 0, 0,
+ax_anim 2, 0, 58, 0, 2, 0, 0,
+ax_anim 2, 0, 59, 0, 2, 0, 0,
+ax_anim 2, 0, 59, 0, 1, 0, 0,
+ax_anim 4, 2, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 3, -4, 3, -4,
+ax_anim 1, 0, 57, 14, -13, 14, -13,
+ax_anim 2, 1, 57, 15, -13, 15, -13,
+ax_anim 2, 0, 57, 16, -12, 16, -12,
+ax_anim 2, 0, 57, 15, -13, 15, -13,
+ax_anim 2, 0, 57, 16, -12, 16, -12,
+ax_anim 2, 0, 57, 15, -13, 15, -13,
+ax_anim 2, 0, 57, 9, -9, 9, -9,
+ax_anim 2, 0, 57, 3, -4, 3, -4,
+ax_anim_terminator
+sMantineAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 1, 0, 0,
+ax_anim 2, 0, 61, 0, 2, 0, 0,
+ax_anim 2, 0, 62, 0, 2, 0, 0,
+ax_anim 2, 0, 62, 0, 1, 0, 0,
+ax_anim 4, 2, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 60, 0, -4, 0, -7,
+ax_anim 1, 0, 60, 0, -8, 0, -8,
+ax_anim 2, 1, 60, 0, -14, 0, -14,
+ax_anim 2, 0, 60, 1, -14, 1, -14,
+ax_anim 2, 0, 60, 0, -14, 0, -14,
+ax_anim 2, 0, 60, 1, -14, 1, -14,
+ax_anim 2, 0, 60, 0, -14, 0, -14,
+ax_anim 2, 0, 60, 0, -8, 0, -8,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sMantineAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 1, 0, 0,
+ax_anim 2, 0, 64, 0, 2, 0, 0,
+ax_anim 2, 0, 65, 0, 2, 0, 0,
+ax_anim 2, 0, 65, 0, 1, 0, 0,
+ax_anim 4, 2, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 63, -3, -4, -3, -4,
+ax_anim 1, 0, 63, -14, -13, -14, -13,
+ax_anim 2, 1, 63, -15, -13, -15, -13,
+ax_anim 2, 0, 63, -16, -12, -16, -12,
+ax_anim 2, 0, 63, -15, -13, -15, -13,
+ax_anim 2, 0, 63, -16, -12, -16, -12,
+ax_anim 2, 0, 63, -15, -13, -15, -13,
+ax_anim 2, 0, 63, -9, -9, -9, -9,
+ax_anim 2, 0, 63, -3, -4, -3, -4,
+ax_anim_terminator
+sMantineAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, 1, 0, 0,
+ax_anim 2, 0, 67, 0, 2, 0, 0,
+ax_anim 2, 0, 68, 0, 2, 0, 0,
+ax_anim 2, 0, 68, 0, 1, 0, 0,
+ax_anim 4, 2, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 66, -2, 2, -2, 0,
+ax_anim 1, 0, 66, -10, 3, -10, 0,
+ax_anim 2, 1, 66, -16, 4, -16, 0,
+ax_anim 2, 0, 66, -16, 5, -16, 1,
+ax_anim 2, 0, 66, -16, 4, -16, 0,
+ax_anim 2, 0, 66, -16, 5, -16, 1,
+ax_anim 2, 0, 66, -16, 4, -16, 0,
+ax_anim 2, 0, 66, -7, 3, -7, 0,
+ax_anim 2, 0, 66, -2, 2, -2, 0,
+ax_anim_terminator
+sMantineAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 1, 0, 0,
+ax_anim 2, 0, 70, 0, 2, 0, 0,
+ax_anim 2, 0, 71, 0, 2, 0, 0,
+ax_anim 2, 0, 71, 0, 1, 0, 0,
+ax_anim 4, 2, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 69, -2, 4, -2, 4,
+ax_anim 1, 0, 69, -10, 14, -10, 14,
+ax_anim 2, 1, 69, -14, 20, -14, 20,
+ax_anim 2, 0, 69, -15, 19, -15, 19,
+ax_anim 2, 0, 69, -14, 20, -14, 20,
+ax_anim 2, 0, 69, -15, 19, -15, 19,
+ax_anim 2, 0, 69, -14, 20, -14, 20,
+ax_anim 2, 0, 69, -7, 10, -7, 10,
+ax_anim 2, 0, 69, -2, 4, -2, 4,
+ax_anim_terminator
+.align 2
+sMantineAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim 2, 0, 74, 0, -5, 0, -5,
+ax_anim 6, 2, 74, 0, -6, 0, -6,
+ax_anim 1, 0, 72, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -1, 0, -1,
+ax_anim 2, 1, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sMantineAnims_4_2:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim 2, 0, 78, -5, -5, -5, -5,
+ax_anim 6, 2, 78, -6, -6, -6, -6,
+ax_anim 1, 0, 76, -4, -4, -4, -4,
+ax_anim 1, 0, 79, -1, -1, -1, -1,
+ax_anim 2, 1, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sMantineAnims_4_3:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim 2, 0, 82, -5, 0, -5, 0,
+ax_anim 6, 2, 82, -6, 0, -6, 0,
+ax_anim 1, 0, 80, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -1, 0, -1, 0,
+ax_anim 2, 1, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sMantineAnims_4_4:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim 2, 0, 86, -5, 5, -5, 5,
+ax_anim 6, 2, 86, -6, 6, -6, 6,
+ax_anim 1, 0, 84, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -1, 1, -1, 1,
+ax_anim 2, 1, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sMantineAnims_4_5:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 6, 2, 90, 0, 6, 0, 6,
+ax_anim 1, 0, 88, 0, 4, 0, 4,
+ax_anim 1, 0, 91, 0, 1, 0, 1,
+ax_anim 2, 1, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sMantineAnims_4_6:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 92, 4, 4, 4, 4,
+ax_anim 2, 0, 94, 5, 5, 5, 5,
+ax_anim 6, 2, 94, 6, 6, 6, 6,
+ax_anim 1, 0, 92, 4, 4, 4, 4,
+ax_anim 1, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 1, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sMantineAnims_4_7:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 98, 5, 0, 5, 0,
+ax_anim 6, 2, 98, 6, 0, 6, 0,
+ax_anim 1, 0, 96, 4, 0, 4, 0,
+ax_anim 1, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 1, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sMantineAnims_4_8:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 4, -4, 4, -4,
+ax_anim 2, 0, 102, 5, -5, 5, -5,
+ax_anim 6, 2, 102, 6, -6, 6, -6,
+ax_anim 1, 0, 100, 4, -4, 4, -4,
+ax_anim 1, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMantineAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 1, 0, 0,
+ax_anim 2, 0, 104, 0, 2, 0, 0,
+ax_anim 3, 0, 106, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 1, 0, 0,
+ax_anim 2, 2, 104, 0, 2, 0, 0,
+ax_anim 3, 0, 106, 0, 1, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_5_2:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 108, 0, 1, 0, 0,
+ax_anim 2, 0, 107, 0, 2, 0, 0,
+ax_anim 3, 0, 109, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 108, 0, 1, 0, 0,
+ax_anim 2, 2, 107, 0, 2, 0, 0,
+ax_anim 3, 0, 109, 0, 1, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 1, 0, 0,
+ax_anim 2, 0, 110, 0, 2, 0, 0,
+ax_anim 3, 0, 112, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 1, 0, 0,
+ax_anim 2, 2, 110, 0, 2, 0, 0,
+ax_anim 3, 0, 112, 0, 1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_5_4:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 1, 0, 0,
+ax_anim 2, 0, 113, 0, 2, 0, 0,
+ax_anim 3, 0, 115, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 1, 0, 0,
+ax_anim 2, 2, 113, 0, 2, 0, 0,
+ax_anim 3, 0, 115, 0, 1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 1, 0, 0,
+ax_anim 2, 0, 116, 0, 2, 0, 0,
+ax_anim 3, 0, 118, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 1, 0, 0,
+ax_anim 2, 2, 116, 0, 2, 0, 0,
+ax_anim 3, 0, 118, 0, 1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_5_6:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 1, 0, 0,
+ax_anim 2, 0, 119, 0, 2, 0, 0,
+ax_anim 3, 0, 121, 0, 1, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 1, 0, 0,
+ax_anim 2, 2, 119, 0, 2, 0, 0,
+ax_anim 3, 0, 121, 0, 1, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 1, 0, 0,
+ax_anim 2, 0, 122, 0, 2, 0, 0,
+ax_anim 3, 0, 124, 0, 1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 1, 0, 0,
+ax_anim 2, 2, 122, 0, 2, 0, 0,
+ax_anim 3, 0, 124, 0, 1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_5_8:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 1, 0, 0,
+ax_anim 2, 0, 125, 0, 2, 0, 0,
+ax_anim 3, 0, 127, 0, 1, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 1, 0, 0,
+ax_anim 2, 2, 125, 0, 2, 0, 0,
+ax_anim 3, 0, 127, 0, 1, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_6_1:
+ax_anim 16, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, -1, 0, 0,
+ax_anim 16, 0, 128, 0, -2, 0, 0,
+ax_anim 16, 0, 129, 0, -2, 0, 0,
+ax_anim 12, 0, 129, 0, -1, 0, 0,
+ax_anim 16, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sMantineAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sMantineAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sMantineAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sMantineAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sMantineAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sMantineAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sMantineAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMantineAnims_8_1:
+ax_anim 12, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 139, 0, 0, 0, 0,
+ax_anim 12, 0, 139, 0, 1, 0, 0,
+ax_anim 12, 0, 139, 0, 2, 0, 0,
+ax_anim 12, 0, 138, 0, 2, 0, 0,
+ax_anim 12, 0, 140, 0, 2, 0, 0,
+ax_anim 12, 0, 140, 0, 1, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_8_2:
+ax_anim 12, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, 1, 0, 0,
+ax_anim 12, 0, 142, 0, 2, 0, 0,
+ax_anim 12, 0, 141, 0, 2, 0, 0,
+ax_anim 12, 0, 143, 0, 2, 0, 0,
+ax_anim 12, 0, 143, 0, 1, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_8_3:
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, 1, 0, 0,
+ax_anim 12, 0, 145, 0, 2, 0, 0,
+ax_anim 12, 0, 144, 0, 2, 0, 0,
+ax_anim 12, 0, 146, 0, 2, 0, 0,
+ax_anim 12, 0, 146, 0, 1, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_8_4:
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, 1, 0, 0,
+ax_anim 12, 0, 148, 0, 2, 0, 0,
+ax_anim 12, 0, 147, 0, 2, 0, 0,
+ax_anim 12, 0, 149, 0, 2, 0, 0,
+ax_anim 12, 0, 149, 0, 1, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_8_5:
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 1, 0, 0,
+ax_anim 12, 0, 151, 0, 2, 0, 0,
+ax_anim 12, 0, 150, 0, 2, 0, 0,
+ax_anim 12, 0, 152, 0, 2, 0, 0,
+ax_anim 12, 0, 152, 0, 1, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_8_6:
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 1, 0, 0,
+ax_anim 12, 0, 154, 0, 2, 0, 0,
+ax_anim 12, 0, 153, 0, 2, 0, 0,
+ax_anim 12, 0, 155, 0, 2, 0, 0,
+ax_anim 12, 0, 155, 0, 1, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_8_7:
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 1, 0, 0,
+ax_anim 12, 0, 157, 0, 2, 0, 0,
+ax_anim 12, 0, 156, 0, 2, 0, 0,
+ax_anim 12, 0, 158, 0, 2, 0, 0,
+ax_anim 12, 0, 158, 0, 1, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_8_8:
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 1, 0, 0,
+ax_anim 12, 0, 160, 0, 2, 0, 0,
+ax_anim 12, 0, 159, 0, 2, 0, 0,
+ax_anim 12, 0, 161, 0, 2, 0, 0,
+ax_anim 12, 0, 161, 0, 1, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 10, 13, 10, 13,
+ax_anim 2, 0, 165, 6, 21, 6, 19,
+ax_anim 3, 0, 166, 0, 24, 0, 21,
+ax_anim 2, 3, 167, -6, 21, -6, 19,
+ax_anim 2, 0, 168, -10, 13, -10, 13,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, -2, 9, -2,
+ax_anim 2, 0, 163, 18, 2, 18, 2,
+ax_anim 2, 0, 164, 23, 12, 23, 10,
+ax_anim 3, 0, 165, 17, 23, 21, 20,
+ax_anim 2, 3, 166, 10, 24, 10, 22,
+ax_anim 2, 0, 167, 2, 19, 2, 19,
+ax_anim 1, 0, 168, -1, 9, -1, 9,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 4, -6, 4, -6,
+ax_anim 2, 0, 162, 11, -9, 11, -9,
+ax_anim 2, 0, 163, 16, -5, 16, -6,
+ax_anim 3, 0, 164, 20, 4, 20, 0,
+ax_anim 2, 3, 165, 15, 11, 17, 9,
+ax_anim 2, 0, 166, 12, 11, 12, 11,
+ax_anim 1, 0, 167, 3, 8, 3, 8,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 2, -5, 2, -5,
+ax_anim 2, 0, 169, 3, -11, 3, -11,
+ax_anim 2, 0, 162, 12, -15, 12, -16,
+ax_anim 3, 0, 163, 19, -15, 19, -17,
+ax_anim 2, 3, 164, 24, -7, 24, -8,
+ax_anim 2, 0, 165, 17, 2, 17, 2,
+ax_anim 1, 0, 166, 10, 3, 10, 3,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -5, -2, -5, -2,
+ax_anim 2, 0, 168, -9, -7, -9, -7,
+ax_anim 2, 0, 169, -7, -14, -7, -16,
+ax_anim 3, 0, 162, 0, -16, 0, -18,
+ax_anim 2, 3, 163, 7, -14, 7, -16,
+ax_anim 2, 0, 164, 9, -7, 9, -7,
+ax_anim 1, 0, 165, 5, -2, 5, -2,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 2, -5, 2, -5,
+ax_anim 2, 0, 163, -3, -11, -3, -11,
+ax_anim 2, 0, 162, -12, -15, -12, -16,
+ax_anim 3, 0, 169, -19, -15, -19, -17,
+ax_anim 2, 3, 168, -24, -7, -24, -8,
+ax_anim 2, 0, 167, -17, -2, -17, -2,
+ax_anim 1, 0, 166, -10, 3, -10, 3,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -4, -6, -4, -6,
+ax_anim 2, 0, 162, -11, -9, -11, -9,
+ax_anim 2, 0, 169, -16, -5, -16, -6,
+ax_anim 3, 0, 168, -20, 4, -20, 0,
+ax_anim 2, 3, 167, -15, 11, -17, 9,
+ax_anim 2, 0, 166, -12, 11, -12, 11,
+ax_anim 1, 0, 165, -3, 8, -3, 8,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, -2, -9, -2,
+ax_anim 2, 0, 169, -18, 2, -18, 2,
+ax_anim 2, 0, 168, -23, 12, -23, 10,
+ax_anim 3, 0, 167, -17, 23, -17, 20,
+ax_anim 2, 3, 166, -10, 24, -10, 22,
+ax_anim 2, 0, 165, -2, 19, -2, 19,
+ax_anim 1, 0, 164, -1, 9, -1, 9,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 8, 0, 0,
+ax_anim_terminator
+sMantineAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 182, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 8, 0, 0,
+ax_anim_terminator
+sMantineAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 8, 0, 0,
+ax_anim_terminator
+sMantineAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -17, 0, 0,
+ax_anim 1, 0, 188, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 8, 0, 0,
+ax_anim_terminator
+sMantineAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 8, 0, 0,
+ax_anim_terminator
+sMantineAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -17, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 8, 0, 0,
+ax_anim_terminator
+sMantineAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 8, 0, 0,
+ax_anim_terminator
+sMantineAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 8, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMantineAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMantineGfx1:
+.incbin "baserom.gba", 0xF29494, 0x200
+sMantineSprites1:
+ax_sprite sMantineGfx1, 0x200
+ax_sprite_terminator
+sMantineGfx2:
+.incbin "baserom.gba", 0xF296A4, 0x100
+sMantineSprites2:
+ax_sprite sMantineGfx2, 0x100
+ax_sprite_terminator
+sMantineGfx3:
+.incbin "baserom.gba", 0xF297B4, 0x80
+sMantineSprites3:
+ax_sprite sMantineGfx3, 0x80
+ax_sprite_terminator
+sMantineGfx4:
+.incbin "baserom.gba", 0xF29844, 0x200
+sMantineSprites4:
+ax_sprite sMantineGfx4, 0x200
+ax_sprite_terminator
+sMantineGfx5:
+.incbin "baserom.gba", 0xF29A54, 0x100
+sMantineSprites5:
+ax_sprite sMantineGfx5, 0x100
+ax_sprite_terminator
+sMantineGfx6:
+.incbin "baserom.gba", 0xF29B64, 0x20
+sMantineSprites6:
+ax_sprite sMantineGfx6, 0x20
+ax_sprite_terminator
+sMantineGfx7:
+.incbin "baserom.gba", 0xF29B94, 0x80
+sMantineSprites7:
+ax_sprite sMantineGfx7, 0x80
+ax_sprite_terminator
+sMantineGfx8:
+.incbin "baserom.gba", 0xF29C24, 0x400
+sMantineSprites8:
+ax_sprite sMantineGfx8, 0x400
+ax_sprite_terminator
+sMantineGfx9:
+.incbin "baserom.gba", 0xF2A034, 0x200
+sMantineSprites9:
+ax_sprite sMantineGfx9, 0x200
+ax_sprite_terminator
+sMantineGfx10:
+.incbin "baserom.gba", 0xF2A244, 0x100
+sMantineSprites10:
+ax_sprite sMantineGfx10, 0x100
+ax_sprite_terminator
+sMantineGfx11:
+.incbin "baserom.gba", 0xF2A354, 0x40
+sMantineSprites11:
+ax_sprite sMantineGfx11, 0x40
+ax_sprite_terminator
+sMantineGfx12:
+.incbin "baserom.gba", 0xF2A3A4, 0x200
+sMantineSprites12:
+ax_sprite sMantineGfx12, 0x200
+ax_sprite_terminator
+sMantineGfx13:
+.incbin "baserom.gba", 0xF2A5B4, 0x80
+sMantineSprites13:
+ax_sprite sMantineGfx13, 0x80
+ax_sprite_terminator
+sMantineGfx14:
+.incbin "baserom.gba", 0xF2A644, 0x40
+sMantineSprites14:
+ax_sprite sMantineGfx14, 0x40
+ax_sprite_terminator
+sMantineGfx15:
+.incbin "baserom.gba", 0xF2A694, 0x40
+sMantineSprites15:
+ax_sprite sMantineGfx15, 0x40
+ax_sprite_terminator
+sMantineGfx16:
+.incbin "baserom.gba", 0xF2A6E4, 0x200
+sMantineSprites16:
+ax_sprite sMantineGfx16, 0x200
+ax_sprite_terminator
+sMantineGfx17:
+.incbin "baserom.gba", 0xF2A8F4, 0x100
+sMantineSprites17:
+ax_sprite sMantineGfx17, 0x100
+ax_sprite_terminator
+sMantineGfx18:
+.incbin "baserom.gba", 0xF2AA04, 0x40
+sMantineSprites18:
+ax_sprite sMantineGfx18, 0x40
+ax_sprite_terminator
+sMantineGfx19:
+.incbin "baserom.gba", 0xF2AA54, 0x80
+sMantineSprites19:
+ax_sprite sMantineGfx19, 0x80
+ax_sprite_terminator
+sMantineGfx20:
+.incbin "baserom.gba", 0xF2AAE4, 0x200
+sMantineSprites20:
+ax_sprite sMantineGfx20, 0x200
+ax_sprite_terminator
+sMantineGfx21:
+.incbin "baserom.gba", 0xF2ACF4, 0x80
+sMantineSprites21:
+ax_sprite sMantineGfx21, 0x80
+ax_sprite_terminator
+sMantineGfx22:
+.incbin "baserom.gba", 0xF2AD84, 0x400
+sMantineSprites22:
+ax_sprite sMantineGfx22, 0x400
+ax_sprite_terminator
+sMantineGfx23:
+.incbin "baserom.gba", 0xF2B194, 0x40
+sMantineSprites23:
+ax_sprite sMantineGfx23, 0x40
+ax_sprite_terminator
+sMantineGfx24:
+.incbin "baserom.gba", 0xF2B1E4, 0x80
+sMantineSprites24:
+ax_sprite sMantineGfx24, 0x80
+ax_sprite_terminator
+sMantineGfx25:
+.incbin "baserom.gba", 0xF2B274, 0x200
+sMantineSprites25:
+ax_sprite sMantineGfx25, 0x200
+ax_sprite_terminator
+sMantineGfx26:
+.incbin "baserom.gba", 0xF2B484, 0x40
+sMantineSprites26:
+ax_sprite sMantineGfx26, 0x40
+ax_sprite_terminator
+sMantineGfx27:
+.incbin "baserom.gba", 0xF2B4D4, 0x200
+sMantineSprites27:
+ax_sprite sMantineGfx27, 0x200
+ax_sprite_terminator
+sMantineGfx28:
+.incbin "baserom.gba", 0xF2B6E4, 0x100
+sMantineSprites28:
+ax_sprite sMantineGfx28, 0x100
+ax_sprite_terminator
+sMantineGfx29:
+.incbin "baserom.gba", 0xF2B7F4, 0x40
+sMantineSprites29:
+ax_sprite sMantineGfx29, 0x40
+ax_sprite_terminator
+sMantineGfx30:
+.incbin "baserom.gba", 0xF2B844, 0x200
+sMantineSprites30:
+ax_sprite sMantineGfx30, 0x200
+ax_sprite_terminator
+sMantineGfx31:
+.incbin "baserom.gba", 0xF2BA54, 0x100
+sMantineSprites31:
+ax_sprite sMantineGfx31, 0x100
+ax_sprite_terminator
+sMantineGfx32:
+.incbin "baserom.gba", 0xF2BB64, 0x200
+sMantineSprites32:
+ax_sprite sMantineGfx32, 0x200
+ax_sprite_terminator
+sMantineGfx33:
+.incbin "baserom.gba", 0xF2BD74, 0x100
+sMantineSprites33:
+ax_sprite sMantineGfx33, 0x100
+ax_sprite_terminator
+sMantineGfx34:
+.incbin "baserom.gba", 0xF2BE84, 0x40
+sMantineSprites34:
+ax_sprite sMantineGfx34, 0x40
+ax_sprite_terminator
+sMantineGfx35:
+.incbin "baserom.gba", 0xF2BED4, 0x200
+sMantineSprites35:
+ax_sprite sMantineGfx35, 0x200
+ax_sprite_terminator
+sMantineGfx36:
+.incbin "baserom.gba", 0xF2C0E4, 0x100
+sMantineSprites36:
+ax_sprite sMantineGfx36, 0x100
+ax_sprite_terminator
+sMantineGfx37:
+.incbin "baserom.gba", 0xF2C1F4, 0x40
+sMantineSprites37:
+ax_sprite sMantineGfx37, 0x40
+ax_sprite_terminator
+sMantineGfx38:
+.incbin "baserom.gba", 0xF2C244, 0x80
+sMantineSprites38:
+ax_sprite sMantineGfx38, 0x80
+ax_sprite_terminator
+sMantineGfx39:
+.incbin "baserom.gba", 0xF2C2D4, 0x200
+sMantineSprites39:
+ax_sprite sMantineGfx39, 0x200
+ax_sprite_terminator
+sMantineGfx40:
+.incbin "baserom.gba", 0xF2C4E4, 0x100
+sMantineSprites40:
+ax_sprite sMantineGfx40, 0x100
+ax_sprite_terminator
+sMantineGfx41:
+.incbin "baserom.gba", 0xF2C5F4, 0x40
+sMantineSprites41:
+ax_sprite sMantineGfx41, 0x40
+ax_sprite_terminator
+sMantineGfx42:
+.incbin "baserom.gba", 0xF2C644, 0x20
+sMantineSprites42:
+ax_sprite sMantineGfx42, 0x20
+ax_sprite_terminator
+sMantineGfx43:
+.incbin "baserom.gba", 0xF2C674, 0x200
+sMantineSprites43:
+ax_sprite sMantineGfx43, 0x200
+ax_sprite_terminator
+sMantineGfx44:
+.incbin "baserom.gba", 0xF2C884, 0x100
+sMantineSprites44:
+ax_sprite sMantineGfx44, 0x100
+ax_sprite_terminator
+sMantineGfx45:
+.incbin "baserom.gba", 0xF2C994, 0x40
+sMantineSprites45:
+ax_sprite sMantineGfx45, 0x40
+ax_sprite_terminator
+sMantineGfx46:
+.incbin "baserom.gba", 0xF2C9E4, 0x80
+sMantineSprites46:
+ax_sprite sMantineGfx46, 0x80
+ax_sprite_terminator
+sMantineGfx47:
+.incbin "baserom.gba", 0xF2CA74, 0x200
+sMantineSprites47:
+ax_sprite sMantineGfx47, 0x200
+ax_sprite_terminator
+sMantineGfx48:
+.incbin "baserom.gba", 0xF2CC84, 0x100
+sMantineSprites48:
+ax_sprite sMantineGfx48, 0x100
+ax_sprite_terminator
+sMantineGfx49:
+.incbin "baserom.gba", 0xF2CD94, 0x40
+sMantineSprites49:
+ax_sprite sMantineGfx49, 0x40
+ax_sprite_terminator
+sMantineGfx50:
+.incbin "baserom.gba", 0xF2CDE4, 0x200
+sMantineSprites50:
+ax_sprite sMantineGfx50, 0x200
+ax_sprite_terminator
+sMantineGfx51:
+.incbin "baserom.gba", 0xF2CFF4, 0x100
+sMantineSprites51:
+ax_sprite sMantineGfx51, 0x100
+ax_sprite_terminator
+sMantineGfx52:
+.incbin "baserom.gba", 0xF2D104, 0x20
+sMantineSprites52:
+ax_sprite sMantineGfx52, 0x20
+ax_sprite_terminator
+sMantineGfx53:
+.incbin "baserom.gba", 0xF2D134, 0x200
+sMantineSprites53:
+ax_sprite sMantineGfx53, 0x200
+ax_sprite_terminator
+sMantineGfx54:
+.incbin "baserom.gba", 0xF2D344, 0x80
+sMantineSprites54:
+ax_sprite sMantineGfx54, 0x80
+ax_sprite_terminator
+sMantineGfx55:
+.incbin "baserom.gba", 0xF2D3D4, 0x40
+sMantineSprites55:
+ax_sprite sMantineGfx55, 0x40
+ax_sprite_terminator
+sMantineGfx56:
+.incbin "baserom.gba", 0xF2D424, 0x200
+sMantineSprites56:
+ax_sprite sMantineGfx56, 0x200
+ax_sprite_terminator
+sMantineGfx57:
+.incbin "baserom.gba", 0xF2D634, 0x100
+sMantineSprites57:
+ax_sprite sMantineGfx57, 0x100
+ax_sprite_terminator
+sMantineGfx58:
+.incbin "baserom.gba", 0xF2D744, 0x40
+sMantineSprites58:
+ax_sprite sMantineGfx58, 0x40
+ax_sprite_terminator
+sMantineGfx59:
+.incbin "baserom.gba", 0xF2D794, 0x400
+sMantineSprites59:
+ax_sprite sMantineGfx59, 0x400
+ax_sprite_terminator
+sMantineGfx60:
+.incbin "baserom.gba", 0xF2DBA4, 0x200
+sMantineSprites60:
+ax_sprite sMantineGfx60, 0x200
+ax_sprite_terminator
+sMantineGfx61:
+.incbin "baserom.gba", 0xF2DDB4, 0x100
+sMantineSprites61:
+ax_sprite sMantineGfx61, 0x100
+ax_sprite_terminator
+sMantineGfx62:
+.incbin "baserom.gba", 0xF2DEC4, 0x40
+sMantineSprites62:
+ax_sprite sMantineGfx62, 0x40
+ax_sprite_terminator
+sMantineGfx63:
+.incbin "baserom.gba", 0xF2DF14, 0x1A0
+sMantineSprites63:
+ax_sprite 0, 0x60
+ax_sprite sMantineGfx63, 0x1a0
+ax_sprite_terminator
+sMantineGfx64:
+.incbin "baserom.gba", 0xF2E0CC, 0xC0
+sMantineSprites64:
+ax_sprite 0, 0x40
+ax_sprite sMantineGfx64, 0xc0
+ax_sprite_terminator
+sMantineGfx65:
+.incbin "baserom.gba", 0xF2E1A4, 0x40
+sMantineSprites65:
+ax_sprite sMantineGfx65, 0x40
+ax_sprite_terminator
+sMantineGfx66:
+.incbin "baserom.gba", 0xF2E1F4, 0x20
+sMantineSprites66:
+ax_sprite sMantineGfx66, 0x20
+ax_sprite_terminator
+sMantineGfx67:
+.incbin "baserom.gba", 0xF2E224, 0xC0
+sMantineGfx67_1:
+.incbin "baserom.gba", 0xF2E2E4, 0xC0
+sMantineGfx67_2:
+.incbin "baserom.gba", 0xF2E3A4, 0xA0
+sMantineGfx67_3:
+.incbin "baserom.gba", 0xF2E444, 0x80
+sMantineSprites67:
+ax_sprite sMantineGfx67, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sMantineGfx67_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sMantineGfx67_2, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sMantineGfx67_3, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMantineGfx68:
+.incbin "baserom.gba", 0xF2E50C, 0x140
+sMantineGfx68_1:
+.incbin "baserom.gba", 0xF2E64C, 0x40
+sMantineSprites68:
+ax_sprite 0, 0x40
+ax_sprite sMantineGfx68, 0x140
+ax_sprite 0, 0x40
+ax_sprite sMantineGfx68_1, 0x40
+ax_sprite_terminator
+sMantineGfx69:
+.incbin "baserom.gba", 0xF2E6B4, 0xE0
+sMantineSprites69:
+ax_sprite sMantineGfx69, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMantineGfx70:
+.incbin "baserom.gba", 0xF2E7AC, 0x20
+sMantineSprites70:
+ax_sprite sMantineGfx70, 0x20
+ax_sprite_terminator
+sMantineGfx71:
+.incbin "baserom.gba", 0xF2E7DC, 0x20
+sMantineSprites71:
+ax_sprite sMantineGfx71, 0x20
+ax_sprite_terminator
+sMantineGfx72:
+.incbin "baserom.gba", 0xF2E80C, 0x200
+sMantineSprites72:
+ax_sprite sMantineGfx72, 0x200
+ax_sprite_terminator
+sMantineGfx73:
+.incbin "baserom.gba", 0xF2EA1C, 0x20
+sMantineGfx73_1:
+.incbin "baserom.gba", 0xF2EA3C, 0x20
+sMantineGfx73_2:
+.incbin "baserom.gba", 0xF2EA5C, 0x80
+sMantineSprites73:
+ax_sprite sMantineGfx73, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx73_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx73_2, 0x80
+ax_sprite_terminator
+sMantineGfx74:
+.incbin "baserom.gba", 0xF2EB0C, 0x40
+sMantineSprites74:
+ax_sprite sMantineGfx74, 0x40
+ax_sprite_terminator
+sMantineGfx75:
+.incbin "baserom.gba", 0xF2EB5C, 0x40
+sMantineSprites75:
+ax_sprite sMantineGfx75, 0x40
+ax_sprite_terminator
+sMantineGfx76:
+.incbin "baserom.gba", 0xF2EBAC, 0x140
+sMantineGfx76_1:
+.incbin "baserom.gba", 0xF2ECEC, 0x60
+sMantineSprites76:
+ax_sprite 0, 0x40
+ax_sprite sMantineGfx76, 0x140
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx76_1, 0x60
+ax_sprite_terminator
+sMantineGfx77:
+.incbin "baserom.gba", 0xF2ED74, 0x20
+sMantineGfx77_1:
+.incbin "baserom.gba", 0xF2ED94, 0xA0
+sMantineSprites77:
+ax_sprite sMantineGfx77, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx77_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMantineGfx78:
+.incbin "baserom.gba", 0xF2EE5C, 0x20
+sMantineSprites78:
+ax_sprite sMantineGfx78, 0x20
+ax_sprite_terminator
+sMantineGfx79:
+.incbin "baserom.gba", 0xF2EE8C, 0x20
+sMantineSprites79:
+ax_sprite sMantineGfx79, 0x20
+ax_sprite_terminator
+sMantineGfx80:
+.incbin "baserom.gba", 0xF2EEBC, 0x40
+sMantineSprites80:
+ax_sprite sMantineGfx80, 0x40
+ax_sprite_terminator
+sMantineGfx81:
+.incbin "baserom.gba", 0xF2EF0C, 0x60
+sMantineGfx81_1:
+.incbin "baserom.gba", 0xF2EF6C, 0x160
+sMantineSprites81:
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx81, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx81_1, 0x160
+ax_sprite_terminator
+sMantineGfx82:
+.incbin "baserom.gba", 0xF2F0F4, 0xA0
+sMantineGfx82_1:
+.incbin "baserom.gba", 0xF2F194, 0x20
+sMantineSprites82:
+ax_sprite sMantineGfx82, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx82_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMantineGfx83:
+.incbin "baserom.gba", 0xF2F1DC, 0x20
+sMantineSprites83:
+ax_sprite sMantineGfx83, 0x20
+ax_sprite_terminator
+sMantineGfx84:
+.incbin "baserom.gba", 0xF2F20C, 0x20
+sMantineSprites84:
+ax_sprite sMantineGfx84, 0x20
+ax_sprite_terminator
+sMantineGfx85:
+.incbin "baserom.gba", 0xF2F23C, 0x40
+sMantineSprites85:
+ax_sprite sMantineGfx85, 0x40
+ax_sprite_terminator
+sMantineGfx86:
+.incbin "baserom.gba", 0xF2F28C, 0x20
+sMantineSprites86:
+ax_sprite sMantineGfx86, 0x20
+ax_sprite_terminator
+sMantineGfx87:
+.incbin "baserom.gba", 0xF2F2BC, 0x180
+sMantineGfx87_1:
+.incbin "baserom.gba", 0xF2F43C, 0x60
+sMantineSprites87:
+ax_sprite sMantineGfx87, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMantineGfx87_1, 0x60
+ax_sprite_terminator
+sMantineGfx88:
+.incbin "baserom.gba", 0xF2F4BC, 0x60
+sMantineSprites88:
+ax_sprite sMantineGfx88, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMantineGfx89:
+.incbin "baserom.gba", 0xF2F534, 0x40
+sMantineSprites89:
+ax_sprite sMantineGfx89, 0x40
+ax_sprite_terminator
+sMantineGfx90:
+.incbin "baserom.gba", 0xF2F584, 0x200
+sMantineSprites90:
+ax_sprite sMantineGfx90, 0x200
+ax_sprite_terminator
+sMantineGfx91:
+.incbin "baserom.gba", 0xF2F794, 0x100
+sMantineSprites91:
+ax_sprite sMantineGfx91, 0x100
+ax_sprite_terminator
+sMantineGfx92:
+.incbin "baserom.gba", 0xF2F8A4, 0x200
+sMantineSprites92:
+ax_sprite sMantineGfx92, 0x200
+ax_sprite_terminator
+sMantineGfx93:
+.incbin "baserom.gba", 0xF2FAB4, 0x100
+sMantineSprites93:
+ax_sprite sMantineGfx93, 0x100
+ax_sprite_terminator
+sMantineGfx94:
+.incbin "baserom.gba", 0xF2FBC4, 0x100
+sMantineSprites94:
+ax_sprite sMantineGfx94, 0x100
+ax_sprite_terminator
+sMantineGfx95:
+.incbin "baserom.gba", 0xF2FCD4, 0x20
+sMantineSprites95:
+ax_sprite sMantineGfx95, 0x20
+ax_sprite_terminator
+sMantineGfx96:
+.incbin "baserom.gba", 0xF2FD04, 0x80
+sMantineSprites96:
+ax_sprite sMantineGfx96, 0x80
+ax_sprite_terminator
+sMantineGfx97:
+.incbin "baserom.gba", 0xF2FD94, 0x40
+sMantineSprites97:
+ax_sprite sMantineGfx97, 0x40
+ax_sprite_terminator
+sMantineGfx98:
+.incbin "baserom.gba", 0xF2FDE4, 0x200
+sMantineSprites98:
+ax_sprite sMantineGfx98, 0x200
+ax_sprite_terminator
+sMantineGfx99:
+.incbin "baserom.gba", 0xF2FFF4, 0x80
+sMantineSprites99:
+ax_sprite sMantineGfx99, 0x80
+ax_sprite_terminator
+sMantineGfx100:
+.incbin "baserom.gba", 0xF30084, 0x100
+sMantineSprites100:
+ax_sprite sMantineGfx100, 0x100
+ax_sprite_terminator
+sMantineGfx101:
+.incbin "baserom.gba", 0xF30194, 0x80
+sMantineSprites101:
+ax_sprite sMantineGfx101, 0x80
+ax_sprite_terminator
+sMantineGfx102:
+.incbin "baserom.gba", 0xF30224, 0x80
+sMantineSprites102:
+ax_sprite sMantineGfx102, 0x80
+ax_sprite_terminator
+sMantineGfx103:
+.incbin "baserom.gba", 0xF302B4, 0x40
+sMantineSprites103:
+ax_sprite sMantineGfx103, 0x40
+ax_sprite_terminator
+sMantineGfx104:
+.incbin "baserom.gba", 0xF30304, 0x40
+sMantineSprites104:
+ax_sprite sMantineGfx104, 0x40
+ax_sprite_terminator
+sMantineGfx105:
+.incbin "baserom.gba", 0xF30354, 0x20
+sMantineSprites105:
+ax_sprite sMantineGfx105, 0x20
+ax_sprite_terminator
+sMantineGfx106:
+.incbin "baserom.gba", 0xF30384, 0x20
+sMantineSprites106:
+ax_sprite sMantineGfx106, 0x20
+ax_sprite_terminator
+sMantineGfx107:
+.incbin "baserom.gba", 0xF303B4, 0x80
+sMantineSprites107:
+ax_sprite sMantineGfx107, 0x80
+ax_sprite_terminator
+sMantineGfx108:
+.incbin "baserom.gba", 0xF30444, 0x20
+sMantineSprites108:
+ax_sprite sMantineGfx108, 0x20
+ax_sprite_terminator
+sMantineGfx109:
+.incbin "baserom.gba", 0xF30474, 0x100
+sMantineSprites109:
+ax_sprite sMantineGfx109, 0x100
+ax_sprite_terminator
+sMantineGfx110:
+.incbin "baserom.gba", 0xF30584, 0x200
+sMantineSprites110:
+ax_sprite sMantineGfx110, 0x200
+ax_sprite_terminator
+sMantineGfx111:
+.incbin "baserom.gba", 0xF30794, 0x80
+sMantineSprites111:
+ax_sprite sMantineGfx111, 0x80
+ax_sprite_terminator
+sMantineGfx112:
+.incbin "baserom.gba", 0xF30824, 0x80
+sMantineSprites112:
+ax_sprite sMantineGfx112, 0x80
+ax_sprite_terminator
+sMantineGfx113:
+.incbin "baserom.gba", 0xF308B4, 0x20
+sMantineSprites113:
+ax_sprite sMantineGfx113, 0x20
+ax_sprite_terminator
+sMantineGfx114:
+.incbin "baserom.gba", 0xF308E4, 0x200
+sMantineSprites114:
+ax_sprite sMantineGfx114, 0x200
+ax_sprite_terminator
+sMantineGfx115:
+.incbin "baserom.gba", 0xF30AF4, 0x40
+sMantineSprites115:
+ax_sprite sMantineGfx115, 0x40
+ax_sprite_terminator
+sMantineGfx116:
+.incbin "baserom.gba", 0xF30B44, 0x100
+sMantineSprites116:
+ax_sprite sMantineGfx116, 0x100
+ax_sprite_terminator
+sMantineGfx117:
+.incbin "baserom.gba", 0xF30C54, 0x100
+sMantineSprites117:
+ax_sprite sMantineGfx117, 0x100
+ax_sprite_terminator
+sMantineGfx118:
+.incbin "baserom.gba", 0xF30D64, 0x40
+sMantineSprites118:
+ax_sprite sMantineGfx118, 0x40
+ax_sprite_terminator
+sMantineGfx119:
+.incbin "baserom.gba", 0xF30DB4, 0x40
+sMantineSprites119:
+ax_sprite sMantineGfx119, 0x40
+ax_sprite_terminator
+sMantineGfx120:
+.incbin "baserom.gba", 0xF30E04, 0x200
+sMantineSprites120:
+ax_sprite sMantineGfx120, 0x200
+ax_sprite_terminator
+sAxPosesMantine:
+.4byte sMantinePose1
+.4byte sMantinePose2
+.4byte sMantinePose3
+.4byte sMantinePose4
+.4byte sMantinePose5
+.4byte sMantinePose6
+.4byte sMantinePose7
+.4byte sMantinePose8
+.4byte sMantinePose9
+.4byte sMantinePose10
+.4byte sMantinePose11
+.4byte sMantinePose12
+.4byte sMantinePose13
+.4byte sMantinePose14
+.4byte sMantinePose15
+.4byte sMantinePose16
+.4byte sMantinePose17
+.4byte sMantinePose18
+.4byte sMantinePose19
+.4byte sMantinePose20
+.4byte sMantinePose21
+.4byte sMantinePose22
+.4byte sMantinePose23
+.4byte sMantinePose24
+.4byte sMantinePose25
+.4byte sMantinePose26
+.4byte sMantinePose27
+.4byte sMantinePose28
+.4byte sMantinePose29
+.4byte sMantinePose30
+.4byte sMantinePose31
+.4byte sMantinePose32
+.4byte sMantinePose33
+.4byte sMantinePose34
+.4byte sMantinePose35
+.4byte sMantinePose36
+.4byte sMantinePose37
+.4byte sMantinePose38
+.4byte sMantinePose39
+.4byte sMantinePose40
+.4byte sMantinePose41
+.4byte sMantinePose42
+.4byte sMantinePose43
+.4byte sMantinePose44
+.4byte sMantinePose45
+.4byte sMantinePose46
+.4byte sMantinePose47
+.4byte sMantinePose48
+.4byte sMantinePose49
+.4byte sMantinePose50
+.4byte sMantinePose51
+.4byte sMantinePose52
+.4byte sMantinePose53
+.4byte sMantinePose54
+.4byte sMantinePose55
+.4byte sMantinePose56
+.4byte sMantinePose57
+.4byte sMantinePose58
+.4byte sMantinePose59
+.4byte sMantinePose60
+.4byte sMantinePose61
+.4byte sMantinePose62
+.4byte sMantinePose63
+.4byte sMantinePose64
+.4byte sMantinePose65
+.4byte sMantinePose66
+.4byte sMantinePose67
+.4byte sMantinePose68
+.4byte sMantinePose69
+.4byte sMantinePose70
+.4byte sMantinePose71
+.4byte sMantinePose72
+.4byte sMantinePose73
+.4byte sMantinePose74
+.4byte sMantinePose75
+.4byte sMantinePose76
+.4byte sMantinePose77
+.4byte sMantinePose78
+.4byte sMantinePose79
+.4byte sMantinePose80
+.4byte sMantinePose81
+.4byte sMantinePose82
+.4byte sMantinePose83
+.4byte sMantinePose84
+.4byte sMantinePose85
+.4byte sMantinePose86
+.4byte sMantinePose87
+.4byte sMantinePose88
+.4byte sMantinePose89
+.4byte sMantinePose90
+.4byte sMantinePose91
+.4byte sMantinePose92
+.4byte sMantinePose93
+.4byte sMantinePose94
+.4byte sMantinePose95
+.4byte sMantinePose96
+.4byte sMantinePose97
+.4byte sMantinePose98
+.4byte sMantinePose99
+.4byte sMantinePose100
+.4byte sMantinePose101
+.4byte sMantinePose102
+.4byte sMantinePose103
+.4byte sMantinePose104
+.4byte sMantinePose105
+.4byte sMantinePose106
+.4byte sMantinePose107
+.4byte sMantinePose108
+.4byte sMantinePose109
+.4byte sMantinePose110
+.4byte sMantinePose111
+.4byte sMantinePose112
+.4byte sMantinePose113
+.4byte sMantinePose114
+.4byte sMantinePose115
+.4byte sMantinePose116
+.4byte sMantinePose117
+.4byte sMantinePose118
+.4byte sMantinePose119
+.4byte sMantinePose120
+.4byte sMantinePose121
+.4byte sMantinePose122
+.4byte sMantinePose123
+.4byte sMantinePose124
+.4byte sMantinePose125
+.4byte sMantinePose126
+.4byte sMantinePose127
+.4byte sMantinePose128
+.4byte sMantinePose129
+.4byte sMantinePose130
+.4byte sMantinePose131
+.4byte sMantinePose132
+.4byte sMantinePose133
+.4byte sMantinePose134
+.4byte sMantinePose135
+.4byte sMantinePose136
+.4byte sMantinePose137
+.4byte sMantinePose138
+.4byte sMantinePose139
+.4byte sMantinePose140
+.4byte sMantinePose141
+.4byte sMantinePose142
+.4byte sMantinePose143
+.4byte sMantinePose144
+.4byte sMantinePose145
+.4byte sMantinePose146
+.4byte sMantinePose147
+.4byte sMantinePose148
+.4byte sMantinePose149
+.4byte sMantinePose150
+.4byte sMantinePose151
+.4byte sMantinePose152
+.4byte sMantinePose153
+.4byte sMantinePose154
+.4byte sMantinePose155
+.4byte sMantinePose156
+.4byte sMantinePose157
+.4byte sMantinePose158
+.4byte sMantinePose159
+.4byte sMantinePose160
+.4byte sMantinePose161
+.4byte sMantinePose162
+.4byte sMantinePose163
+.4byte sMantinePose164
+.4byte sMantinePose165
+.4byte sMantinePose166
+.4byte sMantinePose167
+.4byte sMantinePose168
+.4byte sMantinePose169
+.4byte sMantinePose170
+.4byte sMantinePose171
+.4byte sMantinePose172
+.4byte sMantinePose173
+.4byte sMantinePose174
+.4byte sMantinePose175
+.4byte sMantinePose176
+.4byte sMantinePose177
+.4byte sMantinePose178
+.4byte sMantinePose179
+.4byte sMantinePose180
+.4byte sMantinePose181
+.4byte sMantinePose182
+.4byte sMantinePose183
+.4byte sMantinePose184
+.4byte sMantinePose185
+.4byte sMantinePose186
+.4byte sMantinePose187
+.4byte sMantinePose188
+.4byte sMantinePose189
+.4byte sMantinePose190
+.4byte sMantinePose191
+.4byte sMantinePose192
+.4byte sMantinePose193
+.4byte sMantinePose194
+.4byte sMantinePose195
+.4byte sMantinePose196
+.4byte sMantinePose197
+.4byte sMantinePose198
+.4byte sMantinePose199
+.4byte sMantinePose200
+.4byte sMantinePose201
+.4byte sMantinePose202
+.4byte sMantinePose203
+.4byte sMantinePose204
+.4byte sMantinePose205
+.4byte sMantinePose206
+.4byte sMantinePose207
+.4byte sMantinePose208
+.4byte sMantinePose209
+.4byte sMantinePose210
+.4byte sMantinePose211
+.4byte sMantinePose212
+.4byte sMantinePose213
+.4byte sMantinePose214
+.4byte sMantinePose215
+.4byte sMantinePose216
+.4byte sMantinePose217
+.4byte sMantinePose218
+sAxPositionsMantine:
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -20,  -17, 	  19,  -17, 	   0,  -13
+.2byte    0,   -4, 	 -21,   -9, 	  20,   -9, 	   0,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+.2byte    6,   -5, 	  11,  -24, 	 -11,   -5, 	   2,  -13
+.2byte    5,   -5, 	  11,  -20, 	 -10,   -2, 	   1,  -13
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    8,  -12, 	   1,   -4, 	   1,  -25, 	   1,  -14
+.2byte    7,  -13, 	   2,    1, 	   1,  -21, 	   3,  -13
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    5,  -15, 	  16,   -6, 	 -12,  -22, 	   2,  -14
+.2byte    5,  -15, 	  15,   -3, 	 -13,  -17, 	   2,  -12
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    0,  -18, 	  19,  -17, 	 -19,  -16, 	   0,  -14
+.2byte    0,  -17, 	  19,  -10, 	 -20,  -10, 	  -1,  -14
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -4,  -17, 	  14,  -24, 	 -14,   -8, 	   1,  -15
+.2byte   -5,  -16, 	  14,  -18, 	 -13,   -4, 	   0,  -15
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -25, 	  -2,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	  -2,  -21, 	  -2,    1, 	  -2,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte   -7,   -5, 	 -12,  -24, 	  10,   -5, 	  -3,  -13
+.2byte   -6,   -5, 	 -12,  -20, 	   9,   -2, 	  -2,  -13
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -20,  -17, 	  19,  -17, 	   0,  -13
+.2byte    0,   -4, 	 -21,   -9, 	  20,   -9, 	   0,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+.2byte    6,   -5, 	  11,  -24, 	 -11,   -5, 	   2,  -13
+.2byte    5,   -5, 	  11,  -20, 	 -10,   -2, 	   1,  -13
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    8,  -12, 	   1,   -4, 	   1,  -25, 	   1,  -14
+.2byte    7,  -13, 	   2,    1, 	   1,  -21, 	   3,  -13
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    5,  -15, 	  16,   -6, 	 -12,  -22, 	   2,  -14
+.2byte    5,  -15, 	  15,   -3, 	 -13,  -17, 	   2,  -12
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    0,  -18, 	  19,  -17, 	 -19,  -16, 	   0,  -14
+.2byte    0,  -17, 	  19,  -10, 	 -20,  -10, 	  -1,  -14
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -4,  -17, 	  14,  -24, 	 -14,   -8, 	   1,  -15
+.2byte   -5,  -16, 	  14,  -18, 	 -13,   -4, 	   0,  -15
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -25, 	  -2,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	  -2,  -21, 	  -2,    1, 	  -2,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte   -7,   -5, 	 -12,  -24, 	  10,   -5, 	  -3,  -13
+.2byte   -6,   -5, 	 -12,  -20, 	   9,   -2, 	  -2,  -13
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -20,  -17, 	  19,  -17, 	   0,  -13
+.2byte    0,   -4, 	 -21,   -9, 	  20,   -9, 	   0,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+.2byte    6,   -5, 	  11,  -24, 	 -11,   -5, 	   2,  -13
+.2byte    5,   -5, 	  11,  -20, 	 -10,   -2, 	   1,  -13
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    8,  -12, 	   1,   -4, 	   1,  -25, 	   1,  -14
+.2byte    7,  -13, 	   2,    1, 	   1,  -21, 	   3,  -13
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    5,  -15, 	  16,   -6, 	 -12,  -22, 	   2,  -14
+.2byte    5,  -15, 	  15,   -3, 	 -13,  -17, 	   2,  -12
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    0,  -18, 	  19,  -17, 	 -19,  -16, 	   0,  -14
+.2byte    0,  -17, 	  19,  -10, 	 -20,  -10, 	  -1,  -14
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -4,  -17, 	  14,  -24, 	 -14,   -8, 	   1,  -15
+.2byte   -5,  -16, 	  14,  -18, 	 -13,   -4, 	   0,  -15
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -25, 	  -2,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	  -2,  -21, 	  -2,    1, 	  -2,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte   -7,   -5, 	 -12,  -24, 	  10,   -5, 	  -3,  -13
+.2byte   -6,   -5, 	 -12,  -20, 	   9,   -2, 	  -2,  -13
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -20,  -17, 	  19,  -17, 	   0,  -13
+.2byte    0,   -4, 	 -21,   -9, 	  20,   -9, 	   0,  -13
+.2byte   -1,   -3, 	 -21,  -15, 	  20,  -15, 	   0,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+.2byte    6,   -5, 	  11,  -24, 	 -11,   -5, 	   2,  -13
+.2byte    5,   -5, 	  11,  -20, 	 -10,   -2, 	   1,  -13
+.2byte    7,   -4, 	  11,  -23, 	 -12,   -3, 	   0,  -12
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    8,  -12, 	   1,   -4, 	   1,  -25, 	   1,  -14
+.2byte    7,  -13, 	   2,    1, 	   1,  -21, 	   3,  -13
+.2byte   12,  -10, 	   1,   -1, 	   0,  -23, 	   1,  -12
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    5,  -15, 	  16,   -6, 	 -12,  -22, 	   2,  -14
+.2byte    5,  -15, 	  15,   -3, 	 -13,  -17, 	   2,  -12
+.2byte    6,  -14, 	  15,   -4, 	 -14,  -20, 	   1,  -12
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    0,  -18, 	  19,  -17, 	 -19,  -16, 	   0,  -14
+.2byte    0,  -17, 	  19,  -10, 	 -20,  -10, 	  -1,  -14
+.2byte    0,  -19, 	  20,  -13, 	 -21,  -14, 	  -1,  -14
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -4,  -17, 	  14,  -24, 	 -14,   -8, 	   1,  -15
+.2byte   -5,  -16, 	  14,  -18, 	 -13,   -4, 	   0,  -15
+.2byte   -5,  -18, 	  15,  -21, 	 -14,   -6, 	   1,  -15
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -25, 	  -2,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	  -2,  -21, 	  -2,    1, 	  -2,  -13
+.2byte  -13,  -10, 	  -1,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte   -7,   -5, 	 -12,  -24, 	  10,   -5, 	  -3,  -13
+.2byte   -6,   -5, 	 -12,  -20, 	   9,   -2, 	  -2,  -13
+.2byte   -8,   -4, 	 -12,  -23, 	  11,   -3, 	  -1,  -12
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -20,  -17, 	  19,  -17, 	   0,  -13
+.2byte    0,   -4, 	 -21,   -9, 	  20,   -9, 	   0,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+.2byte    6,   -5, 	  11,  -24, 	 -11,   -5, 	   2,  -13
+.2byte    5,   -5, 	  11,  -20, 	 -10,   -2, 	   1,  -13
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    8,  -12, 	   1,   -4, 	   1,  -25, 	   1,  -14
+.2byte    7,  -13, 	   2,    1, 	   1,  -21, 	   3,  -13
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    5,  -15, 	  16,   -6, 	 -12,  -22, 	   2,  -14
+.2byte    5,  -15, 	  15,   -3, 	 -13,  -17, 	   2,  -12
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    0,  -18, 	  19,  -17, 	 -19,  -16, 	   0,  -14
+.2byte    0,  -17, 	  19,  -10, 	 -20,  -10, 	  -1,  -14
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -4,  -17, 	  14,  -24, 	 -14,   -8, 	   1,  -15
+.2byte   -5,  -16, 	  14,  -18, 	 -13,   -4, 	   0,  -15
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -25, 	  -2,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	  -2,  -21, 	  -2,    1, 	  -2,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte   -7,   -5, 	 -12,  -24, 	  10,   -5, 	  -3,  -13
+.2byte   -6,   -5, 	 -12,  -20, 	   9,   -2, 	  -2,  -13
+.2byte   -5,   -8, 	 -11,  -20, 	   9,   -1, 	  -2,  -14
+.2byte   -5,   -7, 	 -12,  -20, 	  10,   -2, 	  -1,  -14
+.2byte    0,  -25, 	 -20,  -18, 	  20,  -18, 	   1,  -19
+.2byte    0,  -25, 	  14,  -24, 	 -17,  -15, 	   0,  -18
+.2byte    4,  -24, 	   5,  -24, 	  -4,  -17, 	  -1,  -17
+.2byte    1,  -23, 	 -15,  -23, 	  12,   -8, 	  -1,  -18
+.2byte    0,  -22, 	  21,  -17, 	 -20,  -17, 	   0,  -19
+.2byte   -2,  -23, 	  14,  -23, 	 -13,   -8, 	   0,  -18
+.2byte   -5,  -24, 	  -6,  -24, 	   3,  -17, 	   0,  -17
+.2byte   -1,  -25, 	 -15,  -24, 	  16,  -15, 	  -1,  -18
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -20,  -17, 	  19,  -17, 	   0,  -13
+.2byte    0,   -4, 	 -21,   -9, 	  20,   -9, 	   0,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+.2byte    6,   -5, 	  11,  -24, 	 -11,   -5, 	   2,  -13
+.2byte    5,   -5, 	  11,  -20, 	 -10,   -2, 	   1,  -13
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    8,  -12, 	   1,   -4, 	   1,  -25, 	   1,  -14
+.2byte    7,  -13, 	   2,    1, 	   1,  -21, 	   3,  -13
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    5,  -15, 	  16,   -6, 	 -12,  -22, 	   2,  -14
+.2byte    5,  -15, 	  15,   -3, 	 -13,  -17, 	   2,  -12
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    0,  -18, 	  19,  -17, 	 -19,  -16, 	   0,  -14
+.2byte    0,  -17, 	  19,  -10, 	 -20,  -10, 	  -1,  -14
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -4,  -17, 	  14,  -24, 	 -14,   -8, 	   1,  -15
+.2byte   -5,  -16, 	  14,  -18, 	 -13,   -4, 	   0,  -15
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -25, 	  -2,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	  -2,  -21, 	  -2,    1, 	  -2,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte   -7,   -5, 	 -12,  -24, 	  10,   -5, 	  -3,  -13
+.2byte   -6,   -5, 	 -12,  -20, 	   9,   -2, 	  -2,  -13
+.2byte   -1,   -3, 	 -21,  -15, 	  20,  -15, 	   0,  -13
+.2byte   -8,   -4, 	 -12,  -23, 	  11,   -3, 	  -1,  -12
+.2byte  -13,  -10, 	  -1,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte   -5,  -18, 	  15,  -21, 	 -14,   -6, 	   1,  -15
+.2byte    0,  -19, 	  20,  -13, 	 -21,  -14, 	  -1,  -14
+.2byte    6,  -14, 	  15,   -4, 	 -14,  -20, 	   1,  -12
+.2byte   12,  -10, 	   1,   -1, 	   0,  -23, 	   1,  -12
+.2byte    7,   -4, 	  11,  -23, 	 -12,   -3, 	   0,  -12
+.2byte   -1,   -3, 	 -21,  -15, 	  20,  -15, 	   0,  -13
+.2byte    7,   -4, 	  11,  -23, 	 -12,   -3, 	   0,  -12
+.2byte   13,  -10, 	   2,   -1, 	   1,  -23, 	   2,  -12
+.2byte    7,  -15, 	  16,   -5, 	 -13,  -21, 	   2,  -13
+.2byte    0,  -20, 	  20,  -14, 	 -21,  -15, 	  -1,  -15
+.2byte   -7,  -17, 	  13,  -20, 	 -16,   -5, 	  -1,  -14
+.2byte  -14,  -10, 	  -2,  -23, 	  -3,   -2, 	  -2,  -13
+.2byte   -8,   -4, 	 -12,  -23, 	  11,   -3, 	  -1,  -12
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -20,  -17, 	  19,  -17, 	   0,  -13
+.2byte    0,   -4, 	 -21,   -9, 	  20,   -9, 	   0,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+.2byte    6,   -5, 	  11,  -24, 	 -11,   -5, 	   2,  -13
+.2byte    5,   -5, 	  11,  -20, 	 -10,   -2, 	   1,  -13
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    8,  -12, 	   1,   -4, 	   1,  -25, 	   1,  -14
+.2byte    7,  -13, 	   2,    1, 	   1,  -21, 	   3,  -13
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    5,  -15, 	  16,   -6, 	 -12,  -22, 	   2,  -14
+.2byte    5,  -15, 	  15,   -3, 	 -13,  -17, 	   2,  -12
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    0,  -18, 	  19,  -17, 	 -19,  -16, 	   0,  -14
+.2byte    0,  -17, 	  19,  -10, 	 -20,  -10, 	  -1,  -14
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -4,  -17, 	  14,  -24, 	 -14,   -8, 	   1,  -15
+.2byte   -5,  -16, 	  14,  -18, 	 -13,   -4, 	   0,  -15
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -25, 	  -2,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	  -2,  -21, 	  -2,    1, 	  -2,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte   -7,   -5, 	 -12,  -24, 	  10,   -5, 	  -3,  -13
+.2byte   -6,   -5, 	 -12,  -20, 	   9,   -2, 	  -2,  -13
+.2byte   -1,   -3, 	 -21,  -15, 	  20,  -15, 	   0,  -13
+.2byte   -8,   -4, 	 -12,  -23, 	  11,   -3, 	  -1,  -12
+.2byte  -14,  -10, 	  -2,  -23, 	  -3,   -2, 	  -2,  -13
+.2byte   -7,  -17, 	  13,  -20, 	 -16,   -5, 	  -1,  -14
+.2byte    0,  -20, 	  20,  -14, 	 -21,  -15, 	  -1,  -15
+.2byte    7,  -15, 	  16,   -5, 	 -13,  -21, 	   2,  -13
+.2byte   13,  -10, 	   2,   -1, 	   1,  -23, 	   2,  -12
+.2byte    7,   -4, 	  11,  -23, 	 -12,   -3, 	   0,  -12
+.2byte    0,   -4, 	 -21,  -14, 	  20,  -14, 	   0,  -13
+.2byte   -7,   -5, 	 -13,  -23, 	  10,   -3, 	  -3,  -13
+.2byte  -10,  -10, 	  -2,  -23, 	  -2,   -2, 	  -1,  -13
+.2byte   -4,  -17, 	  14,  -21, 	 -14,   -6, 	   1,  -15
+.2byte   -1,  -18, 	  20,  -14, 	 -21,  -14, 	  -1,  -14
+.2byte    4,  -15, 	  16,   -5, 	 -13,  -20, 	   1,  -13
+.2byte    6,  -10, 	   2,   -1, 	   2,  -23, 	   1,  -13
+.2byte    6,   -5, 	  12,  -23, 	 -11,   -3, 	   2,  -13
+sMantineAnimTable1:
+.4byte sMantineAnims_1_1
+.4byte sMantineAnims_1_2
+.4byte sMantineAnims_1_3
+.4byte sMantineAnims_1_4
+.4byte sMantineAnims_1_5
+.4byte sMantineAnims_1_6
+.4byte sMantineAnims_1_7
+.4byte sMantineAnims_1_8
+sMantineAnimTable2:
+.4byte sMantineAnims_2_1
+.4byte sMantineAnims_2_2
+.4byte sMantineAnims_2_3
+.4byte sMantineAnims_2_4
+.4byte sMantineAnims_2_5
+.4byte sMantineAnims_2_6
+.4byte sMantineAnims_2_7
+.4byte sMantineAnims_2_8
+sMantineAnimTable3:
+.4byte sMantineAnims_3_1
+.4byte sMantineAnims_3_2
+.4byte sMantineAnims_3_3
+.4byte sMantineAnims_3_4
+.4byte sMantineAnims_3_5
+.4byte sMantineAnims_3_6
+.4byte sMantineAnims_3_7
+.4byte sMantineAnims_3_8
+sMantineAnimTable4:
+.4byte sMantineAnims_4_1
+.4byte sMantineAnims_4_2
+.4byte sMantineAnims_4_3
+.4byte sMantineAnims_4_4
+.4byte sMantineAnims_4_5
+.4byte sMantineAnims_4_6
+.4byte sMantineAnims_4_7
+.4byte sMantineAnims_4_8
+sMantineAnimTable5:
+.4byte sMantineAnims_5_1
+.4byte sMantineAnims_5_2
+.4byte sMantineAnims_5_3
+.4byte sMantineAnims_5_4
+.4byte sMantineAnims_5_5
+.4byte sMantineAnims_5_6
+.4byte sMantineAnims_5_7
+.4byte sMantineAnims_5_8
+sMantineAnimTable6:
+.4byte sMantineAnims_6_1
+.4byte sMantineAnims_6_1
+.4byte sMantineAnims_6_1
+.4byte sMantineAnims_6_1
+.4byte sMantineAnims_6_1
+.4byte sMantineAnims_6_1
+.4byte sMantineAnims_6_1
+.4byte sMantineAnims_6_1
+sMantineAnimTable7:
+.4byte sMantineAnims_7_1
+.4byte sMantineAnims_7_2
+.4byte sMantineAnims_7_3
+.4byte sMantineAnims_7_4
+.4byte sMantineAnims_7_5
+.4byte sMantineAnims_7_6
+.4byte sMantineAnims_7_7
+.4byte sMantineAnims_7_8
+sMantineAnimTable8:
+.4byte sMantineAnims_8_1
+.4byte sMantineAnims_8_2
+.4byte sMantineAnims_8_3
+.4byte sMantineAnims_8_4
+.4byte sMantineAnims_8_5
+.4byte sMantineAnims_8_6
+.4byte sMantineAnims_8_7
+.4byte sMantineAnims_8_8
+sMantineAnimTable9:
+.4byte sMantineAnims_9_1
+.4byte sMantineAnims_9_2
+.4byte sMantineAnims_9_3
+.4byte sMantineAnims_9_4
+.4byte sMantineAnims_9_5
+.4byte sMantineAnims_9_6
+.4byte sMantineAnims_9_7
+.4byte sMantineAnims_9_8
+sMantineAnimTable10:
+.4byte sMantineAnims_10_1
+.4byte sMantineAnims_10_2
+.4byte sMantineAnims_10_3
+.4byte sMantineAnims_10_4
+.4byte sMantineAnims_10_5
+.4byte sMantineAnims_10_6
+.4byte sMantineAnims_10_7
+.4byte sMantineAnims_10_8
+sMantineAnimTable11:
+.4byte sMantineAnims_11_1
+.4byte sMantineAnims_11_2
+.4byte sMantineAnims_11_3
+.4byte sMantineAnims_11_4
+.4byte sMantineAnims_11_5
+.4byte sMantineAnims_11_6
+.4byte sMantineAnims_11_7
+.4byte sMantineAnims_11_8
+sMantineAnimTable12:
+.4byte sMantineAnims_12_1
+.4byte sMantineAnims_12_2
+.4byte sMantineAnims_12_3
+.4byte sMantineAnims_12_4
+.4byte sMantineAnims_12_5
+.4byte sMantineAnims_12_6
+.4byte sMantineAnims_12_7
+.4byte sMantineAnims_12_8
+sMantineAnimTable13:
+.4byte sMantineAnims_13_1
+.4byte sMantineAnims_13_2
+.4byte sMantineAnims_13_3
+.4byte sMantineAnims_13_4
+.4byte sMantineAnims_13_5
+.4byte sMantineAnims_13_6
+.4byte sMantineAnims_13_7
+.4byte sMantineAnims_13_8
+sAxAnimationsMantine:
+.4byte sMantineAnimTable1
+.4byte sMantineAnimTable2
+.4byte sMantineAnimTable3
+.4byte sMantineAnimTable4
+.4byte sMantineAnimTable5
+.4byte sMantineAnimTable6
+.4byte sMantineAnimTable7
+.4byte sMantineAnimTable8
+.4byte sMantineAnimTable9
+.4byte sMantineAnimTable10
+.4byte sMantineAnimTable11
+.4byte sMantineAnimTable12
+.4byte sMantineAnimTable13
+sAxSpritesMantine:
+.4byte sMantineSprites1
+.4byte sMantineSprites2
+.4byte sMantineSprites3
+.4byte sMantineSprites4
+.4byte sMantineSprites5
+.4byte sMantineSprites6
+.4byte sMantineSprites7
+.4byte sMantineSprites8
+.4byte sMantineSprites9
+.4byte sMantineSprites10
+.4byte sMantineSprites11
+.4byte sMantineSprites12
+.4byte sMantineSprites13
+.4byte sMantineSprites14
+.4byte sMantineSprites15
+.4byte sMantineSprites16
+.4byte sMantineSprites17
+.4byte sMantineSprites18
+.4byte sMantineSprites19
+.4byte sMantineSprites20
+.4byte sMantineSprites21
+.4byte sMantineSprites22
+.4byte sMantineSprites23
+.4byte sMantineSprites24
+.4byte sMantineSprites25
+.4byte sMantineSprites26
+.4byte sMantineSprites27
+.4byte sMantineSprites28
+.4byte sMantineSprites29
+.4byte sMantineSprites30
+.4byte sMantineSprites31
+.4byte sMantineSprites32
+.4byte sMantineSprites33
+.4byte sMantineSprites34
+.4byte sMantineSprites35
+.4byte sMantineSprites36
+.4byte sMantineSprites37
+.4byte sMantineSprites38
+.4byte sMantineSprites39
+.4byte sMantineSprites40
+.4byte sMantineSprites41
+.4byte sMantineSprites42
+.4byte sMantineSprites43
+.4byte sMantineSprites44
+.4byte sMantineSprites45
+.4byte sMantineSprites46
+.4byte sMantineSprites47
+.4byte sMantineSprites48
+.4byte sMantineSprites49
+.4byte sMantineSprites50
+.4byte sMantineSprites51
+.4byte sMantineSprites52
+.4byte sMantineSprites53
+.4byte sMantineSprites54
+.4byte sMantineSprites55
+.4byte sMantineSprites56
+.4byte sMantineSprites57
+.4byte sMantineSprites58
+.4byte sMantineSprites59
+.4byte sMantineSprites60
+.4byte sMantineSprites61
+.4byte sMantineSprites62
+.4byte sMantineSprites63
+.4byte sMantineSprites64
+.4byte sMantineSprites65
+.4byte sMantineSprites66
+.4byte sMantineSprites67
+.4byte sMantineSprites68
+.4byte sMantineSprites69
+.4byte sMantineSprites70
+.4byte sMantineSprites71
+.4byte sMantineSprites72
+.4byte sMantineSprites73
+.4byte sMantineSprites74
+.4byte sMantineSprites75
+.4byte sMantineSprites76
+.4byte sMantineSprites77
+.4byte sMantineSprites78
+.4byte sMantineSprites79
+.4byte sMantineSprites80
+.4byte sMantineSprites81
+.4byte sMantineSprites82
+.4byte sMantineSprites83
+.4byte sMantineSprites84
+.4byte sMantineSprites85
+.4byte sMantineSprites86
+.4byte sMantineSprites87
+.4byte sMantineSprites88
+.4byte sMantineSprites89
+.4byte sMantineSprites90
+.4byte sMantineSprites91
+.4byte sMantineSprites92
+.4byte sMantineSprites93
+.4byte sMantineSprites94
+.4byte sMantineSprites95
+.4byte sMantineSprites96
+.4byte sMantineSprites97
+.4byte sMantineSprites98
+.4byte sMantineSprites99
+.4byte sMantineSprites100
+.4byte sMantineSprites101
+.4byte sMantineSprites102
+.4byte sMantineSprites103
+.4byte sMantineSprites104
+.4byte sMantineSprites105
+.4byte sMantineSprites106
+.4byte sMantineSprites107
+.4byte sMantineSprites108
+.4byte sMantineSprites109
+.4byte sMantineSprites110
+.4byte sMantineSprites111
+.4byte sMantineSprites112
+.4byte sMantineSprites113
+.4byte sMantineSprites114
+.4byte sMantineSprites115
+.4byte sMantineSprites116
+.4byte sMantineSprites117
+.4byte sMantineSprites118
+.4byte sMantineSprites119
+.4byte sMantineSprites120
+sAxMainMantine:
+ax_main sAxPosesMantine, sAxAnimationsMantine, 13, sAxSpritesMantine, sAxPositionsMantine

--- a/data/ax/mareep.inc
+++ b/data/ax/mareep.inc
@@ -1,0 +1,2874 @@
+.global gAxMareep
+gAxMareep:
+ax_siro sAxMainMareep
+sMareepPose1:
+ax_pose 0, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose2:
+ax_pose 1, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose3:
+ax_pose 2, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose4:
+ax_pose 3, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose5:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose6:
+ax_pose 5, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose7:
+ax_pose 6, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose8:
+ax_pose 7, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose9:
+ax_pose 8, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose10:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose11:
+ax_pose 10, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose12:
+ax_pose 11, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose13:
+ax_pose 12, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose14:
+ax_pose 13, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose15:
+ax_pose 14, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose16:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose17:
+ax_pose 10, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose18:
+ax_pose 11, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose19:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose20:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose21:
+ax_pose 8, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose22:
+ax_pose 3, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose23:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose24:
+ax_pose 5, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose25:
+ax_pose 0, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose26:
+ax_pose 15, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose27:
+ax_pose 2, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose28:
+ax_pose 16, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose29:
+ax_pose 3, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose30:
+ax_pose 17, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose31:
+ax_pose 5, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose32:
+ax_pose 18, 0x01ed, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose33:
+ax_pose 6, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose34:
+ax_pose 19, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose35:
+ax_pose 8, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose36:
+ax_pose 20, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose37:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose38:
+ax_pose 21, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose39:
+ax_pose 11, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose40:
+ax_pose 22, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose41:
+ax_pose 12, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose42:
+ax_pose 23, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose43:
+ax_pose 14, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose44:
+ax_pose 24, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose45:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose46:
+ax_pose 21, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose47:
+ax_pose 11, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose48:
+ax_pose 22, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose49:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose50:
+ax_pose 19, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose51:
+ax_pose 8, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose52:
+ax_pose 20, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose53:
+ax_pose 3, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose54:
+ax_pose 17, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose55:
+ax_pose 5, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose56:
+ax_pose 18, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose57:
+ax_pose 0, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose58:
+ax_pose 15, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose59:
+ax_pose 2, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose60:
+ax_pose 16, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose61:
+ax_pose 3, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose62:
+ax_pose 17, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose63:
+ax_pose 5, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose64:
+ax_pose 18, 0x01ed, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose65:
+ax_pose 6, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose66:
+ax_pose 19, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose67:
+ax_pose 8, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose68:
+ax_pose 20, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose69:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose70:
+ax_pose 21, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose71:
+ax_pose 11, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose72:
+ax_pose 22, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose73:
+ax_pose 12, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose74:
+ax_pose 23, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose75:
+ax_pose 14, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose76:
+ax_pose 24, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose77:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose78:
+ax_pose 21, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose79:
+ax_pose 11, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose80:
+ax_pose 22, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose81:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose82:
+ax_pose 19, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose83:
+ax_pose 8, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose84:
+ax_pose 20, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose85:
+ax_pose 3, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose86:
+ax_pose 17, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose87:
+ax_pose 5, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose88:
+ax_pose 18, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose89:
+ax_pose 0, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose90:
+ax_pose 1, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose91:
+ax_pose 2, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose92:
+ax_pose 15, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose93:
+ax_pose 16, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose94:
+ax_pose 3, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose95:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose96:
+ax_pose 5, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose97:
+ax_pose 17, 0x01ed, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose98:
+ax_pose 18, 0x01ed, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose99:
+ax_pose 6, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose100:
+ax_pose 7, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose101:
+ax_pose 8, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose102:
+ax_pose 19, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sMareepPose103:
+ax_pose 20, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose104:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose105:
+ax_pose 10, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose106:
+ax_pose 11, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose107:
+ax_pose 21, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sMareepPose108:
+ax_pose 22, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose109:
+ax_pose 12, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose110:
+ax_pose 13, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose111:
+ax_pose 14, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose112:
+ax_pose 23, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose113:
+ax_pose 24, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose114:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose115:
+ax_pose 10, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose116:
+ax_pose 11, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose117:
+ax_pose 21, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sMareepPose118:
+ax_pose 22, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose119:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose120:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose121:
+ax_pose 8, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose122:
+ax_pose 19, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose123:
+ax_pose 20, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose124:
+ax_pose 3, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose125:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose126:
+ax_pose 5, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose127:
+ax_pose 17, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose128:
+ax_pose 18, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose129:
+ax_pose 15, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose130:
+ax_pose 25, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose131:
+ax_pose 17, 0x01ed, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose132:
+ax_pose 26, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose133:
+ax_pose 19, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sMareepPose134:
+ax_pose 27, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sMareepPose135:
+ax_pose 21, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sMareepPose136:
+ax_pose 28, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sMareepPose137:
+ax_pose 23, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose138:
+ax_pose 29, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose139:
+ax_pose 21, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sMareepPose140:
+ax_pose 28, 0x01ee, 0x80f5, 0x0c00
+ax_pose_terminator
+sMareepPose141:
+ax_pose 19, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose142:
+ax_pose 27, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose143:
+ax_pose 17, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose144:
+ax_pose 26, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose145:
+ax_pose 30, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose146:
+ax_pose 31, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose147:
+ax_pose 32, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose148:
+ax_pose 33, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose149:
+ax_pose 34, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose150:
+ax_pose 35, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose151:
+ax_pose 36, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose152:
+ax_pose 35, 0x01e9, 0x80f5, 0x0c00
+ax_pose_terminator
+sMareepPose153:
+ax_pose 34, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose154:
+ax_pose 33, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose155:
+ax_pose 0, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose156:
+ax_pose 1, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose157:
+ax_pose 2, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose158:
+ax_pose 3, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose159:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose160:
+ax_pose 5, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose161:
+ax_pose 6, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose162:
+ax_pose 7, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose163:
+ax_pose 8, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose164:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose165:
+ax_pose 10, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose166:
+ax_pose 11, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose167:
+ax_pose 12, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose168:
+ax_pose 13, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose169:
+ax_pose 14, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose170:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose171:
+ax_pose 10, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose172:
+ax_pose 11, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose173:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose174:
+ax_pose 7, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose175:
+ax_pose 8, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose176:
+ax_pose 3, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose177:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose178:
+ax_pose 5, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose179:
+ax_pose 16, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose180:
+ax_pose 18, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose181:
+ax_pose 20, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose182:
+ax_pose 22, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose183:
+ax_pose 24, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose184:
+ax_pose 22, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose185:
+ax_pose 20, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose186:
+ax_pose 18, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sMareepPose187:
+ax_pose 15, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose188:
+ax_pose 17, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose189:
+ax_pose 19, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose190:
+ax_pose 21, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose191:
+ax_pose 23, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose192:
+ax_pose 21, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose193:
+ax_pose 19, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose194:
+ax_pose 17, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose195:
+ax_pose 0, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose196:
+ax_pose 15, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose197:
+ax_pose 25, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose198:
+ax_pose 3, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose199:
+ax_pose 17, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose200:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose201:
+ax_pose 6, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose202:
+ax_pose 19, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose203:
+ax_pose 27, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose204:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose205:
+ax_pose 21, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose206:
+ax_pose 28, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose207:
+ax_pose 12, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose208:
+ax_pose 23, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose209:
+ax_pose 29, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose210:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose211:
+ax_pose 21, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sMareepPose212:
+ax_pose 28, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose213:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose214:
+ax_pose 19, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose215:
+ax_pose 27, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose216:
+ax_pose 3, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose217:
+ax_pose 17, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose218:
+ax_pose 26, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose219:
+ax_pose 25, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sMareepPose220:
+ax_pose 26, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose221:
+ax_pose 27, 0x01ef, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose222:
+ax_pose 28, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose223:
+ax_pose 29, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose224:
+ax_pose 28, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose225:
+ax_pose 27, 0x01ef, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose226:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose227:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose228:
+ax_pose 27, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose229:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose230:
+ax_pose 28, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose231:
+ax_pose 27, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose232:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose233:
+ax_pose 29, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose234:
+ax_pose 28, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose235:
+ax_pose 27, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose236:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose237:
+ax_pose 28, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose238:
+ax_pose 29, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose239:
+ax_pose 28, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose240:
+ax_pose 27, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose241:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose242:
+ax_pose 27, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose243:
+ax_pose 28, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose244:
+ax_pose 29, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose245:
+ax_pose 28, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose246:
+ax_pose 27, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose247:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose248:
+ax_pose 26, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose249:
+ax_pose 27, 0x01ee, 0x80ef, 0x0c00
+ax_pose_terminator
+sMareepPose250:
+ax_pose 28, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose251:
+ax_pose 29, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sMareepPose252:
+ax_pose 28, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose253:
+ax_pose 27, 0x01ee, 0x90f1, 0x0c00
+ax_pose_terminator
+sMareepPose254:
+ax_pose 26, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sMareepPose255:
+ax_pose 0, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose256:
+ax_pose 3, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sMareepPose257:
+ax_pose 6, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose258:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sMareepPose259:
+ax_pose 12, 0x01ee, 0x80f0, 0x0c00
+ax_pose_terminator
+sMareepPose260:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sMareepPose261:
+ax_pose 6, 0x01ee, 0x90f0, 0x0c00
+ax_pose_terminator
+sMareepPose262:
+ax_pose 3, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sMareepAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMareepAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 17, 18, 17,
+ax_anim 2, 1, 31, 19, 16, 19, 16,
+ax_anim 2, 0, 31, 18, 17, 18, 17,
+ax_anim 2, 0, 31, 19, 16, 19, 16,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sMareepAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 6, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 9, 0, 9, 0,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 1, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 0, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMareepAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 36, 5, -6, 5, -6,
+ax_anim 1, 0, 36, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 18, -21, 18, -21,
+ax_anim 2, 1, 39, 19, -20, 19, -20,
+ax_anim 2, 0, 39, 18, -21, 18, -21,
+ax_anim 2, 0, 39, 19, -20, 19, -20,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sMareepAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 0, -4, 0, -4,
+ax_anim 1, 0, 40, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 1, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 0, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sMareepAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 44, -5, -6, -5, -6,
+ax_anim 1, 0, 44, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -18, -21, -18, -21,
+ax_anim 2, 1, 47, -19, -20, -19, -20,
+ax_anim 2, 0, 47, -18, -21, -18, -21,
+ax_anim 2, 0, 47, -19, -20, -19, -20,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sMareepAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, -4, 0, -4, 0,
+ax_anim 1, 0, 48, -9, 0, -9, 0,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 1, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sMareepAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, -4, 4, -4, 4,
+ax_anim 1, 0, 52, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 17, -18, 17,
+ax_anim 2, 1, 55, -19, 16, -19, 16,
+ax_anim 2, 0, 55, -18, 17, -18, 17,
+ax_anim 2, 0, 55, -19, 16, -19, 16,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMareepAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 6, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 0, 4, 0, 4,
+ax_anim 1, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 1, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sMareepAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 6, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 4, 4, 4, 4,
+ax_anim 1, 0, 60, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 1, 63, 19, 16, 19, 16,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 19, 16, 19, 16,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sMareepAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 6, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 4, 0, 4, 0,
+ax_anim 1, 0, 64, 9, 0, 9, 0,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 1, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 0, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sMareepAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 6, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 68, 5, -6, 5, -6,
+ax_anim 1, 0, 68, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 18, -21, 18, -21,
+ax_anim 2, 1, 71, 19, -20, 19, -20,
+ax_anim 2, 0, 71, 18, -21, 18, -21,
+ax_anim 2, 0, 71, 19, -20, 19, -20,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sMareepAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 6, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 72, 0, -4, 0, -4,
+ax_anim 1, 0, 72, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -19, 0, -19,
+ax_anim 2, 1, 75, 1, -19, 1, -19,
+ax_anim 2, 0, 75, 0, -19, 0, -19,
+ax_anim 2, 0, 75, 1, -19, 1, -19,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sMareepAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 6, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 76, -5, -6, -5, -6,
+ax_anim 1, 0, 76, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -18, -21, -18, -21,
+ax_anim 2, 1, 79, -19, -20, -19, -20,
+ax_anim 2, 0, 79, -18, -21, -18, -21,
+ax_anim 2, 0, 79, -19, -20, -19, -20,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sMareepAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 6, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 80, -4, 0, -4, 0,
+ax_anim 1, 0, 80, -9, 0, -9, 0,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 1, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 0, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sMareepAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 6, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 84, -4, 4, -4, 4,
+ax_anim 1, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 1, 87, -19, 16, -19, 16,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -19, 16, -19, 16,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMareepAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim 6, 2, 91, 0, -4, 0, -4,
+ax_anim 1, 0, 92, 0, -1, 0, -1,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 1, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 92, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 1, 3, 1, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sMareepAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 93, -3, -3, -3, -3,
+ax_anim 6, 2, 96, -4, -4, -4, -4,
+ax_anim 1, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 3, 3, 3, 3,
+ax_anim 2, 1, 97, 4, 2, 4, 2,
+ax_anim 2, 0, 97, 3, 3, 3, 3,
+ax_anim 2, 0, 97, 4, 2, 4, 2,
+ax_anim 2, 0, 97, 3, 3, 3, 3,
+ax_anim 2, 0, 97, 4, 2, 4, 2,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim_terminator
+sMareepAnims_4_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 6, 2, 101, -4, 0, -4, 0,
+ax_anim 1, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 1, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 102, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 3, 1, 3, 1,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim_terminator
+sMareepAnims_4_4:
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 6, 2, 106, -4, 4, -4, 4,
+ax_anim 1, 0, 107, -1, 1, -1, 1,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim 2, 1, 107, 4, -2, 4, -2,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 4, -2, 4, -2,
+ax_anim 2, 0, 107, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim_terminator
+sMareepAnims_4_5:
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 6, 2, 111, 0, 3, 0, 4,
+ax_anim 1, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 1, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 1, -3, 1, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sMareepAnims_4_6:
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 6, 2, 116, 4, 4, 4, 4,
+ax_anim 1, 0, 117, 1, 1, 1, 1,
+ax_anim 2, 0, 117, -3, -3, -3, -3,
+ax_anim 2, 1, 117, -4, -2, -4, -2,
+ax_anim 2, 0, 117, -3, -3, -3, -3,
+ax_anim 2, 0, 117, -4, -2, -4, -2,
+ax_anim 2, 0, 117, -3, -3, -3, -3,
+ax_anim 2, 0, 117, -4, -2, -4, -2,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim_terminator
+sMareepAnims_4_7:
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 6, 2, 121, 4, 0, 4, 0,
+ax_anim 1, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 1, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim_terminator
+sMareepAnims_4_8:
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 6, 2, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 1, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMareepAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, -1, 0, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 1, 0, 1,
+ax_anim 2, 0, 129, 1, 1, 1, 1,
+ax_anim 2, 0, 129, 0, 1, 0, 1,
+ax_anim 2, 0, 129, 1, 1, 1, 1,
+ax_anim 2, 0, 129, 0, 1, 0, 1,
+ax_anim 2, 0, 129, 1, 1, 1, 1,
+ax_anim_terminator
+sMareepAnims_5_2:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 130, -1, -1, -1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim_terminator
+sMareepAnims_5_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 132, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim_terminator
+sMareepAnims_5_4:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 134, -1, 1, -1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim_terminator
+sMareepAnims_5_5:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 136, 0, 1, 0, 1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, -1, 0, -1,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 0, 137, 0, -1, 0, -1,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim 2, 0, 137, 0, -1, 0, -1,
+ax_anim 2, 0, 137, 0, -1, 0, -1,
+ax_anim_terminator
+sMareepAnims_5_6:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 1, 1, 1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, -2, 0, -2, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, -2, 0, -2, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, -2, 0, -2, 0,
+ax_anim_terminator
+sMareepAnims_5_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim_terminator
+sMareepAnims_5_8:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 143, -1, 1, -1, 1,
+ax_anim 2, 0, 143, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -1, 1, -1, 1,
+ax_anim 2, 0, 143, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -1, 1, -1, 1,
+ax_anim 2, 0, 143, -2, 0, -2, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sMareepAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sMareepAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sMareepAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sMareepAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sMareepAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sMareepAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sMareepAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMareepAnims_8_1:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 3, 0, 155, 0, -4, 0, 0,
+ax_anim 3, 0, 154, 0, -4, 0, 0,
+ax_anim 3, 0, 156, 0, -4, 0, 0,
+ax_anim 4, 0, 156, 0, -3, 0, 0,
+ax_anim_terminator
+sMareepAnims_8_2:
+ax_anim 30, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 3, 0, 158, 0, -4, 0, 0,
+ax_anim 3, 0, 157, 0, -4, 0, 0,
+ax_anim 3, 0, 159, 0, -4, 0, 0,
+ax_anim 4, 0, 159, 0, -3, 0, 0,
+ax_anim_terminator
+sMareepAnims_8_3:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 3, 0, 161, 0, -4, 0, 0,
+ax_anim 3, 0, 160, 0, -4, 0, 0,
+ax_anim 3, 0, 162, 0, -4, 0, 0,
+ax_anim 4, 0, 162, 0, -3, 0, 0,
+ax_anim_terminator
+sMareepAnims_8_4:
+ax_anim 30, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim 3, 0, 164, 0, -4, 0, 0,
+ax_anim 3, 0, 163, 0, -4, 0, 0,
+ax_anim 3, 0, 165, 0, -4, 0, 0,
+ax_anim 4, 0, 165, 0, -3, 0, 0,
+ax_anim_terminator
+sMareepAnims_8_5:
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 3, 0, 167, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -4, 0, 0,
+ax_anim 3, 0, 168, 0, -4, 0, 0,
+ax_anim 4, 0, 168, 0, -3, 0, 0,
+ax_anim_terminator
+sMareepAnims_8_6:
+ax_anim 30, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -3, 0, 0,
+ax_anim 3, 0, 170, 0, -4, 0, 0,
+ax_anim 3, 0, 169, 0, -4, 0, 0,
+ax_anim 3, 0, 171, 0, -4, 0, 0,
+ax_anim 4, 0, 171, 0, -3, 0, 0,
+ax_anim_terminator
+sMareepAnims_8_7:
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -3, 0, 0,
+ax_anim 3, 0, 173, 0, -4, 0, 0,
+ax_anim 3, 0, 172, 0, -4, 0, 0,
+ax_anim 3, 0, 174, 0, -4, 0, 0,
+ax_anim 4, 0, 174, 0, -3, 0, 0,
+ax_anim_terminator
+sMareepAnims_8_8:
+ax_anim 30, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 3, 0, 176, 0, -4, 0, 0,
+ax_anim 3, 0, 175, 0, -4, 0, 0,
+ax_anim 3, 0, 177, 0, -4, 0, 0,
+ax_anim 4, 0, 177, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 10, 7, 10, 7,
+ax_anim 2, 0, 181, 8, 16, 8, 16,
+ax_anim 3, 0, 182, 0, 19, 0, 19,
+ax_anim 2, 3, 183, -8, 16, -8, 16,
+ax_anim 2, 0, 184, -10, 7, -10, 7,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 9, 1, 9, 1,
+ax_anim 2, 0, 179, 17, 5, 17, 5,
+ax_anim 2, 0, 180, 23, 12, 23, 12,
+ax_anim 3, 0, 181, 21, 19, 21, 19,
+ax_anim 2, 3, 182, 14, 20, 14, 20,
+ax_anim 2, 0, 183, 3, 14, 3, 14,
+ax_anim 1, 0, 184, -2, 5, -2, 5,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 16, -5, 16, -5,
+ax_anim 3, 0, 180, 21, 0, 21, 0,
+ax_anim 2, 3, 181, 19, 6, 19, 6,
+ax_anim 2, 0, 182, 12, 9, 12, 9,
+ax_anim 1, 0, 183, 4, 6, 4, 6,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -4, -9, -4, -9,
+ax_anim 2, 0, 185, 2, -17, 2, -17,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 22, -21, 22, -21,
+ax_anim 2, 3, 180, 25, -12, 25, -12,
+ax_anim 2, 0, 181, 20, -2, 20, -2,
+ax_anim 1, 0, 182, 10, 3, 10, 3,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -10, -5, -10, -5,
+ax_anim 2, 0, 184, -15, -13, -15, -13,
+ax_anim 2, 0, 185, -10, -19, -10, -19,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 10, -19, 10, -19,
+ax_anim 2, 0, 180, 15, -13, 15, -13,
+ax_anim 1, 0, 181, 10, -5, 10, -5,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 4, -9, 4, -9,
+ax_anim 2, 0, 179, -2, -17, -2, -17,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -22, -21, -22, -21,
+ax_anim 2, 3, 184, -25, -12, -25, -12,
+ax_anim 2, 0, 183, -20, -2, -20, -2,
+ax_anim 1, 0, 182, -10, 3, -10, 3,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -16, -5, -16, -5,
+ax_anim 3, 0, 184, -21, 0, -21, 0,
+ax_anim 2, 3, 183, -19, 6, -19, 6,
+ax_anim 2, 0, 182, -12, 9, -12, 9,
+ax_anim 1, 0, 181, -4, 6, -4, 6,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -9, 1, -9, 1,
+ax_anim 2, 0, 185, -17, 5, -17, 5,
+ax_anim 2, 0, 184, -23, 12, -23, 12,
+ax_anim 3, 0, 183, -21, 19, -21, 19,
+ax_anim 2, 3, 182, -14, 20, -14, 20,
+ax_anim 2, 0, 181, -3, 14, -3, 14,
+ax_anim 1, 0, 180, 2, 5, 2, 5,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -9, 0, 0,
+ax_anim 2, 0, 195, 0, -15, 0, 0,
+ax_anim 3, 0, 195, 0, -19, 0, 0,
+ax_anim 4, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -9, 0, 0,
+ax_anim 2, 0, 198, 0, -15, 0, 0,
+ax_anim 3, 0, 198, 0, -19, 0, 0,
+ax_anim 4, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -9, 0, 0,
+ax_anim 2, 0, 201, 0, -15, 0, 0,
+ax_anim 3, 0, 201, 0, -19, 0, 0,
+ax_anim 4, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -24, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -9, 0, 0,
+ax_anim 2, 0, 204, 0, -15, 0, 0,
+ax_anim 3, 0, 204, 0, -19, 0, 0,
+ax_anim 4, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -9, 0, 0,
+ax_anim 2, 0, 207, 0, -15, 0, 0,
+ax_anim 3, 0, 207, 0, -19, 0, 0,
+ax_anim 4, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -19, 0, 0,
+ax_anim 2, 0, 208, 0, -15, 0, 0,
+ax_anim 1, 0, 208, 0, -9, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -9, 0, 0,
+ax_anim 2, 0, 210, 0, -15, 0, 0,
+ax_anim 3, 0, 210, 0, -19, 0, 0,
+ax_anim 4, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -9, 0, 0,
+ax_anim 2, 0, 213, 0, -15, 0, 0,
+ax_anim 3, 0, 213, 0, -19, 0, 0,
+ax_anim 4, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -24, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -17, 0, 0,
+ax_anim 1, 0, 214, 0, -11, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -9, 0, 0,
+ax_anim 2, 0, 216, 0, -15, 0, 0,
+ax_anim 3, 0, 216, 0, -19, 0, 0,
+ax_anim 4, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMareepAnims_13_1:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_13_2:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_13_3:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_13_4:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_13_5:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_13_6:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_13_7:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepAnims_13_8:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMareepGfx1:
+.incbin "baserom.gba", 0xCC2454, 0x200
+sMareepSprites1:
+ax_sprite sMareepGfx1, 0x200
+ax_sprite_terminator
+sMareepGfx2:
+.incbin "baserom.gba", 0xCC2664, 0x200
+sMareepSprites2:
+ax_sprite sMareepGfx2, 0x200
+ax_sprite_terminator
+sMareepGfx3:
+.incbin "baserom.gba", 0xCC2874, 0x200
+sMareepSprites3:
+ax_sprite sMareepGfx3, 0x200
+ax_sprite_terminator
+sMareepGfx4:
+.incbin "baserom.gba", 0xCC2A84, 0x200
+sMareepSprites4:
+ax_sprite sMareepGfx4, 0x200
+ax_sprite_terminator
+sMareepGfx5:
+.incbin "baserom.gba", 0xCC2C94, 0x200
+sMareepSprites5:
+ax_sprite sMareepGfx5, 0x200
+ax_sprite_terminator
+sMareepGfx6:
+.incbin "baserom.gba", 0xCC2EA4, 0x200
+sMareepSprites6:
+ax_sprite sMareepGfx6, 0x200
+ax_sprite_terminator
+sMareepGfx7:
+.incbin "baserom.gba", 0xCC30B4, 0x200
+sMareepSprites7:
+ax_sprite sMareepGfx7, 0x200
+ax_sprite_terminator
+sMareepGfx8:
+.incbin "baserom.gba", 0xCC32C4, 0x200
+sMareepSprites8:
+ax_sprite sMareepGfx8, 0x200
+ax_sprite_terminator
+sMareepGfx9:
+.incbin "baserom.gba", 0xCC34D4, 0x200
+sMareepSprites9:
+ax_sprite sMareepGfx9, 0x200
+ax_sprite_terminator
+sMareepGfx10:
+.incbin "baserom.gba", 0xCC36E4, 0x200
+sMareepSprites10:
+ax_sprite sMareepGfx10, 0x200
+ax_sprite_terminator
+sMareepGfx11:
+.incbin "baserom.gba", 0xCC38F4, 0x200
+sMareepSprites11:
+ax_sprite sMareepGfx11, 0x200
+ax_sprite_terminator
+sMareepGfx12:
+.incbin "baserom.gba", 0xCC3B04, 0x200
+sMareepSprites12:
+ax_sprite sMareepGfx12, 0x200
+ax_sprite_terminator
+sMareepGfx13:
+.incbin "baserom.gba", 0xCC3D14, 0x200
+sMareepSprites13:
+ax_sprite sMareepGfx13, 0x200
+ax_sprite_terminator
+sMareepGfx14:
+.incbin "baserom.gba", 0xCC3F24, 0x200
+sMareepSprites14:
+ax_sprite sMareepGfx14, 0x200
+ax_sprite_terminator
+sMareepGfx15:
+.incbin "baserom.gba", 0xCC4134, 0x200
+sMareepSprites15:
+ax_sprite sMareepGfx15, 0x200
+ax_sprite_terminator
+sMareepGfx16:
+.incbin "baserom.gba", 0xCC4344, 0x60
+sMareepGfx16_1:
+.incbin "baserom.gba", 0xCC43A4, 0x60
+sMareepGfx16_2:
+.incbin "baserom.gba", 0xCC4404, 0x60
+sMareepSprites16:
+ax_sprite sMareepGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx17:
+.incbin "baserom.gba", 0xCC449C, 0x20
+sMareepGfx17_1:
+.incbin "baserom.gba", 0xCC44BC, 0x60
+sMareepGfx17_2:
+.incbin "baserom.gba", 0xCC451C, 0x60
+sMareepGfx17_3:
+.incbin "baserom.gba", 0xCC457C, 0x60
+sMareepSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMareepGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMareepGfx18:
+.incbin "baserom.gba", 0xCC462C, 0x60
+sMareepGfx18_1:
+.incbin "baserom.gba", 0xCC468C, 0x60
+sMareepGfx18_2:
+.incbin "baserom.gba", 0xCC46EC, 0x40
+sMareepSprites18:
+ax_sprite sMareepGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMareepGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx19:
+.incbin "baserom.gba", 0xCC4764, 0x40
+sMareepGfx19_1:
+.incbin "baserom.gba", 0xCC47A4, 0x60
+sMareepGfx19_2:
+.incbin "baserom.gba", 0xCC4804, 0x60
+sMareepGfx19_3:
+.incbin "baserom.gba", 0xCC4864, 0x20
+sMareepSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMareepGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMareepGfx20:
+.incbin "baserom.gba", 0xCC48D4, 0x100
+sMareepGfx20_1:
+.incbin "baserom.gba", 0xCC49D4, 0x40
+sMareepSprites20:
+ax_sprite sMareepGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx20_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx21:
+.incbin "baserom.gba", 0xCC4A3C, 0x100
+sMareepGfx21_1:
+.incbin "baserom.gba", 0xCC4B3C, 0x40
+sMareepSprites21:
+ax_sprite sMareepGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx21_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx22:
+.incbin "baserom.gba", 0xCC4BA4, 0x60
+sMareepGfx22_1:
+.incbin "baserom.gba", 0xCC4C04, 0x80
+sMareepGfx22_2:
+.incbin "baserom.gba", 0xCC4C84, 0x40
+sMareepSprites22:
+ax_sprite sMareepGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx22_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx22_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx23:
+.incbin "baserom.gba", 0xCC4CFC, 0x60
+sMareepGfx23_1:
+.incbin "baserom.gba", 0xCC4D5C, 0x60
+sMareepGfx23_2:
+.incbin "baserom.gba", 0xCC4DBC, 0x40
+sMareepSprites23:
+ax_sprite sMareepGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMareepGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx24:
+.incbin "baserom.gba", 0xCC4E34, 0x40
+sMareepGfx24_1:
+.incbin "baserom.gba", 0xCC4E74, 0x60
+sMareepGfx24_2:
+.incbin "baserom.gba", 0xCC4ED4, 0x60
+sMareepSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx25:
+.incbin "baserom.gba", 0xCC4F74, 0x40
+sMareepGfx25_1:
+.incbin "baserom.gba", 0xCC4FB4, 0x60
+sMareepGfx25_2:
+.incbin "baserom.gba", 0xCC5014, 0x60
+sMareepGfx25_3:
+.incbin "baserom.gba", 0xCC5074, 0x40
+sMareepSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMareepGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMareepGfx26:
+.incbin "baserom.gba", 0xCC5104, 0x20
+sMareepGfx26_1:
+.incbin "baserom.gba", 0xCC5124, 0x60
+sMareepGfx26_2:
+.incbin "baserom.gba", 0xCC5184, 0x60
+sMareepGfx26_3:
+.incbin "baserom.gba", 0xCC51E4, 0x60
+sMareepSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx26, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMareepGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMareepGfx27:
+.incbin "baserom.gba", 0xCC5294, 0x40
+sMareepGfx27_1:
+.incbin "baserom.gba", 0xCC52D4, 0x60
+sMareepGfx27_2:
+.incbin "baserom.gba", 0xCC5334, 0x60
+sMareepGfx27_3:
+.incbin "baserom.gba", 0xCC5394, 0x20
+sMareepSprites27:
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMareepGfx27_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMareepGfx28:
+.incbin "baserom.gba", 0xCC5404, 0x160
+sMareepSprites28:
+ax_sprite sMareepGfx28, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx29:
+.incbin "baserom.gba", 0xCC557C, 0x60
+sMareepGfx29_1:
+.incbin "baserom.gba", 0xCC55DC, 0x60
+sMareepGfx29_2:
+.incbin "baserom.gba", 0xCC563C, 0x60
+sMareepSprites29:
+ax_sprite sMareepGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx30:
+.incbin "baserom.gba", 0xCC56D4, 0x40
+sMareepGfx30_1:
+.incbin "baserom.gba", 0xCC5714, 0x60
+sMareepGfx30_2:
+.incbin "baserom.gba", 0xCC5774, 0x60
+sMareepSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMareepGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMareepGfx31:
+.incbin "baserom.gba", 0xCC5814, 0x200
+sMareepSprites31:
+ax_sprite sMareepGfx31, 0x200
+ax_sprite_terminator
+sMareepGfx32:
+.incbin "baserom.gba", 0xCC5A24, 0x200
+sMareepSprites32:
+ax_sprite sMareepGfx32, 0x200
+ax_sprite_terminator
+sMareepGfx33:
+.incbin "baserom.gba", 0xCC5C34, 0x200
+sMareepSprites33:
+ax_sprite sMareepGfx33, 0x200
+ax_sprite_terminator
+sMareepGfx34:
+.incbin "baserom.gba", 0xCC5E44, 0x200
+sMareepSprites34:
+ax_sprite sMareepGfx34, 0x200
+ax_sprite_terminator
+sMareepGfx35:
+.incbin "baserom.gba", 0xCC6054, 0x200
+sMareepSprites35:
+ax_sprite sMareepGfx35, 0x200
+ax_sprite_terminator
+sMareepGfx36:
+.incbin "baserom.gba", 0xCC6264, 0x200
+sMareepSprites36:
+ax_sprite sMareepGfx36, 0x200
+ax_sprite_terminator
+sMareepGfx37:
+.incbin "baserom.gba", 0xCC6474, 0x200
+sMareepSprites37:
+ax_sprite sMareepGfx37, 0x200
+ax_sprite_terminator
+sAxPosesMareep:
+.4byte sMareepPose1
+.4byte sMareepPose2
+.4byte sMareepPose3
+.4byte sMareepPose4
+.4byte sMareepPose5
+.4byte sMareepPose6
+.4byte sMareepPose7
+.4byte sMareepPose8
+.4byte sMareepPose9
+.4byte sMareepPose10
+.4byte sMareepPose11
+.4byte sMareepPose12
+.4byte sMareepPose13
+.4byte sMareepPose14
+.4byte sMareepPose15
+.4byte sMareepPose16
+.4byte sMareepPose17
+.4byte sMareepPose18
+.4byte sMareepPose19
+.4byte sMareepPose20
+.4byte sMareepPose21
+.4byte sMareepPose22
+.4byte sMareepPose23
+.4byte sMareepPose24
+.4byte sMareepPose25
+.4byte sMareepPose26
+.4byte sMareepPose27
+.4byte sMareepPose28
+.4byte sMareepPose29
+.4byte sMareepPose30
+.4byte sMareepPose31
+.4byte sMareepPose32
+.4byte sMareepPose33
+.4byte sMareepPose34
+.4byte sMareepPose35
+.4byte sMareepPose36
+.4byte sMareepPose37
+.4byte sMareepPose38
+.4byte sMareepPose39
+.4byte sMareepPose40
+.4byte sMareepPose41
+.4byte sMareepPose42
+.4byte sMareepPose43
+.4byte sMareepPose44
+.4byte sMareepPose45
+.4byte sMareepPose46
+.4byte sMareepPose47
+.4byte sMareepPose48
+.4byte sMareepPose49
+.4byte sMareepPose50
+.4byte sMareepPose51
+.4byte sMareepPose52
+.4byte sMareepPose53
+.4byte sMareepPose54
+.4byte sMareepPose55
+.4byte sMareepPose56
+.4byte sMareepPose57
+.4byte sMareepPose58
+.4byte sMareepPose59
+.4byte sMareepPose60
+.4byte sMareepPose61
+.4byte sMareepPose62
+.4byte sMareepPose63
+.4byte sMareepPose64
+.4byte sMareepPose65
+.4byte sMareepPose66
+.4byte sMareepPose67
+.4byte sMareepPose68
+.4byte sMareepPose69
+.4byte sMareepPose70
+.4byte sMareepPose71
+.4byte sMareepPose72
+.4byte sMareepPose73
+.4byte sMareepPose74
+.4byte sMareepPose75
+.4byte sMareepPose76
+.4byte sMareepPose77
+.4byte sMareepPose78
+.4byte sMareepPose79
+.4byte sMareepPose80
+.4byte sMareepPose81
+.4byte sMareepPose82
+.4byte sMareepPose83
+.4byte sMareepPose84
+.4byte sMareepPose85
+.4byte sMareepPose86
+.4byte sMareepPose87
+.4byte sMareepPose88
+.4byte sMareepPose89
+.4byte sMareepPose90
+.4byte sMareepPose91
+.4byte sMareepPose92
+.4byte sMareepPose93
+.4byte sMareepPose94
+.4byte sMareepPose95
+.4byte sMareepPose96
+.4byte sMareepPose97
+.4byte sMareepPose98
+.4byte sMareepPose99
+.4byte sMareepPose100
+.4byte sMareepPose101
+.4byte sMareepPose102
+.4byte sMareepPose103
+.4byte sMareepPose104
+.4byte sMareepPose105
+.4byte sMareepPose106
+.4byte sMareepPose107
+.4byte sMareepPose108
+.4byte sMareepPose109
+.4byte sMareepPose110
+.4byte sMareepPose111
+.4byte sMareepPose112
+.4byte sMareepPose113
+.4byte sMareepPose114
+.4byte sMareepPose115
+.4byte sMareepPose116
+.4byte sMareepPose117
+.4byte sMareepPose118
+.4byte sMareepPose119
+.4byte sMareepPose120
+.4byte sMareepPose121
+.4byte sMareepPose122
+.4byte sMareepPose123
+.4byte sMareepPose124
+.4byte sMareepPose125
+.4byte sMareepPose126
+.4byte sMareepPose127
+.4byte sMareepPose128
+.4byte sMareepPose129
+.4byte sMareepPose130
+.4byte sMareepPose131
+.4byte sMareepPose132
+.4byte sMareepPose133
+.4byte sMareepPose134
+.4byte sMareepPose135
+.4byte sMareepPose136
+.4byte sMareepPose137
+.4byte sMareepPose138
+.4byte sMareepPose139
+.4byte sMareepPose140
+.4byte sMareepPose141
+.4byte sMareepPose142
+.4byte sMareepPose143
+.4byte sMareepPose144
+.4byte sMareepPose145
+.4byte sMareepPose146
+.4byte sMareepPose147
+.4byte sMareepPose148
+.4byte sMareepPose149
+.4byte sMareepPose150
+.4byte sMareepPose151
+.4byte sMareepPose152
+.4byte sMareepPose153
+.4byte sMareepPose154
+.4byte sMareepPose155
+.4byte sMareepPose156
+.4byte sMareepPose157
+.4byte sMareepPose158
+.4byte sMareepPose159
+.4byte sMareepPose160
+.4byte sMareepPose161
+.4byte sMareepPose162
+.4byte sMareepPose163
+.4byte sMareepPose164
+.4byte sMareepPose165
+.4byte sMareepPose166
+.4byte sMareepPose167
+.4byte sMareepPose168
+.4byte sMareepPose169
+.4byte sMareepPose170
+.4byte sMareepPose171
+.4byte sMareepPose172
+.4byte sMareepPose173
+.4byte sMareepPose174
+.4byte sMareepPose175
+.4byte sMareepPose176
+.4byte sMareepPose177
+.4byte sMareepPose178
+.4byte sMareepPose179
+.4byte sMareepPose180
+.4byte sMareepPose181
+.4byte sMareepPose182
+.4byte sMareepPose183
+.4byte sMareepPose184
+.4byte sMareepPose185
+.4byte sMareepPose186
+.4byte sMareepPose187
+.4byte sMareepPose188
+.4byte sMareepPose189
+.4byte sMareepPose190
+.4byte sMareepPose191
+.4byte sMareepPose192
+.4byte sMareepPose193
+.4byte sMareepPose194
+.4byte sMareepPose195
+.4byte sMareepPose196
+.4byte sMareepPose197
+.4byte sMareepPose198
+.4byte sMareepPose199
+.4byte sMareepPose200
+.4byte sMareepPose201
+.4byte sMareepPose202
+.4byte sMareepPose203
+.4byte sMareepPose204
+.4byte sMareepPose205
+.4byte sMareepPose206
+.4byte sMareepPose207
+.4byte sMareepPose208
+.4byte sMareepPose209
+.4byte sMareepPose210
+.4byte sMareepPose211
+.4byte sMareepPose212
+.4byte sMareepPose213
+.4byte sMareepPose214
+.4byte sMareepPose215
+.4byte sMareepPose216
+.4byte sMareepPose217
+.4byte sMareepPose218
+.4byte sMareepPose219
+.4byte sMareepPose220
+.4byte sMareepPose221
+.4byte sMareepPose222
+.4byte sMareepPose223
+.4byte sMareepPose224
+.4byte sMareepPose225
+.4byte sMareepPose226
+.4byte sMareepPose227
+.4byte sMareepPose228
+.4byte sMareepPose229
+.4byte sMareepPose230
+.4byte sMareepPose231
+.4byte sMareepPose232
+.4byte sMareepPose233
+.4byte sMareepPose234
+.4byte sMareepPose235
+.4byte sMareepPose236
+.4byte sMareepPose237
+.4byte sMareepPose238
+.4byte sMareepPose239
+.4byte sMareepPose240
+.4byte sMareepPose241
+.4byte sMareepPose242
+.4byte sMareepPose243
+.4byte sMareepPose244
+.4byte sMareepPose245
+.4byte sMareepPose246
+.4byte sMareepPose247
+.4byte sMareepPose248
+.4byte sMareepPose249
+.4byte sMareepPose250
+.4byte sMareepPose251
+.4byte sMareepPose252
+.4byte sMareepPose253
+.4byte sMareepPose254
+.4byte sMareepPose255
+.4byte sMareepPose256
+.4byte sMareepPose257
+.4byte sMareepPose258
+.4byte sMareepPose259
+.4byte sMareepPose260
+.4byte sMareepPose261
+.4byte sMareepPose262
+sAxPositionsMareep:
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -2,    1, 	  -5,    1, 	   3,    3, 	   0,   -6
+.2byte    0,    1, 	  -5,    3, 	   3,    1, 	  -1,   -6
+.2byte    7,   -1, 	   6,    0, 	   0,    2, 	  -2,   -7
+.2byte    8,    0, 	   3,    0, 	   2,    4, 	  -1,   -7
+.2byte    7,    1, 	   8,    2, 	  -1,    2, 	  -1,   -7
+.2byte   10,   -3, 	   4,   -2, 	   3,    0, 	  -1,   -7
+.2byte   10,   -2, 	   1,   -2, 	   5,    0, 	  -2,   -7
+.2byte    9,   -2, 	   6,    0, 	   1,    0, 	  -2,   -7
+.2byte    5,   -9, 	  -2,   -5, 	   4,   -3, 	  -3,   -7
+.2byte    4,   -8, 	  -3,   -3, 	   6,   -4, 	  -2,   -6
+.2byte    6,   -8, 	   1,   -5, 	   3,   -1, 	  -2,   -7
+.2byte   -1,  -14, 	   3,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte    0,  -13, 	   3,   -4, 	  -3,   -6, 	  -1,   -7
+.2byte   -2,  -13, 	   1,   -6, 	  -5,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	   1,   -5, 	  -5,   -3, 	   2,   -7
+.2byte   -5,   -8, 	   2,   -3, 	  -7,   -4, 	   1,   -6
+.2byte   -7,   -8, 	  -2,   -5, 	  -4,   -1, 	   1,   -7
+.2byte  -11,   -3, 	  -5,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -11,   -2, 	  -2,   -2, 	  -6,    0, 	   1,   -7
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    0, 	   1,   -7
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   1,   -7
+.2byte   -9,    0, 	  -4,    0, 	  -3,    4, 	   0,   -7
+.2byte   -8,    1, 	  -9,    2, 	   0,    2, 	   0,   -7
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,   -7, 	  -4,   -3, 	   2,   -3, 	  -1,  -12
+.2byte    0,    1, 	  -5,    3, 	   3,    1, 	  -1,   -6
+.2byte   -1,    2, 	  -5,    3, 	   3,    3, 	  -1,   -6
+.2byte    7,   -1, 	   6,    0, 	   0,    2, 	  -2,   -7
+.2byte    7,   -5, 	   6,   -4, 	   0,   -2, 	  -2,   -9
+.2byte    7,    1, 	   8,    2, 	  -1,    2, 	  -1,   -7
+.2byte   10,    0, 	   7,    2, 	   1,    4, 	   0,   -6
+.2byte   10,   -3, 	   4,   -2, 	   3,    0, 	  -1,   -7
+.2byte    9,   -8, 	   3,   -5, 	   3,   -3, 	  -2,   -9
+.2byte    9,   -2, 	   6,    0, 	   1,    0, 	  -2,   -7
+.2byte   15,   -5, 	   6,   -2, 	   5,    0, 	   0,   -8
+.2byte    5,   -9, 	  -2,   -5, 	   4,   -3, 	  -3,   -7
+.2byte    4,  -11, 	  -2,   -7, 	   4,   -5, 	  -3,   -7
+.2byte    6,   -8, 	   1,   -5, 	   3,   -1, 	  -2,   -7
+.2byte    9,  -16, 	   1,   -6, 	   6,   -4, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -2,  -13, 	   1,   -6, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,  -21, 	   3,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte   -6,   -9, 	   1,   -5, 	  -5,   -3, 	   2,   -7
+.2byte   -5,  -11, 	   1,   -7, 	  -5,   -5, 	   2,   -7
+.2byte   -7,   -8, 	  -2,   -5, 	  -4,   -1, 	   1,   -7
+.2byte  -10,  -16, 	  -2,   -6, 	  -7,   -4, 	   0,   -8
+.2byte  -11,   -3, 	  -5,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -10,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -9
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    0, 	   1,   -7
+.2byte  -16,   -5, 	  -7,   -2, 	  -6,    0, 	  -1,   -8
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   1,   -7
+.2byte   -9,   -5, 	  -8,   -4, 	  -2,   -2, 	   0,   -9
+.2byte   -8,    1, 	  -9,    2, 	   0,    2, 	   0,   -7
+.2byte  -11,    0, 	  -8,    2, 	  -2,    4, 	  -1,   -6
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,   -7, 	  -4,   -3, 	   2,   -3, 	  -1,  -12
+.2byte    0,    1, 	  -5,    3, 	   3,    1, 	  -1,   -6
+.2byte   -1,    2, 	  -5,    3, 	   3,    3, 	  -1,   -6
+.2byte    7,   -1, 	   6,    0, 	   0,    2, 	  -2,   -7
+.2byte    7,   -5, 	   6,   -4, 	   0,   -2, 	  -2,   -9
+.2byte    7,    1, 	   8,    2, 	  -1,    2, 	  -1,   -7
+.2byte   10,    0, 	   7,    2, 	   1,    4, 	   0,   -6
+.2byte   10,   -3, 	   4,   -2, 	   3,    0, 	  -1,   -7
+.2byte    9,   -8, 	   3,   -5, 	   3,   -3, 	  -2,   -9
+.2byte    9,   -2, 	   6,    0, 	   1,    0, 	  -2,   -7
+.2byte   15,   -5, 	   6,   -2, 	   5,    0, 	   0,   -8
+.2byte    5,   -9, 	  -2,   -5, 	   4,   -3, 	  -3,   -7
+.2byte    4,  -11, 	  -2,   -7, 	   4,   -5, 	  -3,   -7
+.2byte    6,   -8, 	   1,   -5, 	   3,   -1, 	  -2,   -7
+.2byte    9,  -16, 	   1,   -6, 	   6,   -4, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -2,  -13, 	   1,   -6, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,  -21, 	   3,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte   -6,   -9, 	   1,   -5, 	  -5,   -3, 	   2,   -7
+.2byte   -5,  -11, 	   1,   -7, 	  -5,   -5, 	   2,   -7
+.2byte   -7,   -8, 	  -2,   -5, 	  -4,   -1, 	   1,   -7
+.2byte  -10,  -16, 	  -2,   -6, 	  -7,   -4, 	   0,   -8
+.2byte  -11,   -3, 	  -5,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -10,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -9
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    0, 	   1,   -7
+.2byte  -16,   -5, 	  -7,   -2, 	  -6,    0, 	  -1,   -8
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   1,   -7
+.2byte   -9,   -5, 	  -8,   -4, 	  -2,   -2, 	   0,   -9
+.2byte   -8,    1, 	  -9,    2, 	   0,    2, 	   0,   -7
+.2byte  -11,    0, 	  -8,    2, 	  -2,    4, 	  -1,   -6
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -2,    1, 	  -5,    1, 	   3,    3, 	   0,   -6
+.2byte    0,    1, 	  -5,    3, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,   -2, 	   2,   -2, 	  -1,  -11
+.2byte   -1,    2, 	  -5,    3, 	   3,    3, 	  -1,   -6
+.2byte    7,   -1, 	   6,    0, 	   0,    2, 	  -2,   -7
+.2byte    8,    0, 	   3,    0, 	   2,    4, 	  -1,   -7
+.2byte    7,    1, 	   8,    2, 	  -1,    2, 	  -1,   -7
+.2byte    6,   -6, 	   5,   -5, 	  -1,   -3, 	  -3,  -10
+.2byte   10,    0, 	   7,    2, 	   1,    4, 	   0,   -6
+.2byte   10,   -3, 	   4,   -2, 	   3,    0, 	  -1,   -7
+.2byte   10,   -2, 	   1,   -2, 	   5,    0, 	  -2,   -7
+.2byte    9,   -2, 	   6,    0, 	   1,    0, 	  -2,   -7
+.2byte    7,   -8, 	   1,   -5, 	   1,   -3, 	  -4,   -9
+.2byte   15,   -5, 	   6,   -2, 	   5,    0, 	   0,   -8
+.2byte    5,   -9, 	  -2,   -5, 	   4,   -3, 	  -3,   -7
+.2byte    4,   -8, 	  -3,   -3, 	   6,   -4, 	  -2,   -6
+.2byte    6,   -8, 	   1,   -5, 	   3,   -1, 	  -2,   -7
+.2byte    3,  -12, 	  -3,   -8, 	   3,   -6, 	  -4,   -8
+.2byte    9,  -16, 	   1,   -6, 	   6,   -4, 	  -1,   -8
+.2byte   -1,  -14, 	   3,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte    0,  -13, 	   3,   -4, 	  -3,   -6, 	  -1,   -7
+.2byte   -2,  -13, 	   1,   -6, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,  -15, 	   3,   -8, 	  -5,   -8, 	  -1,   -9
+.2byte   -1,  -21, 	   3,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte   -6,   -9, 	   1,   -5, 	  -5,   -3, 	   2,   -7
+.2byte   -5,   -8, 	   2,   -3, 	  -7,   -4, 	   1,   -6
+.2byte   -7,   -8, 	  -2,   -5, 	  -4,   -1, 	   1,   -7
+.2byte   -4,  -12, 	   2,   -8, 	  -4,   -6, 	   3,   -8
+.2byte  -10,  -16, 	  -2,   -6, 	  -7,   -4, 	   0,   -8
+.2byte  -11,   -3, 	  -5,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -11,   -2, 	  -2,   -2, 	  -6,    0, 	   1,   -7
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    0, 	   1,   -7
+.2byte   -8,   -8, 	  -2,   -5, 	  -2,   -3, 	   3,   -9
+.2byte  -16,   -5, 	  -7,   -2, 	  -6,    0, 	  -1,   -8
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   1,   -7
+.2byte   -9,    0, 	  -4,    0, 	  -3,    4, 	   0,   -7
+.2byte   -8,    1, 	  -9,    2, 	   0,    2, 	   0,   -7
+.2byte   -7,   -6, 	  -6,   -5, 	   0,   -3, 	   2,  -10
+.2byte  -11,    0, 	  -8,    2, 	  -2,    4, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,   -2, 	   2,   -2, 	  -1,  -11
+.2byte   -1,    2, 	  -5,    1, 	   3,    1, 	  -1,   -8
+.2byte    6,   -6, 	   5,   -5, 	  -1,   -3, 	  -3,  -10
+.2byte    5,    1, 	   4,    0, 	   0,    2, 	  -2,   -8
+.2byte    7,   -8, 	   1,   -5, 	   1,   -3, 	  -4,   -9
+.2byte    8,   -1, 	   4,   -3, 	   3,    0, 	  -4,   -8
+.2byte    3,  -12, 	  -3,   -8, 	   3,   -6, 	  -4,   -8
+.2byte    7,   -7, 	  -1,   -5, 	   4,   -3, 	  -3,   -6
+.2byte   -1,  -15, 	   3,   -8, 	  -5,   -8, 	  -1,   -9
+.2byte   -1,  -10, 	   3,   -4, 	  -5,   -4, 	  -1,   -7
+.2byte   -4,  -12, 	   2,   -8, 	  -4,   -6, 	   3,   -8
+.2byte   -8,   -7, 	   0,   -5, 	  -5,   -3, 	   2,   -6
+.2byte   -8,   -8, 	  -2,   -5, 	  -2,   -3, 	   3,   -9
+.2byte   -9,   -1, 	  -5,   -3, 	  -4,    0, 	   3,   -8
+.2byte   -7,   -6, 	  -6,   -5, 	   0,   -3, 	   2,  -10
+.2byte   -6,    1, 	  -5,    0, 	  -1,    2, 	   1,   -8
+.2byte   -1,    2, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,    3, 	  -5,    1, 	   2,    1, 	  -1,   -5
+.2byte    0,    1, 	  -8,    0, 	   8,    0, 	   0,   -5
+.2byte    9,    2, 	   9,    0, 	  -1,    2, 	   0,   -5
+.2byte   12,    0, 	   8,   -3, 	   6,    2, 	   0,   -3
+.2byte    6,   -5, 	   0,   -8, 	  10,   -3, 	   0,   -4
+.2byte    0,  -10, 	   7,   -5, 	  -7,   -5, 	   0,   -5
+.2byte   -6,   -5, 	   0,   -8, 	 -10,   -3, 	   0,   -4
+.2byte  -12,    0, 	  -8,   -3, 	  -6,    2, 	   0,   -3
+.2byte   -9,    2, 	  -9,    0, 	   1,    2, 	   0,   -5
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -2,    1, 	  -5,    1, 	   3,    3, 	   0,   -6
+.2byte    0,    1, 	  -5,    3, 	   3,    1, 	  -1,   -6
+.2byte    7,   -1, 	   6,    0, 	   0,    2, 	  -2,   -7
+.2byte    8,    0, 	   3,    0, 	   2,    4, 	  -1,   -7
+.2byte    7,    1, 	   8,    2, 	  -1,    2, 	  -1,   -7
+.2byte   10,   -3, 	   4,   -2, 	   3,    0, 	  -1,   -7
+.2byte   10,   -2, 	   1,   -2, 	   5,    0, 	  -2,   -7
+.2byte    9,   -2, 	   6,    0, 	   1,    0, 	  -2,   -7
+.2byte    5,   -9, 	  -2,   -5, 	   4,   -3, 	  -3,   -7
+.2byte    4,   -8, 	  -3,   -3, 	   6,   -4, 	  -2,   -6
+.2byte    6,   -8, 	   1,   -5, 	   3,   -1, 	  -2,   -7
+.2byte   -1,  -14, 	   3,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte    0,  -13, 	   3,   -4, 	  -3,   -6, 	  -1,   -7
+.2byte   -2,  -13, 	   1,   -6, 	  -5,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	   1,   -5, 	  -5,   -3, 	   2,   -7
+.2byte   -5,   -8, 	   2,   -3, 	  -7,   -4, 	   1,   -6
+.2byte   -7,   -8, 	  -2,   -5, 	  -4,   -1, 	   1,   -7
+.2byte  -11,   -3, 	  -5,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -11,   -2, 	  -2,   -2, 	  -6,    0, 	   1,   -7
+.2byte  -10,   -2, 	  -7,    0, 	  -2,    0, 	   1,   -7
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   1,   -7
+.2byte   -9,    0, 	  -4,    0, 	  -3,    4, 	   0,   -7
+.2byte   -8,    1, 	  -9,    2, 	   0,    2, 	   0,   -7
+.2byte   -1,    1, 	  -5,    2, 	   3,    2, 	  -1,   -7
+.2byte  -11,   -1, 	  -8,    1, 	  -2,    3, 	  -1,   -7
+.2byte  -16,   -5, 	  -7,   -2, 	  -6,    0, 	  -1,   -8
+.2byte  -10,  -16, 	  -2,   -6, 	  -7,   -4, 	   0,   -8
+.2byte   -1,  -20, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte    9,  -16, 	   1,   -6, 	   6,   -4, 	  -1,   -8
+.2byte   15,   -5, 	   6,   -2, 	   5,    0, 	   0,   -8
+.2byte   10,   -1, 	   7,    1, 	   1,    3, 	   0,   -7
+.2byte   -1,   -6, 	  -4,   -2, 	   2,   -2, 	  -1,  -11
+.2byte    7,   -6, 	   6,   -5, 	   0,   -3, 	  -2,  -10
+.2byte    9,   -8, 	   3,   -5, 	   3,   -3, 	  -2,   -9
+.2byte    4,  -12, 	  -2,   -8, 	   4,   -6, 	  -3,   -8
+.2byte   -1,  -15, 	   3,   -8, 	  -5,   -8, 	  -1,   -9
+.2byte   -5,  -12, 	   1,   -8, 	  -5,   -6, 	   2,   -8
+.2byte  -10,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -9
+.2byte   -8,   -6, 	  -7,   -5, 	  -1,   -3, 	   1,  -10
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -2, 	   2,   -2, 	  -1,  -11
+.2byte   -1,    4, 	  -5,    3, 	   3,    3, 	  -1,   -6
+.2byte    7,   -1, 	   6,    0, 	   0,    2, 	  -2,   -7
+.2byte    7,   -6, 	   6,   -5, 	   0,   -3, 	  -2,  -10
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte   10,   -3, 	   4,   -2, 	   3,    0, 	  -1,   -7
+.2byte    9,   -8, 	   3,   -5, 	   3,   -3, 	  -2,   -9
+.2byte   10,   -1, 	   6,   -3, 	   5,    0, 	  -2,   -8
+.2byte    5,   -9, 	  -2,   -5, 	   4,   -3, 	  -3,   -7
+.2byte    4,  -12, 	  -2,   -8, 	   4,   -6, 	  -3,   -8
+.2byte    8,   -7, 	   0,   -5, 	   5,   -3, 	  -2,   -6
+.2byte   -1,  -14, 	   3,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte   -1,  -15, 	   3,   -8, 	  -5,   -8, 	  -1,   -9
+.2byte   -1,  -14, 	   3,   -8, 	  -5,   -8, 	  -1,  -11
+.2byte   -6,   -9, 	   1,   -5, 	  -5,   -3, 	   2,   -7
+.2byte   -4,  -12, 	   2,   -8, 	  -4,   -6, 	   3,   -8
+.2byte   -9,   -7, 	  -1,   -5, 	  -6,   -3, 	   1,   -6
+.2byte  -11,   -3, 	  -5,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -10,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -9
+.2byte  -11,   -1, 	  -7,   -3, 	  -6,    0, 	   1,   -8
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   1,   -7
+.2byte   -7,   -6, 	  -6,   -5, 	   0,   -3, 	   2,  -10
+.2byte   -7,    3, 	  -6,    2, 	  -2,    4, 	   0,   -6
+.2byte   -1,    4, 	  -5,    3, 	   3,    3, 	  -1,   -6
+.2byte   -7,    3, 	  -6,    2, 	  -2,    4, 	   0,   -6
+.2byte  -11,    0, 	  -7,   -2, 	  -6,    1, 	   1,   -7
+.2byte   -9,   -7, 	  -1,   -5, 	  -6,   -3, 	   1,   -6
+.2byte   -1,  -10, 	   3,   -4, 	  -5,   -4, 	  -1,   -7
+.2byte    8,   -7, 	   0,   -5, 	   5,   -3, 	  -2,   -6
+.2byte   10,    0, 	   6,   -2, 	   5,    1, 	  -2,   -7
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte   10,   -1, 	   6,   -3, 	   5,    0, 	  -2,   -8
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte    8,   -7, 	   0,   -5, 	   5,   -3, 	  -2,   -6
+.2byte   10,   -1, 	   6,   -3, 	   5,    0, 	  -2,   -8
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte   -1,  -14, 	   3,   -8, 	  -5,   -8, 	  -1,  -11
+.2byte    8,   -7, 	   0,   -5, 	   5,   -3, 	  -2,   -6
+.2byte   10,   -1, 	   6,   -3, 	   5,    0, 	  -2,   -8
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte   -9,   -7, 	  -1,   -5, 	  -6,   -3, 	   1,   -6
+.2byte   -1,  -14, 	   3,   -8, 	  -5,   -8, 	  -1,  -11
+.2byte    8,   -7, 	   0,   -5, 	   5,   -3, 	  -2,   -6
+.2byte   10,   -1, 	   6,   -3, 	   5,    0, 	  -2,   -8
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte  -11,   -1, 	  -7,   -3, 	  -6,    0, 	   1,   -8
+.2byte   -9,   -7, 	  -1,   -5, 	  -6,   -3, 	   1,   -6
+.2byte   -1,  -14, 	   3,   -8, 	  -5,   -8, 	  -1,  -11
+.2byte    8,   -7, 	   0,   -5, 	   5,   -3, 	  -2,   -6
+.2byte   10,   -1, 	   6,   -3, 	   5,    0, 	  -2,   -8
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte   -7,    3, 	  -6,    2, 	  -2,    4, 	   0,   -6
+.2byte  -11,   -1, 	  -7,   -3, 	  -6,    0, 	   1,   -8
+.2byte   -9,   -7, 	  -1,   -5, 	  -6,   -3, 	   1,   -6
+.2byte   -1,  -14, 	   3,   -8, 	  -5,   -8, 	  -1,  -11
+.2byte    8,   -7, 	   0,   -5, 	   5,   -3, 	  -2,   -6
+.2byte   10,   -1, 	   6,   -3, 	   5,    0, 	  -2,   -8
+.2byte    6,    3, 	   5,    2, 	   1,    4, 	  -1,   -6
+.2byte   -1,    0, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   1,   -7
+.2byte  -11,   -3, 	  -5,   -2, 	  -4,    0, 	   0,   -7
+.2byte   -6,   -9, 	   1,   -5, 	  -5,   -3, 	   2,   -7
+.2byte   -1,  -14, 	   3,   -6, 	  -5,   -6, 	  -1,   -9
+.2byte    5,   -9, 	  -2,   -5, 	   4,   -3, 	  -3,   -7
+.2byte   10,   -3, 	   4,   -2, 	   3,    0, 	  -1,   -7
+.2byte    7,   -1, 	   6,    0, 	   0,    2, 	  -2,   -7
+sMareepAnimTable1:
+.4byte sMareepAnims_1_1
+.4byte sMareepAnims_1_2
+.4byte sMareepAnims_1_3
+.4byte sMareepAnims_1_4
+.4byte sMareepAnims_1_5
+.4byte sMareepAnims_1_6
+.4byte sMareepAnims_1_7
+.4byte sMareepAnims_1_8
+sMareepAnimTable2:
+.4byte sMareepAnims_2_1
+.4byte sMareepAnims_2_2
+.4byte sMareepAnims_2_3
+.4byte sMareepAnims_2_4
+.4byte sMareepAnims_2_5
+.4byte sMareepAnims_2_6
+.4byte sMareepAnims_2_7
+.4byte sMareepAnims_2_8
+sMareepAnimTable3:
+.4byte sMareepAnims_3_1
+.4byte sMareepAnims_3_2
+.4byte sMareepAnims_3_3
+.4byte sMareepAnims_3_4
+.4byte sMareepAnims_3_5
+.4byte sMareepAnims_3_6
+.4byte sMareepAnims_3_7
+.4byte sMareepAnims_3_8
+sMareepAnimTable4:
+.4byte sMareepAnims_4_1
+.4byte sMareepAnims_4_2
+.4byte sMareepAnims_4_3
+.4byte sMareepAnims_4_4
+.4byte sMareepAnims_4_5
+.4byte sMareepAnims_4_6
+.4byte sMareepAnims_4_7
+.4byte sMareepAnims_4_8
+sMareepAnimTable5:
+.4byte sMareepAnims_5_1
+.4byte sMareepAnims_5_2
+.4byte sMareepAnims_5_3
+.4byte sMareepAnims_5_4
+.4byte sMareepAnims_5_5
+.4byte sMareepAnims_5_6
+.4byte sMareepAnims_5_7
+.4byte sMareepAnims_5_8
+sMareepAnimTable6:
+.4byte sMareepAnims_6_1
+.4byte sMareepAnims_6_1
+.4byte sMareepAnims_6_1
+.4byte sMareepAnims_6_1
+.4byte sMareepAnims_6_1
+.4byte sMareepAnims_6_1
+.4byte sMareepAnims_6_1
+.4byte sMareepAnims_6_1
+sMareepAnimTable7:
+.4byte sMareepAnims_7_1
+.4byte sMareepAnims_7_2
+.4byte sMareepAnims_7_3
+.4byte sMareepAnims_7_4
+.4byte sMareepAnims_7_5
+.4byte sMareepAnims_7_6
+.4byte sMareepAnims_7_7
+.4byte sMareepAnims_7_8
+sMareepAnimTable8:
+.4byte sMareepAnims_8_1
+.4byte sMareepAnims_8_2
+.4byte sMareepAnims_8_3
+.4byte sMareepAnims_8_4
+.4byte sMareepAnims_8_5
+.4byte sMareepAnims_8_6
+.4byte sMareepAnims_8_7
+.4byte sMareepAnims_8_8
+sMareepAnimTable9:
+.4byte sMareepAnims_9_1
+.4byte sMareepAnims_9_2
+.4byte sMareepAnims_9_3
+.4byte sMareepAnims_9_4
+.4byte sMareepAnims_9_5
+.4byte sMareepAnims_9_6
+.4byte sMareepAnims_9_7
+.4byte sMareepAnims_9_8
+sMareepAnimTable10:
+.4byte sMareepAnims_10_1
+.4byte sMareepAnims_10_2
+.4byte sMareepAnims_10_3
+.4byte sMareepAnims_10_4
+.4byte sMareepAnims_10_5
+.4byte sMareepAnims_10_6
+.4byte sMareepAnims_10_7
+.4byte sMareepAnims_10_8
+sMareepAnimTable11:
+.4byte sMareepAnims_11_1
+.4byte sMareepAnims_11_2
+.4byte sMareepAnims_11_3
+.4byte sMareepAnims_11_4
+.4byte sMareepAnims_11_5
+.4byte sMareepAnims_11_6
+.4byte sMareepAnims_11_7
+.4byte sMareepAnims_11_8
+sMareepAnimTable12:
+.4byte sMareepAnims_12_1
+.4byte sMareepAnims_12_2
+.4byte sMareepAnims_12_3
+.4byte sMareepAnims_12_4
+.4byte sMareepAnims_12_5
+.4byte sMareepAnims_12_6
+.4byte sMareepAnims_12_7
+.4byte sMareepAnims_12_8
+sMareepAnimTable13:
+.4byte sMareepAnims_13_1
+.4byte sMareepAnims_13_2
+.4byte sMareepAnims_13_3
+.4byte sMareepAnims_13_4
+.4byte sMareepAnims_13_5
+.4byte sMareepAnims_13_6
+.4byte sMareepAnims_13_7
+.4byte sMareepAnims_13_8
+sAxAnimationsMareep:
+.4byte sMareepAnimTable1
+.4byte sMareepAnimTable2
+.4byte sMareepAnimTable3
+.4byte sMareepAnimTable4
+.4byte sMareepAnimTable5
+.4byte sMareepAnimTable6
+.4byte sMareepAnimTable7
+.4byte sMareepAnimTable8
+.4byte sMareepAnimTable9
+.4byte sMareepAnimTable10
+.4byte sMareepAnimTable11
+.4byte sMareepAnimTable12
+.4byte sMareepAnimTable13
+sAxSpritesMareep:
+.4byte sMareepSprites1
+.4byte sMareepSprites2
+.4byte sMareepSprites3
+.4byte sMareepSprites4
+.4byte sMareepSprites5
+.4byte sMareepSprites6
+.4byte sMareepSprites7
+.4byte sMareepSprites8
+.4byte sMareepSprites9
+.4byte sMareepSprites10
+.4byte sMareepSprites11
+.4byte sMareepSprites12
+.4byte sMareepSprites13
+.4byte sMareepSprites14
+.4byte sMareepSprites15
+.4byte sMareepSprites16
+.4byte sMareepSprites17
+.4byte sMareepSprites18
+.4byte sMareepSprites19
+.4byte sMareepSprites20
+.4byte sMareepSprites21
+.4byte sMareepSprites22
+.4byte sMareepSprites23
+.4byte sMareepSprites24
+.4byte sMareepSprites25
+.4byte sMareepSprites26
+.4byte sMareepSprites27
+.4byte sMareepSprites28
+.4byte sMareepSprites29
+.4byte sMareepSprites30
+.4byte sMareepSprites31
+.4byte sMareepSprites32
+.4byte sMareepSprites33
+.4byte sMareepSprites34
+.4byte sMareepSprites35
+.4byte sMareepSprites36
+.4byte sMareepSprites37
+sAxMainMareep:
+ax_main sAxPosesMareep, sAxAnimationsMareep, 13, sAxSpritesMareep, sAxPositionsMareep

--- a/data/ax/marill.inc
+++ b/data/ax/marill.inc
@@ -1,0 +1,2625 @@
+.global gAxMarill
+gAxMarill:
+ax_siro sAxMainMarill
+sMarillPose1:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose2:
+ax_pose 1, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose3:
+ax_pose 2, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose4:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose5:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose6:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose7:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose8:
+ax_pose 7, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose9:
+ax_pose 8, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose10:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose11:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose12:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose13:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose14:
+ax_pose 13, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose15:
+ax_pose 14, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose16:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose17:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose18:
+ax_pose 11, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose19:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose20:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose21:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose22:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose23:
+ax_pose 4, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose24:
+ax_pose 5, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose25:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose26:
+ax_pose 1, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose27:
+ax_pose 2, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose28:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose29:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose30:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose31:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose32:
+ax_pose 16, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose33:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose34:
+ax_pose 7, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose35:
+ax_pose 8, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose36:
+ax_pose 17, 0x81e3, 0x90f9, 0x5c00
+ax_pose_terminator
+sMarillPose37:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose38:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose39:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose40:
+ax_pose 18, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose41:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose42:
+ax_pose 13, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose43:
+ax_pose 14, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose44:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose45:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose46:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose47:
+ax_pose 11, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose48:
+ax_pose 18, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose49:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose50:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose51:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose52:
+ax_pose 17, 0x81e3, 0x80f7, 0x5c00
+ax_pose_terminator
+sMarillPose53:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose54:
+ax_pose 4, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose55:
+ax_pose 5, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose56:
+ax_pose 16, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose57:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose58:
+ax_pose 1, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose59:
+ax_pose 2, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose60:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose61:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose62:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose63:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose64:
+ax_pose 16, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose65:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose66:
+ax_pose 7, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose67:
+ax_pose 8, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose68:
+ax_pose 17, 0x81e3, 0x90f9, 0x5c00
+ax_pose_terminator
+sMarillPose69:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose70:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose71:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose72:
+ax_pose 18, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose73:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose74:
+ax_pose 13, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose75:
+ax_pose 14, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose76:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose77:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose78:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose79:
+ax_pose 11, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose80:
+ax_pose 18, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose81:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose82:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose83:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose84:
+ax_pose 17, 0x81e3, 0x80f7, 0x5c00
+ax_pose_terminator
+sMarillPose85:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose86:
+ax_pose 4, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose87:
+ax_pose 5, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose88:
+ax_pose 16, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose89:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose90:
+ax_pose 20, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose91:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose92:
+ax_pose 21, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose93:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose94:
+ax_pose 22, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose95:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose96:
+ax_pose 23, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sMarillPose97:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose98:
+ax_pose 24, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose99:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose100:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarillPose101:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose102:
+ax_pose 22, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose103:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose104:
+ax_pose 21, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose105:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose106:
+ax_pose 1, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose107:
+ax_pose 2, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose108:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose109:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose110:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose111:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose112:
+ax_pose 16, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose113:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose114:
+ax_pose 7, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose115:
+ax_pose 8, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose116:
+ax_pose 17, 0x81e3, 0x90f9, 0x5c00
+ax_pose_terminator
+sMarillPose117:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose118:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose119:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose120:
+ax_pose 18, 0x01e4, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose121:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose122:
+ax_pose 13, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose123:
+ax_pose 14, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose124:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose125:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose126:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose127:
+ax_pose 11, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose128:
+ax_pose 18, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose129:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose130:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose131:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose132:
+ax_pose 17, 0x81e3, 0x80f7, 0x5c00
+ax_pose_terminator
+sMarillPose133:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose134:
+ax_pose 4, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose135:
+ax_pose 5, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose136:
+ax_pose 16, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose137:
+ax_pose 25, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarillPose138:
+ax_pose 26, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarillPose139:
+ax_pose 27, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sMarillPose140:
+ax_pose 28, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose141:
+ax_pose 29, 0x01e4, 0x90e8, 0x5c00
+ax_pose_terminator
+sMarillPose142:
+ax_pose 30, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sMarillPose143:
+ax_pose 31, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarillPose144:
+ax_pose 30, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarillPose145:
+ax_pose 29, 0x01e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sMarillPose146:
+ax_pose 28, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose147:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose148:
+ax_pose 1, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose149:
+ax_pose 2, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose150:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose151:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose152:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose153:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose154:
+ax_pose 7, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose155:
+ax_pose 8, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose156:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose157:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose158:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose159:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose160:
+ax_pose 13, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose161:
+ax_pose 14, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose162:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose163:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose164:
+ax_pose 11, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose165:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose166:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose167:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose168:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose169:
+ax_pose 4, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose170:
+ax_pose 5, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose171:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose172:
+ax_pose 16, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose173:
+ax_pose 17, 0x81e3, 0x80f9, 0x5c00
+ax_pose_terminator
+sMarillPose174:
+ax_pose 18, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose175:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose176:
+ax_pose 18, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose177:
+ax_pose 17, 0x81e3, 0x90f8, 0x5c00
+ax_pose_terminator
+sMarillPose178:
+ax_pose 16, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose179:
+ax_pose 20, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose180:
+ax_pose 21, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sMarillPose181:
+ax_pose 22, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sMarillPose182:
+ax_pose 23, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose183:
+ax_pose 24, 0x01e9, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose184:
+ax_pose 23, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose185:
+ax_pose 22, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMarillPose186:
+ax_pose 21, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose187:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose188:
+ax_pose 20, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose189:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose190:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose191:
+ax_pose 21, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose192:
+ax_pose 16, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose193:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose194:
+ax_pose 22, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sMarillPose195:
+ax_pose 17, 0x81e3, 0x90f8, 0x5c00
+ax_pose_terminator
+sMarillPose196:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose197:
+ax_pose 23, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose198:
+ax_pose 18, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose199:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose200:
+ax_pose 24, 0x01e9, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose201:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose202:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose203:
+ax_pose 23, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose204:
+ax_pose 18, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose205:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose206:
+ax_pose 22, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMarillPose207:
+ax_pose 17, 0x81e3, 0x80f8, 0x5c00
+ax_pose_terminator
+sMarillPose208:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose209:
+ax_pose 21, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose210:
+ax_pose 16, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose211:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose212:
+ax_pose 16, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose213:
+ax_pose 17, 0x81e3, 0x80f8, 0x5c00
+ax_pose_terminator
+sMarillPose214:
+ax_pose 18, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose215:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose216:
+ax_pose 18, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose217:
+ax_pose 17, 0x81e3, 0x90f8, 0x5c00
+ax_pose_terminator
+sMarillPose218:
+ax_pose 16, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose219:
+ax_pose 0, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose220:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose221:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarillPose222:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose223:
+ax_pose 12, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sMarillPose224:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sMarillPose225:
+ax_pose 6, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarillPose226:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+.align 2
+sMarillAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 5, 0, 9,
+ax_anim 2, 0, 24, 0, 4, 0, 7,
+ax_anim_terminator
+sMarillAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 8, 2, 8, 8,
+ax_anim 2, 0, 28, 4, 2, 4, 4,
+ax_anim_terminator
+sMarillAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 8, -5, 8, 0,
+ax_anim 2, 0, 32, 4, -3, 6, 0,
+ax_anim_terminator
+sMarillAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -14, 11, -14,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 1, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 36, 8, -11, 8, -8,
+ax_anim 2, 0, 36, 4, -6, 4, -4,
+ax_anim_terminator
+sMarillAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -12, 0, -8,
+ax_anim 2, 0, 40, 0, -6, 0, -4,
+ax_anim_terminator
+sMarillAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -14, -11, -14,
+ax_anim 2, 0, 47, -19, -23, -19, -23,
+ax_anim 2, 1, 47, -20, -22, -20, -22,
+ax_anim 2, 0, 47, -19, -23, -19, -23,
+ax_anim 2, 0, 47, -20, -22, -20, -22,
+ax_anim 2, 0, 44, -8, -11, -8, -8,
+ax_anim 2, 0, 44, -4, -6, -4, -4,
+ax_anim_terminator
+sMarillAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -8, -5, -8, 0,
+ax_anim 2, 0, 48, -4, -3, -6, 0,
+ax_anim_terminator
+sMarillAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -12, 12, -12, 12,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 1, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 52, -8, 2, -8, 8,
+ax_anim 2, 0, 52, -4, 2, -4, 4,
+ax_anim_terminator
+.align 2
+sMarillAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 5, 0, 9,
+ax_anim 2, 0, 56, 0, 4, 0, 7,
+ax_anim_terminator
+sMarillAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 12, 12, 12, 12,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 1, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 60, 8, 2, 8, 8,
+ax_anim 2, 0, 60, 4, 2, 4, 4,
+ax_anim_terminator
+sMarillAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 1, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 0, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 8, -5, 8, 0,
+ax_anim 2, 0, 64, 4, -3, 6, 0,
+ax_anim_terminator
+sMarillAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 11, -14, 11, -14,
+ax_anim 2, 0, 71, 19, -23, 19, -23,
+ax_anim 2, 1, 71, 20, -22, 20, -22,
+ax_anim 2, 0, 71, 19, -23, 19, -23,
+ax_anim 2, 0, 71, 20, -22, 20, -22,
+ax_anim 2, 0, 68, 8, -11, 8, -8,
+ax_anim 2, 0, 68, 4, -6, 4, -4,
+ax_anim_terminator
+sMarillAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 1, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 72, 0, -12, 0, -8,
+ax_anim 2, 0, 72, 0, -6, 0, -4,
+ax_anim_terminator
+sMarillAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -11, -14, -11, -14,
+ax_anim 2, 0, 79, -19, -23, -19, -23,
+ax_anim 2, 1, 79, -20, -22, -20, -22,
+ax_anim 2, 0, 79, -19, -23, -19, -23,
+ax_anim 2, 0, 79, -20, -22, -20, -22,
+ax_anim 2, 0, 76, -8, -11, -8, -8,
+ax_anim 2, 0, 76, -4, -6, -4, -4,
+ax_anim_terminator
+sMarillAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 1, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 0, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -8, -5, -8, 0,
+ax_anim 2, 0, 80, -4, -3, -6, 0,
+ax_anim_terminator
+sMarillAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -12, 12, -12, 12,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 1, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 84, -8, 2, -8, 8,
+ax_anim 2, 0, 84, -4, 2, -4, 4,
+ax_anim_terminator
+.align 2
+sMarillAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 6, 2, 88, 0, -2, 0, -2,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 1, 89, 1, 2, 1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 1, 2, 1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 1, 2, 1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sMarillAnims_4_2:
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 6, 2, 90, -2, -2, -2, -2,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 1, 91, 3, 1, 3, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 3, 1, 3, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 3, 1, 3, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim_terminator
+sMarillAnims_4_3:
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 6, 2, 92, -2, 0, -2, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 1, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim_terminator
+sMarillAnims_4_4:
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 6, 2, 94, -2, 2, -2, 2,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 1, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim_terminator
+sMarillAnims_4_5:
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 6, 2, 96, 0, 2, 0, 2,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 1, 97, 1, -2, 1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, 1, -2, 1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, 1, -2, 1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim_terminator
+sMarillAnims_4_6:
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 6, 2, 98, 2, 2, 2, 2,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 1, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 98, -1, -1, -1, -1,
+ax_anim_terminator
+sMarillAnims_4_7:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 6, 2, 100, 2, 0, 2, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 1, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim_terminator
+sMarillAnims_4_8:
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 6, 2, 102, 2, -2, 2, -2,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 1, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMarillAnims_5_1:
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 3, 0, 105, 0, -4, 0, 0,
+ax_anim 3, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_5_2:
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 3, 0, 110, 0, -4, 0, 0,
+ax_anim 3, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_5_3:
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 3, 0, 113, 0, -4, 0, 0,
+ax_anim 3, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_5_4:
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 3, 0, 118, 0, -4, 0, 0,
+ax_anim 3, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_5_5:
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 3, 0, 121, 0, -4, 0, 0,
+ax_anim 3, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 1, 0, 123, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_5_6:
+ax_anim 1, 0, 126, 0, -2, 0, 0,
+ax_anim 2, 0, 126, 0, -3, 0, 0,
+ax_anim 3, 0, 126, 0, -4, 0, 0,
+ax_anim 3, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -3, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 1, -1, 1,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_5_7:
+ax_anim 1, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -3, 0, 0,
+ax_anim 3, 0, 129, 0, -4, 0, 0,
+ax_anim 3, 0, 128, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -3, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_5_8:
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -3, 0, 0,
+ax_anim 3, 0, 134, 0, -4, 0, 0,
+ax_anim 3, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -3, 0, 0,
+ax_anim 1, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sMarillAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sMarillAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sMarillAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sMarillAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sMarillAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sMarillAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sMarillAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMarillAnims_8_1:
+ax_anim 26, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_8_2:
+ax_anim 26, 0, 149, 0, 0, 0, 0,
+ax_anim 16, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_8_3:
+ax_anim 26, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_8_4:
+ax_anim 26, 0, 155, 0, 0, 0, 0,
+ax_anim 16, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_8_5:
+ax_anim 26, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_8_6:
+ax_anim 26, 0, 161, 0, 0, 0, 0,
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_8_7:
+ax_anim 26, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_8_8:
+ax_anim 26, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 4, 7, 4,
+ax_anim 2, 0, 172, 10, 10, 10, 10,
+ax_anim 2, 0, 173, 10, 18, 10, 18,
+ax_anim 3, 0, 174, 0, 22, 0, 22,
+ax_anim 2, 3, 175, -8, 18, -8, 18,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 1, 0, 177, -7, 4, -7, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 18, 4, 18, 4,
+ax_anim 2, 0, 172, 21, 13, 21, 13,
+ax_anim 3, 0, 173, 21, 21, 21, 21,
+ax_anim 2, 3, 174, 12, 22, 12, 22,
+ax_anim 2, 0, 175, 3, 16, 3, 16,
+ax_anim 1, 0, 176, 0, 8, 0, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -5, 17, -5,
+ax_anim 3, 0, 172, 22, 0, 22, 0,
+ax_anim 2, 3, 173, 20, 5, 20, 5,
+ax_anim 2, 0, 174, 12, 6, 12, 6,
+ax_anim 1, 0, 175, 4, 4, 4, 4,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 20, -22, 20, -22,
+ax_anim 2, 3, 172, 22, -15, 22, -15,
+ax_anim 2, 0, 173, 18, -5, 18, -5,
+ax_anim 1, 0, 174, 9, -1, 9, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -11, -10, -11, -10,
+ax_anim 2, 0, 177, -7, -19, -7, -19,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -19, 7, -19,
+ax_anim 2, 0, 172, 11, -10, 11, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -20, -22, -20, -22,
+ax_anim 2, 3, 176, -22, -15, -22, -15,
+ax_anim 2, 0, 175, -18, -5, -18, -5,
+ax_anim 1, 0, 174, -9, -1, -9, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -5, -17, -5,
+ax_anim 3, 0, 176, -22, 0, -22, 0,
+ax_anim 2, 3, 175, -20, 5, -20, 5,
+ax_anim 2, 0, 174, -12, 6, -12, 6,
+ax_anim 1, 0, 173, -4, 4, -4, 4,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -18, 4, -18, 4,
+ax_anim 2, 0, 176, -21, 13, -21, 13,
+ax_anim 3, 0, 175, -21, 21, -21, 21,
+ax_anim 2, 3, 174, -12, 22, -12, 22,
+ax_anim 2, 0, 173, -3, 16, -3, 16,
+ax_anim 1, 0, 172, 0, 8, 0, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -11, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -11, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarillAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMarillGfx1:
+.incbin "baserom.gba", 0xCE9D94, 0x200
+sMarillSprites1:
+ax_sprite sMarillGfx1, 0x200
+ax_sprite_terminator
+sMarillGfx2:
+.incbin "baserom.gba", 0xCE9FA4, 0x200
+sMarillSprites2:
+ax_sprite sMarillGfx2, 0x200
+ax_sprite_terminator
+sMarillGfx3:
+.incbin "baserom.gba", 0xCEA1B4, 0x200
+sMarillSprites3:
+ax_sprite sMarillGfx3, 0x200
+ax_sprite_terminator
+sMarillGfx4:
+.incbin "baserom.gba", 0xCEA3C4, 0x200
+sMarillSprites4:
+ax_sprite sMarillGfx4, 0x200
+ax_sprite_terminator
+sMarillGfx5:
+.incbin "baserom.gba", 0xCEA5D4, 0x200
+sMarillSprites5:
+ax_sprite sMarillGfx5, 0x200
+ax_sprite_terminator
+sMarillGfx6:
+.incbin "baserom.gba", 0xCEA7E4, 0x200
+sMarillSprites6:
+ax_sprite sMarillGfx6, 0x200
+ax_sprite_terminator
+sMarillGfx7:
+.incbin "baserom.gba", 0xCEA9F4, 0x200
+sMarillSprites7:
+ax_sprite sMarillGfx7, 0x200
+ax_sprite_terminator
+sMarillGfx8:
+.incbin "baserom.gba", 0xCEAC04, 0x200
+sMarillSprites8:
+ax_sprite sMarillGfx8, 0x200
+ax_sprite_terminator
+sMarillGfx9:
+.incbin "baserom.gba", 0xCEAE14, 0x200
+sMarillSprites9:
+ax_sprite sMarillGfx9, 0x200
+ax_sprite_terminator
+sMarillGfx10:
+.incbin "baserom.gba", 0xCEB024, 0x200
+sMarillSprites10:
+ax_sprite sMarillGfx10, 0x200
+ax_sprite_terminator
+sMarillGfx11:
+.incbin "baserom.gba", 0xCEB234, 0x200
+sMarillSprites11:
+ax_sprite sMarillGfx11, 0x200
+ax_sprite_terminator
+sMarillGfx12:
+.incbin "baserom.gba", 0xCEB444, 0x200
+sMarillSprites12:
+ax_sprite sMarillGfx12, 0x200
+ax_sprite_terminator
+sMarillGfx13:
+.incbin "baserom.gba", 0xCEB654, 0x200
+sMarillSprites13:
+ax_sprite sMarillGfx13, 0x200
+ax_sprite_terminator
+sMarillGfx14:
+.incbin "baserom.gba", 0xCEB864, 0x200
+sMarillSprites14:
+ax_sprite sMarillGfx14, 0x200
+ax_sprite_terminator
+sMarillGfx15:
+.incbin "baserom.gba", 0xCEBA74, 0x200
+sMarillSprites15:
+ax_sprite sMarillGfx15, 0x200
+ax_sprite_terminator
+sMarillGfx16:
+.incbin "baserom.gba", 0xCEBC84, 0x20
+sMarillGfx16_1:
+.incbin "baserom.gba", 0xCEBCA4, 0x20
+sMarillGfx16_2:
+.incbin "baserom.gba", 0xCEBCC4, 0x60
+sMarillGfx16_3:
+.incbin "baserom.gba", 0xCEBD24, 0x60
+sMarillSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx16, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMarillGfx16_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMarillGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarillGfx17:
+.incbin "baserom.gba", 0xCEBDD4, 0x40
+sMarillGfx17_1:
+.incbin "baserom.gba", 0xCEBE14, 0x60
+sMarillGfx17_2:
+.incbin "baserom.gba", 0xCEBE74, 0x60
+sMarillGfx17_3:
+.incbin "baserom.gba", 0xCEBED4, 0x60
+sMarillSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarillGfx18:
+.incbin "baserom.gba", 0xCEBF84, 0xE0
+sMarillSprites18:
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx18, 0xe0
+ax_sprite_terminator
+sMarillGfx19:
+.incbin "baserom.gba", 0xCEC07C, 0x20
+sMarillGfx19_1:
+.incbin "baserom.gba", 0xCEC09C, 0x60
+sMarillGfx19_2:
+.incbin "baserom.gba", 0xCEC0FC, 0x60
+sMarillGfx19_3:
+.incbin "baserom.gba", 0xCEC15C, 0x60
+sMarillSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMarillGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarillGfx20:
+.incbin "baserom.gba", 0xCEC20C, 0x20
+sMarillGfx20_1:
+.incbin "baserom.gba", 0xCEC22C, 0x60
+sMarillGfx20_2:
+.incbin "baserom.gba", 0xCEC28C, 0x60
+sMarillGfx20_3:
+.incbin "baserom.gba", 0xCEC2EC, 0x40
+sMarillSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMarillGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx20_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMarillGfx21:
+.incbin "baserom.gba", 0xCEC37C, 0x20
+sMarillGfx21_1:
+.incbin "baserom.gba", 0xCEC39C, 0x60
+sMarillGfx21_2:
+.incbin "baserom.gba", 0xCEC3FC, 0x60
+sMarillGfx21_3:
+.incbin "baserom.gba", 0xCEC45C, 0x60
+sMarillSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMarillGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarillGfx22:
+.incbin "baserom.gba", 0xCEC50C, 0xE0
+sMarillGfx22_1:
+.incbin "baserom.gba", 0xCEC5EC, 0x60
+sMarillSprites22:
+ax_sprite sMarillGfx22, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx22_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMarillGfx23:
+.incbin "baserom.gba", 0xCEC674, 0x140
+sMarillSprites23:
+ax_sprite sMarillGfx23, 0x140
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMarillGfx24:
+.incbin "baserom.gba", 0xCEC7CC, 0x40
+sMarillGfx24_1:
+.incbin "baserom.gba", 0xCEC80C, 0xE0
+sMarillSprites24:
+ax_sprite sMarillGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarillGfx24_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMarillGfx25:
+.incbin "baserom.gba", 0xCEC914, 0x60
+sMarillGfx25_1:
+.incbin "baserom.gba", 0xCEC974, 0x60
+sMarillGfx25_2:
+.incbin "baserom.gba", 0xCEC9D4, 0x60
+sMarillSprites25:
+ax_sprite sMarillGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarillGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMarillGfx26:
+.incbin "baserom.gba", 0xCECA6C, 0x200
+sMarillSprites26:
+ax_sprite sMarillGfx26, 0x200
+ax_sprite_terminator
+sMarillGfx27:
+.incbin "baserom.gba", 0xCECC7C, 0x200
+sMarillSprites27:
+ax_sprite sMarillGfx27, 0x200
+ax_sprite_terminator
+sMarillGfx28:
+.incbin "baserom.gba", 0xCECE8C, 0x200
+sMarillSprites28:
+ax_sprite sMarillGfx28, 0x200
+ax_sprite_terminator
+sMarillGfx29:
+.incbin "baserom.gba", 0xCED09C, 0x200
+sMarillSprites29:
+ax_sprite sMarillGfx29, 0x200
+ax_sprite_terminator
+sMarillGfx30:
+.incbin "baserom.gba", 0xCED2AC, 0x200
+sMarillSprites30:
+ax_sprite sMarillGfx30, 0x200
+ax_sprite_terminator
+sMarillGfx31:
+.incbin "baserom.gba", 0xCED4BC, 0x200
+sMarillSprites31:
+ax_sprite sMarillGfx31, 0x200
+ax_sprite_terminator
+sMarillGfx32:
+.incbin "baserom.gba", 0xCED6CC, 0x200
+sMarillSprites32:
+ax_sprite sMarillGfx32, 0x200
+ax_sprite_terminator
+sAxPosesMarill:
+.4byte sMarillPose1
+.4byte sMarillPose2
+.4byte sMarillPose3
+.4byte sMarillPose4
+.4byte sMarillPose5
+.4byte sMarillPose6
+.4byte sMarillPose7
+.4byte sMarillPose8
+.4byte sMarillPose9
+.4byte sMarillPose10
+.4byte sMarillPose11
+.4byte sMarillPose12
+.4byte sMarillPose13
+.4byte sMarillPose14
+.4byte sMarillPose15
+.4byte sMarillPose16
+.4byte sMarillPose17
+.4byte sMarillPose18
+.4byte sMarillPose19
+.4byte sMarillPose20
+.4byte sMarillPose21
+.4byte sMarillPose22
+.4byte sMarillPose23
+.4byte sMarillPose24
+.4byte sMarillPose25
+.4byte sMarillPose26
+.4byte sMarillPose27
+.4byte sMarillPose28
+.4byte sMarillPose29
+.4byte sMarillPose30
+.4byte sMarillPose31
+.4byte sMarillPose32
+.4byte sMarillPose33
+.4byte sMarillPose34
+.4byte sMarillPose35
+.4byte sMarillPose36
+.4byte sMarillPose37
+.4byte sMarillPose38
+.4byte sMarillPose39
+.4byte sMarillPose40
+.4byte sMarillPose41
+.4byte sMarillPose42
+.4byte sMarillPose43
+.4byte sMarillPose44
+.4byte sMarillPose45
+.4byte sMarillPose46
+.4byte sMarillPose47
+.4byte sMarillPose48
+.4byte sMarillPose49
+.4byte sMarillPose50
+.4byte sMarillPose51
+.4byte sMarillPose52
+.4byte sMarillPose53
+.4byte sMarillPose54
+.4byte sMarillPose55
+.4byte sMarillPose56
+.4byte sMarillPose57
+.4byte sMarillPose58
+.4byte sMarillPose59
+.4byte sMarillPose60
+.4byte sMarillPose61
+.4byte sMarillPose62
+.4byte sMarillPose63
+.4byte sMarillPose64
+.4byte sMarillPose65
+.4byte sMarillPose66
+.4byte sMarillPose67
+.4byte sMarillPose68
+.4byte sMarillPose69
+.4byte sMarillPose70
+.4byte sMarillPose71
+.4byte sMarillPose72
+.4byte sMarillPose73
+.4byte sMarillPose74
+.4byte sMarillPose75
+.4byte sMarillPose76
+.4byte sMarillPose77
+.4byte sMarillPose78
+.4byte sMarillPose79
+.4byte sMarillPose80
+.4byte sMarillPose81
+.4byte sMarillPose82
+.4byte sMarillPose83
+.4byte sMarillPose84
+.4byte sMarillPose85
+.4byte sMarillPose86
+.4byte sMarillPose87
+.4byte sMarillPose88
+.4byte sMarillPose89
+.4byte sMarillPose90
+.4byte sMarillPose91
+.4byte sMarillPose92
+.4byte sMarillPose93
+.4byte sMarillPose94
+.4byte sMarillPose95
+.4byte sMarillPose96
+.4byte sMarillPose97
+.4byte sMarillPose98
+.4byte sMarillPose99
+.4byte sMarillPose100
+.4byte sMarillPose101
+.4byte sMarillPose102
+.4byte sMarillPose103
+.4byte sMarillPose104
+.4byte sMarillPose105
+.4byte sMarillPose106
+.4byte sMarillPose107
+.4byte sMarillPose108
+.4byte sMarillPose109
+.4byte sMarillPose110
+.4byte sMarillPose111
+.4byte sMarillPose112
+.4byte sMarillPose113
+.4byte sMarillPose114
+.4byte sMarillPose115
+.4byte sMarillPose116
+.4byte sMarillPose117
+.4byte sMarillPose118
+.4byte sMarillPose119
+.4byte sMarillPose120
+.4byte sMarillPose121
+.4byte sMarillPose122
+.4byte sMarillPose123
+.4byte sMarillPose124
+.4byte sMarillPose125
+.4byte sMarillPose126
+.4byte sMarillPose127
+.4byte sMarillPose128
+.4byte sMarillPose129
+.4byte sMarillPose130
+.4byte sMarillPose131
+.4byte sMarillPose132
+.4byte sMarillPose133
+.4byte sMarillPose134
+.4byte sMarillPose135
+.4byte sMarillPose136
+.4byte sMarillPose137
+.4byte sMarillPose138
+.4byte sMarillPose139
+.4byte sMarillPose140
+.4byte sMarillPose141
+.4byte sMarillPose142
+.4byte sMarillPose143
+.4byte sMarillPose144
+.4byte sMarillPose145
+.4byte sMarillPose146
+.4byte sMarillPose147
+.4byte sMarillPose148
+.4byte sMarillPose149
+.4byte sMarillPose150
+.4byte sMarillPose151
+.4byte sMarillPose152
+.4byte sMarillPose153
+.4byte sMarillPose154
+.4byte sMarillPose155
+.4byte sMarillPose156
+.4byte sMarillPose157
+.4byte sMarillPose158
+.4byte sMarillPose159
+.4byte sMarillPose160
+.4byte sMarillPose161
+.4byte sMarillPose162
+.4byte sMarillPose163
+.4byte sMarillPose164
+.4byte sMarillPose165
+.4byte sMarillPose166
+.4byte sMarillPose167
+.4byte sMarillPose168
+.4byte sMarillPose169
+.4byte sMarillPose170
+.4byte sMarillPose171
+.4byte sMarillPose172
+.4byte sMarillPose173
+.4byte sMarillPose174
+.4byte sMarillPose175
+.4byte sMarillPose176
+.4byte sMarillPose177
+.4byte sMarillPose178
+.4byte sMarillPose179
+.4byte sMarillPose180
+.4byte sMarillPose181
+.4byte sMarillPose182
+.4byte sMarillPose183
+.4byte sMarillPose184
+.4byte sMarillPose185
+.4byte sMarillPose186
+.4byte sMarillPose187
+.4byte sMarillPose188
+.4byte sMarillPose189
+.4byte sMarillPose190
+.4byte sMarillPose191
+.4byte sMarillPose192
+.4byte sMarillPose193
+.4byte sMarillPose194
+.4byte sMarillPose195
+.4byte sMarillPose196
+.4byte sMarillPose197
+.4byte sMarillPose198
+.4byte sMarillPose199
+.4byte sMarillPose200
+.4byte sMarillPose201
+.4byte sMarillPose202
+.4byte sMarillPose203
+.4byte sMarillPose204
+.4byte sMarillPose205
+.4byte sMarillPose206
+.4byte sMarillPose207
+.4byte sMarillPose208
+.4byte sMarillPose209
+.4byte sMarillPose210
+.4byte sMarillPose211
+.4byte sMarillPose212
+.4byte sMarillPose213
+.4byte sMarillPose214
+.4byte sMarillPose215
+.4byte sMarillPose216
+.4byte sMarillPose217
+.4byte sMarillPose218
+.4byte sMarillPose219
+.4byte sMarillPose220
+.4byte sMarillPose221
+.4byte sMarillPose222
+.4byte sMarillPose223
+.4byte sMarillPose224
+.4byte sMarillPose225
+.4byte sMarillPose226
+sAxPositionsMarill:
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte    0,   -5, 	  -7,   -4, 	   7,   -6, 	  -1,   -5
+.2byte    0,   -5, 	  -8,   -6, 	   6,   -4, 	  -1,   -5
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    2,   -6, 	   6,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    2,   -6, 	   6,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    5,   -6, 	  -1,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    5,   -6, 	   3,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -6, 	  -4,   -7, 	   3,   -3, 	  -1,   -6
+.2byte    1,   -7, 	  -6,   -8, 	   6,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,   -6, 	   7,   -7, 	  -8,   -4, 	   0,   -5
+.2byte    0,   -6, 	   7,   -4, 	  -8,   -7, 	   0,   -5
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -6, 	   3,   -7, 	  -4,   -3, 	   0,   -6
+.2byte   -2,   -7, 	   5,   -8, 	  -7,   -4, 	   0,   -6
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -6, 	   0,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -6,   -6, 	  -4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -3,   -6, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -7,   -8, 	   2,   -3, 	  -1,   -6
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte    0,   -5, 	  -7,   -4, 	   7,   -6, 	  -1,   -5
+.2byte    0,   -5, 	  -8,   -6, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -4, 	  -1,   -6
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    2,   -6, 	   6,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    2,   -6, 	   6,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    4,   -3, 	   8,   -6, 	  -3,   -4, 	   1,   -6
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    5,   -6, 	  -1,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    5,   -6, 	   3,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    6,   -4, 	   3,   -9, 	   2,   -5, 	   2,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -6, 	  -4,   -7, 	   3,   -3, 	  -1,   -6
+.2byte    1,   -7, 	  -6,   -8, 	   6,   -4, 	  -1,   -6
+.2byte    2,   -8, 	  -3,  -12, 	   6,   -6, 	   0,   -8
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,   -6, 	   7,   -7, 	  -8,   -4, 	   0,   -5
+.2byte    0,   -6, 	   7,   -4, 	  -8,   -7, 	   0,   -5
+.2byte    0,   -6, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -6, 	   3,   -7, 	  -4,   -3, 	   0,   -6
+.2byte   -2,   -7, 	   5,   -8, 	  -7,   -4, 	   0,   -6
+.2byte   -3,   -8, 	   2,  -12, 	  -7,   -6, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -6, 	   0,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -6,   -6, 	  -4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -7,   -4, 	  -4,   -9, 	  -3,   -5, 	  -3,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -3,   -6, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -7,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -6, 	   2,   -4, 	  -2,   -6
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte    0,   -5, 	  -7,   -4, 	   7,   -6, 	  -1,   -5
+.2byte    0,   -5, 	  -8,   -6, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -4, 	  -1,   -6
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    2,   -6, 	   6,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    2,   -6, 	   6,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    4,   -3, 	   8,   -6, 	  -3,   -4, 	   1,   -6
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    5,   -6, 	  -1,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    5,   -6, 	   3,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    6,   -4, 	   3,   -9, 	   2,   -5, 	   2,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -6, 	  -4,   -7, 	   3,   -3, 	  -1,   -6
+.2byte    1,   -7, 	  -6,   -8, 	   6,   -4, 	  -1,   -6
+.2byte    2,   -8, 	  -3,  -12, 	   6,   -6, 	   0,   -8
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,   -6, 	   7,   -7, 	  -8,   -4, 	   0,   -5
+.2byte    0,   -6, 	   7,   -4, 	  -8,   -7, 	   0,   -5
+.2byte    0,   -6, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -6, 	   3,   -7, 	  -4,   -3, 	   0,   -6
+.2byte   -2,   -7, 	   5,   -8, 	  -7,   -4, 	   0,   -6
+.2byte   -3,   -8, 	   2,  -12, 	  -7,   -6, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -6, 	   0,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -6,   -6, 	  -4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -7,   -4, 	  -4,   -9, 	  -3,   -5, 	  -3,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -3,   -6, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -7,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -6, 	   2,   -4, 	  -2,   -6
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    4,   -6, 	   8,   -6, 	  -5,   -4, 	   1,   -6
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    7,   -5, 	   3,   -8, 	   1,   -4, 	   1,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -7, 	  -3,   -9, 	   5,   -4, 	   0,   -8
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,   -7, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -7, 	   2,   -9, 	  -6,   -4, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -8,   -5, 	  -4,   -8, 	  -2,   -4, 	  -2,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -5,   -6, 	  -9,   -6, 	   4,   -4, 	  -2,   -6
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte    0,   -5, 	  -7,   -4, 	   7,   -6, 	  -1,   -5
+.2byte    0,   -5, 	  -8,   -6, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -4, 	  -1,   -6
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    2,   -6, 	   6,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    2,   -6, 	   6,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    4,   -3, 	   8,   -6, 	  -3,   -4, 	   1,   -6
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    5,   -6, 	  -1,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    5,   -6, 	   3,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    6,   -4, 	   3,   -9, 	   2,   -5, 	   2,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -6, 	  -4,   -7, 	   3,   -3, 	  -1,   -6
+.2byte    1,   -7, 	  -6,   -8, 	   6,   -4, 	  -1,   -6
+.2byte    1,   -8, 	  -4,  -12, 	   5,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,   -6, 	   7,   -7, 	  -8,   -4, 	   0,   -5
+.2byte    0,   -6, 	   7,   -4, 	  -8,   -7, 	   0,   -5
+.2byte    0,   -6, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -6, 	   3,   -7, 	  -4,   -3, 	   0,   -6
+.2byte   -2,   -7, 	   5,   -8, 	  -7,   -4, 	   0,   -6
+.2byte   -2,   -8, 	   3,  -12, 	  -6,   -6, 	   0,   -8
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -6, 	   0,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -6,   -6, 	  -4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -7,   -4, 	  -4,   -9, 	  -3,   -5, 	  -3,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -3,   -6, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -7,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -5,   -3, 	  -9,   -6, 	   2,   -4, 	  -2,   -6
+.2byte    0,   -8, 	  -4,   -8, 	   3,   -2, 	   1,   -6
+.2byte    0,   -8, 	  -4,   -8, 	   3,   -2, 	   1,   -6
+.2byte   -1,   -9, 	  -8,   -9, 	   7,   -9, 	   0,   -9
+.2byte    1,  -10, 	   6,  -11, 	  -5,   -7, 	  -1,   -9
+.2byte    5,  -10, 	   1,  -12, 	   0,   -9, 	  -1,   -8
+.2byte    3,  -11, 	  -3,  -13, 	   7,   -9, 	   0,   -9
+.2byte    0,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte   -4,  -11, 	   2,  -13, 	  -8,   -9, 	  -1,   -9
+.2byte   -6,  -10, 	  -2,  -12, 	  -1,   -9, 	   0,   -8
+.2byte   -2,  -10, 	  -7,  -11, 	   4,   -7, 	   0,   -9
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte    0,   -5, 	  -7,   -4, 	   7,   -6, 	  -1,   -5
+.2byte    0,   -5, 	  -8,   -6, 	   6,   -4, 	  -1,   -5
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    2,   -6, 	   6,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    2,   -6, 	   6,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    5,   -6, 	  -1,   -5, 	  -2,   -3, 	  -1,   -6
+.2byte    5,   -6, 	   3,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -6, 	  -4,   -7, 	   3,   -3, 	  -1,   -6
+.2byte    1,   -7, 	  -6,   -8, 	   6,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,   -6, 	   7,   -7, 	  -8,   -4, 	   0,   -5
+.2byte    0,   -6, 	   7,   -4, 	  -8,   -7, 	   0,   -5
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -3,   -6, 	   3,   -7, 	  -4,   -3, 	   0,   -6
+.2byte   -2,   -7, 	   5,   -8, 	  -7,   -4, 	   0,   -6
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -6, 	   0,   -5, 	   1,   -3, 	   0,   -6
+.2byte   -6,   -6, 	  -4,   -6, 	  -2,   -3, 	   0,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -3,   -6, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -7,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -4, 	  -1,   -6
+.2byte   -4,   -3, 	  -8,   -6, 	   3,   -4, 	  -1,   -6
+.2byte   -5,   -4, 	  -2,   -9, 	  -1,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	   2,  -12, 	  -7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    2,   -8, 	  -3,  -12, 	   6,   -6, 	   0,   -8
+.2byte    5,   -4, 	   2,   -9, 	   1,   -5, 	   1,   -6
+.2byte    3,   -3, 	   7,   -6, 	  -4,   -4, 	   0,   -6
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte    2,   -6, 	   6,   -6, 	  -7,   -4, 	  -1,   -6
+.2byte    6,   -5, 	   2,   -8, 	   0,   -4, 	   0,   -6
+.2byte    1,   -6, 	  -4,   -8, 	   4,   -3, 	  -1,   -7
+.2byte    0,   -6, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte   -2,   -6, 	   3,   -8, 	  -5,   -3, 	   0,   -7
+.2byte   -7,   -5, 	  -3,   -8, 	  -1,   -4, 	  -1,   -6
+.2byte   -4,   -6, 	  -8,   -6, 	   5,   -4, 	  -1,   -6
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -4, 	  -1,   -6
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+.2byte    3,   -6, 	   7,   -6, 	  -6,   -4, 	   0,   -6
+.2byte    3,   -3, 	   7,   -6, 	  -4,   -4, 	   0,   -6
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    6,   -5, 	   2,   -8, 	   0,   -4, 	   0,   -6
+.2byte    5,   -4, 	   2,   -9, 	   1,   -5, 	   1,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    1,   -6, 	  -4,   -8, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -8, 	  -3,  -12, 	   6,   -6, 	   0,   -8
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    0,   -6, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte    0,   -6, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -2,   -6, 	   3,   -8, 	  -5,   -3, 	   0,   -7
+.2byte   -3,   -8, 	   2,  -12, 	  -7,   -6, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -7,   -5, 	  -3,   -8, 	  -1,   -4, 	  -1,   -6
+.2byte   -6,   -4, 	  -3,   -9, 	  -2,   -5, 	  -2,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -4,   -6, 	  -8,   -6, 	   5,   -4, 	  -1,   -6
+.2byte   -4,   -3, 	  -8,   -6, 	   3,   -4, 	  -1,   -6
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -4, 	  -1,   -6
+.2byte   -4,   -3, 	  -8,   -6, 	   3,   -4, 	  -1,   -6
+.2byte   -6,   -4, 	  -3,   -9, 	  -2,   -5, 	  -2,   -6
+.2byte   -3,   -8, 	   2,  -12, 	  -7,   -6, 	  -1,   -8
+.2byte    0,   -6, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    2,   -8, 	  -3,  -12, 	   6,   -6, 	   0,   -8
+.2byte    5,   -4, 	   2,   -9, 	   1,   -5, 	   1,   -6
+.2byte    3,   -3, 	   7,   -6, 	  -4,   -4, 	   0,   -6
+.2byte    0,   -6, 	  -8,   -6, 	   7,   -6, 	  -1,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   3,   -4, 	  -1,   -7
+.2byte   -6,   -7, 	  -2,   -7, 	  -1,   -4, 	   0,   -7
+.2byte   -2,   -7, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -1,   -7, 	   7,   -7, 	  -8,   -7, 	   0,   -6
+.2byte    1,   -7, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    5,   -7, 	   1,   -7, 	   0,   -4, 	  -1,   -7
+.2byte    2,   -7, 	   6,   -7, 	  -4,   -4, 	   0,   -7
+sMarillAnimTable1:
+.4byte sMarillAnims_1_1
+.4byte sMarillAnims_1_2
+.4byte sMarillAnims_1_3
+.4byte sMarillAnims_1_4
+.4byte sMarillAnims_1_5
+.4byte sMarillAnims_1_6
+.4byte sMarillAnims_1_7
+.4byte sMarillAnims_1_8
+sMarillAnimTable2:
+.4byte sMarillAnims_2_1
+.4byte sMarillAnims_2_2
+.4byte sMarillAnims_2_3
+.4byte sMarillAnims_2_4
+.4byte sMarillAnims_2_5
+.4byte sMarillAnims_2_6
+.4byte sMarillAnims_2_7
+.4byte sMarillAnims_2_8
+sMarillAnimTable3:
+.4byte sMarillAnims_3_1
+.4byte sMarillAnims_3_2
+.4byte sMarillAnims_3_3
+.4byte sMarillAnims_3_4
+.4byte sMarillAnims_3_5
+.4byte sMarillAnims_3_6
+.4byte sMarillAnims_3_7
+.4byte sMarillAnims_3_8
+sMarillAnimTable4:
+.4byte sMarillAnims_4_1
+.4byte sMarillAnims_4_2
+.4byte sMarillAnims_4_3
+.4byte sMarillAnims_4_4
+.4byte sMarillAnims_4_5
+.4byte sMarillAnims_4_6
+.4byte sMarillAnims_4_7
+.4byte sMarillAnims_4_8
+sMarillAnimTable5:
+.4byte sMarillAnims_5_1
+.4byte sMarillAnims_5_2
+.4byte sMarillAnims_5_3
+.4byte sMarillAnims_5_4
+.4byte sMarillAnims_5_5
+.4byte sMarillAnims_5_6
+.4byte sMarillAnims_5_7
+.4byte sMarillAnims_5_8
+sMarillAnimTable6:
+.4byte sMarillAnims_6_1
+.4byte sMarillAnims_6_1
+.4byte sMarillAnims_6_1
+.4byte sMarillAnims_6_1
+.4byte sMarillAnims_6_1
+.4byte sMarillAnims_6_1
+.4byte sMarillAnims_6_1
+.4byte sMarillAnims_6_1
+sMarillAnimTable7:
+.4byte sMarillAnims_7_1
+.4byte sMarillAnims_7_2
+.4byte sMarillAnims_7_3
+.4byte sMarillAnims_7_4
+.4byte sMarillAnims_7_5
+.4byte sMarillAnims_7_6
+.4byte sMarillAnims_7_7
+.4byte sMarillAnims_7_8
+sMarillAnimTable8:
+.4byte sMarillAnims_8_1
+.4byte sMarillAnims_8_2
+.4byte sMarillAnims_8_3
+.4byte sMarillAnims_8_4
+.4byte sMarillAnims_8_5
+.4byte sMarillAnims_8_6
+.4byte sMarillAnims_8_7
+.4byte sMarillAnims_8_8
+sMarillAnimTable9:
+.4byte sMarillAnims_9_1
+.4byte sMarillAnims_9_2
+.4byte sMarillAnims_9_3
+.4byte sMarillAnims_9_4
+.4byte sMarillAnims_9_5
+.4byte sMarillAnims_9_6
+.4byte sMarillAnims_9_7
+.4byte sMarillAnims_9_8
+sMarillAnimTable10:
+.4byte sMarillAnims_10_1
+.4byte sMarillAnims_10_2
+.4byte sMarillAnims_10_3
+.4byte sMarillAnims_10_4
+.4byte sMarillAnims_10_5
+.4byte sMarillAnims_10_6
+.4byte sMarillAnims_10_7
+.4byte sMarillAnims_10_8
+sMarillAnimTable11:
+.4byte sMarillAnims_11_1
+.4byte sMarillAnims_11_2
+.4byte sMarillAnims_11_3
+.4byte sMarillAnims_11_4
+.4byte sMarillAnims_11_5
+.4byte sMarillAnims_11_6
+.4byte sMarillAnims_11_7
+.4byte sMarillAnims_11_8
+sMarillAnimTable12:
+.4byte sMarillAnims_12_1
+.4byte sMarillAnims_12_2
+.4byte sMarillAnims_12_3
+.4byte sMarillAnims_12_4
+.4byte sMarillAnims_12_5
+.4byte sMarillAnims_12_6
+.4byte sMarillAnims_12_7
+.4byte sMarillAnims_12_8
+sMarillAnimTable13:
+.4byte sMarillAnims_13_1
+.4byte sMarillAnims_13_2
+.4byte sMarillAnims_13_3
+.4byte sMarillAnims_13_4
+.4byte sMarillAnims_13_5
+.4byte sMarillAnims_13_6
+.4byte sMarillAnims_13_7
+.4byte sMarillAnims_13_8
+sAxAnimationsMarill:
+.4byte sMarillAnimTable1
+.4byte sMarillAnimTable2
+.4byte sMarillAnimTable3
+.4byte sMarillAnimTable4
+.4byte sMarillAnimTable5
+.4byte sMarillAnimTable6
+.4byte sMarillAnimTable7
+.4byte sMarillAnimTable8
+.4byte sMarillAnimTable9
+.4byte sMarillAnimTable10
+.4byte sMarillAnimTable11
+.4byte sMarillAnimTable12
+.4byte sMarillAnimTable13
+sAxSpritesMarill:
+.4byte sMarillSprites1
+.4byte sMarillSprites2
+.4byte sMarillSprites3
+.4byte sMarillSprites4
+.4byte sMarillSprites5
+.4byte sMarillSprites6
+.4byte sMarillSprites7
+.4byte sMarillSprites8
+.4byte sMarillSprites9
+.4byte sMarillSprites10
+.4byte sMarillSprites11
+.4byte sMarillSprites12
+.4byte sMarillSprites13
+.4byte sMarillSprites14
+.4byte sMarillSprites15
+.4byte sMarillSprites16
+.4byte sMarillSprites17
+.4byte sMarillSprites18
+.4byte sMarillSprites19
+.4byte sMarillSprites20
+.4byte sMarillSprites21
+.4byte sMarillSprites22
+.4byte sMarillSprites23
+.4byte sMarillSprites24
+.4byte sMarillSprites25
+.4byte sMarillSprites26
+.4byte sMarillSprites27
+.4byte sMarillSprites28
+.4byte sMarillSprites29
+.4byte sMarillSprites30
+.4byte sMarillSprites31
+.4byte sMarillSprites32
+sAxMainMarill:
+ax_main sAxPosesMarill, sAxAnimationsMarill, 13, sAxSpritesMarill, sAxPositionsMarill

--- a/data/ax/marowak.inc
+++ b/data/ax/marowak.inc
@@ -1,0 +1,3090 @@
+.global gAxMarowak
+gAxMarowak:
+ax_siro sAxMainMarowak
+sMarowakPose1:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose2:
+ax_pose 1, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose3:
+ax_pose 2, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose4:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose5:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose6:
+ax_pose 5, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose7:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose8:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose9:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose10:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose11:
+ax_pose 10, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose12:
+ax_pose 11, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose13:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose14:
+ax_pose 13, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose15:
+ax_pose 14, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose16:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose17:
+ax_pose 16, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose18:
+ax_pose 17, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose19:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose20:
+ax_pose 19, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose21:
+ax_pose 20, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose22:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose23:
+ax_pose 22, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose24:
+ax_pose 23, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose25:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose26:
+ax_pose 1, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose27:
+ax_pose 2, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose28:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose29:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose30:
+ax_pose 5, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose31:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose32:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose33:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose34:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose35:
+ax_pose 10, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose36:
+ax_pose 11, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose37:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose38:
+ax_pose 13, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose39:
+ax_pose 14, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose40:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose41:
+ax_pose 16, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose42:
+ax_pose 17, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose43:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose44:
+ax_pose 19, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose45:
+ax_pose 20, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose46:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose47:
+ax_pose 22, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose48:
+ax_pose 23, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose49:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose50:
+ax_pose 24, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose51:
+ax_pose 25, 0x01e5, 0x80f2, 0x6c00
+ax_pose 26, 0x01e5, 0x80f2, 0x6c10
+ax_pose_terminator
+sMarowakPose52:
+ax_pose 26, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose53:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose54:
+ax_pose 27, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sMarowakPose55:
+ax_pose 28, 0x01e7, 0x80f0, 0x6c00
+ax_pose 29, 0x01e4, 0x80f2, 0x6c10
+ax_pose_terminator
+sMarowakPose56:
+ax_pose 29, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose57:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose58:
+ax_pose 30, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose59:
+ax_pose 31, 0x01e7, 0x80ef, 0x6c00
+ax_pose 32, 0x01e4, 0x80f4, 0x6c10
+ax_pose_terminator
+sMarowakPose60:
+ax_pose 31, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose61:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose62:
+ax_pose 33, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose63:
+ax_pose 34, 0x01e5, 0x80ef, 0x6c00
+ax_pose 35, 0x01e5, 0x80ef, 0x6c10
+ax_pose_terminator
+sMarowakPose64:
+ax_pose 35, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose65:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose66:
+ax_pose 36, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose67:
+ax_pose 37, 0x41e5, 0x80ee, 0x6c00
+ax_pose 38, 0x01e5, 0x80ee, 0x6c08
+ax_pose_terminator
+sMarowakPose68:
+ax_pose 38, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sMarowakPose69:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose70:
+ax_pose 39, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose71:
+ax_pose 40, 0x01e5, 0x80ed, 0x6c00
+ax_pose 41, 0x01e5, 0x80ed, 0x6c10
+ax_pose_terminator
+sMarowakPose72:
+ax_pose 41, 0x01e5, 0x80ed, 0x6c00
+ax_pose_terminator
+sMarowakPose73:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose74:
+ax_pose 42, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sMarowakPose75:
+ax_pose 43, 0x81e6, 0x80ef, 0x6c00
+ax_pose 44, 0x01e6, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose76:
+ax_pose 44, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose77:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose78:
+ax_pose 45, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose79:
+ax_pose 46, 0x81e5, 0x80ef, 0x6c00
+ax_pose 47, 0x01e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose80:
+ax_pose 47, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose81:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose82:
+ax_pose 24, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose83:
+ax_pose 25, 0x01e5, 0x80f2, 0x6c00
+ax_pose 26, 0x01e5, 0x80f2, 0x6c10
+ax_pose_terminator
+sMarowakPose84:
+ax_pose 26, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose85:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose86:
+ax_pose 27, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sMarowakPose87:
+ax_pose 28, 0x01e7, 0x80f0, 0x6c00
+ax_pose 29, 0x01e4, 0x80f2, 0x6c10
+ax_pose_terminator
+sMarowakPose88:
+ax_pose 29, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose89:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose90:
+ax_pose 30, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose91:
+ax_pose 31, 0x01e7, 0x80ef, 0x6c00
+ax_pose 32, 0x01e4, 0x80f4, 0x6c10
+ax_pose_terminator
+sMarowakPose92:
+ax_pose 31, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose93:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose94:
+ax_pose 33, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose95:
+ax_pose 34, 0x01e5, 0x80ef, 0x6c00
+ax_pose 35, 0x01e5, 0x80ef, 0x6c10
+ax_pose_terminator
+sMarowakPose96:
+ax_pose 35, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose97:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose98:
+ax_pose 36, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose99:
+ax_pose 37, 0x41e5, 0x80ee, 0x6c00
+ax_pose 38, 0x01e5, 0x80ee, 0x6c08
+ax_pose_terminator
+sMarowakPose100:
+ax_pose 38, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sMarowakPose101:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose102:
+ax_pose 39, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose103:
+ax_pose 40, 0x01e5, 0x80ed, 0x6c00
+ax_pose 41, 0x01e5, 0x80ed, 0x6c10
+ax_pose_terminator
+sMarowakPose104:
+ax_pose 41, 0x01e5, 0x80ed, 0x6c00
+ax_pose_terminator
+sMarowakPose105:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose106:
+ax_pose 42, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sMarowakPose107:
+ax_pose 43, 0x81e6, 0x80ef, 0x6c00
+ax_pose 44, 0x01e6, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose108:
+ax_pose 44, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose109:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose110:
+ax_pose 45, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose111:
+ax_pose 46, 0x81e5, 0x80ef, 0x6c00
+ax_pose 47, 0x01e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose112:
+ax_pose 47, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose113:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose114:
+ax_pose 24, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose115:
+ax_pose 48, 0x81e4, 0x80f3, 0x6c00
+ax_pose 49, 0x01e5, 0x80f2, 0x6c08
+ax_pose_terminator
+sMarowakPose116:
+ax_pose 49, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose117:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose118:
+ax_pose 27, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sMarowakPose119:
+ax_pose 50, 0x81e9, 0x80ff, 0x6c00
+ax_pose 51, 0x01e5, 0x80f2, 0x6c08
+ax_pose_terminator
+sMarowakPose120:
+ax_pose 51, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose121:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose122:
+ax_pose 30, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose123:
+ax_pose 52, 0x41ea, 0x80f5, 0x6c00
+ax_pose 31, 0x01e7, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose124:
+ax_pose 31, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose125:
+ax_pose 42, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sMarowakPose126:
+ax_pose 53, 0x81e3, 0x9100, 0x6c00
+ax_pose 54, 0x01e6, 0x90f1, 0x6c08
+ax_pose_terminator
+sMarowakPose127:
+ax_pose 54, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sMarowakPose128:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose129:
+ax_pose 33, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose130:
+ax_pose 55, 0x41e9, 0x80ef, 0x6c00
+ax_pose 56, 0x01e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose131:
+ax_pose 56, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose132:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose133:
+ax_pose 36, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose134:
+ax_pose 57, 0x01e5, 0x80ee, 0x6c00
+ax_pose 58, 0x41e3, 0x80f3, 0x6c10
+ax_pose_terminator
+sMarowakPose135:
+ax_pose 57, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sMarowakPose136:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose137:
+ax_pose 39, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose138:
+ax_pose 59, 0x81e4, 0x80ee, 0x6c00
+ax_pose 60, 0x01e5, 0x80ed, 0x6c08
+ax_pose_terminator
+sMarowakPose139:
+ax_pose 60, 0x01e5, 0x80ed, 0x6c00
+ax_pose_terminator
+sMarowakPose140:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose141:
+ax_pose 42, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sMarowakPose142:
+ax_pose 53, 0x81e3, 0x80f0, 0x6c00
+ax_pose 54, 0x01e6, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose143:
+ax_pose 54, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose144:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose145:
+ax_pose 45, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose146:
+ax_pose 61, 0x81e2, 0x80ef, 0x6c00
+ax_pose 62, 0x01e4, 0x80ef, 0x6c08
+ax_pose_terminator
+sMarowakPose147:
+ax_pose 62, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose148:
+ax_pose 63, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sMarowakPose149:
+ax_pose 64, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sMarowakPose150:
+ax_pose 65, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose151:
+ax_pose 66, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sMarowakPose152:
+ax_pose 67, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sMarowakPose153:
+ax_pose 68, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sMarowakPose154:
+ax_pose 69, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose155:
+ax_pose 68, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sMarowakPose156:
+ax_pose 67, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose157:
+ax_pose 66, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sMarowakPose158:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose159:
+ax_pose 1, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose160:
+ax_pose 2, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose161:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose162:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose163:
+ax_pose 5, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose164:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose165:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose166:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose167:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose168:
+ax_pose 10, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose169:
+ax_pose 11, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose170:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose171:
+ax_pose 13, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose172:
+ax_pose 14, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose173:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose174:
+ax_pose 16, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose175:
+ax_pose 17, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose176:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose177:
+ax_pose 19, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose178:
+ax_pose 20, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose179:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose180:
+ax_pose 22, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose181:
+ax_pose 23, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose182:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose183:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose184:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose185:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose186:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose187:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose188:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose189:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose190:
+ax_pose 26, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose191:
+ax_pose 29, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sMarowakPose192:
+ax_pose 31, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose193:
+ax_pose 35, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose194:
+ax_pose 38, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sMarowakPose195:
+ax_pose 41, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sMarowakPose196:
+ax_pose 44, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sMarowakPose197:
+ax_pose 47, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose198:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose199:
+ax_pose 1, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose200:
+ax_pose 2, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose201:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose202:
+ax_pose 4, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose203:
+ax_pose 5, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose204:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose205:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose206:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose207:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose208:
+ax_pose 10, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose209:
+ax_pose 11, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose210:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose211:
+ax_pose 13, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose212:
+ax_pose 14, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose213:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose214:
+ax_pose 16, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose215:
+ax_pose 17, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose216:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose217:
+ax_pose 19, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose218:
+ax_pose 20, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose219:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose220:
+ax_pose 22, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose221:
+ax_pose 23, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose222:
+ax_pose 1, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose223:
+ax_pose 22, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose224:
+ax_pose 20, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose225:
+ax_pose 17, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose226:
+ax_pose 13, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose227:
+ax_pose 10, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose228:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose229:
+ax_pose 4, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose230:
+ax_pose 0, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose231:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose232:
+ax_pose 18, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose233:
+ax_pose 15, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sMarowakPose234:
+ax_pose 12, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose235:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sMarowakPose236:
+ax_pose 6, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sMarowakPose237:
+ax_pose 3, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+.align 2
+sMarowakAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarowakAnims_2_1:
+ax_anim 2, 0, 47, 0, -1, 0, -1,
+ax_anim 6, 0, 47, 0, -2, 0, -2,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMarowakAnims_2_2:
+ax_anim 2, 0, 26, -1, -1, -1, -1,
+ax_anim 6, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 2, 29, 3, 3, 3, 3,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 1, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 0, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sMarowakAnims_2_3:
+ax_anim 2, 0, 28, -1, 0, -1, 0,
+ax_anim 6, 0, 28, -2, 0, -2, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 1, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sMarowakAnims_2_4:
+ax_anim 2, 0, 31, -1, 1, -1, 1,
+ax_anim 6, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 35, 13, -13, 13, -13,
+ax_anim 2, 0, 35, 21, -21, 21, -21,
+ax_anim 2, 1, 35, 22, -20, 22, -20,
+ax_anim 2, 0, 35, 21, -21, 21, -21,
+ax_anim 2, 0, 35, 22, -20, 22, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMarowakAnims_2_5:
+ax_anim 2, 0, 34, 0, 1, 0, 1,
+ax_anim 6, 0, 34, 0, 2, 0, 2,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 1, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 0, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMarowakAnims_2_6:
+ax_anim 2, 0, 37, 1, 1, 1, 1,
+ax_anim 6, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 40, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMarowakAnims_2_7:
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim 6, 0, 41, 2, 0, 2, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sMarowakAnims_2_8:
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 6, 0, 43, 2, -2, 2, -2,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -19, 19, -19, 19,
+ax_anim 2, 1, 46, -20, 18, -20, 18,
+ax_anim 2, 0, 46, -19, 19, -19, 19,
+ax_anim 2, 0, 46, -20, 18, -20, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMarowakAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 6, 0, 49, 0, -3, 0, -3,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 49, 0, 6, 0, 6,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 1, 51, -1, 16, -1, 16,
+ax_anim 2, 0, 51, 0, 16, 0, 16,
+ax_anim 2, 0, 51, -1, 16, -1, 16,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sMarowakAnims_3_2:
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 53, -3, -3, -3, -3,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 2, 53, 6, 8, 6, 8,
+ax_anim 2, 0, 54, 13, 18, 13, 18,
+ax_anim 2, 1, 55, 14, 17, 14, 17,
+ax_anim 2, 0, 55, 13, 18, 13, 18,
+ax_anim 2, 0, 55, 14, 17, 14, 17,
+ax_anim 2, 0, 52, 6, 8, 6, 8,
+ax_anim_terminator
+sMarowakAnims_3_3:
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 6, 0, 57, -3, 0, -3, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 2, 57, 4, 0, 6, 0,
+ax_anim 2, 0, 58, 12, 0, 12, 0,
+ax_anim 2, 1, 59, 12, -1, 12, -1,
+ax_anim 2, 0, 59, 12, 0, 12, 0,
+ax_anim 2, 0, 59, 12, -1, 12, -1,
+ax_anim 2, 0, 56, 4, 0, 4, 0,
+ax_anim_terminator
+sMarowakAnims_3_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 6, 0, 61, -3, 3, -3, 3,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 2, 61, 6, -7, 6, -7,
+ax_anim 2, 0, 62, 16, -16, 16, -16,
+ax_anim 2, 1, 63, 15, -17, 15, -17,
+ax_anim 2, 0, 63, 16, -16, 16, -16,
+ax_anim 2, 0, 63, 15, -17, 15, -17,
+ax_anim 2, 0, 60, 6, -6, 6, -6,
+ax_anim_terminator
+sMarowakAnims_3_5:
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 6, 0, 65, 0, 3, 0, 3,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 65, 0, -6, 0, -6,
+ax_anim 2, 0, 66, 0, -16, 0, -16,
+ax_anim 2, 1, 67, 1, -16, 1, -16,
+ax_anim 2, 0, 67, 0, -16, 0, -16,
+ax_anim 2, 0, 67, 1, -16, 1, -16,
+ax_anim 2, 0, 64, 0, -6, 0, -6,
+ax_anim_terminator
+sMarowakAnims_3_6:
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 6, 0, 69, 3, 3, 3, 3,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 2, 69, -4, -7, -4, -7,
+ax_anim 2, 0, 70, -12, -18, -12, -18,
+ax_anim 2, 1, 71, -11, -19, -11, -19,
+ax_anim 2, 0, 71, -12, -18, -12, -18,
+ax_anim 2, 0, 71, -11, -19, -11, -19,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim_terminator
+sMarowakAnims_3_7:
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 6, 0, 73, 3, 0, 3, 0,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 73, -4, 0, -4, 0,
+ax_anim 2, 0, 74, -14, 0, -14, 0,
+ax_anim 2, 1, 75, -14, -1, -14, -1,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 75, -14, -1, -14, -1,
+ax_anim 2, 0, 72, -4, 0, -4, 0,
+ax_anim_terminator
+sMarowakAnims_3_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 6, 0, 77, 3, -3, 3, -3,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 77, -6, 6, -6, 6,
+ax_anim 2, 0, 78, -16, 16, -16, 16,
+ax_anim 2, 1, 79, -17, 15, -17, 15,
+ax_anim 2, 0, 79, -16, 16, -16, 16,
+ax_anim 2, 0, 79, -17, 15, -17, 15,
+ax_anim 2, 0, 76, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMarowakAnims_4_1:
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 6, 0, 81, 0, -3, 0, -3,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 81, 0, 6, 0, 6,
+ax_anim 2, 0, 82, 0, 16, 0, 16,
+ax_anim 2, 1, 83, -1, 16, -1, 16,
+ax_anim 2, 0, 83, 0, 16, 0, 16,
+ax_anim 2, 0, 83, -1, 16, -1, 16,
+ax_anim 2, 0, 80, 0, 6, 0, 6,
+ax_anim_terminator
+sMarowakAnims_4_2:
+ax_anim 2, 0, 85, -2, -2, -2, -2,
+ax_anim 6, 0, 85, -3, -3, -3, -3,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 85, 6, 8, 6, 8,
+ax_anim 2, 0, 86, 13, 18, 13, 18,
+ax_anim 2, 1, 87, 14, 17, 14, 17,
+ax_anim 2, 0, 87, 13, 18, 13, 18,
+ax_anim 2, 0, 87, 14, 17, 14, 17,
+ax_anim 2, 0, 84, 6, 8, 6, 8,
+ax_anim_terminator
+sMarowakAnims_4_3:
+ax_anim 2, 0, 89, -2, 0, -2, 0,
+ax_anim 6, 0, 89, -3, 0, -3, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 4, 0, 6, 0,
+ax_anim 2, 0, 90, 12, 0, 12, 0,
+ax_anim 2, 1, 91, 12, -1, 12, -1,
+ax_anim 2, 0, 91, 12, 0, 12, 0,
+ax_anim 2, 0, 91, 12, -1, 12, -1,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim_terminator
+sMarowakAnims_4_4:
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim 6, 0, 93, -3, 3, -3, 3,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 6, -7, 6, -7,
+ax_anim 2, 0, 94, 16, -16, 16, -16,
+ax_anim 2, 1, 95, 15, -17, 15, -17,
+ax_anim 2, 0, 95, 16, -16, 16, -16,
+ax_anim 2, 0, 95, 15, -17, 15, -17,
+ax_anim 2, 0, 92, 6, -6, 6, -6,
+ax_anim_terminator
+sMarowakAnims_4_5:
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 6, 0, 97, 0, 3, 0, 3,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, -6, 0, -6,
+ax_anim 2, 0, 98, 0, -16, 0, -16,
+ax_anim 2, 1, 99, 1, -16, 1, -16,
+ax_anim 2, 0, 99, 0, -16, 0, -16,
+ax_anim 2, 0, 99, 1, -16, 1, -16,
+ax_anim 2, 0, 96, 0, -6, 0, -6,
+ax_anim_terminator
+sMarowakAnims_4_6:
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 6, 0, 101, 3, 3, 3, 3,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 101, -4, -7, -4, -7,
+ax_anim 2, 0, 102, -12, -18, -12, -18,
+ax_anim 2, 1, 103, -11, -19, -11, -19,
+ax_anim 2, 0, 103, -12, -18, -12, -18,
+ax_anim 2, 0, 103, -11, -19, -11, -19,
+ax_anim 2, 0, 100, -6, -6, -6, -6,
+ax_anim_terminator
+sMarowakAnims_4_7:
+ax_anim 2, 0, 105, 2, 0, 2, 0,
+ax_anim 6, 0, 105, 3, 0, 3, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 105, -4, 0, -4, 0,
+ax_anim 2, 0, 106, -14, 0, -14, 0,
+ax_anim 2, 1, 107, -14, -1, -14, -1,
+ax_anim 2, 0, 107, -14, 0, -14, 0,
+ax_anim 2, 0, 107, -14, -1, -14, -1,
+ax_anim 2, 0, 104, -4, 0, -4, 0,
+ax_anim_terminator
+sMarowakAnims_4_8:
+ax_anim 2, 0, 109, 2, -2, 2, -2,
+ax_anim 6, 0, 109, 3, -3, 3, -3,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 109, -6, 6, -6, 6,
+ax_anim 2, 0, 110, -16, 16, -16, 16,
+ax_anim 2, 1, 111, -17, 15, -17, 15,
+ax_anim 2, 0, 111, -16, 16, -16, 16,
+ax_anim 2, 0, 111, -17, 15, -17, 15,
+ax_anim 2, 0, 108, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMarowakAnims_5_1:
+ax_anim 2, 0, 113, 0, -2, 0, -2,
+ax_anim 6, 2, 113, 0, -4, 0, -4,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 0, 6, 0, 6,
+ax_anim 3, 0, 115, 0, 7, 0, 7,
+ax_anim 4, 0, 115, 0, 8, 0, 8,
+ax_anim_terminator
+sMarowakAnims_5_2:
+ax_anim 2, 0, 117, -2, -2, -2, -2,
+ax_anim 6, 2, 117, -4, -4, -4, -4,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 6, 6, 6, 6,
+ax_anim 3, 0, 119, 7, 7, 7, 7,
+ax_anim 4, 0, 119, 8, 8, 8, 8,
+ax_anim_terminator
+sMarowakAnims_5_3:
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 6, 2, 121, -4, 0, -4, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 122, 6, 0, 6, 0,
+ax_anim 3, 0, 123, 7, 0, 7, 0,
+ax_anim 4, 0, 123, 8, 0, 8, 0,
+ax_anim_terminator
+sMarowakAnims_5_4:
+ax_anim 2, 0, 128, -2, 2, -2, 2,
+ax_anim 6, 2, 128, -4, 4, -4, 4,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 1, 129, 6, -6, 6, -6,
+ax_anim 3, 0, 130, 7, -7, 7, -7,
+ax_anim 4, 0, 130, 8, -8, 8, -8,
+ax_anim_terminator
+sMarowakAnims_5_5:
+ax_anim 2, 0, 132, 0, 2, 0, 2,
+ax_anim 6, 2, 132, 0, 4, 0, 4,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 1, 133, 0, -6, 0, -6,
+ax_anim 3, 0, 134, 0, -7, 0, -7,
+ax_anim 4, 0, 134, 0, -8, 0, -8,
+ax_anim_terminator
+sMarowakAnims_5_6:
+ax_anim 2, 0, 136, 2, 2, 2, 2,
+ax_anim 6, 2, 136, 4, 4, 4, 4,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 1, 137, -6, -6, -6, -6,
+ax_anim 3, 0, 138, -7, -7, -7, -7,
+ax_anim 4, 0, 138, -8, -8, -8, -8,
+ax_anim_terminator
+sMarowakAnims_5_7:
+ax_anim 2, 0, 140, 2, 0, 2, 0,
+ax_anim 6, 2, 140, 4, 0, 4, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 1, 141, -6, 0, -6, 0,
+ax_anim 3, 0, 142, -7, 0, -7, 0,
+ax_anim 4, 0, 142, -8, 0, -8, 0,
+ax_anim_terminator
+sMarowakAnims_5_8:
+ax_anim 2, 0, 144, 2, -2, 2, -2,
+ax_anim 6, 2, 144, 4, -4, 4, -4,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 1, 145, -6, 6, -6, 6,
+ax_anim 3, 0, 146, -7, 7, -7, 7,
+ax_anim 4, 0, 146, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sMarowakAnims_6_1:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 35, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarowakAnims_7_1:
+ax_anim 2, 0, 149, 0, -4, 0, -4,
+ax_anim 8, 0, 149, 0, -5, 0, -5,
+ax_anim_terminator
+sMarowakAnims_7_2:
+ax_anim 2, 0, 150, -4, -4, -4, -4,
+ax_anim 8, 0, 150, -5, -5, -5, -5,
+ax_anim_terminator
+sMarowakAnims_7_3:
+ax_anim 2, 0, 151, -4, 0, -4, 0,
+ax_anim 8, 0, 151, -5, 0, -5, 0,
+ax_anim_terminator
+sMarowakAnims_7_4:
+ax_anim 2, 0, 152, -4, 4, -4, 4,
+ax_anim 8, 0, 152, -5, 5, -5, 5,
+ax_anim_terminator
+sMarowakAnims_7_5:
+ax_anim 2, 0, 153, 0, 4, 0, 4,
+ax_anim 8, 0, 153, 0, 5, 0, 5,
+ax_anim_terminator
+sMarowakAnims_7_6:
+ax_anim 2, 0, 154, 4, 4, 4, 4,
+ax_anim 8, 0, 154, 5, 5, 5, 5,
+ax_anim_terminator
+sMarowakAnims_7_7:
+ax_anim 2, 0, 155, 4, 0, 4, 0,
+ax_anim 8, 0, 155, 5, 0, 5, 0,
+ax_anim_terminator
+sMarowakAnims_7_8:
+ax_anim 2, 0, 156, 4, -4, 4, -4,
+ax_anim 8, 0, 156, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMarowakAnims_8_1:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 16, 0, 159, 0, 1, 0, 1,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_8_2:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 162, 1, 1, 1, 1,
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_8_3:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 1, 0, 0, 0,
+ax_anim 16, 0, 165, 2, 0, 1, 0,
+ax_anim 6, 0, 165, 1, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_8_4:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 6, 0, 168, 0, -2, 0, 0,
+ax_anim 16, 0, 168, 1, -3, 1, -1,
+ax_anim 6, 0, 168, 0, -2, 0, 0,
+ax_anim_terminator
+sMarowakAnims_8_5:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 6, 0, 170, 0, -2, 0, 0,
+ax_anim 16, 0, 170, 0, -3, 0, -1,
+ax_anim 6, 0, 170, 0, -2, 0, 0,
+ax_anim_terminator
+sMarowakAnims_8_6:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 6, 0, 174, 0, -2, 0, 0,
+ax_anim 16, 0, 174, -1, -3, -1, -1,
+ax_anim 6, 0, 174, 0, -2, 0, 0,
+ax_anim_terminator
+sMarowakAnims_8_7:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 6, 0, 176, -1, 0, 0, 0,
+ax_anim 16, 0, 176, -2, 0, -1, 0,
+ax_anim 6, 0, 176, -1, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_8_8:
+ax_anim 40, 0, 178, 0, 0, 0, 0,
+ax_anim 6, 0, 179, 0, 0, 0, 0,
+ax_anim 16, 0, 179, -1, 1, -1, 1,
+ax_anim 6, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarowakAnims_9_1:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 6, 3, 6, 3,
+ax_anim 2, 0, 183, 8, 9, 8, 9,
+ax_anim 2, 0, 184, 7, 15, 7, 15,
+ax_anim 3, 0, 185, 0, 18, 0, 18,
+ax_anim 2, 3, 186, -7, 15, -7, 15,
+ax_anim 2, 0, 187, -8, 9, -8, 9,
+ax_anim 1, 0, 188, -6, 3, -6, 3,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_9_2:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 8, 0, 8, 0,
+ax_anim 2, 0, 182, 17, 3, 17, 3,
+ax_anim 2, 0, 183, 19, 10, 19, 10,
+ax_anim 3, 0, 184, 19, 19, 19, 19,
+ax_anim 2, 3, 185, 11, 19, 11, 19,
+ax_anim 2, 0, 186, 3, 15, 3, 15,
+ax_anim 1, 0, 187, 0, 7, 0, 7,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_9_3:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 3, -5, 3, -5,
+ax_anim 2, 0, 181, 11, -6, 11, -6,
+ax_anim 2, 0, 182, 16, -5, 16, -5,
+ax_anim 3, 0, 183, 20, -2, 20, -2,
+ax_anim 2, 3, 184, 16, 4, 16, 4,
+ax_anim 2, 0, 185, 12, 5, 12, 5,
+ax_anim 1, 0, 186, 4, 5, 4, 5,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_9_4:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -1, -8, -1, -8,
+ax_anim 2, 0, 188, 4, -16, 4, -16,
+ax_anim 2, 0, 181, 12, -22, 12, -22,
+ax_anim 3, 0, 182, 20, -21, 20, -21,
+ax_anim 2, 3, 183, 21, -13, 21, -13,
+ax_anim 2, 0, 184, 17, -4, 17, -4,
+ax_anim 1, 0, 185, 7, -1, 7, -1,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_9_5:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, -4, -8, -4,
+ax_anim 2, 0, 187, -9, -12, -9, -12,
+ax_anim 2, 0, 188, -7, -18, -7, -18,
+ax_anim 3, 0, 181, 0, -22, 0, -22,
+ax_anim 2, 3, 182, 7, -18, 7, -18,
+ax_anim 2, 0, 183, 9, -10, 9, -10,
+ax_anim 1, 0, 184, 8, -4, 8, -4,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_9_6:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 1, -8, 1, -8,
+ax_anim 2, 0, 182, -4, -16, -4, -16,
+ax_anim 2, 0, 181, -12, -22, -12, -22,
+ax_anim 3, 0, 188, -20, -20, -20, -20,
+ax_anim 2, 3, 187, -21, -13, -21, -13,
+ax_anim 2, 0, 186, -17, -4, -17, -4,
+ax_anim 1, 0, 185, -7, -1, -7, -1,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_9_7:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 182, -3, -5, -3, -5,
+ax_anim 2, 0, 181, -11, -6, -11, -6,
+ax_anim 2, 0, 188, -16, -5, -16, -5,
+ax_anim 3, 0, 187, -20, -2, -20, -2,
+ax_anim 2, 3, 186, -16, 4, -16, 4,
+ax_anim 2, 0, 185, -12, 5, -12, 5,
+ax_anim 1, 0, 184, -4, 5, -4, 5,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_9_8:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 181, -8, 0, -8, 0,
+ax_anim 2, 0, 188, -17, 3, -17, 3,
+ax_anim 2, 0, 187, -19, 10, -19, 10,
+ax_anim 3, 0, 186, -19, 19, -19, 19,
+ax_anim 2, 3, 185, -11, 19, -11, 19,
+ax_anim 2, 0, 184, -3, 15, -3, 15,
+ax_anim 1, 0, 183, 0, 7, 0, 7,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarowakAnims_10_1:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 6, 0, 6, 0,
+ax_anim 2, 0, 189, -6, 0, -6, 0,
+ax_anim 2, 0, 189, 10, 0, 10, 0,
+ax_anim 2, 0, 189, -10, 0, -10, 0,
+ax_anim 2, 0, 189, 12, 0, 12, 0,
+ax_anim 3, 0, 189, -12, 0, -12, 0,
+ax_anim 3, 0, 189, 13, 0, 13, 0,
+ax_anim 3, 0, 189, -13, 0, -13, 0,
+ax_anim 2, 0, 189, 12, 0, 12, 0,
+ax_anim 3, 0, 189, -12, 0, -12, 0,
+ax_anim 2, 0, 189, 10, 0, 10, 0,
+ax_anim 2, 0, 189, -10, 0, -10, 0,
+ax_anim 2, 0, 189, 6, 0, 6, 0,
+ax_anim 2, 0, 189, -6, 0, -6, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_10_2:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, -6, 6, -6,
+ax_anim 2, 0, 190, -6, 6, -6, 6,
+ax_anim 2, 0, 190, 10, -10, 10, -10,
+ax_anim 2, 0, 190, -10, 10, -10, 10,
+ax_anim 2, 0, 190, 12, -12, 12, -12,
+ax_anim 3, 0, 190, -12, 12, -12, 12,
+ax_anim 3, 0, 190, 13, -13, 13, -13,
+ax_anim 3, 0, 190, -13, 13, -13, 13,
+ax_anim 2, 0, 190, 12, -12, 12, -12,
+ax_anim 3, 0, 190, -12, 12, -12, 12,
+ax_anim 2, 0, 190, 10, -10, 10, -10,
+ax_anim 2, 0, 190, -10, 10, -10, 10,
+ax_anim 2, 0, 190, 6, -6, 6, -6,
+ax_anim 2, 0, 190, -6, 6, -6, 6,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_10_3:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -6, 0, -6,
+ax_anim 2, 0, 191, 0, 6, 0, 6,
+ax_anim 2, 0, 191, 0, -10, 0, -10,
+ax_anim 2, 0, 191, 0, 10, 0, 10,
+ax_anim 2, 0, 191, 0, -12, 0, -12,
+ax_anim 3, 0, 191, 0, 12, 0, 12,
+ax_anim 3, 0, 191, 0, -13, 0, -13,
+ax_anim 3, 0, 191, 0, 13, 0, 13,
+ax_anim 2, 0, 191, 0, -12, 0, -12,
+ax_anim 3, 0, 191, 0, 12, 0, 12,
+ax_anim 2, 0, 191, 0, -10, 0, -10,
+ax_anim 2, 0, 191, 0, 10, 0, 10,
+ax_anim 2, 0, 191, 0, -6, 0, -6,
+ax_anim 2, 0, 191, 0, 6, 0, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_10_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -6, -6, -6, -6,
+ax_anim 2, 0, 192, 6, 6, 6, 6,
+ax_anim 2, 0, 192, -10, -10, -10, -10,
+ax_anim 2, 0, 192, 10, 10, 10, 10,
+ax_anim 2, 0, 192, -12, -12, -12, -12,
+ax_anim 3, 0, 192, 12, 12, 12, 12,
+ax_anim 3, 0, 192, -13, -13, -13, -13,
+ax_anim 3, 0, 192, 13, 13, 13, 13,
+ax_anim 2, 0, 192, -12, -12, -12, -12,
+ax_anim 3, 0, 192, 12, 12, 12, 12,
+ax_anim 2, 0, 192, -10, -10, -10, -10,
+ax_anim 2, 0, 192, 10, 10, 10, 10,
+ax_anim 2, 0, 192, -6, -6, -6, -6,
+ax_anim 2, 0, 192, 6, 6, 6, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_10_5:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 6, 0, 6, 0,
+ax_anim 2, 0, 193, -6, 0, -6, 0,
+ax_anim 2, 0, 193, 10, 0, 10, 0,
+ax_anim 2, 0, 193, -10, 0, -10, 0,
+ax_anim 2, 0, 193, 12, 0, 12, 0,
+ax_anim 3, 0, 193, -12, 0, -12, 0,
+ax_anim 3, 0, 193, 13, 0, 13, 0,
+ax_anim 3, 0, 193, -13, 0, -13, 0,
+ax_anim 2, 0, 193, 12, 0, 12, 0,
+ax_anim 3, 0, 193, -12, 0, -12, 0,
+ax_anim 2, 0, 193, 10, 0, 10, 0,
+ax_anim 2, 0, 193, -10, 0, -10, 0,
+ax_anim 2, 0, 193, 6, 0, 6, 0,
+ax_anim 2, 0, 193, -6, 0, -6, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_10_6:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, -6, 6, -6,
+ax_anim 2, 0, 194, -6, 6, -6, 6,
+ax_anim 2, 0, 194, 10, -10, 10, -10,
+ax_anim 2, 0, 194, -10, 10, -10, 10,
+ax_anim 2, 0, 194, 12, -12, 12, -12,
+ax_anim 3, 0, 194, -12, 12, -12, 12,
+ax_anim 3, 0, 194, 13, -13, 13, -13,
+ax_anim 3, 0, 194, -13, 13, -13, 13,
+ax_anim 2, 0, 194, 12, -12, 12, -12,
+ax_anim 3, 0, 194, -12, 12, -12, 12,
+ax_anim 2, 0, 194, 10, -10, 10, -10,
+ax_anim 2, 0, 194, -10, 10, -10, 10,
+ax_anim 2, 0, 194, 6, -6, 6, -6,
+ax_anim 2, 0, 194, -6, 6, -6, 6,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_10_7:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, -6, 0, -6,
+ax_anim 2, 0, 195, 0, 6, 0, 6,
+ax_anim 2, 0, 195, 0, -10, 0, -10,
+ax_anim 2, 0, 195, 0, 10, 0, 10,
+ax_anim 2, 0, 195, 0, -12, 0, -12,
+ax_anim 3, 0, 195, 0, 12, 0, 12,
+ax_anim 3, 0, 195, 0, -13, 0, -13,
+ax_anim 3, 0, 195, 0, 13, 0, 13,
+ax_anim 2, 0, 195, 0, -12, 0, -12,
+ax_anim 3, 0, 195, 0, 12, 0, 12,
+ax_anim 2, 0, 195, 0, -10, 0, -10,
+ax_anim 2, 0, 195, 0, 10, 0, 10,
+ax_anim 2, 0, 195, 0, -6, 0, -6,
+ax_anim 2, 0, 195, 0, 6, 0, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_10_8:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, -6, -6, -6, -6,
+ax_anim 2, 0, 196, 6, 6, 6, 6,
+ax_anim 2, 0, 196, -10, -10, -10, -10,
+ax_anim 2, 0, 196, 10, 10, 10, 10,
+ax_anim 2, 0, 196, -12, -12, -12, -12,
+ax_anim 3, 0, 196, 12, 12, 12, 12,
+ax_anim 3, 0, 196, -13, -13, -13, -13,
+ax_anim 3, 0, 196, 13, 13, 13, 13,
+ax_anim 2, 0, 196, -12, -12, -12, -12,
+ax_anim 3, 0, 196, 12, 12, 12, 12,
+ax_anim 2, 0, 196, -10, -10, -10, -10,
+ax_anim 2, 0, 196, 10, 10, 10, 10,
+ax_anim 2, 0, 196, -6, -6, -6, -6,
+ax_anim 2, 0, 196, 6, 6, 6, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarowakAnims_11_1:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_11_2:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_11_3:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_11_4:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -17, 0, 0,
+ax_anim 1, 0, 208, 0, -11, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_11_5:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -22, 0, 0,
+ax_anim 2, 0, 211, 0, -18, 0, 0,
+ax_anim 1, 0, 211, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_11_6:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -17, 0, 0,
+ax_anim 1, 0, 214, 0, -11, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_11_7:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_11_8:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarowakAnims_12_1:
+ax_anim 2, 0, 221, 1, 0, 1, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, 0, 1, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, 0, 1, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, 0, 1, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, 0, 1, 0,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_12_2:
+ax_anim 2, 0, 228, 1, -1, 1, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, -1, 1, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, -1, 1, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, -1, 1, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 1, -1, 1, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_12_3:
+ax_anim 2, 0, 227, 0, -1, 0, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, -1, 0, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, -1, 0, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, -1, 0, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, -1, 0, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_12_4:
+ax_anim 2, 0, 226, -1, -1, -1, -1,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, -1, -1, -1, -1,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, -1, -1, -1, -1,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, -1, -1, -1, -1,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, -1, -1, -1, -1,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_12_5:
+ax_anim 2, 0, 225, 1, 0, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, 0, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, 0, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, 0, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, 0, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_12_6:
+ax_anim 2, 0, 224, 1, -1, 1, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, -1, 1, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, -1, 1, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, -1, 1, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 1, -1, 1, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_12_7:
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, -1, 0, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_12_8:
+ax_anim 2, 0, 222, -1, -1, -1, -1,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, -1, -1, -1,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, -1, -1, -1,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, -1, -1, -1,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, -1, -1, -1,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarowakAnims_13_1:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_13_2:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_13_3:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_13_4:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_13_5:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_13_6:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_13_7:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakAnims_13_8:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMarowakGfx1:
+.incbin "baserom.gba", 0x981B08, 0x200
+sMarowakSprites1:
+ax_sprite sMarowakGfx1, 0x200
+ax_sprite_terminator
+sMarowakGfx2:
+.incbin "baserom.gba", 0x981D18, 0x200
+sMarowakSprites2:
+ax_sprite sMarowakGfx2, 0x200
+ax_sprite_terminator
+sMarowakGfx3:
+.incbin "baserom.gba", 0x981F28, 0x200
+sMarowakSprites3:
+ax_sprite sMarowakGfx3, 0x200
+ax_sprite_terminator
+sMarowakGfx4:
+.incbin "baserom.gba", 0x982138, 0x200
+sMarowakSprites4:
+ax_sprite sMarowakGfx4, 0x200
+ax_sprite_terminator
+sMarowakGfx5:
+.incbin "baserom.gba", 0x982348, 0x200
+sMarowakSprites5:
+ax_sprite sMarowakGfx5, 0x200
+ax_sprite_terminator
+sMarowakGfx6:
+.incbin "baserom.gba", 0x982558, 0x200
+sMarowakSprites6:
+ax_sprite sMarowakGfx6, 0x200
+ax_sprite_terminator
+sMarowakGfx7:
+.incbin "baserom.gba", 0x982768, 0x200
+sMarowakSprites7:
+ax_sprite sMarowakGfx7, 0x200
+ax_sprite_terminator
+sMarowakGfx8:
+.incbin "baserom.gba", 0x982978, 0x200
+sMarowakSprites8:
+ax_sprite sMarowakGfx8, 0x200
+ax_sprite_terminator
+sMarowakGfx9:
+.incbin "baserom.gba", 0x982B88, 0x200
+sMarowakSprites9:
+ax_sprite sMarowakGfx9, 0x200
+ax_sprite_terminator
+sMarowakGfx10:
+.incbin "baserom.gba", 0x982D98, 0x200
+sMarowakSprites10:
+ax_sprite sMarowakGfx10, 0x200
+ax_sprite_terminator
+sMarowakGfx11:
+.incbin "baserom.gba", 0x982FA8, 0x200
+sMarowakSprites11:
+ax_sprite sMarowakGfx11, 0x200
+ax_sprite_terminator
+sMarowakGfx12:
+.incbin "baserom.gba", 0x9831B8, 0x200
+sMarowakSprites12:
+ax_sprite sMarowakGfx12, 0x200
+ax_sprite_terminator
+sMarowakGfx13:
+.incbin "baserom.gba", 0x9833C8, 0x200
+sMarowakSprites13:
+ax_sprite sMarowakGfx13, 0x200
+ax_sprite_terminator
+sMarowakGfx14:
+.incbin "baserom.gba", 0x9835D8, 0x200
+sMarowakSprites14:
+ax_sprite sMarowakGfx14, 0x200
+ax_sprite_terminator
+sMarowakGfx15:
+.incbin "baserom.gba", 0x9837E8, 0x200
+sMarowakSprites15:
+ax_sprite sMarowakGfx15, 0x200
+ax_sprite_terminator
+sMarowakGfx16:
+.incbin "baserom.gba", 0x9839F8, 0x200
+sMarowakSprites16:
+ax_sprite sMarowakGfx16, 0x200
+ax_sprite_terminator
+sMarowakGfx17:
+.incbin "baserom.gba", 0x983C08, 0x200
+sMarowakSprites17:
+ax_sprite sMarowakGfx17, 0x200
+ax_sprite_terminator
+sMarowakGfx18:
+.incbin "baserom.gba", 0x983E18, 0x200
+sMarowakSprites18:
+ax_sprite sMarowakGfx18, 0x200
+ax_sprite_terminator
+sMarowakGfx19:
+.incbin "baserom.gba", 0x984028, 0x200
+sMarowakSprites19:
+ax_sprite sMarowakGfx19, 0x200
+ax_sprite_terminator
+sMarowakGfx20:
+.incbin "baserom.gba", 0x984238, 0x200
+sMarowakSprites20:
+ax_sprite sMarowakGfx20, 0x200
+ax_sprite_terminator
+sMarowakGfx21:
+.incbin "baserom.gba", 0x984448, 0x200
+sMarowakSprites21:
+ax_sprite sMarowakGfx21, 0x200
+ax_sprite_terminator
+sMarowakGfx22:
+.incbin "baserom.gba", 0x984658, 0x200
+sMarowakSprites22:
+ax_sprite sMarowakGfx22, 0x200
+ax_sprite_terminator
+sMarowakGfx23:
+.incbin "baserom.gba", 0x984868, 0x200
+sMarowakSprites23:
+ax_sprite sMarowakGfx23, 0x200
+ax_sprite_terminator
+sMarowakGfx24:
+.incbin "baserom.gba", 0x984A78, 0x200
+sMarowakSprites24:
+ax_sprite sMarowakGfx24, 0x200
+ax_sprite_terminator
+sMarowakGfx25:
+.incbin "baserom.gba", 0x984C88, 0x40
+sMarowakGfx25_1:
+.incbin "baserom.gba", 0x984CC8, 0x80
+sMarowakGfx25_2:
+.incbin "baserom.gba", 0x984D48, 0x60
+sMarowakGfx25_3:
+.incbin "baserom.gba", 0x984DA8, 0x60
+sMarowakSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx25_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx25_3, 0x60
+ax_sprite_terminator
+sMarowakGfx26:
+.incbin "baserom.gba", 0x984E50, 0x20
+sMarowakGfx26_1:
+.incbin "baserom.gba", 0x984E70, 0x20
+sMarowakGfx26_2:
+.incbin "baserom.gba", 0x984E90, 0x40
+sMarowakGfx26_3:
+.incbin "baserom.gba", 0x984ED0, 0x60
+sMarowakSprites26:
+ax_sprite sMarowakGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx26_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx26_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx27:
+.incbin "baserom.gba", 0x984F78, 0x40
+sMarowakGfx27_1:
+.incbin "baserom.gba", 0x984FB8, 0xE0
+sMarowakGfx27_2:
+.incbin "baserom.gba", 0x985098, 0x60
+sMarowakSprites27:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx27_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx28:
+.incbin "baserom.gba", 0x985138, 0x40
+sMarowakGfx28_1:
+.incbin "baserom.gba", 0x985178, 0xE0
+sMarowakGfx28_2:
+.incbin "baserom.gba", 0x985258, 0x60
+sMarowakSprites28:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx28_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx28_2, 0x60
+ax_sprite_terminator
+sMarowakGfx29:
+.incbin "baserom.gba", 0x9852F0, 0x40
+sMarowakGfx29_1:
+.incbin "baserom.gba", 0x985330, 0x20
+sMarowakGfx29_2:
+.incbin "baserom.gba", 0x985350, 0x20
+sMarowakGfx29_3:
+.incbin "baserom.gba", 0x985370, 0x60
+sMarowakSprites29:
+ax_sprite 0, 0x80
+ax_sprite sMarowakGfx29, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx29_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx29_3, 0x60
+ax_sprite_terminator
+sMarowakGfx30:
+.incbin "baserom.gba", 0x985418, 0x20
+sMarowakGfx30_1:
+.incbin "baserom.gba", 0x985438, 0x160
+sMarowakSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx30, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx30_1, 0x160
+ax_sprite_terminator
+sMarowakGfx31:
+.incbin "baserom.gba", 0x9855C0, 0x60
+sMarowakGfx31_1:
+.incbin "baserom.gba", 0x985620, 0x80
+sMarowakGfx31_2:
+.incbin "baserom.gba", 0x9856A0, 0xC0
+sMarowakSprites31:
+ax_sprite sMarowakGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx31_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx31_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx32:
+.incbin "baserom.gba", 0x985798, 0x60
+sMarowakGfx32_1:
+.incbin "baserom.gba", 0x9857F8, 0x60
+sMarowakGfx32_2:
+.incbin "baserom.gba", 0x985858, 0x40
+sMarowakGfx32_3:
+.incbin "baserom.gba", 0x985898, 0x40
+sMarowakSprites32:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx32_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx33:
+.incbin "baserom.gba", 0x985928, 0x40
+sMarowakGfx33_1:
+.incbin "baserom.gba", 0x985968, 0x20
+sMarowakGfx33_2:
+.incbin "baserom.gba", 0x985988, 0x60
+sMarowakGfx33_3:
+.incbin "baserom.gba", 0x9859E8, 0x40
+sMarowakSprites33:
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx33, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx33_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx34:
+.incbin "baserom.gba", 0x985A78, 0x60
+sMarowakGfx34_1:
+.incbin "baserom.gba", 0x985AD8, 0x60
+sMarowakGfx34_2:
+.incbin "baserom.gba", 0x985B38, 0x80
+sMarowakGfx34_3:
+.incbin "baserom.gba", 0x985BB8, 0x60
+sMarowakSprites34:
+ax_sprite sMarowakGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx34_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx34_3, 0x60
+ax_sprite_terminator
+sMarowakGfx35:
+.incbin "baserom.gba", 0x985C58, 0x20
+sMarowakGfx35_1:
+.incbin "baserom.gba", 0x985C78, 0xC0
+sMarowakSprites35:
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx35, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx35_1, 0xc0
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMarowakGfx36:
+.incbin "baserom.gba", 0x985D68, 0x60
+sMarowakGfx36_1:
+.incbin "baserom.gba", 0x985DC8, 0xE0
+sMarowakGfx36_2:
+.incbin "baserom.gba", 0x985EA8, 0x60
+sMarowakSprites36:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx36_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx36_2, 0x60
+ax_sprite_terminator
+sMarowakGfx37:
+.incbin "baserom.gba", 0x985F40, 0x100
+sMarowakGfx37_1:
+.incbin "baserom.gba", 0x986040, 0x40
+sMarowakGfx37_2:
+.incbin "baserom.gba", 0x986080, 0x80
+sMarowakSprites37:
+ax_sprite sMarowakGfx37, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx37_2, 0x80
+ax_sprite_terminator
+sMarowakGfx38:
+.incbin "baserom.gba", 0x986130, 0xA0
+sMarowakGfx38_1:
+.incbin "baserom.gba", 0x9861D0, 0x20
+sMarowakSprites38:
+ax_sprite sMarowakGfx38, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx38_1, 0x20
+ax_sprite_terminator
+sMarowakGfx39:
+.incbin "baserom.gba", 0x986210, 0x40
+sMarowakGfx39_1:
+.incbin "baserom.gba", 0x986250, 0x60
+sMarowakGfx39_2:
+.incbin "baserom.gba", 0x9862B0, 0x80
+sMarowakGfx39_3:
+.incbin "baserom.gba", 0x986330, 0x60
+sMarowakSprites39:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx39_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx39_3, 0x60
+ax_sprite_terminator
+sMarowakGfx40:
+.incbin "baserom.gba", 0x9863D8, 0x40
+sMarowakGfx40_1:
+.incbin "baserom.gba", 0x986418, 0x160
+sMarowakSprites40:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx40_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx41:
+.incbin "baserom.gba", 0x9865A8, 0x60
+sMarowakGfx41_1:
+.incbin "baserom.gba", 0x986608, 0x20
+sMarowakGfx41_2:
+.incbin "baserom.gba", 0x986628, 0x20
+sMarowakGfx41_3:
+.incbin "baserom.gba", 0x986648, 0x20
+sMarowakSprites41:
+ax_sprite sMarowakGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx41_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx41_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx41_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMarowakGfx42:
+.incbin "baserom.gba", 0x9866B0, 0x40
+sMarowakGfx42_1:
+.incbin "baserom.gba", 0x9866F0, 0x180
+sMarowakSprites42:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx42_1, 0x180
+ax_sprite_terminator
+sMarowakGfx43:
+.incbin "baserom.gba", 0x986898, 0x40
+sMarowakGfx43_1:
+.incbin "baserom.gba", 0x9868D8, 0x160
+sMarowakSprites43:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx43_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx44:
+.incbin "baserom.gba", 0x986A68, 0x60
+sMarowakGfx44_1:
+.incbin "baserom.gba", 0x986AC8, 0x20
+sMarowakGfx44_2:
+.incbin "baserom.gba", 0x986AE8, 0x20
+sMarowakSprites44:
+ax_sprite sMarowakGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx44_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx44_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx45:
+.incbin "baserom.gba", 0x986B40, 0x40
+sMarowakGfx45_1:
+.incbin "baserom.gba", 0x986B80, 0x160
+sMarowakSprites45:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx45_1, 0x160
+ax_sprite_terminator
+sMarowakGfx46:
+.incbin "baserom.gba", 0x986D08, 0x40
+sMarowakGfx46_1:
+.incbin "baserom.gba", 0x986D48, 0x80
+sMarowakGfx46_2:
+.incbin "baserom.gba", 0x986DC8, 0x60
+sMarowakGfx46_3:
+.incbin "baserom.gba", 0x986E28, 0x60
+sMarowakSprites46:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx46_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx46_3, 0x60
+ax_sprite_terminator
+sMarowakGfx47:
+.incbin "baserom.gba", 0x986ED0, 0x60
+sMarowakGfx47_1:
+.incbin "baserom.gba", 0x986F30, 0x20
+sMarowakGfx47_2:
+.incbin "baserom.gba", 0x986F50, 0x40
+sMarowakSprites47:
+ax_sprite sMarowakGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx47_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx47_2, 0x40
+ax_sprite_terminator
+sMarowakGfx48:
+.incbin "baserom.gba", 0x986FC0, 0x60
+sMarowakGfx48_1:
+.incbin "baserom.gba", 0x987020, 0x100
+sMarowakGfx48_2:
+.incbin "baserom.gba", 0x987120, 0x60
+sMarowakSprites48:
+ax_sprite sMarowakGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx48_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx48_2, 0x60
+ax_sprite_terminator
+sMarowakGfx49:
+.incbin "baserom.gba", 0x9871B0, 0x20
+sMarowakGfx49_1:
+.incbin "baserom.gba", 0x9871D0, 0x80
+sMarowakSprites49:
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx49, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx49_1, 0x80
+ax_sprite_terminator
+sMarowakGfx50:
+.incbin "baserom.gba", 0x987278, 0x40
+sMarowakGfx50_1:
+.incbin "baserom.gba", 0x9872B8, 0xE0
+sMarowakGfx50_2:
+.incbin "baserom.gba", 0x987398, 0x60
+sMarowakSprites50:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx50_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx51:
+.incbin "baserom.gba", 0x987438, 0x40
+sMarowakGfx51_1:
+.incbin "baserom.gba", 0x987478, 0x20
+sMarowakGfx51_2:
+.incbin "baserom.gba", 0x987498, 0x20
+sMarowakSprites51:
+ax_sprite sMarowakGfx51, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx51_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx51_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMarowakGfx52:
+.incbin "baserom.gba", 0x9874F0, 0x20
+sMarowakGfx52_1:
+.incbin "baserom.gba", 0x987510, 0x140
+sMarowakSprites52:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx52, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMarowakGfx52_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx53:
+.incbin "baserom.gba", 0x987680, 0x60
+sMarowakGfx53_1:
+.incbin "baserom.gba", 0x9876E0, 0x40
+sMarowakSprites53:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx53, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx53_1, 0x40
+ax_sprite_terminator
+sMarowakGfx54:
+.incbin "baserom.gba", 0x987748, 0x60
+sMarowakGfx54_1:
+.incbin "baserom.gba", 0x9877A8, 0x20
+sMarowakSprites54:
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx54_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarowakGfx55:
+.incbin "baserom.gba", 0x9877F8, 0x40
+sMarowakGfx55_1:
+.incbin "baserom.gba", 0x987838, 0x160
+sMarowakSprites55:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx55, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx55_1, 0x160
+ax_sprite_terminator
+sMarowakGfx56:
+.incbin "baserom.gba", 0x9879C0, 0x60
+sMarowakGfx56_1:
+.incbin "baserom.gba", 0x987A20, 0x40
+sMarowakSprites56:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx56, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx56_1, 0x40
+ax_sprite_terminator
+sMarowakGfx57:
+.incbin "baserom.gba", 0x987A88, 0x60
+sMarowakGfx57_1:
+.incbin "baserom.gba", 0x987AE8, 0x60
+sMarowakGfx57_2:
+.incbin "baserom.gba", 0x987B48, 0x60
+sMarowakGfx57_3:
+.incbin "baserom.gba", 0x987BA8, 0x60
+sMarowakSprites57:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx57, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx57_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx57_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx57_3, 0x60
+ax_sprite_terminator
+sMarowakGfx58:
+.incbin "baserom.gba", 0x987C50, 0x40
+sMarowakGfx58_1:
+.incbin "baserom.gba", 0x987C90, 0x60
+sMarowakGfx58_2:
+.incbin "baserom.gba", 0x987CF0, 0x60
+sMarowakGfx58_3:
+.incbin "baserom.gba", 0x987D50, 0x60
+sMarowakSprites58:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx58, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx58_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx58_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx58_3, 0x60
+ax_sprite_terminator
+sMarowakGfx59:
+.incbin "baserom.gba", 0x987DF8, 0x60
+sMarowakGfx59_1:
+.incbin "baserom.gba", 0x987E58, 0x40
+sMarowakSprites59:
+ax_sprite sMarowakGfx59, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx59_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMarowakGfx60:
+.incbin "baserom.gba", 0x987EC0, 0x80
+sMarowakSprites60:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx60, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMarowakGfx61:
+.incbin "baserom.gba", 0x987F60, 0x40
+sMarowakGfx61_1:
+.incbin "baserom.gba", 0x987FA0, 0x100
+sMarowakGfx61_2:
+.incbin "baserom.gba", 0x9880A0, 0x60
+sMarowakSprites61:
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx61, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx61_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx61_2, 0x60
+ax_sprite_terminator
+sMarowakGfx62:
+.incbin "baserom.gba", 0x988138, 0x20
+sMarowakGfx62_1:
+.incbin "baserom.gba", 0x988158, 0x20
+sMarowakGfx62_2:
+.incbin "baserom.gba", 0x988178, 0x40
+sMarowakSprites62:
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx62, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx62_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx62_2, 0x40
+ax_sprite_terminator
+sMarowakGfx63:
+.incbin "baserom.gba", 0x9881F0, 0x20
+sMarowakGfx63_1:
+.incbin "baserom.gba", 0x988210, 0x100
+sMarowakGfx63_2:
+.incbin "baserom.gba", 0x988310, 0x60
+sMarowakSprites63:
+ax_sprite 0, 0x40
+ax_sprite sMarowakGfx63, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx63_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMarowakGfx63_2, 0x60
+ax_sprite_terminator
+sMarowakGfx64:
+.incbin "baserom.gba", 0x9883A8, 0x200
+sMarowakSprites64:
+ax_sprite sMarowakGfx64, 0x200
+ax_sprite_terminator
+sMarowakGfx65:
+.incbin "baserom.gba", 0x9885B8, 0x200
+sMarowakSprites65:
+ax_sprite sMarowakGfx65, 0x200
+ax_sprite_terminator
+sMarowakGfx66:
+.incbin "baserom.gba", 0x9887C8, 0x200
+sMarowakSprites66:
+ax_sprite sMarowakGfx66, 0x200
+ax_sprite_terminator
+sMarowakGfx67:
+.incbin "baserom.gba", 0x9889D8, 0x200
+sMarowakSprites67:
+ax_sprite sMarowakGfx67, 0x200
+ax_sprite_terminator
+sMarowakGfx68:
+.incbin "baserom.gba", 0x988BE8, 0x200
+sMarowakSprites68:
+ax_sprite sMarowakGfx68, 0x200
+ax_sprite_terminator
+sMarowakGfx69:
+.incbin "baserom.gba", 0x988DF8, 0x200
+sMarowakSprites69:
+ax_sprite sMarowakGfx69, 0x200
+ax_sprite_terminator
+sMarowakGfx70:
+.incbin "baserom.gba", 0x989008, 0x200
+sMarowakSprites70:
+ax_sprite sMarowakGfx70, 0x200
+ax_sprite_terminator
+sAxPosesMarowak:
+.4byte sMarowakPose1
+.4byte sMarowakPose2
+.4byte sMarowakPose3
+.4byte sMarowakPose4
+.4byte sMarowakPose5
+.4byte sMarowakPose6
+.4byte sMarowakPose7
+.4byte sMarowakPose8
+.4byte sMarowakPose9
+.4byte sMarowakPose10
+.4byte sMarowakPose11
+.4byte sMarowakPose12
+.4byte sMarowakPose13
+.4byte sMarowakPose14
+.4byte sMarowakPose15
+.4byte sMarowakPose16
+.4byte sMarowakPose17
+.4byte sMarowakPose18
+.4byte sMarowakPose19
+.4byte sMarowakPose20
+.4byte sMarowakPose21
+.4byte sMarowakPose22
+.4byte sMarowakPose23
+.4byte sMarowakPose24
+.4byte sMarowakPose25
+.4byte sMarowakPose26
+.4byte sMarowakPose27
+.4byte sMarowakPose28
+.4byte sMarowakPose29
+.4byte sMarowakPose30
+.4byte sMarowakPose31
+.4byte sMarowakPose32
+.4byte sMarowakPose33
+.4byte sMarowakPose34
+.4byte sMarowakPose35
+.4byte sMarowakPose36
+.4byte sMarowakPose37
+.4byte sMarowakPose38
+.4byte sMarowakPose39
+.4byte sMarowakPose40
+.4byte sMarowakPose41
+.4byte sMarowakPose42
+.4byte sMarowakPose43
+.4byte sMarowakPose44
+.4byte sMarowakPose45
+.4byte sMarowakPose46
+.4byte sMarowakPose47
+.4byte sMarowakPose48
+.4byte sMarowakPose49
+.4byte sMarowakPose50
+.4byte sMarowakPose51
+.4byte sMarowakPose52
+.4byte sMarowakPose53
+.4byte sMarowakPose54
+.4byte sMarowakPose55
+.4byte sMarowakPose56
+.4byte sMarowakPose57
+.4byte sMarowakPose58
+.4byte sMarowakPose59
+.4byte sMarowakPose60
+.4byte sMarowakPose61
+.4byte sMarowakPose62
+.4byte sMarowakPose63
+.4byte sMarowakPose64
+.4byte sMarowakPose65
+.4byte sMarowakPose66
+.4byte sMarowakPose67
+.4byte sMarowakPose68
+.4byte sMarowakPose69
+.4byte sMarowakPose70
+.4byte sMarowakPose71
+.4byte sMarowakPose72
+.4byte sMarowakPose73
+.4byte sMarowakPose74
+.4byte sMarowakPose75
+.4byte sMarowakPose76
+.4byte sMarowakPose77
+.4byte sMarowakPose78
+.4byte sMarowakPose79
+.4byte sMarowakPose80
+.4byte sMarowakPose81
+.4byte sMarowakPose82
+.4byte sMarowakPose83
+.4byte sMarowakPose84
+.4byte sMarowakPose85
+.4byte sMarowakPose86
+.4byte sMarowakPose87
+.4byte sMarowakPose88
+.4byte sMarowakPose89
+.4byte sMarowakPose90
+.4byte sMarowakPose91
+.4byte sMarowakPose92
+.4byte sMarowakPose93
+.4byte sMarowakPose94
+.4byte sMarowakPose95
+.4byte sMarowakPose96
+.4byte sMarowakPose97
+.4byte sMarowakPose98
+.4byte sMarowakPose99
+.4byte sMarowakPose100
+.4byte sMarowakPose101
+.4byte sMarowakPose102
+.4byte sMarowakPose103
+.4byte sMarowakPose104
+.4byte sMarowakPose105
+.4byte sMarowakPose106
+.4byte sMarowakPose107
+.4byte sMarowakPose108
+.4byte sMarowakPose109
+.4byte sMarowakPose110
+.4byte sMarowakPose111
+.4byte sMarowakPose112
+.4byte sMarowakPose113
+.4byte sMarowakPose114
+.4byte sMarowakPose115
+.4byte sMarowakPose116
+.4byte sMarowakPose117
+.4byte sMarowakPose118
+.4byte sMarowakPose119
+.4byte sMarowakPose120
+.4byte sMarowakPose121
+.4byte sMarowakPose122
+.4byte sMarowakPose123
+.4byte sMarowakPose124
+.4byte sMarowakPose125
+.4byte sMarowakPose126
+.4byte sMarowakPose127
+.4byte sMarowakPose128
+.4byte sMarowakPose129
+.4byte sMarowakPose130
+.4byte sMarowakPose131
+.4byte sMarowakPose132
+.4byte sMarowakPose133
+.4byte sMarowakPose134
+.4byte sMarowakPose135
+.4byte sMarowakPose136
+.4byte sMarowakPose137
+.4byte sMarowakPose138
+.4byte sMarowakPose139
+.4byte sMarowakPose140
+.4byte sMarowakPose141
+.4byte sMarowakPose142
+.4byte sMarowakPose143
+.4byte sMarowakPose144
+.4byte sMarowakPose145
+.4byte sMarowakPose146
+.4byte sMarowakPose147
+.4byte sMarowakPose148
+.4byte sMarowakPose149
+.4byte sMarowakPose150
+.4byte sMarowakPose151
+.4byte sMarowakPose152
+.4byte sMarowakPose153
+.4byte sMarowakPose154
+.4byte sMarowakPose155
+.4byte sMarowakPose156
+.4byte sMarowakPose157
+.4byte sMarowakPose158
+.4byte sMarowakPose159
+.4byte sMarowakPose160
+.4byte sMarowakPose161
+.4byte sMarowakPose162
+.4byte sMarowakPose163
+.4byte sMarowakPose164
+.4byte sMarowakPose165
+.4byte sMarowakPose166
+.4byte sMarowakPose167
+.4byte sMarowakPose168
+.4byte sMarowakPose169
+.4byte sMarowakPose170
+.4byte sMarowakPose171
+.4byte sMarowakPose172
+.4byte sMarowakPose173
+.4byte sMarowakPose174
+.4byte sMarowakPose175
+.4byte sMarowakPose176
+.4byte sMarowakPose177
+.4byte sMarowakPose178
+.4byte sMarowakPose179
+.4byte sMarowakPose180
+.4byte sMarowakPose181
+.4byte sMarowakPose182
+.4byte sMarowakPose183
+.4byte sMarowakPose184
+.4byte sMarowakPose185
+.4byte sMarowakPose186
+.4byte sMarowakPose187
+.4byte sMarowakPose188
+.4byte sMarowakPose189
+.4byte sMarowakPose190
+.4byte sMarowakPose191
+.4byte sMarowakPose192
+.4byte sMarowakPose193
+.4byte sMarowakPose194
+.4byte sMarowakPose195
+.4byte sMarowakPose196
+.4byte sMarowakPose197
+.4byte sMarowakPose198
+.4byte sMarowakPose199
+.4byte sMarowakPose200
+.4byte sMarowakPose201
+.4byte sMarowakPose202
+.4byte sMarowakPose203
+.4byte sMarowakPose204
+.4byte sMarowakPose205
+.4byte sMarowakPose206
+.4byte sMarowakPose207
+.4byte sMarowakPose208
+.4byte sMarowakPose209
+.4byte sMarowakPose210
+.4byte sMarowakPose211
+.4byte sMarowakPose212
+.4byte sMarowakPose213
+.4byte sMarowakPose214
+.4byte sMarowakPose215
+.4byte sMarowakPose216
+.4byte sMarowakPose217
+.4byte sMarowakPose218
+.4byte sMarowakPose219
+.4byte sMarowakPose220
+.4byte sMarowakPose221
+.4byte sMarowakPose222
+.4byte sMarowakPose223
+.4byte sMarowakPose224
+.4byte sMarowakPose225
+.4byte sMarowakPose226
+.4byte sMarowakPose227
+.4byte sMarowakPose228
+.4byte sMarowakPose229
+.4byte sMarowakPose230
+.4byte sMarowakPose231
+.4byte sMarowakPose232
+.4byte sMarowakPose233
+.4byte sMarowakPose234
+.4byte sMarowakPose235
+.4byte sMarowakPose236
+.4byte sMarowakPose237
+sAxPositionsMarowak:
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -8, 	   9,  -11, 	   0,   -8
+.2byte   -1,   -6, 	  -9,  -11, 	   6,   -3, 	  -1,   -8
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte    2,   -9, 	  -2,   -7, 	   5,   -8, 	   1,   -8
+.2byte    3,   -9, 	  -8,   -9, 	  11,   -8, 	   0,   -7
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte    6,   -9, 	  -3,   -6, 	   7,   -7, 	   1,   -5
+.2byte    7,   -9, 	   4,   -6, 	  -5,  -10, 	   1,   -5
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -3,   -8, 	  -1,   -5
+.2byte    5,  -14, 	   9,   -9, 	 -10,   -9, 	   0,   -6
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    1,  -19, 	   8,   -9, 	  -7,   -8, 	   0,   -6
+.2byte    0,  -19, 	   8,  -13, 	  -8,   -5, 	   1,   -6
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   1,  -13, 	  -1,   -4, 	   0,   -7
+.2byte   -8,  -12, 	   6,  -10, 	 -11,  -10, 	   0,   -6
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte   -5,   -9, 	  -1,  -12, 	  -6,   -7, 	  -1,   -7
+.2byte   -6,   -9, 	  -8,  -11, 	   3,   -5, 	  -3,   -6
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -6,   -7, 	 -11,   -8, 	   8,  -10, 	   0,   -6
+.2byte   -3,   -7, 	  -4,  -15, 	   0,   -5, 	   0,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -8, 	   9,  -11, 	   0,   -8
+.2byte   -1,   -6, 	  -9,  -11, 	   6,   -3, 	  -1,   -8
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte    2,   -9, 	  -2,   -7, 	   5,   -8, 	   1,   -8
+.2byte    3,   -9, 	  -8,   -9, 	  11,   -8, 	   0,   -7
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte    6,   -9, 	  -3,   -6, 	   7,   -7, 	   1,   -5
+.2byte    7,   -9, 	   4,   -6, 	  -5,  -10, 	   1,   -5
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -3,   -8, 	  -1,   -5
+.2byte    5,  -14, 	   9,   -9, 	 -10,   -9, 	   0,   -6
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    1,  -19, 	   8,   -9, 	  -7,   -8, 	   0,   -6
+.2byte    0,  -19, 	   8,  -13, 	  -8,   -5, 	   1,   -6
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   1,  -13, 	  -1,   -4, 	   0,   -7
+.2byte   -8,  -12, 	   6,  -10, 	 -11,  -10, 	   0,   -6
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte   -5,   -9, 	  -1,  -12, 	  -6,   -7, 	  -1,   -7
+.2byte   -6,   -9, 	  -8,  -11, 	   3,   -5, 	  -3,   -6
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -6,   -7, 	 -11,   -8, 	   8,  -10, 	   0,   -6
+.2byte   -3,   -7, 	  -4,  -15, 	   0,   -5, 	   0,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte   -5,  -16, 	   6,  -14, 	  -9,  -14, 	  -1,   -6
+.2byte    4,   -7, 	   1,   -2, 	   9,  -14, 	   1,   -8
+.2byte    4,   -7, 	   1,   -2, 	   9,  -14, 	   1,   -8
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte   -2,  -14, 	   4,  -17, 	  -7,   -9, 	   1,   -7
+.2byte    4,  -14, 	   5,   -3, 	  -2,  -20, 	  -1,   -9
+.2byte    4,  -14, 	   5,   -3, 	  -2,  -20, 	  -1,   -9
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte   -3,  -14, 	  -6,  -14, 	   2,   -9, 	  -2,   -7
+.2byte    1,  -14, 	   4,   -5, 	  -4,  -18, 	   1,   -8
+.2byte    1,  -14, 	   4,   -5, 	  -4,  -18, 	   1,   -8
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte   -6,  -14, 	 -10,  -13, 	   7,   -9, 	  -1,   -6
+.2byte   -7,  -14, 	  -4,   -9, 	  -4,  -19, 	   1,   -9
+.2byte   -7,  -14, 	  -4,   -9, 	  -4,  -19, 	   1,   -9
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    4,  -13, 	   6,  -13, 	  -1,  -12, 	  -1,   -7
+.2byte   -8,  -12, 	  -9,  -13, 	  -5,   -9, 	   1,   -7
+.2byte   -8,  -12, 	  -9,  -13, 	  -5,   -9, 	   1,   -7
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte    8,  -17, 	  11,  -11, 	  -7,  -16, 	   0,   -7
+.2byte   -6,   -9, 	 -12,   -9, 	   4,  -12, 	  -2,   -8
+.2byte   -6,   -9, 	 -12,   -9, 	   4,  -12, 	  -2,   -8
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte    4,  -19, 	  10,  -14, 	  -7,  -14, 	   0,   -6
+.2byte   -2,   -8, 	  -8,   -4, 	   8,  -11, 	   0,   -7
+.2byte   -2,   -8, 	  -8,   -4, 	   8,  -11, 	   0,   -7
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -1,  -20, 	   7,  -15, 	  -9,  -16, 	  -1,   -6
+.2byte   -2,   -8, 	  -6,   -3, 	   6,  -14, 	  -3,   -9
+.2byte   -2,   -8, 	  -6,   -3, 	   6,  -14, 	  -3,   -9
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte   -5,  -16, 	   6,  -14, 	  -9,  -14, 	  -1,   -6
+.2byte    4,   -7, 	   1,   -2, 	   9,  -14, 	   1,   -8
+.2byte    4,   -7, 	   1,   -2, 	   9,  -14, 	   1,   -8
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte   -2,  -14, 	   4,  -17, 	  -7,   -9, 	   1,   -7
+.2byte    4,  -14, 	   5,   -3, 	  -2,  -20, 	  -1,   -9
+.2byte    4,  -14, 	   5,   -3, 	  -2,  -20, 	  -1,   -9
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte   -3,  -14, 	  -6,  -14, 	   2,   -9, 	  -2,   -7
+.2byte    1,  -14, 	   4,   -5, 	  -4,  -18, 	   1,   -8
+.2byte    1,  -14, 	   4,   -5, 	  -4,  -18, 	   1,   -8
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte   -6,  -14, 	 -10,  -13, 	   7,   -9, 	  -1,   -6
+.2byte   -7,  -14, 	  -4,   -9, 	  -4,  -19, 	   1,   -9
+.2byte   -7,  -14, 	  -4,   -9, 	  -4,  -19, 	   1,   -9
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    4,  -13, 	   6,  -13, 	  -1,  -12, 	  -1,   -7
+.2byte   -8,  -12, 	  -9,  -13, 	  -5,   -9, 	   1,   -7
+.2byte   -8,  -12, 	  -9,  -13, 	  -5,   -9, 	   1,   -7
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte    8,  -17, 	  11,  -11, 	  -7,  -16, 	   0,   -7
+.2byte   -6,   -9, 	 -12,   -9, 	   4,  -12, 	  -2,   -8
+.2byte   -6,   -9, 	 -12,   -9, 	   4,  -12, 	  -2,   -8
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte    4,  -19, 	  10,  -14, 	  -7,  -14, 	   0,   -6
+.2byte   -2,   -8, 	  -8,   -4, 	   8,  -11, 	   0,   -7
+.2byte   -2,   -8, 	  -8,   -4, 	   8,  -11, 	   0,   -7
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -1,  -20, 	   7,  -15, 	  -9,  -16, 	  -1,   -6
+.2byte   -2,   -8, 	  -6,   -3, 	   6,  -14, 	  -3,   -9
+.2byte   -2,   -8, 	  -6,   -3, 	   6,  -14, 	  -3,   -9
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte   -5,  -16, 	   6,  -14, 	  -9,  -14, 	  -1,   -6
+.2byte    2,   -8, 	   1,   -1, 	   9,  -14, 	   1,   -6
+.2byte    2,   -8, 	   1,   -1, 	   9,  -14, 	   1,   -6
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte   -2,  -14, 	   4,  -17, 	  -7,   -9, 	   1,   -7
+.2byte    4,  -14, 	   5,   -5, 	  -3,  -20, 	  -2,   -8
+.2byte    4,  -14, 	   5,   -5, 	  -3,  -20, 	  -2,   -8
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte   -3,  -14, 	  -6,  -14, 	   2,   -9, 	  -2,   -7
+.2byte    1,  -14, 	   4,   -5, 	  -4,  -18, 	   1,   -8
+.2byte    1,  -14, 	   4,   -5, 	  -4,  -18, 	   1,   -8
+.2byte   -5,  -19, 	 -11,  -14, 	   6,  -14, 	  -1,   -6
+.2byte    2,   -7, 	   8,   -4, 	  -9,  -11, 	  -1,   -6
+.2byte    2,   -7, 	   8,   -4, 	  -9,  -11, 	  -1,   -6
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte   -6,  -14, 	 -10,  -13, 	   7,   -9, 	  -1,   -6
+.2byte   -7,  -14, 	  -4,  -10, 	  -4,  -19, 	   1,   -8
+.2byte   -7,  -14, 	  -4,  -10, 	  -4,  -19, 	   1,   -8
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    4,  -13, 	   6,  -13, 	  -1,  -12, 	  -1,   -7
+.2byte   -8,  -12, 	  -9,  -13, 	  -5,   -9, 	   2,   -7
+.2byte   -8,  -12, 	  -9,  -13, 	  -5,   -9, 	   2,   -7
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte    8,  -17, 	  11,  -11, 	  -7,  -16, 	   0,   -7
+.2byte   -7,   -9, 	 -13,   -8, 	   4,  -12, 	  -3,   -8
+.2byte   -7,   -9, 	 -13,   -8, 	   4,  -12, 	  -3,   -8
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte    4,  -19, 	  10,  -14, 	  -7,  -14, 	   0,   -6
+.2byte   -3,   -7, 	  -9,   -4, 	   8,  -11, 	   0,   -6
+.2byte   -3,   -7, 	  -9,   -4, 	   8,  -11, 	   0,   -6
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -1,  -20, 	   7,  -15, 	  -9,  -16, 	  -1,   -6
+.2byte   -2,   -8, 	  -6,   -1, 	   6,  -14, 	   0,   -6
+.2byte   -2,   -8, 	  -6,   -1, 	   6,  -14, 	   0,   -6
+.2byte   -1,   -7, 	  -8,   -9, 	   7,   -2, 	   0,   -5
+.2byte   -1,   -6, 	  -8,   -8, 	   7,   -1, 	   1,   -5
+.2byte    0,   -5, 	  -6,   -9, 	   5,   -9, 	   0,   -7
+.2byte    5,   -4, 	  11,  -10, 	   2,   -7, 	   0,   -7
+.2byte    6,   -8, 	   8,  -15, 	   6,  -10, 	  -1,   -6
+.2byte    5,   -9, 	   2,  -14, 	   9,  -11, 	  -1,   -6
+.2byte    0,  -12, 	   5,  -12, 	  -6,  -12, 	   0,   -7
+.2byte   -6,   -9, 	  -3,  -14, 	 -10,  -11, 	   0,   -6
+.2byte   -7,   -8, 	  -9,  -15, 	  -7,  -10, 	   0,   -6
+.2byte   -6,   -4, 	 -12,  -10, 	  -3,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -8, 	   9,  -11, 	   0,   -8
+.2byte   -1,   -6, 	  -9,  -11, 	   6,   -3, 	  -1,   -8
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte    2,   -9, 	  -2,   -7, 	   5,   -8, 	   1,   -8
+.2byte    3,   -9, 	  -8,   -9, 	  11,   -8, 	   0,   -7
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte    6,   -9, 	  -3,   -6, 	   7,   -7, 	   1,   -5
+.2byte    7,   -9, 	   4,   -6, 	  -5,  -10, 	   1,   -5
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -3,   -8, 	  -1,   -5
+.2byte    5,  -14, 	   9,   -9, 	 -10,   -9, 	   0,   -6
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    1,  -19, 	   8,   -9, 	  -7,   -8, 	   0,   -6
+.2byte    0,  -19, 	   8,  -13, 	  -8,   -5, 	   1,   -6
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   1,  -13, 	  -1,   -4, 	   0,   -7
+.2byte   -8,  -12, 	   6,  -10, 	 -11,  -10, 	   0,   -6
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte   -5,   -9, 	  -1,  -12, 	  -6,   -7, 	  -1,   -7
+.2byte   -6,   -9, 	  -8,  -11, 	   3,   -5, 	  -3,   -6
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -6,   -7, 	 -11,   -8, 	   8,  -10, 	   0,   -6
+.2byte   -3,   -7, 	  -4,  -15, 	   0,   -5, 	   0,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte    4,   -7, 	   1,   -2, 	   9,  -14, 	   1,   -8
+.2byte    4,  -14, 	   5,   -3, 	  -2,  -20, 	  -1,   -9
+.2byte    1,  -14, 	   4,   -5, 	  -4,  -18, 	   1,   -8
+.2byte   -7,  -14, 	  -4,   -9, 	  -4,  -19, 	   1,   -9
+.2byte   -8,  -12, 	  -9,  -13, 	  -5,   -9, 	   1,   -7
+.2byte   -5,   -8, 	 -11,   -8, 	   5,  -11, 	  -1,   -7
+.2byte   -2,   -8, 	  -8,   -4, 	   8,  -11, 	   0,   -7
+.2byte   -1,   -7, 	  -5,   -2, 	   7,  -13, 	  -2,   -8
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -8, 	   9,  -11, 	   0,   -8
+.2byte   -1,   -6, 	  -9,  -11, 	   6,   -3, 	  -1,   -8
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+.2byte    2,   -9, 	  -2,   -7, 	   5,   -8, 	   1,   -8
+.2byte    3,   -9, 	  -8,   -9, 	  11,   -8, 	   0,   -7
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte    6,   -9, 	  -3,   -6, 	   7,   -7, 	   1,   -5
+.2byte    7,   -9, 	   4,   -6, 	  -5,  -10, 	   1,   -5
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte    6,  -15, 	   5,   -5, 	  -3,   -8, 	  -1,   -5
+.2byte    5,  -14, 	   9,   -9, 	 -10,   -9, 	   0,   -6
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    1,  -19, 	   8,   -9, 	  -7,   -8, 	   0,   -6
+.2byte    0,  -19, 	   8,  -13, 	  -8,   -5, 	   1,   -6
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte   -7,  -12, 	   1,  -13, 	  -1,   -4, 	   0,   -7
+.2byte   -8,  -12, 	   6,  -10, 	 -11,  -10, 	   0,   -6
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte   -5,   -9, 	  -1,  -12, 	  -6,   -7, 	  -1,   -7
+.2byte   -6,   -9, 	  -8,  -11, 	   3,   -5, 	  -3,   -6
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -6,   -7, 	 -11,   -8, 	   8,  -10, 	   0,   -6
+.2byte   -3,   -7, 	  -4,  -15, 	   0,   -5, 	   0,   -8
+.2byte    0,   -6, 	  -9,   -8, 	   9,  -11, 	   0,   -8
+.2byte   -6,   -7, 	 -11,   -8, 	   8,  -10, 	   0,   -6
+.2byte   -6,   -9, 	  -8,  -11, 	   3,   -5, 	  -3,   -6
+.2byte   -8,  -12, 	   6,  -10, 	 -11,  -10, 	   0,   -6
+.2byte    1,  -19, 	   8,   -9, 	  -7,   -8, 	   0,   -6
+.2byte    6,  -15, 	   5,   -5, 	  -3,   -8, 	  -1,   -5
+.2byte    6,   -9, 	  -3,   -6, 	   7,   -7, 	   1,   -5
+.2byte    2,   -7, 	  -2,   -5, 	   5,   -6, 	   1,   -6
+.2byte   -1,   -7, 	 -11,  -10, 	   9,   -8, 	  -1,   -8
+.2byte   -5,   -8, 	  -9,  -12, 	   5,   -5, 	  -1,   -7
+.2byte   -6,  -10, 	  -3,  -14, 	  -2,   -3, 	  -1,   -7
+.2byte   -7,  -13, 	   6,  -12, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -20, 	   8,  -12, 	  -9,   -9, 	   0,   -8
+.2byte    6,  -14, 	   6,   -8, 	  -7,   -9, 	  -1,   -7
+.2byte    6,  -10, 	   0,   -6, 	   3,   -6, 	   1,   -5
+.2byte    1,  -10, 	  -6,   -8, 	   7,  -11, 	   1,   -7
+sMarowakAnimTable1:
+.4byte sMarowakAnims_1_1
+.4byte sMarowakAnims_1_2
+.4byte sMarowakAnims_1_3
+.4byte sMarowakAnims_1_4
+.4byte sMarowakAnims_1_5
+.4byte sMarowakAnims_1_6
+.4byte sMarowakAnims_1_7
+.4byte sMarowakAnims_1_8
+sMarowakAnimTable2:
+.4byte sMarowakAnims_2_1
+.4byte sMarowakAnims_2_2
+.4byte sMarowakAnims_2_3
+.4byte sMarowakAnims_2_4
+.4byte sMarowakAnims_2_5
+.4byte sMarowakAnims_2_6
+.4byte sMarowakAnims_2_7
+.4byte sMarowakAnims_2_8
+sMarowakAnimTable3:
+.4byte sMarowakAnims_3_1
+.4byte sMarowakAnims_3_2
+.4byte sMarowakAnims_3_3
+.4byte sMarowakAnims_3_4
+.4byte sMarowakAnims_3_5
+.4byte sMarowakAnims_3_6
+.4byte sMarowakAnims_3_7
+.4byte sMarowakAnims_3_8
+sMarowakAnimTable4:
+.4byte sMarowakAnims_4_1
+.4byte sMarowakAnims_4_2
+.4byte sMarowakAnims_4_3
+.4byte sMarowakAnims_4_4
+.4byte sMarowakAnims_4_5
+.4byte sMarowakAnims_4_6
+.4byte sMarowakAnims_4_7
+.4byte sMarowakAnims_4_8
+sMarowakAnimTable5:
+.4byte sMarowakAnims_5_1
+.4byte sMarowakAnims_5_2
+.4byte sMarowakAnims_5_3
+.4byte sMarowakAnims_5_4
+.4byte sMarowakAnims_5_5
+.4byte sMarowakAnims_5_6
+.4byte sMarowakAnims_5_7
+.4byte sMarowakAnims_5_8
+sMarowakAnimTable6:
+.4byte sMarowakAnims_6_1
+.4byte sMarowakAnims_6_1
+.4byte sMarowakAnims_6_1
+.4byte sMarowakAnims_6_1
+.4byte sMarowakAnims_6_1
+.4byte sMarowakAnims_6_1
+.4byte sMarowakAnims_6_1
+.4byte sMarowakAnims_6_1
+sMarowakAnimTable7:
+.4byte sMarowakAnims_7_1
+.4byte sMarowakAnims_7_2
+.4byte sMarowakAnims_7_3
+.4byte sMarowakAnims_7_4
+.4byte sMarowakAnims_7_5
+.4byte sMarowakAnims_7_6
+.4byte sMarowakAnims_7_7
+.4byte sMarowakAnims_7_8
+sMarowakAnimTable8:
+.4byte sMarowakAnims_8_1
+.4byte sMarowakAnims_8_2
+.4byte sMarowakAnims_8_3
+.4byte sMarowakAnims_8_4
+.4byte sMarowakAnims_8_5
+.4byte sMarowakAnims_8_6
+.4byte sMarowakAnims_8_7
+.4byte sMarowakAnims_8_8
+sMarowakAnimTable9:
+.4byte sMarowakAnims_9_1
+.4byte sMarowakAnims_9_2
+.4byte sMarowakAnims_9_3
+.4byte sMarowakAnims_9_4
+.4byte sMarowakAnims_9_5
+.4byte sMarowakAnims_9_6
+.4byte sMarowakAnims_9_7
+.4byte sMarowakAnims_9_8
+sMarowakAnimTable10:
+.4byte sMarowakAnims_10_1
+.4byte sMarowakAnims_10_2
+.4byte sMarowakAnims_10_3
+.4byte sMarowakAnims_10_4
+.4byte sMarowakAnims_10_5
+.4byte sMarowakAnims_10_6
+.4byte sMarowakAnims_10_7
+.4byte sMarowakAnims_10_8
+sMarowakAnimTable11:
+.4byte sMarowakAnims_11_1
+.4byte sMarowakAnims_11_2
+.4byte sMarowakAnims_11_3
+.4byte sMarowakAnims_11_4
+.4byte sMarowakAnims_11_5
+.4byte sMarowakAnims_11_6
+.4byte sMarowakAnims_11_7
+.4byte sMarowakAnims_11_8
+sMarowakAnimTable12:
+.4byte sMarowakAnims_12_1
+.4byte sMarowakAnims_12_2
+.4byte sMarowakAnims_12_3
+.4byte sMarowakAnims_12_4
+.4byte sMarowakAnims_12_5
+.4byte sMarowakAnims_12_6
+.4byte sMarowakAnims_12_7
+.4byte sMarowakAnims_12_8
+sMarowakAnimTable13:
+.4byte sMarowakAnims_13_1
+.4byte sMarowakAnims_13_2
+.4byte sMarowakAnims_13_3
+.4byte sMarowakAnims_13_4
+.4byte sMarowakAnims_13_5
+.4byte sMarowakAnims_13_6
+.4byte sMarowakAnims_13_7
+.4byte sMarowakAnims_13_8
+sAxAnimationsMarowak:
+.4byte sMarowakAnimTable1
+.4byte sMarowakAnimTable2
+.4byte sMarowakAnimTable3
+.4byte sMarowakAnimTable4
+.4byte sMarowakAnimTable5
+.4byte sMarowakAnimTable6
+.4byte sMarowakAnimTable7
+.4byte sMarowakAnimTable8
+.4byte sMarowakAnimTable9
+.4byte sMarowakAnimTable10
+.4byte sMarowakAnimTable11
+.4byte sMarowakAnimTable12
+.4byte sMarowakAnimTable13
+sAxSpritesMarowak:
+.4byte sMarowakSprites1
+.4byte sMarowakSprites2
+.4byte sMarowakSprites3
+.4byte sMarowakSprites4
+.4byte sMarowakSprites5
+.4byte sMarowakSprites6
+.4byte sMarowakSprites7
+.4byte sMarowakSprites8
+.4byte sMarowakSprites9
+.4byte sMarowakSprites10
+.4byte sMarowakSprites11
+.4byte sMarowakSprites12
+.4byte sMarowakSprites13
+.4byte sMarowakSprites14
+.4byte sMarowakSprites15
+.4byte sMarowakSprites16
+.4byte sMarowakSprites17
+.4byte sMarowakSprites18
+.4byte sMarowakSprites19
+.4byte sMarowakSprites20
+.4byte sMarowakSprites21
+.4byte sMarowakSprites22
+.4byte sMarowakSprites23
+.4byte sMarowakSprites24
+.4byte sMarowakSprites25
+.4byte sMarowakSprites26
+.4byte sMarowakSprites27
+.4byte sMarowakSprites28
+.4byte sMarowakSprites29
+.4byte sMarowakSprites30
+.4byte sMarowakSprites31
+.4byte sMarowakSprites32
+.4byte sMarowakSprites33
+.4byte sMarowakSprites34
+.4byte sMarowakSprites35
+.4byte sMarowakSprites36
+.4byte sMarowakSprites37
+.4byte sMarowakSprites38
+.4byte sMarowakSprites39
+.4byte sMarowakSprites40
+.4byte sMarowakSprites41
+.4byte sMarowakSprites42
+.4byte sMarowakSprites43
+.4byte sMarowakSprites44
+.4byte sMarowakSprites45
+.4byte sMarowakSprites46
+.4byte sMarowakSprites47
+.4byte sMarowakSprites48
+.4byte sMarowakSprites49
+.4byte sMarowakSprites50
+.4byte sMarowakSprites51
+.4byte sMarowakSprites52
+.4byte sMarowakSprites53
+.4byte sMarowakSprites54
+.4byte sMarowakSprites55
+.4byte sMarowakSprites56
+.4byte sMarowakSprites57
+.4byte sMarowakSprites58
+.4byte sMarowakSprites59
+.4byte sMarowakSprites60
+.4byte sMarowakSprites61
+.4byte sMarowakSprites62
+.4byte sMarowakSprites63
+.4byte sMarowakSprites64
+.4byte sMarowakSprites65
+.4byte sMarowakSprites66
+.4byte sMarowakSprites67
+.4byte sMarowakSprites68
+.4byte sMarowakSprites69
+.4byte sMarowakSprites70
+sAxMainMarowak:
+ax_main sAxPosesMarowak, sAxAnimationsMarowak, 13, sAxSpritesMarowak, sAxPositionsMarowak

--- a/data/ax/marshtomp.inc
+++ b/data/ax/marshtomp.inc
@@ -1,0 +1,2692 @@
+.global gAxMarshtomp
+gAxMarshtomp:
+ax_siro sAxMainMarshtomp
+sMarshtompPose1:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose3:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose4:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose5:
+ax_pose 4, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose6:
+ax_pose 5, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose7:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose8:
+ax_pose 7, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose9:
+ax_pose 8, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose10:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose11:
+ax_pose 10, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose12:
+ax_pose 11, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose14:
+ax_pose 13, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose15:
+ax_pose 14, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose16:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose17:
+ax_pose 10, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose18:
+ax_pose 11, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose19:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose20:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose21:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose22:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose23:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose24:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose25:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose26:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose27:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose28:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose29:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose30:
+ax_pose 4, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose31:
+ax_pose 5, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose32:
+ax_pose 16, 0x41f2, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose33:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose34:
+ax_pose 7, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose35:
+ax_pose 8, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose36:
+ax_pose 17, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose37:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose38:
+ax_pose 10, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose39:
+ax_pose 11, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose40:
+ax_pose 18, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose41:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose42:
+ax_pose 13, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose43:
+ax_pose 14, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose44:
+ax_pose 19, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose45:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose46:
+ax_pose 10, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose47:
+ax_pose 11, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose48:
+ax_pose 18, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose49:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose50:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose51:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose52:
+ax_pose 17, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose53:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose54:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose55:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose56:
+ax_pose 16, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose57:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose58:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose59:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose60:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose61:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose62:
+ax_pose 4, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose63:
+ax_pose 5, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose64:
+ax_pose 16, 0x41f2, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose65:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose66:
+ax_pose 7, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose67:
+ax_pose 8, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose68:
+ax_pose 17, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose69:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose70:
+ax_pose 10, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose71:
+ax_pose 11, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose72:
+ax_pose 18, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose73:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose74:
+ax_pose 13, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose75:
+ax_pose 14, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose76:
+ax_pose 19, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose77:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose78:
+ax_pose 10, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose79:
+ax_pose 11, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose80:
+ax_pose 18, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose81:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose82:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose83:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose84:
+ax_pose 17, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose85:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose86:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose87:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose88:
+ax_pose 16, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose89:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose90:
+ax_pose 20, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose91:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose92:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose93:
+ax_pose 21, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose94:
+ax_pose 16, 0x41f2, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose95:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose96:
+ax_pose 22, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose97:
+ax_pose 17, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose98:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose99:
+ax_pose 23, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose100:
+ax_pose 18, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose101:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose102:
+ax_pose 24, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose103:
+ax_pose 19, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose104:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose105:
+ax_pose 23, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose106:
+ax_pose 18, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose107:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose108:
+ax_pose 22, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose109:
+ax_pose 17, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose110:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose111:
+ax_pose 21, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose112:
+ax_pose 16, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose113:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose114:
+ax_pose 20, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose115:
+ax_pose 25, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose116:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose117:
+ax_pose 21, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose118:
+ax_pose 26, 0x41f2, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose119:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose120:
+ax_pose 22, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose121:
+ax_pose 27, 0x41f4, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose122:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose123:
+ax_pose 23, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose124:
+ax_pose 28, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose125:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose126:
+ax_pose 24, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose127:
+ax_pose 29, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose128:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose129:
+ax_pose 23, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose130:
+ax_pose 28, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose131:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose132:
+ax_pose 22, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose133:
+ax_pose 27, 0x41f4, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose134:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose135:
+ax_pose 21, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose136:
+ax_pose 26, 0x41f2, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose137:
+ax_pose 30, 0x01f0, 0x80f3, 0x5c00
+ax_pose_terminator
+sMarshtompPose138:
+ax_pose 31, 0x01f0, 0x80f3, 0x5c00
+ax_pose_terminator
+sMarshtompPose139:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose140:
+ax_pose 33, 0x01e4, 0x90ea, 0x5c00
+ax_pose_terminator
+sMarshtompPose141:
+ax_pose 34, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sMarshtompPose142:
+ax_pose 35, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sMarshtompPose143:
+ax_pose 36, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose144:
+ax_pose 35, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarshtompPose145:
+ax_pose 34, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sMarshtompPose146:
+ax_pose 33, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sMarshtompPose147:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose148:
+ax_pose 1, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose149:
+ax_pose 2, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose150:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose151:
+ax_pose 4, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose152:
+ax_pose 5, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose153:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose154:
+ax_pose 7, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose155:
+ax_pose 8, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose156:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose157:
+ax_pose 10, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose158:
+ax_pose 11, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose159:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose160:
+ax_pose 13, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose161:
+ax_pose 14, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose162:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose163:
+ax_pose 10, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose164:
+ax_pose 11, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose165:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose166:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose167:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose168:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose169:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose170:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose171:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose172:
+ax_pose 16, 0x41f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose173:
+ax_pose 17, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarshtompPose174:
+ax_pose 18, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sMarshtompPose175:
+ax_pose 19, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose176:
+ax_pose 18, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sMarshtompPose177:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sMarshtompPose178:
+ax_pose 16, 0x41f2, 0x90f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose179:
+ax_pose 20, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose180:
+ax_pose 21, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose181:
+ax_pose 22, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose182:
+ax_pose 23, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose183:
+ax_pose 24, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose184:
+ax_pose 23, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose185:
+ax_pose 22, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose186:
+ax_pose 21, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose187:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose188:
+ax_pose 20, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose189:
+ax_pose 15, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose190:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose191:
+ax_pose 21, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose192:
+ax_pose 16, 0x41f1, 0x90ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose193:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose194:
+ax_pose 22, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose195:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sMarshtompPose196:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose197:
+ax_pose 23, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose198:
+ax_pose 18, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose199:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose200:
+ax_pose 24, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose201:
+ax_pose 19, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose202:
+ax_pose 9, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose203:
+ax_pose 23, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose204:
+ax_pose 18, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose205:
+ax_pose 6, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose206:
+ax_pose 22, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose207:
+ax_pose 17, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarshtompPose208:
+ax_pose 3, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose209:
+ax_pose 21, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose210:
+ax_pose 16, 0x41f1, 0x80f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose211:
+ax_pose 15, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose212:
+ax_pose 16, 0x41f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose213:
+ax_pose 17, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sMarshtompPose214:
+ax_pose 18, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sMarshtompPose215:
+ax_pose 19, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose216:
+ax_pose 18, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sMarshtompPose217:
+ax_pose 17, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sMarshtompPose218:
+ax_pose 16, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sMarshtompPose219:
+ax_pose 0, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose220:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose221:
+ax_pose 6, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose222:
+ax_pose 9, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose223:
+ax_pose 12, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sMarshtompPose224:
+ax_pose 9, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose225:
+ax_pose 6, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sMarshtompPose226:
+ax_pose 3, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+.align 2
+sMarshtompAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, -1, 19, -1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, -1, 19, -1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMarshtompAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 1, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sMarshtompAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 1, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 35, 14, 0, 14, 0,
+ax_anim 2, 0, 35, 14, 1, 14, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMarshtompAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 16, -21, 16, -21,
+ax_anim 2, 1, 39, 17, -20, 17, -20,
+ax_anim 2, 0, 39, 16, -21, 16, -21,
+ax_anim 2, 0, 39, 17, -20, 17, -20,
+ax_anim 2, 0, 36, 5, -6, 5, -6,
+ax_anim_terminator
+sMarshtompAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, -1, -18, -1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, -1, -18, -1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sMarshtompAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -16, -21, -16, -21,
+ax_anim 2, 1, 47, -17, -20, -17, -20,
+ax_anim 2, 0, 47, -16, -21, -16, -21,
+ax_anim 2, 0, 47, -17, -20, -17, -20,
+ax_anim 2, 0, 44, -5, -6, -5, -6,
+ax_anim_terminator
+sMarshtompAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -8, 0, -8, 0,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 1, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 51, -14, 0, -14, 0,
+ax_anim 2, 0, 51, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sMarshtompAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 1, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 0, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 59, -1, 19, -1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, -1, 19, -1, 19,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sMarshtompAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 18, 19, 18, 19,
+ax_anim 2, 1, 63, 19, 18, 19, 18,
+ax_anim 2, 0, 63, 18, 19, 18, 19,
+ax_anim 2, 0, 63, 19, 18, 19, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sMarshtompAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 8, 0, 8, 0,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 1, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 0, 67, 14, 1, 14, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sMarshtompAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 16, -21, 16, -21,
+ax_anim 2, 1, 71, 17, -20, 17, -20,
+ax_anim 2, 0, 71, 16, -21, 16, -21,
+ax_anim 2, 0, 71, 17, -20, 17, -20,
+ax_anim 2, 0, 68, 5, -6, 5, -6,
+ax_anim_terminator
+sMarshtompAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, -1, -18, -1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, -1, -18, -1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sMarshtompAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -16, -21, -16, -21,
+ax_anim 2, 1, 79, -17, -20, -17, -20,
+ax_anim 2, 0, 79, -16, -21, -16, -21,
+ax_anim 2, 0, 79, -17, -20, -17, -20,
+ax_anim 2, 0, 76, -5, -6, -5, -6,
+ax_anim_terminator
+sMarshtompAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -8, 0, -8, 0,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 1, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 83, -14, 0, -14, 0,
+ax_anim 2, 0, 83, -14, 1, -14, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sMarshtompAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 19, -18, 19,
+ax_anim 2, 1, 87, -19, 18, -19, 18,
+ax_anim 2, 0, 87, -18, 19, -18, 19,
+ax_anim 2, 0, 87, -19, 18, -19, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sMarshtompAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sMarshtompAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sMarshtompAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sMarshtompAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sMarshtompAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sMarshtompAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sMarshtompAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_5_1:
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 4, 0, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim_terminator
+sMarshtompAnims_5_2:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 4, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim_terminator
+sMarshtompAnims_5_3:
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sMarshtompAnims_5_4:
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim_terminator
+sMarshtompAnims_5_5:
+ax_anim 1, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -1, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim_terminator
+sMarshtompAnims_5_6:
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim_terminator
+sMarshtompAnims_5_7:
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim_terminator
+sMarshtompAnims_5_8:
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sMarshtompAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sMarshtompAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sMarshtompAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sMarshtompAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sMarshtompAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sMarshtompAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sMarshtompAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_8_1:
+ax_anim 36, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim 36, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_8_2:
+ax_anim 36, 0, 149, 0, 0, 0, 0,
+ax_anim 16, 0, 150, 0, 0, 0, 0,
+ax_anim 36, 0, 149, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_8_3:
+ax_anim 36, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim 36, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_8_4:
+ax_anim 36, 0, 155, 0, 0, 0, 0,
+ax_anim 16, 0, 156, 0, 0, 0, 0,
+ax_anim 36, 0, 155, 0, 0, 0, 0,
+ax_anim 16, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_8_5:
+ax_anim 36, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim 36, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_8_6:
+ax_anim 36, 0, 161, 0, 0, 0, 0,
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 36, 0, 161, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_8_7:
+ax_anim 36, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 165, 0, 0, 0, 0,
+ax_anim 36, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_8_8:
+ax_anim 36, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim 36, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 4, 7, 4,
+ax_anim 2, 0, 172, 10, 10, 10, 10,
+ax_anim 2, 0, 173, 9, 16, 9, 16,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -9, 16, -9, 16,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 1, 0, 177, -7, 4, -7, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 171, 18, 3, 18, 3,
+ax_anim 2, 0, 172, 22, 11, 22, 11,
+ax_anim 3, 0, 173, 22, 19, 22, 19,
+ax_anim 2, 3, 174, 14, 20, 14, 20,
+ax_anim 2, 0, 175, 6, 16, 6, 16,
+ax_anim 1, 0, 176, 1, 9, 1, 9,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 5, -4, 5, -4,
+ax_anim 2, 0, 170, 12, -5, 12, -5,
+ax_anim 2, 0, 171, 19, -4, 19, -4,
+ax_anim 3, 0, 172, 22, 0, 22, 0,
+ax_anim 2, 3, 173, 17, 5, 17, 5,
+ax_anim 2, 0, 174, 11, 7, 11, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -9, -1, -9,
+ax_anim 2, 0, 177, 4, -18, 4, -18,
+ax_anim 2, 0, 170, 10, -21, 10, -21,
+ax_anim 3, 0, 171, 21, -24, 21, -24,
+ax_anim 2, 3, 172, 25, -16, 25, -16,
+ax_anim 2, 0, 173, 22, -8, 22, -8,
+ax_anim 1, 0, 174, 12, -1, 12, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -10, -4, -10, -4,
+ax_anim 2, 0, 176, -13, -12, -13, -12,
+ax_anim 2, 0, 177, -8, -21, -8, -21,
+ax_anim 3, 0, 170, 0, -24, 0, -24,
+ax_anim 2, 3, 171, 8, -21, 8, -21,
+ax_anim 2, 0, 172, 13, -12, 13, -12,
+ax_anim 1, 0, 173, 10, -4, 10, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -9, 1, -9,
+ax_anim 2, 0, 171, -4, -18, -4, -18,
+ax_anim 2, 0, 170, -10, -21, -10, -21,
+ax_anim 3, 0, 177, -21, -24, -21, -24,
+ax_anim 2, 3, 176, -25, -16, -25, -16,
+ax_anim 2, 0, 175, -22, -8, -22, -8,
+ax_anim 1, 0, 174, -12, -1, -12, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -5, -4, -5, -4,
+ax_anim 2, 0, 170, -12, -5, -12, -5,
+ax_anim 2, 0, 177, -19, -4, -19, -4,
+ax_anim 3, 0, 176, -22, 0, -22, 0,
+ax_anim 2, 3, 175, -17, 5, -17, 5,
+ax_anim 2, 0, 174, -11, 7, -11, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 177, -18, 3, -18, 3,
+ax_anim 2, 0, 176, -22, 11, -22, 11,
+ax_anim 3, 0, 175, -22, 19, -22, 19,
+ax_anim 2, 3, 174, -14, 20, -14, 20,
+ax_anim 2, 0, 173, -6, 16, -6, 16,
+ax_anim 1, 0, 172, -1, 9, -1, 9,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -23, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -23, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -22, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -19, 0, 0,
+ax_anim 4, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -22, 0, 0,
+ax_anim 2, 0, 203, 0, -18, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -23, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMarshtompAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMarshtompGfx1:
+.incbin "baserom.gba", 0x10A84FC, 0x200
+sMarshtompSprites1:
+ax_sprite sMarshtompGfx1, 0x200
+ax_sprite_terminator
+sMarshtompGfx2:
+.incbin "baserom.gba", 0x10A870C, 0x200
+sMarshtompSprites2:
+ax_sprite sMarshtompGfx2, 0x200
+ax_sprite_terminator
+sMarshtompGfx3:
+.incbin "baserom.gba", 0x10A891C, 0x200
+sMarshtompSprites3:
+ax_sprite sMarshtompGfx3, 0x200
+ax_sprite_terminator
+sMarshtompGfx4:
+.incbin "baserom.gba", 0x10A8B2C, 0x200
+sMarshtompSprites4:
+ax_sprite sMarshtompGfx4, 0x200
+ax_sprite_terminator
+sMarshtompGfx5:
+.incbin "baserom.gba", 0x10A8D3C, 0x200
+sMarshtompSprites5:
+ax_sprite sMarshtompGfx5, 0x200
+ax_sprite_terminator
+sMarshtompGfx6:
+.incbin "baserom.gba", 0x10A8F4C, 0x200
+sMarshtompSprites6:
+ax_sprite sMarshtompGfx6, 0x200
+ax_sprite_terminator
+sMarshtompGfx7:
+.incbin "baserom.gba", 0x10A915C, 0x200
+sMarshtompSprites7:
+ax_sprite sMarshtompGfx7, 0x200
+ax_sprite_terminator
+sMarshtompGfx8:
+.incbin "baserom.gba", 0x10A936C, 0x200
+sMarshtompSprites8:
+ax_sprite sMarshtompGfx8, 0x200
+ax_sprite_terminator
+sMarshtompGfx9:
+.incbin "baserom.gba", 0x10A957C, 0x200
+sMarshtompSprites9:
+ax_sprite sMarshtompGfx9, 0x200
+ax_sprite_terminator
+sMarshtompGfx10:
+.incbin "baserom.gba", 0x10A978C, 0x200
+sMarshtompSprites10:
+ax_sprite sMarshtompGfx10, 0x200
+ax_sprite_terminator
+sMarshtompGfx11:
+.incbin "baserom.gba", 0x10A999C, 0x200
+sMarshtompSprites11:
+ax_sprite sMarshtompGfx11, 0x200
+ax_sprite_terminator
+sMarshtompGfx12:
+.incbin "baserom.gba", 0x10A9BAC, 0x200
+sMarshtompSprites12:
+ax_sprite sMarshtompGfx12, 0x200
+ax_sprite_terminator
+sMarshtompGfx13:
+.incbin "baserom.gba", 0x10A9DBC, 0x200
+sMarshtompSprites13:
+ax_sprite sMarshtompGfx13, 0x200
+ax_sprite_terminator
+sMarshtompGfx14:
+.incbin "baserom.gba", 0x10A9FCC, 0x200
+sMarshtompSprites14:
+ax_sprite sMarshtompGfx14, 0x200
+ax_sprite_terminator
+sMarshtompGfx15:
+.incbin "baserom.gba", 0x10AA1DC, 0x200
+sMarshtompSprites15:
+ax_sprite sMarshtompGfx15, 0x200
+ax_sprite_terminator
+sMarshtompGfx16:
+.incbin "baserom.gba", 0x10AA3EC, 0x40
+sMarshtompGfx16_1:
+.incbin "baserom.gba", 0x10AA42C, 0x80
+sMarshtompGfx16_2:
+.incbin "baserom.gba", 0x10AA4AC, 0x40
+sMarshtompSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx16_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMarshtompGfx17:
+.incbin "baserom.gba", 0x10AA52C, 0x60
+sMarshtompGfx17_1:
+.incbin "baserom.gba", 0x10AA58C, 0x80
+sMarshtompSprites17:
+ax_sprite sMarshtompGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx17_1, 0x80
+ax_sprite_terminator
+sMarshtompGfx18:
+.incbin "baserom.gba", 0x10AA62C, 0x60
+sMarshtompGfx18_1:
+.incbin "baserom.gba", 0x10AA68C, 0x60
+sMarshtompGfx18_2:
+.incbin "baserom.gba", 0x10AA6EC, 0x40
+sMarshtompSprites18:
+ax_sprite 0, 0x80
+ax_sprite sMarshtompGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx19:
+.incbin "baserom.gba", 0x10AA76C, 0x20
+sMarshtompGfx19_1:
+.incbin "baserom.gba", 0x10AA78C, 0x60
+sMarshtompGfx19_2:
+.incbin "baserom.gba", 0x10AA7EC, 0x60
+sMarshtompGfx19_3:
+.incbin "baserom.gba", 0x10AA84C, 0x40
+sMarshtompSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx20:
+.incbin "baserom.gba", 0x10AA8DC, 0x40
+sMarshtompGfx20_1:
+.incbin "baserom.gba", 0x10AA91C, 0xE0
+sMarshtompGfx20_2:
+.incbin "baserom.gba", 0x10AA9FC, 0x40
+sMarshtompSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx20_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx21:
+.incbin "baserom.gba", 0x10AAA7C, 0x20
+sMarshtompGfx21_1:
+.incbin "baserom.gba", 0x10AAA9C, 0x60
+sMarshtompGfx21_2:
+.incbin "baserom.gba", 0x10AAAFC, 0x40
+sMarshtompGfx21_3:
+.incbin "baserom.gba", 0x10AAB3C, 0x40
+sMarshtompSprites21:
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx21_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx22:
+.incbin "baserom.gba", 0x10AABCC, 0x40
+sMarshtompGfx22_1:
+.incbin "baserom.gba", 0x10AAC0C, 0x60
+sMarshtompGfx22_2:
+.incbin "baserom.gba", 0x10AAC6C, 0x40
+sMarshtompSprites22:
+ax_sprite 0, 0xa0
+ax_sprite sMarshtompGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx23:
+.incbin "baserom.gba", 0x10AACEC, 0x60
+sMarshtompGfx23_1:
+.incbin "baserom.gba", 0x10AAD4C, 0x60
+sMarshtompGfx23_2:
+.incbin "baserom.gba", 0x10AADAC, 0x60
+sMarshtompSprites23:
+ax_sprite 0, 0xa0
+ax_sprite sMarshtompGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx23_2, 0x60
+ax_sprite_terminator
+sMarshtompGfx24:
+.incbin "baserom.gba", 0x10AAE44, 0x60
+sMarshtompGfx24_1:
+.incbin "baserom.gba", 0x10AAEA4, 0x60
+sMarshtompGfx24_2:
+.incbin "baserom.gba", 0x10AAF04, 0x60
+sMarshtompSprites24:
+ax_sprite 0, 0xa0
+ax_sprite sMarshtompGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx24_2, 0x60
+ax_sprite_terminator
+sMarshtompGfx25:
+.incbin "baserom.gba", 0x10AAF9C, 0x40
+sMarshtompGfx25_1:
+.incbin "baserom.gba", 0x10AAFDC, 0x60
+sMarshtompGfx25_2:
+.incbin "baserom.gba", 0x10AB03C, 0x40
+sMarshtompSprites25:
+ax_sprite 0, 0xa0
+ax_sprite sMarshtompGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx26:
+.incbin "baserom.gba", 0x10AB0BC, 0x40
+sMarshtompGfx26_1:
+.incbin "baserom.gba", 0x10AB0FC, 0x100
+sMarshtompSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx26_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMarshtompGfx27:
+.incbin "baserom.gba", 0x10AB22C, 0xE0
+sMarshtompSprites27:
+ax_sprite sMarshtompGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx28:
+.incbin "baserom.gba", 0x10AB324, 0x60
+sMarshtompGfx28_1:
+.incbin "baserom.gba", 0x10AB384, 0x60
+sMarshtompSprites28:
+ax_sprite sMarshtompGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx29:
+.incbin "baserom.gba", 0x10AB40C, 0x60
+sMarshtompGfx29_1:
+.incbin "baserom.gba", 0x10AB46C, 0x60
+sMarshtompGfx29_2:
+.incbin "baserom.gba", 0x10AB4CC, 0x40
+sMarshtompSprites29:
+ax_sprite 0, 0x80
+ax_sprite sMarshtompGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx30:
+.incbin "baserom.gba", 0x10AB54C, 0x40
+sMarshtompGfx30_1:
+.incbin "baserom.gba", 0x10AB58C, 0x40
+sMarshtompGfx30_2:
+.incbin "baserom.gba", 0x10AB5CC, 0x60
+sMarshtompGfx30_3:
+.incbin "baserom.gba", 0x10AB62C, 0x40
+sMarshtompSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMarshtompGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMarshtompGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMarshtompGfx31:
+.incbin "baserom.gba", 0x10AB6BC, 0x200
+sMarshtompSprites31:
+ax_sprite sMarshtompGfx31, 0x200
+ax_sprite_terminator
+sMarshtompGfx32:
+.incbin "baserom.gba", 0x10AB8CC, 0x200
+sMarshtompSprites32:
+ax_sprite sMarshtompGfx32, 0x200
+ax_sprite_terminator
+sMarshtompGfx33:
+.incbin "baserom.gba", 0x10ABADC, 0x200
+sMarshtompSprites33:
+ax_sprite sMarshtompGfx33, 0x200
+ax_sprite_terminator
+sMarshtompGfx34:
+.incbin "baserom.gba", 0x10ABCEC, 0x200
+sMarshtompSprites34:
+ax_sprite sMarshtompGfx34, 0x200
+ax_sprite_terminator
+sMarshtompGfx35:
+.incbin "baserom.gba", 0x10ABEFC, 0x200
+sMarshtompSprites35:
+ax_sprite sMarshtompGfx35, 0x200
+ax_sprite_terminator
+sMarshtompGfx36:
+.incbin "baserom.gba", 0x10AC10C, 0x200
+sMarshtompSprites36:
+ax_sprite sMarshtompGfx36, 0x200
+ax_sprite_terminator
+sMarshtompGfx37:
+.incbin "baserom.gba", 0x10AC31C, 0x200
+sMarshtompSprites37:
+ax_sprite sMarshtompGfx37, 0x200
+ax_sprite_terminator
+sAxPosesMarshtomp:
+.4byte sMarshtompPose1
+.4byte sMarshtompPose2
+.4byte sMarshtompPose3
+.4byte sMarshtompPose4
+.4byte sMarshtompPose5
+.4byte sMarshtompPose6
+.4byte sMarshtompPose7
+.4byte sMarshtompPose8
+.4byte sMarshtompPose9
+.4byte sMarshtompPose10
+.4byte sMarshtompPose11
+.4byte sMarshtompPose12
+.4byte sMarshtompPose13
+.4byte sMarshtompPose14
+.4byte sMarshtompPose15
+.4byte sMarshtompPose16
+.4byte sMarshtompPose17
+.4byte sMarshtompPose18
+.4byte sMarshtompPose19
+.4byte sMarshtompPose20
+.4byte sMarshtompPose21
+.4byte sMarshtompPose22
+.4byte sMarshtompPose23
+.4byte sMarshtompPose24
+.4byte sMarshtompPose25
+.4byte sMarshtompPose26
+.4byte sMarshtompPose27
+.4byte sMarshtompPose28
+.4byte sMarshtompPose29
+.4byte sMarshtompPose30
+.4byte sMarshtompPose31
+.4byte sMarshtompPose32
+.4byte sMarshtompPose33
+.4byte sMarshtompPose34
+.4byte sMarshtompPose35
+.4byte sMarshtompPose36
+.4byte sMarshtompPose37
+.4byte sMarshtompPose38
+.4byte sMarshtompPose39
+.4byte sMarshtompPose40
+.4byte sMarshtompPose41
+.4byte sMarshtompPose42
+.4byte sMarshtompPose43
+.4byte sMarshtompPose44
+.4byte sMarshtompPose45
+.4byte sMarshtompPose46
+.4byte sMarshtompPose47
+.4byte sMarshtompPose48
+.4byte sMarshtompPose49
+.4byte sMarshtompPose50
+.4byte sMarshtompPose51
+.4byte sMarshtompPose52
+.4byte sMarshtompPose53
+.4byte sMarshtompPose54
+.4byte sMarshtompPose55
+.4byte sMarshtompPose56
+.4byte sMarshtompPose57
+.4byte sMarshtompPose58
+.4byte sMarshtompPose59
+.4byte sMarshtompPose60
+.4byte sMarshtompPose61
+.4byte sMarshtompPose62
+.4byte sMarshtompPose63
+.4byte sMarshtompPose64
+.4byte sMarshtompPose65
+.4byte sMarshtompPose66
+.4byte sMarshtompPose67
+.4byte sMarshtompPose68
+.4byte sMarshtompPose69
+.4byte sMarshtompPose70
+.4byte sMarshtompPose71
+.4byte sMarshtompPose72
+.4byte sMarshtompPose73
+.4byte sMarshtompPose74
+.4byte sMarshtompPose75
+.4byte sMarshtompPose76
+.4byte sMarshtompPose77
+.4byte sMarshtompPose78
+.4byte sMarshtompPose79
+.4byte sMarshtompPose80
+.4byte sMarshtompPose81
+.4byte sMarshtompPose82
+.4byte sMarshtompPose83
+.4byte sMarshtompPose84
+.4byte sMarshtompPose85
+.4byte sMarshtompPose86
+.4byte sMarshtompPose87
+.4byte sMarshtompPose88
+.4byte sMarshtompPose89
+.4byte sMarshtompPose90
+.4byte sMarshtompPose91
+.4byte sMarshtompPose92
+.4byte sMarshtompPose93
+.4byte sMarshtompPose94
+.4byte sMarshtompPose95
+.4byte sMarshtompPose96
+.4byte sMarshtompPose97
+.4byte sMarshtompPose98
+.4byte sMarshtompPose99
+.4byte sMarshtompPose100
+.4byte sMarshtompPose101
+.4byte sMarshtompPose102
+.4byte sMarshtompPose103
+.4byte sMarshtompPose104
+.4byte sMarshtompPose105
+.4byte sMarshtompPose106
+.4byte sMarshtompPose107
+.4byte sMarshtompPose108
+.4byte sMarshtompPose109
+.4byte sMarshtompPose110
+.4byte sMarshtompPose111
+.4byte sMarshtompPose112
+.4byte sMarshtompPose113
+.4byte sMarshtompPose114
+.4byte sMarshtompPose115
+.4byte sMarshtompPose116
+.4byte sMarshtompPose117
+.4byte sMarshtompPose118
+.4byte sMarshtompPose119
+.4byte sMarshtompPose120
+.4byte sMarshtompPose121
+.4byte sMarshtompPose122
+.4byte sMarshtompPose123
+.4byte sMarshtompPose124
+.4byte sMarshtompPose125
+.4byte sMarshtompPose126
+.4byte sMarshtompPose127
+.4byte sMarshtompPose128
+.4byte sMarshtompPose129
+.4byte sMarshtompPose130
+.4byte sMarshtompPose131
+.4byte sMarshtompPose132
+.4byte sMarshtompPose133
+.4byte sMarshtompPose134
+.4byte sMarshtompPose135
+.4byte sMarshtompPose136
+.4byte sMarshtompPose137
+.4byte sMarshtompPose138
+.4byte sMarshtompPose139
+.4byte sMarshtompPose140
+.4byte sMarshtompPose141
+.4byte sMarshtompPose142
+.4byte sMarshtompPose143
+.4byte sMarshtompPose144
+.4byte sMarshtompPose145
+.4byte sMarshtompPose146
+.4byte sMarshtompPose147
+.4byte sMarshtompPose148
+.4byte sMarshtompPose149
+.4byte sMarshtompPose150
+.4byte sMarshtompPose151
+.4byte sMarshtompPose152
+.4byte sMarshtompPose153
+.4byte sMarshtompPose154
+.4byte sMarshtompPose155
+.4byte sMarshtompPose156
+.4byte sMarshtompPose157
+.4byte sMarshtompPose158
+.4byte sMarshtompPose159
+.4byte sMarshtompPose160
+.4byte sMarshtompPose161
+.4byte sMarshtompPose162
+.4byte sMarshtompPose163
+.4byte sMarshtompPose164
+.4byte sMarshtompPose165
+.4byte sMarshtompPose166
+.4byte sMarshtompPose167
+.4byte sMarshtompPose168
+.4byte sMarshtompPose169
+.4byte sMarshtompPose170
+.4byte sMarshtompPose171
+.4byte sMarshtompPose172
+.4byte sMarshtompPose173
+.4byte sMarshtompPose174
+.4byte sMarshtompPose175
+.4byte sMarshtompPose176
+.4byte sMarshtompPose177
+.4byte sMarshtompPose178
+.4byte sMarshtompPose179
+.4byte sMarshtompPose180
+.4byte sMarshtompPose181
+.4byte sMarshtompPose182
+.4byte sMarshtompPose183
+.4byte sMarshtompPose184
+.4byte sMarshtompPose185
+.4byte sMarshtompPose186
+.4byte sMarshtompPose187
+.4byte sMarshtompPose188
+.4byte sMarshtompPose189
+.4byte sMarshtompPose190
+.4byte sMarshtompPose191
+.4byte sMarshtompPose192
+.4byte sMarshtompPose193
+.4byte sMarshtompPose194
+.4byte sMarshtompPose195
+.4byte sMarshtompPose196
+.4byte sMarshtompPose197
+.4byte sMarshtompPose198
+.4byte sMarshtompPose199
+.4byte sMarshtompPose200
+.4byte sMarshtompPose201
+.4byte sMarshtompPose202
+.4byte sMarshtompPose203
+.4byte sMarshtompPose204
+.4byte sMarshtompPose205
+.4byte sMarshtompPose206
+.4byte sMarshtompPose207
+.4byte sMarshtompPose208
+.4byte sMarshtompPose209
+.4byte sMarshtompPose210
+.4byte sMarshtompPose211
+.4byte sMarshtompPose212
+.4byte sMarshtompPose213
+.4byte sMarshtompPose214
+.4byte sMarshtompPose215
+.4byte sMarshtompPose216
+.4byte sMarshtompPose217
+.4byte sMarshtompPose218
+.4byte sMarshtompPose219
+.4byte sMarshtompPose220
+.4byte sMarshtompPose221
+.4byte sMarshtompPose222
+.4byte sMarshtompPose223
+.4byte sMarshtompPose224
+.4byte sMarshtompPose225
+.4byte sMarshtompPose226
+sAxPositionsMarshtomp:
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   5,    1, 	   0,   -4
+.2byte    0,   -6, 	  -5,    1, 	   6,   -1, 	   0,   -4
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+.2byte    3,   -7, 	   3,   -1, 	  -1,    2, 	   2,   -4
+.2byte    3,   -7, 	   8,   -1, 	  -6,    0, 	   1,   -4
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    5,   -7, 	   6,    0, 	   3,    2, 	   2,   -5
+.2byte    5,   -7, 	   7,   -2, 	  -2,    1, 	   2,   -5
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    3,   -6, 	  -5,   -1, 	   6,    1, 	   0,   -5
+.2byte    3,   -6, 	   3,   -2, 	   3,    2, 	   0,   -5
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    0,   -8, 	   7,    0, 	  -6,   -3, 	   0,   -5
+.2byte    0,   -8, 	   6,   -3, 	  -7,    0, 	   0,   -5
+.2byte   -3,   -7, 	   4,   -2, 	  -4,    1, 	   0,   -6
+.2byte   -3,   -6, 	   5,   -1, 	  -6,    1, 	   0,   -5
+.2byte   -3,   -6, 	  -3,   -2, 	  -3,    2, 	   0,   -5
+.2byte   -5,   -8, 	  -4,   -2, 	   1,    1, 	  -2,   -6
+.2byte   -5,   -7, 	  -6,    0, 	  -3,    2, 	  -2,   -5
+.2byte   -5,   -7, 	  -7,   -2, 	   2,    1, 	  -2,   -5
+.2byte   -3,   -8, 	  -6,   -3, 	   4,    0, 	  -2,   -5
+.2byte   -3,   -7, 	  -3,   -1, 	   1,    2, 	  -2,   -4
+.2byte   -3,   -7, 	  -8,   -1, 	   6,    0, 	  -1,   -4
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   5,    1, 	   0,   -4
+.2byte    0,   -6, 	  -5,    1, 	   6,   -1, 	   0,   -4
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -5
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+.2byte    3,   -7, 	   3,   -1, 	  -1,    2, 	   2,   -4
+.2byte    3,   -7, 	   8,   -1, 	  -6,    0, 	   1,   -4
+.2byte    6,   -3, 	   9,   -8, 	  -7,   -3, 	   0,   -5
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    5,   -7, 	   6,    0, 	   3,    2, 	   2,   -5
+.2byte    5,   -7, 	   7,   -2, 	  -2,    1, 	   2,   -5
+.2byte   10,   -4, 	   2,   -7, 	   0,   -3, 	   5,   -5
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    3,   -6, 	  -5,   -1, 	   6,    1, 	   0,   -5
+.2byte    3,   -6, 	   3,   -2, 	   3,    2, 	   0,   -5
+.2byte    5,   -6, 	  -3,   -4, 	   1,    0, 	   3,   -6
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    0,   -8, 	   7,    0, 	  -6,   -3, 	   0,   -5
+.2byte    0,   -8, 	   6,   -3, 	  -7,    0, 	   0,   -5
+.2byte    0,  -13, 	   8,   -4, 	  -8,   -4, 	   0,   -9
+.2byte   -3,   -7, 	   4,   -2, 	  -4,    1, 	   0,   -6
+.2byte   -3,   -6, 	   5,   -1, 	  -6,    1, 	   0,   -5
+.2byte   -3,   -6, 	  -3,   -2, 	  -3,    2, 	   0,   -5
+.2byte   -5,   -6, 	   3,   -4, 	  -1,    0, 	  -3,   -6
+.2byte   -5,   -8, 	  -4,   -2, 	   1,    1, 	  -2,   -6
+.2byte   -5,   -7, 	  -6,    0, 	  -3,    2, 	  -2,   -5
+.2byte   -5,   -7, 	  -7,   -2, 	   2,    1, 	  -2,   -5
+.2byte  -10,   -4, 	  -2,   -7, 	   0,   -3, 	  -5,   -5
+.2byte   -3,   -8, 	  -6,   -3, 	   4,    0, 	  -2,   -5
+.2byte   -3,   -7, 	  -3,   -1, 	   1,    2, 	  -2,   -4
+.2byte   -3,   -7, 	  -8,   -1, 	   6,    0, 	  -1,   -4
+.2byte   -6,   -3, 	  -9,   -8, 	   7,   -3, 	   0,   -5
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   5,    1, 	   0,   -4
+.2byte    0,   -6, 	  -5,    1, 	   6,   -1, 	   0,   -4
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -5
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+.2byte    3,   -7, 	   3,   -1, 	  -1,    2, 	   2,   -4
+.2byte    3,   -7, 	   8,   -1, 	  -6,    0, 	   1,   -4
+.2byte    6,   -3, 	   9,   -8, 	  -7,   -3, 	   0,   -5
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    5,   -7, 	   6,    0, 	   3,    2, 	   2,   -5
+.2byte    5,   -7, 	   7,   -2, 	  -2,    1, 	   2,   -5
+.2byte   10,   -4, 	   2,   -7, 	   0,   -3, 	   5,   -5
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    3,   -6, 	  -5,   -1, 	   6,    1, 	   0,   -5
+.2byte    3,   -6, 	   3,   -2, 	   3,    2, 	   0,   -5
+.2byte    5,   -6, 	  -3,   -4, 	   1,    0, 	   3,   -6
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    0,   -8, 	   7,    0, 	  -6,   -3, 	   0,   -5
+.2byte    0,   -8, 	   6,   -3, 	  -7,    0, 	   0,   -5
+.2byte    0,  -13, 	   8,   -4, 	  -8,   -4, 	   0,   -9
+.2byte   -3,   -7, 	   4,   -2, 	  -4,    1, 	   0,   -6
+.2byte   -3,   -6, 	   5,   -1, 	  -6,    1, 	   0,   -5
+.2byte   -3,   -6, 	  -3,   -2, 	  -3,    2, 	   0,   -5
+.2byte   -5,   -6, 	   3,   -4, 	  -1,    0, 	  -3,   -6
+.2byte   -5,   -8, 	  -4,   -2, 	   1,    1, 	  -2,   -6
+.2byte   -5,   -7, 	  -6,    0, 	  -3,    2, 	  -2,   -5
+.2byte   -5,   -7, 	  -7,   -2, 	   2,    1, 	  -2,   -5
+.2byte  -10,   -4, 	  -2,   -7, 	   0,   -3, 	  -5,   -5
+.2byte   -3,   -8, 	  -6,   -3, 	   4,    0, 	  -2,   -5
+.2byte   -3,   -7, 	  -3,   -1, 	   1,    2, 	  -2,   -4
+.2byte   -3,   -7, 	  -8,   -1, 	   6,    0, 	  -1,   -4
+.2byte   -6,   -3, 	  -9,   -8, 	   7,   -3, 	   0,   -5
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte    0,  -12, 	  -2,   -7, 	   2,   -7, 	   0,   -8
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -5
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+.2byte    1,  -10, 	   5,   -7, 	   1,   -4, 	   1,   -7
+.2byte    6,   -3, 	   9,   -8, 	  -7,   -3, 	   0,   -5
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    2,  -14, 	   4,   -7, 	   4,   -4, 	   0,   -6
+.2byte   10,   -4, 	   2,   -7, 	   0,   -3, 	   5,   -5
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    1,  -15, 	  -2,  -11, 	   6,   -6, 	  -1,   -6
+.2byte    5,   -6, 	  -3,   -4, 	   1,    0, 	   3,   -6
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    0,  -10, 	   7,   -5, 	  -7,   -5, 	   0,   -5
+.2byte    0,  -13, 	   8,   -4, 	  -8,   -4, 	   0,   -9
+.2byte   -3,   -7, 	   4,   -2, 	  -4,    1, 	   0,   -6
+.2byte   -1,  -15, 	   2,  -11, 	  -6,   -6, 	   1,   -6
+.2byte   -5,   -6, 	   3,   -4, 	  -1,    0, 	  -3,   -6
+.2byte   -5,   -8, 	  -4,   -2, 	   1,    1, 	  -2,   -6
+.2byte   -2,  -14, 	  -4,   -7, 	  -4,   -4, 	   0,   -6
+.2byte  -10,   -4, 	  -2,   -7, 	   0,   -3, 	  -5,   -5
+.2byte   -3,   -8, 	  -6,   -3, 	   4,    0, 	  -2,   -5
+.2byte   -1,  -10, 	  -5,   -7, 	  -1,   -4, 	  -1,   -7
+.2byte   -6,   -3, 	  -9,   -8, 	   7,   -3, 	   0,   -5
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte    0,  -12, 	  -2,   -7, 	   2,   -7, 	   0,   -8
+.2byte    0,   -2, 	  -7,   -3, 	   7,   -3, 	   0,   -5
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+.2byte    1,  -10, 	   5,   -7, 	   1,   -4, 	   1,   -7
+.2byte    4,   -1, 	   8,   -6, 	  -5,   -1, 	   0,   -5
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    2,  -14, 	   4,   -7, 	   4,   -4, 	   0,   -6
+.2byte    5,   -2, 	   5,   -3, 	  -1,    1, 	   3,   -4
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    1,  -15, 	  -2,  -11, 	   6,   -6, 	  -1,   -6
+.2byte    4,   -7, 	   1,   -4, 	   5,    0, 	   2,   -7
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    0,  -10, 	   7,   -5, 	  -7,   -5, 	   0,   -5
+.2byte    0,  -10, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte   -3,   -7, 	   4,   -2, 	  -4,    1, 	   0,   -6
+.2byte   -1,  -15, 	   2,  -11, 	  -6,   -6, 	   1,   -6
+.2byte   -4,   -7, 	  -1,   -4, 	  -5,    0, 	  -2,   -7
+.2byte   -5,   -8, 	  -4,   -2, 	   1,    1, 	  -2,   -6
+.2byte   -2,  -14, 	  -4,   -7, 	  -4,   -4, 	   0,   -6
+.2byte   -5,   -2, 	  -5,   -3, 	   1,    1, 	  -3,   -4
+.2byte   -3,   -8, 	  -6,   -3, 	   4,    0, 	  -2,   -5
+.2byte   -1,  -10, 	  -5,   -7, 	  -1,   -4, 	  -1,   -7
+.2byte   -4,   -1, 	  -8,   -6, 	   5,   -1, 	   0,   -5
+.2byte   -6,    0, 	   0,   -7, 	   7,   -3, 	   1,   -3
+.2byte   -7,    0, 	   1,   -6, 	   7,   -3, 	   1,   -3
+.2byte    0,   -6, 	  -3,  -13, 	   3,  -13, 	   0,   -5
+.2byte    3,   -7, 	   3,  -13, 	   1,  -12, 	   0,   -5
+.2byte    3,   -4, 	   3,  -13, 	   3,  -10, 	  -1,   -5
+.2byte    3,   -6, 	   0,  -13, 	   5,  -12, 	  -2,   -6
+.2byte    0,   -8, 	   5,  -12, 	  -5,  -12, 	   0,   -6
+.2byte   -4,   -6, 	  -1,  -13, 	  -6,  -12, 	   1,   -6
+.2byte   -4,   -4, 	  -4,  -13, 	  -4,  -10, 	   0,   -5
+.2byte   -4,   -7, 	  -4,  -13, 	  -2,  -12, 	  -1,   -5
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   5,    1, 	   0,   -4
+.2byte    0,   -6, 	  -5,    1, 	   6,   -1, 	   0,   -4
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+.2byte    3,   -7, 	   3,   -1, 	  -1,    2, 	   2,   -4
+.2byte    3,   -7, 	   8,   -1, 	  -6,    0, 	   1,   -4
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    5,   -7, 	   6,    0, 	   3,    2, 	   2,   -5
+.2byte    5,   -7, 	   7,   -2, 	  -2,    1, 	   2,   -5
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    3,   -6, 	  -5,   -1, 	   6,    1, 	   0,   -5
+.2byte    3,   -6, 	   3,   -2, 	   3,    2, 	   0,   -5
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    0,   -8, 	   7,    0, 	  -6,   -3, 	   0,   -5
+.2byte    0,   -8, 	   6,   -3, 	  -7,    0, 	   0,   -5
+.2byte   -3,   -7, 	   4,   -2, 	  -4,    1, 	   0,   -6
+.2byte   -3,   -6, 	   5,   -1, 	  -6,    1, 	   0,   -5
+.2byte   -3,   -6, 	  -3,   -2, 	  -3,    2, 	   0,   -5
+.2byte   -5,   -8, 	  -4,   -2, 	   1,    1, 	  -2,   -6
+.2byte   -5,   -7, 	  -6,    0, 	  -3,    2, 	  -2,   -5
+.2byte   -5,   -7, 	  -7,   -2, 	   2,    1, 	  -2,   -5
+.2byte   -3,   -8, 	  -6,   -3, 	   4,    0, 	  -2,   -5
+.2byte   -3,   -7, 	  -3,   -1, 	   1,    2, 	  -2,   -4
+.2byte   -3,   -7, 	  -8,   -1, 	   6,    0, 	  -1,   -4
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -5
+.2byte   -5,   -3, 	  -8,   -8, 	   8,   -3, 	   1,   -5
+.2byte   -6,   -4, 	   2,   -7, 	   4,   -3, 	  -1,   -5
+.2byte   -3,   -6, 	   5,   -4, 	   1,    0, 	  -1,   -6
+.2byte    0,  -12, 	   8,   -3, 	  -8,   -3, 	   0,   -8
+.2byte    2,   -6, 	  -6,   -4, 	  -2,    0, 	   0,   -6
+.2byte    5,   -4, 	  -3,   -7, 	  -5,   -3, 	   0,   -5
+.2byte    5,   -3, 	   8,   -8, 	  -8,   -3, 	  -1,   -5
+.2byte    0,  -12, 	  -2,   -7, 	   2,   -7, 	   0,   -8
+.2byte    1,  -10, 	   5,   -7, 	   1,   -4, 	   1,   -7
+.2byte    2,  -14, 	   4,   -7, 	   4,   -4, 	   0,   -6
+.2byte    1,  -15, 	  -2,  -11, 	   6,   -6, 	  -1,   -6
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -7, 	   0,   -7
+.2byte   -2,  -15, 	   1,  -11, 	  -7,   -6, 	   0,   -6
+.2byte   -3,  -14, 	  -5,   -7, 	  -5,   -4, 	  -1,   -6
+.2byte   -2,  -10, 	  -6,   -7, 	  -2,   -4, 	  -2,   -7
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte    0,  -12, 	  -2,   -7, 	   2,   -7, 	   0,   -8
+.2byte    0,   -4, 	 -10,   -7, 	  10,   -7, 	   0,   -6
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+.2byte    1,  -10, 	   5,   -7, 	   1,   -4, 	   1,   -7
+.2byte    4,   -4, 	   7,   -9, 	  -9,   -4, 	  -2,   -6
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    2,  -14, 	   4,   -7, 	   4,   -4, 	   0,   -6
+.2byte    5,   -4, 	  -3,   -7, 	  -5,   -3, 	   0,   -5
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    1,  -15, 	  -2,  -11, 	   6,   -6, 	  -1,   -6
+.2byte    3,   -5, 	  -5,   -3, 	  -1,    1, 	   1,   -5
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    0,  -11, 	   7,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    0,  -12, 	   8,   -3, 	  -8,   -3, 	   0,   -8
+.2byte   -4,   -7, 	   3,   -2, 	  -5,    1, 	  -1,   -6
+.2byte   -2,  -15, 	   1,  -11, 	  -7,   -6, 	   0,   -6
+.2byte   -4,   -5, 	   4,   -3, 	   0,    1, 	  -2,   -5
+.2byte   -6,   -8, 	  -5,   -2, 	   0,    1, 	  -3,   -6
+.2byte   -3,  -14, 	  -5,   -7, 	  -5,   -4, 	  -1,   -6
+.2byte   -6,   -4, 	   2,   -7, 	   4,   -3, 	  -1,   -5
+.2byte   -4,   -8, 	  -7,   -3, 	   3,    0, 	  -3,   -5
+.2byte   -2,  -10, 	  -6,   -7, 	  -2,   -4, 	  -2,   -7
+.2byte   -5,   -4, 	  -8,   -9, 	   8,   -4, 	   1,   -6
+.2byte    0,   -3, 	 -10,   -6, 	  10,   -6, 	   0,   -5
+.2byte   -5,   -3, 	  -8,   -8, 	   8,   -3, 	   1,   -5
+.2byte   -6,   -4, 	   2,   -7, 	   4,   -3, 	  -1,   -5
+.2byte   -3,   -6, 	   5,   -4, 	   1,    0, 	  -1,   -6
+.2byte    0,  -12, 	   8,   -3, 	  -8,   -3, 	   0,   -8
+.2byte    2,   -6, 	  -6,   -4, 	  -2,    0, 	   0,   -6
+.2byte    5,   -4, 	  -3,   -7, 	  -5,   -3, 	   0,   -5
+.2byte    4,   -3, 	   7,   -8, 	  -9,   -3, 	  -2,   -5
+.2byte    0,   -7, 	  -7,   -1, 	   7,   -1, 	   0,   -5
+.2byte   -3,   -8, 	  -6,   -3, 	   4,    0, 	  -2,   -5
+.2byte   -5,   -8, 	  -4,   -2, 	   1,    1, 	  -2,   -6
+.2byte   -3,   -7, 	   4,   -2, 	  -4,    1, 	   0,   -6
+.2byte    0,   -9, 	   8,   -1, 	  -8,   -1, 	   0,   -6
+.2byte    3,   -7, 	  -4,   -2, 	   4,    1, 	   0,   -6
+.2byte    5,   -8, 	   4,   -2, 	  -1,    1, 	   2,   -6
+.2byte    3,   -8, 	   6,   -3, 	  -4,    0, 	   2,   -5
+sMarshtompAnimTable1:
+.4byte sMarshtompAnims_1_1
+.4byte sMarshtompAnims_1_2
+.4byte sMarshtompAnims_1_3
+.4byte sMarshtompAnims_1_4
+.4byte sMarshtompAnims_1_5
+.4byte sMarshtompAnims_1_6
+.4byte sMarshtompAnims_1_7
+.4byte sMarshtompAnims_1_8
+sMarshtompAnimTable2:
+.4byte sMarshtompAnims_2_1
+.4byte sMarshtompAnims_2_2
+.4byte sMarshtompAnims_2_3
+.4byte sMarshtompAnims_2_4
+.4byte sMarshtompAnims_2_5
+.4byte sMarshtompAnims_2_6
+.4byte sMarshtompAnims_2_7
+.4byte sMarshtompAnims_2_8
+sMarshtompAnimTable3:
+.4byte sMarshtompAnims_3_1
+.4byte sMarshtompAnims_3_2
+.4byte sMarshtompAnims_3_3
+.4byte sMarshtompAnims_3_4
+.4byte sMarshtompAnims_3_5
+.4byte sMarshtompAnims_3_6
+.4byte sMarshtompAnims_3_7
+.4byte sMarshtompAnims_3_8
+sMarshtompAnimTable4:
+.4byte sMarshtompAnims_4_1
+.4byte sMarshtompAnims_4_2
+.4byte sMarshtompAnims_4_3
+.4byte sMarshtompAnims_4_4
+.4byte sMarshtompAnims_4_5
+.4byte sMarshtompAnims_4_6
+.4byte sMarshtompAnims_4_7
+.4byte sMarshtompAnims_4_8
+sMarshtompAnimTable5:
+.4byte sMarshtompAnims_5_1
+.4byte sMarshtompAnims_5_2
+.4byte sMarshtompAnims_5_3
+.4byte sMarshtompAnims_5_4
+.4byte sMarshtompAnims_5_5
+.4byte sMarshtompAnims_5_6
+.4byte sMarshtompAnims_5_7
+.4byte sMarshtompAnims_5_8
+sMarshtompAnimTable6:
+.4byte sMarshtompAnims_6_1
+.4byte sMarshtompAnims_6_1
+.4byte sMarshtompAnims_6_1
+.4byte sMarshtompAnims_6_1
+.4byte sMarshtompAnims_6_1
+.4byte sMarshtompAnims_6_1
+.4byte sMarshtompAnims_6_1
+.4byte sMarshtompAnims_6_1
+sMarshtompAnimTable7:
+.4byte sMarshtompAnims_7_1
+.4byte sMarshtompAnims_7_2
+.4byte sMarshtompAnims_7_3
+.4byte sMarshtompAnims_7_4
+.4byte sMarshtompAnims_7_5
+.4byte sMarshtompAnims_7_6
+.4byte sMarshtompAnims_7_7
+.4byte sMarshtompAnims_7_8
+sMarshtompAnimTable8:
+.4byte sMarshtompAnims_8_1
+.4byte sMarshtompAnims_8_2
+.4byte sMarshtompAnims_8_3
+.4byte sMarshtompAnims_8_4
+.4byte sMarshtompAnims_8_5
+.4byte sMarshtompAnims_8_6
+.4byte sMarshtompAnims_8_7
+.4byte sMarshtompAnims_8_8
+sMarshtompAnimTable9:
+.4byte sMarshtompAnims_9_1
+.4byte sMarshtompAnims_9_2
+.4byte sMarshtompAnims_9_3
+.4byte sMarshtompAnims_9_4
+.4byte sMarshtompAnims_9_5
+.4byte sMarshtompAnims_9_6
+.4byte sMarshtompAnims_9_7
+.4byte sMarshtompAnims_9_8
+sMarshtompAnimTable10:
+.4byte sMarshtompAnims_10_1
+.4byte sMarshtompAnims_10_2
+.4byte sMarshtompAnims_10_3
+.4byte sMarshtompAnims_10_4
+.4byte sMarshtompAnims_10_5
+.4byte sMarshtompAnims_10_6
+.4byte sMarshtompAnims_10_7
+.4byte sMarshtompAnims_10_8
+sMarshtompAnimTable11:
+.4byte sMarshtompAnims_11_1
+.4byte sMarshtompAnims_11_2
+.4byte sMarshtompAnims_11_3
+.4byte sMarshtompAnims_11_4
+.4byte sMarshtompAnims_11_5
+.4byte sMarshtompAnims_11_6
+.4byte sMarshtompAnims_11_7
+.4byte sMarshtompAnims_11_8
+sMarshtompAnimTable12:
+.4byte sMarshtompAnims_12_1
+.4byte sMarshtompAnims_12_2
+.4byte sMarshtompAnims_12_3
+.4byte sMarshtompAnims_12_4
+.4byte sMarshtompAnims_12_5
+.4byte sMarshtompAnims_12_6
+.4byte sMarshtompAnims_12_7
+.4byte sMarshtompAnims_12_8
+sMarshtompAnimTable13:
+.4byte sMarshtompAnims_13_1
+.4byte sMarshtompAnims_13_2
+.4byte sMarshtompAnims_13_3
+.4byte sMarshtompAnims_13_4
+.4byte sMarshtompAnims_13_5
+.4byte sMarshtompAnims_13_6
+.4byte sMarshtompAnims_13_7
+.4byte sMarshtompAnims_13_8
+sAxAnimationsMarshtomp:
+.4byte sMarshtompAnimTable1
+.4byte sMarshtompAnimTable2
+.4byte sMarshtompAnimTable3
+.4byte sMarshtompAnimTable4
+.4byte sMarshtompAnimTable5
+.4byte sMarshtompAnimTable6
+.4byte sMarshtompAnimTable7
+.4byte sMarshtompAnimTable8
+.4byte sMarshtompAnimTable9
+.4byte sMarshtompAnimTable10
+.4byte sMarshtompAnimTable11
+.4byte sMarshtompAnimTable12
+.4byte sMarshtompAnimTable13
+sAxSpritesMarshtomp:
+.4byte sMarshtompSprites1
+.4byte sMarshtompSprites2
+.4byte sMarshtompSprites3
+.4byte sMarshtompSprites4
+.4byte sMarshtompSprites5
+.4byte sMarshtompSprites6
+.4byte sMarshtompSprites7
+.4byte sMarshtompSprites8
+.4byte sMarshtompSprites9
+.4byte sMarshtompSprites10
+.4byte sMarshtompSprites11
+.4byte sMarshtompSprites12
+.4byte sMarshtompSprites13
+.4byte sMarshtompSprites14
+.4byte sMarshtompSprites15
+.4byte sMarshtompSprites16
+.4byte sMarshtompSprites17
+.4byte sMarshtompSprites18
+.4byte sMarshtompSprites19
+.4byte sMarshtompSprites20
+.4byte sMarshtompSprites21
+.4byte sMarshtompSprites22
+.4byte sMarshtompSprites23
+.4byte sMarshtompSprites24
+.4byte sMarshtompSprites25
+.4byte sMarshtompSprites26
+.4byte sMarshtompSprites27
+.4byte sMarshtompSprites28
+.4byte sMarshtompSprites29
+.4byte sMarshtompSprites30
+.4byte sMarshtompSprites31
+.4byte sMarshtompSprites32
+.4byte sMarshtompSprites33
+.4byte sMarshtompSprites34
+.4byte sMarshtompSprites35
+.4byte sMarshtompSprites36
+.4byte sMarshtompSprites37
+sAxMainMarshtomp:
+ax_main sAxPosesMarshtomp, sAxAnimationsMarshtomp, 13, sAxSpritesMarshtomp, sAxPositionsMarshtomp

--- a/data/ax/masquerain.inc
+++ b/data/ax/masquerain.inc
@@ -1,0 +1,2564 @@
+.global gAxMasquerain
+gAxMasquerain:
+ax_siro sAxMainMasquerain
+sMasquerainPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose3:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose4:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose5:
+ax_pose 4, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose6:
+ax_pose 5, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose7:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose8:
+ax_pose 7, 0x01e7, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose9:
+ax_pose 8, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose10:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose11:
+ax_pose 10, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose12:
+ax_pose 11, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose13:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose14:
+ax_pose 13, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose15:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose16:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose17:
+ax_pose 10, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose18:
+ax_pose 11, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose19:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose20:
+ax_pose 7, 0x01e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose21:
+ax_pose 8, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose22:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose23:
+ax_pose 4, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose24:
+ax_pose 5, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose25:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose27:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose28:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose29:
+ax_pose 4, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose30:
+ax_pose 5, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose31:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose32:
+ax_pose 7, 0x01e7, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose33:
+ax_pose 8, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose34:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose35:
+ax_pose 10, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose36:
+ax_pose 11, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose37:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose38:
+ax_pose 13, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose39:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose40:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose41:
+ax_pose 10, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose42:
+ax_pose 11, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose43:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose44:
+ax_pose 7, 0x01e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose45:
+ax_pose 8, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose46:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose47:
+ax_pose 4, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose48:
+ax_pose 5, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose49:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose50:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose51:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose52:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose53:
+ax_pose 4, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose54:
+ax_pose 5, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose55:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose56:
+ax_pose 7, 0x01e7, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose57:
+ax_pose 8, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose58:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose59:
+ax_pose 10, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose60:
+ax_pose 11, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose61:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose62:
+ax_pose 13, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose63:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose64:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose65:
+ax_pose 10, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose66:
+ax_pose 11, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose67:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose68:
+ax_pose 7, 0x01e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose69:
+ax_pose 8, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose70:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose71:
+ax_pose 4, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose72:
+ax_pose 5, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose73:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose74:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose75:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose76:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose77:
+ax_pose 4, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose78:
+ax_pose 5, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose79:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose80:
+ax_pose 7, 0x01e7, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose81:
+ax_pose 8, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose82:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose83:
+ax_pose 10, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose84:
+ax_pose 11, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose85:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose86:
+ax_pose 13, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose87:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose88:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose89:
+ax_pose 10, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose90:
+ax_pose 11, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose91:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose92:
+ax_pose 7, 0x01e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose93:
+ax_pose 8, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose94:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose95:
+ax_pose 4, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose96:
+ax_pose 5, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose97:
+ax_pose 15, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose98:
+ax_pose 16, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose99:
+ax_pose 17, 0x01e4, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose100:
+ax_pose 18, 0x01e4, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose101:
+ax_pose 19, 0x01e2, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose102:
+ax_pose 20, 0x01e2, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose103:
+ax_pose 21, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose104:
+ax_pose 22, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose105:
+ax_pose 23, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose106:
+ax_pose 24, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose107:
+ax_pose 21, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose108:
+ax_pose 22, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose109:
+ax_pose 19, 0x01e2, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose110:
+ax_pose 20, 0x01e2, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose111:
+ax_pose 17, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose112:
+ax_pose 18, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose113:
+ax_pose 25, 0x01f2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose114:
+ax_pose 26, 0x01f2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose115:
+ax_pose 27, 0x01dd, 0x80f1, 0x3c00
+ax_pose_terminator
+sMasquerainPose116:
+ax_pose 28, 0x01dd, 0x90ea, 0x3c00
+ax_pose_terminator
+sMasquerainPose117:
+ax_pose 29, 0x01e1, 0x90e7, 0x3c00
+ax_pose_terminator
+sMasquerainPose118:
+ax_pose 30, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sMasquerainPose119:
+ax_pose 31, 0x01df, 0x80f1, 0x3c00
+ax_pose_terminator
+sMasquerainPose120:
+ax_pose 30, 0x01e0, 0x80f5, 0x3c00
+ax_pose_terminator
+sMasquerainPose121:
+ax_pose 29, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose122:
+ax_pose 28, 0x01dd, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose123:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose124:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose125:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose126:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose127:
+ax_pose 4, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose128:
+ax_pose 5, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose129:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose130:
+ax_pose 7, 0x01e7, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose131:
+ax_pose 8, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose132:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose133:
+ax_pose 10, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose134:
+ax_pose 11, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose135:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose136:
+ax_pose 13, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose137:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose138:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose139:
+ax_pose 10, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose140:
+ax_pose 11, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose141:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose142:
+ax_pose 7, 0x01e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose143:
+ax_pose 8, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose144:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose145:
+ax_pose 4, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose146:
+ax_pose 5, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose147:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose148:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose149:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose150:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose151:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose152:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose153:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose154:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose155:
+ax_pose 15, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose156:
+ax_pose 17, 0x01e4, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose157:
+ax_pose 19, 0x01e2, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose158:
+ax_pose 21, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose159:
+ax_pose 23, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose160:
+ax_pose 21, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose161:
+ax_pose 19, 0x01e2, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose162:
+ax_pose 17, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose163:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose164:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose165:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose166:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose167:
+ax_pose 4, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose168:
+ax_pose 5, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose169:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose170:
+ax_pose 7, 0x01e7, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose171:
+ax_pose 8, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose172:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose173:
+ax_pose 10, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose174:
+ax_pose 11, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose175:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose176:
+ax_pose 13, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose177:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose178:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose179:
+ax_pose 10, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose180:
+ax_pose 11, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose181:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose182:
+ax_pose 7, 0x01e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose183:
+ax_pose 8, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose184:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose185:
+ax_pose 4, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose186:
+ax_pose 5, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose187:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose188:
+ax_pose 5, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose189:
+ax_pose 8, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose190:
+ax_pose 11, 0x01e8, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose191:
+ax_pose 14, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose192:
+ax_pose 11, 0x01e8, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose193:
+ax_pose 8, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose194:
+ax_pose 5, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sMasquerainPose195:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose196:
+ax_pose 3, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose197:
+ax_pose 6, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sMasquerainPose198:
+ax_pose 9, 0x01e9, 0x80f6, 0x3c00
+ax_pose_terminator
+sMasquerainPose199:
+ax_pose 12, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sMasquerainPose200:
+ax_pose 9, 0x01e9, 0x90e9, 0x3c00
+ax_pose_terminator
+sMasquerainPose201:
+ax_pose 6, 0x01e1, 0x90e6, 0x3c00
+ax_pose_terminator
+sMasquerainPose202:
+ax_pose 3, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+.align 2
+sMasquerainAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 1, 1, 1, 0,
+ax_anim 6, 0, 0, 2, 0, 2, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -1, 1, -1, 0,
+ax_anim 6, 0, 0, -2, 0, -2, 0,
+ax_anim 6, 0, 2, -1, -1, -1, 0,
+ax_anim_terminator
+sMasquerainAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 1, 1, -1,
+ax_anim 6, 0, 3, 2, 0, 2, -2,
+ax_anim 6, 0, 5, 2, -2, 1, -1,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -1, 2, -1, 1,
+ax_anim 6, 0, 3, -2, 0, -2, 2,
+ax_anim 6, 0, 5, -1, -1, -1, 1,
+ax_anim_terminator
+sMasquerainAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, 1, 1, 1,
+ax_anim 6, 0, 6, 2, 0, 2, 0,
+ax_anim 6, 0, 8, 1, -1, 1, -1,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -1, 1, -1, 1,
+ax_anim 6, 0, 6, -2, 0, -2, 0,
+ax_anim 6, 0, 8, -1, -1, -1, -1,
+ax_anim_terminator
+sMasquerainAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, 2, 1, 1,
+ax_anim 6, 0, 9, 2, 0, 2, 2,
+ax_anim 6, 0, 11, 1, -1, 1, 1,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, 1, -1, -1,
+ax_anim 6, 0, 9, -2, -1, -2, -2,
+ax_anim 6, 0, 11, -1, -2, -1, -1,
+ax_anim_terminator
+sMasquerainAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, -1, 1, -1, 0,
+ax_anim 6, 0, 12, -2, 0, -2, 0,
+ax_anim 6, 0, 14, -1, -1, -1, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 1, 1, 1, 0,
+ax_anim 6, 0, 12, 2, 0, 2, 0,
+ax_anim 6, 0, 14, 1, -1, 1, 0,
+ax_anim_terminator
+sMasquerainAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, 2, -1, 1,
+ax_anim 6, 0, 15, -2, 0, -2, 2,
+ax_anim 6, 0, 17, -1, -1, -1, 1,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 1, 1, 1, -1,
+ax_anim 6, 0, 15, 2, -1, 2, -2,
+ax_anim 6, 0, 17, 1, -2, 1, -1,
+ax_anim_terminator
+sMasquerainAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, 1, -1, 1,
+ax_anim 6, 0, 18, -2, 0, -2, 0,
+ax_anim 6, 0, 20, -1, -1, -1, -1,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 1, 1, 1, 1,
+ax_anim 6, 0, 18, 2, 0, 2, 0,
+ax_anim 6, 0, 20, 1, -1, 1, -1,
+ax_anim_terminator
+sMasquerainAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 1, -1, -1,
+ax_anim 6, 0, 21, -2, 0, -2, -2,
+ax_anim 6, 0, 23, -2, -2, -1, -1,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 1, 2, 1, 1,
+ax_anim 6, 0, 21, 2, 0, 2, 2,
+ax_anim 6, 0, 23, 1, -1, 1, 1,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 23, 0, 23,
+ax_anim 2, 1, 27, 0, 23, 0, 23,
+ax_anim 2, 0, 24, 0, 23, 0, 23,
+ax_anim 2, 0, 45, 0, 23, 0, 23,
+ax_anim 2, 0, 24, 0, 23, 0, 23,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim_terminator
+sMasquerainAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 12, 13, 12, 13,
+ax_anim 2, 0, 27, 21, 23, 21, 23,
+ax_anim 2, 1, 30, 21, 23, 21, 23,
+ax_anim 2, 0, 27, 21, 23, 21, 23,
+ax_anim 2, 0, 24, 21, 23, 21, 23,
+ax_anim 2, 0, 27, 21, 23, 21, 23,
+ax_anim 2, 0, 30, 21, 23, 21, 23,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sMasquerainAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 1, 27, 23, 0, 23, 0,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 0, 33, 23, 0, 23, 0,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 0, 27, 23, 0, 23, 0,
+ax_anim 2, 0, 30, 8, 0, 8, 0,
+ax_anim_terminator
+sMasquerainAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 5, -4, 5, -4,
+ax_anim 1, 0, 35, 14, -12, 14, -12,
+ax_anim 2, 0, 33, 22, -19, 22, -19,
+ax_anim 2, 1, 30, 22, -19, 22, -19,
+ax_anim 2, 0, 33, 22, -19, 22, -19,
+ax_anim 2, 0, 36, 22, -19, 22, -19,
+ax_anim 2, 0, 33, 22, -19, 22, -19,
+ax_anim 2, 0, 30, 22, -19, 22, -19,
+ax_anim 2, 0, 33, 9, -7, 9, -7,
+ax_anim_terminator
+sMasquerainAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -12, 0, -12,
+ax_anim 2, 0, 36, 0, -20, 0, -23,
+ax_anim 2, 1, 39, 0, -20, 0, -23,
+ax_anim 2, 0, 36, 0, -20, 0, -23,
+ax_anim 2, 0, 33, 0, -20, 0, -23,
+ax_anim 2, 0, 36, 0, -20, 0, -23,
+ax_anim 2, 0, 39, 0, -20, 0, -23,
+ax_anim 2, 0, 36, 0, -8, 0, -8,
+ax_anim_terminator
+sMasquerainAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -5, -4, -5, -4,
+ax_anim 1, 0, 41, -14, -12, -14, -12,
+ax_anim 2, 0, 39, -22, -19, -22, -19,
+ax_anim 2, 1, 36, -22, -19, -22, -19,
+ax_anim 2, 0, 39, -22, -19, -22, -19,
+ax_anim 2, 0, 42, -22, -19, -22, -19,
+ax_anim 2, 0, 39, -22, -19, -22, -19,
+ax_anim 2, 0, 36, -22, -19, -22, -19,
+ax_anim 2, 0, 39, -9, -7, -9, -7,
+ax_anim_terminator
+sMasquerainAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 2, 0, 42, -23, 0, -23, 0,
+ax_anim 2, 1, 45, -23, 0, -23, 0,
+ax_anim 2, 0, 42, -23, 0, -23, 0,
+ax_anim 2, 0, 39, -23, 0, -23, 0,
+ax_anim 2, 0, 42, -23, 0, -23, 0,
+ax_anim 2, 0, 45, -23, 0, -23, 0,
+ax_anim 2, 0, 42, -8, 0, -8, 0,
+ax_anim_terminator
+sMasquerainAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -12, 13, -12, 13,
+ax_anim 2, 0, 45, -21, 23, -21, 23,
+ax_anim 2, 1, 24, -21, 23, -21, 23,
+ax_anim 2, 0, 45, -21, 23, -21, 23,
+ax_anim 2, 0, 42, -21, 23, -21, 23,
+ax_anim 2, 0, 45, -21, 23, -21, 23,
+ax_anim 2, 0, 24, -21, 23, -21, 23,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 12, 0, 12,
+ax_anim 1, 0, 50, 0, 28, 0, 28,
+ax_anim 2, 0, 48, 0, 47, 0, 47,
+ax_anim 2, 1, 51, 0, 47, 0, 47,
+ax_anim 2, 0, 48, 0, 47, 0, 47,
+ax_anim 2, 0, 69, 0, 47, 0, 47,
+ax_anim 2, 0, 48, 0, 47, 0, 47,
+ax_anim 2, 0, 51, 0, 47, 0, 47,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim_terminator
+sMasquerainAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 12, 12, 12, 12,
+ax_anim 1, 0, 53, 28, 29, 28, 29,
+ax_anim 2, 0, 51, 45, 47, 45, 47,
+ax_anim 2, 1, 54, 45, 47, 45, 47,
+ax_anim 2, 0, 51, 45, 47, 45, 47,
+ax_anim 2, 0, 48, 45, 47, 45, 47,
+ax_anim 2, 0, 51, 45, 47, 45, 47,
+ax_anim 2, 0, 54, 45, 47, 45, 47,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sMasquerainAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 12, 0, 12, 0,
+ax_anim 1, 0, 56, 28, 0, 28, 0,
+ax_anim 2, 0, 54, 47, 0, 47, 0,
+ax_anim 2, 1, 51, 47, 0, 47, 0,
+ax_anim 2, 0, 54, 47, 0, 47, 0,
+ax_anim 2, 0, 57, 47, 0, 47, 0,
+ax_anim 2, 0, 54, 47, 0, 47, 0,
+ax_anim 2, 0, 51, 47, 0, 47, 0,
+ax_anim 2, 0, 54, 8, 0, 8, 0,
+ax_anim_terminator
+sMasquerainAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 13, -12, 13, -12,
+ax_anim 1, 0, 59, 30, -28, 30, -28,
+ax_anim 2, 0, 57, 46, -43, 46, -43,
+ax_anim 2, 1, 54, 46, -43, 46, -43,
+ax_anim 2, 0, 57, 46, -43, 46, -43,
+ax_anim 2, 0, 60, 46, -43, 46, -43,
+ax_anim 2, 0, 57, 46, -43, 46, -43,
+ax_anim 2, 0, 54, 46, -43, 46, -43,
+ax_anim 2, 0, 57, 9, -7, 9, -7,
+ax_anim_terminator
+sMasquerainAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -12, 0, -12,
+ax_anim 1, 0, 62, 0, -28, 0, -28,
+ax_anim 2, 0, 60, 0, -44, 0, -44,
+ax_anim 2, 1, 63, 0, -44, 0, -44,
+ax_anim 2, 0, 60, 0, -44, 0, -44,
+ax_anim 2, 0, 57, 0, -44, 0, -44,
+ax_anim 2, 0, 60, 0, -44, 0, -44,
+ax_anim 2, 0, 63, 0, -44, 0, -44,
+ax_anim 2, 0, 60, 0, -8, 0, -8,
+ax_anim_terminator
+sMasquerainAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 65, -13, -12, -13, -12,
+ax_anim 1, 0, 65, -30, -28, -30, -28,
+ax_anim 2, 0, 63, -46, -43, -46, -43,
+ax_anim 2, 1, 60, -46, -43, -46, -43,
+ax_anim 2, 0, 63, -46, -43, -46, -43,
+ax_anim 2, 0, 66, -46, -43, -46, -43,
+ax_anim 2, 0, 63, -46, -43, -46, -43,
+ax_anim 2, 0, 60, -46, -43, -46, -43,
+ax_anim 2, 0, 63, -9, -7, -9, -7,
+ax_anim_terminator
+sMasquerainAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -12, 0, -12, 0,
+ax_anim 1, 0, 68, -28, 0, -28, 0,
+ax_anim 2, 0, 66, -47, 0, -47, 0,
+ax_anim 2, 1, 69, -47, 0, -47, 0,
+ax_anim 2, 0, 66, -47, 0, -47, 0,
+ax_anim 2, 0, 63, -47, 0, -47, 0,
+ax_anim 2, 0, 66, -47, 0, -47, 0,
+ax_anim 2, 0, 69, -47, 0, -47, 0,
+ax_anim 2, 0, 66, -8, 0, -8, 0,
+ax_anim_terminator
+sMasquerainAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -12, 12, -12, 12,
+ax_anim 1, 0, 71, -28, 29, -28, 29,
+ax_anim 2, 0, 69, -45, 47, -45, 47,
+ax_anim 2, 1, 48, -45, 47, -45, 47,
+ax_anim 2, 0, 69, -45, 47, -45, 47,
+ax_anim 2, 0, 66, -45, 47, -45, 47,
+ax_anim 2, 0, 69, -45, 47, -45, 47,
+ax_anim 2, 0, 48, -45, 47, -45, 47,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 6, 2, 72, 0, -3, 0, -3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 1, 72, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 1, 4, 1, 4,
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 1, 4, 1, 4,
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 1, 4, 1, 4,
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sMasquerainAnims_4_2:
+ax_anim 2, 0, 75, -2, -2, -2, -2,
+ax_anim 6, 2, 75, -3, -3, -3, -3,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 1, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 5, 3, 5, 3,
+ax_anim 2, 0, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 5, 3, 5, 3,
+ax_anim 2, 0, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 5, 3, 5, 3,
+ax_anim 2, 0, 75, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim_terminator
+sMasquerainAnims_4_3:
+ax_anim 2, 0, 78, -2, 0, -2, 0,
+ax_anim 6, 2, 78, -3, 0, -3, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 1, 78, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 4, 1, 4, 1,
+ax_anim 2, 0, 78, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 4, 1, 4, 1,
+ax_anim 2, 0, 78, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 4, 1, 4, 1,
+ax_anim 2, 0, 78, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sMasquerainAnims_4_4:
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim 6, 2, 81, -3, 3, -3, 3,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 1, 81, 4, -4, 4, -4,
+ax_anim 2, 0, 81, 5, -3, 5, -3,
+ax_anim 2, 0, 81, 4, -4, 4, -4,
+ax_anim 2, 0, 81, 5, -3, 5, -3,
+ax_anim 2, 0, 81, 4, -4, 4, -4,
+ax_anim 2, 0, 81, 5, -3, 5, -3,
+ax_anim 2, 0, 81, 4, -4, 4, -4,
+ax_anim 2, 0, 81, 2, -2, 2, -2,
+ax_anim_terminator
+sMasquerainAnims_4_5:
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 6, 2, 84, 0, 3, 0, 3,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 1, 84, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 1, -4, 1, -4,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 1, -4, 1, -4,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 1, -4, 1, -4,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim_terminator
+sMasquerainAnims_4_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 6, 2, 87, 3, 3, 3, 3,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 1, 87, -4, -4, -4, -4,
+ax_anim 2, 0, 87, -5, -3, -5, -3,
+ax_anim 2, 0, 87, -4, -4, -4, -4,
+ax_anim 2, 0, 87, -5, -3, -5, -3,
+ax_anim 2, 0, 87, -4, -4, -4, -4,
+ax_anim 2, 0, 87, -5, -3, -5, -3,
+ax_anim 2, 0, 87, -4, -4, -4, -4,
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim_terminator
+sMasquerainAnims_4_7:
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim 6, 2, 90, 3, 0, 3, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 1, 90, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -4, 1, -4, 1,
+ax_anim 2, 0, 90, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -4, 1, -4, 1,
+ax_anim 2, 0, 90, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -4, 1, -4, 1,
+ax_anim 2, 0, 90, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sMasquerainAnims_4_8:
+ax_anim 2, 0, 93, 2, -2, 2, -2,
+ax_anim 6, 2, 93, 3, -3, 3, -3,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 1, 93, -4, 4, -4, 4,
+ax_anim 2, 0, 93, -5, 3, -5, 3,
+ax_anim 2, 0, 93, -4, 4, -4, 4,
+ax_anim 2, 0, 93, -5, 3, -5, 3,
+ax_anim 2, 0, 93, -4, 4, -4, 4,
+ax_anim 2, 0, 93, -5, 3, -5, 3,
+ax_anim 2, 0, 93, -4, 4, -4, 4,
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 2, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 1, 97, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_5_2:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 2, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 1, 99, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_5_3:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 2, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 1, 101, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_5_4:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 2, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 1, 103, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_5_5:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 2, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 1, 105, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_5_6:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 2, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 1, 107, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_5_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 2, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 1, 109, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_5_8:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 2, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 1, 111, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sMasquerainAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sMasquerainAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sMasquerainAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sMasquerainAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sMasquerainAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sMasquerainAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sMasquerainAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_8_1:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 1, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_8_2:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 1, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_8_3:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 1, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_8_4:
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 1, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_8_5:
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 1, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_8_6:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 1, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_8_7:
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 1, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_8_8:
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 1, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 9, 12, 9, 12,
+ax_anim 2, 0, 149, 6, 21, 6, 20,
+ax_anim 3, 0, 150, 0, 22, 0, 21,
+ax_anim 2, 3, 151, -6, 21, -6, 20,
+ax_anim 2, 0, 152, -9, 12, -9, 12,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 11, 2, 11, 2,
+ax_anim 2, 0, 147, 21, 7, 21, 7,
+ax_anim 2, 0, 148, 24, 15, 24, 15,
+ax_anim 3, 0, 149, 22, 22, 22, 20,
+ax_anim 2, 3, 150, 13, 22, 13, 21,
+ax_anim 2, 0, 151, 4, 19, 4, 19,
+ax_anim 1, 0, 152, 1, 8, 1, 8,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 2, -2, 2, -2,
+ax_anim 2, 0, 146, 9, -4, 9, -4,
+ax_anim 2, 0, 147, 19, -2, 19, -2,
+ax_anim 3, 0, 148, 21, 1, 21, 0,
+ax_anim 2, 3, 149, 19, 5, 19, 5,
+ax_anim 2, 0, 150, 11, 6, 11, 6,
+ax_anim 1, 0, 151, 5, 5, 5, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 1, -7, 1, -7,
+ax_anim 2, 0, 153, 3, -16, 3, -16,
+ax_anim 2, 0, 146, 12, -20, 12, -22,
+ax_anim 3, 0, 147, 21, -21, 21, -24,
+ax_anim 2, 3, 148, 24, -15, 24, -16,
+ax_anim 2, 0, 149, 19, -5, 19, -5,
+ax_anim 1, 0, 150, 11, -1, 11, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -7, -2, -7, -2,
+ax_anim 2, 0, 152, -8, -11, -8, -11,
+ax_anim 2, 0, 153, -6, -19, -6, -21,
+ax_anim 3, 0, 146, 0, -21, 0, -24,
+ax_anim 2, 3, 147, 6, -19, 6, -21,
+ax_anim 2, 0, 148, 8, -11, 8, -11,
+ax_anim 1, 0, 149, 7, -2, 7, -2,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -7, 1, -7,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -20, -12, -22,
+ax_anim 3, 0, 153, -21, -21, -21, -24,
+ax_anim 2, 3, 152, -24, -15, -24, -16,
+ax_anim 2, 0, 151, -19, -5, -19, -5,
+ax_anim 1, 0, 150, -11, -2, -11, -2,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -2, -2, -2, -2,
+ax_anim 2, 0, 146, -9, -4, -9, -4,
+ax_anim 2, 0, 153, -19, -2, -19, -2,
+ax_anim 3, 0, 152, -21, 1, -21, 0,
+ax_anim 2, 3, 151, -19, 5, -19, 5,
+ax_anim 2, 0, 150, -11, 6, -11, 6,
+ax_anim 1, 0, 149, -5, 5, -5, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -11, 2, -11, 2,
+ax_anim 2, 0, 153, -21, 7, -21, 7,
+ax_anim 2, 0, 152, -24, 15, -24, 15,
+ax_anim 3, 0, 151, -22, 22, -22, 20,
+ax_anim 2, 3, 150, -13, 22, -13, 21,
+ax_anim 2, 0, 149, -4, 19, -4, 19,
+ax_anim 1, 0, 148, -1, 8, -1, 8,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 164, 0, -21, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 4, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 167, 0, -21, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 4, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -22, 0, 0,
+ax_anim 3, 0, 170, 0, -21, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 3, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 2, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -22, 0, 0,
+ax_anim 3, 0, 176, 0, -21, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 2, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 2, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 182, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 3, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMasquerainAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMasquerainGfx1:
+.incbin "baserom.gba", 0x1195398, 0x200
+sMasquerainSprites1:
+ax_sprite sMasquerainGfx1, 0x200
+ax_sprite_terminator
+sMasquerainGfx2:
+.incbin "baserom.gba", 0x11955A8, 0x200
+sMasquerainSprites2:
+ax_sprite sMasquerainGfx2, 0x200
+ax_sprite_terminator
+sMasquerainGfx3:
+.incbin "baserom.gba", 0x11957B8, 0x200
+sMasquerainSprites3:
+ax_sprite sMasquerainGfx3, 0x200
+ax_sprite_terminator
+sMasquerainGfx4:
+.incbin "baserom.gba", 0x11959C8, 0x200
+sMasquerainSprites4:
+ax_sprite sMasquerainGfx4, 0x200
+ax_sprite_terminator
+sMasquerainGfx5:
+.incbin "baserom.gba", 0x1195BD8, 0x200
+sMasquerainSprites5:
+ax_sprite sMasquerainGfx5, 0x200
+ax_sprite_terminator
+sMasquerainGfx6:
+.incbin "baserom.gba", 0x1195DE8, 0x200
+sMasquerainSprites6:
+ax_sprite sMasquerainGfx6, 0x200
+ax_sprite_terminator
+sMasquerainGfx7:
+.incbin "baserom.gba", 0x1195FF8, 0x200
+sMasquerainSprites7:
+ax_sprite sMasquerainGfx7, 0x200
+ax_sprite_terminator
+sMasquerainGfx8:
+.incbin "baserom.gba", 0x1196208, 0x200
+sMasquerainSprites8:
+ax_sprite sMasquerainGfx8, 0x200
+ax_sprite_terminator
+sMasquerainGfx9:
+.incbin "baserom.gba", 0x1196418, 0x100
+sMasquerainSprites9:
+ax_sprite sMasquerainGfx9, 0x100
+ax_sprite_terminator
+sMasquerainGfx10:
+.incbin "baserom.gba", 0x1196528, 0x200
+sMasquerainSprites10:
+ax_sprite sMasquerainGfx10, 0x200
+ax_sprite_terminator
+sMasquerainGfx11:
+.incbin "baserom.gba", 0x1196738, 0x200
+sMasquerainSprites11:
+ax_sprite sMasquerainGfx11, 0x200
+ax_sprite_terminator
+sMasquerainGfx12:
+.incbin "baserom.gba", 0x1196948, 0x200
+sMasquerainSprites12:
+ax_sprite sMasquerainGfx12, 0x200
+ax_sprite_terminator
+sMasquerainGfx13:
+.incbin "baserom.gba", 0x1196B58, 0x200
+sMasquerainSprites13:
+ax_sprite sMasquerainGfx13, 0x200
+ax_sprite_terminator
+sMasquerainGfx14:
+.incbin "baserom.gba", 0x1196D68, 0x200
+sMasquerainSprites14:
+ax_sprite sMasquerainGfx14, 0x200
+ax_sprite_terminator
+sMasquerainGfx15:
+.incbin "baserom.gba", 0x1196F78, 0x200
+sMasquerainSprites15:
+ax_sprite sMasquerainGfx15, 0x200
+ax_sprite_terminator
+sMasquerainGfx16:
+.incbin "baserom.gba", 0x1197188, 0x20
+sMasquerainGfx16_1:
+.incbin "baserom.gba", 0x11971A8, 0x180
+sMasquerainSprites16:
+ax_sprite sMasquerainGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx16_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMasquerainGfx17:
+.incbin "baserom.gba", 0x1197350, 0x20
+sMasquerainGfx17_1:
+.incbin "baserom.gba", 0x1197370, 0x120
+sMasquerainSprites17:
+ax_sprite sMasquerainGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx17_1, 0x120
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMasquerainGfx18:
+.incbin "baserom.gba", 0x11974B8, 0x20
+sMasquerainGfx18_1:
+.incbin "baserom.gba", 0x11974D8, 0x120
+sMasquerainGfx18_2:
+.incbin "baserom.gba", 0x11975F8, 0x40
+sMasquerainSprites18:
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx18_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMasquerainGfx19:
+.incbin "baserom.gba", 0x1197678, 0x20
+sMasquerainGfx19_1:
+.incbin "baserom.gba", 0x1197698, 0x120
+sMasquerainGfx19_2:
+.incbin "baserom.gba", 0x11977B8, 0x40
+sMasquerainSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx19_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx19_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMasquerainGfx20:
+.incbin "baserom.gba", 0x1197838, 0x20
+sMasquerainGfx20_1:
+.incbin "baserom.gba", 0x1197858, 0x40
+sMasquerainGfx20_2:
+.incbin "baserom.gba", 0x1197898, 0x40
+sMasquerainGfx20_3:
+.incbin "baserom.gba", 0x11978D8, 0x40
+sMasquerainSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx20_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx20_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMasquerainGfx21:
+.incbin "baserom.gba", 0x1197968, 0x20
+sMasquerainGfx21_1:
+.incbin "baserom.gba", 0x1197988, 0x40
+sMasquerainGfx21_2:
+.incbin "baserom.gba", 0x11979C8, 0x40
+sMasquerainGfx21_3:
+.incbin "baserom.gba", 0x1197A08, 0x40
+sMasquerainSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx21_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMasquerainGfx21_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMasquerainGfx22:
+.incbin "baserom.gba", 0x1197A98, 0x60
+sMasquerainGfx22_1:
+.incbin "baserom.gba", 0x1197AF8, 0x60
+sMasquerainGfx22_2:
+.incbin "baserom.gba", 0x1197B58, 0x60
+sMasquerainGfx22_3:
+.incbin "baserom.gba", 0x1197BB8, 0x40
+sMasquerainSprites22:
+ax_sprite sMasquerainGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx22_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMasquerainGfx23:
+.incbin "baserom.gba", 0x1197C40, 0x60
+sMasquerainGfx23_1:
+.incbin "baserom.gba", 0x1197CA0, 0x60
+sMasquerainGfx23_2:
+.incbin "baserom.gba", 0x1197D00, 0x60
+sMasquerainGfx23_3:
+.incbin "baserom.gba", 0x1197D60, 0x20
+sMasquerainSprites23:
+ax_sprite sMasquerainGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMasquerainGfx23_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMasquerainGfx24:
+.incbin "baserom.gba", 0x1197DC8, 0x180
+sMasquerainSprites24:
+ax_sprite sMasquerainGfx24, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMasquerainGfx25:
+.incbin "baserom.gba", 0x1197F60, 0x180
+sMasquerainSprites25:
+ax_sprite sMasquerainGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMasquerainGfx26:
+.incbin "baserom.gba", 0x11980F8, 0x200
+sMasquerainSprites26:
+ax_sprite sMasquerainGfx26, 0x200
+ax_sprite_terminator
+sMasquerainGfx27:
+.incbin "baserom.gba", 0x1198308, 0x200
+sMasquerainSprites27:
+ax_sprite sMasquerainGfx27, 0x200
+ax_sprite_terminator
+sMasquerainGfx28:
+.incbin "baserom.gba", 0x1198518, 0x200
+sMasquerainSprites28:
+ax_sprite sMasquerainGfx28, 0x200
+ax_sprite_terminator
+sMasquerainGfx29:
+.incbin "baserom.gba", 0x1198728, 0x200
+sMasquerainSprites29:
+ax_sprite sMasquerainGfx29, 0x200
+ax_sprite_terminator
+sMasquerainGfx30:
+.incbin "baserom.gba", 0x1198938, 0x200
+sMasquerainSprites30:
+ax_sprite sMasquerainGfx30, 0x200
+ax_sprite_terminator
+sMasquerainGfx31:
+.incbin "baserom.gba", 0x1198B48, 0x200
+sMasquerainSprites31:
+ax_sprite sMasquerainGfx31, 0x200
+ax_sprite_terminator
+sMasquerainGfx32:
+.incbin "baserom.gba", 0x1198D58, 0x200
+sMasquerainSprites32:
+ax_sprite sMasquerainGfx32, 0x200
+ax_sprite_terminator
+sAxPosesMasquerain:
+.4byte sMasquerainPose1
+.4byte sMasquerainPose2
+.4byte sMasquerainPose3
+.4byte sMasquerainPose4
+.4byte sMasquerainPose5
+.4byte sMasquerainPose6
+.4byte sMasquerainPose7
+.4byte sMasquerainPose8
+.4byte sMasquerainPose9
+.4byte sMasquerainPose10
+.4byte sMasquerainPose11
+.4byte sMasquerainPose12
+.4byte sMasquerainPose13
+.4byte sMasquerainPose14
+.4byte sMasquerainPose15
+.4byte sMasquerainPose16
+.4byte sMasquerainPose17
+.4byte sMasquerainPose18
+.4byte sMasquerainPose19
+.4byte sMasquerainPose20
+.4byte sMasquerainPose21
+.4byte sMasquerainPose22
+.4byte sMasquerainPose23
+.4byte sMasquerainPose24
+.4byte sMasquerainPose25
+.4byte sMasquerainPose26
+.4byte sMasquerainPose27
+.4byte sMasquerainPose28
+.4byte sMasquerainPose29
+.4byte sMasquerainPose30
+.4byte sMasquerainPose31
+.4byte sMasquerainPose32
+.4byte sMasquerainPose33
+.4byte sMasquerainPose34
+.4byte sMasquerainPose35
+.4byte sMasquerainPose36
+.4byte sMasquerainPose37
+.4byte sMasquerainPose38
+.4byte sMasquerainPose39
+.4byte sMasquerainPose40
+.4byte sMasquerainPose41
+.4byte sMasquerainPose42
+.4byte sMasquerainPose43
+.4byte sMasquerainPose44
+.4byte sMasquerainPose45
+.4byte sMasquerainPose46
+.4byte sMasquerainPose47
+.4byte sMasquerainPose48
+.4byte sMasquerainPose49
+.4byte sMasquerainPose50
+.4byte sMasquerainPose51
+.4byte sMasquerainPose52
+.4byte sMasquerainPose53
+.4byte sMasquerainPose54
+.4byte sMasquerainPose55
+.4byte sMasquerainPose56
+.4byte sMasquerainPose57
+.4byte sMasquerainPose58
+.4byte sMasquerainPose59
+.4byte sMasquerainPose60
+.4byte sMasquerainPose61
+.4byte sMasquerainPose62
+.4byte sMasquerainPose63
+.4byte sMasquerainPose64
+.4byte sMasquerainPose65
+.4byte sMasquerainPose66
+.4byte sMasquerainPose67
+.4byte sMasquerainPose68
+.4byte sMasquerainPose69
+.4byte sMasquerainPose70
+.4byte sMasquerainPose71
+.4byte sMasquerainPose72
+.4byte sMasquerainPose73
+.4byte sMasquerainPose74
+.4byte sMasquerainPose75
+.4byte sMasquerainPose76
+.4byte sMasquerainPose77
+.4byte sMasquerainPose78
+.4byte sMasquerainPose79
+.4byte sMasquerainPose80
+.4byte sMasquerainPose81
+.4byte sMasquerainPose82
+.4byte sMasquerainPose83
+.4byte sMasquerainPose84
+.4byte sMasquerainPose85
+.4byte sMasquerainPose86
+.4byte sMasquerainPose87
+.4byte sMasquerainPose88
+.4byte sMasquerainPose89
+.4byte sMasquerainPose90
+.4byte sMasquerainPose91
+.4byte sMasquerainPose92
+.4byte sMasquerainPose93
+.4byte sMasquerainPose94
+.4byte sMasquerainPose95
+.4byte sMasquerainPose96
+.4byte sMasquerainPose97
+.4byte sMasquerainPose98
+.4byte sMasquerainPose99
+.4byte sMasquerainPose100
+.4byte sMasquerainPose101
+.4byte sMasquerainPose102
+.4byte sMasquerainPose103
+.4byte sMasquerainPose104
+.4byte sMasquerainPose105
+.4byte sMasquerainPose106
+.4byte sMasquerainPose107
+.4byte sMasquerainPose108
+.4byte sMasquerainPose109
+.4byte sMasquerainPose110
+.4byte sMasquerainPose111
+.4byte sMasquerainPose112
+.4byte sMasquerainPose113
+.4byte sMasquerainPose114
+.4byte sMasquerainPose115
+.4byte sMasquerainPose116
+.4byte sMasquerainPose117
+.4byte sMasquerainPose118
+.4byte sMasquerainPose119
+.4byte sMasquerainPose120
+.4byte sMasquerainPose121
+.4byte sMasquerainPose122
+.4byte sMasquerainPose123
+.4byte sMasquerainPose124
+.4byte sMasquerainPose125
+.4byte sMasquerainPose126
+.4byte sMasquerainPose127
+.4byte sMasquerainPose128
+.4byte sMasquerainPose129
+.4byte sMasquerainPose130
+.4byte sMasquerainPose131
+.4byte sMasquerainPose132
+.4byte sMasquerainPose133
+.4byte sMasquerainPose134
+.4byte sMasquerainPose135
+.4byte sMasquerainPose136
+.4byte sMasquerainPose137
+.4byte sMasquerainPose138
+.4byte sMasquerainPose139
+.4byte sMasquerainPose140
+.4byte sMasquerainPose141
+.4byte sMasquerainPose142
+.4byte sMasquerainPose143
+.4byte sMasquerainPose144
+.4byte sMasquerainPose145
+.4byte sMasquerainPose146
+.4byte sMasquerainPose147
+.4byte sMasquerainPose148
+.4byte sMasquerainPose149
+.4byte sMasquerainPose150
+.4byte sMasquerainPose151
+.4byte sMasquerainPose152
+.4byte sMasquerainPose153
+.4byte sMasquerainPose154
+.4byte sMasquerainPose155
+.4byte sMasquerainPose156
+.4byte sMasquerainPose157
+.4byte sMasquerainPose158
+.4byte sMasquerainPose159
+.4byte sMasquerainPose160
+.4byte sMasquerainPose161
+.4byte sMasquerainPose162
+.4byte sMasquerainPose163
+.4byte sMasquerainPose164
+.4byte sMasquerainPose165
+.4byte sMasquerainPose166
+.4byte sMasquerainPose167
+.4byte sMasquerainPose168
+.4byte sMasquerainPose169
+.4byte sMasquerainPose170
+.4byte sMasquerainPose171
+.4byte sMasquerainPose172
+.4byte sMasquerainPose173
+.4byte sMasquerainPose174
+.4byte sMasquerainPose175
+.4byte sMasquerainPose176
+.4byte sMasquerainPose177
+.4byte sMasquerainPose178
+.4byte sMasquerainPose179
+.4byte sMasquerainPose180
+.4byte sMasquerainPose181
+.4byte sMasquerainPose182
+.4byte sMasquerainPose183
+.4byte sMasquerainPose184
+.4byte sMasquerainPose185
+.4byte sMasquerainPose186
+.4byte sMasquerainPose187
+.4byte sMasquerainPose188
+.4byte sMasquerainPose189
+.4byte sMasquerainPose190
+.4byte sMasquerainPose191
+.4byte sMasquerainPose192
+.4byte sMasquerainPose193
+.4byte sMasquerainPose194
+.4byte sMasquerainPose195
+.4byte sMasquerainPose196
+.4byte sMasquerainPose197
+.4byte sMasquerainPose198
+.4byte sMasquerainPose199
+.4byte sMasquerainPose200
+.4byte sMasquerainPose201
+.4byte sMasquerainPose202
+sAxPositionsMasquerain:
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -17, 	   9,  -17, 	  -1,   -9
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+.2byte    3,   -6, 	   7,  -17, 	 -12,  -15, 	   1,   -9
+.2byte    3,   -7, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    4,   -6, 	  -6,  -19, 	  -9,  -15, 	   1,   -8
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    3,   -7, 	  -9,  -16, 	   6,  -13, 	  -1,   -9
+.2byte    3,   -8, 	  -8,  -18, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte   -1,   -6, 	  10,  -15, 	 -12,  -15, 	  -1,   -7
+.2byte   -1,   -6, 	   9,  -17, 	 -11,  -17, 	  -1,   -7
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -5,   -7, 	   7,  -16, 	  -8,  -13, 	  -1,   -9
+.2byte   -5,   -8, 	   6,  -18, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -6,   -6, 	   4,  -19, 	   7,  -15, 	  -3,   -8
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -5,   -6, 	  -9,  -17, 	  10,  -15, 	  -3,   -9
+.2byte   -5,   -7, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -17, 	   9,  -17, 	  -1,   -9
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+.2byte    3,   -6, 	   7,  -17, 	 -12,  -15, 	   1,   -9
+.2byte    3,   -7, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    4,   -6, 	  -6,  -19, 	  -9,  -15, 	   1,   -8
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    3,   -7, 	  -9,  -16, 	   6,  -13, 	  -1,   -9
+.2byte    3,   -8, 	  -8,  -18, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte   -1,   -6, 	  10,  -15, 	 -12,  -15, 	  -1,   -7
+.2byte   -1,   -6, 	   9,  -17, 	 -11,  -17, 	  -1,   -7
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -5,   -7, 	   7,  -16, 	  -8,  -13, 	  -1,   -9
+.2byte   -5,   -8, 	   6,  -18, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -6,   -6, 	   4,  -19, 	   7,  -15, 	  -3,   -8
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -5,   -6, 	  -9,  -17, 	  10,  -15, 	  -3,   -9
+.2byte   -5,   -7, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -17, 	   9,  -17, 	  -1,   -9
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+.2byte    3,   -6, 	   7,  -17, 	 -12,  -15, 	   1,   -9
+.2byte    3,   -7, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    4,   -6, 	  -6,  -19, 	  -9,  -15, 	   1,   -8
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    3,   -7, 	  -9,  -16, 	   6,  -13, 	  -1,   -9
+.2byte    3,   -8, 	  -8,  -18, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte   -1,   -6, 	  10,  -15, 	 -12,  -15, 	  -1,   -7
+.2byte   -1,   -6, 	   9,  -17, 	 -11,  -17, 	  -1,   -7
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -5,   -7, 	   7,  -16, 	  -8,  -13, 	  -1,   -9
+.2byte   -5,   -8, 	   6,  -18, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -6,   -6, 	   4,  -19, 	   7,  -15, 	  -3,   -8
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -5,   -6, 	  -9,  -17, 	  10,  -15, 	  -3,   -9
+.2byte   -5,   -7, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -17, 	   9,  -17, 	  -1,   -9
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+.2byte    3,   -6, 	   7,  -17, 	 -12,  -15, 	   1,   -9
+.2byte    3,   -7, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    4,   -6, 	  -6,  -19, 	  -9,  -15, 	   1,   -8
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    3,   -7, 	  -9,  -16, 	   6,  -13, 	  -1,   -9
+.2byte    3,   -8, 	  -8,  -18, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte   -1,   -6, 	  10,  -15, 	 -12,  -15, 	  -1,   -7
+.2byte   -1,   -6, 	   9,  -17, 	 -11,  -17, 	  -1,   -7
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -5,   -7, 	   7,  -16, 	  -8,  -13, 	  -1,   -9
+.2byte   -5,   -8, 	   6,  -18, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -6,   -6, 	   4,  -19, 	   7,  -15, 	  -3,   -8
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -5,   -6, 	  -9,  -17, 	  10,  -15, 	  -3,   -9
+.2byte   -5,   -7, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -1,   -6, 	 -11,  -18, 	   9,  -18, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -18, 	   9,  -18, 	  -1,   -9
+.2byte    3,   -6, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    3,   -6, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   5,  -15, 	  -1,   -9
+.2byte    3,   -8, 	  -8,  -17, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -7, 	   9,  -17, 	 -11,  -17, 	  -1,   -8
+.2byte   -1,   -7, 	   9,  -17, 	 -11,  -17, 	  -1,   -8
+.2byte   -5,   -8, 	   6,  -17, 	  -7,  -15, 	  -1,   -9
+.2byte   -5,   -8, 	   6,  -17, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -5,   -6, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -5,   -4, 	 -13,   -2, 	   8,    2, 	   0,   -4
+.2byte   -5,   -3, 	 -12,   -2, 	   8,    3, 	   0,   -3
+.2byte    0,  -13, 	  -7,  -23, 	   7,  -23, 	   0,  -15
+.2byte    1,  -14, 	  -5,  -25, 	 -13,  -17, 	  -1,  -15
+.2byte    2,  -14, 	  -6,  -22, 	 -13,  -14, 	  -2,  -14
+.2byte    3,  -14, 	  -9,  -21, 	   1,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   9,  -16, 	  -9,  -16, 	   0,  -12
+.2byte   -4,  -14, 	   8,  -21, 	  -2,  -18, 	   0,  -12
+.2byte   -3,  -14, 	   5,  -22, 	  12,  -14, 	   1,  -14
+.2byte   -2,  -14, 	   4,  -25, 	  12,  -17, 	   0,  -15
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -17, 	   9,  -17, 	  -1,   -9
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+.2byte    3,   -6, 	   7,  -17, 	 -12,  -15, 	   1,   -9
+.2byte    3,   -7, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    4,   -6, 	  -6,  -19, 	  -9,  -15, 	   1,   -8
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    3,   -7, 	  -9,  -16, 	   6,  -13, 	  -1,   -9
+.2byte    3,   -8, 	  -8,  -18, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte   -1,   -6, 	  10,  -15, 	 -12,  -15, 	  -1,   -7
+.2byte   -1,   -6, 	   9,  -17, 	 -11,  -17, 	  -1,   -7
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -5,   -7, 	   7,  -16, 	  -8,  -13, 	  -1,   -9
+.2byte   -5,   -8, 	   6,  -18, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -6,   -6, 	   4,  -19, 	   7,  -15, 	  -3,   -8
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -5,   -6, 	  -9,  -17, 	  10,  -15, 	  -3,   -9
+.2byte   -5,   -7, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+.2byte   -1,   -6, 	 -11,  -18, 	   9,  -18, 	  -1,   -9
+.2byte    3,   -6, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -7, 	   9,  -17, 	 -11,  -17, 	  -1,   -8
+.2byte   -5,   -8, 	   6,  -17, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -17, 	   9,  -17, 	  -1,   -9
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+.2byte    3,   -6, 	   7,  -17, 	 -12,  -15, 	   1,   -9
+.2byte    3,   -7, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    4,   -6, 	  -6,  -19, 	  -9,  -15, 	   1,   -8
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    3,   -7, 	  -9,  -16, 	   6,  -13, 	  -1,   -9
+.2byte    3,   -8, 	  -8,  -18, 	   5,  -15, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte   -1,   -6, 	  10,  -15, 	 -12,  -15, 	  -1,   -7
+.2byte   -1,   -6, 	   9,  -17, 	 -11,  -17, 	  -1,   -7
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -5,   -7, 	   7,  -16, 	  -8,  -13, 	  -1,   -9
+.2byte   -5,   -8, 	   6,  -18, 	  -7,  -15, 	  -1,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -6,   -6, 	   4,  -19, 	   7,  -15, 	  -3,   -8
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -5,   -6, 	  -9,  -17, 	  10,  -15, 	  -3,   -9
+.2byte   -5,   -7, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -1,   -6, 	 -11,  -17, 	   9,  -17, 	  -1,   -9
+.2byte   -5,   -7, 	  -7,  -18, 	   9,  -17, 	  -3,   -9
+.2byte   -6,   -6, 	   3,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -8, 	   6,  -18, 	  -7,  -15, 	  -1,   -9
+.2byte   -1,   -6, 	   9,  -17, 	 -11,  -17, 	  -1,   -7
+.2byte    3,   -8, 	  -8,  -18, 	   5,  -15, 	  -1,   -9
+.2byte    4,   -6, 	  -5,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -7, 	   5,  -18, 	 -11,  -17, 	   1,   -9
+.2byte   -1,   -6, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -5,   -6, 	  -8,  -18, 	   9,  -16, 	  -3,   -9
+.2byte   -6,   -6, 	   4,  -20, 	   6,  -16, 	  -3,   -8
+.2byte   -5,   -8, 	   6,  -17, 	  -8,  -14, 	  -1,   -9
+.2byte   -1,   -6, 	  10,  -16, 	 -12,  -16, 	  -1,   -7
+.2byte    3,   -8, 	  -8,  -17, 	   6,  -14, 	  -1,   -9
+.2byte    4,   -6, 	  -6,  -20, 	  -8,  -16, 	   1,   -8
+.2byte    3,   -6, 	   6,  -18, 	 -11,  -16, 	   1,   -9
+sMasquerainAnimTable1:
+.4byte sMasquerainAnims_1_1
+.4byte sMasquerainAnims_1_2
+.4byte sMasquerainAnims_1_3
+.4byte sMasquerainAnims_1_4
+.4byte sMasquerainAnims_1_5
+.4byte sMasquerainAnims_1_6
+.4byte sMasquerainAnims_1_7
+.4byte sMasquerainAnims_1_8
+sMasquerainAnimTable2:
+.4byte sMasquerainAnims_2_1
+.4byte sMasquerainAnims_2_2
+.4byte sMasquerainAnims_2_3
+.4byte sMasquerainAnims_2_4
+.4byte sMasquerainAnims_2_5
+.4byte sMasquerainAnims_2_6
+.4byte sMasquerainAnims_2_7
+.4byte sMasquerainAnims_2_8
+sMasquerainAnimTable3:
+.4byte sMasquerainAnims_3_1
+.4byte sMasquerainAnims_3_2
+.4byte sMasquerainAnims_3_3
+.4byte sMasquerainAnims_3_4
+.4byte sMasquerainAnims_3_5
+.4byte sMasquerainAnims_3_6
+.4byte sMasquerainAnims_3_7
+.4byte sMasquerainAnims_3_8
+sMasquerainAnimTable4:
+.4byte sMasquerainAnims_4_1
+.4byte sMasquerainAnims_4_2
+.4byte sMasquerainAnims_4_3
+.4byte sMasquerainAnims_4_4
+.4byte sMasquerainAnims_4_5
+.4byte sMasquerainAnims_4_6
+.4byte sMasquerainAnims_4_7
+.4byte sMasquerainAnims_4_8
+sMasquerainAnimTable5:
+.4byte sMasquerainAnims_5_1
+.4byte sMasquerainAnims_5_2
+.4byte sMasquerainAnims_5_3
+.4byte sMasquerainAnims_5_4
+.4byte sMasquerainAnims_5_5
+.4byte sMasquerainAnims_5_6
+.4byte sMasquerainAnims_5_7
+.4byte sMasquerainAnims_5_8
+sMasquerainAnimTable6:
+.4byte sMasquerainAnims_6_1
+.4byte sMasquerainAnims_6_1
+.4byte sMasquerainAnims_6_1
+.4byte sMasquerainAnims_6_1
+.4byte sMasquerainAnims_6_1
+.4byte sMasquerainAnims_6_1
+.4byte sMasquerainAnims_6_1
+.4byte sMasquerainAnims_6_1
+sMasquerainAnimTable7:
+.4byte sMasquerainAnims_7_1
+.4byte sMasquerainAnims_7_2
+.4byte sMasquerainAnims_7_3
+.4byte sMasquerainAnims_7_4
+.4byte sMasquerainAnims_7_5
+.4byte sMasquerainAnims_7_6
+.4byte sMasquerainAnims_7_7
+.4byte sMasquerainAnims_7_8
+sMasquerainAnimTable8:
+.4byte sMasquerainAnims_8_1
+.4byte sMasquerainAnims_8_2
+.4byte sMasquerainAnims_8_3
+.4byte sMasquerainAnims_8_4
+.4byte sMasquerainAnims_8_5
+.4byte sMasquerainAnims_8_6
+.4byte sMasquerainAnims_8_7
+.4byte sMasquerainAnims_8_8
+sMasquerainAnimTable9:
+.4byte sMasquerainAnims_9_1
+.4byte sMasquerainAnims_9_2
+.4byte sMasquerainAnims_9_3
+.4byte sMasquerainAnims_9_4
+.4byte sMasquerainAnims_9_5
+.4byte sMasquerainAnims_9_6
+.4byte sMasquerainAnims_9_7
+.4byte sMasquerainAnims_9_8
+sMasquerainAnimTable10:
+.4byte sMasquerainAnims_10_1
+.4byte sMasquerainAnims_10_2
+.4byte sMasquerainAnims_10_3
+.4byte sMasquerainAnims_10_4
+.4byte sMasquerainAnims_10_5
+.4byte sMasquerainAnims_10_6
+.4byte sMasquerainAnims_10_7
+.4byte sMasquerainAnims_10_8
+sMasquerainAnimTable11:
+.4byte sMasquerainAnims_11_1
+.4byte sMasquerainAnims_11_2
+.4byte sMasquerainAnims_11_3
+.4byte sMasquerainAnims_11_4
+.4byte sMasquerainAnims_11_5
+.4byte sMasquerainAnims_11_6
+.4byte sMasquerainAnims_11_7
+.4byte sMasquerainAnims_11_8
+sMasquerainAnimTable12:
+.4byte sMasquerainAnims_12_1
+.4byte sMasquerainAnims_12_2
+.4byte sMasquerainAnims_12_3
+.4byte sMasquerainAnims_12_4
+.4byte sMasquerainAnims_12_5
+.4byte sMasquerainAnims_12_6
+.4byte sMasquerainAnims_12_7
+.4byte sMasquerainAnims_12_8
+sMasquerainAnimTable13:
+.4byte sMasquerainAnims_13_1
+.4byte sMasquerainAnims_13_2
+.4byte sMasquerainAnims_13_3
+.4byte sMasquerainAnims_13_4
+.4byte sMasquerainAnims_13_5
+.4byte sMasquerainAnims_13_6
+.4byte sMasquerainAnims_13_7
+.4byte sMasquerainAnims_13_8
+sAxAnimationsMasquerain:
+.4byte sMasquerainAnimTable1
+.4byte sMasquerainAnimTable2
+.4byte sMasquerainAnimTable3
+.4byte sMasquerainAnimTable4
+.4byte sMasquerainAnimTable5
+.4byte sMasquerainAnimTable6
+.4byte sMasquerainAnimTable7
+.4byte sMasquerainAnimTable8
+.4byte sMasquerainAnimTable9
+.4byte sMasquerainAnimTable10
+.4byte sMasquerainAnimTable11
+.4byte sMasquerainAnimTable12
+.4byte sMasquerainAnimTable13
+sAxSpritesMasquerain:
+.4byte sMasquerainSprites1
+.4byte sMasquerainSprites2
+.4byte sMasquerainSprites3
+.4byte sMasquerainSprites4
+.4byte sMasquerainSprites5
+.4byte sMasquerainSprites6
+.4byte sMasquerainSprites7
+.4byte sMasquerainSprites8
+.4byte sMasquerainSprites9
+.4byte sMasquerainSprites10
+.4byte sMasquerainSprites11
+.4byte sMasquerainSprites12
+.4byte sMasquerainSprites13
+.4byte sMasquerainSprites14
+.4byte sMasquerainSprites15
+.4byte sMasquerainSprites16
+.4byte sMasquerainSprites17
+.4byte sMasquerainSprites18
+.4byte sMasquerainSprites19
+.4byte sMasquerainSprites20
+.4byte sMasquerainSprites21
+.4byte sMasquerainSprites22
+.4byte sMasquerainSprites23
+.4byte sMasquerainSprites24
+.4byte sMasquerainSprites25
+.4byte sMasquerainSprites26
+.4byte sMasquerainSprites27
+.4byte sMasquerainSprites28
+.4byte sMasquerainSprites29
+.4byte sMasquerainSprites30
+.4byte sMasquerainSprites31
+.4byte sMasquerainSprites32
+sAxMainMasquerain:
+ax_main sAxPosesMasquerain, sAxAnimationsMasquerain, 13, sAxSpritesMasquerain, sAxPositionsMasquerain

--- a/data/ax/mawile.inc
+++ b/data/ax/mawile.inc
@@ -1,0 +1,3127 @@
+.global gAxMawile
+gAxMawile:
+ax_siro sAxMainMawile
+sMawilePose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose4:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose5:
+ax_pose 4, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose6:
+ax_pose 5, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose7:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose8:
+ax_pose 7, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose9:
+ax_pose 8, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose10:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose11:
+ax_pose 10, 0x01ed, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose12:
+ax_pose 11, 0x01ed, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose13:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose14:
+ax_pose 13, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose15:
+ax_pose 14, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose16:
+ax_pose 9, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose17:
+ax_pose 10, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose18:
+ax_pose 11, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose19:
+ax_pose 6, 0x01eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMawilePose20:
+ax_pose 7, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose21:
+ax_pose 8, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose22:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose23:
+ax_pose 4, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose24:
+ax_pose 5, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose28:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose29:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose30:
+ax_pose 4, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose31:
+ax_pose 5, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose32:
+ax_pose 16, 0x01e5, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose33:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose34:
+ax_pose 7, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose35:
+ax_pose 8, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose36:
+ax_pose 17, 0x01eb, 0x10e1, 0x5c00
+ax_pose 18, 0x41fb, 0x50e9, 0x5c01
+ax_pose 19, 0x41eb, 0x90e9, 0x5c05
+ax_pose_terminator
+sMawilePose37:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose38:
+ax_pose 10, 0x01ed, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose39:
+ax_pose 11, 0x01ed, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose40:
+ax_pose 20, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose41:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose42:
+ax_pose 13, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose43:
+ax_pose 14, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose44:
+ax_pose 21, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose45:
+ax_pose 9, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose46:
+ax_pose 10, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose47:
+ax_pose 11, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose48:
+ax_pose 20, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose49:
+ax_pose 6, 0x01eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMawilePose50:
+ax_pose 7, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose51:
+ax_pose 8, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose52:
+ax_pose 17, 0x01eb, 0x0118, 0x5c00
+ax_pose 18, 0x41fb, 0x40f8, 0x5c01
+ax_pose 19, 0x41eb, 0x80f8, 0x5c05
+ax_pose_terminator
+sMawilePose53:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose54:
+ax_pose 4, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose55:
+ax_pose 5, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose56:
+ax_pose 16, 0x01e5, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose57:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose58:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose59:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose60:
+ax_pose 22, 0x41f2, 0x80f1, 0x5c00
+ax_pose 23, 0x01e2, 0x40f1, 0x5c08
+ax_pose 24, 0x81e2, 0x0101, 0x5c0c
+ax_pose 25, 0x01da, 0x00f9, 0x5c0e
+ax_pose 26, 0x01da, 0x0101, 0x5c0f
+ax_pose_terminator
+sMawilePose61:
+ax_pose 27, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMawilePose62:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose63:
+ax_pose 4, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose64:
+ax_pose 5, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose65:
+ax_pose 28, 0x01e3, 0x40ea, 0x5c00
+ax_pose 29, 0x01db, 0x00ea, 0x5c04
+ax_pose 30, 0x01db, 0x00f2, 0x5c05
+ax_pose 31, 0x01d3, 0x00ea, 0x5c06
+ax_pose 32, 0x41f3, 0x40ea, 0x5c07
+ax_pose 33, 0x41eb, 0x00fa, 0x5c0b
+ax_pose 34, 0x41fb, 0x00fa, 0x5c0d
+ax_pose_terminator
+sMawilePose66:
+ax_pose 35, 0x41f3, 0x80ea, 0x5c00
+ax_pose 36, 0x41eb, 0x00ea, 0x5c08
+ax_pose 37, 0x01eb, 0x00fa, 0x5c0a
+ax_pose 38, 0x81eb, 0x00e2, 0x5c0b
+ax_pose_terminator
+sMawilePose67:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose68:
+ax_pose 7, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose69:
+ax_pose 8, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose70:
+ax_pose 39, 0x41f3, 0x80e8, 0x5c00
+ax_pose 40, 0x41eb, 0x00e8, 0x5c08
+ax_pose 41, 0x01e3, 0x00e8, 0x5c0a
+ax_pose 42, 0x81db, 0x00e0, 0x5c0b
+ax_pose 43, 0x01eb, 0x00e0, 0x5c0d
+ax_pose 44, 0x01eb, 0x00f8, 0x5c0e
+ax_pose 45, 0x81f3, 0x00e0, 0x5c0f
+ax_pose 46, 0x01db, 0x00e8, 0x5c11
+ax_pose_terminator
+sMawilePose71:
+ax_pose 47, 0x41f2, 0x80e9, 0x5c00
+ax_pose 48, 0x01f2, 0x40d9, 0x5c08
+ax_pose_terminator
+sMawilePose72:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose73:
+ax_pose 10, 0x01ed, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose74:
+ax_pose 11, 0x01ed, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose75:
+ax_pose 49, 0x81e5, 0x80e7, 0x5c00
+ax_pose 50, 0x4205, 0x00e4, 0x5c08
+ax_pose 51, 0x41ed, 0x00f7, 0x5c0a
+ax_pose 52, 0x01f5, 0x40f7, 0x5c0c
+ax_pose_terminator
+sMawilePose76:
+ax_pose 53, 0x81ee, 0x80f5, 0x5c00
+ax_pose 54, 0x81ee, 0x40ed, 0x5c08
+ax_pose 55, 0x81fe, 0x00e5, 0x5c0c
+ax_pose 56, 0x01f3, 0x0105, 0x5c0e
+ax_pose_terminator
+sMawilePose77:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose78:
+ax_pose 13, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose79:
+ax_pose 14, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose80:
+ax_pose 57, 0x41e7, 0x80ed, 0x5c00
+ax_pose 58, 0x01df, 0x00fd, 0x5c08
+ax_pose 59, 0x41f7, 0x40ed, 0x5c09
+ax_pose 60, 0x41ff, 0x00f5, 0x5c0d
+ax_pose 61, 0x01ff, 0x0105, 0x5c0f
+ax_pose_terminator
+sMawilePose81:
+ax_pose 62, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sMawilePose82:
+ax_pose 9, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose83:
+ax_pose 10, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose84:
+ax_pose 11, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose85:
+ax_pose 49, 0x81e5, 0x910a, 0x5c00
+ax_pose 50, 0x4205, 0x110d, 0x5c08
+ax_pose 51, 0x41ed, 0x10fa, 0x5c0a
+ax_pose 52, 0x01f5, 0x50fa, 0x5c0c
+ax_pose_terminator
+sMawilePose86:
+ax_pose 53, 0x81ee, 0x90fc, 0x5c00
+ax_pose 54, 0x81ee, 0x510c, 0x5c08
+ax_pose 55, 0x81fe, 0x1114, 0x5c0c
+ax_pose 56, 0x01f3, 0x10f4, 0x5c0e
+ax_pose_terminator
+sMawilePose87:
+ax_pose 6, 0x01eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMawilePose88:
+ax_pose 7, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose89:
+ax_pose 8, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose90:
+ax_pose 39, 0x41f3, 0x90fa, 0x5c00
+ax_pose 40, 0x41eb, 0x110a, 0x5c08
+ax_pose 41, 0x01e3, 0x1112, 0x5c0a
+ax_pose 42, 0x81db, 0x111a, 0x5c0b
+ax_pose 43, 0x01eb, 0x111a, 0x5c0d
+ax_pose 44, 0x01eb, 0x1102, 0x5c0e
+ax_pose 45, 0x81f3, 0x111a, 0x5c0f
+ax_pose 46, 0x01db, 0x1112, 0x5c11
+ax_pose_terminator
+sMawilePose91:
+ax_pose 47, 0x41f2, 0x90f8, 0x5c00
+ax_pose 48, 0x01f2, 0x5118, 0x5c08
+ax_pose_terminator
+sMawilePose92:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose93:
+ax_pose 4, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose94:
+ax_pose 5, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose95:
+ax_pose 28, 0x01e3, 0x5107, 0x5c00
+ax_pose 29, 0x01db, 0x110f, 0x5c04
+ax_pose 30, 0x01db, 0x1107, 0x5c05
+ax_pose 31, 0x01d3, 0x110f, 0x5c06
+ax_pose 32, 0x41f3, 0x50f7, 0x5c07
+ax_pose 33, 0x41eb, 0x10f7, 0x5c0b
+ax_pose 34, 0x41fb, 0x10f7, 0x5c0d
+ax_pose_terminator
+sMawilePose96:
+ax_pose 35, 0x41f3, 0x90f7, 0x5c00
+ax_pose 36, 0x41eb, 0x1107, 0x5c08
+ax_pose 37, 0x01eb, 0x10ff, 0x5c0a
+ax_pose 38, 0x81eb, 0x1117, 0x5c0b
+ax_pose_terminator
+sMawilePose97:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose98:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose99:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose100:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose101:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose102:
+ax_pose 4, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose103:
+ax_pose 5, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose104:
+ax_pose 16, 0x01e5, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose105:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose106:
+ax_pose 7, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose107:
+ax_pose 8, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose108:
+ax_pose 17, 0x01eb, 0x10e1, 0x5c00
+ax_pose 18, 0x41fb, 0x50e9, 0x5c01
+ax_pose 19, 0x41eb, 0x90e9, 0x5c05
+ax_pose_terminator
+sMawilePose109:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose110:
+ax_pose 10, 0x01ed, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose111:
+ax_pose 11, 0x01ed, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose112:
+ax_pose 20, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose113:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose114:
+ax_pose 13, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose115:
+ax_pose 14, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose116:
+ax_pose 21, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sMawilePose117:
+ax_pose 9, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose118:
+ax_pose 10, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose119:
+ax_pose 11, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose120:
+ax_pose 20, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose121:
+ax_pose 6, 0x01eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMawilePose122:
+ax_pose 7, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose123:
+ax_pose 8, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose124:
+ax_pose 17, 0x01eb, 0x0118, 0x5c00
+ax_pose 18, 0x41fb, 0x40f8, 0x5c01
+ax_pose 19, 0x41eb, 0x80f8, 0x5c05
+ax_pose_terminator
+sMawilePose125:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose126:
+ax_pose 4, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose127:
+ax_pose 5, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose128:
+ax_pose 16, 0x01e5, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose129:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose130:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose131:
+ax_pose 6, 0x01eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMawilePose132:
+ax_pose 9, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose133:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose134:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose135:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose136:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose137:
+ax_pose 63, 0x01ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose138:
+ax_pose 64, 0x01ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose139:
+ax_pose 65, 0x01da, 0x00fd, 0x5c00
+ax_pose 66, 0x81e2, 0x4105, 0x5c01
+ax_pose 67, 0x81e2, 0x80f5, 0x5c05
+ax_pose_terminator
+sMawilePose140:
+ax_pose 68, 0x41e3, 0x90ea, 0x5c00
+ax_pose 69, 0x01db, 0x10f2, 0x5c08
+ax_pose 70, 0x41fb, 0x10fa, 0x5c09
+ax_pose 71, 0x41f3, 0x50ea, 0x5c0b
+ax_pose_terminator
+sMawilePose141:
+ax_pose 72, 0x01e3, 0x90e6, 0x5c00
+ax_pose_terminator
+sMawilePose142:
+ax_pose 73, 0x01e9, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose143:
+ax_pose 74, 0x01ed, 0x80ed, 0x5c00
+ax_pose_terminator
+sMawilePose144:
+ax_pose 73, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose145:
+ax_pose 72, 0x01e3, 0x80fa, 0x5c00
+ax_pose_terminator
+sMawilePose146:
+ax_pose 68, 0x41e3, 0x80f6, 0x5c00
+ax_pose 69, 0x01db, 0x0106, 0x5c08
+ax_pose 70, 0x41fb, 0x00f6, 0x5c09
+ax_pose 71, 0x41f3, 0x40f6, 0x5c0b
+ax_pose_terminator
+sMawilePose147:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose148:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose149:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose150:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose151:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose152:
+ax_pose 4, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose153:
+ax_pose 5, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose154:
+ax_pose 16, 0x01e5, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose155:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose156:
+ax_pose 7, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose157:
+ax_pose 8, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose158:
+ax_pose 17, 0x01eb, 0x10e1, 0x5c00
+ax_pose 18, 0x41fb, 0x50e9, 0x5c01
+ax_pose 19, 0x41eb, 0x90e9, 0x5c05
+ax_pose_terminator
+sMawilePose159:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose160:
+ax_pose 10, 0x01ed, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose161:
+ax_pose 11, 0x01ed, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose162:
+ax_pose 20, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose163:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose164:
+ax_pose 13, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose165:
+ax_pose 14, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose166:
+ax_pose 21, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sMawilePose167:
+ax_pose 9, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose168:
+ax_pose 10, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose169:
+ax_pose 11, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose170:
+ax_pose 20, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose171:
+ax_pose 6, 0x01eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMawilePose172:
+ax_pose 7, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose173:
+ax_pose 8, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose174:
+ax_pose 17, 0x01eb, 0x0118, 0x5c00
+ax_pose 18, 0x41fb, 0x40f8, 0x5c01
+ax_pose 19, 0x41eb, 0x80f8, 0x5c05
+ax_pose_terminator
+sMawilePose175:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose176:
+ax_pose 4, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose177:
+ax_pose 5, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose178:
+ax_pose 16, 0x01e5, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose179:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose180:
+ax_pose 16, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose181:
+ax_pose 17, 0x01eb, 0x0115, 0x5c00
+ax_pose 18, 0x41fb, 0x40f5, 0x5c01
+ax_pose 19, 0x41eb, 0x80f5, 0x5c05
+ax_pose_terminator
+sMawilePose182:
+ax_pose 20, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose183:
+ax_pose 21, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose184:
+ax_pose 20, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose185:
+ax_pose 17, 0x01eb, 0x10e3, 0x5c00
+ax_pose 18, 0x41fb, 0x50eb, 0x5c01
+ax_pose 19, 0x41eb, 0x90eb, 0x5c05
+ax_pose_terminator
+sMawilePose186:
+ax_pose 16, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose187:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose188:
+ax_pose 16, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose189:
+ax_pose 17, 0x01eb, 0x0115, 0x5c00
+ax_pose 18, 0x41fb, 0x40f5, 0x5c01
+ax_pose 19, 0x41eb, 0x80f5, 0x5c05
+ax_pose_terminator
+sMawilePose190:
+ax_pose 20, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose191:
+ax_pose 21, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose192:
+ax_pose 20, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose193:
+ax_pose 17, 0x01eb, 0x10e3, 0x5c00
+ax_pose 18, 0x41fb, 0x50eb, 0x5c01
+ax_pose 19, 0x41eb, 0x90eb, 0x5c05
+ax_pose_terminator
+sMawilePose194:
+ax_pose 16, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose195:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose196:
+ax_pose 27, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMawilePose197:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose198:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose199:
+ax_pose 35, 0x41f3, 0x80ec, 0x5c00
+ax_pose 36, 0x41eb, 0x00ec, 0x5c08
+ax_pose 37, 0x01eb, 0x00fc, 0x5c0a
+ax_pose 38, 0x81eb, 0x00e4, 0x5c0b
+ax_pose_terminator
+sMawilePose200:
+ax_pose 16, 0x01e5, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose201:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose202:
+ax_pose 47, 0x41f2, 0x80e9, 0x5c00
+ax_pose 48, 0x01f2, 0x40d9, 0x5c08
+ax_pose_terminator
+sMawilePose203:
+ax_pose 17, 0x01eb, 0x10e1, 0x5c00
+ax_pose 18, 0x41fb, 0x50e9, 0x5c01
+ax_pose 19, 0x41eb, 0x90e9, 0x5c05
+ax_pose_terminator
+sMawilePose204:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose205:
+ax_pose 53, 0x81ee, 0x80f5, 0x5c00
+ax_pose 54, 0x81ee, 0x40ed, 0x5c08
+ax_pose 55, 0x81fe, 0x00e5, 0x5c0c
+ax_pose 56, 0x01f3, 0x0105, 0x5c0e
+ax_pose_terminator
+sMawilePose206:
+ax_pose 20, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sMawilePose207:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose208:
+ax_pose 62, 0x01e7, 0x80ed, 0x5c00
+ax_pose_terminator
+sMawilePose209:
+ax_pose 21, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sMawilePose210:
+ax_pose 9, 0x01ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose211:
+ax_pose 53, 0x81ee, 0x90fb, 0x5c00
+ax_pose 54, 0x81ee, 0x510b, 0x5c08
+ax_pose 55, 0x81fe, 0x1113, 0x5c0c
+ax_pose 56, 0x01f3, 0x10f3, 0x5c0e
+ax_pose_terminator
+sMawilePose212:
+ax_pose 20, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose213:
+ax_pose 6, 0x01eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose214:
+ax_pose 47, 0x41f2, 0x90f7, 0x5c00
+ax_pose 48, 0x01f2, 0x5117, 0x5c08
+ax_pose_terminator
+sMawilePose215:
+ax_pose 17, 0x01eb, 0x0117, 0x5c00
+ax_pose 18, 0x41fb, 0x40f7, 0x5c01
+ax_pose 19, 0x41eb, 0x80f7, 0x5c05
+ax_pose_terminator
+sMawilePose216:
+ax_pose 3, 0x01ea, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose217:
+ax_pose 35, 0x41f3, 0x90f4, 0x5c00
+ax_pose 36, 0x41eb, 0x1104, 0x5c08
+ax_pose 37, 0x01eb, 0x10fc, 0x5c0a
+ax_pose 38, 0x81eb, 0x1114, 0x5c0b
+ax_pose_terminator
+sMawilePose218:
+ax_pose 16, 0x01e5, 0x80f6, 0x5c00
+ax_pose_terminator
+sMawilePose219:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose220:
+ax_pose 16, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose221:
+ax_pose 17, 0x01eb, 0x0115, 0x5c00
+ax_pose 18, 0x41fb, 0x40f5, 0x5c01
+ax_pose 19, 0x41eb, 0x80f5, 0x5c05
+ax_pose_terminator
+sMawilePose222:
+ax_pose 20, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose223:
+ax_pose 21, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose224:
+ax_pose 20, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose225:
+ax_pose 17, 0x01eb, 0x10e3, 0x5c00
+ax_pose 18, 0x41fb, 0x50eb, 0x5c01
+ax_pose 19, 0x41eb, 0x90eb, 0x5c05
+ax_pose_terminator
+sMawilePose226:
+ax_pose 16, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sMawilePose227:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMawilePose228:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose229:
+ax_pose 6, 0x01eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMawilePose230:
+ax_pose 9, 0x01ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sMawilePose231:
+ax_pose 12, 0x01e7, 0x80f7, 0x5c00
+ax_pose_terminator
+sMawilePose232:
+ax_pose 9, 0x01ec, 0x90e9, 0x5c00
+ax_pose_terminator
+sMawilePose233:
+ax_pose 6, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sMawilePose234:
+ax_pose 3, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+.align 2
+sMawileAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMawileAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 1, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 0, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sMawileAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 1, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMawileAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -6, 6, -6,
+ax_anim 1, 0, 38, 13, -12, 13, -12,
+ax_anim 2, 0, 39, 22, -21, 22, -21,
+ax_anim 2, 1, 39, 23, -20, 23, -20,
+ax_anim 2, 0, 39, 22, -21, 22, -21,
+ax_anim 2, 0, 39, 23, -20, 23, -20,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sMawileAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sMawileAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -6, -6, -6,
+ax_anim 1, 0, 46, -13, -12, -13, -12,
+ax_anim 2, 0, 47, -22, -21, -22, -21,
+ax_anim 2, 1, 47, -23, -20, -23, -20,
+ax_anim 2, 0, 47, -22, -21, -22, -21,
+ax_anim 2, 0, 47, -23, -20, -23, -20,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sMawileAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 1, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sMawileAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 1, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 0, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMawileAnims_3_1:
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, 7, 0, 7,
+ax_anim 2, 0, 79, 0, 15, 0, 15,
+ax_anim 2, 1, 80, 0, 15, 0, 15,
+ax_anim 2, 0, 79, 0, 15, 0, 15,
+ax_anim 4, 0, 80, 0, 15, 0, 15,
+ax_anim 2, 0, 81, 0, 12, 0, 12,
+ax_anim 2, 0, 86, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_3_2:
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 2, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 2, 5, 2, 5,
+ax_anim 2, 0, 84, 5, 11, 5, 11,
+ax_anim 2, 1, 85, 5, 11, 5, 11,
+ax_anim 2, 0, 84, 5, 11, 5, 11,
+ax_anim 4, 0, 85, 5, 11, 5, 11,
+ax_anim 2, 0, 86, 3, 6, 3, 6,
+ax_anim 2, 0, 91, 2, 3, 2, 3,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_3_3:
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 89, -1, 0, -1, 0,
+ax_anim 1, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 1, 90, 3, 0, 3, 0,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 4, 0, 90, 3, 0, 3, 0,
+ax_anim 2, 0, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_3_4:
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 2, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 4, -7, 4, -7,
+ax_anim 2, 0, 94, 7, -11, 7, -11,
+ax_anim 2, 1, 95, 7, -11, 7, -11,
+ax_anim 2, 0, 94, 7, -11, 7, -11,
+ax_anim 4, 0, 95, 7, -11, 7, -11,
+ax_anim 2, 0, 56, 5, -8, 5, -8,
+ax_anim 2, 0, 61, 2, -3, 2, -3,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_3_5:
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 0, -7, 0, -7,
+ax_anim 2, 0, 59, 0, -15, 0, -15,
+ax_anim 2, 1, 60, 0, -15, 0, -15,
+ax_anim 2, 0, 59, 0, -15, 0, -15,
+ax_anim 4, 0, 60, 0, -15, 0, -15,
+ax_anim 2, 0, 61, 0, -12, 0, -12,
+ax_anim 2, 0, 66, 0, -4, 0, -4,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_3_6:
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 4, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -4, -7, -4, -7,
+ax_anim 2, 0, 64, -7, -11, -7, -11,
+ax_anim 2, 1, 65, -7, -11, -7, -11,
+ax_anim 2, 0, 64, -7, -11, -7, -11,
+ax_anim 4, 0, 65, -7, -11, -7, -11,
+ax_anim 2, 0, 66, -5, -8, -5, -8,
+ax_anim 2, 0, 71, -2, -3, -2, -3,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_3_7:
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 69, 1, 0, 1, 0,
+ax_anim 1, 0, 69, -1, 0, -1, 0,
+ax_anim 2, 0, 69, -3, 0, -3, 0,
+ax_anim 2, 1, 70, -3, 0, -3, 0,
+ax_anim 2, 0, 69, -3, 0, -3, 0,
+ax_anim 4, 0, 70, -3, 0, -3, 0,
+ax_anim 2, 0, 71, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_3_8:
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 4, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, -2, 5, -2, 5,
+ax_anim 2, 0, 74, -5, 11, -5, 11,
+ax_anim 2, 1, 75, -5, 11, -5, 11,
+ax_anim 2, 0, 74, -5, 11, -5, 11,
+ax_anim 4, 0, 75, -5, 11, -5, 11,
+ax_anim 2, 0, 76, -3, 6, -3, 6,
+ax_anim 2, 0, 81, -2, 3, -2, 3,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_4_1:
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 2, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 3, 0, 3,
+ax_anim 1, 0, 115, 0, 7, 0, 7,
+ax_anim 2, 1, 115, -1, 7, -1, 7,
+ax_anim 2, 0, 115, 0, 7, 0, 7,
+ax_anim 2, 0, 115, -1, 7, -1, 7,
+ax_anim 4, 0, 115, 0, 7, 0, 7,
+ax_anim 2, 0, 116, 0, 4, 0, 4,
+ax_anim 2, 0, 120, 0, 2, 0, 2,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_4_2:
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 3, 3, 3, 3,
+ax_anim 1, 0, 119, 7, 7, 7, 7,
+ax_anim 2, 1, 119, 6, 8, 6, 8,
+ax_anim 2, 0, 119, 7, 7, 7, 7,
+ax_anim 2, 0, 119, 6, 8, 6, 8,
+ax_anim 4, 0, 119, 7, 7, 7, 7,
+ax_anim 2, 0, 120, 4, 4, 4, 4,
+ax_anim 2, 0, 124, 2, 2, 2, 2,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_4_3:
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 2, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 3, 0, 3, 0,
+ax_anim 1, 0, 123, 7, 0, 7, 0,
+ax_anim 2, 1, 123, 7, 1, 7, 1,
+ax_anim 2, 0, 123, 7, 0, 7, 0,
+ax_anim 2, 0, 123, 7, 1, 7, 1,
+ax_anim 4, 0, 123, 7, 0, 7, 0,
+ax_anim 2, 0, 124, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_4_4:
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 2, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 3, -3, 3, -3,
+ax_anim 1, 0, 127, 7, -7, 7, -7,
+ax_anim 2, 1, 127, 6, -8, 6, -8,
+ax_anim 2, 0, 127, 7, -7, 7, -7,
+ax_anim 2, 0, 127, 6, -8, 6, -8,
+ax_anim 4, 0, 127, 7, -7, 7, -7,
+ax_anim 2, 0, 96, 4, -4, 4, -4,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_4_5:
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 2, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -3, 0, -3,
+ax_anim 1, 0, 99, 0, -7, 0, -7,
+ax_anim 2, 1, 99, -1, -7, -1, -7,
+ax_anim 2, 0, 99, 0, -7, 0, -7,
+ax_anim 2, 0, 99, -1, -7, -1, -7,
+ax_anim 4, 0, 99, 0, -7, 0, -7,
+ax_anim 2, 0, 101, 0, -4, 0, -4,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_4_6:
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 2, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 103, -3, -3, -3, -3,
+ax_anim 1, 0, 103, -7, -7, -7, -7,
+ax_anim 2, 1, 103, -6, -8, -6, -8,
+ax_anim 2, 0, 103, -7, -7, -7, -7,
+ax_anim 2, 0, 103, -6, -8, -6, -8,
+ax_anim 4, 0, 103, -7, -7, -7, -7,
+ax_anim 2, 0, 104, -4, -4, -4, -4,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_4_7:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 2, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 107, -3, 0, -3, 0,
+ax_anim 1, 0, 107, -7, 0, -7, 0,
+ax_anim 2, 1, 107, -7, 1, -7, 1,
+ax_anim 2, 0, 107, -7, 0, -7, 0,
+ax_anim 2, 0, 107, -7, 1, -7, 1,
+ax_anim 4, 0, 107, -7, 0, -7, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_4_8:
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 2, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 111, -3, 3, -3, 3,
+ax_anim 1, 0, 111, -7, 7, -7, 7,
+ax_anim 2, 1, 111, -6, 8, -6, 8,
+ax_anim 2, 0, 111, -7, 7, -7, 7,
+ax_anim 2, 0, 111, -6, 8, -6, 8,
+ax_anim 4, 0, 111, -7, 7, -7, 7,
+ax_anim 2, 0, 112, -4, 4, -4, 4,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sMawileAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sMawileAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sMawileAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sMawileAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sMawileAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sMawileAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sMawileAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMawileAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_8_2:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, 0, 0, 0,
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_8_3:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, 0, 0, 0,
+ax_anim 6, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 6, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_8_4:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_8_5:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_8_6:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_8_7:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_8_8:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 15, 7, 15,
+ax_anim 3, 0, 182, 0, 17, 0, 17,
+ax_anim 2, 3, 183, -7, 15, -7, 15,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 20, 11, 20, 11,
+ax_anim 3, 0, 181, 15, 18, 15, 18,
+ax_anim 2, 3, 182, 11, 19, 11, 19,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 7, -6, 7, -6,
+ax_anim 2, 0, 179, 12, -4, 12, -4,
+ax_anim 3, 0, 180, 14, 0, 14, 0,
+ax_anim 2, 3, 181, 13, 4, 13, 4,
+ax_anim 2, 0, 182, 9, 6, 9, 6,
+ax_anim 1, 0, 183, 3, 5, 3, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -2, -8, -2, -8,
+ax_anim 2, 0, 185, 1, -16, 1, -16,
+ax_anim 2, 0, 178, 7, -20, 7, -20,
+ax_anim 3, 0, 179, 15, -19, 15, -19,
+ax_anim 2, 3, 180, 20, -15, 20, -15,
+ax_anim 2, 0, 181, 17, -5, 17, -5,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -10, -11, -10, -11,
+ax_anim 2, 0, 185, -7, -16, -7, -16,
+ax_anim 3, 0, 178, 0, -18, 0, -18,
+ax_anim 2, 3, 179, 7, -16, 7, -16,
+ax_anim 2, 0, 180, 10, -11, 10, -11,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 2, -8, 2, -8,
+ax_anim 2, 0, 179, -1, -16, -1, -16,
+ax_anim 2, 0, 178, -7, -20, -7, -20,
+ax_anim 3, 0, 185, -15, -19, -15, -19,
+ax_anim 2, 3, 184, -20, -15, -20, -15,
+ax_anim 2, 0, 183, -17, -5, -17, -5,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -7, -6, -7, -6,
+ax_anim 2, 0, 185, -12, -4, -12, -4,
+ax_anim 3, 0, 184, -14, 0, -14, 0,
+ax_anim 2, 3, 183, -13, 4, -13, 4,
+ax_anim 2, 0, 182, -9, 6, -9, 6,
+ax_anim 1, 0, 181, -3, 5, -3, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -20, 11, -20, 11,
+ax_anim 3, 0, 183, -15, 18, -15, 18,
+ax_anim 2, 3, 182, -11, 19, -11, 19,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_10_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 6, -6, 6, -6,
+ax_anim 2, 0, 193, -6, 6, -6, 6,
+ax_anim 2, 0, 193, 10, -10, 10, -10,
+ax_anim 2, 0, 193, -10, 10, -10, 10,
+ax_anim 2, 0, 193, 12, -12, 12, -12,
+ax_anim 3, 0, 193, -12, 12, -12, 12,
+ax_anim 3, 0, 193, 13, -13, 13, -13,
+ax_anim 3, 0, 193, -13, 13, -13, 13,
+ax_anim 2, 0, 193, 12, -12, 12, -12,
+ax_anim 3, 0, 193, -12, 12, -12, 12,
+ax_anim 2, 0, 193, 10, -10, 10, -10,
+ax_anim 2, 0, 193, -10, 10, -10, 10,
+ax_anim 2, 0, 193, 6, -6, 6, -6,
+ax_anim 2, 0, 193, -6, 6, -6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_10_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_10_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -6, -6, -6, -6,
+ax_anim 2, 0, 191, 6, 6, 6, 6,
+ax_anim 2, 0, 191, -10, -10, -10, -10,
+ax_anim 2, 0, 191, 10, 10, 10, 10,
+ax_anim 2, 0, 191, -12, -12, -12, -12,
+ax_anim 3, 0, 191, 12, 12, 12, 12,
+ax_anim 3, 0, 191, -13, -13, -13, -13,
+ax_anim 3, 0, 191, 13, 13, 13, 13,
+ax_anim 2, 0, 191, -12, -12, -12, -12,
+ax_anim 3, 0, 191, 12, 12, 12, 12,
+ax_anim 2, 0, 191, -10, -10, -10, -10,
+ax_anim 2, 0, 191, 10, 10, 10, 10,
+ax_anim 2, 0, 191, -6, -6, -6, -6,
+ax_anim 2, 0, 191, 6, 6, 6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_10_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 6, -6, 6, -6,
+ax_anim 2, 0, 189, -6, 6, -6, 6,
+ax_anim 2, 0, 189, 10, -10, 10, -10,
+ax_anim 2, 0, 189, -10, 10, -10, 10,
+ax_anim 2, 0, 189, 12, -12, 12, -12,
+ax_anim 3, 0, 189, -12, 12, -12, 12,
+ax_anim 3, 0, 189, 13, -13, 13, -13,
+ax_anim 3, 0, 189, -13, 13, -13, 13,
+ax_anim 2, 0, 189, 12, -12, 12, -12,
+ax_anim 3, 0, 189, -12, 12, -12, 12,
+ax_anim 2, 0, 189, 10, -10, 10, -10,
+ax_anim 2, 0, 189, -10, 10, -10, 10,
+ax_anim 2, 0, 189, 6, -6, 6, -6,
+ax_anim 2, 0, 189, -6, 6, -6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_10_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_10_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -6, -6, -6, -6,
+ax_anim 2, 0, 187, 6, 6, 6, 6,
+ax_anim 2, 0, 187, -10, -10, -10, -10,
+ax_anim 2, 0, 187, 10, 10, 10, 10,
+ax_anim 2, 0, 187, -12, -12, -12, -12,
+ax_anim 3, 0, 187, 12, 12, 12, 12,
+ax_anim 3, 0, 187, -13, -13, -13, -13,
+ax_anim 3, 0, 187, 13, 13, 13, 13,
+ax_anim 2, 0, 187, -12, -12, -12, -12,
+ax_anim 3, 0, 187, 12, 12, 12, 12,
+ax_anim 2, 0, 187, -10, -10, -10, -10,
+ax_anim 2, 0, 187, 10, 10, 10, 10,
+ax_anim 2, 0, 187, -6, -6, -6, -6,
+ax_anim 2, 0, 187, 6, 6, 6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMawileAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sMawileGfx1:
+.incbin "baserom.gba", 0x125619C, 0x200
+sMawileSprites1:
+ax_sprite sMawileGfx1, 0x200
+ax_sprite_terminator
+sMawileGfx2:
+.incbin "baserom.gba", 0x12563AC, 0x200
+sMawileSprites2:
+ax_sprite sMawileGfx2, 0x200
+ax_sprite_terminator
+sMawileGfx3:
+.incbin "baserom.gba", 0x12565BC, 0x200
+sMawileSprites3:
+ax_sprite sMawileGfx3, 0x200
+ax_sprite_terminator
+sMawileGfx4:
+.incbin "baserom.gba", 0x12567CC, 0x200
+sMawileSprites4:
+ax_sprite sMawileGfx4, 0x200
+ax_sprite_terminator
+sMawileGfx5:
+.incbin "baserom.gba", 0x12569DC, 0x200
+sMawileSprites5:
+ax_sprite sMawileGfx5, 0x200
+ax_sprite_terminator
+sMawileGfx6:
+.incbin "baserom.gba", 0x1256BEC, 0x200
+sMawileSprites6:
+ax_sprite sMawileGfx6, 0x200
+ax_sprite_terminator
+sMawileGfx7:
+.incbin "baserom.gba", 0x1256DFC, 0x200
+sMawileSprites7:
+ax_sprite sMawileGfx7, 0x200
+ax_sprite_terminator
+sMawileGfx8:
+.incbin "baserom.gba", 0x125700C, 0x200
+sMawileSprites8:
+ax_sprite sMawileGfx8, 0x200
+ax_sprite_terminator
+sMawileGfx9:
+.incbin "baserom.gba", 0x125721C, 0x200
+sMawileSprites9:
+ax_sprite sMawileGfx9, 0x200
+ax_sprite_terminator
+sMawileGfx10:
+.incbin "baserom.gba", 0x125742C, 0x200
+sMawileSprites10:
+ax_sprite sMawileGfx10, 0x200
+ax_sprite_terminator
+sMawileGfx11:
+.incbin "baserom.gba", 0x125763C, 0x200
+sMawileSprites11:
+ax_sprite sMawileGfx11, 0x200
+ax_sprite_terminator
+sMawileGfx12:
+.incbin "baserom.gba", 0x125784C, 0x200
+sMawileSprites12:
+ax_sprite sMawileGfx12, 0x200
+ax_sprite_terminator
+sMawileGfx13:
+.incbin "baserom.gba", 0x1257A5C, 0x200
+sMawileSprites13:
+ax_sprite sMawileGfx13, 0x200
+ax_sprite_terminator
+sMawileGfx14:
+.incbin "baserom.gba", 0x1257C6C, 0x200
+sMawileSprites14:
+ax_sprite sMawileGfx14, 0x200
+ax_sprite_terminator
+sMawileGfx15:
+.incbin "baserom.gba", 0x1257E7C, 0x200
+sMawileSprites15:
+ax_sprite sMawileGfx15, 0x200
+ax_sprite_terminator
+sMawileGfx16:
+.incbin "baserom.gba", 0x125808C, 0x60
+sMawileGfx16_1:
+.incbin "baserom.gba", 0x12580EC, 0x60
+sMawileGfx16_2:
+.incbin "baserom.gba", 0x125814C, 0x60
+sMawileGfx16_3:
+.incbin "baserom.gba", 0x12581AC, 0x60
+sMawileSprites16:
+ax_sprite sMawileGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMawileGfx17:
+.incbin "baserom.gba", 0x1258254, 0x1C0
+sMawileSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx17, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMawileGfx18:
+.incbin "baserom.gba", 0x1258434, 0x20
+sMawileSprites18:
+ax_sprite sMawileGfx18, 0x20
+ax_sprite_terminator
+sMawileGfx19:
+.incbin "baserom.gba", 0x1258464, 0x80
+sMawileSprites19:
+ax_sprite sMawileGfx19, 0x80
+ax_sprite_terminator
+sMawileGfx20:
+.incbin "baserom.gba", 0x12584F4, 0x100
+sMawileSprites20:
+ax_sprite sMawileGfx20, 0x100
+ax_sprite_terminator
+sMawileGfx21:
+.incbin "baserom.gba", 0x1258604, 0x40
+sMawileGfx21_1:
+.incbin "baserom.gba", 0x1258644, 0xE0
+sMawileGfx21_2:
+.incbin "baserom.gba", 0x1258724, 0x80
+sMawileSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx21_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx21_2, 0x80
+ax_sprite_terminator
+sMawileGfx22:
+.incbin "baserom.gba", 0x12587DC, 0x40
+sMawileGfx22_1:
+.incbin "baserom.gba", 0x125881C, 0x60
+sMawileGfx22_2:
+.incbin "baserom.gba", 0x125887C, 0x60
+sMawileGfx22_3:
+.incbin "baserom.gba", 0x12588DC, 0x60
+sMawileSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMawileGfx23:
+.incbin "baserom.gba", 0x125898C, 0x80
+sMawileGfx23_1:
+.incbin "baserom.gba", 0x1258A0C, 0x40
+sMawileSprites23:
+ax_sprite sMawileGfx23, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMawileGfx24:
+.incbin "baserom.gba", 0x1258A74, 0x20
+sMawileGfx24_1:
+.incbin "baserom.gba", 0x1258A94, 0x20
+sMawileSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx24, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx24_1, 0x20
+ax_sprite_terminator
+sMawileGfx25:
+.incbin "baserom.gba", 0x1258ADC, 0x40
+sMawileSprites25:
+ax_sprite sMawileGfx25, 0x40
+ax_sprite_terminator
+sMawileGfx26:
+.incbin "baserom.gba", 0x1258B2C, 0x20
+sMawileSprites26:
+ax_sprite sMawileGfx26, 0x20
+ax_sprite_terminator
+sMawileGfx27:
+.incbin "baserom.gba", 0x1258B5C, 0x20
+sMawileSprites27:
+ax_sprite sMawileGfx27, 0x20
+ax_sprite_terminator
+sMawileGfx28:
+.incbin "baserom.gba", 0x1258B8C, 0x40
+sMawileGfx28_1:
+.incbin "baserom.gba", 0x1258BCC, 0x80
+sMawileGfx28_2:
+.incbin "baserom.gba", 0x1258C4C, 0x40
+sMawileSprites28:
+ax_sprite 0, 0xa0
+ax_sprite sMawileGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx28_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMawileGfx29:
+.incbin "baserom.gba", 0x1258CCC, 0x80
+sMawileSprites29:
+ax_sprite sMawileGfx29, 0x80
+ax_sprite_terminator
+sMawileGfx30:
+.incbin "baserom.gba", 0x1258D5C, 0x20
+sMawileSprites30:
+ax_sprite sMawileGfx30, 0x20
+ax_sprite_terminator
+sMawileGfx31:
+.incbin "baserom.gba", 0x1258D8C, 0x20
+sMawileSprites31:
+ax_sprite sMawileGfx31, 0x20
+ax_sprite_terminator
+sMawileGfx32:
+.incbin "baserom.gba", 0x1258DBC, 0x20
+sMawileSprites32:
+ax_sprite sMawileGfx32, 0x20
+ax_sprite_terminator
+sMawileGfx33:
+.incbin "baserom.gba", 0x1258DEC, 0x80
+sMawileSprites33:
+ax_sprite sMawileGfx33, 0x80
+ax_sprite_terminator
+sMawileGfx34:
+.incbin "baserom.gba", 0x1258E7C, 0x40
+sMawileSprites34:
+ax_sprite sMawileGfx34, 0x40
+ax_sprite_terminator
+sMawileGfx35:
+.incbin "baserom.gba", 0x1258ECC, 0x40
+sMawileSprites35:
+ax_sprite sMawileGfx35, 0x40
+ax_sprite_terminator
+sMawileGfx36:
+.incbin "baserom.gba", 0x1258F1C, 0x80
+sMawileGfx36_1:
+.incbin "baserom.gba", 0x1258F9C, 0x40
+sMawileSprites36:
+ax_sprite sMawileGfx36, 0x80
+ax_sprite 0, 0x40
+ax_sprite sMawileGfx36_1, 0x40
+ax_sprite_terminator
+sMawileGfx37:
+.incbin "baserom.gba", 0x1258FFC, 0x40
+sMawileSprites37:
+ax_sprite sMawileGfx37, 0x40
+ax_sprite_terminator
+sMawileGfx38:
+.incbin "baserom.gba", 0x125904C, 0x20
+sMawileSprites38:
+ax_sprite sMawileGfx38, 0x20
+ax_sprite_terminator
+sMawileGfx39:
+.incbin "baserom.gba", 0x125907C, 0x40
+sMawileSprites39:
+ax_sprite sMawileGfx39, 0x40
+ax_sprite_terminator
+sMawileGfx40:
+.incbin "baserom.gba", 0x12590CC, 0x100
+sMawileSprites40:
+ax_sprite sMawileGfx40, 0x100
+ax_sprite_terminator
+sMawileGfx41:
+.incbin "baserom.gba", 0x12591DC, 0x40
+sMawileSprites41:
+ax_sprite sMawileGfx41, 0x40
+ax_sprite_terminator
+sMawileGfx42:
+.incbin "baserom.gba", 0x125922C, 0x20
+sMawileSprites42:
+ax_sprite sMawileGfx42, 0x20
+ax_sprite_terminator
+sMawileGfx43:
+.incbin "baserom.gba", 0x125925C, 0x40
+sMawileSprites43:
+ax_sprite sMawileGfx43, 0x40
+ax_sprite_terminator
+sMawileGfx44:
+.incbin "baserom.gba", 0x12592AC, 0x20
+sMawileSprites44:
+ax_sprite sMawileGfx44, 0x20
+ax_sprite_terminator
+sMawileGfx45:
+.incbin "baserom.gba", 0x12592DC, 0x20
+sMawileSprites45:
+ax_sprite sMawileGfx45, 0x20
+ax_sprite_terminator
+sMawileGfx46:
+.incbin "baserom.gba", 0x125930C, 0x40
+sMawileSprites46:
+ax_sprite sMawileGfx46, 0x40
+ax_sprite_terminator
+sMawileGfx47:
+.incbin "baserom.gba", 0x125935C, 0x20
+sMawileSprites47:
+ax_sprite sMawileGfx47, 0x20
+ax_sprite_terminator
+sMawileGfx48:
+.incbin "baserom.gba", 0x125938C, 0x100
+sMawileSprites48:
+ax_sprite sMawileGfx48, 0x100
+ax_sprite_terminator
+sMawileGfx49:
+.incbin "baserom.gba", 0x125949C, 0x80
+sMawileSprites49:
+ax_sprite sMawileGfx49, 0x80
+ax_sprite_terminator
+sMawileGfx50:
+.incbin "baserom.gba", 0x125952C, 0x100
+sMawileSprites50:
+ax_sprite sMawileGfx50, 0x100
+ax_sprite_terminator
+sMawileGfx51:
+.incbin "baserom.gba", 0x125963C, 0x40
+sMawileSprites51:
+ax_sprite sMawileGfx51, 0x40
+ax_sprite_terminator
+sMawileGfx52:
+.incbin "baserom.gba", 0x125968C, 0x40
+sMawileSprites52:
+ax_sprite sMawileGfx52, 0x40
+ax_sprite_terminator
+sMawileGfx53:
+.incbin "baserom.gba", 0x12596DC, 0x80
+sMawileSprites53:
+ax_sprite sMawileGfx53, 0x80
+ax_sprite_terminator
+sMawileGfx54:
+.incbin "baserom.gba", 0x125976C, 0xC0
+sMawileSprites54:
+ax_sprite sMawileGfx54, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMawileGfx55:
+.incbin "baserom.gba", 0x1259844, 0x60
+sMawileSprites55:
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx55, 0x60
+ax_sprite_terminator
+sMawileGfx56:
+.incbin "baserom.gba", 0x12598BC, 0x40
+sMawileSprites56:
+ax_sprite sMawileGfx56, 0x40
+ax_sprite_terminator
+sMawileGfx57:
+.incbin "baserom.gba", 0x125990C, 0x20
+sMawileSprites57:
+ax_sprite sMawileGfx57, 0x20
+ax_sprite_terminator
+sMawileGfx58:
+.incbin "baserom.gba", 0x125993C, 0x60
+sMawileGfx58_1:
+.incbin "baserom.gba", 0x125999C, 0x60
+sMawileSprites58:
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx58_1, 0x60
+ax_sprite_terminator
+sMawileGfx59:
+.incbin "baserom.gba", 0x1259A24, 0x20
+sMawileSprites59:
+ax_sprite sMawileGfx59, 0x20
+ax_sprite_terminator
+sMawileGfx60:
+.incbin "baserom.gba", 0x1259A54, 0x60
+sMawileSprites60:
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx60, 0x60
+ax_sprite_terminator
+sMawileGfx61:
+.incbin "baserom.gba", 0x1259ACC, 0x40
+sMawileSprites61:
+ax_sprite sMawileGfx61, 0x40
+ax_sprite_terminator
+sMawileGfx62:
+.incbin "baserom.gba", 0x1259B1C, 0x20
+sMawileSprites62:
+ax_sprite sMawileGfx62, 0x20
+ax_sprite_terminator
+sMawileGfx63:
+.incbin "baserom.gba", 0x1259B4C, 0x40
+sMawileGfx63_1:
+.incbin "baserom.gba", 0x1259B8C, 0x60
+sMawileGfx63_2:
+.incbin "baserom.gba", 0x1259BEC, 0x60
+sMawileSprites63:
+ax_sprite 0, 0xc0
+ax_sprite sMawileGfx63, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx63_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMawileGfx63_2, 0x60
+ax_sprite_terminator
+sMawileGfx64:
+.incbin "baserom.gba", 0x1259C84, 0x200
+sMawileSprites64:
+ax_sprite sMawileGfx64, 0x200
+ax_sprite_terminator
+sMawileGfx65:
+.incbin "baserom.gba", 0x1259E94, 0x200
+sMawileSprites65:
+ax_sprite sMawileGfx65, 0x200
+ax_sprite_terminator
+sMawileGfx66:
+.incbin "baserom.gba", 0x125A0A4, 0x20
+sMawileSprites66:
+ax_sprite sMawileGfx66, 0x20
+ax_sprite_terminator
+sMawileGfx67:
+.incbin "baserom.gba", 0x125A0D4, 0x80
+sMawileSprites67:
+ax_sprite sMawileGfx67, 0x80
+ax_sprite_terminator
+sMawileGfx68:
+.incbin "baserom.gba", 0x125A164, 0x100
+sMawileSprites68:
+ax_sprite sMawileGfx68, 0x100
+ax_sprite_terminator
+sMawileGfx69:
+.incbin "baserom.gba", 0x125A274, 0x100
+sMawileSprites69:
+ax_sprite sMawileGfx69, 0x100
+ax_sprite_terminator
+sMawileGfx70:
+.incbin "baserom.gba", 0x125A384, 0x20
+sMawileSprites70:
+ax_sprite sMawileGfx70, 0x20
+ax_sprite_terminator
+sMawileGfx71:
+.incbin "baserom.gba", 0x125A3B4, 0x40
+sMawileSprites71:
+ax_sprite sMawileGfx71, 0x40
+ax_sprite_terminator
+sMawileGfx72:
+.incbin "baserom.gba", 0x125A404, 0x80
+sMawileSprites72:
+ax_sprite sMawileGfx72, 0x80
+ax_sprite_terminator
+sMawileGfx73:
+.incbin "baserom.gba", 0x125A494, 0x200
+sMawileSprites73:
+ax_sprite sMawileGfx73, 0x200
+ax_sprite_terminator
+sMawileGfx74:
+.incbin "baserom.gba", 0x125A6A4, 0x200
+sMawileSprites74:
+ax_sprite sMawileGfx74, 0x200
+ax_sprite_terminator
+sMawileGfx75:
+.incbin "baserom.gba", 0x125A8B4, 0x200
+sMawileSprites75:
+ax_sprite sMawileGfx75, 0x200
+ax_sprite_terminator
+sAxPosesMawile:
+.4byte sMawilePose1
+.4byte sMawilePose2
+.4byte sMawilePose3
+.4byte sMawilePose4
+.4byte sMawilePose5
+.4byte sMawilePose6
+.4byte sMawilePose7
+.4byte sMawilePose8
+.4byte sMawilePose9
+.4byte sMawilePose10
+.4byte sMawilePose11
+.4byte sMawilePose12
+.4byte sMawilePose13
+.4byte sMawilePose14
+.4byte sMawilePose15
+.4byte sMawilePose16
+.4byte sMawilePose17
+.4byte sMawilePose18
+.4byte sMawilePose19
+.4byte sMawilePose20
+.4byte sMawilePose21
+.4byte sMawilePose22
+.4byte sMawilePose23
+.4byte sMawilePose24
+.4byte sMawilePose25
+.4byte sMawilePose26
+.4byte sMawilePose27
+.4byte sMawilePose28
+.4byte sMawilePose29
+.4byte sMawilePose30
+.4byte sMawilePose31
+.4byte sMawilePose32
+.4byte sMawilePose33
+.4byte sMawilePose34
+.4byte sMawilePose35
+.4byte sMawilePose36
+.4byte sMawilePose37
+.4byte sMawilePose38
+.4byte sMawilePose39
+.4byte sMawilePose40
+.4byte sMawilePose41
+.4byte sMawilePose42
+.4byte sMawilePose43
+.4byte sMawilePose44
+.4byte sMawilePose45
+.4byte sMawilePose46
+.4byte sMawilePose47
+.4byte sMawilePose48
+.4byte sMawilePose49
+.4byte sMawilePose50
+.4byte sMawilePose51
+.4byte sMawilePose52
+.4byte sMawilePose53
+.4byte sMawilePose54
+.4byte sMawilePose55
+.4byte sMawilePose56
+.4byte sMawilePose57
+.4byte sMawilePose58
+.4byte sMawilePose59
+.4byte sMawilePose60
+.4byte sMawilePose61
+.4byte sMawilePose62
+.4byte sMawilePose63
+.4byte sMawilePose64
+.4byte sMawilePose65
+.4byte sMawilePose66
+.4byte sMawilePose67
+.4byte sMawilePose68
+.4byte sMawilePose69
+.4byte sMawilePose70
+.4byte sMawilePose71
+.4byte sMawilePose72
+.4byte sMawilePose73
+.4byte sMawilePose74
+.4byte sMawilePose75
+.4byte sMawilePose76
+.4byte sMawilePose77
+.4byte sMawilePose78
+.4byte sMawilePose79
+.4byte sMawilePose80
+.4byte sMawilePose81
+.4byte sMawilePose82
+.4byte sMawilePose83
+.4byte sMawilePose84
+.4byte sMawilePose85
+.4byte sMawilePose86
+.4byte sMawilePose87
+.4byte sMawilePose88
+.4byte sMawilePose89
+.4byte sMawilePose90
+.4byte sMawilePose91
+.4byte sMawilePose92
+.4byte sMawilePose93
+.4byte sMawilePose94
+.4byte sMawilePose95
+.4byte sMawilePose96
+.4byte sMawilePose97
+.4byte sMawilePose98
+.4byte sMawilePose99
+.4byte sMawilePose100
+.4byte sMawilePose101
+.4byte sMawilePose102
+.4byte sMawilePose103
+.4byte sMawilePose104
+.4byte sMawilePose105
+.4byte sMawilePose106
+.4byte sMawilePose107
+.4byte sMawilePose108
+.4byte sMawilePose109
+.4byte sMawilePose110
+.4byte sMawilePose111
+.4byte sMawilePose112
+.4byte sMawilePose113
+.4byte sMawilePose114
+.4byte sMawilePose115
+.4byte sMawilePose116
+.4byte sMawilePose117
+.4byte sMawilePose118
+.4byte sMawilePose119
+.4byte sMawilePose120
+.4byte sMawilePose121
+.4byte sMawilePose122
+.4byte sMawilePose123
+.4byte sMawilePose124
+.4byte sMawilePose125
+.4byte sMawilePose126
+.4byte sMawilePose127
+.4byte sMawilePose128
+.4byte sMawilePose129
+.4byte sMawilePose130
+.4byte sMawilePose131
+.4byte sMawilePose132
+.4byte sMawilePose133
+.4byte sMawilePose134
+.4byte sMawilePose135
+.4byte sMawilePose136
+.4byte sMawilePose137
+.4byte sMawilePose138
+.4byte sMawilePose139
+.4byte sMawilePose140
+.4byte sMawilePose141
+.4byte sMawilePose142
+.4byte sMawilePose143
+.4byte sMawilePose144
+.4byte sMawilePose145
+.4byte sMawilePose146
+.4byte sMawilePose147
+.4byte sMawilePose148
+.4byte sMawilePose149
+.4byte sMawilePose150
+.4byte sMawilePose151
+.4byte sMawilePose152
+.4byte sMawilePose153
+.4byte sMawilePose154
+.4byte sMawilePose155
+.4byte sMawilePose156
+.4byte sMawilePose157
+.4byte sMawilePose158
+.4byte sMawilePose159
+.4byte sMawilePose160
+.4byte sMawilePose161
+.4byte sMawilePose162
+.4byte sMawilePose163
+.4byte sMawilePose164
+.4byte sMawilePose165
+.4byte sMawilePose166
+.4byte sMawilePose167
+.4byte sMawilePose168
+.4byte sMawilePose169
+.4byte sMawilePose170
+.4byte sMawilePose171
+.4byte sMawilePose172
+.4byte sMawilePose173
+.4byte sMawilePose174
+.4byte sMawilePose175
+.4byte sMawilePose176
+.4byte sMawilePose177
+.4byte sMawilePose178
+.4byte sMawilePose179
+.4byte sMawilePose180
+.4byte sMawilePose181
+.4byte sMawilePose182
+.4byte sMawilePose183
+.4byte sMawilePose184
+.4byte sMawilePose185
+.4byte sMawilePose186
+.4byte sMawilePose187
+.4byte sMawilePose188
+.4byte sMawilePose189
+.4byte sMawilePose190
+.4byte sMawilePose191
+.4byte sMawilePose192
+.4byte sMawilePose193
+.4byte sMawilePose194
+.4byte sMawilePose195
+.4byte sMawilePose196
+.4byte sMawilePose197
+.4byte sMawilePose198
+.4byte sMawilePose199
+.4byte sMawilePose200
+.4byte sMawilePose201
+.4byte sMawilePose202
+.4byte sMawilePose203
+.4byte sMawilePose204
+.4byte sMawilePose205
+.4byte sMawilePose206
+.4byte sMawilePose207
+.4byte sMawilePose208
+.4byte sMawilePose209
+.4byte sMawilePose210
+.4byte sMawilePose211
+.4byte sMawilePose212
+.4byte sMawilePose213
+.4byte sMawilePose214
+.4byte sMawilePose215
+.4byte sMawilePose216
+.4byte sMawilePose217
+.4byte sMawilePose218
+.4byte sMawilePose219
+.4byte sMawilePose220
+.4byte sMawilePose221
+.4byte sMawilePose222
+.4byte sMawilePose223
+.4byte sMawilePose224
+.4byte sMawilePose225
+.4byte sMawilePose226
+.4byte sMawilePose227
+.4byte sMawilePose228
+.4byte sMawilePose229
+.4byte sMawilePose230
+.4byte sMawilePose231
+.4byte sMawilePose232
+.4byte sMawilePose233
+.4byte sMawilePose234
+sAxPositionsMawile:
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -3, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   6,   -3, 	   0,   -5
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+.2byte    2,   -6, 	   5,   -5, 	  -4,    0, 	   1,   -5
+.2byte    2,   -6, 	   7,   -3, 	  -6,   -3, 	   1,   -5
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte    3,   -6, 	  -2,   -3, 	   3,    0, 	   0,   -5
+.2byte    3,   -6, 	   6,   -3, 	  -3,   -1, 	   0,   -5
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte    3,   -7, 	  -8,   -3, 	   6,   -3, 	   0,   -6
+.2byte    3,   -7, 	   0,   -5, 	   2,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -11, 	   7,   -2, 	  -7,   -5, 	   1,   -6
+.2byte    0,  -11, 	   7,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -3,   -8, 	   5,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -7, 	   8,   -3, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -5, 	  -2,   -1, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,   -6, 	   2,   -3, 	  -3,    0, 	   0,   -5
+.2byte   -3,   -6, 	  -6,   -3, 	   3,   -1, 	   0,   -5
+.2byte   -2,   -7, 	  -6,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -2,   -6, 	  -5,   -5, 	   4,    0, 	  -1,   -5
+.2byte   -2,   -6, 	  -7,   -3, 	   6,   -3, 	  -1,   -5
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -3, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   6,   -3, 	   0,   -5
+.2byte    0,   -4, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+.2byte    2,   -6, 	   5,   -5, 	  -4,    0, 	   1,   -5
+.2byte    2,   -6, 	   7,   -3, 	  -6,   -3, 	   1,   -5
+.2byte    2,   -5, 	   5,   -2, 	  -5,   -1, 	  -1,   -5
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte    3,   -6, 	  -2,   -3, 	   3,    0, 	   0,   -5
+.2byte    3,   -6, 	   6,   -3, 	  -3,   -1, 	   0,   -5
+.2byte    5,   -6, 	   3,    0, 	   3,   -2, 	   2,   -5
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte    3,   -7, 	  -8,   -3, 	   6,   -3, 	   0,   -6
+.2byte    3,   -7, 	   0,   -5, 	   2,   -1, 	   0,   -6
+.2byte    3,   -7, 	  -5,   -4, 	   4,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -11, 	   7,   -2, 	  -7,   -5, 	   1,   -6
+.2byte    0,  -11, 	   7,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte    0,   -9, 	  -8,   -3, 	   5,   -3, 	  -2,   -6
+.2byte   -3,   -8, 	   5,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -7, 	   8,   -3, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -5, 	  -2,   -1, 	   0,   -6
+.2byte   -3,   -7, 	   5,   -4, 	  -4,   -1, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,   -6, 	   2,   -3, 	  -3,    0, 	   0,   -5
+.2byte   -3,   -6, 	  -6,   -3, 	   3,   -1, 	   0,   -5
+.2byte   -5,   -6, 	  -3,    0, 	  -3,   -2, 	  -2,   -5
+.2byte   -2,   -7, 	  -6,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -2,   -6, 	  -5,   -5, 	   4,    0, 	  -1,   -5
+.2byte   -2,   -6, 	  -7,   -3, 	   6,   -3, 	  -1,   -5
+.2byte   -2,   -5, 	  -5,   -2, 	   5,   -1, 	   1,   -5
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -3, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   6,   -3, 	   0,   -5
+.2byte    0,   -8, 	  -5,   -7, 	   5,   -7, 	   0,   -5
+.2byte    0,  -10, 	  -5,   -6, 	   4,   -6, 	   0,   -6
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+.2byte    2,   -6, 	   5,   -5, 	  -4,    0, 	   1,   -5
+.2byte    2,   -6, 	   7,   -3, 	  -6,   -3, 	   1,   -5
+.2byte    0,   -9, 	  -2,   -7, 	   5,   -9, 	  -1,   -6
+.2byte   -2,  -10, 	  -2,   -6, 	   5,   -8, 	  -1,   -5
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte    3,   -6, 	  -2,   -3, 	   3,    0, 	   0,   -5
+.2byte    3,   -6, 	   6,   -3, 	  -3,   -1, 	   0,   -5
+.2byte    0,   -9, 	   6,  -10, 	   6,  -11, 	  -1,   -7
+.2byte   -1,   -8, 	   7,   -9, 	   7,  -10, 	  -1,   -6
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte    3,   -7, 	  -8,   -3, 	   6,   -3, 	   0,   -6
+.2byte    3,   -7, 	   0,   -5, 	   2,   -1, 	   0,   -6
+.2byte   -1,   -9, 	   4,  -11, 	  -3,  -12, 	  -1,   -5
+.2byte   -2,   -8, 	   4,  -10, 	  -4,  -11, 	  -2,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -11, 	   7,   -2, 	  -7,   -5, 	   1,   -6
+.2byte    0,  -11, 	   7,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte    2,   -9, 	   5,    0, 	  -6,    0, 	   0,   -6
+.2byte   -1,   -6, 	   4,    0, 	  -6,    0, 	  -3,   -4
+.2byte   -3,   -8, 	   5,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -7, 	   8,   -3, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -5, 	  -2,   -1, 	   0,   -6
+.2byte    1,   -9, 	  -4,  -11, 	   3,  -12, 	   1,   -5
+.2byte    2,   -8, 	  -4,  -10, 	   4,  -11, 	   2,   -5
+.2byte   -3,   -7, 	   0,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,   -6, 	   2,   -3, 	  -3,    0, 	   0,   -5
+.2byte   -3,   -6, 	  -6,   -3, 	   3,   -1, 	   0,   -5
+.2byte    1,   -9, 	  -5,  -10, 	  -5,  -11, 	   2,   -7
+.2byte    1,   -8, 	  -7,   -9, 	  -7,  -10, 	   1,   -6
+.2byte   -2,   -7, 	  -6,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -2,   -6, 	  -5,   -5, 	   4,    0, 	  -1,   -5
+.2byte   -2,   -6, 	  -7,   -3, 	   6,   -3, 	  -1,   -5
+.2byte    0,   -9, 	   2,   -7, 	  -5,   -9, 	   1,   -6
+.2byte    2,  -10, 	   2,   -6, 	  -5,   -8, 	   1,   -5
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -3, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   6,   -3, 	   0,   -5
+.2byte    0,   -4, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+.2byte    2,   -6, 	   5,   -5, 	  -4,    0, 	   1,   -5
+.2byte    2,   -6, 	   7,   -3, 	  -6,   -3, 	   1,   -5
+.2byte    2,   -5, 	   5,   -2, 	  -5,   -1, 	  -1,   -5
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte    3,   -6, 	  -2,   -3, 	   3,    0, 	   0,   -5
+.2byte    3,   -6, 	   6,   -3, 	  -3,   -1, 	   0,   -5
+.2byte    5,   -6, 	   3,    0, 	   3,   -2, 	   2,   -5
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte    3,   -7, 	  -8,   -3, 	   6,   -3, 	   0,   -6
+.2byte    3,   -7, 	   0,   -5, 	   2,   -1, 	   0,   -6
+.2byte    3,   -7, 	  -5,   -4, 	   4,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -11, 	   7,   -2, 	  -7,   -5, 	   1,   -6
+.2byte    0,  -11, 	   7,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte    1,   -9, 	  -7,   -3, 	   6,   -3, 	  -1,   -6
+.2byte   -3,   -8, 	   5,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -7, 	   8,   -3, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -5, 	  -2,   -1, 	   0,   -6
+.2byte   -3,   -7, 	   5,   -4, 	  -4,   -1, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,   -6, 	   2,   -3, 	  -3,    0, 	   0,   -5
+.2byte   -3,   -6, 	  -6,   -3, 	   3,   -1, 	   0,   -5
+.2byte   -5,   -6, 	  -3,    0, 	  -3,   -2, 	  -2,   -5
+.2byte   -2,   -7, 	  -6,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -2,   -6, 	  -5,   -5, 	   4,    0, 	  -1,   -5
+.2byte   -2,   -6, 	  -7,   -3, 	   6,   -3, 	  -1,   -5
+.2byte   -2,   -5, 	  -5,   -2, 	   5,   -1, 	   1,   -5
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte   -2,   -7, 	  -6,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -3,   -7, 	   0,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,   -8, 	   5,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+.2byte   -2,   -5, 	  -6,   -3, 	   5,    0, 	   0,   -5
+.2byte   -2,   -4, 	  -6,   -3, 	   5,    0, 	   0,   -4
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte    1,   -6, 	   5,   -9, 	  -9,   -8, 	  -1,   -6
+.2byte    0,   -6, 	  -7,  -10, 	  -8,   -5, 	  -2,   -5
+.2byte    4,   -5, 	  -2,   -8, 	   4,   -4, 	  -2,   -6
+.2byte   -1,   -4, 	   7,   -6, 	  -7,   -6, 	  -3,   -3
+.2byte   -5,   -5, 	   1,   -8, 	  -5,   -4, 	   1,   -6
+.2byte   -1,   -6, 	   6,  -10, 	   7,   -5, 	   1,   -5
+.2byte   -2,   -6, 	  -6,   -9, 	   8,   -8, 	   0,   -6
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -3, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	  -6,   -1, 	   6,   -3, 	   0,   -5
+.2byte    0,   -4, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+.2byte    2,   -6, 	   5,   -5, 	  -4,    0, 	   1,   -5
+.2byte    2,   -6, 	   7,   -3, 	  -6,   -3, 	   1,   -5
+.2byte    2,   -5, 	   5,   -2, 	  -5,   -1, 	  -1,   -5
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte    3,   -6, 	  -2,   -3, 	   3,    0, 	   0,   -5
+.2byte    3,   -6, 	   6,   -3, 	  -3,   -1, 	   0,   -5
+.2byte    5,   -6, 	   3,    0, 	   3,   -2, 	   2,   -5
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte    3,   -7, 	  -8,   -3, 	   6,   -3, 	   0,   -6
+.2byte    3,   -7, 	   0,   -5, 	   2,   -1, 	   0,   -6
+.2byte    3,   -7, 	  -5,   -4, 	   4,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -11, 	   7,   -2, 	  -7,   -5, 	   1,   -6
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -2, 	  -2,   -6
+.2byte    1,   -9, 	  -7,   -3, 	   6,   -3, 	  -1,   -6
+.2byte   -3,   -8, 	   5,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -7, 	   8,   -3, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -5, 	  -2,   -1, 	   0,   -6
+.2byte   -3,   -7, 	   5,   -4, 	  -4,   -1, 	   0,   -6
+.2byte   -3,   -7, 	   0,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,   -6, 	   2,   -3, 	  -3,    0, 	   0,   -5
+.2byte   -3,   -6, 	  -6,   -3, 	   3,   -1, 	   0,   -5
+.2byte   -5,   -6, 	  -3,    0, 	  -3,   -2, 	  -2,   -5
+.2byte   -2,   -7, 	  -6,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -2,   -6, 	  -5,   -5, 	   4,    0, 	  -1,   -5
+.2byte   -2,   -6, 	  -7,   -3, 	   6,   -3, 	  -1,   -5
+.2byte   -2,   -5, 	  -5,   -2, 	   5,   -1, 	   1,   -5
+.2byte    0,   -4, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte   -5,   -5, 	  -8,   -2, 	   2,   -1, 	  -2,   -5
+.2byte   -8,   -6, 	  -6,    0, 	  -6,   -2, 	  -5,   -5
+.2byte   -6,   -8, 	   2,   -5, 	  -7,   -2, 	  -3,   -7
+.2byte    0,   -9, 	  -8,   -3, 	   5,   -3, 	  -2,   -6
+.2byte    5,   -8, 	  -3,   -5, 	   6,   -2, 	   2,   -7
+.2byte    7,   -6, 	   5,    0, 	   5,   -2, 	   4,   -5
+.2byte    4,   -5, 	   7,   -2, 	  -3,   -1, 	   1,   -5
+.2byte    0,   -4, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte   -5,   -5, 	  -8,   -2, 	   2,   -1, 	  -2,   -5
+.2byte   -8,   -6, 	  -6,    0, 	  -6,   -2, 	  -5,   -5
+.2byte   -6,   -8, 	   2,   -5, 	  -7,   -2, 	  -3,   -7
+.2byte    0,   -9, 	  -8,   -3, 	   5,   -3, 	  -2,   -6
+.2byte    5,   -8, 	  -3,   -5, 	   6,   -2, 	   2,   -7
+.2byte    7,   -6, 	   5,    0, 	   5,   -2, 	   4,   -5
+.2byte    4,   -5, 	   7,   -2, 	  -3,   -1, 	   1,   -5
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte    0,  -10, 	  -5,   -6, 	   4,   -6, 	   0,   -6
+.2byte    0,   -4, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+.2byte    0,  -10, 	   0,   -6, 	   7,   -8, 	   1,   -5
+.2byte    2,   -5, 	   5,   -2, 	  -5,   -1, 	  -1,   -5
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte   -1,   -8, 	   7,   -9, 	   7,  -10, 	  -1,   -6
+.2byte    5,   -6, 	   3,    0, 	   3,   -2, 	   2,   -5
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte   -2,   -8, 	   4,  -10, 	  -4,  -11, 	  -2,   -5
+.2byte    3,   -7, 	  -5,   -4, 	   4,   -1, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte   -1,   -6, 	   4,    0, 	  -6,    0, 	  -3,   -4
+.2byte    2,   -9, 	  -6,   -3, 	   7,   -3, 	   0,   -6
+.2byte   -4,   -8, 	   4,   -6, 	  -7,   -2, 	  -1,   -7
+.2byte    1,   -8, 	  -5,  -10, 	   3,  -11, 	   1,   -5
+.2byte   -4,   -7, 	   4,   -4, 	  -5,   -1, 	  -1,   -6
+.2byte   -4,   -7, 	  -1,   -4, 	  -1,   -1, 	  -2,   -6
+.2byte    0,   -8, 	  -8,   -9, 	  -8,  -10, 	   0,   -6
+.2byte   -6,   -6, 	  -4,    0, 	  -4,   -2, 	  -3,   -5
+.2byte   -3,   -7, 	  -7,   -6, 	   5,   -2, 	  -2,   -6
+.2byte   -1,  -10, 	  -1,   -6, 	  -8,   -8, 	  -2,   -5
+.2byte   -3,   -5, 	  -6,   -2, 	   4,   -1, 	   0,   -5
+.2byte    0,   -4, 	  -7,   -2, 	   7,   -2, 	   0,   -5
+.2byte   -5,   -5, 	  -8,   -2, 	   2,   -1, 	  -2,   -5
+.2byte   -8,   -6, 	  -6,    0, 	  -6,   -2, 	  -5,   -5
+.2byte   -6,   -8, 	   2,   -5, 	  -7,   -2, 	  -3,   -7
+.2byte    0,   -9, 	  -8,   -3, 	   5,   -3, 	  -2,   -6
+.2byte    5,   -8, 	  -3,   -5, 	   6,   -2, 	   2,   -7
+.2byte    7,   -6, 	   5,    0, 	   5,   -2, 	   4,   -5
+.2byte    4,   -5, 	   7,   -2, 	  -3,   -1, 	   1,   -5
+.2byte    0,   -7, 	  -7,   -4, 	   7,   -4, 	   0,   -6
+.2byte   -2,   -7, 	  -6,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -3,   -7, 	   0,   -4, 	   0,   -1, 	  -1,   -6
+.2byte   -3,   -8, 	   5,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -1,  -12, 	   7,   -4, 	  -7,   -4, 	   0,   -7
+.2byte    3,   -8, 	  -5,   -6, 	   6,   -2, 	   0,   -7
+.2byte    3,   -7, 	   0,   -4, 	   0,   -1, 	   1,   -6
+.2byte    2,   -7, 	   6,   -6, 	  -6,   -2, 	   1,   -6
+sMawileAnimTable1:
+.4byte sMawileAnims_1_1
+.4byte sMawileAnims_1_2
+.4byte sMawileAnims_1_3
+.4byte sMawileAnims_1_4
+.4byte sMawileAnims_1_5
+.4byte sMawileAnims_1_6
+.4byte sMawileAnims_1_7
+.4byte sMawileAnims_1_8
+sMawileAnimTable2:
+.4byte sMawileAnims_2_1
+.4byte sMawileAnims_2_2
+.4byte sMawileAnims_2_3
+.4byte sMawileAnims_2_4
+.4byte sMawileAnims_2_5
+.4byte sMawileAnims_2_6
+.4byte sMawileAnims_2_7
+.4byte sMawileAnims_2_8
+sMawileAnimTable3:
+.4byte sMawileAnims_3_1
+.4byte sMawileAnims_3_2
+.4byte sMawileAnims_3_3
+.4byte sMawileAnims_3_4
+.4byte sMawileAnims_3_5
+.4byte sMawileAnims_3_6
+.4byte sMawileAnims_3_7
+.4byte sMawileAnims_3_8
+sMawileAnimTable4:
+.4byte sMawileAnims_4_1
+.4byte sMawileAnims_4_2
+.4byte sMawileAnims_4_3
+.4byte sMawileAnims_4_4
+.4byte sMawileAnims_4_5
+.4byte sMawileAnims_4_6
+.4byte sMawileAnims_4_7
+.4byte sMawileAnims_4_8
+sMawileAnimTable5:
+.4byte sMawileAnims_5_1
+.4byte sMawileAnims_5_2
+.4byte sMawileAnims_5_3
+.4byte sMawileAnims_5_4
+.4byte sMawileAnims_5_5
+.4byte sMawileAnims_5_6
+.4byte sMawileAnims_5_7
+.4byte sMawileAnims_5_8
+sMawileAnimTable6:
+.4byte sMawileAnims_6_1
+.4byte sMawileAnims_6_1
+.4byte sMawileAnims_6_1
+.4byte sMawileAnims_6_1
+.4byte sMawileAnims_6_1
+.4byte sMawileAnims_6_1
+.4byte sMawileAnims_6_1
+.4byte sMawileAnims_6_1
+sMawileAnimTable7:
+.4byte sMawileAnims_7_1
+.4byte sMawileAnims_7_2
+.4byte sMawileAnims_7_3
+.4byte sMawileAnims_7_4
+.4byte sMawileAnims_7_5
+.4byte sMawileAnims_7_6
+.4byte sMawileAnims_7_7
+.4byte sMawileAnims_7_8
+sMawileAnimTable8:
+.4byte sMawileAnims_8_1
+.4byte sMawileAnims_8_2
+.4byte sMawileAnims_8_3
+.4byte sMawileAnims_8_4
+.4byte sMawileAnims_8_5
+.4byte sMawileAnims_8_6
+.4byte sMawileAnims_8_7
+.4byte sMawileAnims_8_8
+sMawileAnimTable9:
+.4byte sMawileAnims_9_1
+.4byte sMawileAnims_9_2
+.4byte sMawileAnims_9_3
+.4byte sMawileAnims_9_4
+.4byte sMawileAnims_9_5
+.4byte sMawileAnims_9_6
+.4byte sMawileAnims_9_7
+.4byte sMawileAnims_9_8
+sMawileAnimTable10:
+.4byte sMawileAnims_10_1
+.4byte sMawileAnims_10_2
+.4byte sMawileAnims_10_3
+.4byte sMawileAnims_10_4
+.4byte sMawileAnims_10_5
+.4byte sMawileAnims_10_6
+.4byte sMawileAnims_10_7
+.4byte sMawileAnims_10_8
+sMawileAnimTable11:
+.4byte sMawileAnims_11_1
+.4byte sMawileAnims_11_2
+.4byte sMawileAnims_11_3
+.4byte sMawileAnims_11_4
+.4byte sMawileAnims_11_5
+.4byte sMawileAnims_11_6
+.4byte sMawileAnims_11_7
+.4byte sMawileAnims_11_8
+sMawileAnimTable12:
+.4byte sMawileAnims_12_1
+.4byte sMawileAnims_12_2
+.4byte sMawileAnims_12_3
+.4byte sMawileAnims_12_4
+.4byte sMawileAnims_12_5
+.4byte sMawileAnims_12_6
+.4byte sMawileAnims_12_7
+.4byte sMawileAnims_12_8
+sMawileAnimTable13:
+.4byte sMawileAnims_13_1
+.4byte sMawileAnims_13_2
+.4byte sMawileAnims_13_3
+.4byte sMawileAnims_13_4
+.4byte sMawileAnims_13_5
+.4byte sMawileAnims_13_6
+.4byte sMawileAnims_13_7
+.4byte sMawileAnims_13_8
+sAxAnimationsMawile:
+.4byte sMawileAnimTable1
+.4byte sMawileAnimTable2
+.4byte sMawileAnimTable3
+.4byte sMawileAnimTable4
+.4byte sMawileAnimTable5
+.4byte sMawileAnimTable6
+.4byte sMawileAnimTable7
+.4byte sMawileAnimTable8
+.4byte sMawileAnimTable9
+.4byte sMawileAnimTable10
+.4byte sMawileAnimTable11
+.4byte sMawileAnimTable12
+.4byte sMawileAnimTable13
+sAxSpritesMawile:
+.4byte sMawileSprites1
+.4byte sMawileSprites2
+.4byte sMawileSprites3
+.4byte sMawileSprites4
+.4byte sMawileSprites5
+.4byte sMawileSprites6
+.4byte sMawileSprites7
+.4byte sMawileSprites8
+.4byte sMawileSprites9
+.4byte sMawileSprites10
+.4byte sMawileSprites11
+.4byte sMawileSprites12
+.4byte sMawileSprites13
+.4byte sMawileSprites14
+.4byte sMawileSprites15
+.4byte sMawileSprites16
+.4byte sMawileSprites17
+.4byte sMawileSprites18
+.4byte sMawileSprites19
+.4byte sMawileSprites20
+.4byte sMawileSprites21
+.4byte sMawileSprites22
+.4byte sMawileSprites23
+.4byte sMawileSprites24
+.4byte sMawileSprites25
+.4byte sMawileSprites26
+.4byte sMawileSprites27
+.4byte sMawileSprites28
+.4byte sMawileSprites29
+.4byte sMawileSprites30
+.4byte sMawileSprites31
+.4byte sMawileSprites32
+.4byte sMawileSprites33
+.4byte sMawileSprites34
+.4byte sMawileSprites35
+.4byte sMawileSprites36
+.4byte sMawileSprites37
+.4byte sMawileSprites38
+.4byte sMawileSprites39
+.4byte sMawileSprites40
+.4byte sMawileSprites41
+.4byte sMawileSprites42
+.4byte sMawileSprites43
+.4byte sMawileSprites44
+.4byte sMawileSprites45
+.4byte sMawileSprites46
+.4byte sMawileSprites47
+.4byte sMawileSprites48
+.4byte sMawileSprites49
+.4byte sMawileSprites50
+.4byte sMawileSprites51
+.4byte sMawileSprites52
+.4byte sMawileSprites53
+.4byte sMawileSprites54
+.4byte sMawileSprites55
+.4byte sMawileSprites56
+.4byte sMawileSprites57
+.4byte sMawileSprites58
+.4byte sMawileSprites59
+.4byte sMawileSprites60
+.4byte sMawileSprites61
+.4byte sMawileSprites62
+.4byte sMawileSprites63
+.4byte sMawileSprites64
+.4byte sMawileSprites65
+.4byte sMawileSprites66
+.4byte sMawileSprites67
+.4byte sMawileSprites68
+.4byte sMawileSprites69
+.4byte sMawileSprites70
+.4byte sMawileSprites71
+.4byte sMawileSprites72
+.4byte sMawileSprites73
+.4byte sMawileSprites74
+.4byte sMawileSprites75
+sAxMainMawile:
+ax_main sAxPosesMawile, sAxAnimationsMawile, 13, sAxSpritesMawile, sAxPositionsMawile

--- a/data/ax/medicham.inc
+++ b/data/ax/medicham.inc
@@ -1,0 +1,3006 @@
+.global gAxMedicham
+gAxMedicham:
+ax_siro sAxMainMedicham
+sMedichamPose1:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose2:
+ax_pose 1, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose3:
+ax_pose 2, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose4:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose5:
+ax_pose 4, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose6:
+ax_pose 5, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose7:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose8:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose9:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose10:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose11:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose12:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose13:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose14:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose15:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose16:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose17:
+ax_pose 10, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose18:
+ax_pose 11, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose19:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose20:
+ax_pose 7, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose21:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose22:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose23:
+ax_pose 4, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose24:
+ax_pose 5, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose25:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose26:
+ax_pose 1, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose27:
+ax_pose 2, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose28:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose29:
+ax_pose 4, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose30:
+ax_pose 5, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose31:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose32:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose33:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose34:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose35:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose36:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose37:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose38:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose39:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose40:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose41:
+ax_pose 10, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose42:
+ax_pose 11, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose43:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose44:
+ax_pose 7, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose45:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose46:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose47:
+ax_pose 4, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose48:
+ax_pose 5, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose49:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose50:
+ax_pose 1, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose51:
+ax_pose 2, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose52:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose53:
+ax_pose 16, 0x01ea, 0x80f4, 0x5c00
+ax_pose 17, 0x01ea, 0x80f4, 0x5c10
+ax_pose_terminator
+sMedichamPose54:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose55:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose56:
+ax_pose 4, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose57:
+ax_pose 5, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose58:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sMedichamPose59:
+ax_pose 19, 0x01e9, 0x90f2, 0x5c00
+ax_pose 20, 0x01e9, 0x90f2, 0x5c10
+ax_pose_terminator
+sMedichamPose60:
+ax_pose 20, 0x01e9, 0x90f2, 0x5c00
+ax_pose_terminator
+sMedichamPose61:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose62:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose63:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose64:
+ax_pose 21, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMedichamPose65:
+ax_pose 22, 0x01e4, 0x90f3, 0x5c00
+ax_pose 23, 0x01e4, 0x90f3, 0x5c10
+ax_pose_terminator
+sMedichamPose66:
+ax_pose 23, 0x01e4, 0x90f3, 0x5c00
+ax_pose_terminator
+sMedichamPose67:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose68:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose69:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose70:
+ax_pose 24, 0x01e3, 0x90f5, 0x5c00
+ax_pose_terminator
+sMedichamPose71:
+ax_pose 25, 0x01e8, 0x90ee, 0x5c00
+ax_pose 26, 0x01e8, 0x90ee, 0x5c10
+ax_pose_terminator
+sMedichamPose72:
+ax_pose 26, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose73:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose74:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose75:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose76:
+ax_pose 27, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose77:
+ax_pose 28, 0x01e7, 0x80f3, 0x5c00
+ax_pose 29, 0x01e7, 0x80f3, 0x5c10
+ax_pose_terminator
+sMedichamPose78:
+ax_pose 29, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose79:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose80:
+ax_pose 10, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose81:
+ax_pose 11, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose82:
+ax_pose 24, 0x01e3, 0x80ec, 0x5c00
+ax_pose_terminator
+sMedichamPose83:
+ax_pose 25, 0x01e8, 0x80f3, 0x5c00
+ax_pose 26, 0x01e8, 0x80f3, 0x5c10
+ax_pose_terminator
+sMedichamPose84:
+ax_pose 26, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose85:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose86:
+ax_pose 7, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose87:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose88:
+ax_pose 21, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedichamPose89:
+ax_pose 22, 0x01e4, 0x80ee, 0x5c00
+ax_pose 23, 0x01e4, 0x80ee, 0x5c10
+ax_pose_terminator
+sMedichamPose90:
+ax_pose 23, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sMedichamPose91:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose92:
+ax_pose 4, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose93:
+ax_pose 5, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose94:
+ax_pose 18, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose95:
+ax_pose 19, 0x01e9, 0x80ef, 0x5c00
+ax_pose 20, 0x01e9, 0x80ef, 0x5c10
+ax_pose_terminator
+sMedichamPose96:
+ax_pose 20, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sMedichamPose97:
+ax_pose 15, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose98:
+ax_pose 18, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose99:
+ax_pose 21, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedichamPose100:
+ax_pose 24, 0x01e3, 0x80ec, 0x5c00
+ax_pose_terminator
+sMedichamPose101:
+ax_pose 27, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose102:
+ax_pose 24, 0x01e3, 0x90f5, 0x5c00
+ax_pose_terminator
+sMedichamPose103:
+ax_pose 21, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMedichamPose104:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sMedichamPose105:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose106:
+ax_pose 30, 0x01ef, 0x00ff, 0x5c00
+ax_pose -1, 0x01ef, 0x00fb, 0x5c00
+ax_pose 0, 0x01e4, 0x80f4, 0x5c01
+ax_pose_terminator
+sMedichamPose107:
+ax_pose 31, 0x01ef, 0x00ff, 0x5c00
+ax_pose -1, 0x01ef, 0x00fb, 0x5c00
+ax_pose 0, 0x01e4, 0x80f4, 0x5c01
+ax_pose_terminator
+sMedichamPose108:
+ax_pose 32, 0x01eb, 0x40f6, 0x5c00
+ax_pose -1, 0x01eb, 0x40fa, 0x5c00
+ax_pose 0, 0x01e4, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedichamPose109:
+ax_pose 33, 0x01eb, 0x40f6, 0x5c00
+ax_pose -1, 0x01eb, 0x40fa, 0x5c00
+ax_pose 0, 0x01e4, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedichamPose110:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose111:
+ax_pose 30, 0x01ee, 0x1100, 0x5c00
+ax_pose -1, 0x01ef, 0x10fd, 0x5c00
+ax_pose 3, 0x01e4, 0x90ee, 0x5c01
+ax_pose_terminator
+sMedichamPose112:
+ax_pose 31, 0x01ee, 0x1100, 0x5c00
+ax_pose -1, 0x01ef, 0x10fd, 0x5c00
+ax_pose 3, 0x01e4, 0x90ee, 0x5c01
+ax_pose_terminator
+sMedichamPose113:
+ax_pose 32, 0x01ea, 0x50fd, 0x5c00
+ax_pose -1, 0x01eb, 0x50fa, 0x5c00
+ax_pose 3, 0x01e4, 0x90ee, 0x5c04
+ax_pose_terminator
+sMedichamPose114:
+ax_pose 33, 0x01ea, 0x50fd, 0x5c00
+ax_pose -1, 0x01eb, 0x50f9, 0x5c00
+ax_pose 3, 0x01e4, 0x90ee, 0x5c04
+ax_pose_terminator
+sMedichamPose115:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose116:
+ax_pose 30, 0x01ee, 0x1100, 0x5c00
+ax_pose 6, 0x01e4, 0x90ed, 0x5c01
+ax_pose -1, 0x01ec, 0x1101, 0x5c00
+ax_pose_terminator
+sMedichamPose117:
+ax_pose 31, 0x01ee, 0x1100, 0x5c00
+ax_pose 6, 0x01e4, 0x90ed, 0x5c01
+ax_pose -1, 0x01ec, 0x1101, 0x5c00
+ax_pose_terminator
+sMedichamPose118:
+ax_pose 32, 0x01ea, 0x50fd, 0x5c00
+ax_pose 6, 0x01e4, 0x90ed, 0x5c04
+ax_pose -1, 0x01e8, 0x50fe, 0x5c00
+ax_pose_terminator
+sMedichamPose119:
+ax_pose 33, 0x01ea, 0x50fd, 0x5c00
+ax_pose 6, 0x01e4, 0x90ed, 0x5c04
+ax_pose -1, 0x01e8, 0x50fe, 0x5c00
+ax_pose_terminator
+sMedichamPose120:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose121:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose 30, 0x01ed, 0x1102, 0x5c10
+ax_pose_terminator
+sMedichamPose122:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose 31, 0x01ed, 0x1102, 0x5c10
+ax_pose_terminator
+sMedichamPose123:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose 32, 0x01e9, 0x50ff, 0x5c10
+ax_pose -1, 0x01e8, 0x50f9, 0x5c10
+ax_pose_terminator
+sMedichamPose124:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose 33, 0x01e8, 0x50fa, 0x5c10
+ax_pose -1, 0x01e9, 0x50fe, 0x5c10
+ax_pose_terminator
+sMedichamPose125:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose126:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose 30, 0x01ea, 0x00f8, 0x5c10
+ax_pose -1, 0x01ea, 0x0102, 0x5c10
+ax_pose_terminator
+sMedichamPose127:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose 31, 0x01ea, 0x00f8, 0x5c10
+ax_pose -1, 0x01ea, 0x0102, 0x5c10
+ax_pose_terminator
+sMedichamPose128:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose 32, 0x01e6, 0x40f9, 0x5c10
+ax_pose -1, 0x01e6, 0x40f7, 0x5c10
+ax_pose_terminator
+sMedichamPose129:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose 33, 0x01e6, 0x40f9, 0x5c10
+ax_pose -1, 0x01e6, 0x40f7, 0x5c10
+ax_pose_terminator
+sMedichamPose130:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose131:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose 30, 0x01ed, 0x00f7, 0x5c10
+ax_pose_terminator
+sMedichamPose132:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose 31, 0x01ed, 0x00f7, 0x5c10
+ax_pose_terminator
+sMedichamPose133:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose 32, 0x01e9, 0x40f2, 0x5c10
+ax_pose -1, 0x01e8, 0x40f8, 0x5c10
+ax_pose_terminator
+sMedichamPose134:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose 33, 0x01e9, 0x40f2, 0x5c10
+ax_pose -1, 0x01e8, 0x40f8, 0x5c10
+ax_pose_terminator
+sMedichamPose135:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose136:
+ax_pose 30, 0x01ee, 0x00f9, 0x5c00
+ax_pose 6, 0x01e4, 0x80f4, 0x5c01
+ax_pose -1, 0x01ec, 0x00f8, 0x5c00
+ax_pose_terminator
+sMedichamPose137:
+ax_pose 31, 0x01ee, 0x00f9, 0x5c00
+ax_pose 6, 0x01e4, 0x80f4, 0x5c01
+ax_pose -1, 0x01ec, 0x00f8, 0x5c00
+ax_pose_terminator
+sMedichamPose138:
+ax_pose 32, 0x01ea, 0x40f4, 0x5c00
+ax_pose 6, 0x01e4, 0x80f4, 0x5c04
+ax_pose -1, 0x01e8, 0x40f3, 0x5c00
+ax_pose_terminator
+sMedichamPose139:
+ax_pose 33, 0x01ea, 0x40f4, 0x5c00
+ax_pose 6, 0x01e4, 0x80f4, 0x5c04
+ax_pose -1, 0x01e8, 0x40f3, 0x5c00
+ax_pose_terminator
+sMedichamPose140:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose141:
+ax_pose 30, 0x01ef, 0x00fd, 0x5c00
+ax_pose -1, 0x01ee, 0x00fa, 0x5c00
+ax_pose 3, 0x01e4, 0x80f3, 0x5c01
+ax_pose_terminator
+sMedichamPose142:
+ax_pose 31, 0x01ef, 0x00fd, 0x5c00
+ax_pose -1, 0x01ee, 0x00fa, 0x5c00
+ax_pose 3, 0x01e4, 0x80f3, 0x5c01
+ax_pose_terminator
+sMedichamPose143:
+ax_pose 32, 0x01eb, 0x40f8, 0x5c00
+ax_pose -1, 0x01ea, 0x40f5, 0x5c00
+ax_pose 3, 0x01e4, 0x80f3, 0x5c04
+ax_pose_terminator
+sMedichamPose144:
+ax_pose 33, 0x01eb, 0x40f8, 0x5c00
+ax_pose -1, 0x01ea, 0x40f5, 0x5c00
+ax_pose 3, 0x01e4, 0x80f3, 0x5c04
+ax_pose_terminator
+sMedichamPose145:
+ax_pose 34, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose146:
+ax_pose 35, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose147:
+ax_pose 36, 0x81df, 0x4105, 0x5c00
+ax_pose 37, 0x01d7, 0x00f9, 0x5c04
+ax_pose 38, 0x81df, 0x80f5, 0x5c05
+ax_pose_terminator
+sMedichamPose148:
+ax_pose 39, 0x01e2, 0x90ea, 0x5c00
+ax_pose_terminator
+sMedichamPose149:
+ax_pose 40, 0x01e2, 0x90e9, 0x5c00
+ax_pose_terminator
+sMedichamPose150:
+ax_pose 41, 0x01e6, 0x90ea, 0x5c00
+ax_pose_terminator
+sMedichamPose151:
+ax_pose 42, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMedichamPose152:
+ax_pose 41, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedichamPose153:
+ax_pose 40, 0x01e2, 0x80f7, 0x5c00
+ax_pose_terminator
+sMedichamPose154:
+ax_pose 39, 0x01e2, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedichamPose155:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose156:
+ax_pose 1, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose157:
+ax_pose 2, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose158:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose159:
+ax_pose 4, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose160:
+ax_pose 5, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose161:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose162:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose163:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose164:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose165:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose166:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose167:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose168:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose169:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose170:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose171:
+ax_pose 10, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose172:
+ax_pose 11, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose173:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose174:
+ax_pose 7, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose175:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose176:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose177:
+ax_pose 4, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose178:
+ax_pose 5, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose179:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose180:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose181:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose182:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose183:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose184:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose185:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose186:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose187:
+ax_pose 1, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose188:
+ax_pose 4, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose189:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose190:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose191:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose192:
+ax_pose 10, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose193:
+ax_pose 7, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose194:
+ax_pose 4, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose195:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose196:
+ax_pose 2, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose197:
+ax_pose 15, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose198:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose199:
+ax_pose 5, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sMedichamPose200:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sMedichamPose201:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose202:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose203:
+ax_pose 21, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMedichamPose204:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose205:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose206:
+ax_pose 24, 0x01e3, 0x90f6, 0x5c00
+ax_pose_terminator
+sMedichamPose207:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose208:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose209:
+ax_pose 27, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose210:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose211:
+ax_pose 11, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose212:
+ax_pose 24, 0x01e3, 0x80eb, 0x5c00
+ax_pose_terminator
+sMedichamPose213:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose214:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose215:
+ax_pose 21, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedichamPose216:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose217:
+ax_pose 5, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose218:
+ax_pose 18, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose219:
+ax_pose 15, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose220:
+ax_pose 18, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedichamPose221:
+ax_pose 21, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedichamPose222:
+ax_pose 24, 0x01e3, 0x80ec, 0x5c00
+ax_pose_terminator
+sMedichamPose223:
+ax_pose 27, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose224:
+ax_pose 24, 0x01e3, 0x90f5, 0x5c00
+ax_pose_terminator
+sMedichamPose225:
+ax_pose 21, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sMedichamPose226:
+ax_pose 18, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sMedichamPose227:
+ax_pose 0, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose228:
+ax_pose 3, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sMedichamPose229:
+ax_pose 6, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose230:
+ax_pose 9, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sMedichamPose231:
+ax_pose 12, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedichamPose232:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sMedichamPose233:
+ax_pose 6, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedichamPose234:
+ax_pose 3, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+.align 2
+sMedichamAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sMedichamAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sMedichamAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sMedichamAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sMedichamAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sMedichamAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sMedichamAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sMedichamAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -6, 0, -6,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 1, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 0, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMedichamAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 29, 3, -1, 3, 3,
+ax_anim 2, 0, 29, 9, 4, 9, 9,
+ax_anim 2, 2, 29, 16, 14, 16, 16,
+ax_anim 2, 0, 29, 21, 20, 21, 20,
+ax_anim 2, 1, 29, 22, 19, 22, 19,
+ax_anim 2, 0, 29, 21, 20, 21, 20,
+ax_anim 2, 0, 29, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sMedichamAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 4, -3, 4, 0,
+ax_anim 2, 0, 31, 9, -5, 9, 0,
+ax_anim 2, 2, 31, 15, -4, 15, 0,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 1, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 0, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 30, 6, 0, 6, -1,
+ax_anim_terminator
+sMedichamAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 35, 3, -9, 3, -3,
+ax_anim 2, 0, 35, 8, -17, 8, -7,
+ax_anim 2, 2, 35, 16, -20, 16, -14,
+ax_anim 2, 0, 35, 21, -18, 21, -18,
+ax_anim 2, 1, 35, 22, -17, 22, -17,
+ax_anim 2, 0, 35, 21, -18, 21, -18,
+ax_anim 2, 0, 35, 22, -17, 22, -17,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMedichamAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, -5, 0, -1,
+ax_anim 2, 0, 38, 0, -11, 0, -6,
+ax_anim 2, 2, 38, 0, -18, 0, -16,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 1, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 0, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMedichamAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 41, -3, -9, -3, -3,
+ax_anim 2, 0, 41, -8, -17, -8, -7,
+ax_anim 2, 2, 41, -16, -20, -16, -14,
+ax_anim 2, 0, 41, -21, -18, -21, -18,
+ax_anim 2, 1, 41, -22, -17, -22, -17,
+ax_anim 2, 0, 41, -21, -18, -21, -18,
+ax_anim 2, 0, 41, -22, -17, -22, -17,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMedichamAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, -4, -3, -4, 0,
+ax_anim 2, 0, 43, -9, -5, -9, 0,
+ax_anim 2, 2, 43, -15, -4, -15, 0,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 1, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 0, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 42, -6, 0, -6, -1,
+ax_anim_terminator
+sMedichamAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 47, -3, -1, -3, 3,
+ax_anim 2, 0, 47, -9, 4, -9, 9,
+ax_anim 2, 2, 47, -16, 14, -16, 16,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 1, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sMedichamAnims_3_1:
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 51, 0, -4, 0, -4,
+ax_anim 8, 2, 51, 0, -5, 0, -5,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 0, 51, 0, 4, 0, 4,
+ax_anim 2, 1, 52, 0, 13, 0, 13,
+ax_anim 2, 0, 53, -1, 13, -1, 13,
+ax_anim 2, 0, 53, 0, 13, 0, 13,
+ax_anim 2, 0, 53, -1, 13, -1, 13,
+ax_anim 2, 0, 53, 0, 13, 0, 13,
+ax_anim 2, 0, 53, -1, 13, -1, 13,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sMedichamAnims_3_2:
+ax_anim 2, 0, 54, -2, -2, -2, -2,
+ax_anim 2, 0, 57, -4, -4, -4, -4,
+ax_anim 8, 2, 57, -5, -5, -5, -5,
+ax_anim 1, 0, 57, -1, -1, -1, -1,
+ax_anim 1, 0, 57, 4, 4, 4, 4,
+ax_anim 2, 1, 58, 13, 13, 13, 13,
+ax_anim 2, 0, 59, 12, 14, 12, 14,
+ax_anim 2, 0, 59, 13, 13, 13, 13,
+ax_anim 2, 0, 59, 12, 14, 12, 14,
+ax_anim 2, 0, 59, 13, 13, 13, 13,
+ax_anim 2, 0, 59, 12, 14, 12, 14,
+ax_anim 2, 0, 54, 6, 6, 6, 6,
+ax_anim 2, 0, 54, 3, 3, 3, 3,
+ax_anim_terminator
+sMedichamAnims_3_3:
+ax_anim 2, 0, 60, -2, 0, -2, 0,
+ax_anim 2, 0, 63, -4, 0, -4, 0,
+ax_anim 8, 2, 63, -5, 0, -5, 0,
+ax_anim 1, 0, 63, -1, 0, -1, 0,
+ax_anim 1, 0, 63, 4, 0, 4, 0,
+ax_anim 2, 1, 64, 13, 0, 13, 0,
+ax_anim 2, 0, 65, 13, 1, 13, 1,
+ax_anim 2, 0, 65, 13, 0, 13, 0,
+ax_anim 2, 0, 65, 13, 1, 13, 1,
+ax_anim 2, 0, 65, 13, 0, 13, 0,
+ax_anim 2, 0, 65, 13, 1, 13, 1,
+ax_anim 2, 0, 60, 6, 0, 6, 0,
+ax_anim 2, 0, 60, 3, 0, 3, 0,
+ax_anim_terminator
+sMedichamAnims_3_4:
+ax_anim 2, 0, 66, -2, 2, -2, 2,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim 8, 2, 69, -5, 5, -5, 5,
+ax_anim 1, 0, 69, -1, 1, -1, 1,
+ax_anim 1, 0, 69, 4, -4, 4, -4,
+ax_anim 2, 1, 70, 15, -14, 15, -14,
+ax_anim 2, 0, 71, 14, -15, 14, -15,
+ax_anim 2, 0, 71, 15, -14, 15, -14,
+ax_anim 2, 0, 71, 14, -15, 14, -15,
+ax_anim 2, 0, 71, 15, -14, 15, -14,
+ax_anim 2, 0, 71, 14, -15, 14, -15,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, 3, -3, 3, -3,
+ax_anim_terminator
+sMedichamAnims_3_5:
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 8, 2, 75, 0, 5, 0, 5,
+ax_anim 1, 0, 75, 0, 1, 0, 1,
+ax_anim 1, 0, 75, 0, -4, 0, -4,
+ax_anim 2, 1, 76, 0, -13, 0, -13,
+ax_anim 2, 0, 77, -1, -13, -1, -13,
+ax_anim 2, 0, 77, 0, -13, 0, -13,
+ax_anim 2, 0, 77, -1, -13, -1, -13,
+ax_anim 2, 0, 77, 0, -13, 0, -13,
+ax_anim 2, 0, 77, -1, -13, -1, -13,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sMedichamAnims_3_6:
+ax_anim 2, 0, 78, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 4, 4, 4, 4,
+ax_anim 8, 2, 81, 5, 5, 5, 5,
+ax_anim 1, 0, 81, 1, 1, 1, 1,
+ax_anim 1, 0, 81, -4, -4, -4, -4,
+ax_anim 2, 1, 82, -15, -14, -15, -14,
+ax_anim 2, 0, 83, -14, -15, -14, -15,
+ax_anim 2, 0, 83, -15, -14, -15, -14,
+ax_anim 2, 0, 83, -14, -15, -14, -15,
+ax_anim 2, 0, 83, -15, -14, -15, -14,
+ax_anim 2, 0, 83, -14, -15, -14, -15,
+ax_anim 2, 0, 78, -6, -6, -6, -6,
+ax_anim 2, 0, 78, -3, -3, -3, -3,
+ax_anim_terminator
+sMedichamAnims_3_7:
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 2, 0, 87, 4, 0, 4, 0,
+ax_anim 8, 2, 87, 5, 0, 5, 0,
+ax_anim 1, 0, 87, 1, 0, 1, 0,
+ax_anim 1, 0, 87, -4, 0, -4, 0,
+ax_anim 2, 1, 88, -13, 0, -13, 0,
+ax_anim 2, 0, 89, -13, 1, -13, 1,
+ax_anim 2, 0, 89, -13, 0, -13, 0,
+ax_anim 2, 0, 89, -13, 1, -13, 1,
+ax_anim 2, 0, 89, -13, 0, -13, 0,
+ax_anim 2, 0, 89, -13, 1, -13, 1,
+ax_anim 2, 0, 84, -6, 0, -6, 0,
+ax_anim 2, 0, 84, -3, 0, -3, 0,
+ax_anim_terminator
+sMedichamAnims_3_8:
+ax_anim 2, 0, 90, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 4, -4, 4, -4,
+ax_anim 8, 2, 93, 5, -5, 5, -5,
+ax_anim 1, 0, 93, 1, -1, 1, -1,
+ax_anim 1, 0, 93, -4, 4, -4, 4,
+ax_anim 2, 1, 94, -13, 13, -13, 13,
+ax_anim 2, 0, 95, -12, 14, -12, 14,
+ax_anim 2, 0, 95, -13, 13, -13, 13,
+ax_anim 2, 0, 95, -12, 14, -12, 14,
+ax_anim 2, 0, 95, -13, 13, -13, 13,
+ax_anim 2, 0, 95, -12, 14, -12, 14,
+ax_anim 2, 0, 90, -6, 6, -6, 6,
+ax_anim 2, 0, 90, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sMedichamAnims_4_1:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_4_2:
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_4_3:
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 1, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_4_4:
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_4_5:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 1, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_4_6:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_4_7:
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_4_8:
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 1, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_5_1:
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 1, 0, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 2, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 1, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_5_2:
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 2, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 1, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_5_3:
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 2, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 1, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_5_4:
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 2, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 1, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_5_5:
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 2, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 1, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_5_6:
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 1, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 109, 0, -5, 0, 0,
+ax_anim 1, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 2, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 1, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_5_7:
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 1, 0, 109, 0, -5, 0, 0,
+ax_anim 1, 0, 114, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 2, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 1, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_5_8:
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 2, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 1, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sMedichamAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sMedichamAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sMedichamAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sMedichamAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sMedichamAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sMedichamAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sMedichamAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMedichamAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 3, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 154, 0, -6, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 3, 0, 158, 0, -3, 0, 0,
+ax_anim 4, 0, 157, 0, -6, 0, 0,
+ax_anim 3, 0, 159, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 3, 0, 161, 0, -3, 0, 0,
+ax_anim 4, 0, 160, 0, -6, 0, 0,
+ax_anim 3, 0, 162, 0, -3, 0, 0,
+ax_anim 2, 0, 162, 0, -2, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -2, 0, 0,
+ax_anim 3, 0, 164, 0, -3, 0, 0,
+ax_anim 4, 0, 163, 0, -6, 0, 0,
+ax_anim 3, 0, 165, 0, -3, 0, 0,
+ax_anim 2, 0, 165, 0, -2, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 3, 0, 167, 0, -3, 0, 0,
+ax_anim 4, 0, 166, 0, -6, 0, 0,
+ax_anim 3, 0, 168, 0, -3, 0, 0,
+ax_anim 2, 0, 168, 0, -2, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -2, 0, 0,
+ax_anim 3, 0, 170, 0, -3, 0, 0,
+ax_anim 4, 0, 169, 0, -6, 0, 0,
+ax_anim 3, 0, 171, 0, -3, 0, 0,
+ax_anim 2, 0, 171, 0, -2, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -2, 0, 0,
+ax_anim 3, 0, 173, 0, -3, 0, 0,
+ax_anim 4, 0, 172, 0, -6, 0, 0,
+ax_anim 3, 0, 174, 0, -3, 0, 0,
+ax_anim 2, 0, 174, 0, -2, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -2, 0, 0,
+ax_anim 3, 0, 176, 0, -3, 0, 0,
+ax_anim 4, 0, 175, 0, -6, 0, 0,
+ax_anim 3, 0, 177, 0, -3, 0, 0,
+ax_anim 2, 0, 177, 0, -2, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 10, 12, 10, 12,
+ax_anim 2, 0, 181, 7, 19, 7, 19,
+ax_anim 3, 0, 182, 0, 22, 0, 22,
+ax_anim 2, 3, 183, -7, 19, -7, 19,
+ax_anim 2, 0, 184, -10, 12, -10, 12,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 9, 0, 9, 0,
+ax_anim 2, 0, 179, 19, 5, 19, 5,
+ax_anim 2, 0, 180, 26, 13, 26, 13,
+ax_anim 3, 0, 181, 24, 21, 24, 21,
+ax_anim 2, 3, 182, 12, 21, 12, 21,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 5, -5, 5, -5,
+ax_anim 2, 0, 178, 12, -6, 12, -6,
+ax_anim 2, 0, 179, 19, -5, 19, -5,
+ax_anim 3, 0, 180, 23, -2, 23, -2,
+ax_anim 2, 3, 181, 19, 4, 19, 4,
+ax_anim 2, 0, 182, 12, 5, 12, 5,
+ax_anim 1, 0, 183, 4, 4, 4, 4,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -8, -1, -8,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -19, 12, -19,
+ax_anim 3, 0, 179, 21, -19, 21, -19,
+ax_anim 2, 3, 180, 24, -13, 24, -13,
+ax_anim 2, 0, 181, 18, -5, 18, -5,
+ax_anim 1, 0, 182, 9, 0, 9, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -10, -12, -10, -12,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -20, 0, -20,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 10, -12, 10, -12,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -8, 1, -8,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -19, -12, -19,
+ax_anim 3, 0, 185, -21, -19, -21, -19,
+ax_anim 2, 3, 184, -24, -13, -24, -13,
+ax_anim 2, 0, 183, -18, -5, -18, -5,
+ax_anim 1, 0, 182, -9, 0, -9, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -5, -5, -5, -5,
+ax_anim 2, 0, 178, -12, -6, -12, -6,
+ax_anim 2, 0, 185, -19, -5, -19, -5,
+ax_anim 3, 0, 184, -23, -2, -23, -2,
+ax_anim 2, 3, 183, -19, 4, -19, 4,
+ax_anim 2, 0, 182, -12, 5, -12, 5,
+ax_anim 1, 0, 181, -4, 4, -4, 4,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -9, 0, -9, 0,
+ax_anim 2, 0, 185, -19, 5, -19, 5,
+ax_anim 2, 0, 184, -26, 13, -26, 13,
+ax_anim 3, 0, 183, -24, 21, -24, 21,
+ax_anim 2, 3, 182, -12, 21, -12, 21,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -19, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 3, 0, 198, 0, -18, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 1, 0, 204, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 2, 0, 210, 0, -17, 0, 0,
+ax_anim 1, 0, 210, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 3, 0, 216, 0, -18, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedichamAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sMedichamGfx1:
+.incbin "baserom.gba", 0x1287828, 0x200
+sMedichamSprites1:
+ax_sprite sMedichamGfx1, 0x200
+ax_sprite_terminator
+sMedichamGfx2:
+.incbin "baserom.gba", 0x1287A38, 0x200
+sMedichamSprites2:
+ax_sprite sMedichamGfx2, 0x200
+ax_sprite_terminator
+sMedichamGfx3:
+.incbin "baserom.gba", 0x1287C48, 0x200
+sMedichamSprites3:
+ax_sprite sMedichamGfx3, 0x200
+ax_sprite_terminator
+sMedichamGfx4:
+.incbin "baserom.gba", 0x1287E58, 0x200
+sMedichamSprites4:
+ax_sprite sMedichamGfx4, 0x200
+ax_sprite_terminator
+sMedichamGfx5:
+.incbin "baserom.gba", 0x1288068, 0x200
+sMedichamSprites5:
+ax_sprite sMedichamGfx5, 0x200
+ax_sprite_terminator
+sMedichamGfx6:
+.incbin "baserom.gba", 0x1288278, 0x200
+sMedichamSprites6:
+ax_sprite sMedichamGfx6, 0x200
+ax_sprite_terminator
+sMedichamGfx7:
+.incbin "baserom.gba", 0x1288488, 0x200
+sMedichamSprites7:
+ax_sprite sMedichamGfx7, 0x200
+ax_sprite_terminator
+sMedichamGfx8:
+.incbin "baserom.gba", 0x1288698, 0x200
+sMedichamSprites8:
+ax_sprite sMedichamGfx8, 0x200
+ax_sprite_terminator
+sMedichamGfx9:
+.incbin "baserom.gba", 0x12888A8, 0x200
+sMedichamSprites9:
+ax_sprite sMedichamGfx9, 0x200
+ax_sprite_terminator
+sMedichamGfx10:
+.incbin "baserom.gba", 0x1288AB8, 0x200
+sMedichamSprites10:
+ax_sprite sMedichamGfx10, 0x200
+ax_sprite_terminator
+sMedichamGfx11:
+.incbin "baserom.gba", 0x1288CC8, 0x200
+sMedichamSprites11:
+ax_sprite sMedichamGfx11, 0x200
+ax_sprite_terminator
+sMedichamGfx12:
+.incbin "baserom.gba", 0x1288ED8, 0x200
+sMedichamSprites12:
+ax_sprite sMedichamGfx12, 0x200
+ax_sprite_terminator
+sMedichamGfx13:
+.incbin "baserom.gba", 0x12890E8, 0x200
+sMedichamSprites13:
+ax_sprite sMedichamGfx13, 0x200
+ax_sprite_terminator
+sMedichamGfx14:
+.incbin "baserom.gba", 0x12892F8, 0x200
+sMedichamSprites14:
+ax_sprite sMedichamGfx14, 0x200
+ax_sprite_terminator
+sMedichamGfx15:
+.incbin "baserom.gba", 0x1289508, 0x200
+sMedichamSprites15:
+ax_sprite sMedichamGfx15, 0x200
+ax_sprite_terminator
+sMedichamGfx16:
+.incbin "baserom.gba", 0x1289718, 0x20
+sMedichamGfx16_1:
+.incbin "baserom.gba", 0x1289738, 0x60
+sMedichamGfx16_2:
+.incbin "baserom.gba", 0x1289798, 0x60
+sMedichamGfx16_3:
+.incbin "baserom.gba", 0x12897F8, 0x60
+sMedichamSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx17:
+.incbin "baserom.gba", 0x12898A8, 0x20
+sMedichamGfx17_1:
+.incbin "baserom.gba", 0x12898C8, 0x20
+sMedichamGfx17_2:
+.incbin "baserom.gba", 0x12898E8, 0x40
+sMedichamGfx17_3:
+.incbin "baserom.gba", 0x1289928, 0x40
+sMedichamSprites17:
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx17, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMedichamGfx17_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx17_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx18:
+.incbin "baserom.gba", 0x12899B8, 0x40
+sMedichamGfx18_1:
+.incbin "baserom.gba", 0x12899F8, 0x60
+sMedichamGfx18_2:
+.incbin "baserom.gba", 0x1289A58, 0x60
+sMedichamGfx18_3:
+.incbin "baserom.gba", 0x1289AB8, 0x40
+sMedichamSprites18:
+ax_sprite sMedichamGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx19:
+.incbin "baserom.gba", 0x1289B40, 0x40
+sMedichamGfx19_1:
+.incbin "baserom.gba", 0x1289B80, 0x60
+sMedichamGfx19_2:
+.incbin "baserom.gba", 0x1289BE0, 0x60
+sMedichamGfx19_3:
+.incbin "baserom.gba", 0x1289C40, 0x60
+sMedichamSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx20:
+.incbin "baserom.gba", 0x1289CF0, 0xA0
+sMedichamGfx20_1:
+.incbin "baserom.gba", 0x1289D90, 0x40
+sMedichamSprites20:
+ax_sprite 0, 0xc0
+ax_sprite sMedichamGfx20, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedichamGfx21:
+.incbin "baserom.gba", 0x1289E00, 0x40
+sMedichamGfx21_1:
+.incbin "baserom.gba", 0x1289E40, 0x40
+sMedichamGfx21_2:
+.incbin "baserom.gba", 0x1289E80, 0x60
+sMedichamGfx21_3:
+.incbin "baserom.gba", 0x1289EE0, 0x60
+sMedichamSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx21_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx22:
+.incbin "baserom.gba", 0x1289F90, 0x40
+sMedichamGfx22_1:
+.incbin "baserom.gba", 0x1289FD0, 0x60
+sMedichamGfx22_2:
+.incbin "baserom.gba", 0x128A030, 0x60
+sMedichamGfx22_3:
+.incbin "baserom.gba", 0x128A090, 0x40
+sMedichamSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx22_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedichamGfx23:
+.incbin "baserom.gba", 0x128A120, 0x40
+sMedichamGfx23_1:
+.incbin "baserom.gba", 0x128A160, 0xC0
+sMedichamSprites23:
+ax_sprite 0, 0x80
+ax_sprite sMedichamGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx23_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedichamGfx24:
+.incbin "baserom.gba", 0x128A250, 0x40
+sMedichamGfx24_1:
+.incbin "baserom.gba", 0x128A290, 0x40
+sMedichamGfx24_2:
+.incbin "baserom.gba", 0x128A2D0, 0x60
+sMedichamGfx24_3:
+.incbin "baserom.gba", 0x128A330, 0x80
+sMedichamSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx24_3, 0x80
+ax_sprite_terminator
+sMedichamGfx25:
+.incbin "baserom.gba", 0x128A3F8, 0x40
+sMedichamGfx25_1:
+.incbin "baserom.gba", 0x128A438, 0x60
+sMedichamGfx25_2:
+.incbin "baserom.gba", 0x128A498, 0x60
+sMedichamGfx25_3:
+.incbin "baserom.gba", 0x128A4F8, 0x60
+sMedichamSprites25:
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx25_3, 0x60
+ax_sprite_terminator
+sMedichamGfx26:
+.incbin "baserom.gba", 0x128A5A0, 0x40
+sMedichamGfx26_1:
+.incbin "baserom.gba", 0x128A5E0, 0x40
+sMedichamGfx26_2:
+.incbin "baserom.gba", 0x128A620, 0x40
+sMedichamSprites26:
+ax_sprite sMedichamGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx26_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMedichamGfx26_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMedichamGfx27:
+.incbin "baserom.gba", 0x128A698, 0x60
+sMedichamGfx27_1:
+.incbin "baserom.gba", 0x128A6F8, 0x60
+sMedichamGfx27_2:
+.incbin "baserom.gba", 0x128A758, 0x60
+sMedichamGfx27_3:
+.incbin "baserom.gba", 0x128A7B8, 0x40
+sMedichamSprites27:
+ax_sprite sMedichamGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx28:
+.incbin "baserom.gba", 0x128A840, 0x20
+sMedichamGfx28_1:
+.incbin "baserom.gba", 0x128A860, 0x60
+sMedichamGfx28_2:
+.incbin "baserom.gba", 0x128A8C0, 0x60
+sMedichamGfx28_3:
+.incbin "baserom.gba", 0x128A920, 0x60
+sMedichamSprites28:
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx29:
+.incbin "baserom.gba", 0x128A9D0, 0x40
+sMedichamGfx29_1:
+.incbin "baserom.gba", 0x128AA10, 0x40
+sMedichamGfx29_2:
+.incbin "baserom.gba", 0x128AA50, 0x20
+sMedichamGfx29_3:
+.incbin "baserom.gba", 0x128AA70, 0x20
+sMedichamSprites29:
+ax_sprite sMedichamGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx29_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMedichamGfx29_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMedichamGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedichamGfx30:
+.incbin "baserom.gba", 0x128AAD8, 0x40
+sMedichamGfx30_1:
+.incbin "baserom.gba", 0x128AB18, 0x40
+sMedichamGfx30_2:
+.incbin "baserom.gba", 0x128AB58, 0x60
+sMedichamGfx30_3:
+.incbin "baserom.gba", 0x128ABB8, 0x40
+sMedichamSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMedichamGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMedichamGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedichamGfx31:
+.incbin "baserom.gba", 0x128AC48, 0x20
+sMedichamSprites31:
+ax_sprite sMedichamGfx31, 0x20
+ax_sprite_terminator
+sMedichamGfx32:
+.incbin "baserom.gba", 0x128AC78, 0x20
+sMedichamSprites32:
+ax_sprite sMedichamGfx32, 0x20
+ax_sprite_terminator
+sMedichamGfx33:
+.incbin "baserom.gba", 0x128ACA8, 0x80
+sMedichamSprites33:
+ax_sprite sMedichamGfx33, 0x80
+ax_sprite_terminator
+sMedichamGfx34:
+.incbin "baserom.gba", 0x128AD38, 0x80
+sMedichamSprites34:
+ax_sprite sMedichamGfx34, 0x80
+ax_sprite_terminator
+sMedichamGfx35:
+.incbin "baserom.gba", 0x128ADC8, 0x200
+sMedichamSprites35:
+ax_sprite sMedichamGfx35, 0x200
+ax_sprite_terminator
+sMedichamGfx36:
+.incbin "baserom.gba", 0x128AFD8, 0x200
+sMedichamSprites36:
+ax_sprite sMedichamGfx36, 0x200
+ax_sprite_terminator
+sMedichamGfx37:
+.incbin "baserom.gba", 0x128B1E8, 0x80
+sMedichamSprites37:
+ax_sprite sMedichamGfx37, 0x80
+ax_sprite_terminator
+sMedichamGfx38:
+.incbin "baserom.gba", 0x128B278, 0x20
+sMedichamSprites38:
+ax_sprite sMedichamGfx38, 0x20
+ax_sprite_terminator
+sMedichamGfx39:
+.incbin "baserom.gba", 0x128B2A8, 0x100
+sMedichamSprites39:
+ax_sprite sMedichamGfx39, 0x100
+ax_sprite_terminator
+sMedichamGfx40:
+.incbin "baserom.gba", 0x128B3B8, 0x200
+sMedichamSprites40:
+ax_sprite sMedichamGfx40, 0x200
+ax_sprite_terminator
+sMedichamGfx41:
+.incbin "baserom.gba", 0x128B5C8, 0x200
+sMedichamSprites41:
+ax_sprite sMedichamGfx41, 0x200
+ax_sprite_terminator
+sMedichamGfx42:
+.incbin "baserom.gba", 0x128B7D8, 0x200
+sMedichamSprites42:
+ax_sprite sMedichamGfx42, 0x200
+ax_sprite_terminator
+sMedichamGfx43:
+.incbin "baserom.gba", 0x128B9E8, 0x200
+sMedichamSprites43:
+ax_sprite sMedichamGfx43, 0x200
+ax_sprite_terminator
+sAxPosesMedicham:
+.4byte sMedichamPose1
+.4byte sMedichamPose2
+.4byte sMedichamPose3
+.4byte sMedichamPose4
+.4byte sMedichamPose5
+.4byte sMedichamPose6
+.4byte sMedichamPose7
+.4byte sMedichamPose8
+.4byte sMedichamPose9
+.4byte sMedichamPose10
+.4byte sMedichamPose11
+.4byte sMedichamPose12
+.4byte sMedichamPose13
+.4byte sMedichamPose14
+.4byte sMedichamPose15
+.4byte sMedichamPose16
+.4byte sMedichamPose17
+.4byte sMedichamPose18
+.4byte sMedichamPose19
+.4byte sMedichamPose20
+.4byte sMedichamPose21
+.4byte sMedichamPose22
+.4byte sMedichamPose23
+.4byte sMedichamPose24
+.4byte sMedichamPose25
+.4byte sMedichamPose26
+.4byte sMedichamPose27
+.4byte sMedichamPose28
+.4byte sMedichamPose29
+.4byte sMedichamPose30
+.4byte sMedichamPose31
+.4byte sMedichamPose32
+.4byte sMedichamPose33
+.4byte sMedichamPose34
+.4byte sMedichamPose35
+.4byte sMedichamPose36
+.4byte sMedichamPose37
+.4byte sMedichamPose38
+.4byte sMedichamPose39
+.4byte sMedichamPose40
+.4byte sMedichamPose41
+.4byte sMedichamPose42
+.4byte sMedichamPose43
+.4byte sMedichamPose44
+.4byte sMedichamPose45
+.4byte sMedichamPose46
+.4byte sMedichamPose47
+.4byte sMedichamPose48
+.4byte sMedichamPose49
+.4byte sMedichamPose50
+.4byte sMedichamPose51
+.4byte sMedichamPose52
+.4byte sMedichamPose53
+.4byte sMedichamPose54
+.4byte sMedichamPose55
+.4byte sMedichamPose56
+.4byte sMedichamPose57
+.4byte sMedichamPose58
+.4byte sMedichamPose59
+.4byte sMedichamPose60
+.4byte sMedichamPose61
+.4byte sMedichamPose62
+.4byte sMedichamPose63
+.4byte sMedichamPose64
+.4byte sMedichamPose65
+.4byte sMedichamPose66
+.4byte sMedichamPose67
+.4byte sMedichamPose68
+.4byte sMedichamPose69
+.4byte sMedichamPose70
+.4byte sMedichamPose71
+.4byte sMedichamPose72
+.4byte sMedichamPose73
+.4byte sMedichamPose74
+.4byte sMedichamPose75
+.4byte sMedichamPose76
+.4byte sMedichamPose77
+.4byte sMedichamPose78
+.4byte sMedichamPose79
+.4byte sMedichamPose80
+.4byte sMedichamPose81
+.4byte sMedichamPose82
+.4byte sMedichamPose83
+.4byte sMedichamPose84
+.4byte sMedichamPose85
+.4byte sMedichamPose86
+.4byte sMedichamPose87
+.4byte sMedichamPose88
+.4byte sMedichamPose89
+.4byte sMedichamPose90
+.4byte sMedichamPose91
+.4byte sMedichamPose92
+.4byte sMedichamPose93
+.4byte sMedichamPose94
+.4byte sMedichamPose95
+.4byte sMedichamPose96
+.4byte sMedichamPose97
+.4byte sMedichamPose98
+.4byte sMedichamPose99
+.4byte sMedichamPose100
+.4byte sMedichamPose101
+.4byte sMedichamPose102
+.4byte sMedichamPose103
+.4byte sMedichamPose104
+.4byte sMedichamPose105
+.4byte sMedichamPose106
+.4byte sMedichamPose107
+.4byte sMedichamPose108
+.4byte sMedichamPose109
+.4byte sMedichamPose110
+.4byte sMedichamPose111
+.4byte sMedichamPose112
+.4byte sMedichamPose113
+.4byte sMedichamPose114
+.4byte sMedichamPose115
+.4byte sMedichamPose116
+.4byte sMedichamPose117
+.4byte sMedichamPose118
+.4byte sMedichamPose119
+.4byte sMedichamPose120
+.4byte sMedichamPose121
+.4byte sMedichamPose122
+.4byte sMedichamPose123
+.4byte sMedichamPose124
+.4byte sMedichamPose125
+.4byte sMedichamPose126
+.4byte sMedichamPose127
+.4byte sMedichamPose128
+.4byte sMedichamPose129
+.4byte sMedichamPose130
+.4byte sMedichamPose131
+.4byte sMedichamPose132
+.4byte sMedichamPose133
+.4byte sMedichamPose134
+.4byte sMedichamPose135
+.4byte sMedichamPose136
+.4byte sMedichamPose137
+.4byte sMedichamPose138
+.4byte sMedichamPose139
+.4byte sMedichamPose140
+.4byte sMedichamPose141
+.4byte sMedichamPose142
+.4byte sMedichamPose143
+.4byte sMedichamPose144
+.4byte sMedichamPose145
+.4byte sMedichamPose146
+.4byte sMedichamPose147
+.4byte sMedichamPose148
+.4byte sMedichamPose149
+.4byte sMedichamPose150
+.4byte sMedichamPose151
+.4byte sMedichamPose152
+.4byte sMedichamPose153
+.4byte sMedichamPose154
+.4byte sMedichamPose155
+.4byte sMedichamPose156
+.4byte sMedichamPose157
+.4byte sMedichamPose158
+.4byte sMedichamPose159
+.4byte sMedichamPose160
+.4byte sMedichamPose161
+.4byte sMedichamPose162
+.4byte sMedichamPose163
+.4byte sMedichamPose164
+.4byte sMedichamPose165
+.4byte sMedichamPose166
+.4byte sMedichamPose167
+.4byte sMedichamPose168
+.4byte sMedichamPose169
+.4byte sMedichamPose170
+.4byte sMedichamPose171
+.4byte sMedichamPose172
+.4byte sMedichamPose173
+.4byte sMedichamPose174
+.4byte sMedichamPose175
+.4byte sMedichamPose176
+.4byte sMedichamPose177
+.4byte sMedichamPose178
+.4byte sMedichamPose179
+.4byte sMedichamPose180
+.4byte sMedichamPose181
+.4byte sMedichamPose182
+.4byte sMedichamPose183
+.4byte sMedichamPose184
+.4byte sMedichamPose185
+.4byte sMedichamPose186
+.4byte sMedichamPose187
+.4byte sMedichamPose188
+.4byte sMedichamPose189
+.4byte sMedichamPose190
+.4byte sMedichamPose191
+.4byte sMedichamPose192
+.4byte sMedichamPose193
+.4byte sMedichamPose194
+.4byte sMedichamPose195
+.4byte sMedichamPose196
+.4byte sMedichamPose197
+.4byte sMedichamPose198
+.4byte sMedichamPose199
+.4byte sMedichamPose200
+.4byte sMedichamPose201
+.4byte sMedichamPose202
+.4byte sMedichamPose203
+.4byte sMedichamPose204
+.4byte sMedichamPose205
+.4byte sMedichamPose206
+.4byte sMedichamPose207
+.4byte sMedichamPose208
+.4byte sMedichamPose209
+.4byte sMedichamPose210
+.4byte sMedichamPose211
+.4byte sMedichamPose212
+.4byte sMedichamPose213
+.4byte sMedichamPose214
+.4byte sMedichamPose215
+.4byte sMedichamPose216
+.4byte sMedichamPose217
+.4byte sMedichamPose218
+.4byte sMedichamPose219
+.4byte sMedichamPose220
+.4byte sMedichamPose221
+.4byte sMedichamPose222
+.4byte sMedichamPose223
+.4byte sMedichamPose224
+.4byte sMedichamPose225
+.4byte sMedichamPose226
+.4byte sMedichamPose227
+.4byte sMedichamPose228
+.4byte sMedichamPose229
+.4byte sMedichamPose230
+.4byte sMedichamPose231
+.4byte sMedichamPose232
+.4byte sMedichamPose233
+.4byte sMedichamPose234
+sAxPositionsMedicham:
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -13, 	  -6,  -11, 	   9,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -16, 	   6,  -11, 	   0,  -11
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -13, 	   5,  -12, 	  -6,  -15, 	   1,  -12
+.2byte    3,  -13, 	   8,  -16, 	  -3,  -10, 	   1,  -12
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -14, 	   3,   -9, 	   3,  -12, 	   1,  -12
+.2byte    4,  -14, 	   6,  -15, 	   4,   -8, 	   0,  -12
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    4,  -15, 	  -1,  -11, 	   9,  -14, 	   0,  -13
+.2byte    3,  -14, 	  -1,  -16, 	   6,  -10, 	   0,  -13
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -14, 	   6,  -12, 	  -8,  -14, 	   0,  -13
+.2byte    0,  -14, 	   8,  -14, 	  -6,  -12, 	   0,  -13
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -4,  -15, 	   1,  -11, 	  -9,  -14, 	   0,  -13
+.2byte   -3,  -14, 	   1,  -16, 	  -6,  -10, 	   0,  -13
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -14, 	  -3,   -9, 	  -3,  -12, 	  -1,  -12
+.2byte   -4,  -14, 	  -6,  -15, 	  -4,   -8, 	   0,  -12
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -13, 	  -5,  -12, 	   6,  -15, 	  -1,  -12
+.2byte   -3,  -13, 	  -8,  -16, 	   3,  -10, 	  -1,  -12
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -13, 	  -6,  -11, 	   9,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -16, 	   6,  -11, 	   0,  -11
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -13, 	   5,  -12, 	  -6,  -15, 	   1,  -12
+.2byte    3,  -13, 	   8,  -16, 	  -3,  -10, 	   1,  -12
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -14, 	   3,   -9, 	   3,  -12, 	   1,  -12
+.2byte    4,  -14, 	   6,  -15, 	   4,   -8, 	   0,  -12
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    4,  -15, 	  -1,  -11, 	   9,  -14, 	   0,  -13
+.2byte    3,  -14, 	  -1,  -16, 	   6,  -10, 	   0,  -13
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -14, 	   6,  -12, 	  -8,  -14, 	   0,  -13
+.2byte    0,  -14, 	   8,  -14, 	  -6,  -12, 	   0,  -13
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -4,  -15, 	   1,  -11, 	  -9,  -14, 	   0,  -13
+.2byte   -3,  -14, 	   1,  -16, 	  -6,  -10, 	   0,  -13
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -14, 	  -3,   -9, 	  -3,  -12, 	  -1,  -12
+.2byte   -4,  -14, 	  -6,  -15, 	  -4,   -8, 	   0,  -12
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -13, 	  -5,  -12, 	   6,  -15, 	  -1,  -12
+.2byte   -3,  -13, 	  -8,  -16, 	   3,  -10, 	  -1,  -12
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -13, 	  -6,  -11, 	   9,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -16, 	   6,  -11, 	   0,  -11
+.2byte    0,  -10, 	  -3,   -5, 	   6,  -10, 	   0,   -9
+.2byte   -5,   -7, 	  -3,  -16, 	   0,    4, 	   0,   -8
+.2byte   -5,   -7, 	  -3,  -16, 	   0,    4, 	   0,   -8
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -13, 	   5,  -12, 	  -6,  -15, 	   1,  -12
+.2byte    3,  -13, 	   8,  -16, 	  -3,  -10, 	   1,  -12
+.2byte    3,   -9, 	   9,   -9, 	  -3,   -9, 	   1,   -8
+.2byte    6,   -6, 	  -2,  -11, 	  12,    3, 	   0,   -7
+.2byte    6,   -6, 	  -2,  -11, 	  12,    3, 	   0,   -7
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -14, 	   3,   -9, 	   3,  -12, 	   1,  -12
+.2byte    4,  -14, 	   6,  -15, 	   4,   -8, 	   0,  -12
+.2byte    3,  -11, 	   8,  -13, 	  -2,  -10, 	   0,  -10
+.2byte    7,   -9, 	  -3,  -13, 	  14,   -8, 	   1,  -10
+.2byte    7,   -9, 	  -3,  -13, 	  14,   -8, 	   1,  -10
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    4,  -15, 	  -1,  -11, 	   9,  -14, 	   0,  -13
+.2byte    3,  -14, 	  -1,  -16, 	   6,  -10, 	   0,  -13
+.2byte    3,  -11, 	   5,  -16, 	   4,  -10, 	  -1,  -12
+.2byte   -2,  -11, 	  -8,  -10, 	   9,  -19, 	  -1,  -11
+.2byte   -2,  -11, 	  -8,  -10, 	   9,  -19, 	  -1,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -14, 	   6,  -12, 	  -8,  -14, 	   0,  -13
+.2byte    0,  -14, 	   8,  -14, 	  -6,  -12, 	   0,  -13
+.2byte    0,  -11, 	   4,  -16, 	  -5,  -11, 	   0,  -10
+.2byte    4,   -8, 	   6,   -5, 	  -2,  -23, 	   0,  -10
+.2byte    4,   -8, 	   6,   -5, 	  -2,  -23, 	   0,  -10
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -4,  -15, 	   1,  -11, 	  -9,  -14, 	   0,  -13
+.2byte   -3,  -14, 	   1,  -16, 	  -6,  -10, 	   0,  -13
+.2byte   -3,  -11, 	  -5,  -16, 	  -4,  -10, 	   1,  -12
+.2byte    2,  -11, 	   8,  -10, 	  -9,  -19, 	   1,  -11
+.2byte    2,  -11, 	   8,  -10, 	  -9,  -19, 	   1,  -11
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -14, 	  -3,   -9, 	  -3,  -12, 	  -1,  -12
+.2byte   -4,  -14, 	  -6,  -15, 	  -4,   -8, 	   0,  -12
+.2byte   -3,  -11, 	  -8,  -13, 	   2,  -10, 	   0,  -10
+.2byte   -7,   -9, 	   3,  -13, 	 -14,   -8, 	  -1,  -10
+.2byte   -7,   -9, 	   3,  -13, 	 -14,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -13, 	  -5,  -12, 	   6,  -15, 	  -1,  -12
+.2byte   -3,  -13, 	  -8,  -16, 	   3,  -10, 	  -1,  -12
+.2byte   -3,   -9, 	  -9,   -9, 	   3,   -9, 	  -1,   -8
+.2byte   -6,   -6, 	   2,  -11, 	 -12,    3, 	   0,   -7
+.2byte   -6,   -6, 	   2,  -11, 	 -12,    3, 	   0,   -7
+.2byte    0,   -9, 	  -3,   -4, 	   6,   -9, 	   0,   -8
+.2byte   -3,   -9, 	  -9,   -9, 	   3,   -9, 	  -1,   -8
+.2byte   -3,  -11, 	  -8,  -13, 	   2,  -10, 	   0,  -10
+.2byte   -3,  -11, 	  -5,  -16, 	  -4,  -10, 	   1,  -12
+.2byte    0,  -12, 	   4,  -17, 	  -5,  -12, 	   0,  -11
+.2byte    3,  -11, 	   5,  -16, 	   4,  -10, 	  -1,  -12
+.2byte    3,  -11, 	   8,  -13, 	  -2,  -10, 	   0,  -10
+.2byte    3,   -9, 	   9,   -9, 	  -3,   -9, 	   1,   -8
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,   -6, 	  -7,   -2, 	   7,    0, 	   0,   -6
+.2byte   -3,   -7, 	  -7,   -2, 	   7,    0, 	   0,   -6
+.2byte    0,  -16, 	  -8,  -18, 	   8,  -18, 	   0,  -14
+.2byte   -4,  -17, 	  -1,  -22, 	 -12,   -9, 	  -2,  -14
+.2byte    1,  -15, 	  -2,  -20, 	  -9,  -12, 	  -1,  -11
+.2byte    0,  -16, 	  -8,  -17, 	   6,  -13, 	   0,   -9
+.2byte    0,  -13, 	   9,  -12, 	  -9,  -12, 	   0,   -8
+.2byte   -1,  -16, 	   7,  -17, 	  -7,  -13, 	  -1,   -9
+.2byte   -2,  -15, 	   1,  -20, 	   8,  -12, 	   0,  -11
+.2byte    3,  -17, 	   0,  -22, 	  11,   -9, 	   1,  -14
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -13, 	  -6,  -11, 	   9,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -16, 	   6,  -11, 	   0,  -11
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -13, 	   5,  -12, 	  -6,  -15, 	   1,  -12
+.2byte    3,  -13, 	   8,  -16, 	  -3,  -10, 	   1,  -12
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -14, 	   3,   -9, 	   3,  -12, 	   1,  -12
+.2byte    4,  -14, 	   6,  -15, 	   4,   -8, 	   0,  -12
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    4,  -15, 	  -1,  -11, 	   9,  -14, 	   0,  -13
+.2byte    3,  -14, 	  -1,  -16, 	   6,  -10, 	   0,  -13
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -14, 	   6,  -12, 	  -8,  -14, 	   0,  -13
+.2byte    0,  -14, 	   8,  -14, 	  -6,  -12, 	   0,  -13
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -4,  -15, 	   1,  -11, 	  -9,  -14, 	   0,  -13
+.2byte   -3,  -14, 	   1,  -16, 	  -6,  -10, 	   0,  -13
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -14, 	  -3,   -9, 	  -3,  -12, 	  -1,  -12
+.2byte   -4,  -14, 	  -6,  -15, 	  -4,   -8, 	   0,  -12
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -13, 	  -5,  -12, 	   6,  -15, 	  -1,  -12
+.2byte   -3,  -13, 	  -8,  -16, 	   3,  -10, 	  -1,  -12
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    0,  -13, 	  -6,  -11, 	   9,  -16, 	   0,  -11
+.2byte    3,  -13, 	   5,  -12, 	  -6,  -15, 	   1,  -12
+.2byte    4,  -14, 	   3,   -9, 	   3,  -12, 	   1,  -12
+.2byte    4,  -15, 	  -1,  -11, 	   9,  -14, 	   0,  -13
+.2byte    0,  -14, 	   6,  -12, 	  -8,  -14, 	   0,  -13
+.2byte   -4,  -15, 	   1,  -11, 	  -9,  -14, 	   0,  -13
+.2byte   -4,  -14, 	  -3,   -9, 	  -3,  -12, 	  -1,  -12
+.2byte   -3,  -13, 	  -5,  -12, 	   6,  -15, 	  -1,  -12
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte    0,  -13, 	  -9,  -16, 	   6,  -11, 	   0,  -11
+.2byte    0,  -10, 	  -3,   -5, 	   6,  -10, 	   0,   -9
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+.2byte    3,  -13, 	   8,  -16, 	  -3,  -10, 	   1,  -12
+.2byte    3,   -9, 	   9,   -9, 	  -3,   -9, 	   1,   -8
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    4,  -14, 	   6,  -15, 	   4,   -8, 	   0,  -12
+.2byte    3,  -11, 	   8,  -13, 	  -2,  -10, 	   0,  -10
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    3,  -14, 	  -1,  -16, 	   6,  -10, 	   0,  -13
+.2byte    4,  -11, 	   6,  -16, 	   5,  -10, 	   0,  -12
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    0,  -14, 	   8,  -14, 	  -6,  -12, 	   0,  -13
+.2byte    0,  -11, 	   4,  -16, 	  -5,  -11, 	   0,  -10
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte   -3,  -14, 	   1,  -16, 	  -6,  -10, 	   0,  -13
+.2byte   -4,  -11, 	  -6,  -16, 	  -5,  -10, 	   0,  -12
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -4,  -14, 	  -6,  -15, 	  -4,   -8, 	   0,  -12
+.2byte   -3,  -11, 	  -8,  -13, 	   2,  -10, 	   0,  -10
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -3,  -13, 	  -8,  -16, 	   3,  -10, 	  -1,  -12
+.2byte   -3,   -9, 	  -9,   -9, 	   3,   -9, 	  -1,   -8
+.2byte    0,   -9, 	  -3,   -4, 	   6,   -9, 	   0,   -8
+.2byte   -3,   -9, 	  -9,   -9, 	   3,   -9, 	  -1,   -8
+.2byte   -3,  -11, 	  -8,  -13, 	   2,  -10, 	   0,  -10
+.2byte   -3,  -11, 	  -5,  -16, 	  -4,  -10, 	   1,  -12
+.2byte    0,  -12, 	   4,  -17, 	  -5,  -12, 	   0,  -11
+.2byte    3,  -11, 	   5,  -16, 	   4,  -10, 	  -1,  -12
+.2byte    3,  -11, 	   8,  -13, 	  -2,  -10, 	   0,  -10
+.2byte    3,   -9, 	   9,   -9, 	  -3,   -9, 	   1,   -8
+.2byte    0,  -11, 	  -9,   -9, 	   9,   -9, 	   0,   -9
+.2byte   -3,  -11, 	  -7,  -11, 	   5,   -8, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,  -10, 	  -2,   -7, 	  -1,  -10
+.2byte   -3,  -12, 	   1,  -11, 	  -7,   -8, 	   0,  -11
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    3,  -12, 	  -1,  -11, 	   7,   -8, 	   0,  -11
+.2byte    4,  -12, 	   3,  -10, 	   2,   -7, 	   1,  -10
+.2byte    3,  -11, 	   7,  -11, 	  -5,   -8, 	   1,  -10
+sMedichamAnimTable1:
+.4byte sMedichamAnims_1_1
+.4byte sMedichamAnims_1_2
+.4byte sMedichamAnims_1_3
+.4byte sMedichamAnims_1_4
+.4byte sMedichamAnims_1_5
+.4byte sMedichamAnims_1_6
+.4byte sMedichamAnims_1_7
+.4byte sMedichamAnims_1_8
+sMedichamAnimTable2:
+.4byte sMedichamAnims_2_1
+.4byte sMedichamAnims_2_2
+.4byte sMedichamAnims_2_3
+.4byte sMedichamAnims_2_4
+.4byte sMedichamAnims_2_5
+.4byte sMedichamAnims_2_6
+.4byte sMedichamAnims_2_7
+.4byte sMedichamAnims_2_8
+sMedichamAnimTable3:
+.4byte sMedichamAnims_3_1
+.4byte sMedichamAnims_3_2
+.4byte sMedichamAnims_3_3
+.4byte sMedichamAnims_3_4
+.4byte sMedichamAnims_3_5
+.4byte sMedichamAnims_3_6
+.4byte sMedichamAnims_3_7
+.4byte sMedichamAnims_3_8
+sMedichamAnimTable4:
+.4byte sMedichamAnims_4_1
+.4byte sMedichamAnims_4_2
+.4byte sMedichamAnims_4_3
+.4byte sMedichamAnims_4_4
+.4byte sMedichamAnims_4_5
+.4byte sMedichamAnims_4_6
+.4byte sMedichamAnims_4_7
+.4byte sMedichamAnims_4_8
+sMedichamAnimTable5:
+.4byte sMedichamAnims_5_1
+.4byte sMedichamAnims_5_2
+.4byte sMedichamAnims_5_3
+.4byte sMedichamAnims_5_4
+.4byte sMedichamAnims_5_5
+.4byte sMedichamAnims_5_6
+.4byte sMedichamAnims_5_7
+.4byte sMedichamAnims_5_8
+sMedichamAnimTable6:
+.4byte sMedichamAnims_6_1
+.4byte sMedichamAnims_6_1
+.4byte sMedichamAnims_6_1
+.4byte sMedichamAnims_6_1
+.4byte sMedichamAnims_6_1
+.4byte sMedichamAnims_6_1
+.4byte sMedichamAnims_6_1
+.4byte sMedichamAnims_6_1
+sMedichamAnimTable7:
+.4byte sMedichamAnims_7_1
+.4byte sMedichamAnims_7_2
+.4byte sMedichamAnims_7_3
+.4byte sMedichamAnims_7_4
+.4byte sMedichamAnims_7_5
+.4byte sMedichamAnims_7_6
+.4byte sMedichamAnims_7_7
+.4byte sMedichamAnims_7_8
+sMedichamAnimTable8:
+.4byte sMedichamAnims_8_1
+.4byte sMedichamAnims_8_2
+.4byte sMedichamAnims_8_3
+.4byte sMedichamAnims_8_4
+.4byte sMedichamAnims_8_5
+.4byte sMedichamAnims_8_6
+.4byte sMedichamAnims_8_7
+.4byte sMedichamAnims_8_8
+sMedichamAnimTable9:
+.4byte sMedichamAnims_9_1
+.4byte sMedichamAnims_9_2
+.4byte sMedichamAnims_9_3
+.4byte sMedichamAnims_9_4
+.4byte sMedichamAnims_9_5
+.4byte sMedichamAnims_9_6
+.4byte sMedichamAnims_9_7
+.4byte sMedichamAnims_9_8
+sMedichamAnimTable10:
+.4byte sMedichamAnims_10_1
+.4byte sMedichamAnims_10_2
+.4byte sMedichamAnims_10_3
+.4byte sMedichamAnims_10_4
+.4byte sMedichamAnims_10_5
+.4byte sMedichamAnims_10_6
+.4byte sMedichamAnims_10_7
+.4byte sMedichamAnims_10_8
+sMedichamAnimTable11:
+.4byte sMedichamAnims_11_1
+.4byte sMedichamAnims_11_2
+.4byte sMedichamAnims_11_3
+.4byte sMedichamAnims_11_4
+.4byte sMedichamAnims_11_5
+.4byte sMedichamAnims_11_6
+.4byte sMedichamAnims_11_7
+.4byte sMedichamAnims_11_8
+sMedichamAnimTable12:
+.4byte sMedichamAnims_12_1
+.4byte sMedichamAnims_12_2
+.4byte sMedichamAnims_12_3
+.4byte sMedichamAnims_12_4
+.4byte sMedichamAnims_12_5
+.4byte sMedichamAnims_12_6
+.4byte sMedichamAnims_12_7
+.4byte sMedichamAnims_12_8
+sMedichamAnimTable13:
+.4byte sMedichamAnims_13_1
+.4byte sMedichamAnims_13_2
+.4byte sMedichamAnims_13_3
+.4byte sMedichamAnims_13_4
+.4byte sMedichamAnims_13_5
+.4byte sMedichamAnims_13_6
+.4byte sMedichamAnims_13_7
+.4byte sMedichamAnims_13_8
+sAxAnimationsMedicham:
+.4byte sMedichamAnimTable1
+.4byte sMedichamAnimTable2
+.4byte sMedichamAnimTable3
+.4byte sMedichamAnimTable4
+.4byte sMedichamAnimTable5
+.4byte sMedichamAnimTable6
+.4byte sMedichamAnimTable7
+.4byte sMedichamAnimTable8
+.4byte sMedichamAnimTable9
+.4byte sMedichamAnimTable10
+.4byte sMedichamAnimTable11
+.4byte sMedichamAnimTable12
+.4byte sMedichamAnimTable13
+sAxSpritesMedicham:
+.4byte sMedichamSprites1
+.4byte sMedichamSprites2
+.4byte sMedichamSprites3
+.4byte sMedichamSprites4
+.4byte sMedichamSprites5
+.4byte sMedichamSprites6
+.4byte sMedichamSprites7
+.4byte sMedichamSprites8
+.4byte sMedichamSprites9
+.4byte sMedichamSprites10
+.4byte sMedichamSprites11
+.4byte sMedichamSprites12
+.4byte sMedichamSprites13
+.4byte sMedichamSprites14
+.4byte sMedichamSprites15
+.4byte sMedichamSprites16
+.4byte sMedichamSprites17
+.4byte sMedichamSprites18
+.4byte sMedichamSprites19
+.4byte sMedichamSprites20
+.4byte sMedichamSprites21
+.4byte sMedichamSprites22
+.4byte sMedichamSprites23
+.4byte sMedichamSprites24
+.4byte sMedichamSprites25
+.4byte sMedichamSprites26
+.4byte sMedichamSprites27
+.4byte sMedichamSprites28
+.4byte sMedichamSprites29
+.4byte sMedichamSprites30
+.4byte sMedichamSprites31
+.4byte sMedichamSprites32
+.4byte sMedichamSprites33
+.4byte sMedichamSprites34
+.4byte sMedichamSprites35
+.4byte sMedichamSprites36
+.4byte sMedichamSprites37
+.4byte sMedichamSprites38
+.4byte sMedichamSprites39
+.4byte sMedichamSprites40
+.4byte sMedichamSprites41
+.4byte sMedichamSprites42
+.4byte sMedichamSprites43
+sAxMainMedicham:
+ax_main sAxPosesMedicham, sAxAnimationsMedicham, 13, sAxSpritesMedicham, sAxPositionsMedicham

--- a/data/ax/meditite.inc
+++ b/data/ax/meditite.inc
@@ -1,0 +1,2903 @@
+.global gAxMeditite
+gAxMeditite:
+ax_siro sAxMainMeditite
+sMedititePose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose4:
+ax_pose 3, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose5:
+ax_pose 4, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose6:
+ax_pose 5, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose7:
+ax_pose 6, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose8:
+ax_pose 7, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose9:
+ax_pose 8, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose10:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose11:
+ax_pose 10, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose12:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose13:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose16:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose17:
+ax_pose 10, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose18:
+ax_pose 11, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose19:
+ax_pose 6, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose20:
+ax_pose 7, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose21:
+ax_pose 8, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose22:
+ax_pose 3, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose23:
+ax_pose 4, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose24:
+ax_pose 5, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose26:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose27:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose28:
+ax_pose 15, 0x41f1, 0x80f4, 0x5c00
+ax_pose 16, 0x01e9, 0x00fc, 0x5c08
+ax_pose_terminator
+sMedititePose29:
+ax_pose 3, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose30:
+ax_pose 4, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose31:
+ax_pose 5, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose32:
+ax_pose 17, 0x81e9, 0x90fc, 0x5c00
+ax_pose 18, 0x81f1, 0x10f4, 0x5c08
+ax_pose_terminator
+sMedititePose33:
+ax_pose 6, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose34:
+ax_pose 7, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose35:
+ax_pose 8, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose36:
+ax_pose 19, 0x81e9, 0x90fb, 0x5c00
+ax_pose 20, 0x81f1, 0x10f3, 0x5c08
+ax_pose_terminator
+sMedititePose37:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose38:
+ax_pose 10, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose39:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose40:
+ax_pose 21, 0x81e9, 0x90fe, 0x5c00
+ax_pose 22, 0x81e9, 0x50f6, 0x5c08
+ax_pose_terminator
+sMedititePose41:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose42:
+ax_pose 13, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose43:
+ax_pose 14, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose44:
+ax_pose 23, 0x81e9, 0x80f4, 0x5c00
+ax_pose 24, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose45:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose46:
+ax_pose 10, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose47:
+ax_pose 11, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose48:
+ax_pose 21, 0x81e9, 0x80f3, 0x5c00
+ax_pose 22, 0x81e9, 0x4103, 0x5c08
+ax_pose_terminator
+sMedititePose49:
+ax_pose 6, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose50:
+ax_pose 7, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose51:
+ax_pose 8, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose52:
+ax_pose 19, 0x81e9, 0x80f6, 0x5c00
+ax_pose 20, 0x81f1, 0x0106, 0x5c08
+ax_pose_terminator
+sMedititePose53:
+ax_pose 3, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose54:
+ax_pose 4, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose55:
+ax_pose 5, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose56:
+ax_pose 17, 0x81e9, 0x80f5, 0x5c00
+ax_pose 18, 0x81f1, 0x0105, 0x5c08
+ax_pose_terminator
+sMedititePose57:
+ax_pose 0, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose58:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose59:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose60:
+ax_pose 15, 0x41f1, 0x80f4, 0x5c00
+ax_pose 16, 0x01e9, 0x00fc, 0x5c08
+ax_pose_terminator
+sMedititePose61:
+ax_pose 3, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose62:
+ax_pose 4, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose63:
+ax_pose 5, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose64:
+ax_pose 17, 0x81e9, 0x90fc, 0x5c00
+ax_pose 18, 0x81f1, 0x10f4, 0x5c08
+ax_pose_terminator
+sMedititePose65:
+ax_pose 6, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose66:
+ax_pose 7, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose67:
+ax_pose 8, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose68:
+ax_pose 19, 0x81e9, 0x90fb, 0x5c00
+ax_pose 20, 0x81f1, 0x10f3, 0x5c08
+ax_pose_terminator
+sMedititePose69:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose70:
+ax_pose 10, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose71:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose72:
+ax_pose 21, 0x81e9, 0x90fe, 0x5c00
+ax_pose 22, 0x81e9, 0x50f6, 0x5c08
+ax_pose_terminator
+sMedititePose73:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose74:
+ax_pose 13, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose75:
+ax_pose 14, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose76:
+ax_pose 23, 0x81e9, 0x80f4, 0x5c00
+ax_pose 24, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose77:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose78:
+ax_pose 10, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose79:
+ax_pose 11, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose80:
+ax_pose 21, 0x81e9, 0x80f3, 0x5c00
+ax_pose 22, 0x81e9, 0x4103, 0x5c08
+ax_pose_terminator
+sMedititePose81:
+ax_pose 6, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose82:
+ax_pose 7, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose83:
+ax_pose 8, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose84:
+ax_pose 19, 0x81e9, 0x80f6, 0x5c00
+ax_pose 20, 0x81f1, 0x0106, 0x5c08
+ax_pose_terminator
+sMedititePose85:
+ax_pose 3, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose86:
+ax_pose 4, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose87:
+ax_pose 5, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose88:
+ax_pose 17, 0x81e9, 0x80f5, 0x5c00
+ax_pose 18, 0x81f1, 0x0105, 0x5c08
+ax_pose_terminator
+sMedititePose89:
+ax_pose 0, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose90:
+ax_pose 25, 0x81e8, 0x80f4, 0x5c00
+ax_pose 26, 0x81f0, 0x0104, 0x5c08
+ax_pose_terminator
+sMedititePose91:
+ax_pose 15, 0x41f1, 0x80f4, 0x5c00
+ax_pose 16, 0x01e9, 0x00fc, 0x5c08
+ax_pose_terminator
+sMedititePose92:
+ax_pose 3, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose93:
+ax_pose 27, 0x81ea, 0x90fa, 0x5c00
+ax_pose 28, 0x01f2, 0x10f2, 0x5c08
+ax_pose_terminator
+sMedititePose94:
+ax_pose 17, 0x81e9, 0x90fc, 0x5c00
+ax_pose 18, 0x81f1, 0x10f4, 0x5c08
+ax_pose_terminator
+sMedititePose95:
+ax_pose 6, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose96:
+ax_pose 29, 0x81e9, 0x90f9, 0x5c00
+ax_pose_terminator
+sMedititePose97:
+ax_pose 19, 0x81e9, 0x90fb, 0x5c00
+ax_pose 20, 0x81f1, 0x10f3, 0x5c08
+ax_pose_terminator
+sMedititePose98:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose99:
+ax_pose 30, 0x41f0, 0x90ee, 0x5c00
+ax_pose 31, 0x01e8, 0x10fe, 0x5c08
+ax_pose_terminator
+sMedititePose100:
+ax_pose 21, 0x81e9, 0x90fe, 0x5c00
+ax_pose 22, 0x81e9, 0x50f6, 0x5c08
+ax_pose_terminator
+sMedititePose101:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose102:
+ax_pose 32, 0x81e9, 0x80f4, 0x5c00
+ax_pose 33, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose103:
+ax_pose 23, 0x81e9, 0x80f4, 0x5c00
+ax_pose 24, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose104:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose105:
+ax_pose 30, 0x41f0, 0x80f3, 0x5c00
+ax_pose 31, 0x01e8, 0x00fb, 0x5c08
+ax_pose_terminator
+sMedititePose106:
+ax_pose 21, 0x81e9, 0x80f3, 0x5c00
+ax_pose 22, 0x81e9, 0x4103, 0x5c08
+ax_pose_terminator
+sMedititePose107:
+ax_pose 6, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose108:
+ax_pose 29, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sMedititePose109:
+ax_pose 19, 0x81e9, 0x80f6, 0x5c00
+ax_pose 20, 0x81f1, 0x0106, 0x5c08
+ax_pose_terminator
+sMedititePose110:
+ax_pose 3, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose111:
+ax_pose 27, 0x81ea, 0x80f7, 0x5c00
+ax_pose 28, 0x01f2, 0x0107, 0x5c08
+ax_pose_terminator
+sMedititePose112:
+ax_pose 17, 0x81e9, 0x80f5, 0x5c00
+ax_pose 18, 0x81f1, 0x0105, 0x5c08
+ax_pose_terminator
+sMedititePose113:
+ax_pose 0, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose114:
+ax_pose 34, 0x01f2, 0x04f9, 0x3c00
+ax_pose -1, 0x01f2, 0x04ff, 0x3c00
+ax_pose 0, 0x01e9, 0x80f4, 0x5c01
+ax_pose_terminator
+sMedititePose115:
+ax_pose 35, 0x01ee, 0x44f5, 0x3c00
+ax_pose -1, 0x01ee, 0x44fb, 0x3c00
+ax_pose 0, 0x01e9, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedititePose116:
+ax_pose 36, 0x01ee, 0x44f5, 0x3c00
+ax_pose -1, 0x01ee, 0x44fb, 0x3c00
+ax_pose 0, 0x01e9, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedititePose117:
+ax_pose 37, 0x01ee, 0x44f5, 0x3c00
+ax_pose -1, 0x01ee, 0x44fb, 0x3c00
+ax_pose 0, 0x01e9, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedititePose118:
+ax_pose 3, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose119:
+ax_pose 34, 0x01f3, 0x04fb, 0x3c00
+ax_pose -1, 0x01f2, 0x0501, 0x3c00
+ax_pose 3, 0x01e9, 0x90ed, 0x5c01
+ax_pose_terminator
+sMedititePose120:
+ax_pose 35, 0x01ef, 0x44f7, 0x3c00
+ax_pose -1, 0x01ee, 0x44fd, 0x3c00
+ax_pose 3, 0x01e9, 0x90ed, 0x5c04
+ax_pose_terminator
+sMedititePose121:
+ax_pose 36, 0x01ef, 0x44f7, 0x3c00
+ax_pose -1, 0x01ee, 0x44fd, 0x3c00
+ax_pose 3, 0x01e9, 0x90ed, 0x5c04
+ax_pose_terminator
+sMedititePose122:
+ax_pose 37, 0x01ef, 0x44f7, 0x3c00
+ax_pose -1, 0x01ee, 0x44fd, 0x3c00
+ax_pose 3, 0x01e9, 0x90ed, 0x5c04
+ax_pose_terminator
+sMedititePose123:
+ax_pose 6, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose124:
+ax_pose 34, 0x01f2, 0x0500, 0x3c00
+ax_pose 6, 0x81e9, 0x90f8, 0x5c01
+ax_pose -1, 0x01f1, 0x0504, 0x3c00
+ax_pose_terminator
+sMedititePose125:
+ax_pose 35, 0x01ee, 0x44fc, 0x3c00
+ax_pose 6, 0x81e9, 0x90f8, 0x5c04
+ax_pose -1, 0x01ed, 0x4500, 0x3c00
+ax_pose_terminator
+sMedititePose126:
+ax_pose 36, 0x01ee, 0x44fc, 0x3c00
+ax_pose 6, 0x81e9, 0x90f8, 0x5c04
+ax_pose -1, 0x01ed, 0x4500, 0x3c00
+ax_pose_terminator
+sMedititePose127:
+ax_pose 37, 0x01ee, 0x44fc, 0x3c00
+ax_pose 6, 0x81e9, 0x90f8, 0x5c04
+ax_pose -1, 0x01ed, 0x4500, 0x3c00
+ax_pose_terminator
+sMedititePose128:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose129:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose 34, 0x01ee, 0x04fa, 0x3c10
+ax_pose -1, 0x01f1, 0x0504, 0x3c10
+ax_pose_terminator
+sMedititePose130:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose 35, 0x01ea, 0x44f6, 0x3c10
+ax_pose -1, 0x01ed, 0x4500, 0x3c10
+ax_pose_terminator
+sMedititePose131:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose 36, 0x01ea, 0x44f6, 0x3c10
+ax_pose -1, 0x01ed, 0x4500, 0x3c10
+ax_pose_terminator
+sMedititePose132:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose 37, 0x01ea, 0x44f6, 0x3c10
+ax_pose -1, 0x01ed, 0x4500, 0x3c10
+ax_pose_terminator
+sMedititePose133:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose134:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose 34, 0x01ee, 0x04f6, 0x3c10
+ax_pose -1, 0x01ee, 0x0502, 0x3c10
+ax_pose_terminator
+sMedititePose135:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose 35, 0x01ea, 0x44f2, 0x3c10
+ax_pose -1, 0x01ea, 0x44fe, 0x3c10
+ax_pose_terminator
+sMedititePose136:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose 36, 0x01ea, 0x44f2, 0x3c10
+ax_pose -1, 0x01ea, 0x44fe, 0x3c10
+ax_pose_terminator
+sMedititePose137:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose 37, 0x01ea, 0x44f2, 0x3c10
+ax_pose -1, 0x01ea, 0x44fe, 0x3c10
+ax_pose_terminator
+sMedititePose138:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose139:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose 34, 0x01ee, 0x14ff, 0x3c10
+ax_pose -1, 0x01f1, 0x14f5, 0x3c10
+ax_pose_terminator
+sMedititePose140:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose 35, 0x01ea, 0x54fb, 0x3c10
+ax_pose -1, 0x01ed, 0x54f1, 0x3c10
+ax_pose_terminator
+sMedititePose141:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose 36, 0x01ea, 0x54fb, 0x3c10
+ax_pose -1, 0x01ed, 0x54f1, 0x3c10
+ax_pose_terminator
+sMedititePose142:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose 37, 0x01ea, 0x54fb, 0x3c10
+ax_pose -1, 0x01ed, 0x54f1, 0x3c10
+ax_pose_terminator
+sMedititePose143:
+ax_pose 6, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose144:
+ax_pose 34, 0x01f2, 0x14f9, 0x3c00
+ax_pose 6, 0x81e9, 0x80f9, 0x5c01
+ax_pose -1, 0x01f1, 0x14f5, 0x3c00
+ax_pose_terminator
+sMedititePose145:
+ax_pose 35, 0x01ee, 0x54f5, 0x3c00
+ax_pose 6, 0x81e9, 0x80f9, 0x5c04
+ax_pose -1, 0x01ed, 0x54f1, 0x3c00
+ax_pose_terminator
+sMedititePose146:
+ax_pose 36, 0x01ee, 0x54f5, 0x3c00
+ax_pose 6, 0x81e9, 0x80f9, 0x5c04
+ax_pose -1, 0x01ed, 0x54f1, 0x3c00
+ax_pose_terminator
+sMedititePose147:
+ax_pose 37, 0x01ee, 0x54f5, 0x3c00
+ax_pose 6, 0x81e9, 0x80f9, 0x5c04
+ax_pose -1, 0x01ed, 0x54f1, 0x3c00
+ax_pose_terminator
+sMedititePose148:
+ax_pose 3, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose149:
+ax_pose 34, 0x01f3, 0x14fe, 0x3c00
+ax_pose -1, 0x01f2, 0x14f8, 0x3c00
+ax_pose 3, 0x01e9, 0x80f4, 0x5c01
+ax_pose_terminator
+sMedititePose150:
+ax_pose 35, 0x01ef, 0x54fa, 0x3c00
+ax_pose -1, 0x01ee, 0x54f4, 0x3c00
+ax_pose 3, 0x01e9, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedititePose151:
+ax_pose 36, 0x01ef, 0x54fa, 0x3c00
+ax_pose -1, 0x01ee, 0x54f4, 0x3c00
+ax_pose 3, 0x01e9, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedititePose152:
+ax_pose 37, 0x01ef, 0x54fa, 0x3c00
+ax_pose -1, 0x01ee, 0x54f4, 0x3c00
+ax_pose 3, 0x01e9, 0x80f4, 0x5c04
+ax_pose_terminator
+sMedititePose153:
+ax_pose 38, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedititePose154:
+ax_pose 39, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedititePose155:
+ax_pose 40, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMedititePose156:
+ax_pose 41, 0x01e2, 0x90e9, 0x5c00
+ax_pose_terminator
+sMedititePose157:
+ax_pose 42, 0x01e4, 0x90ea, 0x5c00
+ax_pose_terminator
+sMedititePose158:
+ax_pose 43, 0x01e5, 0x90eb, 0x5c00
+ax_pose_terminator
+sMedititePose159:
+ax_pose 44, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sMedititePose160:
+ax_pose 43, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sMedititePose161:
+ax_pose 42, 0x01e4, 0x80f6, 0x5c00
+ax_pose_terminator
+sMedititePose162:
+ax_pose 41, 0x01e2, 0x80f7, 0x5c00
+ax_pose_terminator
+sMedititePose163:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose164:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose165:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose166:
+ax_pose 3, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose167:
+ax_pose 4, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose168:
+ax_pose 5, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose169:
+ax_pose 6, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose170:
+ax_pose 7, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose171:
+ax_pose 8, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose172:
+ax_pose 9, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose173:
+ax_pose 10, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose174:
+ax_pose 11, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose175:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose176:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose177:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose178:
+ax_pose 9, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose179:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose180:
+ax_pose 11, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose181:
+ax_pose 6, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose182:
+ax_pose 7, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose183:
+ax_pose 8, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose184:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose185:
+ax_pose 4, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose186:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose187:
+ax_pose 15, 0x41f1, 0x80f4, 0x5c00
+ax_pose 16, 0x01e9, 0x00fc, 0x5c08
+ax_pose_terminator
+sMedititePose188:
+ax_pose 17, 0x81e9, 0x80f5, 0x5c00
+ax_pose 18, 0x81f1, 0x0105, 0x5c08
+ax_pose_terminator
+sMedititePose189:
+ax_pose 19, 0x81e9, 0x80f6, 0x5c00
+ax_pose 20, 0x81f1, 0x0106, 0x5c08
+ax_pose_terminator
+sMedititePose190:
+ax_pose 21, 0x81e9, 0x80f4, 0x5c00
+ax_pose 22, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose191:
+ax_pose 23, 0x81e9, 0x80f4, 0x5c00
+ax_pose 24, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose192:
+ax_pose 21, 0x81e9, 0x90fd, 0x5c00
+ax_pose 22, 0x81e9, 0x50f5, 0x5c08
+ax_pose_terminator
+sMedititePose193:
+ax_pose 19, 0x81e9, 0x90fb, 0x5c00
+ax_pose 20, 0x81f1, 0x10f3, 0x5c08
+ax_pose_terminator
+sMedititePose194:
+ax_pose 17, 0x81e9, 0x90fc, 0x5c00
+ax_pose 18, 0x81f1, 0x10f4, 0x5c08
+ax_pose_terminator
+sMedititePose195:
+ax_pose 15, 0x41f1, 0x80f4, 0x5c00
+ax_pose 16, 0x01e9, 0x00fc, 0x5c08
+ax_pose_terminator
+sMedititePose196:
+ax_pose 17, 0x81e9, 0x90fb, 0x5c00
+ax_pose 18, 0x81f1, 0x10f3, 0x5c08
+ax_pose_terminator
+sMedititePose197:
+ax_pose 19, 0x81e9, 0x90fa, 0x5c00
+ax_pose 20, 0x81f1, 0x10f2, 0x5c08
+ax_pose_terminator
+sMedititePose198:
+ax_pose 21, 0x81ea, 0x90fc, 0x5c00
+ax_pose 22, 0x81ea, 0x50f4, 0x5c08
+ax_pose_terminator
+sMedititePose199:
+ax_pose 23, 0x81eb, 0x80f4, 0x5c00
+ax_pose 24, 0x81eb, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose200:
+ax_pose 21, 0x81ea, 0x80f4, 0x5c00
+ax_pose 22, 0x81ea, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose201:
+ax_pose 19, 0x81e9, 0x80f6, 0x5c00
+ax_pose 20, 0x81f1, 0x0106, 0x5c08
+ax_pose_terminator
+sMedititePose202:
+ax_pose 17, 0x81e9, 0x80f5, 0x5c00
+ax_pose 18, 0x81f1, 0x0105, 0x5c08
+ax_pose_terminator
+sMedititePose203:
+ax_pose 0, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose204:
+ax_pose 25, 0x81e8, 0x80f4, 0x5c00
+ax_pose 26, 0x81f0, 0x0104, 0x5c08
+ax_pose_terminator
+sMedititePose205:
+ax_pose 3, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose206:
+ax_pose 27, 0x81ea, 0x90fa, 0x5c00
+ax_pose 28, 0x01f2, 0x10f2, 0x5c08
+ax_pose_terminator
+sMedititePose207:
+ax_pose 6, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose208:
+ax_pose 29, 0x81e9, 0x90f9, 0x5c00
+ax_pose_terminator
+sMedititePose209:
+ax_pose 9, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose210:
+ax_pose 30, 0x41f0, 0x90ee, 0x5c00
+ax_pose 31, 0x01e8, 0x10fe, 0x5c08
+ax_pose_terminator
+sMedititePose211:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose212:
+ax_pose 32, 0x81e9, 0x80f4, 0x5c00
+ax_pose 33, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose213:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose214:
+ax_pose 30, 0x41f0, 0x80f3, 0x5c00
+ax_pose 31, 0x01e8, 0x00fb, 0x5c08
+ax_pose_terminator
+sMedititePose215:
+ax_pose 6, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose216:
+ax_pose 29, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sMedititePose217:
+ax_pose 3, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose218:
+ax_pose 27, 0x81ea, 0x80f7, 0x5c00
+ax_pose 28, 0x01f2, 0x0107, 0x5c08
+ax_pose_terminator
+sMedititePose219:
+ax_pose 25, 0x81e8, 0x80f4, 0x5c00
+ax_pose 26, 0x81f0, 0x0104, 0x5c08
+ax_pose_terminator
+sMedititePose220:
+ax_pose 27, 0x81ea, 0x80f7, 0x5c00
+ax_pose 28, 0x01f2, 0x0107, 0x5c08
+ax_pose_terminator
+sMedititePose221:
+ax_pose 29, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose222:
+ax_pose 30, 0x41f0, 0x80f3, 0x5c00
+ax_pose 31, 0x01e8, 0x00fb, 0x5c08
+ax_pose_terminator
+sMedititePose223:
+ax_pose 32, 0x81e9, 0x80f4, 0x5c00
+ax_pose 33, 0x81e9, 0x4104, 0x5c08
+ax_pose_terminator
+sMedititePose224:
+ax_pose 30, 0x41f0, 0x90ed, 0x5c00
+ax_pose 31, 0x01e8, 0x10fd, 0x5c08
+ax_pose_terminator
+sMedititePose225:
+ax_pose 29, 0x81e9, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose226:
+ax_pose 27, 0x81ea, 0x90f9, 0x5c00
+ax_pose 28, 0x01f2, 0x10f1, 0x5c08
+ax_pose_terminator
+sMedititePose227:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose228:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose229:
+ax_pose 6, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sMedititePose230:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose231:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sMedititePose232:
+ax_pose 9, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sMedititePose233:
+ax_pose 6, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sMedititePose234:
+ax_pose 3, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+.align 2
+sMedititeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMedititeAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 12, 10, 12,
+ax_anim 2, 0, 31, 18, 21, 18, 21,
+ax_anim 2, 1, 31, 19, 20, 19, 20,
+ax_anim 2, 0, 31, 18, 21, 18, 21,
+ax_anim 2, 0, 31, 19, 20, 19, 20,
+ax_anim 2, 0, 28, 6, 7, 6, 7,
+ax_anim_terminator
+sMedititeAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMedititeAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 38, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 11, -12, 11, -12,
+ax_anim 2, 0, 39, 17, -19, 17, -19,
+ax_anim 2, 1, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sMedititeAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sMedititeAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 46, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -11, -12, -11, -12,
+ax_anim 2, 0, 47, -17, -19, -17, -19,
+ax_anim 2, 1, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sMedititeAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sMedititeAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 12, -10, 12,
+ax_anim 2, 0, 55, -18, 21, -18, 21,
+ax_anim 2, 1, 55, -19, 20, -19, 20,
+ax_anim 2, 0, 55, -18, 21, -18, 21,
+ax_anim 2, 0, 55, -19, 20, -19, 20,
+ax_anim 2, 0, 52, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sMedititeAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 1, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 0, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sMedititeAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 12, 10, 12,
+ax_anim 2, 0, 63, 18, 21, 18, 21,
+ax_anim 2, 1, 63, 19, 20, 19, 20,
+ax_anim 2, 0, 63, 18, 21, 18, 21,
+ax_anim 2, 0, 63, 19, 20, 19, 20,
+ax_anim 2, 0, 60, 6, 7, 6, 7,
+ax_anim_terminator
+sMedititeAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 1, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 0, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sMedititeAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 70, 5, -6, 5, -6,
+ax_anim 1, 0, 70, 11, -12, 11, -12,
+ax_anim 2, 0, 71, 17, -19, 17, -19,
+ax_anim 2, 1, 71, 18, -18, 18, -18,
+ax_anim 2, 0, 71, 17, -19, 17, -19,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sMedititeAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sMedititeAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 78, -5, -6, -5, -6,
+ax_anim 1, 0, 78, -11, -12, -11, -12,
+ax_anim 2, 0, 79, -17, -19, -17, -19,
+ax_anim 2, 1, 79, -18, -18, -18, -18,
+ax_anim 2, 0, 79, -17, -19, -17, -19,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sMedititeAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 1, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 0, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sMedititeAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 86, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 12, -10, 12,
+ax_anim 2, 0, 87, -18, 21, -18, 21,
+ax_anim 2, 1, 87, -19, 20, -19, 20,
+ax_anim 2, 0, 87, -18, 21, -18, 21,
+ax_anim 2, 0, 87, -19, 20, -19, 20,
+ax_anim 2, 0, 84, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sMedititeAnims_4_1:
+ax_anim 1, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 4, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 89, -1, -5, -1, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 89, -1, -5, -1, 0,
+ax_anim 4, 2, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 0, 8, 0, 8,
+ax_anim 4, 1, 90, 0, 9, 0, 9,
+ax_anim 2, 0, 90, 0, 7, 0, 7,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim_terminator
+sMedititeAnims_4_2:
+ax_anim 1, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 4, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 92, -1, -4, -1, 1,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 92, -1, -4, -1, 1,
+ax_anim 4, 2, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 93, 1, -4, 1, 1,
+ax_anim 1, 0, 93, 3, -2, 3, 3,
+ax_anim 2, 0, 93, 8, 3, 8, 8,
+ax_anim 4, 1, 93, 9, 4, 9, 9,
+ax_anim 2, 0, 93, 7, 2, 7, 7,
+ax_anim 2, 0, 91, 3, 0, 3, 2,
+ax_anim_terminator
+sMedititeAnims_4_3:
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 4, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -6, 0, -1,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -6, 0, -1,
+ax_anim 4, 2, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 96, 1, -5, 1, 0,
+ax_anim 1, 0, 96, 3, -5, 3, 0,
+ax_anim 2, 0, 96, 8, -5, 8, 0,
+ax_anim 4, 1, 96, 9, -5, 9, 0,
+ax_anim 2, 0, 96, 7, -5, 7, 0,
+ax_anim 2, 0, 94, 3, -3, 3, 0,
+ax_anim_terminator
+sMedititeAnims_4_4:
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 4, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 98, -1, -6, -1, -1,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 98, -1, -6, -1, -1,
+ax_anim 4, 2, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 99, 1, -6, 1, -1,
+ax_anim 1, 0, 99, 3, -8, 3, -3,
+ax_anim 2, 0, 99, 8, -13, 8, -8,
+ax_anim 4, 1, 99, 9, -14, 9, -9,
+ax_anim 2, 0, 99, 7, -12, 7, -7,
+ax_anim 2, 0, 97, 3, -5, 3, -1,
+ax_anim_terminator
+sMedititeAnims_4_5:
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 4, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, -1, -5, -1, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 101, -1, -5, -1, 0,
+ax_anim 4, 2, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 102, 0, -6, 0, 1,
+ax_anim 1, 0, 102, 0, -9, 0, -3,
+ax_anim 2, 0, 102, 0, -14, 0, -8,
+ax_anim 4, 1, 102, 0, -15, 0, -9,
+ax_anim 2, 0, 102, 0, -13, 0, -7,
+ax_anim 2, 0, 100, 0, -4, 0, -3,
+ax_anim_terminator
+sMedititeAnims_4_6:
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 4, 0, 104, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 1, -6, 1, -1,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 1, -6, 1, -1,
+ax_anim 4, 2, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 105, -1, -6, -1, -1,
+ax_anim 1, 0, 105, -3, -8, -3, -3,
+ax_anim 2, 0, 105, -8, -13, -8, -8,
+ax_anim 4, 1, 105, -9, -14, -9, -9,
+ax_anim 2, 0, 105, -7, -12, -7, -7,
+ax_anim 2, 0, 103, -3, -5, -3, -1,
+ax_anim_terminator
+sMedititeAnims_4_7:
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 4, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, -1,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, -1,
+ax_anim 4, 2, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 108, -1, -5, -1, 0,
+ax_anim 1, 0, 108, -3, -5, -3, 0,
+ax_anim 2, 0, 108, -8, -5, -8, 0,
+ax_anim 4, 1, 108, -9, -5, -9, 0,
+ax_anim 2, 0, 108, -7, -5, -7, 0,
+ax_anim 2, 0, 106, -3, -3, -3, 0,
+ax_anim_terminator
+sMedititeAnims_4_8:
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 0, 110, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 1, -4, 1, 1,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 1, -4, 1, 1,
+ax_anim 4, 2, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 111, -1, -4, -1, 1,
+ax_anim 1, 0, 111, -3, -2, -3, 3,
+ax_anim 2, 0, 111, -8, 3, -8, 8,
+ax_anim 4, 1, 111, -9, 4, -9, 9,
+ax_anim 2, 0, 111, -7, 2, -7, 7,
+ax_anim 2, 0, 109, -3, 0, -3, 2,
+ax_anim_terminator
+.align 2
+sMedititeAnims_5_1:
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 1, 0, 127, 0, -1, 0, 0,
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 113, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 2, 114, 0, -4, 0, 0,
+ax_anim 1, 0, 113, 0, -4, 0, 0,
+ax_anim 4, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 1, 112, 0, -1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_5_2:
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -1, 0, 0,
+ax_anim 1, 0, 132, 0, -1, 0, 0,
+ax_anim 1, 0, 137, 0, -2, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 4, 0, 117, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -4, 0, 0,
+ax_anim 1, 2, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -4, 0, 0,
+ax_anim 4, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 1, 117, 0, -1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_5_3:
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -1, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, -2, 0, 0,
+ax_anim 1, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -4, 0, 0,
+ax_anim 1, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 2, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 123, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 1, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_5_4:
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, -2, 0, 0,
+ax_anim 1, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 2, 129, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 2, 1, 127, 0, -1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_5_5:
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, -1, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 1, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 1, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 0, 136, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 1, 2, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 1, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_5_6:
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -1, 0, 0,
+ax_anim 1, 0, 112, 0, -1, 0, 0,
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 1, 0, 138, 0, -4, 0, 0,
+ax_anim 1, 0, 139, 0, -4, 0, 0,
+ax_anim 1, 0, 140, 0, -4, 0, 0,
+ax_anim 1, 0, 141, 0, -4, 0, 0,
+ax_anim 1, 0, 141, 0, -4, 0, 0,
+ax_anim 1, 0, 140, 0, -4, 0, 0,
+ax_anim 1, 2, 139, 0, -4, 0, 0,
+ax_anim 1, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 1, 137, 0, -1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_5_7:
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, -1, 0, 0,
+ax_anim 1, 0, 117, 0, -1, 0, 0,
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 1, 0, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 144, 0, -4, 0, 0,
+ax_anim 1, 0, 145, 0, -4, 0, 0,
+ax_anim 1, 0, 146, 0, -4, 0, 0,
+ax_anim 1, 0, 146, 0, -4, 0, 0,
+ax_anim 1, 0, 145, 0, -4, 0, 0,
+ax_anim 1, 2, 144, 0, -4, 0, 0,
+ax_anim 1, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 1, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_5_8:
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, -1, 0, 0,
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 147, 0, -4, 0, 0,
+ax_anim 1, 0, 148, 0, -4, 0, 0,
+ax_anim 1, 0, 149, 0, -4, 0, 0,
+ax_anim 1, 0, 150, 0, -4, 0, 0,
+ax_anim 1, 0, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 150, 0, -4, 0, 0,
+ax_anim 1, 2, 149, 0, -4, 0, 0,
+ax_anim 1, 0, 148, 0, -4, 0, 0,
+ax_anim 4, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 2, 1, 147, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sMedititeAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sMedititeAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sMedititeAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sMedititeAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sMedititeAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sMedititeAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sMedititeAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMedititeAnims_8_1:
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, -1, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, 1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_8_2:
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 16, 0, 166, 0, -1, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 166, 0, 1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_8_3:
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 169, 0, -1, 0, 0,
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim 16, 0, 169, 0, 1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_8_4:
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 16, 0, 172, 0, -1, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim 16, 0, 172, 0, 1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_8_5:
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 16, 0, 175, 0, -1, 0, 0,
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim 16, 0, 175, 0, 1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_8_6:
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 16, 0, 178, 0, -1, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim 16, 0, 178, 0, 1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_8_7:
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim 16, 0, 181, 0, -1, 0, 0,
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim 16, 0, 181, 0, 1, 0, 0,
+ax_anim_terminator
+sMedititeAnims_8_8:
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 16, 0, 184, 0, -1, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim 16, 0, 184, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 19, 7, 19,
+ax_anim 3, 0, 190, 0, 22, 0, 21,
+ax_anim 2, 3, 191, -7, 19, -7, 19,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 9, 1, 9, 1,
+ax_anim 2, 0, 187, 18, 5, 18, 5,
+ax_anim 2, 0, 188, 24, 12, 24, 12,
+ax_anim 3, 0, 189, 23, 21, 23, 21,
+ax_anim 2, 3, 190, 11, 22, 11, 22,
+ax_anim 2, 0, 191, 4, 15, 4, 15,
+ax_anim 1, 0, 192, 1, 7, 1, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 2, -3, 2, -3,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 19, -5, 18, -5,
+ax_anim 3, 0, 188, 23, 0, 21, 0,
+ax_anim 2, 3, 189, 20, 4, 19, 4,
+ax_anim 2, 0, 190, 12, 6, 12, 6,
+ax_anim 1, 0, 191, 4, 4, 4, 4,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 2, -17, 2, -17,
+ax_anim 2, 0, 186, 13, -23, 13, -23,
+ax_anim 3, 0, 187, 22, -23, 22, -23,
+ax_anim 2, 3, 188, 24, -15, 24, -15,
+ax_anim 2, 0, 189, 21, -4, 21, -4,
+ax_anim 1, 0, 190, 11, 0, 11, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -11, -11, -11, -11,
+ax_anim 2, 0, 193, -9, -20, -9, -20,
+ax_anim 3, 0, 186, 0, -23, 0, -23,
+ax_anim 2, 3, 187, 9, -20, 9, -20,
+ax_anim 2, 0, 188, 11, -11, 11, -11,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -2, -17, -2, -17,
+ax_anim 2, 0, 186, -13, -23, -13, -23,
+ax_anim 3, 0, 193, -22, -23, -22, -23,
+ax_anim 2, 3, 192, -24, -15, -24, -15,
+ax_anim 2, 0, 191, -21, -4, -21, -4,
+ax_anim 1, 0, 190, -11, 0, -11, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -2, -3, -2, -3,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -19, -5, -18, -5,
+ax_anim 3, 0, 192, -23, 0, -21, 0,
+ax_anim 2, 3, 191, -20, 4, -19, 4,
+ax_anim 2, 0, 190, -12, 6, -12, 6,
+ax_anim 1, 0, 189, -4, 4, -4, 4,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -9, 1, -9, 1,
+ax_anim 2, 0, 193, -18, 5, -18, 5,
+ax_anim 2, 0, 192, -24, 12, -24, 12,
+ax_anim 3, 0, 191, -23, 21, -23, 21,
+ax_anim 2, 3, 190, -11, 22, -11, 22,
+ax_anim 2, 0, 189, -4, 15, -4, 15,
+ax_anim 1, 0, 188, -1, 7, -1, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -22, 0, 0,
+ax_anim 2, 0, 203, 0, -18, 0, 0,
+ax_anim 1, 0, 203, 0, -12, 0, 0,
+ax_anim 2, 2, 203, 0, 2, 0, 0,
+ax_anim_terminator
+sMedititeAnims_11_2:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 2, 0, 0,
+ax_anim_terminator
+sMedititeAnims_11_3:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 2, 0, 0,
+ax_anim_terminator
+sMedititeAnims_11_4:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -17, 0, 0,
+ax_anim 1, 0, 209, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 2, 0, 0,
+ax_anim_terminator
+sMedititeAnims_11_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -22, 0, 0,
+ax_anim 2, 0, 211, 0, -18, 0, 0,
+ax_anim 1, 0, 211, 0, -12, 0, 0,
+ax_anim 2, 2, 211, 0, 2, 0, 0,
+ax_anim_terminator
+sMedititeAnims_11_6:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 2, 0, 0,
+ax_anim_terminator
+sMedititeAnims_11_7:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 2, 0, 0,
+ax_anim_terminator
+sMedititeAnims_11_8:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMedititeAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sMedititeGfx1:
+.incbin "baserom.gba", 0x127E404, 0x200
+sMedititeSprites1:
+ax_sprite sMedititeGfx1, 0x200
+ax_sprite_terminator
+sMedititeGfx2:
+.incbin "baserom.gba", 0x127E614, 0x200
+sMedititeSprites2:
+ax_sprite sMedititeGfx2, 0x200
+ax_sprite_terminator
+sMedititeGfx3:
+.incbin "baserom.gba", 0x127E824, 0x200
+sMedititeSprites3:
+ax_sprite sMedititeGfx3, 0x200
+ax_sprite_terminator
+sMedititeGfx4:
+.incbin "baserom.gba", 0x127EA34, 0x200
+sMedititeSprites4:
+ax_sprite sMedititeGfx4, 0x200
+ax_sprite_terminator
+sMedititeGfx5:
+.incbin "baserom.gba", 0x127EC44, 0x200
+sMedititeSprites5:
+ax_sprite sMedititeGfx5, 0x200
+ax_sprite_terminator
+sMedititeGfx6:
+.incbin "baserom.gba", 0x127EE54, 0x200
+sMedititeSprites6:
+ax_sprite sMedititeGfx6, 0x200
+ax_sprite_terminator
+sMedititeGfx7:
+.incbin "baserom.gba", 0x127F064, 0x100
+sMedititeSprites7:
+ax_sprite sMedititeGfx7, 0x100
+ax_sprite_terminator
+sMedititeGfx8:
+.incbin "baserom.gba", 0x127F174, 0x100
+sMedititeSprites8:
+ax_sprite sMedititeGfx8, 0x100
+ax_sprite_terminator
+sMedititeGfx9:
+.incbin "baserom.gba", 0x127F284, 0x100
+sMedititeSprites9:
+ax_sprite sMedititeGfx9, 0x100
+ax_sprite_terminator
+sMedititeGfx10:
+.incbin "baserom.gba", 0x127F394, 0x200
+sMedititeSprites10:
+ax_sprite sMedititeGfx10, 0x200
+ax_sprite_terminator
+sMedititeGfx11:
+.incbin "baserom.gba", 0x127F5A4, 0x200
+sMedititeSprites11:
+ax_sprite sMedititeGfx11, 0x200
+ax_sprite_terminator
+sMedititeGfx12:
+.incbin "baserom.gba", 0x127F7B4, 0x200
+sMedititeSprites12:
+ax_sprite sMedititeGfx12, 0x200
+ax_sprite_terminator
+sMedititeGfx13:
+.incbin "baserom.gba", 0x127F9C4, 0x200
+sMedititeSprites13:
+ax_sprite sMedititeGfx13, 0x200
+ax_sprite_terminator
+sMedititeGfx14:
+.incbin "baserom.gba", 0x127FBD4, 0x200
+sMedititeSprites14:
+ax_sprite sMedititeGfx14, 0x200
+ax_sprite_terminator
+sMedititeGfx15:
+.incbin "baserom.gba", 0x127FDE4, 0x200
+sMedititeSprites15:
+ax_sprite sMedititeGfx15, 0x200
+ax_sprite_terminator
+sMedititeGfx16:
+.incbin "baserom.gba", 0x127FFF4, 0x60
+sMedititeGfx16_1:
+.incbin "baserom.gba", 0x1280054, 0x60
+sMedititeSprites16:
+ax_sprite sMedititeGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedititeGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedititeGfx17:
+.incbin "baserom.gba", 0x12800DC, 0x20
+sMedititeSprites17:
+ax_sprite sMedititeGfx17, 0x20
+ax_sprite_terminator
+sMedititeGfx18:
+.incbin "baserom.gba", 0x128010C, 0xC0
+sMedititeSprites18:
+ax_sprite sMedititeGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedititeGfx19:
+.incbin "baserom.gba", 0x12801E4, 0x40
+sMedititeSprites19:
+ax_sprite sMedititeGfx19, 0x40
+ax_sprite_terminator
+sMedititeGfx20:
+.incbin "baserom.gba", 0x1280234, 0xC0
+sMedititeSprites20:
+ax_sprite sMedititeGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedititeGfx21:
+.incbin "baserom.gba", 0x128030C, 0x40
+sMedititeSprites21:
+ax_sprite sMedititeGfx21, 0x40
+ax_sprite_terminator
+sMedititeGfx22:
+.incbin "baserom.gba", 0x128035C, 0xC0
+sMedititeSprites22:
+ax_sprite sMedititeGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedititeGfx23:
+.incbin "baserom.gba", 0x1280434, 0x60
+sMedititeSprites23:
+ax_sprite sMedititeGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedititeGfx24:
+.incbin "baserom.gba", 0x12804AC, 0xC0
+sMedititeSprites24:
+ax_sprite sMedititeGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedititeGfx25:
+.incbin "baserom.gba", 0x1280584, 0x60
+sMedititeSprites25:
+ax_sprite sMedititeGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedititeGfx26:
+.incbin "baserom.gba", 0x12805FC, 0xA0
+sMedititeGfx26_1:
+.incbin "baserom.gba", 0x128069C, 0x20
+sMedititeSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMedititeGfx26, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sMedititeGfx26_1, 0x20
+ax_sprite_terminator
+sMedititeGfx27:
+.incbin "baserom.gba", 0x12806E4, 0x40
+sMedititeSprites27:
+ax_sprite sMedititeGfx27, 0x40
+ax_sprite_terminator
+sMedititeGfx28:
+.incbin "baserom.gba", 0x1280734, 0xC0
+sMedititeSprites28:
+ax_sprite sMedititeGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedititeGfx29:
+.incbin "baserom.gba", 0x128080C, 0x20
+sMedititeSprites29:
+ax_sprite sMedititeGfx29, 0x20
+ax_sprite_terminator
+sMedititeGfx30:
+.incbin "baserom.gba", 0x128083C, 0xC0
+sMedititeSprites30:
+ax_sprite sMedititeGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedititeGfx31:
+.incbin "baserom.gba", 0x1280914, 0x60
+sMedititeGfx31_1:
+.incbin "baserom.gba", 0x1280974, 0x60
+sMedititeSprites31:
+ax_sprite sMedititeGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMedititeGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedititeGfx32:
+.incbin "baserom.gba", 0x12809FC, 0x20
+sMedititeSprites32:
+ax_sprite sMedititeGfx32, 0x20
+ax_sprite_terminator
+sMedititeGfx33:
+.incbin "baserom.gba", 0x1280A2C, 0xC0
+sMedititeSprites33:
+ax_sprite sMedititeGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMedititeGfx34:
+.incbin "baserom.gba", 0x1280B04, 0x60
+sMedititeSprites34:
+ax_sprite sMedititeGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMedititeGfx35:
+.incbin "baserom.gba", 0x1280B7C, 0x20
+sMedititeSprites35:
+ax_sprite sMedititeGfx35, 0x20
+ax_sprite_terminator
+sMedititeGfx36:
+.incbin "baserom.gba", 0x1280BAC, 0x80
+sMedititeSprites36:
+ax_sprite sMedititeGfx36, 0x80
+ax_sprite_terminator
+sMedititeGfx37:
+.incbin "baserom.gba", 0x1280C3C, 0x80
+sMedititeSprites37:
+ax_sprite sMedititeGfx37, 0x80
+ax_sprite_terminator
+sMedititeGfx38:
+.incbin "baserom.gba", 0x1280CCC, 0x80
+sMedititeSprites38:
+ax_sprite sMedititeGfx38, 0x80
+ax_sprite_terminator
+sMedititeGfx39:
+.incbin "baserom.gba", 0x1280D5C, 0x200
+sMedititeSprites39:
+ax_sprite sMedititeGfx39, 0x200
+ax_sprite_terminator
+sMedititeGfx40:
+.incbin "baserom.gba", 0x1280F6C, 0x200
+sMedititeSprites40:
+ax_sprite sMedititeGfx40, 0x200
+ax_sprite_terminator
+sMedititeGfx41:
+.incbin "baserom.gba", 0x128117C, 0x200
+sMedititeSprites41:
+ax_sprite sMedititeGfx41, 0x200
+ax_sprite_terminator
+sMedititeGfx42:
+.incbin "baserom.gba", 0x128138C, 0x200
+sMedititeSprites42:
+ax_sprite sMedititeGfx42, 0x200
+ax_sprite_terminator
+sMedititeGfx43:
+.incbin "baserom.gba", 0x128159C, 0x200
+sMedititeSprites43:
+ax_sprite sMedititeGfx43, 0x200
+ax_sprite_terminator
+sMedititeGfx44:
+.incbin "baserom.gba", 0x12817AC, 0x200
+sMedititeSprites44:
+ax_sprite sMedititeGfx44, 0x200
+ax_sprite_terminator
+sMedititeGfx45:
+.incbin "baserom.gba", 0x12819BC, 0x200
+sMedititeSprites45:
+ax_sprite sMedititeGfx45, 0x200
+ax_sprite_terminator
+sAxPosesMeditite:
+.4byte sMedititePose1
+.4byte sMedititePose2
+.4byte sMedititePose3
+.4byte sMedititePose4
+.4byte sMedititePose5
+.4byte sMedititePose6
+.4byte sMedititePose7
+.4byte sMedititePose8
+.4byte sMedititePose9
+.4byte sMedititePose10
+.4byte sMedititePose11
+.4byte sMedititePose12
+.4byte sMedititePose13
+.4byte sMedititePose14
+.4byte sMedititePose15
+.4byte sMedititePose16
+.4byte sMedititePose17
+.4byte sMedititePose18
+.4byte sMedititePose19
+.4byte sMedititePose20
+.4byte sMedititePose21
+.4byte sMedititePose22
+.4byte sMedititePose23
+.4byte sMedititePose24
+.4byte sMedititePose25
+.4byte sMedititePose26
+.4byte sMedititePose27
+.4byte sMedititePose28
+.4byte sMedititePose29
+.4byte sMedititePose30
+.4byte sMedititePose31
+.4byte sMedititePose32
+.4byte sMedititePose33
+.4byte sMedititePose34
+.4byte sMedititePose35
+.4byte sMedititePose36
+.4byte sMedititePose37
+.4byte sMedititePose38
+.4byte sMedititePose39
+.4byte sMedititePose40
+.4byte sMedititePose41
+.4byte sMedititePose42
+.4byte sMedititePose43
+.4byte sMedititePose44
+.4byte sMedititePose45
+.4byte sMedititePose46
+.4byte sMedititePose47
+.4byte sMedititePose48
+.4byte sMedititePose49
+.4byte sMedititePose50
+.4byte sMedititePose51
+.4byte sMedititePose52
+.4byte sMedititePose53
+.4byte sMedititePose54
+.4byte sMedititePose55
+.4byte sMedititePose56
+.4byte sMedititePose57
+.4byte sMedititePose58
+.4byte sMedititePose59
+.4byte sMedititePose60
+.4byte sMedititePose61
+.4byte sMedititePose62
+.4byte sMedititePose63
+.4byte sMedititePose64
+.4byte sMedititePose65
+.4byte sMedititePose66
+.4byte sMedititePose67
+.4byte sMedititePose68
+.4byte sMedititePose69
+.4byte sMedititePose70
+.4byte sMedititePose71
+.4byte sMedititePose72
+.4byte sMedititePose73
+.4byte sMedititePose74
+.4byte sMedititePose75
+.4byte sMedititePose76
+.4byte sMedititePose77
+.4byte sMedititePose78
+.4byte sMedititePose79
+.4byte sMedititePose80
+.4byte sMedititePose81
+.4byte sMedititePose82
+.4byte sMedititePose83
+.4byte sMedititePose84
+.4byte sMedititePose85
+.4byte sMedititePose86
+.4byte sMedititePose87
+.4byte sMedititePose88
+.4byte sMedititePose89
+.4byte sMedititePose90
+.4byte sMedititePose91
+.4byte sMedititePose92
+.4byte sMedititePose93
+.4byte sMedititePose94
+.4byte sMedititePose95
+.4byte sMedititePose96
+.4byte sMedititePose97
+.4byte sMedititePose98
+.4byte sMedititePose99
+.4byte sMedititePose100
+.4byte sMedititePose101
+.4byte sMedititePose102
+.4byte sMedititePose103
+.4byte sMedititePose104
+.4byte sMedititePose105
+.4byte sMedititePose106
+.4byte sMedititePose107
+.4byte sMedititePose108
+.4byte sMedititePose109
+.4byte sMedititePose110
+.4byte sMedititePose111
+.4byte sMedititePose112
+.4byte sMedititePose113
+.4byte sMedititePose114
+.4byte sMedititePose115
+.4byte sMedititePose116
+.4byte sMedititePose117
+.4byte sMedititePose118
+.4byte sMedititePose119
+.4byte sMedititePose120
+.4byte sMedititePose121
+.4byte sMedititePose122
+.4byte sMedititePose123
+.4byte sMedititePose124
+.4byte sMedititePose125
+.4byte sMedititePose126
+.4byte sMedititePose127
+.4byte sMedititePose128
+.4byte sMedititePose129
+.4byte sMedititePose130
+.4byte sMedititePose131
+.4byte sMedititePose132
+.4byte sMedititePose133
+.4byte sMedititePose134
+.4byte sMedititePose135
+.4byte sMedititePose136
+.4byte sMedititePose137
+.4byte sMedititePose138
+.4byte sMedititePose139
+.4byte sMedititePose140
+.4byte sMedititePose141
+.4byte sMedititePose142
+.4byte sMedititePose143
+.4byte sMedititePose144
+.4byte sMedititePose145
+.4byte sMedititePose146
+.4byte sMedititePose147
+.4byte sMedititePose148
+.4byte sMedititePose149
+.4byte sMedititePose150
+.4byte sMedititePose151
+.4byte sMedititePose152
+.4byte sMedititePose153
+.4byte sMedititePose154
+.4byte sMedititePose155
+.4byte sMedititePose156
+.4byte sMedititePose157
+.4byte sMedititePose158
+.4byte sMedititePose159
+.4byte sMedititePose160
+.4byte sMedititePose161
+.4byte sMedititePose162
+.4byte sMedititePose163
+.4byte sMedititePose164
+.4byte sMedititePose165
+.4byte sMedititePose166
+.4byte sMedititePose167
+.4byte sMedititePose168
+.4byte sMedititePose169
+.4byte sMedititePose170
+.4byte sMedititePose171
+.4byte sMedititePose172
+.4byte sMedititePose173
+.4byte sMedititePose174
+.4byte sMedititePose175
+.4byte sMedititePose176
+.4byte sMedititePose177
+.4byte sMedititePose178
+.4byte sMedititePose179
+.4byte sMedititePose180
+.4byte sMedititePose181
+.4byte sMedititePose182
+.4byte sMedititePose183
+.4byte sMedititePose184
+.4byte sMedititePose185
+.4byte sMedititePose186
+.4byte sMedititePose187
+.4byte sMedititePose188
+.4byte sMedititePose189
+.4byte sMedititePose190
+.4byte sMedititePose191
+.4byte sMedititePose192
+.4byte sMedititePose193
+.4byte sMedititePose194
+.4byte sMedititePose195
+.4byte sMedititePose196
+.4byte sMedititePose197
+.4byte sMedititePose198
+.4byte sMedititePose199
+.4byte sMedititePose200
+.4byte sMedititePose201
+.4byte sMedititePose202
+.4byte sMedititePose203
+.4byte sMedititePose204
+.4byte sMedititePose205
+.4byte sMedititePose206
+.4byte sMedititePose207
+.4byte sMedititePose208
+.4byte sMedititePose209
+.4byte sMedititePose210
+.4byte sMedititePose211
+.4byte sMedititePose212
+.4byte sMedititePose213
+.4byte sMedititePose214
+.4byte sMedititePose215
+.4byte sMedititePose216
+.4byte sMedititePose217
+.4byte sMedititePose218
+.4byte sMedititePose219
+.4byte sMedititePose220
+.4byte sMedititePose221
+.4byte sMedititePose222
+.4byte sMedititePose223
+.4byte sMedititePose224
+.4byte sMedititePose225
+.4byte sMedititePose226
+.4byte sMedititePose227
+.4byte sMedititePose228
+.4byte sMedititePose229
+.4byte sMedititePose230
+.4byte sMedititePose231
+.4byte sMedititePose232
+.4byte sMedititePose233
+.4byte sMedititePose234
+sAxPositionsMeditite:
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   0,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	  -1,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   1,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	   0,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -5
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    4,   -7, 	   7,   -5, 	   4,   -3, 	   2,   -6
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   0,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   0,   -7
+.2byte    6,   -7, 	   8,   -8, 	   7,   -5, 	   1,   -6
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	  -1,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    6,  -10, 	   4,  -14, 	  11,  -10, 	   2,   -7
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   5,  -16, 	  -5,  -16, 	   0,   -8
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   1,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -6,  -10, 	  -4,  -14, 	 -11,  -10, 	  -2,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	   0,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -8, 	  -7,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -4,   -7, 	  -7,   -5, 	  -4,   -3, 	  -2,   -6
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -5
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    4,   -7, 	   7,   -5, 	   4,   -3, 	   2,   -6
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   0,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   0,   -7
+.2byte    6,   -7, 	   8,   -8, 	   7,   -5, 	   1,   -6
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	  -1,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    6,  -10, 	   4,  -14, 	  11,  -10, 	   2,   -7
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   5,  -16, 	  -5,  -16, 	   0,   -8
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   1,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -6,  -10, 	  -4,  -14, 	 -11,  -10, 	  -2,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	   0,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -8, 	  -7,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -4,   -7, 	  -7,   -5, 	  -4,   -3, 	  -2,   -6
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -7, 	  -2,   -5, 	   2,   -5, 	   0,   -6
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -5
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -6, 	   4,   -5, 	   2,   -5, 	   2,   -6
+.2byte    4,   -7, 	   7,   -5, 	   4,   -3, 	   2,   -6
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    5,   -7, 	   5,   -8, 	   6,   -4, 	   1,   -6
+.2byte    6,   -7, 	   8,   -8, 	   7,   -5, 	   1,   -6
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    5,   -9, 	   1,   -6, 	   3,   -6, 	   1,   -7
+.2byte    6,  -10, 	   4,  -14, 	  11,  -10, 	   2,   -7
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -10, 	   3,   -7, 	  -3,   -7, 	   0,   -7
+.2byte    0,  -11, 	   5,  -16, 	  -5,  -16, 	   0,   -8
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -5,   -9, 	  -1,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte   -6,  -10, 	  -4,  -14, 	 -11,  -10, 	  -2,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -5,   -7, 	  -5,   -8, 	  -6,   -4, 	  -1,   -6
+.2byte   -6,   -7, 	  -8,   -8, 	  -7,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -6, 	  -4,   -5, 	  -2,   -5, 	  -2,   -6
+.2byte   -4,   -7, 	  -7,   -5, 	  -4,   -3, 	  -2,   -6
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -1,   -7, 	  -4,   -2, 	   4,    0, 	   1,   -6
+.2byte   -1,   -6, 	  -4,   -2, 	   4,    0, 	   0,   -5
+.2byte    0,   -7, 	  -9,  -10, 	   8,  -10, 	   0,   -6
+.2byte   -2,   -7, 	   3,  -12, 	 -10,   -4, 	  -2,   -6
+.2byte    0,   -7, 	  -7,  -12, 	  -7,   -6, 	  -2,   -6
+.2byte    1,   -9, 	  -5,  -17, 	   6,   -7, 	  -2,   -6
+.2byte    0,   -9, 	   8,   -9, 	  -8,   -9, 	   0,   -7
+.2byte   -2,   -9, 	   4,  -17, 	  -7,   -7, 	   1,   -6
+.2byte   -1,   -7, 	   6,  -12, 	   6,   -6, 	   1,   -6
+.2byte    1,   -7, 	  -4,  -12, 	   9,   -4, 	   1,   -6
+.2byte    0,   -7, 	  -9,   -4, 	   9,   -4, 	   0,   -6
+.2byte    0,   -7, 	  -9,   -4, 	   9,   -4, 	   0,   -6
+.2byte    0,   -7, 	  -9,   -4, 	   9,   -4, 	   0,   -6
+.2byte    3,   -7, 	   7,   -7, 	  -7,   -2, 	   0,   -6
+.2byte    3,   -7, 	   7,   -7, 	  -7,   -2, 	   0,   -6
+.2byte    3,   -7, 	   7,   -7, 	  -7,   -2, 	   0,   -6
+.2byte    4,   -7, 	   3,   -8, 	   3,   -3, 	   1,   -6
+.2byte    4,   -7, 	   3,   -8, 	   3,   -3, 	   0,   -6
+.2byte    4,   -7, 	   3,   -8, 	   3,   -3, 	   0,   -6
+.2byte    4,   -9, 	  -5,   -6, 	   7,   -4, 	   0,   -6
+.2byte    4,   -9, 	  -5,   -6, 	   7,   -4, 	  -1,   -6
+.2byte    4,   -9, 	  -5,   -6, 	   7,   -4, 	   0,   -6
+.2byte    0,  -10, 	   8,   -4, 	  -8,   -4, 	   0,   -7
+.2byte    0,  -10, 	   8,   -4, 	  -8,   -4, 	   0,   -7
+.2byte    0,  -10, 	   8,   -4, 	  -8,   -4, 	   0,   -7
+.2byte   -4,   -9, 	   5,   -6, 	  -7,   -4, 	   0,   -6
+.2byte   -4,   -9, 	   5,   -6, 	  -7,   -4, 	   1,   -6
+.2byte   -4,   -9, 	   5,   -6, 	  -7,   -4, 	   0,   -6
+.2byte   -4,   -7, 	  -3,   -8, 	  -3,   -3, 	  -1,   -6
+.2byte   -4,   -7, 	  -3,   -8, 	  -3,   -3, 	   0,   -6
+.2byte   -4,   -7, 	  -3,   -8, 	  -3,   -3, 	   0,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   7,   -2, 	   0,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   7,   -2, 	   0,   -6
+.2byte   -3,   -7, 	  -7,   -7, 	   7,   -2, 	   0,   -6
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -5
+.2byte   -4,   -7, 	  -7,   -5, 	  -4,   -3, 	  -2,   -6
+.2byte   -6,   -7, 	  -8,   -8, 	  -7,   -5, 	  -1,   -6
+.2byte   -5,  -10, 	  -3,  -14, 	 -10,  -10, 	  -1,   -7
+.2byte    0,  -11, 	   5,  -16, 	  -5,  -16, 	   0,   -8
+.2byte    5,  -10, 	   3,  -14, 	  10,  -10, 	   1,   -7
+.2byte    6,   -7, 	   8,   -8, 	   7,   -5, 	   1,   -6
+.2byte    4,   -7, 	   7,   -5, 	   4,   -3, 	   2,   -6
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -5
+.2byte    3,   -7, 	   6,   -5, 	   3,   -3, 	   1,   -6
+.2byte    5,   -7, 	   7,   -8, 	   6,   -5, 	   0,   -6
+.2byte    4,   -9, 	   2,  -13, 	   9,   -9, 	   0,   -6
+.2byte    0,   -9, 	   5,  -14, 	  -5,  -14, 	   0,   -6
+.2byte   -5,   -9, 	  -3,  -13, 	 -10,   -9, 	  -1,   -6
+.2byte   -6,   -7, 	  -8,   -8, 	  -7,   -5, 	  -1,   -6
+.2byte   -4,   -7, 	  -7,   -5, 	  -4,   -3, 	  -2,   -6
+.2byte    0,   -8, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    0,   -7, 	  -2,   -5, 	   2,   -5, 	   0,   -6
+.2byte    3,   -8, 	   7,   -8, 	  -7,   -3, 	   0,   -7
+.2byte    3,   -6, 	   4,   -5, 	   2,   -5, 	   2,   -6
+.2byte    4,   -8, 	   3,   -9, 	   3,   -4, 	   1,   -7
+.2byte    5,   -7, 	   5,   -8, 	   6,   -4, 	   1,   -6
+.2byte    4,  -10, 	  -5,   -7, 	   7,   -5, 	   0,   -7
+.2byte    5,   -9, 	   1,   -6, 	   3,   -6, 	   1,   -7
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -10, 	   3,   -7, 	  -3,   -7, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -5,   -9, 	  -1,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte   -4,   -8, 	  -3,   -9, 	  -3,   -4, 	  -1,   -7
+.2byte   -5,   -7, 	  -5,   -8, 	  -6,   -4, 	  -1,   -6
+.2byte   -3,   -8, 	  -7,   -8, 	   7,   -3, 	   0,   -7
+.2byte   -3,   -6, 	  -4,   -5, 	  -2,   -5, 	  -2,   -6
+.2byte    0,   -7, 	  -2,   -5, 	   2,   -5, 	   0,   -6
+.2byte   -3,   -6, 	  -4,   -5, 	  -2,   -5, 	  -2,   -6
+.2byte   -4,   -7, 	  -4,   -8, 	  -5,   -4, 	   0,   -6
+.2byte   -5,   -9, 	  -1,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte    0,  -10, 	   3,   -7, 	  -3,   -7, 	   0,   -7
+.2byte    4,   -9, 	   0,   -6, 	   2,   -6, 	   0,   -7
+.2byte    4,   -7, 	   4,   -8, 	   5,   -4, 	   0,   -6
+.2byte    2,   -6, 	   3,   -5, 	   1,   -5, 	   1,   -6
+.2byte    0,   -6, 	  -9,   -3, 	   9,   -3, 	   0,   -5
+.2byte   -3,   -6, 	  -7,   -6, 	   7,   -1, 	   0,   -5
+.2byte   -4,   -6, 	  -3,   -7, 	  -3,   -2, 	  -1,   -5
+.2byte   -4,   -8, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    0,   -9, 	   8,   -3, 	  -8,   -3, 	   0,   -6
+.2byte    4,   -8, 	  -5,   -5, 	   7,   -3, 	   0,   -5
+.2byte    4,   -6, 	   3,   -7, 	   3,   -2, 	   1,   -5
+.2byte    3,   -6, 	   7,   -6, 	  -7,   -1, 	   0,   -5
+sMedititeAnimTable1:
+.4byte sMedititeAnims_1_1
+.4byte sMedititeAnims_1_2
+.4byte sMedititeAnims_1_3
+.4byte sMedititeAnims_1_4
+.4byte sMedititeAnims_1_5
+.4byte sMedititeAnims_1_6
+.4byte sMedititeAnims_1_7
+.4byte sMedititeAnims_1_8
+sMedititeAnimTable2:
+.4byte sMedititeAnims_2_1
+.4byte sMedititeAnims_2_2
+.4byte sMedititeAnims_2_3
+.4byte sMedititeAnims_2_4
+.4byte sMedititeAnims_2_5
+.4byte sMedititeAnims_2_6
+.4byte sMedititeAnims_2_7
+.4byte sMedititeAnims_2_8
+sMedititeAnimTable3:
+.4byte sMedititeAnims_3_1
+.4byte sMedititeAnims_3_2
+.4byte sMedititeAnims_3_3
+.4byte sMedititeAnims_3_4
+.4byte sMedititeAnims_3_5
+.4byte sMedititeAnims_3_6
+.4byte sMedititeAnims_3_7
+.4byte sMedititeAnims_3_8
+sMedititeAnimTable4:
+.4byte sMedititeAnims_4_1
+.4byte sMedititeAnims_4_2
+.4byte sMedititeAnims_4_3
+.4byte sMedititeAnims_4_4
+.4byte sMedititeAnims_4_5
+.4byte sMedititeAnims_4_6
+.4byte sMedititeAnims_4_7
+.4byte sMedititeAnims_4_8
+sMedititeAnimTable5:
+.4byte sMedititeAnims_5_1
+.4byte sMedititeAnims_5_2
+.4byte sMedititeAnims_5_3
+.4byte sMedititeAnims_5_4
+.4byte sMedititeAnims_5_5
+.4byte sMedititeAnims_5_6
+.4byte sMedititeAnims_5_7
+.4byte sMedititeAnims_5_8
+sMedititeAnimTable6:
+.4byte sMedititeAnims_6_1
+.4byte sMedititeAnims_6_1
+.4byte sMedititeAnims_6_1
+.4byte sMedititeAnims_6_1
+.4byte sMedititeAnims_6_1
+.4byte sMedititeAnims_6_1
+.4byte sMedititeAnims_6_1
+.4byte sMedititeAnims_6_1
+sMedititeAnimTable7:
+.4byte sMedititeAnims_7_1
+.4byte sMedititeAnims_7_2
+.4byte sMedititeAnims_7_3
+.4byte sMedititeAnims_7_4
+.4byte sMedititeAnims_7_5
+.4byte sMedititeAnims_7_6
+.4byte sMedititeAnims_7_7
+.4byte sMedititeAnims_7_8
+sMedititeAnimTable8:
+.4byte sMedititeAnims_8_1
+.4byte sMedititeAnims_8_2
+.4byte sMedititeAnims_8_3
+.4byte sMedititeAnims_8_4
+.4byte sMedititeAnims_8_5
+.4byte sMedititeAnims_8_6
+.4byte sMedititeAnims_8_7
+.4byte sMedititeAnims_8_8
+sMedititeAnimTable9:
+.4byte sMedititeAnims_9_1
+.4byte sMedititeAnims_9_2
+.4byte sMedititeAnims_9_3
+.4byte sMedititeAnims_9_4
+.4byte sMedititeAnims_9_5
+.4byte sMedititeAnims_9_6
+.4byte sMedititeAnims_9_7
+.4byte sMedititeAnims_9_8
+sMedititeAnimTable10:
+.4byte sMedititeAnims_10_1
+.4byte sMedititeAnims_10_2
+.4byte sMedititeAnims_10_3
+.4byte sMedititeAnims_10_4
+.4byte sMedititeAnims_10_5
+.4byte sMedititeAnims_10_6
+.4byte sMedititeAnims_10_7
+.4byte sMedititeAnims_10_8
+sMedititeAnimTable11:
+.4byte sMedititeAnims_11_1
+.4byte sMedititeAnims_11_2
+.4byte sMedititeAnims_11_3
+.4byte sMedititeAnims_11_4
+.4byte sMedititeAnims_11_5
+.4byte sMedititeAnims_11_6
+.4byte sMedititeAnims_11_7
+.4byte sMedititeAnims_11_8
+sMedititeAnimTable12:
+.4byte sMedititeAnims_12_1
+.4byte sMedititeAnims_12_2
+.4byte sMedititeAnims_12_3
+.4byte sMedititeAnims_12_4
+.4byte sMedititeAnims_12_5
+.4byte sMedititeAnims_12_6
+.4byte sMedititeAnims_12_7
+.4byte sMedititeAnims_12_8
+sMedititeAnimTable13:
+.4byte sMedititeAnims_13_1
+.4byte sMedititeAnims_13_2
+.4byte sMedititeAnims_13_3
+.4byte sMedititeAnims_13_4
+.4byte sMedititeAnims_13_5
+.4byte sMedititeAnims_13_6
+.4byte sMedititeAnims_13_7
+.4byte sMedititeAnims_13_8
+sAxAnimationsMeditite:
+.4byte sMedititeAnimTable1
+.4byte sMedititeAnimTable2
+.4byte sMedititeAnimTable3
+.4byte sMedititeAnimTable4
+.4byte sMedititeAnimTable5
+.4byte sMedititeAnimTable6
+.4byte sMedititeAnimTable7
+.4byte sMedititeAnimTable8
+.4byte sMedititeAnimTable9
+.4byte sMedititeAnimTable10
+.4byte sMedititeAnimTable11
+.4byte sMedititeAnimTable12
+.4byte sMedititeAnimTable13
+sAxSpritesMeditite:
+.4byte sMedititeSprites1
+.4byte sMedititeSprites2
+.4byte sMedititeSprites3
+.4byte sMedititeSprites4
+.4byte sMedititeSprites5
+.4byte sMedititeSprites6
+.4byte sMedititeSprites7
+.4byte sMedititeSprites8
+.4byte sMedititeSprites9
+.4byte sMedititeSprites10
+.4byte sMedititeSprites11
+.4byte sMedititeSprites12
+.4byte sMedititeSprites13
+.4byte sMedititeSprites14
+.4byte sMedititeSprites15
+.4byte sMedititeSprites16
+.4byte sMedititeSprites17
+.4byte sMedititeSprites18
+.4byte sMedititeSprites19
+.4byte sMedititeSprites20
+.4byte sMedititeSprites21
+.4byte sMedititeSprites22
+.4byte sMedititeSprites23
+.4byte sMedititeSprites24
+.4byte sMedititeSprites25
+.4byte sMedititeSprites26
+.4byte sMedititeSprites27
+.4byte sMedititeSprites28
+.4byte sMedititeSprites29
+.4byte sMedititeSprites30
+.4byte sMedititeSprites31
+.4byte sMedititeSprites32
+.4byte sMedititeSprites33
+.4byte sMedititeSprites34
+.4byte sMedititeSprites35
+.4byte sMedititeSprites36
+.4byte sMedititeSprites37
+.4byte sMedititeSprites38
+.4byte sMedititeSprites39
+.4byte sMedititeSprites40
+.4byte sMedititeSprites41
+.4byte sMedititeSprites42
+.4byte sMedititeSprites43
+.4byte sMedititeSprites44
+.4byte sMedititeSprites45
+sAxMainMeditite:
+ax_main sAxPosesMeditite, sAxAnimationsMeditite, 13, sAxSpritesMeditite, sAxPositionsMeditite

--- a/data/ax/meganium.inc
+++ b/data/ax/meganium.inc
@@ -1,0 +1,2820 @@
+.global gAxMeganium
+gAxMeganium:
+ax_siro sAxMainMeganium
+sMeganiumPose1:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose2:
+ax_pose 1, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose3:
+ax_pose 2, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose4:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose5:
+ax_pose 4, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose6:
+ax_pose 5, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose7:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose8:
+ax_pose 7, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose9:
+ax_pose 8, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose10:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose11:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose12:
+ax_pose 11, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose13:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose14:
+ax_pose 13, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose15:
+ax_pose 14, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose16:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose17:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose18:
+ax_pose 11, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose19:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose20:
+ax_pose 7, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose21:
+ax_pose 8, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose22:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose23:
+ax_pose 4, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose24:
+ax_pose 5, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose25:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose26:
+ax_pose 1, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose27:
+ax_pose 2, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose28:
+ax_pose 15, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose29:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose30:
+ax_pose 4, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose31:
+ax_pose 5, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose32:
+ax_pose 16, 0x01e3, 0x90f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose33:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose34:
+ax_pose 7, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose35:
+ax_pose 8, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose36:
+ax_pose 17, 0x01e2, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose37:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose38:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose39:
+ax_pose 11, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose40:
+ax_pose 18, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose41:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose42:
+ax_pose 13, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose43:
+ax_pose 14, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose44:
+ax_pose 19, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose45:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose46:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose47:
+ax_pose 11, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose48:
+ax_pose 18, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose49:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose50:
+ax_pose 7, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose51:
+ax_pose 8, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose52:
+ax_pose 17, 0x01e2, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose53:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose54:
+ax_pose 4, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose55:
+ax_pose 5, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose56:
+ax_pose 16, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose57:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose58:
+ax_pose 1, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose59:
+ax_pose 2, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose60:
+ax_pose 15, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose61:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose62:
+ax_pose 4, 0x01e3, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose63:
+ax_pose 5, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose64:
+ax_pose 16, 0x01e3, 0x90f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose65:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose66:
+ax_pose 7, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose67:
+ax_pose 8, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose68:
+ax_pose 17, 0x01e2, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose69:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose70:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose71:
+ax_pose 11, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose72:
+ax_pose 18, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose73:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose74:
+ax_pose 13, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose75:
+ax_pose 14, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose76:
+ax_pose 19, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose77:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose78:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose79:
+ax_pose 11, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose80:
+ax_pose 18, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose81:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose82:
+ax_pose 7, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose83:
+ax_pose 8, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose84:
+ax_pose 17, 0x01e2, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose85:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose86:
+ax_pose 4, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose87:
+ax_pose 5, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose88:
+ax_pose 16, 0x01e3, 0x80ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose89:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose90:
+ax_pose 20, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose91:
+ax_pose 15, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose92:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose93:
+ax_pose 21, 0x01df, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose94:
+ax_pose 16, 0x01e4, 0x90f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose95:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose96:
+ax_pose 22, 0x01e2, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose97:
+ax_pose 17, 0x01e2, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose98:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose99:
+ax_pose 23, 0x01e3, 0x90f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose100:
+ax_pose 18, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose101:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose102:
+ax_pose 24, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose103:
+ax_pose 19, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose104:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose105:
+ax_pose 23, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose106:
+ax_pose 18, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose107:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose108:
+ax_pose 22, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose109:
+ax_pose 17, 0x01e2, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose110:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose111:
+ax_pose 21, 0x01df, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose112:
+ax_pose 16, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose113:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose114:
+ax_pose 25, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose115:
+ax_pose 26, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose116:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose117:
+ax_pose 27, 0x01e4, 0x90f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose118:
+ax_pose 28, 0x01e4, 0x90f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose119:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose120:
+ax_pose 29, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose121:
+ax_pose 30, 0x01e1, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose122:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose123:
+ax_pose 31, 0x01e2, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose124:
+ax_pose 32, 0x81e2, 0x90f5, 0x3c00
+ax_pose 33, 0x81e2, 0x5105, 0x3c08
+ax_pose 34, 0x01da, 0x10fd, 0x3c0c
+ax_pose_terminator
+sMeganiumPose125:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose126:
+ax_pose 35, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose127:
+ax_pose 36, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose128:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose129:
+ax_pose 31, 0x01e2, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose130:
+ax_pose 32, 0x81e2, 0x80fc, 0x3c00
+ax_pose 33, 0x81e2, 0x40f4, 0x3c08
+ax_pose 34, 0x01da, 0x00fc, 0x3c0c
+ax_pose_terminator
+sMeganiumPose131:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose132:
+ax_pose 29, 0x01e2, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose133:
+ax_pose 30, 0x01e1, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose134:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose135:
+ax_pose 27, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose136:
+ax_pose 28, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose137:
+ax_pose 37, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose138:
+ax_pose 38, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose139:
+ax_pose 39, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose140:
+ax_pose 40, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose141:
+ax_pose 41, 0x01e2, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose142:
+ax_pose 42, 0x81e1, 0x50f7, 0x3c00
+ax_pose 43, 0x0201, 0x10ff, 0x3c04
+ax_pose 44, 0x81e1, 0x10ef, 0x3c05
+ax_pose 45, 0x81e1, 0x90ff, 0x3c07
+ax_pose_terminator
+sMeganiumPose143:
+ax_pose 46, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose144:
+ax_pose 42, 0x81e1, 0x4101, 0x3c00
+ax_pose 43, 0x0201, 0x00f9, 0x3c04
+ax_pose 44, 0x81e1, 0x0109, 0x3c05
+ax_pose 45, 0x81e1, 0x80f1, 0x3c07
+ax_pose_terminator
+sMeganiumPose145:
+ax_pose 41, 0x01e2, 0x80f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose146:
+ax_pose 40, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose147:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose148:
+ax_pose 25, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose149:
+ax_pose 26, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose150:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose151:
+ax_pose 27, 0x01e4, 0x90f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose152:
+ax_pose 28, 0x01e4, 0x90f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose153:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose154:
+ax_pose 29, 0x01e2, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose155:
+ax_pose 30, 0x01e1, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose156:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose157:
+ax_pose 31, 0x01e2, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose158:
+ax_pose 32, 0x81e2, 0x90f5, 0x3c00
+ax_pose 33, 0x81e2, 0x5105, 0x3c08
+ax_pose 34, 0x01da, 0x10fd, 0x3c0c
+ax_pose_terminator
+sMeganiumPose159:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose160:
+ax_pose 35, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose161:
+ax_pose 36, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose162:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose163:
+ax_pose 31, 0x01e2, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose164:
+ax_pose 32, 0x81e2, 0x80fc, 0x3c00
+ax_pose 33, 0x81e2, 0x40f4, 0x3c08
+ax_pose 34, 0x01da, 0x00fc, 0x3c0c
+ax_pose_terminator
+sMeganiumPose165:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose166:
+ax_pose 29, 0x01e2, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose167:
+ax_pose 30, 0x01e1, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose168:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose169:
+ax_pose 27, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose170:
+ax_pose 28, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose171:
+ax_pose 15, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose172:
+ax_pose 16, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose173:
+ax_pose 17, 0x01e3, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose174:
+ax_pose 18, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose175:
+ax_pose 19, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose176:
+ax_pose 18, 0x01e4, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose177:
+ax_pose 17, 0x01e3, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose178:
+ax_pose 16, 0x01e4, 0x90f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose179:
+ax_pose 20, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose180:
+ax_pose 21, 0x01e1, 0x90f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose181:
+ax_pose 22, 0x01e3, 0x90f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose182:
+ax_pose 23, 0x01e3, 0x90f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose183:
+ax_pose 24, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose184:
+ax_pose 23, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose185:
+ax_pose 22, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose186:
+ax_pose 21, 0x01e1, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose187:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose188:
+ax_pose 20, 0x01e1, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose189:
+ax_pose 15, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose190:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose191:
+ax_pose 21, 0x01df, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose192:
+ax_pose 16, 0x01e4, 0x90f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose193:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose194:
+ax_pose 22, 0x01e2, 0x90ee, 0x3c00
+ax_pose_terminator
+sMeganiumPose195:
+ax_pose 17, 0x01e2, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose196:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose197:
+ax_pose 23, 0x01e3, 0x90f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose198:
+ax_pose 18, 0x01e3, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose199:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose200:
+ax_pose 24, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose201:
+ax_pose 19, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose202:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose203:
+ax_pose 23, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose204:
+ax_pose 18, 0x01e3, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose205:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose206:
+ax_pose 22, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose207:
+ax_pose 17, 0x01e2, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose208:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose209:
+ax_pose 21, 0x01df, 0x80f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose210:
+ax_pose 16, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose211:
+ax_pose 15, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose212:
+ax_pose 16, 0x01e4, 0x80ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose213:
+ax_pose 17, 0x01e3, 0x80ec, 0x3c00
+ax_pose_terminator
+sMeganiumPose214:
+ax_pose 18, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sMeganiumPose215:
+ax_pose 19, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose216:
+ax_pose 18, 0x01e4, 0x90f2, 0x3c00
+ax_pose_terminator
+sMeganiumPose217:
+ax_pose 17, 0x01e3, 0x90f5, 0x3c00
+ax_pose_terminator
+sMeganiumPose218:
+ax_pose 16, 0x01e4, 0x90f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose219:
+ax_pose 0, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose220:
+ax_pose 3, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sMeganiumPose221:
+ax_pose 6, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sMeganiumPose222:
+ax_pose 9, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose223:
+ax_pose 12, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sMeganiumPose224:
+ax_pose 9, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sMeganiumPose225:
+ax_pose 6, 0x01e2, 0x90f1, 0x3c00
+ax_pose_terminator
+sMeganiumPose226:
+ax_pose 3, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+.align 2
+sMeganiumAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim 2, 0, 26, 0, 3, 0, 3,
+ax_anim_terminator
+sMeganiumAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 12, 10, 12,
+ax_anim 2, 0, 31, 16, 20, 16, 20,
+ax_anim 2, 1, 31, 17, 19, 17, 19,
+ax_anim 2, 0, 31, 16, 20, 16, 20,
+ax_anim 2, 0, 31, 17, 19, 17, 19,
+ax_anim 2, 0, 31, 16, 20, 16, 20,
+ax_anim 2, 0, 31, 17, 19, 17, 19,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim 2, 0, 30, 3, 3, 3, 3,
+ax_anim_terminator
+sMeganiumAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 1, 35, 13, 1, 13, 1,
+ax_anim 2, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 0, 35, 13, 1, 13, 1,
+ax_anim 2, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 0, 35, 13, 1, 13, 1,
+ax_anim 2, 0, 33, 6, 0, 6, 0,
+ax_anim 2, 0, 34, 3, 0, 3, 0,
+ax_anim_terminator
+sMeganiumAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 15, -19, 15, -19,
+ax_anim 2, 1, 39, 16, -18, 16, -18,
+ax_anim 2, 0, 39, 15, -19, 15, -19,
+ax_anim 2, 0, 39, 16, -18, 16, -18,
+ax_anim 2, 0, 39, 15, -19, 15, -19,
+ax_anim 2, 0, 39, 16, -18, 16, -18,
+ax_anim 2, 0, 37, 6, -6, 6, -6,
+ax_anim 2, 0, 38, 3, -3, 3, -3,
+ax_anim_terminator
+sMeganiumAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 41, 0, -6, 0, -6,
+ax_anim 2, 0, 42, 0, -3, 0, -3,
+ax_anim_terminator
+sMeganiumAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -15, -19, -15, -19,
+ax_anim 2, 1, 47, -16, -18, -16, -18,
+ax_anim 2, 0, 47, -15, -19, -15, -19,
+ax_anim 2, 0, 47, -16, -18, -16, -18,
+ax_anim 2, 0, 47, -15, -19, -15, -19,
+ax_anim 2, 0, 47, -16, -18, -16, -18,
+ax_anim 2, 0, 45, -6, -6, -6, -6,
+ax_anim 2, 0, 46, -3, -3, -3, -3,
+ax_anim_terminator
+sMeganiumAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -13, 0, -13, 0,
+ax_anim 2, 1, 51, -13, 1, -13, 1,
+ax_anim 2, 0, 51, -13, 0, -13, 0,
+ax_anim 2, 0, 51, -13, 1, -13, 1,
+ax_anim 2, 0, 51, -13, 0, -13, 0,
+ax_anim 2, 0, 51, -13, 1, -13, 1,
+ax_anim 2, 0, 49, -6, 0, -6, 0,
+ax_anim 2, 0, 50, -3, 0, -3, 0,
+ax_anim_terminator
+sMeganiumAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 12, -10, 12,
+ax_anim 2, 0, 55, -16, 20, -16, 20,
+ax_anim 2, 1, 55, -17, 19, -17, 19,
+ax_anim 2, 0, 55, -16, 20, -16, 20,
+ax_anim 2, 0, 55, -17, 19, -17, 19,
+ax_anim 2, 0, 55, -16, 20, -16, 20,
+ax_anim 2, 0, 55, -17, 19, -17, 19,
+ax_anim 2, 0, 53, -6, 6, -6, 6,
+ax_anim 2, 0, 54, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 1, 19, 1, 19,
+ax_anim 2, 0, 57, 0, 6, 0, 6,
+ax_anim 2, 0, 58, 0, 3, 0, 3,
+ax_anim_terminator
+sMeganiumAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 12, 10, 12,
+ax_anim 2, 0, 63, 16, 20, 16, 20,
+ax_anim 2, 1, 63, 17, 19, 17, 19,
+ax_anim 2, 0, 63, 16, 20, 16, 20,
+ax_anim 2, 0, 63, 17, 19, 17, 19,
+ax_anim 2, 0, 63, 16, 20, 16, 20,
+ax_anim 2, 0, 63, 17, 19, 17, 19,
+ax_anim 2, 0, 61, 6, 6, 6, 6,
+ax_anim 2, 0, 62, 3, 3, 3, 3,
+ax_anim_terminator
+sMeganiumAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 13, 0, 13, 0,
+ax_anim 2, 1, 67, 13, 1, 13, 1,
+ax_anim 2, 0, 67, 13, 0, 13, 0,
+ax_anim 2, 0, 67, 13, 1, 13, 1,
+ax_anim 2, 0, 67, 13, 0, 13, 0,
+ax_anim 2, 0, 67, 13, 1, 13, 1,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 66, 3, 0, 3, 0,
+ax_anim_terminator
+sMeganiumAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 15, -19, 15, -19,
+ax_anim 2, 1, 71, 16, -18, 16, -18,
+ax_anim 2, 0, 71, 15, -19, 15, -19,
+ax_anim 2, 0, 71, 16, -18, 16, -18,
+ax_anim 2, 0, 71, 15, -19, 15, -19,
+ax_anim 2, 0, 71, 16, -18, 16, -18,
+ax_anim 2, 0, 69, 6, -6, 6, -6,
+ax_anim 2, 0, 70, 3, -3, 3, -3,
+ax_anim_terminator
+sMeganiumAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 1, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 73, 0, -6, 0, -6,
+ax_anim 2, 0, 74, 0, -3, 0, -3,
+ax_anim_terminator
+sMeganiumAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -15, -19, -15, -19,
+ax_anim 2, 1, 79, -16, -18, -16, -18,
+ax_anim 2, 0, 79, -15, -19, -15, -19,
+ax_anim 2, 0, 79, -16, -18, -16, -18,
+ax_anim 2, 0, 79, -15, -19, -15, -19,
+ax_anim 2, 0, 79, -16, -18, -16, -18,
+ax_anim 2, 0, 77, -6, -6, -6, -6,
+ax_anim 2, 0, 78, -3, -3, -3, -3,
+ax_anim_terminator
+sMeganiumAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -13, 0, -13, 0,
+ax_anim 2, 1, 83, -13, 1, -13, 1,
+ax_anim 2, 0, 83, -13, 0, -13, 0,
+ax_anim 2, 0, 83, -13, 1, -13, 1,
+ax_anim 2, 0, 83, -13, 0, -13, 0,
+ax_anim 2, 0, 83, -13, 1, -13, 1,
+ax_anim 2, 0, 81, -6, 0, -6, 0,
+ax_anim 2, 0, 82, -3, 0, -3, 0,
+ax_anim_terminator
+sMeganiumAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 12, -10, 12,
+ax_anim 2, 0, 87, -16, 20, -16, 20,
+ax_anim 2, 1, 87, -17, 19, -17, 19,
+ax_anim 2, 0, 87, -16, 20, -16, 20,
+ax_anim 2, 0, 87, -17, 19, -17, 19,
+ax_anim 2, 0, 87, -16, 20, -16, 20,
+ax_anim 2, 0, 87, -17, 19, -17, 19,
+ax_anim 2, 0, 85, -6, 6, -6, 6,
+ax_anim 2, 0, 86, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 110, 1, -3, 1, -3,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 1, 90, 1, 2, 1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 1, 2, 1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 1, 2, 1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sMeganiumAnims_4_2:
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 95, -3, -2, -3, -2,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 1, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sMeganiumAnims_4_3:
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 98, -6, 2, -3, 1,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 1, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sMeganiumAnims_4_4:
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 101, -2, 3, -2, 3,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 1, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sMeganiumAnims_4_5:
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 98, -1, 3, -1, 3,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 1, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sMeganiumAnims_4_6:
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 101, 4, 3, 2, 3,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 1, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sMeganiumAnims_4_7:
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 104, 4, 2, 3, 1,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 1, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sMeganiumAnims_4_8:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 107, 3, -3, 3, -2,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 1, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_5_1:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_5_2:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_5_3:
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_5_4:
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 1, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_5_5:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_5_6:
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 1, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_5_7:
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 1, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_5_8:
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 1, 133, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sMeganiumAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sMeganiumAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sMeganiumAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sMeganiumAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sMeganiumAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sMeganiumAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sMeganiumAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 147, 0, 0, 0, 0,
+ax_anim 20, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 150, 0, 0, 0, 0,
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 153, 0, 0, 0, 0,
+ax_anim 20, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 14, 0, 156, 0, 0, 0, 0,
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim 14, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 14, 0, 159, 0, 0, 0, 0,
+ax_anim 20, 0, 158, 0, 0, 0, 0,
+ax_anim 14, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 14, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim 14, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 14, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim 14, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 14, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim 14, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 11, 8, 11,
+ax_anim 2, 0, 173, 7, 18, 7, 18,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 18, -7, 18,
+ax_anim 2, 0, 176, -8, 11, -8, 11,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 22, 12, 22, 12,
+ax_anim 3, 0, 173, 20, 20, 20, 20,
+ax_anim 2, 3, 174, 13, 20, 13, 20,
+ax_anim 2, 0, 175, 2, 15, 2, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 10, -6, 10, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 20, 0, 20, 0,
+ax_anim 2, 3, 173, 17, 4, 17, 4,
+ax_anim 2, 0, 174, 10, 5, 10, 5,
+ax_anim 1, 0, 175, 4, 3, 4, 3,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -2, -8, -2, -8,
+ax_anim 2, 0, 177, 1, -16, 1, -16,
+ax_anim 2, 0, 170, 10, -22, 10, -22,
+ax_anim 3, 0, 171, 20, -20, 20, -20,
+ax_anim 2, 3, 172, 22, -12, 22, -12,
+ax_anim 2, 0, 173, 18, -3, 18, -3,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -1, -8, -1,
+ax_anim 2, 0, 176, -11, -12, -11, -12,
+ax_anim 2, 0, 177, -9, -18, -9, -18,
+ax_anim 3, 0, 170, 0, -20, 0, -20,
+ax_anim 2, 3, 171, 9, -18, 9, -18,
+ax_anim 2, 0, 172, 11, -10, 11, -10,
+ax_anim 1, 0, 173, 8, -1, 8, -1,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 2, -6, 2, -6,
+ax_anim 2, 0, 171, -1, -16, -1, -16,
+ax_anim 2, 0, 170, -10, -22, -10, -22,
+ax_anim 3, 0, 177, -20, -20, -20, -20,
+ax_anim 2, 3, 176, -22, -12, -22, -12,
+ax_anim 2, 0, 175, -18, -3, -18, -3,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -10, -6, -10, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -20, 0, -20, 0,
+ax_anim 2, 3, 175, -17, 4, -17, 4,
+ax_anim 2, 0, 174, -10, 5, -10, 5,
+ax_anim 1, 0, 173, -4, 3, -4, 3,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -22, 12, -22, 12,
+ax_anim 3, 0, 175, -20, 20, -20, 20,
+ax_anim 2, 3, 174, -13, 20, -13, 20,
+ax_anim 2, 0, 173, -2, 15, -2, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -5, 0, 0,
+ax_anim 2, 0, 187, 0, -11, 0, 0,
+ax_anim 3, 0, 187, 0, -15, 0, 0,
+ax_anim 4, 0, 187, 0, -16, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -4, 0, 0,
+ax_anim 2, 0, 190, 0, -10, 0, 0,
+ax_anim 3, 0, 190, 0, -14, 0, 0,
+ax_anim 4, 0, 190, 0, -15, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -7, 0, 0,
+ax_anim 2, 0, 193, 0, -13, 0, 0,
+ax_anim 3, 0, 193, 0, -17, 0, 0,
+ax_anim 4, 0, 193, 0, -18, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -5, 0, 0,
+ax_anim 2, 0, 196, 0, -11, 0, 0,
+ax_anim 3, 0, 196, 0, -15, 0, 0,
+ax_anim 4, 0, 196, 0, -16, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -9, 0, 0,
+ax_anim 2, 0, 199, 0, -15, 0, 0,
+ax_anim 3, 0, 199, 0, -19, 0, 0,
+ax_anim 4, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -5, 0, 0,
+ax_anim 2, 0, 202, 0, -11, 0, 0,
+ax_anim 3, 0, 202, 0, -15, 0, 0,
+ax_anim 4, 0, 202, 0, -16, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -7, 0, 0,
+ax_anim 2, 0, 205, 0, -13, 0, 0,
+ax_anim 3, 0, 205, 0, -17, 0, 0,
+ax_anim 4, 0, 205, 0, -18, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -4, 0, 0,
+ax_anim 2, 0, 208, 0, -10, 0, 0,
+ax_anim 3, 0, 208, 0, -14, 0, 0,
+ax_anim 4, 0, 208, 0, -15, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeganiumAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeganiumGfx1:
+.incbin "baserom.gba", 0xBBBCDC, 0x200
+sMeganiumSprites1:
+ax_sprite sMeganiumGfx1, 0x200
+ax_sprite_terminator
+sMeganiumGfx2:
+.incbin "baserom.gba", 0xBBBEEC, 0x200
+sMeganiumSprites2:
+ax_sprite sMeganiumGfx2, 0x200
+ax_sprite_terminator
+sMeganiumGfx3:
+.incbin "baserom.gba", 0xBBC0FC, 0x200
+sMeganiumSprites3:
+ax_sprite sMeganiumGfx3, 0x200
+ax_sprite_terminator
+sMeganiumGfx4:
+.incbin "baserom.gba", 0xBBC30C, 0x200
+sMeganiumSprites4:
+ax_sprite sMeganiumGfx4, 0x200
+ax_sprite_terminator
+sMeganiumGfx5:
+.incbin "baserom.gba", 0xBBC51C, 0x200
+sMeganiumSprites5:
+ax_sprite sMeganiumGfx5, 0x200
+ax_sprite_terminator
+sMeganiumGfx6:
+.incbin "baserom.gba", 0xBBC72C, 0x200
+sMeganiumSprites6:
+ax_sprite sMeganiumGfx6, 0x200
+ax_sprite_terminator
+sMeganiumGfx7:
+.incbin "baserom.gba", 0xBBC93C, 0x200
+sMeganiumSprites7:
+ax_sprite sMeganiumGfx7, 0x200
+ax_sprite_terminator
+sMeganiumGfx8:
+.incbin "baserom.gba", 0xBBCB4C, 0x200
+sMeganiumSprites8:
+ax_sprite sMeganiumGfx8, 0x200
+ax_sprite_terminator
+sMeganiumGfx9:
+.incbin "baserom.gba", 0xBBCD5C, 0x200
+sMeganiumSprites9:
+ax_sprite sMeganiumGfx9, 0x200
+ax_sprite_terminator
+sMeganiumGfx10:
+.incbin "baserom.gba", 0xBBCF6C, 0x200
+sMeganiumSprites10:
+ax_sprite sMeganiumGfx10, 0x200
+ax_sprite_terminator
+sMeganiumGfx11:
+.incbin "baserom.gba", 0xBBD17C, 0x200
+sMeganiumSprites11:
+ax_sprite sMeganiumGfx11, 0x200
+ax_sprite_terminator
+sMeganiumGfx12:
+.incbin "baserom.gba", 0xBBD38C, 0x200
+sMeganiumSprites12:
+ax_sprite sMeganiumGfx12, 0x200
+ax_sprite_terminator
+sMeganiumGfx13:
+.incbin "baserom.gba", 0xBBD59C, 0x200
+sMeganiumSprites13:
+ax_sprite sMeganiumGfx13, 0x200
+ax_sprite_terminator
+sMeganiumGfx14:
+.incbin "baserom.gba", 0xBBD7AC, 0x200
+sMeganiumSprites14:
+ax_sprite sMeganiumGfx14, 0x200
+ax_sprite_terminator
+sMeganiumGfx15:
+.incbin "baserom.gba", 0xBBD9BC, 0x200
+sMeganiumSprites15:
+ax_sprite sMeganiumGfx15, 0x200
+ax_sprite_terminator
+sMeganiumGfx16:
+.incbin "baserom.gba", 0xBBDBCC, 0x180
+sMeganiumSprites16:
+ax_sprite 0, 0x80
+ax_sprite sMeganiumGfx16, 0x180
+ax_sprite_terminator
+sMeganiumGfx17:
+.incbin "baserom.gba", 0xBBDD64, 0x20
+sMeganiumGfx17_1:
+.incbin "baserom.gba", 0xBBDD84, 0x180
+sMeganiumSprites17:
+ax_sprite sMeganiumGfx17, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeganiumGfx17_1, 0x180
+ax_sprite_terminator
+sMeganiumGfx18:
+.incbin "baserom.gba", 0xBBDF24, 0x40
+sMeganiumGfx18_1:
+.incbin "baserom.gba", 0xBBDF64, 0x60
+sMeganiumGfx18_2:
+.incbin "baserom.gba", 0xBBDFC4, 0x100
+sMeganiumSprites18:
+ax_sprite sMeganiumGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx18_2, 0x100
+ax_sprite_terminator
+sMeganiumGfx19:
+.incbin "baserom.gba", 0xBBE0F4, 0x40
+sMeganiumGfx19_1:
+.incbin "baserom.gba", 0xBBE134, 0x60
+sMeganiumGfx19_2:
+.incbin "baserom.gba", 0xBBE194, 0x80
+sMeganiumGfx19_3:
+.incbin "baserom.gba", 0xBBE214, 0x60
+sMeganiumSprites19:
+ax_sprite sMeganiumGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx19_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx19_3, 0x60
+ax_sprite_terminator
+sMeganiumGfx20:
+.incbin "baserom.gba", 0xBBE2B4, 0x40
+sMeganiumGfx20_1:
+.incbin "baserom.gba", 0xBBE2F4, 0x40
+sMeganiumGfx20_2:
+.incbin "baserom.gba", 0xBBE334, 0x80
+sMeganiumGfx20_3:
+.incbin "baserom.gba", 0xBBE3B4, 0x60
+sMeganiumSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx20_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx20_3, 0x60
+ax_sprite_terminator
+sMeganiumGfx21:
+.incbin "baserom.gba", 0xBBE45C, 0x1E0
+sMeganiumSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx21, 0x1e0
+ax_sprite_terminator
+sMeganiumGfx22:
+.incbin "baserom.gba", 0xBBE654, 0x1E0
+sMeganiumSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx22, 0x1e0
+ax_sprite_terminator
+sMeganiumGfx23:
+.incbin "baserom.gba", 0xBBE84C, 0x160
+sMeganiumGfx23_1:
+.incbin "baserom.gba", 0xBBE9AC, 0x60
+sMeganiumSprites23:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx23, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx23_1, 0x60
+ax_sprite_terminator
+sMeganiumGfx24:
+.incbin "baserom.gba", 0xBBEA34, 0x160
+sMeganiumGfx24_1:
+.incbin "baserom.gba", 0xBBEB94, 0x60
+sMeganiumSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx24_1, 0x60
+ax_sprite_terminator
+sMeganiumGfx25:
+.incbin "baserom.gba", 0xBBEC1C, 0xE0
+sMeganiumGfx25_1:
+.incbin "baserom.gba", 0xBBECFC, 0x60
+sMeganiumGfx25_2:
+.incbin "baserom.gba", 0xBBED5C, 0x40
+sMeganiumSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx25, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMeganiumGfx26:
+.incbin "baserom.gba", 0xBBEDDC, 0x40
+sMeganiumGfx26_1:
+.incbin "baserom.gba", 0xBBEE1C, 0x40
+sMeganiumGfx26_2:
+.incbin "baserom.gba", 0xBBEE5C, 0x60
+sMeganiumGfx26_3:
+.incbin "baserom.gba", 0xBBEEBC, 0x60
+sMeganiumSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx26_3, 0x60
+ax_sprite_terminator
+sMeganiumGfx27:
+.incbin "baserom.gba", 0xBBEF64, 0x40
+sMeganiumGfx27_1:
+.incbin "baserom.gba", 0xBBEFA4, 0x140
+sMeganiumSprites27:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx27_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMeganiumGfx28:
+.incbin "baserom.gba", 0xBBF114, 0x40
+sMeganiumGfx28_1:
+.incbin "baserom.gba", 0xBBF154, 0xE0
+sMeganiumGfx28_2:
+.incbin "baserom.gba", 0xBBF234, 0x60
+sMeganiumSprites28:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx28_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx28_2, 0x60
+ax_sprite_terminator
+sMeganiumGfx29:
+.incbin "baserom.gba", 0xBBF2CC, 0x60
+sMeganiumGfx29_1:
+.incbin "baserom.gba", 0xBBF32C, 0x100
+sMeganiumGfx29_2:
+.incbin "baserom.gba", 0xBBF42C, 0x60
+sMeganiumSprites29:
+ax_sprite sMeganiumGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx29_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx29_2, 0x60
+ax_sprite_terminator
+sMeganiumGfx30:
+.incbin "baserom.gba", 0xBBF4BC, 0x40
+sMeganiumGfx30_1:
+.incbin "baserom.gba", 0xBBF4FC, 0x60
+sMeganiumGfx30_2:
+.incbin "baserom.gba", 0xBBF55C, 0x100
+sMeganiumSprites30:
+ax_sprite sMeganiumGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx30_2, 0x100
+ax_sprite_terminator
+sMeganiumGfx31:
+.incbin "baserom.gba", 0xBBF68C, 0x40
+sMeganiumGfx31_1:
+.incbin "baserom.gba", 0xBBF6CC, 0x60
+sMeganiumGfx31_2:
+.incbin "baserom.gba", 0xBBF72C, 0x100
+sMeganiumSprites31:
+ax_sprite sMeganiumGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx31_2, 0x100
+ax_sprite_terminator
+sMeganiumGfx32:
+.incbin "baserom.gba", 0xBBF85C, 0x60
+sMeganiumGfx32_1:
+.incbin "baserom.gba", 0xBBF8BC, 0x80
+sMeganiumGfx32_2:
+.incbin "baserom.gba", 0xBBF93C, 0x60
+sMeganiumGfx32_3:
+.incbin "baserom.gba", 0xBBF99C, 0x60
+sMeganiumSprites32:
+ax_sprite sMeganiumGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx32_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx32_3, 0x60
+ax_sprite_terminator
+sMeganiumGfx33:
+.incbin "baserom.gba", 0xBBFA3C, 0x20
+sMeganiumGfx33_1:
+.incbin "baserom.gba", 0xBBFA5C, 0xC0
+sMeganiumSprites33:
+ax_sprite sMeganiumGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx33_1, 0xc0
+ax_sprite_terminator
+sMeganiumGfx34:
+.incbin "baserom.gba", 0xBBFB3C, 0x80
+sMeganiumSprites34:
+ax_sprite sMeganiumGfx34, 0x80
+ax_sprite_terminator
+sMeganiumGfx35:
+.incbin "baserom.gba", 0xBBFBCC, 0x20
+sMeganiumSprites35:
+ax_sprite sMeganiumGfx35, 0x20
+ax_sprite_terminator
+sMeganiumGfx36:
+.incbin "baserom.gba", 0xBBFBFC, 0x40
+sMeganiumGfx36_1:
+.incbin "baserom.gba", 0xBBFC3C, 0xE0
+sMeganiumGfx36_2:
+.incbin "baserom.gba", 0xBBFD1C, 0x60
+sMeganiumSprites36:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeganiumGfx36_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx36_2, 0x60
+ax_sprite_terminator
+sMeganiumGfx37:
+.incbin "baserom.gba", 0xBBFDB4, 0x40
+sMeganiumGfx37_1:
+.incbin "baserom.gba", 0xBBFDF4, 0x60
+sMeganiumGfx37_2:
+.incbin "baserom.gba", 0xBBFE54, 0x80
+sMeganiumGfx37_3:
+.incbin "baserom.gba", 0xBBFED4, 0x60
+sMeganiumSprites37:
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx37_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMeganiumGfx37_3, 0x60
+ax_sprite_terminator
+sMeganiumGfx38:
+.incbin "baserom.gba", 0xBBFF7C, 0x200
+sMeganiumSprites38:
+ax_sprite sMeganiumGfx38, 0x200
+ax_sprite_terminator
+sMeganiumGfx39:
+.incbin "baserom.gba", 0xBC018C, 0x200
+sMeganiumSprites39:
+ax_sprite sMeganiumGfx39, 0x200
+ax_sprite_terminator
+sMeganiumGfx40:
+.incbin "baserom.gba", 0xBC039C, 0x200
+sMeganiumSprites40:
+ax_sprite sMeganiumGfx40, 0x200
+ax_sprite_terminator
+sMeganiumGfx41:
+.incbin "baserom.gba", 0xBC05AC, 0x200
+sMeganiumSprites41:
+ax_sprite sMeganiumGfx41, 0x200
+ax_sprite_terminator
+sMeganiumGfx42:
+.incbin "baserom.gba", 0xBC07BC, 0x200
+sMeganiumSprites42:
+ax_sprite sMeganiumGfx42, 0x200
+ax_sprite_terminator
+sMeganiumGfx43:
+.incbin "baserom.gba", 0xBC09CC, 0x80
+sMeganiumSprites43:
+ax_sprite sMeganiumGfx43, 0x80
+ax_sprite_terminator
+sMeganiumGfx44:
+.incbin "baserom.gba", 0xBC0A5C, 0x20
+sMeganiumSprites44:
+ax_sprite sMeganiumGfx44, 0x20
+ax_sprite_terminator
+sMeganiumGfx45:
+.incbin "baserom.gba", 0xBC0A8C, 0x40
+sMeganiumSprites45:
+ax_sprite sMeganiumGfx45, 0x40
+ax_sprite_terminator
+sMeganiumGfx46:
+.incbin "baserom.gba", 0xBC0ADC, 0x100
+sMeganiumSprites46:
+ax_sprite sMeganiumGfx46, 0x100
+ax_sprite_terminator
+sMeganiumGfx47:
+.incbin "baserom.gba", 0xBC0BEC, 0x200
+sMeganiumSprites47:
+ax_sprite sMeganiumGfx47, 0x200
+ax_sprite_terminator
+sAxPosesMeganium:
+.4byte sMeganiumPose1
+.4byte sMeganiumPose2
+.4byte sMeganiumPose3
+.4byte sMeganiumPose4
+.4byte sMeganiumPose5
+.4byte sMeganiumPose6
+.4byte sMeganiumPose7
+.4byte sMeganiumPose8
+.4byte sMeganiumPose9
+.4byte sMeganiumPose10
+.4byte sMeganiumPose11
+.4byte sMeganiumPose12
+.4byte sMeganiumPose13
+.4byte sMeganiumPose14
+.4byte sMeganiumPose15
+.4byte sMeganiumPose16
+.4byte sMeganiumPose17
+.4byte sMeganiumPose18
+.4byte sMeganiumPose19
+.4byte sMeganiumPose20
+.4byte sMeganiumPose21
+.4byte sMeganiumPose22
+.4byte sMeganiumPose23
+.4byte sMeganiumPose24
+.4byte sMeganiumPose25
+.4byte sMeganiumPose26
+.4byte sMeganiumPose27
+.4byte sMeganiumPose28
+.4byte sMeganiumPose29
+.4byte sMeganiumPose30
+.4byte sMeganiumPose31
+.4byte sMeganiumPose32
+.4byte sMeganiumPose33
+.4byte sMeganiumPose34
+.4byte sMeganiumPose35
+.4byte sMeganiumPose36
+.4byte sMeganiumPose37
+.4byte sMeganiumPose38
+.4byte sMeganiumPose39
+.4byte sMeganiumPose40
+.4byte sMeganiumPose41
+.4byte sMeganiumPose42
+.4byte sMeganiumPose43
+.4byte sMeganiumPose44
+.4byte sMeganiumPose45
+.4byte sMeganiumPose46
+.4byte sMeganiumPose47
+.4byte sMeganiumPose48
+.4byte sMeganiumPose49
+.4byte sMeganiumPose50
+.4byte sMeganiumPose51
+.4byte sMeganiumPose52
+.4byte sMeganiumPose53
+.4byte sMeganiumPose54
+.4byte sMeganiumPose55
+.4byte sMeganiumPose56
+.4byte sMeganiumPose57
+.4byte sMeganiumPose58
+.4byte sMeganiumPose59
+.4byte sMeganiumPose60
+.4byte sMeganiumPose61
+.4byte sMeganiumPose62
+.4byte sMeganiumPose63
+.4byte sMeganiumPose64
+.4byte sMeganiumPose65
+.4byte sMeganiumPose66
+.4byte sMeganiumPose67
+.4byte sMeganiumPose68
+.4byte sMeganiumPose69
+.4byte sMeganiumPose70
+.4byte sMeganiumPose71
+.4byte sMeganiumPose72
+.4byte sMeganiumPose73
+.4byte sMeganiumPose74
+.4byte sMeganiumPose75
+.4byte sMeganiumPose76
+.4byte sMeganiumPose77
+.4byte sMeganiumPose78
+.4byte sMeganiumPose79
+.4byte sMeganiumPose80
+.4byte sMeganiumPose81
+.4byte sMeganiumPose82
+.4byte sMeganiumPose83
+.4byte sMeganiumPose84
+.4byte sMeganiumPose85
+.4byte sMeganiumPose86
+.4byte sMeganiumPose87
+.4byte sMeganiumPose88
+.4byte sMeganiumPose89
+.4byte sMeganiumPose90
+.4byte sMeganiumPose91
+.4byte sMeganiumPose92
+.4byte sMeganiumPose93
+.4byte sMeganiumPose94
+.4byte sMeganiumPose95
+.4byte sMeganiumPose96
+.4byte sMeganiumPose97
+.4byte sMeganiumPose98
+.4byte sMeganiumPose99
+.4byte sMeganiumPose100
+.4byte sMeganiumPose101
+.4byte sMeganiumPose102
+.4byte sMeganiumPose103
+.4byte sMeganiumPose104
+.4byte sMeganiumPose105
+.4byte sMeganiumPose106
+.4byte sMeganiumPose107
+.4byte sMeganiumPose108
+.4byte sMeganiumPose109
+.4byte sMeganiumPose110
+.4byte sMeganiumPose111
+.4byte sMeganiumPose112
+.4byte sMeganiumPose113
+.4byte sMeganiumPose114
+.4byte sMeganiumPose115
+.4byte sMeganiumPose116
+.4byte sMeganiumPose117
+.4byte sMeganiumPose118
+.4byte sMeganiumPose119
+.4byte sMeganiumPose120
+.4byte sMeganiumPose121
+.4byte sMeganiumPose122
+.4byte sMeganiumPose123
+.4byte sMeganiumPose124
+.4byte sMeganiumPose125
+.4byte sMeganiumPose126
+.4byte sMeganiumPose127
+.4byte sMeganiumPose128
+.4byte sMeganiumPose129
+.4byte sMeganiumPose130
+.4byte sMeganiumPose131
+.4byte sMeganiumPose132
+.4byte sMeganiumPose133
+.4byte sMeganiumPose134
+.4byte sMeganiumPose135
+.4byte sMeganiumPose136
+.4byte sMeganiumPose137
+.4byte sMeganiumPose138
+.4byte sMeganiumPose139
+.4byte sMeganiumPose140
+.4byte sMeganiumPose141
+.4byte sMeganiumPose142
+.4byte sMeganiumPose143
+.4byte sMeganiumPose144
+.4byte sMeganiumPose145
+.4byte sMeganiumPose146
+.4byte sMeganiumPose147
+.4byte sMeganiumPose148
+.4byte sMeganiumPose149
+.4byte sMeganiumPose150
+.4byte sMeganiumPose151
+.4byte sMeganiumPose152
+.4byte sMeganiumPose153
+.4byte sMeganiumPose154
+.4byte sMeganiumPose155
+.4byte sMeganiumPose156
+.4byte sMeganiumPose157
+.4byte sMeganiumPose158
+.4byte sMeganiumPose159
+.4byte sMeganiumPose160
+.4byte sMeganiumPose161
+.4byte sMeganiumPose162
+.4byte sMeganiumPose163
+.4byte sMeganiumPose164
+.4byte sMeganiumPose165
+.4byte sMeganiumPose166
+.4byte sMeganiumPose167
+.4byte sMeganiumPose168
+.4byte sMeganiumPose169
+.4byte sMeganiumPose170
+.4byte sMeganiumPose171
+.4byte sMeganiumPose172
+.4byte sMeganiumPose173
+.4byte sMeganiumPose174
+.4byte sMeganiumPose175
+.4byte sMeganiumPose176
+.4byte sMeganiumPose177
+.4byte sMeganiumPose178
+.4byte sMeganiumPose179
+.4byte sMeganiumPose180
+.4byte sMeganiumPose181
+.4byte sMeganiumPose182
+.4byte sMeganiumPose183
+.4byte sMeganiumPose184
+.4byte sMeganiumPose185
+.4byte sMeganiumPose186
+.4byte sMeganiumPose187
+.4byte sMeganiumPose188
+.4byte sMeganiumPose189
+.4byte sMeganiumPose190
+.4byte sMeganiumPose191
+.4byte sMeganiumPose192
+.4byte sMeganiumPose193
+.4byte sMeganiumPose194
+.4byte sMeganiumPose195
+.4byte sMeganiumPose196
+.4byte sMeganiumPose197
+.4byte sMeganiumPose198
+.4byte sMeganiumPose199
+.4byte sMeganiumPose200
+.4byte sMeganiumPose201
+.4byte sMeganiumPose202
+.4byte sMeganiumPose203
+.4byte sMeganiumPose204
+.4byte sMeganiumPose205
+.4byte sMeganiumPose206
+.4byte sMeganiumPose207
+.4byte sMeganiumPose208
+.4byte sMeganiumPose209
+.4byte sMeganiumPose210
+.4byte sMeganiumPose211
+.4byte sMeganiumPose212
+.4byte sMeganiumPose213
+.4byte sMeganiumPose214
+.4byte sMeganiumPose215
+.4byte sMeganiumPose216
+.4byte sMeganiumPose217
+.4byte sMeganiumPose218
+.4byte sMeganiumPose219
+.4byte sMeganiumPose220
+.4byte sMeganiumPose221
+.4byte sMeganiumPose222
+.4byte sMeganiumPose223
+.4byte sMeganiumPose224
+.4byte sMeganiumPose225
+.4byte sMeganiumPose226
+sAxPositionsMeganium:
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte    0,  -12, 	  -5,    0, 	   4,    0, 	   0,  -10
+.2byte    0,  -12, 	  -4,    0, 	   5,    0, 	   0,  -10
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+.2byte    7,  -13, 	  10,   -1, 	  -1,    1, 	   1,   -7
+.2byte    7,  -13, 	   8,   -1, 	   2,    0, 	   0,   -7
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte   11,  -16, 	   9,   -2, 	   4,    0, 	   0,   -7
+.2byte   11,  -16, 	   3,   -3, 	   9,   -1, 	   1,   -7
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte    8,  -17, 	   2,   -8, 	   6,   -3, 	  -1,   -7
+.2byte    8,  -17, 	   0,   -6, 	   8,   -5, 	   0,   -7
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte    0,  -18, 	   6,   -7, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -18, 	   6,   -4, 	  -6,   -7, 	   0,   -7
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -17, 	  -2,   -8, 	  -6,   -3, 	   1,   -7
+.2byte   -8,  -17, 	   0,   -6, 	  -8,   -5, 	   0,   -7
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte  -11,  -16, 	  -9,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -11,  -16, 	  -3,   -3, 	  -9,   -1, 	  -1,   -7
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -7,  -13, 	 -10,   -1, 	   1,    1, 	  -1,   -7
+.2byte   -7,  -13, 	  -8,   -1, 	  -2,    0, 	   0,   -7
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte    0,  -12, 	  -5,    0, 	   4,    0, 	   0,  -10
+.2byte    0,  -12, 	  -4,    0, 	   5,    0, 	   0,  -10
+.2byte    0,   -4, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+.2byte    7,  -13, 	  10,   -1, 	  -1,    1, 	   1,   -7
+.2byte    7,  -13, 	   8,   -1, 	   2,    0, 	   0,   -7
+.2byte   15,   -7, 	   9,   -1, 	   1,    1, 	   3,   -8
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte   11,  -16, 	   9,   -2, 	   4,    0, 	   0,   -7
+.2byte   11,  -16, 	   3,   -3, 	   9,   -1, 	   1,   -7
+.2byte   16,  -11, 	   9,   -3, 	   6,   -1, 	   0,   -8
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte    8,  -17, 	   2,   -8, 	   6,   -3, 	  -1,   -7
+.2byte    8,  -17, 	   0,   -6, 	   8,   -5, 	   0,   -7
+.2byte   13,  -15, 	   1,   -8, 	   8,   -5, 	   0,   -9
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte    0,  -18, 	   6,   -7, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -18, 	   6,   -4, 	  -6,   -7, 	   0,   -7
+.2byte    0,  -17, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -17, 	  -2,   -8, 	  -6,   -3, 	   1,   -7
+.2byte   -8,  -17, 	   0,   -6, 	  -8,   -5, 	   0,   -7
+.2byte  -13,  -15, 	  -1,   -8, 	  -8,   -5, 	   0,   -9
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte  -11,  -16, 	  -9,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -11,  -16, 	  -3,   -3, 	  -9,   -1, 	  -1,   -7
+.2byte  -16,  -11, 	  -9,   -3, 	  -6,   -1, 	   0,   -8
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -7,  -13, 	 -10,   -1, 	   1,    1, 	  -1,   -7
+.2byte   -7,  -13, 	  -8,   -1, 	  -2,    0, 	   0,   -7
+.2byte  -15,   -7, 	  -9,   -1, 	  -1,    1, 	  -3,   -8
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte    0,  -12, 	  -5,    0, 	   4,    0, 	   0,  -10
+.2byte    0,  -12, 	  -4,    0, 	   5,    0, 	   0,  -10
+.2byte    0,   -4, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+.2byte    7,  -13, 	  10,   -1, 	  -1,    1, 	   1,   -7
+.2byte    7,  -13, 	   8,   -1, 	   2,    0, 	   0,   -7
+.2byte   15,   -7, 	   9,   -1, 	   1,    1, 	   3,   -8
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte   11,  -16, 	   9,   -2, 	   4,    0, 	   0,   -7
+.2byte   11,  -16, 	   3,   -3, 	   9,   -1, 	   1,   -7
+.2byte   16,  -11, 	   9,   -3, 	   6,   -1, 	   0,   -8
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte    8,  -17, 	   2,   -8, 	   6,   -3, 	  -1,   -7
+.2byte    8,  -17, 	   0,   -6, 	   8,   -5, 	   0,   -7
+.2byte   13,  -15, 	   1,   -8, 	   8,   -5, 	   0,   -9
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte    0,  -18, 	   6,   -7, 	  -7,   -4, 	   0,   -7
+.2byte    0,  -18, 	   6,   -4, 	  -6,   -7, 	   0,   -7
+.2byte    0,  -17, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -17, 	  -2,   -8, 	  -6,   -3, 	   1,   -7
+.2byte   -8,  -17, 	   0,   -6, 	  -8,   -5, 	   0,   -7
+.2byte  -13,  -15, 	  -1,   -8, 	  -8,   -5, 	   0,   -9
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte  -11,  -16, 	  -9,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -11,  -16, 	  -3,   -3, 	  -9,   -1, 	  -1,   -7
+.2byte  -16,  -11, 	  -9,   -3, 	  -6,   -1, 	   0,   -8
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -7,  -13, 	 -10,   -1, 	   1,    1, 	  -1,   -7
+.2byte   -7,  -13, 	  -8,   -1, 	  -2,    0, 	   0,   -7
+.2byte  -15,   -7, 	  -9,   -1, 	  -1,    1, 	  -3,   -8
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte   -4,  -26, 	 -11,   -7, 	  -5,   -5, 	   0,   -9
+.2byte    0,   -4, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -2,  -29, 	  13,  -13, 	   9,   -9, 	  -1,  -11
+.2byte   14,   -6, 	   8,    0, 	   0,    2, 	   2,   -7
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte   -7,  -26, 	   4,  -18, 	   8,  -12, 	  -3,  -10
+.2byte   16,  -11, 	   9,   -3, 	   6,   -1, 	   0,   -8
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte   -6,  -26, 	  -1,  -19, 	   8,  -16, 	  -1,  -10
+.2byte   13,  -15, 	   1,   -8, 	   8,   -5, 	   0,   -9
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte    2,  -25, 	   9,  -17, 	  -3,  -19, 	   0,   -8
+.2byte    0,  -17, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte    6,  -26, 	   1,  -19, 	  -8,  -16, 	   1,  -10
+.2byte  -13,  -15, 	  -1,   -8, 	  -8,   -5, 	   0,   -9
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte    7,  -26, 	  -4,  -18, 	  -8,  -12, 	   3,  -10
+.2byte  -16,  -11, 	  -9,   -3, 	  -6,   -1, 	   0,   -8
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte    3,  -29, 	 -12,  -13, 	  -8,   -9, 	   2,  -11
+.2byte  -15,   -6, 	  -9,    0, 	  -1,    2, 	  -3,   -7
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte    2,  -13, 	  -4,    1, 	   4,    1, 	   1,   -7
+.2byte   -2,  -13, 	  -4,    1, 	   4,    1, 	  -1,   -7
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+.2byte    6,  -13, 	   8,   -1, 	   0,    1, 	   0,   -7
+.2byte    9,  -15, 	   8,   -1, 	   0,    1, 	   1,   -9
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte   12,  -15, 	   8,   -3, 	   6,   -1, 	  -1,   -8
+.2byte   12,  -18, 	   8,   -3, 	   6,   -1, 	  -1,   -8
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte   11,  -17, 	   0,   -8, 	   7,   -4, 	  -1,   -8
+.2byte    6,  -19, 	   0,   -7, 	   7,   -4, 	  -1,   -8
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte   -2,  -21, 	   7,   -4, 	  -7,   -4, 	   0,   -9
+.2byte    2,  -20, 	   7,   -4, 	  -7,   -4, 	   1,   -9
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte  -11,  -17, 	   0,   -8, 	  -7,   -4, 	   1,   -8
+.2byte   -6,  -19, 	   0,   -7, 	  -7,   -4, 	   1,   -8
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte  -12,  -15, 	  -8,   -3, 	  -6,   -1, 	   1,   -8
+.2byte  -12,  -18, 	  -8,   -3, 	  -6,   -1, 	   1,   -8
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -6,  -13, 	  -8,   -1, 	   0,    1, 	   0,   -7
+.2byte   -9,  -15, 	  -8,   -1, 	   0,    1, 	  -1,   -9
+.2byte   -8,  -10, 	  -8,    1, 	  -6,    1, 	   1,   -5
+.2byte   -8,  -10, 	  -8,    1, 	  -6,    1, 	   0,   -4
+.2byte    0,  -22, 	  -5,   -6, 	   5,   -6, 	   0,  -14
+.2byte    2,  -21, 	   8,   -7, 	   2,   -4, 	  -2,   -9
+.2byte    4,  -23, 	  10,  -11, 	   9,   -8, 	  -1,   -9
+.2byte    1,  -26, 	  -1,  -18, 	  10,  -16, 	   1,  -10
+.2byte    0,  -26, 	   7,  -16, 	  -7,  -16, 	   0,   -9
+.2byte   -2,  -26, 	   0,  -18, 	 -11,  -16, 	  -2,  -10
+.2byte   -5,  -23, 	 -11,  -11, 	 -10,   -8, 	   0,   -9
+.2byte   -3,  -21, 	  -9,   -7, 	  -3,   -4, 	   1,   -9
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte    2,  -13, 	  -4,    1, 	   4,    1, 	   1,   -7
+.2byte   -2,  -13, 	  -4,    1, 	   4,    1, 	  -1,   -7
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+.2byte    6,  -13, 	   8,   -1, 	   0,    1, 	   0,   -7
+.2byte    9,  -15, 	   8,   -1, 	   0,    1, 	   1,   -9
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte   12,  -15, 	   8,   -3, 	   6,   -1, 	  -1,   -8
+.2byte   12,  -18, 	   8,   -3, 	   6,   -1, 	  -1,   -8
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte   11,  -17, 	   0,   -8, 	   7,   -4, 	  -1,   -8
+.2byte    6,  -19, 	   0,   -7, 	   7,   -4, 	  -1,   -8
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte   -2,  -21, 	   7,   -4, 	  -7,   -4, 	   0,   -9
+.2byte    2,  -20, 	   7,   -4, 	  -7,   -4, 	   1,   -9
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte  -11,  -17, 	   0,   -8, 	  -7,   -4, 	   1,   -8
+.2byte   -6,  -19, 	   0,   -7, 	  -7,   -4, 	   1,   -8
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte  -12,  -15, 	  -8,   -3, 	  -6,   -1, 	   1,   -8
+.2byte  -12,  -18, 	  -8,   -3, 	  -6,   -1, 	   1,   -8
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -6,  -13, 	  -8,   -1, 	   0,    1, 	   0,   -7
+.2byte   -9,  -15, 	  -8,   -1, 	   0,    1, 	  -1,   -9
+.2byte    0,   -4, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte  -15,   -6, 	  -9,    0, 	  -1,    2, 	  -3,   -7
+.2byte  -16,  -10, 	  -9,   -2, 	  -6,    0, 	   0,   -7
+.2byte  -13,  -14, 	  -1,   -7, 	  -8,   -4, 	   0,   -8
+.2byte    0,  -16, 	   7,   -3, 	  -7,   -3, 	   0,   -7
+.2byte   13,  -14, 	   1,   -7, 	   8,   -4, 	   0,   -8
+.2byte   16,  -10, 	   9,   -2, 	   6,    0, 	   0,   -7
+.2byte   14,   -6, 	   8,    0, 	   0,    2, 	   2,   -7
+.2byte   -4,  -26, 	 -11,   -7, 	  -5,   -5, 	   0,   -9
+.2byte   -3,  -27, 	  12,  -11, 	   8,   -7, 	  -2,   -9
+.2byte   -5,  -25, 	   6,  -17, 	  10,  -11, 	  -1,   -9
+.2byte   -6,  -26, 	  -1,  -19, 	   8,  -16, 	  -1,  -10
+.2byte    2,  -25, 	   9,  -17, 	  -3,  -19, 	   0,   -8
+.2byte    6,  -26, 	   1,  -19, 	  -8,  -16, 	   1,  -10
+.2byte    5,  -25, 	  -6,  -17, 	 -10,  -11, 	   1,   -9
+.2byte    3,  -27, 	 -12,  -11, 	  -8,   -7, 	   2,   -9
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte   -3,  -26, 	 -10,   -7, 	  -4,   -5, 	   1,   -9
+.2byte    0,   -4, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+.2byte   -1,  -29, 	  14,  -13, 	  10,   -9, 	   0,  -11
+.2byte   15,   -6, 	   9,    0, 	   1,    2, 	   3,   -7
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte   -7,  -26, 	   4,  -18, 	   8,  -12, 	  -3,  -10
+.2byte   16,  -11, 	   9,   -3, 	   6,   -1, 	   0,   -8
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte   -6,  -26, 	  -1,  -19, 	   8,  -16, 	  -1,  -10
+.2byte   13,  -15, 	   1,   -8, 	   8,   -5, 	   0,   -9
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte    2,  -25, 	   9,  -17, 	  -3,  -19, 	   0,   -8
+.2byte    0,  -17, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte    6,  -26, 	   1,  -19, 	  -8,  -16, 	   1,  -10
+.2byte  -13,  -15, 	  -1,   -8, 	  -8,   -5, 	   0,   -9
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte    7,  -26, 	  -4,  -18, 	  -8,  -12, 	   3,  -10
+.2byte  -16,  -11, 	  -9,   -3, 	  -6,   -1, 	   0,   -8
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte    3,  -29, 	 -12,  -13, 	  -8,   -9, 	   2,  -11
+.2byte  -15,   -6, 	  -9,    0, 	  -1,    2, 	  -3,   -7
+.2byte    0,   -4, 	  -5,    1, 	   5,    1, 	   0,   -7
+.2byte  -15,   -6, 	  -9,    0, 	  -1,    2, 	  -3,   -7
+.2byte  -16,  -10, 	  -9,   -2, 	  -6,    0, 	   0,   -7
+.2byte  -13,  -14, 	  -1,   -7, 	  -8,   -4, 	   0,   -8
+.2byte    0,  -16, 	   7,   -3, 	  -7,   -3, 	   0,   -7
+.2byte   13,  -14, 	   1,   -7, 	   8,   -4, 	   0,   -8
+.2byte   16,  -10, 	   9,   -2, 	   6,    0, 	   0,   -7
+.2byte   14,   -6, 	   8,    0, 	   0,    2, 	   2,   -7
+.2byte    0,  -13, 	  -4,    1, 	   4,    1, 	   0,  -11
+.2byte   -7,  -14, 	  -8,   -1, 	   0,    1, 	   0,   -8
+.2byte  -11,  -17, 	  -8,   -3, 	  -6,   -1, 	   0,   -8
+.2byte   -8,  -18, 	   0,   -7, 	  -7,   -4, 	   0,   -8
+.2byte    0,  -19, 	   7,   -4, 	  -7,   -4, 	   0,   -8
+.2byte    8,  -18, 	   0,   -7, 	   7,   -4, 	   0,   -8
+.2byte   11,  -17, 	   8,   -3, 	   6,   -1, 	   0,   -8
+.2byte    7,  -14, 	   8,   -1, 	   0,    1, 	   0,   -8
+sMeganiumAnimTable1:
+.4byte sMeganiumAnims_1_1
+.4byte sMeganiumAnims_1_2
+.4byte sMeganiumAnims_1_3
+.4byte sMeganiumAnims_1_4
+.4byte sMeganiumAnims_1_5
+.4byte sMeganiumAnims_1_6
+.4byte sMeganiumAnims_1_7
+.4byte sMeganiumAnims_1_8
+sMeganiumAnimTable2:
+.4byte sMeganiumAnims_2_1
+.4byte sMeganiumAnims_2_2
+.4byte sMeganiumAnims_2_3
+.4byte sMeganiumAnims_2_4
+.4byte sMeganiumAnims_2_5
+.4byte sMeganiumAnims_2_6
+.4byte sMeganiumAnims_2_7
+.4byte sMeganiumAnims_2_8
+sMeganiumAnimTable3:
+.4byte sMeganiumAnims_3_1
+.4byte sMeganiumAnims_3_2
+.4byte sMeganiumAnims_3_3
+.4byte sMeganiumAnims_3_4
+.4byte sMeganiumAnims_3_5
+.4byte sMeganiumAnims_3_6
+.4byte sMeganiumAnims_3_7
+.4byte sMeganiumAnims_3_8
+sMeganiumAnimTable4:
+.4byte sMeganiumAnims_4_1
+.4byte sMeganiumAnims_4_2
+.4byte sMeganiumAnims_4_3
+.4byte sMeganiumAnims_4_4
+.4byte sMeganiumAnims_4_5
+.4byte sMeganiumAnims_4_6
+.4byte sMeganiumAnims_4_7
+.4byte sMeganiumAnims_4_8
+sMeganiumAnimTable5:
+.4byte sMeganiumAnims_5_1
+.4byte sMeganiumAnims_5_2
+.4byte sMeganiumAnims_5_3
+.4byte sMeganiumAnims_5_4
+.4byte sMeganiumAnims_5_5
+.4byte sMeganiumAnims_5_6
+.4byte sMeganiumAnims_5_7
+.4byte sMeganiumAnims_5_8
+sMeganiumAnimTable6:
+.4byte sMeganiumAnims_6_1
+.4byte sMeganiumAnims_6_1
+.4byte sMeganiumAnims_6_1
+.4byte sMeganiumAnims_6_1
+.4byte sMeganiumAnims_6_1
+.4byte sMeganiumAnims_6_1
+.4byte sMeganiumAnims_6_1
+.4byte sMeganiumAnims_6_1
+sMeganiumAnimTable7:
+.4byte sMeganiumAnims_7_1
+.4byte sMeganiumAnims_7_2
+.4byte sMeganiumAnims_7_3
+.4byte sMeganiumAnims_7_4
+.4byte sMeganiumAnims_7_5
+.4byte sMeganiumAnims_7_6
+.4byte sMeganiumAnims_7_7
+.4byte sMeganiumAnims_7_8
+sMeganiumAnimTable8:
+.4byte sMeganiumAnims_8_1
+.4byte sMeganiumAnims_8_2
+.4byte sMeganiumAnims_8_3
+.4byte sMeganiumAnims_8_4
+.4byte sMeganiumAnims_8_5
+.4byte sMeganiumAnims_8_6
+.4byte sMeganiumAnims_8_7
+.4byte sMeganiumAnims_8_8
+sMeganiumAnimTable9:
+.4byte sMeganiumAnims_9_1
+.4byte sMeganiumAnims_9_2
+.4byte sMeganiumAnims_9_3
+.4byte sMeganiumAnims_9_4
+.4byte sMeganiumAnims_9_5
+.4byte sMeganiumAnims_9_6
+.4byte sMeganiumAnims_9_7
+.4byte sMeganiumAnims_9_8
+sMeganiumAnimTable10:
+.4byte sMeganiumAnims_10_1
+.4byte sMeganiumAnims_10_2
+.4byte sMeganiumAnims_10_3
+.4byte sMeganiumAnims_10_4
+.4byte sMeganiumAnims_10_5
+.4byte sMeganiumAnims_10_6
+.4byte sMeganiumAnims_10_7
+.4byte sMeganiumAnims_10_8
+sMeganiumAnimTable11:
+.4byte sMeganiumAnims_11_1
+.4byte sMeganiumAnims_11_2
+.4byte sMeganiumAnims_11_3
+.4byte sMeganiumAnims_11_4
+.4byte sMeganiumAnims_11_5
+.4byte sMeganiumAnims_11_6
+.4byte sMeganiumAnims_11_7
+.4byte sMeganiumAnims_11_8
+sMeganiumAnimTable12:
+.4byte sMeganiumAnims_12_1
+.4byte sMeganiumAnims_12_2
+.4byte sMeganiumAnims_12_3
+.4byte sMeganiumAnims_12_4
+.4byte sMeganiumAnims_12_5
+.4byte sMeganiumAnims_12_6
+.4byte sMeganiumAnims_12_7
+.4byte sMeganiumAnims_12_8
+sMeganiumAnimTable13:
+.4byte sMeganiumAnims_13_1
+.4byte sMeganiumAnims_13_2
+.4byte sMeganiumAnims_13_3
+.4byte sMeganiumAnims_13_4
+.4byte sMeganiumAnims_13_5
+.4byte sMeganiumAnims_13_6
+.4byte sMeganiumAnims_13_7
+.4byte sMeganiumAnims_13_8
+sAxAnimationsMeganium:
+.4byte sMeganiumAnimTable1
+.4byte sMeganiumAnimTable2
+.4byte sMeganiumAnimTable3
+.4byte sMeganiumAnimTable4
+.4byte sMeganiumAnimTable5
+.4byte sMeganiumAnimTable6
+.4byte sMeganiumAnimTable7
+.4byte sMeganiumAnimTable8
+.4byte sMeganiumAnimTable9
+.4byte sMeganiumAnimTable10
+.4byte sMeganiumAnimTable11
+.4byte sMeganiumAnimTable12
+.4byte sMeganiumAnimTable13
+sAxSpritesMeganium:
+.4byte sMeganiumSprites1
+.4byte sMeganiumSprites2
+.4byte sMeganiumSprites3
+.4byte sMeganiumSprites4
+.4byte sMeganiumSprites5
+.4byte sMeganiumSprites6
+.4byte sMeganiumSprites7
+.4byte sMeganiumSprites8
+.4byte sMeganiumSprites9
+.4byte sMeganiumSprites10
+.4byte sMeganiumSprites11
+.4byte sMeganiumSprites12
+.4byte sMeganiumSprites13
+.4byte sMeganiumSprites14
+.4byte sMeganiumSprites15
+.4byte sMeganiumSprites16
+.4byte sMeganiumSprites17
+.4byte sMeganiumSprites18
+.4byte sMeganiumSprites19
+.4byte sMeganiumSprites20
+.4byte sMeganiumSprites21
+.4byte sMeganiumSprites22
+.4byte sMeganiumSprites23
+.4byte sMeganiumSprites24
+.4byte sMeganiumSprites25
+.4byte sMeganiumSprites26
+.4byte sMeganiumSprites27
+.4byte sMeganiumSprites28
+.4byte sMeganiumSprites29
+.4byte sMeganiumSprites30
+.4byte sMeganiumSprites31
+.4byte sMeganiumSprites32
+.4byte sMeganiumSprites33
+.4byte sMeganiumSprites34
+.4byte sMeganiumSprites35
+.4byte sMeganiumSprites36
+.4byte sMeganiumSprites37
+.4byte sMeganiumSprites38
+.4byte sMeganiumSprites39
+.4byte sMeganiumSprites40
+.4byte sMeganiumSprites41
+.4byte sMeganiumSprites42
+.4byte sMeganiumSprites43
+.4byte sMeganiumSprites44
+.4byte sMeganiumSprites45
+.4byte sMeganiumSprites46
+.4byte sMeganiumSprites47
+sAxMainMeganium:
+ax_main sAxPosesMeganium, sAxAnimationsMeganium, 13, sAxSpritesMeganium, sAxPositionsMeganium

--- a/data/ax/meowth.inc
+++ b/data/ax/meowth.inc
@@ -1,0 +1,4207 @@
+.global gAxMeowth
+gAxMeowth:
+ax_siro sAxMainMeowth
+sMeowthPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose2:
+ax_pose 1, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose3:
+ax_pose 2, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose4:
+ax_pose 3, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose5:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose6:
+ax_pose 5, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose7:
+ax_pose 6, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose8:
+ax_pose 7, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose9:
+ax_pose 8, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sMeowthPose10:
+ax_pose 9, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose11:
+ax_pose 10, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose12:
+ax_pose 11, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose16:
+ax_pose 9, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose17:
+ax_pose 10, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose18:
+ax_pose 11, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose19:
+ax_pose 6, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose20:
+ax_pose 7, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose21:
+ax_pose 8, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sMeowthPose22:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose24:
+ax_pose 5, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose26:
+ax_pose 1, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose27:
+ax_pose 2, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose28:
+ax_pose 3, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose29:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose30:
+ax_pose 5, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose31:
+ax_pose 6, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose32:
+ax_pose 7, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose33:
+ax_pose 8, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sMeowthPose34:
+ax_pose 9, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose35:
+ax_pose 10, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose36:
+ax_pose 11, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose40:
+ax_pose 9, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose41:
+ax_pose 10, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose42:
+ax_pose 11, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose43:
+ax_pose 6, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose44:
+ax_pose 7, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose45:
+ax_pose 8, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sMeowthPose46:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose47:
+ax_pose 4, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose48:
+ax_pose 5, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose49:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose50:
+ax_pose 15, 0x01eb, 0x80f4, 0x4c00
+ax_pose 16, 0x01eb, 0x80f4, 0x4c10
+ax_pose_terminator
+sMeowthPose51:
+ax_pose 16, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose52:
+ax_pose 16, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose53:
+ax_pose 5, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose54:
+ax_pose 17, 0x81eb, 0x90fe, 0x4c00
+ax_pose 18, 0x01eb, 0x90ec, 0x4c08
+ax_pose_terminator
+sMeowthPose55:
+ax_pose 18, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose56:
+ax_pose 19, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sMeowthPose57:
+ax_pose 8, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose58:
+ax_pose 20, 0x01ea, 0x90f0, 0x4c00
+ax_pose 21, 0x01ea, 0x90ed, 0x4c10
+ax_pose_terminator
+sMeowthPose59:
+ax_pose 21, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose60:
+ax_pose 22, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose61:
+ax_pose 11, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose62:
+ax_pose 23, 0x01eb, 0x90ee, 0x4c00
+ax_pose 24, 0x01eb, 0x90ee, 0x4c10
+ax_pose_terminator
+sMeowthPose63:
+ax_pose 24, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose64:
+ax_pose 25, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sMeowthPose65:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose66:
+ax_pose 26, 0x01ec, 0x80f3, 0x4c00
+ax_pose 27, 0x81e7, 0x80fd, 0x4c10
+ax_pose_terminator
+sMeowthPose67:
+ax_pose 26, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose68:
+ax_pose 28, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose69:
+ax_pose 10, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose70:
+ax_pose 23, 0x01eb, 0x80f2, 0x4c00
+ax_pose 24, 0x01eb, 0x80f2, 0x4c10
+ax_pose_terminator
+sMeowthPose71:
+ax_pose 24, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose72:
+ax_pose 25, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sMeowthPose73:
+ax_pose 7, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose74:
+ax_pose 20, 0x01ea, 0x80f0, 0x4c00
+ax_pose 21, 0x01ea, 0x80f3, 0x4c10
+ax_pose_terminator
+sMeowthPose75:
+ax_pose 21, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose76:
+ax_pose 22, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose77:
+ax_pose 5, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose78:
+ax_pose 17, 0x81eb, 0x80f2, 0x4c00
+ax_pose 18, 0x01eb, 0x80f4, 0x4c08
+ax_pose_terminator
+sMeowthPose79:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose80:
+ax_pose 19, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sMeowthPose81:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose82:
+ax_pose 29, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose83:
+ax_pose 3, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose84:
+ax_pose 30, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose85:
+ax_pose 6, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose86:
+ax_pose 31, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose87:
+ax_pose 9, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose88:
+ax_pose 32, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose89:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose90:
+ax_pose 33, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose91:
+ax_pose 9, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose92:
+ax_pose 32, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose93:
+ax_pose 6, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose94:
+ax_pose 31, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose95:
+ax_pose 3, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose96:
+ax_pose 30, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose97:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose98:
+ax_pose 34, 0x01eb, 0x80f4, 0x4c00
+ax_pose 16, 0x01eb, 0x80f4, 0x4c10
+ax_pose_terminator
+sMeowthPose99:
+ax_pose 16, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose100:
+ax_pose 34, 0x01eb, 0x90ec, 0x4c00
+ax_pose 35, 0x01eb, 0x80f4, 0x4c10
+ax_pose_terminator
+sMeowthPose101:
+ax_pose 35, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose102:
+ax_pose 5, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose103:
+ax_pose 36, 0x01eb, 0x90ec, 0x4c00
+ax_pose 18, 0x01eb, 0x90ec, 0x4c10
+ax_pose_terminator
+sMeowthPose104:
+ax_pose 18, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose105:
+ax_pose 37, 0x01eb, 0x90ec, 0x4c00
+ax_pose 19, 0x01eb, 0x90ec, 0x4c10
+ax_pose_terminator
+sMeowthPose106:
+ax_pose 19, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose107:
+ax_pose 7, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose108:
+ax_pose 38, 0x01ea, 0x90ed, 0x4c00
+ax_pose 21, 0x01ea, 0x90ed, 0x4c10
+ax_pose_terminator
+sMeowthPose109:
+ax_pose 21, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose110:
+ax_pose 39, 0x81ea, 0x90fd, 0x4c00
+ax_pose 22, 0x01ea, 0x90ed, 0x4c08
+ax_pose_terminator
+sMeowthPose111:
+ax_pose 22, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose112:
+ax_pose 10, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose113:
+ax_pose 40, 0x01eb, 0x90ee, 0x4c00
+ax_pose 24, 0x01eb, 0x90ee, 0x4c10
+ax_pose_terminator
+sMeowthPose114:
+ax_pose 24, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose115:
+ax_pose 41, 0x01eb, 0x50fe, 0x4c00
+ax_pose 25, 0x01eb, 0x90ee, 0x4c04
+ax_pose_terminator
+sMeowthPose116:
+ax_pose 25, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose117:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose118:
+ax_pose 42, 0x81ec, 0x4104, 0x4c00
+ax_pose 26, 0x01ec, 0x80f4, 0x4c04
+ax_pose_terminator
+sMeowthPose119:
+ax_pose 26, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose120:
+ax_pose 42, 0x81ec, 0x50f4, 0x4c00
+ax_pose 28, 0x01ec, 0x80f4, 0x4c04
+ax_pose_terminator
+sMeowthPose121:
+ax_pose 28, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose122:
+ax_pose 10, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose123:
+ax_pose 40, 0x01eb, 0x80f2, 0x4c00
+ax_pose 24, 0x01eb, 0x80f2, 0x4c10
+ax_pose_terminator
+sMeowthPose124:
+ax_pose 24, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose125:
+ax_pose 41, 0x01eb, 0x40f2, 0x4c00
+ax_pose 25, 0x01eb, 0x80f2, 0x4c04
+ax_pose_terminator
+sMeowthPose126:
+ax_pose 25, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose127:
+ax_pose 6, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose128:
+ax_pose 38, 0x01ea, 0x80f3, 0x4c00
+ax_pose 21, 0x01ea, 0x80f3, 0x4c10
+ax_pose_terminator
+sMeowthPose129:
+ax_pose 21, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose130:
+ax_pose 39, 0x81ea, 0x80f3, 0x4c00
+ax_pose 22, 0x01ea, 0x80f3, 0x4c08
+ax_pose_terminator
+sMeowthPose131:
+ax_pose 22, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose132:
+ax_pose 5, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose133:
+ax_pose 36, 0x01eb, 0x80f4, 0x4c00
+ax_pose 18, 0x01eb, 0x80f4, 0x4c10
+ax_pose_terminator
+sMeowthPose134:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose135:
+ax_pose 37, 0x01eb, 0x80f4, 0x4c00
+ax_pose 19, 0x01eb, 0x80f4, 0x4c10
+ax_pose_terminator
+sMeowthPose136:
+ax_pose 19, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose137:
+ax_pose 43, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose138:
+ax_pose 44, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose139:
+ax_pose 45, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose140:
+ax_pose 46, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMeowthPose141:
+ax_pose 47, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose142:
+ax_pose 48, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sMeowthPose143:
+ax_pose 49, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose144:
+ax_pose 48, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sMeowthPose145:
+ax_pose 47, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose146:
+ax_pose 46, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sMeowthPose147:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose148:
+ax_pose 1, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose149:
+ax_pose 2, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose150:
+ax_pose 3, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose151:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose152:
+ax_pose 5, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose153:
+ax_pose 6, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose154:
+ax_pose 7, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose155:
+ax_pose 8, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sMeowthPose156:
+ax_pose 9, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose157:
+ax_pose 10, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose158:
+ax_pose 11, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose159:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose160:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose161:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose162:
+ax_pose 9, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose163:
+ax_pose 10, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose164:
+ax_pose 11, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose165:
+ax_pose 6, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose166:
+ax_pose 7, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose167:
+ax_pose 8, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sMeowthPose168:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose169:
+ax_pose 4, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose170:
+ax_pose 5, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose171:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose172:
+ax_pose 3, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose173:
+ax_pose 6, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose174:
+ax_pose 9, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose175:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose176:
+ax_pose 9, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose177:
+ax_pose 6, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose178:
+ax_pose 3, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose179:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose180:
+ax_pose 3, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose181:
+ax_pose 6, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose182:
+ax_pose 9, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose183:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose184:
+ax_pose 9, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose185:
+ax_pose 6, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose186:
+ax_pose 3, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose187:
+ax_pose 29, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose188:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose189:
+ax_pose 30, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose190:
+ax_pose 3, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose191:
+ax_pose 31, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose192:
+ax_pose 6, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose193:
+ax_pose 32, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose194:
+ax_pose 9, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose195:
+ax_pose 33, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose196:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose197:
+ax_pose 32, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose198:
+ax_pose 9, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose199:
+ax_pose 31, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose200:
+ax_pose 6, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose201:
+ax_pose 30, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose202:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose203:
+ax_pose 29, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose204:
+ax_pose 30, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose205:
+ax_pose 31, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose206:
+ax_pose 32, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sMeowthPose207:
+ax_pose 33, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose208:
+ax_pose 32, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sMeowthPose209:
+ax_pose 31, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose210:
+ax_pose 30, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose211:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose212:
+ax_pose 3, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose213:
+ax_pose 6, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose214:
+ax_pose 9, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sMeowthPose215:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose216:
+ax_pose 9, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose217:
+ax_pose 6, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose218:
+ax_pose 3, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sMeowthPose219:
+ax_pose 50, 0x01ed, 0x80ef, 0x4c00
+ax_pose_terminator
+sMeowthPose220:
+ax_pose 51, 0x01ed, 0x80ef, 0x4c00
+ax_pose_terminator
+sMeowthPose221:
+ax_pose 50, 0x01ed, 0x90f1, 0x4c00
+ax_pose_terminator
+sMeowthPose222:
+ax_pose 51, 0x01ed, 0x90f1, 0x4c00
+ax_pose_terminator
+sMeowthPose223:
+ax_pose 50, 0x01ed, 0x80ef, 0x4c00
+ax_pose_terminator
+sMeowthPose224:
+ax_pose 52, 0x01ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sMeowthPose225:
+ax_pose 53, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose226:
+ax_pose 54, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose227:
+ax_pose 6, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose228:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose229:
+ax_pose 55, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose230:
+ax_pose 56, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose231:
+ax_pose 57, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose232:
+ax_pose 58, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose233:
+ax_pose 59, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose234:
+ax_pose 60, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose235:
+ax_pose 61, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose236:
+ax_pose 62, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose237:
+ax_pose 63, 0x01ec, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose238:
+ax_pose 63, 0x01ec, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose239:
+ax_pose 64, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose240:
+ax_pose 65, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose241:
+ax_pose 66, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose242:
+ax_pose 6, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose243:
+ax_pose 67, 0x01ec, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose244:
+ax_pose 68, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose245:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose246:
+ax_pose 69, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose247:
+ax_pose 70, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose248:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose249:
+ax_pose 58, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose250:
+ax_pose 71, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose251:
+ax_pose 6, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose252:
+ax_pose 72, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sMeowthPose253:
+ax_pose 6, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sMeowthPose254:
+ax_pose 72, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sMeowthPose255:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose256:
+ax_pose 73, 0x01f0, 0x80f4, 0x4c00
+ax_pose_terminator
+sMeowthPose257:
+ax_pose 74, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose258:
+ax_pose 75, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose259:
+ax_pose 76, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose260:
+ax_pose 77, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose261:
+ax_pose 78, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sMeowthPose262:
+ax_pose 74, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose263:
+ax_pose 75, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose264:
+ax_pose 76, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose265:
+ax_pose 77, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose266:
+ax_pose 78, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sMeowthPose267:
+ax_pose 79, 0x81ec, 0x90f8, 0x4c00
+ax_pose_terminator
+sMeowthPose268:
+ax_pose 50, 0x01ed, 0x80ef, 0x4c00
+ax_pose_terminator
+sMeowthPose269:
+ax_pose 51, 0x01ed, 0x80ef, 0x4c00
+ax_pose_terminator
+sMeowthPose270:
+ax_pose 50, 0x01ed, 0x90f1, 0x4c00
+ax_pose_terminator
+sMeowthPose271:
+ax_pose 51, 0x01ed, 0x90f1, 0x4c00
+ax_pose_terminator
+sMeowthPose272:
+ax_pose 50, 0x01ed, 0x80ef, 0x4c00
+ax_pose_terminator
+sMeowthPose273:
+ax_pose 51, 0x01ed, 0x80ef, 0x4c00
+ax_pose_terminator
+sMeowthPose274:
+ax_pose 50, 0x01ed, 0x90f1, 0x4c00
+ax_pose_terminator
+sMeowthPose275:
+ax_pose 51, 0x01ed, 0x90f1, 0x4c00
+ax_pose_terminator
+.align 2
+sMeowthAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 1, 0, 1, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, -1, 1, -1, 1,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 1, -1, 1, -1,
+ax_anim_terminator
+sMeowthAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 1, 0, 1, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 1, 0, 1, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 1, 1, 1, 1,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sMeowthAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMeowthAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sMeowthAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sMeowthAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -2, 0, -2,
+ax_anim 1, 2, 34, 4, -7, 4, -7,
+ax_anim 1, 0, 35, 10, -14, 10, -14,
+ax_anim 2, 0, 34, 18, -24, 18, -24,
+ax_anim 2, 1, 34, 19, -23, 19, -23,
+ax_anim 2, 0, 34, 18, -24, 18, -24,
+ax_anim 2, 0, 34, 19, -23, 19, -23,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMeowthAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -5, 0, -5,
+ax_anim 1, 0, 38, 0, -13, 0, -13,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 1, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 0, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMeowthAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -2, 0, -2,
+ax_anim 1, 2, 40, -4, -7, -4, -7,
+ax_anim 1, 0, 41, -10, -14, -10, -14,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 1, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 0, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMeowthAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sMeowthAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMeowthAnims_3_1:
+ax_anim 8, 0, 51, 0, -2, 0, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 0, 3, 0, 3,
+ax_anim 1, 0, 51, 0, 7, 0, 7,
+ax_anim 2, 0, 49, 0, 15, 0, 15,
+ax_anim 2, 1, 50, 1, 15, 1, 15,
+ax_anim 2, 0, 50, 0, 15, 0, 15,
+ax_anim 2, 0, 50, 1, 15, 1, 15,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim_terminator
+sMeowthAnims_3_2:
+ax_anim 8, 0, 55, -2, -2, -2, -2,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 4, 4, 4,
+ax_anim 1, 0, 55, 7, 7, 7, 7,
+ax_anim 2, 0, 53, 16, 16, 16, 16,
+ax_anim 2, 1, 54, 15, 17, 15, 17,
+ax_anim 2, 0, 54, 16, 16, 16, 16,
+ax_anim 2, 0, 54, 15, 17, 15, 17,
+ax_anim 2, 0, 52, 8, 8, 8, 8,
+ax_anim_terminator
+sMeowthAnims_3_3:
+ax_anim 8, 0, 59, -2, 0, -2, 0,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 4, 0, 4, 0,
+ax_anim 1, 0, 59, 9, 0, 9, 0,
+ax_anim 2, 0, 57, 16, 0, 16, 0,
+ax_anim 2, 1, 58, 16, 1, 16, 1,
+ax_anim 2, 0, 58, 16, 0, 16, 0,
+ax_anim 2, 0, 58, 16, 1, 16, 1,
+ax_anim 2, 0, 56, 8, 0, 8, 0,
+ax_anim_terminator
+sMeowthAnims_3_4:
+ax_anim 8, 0, 63, -2, 2, -2, 2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, -4, 4, -4,
+ax_anim 1, 0, 63, 9, -9, 9, -9,
+ax_anim 2, 0, 61, 17, -18, 17, -18,
+ax_anim 2, 1, 62, 18, -18, 18, -18,
+ax_anim 2, 0, 62, 17, -19, 17, -19,
+ax_anim 2, 0, 62, 18, -18, 18, -18,
+ax_anim 2, 0, 60, 8, -8, 8, -8,
+ax_anim_terminator
+sMeowthAnims_3_5:
+ax_anim 8, 0, 67, 0, 2, 0, 2,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 0, -3, 0, -3,
+ax_anim 1, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 65, 0, -14, 0, -14,
+ax_anim 2, 1, 66, -1, -14, -1, -14,
+ax_anim 2, 0, 66, 0, -14, 0, -14,
+ax_anim 2, 0, 66, -1, -14, -1, -14,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim_terminator
+sMeowthAnims_3_6:
+ax_anim 8, 0, 71, 2, 2, 2, 2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, -4, -4, -4,
+ax_anim 1, 0, 71, -9, -9, -9, -9,
+ax_anim 2, 0, 69, -17, -18, -17, -18,
+ax_anim 2, 1, 70, -18, -18, -18, -18,
+ax_anim 2, 0, 70, -17, -19, -17, -19,
+ax_anim 2, 0, 70, -18, -18, -18, -18,
+ax_anim 2, 0, 68, -8, -8, -8, -8,
+ax_anim_terminator
+sMeowthAnims_3_7:
+ax_anim 8, 0, 75, 2, 0, 2, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 2, 75, -4, 0, -4, 0,
+ax_anim 1, 0, 75, -9, 0, -9, 0,
+ax_anim 2, 0, 73, -16, 0, -16, 0,
+ax_anim 2, 1, 74, -16, 1, -16, 1,
+ax_anim 2, 0, 74, -16, 0, -16, 0,
+ax_anim 2, 0, 74, -16, 1, -16, 1,
+ax_anim 2, 0, 72, -8, 0, -8, 0,
+ax_anim_terminator
+sMeowthAnims_3_8:
+ax_anim 8, 0, 79, 2, -2, 2, -2,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 2, 79, -4, 4, -4, 4,
+ax_anim 1, 0, 79, -7, 7, -7, 7,
+ax_anim 2, 0, 77, -16, 16, -16, 16,
+ax_anim 2, 1, 78, -15, 17, -15, 17,
+ax_anim 2, 0, 78, -16, 16, -16, 16,
+ax_anim 2, 0, 78, -15, 17, -15, 17,
+ax_anim 2, 0, 76, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sMeowthAnims_4_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 3, 2, 80, 0, -4, 0, 0,
+ax_anim 3, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_4_2:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 3, 2, 82, 0, -4, 0, 0,
+ax_anim 3, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_4_3:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 3, 2, 84, 0, -4, 0, 0,
+ax_anim 3, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_4_4:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 3, 2, 86, 0, -4, 0, 0,
+ax_anim 3, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_4_5:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 3, 2, 88, 0, -4, 0, 0,
+ax_anim 3, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_4_6:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 3, 2, 90, 0, -4, 0, 0,
+ax_anim 3, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_4_7:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 3, 2, 92, 0, -4, 0, 0,
+ax_anim 3, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_4_8:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 3, 2, 94, 0, -4, 0, 0,
+ax_anim 3, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_5_1:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 4, 0, 4,
+ax_anim 2, 0, 97, 0, 15, 0, 15,
+ax_anim 2, 1, 98, 1, 16, 1, 16,
+ax_anim 2, 0, 98, 1, 15, 1, 15,
+ax_anim 4, 0, 98, 1, 14, 1, 14,
+ax_anim 2, 0, 99, 0, 16, 0, 16,
+ax_anim 4, 0, 100, -1, 17, -1, 17,
+ax_anim 2, 0, 97, 0, 15, 0, 15,
+ax_anim 2, 0, 98, 1, 16, 1, 16,
+ax_anim 2, 0, 99, 0, 15, 0, 15,
+ax_anim 2, 0, 100, -1, 16, -1, 16,
+ax_anim 2, 0, 96, 0, 6, 0, 6,
+ax_anim_terminator
+sMeowthAnims_5_2:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 4, 4, 4, 4,
+ax_anim 2, 0, 102, 15, 15, 15, 15,
+ax_anim 2, 1, 103, 16, 16, 16, 16,
+ax_anim 2, 0, 103, 16, 17, 16, 17,
+ax_anim 4, 0, 103, 15, 16, 15, 16,
+ax_anim 2, 0, 104, 15, 16, 15, 16,
+ax_anim 4, 0, 105, 16, 16, 16, 16,
+ax_anim 2, 0, 102, 16, 16, 16, 16,
+ax_anim 2, 0, 103, 15, 16, 15, 16,
+ax_anim 2, 0, 104, 15, 15, 15, 15,
+ax_anim 2, 0, 105, 17, 16, 17, 16,
+ax_anim 2, 0, 101, 6, 6, 6, 6,
+ax_anim_terminator
+sMeowthAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 4, 0, 4, 0,
+ax_anim 2, 0, 107, 15, 0, 15, 0,
+ax_anim 2, 1, 108, 16, 1, 16, 0,
+ax_anim 2, 0, 108, 16, 1, 16, 0,
+ax_anim 4, 0, 108, 15, 1, 15, 0,
+ax_anim 2, 0, 109, 15, 0, 15, 0,
+ax_anim 4, 0, 110, 16, -1, 16, 0,
+ax_anim 2, 0, 107, 16, 0, 16, 0,
+ax_anim 2, 0, 108, 16, 1, 15, 0,
+ax_anim 2, 0, 109, 15, 0, 15, 0,
+ax_anim 2, 0, 110, 16, -1, 16, -1,
+ax_anim 2, 0, 106, 6, 0, 6, 0,
+ax_anim_terminator
+sMeowthAnims_5_4:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 4, -4, 4, -4,
+ax_anim 2, 0, 112, 17, -17, 15, -15,
+ax_anim 2, 1, 113, 19, -18, 17, -16,
+ax_anim 2, 0, 113, 19, -18, 17, -16,
+ax_anim 4, 0, 113, 19, -17, 17, -15,
+ax_anim 2, 0, 114, 17, -18, 15, -16,
+ax_anim 4, 0, 115, 16, -18, 14, -16,
+ax_anim 2, 0, 112, 18, -18, 16, -16,
+ax_anim 2, 0, 113, 19, -18, 17, -16,
+ax_anim 2, 0, 114, 17, -17, 15, -15,
+ax_anim 2, 0, 115, 16, -17, 14, -15,
+ax_anim 2, 0, 111, 6, -6, 6, -6,
+ax_anim_terminator
+sMeowthAnims_5_5:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, -4, 0, -4,
+ax_anim 2, 0, 117, 0, -15, 0, -15,
+ax_anim 2, 1, 118, -1, -16, -1, -16,
+ax_anim 2, 0, 118, -1, -15, -1, -15,
+ax_anim 4, 0, 118, -1, -14, -1, -14,
+ax_anim 2, 0, 119, 0, -16, 0, -16,
+ax_anim 4, 0, 120, 1, -17, 1, -17,
+ax_anim 2, 0, 117, 0, -15, 0, -15,
+ax_anim 2, 0, 118, -1, -16, -1, -16,
+ax_anim 2, 0, 119, 0, -15, 0, -15,
+ax_anim 2, 0, 120, 1, -16, 1, -16,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim_terminator
+sMeowthAnims_5_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 125, -4, -4, -4, -4,
+ax_anim 2, 0, 122, -17, -17, -15, -15,
+ax_anim 2, 1, 123, -19, -18, -17, -16,
+ax_anim 2, 0, 123, -19, -18, -17, -16,
+ax_anim 4, 0, 123, -19, -17, -17, -15,
+ax_anim 2, 0, 124, -17, -18, -15, -16,
+ax_anim 4, 0, 125, -16, -18, -14, -16,
+ax_anim 2, 0, 122, -18, -18, -16, -16,
+ax_anim 2, 0, 123, -19, -18, -17, -16,
+ax_anim 2, 0, 124, -17, -17, -15, -15,
+ax_anim 2, 0, 125, -16, -17, -14, -15,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim_terminator
+sMeowthAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 130, -4, 0, -4, 0,
+ax_anim 2, 0, 127, -15, 0, -15, 0,
+ax_anim 2, 1, 128, -16, 1, -16, 0,
+ax_anim 2, 0, 128, -16, 1, -16, 0,
+ax_anim 4, 0, 128, -15, 1, -15, 0,
+ax_anim 2, 0, 129, -15, 0, -15, 0,
+ax_anim 4, 0, 130, -16, -1, -16, 0,
+ax_anim 2, 0, 127, -16, 0, -16, 0,
+ax_anim 2, 0, 128, -16, 1, -15, 0,
+ax_anim 2, 0, 129, -15, 0, -15, 0,
+ax_anim 2, 0, 130, -15, -1, -17, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim_terminator
+sMeowthAnims_5_8:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 135, -4, 4, -4, 4,
+ax_anim 2, 0, 132, -15, 15, -15, 15,
+ax_anim 2, 1, 133, -15, 16, -16, 16,
+ax_anim 2, 0, 133, -15, 16, -16, 17,
+ax_anim 4, 0, 133, -14, 15, -15, 16,
+ax_anim 2, 0, 134, -16, 16, -15, 16,
+ax_anim 4, 0, 135, -17, 16, -16, 16,
+ax_anim 2, 0, 132, -16, 16, -16, 16,
+ax_anim 2, 0, 133, -15, 16, -15, 16,
+ax_anim 2, 0, 134, -15, 15, -15, 15,
+ax_anim 2, 0, 135, -17, 15, -17, 16,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMeowthAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sMeowthAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sMeowthAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sMeowthAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sMeowthAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sMeowthAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sMeowthAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sMeowthAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMeowthAnims_8_1:
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 3, 0, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 148, -2, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_8_2:
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, 2, 1, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 2, -1, 0, 0,
+ax_anim_terminator
+sMeowthAnims_8_3:
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 2, 1, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_8_4:
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 2, -2, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 157, -1, -2, 0, 0,
+ax_anim_terminator
+sMeowthAnims_8_5:
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 1, -1, 0, 0,
+ax_anim_terminator
+sMeowthAnims_8_6:
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, -2, -2, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 1, -2, 0, 0,
+ax_anim_terminator
+sMeowthAnims_8_7:
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, -2, 1, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 166, -1, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_8_8:
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, -2, 1, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 169, -2, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 19, 7, 19,
+ax_anim 3, 0, 174, 0, 22, 0, 22,
+ax_anim 2, 3, 175, -7, 19, -7, 19,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 24, 9, 24, 9,
+ax_anim 3, 0, 173, 23, 21, 23, 21,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 2, 12, 2, 12,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 19, -4, 17, -4,
+ax_anim 3, 0, 172, 23, 1, 20, 1,
+ax_anim 2, 3, 173, 19, 5, 17, 5,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -20, 11, -20,
+ax_anim 3, 0, 171, 20, -22, 20, -22,
+ax_anim 2, 3, 172, 20, -13, 20, -13,
+ax_anim 2, 0, 173, 16, -6, 16, -6,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -6, -4, -6, -4,
+ax_anim 2, 0, 176, -8, -10, -8, -10,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 8, -8, 8, -8,
+ax_anim 1, 0, 173, 6, -4, 6, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -20, -11, -20,
+ax_anim 3, 0, 177, -20, -22, -20, -22,
+ax_anim 2, 3, 176, -20, -13, -20, -13,
+ax_anim 2, 0, 175, -16, -6, -16, -6,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -19, -4, -19, -4,
+ax_anim 3, 0, 176, -23, 1, -23, 1,
+ax_anim 2, 3, 175, -19, 5, -19, 5,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -24, 9, -24, 9,
+ax_anim 3, 0, 175, -23, 21, -23, 16,
+ax_anim 2, 3, 174, -11, 21, -11, 16,
+ax_anim 2, 0, 173, -2, 12, -4, 12,
+ax_anim 1, 0, 172, 0, 7, -3, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_11_2:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_11_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_11_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_11_6:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_11_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_14_1:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_14_2:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_14_3:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_14_4:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_14_5:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_14_6:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_14_7:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_14_8:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_15_1:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_15_2:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_15_3:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_15_4:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_15_5:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_15_6:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_15_7:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_15_8:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_16_1:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_16_2:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_16_3:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_16_4:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_16_5:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_16_6:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_16_7:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_16_8:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_17_1:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_17_2:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_17_3:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_17_4:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_17_5:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_17_6:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_17_7:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sMeowthAnims_17_8:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_18_1:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_18_2:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_18_3:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_18_4:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_18_5:
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_18_6:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_18_7:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_18_8:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_19_1:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_19_2:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_19_3:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_19_4:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_19_5:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_19_6:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_19_7:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_19_8:
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_20_1:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 1, 0, 0,
+ax_anim 2, 0, 243, 1, 1, 1, 0,
+ax_anim 2, 0, 243, 0, 1, 0, 0,
+ax_anim 2, 0, 243, 1, 1, 1, 0,
+ax_anim 2, 0, 243, 0, 1, 0, 0,
+ax_anim 2, 0, 243, 1, 1, 1, 0,
+ax_anim_terminator
+sMeowthAnims_20_2:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim_terminator
+sMeowthAnims_20_3:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim_terminator
+sMeowthAnims_20_4:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim_terminator
+sMeowthAnims_20_5:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim_terminator
+sMeowthAnims_20_6:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim_terminator
+sMeowthAnims_20_7:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim_terminator
+sMeowthAnims_20_8:
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -2, 0, 0,
+ax_anim 1, 0, 242, 0, -4, 0, 0,
+ax_anim 2, 0, 243, 0, -4, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 4, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_21_1:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_21_2:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_21_3:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_21_4:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_21_5:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_21_6:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_21_7:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_21_8:
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_22_1:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_22_2:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_22_3:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_22_4:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_22_5:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_22_6:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_22_7:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_22_8:
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 30, 0, 248, 0, 0, 0, 0,
+ax_anim 34, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_23_1:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_23_2:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_23_3:
+ax_anim 10, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim 4, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_23_4:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_23_5:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_23_6:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_23_7:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_23_8:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_24_1:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_24_2:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_24_3:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_24_4:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_24_5:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_24_6:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_24_7:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_24_8:
+ax_anim 4, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_25_1:
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_25_2:
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_25_3:
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_25_4:
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_25_5:
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_25_6:
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 10, 0, 261, 0, 0, 0, 0,
+ax_anim 8, 0, 264, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_25_7:
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim 8, 0, 257, 0, 0, 0, 0,
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_25_8:
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim 8, 0, 257, 0, 0, 0, 0,
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim 10, 0, 256, 0, 0, 0, 0,
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_26_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+sMeowthAnims_26_2:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+sMeowthAnims_26_3:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+sMeowthAnims_26_4:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+sMeowthAnims_26_5:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+sMeowthAnims_26_6:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+sMeowthAnims_26_7:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+sMeowthAnims_26_8:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sMeowthAnims_27_1:
+ax_anim 12, 0, 267, 0, 0, 0, 0,
+ax_anim 12, 0, 267, 0, 0, 0, 0,
+ax_anim 16, 0, 267, -1, 0, 0, 0,
+ax_anim 12, 0, 267, 0, 0, 0, 0,
+ax_anim 12, 0, 267, 1, 0, 0, 0,
+ax_anim 16, 0, 267, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMeowthAnims_28_1:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_28_2:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_28_3:
+ax_anim 12, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_28_4:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_28_5:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_28_6:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_28_7:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthAnims_28_8:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sMeowthGfx1:
+.incbin "baserom.gba", 0x73A8A8, 0x200
+sMeowthSprites1:
+ax_sprite sMeowthGfx1, 0x200
+ax_sprite_terminator
+sMeowthGfx2:
+.incbin "baserom.gba", 0x73AAB8, 0x200
+sMeowthSprites2:
+ax_sprite sMeowthGfx2, 0x200
+ax_sprite_terminator
+sMeowthGfx3:
+.incbin "baserom.gba", 0x73ACC8, 0x200
+sMeowthSprites3:
+ax_sprite sMeowthGfx3, 0x200
+ax_sprite_terminator
+sMeowthGfx4:
+.incbin "baserom.gba", 0x73AED8, 0x200
+sMeowthSprites4:
+ax_sprite sMeowthGfx4, 0x200
+ax_sprite_terminator
+sMeowthGfx5:
+.incbin "baserom.gba", 0x73B0E8, 0x200
+sMeowthSprites5:
+ax_sprite sMeowthGfx5, 0x200
+ax_sprite_terminator
+sMeowthGfx6:
+.incbin "baserom.gba", 0x73B2F8, 0x200
+sMeowthSprites6:
+ax_sprite sMeowthGfx6, 0x200
+ax_sprite_terminator
+sMeowthGfx7:
+.incbin "baserom.gba", 0x73B508, 0x200
+sMeowthSprites7:
+ax_sprite sMeowthGfx7, 0x200
+ax_sprite_terminator
+sMeowthGfx8:
+.incbin "baserom.gba", 0x73B718, 0x200
+sMeowthSprites8:
+ax_sprite sMeowthGfx8, 0x200
+ax_sprite_terminator
+sMeowthGfx9:
+.incbin "baserom.gba", 0x73B928, 0x200
+sMeowthSprites9:
+ax_sprite sMeowthGfx9, 0x200
+ax_sprite_terminator
+sMeowthGfx10:
+.incbin "baserom.gba", 0x73BB38, 0x200
+sMeowthSprites10:
+ax_sprite sMeowthGfx10, 0x200
+ax_sprite_terminator
+sMeowthGfx11:
+.incbin "baserom.gba", 0x73BD48, 0x200
+sMeowthSprites11:
+ax_sprite sMeowthGfx11, 0x200
+ax_sprite_terminator
+sMeowthGfx12:
+.incbin "baserom.gba", 0x73BF58, 0x200
+sMeowthSprites12:
+ax_sprite sMeowthGfx12, 0x200
+ax_sprite_terminator
+sMeowthGfx13:
+.incbin "baserom.gba", 0x73C168, 0x200
+sMeowthSprites13:
+ax_sprite sMeowthGfx13, 0x200
+ax_sprite_terminator
+sMeowthGfx14:
+.incbin "baserom.gba", 0x73C378, 0x200
+sMeowthSprites14:
+ax_sprite sMeowthGfx14, 0x200
+ax_sprite_terminator
+sMeowthGfx15:
+.incbin "baserom.gba", 0x73C588, 0x200
+sMeowthSprites15:
+ax_sprite sMeowthGfx15, 0x200
+ax_sprite_terminator
+sMeowthGfx16:
+.incbin "baserom.gba", 0x73C798, 0x20
+sMeowthGfx16_1:
+.incbin "baserom.gba", 0x73C7B8, 0x20
+sMeowthGfx16_2:
+.incbin "baserom.gba", 0x73C7D8, 0x60
+sMeowthGfx16_3:
+.incbin "baserom.gba", 0x73C838, 0x40
+sMeowthSprites16:
+ax_sprite sMeowthGfx16, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx16_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx16_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMeowthGfx17:
+.incbin "baserom.gba", 0x73C8C0, 0x60
+sMeowthGfx17_1:
+.incbin "baserom.gba", 0x73C920, 0x60
+sMeowthGfx17_2:
+.incbin "baserom.gba", 0x73C980, 0x60
+sMeowthSprites17:
+ax_sprite sMeowthGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx18:
+.incbin "baserom.gba", 0x73CA18, 0x20
+sMeowthGfx18_1:
+.incbin "baserom.gba", 0x73CA38, 0x80
+sMeowthSprites18:
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx18_1, 0x80
+ax_sprite_terminator
+sMeowthGfx19:
+.incbin "baserom.gba", 0x73CAE0, 0x60
+sMeowthGfx19_1:
+.incbin "baserom.gba", 0x73CB40, 0x60
+sMeowthGfx19_2:
+.incbin "baserom.gba", 0x73CBA0, 0x60
+sMeowthSprites19:
+ax_sprite sMeowthGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx20:
+.incbin "baserom.gba", 0x73CC38, 0x60
+sMeowthGfx20_1:
+.incbin "baserom.gba", 0x73CC98, 0x60
+sMeowthGfx20_2:
+.incbin "baserom.gba", 0x73CCF8, 0x40
+sMeowthSprites20:
+ax_sprite sMeowthGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx20_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMeowthGfx21:
+.incbin "baserom.gba", 0x73CD70, 0x40
+sMeowthGfx21_1:
+.incbin "baserom.gba", 0x73CDB0, 0x20
+sMeowthGfx21_2:
+.incbin "baserom.gba", 0x73CDD0, 0x40
+sMeowthSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx21_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx21_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMeowthGfx22:
+.incbin "baserom.gba", 0x73CE50, 0x60
+sMeowthGfx22_1:
+.incbin "baserom.gba", 0x73CEB0, 0x60
+sMeowthGfx22_2:
+.incbin "baserom.gba", 0x73CF10, 0x60
+sMeowthSprites22:
+ax_sprite sMeowthGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx23:
+.incbin "baserom.gba", 0x73CFA8, 0x60
+sMeowthGfx23_1:
+.incbin "baserom.gba", 0x73D008, 0x60
+sMeowthGfx23_2:
+.incbin "baserom.gba", 0x73D068, 0x60
+sMeowthSprites23:
+ax_sprite sMeowthGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx24:
+.incbin "baserom.gba", 0x73D100, 0x20
+sMeowthGfx24_1:
+.incbin "baserom.gba", 0x73D120, 0x20
+sMeowthGfx24_2:
+.incbin "baserom.gba", 0x73D140, 0x40
+sMeowthSprites24:
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx24, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx24_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx24_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMeowthGfx25:
+.incbin "baserom.gba", 0x73D1C0, 0x60
+sMeowthGfx25_1:
+.incbin "baserom.gba", 0x73D220, 0x60
+sMeowthGfx25_2:
+.incbin "baserom.gba", 0x73D280, 0x60
+sMeowthSprites25:
+ax_sprite sMeowthGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx26:
+.incbin "baserom.gba", 0x73D318, 0x60
+sMeowthGfx26_1:
+.incbin "baserom.gba", 0x73D378, 0x60
+sMeowthGfx26_2:
+.incbin "baserom.gba", 0x73D3D8, 0x40
+sMeowthSprites26:
+ax_sprite sMeowthGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx26_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx27:
+.incbin "baserom.gba", 0x73D450, 0x60
+sMeowthGfx27_1:
+.incbin "baserom.gba", 0x73D4B0, 0x60
+sMeowthGfx27_2:
+.incbin "baserom.gba", 0x73D510, 0x60
+sMeowthSprites27:
+ax_sprite sMeowthGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx28:
+.incbin "baserom.gba", 0x73D5A8, 0x80
+sMeowthSprites28:
+ax_sprite sMeowthGfx28, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMeowthGfx29:
+.incbin "baserom.gba", 0x73D640, 0x60
+sMeowthGfx29_1:
+.incbin "baserom.gba", 0x73D6A0, 0x60
+sMeowthGfx29_2:
+.incbin "baserom.gba", 0x73D700, 0x60
+sMeowthSprites29:
+ax_sprite sMeowthGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx30:
+.incbin "baserom.gba", 0x73D798, 0x60
+sMeowthGfx30_1:
+.incbin "baserom.gba", 0x73D7F8, 0x60
+sMeowthGfx30_2:
+.incbin "baserom.gba", 0x73D858, 0x60
+sMeowthSprites30:
+ax_sprite sMeowthGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx31:
+.incbin "baserom.gba", 0x73D8F0, 0x60
+sMeowthGfx31_1:
+.incbin "baserom.gba", 0x73D950, 0x60
+sMeowthGfx31_2:
+.incbin "baserom.gba", 0x73D9B0, 0x60
+sMeowthSprites31:
+ax_sprite sMeowthGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx32:
+.incbin "baserom.gba", 0x73DA48, 0x60
+sMeowthGfx32_1:
+.incbin "baserom.gba", 0x73DAA8, 0x60
+sMeowthGfx32_2:
+.incbin "baserom.gba", 0x73DB08, 0x60
+sMeowthSprites32:
+ax_sprite sMeowthGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx33:
+.incbin "baserom.gba", 0x73DBA0, 0x60
+sMeowthGfx33_1:
+.incbin "baserom.gba", 0x73DC00, 0x60
+sMeowthGfx33_2:
+.incbin "baserom.gba", 0x73DC60, 0x40
+sMeowthSprites33:
+ax_sprite sMeowthGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx33_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx34:
+.incbin "baserom.gba", 0x73DCD8, 0x60
+sMeowthGfx34_1:
+.incbin "baserom.gba", 0x73DD38, 0x60
+sMeowthGfx34_2:
+.incbin "baserom.gba", 0x73DD98, 0x60
+sMeowthSprites34:
+ax_sprite sMeowthGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx35:
+.incbin "baserom.gba", 0x73DE30, 0x20
+sMeowthGfx35_1:
+.incbin "baserom.gba", 0x73DE50, 0x20
+sMeowthGfx35_2:
+.incbin "baserom.gba", 0x73DE70, 0x60
+sMeowthGfx35_3:
+.incbin "baserom.gba", 0x73DED0, 0x40
+sMeowthSprites35:
+ax_sprite sMeowthGfx35, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx35_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx35_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMeowthGfx36:
+.incbin "baserom.gba", 0x73DF58, 0x60
+sMeowthGfx36_1:
+.incbin "baserom.gba", 0x73DFB8, 0x60
+sMeowthGfx36_2:
+.incbin "baserom.gba", 0x73E018, 0x60
+sMeowthSprites36:
+ax_sprite sMeowthGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMeowthGfx37:
+.incbin "baserom.gba", 0x73E0B0, 0x20
+sMeowthGfx37_1:
+.incbin "baserom.gba", 0x73E0D0, 0x40
+sMeowthGfx37_2:
+.incbin "baserom.gba", 0x73E110, 0x20
+sMeowthSprites37:
+ax_sprite 0, 0x80
+ax_sprite sMeowthGfx37, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx37_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx37_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMeowthGfx38:
+.incbin "baserom.gba", 0x73E170, 0x20
+sMeowthGfx38_1:
+.incbin "baserom.gba", 0x73E190, 0x60
+sMeowthGfx38_2:
+.incbin "baserom.gba", 0x73E1F0, 0x40
+sMeowthSprites38:
+ax_sprite 0, 0xc0
+ax_sprite sMeowthGfx38, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMeowthGfx39:
+.incbin "baserom.gba", 0x73E270, 0x20
+sMeowthGfx39_1:
+.incbin "baserom.gba", 0x73E290, 0x20
+sMeowthGfx39_2:
+.incbin "baserom.gba", 0x73E2B0, 0x20
+sMeowthGfx39_3:
+.incbin "baserom.gba", 0x73E2D0, 0x20
+sMeowthSprites39:
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx39, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx39_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx39_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMeowthGfx39_3, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sMeowthGfx40:
+.incbin "baserom.gba", 0x73E340, 0x80
+sMeowthSprites40:
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx40, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMeowthGfx41:
+.incbin "baserom.gba", 0x73E3E0, 0x60
+sMeowthGfx41_1:
+.incbin "baserom.gba", 0x73E440, 0x40
+sMeowthSprites41:
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx41, 0x60
+ax_sprite 0, 0x60
+ax_sprite sMeowthGfx41_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMeowthGfx42:
+.incbin "baserom.gba", 0x73E4B0, 0x40
+sMeowthSprites42:
+ax_sprite 0, 0x40
+ax_sprite sMeowthGfx42, 0x40
+ax_sprite_terminator
+sMeowthGfx43:
+.incbin "baserom.gba", 0x73E508, 0x40
+sMeowthSprites43:
+ax_sprite sMeowthGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMeowthGfx44:
+.incbin "baserom.gba", 0x73E560, 0x200
+sMeowthSprites44:
+ax_sprite sMeowthGfx44, 0x200
+ax_sprite_terminator
+sMeowthGfx45:
+.incbin "baserom.gba", 0x73E770, 0x200
+sMeowthSprites45:
+ax_sprite sMeowthGfx45, 0x200
+ax_sprite_terminator
+sMeowthGfx46:
+.incbin "baserom.gba", 0x73E980, 0x200
+sMeowthSprites46:
+ax_sprite sMeowthGfx46, 0x200
+ax_sprite_terminator
+sMeowthGfx47:
+.incbin "baserom.gba", 0x73EB90, 0x200
+sMeowthSprites47:
+ax_sprite sMeowthGfx47, 0x200
+ax_sprite_terminator
+sMeowthGfx48:
+.incbin "baserom.gba", 0x73EDA0, 0x200
+sMeowthSprites48:
+ax_sprite sMeowthGfx48, 0x200
+ax_sprite_terminator
+sMeowthGfx49:
+.incbin "baserom.gba", 0x73EFB0, 0x200
+sMeowthSprites49:
+ax_sprite sMeowthGfx49, 0x200
+ax_sprite_terminator
+sMeowthGfx50:
+.incbin "baserom.gba", 0x73F1C0, 0x200
+sMeowthSprites50:
+ax_sprite sMeowthGfx50, 0x200
+ax_sprite_terminator
+sMeowthGfx51:
+.incbin "baserom.gba", 0x73F3D0, 0x200
+sMeowthSprites51:
+ax_sprite sMeowthGfx51, 0x200
+ax_sprite_terminator
+sMeowthGfx52:
+.incbin "baserom.gba", 0x73F5E0, 0x200
+sMeowthSprites52:
+ax_sprite sMeowthGfx52, 0x200
+ax_sprite_terminator
+sMeowthGfx53:
+.incbin "baserom.gba", 0x73F7F0, 0x200
+sMeowthSprites53:
+ax_sprite sMeowthGfx53, 0x200
+ax_sprite_terminator
+sMeowthGfx54:
+.incbin "baserom.gba", 0x73FA00, 0x200
+sMeowthSprites54:
+ax_sprite sMeowthGfx54, 0x200
+ax_sprite_terminator
+sMeowthGfx55:
+.incbin "baserom.gba", 0x73FC10, 0x200
+sMeowthSprites55:
+ax_sprite sMeowthGfx55, 0x200
+ax_sprite_terminator
+sMeowthGfx56:
+.incbin "baserom.gba", 0x73FE20, 0x200
+sMeowthSprites56:
+ax_sprite sMeowthGfx56, 0x200
+ax_sprite_terminator
+sMeowthGfx57:
+.incbin "baserom.gba", 0x740030, 0x200
+sMeowthSprites57:
+ax_sprite sMeowthGfx57, 0x200
+ax_sprite_terminator
+sMeowthGfx58:
+.incbin "baserom.gba", 0x740240, 0x200
+sMeowthSprites58:
+ax_sprite sMeowthGfx58, 0x200
+ax_sprite_terminator
+sMeowthGfx59:
+.incbin "baserom.gba", 0x740450, 0x200
+sMeowthSprites59:
+ax_sprite sMeowthGfx59, 0x200
+ax_sprite_terminator
+sMeowthGfx60:
+.incbin "baserom.gba", 0x740660, 0x200
+sMeowthSprites60:
+ax_sprite sMeowthGfx60, 0x200
+ax_sprite_terminator
+sMeowthGfx61:
+.incbin "baserom.gba", 0x740870, 0x200
+sMeowthSprites61:
+ax_sprite sMeowthGfx61, 0x200
+ax_sprite_terminator
+sMeowthGfx62:
+.incbin "baserom.gba", 0x740A80, 0x200
+sMeowthSprites62:
+ax_sprite sMeowthGfx62, 0x200
+ax_sprite_terminator
+sMeowthGfx63:
+.incbin "baserom.gba", 0x740C90, 0x200
+sMeowthSprites63:
+ax_sprite sMeowthGfx63, 0x200
+ax_sprite_terminator
+sMeowthGfx64:
+.incbin "baserom.gba", 0x740EA0, 0x200
+sMeowthSprites64:
+ax_sprite sMeowthGfx64, 0x200
+ax_sprite_terminator
+sMeowthGfx65:
+.incbin "baserom.gba", 0x7410B0, 0x200
+sMeowthSprites65:
+ax_sprite sMeowthGfx65, 0x200
+ax_sprite_terminator
+sMeowthGfx66:
+.incbin "baserom.gba", 0x7412C0, 0x200
+sMeowthSprites66:
+ax_sprite sMeowthGfx66, 0x200
+ax_sprite_terminator
+sMeowthGfx67:
+.incbin "baserom.gba", 0x7414D0, 0x200
+sMeowthSprites67:
+ax_sprite sMeowthGfx67, 0x200
+ax_sprite_terminator
+sMeowthGfx68:
+.incbin "baserom.gba", 0x7416E0, 0x200
+sMeowthSprites68:
+ax_sprite sMeowthGfx68, 0x200
+ax_sprite_terminator
+sMeowthGfx69:
+.incbin "baserom.gba", 0x7418F0, 0x200
+sMeowthSprites69:
+ax_sprite sMeowthGfx69, 0x200
+ax_sprite_terminator
+sMeowthGfx70:
+.incbin "baserom.gba", 0x741B00, 0x200
+sMeowthSprites70:
+ax_sprite sMeowthGfx70, 0x200
+ax_sprite_terminator
+sMeowthGfx71:
+.incbin "baserom.gba", 0x741D10, 0x200
+sMeowthSprites71:
+ax_sprite sMeowthGfx71, 0x200
+ax_sprite_terminator
+sMeowthGfx72:
+.incbin "baserom.gba", 0x741F20, 0x200
+sMeowthSprites72:
+ax_sprite sMeowthGfx72, 0x200
+ax_sprite_terminator
+sMeowthGfx73:
+.incbin "baserom.gba", 0x742130, 0x200
+sMeowthSprites73:
+ax_sprite sMeowthGfx73, 0x200
+ax_sprite_terminator
+sMeowthGfx74:
+.incbin "baserom.gba", 0x742340, 0x200
+sMeowthSprites74:
+ax_sprite sMeowthGfx74, 0x200
+ax_sprite_terminator
+sMeowthGfx75:
+.incbin "baserom.gba", 0x742550, 0x200
+sMeowthSprites75:
+ax_sprite sMeowthGfx75, 0x200
+ax_sprite_terminator
+sMeowthGfx76:
+.incbin "baserom.gba", 0x742760, 0x200
+sMeowthSprites76:
+ax_sprite sMeowthGfx76, 0x200
+ax_sprite_terminator
+sMeowthGfx77:
+.incbin "baserom.gba", 0x742970, 0x200
+sMeowthSprites77:
+ax_sprite sMeowthGfx77, 0x200
+ax_sprite_terminator
+sMeowthGfx78:
+.incbin "baserom.gba", 0x742B80, 0x200
+sMeowthSprites78:
+ax_sprite sMeowthGfx78, 0x200
+ax_sprite_terminator
+sMeowthGfx79:
+.incbin "baserom.gba", 0x742D90, 0x200
+sMeowthSprites79:
+ax_sprite sMeowthGfx79, 0x200
+ax_sprite_terminator
+sMeowthGfx80:
+.incbin "baserom.gba", 0x742FA0, 0x100
+sMeowthSprites80:
+ax_sprite sMeowthGfx80, 0x100
+ax_sprite_terminator
+sAxPosesMeowth:
+.4byte sMeowthPose1
+.4byte sMeowthPose2
+.4byte sMeowthPose3
+.4byte sMeowthPose4
+.4byte sMeowthPose5
+.4byte sMeowthPose6
+.4byte sMeowthPose7
+.4byte sMeowthPose8
+.4byte sMeowthPose9
+.4byte sMeowthPose10
+.4byte sMeowthPose11
+.4byte sMeowthPose12
+.4byte sMeowthPose13
+.4byte sMeowthPose14
+.4byte sMeowthPose15
+.4byte sMeowthPose16
+.4byte sMeowthPose17
+.4byte sMeowthPose18
+.4byte sMeowthPose19
+.4byte sMeowthPose20
+.4byte sMeowthPose21
+.4byte sMeowthPose22
+.4byte sMeowthPose23
+.4byte sMeowthPose24
+.4byte sMeowthPose25
+.4byte sMeowthPose26
+.4byte sMeowthPose27
+.4byte sMeowthPose28
+.4byte sMeowthPose29
+.4byte sMeowthPose30
+.4byte sMeowthPose31
+.4byte sMeowthPose32
+.4byte sMeowthPose33
+.4byte sMeowthPose34
+.4byte sMeowthPose35
+.4byte sMeowthPose36
+.4byte sMeowthPose37
+.4byte sMeowthPose38
+.4byte sMeowthPose39
+.4byte sMeowthPose40
+.4byte sMeowthPose41
+.4byte sMeowthPose42
+.4byte sMeowthPose43
+.4byte sMeowthPose44
+.4byte sMeowthPose45
+.4byte sMeowthPose46
+.4byte sMeowthPose47
+.4byte sMeowthPose48
+.4byte sMeowthPose49
+.4byte sMeowthPose50
+.4byte sMeowthPose51
+.4byte sMeowthPose52
+.4byte sMeowthPose53
+.4byte sMeowthPose54
+.4byte sMeowthPose55
+.4byte sMeowthPose56
+.4byte sMeowthPose57
+.4byte sMeowthPose58
+.4byte sMeowthPose59
+.4byte sMeowthPose60
+.4byte sMeowthPose61
+.4byte sMeowthPose62
+.4byte sMeowthPose63
+.4byte sMeowthPose64
+.4byte sMeowthPose65
+.4byte sMeowthPose66
+.4byte sMeowthPose67
+.4byte sMeowthPose68
+.4byte sMeowthPose69
+.4byte sMeowthPose70
+.4byte sMeowthPose71
+.4byte sMeowthPose72
+.4byte sMeowthPose73
+.4byte sMeowthPose74
+.4byte sMeowthPose75
+.4byte sMeowthPose76
+.4byte sMeowthPose77
+.4byte sMeowthPose78
+.4byte sMeowthPose79
+.4byte sMeowthPose80
+.4byte sMeowthPose81
+.4byte sMeowthPose82
+.4byte sMeowthPose83
+.4byte sMeowthPose84
+.4byte sMeowthPose85
+.4byte sMeowthPose86
+.4byte sMeowthPose87
+.4byte sMeowthPose88
+.4byte sMeowthPose89
+.4byte sMeowthPose90
+.4byte sMeowthPose91
+.4byte sMeowthPose92
+.4byte sMeowthPose93
+.4byte sMeowthPose94
+.4byte sMeowthPose95
+.4byte sMeowthPose96
+.4byte sMeowthPose97
+.4byte sMeowthPose98
+.4byte sMeowthPose99
+.4byte sMeowthPose100
+.4byte sMeowthPose101
+.4byte sMeowthPose102
+.4byte sMeowthPose103
+.4byte sMeowthPose104
+.4byte sMeowthPose105
+.4byte sMeowthPose106
+.4byte sMeowthPose107
+.4byte sMeowthPose108
+.4byte sMeowthPose109
+.4byte sMeowthPose110
+.4byte sMeowthPose111
+.4byte sMeowthPose112
+.4byte sMeowthPose113
+.4byte sMeowthPose114
+.4byte sMeowthPose115
+.4byte sMeowthPose116
+.4byte sMeowthPose117
+.4byte sMeowthPose118
+.4byte sMeowthPose119
+.4byte sMeowthPose120
+.4byte sMeowthPose121
+.4byte sMeowthPose122
+.4byte sMeowthPose123
+.4byte sMeowthPose124
+.4byte sMeowthPose125
+.4byte sMeowthPose126
+.4byte sMeowthPose127
+.4byte sMeowthPose128
+.4byte sMeowthPose129
+.4byte sMeowthPose130
+.4byte sMeowthPose131
+.4byte sMeowthPose132
+.4byte sMeowthPose133
+.4byte sMeowthPose134
+.4byte sMeowthPose135
+.4byte sMeowthPose136
+.4byte sMeowthPose137
+.4byte sMeowthPose138
+.4byte sMeowthPose139
+.4byte sMeowthPose140
+.4byte sMeowthPose141
+.4byte sMeowthPose142
+.4byte sMeowthPose143
+.4byte sMeowthPose144
+.4byte sMeowthPose145
+.4byte sMeowthPose146
+.4byte sMeowthPose147
+.4byte sMeowthPose148
+.4byte sMeowthPose149
+.4byte sMeowthPose150
+.4byte sMeowthPose151
+.4byte sMeowthPose152
+.4byte sMeowthPose153
+.4byte sMeowthPose154
+.4byte sMeowthPose155
+.4byte sMeowthPose156
+.4byte sMeowthPose157
+.4byte sMeowthPose158
+.4byte sMeowthPose159
+.4byte sMeowthPose160
+.4byte sMeowthPose161
+.4byte sMeowthPose162
+.4byte sMeowthPose163
+.4byte sMeowthPose164
+.4byte sMeowthPose165
+.4byte sMeowthPose166
+.4byte sMeowthPose167
+.4byte sMeowthPose168
+.4byte sMeowthPose169
+.4byte sMeowthPose170
+.4byte sMeowthPose171
+.4byte sMeowthPose172
+.4byte sMeowthPose173
+.4byte sMeowthPose174
+.4byte sMeowthPose175
+.4byte sMeowthPose176
+.4byte sMeowthPose177
+.4byte sMeowthPose178
+.4byte sMeowthPose179
+.4byte sMeowthPose180
+.4byte sMeowthPose181
+.4byte sMeowthPose182
+.4byte sMeowthPose183
+.4byte sMeowthPose184
+.4byte sMeowthPose185
+.4byte sMeowthPose186
+.4byte sMeowthPose187
+.4byte sMeowthPose188
+.4byte sMeowthPose189
+.4byte sMeowthPose190
+.4byte sMeowthPose191
+.4byte sMeowthPose192
+.4byte sMeowthPose193
+.4byte sMeowthPose194
+.4byte sMeowthPose195
+.4byte sMeowthPose196
+.4byte sMeowthPose197
+.4byte sMeowthPose198
+.4byte sMeowthPose199
+.4byte sMeowthPose200
+.4byte sMeowthPose201
+.4byte sMeowthPose202
+.4byte sMeowthPose203
+.4byte sMeowthPose204
+.4byte sMeowthPose205
+.4byte sMeowthPose206
+.4byte sMeowthPose207
+.4byte sMeowthPose208
+.4byte sMeowthPose209
+.4byte sMeowthPose210
+.4byte sMeowthPose211
+.4byte sMeowthPose212
+.4byte sMeowthPose213
+.4byte sMeowthPose214
+.4byte sMeowthPose215
+.4byte sMeowthPose216
+.4byte sMeowthPose217
+.4byte sMeowthPose218
+.4byte sMeowthPose219
+.4byte sMeowthPose220
+.4byte sMeowthPose221
+.4byte sMeowthPose222
+.4byte sMeowthPose223
+.4byte sMeowthPose224
+.4byte sMeowthPose225
+.4byte sMeowthPose226
+.4byte sMeowthPose227
+.4byte sMeowthPose228
+.4byte sMeowthPose229
+.4byte sMeowthPose230
+.4byte sMeowthPose231
+.4byte sMeowthPose232
+.4byte sMeowthPose233
+.4byte sMeowthPose234
+.4byte sMeowthPose235
+.4byte sMeowthPose236
+.4byte sMeowthPose237
+.4byte sMeowthPose238
+.4byte sMeowthPose239
+.4byte sMeowthPose240
+.4byte sMeowthPose241
+.4byte sMeowthPose242
+.4byte sMeowthPose243
+.4byte sMeowthPose244
+.4byte sMeowthPose245
+.4byte sMeowthPose246
+.4byte sMeowthPose247
+.4byte sMeowthPose248
+.4byte sMeowthPose249
+.4byte sMeowthPose250
+.4byte sMeowthPose251
+.4byte sMeowthPose252
+.4byte sMeowthPose253
+.4byte sMeowthPose254
+.4byte sMeowthPose255
+.4byte sMeowthPose256
+.4byte sMeowthPose257
+.4byte sMeowthPose258
+.4byte sMeowthPose259
+.4byte sMeowthPose260
+.4byte sMeowthPose261
+.4byte sMeowthPose262
+.4byte sMeowthPose263
+.4byte sMeowthPose264
+.4byte sMeowthPose265
+.4byte sMeowthPose266
+.4byte sMeowthPose267
+.4byte sMeowthPose268
+.4byte sMeowthPose269
+.4byte sMeowthPose270
+.4byte sMeowthPose271
+.4byte sMeowthPose272
+.4byte sMeowthPose273
+.4byte sMeowthPose274
+.4byte sMeowthPose275
+sAxPositionsMeowth:
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte    0,   -7, 	  -9,   -7, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -6, 	   8,   -7, 	   0,   -6
+.2byte    1,   -8, 	   6,   -9, 	  -5,   -7, 	  -1,   -7
+.2byte    1,   -7, 	   3,   -5, 	  -4,   -5, 	  -1,   -5
+.2byte    1,   -7, 	   7,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte    3,   -9, 	   0,  -11, 	  -2,   -7, 	  -1,   -7
+.2byte    3,   -8, 	  -2,  -11, 	   0,   -6, 	  -1,   -7
+.2byte    3,   -8, 	   2,  -10, 	  -3,   -6, 	  -2,   -7
+.2byte    0,  -11, 	  -5,  -11, 	   5,   -8, 	  -1,   -7
+.2byte    2,  -11, 	  -5,  -10, 	   6,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -6, 	  -3,   -6
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -1,  -12, 	   5,   -6, 	  -6,   -9, 	  -1,   -6
+.2byte    1,  -12, 	   6,   -6, 	  -6,   -6, 	   0,   -5
+.2byte   -1,  -11, 	   4,  -11, 	  -6,   -8, 	   0,   -7
+.2byte   -3,  -11, 	   4,  -10, 	  -7,   -7, 	   0,   -6
+.2byte    0,  -11, 	   3,  -11, 	  -5,   -6, 	   2,   -6
+.2byte   -4,   -9, 	  -1,  -11, 	   1,   -7, 	   0,   -7
+.2byte   -4,   -8, 	   1,  -11, 	  -1,   -6, 	   0,   -7
+.2byte   -4,   -8, 	  -3,  -10, 	   2,   -6, 	   1,   -7
+.2byte   -2,   -8, 	  -7,   -9, 	   4,   -7, 	   0,   -7
+.2byte   -2,   -7, 	  -4,   -5, 	   3,   -5, 	   0,   -5
+.2byte   -2,   -7, 	  -8,   -7, 	   4,   -6, 	   0,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte    0,   -7, 	  -9,   -7, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -6, 	   8,   -7, 	   0,   -6
+.2byte    1,   -8, 	   6,   -9, 	  -5,   -7, 	  -1,   -7
+.2byte    1,   -7, 	   3,   -5, 	  -4,   -5, 	  -1,   -5
+.2byte    1,   -7, 	   7,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte    3,   -9, 	   0,  -11, 	  -2,   -7, 	  -1,   -7
+.2byte    3,   -8, 	  -2,  -11, 	   0,   -6, 	  -1,   -7
+.2byte    3,   -8, 	   2,  -10, 	  -3,   -6, 	  -2,   -7
+.2byte    0,  -11, 	  -5,  -11, 	   5,   -8, 	  -1,   -7
+.2byte    2,  -11, 	  -5,  -10, 	   6,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -6, 	  -3,   -6
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -1,  -12, 	   5,   -6, 	  -6,   -9, 	  -1,   -6
+.2byte    1,  -12, 	   6,   -6, 	  -6,   -6, 	   0,   -5
+.2byte   -1,  -11, 	   4,  -11, 	  -6,   -8, 	   0,   -7
+.2byte   -3,  -11, 	   4,  -10, 	  -7,   -7, 	   0,   -6
+.2byte    0,  -11, 	   3,  -11, 	  -5,   -6, 	   2,   -6
+.2byte   -4,   -9, 	  -1,  -11, 	   1,   -7, 	   0,   -7
+.2byte   -4,   -8, 	   1,  -11, 	  -1,   -6, 	   0,   -7
+.2byte   -4,   -8, 	  -3,  -10, 	   2,   -6, 	   1,   -7
+.2byte   -2,   -8, 	  -7,   -9, 	   4,   -7, 	   0,   -7
+.2byte   -2,   -7, 	  -4,   -5, 	   3,   -5, 	   0,   -5
+.2byte   -2,   -7, 	  -8,   -7, 	   4,   -6, 	   0,   -6
+.2byte    1,   -7, 	  -8,   -7, 	   7,   -6, 	   0,   -6
+.2byte    1,   -6, 	   3,   -2, 	   7,  -12, 	  -1,   -7
+.2byte    1,   -6, 	   3,   -2, 	   7,  -12, 	  -1,   -7
+.2byte   -2,   -6, 	  -4,   -2, 	  -8,  -12, 	   0,   -7
+.2byte    1,   -7, 	   7,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte    2,   -6, 	   0,   -1, 	  -6,  -12, 	   1,   -7
+.2byte    2,   -6, 	   0,   -1, 	  -6,  -12, 	   1,   -7
+.2byte    3,   -6, 	   7,  -10, 	   4,   -2, 	   0,   -6
+.2byte    5,   -8, 	   4,  -10, 	  -1,   -6, 	   0,   -7
+.2byte    5,   -8, 	   6,   -4, 	   0,  -13, 	   0,   -8
+.2byte    5,   -8, 	   6,   -4, 	   0,  -13, 	   0,   -8
+.2byte    4,  -10, 	  -2,  -13, 	   4,   -8, 	   0,   -9
+.2byte    0,  -11, 	  -3,  -11, 	   5,   -6, 	  -2,   -6
+.2byte    3,  -12, 	  -3,   -9, 	   6,  -10, 	   0,   -8
+.2byte    3,  -12, 	  -3,   -9, 	   6,  -10, 	   0,   -8
+.2byte    2,  -10, 	  -7,  -12, 	   1,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	   5,   -6, 	  -6,   -9, 	  -1,   -6
+.2byte   -2,  -13, 	  -3,   -7, 	  -8,  -11, 	  -1,   -8
+.2byte   -2,  -13, 	  -3,   -7, 	  -8,  -11, 	  -1,   -8
+.2byte   -1,  -12, 	   6,  -11, 	   1,   -7, 	  -1,   -8
+.2byte   -4,  -11, 	   3,  -10, 	  -8,   -7, 	  -1,   -6
+.2byte   -4,  -12, 	   2,   -9, 	  -7,  -10, 	  -1,   -8
+.2byte   -4,  -12, 	   2,   -9, 	  -7,  -10, 	  -1,   -8
+.2byte   -3,  -10, 	   6,  -12, 	  -2,   -8, 	   0,   -8
+.2byte   -4,   -8, 	   1,  -11, 	  -1,   -6, 	   0,   -7
+.2byte   -6,   -8, 	  -7,   -4, 	  -1,  -13, 	  -1,   -8
+.2byte   -6,   -8, 	  -7,   -4, 	  -1,  -13, 	  -1,   -8
+.2byte   -5,  -10, 	   1,  -13, 	  -5,   -8, 	  -1,   -9
+.2byte   -2,   -7, 	  -8,   -7, 	   4,   -6, 	   0,   -6
+.2byte   -3,   -6, 	  -1,   -1, 	   5,  -12, 	  -2,   -7
+.2byte   -3,   -6, 	  -1,   -1, 	   5,  -12, 	  -2,   -7
+.2byte   -4,   -6, 	  -8,  -10, 	  -5,   -2, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte    0,   -9, 	  -7,   -6, 	   6,  -10, 	   0,   -8
+.2byte    2,   -8, 	   7,   -9, 	  -4,   -7, 	   0,   -7
+.2byte    2,   -9, 	   5,   -6, 	  -4,   -9, 	  -1,   -8
+.2byte    4,   -9, 	   1,  -11, 	  -1,   -7, 	   0,   -7
+.2byte    2,   -9, 	   4,   -6, 	   1,   -9, 	  -1,   -6
+.2byte    1,  -11, 	  -4,  -11, 	   6,   -8, 	   0,   -7
+.2byte    1,  -11, 	  -3,   -9, 	   5,   -9, 	  -2,   -8
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -1,  -11, 	   5,   -7, 	  -6,   -9, 	   0,   -6
+.2byte   -2,  -11, 	   3,  -11, 	  -7,   -8, 	  -1,   -7
+.2byte   -2,  -11, 	   2,   -9, 	  -6,   -9, 	   1,   -8
+.2byte   -5,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte   -3,   -9, 	  -5,   -6, 	  -2,   -9, 	   0,   -6
+.2byte   -3,   -8, 	  -8,   -9, 	   3,   -7, 	  -1,   -7
+.2byte   -3,   -9, 	  -6,   -6, 	   3,   -9, 	   0,   -8
+.2byte    1,   -7, 	  -8,   -7, 	   7,   -6, 	   0,   -6
+.2byte    1,   -6, 	   3,   -2, 	   7,  -12, 	  -1,   -7
+.2byte    1,   -6, 	   3,   -2, 	   7,  -12, 	  -1,   -7
+.2byte   -1,   -6, 	  -8,  -12, 	  -4,   -2, 	  -1,   -8
+.2byte   -1,   -6, 	  -8,  -12, 	  -4,   -2, 	  -1,   -8
+.2byte    1,   -7, 	   7,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte    2,   -6, 	   0,   -1, 	  -6,  -12, 	   1,   -7
+.2byte    2,   -6, 	   0,   -1, 	  -6,  -12, 	   1,   -7
+.2byte    5,   -6, 	   9,  -10, 	   6,   -2, 	   2,   -6
+.2byte    5,   -6, 	   9,  -10, 	   6,   -2, 	   2,   -6
+.2byte    3,   -8, 	  -2,  -11, 	   0,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -4, 	   0,  -13, 	   0,   -8
+.2byte    5,   -8, 	   6,   -4, 	   0,  -13, 	   0,   -8
+.2byte    4,  -10, 	  -2,  -13, 	   4,   -8, 	   0,   -9
+.2byte    4,  -10, 	  -2,  -13, 	   4,   -8, 	   0,   -9
+.2byte    3,  -11, 	  -4,  -10, 	   7,   -7, 	   0,   -6
+.2byte    3,  -12, 	  -3,   -9, 	   6,  -10, 	   0,   -8
+.2byte    3,  -12, 	  -3,   -9, 	   6,  -10, 	   0,   -8
+.2byte    1,  -10, 	  -8,  -12, 	   0,   -8, 	  -2,   -8
+.2byte    1,  -10, 	  -8,  -12, 	   0,   -8, 	  -2,   -8
+.2byte   -1,  -12, 	   5,   -6, 	  -6,   -9, 	  -1,   -6
+.2byte   -1,  -13, 	  -2,   -7, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -13, 	  -2,   -7, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -12, 	   6,  -11, 	   1,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	   6,  -11, 	   1,   -7, 	  -1,   -8
+.2byte   -4,  -11, 	   3,  -10, 	  -8,   -7, 	  -1,   -6
+.2byte   -4,  -12, 	   2,   -9, 	  -7,  -10, 	  -1,   -8
+.2byte   -4,  -12, 	   2,   -9, 	  -7,  -10, 	  -1,   -8
+.2byte   -2,  -10, 	   7,  -12, 	  -1,   -8, 	   1,   -8
+.2byte   -2,  -10, 	   7,  -12, 	  -1,   -8, 	   1,   -8
+.2byte   -5,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte   -6,   -8, 	  -7,   -4, 	  -1,  -13, 	  -1,   -8
+.2byte   -6,   -8, 	  -7,   -4, 	  -1,  -13, 	  -1,   -8
+.2byte   -5,  -10, 	   1,  -13, 	  -5,   -8, 	  -1,   -9
+.2byte   -5,  -10, 	   1,  -13, 	  -5,   -8, 	  -1,   -9
+.2byte   -2,   -7, 	  -8,   -7, 	   4,   -6, 	   0,   -6
+.2byte   -3,   -6, 	  -1,   -1, 	   5,  -12, 	  -2,   -7
+.2byte   -3,   -6, 	  -1,   -1, 	   5,  -12, 	  -2,   -7
+.2byte   -6,   -6, 	 -10,  -10, 	  -7,   -2, 	  -3,   -6
+.2byte   -6,   -6, 	 -10,  -10, 	  -7,   -2, 	  -3,   -6
+.2byte   -3,   -7, 	  -5,   -3, 	   4,    0, 	  -1,   -5
+.2byte   -3,   -6, 	  -5,   -2, 	   3,    1, 	  -1,   -5
+.2byte    0,   -9, 	  -9,  -10, 	   8,  -10, 	   0,   -7
+.2byte    1,   -8, 	   7,  -11, 	  -6,   -8, 	   0,   -7
+.2byte    2,  -10, 	   0,  -12, 	  -3,   -9, 	  -1,   -7
+.2byte    0,  -12, 	  -7,  -10, 	   4,   -9, 	  -1,   -7
+.2byte    0,  -12, 	   7,   -8, 	  -8,   -8, 	   0,   -6
+.2byte   -1,  -11, 	   6,   -9, 	  -5,   -8, 	   0,   -6
+.2byte   -3,   -9, 	  -1,  -11, 	   2,   -8, 	   0,   -6
+.2byte   -2,   -8, 	  -8,  -11, 	   5,   -8, 	  -1,   -7
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte    0,   -7, 	  -9,   -7, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -6, 	   8,   -7, 	   0,   -6
+.2byte    1,   -8, 	   6,   -9, 	  -5,   -7, 	  -1,   -7
+.2byte    1,   -7, 	   3,   -5, 	  -4,   -5, 	  -1,   -5
+.2byte    1,   -7, 	   7,   -7, 	  -5,   -6, 	  -1,   -6
+.2byte    3,   -9, 	   0,  -11, 	  -2,   -7, 	  -1,   -7
+.2byte    3,   -8, 	  -2,  -11, 	   0,   -6, 	  -1,   -7
+.2byte    3,   -8, 	   2,  -10, 	  -3,   -6, 	  -2,   -7
+.2byte    0,  -11, 	  -5,  -11, 	   5,   -8, 	  -1,   -7
+.2byte    2,  -11, 	  -5,  -10, 	   6,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -6, 	  -3,   -6
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -1,  -12, 	   5,   -6, 	  -6,   -9, 	  -1,   -6
+.2byte    1,  -12, 	   6,   -6, 	  -6,   -6, 	   0,   -5
+.2byte   -1,  -11, 	   4,  -11, 	  -6,   -8, 	   0,   -7
+.2byte   -3,  -11, 	   4,  -10, 	  -7,   -7, 	   0,   -6
+.2byte    0,  -11, 	   3,  -11, 	  -5,   -6, 	   2,   -6
+.2byte   -4,   -9, 	  -1,  -11, 	   1,   -7, 	   0,   -7
+.2byte   -4,   -8, 	   1,  -11, 	  -1,   -6, 	   0,   -7
+.2byte   -4,   -8, 	  -3,  -10, 	   2,   -6, 	   1,   -7
+.2byte   -2,   -8, 	  -7,   -9, 	   4,   -7, 	   0,   -7
+.2byte   -2,   -7, 	  -4,   -5, 	   3,   -5, 	   0,   -5
+.2byte   -2,   -7, 	  -8,   -7, 	   4,   -6, 	   0,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte   -3,   -8, 	  -8,   -9, 	   3,   -7, 	  -1,   -7
+.2byte   -5,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte   -2,  -11, 	   3,  -11, 	  -7,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte    1,  -11, 	  -4,  -11, 	   6,   -8, 	   0,   -7
+.2byte    4,   -9, 	   1,  -11, 	  -1,   -7, 	   0,   -7
+.2byte    2,   -8, 	   7,   -9, 	  -4,   -7, 	   0,   -7
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte    2,   -8, 	   7,   -9, 	  -4,   -7, 	   0,   -7
+.2byte    4,   -9, 	   1,  -11, 	  -1,   -7, 	   0,   -7
+.2byte    1,  -11, 	  -4,  -11, 	   6,   -8, 	   0,   -7
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -1,  -11, 	   4,  -11, 	  -6,   -8, 	   0,   -7
+.2byte   -4,   -9, 	  -1,  -11, 	   1,   -7, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -9, 	   4,   -7, 	   0,   -7
+.2byte   -1,   -9, 	  -8,   -6, 	   5,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte    2,   -9, 	   5,   -6, 	  -4,   -9, 	  -1,   -8
+.2byte    1,   -8, 	   6,   -9, 	  -5,   -7, 	  -1,   -7
+.2byte    1,   -9, 	   3,   -6, 	   0,   -9, 	  -2,   -6
+.2byte    3,   -9, 	   0,  -11, 	  -2,   -7, 	  -1,   -7
+.2byte    0,  -11, 	  -4,   -9, 	   4,   -9, 	  -3,   -8
+.2byte    0,  -11, 	  -5,  -11, 	   5,   -8, 	  -1,   -7
+.2byte   -1,  -12, 	   5,   -8, 	  -6,  -10, 	   0,   -7
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -1,  -11, 	   3,   -9, 	  -5,   -9, 	   2,   -8
+.2byte   -1,  -11, 	   4,  -11, 	  -6,   -8, 	   0,   -7
+.2byte   -2,   -9, 	  -4,   -6, 	  -1,   -9, 	   1,   -6
+.2byte   -5,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte   -3,   -9, 	  -6,   -6, 	   3,   -9, 	   0,   -8
+.2byte   -1,   -8, 	  -6,   -9, 	   5,   -7, 	   1,   -7
+.2byte    0,   -9, 	  -7,   -6, 	   6,  -10, 	   0,   -8
+.2byte   -3,   -9, 	  -6,   -6, 	   3,   -9, 	   0,   -8
+.2byte   -3,   -9, 	  -5,   -6, 	  -2,   -9, 	   0,   -6
+.2byte   -3,  -11, 	   1,   -9, 	  -7,   -9, 	   0,   -8
+.2byte    0,  -12, 	   6,   -8, 	  -5,  -10, 	   1,   -7
+.2byte    2,  -11, 	  -2,   -9, 	   6,   -9, 	  -1,   -8
+.2byte    2,   -9, 	   4,   -6, 	   1,   -9, 	  -1,   -6
+.2byte    3,   -9, 	   6,   -6, 	  -3,   -9, 	   0,   -8
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte   -3,   -8, 	  -8,   -9, 	   3,   -7, 	  -1,   -7
+.2byte   -5,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte   -2,  -11, 	   3,  -11, 	  -7,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte    1,  -11, 	  -4,  -11, 	   6,   -8, 	   0,   -7
+.2byte    4,   -9, 	   1,  -11, 	  -1,   -7, 	   0,   -7
+.2byte    2,   -8, 	   7,   -9, 	  -4,   -7, 	   0,   -7
+.2byte   -2,   -4, 	  -6,   -1, 	  -1,    1, 	  -1,   -3
+.2byte   -2,   -3, 	  -6,   -1, 	  -1,    1, 	   0,   -2
+.2byte    1,   -4, 	   5,   -1, 	   0,    1, 	   0,   -3
+.2byte    1,   -3, 	   5,   -1, 	   0,    1, 	  -1,   -2
+.2byte   -2,   -4, 	  -6,   -1, 	  -1,    1, 	  -1,   -3
+.2byte    1,   -5, 	  -4,    0, 	   4,   -2, 	   0,   -7
+.2byte    2,   -5, 	   3,   -6, 	   4,   -2, 	   2,   -7
+.2byte    4,   -6, 	   2,   -6, 	   6,   -5, 	   2,   -7
+.2byte    4,   -9, 	   1,  -11, 	  -1,   -7, 	   0,   -7
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -1,   -9, 	   7,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte    0,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -7
+.2byte    0,  -10, 	  -9,  -10, 	   8,  -10, 	   0,   -7
+.2byte   -2,   -4, 	  -8,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -8, 	  -7,  -14, 	   7,   -3, 	   0,   -9
+.2byte    2,   -8, 	   6,   -5, 	  -2,   -8, 	   0,   -8
+.2byte   -1,  -11, 	   5,  -15, 	  -7,   -3, 	  -1,   -8
+.2byte   -1,  -11, 	   5,  -15, 	  -7,   -3, 	  -1,   -8
+.2byte    0,   -5, 	  -6,   -3, 	   5,   -3, 	   0,   -7
+.2byte    0,   -4, 	  -6,   -2, 	   5,   -2, 	   0,   -6
+.2byte    0,   -4, 	  -6,   -2, 	   5,   -2, 	   0,   -6
+.2byte   -5,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	  -7,  -10, 	   0,   -8, 	   1,   -7
+.2byte   -1,   -7, 	  -7,  -12, 	   3,   -4, 	  -1,   -5
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte    0,   -9, 	   4,   -4, 	  -5,   -4, 	   0,   -7
+.2byte    0,   -4, 	   3,   -2, 	  -4,   -2, 	   0,   -5
+.2byte   -1,   -7, 	  -8,   -8, 	   7,   -8, 	   0,   -7
+.2byte    0,  -10, 	  -9,  -10, 	   8,  -10, 	   0,   -7
+.2byte    0,   -6, 	  -3,   -2, 	   2,   -2, 	   0,   -7
+.2byte   -5,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte   -7,   -4, 	  -3,   -6, 	  -1,   -5, 	  -3,   -7
+.2byte    4,   -9, 	   1,  -11, 	  -1,   -7, 	   0,   -7
+.2byte    6,   -4, 	   2,   -6, 	   0,   -5, 	   2,   -7
+.2byte   -1,  -13, 	   6,   -9, 	  -7,   -9, 	   0,   -7
+.2byte    0,   -7, 	   6,   -7, 	  -7,   -7, 	   0,   -5
+.2byte   -4,   -7, 	   1,   -5, 	   3,   -3, 	   0,   -6
+.2byte   -1,   -8, 	  -3,   -5, 	   7,   -3, 	   2,   -7
+.2byte   -4,   -5, 	  -2,   -5, 	   5,   -4, 	  -1,   -6
+.2byte   -2,   -8, 	   2,   -6, 	   6,   -4, 	   1,   -8
+.2byte   -5,   -5, 	  -2,   -5, 	   4,   -4, 	  -1,   -6
+.2byte    3,   -7, 	  -2,   -5, 	  -4,   -3, 	  -1,   -6
+.2byte    0,   -8, 	   2,   -5, 	  -8,   -3, 	  -3,   -7
+.2byte    3,   -5, 	   1,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    1,   -8, 	  -3,   -6, 	  -7,   -4, 	  -2,   -8
+.2byte    4,   -5, 	   1,   -5, 	  -5,   -4, 	   0,   -6
+.2byte    0,   -9, 	  -3,  -11, 	   5,   -7, 	  -2,   -6
+.2byte   -2,   -4, 	  -6,   -1, 	  -1,    1, 	  -1,   -3
+.2byte   -2,   -3, 	  -6,   -1, 	  -1,    1, 	   0,   -2
+.2byte    1,   -4, 	   5,   -1, 	   0,    1, 	   0,   -3
+.2byte    1,   -3, 	   5,   -1, 	   0,    1, 	  -1,   -2
+.2byte   -2,   -4, 	  -6,   -1, 	  -1,    1, 	  -1,   -3
+.2byte   -2,   -3, 	  -6,   -1, 	  -1,    1, 	   0,   -2
+.2byte    1,   -4, 	   5,   -1, 	   0,    1, 	   0,   -3
+.2byte    1,   -3, 	   5,   -1, 	   0,    1, 	  -1,   -2
+sMeowthAnimTable1:
+.4byte sMeowthAnims_1_1
+.4byte sMeowthAnims_1_2
+.4byte sMeowthAnims_1_3
+.4byte sMeowthAnims_1_4
+.4byte sMeowthAnims_1_5
+.4byte sMeowthAnims_1_6
+.4byte sMeowthAnims_1_7
+.4byte sMeowthAnims_1_8
+sMeowthAnimTable2:
+.4byte sMeowthAnims_2_1
+.4byte sMeowthAnims_2_2
+.4byte sMeowthAnims_2_3
+.4byte sMeowthAnims_2_4
+.4byte sMeowthAnims_2_5
+.4byte sMeowthAnims_2_6
+.4byte sMeowthAnims_2_7
+.4byte sMeowthAnims_2_8
+sMeowthAnimTable3:
+.4byte sMeowthAnims_3_1
+.4byte sMeowthAnims_3_2
+.4byte sMeowthAnims_3_3
+.4byte sMeowthAnims_3_4
+.4byte sMeowthAnims_3_5
+.4byte sMeowthAnims_3_6
+.4byte sMeowthAnims_3_7
+.4byte sMeowthAnims_3_8
+sMeowthAnimTable4:
+.4byte sMeowthAnims_4_1
+.4byte sMeowthAnims_4_2
+.4byte sMeowthAnims_4_3
+.4byte sMeowthAnims_4_4
+.4byte sMeowthAnims_4_5
+.4byte sMeowthAnims_4_6
+.4byte sMeowthAnims_4_7
+.4byte sMeowthAnims_4_8
+sMeowthAnimTable5:
+.4byte sMeowthAnims_5_1
+.4byte sMeowthAnims_5_2
+.4byte sMeowthAnims_5_3
+.4byte sMeowthAnims_5_4
+.4byte sMeowthAnims_5_5
+.4byte sMeowthAnims_5_6
+.4byte sMeowthAnims_5_7
+.4byte sMeowthAnims_5_8
+sMeowthAnimTable6:
+.4byte sMeowthAnims_6_1
+.4byte sMeowthAnims_6_1
+.4byte sMeowthAnims_6_1
+.4byte sMeowthAnims_6_1
+.4byte sMeowthAnims_6_1
+.4byte sMeowthAnims_6_1
+.4byte sMeowthAnims_6_1
+.4byte sMeowthAnims_6_1
+sMeowthAnimTable7:
+.4byte sMeowthAnims_7_1
+.4byte sMeowthAnims_7_2
+.4byte sMeowthAnims_7_3
+.4byte sMeowthAnims_7_4
+.4byte sMeowthAnims_7_5
+.4byte sMeowthAnims_7_6
+.4byte sMeowthAnims_7_7
+.4byte sMeowthAnims_7_8
+sMeowthAnimTable8:
+.4byte sMeowthAnims_8_1
+.4byte sMeowthAnims_8_2
+.4byte sMeowthAnims_8_3
+.4byte sMeowthAnims_8_4
+.4byte sMeowthAnims_8_5
+.4byte sMeowthAnims_8_6
+.4byte sMeowthAnims_8_7
+.4byte sMeowthAnims_8_8
+sMeowthAnimTable9:
+.4byte sMeowthAnims_9_1
+.4byte sMeowthAnims_9_2
+.4byte sMeowthAnims_9_3
+.4byte sMeowthAnims_9_4
+.4byte sMeowthAnims_9_5
+.4byte sMeowthAnims_9_6
+.4byte sMeowthAnims_9_7
+.4byte sMeowthAnims_9_8
+sMeowthAnimTable10:
+.4byte sMeowthAnims_10_1
+.4byte sMeowthAnims_10_2
+.4byte sMeowthAnims_10_3
+.4byte sMeowthAnims_10_4
+.4byte sMeowthAnims_10_5
+.4byte sMeowthAnims_10_6
+.4byte sMeowthAnims_10_7
+.4byte sMeowthAnims_10_8
+sMeowthAnimTable11:
+.4byte sMeowthAnims_11_1
+.4byte sMeowthAnims_11_2
+.4byte sMeowthAnims_11_3
+.4byte sMeowthAnims_11_4
+.4byte sMeowthAnims_11_5
+.4byte sMeowthAnims_11_6
+.4byte sMeowthAnims_11_7
+.4byte sMeowthAnims_11_8
+sMeowthAnimTable12:
+.4byte sMeowthAnims_12_1
+.4byte sMeowthAnims_12_2
+.4byte sMeowthAnims_12_3
+.4byte sMeowthAnims_12_4
+.4byte sMeowthAnims_12_5
+.4byte sMeowthAnims_12_6
+.4byte sMeowthAnims_12_7
+.4byte sMeowthAnims_12_8
+sMeowthAnimTable13:
+.4byte sMeowthAnims_13_1
+.4byte sMeowthAnims_13_2
+.4byte sMeowthAnims_13_3
+.4byte sMeowthAnims_13_4
+.4byte sMeowthAnims_13_5
+.4byte sMeowthAnims_13_6
+.4byte sMeowthAnims_13_7
+.4byte sMeowthAnims_13_8
+sMeowthAnimTable14:
+.4byte sMeowthAnims_14_1
+.4byte sMeowthAnims_14_2
+.4byte sMeowthAnims_14_3
+.4byte sMeowthAnims_14_4
+.4byte sMeowthAnims_14_5
+.4byte sMeowthAnims_14_6
+.4byte sMeowthAnims_14_7
+.4byte sMeowthAnims_14_8
+sMeowthAnimTable15:
+.4byte sMeowthAnims_15_1
+.4byte sMeowthAnims_15_2
+.4byte sMeowthAnims_15_3
+.4byte sMeowthAnims_15_4
+.4byte sMeowthAnims_15_5
+.4byte sMeowthAnims_15_6
+.4byte sMeowthAnims_15_7
+.4byte sMeowthAnims_15_8
+sMeowthAnimTable16:
+.4byte sMeowthAnims_16_1
+.4byte sMeowthAnims_16_2
+.4byte sMeowthAnims_16_3
+.4byte sMeowthAnims_16_4
+.4byte sMeowthAnims_16_5
+.4byte sMeowthAnims_16_6
+.4byte sMeowthAnims_16_7
+.4byte sMeowthAnims_16_8
+sMeowthAnimTable17:
+.4byte sMeowthAnims_17_1
+.4byte sMeowthAnims_17_2
+.4byte sMeowthAnims_17_3
+.4byte sMeowthAnims_17_4
+.4byte sMeowthAnims_17_5
+.4byte sMeowthAnims_17_6
+.4byte sMeowthAnims_17_7
+.4byte sMeowthAnims_17_8
+sMeowthAnimTable18:
+.4byte sMeowthAnims_18_1
+.4byte sMeowthAnims_18_2
+.4byte sMeowthAnims_18_3
+.4byte sMeowthAnims_18_4
+.4byte sMeowthAnims_18_5
+.4byte sMeowthAnims_18_6
+.4byte sMeowthAnims_18_7
+.4byte sMeowthAnims_18_8
+sMeowthAnimTable19:
+.4byte sMeowthAnims_19_1
+.4byte sMeowthAnims_19_2
+.4byte sMeowthAnims_19_3
+.4byte sMeowthAnims_19_4
+.4byte sMeowthAnims_19_5
+.4byte sMeowthAnims_19_6
+.4byte sMeowthAnims_19_7
+.4byte sMeowthAnims_19_8
+sMeowthAnimTable20:
+.4byte sMeowthAnims_20_1
+.4byte sMeowthAnims_20_2
+.4byte sMeowthAnims_20_3
+.4byte sMeowthAnims_20_4
+.4byte sMeowthAnims_20_5
+.4byte sMeowthAnims_20_6
+.4byte sMeowthAnims_20_7
+.4byte sMeowthAnims_20_8
+sMeowthAnimTable21:
+.4byte sMeowthAnims_21_1
+.4byte sMeowthAnims_21_2
+.4byte sMeowthAnims_21_3
+.4byte sMeowthAnims_21_4
+.4byte sMeowthAnims_21_5
+.4byte sMeowthAnims_21_6
+.4byte sMeowthAnims_21_7
+.4byte sMeowthAnims_21_8
+sMeowthAnimTable22:
+.4byte sMeowthAnims_22_1
+.4byte sMeowthAnims_22_2
+.4byte sMeowthAnims_22_3
+.4byte sMeowthAnims_22_4
+.4byte sMeowthAnims_22_5
+.4byte sMeowthAnims_22_6
+.4byte sMeowthAnims_22_7
+.4byte sMeowthAnims_22_8
+sMeowthAnimTable23:
+.4byte sMeowthAnims_23_1
+.4byte sMeowthAnims_23_2
+.4byte sMeowthAnims_23_3
+.4byte sMeowthAnims_23_4
+.4byte sMeowthAnims_23_5
+.4byte sMeowthAnims_23_6
+.4byte sMeowthAnims_23_7
+.4byte sMeowthAnims_23_8
+sMeowthAnimTable24:
+.4byte sMeowthAnims_24_1
+.4byte sMeowthAnims_24_2
+.4byte sMeowthAnims_24_3
+.4byte sMeowthAnims_24_4
+.4byte sMeowthAnims_24_5
+.4byte sMeowthAnims_24_6
+.4byte sMeowthAnims_24_7
+.4byte sMeowthAnims_24_8
+sMeowthAnimTable25:
+.4byte sMeowthAnims_25_1
+.4byte sMeowthAnims_25_2
+.4byte sMeowthAnims_25_3
+.4byte sMeowthAnims_25_4
+.4byte sMeowthAnims_25_5
+.4byte sMeowthAnims_25_6
+.4byte sMeowthAnims_25_7
+.4byte sMeowthAnims_25_8
+sMeowthAnimTable26:
+.4byte sMeowthAnims_26_1
+.4byte sMeowthAnims_26_2
+.4byte sMeowthAnims_26_3
+.4byte sMeowthAnims_26_4
+.4byte sMeowthAnims_26_5
+.4byte sMeowthAnims_26_6
+.4byte sMeowthAnims_26_7
+.4byte sMeowthAnims_26_8
+sMeowthAnimTable27:
+.4byte sMeowthAnims_27_1
+.4byte sMeowthAnims_27_1
+.4byte sMeowthAnims_27_1
+.4byte sMeowthAnims_27_1
+.4byte sMeowthAnims_27_1
+.4byte sMeowthAnims_27_1
+.4byte sMeowthAnims_27_1
+.4byte sMeowthAnims_27_1
+sMeowthAnimTable28:
+.4byte sMeowthAnims_28_1
+.4byte sMeowthAnims_28_2
+.4byte sMeowthAnims_28_3
+.4byte sMeowthAnims_28_4
+.4byte sMeowthAnims_28_5
+.4byte sMeowthAnims_28_6
+.4byte sMeowthAnims_28_7
+.4byte sMeowthAnims_28_8
+sAxAnimationsMeowth:
+.4byte sMeowthAnimTable1
+.4byte sMeowthAnimTable2
+.4byte sMeowthAnimTable3
+.4byte sMeowthAnimTable4
+.4byte sMeowthAnimTable5
+.4byte sMeowthAnimTable6
+.4byte sMeowthAnimTable7
+.4byte sMeowthAnimTable8
+.4byte sMeowthAnimTable9
+.4byte sMeowthAnimTable10
+.4byte sMeowthAnimTable11
+.4byte sMeowthAnimTable12
+.4byte sMeowthAnimTable13
+.4byte sMeowthAnimTable14
+.4byte sMeowthAnimTable15
+.4byte sMeowthAnimTable16
+.4byte sMeowthAnimTable17
+.4byte sMeowthAnimTable18
+.4byte sMeowthAnimTable19
+.4byte sMeowthAnimTable20
+.4byte sMeowthAnimTable21
+.4byte sMeowthAnimTable22
+.4byte sMeowthAnimTable23
+.4byte sMeowthAnimTable24
+.4byte sMeowthAnimTable25
+.4byte sMeowthAnimTable26
+.4byte sMeowthAnimTable27
+.4byte sMeowthAnimTable28
+sAxSpritesMeowth:
+.4byte sMeowthSprites1
+.4byte sMeowthSprites2
+.4byte sMeowthSprites3
+.4byte sMeowthSprites4
+.4byte sMeowthSprites5
+.4byte sMeowthSprites6
+.4byte sMeowthSprites7
+.4byte sMeowthSprites8
+.4byte sMeowthSprites9
+.4byte sMeowthSprites10
+.4byte sMeowthSprites11
+.4byte sMeowthSprites12
+.4byte sMeowthSprites13
+.4byte sMeowthSprites14
+.4byte sMeowthSprites15
+.4byte sMeowthSprites16
+.4byte sMeowthSprites17
+.4byte sMeowthSprites18
+.4byte sMeowthSprites19
+.4byte sMeowthSprites20
+.4byte sMeowthSprites21
+.4byte sMeowthSprites22
+.4byte sMeowthSprites23
+.4byte sMeowthSprites24
+.4byte sMeowthSprites25
+.4byte sMeowthSprites26
+.4byte sMeowthSprites27
+.4byte sMeowthSprites28
+.4byte sMeowthSprites29
+.4byte sMeowthSprites30
+.4byte sMeowthSprites31
+.4byte sMeowthSprites32
+.4byte sMeowthSprites33
+.4byte sMeowthSprites34
+.4byte sMeowthSprites35
+.4byte sMeowthSprites36
+.4byte sMeowthSprites37
+.4byte sMeowthSprites38
+.4byte sMeowthSprites39
+.4byte sMeowthSprites40
+.4byte sMeowthSprites41
+.4byte sMeowthSprites42
+.4byte sMeowthSprites43
+.4byte sMeowthSprites44
+.4byte sMeowthSprites45
+.4byte sMeowthSprites46
+.4byte sMeowthSprites47
+.4byte sMeowthSprites48
+.4byte sMeowthSprites49
+.4byte sMeowthSprites50
+.4byte sMeowthSprites51
+.4byte sMeowthSprites52
+.4byte sMeowthSprites53
+.4byte sMeowthSprites54
+.4byte sMeowthSprites55
+.4byte sMeowthSprites56
+.4byte sMeowthSprites57
+.4byte sMeowthSprites58
+.4byte sMeowthSprites59
+.4byte sMeowthSprites60
+.4byte sMeowthSprites61
+.4byte sMeowthSprites62
+.4byte sMeowthSprites63
+.4byte sMeowthSprites64
+.4byte sMeowthSprites65
+.4byte sMeowthSprites66
+.4byte sMeowthSprites67
+.4byte sMeowthSprites68
+.4byte sMeowthSprites69
+.4byte sMeowthSprites70
+.4byte sMeowthSprites71
+.4byte sMeowthSprites72
+.4byte sMeowthSprites73
+.4byte sMeowthSprites74
+.4byte sMeowthSprites75
+.4byte sMeowthSprites76
+.4byte sMeowthSprites77
+.4byte sMeowthSprites78
+.4byte sMeowthSprites79
+.4byte sMeowthSprites80
+sAxMainMeowth:
+ax_main sAxPosesMeowth, sAxAnimationsMeowth, 28, sAxSpritesMeowth, sAxPositionsMeowth

--- a/data/ax/metagross.inc
+++ b/data/ax/metagross.inc
@@ -1,0 +1,2645 @@
+.global gAxMetagross
+gAxMetagross:
+ax_siro sAxMainMetagross
+sMetagrossPose1:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose2:
+ax_pose 2, 0x81e8, 0x8108, 0xbc00
+ax_pose 3, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose3:
+ax_pose 4, 0x81e8, 0x8108, 0xbc00
+ax_pose 5, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose4:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose5:
+ax_pose 8, 0x81e9, 0x90e7, 0xbc00
+ax_pose 9, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose6:
+ax_pose 10, 0x81e9, 0x90e7, 0xbc00
+ax_pose 11, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose7:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose8:
+ax_pose 14, 0x81e8, 0x90e7, 0xbc00
+ax_pose 15, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose9:
+ax_pose 16, 0x81e8, 0x90e7, 0xbc00
+ax_pose 17, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose10:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose11:
+ax_pose 20, 0x01e9, 0x90f7, 0xbc00
+ax_pose 21, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose12:
+ax_pose 22, 0x01e9, 0x90f7, 0xbc00
+ax_pose 23, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose13:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose14:
+ax_pose 26, 0x81e8, 0x8108, 0xbc00
+ax_pose 27, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose15:
+ax_pose 28, 0x81e8, 0x8108, 0xbc00
+ax_pose 29, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose16:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose17:
+ax_pose 20, 0x01e9, 0x80e8, 0xbc00
+ax_pose 21, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose18:
+ax_pose 22, 0x01e9, 0x80e8, 0xbc00
+ax_pose 23, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose19:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose20:
+ax_pose 14, 0x81e8, 0x8108, 0xbc00
+ax_pose 15, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose21:
+ax_pose 16, 0x81e8, 0x8108, 0xbc00
+ax_pose 17, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose22:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose23:
+ax_pose 8, 0x81e9, 0x8108, 0xbc00
+ax_pose 9, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose24:
+ax_pose 10, 0x81e9, 0x8108, 0xbc00
+ax_pose 11, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose25:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose26:
+ax_pose 30, 0x01e8, 0x80e8, 0xbc00
+ax_pose 31, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose27:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose28:
+ax_pose 32, 0x01e8, 0x90f7, 0xbc00
+ax_pose 33, 0x81e8, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose29:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose30:
+ax_pose 34, 0x01e8, 0x90f7, 0xbc00
+ax_pose 35, 0x81e8, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose31:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose32:
+ax_pose 36, 0x01e9, 0x90f7, 0xbc00
+ax_pose 37, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose33:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose34:
+ax_pose 38, 0x01e8, 0x80e8, 0xbc00
+ax_pose 39, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose35:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose36:
+ax_pose 36, 0x01e9, 0x80e8, 0xbc00
+ax_pose 37, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose37:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose38:
+ax_pose 34, 0x01e8, 0x80e8, 0xbc00
+ax_pose 35, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose39:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose40:
+ax_pose 32, 0x01e8, 0x80e8, 0xbc00
+ax_pose 33, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose41:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose42:
+ax_pose 30, 0x01e8, 0x80e8, 0xbc00
+ax_pose 31, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose43:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose44:
+ax_pose 32, 0x01e8, 0x90f7, 0xbc00
+ax_pose 33, 0x81e8, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose45:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose46:
+ax_pose 34, 0x01e8, 0x90f7, 0xbc00
+ax_pose 35, 0x81e8, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose47:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose48:
+ax_pose 36, 0x01e9, 0x90f7, 0xbc00
+ax_pose 37, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose49:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose50:
+ax_pose 38, 0x01e8, 0x80e8, 0xbc00
+ax_pose 39, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose51:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose52:
+ax_pose 36, 0x01e9, 0x80e8, 0xbc00
+ax_pose 37, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose53:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose54:
+ax_pose 34, 0x01e8, 0x80e8, 0xbc00
+ax_pose 35, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose55:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose56:
+ax_pose 32, 0x01e8, 0x80e8, 0xbc00
+ax_pose 33, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose57:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose58:
+ax_pose 40, 0x81e8, 0x80e8, 0xbc00
+ax_pose 41, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose59:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose60:
+ax_pose 42, 0x81e9, 0x9107, 0xbc00
+ax_pose 43, 0x01e9, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose61:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose62:
+ax_pose 44, 0x81e8, 0x9107, 0xbc00
+ax_pose 45, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose63:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose64:
+ax_pose 46, 0x81e8, 0x9107, 0xbc00
+ax_pose 47, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose65:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose66:
+ax_pose 48, 0x81e8, 0x80e8, 0xbc00
+ax_pose 49, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose67:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose68:
+ax_pose 46, 0x81e8, 0x80e8, 0xbc00
+ax_pose 47, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose69:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose70:
+ax_pose 44, 0x81e8, 0x80e8, 0xbc00
+ax_pose 45, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose71:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose72:
+ax_pose 42, 0x81e9, 0x80e8, 0xbc00
+ax_pose 43, 0x01e9, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose73:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose74:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose75:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose76:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose77:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose78:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose79:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose80:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose81:
+ax_pose 50, 0x01e9, 0x80e9, 0xbc00
+ax_pose 51, 0x81e9, 0x8109, 0xbc10
+ax_pose_terminator
+sMetagrossPose82:
+ax_pose 52, 0x01e9, 0x80e9, 0xbc00
+ax_pose 51, 0x81e9, 0x8109, 0xbc10
+ax_pose_terminator
+sMetagrossPose83:
+ax_pose 53, 0x81eb, 0x8108, 0xbc00
+ax_pose 54, 0x01eb, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose84:
+ax_pose 55, 0x01ea, 0x90f5, 0xbc00
+ax_pose 56, 0x81ea, 0x90e5, 0xbc10
+ax_pose_terminator
+sMetagrossPose85:
+ax_pose 57, 0x81ec, 0x90e7, 0xbc00
+ax_pose 58, 0x01ec, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose86:
+ax_pose 59, 0x81e8, 0x90e7, 0xbc00
+ax_pose 60, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose87:
+ax_pose 61, 0x81ec, 0x8108, 0xbc00
+ax_pose 62, 0x01ec, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose88:
+ax_pose 59, 0x81e8, 0x8109, 0xbc00
+ax_pose 60, 0x01e8, 0x80e9, 0xbc08
+ax_pose_terminator
+sMetagrossPose89:
+ax_pose 57, 0x81ec, 0x8109, 0xbc00
+ax_pose 58, 0x01ec, 0x80e9, 0xbc08
+ax_pose_terminator
+sMetagrossPose90:
+ax_pose 55, 0x01ea, 0x80eb, 0xbc00
+ax_pose 56, 0x81ea, 0x810b, 0xbc10
+ax_pose_terminator
+sMetagrossPose91:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose92:
+ax_pose 40, 0x81e8, 0x80e8, 0xbc00
+ax_pose 41, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose93:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose94:
+ax_pose 42, 0x81e9, 0x9107, 0xbc00
+ax_pose 43, 0x01e9, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose95:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose96:
+ax_pose 44, 0x81e8, 0x9107, 0xbc00
+ax_pose 45, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose97:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose98:
+ax_pose 46, 0x81e8, 0x9107, 0xbc00
+ax_pose 47, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose99:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose100:
+ax_pose 48, 0x81e8, 0x80e8, 0xbc00
+ax_pose 49, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose101:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose102:
+ax_pose 46, 0x81e8, 0x80e8, 0xbc00
+ax_pose 47, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose103:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose104:
+ax_pose 44, 0x81e8, 0x80e8, 0xbc00
+ax_pose 45, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose105:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose106:
+ax_pose 42, 0x81e9, 0x80e8, 0xbc00
+ax_pose 43, 0x01e9, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose107:
+ax_pose 30, 0x01e8, 0x80e8, 0xbc00
+ax_pose 31, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose108:
+ax_pose 32, 0x01e8, 0x80e8, 0xbc00
+ax_pose 33, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose109:
+ax_pose 34, 0x01e8, 0x80e8, 0xbc00
+ax_pose 35, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose110:
+ax_pose 36, 0x01e9, 0x80e8, 0xbc00
+ax_pose 37, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose111:
+ax_pose 38, 0x01e8, 0x80e8, 0xbc00
+ax_pose 39, 0x81e8, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose112:
+ax_pose 36, 0x01e9, 0x90f7, 0xbc00
+ax_pose 37, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose113:
+ax_pose 34, 0x01e8, 0x90f7, 0xbc00
+ax_pose 35, 0x81e8, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose114:
+ax_pose 32, 0x01e8, 0x90f7, 0xbc00
+ax_pose 33, 0x81e8, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose115:
+ax_pose 40, 0x81e8, 0x80e8, 0xbc00
+ax_pose 41, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose116:
+ax_pose 42, 0x81e9, 0x9107, 0xbc00
+ax_pose 43, 0x01e9, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose117:
+ax_pose 44, 0x81e8, 0x9107, 0xbc00
+ax_pose 45, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose118:
+ax_pose 46, 0x81e9, 0x9107, 0xbc00
+ax_pose 47, 0x01e9, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose119:
+ax_pose 48, 0x81ea, 0x80e8, 0xbc00
+ax_pose 49, 0x01ea, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose120:
+ax_pose 46, 0x81e9, 0x80e8, 0xbc00
+ax_pose 47, 0x01e9, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose121:
+ax_pose 44, 0x81e8, 0x80e8, 0xbc00
+ax_pose 45, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose122:
+ax_pose 42, 0x81e9, 0x80e8, 0xbc00
+ax_pose 43, 0x01e9, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose123:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose124:
+ax_pose 40, 0x81e8, 0x80e8, 0xbc00
+ax_pose 41, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose125:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose126:
+ax_pose 42, 0x81e9, 0x9107, 0xbc00
+ax_pose 43, 0x01e9, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose127:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose128:
+ax_pose 44, 0x81e8, 0x9107, 0xbc00
+ax_pose 45, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose129:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose130:
+ax_pose 46, 0x81e8, 0x9107, 0xbc00
+ax_pose 47, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose131:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose132:
+ax_pose 48, 0x81e8, 0x80e8, 0xbc00
+ax_pose 49, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose133:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose134:
+ax_pose 46, 0x81e8, 0x80e8, 0xbc00
+ax_pose 47, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose135:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose136:
+ax_pose 44, 0x81e8, 0x80e8, 0xbc00
+ax_pose 45, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose137:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose138:
+ax_pose 42, 0x81e9, 0x80e8, 0xbc00
+ax_pose 43, 0x01e9, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose139:
+ax_pose 40, 0x81e8, 0x80e8, 0xbc00
+ax_pose 41, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose140:
+ax_pose 42, 0x81e9, 0x80e8, 0xbc00
+ax_pose 43, 0x01e9, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose141:
+ax_pose 44, 0x81e8, 0x80e8, 0xbc00
+ax_pose 45, 0x01e8, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose142:
+ax_pose 46, 0x81e9, 0x80e8, 0xbc00
+ax_pose 47, 0x01e9, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose143:
+ax_pose 48, 0x81ea, 0x80e8, 0xbc00
+ax_pose 49, 0x01ea, 0x80f8, 0xbc08
+ax_pose_terminator
+sMetagrossPose144:
+ax_pose 46, 0x81e9, 0x9107, 0xbc00
+ax_pose 47, 0x01e9, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose145:
+ax_pose 44, 0x81e8, 0x9107, 0xbc00
+ax_pose 45, 0x01e8, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose146:
+ax_pose 42, 0x81e9, 0x9107, 0xbc00
+ax_pose 43, 0x01e9, 0x90e7, 0xbc08
+ax_pose_terminator
+sMetagrossPose147:
+ax_pose 0, 0x81e8, 0x8108, 0xbc00
+ax_pose 1, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose148:
+ax_pose 6, 0x81e9, 0x8108, 0xbc00
+ax_pose 7, 0x01e9, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose149:
+ax_pose 12, 0x81e8, 0x8108, 0xbc00
+ax_pose 13, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose150:
+ax_pose 18, 0x01e9, 0x80e8, 0xbc00
+ax_pose 19, 0x81e9, 0x8108, 0xbc10
+ax_pose_terminator
+sMetagrossPose151:
+ax_pose 24, 0x81e8, 0x8108, 0xbc00
+ax_pose 25, 0x01e8, 0x80e8, 0xbc08
+ax_pose_terminator
+sMetagrossPose152:
+ax_pose 18, 0x01e9, 0x90f7, 0xbc00
+ax_pose 19, 0x81e9, 0x90e7, 0xbc10
+ax_pose_terminator
+sMetagrossPose153:
+ax_pose 12, 0x81e8, 0x90e7, 0xbc00
+ax_pose 13, 0x01e8, 0x90f7, 0xbc08
+ax_pose_terminator
+sMetagrossPose154:
+ax_pose 6, 0x81e9, 0x90e7, 0xbc00
+ax_pose 7, 0x01e9, 0x90f7, 0xbc08
+ax_pose_terminator
+.align 2
+sMetagrossAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_2_1:
+ax_anim 2, 0, 24, 0, -3, 0, 0,
+ax_anim 2, 0, 24, 0, -5, 0, 0,
+ax_anim 2, 0, 24, 0, -7, 0, 0,
+ax_anim 6, 0, 25, 0, -8, 0, 0,
+ax_anim 1, 2, 25, 0, -2, 0, 4,
+ax_anim 1, 0, 25, 0, 6, 0, 8,
+ax_anim 2, 0, 25, 0, 14, 0, 12,
+ax_anim 2, 1, 25, 0, 23, 0, 23,
+ax_anim 2, 0, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 0, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim_terminator
+sMetagrossAnims_2_2:
+ax_anim 2, 0, 26, 0, -3, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 2, 0, 26, 0, -7, 0, 0,
+ax_anim 6, 0, 27, 0, -8, 0, 0,
+ax_anim 1, 2, 27, 2, -6, 2, 2,
+ax_anim 1, 0, 27, 6, 2, 6, 6,
+ax_anim 2, 0, 27, 14, 14, 14, 14,
+ax_anim 2, 1, 27, 23, 23, 23, 23,
+ax_anim 2, 0, 27, 24, 22, 24, 22,
+ax_anim 2, 0, 27, 23, 23, 23, 23,
+ax_anim 2, 0, 27, 24, 22, 24, 22,
+ax_anim 2, 0, 27, 6, 6, 6, 8,
+ax_anim 2, 0, 27, 4, -4, 4, 4,
+ax_anim 2, 0, 26, 2, -2, 2, 2,
+ax_anim_terminator
+sMetagrossAnims_2_3:
+ax_anim 2, 0, 28, 0, -3, 0, 0,
+ax_anim 2, 0, 28, 0, -5, 0, 0,
+ax_anim 2, 0, 28, 0, -7, 0, 0,
+ax_anim 6, 0, 29, 0, -8, 0, 0,
+ax_anim 1, 2, 29, 2, -6, 2, 0,
+ax_anim 1, 0, 29, 6, -4, 6, 0,
+ax_anim 2, 0, 29, 14, -2, 14, 0,
+ax_anim 2, 1, 29, 23, 0, 23, 0,
+ax_anim 2, 0, 29, 23, -1, 23, -1,
+ax_anim 2, 0, 29, 23, 0, 23, 0,
+ax_anim 2, 0, 29, 23, -1, 23, -1,
+ax_anim 2, 0, 29, 6, 6, 6, 0,
+ax_anim 2, 0, 29, 4, -4, 4, 0,
+ax_anim 2, 0, 28, 2, -2, 2, 0,
+ax_anim_terminator
+sMetagrossAnims_2_4:
+ax_anim 2, 0, 30, 0, -3, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 2, 0, 30, 0, -7, 0, 0,
+ax_anim 6, 0, 31, 0, -8, 0, 0,
+ax_anim 1, 2, 31, 2, -8, 2, -2,
+ax_anim 1, 0, 31, 6, -9, 6, -6,
+ax_anim 2, 0, 31, 14, -12, 14, -14,
+ax_anim 2, 1, 31, 23, -17, 23, -23,
+ax_anim 2, 0, 31, 24, -16, 24, -22,
+ax_anim 2, 0, 31, 23, -17, 23, -23,
+ax_anim 2, 0, 31, 24, -16, 24, -22,
+ax_anim 2, 0, 31, 6, -5, 6, -6,
+ax_anim 2, 0, 31, 4, -4, 4, -4,
+ax_anim 2, 0, 30, 2, -2, 2, -2,
+ax_anim_terminator
+sMetagrossAnims_2_5:
+ax_anim 2, 0, 32, 0, -3, 0, 0,
+ax_anim 2, 0, 32, 0, -5, 0, 0,
+ax_anim 2, 0, 32, 0, -7, 0, 0,
+ax_anim 6, 0, 33, 0, -8, 0, 0,
+ax_anim 1, 2, 33, 0, -8, 0, -2,
+ax_anim 1, 0, 33, 0, -9, 0, -6,
+ax_anim 2, 0, 33, 0, -12, 0, -14,
+ax_anim 2, 1, 33, 0, -17, 0, -23,
+ax_anim 2, 0, 33, 0, -16, 0, -22,
+ax_anim 2, 0, 33, 0, -17, 0, -23,
+ax_anim 2, 0, 33, 0, -16, 0, -22,
+ax_anim 2, 0, 33, 0, -5, 0, -6,
+ax_anim 2, 0, 33, 0, -4, 0, -4,
+ax_anim 2, 0, 32, 0, -2, 0, -2,
+ax_anim_terminator
+sMetagrossAnims_2_6:
+ax_anim 2, 0, 34, 0, -3, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 2, 0, 34, 0, -7, 0, 0,
+ax_anim 6, 0, 35, 0, -8, 0, 0,
+ax_anim 1, 2, 35, -2, -8, -2, -2,
+ax_anim 1, 0, 35, -6, -9, -6, -6,
+ax_anim 2, 0, 35, -14, -12, -14, -14,
+ax_anim 2, 1, 35, -23, -17, -23, -23,
+ax_anim 2, 0, 35, -24, -16, -24, -22,
+ax_anim 2, 0, 35, -23, -17, -23, -23,
+ax_anim 2, 0, 35, -24, -16, -24, -22,
+ax_anim 2, 0, 35, -6, -5, -6, -6,
+ax_anim 2, 0, 35, -4, -4, -4, -4,
+ax_anim 2, 0, 34, -2, -2, -2, -2,
+ax_anim_terminator
+sMetagrossAnims_2_7:
+ax_anim 2, 0, 36, 0, -3, 0, 0,
+ax_anim 2, 0, 36, 0, -5, 0, 0,
+ax_anim 2, 0, 36, 0, -7, 0, 0,
+ax_anim 6, 0, 37, 0, -8, 0, 0,
+ax_anim 1, 2, 37, -2, -6, -2, 0,
+ax_anim 1, 0, 37, -6, -4, -6, 0,
+ax_anim 2, 0, 37, -14, -2, -14, 0,
+ax_anim 2, 1, 37, -23, 0, -23, 0,
+ax_anim 2, 0, 37, -23, -1, -23, -1,
+ax_anim 2, 0, 37, -23, 0, -23, 0,
+ax_anim 2, 0, 37, -23, -1, -23, -1,
+ax_anim 2, 0, 37, -6, 6, -6, 0,
+ax_anim 2, 0, 37, -4, -4, -4, 0,
+ax_anim 2, 0, 36, -2, -2, -2, 0,
+ax_anim_terminator
+sMetagrossAnims_2_8:
+ax_anim 2, 0, 38, 0, -3, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 2, 0, 38, 0, -7, 0, 0,
+ax_anim 6, 0, 39, 0, -8, 0, 0,
+ax_anim 1, 2, 39, -2, -6, -2, 2,
+ax_anim 1, 0, 39, -6, 2, -6, 6,
+ax_anim 2, 0, 39, -14, 14, -14, 14,
+ax_anim 2, 1, 39, -23, 23, -23, 23,
+ax_anim 2, 0, 39, -24, 22, -24, 22,
+ax_anim 2, 0, 39, -23, 23, -23, 23,
+ax_anim 2, 0, 39, -24, 22, -24, 22,
+ax_anim 2, 0, 39, -6, 6, -6, 8,
+ax_anim 2, 0, 39, -4, -4, -4, 4,
+ax_anim 2, 0, 38, -2, -2, -2, 2,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_3_1:
+ax_anim 2, 0, 40, 0, -3, 0, 0,
+ax_anim 2, 0, 40, 0, -5, 0, 0,
+ax_anim 2, 0, 40, 0, -7, 0, 0,
+ax_anim 6, 0, 41, 0, -8, 0, 0,
+ax_anim 1, 0, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 45, 0, 2, 0, 2,
+ax_anim 2, 2, 47, 0, 12, 0, 12,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 51, 0, 23, 0, 23,
+ax_anim 2, 0, 53, 0, 23, 0, 23,
+ax_anim 2, 0, 55, 0, 23, 0, 23,
+ax_anim 2, 0, 41, 0, 23, 0, 23,
+ax_anim 2, 0, 41, 0, 17, 0, 17,
+ax_anim 2, 0, 41, 0, 9, 0, 10,
+ax_anim 2, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 40, 0, -2, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_3_2:
+ax_anim 2, 0, 42, 0, -3, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 2, 0, 42, 0, -7, 0, 0,
+ax_anim 6, 0, 43, 0, -8, 0, 0,
+ax_anim 1, 0, 45, -2, -2, -2, -2,
+ax_anim 1, 0, 47, 1, 2, 1, 2,
+ax_anim 2, 2, 49, 5, 7, 5, 7,
+ax_anim 2, 0, 51, 14, 20, 14, 19,
+ax_anim 2, 1, 53, 16, 23, 16, 20,
+ax_anim 2, 0, 55, 16, 23, 16, 20,
+ax_anim 2, 0, 41, 16, 23, 16, 20,
+ax_anim 2, 0, 43, 16, 23, 16, 20,
+ax_anim 2, 0, 43, 13, 16, 12, 16,
+ax_anim 2, 0, 43, 7, 8, 7, 8,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_3_3:
+ax_anim 2, 0, 44, 0, -3, 0, 0,
+ax_anim 2, 0, 44, 0, -5, 0, 0,
+ax_anim 2, 0, 44, 0, -7, 0, 0,
+ax_anim 6, 0, 45, 0, -8, 0, 0,
+ax_anim 1, 0, 47, 2, -3, 2, 0,
+ax_anim 1, 0, 49, 5, -1, 5, 0,
+ax_anim 2, 2, 51, 8, 1, 8, 0,
+ax_anim 2, 0, 53, 14, 4, 14, 0,
+ax_anim 2, 1, 55, 15, 4, 15, 0,
+ax_anim 2, 0, 41, 15, 4, 15, 0,
+ax_anim 2, 0, 43, 15, 4, 15, 0,
+ax_anim 2, 0, 45, 15, 4, 15, 0,
+ax_anim 2, 0, 45, 11, 2, 11, 0,
+ax_anim 2, 0, 45, 7, -1, 7, 0,
+ax_anim 2, 0, 45, 0, -5, 0, 0,
+ax_anim 2, 0, 44, 0, -2, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_3_4:
+ax_anim 2, 0, 46, 0, -3, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 2, 0, 46, 0, -7, 0, 0,
+ax_anim 6, 0, 47, 0, -8, 0, 0,
+ax_anim 1, 0, 49, -2, -3, -2, 1,
+ax_anim 1, 0, 51, 4, -8, 4, -5,
+ax_anim 2, 2, 53, 10, -12, 10, -12,
+ax_anim 2, 0, 55, 14, -15, 14, -17,
+ax_anim 2, 1, 41, 16, -17, 16, -20,
+ax_anim 2, 0, 43, 16, -17, 16, -20,
+ax_anim 2, 0, 45, 16, -17, 16, -20,
+ax_anim 2, 0, 47, 16, -17, 16, -20,
+ax_anim 2, 0, 47, 10, -13, 10, -13,
+ax_anim 2, 0, 47, 5, -7, 5, -7,
+ax_anim 2, 0, 47, 0, -5, 0, 0,
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_3_5:
+ax_anim 2, 0, 48, 0, -3, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 2, 0, 48, 0, -7, 0, 0,
+ax_anim 6, 0, 49, 0, -8, 0, 0,
+ax_anim 1, 0, 51, 0, 1, 0, 3,
+ax_anim 1, 0, 53, 0, -5, 0, -2,
+ax_anim 2, 2, 55, 0, -9, 0, -7,
+ax_anim 2, 0, 41, 0, -13, 0, -11,
+ax_anim 2, 1, 43, 0, -16, 0, -18,
+ax_anim 2, 0, 45, 0, -16, 0, -18,
+ax_anim 2, 0, 47, 0, -16, 0, -18,
+ax_anim 2, 0, 49, 0, -16, 0, -18,
+ax_anim 2, 0, 49, 0, -11, 0, -14,
+ax_anim 2, 0, 49, 0, -8, 0, -7,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 2, 0, 48, 0, -2, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_3_6:
+ax_anim 2, 0, 50, 0, -3, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 2, 0, 50, 0, -7, 0, 0,
+ax_anim 6, 0, 51, 0, -8, 0, 0,
+ax_anim 1, 0, 53, 2, -3, 2, 1,
+ax_anim 1, 0, 55, -4, -8, -4, -5,
+ax_anim 2, 2, 41, -10, -12, -10, -12,
+ax_anim 2, 0, 43, -14, -15, -14, -17,
+ax_anim 2, 1, 45, -16, -17, -16, -20,
+ax_anim 2, 0, 47, -16, -17, -16, -20,
+ax_anim 2, 0, 49, -16, -17, -16, -20,
+ax_anim 2, 0, 51, -16, -17, -16, -20,
+ax_anim 2, 0, 51, -10, -13, -10, -13,
+ax_anim 2, 0, 51, -5, -7, -5, -7,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_3_7:
+ax_anim 2, 0, 52, 0, -3, 0, 0,
+ax_anim 2, 0, 52, 0, -5, 0, 0,
+ax_anim 2, 0, 52, 0, -7, 0, 0,
+ax_anim 6, 0, 53, 0, -8, 0, 0,
+ax_anim 1, 0, 55, -2, -3, -2, 0,
+ax_anim 1, 0, 41, -5, -1, -5, 0,
+ax_anim 2, 2, 43, -8, 1, -8, 0,
+ax_anim 2, 0, 45, -14, 4, -14, 0,
+ax_anim 2, 1, 47, -15, 4, -15, 0,
+ax_anim 2, 0, 49, -15, 4, -15, 0,
+ax_anim 2, 0, 51, -15, 4, -15, 0,
+ax_anim 2, 0, 53, -15, 4, -15, 0,
+ax_anim 2, 0, 53, -11, 2, -11, 0,
+ax_anim 2, 0, 53, -7, -1, -7, 0,
+ax_anim 2, 0, 53, 0, -5, 0, 0,
+ax_anim 2, 0, 52, 0, -2, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_3_8:
+ax_anim 2, 0, 54, 0, -3, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 2, 0, 54, 0, -7, 0, 0,
+ax_anim 6, 0, 55, 0, -8, 0, 0,
+ax_anim 1, 0, 41, 2, -2, 2, -2,
+ax_anim 1, 0, 43, -1, 2, -1, 2,
+ax_anim 2, 2, 45, -5, 7, -5, 7,
+ax_anim 2, 0, 51, -14, 20, -14, 19,
+ax_anim 2, 1, 49, -15, 23, -16, 20,
+ax_anim 2, 0, 51, -15, 23, -16, 20,
+ax_anim 2, 0, 53, -15, 23, -16, 20,
+ax_anim 2, 0, 55, -15, 23, -16, 20,
+ax_anim 2, 0, 55, -13, 16, -12, 16,
+ax_anim 2, 0, 55, -7, 8, -7, 8,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_4_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 6, 2, 56, 0, -3, 0, -3,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 2, 1, 57, 0, 3, 0, 3,
+ax_anim 2, 0, 57, 1, 3, 1, 3,
+ax_anim 2, 0, 57, 0, 3, 0, 3,
+ax_anim 2, 0, 57, 1, 3, 1, 3,
+ax_anim 2, 0, 57, 0, 3, 0, 3,
+ax_anim 2, 0, 57, 1, 3, 1, 3,
+ax_anim 2, 0, 57, 0, 3, 0, 3,
+ax_anim 2, 0, 56, 0, 1, 0, 1,
+ax_anim_terminator
+sMetagrossAnims_4_2:
+ax_anim 2, 0, 58, -2, -2, -2, -2,
+ax_anim 6, 2, 58, -3, -3, -3, -3,
+ax_anim 2, 0, 58, -1, -1, -1, -1,
+ax_anim 2, 1, 59, 2, 2, 2, 2,
+ax_anim 2, 0, 59, 3, 1, 3, 1,
+ax_anim 2, 0, 59, 2, 2, 2, 2,
+ax_anim 2, 0, 59, 3, 1, 3, 1,
+ax_anim 2, 0, 59, 2, 2, 2, 2,
+ax_anim 2, 0, 59, 3, 1, 3, 1,
+ax_anim 2, 0, 59, 2, 2, 2, 2,
+ax_anim 2, 0, 58, 1, 1, 1, 1,
+ax_anim_terminator
+sMetagrossAnims_4_3:
+ax_anim 2, 0, 60, -2, 0, -2, 0,
+ax_anim 6, 2, 60, -3, 0, -3, 0,
+ax_anim 2, 0, 60, -1, 0, -1, 0,
+ax_anim 2, 1, 61, 2, 0, 2, 0,
+ax_anim 2, 0, 61, 2, 1, 2, 1,
+ax_anim 2, 0, 61, 2, 0, 2, 0,
+ax_anim 2, 0, 61, 2, 1, 2, 1,
+ax_anim 2, 0, 61, 2, 0, 2, 0,
+ax_anim 2, 0, 61, 2, 1, 2, 1,
+ax_anim 2, 0, 61, 2, 0, 2, 0,
+ax_anim 2, 0, 60, 1, 0, 1, 0,
+ax_anim_terminator
+sMetagrossAnims_4_4:
+ax_anim 2, 0, 62, -2, 2, -2, 2,
+ax_anim 6, 2, 62, -3, 3, -3, 3,
+ax_anim 2, 0, 62, -1, 1, -1, 1,
+ax_anim 2, 1, 63, 2, -2, 2, -2,
+ax_anim 2, 0, 63, 3, -1, 3, -1,
+ax_anim 2, 0, 63, 2, -2, 2, -2,
+ax_anim 2, 0, 63, 3, -1, 3, -1,
+ax_anim 2, 0, 63, 2, -2, 2, -2,
+ax_anim 2, 0, 63, 3, -1, 3, -1,
+ax_anim 2, 0, 63, 2, -2, 2, -2,
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim_terminator
+sMetagrossAnims_4_5:
+ax_anim 2, 0, 64, 0, 2, 0, 2,
+ax_anim 6, 2, 64, 0, 3, 0, 3,
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 1, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 65, 1, -3, 1, -3,
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 65, 1, -3, 1, -3,
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 65, 1, -3, 1, -3,
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim_terminator
+sMetagrossAnims_4_6:
+ax_anim 2, 0, 66, 2, 2, 2, 2,
+ax_anim 6, 2, 66, 3, 3, 3, 3,
+ax_anim 2, 0, 66, 1, 1, 1, 1,
+ax_anim 2, 1, 67, -2, -2, -2, -2,
+ax_anim 2, 0, 67, -3, -1, -3, -1,
+ax_anim 2, 0, 67, -2, -2, -2, -2,
+ax_anim 2, 0, 67, -3, -1, -3, -1,
+ax_anim 2, 0, 67, -2, -2, -2, -2,
+ax_anim 2, 0, 67, -3, -1, -3, -1,
+ax_anim 2, 0, 67, -2, -2, -2, -2,
+ax_anim 2, 0, 66, -1, -1, -1, -1,
+ax_anim_terminator
+sMetagrossAnims_4_7:
+ax_anim 2, 0, 68, 2, 0, 2, 0,
+ax_anim 6, 2, 68, 3, 0, 3, 0,
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 1, 69, -2, 0, -2, 0,
+ax_anim 2, 0, 69, -2, 1, -2, 1,
+ax_anim 2, 0, 69, -2, 0, -2, 0,
+ax_anim 2, 0, 69, -2, 1, -2, 1,
+ax_anim 2, 0, 69, -2, 0, -2, 0,
+ax_anim 2, 0, 69, -2, 1, -2, 1,
+ax_anim 2, 0, 69, -2, 0, -2, 0,
+ax_anim 2, 0, 68, -1, 0, -1, 0,
+ax_anim_terminator
+sMetagrossAnims_4_8:
+ax_anim 2, 0, 70, 2, -2, 2, -2,
+ax_anim 6, 2, 70, 3, -3, 3, -3,
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 2, 1, 71, -2, 2, -2, 2,
+ax_anim 2, 0, 71, -3, 1, -3, 1,
+ax_anim 2, 0, 71, -2, 2, -2, 2,
+ax_anim 2, 0, 71, -3, 1, -3, 1,
+ax_anim 2, 0, 71, -2, 2, -2, 2,
+ax_anim 2, 0, 71, -3, 1, -3, 1,
+ax_anim 2, 0, 71, -2, 2, -2, 2,
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_5_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_5_2:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_5_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_5_4:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_5_5:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_5_6:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_5_7:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_5_8:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_6_1:
+ax_anim 30, 0, 80, 0, 0, 0, 0,
+ax_anim 35, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_7_1:
+ax_anim 2, 0, 82, 0, -2, 0, -2,
+ax_anim 8, 0, 82, 0, -3, 0, -3,
+ax_anim_terminator
+sMetagrossAnims_7_2:
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 8, 0, 83, -3, -3, -3, -3,
+ax_anim_terminator
+sMetagrossAnims_7_3:
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 8, 0, 84, -3, 0, -3, 0,
+ax_anim_terminator
+sMetagrossAnims_7_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 8, 0, 85, -3, 3, -3, 3,
+ax_anim_terminator
+sMetagrossAnims_7_5:
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 8, 0, 86, 0, 3, 0, 3,
+ax_anim_terminator
+sMetagrossAnims_7_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 8, 0, 87, 3, 3, 3, 3,
+ax_anim_terminator
+sMetagrossAnims_7_7:
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 8, 0, 88, 3, 0, 3, 0,
+ax_anim_terminator
+sMetagrossAnims_7_8:
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim 8, 0, 89, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_8_1:
+ax_anim 40, 0, 90, 0, 0, 0, 0,
+ax_anim 20, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_8_2:
+ax_anim 40, 0, 92, 0, 0, 0, 0,
+ax_anim 20, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_8_3:
+ax_anim 40, 0, 94, 0, 0, 0, 0,
+ax_anim 20, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_8_4:
+ax_anim 40, 0, 96, 0, 0, 0, 0,
+ax_anim 20, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_8_5:
+ax_anim 40, 0, 98, 0, 0, 0, 0,
+ax_anim 20, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_8_6:
+ax_anim 40, 0, 100, 0, 0, 0, 0,
+ax_anim 20, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_8_7:
+ax_anim 40, 0, 102, 0, 0, 0, 0,
+ax_anim 20, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_8_8:
+ax_anim 40, 0, 104, 0, 0, 0, 0,
+ax_anim 20, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_9_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 6, 4, 6, 4,
+ax_anim 2, 0, 108, 9, 12, 9, 12,
+ax_anim 2, 0, 109, 7, 21, 7, 19,
+ax_anim 3, 0, 110, 0, 25, 0, 22,
+ax_anim 2, 3, 111, -7, 21, -7, 19,
+ax_anim 2, 0, 112, -9, 12, -9, 12,
+ax_anim 1, 0, 113, -6, 4, -6, 4,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_9_2:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 11, 2, 11, 2,
+ax_anim 2, 0, 107, 20, 7, 20, 7,
+ax_anim 2, 0, 108, 24, 15, 24, 15,
+ax_anim 3, 0, 109, 23, 24, 23, 22,
+ax_anim 2, 3, 110, 13, 27, 13, 24,
+ax_anim 2, 0, 111, 6, 19, 6, 19,
+ax_anim 1, 0, 112, 1, 9, 1, 9,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_9_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 4, -4, 4, -4,
+ax_anim 2, 0, 106, 13, -6, 13, -6,
+ax_anim 2, 0, 107, 20, -2, 20, -3,
+ax_anim 3, 0, 108, 23, 4, 23, 2,
+ax_anim 2, 3, 109, 19, 9, 19, 9,
+ax_anim 2, 0, 110, 11, 11, 11, 10,
+ax_anim 1, 0, 111, 4, 7, 4, 7,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_9_4:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 1, -7, 1, -7,
+ax_anim 2, 0, 113, 5, -13, 5, -13,
+ax_anim 2, 0, 106, 13, -17, 13, -19,
+ax_anim 3, 0, 107, 21, -16, 21, -19,
+ax_anim 2, 3, 108, 23, -11, 23, -12,
+ax_anim 2, 0, 109, 19, -4, 19, -4,
+ax_anim 1, 0, 110, 12, 0, 12, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_9_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, -5, -2, -4, -2,
+ax_anim 2, 0, 112, -9, -7, -9, -7,
+ax_anim 2, 0, 113, -7, -14, -7, -16,
+ax_anim 3, 0, 106, 0, -17, 0, -19,
+ax_anim 2, 3, 107, 7, -14, 7, -16,
+ax_anim 2, 0, 108, 9, -7, 9, -7,
+ax_anim 1, 0, 109, 5, -2, 4, -2,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_9_6:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 1, -7, 1, -7,
+ax_anim 2, 0, 107, -5, -13, -5, -13,
+ax_anim 2, 0, 106, -13, -17, -13, -19,
+ax_anim 3, 0, 113, -21, -16, -21, -19,
+ax_anim 2, 3, 112, -23, -11, -23, -12,
+ax_anim 2, 0, 111, -19, -4, -19, -4,
+ax_anim 1, 0, 110, -12, 0, -12, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_9_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, -4, -4, -4, -4,
+ax_anim 2, 0, 106, -13, -6, -13, -6,
+ax_anim 2, 0, 113, -20, -2, -20, -3,
+ax_anim 3, 0, 112, -23, 4, -23, 2,
+ax_anim 2, 3, 111, -19, 9, -19, 9,
+ax_anim 2, 0, 110, -11, 11, -11, 10,
+ax_anim 1, 0, 109, -4, 7, -4, 7,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_9_8:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, -11, 2, -11, 2,
+ax_anim 2, 0, 113, -20, 7, -20, 7,
+ax_anim 2, 0, 112, -24, 15, -24, 15,
+ax_anim 3, 0, 111, -23, 24, -23, 22,
+ax_anim 2, 3, 110, -13, 27, -13, 24,
+ax_anim 2, 0, 109, -6, 19, -6, 19,
+ax_anim 1, 0, 108, -1, 9, -1, 9,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_10_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 3, 0, 114, 13, 0, 13, 0,
+ax_anim 3, 0, 114, -13, 0, -13, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_10_2:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 3, 0, 115, 13, -13, 13, -13,
+ax_anim 3, 0, 115, -13, 13, -13, 13,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_10_3:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 3, 0, 116, 0, -13, 0, -13,
+ax_anim 3, 0, 116, 0, 13, 0, 13,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_10_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 3, 0, 117, -13, -13, -13, -13,
+ax_anim 3, 0, 117, 13, 13, 13, 13,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_10_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 3, 0, 118, 13, 0, 13, 0,
+ax_anim 3, 0, 118, -13, 0, -13, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_10_6:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 3, 0, 119, 13, -13, 13, -13,
+ax_anim 3, 0, 119, -13, 13, -13, 13,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_10_7:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 3, 0, 120, 0, -13, 0, -13,
+ax_anim 3, 0, 120, 0, 13, 0, 13,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_10_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 3, 0, 121, -13, -13, -13, -13,
+ax_anim 3, 0, 121, 13, 13, 13, 13,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_11_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -10, 0, 0,
+ax_anim 2, 0, 122, 0, -16, 0, 0,
+ax_anim 3, 0, 122, 0, -20, 0, 0,
+ax_anim 4, 0, 122, 0, -21, 0, 0,
+ax_anim 4, 0, 122, 0, -23, 0, 0,
+ax_anim 3, 0, 123, 0, -22, 0, 0,
+ax_anim 2, 0, 123, 0, -18, 0, 0,
+ax_anim 1, 0, 123, 0, -8, 0, 0,
+ax_anim 2, 2, 123, 0, 5, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_11_2:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, -10, 0, 0,
+ax_anim 2, 0, 124, 0, -16, 0, 0,
+ax_anim 3, 0, 124, 0, -20, 0, 0,
+ax_anim 4, 0, 124, 0, -21, 0, 0,
+ax_anim 4, 0, 124, 0, -23, 0, 0,
+ax_anim 3, 0, 125, 0, -21, 0, 0,
+ax_anim 2, 0, 125, 0, -18, 0, 0,
+ax_anim 1, 0, 125, 0, -8, 0, 0,
+ax_anim 2, 2, 125, 0, 5, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_11_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, -10, 0, 0,
+ax_anim 2, 0, 126, 0, -16, 0, 0,
+ax_anim 3, 0, 126, 0, -20, 0, 0,
+ax_anim 4, 0, 126, 0, -21, 0, 0,
+ax_anim 4, 0, 126, 0, -23, 0, 0,
+ax_anim 3, 0, 127, 0, -22, 0, 0,
+ax_anim 2, 0, 127, 0, -18, 0, 0,
+ax_anim 1, 0, 127, 0, -8, 0, 0,
+ax_anim 2, 2, 127, 0, 5, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_11_4:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 2, 0, 128, 0, -16, 0, 0,
+ax_anim 3, 0, 128, 0, -20, 0, 0,
+ax_anim 4, 0, 128, 0, -21, 0, 0,
+ax_anim 4, 0, 128, 0, -22, 0, 0,
+ax_anim 3, 0, 129, 0, -21, 0, 0,
+ax_anim 2, 0, 129, 0, -17, 0, 0,
+ax_anim 1, 0, 129, 0, -8, 0, 0,
+ax_anim 2, 2, 129, 0, 5, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_11_5:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 2, 0, 130, 0, -16, 0, 0,
+ax_anim 3, 0, 130, 0, -20, 0, 0,
+ax_anim 4, 0, 130, 0, -21, 0, 0,
+ax_anim 4, 0, 130, 0, -23, 0, 0,
+ax_anim 3, 0, 131, 0, -22, 0, 0,
+ax_anim 2, 0, 131, 0, -18, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 2, 131, 0, 5, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_11_6:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 2, 0, 132, 0, -16, 0, 0,
+ax_anim 3, 0, 132, 0, -20, 0, 0,
+ax_anim 4, 0, 132, 0, -21, 0, 0,
+ax_anim 4, 0, 132, 0, -22, 0, 0,
+ax_anim 3, 0, 133, 0, -21, 0, 0,
+ax_anim 2, 0, 133, 0, -17, 0, 0,
+ax_anim 1, 0, 133, 0, -8, 0, 0,
+ax_anim 2, 2, 133, 0, 5, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_11_7:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 2, 0, 134, 0, -16, 0, 0,
+ax_anim 3, 0, 134, 0, -20, 0, 0,
+ax_anim 4, 0, 134, 0, -21, 0, 0,
+ax_anim 4, 0, 134, 0, -23, 0, 0,
+ax_anim 3, 0, 135, 0, -22, 0, 0,
+ax_anim 2, 0, 135, 0, -18, 0, 0,
+ax_anim 1, 0, 135, 0, -8, 0, 0,
+ax_anim 2, 2, 135, 0, 5, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_11_8:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, -10, 0, 0,
+ax_anim 2, 0, 136, 0, -16, 0, 0,
+ax_anim 3, 0, 136, 0, -20, 0, 0,
+ax_anim 4, 0, 136, 0, -21, 0, 0,
+ax_anim 4, 0, 136, 0, -23, 0, 0,
+ax_anim 3, 0, 137, 0, -21, 0, 0,
+ax_anim 2, 0, 137, 0, -18, 0, 0,
+ax_anim 1, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 2, 137, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_12_1:
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_12_2:
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 1, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_12_3:
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_12_4:
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_12_5:
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_12_6:
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_12_7:
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 1, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_12_8:
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetagrossAnims_13_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_13_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_13_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_13_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_13_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_13_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_13_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossAnims_13_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMetagrossGfx1:
+.incbin "baserom.gba", 0x157DD94, 0x100
+sMetagrossSprites1:
+ax_sprite sMetagrossGfx1, 0x100
+ax_sprite_terminator
+sMetagrossGfx2:
+.incbin "baserom.gba", 0x157DEA4, 0x200
+sMetagrossSprites2:
+ax_sprite sMetagrossGfx2, 0x200
+ax_sprite_terminator
+sMetagrossGfx3:
+.incbin "baserom.gba", 0x157E0B4, 0x100
+sMetagrossSprites3:
+ax_sprite sMetagrossGfx3, 0x100
+ax_sprite_terminator
+sMetagrossGfx4:
+.incbin "baserom.gba", 0x157E1C4, 0x200
+sMetagrossSprites4:
+ax_sprite sMetagrossGfx4, 0x200
+ax_sprite_terminator
+sMetagrossGfx5:
+.incbin "baserom.gba", 0x157E3D4, 0x100
+sMetagrossSprites5:
+ax_sprite sMetagrossGfx5, 0x100
+ax_sprite_terminator
+sMetagrossGfx6:
+.incbin "baserom.gba", 0x157E4E4, 0x200
+sMetagrossSprites6:
+ax_sprite sMetagrossGfx6, 0x200
+ax_sprite_terminator
+sMetagrossGfx7:
+.incbin "baserom.gba", 0x157E6F4, 0x100
+sMetagrossSprites7:
+ax_sprite sMetagrossGfx7, 0x100
+ax_sprite_terminator
+sMetagrossGfx8:
+.incbin "baserom.gba", 0x157E804, 0x200
+sMetagrossSprites8:
+ax_sprite sMetagrossGfx8, 0x200
+ax_sprite_terminator
+sMetagrossGfx9:
+.incbin "baserom.gba", 0x157EA14, 0x100
+sMetagrossSprites9:
+ax_sprite sMetagrossGfx9, 0x100
+ax_sprite_terminator
+sMetagrossGfx10:
+.incbin "baserom.gba", 0x157EB24, 0x200
+sMetagrossSprites10:
+ax_sprite sMetagrossGfx10, 0x200
+ax_sprite_terminator
+sMetagrossGfx11:
+.incbin "baserom.gba", 0x157ED34, 0x100
+sMetagrossSprites11:
+ax_sprite sMetagrossGfx11, 0x100
+ax_sprite_terminator
+sMetagrossGfx12:
+.incbin "baserom.gba", 0x157EE44, 0x200
+sMetagrossSprites12:
+ax_sprite sMetagrossGfx12, 0x200
+ax_sprite_terminator
+sMetagrossGfx13:
+.incbin "baserom.gba", 0x157F054, 0x100
+sMetagrossSprites13:
+ax_sprite sMetagrossGfx13, 0x100
+ax_sprite_terminator
+sMetagrossGfx14:
+.incbin "baserom.gba", 0x157F164, 0x200
+sMetagrossSprites14:
+ax_sprite sMetagrossGfx14, 0x200
+ax_sprite_terminator
+sMetagrossGfx15:
+.incbin "baserom.gba", 0x157F374, 0x100
+sMetagrossSprites15:
+ax_sprite sMetagrossGfx15, 0x100
+ax_sprite_terminator
+sMetagrossGfx16:
+.incbin "baserom.gba", 0x157F484, 0x200
+sMetagrossSprites16:
+ax_sprite sMetagrossGfx16, 0x200
+ax_sprite_terminator
+sMetagrossGfx17:
+.incbin "baserom.gba", 0x157F694, 0x100
+sMetagrossSprites17:
+ax_sprite sMetagrossGfx17, 0x100
+ax_sprite_terminator
+sMetagrossGfx18:
+.incbin "baserom.gba", 0x157F7A4, 0x200
+sMetagrossSprites18:
+ax_sprite sMetagrossGfx18, 0x200
+ax_sprite_terminator
+sMetagrossGfx19:
+.incbin "baserom.gba", 0x157F9B4, 0x200
+sMetagrossSprites19:
+ax_sprite sMetagrossGfx19, 0x200
+ax_sprite_terminator
+sMetagrossGfx20:
+.incbin "baserom.gba", 0x157FBC4, 0x100
+sMetagrossSprites20:
+ax_sprite sMetagrossGfx20, 0x100
+ax_sprite_terminator
+sMetagrossGfx21:
+.incbin "baserom.gba", 0x157FCD4, 0x200
+sMetagrossSprites21:
+ax_sprite sMetagrossGfx21, 0x200
+ax_sprite_terminator
+sMetagrossGfx22:
+.incbin "baserom.gba", 0x157FEE4, 0x100
+sMetagrossSprites22:
+ax_sprite sMetagrossGfx22, 0x100
+ax_sprite_terminator
+sMetagrossGfx23:
+.incbin "baserom.gba", 0x157FFF4, 0x200
+sMetagrossSprites23:
+ax_sprite sMetagrossGfx23, 0x200
+ax_sprite_terminator
+sMetagrossGfx24:
+.incbin "baserom.gba", 0x1580204, 0x100
+sMetagrossSprites24:
+ax_sprite sMetagrossGfx24, 0x100
+ax_sprite_terminator
+sMetagrossGfx25:
+.incbin "baserom.gba", 0x1580314, 0x100
+sMetagrossSprites25:
+ax_sprite sMetagrossGfx25, 0x100
+ax_sprite_terminator
+sMetagrossGfx26:
+.incbin "baserom.gba", 0x1580424, 0x200
+sMetagrossSprites26:
+ax_sprite sMetagrossGfx26, 0x200
+ax_sprite_terminator
+sMetagrossGfx27:
+.incbin "baserom.gba", 0x1580634, 0x100
+sMetagrossSprites27:
+ax_sprite sMetagrossGfx27, 0x100
+ax_sprite_terminator
+sMetagrossGfx28:
+.incbin "baserom.gba", 0x1580744, 0x200
+sMetagrossSprites28:
+ax_sprite sMetagrossGfx28, 0x200
+ax_sprite_terminator
+sMetagrossGfx29:
+.incbin "baserom.gba", 0x1580954, 0x100
+sMetagrossSprites29:
+ax_sprite sMetagrossGfx29, 0x100
+ax_sprite_terminator
+sMetagrossGfx30:
+.incbin "baserom.gba", 0x1580A64, 0x200
+sMetagrossSprites30:
+ax_sprite sMetagrossGfx30, 0x200
+ax_sprite_terminator
+sMetagrossGfx31:
+.incbin "baserom.gba", 0x1580C74, 0x160
+sMetagrossSprites31:
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx31, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetagrossGfx32:
+.incbin "baserom.gba", 0x1580DF4, 0x20
+sMetagrossGfx32_1:
+.incbin "baserom.gba", 0x1580E14, 0x80
+sMetagrossSprites32:
+ax_sprite sMetagrossGfx32, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx32_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetagrossGfx33:
+.incbin "baserom.gba", 0x1580EBC, 0x100
+sMetagrossGfx33_1:
+.incbin "baserom.gba", 0x1580FBC, 0x60
+sMetagrossSprites33:
+ax_sprite sMetagrossGfx33, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx33_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetagrossGfx34:
+.incbin "baserom.gba", 0x1581044, 0xA0
+sMetagrossSprites34:
+ax_sprite sMetagrossGfx34, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMetagrossGfx35:
+.incbin "baserom.gba", 0x15810FC, 0x160
+sMetagrossSprites35:
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx35, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetagrossGfx36:
+.incbin "baserom.gba", 0x158127C, 0x20
+sMetagrossGfx36_1:
+.incbin "baserom.gba", 0x158129C, 0x80
+sMetagrossSprites36:
+ax_sprite sMetagrossGfx36, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx36_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetagrossGfx37:
+.incbin "baserom.gba", 0x1581344, 0x100
+sMetagrossGfx37_1:
+.incbin "baserom.gba", 0x1581444, 0x60
+sMetagrossSprites37:
+ax_sprite sMetagrossGfx37, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx37_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetagrossGfx38:
+.incbin "baserom.gba", 0x15814CC, 0x80
+sMetagrossSprites38:
+ax_sprite sMetagrossGfx38, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetagrossGfx39:
+.incbin "baserom.gba", 0x1581564, 0x160
+sMetagrossSprites39:
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx39, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetagrossGfx40:
+.incbin "baserom.gba", 0x15816E4, 0x20
+sMetagrossGfx40_1:
+.incbin "baserom.gba", 0x1581704, 0x80
+sMetagrossSprites40:
+ax_sprite sMetagrossGfx40, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx40_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetagrossGfx41:
+.incbin "baserom.gba", 0x15817AC, 0xE0
+sMetagrossSprites41:
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx41, 0xe0
+ax_sprite_terminator
+sMetagrossGfx42:
+.incbin "baserom.gba", 0x15818A4, 0x60
+sMetagrossGfx42_1:
+.incbin "baserom.gba", 0x1581904, 0x60
+sMetagrossGfx42_2:
+.incbin "baserom.gba", 0x1581964, 0x80
+sMetagrossGfx42_3:
+.incbin "baserom.gba", 0x15819E4, 0x40
+sMetagrossSprites42:
+ax_sprite sMetagrossGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx42_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sMetagrossGfx42_3, 0x40
+ax_sprite_terminator
+sMetagrossGfx43:
+.incbin "baserom.gba", 0x1581A64, 0xC0
+sMetagrossSprites43:
+ax_sprite sMetagrossGfx43, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetagrossGfx44:
+.incbin "baserom.gba", 0x1581B3C, 0x60
+sMetagrossGfx44_1:
+.incbin "baserom.gba", 0x1581B9C, 0x160
+sMetagrossSprites44:
+ax_sprite sMetagrossGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx44_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetagrossGfx45:
+.incbin "baserom.gba", 0x1581D24, 0x20
+sMetagrossGfx45_1:
+.incbin "baserom.gba", 0x1581D44, 0xA0
+sMetagrossSprites45:
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx45, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx45_1, 0xa0
+ax_sprite_terminator
+sMetagrossGfx46:
+.incbin "baserom.gba", 0x1581E0C, 0x40
+sMetagrossGfx46_1:
+.incbin "baserom.gba", 0x1581E4C, 0x60
+sMetagrossGfx46_2:
+.incbin "baserom.gba", 0x1581EAC, 0x80
+sMetagrossGfx46_3:
+.incbin "baserom.gba", 0x1581F2C, 0x60
+sMetagrossSprites46:
+ax_sprite sMetagrossGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetagrossGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx46_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx46_3, 0x60
+ax_sprite_terminator
+sMetagrossGfx47:
+.incbin "baserom.gba", 0x1581FCC, 0xC0
+sMetagrossGfx47_1:
+.incbin "baserom.gba", 0x158208C, 0x20
+sMetagrossSprites47:
+ax_sprite sMetagrossGfx47, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx47_1, 0x20
+ax_sprite_terminator
+sMetagrossGfx48:
+.incbin "baserom.gba", 0x15820CC, 0x60
+sMetagrossGfx48_1:
+.incbin "baserom.gba", 0x158212C, 0x60
+sMetagrossGfx48_2:
+.incbin "baserom.gba", 0x158218C, 0xA0
+sMetagrossSprites48:
+ax_sprite sMetagrossGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx48_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMetagrossGfx49:
+.incbin "baserom.gba", 0x1582264, 0x20
+sMetagrossGfx49_1:
+.incbin "baserom.gba", 0x1582284, 0xA0
+sMetagrossSprites49:
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx49, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx49_1, 0xa0
+ax_sprite_terminator
+sMetagrossGfx50:
+.incbin "baserom.gba", 0x158234C, 0x60
+sMetagrossGfx50_1:
+.incbin "baserom.gba", 0x15823AC, 0x60
+sMetagrossGfx50_2:
+.incbin "baserom.gba", 0x158240C, 0x80
+sMetagrossGfx50_3:
+.incbin "baserom.gba", 0x158248C, 0x60
+sMetagrossSprites50:
+ax_sprite sMetagrossGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx50_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMetagrossGfx50_3, 0x60
+ax_sprite_terminator
+sMetagrossGfx51:
+.incbin "baserom.gba", 0x158252C, 0x200
+sMetagrossSprites51:
+ax_sprite sMetagrossGfx51, 0x200
+ax_sprite_terminator
+sMetagrossGfx52:
+.incbin "baserom.gba", 0x158273C, 0x100
+sMetagrossSprites52:
+ax_sprite sMetagrossGfx52, 0x100
+ax_sprite_terminator
+sMetagrossGfx53:
+.incbin "baserom.gba", 0x158284C, 0x200
+sMetagrossSprites53:
+ax_sprite sMetagrossGfx53, 0x200
+ax_sprite_terminator
+sMetagrossGfx54:
+.incbin "baserom.gba", 0x1582A5C, 0x100
+sMetagrossSprites54:
+ax_sprite sMetagrossGfx54, 0x100
+ax_sprite_terminator
+sMetagrossGfx55:
+.incbin "baserom.gba", 0x1582B6C, 0x200
+sMetagrossSprites55:
+ax_sprite sMetagrossGfx55, 0x200
+ax_sprite_terminator
+sMetagrossGfx56:
+.incbin "baserom.gba", 0x1582D7C, 0x200
+sMetagrossSprites56:
+ax_sprite sMetagrossGfx56, 0x200
+ax_sprite_terminator
+sMetagrossGfx57:
+.incbin "baserom.gba", 0x1582F8C, 0x100
+sMetagrossSprites57:
+ax_sprite sMetagrossGfx57, 0x100
+ax_sprite_terminator
+sMetagrossGfx58:
+.incbin "baserom.gba", 0x158309C, 0x100
+sMetagrossSprites58:
+ax_sprite sMetagrossGfx58, 0x100
+ax_sprite_terminator
+sMetagrossGfx59:
+.incbin "baserom.gba", 0x15831AC, 0x200
+sMetagrossSprites59:
+ax_sprite sMetagrossGfx59, 0x200
+ax_sprite_terminator
+sMetagrossGfx60:
+.incbin "baserom.gba", 0x15833BC, 0x100
+sMetagrossSprites60:
+ax_sprite sMetagrossGfx60, 0x100
+ax_sprite_terminator
+sMetagrossGfx61:
+.incbin "baserom.gba", 0x15834CC, 0x200
+sMetagrossSprites61:
+ax_sprite sMetagrossGfx61, 0x200
+ax_sprite_terminator
+sMetagrossGfx62:
+.incbin "baserom.gba", 0x15836DC, 0x100
+sMetagrossSprites62:
+ax_sprite sMetagrossGfx62, 0x100
+ax_sprite_terminator
+sMetagrossGfx63:
+.incbin "baserom.gba", 0x15837EC, 0x200
+sMetagrossSprites63:
+ax_sprite sMetagrossGfx63, 0x200
+ax_sprite_terminator
+sAxPosesMetagross:
+.4byte sMetagrossPose1
+.4byte sMetagrossPose2
+.4byte sMetagrossPose3
+.4byte sMetagrossPose4
+.4byte sMetagrossPose5
+.4byte sMetagrossPose6
+.4byte sMetagrossPose7
+.4byte sMetagrossPose8
+.4byte sMetagrossPose9
+.4byte sMetagrossPose10
+.4byte sMetagrossPose11
+.4byte sMetagrossPose12
+.4byte sMetagrossPose13
+.4byte sMetagrossPose14
+.4byte sMetagrossPose15
+.4byte sMetagrossPose16
+.4byte sMetagrossPose17
+.4byte sMetagrossPose18
+.4byte sMetagrossPose19
+.4byte sMetagrossPose20
+.4byte sMetagrossPose21
+.4byte sMetagrossPose22
+.4byte sMetagrossPose23
+.4byte sMetagrossPose24
+.4byte sMetagrossPose25
+.4byte sMetagrossPose26
+.4byte sMetagrossPose27
+.4byte sMetagrossPose28
+.4byte sMetagrossPose29
+.4byte sMetagrossPose30
+.4byte sMetagrossPose31
+.4byte sMetagrossPose32
+.4byte sMetagrossPose33
+.4byte sMetagrossPose34
+.4byte sMetagrossPose35
+.4byte sMetagrossPose36
+.4byte sMetagrossPose37
+.4byte sMetagrossPose38
+.4byte sMetagrossPose39
+.4byte sMetagrossPose40
+.4byte sMetagrossPose41
+.4byte sMetagrossPose42
+.4byte sMetagrossPose43
+.4byte sMetagrossPose44
+.4byte sMetagrossPose45
+.4byte sMetagrossPose46
+.4byte sMetagrossPose47
+.4byte sMetagrossPose48
+.4byte sMetagrossPose49
+.4byte sMetagrossPose50
+.4byte sMetagrossPose51
+.4byte sMetagrossPose52
+.4byte sMetagrossPose53
+.4byte sMetagrossPose54
+.4byte sMetagrossPose55
+.4byte sMetagrossPose56
+.4byte sMetagrossPose57
+.4byte sMetagrossPose58
+.4byte sMetagrossPose59
+.4byte sMetagrossPose60
+.4byte sMetagrossPose61
+.4byte sMetagrossPose62
+.4byte sMetagrossPose63
+.4byte sMetagrossPose64
+.4byte sMetagrossPose65
+.4byte sMetagrossPose66
+.4byte sMetagrossPose67
+.4byte sMetagrossPose68
+.4byte sMetagrossPose69
+.4byte sMetagrossPose70
+.4byte sMetagrossPose71
+.4byte sMetagrossPose72
+.4byte sMetagrossPose73
+.4byte sMetagrossPose74
+.4byte sMetagrossPose75
+.4byte sMetagrossPose76
+.4byte sMetagrossPose77
+.4byte sMetagrossPose78
+.4byte sMetagrossPose79
+.4byte sMetagrossPose80
+.4byte sMetagrossPose81
+.4byte sMetagrossPose82
+.4byte sMetagrossPose83
+.4byte sMetagrossPose84
+.4byte sMetagrossPose85
+.4byte sMetagrossPose86
+.4byte sMetagrossPose87
+.4byte sMetagrossPose88
+.4byte sMetagrossPose89
+.4byte sMetagrossPose90
+.4byte sMetagrossPose91
+.4byte sMetagrossPose92
+.4byte sMetagrossPose93
+.4byte sMetagrossPose94
+.4byte sMetagrossPose95
+.4byte sMetagrossPose96
+.4byte sMetagrossPose97
+.4byte sMetagrossPose98
+.4byte sMetagrossPose99
+.4byte sMetagrossPose100
+.4byte sMetagrossPose101
+.4byte sMetagrossPose102
+.4byte sMetagrossPose103
+.4byte sMetagrossPose104
+.4byte sMetagrossPose105
+.4byte sMetagrossPose106
+.4byte sMetagrossPose107
+.4byte sMetagrossPose108
+.4byte sMetagrossPose109
+.4byte sMetagrossPose110
+.4byte sMetagrossPose111
+.4byte sMetagrossPose112
+.4byte sMetagrossPose113
+.4byte sMetagrossPose114
+.4byte sMetagrossPose115
+.4byte sMetagrossPose116
+.4byte sMetagrossPose117
+.4byte sMetagrossPose118
+.4byte sMetagrossPose119
+.4byte sMetagrossPose120
+.4byte sMetagrossPose121
+.4byte sMetagrossPose122
+.4byte sMetagrossPose123
+.4byte sMetagrossPose124
+.4byte sMetagrossPose125
+.4byte sMetagrossPose126
+.4byte sMetagrossPose127
+.4byte sMetagrossPose128
+.4byte sMetagrossPose129
+.4byte sMetagrossPose130
+.4byte sMetagrossPose131
+.4byte sMetagrossPose132
+.4byte sMetagrossPose133
+.4byte sMetagrossPose134
+.4byte sMetagrossPose135
+.4byte sMetagrossPose136
+.4byte sMetagrossPose137
+.4byte sMetagrossPose138
+.4byte sMetagrossPose139
+.4byte sMetagrossPose140
+.4byte sMetagrossPose141
+.4byte sMetagrossPose142
+.4byte sMetagrossPose143
+.4byte sMetagrossPose144
+.4byte sMetagrossPose145
+.4byte sMetagrossPose146
+.4byte sMetagrossPose147
+.4byte sMetagrossPose148
+.4byte sMetagrossPose149
+.4byte sMetagrossPose150
+.4byte sMetagrossPose151
+.4byte sMetagrossPose152
+.4byte sMetagrossPose153
+.4byte sMetagrossPose154
+sAxPositionsMetagross:
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte    0,   -7, 	 -14,    4, 	  11,   -1, 	   0,  -11
+.2byte   -2,   -7, 	 -12,   -1, 	  12,    4, 	  -2,  -12
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+.2byte    3,   -7, 	  19,    0, 	  -8,    2, 	  -2,  -11
+.2byte    5,   -7, 	  11,   -3, 	   2,    6, 	  -2,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    5,   -7, 	  17,   -9, 	   9,   -1, 	  -1,  -11
+.2byte    6,  -12, 	   1,   -8, 	  20,   -1, 	  -1,  -11
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    4,   -9, 	   1,  -13, 	  12,   -4, 	  -2,  -10
+.2byte    4,  -12, 	  -7,  -11, 	  16,   -9, 	  -2,  -11
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -3,  -13, 	   6,  -13, 	 -11,   -8, 	  -1,  -10
+.2byte    1,  -13, 	  10,   -9, 	  -9,  -14, 	  -1,  -10
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -6,   -9, 	  -3,  -13, 	 -14,   -4, 	   0,  -10
+.2byte   -6,  -12, 	   5,  -11, 	 -18,   -9, 	   0,  -11
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte   -7,   -7, 	 -19,   -9, 	 -11,   -1, 	  -1,  -11
+.2byte   -8,  -12, 	  -3,   -8, 	 -22,   -1, 	  -1,  -11
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -5,   -7, 	 -21,    0, 	   6,    2, 	   0,  -11
+.2byte   -7,   -7, 	 -13,   -3, 	  -4,    6, 	   0,  -11
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte   -1,   -8, 	 -17,  -11, 	  15,  -11, 	  -1,  -12
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+.2byte    4,   -9, 	  17,  -15, 	  -4,   -5, 	  -1,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    6,  -11, 	  12,  -20, 	  15,  -11, 	  -1,  -12
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    5,  -11, 	  -2,  -21, 	  16,  -14, 	  -2,  -11
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  11,  -21, 	 -13,  -21, 	  -1,  -11
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -7,  -11, 	   0,  -21, 	 -18,  -14, 	   0,  -11
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte   -8,  -11, 	 -14,  -20, 	 -17,  -11, 	  -1,  -12
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -6,   -9, 	 -19,  -15, 	   2,   -5, 	  -1,  -11
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte   -1,   -8, 	 -17,  -11, 	  15,  -11, 	  -1,  -12
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+.2byte    4,   -9, 	  17,  -15, 	  -4,   -5, 	  -1,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    6,  -11, 	  12,  -20, 	  15,  -11, 	  -1,  -12
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    5,  -11, 	  -2,  -21, 	  16,  -14, 	  -2,  -11
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  11,  -21, 	 -13,  -21, 	  -1,  -11
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -7,  -11, 	   0,  -21, 	 -18,  -14, 	   0,  -11
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte   -8,  -11, 	 -14,  -20, 	 -17,  -11, 	  -1,  -12
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -6,   -9, 	 -19,  -15, 	   2,   -5, 	  -1,  -11
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte   -1,   -9, 	 -15,    1, 	  13,    0, 	  -1,  -11
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+.2byte    6,   -9, 	  15,   -4, 	  -5,    4, 	   0,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    9,  -12, 	  10,  -11, 	  12,    0, 	   2,  -12
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    6,  -15, 	  -3,  -14, 	  14,   -6, 	   0,  -13
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -18, 	  11,  -10, 	 -11,   -8, 	  -1,  -14
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -8,  -15, 	   1,  -14, 	 -16,   -6, 	  -2,  -13
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte  -11,  -12, 	 -12,  -11, 	 -14,    0, 	  -4,  -12
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -8,   -9, 	 -17,   -4, 	   3,    4, 	  -2,  -11
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+.2byte   -6,   -4, 	 -18,   -3, 	   4,    4, 	  -1,   -6
+.2byte   -6,   -4, 	 -18,   -2, 	   4,    4, 	   0,   -5
+.2byte   -1,   -1, 	 -18,   -1, 	  15,    3, 	  -1,   -7
+.2byte    4,   -1, 	  18,   -9, 	 -10,    6, 	  -3,   -4
+.2byte    6,   -5, 	  15,  -10, 	  17,    4, 	  -1,   -5
+.2byte    4,   -4, 	  -4,  -10, 	  19,   -2, 	  -2,   -5
+.2byte   -1,   -5, 	  13,   -7, 	 -11,   -6, 	  -1,   -6
+.2byte   -5,   -4, 	   3,  -10, 	 -20,   -2, 	   1,   -5
+.2byte   -7,   -5, 	 -16,  -10, 	 -18,    4, 	   0,   -5
+.2byte   -5,   -1, 	 -19,   -9, 	   9,    6, 	   2,   -4
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte   -1,   -9, 	 -15,    1, 	  13,    0, 	  -1,  -11
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+.2byte    6,   -9, 	  15,   -4, 	  -5,    4, 	   0,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    9,  -12, 	  10,  -11, 	  12,    0, 	   2,  -12
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    6,  -15, 	  -3,  -14, 	  14,   -6, 	   0,  -13
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -18, 	  11,  -10, 	 -11,   -8, 	  -1,  -14
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -8,  -15, 	   1,  -14, 	 -16,   -6, 	  -2,  -13
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte  -11,  -12, 	 -12,  -11, 	 -14,    0, 	  -4,  -12
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -8,   -9, 	 -17,   -4, 	   3,    4, 	  -2,  -11
+.2byte   -1,   -8, 	 -17,  -11, 	  15,  -11, 	  -1,  -12
+.2byte   -6,   -9, 	 -19,  -15, 	   2,   -5, 	  -1,  -11
+.2byte   -8,  -11, 	 -14,  -20, 	 -17,  -11, 	  -1,  -12
+.2byte   -7,  -11, 	   0,  -21, 	 -18,  -14, 	   0,  -11
+.2byte   -1,  -12, 	  11,  -21, 	 -13,  -21, 	  -1,  -11
+.2byte    5,  -11, 	  -2,  -21, 	  16,  -14, 	  -2,  -11
+.2byte    6,  -11, 	  12,  -20, 	  15,  -11, 	  -1,  -12
+.2byte    4,   -9, 	  17,  -15, 	  -4,   -5, 	  -1,  -11
+.2byte   -1,   -9, 	 -15,    1, 	  13,    0, 	  -1,  -11
+.2byte    6,   -9, 	  15,   -4, 	  -5,    4, 	   0,  -11
+.2byte    9,  -12, 	  10,  -11, 	  12,    0, 	   2,  -12
+.2byte    6,  -14, 	  -3,  -13, 	  14,   -5, 	   0,  -12
+.2byte   -1,  -16, 	  11,   -8, 	 -11,   -6, 	  -1,  -12
+.2byte   -8,  -14, 	   1,  -13, 	 -16,   -5, 	  -2,  -12
+.2byte  -11,  -12, 	 -12,  -11, 	 -14,    0, 	  -4,  -12
+.2byte   -8,   -9, 	 -17,   -4, 	   3,    4, 	  -2,  -11
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte   -1,   -9, 	 -15,    1, 	  13,    0, 	  -1,  -11
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+.2byte    6,   -9, 	  15,   -4, 	  -5,    4, 	   0,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    9,  -12, 	  10,  -11, 	  12,    0, 	   2,  -12
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    6,  -15, 	  -3,  -14, 	  14,   -6, 	   0,  -13
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -18, 	  11,  -10, 	 -11,   -8, 	  -1,  -14
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -8,  -15, 	   1,  -14, 	 -16,   -6, 	  -2,  -13
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte  -11,  -12, 	 -12,  -11, 	 -14,    0, 	  -4,  -12
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -8,   -9, 	 -17,   -4, 	   3,    4, 	  -2,  -11
+.2byte   -1,   -9, 	 -15,    1, 	  13,    0, 	  -1,  -11
+.2byte   -8,   -9, 	 -17,   -4, 	   3,    4, 	  -2,  -11
+.2byte  -11,  -12, 	 -12,  -11, 	 -14,    0, 	  -4,  -12
+.2byte   -8,  -14, 	   1,  -13, 	 -16,   -5, 	  -2,  -12
+.2byte   -1,  -16, 	  11,   -8, 	 -11,   -6, 	  -1,  -12
+.2byte    6,  -14, 	  -3,  -13, 	  14,   -5, 	   0,  -12
+.2byte    9,  -12, 	  10,  -11, 	  12,    0, 	   2,  -12
+.2byte    6,   -9, 	  15,   -4, 	  -5,    4, 	   0,  -11
+.2byte   -1,   -8, 	 -14,    0, 	  12,    0, 	  -1,  -12
+.2byte   -6,   -8, 	 -17,   -3, 	   3,    5, 	   0,  -11
+.2byte   -9,  -10, 	 -11,  -12, 	 -15,    0, 	  -1,  -12
+.2byte   -8,  -12, 	   2,  -13, 	 -18,   -7, 	   0,  -11
+.2byte   -1,  -13, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte    6,  -12, 	  -4,  -13, 	  16,   -7, 	  -2,  -11
+.2byte    7,  -10, 	   9,  -12, 	  13,    0, 	  -1,  -12
+.2byte    4,   -8, 	  15,   -3, 	  -5,    5, 	  -2,  -11
+sMetagrossAnimTable1:
+.4byte sMetagrossAnims_1_1
+.4byte sMetagrossAnims_1_2
+.4byte sMetagrossAnims_1_3
+.4byte sMetagrossAnims_1_4
+.4byte sMetagrossAnims_1_5
+.4byte sMetagrossAnims_1_6
+.4byte sMetagrossAnims_1_7
+.4byte sMetagrossAnims_1_8
+sMetagrossAnimTable2:
+.4byte sMetagrossAnims_2_1
+.4byte sMetagrossAnims_2_2
+.4byte sMetagrossAnims_2_3
+.4byte sMetagrossAnims_2_4
+.4byte sMetagrossAnims_2_5
+.4byte sMetagrossAnims_2_6
+.4byte sMetagrossAnims_2_7
+.4byte sMetagrossAnims_2_8
+sMetagrossAnimTable3:
+.4byte sMetagrossAnims_3_1
+.4byte sMetagrossAnims_3_2
+.4byte sMetagrossAnims_3_3
+.4byte sMetagrossAnims_3_4
+.4byte sMetagrossAnims_3_5
+.4byte sMetagrossAnims_3_6
+.4byte sMetagrossAnims_3_7
+.4byte sMetagrossAnims_3_8
+sMetagrossAnimTable4:
+.4byte sMetagrossAnims_4_1
+.4byte sMetagrossAnims_4_2
+.4byte sMetagrossAnims_4_3
+.4byte sMetagrossAnims_4_4
+.4byte sMetagrossAnims_4_5
+.4byte sMetagrossAnims_4_6
+.4byte sMetagrossAnims_4_7
+.4byte sMetagrossAnims_4_8
+sMetagrossAnimTable5:
+.4byte sMetagrossAnims_5_1
+.4byte sMetagrossAnims_5_2
+.4byte sMetagrossAnims_5_3
+.4byte sMetagrossAnims_5_4
+.4byte sMetagrossAnims_5_5
+.4byte sMetagrossAnims_5_6
+.4byte sMetagrossAnims_5_7
+.4byte sMetagrossAnims_5_8
+sMetagrossAnimTable6:
+.4byte sMetagrossAnims_6_1
+.4byte sMetagrossAnims_6_1
+.4byte sMetagrossAnims_6_1
+.4byte sMetagrossAnims_6_1
+.4byte sMetagrossAnims_6_1
+.4byte sMetagrossAnims_6_1
+.4byte sMetagrossAnims_6_1
+.4byte sMetagrossAnims_6_1
+sMetagrossAnimTable7:
+.4byte sMetagrossAnims_7_1
+.4byte sMetagrossAnims_7_2
+.4byte sMetagrossAnims_7_3
+.4byte sMetagrossAnims_7_4
+.4byte sMetagrossAnims_7_5
+.4byte sMetagrossAnims_7_6
+.4byte sMetagrossAnims_7_7
+.4byte sMetagrossAnims_7_8
+sMetagrossAnimTable8:
+.4byte sMetagrossAnims_8_1
+.4byte sMetagrossAnims_8_2
+.4byte sMetagrossAnims_8_3
+.4byte sMetagrossAnims_8_4
+.4byte sMetagrossAnims_8_5
+.4byte sMetagrossAnims_8_6
+.4byte sMetagrossAnims_8_7
+.4byte sMetagrossAnims_8_8
+sMetagrossAnimTable9:
+.4byte sMetagrossAnims_9_1
+.4byte sMetagrossAnims_9_2
+.4byte sMetagrossAnims_9_3
+.4byte sMetagrossAnims_9_4
+.4byte sMetagrossAnims_9_5
+.4byte sMetagrossAnims_9_6
+.4byte sMetagrossAnims_9_7
+.4byte sMetagrossAnims_9_8
+sMetagrossAnimTable10:
+.4byte sMetagrossAnims_10_1
+.4byte sMetagrossAnims_10_2
+.4byte sMetagrossAnims_10_3
+.4byte sMetagrossAnims_10_4
+.4byte sMetagrossAnims_10_5
+.4byte sMetagrossAnims_10_6
+.4byte sMetagrossAnims_10_7
+.4byte sMetagrossAnims_10_8
+sMetagrossAnimTable11:
+.4byte sMetagrossAnims_11_1
+.4byte sMetagrossAnims_11_2
+.4byte sMetagrossAnims_11_3
+.4byte sMetagrossAnims_11_4
+.4byte sMetagrossAnims_11_5
+.4byte sMetagrossAnims_11_6
+.4byte sMetagrossAnims_11_7
+.4byte sMetagrossAnims_11_8
+sMetagrossAnimTable12:
+.4byte sMetagrossAnims_12_1
+.4byte sMetagrossAnims_12_2
+.4byte sMetagrossAnims_12_3
+.4byte sMetagrossAnims_12_4
+.4byte sMetagrossAnims_12_5
+.4byte sMetagrossAnims_12_6
+.4byte sMetagrossAnims_12_7
+.4byte sMetagrossAnims_12_8
+sMetagrossAnimTable13:
+.4byte sMetagrossAnims_13_1
+.4byte sMetagrossAnims_13_2
+.4byte sMetagrossAnims_13_3
+.4byte sMetagrossAnims_13_4
+.4byte sMetagrossAnims_13_5
+.4byte sMetagrossAnims_13_6
+.4byte sMetagrossAnims_13_7
+.4byte sMetagrossAnims_13_8
+sAxAnimationsMetagross:
+.4byte sMetagrossAnimTable1
+.4byte sMetagrossAnimTable2
+.4byte sMetagrossAnimTable3
+.4byte sMetagrossAnimTable4
+.4byte sMetagrossAnimTable5
+.4byte sMetagrossAnimTable6
+.4byte sMetagrossAnimTable7
+.4byte sMetagrossAnimTable8
+.4byte sMetagrossAnimTable9
+.4byte sMetagrossAnimTable10
+.4byte sMetagrossAnimTable11
+.4byte sMetagrossAnimTable12
+.4byte sMetagrossAnimTable13
+sAxSpritesMetagross:
+.4byte sMetagrossSprites1
+.4byte sMetagrossSprites2
+.4byte sMetagrossSprites3
+.4byte sMetagrossSprites4
+.4byte sMetagrossSprites5
+.4byte sMetagrossSprites6
+.4byte sMetagrossSprites7
+.4byte sMetagrossSprites8
+.4byte sMetagrossSprites9
+.4byte sMetagrossSprites10
+.4byte sMetagrossSprites11
+.4byte sMetagrossSprites12
+.4byte sMetagrossSprites13
+.4byte sMetagrossSprites14
+.4byte sMetagrossSprites15
+.4byte sMetagrossSprites16
+.4byte sMetagrossSprites17
+.4byte sMetagrossSprites18
+.4byte sMetagrossSprites19
+.4byte sMetagrossSprites20
+.4byte sMetagrossSprites21
+.4byte sMetagrossSprites22
+.4byte sMetagrossSprites23
+.4byte sMetagrossSprites24
+.4byte sMetagrossSprites25
+.4byte sMetagrossSprites26
+.4byte sMetagrossSprites27
+.4byte sMetagrossSprites28
+.4byte sMetagrossSprites29
+.4byte sMetagrossSprites30
+.4byte sMetagrossSprites31
+.4byte sMetagrossSprites32
+.4byte sMetagrossSprites33
+.4byte sMetagrossSprites34
+.4byte sMetagrossSprites35
+.4byte sMetagrossSprites36
+.4byte sMetagrossSprites37
+.4byte sMetagrossSprites38
+.4byte sMetagrossSprites39
+.4byte sMetagrossSprites40
+.4byte sMetagrossSprites41
+.4byte sMetagrossSprites42
+.4byte sMetagrossSprites43
+.4byte sMetagrossSprites44
+.4byte sMetagrossSprites45
+.4byte sMetagrossSprites46
+.4byte sMetagrossSprites47
+.4byte sMetagrossSprites48
+.4byte sMetagrossSprites49
+.4byte sMetagrossSprites50
+.4byte sMetagrossSprites51
+.4byte sMetagrossSprites52
+.4byte sMetagrossSprites53
+.4byte sMetagrossSprites54
+.4byte sMetagrossSprites55
+.4byte sMetagrossSprites56
+.4byte sMetagrossSprites57
+.4byte sMetagrossSprites58
+.4byte sMetagrossSprites59
+.4byte sMetagrossSprites60
+.4byte sMetagrossSprites61
+.4byte sMetagrossSprites62
+.4byte sMetagrossSprites63
+sAxMainMetagross:
+ax_main sAxPosesMetagross, sAxAnimationsMetagross, 13, sAxSpritesMetagross, sAxPositionsMetagross

--- a/data/ax/metang.inc
+++ b/data/ax/metang.inc
@@ -1,0 +1,2967 @@
+.global gAxMetang
+gAxMetang:
+ax_siro sAxMainMetang
+sMetangPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose4:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose5:
+ax_pose 4, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose6:
+ax_pose 5, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose7:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose8:
+ax_pose 7, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose9:
+ax_pose 8, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose10:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose11:
+ax_pose 10, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose12:
+ax_pose 11, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose16:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose17:
+ax_pose 10, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose18:
+ax_pose 11, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose22:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose23:
+ax_pose 4, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose24:
+ax_pose 5, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose27:
+ax_pose 15, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose28:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose29:
+ax_pose 4, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose30:
+ax_pose 16, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMetangPose31:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose32:
+ax_pose 7, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose33:
+ax_pose 17, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose34:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose35:
+ax_pose 10, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose36:
+ax_pose 18, 0x01e7, 0x90ee, 0xbc00
+ax_pose_terminator
+sMetangPose37:
+ax_pose 12, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose38:
+ax_pose 13, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose39:
+ax_pose 19, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose40:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose41:
+ax_pose 10, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose42:
+ax_pose 18, 0x01e7, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose43:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose44:
+ax_pose 7, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose45:
+ax_pose 17, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose46:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose47:
+ax_pose 4, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose48:
+ax_pose 16, 0x01e4, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose49:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose50:
+ax_pose 20, 0x01e4, 0x80f0, 0xbc00
+ax_pose 21, 0x01e4, 0x80f0, 0xbc10
+ax_pose_terminator
+sMetangPose51:
+ax_pose 21, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose52:
+ax_pose 20, 0x01e4, 0x90f0, 0xbc00
+ax_pose 22, 0x01e4, 0x80f0, 0xbc10
+ax_pose_terminator
+sMetangPose53:
+ax_pose 22, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose54:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose55:
+ax_pose 23, 0x81e5, 0x9103, 0xbc00
+ax_pose 24, 0x01e5, 0x90ef, 0xbc08
+ax_pose_terminator
+sMetangPose56:
+ax_pose 24, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose57:
+ax_pose 25, 0x41f4, 0x90f4, 0xbc00
+ax_pose 26, 0x01e4, 0x90f4, 0xbc08
+ax_pose_terminator
+sMetangPose58:
+ax_pose 26, 0x01e4, 0x90f4, 0xbc00
+ax_pose_terminator
+sMetangPose59:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose60:
+ax_pose 27, 0x01e3, 0x90f5, 0xbc00
+ax_pose 28, 0x41e6, 0x90f1, 0xbc10
+ax_pose 29, 0x41f6, 0x50f1, 0xbc18
+ax_pose 30, 0x01f6, 0x1111, 0xbc1c
+ax_pose 31, 0x01ee, 0x1111, 0xbc1d
+ax_pose_terminator
+sMetangPose61:
+ax_pose 28, 0x41e6, 0x90f1, 0xbc00
+ax_pose 29, 0x41f6, 0x50f1, 0xbc08
+ax_pose 30, 0x01f6, 0x1111, 0xbc0c
+ax_pose 31, 0x01ee, 0x1111, 0xbc0d
+ax_pose_terminator
+sMetangPose62:
+ax_pose 32, 0x01e4, 0x90f6, 0xbc00
+ax_pose 33, 0x41e4, 0x90f2, 0xbc10
+ax_pose 34, 0x41f4, 0x50f2, 0xbc18
+ax_pose 35, 0x01ec, 0x1112, 0xbc1c
+ax_pose 36, 0x01e4, 0x1112, 0xbc1d
+ax_pose_terminator
+sMetangPose63:
+ax_pose 33, 0x41e4, 0x90f2, 0xbc00
+ax_pose 34, 0x41f4, 0x50f2, 0xbc08
+ax_pose 35, 0x01ec, 0x1112, 0xbc0c
+ax_pose 36, 0x01e4, 0x1112, 0xbc0d
+ax_pose_terminator
+sMetangPose64:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose65:
+ax_pose 37, 0x41e5, 0x90f4, 0xbc00
+ax_pose 38, 0x01e7, 0x90f3, 0xbc08
+ax_pose_terminator
+sMetangPose66:
+ax_pose 38, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose67:
+ax_pose 39, 0x81e3, 0x9104, 0xbc00
+ax_pose 40, 0x01e4, 0x90ed, 0xbc08
+ax_pose_terminator
+sMetangPose68:
+ax_pose 40, 0x01e4, 0x90ed, 0xbc00
+ax_pose_terminator
+sMetangPose69:
+ax_pose 12, 0x01e4, 0x90f0, 0xbc00
+ax_pose_terminator
+sMetangPose70:
+ax_pose 41, 0x01e4, 0x80f0, 0xbc00
+ax_pose 42, 0x01e4, 0x80f0, 0xbc10
+ax_pose_terminator
+sMetangPose71:
+ax_pose 42, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose72:
+ax_pose 41, 0x01e4, 0x90f0, 0xbc00
+ax_pose 43, 0x01e4, 0x80f0, 0xbc10
+ax_pose_terminator
+sMetangPose73:
+ax_pose 43, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose74:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose75:
+ax_pose 37, 0x41e5, 0x80e9, 0xbc00
+ax_pose 38, 0x01e7, 0x80eb, 0xbc08
+ax_pose_terminator
+sMetangPose76:
+ax_pose 38, 0x01e7, 0x80eb, 0xbc00
+ax_pose_terminator
+sMetangPose77:
+ax_pose 39, 0x81e4, 0x80ea, 0xbc00
+ax_pose 40, 0x01e4, 0x80f1, 0xbc08
+ax_pose_terminator
+sMetangPose78:
+ax_pose 40, 0x01e4, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose79:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose80:
+ax_pose 27, 0x01e3, 0x80eb, 0xbc00
+ax_pose 28, 0x41e6, 0x80ef, 0xbc10
+ax_pose 29, 0x41f6, 0x40ef, 0xbc18
+ax_pose 30, 0x01f6, 0x00e7, 0xbc1c
+ax_pose 31, 0x01ee, 0x00e7, 0xbc1d
+ax_pose_terminator
+sMetangPose81:
+ax_pose 28, 0x41e6, 0x80ef, 0xbc00
+ax_pose 29, 0x41f6, 0x40ef, 0xbc08
+ax_pose 30, 0x01f6, 0x00e7, 0xbc0c
+ax_pose 31, 0x01ee, 0x00e7, 0xbc0d
+ax_pose_terminator
+sMetangPose82:
+ax_pose 32, 0x01e4, 0x80ea, 0xbc00
+ax_pose 33, 0x41e4, 0x80ee, 0xbc10
+ax_pose 34, 0x41f4, 0x40ee, 0xbc18
+ax_pose 35, 0x01ec, 0x00e6, 0xbc1c
+ax_pose 36, 0x01e4, 0x00e6, 0xbc1d
+ax_pose_terminator
+sMetangPose83:
+ax_pose 33, 0x41e4, 0x80ee, 0xbc00
+ax_pose 34, 0x41f4, 0x40ee, 0xbc08
+ax_pose 35, 0x01ec, 0x00e6, 0xbc0c
+ax_pose 36, 0x01e4, 0x00e6, 0xbc0d
+ax_pose_terminator
+sMetangPose84:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose85:
+ax_pose 23, 0x81e5, 0x80ec, 0xbc00
+ax_pose 24, 0x01e5, 0x80f0, 0xbc08
+ax_pose_terminator
+sMetangPose86:
+ax_pose 24, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose87:
+ax_pose 25, 0x41f4, 0x80ee, 0xbc00
+ax_pose 26, 0x01e4, 0x80ee, 0xbc08
+ax_pose_terminator
+sMetangPose88:
+ax_pose 26, 0x01e4, 0x80ee, 0xbc00
+ax_pose_terminator
+sMetangPose89:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose90:
+ax_pose 44, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose91:
+ax_pose 15, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose92:
+ax_pose 1, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose93:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose94:
+ax_pose 45, 0x01e4, 0x90f1, 0xbc00
+ax_pose_terminator
+sMetangPose95:
+ax_pose 16, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMetangPose96:
+ax_pose 4, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose97:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose98:
+ax_pose 46, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose99:
+ax_pose 17, 0x01e4, 0x90f1, 0xbc00
+ax_pose_terminator
+sMetangPose100:
+ax_pose 7, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose101:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose102:
+ax_pose 47, 0x01e3, 0x90f2, 0xbc00
+ax_pose_terminator
+sMetangPose103:
+ax_pose 18, 0x01e7, 0x90ee, 0xbc00
+ax_pose_terminator
+sMetangPose104:
+ax_pose 10, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose105:
+ax_pose 12, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose106:
+ax_pose 48, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose107:
+ax_pose 19, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose108:
+ax_pose 13, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose109:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose110:
+ax_pose 47, 0x01e3, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose111:
+ax_pose 18, 0x01e7, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose112:
+ax_pose 10, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose113:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose114:
+ax_pose 46, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose115:
+ax_pose 17, 0x01e4, 0x80ee, 0xbc00
+ax_pose_terminator
+sMetangPose116:
+ax_pose 7, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose117:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose118:
+ax_pose 45, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose119:
+ax_pose 16, 0x01e4, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose120:
+ax_pose 4, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose121:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose122:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose123:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose124:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose125:
+ax_pose 12, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose126:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose127:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose128:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose129:
+ax_pose 49, 0x01e8, 0x80ef, 0xbc00
+ax_pose_terminator
+sMetangPose130:
+ax_pose 50, 0x01e9, 0x80ef, 0xbc00
+ax_pose_terminator
+sMetangPose131:
+ax_pose 51, 0x01db, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose132:
+ax_pose 52, 0x01de, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose133:
+ax_pose 53, 0x01de, 0x90ec, 0xbc00
+ax_pose_terminator
+sMetangPose134:
+ax_pose 54, 0x81df, 0x90f2, 0xbc00
+ax_pose 55, 0x81eb, 0x110a, 0xbc08
+ax_pose 56, 0x01e3, 0x110a, 0xbc0a
+ax_pose 57, 0x01e7, 0x1102, 0xbc0b
+ax_pose 58, 0x01d7, 0x10fa, 0xbc0c
+ax_pose 59, 0x01d7, 0x10f2, 0xbc0d
+ax_pose 60, 0x81ef, 0x1102, 0xbc0e
+ax_pose_terminator
+sMetangPose135:
+ax_pose 61, 0x01df, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose136:
+ax_pose 54, 0x81df, 0x80ff, 0xbc00
+ax_pose 55, 0x81eb, 0x00ef, 0xbc08
+ax_pose 56, 0x01e3, 0x00ef, 0xbc0a
+ax_pose 57, 0x01e7, 0x00f7, 0xbc0b
+ax_pose 58, 0x01d7, 0x00ff, 0xbc0c
+ax_pose 59, 0x01d7, 0x0107, 0xbc0d
+ax_pose 60, 0x81ef, 0x00f7, 0xbc0e
+ax_pose_terminator
+sMetangPose137:
+ax_pose 53, 0x01de, 0x80f4, 0xbc00
+ax_pose_terminator
+sMetangPose138:
+ax_pose 52, 0x01dd, 0x80f2, 0xbc00
+ax_pose_terminator
+sMetangPose139:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose140:
+ax_pose 1, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose141:
+ax_pose 2, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose142:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose143:
+ax_pose 4, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose144:
+ax_pose 5, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose145:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose146:
+ax_pose 7, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose147:
+ax_pose 8, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose148:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose149:
+ax_pose 10, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose150:
+ax_pose 11, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose151:
+ax_pose 12, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose152:
+ax_pose 13, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose153:
+ax_pose 14, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose154:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose155:
+ax_pose 10, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose156:
+ax_pose 11, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose157:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose158:
+ax_pose 7, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose159:
+ax_pose 8, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose160:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose161:
+ax_pose 4, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose162:
+ax_pose 5, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose163:
+ax_pose 15, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose164:
+ax_pose 16, 0x01e4, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose165:
+ax_pose 17, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose166:
+ax_pose 18, 0x01e7, 0x80f1, 0xbc00
+ax_pose_terminator
+sMetangPose167:
+ax_pose 19, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose168:
+ax_pose 18, 0x01e7, 0x90ee, 0xbc00
+ax_pose_terminator
+sMetangPose169:
+ax_pose 17, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose170:
+ax_pose 16, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMetangPose171:
+ax_pose 44, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose172:
+ax_pose 45, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose173:
+ax_pose 46, 0x01e4, 0x90f0, 0xbc00
+ax_pose_terminator
+sMetangPose174:
+ax_pose 47, 0x01e3, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose175:
+ax_pose 48, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose176:
+ax_pose 47, 0x01e3, 0x80ed, 0xbc00
+ax_pose_terminator
+sMetangPose177:
+ax_pose 46, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose178:
+ax_pose 45, 0x01e4, 0x80ed, 0xbc00
+ax_pose_terminator
+sMetangPose179:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose180:
+ax_pose 2, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose181:
+ax_pose 44, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose182:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose183:
+ax_pose 5, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose184:
+ax_pose 45, 0x01e4, 0x90f1, 0xbc00
+ax_pose_terminator
+sMetangPose185:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose186:
+ax_pose 8, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose187:
+ax_pose 46, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose188:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose189:
+ax_pose 11, 0x01e6, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose190:
+ax_pose 47, 0x01e3, 0x90f2, 0xbc00
+ax_pose_terminator
+sMetangPose191:
+ax_pose 12, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose192:
+ax_pose 14, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose193:
+ax_pose 48, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose194:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose195:
+ax_pose 11, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose196:
+ax_pose 47, 0x01e3, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose197:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose198:
+ax_pose 8, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose199:
+ax_pose 46, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose200:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose201:
+ax_pose 5, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose202:
+ax_pose 45, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose203:
+ax_pose 1, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose204:
+ax_pose 4, 0x01e4, 0x80ed, 0xbc00
+ax_pose_terminator
+sMetangPose205:
+ax_pose 7, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose206:
+ax_pose 10, 0x01e6, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose207:
+ax_pose 13, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose208:
+ax_pose 10, 0x01e6, 0x90f4, 0xbc00
+ax_pose_terminator
+sMetangPose209:
+ax_pose 7, 0x01e4, 0x90f0, 0xbc00
+ax_pose_terminator
+sMetangPose210:
+ax_pose 4, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose211:
+ax_pose 0, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose212:
+ax_pose 3, 0x01e4, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose213:
+ax_pose 6, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose214:
+ax_pose 9, 0x01e7, 0x80ec, 0xbc00
+ax_pose_terminator
+sMetangPose215:
+ax_pose 12, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMetangPose216:
+ax_pose 9, 0x01e7, 0x90f3, 0xbc00
+ax_pose_terminator
+sMetangPose217:
+ax_pose 6, 0x01e4, 0x90ef, 0xbc00
+ax_pose_terminator
+sMetangPose218:
+ax_pose 3, 0x01e4, 0x90f3, 0xbc00
+ax_pose_terminator
+.align 2
+sMetangAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -3, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -3, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 3, 0, 3,
+ax_anim 1, 2, 26, 0, 7, 0, 7,
+ax_anim 1, 0, 26, 0, 13, 0, 11,
+ax_anim 2, 0, 26, 0, 28, 0, 21,
+ax_anim 2, 1, 26, 1, 28, 1, 21,
+ax_anim 2, 0, 26, 0, 28, 0, 21,
+ax_anim 2, 0, 26, 1, 28, 1, 21,
+ax_anim 2, 0, 26, 0, 28, 0, 21,
+ax_anim 2, 0, 26, 1, 28, 1, 21,
+ax_anim 2, 0, 24, 0, 14, 0, 14,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMetangAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 5, 5, 5, 5,
+ax_anim 1, 2, 29, 7, 9, 7, 8,
+ax_anim 1, 0, 29, 11, 15, 11, 13,
+ax_anim 2, 0, 29, 19, 27, 19, 22,
+ax_anim 2, 1, 29, 20, 26, 20, 21,
+ax_anim 2, 0, 29, 19, 27, 19, 22,
+ax_anim 2, 0, 29, 20, 26, 20, 21,
+ax_anim 2, 0, 29, 19, 27, 19, 22,
+ax_anim 2, 0, 29, 20, 26, 20, 21,
+ax_anim 2, 0, 27, 12, 14, 12, 12,
+ax_anim 2, 0, 27, 4, 6, 4, 4,
+ax_anim_terminator
+sMetangAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 5, 0, 5, 0,
+ax_anim 1, 2, 32, 7, 2, 7, 0,
+ax_anim 1, 0, 32, 12, 3, 12, 0,
+ax_anim 2, 0, 32, 23, 5, 23, 0,
+ax_anim 2, 1, 32, 23, 6, 23, 1,
+ax_anim 2, 0, 32, 23, 5, 23, 0,
+ax_anim 2, 0, 32, 23, 6, 23, 1,
+ax_anim 2, 0, 32, 23, 5, 23, 0,
+ax_anim 2, 0, 32, 23, 6, 23, 1,
+ax_anim 2, 0, 30, 12, 4, 12, 0,
+ax_anim 2, 0, 30, 5, 2, 5, 0,
+ax_anim_terminator
+sMetangAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 34, -2, 2, -2, 2,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 4, -5, 4, -5,
+ax_anim 1, 2, 35, 6, -7, 6, -7,
+ax_anim 1, 0, 35, 12, -11, 11, -12,
+ax_anim 2, 0, 35, 20, -16, 19, -22,
+ax_anim 2, 1, 35, 21, -15, 20, -21,
+ax_anim 2, 0, 35, 20, -16, 19, -22,
+ax_anim 2, 0, 35, 21, -15, 20, -21,
+ax_anim 2, 0, 35, 20, -16, 19, -22,
+ax_anim 2, 0, 35, 21, -15, 20, -21,
+ax_anim 2, 0, 33, 12, -10, 12, -12,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMetangAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, -3, 0, -3,
+ax_anim 1, 2, 38, 0, -7, 0, -7,
+ax_anim 1, 0, 38, 0, -13, 0, -15,
+ax_anim 2, 0, 38, 0, -17, 0, -22,
+ax_anim 2, 1, 38, 1, -17, 1, -22,
+ax_anim 2, 0, 38, 0, -17, 0, -22,
+ax_anim 2, 0, 38, 1, -17, 1, -22,
+ax_anim 2, 0, 38, 0, -17, 0, -22,
+ax_anim 2, 0, 38, 1, -17, 1, -22,
+ax_anim 2, 0, 36, 0, -11, 0, -14,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMetangAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 40, 2, 2, 2, 2,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 41, -4, -5, -4, -5,
+ax_anim 1, 2, 41, -6, -7, -6, -7,
+ax_anim 1, 0, 41, -12, -11, -11, -12,
+ax_anim 2, 0, 41, -20, -16, -19, -22,
+ax_anim 2, 1, 41, -21, -15, -20, -21,
+ax_anim 2, 0, 41, -20, -16, -19, -22,
+ax_anim 2, 0, 41, -21, -15, -20, -21,
+ax_anim 2, 0, 41, -20, -16, -19, -22,
+ax_anim 2, 0, 41, -21, -15, -20, -21,
+ax_anim 2, 0, 39, -12, -10, -12, -12,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMetangAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 43, 2, 0, 2, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 44, -5, 0, -5, 0,
+ax_anim 1, 2, 44, -7, 2, -7, 0,
+ax_anim 1, 0, 44, -12, 3, -12, 0,
+ax_anim 2, 0, 44, -23, 5, -23, 0,
+ax_anim 2, 1, 44, -23, 6, -23, 1,
+ax_anim 2, 0, 44, -23, 5, -23, 0,
+ax_anim 2, 0, 44, -23, 6, -23, 1,
+ax_anim 2, 0, 44, -23, 5, -23, 0,
+ax_anim 2, 0, 44, -23, 6, -23, 1,
+ax_anim 2, 0, 42, -12, 4, -12, 0,
+ax_anim 2, 0, 42, -5, 2, -5, 0,
+ax_anim_terminator
+sMetangAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 46, 2, -2, 2, -2,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 47, -5, 5, -5, 5,
+ax_anim 1, 2, 47, -7, 9, -7, 8,
+ax_anim 1, 0, 47, -11, 15, -11, 13,
+ax_anim 2, 0, 47, -19, 27, -19, 22,
+ax_anim 2, 1, 47, -20, 26, -20, 21,
+ax_anim 2, 0, 47, -19, 27, -19, 22,
+ax_anim 2, 0, 47, -20, 26, -20, 21,
+ax_anim 2, 0, 47, -19, 27, -19, 22,
+ax_anim 2, 0, 47, -20, 26, -20, 21,
+ax_anim 2, 0, 45, -12, 14, -12, 12,
+ax_anim 2, 0, 45, -4, 6, -4, 5,
+ax_anim_terminator
+.align 2
+sMetangAnims_3_1:
+ax_anim 2, 0, 52, 0, -2, 0, -2,
+ax_anim 6, 0, 87, 0, -3, 0, -3,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 52, 0, 7, 0, 7,
+ax_anim 2, 0, 49, 0, 15, 0, 15,
+ax_anim 4, 1, 57, -1, 16, -1, 16,
+ax_anim 2, 0, 50, 2, 16, 2, 16,
+ax_anim 2, 0, 51, -1, 18, -1, 18,
+ax_anim 4, 0, 87, -2, 20, -2, 20,
+ax_anim 2, 0, 52, -1, 16, -1, 16,
+ax_anim 1, 0, 48, 0, 9, 0, 9,
+ax_anim 1, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sMetangAnims_3_2:
+ax_anim 2, 0, 55, -2, -2, -2, -2,
+ax_anim 6, 0, 52, -2, -4, -2, -4,
+ax_anim 2, 0, 52, 0, -2, 0, -2,
+ax_anim 2, 2, 55, 6, 8, 6, 8,
+ax_anim 2, 0, 56, 11, 16, 11, 16,
+ax_anim 4, 1, 62, 15, 18, 15, 18,
+ax_anim 2, 0, 57, 11, 14, 11, 14,
+ax_anim 2, 0, 54, 13, 17, 13, 17,
+ax_anim 4, 0, 52, 13, 18, 13, 18,
+ax_anim 2, 0, 55, 11, 15, 11, 15,
+ax_anim 1, 0, 53, 7, 7, 7, 7,
+ax_anim 1, 0, 53, 3, 3, 3, 3,
+ax_anim_terminator
+sMetangAnims_3_3:
+ax_anim 2, 0, 60, -4, 0, -4, 0,
+ax_anim 6, 0, 55, -5, 0, -5, 0,
+ax_anim 2, 0, 55, -3, 0, -3, 0,
+ax_anim 2, 2, 60, 2, 2, 2, 0,
+ax_anim 2, 0, 61, 8, 5, 8, 0,
+ax_anim 4, 1, 67, 10, 3, 10, 0,
+ax_anim 2, 0, 62, 9, 3, 9, 0,
+ax_anim 2, 0, 59, 13, 3, 13, 0,
+ax_anim 4, 0, 55, 13, 4, 13, 0,
+ax_anim 2, 0, 60, 10, 4, 10, 0,
+ax_anim 1, 0, 58, 5, 1, 5, 0,
+ax_anim 1, 0, 58, 3, 0, 3, 0,
+ax_anim_terminator
+sMetangAnims_3_4:
+ax_anim 2, 0, 65, -2, 2, -2, 2,
+ax_anim 6, 0, 60, -4, 4, -4, 4,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 2, 65, 6, -6, 6, -6,
+ax_anim 2, 0, 66, 9, -10, 9, -9,
+ax_anim 4, 1, 70, 12, -12, 12, -12,
+ax_anim 2, 0, 67, 14, -12, 14, -13,
+ax_anim 2, 0, 64, 15, -14, 15, -14,
+ax_anim 4, 0, 60, 17, -14, 17, -14,
+ax_anim 2, 0, 65, 11, -11, 11, -11,
+ax_anim 1, 0, 63, 6, -5, 6, -6,
+ax_anim 1, 0, 63, 3, -3, 3, -3,
+ax_anim_terminator
+sMetangAnims_3_5:
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim 6, 0, 65, 0, 6, 0, 6,
+ax_anim 2, 0, 65, 0, 1, 0, 1,
+ax_anim 2, 2, 72, 0, -3, 0, -3,
+ax_anim 2, 0, 69, 0, -8, 0, -8,
+ax_anim 4, 1, 75, 0, -12, 0, -12,
+ax_anim 2, 0, 70, -1, -13, -1, -13,
+ax_anim 2, 0, 71, 0, -15, 0, -15,
+ax_anim 4, 0, 65, 1, -18, 1, -18,
+ax_anim 2, 0, 77, 1, -10, 1, -10,
+ax_anim 1, 0, 68, 0, -5, 0, -5,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim_terminator
+sMetangAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 6, 0, 72, 4, 4, 4, 4,
+ax_anim 2, 0, 72, 2, 2, 2, 2,
+ax_anim 2, 2, 77, -2, -3, -2, -2,
+ax_anim 2, 0, 74, -11, -10, -10, -10,
+ax_anim 4, 1, 80, -15, -9, -15, -13,
+ax_anim 2, 0, 75, -13, -12, -13, -13,
+ax_anim 2, 0, 76, -15, -14, -16, -15,
+ax_anim 4, 0, 72, -17, -16, -17, -17,
+ax_anim 2, 0, 77, -12, -10, -12, -12,
+ax_anim 1, 0, 73, -8, -7, -8, -7,
+ax_anim 1, 0, 73, -3, -3, -3, -3,
+ax_anim_terminator
+sMetangAnims_3_7:
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 6, 0, 77, 6, 0, 6, 0,
+ax_anim 2, 0, 77, 4, 0, 4, 0,
+ax_anim 2, 2, 82, -2, 2, -2, 0,
+ax_anim 2, 0, 79, -8, 2, -8, 0,
+ax_anim 4, 1, 85, -9, 3, -9, 0,
+ax_anim 2, 0, 80, -11, 3, -11, 0,
+ax_anim 2, 0, 81, -10, 5, -10, 0,
+ax_anim 4, 0, 77, -12, 4, -12, 0,
+ax_anim 2, 0, 82, -9, 5, -9, 0,
+ax_anim 1, 0, 78, -6, 4, -6, 0,
+ax_anim 1, 0, 78, -3, 0, -3, 0,
+ax_anim_terminator
+sMetangAnims_3_8:
+ax_anim 2, 0, 85, 3, 0, 3, 0,
+ax_anim 6, 0, 50, 4, -4, 4, -4,
+ax_anim 2, 0, 50, 2, -2, 2, -2,
+ax_anim 2, 2, 85, -6, 6, -6, 6,
+ax_anim 2, 0, 86, -12, 12, -12, 12,
+ax_anim 4, 1, 82, -13, 16, -13, 16,
+ax_anim 2, 0, 87, -14, 17, -14, 17,
+ax_anim 2, 0, 84, -13, 20, -13, 20,
+ax_anim 4, 0, 50, -14, 20, -14, 20,
+ax_anim 2, 0, 85, -11, 15, -11, 15,
+ax_anim 1, 0, 83, -7, 9, -7, 9,
+ax_anim 1, 0, 83, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sMetangAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -5, 0, -3,
+ax_anim 1, 0, 91, 0, -1, 0, -1,
+ax_anim 1, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sMetangAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 2, 93, -3, -3, -3, -3,
+ax_anim 1, 0, 92, -1, -1, -1, -1,
+ax_anim 1, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 1, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 3, 1, 3, 1,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sMetangAnims_4_3:
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim 6, 2, 97, -3, 0, -3, 0,
+ax_anim 1, 0, 96, -1, 0, -1, 0,
+ax_anim 1, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 1, 98, 2, 1, 2, 1,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 1, 2, 1,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 1, 2, 1,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sMetangAnims_4_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 6, 2, 101, -3, 3, -3, 3,
+ax_anim 1, 0, 100, -1, 1, -1, 1,
+ax_anim 1, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 1, 102, 3, -1, 3, -1,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 3, -1, 3, -1,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 3, -1, 3, -1,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 3, -1, 3, -1,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim_terminator
+sMetangAnims_4_5:
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim 6, 2, 105, 0, 3, 0, 3,
+ax_anim 1, 0, 104, 0, 1, 0, 1,
+ax_anim 1, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 1, 106, 1, -3, 1, -3,
+ax_anim 2, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 1, -3, 1, -3,
+ax_anim 2, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 1, -3, 1, -3,
+ax_anim 2, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 1, -3, 1, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim_terminator
+sMetangAnims_4_6:
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 6, 2, 109, 3, 3, 3, 3,
+ax_anim 1, 0, 108, 1, 1, 1, 1,
+ax_anim 1, 0, 110, -2, -2, -2, -2,
+ax_anim 2, 1, 110, -3, -1, -3, -1,
+ax_anim 2, 0, 110, -2, -2, -2, -2,
+ax_anim 2, 0, 110, -3, -1, -3, -1,
+ax_anim 2, 0, 110, -2, -2, -2, -2,
+ax_anim 2, 0, 110, -3, -1, -3, -1,
+ax_anim 2, 0, 110, -2, -2, -2, -2,
+ax_anim 2, 0, 110, -3, -1, -3, -1,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim_terminator
+sMetangAnims_4_7:
+ax_anim 2, 0, 113, 2, 0, 2, 0,
+ax_anim 6, 2, 113, 3, 0, 3, 0,
+ax_anim 1, 0, 112, 1, 0, 1, 0,
+ax_anim 1, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 1, 114, -2, 1, -2, 1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 1,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim_terminator
+sMetangAnims_4_8:
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 6, 2, 117, 3, -3, 3, -3,
+ax_anim 1, 0, 116, 1, -1, 1, -1,
+ax_anim 1, 0, 118, -2, 2, -2, 2,
+ax_anim 2, 1, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMetangAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_6_1:
+ax_anim 16, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, -1, 0, 0,
+ax_anim 16, 0, 128, 0, -2, 0, 0,
+ax_anim 16, 0, 129, 0, -2, 0, 0,
+ax_anim 12, 0, 129, 0, -1, 0, 0,
+ax_anim 16, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_7_1:
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 8, 0, 130, 0, -4, 0, -4,
+ax_anim_terminator
+sMetangAnims_7_2:
+ax_anim 2, 0, 131, -3, -3, -3, -3,
+ax_anim 8, 0, 131, -4, -4, -4, -4,
+ax_anim_terminator
+sMetangAnims_7_3:
+ax_anim 2, 0, 132, -3, 0, -3, 0,
+ax_anim 8, 0, 132, -4, 0, -4, 0,
+ax_anim_terminator
+sMetangAnims_7_4:
+ax_anim 2, 0, 133, -3, 3, -3, 3,
+ax_anim 8, 0, 133, -4, 4, -4, 4,
+ax_anim_terminator
+sMetangAnims_7_5:
+ax_anim 2, 0, 134, 0, 3, 0, 3,
+ax_anim 8, 0, 134, 0, 4, 0, 4,
+ax_anim_terminator
+sMetangAnims_7_6:
+ax_anim 2, 0, 135, 3, 3, 3, 3,
+ax_anim 8, 0, 135, 4, 4, 4, 4,
+ax_anim_terminator
+sMetangAnims_7_7:
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 8, 0, 136, 4, 0, 4, 0,
+ax_anim_terminator
+sMetangAnims_7_8:
+ax_anim 2, 0, 137, 3, -3, 3, -3,
+ax_anim 8, 0, 137, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sMetangAnims_8_1:
+ax_anim 12, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, -1, 0, 0,
+ax_anim 12, 0, 140, 0, -2, 0, 0,
+ax_anim 12, 0, 140, 0, -3, 0, 0,
+ax_anim 12, 0, 138, 0, -3, 0, 0,
+ax_anim 12, 0, 139, 0, -2, 0, 0,
+ax_anim 12, 0, 139, 0, -1, 0, 0,
+ax_anim 12, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_8_2:
+ax_anim 12, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, -1, 0, 0,
+ax_anim 12, 0, 143, 0, -2, 0, 0,
+ax_anim 12, 0, 143, 0, -3, 0, 0,
+ax_anim 12, 0, 141, 0, -3, 0, 0,
+ax_anim 12, 0, 142, 0, -2, 0, 0,
+ax_anim 12, 0, 142, 0, -1, 0, 0,
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_8_3:
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, -2, 0, 0,
+ax_anim 12, 0, 146, 0, -3, 0, 0,
+ax_anim 12, 0, 144, 0, -3, 0, 0,
+ax_anim 12, 0, 145, 0, -2, 0, 0,
+ax_anim 12, 0, 145, 0, -1, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_8_4:
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, -2, 0, 0,
+ax_anim 12, 0, 149, 0, -3, 0, 0,
+ax_anim 12, 0, 147, 0, -3, 0, 0,
+ax_anim 12, 0, 148, 0, -2, 0, 0,
+ax_anim 12, 0, 148, 0, -1, 0, 0,
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_8_5:
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, -2, 0, 0,
+ax_anim 12, 0, 152, 0, -3, 0, 0,
+ax_anim 12, 0, 150, 0, -3, 0, 0,
+ax_anim 12, 0, 151, 0, -2, 0, 0,
+ax_anim 12, 0, 151, 0, -1, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_8_6:
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, -2, 0, 0,
+ax_anim 12, 0, 155, 0, -3, 0, 0,
+ax_anim 12, 0, 153, 0, -3, 0, 0,
+ax_anim 12, 0, 154, 0, -2, 0, 0,
+ax_anim 12, 0, 154, 0, -1, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_8_7:
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, -2, 0, 0,
+ax_anim 12, 0, 158, 0, -3, 0, 0,
+ax_anim 12, 0, 156, 0, -3, 0, 0,
+ax_anim 12, 0, 157, 0, -2, 0, 0,
+ax_anim 12, 0, 157, 0, -1, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_8_8:
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, -2, 0, 0,
+ax_anim 12, 0, 161, 0, -3, 0, 0,
+ax_anim 12, 0, 159, 0, -3, 0, 0,
+ax_anim 12, 0, 160, 0, -2, 0, 0,
+ax_anim 12, 0, 160, 0, -1, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 3,
+ax_anim 2, 0, 164, 8, 13, 8, 9,
+ax_anim 2, 0, 165, 6, 18, 7, 15,
+ax_anim 3, 0, 166, 0, 22, 0, 18,
+ax_anim 2, 3, 167, -6, 18, -7, 15,
+ax_anim 2, 0, 168, -8, 13, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 19, 4, 19, 4,
+ax_anim 2, 0, 164, 23, 14, 23, 14,
+ax_anim 3, 0, 165, 21, 22, 21, 16,
+ax_anim 2, 3, 166, 11, 22, 11, 18,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -3, 3, -3,
+ax_anim 2, 0, 162, 12, -4, 12, -4,
+ax_anim 2, 0, 163, 18, 0, 18, -3,
+ax_anim 3, 0, 164, 19, 4, 19, 0,
+ax_anim 2, 3, 165, 15, 9, 15, 7,
+ax_anim 2, 0, 166, 10, 9, 10, 9,
+ax_anim 1, 0, 167, 3, 7, 3, 7,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -5, 0, -5,
+ax_anim 2, 0, 169, 2, -11, 2, -13,
+ax_anim 2, 0, 162, 10, -15, 10, -19,
+ax_anim 3, 0, 163, 18, -17, 18, -22,
+ax_anim 2, 3, 164, 20, -8, 20, -12,
+ax_anim 2, 0, 165, 17, -2, 17, -2,
+ax_anim 1, 0, 166, 10, 0, 10, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -4, -1, -4, -1,
+ax_anim 2, 0, 168, -8, -6, -8, -6,
+ax_anim 2, 0, 169, -6, -14, -6, -18,
+ax_anim 3, 0, 162, 0, -17, 0, -22,
+ax_anim 2, 3, 163, 6, -14, 6, -18,
+ax_anim 2, 0, 164, 8, -6, 8, -6,
+ax_anim 1, 0, 165, 5, -1, 5, -1,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -5, 0, -5,
+ax_anim 2, 0, 163, -2, -11, -2, -13,
+ax_anim 2, 0, 162, -10, -15, -10, -19,
+ax_anim 3, 0, 169, -18, -17, -18, -22,
+ax_anim 2, 3, 168, -20, -8, -20, -12,
+ax_anim 2, 0, 167, -17, -2, -17, -2,
+ax_anim 1, 0, 166, -10, 0, -10, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -3, -3, -3,
+ax_anim 2, 0, 162, -12, -4, -12, -4,
+ax_anim 2, 0, 169, -18, 0, -18, -3,
+ax_anim 3, 0, 168, -19, 4, -19, 0,
+ax_anim 2, 3, 167, -15, 9, -15, 7,
+ax_anim 2, 0, 166, -10, 9, -10, 9,
+ax_anim 1, 0, 165, -3, 7, -3, 7,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -19, 4, -19, 4,
+ax_anim 2, 0, 168, -23, 14, -23, 14,
+ax_anim 3, 0, 167, -21, 22, -21, 16,
+ax_anim 2, 3, 166, -11, 22, -11, 18,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -8, 0, 0,
+ax_anim 2, 2, 180, 0, 10, 0, 0,
+ax_anim_terminator
+sMetangAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -8, 0, 0,
+ax_anim 2, 2, 183, 0, 9, 0, 0,
+ax_anim_terminator
+sMetangAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -8, 0, 0,
+ax_anim 2, 2, 186, 0, 9, 0, 0,
+ax_anim_terminator
+sMetangAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -8, 0, 0,
+ax_anim 2, 2, 189, 0, 10, 0, 0,
+ax_anim_terminator
+sMetangAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, 0,
+ax_anim 2, 2, 192, 0, 9, 0, 0,
+ax_anim_terminator
+sMetangAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -8, 0, 0,
+ax_anim 2, 2, 195, 0, 10, 0, 0,
+ax_anim_terminator
+sMetangAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -8, 0, 0,
+ax_anim 2, 2, 198, 0, 9, 0, 0,
+ax_anim_terminator
+sMetangAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -8, 0, 0,
+ax_anim 2, 2, 201, 0, 9, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetangAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMetangGfx1:
+.incbin "baserom.gba", 0x1572E74, 0x200
+sMetangSprites1:
+ax_sprite sMetangGfx1, 0x200
+ax_sprite_terminator
+sMetangGfx2:
+.incbin "baserom.gba", 0x1573084, 0x200
+sMetangSprites2:
+ax_sprite sMetangGfx2, 0x200
+ax_sprite_terminator
+sMetangGfx3:
+.incbin "baserom.gba", 0x1573294, 0x200
+sMetangSprites3:
+ax_sprite sMetangGfx3, 0x200
+ax_sprite_terminator
+sMetangGfx4:
+.incbin "baserom.gba", 0x15734A4, 0x200
+sMetangSprites4:
+ax_sprite sMetangGfx4, 0x200
+ax_sprite_terminator
+sMetangGfx5:
+.incbin "baserom.gba", 0x15736B4, 0x200
+sMetangSprites5:
+ax_sprite sMetangGfx5, 0x200
+ax_sprite_terminator
+sMetangGfx6:
+.incbin "baserom.gba", 0x15738C4, 0x200
+sMetangSprites6:
+ax_sprite sMetangGfx6, 0x200
+ax_sprite_terminator
+sMetangGfx7:
+.incbin "baserom.gba", 0x1573AD4, 0x200
+sMetangSprites7:
+ax_sprite sMetangGfx7, 0x200
+ax_sprite_terminator
+sMetangGfx8:
+.incbin "baserom.gba", 0x1573CE4, 0x200
+sMetangSprites8:
+ax_sprite sMetangGfx8, 0x200
+ax_sprite_terminator
+sMetangGfx9:
+.incbin "baserom.gba", 0x1573EF4, 0x200
+sMetangSprites9:
+ax_sprite sMetangGfx9, 0x200
+ax_sprite_terminator
+sMetangGfx10:
+.incbin "baserom.gba", 0x1574104, 0x200
+sMetangSprites10:
+ax_sprite sMetangGfx10, 0x200
+ax_sprite_terminator
+sMetangGfx11:
+.incbin "baserom.gba", 0x1574314, 0x200
+sMetangSprites11:
+ax_sprite sMetangGfx11, 0x200
+ax_sprite_terminator
+sMetangGfx12:
+.incbin "baserom.gba", 0x1574524, 0x200
+sMetangSprites12:
+ax_sprite sMetangGfx12, 0x200
+ax_sprite_terminator
+sMetangGfx13:
+.incbin "baserom.gba", 0x1574734, 0x200
+sMetangSprites13:
+ax_sprite sMetangGfx13, 0x200
+ax_sprite_terminator
+sMetangGfx14:
+.incbin "baserom.gba", 0x1574944, 0x200
+sMetangSprites14:
+ax_sprite sMetangGfx14, 0x200
+ax_sprite_terminator
+sMetangGfx15:
+.incbin "baserom.gba", 0x1574B54, 0x200
+sMetangSprites15:
+ax_sprite sMetangGfx15, 0x200
+ax_sprite_terminator
+sMetangGfx16:
+.incbin "baserom.gba", 0x1574D64, 0x180
+sMetangSprites16:
+ax_sprite sMetangGfx16, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetangGfx17:
+.incbin "baserom.gba", 0x1574EFC, 0x60
+sMetangGfx17_1:
+.incbin "baserom.gba", 0x1574F5C, 0x100
+sMetangGfx17_2:
+.incbin "baserom.gba", 0x157505C, 0x20
+sMetangSprites17:
+ax_sprite sMetangGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx17_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx17_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetangGfx18:
+.incbin "baserom.gba", 0x15750B4, 0x40
+sMetangGfx18_1:
+.incbin "baserom.gba", 0x15750F4, 0x100
+sMetangGfx18_2:
+.incbin "baserom.gba", 0x15751F4, 0x60
+sMetangSprites18:
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx18_2, 0x60
+ax_sprite_terminator
+sMetangGfx19:
+.incbin "baserom.gba", 0x157528C, 0x1C0
+sMetangSprites19:
+ax_sprite sMetangGfx19, 0x1c0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetangGfx20:
+.incbin "baserom.gba", 0x1575464, 0x40
+sMetangGfx20_1:
+.incbin "baserom.gba", 0x15754A4, 0x180
+sMetangSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx20_1, 0x180
+ax_sprite_terminator
+sMetangGfx21:
+.incbin "baserom.gba", 0x157564C, 0x20
+sMetangGfx21_1:
+.incbin "baserom.gba", 0x157566C, 0x100
+sMetangSprites21:
+ax_sprite 0, 0x80
+ax_sprite sMetangGfx21, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMetangGfx21_1, 0x100
+ax_sprite_terminator
+sMetangGfx22:
+.incbin "baserom.gba", 0x1575794, 0x40
+sMetangGfx22_1:
+.incbin "baserom.gba", 0x15757D4, 0x100
+sMetangGfx22_2:
+.incbin "baserom.gba", 0x15758D4, 0x60
+sMetangSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx22_2, 0x60
+ax_sprite_terminator
+sMetangGfx23:
+.incbin "baserom.gba", 0x157596C, 0x40
+sMetangGfx23_1:
+.incbin "baserom.gba", 0x15759AC, 0x160
+sMetangSprites23:
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx23_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetangGfx24:
+.incbin "baserom.gba", 0x1575B3C, 0x20
+sMetangGfx24_1:
+.incbin "baserom.gba", 0x1575B5C, 0x20
+sMetangGfx24_2:
+.incbin "baserom.gba", 0x1575B7C, 0x80
+sMetangSprites24:
+ax_sprite sMetangGfx24, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx24_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx24_2, 0x80
+ax_sprite_terminator
+sMetangGfx25:
+.incbin "baserom.gba", 0x1575C2C, 0x60
+sMetangGfx25_1:
+.incbin "baserom.gba", 0x1575C8C, 0x140
+sMetangSprites25:
+ax_sprite sMetangGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx25_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetangGfx26:
+.incbin "baserom.gba", 0x1575DF4, 0x40
+sMetangGfx26_1:
+.incbin "baserom.gba", 0x1575E34, 0xA0
+sMetangSprites26:
+ax_sprite sMetangGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx26_1, 0xa0
+ax_sprite_terminator
+sMetangGfx27:
+.incbin "baserom.gba", 0x1575EF4, 0x1C0
+sMetangSprites27:
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx27, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetangGfx28:
+.incbin "baserom.gba", 0x15760D4, 0x60
+sMetangGfx28_1:
+.incbin "baserom.gba", 0x1576134, 0x40
+sMetangGfx28_2:
+.incbin "baserom.gba", 0x1576174, 0x40
+sMetangGfx28_3:
+.incbin "baserom.gba", 0x15761B4, 0x40
+sMetangSprites28:
+ax_sprite sMetangGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx28_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx28_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetangGfx29:
+.incbin "baserom.gba", 0x157623C, 0xE0
+sMetangSprites29:
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx29, 0xe0
+ax_sprite_terminator
+sMetangGfx30:
+.incbin "baserom.gba", 0x1576334, 0x80
+sMetangSprites30:
+ax_sprite sMetangGfx30, 0x80
+ax_sprite_terminator
+sMetangGfx31:
+.incbin "baserom.gba", 0x15763C4, 0x20
+sMetangSprites31:
+ax_sprite sMetangGfx31, 0x20
+ax_sprite_terminator
+sMetangGfx32:
+.incbin "baserom.gba", 0x15763F4, 0x20
+sMetangSprites32:
+ax_sprite sMetangGfx32, 0x20
+ax_sprite_terminator
+sMetangGfx33:
+.incbin "baserom.gba", 0x1576424, 0x40
+sMetangGfx33_1:
+.incbin "baserom.gba", 0x1576464, 0x40
+sMetangGfx33_2:
+.incbin "baserom.gba", 0x15764A4, 0x60
+sMetangSprites33:
+ax_sprite sMetangGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx33_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMetangGfx34:
+.incbin "baserom.gba", 0x157653C, 0x100
+sMetangSprites34:
+ax_sprite sMetangGfx34, 0x100
+ax_sprite_terminator
+sMetangGfx35:
+.incbin "baserom.gba", 0x157664C, 0x80
+sMetangSprites35:
+ax_sprite sMetangGfx35, 0x80
+ax_sprite_terminator
+sMetangGfx36:
+.incbin "baserom.gba", 0x15766DC, 0x20
+sMetangSprites36:
+ax_sprite sMetangGfx36, 0x20
+ax_sprite_terminator
+sMetangGfx37:
+.incbin "baserom.gba", 0x157670C, 0x20
+sMetangSprites37:
+ax_sprite sMetangGfx37, 0x20
+ax_sprite_terminator
+sMetangGfx38:
+.incbin "baserom.gba", 0x157673C, 0xC0
+sMetangSprites38:
+ax_sprite sMetangGfx38, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetangGfx39:
+.incbin "baserom.gba", 0x1576814, 0x100
+sMetangGfx39_1:
+.incbin "baserom.gba", 0x1576914, 0x60
+sMetangGfx39_2:
+.incbin "baserom.gba", 0x1576974, 0x40
+sMetangSprites39:
+ax_sprite sMetangGfx39, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx39_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx39_2, 0x40
+ax_sprite_terminator
+sMetangGfx40:
+.incbin "baserom.gba", 0x15769E4, 0xC0
+sMetangGfx40_1:
+.incbin "baserom.gba", 0x1576AA4, 0x20
+sMetangSprites40:
+ax_sprite sMetangGfx40, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx40_1, 0x20
+ax_sprite_terminator
+sMetangGfx41:
+.incbin "baserom.gba", 0x1576AE4, 0x60
+sMetangGfx41_1:
+.incbin "baserom.gba", 0x1576B44, 0x100
+sMetangGfx41_2:
+.incbin "baserom.gba", 0x1576C44, 0x20
+sMetangSprites41:
+ax_sprite sMetangGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx41_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx41_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetangGfx42:
+.incbin "baserom.gba", 0x1576C9C, 0x60
+sMetangGfx42_1:
+.incbin "baserom.gba", 0x1576CFC, 0x80
+sMetangGfx42_2:
+.incbin "baserom.gba", 0x1576D7C, 0x20
+sMetangSprites42:
+ax_sprite sMetangGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx42_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sMetangGfx42_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetangGfx43:
+.incbin "baserom.gba", 0x1576DD4, 0x60
+sMetangGfx43_1:
+.incbin "baserom.gba", 0x1576E34, 0x160
+sMetangSprites43:
+ax_sprite sMetangGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx43_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetangGfx44:
+.incbin "baserom.gba", 0x1576FBC, 0x160
+sMetangGfx44_1:
+.incbin "baserom.gba", 0x157711C, 0x60
+sMetangSprites44:
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx44, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx44_1, 0x60
+ax_sprite_terminator
+sMetangGfx45:
+.incbin "baserom.gba", 0x15771A4, 0x180
+sMetangSprites45:
+ax_sprite sMetangGfx45, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetangGfx46:
+.incbin "baserom.gba", 0x157733C, 0x60
+sMetangGfx46_1:
+.incbin "baserom.gba", 0x157739C, 0x100
+sMetangGfx46_2:
+.incbin "baserom.gba", 0x157749C, 0x20
+sMetangSprites46:
+ax_sprite sMetangGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx46_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sMetangGfx46_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetangGfx47:
+.incbin "baserom.gba", 0x15774F4, 0x60
+sMetangGfx47_1:
+.incbin "baserom.gba", 0x1577554, 0x120
+sMetangSprites47:
+ax_sprite sMetangGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx47_1, 0x120
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sMetangGfx48:
+.incbin "baserom.gba", 0x157769C, 0x180
+sMetangGfx48_1:
+.incbin "baserom.gba", 0x157781C, 0x40
+sMetangSprites48:
+ax_sprite sMetangGfx48, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMetangGfx48_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetangGfx49:
+.incbin "baserom.gba", 0x1577884, 0x180
+sMetangSprites49:
+ax_sprite sMetangGfx49, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetangGfx50:
+.incbin "baserom.gba", 0x1577A1C, 0x200
+sMetangSprites50:
+ax_sprite sMetangGfx50, 0x200
+ax_sprite_terminator
+sMetangGfx51:
+.incbin "baserom.gba", 0x1577C2C, 0x200
+sMetangSprites51:
+ax_sprite sMetangGfx51, 0x200
+ax_sprite_terminator
+sMetangGfx52:
+.incbin "baserom.gba", 0x1577E3C, 0x200
+sMetangSprites52:
+ax_sprite sMetangGfx52, 0x200
+ax_sprite_terminator
+sMetangGfx53:
+.incbin "baserom.gba", 0x157804C, 0x200
+sMetangSprites53:
+ax_sprite sMetangGfx53, 0x200
+ax_sprite_terminator
+sMetangGfx54:
+.incbin "baserom.gba", 0x157825C, 0x200
+sMetangSprites54:
+ax_sprite sMetangGfx54, 0x200
+ax_sprite_terminator
+sMetangGfx55:
+.incbin "baserom.gba", 0x157846C, 0x100
+sMetangSprites55:
+ax_sprite sMetangGfx55, 0x100
+ax_sprite_terminator
+sMetangGfx56:
+.incbin "baserom.gba", 0x157857C, 0x40
+sMetangSprites56:
+ax_sprite sMetangGfx56, 0x40
+ax_sprite_terminator
+sMetangGfx57:
+.incbin "baserom.gba", 0x15785CC, 0x20
+sMetangSprites57:
+ax_sprite sMetangGfx57, 0x20
+ax_sprite_terminator
+sMetangGfx58:
+.incbin "baserom.gba", 0x15785FC, 0x20
+sMetangSprites58:
+ax_sprite sMetangGfx58, 0x20
+ax_sprite_terminator
+sMetangGfx59:
+.incbin "baserom.gba", 0x157862C, 0x20
+sMetangSprites59:
+ax_sprite sMetangGfx59, 0x20
+ax_sprite_terminator
+sMetangGfx60:
+.incbin "baserom.gba", 0x157865C, 0x20
+sMetangSprites60:
+ax_sprite sMetangGfx60, 0x20
+ax_sprite_terminator
+sMetangGfx61:
+.incbin "baserom.gba", 0x157868C, 0x40
+sMetangSprites61:
+ax_sprite sMetangGfx61, 0x40
+ax_sprite_terminator
+sMetangGfx62:
+.incbin "baserom.gba", 0x15786DC, 0x200
+sMetangSprites62:
+ax_sprite sMetangGfx62, 0x200
+ax_sprite_terminator
+sAxPosesMetang:
+.4byte sMetangPose1
+.4byte sMetangPose2
+.4byte sMetangPose3
+.4byte sMetangPose4
+.4byte sMetangPose5
+.4byte sMetangPose6
+.4byte sMetangPose7
+.4byte sMetangPose8
+.4byte sMetangPose9
+.4byte sMetangPose10
+.4byte sMetangPose11
+.4byte sMetangPose12
+.4byte sMetangPose13
+.4byte sMetangPose14
+.4byte sMetangPose15
+.4byte sMetangPose16
+.4byte sMetangPose17
+.4byte sMetangPose18
+.4byte sMetangPose19
+.4byte sMetangPose20
+.4byte sMetangPose21
+.4byte sMetangPose22
+.4byte sMetangPose23
+.4byte sMetangPose24
+.4byte sMetangPose25
+.4byte sMetangPose26
+.4byte sMetangPose27
+.4byte sMetangPose28
+.4byte sMetangPose29
+.4byte sMetangPose30
+.4byte sMetangPose31
+.4byte sMetangPose32
+.4byte sMetangPose33
+.4byte sMetangPose34
+.4byte sMetangPose35
+.4byte sMetangPose36
+.4byte sMetangPose37
+.4byte sMetangPose38
+.4byte sMetangPose39
+.4byte sMetangPose40
+.4byte sMetangPose41
+.4byte sMetangPose42
+.4byte sMetangPose43
+.4byte sMetangPose44
+.4byte sMetangPose45
+.4byte sMetangPose46
+.4byte sMetangPose47
+.4byte sMetangPose48
+.4byte sMetangPose49
+.4byte sMetangPose50
+.4byte sMetangPose51
+.4byte sMetangPose52
+.4byte sMetangPose53
+.4byte sMetangPose54
+.4byte sMetangPose55
+.4byte sMetangPose56
+.4byte sMetangPose57
+.4byte sMetangPose58
+.4byte sMetangPose59
+.4byte sMetangPose60
+.4byte sMetangPose61
+.4byte sMetangPose62
+.4byte sMetangPose63
+.4byte sMetangPose64
+.4byte sMetangPose65
+.4byte sMetangPose66
+.4byte sMetangPose67
+.4byte sMetangPose68
+.4byte sMetangPose69
+.4byte sMetangPose70
+.4byte sMetangPose71
+.4byte sMetangPose72
+.4byte sMetangPose73
+.4byte sMetangPose74
+.4byte sMetangPose75
+.4byte sMetangPose76
+.4byte sMetangPose77
+.4byte sMetangPose78
+.4byte sMetangPose79
+.4byte sMetangPose80
+.4byte sMetangPose81
+.4byte sMetangPose82
+.4byte sMetangPose83
+.4byte sMetangPose84
+.4byte sMetangPose85
+.4byte sMetangPose86
+.4byte sMetangPose87
+.4byte sMetangPose88
+.4byte sMetangPose89
+.4byte sMetangPose90
+.4byte sMetangPose91
+.4byte sMetangPose92
+.4byte sMetangPose93
+.4byte sMetangPose94
+.4byte sMetangPose95
+.4byte sMetangPose96
+.4byte sMetangPose97
+.4byte sMetangPose98
+.4byte sMetangPose99
+.4byte sMetangPose100
+.4byte sMetangPose101
+.4byte sMetangPose102
+.4byte sMetangPose103
+.4byte sMetangPose104
+.4byte sMetangPose105
+.4byte sMetangPose106
+.4byte sMetangPose107
+.4byte sMetangPose108
+.4byte sMetangPose109
+.4byte sMetangPose110
+.4byte sMetangPose111
+.4byte sMetangPose112
+.4byte sMetangPose113
+.4byte sMetangPose114
+.4byte sMetangPose115
+.4byte sMetangPose116
+.4byte sMetangPose117
+.4byte sMetangPose118
+.4byte sMetangPose119
+.4byte sMetangPose120
+.4byte sMetangPose121
+.4byte sMetangPose122
+.4byte sMetangPose123
+.4byte sMetangPose124
+.4byte sMetangPose125
+.4byte sMetangPose126
+.4byte sMetangPose127
+.4byte sMetangPose128
+.4byte sMetangPose129
+.4byte sMetangPose130
+.4byte sMetangPose131
+.4byte sMetangPose132
+.4byte sMetangPose133
+.4byte sMetangPose134
+.4byte sMetangPose135
+.4byte sMetangPose136
+.4byte sMetangPose137
+.4byte sMetangPose138
+.4byte sMetangPose139
+.4byte sMetangPose140
+.4byte sMetangPose141
+.4byte sMetangPose142
+.4byte sMetangPose143
+.4byte sMetangPose144
+.4byte sMetangPose145
+.4byte sMetangPose146
+.4byte sMetangPose147
+.4byte sMetangPose148
+.4byte sMetangPose149
+.4byte sMetangPose150
+.4byte sMetangPose151
+.4byte sMetangPose152
+.4byte sMetangPose153
+.4byte sMetangPose154
+.4byte sMetangPose155
+.4byte sMetangPose156
+.4byte sMetangPose157
+.4byte sMetangPose158
+.4byte sMetangPose159
+.4byte sMetangPose160
+.4byte sMetangPose161
+.4byte sMetangPose162
+.4byte sMetangPose163
+.4byte sMetangPose164
+.4byte sMetangPose165
+.4byte sMetangPose166
+.4byte sMetangPose167
+.4byte sMetangPose168
+.4byte sMetangPose169
+.4byte sMetangPose170
+.4byte sMetangPose171
+.4byte sMetangPose172
+.4byte sMetangPose173
+.4byte sMetangPose174
+.4byte sMetangPose175
+.4byte sMetangPose176
+.4byte sMetangPose177
+.4byte sMetangPose178
+.4byte sMetangPose179
+.4byte sMetangPose180
+.4byte sMetangPose181
+.4byte sMetangPose182
+.4byte sMetangPose183
+.4byte sMetangPose184
+.4byte sMetangPose185
+.4byte sMetangPose186
+.4byte sMetangPose187
+.4byte sMetangPose188
+.4byte sMetangPose189
+.4byte sMetangPose190
+.4byte sMetangPose191
+.4byte sMetangPose192
+.4byte sMetangPose193
+.4byte sMetangPose194
+.4byte sMetangPose195
+.4byte sMetangPose196
+.4byte sMetangPose197
+.4byte sMetangPose198
+.4byte sMetangPose199
+.4byte sMetangPose200
+.4byte sMetangPose201
+.4byte sMetangPose202
+.4byte sMetangPose203
+.4byte sMetangPose204
+.4byte sMetangPose205
+.4byte sMetangPose206
+.4byte sMetangPose207
+.4byte sMetangPose208
+.4byte sMetangPose209
+.4byte sMetangPose210
+.4byte sMetangPose211
+.4byte sMetangPose212
+.4byte sMetangPose213
+.4byte sMetangPose214
+.4byte sMetangPose215
+.4byte sMetangPose216
+.4byte sMetangPose217
+.4byte sMetangPose218
+sAxPositionsMetang:
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte   -1,  -11, 	 -12,   -4, 	   9,   -4, 	  -1,  -16
+.2byte   -1,  -11, 	 -11,    0, 	   9,    0, 	  -1,  -16
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+.2byte    5,  -11, 	  14,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte    5,  -11, 	  13,   -6, 	  -5,    2, 	   0,  -15
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    8,  -16, 	   8,  -22, 	   9,   -9, 	  -1,  -16
+.2byte    8,  -16, 	   9,  -14, 	   6,   -1, 	  -2,  -16
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    4,  -20, 	  -5,  -23, 	  15,  -16, 	  -1,  -17
+.2byte    4,  -20, 	  -5,  -17, 	  13,   -8, 	  -1,  -16
+.2byte   -1,  -20, 	  10,  -20, 	 -12,  -20, 	  -1,  -17
+.2byte   -1,  -20, 	  11,  -21, 	 -12,  -21, 	  -1,  -17
+.2byte   -1,  -20, 	  11,  -14, 	 -13,  -14, 	  -1,  -17
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte   -6,  -20, 	   3,  -23, 	 -17,  -16, 	  -1,  -17
+.2byte   -6,  -20, 	   3,  -17, 	 -15,   -8, 	  -1,  -16
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte  -10,  -16, 	 -10,  -22, 	 -11,   -9, 	  -1,  -16
+.2byte  -10,  -16, 	 -11,  -14, 	  -8,   -1, 	   0,  -16
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte   -7,  -11, 	 -16,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte   -7,  -11, 	 -15,   -6, 	   3,    2, 	  -2,  -15
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte   -1,  -11, 	 -12,   -4, 	   9,   -4, 	  -1,  -16
+.2byte   -1,  -11, 	 -12,  -19, 	  10,  -19, 	  -1,  -15
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+.2byte    5,  -11, 	  14,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte    5,  -11, 	   6,  -20, 	 -16,  -14, 	  -1,  -17
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    8,  -16, 	   8,  -22, 	   9,   -9, 	  -1,  -16
+.2byte    7,  -16, 	 -11,  -18, 	 -12,   -3, 	  -3,  -17
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    4,  -20, 	  -5,  -23, 	  15,  -16, 	  -1,  -17
+.2byte    4,  -20, 	 -15,  -12, 	   2,    1, 	  -1,  -17
+.2byte   -1,  -20, 	  10,  -20, 	 -12,  -20, 	  -1,  -17
+.2byte   -1,  -20, 	  11,  -21, 	 -12,  -21, 	  -1,  -17
+.2byte   -1,  -20, 	  10,   -4, 	 -11,   -4, 	  -1,  -16
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte   -6,  -20, 	   3,  -23, 	 -17,  -16, 	  -1,  -17
+.2byte   -6,  -20, 	  13,  -12, 	  -4,    1, 	  -1,  -17
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte  -10,  -16, 	 -10,  -22, 	 -11,   -9, 	  -1,  -16
+.2byte   -9,  -16, 	   9,  -18, 	  10,   -3, 	   1,  -17
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte   -7,  -11, 	 -16,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte   -7,  -11, 	  -8,  -20, 	  14,  -14, 	  -1,  -17
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte    5,  -11, 	   8,   -1, 	  12,  -17, 	   0,  -17
+.2byte    5,  -11, 	   8,   -1, 	  12,  -17, 	   0,  -17
+.2byte   -6,  -11, 	 -12,  -16, 	  -8,   -1, 	   0,  -17
+.2byte   -6,  -11, 	 -12,  -16, 	  -8,   -1, 	   0,  -17
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+.2byte    1,  -10, 	   8,    1, 	 -14,  -13, 	   1,  -16
+.2byte    1,  -10, 	   8,    1, 	 -14,  -13, 	   1,  -16
+.2byte   11,  -15, 	   7,  -22, 	  16,   -7, 	   1,  -16
+.2byte   11,  -15, 	   7,  -22, 	  16,   -7, 	   1,  -16
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    7,  -12, 	  15,   -7, 	 -10,   -6, 	  -1,  -17
+.2byte    7,  -12, 	  15,   -7, 	 -10,   -6, 	  -1,  -17
+.2byte    7,  -19, 	 -10,  -22, 	  15,  -19, 	   0,  -17
+.2byte    7,  -19, 	 -10,  -22, 	  15,  -19, 	   0,  -17
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    7,  -15, 	  15,  -17, 	  -3,   -3, 	  -2,  -17
+.2byte    7,  -15, 	  15,  -17, 	  -3,   -3, 	  -2,  -17
+.2byte   -1,  -20, 	 -14,  -14, 	   8,  -26, 	  -1,  -16
+.2byte   -1,  -20, 	 -14,  -14, 	   8,  -26, 	  -1,  -16
+.2byte    0,  -20, 	 -11,  -20, 	  11,  -20, 	   0,  -17
+.2byte   -8,  -16, 	 -12,  -22, 	  -8,   -6, 	   0,  -16
+.2byte   -8,  -16, 	 -12,  -22, 	  -8,   -6, 	   0,  -16
+.2byte    7,  -16, 	   8,   -5, 	  11,  -22, 	  -2,  -16
+.2byte    7,  -16, 	   8,   -5, 	  11,  -22, 	  -2,  -16
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte  -10,  -15, 	 -18,  -17, 	   0,   -3, 	  -1,  -17
+.2byte  -10,  -15, 	 -18,  -17, 	   0,   -3, 	  -1,  -17
+.2byte   -2,  -20, 	  11,  -14, 	 -11,  -26, 	  -2,  -16
+.2byte   -2,  -20, 	  11,  -14, 	 -11,  -26, 	  -2,  -16
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte   -8,  -12, 	 -16,   -7, 	   9,   -6, 	   0,  -17
+.2byte   -8,  -12, 	 -16,   -7, 	   9,   -6, 	   0,  -17
+.2byte   -8,  -19, 	   9,  -22, 	 -16,  -19, 	  -1,  -17
+.2byte   -8,  -19, 	   9,  -22, 	 -16,  -19, 	  -1,  -17
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte   -3,  -10, 	 -10,    1, 	  12,  -13, 	  -3,  -16
+.2byte   -3,  -10, 	 -10,    1, 	  12,  -13, 	  -3,  -16
+.2byte  -10,  -15, 	  -6,  -22, 	 -15,   -7, 	   0,  -16
+.2byte  -10,  -15, 	  -6,  -22, 	 -15,   -7, 	   0,  -16
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte   -1,  -17, 	 -10,  -19, 	   8,  -19, 	  -1,  -15
+.2byte   -1,  -11, 	 -12,  -19, 	  10,  -19, 	  -1,  -15
+.2byte   -1,  -11, 	 -12,   -4, 	   9,   -4, 	  -1,  -16
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+.2byte    3,  -19, 	   9,  -22, 	   0,  -16, 	  -3,  -14
+.2byte    5,  -11, 	   6,  -20, 	 -16,  -14, 	  -1,  -17
+.2byte    5,  -11, 	  14,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    5,  -18, 	   7,  -25, 	   8,  -18, 	  -2,  -17
+.2byte    9,  -16, 	  -9,  -18, 	 -10,   -3, 	  -1,  -17
+.2byte    8,  -16, 	   8,  -22, 	   9,   -9, 	  -1,  -16
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    2,  -21, 	  -1,  -26, 	  10,  -23, 	  -2,  -17
+.2byte    4,  -20, 	 -15,  -12, 	   2,    1, 	  -1,  -17
+.2byte    4,  -19, 	  -5,  -22, 	  15,  -15, 	  -1,  -16
+.2byte   -1,  -20, 	  10,  -20, 	 -12,  -20, 	  -1,  -17
+.2byte   -1,  -21, 	   8,  -23, 	  -9,  -23, 	  -1,  -17
+.2byte   -1,  -20, 	  10,   -4, 	 -11,   -4, 	  -1,  -16
+.2byte   -1,  -20, 	  11,  -21, 	 -12,  -21, 	  -1,  -17
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte   -5,  -21, 	  -2,  -26, 	 -13,  -23, 	  -1,  -17
+.2byte   -6,  -20, 	  13,  -12, 	  -4,    1, 	  -1,  -17
+.2byte   -6,  -19, 	   3,  -22, 	 -17,  -15, 	  -1,  -16
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte   -7,  -18, 	  -9,  -25, 	 -10,  -18, 	   0,  -17
+.2byte  -11,  -16, 	   7,  -18, 	   8,   -3, 	  -1,  -17
+.2byte  -10,  -16, 	 -10,  -22, 	 -11,   -9, 	  -1,  -16
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte   -7,  -19, 	 -13,  -22, 	  -4,  -16, 	  -1,  -14
+.2byte   -7,  -11, 	  -8,  -20, 	  14,  -14, 	  -1,  -17
+.2byte   -7,  -11, 	 -16,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte   -1,  -20, 	  10,  -20, 	 -12,  -20, 	  -1,  -17
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+.2byte   -4,   -9, 	 -14,   -6, 	   4,    3, 	   2,  -15
+.2byte   -4,   -9, 	 -13,   -8, 	   4,    2, 	   1,  -16
+.2byte    0,  -17, 	 -10,  -27, 	  10,  -27, 	   0,  -13
+.2byte    6,  -15, 	   4,  -29, 	 -10,  -19, 	   0,  -14
+.2byte    8,  -18, 	  -7,  -27, 	 -11,  -22, 	   0,  -15
+.2byte    2,  -19, 	 -10,  -27, 	  13,  -22, 	  -2,  -13
+.2byte    0,  -20, 	  10,  -27, 	 -10,  -26, 	   0,  -14
+.2byte   -2,  -19, 	  10,  -27, 	 -13,  -22, 	   2,  -13
+.2byte   -9,  -18, 	   6,  -27, 	  10,  -22, 	  -1,  -15
+.2byte   -6,  -16, 	  -4,  -30, 	  10,  -20, 	   0,  -15
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte   -1,  -11, 	 -12,   -4, 	   9,   -4, 	  -1,  -16
+.2byte   -1,  -11, 	 -11,    0, 	   9,    0, 	  -1,  -16
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+.2byte    5,  -11, 	  14,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte    5,  -11, 	  13,   -6, 	  -5,    2, 	   0,  -15
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    8,  -16, 	   8,  -22, 	   9,   -9, 	  -1,  -16
+.2byte    8,  -16, 	   9,  -14, 	   6,   -1, 	  -2,  -16
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    4,  -20, 	  -5,  -23, 	  15,  -16, 	  -1,  -17
+.2byte    4,  -20, 	  -5,  -17, 	  13,   -8, 	  -1,  -16
+.2byte   -1,  -20, 	  10,  -20, 	 -12,  -20, 	  -1,  -17
+.2byte   -1,  -20, 	  11,  -21, 	 -12,  -21, 	  -1,  -17
+.2byte   -1,  -20, 	  11,  -14, 	 -13,  -14, 	  -1,  -17
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte   -6,  -20, 	   3,  -23, 	 -17,  -16, 	  -1,  -17
+.2byte   -6,  -20, 	   3,  -17, 	 -15,   -8, 	  -1,  -16
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte  -10,  -16, 	 -10,  -22, 	 -11,   -9, 	  -1,  -16
+.2byte  -10,  -16, 	 -11,  -14, 	  -8,   -1, 	   0,  -16
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte   -7,  -11, 	 -16,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte   -7,  -11, 	 -15,   -6, 	   3,    2, 	  -2,  -15
+.2byte   -1,  -11, 	 -12,  -19, 	  10,  -19, 	  -1,  -15
+.2byte   -7,  -11, 	  -8,  -20, 	  14,  -14, 	  -1,  -17
+.2byte   -9,  -16, 	   9,  -18, 	  10,   -3, 	   1,  -17
+.2byte   -6,  -20, 	  13,  -12, 	  -4,    1, 	  -1,  -17
+.2byte   -1,  -20, 	  10,   -4, 	 -11,   -4, 	  -1,  -16
+.2byte    4,  -20, 	 -15,  -12, 	   2,    1, 	  -1,  -17
+.2byte    7,  -16, 	 -11,  -18, 	 -12,   -3, 	  -3,  -17
+.2byte    5,  -11, 	   6,  -20, 	 -16,  -14, 	  -1,  -17
+.2byte   -1,  -16, 	 -10,  -18, 	   8,  -18, 	  -1,  -14
+.2byte    5,  -19, 	  11,  -22, 	   2,  -16, 	  -1,  -14
+.2byte    6,  -18, 	   8,  -25, 	   9,  -18, 	  -1,  -17
+.2byte    3,  -21, 	   0,  -26, 	  11,  -23, 	  -1,  -17
+.2byte   -1,  -21, 	   8,  -23, 	  -9,  -23, 	  -1,  -17
+.2byte   -4,  -21, 	  -1,  -26, 	 -12,  -23, 	   0,  -17
+.2byte   -7,  -18, 	  -9,  -25, 	 -10,  -18, 	   0,  -17
+.2byte   -6,  -19, 	 -12,  -22, 	  -3,  -16, 	   0,  -14
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte   -1,  -11, 	 -11,    0, 	   9,    0, 	  -1,  -16
+.2byte   -1,  -17, 	 -10,  -19, 	   8,  -19, 	  -1,  -15
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+.2byte    5,  -11, 	  13,   -6, 	  -5,    2, 	   0,  -15
+.2byte    3,  -19, 	   9,  -22, 	   0,  -16, 	  -3,  -14
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    8,  -16, 	   9,  -14, 	   6,   -1, 	  -2,  -16
+.2byte    5,  -18, 	   7,  -25, 	   8,  -18, 	  -2,  -17
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    4,  -20, 	  -5,  -17, 	  13,   -8, 	  -1,  -16
+.2byte    2,  -21, 	  -1,  -26, 	  10,  -23, 	  -2,  -17
+.2byte   -1,  -20, 	  10,  -20, 	 -12,  -20, 	  -1,  -17
+.2byte   -1,  -20, 	  11,  -14, 	 -13,  -14, 	  -1,  -17
+.2byte   -1,  -21, 	   8,  -23, 	  -9,  -23, 	  -1,  -17
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte   -6,  -20, 	   3,  -17, 	 -15,   -8, 	  -1,  -16
+.2byte   -5,  -21, 	  -2,  -26, 	 -13,  -23, 	  -1,  -17
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte  -10,  -16, 	 -11,  -14, 	  -8,   -1, 	   0,  -16
+.2byte   -7,  -18, 	  -9,  -25, 	 -10,  -18, 	   0,  -17
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte   -7,  -11, 	 -15,   -6, 	   3,    2, 	  -2,  -15
+.2byte   -7,  -19, 	 -13,  -22, 	  -4,  -16, 	  -1,  -14
+.2byte   -1,  -11, 	 -12,   -4, 	   9,   -4, 	  -1,  -16
+.2byte   -6,  -11, 	 -15,  -13, 	   0,   -4, 	   0,  -16
+.2byte  -10,  -16, 	 -10,  -22, 	 -11,   -9, 	  -1,  -16
+.2byte   -6,  -20, 	   3,  -23, 	 -17,  -16, 	  -1,  -17
+.2byte   -1,  -20, 	  11,  -21, 	 -12,  -21, 	  -1,  -17
+.2byte    5,  -20, 	  -4,  -23, 	  16,  -16, 	   0,  -17
+.2byte    9,  -16, 	   9,  -22, 	  10,   -9, 	   0,  -16
+.2byte    5,  -11, 	  14,  -13, 	  -1,   -4, 	  -1,  -16
+.2byte   -1,  -11, 	 -11,   -2, 	   9,   -2, 	  -1,  -16
+.2byte   -7,  -11, 	 -17,  -10, 	   1,   -1, 	  -2,  -15
+.2byte  -10,  -16, 	 -11,  -19, 	 -11,   -4, 	  -1,  -16
+.2byte   -6,  -20, 	   2,  -22, 	 -16,  -12, 	  -1,  -17
+.2byte   -1,  -20, 	  10,  -20, 	 -12,  -20, 	  -1,  -17
+.2byte    4,  -20, 	  -4,  -22, 	  14,  -12, 	  -1,  -17
+.2byte    8,  -16, 	   9,  -19, 	   9,   -4, 	  -1,  -16
+.2byte    5,  -11, 	  15,  -10, 	  -3,   -1, 	   0,  -15
+sMetangAnimTable1:
+.4byte sMetangAnims_1_1
+.4byte sMetangAnims_1_2
+.4byte sMetangAnims_1_3
+.4byte sMetangAnims_1_4
+.4byte sMetangAnims_1_5
+.4byte sMetangAnims_1_6
+.4byte sMetangAnims_1_7
+.4byte sMetangAnims_1_8
+sMetangAnimTable2:
+.4byte sMetangAnims_2_1
+.4byte sMetangAnims_2_2
+.4byte sMetangAnims_2_3
+.4byte sMetangAnims_2_4
+.4byte sMetangAnims_2_5
+.4byte sMetangAnims_2_6
+.4byte sMetangAnims_2_7
+.4byte sMetangAnims_2_8
+sMetangAnimTable3:
+.4byte sMetangAnims_3_1
+.4byte sMetangAnims_3_2
+.4byte sMetangAnims_3_3
+.4byte sMetangAnims_3_4
+.4byte sMetangAnims_3_5
+.4byte sMetangAnims_3_6
+.4byte sMetangAnims_3_7
+.4byte sMetangAnims_3_8
+sMetangAnimTable4:
+.4byte sMetangAnims_4_1
+.4byte sMetangAnims_4_2
+.4byte sMetangAnims_4_3
+.4byte sMetangAnims_4_4
+.4byte sMetangAnims_4_5
+.4byte sMetangAnims_4_6
+.4byte sMetangAnims_4_7
+.4byte sMetangAnims_4_8
+sMetangAnimTable5:
+.4byte sMetangAnims_5_1
+.4byte sMetangAnims_5_2
+.4byte sMetangAnims_5_3
+.4byte sMetangAnims_5_4
+.4byte sMetangAnims_5_5
+.4byte sMetangAnims_5_6
+.4byte sMetangAnims_5_7
+.4byte sMetangAnims_5_8
+sMetangAnimTable6:
+.4byte sMetangAnims_6_1
+.4byte sMetangAnims_6_1
+.4byte sMetangAnims_6_1
+.4byte sMetangAnims_6_1
+.4byte sMetangAnims_6_1
+.4byte sMetangAnims_6_1
+.4byte sMetangAnims_6_1
+.4byte sMetangAnims_6_1
+sMetangAnimTable7:
+.4byte sMetangAnims_7_1
+.4byte sMetangAnims_7_2
+.4byte sMetangAnims_7_3
+.4byte sMetangAnims_7_4
+.4byte sMetangAnims_7_5
+.4byte sMetangAnims_7_6
+.4byte sMetangAnims_7_7
+.4byte sMetangAnims_7_8
+sMetangAnimTable8:
+.4byte sMetangAnims_8_1
+.4byte sMetangAnims_8_2
+.4byte sMetangAnims_8_3
+.4byte sMetangAnims_8_4
+.4byte sMetangAnims_8_5
+.4byte sMetangAnims_8_6
+.4byte sMetangAnims_8_7
+.4byte sMetangAnims_8_8
+sMetangAnimTable9:
+.4byte sMetangAnims_9_1
+.4byte sMetangAnims_9_2
+.4byte sMetangAnims_9_3
+.4byte sMetangAnims_9_4
+.4byte sMetangAnims_9_5
+.4byte sMetangAnims_9_6
+.4byte sMetangAnims_9_7
+.4byte sMetangAnims_9_8
+sMetangAnimTable10:
+.4byte sMetangAnims_10_1
+.4byte sMetangAnims_10_2
+.4byte sMetangAnims_10_3
+.4byte sMetangAnims_10_4
+.4byte sMetangAnims_10_5
+.4byte sMetangAnims_10_6
+.4byte sMetangAnims_10_7
+.4byte sMetangAnims_10_8
+sMetangAnimTable11:
+.4byte sMetangAnims_11_1
+.4byte sMetangAnims_11_2
+.4byte sMetangAnims_11_3
+.4byte sMetangAnims_11_4
+.4byte sMetangAnims_11_5
+.4byte sMetangAnims_11_6
+.4byte sMetangAnims_11_7
+.4byte sMetangAnims_11_8
+sMetangAnimTable12:
+.4byte sMetangAnims_12_1
+.4byte sMetangAnims_12_2
+.4byte sMetangAnims_12_3
+.4byte sMetangAnims_12_4
+.4byte sMetangAnims_12_5
+.4byte sMetangAnims_12_6
+.4byte sMetangAnims_12_7
+.4byte sMetangAnims_12_8
+sMetangAnimTable13:
+.4byte sMetangAnims_13_1
+.4byte sMetangAnims_13_2
+.4byte sMetangAnims_13_3
+.4byte sMetangAnims_13_4
+.4byte sMetangAnims_13_5
+.4byte sMetangAnims_13_6
+.4byte sMetangAnims_13_7
+.4byte sMetangAnims_13_8
+sAxAnimationsMetang:
+.4byte sMetangAnimTable1
+.4byte sMetangAnimTable2
+.4byte sMetangAnimTable3
+.4byte sMetangAnimTable4
+.4byte sMetangAnimTable5
+.4byte sMetangAnimTable6
+.4byte sMetangAnimTable7
+.4byte sMetangAnimTable8
+.4byte sMetangAnimTable9
+.4byte sMetangAnimTable10
+.4byte sMetangAnimTable11
+.4byte sMetangAnimTable12
+.4byte sMetangAnimTable13
+sAxSpritesMetang:
+.4byte sMetangSprites1
+.4byte sMetangSprites2
+.4byte sMetangSprites3
+.4byte sMetangSprites4
+.4byte sMetangSprites5
+.4byte sMetangSprites6
+.4byte sMetangSprites7
+.4byte sMetangSprites8
+.4byte sMetangSprites9
+.4byte sMetangSprites10
+.4byte sMetangSprites11
+.4byte sMetangSprites12
+.4byte sMetangSprites13
+.4byte sMetangSprites14
+.4byte sMetangSprites15
+.4byte sMetangSprites16
+.4byte sMetangSprites17
+.4byte sMetangSprites18
+.4byte sMetangSprites19
+.4byte sMetangSprites20
+.4byte sMetangSprites21
+.4byte sMetangSprites22
+.4byte sMetangSprites23
+.4byte sMetangSprites24
+.4byte sMetangSprites25
+.4byte sMetangSprites26
+.4byte sMetangSprites27
+.4byte sMetangSprites28
+.4byte sMetangSprites29
+.4byte sMetangSprites30
+.4byte sMetangSprites31
+.4byte sMetangSprites32
+.4byte sMetangSprites33
+.4byte sMetangSprites34
+.4byte sMetangSprites35
+.4byte sMetangSprites36
+.4byte sMetangSprites37
+.4byte sMetangSprites38
+.4byte sMetangSprites39
+.4byte sMetangSprites40
+.4byte sMetangSprites41
+.4byte sMetangSprites42
+.4byte sMetangSprites43
+.4byte sMetangSprites44
+.4byte sMetangSprites45
+.4byte sMetangSprites46
+.4byte sMetangSprites47
+.4byte sMetangSprites48
+.4byte sMetangSprites49
+.4byte sMetangSprites50
+.4byte sMetangSprites51
+.4byte sMetangSprites52
+.4byte sMetangSprites53
+.4byte sMetangSprites54
+.4byte sMetangSprites55
+.4byte sMetangSprites56
+.4byte sMetangSprites57
+.4byte sMetangSprites58
+.4byte sMetangSprites59
+.4byte sMetangSprites60
+.4byte sMetangSprites61
+.4byte sMetangSprites62
+sAxMainMetang:
+ax_main sAxPosesMetang, sAxAnimationsMetang, 13, sAxSpritesMetang, sAxPositionsMetang

--- a/data/ax/metapod.inc
+++ b/data/ax/metapod.inc
@@ -1,0 +1,2966 @@
+.global gAxMetapod
+gAxMetapod:
+ax_siro sAxMainMetapod
+sMetapodPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose2:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose4:
+ax_pose 3, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose5:
+ax_pose 4, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose6:
+ax_pose 5, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose7:
+ax_pose 6, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose8:
+ax_pose 7, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose9:
+ax_pose 8, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose16:
+ax_pose 9, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose17:
+ax_pose 10, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose18:
+ax_pose 11, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose19:
+ax_pose 6, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose20:
+ax_pose 7, 0x01ea, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose21:
+ax_pose 8, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose26:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose28:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose 16, 0x01ed, 0x80f4, 0x3c10
+ax_pose_terminator
+sMetapodPose29:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose30:
+ax_pose 3, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose31:
+ax_pose 4, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose32:
+ax_pose 5, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose33:
+ax_pose 17, 0x01eb, 0x90ee, 0x3c00
+ax_pose 18, 0x01eb, 0x90ee, 0x3c10
+ax_pose_terminator
+sMetapodPose34:
+ax_pose 18, 0x01eb, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose35:
+ax_pose 6, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose36:
+ax_pose 7, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose37:
+ax_pose 8, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose38:
+ax_pose 19, 0x01ea, 0x90f0, 0x3c00
+ax_pose 20, 0x01ea, 0x90f0, 0x3c10
+ax_pose_terminator
+sMetapodPose39:
+ax_pose 20, 0x01ea, 0x90f0, 0x3c00
+ax_pose_terminator
+sMetapodPose40:
+ax_pose 9, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose41:
+ax_pose 10, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose42:
+ax_pose 11, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose43:
+ax_pose 21, 0x01eb, 0x90ec, 0x3c00
+ax_pose 22, 0x01ec, 0x90ea, 0x3c10
+ax_pose_terminator
+sMetapodPose44:
+ax_pose 22, 0x01ec, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose45:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose46:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose47:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose48:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose 24, 0x01ee, 0x80f4, 0x3c10
+ax_pose_terminator
+sMetapodPose49:
+ax_pose 24, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose50:
+ax_pose 9, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose51:
+ax_pose 10, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose52:
+ax_pose 11, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose53:
+ax_pose 21, 0x01eb, 0x80f4, 0x3c00
+ax_pose 22, 0x01ec, 0x80f6, 0x3c10
+ax_pose_terminator
+sMetapodPose54:
+ax_pose 22, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose55:
+ax_pose 6, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose56:
+ax_pose 7, 0x01ea, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose57:
+ax_pose 8, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose58:
+ax_pose 19, 0x01ea, 0x80f0, 0x3c00
+ax_pose 20, 0x01ea, 0x80f0, 0x3c10
+ax_pose_terminator
+sMetapodPose59:
+ax_pose 20, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sMetapodPose60:
+ax_pose 3, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose61:
+ax_pose 4, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose62:
+ax_pose 5, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose63:
+ax_pose 17, 0x01eb, 0x80f2, 0x3c00
+ax_pose 18, 0x01eb, 0x80f2, 0x3c10
+ax_pose_terminator
+sMetapodPose64:
+ax_pose 18, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose65:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose66:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose67:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose68:
+ax_pose 15, 0x01ed, 0x80f4, 0x3c00
+ax_pose 16, 0x01ed, 0x80f4, 0x3c10
+ax_pose_terminator
+sMetapodPose69:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose70:
+ax_pose 3, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose71:
+ax_pose 4, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose72:
+ax_pose 5, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose73:
+ax_pose 17, 0x01eb, 0x90ee, 0x3c00
+ax_pose 18, 0x01eb, 0x90ee, 0x3c10
+ax_pose_terminator
+sMetapodPose74:
+ax_pose 18, 0x01eb, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose75:
+ax_pose 6, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose76:
+ax_pose 7, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose77:
+ax_pose 8, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose78:
+ax_pose 19, 0x01ea, 0x90f0, 0x3c00
+ax_pose 20, 0x01ea, 0x90f0, 0x3c10
+ax_pose_terminator
+sMetapodPose79:
+ax_pose 20, 0x01ea, 0x90f0, 0x3c00
+ax_pose_terminator
+sMetapodPose80:
+ax_pose 9, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose81:
+ax_pose 10, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose82:
+ax_pose 11, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose83:
+ax_pose 21, 0x01eb, 0x90ec, 0x3c00
+ax_pose 22, 0x01ec, 0x90ea, 0x3c10
+ax_pose_terminator
+sMetapodPose84:
+ax_pose 22, 0x01ec, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose85:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose86:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose87:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose88:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose 24, 0x01ee, 0x80f4, 0x3c10
+ax_pose_terminator
+sMetapodPose89:
+ax_pose 24, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose90:
+ax_pose 9, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose91:
+ax_pose 10, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose92:
+ax_pose 11, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose93:
+ax_pose 21, 0x01eb, 0x80f4, 0x3c00
+ax_pose 22, 0x01ec, 0x80f6, 0x3c10
+ax_pose_terminator
+sMetapodPose94:
+ax_pose 22, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose95:
+ax_pose 6, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose96:
+ax_pose 7, 0x01ea, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose97:
+ax_pose 8, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose98:
+ax_pose 19, 0x01ea, 0x80f0, 0x3c00
+ax_pose 20, 0x01ea, 0x80f0, 0x3c10
+ax_pose_terminator
+sMetapodPose99:
+ax_pose 20, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sMetapodPose100:
+ax_pose 3, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose101:
+ax_pose 4, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose102:
+ax_pose 5, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose103:
+ax_pose 17, 0x01eb, 0x80f2, 0x3c00
+ax_pose 18, 0x01eb, 0x80f2, 0x3c10
+ax_pose_terminator
+sMetapodPose104:
+ax_pose 18, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose105:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose106:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose107:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose108:
+ax_pose 25, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose109:
+ax_pose 3, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose110:
+ax_pose 4, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose111:
+ax_pose 5, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose112:
+ax_pose 26, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sMetapodPose113:
+ax_pose 6, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose114:
+ax_pose 7, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose115:
+ax_pose 8, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose116:
+ax_pose 27, 0x01ea, 0x90f0, 0x3c00
+ax_pose_terminator
+sMetapodPose117:
+ax_pose 9, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose118:
+ax_pose 10, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose119:
+ax_pose 11, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose120:
+ax_pose 28, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose121:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose122:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose123:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose124:
+ax_pose 29, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose125:
+ax_pose 9, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose126:
+ax_pose 10, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose127:
+ax_pose 11, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose128:
+ax_pose 28, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose129:
+ax_pose 6, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose130:
+ax_pose 7, 0x01ea, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose131:
+ax_pose 8, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose132:
+ax_pose 27, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sMetapodPose133:
+ax_pose 3, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose134:
+ax_pose 4, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose135:
+ax_pose 5, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose136:
+ax_pose 26, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose137:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose138:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose139:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose140:
+ax_pose 25, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose141:
+ax_pose 3, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose142:
+ax_pose 4, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose143:
+ax_pose 5, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose144:
+ax_pose 26, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sMetapodPose145:
+ax_pose 6, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose146:
+ax_pose 7, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose147:
+ax_pose 8, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose148:
+ax_pose 27, 0x01ea, 0x90f0, 0x3c00
+ax_pose_terminator
+sMetapodPose149:
+ax_pose 9, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose150:
+ax_pose 10, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose151:
+ax_pose 11, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose152:
+ax_pose 28, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose153:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose154:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose155:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose156:
+ax_pose 29, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose157:
+ax_pose 9, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose158:
+ax_pose 10, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose159:
+ax_pose 11, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose160:
+ax_pose 28, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose161:
+ax_pose 6, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose162:
+ax_pose 7, 0x01ea, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose163:
+ax_pose 8, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose164:
+ax_pose 27, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sMetapodPose165:
+ax_pose 3, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose166:
+ax_pose 4, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose167:
+ax_pose 5, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose168:
+ax_pose 26, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose169:
+ax_pose 30, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose170:
+ax_pose 31, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose171:
+ax_pose 32, 0x01e0, 0x80f1, 0x3c00
+ax_pose_terminator
+sMetapodPose172:
+ax_pose 33, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose173:
+ax_pose 34, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose174:
+ax_pose 35, 0x01e1, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose175:
+ax_pose 36, 0x01e0, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose176:
+ax_pose 35, 0x01e1, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose177:
+ax_pose 34, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose178:
+ax_pose 33, 0x01e1, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose179:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose180:
+ax_pose 1, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose181:
+ax_pose 2, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose182:
+ax_pose 3, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sMetapodPose183:
+ax_pose 4, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sMetapodPose184:
+ax_pose 5, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+sMetapodPose185:
+ax_pose 6, 0x01ea, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose186:
+ax_pose 7, 0x01ea, 0x90f0, 0x3c00
+ax_pose_terminator
+sMetapodPose187:
+ax_pose 8, 0x01ea, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose188:
+ax_pose 9, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose189:
+ax_pose 10, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose190:
+ax_pose 11, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose191:
+ax_pose 12, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose192:
+ax_pose 13, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose193:
+ax_pose 14, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose194:
+ax_pose 9, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose195:
+ax_pose 10, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose196:
+ax_pose 11, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose197:
+ax_pose 6, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose198:
+ax_pose 7, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sMetapodPose199:
+ax_pose 8, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose200:
+ax_pose 3, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose201:
+ax_pose 4, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose202:
+ax_pose 5, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose203:
+ax_pose 16, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose204:
+ax_pose 18, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose205:
+ax_pose 20, 0x01ea, 0x80f0, 0x3c00
+ax_pose_terminator
+sMetapodPose206:
+ax_pose 22, 0x01ed, 0x80f7, 0x3c00
+ax_pose_terminator
+sMetapodPose207:
+ax_pose 24, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose208:
+ax_pose 22, 0x01ed, 0x90e9, 0x3c00
+ax_pose_terminator
+sMetapodPose209:
+ax_pose 20, 0x01ea, 0x90f0, 0x3c00
+ax_pose_terminator
+sMetapodPose210:
+ax_pose 18, 0x01ec, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose211:
+ax_pose 25, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose212:
+ax_pose 26, 0x01eb, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose213:
+ax_pose 27, 0x01ea, 0x90f2, 0x3c00
+ax_pose_terminator
+sMetapodPose214:
+ax_pose 28, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sMetapodPose215:
+ax_pose 29, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose216:
+ax_pose 28, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose217:
+ax_pose 27, 0x01ea, 0x80ed, 0x3c00
+ax_pose_terminator
+sMetapodPose218:
+ax_pose 26, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose219:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose220:
+ax_pose 1, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose221:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose222:
+ax_pose 3, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose223:
+ax_pose 4, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose224:
+ax_pose 5, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose225:
+ax_pose 6, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose226:
+ax_pose 7, 0x01ea, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose227:
+ax_pose 8, 0x01ea, 0x90ea, 0x3c00
+ax_pose_terminator
+sMetapodPose228:
+ax_pose 9, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose229:
+ax_pose 10, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose230:
+ax_pose 11, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sMetapodPose231:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose232:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose233:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose234:
+ax_pose 9, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose235:
+ax_pose 10, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose236:
+ax_pose 11, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sMetapodPose237:
+ax_pose 6, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose238:
+ax_pose 7, 0x01ea, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose239:
+ax_pose 8, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sMetapodPose240:
+ax_pose 3, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose241:
+ax_pose 4, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose242:
+ax_pose 5, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose243:
+ax_pose 25, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose244:
+ax_pose 26, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose245:
+ax_pose 27, 0x01e9, 0x80ee, 0x3c00
+ax_pose_terminator
+sMetapodPose246:
+ax_pose 28, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sMetapodPose247:
+ax_pose 29, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose248:
+ax_pose 28, 0x01e9, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose249:
+ax_pose 27, 0x01e9, 0x90f2, 0x3c00
+ax_pose_terminator
+sMetapodPose250:
+ax_pose 26, 0x01eb, 0x90ee, 0x3c00
+ax_pose_terminator
+sMetapodPose251:
+ax_pose 0, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose252:
+ax_pose 3, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sMetapodPose253:
+ax_pose 6, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose254:
+ax_pose 9, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose255:
+ax_pose 12, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sMetapodPose256:
+ax_pose 9, 0x01eb, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose257:
+ax_pose 6, 0x01ea, 0x90ec, 0x3c00
+ax_pose_terminator
+sMetapodPose258:
+ax_pose 3, 0x01ec, 0x90ed, 0x3c00
+ax_pose_terminator
+.align 2
+sMetapodAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 2, 0, 1, 0, -3, 0, 0,
+ax_anim 2, 0, 1, -1, -3, 0, 0,
+ax_anim 2, 0, 1, 0, -3, 0, 0,
+ax_anim 2, 0, 1, -1, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -5, 0, 0,
+ax_anim 4, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim_terminator
+sMetapodAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 2, 0, 4, 0, 0, 0, 0,
+ax_anim 2, 0, 4, -1, 1, 0, 0,
+ax_anim 2, 0, 4, 0, 0, 0, 0,
+ax_anim 2, 0, 4, -1, 1, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 0, -5, 0, 0,
+ax_anim 4, 0, 3, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim_terminator
+sMetapodAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 2, 0, 7, 0, 0, 0, 0,
+ax_anim 2, 0, 7, -1, 0, 0, 0,
+ax_anim 2, 0, 7, 0, 0, 0, 0,
+ax_anim 2, 0, 7, -1, 0, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -4, 0, 0,
+ax_anim 4, 0, 8, 0, -5, 0, 0,
+ax_anim 4, 0, 6, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim_terminator
+sMetapodAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 10, -1, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 2, 0, 10, -1, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim 4, 0, 11, 0, -5, 0, 0,
+ax_anim 4, 0, 9, 0, -4, 0, 0,
+ax_anim 4, 0, 9, 0, -2, 0, 0,
+ax_anim_terminator
+sMetapodAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 13, -1, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 2, 0, 13, -1, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -4, 0, 0,
+ax_anim 4, 0, 14, 0, -5, 0, 0,
+ax_anim 4, 0, 12, 0, -4, 0, 0,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim_terminator
+sMetapodAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 1, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 1, 0, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 4, 0, 17, 0, -4, 0, 0,
+ax_anim 4, 0, 17, 0, -5, 0, 0,
+ax_anim 4, 0, 15, 0, -4, 0, 0,
+ax_anim 4, 0, 15, 0, -2, 0, 0,
+ax_anim_terminator
+sMetapodAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 1, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 1, 0, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 4, 0, 20, 0, -4, 0, 0,
+ax_anim 4, 0, 20, 0, -5, 0, 0,
+ax_anim 4, 0, 18, 0, -4, 0, 0,
+ax_anim 4, 0, 18, 0, -2, 0, 0,
+ax_anim_terminator
+sMetapodAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 1, 1, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 1, 1, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 4, 0, 23, 0, -4, 0, 0,
+ax_anim 4, 0, 23, 0, -5, 0, 0,
+ax_anim 4, 0, 21, 0, -4, 0, 0,
+ax_anim 4, 0, 21, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMetapodAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 4, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 4, 4, 4,
+ax_anim 1, 0, 32, 10, 10, 10, 10,
+ax_anim 2, 0, 32, 18, 18, 18, 18,
+ax_anim 2, 1, 33, 19, 17, 19, 17,
+ax_anim 2, 0, 33, 18, 18, 18, 18,
+ax_anim 2, 0, 33, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sMetapodAnims_2_3:
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 4, 0, 36, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 4, 0, 4, 0,
+ax_anim 1, 0, 37, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sMetapodAnims_2_4:
+ax_anim 2, 0, 41, -1, 1, -1, 1,
+ax_anim 4, 0, 41, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 42, 4, -6, 4, -6,
+ax_anim 1, 0, 42, 10, -13, 10, -13,
+ax_anim 2, 0, 42, 18, -23, 18, -23,
+ax_anim 2, 1, 43, 19, -22, 19, -22,
+ax_anim 2, 0, 43, 18, -23, 18, -23,
+ax_anim 2, 0, 43, 19, -22, 19, -22,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sMetapodAnims_2_5:
+ax_anim 2, 0, 46, 0, 1, 0, 1,
+ax_anim 4, 0, 46, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 47, 0, -4, 0, -4,
+ax_anim 1, 0, 47, 0, -11, 0, -11,
+ax_anim 2, 0, 47, 0, -21, 0, -21,
+ax_anim 2, 1, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 0, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sMetapodAnims_2_6:
+ax_anim 2, 0, 51, 1, 1, 1, 1,
+ax_anim 4, 0, 51, 2, 2, 2, 2,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 2, 52, -4, -6, -4, -6,
+ax_anim 1, 0, 52, -10, -13, -10, -13,
+ax_anim 2, 0, 52, -18, -23, -18, -23,
+ax_anim 2, 1, 53, -19, -22, -19, -22,
+ax_anim 2, 0, 53, -18, -23, -18, -23,
+ax_anim 2, 0, 53, -19, -22, -19, -22,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sMetapodAnims_2_7:
+ax_anim 2, 0, 56, 1, 0, 1, 0,
+ax_anim 4, 0, 56, 2, 0, 2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 57, -4, 0, -4, 0,
+ax_anim 1, 0, 57, -10, 0, -10, 0,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sMetapodAnims_2_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 4, 0, 61, 2, -2, 2, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 62, -4, 4, -4, 4,
+ax_anim 1, 0, 62, -10, 10, -10, 10,
+ax_anim 2, 0, 62, -17, 19, -17, 19,
+ax_anim 2, 1, 63, -18, 18, -18, 18,
+ax_anim 2, 0, 63, -17, 19, -17, 19,
+ax_anim 2, 0, 63, -18, 18, -18, 18,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMetapodAnims_3_1:
+ax_anim 2, 0, 66, 0, -1, 0, -1,
+ax_anim 4, 0, 66, 0, -2, 0, -2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 0, 4, 0, 4,
+ax_anim 1, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 1, 68, 1, 18, 1, 18,
+ax_anim 2, 0, 68, 0, 18, 0, 18,
+ax_anim 2, 0, 68, 1, 18, 1, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sMetapodAnims_3_2:
+ax_anim 2, 0, 71, -1, -1, -1, -1,
+ax_anim 4, 0, 71, -2, -2, -2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 72, 4, 4, 4, 4,
+ax_anim 1, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, 18, 18, 18, 18,
+ax_anim 2, 1, 73, 19, 17, 19, 17,
+ax_anim 2, 0, 73, 18, 18, 18, 18,
+ax_anim 2, 0, 73, 19, 17, 19, 17,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sMetapodAnims_3_3:
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 4, 0, 76, -2, 0, -2, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 77, 4, 0, 4, 0,
+ax_anim 1, 0, 77, 10, 0, 10, 0,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 1, 78, 18, 1, 18, 1,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 78, 18, 1, 18, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sMetapodAnims_3_4:
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 4, 0, 81, -2, 2, -2, 2,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 1, 2, 82, 4, -6, 4, -6,
+ax_anim 1, 0, 82, 10, -13, 10, -13,
+ax_anim 2, 0, 82, 18, -23, 18, -23,
+ax_anim 2, 1, 83, 19, -22, 19, -22,
+ax_anim 2, 0, 83, 18, -23, 18, -23,
+ax_anim 2, 0, 83, 19, -22, 19, -22,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sMetapodAnims_3_5:
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 4, 0, 86, 0, 2, 0, 2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 87, 0, -4, 0, -4,
+ax_anim 1, 0, 87, 0, -11, 0, -11,
+ax_anim 2, 0, 87, 0, -21, 0, -21,
+ax_anim 2, 1, 88, 1, -21, 1, -21,
+ax_anim 2, 0, 88, 0, -21, 0, -21,
+ax_anim 2, 0, 88, 1, -21, 1, -21,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sMetapodAnims_3_6:
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim 4, 0, 91, 2, 2, 2, 2,
+ax_anim 1, 0, 89, 0, -1, 0, -1,
+ax_anim 1, 2, 92, -4, -6, -4, -6,
+ax_anim 1, 0, 92, -10, -13, -10, -13,
+ax_anim 2, 0, 92, -18, -23, -18, -23,
+ax_anim 2, 1, 93, -19, -22, -19, -22,
+ax_anim 2, 0, 93, -18, -23, -18, -23,
+ax_anim 2, 0, 93, -19, -22, -19, -22,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sMetapodAnims_3_7:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 4, 0, 96, 2, 0, 2, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 2, 97, -4, 0, -4, 0,
+ax_anim 1, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 1, 98, -18, 1, -18, 1,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 0, 98, -18, 1, -18, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sMetapodAnims_3_8:
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 4, 0, 101, 2, -2, 2, -2,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 102, -4, 4, -4, 4,
+ax_anim 1, 0, 102, -10, 10, -10, 10,
+ax_anim 2, 0, 102, -17, 19, -17, 19,
+ax_anim 2, 1, 103, -18, 18, -18, 18,
+ax_anim 2, 0, 103, -17, 19, -17, 19,
+ax_anim 2, 0, 103, -18, 18, -18, 18,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMetapodAnims_4_1:
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 4, 2, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_4_2:
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, -2, 0, 0,
+ax_anim 4, 2, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_4_3:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 2, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 0, -1, 0, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_4_4:
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 4, 2, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_4_5:
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -2, 0, 0,
+ax_anim 4, 2, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 123, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 1, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_4_6:
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 4, 2, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 1, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_4_7:
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 4, 2, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 1, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_4_8:
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 4, 2, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_5_1:
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_5_2:
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_5_3:
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 1, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_5_4:
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -3, 0, 0,
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, 1, 1, 1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, 1, 1, 1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, 1, 1, 1,
+ax_anim 2, 1, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_5_5:
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, 0, 1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, 0, 1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 1, 0, 1, 0,
+ax_anim 2, 1, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_5_6:
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 4, 0, 159, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 1, -1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 1, -1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 1, -1, 1,
+ax_anim 2, 1, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_5_7:
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -2, 0, 0,
+ax_anim 4, 0, 163, 0, -3, 0, 0,
+ax_anim 2, 0, 163, 0, -2, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, -1,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_5_8:
+ax_anim 4, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_7_1:
+ax_anim 2, 0, 170, 0, -3, 0, -3,
+ax_anim 8, 0, 170, 0, -4, 0, -4,
+ax_anim_terminator
+sMetapodAnims_7_2:
+ax_anim 2, 0, 171, -3, -3, -3, -3,
+ax_anim 8, 0, 171, -4, -4, -4, -4,
+ax_anim_terminator
+sMetapodAnims_7_3:
+ax_anim 2, 0, 172, -3, 0, -3, 0,
+ax_anim 8, 0, 172, -4, 0, -4, 0,
+ax_anim_terminator
+sMetapodAnims_7_4:
+ax_anim 2, 0, 173, -3, 3, -3, 3,
+ax_anim 8, 0, 173, -4, 4, -4, 4,
+ax_anim_terminator
+sMetapodAnims_7_5:
+ax_anim 2, 0, 174, 0, 3, 0, 3,
+ax_anim 8, 0, 174, 0, 4, 0, 4,
+ax_anim_terminator
+sMetapodAnims_7_6:
+ax_anim 2, 0, 175, 3, 3, 3, 3,
+ax_anim 8, 0, 175, 4, 4, 4, 4,
+ax_anim_terminator
+sMetapodAnims_7_7:
+ax_anim 2, 0, 176, 3, 0, 3, 0,
+ax_anim 8, 0, 176, 4, 0, 4, 0,
+ax_anim_terminator
+sMetapodAnims_7_8:
+ax_anim 2, 0, 177, 3, -3, 3, -3,
+ax_anim 8, 0, 177, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sMetapodAnims_8_1:
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 14, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 14, 0, 180, 0, 0, 0, 1,
+ax_anim_terminator
+sMetapodAnims_8_2:
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 14, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 14, 0, 183, 0, 0, 0, 1,
+ax_anim_terminator
+sMetapodAnims_8_3:
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 14, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 14, 0, 186, 0, 0, 0, 1,
+ax_anim_terminator
+sMetapodAnims_8_4:
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim 14, 0, 188, 0, 0, 0, 0,
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim 14, 0, 189, 0, 0, 0, 1,
+ax_anim_terminator
+sMetapodAnims_8_5:
+ax_anim 10, 0, 190, 0, 0, 0, 0,
+ax_anim 14, 0, 191, 0, 0, 0, 0,
+ax_anim 10, 0, 190, 0, 0, 0, 0,
+ax_anim 14, 0, 192, 0, 0, 0, 1,
+ax_anim_terminator
+sMetapodAnims_8_6:
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim 14, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim 14, 0, 195, 0, 0, 0, 1,
+ax_anim_terminator
+sMetapodAnims_8_7:
+ax_anim 10, 0, 196, 0, 0, 0, 0,
+ax_anim 14, 0, 197, 0, 0, 0, 0,
+ax_anim 10, 0, 196, 0, 0, 0, 0,
+ax_anim 14, 0, 198, 0, 0, 0, 1,
+ax_anim_terminator
+sMetapodAnims_8_8:
+ax_anim 10, 0, 199, 0, 0, 0, 0,
+ax_anim 14, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 199, 0, 0, 0, 0,
+ax_anim 14, 0, 201, 0, 0, 0, 1,
+ax_anim_terminator
+.align 2
+sMetapodAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 4, 6, 4,
+ax_anim 2, 0, 204, 10, 9, 10, 9,
+ax_anim 2, 0, 205, 7, 19, 7, 19,
+ax_anim 3, 0, 206, 0, 22, 0, 22,
+ax_anim 2, 3, 207, -7, 19, -7, 19,
+ax_anim 2, 0, 208, -8, 9, -8, 9,
+ax_anim 1, 0, 209, -8, 4, -8, 4,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 203, 17, 3, 17, 3,
+ax_anim 2, 0, 204, 24, 9, 24, 9,
+ax_anim 3, 0, 205, 19, 21, 19, 21,
+ax_anim 2, 3, 206, 11, 21, 11, 21,
+ax_anim 2, 0, 207, 2, 12, 2, 12,
+ax_anim 1, 0, 208, -2, 7, -2, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -4, 3, -4,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 17, -4, 17, -4,
+ax_anim 3, 0, 204, 20, 1, 20, 1,
+ax_anim 2, 3, 205, 17, 5, 17, 5,
+ax_anim 2, 0, 206, 12, 7, 12, 7,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -6, -1, -6,
+ax_anim 2, 0, 209, 2, -18, 2, -18,
+ax_anim 2, 0, 202, 11, -24, 11, -24,
+ax_anim 3, 0, 203, 19, -23, 19, -23,
+ax_anim 2, 3, 204, 22, -12, 22, -12,
+ax_anim 2, 0, 205, 17, -4, 17, -4,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -6, -4, -6, -4,
+ax_anim 2, 0, 208, -10, -10, -10, -10,
+ax_anim 2, 0, 209, -7, -20, -7, -20,
+ax_anim 3, 0, 202, 0, -24, 0, -24,
+ax_anim 2, 3, 203, 7, -20, 7, -20,
+ax_anim 2, 0, 204, 10, -8, 10, -8,
+ax_anim 1, 0, 205, 6, -4, 6, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -6, 1, -6,
+ax_anim 2, 0, 203, -2, -18, -2, -18,
+ax_anim 2, 0, 202, -11, -24, -11, -24,
+ax_anim 3, 0, 209, -19, -23, -19, -23,
+ax_anim 2, 3, 208, -22, -12, -22, -12,
+ax_anim 2, 0, 207, -17, -4, -17, -4,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -4, -3, -4,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -17, -4, -17, -4,
+ax_anim 3, 0, 208, -20, 1, -20, 1,
+ax_anim 2, 3, 207, -17, 5, -17, 5,
+ax_anim 2, 0, 206, -12, 7, -12, 7,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 209, -17, 3, -17, 3,
+ax_anim 2, 0, 208, -24, 9, -24, 9,
+ax_anim 3, 0, 207, -19, 21, -19, 21,
+ax_anim 2, 3, 206, -11, 21, -11, 21,
+ax_anim 2, 0, 205, -2, 12, -2, 12,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -24, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 228, 0, -21, 0, 0,
+ax_anim 2, 0, 228, 0, -17, 0, 0,
+ax_anim 1, 0, 228, 0, -11, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 3, 0, 231, 0, -21, 0, 0,
+ax_anim 2, 0, 231, 0, -18, 0, 0,
+ax_anim 1, 0, 231, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -22, 0, 0,
+ax_anim 3, 0, 234, 0, -21, 0, 0,
+ax_anim 2, 0, 234, 0, -17, 0, 0,
+ax_anim 1, 0, 234, 0, -11, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 0, -10, 0, 0,
+ax_anim 2, 0, 238, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 4, 0, 238, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -23, 0, 0,
+ax_anim 3, 0, 237, 0, -22, 0, 0,
+ax_anim 2, 0, 237, 0, -18, 0, 0,
+ax_anim 1, 0, 237, 0, -12, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 240, 0, -22, 0, 0,
+ax_anim 2, 0, 240, 0, -18, 0, 0,
+ax_anim 1, 0, 240, 0, -12, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMetapodAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sMetapodGfx1:
+.incbin "baserom.gba", 0x58DCB4, 0x200
+sMetapodSprites1:
+ax_sprite sMetapodGfx1, 0x200
+ax_sprite_terminator
+sMetapodGfx2:
+.incbin "baserom.gba", 0x58DEC4, 0x200
+sMetapodSprites2:
+ax_sprite sMetapodGfx2, 0x200
+ax_sprite_terminator
+sMetapodGfx3:
+.incbin "baserom.gba", 0x58E0D4, 0x200
+sMetapodSprites3:
+ax_sprite sMetapodGfx3, 0x200
+ax_sprite_terminator
+sMetapodGfx4:
+.incbin "baserom.gba", 0x58E2E4, 0x200
+sMetapodSprites4:
+ax_sprite sMetapodGfx4, 0x200
+ax_sprite_terminator
+sMetapodGfx5:
+.incbin "baserom.gba", 0x58E4F4, 0x200
+sMetapodSprites5:
+ax_sprite sMetapodGfx5, 0x200
+ax_sprite_terminator
+sMetapodGfx6:
+.incbin "baserom.gba", 0x58E704, 0x200
+sMetapodSprites6:
+ax_sprite sMetapodGfx6, 0x200
+ax_sprite_terminator
+sMetapodGfx7:
+.incbin "baserom.gba", 0x58E914, 0x200
+sMetapodSprites7:
+ax_sprite sMetapodGfx7, 0x200
+ax_sprite_terminator
+sMetapodGfx8:
+.incbin "baserom.gba", 0x58EB24, 0x200
+sMetapodSprites8:
+ax_sprite sMetapodGfx8, 0x200
+ax_sprite_terminator
+sMetapodGfx9:
+.incbin "baserom.gba", 0x58ED34, 0x200
+sMetapodSprites9:
+ax_sprite sMetapodGfx9, 0x200
+ax_sprite_terminator
+sMetapodGfx10:
+.incbin "baserom.gba", 0x58EF44, 0x200
+sMetapodSprites10:
+ax_sprite sMetapodGfx10, 0x200
+ax_sprite_terminator
+sMetapodGfx11:
+.incbin "baserom.gba", 0x58F154, 0x200
+sMetapodSprites11:
+ax_sprite sMetapodGfx11, 0x200
+ax_sprite_terminator
+sMetapodGfx12:
+.incbin "baserom.gba", 0x58F364, 0x200
+sMetapodSprites12:
+ax_sprite sMetapodGfx12, 0x200
+ax_sprite_terminator
+sMetapodGfx13:
+.incbin "baserom.gba", 0x58F574, 0x200
+sMetapodSprites13:
+ax_sprite sMetapodGfx13, 0x200
+ax_sprite_terminator
+sMetapodGfx14:
+.incbin "baserom.gba", 0x58F784, 0x200
+sMetapodSprites14:
+ax_sprite sMetapodGfx14, 0x200
+ax_sprite_terminator
+sMetapodGfx15:
+.incbin "baserom.gba", 0x58F994, 0x200
+sMetapodSprites15:
+ax_sprite sMetapodGfx15, 0x200
+ax_sprite_terminator
+sMetapodGfx16:
+.incbin "baserom.gba", 0x58FBA4, 0x20
+sMetapodGfx16_1:
+.incbin "baserom.gba", 0x58FBC4, 0x60
+sMetapodGfx16_2:
+.incbin "baserom.gba", 0x58FC24, 0x60
+sMetapodGfx16_3:
+.incbin "baserom.gba", 0x58FC84, 0x40
+sMetapodSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx16_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetapodGfx17:
+.incbin "baserom.gba", 0x58FD14, 0x20
+sMetapodGfx17_1:
+.incbin "baserom.gba", 0x58FD34, 0x60
+sMetapodGfx17_2:
+.incbin "baserom.gba", 0x58FD94, 0x60
+sMetapodGfx17_3:
+.incbin "baserom.gba", 0x58FDF4, 0x20
+sMetapodSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx17_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetapodGfx18:
+.incbin "baserom.gba", 0x58FE64, 0x40
+sMetapodGfx18_1:
+.incbin "baserom.gba", 0x58FEA4, 0x60
+sMetapodGfx18_2:
+.incbin "baserom.gba", 0x58FF04, 0x60
+sMetapodGfx18_3:
+.incbin "baserom.gba", 0x58FF64, 0x40
+sMetapodSprites18:
+ax_sprite sMetapodGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx18_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetapodGfx19:
+.incbin "baserom.gba", 0x58FFEC, 0x20
+sMetapodGfx19_1:
+.incbin "baserom.gba", 0x59000C, 0x60
+sMetapodGfx19_2:
+.incbin "baserom.gba", 0x59006C, 0x60
+sMetapodSprites19:
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMetapodGfx20:
+.incbin "baserom.gba", 0x59010C, 0x40
+sMetapodGfx20_1:
+.incbin "baserom.gba", 0x59014C, 0x60
+sMetapodGfx20_2:
+.incbin "baserom.gba", 0x5901AC, 0x60
+sMetapodGfx20_3:
+.incbin "baserom.gba", 0x59020C, 0x40
+sMetapodSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetapodGfx21:
+.incbin "baserom.gba", 0x59029C, 0x100
+sMetapodSprites21:
+ax_sprite 0, 0x80
+ax_sprite sMetapodGfx21, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetapodGfx22:
+.incbin "baserom.gba", 0x5903BC, 0x60
+sMetapodGfx22_1:
+.incbin "baserom.gba", 0x59041C, 0x60
+sMetapodGfx22_2:
+.incbin "baserom.gba", 0x59047C, 0x40
+sMetapodSprites22:
+ax_sprite sMetapodGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx22_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMetapodGfx23:
+.incbin "baserom.gba", 0x5904F4, 0x40
+sMetapodGfx23_1:
+.incbin "baserom.gba", 0x590534, 0x60
+sMetapodGfx23_2:
+.incbin "baserom.gba", 0x590594, 0x60
+sMetapodSprites23:
+ax_sprite sMetapodGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMetapodGfx24:
+.incbin "baserom.gba", 0x59062C, 0x60
+sMetapodGfx24_1:
+.incbin "baserom.gba", 0x59068C, 0x60
+sMetapodGfx24_2:
+.incbin "baserom.gba", 0x5906EC, 0x20
+sMetapodGfx24_3:
+.incbin "baserom.gba", 0x59070C, 0x20
+sMetapodSprites24:
+ax_sprite sMetapodGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx24_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx24_3, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMetapodGfx25:
+.incbin "baserom.gba", 0x590774, 0x60
+sMetapodGfx25_1:
+.incbin "baserom.gba", 0x5907D4, 0x60
+sMetapodGfx25_2:
+.incbin "baserom.gba", 0x590834, 0x40
+sMetapodSprites25:
+ax_sprite sMetapodGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx25_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMetapodGfx26:
+.incbin "baserom.gba", 0x5908AC, 0x60
+sMetapodGfx26_1:
+.incbin "baserom.gba", 0x59090C, 0x60
+sMetapodGfx26_2:
+.incbin "baserom.gba", 0x59096C, 0x60
+sMetapodSprites26:
+ax_sprite sMetapodGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMetapodGfx27:
+.incbin "baserom.gba", 0x590A04, 0x60
+sMetapodGfx27_1:
+.incbin "baserom.gba", 0x590A64, 0x60
+sMetapodGfx27_2:
+.incbin "baserom.gba", 0x590AC4, 0x60
+sMetapodSprites27:
+ax_sprite sMetapodGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMetapodGfx28:
+.incbin "baserom.gba", 0x590B5C, 0x40
+sMetapodGfx28_1:
+.incbin "baserom.gba", 0x590B9C, 0x40
+sMetapodGfx28_2:
+.incbin "baserom.gba", 0x590BDC, 0x60
+sMetapodSprites28:
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx28_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMetapodGfx29:
+.incbin "baserom.gba", 0x590C7C, 0x60
+sMetapodGfx29_1:
+.incbin "baserom.gba", 0x590CDC, 0x60
+sMetapodGfx29_2:
+.incbin "baserom.gba", 0x590D3C, 0x60
+sMetapodGfx29_3:
+.incbin "baserom.gba", 0x590D9C, 0x40
+sMetapodSprites29:
+ax_sprite sMetapodGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMetapodGfx30:
+.incbin "baserom.gba", 0x590E24, 0x20
+sMetapodGfx30_1:
+.incbin "baserom.gba", 0x590E44, 0x60
+sMetapodGfx30_2:
+.incbin "baserom.gba", 0x590EA4, 0x60
+sMetapodGfx30_3:
+.incbin "baserom.gba", 0x590F04, 0x20
+sMetapodSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMetapodGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMetapodGfx30_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMetapodGfx31:
+.incbin "baserom.gba", 0x590F74, 0x200
+sMetapodSprites31:
+ax_sprite sMetapodGfx31, 0x200
+ax_sprite_terminator
+sMetapodGfx32:
+.incbin "baserom.gba", 0x591184, 0x200
+sMetapodSprites32:
+ax_sprite sMetapodGfx32, 0x200
+ax_sprite_terminator
+sMetapodGfx33:
+.incbin "baserom.gba", 0x591394, 0x200
+sMetapodSprites33:
+ax_sprite sMetapodGfx33, 0x200
+ax_sprite_terminator
+sMetapodGfx34:
+.incbin "baserom.gba", 0x5915A4, 0x200
+sMetapodSprites34:
+ax_sprite sMetapodGfx34, 0x200
+ax_sprite_terminator
+sMetapodGfx35:
+.incbin "baserom.gba", 0x5917B4, 0x200
+sMetapodSprites35:
+ax_sprite sMetapodGfx35, 0x200
+ax_sprite_terminator
+sMetapodGfx36:
+.incbin "baserom.gba", 0x5919C4, 0x200
+sMetapodSprites36:
+ax_sprite sMetapodGfx36, 0x200
+ax_sprite_terminator
+sMetapodGfx37:
+.incbin "baserom.gba", 0x591BD4, 0x200
+sMetapodSprites37:
+ax_sprite sMetapodGfx37, 0x200
+ax_sprite_terminator
+sAxPosesMetapod:
+.4byte sMetapodPose1
+.4byte sMetapodPose2
+.4byte sMetapodPose3
+.4byte sMetapodPose4
+.4byte sMetapodPose5
+.4byte sMetapodPose6
+.4byte sMetapodPose7
+.4byte sMetapodPose8
+.4byte sMetapodPose9
+.4byte sMetapodPose10
+.4byte sMetapodPose11
+.4byte sMetapodPose12
+.4byte sMetapodPose13
+.4byte sMetapodPose14
+.4byte sMetapodPose15
+.4byte sMetapodPose16
+.4byte sMetapodPose17
+.4byte sMetapodPose18
+.4byte sMetapodPose19
+.4byte sMetapodPose20
+.4byte sMetapodPose21
+.4byte sMetapodPose22
+.4byte sMetapodPose23
+.4byte sMetapodPose24
+.4byte sMetapodPose25
+.4byte sMetapodPose26
+.4byte sMetapodPose27
+.4byte sMetapodPose28
+.4byte sMetapodPose29
+.4byte sMetapodPose30
+.4byte sMetapodPose31
+.4byte sMetapodPose32
+.4byte sMetapodPose33
+.4byte sMetapodPose34
+.4byte sMetapodPose35
+.4byte sMetapodPose36
+.4byte sMetapodPose37
+.4byte sMetapodPose38
+.4byte sMetapodPose39
+.4byte sMetapodPose40
+.4byte sMetapodPose41
+.4byte sMetapodPose42
+.4byte sMetapodPose43
+.4byte sMetapodPose44
+.4byte sMetapodPose45
+.4byte sMetapodPose46
+.4byte sMetapodPose47
+.4byte sMetapodPose48
+.4byte sMetapodPose49
+.4byte sMetapodPose50
+.4byte sMetapodPose51
+.4byte sMetapodPose52
+.4byte sMetapodPose53
+.4byte sMetapodPose54
+.4byte sMetapodPose55
+.4byte sMetapodPose56
+.4byte sMetapodPose57
+.4byte sMetapodPose58
+.4byte sMetapodPose59
+.4byte sMetapodPose60
+.4byte sMetapodPose61
+.4byte sMetapodPose62
+.4byte sMetapodPose63
+.4byte sMetapodPose64
+.4byte sMetapodPose65
+.4byte sMetapodPose66
+.4byte sMetapodPose67
+.4byte sMetapodPose68
+.4byte sMetapodPose69
+.4byte sMetapodPose70
+.4byte sMetapodPose71
+.4byte sMetapodPose72
+.4byte sMetapodPose73
+.4byte sMetapodPose74
+.4byte sMetapodPose75
+.4byte sMetapodPose76
+.4byte sMetapodPose77
+.4byte sMetapodPose78
+.4byte sMetapodPose79
+.4byte sMetapodPose80
+.4byte sMetapodPose81
+.4byte sMetapodPose82
+.4byte sMetapodPose83
+.4byte sMetapodPose84
+.4byte sMetapodPose85
+.4byte sMetapodPose86
+.4byte sMetapodPose87
+.4byte sMetapodPose88
+.4byte sMetapodPose89
+.4byte sMetapodPose90
+.4byte sMetapodPose91
+.4byte sMetapodPose92
+.4byte sMetapodPose93
+.4byte sMetapodPose94
+.4byte sMetapodPose95
+.4byte sMetapodPose96
+.4byte sMetapodPose97
+.4byte sMetapodPose98
+.4byte sMetapodPose99
+.4byte sMetapodPose100
+.4byte sMetapodPose101
+.4byte sMetapodPose102
+.4byte sMetapodPose103
+.4byte sMetapodPose104
+.4byte sMetapodPose105
+.4byte sMetapodPose106
+.4byte sMetapodPose107
+.4byte sMetapodPose108
+.4byte sMetapodPose109
+.4byte sMetapodPose110
+.4byte sMetapodPose111
+.4byte sMetapodPose112
+.4byte sMetapodPose113
+.4byte sMetapodPose114
+.4byte sMetapodPose115
+.4byte sMetapodPose116
+.4byte sMetapodPose117
+.4byte sMetapodPose118
+.4byte sMetapodPose119
+.4byte sMetapodPose120
+.4byte sMetapodPose121
+.4byte sMetapodPose122
+.4byte sMetapodPose123
+.4byte sMetapodPose124
+.4byte sMetapodPose125
+.4byte sMetapodPose126
+.4byte sMetapodPose127
+.4byte sMetapodPose128
+.4byte sMetapodPose129
+.4byte sMetapodPose130
+.4byte sMetapodPose131
+.4byte sMetapodPose132
+.4byte sMetapodPose133
+.4byte sMetapodPose134
+.4byte sMetapodPose135
+.4byte sMetapodPose136
+.4byte sMetapodPose137
+.4byte sMetapodPose138
+.4byte sMetapodPose139
+.4byte sMetapodPose140
+.4byte sMetapodPose141
+.4byte sMetapodPose142
+.4byte sMetapodPose143
+.4byte sMetapodPose144
+.4byte sMetapodPose145
+.4byte sMetapodPose146
+.4byte sMetapodPose147
+.4byte sMetapodPose148
+.4byte sMetapodPose149
+.4byte sMetapodPose150
+.4byte sMetapodPose151
+.4byte sMetapodPose152
+.4byte sMetapodPose153
+.4byte sMetapodPose154
+.4byte sMetapodPose155
+.4byte sMetapodPose156
+.4byte sMetapodPose157
+.4byte sMetapodPose158
+.4byte sMetapodPose159
+.4byte sMetapodPose160
+.4byte sMetapodPose161
+.4byte sMetapodPose162
+.4byte sMetapodPose163
+.4byte sMetapodPose164
+.4byte sMetapodPose165
+.4byte sMetapodPose166
+.4byte sMetapodPose167
+.4byte sMetapodPose168
+.4byte sMetapodPose169
+.4byte sMetapodPose170
+.4byte sMetapodPose171
+.4byte sMetapodPose172
+.4byte sMetapodPose173
+.4byte sMetapodPose174
+.4byte sMetapodPose175
+.4byte sMetapodPose176
+.4byte sMetapodPose177
+.4byte sMetapodPose178
+.4byte sMetapodPose179
+.4byte sMetapodPose180
+.4byte sMetapodPose181
+.4byte sMetapodPose182
+.4byte sMetapodPose183
+.4byte sMetapodPose184
+.4byte sMetapodPose185
+.4byte sMetapodPose186
+.4byte sMetapodPose187
+.4byte sMetapodPose188
+.4byte sMetapodPose189
+.4byte sMetapodPose190
+.4byte sMetapodPose191
+.4byte sMetapodPose192
+.4byte sMetapodPose193
+.4byte sMetapodPose194
+.4byte sMetapodPose195
+.4byte sMetapodPose196
+.4byte sMetapodPose197
+.4byte sMetapodPose198
+.4byte sMetapodPose199
+.4byte sMetapodPose200
+.4byte sMetapodPose201
+.4byte sMetapodPose202
+.4byte sMetapodPose203
+.4byte sMetapodPose204
+.4byte sMetapodPose205
+.4byte sMetapodPose206
+.4byte sMetapodPose207
+.4byte sMetapodPose208
+.4byte sMetapodPose209
+.4byte sMetapodPose210
+.4byte sMetapodPose211
+.4byte sMetapodPose212
+.4byte sMetapodPose213
+.4byte sMetapodPose214
+.4byte sMetapodPose215
+.4byte sMetapodPose216
+.4byte sMetapodPose217
+.4byte sMetapodPose218
+.4byte sMetapodPose219
+.4byte sMetapodPose220
+.4byte sMetapodPose221
+.4byte sMetapodPose222
+.4byte sMetapodPose223
+.4byte sMetapodPose224
+.4byte sMetapodPose225
+.4byte sMetapodPose226
+.4byte sMetapodPose227
+.4byte sMetapodPose228
+.4byte sMetapodPose229
+.4byte sMetapodPose230
+.4byte sMetapodPose231
+.4byte sMetapodPose232
+.4byte sMetapodPose233
+.4byte sMetapodPose234
+.4byte sMetapodPose235
+.4byte sMetapodPose236
+.4byte sMetapodPose237
+.4byte sMetapodPose238
+.4byte sMetapodPose239
+.4byte sMetapodPose240
+.4byte sMetapodPose241
+.4byte sMetapodPose242
+.4byte sMetapodPose243
+.4byte sMetapodPose244
+.4byte sMetapodPose245
+.4byte sMetapodPose246
+.4byte sMetapodPose247
+.4byte sMetapodPose248
+.4byte sMetapodPose249
+.4byte sMetapodPose250
+.4byte sMetapodPose251
+.4byte sMetapodPose252
+.4byte sMetapodPose253
+.4byte sMetapodPose254
+.4byte sMetapodPose255
+.4byte sMetapodPose256
+.4byte sMetapodPose257
+.4byte sMetapodPose258
+sAxPositionsMetapod:
+.2byte   -1,   -4, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    2, 	  -7,    0, 	   5,    0, 	  -1,   -2
+.2byte   -1,   -6, 	  -7,   -9, 	   5,   -9, 	  -1,   -9
+.2byte    7,   -4, 	   9,   -9, 	  -3,   -7, 	   3,   -7
+.2byte    7,   -1, 	  10,   -5, 	  -2,   -6, 	   3,   -4
+.2byte    5,   -5, 	   8,   -9, 	  -4,   -8, 	   1,   -7
+.2byte    8,   -5, 	  -1,  -11, 	   0,   -6, 	   2,   -6
+.2byte    9,   -3, 	   1,  -10, 	   2,   -6, 	   0,   -5
+.2byte    8,   -7, 	  -2,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    4,  -10, 	  -4,  -11, 	   7,   -7, 	   1,   -6
+.2byte    5,   -8, 	  -3,  -10, 	   7,   -5, 	   0,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   6,   -8, 	   0,   -7
+.2byte   -1,  -13, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   6,  -11, 	  -8,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte   -5,  -10, 	   3,  -11, 	  -8,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	   2,  -10, 	  -8,   -5, 	  -1,   -5
+.2byte   -3,  -12, 	   4,  -12, 	  -7,   -8, 	  -1,   -7
+.2byte   -9,   -5, 	   0,  -11, 	  -1,   -6, 	  -3,   -6
+.2byte  -10,   -3, 	  -2,  -10, 	  -3,   -6, 	  -1,   -5
+.2byte   -9,   -7, 	   1,  -11, 	   0,   -8, 	  -1,   -6
+.2byte   -8,   -4, 	 -10,   -9, 	   2,   -7, 	  -4,   -7
+.2byte   -8,   -1, 	 -11,   -5, 	   1,   -6, 	  -4,   -4
+.2byte   -6,   -5, 	  -9,   -9, 	   3,   -8, 	  -2,   -7
+.2byte   -1,   -4, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    2, 	  -7,    0, 	   5,    0, 	  -1,   -2
+.2byte   -1,   -6, 	  -7,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -1,    0, 	  -8,   -2, 	   6,   -2, 	  -1,   -4
+.2byte   -1,    0, 	  -8,   -2, 	   6,   -2, 	  -1,   -4
+.2byte    7,   -4, 	   9,   -9, 	  -3,   -7, 	   3,   -7
+.2byte    7,   -1, 	  10,   -5, 	  -2,   -6, 	   3,   -4
+.2byte    5,   -5, 	   8,   -9, 	  -4,   -8, 	   1,   -7
+.2byte    1,   -2, 	   8,   -8, 	  -5,   -5, 	   0,   -5
+.2byte    1,   -2, 	   8,   -8, 	  -5,   -5, 	   0,   -5
+.2byte    8,   -5, 	  -1,  -11, 	   0,   -6, 	   2,   -6
+.2byte    9,   -3, 	   1,  -10, 	   2,   -6, 	   0,   -5
+.2byte    8,   -7, 	  -2,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    6,   -1, 	   3,  -11, 	   1,   -5, 	  -1,   -4
+.2byte    6,   -1, 	   3,  -11, 	   1,   -5, 	  -1,   -4
+.2byte    4,  -10, 	  -4,  -11, 	   7,   -7, 	   1,   -6
+.2byte    5,   -8, 	  -3,  -10, 	   7,   -5, 	   0,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   6,   -8, 	   0,   -7
+.2byte    4,   -7, 	  -3,  -12, 	   8,   -7, 	   1,   -7
+.2byte    4,   -7, 	  -3,  -12, 	   8,   -7, 	   1,   -7
+.2byte   -1,  -13, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   6,  -11, 	  -8,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -5,  -10, 	   3,  -11, 	  -8,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	   2,  -10, 	  -8,   -5, 	  -1,   -5
+.2byte   -3,  -12, 	   4,  -12, 	  -7,   -8, 	  -1,   -7
+.2byte   -5,   -7, 	   2,  -12, 	  -9,   -7, 	  -2,   -7
+.2byte   -5,   -7, 	   2,  -12, 	  -9,   -7, 	  -2,   -7
+.2byte   -9,   -5, 	   0,  -11, 	  -1,   -6, 	  -3,   -6
+.2byte  -10,   -3, 	  -2,  -10, 	  -3,   -6, 	  -1,   -5
+.2byte   -9,   -7, 	   1,  -11, 	   0,   -8, 	  -1,   -6
+.2byte   -7,   -1, 	  -4,  -11, 	  -2,   -5, 	   0,   -4
+.2byte   -7,   -1, 	  -4,  -11, 	  -2,   -5, 	   0,   -4
+.2byte   -8,   -4, 	 -10,   -9, 	   2,   -7, 	  -4,   -7
+.2byte   -8,   -1, 	 -11,   -5, 	   1,   -6, 	  -4,   -4
+.2byte   -6,   -5, 	  -9,   -9, 	   3,   -8, 	  -2,   -7
+.2byte   -2,   -2, 	  -9,   -8, 	   4,   -5, 	  -1,   -5
+.2byte   -2,   -2, 	  -9,   -8, 	   4,   -5, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    2, 	  -7,    0, 	   5,    0, 	  -1,   -2
+.2byte   -1,   -6, 	  -7,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -1,    0, 	  -8,   -2, 	   6,   -2, 	  -1,   -4
+.2byte   -1,    0, 	  -8,   -2, 	   6,   -2, 	  -1,   -4
+.2byte    7,   -4, 	   9,   -9, 	  -3,   -7, 	   3,   -7
+.2byte    7,   -1, 	  10,   -5, 	  -2,   -6, 	   3,   -4
+.2byte    5,   -5, 	   8,   -9, 	  -4,   -8, 	   1,   -7
+.2byte    1,   -2, 	   8,   -8, 	  -5,   -5, 	   0,   -5
+.2byte    1,   -2, 	   8,   -8, 	  -5,   -5, 	   0,   -5
+.2byte    8,   -5, 	  -1,  -11, 	   0,   -6, 	   2,   -6
+.2byte    9,   -3, 	   1,  -10, 	   2,   -6, 	   0,   -5
+.2byte    8,   -7, 	  -2,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    6,   -1, 	   3,  -11, 	   1,   -5, 	  -1,   -4
+.2byte    6,   -1, 	   3,  -11, 	   1,   -5, 	  -1,   -4
+.2byte    4,  -10, 	  -4,  -11, 	   7,   -7, 	   1,   -6
+.2byte    5,   -8, 	  -3,  -10, 	   7,   -5, 	   0,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   6,   -8, 	   0,   -7
+.2byte    4,   -7, 	  -3,  -12, 	   8,   -7, 	   1,   -7
+.2byte    4,   -7, 	  -3,  -12, 	   8,   -7, 	   1,   -7
+.2byte   -1,  -13, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   6,  -11, 	  -8,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte   -1,   -9, 	   6,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -5,  -10, 	   3,  -11, 	  -8,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	   2,  -10, 	  -8,   -5, 	  -1,   -5
+.2byte   -3,  -12, 	   4,  -12, 	  -7,   -8, 	  -1,   -7
+.2byte   -5,   -7, 	   2,  -12, 	  -9,   -7, 	  -2,   -7
+.2byte   -5,   -7, 	   2,  -12, 	  -9,   -7, 	  -2,   -7
+.2byte   -9,   -5, 	   0,  -11, 	  -1,   -6, 	  -3,   -6
+.2byte  -10,   -3, 	  -2,  -10, 	  -3,   -6, 	  -1,   -5
+.2byte   -9,   -7, 	   1,  -11, 	   0,   -8, 	  -1,   -6
+.2byte   -7,   -1, 	  -4,  -11, 	  -2,   -5, 	   0,   -4
+.2byte   -7,   -1, 	  -4,  -11, 	  -2,   -5, 	   0,   -4
+.2byte   -8,   -4, 	 -10,   -9, 	   2,   -7, 	  -4,   -7
+.2byte   -8,   -1, 	 -11,   -5, 	   1,   -6, 	  -4,   -4
+.2byte   -6,   -5, 	  -9,   -9, 	   3,   -8, 	  -2,   -7
+.2byte   -2,   -2, 	  -9,   -8, 	   4,   -5, 	  -1,   -5
+.2byte   -2,   -2, 	  -9,   -8, 	   4,   -5, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    0, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -6, 	  -7,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	  -8,  -12, 	   6,  -12, 	  -1,  -10
+.2byte    7,   -4, 	   9,   -9, 	  -3,   -7, 	   3,   -7
+.2byte    7,   -1, 	  10,   -5, 	  -2,   -6, 	   3,   -4
+.2byte    5,   -5, 	   8,   -9, 	  -4,   -8, 	   1,   -7
+.2byte    3,   -6, 	   3,  -12, 	  -6,   -9, 	  -1,   -6
+.2byte    8,   -5, 	  -1,  -11, 	   0,   -6, 	   2,   -6
+.2byte    9,   -3, 	   1,  -10, 	   2,   -6, 	   0,   -5
+.2byte    8,   -7, 	  -2,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    4,  -12, 	  -5,   -9, 	  -3,   -8, 	  -1,   -6
+.2byte    4,  -10, 	  -4,  -11, 	   7,   -7, 	   1,   -6
+.2byte    5,   -8, 	  -3,  -10, 	   7,   -5, 	   0,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   6,   -8, 	   0,   -7
+.2byte    1,  -11, 	  -6,   -9, 	   5,   -8, 	  -1,   -6
+.2byte   -1,  -13, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   6,  -11, 	  -8,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -5,  -10, 	   3,  -11, 	  -8,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	   2,  -10, 	  -8,   -5, 	  -1,   -5
+.2byte   -3,  -12, 	   4,  -12, 	  -7,   -8, 	  -1,   -7
+.2byte   -2,  -11, 	   5,   -9, 	  -6,   -8, 	   0,   -6
+.2byte   -9,   -5, 	   0,  -11, 	  -1,   -6, 	  -3,   -6
+.2byte  -10,   -3, 	  -2,  -10, 	  -3,   -6, 	  -1,   -5
+.2byte   -9,   -7, 	   1,  -11, 	   0,   -8, 	  -1,   -6
+.2byte   -5,  -12, 	   4,   -9, 	   2,   -8, 	   0,   -6
+.2byte   -8,   -4, 	 -10,   -9, 	   2,   -7, 	  -4,   -7
+.2byte   -8,   -1, 	 -11,   -5, 	   1,   -6, 	  -4,   -4
+.2byte   -6,   -5, 	  -9,   -9, 	   3,   -8, 	  -2,   -7
+.2byte   -4,   -6, 	  -4,  -12, 	   5,   -9, 	   0,   -6
+.2byte   -1,   -4, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    0, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -6, 	  -7,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	  -8,  -12, 	   6,  -12, 	  -1,  -10
+.2byte    7,   -4, 	   9,   -9, 	  -3,   -7, 	   3,   -7
+.2byte    7,   -1, 	  10,   -5, 	  -2,   -6, 	   3,   -4
+.2byte    5,   -5, 	   8,   -9, 	  -4,   -8, 	   1,   -7
+.2byte    3,   -6, 	   3,  -12, 	  -6,   -9, 	  -1,   -6
+.2byte    8,   -5, 	  -1,  -11, 	   0,   -6, 	   2,   -6
+.2byte    9,   -3, 	   1,  -10, 	   2,   -6, 	   0,   -5
+.2byte    8,   -7, 	  -2,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    4,  -12, 	  -5,   -9, 	  -3,   -8, 	  -1,   -6
+.2byte    4,  -10, 	  -4,  -11, 	   7,   -7, 	   1,   -6
+.2byte    5,   -8, 	  -3,  -10, 	   7,   -5, 	   0,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   6,   -8, 	   0,   -7
+.2byte    1,  -11, 	  -6,   -9, 	   5,   -8, 	  -1,   -6
+.2byte   -1,  -13, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   6,  -11, 	  -8,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -5,  -10, 	   3,  -11, 	  -8,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	   2,  -10, 	  -8,   -5, 	  -1,   -5
+.2byte   -3,  -12, 	   4,  -12, 	  -7,   -8, 	  -1,   -7
+.2byte   -2,  -11, 	   5,   -9, 	  -6,   -8, 	   0,   -6
+.2byte   -9,   -5, 	   0,  -11, 	  -1,   -6, 	  -3,   -6
+.2byte  -10,   -3, 	  -2,  -10, 	  -3,   -6, 	  -1,   -5
+.2byte   -9,   -7, 	   1,  -11, 	   0,   -8, 	  -1,   -6
+.2byte   -5,  -12, 	   4,   -9, 	   2,   -8, 	   0,   -6
+.2byte   -8,   -4, 	 -10,   -9, 	   2,   -7, 	  -4,   -7
+.2byte   -8,   -1, 	 -11,   -5, 	   1,   -6, 	  -4,   -4
+.2byte   -6,   -5, 	  -9,   -9, 	   3,   -8, 	  -2,   -7
+.2byte   -4,   -6, 	  -4,  -12, 	   5,   -9, 	   0,   -6
+.2byte   -8,    0, 	  -9,   -8, 	   1,   -6, 	  -2,   -2
+.2byte   -8,    1, 	  -9,   -7, 	   1,   -5, 	  -2,   -1
+.2byte    0,  -11, 	  -9,  -14, 	   9,  -14, 	   0,  -12
+.2byte    4,  -12, 	   2,  -17, 	  -9,  -13, 	   1,  -13
+.2byte    3,  -16, 	  -9,  -13, 	  -7,  -12, 	   2,  -11
+.2byte    2,  -19, 	  -9,  -14, 	   2,  -12, 	   0,  -14
+.2byte   -1,  -17, 	   7,  -14, 	  -9,  -14, 	  -1,  -12
+.2byte   -3,  -19, 	   8,  -14, 	  -3,  -12, 	  -1,  -14
+.2byte   -4,  -16, 	   8,  -13, 	   6,  -12, 	  -3,  -11
+.2byte   -5,  -12, 	  -3,  -17, 	   8,  -13, 	  -2,  -13
+.2byte   -1,   -2, 	  -7,   -5, 	   5,   -5, 	  -1,   -5
+.2byte   -1,    0, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -4, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte    8,   -3, 	  10,   -8, 	  -2,   -6, 	   4,   -6
+.2byte    8,    0, 	  11,   -4, 	  -1,   -5, 	   4,   -3
+.2byte    6,   -4, 	   9,   -8, 	  -3,   -7, 	   2,   -6
+.2byte   10,   -5, 	   1,  -11, 	   2,   -6, 	   4,   -6
+.2byte   11,   -3, 	   3,  -10, 	   4,   -6, 	   2,   -5
+.2byte   10,   -7, 	   0,  -11, 	   1,   -8, 	   2,   -6
+.2byte    5,  -10, 	  -3,  -11, 	   8,   -7, 	   2,   -6
+.2byte    6,   -8, 	  -2,  -10, 	   8,   -5, 	   1,   -5
+.2byte    3,  -12, 	  -4,  -12, 	   7,   -8, 	   1,   -7
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	   6,  -13, 	  -8,  -13, 	  -1,  -11
+.2byte   -1,  -11, 	   6,  -12, 	  -8,  -12, 	  -1,   -9
+.2byte   -6,  -10, 	   2,  -11, 	  -9,   -7, 	  -3,   -6
+.2byte   -7,   -8, 	   1,  -10, 	  -9,   -5, 	  -2,   -5
+.2byte   -4,  -12, 	   3,  -12, 	  -8,   -8, 	  -2,   -7
+.2byte  -11,   -5, 	  -2,  -11, 	  -3,   -6, 	  -5,   -6
+.2byte  -12,   -3, 	  -4,  -10, 	  -5,   -6, 	  -3,   -5
+.2byte  -11,   -7, 	  -1,  -11, 	  -2,   -8, 	  -3,   -6
+.2byte   -9,   -3, 	 -11,   -8, 	   1,   -6, 	  -5,   -6
+.2byte   -9,    0, 	 -12,   -4, 	   0,   -5, 	  -5,   -3
+.2byte   -7,   -4, 	 -10,   -8, 	   2,   -7, 	  -3,   -6
+.2byte   -1,    0, 	  -8,   -2, 	   6,   -2, 	  -1,   -4
+.2byte   -2,   -1, 	  -9,   -7, 	   4,   -4, 	  -1,   -4
+.2byte   -7,   -1, 	  -4,  -11, 	  -2,   -5, 	   0,   -4
+.2byte   -4,   -6, 	   3,  -11, 	  -8,   -6, 	  -1,   -6
+.2byte   -1,   -9, 	   6,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte    3,   -6, 	  -4,  -11, 	   7,   -6, 	   0,   -6
+.2byte    6,   -1, 	   3,  -11, 	   1,   -5, 	  -1,   -4
+.2byte    1,   -1, 	   8,   -7, 	  -5,   -4, 	   0,   -4
+.2byte   -1,   -6, 	  -8,  -10, 	   6,  -10, 	  -1,   -8
+.2byte    4,   -6, 	   4,  -12, 	  -5,   -9, 	   0,   -6
+.2byte    6,  -12, 	  -3,   -9, 	  -1,   -8, 	   1,   -6
+.2byte    2,  -11, 	  -5,   -9, 	   6,   -8, 	   0,   -6
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -6
+.2byte   -4,  -11, 	   3,   -9, 	  -8,   -8, 	  -2,   -6
+.2byte   -8,  -12, 	   1,   -9, 	  -1,   -8, 	  -3,   -6
+.2byte   -5,   -6, 	  -5,  -12, 	   4,   -9, 	  -1,   -6
+.2byte   -1,   -4, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    2, 	  -7,    0, 	   5,    0, 	  -1,   -2
+.2byte   -1,   -6, 	  -7,   -9, 	   5,   -9, 	  -1,   -9
+.2byte    7,   -4, 	   9,   -9, 	  -3,   -7, 	   3,   -7
+.2byte    7,   -1, 	  10,   -5, 	  -2,   -6, 	   3,   -4
+.2byte    5,   -5, 	   8,   -9, 	  -4,   -8, 	   1,   -7
+.2byte    8,   -5, 	  -1,  -11, 	   0,   -6, 	   2,   -6
+.2byte    9,   -3, 	   1,  -10, 	   2,   -6, 	   0,   -5
+.2byte    8,   -7, 	  -2,  -11, 	  -1,   -8, 	   0,   -6
+.2byte    4,  -10, 	  -4,  -11, 	   7,   -7, 	   1,   -6
+.2byte    5,   -8, 	  -3,  -10, 	   7,   -5, 	   0,   -5
+.2byte    2,  -12, 	  -5,  -12, 	   6,   -8, 	   0,   -7
+.2byte   -1,  -13, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	   6,  -11, 	  -8,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte   -5,  -10, 	   3,  -11, 	  -8,   -7, 	  -2,   -6
+.2byte   -6,   -8, 	   2,  -10, 	  -8,   -5, 	  -1,   -5
+.2byte   -3,  -12, 	   4,  -12, 	  -7,   -8, 	  -1,   -7
+.2byte   -9,   -5, 	   0,  -11, 	  -1,   -6, 	  -3,   -6
+.2byte  -10,   -3, 	  -2,  -10, 	  -3,   -6, 	  -1,   -5
+.2byte   -9,   -7, 	   1,  -11, 	   0,   -8, 	  -1,   -6
+.2byte   -8,   -4, 	 -10,   -9, 	   2,   -7, 	  -4,   -7
+.2byte   -8,   -1, 	 -11,   -5, 	   1,   -6, 	  -4,   -4
+.2byte   -6,   -5, 	  -9,   -9, 	   3,   -8, 	  -2,   -7
+.2byte   -1,   -7, 	  -8,  -11, 	   6,  -11, 	  -1,   -9
+.2byte   -5,   -6, 	  -5,  -12, 	   4,   -9, 	  -1,   -6
+.2byte   -7,  -13, 	   2,  -10, 	   0,   -9, 	  -2,   -7
+.2byte   -4,  -13, 	   3,  -11, 	  -8,  -10, 	  -2,   -8
+.2byte   -1,  -14, 	   6,  -13, 	  -8,  -13, 	  -1,  -10
+.2byte    3,  -13, 	  -4,  -11, 	   7,  -10, 	   1,   -8
+.2byte    6,  -13, 	  -3,  -10, 	  -1,   -9, 	   1,   -7
+.2byte    4,   -6, 	   4,  -12, 	  -5,   -9, 	   0,   -6
+.2byte   -1,   -2, 	  -7,   -5, 	   5,   -5, 	  -1,   -5
+.2byte   -9,   -3, 	 -11,   -8, 	   1,   -6, 	  -5,   -6
+.2byte  -11,   -5, 	  -2,  -11, 	  -3,   -6, 	  -5,   -6
+.2byte   -6,  -10, 	   2,  -11, 	  -9,   -7, 	  -3,   -6
+.2byte   -1,  -14, 	   6,  -11, 	  -8,  -11, 	  -1,  -10
+.2byte    5,  -10, 	  -3,  -11, 	   8,   -7, 	   2,   -6
+.2byte   10,   -5, 	   1,  -11, 	   2,   -6, 	   4,   -6
+.2byte    8,   -3, 	  10,   -8, 	  -2,   -6, 	   4,   -6
+sMetapodAnimTable1:
+.4byte sMetapodAnims_1_1
+.4byte sMetapodAnims_1_2
+.4byte sMetapodAnims_1_3
+.4byte sMetapodAnims_1_4
+.4byte sMetapodAnims_1_5
+.4byte sMetapodAnims_1_6
+.4byte sMetapodAnims_1_7
+.4byte sMetapodAnims_1_8
+sMetapodAnimTable2:
+.4byte sMetapodAnims_2_1
+.4byte sMetapodAnims_2_2
+.4byte sMetapodAnims_2_3
+.4byte sMetapodAnims_2_4
+.4byte sMetapodAnims_2_5
+.4byte sMetapodAnims_2_6
+.4byte sMetapodAnims_2_7
+.4byte sMetapodAnims_2_8
+sMetapodAnimTable3:
+.4byte sMetapodAnims_3_1
+.4byte sMetapodAnims_3_2
+.4byte sMetapodAnims_3_3
+.4byte sMetapodAnims_3_4
+.4byte sMetapodAnims_3_5
+.4byte sMetapodAnims_3_6
+.4byte sMetapodAnims_3_7
+.4byte sMetapodAnims_3_8
+sMetapodAnimTable4:
+.4byte sMetapodAnims_4_1
+.4byte sMetapodAnims_4_2
+.4byte sMetapodAnims_4_3
+.4byte sMetapodAnims_4_4
+.4byte sMetapodAnims_4_5
+.4byte sMetapodAnims_4_6
+.4byte sMetapodAnims_4_7
+.4byte sMetapodAnims_4_8
+sMetapodAnimTable5:
+.4byte sMetapodAnims_5_1
+.4byte sMetapodAnims_5_2
+.4byte sMetapodAnims_5_3
+.4byte sMetapodAnims_5_4
+.4byte sMetapodAnims_5_5
+.4byte sMetapodAnims_5_6
+.4byte sMetapodAnims_5_7
+.4byte sMetapodAnims_5_8
+sMetapodAnimTable6:
+.4byte sMetapodAnims_6_1
+.4byte sMetapodAnims_6_1
+.4byte sMetapodAnims_6_1
+.4byte sMetapodAnims_6_1
+.4byte sMetapodAnims_6_1
+.4byte sMetapodAnims_6_1
+.4byte sMetapodAnims_6_1
+.4byte sMetapodAnims_6_1
+sMetapodAnimTable7:
+.4byte sMetapodAnims_7_1
+.4byte sMetapodAnims_7_2
+.4byte sMetapodAnims_7_3
+.4byte sMetapodAnims_7_4
+.4byte sMetapodAnims_7_5
+.4byte sMetapodAnims_7_6
+.4byte sMetapodAnims_7_7
+.4byte sMetapodAnims_7_8
+sMetapodAnimTable8:
+.4byte sMetapodAnims_8_1
+.4byte sMetapodAnims_8_2
+.4byte sMetapodAnims_8_3
+.4byte sMetapodAnims_8_4
+.4byte sMetapodAnims_8_5
+.4byte sMetapodAnims_8_6
+.4byte sMetapodAnims_8_7
+.4byte sMetapodAnims_8_8
+sMetapodAnimTable9:
+.4byte sMetapodAnims_9_1
+.4byte sMetapodAnims_9_2
+.4byte sMetapodAnims_9_3
+.4byte sMetapodAnims_9_4
+.4byte sMetapodAnims_9_5
+.4byte sMetapodAnims_9_6
+.4byte sMetapodAnims_9_7
+.4byte sMetapodAnims_9_8
+sMetapodAnimTable10:
+.4byte sMetapodAnims_10_1
+.4byte sMetapodAnims_10_2
+.4byte sMetapodAnims_10_3
+.4byte sMetapodAnims_10_4
+.4byte sMetapodAnims_10_5
+.4byte sMetapodAnims_10_6
+.4byte sMetapodAnims_10_7
+.4byte sMetapodAnims_10_8
+sMetapodAnimTable11:
+.4byte sMetapodAnims_11_1
+.4byte sMetapodAnims_11_2
+.4byte sMetapodAnims_11_3
+.4byte sMetapodAnims_11_4
+.4byte sMetapodAnims_11_5
+.4byte sMetapodAnims_11_6
+.4byte sMetapodAnims_11_7
+.4byte sMetapodAnims_11_8
+sMetapodAnimTable12:
+.4byte sMetapodAnims_12_1
+.4byte sMetapodAnims_12_2
+.4byte sMetapodAnims_12_3
+.4byte sMetapodAnims_12_4
+.4byte sMetapodAnims_12_5
+.4byte sMetapodAnims_12_6
+.4byte sMetapodAnims_12_7
+.4byte sMetapodAnims_12_8
+sMetapodAnimTable13:
+.4byte sMetapodAnims_13_1
+.4byte sMetapodAnims_13_2
+.4byte sMetapodAnims_13_3
+.4byte sMetapodAnims_13_4
+.4byte sMetapodAnims_13_5
+.4byte sMetapodAnims_13_6
+.4byte sMetapodAnims_13_7
+.4byte sMetapodAnims_13_8
+sAxAnimationsMetapod:
+.4byte sMetapodAnimTable1
+.4byte sMetapodAnimTable2
+.4byte sMetapodAnimTable3
+.4byte sMetapodAnimTable4
+.4byte sMetapodAnimTable5
+.4byte sMetapodAnimTable6
+.4byte sMetapodAnimTable7
+.4byte sMetapodAnimTable8
+.4byte sMetapodAnimTable9
+.4byte sMetapodAnimTable10
+.4byte sMetapodAnimTable11
+.4byte sMetapodAnimTable12
+.4byte sMetapodAnimTable13
+sAxSpritesMetapod:
+.4byte sMetapodSprites1
+.4byte sMetapodSprites2
+.4byte sMetapodSprites3
+.4byte sMetapodSprites4
+.4byte sMetapodSprites5
+.4byte sMetapodSprites6
+.4byte sMetapodSprites7
+.4byte sMetapodSprites8
+.4byte sMetapodSprites9
+.4byte sMetapodSprites10
+.4byte sMetapodSprites11
+.4byte sMetapodSprites12
+.4byte sMetapodSprites13
+.4byte sMetapodSprites14
+.4byte sMetapodSprites15
+.4byte sMetapodSprites16
+.4byte sMetapodSprites17
+.4byte sMetapodSprites18
+.4byte sMetapodSprites19
+.4byte sMetapodSprites20
+.4byte sMetapodSprites21
+.4byte sMetapodSprites22
+.4byte sMetapodSprites23
+.4byte sMetapodSprites24
+.4byte sMetapodSprites25
+.4byte sMetapodSprites26
+.4byte sMetapodSprites27
+.4byte sMetapodSprites28
+.4byte sMetapodSprites29
+.4byte sMetapodSprites30
+.4byte sMetapodSprites31
+.4byte sMetapodSprites32
+.4byte sMetapodSprites33
+.4byte sMetapodSprites34
+.4byte sMetapodSprites35
+.4byte sMetapodSprites36
+.4byte sMetapodSprites37
+sAxMainMetapod:
+ax_main sAxPosesMetapod, sAxAnimationsMetapod, 13, sAxSpritesMetapod, sAxPositionsMetapod

--- a/data/ax/mew.inc
+++ b/data/ax/mew.inc
@@ -1,0 +1,2952 @@
+.global gAxMew
+gAxMew:
+ax_siro sAxMainMew
+sMewPose1:
+ax_pose 0, 0x01de, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose2:
+ax_pose 1, 0x01de, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose3:
+ax_pose 2, 0x01df, 0x90ef, 0x1c00
+ax_pose_terminator
+sMewPose4:
+ax_pose 3, 0x01df, 0x90ef, 0x1c00
+ax_pose_terminator
+sMewPose5:
+ax_pose 4, 0x01de, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose6:
+ax_pose 5, 0x01de, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose7:
+ax_pose 6, 0x01e1, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose8:
+ax_pose 7, 0x01e1, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose9:
+ax_pose 8, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose10:
+ax_pose 9, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose11:
+ax_pose 6, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose12:
+ax_pose 7, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose13:
+ax_pose 4, 0x01de, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose14:
+ax_pose 5, 0x01de, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose15:
+ax_pose 2, 0x01df, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose16:
+ax_pose 3, 0x01df, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose17:
+ax_pose 10, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose19:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose20:
+ax_pose 13, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose21:
+ax_pose 14, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose22:
+ax_pose 15, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose23:
+ax_pose 16, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose24:
+ax_pose 17, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose25:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose26:
+ax_pose 19, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose27:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose28:
+ax_pose 21, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose29:
+ax_pose 22, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose30:
+ax_pose 23, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose31:
+ax_pose 24, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose32:
+ax_pose 25, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose33:
+ax_pose 26, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose34:
+ax_pose 27, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose35:
+ax_pose 28, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sMewPose36:
+ax_pose 29, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sMewPose37:
+ax_pose 30, 0x01e5, 0x80f8, 0x1c00
+ax_pose_terminator
+sMewPose38:
+ax_pose 31, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose39:
+ax_pose 32, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose40:
+ax_pose 33, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose41:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose42:
+ax_pose 10, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose43:
+ax_pose 11, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose44:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose45:
+ax_pose 13, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose46:
+ax_pose 14, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose47:
+ax_pose 15, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose48:
+ax_pose 16, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose49:
+ax_pose 17, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose50:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose51:
+ax_pose 19, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose52:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose53:
+ax_pose 21, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose54:
+ax_pose 22, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose55:
+ax_pose 23, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose56:
+ax_pose 24, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose57:
+ax_pose 25, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose58:
+ax_pose 26, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose59:
+ax_pose 27, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose60:
+ax_pose 28, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sMewPose61:
+ax_pose 29, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sMewPose62:
+ax_pose 30, 0x01e5, 0x80f8, 0x1c00
+ax_pose_terminator
+sMewPose63:
+ax_pose 31, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose64:
+ax_pose 32, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose65:
+ax_pose 33, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose66:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose67:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose68:
+ax_pose 34, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose69:
+ax_pose 35, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose70:
+ax_pose 15, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose71:
+ax_pose 36, 0x01e1, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose72:
+ax_pose 37, 0x01e1, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose73:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose74:
+ax_pose 38, 0x01e2, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose75:
+ax_pose 39, 0x01e2, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose76:
+ax_pose 21, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose77:
+ax_pose 40, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sMewPose78:
+ax_pose 41, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sMewPose79:
+ax_pose 24, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose80:
+ax_pose 42, 0x01e2, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose81:
+ax_pose 43, 0x01e2, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose82:
+ax_pose 27, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose83:
+ax_pose 40, 0x01e5, 0x80f1, 0x1c00
+ax_pose_terminator
+sMewPose84:
+ax_pose 41, 0x01e5, 0x80f1, 0x1c00
+ax_pose_terminator
+sMewPose85:
+ax_pose 30, 0x01e5, 0x80f8, 0x1c00
+ax_pose_terminator
+sMewPose86:
+ax_pose 38, 0x01e1, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose87:
+ax_pose 39, 0x01e1, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose88:
+ax_pose 33, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose89:
+ax_pose 36, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose90:
+ax_pose 37, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose91:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose92:
+ax_pose 33, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose93:
+ax_pose 30, 0x01e5, 0x80f8, 0x1c00
+ax_pose_terminator
+sMewPose94:
+ax_pose 27, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose95:
+ax_pose 24, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose96:
+ax_pose 21, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose97:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose98:
+ax_pose 15, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose99:
+ax_pose 44, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose100:
+ax_pose 45, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose101:
+ax_pose 46, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose102:
+ax_pose 47, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose103:
+ax_pose 48, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose104:
+ax_pose 49, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose105:
+ax_pose 50, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose106:
+ax_pose 51, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose107:
+ax_pose 52, 0x01e2, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose108:
+ax_pose 53, 0x01e2, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose109:
+ax_pose 54, 0x01e3, 0x80ef, 0x1c00
+ax_pose_terminator
+sMewPose110:
+ax_pose 55, 0x01e2, 0x90ef, 0x1c00
+ax_pose_terminator
+sMewPose111:
+ax_pose 56, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sMewPose112:
+ax_pose 57, 0x01e1, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose113:
+ax_pose 58, 0x01e0, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose114:
+ax_pose 57, 0x01e1, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose115:
+ax_pose 56, 0x01e3, 0x80f1, 0x1c00
+ax_pose_terminator
+sMewPose116:
+ax_pose 55, 0x01e2, 0x80f1, 0x1c00
+ax_pose_terminator
+sMewPose117:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose118:
+ax_pose 15, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose119:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose120:
+ax_pose 21, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose121:
+ax_pose 24, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose122:
+ax_pose 27, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose123:
+ax_pose 30, 0x01e5, 0x80f8, 0x1c00
+ax_pose_terminator
+sMewPose124:
+ax_pose 33, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose125:
+ax_pose 1, 0x01de, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose126:
+ax_pose 3, 0x01df, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose127:
+ax_pose 5, 0x01de, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose128:
+ax_pose 7, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose129:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose130:
+ax_pose 7, 0x01e1, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose131:
+ax_pose 5, 0x01de, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose132:
+ax_pose 3, 0x01df, 0x90f0, 0x1c00
+ax_pose_terminator
+sMewPose133:
+ax_pose 1, 0x01de, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose134:
+ax_pose 3, 0x01df, 0x90f0, 0x1c00
+ax_pose_terminator
+sMewPose135:
+ax_pose 5, 0x01de, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose136:
+ax_pose 7, 0x01e1, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose137:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose138:
+ax_pose 7, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose139:
+ax_pose 5, 0x01de, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose140:
+ax_pose 3, 0x01df, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose141:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose142:
+ax_pose 11, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose143:
+ax_pose 1, 0x01de, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose144:
+ax_pose 15, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose145:
+ax_pose 14, 0x01e6, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose146:
+ax_pose 3, 0x01df, 0x90f0, 0x1c00
+ax_pose_terminator
+sMewPose147:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose148:
+ax_pose 17, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose149:
+ax_pose 5, 0x01de, 0x90ed, 0x1c00
+ax_pose_terminator
+sMewPose150:
+ax_pose 21, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose151:
+ax_pose 20, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose152:
+ax_pose 7, 0x01e1, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose153:
+ax_pose 24, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose154:
+ax_pose 23, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose155:
+ax_pose 9, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose156:
+ax_pose 27, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose157:
+ax_pose 26, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose158:
+ax_pose 7, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose159:
+ax_pose 30, 0x01e5, 0x80f8, 0x1c00
+ax_pose_terminator
+sMewPose160:
+ax_pose 29, 0x01e5, 0x80f6, 0x1c00
+ax_pose_terminator
+sMewPose161:
+ax_pose 5, 0x01de, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose162:
+ax_pose 33, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose163:
+ax_pose 32, 0x01e4, 0x80f5, 0x1c00
+ax_pose_terminator
+sMewPose164:
+ax_pose 3, 0x01df, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose165:
+ax_pose 34, 0x01e1, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose166:
+ax_pose 36, 0x01e1, 0x80f3, 0x1c00
+ax_pose_terminator
+sMewPose167:
+ax_pose 38, 0x01e1, 0x80f2, 0x1c00
+ax_pose_terminator
+sMewPose168:
+ax_pose 40, 0x01e5, 0x80f1, 0x1c00
+ax_pose_terminator
+sMewPose169:
+ax_pose 42, 0x01e2, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose170:
+ax_pose 40, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sMewPose171:
+ax_pose 38, 0x01e2, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose172:
+ax_pose 36, 0x01e1, 0x90ee, 0x1c00
+ax_pose_terminator
+sMewPose173:
+ax_pose 12, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose174:
+ax_pose 33, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose175:
+ax_pose 30, 0x01e5, 0x80f8, 0x1c00
+ax_pose_terminator
+sMewPose176:
+ax_pose 27, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose177:
+ax_pose 24, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose178:
+ax_pose 21, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sMewPose179:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sMewPose180:
+ax_pose 15, 0x01e1, 0x80f0, 0x1c00
+ax_pose_terminator
+.align 2
+sMewAnims_1_1:
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 2, 0, 0,
+ax_anim 8, 0, 0, 0, 2, 0, 0,
+ax_anim 8, 0, 0, 0, 1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 1, 0, 0,
+ax_anim 8, 0, 3, 0, 2, 0, 0,
+ax_anim 8, 0, 2, 0, 2, 0, 0,
+ax_anim 8, 0, 2, 0, 1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_1_3:
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 1, 0, 0,
+ax_anim 8, 0, 5, 0, 2, 0, 0,
+ax_anim 8, 0, 4, 0, 2, 0, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_1_4:
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 2, 0, 0,
+ax_anim 8, 0, 6, 0, 2, 0, 0,
+ax_anim 8, 0, 6, 0, 1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_1_5:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 1, 0, 0,
+ax_anim 8, 0, 9, 0, 2, 0, 0,
+ax_anim 8, 0, 8, 0, 2, 0, 0,
+ax_anim 8, 0, 8, 0, 1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_1_6:
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 1, 0, 0,
+ax_anim 8, 0, 11, 0, 2, 0, 0,
+ax_anim 8, 0, 10, 0, 2, 0, 0,
+ax_anim 8, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_1_7:
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 2, 0, 0,
+ax_anim 8, 0, 12, 0, 2, 0, 0,
+ax_anim 8, 0, 12, 0, 1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_1_8:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 1, 0, 0,
+ax_anim 8, 0, 15, 0, 2, 0, 0,
+ax_anim 8, 0, 14, 0, 2, 0, 0,
+ax_anim 8, 0, 14, 0, 1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_2_1:
+ax_anim 2, 0, 18, 0, -1, 0, -1,
+ax_anim 2, 0, 18, 0, -2, 0, -2,
+ax_anim 1, 0, 18, 1, -2, 1, -2,
+ax_anim 3, 0, 18, 2, -2, 2, -2,
+ax_anim 1, 0, 18, -1, -2, -1, -2,
+ax_anim 3, 0, 18, -2, -2, -2, -2,
+ax_anim 2, 0, 18, 0, -2, 0, -2,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 9,
+ax_anim 2, 0, 17, 0, 27, 0, 24,
+ax_anim 2, 1, 17, 1, 27, 1, 24,
+ax_anim 2, 0, 17, 0, 27, 0, 24,
+ax_anim 2, 0, 17, 1, 27, 1, 24,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sMewAnims_2_2:
+ax_anim 2, 0, 21, -1, -1, -1, -1,
+ax_anim 2, 0, 21, -2, -2, -2, -2,
+ax_anim 1, 0, 21, -1, -3, -1, -3,
+ax_anim 3, 0, 21, 0, -4, 0, -4,
+ax_anim 1, 0, 21, -3, -1, -3, -1,
+ax_anim 3, 0, 21, -4, 0, -4, 0,
+ax_anim 2, 0, 21, -2, -1, -2, -2,
+ax_anim 1, 2, 19, 4, 6, 4, 4,
+ax_anim 1, 0, 19, 10, 13, 10, 10,
+ax_anim 2, 0, 20, 18, 22, 18, 18,
+ax_anim 2, 1, 20, 19, 26, 20, 17,
+ax_anim 2, 0, 20, 18, 27, 18, 18,
+ax_anim 2, 0, 20, 19, 26, 20, 17,
+ax_anim 2, 0, 19, 6, 6, 6, 6,
+ax_anim_terminator
+sMewAnims_2_3:
+ax_anim 2, 0, 24, -1, 0, -1, 0,
+ax_anim 2, 0, 24, -2, 0, -2, 0,
+ax_anim 1, 0, 24, -2, -1, -2, -1,
+ax_anim 3, 0, 24, -2, -2, -2, -2,
+ax_anim 1, 0, 24, -2, 1, -2, 1,
+ax_anim 3, 0, 24, -2, 3, -2, 3,
+ax_anim 2, 0, 24, -2, 0, -2, 0,
+ax_anim 1, 2, 22, 4, 1, 4, 0,
+ax_anim 1, 0, 22, 10, 2, 10, 0,
+ax_anim 2, 0, 23, 19, 4, 19, 0,
+ax_anim 2, 1, 23, 19, 3, 19, -1,
+ax_anim 2, 0, 23, 19, 4, 19, 0,
+ax_anim 2, 0, 23, 19, 3, 19, -1,
+ax_anim 2, 0, 22, 6, 0, 6, 0,
+ax_anim_terminator
+sMewAnims_2_4:
+ax_anim 2, 0, 27, -1, 1, -1, 1,
+ax_anim 2, 0, 27, -2, 2, -2, 2,
+ax_anim 1, 0, 27, -3, 1, -3, 1,
+ax_anim 3, 0, 27, -4, 0, -4, 0,
+ax_anim 1, 0, 27, -1, 3, -1, 3,
+ax_anim 3, 0, 27, 0, 4, 0, 4,
+ax_anim 2, 0, 27, -2, 2, -2, 2,
+ax_anim 1, 2, 25, 4, -4, 4, -5,
+ax_anim 1, 0, 25, 10, -10, 10, -13,
+ax_anim 2, 0, 26, 18, -20, 18, -24,
+ax_anim 2, 1, 26, 19, -19, 19, -23,
+ax_anim 2, 0, 26, 18, -20, 18, -24,
+ax_anim 2, 0, 26, 19, -19, 19, -23,
+ax_anim 2, 0, 25, 6, -6, 6, -6,
+ax_anim_terminator
+sMewAnims_2_5:
+ax_anim 2, 0, 30, 0, 1, 0, 1,
+ax_anim 2, 0, 30, 0, 2, 0, 2,
+ax_anim 1, 0, 30, 1, 2, 1, 2,
+ax_anim 3, 0, 30, 2, 2, 2, 2,
+ax_anim 1, 0, 30, -1, 2, -1, 2,
+ax_anim 3, 0, 30, -2, 2, -2, 2,
+ax_anim 2, 0, 30, 0, 2, 0, 2,
+ax_anim 1, 2, 28, 0, -4, 0, -5,
+ax_anim 1, 0, 28, 0, -10, 0, -12,
+ax_anim 2, 0, 29, 0, -17, 0, -22,
+ax_anim 2, 1, 29, 1, -17, 1, -22,
+ax_anim 2, 0, 29, 0, -17, 0, -22,
+ax_anim 2, 0, 29, 1, -17, 1, -22,
+ax_anim 2, 0, 28, 0, -6, 0, -6,
+ax_anim_terminator
+sMewAnims_2_6:
+ax_anim 2, 0, 33, 1, 1, 1, 1,
+ax_anim 2, 0, 33, 2, 2, 2, 2,
+ax_anim 1, 0, 33, 3, 1, 3, 1,
+ax_anim 3, 0, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 1, 3, 1, 3,
+ax_anim 3, 0, 33, 0, 4, 0, 4,
+ax_anim 2, 0, 33, 2, 2, 2, 2,
+ax_anim 1, 2, 31, -4, -4, -4, -5,
+ax_anim 1, 0, 31, -10, -10, -10, -13,
+ax_anim 2, 0, 32, -18, -20, -18, -24,
+ax_anim 2, 1, 32, -19, -19, -19, -23,
+ax_anim 2, 0, 32, -18, -20, -18, -24,
+ax_anim 2, 0, 32, -19, -19, -19, -23,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim_terminator
+sMewAnims_2_7:
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 2, 0, 36, 2, 0, 2, 0,
+ax_anim 1, 0, 36, 2, -1, 2, -1,
+ax_anim 3, 0, 36, 2, -2, 2, -2,
+ax_anim 1, 0, 36, 2, 1, 2, 1,
+ax_anim 3, 0, 36, 2, 3, 2, 3,
+ax_anim 2, 0, 36, 2, 0, 2, 0,
+ax_anim 1, 2, 34, -4, 1, -4, 0,
+ax_anim 1, 0, 34, -10, 2, -10, 0,
+ax_anim 2, 0, 35, -19, 4, -19, 0,
+ax_anim 2, 1, 35, -19, 3, -19, -1,
+ax_anim 2, 0, 35, -19, 4, -19, 0,
+ax_anim 2, 0, 35, -19, 3, -19, -1,
+ax_anim 2, 0, 34, -6, 0, -6, 0,
+ax_anim_terminator
+sMewAnims_2_8:
+ax_anim 2, 0, 39, 1, -1, 1, -1,
+ax_anim 2, 0, 39, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 1, -3, 1, -3,
+ax_anim 3, 0, 39, 0, -4, 0, -4,
+ax_anim 1, 0, 39, 3, -1, 3, -1,
+ax_anim 3, 0, 39, 4, 0, 4, 0,
+ax_anim 2, 0, 39, 2, -1, 2, -2,
+ax_anim 1, 2, 37, -4, 6, -4, 4,
+ax_anim 1, 0, 37, -10, 13, -10, 10,
+ax_anim 2, 0, 38, -18, 22, -18, 18,
+ax_anim 2, 1, 38, -19, 26, -20, 17,
+ax_anim 2, 0, 38, -18, 27, -18, 18,
+ax_anim 2, 0, 38, -19, 26, -20, 17,
+ax_anim 2, 0, 37, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMewAnims_3_1:
+ax_anim 2, 0, 43, 0, -1, 0, -1,
+ax_anim 2, 0, 43, 0, -2, 0, -2,
+ax_anim 1, 0, 43, 1, -2, 1, -2,
+ax_anim 3, 0, 43, 2, -2, 2, -2,
+ax_anim 1, 0, 43, -1, -2, -1, -2,
+ax_anim 3, 0, 43, -2, -2, -2, -2,
+ax_anim 2, 0, 43, 0, -2, 0, -2,
+ax_anim 1, 2, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 41, 0, 10, 0, 9,
+ax_anim 2, 0, 42, 0, 27, 0, 24,
+ax_anim 2, 1, 42, 1, 27, 1, 24,
+ax_anim 2, 0, 42, 0, 27, 0, 24,
+ax_anim 2, 0, 42, 1, 27, 1, 24,
+ax_anim 2, 0, 41, 0, 6, 0, 6,
+ax_anim_terminator
+sMewAnims_3_2:
+ax_anim 2, 0, 46, -1, -1, -1, -1,
+ax_anim 2, 0, 46, -2, -2, -2, -2,
+ax_anim 1, 0, 46, -1, -3, -1, -3,
+ax_anim 3, 0, 46, 0, -4, 0, -4,
+ax_anim 1, 0, 46, -3, -1, -3, -1,
+ax_anim 3, 0, 46, -4, 0, -4, 0,
+ax_anim 2, 0, 46, -2, -1, -2, -2,
+ax_anim 1, 2, 44, 4, 6, 4, 4,
+ax_anim 1, 0, 44, 10, 13, 10, 10,
+ax_anim 2, 0, 45, 18, 22, 18, 18,
+ax_anim 2, 1, 45, 19, 26, 20, 17,
+ax_anim 2, 0, 45, 18, 27, 18, 18,
+ax_anim 2, 0, 45, 19, 26, 20, 17,
+ax_anim 2, 0, 44, 6, 6, 6, 6,
+ax_anim_terminator
+sMewAnims_3_3:
+ax_anim 2, 0, 49, -1, 0, -1, 0,
+ax_anim 2, 0, 49, -2, 0, -2, 0,
+ax_anim 1, 0, 49, -2, -1, -2, -1,
+ax_anim 3, 0, 49, -2, -2, -2, -2,
+ax_anim 1, 0, 49, -2, 1, -2, 1,
+ax_anim 3, 0, 49, -2, 3, -2, 3,
+ax_anim 2, 0, 49, -2, 0, -2, 0,
+ax_anim 1, 2, 47, 4, 1, 4, 0,
+ax_anim 1, 0, 47, 10, 2, 10, 0,
+ax_anim 2, 0, 48, 19, 4, 19, 0,
+ax_anim 2, 1, 48, 19, 3, 19, -1,
+ax_anim 2, 0, 48, 19, 4, 19, 0,
+ax_anim 2, 0, 48, 19, 3, 19, -1,
+ax_anim 2, 0, 47, 6, 0, 6, 0,
+ax_anim_terminator
+sMewAnims_3_4:
+ax_anim 2, 0, 52, -1, 1, -1, 1,
+ax_anim 2, 0, 52, -2, 2, -2, 2,
+ax_anim 1, 0, 52, -3, 1, -3, 1,
+ax_anim 3, 0, 52, -4, 0, -4, 0,
+ax_anim 1, 0, 52, -1, 3, -1, 3,
+ax_anim 3, 0, 52, 0, 4, 0, 4,
+ax_anim 2, 0, 52, -2, 2, -2, 2,
+ax_anim 1, 2, 50, 4, -4, 4, -5,
+ax_anim 1, 0, 50, 10, -10, 10, -13,
+ax_anim 2, 0, 51, 18, -20, 18, -24,
+ax_anim 2, 1, 51, 19, -19, 19, -23,
+ax_anim 2, 0, 51, 18, -20, 18, -24,
+ax_anim 2, 0, 51, 19, -19, 19, -23,
+ax_anim 2, 0, 50, 6, -6, 6, -6,
+ax_anim_terminator
+sMewAnims_3_5:
+ax_anim 2, 0, 55, 0, 1, 0, 1,
+ax_anim 2, 0, 55, 0, 2, 0, 2,
+ax_anim 1, 0, 55, 1, 2, 1, 2,
+ax_anim 3, 0, 55, 2, 2, 2, 2,
+ax_anim 1, 0, 55, -1, 2, -1, 2,
+ax_anim 3, 0, 55, -2, 2, -2, 2,
+ax_anim 2, 0, 55, 0, 2, 0, 2,
+ax_anim 1, 2, 53, 0, -4, 0, -5,
+ax_anim 1, 0, 53, 0, -10, 0, -12,
+ax_anim 2, 0, 54, 0, -17, 0, -22,
+ax_anim 2, 1, 54, 1, -17, 1, -22,
+ax_anim 2, 0, 54, 0, -17, 0, -22,
+ax_anim 2, 0, 54, 1, -17, 1, -22,
+ax_anim 2, 0, 53, 0, -6, 0, -6,
+ax_anim_terminator
+sMewAnims_3_6:
+ax_anim 2, 0, 58, 1, 1, 1, 1,
+ax_anim 2, 0, 58, 2, 2, 2, 2,
+ax_anim 1, 0, 58, 3, 1, 3, 1,
+ax_anim 3, 0, 58, 4, 0, 4, 0,
+ax_anim 1, 0, 58, 1, 3, 1, 3,
+ax_anim 3, 0, 58, 0, 4, 0, 4,
+ax_anim 2, 0, 58, 2, 2, 2, 2,
+ax_anim 1, 2, 56, -4, -4, -4, -5,
+ax_anim 1, 0, 56, -10, -10, -10, -13,
+ax_anim 2, 0, 57, -18, -20, -18, -24,
+ax_anim 2, 1, 57, -19, -19, -19, -23,
+ax_anim 2, 0, 57, -18, -20, -18, -24,
+ax_anim 2, 0, 57, -19, -19, -19, -23,
+ax_anim 2, 0, 56, -6, -6, -6, -6,
+ax_anim_terminator
+sMewAnims_3_7:
+ax_anim 2, 0, 61, 1, 0, 1, 0,
+ax_anim 2, 0, 61, 2, 0, 2, 0,
+ax_anim 1, 0, 61, 2, -1, 2, -1,
+ax_anim 3, 0, 61, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 2, 1, 2, 1,
+ax_anim 3, 0, 61, 2, 3, 2, 3,
+ax_anim 2, 0, 61, 2, 0, 2, 0,
+ax_anim 1, 2, 59, -4, 1, -4, 0,
+ax_anim 1, 0, 59, -10, 2, -10, 0,
+ax_anim 2, 0, 60, -19, 4, -19, 0,
+ax_anim 2, 1, 60, -19, 3, -19, -1,
+ax_anim 2, 0, 60, -19, 4, -19, 0,
+ax_anim 2, 0, 60, -19, 3, -19, -1,
+ax_anim 2, 0, 59, -6, 0, -6, 0,
+ax_anim_terminator
+sMewAnims_3_8:
+ax_anim 2, 0, 64, 1, -1, 1, -1,
+ax_anim 2, 0, 64, 2, -2, 2, -2,
+ax_anim 1, 0, 64, 1, -3, 1, -3,
+ax_anim 3, 0, 64, 0, -4, 0, -4,
+ax_anim 1, 0, 64, 3, -1, 3, -1,
+ax_anim 3, 0, 64, 4, 0, 4, 0,
+ax_anim 2, 0, 64, 2, -1, 2, -2,
+ax_anim 1, 2, 62, -4, 6, -4, 4,
+ax_anim 1, 0, 62, -10, 13, -10, 10,
+ax_anim 2, 0, 63, -18, 22, -18, 18,
+ax_anim 2, 1, 63, -19, 26, -20, 17,
+ax_anim 2, 0, 63, -18, 27, -18, 18,
+ax_anim 2, 0, 63, -19, 26, -20, 17,
+ax_anim 2, 0, 62, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMewAnims_4_1:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 66, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 3, 0, 67, 0, -5, 0, 0,
+ax_anim 3, 0, 68, 0, -5, 0, 0,
+ax_anim 3, 0, 67, 0, -5, 0, 0,
+ax_anim 3, 0, 68, 0, -5, 0, 0,
+ax_anim 3, 2, 67, 0, -5, 0, 0,
+ax_anim 3, 0, 68, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 66, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim_terminator
+sMewAnims_4_2:
+ax_anim 2, 0, 69, 0, -2, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 3, 0, 70, 0, -5, 0, 0,
+ax_anim 3, 0, 71, 0, -5, 0, 0,
+ax_anim 3, 0, 70, 0, -5, 0, 0,
+ax_anim 3, 0, 71, 0, -5, 0, 0,
+ax_anim 3, 2, 70, 0, -5, 0, 0,
+ax_anim 3, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 2, 0, 69, 0, -2, 0, 0,
+ax_anim_terminator
+sMewAnims_4_3:
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 72, 0, -4, 0, 0,
+ax_anim 2, 0, 72, 0, -5, 0, 0,
+ax_anim 3, 0, 73, 0, -5, 0, 0,
+ax_anim 3, 0, 74, 0, -5, 0, 0,
+ax_anim 3, 0, 73, 0, -5, 0, 0,
+ax_anim 3, 0, 74, 0, -5, 0, 0,
+ax_anim 3, 2, 73, 0, -5, 0, 0,
+ax_anim 3, 0, 74, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 72, 0, -4, 0, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim_terminator
+sMewAnims_4_4:
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 3, 0, 76, 0, -5, 0, 0,
+ax_anim 3, 0, 77, 0, -5, 0, 0,
+ax_anim 3, 0, 76, 0, -5, 0, 0,
+ax_anim 3, 0, 77, 0, -5, 0, 0,
+ax_anim 3, 2, 76, 0, -5, 0, 0,
+ax_anim 3, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim_terminator
+sMewAnims_4_5:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 3, 0, 79, 0, -5, 0, 0,
+ax_anim 3, 0, 80, 0, -5, 0, 0,
+ax_anim 3, 0, 79, 0, -5, 0, 0,
+ax_anim 3, 0, 80, 0, -5, 0, 0,
+ax_anim 3, 2, 79, 0, -5, 0, 0,
+ax_anim 3, 0, 80, 0, -5, 0, 0,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim_terminator
+sMewAnims_4_6:
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -5, 0, 0,
+ax_anim 3, 0, 82, 0, -5, 0, 0,
+ax_anim 3, 0, 83, 0, -5, 0, 0,
+ax_anim 3, 0, 82, 0, -5, 0, 0,
+ax_anim 3, 0, 83, 0, -5, 0, 0,
+ax_anim 3, 2, 82, 0, -5, 0, 0,
+ax_anim 3, 0, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim_terminator
+sMewAnims_4_7:
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -5, 0, 0,
+ax_anim 3, 0, 85, 0, -5, 0, 0,
+ax_anim 3, 0, 86, 0, -5, 0, 0,
+ax_anim 3, 0, 85, 0, -5, 0, 0,
+ax_anim 3, 0, 86, 0, -5, 0, 0,
+ax_anim 3, 2, 85, 0, -5, 0, 0,
+ax_anim 3, 0, 86, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim_terminator
+sMewAnims_4_8:
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -5, 0, 0,
+ax_anim 3, 0, 88, 0, -5, 0, 0,
+ax_anim 3, 0, 89, 0, -5, 0, 0,
+ax_anim 3, 0, 88, 0, -5, 0, 0,
+ax_anim 3, 0, 89, 0, -5, 0, 0,
+ax_anim 3, 2, 88, 0, -5, 0, 0,
+ax_anim 3, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_5_1:
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -8, 0, 0,
+ax_anim 2, 0, 94, 0, -9, 0, 0,
+ax_anim 2, 0, 95, 0, -9, 0, 0,
+ax_anim 2, 2, 96, 0, -8, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_5_2:
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -8, 0, 0,
+ax_anim 2, 0, 93, 0, -9, 0, 0,
+ax_anim 2, 0, 94, 0, -9, 0, 0,
+ax_anim 2, 2, 95, 0, -8, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_5_3:
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -8, 0, 0,
+ax_anim 2, 0, 92, 0, -9, 0, 0,
+ax_anim 2, 0, 93, 0, -9, 0, 0,
+ax_anim 2, 2, 94, 0, -8, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_5_4:
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -8, 0, 0,
+ax_anim 2, 0, 91, 0, -9, 0, 0,
+ax_anim 2, 0, 92, 0, -9, 0, 0,
+ax_anim 2, 2, 93, 0, -8, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_5_5:
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -8, 0, 0,
+ax_anim 2, 0, 90, 0, -9, 0, 0,
+ax_anim 2, 0, 91, 0, -9, 0, 0,
+ax_anim 2, 2, 92, 0, -8, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_5_6:
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -8, 0, 0,
+ax_anim 2, 0, 97, 0, -9, 0, 0,
+ax_anim 2, 0, 90, 0, -9, 0, 0,
+ax_anim 2, 2, 91, 0, -8, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_5_7:
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -8, 0, 0,
+ax_anim 2, 0, 96, 0, -9, 0, 0,
+ax_anim 2, 0, 97, 0, -9, 0, 0,
+ax_anim 2, 2, 90, 0, -8, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_5_8:
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -8, 0, 0,
+ax_anim 2, 0, 95, 0, -9, 0, 0,
+ax_anim 2, 0, 96, 0, -9, 0, 0,
+ax_anim 2, 2, 97, 0, -8, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_6_1:
+ax_anim 16, 0, 106, 0, 0, 0, 0,
+ax_anim 12, 0, 106, 0, -1, 0, 0,
+ax_anim 16, 0, 106, 0, -2, 0, 0,
+ax_anim 16, 0, 107, 0, -2, 0, 0,
+ax_anim 12, 0, 107, 0, -1, 0, 0,
+ax_anim 16, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_7_1:
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim 8, 0, 108, 0, -3, 0, -3,
+ax_anim_terminator
+sMewAnims_7_2:
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 8, 0, 109, -3, -3, -3, -3,
+ax_anim_terminator
+sMewAnims_7_3:
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 8, 0, 110, -3, 0, -3, 0,
+ax_anim_terminator
+sMewAnims_7_4:
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 8, 0, 111, -3, 3, -3, 3,
+ax_anim_terminator
+sMewAnims_7_5:
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim 8, 0, 112, 0, 3, 0, 3,
+ax_anim_terminator
+sMewAnims_7_6:
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 8, 0, 113, 3, 3, 3, 3,
+ax_anim_terminator
+sMewAnims_7_7:
+ax_anim 2, 0, 114, 2, 0, 2, 0,
+ax_anim 8, 0, 114, 3, 0, 3, 0,
+ax_anim_terminator
+sMewAnims_7_8:
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 8, 0, 115, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMewAnims_8_1:
+ax_anim 12, 0, 116, 0, 0, 0, 0,
+ax_anim 8, 0, 116, 0, -1, 0, 0,
+ax_anim 12, 0, 116, 0, -2, 0, 0,
+ax_anim 8, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sMewAnims_8_2:
+ax_anim 12, 0, 117, 0, 0, 0, 0,
+ax_anim 8, 0, 117, 0, -1, 0, 0,
+ax_anim 12, 0, 117, 0, -2, 0, 0,
+ax_anim 8, 0, 117, 0, -1, 0, 0,
+ax_anim_terminator
+sMewAnims_8_3:
+ax_anim 12, 0, 118, 0, 0, 0, 0,
+ax_anim 8, 0, 118, 0, -1, 0, 0,
+ax_anim 12, 0, 118, 0, -2, 0, 0,
+ax_anim 8, 0, 118, 0, -1, 0, 0,
+ax_anim_terminator
+sMewAnims_8_4:
+ax_anim 12, 0, 119, 0, 0, 0, 0,
+ax_anim 8, 0, 119, 0, -1, 0, 0,
+ax_anim 12, 0, 119, 0, -2, 0, 0,
+ax_anim 8, 0, 119, 0, -1, 0, 0,
+ax_anim_terminator
+sMewAnims_8_5:
+ax_anim 12, 0, 120, 0, 0, 0, 0,
+ax_anim 8, 0, 120, 0, -1, 0, 0,
+ax_anim 12, 0, 120, 0, -2, 0, 0,
+ax_anim 8, 0, 120, 0, -1, 0, 0,
+ax_anim_terminator
+sMewAnims_8_6:
+ax_anim 12, 0, 121, 0, 0, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim 12, 0, 121, 0, -2, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim_terminator
+sMewAnims_8_7:
+ax_anim 12, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim 12, 0, 122, 0, -2, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sMewAnims_8_8:
+ax_anim 12, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, -1, 0, 0,
+ax_anim 12, 0, 123, 0, -2, 0, 0,
+ax_anim 8, 0, 123, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_9_1:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 6, 3, 6, 3,
+ax_anim 2, 0, 126, 10, 10, 10, 10,
+ax_anim 2, 0, 127, 7, 19, 7, 19,
+ax_anim 3, 0, 128, 0, 23, 0, 23,
+ax_anim 2, 3, 129, -7, 19, -7, 19,
+ax_anim 2, 0, 130, -10, 10, -10, 10,
+ax_anim 1, 0, 131, -6, 3, -6, 3,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_9_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 8, 0, 8, 0,
+ax_anim 2, 0, 125, 17, 3, 17, 3,
+ax_anim 2, 0, 126, 21, 15, 21, 15,
+ax_anim 3, 0, 127, 20, 22, 20, 22,
+ax_anim 2, 3, 128, 11, 22, 11, 22,
+ax_anim 2, 0, 129, 3, 15, 3, 15,
+ax_anim 1, 0, 130, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_9_3:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 3, -5, 3, -5,
+ax_anim 2, 0, 124, 11, -6, 11, -6,
+ax_anim 2, 0, 125, 17, -3, 17, -3,
+ax_anim 3, 0, 126, 21, 2, 21, 2,
+ax_anim 2, 3, 127, 16, 4, 16, 4,
+ax_anim 2, 0, 128, 12, 5, 12, 5,
+ax_anim 1, 0, 129, 4, 5, 4, 5,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_9_4:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -1, -8, -1, -8,
+ax_anim 2, 0, 131, 4, -16, 4, -16,
+ax_anim 2, 0, 124, 14, -20, 14, -20,
+ax_anim 3, 0, 125, 22, -17, 22, -17,
+ax_anim 2, 3, 126, 21, -11, 21, -11,
+ax_anim 2, 0, 127, 17, -4, 17, -4,
+ax_anim 1, 0, 128, 7, -1, 7, -1,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_9_5:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, -8, -4, -8, -4,
+ax_anim 2, 0, 130, -9, -12, -9, -12,
+ax_anim 2, 0, 131, -7, -16, -7, -16,
+ax_anim 3, 0, 124, 0, -18, 0, -18,
+ax_anim 2, 3, 125, 7, -16, 7, -16,
+ax_anim 2, 0, 126, 9, -10, 9, -10,
+ax_anim 1, 0, 127, 8, -4, 8, -4,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_9_6:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 1, -8, 1, -8,
+ax_anim 2, 0, 125, -4, -16, -4, -16,
+ax_anim 2, 0, 124, -14, -20, -14, -20,
+ax_anim 3, 0, 131, -22, -17, -22, -17,
+ax_anim 2, 3, 130, -21, -11, -21, -11,
+ax_anim 2, 0, 129, -17, -4, -17, -4,
+ax_anim 1, 0, 128, -7, -1, -7, -1,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_9_7:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, -3, -5, -3, -5,
+ax_anim 2, 0, 124, -11, -6, -11, -6,
+ax_anim 2, 0, 131, -17, -3, -17, -3,
+ax_anim 3, 0, 130, -21, 2, -21, 2,
+ax_anim 2, 3, 129, -16, 4, -16, 4,
+ax_anim 2, 0, 128, -12, 5, -12, 5,
+ax_anim 1, 0, 127, -4, 5, -4, 5,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_9_8:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, -8, 0, -8, 0,
+ax_anim 2, 0, 131, -17, 3, -17, 3,
+ax_anim 2, 0, 130, -21, 15, -21, 15,
+ax_anim 3, 0, 129, -20, 22, -20, 22,
+ax_anim 2, 3, 128, -11, 22, -11, 22,
+ax_anim 2, 0, 127, -3, 15, -3, 15,
+ax_anim 1, 0, 126, 0, 7, 0, 7,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_10_1:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 6, 0, 6, 0,
+ax_anim 2, 0, 132, -6, 0, -6, 0,
+ax_anim 2, 0, 132, 10, 0, 10, 0,
+ax_anim 2, 0, 132, -10, 0, -10, 0,
+ax_anim 2, 0, 132, 12, 0, 12, 0,
+ax_anim 3, 0, 132, -12, 0, -12, 0,
+ax_anim 3, 0, 132, 13, 0, 13, 0,
+ax_anim 3, 0, 132, -13, 0, -13, 0,
+ax_anim 2, 0, 132, 12, 0, 12, 0,
+ax_anim 3, 0, 132, -12, 0, -12, 0,
+ax_anim 2, 0, 132, 10, 0, 10, 0,
+ax_anim 2, 0, 132, -10, 0, -10, 0,
+ax_anim 2, 0, 132, 6, 0, 6, 0,
+ax_anim 2, 0, 132, -6, 0, -6, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_10_2:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 6, -6, 6, -6,
+ax_anim 2, 0, 133, -6, 6, -6, 6,
+ax_anim 2, 0, 133, 10, -10, 10, -10,
+ax_anim 2, 0, 133, -10, 10, -10, 10,
+ax_anim 2, 0, 133, 12, -12, 12, -12,
+ax_anim 3, 0, 133, -12, 12, -12, 12,
+ax_anim 3, 0, 133, 13, -13, 13, -13,
+ax_anim 3, 0, 133, -13, 13, -13, 13,
+ax_anim 2, 0, 133, 12, -12, 12, -12,
+ax_anim 3, 0, 133, -12, 12, -12, 12,
+ax_anim 2, 0, 133, 10, -10, 10, -10,
+ax_anim 2, 0, 133, -10, 10, -10, 10,
+ax_anim 2, 0, 133, 6, -6, 6, -6,
+ax_anim 2, 0, 133, -6, 6, -6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_10_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -6, 0, -6,
+ax_anim 2, 0, 134, 0, 6, 0, 6,
+ax_anim 2, 0, 134, 0, -10, 0, -10,
+ax_anim 2, 0, 134, 0, 10, 0, 10,
+ax_anim 2, 0, 134, 0, -12, 0, -12,
+ax_anim 3, 0, 134, 0, 12, 0, 12,
+ax_anim 3, 0, 134, 0, -13, 0, -13,
+ax_anim 3, 0, 134, 0, 13, 0, 13,
+ax_anim 2, 0, 134, 0, -12, 0, -12,
+ax_anim 3, 0, 134, 0, 12, 0, 12,
+ax_anim 2, 0, 134, 0, -10, 0, -10,
+ax_anim 2, 0, 134, 0, 10, 0, 10,
+ax_anim 2, 0, 134, 0, -6, 0, -6,
+ax_anim 2, 0, 134, 0, 6, 0, 6,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_10_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -6, -6, -6, -6,
+ax_anim 2, 0, 135, 6, 6, 6, 6,
+ax_anim 2, 0, 135, -10, -10, -10, -10,
+ax_anim 2, 0, 135, 10, 10, 10, 10,
+ax_anim 2, 0, 135, -12, -12, -12, -12,
+ax_anim 3, 0, 135, 12, 12, 12, 12,
+ax_anim 3, 0, 135, -13, -13, -13, -13,
+ax_anim 3, 0, 135, 13, 13, 13, 13,
+ax_anim 2, 0, 135, -12, -12, -12, -12,
+ax_anim 3, 0, 135, 12, 12, 12, 12,
+ax_anim 2, 0, 135, -10, -10, -10, -10,
+ax_anim 2, 0, 135, 10, 10, 10, 10,
+ax_anim 2, 0, 135, -6, -6, -6, -6,
+ax_anim 2, 0, 135, 6, 6, 6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_10_5:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 6, 0, 6, 0,
+ax_anim 2, 0, 136, -6, 0, -6, 0,
+ax_anim 2, 0, 136, 10, 0, 10, 0,
+ax_anim 2, 0, 136, -10, 0, -10, 0,
+ax_anim 2, 0, 136, 12, 0, 12, 0,
+ax_anim 3, 0, 136, -12, 0, -12, 0,
+ax_anim 3, 0, 136, 13, 0, 13, 0,
+ax_anim 3, 0, 136, -13, 0, -13, 0,
+ax_anim 2, 0, 136, 12, 0, 12, 0,
+ax_anim 3, 0, 136, -12, 0, -12, 0,
+ax_anim 2, 0, 136, 10, 0, 10, 0,
+ax_anim 2, 0, 136, -10, 0, -10, 0,
+ax_anim 2, 0, 136, 6, 0, 6, 0,
+ax_anim 2, 0, 136, -6, 0, -6, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_10_6:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 6, -6, 6, -6,
+ax_anim 2, 0, 137, -6, 6, -6, 6,
+ax_anim 2, 0, 137, 10, -10, 10, -10,
+ax_anim 2, 0, 137, -10, 10, -10, 10,
+ax_anim 2, 0, 137, 12, -12, 12, -12,
+ax_anim 3, 0, 137, -12, 12, -12, 12,
+ax_anim 3, 0, 137, 13, -13, 13, -13,
+ax_anim 3, 0, 137, -13, 13, -13, 13,
+ax_anim 2, 0, 137, 12, -12, 12, -12,
+ax_anim 3, 0, 137, -12, 12, -12, 12,
+ax_anim 2, 0, 137, 10, -10, 10, -10,
+ax_anim 2, 0, 137, -10, 10, -10, 10,
+ax_anim 2, 0, 137, 6, -6, 6, -6,
+ax_anim 2, 0, 137, -6, 6, -6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_10_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -6, 0, -6,
+ax_anim 2, 0, 138, 0, 6, 0, 6,
+ax_anim 2, 0, 138, 0, -10, 0, -10,
+ax_anim 2, 0, 138, 0, 10, 0, 10,
+ax_anim 2, 0, 138, 0, -12, 0, -12,
+ax_anim 3, 0, 138, 0, 12, 0, 12,
+ax_anim 3, 0, 138, 0, -13, 0, -13,
+ax_anim 3, 0, 138, 0, 13, 0, 13,
+ax_anim 2, 0, 138, 0, -12, 0, -12,
+ax_anim 3, 0, 138, 0, 12, 0, 12,
+ax_anim 2, 0, 138, 0, -10, 0, -10,
+ax_anim 2, 0, 138, 0, 10, 0, 10,
+ax_anim 2, 0, 138, 0, -6, 0, -6,
+ax_anim 2, 0, 138, 0, 6, 0, 6,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_10_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -6, -6, -6, -6,
+ax_anim 2, 0, 139, 6, 6, 6, 6,
+ax_anim 2, 0, 139, -10, -10, -10, -10,
+ax_anim 2, 0, 139, 10, 10, 10, 10,
+ax_anim 2, 0, 139, -12, -12, -12, -12,
+ax_anim 3, 0, 139, 12, 12, 12, 12,
+ax_anim 3, 0, 139, -13, -13, -13, -13,
+ax_anim 3, 0, 139, 13, 13, 13, 13,
+ax_anim 2, 0, 139, -12, -12, -12, -12,
+ax_anim 3, 0, 139, 12, 12, 12, 12,
+ax_anim 2, 0, 139, -10, -10, -10, -10,
+ax_anim 2, 0, 139, 10, 10, 10, 10,
+ax_anim 2, 0, 139, -6, -6, -6, -6,
+ax_anim 2, 0, 139, 6, 6, 6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_11_1:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -10, 0, 0,
+ax_anim 2, 0, 141, 0, -16, 0, 0,
+ax_anim 3, 0, 141, 0, -20, 0, 0,
+ax_anim 4, 0, 141, 0, -21, 0, 0,
+ax_anim 4, 0, 140, 0, -23, 0, 0,
+ax_anim 3, 0, 142, 0, -22, 0, 0,
+ax_anim 2, 0, 142, 0, -18, 0, 0,
+ax_anim 1, 0, 142, 0, -12, 0, 0,
+ax_anim 2, 2, 142, 0, 4, 0, 0,
+ax_anim_terminator
+sMewAnims_11_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -10, 0, 0,
+ax_anim 2, 0, 144, 0, -16, 0, 0,
+ax_anim 3, 0, 144, 0, -20, 0, 0,
+ax_anim 4, 0, 144, 0, -21, 0, 0,
+ax_anim 4, 0, 143, 0, -23, 0, 0,
+ax_anim 3, 0, 145, 0, -22, 0, 0,
+ax_anim 2, 0, 145, 0, -18, 0, 0,
+ax_anim 1, 0, 145, 0, -12, 0, 0,
+ax_anim 2, 2, 145, 0, 4, 0, 0,
+ax_anim_terminator
+sMewAnims_11_3:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -23, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 4, 0, 0,
+ax_anim_terminator
+sMewAnims_11_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 149, 0, -23, 0, 0,
+ax_anim 3, 0, 151, 0, -21, 0, 0,
+ax_anim 2, 0, 151, 0, -17, 0, 0,
+ax_anim 1, 0, 151, 0, -11, 0, 0,
+ax_anim 2, 2, 151, 0, 2, 0, 0,
+ax_anim_terminator
+sMewAnims_11_5:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -23, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 5, 0, 0,
+ax_anim_terminator
+sMewAnims_11_6:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 155, 0, -23, 0, 0,
+ax_anim 3, 0, 157, 0, -21, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 2, 0, 0,
+ax_anim_terminator
+sMewAnims_11_7:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 158, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 4, 0, 0,
+ax_anim_terminator
+sMewAnims_11_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -23, 0, 0,
+ax_anim 3, 0, 163, 0, -22, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_12_1:
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_12_2:
+ax_anim 2, 0, 171, 1, -1, 1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 1, -1, 1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 1, -1, 1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 1, -1, 1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 1, -1, 1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_12_3:
+ax_anim 2, 0, 170, 0, -1, 0, -1,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -1, 0, -1,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -1, 0, -1,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -1, 0, -1,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -1, 0, -1,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_12_4:
+ax_anim 2, 0, 169, -1, -1, -1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, -1, -1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, -1, -1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, -1, -1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, -1, -1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_12_5:
+ax_anim 2, 0, 168, 1, 0, 1, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 1, 0, 1, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 1, 0, 1, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 1, 0, 1, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 1, 0, 1, 0,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_12_6:
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_12_7:
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_12_8:
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewAnims_13_1:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_13_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_13_3:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_13_4:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_13_5:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_13_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_13_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMewAnims_13_8:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMewGfx1:
+.incbin "baserom.gba", 0xB99528, 0x200
+sMewSprites1:
+ax_sprite sMewGfx1, 0x200
+ax_sprite_terminator
+sMewGfx2:
+.incbin "baserom.gba", 0xB99738, 0x200
+sMewSprites2:
+ax_sprite sMewGfx2, 0x200
+ax_sprite_terminator
+sMewGfx3:
+.incbin "baserom.gba", 0xB99948, 0x200
+sMewSprites3:
+ax_sprite sMewGfx3, 0x200
+ax_sprite_terminator
+sMewGfx4:
+.incbin "baserom.gba", 0xB99B58, 0x200
+sMewSprites4:
+ax_sprite sMewGfx4, 0x200
+ax_sprite_terminator
+sMewGfx5:
+.incbin "baserom.gba", 0xB99D68, 0x200
+sMewSprites5:
+ax_sprite sMewGfx5, 0x200
+ax_sprite_terminator
+sMewGfx6:
+.incbin "baserom.gba", 0xB99F78, 0x200
+sMewSprites6:
+ax_sprite sMewGfx6, 0x200
+ax_sprite_terminator
+sMewGfx7:
+.incbin "baserom.gba", 0xB9A188, 0x200
+sMewSprites7:
+ax_sprite sMewGfx7, 0x200
+ax_sprite_terminator
+sMewGfx8:
+.incbin "baserom.gba", 0xB9A398, 0x200
+sMewSprites8:
+ax_sprite sMewGfx8, 0x200
+ax_sprite_terminator
+sMewGfx9:
+.incbin "baserom.gba", 0xB9A5A8, 0x200
+sMewSprites9:
+ax_sprite sMewGfx9, 0x200
+ax_sprite_terminator
+sMewGfx10:
+.incbin "baserom.gba", 0xB9A7B8, 0x200
+sMewSprites10:
+ax_sprite sMewGfx10, 0x200
+ax_sprite_terminator
+sMewGfx11:
+.incbin "baserom.gba", 0xB9A9C8, 0x60
+sMewGfx11_1:
+.incbin "baserom.gba", 0xB9AA28, 0x60
+sMewGfx11_2:
+.incbin "baserom.gba", 0xB9AA88, 0x60
+sMewSprites11:
+ax_sprite sMewGfx11, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx11_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx11_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx12:
+.incbin "baserom.gba", 0xB9AB20, 0x60
+sMewGfx12_1:
+.incbin "baserom.gba", 0xB9AB80, 0x60
+sMewGfx12_2:
+.incbin "baserom.gba", 0xB9ABE0, 0x60
+sMewSprites12:
+ax_sprite sMewGfx12, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx12_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx12_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx13:
+.incbin "baserom.gba", 0xB9AC78, 0x40
+sMewGfx13_1:
+.incbin "baserom.gba", 0xB9ACB8, 0x60
+sMewGfx13_2:
+.incbin "baserom.gba", 0xB9AD18, 0x60
+sMewGfx13_3:
+.incbin "baserom.gba", 0xB9AD78, 0x60
+sMewSprites13:
+ax_sprite sMewGfx13, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx13_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx13_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx13_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx14:
+.incbin "baserom.gba", 0xB9AE20, 0x60
+sMewGfx14_1:
+.incbin "baserom.gba", 0xB9AE80, 0x60
+sMewGfx14_2:
+.incbin "baserom.gba", 0xB9AEE0, 0x40
+sMewSprites14:
+ax_sprite sMewGfx14, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx14_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMewGfx14_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx15:
+.incbin "baserom.gba", 0xB9AF58, 0x60
+sMewGfx15_1:
+.incbin "baserom.gba", 0xB9AFB8, 0x60
+sMewGfx15_2:
+.incbin "baserom.gba", 0xB9B018, 0x40
+sMewSprites15:
+ax_sprite sMewGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx15_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMewGfx15_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx16:
+.incbin "baserom.gba", 0xB9B090, 0x40
+sMewGfx16_1:
+.incbin "baserom.gba", 0xB9B0D0, 0x60
+sMewGfx16_2:
+.incbin "baserom.gba", 0xB9B130, 0x40
+sMewGfx16_3:
+.incbin "baserom.gba", 0xB9B170, 0x40
+sMewSprites16:
+ax_sprite sMewGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMewGfx16_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx17:
+.incbin "baserom.gba", 0xB9B1F8, 0x60
+sMewGfx17_1:
+.incbin "baserom.gba", 0xB9B258, 0x60
+sMewGfx17_2:
+.incbin "baserom.gba", 0xB9B2B8, 0x60
+sMewSprites17:
+ax_sprite sMewGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx18:
+.incbin "baserom.gba", 0xB9B350, 0x60
+sMewGfx18_1:
+.incbin "baserom.gba", 0xB9B3B0, 0x60
+sMewGfx18_2:
+.incbin "baserom.gba", 0xB9B410, 0x60
+sMewSprites18:
+ax_sprite sMewGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx19:
+.incbin "baserom.gba", 0xB9B4A8, 0x60
+sMewGfx19_1:
+.incbin "baserom.gba", 0xB9B508, 0x60
+sMewGfx19_2:
+.incbin "baserom.gba", 0xB9B568, 0x60
+sMewSprites19:
+ax_sprite sMewGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx20:
+.incbin "baserom.gba", 0xB9B600, 0x60
+sMewGfx20_1:
+.incbin "baserom.gba", 0xB9B660, 0x60
+sMewGfx20_2:
+.incbin "baserom.gba", 0xB9B6C0, 0x60
+sMewSprites20:
+ax_sprite sMewGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx21:
+.incbin "baserom.gba", 0xB9B758, 0x60
+sMewGfx21_1:
+.incbin "baserom.gba", 0xB9B7B8, 0x60
+sMewGfx21_2:
+.incbin "baserom.gba", 0xB9B818, 0x60
+sMewSprites21:
+ax_sprite sMewGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx22:
+.incbin "baserom.gba", 0xB9B8B0, 0x60
+sMewGfx22_1:
+.incbin "baserom.gba", 0xB9B910, 0x60
+sMewGfx22_2:
+.incbin "baserom.gba", 0xB9B970, 0x60
+sMewSprites22:
+ax_sprite sMewGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx23:
+.incbin "baserom.gba", 0xB9BA08, 0x60
+sMewGfx23_1:
+.incbin "baserom.gba", 0xB9BA68, 0x60
+sMewGfx23_2:
+.incbin "baserom.gba", 0xB9BAC8, 0x60
+sMewSprites23:
+ax_sprite sMewGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx24:
+.incbin "baserom.gba", 0xB9BB60, 0x60
+sMewGfx24_1:
+.incbin "baserom.gba", 0xB9BBC0, 0x60
+sMewGfx24_2:
+.incbin "baserom.gba", 0xB9BC20, 0x60
+sMewSprites24:
+ax_sprite sMewGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx25:
+.incbin "baserom.gba", 0xB9BCB8, 0x60
+sMewGfx25_1:
+.incbin "baserom.gba", 0xB9BD18, 0x60
+sMewGfx25_2:
+.incbin "baserom.gba", 0xB9BD78, 0x60
+sMewSprites25:
+ax_sprite sMewGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx26:
+.incbin "baserom.gba", 0xB9BE10, 0x60
+sMewGfx26_1:
+.incbin "baserom.gba", 0xB9BE70, 0x60
+sMewGfx26_2:
+.incbin "baserom.gba", 0xB9BED0, 0x40
+sMewSprites26:
+ax_sprite sMewGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx26_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMewGfx27:
+.incbin "baserom.gba", 0xB9BF48, 0x60
+sMewGfx27_1:
+.incbin "baserom.gba", 0xB9BFA8, 0x60
+sMewGfx27_2:
+.incbin "baserom.gba", 0xB9C008, 0x40
+sMewSprites27:
+ax_sprite sMewGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx27_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sMewGfx28:
+.incbin "baserom.gba", 0xB9C080, 0x60
+sMewGfx28_1:
+.incbin "baserom.gba", 0xB9C0E0, 0x60
+sMewGfx28_2:
+.incbin "baserom.gba", 0xB9C140, 0x60
+sMewSprites28:
+ax_sprite sMewGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx29:
+.incbin "baserom.gba", 0xB9C1D8, 0x60
+sMewGfx29_1:
+.incbin "baserom.gba", 0xB9C238, 0x60
+sMewGfx29_2:
+.incbin "baserom.gba", 0xB9C298, 0x60
+sMewSprites29:
+ax_sprite sMewGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx30:
+.incbin "baserom.gba", 0xB9C330, 0x60
+sMewGfx30_1:
+.incbin "baserom.gba", 0xB9C390, 0x60
+sMewGfx30_2:
+.incbin "baserom.gba", 0xB9C3F0, 0x60
+sMewSprites30:
+ax_sprite sMewGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx31:
+.incbin "baserom.gba", 0xB9C488, 0x60
+sMewGfx31_1:
+.incbin "baserom.gba", 0xB9C4E8, 0x60
+sMewGfx31_2:
+.incbin "baserom.gba", 0xB9C548, 0x60
+sMewSprites31:
+ax_sprite sMewGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx32:
+.incbin "baserom.gba", 0xB9C5E0, 0x60
+sMewGfx32_1:
+.incbin "baserom.gba", 0xB9C640, 0x60
+sMewGfx32_2:
+.incbin "baserom.gba", 0xB9C6A0, 0x60
+sMewSprites32:
+ax_sprite sMewGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx33:
+.incbin "baserom.gba", 0xB9C738, 0x60
+sMewGfx33_1:
+.incbin "baserom.gba", 0xB9C798, 0x60
+sMewGfx33_2:
+.incbin "baserom.gba", 0xB9C7F8, 0x60
+sMewSprites33:
+ax_sprite sMewGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMewGfx34:
+.incbin "baserom.gba", 0xB9C890, 0x40
+sMewGfx34_1:
+.incbin "baserom.gba", 0xB9C8D0, 0x60
+sMewGfx34_2:
+.incbin "baserom.gba", 0xB9C930, 0x60
+sMewGfx34_3:
+.incbin "baserom.gba", 0xB9C990, 0x40
+sMewSprites34:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx34_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMewGfx35:
+.incbin "baserom.gba", 0xB9CA20, 0x40
+sMewGfx35_1:
+.incbin "baserom.gba", 0xB9CA60, 0x60
+sMewGfx35_2:
+.incbin "baserom.gba", 0xB9CAC0, 0x60
+sMewSprites35:
+ax_sprite 0, 0xa0
+ax_sprite sMewGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx35_2, 0x60
+ax_sprite_terminator
+sMewGfx36:
+.incbin "baserom.gba", 0xB9CB58, 0x60
+sMewGfx36_1:
+.incbin "baserom.gba", 0xB9CBB8, 0xE0
+sMewSprites36:
+ax_sprite 0, 0x80
+ax_sprite sMewGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx36_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx37:
+.incbin "baserom.gba", 0xB9CCC8, 0x40
+sMewGfx37_1:
+.incbin "baserom.gba", 0xB9CD08, 0x100
+sMewSprites37:
+ax_sprite 0, 0xa0
+ax_sprite sMewGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx37_1, 0x100
+ax_sprite_terminator
+sMewGfx38:
+.incbin "baserom.gba", 0xB9CE30, 0x60
+sMewGfx38_1:
+.incbin "baserom.gba", 0xB9CE90, 0xE0
+sMewSprites38:
+ax_sprite 0, 0x80
+ax_sprite sMewGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx38_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx39:
+.incbin "baserom.gba", 0xB9CFA0, 0x20
+sMewGfx39_1:
+.incbin "baserom.gba", 0xB9CFC0, 0x40
+sMewGfx39_2:
+.incbin "baserom.gba", 0xB9D000, 0x80
+sMewGfx39_3:
+.incbin "baserom.gba", 0xB9D080, 0x40
+sMewSprites39:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx39, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMewGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx39_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMewGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx40:
+.incbin "baserom.gba", 0xB9D110, 0x20
+sMewGfx40_1:
+.incbin "baserom.gba", 0xB9D130, 0x40
+sMewGfx40_2:
+.incbin "baserom.gba", 0xB9D170, 0x80
+sMewGfx40_3:
+.incbin "baserom.gba", 0xB9D1F0, 0x60
+sMewSprites40:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx40, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMewGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx40_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMewGfx40_3, 0x60
+ax_sprite_terminator
+sMewGfx41:
+.incbin "baserom.gba", 0xB9D298, 0x40
+sMewGfx41_1:
+.incbin "baserom.gba", 0xB9D2D8, 0x60
+sMewGfx41_2:
+.incbin "baserom.gba", 0xB9D338, 0x60
+sMewGfx41_3:
+.incbin "baserom.gba", 0xB9D398, 0x60
+sMewSprites41:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx41_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx42:
+.incbin "baserom.gba", 0xB9D448, 0x40
+sMewGfx42_1:
+.incbin "baserom.gba", 0xB9D488, 0x60
+sMewGfx42_2:
+.incbin "baserom.gba", 0xB9D4E8, 0x60
+sMewGfx42_3:
+.incbin "baserom.gba", 0xB9D548, 0x40
+sMewSprites42:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx42_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMewGfx42_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMewGfx42_3, 0x40
+ax_sprite_terminator
+sMewGfx43:
+.incbin "baserom.gba", 0xB9D5D0, 0x40
+sMewGfx43_1:
+.incbin "baserom.gba", 0xB9D610, 0x60
+sMewGfx43_2:
+.incbin "baserom.gba", 0xB9D670, 0x60
+sMewSprites43:
+ax_sprite 0, 0xa0
+ax_sprite sMewGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx44:
+.incbin "baserom.gba", 0xB9D710, 0x40
+sMewGfx44_1:
+.incbin "baserom.gba", 0xB9D750, 0x40
+sMewGfx44_2:
+.incbin "baserom.gba", 0xB9D790, 0x60
+sMewSprites44:
+ax_sprite 0, 0xa0
+ax_sprite sMewGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx44_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx45:
+.incbin "baserom.gba", 0xB9D830, 0x40
+sMewGfx45_1:
+.incbin "baserom.gba", 0xB9D870, 0x40
+sMewGfx45_2:
+.incbin "baserom.gba", 0xB9D8B0, 0x60
+sMewGfx45_3:
+.incbin "baserom.gba", 0xB9D910, 0x60
+sMewSprites45:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx45_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx45_3, 0x60
+ax_sprite_terminator
+sMewGfx46:
+.incbin "baserom.gba", 0xB9D9B8, 0x40
+sMewGfx46_1:
+.incbin "baserom.gba", 0xB9D9F8, 0x60
+sMewGfx46_2:
+.incbin "baserom.gba", 0xB9DA58, 0xE0
+sMewSprites46:
+ax_sprite 0, 0x40
+ax_sprite sMewGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx46_2, 0xe0
+ax_sprite_terminator
+sMewGfx47:
+.incbin "baserom.gba", 0xB9DB70, 0x60
+sMewGfx47_1:
+.incbin "baserom.gba", 0xB9DBD0, 0x60
+sMewGfx47_2:
+.incbin "baserom.gba", 0xB9DC30, 0x60
+sMewSprites47:
+ax_sprite 0, 0xa0
+ax_sprite sMewGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx47_2, 0x60
+ax_sprite_terminator
+sMewGfx48:
+.incbin "baserom.gba", 0xB9DCC8, 0x60
+sMewGfx48_1:
+.incbin "baserom.gba", 0xB9DD28, 0x60
+sMewGfx48_2:
+.incbin "baserom.gba", 0xB9DD88, 0x40
+sMewSprites48:
+ax_sprite 0, 0xa0
+ax_sprite sMewGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx48_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx49:
+.incbin "baserom.gba", 0xB9DE08, 0x40
+sMewGfx49_1:
+.incbin "baserom.gba", 0xB9DE48, 0x60
+sMewGfx49_2:
+.incbin "baserom.gba", 0xB9DEA8, 0x60
+sMewSprites49:
+ax_sprite 0, 0xa0
+ax_sprite sMewGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx50:
+.incbin "baserom.gba", 0xB9DF48, 0x60
+sMewGfx50_1:
+.incbin "baserom.gba", 0xB9DFA8, 0x60
+sMewGfx50_2:
+.incbin "baserom.gba", 0xB9E008, 0x60
+sMewSprites50:
+ax_sprite 0, 0x80
+ax_sprite sMewGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx51:
+.incbin "baserom.gba", 0xB9E0A8, 0x20
+sMewGfx51_1:
+.incbin "baserom.gba", 0xB9E0C8, 0x40
+sMewGfx51_2:
+.incbin "baserom.gba", 0xB9E108, 0x60
+sMewGfx51_3:
+.incbin "baserom.gba", 0xB9E168, 0x40
+sMewSprites51:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx51, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMewGfx51_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewGfx51_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMewGfx51_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx52:
+.incbin "baserom.gba", 0xB9E1F8, 0x20
+sMewGfx52_1:
+.incbin "baserom.gba", 0xB9E218, 0x40
+sMewGfx52_2:
+.incbin "baserom.gba", 0xB9E258, 0x40
+sMewGfx52_3:
+.incbin "baserom.gba", 0xB9E298, 0x40
+sMewSprites52:
+ax_sprite 0, 0x20
+ax_sprite sMewGfx52, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMewGfx52_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx52_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewGfx52_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewGfx53:
+.incbin "baserom.gba", 0xB9E328, 0x200
+sMewSprites53:
+ax_sprite sMewGfx53, 0x200
+ax_sprite_terminator
+sMewGfx54:
+.incbin "baserom.gba", 0xB9E538, 0x200
+sMewSprites54:
+ax_sprite sMewGfx54, 0x200
+ax_sprite_terminator
+sMewGfx55:
+.incbin "baserom.gba", 0xB9E748, 0x200
+sMewSprites55:
+ax_sprite sMewGfx55, 0x200
+ax_sprite_terminator
+sMewGfx56:
+.incbin "baserom.gba", 0xB9E958, 0x200
+sMewSprites56:
+ax_sprite sMewGfx56, 0x200
+ax_sprite_terminator
+sMewGfx57:
+.incbin "baserom.gba", 0xB9EB68, 0x200
+sMewSprites57:
+ax_sprite sMewGfx57, 0x200
+ax_sprite_terminator
+sMewGfx58:
+.incbin "baserom.gba", 0xB9ED78, 0x200
+sMewSprites58:
+ax_sprite sMewGfx58, 0x200
+ax_sprite_terminator
+sMewGfx59:
+.incbin "baserom.gba", 0xB9EF88, 0x200
+sMewSprites59:
+ax_sprite sMewGfx59, 0x200
+ax_sprite_terminator
+sAxPosesMew:
+.4byte sMewPose1
+.4byte sMewPose2
+.4byte sMewPose3
+.4byte sMewPose4
+.4byte sMewPose5
+.4byte sMewPose6
+.4byte sMewPose7
+.4byte sMewPose8
+.4byte sMewPose9
+.4byte sMewPose10
+.4byte sMewPose11
+.4byte sMewPose12
+.4byte sMewPose13
+.4byte sMewPose14
+.4byte sMewPose15
+.4byte sMewPose16
+.4byte sMewPose17
+.4byte sMewPose18
+.4byte sMewPose19
+.4byte sMewPose20
+.4byte sMewPose21
+.4byte sMewPose22
+.4byte sMewPose23
+.4byte sMewPose24
+.4byte sMewPose25
+.4byte sMewPose26
+.4byte sMewPose27
+.4byte sMewPose28
+.4byte sMewPose29
+.4byte sMewPose30
+.4byte sMewPose31
+.4byte sMewPose32
+.4byte sMewPose33
+.4byte sMewPose34
+.4byte sMewPose35
+.4byte sMewPose36
+.4byte sMewPose37
+.4byte sMewPose38
+.4byte sMewPose39
+.4byte sMewPose40
+.4byte sMewPose41
+.4byte sMewPose42
+.4byte sMewPose43
+.4byte sMewPose44
+.4byte sMewPose45
+.4byte sMewPose46
+.4byte sMewPose47
+.4byte sMewPose48
+.4byte sMewPose49
+.4byte sMewPose50
+.4byte sMewPose51
+.4byte sMewPose52
+.4byte sMewPose53
+.4byte sMewPose54
+.4byte sMewPose55
+.4byte sMewPose56
+.4byte sMewPose57
+.4byte sMewPose58
+.4byte sMewPose59
+.4byte sMewPose60
+.4byte sMewPose61
+.4byte sMewPose62
+.4byte sMewPose63
+.4byte sMewPose64
+.4byte sMewPose65
+.4byte sMewPose66
+.4byte sMewPose67
+.4byte sMewPose68
+.4byte sMewPose69
+.4byte sMewPose70
+.4byte sMewPose71
+.4byte sMewPose72
+.4byte sMewPose73
+.4byte sMewPose74
+.4byte sMewPose75
+.4byte sMewPose76
+.4byte sMewPose77
+.4byte sMewPose78
+.4byte sMewPose79
+.4byte sMewPose80
+.4byte sMewPose81
+.4byte sMewPose82
+.4byte sMewPose83
+.4byte sMewPose84
+.4byte sMewPose85
+.4byte sMewPose86
+.4byte sMewPose87
+.4byte sMewPose88
+.4byte sMewPose89
+.4byte sMewPose90
+.4byte sMewPose91
+.4byte sMewPose92
+.4byte sMewPose93
+.4byte sMewPose94
+.4byte sMewPose95
+.4byte sMewPose96
+.4byte sMewPose97
+.4byte sMewPose98
+.4byte sMewPose99
+.4byte sMewPose100
+.4byte sMewPose101
+.4byte sMewPose102
+.4byte sMewPose103
+.4byte sMewPose104
+.4byte sMewPose105
+.4byte sMewPose106
+.4byte sMewPose107
+.4byte sMewPose108
+.4byte sMewPose109
+.4byte sMewPose110
+.4byte sMewPose111
+.4byte sMewPose112
+.4byte sMewPose113
+.4byte sMewPose114
+.4byte sMewPose115
+.4byte sMewPose116
+.4byte sMewPose117
+.4byte sMewPose118
+.4byte sMewPose119
+.4byte sMewPose120
+.4byte sMewPose121
+.4byte sMewPose122
+.4byte sMewPose123
+.4byte sMewPose124
+.4byte sMewPose125
+.4byte sMewPose126
+.4byte sMewPose127
+.4byte sMewPose128
+.4byte sMewPose129
+.4byte sMewPose130
+.4byte sMewPose131
+.4byte sMewPose132
+.4byte sMewPose133
+.4byte sMewPose134
+.4byte sMewPose135
+.4byte sMewPose136
+.4byte sMewPose137
+.4byte sMewPose138
+.4byte sMewPose139
+.4byte sMewPose140
+.4byte sMewPose141
+.4byte sMewPose142
+.4byte sMewPose143
+.4byte sMewPose144
+.4byte sMewPose145
+.4byte sMewPose146
+.4byte sMewPose147
+.4byte sMewPose148
+.4byte sMewPose149
+.4byte sMewPose150
+.4byte sMewPose151
+.4byte sMewPose152
+.4byte sMewPose153
+.4byte sMewPose154
+.4byte sMewPose155
+.4byte sMewPose156
+.4byte sMewPose157
+.4byte sMewPose158
+.4byte sMewPose159
+.4byte sMewPose160
+.4byte sMewPose161
+.4byte sMewPose162
+.4byte sMewPose163
+.4byte sMewPose164
+.4byte sMewPose165
+.4byte sMewPose166
+.4byte sMewPose167
+.4byte sMewPose168
+.4byte sMewPose169
+.4byte sMewPose170
+.4byte sMewPose171
+.4byte sMewPose172
+.4byte sMewPose173
+.4byte sMewPose174
+.4byte sMewPose175
+.4byte sMewPose176
+.4byte sMewPose177
+.4byte sMewPose178
+.4byte sMewPose179
+.4byte sMewPose180
+sAxPositionsMew:
+.2byte    0,  -11, 	  -3,   -9, 	   2,   -9, 	   0,  -12
+.2byte    0,  -11, 	  -3,   -9, 	   2,   -9, 	   0,  -12
+.2byte    5,  -13, 	   3,  -11, 	   0,  -10, 	  -1,  -13
+.2byte    4,  -12, 	   3,  -11, 	   0,  -10, 	  -1,  -12
+.2byte   10,  -14, 	   3,  -11, 	   1,  -11, 	   1,  -13
+.2byte    9,  -14, 	   3,  -11, 	   1,  -10, 	   0,  -12
+.2byte    5,  -16, 	  -2,  -13, 	   4,  -12, 	   1,  -13
+.2byte    5,  -18, 	   0,  -13, 	   4,  -12, 	  -1,  -12
+.2byte   -1,  -20, 	   3,  -13, 	  -4,  -13, 	   0,  -15
+.2byte   -1,  -20, 	   3,  -13, 	  -4,  -13, 	   0,  -15
+.2byte   -5,  -16, 	   2,  -13, 	  -4,  -12, 	  -1,  -13
+.2byte   -5,  -18, 	   0,  -13, 	  -4,  -12, 	   1,  -12
+.2byte  -10,  -14, 	  -3,  -11, 	  -1,  -11, 	  -1,  -13
+.2byte   -9,  -14, 	  -3,  -11, 	  -1,  -10, 	   0,  -12
+.2byte   -7,  -13, 	  -5,  -11, 	  -2,  -10, 	  -1,  -13
+.2byte   -6,  -12, 	  -5,  -11, 	  -2,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	  -5,  -11, 	   4,  -11, 	   0,  -13
+.2byte   -1,  -14, 	  -4,  -12, 	   3,  -12, 	   0,  -13
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte    3,  -14, 	  -2,  -11, 	   6,  -13, 	   1,  -12
+.2byte    3,  -14, 	  -2,  -11, 	   6,  -13, 	   2,  -12
+.2byte    3,  -13, 	  -2,  -11, 	   4,  -12, 	  -1,  -12
+.2byte    4,  -15, 	   0,  -10, 	   1,  -13, 	   1,  -11
+.2byte    4,  -15, 	   0,  -10, 	   1,  -12, 	   0,  -11
+.2byte    4,  -14, 	   1,  -11, 	   0,  -12, 	  -1,  -10
+.2byte    3,  -16, 	   2,  -12, 	   1,  -15, 	   1,  -12
+.2byte    3,  -16, 	   2,  -12, 	   1,  -14, 	   0,  -13
+.2byte    3,  -15, 	   2,  -12, 	  -2,  -14, 	  -1,  -10
+.2byte    0,  -17, 	   3,  -13, 	  -4,  -13, 	   0,  -12
+.2byte    0,  -17, 	   4,  -11, 	  -4,  -13, 	   0,  -12
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -2,  -17, 	  -2,  -15, 	  -3,  -12, 	  -1,  -13
+.2byte   -2,  -17, 	   1,  -13, 	  -5,  -12, 	  -1,  -12
+.2byte   -2,  -17, 	   1,  -14, 	  -3,  -12, 	   0,  -11
+.2byte   -5,  -16, 	  -2,  -12, 	  -1,  -11, 	  -1,  -12
+.2byte   -5,  -16, 	  -3,  -12, 	  -1,  -11, 	  -1,  -12
+.2byte   -5,  -15, 	  -2,  -12, 	  -2,  -10, 	   0,  -12
+.2byte   -4,  -15, 	  -7,  -13, 	   1,  -11, 	  -3,  -12
+.2byte   -4,  -15, 	  -7,  -13, 	  -2,  -12, 	  -3,  -13
+.2byte   -4,  -14, 	  -5,  -12, 	   1,  -11, 	   0,  -12
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -14, 	  -5,  -11, 	   4,  -11, 	   0,  -13
+.2byte   -1,  -14, 	  -4,  -12, 	   3,  -12, 	   0,  -13
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte    3,  -14, 	  -2,  -11, 	   6,  -13, 	   1,  -12
+.2byte    3,  -14, 	  -2,  -11, 	   6,  -13, 	   2,  -12
+.2byte    3,  -13, 	  -2,  -11, 	   4,  -12, 	  -1,  -12
+.2byte    4,  -15, 	   0,  -10, 	   1,  -13, 	   1,  -11
+.2byte    4,  -15, 	   0,  -10, 	   1,  -12, 	   0,  -11
+.2byte    4,  -14, 	   1,  -11, 	   0,  -12, 	  -1,  -10
+.2byte    3,  -16, 	   2,  -12, 	   1,  -15, 	   1,  -12
+.2byte    3,  -16, 	   2,  -12, 	   1,  -14, 	   0,  -13
+.2byte    3,  -15, 	   2,  -12, 	  -2,  -14, 	  -1,  -10
+.2byte    0,  -17, 	   3,  -13, 	  -4,  -13, 	   0,  -12
+.2byte    0,  -17, 	   4,  -11, 	  -4,  -13, 	   0,  -12
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -2,  -17, 	  -2,  -15, 	  -3,  -12, 	  -1,  -13
+.2byte   -2,  -17, 	   1,  -13, 	  -5,  -12, 	  -1,  -12
+.2byte   -2,  -17, 	   1,  -14, 	  -3,  -12, 	   0,  -11
+.2byte   -5,  -16, 	  -2,  -12, 	  -1,  -11, 	  -1,  -12
+.2byte   -5,  -16, 	  -3,  -12, 	  -1,  -11, 	  -1,  -12
+.2byte   -5,  -15, 	  -2,  -12, 	  -2,  -10, 	   0,  -12
+.2byte   -4,  -15, 	  -7,  -13, 	   1,  -11, 	  -3,  -12
+.2byte   -4,  -15, 	  -7,  -13, 	  -2,  -12, 	  -3,  -13
+.2byte   -4,  -14, 	  -5,  -12, 	   1,  -11, 	   0,  -12
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte    0,  -12, 	  -4,  -11, 	   5,  -10, 	   1,  -11
+.2byte   -1,  -12, 	  -4,  -11, 	   5,  -11, 	   1,  -11
+.2byte    3,  -13, 	  -2,  -11, 	   4,  -12, 	  -1,  -12
+.2byte    0,  -13, 	   3,  -12, 	  -1,  -11, 	  -1,  -10
+.2byte    1,  -13, 	   4,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    4,  -14, 	   1,  -11, 	   0,  -12, 	  -1,  -10
+.2byte    2,  -14, 	   1,  -12, 	   0,   -9, 	   1,  -10
+.2byte    3,  -14, 	   1,  -12, 	  -1,  -10, 	   0,  -10
+.2byte    3,  -15, 	   2,  -12, 	  -2,  -14, 	  -1,  -10
+.2byte    0,  -16, 	   1,  -13, 	   2,  -12, 	   0,  -10
+.2byte   -1,  -16, 	  -1,  -13, 	   2,  -11, 	  -1,  -10
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -11, 	  -4,  -11, 	   0,  -11
+.2byte    0,  -16, 	   5,  -10, 	  -5,  -12, 	   0,  -11
+.2byte   -2,  -17, 	   1,  -14, 	  -3,  -12, 	   0,  -11
+.2byte   -1,  -16, 	  -2,  -13, 	  -3,  -12, 	  -1,  -10
+.2byte    0,  -16, 	   0,  -13, 	  -3,  -11, 	   0,  -10
+.2byte   -5,  -15, 	  -2,  -12, 	  -2,  -10, 	   0,  -12
+.2byte   -3,  -15, 	  -2,  -13, 	  -1,  -10, 	  -2,  -11
+.2byte   -4,  -15, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -4,  -14, 	  -5,  -12, 	   1,  -11, 	   0,  -12
+.2byte   -1,  -13, 	  -4,  -12, 	   0,  -11, 	   0,  -10
+.2byte   -2,  -13, 	  -5,  -12, 	   2,  -11, 	   0,  -11
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte   -4,  -14, 	  -5,  -12, 	   1,  -11, 	   0,  -12
+.2byte   -5,  -15, 	  -2,  -12, 	  -2,  -10, 	   0,  -12
+.2byte   -2,  -17, 	   1,  -14, 	  -3,  -12, 	   0,  -11
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte    3,  -15, 	   2,  -12, 	  -2,  -14, 	  -1,  -10
+.2byte    4,  -14, 	   1,  -11, 	   0,  -12, 	  -1,  -10
+.2byte    3,  -13, 	  -2,  -11, 	   4,  -12, 	  -1,  -12
+.2byte   -1,  -11, 	  -4,  -12, 	   2,  -10, 	   0,  -10
+.2byte   -3,  -12, 	  -4,  -11, 	   0,   -9, 	   0,  -11
+.2byte   -3,  -13, 	  -3,  -11, 	  -2,   -9, 	   0,  -11
+.2byte   -2,  -13, 	   1,  -11, 	  -4,   -9, 	   1,   -9
+.2byte   -2,  -15, 	   3,  -11, 	  -4,  -11, 	  -2,  -11
+.2byte    0,  -15, 	  -1,  -11, 	  -4,  -12, 	  -2,  -10
+.2byte    2,  -13, 	  -2,  -11, 	   0,  -12, 	  -2,  -12
+.2byte    2,  -12, 	  -3,  -11, 	   4,   -9, 	  -1,  -11
+.2byte   -4,  -12, 	  -6,  -11, 	   0,  -10, 	   0,  -11
+.2byte   -5,  -11, 	  -6,  -10, 	   0,   -9, 	  -1,  -10
+.2byte    0,  -17, 	  -5,  -13, 	   4,  -13, 	   0,  -14
+.2byte   -3,  -18, 	   0,  -14, 	  -7,  -10, 	  -2,  -12
+.2byte   -1,  -18, 	  -5,  -12, 	  -6,   -9, 	  -1,  -11
+.2byte   -3,  -17, 	  -6,  -11, 	  -1,   -9, 	  -2,  -10
+.2byte    0,  -15, 	   5,   -9, 	  -6,   -9, 	  -1,  -11
+.2byte    2,  -17, 	   5,  -11, 	   0,   -9, 	   1,  -10
+.2byte    0,  -18, 	   4,  -12, 	   5,   -9, 	   0,  -11
+.2byte    2,  -18, 	  -1,  -14, 	   6,  -10, 	   1,  -12
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte    3,  -13, 	  -2,  -11, 	   4,  -12, 	  -1,  -12
+.2byte    4,  -14, 	   1,  -11, 	   0,  -12, 	  -1,  -10
+.2byte    3,  -15, 	   2,  -12, 	  -2,  -14, 	  -1,  -10
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -2,  -17, 	   1,  -14, 	  -3,  -12, 	   0,  -11
+.2byte   -5,  -15, 	  -2,  -12, 	  -2,  -10, 	   0,  -12
+.2byte   -4,  -14, 	  -5,  -12, 	   1,  -11, 	   0,  -12
+.2byte    0,  -11, 	  -3,   -9, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -12, 	  -5,  -11, 	  -2,  -10, 	  -1,  -12
+.2byte   -9,  -14, 	  -3,  -11, 	  -1,  -10, 	   0,  -12
+.2byte   -5,  -18, 	   0,  -13, 	  -4,  -12, 	   1,  -12
+.2byte   -1,  -18, 	   3,  -11, 	  -4,  -11, 	   0,  -13
+.2byte    4,  -18, 	  -1,  -13, 	   3,  -12, 	  -2,  -12
+.2byte    9,  -14, 	   3,  -11, 	   1,  -10, 	   0,  -12
+.2byte    5,  -12, 	   4,  -11, 	   1,  -10, 	   0,  -12
+.2byte    0,  -11, 	  -3,   -9, 	   2,   -9, 	   0,  -12
+.2byte    5,  -12, 	   4,  -11, 	   1,  -10, 	   0,  -12
+.2byte    9,  -14, 	   3,  -11, 	   1,  -10, 	   0,  -12
+.2byte    4,  -18, 	  -1,  -13, 	   3,  -12, 	  -2,  -12
+.2byte   -1,  -18, 	   3,  -11, 	  -4,  -11, 	   0,  -13
+.2byte   -5,  -18, 	   0,  -13, 	  -4,  -12, 	   1,  -12
+.2byte   -9,  -14, 	  -3,  -11, 	  -1,  -10, 	   0,  -12
+.2byte   -6,  -12, 	  -5,  -11, 	  -2,  -10, 	  -1,  -12
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte   -1,  -14, 	  -4,  -12, 	   3,  -12, 	   0,  -13
+.2byte    0,  -11, 	  -3,   -9, 	   2,   -9, 	   0,  -12
+.2byte    3,  -13, 	  -2,  -11, 	   4,  -12, 	  -1,  -12
+.2byte    2,  -14, 	  -3,  -11, 	   5,  -13, 	   1,  -12
+.2byte    5,  -12, 	   4,  -11, 	   1,  -10, 	   0,  -12
+.2byte    4,  -14, 	   1,  -11, 	   0,  -12, 	  -1,  -10
+.2byte    4,  -15, 	   0,  -10, 	   1,  -12, 	   0,  -11
+.2byte    9,  -14, 	   3,  -11, 	   1,  -10, 	   0,  -12
+.2byte    3,  -15, 	   2,  -12, 	  -2,  -14, 	  -1,  -10
+.2byte    3,  -16, 	   2,  -12, 	   1,  -14, 	   0,  -13
+.2byte    5,  -18, 	   0,  -13, 	   4,  -12, 	  -1,  -12
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte    0,  -17, 	   4,  -11, 	  -4,  -13, 	   0,  -12
+.2byte   -1,  -20, 	   3,  -13, 	  -4,  -13, 	   0,  -15
+.2byte   -2,  -17, 	   1,  -14, 	  -3,  -12, 	   0,  -11
+.2byte   -2,  -17, 	   1,  -13, 	  -5,  -12, 	  -1,  -12
+.2byte   -5,  -18, 	   0,  -13, 	  -4,  -12, 	   1,  -12
+.2byte   -5,  -15, 	  -2,  -12, 	  -2,  -10, 	   0,  -12
+.2byte   -5,  -16, 	  -3,  -12, 	  -1,  -11, 	  -1,  -12
+.2byte   -9,  -14, 	  -3,  -11, 	  -1,  -10, 	   0,  -12
+.2byte   -4,  -14, 	  -5,  -12, 	   1,  -11, 	   0,  -12
+.2byte   -3,  -15, 	  -6,  -13, 	  -1,  -12, 	  -2,  -13
+.2byte   -6,  -12, 	  -5,  -11, 	  -2,  -10, 	  -1,  -12
+.2byte   -1,  -12, 	  -5,  -11, 	   4,  -10, 	   0,  -11
+.2byte   -1,  -13, 	  -4,  -12, 	   0,  -11, 	   0,  -10
+.2byte   -3,  -15, 	  -2,  -13, 	  -1,  -10, 	  -2,  -11
+.2byte   -1,  -16, 	  -2,  -13, 	  -3,  -12, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -11, 	  -4,  -11, 	   0,  -11
+.2byte    0,  -16, 	   1,  -13, 	   2,  -12, 	   0,  -10
+.2byte    2,  -14, 	   1,  -12, 	   0,   -9, 	   1,  -10
+.2byte    1,  -13, 	   4,  -12, 	   0,  -11, 	   0,  -10
+.2byte   -1,  -13, 	  -5,  -10, 	   4,  -10, 	   0,  -12
+.2byte   -4,  -14, 	  -5,  -12, 	   1,  -11, 	   0,  -12
+.2byte   -5,  -15, 	  -2,  -12, 	  -2,  -10, 	   0,  -12
+.2byte   -2,  -17, 	   1,  -14, 	  -3,  -12, 	   0,  -11
+.2byte   -1,  -17, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte    3,  -15, 	   2,  -12, 	  -2,  -14, 	  -1,  -10
+.2byte    4,  -14, 	   1,  -11, 	   0,  -12, 	  -1,  -10
+.2byte    3,  -13, 	  -2,  -11, 	   4,  -12, 	  -1,  -12
+sMewAnimTable1:
+.4byte sMewAnims_1_1
+.4byte sMewAnims_1_2
+.4byte sMewAnims_1_3
+.4byte sMewAnims_1_4
+.4byte sMewAnims_1_5
+.4byte sMewAnims_1_6
+.4byte sMewAnims_1_7
+.4byte sMewAnims_1_8
+sMewAnimTable2:
+.4byte sMewAnims_2_1
+.4byte sMewAnims_2_2
+.4byte sMewAnims_2_3
+.4byte sMewAnims_2_4
+.4byte sMewAnims_2_5
+.4byte sMewAnims_2_6
+.4byte sMewAnims_2_7
+.4byte sMewAnims_2_8
+sMewAnimTable3:
+.4byte sMewAnims_3_1
+.4byte sMewAnims_3_2
+.4byte sMewAnims_3_3
+.4byte sMewAnims_3_4
+.4byte sMewAnims_3_5
+.4byte sMewAnims_3_6
+.4byte sMewAnims_3_7
+.4byte sMewAnims_3_8
+sMewAnimTable4:
+.4byte sMewAnims_4_1
+.4byte sMewAnims_4_2
+.4byte sMewAnims_4_3
+.4byte sMewAnims_4_4
+.4byte sMewAnims_4_5
+.4byte sMewAnims_4_6
+.4byte sMewAnims_4_7
+.4byte sMewAnims_4_8
+sMewAnimTable5:
+.4byte sMewAnims_5_1
+.4byte sMewAnims_5_2
+.4byte sMewAnims_5_3
+.4byte sMewAnims_5_4
+.4byte sMewAnims_5_5
+.4byte sMewAnims_5_6
+.4byte sMewAnims_5_7
+.4byte sMewAnims_5_8
+sMewAnimTable6:
+.4byte sMewAnims_6_1
+.4byte sMewAnims_6_1
+.4byte sMewAnims_6_1
+.4byte sMewAnims_6_1
+.4byte sMewAnims_6_1
+.4byte sMewAnims_6_1
+.4byte sMewAnims_6_1
+.4byte sMewAnims_6_1
+sMewAnimTable7:
+.4byte sMewAnims_7_1
+.4byte sMewAnims_7_2
+.4byte sMewAnims_7_3
+.4byte sMewAnims_7_4
+.4byte sMewAnims_7_5
+.4byte sMewAnims_7_6
+.4byte sMewAnims_7_7
+.4byte sMewAnims_7_8
+sMewAnimTable8:
+.4byte sMewAnims_8_1
+.4byte sMewAnims_8_2
+.4byte sMewAnims_8_3
+.4byte sMewAnims_8_4
+.4byte sMewAnims_8_5
+.4byte sMewAnims_8_6
+.4byte sMewAnims_8_7
+.4byte sMewAnims_8_8
+sMewAnimTable9:
+.4byte sMewAnims_9_1
+.4byte sMewAnims_9_2
+.4byte sMewAnims_9_3
+.4byte sMewAnims_9_4
+.4byte sMewAnims_9_5
+.4byte sMewAnims_9_6
+.4byte sMewAnims_9_7
+.4byte sMewAnims_9_8
+sMewAnimTable10:
+.4byte sMewAnims_10_1
+.4byte sMewAnims_10_2
+.4byte sMewAnims_10_3
+.4byte sMewAnims_10_4
+.4byte sMewAnims_10_5
+.4byte sMewAnims_10_6
+.4byte sMewAnims_10_7
+.4byte sMewAnims_10_8
+sMewAnimTable11:
+.4byte sMewAnims_11_1
+.4byte sMewAnims_11_2
+.4byte sMewAnims_11_3
+.4byte sMewAnims_11_4
+.4byte sMewAnims_11_5
+.4byte sMewAnims_11_6
+.4byte sMewAnims_11_7
+.4byte sMewAnims_11_8
+sMewAnimTable12:
+.4byte sMewAnims_12_1
+.4byte sMewAnims_12_2
+.4byte sMewAnims_12_3
+.4byte sMewAnims_12_4
+.4byte sMewAnims_12_5
+.4byte sMewAnims_12_6
+.4byte sMewAnims_12_7
+.4byte sMewAnims_12_8
+sMewAnimTable13:
+.4byte sMewAnims_13_1
+.4byte sMewAnims_13_2
+.4byte sMewAnims_13_3
+.4byte sMewAnims_13_4
+.4byte sMewAnims_13_5
+.4byte sMewAnims_13_6
+.4byte sMewAnims_13_7
+.4byte sMewAnims_13_8
+sAxAnimationsMew:
+.4byte sMewAnimTable1
+.4byte sMewAnimTable2
+.4byte sMewAnimTable3
+.4byte sMewAnimTable4
+.4byte sMewAnimTable5
+.4byte sMewAnimTable6
+.4byte sMewAnimTable7
+.4byte sMewAnimTable8
+.4byte sMewAnimTable9
+.4byte sMewAnimTable10
+.4byte sMewAnimTable11
+.4byte sMewAnimTable12
+.4byte sMewAnimTable13
+sAxSpritesMew:
+.4byte sMewSprites1
+.4byte sMewSprites2
+.4byte sMewSprites3
+.4byte sMewSprites4
+.4byte sMewSprites5
+.4byte sMewSprites6
+.4byte sMewSprites7
+.4byte sMewSprites8
+.4byte sMewSprites9
+.4byte sMewSprites10
+.4byte sMewSprites11
+.4byte sMewSprites12
+.4byte sMewSprites13
+.4byte sMewSprites14
+.4byte sMewSprites15
+.4byte sMewSprites16
+.4byte sMewSprites17
+.4byte sMewSprites18
+.4byte sMewSprites19
+.4byte sMewSprites20
+.4byte sMewSprites21
+.4byte sMewSprites22
+.4byte sMewSprites23
+.4byte sMewSprites24
+.4byte sMewSprites25
+.4byte sMewSprites26
+.4byte sMewSprites27
+.4byte sMewSprites28
+.4byte sMewSprites29
+.4byte sMewSprites30
+.4byte sMewSprites31
+.4byte sMewSprites32
+.4byte sMewSprites33
+.4byte sMewSprites34
+.4byte sMewSprites35
+.4byte sMewSprites36
+.4byte sMewSprites37
+.4byte sMewSprites38
+.4byte sMewSprites39
+.4byte sMewSprites40
+.4byte sMewSprites41
+.4byte sMewSprites42
+.4byte sMewSprites43
+.4byte sMewSprites44
+.4byte sMewSprites45
+.4byte sMewSprites46
+.4byte sMewSprites47
+.4byte sMewSprites48
+.4byte sMewSprites49
+.4byte sMewSprites50
+.4byte sMewSprites51
+.4byte sMewSprites52
+.4byte sMewSprites53
+.4byte sMewSprites54
+.4byte sMewSprites55
+.4byte sMewSprites56
+.4byte sMewSprites57
+.4byte sMewSprites58
+.4byte sMewSprites59
+sAxMainMew:
+ax_main sAxPosesMew, sAxAnimationsMew, 13, sAxSpritesMew, sAxPositionsMew

--- a/data/ax/mewtwo.inc
+++ b/data/ax/mewtwo.inc
@@ -1,0 +1,3165 @@
+.global gAxMewtwo
+gAxMewtwo:
+ax_siro sAxMainMewtwo
+sMewtwoPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose2:
+ax_pose 1, 0x01e3, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose3:
+ax_pose 2, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose4:
+ax_pose 3, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose5:
+ax_pose 4, 0x01e2, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose6:
+ax_pose 5, 0x01e2, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose7:
+ax_pose 6, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose8:
+ax_pose 7, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose9:
+ax_pose 8, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose10:
+ax_pose 9, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose11:
+ax_pose 6, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose12:
+ax_pose 7, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose13:
+ax_pose 4, 0x01e2, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose14:
+ax_pose 5, 0x01e2, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose15:
+ax_pose 2, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose16:
+ax_pose 3, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose17:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose18:
+ax_pose 1, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose19:
+ax_pose 2, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose20:
+ax_pose 3, 0x01e1, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose21:
+ax_pose 4, 0x01e2, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose22:
+ax_pose 5, 0x01e1, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose23:
+ax_pose 6, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose24:
+ax_pose 7, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sMewtwoPose25:
+ax_pose 8, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose26:
+ax_pose 9, 0x01e0, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose27:
+ax_pose 6, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose28:
+ax_pose 7, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose29:
+ax_pose 4, 0x01e2, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose30:
+ax_pose 5, 0x01e1, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose31:
+ax_pose 2, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose32:
+ax_pose 3, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose33:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose34:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose35:
+ax_pose 12, 0x01e8, 0x80f0, 0x7c00
+ax_pose 13, 0x01e4, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose36:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose37:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01f2, 0x00f4, 0x7c10
+ax_pose_terminator
+sMewtwoPose38:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01f2, 0x00f4, 0x7c10
+ax_pose_terminator
+sMewtwoPose39:
+ax_pose 16, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose40:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose41:
+ax_pose 18, 0x01e7, 0x90f6, 0x7c00
+ax_pose 19, 0x01e4, 0x90f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose42:
+ax_pose 19, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose43:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose 14, 0x01f0, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose44:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose 15, 0x01f0, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose45:
+ax_pose 20, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose46:
+ax_pose 21, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose47:
+ax_pose 22, 0x01e4, 0x90f6, 0x7c00
+ax_pose 23, 0x01e4, 0x90f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose48:
+ax_pose 23, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose49:
+ax_pose 21, 0x01e4, 0x90f0, 0x7c00
+ax_pose 14, 0x01ec, 0x00f8, 0x7c10
+ax_pose_terminator
+sMewtwoPose50:
+ax_pose 21, 0x01e4, 0x90f0, 0x7c00
+ax_pose 15, 0x01ec, 0x00f8, 0x7c10
+ax_pose_terminator
+sMewtwoPose51:
+ax_pose 24, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose52:
+ax_pose 25, 0x01e4, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose53:
+ax_pose 26, 0x01e2, 0x90f7, 0x7c00
+ax_pose 27, 0x01e4, 0x90ed, 0x7c10
+ax_pose_terminator
+sMewtwoPose54:
+ax_pose 27, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose55:
+ax_pose 25, 0x01e4, 0x90ef, 0x7c00
+ax_pose 14, 0x01ee, 0x00f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose56:
+ax_pose 25, 0x01e4, 0x90ef, 0x7c00
+ax_pose 15, 0x01ee, 0x00f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose57:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose58:
+ax_pose 29, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose59:
+ax_pose 12, 0x01de, 0xa0ef, 0x7c00
+ax_pose 30, 0x01e6, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose60:
+ax_pose 30, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose61:
+ax_pose 31, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01f3, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose62:
+ax_pose 31, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01f3, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose63:
+ax_pose 24, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose64:
+ax_pose 25, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose65:
+ax_pose 26, 0x01e2, 0x80e9, 0x7c00
+ax_pose 27, 0x01e4, 0x80f3, 0x7c10
+ax_pose_terminator
+sMewtwoPose66:
+ax_pose 27, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose67:
+ax_pose 25, 0x01e4, 0x80f1, 0x7c00
+ax_pose 14, 0x01ee, 0x1103, 0x7c10
+ax_pose_terminator
+sMewtwoPose68:
+ax_pose 25, 0x01e4, 0x80f1, 0x7c00
+ax_pose 15, 0x01ee, 0x1103, 0x7c10
+ax_pose_terminator
+sMewtwoPose69:
+ax_pose 20, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose70:
+ax_pose 21, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose71:
+ax_pose 22, 0x01e4, 0x80ea, 0x7c00
+ax_pose 23, 0x01e4, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose72:
+ax_pose 23, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose73:
+ax_pose 21, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01ec, 0x1100, 0x7c10
+ax_pose_terminator
+sMewtwoPose74:
+ax_pose 21, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01ec, 0x1100, 0x7c10
+ax_pose_terminator
+sMewtwoPose75:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose76:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose77:
+ax_pose 18, 0x01e7, 0x80ea, 0x7c00
+ax_pose 19, 0x01e4, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose78:
+ax_pose 19, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose79:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01f0, 0x10f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose80:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01f0, 0x10f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose81:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose82:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose83:
+ax_pose 12, 0x01e8, 0x80f0, 0x7c00
+ax_pose 13, 0x01e4, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose84:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose85:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01f2, 0x00f4, 0x7c10
+ax_pose_terminator
+sMewtwoPose86:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01f2, 0x00f4, 0x7c10
+ax_pose_terminator
+sMewtwoPose87:
+ax_pose 16, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose88:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose89:
+ax_pose 18, 0x01e7, 0x90f6, 0x7c00
+ax_pose 19, 0x01e4, 0x90f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose90:
+ax_pose 19, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose91:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose 14, 0x01f0, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose92:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose 15, 0x01f0, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose93:
+ax_pose 20, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose94:
+ax_pose 21, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose95:
+ax_pose 22, 0x01e4, 0x90f6, 0x7c00
+ax_pose 23, 0x01e4, 0x90f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose96:
+ax_pose 23, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose97:
+ax_pose 21, 0x01e4, 0x90f0, 0x7c00
+ax_pose 14, 0x01ec, 0x00f8, 0x7c10
+ax_pose_terminator
+sMewtwoPose98:
+ax_pose 21, 0x01e4, 0x90f0, 0x7c00
+ax_pose 15, 0x01ec, 0x00f8, 0x7c10
+ax_pose_terminator
+sMewtwoPose99:
+ax_pose 24, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose100:
+ax_pose 25, 0x01e4, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose101:
+ax_pose 26, 0x01e2, 0x90f7, 0x7c00
+ax_pose 27, 0x01e4, 0x90ed, 0x7c10
+ax_pose_terminator
+sMewtwoPose102:
+ax_pose 27, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose103:
+ax_pose 25, 0x01e4, 0x90ef, 0x7c00
+ax_pose 14, 0x01ee, 0x00f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose104:
+ax_pose 25, 0x01e4, 0x90ef, 0x7c00
+ax_pose 15, 0x01ee, 0x00f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose105:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose106:
+ax_pose 29, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose107:
+ax_pose 12, 0x01de, 0xa0ef, 0x7c00
+ax_pose 30, 0x01e6, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose108:
+ax_pose 30, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose109:
+ax_pose 31, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01f3, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose110:
+ax_pose 31, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01f3, 0x0103, 0x7c10
+ax_pose_terminator
+sMewtwoPose111:
+ax_pose 24, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose112:
+ax_pose 25, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose113:
+ax_pose 26, 0x01e2, 0x80e9, 0x7c00
+ax_pose 27, 0x01e4, 0x80f3, 0x7c10
+ax_pose_terminator
+sMewtwoPose114:
+ax_pose 27, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose115:
+ax_pose 25, 0x01e4, 0x80f1, 0x7c00
+ax_pose 14, 0x01ee, 0x1103, 0x7c10
+ax_pose_terminator
+sMewtwoPose116:
+ax_pose 25, 0x01e4, 0x80f1, 0x7c00
+ax_pose 15, 0x01ee, 0x1103, 0x7c10
+ax_pose_terminator
+sMewtwoPose117:
+ax_pose 20, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose118:
+ax_pose 21, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose119:
+ax_pose 22, 0x01e4, 0x80ea, 0x7c00
+ax_pose 23, 0x01e4, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose120:
+ax_pose 23, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose121:
+ax_pose 21, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01ec, 0x1100, 0x7c10
+ax_pose_terminator
+sMewtwoPose122:
+ax_pose 21, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01ec, 0x1100, 0x7c10
+ax_pose_terminator
+sMewtwoPose123:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose124:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose125:
+ax_pose 18, 0x01e7, 0x80ea, 0x7c00
+ax_pose 19, 0x01e4, 0x80f0, 0x7c10
+ax_pose_terminator
+sMewtwoPose126:
+ax_pose 19, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose127:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose 14, 0x01f0, 0x10f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose128:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose 15, 0x01f0, 0x10f5, 0x7c10
+ax_pose_terminator
+sMewtwoPose129:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose130:
+ax_pose 32, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose131:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose132:
+ax_pose 1, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose133:
+ax_pose 16, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose134:
+ax_pose 33, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose135:
+ax_pose 2, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose136:
+ax_pose 3, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose137:
+ax_pose 20, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose138:
+ax_pose 34, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose139:
+ax_pose 4, 0x01e2, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose140:
+ax_pose 5, 0x01e1, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose141:
+ax_pose 24, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose142:
+ax_pose 35, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose143:
+ax_pose 6, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sMewtwoPose144:
+ax_pose 7, 0x01e1, 0x90ee, 0x7c00
+ax_pose_terminator
+sMewtwoPose145:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose146:
+ax_pose 36, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose147:
+ax_pose 8, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose148:
+ax_pose 9, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose149:
+ax_pose 24, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose150:
+ax_pose 35, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose151:
+ax_pose 6, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sMewtwoPose152:
+ax_pose 7, 0x01e1, 0x80f2, 0x7c00
+ax_pose_terminator
+sMewtwoPose153:
+ax_pose 20, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose154:
+ax_pose 34, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose155:
+ax_pose 4, 0x01e2, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose156:
+ax_pose 5, 0x01e1, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose157:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose158:
+ax_pose 33, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose159:
+ax_pose 2, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose160:
+ax_pose 3, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose161:
+ax_pose 37, 0x01e8, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose162:
+ax_pose 38, 0x01e8, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose163:
+ax_pose 39, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose164:
+ax_pose 40, 0x01ff, 0x1101, 0x7c00
+ax_pose 41, 0x81ef, 0x1109, 0x7c01
+ax_pose 42, 0x01e7, 0x1109, 0x7c03
+ax_pose 43, 0x81df, 0x5101, 0x7c04
+ax_pose 44, 0x81df, 0x90f1, 0x7c08
+ax_pose_terminator
+sMewtwoPose165:
+ax_pose 45, 0x01e3, 0x90f2, 0x7c00
+ax_pose_terminator
+sMewtwoPose166:
+ax_pose 46, 0x01e2, 0x90f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose167:
+ax_pose 47, 0x01e3, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose168:
+ax_pose 46, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose169:
+ax_pose 45, 0x01e3, 0x80ee, 0x7c00
+ax_pose_terminator
+sMewtwoPose170:
+ax_pose 40, 0x0201, 0x00f7, 0x7c00
+ax_pose 41, 0x81f1, 0x00ef, 0x7c01
+ax_pose 42, 0x01e9, 0x00ef, 0x7c03
+ax_pose 43, 0x81e1, 0x40f7, 0x7c04
+ax_pose 44, 0x81e1, 0x80ff, 0x7c08
+ax_pose_terminator
+sMewtwoPose171:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose172:
+ax_pose 32, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose173:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose174:
+ax_pose 1, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose175:
+ax_pose 16, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose176:
+ax_pose 33, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose177:
+ax_pose 2, 0x01e2, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose178:
+ax_pose 3, 0x01e1, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose179:
+ax_pose 20, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose180:
+ax_pose 34, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose181:
+ax_pose 4, 0x01e2, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose182:
+ax_pose 5, 0x01e1, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose183:
+ax_pose 24, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose184:
+ax_pose 35, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose185:
+ax_pose 6, 0x01e2, 0x90ee, 0x7c00
+ax_pose_terminator
+sMewtwoPose186:
+ax_pose 7, 0x01e1, 0x90ee, 0x7c00
+ax_pose_terminator
+sMewtwoPose187:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose188:
+ax_pose 36, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose189:
+ax_pose 8, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose190:
+ax_pose 9, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose191:
+ax_pose 24, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose192:
+ax_pose 35, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose193:
+ax_pose 6, 0x01e2, 0x80f2, 0x7c00
+ax_pose_terminator
+sMewtwoPose194:
+ax_pose 7, 0x01e1, 0x80f2, 0x7c00
+ax_pose_terminator
+sMewtwoPose195:
+ax_pose 20, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose196:
+ax_pose 34, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose197:
+ax_pose 4, 0x01e2, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose198:
+ax_pose 5, 0x01e1, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose199:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose200:
+ax_pose 33, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose201:
+ax_pose 2, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose202:
+ax_pose 3, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose203:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose204:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose205:
+ax_pose 21, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose206:
+ax_pose 25, 0x01e4, 0x80f2, 0x7c00
+ax_pose_terminator
+sMewtwoPose207:
+ax_pose 29, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose208:
+ax_pose 25, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose209:
+ax_pose 21, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose210:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose211:
+ax_pose 32, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose212:
+ax_pose 33, 0x01e4, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose213:
+ax_pose 34, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose214:
+ax_pose 35, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose215:
+ax_pose 36, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose216:
+ax_pose 35, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose217:
+ax_pose 34, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose218:
+ax_pose 33, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose219:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose220:
+ax_pose 0, 0x01e6, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose221:
+ax_pose 32, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose222:
+ax_pose 16, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose223:
+ax_pose 2, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose224:
+ax_pose 33, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose225:
+ax_pose 20, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose226:
+ax_pose 4, 0x01e2, 0x90eb, 0x7c00
+ax_pose_terminator
+sMewtwoPose227:
+ax_pose 34, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose228:
+ax_pose 24, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose229:
+ax_pose 6, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose230:
+ax_pose 35, 0x01e2, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose231:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose232:
+ax_pose 8, 0x01e1, 0x80f4, 0x7c00
+ax_pose_terminator
+sMewtwoPose233:
+ax_pose 36, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose234:
+ax_pose 24, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose235:
+ax_pose 6, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose236:
+ax_pose 35, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose237:
+ax_pose 20, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose238:
+ax_pose 4, 0x01e2, 0x80f5, 0x7c00
+ax_pose_terminator
+sMewtwoPose239:
+ax_pose 34, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose240:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose241:
+ax_pose 2, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose242:
+ax_pose 33, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose243:
+ax_pose 32, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose244:
+ax_pose 33, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose245:
+ax_pose 34, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose246:
+ax_pose 35, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sMewtwoPose247:
+ax_pose 36, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose248:
+ax_pose 35, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose249:
+ax_pose 34, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose250:
+ax_pose 33, 0x01e4, 0x90ef, 0x7c00
+ax_pose_terminator
+sMewtwoPose251:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose252:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose253:
+ax_pose 20, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose254:
+ax_pose 24, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sMewtwoPose255:
+ax_pose 28, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose256:
+ax_pose 24, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sMewtwoPose257:
+ax_pose 20, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sMewtwoPose258:
+ax_pose 16, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+.align 2
+sMewtwoAnims_1_1:
+ax_anim 12, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 1, 0, 0,
+ax_anim 6, 0, 0, 0, 2, 0, 0,
+ax_anim 12, 0, 1, 0, 2, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_1_2:
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 2, 0, 0,
+ax_anim 12, 0, 3, 0, 2, 0, 0,
+ax_anim 6, 0, 3, 0, 1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_1_3:
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 2, 0, 0,
+ax_anim 12, 0, 5, 0, 2, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_1_4:
+ax_anim 12, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 1, 0, 0,
+ax_anim 6, 0, 6, 0, 2, 0, 0,
+ax_anim 12, 0, 7, 0, 2, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_1_5:
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 2, 0, 0,
+ax_anim 12, 0, 9, 0, 2, 0, 0,
+ax_anim 6, 0, 9, 0, 1, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_1_6:
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 10, 0, 2, 0, 0,
+ax_anim 12, 0, 11, 0, 2, 0, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_1_7:
+ax_anim 12, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 1, 0, 0,
+ax_anim 6, 0, 12, 0, 2, 0, 0,
+ax_anim 12, 0, 13, 0, 2, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_1_8:
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 2, 0, 0,
+ax_anim 12, 0, 15, 0, 2, 0, 0,
+ax_anim 6, 0, 15, 0, 1, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 3, 0, 17, 0, -2, 0, -2,
+ax_anim 4, 0, 16, 0, -5, 0, -5,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 17, 0, 10, 0, 10,
+ax_anim 2, 0, 16, 0, 24, 0, 24,
+ax_anim 2, 1, 17, 1, 24, 1, 24,
+ax_anim 2, 0, 16, 0, 24, 0, 24,
+ax_anim 2, 0, 17, 1, 24, 1, 24,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sMewtwoAnims_2_2:
+ax_anim 2, 0, 18, -1, -1, -1, -1,
+ax_anim 3, 0, 19, -2, -2, -2, -2,
+ax_anim 4, 0, 18, -5, -5, -5, -5,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 4, 4, 4,
+ax_anim 1, 0, 19, 10, 10, 10, 10,
+ax_anim 2, 0, 18, 24, 24, 24, 24,
+ax_anim 2, 1, 19, 25, 23, 25, 23,
+ax_anim 2, 0, 18, 24, 24, 24, 24,
+ax_anim 2, 0, 19, 25, 23, 25, 23,
+ax_anim 2, 0, 18, 6, 6, 6, 6,
+ax_anim_terminator
+sMewtwoAnims_2_3:
+ax_anim 2, 0, 20, -1, 0, -1, 0,
+ax_anim 3, 0, 21, -2, 0, -2, 0,
+ax_anim 4, 0, 20, -5, 0, -5, 0,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 4, 0, 4, 0,
+ax_anim 1, 0, 21, 10, 0, 10, 0,
+ax_anim 2, 0, 20, 22, 0, 22, 0,
+ax_anim 2, 1, 21, 22, 1, 22, 1,
+ax_anim 2, 0, 20, 22, 0, 22, 0,
+ax_anim 2, 0, 21, 22, 1, 22, 1,
+ax_anim 2, 0, 20, 6, 0, 6, 0,
+ax_anim_terminator
+sMewtwoAnims_2_4:
+ax_anim 2, 0, 22, -1, 1, -1, 1,
+ax_anim 3, 0, 23, -2, 2, -2, 2,
+ax_anim 4, 0, 22, -5, 5, -5, 5,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 22, 4, -4, 4, -4,
+ax_anim 1, 0, 23, 10, -9, 10, -9,
+ax_anim 2, 0, 22, 19, -16, 19, -16,
+ax_anim 2, 1, 23, 20, -15, 20, -15,
+ax_anim 2, 0, 22, 19, -16, 19, -16,
+ax_anim 2, 0, 23, 20, -15, 20, -15,
+ax_anim 2, 0, 22, 6, -6, 6, -6,
+ax_anim_terminator
+sMewtwoAnims_2_5:
+ax_anim 2, 0, 24, 0, 1, 0, 1,
+ax_anim 3, 0, 25, 0, 2, 0, 2,
+ax_anim 4, 0, 24, 0, 5, 0, 5,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, -4, 0, -4,
+ax_anim 1, 0, 25, 0, -9, 0, -9,
+ax_anim 2, 0, 24, 0, -15, 0, -15,
+ax_anim 2, 1, 25, 1, -15, 1, -15,
+ax_anim 2, 0, 24, 0, -15, 0, -15,
+ax_anim 2, 0, 25, 1, -15, 1, -15,
+ax_anim 2, 0, 24, 0, -6, 0, -6,
+ax_anim_terminator
+sMewtwoAnims_2_6:
+ax_anim 2, 0, 26, 1, 1, 1, 1,
+ax_anim 3, 0, 27, 2, 2, 2, 2,
+ax_anim 4, 0, 26, 5, 5, 5, 5,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 26, -4, -4, -4, -4,
+ax_anim 1, 0, 27, -10, -9, -10, -9,
+ax_anim 2, 0, 26, -19, -16, -19, -16,
+ax_anim 2, 1, 27, -20, -15, -20, -15,
+ax_anim 2, 0, 26, -19, -16, -19, -16,
+ax_anim 2, 0, 27, -20, -15, -20, -15,
+ax_anim 2, 0, 26, -6, -6, -6, -6,
+ax_anim_terminator
+sMewtwoAnims_2_7:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 3, 0, 29, 2, 0, 2, 0,
+ax_anim 4, 0, 28, 5, 0, 5, 0,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, -4, 0, -4, 0,
+ax_anim 1, 0, 29, -10, 0, -10, 0,
+ax_anim 2, 0, 28, -22, 0, -22, 0,
+ax_anim 2, 1, 29, -22, 1, -22, 1,
+ax_anim 2, 0, 28, -22, 0, -22, 0,
+ax_anim 2, 0, 29, -22, 1, -22, 1,
+ax_anim 2, 0, 28, -6, 0, -6, 0,
+ax_anim_terminator
+sMewtwoAnims_2_8:
+ax_anim 2, 0, 30, 1, -1, 1, -1,
+ax_anim 3, 0, 31, 2, -2, 2, -2,
+ax_anim 4, 0, 30, 5, -5, 5, -5,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, -4, 4, -4, 4,
+ax_anim 1, 0, 31, -10, 10, -10, 10,
+ax_anim 2, 0, 30, -24, 24, -24, 24,
+ax_anim 2, 1, 31, -25, 23, -25, 23,
+ax_anim 2, 0, 30, -24, 24, -24, 24,
+ax_anim 2, 0, 31, -25, 23, -25, 23,
+ax_anim 2, 0, 30, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_3_1:
+ax_anim 2, 0, 33, 0, -1, 0, -1,
+ax_anim 2, 0, 33, 0, -2, 0, -2,
+ax_anim 2, 0, 36, 0, -3, 0, -3,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim 1, 2, 35, 0, 1, 0, 1,
+ax_anim 1, 0, 35, 0, 7, 0, 7,
+ax_anim 2, 0, 34, 0, 19, 0, 19,
+ax_anim 2, 1, 35, 1, 19, 1, 19,
+ax_anim 2, 0, 35, 0, 19, 0, 19,
+ax_anim 2, 0, 35, 1, 19, 1, 19,
+ax_anim 2, 0, 32, 0, 13, 0, 13,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sMewtwoAnims_3_2:
+ax_anim 2, 0, 39, -1, -1, -1, -1,
+ax_anim 2, 0, 39, -2, -2, -2, -2,
+ax_anim 2, 0, 42, -3, -3, -3, -3,
+ax_anim 2, 0, 43, -4, -4, -4, -4,
+ax_anim 2, 0, 42, -4, -4, -4, -4,
+ax_anim 2, 0, 43, -4, -4, -4, -4,
+ax_anim 2, 0, 42, -4, -4, -4, -4,
+ax_anim 1, 2, 41, 1, 2, 1, 2,
+ax_anim 1, 0, 41, 6, 9, 6, 9,
+ax_anim 2, 0, 40, 13, 19, 13, 19,
+ax_anim 2, 1, 41, 14, 18, 14, 18,
+ax_anim 2, 0, 41, 13, 19, 13, 19,
+ax_anim 2, 0, 41, 14, 18, 14, 18,
+ax_anim 2, 0, 38, 11, 13, 11, 13,
+ax_anim 2, 0, 38, 5, 6, 5, 6,
+ax_anim_terminator
+sMewtwoAnims_3_3:
+ax_anim 2, 0, 44, -1, 0, -1, 0,
+ax_anim 2, 0, 45, -2, 0, -2, 0,
+ax_anim 2, 0, 48, -3, 0, -3, 0,
+ax_anim 2, 0, 49, -4, 0, -4, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim 2, 0, 49, -4, 0, -4, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim 1, 2, 47, 1, 0, 1, 0,
+ax_anim 1, 0, 47, 6, 0, 6, 0,
+ax_anim 2, 0, 46, 13, 0, 13, 0,
+ax_anim 2, 1, 47, 13, 1, 13, 1,
+ax_anim 2, 0, 47, 13, 0, 13, 0,
+ax_anim 2, 0, 47, 13, 1, 13, 1,
+ax_anim 2, 0, 44, 11, 0, 11, 0,
+ax_anim 2, 0, 44, 5, 0, 5, 0,
+ax_anim_terminator
+sMewtwoAnims_3_4:
+ax_anim 2, 0, 50, -1, 1, -1, 1,
+ax_anim 2, 0, 51, -2, 2, -2, 2,
+ax_anim 2, 0, 54, -3, 3, -3, 3,
+ax_anim 2, 0, 55, -4, 4, -4, 4,
+ax_anim 2, 0, 54, -4, 4, -4, 4,
+ax_anim 2, 0, 55, -4, 4, -4, 4,
+ax_anim 2, 0, 54, -4, 4, -4, 4,
+ax_anim 1, 2, 53, 1, -1, 1, -1,
+ax_anim 1, 0, 53, 6, -6, 6, -6,
+ax_anim 2, 0, 52, 14, -14, 14, -14,
+ax_anim 2, 1, 53, 13, -15, 13, -15,
+ax_anim 2, 0, 53, 14, -14, 14, -14,
+ax_anim 2, 0, 53, 13, -15, 13, -15,
+ax_anim 2, 0, 50, 11, -11, 11, -11,
+ax_anim 2, 0, 50, 5, -5, 5, -5,
+ax_anim_terminator
+sMewtwoAnims_3_5:
+ax_anim 2, 0, 56, 0, 1, 0, 1,
+ax_anim 2, 0, 57, 0, 2, 0, 2,
+ax_anim 2, 0, 60, 0, 3, 0, 3,
+ax_anim 2, 0, 61, 0, 4, 0, 4,
+ax_anim 2, 0, 60, 0, 4, 0, 4,
+ax_anim 2, 0, 61, 0, 4, 0, 4,
+ax_anim 2, 0, 60, 0, 4, 0, 4,
+ax_anim 1, 2, 59, 0, -1, 0, -1,
+ax_anim 1, 0, 59, 0, -6, 0, -6,
+ax_anim 2, 0, 58, 0, -14, 0, -14,
+ax_anim 2, 1, 59, 1, -14, 1, -14,
+ax_anim 2, 0, 59, 0, -14, 0, -14,
+ax_anim 2, 0, 59, 1, -14, 1, -14,
+ax_anim 2, 0, 56, 0, -11, 0, -11,
+ax_anim 2, 0, 56, 0, -5, 0, -5,
+ax_anim_terminator
+sMewtwoAnims_3_6:
+ax_anim 2, 0, 62, 1, 1, 1, 1,
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 66, 3, 3, 3, 3,
+ax_anim 2, 0, 67, 4, 4, 4, 4,
+ax_anim 2, 0, 66, 4, 4, 4, 4,
+ax_anim 2, 0, 67, 4, 4, 4, 4,
+ax_anim 2, 0, 66, 4, 4, 4, 4,
+ax_anim 1, 2, 65, -1, -1, -1, -1,
+ax_anim 1, 0, 65, -6, -6, -6, -6,
+ax_anim 2, 0, 64, -14, -14, -14, -14,
+ax_anim 2, 1, 65, -13, -15, -13, -15,
+ax_anim 2, 0, 65, -14, -14, -14, -14,
+ax_anim 2, 0, 65, -13, -15, -13, -15,
+ax_anim 2, 0, 62, -11, -11, -11, -11,
+ax_anim 2, 0, 62, -5, -5, -5, -5,
+ax_anim_terminator
+sMewtwoAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 69, 2, 0, 2, 0,
+ax_anim 2, 0, 72, 3, 0, 3, 0,
+ax_anim 2, 0, 73, 4, 0, 4, 0,
+ax_anim 2, 0, 72, 4, 0, 4, 0,
+ax_anim 2, 0, 73, 4, 0, 4, 0,
+ax_anim 2, 0, 72, 4, 0, 4, 0,
+ax_anim 1, 2, 71, -1, 0, -1, 0,
+ax_anim 1, 0, 71, -6, 0, -6, 0,
+ax_anim 2, 0, 70, -13, 0, -13, 0,
+ax_anim 2, 1, 71, -13, 1, -13, 1,
+ax_anim 2, 0, 71, -13, 0, -13, 0,
+ax_anim 2, 0, 71, -13, 1, -13, 1,
+ax_anim 2, 0, 68, -11, 0, -11, 0,
+ax_anim 2, 0, 68, -5, 0, -5, 0,
+ax_anim_terminator
+sMewtwoAnims_3_8:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 2, -2, 2, -2,
+ax_anim 2, 0, 78, 3, -3, 3, -3,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim 2, 0, 78, 4, -4, 4, -4,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim 2, 0, 78, 4, -4, 4, -4,
+ax_anim 1, 2, 77, -1, 2, -1, 2,
+ax_anim 1, 0, 77, -6, 9, -6, 9,
+ax_anim 2, 0, 76, -13, 19, -13, 19,
+ax_anim 2, 1, 77, -14, 18, -14, 18,
+ax_anim 2, 0, 77, -13, 19, -13, 19,
+ax_anim 2, 0, 77, -14, 18, -14, 18,
+ax_anim 2, 0, 74, -11, 13, -11, 13,
+ax_anim 2, 0, 74, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_4_1:
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 2, 0, 84, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim 2, 2, 84, 0, -4, 0, -4,
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 1, 83, 1, 3, 1, 3,
+ax_anim 2, 0, 83, 0, 3, 0, 3,
+ax_anim 2, 0, 83, 1, 3, 1, 3,
+ax_anim 2, 0, 83, 0, 3, 0, 3,
+ax_anim 2, 0, 83, 1, 3, 1, 3,
+ax_anim_terminator
+sMewtwoAnims_4_2:
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim 2, 0, 90, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -4, -4, -4, -4,
+ax_anim 2, 2, 90, -4, -4, -4, -4,
+ax_anim 2, 0, 91, -4, -4, -4, -4,
+ax_anim 2, 0, 90, -4, -4, -4, -4,
+ax_anim 2, 0, 88, 3, 3, 3, 3,
+ax_anim 2, 1, 89, 4, 2, 4, 2,
+ax_anim 2, 0, 89, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 4, 2, 4, 2,
+ax_anim 2, 0, 89, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 4, 2, 4, 2,
+ax_anim_terminator
+sMewtwoAnims_4_3:
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 2, 0, 93, -2, 0, -2, 0,
+ax_anim 2, 0, 96, -3, 0, -3, 0,
+ax_anim 2, 0, 97, -4, 0, -4, 0,
+ax_anim 2, 2, 96, -4, 0, -4, 0,
+ax_anim 2, 0, 97, -4, 0, -4, 0,
+ax_anim 2, 0, 96, -4, 0, -4, 0,
+ax_anim 2, 0, 94, 3, 0, 3, 0,
+ax_anim 2, 1, 95, 3, 1, 3, 1,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, 1, 3, 1,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, 1, 3, 1,
+ax_anim_terminator
+sMewtwoAnims_4_4:
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 2, 0, 99, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 2, 102, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 102, -4, 4, -4, 4,
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 1, 101, 2, -4, 2, -4,
+ax_anim 2, 0, 101, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 2, -4, 2, -4,
+ax_anim 2, 0, 101, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 2, -4, 2, -4,
+ax_anim_terminator
+sMewtwoAnims_4_5:
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 109, 0, 4, 0, 4,
+ax_anim 2, 2, 108, 0, 4, 0, 4,
+ax_anim 2, 0, 109, 0, 4, 0, 4,
+ax_anim 2, 0, 108, 0, 4, 0, 4,
+ax_anim 2, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 1, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 1, -3, 1, -3,
+ax_anim_terminator
+sMewtwoAnims_4_6:
+ax_anim 2, 0, 110, 1, 1, 1, 1,
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 2, 0, 114, 3, 3, 3, 3,
+ax_anim 2, 0, 115, 4, 4, 4, 4,
+ax_anim 2, 2, 114, 4, 4, 4, 4,
+ax_anim 2, 0, 115, 4, 4, 4, 4,
+ax_anim 2, 0, 114, 4, 4, 4, 4,
+ax_anim 2, 0, 112, -3, -3, -3, -3,
+ax_anim 2, 1, 113, -2, -4, -2, -4,
+ax_anim 2, 0, 113, -3, -3, -3, -3,
+ax_anim 2, 0, 113, -2, -4, -2, -4,
+ax_anim 2, 0, 113, -3, -3, -3, -3,
+ax_anim 2, 0, 113, -2, -4, -2, -4,
+ax_anim_terminator
+sMewtwoAnims_4_7:
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 3, 0, 3, 0,
+ax_anim 2, 0, 121, 4, 0, 4, 0,
+ax_anim 2, 2, 120, 4, 0, 4, 0,
+ax_anim 2, 0, 121, 4, 0, 4, 0,
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 2, 0, 118, -3, 0, -3, 0,
+ax_anim 2, 1, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim_terminator
+sMewtwoAnims_4_8:
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 127, 4, -4, 4, -4,
+ax_anim 2, 2, 126, 4, -4, 4, -4,
+ax_anim 2, 0, 127, 4, -4, 4, -4,
+ax_anim 2, 0, 126, 4, -4, 4, -4,
+ax_anim 2, 0, 124, -3, 3, -3, 3,
+ax_anim 2, 1, 125, -4, 2, -4, 2,
+ax_anim 2, 0, 125, -3, 3, -3, 3,
+ax_anim 2, 0, 125, -4, 2, -4, 2,
+ax_anim 2, 0, 125, -3, 3, -3, 3,
+ax_anim 2, 0, 125, -4, 2, -4, 2,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_5_1:
+ax_anim 2, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 6, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 2, 129, 0, -9, 0, 0,
+ax_anim 2, 0, 129, 1, -9, 1, 0,
+ax_anim 2, 0, 129, 0, -9, 0, 0,
+ax_anim 2, 0, 129, 1, -9, 1, 0,
+ax_anim 2, 0, 129, 0, -9, 0, 0,
+ax_anim 2, 1, 129, 1, -9, 1, 0,
+ax_anim 6, 0, 129, 0, -9, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_5_2:
+ax_anim 2, 0, 135, 0, -1, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 6, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 2, 133, 0, -9, 0, 0,
+ax_anim 2, 0, 133, 1, -9, 1, 0,
+ax_anim 2, 0, 133, 0, -9, 0, 0,
+ax_anim 2, 0, 133, 1, -9, 1, 0,
+ax_anim 2, 0, 133, 0, -9, 0, 0,
+ax_anim 2, 1, 133, 1, -9, 1, 0,
+ax_anim 6, 0, 133, 0, -9, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_5_3:
+ax_anim 2, 0, 139, 0, -1, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 6, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 2, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 137, 1, -9, 1, 0,
+ax_anim 2, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 137, 1, -9, 1, 0,
+ax_anim 2, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 1, 137, 1, -9, 1, 0,
+ax_anim 6, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_5_4:
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 6, 0, 143, 0, -6, 0, 0,
+ax_anim 2, 2, 141, 0, -9, 0, 0,
+ax_anim 2, 0, 141, 1, -9, 1, 0,
+ax_anim 2, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 0, 141, 1, -9, 1, 0,
+ax_anim 2, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 1, 141, 1, -9, 1, 0,
+ax_anim 6, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_5_5:
+ax_anim 2, 0, 147, 0, -1, 0, 0,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -5, 0, 0,
+ax_anim 6, 0, 147, 0, -6, 0, 0,
+ax_anim 2, 2, 145, 0, -9, 0, 0,
+ax_anim 2, 0, 145, 1, -9, 1, 0,
+ax_anim 2, 0, 145, 0, -9, 0, 0,
+ax_anim 2, 0, 145, 1, -9, 1, 0,
+ax_anim 2, 0, 145, 0, -9, 0, 0,
+ax_anim 2, 1, 145, 1, -9, 1, 0,
+ax_anim 6, 0, 145, 0, -9, 0, 0,
+ax_anim 2, 0, 146, 0, -5, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_5_6:
+ax_anim 2, 0, 151, 0, -1, 0, 0,
+ax_anim 2, 0, 151, 0, -3, 0, 0,
+ax_anim 2, 0, 151, 0, -5, 0, 0,
+ax_anim 6, 0, 151, 0, -6, 0, 0,
+ax_anim 2, 2, 149, 0, -9, 0, 0,
+ax_anim 2, 0, 149, 1, -9, 1, 0,
+ax_anim 2, 0, 149, 0, -9, 0, 0,
+ax_anim 2, 0, 149, 1, -9, 1, 0,
+ax_anim 2, 0, 149, 0, -9, 0, 0,
+ax_anim 2, 1, 149, 1, -9, 1, 0,
+ax_anim 6, 0, 149, 0, -9, 0, 0,
+ax_anim 2, 0, 150, 0, -5, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_5_7:
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 155, 0, -5, 0, 0,
+ax_anim 6, 0, 155, 0, -6, 0, 0,
+ax_anim 2, 2, 153, 0, -9, 0, 0,
+ax_anim 2, 0, 153, 1, -9, 1, 0,
+ax_anim 2, 0, 153, 0, -9, 0, 0,
+ax_anim 2, 0, 153, 1, -9, 1, 0,
+ax_anim 2, 0, 153, 0, -9, 0, 0,
+ax_anim 2, 1, 153, 1, -9, 1, 0,
+ax_anim 6, 0, 153, 0, -9, 0, 0,
+ax_anim 2, 0, 154, 0, -5, 0, 0,
+ax_anim 2, 0, 154, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_5_8:
+ax_anim 2, 0, 159, 0, -1, 0, 0,
+ax_anim 2, 0, 159, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, -5, 0, 0,
+ax_anim 6, 0, 159, 0, -6, 0, 0,
+ax_anim 2, 2, 157, 0, -9, 0, 0,
+ax_anim 2, 0, 157, 1, -9, 1, 0,
+ax_anim 2, 0, 157, 0, -9, 0, 0,
+ax_anim 2, 0, 157, 1, -9, 1, 0,
+ax_anim 2, 0, 157, 0, -9, 0, 0,
+ax_anim 2, 1, 157, 1, -9, 1, 0,
+ax_anim 6, 0, 157, 0, -9, 0, 0,
+ax_anim 2, 0, 158, 0, -5, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sMewtwoAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sMewtwoAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sMewtwoAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sMewtwoAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sMewtwoAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sMewtwoAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sMewtwoAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_8_1:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, -2, 0, 0,
+ax_anim 4, 0, 171, 0, -3, 0, 0,
+ax_anim 6, 0, 171, 0, -4, 0, 0,
+ax_anim 8, 0, 171, 0, -5, 0, 0,
+ax_anim 6, 0, 171, 0, -4, 0, 0,
+ax_anim 4, 0, 171, 0, -3, 0, 0,
+ax_anim 2, 0, 171, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_8_2:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, -2, 0, 0,
+ax_anim 4, 0, 175, 0, -3, 0, 0,
+ax_anim 6, 0, 175, 0, -4, 0, 0,
+ax_anim 8, 0, 175, 0, -5, 0, 0,
+ax_anim 6, 0, 175, 0, -4, 0, 0,
+ax_anim 4, 0, 175, 0, -3, 0, 0,
+ax_anim 2, 0, 175, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_8_3:
+ax_anim 40, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, -2, 0, 0,
+ax_anim 4, 0, 179, 0, -3, 0, 0,
+ax_anim 6, 0, 179, 0, -4, 0, 0,
+ax_anim 8, 0, 179, 0, -5, 0, 0,
+ax_anim 6, 0, 179, 0, -4, 0, 0,
+ax_anim 4, 0, 179, 0, -3, 0, 0,
+ax_anim 2, 0, 179, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_8_4:
+ax_anim 40, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, -2, 0, 0,
+ax_anim 4, 0, 183, 0, -3, 0, 0,
+ax_anim 6, 0, 183, 0, -4, 0, 0,
+ax_anim 8, 0, 183, 0, -5, 0, 0,
+ax_anim 6, 0, 183, 0, -4, 0, 0,
+ax_anim 4, 0, 183, 0, -3, 0, 0,
+ax_anim 2, 0, 183, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_8_5:
+ax_anim 40, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, -2, 0, 0,
+ax_anim 4, 0, 187, 0, -3, 0, 0,
+ax_anim 6, 0, 187, 0, -4, 0, 0,
+ax_anim 8, 0, 187, 0, -5, 0, 0,
+ax_anim 6, 0, 187, 0, -4, 0, 0,
+ax_anim 4, 0, 187, 0, -3, 0, 0,
+ax_anim 2, 0, 187, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_8_6:
+ax_anim 40, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -2, 0, 0,
+ax_anim 4, 0, 191, 0, -3, 0, 0,
+ax_anim 6, 0, 191, 0, -4, 0, 0,
+ax_anim 8, 0, 191, 0, -5, 0, 0,
+ax_anim 6, 0, 191, 0, -4, 0, 0,
+ax_anim 4, 0, 191, 0, -3, 0, 0,
+ax_anim 2, 0, 191, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_8_7:
+ax_anim 40, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, -2, 0, 0,
+ax_anim 4, 0, 195, 0, -3, 0, 0,
+ax_anim 6, 0, 195, 0, -4, 0, 0,
+ax_anim 8, 0, 195, 0, -5, 0, 0,
+ax_anim 6, 0, 195, 0, -4, 0, 0,
+ax_anim 4, 0, 195, 0, -3, 0, 0,
+ax_anim 2, 0, 195, 0, -2, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_8_8:
+ax_anim 40, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -2, 0, 0,
+ax_anim 4, 0, 199, 0, -3, 0, 0,
+ax_anim 6, 0, 199, 0, -4, 0, 0,
+ax_anim 8, 0, 199, 0, -5, 0, 0,
+ax_anim 6, 0, 199, 0, -4, 0, 0,
+ax_anim 4, 0, 199, 0, -3, 0, 0,
+ax_anim 2, 0, 199, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 4, 6, 4,
+ax_anim 2, 0, 204, 8, 9, 8, 9,
+ax_anim 2, 0, 205, 7, 19, 7, 19,
+ax_anim 3, 0, 206, 0, 22, 0, 24,
+ax_anim 2, 3, 207, -7, 19, -7, 19,
+ax_anim 2, 0, 208, -8, 9, -8, 9,
+ax_anim 1, 0, 209, -6, 4, -6, 4,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 203, 17, 3, 17, 3,
+ax_anim 2, 0, 204, 24, 9, 24, 9,
+ax_anim 3, 0, 205, 23, 21, 23, 21,
+ax_anim 2, 3, 206, 11, 21, 11, 21,
+ax_anim 2, 0, 207, 2, 12, 2, 12,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -4, 3, -4,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 17, -4, 17, -4,
+ax_anim 3, 0, 204, 22, 1, 22, 1,
+ax_anim 2, 3, 205, 17, 5, 17, 5,
+ax_anim 2, 0, 206, 12, 7, 12, 7,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -6, -1, -6,
+ax_anim 2, 0, 209, 4, -16, 4, -16,
+ax_anim 2, 0, 202, 11, -20, 11, -20,
+ax_anim 3, 0, 203, 20, -20, 20, -20,
+ax_anim 2, 3, 204, 22, -10, 22, -10,
+ax_anim 2, 0, 205, 17, -2, 17, -2,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -6, -4, -6, -4,
+ax_anim 2, 0, 208, -8, -10, -8, -10,
+ax_anim 2, 0, 209, -7, -18, -7, -18,
+ax_anim 3, 0, 202, 0, -20, 0, -20,
+ax_anim 2, 3, 203, 7, -18, 7, -18,
+ax_anim 2, 0, 204, 8, -8, 8, -8,
+ax_anim 1, 0, 205, 6, -4, 6, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -6, 1, -6,
+ax_anim 2, 0, 203, -4, -16, -4, -16,
+ax_anim 2, 0, 202, -11, -20, -11, -20,
+ax_anim 3, 0, 209, -20, -20, -20, -20,
+ax_anim 2, 3, 208, -22, -10, -22, -10,
+ax_anim 2, 0, 207, -20, -4, -20, -4,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -4, -3, -4,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -17, -4, -17, -4,
+ax_anim 3, 0, 208, -22, 1, -22, 1,
+ax_anim 2, 3, 207, -17, 5, -17, 5,
+ax_anim 2, 0, 206, -12, 7, -12, 7,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 209, -17, 3, -17, 3,
+ax_anim 2, 0, 208, -24, 9, -24, 9,
+ax_anim 3, 0, 207, -23, 21, -23, 16,
+ax_anim 2, 3, 206, -11, 21, -11, 16,
+ax_anim 2, 0, 205, -2, 12, -4, 12,
+ax_anim 1, 0, 204, 0, 7, -3, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, 0,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMewtwoAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sMewtwoGfx1:
+.incbin "baserom.gba", 0xB8EFE4, 0x200
+sMewtwoSprites1:
+ax_sprite sMewtwoGfx1, 0x200
+ax_sprite_terminator
+sMewtwoGfx2:
+.incbin "baserom.gba", 0xB8F1F4, 0x200
+sMewtwoSprites2:
+ax_sprite sMewtwoGfx2, 0x200
+ax_sprite_terminator
+sMewtwoGfx3:
+.incbin "baserom.gba", 0xB8F404, 0x200
+sMewtwoSprites3:
+ax_sprite sMewtwoGfx3, 0x200
+ax_sprite_terminator
+sMewtwoGfx4:
+.incbin "baserom.gba", 0xB8F614, 0x200
+sMewtwoSprites4:
+ax_sprite sMewtwoGfx4, 0x200
+ax_sprite_terminator
+sMewtwoGfx5:
+.incbin "baserom.gba", 0xB8F824, 0x200
+sMewtwoSprites5:
+ax_sprite sMewtwoGfx5, 0x200
+ax_sprite_terminator
+sMewtwoGfx6:
+.incbin "baserom.gba", 0xB8FA34, 0x200
+sMewtwoSprites6:
+ax_sprite sMewtwoGfx6, 0x200
+ax_sprite_terminator
+sMewtwoGfx7:
+.incbin "baserom.gba", 0xB8FC44, 0x200
+sMewtwoSprites7:
+ax_sprite sMewtwoGfx7, 0x200
+ax_sprite_terminator
+sMewtwoGfx8:
+.incbin "baserom.gba", 0xB8FE54, 0x200
+sMewtwoSprites8:
+ax_sprite sMewtwoGfx8, 0x200
+ax_sprite_terminator
+sMewtwoGfx9:
+.incbin "baserom.gba", 0xB90064, 0x200
+sMewtwoSprites9:
+ax_sprite sMewtwoGfx9, 0x200
+ax_sprite_terminator
+sMewtwoGfx10:
+.incbin "baserom.gba", 0xB90274, 0x200
+sMewtwoSprites10:
+ax_sprite sMewtwoGfx10, 0x200
+ax_sprite_terminator
+sMewtwoGfx11:
+.incbin "baserom.gba", 0xB90484, 0x40
+sMewtwoGfx11_1:
+.incbin "baserom.gba", 0xB904C4, 0x160
+sMewtwoSprites11:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx11, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx11_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx12:
+.incbin "baserom.gba", 0xB90654, 0x40
+sMewtwoGfx12_1:
+.incbin "baserom.gba", 0xB90694, 0x160
+sMewtwoSprites12:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx12, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx12_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx13:
+.incbin "baserom.gba", 0xB90824, 0x160
+sMewtwoSprites13:
+ax_sprite 0, 0xa0
+ax_sprite sMewtwoGfx13, 0x160
+ax_sprite_terminator
+sMewtwoGfx14:
+.incbin "baserom.gba", 0xB9099C, 0x60
+sMewtwoGfx14_1:
+.incbin "baserom.gba", 0xB909FC, 0x60
+sMewtwoGfx14_2:
+.incbin "baserom.gba", 0xB90A5C, 0x60
+sMewtwoGfx14_3:
+.incbin "baserom.gba", 0xB90ABC, 0x60
+sMewtwoSprites14:
+ax_sprite sMewtwoGfx14, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx14_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx14_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx14_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx15:
+.incbin "baserom.gba", 0xB90B64, 0x20
+sMewtwoSprites15:
+ax_sprite sMewtwoGfx15, 0x20
+ax_sprite_terminator
+sMewtwoGfx16:
+.incbin "baserom.gba", 0xB90B94, 0x20
+sMewtwoSprites16:
+ax_sprite sMewtwoGfx16, 0x20
+ax_sprite_terminator
+sMewtwoGfx17:
+.incbin "baserom.gba", 0xB90BC4, 0x40
+sMewtwoGfx17_1:
+.incbin "baserom.gba", 0xB90C04, 0x80
+sMewtwoGfx17_2:
+.incbin "baserom.gba", 0xB90C84, 0xE0
+sMewtwoSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx17_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx17_2, 0xe0
+ax_sprite_terminator
+sMewtwoGfx18:
+.incbin "baserom.gba", 0xB90D9C, 0x40
+sMewtwoGfx18_1:
+.incbin "baserom.gba", 0xB90DDC, 0x100
+sMewtwoGfx18_2:
+.incbin "baserom.gba", 0xB90EDC, 0x40
+sMewtwoSprites18:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx19:
+.incbin "baserom.gba", 0xB90F5C, 0x20
+sMewtwoGfx19_1:
+.incbin "baserom.gba", 0xB90F7C, 0x60
+sMewtwoGfx19_2:
+.incbin "baserom.gba", 0xB90FDC, 0x100
+sMewtwoSprites19:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx19_2, 0x100
+ax_sprite_terminator
+sMewtwoGfx20:
+.incbin "baserom.gba", 0xB91114, 0x60
+sMewtwoGfx20_1:
+.incbin "baserom.gba", 0xB91174, 0x60
+sMewtwoGfx20_2:
+.incbin "baserom.gba", 0xB911D4, 0x60
+sMewtwoGfx20_3:
+.incbin "baserom.gba", 0xB91234, 0x60
+sMewtwoSprites20:
+ax_sprite sMewtwoGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx21:
+.incbin "baserom.gba", 0xB912DC, 0x60
+sMewtwoGfx21_1:
+.incbin "baserom.gba", 0xB9133C, 0x60
+sMewtwoGfx21_2:
+.incbin "baserom.gba", 0xB9139C, 0x60
+sMewtwoGfx21_3:
+.incbin "baserom.gba", 0xB913FC, 0x60
+sMewtwoSprites21:
+ax_sprite sMewtwoGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx21_3, 0x60
+ax_sprite_terminator
+sMewtwoGfx22:
+.incbin "baserom.gba", 0xB9149C, 0x40
+sMewtwoGfx22_1:
+.incbin "baserom.gba", 0xB914DC, 0x60
+sMewtwoGfx22_2:
+.incbin "baserom.gba", 0xB9153C, 0x60
+sMewtwoGfx22_3:
+.incbin "baserom.gba", 0xB9159C, 0x60
+sMewtwoSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx22_3, 0x60
+ax_sprite_terminator
+sMewtwoGfx23:
+.incbin "baserom.gba", 0xB91644, 0x40
+sMewtwoGfx23_1:
+.incbin "baserom.gba", 0xB91684, 0x60
+sMewtwoGfx23_2:
+.incbin "baserom.gba", 0xB916E4, 0x60
+sMewtwoGfx23_3:
+.incbin "baserom.gba", 0xB91744, 0x60
+sMewtwoSprites23:
+ax_sprite sMewtwoGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx24:
+.incbin "baserom.gba", 0xB917EC, 0x60
+sMewtwoGfx24_1:
+.incbin "baserom.gba", 0xB9184C, 0x180
+sMewtwoSprites24:
+ax_sprite sMewtwoGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx24_1, 0x180
+ax_sprite_terminator
+sMewtwoGfx25:
+.incbin "baserom.gba", 0xB919EC, 0x60
+sMewtwoGfx25_1:
+.incbin "baserom.gba", 0xB91A4C, 0x60
+sMewtwoGfx25_2:
+.incbin "baserom.gba", 0xB91AAC, 0x60
+sMewtwoGfx25_3:
+.incbin "baserom.gba", 0xB91B0C, 0x60
+sMewtwoSprites25:
+ax_sprite sMewtwoGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx26:
+.incbin "baserom.gba", 0xB91BB4, 0x40
+sMewtwoGfx26_1:
+.incbin "baserom.gba", 0xB91BF4, 0x60
+sMewtwoGfx26_2:
+.incbin "baserom.gba", 0xB91C54, 0xE0
+sMewtwoSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx26_2, 0xe0
+ax_sprite_terminator
+sMewtwoGfx27:
+.incbin "baserom.gba", 0xB91D6C, 0x1E0
+sMewtwoSprites27:
+ax_sprite sMewtwoGfx27, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx28:
+.incbin "baserom.gba", 0xB91F64, 0x40
+sMewtwoGfx28_1:
+.incbin "baserom.gba", 0xB91FA4, 0x100
+sMewtwoGfx28_2:
+.incbin "baserom.gba", 0xB920A4, 0x40
+sMewtwoSprites28:
+ax_sprite sMewtwoGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx28_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx29:
+.incbin "baserom.gba", 0xB9211C, 0x40
+sMewtwoGfx29_1:
+.incbin "baserom.gba", 0xB9215C, 0x100
+sMewtwoGfx29_2:
+.incbin "baserom.gba", 0xB9225C, 0x40
+sMewtwoSprites29:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx29_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx30:
+.incbin "baserom.gba", 0xB922DC, 0x40
+sMewtwoGfx30_1:
+.incbin "baserom.gba", 0xB9231C, 0x40
+sMewtwoGfx30_2:
+.incbin "baserom.gba", 0xB9235C, 0xE0
+sMewtwoSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx30_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx31:
+.incbin "baserom.gba", 0xB9247C, 0x40
+sMewtwoGfx31_1:
+.incbin "baserom.gba", 0xB924BC, 0x60
+sMewtwoGfx31_2:
+.incbin "baserom.gba", 0xB9251C, 0x60
+sMewtwoGfx31_3:
+.incbin "baserom.gba", 0xB9257C, 0x60
+sMewtwoSprites31:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx31_3, 0x60
+ax_sprite_terminator
+sMewtwoGfx32:
+.incbin "baserom.gba", 0xB92624, 0x40
+sMewtwoGfx32_1:
+.incbin "baserom.gba", 0xB92664, 0x40
+sMewtwoGfx32_2:
+.incbin "baserom.gba", 0xB926A4, 0xE0
+sMewtwoSprites32:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMewtwoGfx32_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx32_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx33:
+.incbin "baserom.gba", 0xB927C4, 0x1E0
+sMewtwoSprites33:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx33, 0x1e0
+ax_sprite_terminator
+sMewtwoGfx34:
+.incbin "baserom.gba", 0xB929BC, 0x1E0
+sMewtwoSprites34:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx34, 0x1e0
+ax_sprite_terminator
+sMewtwoGfx35:
+.incbin "baserom.gba", 0xB92BB4, 0xE0
+sMewtwoGfx35_1:
+.incbin "baserom.gba", 0xB92C94, 0x60
+sMewtwoGfx35_2:
+.incbin "baserom.gba", 0xB92CF4, 0x40
+sMewtwoSprites35:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx35, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx36:
+.incbin "baserom.gba", 0xB92D74, 0x160
+sMewtwoGfx36_1:
+.incbin "baserom.gba", 0xB92ED4, 0x40
+sMewtwoSprites36:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx36, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx36_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMewtwoGfx37:
+.incbin "baserom.gba", 0xB92F44, 0x40
+sMewtwoGfx37_1:
+.incbin "baserom.gba", 0xB92F84, 0x180
+sMewtwoSprites37:
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMewtwoGfx37_1, 0x180
+ax_sprite_terminator
+sMewtwoGfx38:
+.incbin "baserom.gba", 0xB9312C, 0x200
+sMewtwoSprites38:
+ax_sprite sMewtwoGfx38, 0x200
+ax_sprite_terminator
+sMewtwoGfx39:
+.incbin "baserom.gba", 0xB9333C, 0x200
+sMewtwoSprites39:
+ax_sprite sMewtwoGfx39, 0x200
+ax_sprite_terminator
+sMewtwoGfx40:
+.incbin "baserom.gba", 0xB9354C, 0x200
+sMewtwoSprites40:
+ax_sprite sMewtwoGfx40, 0x200
+ax_sprite_terminator
+sMewtwoGfx41:
+.incbin "baserom.gba", 0xB9375C, 0x20
+sMewtwoSprites41:
+ax_sprite sMewtwoGfx41, 0x20
+ax_sprite_terminator
+sMewtwoGfx42:
+.incbin "baserom.gba", 0xB9378C, 0x40
+sMewtwoSprites42:
+ax_sprite sMewtwoGfx42, 0x40
+ax_sprite_terminator
+sMewtwoGfx43:
+.incbin "baserom.gba", 0xB937DC, 0x20
+sMewtwoSprites43:
+ax_sprite sMewtwoGfx43, 0x20
+ax_sprite_terminator
+sMewtwoGfx44:
+.incbin "baserom.gba", 0xB9380C, 0x80
+sMewtwoSprites44:
+ax_sprite sMewtwoGfx44, 0x80
+ax_sprite_terminator
+sMewtwoGfx45:
+.incbin "baserom.gba", 0xB9389C, 0x100
+sMewtwoSprites45:
+ax_sprite sMewtwoGfx45, 0x100
+ax_sprite_terminator
+sMewtwoGfx46:
+.incbin "baserom.gba", 0xB939AC, 0x200
+sMewtwoSprites46:
+ax_sprite sMewtwoGfx46, 0x200
+ax_sprite_terminator
+sMewtwoGfx47:
+.incbin "baserom.gba", 0xB93BBC, 0x200
+sMewtwoSprites47:
+ax_sprite sMewtwoGfx47, 0x200
+ax_sprite_terminator
+sMewtwoGfx48:
+.incbin "baserom.gba", 0xB93DCC, 0x200
+sMewtwoSprites48:
+ax_sprite sMewtwoGfx48, 0x200
+ax_sprite_terminator
+sAxPosesMewtwo:
+.4byte sMewtwoPose1
+.4byte sMewtwoPose2
+.4byte sMewtwoPose3
+.4byte sMewtwoPose4
+.4byte sMewtwoPose5
+.4byte sMewtwoPose6
+.4byte sMewtwoPose7
+.4byte sMewtwoPose8
+.4byte sMewtwoPose9
+.4byte sMewtwoPose10
+.4byte sMewtwoPose11
+.4byte sMewtwoPose12
+.4byte sMewtwoPose13
+.4byte sMewtwoPose14
+.4byte sMewtwoPose15
+.4byte sMewtwoPose16
+.4byte sMewtwoPose17
+.4byte sMewtwoPose18
+.4byte sMewtwoPose19
+.4byte sMewtwoPose20
+.4byte sMewtwoPose21
+.4byte sMewtwoPose22
+.4byte sMewtwoPose23
+.4byte sMewtwoPose24
+.4byte sMewtwoPose25
+.4byte sMewtwoPose26
+.4byte sMewtwoPose27
+.4byte sMewtwoPose28
+.4byte sMewtwoPose29
+.4byte sMewtwoPose30
+.4byte sMewtwoPose31
+.4byte sMewtwoPose32
+.4byte sMewtwoPose33
+.4byte sMewtwoPose34
+.4byte sMewtwoPose35
+.4byte sMewtwoPose36
+.4byte sMewtwoPose37
+.4byte sMewtwoPose38
+.4byte sMewtwoPose39
+.4byte sMewtwoPose40
+.4byte sMewtwoPose41
+.4byte sMewtwoPose42
+.4byte sMewtwoPose43
+.4byte sMewtwoPose44
+.4byte sMewtwoPose45
+.4byte sMewtwoPose46
+.4byte sMewtwoPose47
+.4byte sMewtwoPose48
+.4byte sMewtwoPose49
+.4byte sMewtwoPose50
+.4byte sMewtwoPose51
+.4byte sMewtwoPose52
+.4byte sMewtwoPose53
+.4byte sMewtwoPose54
+.4byte sMewtwoPose55
+.4byte sMewtwoPose56
+.4byte sMewtwoPose57
+.4byte sMewtwoPose58
+.4byte sMewtwoPose59
+.4byte sMewtwoPose60
+.4byte sMewtwoPose61
+.4byte sMewtwoPose62
+.4byte sMewtwoPose63
+.4byte sMewtwoPose64
+.4byte sMewtwoPose65
+.4byte sMewtwoPose66
+.4byte sMewtwoPose67
+.4byte sMewtwoPose68
+.4byte sMewtwoPose69
+.4byte sMewtwoPose70
+.4byte sMewtwoPose71
+.4byte sMewtwoPose72
+.4byte sMewtwoPose73
+.4byte sMewtwoPose74
+.4byte sMewtwoPose75
+.4byte sMewtwoPose76
+.4byte sMewtwoPose77
+.4byte sMewtwoPose78
+.4byte sMewtwoPose79
+.4byte sMewtwoPose80
+.4byte sMewtwoPose81
+.4byte sMewtwoPose82
+.4byte sMewtwoPose83
+.4byte sMewtwoPose84
+.4byte sMewtwoPose85
+.4byte sMewtwoPose86
+.4byte sMewtwoPose87
+.4byte sMewtwoPose88
+.4byte sMewtwoPose89
+.4byte sMewtwoPose90
+.4byte sMewtwoPose91
+.4byte sMewtwoPose92
+.4byte sMewtwoPose93
+.4byte sMewtwoPose94
+.4byte sMewtwoPose95
+.4byte sMewtwoPose96
+.4byte sMewtwoPose97
+.4byte sMewtwoPose98
+.4byte sMewtwoPose99
+.4byte sMewtwoPose100
+.4byte sMewtwoPose101
+.4byte sMewtwoPose102
+.4byte sMewtwoPose103
+.4byte sMewtwoPose104
+.4byte sMewtwoPose105
+.4byte sMewtwoPose106
+.4byte sMewtwoPose107
+.4byte sMewtwoPose108
+.4byte sMewtwoPose109
+.4byte sMewtwoPose110
+.4byte sMewtwoPose111
+.4byte sMewtwoPose112
+.4byte sMewtwoPose113
+.4byte sMewtwoPose114
+.4byte sMewtwoPose115
+.4byte sMewtwoPose116
+.4byte sMewtwoPose117
+.4byte sMewtwoPose118
+.4byte sMewtwoPose119
+.4byte sMewtwoPose120
+.4byte sMewtwoPose121
+.4byte sMewtwoPose122
+.4byte sMewtwoPose123
+.4byte sMewtwoPose124
+.4byte sMewtwoPose125
+.4byte sMewtwoPose126
+.4byte sMewtwoPose127
+.4byte sMewtwoPose128
+.4byte sMewtwoPose129
+.4byte sMewtwoPose130
+.4byte sMewtwoPose131
+.4byte sMewtwoPose132
+.4byte sMewtwoPose133
+.4byte sMewtwoPose134
+.4byte sMewtwoPose135
+.4byte sMewtwoPose136
+.4byte sMewtwoPose137
+.4byte sMewtwoPose138
+.4byte sMewtwoPose139
+.4byte sMewtwoPose140
+.4byte sMewtwoPose141
+.4byte sMewtwoPose142
+.4byte sMewtwoPose143
+.4byte sMewtwoPose144
+.4byte sMewtwoPose145
+.4byte sMewtwoPose146
+.4byte sMewtwoPose147
+.4byte sMewtwoPose148
+.4byte sMewtwoPose149
+.4byte sMewtwoPose150
+.4byte sMewtwoPose151
+.4byte sMewtwoPose152
+.4byte sMewtwoPose153
+.4byte sMewtwoPose154
+.4byte sMewtwoPose155
+.4byte sMewtwoPose156
+.4byte sMewtwoPose157
+.4byte sMewtwoPose158
+.4byte sMewtwoPose159
+.4byte sMewtwoPose160
+.4byte sMewtwoPose161
+.4byte sMewtwoPose162
+.4byte sMewtwoPose163
+.4byte sMewtwoPose164
+.4byte sMewtwoPose165
+.4byte sMewtwoPose166
+.4byte sMewtwoPose167
+.4byte sMewtwoPose168
+.4byte sMewtwoPose169
+.4byte sMewtwoPose170
+.4byte sMewtwoPose171
+.4byte sMewtwoPose172
+.4byte sMewtwoPose173
+.4byte sMewtwoPose174
+.4byte sMewtwoPose175
+.4byte sMewtwoPose176
+.4byte sMewtwoPose177
+.4byte sMewtwoPose178
+.4byte sMewtwoPose179
+.4byte sMewtwoPose180
+.4byte sMewtwoPose181
+.4byte sMewtwoPose182
+.4byte sMewtwoPose183
+.4byte sMewtwoPose184
+.4byte sMewtwoPose185
+.4byte sMewtwoPose186
+.4byte sMewtwoPose187
+.4byte sMewtwoPose188
+.4byte sMewtwoPose189
+.4byte sMewtwoPose190
+.4byte sMewtwoPose191
+.4byte sMewtwoPose192
+.4byte sMewtwoPose193
+.4byte sMewtwoPose194
+.4byte sMewtwoPose195
+.4byte sMewtwoPose196
+.4byte sMewtwoPose197
+.4byte sMewtwoPose198
+.4byte sMewtwoPose199
+.4byte sMewtwoPose200
+.4byte sMewtwoPose201
+.4byte sMewtwoPose202
+.4byte sMewtwoPose203
+.4byte sMewtwoPose204
+.4byte sMewtwoPose205
+.4byte sMewtwoPose206
+.4byte sMewtwoPose207
+.4byte sMewtwoPose208
+.4byte sMewtwoPose209
+.4byte sMewtwoPose210
+.4byte sMewtwoPose211
+.4byte sMewtwoPose212
+.4byte sMewtwoPose213
+.4byte sMewtwoPose214
+.4byte sMewtwoPose215
+.4byte sMewtwoPose216
+.4byte sMewtwoPose217
+.4byte sMewtwoPose218
+.4byte sMewtwoPose219
+.4byte sMewtwoPose220
+.4byte sMewtwoPose221
+.4byte sMewtwoPose222
+.4byte sMewtwoPose223
+.4byte sMewtwoPose224
+.4byte sMewtwoPose225
+.4byte sMewtwoPose226
+.4byte sMewtwoPose227
+.4byte sMewtwoPose228
+.4byte sMewtwoPose229
+.4byte sMewtwoPose230
+.4byte sMewtwoPose231
+.4byte sMewtwoPose232
+.4byte sMewtwoPose233
+.4byte sMewtwoPose234
+.4byte sMewtwoPose235
+.4byte sMewtwoPose236
+.4byte sMewtwoPose237
+.4byte sMewtwoPose238
+.4byte sMewtwoPose239
+.4byte sMewtwoPose240
+.4byte sMewtwoPose241
+.4byte sMewtwoPose242
+.4byte sMewtwoPose243
+.4byte sMewtwoPose244
+.4byte sMewtwoPose245
+.4byte sMewtwoPose246
+.4byte sMewtwoPose247
+.4byte sMewtwoPose248
+.4byte sMewtwoPose249
+.4byte sMewtwoPose250
+.4byte sMewtwoPose251
+.4byte sMewtwoPose252
+.4byte sMewtwoPose253
+.4byte sMewtwoPose254
+.4byte sMewtwoPose255
+.4byte sMewtwoPose256
+.4byte sMewtwoPose257
+.4byte sMewtwoPose258
+sAxPositionsMewtwo:
+.2byte   -1,  -15, 	  -9,  -10, 	   7,  -10, 	  -1,  -12
+.2byte   -1,  -14, 	  -9,   -8, 	   7,   -8, 	  -1,  -11
+.2byte    4,  -15, 	   9,  -10, 	  -4,   -8, 	   1,  -12
+.2byte    4,  -14, 	   9,   -8, 	  -4,   -6, 	   1,  -11
+.2byte    7,  -15, 	   5,  -10, 	   0,   -6, 	  -2,  -11
+.2byte    7,  -14, 	   4,   -8, 	  -1,   -4, 	  -2,  -10
+.2byte    5,  -19, 	  -1,  -15, 	   8,  -11, 	  -1,  -13
+.2byte    5,  -18, 	  -1,  -13, 	   8,   -9, 	  -1,  -12
+.2byte   -1,  -20, 	   8,  -16, 	 -10,  -16, 	  -1,  -17
+.2byte   -1,  -19, 	   8,  -14, 	 -10,  -14, 	  -1,  -15
+.2byte   -6,  -19, 	   0,  -15, 	  -9,  -11, 	   0,  -13
+.2byte   -6,  -18, 	   0,  -13, 	  -9,   -9, 	   0,  -12
+.2byte   -8,  -15, 	  -6,  -10, 	  -1,   -6, 	   1,  -11
+.2byte   -8,  -14, 	  -5,   -8, 	   0,   -4, 	   1,  -10
+.2byte   -5,  -15, 	 -10,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -5,  -14, 	 -10,   -8, 	   3,   -6, 	  -2,  -11
+.2byte   -1,  -15, 	  -9,  -10, 	   7,  -10, 	  -1,  -12
+.2byte   -1,  -15, 	  -9,   -9, 	   7,   -9, 	  -1,  -12
+.2byte    4,  -15, 	   9,  -10, 	  -4,   -8, 	   1,  -12
+.2byte    4,  -15, 	   9,   -9, 	  -4,   -7, 	   1,  -12
+.2byte    7,  -15, 	   5,  -10, 	   0,   -6, 	  -2,  -11
+.2byte    7,  -15, 	   4,   -9, 	  -1,   -5, 	  -2,  -11
+.2byte    5,  -19, 	  -1,  -15, 	   8,  -11, 	  -1,  -13
+.2byte    4,  -18, 	  -2,  -13, 	   7,   -9, 	  -2,  -12
+.2byte   -1,  -20, 	   8,  -16, 	 -10,  -16, 	  -1,  -17
+.2byte   -1,  -20, 	   8,  -15, 	 -10,  -15, 	  -1,  -16
+.2byte   -6,  -19, 	   0,  -15, 	  -9,  -11, 	   0,  -13
+.2byte   -6,  -19, 	   0,  -14, 	  -9,  -10, 	   0,  -13
+.2byte   -8,  -15, 	  -6,  -10, 	  -1,   -6, 	   1,  -11
+.2byte   -8,  -15, 	  -5,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -5,  -15, 	 -10,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -5,  -15, 	 -10,   -9, 	   3,   -7, 	  -2,  -12
+.2byte   -1,  -15, 	 -12,  -14, 	  10,  -14, 	  -1,  -11
+.2byte   -7,  -13, 	  -4,  -14, 	  -6,  -11, 	  -1,  -10
+.2byte    0,  -12, 	  -3,   -4, 	   3,   -2, 	   0,   -9
+.2byte    0,  -12, 	  -3,   -4, 	   3,   -2, 	   0,   -9
+.2byte   -7,  -13, 	  -4,  -14, 	  -6,  -11, 	  -1,  -10
+.2byte   -7,  -13, 	  -4,  -14, 	  -6,  -11, 	  -1,  -10
+.2byte    2,  -15, 	  10,  -16, 	  -3,  -11, 	   0,  -11
+.2byte    5,  -14, 	   1,  -14, 	   4,  -13, 	   1,  -10
+.2byte    5,  -10, 	  12,   -6, 	   4,   -2, 	   2,   -8
+.2byte    5,  -10, 	  12,   -6, 	   4,   -2, 	   2,   -8
+.2byte    5,  -14, 	   1,  -14, 	   4,  -13, 	   1,  -10
+.2byte    5,  -14, 	   1,  -14, 	   4,  -13, 	   1,  -10
+.2byte    4,  -15, 	   8,  -18, 	   4,  -10, 	  -1,  -10
+.2byte    2,  -16, 	 -10,  -16, 	  -4,  -15, 	  -2,  -12
+.2byte    7,  -14, 	  13,  -14, 	  11,   -6, 	   0,  -10
+.2byte    7,  -14, 	  13,  -14, 	  11,   -6, 	   0,  -10
+.2byte    2,  -16, 	 -10,  -16, 	  -4,  -15, 	  -2,  -12
+.2byte    2,  -16, 	 -10,  -16, 	  -4,  -15, 	  -2,  -12
+.2byte    3,  -17, 	  -1,  -15, 	  10,  -13, 	  -2,  -12
+.2byte   -1,  -17, 	 -10,  -13, 	  -3,  -13, 	  -2,  -11
+.2byte    4,  -17, 	   8,  -18, 	  10,  -12, 	   0,  -12
+.2byte    4,  -17, 	   8,  -18, 	  10,  -12, 	   0,  -12
+.2byte   -1,  -17, 	 -10,  -13, 	  -3,  -13, 	  -2,  -11
+.2byte   -1,  -17, 	 -10,  -13, 	  -3,  -13, 	  -2,  -11
+.2byte   -1,  -17, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte    3,  -14, 	   6,   -8, 	   6,  -10, 	  -1,   -9
+.2byte   -1,  -17, 	   5,  -20, 	  -5,  -18, 	  -1,  -13
+.2byte   -1,  -17, 	   5,  -20, 	  -5,  -18, 	  -1,  -13
+.2byte    3,  -14, 	   6,   -8, 	   4,   -9, 	  -2,   -8
+.2byte    3,  -14, 	   6,   -8, 	   4,   -9, 	  -2,   -8
+.2byte   -4,  -17, 	   0,  -15, 	 -11,  -13, 	   1,  -12
+.2byte    0,  -17, 	   9,  -13, 	   2,  -13, 	   1,  -11
+.2byte   -5,  -17, 	  -9,  -18, 	 -11,  -12, 	  -1,  -12
+.2byte   -5,  -17, 	  -9,  -18, 	 -11,  -12, 	  -1,  -12
+.2byte    0,  -17, 	   9,  -13, 	   2,  -13, 	   1,  -11
+.2byte    0,  -17, 	   9,  -13, 	   2,  -13, 	   1,  -11
+.2byte   -5,  -15, 	  -9,  -18, 	  -5,  -10, 	   0,  -10
+.2byte   -3,  -16, 	   9,  -16, 	   3,  -15, 	   1,  -12
+.2byte   -8,  -14, 	 -14,  -14, 	 -12,   -6, 	  -1,  -10
+.2byte   -8,  -14, 	 -14,  -14, 	 -12,   -6, 	  -1,  -10
+.2byte   -3,  -16, 	   9,  -16, 	   3,  -15, 	   1,  -12
+.2byte   -3,  -16, 	   9,  -16, 	   3,  -15, 	   1,  -12
+.2byte   -3,  -15, 	 -11,  -16, 	   2,  -11, 	  -1,  -11
+.2byte   -6,  -14, 	  -2,  -14, 	  -5,  -13, 	  -2,  -10
+.2byte   -6,  -10, 	 -13,   -6, 	  -5,   -2, 	  -3,   -8
+.2byte   -6,  -10, 	 -13,   -6, 	  -5,   -2, 	  -3,   -8
+.2byte   -6,  -14, 	  -2,  -14, 	  -5,  -13, 	  -2,  -10
+.2byte   -6,  -14, 	  -2,  -14, 	  -5,  -13, 	  -2,  -10
+.2byte   -1,  -15, 	 -12,  -14, 	  10,  -14, 	  -1,  -11
+.2byte   -7,  -13, 	  -4,  -14, 	  -6,  -11, 	  -1,  -10
+.2byte    0,  -12, 	  -3,   -4, 	   3,   -2, 	   0,   -9
+.2byte    0,  -12, 	  -3,   -4, 	   3,   -2, 	   0,   -9
+.2byte   -7,  -13, 	  -4,  -14, 	  -6,  -11, 	  -1,  -10
+.2byte   -7,  -13, 	  -4,  -14, 	  -6,  -11, 	  -1,  -10
+.2byte    2,  -15, 	  10,  -16, 	  -3,  -11, 	   0,  -11
+.2byte    5,  -14, 	   1,  -14, 	   4,  -13, 	   1,  -10
+.2byte    5,  -10, 	  12,   -6, 	   4,   -2, 	   2,   -8
+.2byte    5,  -10, 	  12,   -6, 	   4,   -2, 	   2,   -8
+.2byte    5,  -14, 	   1,  -14, 	   4,  -13, 	   1,  -10
+.2byte    5,  -14, 	   1,  -14, 	   4,  -13, 	   1,  -10
+.2byte    4,  -15, 	   8,  -18, 	   4,  -10, 	  -1,  -10
+.2byte    2,  -16, 	 -10,  -16, 	  -4,  -15, 	  -2,  -12
+.2byte    7,  -14, 	  13,  -14, 	  11,   -6, 	   0,  -10
+.2byte    7,  -14, 	  13,  -14, 	  11,   -6, 	   0,  -10
+.2byte    2,  -16, 	 -10,  -16, 	  -4,  -15, 	  -2,  -12
+.2byte    2,  -16, 	 -10,  -16, 	  -4,  -15, 	  -2,  -12
+.2byte    3,  -17, 	  -1,  -15, 	  10,  -13, 	  -2,  -12
+.2byte   -1,  -17, 	 -10,  -13, 	  -3,  -13, 	  -2,  -11
+.2byte    4,  -17, 	   8,  -18, 	  10,  -12, 	   0,  -12
+.2byte    4,  -17, 	   8,  -18, 	  10,  -12, 	   0,  -12
+.2byte   -1,  -17, 	 -10,  -13, 	  -3,  -13, 	  -2,  -11
+.2byte   -1,  -17, 	 -10,  -13, 	  -3,  -13, 	  -2,  -11
+.2byte   -1,  -17, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte    3,  -14, 	   6,   -8, 	   6,  -10, 	  -1,   -9
+.2byte   -1,  -17, 	   5,  -20, 	  -5,  -18, 	  -1,  -13
+.2byte   -1,  -17, 	   5,  -20, 	  -5,  -18, 	  -1,  -13
+.2byte    3,  -14, 	   6,   -8, 	   4,   -9, 	  -2,   -8
+.2byte    3,  -14, 	   6,   -8, 	   4,   -9, 	  -2,   -8
+.2byte   -4,  -17, 	   0,  -15, 	 -11,  -13, 	   1,  -12
+.2byte    0,  -17, 	   9,  -13, 	   2,  -13, 	   1,  -11
+.2byte   -5,  -17, 	  -9,  -18, 	 -11,  -12, 	  -1,  -12
+.2byte   -5,  -17, 	  -9,  -18, 	 -11,  -12, 	  -1,  -12
+.2byte    0,  -17, 	   9,  -13, 	   2,  -13, 	   1,  -11
+.2byte    0,  -17, 	   9,  -13, 	   2,  -13, 	   1,  -11
+.2byte   -5,  -15, 	  -9,  -18, 	  -5,  -10, 	   0,  -10
+.2byte   -3,  -16, 	   9,  -16, 	   3,  -15, 	   1,  -12
+.2byte   -8,  -14, 	 -14,  -14, 	 -12,   -6, 	  -1,  -10
+.2byte   -8,  -14, 	 -14,  -14, 	 -12,   -6, 	  -1,  -10
+.2byte   -3,  -16, 	   9,  -16, 	   3,  -15, 	   1,  -12
+.2byte   -3,  -16, 	   9,  -16, 	   3,  -15, 	   1,  -12
+.2byte   -3,  -15, 	 -11,  -16, 	   2,  -11, 	  -1,  -11
+.2byte   -6,  -14, 	  -2,  -14, 	  -5,  -13, 	  -2,  -10
+.2byte   -6,  -10, 	 -13,   -6, 	  -5,   -2, 	  -3,   -8
+.2byte   -6,  -10, 	 -13,   -6, 	  -5,   -2, 	  -3,   -8
+.2byte   -6,  -14, 	  -2,  -14, 	  -5,  -13, 	  -2,  -10
+.2byte   -6,  -14, 	  -2,  -14, 	  -5,  -13, 	  -2,  -10
+.2byte   -1,  -15, 	 -12,  -14, 	  10,  -14, 	  -1,  -11
+.2byte   -1,  -14, 	 -14,  -16, 	  12,  -16, 	  -1,  -10
+.2byte   -1,  -15, 	  -9,  -10, 	   7,  -10, 	  -1,  -12
+.2byte   -1,  -15, 	  -9,   -9, 	   7,   -9, 	  -1,  -12
+.2byte    2,  -15, 	  10,  -16, 	  -3,  -11, 	   0,  -11
+.2byte    4,  -14, 	  13,  -17, 	  -9,  -13, 	   1,  -11
+.2byte    5,  -15, 	  10,  -10, 	  -3,   -8, 	   2,  -12
+.2byte    5,  -15, 	  10,   -9, 	  -3,   -7, 	   2,  -12
+.2byte    4,  -15, 	   8,  -18, 	   4,  -10, 	  -1,  -10
+.2byte    6,  -14, 	   2,  -16, 	   2,   -8, 	  -2,  -10
+.2byte    7,  -15, 	   5,  -10, 	   0,   -6, 	  -2,  -11
+.2byte    7,  -15, 	   4,   -9, 	  -1,   -5, 	  -2,  -11
+.2byte    3,  -17, 	  -1,  -15, 	  10,  -13, 	  -2,  -12
+.2byte    3,  -17, 	  -8,  -19, 	  11,  -11, 	  -1,  -13
+.2byte    4,  -19, 	  -2,  -15, 	   7,  -11, 	  -2,  -13
+.2byte    4,  -19, 	  -2,  -14, 	   7,  -10, 	  -2,  -13
+.2byte   -1,  -17, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte   -1,  -20, 	  12,  -17, 	 -14,  -17, 	  -1,  -14
+.2byte   -1,  -19, 	   8,  -15, 	 -10,  -15, 	  -1,  -16
+.2byte   -1,  -19, 	   8,  -14, 	 -10,  -14, 	  -1,  -15
+.2byte   -4,  -17, 	   0,  -15, 	 -11,  -13, 	   1,  -12
+.2byte   -4,  -17, 	   7,  -19, 	 -12,  -11, 	   0,  -13
+.2byte   -5,  -19, 	   1,  -15, 	  -8,  -11, 	   1,  -13
+.2byte   -5,  -19, 	   1,  -14, 	  -8,  -10, 	   1,  -13
+.2byte   -5,  -15, 	  -9,  -18, 	  -5,  -10, 	   0,  -10
+.2byte   -7,  -14, 	  -3,  -16, 	  -3,   -8, 	   1,  -10
+.2byte   -8,  -15, 	  -6,  -10, 	  -1,   -6, 	   1,  -11
+.2byte   -8,  -15, 	  -5,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -3,  -15, 	 -11,  -16, 	   2,  -11, 	  -1,  -11
+.2byte   -5,  -14, 	 -14,  -17, 	   8,  -13, 	  -2,  -11
+.2byte   -6,  -15, 	 -11,  -10, 	   2,   -8, 	  -3,  -12
+.2byte   -6,  -15, 	 -11,   -9, 	   2,   -7, 	  -3,  -12
+.2byte   -4,   -8, 	  -7,   -2, 	   5,    1, 	  -1,   -6
+.2byte   -5,   -7, 	  -7,   -2, 	   5,    2, 	  -1,   -5
+.2byte    0,  -23, 	 -11,  -16, 	  11,  -16, 	   0,  -16
+.2byte   -2,  -23, 	  10,  -17, 	  -1,  -11, 	   0,  -16
+.2byte   -2,  -23, 	   7,  -18, 	   3,  -11, 	  -1,  -14
+.2byte   -3,  -20, 	   2,  -24, 	  10,  -20, 	  -1,  -11
+.2byte    0,  -21, 	  10,  -22, 	  -9,  -22, 	   0,  -12
+.2byte    4,  -20, 	  -1,  -24, 	  -9,  -20, 	   2,  -11
+.2byte    1,  -23, 	  -8,  -18, 	  -4,  -11, 	   0,  -14
+.2byte    1,  -21, 	 -11,  -15, 	   0,   -9, 	  -1,  -14
+.2byte   -1,  -15, 	 -12,  -14, 	  10,  -14, 	  -1,  -11
+.2byte   -1,  -14, 	 -14,  -16, 	  12,  -16, 	  -1,  -10
+.2byte   -1,  -15, 	  -9,  -10, 	   7,  -10, 	  -1,  -12
+.2byte   -1,  -15, 	  -9,   -9, 	   7,   -9, 	  -1,  -12
+.2byte    2,  -15, 	  10,  -16, 	  -3,  -11, 	   0,  -11
+.2byte    4,  -14, 	  13,  -17, 	  -9,  -13, 	   1,  -11
+.2byte    5,  -15, 	  10,  -10, 	  -3,   -8, 	   2,  -12
+.2byte    5,  -15, 	  10,   -9, 	  -3,   -7, 	   2,  -12
+.2byte    4,  -15, 	   8,  -18, 	   4,  -10, 	  -1,  -10
+.2byte    6,  -14, 	   2,  -16, 	   2,   -8, 	  -2,  -10
+.2byte    7,  -15, 	   5,  -10, 	   0,   -6, 	  -2,  -11
+.2byte    7,  -15, 	   4,   -9, 	  -1,   -5, 	  -2,  -11
+.2byte    3,  -17, 	  -1,  -15, 	  10,  -13, 	  -2,  -12
+.2byte    3,  -17, 	  -8,  -19, 	  11,  -11, 	  -1,  -13
+.2byte    4,  -19, 	  -2,  -15, 	   7,  -11, 	  -2,  -13
+.2byte    4,  -19, 	  -2,  -14, 	   7,  -10, 	  -2,  -13
+.2byte   -1,  -17, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte   -1,  -20, 	  12,  -17, 	 -14,  -17, 	  -1,  -14
+.2byte   -1,  -19, 	   8,  -15, 	 -10,  -15, 	  -1,  -16
+.2byte   -1,  -19, 	   8,  -14, 	 -10,  -14, 	  -1,  -15
+.2byte   -4,  -17, 	   0,  -15, 	 -11,  -13, 	   1,  -12
+.2byte   -4,  -17, 	   7,  -19, 	 -12,  -11, 	   0,  -13
+.2byte   -5,  -19, 	   1,  -15, 	  -8,  -11, 	   1,  -13
+.2byte   -5,  -19, 	   1,  -14, 	  -8,  -10, 	   1,  -13
+.2byte   -5,  -15, 	  -9,  -18, 	  -5,  -10, 	   0,  -10
+.2byte   -7,  -14, 	  -3,  -16, 	  -3,   -8, 	   1,  -10
+.2byte   -8,  -15, 	  -6,  -10, 	  -1,   -6, 	   1,  -11
+.2byte   -8,  -15, 	  -5,   -9, 	   0,   -5, 	   1,  -11
+.2byte   -3,  -15, 	 -11,  -16, 	   2,  -11, 	  -1,  -11
+.2byte   -5,  -14, 	 -14,  -17, 	   8,  -13, 	  -2,  -11
+.2byte   -6,  -15, 	 -11,  -10, 	   2,   -8, 	  -3,  -12
+.2byte   -6,  -15, 	 -11,   -9, 	   2,   -7, 	  -3,  -12
+.2byte   -7,  -13, 	  -4,  -14, 	  -6,  -11, 	  -1,  -10
+.2byte   -6,  -14, 	  -2,  -14, 	  -5,  -13, 	  -2,  -10
+.2byte   -3,  -16, 	   9,  -16, 	   3,  -15, 	   1,  -12
+.2byte    1,  -17, 	  10,  -13, 	   3,  -13, 	   2,  -11
+.2byte    3,  -14, 	   6,   -8, 	   6,  -10, 	  -1,   -9
+.2byte    0,  -17, 	  -9,  -13, 	  -2,  -13, 	  -1,  -11
+.2byte    2,  -16, 	 -10,  -16, 	  -4,  -15, 	  -2,  -12
+.2byte    5,  -14, 	   1,  -14, 	   4,  -13, 	   1,  -10
+.2byte   -1,  -14, 	 -14,  -16, 	  12,  -16, 	  -1,  -10
+.2byte    3,  -14, 	  12,  -17, 	 -10,  -13, 	   0,  -11
+.2byte    6,  -14, 	   2,  -16, 	   2,   -8, 	  -2,  -10
+.2byte    3,  -17, 	  -8,  -19, 	  11,  -11, 	  -1,  -13
+.2byte   -1,  -20, 	  12,  -17, 	 -14,  -17, 	  -1,  -14
+.2byte   -3,  -17, 	   8,  -19, 	 -11,  -11, 	   1,  -13
+.2byte   -7,  -14, 	  -3,  -16, 	  -3,   -8, 	   1,  -10
+.2byte   -4,  -14, 	 -13,  -17, 	   9,  -13, 	  -1,  -11
+.2byte   -1,  -15, 	 -12,  -14, 	  10,  -14, 	  -1,  -11
+.2byte   -1,  -15, 	  -9,  -10, 	   7,  -10, 	  -1,  -12
+.2byte   -1,  -15, 	 -14,  -17, 	  12,  -17, 	  -1,  -11
+.2byte    2,  -15, 	  10,  -16, 	  -3,  -11, 	   0,  -11
+.2byte    4,  -15, 	   9,  -10, 	  -4,   -8, 	   1,  -12
+.2byte    3,  -16, 	  12,  -19, 	 -10,  -15, 	   0,  -13
+.2byte    4,  -15, 	   8,  -18, 	   4,  -10, 	  -1,  -10
+.2byte    7,  -15, 	   5,  -10, 	   0,   -6, 	  -2,  -11
+.2byte    5,  -16, 	   1,  -18, 	   1,  -10, 	  -3,  -12
+.2byte    3,  -17, 	  -1,  -15, 	  10,  -13, 	  -2,  -12
+.2byte    5,  -19, 	  -1,  -15, 	   8,  -11, 	  -1,  -13
+.2byte    2,  -19, 	  -9,  -21, 	  10,  -13, 	  -2,  -15
+.2byte   -1,  -17, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte   -1,  -20, 	   8,  -16, 	 -10,  -16, 	  -1,  -17
+.2byte   -1,  -23, 	  12,  -20, 	 -14,  -20, 	  -1,  -17
+.2byte   -4,  -17, 	   0,  -15, 	 -11,  -13, 	   1,  -12
+.2byte   -6,  -19, 	   0,  -15, 	  -9,  -11, 	   0,  -13
+.2byte   -3,  -19, 	   8,  -21, 	 -11,  -13, 	   1,  -15
+.2byte   -5,  -15, 	  -9,  -18, 	  -5,  -10, 	   0,  -10
+.2byte   -8,  -15, 	  -6,  -10, 	  -1,   -6, 	   1,  -11
+.2byte   -6,  -16, 	  -2,  -18, 	  -2,  -10, 	   2,  -12
+.2byte   -3,  -15, 	 -11,  -16, 	   2,  -11, 	  -1,  -11
+.2byte   -5,  -15, 	 -10,  -10, 	   3,   -8, 	  -2,  -12
+.2byte   -4,  -16, 	 -13,  -19, 	   9,  -15, 	  -1,  -13
+.2byte   -1,  -14, 	 -14,  -16, 	  12,  -16, 	  -1,  -10
+.2byte   -4,  -14, 	 -13,  -17, 	   9,  -13, 	  -1,  -11
+.2byte   -7,  -14, 	  -3,  -16, 	  -3,   -8, 	   1,  -10
+.2byte   -3,  -17, 	   8,  -19, 	 -11,  -11, 	   1,  -13
+.2byte   -1,  -20, 	  12,  -17, 	 -14,  -17, 	  -1,  -14
+.2byte    3,  -17, 	  -8,  -19, 	  11,  -11, 	  -1,  -13
+.2byte    6,  -14, 	   2,  -16, 	   2,   -8, 	  -2,  -10
+.2byte    3,  -14, 	  12,  -17, 	 -10,  -13, 	   0,  -11
+.2byte   -1,  -15, 	 -12,  -14, 	  10,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	 -11,  -16, 	   2,  -11, 	  -1,  -11
+.2byte   -5,  -15, 	  -9,  -18, 	  -5,  -10, 	   0,  -10
+.2byte   -4,  -17, 	   0,  -15, 	 -11,  -13, 	   1,  -12
+.2byte   -1,  -17, 	   9,  -16, 	 -11,  -16, 	  -1,  -13
+.2byte    3,  -17, 	  -1,  -15, 	  10,  -13, 	  -2,  -12
+.2byte    4,  -15, 	   8,  -18, 	   4,  -10, 	  -1,  -10
+.2byte    2,  -15, 	  10,  -16, 	  -3,  -11, 	   0,  -11
+sMewtwoAnimTable1:
+.4byte sMewtwoAnims_1_1
+.4byte sMewtwoAnims_1_2
+.4byte sMewtwoAnims_1_3
+.4byte sMewtwoAnims_1_4
+.4byte sMewtwoAnims_1_5
+.4byte sMewtwoAnims_1_6
+.4byte sMewtwoAnims_1_7
+.4byte sMewtwoAnims_1_8
+sMewtwoAnimTable2:
+.4byte sMewtwoAnims_2_1
+.4byte sMewtwoAnims_2_2
+.4byte sMewtwoAnims_2_3
+.4byte sMewtwoAnims_2_4
+.4byte sMewtwoAnims_2_5
+.4byte sMewtwoAnims_2_6
+.4byte sMewtwoAnims_2_7
+.4byte sMewtwoAnims_2_8
+sMewtwoAnimTable3:
+.4byte sMewtwoAnims_3_1
+.4byte sMewtwoAnims_3_2
+.4byte sMewtwoAnims_3_3
+.4byte sMewtwoAnims_3_4
+.4byte sMewtwoAnims_3_5
+.4byte sMewtwoAnims_3_6
+.4byte sMewtwoAnims_3_7
+.4byte sMewtwoAnims_3_8
+sMewtwoAnimTable4:
+.4byte sMewtwoAnims_4_1
+.4byte sMewtwoAnims_4_2
+.4byte sMewtwoAnims_4_3
+.4byte sMewtwoAnims_4_4
+.4byte sMewtwoAnims_4_5
+.4byte sMewtwoAnims_4_6
+.4byte sMewtwoAnims_4_7
+.4byte sMewtwoAnims_4_8
+sMewtwoAnimTable5:
+.4byte sMewtwoAnims_5_1
+.4byte sMewtwoAnims_5_2
+.4byte sMewtwoAnims_5_3
+.4byte sMewtwoAnims_5_4
+.4byte sMewtwoAnims_5_5
+.4byte sMewtwoAnims_5_6
+.4byte sMewtwoAnims_5_7
+.4byte sMewtwoAnims_5_8
+sMewtwoAnimTable6:
+.4byte sMewtwoAnims_6_1
+.4byte sMewtwoAnims_6_1
+.4byte sMewtwoAnims_6_1
+.4byte sMewtwoAnims_6_1
+.4byte sMewtwoAnims_6_1
+.4byte sMewtwoAnims_6_1
+.4byte sMewtwoAnims_6_1
+.4byte sMewtwoAnims_6_1
+sMewtwoAnimTable7:
+.4byte sMewtwoAnims_7_1
+.4byte sMewtwoAnims_7_2
+.4byte sMewtwoAnims_7_3
+.4byte sMewtwoAnims_7_4
+.4byte sMewtwoAnims_7_5
+.4byte sMewtwoAnims_7_6
+.4byte sMewtwoAnims_7_7
+.4byte sMewtwoAnims_7_8
+sMewtwoAnimTable8:
+.4byte sMewtwoAnims_8_1
+.4byte sMewtwoAnims_8_2
+.4byte sMewtwoAnims_8_3
+.4byte sMewtwoAnims_8_4
+.4byte sMewtwoAnims_8_5
+.4byte sMewtwoAnims_8_6
+.4byte sMewtwoAnims_8_7
+.4byte sMewtwoAnims_8_8
+sMewtwoAnimTable9:
+.4byte sMewtwoAnims_9_1
+.4byte sMewtwoAnims_9_2
+.4byte sMewtwoAnims_9_3
+.4byte sMewtwoAnims_9_4
+.4byte sMewtwoAnims_9_5
+.4byte sMewtwoAnims_9_6
+.4byte sMewtwoAnims_9_7
+.4byte sMewtwoAnims_9_8
+sMewtwoAnimTable10:
+.4byte sMewtwoAnims_10_1
+.4byte sMewtwoAnims_10_2
+.4byte sMewtwoAnims_10_3
+.4byte sMewtwoAnims_10_4
+.4byte sMewtwoAnims_10_5
+.4byte sMewtwoAnims_10_6
+.4byte sMewtwoAnims_10_7
+.4byte sMewtwoAnims_10_8
+sMewtwoAnimTable11:
+.4byte sMewtwoAnims_11_1
+.4byte sMewtwoAnims_11_2
+.4byte sMewtwoAnims_11_3
+.4byte sMewtwoAnims_11_4
+.4byte sMewtwoAnims_11_5
+.4byte sMewtwoAnims_11_6
+.4byte sMewtwoAnims_11_7
+.4byte sMewtwoAnims_11_8
+sMewtwoAnimTable12:
+.4byte sMewtwoAnims_12_1
+.4byte sMewtwoAnims_12_2
+.4byte sMewtwoAnims_12_3
+.4byte sMewtwoAnims_12_4
+.4byte sMewtwoAnims_12_5
+.4byte sMewtwoAnims_12_6
+.4byte sMewtwoAnims_12_7
+.4byte sMewtwoAnims_12_8
+sMewtwoAnimTable13:
+.4byte sMewtwoAnims_13_1
+.4byte sMewtwoAnims_13_2
+.4byte sMewtwoAnims_13_3
+.4byte sMewtwoAnims_13_4
+.4byte sMewtwoAnims_13_5
+.4byte sMewtwoAnims_13_6
+.4byte sMewtwoAnims_13_7
+.4byte sMewtwoAnims_13_8
+sAxAnimationsMewtwo:
+.4byte sMewtwoAnimTable1
+.4byte sMewtwoAnimTable2
+.4byte sMewtwoAnimTable3
+.4byte sMewtwoAnimTable4
+.4byte sMewtwoAnimTable5
+.4byte sMewtwoAnimTable6
+.4byte sMewtwoAnimTable7
+.4byte sMewtwoAnimTable8
+.4byte sMewtwoAnimTable9
+.4byte sMewtwoAnimTable10
+.4byte sMewtwoAnimTable11
+.4byte sMewtwoAnimTable12
+.4byte sMewtwoAnimTable13
+sAxSpritesMewtwo:
+.4byte sMewtwoSprites1
+.4byte sMewtwoSprites2
+.4byte sMewtwoSprites3
+.4byte sMewtwoSprites4
+.4byte sMewtwoSprites5
+.4byte sMewtwoSprites6
+.4byte sMewtwoSprites7
+.4byte sMewtwoSprites8
+.4byte sMewtwoSprites9
+.4byte sMewtwoSprites10
+.4byte sMewtwoSprites11
+.4byte sMewtwoSprites12
+.4byte sMewtwoSprites13
+.4byte sMewtwoSprites14
+.4byte sMewtwoSprites15
+.4byte sMewtwoSprites16
+.4byte sMewtwoSprites17
+.4byte sMewtwoSprites18
+.4byte sMewtwoSprites19
+.4byte sMewtwoSprites20
+.4byte sMewtwoSprites21
+.4byte sMewtwoSprites22
+.4byte sMewtwoSprites23
+.4byte sMewtwoSprites24
+.4byte sMewtwoSprites25
+.4byte sMewtwoSprites26
+.4byte sMewtwoSprites27
+.4byte sMewtwoSprites28
+.4byte sMewtwoSprites29
+.4byte sMewtwoSprites30
+.4byte sMewtwoSprites31
+.4byte sMewtwoSprites32
+.4byte sMewtwoSprites33
+.4byte sMewtwoSprites34
+.4byte sMewtwoSprites35
+.4byte sMewtwoSprites36
+.4byte sMewtwoSprites37
+.4byte sMewtwoSprites38
+.4byte sMewtwoSprites39
+.4byte sMewtwoSprites40
+.4byte sMewtwoSprites41
+.4byte sMewtwoSprites42
+.4byte sMewtwoSprites43
+.4byte sMewtwoSprites44
+.4byte sMewtwoSprites45
+.4byte sMewtwoSprites46
+.4byte sMewtwoSprites47
+.4byte sMewtwoSprites48
+sAxMainMewtwo:
+ax_main sAxPosesMewtwo, sAxAnimationsMewtwo, 13, sAxSpritesMewtwo, sAxPositionsMewtwo

--- a/data/ax/mightyena.inc
+++ b/data/ax/mightyena.inc
@@ -1,0 +1,2756 @@
+.global gAxMightyena
+gAxMightyena:
+ax_siro sAxMainMightyena
+sMightyenaPose1:
+ax_pose 0, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose2:
+ax_pose 1, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose3:
+ax_pose 2, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose4:
+ax_pose 3, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose5:
+ax_pose 4, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose6:
+ax_pose 5, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose7:
+ax_pose 6, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose8:
+ax_pose 7, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose9:
+ax_pose 8, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose10:
+ax_pose 9, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose11:
+ax_pose 10, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose12:
+ax_pose 11, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose13:
+ax_pose 12, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose14:
+ax_pose 13, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose15:
+ax_pose 14, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose16:
+ax_pose 9, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose17:
+ax_pose 10, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose18:
+ax_pose 11, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose19:
+ax_pose 6, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose20:
+ax_pose 7, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose21:
+ax_pose 8, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose22:
+ax_pose 3, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose23:
+ax_pose 4, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose24:
+ax_pose 5, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose25:
+ax_pose 0, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose26:
+ax_pose 15, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose27:
+ax_pose 16, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose28:
+ax_pose 17, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose29:
+ax_pose 3, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose30:
+ax_pose 18, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose31:
+ax_pose 19, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose32:
+ax_pose 20, 0x01ea, 0x90ef, 0xbc00
+ax_pose_terminator
+sMightyenaPose33:
+ax_pose 6, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose34:
+ax_pose 21, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose35:
+ax_pose 22, 0x01e8, 0x90f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose36:
+ax_pose 23, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose37:
+ax_pose 9, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose38:
+ax_pose 24, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose39:
+ax_pose 25, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose40:
+ax_pose 26, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose41:
+ax_pose 12, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose42:
+ax_pose 27, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose43:
+ax_pose 28, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose44:
+ax_pose 29, 0x81e6, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose45:
+ax_pose 9, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose46:
+ax_pose 24, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose47:
+ax_pose 25, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose48:
+ax_pose 26, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose49:
+ax_pose 6, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose50:
+ax_pose 21, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose51:
+ax_pose 22, 0x01e8, 0x80ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose52:
+ax_pose 23, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose54:
+ax_pose 18, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose55:
+ax_pose 19, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose56:
+ax_pose 20, 0x01ea, 0x80f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose57:
+ax_pose 0, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose58:
+ax_pose 15, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose59:
+ax_pose 16, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose60:
+ax_pose 17, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose61:
+ax_pose 3, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose62:
+ax_pose 18, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose63:
+ax_pose 19, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose64:
+ax_pose 20, 0x01ea, 0x90ef, 0xbc00
+ax_pose_terminator
+sMightyenaPose65:
+ax_pose 6, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose66:
+ax_pose 21, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose67:
+ax_pose 22, 0x01e8, 0x90f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose68:
+ax_pose 23, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose69:
+ax_pose 9, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose70:
+ax_pose 24, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose71:
+ax_pose 25, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose72:
+ax_pose 26, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose73:
+ax_pose 12, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose74:
+ax_pose 27, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose75:
+ax_pose 28, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose76:
+ax_pose 29, 0x81e6, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose77:
+ax_pose 9, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose78:
+ax_pose 24, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose79:
+ax_pose 25, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose80:
+ax_pose 26, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose81:
+ax_pose 6, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose82:
+ax_pose 21, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose83:
+ax_pose 22, 0x01e8, 0x80ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose84:
+ax_pose 23, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose86:
+ax_pose 18, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose87:
+ax_pose 19, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose88:
+ax_pose 20, 0x01ea, 0x80f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose89:
+ax_pose 0, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose90:
+ax_pose 15, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose91:
+ax_pose 16, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose92:
+ax_pose 30, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose93:
+ax_pose 3, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose94:
+ax_pose 18, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose95:
+ax_pose 19, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose96:
+ax_pose 31, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose97:
+ax_pose 6, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose98:
+ax_pose 21, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose99:
+ax_pose 22, 0x01e8, 0x90f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose100:
+ax_pose 32, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose101:
+ax_pose 9, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose102:
+ax_pose 24, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose103:
+ax_pose 25, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose104:
+ax_pose 33, 0x01e6, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose105:
+ax_pose 12, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose106:
+ax_pose 27, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose107:
+ax_pose 28, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose108:
+ax_pose 34, 0x81e7, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose109:
+ax_pose 9, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose110:
+ax_pose 24, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose111:
+ax_pose 25, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose112:
+ax_pose 33, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose113:
+ax_pose 6, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose114:
+ax_pose 21, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose115:
+ax_pose 22, 0x01e8, 0x80ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose116:
+ax_pose 32, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose117:
+ax_pose 3, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose118:
+ax_pose 18, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose119:
+ax_pose 19, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose120:
+ax_pose 31, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose121:
+ax_pose 30, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose122:
+ax_pose 15, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose123:
+ax_pose 31, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose124:
+ax_pose 18, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose125:
+ax_pose 32, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose126:
+ax_pose 21, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose127:
+ax_pose 33, 0x01e6, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose128:
+ax_pose 24, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose129:
+ax_pose 34, 0x81e7, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose130:
+ax_pose 27, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose131:
+ax_pose 33, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose132:
+ax_pose 24, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose133:
+ax_pose 32, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose134:
+ax_pose 21, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose135:
+ax_pose 31, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose136:
+ax_pose 18, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose137:
+ax_pose 35, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose138:
+ax_pose 36, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose139:
+ax_pose 37, 0x01e2, 0x80f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose140:
+ax_pose 38, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sMightyenaPose141:
+ax_pose 39, 0x01e3, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose142:
+ax_pose 40, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose143:
+ax_pose 41, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose144:
+ax_pose 40, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose145:
+ax_pose 39, 0x01e3, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose146:
+ax_pose 38, 0x01e5, 0x80f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose147:
+ax_pose 0, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose148:
+ax_pose 15, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose149:
+ax_pose 16, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose150:
+ax_pose 30, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose151:
+ax_pose 3, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose152:
+ax_pose 18, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose153:
+ax_pose 19, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose154:
+ax_pose 31, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose155:
+ax_pose 6, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose156:
+ax_pose 21, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose157:
+ax_pose 22, 0x01e8, 0x90f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose158:
+ax_pose 32, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose159:
+ax_pose 9, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose160:
+ax_pose 24, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose161:
+ax_pose 25, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose162:
+ax_pose 33, 0x01e6, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose163:
+ax_pose 12, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose164:
+ax_pose 27, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose165:
+ax_pose 28, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose166:
+ax_pose 34, 0x81e7, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose167:
+ax_pose 9, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose168:
+ax_pose 24, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose169:
+ax_pose 25, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose170:
+ax_pose 33, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose171:
+ax_pose 6, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose172:
+ax_pose 21, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose173:
+ax_pose 22, 0x01e8, 0x80ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose174:
+ax_pose 32, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose175:
+ax_pose 3, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose176:
+ax_pose 18, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose177:
+ax_pose 19, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose178:
+ax_pose 31, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose179:
+ax_pose 17, 0x81eb, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose180:
+ax_pose 20, 0x01ec, 0x80f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose181:
+ax_pose 23, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose182:
+ax_pose 26, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose183:
+ax_pose 29, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose184:
+ax_pose 26, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose185:
+ax_pose 23, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose186:
+ax_pose 20, 0x01ec, 0x90ef, 0xbc00
+ax_pose_terminator
+sMightyenaPose187:
+ax_pose 15, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose188:
+ax_pose 18, 0x01e9, 0x90ee, 0xbc00
+ax_pose_terminator
+sMightyenaPose189:
+ax_pose 21, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose190:
+ax_pose 24, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose191:
+ax_pose 27, 0x81e7, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose192:
+ax_pose 24, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose193:
+ax_pose 21, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose194:
+ax_pose 18, 0x01e9, 0x80f2, 0xbc00
+ax_pose_terminator
+sMightyenaPose195:
+ax_pose 0, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose196:
+ax_pose 16, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose197:
+ax_pose 17, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose198:
+ax_pose 3, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sMightyenaPose199:
+ax_pose 19, 0x01e8, 0x90ef, 0xbc00
+ax_pose_terminator
+sMightyenaPose200:
+ax_pose 20, 0x01ea, 0x90ef, 0xbc00
+ax_pose_terminator
+sMightyenaPose201:
+ax_pose 6, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose202:
+ax_pose 22, 0x01e8, 0x90f2, 0xbc00
+ax_pose_terminator
+sMightyenaPose203:
+ax_pose 23, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose204:
+ax_pose 9, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose205:
+ax_pose 25, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose206:
+ax_pose 26, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose207:
+ax_pose 12, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose208:
+ax_pose 28, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose209:
+ax_pose 29, 0x81e6, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose210:
+ax_pose 9, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose211:
+ax_pose 25, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose212:
+ax_pose 26, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose213:
+ax_pose 6, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose214:
+ax_pose 22, 0x01e8, 0x80ee, 0xbc00
+ax_pose_terminator
+sMightyenaPose215:
+ax_pose 23, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose216:
+ax_pose 3, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose217:
+ax_pose 19, 0x01e8, 0x80f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose218:
+ax_pose 20, 0x01ea, 0x80f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose219:
+ax_pose 16, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose220:
+ax_pose 19, 0x01e8, 0x80f2, 0xbc00
+ax_pose_terminator
+sMightyenaPose221:
+ax_pose 22, 0x01e8, 0x80ef, 0xbc00
+ax_pose_terminator
+sMightyenaPose222:
+ax_pose 25, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose223:
+ax_pose 28, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose224:
+ax_pose 25, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose225:
+ax_pose 22, 0x01e8, 0x90f1, 0xbc00
+ax_pose_terminator
+sMightyenaPose226:
+ax_pose 19, 0x01e8, 0x90ee, 0xbc00
+ax_pose_terminator
+sMightyenaPose227:
+ax_pose 0, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose228:
+ax_pose 3, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sMightyenaPose229:
+ax_pose 6, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose230:
+ax_pose 9, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sMightyenaPose231:
+ax_pose 12, 0x81e8, 0x80f8, 0xbc00
+ax_pose_terminator
+sMightyenaPose232:
+ax_pose 9, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sMightyenaPose233:
+ax_pose 6, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sMightyenaPose234:
+ax_pose 3, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+.align 2
+sMightyenaAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_2_1:
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 2, 24, 0, -4, 0, -4,
+ax_anim 4, 2, 24, 0, -5, 0, -5,
+ax_anim 2, 0, 27, 0, -5, 0, -5,
+ax_anim 2, 0, 27, 0, 4, 0, 4,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sMightyenaAnims_2_2:
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 4, 2, 28, -5, -5, -5, -5,
+ax_anim 2, 0, 31, 1, -3, 1, 1,
+ax_anim 2, 0, 31, 8, 3, 8, 8,
+ax_anim 2, 0, 30, 16, 17, 16, 17,
+ax_anim 2, 1, 28, 17, 16, 17, 16,
+ax_anim 2, 0, 30, 16, 17, 16, 17,
+ax_anim 2, 0, 28, 17, 16, 17, 16,
+ax_anim 2, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sMightyenaAnims_2_3:
+ax_anim 2, 0, 32, -2, 0, -2, 0,
+ax_anim 2, 0, 32, -4, 0, -4, 0,
+ax_anim 4, 2, 32, -5, 0, -5, 0,
+ax_anim 2, 0, 35, 1, -1, 1, 0,
+ax_anim 2, 0, 35, 8, -3, 8, 0,
+ax_anim 2, 0, 34, 13, 0, 13, 0,
+ax_anim 2, 1, 32, 13, 1, 13, 1,
+ax_anim 2, 0, 34, 13, 0, 13, 0,
+ax_anim 2, 0, 32, 13, 1, 13, 1,
+ax_anim 2, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sMightyenaAnims_2_4:
+ax_anim 2, 0, 36, -2, 2, -2, 2,
+ax_anim 2, 0, 36, -4, 4, -4, 4,
+ax_anim 4, 2, 36, -5, 5, -5, 5,
+ax_anim 2, 0, 39, 1, -7, 1, -1,
+ax_anim 2, 0, 39, 8, -13, 8, -8,
+ax_anim 2, 0, 38, 17, -16, 17, -16,
+ax_anim 2, 1, 36, 18, -15, 18, -15,
+ax_anim 2, 0, 38, 17, -16, 17, -16,
+ax_anim 2, 0, 36, 18, -15, 18, -15,
+ax_anim 2, 0, 36, 10, -10, 10, -10,
+ax_anim 2, 0, 36, 4, -4, 4, -4,
+ax_anim_terminator
+sMightyenaAnims_2_5:
+ax_anim 2, 0, 40, 0, 2, 0, 2,
+ax_anim 2, 0, 40, 0, 4, 0, 4,
+ax_anim 4, 2, 40, 0, 5, 0, 5,
+ax_anim 2, 0, 43, 0, -6, 0, -2,
+ax_anim 2, 0, 43, 0, -12, 0, -8,
+ax_anim 2, 0, 42, 0, -16, 0, -16,
+ax_anim 2, 1, 40, 1, -16, 1, -16,
+ax_anim 2, 0, 42, 0, -16, 0, -16,
+ax_anim 2, 0, 40, 1, -16, 1, -16,
+ax_anim 2, 0, 40, 0, -10, 0, -10,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sMightyenaAnims_2_6:
+ax_anim 2, 0, 44, 2, 2, 2, 2,
+ax_anim 2, 0, 44, 4, 4, 4, 4,
+ax_anim 4, 2, 44, 5, 5, 5, 5,
+ax_anim 2, 0, 47, -1, -7, -1, -1,
+ax_anim 2, 0, 47, -8, -13, -8, -8,
+ax_anim 2, 0, 46, -17, -16, -17, -16,
+ax_anim 2, 1, 44, -18, -15, -18, -15,
+ax_anim 2, 0, 46, -17, -16, -17, -16,
+ax_anim 2, 0, 44, -18, -15, -18, -15,
+ax_anim 2, 0, 44, -10, -10, -10, -10,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim_terminator
+sMightyenaAnims_2_7:
+ax_anim 2, 0, 48, 2, 0, 2, 0,
+ax_anim 2, 0, 48, 4, 0, 4, 0,
+ax_anim 4, 2, 48, 5, 0, 5, 0,
+ax_anim 2, 0, 51, -1, -1, -1, 0,
+ax_anim 2, 0, 51, -8, -3, -8, 0,
+ax_anim 2, 0, 50, -13, 0, -13, 0,
+ax_anim 2, 1, 48, -13, 1, -13, 1,
+ax_anim 2, 0, 50, -13, 1, -13, 0,
+ax_anim 2, 0, 48, -13, 1, -13, 1,
+ax_anim 2, 0, 48, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sMightyenaAnims_2_8:
+ax_anim 2, 0, 52, 2, -2, 2, -2,
+ax_anim 2, 0, 52, 4, -4, 4, -4,
+ax_anim 4, 2, 52, 5, -5, 5, -5,
+ax_anim 2, 0, 55, -1, -3, -1, 1,
+ax_anim 2, 0, 55, -8, 3, -8, 8,
+ax_anim 2, 0, 54, -16, 17, -16, 17,
+ax_anim 2, 1, 52, -17, 16, -17, 16,
+ax_anim 2, 0, 54, -16, 17, -16, 17,
+ax_anim 2, 0, 52, -17, 16, -17, 16,
+ax_anim 2, 0, 52, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 2, 56, 0, -4, 0, -4,
+ax_anim 4, 2, 56, 0, -5, 0, -5,
+ax_anim 2, 0, 59, 0, -5, 0, -5,
+ax_anim 2, 0, 59, 0, 4, 0, 4,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 1, 56, 1, 18, 1, 18,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 0, 56, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sMightyenaAnims_3_2:
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 60, -4, -4, -4, -4,
+ax_anim 4, 2, 60, -5, -5, -5, -5,
+ax_anim 2, 0, 63, 1, -3, 1, 1,
+ax_anim 2, 0, 63, 8, 3, 8, 8,
+ax_anim 2, 0, 62, 16, 17, 16, 17,
+ax_anim 2, 1, 60, 17, 16, 17, 16,
+ax_anim 2, 0, 62, 16, 17, 16, 17,
+ax_anim 2, 0, 60, 17, 16, 17, 16,
+ax_anim 2, 0, 60, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sMightyenaAnims_3_3:
+ax_anim 2, 0, 64, -2, 0, -2, 0,
+ax_anim 2, 0, 64, -4, 0, -4, 0,
+ax_anim 4, 2, 64, -5, 0, -5, 0,
+ax_anim 2, 0, 67, 1, -1, 1, 0,
+ax_anim 2, 0, 67, 8, -3, 8, 0,
+ax_anim 2, 0, 66, 13, 0, 13, 0,
+ax_anim 2, 1, 64, 13, 1, 13, 1,
+ax_anim 2, 0, 66, 13, 0, 13, 0,
+ax_anim 2, 0, 64, 13, 1, 13, 1,
+ax_anim 2, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sMightyenaAnims_3_4:
+ax_anim 2, 0, 68, -2, 2, -2, 2,
+ax_anim 2, 0, 68, -4, 4, -4, 4,
+ax_anim 4, 2, 68, -5, 5, -5, 5,
+ax_anim 2, 0, 71, 1, -7, 1, -1,
+ax_anim 2, 0, 71, 8, -13, 8, -8,
+ax_anim 2, 0, 70, 17, -16, 17, -16,
+ax_anim 2, 1, 68, 18, -15, 18, -15,
+ax_anim 2, 0, 70, 17, -16, 17, -16,
+ax_anim 2, 0, 68, 18, -15, 18, -15,
+ax_anim 2, 0, 68, 10, -10, 10, -10,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sMightyenaAnims_3_5:
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim 4, 2, 72, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 0, -6, 0, -2,
+ax_anim 2, 0, 75, 0, -12, 0, -8,
+ax_anim 2, 0, 74, 0, -16, 0, -16,
+ax_anim 2, 1, 72, 1, -16, 1, -16,
+ax_anim 2, 0, 74, 0, -16, 0, -16,
+ax_anim 2, 0, 72, 1, -16, 1, -16,
+ax_anim 2, 0, 72, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sMightyenaAnims_3_6:
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 4, 2, 76, 5, 5, 5, 5,
+ax_anim 2, 0, 79, -1, -7, -1, -1,
+ax_anim 2, 0, 79, -8, -13, -8, -8,
+ax_anim 2, 0, 78, -17, -16, -17, -16,
+ax_anim 2, 1, 76, -18, -15, -18, -15,
+ax_anim 2, 0, 78, -17, -16, -17, -16,
+ax_anim 2, 0, 76, -18, -15, -18, -15,
+ax_anim 2, 0, 76, -10, -10, -10, -10,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim_terminator
+sMightyenaAnims_3_7:
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 4, 2, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 83, -1, -1, -1, 0,
+ax_anim 2, 0, 83, -8, -3, -8, 0,
+ax_anim 2, 0, 82, -13, 0, -13, 0,
+ax_anim 2, 1, 80, -13, 1, -13, 1,
+ax_anim 2, 0, 82, -13, 1, -13, 0,
+ax_anim 2, 0, 80, -13, 1, -13, 1,
+ax_anim 2, 0, 80, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sMightyenaAnims_3_8:
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim 2, 0, 84, 4, -4, 4, -4,
+ax_anim 4, 2, 84, 5, -5, 5, -5,
+ax_anim 2, 0, 87, -1, -3, -1, 1,
+ax_anim 2, 0, 87, -8, 3, -8, 8,
+ax_anim 2, 0, 86, -16, 17, -16, 17,
+ax_anim 2, 1, 84, -17, 16, -17, 16,
+ax_anim 2, 0, 86, -16, 17, -16, 17,
+ax_anim 2, 0, 84, -17, 16, -17, 16,
+ax_anim 2, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_4_1:
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 2, 89, 0, -3, 0, -3,
+ax_anim 4, 0, 89, 0, -4, 0, -4,
+ax_anim 1, 0, 90, 0, -1, 0, -1,
+ax_anim 1, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 1, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sMightyenaAnims_4_2:
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -2, -2, -1, -1,
+ax_anim 2, 2, 93, -3, -3, -3, -3,
+ax_anim 4, 0, 93, -4, -4, -4, -4,
+ax_anim 1, 0, 94, -1, -1, -1, -1,
+ax_anim 1, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 1, 94, 6, 6, 6, 6,
+ax_anim 2, 0, 94, 7, 5, 7, 5,
+ax_anim 2, 0, 94, 6, 6, 6, 6,
+ax_anim 2, 0, 94, 7, 5, 7, 5,
+ax_anim 2, 0, 94, 6, 6, 6, 6,
+ax_anim 2, 0, 94, 7, 5, 7, 5,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sMightyenaAnims_4_3:
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim 2, 2, 97, -3, 0, -3, 0,
+ax_anim 4, 0, 97, -4, 0, -4, 0,
+ax_anim 1, 0, 98, -1, 0, -1, 0,
+ax_anim 1, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 1, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, 6, 1, 6, 1,
+ax_anim 2, 0, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, 6, 1, 6, 1,
+ax_anim 2, 0, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, 6, 1, 6, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sMightyenaAnims_4_4:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 2, 101, -3, 3, -3, 3,
+ax_anim 4, 0, 101, -4, 4, -4, 4,
+ax_anim 1, 0, 102, -1, 1, -1, 1,
+ax_anim 1, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 1, 102, 6, -6, 6, -6,
+ax_anim 2, 0, 102, 7, -5, 7, -5,
+ax_anim 2, 0, 102, 6, -6, 6, -6,
+ax_anim 2, 0, 102, 7, -5, 7, -5,
+ax_anim 2, 0, 102, 6, -6, 6, -6,
+ax_anim 2, 0, 102, 7, -5, 7, -5,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sMightyenaAnims_4_5:
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 1, 0, 1,
+ax_anim 2, 2, 105, 0, 3, 0, 3,
+ax_anim 4, 0, 105, 0, 4, 0, 4,
+ax_anim 1, 0, 106, 0, 1, 0, 1,
+ax_anim 1, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 1, 106, 0, -6, 0, -5,
+ax_anim 2, 0, 106, 1, -6, 1, -5,
+ax_anim 2, 0, 106, 0, -6, 0, -5,
+ax_anim 2, 0, 106, 1, -6, 1, -5,
+ax_anim 2, 0, 106, 0, -6, 0, -5,
+ax_anim 2, 0, 106, 1, -6, 1, -5,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sMightyenaAnims_4_6:
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim 2, 2, 109, 3, 3, 3, 3,
+ax_anim 4, 0, 109, 4, 4, 4, 4,
+ax_anim 1, 0, 110, 1, 1, 1, 1,
+ax_anim 1, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 1, 110, -6, -6, -6, -6,
+ax_anim 2, 0, 110, -7, -5, -7, -5,
+ax_anim 2, 0, 110, -6, -6, -6, -6,
+ax_anim 2, 0, 110, -7, -5, -7, -5,
+ax_anim 2, 0, 110, -6, -6, -6, -6,
+ax_anim 2, 0, 110, -7, -5, -7, -5,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sMightyenaAnims_4_7:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 2, 0, 2, 0,
+ax_anim 2, 2, 113, 3, 0, 3, 0,
+ax_anim 4, 0, 113, 4, 0, 4, 0,
+ax_anim 1, 0, 114, 1, 0, 1, 0,
+ax_anim 1, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 1, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, -6, 1, -6, 1,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, -6, 1, -6, 1,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, -6, 1, -6, 1,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sMightyenaAnims_4_8:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 2, 2, 117, 3, -3, 3, -3,
+ax_anim 4, 0, 117, 4, -4, 4, -4,
+ax_anim 1, 0, 118, 1, -1, 1, -1,
+ax_anim 1, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 1, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_5_1:
+ax_anim 10, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 2, 121, 0, 1, 1, 0,
+ax_anim 2, 0, 121, -1, 1, 0, 0,
+ax_anim 2, 0, 121, 0, 1, 1, 0,
+ax_anim 2, 0, 121, -1, 1, 0, 0,
+ax_anim 2, 0, 121, 0, 1, 1, 0,
+ax_anim 2, 0, 121, -1, 1, 0, 0,
+ax_anim 2, 0, 121, 0, 1, 1, 0,
+ax_anim_terminator
+sMightyenaAnims_5_2:
+ax_anim 10, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 2, 123, 2, 1, 1, -1,
+ax_anim 2, 0, 123, 1, 2, 0, 0,
+ax_anim 2, 0, 123, 2, 1, 1, -1,
+ax_anim 2, 0, 123, 1, 2, 0, 0,
+ax_anim 2, 0, 123, 2, 1, 1, -1,
+ax_anim 2, 0, 123, 1, 2, 0, 0,
+ax_anim 2, 0, 123, 2, 1, 1, -1,
+ax_anim_terminator
+sMightyenaAnims_5_3:
+ax_anim 10, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 2, 125, 3, 0, 0, 1,
+ax_anim 2, 0, 125, 3, -1, 0, 0,
+ax_anim 2, 0, 125, 3, 0, 0, 1,
+ax_anim 2, 0, 125, 3, -1, 0, 0,
+ax_anim 2, 0, 125, 3, 0, 0, 1,
+ax_anim 2, 0, 125, 3, -1, 0, 0,
+ax_anim 2, 0, 125, 3, 0, 0, 1,
+ax_anim_terminator
+sMightyenaAnims_5_4:
+ax_anim 10, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 2, 127, 0, -1, 1, 1,
+ax_anim 2, 0, 127, -1, -2, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 1, 1,
+ax_anim 2, 0, 127, -1, -2, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 1, 1,
+ax_anim 2, 0, 127, -1, -2, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 1, 1,
+ax_anim_terminator
+sMightyenaAnims_5_5:
+ax_anim 10, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 2, 129, 0, -1, 1, 0,
+ax_anim 2, 0, 129, -1, -1, 0, 0,
+ax_anim 2, 0, 129, 0, -1, 1, 0,
+ax_anim 2, 0, 129, -1, -1, 0, 0,
+ax_anim 2, 0, 129, 0, -1, 1, 0,
+ax_anim 2, 0, 129, -1, -1, 0, 0,
+ax_anim 2, 0, 129, 0, -1, 1, 0,
+ax_anim_terminator
+sMightyenaAnims_5_6:
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 2, 131, 0, -1, -1, 1,
+ax_anim 2, 0, 131, 1, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -1, -1, 1,
+ax_anim 2, 0, 131, 1, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -1, -1, 1,
+ax_anim 2, 0, 131, 1, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -1, -1, 1,
+ax_anim_terminator
+sMightyenaAnims_5_7:
+ax_anim 10, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 2, 133, -2, 0, 0, 1,
+ax_anim 2, 0, 133, -2, -1, 0, 0,
+ax_anim 2, 0, 133, -2, 0, 0, 1,
+ax_anim 2, 0, 133, -2, -1, 0, 0,
+ax_anim 2, 0, 133, -2, 0, 0, 1,
+ax_anim 2, 0, 133, -2, -1, 0, 0,
+ax_anim 2, 0, 133, -2, 0, 0, 1,
+ax_anim_terminator
+sMightyenaAnims_5_8:
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 2, 135, -2, 1, -1, -1,
+ax_anim 2, 0, 135, -1, 2, 0, 0,
+ax_anim 2, 0, 135, -2, 1, -1, -1,
+ax_anim 2, 0, 135, -1, 2, 0, 0,
+ax_anim 2, 0, 135, -2, 1, -1, -1,
+ax_anim 2, 0, 135, -1, 2, 0, 0,
+ax_anim 2, 0, 135, -2, 1, -1, -1,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sMightyenaAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sMightyenaAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sMightyenaAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sMightyenaAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sMightyenaAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sMightyenaAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sMightyenaAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_8_1:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 2, 0, 2,
+ax_anim 5, 0, 146, 0, 2, 0, 2,
+ax_anim 8, 0, 148, 0, 2, 0, 2,
+ax_anim 5, 0, 146, 0, 2, 0, 2,
+ax_anim 8, 0, 148, 0, 2, 0, 2,
+ax_anim_terminator
+sMightyenaAnims_8_2:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 1, 1, 1, 1,
+ax_anim 5, 0, 150, 1, 1, 1, 1,
+ax_anim 8, 0, 152, 1, 1, 1, 1,
+ax_anim 5, 0, 150, 1, 1, 1, 1,
+ax_anim 8, 0, 152, 1, 1, 1, 1,
+ax_anim_terminator
+sMightyenaAnims_8_3:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 3, 0, 3, 0,
+ax_anim 5, 0, 154, 3, 0, 3, 0,
+ax_anim 8, 0, 156, 3, 0, 3, 0,
+ax_anim 5, 0, 154, 3, 0, 3, 0,
+ax_anim 8, 0, 156, 3, 0, 3, 0,
+ax_anim_terminator
+sMightyenaAnims_8_4:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 1, -1, 1, -1,
+ax_anim 5, 0, 158, 1, -1, 1, -1,
+ax_anim 8, 0, 160, 1, -1, 1, -1,
+ax_anim 5, 0, 158, 1, -1, 1, -1,
+ax_anim 8, 0, 160, 1, -1, 1, -1,
+ax_anim_terminator
+sMightyenaAnims_8_5:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, -1, 0, -1,
+ax_anim 5, 0, 162, 0, -1, 0, -1,
+ax_anim 8, 0, 164, 0, -1, 0, -1,
+ax_anim 5, 0, 162, 0, -1, 0, -1,
+ax_anim 8, 0, 164, 0, -1, 0, -1,
+ax_anim_terminator
+sMightyenaAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 168, -1, -1, -1, -1,
+ax_anim 5, 0, 166, -1, -1, -1, -1,
+ax_anim 8, 0, 168, -1, -1, -1, -1,
+ax_anim 5, 0, 166, -1, -1, -1, -1,
+ax_anim 8, 0, 168, -1, -1, -1, -1,
+ax_anim_terminator
+sMightyenaAnims_8_7:
+ax_anim 40, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 172, -3, 0, -3, 0,
+ax_anim 5, 0, 170, -3, 0, -3, 0,
+ax_anim 8, 0, 172, -3, 0, -3, 0,
+ax_anim 5, 0, 170, -3, 0, -3, 0,
+ax_anim 8, 0, 172, -3, 0, -3, 0,
+ax_anim_terminator
+sMightyenaAnims_8_8:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 176, -1, 1, -1, 1,
+ax_anim 5, 0, 174, -1, 1, -1, 1,
+ax_anim 8, 0, 176, -1, 1, -1, 1,
+ax_anim 5, 0, 174, -1, 1, -1, 1,
+ax_anim 8, 0, 176, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 10, 1, 10, 1,
+ax_anim 2, 0, 180, 15, 8, 15, 8,
+ax_anim 2, 0, 181, 9, 15, 9, 15,
+ax_anim 3, 0, 182, 0, 17, 0, 17,
+ax_anim 2, 3, 183, -9, 15, -9, 15,
+ax_anim 2, 0, 184, -15, 8, -15, 8,
+ax_anim 1, 0, 185, -10, 1, -10, 1,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 11, 1, 11, 1,
+ax_anim 2, 0, 179, 19, 2, 19, 2,
+ax_anim 2, 0, 180, 23, 9, 23, 9,
+ax_anim 3, 0, 181, 19, 17, 19, 17,
+ax_anim 2, 3, 182, 11, 17, 11, 17,
+ax_anim 2, 0, 183, 4, 15, 4, 15,
+ax_anim 1, 0, 184, -3, 8, -3, 8,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 2, -4, 2, -4,
+ax_anim 2, 0, 178, 11, -5, 11, -5,
+ax_anim 2, 0, 179, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 19, 1, 19, 1,
+ax_anim 2, 3, 181, 14, 8, 14, 8,
+ax_anim 2, 0, 182, 11, 8, 11, 8,
+ax_anim 1, 0, 183, 4, 7, 4, 7,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -4, -8, -4, -8,
+ax_anim 2, 0, 185, 0, -16, 0, -16,
+ax_anim 2, 0, 178, 10, -19, 10, -19,
+ax_anim 3, 0, 179, 20, -21, 20, -21,
+ax_anim 2, 3, 180, 24, -11, 24, -11,
+ax_anim 2, 0, 181, 17, -2, 17, -2,
+ax_anim 1, 0, 182, 11, -1, 11, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -10, -4, -10, -4,
+ax_anim 2, 0, 184, -15, -11, -15, -11,
+ax_anim 2, 0, 185, -11, -18, -11, -18,
+ax_anim 3, 0, 178, 0, -21, 0, -21,
+ax_anim 2, 3, 179, 11, -18, 11, -18,
+ax_anim 2, 0, 180, 15, -11, 15, -11,
+ax_anim 1, 0, 181, 10, -4, 10, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 4, -8, 4, -8,
+ax_anim 2, 0, 179, 0, -16, 0, -16,
+ax_anim 2, 0, 178, -10, -19, -10, -19,
+ax_anim 3, 0, 185, -20, -21, -20, -21,
+ax_anim 2, 3, 184, -24, -11, -24, -11,
+ax_anim 2, 0, 183, -17, -2, -17, -2,
+ax_anim 1, 0, 182, -11, -1, -11, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -2, -4, -2, -4,
+ax_anim 2, 0, 178, -11, -5, -11, -5,
+ax_anim 2, 0, 185, -17, -4, -17, -4,
+ax_anim 3, 0, 184, -19, 1, -19, 1,
+ax_anim 2, 3, 183, -14, 8, -14, 8,
+ax_anim 2, 0, 182, -11, 8, -11, 8,
+ax_anim 1, 0, 181, -4, 7, -4, 7,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -11, -1, -11, -1,
+ax_anim 2, 0, 185, -19, 2, -19, 2,
+ax_anim 2, 0, 184, -23, 9, -23, 9,
+ax_anim 3, 0, 183, -19, 17, -19, 17,
+ax_anim 2, 3, 182, -11, 17, -11, 17,
+ax_anim 2, 0, 181, -4, 15, -4, 15,
+ax_anim 1, 0, 180, 3, 8, 3, 8,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -24, 0, 0,
+ax_anim 3, 0, 195, 0, -24, 0, 0,
+ax_anim 2, 0, 195, 0, -19, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -23, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -19, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 1, 0, 204, 0, -11, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 2, 0, 207, 0, -17, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -19, 0, 0,
+ax_anim 2, 0, 210, 0, -17, 0, 0,
+ax_anim 1, 0, 210, 0, -11, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -23, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMightyenaAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sMightyenaGfx1:
+.incbin "baserom.gba", 0x10C4FC8, 0x100
+sMightyenaSprites1:
+ax_sprite sMightyenaGfx1, 0x100
+ax_sprite_terminator
+sMightyenaGfx2:
+.incbin "baserom.gba", 0x10C50D8, 0x100
+sMightyenaSprites2:
+ax_sprite sMightyenaGfx2, 0x100
+ax_sprite_terminator
+sMightyenaGfx3:
+.incbin "baserom.gba", 0x10C51E8, 0x100
+sMightyenaSprites3:
+ax_sprite sMightyenaGfx3, 0x100
+ax_sprite_terminator
+sMightyenaGfx4:
+.incbin "baserom.gba", 0x10C52F8, 0x200
+sMightyenaSprites4:
+ax_sprite sMightyenaGfx4, 0x200
+ax_sprite_terminator
+sMightyenaGfx5:
+.incbin "baserom.gba", 0x10C5508, 0x200
+sMightyenaSprites5:
+ax_sprite sMightyenaGfx5, 0x200
+ax_sprite_terminator
+sMightyenaGfx6:
+.incbin "baserom.gba", 0x10C5718, 0x200
+sMightyenaSprites6:
+ax_sprite sMightyenaGfx6, 0x200
+ax_sprite_terminator
+sMightyenaGfx7:
+.incbin "baserom.gba", 0x10C5928, 0x200
+sMightyenaSprites7:
+ax_sprite sMightyenaGfx7, 0x200
+ax_sprite_terminator
+sMightyenaGfx8:
+.incbin "baserom.gba", 0x10C5B38, 0x200
+sMightyenaSprites8:
+ax_sprite sMightyenaGfx8, 0x200
+ax_sprite_terminator
+sMightyenaGfx9:
+.incbin "baserom.gba", 0x10C5D48, 0x200
+sMightyenaSprites9:
+ax_sprite sMightyenaGfx9, 0x200
+ax_sprite_terminator
+sMightyenaGfx10:
+.incbin "baserom.gba", 0x10C5F58, 0x200
+sMightyenaSprites10:
+ax_sprite sMightyenaGfx10, 0x200
+ax_sprite_terminator
+sMightyenaGfx11:
+.incbin "baserom.gba", 0x10C6168, 0x200
+sMightyenaSprites11:
+ax_sprite sMightyenaGfx11, 0x200
+ax_sprite_terminator
+sMightyenaGfx12:
+.incbin "baserom.gba", 0x10C6378, 0x200
+sMightyenaSprites12:
+ax_sprite sMightyenaGfx12, 0x200
+ax_sprite_terminator
+sMightyenaGfx13:
+.incbin "baserom.gba", 0x10C6588, 0x100
+sMightyenaSprites13:
+ax_sprite sMightyenaGfx13, 0x100
+ax_sprite_terminator
+sMightyenaGfx14:
+.incbin "baserom.gba", 0x10C6698, 0x100
+sMightyenaSprites14:
+ax_sprite sMightyenaGfx14, 0x100
+ax_sprite_terminator
+sMightyenaGfx15:
+.incbin "baserom.gba", 0x10C67A8, 0x100
+sMightyenaSprites15:
+ax_sprite sMightyenaGfx15, 0x100
+ax_sprite_terminator
+sMightyenaGfx16:
+.incbin "baserom.gba", 0x10C68B8, 0x100
+sMightyenaSprites16:
+ax_sprite sMightyenaGfx16, 0x100
+ax_sprite_terminator
+sMightyenaGfx17:
+.incbin "baserom.gba", 0x10C69C8, 0x100
+sMightyenaSprites17:
+ax_sprite sMightyenaGfx17, 0x100
+ax_sprite_terminator
+sMightyenaGfx18:
+.incbin "baserom.gba", 0x10C6AD8, 0xC0
+sMightyenaSprites18:
+ax_sprite sMightyenaGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMightyenaGfx19:
+.incbin "baserom.gba", 0x10C6BB0, 0xE0
+sMightyenaGfx19_1:
+.incbin "baserom.gba", 0x10C6C90, 0x60
+sMightyenaGfx19_2:
+.incbin "baserom.gba", 0x10C6CF0, 0x40
+sMightyenaSprites19:
+ax_sprite sMightyenaGfx19, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx19_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMightyenaGfx20:
+.incbin "baserom.gba", 0x10C6D68, 0x20
+sMightyenaGfx20_1:
+.incbin "baserom.gba", 0x10C6D88, 0x20
+sMightyenaGfx20_2:
+.incbin "baserom.gba", 0x10C6DA8, 0x160
+sMightyenaSprites20:
+ax_sprite sMightyenaGfx20, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx20_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx20_2, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMightyenaGfx21:
+.incbin "baserom.gba", 0x10C6F40, 0x180
+sMightyenaSprites21:
+ax_sprite sMightyenaGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMightyenaGfx22:
+.incbin "baserom.gba", 0x10C70D8, 0x60
+sMightyenaGfx22_1:
+.incbin "baserom.gba", 0x10C7138, 0x100
+sMightyenaGfx22_2:
+.incbin "baserom.gba", 0x10C7238, 0x60
+sMightyenaSprites22:
+ax_sprite sMightyenaGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx22_2, 0x60
+ax_sprite_terminator
+sMightyenaGfx23:
+.incbin "baserom.gba", 0x10C72C8, 0x160
+sMightyenaGfx23_1:
+.incbin "baserom.gba", 0x10C7428, 0x20
+sMightyenaGfx23_2:
+.incbin "baserom.gba", 0x10C7448, 0x20
+sMightyenaSprites23:
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx23, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx23_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx23_2, 0x20
+ax_sprite_terminator
+sMightyenaGfx24:
+.incbin "baserom.gba", 0x10C74A0, 0x40
+sMightyenaGfx24_1:
+.incbin "baserom.gba", 0x10C74E0, 0x100
+sMightyenaGfx24_2:
+.incbin "baserom.gba", 0x10C75E0, 0x20
+sMightyenaSprites24:
+ax_sprite sMightyenaGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMightyenaGfx24_1, 0x100
+ax_sprite 0, 0x60
+ax_sprite sMightyenaGfx24_2, 0x20
+ax_sprite_terminator
+sMightyenaGfx25:
+.incbin "baserom.gba", 0x10C7630, 0x60
+sMightyenaGfx25_1:
+.incbin "baserom.gba", 0x10C7690, 0x60
+sMightyenaGfx25_2:
+.incbin "baserom.gba", 0x10C76F0, 0x60
+sMightyenaGfx25_3:
+.incbin "baserom.gba", 0x10C7750, 0x40
+sMightyenaSprites25:
+ax_sprite sMightyenaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMightyenaGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMightyenaGfx26:
+.incbin "baserom.gba", 0x10C77D8, 0x60
+sMightyenaGfx26_1:
+.incbin "baserom.gba", 0x10C7838, 0x60
+sMightyenaGfx26_2:
+.incbin "baserom.gba", 0x10C7898, 0x60
+sMightyenaGfx26_3:
+.incbin "baserom.gba", 0x10C78F8, 0x40
+sMightyenaSprites26:
+ax_sprite sMightyenaGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMightyenaGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMightyenaGfx27:
+.incbin "baserom.gba", 0x10C7980, 0x40
+sMightyenaGfx27_1:
+.incbin "baserom.gba", 0x10C79C0, 0x60
+sMightyenaGfx27_2:
+.incbin "baserom.gba", 0x10C7A20, 0x80
+sMightyenaGfx27_3:
+.incbin "baserom.gba", 0x10C7AA0, 0x40
+sMightyenaSprites27:
+ax_sprite sMightyenaGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMightyenaGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx27_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMightyenaGfx28:
+.incbin "baserom.gba", 0x10C7B28, 0x100
+sMightyenaSprites28:
+ax_sprite sMightyenaGfx28, 0x100
+ax_sprite_terminator
+sMightyenaGfx29:
+.incbin "baserom.gba", 0x10C7C38, 0x100
+sMightyenaSprites29:
+ax_sprite sMightyenaGfx29, 0x100
+ax_sprite_terminator
+sMightyenaGfx30:
+.incbin "baserom.gba", 0x10C7D48, 0x100
+sMightyenaSprites30:
+ax_sprite sMightyenaGfx30, 0x100
+ax_sprite_terminator
+sMightyenaGfx31:
+.incbin "baserom.gba", 0x10C7E58, 0x100
+sMightyenaSprites31:
+ax_sprite sMightyenaGfx31, 0x100
+ax_sprite_terminator
+sMightyenaGfx32:
+.incbin "baserom.gba", 0x10C7F68, 0x160
+sMightyenaGfx32_1:
+.incbin "baserom.gba", 0x10C80C8, 0x40
+sMightyenaSprites32:
+ax_sprite sMightyenaGfx32, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMightyenaGfx33:
+.incbin "baserom.gba", 0x10C8130, 0x40
+sMightyenaGfx33_1:
+.incbin "baserom.gba", 0x10C8170, 0x60
+sMightyenaGfx33_2:
+.incbin "baserom.gba", 0x10C81D0, 0x80
+sMightyenaGfx33_3:
+.incbin "baserom.gba", 0x10C8250, 0x60
+sMightyenaSprites33:
+ax_sprite sMightyenaGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMightyenaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx33_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx33_3, 0x60
+ax_sprite_terminator
+sMightyenaGfx34:
+.incbin "baserom.gba", 0x10C82F0, 0x60
+sMightyenaGfx34_1:
+.incbin "baserom.gba", 0x10C8350, 0x60
+sMightyenaGfx34_2:
+.incbin "baserom.gba", 0x10C83B0, 0x60
+sMightyenaGfx34_3:
+.incbin "baserom.gba", 0x10C8410, 0x60
+sMightyenaSprites34:
+ax_sprite sMightyenaGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMightyenaGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMightyenaGfx35:
+.incbin "baserom.gba", 0x10C84B8, 0x100
+sMightyenaSprites35:
+ax_sprite sMightyenaGfx35, 0x100
+ax_sprite_terminator
+sMightyenaGfx36:
+.incbin "baserom.gba", 0x10C85C8, 0x200
+sMightyenaSprites36:
+ax_sprite sMightyenaGfx36, 0x200
+ax_sprite_terminator
+sMightyenaGfx37:
+.incbin "baserom.gba", 0x10C87D8, 0x200
+sMightyenaSprites37:
+ax_sprite sMightyenaGfx37, 0x200
+ax_sprite_terminator
+sMightyenaGfx38:
+.incbin "baserom.gba", 0x10C89E8, 0x200
+sMightyenaSprites38:
+ax_sprite sMightyenaGfx38, 0x200
+ax_sprite_terminator
+sMightyenaGfx39:
+.incbin "baserom.gba", 0x10C8BF8, 0x200
+sMightyenaSprites39:
+ax_sprite sMightyenaGfx39, 0x200
+ax_sprite_terminator
+sMightyenaGfx40:
+.incbin "baserom.gba", 0x10C8E08, 0x200
+sMightyenaSprites40:
+ax_sprite sMightyenaGfx40, 0x200
+ax_sprite_terminator
+sMightyenaGfx41:
+.incbin "baserom.gba", 0x10C9018, 0x200
+sMightyenaSprites41:
+ax_sprite sMightyenaGfx41, 0x200
+ax_sprite_terminator
+sMightyenaGfx42:
+.incbin "baserom.gba", 0x10C9228, 0x200
+sMightyenaSprites42:
+ax_sprite sMightyenaGfx42, 0x200
+ax_sprite_terminator
+sAxPosesMightyena:
+.4byte sMightyenaPose1
+.4byte sMightyenaPose2
+.4byte sMightyenaPose3
+.4byte sMightyenaPose4
+.4byte sMightyenaPose5
+.4byte sMightyenaPose6
+.4byte sMightyenaPose7
+.4byte sMightyenaPose8
+.4byte sMightyenaPose9
+.4byte sMightyenaPose10
+.4byte sMightyenaPose11
+.4byte sMightyenaPose12
+.4byte sMightyenaPose13
+.4byte sMightyenaPose14
+.4byte sMightyenaPose15
+.4byte sMightyenaPose16
+.4byte sMightyenaPose17
+.4byte sMightyenaPose18
+.4byte sMightyenaPose19
+.4byte sMightyenaPose20
+.4byte sMightyenaPose21
+.4byte sMightyenaPose22
+.4byte sMightyenaPose23
+.4byte sMightyenaPose24
+.4byte sMightyenaPose25
+.4byte sMightyenaPose26
+.4byte sMightyenaPose27
+.4byte sMightyenaPose28
+.4byte sMightyenaPose29
+.4byte sMightyenaPose30
+.4byte sMightyenaPose31
+.4byte sMightyenaPose32
+.4byte sMightyenaPose33
+.4byte sMightyenaPose34
+.4byte sMightyenaPose35
+.4byte sMightyenaPose36
+.4byte sMightyenaPose37
+.4byte sMightyenaPose38
+.4byte sMightyenaPose39
+.4byte sMightyenaPose40
+.4byte sMightyenaPose41
+.4byte sMightyenaPose42
+.4byte sMightyenaPose43
+.4byte sMightyenaPose44
+.4byte sMightyenaPose45
+.4byte sMightyenaPose46
+.4byte sMightyenaPose47
+.4byte sMightyenaPose48
+.4byte sMightyenaPose49
+.4byte sMightyenaPose50
+.4byte sMightyenaPose51
+.4byte sMightyenaPose52
+.4byte sMightyenaPose53
+.4byte sMightyenaPose54
+.4byte sMightyenaPose55
+.4byte sMightyenaPose56
+.4byte sMightyenaPose57
+.4byte sMightyenaPose58
+.4byte sMightyenaPose59
+.4byte sMightyenaPose60
+.4byte sMightyenaPose61
+.4byte sMightyenaPose62
+.4byte sMightyenaPose63
+.4byte sMightyenaPose64
+.4byte sMightyenaPose65
+.4byte sMightyenaPose66
+.4byte sMightyenaPose67
+.4byte sMightyenaPose68
+.4byte sMightyenaPose69
+.4byte sMightyenaPose70
+.4byte sMightyenaPose71
+.4byte sMightyenaPose72
+.4byte sMightyenaPose73
+.4byte sMightyenaPose74
+.4byte sMightyenaPose75
+.4byte sMightyenaPose76
+.4byte sMightyenaPose77
+.4byte sMightyenaPose78
+.4byte sMightyenaPose79
+.4byte sMightyenaPose80
+.4byte sMightyenaPose81
+.4byte sMightyenaPose82
+.4byte sMightyenaPose83
+.4byte sMightyenaPose84
+.4byte sMightyenaPose85
+.4byte sMightyenaPose86
+.4byte sMightyenaPose87
+.4byte sMightyenaPose88
+.4byte sMightyenaPose89
+.4byte sMightyenaPose90
+.4byte sMightyenaPose91
+.4byte sMightyenaPose92
+.4byte sMightyenaPose93
+.4byte sMightyenaPose94
+.4byte sMightyenaPose95
+.4byte sMightyenaPose96
+.4byte sMightyenaPose97
+.4byte sMightyenaPose98
+.4byte sMightyenaPose99
+.4byte sMightyenaPose100
+.4byte sMightyenaPose101
+.4byte sMightyenaPose102
+.4byte sMightyenaPose103
+.4byte sMightyenaPose104
+.4byte sMightyenaPose105
+.4byte sMightyenaPose106
+.4byte sMightyenaPose107
+.4byte sMightyenaPose108
+.4byte sMightyenaPose109
+.4byte sMightyenaPose110
+.4byte sMightyenaPose111
+.4byte sMightyenaPose112
+.4byte sMightyenaPose113
+.4byte sMightyenaPose114
+.4byte sMightyenaPose115
+.4byte sMightyenaPose116
+.4byte sMightyenaPose117
+.4byte sMightyenaPose118
+.4byte sMightyenaPose119
+.4byte sMightyenaPose120
+.4byte sMightyenaPose121
+.4byte sMightyenaPose122
+.4byte sMightyenaPose123
+.4byte sMightyenaPose124
+.4byte sMightyenaPose125
+.4byte sMightyenaPose126
+.4byte sMightyenaPose127
+.4byte sMightyenaPose128
+.4byte sMightyenaPose129
+.4byte sMightyenaPose130
+.4byte sMightyenaPose131
+.4byte sMightyenaPose132
+.4byte sMightyenaPose133
+.4byte sMightyenaPose134
+.4byte sMightyenaPose135
+.4byte sMightyenaPose136
+.4byte sMightyenaPose137
+.4byte sMightyenaPose138
+.4byte sMightyenaPose139
+.4byte sMightyenaPose140
+.4byte sMightyenaPose141
+.4byte sMightyenaPose142
+.4byte sMightyenaPose143
+.4byte sMightyenaPose144
+.4byte sMightyenaPose145
+.4byte sMightyenaPose146
+.4byte sMightyenaPose147
+.4byte sMightyenaPose148
+.4byte sMightyenaPose149
+.4byte sMightyenaPose150
+.4byte sMightyenaPose151
+.4byte sMightyenaPose152
+.4byte sMightyenaPose153
+.4byte sMightyenaPose154
+.4byte sMightyenaPose155
+.4byte sMightyenaPose156
+.4byte sMightyenaPose157
+.4byte sMightyenaPose158
+.4byte sMightyenaPose159
+.4byte sMightyenaPose160
+.4byte sMightyenaPose161
+.4byte sMightyenaPose162
+.4byte sMightyenaPose163
+.4byte sMightyenaPose164
+.4byte sMightyenaPose165
+.4byte sMightyenaPose166
+.4byte sMightyenaPose167
+.4byte sMightyenaPose168
+.4byte sMightyenaPose169
+.4byte sMightyenaPose170
+.4byte sMightyenaPose171
+.4byte sMightyenaPose172
+.4byte sMightyenaPose173
+.4byte sMightyenaPose174
+.4byte sMightyenaPose175
+.4byte sMightyenaPose176
+.4byte sMightyenaPose177
+.4byte sMightyenaPose178
+.4byte sMightyenaPose179
+.4byte sMightyenaPose180
+.4byte sMightyenaPose181
+.4byte sMightyenaPose182
+.4byte sMightyenaPose183
+.4byte sMightyenaPose184
+.4byte sMightyenaPose185
+.4byte sMightyenaPose186
+.4byte sMightyenaPose187
+.4byte sMightyenaPose188
+.4byte sMightyenaPose189
+.4byte sMightyenaPose190
+.4byte sMightyenaPose191
+.4byte sMightyenaPose192
+.4byte sMightyenaPose193
+.4byte sMightyenaPose194
+.4byte sMightyenaPose195
+.4byte sMightyenaPose196
+.4byte sMightyenaPose197
+.4byte sMightyenaPose198
+.4byte sMightyenaPose199
+.4byte sMightyenaPose200
+.4byte sMightyenaPose201
+.4byte sMightyenaPose202
+.4byte sMightyenaPose203
+.4byte sMightyenaPose204
+.4byte sMightyenaPose205
+.4byte sMightyenaPose206
+.4byte sMightyenaPose207
+.4byte sMightyenaPose208
+.4byte sMightyenaPose209
+.4byte sMightyenaPose210
+.4byte sMightyenaPose211
+.4byte sMightyenaPose212
+.4byte sMightyenaPose213
+.4byte sMightyenaPose214
+.4byte sMightyenaPose215
+.4byte sMightyenaPose216
+.4byte sMightyenaPose217
+.4byte sMightyenaPose218
+.4byte sMightyenaPose219
+.4byte sMightyenaPose220
+.4byte sMightyenaPose221
+.4byte sMightyenaPose222
+.4byte sMightyenaPose223
+.4byte sMightyenaPose224
+.4byte sMightyenaPose225
+.4byte sMightyenaPose226
+.4byte sMightyenaPose227
+.4byte sMightyenaPose228
+.4byte sMightyenaPose229
+.4byte sMightyenaPose230
+.4byte sMightyenaPose231
+.4byte sMightyenaPose232
+.4byte sMightyenaPose233
+.4byte sMightyenaPose234
+sAxPositionsMightyena:
+.2byte   -1,   -2, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -1, 	  -4,    4, 	   2,    1, 	  -1,   -6
+.2byte   -1,   -1, 	  -3,    1, 	   3,    4, 	  -1,   -6
+.2byte    7,   -5, 	   7,    0, 	   1,    3, 	  -1,   -7
+.2byte    7,   -4, 	   9,    3, 	  -1,   -1, 	  -2,   -8
+.2byte    7,   -4, 	   2,    0, 	   3,    5, 	  -2,   -7
+.2byte   12,   -9, 	   8,   -4, 	   6,    1, 	  -1,   -7
+.2byte   12,   -8, 	  11,   -1, 	   3,    1, 	  -2,   -6
+.2byte   12,   -8, 	   1,   -1, 	  10,    1, 	  -2,   -6
+.2byte    8,  -14, 	   1,   -7, 	   7,   -3, 	   1,   -8
+.2byte    8,  -13, 	   3,   -9, 	   4,   -1, 	   1,   -8
+.2byte    8,  -13, 	  -1,   -6, 	   9,   -4, 	   0,   -7
+.2byte   -1,  -16, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   4,   -1, 	  -5,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -1, 	  -1,   -8
+.2byte   -9,  -14, 	  -2,   -7, 	  -8,   -3, 	  -2,   -8
+.2byte   -9,  -13, 	  -4,   -9, 	  -5,   -1, 	  -2,   -8
+.2byte   -9,  -13, 	   0,   -6, 	 -10,   -4, 	  -1,   -7
+.2byte  -13,   -9, 	  -9,   -4, 	  -7,    1, 	   0,   -7
+.2byte  -13,   -8, 	 -12,   -1, 	  -4,    1, 	   1,   -6
+.2byte  -13,   -8, 	  -2,   -1, 	 -11,    1, 	   1,   -6
+.2byte   -8,   -5, 	  -8,    0, 	  -2,    3, 	   0,   -7
+.2byte   -8,   -4, 	 -10,    3, 	   0,   -1, 	   1,   -8
+.2byte   -8,   -4, 	  -3,    0, 	  -4,    5, 	   1,   -7
+.2byte   -1,   -2, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    2, 	   5,    2, 	  -1,   -8
+.2byte   -1,   -6, 	  -5,   -5, 	   5,   -5, 	  -1,  -11
+.2byte    7,   -5, 	   7,    0, 	   1,    3, 	  -1,   -7
+.2byte    7,  -12, 	   7,    0, 	   1,    3, 	  -2,   -8
+.2byte    9,   -2, 	   7,    0, 	   1,    3, 	   0,   -9
+.2byte    8,   -8, 	  12,   -5, 	   5,   -2, 	  -2,  -11
+.2byte   12,   -9, 	   8,   -4, 	   6,    1, 	  -1,   -7
+.2byte    8,  -13, 	   8,   -5, 	   6,    1, 	  -2,   -7
+.2byte   12,   -5, 	   8,   -4, 	   6,    1, 	   1,   -7
+.2byte   12,  -13, 	  12,  -14, 	  12,   -9, 	  -1,  -10
+.2byte    8,  -14, 	   1,   -7, 	   7,   -3, 	   1,   -8
+.2byte    6,  -18, 	  -2,   -9, 	   7,   -3, 	  -1,   -8
+.2byte   10,  -15, 	   0,   -7, 	   7,   -3, 	   2,  -10
+.2byte    7,  -17, 	   0,  -19, 	   9,  -15, 	  -1,  -10
+.2byte   -1,  -16, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -20, 	   4,   -2, 	  -5,   -2, 	  -1,  -11
+.2byte   -1,  -13, 	   4,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -1,  -16, 	   5,  -18, 	  -6,  -18, 	  -1,  -13
+.2byte   -9,  -14, 	  -2,   -7, 	  -8,   -3, 	  -2,   -8
+.2byte   -7,  -18, 	   1,   -9, 	  -8,   -3, 	   0,   -8
+.2byte  -11,  -15, 	  -1,   -7, 	  -8,   -3, 	  -3,  -10
+.2byte   -8,  -17, 	  -1,  -19, 	 -10,  -15, 	   0,  -10
+.2byte  -13,   -9, 	  -9,   -4, 	  -7,    1, 	   0,   -7
+.2byte   -9,  -13, 	  -9,   -5, 	  -7,    1, 	   1,   -7
+.2byte  -13,   -5, 	  -9,   -4, 	  -7,    1, 	  -2,   -7
+.2byte  -13,  -13, 	 -13,  -14, 	 -13,   -9, 	   0,  -10
+.2byte   -8,   -5, 	  -8,    0, 	  -2,    3, 	   0,   -7
+.2byte   -8,  -12, 	  -8,    0, 	  -2,    3, 	   1,   -8
+.2byte  -10,   -2, 	  -8,    0, 	  -2,    3, 	  -1,   -9
+.2byte   -9,   -8, 	 -13,   -5, 	  -6,   -2, 	   1,  -11
+.2byte   -1,   -2, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    2, 	   5,    2, 	  -1,   -8
+.2byte   -1,   -6, 	  -5,   -5, 	   5,   -5, 	  -1,  -11
+.2byte    7,   -5, 	   7,    0, 	   1,    3, 	  -1,   -7
+.2byte    7,  -12, 	   7,    0, 	   1,    3, 	  -2,   -8
+.2byte    9,   -2, 	   7,    0, 	   1,    3, 	   0,   -9
+.2byte    8,   -8, 	  12,   -5, 	   5,   -2, 	  -2,  -11
+.2byte   12,   -9, 	   8,   -4, 	   6,    1, 	  -1,   -7
+.2byte    8,  -13, 	   8,   -5, 	   6,    1, 	  -2,   -7
+.2byte   12,   -5, 	   8,   -4, 	   6,    1, 	   1,   -7
+.2byte   12,  -13, 	  12,  -14, 	  12,   -9, 	  -1,  -10
+.2byte    8,  -14, 	   1,   -7, 	   7,   -3, 	   1,   -8
+.2byte    6,  -18, 	  -2,   -9, 	   7,   -3, 	  -1,   -8
+.2byte   10,  -15, 	   0,   -7, 	   7,   -3, 	   2,  -10
+.2byte    7,  -17, 	   0,  -19, 	   9,  -15, 	  -1,  -10
+.2byte   -1,  -16, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -20, 	   4,   -2, 	  -5,   -2, 	  -1,  -11
+.2byte   -1,  -13, 	   4,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -1,  -16, 	   5,  -18, 	  -6,  -18, 	  -1,  -13
+.2byte   -9,  -14, 	  -2,   -7, 	  -8,   -3, 	  -2,   -8
+.2byte   -7,  -18, 	   1,   -9, 	  -8,   -3, 	   0,   -8
+.2byte  -11,  -15, 	  -1,   -7, 	  -8,   -3, 	  -3,  -10
+.2byte   -8,  -17, 	  -1,  -19, 	 -10,  -15, 	   0,  -10
+.2byte  -13,   -9, 	  -9,   -4, 	  -7,    1, 	   0,   -7
+.2byte   -9,  -13, 	  -9,   -5, 	  -7,    1, 	   1,   -7
+.2byte  -13,   -5, 	  -9,   -4, 	  -7,    1, 	  -2,   -7
+.2byte  -13,  -13, 	 -13,  -14, 	 -13,   -9, 	   0,  -10
+.2byte   -8,   -5, 	  -8,    0, 	  -2,    3, 	   0,   -7
+.2byte   -8,  -12, 	  -8,    0, 	  -2,    3, 	   1,   -8
+.2byte  -10,   -2, 	  -8,    0, 	  -2,    3, 	  -1,   -9
+.2byte   -9,   -8, 	 -13,   -5, 	  -6,   -2, 	   1,  -11
+.2byte   -1,   -2, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    2, 	   5,    2, 	  -1,   -8
+.2byte   -1,   -7, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte    7,   -5, 	   7,    0, 	   1,    3, 	  -1,   -7
+.2byte    7,  -12, 	   7,    0, 	   1,    3, 	  -2,   -8
+.2byte    9,   -2, 	   7,    0, 	   1,    3, 	   0,   -9
+.2byte    4,   -9, 	   5,   -1, 	   0,    2, 	  -4,   -8
+.2byte   12,   -9, 	   8,   -4, 	   6,    1, 	  -1,   -7
+.2byte    8,  -13, 	   8,   -5, 	   6,    1, 	  -2,   -7
+.2byte   12,   -5, 	   8,   -4, 	   6,    1, 	   1,   -7
+.2byte    9,  -13, 	   6,   -5, 	   3,    1, 	  -2,   -8
+.2byte    8,  -14, 	   1,   -7, 	   7,   -3, 	   1,   -8
+.2byte    6,  -18, 	  -2,   -9, 	   7,   -3, 	  -1,   -8
+.2byte   10,  -15, 	   0,   -7, 	   7,   -3, 	   2,  -10
+.2byte    5,  -16, 	  -3,   -5, 	   5,   -2, 	  -1,   -9
+.2byte   -1,  -16, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -20, 	   4,   -2, 	  -5,   -2, 	  -1,  -11
+.2byte   -1,  -13, 	   4,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   4,   -3, 	  -5,   -3, 	  -1,  -10
+.2byte   -9,  -14, 	  -2,   -7, 	  -8,   -3, 	  -2,   -8
+.2byte   -7,  -18, 	   1,   -9, 	  -8,   -3, 	   0,   -8
+.2byte  -11,  -15, 	  -1,   -7, 	  -8,   -3, 	  -3,  -10
+.2byte   -6,  -16, 	   2,   -5, 	  -6,   -2, 	   0,   -9
+.2byte  -13,   -9, 	  -9,   -4, 	  -7,    1, 	   0,   -7
+.2byte   -9,  -13, 	  -9,   -5, 	  -7,    1, 	   1,   -7
+.2byte  -13,   -5, 	  -9,   -4, 	  -7,    1, 	  -2,   -7
+.2byte  -10,  -13, 	  -7,   -5, 	  -4,    1, 	   1,   -8
+.2byte   -8,   -5, 	  -8,    0, 	  -2,    3, 	   0,   -7
+.2byte   -8,  -12, 	  -8,    0, 	  -2,    3, 	   1,   -8
+.2byte  -10,   -2, 	  -8,    0, 	  -2,    3, 	  -1,   -9
+.2byte   -5,   -9, 	  -6,   -1, 	  -1,    2, 	   3,   -8
+.2byte   -1,   -7, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte   -1,   -9, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte    4,   -9, 	   5,   -1, 	   0,    2, 	  -4,   -8
+.2byte    7,  -12, 	   7,    0, 	   1,    3, 	  -2,   -8
+.2byte    9,  -13, 	   6,   -5, 	   3,    1, 	  -2,   -8
+.2byte    8,  -13, 	   8,   -5, 	   6,    1, 	  -2,   -7
+.2byte    5,  -16, 	  -3,   -5, 	   5,   -2, 	  -1,   -9
+.2byte    6,  -18, 	  -2,   -9, 	   7,   -3, 	  -1,   -8
+.2byte   -1,  -14, 	   4,   -3, 	  -5,   -3, 	  -1,  -10
+.2byte   -1,  -20, 	   4,   -2, 	  -5,   -2, 	  -1,  -11
+.2byte   -6,  -16, 	   2,   -5, 	  -6,   -2, 	   0,   -9
+.2byte   -7,  -18, 	   1,   -9, 	  -8,   -3, 	   0,   -8
+.2byte  -10,  -13, 	  -7,   -5, 	  -4,    1, 	   1,   -8
+.2byte   -9,  -13, 	  -9,   -5, 	  -7,    1, 	   1,   -7
+.2byte   -5,   -9, 	  -6,   -1, 	  -1,    2, 	   3,   -8
+.2byte   -8,  -12, 	  -8,    0, 	  -2,    3, 	   1,   -8
+.2byte   -1,    1, 	  -4,    3, 	   1,    3, 	   0,   -5
+.2byte   -1,    2, 	  -4,    3, 	   1,    3, 	   0,   -4
+.2byte    0,  -10, 	  -7,  -10, 	   7,   -7, 	   0,  -11
+.2byte    2,  -14, 	   8,  -17, 	  -1,  -14, 	  -3,  -10
+.2byte    3,  -15, 	   8,  -18, 	   2,  -11, 	  -2,   -9
+.2byte    4,  -15, 	  -2,  -16, 	   8,  -12, 	  -2,   -8
+.2byte   -1,  -15, 	   5,  -13, 	  -6,  -13, 	  -1,  -10
+.2byte   -5,  -16, 	   1,  -17, 	  -9,  -13, 	   1,   -9
+.2byte   -4,  -15, 	  -9,  -18, 	  -3,  -11, 	   1,   -9
+.2byte   -3,  -14, 	  -9,  -17, 	   0,  -14, 	   2,  -10
+.2byte   -1,   -2, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    2, 	   5,    2, 	  -1,   -8
+.2byte   -1,   -7, 	  -5,    1, 	   4,    1, 	  -1,   -9
+.2byte    7,   -5, 	   7,    0, 	   1,    3, 	  -1,   -7
+.2byte    7,  -12, 	   7,    0, 	   1,    3, 	  -2,   -8
+.2byte    9,   -2, 	   7,    0, 	   1,    3, 	   0,   -9
+.2byte    4,   -9, 	   5,   -1, 	   0,    2, 	  -4,   -8
+.2byte   12,   -9, 	   8,   -4, 	   6,    1, 	  -1,   -7
+.2byte    8,  -13, 	   8,   -5, 	   6,    1, 	  -2,   -7
+.2byte   12,   -5, 	   8,   -4, 	   6,    1, 	   1,   -7
+.2byte    9,  -13, 	   6,   -5, 	   3,    1, 	  -2,   -8
+.2byte    8,  -14, 	   1,   -7, 	   7,   -3, 	   1,   -8
+.2byte    6,  -18, 	  -2,   -9, 	   7,   -3, 	  -1,   -8
+.2byte   10,  -15, 	   0,   -7, 	   7,   -3, 	   2,  -10
+.2byte    5,  -16, 	  -3,   -5, 	   5,   -2, 	  -1,   -9
+.2byte   -1,  -16, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -20, 	   4,   -2, 	  -5,   -2, 	  -1,  -11
+.2byte   -1,  -13, 	   4,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   4,   -3, 	  -5,   -3, 	  -1,  -10
+.2byte   -9,  -14, 	  -2,   -7, 	  -8,   -3, 	  -2,   -8
+.2byte   -7,  -18, 	   1,   -9, 	  -8,   -3, 	   0,   -8
+.2byte  -11,  -15, 	  -1,   -7, 	  -8,   -3, 	  -3,  -10
+.2byte   -6,  -16, 	   2,   -5, 	  -6,   -2, 	   0,   -9
+.2byte  -13,   -9, 	  -9,   -4, 	  -7,    1, 	   0,   -7
+.2byte   -9,  -13, 	  -9,   -5, 	  -7,    1, 	   1,   -7
+.2byte  -13,   -5, 	  -9,   -4, 	  -7,    1, 	  -2,   -7
+.2byte  -10,  -13, 	  -7,   -5, 	  -4,    1, 	   1,   -8
+.2byte   -8,   -5, 	  -8,    0, 	  -2,    3, 	   0,   -7
+.2byte   -8,  -12, 	  -8,    0, 	  -2,    3, 	   1,   -8
+.2byte  -10,   -2, 	  -8,    0, 	  -2,    3, 	  -1,   -9
+.2byte   -5,   -9, 	  -6,   -1, 	  -1,    2, 	   3,   -8
+.2byte   -1,   -3, 	  -5,   -2, 	   5,   -2, 	  -1,   -8
+.2byte   -9,   -6, 	 -13,   -3, 	  -6,    0, 	   1,   -9
+.2byte  -13,  -11, 	 -13,  -12, 	 -13,   -7, 	   0,   -8
+.2byte   -8,  -15, 	  -1,  -17, 	 -10,  -13, 	   0,   -8
+.2byte   -1,  -14, 	   5,  -16, 	  -6,  -16, 	  -1,  -11
+.2byte    7,  -15, 	   0,  -17, 	   9,  -13, 	  -1,   -8
+.2byte   12,  -11, 	  12,  -12, 	  12,   -7, 	  -1,   -8
+.2byte    8,   -6, 	  12,   -3, 	   5,    0, 	  -2,   -9
+.2byte   -1,   -9, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte    8,  -11, 	   8,    1, 	   2,    4, 	  -1,   -7
+.2byte    8,  -13, 	   8,   -5, 	   6,    1, 	  -2,   -7
+.2byte    6,  -18, 	  -2,   -9, 	   7,   -3, 	  -1,   -8
+.2byte   -1,  -21, 	   4,   -3, 	  -5,   -3, 	  -1,  -12
+.2byte   -7,  -18, 	   1,   -9, 	  -8,   -3, 	   0,   -8
+.2byte   -9,  -13, 	  -9,   -5, 	  -7,    1, 	   1,   -7
+.2byte   -9,  -11, 	  -9,    1, 	  -3,    4, 	   0,   -7
+.2byte   -1,   -2, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    2, 	   5,    2, 	  -1,   -8
+.2byte   -1,   -6, 	  -5,   -5, 	   5,   -5, 	  -1,  -11
+.2byte    7,   -5, 	   7,    0, 	   1,    3, 	  -1,   -7
+.2byte    8,   -2, 	   6,    0, 	   0,    3, 	  -1,   -9
+.2byte    8,   -8, 	  12,   -5, 	   5,   -2, 	  -2,  -11
+.2byte   12,   -9, 	   8,   -4, 	   6,    1, 	  -1,   -7
+.2byte   11,   -5, 	   7,   -4, 	   5,    1, 	   0,   -7
+.2byte   12,  -13, 	  12,  -14, 	  12,   -9, 	  -1,  -10
+.2byte    8,  -14, 	   1,   -7, 	   7,   -3, 	   1,   -8
+.2byte    9,  -15, 	  -1,   -7, 	   6,   -3, 	   1,  -10
+.2byte    7,  -17, 	   0,  -19, 	   9,  -15, 	  -1,  -10
+.2byte   -1,  -16, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -13, 	   4,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -1,  -16, 	   5,  -18, 	  -6,  -18, 	  -1,  -13
+.2byte   -9,  -14, 	  -2,   -7, 	  -8,   -3, 	  -2,   -8
+.2byte  -10,  -15, 	   0,   -7, 	  -7,   -3, 	  -2,  -10
+.2byte   -9,  -17, 	  -2,  -19, 	 -11,  -15, 	  -1,  -10
+.2byte  -13,   -9, 	  -9,   -4, 	  -7,    1, 	   0,   -7
+.2byte  -12,   -5, 	  -8,   -4, 	  -6,    1, 	  -1,   -7
+.2byte  -13,  -13, 	 -13,  -14, 	 -13,   -9, 	   0,  -10
+.2byte   -8,   -5, 	  -8,    0, 	  -2,    3, 	   0,   -7
+.2byte   -9,   -2, 	  -7,    0, 	  -1,    3, 	   0,   -9
+.2byte   -9,   -8, 	 -13,   -5, 	  -6,   -2, 	   1,  -11
+.2byte   -1,   -1, 	  -6,    2, 	   5,    2, 	  -1,   -8
+.2byte   -8,   -2, 	  -6,    0, 	   0,    3, 	   1,   -9
+.2byte  -11,   -5, 	  -7,   -4, 	  -5,    1, 	   0,   -7
+.2byte  -10,  -15, 	   0,   -7, 	  -7,   -3, 	  -2,  -10
+.2byte   -1,  -13, 	   4,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte    9,  -15, 	  -1,   -7, 	   6,   -3, 	   1,  -10
+.2byte   10,   -5, 	   6,   -4, 	   4,    1, 	  -1,   -7
+.2byte    7,   -2, 	   5,    0, 	  -1,    3, 	  -2,   -9
+.2byte   -1,   -2, 	  -5,    2, 	   4,    2, 	  -1,   -7
+.2byte   -8,   -5, 	  -8,    0, 	  -2,    3, 	   0,   -7
+.2byte  -13,   -9, 	  -9,   -4, 	  -7,    1, 	   0,   -7
+.2byte   -9,  -14, 	  -2,   -7, 	  -8,   -3, 	  -2,   -8
+.2byte   -1,  -16, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte    8,  -14, 	   1,   -7, 	   7,   -3, 	   1,   -8
+.2byte   12,   -9, 	   8,   -4, 	   6,    1, 	  -1,   -7
+.2byte    7,   -5, 	   7,    0, 	   1,    3, 	  -1,   -7
+sMightyenaAnimTable1:
+.4byte sMightyenaAnims_1_1
+.4byte sMightyenaAnims_1_2
+.4byte sMightyenaAnims_1_3
+.4byte sMightyenaAnims_1_4
+.4byte sMightyenaAnims_1_5
+.4byte sMightyenaAnims_1_6
+.4byte sMightyenaAnims_1_7
+.4byte sMightyenaAnims_1_8
+sMightyenaAnimTable2:
+.4byte sMightyenaAnims_2_1
+.4byte sMightyenaAnims_2_2
+.4byte sMightyenaAnims_2_3
+.4byte sMightyenaAnims_2_4
+.4byte sMightyenaAnims_2_5
+.4byte sMightyenaAnims_2_6
+.4byte sMightyenaAnims_2_7
+.4byte sMightyenaAnims_2_8
+sMightyenaAnimTable3:
+.4byte sMightyenaAnims_3_1
+.4byte sMightyenaAnims_3_2
+.4byte sMightyenaAnims_3_3
+.4byte sMightyenaAnims_3_4
+.4byte sMightyenaAnims_3_5
+.4byte sMightyenaAnims_3_6
+.4byte sMightyenaAnims_3_7
+.4byte sMightyenaAnims_3_8
+sMightyenaAnimTable4:
+.4byte sMightyenaAnims_4_1
+.4byte sMightyenaAnims_4_2
+.4byte sMightyenaAnims_4_3
+.4byte sMightyenaAnims_4_4
+.4byte sMightyenaAnims_4_5
+.4byte sMightyenaAnims_4_6
+.4byte sMightyenaAnims_4_7
+.4byte sMightyenaAnims_4_8
+sMightyenaAnimTable5:
+.4byte sMightyenaAnims_5_1
+.4byte sMightyenaAnims_5_2
+.4byte sMightyenaAnims_5_3
+.4byte sMightyenaAnims_5_4
+.4byte sMightyenaAnims_5_5
+.4byte sMightyenaAnims_5_6
+.4byte sMightyenaAnims_5_7
+.4byte sMightyenaAnims_5_8
+sMightyenaAnimTable6:
+.4byte sMightyenaAnims_6_1
+.4byte sMightyenaAnims_6_1
+.4byte sMightyenaAnims_6_1
+.4byte sMightyenaAnims_6_1
+.4byte sMightyenaAnims_6_1
+.4byte sMightyenaAnims_6_1
+.4byte sMightyenaAnims_6_1
+.4byte sMightyenaAnims_6_1
+sMightyenaAnimTable7:
+.4byte sMightyenaAnims_7_1
+.4byte sMightyenaAnims_7_2
+.4byte sMightyenaAnims_7_3
+.4byte sMightyenaAnims_7_4
+.4byte sMightyenaAnims_7_5
+.4byte sMightyenaAnims_7_6
+.4byte sMightyenaAnims_7_7
+.4byte sMightyenaAnims_7_8
+sMightyenaAnimTable8:
+.4byte sMightyenaAnims_8_1
+.4byte sMightyenaAnims_8_2
+.4byte sMightyenaAnims_8_3
+.4byte sMightyenaAnims_8_4
+.4byte sMightyenaAnims_8_5
+.4byte sMightyenaAnims_8_6
+.4byte sMightyenaAnims_8_7
+.4byte sMightyenaAnims_8_8
+sMightyenaAnimTable9:
+.4byte sMightyenaAnims_9_1
+.4byte sMightyenaAnims_9_2
+.4byte sMightyenaAnims_9_3
+.4byte sMightyenaAnims_9_4
+.4byte sMightyenaAnims_9_5
+.4byte sMightyenaAnims_9_6
+.4byte sMightyenaAnims_9_7
+.4byte sMightyenaAnims_9_8
+sMightyenaAnimTable10:
+.4byte sMightyenaAnims_10_1
+.4byte sMightyenaAnims_10_2
+.4byte sMightyenaAnims_10_3
+.4byte sMightyenaAnims_10_4
+.4byte sMightyenaAnims_10_5
+.4byte sMightyenaAnims_10_6
+.4byte sMightyenaAnims_10_7
+.4byte sMightyenaAnims_10_8
+sMightyenaAnimTable11:
+.4byte sMightyenaAnims_11_1
+.4byte sMightyenaAnims_11_2
+.4byte sMightyenaAnims_11_3
+.4byte sMightyenaAnims_11_4
+.4byte sMightyenaAnims_11_5
+.4byte sMightyenaAnims_11_6
+.4byte sMightyenaAnims_11_7
+.4byte sMightyenaAnims_11_8
+sMightyenaAnimTable12:
+.4byte sMightyenaAnims_12_1
+.4byte sMightyenaAnims_12_2
+.4byte sMightyenaAnims_12_3
+.4byte sMightyenaAnims_12_4
+.4byte sMightyenaAnims_12_5
+.4byte sMightyenaAnims_12_6
+.4byte sMightyenaAnims_12_7
+.4byte sMightyenaAnims_12_8
+sMightyenaAnimTable13:
+.4byte sMightyenaAnims_13_1
+.4byte sMightyenaAnims_13_2
+.4byte sMightyenaAnims_13_3
+.4byte sMightyenaAnims_13_4
+.4byte sMightyenaAnims_13_5
+.4byte sMightyenaAnims_13_6
+.4byte sMightyenaAnims_13_7
+.4byte sMightyenaAnims_13_8
+sAxAnimationsMightyena:
+.4byte sMightyenaAnimTable1
+.4byte sMightyenaAnimTable2
+.4byte sMightyenaAnimTable3
+.4byte sMightyenaAnimTable4
+.4byte sMightyenaAnimTable5
+.4byte sMightyenaAnimTable6
+.4byte sMightyenaAnimTable7
+.4byte sMightyenaAnimTable8
+.4byte sMightyenaAnimTable9
+.4byte sMightyenaAnimTable10
+.4byte sMightyenaAnimTable11
+.4byte sMightyenaAnimTable12
+.4byte sMightyenaAnimTable13
+sAxSpritesMightyena:
+.4byte sMightyenaSprites1
+.4byte sMightyenaSprites2
+.4byte sMightyenaSprites3
+.4byte sMightyenaSprites4
+.4byte sMightyenaSprites5
+.4byte sMightyenaSprites6
+.4byte sMightyenaSprites7
+.4byte sMightyenaSprites8
+.4byte sMightyenaSprites9
+.4byte sMightyenaSprites10
+.4byte sMightyenaSprites11
+.4byte sMightyenaSprites12
+.4byte sMightyenaSprites13
+.4byte sMightyenaSprites14
+.4byte sMightyenaSprites15
+.4byte sMightyenaSprites16
+.4byte sMightyenaSprites17
+.4byte sMightyenaSprites18
+.4byte sMightyenaSprites19
+.4byte sMightyenaSprites20
+.4byte sMightyenaSprites21
+.4byte sMightyenaSprites22
+.4byte sMightyenaSprites23
+.4byte sMightyenaSprites24
+.4byte sMightyenaSprites25
+.4byte sMightyenaSprites26
+.4byte sMightyenaSprites27
+.4byte sMightyenaSprites28
+.4byte sMightyenaSprites29
+.4byte sMightyenaSprites30
+.4byte sMightyenaSprites31
+.4byte sMightyenaSprites32
+.4byte sMightyenaSprites33
+.4byte sMightyenaSprites34
+.4byte sMightyenaSprites35
+.4byte sMightyenaSprites36
+.4byte sMightyenaSprites37
+.4byte sMightyenaSprites38
+.4byte sMightyenaSprites39
+.4byte sMightyenaSprites40
+.4byte sMightyenaSprites41
+.4byte sMightyenaSprites42
+sAxMainMightyena:
+ax_main sAxPosesMightyena, sAxAnimationsMightyena, 13, sAxSpritesMightyena, sAxPositionsMightyena

--- a/data/ax/milotic.inc
+++ b/data/ax/milotic.inc
@@ -1,0 +1,3451 @@
+.global gAxMilotic
+gAxMilotic:
+ax_siro sAxMainMilotic
+sMiloticPose1:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose2:
+ax_pose 1, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose3:
+ax_pose 2, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose4:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose5:
+ax_pose 4, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose6:
+ax_pose 5, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose7:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose8:
+ax_pose 7, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose9:
+ax_pose 8, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose10:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose11:
+ax_pose 10, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose12:
+ax_pose 11, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose13:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose14:
+ax_pose 13, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose15:
+ax_pose 14, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose16:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose17:
+ax_pose 16, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose18:
+ax_pose 17, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose19:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose20:
+ax_pose 19, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose21:
+ax_pose 20, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose22:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose23:
+ax_pose 22, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose24:
+ax_pose 23, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose25:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose26:
+ax_pose 1, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose27:
+ax_pose 2, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose28:
+ax_pose 24, 0x81d7, 0xc0ed, 0x0c00
+ax_pose 25, 0x81d7, 0x010d, 0x0c20
+ax_pose_terminator
+sMiloticPose29:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose30:
+ax_pose 4, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose31:
+ax_pose 5, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose32:
+ax_pose 26, 0x01e5, 0x80df, 0x0c00
+ax_pose 27, 0x01ea, 0x80ff, 0x0c10
+ax_pose 28, 0x01d5, 0x40e5, 0x0c20
+ax_pose_terminator
+sMiloticPose33:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose34:
+ax_pose 7, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose35:
+ax_pose 8, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose36:
+ax_pose 29, 0x41e9, 0xc0e8, 0x0c00
+ax_pose 30, 0x41e3, 0x80c8, 0x0c20
+ax_pose_terminator
+sMiloticPose37:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose38:
+ax_pose 10, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose39:
+ax_pose 11, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose40:
+ax_pose 31, 0x01df, 0x80fd, 0x0c00
+ax_pose 32, 0x01ff, 0x40fd, 0x0c10
+ax_pose 33, 0x01f7, 0x40ed, 0x0c14
+ax_pose 34, 0x41f2, 0x80cd, 0x0c18
+ax_pose_terminator
+sMiloticPose41:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose42:
+ax_pose 13, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose43:
+ax_pose 14, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose44:
+ax_pose 35, 0x81dd, 0xc0ef, 0x0c00
+ax_pose 36, 0x81f5, 0x010f, 0x0c20
+ax_pose_terminator
+sMiloticPose45:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose46:
+ax_pose 16, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose47:
+ax_pose 17, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose48:
+ax_pose 37, 0x01e1, 0x80e6, 0x0c00
+ax_pose 38, 0x01f1, 0x8106, 0x0c10
+ax_pose 39, 0x0201, 0x0126, 0x0c20
+ax_pose 40, 0x0201, 0x00fe, 0x0c21
+ax_pose_terminator
+sMiloticPose49:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose50:
+ax_pose 19, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose51:
+ax_pose 20, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose52:
+ax_pose 41, 0x41e8, 0xc0de, 0x0c00
+ax_pose 42, 0x81e8, 0x811e, 0x0c20
+ax_pose_terminator
+sMiloticPose53:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose54:
+ax_pose 22, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose55:
+ax_pose 23, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose56:
+ax_pose 43, 0x01e8, 0x80e3, 0x0c00
+ax_pose 44, 0x01db, 0x8103, 0x0c10
+ax_pose_terminator
+sMiloticPose57:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose58:
+ax_pose 1, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose59:
+ax_pose 2, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose60:
+ax_pose 24, 0x81d7, 0xc0ed, 0x0c00
+ax_pose 25, 0x81d7, 0x010d, 0x0c20
+ax_pose_terminator
+sMiloticPose61:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose62:
+ax_pose 4, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose63:
+ax_pose 5, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose64:
+ax_pose 26, 0x01e5, 0x80df, 0x0c00
+ax_pose 27, 0x01ea, 0x80ff, 0x0c10
+ax_pose 28, 0x01d5, 0x40e5, 0x0c20
+ax_pose_terminator
+sMiloticPose65:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose66:
+ax_pose 7, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose67:
+ax_pose 8, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose68:
+ax_pose 29, 0x41e9, 0xc0e8, 0x0c00
+ax_pose 30, 0x41e3, 0x80c8, 0x0c20
+ax_pose_terminator
+sMiloticPose69:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose70:
+ax_pose 10, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose71:
+ax_pose 11, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose72:
+ax_pose 31, 0x01df, 0x80fd, 0x0c00
+ax_pose 32, 0x01ff, 0x40fd, 0x0c10
+ax_pose 33, 0x01f7, 0x40ed, 0x0c14
+ax_pose 34, 0x41f2, 0x80cd, 0x0c18
+ax_pose_terminator
+sMiloticPose73:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose74:
+ax_pose 13, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose75:
+ax_pose 14, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose76:
+ax_pose 35, 0x81dd, 0xc0ef, 0x0c00
+ax_pose 36, 0x81f5, 0x010f, 0x0c20
+ax_pose_terminator
+sMiloticPose77:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose78:
+ax_pose 16, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose79:
+ax_pose 17, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose80:
+ax_pose 37, 0x01e1, 0x80e6, 0x0c00
+ax_pose 38, 0x01f1, 0x8106, 0x0c10
+ax_pose 39, 0x0201, 0x0126, 0x0c20
+ax_pose 40, 0x0201, 0x00fe, 0x0c21
+ax_pose_terminator
+sMiloticPose81:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose82:
+ax_pose 19, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose83:
+ax_pose 20, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose84:
+ax_pose 41, 0x41e8, 0xc0de, 0x0c00
+ax_pose 42, 0x81e8, 0x811e, 0x0c20
+ax_pose_terminator
+sMiloticPose85:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose86:
+ax_pose 22, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose87:
+ax_pose 23, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose88:
+ax_pose 43, 0x01e8, 0x80e3, 0x0c00
+ax_pose 44, 0x01db, 0x8103, 0x0c10
+ax_pose_terminator
+sMiloticPose89:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose90:
+ax_pose 1, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose91:
+ax_pose 2, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose92:
+ax_pose 45, 0x01e7, 0x80ee, 0x0c00
+ax_pose 46, 0x41d7, 0x80fe, 0x0c10
+ax_pose_terminator
+sMiloticPose93:
+ax_pose 47, 0x81cf, 0xc0ea, 0x0c00
+ax_pose 48, 0x81d7, 0x410a, 0x0c20
+ax_pose_terminator
+sMiloticPose94:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose95:
+ax_pose 4, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose96:
+ax_pose 5, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose97:
+ax_pose 49, 0x01e7, 0x80e9, 0x0c00
+ax_pose 50, 0x81e7, 0x8109, 0x0c10
+ax_pose 51, 0x01d7, 0x40e9, 0x0c18
+ax_pose_terminator
+sMiloticPose98:
+ax_pose 52, 0x81c8, 0xc0ec, 0x0c00
+ax_pose_terminator
+sMiloticPose99:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose100:
+ax_pose 7, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose101:
+ax_pose 8, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose102:
+ax_pose 53, 0x41e3, 0xc0e1, 0x0c00
+ax_pose 54, 0x4203, 0x40ef, 0x0c20
+ax_pose 55, 0x0203, 0x010f, 0x0c24
+ax_pose 56, 0x81e3, 0x00d9, 0x0c25
+ax_pose_terminator
+sMiloticPose103:
+ax_pose 57, 0x81cc, 0xc0ef, 0x0c00
+ax_pose 58, 0x01dc, 0x40df, 0x0c20
+ax_pose_terminator
+sMiloticPose104:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose105:
+ax_pose 10, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose106:
+ax_pose 11, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose107:
+ax_pose 59, 0x01d9, 0x80f8, 0x0c00
+ax_pose 60, 0x01f1, 0x80d8, 0x0c10
+ax_pose 61, 0x41f9, 0x80f8, 0x0c20
+ax_pose_terminator
+sMiloticPose108:
+ax_pose 62, 0x81ca, 0xc0f3, 0x0c00
+ax_pose 63, 0x81e9, 0x80e3, 0x0c20
+ax_pose_terminator
+sMiloticPose109:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose110:
+ax_pose 13, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose111:
+ax_pose 14, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose112:
+ax_pose 64, 0x81d1, 0xc0f1, 0x0c00
+ax_pose 65, 0x0201, 0x00e9, 0x0c20
+ax_pose_terminator
+sMiloticPose113:
+ax_pose 66, 0x81ce, 0xc0ed, 0x0c00
+ax_pose 67, 0x81f6, 0x010d, 0x0c20
+ax_pose_terminator
+sMiloticPose114:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose115:
+ax_pose 16, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose116:
+ax_pose 17, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose117:
+ax_pose 68, 0x01db, 0x80e7, 0x0c00
+ax_pose 69, 0x01f1, 0x8107, 0x0c10
+ax_pose 70, 0x41fb, 0x40e7, 0x0c20
+ax_pose_terminator
+sMiloticPose118:
+ax_pose 71, 0x81ca, 0xc0f2, 0x0c00
+ax_pose 72, 0x81f2, 0x0112, 0x0c20
+ax_pose_terminator
+sMiloticPose119:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose120:
+ax_pose 19, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose121:
+ax_pose 20, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose122:
+ax_pose 73, 0x01e1, 0x80df, 0x0c00
+ax_pose 74, 0x01e9, 0x80ff, 0x0c10
+ax_pose 75, 0x0201, 0x00ef, 0x0c20
+ax_pose 76, 0x01e9, 0x411f, 0x0c21
+ax_pose_terminator
+sMiloticPose123:
+ax_pose 77, 0x81c7, 0xc0f0, 0x0c00
+ax_pose 78, 0x81e7, 0x8110, 0x0c20
+ax_pose_terminator
+sMiloticPose124:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose125:
+ax_pose 22, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose126:
+ax_pose 23, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose127:
+ax_pose 79, 0x01e7, 0x80e6, 0x0c00
+ax_pose 80, 0x01db, 0x8106, 0x0c10
+ax_pose_terminator
+sMiloticPose128:
+ax_pose 81, 0x81ce, 0xc0ed, 0x0c00
+ax_pose 82, 0x81de, 0x810d, 0x0c20
+ax_pose_terminator
+sMiloticPose129:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose130:
+ax_pose 1, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose131:
+ax_pose 2, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose132:
+ax_pose 47, 0x81d0, 0xc0ea, 0x0c00
+ax_pose 48, 0x81d8, 0x410a, 0x0c20
+ax_pose_terminator
+sMiloticPose133:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose134:
+ax_pose 4, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose135:
+ax_pose 5, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose136:
+ax_pose 52, 0x81ca, 0xc0ec, 0x0c00
+ax_pose_terminator
+sMiloticPose137:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose138:
+ax_pose 7, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose139:
+ax_pose 8, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose140:
+ax_pose 57, 0x81cc, 0xc0f0, 0x0c00
+ax_pose 58, 0x01dc, 0x40e0, 0x0c20
+ax_pose_terminator
+sMiloticPose141:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose142:
+ax_pose 10, 0x01d3, 0xc0dd, 0x0c00
+ax_pose_terminator
+sMiloticPose143:
+ax_pose 11, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose144:
+ax_pose 62, 0x81ca, 0xc0f5, 0x0c00
+ax_pose 63, 0x81e9, 0x80e5, 0x0c20
+ax_pose_terminator
+sMiloticPose145:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose146:
+ax_pose 13, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose147:
+ax_pose 14, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose148:
+ax_pose 66, 0x81ce, 0xc0ed, 0x0c00
+ax_pose 67, 0x81f6, 0x010d, 0x0c20
+ax_pose_terminator
+sMiloticPose149:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose150:
+ax_pose 16, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose151:
+ax_pose 17, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose152:
+ax_pose 71, 0x81c9, 0xc0f2, 0x0c00
+ax_pose 72, 0x81f1, 0x0112, 0x0c20
+ax_pose_terminator
+sMiloticPose153:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose154:
+ax_pose 19, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose155:
+ax_pose 20, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose156:
+ax_pose 77, 0x81c6, 0xc0ee, 0x0c00
+ax_pose 78, 0x81e6, 0x810e, 0x0c20
+ax_pose_terminator
+sMiloticPose157:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose158:
+ax_pose 22, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose159:
+ax_pose 23, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose160:
+ax_pose 81, 0x81ce, 0xc0eb, 0x0c00
+ax_pose 82, 0x81de, 0x810b, 0x0c20
+ax_pose_terminator
+sMiloticPose161:
+ax_pose 83, 0x01d2, 0xc0e1, 0x0c00
+ax_pose_terminator
+sMiloticPose162:
+ax_pose 84, 0x01d2, 0xc0e1, 0x0c00
+ax_pose_terminator
+sMiloticPose163:
+ax_pose 85, 0x01ce, 0xc0e2, 0x0c00
+ax_pose_terminator
+sMiloticPose164:
+ax_pose 86, 0x01cf, 0xd0db, 0x0c00
+ax_pose_terminator
+sMiloticPose165:
+ax_pose 87, 0x01d2, 0xd0dc, 0x0c00
+ax_pose_terminator
+sMiloticPose166:
+ax_pose 88, 0x01d4, 0xd0dc, 0x0c00
+ax_pose_terminator
+sMiloticPose167:
+ax_pose 89, 0x01ef, 0x80ef, 0x0c00
+ax_pose 90, 0x81cf, 0x410d, 0x0c10
+ax_pose 91, 0x01cf, 0x80ed, 0x0c14
+ax_pose_terminator
+sMiloticPose168:
+ax_pose 88, 0x01d4, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose169:
+ax_pose 87, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose170:
+ax_pose 86, 0x01cf, 0xc0e5, 0x0c00
+ax_pose_terminator
+sMiloticPose171:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose172:
+ax_pose 1, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose173:
+ax_pose 2, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose174:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose175:
+ax_pose 4, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose176:
+ax_pose 5, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose177:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose178:
+ax_pose 7, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose179:
+ax_pose 8, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose180:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose181:
+ax_pose 10, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose182:
+ax_pose 11, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose183:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose184:
+ax_pose 13, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose185:
+ax_pose 14, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose186:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose187:
+ax_pose 16, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose188:
+ax_pose 17, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose189:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose190:
+ax_pose 19, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose191:
+ax_pose 20, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose192:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose193:
+ax_pose 22, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose194:
+ax_pose 23, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose195:
+ax_pose 2, 0x01d2, 0xc0e1, 0x0c00
+ax_pose_terminator
+sMiloticPose196:
+ax_pose 23, 0x01d2, 0xc0e1, 0x0c00
+ax_pose_terminator
+sMiloticPose197:
+ax_pose 20, 0x01d3, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose198:
+ax_pose 17, 0x01d4, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose199:
+ax_pose 14, 0x01d1, 0xc0df, 0x0c00
+ax_pose_terminator
+sMiloticPose200:
+ax_pose 11, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose201:
+ax_pose 8, 0x01d1, 0xc0da, 0x0c00
+ax_pose_terminator
+sMiloticPose202:
+ax_pose 5, 0x01d1, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose203:
+ax_pose 47, 0x81d0, 0xc0eb, 0x0c00
+ax_pose 48, 0x81d8, 0x410b, 0x0c20
+ax_pose_terminator
+sMiloticPose204:
+ax_pose 52, 0x81ca, 0xc0ee, 0x0c00
+ax_pose_terminator
+sMiloticPose205:
+ax_pose 57, 0x81cc, 0xc0ed, 0x0c00
+ax_pose 58, 0x01dc, 0x40dd, 0x0c20
+ax_pose_terminator
+sMiloticPose206:
+ax_pose 62, 0x81ca, 0xc0f1, 0x0c00
+ax_pose 63, 0x81e9, 0x80e1, 0x0c20
+ax_pose_terminator
+sMiloticPose207:
+ax_pose 66, 0x81ce, 0xc0ec, 0x0c00
+ax_pose 67, 0x81f6, 0x010c, 0x0c20
+ax_pose_terminator
+sMiloticPose208:
+ax_pose 71, 0x81c9, 0xc0f2, 0x0c00
+ax_pose 72, 0x81f1, 0x0112, 0x0c20
+ax_pose_terminator
+sMiloticPose209:
+ax_pose 77, 0x81c6, 0xc0ef, 0x0c00
+ax_pose 78, 0x81e6, 0x810f, 0x0c20
+ax_pose_terminator
+sMiloticPose210:
+ax_pose 81, 0x81ce, 0xc0ee, 0x0c00
+ax_pose 82, 0x81de, 0x810e, 0x0c20
+ax_pose_terminator
+sMiloticPose211:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose212:
+ax_pose 45, 0x01e7, 0x80ee, 0x0c00
+ax_pose 46, 0x41d7, 0x80fe, 0x0c10
+ax_pose_terminator
+sMiloticPose213:
+ax_pose 47, 0x81cf, 0xc0ea, 0x0c00
+ax_pose 48, 0x81d7, 0x410a, 0x0c20
+ax_pose_terminator
+sMiloticPose214:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose215:
+ax_pose 49, 0x01e7, 0x80e9, 0x0c00
+ax_pose 50, 0x81e7, 0x8109, 0x0c10
+ax_pose 51, 0x01d7, 0x40e9, 0x0c18
+ax_pose_terminator
+sMiloticPose216:
+ax_pose 52, 0x81c8, 0xc0ec, 0x0c00
+ax_pose_terminator
+sMiloticPose217:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose218:
+ax_pose 53, 0x41e3, 0xc0e1, 0x0c00
+ax_pose 54, 0x4203, 0x40ef, 0x0c20
+ax_pose 55, 0x0203, 0x010f, 0x0c24
+ax_pose 56, 0x81e3, 0x00d9, 0x0c25
+ax_pose_terminator
+sMiloticPose219:
+ax_pose 57, 0x81cc, 0xc0ef, 0x0c00
+ax_pose 58, 0x01dc, 0x40df, 0x0c20
+ax_pose_terminator
+sMiloticPose220:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose221:
+ax_pose 59, 0x01d9, 0x80f8, 0x0c00
+ax_pose 60, 0x01f1, 0x80d8, 0x0c10
+ax_pose 61, 0x41f9, 0x80f8, 0x0c20
+ax_pose_terminator
+sMiloticPose222:
+ax_pose 62, 0x81ca, 0xc0f3, 0x0c00
+ax_pose 63, 0x81e9, 0x80e3, 0x0c20
+ax_pose_terminator
+sMiloticPose223:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose224:
+ax_pose 64, 0x81d1, 0xc0f1, 0x0c00
+ax_pose 65, 0x0201, 0x00e9, 0x0c20
+ax_pose_terminator
+sMiloticPose225:
+ax_pose 66, 0x81ce, 0xc0ed, 0x0c00
+ax_pose 67, 0x81f6, 0x010d, 0x0c20
+ax_pose_terminator
+sMiloticPose226:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose227:
+ax_pose 68, 0x01db, 0x80e7, 0x0c00
+ax_pose 69, 0x01f1, 0x8107, 0x0c10
+ax_pose 70, 0x41fb, 0x40e7, 0x0c20
+ax_pose_terminator
+sMiloticPose228:
+ax_pose 71, 0x81ca, 0xc0f2, 0x0c00
+ax_pose 72, 0x81f2, 0x0112, 0x0c20
+ax_pose_terminator
+sMiloticPose229:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose230:
+ax_pose 73, 0x01e1, 0x80df, 0x0c00
+ax_pose 74, 0x01e9, 0x80ff, 0x0c10
+ax_pose 75, 0x0201, 0x00ef, 0x0c20
+ax_pose 76, 0x01e9, 0x411f, 0x0c21
+ax_pose_terminator
+sMiloticPose231:
+ax_pose 77, 0x81c7, 0xc0f0, 0x0c00
+ax_pose 78, 0x81e7, 0x8110, 0x0c20
+ax_pose_terminator
+sMiloticPose232:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose233:
+ax_pose 79, 0x01e7, 0x80e6, 0x0c00
+ax_pose 80, 0x01db, 0x8106, 0x0c10
+ax_pose_terminator
+sMiloticPose234:
+ax_pose 81, 0x81ce, 0xc0ed, 0x0c00
+ax_pose 82, 0x81de, 0x810d, 0x0c20
+ax_pose_terminator
+sMiloticPose235:
+ax_pose 1, 0x01d2, 0xc0e2, 0x0c00
+ax_pose_terminator
+sMiloticPose236:
+ax_pose 22, 0x01d2, 0xc0e2, 0x0c00
+ax_pose_terminator
+sMiloticPose237:
+ax_pose 19, 0x01d2, 0xc0e5, 0x0c00
+ax_pose_terminator
+sMiloticPose238:
+ax_pose 16, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose239:
+ax_pose 13, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose240:
+ax_pose 10, 0x01d2, 0xc0da, 0x0c00
+ax_pose_terminator
+sMiloticPose241:
+ax_pose 7, 0x01d2, 0xc0d9, 0x0c00
+ax_pose_terminator
+sMiloticPose242:
+ax_pose 4, 0x01d2, 0xc0e2, 0x0c00
+ax_pose_terminator
+sMiloticPose243:
+ax_pose 0, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose244:
+ax_pose 21, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose245:
+ax_pose 18, 0x01d2, 0xc0e4, 0x0c00
+ax_pose_terminator
+sMiloticPose246:
+ax_pose 15, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose247:
+ax_pose 12, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+sMiloticPose248:
+ax_pose 9, 0x01d2, 0xc0de, 0x0c00
+ax_pose_terminator
+sMiloticPose249:
+ax_pose 6, 0x01d2, 0xc0db, 0x0c00
+ax_pose_terminator
+sMiloticPose250:
+ax_pose 3, 0x01d2, 0xc0e0, 0x0c00
+ax_pose_terminator
+.align 2
+sMiloticAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 1, 0, 1,
+ax_anim 8, 0, 2, 0, 3, 0, 3,
+ax_anim 8, 0, 0, 0, 2, 0, 2,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, -2,
+ax_anim_terminator
+sMiloticAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 1, 1, 1, 1,
+ax_anim 8, 0, 5, 3, 3, 3, 3,
+ax_anim 8, 0, 3, 1, 1, 1, 1,
+ax_anim 8, 0, 4, -2, -2, -2, -2,
+ax_anim 8, 0, 4, -3, -3, -3, -3,
+ax_anim_terminator
+sMiloticAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 2, 0, 2, 0,
+ax_anim 8, 0, 8, 4, 0, 4, 0,
+ax_anim 8, 0, 6, 2, 0, 2, 0,
+ax_anim 8, 0, 7, -1, 0, -1, 0,
+ax_anim 8, 0, 7, -3, 0, -3, 0,
+ax_anim_terminator
+sMiloticAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 1, -1, 1, -1,
+ax_anim 8, 0, 11, 3, -3, 3, -3,
+ax_anim 8, 0, 9, 1, -1, 1, -1,
+ax_anim 8, 0, 10, -2, 2, -2, 2,
+ax_anim 8, 0, 10, -3, 3, -3, 3,
+ax_anim_terminator
+sMiloticAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, -3, 0, -3,
+ax_anim 8, 0, 12, 0, -2, 0, -2,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 2, 0, 2,
+ax_anim_terminator
+sMiloticAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, -1, -1, -3, -3,
+ax_anim 8, 0, 17, -3, -3, -5, -5,
+ax_anim 8, 0, 15, -1, -1, -1, -1,
+ax_anim 8, 0, 16, 2, 2, 2, 2,
+ax_anim 8, 0, 16, 3, 3, 3, 3,
+ax_anim_terminator
+sMiloticAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, -1, 0, -1, 0,
+ax_anim 8, 0, 20, -4, 0, -4, 0,
+ax_anim 8, 0, 18, -2, 0, -2, 0,
+ax_anim 8, 0, 19, 1, 0, 1, 0,
+ax_anim 8, 0, 19, 3, 0, 3, 0,
+ax_anim_terminator
+sMiloticAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, -1, 1, -1, 1,
+ax_anim 8, 0, 23, -3, 3, -3, 3,
+ax_anim 8, 0, 21, -1, 1, -1, 1,
+ax_anim 8, 0, 22, 2, -2, 2, -2,
+ax_anim 8, 0, 22, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMiloticAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 2, 0, 2,
+ax_anim 1, 0, 27, 0, 7, 0, 7,
+ax_anim 2, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 1, 27, 1, 14, 1, 14,
+ax_anim 2, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 0, 27, 1, 14, 1, 14,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMiloticAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 2, 3, 2, 3,
+ax_anim 1, 0, 31, 7, 9, 7, 9,
+ax_anim 2, 0, 31, 12, 15, 12, 15,
+ax_anim 2, 1, 31, 13, 14, 13, 14,
+ax_anim 2, 0, 31, 12, 15, 12, 15,
+ax_anim 2, 0, 31, 13, 14, 13, 14,
+ax_anim 2, 0, 28, 5, 5, 5, 5,
+ax_anim_terminator
+sMiloticAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 6, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 2, 0, 2, 0,
+ax_anim 1, 0, 35, 4, 0, 4, 0,
+ax_anim 2, 0, 35, 7, 0, 7, 0,
+ax_anim 2, 1, 35, 7, 1, 7, 1,
+ax_anim 2, 0, 35, 7, 0, 7, 0,
+ax_anim 2, 0, 35, 7, 1, 7, 1,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim_terminator
+sMiloticAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 38, 2, -4, 2, -4,
+ax_anim 1, 0, 39, 5, -8, 5, -8,
+ax_anim 2, 0, 39, 9, -14, 9, -14,
+ax_anim 2, 1, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 9, -14, 9, -14,
+ax_anim 2, 0, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 36, 3, -6, 3, -6,
+ax_anim_terminator
+sMiloticAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -6, 0, -6,
+ax_anim 1, 0, 43, 0, -10, 0, -10,
+ax_anim 2, 0, 43, 0, -14, 0, -14,
+ax_anim 2, 1, 43, 1, -14, 1, -14,
+ax_anim 2, 0, 43, 0, -14, 0, -14,
+ax_anim 2, 0, 43, 1, -14, 1, -14,
+ax_anim 2, 0, 40, 0, -3, 0, -3,
+ax_anim_terminator
+sMiloticAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 46, -3, -4, -3, -4,
+ax_anim 1, 0, 47, -7, -8, -7, -8,
+ax_anim 2, 0, 47, -13, -16, -13, -16,
+ax_anim 2, 1, 47, -14, -15, -14, -15,
+ax_anim 2, 0, 47, -13, -16, -13, -16,
+ax_anim 2, 0, 47, -14, -15, -14, -15,
+ax_anim 2, 0, 44, -5, -6, -5, -6,
+ax_anim_terminator
+sMiloticAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -2, 0, -2, 0,
+ax_anim 1, 0, 51, -4, 0, -4, 0,
+ax_anim 2, 0, 51, -7, 0, -7, 0,
+ax_anim 2, 1, 51, -7, 1, -7, 1,
+ax_anim 2, 0, 51, -7, 0, -7, 0,
+ax_anim 2, 0, 51, -7, 1, -7, 1,
+ax_anim 2, 0, 48, -3, 0, -3, 0,
+ax_anim_terminator
+sMiloticAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -1, 3, -1, 3,
+ax_anim 1, 0, 55, -8, 11, -6, 9,
+ax_anim 2, 0, 55, -11, 17, -11, 17,
+ax_anim 2, 1, 55, -12, 16, -12, 16,
+ax_anim 2, 0, 55, -11, 17, -11, 17,
+ax_anim 2, 0, 55, -12, 16, -12, 16,
+ax_anim 2, 0, 52, -3, 6, -3, 6,
+ax_anim_terminator
+.align 2
+sMiloticAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 6, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 0, 2, 0, 2,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 2, 0, 59, 0, 14, 0, 14,
+ax_anim 2, 1, 59, 1, 14, 1, 14,
+ax_anim 2, 0, 59, 0, 14, 0, 14,
+ax_anim 2, 0, 59, 1, 14, 1, 14,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sMiloticAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 6, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 2, 3, 2, 3,
+ax_anim 1, 0, 63, 7, 9, 7, 9,
+ax_anim 2, 0, 63, 12, 15, 12, 15,
+ax_anim 2, 1, 63, 13, 14, 13, 14,
+ax_anim 2, 0, 63, 12, 15, 12, 15,
+ax_anim 2, 0, 63, 13, 14, 13, 14,
+ax_anim 2, 0, 60, 5, 5, 5, 5,
+ax_anim_terminator
+sMiloticAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 6, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 4, 0, 4, 0,
+ax_anim 2, 0, 67, 7, 0, 7, 0,
+ax_anim 2, 1, 67, 7, 1, 7, 1,
+ax_anim 2, 0, 67, 7, 0, 7, 0,
+ax_anim 2, 0, 67, 7, 1, 7, 1,
+ax_anim 2, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sMiloticAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 6, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 70, 2, -4, 2, -4,
+ax_anim 1, 0, 71, 5, -8, 5, -8,
+ax_anim 2, 0, 71, 9, -14, 9, -14,
+ax_anim 2, 1, 71, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 9, -14, 9, -14,
+ax_anim 2, 0, 71, 10, -13, 10, -13,
+ax_anim 2, 0, 68, 3, -6, 3, -6,
+ax_anim_terminator
+sMiloticAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 6, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, -6, 0, -6,
+ax_anim 1, 0, 75, 0, -10, 0, -10,
+ax_anim 2, 0, 75, 0, -14, 0, -14,
+ax_anim 2, 1, 75, 1, -14, 1, -14,
+ax_anim 2, 0, 75, 0, -14, 0, -14,
+ax_anim 2, 0, 75, 1, -14, 1, -14,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sMiloticAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 6, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 78, -3, -4, -3, -4,
+ax_anim 1, 0, 79, -7, -8, -7, -8,
+ax_anim 2, 0, 79, -13, -16, -13, -16,
+ax_anim 2, 1, 79, -14, -15, -14, -15,
+ax_anim 2, 0, 79, -13, -16, -13, -16,
+ax_anim 2, 0, 79, -14, -15, -14, -15,
+ax_anim 2, 0, 76, -5, -6, -5, -6,
+ax_anim_terminator
+sMiloticAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 6, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -2, 0, -2, 0,
+ax_anim 1, 0, 83, -4, 0, -4, 0,
+ax_anim 2, 0, 83, -7, 0, -7, 0,
+ax_anim 2, 1, 83, -7, 1, -7, 1,
+ax_anim 2, 0, 83, -7, 0, -7, 0,
+ax_anim 2, 0, 83, -7, 1, -7, 1,
+ax_anim 2, 0, 80, -3, 0, -3, 0,
+ax_anim_terminator
+sMiloticAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 6, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 86, -1, 3, -1, 3,
+ax_anim 1, 0, 87, -8, 11, -6, 9,
+ax_anim 2, 0, 87, -11, 17, -11, 17,
+ax_anim 2, 1, 87, -12, 16, -12, 16,
+ax_anim 2, 0, 87, -11, 17, -11, 17,
+ax_anim 2, 0, 87, -12, 16, -12, 16,
+ax_anim 2, 0, 84, -3, 6, -3, 6,
+ax_anim_terminator
+.align 2
+sMiloticAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 92, 0, -3, 0, -3,
+ax_anim 6, 2, 92, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 1, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sMiloticAnims_4_2:
+ax_anim 2, 0, 94, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -3, -3, -3,
+ax_anim 6, 2, 97, -5, -5, -5, -5,
+ax_anim 2, 0, 96, -1, -1, -1, -1,
+ax_anim 2, 1, 96, 2, 2, 2, 2,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim_terminator
+sMiloticAnims_4_3:
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 102, -3, 0, -3, 0,
+ax_anim 6, 2, 102, -5, 0, -5, 0,
+ax_anim 2, 0, 101, -1, 0, -1, 0,
+ax_anim 2, 1, 101, 3, 0, 3, 0,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 3, 0, 3, 0,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 3, 0, 3, 0,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 3, 0, 3, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim_terminator
+sMiloticAnims_4_4:
+ax_anim 2, 0, 104, -2, 2, -2, 2,
+ax_anim 2, 0, 107, -3, 3, -3, 3,
+ax_anim 6, 2, 107, -5, 5, -5, 5,
+ax_anim 2, 0, 106, -1, 1, -1, 1,
+ax_anim 2, 1, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 106, 3, -1, 3, -1,
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 106, 3, -1, 3, -1,
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 106, 3, -1, 3, -1,
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim_terminator
+sMiloticAnims_4_5:
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim 2, 0, 112, 0, 3, 0, 3,
+ax_anim 6, 2, 112, 0, 5, 0, 5,
+ax_anim 2, 0, 111, 0, 1, 0, 1,
+ax_anim 2, 1, 111, 0, -3, 0, -3,
+ax_anim 2, 0, 111, 1, -3, 1, -3,
+ax_anim 2, 0, 111, 0, -3, 0, -3,
+ax_anim 2, 0, 111, 1, -3, 1, -3,
+ax_anim 2, 0, 111, 0, -3, 0, -3,
+ax_anim 2, 0, 111, 1, -3, 1, -3,
+ax_anim 2, 0, 111, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sMiloticAnims_4_6:
+ax_anim 2, 0, 114, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 3, 3, 3, 3,
+ax_anim 6, 2, 117, 5, 5, 5, 5,
+ax_anim 2, 0, 116, 1, 1, 1, 1,
+ax_anim 2, 1, 116, -2, -2, -2, -2,
+ax_anim 2, 0, 116, -3, -1, -3, -1,
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim 2, 0, 116, -3, -1, -3, -1,
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim 2, 0, 116, -3, -1, -3, -1,
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim_terminator
+sMiloticAnims_4_7:
+ax_anim 2, 0, 119, 2, 0, 2, 0,
+ax_anim 2, 0, 122, 3, 0, 3, 0,
+ax_anim 6, 2, 122, 5, 0, 5, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 2, 1, 121, -3, 0, -3, 0,
+ax_anim 2, 0, 121, -3, 1, -3, 1,
+ax_anim 2, 0, 121, -3, 0, -3, 0,
+ax_anim 2, 0, 121, -3, 1, -3, 1,
+ax_anim 2, 0, 121, -3, 0, -3, 0,
+ax_anim 2, 0, 121, -3, 1, -3, 1,
+ax_anim 2, 0, 121, -3, 0, -3, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim_terminator
+sMiloticAnims_4_8:
+ax_anim 2, 0, 124, 2, -2, 2, -2,
+ax_anim 2, 0, 127, 3, -3, 3, -3,
+ax_anim 6, 2, 127, 5, -5, 5, -5,
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim 2, 1, 126, -2, 2, -2, 2,
+ax_anim 2, 0, 126, -3, 1, -3, 1,
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim 2, 0, 126, -3, 1, -3, 1,
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim 2, 0, 126, -3, 1, -3, 1,
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sMiloticAnims_5_1:
+ax_anim 2, 0, 128, 0, -1, 0, -1,
+ax_anim 2, 0, 129, 0, -2, 0, -2,
+ax_anim 8, 2, 131, 0, -3, 0, -3,
+ax_anim 2, 0, 131, 1, -3, 1, -3,
+ax_anim 2, 0, 131, 0, -3, 0, -3,
+ax_anim 2, 0, 131, 1, -3, 1, -3,
+ax_anim 2, 0, 131, 0, -3, 0, -3,
+ax_anim 2, 0, 131, 1, -3, 1, -3,
+ax_anim 2, 0, 131, 0, -3, 0, -3,
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim_terminator
+sMiloticAnims_5_2:
+ax_anim 2, 0, 132, -1, -1, 0, -1,
+ax_anim 2, 0, 133, -2, -2, 0, -2,
+ax_anim 8, 2, 135, -3, -3, 0, -3,
+ax_anim 2, 0, 135, -2, -4, -2, -4,
+ax_anim 2, 0, 135, -3, -3, 0, -3,
+ax_anim 2, 0, 135, -2, -4, -2, -4,
+ax_anim 2, 0, 135, -3, -3, 0, -3,
+ax_anim 2, 0, 135, -2, -4, -2, -4,
+ax_anim 2, 0, 135, -3, -3, 0, -3,
+ax_anim 2, 0, 133, -1, -1, 0, -1,
+ax_anim_terminator
+sMiloticAnims_5_3:
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 137, -2, 0, -2, 0,
+ax_anim 8, 2, 139, -3, 0, -3, 0,
+ax_anim 2, 0, 139, -3, 1, -3, 1,
+ax_anim 2, 0, 139, -3, 0, -3, 0,
+ax_anim 2, 0, 139, -3, 1, -3, 1,
+ax_anim 2, 0, 139, -3, 0, -3, 0,
+ax_anim 2, 0, 139, -3, 1, -3, 1,
+ax_anim 2, 0, 139, -3, 0, -3, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim_terminator
+sMiloticAnims_5_4:
+ax_anim 2, 0, 140, -1, 1, 0, 1,
+ax_anim 2, 0, 141, -2, 2, 0, 2,
+ax_anim 8, 2, 143, -3, 3, 0, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, 0, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, 0, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, 0, 3,
+ax_anim 2, 0, 141, -1, 1, 0, 1,
+ax_anim_terminator
+sMiloticAnims_5_5:
+ax_anim 2, 0, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 146, 0, 2, 0, 2,
+ax_anim 8, 2, 147, 0, 3, 0, 3,
+ax_anim 2, 0, 147, -1, 3, -1, 3,
+ax_anim 2, 0, 147, 0, 3, 0, 3,
+ax_anim 2, 0, 147, -1, 3, -1, 3,
+ax_anim 2, 0, 147, 0, 3, 0, 3,
+ax_anim 2, 0, 147, -1, 3, -1, 3,
+ax_anim 2, 0, 147, 0, 3, 0, 3,
+ax_anim 2, 0, 145, 0, 1, 0, 1,
+ax_anim_terminator
+sMiloticAnims_5_6:
+ax_anim 2, 0, 148, 1, 1, 0, 1,
+ax_anim 2, 0, 149, 2, 2, 0, 2,
+ax_anim 8, 2, 151, 3, 3, 0, 3,
+ax_anim 2, 0, 151, 2, 4, 2, 4,
+ax_anim 2, 0, 151, 3, 3, 0, 3,
+ax_anim 2, 0, 151, 2, 4, 2, 4,
+ax_anim 2, 0, 151, 3, 3, 0, 3,
+ax_anim 2, 0, 151, 2, 4, 2, 4,
+ax_anim 2, 0, 151, 3, 3, 0, 3,
+ax_anim 2, 0, 149, 1, 1, 0, 1,
+ax_anim_terminator
+sMiloticAnims_5_7:
+ax_anim 2, 0, 152, 1, 0, 1, 0,
+ax_anim 2, 0, 153, 2, 0, 2, 0,
+ax_anim 8, 2, 155, 3, 0, 3, 0,
+ax_anim 2, 0, 155, 3, 1, 3, 1,
+ax_anim 2, 0, 155, 3, 0, 3, 0,
+ax_anim 2, 0, 155, 3, 1, 3, 1,
+ax_anim 2, 0, 155, 3, 0, 3, 0,
+ax_anim 2, 0, 155, 3, 1, 3, 1,
+ax_anim 2, 0, 155, 3, 0, 3, 0,
+ax_anim 2, 0, 153, 1, 0, 1, 0,
+ax_anim_terminator
+sMiloticAnims_5_8:
+ax_anim 2, 0, 156, 1, -1, 0, -1,
+ax_anim 2, 0, 157, 2, -2, 0, -2,
+ax_anim 8, 2, 159, 3, -3, 0, -3,
+ax_anim 2, 0, 159, 2, -4, 2, -4,
+ax_anim 2, 0, 159, 3, -3, 0, -3,
+ax_anim 2, 0, 159, 2, -4, 2, -4,
+ax_anim 2, 0, 159, 3, -3, 0, -3,
+ax_anim 2, 0, 159, 2, -4, 2, -4,
+ax_anim 2, 0, 159, 3, -3, 0, -3,
+ax_anim 2, 0, 157, 1, -1, 0, -1,
+ax_anim_terminator
+.align 2
+sMiloticAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiloticAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sMiloticAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sMiloticAnims_7_3:
+ax_anim 2, 0, 164, -6, 0, -6, 0,
+ax_anim 8, 0, 164, -7, 0, -7, 0,
+ax_anim_terminator
+sMiloticAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sMiloticAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sMiloticAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sMiloticAnims_7_7:
+ax_anim 2, 0, 168, 6, 0, 6, 0,
+ax_anim 8, 0, 168, 7, 0, 7, 0,
+ax_anim_terminator
+sMiloticAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMiloticAnims_8_1:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, -1, 0, -1,
+ax_anim 8, 0, 170, 0, -1, 0, -1,
+ax_anim_terminator
+sMiloticAnims_8_2:
+ax_anim 40, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, -1, 0, -1,
+ax_anim 8, 0, 174, -1, -2, -1, -2,
+ax_anim 8, 0, 173, -1, -1, -1, -1,
+ax_anim_terminator
+sMiloticAnims_8_3:
+ax_anim 40, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 177, -3, 0, -3, 0,
+ax_anim 8, 0, 177, -4, 0, -4, 0,
+ax_anim 8, 0, 176, -1, 0, -1, 0,
+ax_anim_terminator
+sMiloticAnims_8_4:
+ax_anim 40, 0, 179, 0, 0, 0, 0,
+ax_anim 8, 0, 180, -1, 1, -1, 1,
+ax_anim 8, 0, 180, -2, 2, -2, 2,
+ax_anim 8, 0, 179, -1, 1, -1, 1,
+ax_anim_terminator
+sMiloticAnims_8_5:
+ax_anim 40, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, 3, 0, 3,
+ax_anim 8, 0, 183, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 1, 0, 1,
+ax_anim_terminator
+sMiloticAnims_8_6:
+ax_anim 40, 0, 185, 0, 0, 0, 0,
+ax_anim 8, 0, 186, 1, 1, 1, 1,
+ax_anim 8, 0, 186, 2, 2, 2, 2,
+ax_anim 8, 0, 185, 1, 1, 1, 1,
+ax_anim_terminator
+sMiloticAnims_8_7:
+ax_anim 40, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 2, 0, 2, 0,
+ax_anim 8, 0, 189, 3, 0, 3, 0,
+ax_anim 8, 0, 188, 1, 0, 1, 0,
+ax_anim_terminator
+sMiloticAnims_8_8:
+ax_anim 40, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 1, -1, 1, -1,
+ax_anim 8, 0, 192, 2, -2, 2, -2,
+ax_anim 8, 0, 191, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sMiloticAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 9, 8, 9,
+ax_anim 2, 0, 197, 7, 15, 7, 15,
+ax_anim 3, 0, 198, 0, 18, 0, 18,
+ax_anim 2, 3, 199, -7, 15, -7, 15,
+ax_anim 2, 0, 200, -8, 9, -8, 9,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 19, 10, 19, 10,
+ax_anim 3, 0, 197, 17, 19, 17, 19,
+ax_anim 2, 3, 198, 11, 19, 11, 19,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -5, 16, -5,
+ax_anim 3, 0, 196, 18, -2, 18, -2,
+ax_anim 2, 3, 197, 16, 4, 16, 4,
+ax_anim 2, 0, 198, 12, 5, 12, 5,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -15, 4, -15,
+ax_anim 2, 0, 194, 12, -20, 12, -20,
+ax_anim 3, 0, 195, 18, -19, 18, -19,
+ax_anim 2, 3, 196, 20, -13, 20, -13,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -17, -7, -17,
+ax_anim 3, 0, 194, 0, -20, 0, -20,
+ax_anim 2, 3, 195, 7, -17, 7, -17,
+ax_anim 2, 0, 196, 9, -12, 9, -12,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -15, -4, -15,
+ax_anim 2, 0, 194, -12, -20, -12, -20,
+ax_anim 3, 0, 201, -18, -19, -18, -19,
+ax_anim 2, 3, 200, -20, -13, -20, -13,
+ax_anim 2, 0, 199, -17, -4, -17, -4,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -5, -16, -5,
+ax_anim 3, 0, 200, -18, -2, -18, -2,
+ax_anim 2, 3, 199, -16, 4, -16, 4,
+ax_anim 2, 0, 198, -12, 5, -12, 5,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -19, 10, -19, 10,
+ax_anim 3, 0, 199, -17, 19, -17, 19,
+ax_anim 2, 3, 198, -11, 19, -11, 19,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiloticAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiloticAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 2, 0, 225, 0, -17, 0, 0,
+ax_anim 1, 0, 225, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 230, 0, -16, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 228, 0, -22, 0, 0,
+ax_anim 2, 0, 228, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 231, 0, -22, 0, 0,
+ax_anim 2, 0, 231, 0, -18, 0, 0,
+ax_anim 1, 0, 231, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiloticAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiloticAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sMiloticGfx1:
+.incbin "baserom.gba", 0x1446CDC, 0x800
+sMiloticSprites1:
+ax_sprite sMiloticGfx1, 0x800
+ax_sprite_terminator
+sMiloticGfx2:
+.incbin "baserom.gba", 0x14474EC, 0x800
+sMiloticSprites2:
+ax_sprite sMiloticGfx2, 0x800
+ax_sprite_terminator
+sMiloticGfx3:
+.incbin "baserom.gba", 0x1447CFC, 0x800
+sMiloticSprites3:
+ax_sprite sMiloticGfx3, 0x800
+ax_sprite_terminator
+sMiloticGfx4:
+.incbin "baserom.gba", 0x144850C, 0x800
+sMiloticSprites4:
+ax_sprite sMiloticGfx4, 0x800
+ax_sprite_terminator
+sMiloticGfx5:
+.incbin "baserom.gba", 0x1448D1C, 0x800
+sMiloticSprites5:
+ax_sprite sMiloticGfx5, 0x800
+ax_sprite_terminator
+sMiloticGfx6:
+.incbin "baserom.gba", 0x144952C, 0x800
+sMiloticSprites6:
+ax_sprite sMiloticGfx6, 0x800
+ax_sprite_terminator
+sMiloticGfx7:
+.incbin "baserom.gba", 0x1449D3C, 0x800
+sMiloticSprites7:
+ax_sprite sMiloticGfx7, 0x800
+ax_sprite_terminator
+sMiloticGfx8:
+.incbin "baserom.gba", 0x144A54C, 0x800
+sMiloticSprites8:
+ax_sprite sMiloticGfx8, 0x800
+ax_sprite_terminator
+sMiloticGfx9:
+.incbin "baserom.gba", 0x144AD5C, 0x800
+sMiloticSprites9:
+ax_sprite sMiloticGfx9, 0x800
+ax_sprite_terminator
+sMiloticGfx10:
+.incbin "baserom.gba", 0x144B56C, 0x800
+sMiloticSprites10:
+ax_sprite sMiloticGfx10, 0x800
+ax_sprite_terminator
+sMiloticGfx11:
+.incbin "baserom.gba", 0x144BD7C, 0x800
+sMiloticSprites11:
+ax_sprite sMiloticGfx11, 0x800
+ax_sprite_terminator
+sMiloticGfx12:
+.incbin "baserom.gba", 0x144C58C, 0x800
+sMiloticSprites12:
+ax_sprite sMiloticGfx12, 0x800
+ax_sprite_terminator
+sMiloticGfx13:
+.incbin "baserom.gba", 0x144CD9C, 0x800
+sMiloticSprites13:
+ax_sprite sMiloticGfx13, 0x800
+ax_sprite_terminator
+sMiloticGfx14:
+.incbin "baserom.gba", 0x144D5AC, 0x800
+sMiloticSprites14:
+ax_sprite sMiloticGfx14, 0x800
+ax_sprite_terminator
+sMiloticGfx15:
+.incbin "baserom.gba", 0x144DDBC, 0x800
+sMiloticSprites15:
+ax_sprite sMiloticGfx15, 0x800
+ax_sprite_terminator
+sMiloticGfx16:
+.incbin "baserom.gba", 0x144E5CC, 0x800
+sMiloticSprites16:
+ax_sprite sMiloticGfx16, 0x800
+ax_sprite_terminator
+sMiloticGfx17:
+.incbin "baserom.gba", 0x144EDDC, 0x800
+sMiloticSprites17:
+ax_sprite sMiloticGfx17, 0x800
+ax_sprite_terminator
+sMiloticGfx18:
+.incbin "baserom.gba", 0x144F5EC, 0x800
+sMiloticSprites18:
+ax_sprite sMiloticGfx18, 0x800
+ax_sprite_terminator
+sMiloticGfx19:
+.incbin "baserom.gba", 0x144FDFC, 0x800
+sMiloticSprites19:
+ax_sprite sMiloticGfx19, 0x800
+ax_sprite_terminator
+sMiloticGfx20:
+.incbin "baserom.gba", 0x145060C, 0x800
+sMiloticSprites20:
+ax_sprite sMiloticGfx20, 0x800
+ax_sprite_terminator
+sMiloticGfx21:
+.incbin "baserom.gba", 0x1450E1C, 0x800
+sMiloticSprites21:
+ax_sprite sMiloticGfx21, 0x800
+ax_sprite_terminator
+sMiloticGfx22:
+.incbin "baserom.gba", 0x145162C, 0x800
+sMiloticSprites22:
+ax_sprite sMiloticGfx22, 0x800
+ax_sprite_terminator
+sMiloticGfx23:
+.incbin "baserom.gba", 0x1451E3C, 0x800
+sMiloticSprites23:
+ax_sprite sMiloticGfx23, 0x800
+ax_sprite_terminator
+sMiloticGfx24:
+.incbin "baserom.gba", 0x145264C, 0x800
+sMiloticSprites24:
+ax_sprite sMiloticGfx24, 0x800
+ax_sprite_terminator
+sMiloticGfx25:
+.incbin "baserom.gba", 0x1452E5C, 0x40
+sMiloticGfx25_1:
+.incbin "baserom.gba", 0x1452E9C, 0x40
+sMiloticGfx25_2:
+.incbin "baserom.gba", 0x1452EDC, 0x260
+sMiloticSprites25:
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx25_2, 0x260
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMiloticGfx26:
+.incbin "baserom.gba", 0x145317C, 0x40
+sMiloticSprites26:
+ax_sprite sMiloticGfx26, 0x40
+ax_sprite_terminator
+sMiloticGfx27:
+.incbin "baserom.gba", 0x14531CC, 0x40
+sMiloticGfx27_1:
+.incbin "baserom.gba", 0x145320C, 0x40
+sMiloticGfx27_2:
+.incbin "baserom.gba", 0x145324C, 0x60
+sMiloticGfx27_3:
+.incbin "baserom.gba", 0x14532AC, 0x60
+sMiloticSprites27:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx27_3, 0x60
+ax_sprite_terminator
+sMiloticGfx28:
+.incbin "baserom.gba", 0x1453354, 0x1E0
+sMiloticSprites28:
+ax_sprite sMiloticGfx28, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx29:
+.incbin "baserom.gba", 0x145354C, 0x80
+sMiloticSprites29:
+ax_sprite sMiloticGfx29, 0x80
+ax_sprite_terminator
+sMiloticGfx30:
+.incbin "baserom.gba", 0x14535DC, 0x40
+sMiloticGfx30_1:
+.incbin "baserom.gba", 0x145361C, 0x60
+sMiloticGfx30_2:
+.incbin "baserom.gba", 0x145367C, 0x40
+sMiloticGfx30_3:
+.incbin "baserom.gba", 0x14536BC, 0x160
+sMiloticGfx30_4:
+.incbin "baserom.gba", 0x145381C, 0xC0
+sMiloticSprites30:
+ax_sprite sMiloticGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx30_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx30_3, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx30_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMiloticGfx31:
+.incbin "baserom.gba", 0x1453934, 0x60
+sMiloticGfx31_1:
+.incbin "baserom.gba", 0x1453994, 0x60
+sMiloticSprites31:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx31_1, 0x60
+ax_sprite_terminator
+sMiloticGfx32:
+.incbin "baserom.gba", 0x1453A1C, 0x60
+sMiloticGfx32_1:
+.incbin "baserom.gba", 0x1453A7C, 0x160
+sMiloticSprites32:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx32_1, 0x160
+ax_sprite_terminator
+sMiloticGfx33:
+.incbin "baserom.gba", 0x1453C04, 0x40
+sMiloticSprites33:
+ax_sprite sMiloticGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMiloticGfx34:
+.incbin "baserom.gba", 0x1453C5C, 0x80
+sMiloticSprites34:
+ax_sprite sMiloticGfx34, 0x80
+ax_sprite_terminator
+sMiloticGfx35:
+.incbin "baserom.gba", 0x1453CEC, 0x60
+sMiloticGfx35_1:
+.incbin "baserom.gba", 0x1453D4C, 0x60
+sMiloticSprites35:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx35_1, 0x60
+ax_sprite_terminator
+sMiloticGfx36:
+.incbin "baserom.gba", 0x1453DD4, 0x180
+sMiloticGfx36_1:
+.incbin "baserom.gba", 0x1453F54, 0x60
+sMiloticGfx36_2:
+.incbin "baserom.gba", 0x1453FB4, 0x140
+sMiloticSprites36:
+ax_sprite sMiloticGfx36, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx36_2, 0x140
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMiloticGfx37:
+.incbin "baserom.gba", 0x145412C, 0x40
+sMiloticSprites37:
+ax_sprite sMiloticGfx37, 0x40
+ax_sprite_terminator
+sMiloticGfx38:
+.incbin "baserom.gba", 0x145417C, 0x60
+sMiloticGfx38_1:
+.incbin "baserom.gba", 0x14541DC, 0x60
+sMiloticGfx38_2:
+.incbin "baserom.gba", 0x145423C, 0x100
+sMiloticSprites38:
+ax_sprite sMiloticGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx38_2, 0x100
+ax_sprite_terminator
+sMiloticGfx39:
+.incbin "baserom.gba", 0x145436C, 0x40
+sMiloticGfx39_1:
+.incbin "baserom.gba", 0x14543AC, 0x60
+sMiloticGfx39_2:
+.incbin "baserom.gba", 0x145440C, 0x100
+sMiloticSprites39:
+ax_sprite sMiloticGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx39_2, 0x100
+ax_sprite_terminator
+sMiloticGfx40:
+.incbin "baserom.gba", 0x145453C, 0x20
+sMiloticSprites40:
+ax_sprite sMiloticGfx40, 0x20
+ax_sprite_terminator
+sMiloticGfx41:
+.incbin "baserom.gba", 0x145456C, 0x20
+sMiloticSprites41:
+ax_sprite sMiloticGfx41, 0x20
+ax_sprite_terminator
+sMiloticGfx42:
+.incbin "baserom.gba", 0x145459C, 0x60
+sMiloticGfx42_1:
+.incbin "baserom.gba", 0x14545FC, 0xE0
+sMiloticGfx42_2:
+.incbin "baserom.gba", 0x14546DC, 0x100
+sMiloticGfx42_3:
+.incbin "baserom.gba", 0x14547DC, 0xE0
+sMiloticSprites42:
+ax_sprite sMiloticGfx42, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sMiloticGfx42_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx42_2, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx42_3, 0xe0
+ax_sprite_terminator
+sMiloticGfx43:
+.incbin "baserom.gba", 0x14548FC, 0xE0
+sMiloticSprites43:
+ax_sprite sMiloticGfx43, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx44:
+.incbin "baserom.gba", 0x14549F4, 0x180
+sMiloticGfx44_1:
+.incbin "baserom.gba", 0x1454B74, 0x60
+sMiloticSprites44:
+ax_sprite sMiloticGfx44, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx44_1, 0x60
+ax_sprite_terminator
+sMiloticGfx45:
+.incbin "baserom.gba", 0x1454BF4, 0x40
+sMiloticGfx45_1:
+.incbin "baserom.gba", 0x1454C34, 0xA0
+sMiloticGfx45_2:
+.incbin "baserom.gba", 0x1454CD4, 0x60
+sMiloticSprites45:
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx45_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx46:
+.incbin "baserom.gba", 0x1454D74, 0x200
+sMiloticSprites46:
+ax_sprite sMiloticGfx46, 0x200
+ax_sprite_terminator
+sMiloticGfx47:
+.incbin "baserom.gba", 0x1454F84, 0x60
+sMiloticGfx47_1:
+.incbin "baserom.gba", 0x1454FE4, 0x60
+sMiloticSprites47:
+ax_sprite sMiloticGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx48:
+.incbin "baserom.gba", 0x145506C, 0x40
+sMiloticGfx48_1:
+.incbin "baserom.gba", 0x14550AC, 0x60
+sMiloticGfx48_2:
+.incbin "baserom.gba", 0x145510C, 0x60
+sMiloticGfx48_3:
+.incbin "baserom.gba", 0x145516C, 0x1E0
+sMiloticSprites48:
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx48_3, 0x1e0
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMiloticGfx49:
+.incbin "baserom.gba", 0x145539C, 0x80
+sMiloticSprites49:
+ax_sprite sMiloticGfx49, 0x80
+ax_sprite_terminator
+sMiloticGfx50:
+.incbin "baserom.gba", 0x145542C, 0x200
+sMiloticSprites50:
+ax_sprite sMiloticGfx50, 0x200
+ax_sprite_terminator
+sMiloticGfx51:
+.incbin "baserom.gba", 0x145563C, 0xE0
+sMiloticSprites51:
+ax_sprite sMiloticGfx51, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx52:
+.incbin "baserom.gba", 0x1455734, 0x80
+sMiloticSprites52:
+ax_sprite sMiloticGfx52, 0x80
+ax_sprite_terminator
+sMiloticGfx53:
+.incbin "baserom.gba", 0x14557C4, 0x20
+sMiloticGfx53_1:
+.incbin "baserom.gba", 0x14557E4, 0x160
+sMiloticGfx53_2:
+.incbin "baserom.gba", 0x1455944, 0x1E0
+sMiloticSprites53:
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx53, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx53_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx53_2, 0x1e0
+ax_sprite_terminator
+sMiloticGfx54:
+.incbin "baserom.gba", 0x1455B5C, 0x20
+sMiloticGfx54_1:
+.incbin "baserom.gba", 0x1455B7C, 0xC0
+sMiloticGfx54_2:
+.incbin "baserom.gba", 0x1455C3C, 0x60
+sMiloticGfx54_3:
+.incbin "baserom.gba", 0x1455C9C, 0x40
+sMiloticGfx54_4:
+.incbin "baserom.gba", 0x1455CDC, 0x60
+sMiloticGfx54_5:
+.incbin "baserom.gba", 0x1455D3C, 0xC0
+sMiloticSprites54:
+ax_sprite sMiloticGfx54, 0x20
+ax_sprite 0, 0x80
+ax_sprite sMiloticGfx54_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx54_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx54_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx54_4, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx54_5, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx55:
+.incbin "baserom.gba", 0x1455E64, 0x80
+sMiloticSprites55:
+ax_sprite sMiloticGfx55, 0x80
+ax_sprite_terminator
+sMiloticSprites56:
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx57:
+.incbin "baserom.gba", 0x1455F04, 0x40
+sMiloticSprites57:
+ax_sprite sMiloticGfx57, 0x40
+ax_sprite_terminator
+sMiloticGfx58:
+.incbin "baserom.gba", 0x1455F54, 0x40
+sMiloticGfx58_1:
+.incbin "baserom.gba", 0x1455F94, 0x40
+sMiloticGfx58_2:
+.incbin "baserom.gba", 0x1455FD4, 0x60
+sMiloticGfx58_3:
+.incbin "baserom.gba", 0x1456034, 0x280
+sMiloticSprites58:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx58, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx58_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx58_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx58_3, 0x280
+ax_sprite_terminator
+sMiloticGfx59:
+.incbin "baserom.gba", 0x14562FC, 0x40
+sMiloticGfx59_1:
+.incbin "baserom.gba", 0x145633C, 0x20
+sMiloticSprites59:
+ax_sprite sMiloticGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx59_1, 0x20
+ax_sprite_terminator
+sMiloticGfx60:
+.incbin "baserom.gba", 0x145637C, 0x60
+sMiloticGfx60_1:
+.incbin "baserom.gba", 0x14563DC, 0x60
+sMiloticGfx60_2:
+.incbin "baserom.gba", 0x145643C, 0xE0
+sMiloticSprites60:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx60, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx60_2, 0xe0
+ax_sprite_terminator
+sMiloticGfx61:
+.incbin "baserom.gba", 0x1456554, 0x60
+sMiloticGfx61_1:
+.incbin "baserom.gba", 0x14565B4, 0x80
+sMiloticGfx61_2:
+.incbin "baserom.gba", 0x1456634, 0x40
+sMiloticSprites61:
+ax_sprite sMiloticGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx61_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx61_2, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMiloticGfx62:
+.incbin "baserom.gba", 0x14566AC, 0x60
+sMiloticGfx62_1:
+.incbin "baserom.gba", 0x145670C, 0x60
+sMiloticSprites62:
+ax_sprite sMiloticGfx62, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx62_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx63:
+.incbin "baserom.gba", 0x1456794, 0x20
+sMiloticGfx63_1:
+.incbin "baserom.gba", 0x14567B4, 0x60
+sMiloticGfx63_2:
+.incbin "baserom.gba", 0x1456814, 0x60
+sMiloticGfx63_3:
+.incbin "baserom.gba", 0x1456874, 0x60
+sMiloticGfx63_4:
+.incbin "baserom.gba", 0x14568D4, 0x60
+sMiloticGfx63_5:
+.incbin "baserom.gba", 0x1456934, 0x180
+sMiloticSprites63:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx63, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx63_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx63_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx63_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx63_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx63_5, 0x180
+ax_sprite_terminator
+sMiloticGfx64:
+.incbin "baserom.gba", 0x1456B1C, 0x80
+sMiloticGfx64_1:
+.incbin "baserom.gba", 0x1456B9C, 0x20
+sMiloticSprites64:
+ax_sprite sMiloticGfx64, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx64_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMiloticGfx65:
+.incbin "baserom.gba", 0x1456BE4, 0x160
+sMiloticGfx65_1:
+.incbin "baserom.gba", 0x1456D44, 0x80
+sMiloticGfx65_2:
+.incbin "baserom.gba", 0x1456DC4, 0x140
+sMiloticSprites65:
+ax_sprite 0, 0x80
+ax_sprite sMiloticGfx65, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx65_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx65_2, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx66:
+.incbin "baserom.gba", 0x1456F44, 0x20
+sMiloticSprites66:
+ax_sprite sMiloticGfx66, 0x20
+ax_sprite_terminator
+sMiloticGfx67:
+.incbin "baserom.gba", 0x1456F74, 0x60
+sMiloticGfx67_1:
+.incbin "baserom.gba", 0x1456FD4, 0x60
+sMiloticGfx67_2:
+.incbin "baserom.gba", 0x1457034, 0x60
+sMiloticGfx67_3:
+.incbin "baserom.gba", 0x1457094, 0x60
+sMiloticGfx67_4:
+.incbin "baserom.gba", 0x14570F4, 0x160
+sMiloticGfx67_5:
+.incbin "baserom.gba", 0x1457254, 0x60
+sMiloticSprites67:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx67, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx67_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx67_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx67_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx67_4, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx67_5, 0x60
+ax_sprite_terminator
+sMiloticGfx68:
+.incbin "baserom.gba", 0x145731C, 0x40
+sMiloticSprites68:
+ax_sprite sMiloticGfx68, 0x40
+ax_sprite_terminator
+sMiloticGfx69:
+.incbin "baserom.gba", 0x145736C, 0x60
+sMiloticGfx69_1:
+.incbin "baserom.gba", 0x14573CC, 0x60
+sMiloticGfx69_2:
+.incbin "baserom.gba", 0x145742C, 0x100
+sMiloticSprites69:
+ax_sprite sMiloticGfx69, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx69_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx69_2, 0x100
+ax_sprite_terminator
+sMiloticGfx70:
+.incbin "baserom.gba", 0x145755C, 0x40
+sMiloticGfx70_1:
+.incbin "baserom.gba", 0x145759C, 0x60
+sMiloticGfx70_2:
+.incbin "baserom.gba", 0x14575FC, 0xE0
+sMiloticSprites70:
+ax_sprite sMiloticGfx70, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx70_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx70_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx71:
+.incbin "baserom.gba", 0x1457714, 0x60
+sMiloticSprites71:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx71, 0x60
+ax_sprite_terminator
+sMiloticGfx72:
+.incbin "baserom.gba", 0x145778C, 0x40
+sMiloticGfx72_1:
+.incbin "baserom.gba", 0x14577CC, 0x60
+sMiloticGfx72_2:
+.incbin "baserom.gba", 0x145782C, 0x60
+sMiloticGfx72_3:
+.incbin "baserom.gba", 0x145788C, 0x60
+sMiloticGfx72_4:
+.incbin "baserom.gba", 0x14578EC, 0x180
+sMiloticGfx72_5:
+.incbin "baserom.gba", 0x1457A6C, 0x60
+sMiloticSprites72:
+ax_sprite sMiloticGfx72, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx72_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx72_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx72_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx72_4, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx72_5, 0x60
+ax_sprite_terminator
+sMiloticGfx73:
+.incbin "baserom.gba", 0x1457B2C, 0x40
+sMiloticSprites73:
+ax_sprite sMiloticGfx73, 0x40
+ax_sprite_terminator
+sMiloticGfx74:
+.incbin "baserom.gba", 0x1457B7C, 0x60
+sMiloticGfx74_1:
+.incbin "baserom.gba", 0x1457BDC, 0x60
+sMiloticGfx74_2:
+.incbin "baserom.gba", 0x1457C3C, 0x60
+sMiloticGfx74_3:
+.incbin "baserom.gba", 0x1457C9C, 0x60
+sMiloticSprites74:
+ax_sprite sMiloticGfx74, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx74_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx74_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx74_3, 0x60
+ax_sprite_terminator
+sMiloticGfx75:
+.incbin "baserom.gba", 0x1457D3C, 0x40
+sMiloticGfx75_1:
+.incbin "baserom.gba", 0x1457D7C, 0x120
+sMiloticGfx75_2:
+.incbin "baserom.gba", 0x1457E9C, 0x40
+sMiloticSprites75:
+ax_sprite sMiloticGfx75, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx75_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx75_2, 0x40
+ax_sprite_terminator
+sMiloticGfx76:
+.incbin "baserom.gba", 0x1457F0C, 0x20
+sMiloticSprites76:
+ax_sprite sMiloticGfx76, 0x20
+ax_sprite_terminator
+sMiloticGfx77:
+.incbin "baserom.gba", 0x1457F3C, 0x80
+sMiloticSprites77:
+ax_sprite sMiloticGfx77, 0x80
+ax_sprite_terminator
+sMiloticGfx78:
+.incbin "baserom.gba", 0x1457FCC, 0x40
+sMiloticGfx78_1:
+.incbin "baserom.gba", 0x145800C, 0x40
+sMiloticGfx78_2:
+.incbin "baserom.gba", 0x145804C, 0x260
+sMiloticSprites78:
+ax_sprite 0, 0xa0
+ax_sprite sMiloticGfx78, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx78_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx78_2, 0x260
+ax_sprite_terminator
+sMiloticGfx79:
+.incbin "baserom.gba", 0x14582E4, 0xE0
+sMiloticSprites79:
+ax_sprite sMiloticGfx79, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx80:
+.incbin "baserom.gba", 0x14583DC, 0x200
+sMiloticSprites80:
+ax_sprite sMiloticGfx80, 0x200
+ax_sprite_terminator
+sMiloticGfx81:
+.incbin "baserom.gba", 0x14585EC, 0x60
+sMiloticGfx81_1:
+.incbin "baserom.gba", 0x145864C, 0xC0
+sMiloticGfx81_2:
+.incbin "baserom.gba", 0x145870C, 0x60
+sMiloticSprites81:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx81, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx81_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx81_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx82:
+.incbin "baserom.gba", 0x14587AC, 0x40
+sMiloticGfx82_1:
+.incbin "baserom.gba", 0x14587EC, 0x60
+sMiloticGfx82_2:
+.incbin "baserom.gba", 0x145884C, 0x60
+sMiloticGfx82_3:
+.incbin "baserom.gba", 0x14588AC, 0x1C0
+sMiloticSprites82:
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx82, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiloticGfx82_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx82_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx82_3, 0x1c0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMiloticGfx83:
+.incbin "baserom.gba", 0x1458ABC, 0xA0
+sMiloticGfx83_1:
+.incbin "baserom.gba", 0x1458B5C, 0x20
+sMiloticSprites83:
+ax_sprite sMiloticGfx83, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sMiloticGfx83_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiloticGfx84:
+.incbin "baserom.gba", 0x1458BA4, 0x800
+sMiloticSprites84:
+ax_sprite sMiloticGfx84, 0x800
+ax_sprite_terminator
+sMiloticGfx85:
+.incbin "baserom.gba", 0x14593B4, 0x800
+sMiloticSprites85:
+ax_sprite sMiloticGfx85, 0x800
+ax_sprite_terminator
+sMiloticGfx86:
+.incbin "baserom.gba", 0x1459BC4, 0x800
+sMiloticSprites86:
+ax_sprite sMiloticGfx86, 0x800
+ax_sprite_terminator
+sMiloticGfx87:
+.incbin "baserom.gba", 0x145A3D4, 0x800
+sMiloticSprites87:
+ax_sprite sMiloticGfx87, 0x800
+ax_sprite_terminator
+sMiloticGfx88:
+.incbin "baserom.gba", 0x145ABE4, 0x800
+sMiloticSprites88:
+ax_sprite sMiloticGfx88, 0x800
+ax_sprite_terminator
+sMiloticGfx89:
+.incbin "baserom.gba", 0x145B3F4, 0x800
+sMiloticSprites89:
+ax_sprite sMiloticGfx89, 0x800
+ax_sprite_terminator
+sMiloticGfx90:
+.incbin "baserom.gba", 0x145BC04, 0x200
+sMiloticSprites90:
+ax_sprite sMiloticGfx90, 0x200
+ax_sprite_terminator
+sMiloticGfx91:
+.incbin "baserom.gba", 0x145BE14, 0x80
+sMiloticSprites91:
+ax_sprite sMiloticGfx91, 0x80
+ax_sprite_terminator
+sMiloticGfx92:
+.incbin "baserom.gba", 0x145BEA4, 0x200
+sMiloticSprites92:
+ax_sprite sMiloticGfx92, 0x200
+ax_sprite_terminator
+sAxPosesMilotic:
+.4byte sMiloticPose1
+.4byte sMiloticPose2
+.4byte sMiloticPose3
+.4byte sMiloticPose4
+.4byte sMiloticPose5
+.4byte sMiloticPose6
+.4byte sMiloticPose7
+.4byte sMiloticPose8
+.4byte sMiloticPose9
+.4byte sMiloticPose10
+.4byte sMiloticPose11
+.4byte sMiloticPose12
+.4byte sMiloticPose13
+.4byte sMiloticPose14
+.4byte sMiloticPose15
+.4byte sMiloticPose16
+.4byte sMiloticPose17
+.4byte sMiloticPose18
+.4byte sMiloticPose19
+.4byte sMiloticPose20
+.4byte sMiloticPose21
+.4byte sMiloticPose22
+.4byte sMiloticPose23
+.4byte sMiloticPose24
+.4byte sMiloticPose25
+.4byte sMiloticPose26
+.4byte sMiloticPose27
+.4byte sMiloticPose28
+.4byte sMiloticPose29
+.4byte sMiloticPose30
+.4byte sMiloticPose31
+.4byte sMiloticPose32
+.4byte sMiloticPose33
+.4byte sMiloticPose34
+.4byte sMiloticPose35
+.4byte sMiloticPose36
+.4byte sMiloticPose37
+.4byte sMiloticPose38
+.4byte sMiloticPose39
+.4byte sMiloticPose40
+.4byte sMiloticPose41
+.4byte sMiloticPose42
+.4byte sMiloticPose43
+.4byte sMiloticPose44
+.4byte sMiloticPose45
+.4byte sMiloticPose46
+.4byte sMiloticPose47
+.4byte sMiloticPose48
+.4byte sMiloticPose49
+.4byte sMiloticPose50
+.4byte sMiloticPose51
+.4byte sMiloticPose52
+.4byte sMiloticPose53
+.4byte sMiloticPose54
+.4byte sMiloticPose55
+.4byte sMiloticPose56
+.4byte sMiloticPose57
+.4byte sMiloticPose58
+.4byte sMiloticPose59
+.4byte sMiloticPose60
+.4byte sMiloticPose61
+.4byte sMiloticPose62
+.4byte sMiloticPose63
+.4byte sMiloticPose64
+.4byte sMiloticPose65
+.4byte sMiloticPose66
+.4byte sMiloticPose67
+.4byte sMiloticPose68
+.4byte sMiloticPose69
+.4byte sMiloticPose70
+.4byte sMiloticPose71
+.4byte sMiloticPose72
+.4byte sMiloticPose73
+.4byte sMiloticPose74
+.4byte sMiloticPose75
+.4byte sMiloticPose76
+.4byte sMiloticPose77
+.4byte sMiloticPose78
+.4byte sMiloticPose79
+.4byte sMiloticPose80
+.4byte sMiloticPose81
+.4byte sMiloticPose82
+.4byte sMiloticPose83
+.4byte sMiloticPose84
+.4byte sMiloticPose85
+.4byte sMiloticPose86
+.4byte sMiloticPose87
+.4byte sMiloticPose88
+.4byte sMiloticPose89
+.4byte sMiloticPose90
+.4byte sMiloticPose91
+.4byte sMiloticPose92
+.4byte sMiloticPose93
+.4byte sMiloticPose94
+.4byte sMiloticPose95
+.4byte sMiloticPose96
+.4byte sMiloticPose97
+.4byte sMiloticPose98
+.4byte sMiloticPose99
+.4byte sMiloticPose100
+.4byte sMiloticPose101
+.4byte sMiloticPose102
+.4byte sMiloticPose103
+.4byte sMiloticPose104
+.4byte sMiloticPose105
+.4byte sMiloticPose106
+.4byte sMiloticPose107
+.4byte sMiloticPose108
+.4byte sMiloticPose109
+.4byte sMiloticPose110
+.4byte sMiloticPose111
+.4byte sMiloticPose112
+.4byte sMiloticPose113
+.4byte sMiloticPose114
+.4byte sMiloticPose115
+.4byte sMiloticPose116
+.4byte sMiloticPose117
+.4byte sMiloticPose118
+.4byte sMiloticPose119
+.4byte sMiloticPose120
+.4byte sMiloticPose121
+.4byte sMiloticPose122
+.4byte sMiloticPose123
+.4byte sMiloticPose124
+.4byte sMiloticPose125
+.4byte sMiloticPose126
+.4byte sMiloticPose127
+.4byte sMiloticPose128
+.4byte sMiloticPose129
+.4byte sMiloticPose130
+.4byte sMiloticPose131
+.4byte sMiloticPose132
+.4byte sMiloticPose133
+.4byte sMiloticPose134
+.4byte sMiloticPose135
+.4byte sMiloticPose136
+.4byte sMiloticPose137
+.4byte sMiloticPose138
+.4byte sMiloticPose139
+.4byte sMiloticPose140
+.4byte sMiloticPose141
+.4byte sMiloticPose142
+.4byte sMiloticPose143
+.4byte sMiloticPose144
+.4byte sMiloticPose145
+.4byte sMiloticPose146
+.4byte sMiloticPose147
+.4byte sMiloticPose148
+.4byte sMiloticPose149
+.4byte sMiloticPose150
+.4byte sMiloticPose151
+.4byte sMiloticPose152
+.4byte sMiloticPose153
+.4byte sMiloticPose154
+.4byte sMiloticPose155
+.4byte sMiloticPose156
+.4byte sMiloticPose157
+.4byte sMiloticPose158
+.4byte sMiloticPose159
+.4byte sMiloticPose160
+.4byte sMiloticPose161
+.4byte sMiloticPose162
+.4byte sMiloticPose163
+.4byte sMiloticPose164
+.4byte sMiloticPose165
+.4byte sMiloticPose166
+.4byte sMiloticPose167
+.4byte sMiloticPose168
+.4byte sMiloticPose169
+.4byte sMiloticPose170
+.4byte sMiloticPose171
+.4byte sMiloticPose172
+.4byte sMiloticPose173
+.4byte sMiloticPose174
+.4byte sMiloticPose175
+.4byte sMiloticPose176
+.4byte sMiloticPose177
+.4byte sMiloticPose178
+.4byte sMiloticPose179
+.4byte sMiloticPose180
+.4byte sMiloticPose181
+.4byte sMiloticPose182
+.4byte sMiloticPose183
+.4byte sMiloticPose184
+.4byte sMiloticPose185
+.4byte sMiloticPose186
+.4byte sMiloticPose187
+.4byte sMiloticPose188
+.4byte sMiloticPose189
+.4byte sMiloticPose190
+.4byte sMiloticPose191
+.4byte sMiloticPose192
+.4byte sMiloticPose193
+.4byte sMiloticPose194
+.4byte sMiloticPose195
+.4byte sMiloticPose196
+.4byte sMiloticPose197
+.4byte sMiloticPose198
+.4byte sMiloticPose199
+.4byte sMiloticPose200
+.4byte sMiloticPose201
+.4byte sMiloticPose202
+.4byte sMiloticPose203
+.4byte sMiloticPose204
+.4byte sMiloticPose205
+.4byte sMiloticPose206
+.4byte sMiloticPose207
+.4byte sMiloticPose208
+.4byte sMiloticPose209
+.4byte sMiloticPose210
+.4byte sMiloticPose211
+.4byte sMiloticPose212
+.4byte sMiloticPose213
+.4byte sMiloticPose214
+.4byte sMiloticPose215
+.4byte sMiloticPose216
+.4byte sMiloticPose217
+.4byte sMiloticPose218
+.4byte sMiloticPose219
+.4byte sMiloticPose220
+.4byte sMiloticPose221
+.4byte sMiloticPose222
+.4byte sMiloticPose223
+.4byte sMiloticPose224
+.4byte sMiloticPose225
+.4byte sMiloticPose226
+.4byte sMiloticPose227
+.4byte sMiloticPose228
+.4byte sMiloticPose229
+.4byte sMiloticPose230
+.4byte sMiloticPose231
+.4byte sMiloticPose232
+.4byte sMiloticPose233
+.4byte sMiloticPose234
+.4byte sMiloticPose235
+.4byte sMiloticPose236
+.4byte sMiloticPose237
+.4byte sMiloticPose238
+.4byte sMiloticPose239
+.4byte sMiloticPose240
+.4byte sMiloticPose241
+.4byte sMiloticPose242
+.4byte sMiloticPose243
+.4byte sMiloticPose244
+.4byte sMiloticPose245
+.4byte sMiloticPose246
+.4byte sMiloticPose247
+.4byte sMiloticPose248
+.4byte sMiloticPose249
+.4byte sMiloticPose250
+sAxPositionsMilotic:
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -21, 	  -6,   -7, 	   4,   -7, 	  -2,   -8
+.2byte   -1,  -12, 	  -7,   -3, 	   4,   -3, 	  -2,   -3
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+.2byte    6,  -22, 	  -1,   -5, 	   7,   -9, 	   4,   -5
+.2byte   16,  -13, 	   1,    0, 	  11,   -5, 	   7,   -5
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte   12,  -26, 	   7,   -4, 	   6,  -10, 	   5,   -5
+.2byte   22,  -22, 	   8,   -4, 	   8,   -9, 	   9,   -6
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte    7,  -30, 	   9,  -11, 	   0,  -13, 	   3,  -10
+.2byte   19,  -28, 	  14,   -9, 	   6,  -13, 	   8,  -10
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -30, 	   3,  -16, 	  -5,  -16, 	   0,  -13
+.2byte   -1,  -28, 	   5,  -12, 	  -6,  -12, 	  -1,  -13
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte  -10,  -27, 	  -1,  -15, 	  -8,   -9, 	  -2,  -12
+.2byte  -22,  -29, 	  -7,  -15, 	 -13,   -8, 	  -9,  -12
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -14,  -26, 	  -6,  -14, 	  -5,   -8, 	  -3,  -11
+.2byte  -23,  -22, 	  -8,  -12, 	  -7,   -5, 	  -5,   -9
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte   -7,  -22, 	 -10,  -11, 	   0,   -6, 	  -6,   -8
+.2byte  -17,  -14, 	 -15,   -7, 	  -5,   -2, 	 -10,   -5
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -21, 	  -6,   -7, 	   4,   -7, 	  -2,   -8
+.2byte   -1,  -12, 	  -7,   -3, 	   4,   -3, 	  -2,   -3
+.2byte   -1,    2, 	  -9,    3, 	   3,    3, 	  -2,   -1
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+.2byte    6,  -22, 	  -1,   -5, 	   7,   -9, 	   4,   -5
+.2byte   16,  -13, 	   1,    0, 	  11,   -5, 	   7,   -5
+.2byte   21,   -4, 	   2,    1, 	  10,   -2, 	   3,   -3
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte   12,  -26, 	   7,   -4, 	   6,  -10, 	   5,   -5
+.2byte   22,  -22, 	   8,   -4, 	   8,   -9, 	   9,   -6
+.2byte   32,  -10, 	  15,   -1, 	  15,   -6, 	   9,   -3
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte    7,  -30, 	   9,  -11, 	   0,  -13, 	   3,  -10
+.2byte   19,  -28, 	  14,   -9, 	   6,  -13, 	   8,  -10
+.2byte   25,  -24, 	  13,   -9, 	   5,  -15, 	   7,  -11
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -30, 	   3,  -16, 	  -5,  -16, 	   0,  -13
+.2byte   -1,  -28, 	   5,  -12, 	  -6,  -12, 	  -1,  -13
+.2byte   -1,  -26, 	   4,  -16, 	  -6,  -16, 	   0,  -14
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte  -10,  -27, 	  -1,  -15, 	  -8,   -9, 	  -2,  -12
+.2byte  -22,  -29, 	  -7,  -15, 	 -13,   -8, 	  -9,  -12
+.2byte  -24,  -21, 	  -3,  -12, 	 -10,   -5, 	  -3,   -8
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -14,  -26, 	  -6,  -14, 	  -5,   -8, 	  -3,  -11
+.2byte  -23,  -22, 	  -8,  -12, 	  -7,   -5, 	  -5,   -9
+.2byte  -32,  -11, 	 -12,   -7, 	 -11,   -1, 	  -4,   -4
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte   -7,  -22, 	 -10,  -11, 	   0,   -6, 	  -6,   -8
+.2byte  -17,  -14, 	 -15,   -7, 	  -5,   -2, 	 -10,   -5
+.2byte  -25,   -6, 	 -17,   -5, 	 -10,   -1, 	  -7,   -6
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -21, 	  -6,   -7, 	   4,   -7, 	  -2,   -8
+.2byte   -1,  -12, 	  -7,   -3, 	   4,   -3, 	  -2,   -3
+.2byte   -1,    2, 	  -9,    3, 	   3,    3, 	  -2,   -1
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+.2byte    6,  -22, 	  -1,   -5, 	   7,   -9, 	   4,   -5
+.2byte   16,  -13, 	   1,    0, 	  11,   -5, 	   7,   -5
+.2byte   21,   -4, 	   2,    1, 	  10,   -2, 	   3,   -3
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte   12,  -26, 	   7,   -4, 	   6,  -10, 	   5,   -5
+.2byte   22,  -22, 	   8,   -4, 	   8,   -9, 	   9,   -6
+.2byte   32,  -10, 	  15,   -1, 	  15,   -6, 	   9,   -3
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte    7,  -30, 	   9,  -11, 	   0,  -13, 	   3,  -10
+.2byte   19,  -28, 	  14,   -9, 	   6,  -13, 	   8,  -10
+.2byte   25,  -24, 	  13,   -9, 	   5,  -15, 	   7,  -11
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -30, 	   3,  -16, 	  -5,  -16, 	   0,  -13
+.2byte   -1,  -28, 	   5,  -12, 	  -6,  -12, 	  -1,  -13
+.2byte   -1,  -26, 	   4,  -16, 	  -6,  -16, 	   0,  -14
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte  -10,  -27, 	  -1,  -15, 	  -8,   -9, 	  -2,  -12
+.2byte  -22,  -29, 	  -7,  -15, 	 -13,   -8, 	  -9,  -12
+.2byte  -24,  -21, 	  -3,  -12, 	 -10,   -5, 	  -3,   -8
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -14,  -26, 	  -6,  -14, 	  -5,   -8, 	  -3,  -11
+.2byte  -23,  -22, 	  -8,  -12, 	  -7,   -5, 	  -5,   -9
+.2byte  -32,  -11, 	 -12,   -7, 	 -11,   -1, 	  -4,   -4
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte   -7,  -22, 	 -10,  -11, 	   0,   -6, 	  -6,   -8
+.2byte  -17,  -14, 	 -15,   -7, 	  -5,   -2, 	 -10,   -5
+.2byte  -25,   -6, 	 -17,   -5, 	 -10,   -1, 	  -7,   -6
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -21, 	  -6,   -7, 	   4,   -7, 	  -2,   -8
+.2byte   -1,  -12, 	  -7,   -3, 	   4,   -3, 	  -2,   -3
+.2byte   -1,   -7, 	  -6,    0, 	   4,    0, 	  -1,   -3
+.2byte   -2,  -44, 	  -6,  -13, 	   4,  -13, 	  -2,  -11
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+.2byte    6,  -22, 	  -1,   -5, 	   7,   -9, 	   4,   -5
+.2byte   16,  -13, 	   1,    0, 	  11,   -5, 	   7,   -5
+.2byte   19,  -10, 	   1,    2, 	   8,   -3, 	   1,   -4
+.2byte    0,  -45, 	  -2,   -9, 	   7,  -13, 	   3,   -8
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte   12,  -26, 	   7,   -4, 	   6,  -10, 	   5,   -5
+.2byte   22,  -22, 	   8,   -4, 	   8,   -9, 	   9,   -6
+.2byte   29,  -18, 	  10,    0, 	  10,   -6, 	   5,   -1
+.2byte    4,  -46, 	   8,  -11, 	   6,  -14, 	   7,   -8
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte    7,  -30, 	   9,  -11, 	   0,  -13, 	   3,  -10
+.2byte   19,  -28, 	  14,   -9, 	   6,  -13, 	   8,  -10
+.2byte   22,  -32, 	  12,  -13, 	   4,  -18, 	   6,  -15
+.2byte    1,  -45, 	   4,  -14, 	  -2,  -17, 	   1,  -13
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -30, 	   3,  -16, 	  -5,  -16, 	   0,  -13
+.2byte   -1,  -28, 	   5,  -12, 	  -6,  -12, 	  -1,  -13
+.2byte   -1,  -32, 	   4,  -16, 	  -6,  -16, 	   0,  -15
+.2byte   -1,  -45, 	   2,  -17, 	  -5,  -17, 	  -1,  -14
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte  -10,  -27, 	  -1,  -15, 	  -8,   -9, 	  -2,  -12
+.2byte  -22,  -29, 	  -7,  -15, 	 -13,   -8, 	  -9,  -12
+.2byte  -22,  -29, 	  -6,  -16, 	 -11,   -9, 	  -6,  -11
+.2byte   -6,  -45, 	  -2,  -19, 	  -8,  -11, 	  -4,  -13
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -14,  -26, 	  -6,  -14, 	  -5,   -8, 	  -3,  -11
+.2byte  -23,  -22, 	  -8,  -12, 	  -7,   -5, 	  -5,   -9
+.2byte  -31,  -20, 	  -9,  -12, 	  -5,   -4, 	  -2,   -9
+.2byte   -5,  -45, 	  -6,  -17, 	  -6,   -9, 	  -2,  -11
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte   -7,  -22, 	 -10,  -11, 	   0,   -6, 	  -6,   -8
+.2byte  -17,  -14, 	 -15,   -7, 	  -5,   -2, 	 -10,   -5
+.2byte  -23,  -10, 	 -16,   -5, 	  -8,   -1, 	  -6,   -7
+.2byte   -4,  -45, 	  -9,  -17, 	   0,  -12, 	  -6,  -12
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -21, 	  -6,   -7, 	   4,   -7, 	  -2,   -8
+.2byte   -1,  -12, 	  -7,   -3, 	   4,   -3, 	  -2,   -3
+.2byte   -2,  -43, 	  -6,  -12, 	   4,  -12, 	  -2,  -10
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+.2byte    6,  -22, 	  -1,   -5, 	   7,   -9, 	   4,   -5
+.2byte   16,  -13, 	   1,    0, 	  11,   -5, 	   7,   -5
+.2byte    0,  -43, 	  -2,   -7, 	   7,  -11, 	   3,   -6
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte   12,  -26, 	   7,   -4, 	   6,  -10, 	   5,   -5
+.2byte   22,  -22, 	   8,   -4, 	   8,   -9, 	   9,   -6
+.2byte    5,  -46, 	   9,  -11, 	   7,  -14, 	   8,   -8
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte    6,  -29, 	   8,  -10, 	  -1,  -12, 	   2,   -9
+.2byte   19,  -28, 	  14,   -9, 	   6,  -13, 	   8,  -10
+.2byte    3,  -45, 	   6,  -14, 	   0,  -17, 	   3,  -13
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -30, 	   3,  -16, 	  -5,  -16, 	   0,  -13
+.2byte   -1,  -28, 	   5,  -12, 	  -6,  -12, 	  -1,  -13
+.2byte   -1,  -45, 	   2,  -17, 	  -5,  -17, 	  -1,  -14
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte  -10,  -27, 	  -1,  -15, 	  -8,   -9, 	  -2,  -12
+.2byte  -22,  -29, 	  -7,  -15, 	 -13,   -8, 	  -9,  -12
+.2byte   -6,  -46, 	  -2,  -20, 	  -8,  -12, 	  -4,  -14
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -14,  -26, 	  -6,  -14, 	  -5,   -8, 	  -3,  -11
+.2byte  -23,  -22, 	  -8,  -12, 	  -7,   -5, 	  -5,   -9
+.2byte   -7,  -46, 	  -8,  -18, 	  -8,  -10, 	  -4,  -12
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte   -7,  -22, 	 -10,  -11, 	   0,   -6, 	  -6,   -8
+.2byte  -17,  -14, 	 -15,   -7, 	  -5,   -2, 	 -10,   -5
+.2byte   -6,  -45, 	 -11,  -17, 	  -2,  -12, 	  -8,  -12
+.2byte  -10,  -20, 	  -9,  -10, 	  -1,   -6, 	  -5,   -8
+.2byte  -10,  -19, 	  -8,   -9, 	  -1,   -6, 	  -4,   -8
+.2byte    3,  -40, 	  -6,  -14, 	   4,  -12, 	  -2,  -13
+.2byte   -4,  -41, 	  12,  -17, 	   1,  -13, 	   6,   -9
+.2byte   -4,  -40, 	   9,  -16, 	   9,  -11, 	   6,   -9
+.2byte   -3,  -38, 	   2,  -16, 	   9,  -13, 	   4,  -11
+.2byte    0,  -38, 	   4,  -13, 	  -5,  -14, 	  -1,  -13
+.2byte    2,  -38, 	  -3,  -16, 	 -10,  -13, 	  -5,  -11
+.2byte    3,  -40, 	 -10,  -16, 	 -10,  -11, 	  -7,   -9
+.2byte    3,  -41, 	 -13,  -17, 	  -2,  -13, 	  -7,   -9
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -21, 	  -6,   -7, 	   4,   -7, 	  -2,   -8
+.2byte   -1,  -12, 	  -7,   -3, 	   4,   -3, 	  -2,   -3
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+.2byte    6,  -22, 	  -1,   -5, 	   7,   -9, 	   4,   -5
+.2byte   16,  -13, 	   1,    0, 	  11,   -5, 	   7,   -5
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte   12,  -26, 	   7,   -4, 	   6,  -10, 	   5,   -5
+.2byte   22,  -22, 	   8,   -4, 	   8,   -9, 	   9,   -6
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte    7,  -30, 	   9,  -11, 	   0,  -13, 	   3,  -10
+.2byte   19,  -28, 	  14,   -9, 	   6,  -13, 	   8,  -10
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -30, 	   3,  -16, 	  -5,  -16, 	   0,  -13
+.2byte   -1,  -28, 	   5,  -12, 	  -6,  -12, 	  -1,  -13
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte  -10,  -27, 	  -1,  -15, 	  -8,   -9, 	  -2,  -12
+.2byte  -22,  -29, 	  -7,  -15, 	 -13,   -8, 	  -9,  -12
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -14,  -26, 	  -6,  -14, 	  -5,   -8, 	  -3,  -11
+.2byte  -23,  -22, 	  -8,  -12, 	  -7,   -5, 	  -5,   -9
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte   -7,  -22, 	 -10,  -11, 	   0,   -6, 	  -6,   -8
+.2byte  -17,  -14, 	 -15,   -7, 	  -5,   -2, 	 -10,   -5
+.2byte    0,  -12, 	  -6,   -3, 	   5,   -3, 	  -1,   -3
+.2byte  -16,  -14, 	 -14,   -7, 	  -4,   -2, 	  -9,   -5
+.2byte  -23,  -21, 	  -8,  -11, 	  -7,   -4, 	  -5,   -8
+.2byte  -18,  -27, 	  -3,  -13, 	  -9,   -6, 	  -5,  -10
+.2byte   -2,  -29, 	   4,  -13, 	  -7,  -13, 	  -2,  -14
+.2byte   16,  -28, 	  11,   -9, 	   3,  -13, 	   5,  -10
+.2byte   21,  -23, 	   7,   -5, 	   7,  -10, 	   8,   -7
+.2byte   16,  -14, 	   1,   -1, 	  11,   -6, 	   7,   -6
+.2byte   -1,  -43, 	  -5,  -12, 	   5,  -12, 	  -1,  -10
+.2byte    2,  -43, 	   0,   -7, 	   9,  -11, 	   5,   -6
+.2byte    2,  -46, 	   6,  -11, 	   4,  -14, 	   5,   -8
+.2byte   -1,  -45, 	   2,  -14, 	  -4,  -17, 	  -1,  -13
+.2byte   -2,  -45, 	   1,  -17, 	  -6,  -17, 	  -2,  -14
+.2byte   -6,  -46, 	  -2,  -20, 	  -8,  -12, 	  -4,  -14
+.2byte   -6,  -46, 	  -7,  -18, 	  -7,  -10, 	  -3,  -12
+.2byte   -3,  -45, 	  -8,  -17, 	   1,  -12, 	  -5,  -12
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte   -1,   -7, 	  -6,    0, 	   4,    0, 	  -1,   -3
+.2byte   -2,  -44, 	  -6,  -13, 	   4,  -13, 	  -2,  -11
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+.2byte   19,  -10, 	   1,    2, 	   8,   -3, 	   1,   -4
+.2byte    0,  -45, 	  -2,   -9, 	   7,  -13, 	   3,   -8
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte   29,  -18, 	  10,    0, 	  10,   -6, 	   5,   -1
+.2byte    4,  -46, 	   8,  -11, 	   6,  -14, 	   7,   -8
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte   22,  -32, 	  12,  -13, 	   4,  -18, 	   6,  -15
+.2byte    1,  -45, 	   4,  -14, 	  -2,  -17, 	   1,  -13
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -32, 	   4,  -16, 	  -6,  -16, 	   0,  -15
+.2byte   -1,  -45, 	   2,  -17, 	  -5,  -17, 	  -1,  -14
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte  -22,  -29, 	  -6,  -16, 	 -11,   -9, 	  -6,  -11
+.2byte   -6,  -45, 	  -2,  -19, 	  -8,  -11, 	  -4,  -13
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -31,  -20, 	  -9,  -12, 	  -5,   -4, 	  -2,   -9
+.2byte   -5,  -45, 	  -6,  -17, 	  -6,   -9, 	  -2,  -11
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte  -23,  -10, 	 -16,   -5, 	  -8,   -1, 	  -6,   -7
+.2byte   -4,  -45, 	  -9,  -17, 	   0,  -12, 	  -6,  -12
+.2byte    1,  -21, 	  -4,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -5,  -22, 	  -8,  -11, 	   2,   -6, 	  -4,   -8
+.2byte  -13,  -26, 	  -5,  -14, 	  -4,   -8, 	  -2,  -11
+.2byte  -12,  -27, 	  -3,  -15, 	 -10,   -9, 	  -4,  -12
+.2byte   -3,  -30, 	   1,  -16, 	  -7,  -16, 	  -2,  -13
+.2byte    3,  -30, 	   5,  -11, 	  -4,  -13, 	  -1,  -10
+.2byte   10,  -26, 	   5,   -4, 	   4,  -10, 	   3,   -5
+.2byte    8,  -22, 	   1,   -5, 	   9,   -9, 	   6,   -5
+.2byte   -1,  -19, 	  -8,   -6, 	   3,   -6, 	  -2,   -7
+.2byte  -10,  -21, 	 -10,  -10, 	   0,   -6, 	  -6,   -8
+.2byte  -16,  -26, 	  -6,  -13, 	  -5,   -7, 	  -4,  -10
+.2byte  -13,  -29, 	  -2,  -14, 	 -10,   -9, 	  -5,  -12
+.2byte   -1,  -34, 	   3,  -15, 	  -6,  -15, 	  -1,  -13
+.2byte    9,  -32, 	   9,  -12, 	   1,  -16, 	   5,  -10
+.2byte   14,  -26, 	   8,   -5, 	   8,  -11, 	   6,   -6
+.2byte    8,  -21, 	  -1,   -4, 	   7,   -9, 	   3,   -5
+sMiloticAnimTable1:
+.4byte sMiloticAnims_1_1
+.4byte sMiloticAnims_1_2
+.4byte sMiloticAnims_1_3
+.4byte sMiloticAnims_1_4
+.4byte sMiloticAnims_1_5
+.4byte sMiloticAnims_1_6
+.4byte sMiloticAnims_1_7
+.4byte sMiloticAnims_1_8
+sMiloticAnimTable2:
+.4byte sMiloticAnims_2_1
+.4byte sMiloticAnims_2_2
+.4byte sMiloticAnims_2_3
+.4byte sMiloticAnims_2_4
+.4byte sMiloticAnims_2_5
+.4byte sMiloticAnims_2_6
+.4byte sMiloticAnims_2_7
+.4byte sMiloticAnims_2_8
+sMiloticAnimTable3:
+.4byte sMiloticAnims_3_1
+.4byte sMiloticAnims_3_2
+.4byte sMiloticAnims_3_3
+.4byte sMiloticAnims_3_4
+.4byte sMiloticAnims_3_5
+.4byte sMiloticAnims_3_6
+.4byte sMiloticAnims_3_7
+.4byte sMiloticAnims_3_8
+sMiloticAnimTable4:
+.4byte sMiloticAnims_4_1
+.4byte sMiloticAnims_4_2
+.4byte sMiloticAnims_4_3
+.4byte sMiloticAnims_4_4
+.4byte sMiloticAnims_4_5
+.4byte sMiloticAnims_4_6
+.4byte sMiloticAnims_4_7
+.4byte sMiloticAnims_4_8
+sMiloticAnimTable5:
+.4byte sMiloticAnims_5_1
+.4byte sMiloticAnims_5_2
+.4byte sMiloticAnims_5_3
+.4byte sMiloticAnims_5_4
+.4byte sMiloticAnims_5_5
+.4byte sMiloticAnims_5_6
+.4byte sMiloticAnims_5_7
+.4byte sMiloticAnims_5_8
+sMiloticAnimTable6:
+.4byte sMiloticAnims_6_1
+.4byte sMiloticAnims_6_1
+.4byte sMiloticAnims_6_1
+.4byte sMiloticAnims_6_1
+.4byte sMiloticAnims_6_1
+.4byte sMiloticAnims_6_1
+.4byte sMiloticAnims_6_1
+.4byte sMiloticAnims_6_1
+sMiloticAnimTable7:
+.4byte sMiloticAnims_7_1
+.4byte sMiloticAnims_7_2
+.4byte sMiloticAnims_7_3
+.4byte sMiloticAnims_7_4
+.4byte sMiloticAnims_7_5
+.4byte sMiloticAnims_7_6
+.4byte sMiloticAnims_7_7
+.4byte sMiloticAnims_7_8
+sMiloticAnimTable8:
+.4byte sMiloticAnims_8_1
+.4byte sMiloticAnims_8_2
+.4byte sMiloticAnims_8_3
+.4byte sMiloticAnims_8_4
+.4byte sMiloticAnims_8_5
+.4byte sMiloticAnims_8_6
+.4byte sMiloticAnims_8_7
+.4byte sMiloticAnims_8_8
+sMiloticAnimTable9:
+.4byte sMiloticAnims_9_1
+.4byte sMiloticAnims_9_2
+.4byte sMiloticAnims_9_3
+.4byte sMiloticAnims_9_4
+.4byte sMiloticAnims_9_5
+.4byte sMiloticAnims_9_6
+.4byte sMiloticAnims_9_7
+.4byte sMiloticAnims_9_8
+sMiloticAnimTable10:
+.4byte sMiloticAnims_10_1
+.4byte sMiloticAnims_10_2
+.4byte sMiloticAnims_10_3
+.4byte sMiloticAnims_10_4
+.4byte sMiloticAnims_10_5
+.4byte sMiloticAnims_10_6
+.4byte sMiloticAnims_10_7
+.4byte sMiloticAnims_10_8
+sMiloticAnimTable11:
+.4byte sMiloticAnims_11_1
+.4byte sMiloticAnims_11_2
+.4byte sMiloticAnims_11_3
+.4byte sMiloticAnims_11_4
+.4byte sMiloticAnims_11_5
+.4byte sMiloticAnims_11_6
+.4byte sMiloticAnims_11_7
+.4byte sMiloticAnims_11_8
+sMiloticAnimTable12:
+.4byte sMiloticAnims_12_1
+.4byte sMiloticAnims_12_2
+.4byte sMiloticAnims_12_3
+.4byte sMiloticAnims_12_4
+.4byte sMiloticAnims_12_5
+.4byte sMiloticAnims_12_6
+.4byte sMiloticAnims_12_7
+.4byte sMiloticAnims_12_8
+sMiloticAnimTable13:
+.4byte sMiloticAnims_13_1
+.4byte sMiloticAnims_13_2
+.4byte sMiloticAnims_13_3
+.4byte sMiloticAnims_13_4
+.4byte sMiloticAnims_13_5
+.4byte sMiloticAnims_13_6
+.4byte sMiloticAnims_13_7
+.4byte sMiloticAnims_13_8
+sAxAnimationsMilotic:
+.4byte sMiloticAnimTable1
+.4byte sMiloticAnimTable2
+.4byte sMiloticAnimTable3
+.4byte sMiloticAnimTable4
+.4byte sMiloticAnimTable5
+.4byte sMiloticAnimTable6
+.4byte sMiloticAnimTable7
+.4byte sMiloticAnimTable8
+.4byte sMiloticAnimTable9
+.4byte sMiloticAnimTable10
+.4byte sMiloticAnimTable11
+.4byte sMiloticAnimTable12
+.4byte sMiloticAnimTable13
+sAxSpritesMilotic:
+.4byte sMiloticSprites1
+.4byte sMiloticSprites2
+.4byte sMiloticSprites3
+.4byte sMiloticSprites4
+.4byte sMiloticSprites5
+.4byte sMiloticSprites6
+.4byte sMiloticSprites7
+.4byte sMiloticSprites8
+.4byte sMiloticSprites9
+.4byte sMiloticSprites10
+.4byte sMiloticSprites11
+.4byte sMiloticSprites12
+.4byte sMiloticSprites13
+.4byte sMiloticSprites14
+.4byte sMiloticSprites15
+.4byte sMiloticSprites16
+.4byte sMiloticSprites17
+.4byte sMiloticSprites18
+.4byte sMiloticSprites19
+.4byte sMiloticSprites20
+.4byte sMiloticSprites21
+.4byte sMiloticSprites22
+.4byte sMiloticSprites23
+.4byte sMiloticSprites24
+.4byte sMiloticSprites25
+.4byte sMiloticSprites26
+.4byte sMiloticSprites27
+.4byte sMiloticSprites28
+.4byte sMiloticSprites29
+.4byte sMiloticSprites30
+.4byte sMiloticSprites31
+.4byte sMiloticSprites32
+.4byte sMiloticSprites33
+.4byte sMiloticSprites34
+.4byte sMiloticSprites35
+.4byte sMiloticSprites36
+.4byte sMiloticSprites37
+.4byte sMiloticSprites38
+.4byte sMiloticSprites39
+.4byte sMiloticSprites40
+.4byte sMiloticSprites41
+.4byte sMiloticSprites42
+.4byte sMiloticSprites43
+.4byte sMiloticSprites44
+.4byte sMiloticSprites45
+.4byte sMiloticSprites46
+.4byte sMiloticSprites47
+.4byte sMiloticSprites48
+.4byte sMiloticSprites49
+.4byte sMiloticSprites50
+.4byte sMiloticSprites51
+.4byte sMiloticSprites52
+.4byte sMiloticSprites53
+.4byte sMiloticSprites54
+.4byte sMiloticSprites55
+.4byte sMiloticSprites56
+.4byte sMiloticSprites57
+.4byte sMiloticSprites58
+.4byte sMiloticSprites59
+.4byte sMiloticSprites60
+.4byte sMiloticSprites61
+.4byte sMiloticSprites62
+.4byte sMiloticSprites63
+.4byte sMiloticSprites64
+.4byte sMiloticSprites65
+.4byte sMiloticSprites66
+.4byte sMiloticSprites67
+.4byte sMiloticSprites68
+.4byte sMiloticSprites69
+.4byte sMiloticSprites70
+.4byte sMiloticSprites71
+.4byte sMiloticSprites72
+.4byte sMiloticSprites73
+.4byte sMiloticSprites74
+.4byte sMiloticSprites75
+.4byte sMiloticSprites76
+.4byte sMiloticSprites77
+.4byte sMiloticSprites78
+.4byte sMiloticSprites79
+.4byte sMiloticSprites80
+.4byte sMiloticSprites81
+.4byte sMiloticSprites82
+.4byte sMiloticSprites83
+.4byte sMiloticSprites84
+.4byte sMiloticSprites85
+.4byte sMiloticSprites86
+.4byte sMiloticSprites87
+.4byte sMiloticSprites88
+.4byte sMiloticSprites89
+.4byte sMiloticSprites90
+.4byte sMiloticSprites91
+.4byte sMiloticSprites92
+sAxMainMilotic:
+ax_main sAxPosesMilotic, sAxAnimationsMilotic, 13, sAxSpritesMilotic, sAxPositionsMilotic

--- a/data/ax/miltank.inc
+++ b/data/ax/miltank.inc
@@ -1,0 +1,2827 @@
+.global gAxMiltank
+gAxMiltank:
+ax_siro sAxMainMiltank
+sMiltankPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose4:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose5:
+ax_pose 4, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose6:
+ax_pose 5, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose7:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose8:
+ax_pose 7, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose9:
+ax_pose 8, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose10:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose11:
+ax_pose 10, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose12:
+ax_pose 11, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose17:
+ax_pose 10, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose19:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose20:
+ax_pose 7, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose21:
+ax_pose 8, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose23:
+ax_pose 4, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose24:
+ax_pose 5, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose26:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose27:
+ax_pose 2, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose28:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose29:
+ax_pose 4, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose30:
+ax_pose 5, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose31:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose32:
+ax_pose 7, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose33:
+ax_pose 8, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose34:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose35:
+ax_pose 10, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose36:
+ax_pose 11, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose37:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose38:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose39:
+ax_pose 14, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose40:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose41:
+ax_pose 10, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose42:
+ax_pose 11, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose43:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose44:
+ax_pose 7, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose45:
+ax_pose 8, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose46:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose47:
+ax_pose 4, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose48:
+ax_pose 5, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose49:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose50:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose51:
+ax_pose 2, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose52:
+ax_pose 15, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose53:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose54:
+ax_pose 4, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose55:
+ax_pose 5, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose56:
+ax_pose 16, 0x01e8, 0x90ee, 0xbc00
+ax_pose_terminator
+sMiltankPose57:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose58:
+ax_pose 7, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose59:
+ax_pose 8, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose60:
+ax_pose 17, 0x01e7, 0x90ee, 0xbc00
+ax_pose_terminator
+sMiltankPose61:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose62:
+ax_pose 10, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose63:
+ax_pose 11, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose64:
+ax_pose 18, 0x01e7, 0x90ee, 0xbc00
+ax_pose_terminator
+sMiltankPose65:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose66:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose67:
+ax_pose 14, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose68:
+ax_pose 19, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose69:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose70:
+ax_pose 10, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose71:
+ax_pose 11, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose72:
+ax_pose 18, 0x01e7, 0x80f1, 0xbc00
+ax_pose_terminator
+sMiltankPose73:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose74:
+ax_pose 7, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose75:
+ax_pose 8, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose76:
+ax_pose 17, 0x01e7, 0x80f1, 0xbc00
+ax_pose_terminator
+sMiltankPose77:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose78:
+ax_pose 4, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose79:
+ax_pose 5, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose80:
+ax_pose 16, 0x01e8, 0x80f1, 0xbc00
+ax_pose_terminator
+sMiltankPose81:
+ax_pose 20, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose82:
+ax_pose 21, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose83:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose84:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose85:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose86:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose87:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose88:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose89:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose90:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose91:
+ax_pose 22, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose92:
+ax_pose 23, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMiltankPose93:
+ax_pose 24, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose94:
+ax_pose 25, 0x01e5, 0x90ed, 0xbc00
+ax_pose_terminator
+sMiltankPose95:
+ax_pose 26, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose96:
+ax_pose 27, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose97:
+ax_pose 28, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose98:
+ax_pose 29, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose99:
+ax_pose 26, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose100:
+ax_pose 27, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose101:
+ax_pose 24, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose102:
+ax_pose 25, 0x01e5, 0x80f2, 0xbc00
+ax_pose_terminator
+sMiltankPose103:
+ax_pose 22, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose104:
+ax_pose 23, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose105:
+ax_pose 20, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose106:
+ax_pose 21, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose107:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose108:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose109:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose110:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose111:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose112:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose113:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose114:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose115:
+ax_pose 22, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose116:
+ax_pose 23, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMiltankPose117:
+ax_pose 24, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose118:
+ax_pose 25, 0x01e5, 0x90ed, 0xbc00
+ax_pose_terminator
+sMiltankPose119:
+ax_pose 26, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose120:
+ax_pose 27, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose121:
+ax_pose 28, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose122:
+ax_pose 29, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose123:
+ax_pose 29, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMiltankPose124:
+ax_pose 26, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose125:
+ax_pose 27, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose126:
+ax_pose 24, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose127:
+ax_pose 25, 0x01e5, 0x80f2, 0xbc00
+ax_pose_terminator
+sMiltankPose128:
+ax_pose 22, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose129:
+ax_pose 23, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose130:
+ax_pose 30, 0x01e7, 0x80f2, 0xbc00
+ax_pose_terminator
+sMiltankPose131:
+ax_pose 31, 0x01e7, 0x80f2, 0xbc00
+ax_pose_terminator
+sMiltankPose132:
+ax_pose 32, 0x01e2, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose133:
+ax_pose 33, 0x01e2, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose134:
+ax_pose 34, 0x01e1, 0x90e9, 0xbc00
+ax_pose_terminator
+sMiltankPose135:
+ax_pose 35, 0x01e4, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose136:
+ax_pose 36, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose137:
+ax_pose 35, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose138:
+ax_pose 34, 0x01e1, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose139:
+ax_pose 33, 0x01e2, 0x80f7, 0xbc00
+ax_pose_terminator
+sMiltankPose140:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose141:
+ax_pose 20, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose142:
+ax_pose 21, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose143:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose144:
+ax_pose 22, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMiltankPose145:
+ax_pose 23, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMiltankPose146:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose147:
+ax_pose 24, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose148:
+ax_pose 25, 0x01e5, 0x90ed, 0xbc00
+ax_pose_terminator
+sMiltankPose149:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose150:
+ax_pose 26, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose151:
+ax_pose 27, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose152:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose153:
+ax_pose 28, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose154:
+ax_pose 29, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose155:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose156:
+ax_pose 26, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose157:
+ax_pose 27, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose158:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose159:
+ax_pose 24, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose160:
+ax_pose 25, 0x01e5, 0x80f2, 0xbc00
+ax_pose_terminator
+sMiltankPose161:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose162:
+ax_pose 22, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose163:
+ax_pose 23, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose164:
+ax_pose 0, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose165:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose166:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose167:
+ax_pose 9, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose168:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose169:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose170:
+ax_pose 6, 0x01e5, 0x90e8, 0xbc00
+ax_pose_terminator
+sMiltankPose171:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose172:
+ax_pose 21, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose173:
+ax_pose 23, 0x01e5, 0x90ec, 0xbc00
+ax_pose_terminator
+sMiltankPose174:
+ax_pose 25, 0x01e5, 0x90ee, 0xbc00
+ax_pose_terminator
+sMiltankPose175:
+ax_pose 27, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose176:
+ax_pose 29, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose177:
+ax_pose 27, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose178:
+ax_pose 25, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sMiltankPose179:
+ax_pose 23, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose180:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose181:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose182:
+ax_pose 2, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose183:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose184:
+ax_pose 4, 0x01e5, 0x90ea, 0xbc00
+ax_pose_terminator
+sMiltankPose185:
+ax_pose 5, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose186:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose187:
+ax_pose 7, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose188:
+ax_pose 8, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose189:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose190:
+ax_pose 10, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose191:
+ax_pose 11, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose192:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose193:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose194:
+ax_pose 14, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose195:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose196:
+ax_pose 10, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose197:
+ax_pose 11, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose198:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose199:
+ax_pose 7, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose200:
+ax_pose 8, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose201:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose202:
+ax_pose 4, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose203:
+ax_pose 5, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose204:
+ax_pose 20, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose205:
+ax_pose 22, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose206:
+ax_pose 24, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose207:
+ax_pose 26, 0x01e5, 0x80f6, 0xbc00
+ax_pose_terminator
+sMiltankPose208:
+ax_pose 28, 0x01e5, 0x80f5, 0xbc00
+ax_pose_terminator
+sMiltankPose209:
+ax_pose 26, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose210:
+ax_pose 24, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose211:
+ax_pose 22, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose212:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose213:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose214:
+ax_pose 6, 0x01e5, 0x80f8, 0xbc00
+ax_pose_terminator
+sMiltankPose215:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose216:
+ax_pose 12, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sMiltankPose217:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sMiltankPose218:
+ax_pose 6, 0x01e5, 0x90e7, 0xbc00
+ax_pose_terminator
+sMiltankPose219:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+.align 2
+sMiltankAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 4, 0, 25, 0, -5, 0, -5,
+ax_anim 3, 0, 24, 0, -5, 0, -5,
+ax_anim 2, 0, 26, 0, -5, 0, -5,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMiltankAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, -3, -3, -3, -3,
+ax_anim 4, 0, 28, -5, -5, -5, -5,
+ax_anim 3, 0, 27, -5, -5, -5, -5,
+ax_anim 2, 0, 29, -5, -5, -5, -5,
+ax_anim 2, 0, 27, -4, -4, -4, -4,
+ax_anim 2, 0, 28, -4, -4, -4, -4,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 1, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 20, 20, 20, 20,
+ax_anim 2, 0, 28, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sMiltankAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 4, 0, 31, -5, 0, -5, 0,
+ax_anim 3, 0, 30, -5, 0, -5, 0,
+ax_anim 2, 0, 32, -5, 0, -5, 0,
+ax_anim 2, 0, 30, -4, 0, -4, 0,
+ax_anim 2, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 1, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 0, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sMiltankAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 33, -3, 3, -3, 3,
+ax_anim 4, 0, 34, -5, 5, -5, 5,
+ax_anim 3, 0, 33, -5, 5, -5, 5,
+ax_anim 2, 0, 35, -5, 5, -5, 5,
+ax_anim 2, 0, 33, -4, 4, -4, 4,
+ax_anim 2, 0, 34, -4, 4, -4, 4,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -11, 10, -11,
+ax_anim 2, 0, 34, 19, -19, 19, -19,
+ax_anim 2, 1, 34, 20, -18, 20, -18,
+ax_anim 2, 0, 34, 19, -19, 19, -19,
+ax_anim 2, 0, 34, 20, -18, 20, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMiltankAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 3, 0, 3,
+ax_anim 4, 0, 37, 0, 5, 0, 5,
+ax_anim 3, 0, 36, 0, 5, 0, 5,
+ax_anim 2, 0, 38, 0, 5, 0, 5,
+ax_anim 2, 0, 36, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 4, 0, 4,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 1, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 0, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMiltankAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 3, 3, 3, 3,
+ax_anim 4, 0, 40, 5, 5, 5, 5,
+ax_anim 3, 0, 39, 5, 5, 5, 5,
+ax_anim 2, 0, 41, 5, 5, 5, 5,
+ax_anim 2, 0, 39, 4, 4, 4, 4,
+ax_anim 2, 0, 40, 4, 4, 4, 4,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -11, -10, -11,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 1, 40, -20, -18, -20, -18,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -20, -18, -20, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMiltankAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 4, 0, 43, 5, 0, 5, 0,
+ax_anim 3, 0, 42, 5, 0, 5, 0,
+ax_anim 2, 0, 44, 5, 0, 5, 0,
+ax_anim 2, 0, 42, 4, 0, 4, 0,
+ax_anim 2, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 1, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 0, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sMiltankAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 45, 3, -3, 3, -3,
+ax_anim 4, 0, 46, 5, -5, 5, -5,
+ax_anim 3, 0, 45, 5, -5, 5, -5,
+ax_anim 2, 0, 47, 5, -5, 5, -5,
+ax_anim 2, 0, 45, 4, -4, 4, -4,
+ax_anim 2, 0, 46, 4, -4, 4, -4,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -20, 20, -20, 20,
+ax_anim 2, 1, 46, -21, 19, -21, 19,
+ax_anim 2, 0, 46, -20, 20, -20, 20,
+ax_anim 2, 0, 46, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMiltankAnims_3_1:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 2, 0, 2,
+ax_anim 2, 0, 50, 0, 6, 0, 6,
+ax_anim 1, 2, 51, 0, 15, 0, 14,
+ax_anim 1, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 1, 51, 0, 18, 0, 18,
+ax_anim 2, 0, 51, 1, 18, 1, 18,
+ax_anim 2, 0, 51, 0, 18, 0, 18,
+ax_anim 2, 0, 51, 1, 18, 1, 18,
+ax_anim 2, 0, 51, 0, 18, 0, 18,
+ax_anim 2, 0, 48, 0, 11, 0, 11,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sMiltankAnims_3_2:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim 2, 0, 54, 6, 6, 6, 6,
+ax_anim 1, 2, 55, 15, 15, 14, 14,
+ax_anim 1, 0, 55, 17, 17, 17, 17,
+ax_anim 2, 1, 55, 18, 18, 18, 18,
+ax_anim 2, 0, 55, 19, 18, 19, 18,
+ax_anim 2, 0, 55, 18, 18, 18, 18,
+ax_anim 2, 0, 55, 19, 18, 19, 18,
+ax_anim 2, 0, 55, 18, 18, 18, 18,
+ax_anim 2, 0, 53, 12, 12, 12, 12,
+ax_anim 2, 0, 54, 4, 4, 4, 4,
+ax_anim_terminator
+sMiltankAnims_3_3:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim 2, 0, 58, 6, 0, 6, 0,
+ax_anim 1, 2, 59, 15, 0, 14, 0,
+ax_anim 1, 0, 59, 17, 0, 17, 0,
+ax_anim 2, 1, 59, 18, 0, 18, 0,
+ax_anim 2, 0, 59, 19, 0, 19, 0,
+ax_anim 2, 0, 59, 18, 0, 18, 0,
+ax_anim 2, 0, 59, 19, 0, 19, 0,
+ax_anim 2, 0, 59, 18, 0, 18, 0,
+ax_anim 2, 0, 57, 12, 0, 12, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim_terminator
+sMiltankAnims_3_4:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 2, -2, 2, -2,
+ax_anim 2, 0, 62, 6, -6, 6, -6,
+ax_anim 1, 2, 63, 15, -15, 14, -14,
+ax_anim 1, 0, 63, 17, -17, 17, -17,
+ax_anim 2, 1, 63, 18, -18, 18, -18,
+ax_anim 2, 0, 63, 19, -18, 19, -18,
+ax_anim 2, 0, 63, 18, -18, 18, -18,
+ax_anim 2, 0, 63, 19, -18, 19, -18,
+ax_anim 2, 0, 63, 18, -18, 18, -18,
+ax_anim 2, 0, 61, 12, -12, 12, -12,
+ax_anim 2, 0, 62, 4, -4, 4, -4,
+ax_anim_terminator
+sMiltankAnims_3_5:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 66, 0, -6, 0, -6,
+ax_anim 1, 2, 67, 0, -15, 0, -14,
+ax_anim 1, 0, 67, 0, -17, 0, -17,
+ax_anim 2, 1, 67, 0, -18, 0, -18,
+ax_anim 2, 0, 67, 1, -18, 1, -18,
+ax_anim 2, 0, 67, 0, -18, 0, -18,
+ax_anim 2, 0, 67, 1, -18, 1, -18,
+ax_anim 2, 0, 67, 0, -18, 0, -18,
+ax_anim 2, 0, 64, 0, -11, 0, -11,
+ax_anim 2, 0, 64, 0, -4, 0, -4,
+ax_anim_terminator
+sMiltankAnims_3_6:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim 2, 0, 70, -6, -6, -6, -6,
+ax_anim 1, 2, 71, -15, -15, -14, -14,
+ax_anim 1, 0, 71, -17, -17, -17, -17,
+ax_anim 2, 1, 71, -18, -18, -18, -18,
+ax_anim 2, 0, 71, -19, -18, -19, -18,
+ax_anim 2, 0, 71, -18, -18, -18, -18,
+ax_anim 2, 0, 71, -19, -18, -19, -18,
+ax_anim 2, 0, 71, -18, -18, -18, -18,
+ax_anim 2, 0, 69, -12, -12, -12, -12,
+ax_anim 2, 0, 70, -4, -4, -4, -4,
+ax_anim_terminator
+sMiltankAnims_3_7:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -6, 0, -6, 0,
+ax_anim 1, 2, 75, -15, 0, -14, 0,
+ax_anim 1, 0, 75, -17, 0, -17, 0,
+ax_anim 2, 1, 75, -18, 0, -18, 0,
+ax_anim 2, 0, 75, -19, 0, -19, 0,
+ax_anim 2, 0, 75, -18, 0, -18, 0,
+ax_anim 2, 0, 75, -19, 0, -19, 0,
+ax_anim 2, 0, 75, -18, 0, -18, 0,
+ax_anim 2, 0, 73, -12, 0, -12, 0,
+ax_anim 2, 0, 74, -4, 0, -4, 0,
+ax_anim_terminator
+sMiltankAnims_3_8:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim 2, 0, 78, -6, 6, -6, 6,
+ax_anim 1, 2, 79, -15, 15, -14, 14,
+ax_anim 1, 0, 79, -17, 17, -17, 17,
+ax_anim 2, 1, 79, -18, 18, -18, 18,
+ax_anim 2, 0, 79, -19, 18, -19, 18,
+ax_anim 2, 0, 79, -18, 18, -18, 18,
+ax_anim 2, 0, 79, -19, 18, -19, 18,
+ax_anim 2, 0, 79, -18, 18, -18, 18,
+ax_anim 2, 0, 77, -12, 12, -12, 12,
+ax_anim 2, 0, 78, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMiltankAnims_4_1:
+ax_anim 8, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, -2, 0, 0,
+ax_anim 1, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, 0,
+ax_anim 2, 0, 86, 0, -7, 0, 0,
+ax_anim 2, 0, 87, 0, -7, 0, 0,
+ax_anim 2, 2, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_4_2:
+ax_anim 8, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -2, 0, 0,
+ax_anim 1, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -6, 0, 0,
+ax_anim 2, 0, 85, 0, -7, 0, 0,
+ax_anim 2, 0, 84, 0, -7, 0, 0,
+ax_anim 2, 2, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_4_3:
+ax_anim 8, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 1, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, 0,
+ax_anim 2, 0, 84, 0, -7, 0, 0,
+ax_anim 2, 0, 83, 0, -7, 0, 0,
+ax_anim 2, 2, 82, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 4, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_4_4:
+ax_anim 8, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, -2, 0, 0,
+ax_anim 1, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -6, 0, 0,
+ax_anim 2, 0, 83, 0, -7, 0, 0,
+ax_anim 2, 0, 82, 0, -7, 0, 0,
+ax_anim 2, 2, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_4_5:
+ax_anim 8, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 1, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 82, 0, -7, 0, 0,
+ax_anim 2, 0, 83, 0, -7, 0, 0,
+ax_anim 2, 2, 84, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_4_6:
+ax_anim 8, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, -2, 0, 0,
+ax_anim 1, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -7, 0, 0,
+ax_anim 2, 0, 82, 0, -7, 0, 0,
+ax_anim 2, 2, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_4_7:
+ax_anim 8, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, -2, 0, 0,
+ax_anim 1, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -6, 0, 0,
+ax_anim 2, 0, 88, 0, -7, 0, 0,
+ax_anim 2, 0, 89, 0, -7, 0, 0,
+ax_anim 2, 2, 82, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 0, -2, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_4_8:
+ax_anim 8, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 1, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -6, 0, 0,
+ax_anim 2, 0, 87, 0, -7, 0, 0,
+ax_anim 2, 0, 88, 0, -7, 0, 0,
+ax_anim 2, 2, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_5_1:
+ax_anim 5, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 2, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_5_2:
+ax_anim 5, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 2, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_5_3:
+ax_anim 5, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 2, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, -1, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_5_4:
+ax_anim 5, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 2, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 122, -1, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_5_5:
+ax_anim 5, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 2, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 1, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 1, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_5_6:
+ax_anim 5, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 2, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 1, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 1, 1, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_5_7:
+ax_anim 5, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 2, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 1, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_5_8:
+ax_anim 5, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 2, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 1, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_6_1:
+ax_anim 30, 0, 129, 0, 0, 0, 0,
+ax_anim 35, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_7_1:
+ax_anim 2, 0, 131, 0, -2, 0, -2,
+ax_anim 8, 0, 131, 0, -3, 0, -3,
+ax_anim_terminator
+sMiltankAnims_7_2:
+ax_anim 2, 0, 132, -2, -2, -2, -2,
+ax_anim 8, 0, 132, -3, -3, -3, -3,
+ax_anim_terminator
+sMiltankAnims_7_3:
+ax_anim 2, 0, 133, -2, 0, -2, 0,
+ax_anim 8, 0, 133, -3, 0, -3, 0,
+ax_anim_terminator
+sMiltankAnims_7_4:
+ax_anim 2, 0, 134, -2, 2, -2, 2,
+ax_anim 8, 0, 134, -3, 3, -3, 3,
+ax_anim_terminator
+sMiltankAnims_7_5:
+ax_anim 2, 0, 135, 0, 2, 0, 2,
+ax_anim 8, 0, 135, 0, 3, 0, 3,
+ax_anim_terminator
+sMiltankAnims_7_6:
+ax_anim 2, 0, 136, 2, 2, 2, 2,
+ax_anim 8, 0, 136, 3, 3, 3, 3,
+ax_anim_terminator
+sMiltankAnims_7_7:
+ax_anim 2, 0, 137, 2, 0, 2, 0,
+ax_anim 8, 0, 137, 3, 0, 3, 0,
+ax_anim_terminator
+sMiltankAnims_7_8:
+ax_anim 2, 0, 138, 2, -2, 2, -2,
+ax_anim 8, 0, 138, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMiltankAnims_8_1:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, -2, 0, 0,
+ax_anim 5, 0, 141, 0, -3, 0, 0,
+ax_anim 3, 0, 141, 0, -2, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_8_2:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, -2, 0, 0,
+ax_anim 5, 0, 144, 0, -3, 0, 0,
+ax_anim 3, 0, 144, 0, -2, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_8_3:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 5, 0, 147, 0, -4, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_8_4:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, -3, 0, 0,
+ax_anim 5, 0, 150, 0, -4, 0, 0,
+ax_anim 3, 0, 150, 0, -3, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_8_5:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, -2, 0, 0,
+ax_anim 5, 0, 153, 0, -3, 0, 0,
+ax_anim 3, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_8_6:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 5, 0, 156, 0, -4, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_8_7:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 159, 0, -3, 0, 0,
+ax_anim 5, 0, 159, 0, -4, 0, 0,
+ax_anim 3, 0, 159, 0, -3, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_8_8:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, -2, 0, 0,
+ax_anim 5, 0, 162, 0, -3, 0, 0,
+ax_anim 3, 0, 162, 0, -2, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_9_1:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 6, 3, 6, 3,
+ax_anim 2, 0, 165, 10, 9, 10, 9,
+ax_anim 2, 0, 166, 7, 19, 7, 19,
+ax_anim 3, 0, 167, 0, 20, 0, 20,
+ax_anim 2, 3, 168, -7, 19, -7, 19,
+ax_anim 2, 0, 169, -9, 9, -9, 9,
+ax_anim 1, 0, 170, -6, 3, -6, 3,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_9_2:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 12, 1, 12, 1,
+ax_anim 2, 0, 164, 22, 7, 22, 7,
+ax_anim 2, 0, 165, 24, 14, 24, 14,
+ax_anim 3, 0, 166, 22, 20, 22, 20,
+ax_anim 2, 3, 167, 14, 20, 14, 20,
+ax_anim 2, 0, 168, 4, 17, 4, 17,
+ax_anim 1, 0, 169, 0, 7, 0, 7,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_9_3:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 4, -5, 4, -5,
+ax_anim 2, 0, 163, 12, -8, 12, -8,
+ax_anim 2, 0, 164, 20, -6, 20, -6,
+ax_anim 3, 0, 165, 23, -2, 23, -2,
+ax_anim 2, 3, 166, 20, 4, 20, 4,
+ax_anim 2, 0, 167, 12, 6, 12, 6,
+ax_anim 1, 0, 168, 4, 5, 4, 5,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_9_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 2, -10, 2, -10,
+ax_anim 2, 0, 170, 6, -16, 6, -16,
+ax_anim 2, 0, 163, 12, -21, 12, -21,
+ax_anim 3, 0, 164, 19, -20, 19, -20,
+ax_anim 2, 3, 165, 21, -13, 21, -13,
+ax_anim 2, 0, 166, 18, -6, 18, -6,
+ax_anim 1, 0, 167, 7, -1, 7, -1,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_9_5:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -8, -4, -8, -4,
+ax_anim 2, 0, 169, -12, -13, -12, -13,
+ax_anim 2, 0, 170, -8, -17, -8, -17,
+ax_anim 3, 0, 163, 0, -20, 0, -20,
+ax_anim 2, 3, 164, 8, -17, 8, -17,
+ax_anim 2, 0, 165, 12, -11, 12, -11,
+ax_anim 1, 0, 166, 8, -4, 8, -4,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_9_6:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 165, -2, -10, -2, -10,
+ax_anim 2, 0, 164, -6, -16, -6, -16,
+ax_anim 2, 0, 163, -12, -21, -12, -20,
+ax_anim 3, 0, 170, -19, -20, -18, -18,
+ax_anim 2, 3, 169, -21, -13, -21, -13,
+ax_anim 2, 0, 168, -18, -6, -18, -6,
+ax_anim 1, 0, 167, -7, -1, -7, -1,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_9_7:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, -4, -5, -4, -5,
+ax_anim 2, 0, 163, -12, -8, -10, -8,
+ax_anim 2, 0, 170, -20, -6, -16, -5,
+ax_anim 3, 0, 169, -23, -2, -23, -2,
+ax_anim 2, 3, 168, -20, 4, -20, 4,
+ax_anim 2, 0, 167, -12, 6, -12, 6,
+ax_anim 1, 0, 166, -4, 5, -4, 5,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_9_8:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -12, 0, -12, 0,
+ax_anim 2, 0, 170, -22, 7, -22, 7,
+ax_anim 2, 0, 169, -24, 14, -24, 14,
+ax_anim 3, 0, 168, -22, 20, -22, 20,
+ax_anim 2, 3, 167, -14, 20, -14, 20,
+ax_anim 2, 0, 166, -4, 17, -4, 17,
+ax_anim 1, 0, 165, 0, 7, 0, 7,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_10_1:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, 0, 6, 0,
+ax_anim 2, 0, 171, -6, 0, -6, 0,
+ax_anim 2, 0, 171, 10, 0, 10, 0,
+ax_anim 2, 0, 171, -10, 0, -10, 0,
+ax_anim 2, 0, 171, 12, 0, 12, 0,
+ax_anim 3, 0, 171, -12, 0, -12, 0,
+ax_anim 3, 0, 171, 13, 0, 13, 0,
+ax_anim 3, 0, 171, -13, 0, -13, 0,
+ax_anim 2, 0, 171, 12, 0, 12, 0,
+ax_anim 3, 0, 171, -12, 0, -12, 0,
+ax_anim 2, 0, 171, 10, 0, 10, 0,
+ax_anim 2, 0, 171, -10, 0, -10, 0,
+ax_anim 2, 0, 171, 6, 0, 6, 0,
+ax_anim 2, 0, 171, -6, 0, -6, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_10_2:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 6, -6, 6, -6,
+ax_anim 2, 0, 172, -6, 6, -6, 6,
+ax_anim 2, 0, 172, 10, -10, 10, -10,
+ax_anim 2, 0, 172, -10, 10, -10, 10,
+ax_anim 2, 0, 172, 12, -12, 12, -12,
+ax_anim 3, 0, 172, -12, 12, -12, 12,
+ax_anim 3, 0, 172, 13, -13, 13, -13,
+ax_anim 3, 0, 172, -13, 13, -13, 13,
+ax_anim 2, 0, 172, 12, -12, 12, -12,
+ax_anim 3, 0, 172, -12, 12, -12, 12,
+ax_anim 2, 0, 172, 10, -10, 10, -10,
+ax_anim 2, 0, 172, -10, 10, -10, 10,
+ax_anim 2, 0, 172, 6, -6, 6, -6,
+ax_anim 2, 0, 172, -6, 6, -6, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_10_3:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 3, 0, 173, 0, -13, 0, -13,
+ax_anim 3, 0, 173, 0, 13, 0, 13,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_10_4:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, -6, -6, -6, -6,
+ax_anim 2, 0, 174, 6, 6, 6, 6,
+ax_anim 2, 0, 174, -10, -10, -10, -10,
+ax_anim 2, 0, 174, 10, 10, 10, 10,
+ax_anim 2, 0, 174, -12, -12, -12, -12,
+ax_anim 3, 0, 174, 12, 12, 12, 12,
+ax_anim 3, 0, 174, -13, -13, -13, -13,
+ax_anim 3, 0, 174, 13, 13, 13, 13,
+ax_anim 2, 0, 174, -12, -12, -12, -12,
+ax_anim 3, 0, 174, 12, 12, 12, 12,
+ax_anim 2, 0, 174, -10, -10, -10, -10,
+ax_anim 2, 0, 174, 10, 10, 10, 10,
+ax_anim 2, 0, 174, -6, -6, -6, -6,
+ax_anim 2, 0, 174, 6, 6, 6, 6,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_10_5:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, 0, 6, 0,
+ax_anim 2, 0, 175, -6, 0, -6, 0,
+ax_anim 2, 0, 175, 10, 0, 10, 0,
+ax_anim 2, 0, 175, -10, 0, -10, 0,
+ax_anim 2, 0, 175, 12, 0, 12, 0,
+ax_anim 3, 0, 175, -12, 0, -12, 0,
+ax_anim 3, 0, 175, 13, 0, 13, 0,
+ax_anim 3, 0, 175, -13, 0, -13, 0,
+ax_anim 2, 0, 175, 12, 0, 12, 0,
+ax_anim 3, 0, 175, -12, 0, -12, 0,
+ax_anim 2, 0, 175, 10, 0, 10, 0,
+ax_anim 2, 0, 175, -10, 0, -10, 0,
+ax_anim 2, 0, 175, 6, 0, 6, 0,
+ax_anim 2, 0, 175, -6, 0, -6, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_10_6:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 6, -6, 6, -6,
+ax_anim 2, 0, 176, -6, 6, -6, 6,
+ax_anim 2, 0, 176, 10, -10, 10, -10,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 2, 0, 176, 12, -12, 12, -12,
+ax_anim 3, 0, 176, -12, 12, -12, 12,
+ax_anim 3, 0, 176, 13, -13, 13, -13,
+ax_anim 3, 0, 176, -13, 13, -13, 13,
+ax_anim 2, 0, 176, 12, -12, 12, -12,
+ax_anim 3, 0, 176, -12, 12, -12, 12,
+ax_anim 2, 0, 176, 10, -10, 10, -10,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 2, 0, 176, 6, -6, 6, -6,
+ax_anim 2, 0, 176, -6, 6, -6, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_10_7:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, -6, 0, -6,
+ax_anim 2, 0, 177, 0, 6, 0, 6,
+ax_anim 2, 0, 177, 0, -10, 0, -10,
+ax_anim 2, 0, 177, 0, 10, 0, 10,
+ax_anim 2, 0, 177, 0, -12, 0, -12,
+ax_anim 3, 0, 177, 0, 12, 0, 12,
+ax_anim 3, 0, 177, 0, -13, 0, -13,
+ax_anim 3, 0, 177, 0, 13, 0, 13,
+ax_anim 2, 0, 177, 0, -12, 0, -12,
+ax_anim 3, 0, 177, 0, 12, 0, 12,
+ax_anim 2, 0, 177, 0, -10, 0, -10,
+ax_anim 2, 0, 177, 0, 10, 0, 10,
+ax_anim 2, 0, 177, 0, -6, 0, -6,
+ax_anim 2, 0, 177, 0, 6, 0, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_10_8:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -6, -6, -6, -6,
+ax_anim 2, 0, 178, 6, 6, 6, 6,
+ax_anim 2, 0, 178, -10, -10, -10, -10,
+ax_anim 2, 0, 178, 10, 10, 10, 10,
+ax_anim 2, 0, 178, -12, -12, -12, -12,
+ax_anim 3, 0, 178, 12, 12, 12, 12,
+ax_anim 3, 0, 178, -13, -13, -13, -13,
+ax_anim 3, 0, 178, 13, 13, 13, 13,
+ax_anim 2, 0, 178, -12, -12, -12, -12,
+ax_anim 3, 0, 178, 12, 12, 12, 12,
+ax_anim 2, 0, 178, -10, -10, -10, -10,
+ax_anim 2, 0, 178, 10, 10, 10, 10,
+ax_anim 2, 0, 178, -6, -6, -6, -6,
+ax_anim 2, 0, 178, 6, 6, 6, 6,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_11_1:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_11_2:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_11_3:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_11_4:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -17, 0, 0,
+ax_anim 1, 0, 190, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_11_5:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_11_6:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_11_7:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_12_1:
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_12_2:
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_12_3:
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_12_4:
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_12_5:
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_12_6:
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_12_7:
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_12_8:
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMiltankAnims_13_1:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_13_2:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_13_3:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_13_4:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_13_5:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_13_6:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_13_7:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankAnims_13_8:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMiltankGfx1:
+.incbin "baserom.gba", 0xFC5534, 0x200
+sMiltankSprites1:
+ax_sprite sMiltankGfx1, 0x200
+ax_sprite_terminator
+sMiltankGfx2:
+.incbin "baserom.gba", 0xFC5744, 0x200
+sMiltankSprites2:
+ax_sprite sMiltankGfx2, 0x200
+ax_sprite_terminator
+sMiltankGfx3:
+.incbin "baserom.gba", 0xFC5954, 0x200
+sMiltankSprites3:
+ax_sprite sMiltankGfx3, 0x200
+ax_sprite_terminator
+sMiltankGfx4:
+.incbin "baserom.gba", 0xFC5B64, 0x200
+sMiltankSprites4:
+ax_sprite sMiltankGfx4, 0x200
+ax_sprite_terminator
+sMiltankGfx5:
+.incbin "baserom.gba", 0xFC5D74, 0x200
+sMiltankSprites5:
+ax_sprite sMiltankGfx5, 0x200
+ax_sprite_terminator
+sMiltankGfx6:
+.incbin "baserom.gba", 0xFC5F84, 0x200
+sMiltankSprites6:
+ax_sprite sMiltankGfx6, 0x200
+ax_sprite_terminator
+sMiltankGfx7:
+.incbin "baserom.gba", 0xFC6194, 0x200
+sMiltankSprites7:
+ax_sprite sMiltankGfx7, 0x200
+ax_sprite_terminator
+sMiltankGfx8:
+.incbin "baserom.gba", 0xFC63A4, 0x200
+sMiltankSprites8:
+ax_sprite sMiltankGfx8, 0x200
+ax_sprite_terminator
+sMiltankGfx9:
+.incbin "baserom.gba", 0xFC65B4, 0x200
+sMiltankSprites9:
+ax_sprite sMiltankGfx9, 0x200
+ax_sprite_terminator
+sMiltankGfx10:
+.incbin "baserom.gba", 0xFC67C4, 0x200
+sMiltankSprites10:
+ax_sprite sMiltankGfx10, 0x200
+ax_sprite_terminator
+sMiltankGfx11:
+.incbin "baserom.gba", 0xFC69D4, 0x200
+sMiltankSprites11:
+ax_sprite sMiltankGfx11, 0x200
+ax_sprite_terminator
+sMiltankGfx12:
+.incbin "baserom.gba", 0xFC6BE4, 0x200
+sMiltankSprites12:
+ax_sprite sMiltankGfx12, 0x200
+ax_sprite_terminator
+sMiltankGfx13:
+.incbin "baserom.gba", 0xFC6DF4, 0x200
+sMiltankSprites13:
+ax_sprite sMiltankGfx13, 0x200
+ax_sprite_terminator
+sMiltankGfx14:
+.incbin "baserom.gba", 0xFC7004, 0x200
+sMiltankSprites14:
+ax_sprite sMiltankGfx14, 0x200
+ax_sprite_terminator
+sMiltankGfx15:
+.incbin "baserom.gba", 0xFC7214, 0x200
+sMiltankSprites15:
+ax_sprite sMiltankGfx15, 0x200
+ax_sprite_terminator
+sMiltankGfx16:
+.incbin "baserom.gba", 0xFC7424, 0x20
+sMiltankGfx16_1:
+.incbin "baserom.gba", 0xFC7444, 0x60
+sMiltankGfx16_2:
+.incbin "baserom.gba", 0xFC74A4, 0x60
+sMiltankGfx16_3:
+.incbin "baserom.gba", 0xFC7504, 0x60
+sMiltankSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMiltankGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx17:
+.incbin "baserom.gba", 0xFC75B4, 0x20
+sMiltankGfx17_1:
+.incbin "baserom.gba", 0xFC75D4, 0x60
+sMiltankGfx17_2:
+.incbin "baserom.gba", 0xFC7634, 0xE0
+sMiltankSprites17:
+ax_sprite 0, 0x40
+ax_sprite sMiltankGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx17_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx18:
+.incbin "baserom.gba", 0xFC7754, 0x1C0
+sMiltankSprites18:
+ax_sprite 0, 0x40
+ax_sprite sMiltankGfx18, 0x1c0
+ax_sprite_terminator
+sMiltankGfx19:
+.incbin "baserom.gba", 0xFC792C, 0x60
+sMiltankGfx19_1:
+.incbin "baserom.gba", 0xFC798C, 0x100
+sMiltankSprites19:
+ax_sprite 0, 0x80
+ax_sprite sMiltankGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx19_1, 0x100
+ax_sprite_terminator
+sMiltankGfx20:
+.incbin "baserom.gba", 0xFC7AB4, 0x60
+sMiltankGfx20_1:
+.incbin "baserom.gba", 0xFC7B14, 0x60
+sMiltankGfx20_2:
+.incbin "baserom.gba", 0xFC7B74, 0x60
+sMiltankSprites20:
+ax_sprite 0, 0x80
+ax_sprite sMiltankGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx21:
+.incbin "baserom.gba", 0xFC7C14, 0x60
+sMiltankGfx21_1:
+.incbin "baserom.gba", 0xFC7C74, 0x60
+sMiltankGfx21_2:
+.incbin "baserom.gba", 0xFC7CD4, 0x60
+sMiltankGfx21_3:
+.incbin "baserom.gba", 0xFC7D34, 0x60
+sMiltankSprites21:
+ax_sprite sMiltankGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx22:
+.incbin "baserom.gba", 0xFC7DDC, 0x60
+sMiltankGfx22_1:
+.incbin "baserom.gba", 0xFC7E3C, 0x60
+sMiltankGfx22_2:
+.incbin "baserom.gba", 0xFC7E9C, 0x60
+sMiltankGfx22_3:
+.incbin "baserom.gba", 0xFC7EFC, 0x60
+sMiltankSprites22:
+ax_sprite sMiltankGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx23:
+.incbin "baserom.gba", 0xFC7FA4, 0x60
+sMiltankGfx23_1:
+.incbin "baserom.gba", 0xFC8004, 0x60
+sMiltankGfx23_2:
+.incbin "baserom.gba", 0xFC8064, 0x60
+sMiltankGfx23_3:
+.incbin "baserom.gba", 0xFC80C4, 0x60
+sMiltankSprites23:
+ax_sprite sMiltankGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx24:
+.incbin "baserom.gba", 0xFC816C, 0x60
+sMiltankGfx24_1:
+.incbin "baserom.gba", 0xFC81CC, 0xE0
+sMiltankGfx24_2:
+.incbin "baserom.gba", 0xFC82AC, 0x60
+sMiltankSprites24:
+ax_sprite sMiltankGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx24_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx25:
+.incbin "baserom.gba", 0xFC8344, 0x40
+sMiltankGfx25_1:
+.incbin "baserom.gba", 0xFC8384, 0x60
+sMiltankGfx25_2:
+.incbin "baserom.gba", 0xFC83E4, 0x100
+sMiltankSprites25:
+ax_sprite sMiltankGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiltankGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx25_2, 0x100
+ax_sprite_terminator
+sMiltankGfx26:
+.incbin "baserom.gba", 0xFC8514, 0x40
+sMiltankGfx26_1:
+.incbin "baserom.gba", 0xFC8554, 0x160
+sMiltankSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx26_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx27:
+.incbin "baserom.gba", 0xFC86E4, 0x40
+sMiltankGfx27_1:
+.incbin "baserom.gba", 0xFC8724, 0x40
+sMiltankGfx27_2:
+.incbin "baserom.gba", 0xFC8764, 0x60
+sMiltankGfx27_3:
+.incbin "baserom.gba", 0xFC87C4, 0x60
+sMiltankSprites27:
+ax_sprite sMiltankGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiltankGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMiltankGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx28:
+.incbin "baserom.gba", 0xFC886C, 0x60
+sMiltankGfx28_1:
+.incbin "baserom.gba", 0xFC88CC, 0x60
+sMiltankGfx28_2:
+.incbin "baserom.gba", 0xFC892C, 0x60
+sMiltankGfx28_3:
+.incbin "baserom.gba", 0xFC898C, 0x60
+sMiltankSprites28:
+ax_sprite sMiltankGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx29:
+.incbin "baserom.gba", 0xFC8A34, 0x60
+sMiltankGfx29_1:
+.incbin "baserom.gba", 0xFC8A94, 0x60
+sMiltankGfx29_2:
+.incbin "baserom.gba", 0xFC8AF4, 0x60
+sMiltankGfx29_3:
+.incbin "baserom.gba", 0xFC8B54, 0x60
+sMiltankSprites29:
+ax_sprite sMiltankGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx30:
+.incbin "baserom.gba", 0xFC8BFC, 0x60
+sMiltankGfx30_1:
+.incbin "baserom.gba", 0xFC8C5C, 0x60
+sMiltankGfx30_2:
+.incbin "baserom.gba", 0xFC8CBC, 0x60
+sMiltankGfx30_3:
+.incbin "baserom.gba", 0xFC8D1C, 0x60
+sMiltankSprites30:
+ax_sprite sMiltankGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMiltankGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMiltankGfx31:
+.incbin "baserom.gba", 0xFC8DC4, 0x200
+sMiltankSprites31:
+ax_sprite sMiltankGfx31, 0x200
+ax_sprite_terminator
+sMiltankGfx32:
+.incbin "baserom.gba", 0xFC8FD4, 0x200
+sMiltankSprites32:
+ax_sprite sMiltankGfx32, 0x200
+ax_sprite_terminator
+sMiltankGfx33:
+.incbin "baserom.gba", 0xFC91E4, 0x200
+sMiltankSprites33:
+ax_sprite sMiltankGfx33, 0x200
+ax_sprite_terminator
+sMiltankGfx34:
+.incbin "baserom.gba", 0xFC93F4, 0x200
+sMiltankSprites34:
+ax_sprite sMiltankGfx34, 0x200
+ax_sprite_terminator
+sMiltankGfx35:
+.incbin "baserom.gba", 0xFC9604, 0x200
+sMiltankSprites35:
+ax_sprite sMiltankGfx35, 0x200
+ax_sprite_terminator
+sMiltankGfx36:
+.incbin "baserom.gba", 0xFC9814, 0x200
+sMiltankSprites36:
+ax_sprite sMiltankGfx36, 0x200
+ax_sprite_terminator
+sMiltankGfx37:
+.incbin "baserom.gba", 0xFC9A24, 0x200
+sMiltankSprites37:
+ax_sprite sMiltankGfx37, 0x200
+ax_sprite_terminator
+sAxPosesMiltank:
+.4byte sMiltankPose1
+.4byte sMiltankPose2
+.4byte sMiltankPose3
+.4byte sMiltankPose4
+.4byte sMiltankPose5
+.4byte sMiltankPose6
+.4byte sMiltankPose7
+.4byte sMiltankPose8
+.4byte sMiltankPose9
+.4byte sMiltankPose10
+.4byte sMiltankPose11
+.4byte sMiltankPose12
+.4byte sMiltankPose13
+.4byte sMiltankPose14
+.4byte sMiltankPose15
+.4byte sMiltankPose16
+.4byte sMiltankPose17
+.4byte sMiltankPose18
+.4byte sMiltankPose19
+.4byte sMiltankPose20
+.4byte sMiltankPose21
+.4byte sMiltankPose22
+.4byte sMiltankPose23
+.4byte sMiltankPose24
+.4byte sMiltankPose25
+.4byte sMiltankPose26
+.4byte sMiltankPose27
+.4byte sMiltankPose28
+.4byte sMiltankPose29
+.4byte sMiltankPose30
+.4byte sMiltankPose31
+.4byte sMiltankPose32
+.4byte sMiltankPose33
+.4byte sMiltankPose34
+.4byte sMiltankPose35
+.4byte sMiltankPose36
+.4byte sMiltankPose37
+.4byte sMiltankPose38
+.4byte sMiltankPose39
+.4byte sMiltankPose40
+.4byte sMiltankPose41
+.4byte sMiltankPose42
+.4byte sMiltankPose43
+.4byte sMiltankPose44
+.4byte sMiltankPose45
+.4byte sMiltankPose46
+.4byte sMiltankPose47
+.4byte sMiltankPose48
+.4byte sMiltankPose49
+.4byte sMiltankPose50
+.4byte sMiltankPose51
+.4byte sMiltankPose52
+.4byte sMiltankPose53
+.4byte sMiltankPose54
+.4byte sMiltankPose55
+.4byte sMiltankPose56
+.4byte sMiltankPose57
+.4byte sMiltankPose58
+.4byte sMiltankPose59
+.4byte sMiltankPose60
+.4byte sMiltankPose61
+.4byte sMiltankPose62
+.4byte sMiltankPose63
+.4byte sMiltankPose64
+.4byte sMiltankPose65
+.4byte sMiltankPose66
+.4byte sMiltankPose67
+.4byte sMiltankPose68
+.4byte sMiltankPose69
+.4byte sMiltankPose70
+.4byte sMiltankPose71
+.4byte sMiltankPose72
+.4byte sMiltankPose73
+.4byte sMiltankPose74
+.4byte sMiltankPose75
+.4byte sMiltankPose76
+.4byte sMiltankPose77
+.4byte sMiltankPose78
+.4byte sMiltankPose79
+.4byte sMiltankPose80
+.4byte sMiltankPose81
+.4byte sMiltankPose82
+.4byte sMiltankPose83
+.4byte sMiltankPose84
+.4byte sMiltankPose85
+.4byte sMiltankPose86
+.4byte sMiltankPose87
+.4byte sMiltankPose88
+.4byte sMiltankPose89
+.4byte sMiltankPose90
+.4byte sMiltankPose91
+.4byte sMiltankPose92
+.4byte sMiltankPose93
+.4byte sMiltankPose94
+.4byte sMiltankPose95
+.4byte sMiltankPose96
+.4byte sMiltankPose97
+.4byte sMiltankPose98
+.4byte sMiltankPose99
+.4byte sMiltankPose100
+.4byte sMiltankPose101
+.4byte sMiltankPose102
+.4byte sMiltankPose103
+.4byte sMiltankPose104
+.4byte sMiltankPose105
+.4byte sMiltankPose106
+.4byte sMiltankPose107
+.4byte sMiltankPose108
+.4byte sMiltankPose109
+.4byte sMiltankPose110
+.4byte sMiltankPose111
+.4byte sMiltankPose112
+.4byte sMiltankPose113
+.4byte sMiltankPose114
+.4byte sMiltankPose115
+.4byte sMiltankPose116
+.4byte sMiltankPose117
+.4byte sMiltankPose118
+.4byte sMiltankPose119
+.4byte sMiltankPose120
+.4byte sMiltankPose121
+.4byte sMiltankPose122
+.4byte sMiltankPose123
+.4byte sMiltankPose124
+.4byte sMiltankPose125
+.4byte sMiltankPose126
+.4byte sMiltankPose127
+.4byte sMiltankPose128
+.4byte sMiltankPose129
+.4byte sMiltankPose130
+.4byte sMiltankPose131
+.4byte sMiltankPose132
+.4byte sMiltankPose133
+.4byte sMiltankPose134
+.4byte sMiltankPose135
+.4byte sMiltankPose136
+.4byte sMiltankPose137
+.4byte sMiltankPose138
+.4byte sMiltankPose139
+.4byte sMiltankPose140
+.4byte sMiltankPose141
+.4byte sMiltankPose142
+.4byte sMiltankPose143
+.4byte sMiltankPose144
+.4byte sMiltankPose145
+.4byte sMiltankPose146
+.4byte sMiltankPose147
+.4byte sMiltankPose148
+.4byte sMiltankPose149
+.4byte sMiltankPose150
+.4byte sMiltankPose151
+.4byte sMiltankPose152
+.4byte sMiltankPose153
+.4byte sMiltankPose154
+.4byte sMiltankPose155
+.4byte sMiltankPose156
+.4byte sMiltankPose157
+.4byte sMiltankPose158
+.4byte sMiltankPose159
+.4byte sMiltankPose160
+.4byte sMiltankPose161
+.4byte sMiltankPose162
+.4byte sMiltankPose163
+.4byte sMiltankPose164
+.4byte sMiltankPose165
+.4byte sMiltankPose166
+.4byte sMiltankPose167
+.4byte sMiltankPose168
+.4byte sMiltankPose169
+.4byte sMiltankPose170
+.4byte sMiltankPose171
+.4byte sMiltankPose172
+.4byte sMiltankPose173
+.4byte sMiltankPose174
+.4byte sMiltankPose175
+.4byte sMiltankPose176
+.4byte sMiltankPose177
+.4byte sMiltankPose178
+.4byte sMiltankPose179
+.4byte sMiltankPose180
+.4byte sMiltankPose181
+.4byte sMiltankPose182
+.4byte sMiltankPose183
+.4byte sMiltankPose184
+.4byte sMiltankPose185
+.4byte sMiltankPose186
+.4byte sMiltankPose187
+.4byte sMiltankPose188
+.4byte sMiltankPose189
+.4byte sMiltankPose190
+.4byte sMiltankPose191
+.4byte sMiltankPose192
+.4byte sMiltankPose193
+.4byte sMiltankPose194
+.4byte sMiltankPose195
+.4byte sMiltankPose196
+.4byte sMiltankPose197
+.4byte sMiltankPose198
+.4byte sMiltankPose199
+.4byte sMiltankPose200
+.4byte sMiltankPose201
+.4byte sMiltankPose202
+.4byte sMiltankPose203
+.4byte sMiltankPose204
+.4byte sMiltankPose205
+.4byte sMiltankPose206
+.4byte sMiltankPose207
+.4byte sMiltankPose208
+.4byte sMiltankPose209
+.4byte sMiltankPose210
+.4byte sMiltankPose211
+.4byte sMiltankPose212
+.4byte sMiltankPose213
+.4byte sMiltankPose214
+.4byte sMiltankPose215
+.4byte sMiltankPose216
+.4byte sMiltankPose217
+.4byte sMiltankPose218
+.4byte sMiltankPose219
+sAxPositionsMiltank:
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	 -10,   -9, 	   8,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	 -10,   -8, 	   8,   -9, 	  -1,   -8
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    3,  -12, 	   7,  -10, 	  -9,   -8, 	  -1,   -7
+.2byte    3,  -12, 	   4,   -9, 	  -4,   -6, 	   1,   -8
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    3,  -11, 	  -6,   -6, 	  -5,   -5, 	  -2,   -6
+.2byte    3,  -11, 	   2,   -5, 	   1,   -4, 	  -2,   -5
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    3,  -14, 	  -2,   -9, 	   6,   -6, 	  -1,   -6
+.2byte    4,  -14, 	  -8,  -10, 	   8,   -8, 	  -1,   -6
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -7, 	  -1,   -7
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -5,  -14, 	   0,   -9, 	  -8,   -6, 	  -1,   -6
+.2byte   -6,  -14, 	   6,  -10, 	 -10,   -8, 	  -1,   -6
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -5,  -11, 	   4,   -6, 	   3,   -5, 	   0,   -6
+.2byte   -5,  -11, 	  -4,   -5, 	  -3,   -4, 	   0,   -5
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	  -9,  -10, 	   7,   -8, 	  -1,   -7
+.2byte   -5,  -12, 	  -6,   -9, 	   2,   -6, 	  -3,   -8
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	 -10,   -9, 	   8,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	 -10,   -8, 	   8,   -9, 	  -1,   -8
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    3,  -12, 	   7,  -10, 	  -9,   -8, 	  -1,   -7
+.2byte    3,  -12, 	   4,   -9, 	  -4,   -6, 	   1,   -8
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    3,  -11, 	  -6,   -6, 	  -5,   -5, 	  -2,   -6
+.2byte    3,  -11, 	   2,   -5, 	   1,   -4, 	  -2,   -5
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    3,  -14, 	  -2,   -9, 	   6,   -6, 	  -1,   -6
+.2byte    4,  -14, 	  -8,  -10, 	   8,   -8, 	  -1,   -6
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -7, 	  -1,   -7
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -5,  -14, 	   0,   -9, 	  -8,   -6, 	  -1,   -6
+.2byte   -6,  -14, 	   6,  -10, 	 -10,   -8, 	  -1,   -6
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -5,  -11, 	   4,   -6, 	   3,   -5, 	   0,   -6
+.2byte   -5,  -11, 	  -4,   -5, 	  -3,   -4, 	   0,   -5
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	  -9,  -10, 	   7,   -8, 	  -1,   -7
+.2byte   -5,  -12, 	  -6,   -9, 	   2,   -6, 	  -3,   -8
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	 -10,   -9, 	   8,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	 -10,   -8, 	   8,   -9, 	  -1,   -8
+.2byte   -1,    2, 	  -7,    5, 	   5,    5, 	  -1,   -5
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    3,  -12, 	   7,  -10, 	  -9,   -8, 	  -1,   -7
+.2byte    3,  -12, 	   4,   -9, 	  -4,   -6, 	   1,   -8
+.2byte    8,    2, 	  12,   -1, 	   2,    6, 	  -1,   -3
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    3,  -11, 	  -6,   -6, 	  -5,   -5, 	  -2,   -6
+.2byte    3,  -11, 	   2,   -5, 	   1,   -4, 	  -2,   -5
+.2byte   11,   -2, 	  10,   -1, 	  10,    2, 	   0,   -4
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    3,  -14, 	  -2,   -9, 	   6,   -6, 	  -1,   -6
+.2byte    4,  -14, 	  -8,  -10, 	   8,   -8, 	  -1,   -6
+.2byte   10,   -6, 	   0,   -9, 	  11,   -3, 	  -1,   -3
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -7, 	  -1,   -7
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   5,   -8, 	  -7,   -8, 	  -1,   -4
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -5,  -14, 	   0,   -9, 	  -8,   -6, 	  -1,   -6
+.2byte   -6,  -14, 	   6,  -10, 	 -10,   -8, 	  -1,   -6
+.2byte  -12,   -6, 	  -2,   -9, 	 -13,   -3, 	  -1,   -3
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -5,  -11, 	   4,   -6, 	   3,   -5, 	   0,   -6
+.2byte   -5,  -11, 	  -4,   -5, 	  -3,   -4, 	   0,   -5
+.2byte  -13,   -2, 	 -12,   -1, 	 -12,    2, 	  -2,   -4
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	  -9,  -10, 	   7,   -8, 	  -1,   -7
+.2byte   -5,  -12, 	  -6,   -9, 	   2,   -6, 	  -3,   -8
+.2byte  -10,    2, 	 -14,   -1, 	  -4,    6, 	  -1,   -3
+.2byte    1,   -9, 	   0,   -5, 	   8,  -14, 	   1,   -8
+.2byte    0,  -13, 	 -10,  -13, 	   9,  -15, 	   0,   -9
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    1,  -10, 	   2,   -6, 	  -9,  -13, 	  -2,   -7
+.2byte    2,  -12, 	   7,  -14, 	  -9,  -14, 	  -2,   -8
+.2byte    3,  -10, 	   3,   -7, 	  -8,  -12, 	  -3,   -5
+.2byte    3,  -12, 	  -6,  -14, 	  -7,  -12, 	  -2,   -6
+.2byte    5,  -14, 	  -1,   -9, 	   0,  -12, 	  -2,   -7
+.2byte    6,  -14, 	  -8,  -13, 	   2,  -14, 	  -2,   -7
+.2byte   -2,  -14, 	   1,   -9, 	  -9,  -14, 	   0,   -8
+.2byte   -2,  -14, 	   9,  -12, 	  -9,  -15, 	  -1,   -8
+.2byte   -7,  -14, 	  -1,   -9, 	  -2,  -12, 	   0,   -7
+.2byte   -8,  -14, 	   6,  -13, 	  -4,  -14, 	   0,   -7
+.2byte   -5,  -10, 	  -5,   -7, 	   6,  -12, 	   1,   -5
+.2byte   -5,  -12, 	   4,  -14, 	   5,  -12, 	   0,   -6
+.2byte   -3,  -10, 	  -4,   -6, 	   7,  -13, 	   0,   -7
+.2byte   -4,  -12, 	  -9,  -14, 	   7,  -14, 	   0,   -8
+.2byte    1,   -9, 	   0,   -5, 	   8,  -14, 	   1,   -8
+.2byte    0,  -13, 	 -10,  -13, 	   9,  -15, 	   0,   -9
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    1,  -10, 	   2,   -6, 	  -9,  -13, 	  -2,   -7
+.2byte    2,  -12, 	   7,  -14, 	  -9,  -14, 	  -2,   -8
+.2byte    3,  -10, 	   3,   -7, 	  -8,  -12, 	  -3,   -5
+.2byte    3,  -12, 	  -6,  -14, 	  -7,  -12, 	  -2,   -6
+.2byte    5,  -14, 	  -1,   -9, 	   0,  -12, 	  -2,   -7
+.2byte    6,  -14, 	  -8,  -13, 	   2,  -14, 	  -2,   -7
+.2byte   -2,  -14, 	   1,   -9, 	  -9,  -14, 	   0,   -8
+.2byte   -2,  -14, 	   9,  -12, 	  -9,  -15, 	  -1,   -8
+.2byte    1,  -14, 	 -10,  -12, 	   8,  -15, 	   0,   -8
+.2byte   -7,  -14, 	  -1,   -9, 	  -2,  -12, 	   0,   -7
+.2byte   -8,  -14, 	   6,  -13, 	  -4,  -14, 	   0,   -7
+.2byte   -5,  -10, 	  -5,   -7, 	   6,  -12, 	   1,   -5
+.2byte   -5,  -12, 	   4,  -14, 	   5,  -12, 	   0,   -6
+.2byte   -3,  -10, 	  -4,   -6, 	   7,  -13, 	   0,   -7
+.2byte   -4,  -12, 	  -9,  -14, 	   7,  -14, 	   0,   -8
+.2byte   -4,  -10, 	  -5,   -6, 	   7,   -4, 	   0,   -5
+.2byte   -4,   -9, 	  -5,   -5, 	   7,   -3, 	   0,   -6
+.2byte    0,  -14, 	  -9,  -15, 	   9,  -15, 	   0,  -10
+.2byte   -2,  -14, 	   2,  -20, 	 -14,  -14, 	  -4,  -10
+.2byte    0,  -15, 	  -7,  -15, 	  -7,  -13, 	  -3,   -7
+.2byte    2,  -14, 	  -8,  -12, 	   3,  -11, 	  -2,   -6
+.2byte    0,  -11, 	   9,  -11, 	  -9,  -11, 	   1,   -4
+.2byte   -3,  -14, 	   7,  -12, 	  -4,  -11, 	   1,   -6
+.2byte    0,  -15, 	   7,  -15, 	   7,  -13, 	   3,   -7
+.2byte    2,  -14, 	  -2,  -20, 	  14,  -14, 	   4,  -10
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte    0,   -9, 	  -1,   -5, 	   7,  -14, 	   0,   -8
+.2byte    0,  -13, 	 -10,  -13, 	   9,  -15, 	   0,   -9
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    2,  -10, 	   3,   -6, 	  -8,  -13, 	  -1,   -7
+.2byte    2,  -12, 	   7,  -14, 	  -9,  -14, 	  -2,   -8
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    4,  -10, 	   4,   -7, 	  -7,  -12, 	  -2,   -5
+.2byte    3,  -12, 	  -6,  -14, 	  -7,  -12, 	  -2,   -6
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    5,  -14, 	  -1,   -9, 	   0,  -12, 	  -2,   -7
+.2byte    5,  -14, 	  -9,  -13, 	   1,  -14, 	  -3,   -7
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte   -2,  -14, 	   1,   -9, 	  -9,  -14, 	   0,   -8
+.2byte   -2,  -14, 	   9,  -12, 	  -9,  -15, 	  -1,   -8
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -7,  -14, 	  -1,   -9, 	  -2,  -12, 	   0,   -7
+.2byte   -7,  -14, 	   7,  -13, 	  -3,  -14, 	   1,   -7
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -6,  -10, 	  -6,   -7, 	   5,  -12, 	   0,   -5
+.2byte   -5,  -12, 	   4,  -14, 	   5,  -12, 	   0,   -6
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -4,  -10, 	  -5,   -6, 	   6,  -13, 	  -1,   -7
+.2byte   -4,  -12, 	  -9,  -14, 	   7,  -14, 	   0,   -8
+.2byte    0,  -13, 	 -10,  -10, 	  10,  -10, 	   0,   -9
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -6,  -15, 	   5,  -13, 	  -8,   -7, 	   0,   -7
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    4,  -12, 	  -3,   -6, 	  -1,   -5, 	  -1,   -7
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    1,  -13, 	  -9,  -13, 	  10,  -15, 	   1,   -9
+.2byte    2,  -12, 	   7,  -14, 	  -9,  -14, 	  -2,   -8
+.2byte    4,  -12, 	  -5,  -14, 	  -6,  -12, 	  -1,   -6
+.2byte    6,  -14, 	  -8,  -13, 	   2,  -14, 	  -2,   -7
+.2byte   -2,  -14, 	   9,  -12, 	  -9,  -15, 	  -1,   -8
+.2byte   -7,  -14, 	   7,  -13, 	  -3,  -14, 	   1,   -7
+.2byte   -4,  -12, 	   5,  -14, 	   6,  -12, 	   1,   -6
+.2byte   -3,  -12, 	  -8,  -14, 	   8,  -14, 	   1,   -8
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	 -10,   -9, 	   8,   -8, 	  -1,   -8
+.2byte   -1,  -12, 	 -10,   -8, 	   8,   -9, 	  -1,   -8
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte    3,  -12, 	   7,  -10, 	  -9,   -8, 	  -1,   -7
+.2byte    3,  -12, 	   4,   -9, 	  -4,   -6, 	   1,   -8
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    3,  -11, 	  -6,   -6, 	  -5,   -5, 	  -2,   -6
+.2byte    3,  -11, 	   2,   -5, 	   1,   -4, 	  -2,   -5
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    3,  -14, 	  -2,   -9, 	   6,   -6, 	  -1,   -6
+.2byte    4,  -14, 	  -8,  -10, 	   8,   -8, 	  -1,   -6
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -7, 	  -1,   -7
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -5,  -14, 	   0,   -9, 	  -8,   -6, 	  -1,   -6
+.2byte   -6,  -14, 	   6,  -10, 	 -10,   -8, 	  -1,   -6
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -5,  -11, 	   4,   -6, 	   3,   -5, 	   0,   -6
+.2byte   -5,  -11, 	  -4,   -5, 	  -3,   -4, 	   0,   -5
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	  -9,  -10, 	   7,   -8, 	  -1,   -7
+.2byte   -5,  -12, 	  -6,   -9, 	   2,   -6, 	  -3,   -8
+.2byte    1,   -9, 	   0,   -5, 	   8,  -14, 	   1,   -8
+.2byte   -2,  -10, 	  -3,   -6, 	   8,  -13, 	   1,   -7
+.2byte   -6,  -10, 	  -6,   -7, 	   5,  -12, 	   0,   -5
+.2byte   -6,  -14, 	   0,   -9, 	  -1,  -12, 	   1,   -7
+.2byte   -1,  -14, 	   2,   -9, 	  -8,  -14, 	   1,   -8
+.2byte    6,  -14, 	   0,   -9, 	   1,  -12, 	  -1,   -7
+.2byte    4,  -10, 	   4,   -7, 	  -7,  -12, 	  -2,   -5
+.2byte    1,  -10, 	   2,   -6, 	  -9,  -13, 	  -2,   -7
+.2byte   -1,  -13, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -5,  -13, 	  -8,  -11, 	   6,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	   2,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -7,  -15, 	   4,  -13, 	  -9,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   9,   -9, 	 -11,   -9, 	  -1,   -8
+.2byte    5,  -15, 	  -6,  -13, 	   7,   -7, 	  -1,   -7
+.2byte    3,  -12, 	  -4,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    3,  -13, 	   6,  -11, 	  -8,   -7, 	  -1,   -9
+sMiltankAnimTable1:
+.4byte sMiltankAnims_1_1
+.4byte sMiltankAnims_1_2
+.4byte sMiltankAnims_1_3
+.4byte sMiltankAnims_1_4
+.4byte sMiltankAnims_1_5
+.4byte sMiltankAnims_1_6
+.4byte sMiltankAnims_1_7
+.4byte sMiltankAnims_1_8
+sMiltankAnimTable2:
+.4byte sMiltankAnims_2_1
+.4byte sMiltankAnims_2_2
+.4byte sMiltankAnims_2_3
+.4byte sMiltankAnims_2_4
+.4byte sMiltankAnims_2_5
+.4byte sMiltankAnims_2_6
+.4byte sMiltankAnims_2_7
+.4byte sMiltankAnims_2_8
+sMiltankAnimTable3:
+.4byte sMiltankAnims_3_1
+.4byte sMiltankAnims_3_2
+.4byte sMiltankAnims_3_3
+.4byte sMiltankAnims_3_4
+.4byte sMiltankAnims_3_5
+.4byte sMiltankAnims_3_6
+.4byte sMiltankAnims_3_7
+.4byte sMiltankAnims_3_8
+sMiltankAnimTable4:
+.4byte sMiltankAnims_4_1
+.4byte sMiltankAnims_4_2
+.4byte sMiltankAnims_4_3
+.4byte sMiltankAnims_4_4
+.4byte sMiltankAnims_4_5
+.4byte sMiltankAnims_4_6
+.4byte sMiltankAnims_4_7
+.4byte sMiltankAnims_4_8
+sMiltankAnimTable5:
+.4byte sMiltankAnims_5_1
+.4byte sMiltankAnims_5_2
+.4byte sMiltankAnims_5_3
+.4byte sMiltankAnims_5_4
+.4byte sMiltankAnims_5_5
+.4byte sMiltankAnims_5_6
+.4byte sMiltankAnims_5_7
+.4byte sMiltankAnims_5_8
+sMiltankAnimTable6:
+.4byte sMiltankAnims_6_1
+.4byte sMiltankAnims_6_1
+.4byte sMiltankAnims_6_1
+.4byte sMiltankAnims_6_1
+.4byte sMiltankAnims_6_1
+.4byte sMiltankAnims_6_1
+.4byte sMiltankAnims_6_1
+.4byte sMiltankAnims_6_1
+sMiltankAnimTable7:
+.4byte sMiltankAnims_7_1
+.4byte sMiltankAnims_7_2
+.4byte sMiltankAnims_7_3
+.4byte sMiltankAnims_7_4
+.4byte sMiltankAnims_7_5
+.4byte sMiltankAnims_7_6
+.4byte sMiltankAnims_7_7
+.4byte sMiltankAnims_7_8
+sMiltankAnimTable8:
+.4byte sMiltankAnims_8_1
+.4byte sMiltankAnims_8_2
+.4byte sMiltankAnims_8_3
+.4byte sMiltankAnims_8_4
+.4byte sMiltankAnims_8_5
+.4byte sMiltankAnims_8_6
+.4byte sMiltankAnims_8_7
+.4byte sMiltankAnims_8_8
+sMiltankAnimTable9:
+.4byte sMiltankAnims_9_1
+.4byte sMiltankAnims_9_2
+.4byte sMiltankAnims_9_3
+.4byte sMiltankAnims_9_4
+.4byte sMiltankAnims_9_5
+.4byte sMiltankAnims_9_6
+.4byte sMiltankAnims_9_7
+.4byte sMiltankAnims_9_8
+sMiltankAnimTable10:
+.4byte sMiltankAnims_10_1
+.4byte sMiltankAnims_10_2
+.4byte sMiltankAnims_10_3
+.4byte sMiltankAnims_10_4
+.4byte sMiltankAnims_10_5
+.4byte sMiltankAnims_10_6
+.4byte sMiltankAnims_10_7
+.4byte sMiltankAnims_10_8
+sMiltankAnimTable11:
+.4byte sMiltankAnims_11_1
+.4byte sMiltankAnims_11_2
+.4byte sMiltankAnims_11_3
+.4byte sMiltankAnims_11_4
+.4byte sMiltankAnims_11_5
+.4byte sMiltankAnims_11_6
+.4byte sMiltankAnims_11_7
+.4byte sMiltankAnims_11_8
+sMiltankAnimTable12:
+.4byte sMiltankAnims_12_1
+.4byte sMiltankAnims_12_2
+.4byte sMiltankAnims_12_3
+.4byte sMiltankAnims_12_4
+.4byte sMiltankAnims_12_5
+.4byte sMiltankAnims_12_6
+.4byte sMiltankAnims_12_7
+.4byte sMiltankAnims_12_8
+sMiltankAnimTable13:
+.4byte sMiltankAnims_13_1
+.4byte sMiltankAnims_13_2
+.4byte sMiltankAnims_13_3
+.4byte sMiltankAnims_13_4
+.4byte sMiltankAnims_13_5
+.4byte sMiltankAnims_13_6
+.4byte sMiltankAnims_13_7
+.4byte sMiltankAnims_13_8
+sAxAnimationsMiltank:
+.4byte sMiltankAnimTable1
+.4byte sMiltankAnimTable2
+.4byte sMiltankAnimTable3
+.4byte sMiltankAnimTable4
+.4byte sMiltankAnimTable5
+.4byte sMiltankAnimTable6
+.4byte sMiltankAnimTable7
+.4byte sMiltankAnimTable8
+.4byte sMiltankAnimTable9
+.4byte sMiltankAnimTable10
+.4byte sMiltankAnimTable11
+.4byte sMiltankAnimTable12
+.4byte sMiltankAnimTable13
+sAxSpritesMiltank:
+.4byte sMiltankSprites1
+.4byte sMiltankSprites2
+.4byte sMiltankSprites3
+.4byte sMiltankSprites4
+.4byte sMiltankSprites5
+.4byte sMiltankSprites6
+.4byte sMiltankSprites7
+.4byte sMiltankSprites8
+.4byte sMiltankSprites9
+.4byte sMiltankSprites10
+.4byte sMiltankSprites11
+.4byte sMiltankSprites12
+.4byte sMiltankSprites13
+.4byte sMiltankSprites14
+.4byte sMiltankSprites15
+.4byte sMiltankSprites16
+.4byte sMiltankSprites17
+.4byte sMiltankSprites18
+.4byte sMiltankSprites19
+.4byte sMiltankSprites20
+.4byte sMiltankSprites21
+.4byte sMiltankSprites22
+.4byte sMiltankSprites23
+.4byte sMiltankSprites24
+.4byte sMiltankSprites25
+.4byte sMiltankSprites26
+.4byte sMiltankSprites27
+.4byte sMiltankSprites28
+.4byte sMiltankSprites29
+.4byte sMiltankSprites30
+.4byte sMiltankSprites31
+.4byte sMiltankSprites32
+.4byte sMiltankSprites33
+.4byte sMiltankSprites34
+.4byte sMiltankSprites35
+.4byte sMiltankSprites36
+.4byte sMiltankSprites37
+sAxMainMiltank:
+ax_main sAxPosesMiltank, sAxAnimationsMiltank, 13, sAxSpritesMiltank, sAxPositionsMiltank

--- a/data/ax/minun.inc
+++ b/data/ax/minun.inc
@@ -1,0 +1,2906 @@
+.global gAxMinun
+gAxMinun:
+ax_siro sAxMainMinun
+sMinunPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose4:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose5:
+ax_pose 4, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose6:
+ax_pose 5, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sMinunPose7:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose8:
+ax_pose 7, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose9:
+ax_pose 8, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose10:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose11:
+ax_pose 10, 0x81ea, 0x90f5, 0x0c00
+ax_pose_terminator
+sMinunPose12:
+ax_pose 11, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose16:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose17:
+ax_pose 10, 0x81ea, 0x80fb, 0x0c00
+ax_pose_terminator
+sMinunPose18:
+ax_pose 11, 0x81ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose19:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose20:
+ax_pose 7, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose21:
+ax_pose 8, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose22:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose23:
+ax_pose 4, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose24:
+ax_pose 5, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose26:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose27:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose28:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sMinunPose29:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose30:
+ax_pose 4, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose31:
+ax_pose 5, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sMinunPose32:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose33:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose34:
+ax_pose 7, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose35:
+ax_pose 8, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose36:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose37:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose38:
+ax_pose 10, 0x81ea, 0x90f5, 0x0c00
+ax_pose_terminator
+sMinunPose39:
+ax_pose 11, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose40:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose41:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose42:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose43:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose44:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose45:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose46:
+ax_pose 10, 0x81ea, 0x80fb, 0x0c00
+ax_pose_terminator
+sMinunPose47:
+ax_pose 11, 0x81ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose48:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose49:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose50:
+ax_pose 7, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose51:
+ax_pose 8, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose52:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose53:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose54:
+ax_pose 4, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose55:
+ax_pose 5, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose56:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose57:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose58:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose59:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose60:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sMinunPose61:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose62:
+ax_pose 4, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose63:
+ax_pose 5, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sMinunPose64:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose65:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose66:
+ax_pose 7, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose67:
+ax_pose 8, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose68:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose69:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose70:
+ax_pose 10, 0x81ea, 0x90f5, 0x0c00
+ax_pose_terminator
+sMinunPose71:
+ax_pose 11, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose72:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose73:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose74:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose75:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose76:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose77:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose78:
+ax_pose 10, 0x81ea, 0x80fb, 0x0c00
+ax_pose_terminator
+sMinunPose79:
+ax_pose 11, 0x81ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose80:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose81:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose82:
+ax_pose 7, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose83:
+ax_pose 8, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose84:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose85:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose86:
+ax_pose 4, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose87:
+ax_pose 5, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose88:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose89:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose90:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose91:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sMinunPose92:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose93:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose94:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose95:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose96:
+ax_pose 24, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sMinunPose97:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose98:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose99:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sMinunPose100:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose101:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose102:
+ax_pose 27, 0x81ec, 0x80f9, 0x0c00
+ax_pose 28, 0x01ec, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose103:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose104:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose105:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sMinunPose106:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose107:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose108:
+ax_pose 24, 0x81e9, 0x80fa, 0x0c00
+ax_pose_terminator
+sMinunPose109:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose110:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose111:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose112:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose113:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose114:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose115:
+ax_pose 29, 0x01e7, 0x80f0, 0x0c00
+ax_pose 15, 0x81e7, 0x80f8, 0x0c10
+ax_pose 16, 0x01ef, 0x0108, 0x0c18
+ax_pose_terminator
+sMinunPose116:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose 31, 0x01e7, 0x80f0, 0x0c10
+ax_pose_terminator
+sMinunPose117:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sMinunPose118:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sMinunPose119:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose120:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose121:
+ax_pose 32, 0x01e8, 0x90f1, 0x0c00
+ax_pose 17, 0x81e8, 0x90f9, 0x0c10
+ax_pose_terminator
+sMinunPose122:
+ax_pose 33, 0x01e8, 0x90f1, 0x0c00
+ax_pose 31, 0x01e8, 0x90f1, 0x0c10
+ax_pose_terminator
+sMinunPose123:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose124:
+ax_pose 33, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sMinunPose125:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose126:
+ax_pose 24, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sMinunPose127:
+ax_pose 34, 0x01e8, 0x90f0, 0x0c00
+ax_pose 18, 0x81e8, 0x90f8, 0x0c10
+ax_pose_terminator
+sMinunPose128:
+ax_pose 35, 0x01e8, 0x90f0, 0x0c00
+ax_pose 36, 0x01e8, 0x90f0, 0x0c10
+ax_pose_terminator
+sMinunPose129:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose130:
+ax_pose 35, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sMinunPose131:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose132:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sMinunPose133:
+ax_pose 32, 0x01e8, 0x90f2, 0x0c00
+ax_pose 19, 0x81e8, 0x90f9, 0x0c10
+ax_pose_terminator
+sMinunPose134:
+ax_pose 37, 0x01e8, 0x90f1, 0x0c00
+ax_pose 38, 0x01e7, 0x90f1, 0x0c10
+ax_pose_terminator
+sMinunPose135:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose136:
+ax_pose 37, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sMinunPose137:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose138:
+ax_pose 27, 0x81ec, 0x80f9, 0x0c00
+ax_pose 28, 0x01ec, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose139:
+ax_pose 29, 0x01e7, 0x80f0, 0x0c00
+ax_pose 20, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sMinunPose140:
+ax_pose 39, 0x01e9, 0x80f0, 0x0c00
+ax_pose 31, 0x01e7, 0x80f0, 0x0c10
+ax_pose_terminator
+sMinunPose141:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose142:
+ax_pose 39, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sMinunPose143:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose144:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sMinunPose145:
+ax_pose 32, 0x01e8, 0x80ee, 0x0c00
+ax_pose 19, 0x81e8, 0x80f7, 0x0c10
+ax_pose_terminator
+sMinunPose146:
+ax_pose 37, 0x01e8, 0x80ef, 0x0c00
+ax_pose 38, 0x01e7, 0x80ef, 0x0c10
+ax_pose_terminator
+sMinunPose147:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose148:
+ax_pose 37, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sMinunPose149:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose150:
+ax_pose 24, 0x81e9, 0x80fa, 0x0c00
+ax_pose_terminator
+sMinunPose151:
+ax_pose 34, 0x01e8, 0x80f0, 0x0c00
+ax_pose 18, 0x81e8, 0x80f8, 0x0c10
+ax_pose_terminator
+sMinunPose152:
+ax_pose 35, 0x01e8, 0x80f0, 0x0c00
+ax_pose 36, 0x01e8, 0x80f0, 0x0c10
+ax_pose_terminator
+sMinunPose153:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose154:
+ax_pose 35, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sMinunPose155:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose156:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose157:
+ax_pose 32, 0x01e8, 0x80ef, 0x0c00
+ax_pose 17, 0x81e8, 0x80f7, 0x0c10
+ax_pose_terminator
+sMinunPose158:
+ax_pose 33, 0x01e8, 0x80ef, 0x0c00
+ax_pose 31, 0x01e8, 0x80ef, 0x0c10
+ax_pose_terminator
+sMinunPose159:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose160:
+ax_pose 33, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sMinunPose161:
+ax_pose 40, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose162:
+ax_pose 41, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose163:
+ax_pose 42, 0x01e1, 0x80f0, 0x0c00
+ax_pose_terminator
+sMinunPose164:
+ax_pose 43, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sMinunPose165:
+ax_pose 44, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sMinunPose166:
+ax_pose 45, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sMinunPose167:
+ax_pose 46, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sMinunPose168:
+ax_pose 45, 0x01e8, 0x80f6, 0x0c00
+ax_pose_terminator
+sMinunPose169:
+ax_pose 44, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose170:
+ax_pose 43, 0x01e4, 0x80f3, 0x0c00
+ax_pose_terminator
+sMinunPose171:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose172:
+ax_pose 2, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sMinunPose173:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose174:
+ax_pose 5, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sMinunPose175:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose176:
+ax_pose 8, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose177:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose178:
+ax_pose 11, 0x81ec, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose179:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose180:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose181:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose182:
+ax_pose 11, 0x81ec, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose183:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose184:
+ax_pose 8, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose185:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose186:
+ax_pose 5, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose187:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sMinunPose188:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose189:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose190:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose191:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose192:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose193:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose194:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose195:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose196:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose197:
+ax_pose 24, 0x81e9, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose198:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sMinunPose199:
+ax_pose 27, 0x81ed, 0x80f9, 0x0c00
+ax_pose 28, 0x01ed, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose200:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sMinunPose201:
+ax_pose 24, 0x81e9, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose202:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose203:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose204:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose205:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose206:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose207:
+ax_pose 4, 0x81ed, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose208:
+ax_pose 5, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sMinunPose209:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose210:
+ax_pose 7, 0x81ed, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose211:
+ax_pose 8, 0x81ed, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose212:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose213:
+ax_pose 10, 0x81ed, 0x90f5, 0x0c00
+ax_pose_terminator
+sMinunPose214:
+ax_pose 11, 0x81ed, 0x90f9, 0x0c00
+ax_pose_terminator
+sMinunPose215:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose216:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose217:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose218:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose219:
+ax_pose 10, 0x81ed, 0x80fb, 0x0c00
+ax_pose_terminator
+sMinunPose220:
+ax_pose 11, 0x81ed, 0x80f7, 0x0c00
+ax_pose_terminator
+sMinunPose221:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose222:
+ax_pose 7, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose223:
+ax_pose 8, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose224:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose225:
+ax_pose 4, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose226:
+ax_pose 5, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose227:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose228:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose229:
+ax_pose 24, 0x81e9, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose230:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sMinunPose231:
+ax_pose 27, 0x81ed, 0x80f9, 0x0c00
+ax_pose 28, 0x01ed, 0x00f1, 0x0c08
+ax_pose_terminator
+sMinunPose232:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sMinunPose233:
+ax_pose 24, 0x81e9, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose234:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose235:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose236:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose237:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sMinunPose238:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sMinunPose239:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sMinunPose240:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sMinunPose241:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sMinunPose242:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+.align 2
+sMinunAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sMinunAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sMinunAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sMinunAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim_terminator
+sMinunAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sMinunAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim_terminator
+sMinunAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sMinunAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, -1,
+ax_anim 2, 2, 25, 0, 4, 0, 7,
+ax_anim 2, 0, 25, 0, 11, 0, 13,
+ax_anim 2, 1, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMinunAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 2, 29, 7, 1, 7, 6,
+ax_anim 2, 0, 29, 15, 8, 15, 13,
+ax_anim 2, 1, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 23, 18, 23, 18,
+ax_anim 2, 0, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 23, 18, 23, 18,
+ax_anim 2, 0, 28, 8, 7, 8, 7,
+ax_anim_terminator
+sMinunAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 7, -4, 7, 0,
+ax_anim 2, 0, 33, 15, -4, 15, 0,
+ax_anim 2, 1, 35, 23, 0, 23, 0,
+ax_anim 2, 0, 35, 23, -1, 23, -1,
+ax_anim 2, 0, 35, 23, 0, 23, 0,
+ax_anim 2, 0, 35, 23, -1, 23, -1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMinunAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 2, -2, 2, -2,
+ax_anim 2, 2, 37, 7, -12, 7, -8,
+ax_anim 2, 0, 37, 13, -18, 13, -14,
+ax_anim 2, 1, 39, 21, -23, 21, -23,
+ax_anim 2, 0, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 39, 21, -23, 21, -23,
+ax_anim 2, 0, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sMinunAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 2, 41, 0, -7, 0, -5,
+ax_anim 2, 0, 41, 0, -15, 0, -11,
+ax_anim 2, 1, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sMinunAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, -2, -2, -2, -2,
+ax_anim 2, 2, 45, -7, -12, -7, -8,
+ax_anim 2, 0, 45, -13, -18, -13, -14,
+ax_anim 2, 1, 47, -21, -23, -21, -23,
+ax_anim 2, 0, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 47, -21, -23, -21, -23,
+ax_anim 2, 0, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sMinunAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 49, -7, -4, -7, 0,
+ax_anim 2, 0, 49, -15, -4, -15, 0,
+ax_anim 2, 1, 51, -23, 0, -23, 0,
+ax_anim 2, 0, 51, -23, -1, -23, -1,
+ax_anim 2, 0, 51, -23, 0, -23, 0,
+ax_anim 2, 0, 51, -23, -1, -23, -1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sMinunAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 2, 53, -7, 1, -7, 6,
+ax_anim 2, 0, 53, -15, 8, -15, 13,
+ax_anim 2, 1, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -23, 18, -23, 18,
+ax_anim 2, 0, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -23, 18, -23, 18,
+ax_anim 2, 0, 52, -8, 7, -8, 7,
+ax_anim_terminator
+.align 2
+sMinunAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, -1,
+ax_anim 2, 2, 57, 0, 20, 0, 15,
+ax_anim 2, 0, 57, 0, 35, 0, 29,
+ax_anim 2, 1, 59, 0, 44, 0, 44,
+ax_anim 2, 0, 59, 1, 44, 1, 44,
+ax_anim 2, 0, 59, 0, 44, 0, 44,
+ax_anim 2, 0, 59, 1, 44, 1, 44,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sMinunAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, -1, 0, 0,
+ax_anim 2, 2, 61, 15, 9, 15, 14,
+ax_anim 2, 0, 61, 31, 24, 31, 29,
+ax_anim 2, 1, 63, 46, 43, 46, 43,
+ax_anim 2, 0, 63, 47, 42, 47, 42,
+ax_anim 2, 0, 63, 46, 43, 46, 43,
+ax_anim 2, 0, 63, 47, 42, 47, 42,
+ax_anim 2, 0, 60, 8, 7, 8, 7,
+ax_anim_terminator
+sMinunAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 65, 15, -4, 15, 0,
+ax_anim 2, 0, 65, 31, -4, 31, 0,
+ax_anim 2, 1, 67, 47, 0, 47, 0,
+ax_anim 2, 0, 67, 47, -1, 47, -1,
+ax_anim 2, 0, 67, 47, 0, 47, 0,
+ax_anim 2, 0, 67, 47, -1, 47, -1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sMinunAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 2, 69, 15, -20, 15, -16,
+ax_anim 2, 0, 69, 29, -34, 29, -30,
+ax_anim 2, 1, 71, 45, -47, 45, -47,
+ax_anim 2, 0, 71, 46, -46, 46, -46,
+ax_anim 2, 0, 71, 45, -47, 45, -47,
+ax_anim 2, 0, 71, 46, -46, 46, -46,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sMinunAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 0, -15, 0, -13,
+ax_anim 2, 0, 73, 0, -31, 0, -27,
+ax_anim 2, 1, 75, 0, -48, 0, -48,
+ax_anim 2, 0, 75, 1, -48, 1, -48,
+ax_anim 2, 0, 75, 0, -48, 0, -48,
+ax_anim 2, 0, 75, 1, -48, 1, -48,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sMinunAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 2, 77, -15, -20, -15, -16,
+ax_anim 2, 0, 77, -29, -34, -29, -30,
+ax_anim 2, 1, 79, -45, -47, -45, -39,
+ax_anim 2, 0, 79, -46, -46, -46, -38,
+ax_anim 2, 0, 79, -45, -47, -45, -39,
+ax_anim 2, 0, 79, -46, -46, -46, -38,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sMinunAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 81, -15, -4, -15, 0,
+ax_anim 2, 0, 81, -31, -4, -31, 0,
+ax_anim 2, 1, 83, -47, 0, -47, 0,
+ax_anim 2, 0, 83, -47, -1, -47, -1,
+ax_anim 2, 0, 83, -47, 0, -47, 0,
+ax_anim 2, 0, 83, -47, -1, -47, -1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sMinunAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 2, 85, -15, 9, -15, 14,
+ax_anim 2, 0, 85, -31, 24, -31, 29,
+ax_anim 2, 1, 87, -46, 43, -46, 35,
+ax_anim 2, 0, 87, -47, 42, -47, 34,
+ax_anim 2, 0, 87, -46, 43, -46, 35,
+ax_anim 2, 0, 87, -47, 42, -47, 34,
+ax_anim 2, 0, 84, -8, 7, -8, 7,
+ax_anim_terminator
+.align 2
+sMinunAnims_4_1:
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 4, 2, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 1, -6, 1, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 1, 89, 1, -6, 1, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 1, -6, 1, 0,
+ax_anim 4, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_4_2:
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 4, 2, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 1, -7, 1, -1,
+ax_anim 2, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 1, 92, 1, -7, 1, -1,
+ax_anim 2, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 1, -7, 1, -1,
+ax_anim 4, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_4_3:
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 4, 2, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -7, 0, -1,
+ax_anim 2, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 1, 95, 0, -7, 0, -1,
+ax_anim 2, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -7, 0, -1,
+ax_anim 4, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_4_4:
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 4, 2, 98, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 1, -5, 1, 1,
+ax_anim 2, 0, 98, 0, -6, 0, 0,
+ax_anim 2, 1, 98, 1, -5, 1, 1,
+ax_anim 2, 0, 98, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 1, -5, 1, 1,
+ax_anim 4, 0, 98, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_4_5:
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 4, 2, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 1, -6, 1, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 1, 101, 1, -6, 1, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 1, -6, 1, 0,
+ax_anim 4, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_4_6:
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 4, 2, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, -1, -5, -1, 1,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 1, 104, -1, -5, -1, 1,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, -1, -5, -1, 1,
+ax_anim 4, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_4_7:
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 4, 2, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -7, 0, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 1, 107, 0, -7, 0, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -7, 0, -1,
+ax_anim 4, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_4_8:
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 4, 2, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, -1, -7, -1, -1,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 1, 110, -1, -7, -1, -1,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, -1, -7, -1, -1,
+ax_anim 4, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_5_1:
+ax_anim 8, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 2, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 1, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_5_2:
+ax_anim 8, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 2, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 1, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_5_3:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 2, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 1, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_5_4:
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 2, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 1, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_5_5:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 2, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 1, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_5_6:
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 2, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 1, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_5_7:
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 2, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 1, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_5_8:
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 2, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 1, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sMinunAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sMinunAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sMinunAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sMinunAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sMinunAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sMinunAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sMinunAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMinunAnims_8_1:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 6, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_8_2:
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_8_3:
+ax_anim 30, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_8_4:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_8_5:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_8_6:
+ax_anim 30, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_8_7:
+ax_anim 30, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim 6, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_8_8:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 4, 7, 4,
+ax_anim 2, 0, 188, 10, 12, 10, 12,
+ax_anim 2, 0, 189, 7, 20, 7, 20,
+ax_anim 3, 0, 190, 0, 21, 0, 21,
+ax_anim 2, 3, 191, -7, 20, -7, 20,
+ax_anim 2, 0, 192, -10, 12, -10, 12,
+ax_anim 1, 0, 193, -7, 4, -7, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 11, 2, 11, 2,
+ax_anim 2, 0, 187, 21, 6, 21, 6,
+ax_anim 2, 0, 188, 26, 14, 26, 14,
+ax_anim 3, 0, 189, 24, 21, 24, 21,
+ax_anim 2, 3, 190, 14, 21, 14, 21,
+ax_anim 2, 0, 191, 5, 16, 5, 16,
+ax_anim 1, 0, 192, 2, 7, 2, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 4, -4, 4, -4,
+ax_anim 2, 0, 186, 10, -5, 10, -5,
+ax_anim 2, 0, 187, 18, -4, 18, -4,
+ax_anim 3, 0, 188, 22, 0, 22, 0,
+ax_anim 2, 3, 189, 20, 6, 20, 6,
+ax_anim 2, 0, 190, 12, 8, 12, 8,
+ax_anim 1, 0, 191, 5, 6, 5, 6,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 1, -8, 1, -8,
+ax_anim 2, 0, 193, 4, -18, 4, -18,
+ax_anim 2, 0, 186, 12, -23, 12, -23,
+ax_anim 3, 0, 187, 23, -23, 23, -23,
+ax_anim 2, 3, 188, 27, -15, 27, -15,
+ax_anim 2, 0, 189, 23, -7, 23, -7,
+ax_anim 1, 0, 190, 11, -2, 11, -2,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -7, -4, -7, -4,
+ax_anim 2, 0, 192, -10, -13, -10, -13,
+ax_anim 2, 0, 193, -8, -19, -8, -19,
+ax_anim 3, 0, 186, 0, -23, 0, -23,
+ax_anim 2, 3, 187, 8, -19, 8, -19,
+ax_anim 2, 0, 188, 10, -13, 10, -13,
+ax_anim 1, 0, 189, 7, -4, 7, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -18, -4, -18,
+ax_anim 2, 0, 186, -12, -23, -12, -23,
+ax_anim 3, 0, 193, -23, -23, -23, -23,
+ax_anim 2, 3, 192, -27, -15, -27, -15,
+ax_anim 2, 0, 191, -23, -7, -23, -7,
+ax_anim 1, 0, 190, -11, -2, -11, -2,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -4, -4, -4, -4,
+ax_anim 2, 0, 186, -10, -5, -10, -5,
+ax_anim 2, 0, 193, -18, -4, -18, -4,
+ax_anim 3, 0, 192, -22, 0, -22, 0,
+ax_anim 2, 3, 191, -20, 6, -20, 6,
+ax_anim 2, 0, 190, -12, 8, -12, 8,
+ax_anim 1, 0, 189, -5, 6, -5, 6,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -11, 2, -11, 2,
+ax_anim 2, 0, 193, -21, 6, -21, 6,
+ax_anim 2, 0, 192, -26, 14, -26, 14,
+ax_anim 3, 0, 191, -24, 21, -24, 21,
+ax_anim 2, 3, 190, -14, 21, -14, 21,
+ax_anim 2, 0, 189, -5, 16, -5, 16,
+ax_anim 1, 0, 188, -2, 7, -2, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 210, 0, -21, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -22, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -22, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMinunAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMinunGfx1:
+.incbin "baserom.gba", 0x12B4A38, 0x200
+sMinunSprites1:
+ax_sprite sMinunGfx1, 0x200
+ax_sprite_terminator
+sMinunGfx2:
+.incbin "baserom.gba", 0x12B4C48, 0x200
+sMinunSprites2:
+ax_sprite sMinunGfx2, 0x200
+ax_sprite_terminator
+sMinunGfx3:
+.incbin "baserom.gba", 0x12B4E58, 0x200
+sMinunSprites3:
+ax_sprite sMinunGfx3, 0x200
+ax_sprite_terminator
+sMinunGfx4:
+.incbin "baserom.gba", 0x12B5068, 0x100
+sMinunSprites4:
+ax_sprite sMinunGfx4, 0x100
+ax_sprite_terminator
+sMinunGfx5:
+.incbin "baserom.gba", 0x12B5178, 0x100
+sMinunSprites5:
+ax_sprite sMinunGfx5, 0x100
+ax_sprite_terminator
+sMinunGfx6:
+.incbin "baserom.gba", 0x12B5288, 0x200
+sMinunSprites6:
+ax_sprite sMinunGfx6, 0x200
+ax_sprite_terminator
+sMinunGfx7:
+.incbin "baserom.gba", 0x12B5498, 0x100
+sMinunSprites7:
+ax_sprite sMinunGfx7, 0x100
+ax_sprite_terminator
+sMinunGfx8:
+.incbin "baserom.gba", 0x12B55A8, 0x100
+sMinunSprites8:
+ax_sprite sMinunGfx8, 0x100
+ax_sprite_terminator
+sMinunGfx9:
+.incbin "baserom.gba", 0x12B56B8, 0x100
+sMinunSprites9:
+ax_sprite sMinunGfx9, 0x100
+ax_sprite_terminator
+sMinunGfx10:
+.incbin "baserom.gba", 0x12B57C8, 0x100
+sMinunSprites10:
+ax_sprite sMinunGfx10, 0x100
+ax_sprite_terminator
+sMinunGfx11:
+.incbin "baserom.gba", 0x12B58D8, 0x100
+sMinunSprites11:
+ax_sprite sMinunGfx11, 0x100
+ax_sprite_terminator
+sMinunGfx12:
+.incbin "baserom.gba", 0x12B59E8, 0x100
+sMinunSprites12:
+ax_sprite sMinunGfx12, 0x100
+ax_sprite_terminator
+sMinunGfx13:
+.incbin "baserom.gba", 0x12B5AF8, 0x200
+sMinunSprites13:
+ax_sprite sMinunGfx13, 0x200
+ax_sprite_terminator
+sMinunGfx14:
+.incbin "baserom.gba", 0x12B5D08, 0x200
+sMinunSprites14:
+ax_sprite sMinunGfx14, 0x200
+ax_sprite_terminator
+sMinunGfx15:
+.incbin "baserom.gba", 0x12B5F18, 0x200
+sMinunSprites15:
+ax_sprite sMinunGfx15, 0x200
+ax_sprite_terminator
+sMinunGfx16:
+.incbin "baserom.gba", 0x12B6128, 0xC0
+sMinunSprites16:
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx16, 0xc0
+ax_sprite_terminator
+sMinunGfx17:
+.incbin "baserom.gba", 0x12B6200, 0x20
+sMinunSprites17:
+ax_sprite sMinunGfx17, 0x20
+ax_sprite_terminator
+sMinunGfx18:
+.incbin "baserom.gba", 0x12B6230, 0x20
+sMinunGfx18_1:
+.incbin "baserom.gba", 0x12B6250, 0xC0
+sMinunSprites18:
+ax_sprite sMinunGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx18_1, 0xc0
+ax_sprite_terminator
+sMinunGfx19:
+.incbin "baserom.gba", 0x12B6330, 0x20
+sMinunGfx19_1:
+.incbin "baserom.gba", 0x12B6350, 0xC0
+sMinunSprites19:
+ax_sprite sMinunGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx19_1, 0xc0
+ax_sprite_terminator
+sMinunGfx20:
+.incbin "baserom.gba", 0x12B6430, 0xE0
+sMinunSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx20, 0xe0
+ax_sprite_terminator
+sMinunGfx21:
+.incbin "baserom.gba", 0x12B6528, 0xC0
+sMinunGfx21_1:
+.incbin "baserom.gba", 0x12B65E8, 0x20
+sMinunSprites21:
+ax_sprite sMinunGfx21, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx21_1, 0x20
+ax_sprite_terminator
+sMinunGfx22:
+.incbin "baserom.gba", 0x12B6628, 0x100
+sMinunSprites22:
+ax_sprite sMinunGfx22, 0x100
+ax_sprite_terminator
+sMinunGfx23:
+.incbin "baserom.gba", 0x12B6738, 0x20
+sMinunSprites23:
+ax_sprite sMinunGfx23, 0x20
+ax_sprite_terminator
+sMinunGfx24:
+.incbin "baserom.gba", 0x12B6768, 0x100
+sMinunSprites24:
+ax_sprite sMinunGfx24, 0x100
+ax_sprite_terminator
+sMinunGfx25:
+.incbin "baserom.gba", 0x12B6878, 0x100
+sMinunSprites25:
+ax_sprite sMinunGfx25, 0x100
+ax_sprite_terminator
+sMinunGfx26:
+.incbin "baserom.gba", 0x12B6988, 0xC0
+sMinunSprites26:
+ax_sprite sMinunGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMinunGfx27:
+.incbin "baserom.gba", 0x12B6A60, 0x20
+sMinunSprites27:
+ax_sprite sMinunGfx27, 0x20
+ax_sprite_terminator
+sMinunGfx28:
+.incbin "baserom.gba", 0x12B6A90, 0xC0
+sMinunSprites28:
+ax_sprite sMinunGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMinunGfx29:
+.incbin "baserom.gba", 0x12B6B68, 0x20
+sMinunSprites29:
+ax_sprite sMinunGfx29, 0x20
+ax_sprite_terminator
+sMinunGfx30:
+.incbin "baserom.gba", 0x12B6B98, 0x200
+sMinunSprites30:
+ax_sprite sMinunGfx30, 0x200
+ax_sprite_terminator
+sMinunGfx31:
+.incbin "baserom.gba", 0x12B6DA8, 0x60
+sMinunGfx31_1:
+.incbin "baserom.gba", 0x12B6E08, 0x40
+sMinunGfx31_2:
+.incbin "baserom.gba", 0x12B6E48, 0x40
+sMinunSprites31:
+ax_sprite 0, 0xa0
+ax_sprite sMinunGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMinunGfx32:
+.incbin "baserom.gba", 0x12B6EC8, 0x200
+sMinunSprites32:
+ax_sprite sMinunGfx32, 0x200
+ax_sprite_terminator
+sMinunGfx33:
+.incbin "baserom.gba", 0x12B70D8, 0x200
+sMinunSprites33:
+ax_sprite sMinunGfx33, 0x200
+ax_sprite_terminator
+sMinunGfx34:
+.incbin "baserom.gba", 0x12B72E8, 0x20
+sMinunGfx34_1:
+.incbin "baserom.gba", 0x12B7308, 0x40
+sMinunGfx34_2:
+.incbin "baserom.gba", 0x12B7348, 0x40
+sMinunGfx34_3:
+.incbin "baserom.gba", 0x12B7388, 0x40
+sMinunSprites34:
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx34, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMinunGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMinunGfx35:
+.incbin "baserom.gba", 0x12B7418, 0x40
+sMinunGfx35_1:
+.incbin "baserom.gba", 0x12B7458, 0x100
+sMinunGfx35_2:
+.incbin "baserom.gba", 0x12B7558, 0x60
+sMinunSprites35:
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx35_2, 0x60
+ax_sprite_terminator
+sMinunGfx36:
+.incbin "baserom.gba", 0x12B75F0, 0x20
+sMinunGfx36_1:
+.incbin "baserom.gba", 0x12B7610, 0x40
+sMinunGfx36_2:
+.incbin "baserom.gba", 0x12B7650, 0x40
+sMinunGfx36_3:
+.incbin "baserom.gba", 0x12B7690, 0x40
+sMinunSprites36:
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx36, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMinunGfx36_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx36_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMinunGfx37:
+.incbin "baserom.gba", 0x12B7720, 0x60
+sMinunGfx37_1:
+.incbin "baserom.gba", 0x12B7780, 0x60
+sMinunGfx37_2:
+.incbin "baserom.gba", 0x12B77E0, 0xE0
+sMinunSprites37:
+ax_sprite sMinunGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx37_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMinunGfx38:
+.incbin "baserom.gba", 0x12B78F8, 0x20
+sMinunGfx38_1:
+.incbin "baserom.gba", 0x12B7918, 0x40
+sMinunGfx38_2:
+.incbin "baserom.gba", 0x12B7958, 0x40
+sMinunGfx38_3:
+.incbin "baserom.gba", 0x12B7998, 0x40
+sMinunSprites38:
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx38, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMinunGfx39:
+.incbin "baserom.gba", 0x12B7A28, 0x200
+sMinunSprites39:
+ax_sprite sMinunGfx39, 0x200
+ax_sprite_terminator
+sMinunGfx40:
+.incbin "baserom.gba", 0x12B7C38, 0x40
+sMinunGfx40_1:
+.incbin "baserom.gba", 0x12B7C78, 0x40
+sMinunGfx40_2:
+.incbin "baserom.gba", 0x12B7CB8, 0x40
+sMinunGfx40_3:
+.incbin "baserom.gba", 0x12B7CF8, 0x20
+sMinunSprites40:
+ax_sprite 0, 0x20
+ax_sprite sMinunGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx40_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMinunGfx40_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMinunGfx40_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMinunGfx41:
+.incbin "baserom.gba", 0x12B7D68, 0x100
+sMinunSprites41:
+ax_sprite sMinunGfx41, 0x100
+ax_sprite_terminator
+sMinunGfx42:
+.incbin "baserom.gba", 0x12B7E78, 0x100
+sMinunSprites42:
+ax_sprite sMinunGfx42, 0x100
+ax_sprite_terminator
+sMinunGfx43:
+.incbin "baserom.gba", 0x12B7F88, 0x200
+sMinunSprites43:
+ax_sprite sMinunGfx43, 0x200
+ax_sprite_terminator
+sMinunGfx44:
+.incbin "baserom.gba", 0x12B8198, 0x200
+sMinunSprites44:
+ax_sprite sMinunGfx44, 0x200
+ax_sprite_terminator
+sMinunGfx45:
+.incbin "baserom.gba", 0x12B83A8, 0x200
+sMinunSprites45:
+ax_sprite sMinunGfx45, 0x200
+ax_sprite_terminator
+sMinunGfx46:
+.incbin "baserom.gba", 0x12B85B8, 0x200
+sMinunSprites46:
+ax_sprite sMinunGfx46, 0x200
+ax_sprite_terminator
+sMinunGfx47:
+.incbin "baserom.gba", 0x12B87C8, 0x200
+sMinunSprites47:
+ax_sprite sMinunGfx47, 0x200
+ax_sprite_terminator
+sAxPosesMinun:
+.4byte sMinunPose1
+.4byte sMinunPose2
+.4byte sMinunPose3
+.4byte sMinunPose4
+.4byte sMinunPose5
+.4byte sMinunPose6
+.4byte sMinunPose7
+.4byte sMinunPose8
+.4byte sMinunPose9
+.4byte sMinunPose10
+.4byte sMinunPose11
+.4byte sMinunPose12
+.4byte sMinunPose13
+.4byte sMinunPose14
+.4byte sMinunPose15
+.4byte sMinunPose16
+.4byte sMinunPose17
+.4byte sMinunPose18
+.4byte sMinunPose19
+.4byte sMinunPose20
+.4byte sMinunPose21
+.4byte sMinunPose22
+.4byte sMinunPose23
+.4byte sMinunPose24
+.4byte sMinunPose25
+.4byte sMinunPose26
+.4byte sMinunPose27
+.4byte sMinunPose28
+.4byte sMinunPose29
+.4byte sMinunPose30
+.4byte sMinunPose31
+.4byte sMinunPose32
+.4byte sMinunPose33
+.4byte sMinunPose34
+.4byte sMinunPose35
+.4byte sMinunPose36
+.4byte sMinunPose37
+.4byte sMinunPose38
+.4byte sMinunPose39
+.4byte sMinunPose40
+.4byte sMinunPose41
+.4byte sMinunPose42
+.4byte sMinunPose43
+.4byte sMinunPose44
+.4byte sMinunPose45
+.4byte sMinunPose46
+.4byte sMinunPose47
+.4byte sMinunPose48
+.4byte sMinunPose49
+.4byte sMinunPose50
+.4byte sMinunPose51
+.4byte sMinunPose52
+.4byte sMinunPose53
+.4byte sMinunPose54
+.4byte sMinunPose55
+.4byte sMinunPose56
+.4byte sMinunPose57
+.4byte sMinunPose58
+.4byte sMinunPose59
+.4byte sMinunPose60
+.4byte sMinunPose61
+.4byte sMinunPose62
+.4byte sMinunPose63
+.4byte sMinunPose64
+.4byte sMinunPose65
+.4byte sMinunPose66
+.4byte sMinunPose67
+.4byte sMinunPose68
+.4byte sMinunPose69
+.4byte sMinunPose70
+.4byte sMinunPose71
+.4byte sMinunPose72
+.4byte sMinunPose73
+.4byte sMinunPose74
+.4byte sMinunPose75
+.4byte sMinunPose76
+.4byte sMinunPose77
+.4byte sMinunPose78
+.4byte sMinunPose79
+.4byte sMinunPose80
+.4byte sMinunPose81
+.4byte sMinunPose82
+.4byte sMinunPose83
+.4byte sMinunPose84
+.4byte sMinunPose85
+.4byte sMinunPose86
+.4byte sMinunPose87
+.4byte sMinunPose88
+.4byte sMinunPose89
+.4byte sMinunPose90
+.4byte sMinunPose91
+.4byte sMinunPose92
+.4byte sMinunPose93
+.4byte sMinunPose94
+.4byte sMinunPose95
+.4byte sMinunPose96
+.4byte sMinunPose97
+.4byte sMinunPose98
+.4byte sMinunPose99
+.4byte sMinunPose100
+.4byte sMinunPose101
+.4byte sMinunPose102
+.4byte sMinunPose103
+.4byte sMinunPose104
+.4byte sMinunPose105
+.4byte sMinunPose106
+.4byte sMinunPose107
+.4byte sMinunPose108
+.4byte sMinunPose109
+.4byte sMinunPose110
+.4byte sMinunPose111
+.4byte sMinunPose112
+.4byte sMinunPose113
+.4byte sMinunPose114
+.4byte sMinunPose115
+.4byte sMinunPose116
+.4byte sMinunPose117
+.4byte sMinunPose118
+.4byte sMinunPose119
+.4byte sMinunPose120
+.4byte sMinunPose121
+.4byte sMinunPose122
+.4byte sMinunPose123
+.4byte sMinunPose124
+.4byte sMinunPose125
+.4byte sMinunPose126
+.4byte sMinunPose127
+.4byte sMinunPose128
+.4byte sMinunPose129
+.4byte sMinunPose130
+.4byte sMinunPose131
+.4byte sMinunPose132
+.4byte sMinunPose133
+.4byte sMinunPose134
+.4byte sMinunPose135
+.4byte sMinunPose136
+.4byte sMinunPose137
+.4byte sMinunPose138
+.4byte sMinunPose139
+.4byte sMinunPose140
+.4byte sMinunPose141
+.4byte sMinunPose142
+.4byte sMinunPose143
+.4byte sMinunPose144
+.4byte sMinunPose145
+.4byte sMinunPose146
+.4byte sMinunPose147
+.4byte sMinunPose148
+.4byte sMinunPose149
+.4byte sMinunPose150
+.4byte sMinunPose151
+.4byte sMinunPose152
+.4byte sMinunPose153
+.4byte sMinunPose154
+.4byte sMinunPose155
+.4byte sMinunPose156
+.4byte sMinunPose157
+.4byte sMinunPose158
+.4byte sMinunPose159
+.4byte sMinunPose160
+.4byte sMinunPose161
+.4byte sMinunPose162
+.4byte sMinunPose163
+.4byte sMinunPose164
+.4byte sMinunPose165
+.4byte sMinunPose166
+.4byte sMinunPose167
+.4byte sMinunPose168
+.4byte sMinunPose169
+.4byte sMinunPose170
+.4byte sMinunPose171
+.4byte sMinunPose172
+.4byte sMinunPose173
+.4byte sMinunPose174
+.4byte sMinunPose175
+.4byte sMinunPose176
+.4byte sMinunPose177
+.4byte sMinunPose178
+.4byte sMinunPose179
+.4byte sMinunPose180
+.4byte sMinunPose181
+.4byte sMinunPose182
+.4byte sMinunPose183
+.4byte sMinunPose184
+.4byte sMinunPose185
+.4byte sMinunPose186
+.4byte sMinunPose187
+.4byte sMinunPose188
+.4byte sMinunPose189
+.4byte sMinunPose190
+.4byte sMinunPose191
+.4byte sMinunPose192
+.4byte sMinunPose193
+.4byte sMinunPose194
+.4byte sMinunPose195
+.4byte sMinunPose196
+.4byte sMinunPose197
+.4byte sMinunPose198
+.4byte sMinunPose199
+.4byte sMinunPose200
+.4byte sMinunPose201
+.4byte sMinunPose202
+.4byte sMinunPose203
+.4byte sMinunPose204
+.4byte sMinunPose205
+.4byte sMinunPose206
+.4byte sMinunPose207
+.4byte sMinunPose208
+.4byte sMinunPose209
+.4byte sMinunPose210
+.4byte sMinunPose211
+.4byte sMinunPose212
+.4byte sMinunPose213
+.4byte sMinunPose214
+.4byte sMinunPose215
+.4byte sMinunPose216
+.4byte sMinunPose217
+.4byte sMinunPose218
+.4byte sMinunPose219
+.4byte sMinunPose220
+.4byte sMinunPose221
+.4byte sMinunPose222
+.4byte sMinunPose223
+.4byte sMinunPose224
+.4byte sMinunPose225
+.4byte sMinunPose226
+.4byte sMinunPose227
+.4byte sMinunPose228
+.4byte sMinunPose229
+.4byte sMinunPose230
+.4byte sMinunPose231
+.4byte sMinunPose232
+.4byte sMinunPose233
+.4byte sMinunPose234
+.4byte sMinunPose235
+.4byte sMinunPose236
+.4byte sMinunPose237
+.4byte sMinunPose238
+.4byte sMinunPose239
+.4byte sMinunPose240
+.4byte sMinunPose241
+.4byte sMinunPose242
+sAxPositionsMinun:
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -9, 	  -5,   -7, 	   3,   -8, 	  -1,   -8
+.2byte    0,   -9, 	  -4,   -8, 	   4,   -7, 	   0,   -8
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -8, 	  -2,   -8, 	   2,   -8
+.2byte    1,   -9, 	   3,   -8, 	  -4,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,  -10, 	   1,   -6, 	   0,   -7, 	  -1,   -6
+.2byte    4,  -10, 	   2,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,  -11, 	  -5,   -8, 	   3,   -8, 	  -1,   -7
+.2byte    3,  -10, 	  -4,  -10, 	   5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -12, 	   5,   -8, 	  -5,   -9, 	   1,   -9
+.2byte   -2,  -12, 	   4,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -4,  -10, 	   3,  -10, 	  -6,   -8, 	  -1,   -7
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,  -10, 	  -2,   -6, 	  -1,   -7, 	   0,   -6
+.2byte   -5,  -10, 	  -3,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -8, 	   1,   -8, 	  -3,   -8
+.2byte   -2,   -9, 	  -4,   -8, 	   3,   -6, 	  -1,   -8
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -9, 	  -5,   -7, 	   3,   -8, 	  -1,   -8
+.2byte    0,   -9, 	  -4,   -8, 	   4,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -8, 	  -2,   -8, 	   2,   -8
+.2byte    1,   -9, 	   3,   -8, 	  -4,   -6, 	   0,   -8
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,  -10, 	   1,   -6, 	   0,   -7, 	  -1,   -6
+.2byte    4,  -10, 	   2,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,  -11, 	  -5,   -8, 	   3,   -8, 	  -1,   -7
+.2byte    3,  -10, 	  -4,  -10, 	   5,   -8, 	   0,   -7
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -12, 	   5,   -8, 	  -5,   -9, 	   1,   -9
+.2byte   -2,  -12, 	   4,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -4,  -10, 	   3,  -10, 	  -6,   -8, 	  -1,   -7
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,  -10, 	  -2,   -6, 	  -1,   -7, 	   0,   -6
+.2byte   -5,  -10, 	  -3,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -8, 	   1,   -8, 	  -3,   -8
+.2byte   -2,   -9, 	  -4,   -8, 	   3,   -6, 	  -1,   -8
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -9, 	  -5,   -7, 	   3,   -8, 	  -1,   -8
+.2byte    0,   -9, 	  -4,   -8, 	   4,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -8, 	  -2,   -8, 	   2,   -8
+.2byte    1,   -9, 	   3,   -8, 	  -4,   -6, 	   0,   -8
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,  -10, 	   1,   -6, 	   0,   -7, 	  -1,   -6
+.2byte    4,  -10, 	   2,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,  -11, 	  -5,   -8, 	   3,   -8, 	  -1,   -7
+.2byte    3,  -10, 	  -4,  -10, 	   5,   -8, 	   0,   -7
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -12, 	   5,   -8, 	  -5,   -9, 	   1,   -9
+.2byte   -2,  -12, 	   4,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -4,  -10, 	   3,  -10, 	  -6,   -8, 	  -1,   -7
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,  -10, 	  -2,   -6, 	  -1,   -7, 	   0,   -6
+.2byte   -5,  -10, 	  -3,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -8, 	   1,   -8, 	  -3,   -8
+.2byte   -2,   -9, 	  -4,   -8, 	   3,   -6, 	  -1,   -8
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    3,   -7, 	  -3,   -5, 	  -3,   -3, 	  -1,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    0,  -11, 	   4,   -5, 	  -5,   -5, 	   0,   -7
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -4,   -7, 	   2,   -5, 	   2,   -3, 	   0,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    3,   -4, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    3,   -4, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    3,   -7, 	  -3,   -5, 	  -3,   -3, 	  -1,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   1,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   1,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    4,   -5, 	  -2,   -3, 	   3,   -1, 	   1,   -5
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    4,   -5, 	  -2,   -3, 	   3,   -1, 	   1,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    0,  -11, 	   4,   -5, 	  -5,   -5, 	   0,   -7
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    0,   -5, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    0,   -5, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -5, 	   1,   -3, 	  -4,   -1, 	  -2,   -5
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -5, 	   1,   -3, 	  -4,   -1, 	  -2,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -4,   -7, 	   2,   -5, 	   2,   -3, 	   0,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -2,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -2,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -4,   -4, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -4,   -4, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte    5,   -5, 	   0,   -1, 	   5,   -2, 	   3,   -4
+.2byte    5,   -4, 	   0,   -1, 	   5,   -2, 	   3,   -3
+.2byte    0,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -7
+.2byte    1,   -8, 	   3,   -7, 	  -3,   -6, 	   0,   -7
+.2byte    3,   -9, 	   3,   -7, 	   2,   -6, 	   0,   -5
+.2byte    1,   -8, 	   0,   -9, 	   5,   -8, 	   0,   -6
+.2byte   -1,  -10, 	   4,   -4, 	  -5,   -4, 	   0,   -6
+.2byte   -2,   -8, 	  -1,   -9, 	  -6,   -8, 	  -1,   -6
+.2byte   -4,   -9, 	  -4,   -7, 	  -3,   -6, 	  -1,   -5
+.2byte   -2,   -8, 	  -4,   -7, 	   2,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte    1,   -6, 	  -3,   -5, 	   5,   -4, 	   1,   -5
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    1,   -6, 	   3,   -5, 	  -4,   -3, 	   0,   -5
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,   -8, 	   2,   -7, 	  -2,   -4, 	   0,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    3,   -8, 	  -4,   -8, 	   5,   -6, 	   0,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte   -2,   -9, 	   4,   -6, 	  -6,   -5, 	  -2,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -4,   -8, 	   3,   -8, 	  -6,   -6, 	  -1,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,   -8, 	  -3,   -7, 	   1,   -4, 	  -1,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -2,   -6, 	  -4,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte    4,   -7, 	  -2,   -5, 	  -2,   -3, 	   0,   -4
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    0,  -10, 	   4,   -4, 	  -5,   -4, 	   0,   -6
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte   -5,   -7, 	   1,   -5, 	   1,   -3, 	  -1,   -4
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   3,   -5, 	  -1,   -5
+.2byte    0,   -6, 	  -4,   -5, 	   4,   -4, 	   0,   -5
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -6, 	   5,   -5, 	  -2,   -5, 	   2,   -5
+.2byte    1,   -6, 	   3,   -5, 	  -4,   -3, 	   0,   -5
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,   -7, 	   1,   -3, 	   0,   -4, 	  -1,   -3
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -3
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,   -8, 	  -5,   -5, 	   3,   -5, 	  -1,   -4
+.2byte    3,   -7, 	  -4,   -7, 	   5,   -5, 	   0,   -4
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,   -9, 	   5,   -5, 	  -5,   -6, 	   1,   -6
+.2byte   -2,   -9, 	   4,   -6, 	  -6,   -5, 	  -2,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,   -8, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte   -4,   -7, 	   3,   -7, 	  -6,   -5, 	  -1,   -4
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -4, 	   0,   -3
+.2byte   -5,   -7, 	  -3,   -6, 	   1,   -3, 	  -1,   -3
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -5, 	  -3,   -5
+.2byte   -2,   -6, 	  -4,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -5,   -7, 	   1,   -5, 	   1,   -3, 	  -1,   -4
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte    0,  -10, 	   4,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    4,   -7, 	  -2,   -5, 	  -2,   -3, 	   0,   -4
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+sMinunAnimTable1:
+.4byte sMinunAnims_1_1
+.4byte sMinunAnims_1_2
+.4byte sMinunAnims_1_3
+.4byte sMinunAnims_1_4
+.4byte sMinunAnims_1_5
+.4byte sMinunAnims_1_6
+.4byte sMinunAnims_1_7
+.4byte sMinunAnims_1_8
+sMinunAnimTable2:
+.4byte sMinunAnims_2_1
+.4byte sMinunAnims_2_2
+.4byte sMinunAnims_2_3
+.4byte sMinunAnims_2_4
+.4byte sMinunAnims_2_5
+.4byte sMinunAnims_2_6
+.4byte sMinunAnims_2_7
+.4byte sMinunAnims_2_8
+sMinunAnimTable3:
+.4byte sMinunAnims_3_1
+.4byte sMinunAnims_3_2
+.4byte sMinunAnims_3_3
+.4byte sMinunAnims_3_4
+.4byte sMinunAnims_3_5
+.4byte sMinunAnims_3_6
+.4byte sMinunAnims_3_7
+.4byte sMinunAnims_3_8
+sMinunAnimTable4:
+.4byte sMinunAnims_4_1
+.4byte sMinunAnims_4_2
+.4byte sMinunAnims_4_3
+.4byte sMinunAnims_4_4
+.4byte sMinunAnims_4_5
+.4byte sMinunAnims_4_6
+.4byte sMinunAnims_4_7
+.4byte sMinunAnims_4_8
+sMinunAnimTable5:
+.4byte sMinunAnims_5_1
+.4byte sMinunAnims_5_2
+.4byte sMinunAnims_5_3
+.4byte sMinunAnims_5_4
+.4byte sMinunAnims_5_5
+.4byte sMinunAnims_5_6
+.4byte sMinunAnims_5_7
+.4byte sMinunAnims_5_8
+sMinunAnimTable6:
+.4byte sMinunAnims_6_1
+.4byte sMinunAnims_6_1
+.4byte sMinunAnims_6_1
+.4byte sMinunAnims_6_1
+.4byte sMinunAnims_6_1
+.4byte sMinunAnims_6_1
+.4byte sMinunAnims_6_1
+.4byte sMinunAnims_6_1
+sMinunAnimTable7:
+.4byte sMinunAnims_7_1
+.4byte sMinunAnims_7_2
+.4byte sMinunAnims_7_3
+.4byte sMinunAnims_7_4
+.4byte sMinunAnims_7_5
+.4byte sMinunAnims_7_6
+.4byte sMinunAnims_7_7
+.4byte sMinunAnims_7_8
+sMinunAnimTable8:
+.4byte sMinunAnims_8_1
+.4byte sMinunAnims_8_2
+.4byte sMinunAnims_8_3
+.4byte sMinunAnims_8_4
+.4byte sMinunAnims_8_5
+.4byte sMinunAnims_8_6
+.4byte sMinunAnims_8_7
+.4byte sMinunAnims_8_8
+sMinunAnimTable9:
+.4byte sMinunAnims_9_1
+.4byte sMinunAnims_9_2
+.4byte sMinunAnims_9_3
+.4byte sMinunAnims_9_4
+.4byte sMinunAnims_9_5
+.4byte sMinunAnims_9_6
+.4byte sMinunAnims_9_7
+.4byte sMinunAnims_9_8
+sMinunAnimTable10:
+.4byte sMinunAnims_10_1
+.4byte sMinunAnims_10_2
+.4byte sMinunAnims_10_3
+.4byte sMinunAnims_10_4
+.4byte sMinunAnims_10_5
+.4byte sMinunAnims_10_6
+.4byte sMinunAnims_10_7
+.4byte sMinunAnims_10_8
+sMinunAnimTable11:
+.4byte sMinunAnims_11_1
+.4byte sMinunAnims_11_2
+.4byte sMinunAnims_11_3
+.4byte sMinunAnims_11_4
+.4byte sMinunAnims_11_5
+.4byte sMinunAnims_11_6
+.4byte sMinunAnims_11_7
+.4byte sMinunAnims_11_8
+sMinunAnimTable12:
+.4byte sMinunAnims_12_1
+.4byte sMinunAnims_12_2
+.4byte sMinunAnims_12_3
+.4byte sMinunAnims_12_4
+.4byte sMinunAnims_12_5
+.4byte sMinunAnims_12_6
+.4byte sMinunAnims_12_7
+.4byte sMinunAnims_12_8
+sMinunAnimTable13:
+.4byte sMinunAnims_13_1
+.4byte sMinunAnims_13_2
+.4byte sMinunAnims_13_3
+.4byte sMinunAnims_13_4
+.4byte sMinunAnims_13_5
+.4byte sMinunAnims_13_6
+.4byte sMinunAnims_13_7
+.4byte sMinunAnims_13_8
+sAxAnimationsMinun:
+.4byte sMinunAnimTable1
+.4byte sMinunAnimTable2
+.4byte sMinunAnimTable3
+.4byte sMinunAnimTable4
+.4byte sMinunAnimTable5
+.4byte sMinunAnimTable6
+.4byte sMinunAnimTable7
+.4byte sMinunAnimTable8
+.4byte sMinunAnimTable9
+.4byte sMinunAnimTable10
+.4byte sMinunAnimTable11
+.4byte sMinunAnimTable12
+.4byte sMinunAnimTable13
+sAxSpritesMinun:
+.4byte sMinunSprites1
+.4byte sMinunSprites2
+.4byte sMinunSprites3
+.4byte sMinunSprites4
+.4byte sMinunSprites5
+.4byte sMinunSprites6
+.4byte sMinunSprites7
+.4byte sMinunSprites8
+.4byte sMinunSprites9
+.4byte sMinunSprites10
+.4byte sMinunSprites11
+.4byte sMinunSprites12
+.4byte sMinunSprites13
+.4byte sMinunSprites14
+.4byte sMinunSprites15
+.4byte sMinunSprites16
+.4byte sMinunSprites17
+.4byte sMinunSprites18
+.4byte sMinunSprites19
+.4byte sMinunSprites20
+.4byte sMinunSprites21
+.4byte sMinunSprites22
+.4byte sMinunSprites23
+.4byte sMinunSprites24
+.4byte sMinunSprites25
+.4byte sMinunSprites26
+.4byte sMinunSprites27
+.4byte sMinunSprites28
+.4byte sMinunSprites29
+.4byte sMinunSprites30
+.4byte sMinunSprites31
+.4byte sMinunSprites32
+.4byte sMinunSprites33
+.4byte sMinunSprites34
+.4byte sMinunSprites35
+.4byte sMinunSprites36
+.4byte sMinunSprites37
+.4byte sMinunSprites38
+.4byte sMinunSprites39
+.4byte sMinunSprites40
+.4byte sMinunSprites41
+.4byte sMinunSprites42
+.4byte sMinunSprites43
+.4byte sMinunSprites44
+.4byte sMinunSprites45
+.4byte sMinunSprites46
+.4byte sMinunSprites47
+sAxMainMinun:
+ax_main sAxPosesMinun, sAxAnimationsMinun, 13, sAxSpritesMinun, sAxPositionsMinun

--- a/data/ax/misdreavus.inc
+++ b/data/ax/misdreavus.inc
@@ -1,0 +1,2891 @@
+.global gAxMisdreavus
+gAxMisdreavus:
+ax_siro sAxMainMisdreavus
+sMisdreavusPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose4:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose5:
+ax_pose 4, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose6:
+ax_pose 5, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose7:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose8:
+ax_pose 7, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose9:
+ax_pose 8, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose10:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose11:
+ax_pose 10, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose12:
+ax_pose 11, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose16:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose17:
+ax_pose 10, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose18:
+ax_pose 11, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose22:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose23:
+ax_pose 4, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose25:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose26:
+ax_pose 1, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose27:
+ax_pose 2, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose28:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose29:
+ax_pose 4, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose30:
+ax_pose 5, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose31:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose32:
+ax_pose 7, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose33:
+ax_pose 8, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose34:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose35:
+ax_pose 10, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose36:
+ax_pose 11, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose37:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose38:
+ax_pose 13, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose39:
+ax_pose 14, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose40:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose41:
+ax_pose 10, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose42:
+ax_pose 11, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose43:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose44:
+ax_pose 7, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose45:
+ax_pose 8, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose46:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose47:
+ax_pose 4, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose48:
+ax_pose 5, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose49:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose50:
+ax_pose 1, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose51:
+ax_pose 2, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose52:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose53:
+ax_pose 4, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose54:
+ax_pose 5, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose55:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose56:
+ax_pose 7, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose57:
+ax_pose 8, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose58:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose59:
+ax_pose 10, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose60:
+ax_pose 11, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose61:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose62:
+ax_pose 13, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose63:
+ax_pose 14, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose64:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose65:
+ax_pose 10, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose66:
+ax_pose 11, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose67:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose68:
+ax_pose 7, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose69:
+ax_pose 8, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose70:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose71:
+ax_pose 4, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose72:
+ax_pose 5, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose73:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose74:
+ax_pose 1, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose75:
+ax_pose 2, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose76:
+ax_pose 15, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose77:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose78:
+ax_pose 4, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose79:
+ax_pose 5, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose80:
+ax_pose 16, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose81:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose82:
+ax_pose 7, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose83:
+ax_pose 8, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose84:
+ax_pose 17, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose85:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose86:
+ax_pose 10, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose87:
+ax_pose 11, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose88:
+ax_pose 18, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose89:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose90:
+ax_pose 13, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose91:
+ax_pose 14, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose92:
+ax_pose 19, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose93:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose94:
+ax_pose 10, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose95:
+ax_pose 11, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose96:
+ax_pose 18, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose97:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose98:
+ax_pose 7, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose99:
+ax_pose 8, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose100:
+ax_pose 17, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose101:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose102:
+ax_pose 4, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose103:
+ax_pose 5, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose104:
+ax_pose 16, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose105:
+ax_pose 20, 0x01f4, 0x00f9, 0xbc00
+ax_pose -1, 0x01f4, 0x00ff, 0xbc00
+ax_pose 0, 0x01e6, 0x80f4, 0xbc01
+ax_pose_terminator
+sMisdreavusPose106:
+ax_pose 21, 0x01ee, 0x40f5, 0xbc00
+ax_pose -1, 0x01ee, 0x40fb, 0xbc00
+ax_pose 0, 0x01e6, 0x80f4, 0xbc04
+ax_pose_terminator
+sMisdreavusPose107:
+ax_pose 22, 0x01ee, 0x40f5, 0xbc00
+ax_pose -1, 0x01ee, 0x40fb, 0xbc00
+ax_pose 0, 0x01e6, 0x80f4, 0xbc04
+ax_pose_terminator
+sMisdreavusPose108:
+ax_pose 23, 0x01f4, 0x00f9, 0xbc00
+ax_pose -1, 0x01f4, 0x00ff, 0xbc00
+ax_pose 0, 0x01e6, 0x80f4, 0xbc01
+ax_pose_terminator
+sMisdreavusPose109:
+ax_pose 24, 0x01f4, 0x00f9, 0xbc00
+ax_pose -1, 0x01f4, 0x00ff, 0xbc00
+ax_pose 0, 0x01e6, 0x80f4, 0xbc01
+ax_pose_terminator
+sMisdreavusPose110:
+ax_pose 25, 0x01ee, 0x40f5, 0xbc00
+ax_pose -1, 0x01ee, 0x40fb, 0xbc00
+ax_pose 0, 0x01e6, 0x80f4, 0xbc04
+ax_pose_terminator
+sMisdreavusPose111:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose112:
+ax_pose 20, 0x01f4, 0x00fe, 0xbc00
+ax_pose -1, 0x01f2, 0x0103, 0xbc00
+ax_pose 3, 0x01e6, 0x90ed, 0xbc01
+ax_pose_terminator
+sMisdreavusPose113:
+ax_pose 21, 0x01ee, 0x40fa, 0xbc00
+ax_pose -1, 0x01ec, 0x40ff, 0xbc00
+ax_pose 3, 0x01e6, 0x90ed, 0xbc04
+ax_pose_terminator
+sMisdreavusPose114:
+ax_pose 22, 0x01ee, 0x40fa, 0xbc00
+ax_pose -1, 0x01ec, 0x40ff, 0xbc00
+ax_pose 3, 0x01e6, 0x90ed, 0xbc04
+ax_pose_terminator
+sMisdreavusPose115:
+ax_pose 23, 0x01f4, 0x00fe, 0xbc00
+ax_pose -1, 0x01f2, 0x0103, 0xbc00
+ax_pose 3, 0x01e6, 0x90ed, 0xbc01
+ax_pose_terminator
+sMisdreavusPose116:
+ax_pose 24, 0x01f4, 0x00fe, 0xbc00
+ax_pose -1, 0x01f2, 0x0103, 0xbc00
+ax_pose 3, 0x01e6, 0x90ed, 0xbc01
+ax_pose_terminator
+sMisdreavusPose117:
+ax_pose 25, 0x01ee, 0x40fa, 0xbc00
+ax_pose -1, 0x01ec, 0x40ff, 0xbc00
+ax_pose 3, 0x01e6, 0x90ed, 0xbc04
+ax_pose_terminator
+sMisdreavusPose118:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose119:
+ax_pose 20, 0x01f2, 0x0102, 0xbc00
+ax_pose 6, 0x01e6, 0x90ed, 0xbc01
+ax_pose -1, 0x01f0, 0x0105, 0xbc00
+ax_pose_terminator
+sMisdreavusPose120:
+ax_pose 21, 0x01ec, 0x40fe, 0xbc00
+ax_pose 6, 0x01e6, 0x90ed, 0xbc04
+ax_pose -1, 0x01ea, 0x4101, 0xbc00
+ax_pose_terminator
+sMisdreavusPose121:
+ax_pose 22, 0x01ec, 0x40fe, 0xbc00
+ax_pose 6, 0x01e6, 0x90ed, 0xbc04
+ax_pose -1, 0x01ea, 0x4101, 0xbc00
+ax_pose_terminator
+sMisdreavusPose122:
+ax_pose 23, 0x01f2, 0x0102, 0xbc00
+ax_pose 6, 0x01e6, 0x90ed, 0xbc01
+ax_pose -1, 0x01f0, 0x0105, 0xbc00
+ax_pose_terminator
+sMisdreavusPose123:
+ax_pose 24, 0x01f2, 0x0102, 0xbc00
+ax_pose 6, 0x01e6, 0x90ed, 0xbc01
+ax_pose -1, 0x01f0, 0x0105, 0xbc00
+ax_pose_terminator
+sMisdreavusPose124:
+ax_pose 25, 0x01ec, 0x40fe, 0xbc00
+ax_pose 6, 0x01e6, 0x90ed, 0xbc04
+ax_pose -1, 0x01ea, 0x4101, 0xbc00
+ax_pose_terminator
+sMisdreavusPose125:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose126:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose 20, 0x01e7, 0x00fc, 0xbc10
+ax_pose -1, 0x01f1, 0x0104, 0xbc10
+ax_pose_terminator
+sMisdreavusPose127:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose 21, 0x01e1, 0x40f8, 0xbc10
+ax_pose -1, 0x01eb, 0x4100, 0xbc10
+ax_pose_terminator
+sMisdreavusPose128:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose 22, 0x01e1, 0x40f8, 0xbc10
+ax_pose -1, 0x01eb, 0x4100, 0xbc10
+ax_pose_terminator
+sMisdreavusPose129:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose 23, 0x01e7, 0x00fc, 0xbc10
+ax_pose -1, 0x01f1, 0x0104, 0xbc10
+ax_pose_terminator
+sMisdreavusPose130:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose 24, 0x01e7, 0x00fc, 0xbc10
+ax_pose -1, 0x01f1, 0x0104, 0xbc10
+ax_pose_terminator
+sMisdreavusPose131:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose 25, 0x01e1, 0x40f8, 0xbc10
+ax_pose -1, 0x01eb, 0x4100, 0xbc10
+ax_pose_terminator
+sMisdreavusPose132:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose133:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose 20, 0x01eb, 0x00f4, 0xbc10
+ax_pose -1, 0x01eb, 0x0103, 0xbc10
+ax_pose_terminator
+sMisdreavusPose134:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose 21, 0x01e5, 0x40f0, 0xbc10
+ax_pose -1, 0x01e5, 0x40ff, 0xbc10
+ax_pose_terminator
+sMisdreavusPose135:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose 22, 0x01e5, 0x40f0, 0xbc10
+ax_pose -1, 0x01e5, 0x40ff, 0xbc10
+ax_pose_terminator
+sMisdreavusPose136:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose 23, 0x01eb, 0x00f4, 0xbc10
+ax_pose -1, 0x01eb, 0x0103, 0xbc10
+ax_pose_terminator
+sMisdreavusPose137:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose 24, 0x01eb, 0x00f4, 0xbc10
+ax_pose -1, 0x01eb, 0x0103, 0xbc10
+ax_pose_terminator
+sMisdreavusPose138:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose 25, 0x01e5, 0x40f0, 0xbc10
+ax_pose -1, 0x01e5, 0x40ff, 0xbc10
+ax_pose_terminator
+sMisdreavusPose139:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose140:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose 20, 0x01e7, 0x10fc, 0xbc10
+ax_pose -1, 0x01f1, 0x10f4, 0xbc10
+ax_pose_terminator
+sMisdreavusPose141:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose 21, 0x01e1, 0x50f8, 0xbc10
+ax_pose -1, 0x01eb, 0x50f0, 0xbc10
+ax_pose_terminator
+sMisdreavusPose142:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose 22, 0x01e1, 0x50f8, 0xbc10
+ax_pose -1, 0x01eb, 0x50f0, 0xbc10
+ax_pose_terminator
+sMisdreavusPose143:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose 23, 0x01e7, 0x10fc, 0xbc10
+ax_pose -1, 0x01f1, 0x10f4, 0xbc10
+ax_pose_terminator
+sMisdreavusPose144:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose 24, 0x01e7, 0x10fc, 0xbc10
+ax_pose -1, 0x01f1, 0x10f4, 0xbc10
+ax_pose_terminator
+sMisdreavusPose145:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose 25, 0x01e1, 0x50f8, 0xbc10
+ax_pose -1, 0x01eb, 0x50f0, 0xbc10
+ax_pose_terminator
+sMisdreavusPose146:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose147:
+ax_pose 20, 0x01f2, 0x10f7, 0xbc00
+ax_pose 6, 0x01e6, 0x80f4, 0xbc01
+ax_pose -1, 0x01f0, 0x10f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose148:
+ax_pose 21, 0x01ec, 0x50f3, 0xbc00
+ax_pose 6, 0x01e6, 0x80f4, 0xbc04
+ax_pose -1, 0x01ea, 0x50f0, 0xbc00
+ax_pose_terminator
+sMisdreavusPose149:
+ax_pose 22, 0x01ec, 0x50f3, 0xbc00
+ax_pose 6, 0x01e6, 0x80f4, 0xbc04
+ax_pose -1, 0x01ea, 0x50f0, 0xbc00
+ax_pose_terminator
+sMisdreavusPose150:
+ax_pose 23, 0x01f2, 0x10f7, 0xbc00
+ax_pose 6, 0x01e6, 0x80f4, 0xbc01
+ax_pose -1, 0x01f0, 0x10f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose151:
+ax_pose 24, 0x01f2, 0x10f7, 0xbc00
+ax_pose 6, 0x01e6, 0x80f4, 0xbc01
+ax_pose -1, 0x01f0, 0x10f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose152:
+ax_pose 25, 0x01ec, 0x50f3, 0xbc00
+ax_pose 6, 0x01e6, 0x80f4, 0xbc04
+ax_pose -1, 0x01ea, 0x50f0, 0xbc00
+ax_pose_terminator
+sMisdreavusPose153:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose154:
+ax_pose 20, 0x01f4, 0x10fb, 0xbc00
+ax_pose -1, 0x01f2, 0x10f6, 0xbc00
+ax_pose 3, 0x01e6, 0x80f4, 0xbc01
+ax_pose_terminator
+sMisdreavusPose155:
+ax_pose 21, 0x01ee, 0x50f7, 0xbc00
+ax_pose -1, 0x01ec, 0x50f2, 0xbc00
+ax_pose 3, 0x01e6, 0x80f4, 0xbc04
+ax_pose_terminator
+sMisdreavusPose156:
+ax_pose 22, 0x01ee, 0x50f7, 0xbc00
+ax_pose -1, 0x01ec, 0x50f2, 0xbc00
+ax_pose 3, 0x01e6, 0x80f4, 0xbc04
+ax_pose_terminator
+sMisdreavusPose157:
+ax_pose 23, 0x01f4, 0x10fb, 0xbc00
+ax_pose -1, 0x01f2, 0x10f6, 0xbc00
+ax_pose 3, 0x01e6, 0x80f4, 0xbc01
+ax_pose_terminator
+sMisdreavusPose158:
+ax_pose 24, 0x01f4, 0x10fb, 0xbc00
+ax_pose -1, 0x01f2, 0x10f6, 0xbc00
+ax_pose 3, 0x01e6, 0x80f4, 0xbc01
+ax_pose_terminator
+sMisdreavusPose159:
+ax_pose 25, 0x01ee, 0x50f7, 0xbc00
+ax_pose -1, 0x01ec, 0x50f2, 0xbc00
+ax_pose 3, 0x01e6, 0x80f4, 0xbc04
+ax_pose_terminator
+sMisdreavusPose160:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose161:
+ax_pose 26, 0x01e3, 0x80f0, 0xbc00
+ax_pose_terminator
+sMisdreavusPose162:
+ax_pose 27, 0x01e3, 0x80f0, 0xbc00
+ax_pose_terminator
+sMisdreavusPose163:
+ax_pose 28, 0x01de, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose164:
+ax_pose 29, 0x01de, 0x90e9, 0xbc00
+ax_pose_terminator
+sMisdreavusPose165:
+ax_pose 30, 0x01e1, 0x90ea, 0xbc00
+ax_pose_terminator
+sMisdreavusPose166:
+ax_pose 31, 0x01de, 0x90ea, 0xbc00
+ax_pose_terminator
+sMisdreavusPose167:
+ax_pose 32, 0x01df, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose168:
+ax_pose 31, 0x01de, 0x80f6, 0xbc00
+ax_pose_terminator
+sMisdreavusPose169:
+ax_pose 30, 0x01e1, 0x80f6, 0xbc00
+ax_pose_terminator
+sMisdreavusPose170:
+ax_pose 29, 0x01de, 0x80f7, 0xbc00
+ax_pose_terminator
+sMisdreavusPose171:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose172:
+ax_pose 1, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose173:
+ax_pose 2, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose174:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose175:
+ax_pose 4, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose176:
+ax_pose 5, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose177:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose178:
+ax_pose 7, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose179:
+ax_pose 8, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose180:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose181:
+ax_pose 10, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose182:
+ax_pose 11, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose183:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose184:
+ax_pose 13, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose185:
+ax_pose 14, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose186:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose187:
+ax_pose 10, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose188:
+ax_pose 11, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose189:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose190:
+ax_pose 7, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose191:
+ax_pose 8, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose192:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose193:
+ax_pose 4, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose194:
+ax_pose 5, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose195:
+ax_pose 15, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose196:
+ax_pose 16, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose197:
+ax_pose 17, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose198:
+ax_pose 18, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose199:
+ax_pose 19, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose200:
+ax_pose 18, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose201:
+ax_pose 17, 0x01e6, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose202:
+ax_pose 16, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose203:
+ax_pose 15, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose204:
+ax_pose 16, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose205:
+ax_pose 17, 0x01e6, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose206:
+ax_pose 18, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose207:
+ax_pose 19, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose208:
+ax_pose 18, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose209:
+ax_pose 17, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose210:
+ax_pose 16, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose211:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose212:
+ax_pose 1, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose213:
+ax_pose 2, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose214:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose215:
+ax_pose 4, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose216:
+ax_pose 5, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose217:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose218:
+ax_pose 7, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose219:
+ax_pose 8, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose220:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose221:
+ax_pose 10, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose222:
+ax_pose 11, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose223:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose224:
+ax_pose 13, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose225:
+ax_pose 14, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose226:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose227:
+ax_pose 10, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose228:
+ax_pose 11, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose229:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose230:
+ax_pose 7, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose231:
+ax_pose 8, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose232:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose233:
+ax_pose 4, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose234:
+ax_pose 5, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose235:
+ax_pose 2, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose236:
+ax_pose 5, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose237:
+ax_pose 8, 0x01e6, 0x80f5, 0xbc00
+ax_pose_terminator
+sMisdreavusPose238:
+ax_pose 11, 0x01e7, 0x80f5, 0xbc00
+ax_pose_terminator
+sMisdreavusPose239:
+ax_pose 14, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose240:
+ax_pose 11, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose241:
+ax_pose 8, 0x01e6, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose242:
+ax_pose 5, 0x01e6, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose243:
+ax_pose 0, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose244:
+ax_pose 3, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose245:
+ax_pose 6, 0x01e6, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose246:
+ax_pose 9, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose247:
+ax_pose 12, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sMisdreavusPose248:
+ax_pose 9, 0x01e7, 0x90ec, 0xbc00
+ax_pose_terminator
+sMisdreavusPose249:
+ax_pose 6, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+sMisdreavusPose250:
+ax_pose 3, 0x01e6, 0x90ed, 0xbc00
+ax_pose_terminator
+.align 2
+sMisdreavusAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 0, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 3, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 6, 0, 2, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 9, 0, 2, 0, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 12, 0, 2, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 15, 0, 2, 0, 0,
+ax_anim 6, 0, 17, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 18, 0, 2, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 21, 0, 2, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 6, 0, 6,
+ax_anim 1, 0, 24, 0, 13, 0, 12,
+ax_anim 2, 0, 25, 0, 24, 0, 22,
+ax_anim 2, 1, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 26, 0, 24, 0, 22,
+ax_anim 2, 0, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 25, 0, 10, 0, 10,
+ax_anim_terminator
+sMisdreavusAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 6, 8, 6, 8,
+ax_anim 1, 0, 27, 13, 16, 13, 15,
+ax_anim 2, 0, 28, 20, 25, 20, 23,
+ax_anim 2, 1, 27, 21, 24, 21, 22,
+ax_anim 2, 0, 29, 20, 25, 20, 23,
+ax_anim 2, 0, 27, 21, 24, 21, 22,
+ax_anim 2, 0, 28, 10, 12, 10, 12,
+ax_anim_terminator
+sMisdreavusAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 6, 0, 6, 0,
+ax_anim 1, 0, 30, 13, 1, 13, 0,
+ax_anim 2, 0, 31, 20, 2, 20, 0,
+ax_anim 2, 1, 30, 20, 3, 20, 1,
+ax_anim 2, 0, 32, 20, 2, 20, 0,
+ax_anim 2, 0, 30, 20, 3, 20, 1,
+ax_anim 2, 0, 31, 10, 0, 10, 0,
+ax_anim_terminator
+sMisdreavusAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 6, -6, 6, -6,
+ax_anim 1, 0, 33, 14, -13, 14, -14,
+ax_anim 2, 0, 34, 20, -18, 20, -20,
+ax_anim 2, 1, 33, 21, -17, 21, -19,
+ax_anim 2, 0, 35, 20, -18, 20, -20,
+ax_anim 2, 0, 33, 21, -17, 21, -19,
+ax_anim 2, 0, 34, 10, -10, 10, -10,
+ax_anim_terminator
+sMisdreavusAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -6, 0, -6,
+ax_anim 1, 0, 36, 0, -13, 0, -14,
+ax_anim 2, 0, 37, 0, -18, 0, -20,
+ax_anim 2, 1, 36, -1, -18, -1, -20,
+ax_anim 2, 0, 38, 0, -18, 0, -20,
+ax_anim 2, 0, 36, -1, -18, -1, -20,
+ax_anim 2, 0, 37, 0, -10, 0, -10,
+ax_anim_terminator
+sMisdreavusAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -6, -6, -6, -6,
+ax_anim 1, 0, 39, -14, -13, -14, -14,
+ax_anim 2, 0, 40, -20, -18, -20, -20,
+ax_anim 2, 1, 39, -21, -17, -21, -19,
+ax_anim 2, 0, 41, -20, -18, -20, -20,
+ax_anim 2, 0, 39, -21, -17, -21, -19,
+ax_anim 2, 0, 40, -10, -10, -10, -10,
+ax_anim_terminator
+sMisdreavusAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -6, 0, -6, 0,
+ax_anim 1, 0, 42, -13, 1, -13, 0,
+ax_anim 2, 0, 43, -20, 2, -20, 0,
+ax_anim 2, 1, 42, -20, 3, -20, 1,
+ax_anim 2, 0, 44, -20, 2, -20, 0,
+ax_anim 2, 0, 42, -20, 3, -20, 1,
+ax_anim 2, 0, 43, -10, 0, -10, 0,
+ax_anim_terminator
+sMisdreavusAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -6, 8, -6, 8,
+ax_anim 1, 0, 45, -13, 16, -13, 15,
+ax_anim 2, 0, 46, -20, 25, -20, 23,
+ax_anim 2, 1, 45, -21, 24, -21, 22,
+ax_anim 2, 0, 47, -20, 25, -20, 23,
+ax_anim 2, 0, 45, -21, 24, -21, 22,
+ax_anim 2, 0, 46, -10, 12, -10, 12,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 6, 0, 6,
+ax_anim 1, 0, 48, 0, 13, 0, 12,
+ax_anim 2, 0, 49, 0, 24, 0, 22,
+ax_anim 2, 1, 48, 1, 24, 1, 22,
+ax_anim 2, 0, 50, 0, 24, 0, 22,
+ax_anim 2, 0, 48, 1, 24, 1, 22,
+ax_anim 2, 0, 49, 0, 10, 0, 10,
+ax_anim_terminator
+sMisdreavusAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 6, 8, 6, 8,
+ax_anim 1, 0, 51, 13, 16, 13, 15,
+ax_anim 2, 0, 52, 20, 25, 20, 23,
+ax_anim 2, 1, 51, 21, 24, 21, 22,
+ax_anim 2, 0, 53, 20, 25, 20, 23,
+ax_anim 2, 0, 51, 21, 24, 21, 22,
+ax_anim 2, 0, 52, 10, 12, 10, 12,
+ax_anim_terminator
+sMisdreavusAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 6, 0, 6, 0,
+ax_anim 1, 0, 54, 13, 1, 13, 0,
+ax_anim 2, 0, 55, 20, 2, 20, 0,
+ax_anim 2, 1, 54, 20, 3, 20, 1,
+ax_anim 2, 0, 56, 20, 2, 20, 0,
+ax_anim 2, 0, 54, 20, 3, 20, 1,
+ax_anim 2, 0, 55, 10, 0, 10, 0,
+ax_anim_terminator
+sMisdreavusAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 6, -6, 6, -6,
+ax_anim 1, 0, 57, 14, -13, 14, -14,
+ax_anim 2, 0, 58, 20, -18, 20, -20,
+ax_anim 2, 1, 57, 21, -17, 21, -19,
+ax_anim 2, 0, 59, 20, -18, 20, -20,
+ax_anim 2, 0, 57, 21, -17, 21, -19,
+ax_anim 2, 0, 58, 10, -10, 10, -10,
+ax_anim_terminator
+sMisdreavusAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -6, 0, -6,
+ax_anim 1, 0, 60, 0, -13, 0, -14,
+ax_anim 2, 0, 61, 0, -18, 0, -20,
+ax_anim 2, 1, 60, -1, -18, -1, -20,
+ax_anim 2, 0, 62, 0, -18, 0, -20,
+ax_anim 2, 0, 60, -1, -18, -1, -20,
+ax_anim 2, 0, 61, 0, -10, 0, -10,
+ax_anim_terminator
+sMisdreavusAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 65, -6, -6, -6, -6,
+ax_anim 1, 0, 63, -14, -13, -14, -14,
+ax_anim 2, 0, 64, -20, -18, -20, -20,
+ax_anim 2, 1, 63, -21, -17, -21, -19,
+ax_anim 2, 0, 65, -20, -18, -20, -20,
+ax_anim 2, 0, 63, -21, -17, -21, -19,
+ax_anim 2, 0, 64, -10, -10, -10, -10,
+ax_anim_terminator
+sMisdreavusAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -6, 0, -6, 0,
+ax_anim 1, 0, 66, -13, 1, -13, 0,
+ax_anim 2, 0, 67, -20, 2, -20, 0,
+ax_anim 2, 1, 66, -20, 3, -20, 1,
+ax_anim 2, 0, 68, -20, 2, -20, 0,
+ax_anim 2, 0, 66, -20, 3, -20, 1,
+ax_anim 2, 0, 67, -10, 0, -10, 0,
+ax_anim_terminator
+sMisdreavusAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -6, 8, -6, 8,
+ax_anim 1, 0, 69, -13, 16, -13, 15,
+ax_anim 2, 0, 70, -20, 25, -20, 23,
+ax_anim 2, 1, 69, -21, 24, -21, 22,
+ax_anim 2, 0, 71, -20, 25, -20, 23,
+ax_anim 2, 0, 69, -21, 24, -21, 22,
+ax_anim 2, 0, 70, -10, 12, -10, 12,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 3, 0, 73, 0, -3, 0, -3,
+ax_anim 3, 0, 72, 0, -4, 0, -4,
+ax_anim 3, 0, 74, 0, -4, 0, -4,
+ax_anim 5, 2, 72, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 4, 0, 4,
+ax_anim 1, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 1, 75, -1, 5, -1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, -1, 5, -1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sMisdreavusAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 3, 0, 77, -3, -3, -3, -3,
+ax_anim 3, 0, 76, -4, -4, -4, -4,
+ax_anim 3, 0, 78, -4, -4, -4, -4,
+ax_anim 5, 2, 76, -4, -4, -4, -4,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 4, 4, 4, 4,
+ax_anim 1, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 1, 79, 4, 6, 4, 6,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 4, 6, 4, 6,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sMisdreavusAnims_4_3:
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim 3, 0, 81, -3, 0, -3, 0,
+ax_anim 3, 0, 80, -4, 0, -4, 0,
+ax_anim 3, 0, 82, -4, 0, -4, 0,
+ax_anim 5, 2, 80, -4, 0, -4, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 4, 0, 4, 0,
+ax_anim 1, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 1, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim_terminator
+sMisdreavusAnims_4_4:
+ax_anim 2, 0, 84, -2, 2, -2, 2,
+ax_anim 3, 0, 85, -3, 3, -3, 3,
+ax_anim 3, 0, 84, -4, 4, -4, 4,
+ax_anim 3, 0, 86, -4, 4, -4, 4,
+ax_anim 5, 2, 84, -4, 4, -4, 4,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 4, -4, 4, -4,
+ax_anim 1, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 1, 87, 4, -6, 4, -6,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 4, -6, 4, -6,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sMisdreavusAnims_4_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 3, 0, 89, 0, 3, 0, 3,
+ax_anim 3, 0, 88, 0, 4, 0, 4,
+ax_anim 3, 0, 90, 0, 4, 0, 4,
+ax_anim 5, 2, 88, 0, 4, 0, 4,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -4, 0, -4,
+ax_anim 1, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 1, 91, -1, -5, -1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, -1, -5, -1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sMisdreavusAnims_4_6:
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 3, 0, 93, 3, 3, 3, 3,
+ax_anim 3, 0, 92, 4, 4, 4, 4,
+ax_anim 3, 0, 94, 4, 4, 4, 4,
+ax_anim 5, 2, 92, 4, 4, 4, 4,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -4, -4, -4, -4,
+ax_anim 1, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 1, 95, -4, -6, -4, -6,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -4, -6, -4, -6,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sMisdreavusAnims_4_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 3, 0, 97, 3, 0, 3, 0,
+ax_anim 3, 0, 96, 4, 0, 4, 0,
+ax_anim 3, 0, 98, 4, 0, 4, 0,
+ax_anim 5, 2, 96, 4, 0, 4, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, -4, 0, -4, 0,
+ax_anim 1, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 1, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sMisdreavusAnims_4_8:
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 3, 0, 101, 3, -3, 3, -3,
+ax_anim 3, 0, 100, 4, -4, 4, -4,
+ax_anim 3, 0, 102, 4, -4, 4, -4,
+ax_anim 5, 2, 100, 4, -4, 4, -4,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, -4, 4, -4, 4,
+ax_anim 1, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 1, 103, -4, 6, -4, 6,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -4, 6, -4, 6,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_5_1:
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, -1, 0, 0,
+ax_anim 1, 0, 109, 0, -1, 0, 0,
+ax_anim 1, 2, 105, 0, -2, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 105, 0, -3, 0, 0,
+ax_anim 1, 0, 106, 0, -3, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 1, 0, 108, 0, -1, 0, 0,
+ax_anim 1, 0, 105, 0, -1, 0, 0,
+ax_anim 10, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_5_2:
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, -1, 0, 0,
+ax_anim 1, 0, 116, 0, -1, 0, 0,
+ax_anim 1, 2, 112, 0, -2, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 1, 0, 117, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -3, 0, 0,
+ax_anim 1, 0, 112, 0, -3, 0, 0,
+ax_anim 1, 0, 113, 0, -3, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 1, 0, 115, 0, -1, 0, 0,
+ax_anim 1, 0, 112, 0, -1, 0, 0,
+ax_anim 10, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_5_3:
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, -1, 0, 0,
+ax_anim 1, 0, 123, 0, -1, 0, 0,
+ax_anim 1, 2, 119, 0, -2, 0, 0,
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 1, 0, 118, 0, -3, 0, 0,
+ax_anim 1, 0, 119, 0, -3, 0, 0,
+ax_anim 1, 0, 120, 0, -3, 0, 0,
+ax_anim 1, 0, 123, 0, -2, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 1, 0, 119, 0, -1, 0, 0,
+ax_anim 10, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_5_4:
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -1, 0, 0,
+ax_anim 1, 0, 130, 0, -1, 0, 0,
+ax_anim 1, 2, 126, 0, -2, 0, 0,
+ax_anim 1, 0, 129, 0, -2, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 1, 0, 126, 0, -3, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 1, 0, 126, 0, -2, 0, 0,
+ax_anim 1, 0, 129, 0, -1, 0, 0,
+ax_anim 1, 0, 126, 0, -1, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_5_5:
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -1, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 1, 2, 133, 0, -2, 0, 0,
+ax_anim 1, 0, 136, 0, -2, 0, 0,
+ax_anim 1, 0, 138, 0, -3, 0, 0,
+ax_anim 1, 0, 132, 0, -3, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim 1, 0, 137, 0, -2, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 1, 0, 136, 0, -1, 0, 0,
+ax_anim 1, 0, 133, 0, -1, 0, 0,
+ax_anim 10, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_5_6:
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -1, 0, 0,
+ax_anim 1, 0, 144, 0, -1, 0, 0,
+ax_anim 1, 2, 140, 0, -2, 0, 0,
+ax_anim 1, 0, 143, 0, -2, 0, 0,
+ax_anim 1, 0, 145, 0, -3, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 1, 0, 144, 0, -2, 0, 0,
+ax_anim 1, 0, 140, 0, -2, 0, 0,
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_5_7:
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -1, 0, 0,
+ax_anim 1, 0, 151, 0, -1, 0, 0,
+ax_anim 1, 2, 147, 0, -2, 0, 0,
+ax_anim 1, 0, 150, 0, -2, 0, 0,
+ax_anim 1, 0, 152, 0, -3, 0, 0,
+ax_anim 1, 0, 146, 0, -3, 0, 0,
+ax_anim 1, 0, 147, 0, -3, 0, 0,
+ax_anim 1, 0, 148, 0, -3, 0, 0,
+ax_anim 1, 0, 151, 0, -2, 0, 0,
+ax_anim 1, 0, 147, 0, -2, 0, 0,
+ax_anim 1, 0, 150, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, -1, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_5_8:
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -1, 0, 0,
+ax_anim 1, 0, 158, 0, -1, 0, 0,
+ax_anim 1, 2, 154, 0, -2, 0, 0,
+ax_anim 1, 0, 157, 0, -2, 0, 0,
+ax_anim 1, 0, 159, 0, -3, 0, 0,
+ax_anim 1, 0, 153, 0, -3, 0, 0,
+ax_anim 1, 0, 154, 0, -3, 0, 0,
+ax_anim 1, 0, 155, 0, -3, 0, 0,
+ax_anim 1, 0, 158, 0, -2, 0, 0,
+ax_anim 1, 0, 154, 0, -2, 0, 0,
+ax_anim 1, 0, 157, 0, -1, 0, 0,
+ax_anim 1, 0, 154, 0, -1, 0, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_6_1:
+ax_anim 16, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, -1, 0, 0,
+ax_anim 16, 0, 160, 0, -2, 0, 0,
+ax_anim 16, 0, 161, 0, -2, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sMisdreavusAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sMisdreavusAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sMisdreavusAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sMisdreavusAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sMisdreavusAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sMisdreavusAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sMisdreavusAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_8_1:
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim 10, 0, 170, 0, -1, 0, 0,
+ax_anim 10, 0, 172, 0, -1, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 1, 0, 0,
+ax_anim 10, 0, 170, 0, 1, 0, 0,
+ax_anim 10, 0, 172, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_8_2:
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, -1, 0, 0,
+ax_anim 10, 0, 173, 0, -1, 0, 0,
+ax_anim 10, 0, 175, 0, -1, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, 1, 0, 0,
+ax_anim 10, 0, 173, 0, 1, 0, 0,
+ax_anim 10, 0, 175, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_8_3:
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim 10, 0, 176, 0, -2, 0, 0,
+ax_anim 10, 0, 178, 0, -1, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 1, 0, 0,
+ax_anim 10, 0, 176, 0, 2, 0, 0,
+ax_anim 10, 0, 178, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_8_4:
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim 10, 0, 179, 0, -2, 0, 0,
+ax_anim 10, 0, 181, 0, -1, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, 1, 0, 0,
+ax_anim 10, 0, 179, 0, 2, 0, 0,
+ax_anim 10, 0, 181, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_8_5:
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim 10, 0, 182, 0, -2, 0, 0,
+ax_anim 10, 0, 184, 0, -1, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 1, 0, 0,
+ax_anim 10, 0, 182, 0, 2, 0, 0,
+ax_anim 10, 0, 184, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_8_6:
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 186, 0, -1, 0, 0,
+ax_anim 10, 0, 185, 0, -2, 0, 0,
+ax_anim 10, 0, 187, 0, -1, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 186, 0, 1, 0, 0,
+ax_anim 10, 0, 185, 0, 2, 0, 0,
+ax_anim 10, 0, 187, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_8_7:
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 10, 0, 189, 0, -1, 0, 0,
+ax_anim 10, 0, 188, 0, -2, 0, 0,
+ax_anim 10, 0, 190, 0, -1, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 10, 0, 189, 0, 1, 0, 0,
+ax_anim 10, 0, 188, 0, 2, 0, 0,
+ax_anim 10, 0, 190, 0, 1, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_8_8:
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 10, 0, 192, 0, -1, 0, 0,
+ax_anim 10, 0, 191, 0, -2, 0, 0,
+ax_anim 10, 0, 193, 0, -1, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 10, 0, 192, 0, 1, 0, 0,
+ax_anim 10, 0, 191, 0, 2, 0, 0,
+ax_anim 10, 0, 193, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 14, 8, 14,
+ax_anim 2, 0, 197, 7, 22, 7, 21,
+ax_anim 3, 0, 198, 0, 25, 0, 23,
+ax_anim 2, 3, 199, -7, 22, -7, 21,
+ax_anim 2, 0, 200, -8, 14, -8, 14,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 10, 3, 10, 3,
+ax_anim 2, 0, 195, 17, 7, 17, 7,
+ax_anim 2, 0, 196, 22, 15, 22, 14,
+ax_anim 3, 0, 197, 21, 25, 21, 23,
+ax_anim 2, 3, 198, 14, 26, 14, 24,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -5, 16, -6,
+ax_anim 3, 0, 196, 22, 3, 22, 0,
+ax_anim 2, 3, 197, 18, 7, 18, 6,
+ax_anim 2, 0, 198, 12, 8, 12, 8,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 12, -18, 12, -20,
+ax_anim 3, 0, 195, 21, -14, 21, -16,
+ax_anim 2, 3, 196, 21, -8, 21, -10,
+ax_anim 2, 0, 197, 18, -3, 18, -3,
+ax_anim 1, 0, 198, 9, 0, 9, 0,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -9, -8, -9, -8,
+ax_anim 2, 0, 201, -7, -12, -7, -14,
+ax_anim 3, 0, 194, 0, -14, 0, -17,
+ax_anim 2, 3, 195, 7, -12, 7, -14,
+ax_anim 2, 0, 196, 9, -8, 9, -8,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -12, -18, -12, -20,
+ax_anim 3, 0, 201, -21, -14, -21, -16,
+ax_anim 2, 3, 200, -21, -8, -21, -10,
+ax_anim 2, 0, 199, -18, -3, -18, -3,
+ax_anim 1, 0, 198, -9, 0, -9, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -5, -16, -6,
+ax_anim 3, 0, 200, -22, 3, -22, 0,
+ax_anim 2, 3, 199, -18, 7, -18, 6,
+ax_anim 2, 0, 198, -12, 8, -12, 8,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -10, 3, -10, 3,
+ax_anim 2, 0, 201, -17, 7, -17, 7,
+ax_anim 2, 0, 200, -22, 15, -22, 14,
+ax_anim 3, 0, 199, -21, 25, -21, 23,
+ax_anim 2, 3, 198, -14, 26, -14, 24,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 4, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 215, 0, -21, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 4, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -21, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 4, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 4, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -22, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 4, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 4, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 4, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -22, 0, 0,
+ax_anim 3, 0, 233, 0, -21, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMisdreavusAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sMisdreavusGfx1:
+.incbin "baserom.gba", 0xD8B6DC, 0x200
+sMisdreavusSprites1:
+ax_sprite sMisdreavusGfx1, 0x200
+ax_sprite_terminator
+sMisdreavusGfx2:
+.incbin "baserom.gba", 0xD8B8EC, 0x200
+sMisdreavusSprites2:
+ax_sprite sMisdreavusGfx2, 0x200
+ax_sprite_terminator
+sMisdreavusGfx3:
+.incbin "baserom.gba", 0xD8BAFC, 0x200
+sMisdreavusSprites3:
+ax_sprite sMisdreavusGfx3, 0x200
+ax_sprite_terminator
+sMisdreavusGfx4:
+.incbin "baserom.gba", 0xD8BD0C, 0x200
+sMisdreavusSprites4:
+ax_sprite sMisdreavusGfx4, 0x200
+ax_sprite_terminator
+sMisdreavusGfx5:
+.incbin "baserom.gba", 0xD8BF1C, 0x200
+sMisdreavusSprites5:
+ax_sprite sMisdreavusGfx5, 0x200
+ax_sprite_terminator
+sMisdreavusGfx6:
+.incbin "baserom.gba", 0xD8C12C, 0x200
+sMisdreavusSprites6:
+ax_sprite sMisdreavusGfx6, 0x200
+ax_sprite_terminator
+sMisdreavusGfx7:
+.incbin "baserom.gba", 0xD8C33C, 0x200
+sMisdreavusSprites7:
+ax_sprite sMisdreavusGfx7, 0x200
+ax_sprite_terminator
+sMisdreavusGfx8:
+.incbin "baserom.gba", 0xD8C54C, 0x200
+sMisdreavusSprites8:
+ax_sprite sMisdreavusGfx8, 0x200
+ax_sprite_terminator
+sMisdreavusGfx9:
+.incbin "baserom.gba", 0xD8C75C, 0x200
+sMisdreavusSprites9:
+ax_sprite sMisdreavusGfx9, 0x200
+ax_sprite_terminator
+sMisdreavusGfx10:
+.incbin "baserom.gba", 0xD8C96C, 0x200
+sMisdreavusSprites10:
+ax_sprite sMisdreavusGfx10, 0x200
+ax_sprite_terminator
+sMisdreavusGfx11:
+.incbin "baserom.gba", 0xD8CB7C, 0x200
+sMisdreavusSprites11:
+ax_sprite sMisdreavusGfx11, 0x200
+ax_sprite_terminator
+sMisdreavusGfx12:
+.incbin "baserom.gba", 0xD8CD8C, 0x200
+sMisdreavusSprites12:
+ax_sprite sMisdreavusGfx12, 0x200
+ax_sprite_terminator
+sMisdreavusGfx13:
+.incbin "baserom.gba", 0xD8CF9C, 0x200
+sMisdreavusSprites13:
+ax_sprite sMisdreavusGfx13, 0x200
+ax_sprite_terminator
+sMisdreavusGfx14:
+.incbin "baserom.gba", 0xD8D1AC, 0x200
+sMisdreavusSprites14:
+ax_sprite sMisdreavusGfx14, 0x200
+ax_sprite_terminator
+sMisdreavusGfx15:
+.incbin "baserom.gba", 0xD8D3BC, 0x200
+sMisdreavusSprites15:
+ax_sprite sMisdreavusGfx15, 0x200
+ax_sprite_terminator
+sMisdreavusGfx16:
+.incbin "baserom.gba", 0xD8D5CC, 0x60
+sMisdreavusGfx16_1:
+.incbin "baserom.gba", 0xD8D62C, 0x60
+sMisdreavusGfx16_2:
+.incbin "baserom.gba", 0xD8D68C, 0x60
+sMisdreavusSprites16:
+ax_sprite sMisdreavusGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMisdreavusGfx17:
+.incbin "baserom.gba", 0xD8D724, 0x60
+sMisdreavusGfx17_1:
+.incbin "baserom.gba", 0xD8D784, 0xE0
+sMisdreavusSprites17:
+ax_sprite sMisdreavusGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx17_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMisdreavusGfx18:
+.incbin "baserom.gba", 0xD8D88C, 0x160
+sMisdreavusSprites18:
+ax_sprite sMisdreavusGfx18, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMisdreavusGfx19:
+.incbin "baserom.gba", 0xD8DA04, 0x60
+sMisdreavusGfx19_1:
+.incbin "baserom.gba", 0xD8DA64, 0x60
+sMisdreavusGfx19_2:
+.incbin "baserom.gba", 0xD8DAC4, 0x60
+sMisdreavusSprites19:
+ax_sprite sMisdreavusGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMisdreavusGfx20:
+.incbin "baserom.gba", 0xD8DB5C, 0x60
+sMisdreavusGfx20_1:
+.incbin "baserom.gba", 0xD8DBBC, 0x60
+sMisdreavusGfx20_2:
+.incbin "baserom.gba", 0xD8DC1C, 0x60
+sMisdreavusSprites20:
+ax_sprite sMisdreavusGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMisdreavusGfx21:
+.incbin "baserom.gba", 0xD8DCB4, 0x20
+sMisdreavusSprites21:
+ax_sprite sMisdreavusGfx21, 0x20
+ax_sprite_terminator
+sMisdreavusGfx22:
+.incbin "baserom.gba", 0xD8DCE4, 0x60
+sMisdreavusSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx22, 0x60
+ax_sprite_terminator
+sMisdreavusGfx23:
+.incbin "baserom.gba", 0xD8DD5C, 0x60
+sMisdreavusSprites23:
+ax_sprite 0, 0x20
+ax_sprite sMisdreavusGfx23, 0x60
+ax_sprite_terminator
+sMisdreavusGfx24:
+.incbin "baserom.gba", 0xD8DDD4, 0x20
+sMisdreavusSprites24:
+ax_sprite sMisdreavusGfx24, 0x20
+ax_sprite_terminator
+sMisdreavusGfx25:
+.incbin "baserom.gba", 0xD8DE04, 0x20
+sMisdreavusSprites25:
+ax_sprite sMisdreavusGfx25, 0x20
+ax_sprite_terminator
+sMisdreavusGfx26:
+.incbin "baserom.gba", 0xD8DE34, 0x80
+sMisdreavusSprites26:
+ax_sprite sMisdreavusGfx26, 0x80
+ax_sprite_terminator
+sMisdreavusGfx27:
+.incbin "baserom.gba", 0xD8DEC4, 0x200
+sMisdreavusSprites27:
+ax_sprite sMisdreavusGfx27, 0x200
+ax_sprite_terminator
+sMisdreavusGfx28:
+.incbin "baserom.gba", 0xD8E0D4, 0x200
+sMisdreavusSprites28:
+ax_sprite sMisdreavusGfx28, 0x200
+ax_sprite_terminator
+sMisdreavusGfx29:
+.incbin "baserom.gba", 0xD8E2E4, 0x200
+sMisdreavusSprites29:
+ax_sprite sMisdreavusGfx29, 0x200
+ax_sprite_terminator
+sMisdreavusGfx30:
+.incbin "baserom.gba", 0xD8E4F4, 0x200
+sMisdreavusSprites30:
+ax_sprite sMisdreavusGfx30, 0x200
+ax_sprite_terminator
+sMisdreavusGfx31:
+.incbin "baserom.gba", 0xD8E704, 0x200
+sMisdreavusSprites31:
+ax_sprite sMisdreavusGfx31, 0x200
+ax_sprite_terminator
+sMisdreavusGfx32:
+.incbin "baserom.gba", 0xD8E914, 0x200
+sMisdreavusSprites32:
+ax_sprite sMisdreavusGfx32, 0x200
+ax_sprite_terminator
+sMisdreavusGfx33:
+.incbin "baserom.gba", 0xD8EB24, 0x200
+sMisdreavusSprites33:
+ax_sprite sMisdreavusGfx33, 0x200
+ax_sprite_terminator
+sAxPosesMisdreavus:
+.4byte sMisdreavusPose1
+.4byte sMisdreavusPose2
+.4byte sMisdreavusPose3
+.4byte sMisdreavusPose4
+.4byte sMisdreavusPose5
+.4byte sMisdreavusPose6
+.4byte sMisdreavusPose7
+.4byte sMisdreavusPose8
+.4byte sMisdreavusPose9
+.4byte sMisdreavusPose10
+.4byte sMisdreavusPose11
+.4byte sMisdreavusPose12
+.4byte sMisdreavusPose13
+.4byte sMisdreavusPose14
+.4byte sMisdreavusPose15
+.4byte sMisdreavusPose16
+.4byte sMisdreavusPose17
+.4byte sMisdreavusPose18
+.4byte sMisdreavusPose19
+.4byte sMisdreavusPose20
+.4byte sMisdreavusPose21
+.4byte sMisdreavusPose22
+.4byte sMisdreavusPose23
+.4byte sMisdreavusPose24
+.4byte sMisdreavusPose25
+.4byte sMisdreavusPose26
+.4byte sMisdreavusPose27
+.4byte sMisdreavusPose28
+.4byte sMisdreavusPose29
+.4byte sMisdreavusPose30
+.4byte sMisdreavusPose31
+.4byte sMisdreavusPose32
+.4byte sMisdreavusPose33
+.4byte sMisdreavusPose34
+.4byte sMisdreavusPose35
+.4byte sMisdreavusPose36
+.4byte sMisdreavusPose37
+.4byte sMisdreavusPose38
+.4byte sMisdreavusPose39
+.4byte sMisdreavusPose40
+.4byte sMisdreavusPose41
+.4byte sMisdreavusPose42
+.4byte sMisdreavusPose43
+.4byte sMisdreavusPose44
+.4byte sMisdreavusPose45
+.4byte sMisdreavusPose46
+.4byte sMisdreavusPose47
+.4byte sMisdreavusPose48
+.4byte sMisdreavusPose49
+.4byte sMisdreavusPose50
+.4byte sMisdreavusPose51
+.4byte sMisdreavusPose52
+.4byte sMisdreavusPose53
+.4byte sMisdreavusPose54
+.4byte sMisdreavusPose55
+.4byte sMisdreavusPose56
+.4byte sMisdreavusPose57
+.4byte sMisdreavusPose58
+.4byte sMisdreavusPose59
+.4byte sMisdreavusPose60
+.4byte sMisdreavusPose61
+.4byte sMisdreavusPose62
+.4byte sMisdreavusPose63
+.4byte sMisdreavusPose64
+.4byte sMisdreavusPose65
+.4byte sMisdreavusPose66
+.4byte sMisdreavusPose67
+.4byte sMisdreavusPose68
+.4byte sMisdreavusPose69
+.4byte sMisdreavusPose70
+.4byte sMisdreavusPose71
+.4byte sMisdreavusPose72
+.4byte sMisdreavusPose73
+.4byte sMisdreavusPose74
+.4byte sMisdreavusPose75
+.4byte sMisdreavusPose76
+.4byte sMisdreavusPose77
+.4byte sMisdreavusPose78
+.4byte sMisdreavusPose79
+.4byte sMisdreavusPose80
+.4byte sMisdreavusPose81
+.4byte sMisdreavusPose82
+.4byte sMisdreavusPose83
+.4byte sMisdreavusPose84
+.4byte sMisdreavusPose85
+.4byte sMisdreavusPose86
+.4byte sMisdreavusPose87
+.4byte sMisdreavusPose88
+.4byte sMisdreavusPose89
+.4byte sMisdreavusPose90
+.4byte sMisdreavusPose91
+.4byte sMisdreavusPose92
+.4byte sMisdreavusPose93
+.4byte sMisdreavusPose94
+.4byte sMisdreavusPose95
+.4byte sMisdreavusPose96
+.4byte sMisdreavusPose97
+.4byte sMisdreavusPose98
+.4byte sMisdreavusPose99
+.4byte sMisdreavusPose100
+.4byte sMisdreavusPose101
+.4byte sMisdreavusPose102
+.4byte sMisdreavusPose103
+.4byte sMisdreavusPose104
+.4byte sMisdreavusPose105
+.4byte sMisdreavusPose106
+.4byte sMisdreavusPose107
+.4byte sMisdreavusPose108
+.4byte sMisdreavusPose109
+.4byte sMisdreavusPose110
+.4byte sMisdreavusPose111
+.4byte sMisdreavusPose112
+.4byte sMisdreavusPose113
+.4byte sMisdreavusPose114
+.4byte sMisdreavusPose115
+.4byte sMisdreavusPose116
+.4byte sMisdreavusPose117
+.4byte sMisdreavusPose118
+.4byte sMisdreavusPose119
+.4byte sMisdreavusPose120
+.4byte sMisdreavusPose121
+.4byte sMisdreavusPose122
+.4byte sMisdreavusPose123
+.4byte sMisdreavusPose124
+.4byte sMisdreavusPose125
+.4byte sMisdreavusPose126
+.4byte sMisdreavusPose127
+.4byte sMisdreavusPose128
+.4byte sMisdreavusPose129
+.4byte sMisdreavusPose130
+.4byte sMisdreavusPose131
+.4byte sMisdreavusPose132
+.4byte sMisdreavusPose133
+.4byte sMisdreavusPose134
+.4byte sMisdreavusPose135
+.4byte sMisdreavusPose136
+.4byte sMisdreavusPose137
+.4byte sMisdreavusPose138
+.4byte sMisdreavusPose139
+.4byte sMisdreavusPose140
+.4byte sMisdreavusPose141
+.4byte sMisdreavusPose142
+.4byte sMisdreavusPose143
+.4byte sMisdreavusPose144
+.4byte sMisdreavusPose145
+.4byte sMisdreavusPose146
+.4byte sMisdreavusPose147
+.4byte sMisdreavusPose148
+.4byte sMisdreavusPose149
+.4byte sMisdreavusPose150
+.4byte sMisdreavusPose151
+.4byte sMisdreavusPose152
+.4byte sMisdreavusPose153
+.4byte sMisdreavusPose154
+.4byte sMisdreavusPose155
+.4byte sMisdreavusPose156
+.4byte sMisdreavusPose157
+.4byte sMisdreavusPose158
+.4byte sMisdreavusPose159
+.4byte sMisdreavusPose160
+.4byte sMisdreavusPose161
+.4byte sMisdreavusPose162
+.4byte sMisdreavusPose163
+.4byte sMisdreavusPose164
+.4byte sMisdreavusPose165
+.4byte sMisdreavusPose166
+.4byte sMisdreavusPose167
+.4byte sMisdreavusPose168
+.4byte sMisdreavusPose169
+.4byte sMisdreavusPose170
+.4byte sMisdreavusPose171
+.4byte sMisdreavusPose172
+.4byte sMisdreavusPose173
+.4byte sMisdreavusPose174
+.4byte sMisdreavusPose175
+.4byte sMisdreavusPose176
+.4byte sMisdreavusPose177
+.4byte sMisdreavusPose178
+.4byte sMisdreavusPose179
+.4byte sMisdreavusPose180
+.4byte sMisdreavusPose181
+.4byte sMisdreavusPose182
+.4byte sMisdreavusPose183
+.4byte sMisdreavusPose184
+.4byte sMisdreavusPose185
+.4byte sMisdreavusPose186
+.4byte sMisdreavusPose187
+.4byte sMisdreavusPose188
+.4byte sMisdreavusPose189
+.4byte sMisdreavusPose190
+.4byte sMisdreavusPose191
+.4byte sMisdreavusPose192
+.4byte sMisdreavusPose193
+.4byte sMisdreavusPose194
+.4byte sMisdreavusPose195
+.4byte sMisdreavusPose196
+.4byte sMisdreavusPose197
+.4byte sMisdreavusPose198
+.4byte sMisdreavusPose199
+.4byte sMisdreavusPose200
+.4byte sMisdreavusPose201
+.4byte sMisdreavusPose202
+.4byte sMisdreavusPose203
+.4byte sMisdreavusPose204
+.4byte sMisdreavusPose205
+.4byte sMisdreavusPose206
+.4byte sMisdreavusPose207
+.4byte sMisdreavusPose208
+.4byte sMisdreavusPose209
+.4byte sMisdreavusPose210
+.4byte sMisdreavusPose211
+.4byte sMisdreavusPose212
+.4byte sMisdreavusPose213
+.4byte sMisdreavusPose214
+.4byte sMisdreavusPose215
+.4byte sMisdreavusPose216
+.4byte sMisdreavusPose217
+.4byte sMisdreavusPose218
+.4byte sMisdreavusPose219
+.4byte sMisdreavusPose220
+.4byte sMisdreavusPose221
+.4byte sMisdreavusPose222
+.4byte sMisdreavusPose223
+.4byte sMisdreavusPose224
+.4byte sMisdreavusPose225
+.4byte sMisdreavusPose226
+.4byte sMisdreavusPose227
+.4byte sMisdreavusPose228
+.4byte sMisdreavusPose229
+.4byte sMisdreavusPose230
+.4byte sMisdreavusPose231
+.4byte sMisdreavusPose232
+.4byte sMisdreavusPose233
+.4byte sMisdreavusPose234
+.4byte sMisdreavusPose235
+.4byte sMisdreavusPose236
+.4byte sMisdreavusPose237
+.4byte sMisdreavusPose238
+.4byte sMisdreavusPose239
+.4byte sMisdreavusPose240
+.4byte sMisdreavusPose241
+.4byte sMisdreavusPose242
+.4byte sMisdreavusPose243
+.4byte sMisdreavusPose244
+.4byte sMisdreavusPose245
+.4byte sMisdreavusPose246
+.4byte sMisdreavusPose247
+.4byte sMisdreavusPose248
+.4byte sMisdreavusPose249
+.4byte sMisdreavusPose250
+sAxPositionsMisdreavus:
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   3,   -5, 	   0,  -10
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -5, 	   1,  -11
+.2byte    4,   -7, 	   3,   -6, 	  -2,   -5, 	   1,  -11
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   2,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   3,   -7, 	   1,   -5, 	   3,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -8, 	   2,   -7, 	   1,  -11
+.2byte    3,  -10, 	  -4,   -8, 	   2,   -7, 	   2,  -11
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -8, 	  -3,   -7, 	  -2,  -11
+.2byte   -4,  -10, 	   3,   -8, 	  -3,   -7, 	  -3,  -11
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -2,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -3,   -7, 	  -1,   -5, 	  -3,  -12
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -5, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -6, 	   2,   -5, 	  -1,  -11
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   3,   -5, 	   0,  -10
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -5, 	   1,  -11
+.2byte    4,   -7, 	   3,   -6, 	  -2,   -5, 	   1,  -11
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   2,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   3,   -7, 	   1,   -5, 	   3,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -8, 	   2,   -7, 	   1,  -11
+.2byte    3,  -10, 	  -4,   -8, 	   2,   -7, 	   2,  -11
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -8, 	  -3,   -7, 	  -2,  -11
+.2byte   -4,  -10, 	   3,   -8, 	  -3,   -7, 	  -3,  -11
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -2,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -3,   -7, 	  -1,   -5, 	  -3,  -12
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -5, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -6, 	   2,   -5, 	  -1,  -11
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   3,   -5, 	   0,  -10
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -5, 	   1,  -11
+.2byte    4,   -7, 	   3,   -6, 	  -2,   -5, 	   1,  -11
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   2,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   3,   -7, 	   1,   -5, 	   3,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -8, 	   2,   -7, 	   1,  -11
+.2byte    3,  -10, 	  -4,   -8, 	   2,   -7, 	   2,  -11
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -8, 	  -3,   -7, 	  -2,  -11
+.2byte   -4,  -10, 	   3,   -8, 	  -3,   -7, 	  -3,  -11
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -2,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -3,   -7, 	  -1,   -5, 	  -3,  -12
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -5, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -6, 	   2,   -5, 	  -1,  -11
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   3,   -5, 	   0,  -10
+.2byte    0,   -8, 	  -4,   -7, 	   4,   -7, 	   0,  -10
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -5, 	   1,  -11
+.2byte    4,   -7, 	   3,   -6, 	  -2,   -5, 	   1,  -11
+.2byte    5,  -10, 	   2,   -9, 	  -3,   -7, 	   1,  -10
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   2,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   3,   -7, 	   1,   -5, 	   3,  -12
+.2byte    7,  -11, 	   0,   -8, 	   0,   -7, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -8, 	   2,   -7, 	   1,  -11
+.2byte    3,  -10, 	  -4,   -8, 	   2,   -7, 	   2,  -11
+.2byte    6,  -11, 	  -2,   -7, 	   1,   -6, 	   1,  -11
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -1,  -12, 	   3,   -8, 	  -4,   -8, 	   0,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -8, 	  -3,   -7, 	  -2,  -11
+.2byte   -4,  -10, 	   3,   -8, 	  -3,   -7, 	  -3,  -11
+.2byte   -7,  -11, 	   1,   -7, 	  -2,   -6, 	  -2,  -11
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -2,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -3,   -7, 	  -1,   -5, 	  -3,  -12
+.2byte   -7,  -11, 	   0,   -8, 	   0,   -7, 	  -2,  -12
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -5, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -6, 	   2,   -5, 	  -1,  -11
+.2byte   -5,  -10, 	  -2,   -9, 	   3,   -7, 	  -1,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -5, 	   2,   -4, 	  -1,  -11
+.2byte   -5,   -6, 	  -4,   -5, 	   3,   -4, 	  -2,   -9
+.2byte    0,   -8, 	  -5,   -6, 	   5,   -7, 	   0,  -11
+.2byte    1,   -9, 	   4,   -8, 	  -2,   -5, 	  -1,  -14
+.2byte    0,   -9, 	   1,   -9, 	   3,   -6, 	  -3,  -11
+.2byte   -1,  -11, 	  -1,  -10, 	   4,   -8, 	  -3,  -14
+.2byte    0,  -13, 	   5,   -7, 	  -6,   -7, 	   0,  -14
+.2byte    0,  -11, 	   0,  -10, 	  -5,   -8, 	   2,  -14
+.2byte   -1,   -9, 	  -2,   -9, 	  -4,   -6, 	   2,  -11
+.2byte   -2,   -9, 	  -5,   -8, 	   1,   -5, 	   0,  -14
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   3,   -5, 	   0,  -10
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -5, 	   1,  -11
+.2byte    4,   -7, 	   3,   -6, 	  -2,   -5, 	   1,  -11
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   2,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   3,   -7, 	   1,   -5, 	   3,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -8, 	   2,   -7, 	   1,  -11
+.2byte    3,  -10, 	  -4,   -8, 	   2,   -7, 	   2,  -11
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -8, 	  -3,   -7, 	  -2,  -11
+.2byte   -4,  -10, 	   3,   -8, 	  -3,   -7, 	  -3,  -11
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -2,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -3,   -7, 	  -1,   -5, 	  -3,  -12
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -5, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -6, 	   2,   -5, 	  -1,  -11
+.2byte    0,   -8, 	  -4,   -7, 	   4,   -7, 	   0,  -10
+.2byte   -5,  -10, 	  -2,   -9, 	   3,   -7, 	  -1,  -10
+.2byte   -7,  -11, 	   0,   -8, 	   0,   -7, 	  -2,  -12
+.2byte   -7,  -11, 	   1,   -7, 	  -2,   -6, 	  -2,  -11
+.2byte   -1,  -12, 	   3,   -8, 	  -4,   -8, 	   0,  -12
+.2byte    6,  -11, 	  -2,   -7, 	   1,   -6, 	   1,  -11
+.2byte    6,  -11, 	  -1,   -8, 	  -1,   -7, 	   1,  -12
+.2byte    5,  -10, 	   2,   -9, 	  -3,   -7, 	   1,  -10
+.2byte    0,   -8, 	  -4,   -7, 	   4,   -7, 	   0,  -10
+.2byte    5,  -10, 	   2,   -9, 	  -3,   -7, 	   1,  -10
+.2byte    6,  -11, 	  -1,   -8, 	  -1,   -7, 	   1,  -12
+.2byte    6,  -11, 	  -2,   -7, 	   1,   -6, 	   1,  -11
+.2byte   -1,  -12, 	   3,   -8, 	  -4,   -8, 	   0,  -12
+.2byte   -7,  -11, 	   1,   -7, 	  -2,   -6, 	  -2,  -11
+.2byte   -7,  -11, 	   0,   -8, 	   0,   -7, 	  -2,  -12
+.2byte   -5,  -10, 	  -2,   -9, 	   3,   -7, 	  -1,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -3,   -5, 	   3,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -4,   -6, 	   3,   -5, 	   0,  -10
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -5, 	   1,  -11
+.2byte    4,   -7, 	   3,   -6, 	  -2,   -5, 	   1,  -11
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   2,   -7, 	   0,   -5, 	   2,  -12
+.2byte    7,   -9, 	   3,   -7, 	   1,   -5, 	   3,  -12
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    4,  -10, 	  -3,   -8, 	   2,   -7, 	   1,  -11
+.2byte    3,  -10, 	  -4,   -8, 	   2,   -7, 	   2,  -11
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,  -10
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -5,  -10, 	   2,   -8, 	  -3,   -7, 	  -2,  -11
+.2byte   -4,  -10, 	   3,   -8, 	  -3,   -7, 	  -3,  -11
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -2,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -7,   -9, 	  -3,   -7, 	  -1,   -5, 	  -3,  -12
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -5, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -6, 	   2,   -5, 	  -1,  -11
+.2byte    0,   -7, 	  -4,   -6, 	   3,   -5, 	   0,  -10
+.2byte   -4,   -7, 	  -3,   -6, 	   2,   -5, 	  -1,  -11
+.2byte   -6,   -9, 	  -2,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -3,  -10, 	   4,   -8, 	  -2,   -7, 	  -2,  -11
+.2byte    0,  -11, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte    3,  -10, 	  -4,   -8, 	   2,   -7, 	   2,  -11
+.2byte    6,   -9, 	   2,   -7, 	   0,   -5, 	   2,  -12
+.2byte    3,   -7, 	   2,   -6, 	  -3,   -5, 	   0,  -11
+.2byte    0,   -7, 	  -4,   -6, 	   4,   -6, 	   0,  -10
+.2byte   -4,   -7, 	  -3,   -7, 	   2,   -6, 	  -1,  -11
+.2byte   -7,   -9, 	  -1,   -7, 	   0,   -5, 	  -2,  -12
+.2byte   -5,  -10, 	   2,   -9, 	  -3,   -6, 	  -3,  -12
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    4,  -10, 	  -3,   -9, 	   2,   -6, 	   2,  -12
+.2byte    7,   -9, 	   1,   -7, 	   0,   -5, 	   2,  -12
+.2byte    4,   -7, 	   3,   -7, 	  -2,   -6, 	   1,  -11
+sMisdreavusAnimTable1:
+.4byte sMisdreavusAnims_1_1
+.4byte sMisdreavusAnims_1_2
+.4byte sMisdreavusAnims_1_3
+.4byte sMisdreavusAnims_1_4
+.4byte sMisdreavusAnims_1_5
+.4byte sMisdreavusAnims_1_6
+.4byte sMisdreavusAnims_1_7
+.4byte sMisdreavusAnims_1_8
+sMisdreavusAnimTable2:
+.4byte sMisdreavusAnims_2_1
+.4byte sMisdreavusAnims_2_2
+.4byte sMisdreavusAnims_2_3
+.4byte sMisdreavusAnims_2_4
+.4byte sMisdreavusAnims_2_5
+.4byte sMisdreavusAnims_2_6
+.4byte sMisdreavusAnims_2_7
+.4byte sMisdreavusAnims_2_8
+sMisdreavusAnimTable3:
+.4byte sMisdreavusAnims_3_1
+.4byte sMisdreavusAnims_3_2
+.4byte sMisdreavusAnims_3_3
+.4byte sMisdreavusAnims_3_4
+.4byte sMisdreavusAnims_3_5
+.4byte sMisdreavusAnims_3_6
+.4byte sMisdreavusAnims_3_7
+.4byte sMisdreavusAnims_3_8
+sMisdreavusAnimTable4:
+.4byte sMisdreavusAnims_4_1
+.4byte sMisdreavusAnims_4_2
+.4byte sMisdreavusAnims_4_3
+.4byte sMisdreavusAnims_4_4
+.4byte sMisdreavusAnims_4_5
+.4byte sMisdreavusAnims_4_6
+.4byte sMisdreavusAnims_4_7
+.4byte sMisdreavusAnims_4_8
+sMisdreavusAnimTable5:
+.4byte sMisdreavusAnims_5_1
+.4byte sMisdreavusAnims_5_2
+.4byte sMisdreavusAnims_5_3
+.4byte sMisdreavusAnims_5_4
+.4byte sMisdreavusAnims_5_5
+.4byte sMisdreavusAnims_5_6
+.4byte sMisdreavusAnims_5_7
+.4byte sMisdreavusAnims_5_8
+sMisdreavusAnimTable6:
+.4byte sMisdreavusAnims_6_1
+.4byte sMisdreavusAnims_6_1
+.4byte sMisdreavusAnims_6_1
+.4byte sMisdreavusAnims_6_1
+.4byte sMisdreavusAnims_6_1
+.4byte sMisdreavusAnims_6_1
+.4byte sMisdreavusAnims_6_1
+.4byte sMisdreavusAnims_6_1
+sMisdreavusAnimTable7:
+.4byte sMisdreavusAnims_7_1
+.4byte sMisdreavusAnims_7_2
+.4byte sMisdreavusAnims_7_3
+.4byte sMisdreavusAnims_7_4
+.4byte sMisdreavusAnims_7_5
+.4byte sMisdreavusAnims_7_6
+.4byte sMisdreavusAnims_7_7
+.4byte sMisdreavusAnims_7_8
+sMisdreavusAnimTable8:
+.4byte sMisdreavusAnims_8_1
+.4byte sMisdreavusAnims_8_2
+.4byte sMisdreavusAnims_8_3
+.4byte sMisdreavusAnims_8_4
+.4byte sMisdreavusAnims_8_5
+.4byte sMisdreavusAnims_8_6
+.4byte sMisdreavusAnims_8_7
+.4byte sMisdreavusAnims_8_8
+sMisdreavusAnimTable9:
+.4byte sMisdreavusAnims_9_1
+.4byte sMisdreavusAnims_9_2
+.4byte sMisdreavusAnims_9_3
+.4byte sMisdreavusAnims_9_4
+.4byte sMisdreavusAnims_9_5
+.4byte sMisdreavusAnims_9_6
+.4byte sMisdreavusAnims_9_7
+.4byte sMisdreavusAnims_9_8
+sMisdreavusAnimTable10:
+.4byte sMisdreavusAnims_10_1
+.4byte sMisdreavusAnims_10_2
+.4byte sMisdreavusAnims_10_3
+.4byte sMisdreavusAnims_10_4
+.4byte sMisdreavusAnims_10_5
+.4byte sMisdreavusAnims_10_6
+.4byte sMisdreavusAnims_10_7
+.4byte sMisdreavusAnims_10_8
+sMisdreavusAnimTable11:
+.4byte sMisdreavusAnims_11_1
+.4byte sMisdreavusAnims_11_2
+.4byte sMisdreavusAnims_11_3
+.4byte sMisdreavusAnims_11_4
+.4byte sMisdreavusAnims_11_5
+.4byte sMisdreavusAnims_11_6
+.4byte sMisdreavusAnims_11_7
+.4byte sMisdreavusAnims_11_8
+sMisdreavusAnimTable12:
+.4byte sMisdreavusAnims_12_1
+.4byte sMisdreavusAnims_12_2
+.4byte sMisdreavusAnims_12_3
+.4byte sMisdreavusAnims_12_4
+.4byte sMisdreavusAnims_12_5
+.4byte sMisdreavusAnims_12_6
+.4byte sMisdreavusAnims_12_7
+.4byte sMisdreavusAnims_12_8
+sMisdreavusAnimTable13:
+.4byte sMisdreavusAnims_13_1
+.4byte sMisdreavusAnims_13_2
+.4byte sMisdreavusAnims_13_3
+.4byte sMisdreavusAnims_13_4
+.4byte sMisdreavusAnims_13_5
+.4byte sMisdreavusAnims_13_6
+.4byte sMisdreavusAnims_13_7
+.4byte sMisdreavusAnims_13_8
+sAxAnimationsMisdreavus:
+.4byte sMisdreavusAnimTable1
+.4byte sMisdreavusAnimTable2
+.4byte sMisdreavusAnimTable3
+.4byte sMisdreavusAnimTable4
+.4byte sMisdreavusAnimTable5
+.4byte sMisdreavusAnimTable6
+.4byte sMisdreavusAnimTable7
+.4byte sMisdreavusAnimTable8
+.4byte sMisdreavusAnimTable9
+.4byte sMisdreavusAnimTable10
+.4byte sMisdreavusAnimTable11
+.4byte sMisdreavusAnimTable12
+.4byte sMisdreavusAnimTable13
+sAxSpritesMisdreavus:
+.4byte sMisdreavusSprites1
+.4byte sMisdreavusSprites2
+.4byte sMisdreavusSprites3
+.4byte sMisdreavusSprites4
+.4byte sMisdreavusSprites5
+.4byte sMisdreavusSprites6
+.4byte sMisdreavusSprites7
+.4byte sMisdreavusSprites8
+.4byte sMisdreavusSprites9
+.4byte sMisdreavusSprites10
+.4byte sMisdreavusSprites11
+.4byte sMisdreavusSprites12
+.4byte sMisdreavusSprites13
+.4byte sMisdreavusSprites14
+.4byte sMisdreavusSprites15
+.4byte sMisdreavusSprites16
+.4byte sMisdreavusSprites17
+.4byte sMisdreavusSprites18
+.4byte sMisdreavusSprites19
+.4byte sMisdreavusSprites20
+.4byte sMisdreavusSprites21
+.4byte sMisdreavusSprites22
+.4byte sMisdreavusSprites23
+.4byte sMisdreavusSprites24
+.4byte sMisdreavusSprites25
+.4byte sMisdreavusSprites26
+.4byte sMisdreavusSprites27
+.4byte sMisdreavusSprites28
+.4byte sMisdreavusSprites29
+.4byte sMisdreavusSprites30
+.4byte sMisdreavusSprites31
+.4byte sMisdreavusSprites32
+.4byte sMisdreavusSprites33
+sAxMainMisdreavus:
+ax_main sAxPosesMisdreavus, sAxAnimationsMisdreavus, 13, sAxSpritesMisdreavus, sAxPositionsMisdreavus

--- a/data/ax/moltres.inc
+++ b/data/ax/moltres.inc
@@ -1,0 +1,6018 @@
+.global gAxMoltres
+gAxMoltres:
+ax_siro sAxMainMoltres
+sMoltresPose1:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose2:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose3:
+ax_pose 16, 0x41e5, 0x80f0, 0x0c00
+ax_pose 17, 0x41f5, 0x40f0, 0x0c08
+ax_pose 18, 0x41dd, 0x00f8, 0x0c0c
+ax_pose 19, 0x41d5, 0x00f8, 0x0c0e
+ax_pose 20, 0x01fd, 0x00f0, 0x0c10
+ax_pose 21, 0x01f5, 0x00e0, 0x0c11
+ax_pose 22, 0x81fd, 0x00e0, 0x0c12
+ax_pose 23, 0x81ed, 0x40e8, 0x0c14
+ax_pose 24, 0x81ed, 0x4110, 0x0c18
+ax_pose 25, 0x01fd, 0x0108, 0x0c1c
+ax_pose 26, 0x01f5, 0x0118, 0x0c1d
+ax_pose 27, 0x81fd, 0x0118, 0x0c1e
+ax_pose_terminator
+sMoltresPose4:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose5:
+ax_pose 37, 0x01ce, 0x90f2, 0x0c00
+ax_pose 38, 0x81ce, 0x90e2, 0x0c10
+ax_pose 39, 0x41f6, 0x10f2, 0x0c18
+ax_pose 40, 0x41ee, 0x10ff, 0x0c1a
+ax_pose 41, 0x41ee, 0x10ef, 0x0c1c
+ax_pose_terminator
+sMoltresPose6:
+ax_pose 42, 0x01d5, 0x5102, 0x0c00
+ax_pose 43, 0x4205, 0x10e2, 0x0c04
+ax_pose 44, 0x01e5, 0x90f2, 0x0c06
+ax_pose 45, 0x81e5, 0x90e2, 0x0c16
+ax_pose_terminator
+sMoltresPose7:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose8:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose9:
+ax_pose 59, 0x01ed, 0x10e2, 0x0c00
+ax_pose 60, 0x01ed, 0x90ea, 0x0c01
+ax_pose 61, 0x41e5, 0x50fa, 0x0c11
+ax_pose 62, 0x01d5, 0x5105, 0x0c15
+ax_pose_terminator
+sMoltresPose10:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose11:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose12:
+ax_pose 84, 0x01e5, 0x90f8, 0x0c00
+ax_pose 85, 0x81e5, 0x90e8, 0x0c10
+ax_pose 86, 0x01d5, 0x50ff, 0x0c18
+ax_pose_terminator
+sMoltresPose13:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose14:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose15:
+ax_pose 111, 0x41f5, 0x40f0, 0x0c00
+ax_pose 112, 0x41e5, 0x80f0, 0x0c04
+ax_pose 113, 0x41d5, 0x00f8, 0x0c0c
+ax_pose 114, 0x41dd, 0x00f8, 0x0c0e
+ax_pose 115, 0x81e5, 0x40e8, 0x0c10
+ax_pose 116, 0x81e5, 0x4110, 0x0c14
+ax_pose 117, 0x01ed, 0x00e0, 0x0c18
+ax_pose 118, 0x81f5, 0x00e0, 0x0c19
+ax_pose 119, 0x01ed, 0x0118, 0x0c1b
+ax_pose 120, 0x81f5, 0x0118, 0x0c1c
+ax_pose 121, 0x01fd, 0x00fb, 0x0c1e
+ax_pose_terminator
+sMoltresPose16:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose17:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose18:
+ax_pose 84, 0x01e5, 0x80e8, 0x0c00
+ax_pose 85, 0x81e5, 0x8108, 0x0c10
+ax_pose 86, 0x01d5, 0x40f1, 0x0c18
+ax_pose_terminator
+sMoltresPose19:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose20:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose21:
+ax_pose 59, 0x01ed, 0x0116, 0x0c00
+ax_pose 60, 0x01ed, 0x80f6, 0x0c01
+ax_pose 61, 0x41e5, 0x40e6, 0x0c11
+ax_pose 62, 0x01d5, 0x40eb, 0x0c15
+ax_pose_terminator
+sMoltresPose22:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose23:
+ax_pose 37, 0x01ce, 0x80ee, 0x0c00
+ax_pose 38, 0x81ce, 0x810e, 0x0c10
+ax_pose 39, 0x41f6, 0x00fe, 0x0c18
+ax_pose 40, 0x41ee, 0x00f1, 0x0c1a
+ax_pose 41, 0x41ee, 0x0101, 0x0c1c
+ax_pose_terminator
+sMoltresPose24:
+ax_pose 42, 0x01d5, 0x40ee, 0x0c00
+ax_pose 43, 0x4205, 0x010e, 0x0c04
+ax_pose 44, 0x01e5, 0x80ee, 0x0c06
+ax_pose 45, 0x81e5, 0x810e, 0x0c16
+ax_pose_terminator
+sMoltresPose25:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose26:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose27:
+ax_pose 16, 0x41e5, 0x80f0, 0x0c00
+ax_pose 17, 0x41f5, 0x40f0, 0x0c08
+ax_pose 18, 0x41dd, 0x00f8, 0x0c0c
+ax_pose 19, 0x41d5, 0x00f8, 0x0c0e
+ax_pose 20, 0x01fd, 0x00f0, 0x0c10
+ax_pose 21, 0x01f5, 0x00e0, 0x0c11
+ax_pose 22, 0x81fd, 0x00e0, 0x0c12
+ax_pose 23, 0x81ed, 0x40e8, 0x0c14
+ax_pose 24, 0x81ed, 0x4110, 0x0c18
+ax_pose 25, 0x01fd, 0x0108, 0x0c1c
+ax_pose 26, 0x01f5, 0x0118, 0x0c1d
+ax_pose 27, 0x81fd, 0x0118, 0x0c1e
+ax_pose_terminator
+sMoltresPose28:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose29:
+ax_pose 37, 0x01ce, 0x90f2, 0x0c00
+ax_pose 38, 0x81ce, 0x90e2, 0x0c10
+ax_pose 39, 0x41f6, 0x10f2, 0x0c18
+ax_pose 40, 0x41ee, 0x10ff, 0x0c1a
+ax_pose 41, 0x41ee, 0x10ef, 0x0c1c
+ax_pose_terminator
+sMoltresPose30:
+ax_pose 42, 0x01d5, 0x5102, 0x0c00
+ax_pose 43, 0x4205, 0x10e2, 0x0c04
+ax_pose 44, 0x01e5, 0x90f2, 0x0c06
+ax_pose 45, 0x81e5, 0x90e2, 0x0c16
+ax_pose_terminator
+sMoltresPose31:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose32:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose33:
+ax_pose 59, 0x01ed, 0x10e2, 0x0c00
+ax_pose 60, 0x01ed, 0x90ea, 0x0c01
+ax_pose 61, 0x41e5, 0x50fa, 0x0c11
+ax_pose 62, 0x01d5, 0x5105, 0x0c15
+ax_pose_terminator
+sMoltresPose34:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose35:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose36:
+ax_pose 84, 0x01e5, 0x90f8, 0x0c00
+ax_pose 85, 0x81e5, 0x90e8, 0x0c10
+ax_pose 86, 0x01d5, 0x50ff, 0x0c18
+ax_pose_terminator
+sMoltresPose37:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose38:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose39:
+ax_pose 111, 0x41f5, 0x40f0, 0x0c00
+ax_pose 112, 0x41e5, 0x80f0, 0x0c04
+ax_pose 113, 0x41d5, 0x00f8, 0x0c0c
+ax_pose 114, 0x41dd, 0x00f8, 0x0c0e
+ax_pose 115, 0x81e5, 0x40e8, 0x0c10
+ax_pose 116, 0x81e5, 0x4110, 0x0c14
+ax_pose 117, 0x01ed, 0x00e0, 0x0c18
+ax_pose 118, 0x81f5, 0x00e0, 0x0c19
+ax_pose 119, 0x01ed, 0x0118, 0x0c1b
+ax_pose 120, 0x81f5, 0x0118, 0x0c1c
+ax_pose 121, 0x01fd, 0x00fb, 0x0c1e
+ax_pose_terminator
+sMoltresPose40:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose41:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose42:
+ax_pose 84, 0x01e5, 0x80e8, 0x0c00
+ax_pose 85, 0x81e5, 0x8108, 0x0c10
+ax_pose 86, 0x01d5, 0x40f1, 0x0c18
+ax_pose_terminator
+sMoltresPose43:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose44:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose45:
+ax_pose 59, 0x01ed, 0x0116, 0x0c00
+ax_pose 60, 0x01ed, 0x80f6, 0x0c01
+ax_pose 61, 0x41e5, 0x40e6, 0x0c11
+ax_pose 62, 0x01d5, 0x40eb, 0x0c15
+ax_pose_terminator
+sMoltresPose46:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose47:
+ax_pose 37, 0x01ce, 0x80ee, 0x0c00
+ax_pose 38, 0x81ce, 0x810e, 0x0c10
+ax_pose 39, 0x41f6, 0x00fe, 0x0c18
+ax_pose 40, 0x41ee, 0x00f1, 0x0c1a
+ax_pose 41, 0x41ee, 0x0101, 0x0c1c
+ax_pose_terminator
+sMoltresPose48:
+ax_pose 42, 0x01d5, 0x40ee, 0x0c00
+ax_pose 43, 0x4205, 0x010e, 0x0c04
+ax_pose 44, 0x01e5, 0x80ee, 0x0c06
+ax_pose 45, 0x81e5, 0x810e, 0x0c16
+ax_pose_terminator
+sMoltresPose49:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose50:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose51:
+ax_pose 16, 0x41e5, 0x80f0, 0x0c00
+ax_pose 17, 0x41f5, 0x40f0, 0x0c08
+ax_pose 18, 0x41dd, 0x00f8, 0x0c0c
+ax_pose 19, 0x41d5, 0x00f8, 0x0c0e
+ax_pose 20, 0x01fd, 0x00f0, 0x0c10
+ax_pose 21, 0x01f5, 0x00e0, 0x0c11
+ax_pose 22, 0x81fd, 0x00e0, 0x0c12
+ax_pose 23, 0x81ed, 0x40e8, 0x0c14
+ax_pose 24, 0x81ed, 0x4110, 0x0c18
+ax_pose 25, 0x01fd, 0x0108, 0x0c1c
+ax_pose 26, 0x01f5, 0x0118, 0x0c1d
+ax_pose 27, 0x81fd, 0x0118, 0x0c1e
+ax_pose_terminator
+sMoltresPose52:
+ax_pose 122, 0x41d8, 0x80d0, 0x0c00
+ax_pose 123, 0x41d8, 0x80f0, 0x0c08
+ax_pose 124, 0x41d8, 0x8110, 0x0c10
+ax_pose 125, 0x41e8, 0x80e0, 0x0c18
+ax_pose 126, 0x41e8, 0x8100, 0x0c20
+ax_pose_terminator
+sMoltresPose53:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose54:
+ax_pose 37, 0x01ce, 0x90f2, 0x0c00
+ax_pose 38, 0x81ce, 0x90e2, 0x0c10
+ax_pose 39, 0x41f6, 0x10f2, 0x0c18
+ax_pose 40, 0x41ee, 0x10ff, 0x0c1a
+ax_pose 41, 0x41ee, 0x10ef, 0x0c1c
+ax_pose_terminator
+sMoltresPose55:
+ax_pose 42, 0x01d5, 0x5102, 0x0c00
+ax_pose 43, 0x4205, 0x10e2, 0x0c04
+ax_pose 44, 0x01e5, 0x90f2, 0x0c06
+ax_pose 45, 0x81e5, 0x90e2, 0x0c16
+ax_pose_terminator
+sMoltresPose56:
+ax_pose 127, 0x41d4, 0xd0e2, 0x0c00
+ax_pose 128, 0x01dc, 0x50d2, 0x0c20
+ax_pose 129, 0x41f4, 0x50ea, 0x0c24
+ax_pose_terminator
+sMoltresPose57:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose58:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose59:
+ax_pose 59, 0x01ed, 0x10e2, 0x0c00
+ax_pose 60, 0x01ed, 0x90ea, 0x0c01
+ax_pose 61, 0x41e5, 0x50fa, 0x0c11
+ax_pose 62, 0x01d5, 0x5105, 0x0c15
+ax_pose_terminator
+sMoltresPose60:
+ax_pose 130, 0x41d5, 0xd0da, 0x0c00
+ax_pose 131, 0x41c5, 0x90ea, 0x0c20
+ax_pose 132, 0x41f5, 0x50ea, 0x0c28
+ax_pose_terminator
+sMoltresPose61:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose62:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose63:
+ax_pose 84, 0x01e5, 0x90f8, 0x0c00
+ax_pose 85, 0x81e5, 0x90e8, 0x0c10
+ax_pose 86, 0x01d5, 0x50ff, 0x0c18
+ax_pose_terminator
+sMoltresPose64:
+ax_pose 133, 0x41dd, 0xd0e4, 0x0c00
+ax_pose 134, 0x41d5, 0x50d4, 0x0c20
+ax_pose 135, 0x01dd, 0x10dc, 0x0c24
+ax_pose_terminator
+sMoltresPose65:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose66:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose67:
+ax_pose 111, 0x41f5, 0x40f0, 0x0c00
+ax_pose 112, 0x41e5, 0x80f0, 0x0c04
+ax_pose 113, 0x41d5, 0x00f8, 0x0c0c
+ax_pose 114, 0x41dd, 0x00f8, 0x0c0e
+ax_pose 115, 0x81e5, 0x40e8, 0x0c10
+ax_pose 116, 0x81e5, 0x4110, 0x0c14
+ax_pose 117, 0x01ed, 0x00e0, 0x0c18
+ax_pose 118, 0x81f5, 0x00e0, 0x0c19
+ax_pose 119, 0x01ed, 0x0118, 0x0c1b
+ax_pose 120, 0x81f5, 0x0118, 0x0c1c
+ax_pose 121, 0x01fd, 0x00fb, 0x0c1e
+ax_pose_terminator
+sMoltresPose68:
+ax_pose 136, 0x41da, 0x80d0, 0x0c00
+ax_pose 137, 0x41ea, 0x40d0, 0x0c08
+ax_pose 138, 0x01da, 0x80f0, 0x0c0c
+ax_pose 139, 0x41da, 0x8110, 0x0c1c
+ax_pose 140, 0x41ea, 0x4110, 0x0c24
+ax_pose 141, 0x01fa, 0x40f8, 0x0c28
+ax_pose_terminator
+sMoltresPose69:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose70:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose71:
+ax_pose 84, 0x01e5, 0x80e8, 0x0c00
+ax_pose 85, 0x81e5, 0x8108, 0x0c10
+ax_pose 86, 0x01d5, 0x40f1, 0x0c18
+ax_pose_terminator
+sMoltresPose72:
+ax_pose 133, 0x41dd, 0xc0dc, 0x0c00
+ax_pose 134, 0x41d5, 0x410c, 0x0c20
+ax_pose 135, 0x01dd, 0x011c, 0x0c24
+ax_pose_terminator
+sMoltresPose73:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose74:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose75:
+ax_pose 59, 0x01ed, 0x0116, 0x0c00
+ax_pose 60, 0x01ed, 0x80f6, 0x0c01
+ax_pose 61, 0x41e5, 0x40e6, 0x0c11
+ax_pose 62, 0x01d5, 0x40eb, 0x0c15
+ax_pose_terminator
+sMoltresPose76:
+ax_pose 130, 0x41d5, 0xc0e6, 0x0c00
+ax_pose 131, 0x41c5, 0x80f6, 0x0c20
+ax_pose 132, 0x41f5, 0x40f6, 0x0c28
+ax_pose_terminator
+sMoltresPose77:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose78:
+ax_pose 37, 0x01ce, 0x80ee, 0x0c00
+ax_pose 38, 0x81ce, 0x810e, 0x0c10
+ax_pose 39, 0x41f6, 0x00fe, 0x0c18
+ax_pose 40, 0x41ee, 0x00f1, 0x0c1a
+ax_pose 41, 0x41ee, 0x0101, 0x0c1c
+ax_pose_terminator
+sMoltresPose79:
+ax_pose 42, 0x01d5, 0x40ee, 0x0c00
+ax_pose 43, 0x4205, 0x010e, 0x0c04
+ax_pose 44, 0x01e5, 0x80ee, 0x0c06
+ax_pose 45, 0x81e5, 0x810e, 0x0c16
+ax_pose_terminator
+sMoltresPose80:
+ax_pose 127, 0x41d4, 0xc0de, 0x0c00
+ax_pose 128, 0x01dc, 0x411e, 0x0c20
+ax_pose 129, 0x41f4, 0x40f6, 0x0c24
+ax_pose_terminator
+sMoltresPose81:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose82:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose83:
+ax_pose 16, 0x41e5, 0x80f0, 0x0c00
+ax_pose 17, 0x41f5, 0x40f0, 0x0c08
+ax_pose 18, 0x41dd, 0x00f8, 0x0c0c
+ax_pose 19, 0x41d5, 0x00f8, 0x0c0e
+ax_pose 20, 0x01fd, 0x00f0, 0x0c10
+ax_pose 21, 0x01f5, 0x00e0, 0x0c11
+ax_pose 22, 0x81fd, 0x00e0, 0x0c12
+ax_pose 23, 0x81ed, 0x40e8, 0x0c14
+ax_pose 24, 0x81ed, 0x4110, 0x0c18
+ax_pose 25, 0x01fd, 0x0108, 0x0c1c
+ax_pose 26, 0x01f5, 0x0118, 0x0c1d
+ax_pose 27, 0x81fd, 0x0118, 0x0c1e
+ax_pose_terminator
+sMoltresPose84:
+ax_pose 122, 0x41d8, 0x80d0, 0x0c00
+ax_pose 123, 0x41d8, 0x80f0, 0x0c08
+ax_pose 124, 0x41d8, 0x8110, 0x0c10
+ax_pose 125, 0x41e8, 0x80e0, 0x0c18
+ax_pose 126, 0x41e8, 0x8100, 0x0c20
+ax_pose_terminator
+sMoltresPose85:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose86:
+ax_pose 37, 0x01ce, 0x90f2, 0x0c00
+ax_pose 38, 0x81ce, 0x90e2, 0x0c10
+ax_pose 39, 0x41f6, 0x10f2, 0x0c18
+ax_pose 40, 0x41ee, 0x10ff, 0x0c1a
+ax_pose 41, 0x41ee, 0x10ef, 0x0c1c
+ax_pose_terminator
+sMoltresPose87:
+ax_pose 42, 0x01d5, 0x5102, 0x0c00
+ax_pose 43, 0x4205, 0x10e2, 0x0c04
+ax_pose 44, 0x01e5, 0x90f2, 0x0c06
+ax_pose 45, 0x81e5, 0x90e2, 0x0c16
+ax_pose_terminator
+sMoltresPose88:
+ax_pose 127, 0x41d4, 0xd0e2, 0x0c00
+ax_pose 128, 0x01dc, 0x50d2, 0x0c20
+ax_pose 129, 0x41f4, 0x50ea, 0x0c24
+ax_pose_terminator
+sMoltresPose89:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose90:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose91:
+ax_pose 59, 0x01ed, 0x10e2, 0x0c00
+ax_pose 60, 0x01ed, 0x90ea, 0x0c01
+ax_pose 61, 0x41e5, 0x50fa, 0x0c11
+ax_pose 62, 0x01d5, 0x5105, 0x0c15
+ax_pose_terminator
+sMoltresPose92:
+ax_pose 130, 0x41d5, 0xd0da, 0x0c00
+ax_pose 131, 0x41c5, 0x90ea, 0x0c20
+ax_pose 132, 0x41f5, 0x50ea, 0x0c28
+ax_pose_terminator
+sMoltresPose93:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose94:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose95:
+ax_pose 84, 0x01e5, 0x90f8, 0x0c00
+ax_pose 85, 0x81e5, 0x90e8, 0x0c10
+ax_pose 86, 0x01d5, 0x50ff, 0x0c18
+ax_pose_terminator
+sMoltresPose96:
+ax_pose 133, 0x41dd, 0xd0e4, 0x0c00
+ax_pose 134, 0x41d5, 0x50d4, 0x0c20
+ax_pose 135, 0x01dd, 0x10dc, 0x0c24
+ax_pose_terminator
+sMoltresPose97:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose98:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose99:
+ax_pose 111, 0x41f5, 0x40f0, 0x0c00
+ax_pose 112, 0x41e5, 0x80f0, 0x0c04
+ax_pose 113, 0x41d5, 0x00f8, 0x0c0c
+ax_pose 114, 0x41dd, 0x00f8, 0x0c0e
+ax_pose 115, 0x81e5, 0x40e8, 0x0c10
+ax_pose 116, 0x81e5, 0x4110, 0x0c14
+ax_pose 117, 0x01ed, 0x00e0, 0x0c18
+ax_pose 118, 0x81f5, 0x00e0, 0x0c19
+ax_pose 119, 0x01ed, 0x0118, 0x0c1b
+ax_pose 120, 0x81f5, 0x0118, 0x0c1c
+ax_pose 121, 0x01fd, 0x00fb, 0x0c1e
+ax_pose_terminator
+sMoltresPose100:
+ax_pose 136, 0x41da, 0x80d0, 0x0c00
+ax_pose 137, 0x41ea, 0x40d0, 0x0c08
+ax_pose 138, 0x01da, 0x80f0, 0x0c0c
+ax_pose 139, 0x41da, 0x8110, 0x0c1c
+ax_pose 140, 0x41ea, 0x4110, 0x0c24
+ax_pose 141, 0x01fa, 0x40f8, 0x0c28
+ax_pose_terminator
+sMoltresPose101:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose102:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose103:
+ax_pose 84, 0x01e5, 0x80e8, 0x0c00
+ax_pose 85, 0x81e5, 0x8108, 0x0c10
+ax_pose 86, 0x01d5, 0x40f1, 0x0c18
+ax_pose_terminator
+sMoltresPose104:
+ax_pose 133, 0x41dd, 0xc0dc, 0x0c00
+ax_pose 134, 0x41d5, 0x410c, 0x0c20
+ax_pose 135, 0x01dd, 0x011c, 0x0c24
+ax_pose_terminator
+sMoltresPose105:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose106:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose107:
+ax_pose 59, 0x01ed, 0x0116, 0x0c00
+ax_pose 60, 0x01ed, 0x80f6, 0x0c01
+ax_pose 61, 0x41e5, 0x40e6, 0x0c11
+ax_pose 62, 0x01d5, 0x40eb, 0x0c15
+ax_pose_terminator
+sMoltresPose108:
+ax_pose 130, 0x41d5, 0xc0e6, 0x0c00
+ax_pose 131, 0x41c5, 0x80f6, 0x0c20
+ax_pose 132, 0x41f5, 0x40f6, 0x0c28
+ax_pose_terminator
+sMoltresPose109:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose110:
+ax_pose 37, 0x01ce, 0x80ee, 0x0c00
+ax_pose 38, 0x81ce, 0x810e, 0x0c10
+ax_pose 39, 0x41f6, 0x00fe, 0x0c18
+ax_pose 40, 0x41ee, 0x00f1, 0x0c1a
+ax_pose 41, 0x41ee, 0x0101, 0x0c1c
+ax_pose_terminator
+sMoltresPose111:
+ax_pose 42, 0x01d5, 0x40ee, 0x0c00
+ax_pose 43, 0x4205, 0x010e, 0x0c04
+ax_pose 44, 0x01e5, 0x80ee, 0x0c06
+ax_pose 45, 0x81e5, 0x810e, 0x0c16
+ax_pose_terminator
+sMoltresPose112:
+ax_pose 127, 0x41d4, 0xc0de, 0x0c00
+ax_pose 128, 0x01dc, 0x411e, 0x0c20
+ax_pose 129, 0x41f4, 0x40f6, 0x0c24
+ax_pose_terminator
+sMoltresPose113:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose114:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose115:
+ax_pose 16, 0x41e5, 0x80f0, 0x0c00
+ax_pose 17, 0x41f5, 0x40f0, 0x0c08
+ax_pose 18, 0x41dd, 0x00f8, 0x0c0c
+ax_pose 19, 0x41d5, 0x00f8, 0x0c0e
+ax_pose 20, 0x01fd, 0x00f0, 0x0c10
+ax_pose 21, 0x01f5, 0x00e0, 0x0c11
+ax_pose 22, 0x81fd, 0x00e0, 0x0c12
+ax_pose 23, 0x81ed, 0x40e8, 0x0c14
+ax_pose 24, 0x81ed, 0x4110, 0x0c18
+ax_pose 25, 0x01fd, 0x0108, 0x0c1c
+ax_pose 26, 0x01f5, 0x0118, 0x0c1d
+ax_pose 27, 0x81fd, 0x0118, 0x0c1e
+ax_pose_terminator
+sMoltresPose116:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose117:
+ax_pose 37, 0x01ce, 0x90f2, 0x0c00
+ax_pose 38, 0x81ce, 0x90e2, 0x0c10
+ax_pose 39, 0x41f6, 0x10f2, 0x0c18
+ax_pose 40, 0x41ee, 0x10ff, 0x0c1a
+ax_pose 41, 0x41ee, 0x10ef, 0x0c1c
+ax_pose_terminator
+sMoltresPose118:
+ax_pose 42, 0x01d5, 0x5102, 0x0c00
+ax_pose 43, 0x4205, 0x10e2, 0x0c04
+ax_pose 44, 0x01e5, 0x90f2, 0x0c06
+ax_pose 45, 0x81e5, 0x90e2, 0x0c16
+ax_pose_terminator
+sMoltresPose119:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose120:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose121:
+ax_pose 59, 0x01ed, 0x10e2, 0x0c00
+ax_pose 60, 0x01ed, 0x90ea, 0x0c01
+ax_pose 61, 0x41e5, 0x50fa, 0x0c11
+ax_pose 62, 0x01d5, 0x5105, 0x0c15
+ax_pose_terminator
+sMoltresPose122:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose123:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose124:
+ax_pose 84, 0x01e5, 0x90f8, 0x0c00
+ax_pose 85, 0x81e5, 0x90e8, 0x0c10
+ax_pose 86, 0x01d5, 0x50ff, 0x0c18
+ax_pose_terminator
+sMoltresPose125:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose126:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose127:
+ax_pose 111, 0x41f5, 0x40f0, 0x0c00
+ax_pose 112, 0x41e5, 0x80f0, 0x0c04
+ax_pose 113, 0x41d5, 0x00f8, 0x0c0c
+ax_pose 114, 0x41dd, 0x00f8, 0x0c0e
+ax_pose 115, 0x81e5, 0x40e8, 0x0c10
+ax_pose 116, 0x81e5, 0x4110, 0x0c14
+ax_pose 117, 0x01ed, 0x00e0, 0x0c18
+ax_pose 118, 0x81f5, 0x00e0, 0x0c19
+ax_pose 119, 0x01ed, 0x0118, 0x0c1b
+ax_pose 120, 0x81f5, 0x0118, 0x0c1c
+ax_pose 121, 0x01fd, 0x00fb, 0x0c1e
+ax_pose_terminator
+sMoltresPose128:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose129:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose130:
+ax_pose 84, 0x01e5, 0x80e8, 0x0c00
+ax_pose 85, 0x81e5, 0x8108, 0x0c10
+ax_pose 86, 0x01d5, 0x40f1, 0x0c18
+ax_pose_terminator
+sMoltresPose131:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose132:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose133:
+ax_pose 59, 0x01ed, 0x0116, 0x0c00
+ax_pose 60, 0x01ed, 0x80f6, 0x0c01
+ax_pose 61, 0x41e5, 0x40e6, 0x0c11
+ax_pose 62, 0x01d5, 0x40eb, 0x0c15
+ax_pose_terminator
+sMoltresPose134:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose135:
+ax_pose 37, 0x01ce, 0x80ee, 0x0c00
+ax_pose 38, 0x81ce, 0x810e, 0x0c10
+ax_pose 39, 0x41f6, 0x00fe, 0x0c18
+ax_pose 40, 0x41ee, 0x00f1, 0x0c1a
+ax_pose 41, 0x41ee, 0x0101, 0x0c1c
+ax_pose_terminator
+sMoltresPose136:
+ax_pose 42, 0x01d5, 0x40ee, 0x0c00
+ax_pose 43, 0x4205, 0x010e, 0x0c04
+ax_pose 44, 0x01e5, 0x80ee, 0x0c06
+ax_pose 45, 0x81e5, 0x810e, 0x0c16
+ax_pose_terminator
+sMoltresPose137:
+ax_pose 142, 0x01e7, 0x80e8, 0x0c00
+ax_pose 143, 0x81df, 0x8108, 0x0c10
+ax_pose_terminator
+sMoltresPose138:
+ax_pose 144, 0x01e7, 0x80e8, 0x0c00
+ax_pose 145, 0x81df, 0x8108, 0x0c10
+ax_pose_terminator
+sMoltresPose139:
+ax_pose 146, 0x81ce, 0x80e8, 0x0c00
+ax_pose 147, 0x01fe, 0x0100, 0x0c08
+ax_pose 148, 0x01ee, 0x4100, 0x0c09
+ax_pose 149, 0x01ee, 0x40f0, 0x0c0d
+ax_pose 150, 0x01ce, 0x4108, 0x0c11
+ax_pose 151, 0x41de, 0x80f8, 0x0c15
+ax_pose 152, 0x41d6, 0x00f8, 0x0c1d
+ax_pose_terminator
+sMoltresPose140:
+ax_pose 153, 0x01d3, 0x90e5, 0x0c00
+ax_pose 154, 0x41f3, 0x10f7, 0x0c10
+ax_pose 155, 0x01f3, 0x110b, 0x0c12
+ax_pose 156, 0x41cb, 0x10f7, 0x0c13
+ax_pose 157, 0x81d3, 0x10dd, 0x0c15
+ax_pose 158, 0x01d8, 0x1105, 0x0c17
+ax_pose 159, 0x01c3, 0x10fc, 0x0c18
+ax_pose 160, 0x01cb, 0x10e1, 0x0c19
+ax_pose 161, 0x41eb, 0x1105, 0x0c1a
+ax_pose 162, 0x41fb, 0x10f9, 0x0c1c
+ax_pose 163, 0x01e3, 0x10dd, 0x0c1e
+ax_pose_terminator
+sMoltresPose141:
+ax_pose 164, 0x01cf, 0x90e0, 0x0c00
+ax_pose 165, 0x01ef, 0x10e8, 0x0c10
+ax_pose 166, 0x41ff, 0x10fc, 0x0c11
+ax_pose 167, 0x41ef, 0x90f0, 0x0c13
+ax_pose 168, 0x81cf, 0x5100, 0x0c1b
+ax_pose_terminator
+sMoltresPose142:
+ax_pose 169, 0x01d0, 0x90e6, 0x0c00
+ax_pose 170, 0x81e0, 0x1106, 0x0c10
+ax_pose 171, 0x01d8, 0x1106, 0x0c12
+ax_pose 172, 0x81d0, 0x510e, 0x0c13
+ax_pose 173, 0x0200, 0x10f6, 0x0c17
+ax_pose 174, 0x41f0, 0x90f0, 0x0c18
+ax_pose_terminator
+sMoltresPose143:
+ax_pose 175, 0x01d1, 0x80e7, 0x0c00
+ax_pose 176, 0x41f1, 0x40f0, 0x0c10
+ax_pose 177, 0x81e1, 0x0117, 0x0c14
+ax_pose 178, 0x81f9, 0x00fd, 0x0c16
+ax_pose 179, 0x81d1, 0x8107, 0x0c18
+ax_pose_terminator
+sMoltresPose144:
+ax_pose 169, 0x01d0, 0x80fa, 0x0c00
+ax_pose 170, 0x81e0, 0x00f2, 0x0c10
+ax_pose 171, 0x01d8, 0x00f2, 0x0c12
+ax_pose 172, 0x81d0, 0x40ea, 0x0c13
+ax_pose 173, 0x0200, 0x0102, 0x0c17
+ax_pose 174, 0x41f0, 0x80f0, 0x0c18
+ax_pose_terminator
+sMoltresPose145:
+ax_pose 164, 0x01cf, 0x8100, 0x0c00
+ax_pose 165, 0x01ef, 0x0110, 0x0c10
+ax_pose 166, 0x41ff, 0x00f4, 0x0c11
+ax_pose 167, 0x41ef, 0x80f0, 0x0c13
+ax_pose 168, 0x81cf, 0x40f8, 0x0c1b
+ax_pose_terminator
+sMoltresPose146:
+ax_pose 153, 0x01d3, 0x80fb, 0x0c00
+ax_pose 154, 0x41f3, 0x00f9, 0x0c10
+ax_pose 155, 0x01f3, 0x00ed, 0x0c12
+ax_pose 156, 0x41cb, 0x00f9, 0x0c13
+ax_pose 157, 0x81d3, 0x011b, 0x0c15
+ax_pose 158, 0x01d8, 0x00f3, 0x0c17
+ax_pose 159, 0x01c3, 0x00fc, 0x0c18
+ax_pose 160, 0x01cb, 0x0117, 0x0c19
+ax_pose 161, 0x41eb, 0x00eb, 0x0c1a
+ax_pose 162, 0x41fb, 0x00f7, 0x0c1c
+ax_pose 163, 0x01e3, 0x011b, 0x0c1e
+ax_pose_terminator
+sMoltresPose147:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose148:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose149:
+ax_pose 16, 0x41e5, 0x80f0, 0x0c00
+ax_pose 17, 0x41f5, 0x40f0, 0x0c08
+ax_pose 18, 0x41dd, 0x00f8, 0x0c0c
+ax_pose 19, 0x41d5, 0x00f8, 0x0c0e
+ax_pose 20, 0x01fd, 0x00f0, 0x0c10
+ax_pose 21, 0x01f5, 0x00e0, 0x0c11
+ax_pose 22, 0x81fd, 0x00e0, 0x0c12
+ax_pose 23, 0x81ed, 0x40e8, 0x0c14
+ax_pose 24, 0x81ed, 0x4110, 0x0c18
+ax_pose 25, 0x01fd, 0x0108, 0x0c1c
+ax_pose 26, 0x01f5, 0x0118, 0x0c1d
+ax_pose 27, 0x81fd, 0x0118, 0x0c1e
+ax_pose_terminator
+sMoltresPose150:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose151:
+ax_pose 37, 0x01ce, 0x90f2, 0x0c00
+ax_pose 38, 0x81ce, 0x90e2, 0x0c10
+ax_pose 39, 0x41f6, 0x10f2, 0x0c18
+ax_pose 40, 0x41ee, 0x10ff, 0x0c1a
+ax_pose 41, 0x41ee, 0x10ef, 0x0c1c
+ax_pose_terminator
+sMoltresPose152:
+ax_pose 42, 0x01d5, 0x5102, 0x0c00
+ax_pose 43, 0x4205, 0x10e2, 0x0c04
+ax_pose 44, 0x01e5, 0x90f2, 0x0c06
+ax_pose 45, 0x81e5, 0x90e2, 0x0c16
+ax_pose_terminator
+sMoltresPose153:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose154:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose155:
+ax_pose 59, 0x01ed, 0x10e2, 0x0c00
+ax_pose 60, 0x01ed, 0x90ea, 0x0c01
+ax_pose 61, 0x41e5, 0x50fa, 0x0c11
+ax_pose 62, 0x01d5, 0x5105, 0x0c15
+ax_pose_terminator
+sMoltresPose156:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose157:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose158:
+ax_pose 84, 0x01e5, 0x90f8, 0x0c00
+ax_pose 85, 0x81e5, 0x90e8, 0x0c10
+ax_pose 86, 0x01d5, 0x50ff, 0x0c18
+ax_pose_terminator
+sMoltresPose159:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose160:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose161:
+ax_pose 111, 0x41f5, 0x40f0, 0x0c00
+ax_pose 112, 0x41e5, 0x80f0, 0x0c04
+ax_pose 113, 0x41d5, 0x00f8, 0x0c0c
+ax_pose 114, 0x41dd, 0x00f8, 0x0c0e
+ax_pose 115, 0x81e5, 0x40e8, 0x0c10
+ax_pose 116, 0x81e5, 0x4110, 0x0c14
+ax_pose 117, 0x01ed, 0x00e0, 0x0c18
+ax_pose 118, 0x81f5, 0x00e0, 0x0c19
+ax_pose 119, 0x01ed, 0x0118, 0x0c1b
+ax_pose 120, 0x81f5, 0x0118, 0x0c1c
+ax_pose 121, 0x01fd, 0x00fb, 0x0c1e
+ax_pose_terminator
+sMoltresPose162:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose163:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose164:
+ax_pose 84, 0x01e5, 0x80e8, 0x0c00
+ax_pose 85, 0x81e5, 0x8108, 0x0c10
+ax_pose 86, 0x01d5, 0x40f1, 0x0c18
+ax_pose_terminator
+sMoltresPose165:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose166:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose167:
+ax_pose 59, 0x01ed, 0x0116, 0x0c00
+ax_pose 60, 0x01ed, 0x80f6, 0x0c01
+ax_pose 61, 0x41e5, 0x40e6, 0x0c11
+ax_pose 62, 0x01d5, 0x40eb, 0x0c15
+ax_pose_terminator
+sMoltresPose168:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose169:
+ax_pose 37, 0x01ce, 0x80ee, 0x0c00
+ax_pose 38, 0x81ce, 0x810e, 0x0c10
+ax_pose 39, 0x41f6, 0x00fe, 0x0c18
+ax_pose 40, 0x41ee, 0x00f1, 0x0c1a
+ax_pose 41, 0x41ee, 0x0101, 0x0c1c
+ax_pose_terminator
+sMoltresPose170:
+ax_pose 42, 0x01d5, 0x40ee, 0x0c00
+ax_pose 43, 0x4205, 0x010e, 0x0c04
+ax_pose 44, 0x01e5, 0x80ee, 0x0c06
+ax_pose 45, 0x81e5, 0x810e, 0x0c16
+ax_pose_terminator
+sMoltresPose171:
+ax_pose 180, 0x01d8, 0x80d0, 0x0c00
+ax_pose 181, 0x01d8, 0x80f0, 0x0c10
+ax_pose -1, 0x01d8, 0x910f, 0x0c00
+ax_pose_terminator
+sMoltresPose172:
+ax_pose 182, 0x41e4, 0x80e6, 0x0c00
+ax_pose 183, 0x41d4, 0x80de, 0x0c08
+ax_pose 128, 0x01dc, 0x411e, 0x0c10
+ax_pose 184, 0x01e4, 0x4106, 0x0c14
+ax_pose 185, 0x81e4, 0x0116, 0x0c18
+ax_pose 186, 0x41f4, 0x00f7, 0x0c1a
+ax_pose 187, 0x41dc, 0x010e, 0x0c1c
+ax_pose_terminator
+sMoltresPose173:
+ax_pose 188, 0x41cd, 0x00fa, 0x0c00
+ax_pose 189, 0x01c5, 0x00fa, 0x0c02
+ax_pose 190, 0x41e5, 0x8106, 0x0c03
+ax_pose 191, 0x01cd, 0x010a, 0x0c0b
+ax_pose 192, 0x41dd, 0x010e, 0x0c0c
+ax_pose 193, 0x81d5, 0x0106, 0x0c0e
+ax_pose 194, 0x41f5, 0x00fa, 0x0c10
+ax_pose 195, 0x41dd, 0x00e6, 0x0c12
+ax_pose 196, 0x01d5, 0x40f6, 0x0c14
+ax_pose 197, 0x41e5, 0x80e6, 0x0c18
+ax_pose_terminator
+sMoltresPose174:
+ax_pose 198, 0x01dd, 0x80fc, 0x0c00
+ax_pose 135, 0x01dd, 0x011c, 0x0c10
+ax_pose 199, 0x01dd, 0x00f4, 0x0c11
+ax_pose 200, 0x41e5, 0x40dc, 0x0c12
+ax_pose 201, 0x41ed, 0x40dc, 0x0c16
+ax_pose 202, 0x41d5, 0x0110, 0x0c1a
+ax_pose 203, 0x41f5, 0x00ec, 0x0c1c
+ax_pose 204, 0x01f5, 0x00e4, 0x0c1e
+ax_pose 205, 0x01d5, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose175:
+ax_pose 136, 0x41da, 0x80d0, 0x0c00
+ax_pose 137, 0x41ea, 0x40d0, 0x0c08
+ax_pose -1, 0x41da, 0x910f, 0x0c00
+ax_pose -1, 0x41ea, 0x510f, 0x0c08
+ax_pose 138, 0x01da, 0x80f0, 0x0c0c
+ax_pose 141, 0x01fa, 0x40f8, 0x0c1c
+ax_pose_terminator
+sMoltresPose176:
+ax_pose 198, 0x01dd, 0x90e4, 0x0c00
+ax_pose 135, 0x01dd, 0x10dc, 0x0c10
+ax_pose 199, 0x01dd, 0x1104, 0x0c11
+ax_pose 200, 0x41e5, 0x5104, 0x0c12
+ax_pose 201, 0x41ed, 0x5104, 0x0c16
+ax_pose 202, 0x41d5, 0x10e0, 0x0c1a
+ax_pose 203, 0x41f5, 0x1104, 0x0c1c
+ax_pose 204, 0x01f5, 0x1114, 0x0c1e
+ax_pose 205, 0x01d5, 0x10d8, 0x0c1f
+ax_pose_terminator
+sMoltresPose177:
+ax_pose 188, 0x41cd, 0x10f6, 0x0c00
+ax_pose 189, 0x01c5, 0x10fe, 0x0c02
+ax_pose 190, 0x41e5, 0x90da, 0x0c03
+ax_pose 191, 0x01cd, 0x10ee, 0x0c0b
+ax_pose 192, 0x41dd, 0x10e2, 0x0c0c
+ax_pose 193, 0x81d5, 0x10f2, 0x0c0e
+ax_pose 194, 0x41f5, 0x10f6, 0x0c10
+ax_pose 195, 0x41dd, 0x110a, 0x0c12
+ax_pose 196, 0x01d5, 0x50fa, 0x0c14
+ax_pose 197, 0x41e5, 0x90fa, 0x0c18
+ax_pose_terminator
+sMoltresPose178:
+ax_pose 182, 0x41e4, 0x90fa, 0x0c00
+ax_pose 183, 0x41d4, 0x9102, 0x0c08
+ax_pose 128, 0x01dc, 0x50d2, 0x0c10
+ax_pose 184, 0x01e4, 0x50ea, 0x0c14
+ax_pose 185, 0x81e4, 0x10e2, 0x0c18
+ax_pose 186, 0x41f4, 0x10f9, 0x0c1a
+ax_pose 187, 0x41dc, 0x10e2, 0x0c1c
+ax_pose_terminator
+sMoltresPose179:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose180:
+ax_pose 37, 0x01ce, 0x90f4, 0x0c00
+ax_pose 38, 0x81ce, 0x90e4, 0x0c10
+ax_pose 39, 0x41f6, 0x10f4, 0x0c18
+ax_pose 40, 0x41ee, 0x1101, 0x0c1a
+ax_pose 41, 0x41ee, 0x10f1, 0x0c1c
+ax_pose_terminator
+sMoltresPose181:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose182:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose183:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose184:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose185:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose186:
+ax_pose 37, 0x01ce, 0x80ec, 0x0c00
+ax_pose 38, 0x81ce, 0x810c, 0x0c10
+ax_pose 39, 0x41f6, 0x00fc, 0x0c18
+ax_pose 40, 0x41ee, 0x00ef, 0x0c1a
+ax_pose 41, 0x41ee, 0x00ff, 0x0c1c
+ax_pose_terminator
+sMoltresPose187:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose188:
+ax_pose 9, 0x81cd, 0x00e0, 0x0c00
+ax_pose 10, 0x81cd, 0x0118, 0x0c02
+ax_pose 11, 0x81cd, 0x40e8, 0x0c04
+ax_pose 12, 0x81cd, 0x4110, 0x0c08
+ax_pose 13, 0x01d5, 0x80f0, 0x0c0c
+ax_pose 14, 0x01f5, 0x00f8, 0x0c1c
+ax_pose 15, 0x01f5, 0x0100, 0x0c1d
+ax_pose_terminator
+sMoltresPose189:
+ax_pose 16, 0x41e5, 0x80f0, 0x0c00
+ax_pose 17, 0x41f5, 0x40f0, 0x0c08
+ax_pose 18, 0x41dd, 0x00f8, 0x0c0c
+ax_pose 19, 0x41d5, 0x00f8, 0x0c0e
+ax_pose 20, 0x01fd, 0x00f0, 0x0c10
+ax_pose 21, 0x01f5, 0x00e0, 0x0c11
+ax_pose 22, 0x81fd, 0x00e0, 0x0c12
+ax_pose 23, 0x81ed, 0x40e8, 0x0c14
+ax_pose 24, 0x81ed, 0x4110, 0x0c18
+ax_pose 25, 0x01fd, 0x0108, 0x0c1c
+ax_pose 26, 0x01f5, 0x0118, 0x0c1d
+ax_pose 27, 0x81fd, 0x0118, 0x0c1e
+ax_pose_terminator
+sMoltresPose190:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose191:
+ax_pose 37, 0x01ce, 0x90f2, 0x0c00
+ax_pose 38, 0x81ce, 0x90e2, 0x0c10
+ax_pose 39, 0x41f6, 0x10f2, 0x0c18
+ax_pose 40, 0x41ee, 0x10ff, 0x0c1a
+ax_pose 41, 0x41ee, 0x10ef, 0x0c1c
+ax_pose_terminator
+sMoltresPose192:
+ax_pose 42, 0x01d5, 0x5102, 0x0c00
+ax_pose 43, 0x4205, 0x10e2, 0x0c04
+ax_pose 44, 0x01e5, 0x90f2, 0x0c06
+ax_pose 45, 0x81e5, 0x90e2, 0x0c16
+ax_pose_terminator
+sMoltresPose193:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose194:
+ax_pose 55, 0x01cd, 0x90e8, 0x0c00
+ax_pose 56, 0x01e0, 0x5108, 0x0c10
+ax_pose 57, 0x41ed, 0x90e8, 0x0c14
+ax_pose 58, 0x41fd, 0x10e8, 0x0c1c
+ax_pose_terminator
+sMoltresPose195:
+ax_pose 59, 0x01ed, 0x10e2, 0x0c00
+ax_pose 60, 0x01ed, 0x90ea, 0x0c01
+ax_pose 61, 0x41e5, 0x50fa, 0x0c11
+ax_pose 62, 0x01d5, 0x5105, 0x0c15
+ax_pose_terminator
+sMoltresPose196:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose197:
+ax_pose 74, 0x81d6, 0x9110, 0x0c00
+ax_pose 75, 0x01de, 0x5100, 0x0c08
+ax_pose 76, 0x41ee, 0x1100, 0x0c0c
+ax_pose 77, 0x01fd, 0x10f0, 0x0c0e
+ax_pose 78, 0x81d5, 0x50f8, 0x0c0f
+ax_pose 79, 0x81cd, 0x90e8, 0x0c13
+ax_pose 80, 0x81f5, 0x10f8, 0x0c1b
+ax_pose 81, 0x01ed, 0x10f0, 0x0c1d
+ax_pose 82, 0x01f5, 0x10f0, 0x0c1e
+ax_pose 83, 0x01f6, 0x1100, 0x0c1f
+ax_pose_terminator
+sMoltresPose198:
+ax_pose 84, 0x01e5, 0x90f8, 0x0c00
+ax_pose 85, 0x81e5, 0x90e8, 0x0c10
+ax_pose 86, 0x01d5, 0x50ff, 0x0c18
+ax_pose_terminator
+sMoltresPose199:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose200:
+ax_pose 101, 0x41fd, 0x00f8, 0x0c00
+ax_pose 102, 0x81dd, 0x80f8, 0x0c02
+ax_pose 103, 0x81d5, 0x4108, 0x0c0a
+ax_pose 104, 0x01cd, 0x4110, 0x0c0e
+ax_pose 105, 0x41dd, 0x0110, 0x0c12
+ax_pose 106, 0x01e5, 0x0110, 0x0c14
+ax_pose 107, 0x01cd, 0x40e0, 0x0c15
+ax_pose 108, 0x41dd, 0x00e0, 0x0c19
+ax_pose 109, 0x01e5, 0x00e8, 0x0c1b
+ax_pose 110, 0x81d5, 0x40f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose201:
+ax_pose 111, 0x41f5, 0x40f0, 0x0c00
+ax_pose 112, 0x41e5, 0x80f0, 0x0c04
+ax_pose 113, 0x41d5, 0x00f8, 0x0c0c
+ax_pose 114, 0x41dd, 0x00f8, 0x0c0e
+ax_pose 115, 0x81e5, 0x40e8, 0x0c10
+ax_pose 116, 0x81e5, 0x4110, 0x0c14
+ax_pose 117, 0x01ed, 0x00e0, 0x0c18
+ax_pose 118, 0x81f5, 0x00e0, 0x0c19
+ax_pose 119, 0x01ed, 0x0118, 0x0c1b
+ax_pose 120, 0x81f5, 0x0118, 0x0c1c
+ax_pose 121, 0x01fd, 0x00fb, 0x0c1e
+ax_pose_terminator
+sMoltresPose202:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose203:
+ax_pose 74, 0x81d6, 0x80e0, 0x0c00
+ax_pose 75, 0x01de, 0x40f0, 0x0c08
+ax_pose 76, 0x41ee, 0x00f0, 0x0c0c
+ax_pose 77, 0x01fd, 0x0108, 0x0c0e
+ax_pose 78, 0x81d5, 0x4100, 0x0c0f
+ax_pose 79, 0x81cd, 0x8108, 0x0c13
+ax_pose 80, 0x81f5, 0x0100, 0x0c1b
+ax_pose 81, 0x01ed, 0x0108, 0x0c1d
+ax_pose 82, 0x01f5, 0x0108, 0x0c1e
+ax_pose 83, 0x01f6, 0x00f8, 0x0c1f
+ax_pose_terminator
+sMoltresPose204:
+ax_pose 84, 0x01e5, 0x80e8, 0x0c00
+ax_pose 85, 0x81e5, 0x8108, 0x0c10
+ax_pose 86, 0x01d5, 0x40f1, 0x0c18
+ax_pose_terminator
+sMoltresPose205:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose206:
+ax_pose 55, 0x01cd, 0x80f8, 0x0c00
+ax_pose 56, 0x01e0, 0x40e8, 0x0c10
+ax_pose 57, 0x41ed, 0x80f8, 0x0c14
+ax_pose 58, 0x41fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose207:
+ax_pose 59, 0x01ed, 0x0116, 0x0c00
+ax_pose 60, 0x01ed, 0x80f6, 0x0c01
+ax_pose 61, 0x41e5, 0x40e6, 0x0c11
+ax_pose 62, 0x01d5, 0x40eb, 0x0c15
+ax_pose_terminator
+sMoltresPose208:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose209:
+ax_pose 37, 0x01ce, 0x80ee, 0x0c00
+ax_pose 38, 0x81ce, 0x810e, 0x0c10
+ax_pose 39, 0x41f6, 0x00fe, 0x0c18
+ax_pose 40, 0x41ee, 0x00f1, 0x0c1a
+ax_pose 41, 0x41ee, 0x0101, 0x0c1c
+ax_pose_terminator
+sMoltresPose210:
+ax_pose 42, 0x01d5, 0x40ee, 0x0c00
+ax_pose 43, 0x4205, 0x010e, 0x0c04
+ax_pose 44, 0x01e5, 0x80ee, 0x0c06
+ax_pose 45, 0x81e5, 0x810e, 0x0c16
+ax_pose_terminator
+sMoltresPose211:
+ax_pose 180, 0x01d8, 0x80d0, 0x0c00
+ax_pose 181, 0x01d8, 0x80f0, 0x0c10
+ax_pose -1, 0x01d8, 0x910f, 0x0c00
+ax_pose_terminator
+sMoltresPose212:
+ax_pose 182, 0x41e4, 0x80e6, 0x0c00
+ax_pose 183, 0x41d4, 0x80de, 0x0c08
+ax_pose 128, 0x01dc, 0x411e, 0x0c10
+ax_pose 184, 0x01e4, 0x4106, 0x0c14
+ax_pose 185, 0x81e4, 0x0116, 0x0c18
+ax_pose 186, 0x41f4, 0x00f7, 0x0c1a
+ax_pose 187, 0x41dc, 0x010e, 0x0c1c
+ax_pose_terminator
+sMoltresPose213:
+ax_pose 188, 0x41cd, 0x00fa, 0x0c00
+ax_pose 189, 0x01c5, 0x00fa, 0x0c02
+ax_pose 190, 0x41e5, 0x8106, 0x0c03
+ax_pose 191, 0x01cd, 0x010a, 0x0c0b
+ax_pose 192, 0x41dd, 0x010e, 0x0c0c
+ax_pose 193, 0x81d5, 0x0106, 0x0c0e
+ax_pose 194, 0x41f5, 0x00fa, 0x0c10
+ax_pose 195, 0x41dd, 0x00e6, 0x0c12
+ax_pose 196, 0x01d5, 0x40f6, 0x0c14
+ax_pose 197, 0x41e5, 0x80e6, 0x0c18
+ax_pose_terminator
+sMoltresPose214:
+ax_pose 198, 0x01dd, 0x80fc, 0x0c00
+ax_pose 135, 0x01dd, 0x011c, 0x0c10
+ax_pose 199, 0x01dd, 0x00f4, 0x0c11
+ax_pose 200, 0x41e5, 0x40dc, 0x0c12
+ax_pose 201, 0x41ed, 0x40dc, 0x0c16
+ax_pose 202, 0x41d5, 0x0110, 0x0c1a
+ax_pose 203, 0x41f5, 0x00ec, 0x0c1c
+ax_pose 204, 0x01f5, 0x00e4, 0x0c1e
+ax_pose 205, 0x01d5, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose215:
+ax_pose 136, 0x41da, 0x80d0, 0x0c00
+ax_pose 137, 0x41ea, 0x40d0, 0x0c08
+ax_pose -1, 0x41da, 0x910f, 0x0c00
+ax_pose -1, 0x41ea, 0x510f, 0x0c08
+ax_pose 138, 0x01da, 0x80f0, 0x0c0c
+ax_pose 141, 0x01fa, 0x40f8, 0x0c1c
+ax_pose_terminator
+sMoltresPose216:
+ax_pose 198, 0x01dd, 0x90e4, 0x0c00
+ax_pose 135, 0x01dd, 0x10dc, 0x0c10
+ax_pose 199, 0x01dd, 0x1104, 0x0c11
+ax_pose 200, 0x41e5, 0x5104, 0x0c12
+ax_pose 201, 0x41ed, 0x5104, 0x0c16
+ax_pose 202, 0x41d5, 0x10e0, 0x0c1a
+ax_pose 203, 0x41f5, 0x1104, 0x0c1c
+ax_pose 204, 0x01f5, 0x1114, 0x0c1e
+ax_pose 205, 0x01d5, 0x10d8, 0x0c1f
+ax_pose_terminator
+sMoltresPose217:
+ax_pose 188, 0x41cd, 0x10f6, 0x0c00
+ax_pose 189, 0x01c5, 0x10fe, 0x0c02
+ax_pose 190, 0x41e5, 0x90da, 0x0c03
+ax_pose 191, 0x01cd, 0x10ee, 0x0c0b
+ax_pose 192, 0x41dd, 0x10e2, 0x0c0c
+ax_pose 193, 0x81d5, 0x10f2, 0x0c0e
+ax_pose 194, 0x41f5, 0x10f6, 0x0c10
+ax_pose 195, 0x41dd, 0x110a, 0x0c12
+ax_pose 196, 0x01d5, 0x50fa, 0x0c14
+ax_pose 197, 0x41e5, 0x90fa, 0x0c18
+ax_pose_terminator
+sMoltresPose218:
+ax_pose 182, 0x41e4, 0x90fa, 0x0c00
+ax_pose 183, 0x41d4, 0x9102, 0x0c08
+ax_pose 128, 0x01dc, 0x50d2, 0x0c10
+ax_pose 184, 0x01e4, 0x50ea, 0x0c14
+ax_pose 185, 0x81e4, 0x10e2, 0x0c18
+ax_pose 186, 0x41f4, 0x10f9, 0x0c1a
+ax_pose 187, 0x41dc, 0x10e2, 0x0c1c
+ax_pose_terminator
+sMoltresPose219:
+ax_pose 0, 0x01da, 0x80f0, 0x0c00
+ax_pose 1, 0x01d5, 0x40e0, 0x0c10
+ax_pose 2, 0x01d5, 0x4110, 0x0c14
+ax_pose 3, 0x41e5, 0x00e0, 0x0c18
+ax_pose 4, 0x41e5, 0x0110, 0x0c1a
+ax_pose 5, 0x01d5, 0x00d8, 0x0c1c
+ax_pose 6, 0x01dd, 0x00d8, 0x0c1d
+ax_pose 7, 0x01d5, 0x0120, 0x0c1e
+ax_pose 8, 0x01dd, 0x0120, 0x0c1f
+ax_pose_terminator
+sMoltresPose220:
+ax_pose 28, 0x01cd, 0x40e8, 0x0c00
+ax_pose 29, 0x01d9, 0x4110, 0x0c04
+ax_pose 30, 0x81d9, 0x0120, 0x0c08
+ax_pose 31, 0x01e9, 0x0110, 0x0c0a
+ax_pose 32, 0x41dd, 0x80f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x4100, 0x0c13
+ax_pose 34, 0x41ed, 0x00f0, 0x0c17
+ax_pose 35, 0x01dd, 0x00e8, 0x0c19
+ax_pose 36, 0x01f5, 0x00f8, 0x0c1a
+ax_pose_terminator
+sMoltresPose221:
+ax_pose 46, 0x01d5, 0x8100, 0x0c00
+ax_pose 47, 0x81d5, 0x00f0, 0x0c10
+ax_pose 48, 0x81d5, 0x00e8, 0x0c12
+ax_pose 49, 0x01e5, 0x00e8, 0x0c14
+ax_pose 50, 0x41f5, 0x0100, 0x0c15
+ax_pose 51, 0x01cd, 0x0100, 0x0c17
+ax_pose 52, 0x01e5, 0x00f0, 0x0c18
+ax_pose 53, 0x81d5, 0x40f8, 0x0c19
+ax_pose 54, 0x01f5, 0x0110, 0x0c1d
+ax_pose_terminator
+sMoltresPose222:
+ax_pose 63, 0x41dd, 0x80e0, 0x0c00
+ax_pose 64, 0x41ed, 0x40e0, 0x0c08
+ax_pose 65, 0x01d5, 0x4100, 0x0c0c
+ax_pose 66, 0x41e5, 0x0100, 0x0c10
+ax_pose 67, 0x41d5, 0x00f0, 0x0c12
+ax_pose 68, 0x41ed, 0x0100, 0x0c14
+ax_pose 69, 0x41f5, 0x00fd, 0x0c16
+ax_pose 70, 0x01f5, 0x010d, 0x0c18
+ax_pose 71, 0x01fd, 0x0100, 0x0c19
+ax_pose 72, 0x01d3, 0x4110, 0x0c1a
+ax_pose 73, 0x41e3, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose223:
+ax_pose 87, 0x81d9, 0x80f8, 0x0c00
+ax_pose 88, 0x41f9, 0x00f8, 0x0c08
+ax_pose 89, 0x01dd, 0x00f0, 0x0c0a
+ax_pose 90, 0x01dd, 0x0108, 0x0c0b
+ax_pose 91, 0x81e5, 0x00f0, 0x0c0c
+ax_pose 92, 0x81e5, 0x0108, 0x0c0e
+ax_pose 93, 0x01d5, 0x00d8, 0x0c10
+ax_pose 94, 0x41d5, 0x00e0, 0x0c11
+ax_pose 95, 0x01dd, 0x00d8, 0x0c13
+ax_pose 96, 0x01dd, 0x40e0, 0x0c14
+ax_pose 97, 0x01dd, 0x4110, 0x0c18
+ax_pose 98, 0x01dd, 0x0120, 0x0c1c
+ax_pose 99, 0x01d5, 0x0120, 0x0c1d
+ax_pose 100, 0x41d5, 0x0110, 0x0c1e
+ax_pose_terminator
+sMoltresPose224:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose225:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose226:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose227:
+ax_pose 28, 0x01cd, 0x5108, 0x0c00
+ax_pose 29, 0x01d9, 0x50e0, 0x0c04
+ax_pose 30, 0x81d9, 0x10d8, 0x0c08
+ax_pose 31, 0x01e9, 0x10e8, 0x0c0a
+ax_pose 32, 0x41dd, 0x90f0, 0x0c0b
+ax_pose 33, 0x01ed, 0x50f0, 0x0c13
+ax_pose 34, 0x41ed, 0x1100, 0x0c17
+ax_pose 35, 0x01dd, 0x1110, 0x0c19
+ax_pose 36, 0x01f5, 0x1100, 0x0c1a
+ax_pose_terminator
+sMoltresPose228:
+ax_pose 46, 0x01d5, 0x90e0, 0x0c00
+ax_pose 47, 0x81d5, 0x1108, 0x0c10
+ax_pose 48, 0x81d5, 0x1110, 0x0c12
+ax_pose 49, 0x01e5, 0x1110, 0x0c14
+ax_pose 50, 0x41f5, 0x10f0, 0x0c15
+ax_pose 51, 0x01cd, 0x10f8, 0x0c17
+ax_pose 52, 0x01e5, 0x1108, 0x0c18
+ax_pose 53, 0x81d5, 0x5100, 0x0c19
+ax_pose 54, 0x01f5, 0x10e8, 0x0c1d
+ax_pose_terminator
+sMoltresPose229:
+ax_pose 63, 0x41dd, 0x9100, 0x0c00
+ax_pose 64, 0x41ed, 0x5100, 0x0c08
+ax_pose 65, 0x01d5, 0x50f0, 0x0c0c
+ax_pose 66, 0x41e5, 0x10f0, 0x0c10
+ax_pose 67, 0x41d5, 0x1100, 0x0c12
+ax_pose 68, 0x41ed, 0x10f0, 0x0c14
+ax_pose 69, 0x41f5, 0x10f3, 0x0c16
+ax_pose 70, 0x01f5, 0x10eb, 0x0c18
+ax_pose 71, 0x01fd, 0x10f8, 0x0c19
+ax_pose 72, 0x01d3, 0x50e0, 0x0c1a
+ax_pose 73, 0x41e3, 0x10e0, 0x0c1e
+ax_pose_terminator
+sMoltresPose230:
+ax_pose 206, 0x41f5, 0x80d8, 0x0c00
+ax_pose 207, 0x01e5, 0x80f8, 0x0c08
+ax_pose 208, 0x01f5, 0x4118, 0x0c18
+ax_pose 209, 0x01ed, 0x00f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose231:
+ax_pose 210, 0x41f5, 0x80d8, 0x0c00
+ax_pose 211, 0x01e5, 0x80f8, 0x0c08
+ax_pose 212, 0x01f5, 0x4118, 0x0c18
+ax_pose 213, 0x01ed, 0x00f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose232:
+ax_pose 206, 0x41f5, 0x80d8, 0x0c00
+ax_pose 207, 0x01e5, 0x80f8, 0x0c08
+ax_pose 208, 0x01f5, 0x4118, 0x0c18
+ax_pose 209, 0x01ed, 0x00f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose233:
+ax_pose 210, 0x41f5, 0x80d8, 0x0c00
+ax_pose 211, 0x01e5, 0x80f8, 0x0c08
+ax_pose 212, 0x01f5, 0x4118, 0x0c18
+ax_pose 213, 0x01ed, 0x00f0, 0x0c1c
+ax_pose_terminator
+sMoltresPose234:
+ax_pose 214, 0x41f5, 0x80d4, 0x0c00
+ax_pose 215, 0x01e5, 0x80f4, 0x0c08
+ax_pose 216, 0x01f5, 0x4114, 0x0c18
+ax_pose_terminator
+sMoltresPose235:
+ax_pose 217, 0x41e9, 0x80d8, 0x0c00
+ax_pose 218, 0x01e1, 0x80f8, 0x0c08
+ax_pose 219, 0x01e9, 0x4118, 0x0c18
+ax_pose 220, 0x4201, 0x00f8, 0x0c1c
+ax_pose_terminator
+sMoltresPose236:
+ax_pose 221, 0x01d5, 0x80f0, 0x0c00
+ax_pose 222, 0x81d5, 0x90e1, 0x0c10
+ax_pose -1, 0x81d5, 0x8110, 0x0c10
+ax_pose 223, 0x01f5, 0x40f8, 0x0c18
+ax_pose 224, 0x01fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose237:
+ax_pose 221, 0x01d5, 0x80f0, 0x0c00
+ax_pose 222, 0x81d5, 0x90e1, 0x0c10
+ax_pose -1, 0x81d5, 0x8110, 0x0c10
+ax_pose 223, 0x01f5, 0x40f8, 0x0c18
+ax_pose 224, 0x01fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose238:
+ax_pose 225, 0x81e5, 0x4114, 0x0c00
+ax_pose 226, 0x81e5, 0x8104, 0x0c04
+ax_pose 227, 0x01e5, 0x80e4, 0x0c0c
+ax_pose 228, 0x01dd, 0x00fc, 0x0c1c
+ax_pose_terminator
+sMoltresPose239:
+ax_pose 229, 0x01e5, 0x80ec, 0x0c00
+ax_pose 230, 0x81e5, 0x410c, 0x0c10
+ax_pose 231, 0x01dd, 0x00fc, 0x0c14
+ax_pose_terminator
+sMoltresPose240:
+ax_pose 232, 0x01e5, 0x80f4, 0x0c00
+ax_pose 233, 0x01dd, 0x00fc, 0x0c10
+ax_pose_terminator
+sMoltresPose241:
+ax_pose 217, 0x41e9, 0x80d8, 0x0c00
+ax_pose 218, 0x01e1, 0x80f8, 0x0c08
+ax_pose 219, 0x01e9, 0x4118, 0x0c18
+ax_pose 220, 0x4201, 0x00f8, 0x0c1c
+ax_pose_terminator
+sMoltresPose242:
+ax_pose 221, 0x01d5, 0x80f0, 0x0c00
+ax_pose 222, 0x81d5, 0x90e1, 0x0c10
+ax_pose -1, 0x81d5, 0x8110, 0x0c10
+ax_pose 223, 0x01f5, 0x40f8, 0x0c18
+ax_pose 224, 0x01fd, 0x0108, 0x0c1c
+ax_pose_terminator
+sMoltresPose243:
+ax_pose 229, 0x01e5, 0x80ec, 0x0c00
+ax_pose 230, 0x81e5, 0x410c, 0x0c10
+ax_pose 231, 0x01dd, 0x00fc, 0x0c14
+ax_pose_terminator
+sMoltresPose244:
+ax_pose 232, 0x01e5, 0x80f4, 0x0c00
+ax_pose 233, 0x01dd, 0x00fc, 0x0c10
+ax_pose_terminator
+.align 2
+sMoltresAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 0, 5, 0, 4,
+ax_anim 1, 2, 25, 0, 10, 0, 8,
+ax_anim 1, 0, 25, 0, 15, 0, 13,
+ax_anim 2, 0, 25, 0, 28, 0, 23,
+ax_anim 2, 1, 25, 1, 28, 1, 23,
+ax_anim 2, 0, 25, 0, 28, 0, 23,
+ax_anim 2, 0, 25, 1, 28, 1, 23,
+ax_anim 2, 0, 25, 0, 28, 0, 23,
+ax_anim 2, 0, 26, 0, 13, 0, 13,
+ax_anim_terminator
+sMoltresAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 5, 5, 5, 5,
+ax_anim 1, 2, 28, 10, 13, 10, 11,
+ax_anim 1, 0, 28, 15, 20, 15, 18,
+ax_anim 2, 0, 28, 20, 28, 20, 25,
+ax_anim 2, 1, 28, 21, 27, 21, 24,
+ax_anim 2, 0, 28, 20, 28, 20, 25,
+ax_anim 2, 0, 28, 21, 27, 21, 24,
+ax_anim 2, 0, 28, 20, 28, 20, 25,
+ax_anim 2, 0, 29, 13, 15, 13, 15,
+ax_anim_terminator
+sMoltresAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 3, 0, 3, 0,
+ax_anim 1, 2, 31, 8, 1, 8, 0,
+ax_anim 1, 0, 31, 14, 2, 14, 0,
+ax_anim 2, 0, 31, 19, 3, 19, 0,
+ax_anim 2, 1, 31, 19, 2, 19, 0,
+ax_anim 2, 0, 31, 19, 3, 19, 0,
+ax_anim 2, 0, 31, 19, 2, 19, 0,
+ax_anim 2, 0, 31, 19, 3, 19, 0,
+ax_anim 2, 0, 32, 10, 1, 10, 0,
+ax_anim_terminator
+sMoltresAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 3, -2, 3, -3,
+ax_anim 1, 2, 34, 8, -7, 8, -8,
+ax_anim 1, 0, 34, 12, -12, 12, -14,
+ax_anim 2, 0, 34, 17, -17, 17, -19,
+ax_anim 2, 1, 34, 16, -18, 16, -20,
+ax_anim 2, 0, 34, 17, -17, 17, -19,
+ax_anim 2, 0, 34, 16, -18, 16, -20,
+ax_anim 2, 0, 34, 17, -17, 17, -19,
+ax_anim 2, 0, 35, 9, -8, 9, -8,
+ax_anim_terminator
+sMoltresAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, -3, 0, -3,
+ax_anim 1, 2, 37, 0, -6, 0, -6,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -16, 0, -16,
+ax_anim 2, 1, 37, -1, -16, -1, -16,
+ax_anim 2, 0, 37, 0, -16, 0, -16,
+ax_anim 2, 0, 37, -1, -16, -1, -16,
+ax_anim 2, 0, 37, 0, -16, 0, -16,
+ax_anim 2, 0, 38, 0, -5, 0, -5,
+ax_anim_terminator
+sMoltresAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 40, -3, -2, -3, -3,
+ax_anim 1, 2, 40, -8, -7, -8, -8,
+ax_anim 1, 0, 40, -12, -12, -12, -14,
+ax_anim 2, 0, 40, -17, -17, -17, -19,
+ax_anim 2, 1, 40, -16, -18, -16, -20,
+ax_anim 2, 0, 40, -17, -17, -17, -19,
+ax_anim 2, 0, 40, -16, -18, -16, -20,
+ax_anim 2, 0, 40, -17, -17, -17, -19,
+ax_anim 2, 0, 41, -9, -8, -9, -8,
+ax_anim_terminator
+sMoltresAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, -3, 0, -3, 0,
+ax_anim 1, 2, 43, -8, 1, -8, 0,
+ax_anim 1, 0, 43, -14, 2, -14, 0,
+ax_anim 2, 0, 43, -19, 3, -19, 0,
+ax_anim 2, 1, 43, -19, 2, -19, 0,
+ax_anim 2, 0, 43, -19, 3, -19, 0,
+ax_anim 2, 0, 43, -19, 2, -19, 0,
+ax_anim 2, 0, 43, -19, 3, -19, 0,
+ax_anim 2, 0, 44, -10, 1, -10, 0,
+ax_anim_terminator
+sMoltresAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -5, 5, -5, 5,
+ax_anim 1, 2, 46, -10, 13, -10, 11,
+ax_anim 1, 0, 46, -15, 20, -15, 18,
+ax_anim 2, 0, 46, -20, 28, -20, 25,
+ax_anim 2, 1, 46, -21, 27, -21, 24,
+ax_anim 2, 0, 46, -20, 28, -20, 25,
+ax_anim 2, 0, 46, -21, 27, -21, 24,
+ax_anim 2, 0, 46, -20, 28, -20, 25,
+ax_anim 2, 0, 47, -13, 15, -13, 15,
+ax_anim_terminator
+.align 2
+sMoltresAnims_3_1:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, -3, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 1, 0, 51, 0, 5, 0, 4,
+ax_anim 1, 2, 51, 0, 10, 0, 8,
+ax_anim 1, 0, 51, 0, 15, 0, 13,
+ax_anim 2, 0, 51, 0, 28, 0, 23,
+ax_anim 2, 1, 51, 1, 28, 1, 23,
+ax_anim 2, 0, 51, 0, 28, 0, 23,
+ax_anim 2, 0, 51, 1, 28, 1, 23,
+ax_anim 2, 0, 51, 0, 28, 0, 23,
+ax_anim 2, 0, 50, 0, 13, 0, 13,
+ax_anim 2, 0, 50, 0, 5, 0, 13,
+ax_anim_terminator
+sMoltresAnims_3_2:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -3, -3, -3, -3,
+ax_anim 2, 0, 54, -4, -4, -4, -4,
+ax_anim 2, 0, 55, -4, -4, -4, -4,
+ax_anim 1, 0, 55, 4, 6, 4, 6,
+ax_anim 1, 2, 55, 8, 12, 8, 11,
+ax_anim 1, 0, 55, 12, 17, 12, 15,
+ax_anim 2, 0, 55, 19, 28, 19, 24,
+ax_anim 2, 1, 55, 20, 28, 20, 24,
+ax_anim 2, 0, 55, 19, 29, 19, 25,
+ax_anim 2, 0, 55, 20, 28, 20, 24,
+ax_anim 2, 0, 55, 19, 29, 19, 25,
+ax_anim 2, 0, 54, 10, 15, 10, 13,
+ax_anim 2, 0, 54, 4, 6, 4, 6,
+ax_anim_terminator
+sMoltresAnims_3_3:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 58, -3, 0, -3, 0,
+ax_anim 2, 0, 58, -4, 0, -4, 0,
+ax_anim 2, 0, 59, -4, 0, -4, 0,
+ax_anim 1, 0, 59, 4, 2, 4, 0,
+ax_anim 1, 2, 59, 8, 3, 8, 0,
+ax_anim 1, 0, 59, 12, 4, 12, 0,
+ax_anim 2, 0, 59, 19, 8, 19, 0,
+ax_anim 2, 1, 59, 19, 7, 19, -1,
+ax_anim 2, 0, 59, 19, 8, 19, 0,
+ax_anim 2, 0, 59, 19, 7, 19, -1,
+ax_anim 2, 0, 59, 19, 8, 19, 0,
+ax_anim 2, 0, 58, 10, 5, 10, 0,
+ax_anim 2, 0, 58, 4, 1, 4, 0,
+ax_anim_terminator
+sMoltresAnims_3_4:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 62, -3, 3, -3, 3,
+ax_anim 2, 0, 62, -4, 4, -4, 4,
+ax_anim 2, 0, 63, -4, 4, -4, 4,
+ax_anim 1, 0, 63, 2, 1, 2, -2,
+ax_anim 1, 2, 63, 7, -3, 7, -8,
+ax_anim 1, 0, 63, 11, -6, 11, -12,
+ax_anim 2, 0, 63, 13, -8, 13, -14,
+ax_anim 2, 1, 63, 12, -9, 12, -15,
+ax_anim 2, 0, 63, 13, -8, 13, -14,
+ax_anim 2, 0, 63, 12, -9, 12, -15,
+ax_anim 2, 0, 63, 13, -8, 13, -14,
+ax_anim 2, 0, 62, 8, -4, 8, -9,
+ax_anim 2, 0, 62, 2, -2, 2, -3,
+ax_anim_terminator
+sMoltresAnims_3_5:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 3, 0, 3,
+ax_anim 2, 0, 66, 0, 4, 0, 4,
+ax_anim 2, 0, 67, 0, 4, 0, 4,
+ax_anim 1, 0, 67, 0, 1, 0, 1,
+ax_anim 1, 2, 67, 0, -3, 0, -5,
+ax_anim 1, 0, 67, 0, -6, 0, -10,
+ax_anim 2, 0, 67, 0, -8, 0, -15,
+ax_anim 2, 1, 67, 1, -8, 1, -15,
+ax_anim 2, 0, 67, 0, -8, 0, -15,
+ax_anim 2, 0, 67, 1, -8, 1, -15,
+ax_anim 2, 0, 67, 0, -8, 0, -15,
+ax_anim 2, 0, 66, 0, -4, 0, -6,
+ax_anim 2, 0, 66, 0, -2, 0, -2,
+ax_anim_terminator
+sMoltresAnims_3_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 3, 3, 3, 3,
+ax_anim 2, 0, 70, 4, 4, 4, 4,
+ax_anim 2, 0, 71, 4, 4, 4, 4,
+ax_anim 1, 0, 71, -2, 1, -2, -2,
+ax_anim 1, 2, 71, -7, -3, -7, -8,
+ax_anim 1, 0, 71, -11, -6, -11, -12,
+ax_anim 2, 0, 71, -13, -8, -13, -14,
+ax_anim 2, 1, 71, -12, -9, -12, -15,
+ax_anim 2, 0, 71, -13, -8, -13, -14,
+ax_anim 2, 0, 71, -12, -9, -12, -15,
+ax_anim 2, 0, 71, -13, -8, -13, -14,
+ax_anim 2, 0, 70, -8, -4, -8, -9,
+ax_anim 2, 0, 70, -2, -2, -2, -3,
+ax_anim_terminator
+sMoltresAnims_3_7:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 3, 0, 3, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim 2, 0, 75, 4, 0, 4, 0,
+ax_anim 1, 0, 75, -4, 2, -4, 0,
+ax_anim 1, 2, 75, -8, 3, -8, 0,
+ax_anim 1, 0, 75, -12, 4, -12, 0,
+ax_anim 2, 0, 75, -19, 8, -19, 0,
+ax_anim 2, 1, 75, -19, 7, -19, -1,
+ax_anim 2, 0, 75, -19, 8, -19, 0,
+ax_anim 2, 0, 75, -19, 7, -19, -1,
+ax_anim 2, 0, 75, -19, 8, -19, 0,
+ax_anim 2, 0, 74, -10, 5, -10, 0,
+ax_anim 2, 0, 74, -4, 1, -4, 0,
+ax_anim_terminator
+sMoltresAnims_3_8:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 3, -3, 3, -3,
+ax_anim 2, 0, 78, 4, -4, 4, -4,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim 1, 0, 79, -4, 6, -4, 6,
+ax_anim 1, 2, 79, -8, 12, -8, 11,
+ax_anim 1, 0, 79, -12, 17, -12, 15,
+ax_anim 2, 0, 79, -19, 28, -19, 24,
+ax_anim 2, 1, 79, -20, 28, -20, 24,
+ax_anim 2, 0, 79, -19, 29, -19, 25,
+ax_anim 2, 0, 79, -20, 28, -20, 24,
+ax_anim 2, 0, 79, -19, 29, -19, 25,
+ax_anim 2, 0, 78, -10, 15, -10, 13,
+ax_anim 2, 0, 78, -4, 6, -4, 6,
+ax_anim_terminator
+.align 2
+sMoltresAnims_4_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 5, 0, 5,
+ax_anim 2, 0, 83, 0, 9, 0, 8,
+ax_anim 2, 0, 83, 0, 9, 0, 8,
+ax_anim 2, 0, 83, 1, 9, 1, 8,
+ax_anim 2, 1, 83, 0, 9, 0, 8,
+ax_anim 2, 0, 83, 1, 9, 1, 8,
+ax_anim 2, 0, 83, 0, 9, 0, 8,
+ax_anim 2, 0, 83, 1, 9, 1, 8,
+ax_anim 2, 0, 83, 0, 9, 0, 8,
+ax_anim 2, 0, 80, 0, 4, 0, 4,
+ax_anim_terminator
+sMoltresAnims_4_2:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 5, 5, 5, 5,
+ax_anim 2, 0, 87, 8, 8, 8, 8,
+ax_anim 2, 0, 87, 9, 7, 9, 7,
+ax_anim 2, 0, 87, 8, 8, 8, 8,
+ax_anim 2, 1, 87, 9, 7, 9, 7,
+ax_anim 2, 0, 87, 8, 8, 8, 8,
+ax_anim 2, 0, 87, 9, 7, 9, 7,
+ax_anim 2, 0, 87, 8, 8, 8, 8,
+ax_anim 2, 0, 87, 9, 7, 9, 7,
+ax_anim 2, 0, 84, 5, 5, 4, 4,
+ax_anim_terminator
+sMoltresAnims_4_3:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 5, 2, 5, 0,
+ax_anim 2, 0, 91, 9, 3, 9, 0,
+ax_anim 2, 0, 91, 9, 2, 9, -1,
+ax_anim 2, 0, 91, 9, 3, 9, 0,
+ax_anim 2, 1, 91, 9, 2, 9, -1,
+ax_anim 2, 0, 91, 9, 3, 9, 0,
+ax_anim 2, 0, 91, 9, 2, 9, -1,
+ax_anim 2, 0, 91, 9, 3, 9, 0,
+ax_anim 2, 0, 91, 9, 2, 9, -1,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim_terminator
+sMoltresAnims_4_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 5, -5, 5, -5,
+ax_anim 2, 0, 95, 8, -8, 8, -8,
+ax_anim 2, 0, 95, 9, -7, 9, -7,
+ax_anim 2, 0, 95, 8, -8, 8, -8,
+ax_anim 2, 1, 95, 9, -7, 9, -7,
+ax_anim 2, 0, 95, 8, -8, 8, -8,
+ax_anim 2, 0, 95, 9, -7, 9, -7,
+ax_anim 2, 0, 95, 8, -8, 8, -8,
+ax_anim 2, 0, 95, 9, -7, 9, -7,
+ax_anim 2, 0, 92, 5, -5, 4, -4,
+ax_anim_terminator
+sMoltresAnims_4_5:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, -5, 0, -5,
+ax_anim 2, 0, 99, 0, -9, 0, -8,
+ax_anim 2, 0, 99, 0, -9, 0, -8,
+ax_anim 2, 0, 99, 1, -9, 1, -8,
+ax_anim 2, 1, 99, 0, -9, 0, -8,
+ax_anim 2, 0, 99, 1, -9, 1, -8,
+ax_anim 2, 0, 99, 0, -9, 0, -8,
+ax_anim 2, 0, 99, 1, -9, 1, -8,
+ax_anim 2, 0, 99, 0, -9, 0, -8,
+ax_anim 2, 0, 96, 0, -4, 0, -4,
+ax_anim_terminator
+sMoltresAnims_4_6:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 103, -5, -5, -5, -5,
+ax_anim 2, 0, 103, -8, -8, -8, -8,
+ax_anim 2, 0, 103, -9, -7, -9, -7,
+ax_anim 2, 0, 103, -8, -8, -8, -8,
+ax_anim 2, 1, 103, -9, -7, -9, -7,
+ax_anim 2, 0, 103, -8, -8, -8, -8,
+ax_anim 2, 0, 103, -9, -7, -9, -7,
+ax_anim 2, 0, 103, -8, -8, -8, -8,
+ax_anim 2, 0, 103, -9, -7, -9, -7,
+ax_anim 2, 0, 100, -5, -5, -4, -4,
+ax_anim_terminator
+sMoltresAnims_4_7:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 107, -5, 2, -5, 0,
+ax_anim 2, 0, 107, -9, 3, -9, 0,
+ax_anim 2, 0, 107, -9, 2, -9, -1,
+ax_anim 2, 0, 107, -9, 3, -9, 0,
+ax_anim 2, 1, 107, -9, 2, -9, -1,
+ax_anim 2, 0, 107, -9, 3, -9, 0,
+ax_anim 2, 0, 107, -9, 2, -9, -1,
+ax_anim 2, 0, 107, -9, 3, -9, 0,
+ax_anim 2, 0, 107, -9, 2, -9, -1,
+ax_anim 2, 0, 104, -4, 0, -4, 0,
+ax_anim_terminator
+sMoltresAnims_4_8:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -8, 8, -8, 8,
+ax_anim 2, 0, 111, -9, 7, -9, 7,
+ax_anim 2, 0, 111, -8, 8, -8, 8,
+ax_anim 2, 1, 111, -9, 7, -9, 7,
+ax_anim 2, 0, 111, -8, 8, -8, 8,
+ax_anim 2, 0, 111, -9, 7, -9, 7,
+ax_anim 2, 0, 111, -8, 8, -8, 8,
+ax_anim 2, 0, 111, -9, 7, -9, 7,
+ax_anim 2, 0, 108, -5, 5, -4, 4,
+ax_anim_terminator
+.align 2
+sMoltresAnims_5_1:
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 2, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 1, 114, 0, -1, 0, 0,
+ax_anim 3, 0, 114, 0, -2, 0, 0,
+ax_anim 3, 0, 114, 0, -1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_5_2:
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 2, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 1, 117, 0, -1, 0, 0,
+ax_anim 3, 0, 117, 0, -2, 0, 0,
+ax_anim 3, 0, 117, 0, -1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_5_3:
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 2, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 1, 120, 0, -1, 0, 0,
+ax_anim 3, 0, 120, 0, -2, 0, 0,
+ax_anim 3, 0, 120, 0, -1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_5_4:
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 2, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 1, 123, 0, -1, 0, 0,
+ax_anim 3, 0, 123, 0, -2, 0, 0,
+ax_anim 3, 0, 123, 0, -1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_5_5:
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 2, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 1, 126, 0, -1, 0, 0,
+ax_anim 3, 0, 126, 0, -2, 0, 0,
+ax_anim 3, 0, 126, 0, -1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_5_6:
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 2, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 1, 129, 0, -1, 0, 0,
+ax_anim 3, 0, 129, 0, -2, 0, 0,
+ax_anim 3, 0, 129, 0, -1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_5_7:
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 2, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 1, 132, 0, -1, 0, 0,
+ax_anim 3, 0, 132, 0, -2, 0, 0,
+ax_anim 3, 0, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_5_8:
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 2, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 1, 135, 0, -1, 0, 0,
+ax_anim 3, 0, 135, 0, -2, 0, 0,
+ax_anim 3, 0, 135, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sMoltresAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sMoltresAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sMoltresAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sMoltresAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sMoltresAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sMoltresAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sMoltresAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMoltresAnims_8_1:
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, -1, 0, 0,
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, 1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_8_2:
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, 0, -1, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_8_3:
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, -1, 0, 0,
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_8_4:
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, -1, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_8_5:
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, -1, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_8_6:
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, -1, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_8_7:
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, -1, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, 1, 0, 0,
+ax_anim_terminator
+sMoltresAnims_8_8:
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, -1, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 21, 7, 21,
+ax_anim 3, 0, 174, 0, 28, 0, 28,
+ax_anim 2, 3, 175, -7, 21, -7, 21,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 9, 1, 9, 1,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 22, 12, 22, 12,
+ax_anim 3, 0, 173, 19, 26, 19, 26,
+ax_anim 2, 3, 174, 10, 29, 10, 29,
+ax_anim 2, 0, 175, 2, 16, 2, 16,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 20, 1, 20, 1,
+ax_anim 2, 3, 173, 17, 5, 17, 5,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -20, 11, -20,
+ax_anim 3, 0, 171, 18, -15, 18, -15,
+ax_anim 2, 3, 172, 18, -12, 18, -12,
+ax_anim 2, 0, 173, 16, -6, 16, -6,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -6, -4, -6, -4,
+ax_anim 2, 0, 176, -8, -10, -8, -10,
+ax_anim 2, 0, 177, -7, -12, -7, -12,
+ax_anim 3, 0, 170, 0, -14, 0, -14,
+ax_anim 2, 3, 171, 7, -12, 7, -12,
+ax_anim 2, 0, 172, 8, -8, 8, -8,
+ax_anim 1, 0, 173, 6, -4, 6, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -20, -11, -20,
+ax_anim 3, 0, 177, -18, -15, -18, -15,
+ax_anim 2, 3, 176, -18, -12, -18, -12,
+ax_anim 2, 0, 175, -16, -6, -16, -6,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -20, 1, -20, 1,
+ax_anim 2, 3, 175, -17, 5, -17, 5,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 1, -8, 1,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -22, 12, -22, 12,
+ax_anim 3, 0, 175, -19, 26, -19, 26,
+ax_anim 2, 3, 174, -10, 29, -10, 29,
+ax_anim 2, 0, 173, -2, 16, -2, 16,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -26, 0, 0,
+ax_anim 3, 0, 187, 0, -24, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 9, 0, 0,
+ax_anim_terminator
+sMoltresAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, -1, -26, 0, 0,
+ax_anim 3, 0, 190, -1, -24, 0, 0,
+ax_anim 2, 0, 190, -1, -18, 0, 0,
+ax_anim 1, 0, 190, -1, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 8, 0, 0,
+ax_anim_terminator
+sMoltresAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, -1, -26, 0, 0,
+ax_anim 3, 0, 193, -1, -24, 0, 0,
+ax_anim 2, 0, 193, -1, -18, 0, 0,
+ax_anim 1, 0, 193, -1, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 7, 0, 0,
+ax_anim_terminator
+sMoltresAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, -1, -26, 0, 0,
+ax_anim 3, 0, 196, -1, -24, 0, 0,
+ax_anim 2, 0, 196, -1, -17, 0, 0,
+ax_anim 1, 0, 196, -1, -11, 0, 0,
+ax_anim 2, 2, 195, -1, 8, 0, 0,
+ax_anim_terminator
+sMoltresAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -26, 0, 0,
+ax_anim 3, 0, 199, 0, -24, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 8, 0, 0,
+ax_anim_terminator
+sMoltresAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 1, -26, 0, 0,
+ax_anim 3, 0, 202, 1, -24, 0, 0,
+ax_anim 2, 0, 202, 1, -17, 0, 0,
+ax_anim 1, 0, 202, 1, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 8, 0, 0,
+ax_anim_terminator
+sMoltresAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 1, -26, 0, 0,
+ax_anim 3, 0, 205, 1, -24, 0, 0,
+ax_anim 2, 0, 205, 1, -18, 0, 0,
+ax_anim 1, 0, 205, 1, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 7, 0, 0,
+ax_anim_terminator
+sMoltresAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 1, -26, 0, 0,
+ax_anim 3, 0, 208, 1, -24, 0, 0,
+ax_anim 2, 0, 208, 1, -18, 0, 0,
+ax_anim 1, 0, 208, 1, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 8, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_14_1:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_14_2:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_14_3:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_14_4:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_14_5:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_14_6:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_14_7:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_14_8:
+ax_anim 24, 0, 229, 0, 0, 0, 0,
+ax_anim 20, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_15_1:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_15_2:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_15_3:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_15_4:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_15_5:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_15_6:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_15_7:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_15_8:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 10, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, 0, -1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 6, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, 0, -1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 12, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -1, 0, -1, 0,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, 0, -1, 0,
+ax_anim 10, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_16_1:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_16_2:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_16_3:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_16_4:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_16_5:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_16_6:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_16_7:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_16_8:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim 6, 0, 238, 0, 0, 0, 0,
+ax_anim 10, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMoltresAnims_17_1:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_17_2:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_17_3:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_17_4:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_17_5:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_17_6:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_17_7:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresAnims_17_8:
+ax_anim 10, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 241, -1, 0, -1, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sMoltresGfx1:
+.incbin "baserom.gba", 0xB5C4B8, 0x180
+sMoltresGfx1_1:
+.incbin "baserom.gba", 0xB5C638, 0x40
+sMoltresSprites1:
+ax_sprite sMoltresGfx1, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx1_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx2:
+.incbin "baserom.gba", 0xB5C6A0, 0x80
+sMoltresSprites2:
+ax_sprite sMoltresGfx2, 0x80
+ax_sprite_terminator
+sMoltresGfx3:
+.incbin "baserom.gba", 0xB5C730, 0x80
+sMoltresSprites3:
+ax_sprite sMoltresGfx3, 0x80
+ax_sprite_terminator
+sMoltresGfx4:
+.incbin "baserom.gba", 0xB5C7C0, 0x40
+sMoltresSprites4:
+ax_sprite sMoltresGfx4, 0x40
+ax_sprite_terminator
+sMoltresGfx5:
+.incbin "baserom.gba", 0xB5C810, 0x40
+sMoltresSprites5:
+ax_sprite sMoltresGfx5, 0x40
+ax_sprite_terminator
+sMoltresGfx6:
+.incbin "baserom.gba", 0xB5C860, 0x20
+sMoltresSprites6:
+ax_sprite sMoltresGfx6, 0x20
+ax_sprite_terminator
+sMoltresGfx7:
+.incbin "baserom.gba", 0xB5C890, 0x20
+sMoltresSprites7:
+ax_sprite sMoltresGfx7, 0x20
+ax_sprite_terminator
+sMoltresGfx8:
+.incbin "baserom.gba", 0xB5C8C0, 0x20
+sMoltresSprites8:
+ax_sprite sMoltresGfx8, 0x20
+ax_sprite_terminator
+sMoltresGfx9:
+.incbin "baserom.gba", 0xB5C8F0, 0x20
+sMoltresSprites9:
+ax_sprite sMoltresGfx9, 0x20
+ax_sprite_terminator
+sMoltresGfx10:
+.incbin "baserom.gba", 0xB5C920, 0x40
+sMoltresSprites10:
+ax_sprite sMoltresGfx10, 0x40
+ax_sprite_terminator
+sMoltresGfx11:
+.incbin "baserom.gba", 0xB5C970, 0x40
+sMoltresSprites11:
+ax_sprite sMoltresGfx11, 0x40
+ax_sprite_terminator
+sMoltresGfx12:
+.incbin "baserom.gba", 0xB5C9C0, 0x80
+sMoltresSprites12:
+ax_sprite sMoltresGfx12, 0x80
+ax_sprite_terminator
+sMoltresGfx13:
+.incbin "baserom.gba", 0xB5CA50, 0x80
+sMoltresSprites13:
+ax_sprite sMoltresGfx13, 0x80
+ax_sprite_terminator
+sMoltresGfx14:
+.incbin "baserom.gba", 0xB5CAE0, 0x200
+sMoltresSprites14:
+ax_sprite sMoltresGfx14, 0x200
+ax_sprite_terminator
+sMoltresGfx15:
+.incbin "baserom.gba", 0xB5CCF0, 0x20
+sMoltresSprites15:
+ax_sprite sMoltresGfx15, 0x20
+ax_sprite_terminator
+sMoltresGfx16:
+.incbin "baserom.gba", 0xB5CD20, 0x20
+sMoltresSprites16:
+ax_sprite sMoltresGfx16, 0x20
+ax_sprite_terminator
+sMoltresGfx17:
+.incbin "baserom.gba", 0xB5CD50, 0x100
+sMoltresSprites17:
+ax_sprite sMoltresGfx17, 0x100
+ax_sprite_terminator
+sMoltresGfx18:
+.incbin "baserom.gba", 0xB5CE60, 0x80
+sMoltresSprites18:
+ax_sprite sMoltresGfx18, 0x80
+ax_sprite_terminator
+sMoltresGfx19:
+.incbin "baserom.gba", 0xB5CEF0, 0x40
+sMoltresSprites19:
+ax_sprite sMoltresGfx19, 0x40
+ax_sprite_terminator
+sMoltresGfx20:
+.incbin "baserom.gba", 0xB5CF40, 0x40
+sMoltresSprites20:
+ax_sprite sMoltresGfx20, 0x40
+ax_sprite_terminator
+sMoltresGfx21:
+.incbin "baserom.gba", 0xB5CF90, 0x20
+sMoltresSprites21:
+ax_sprite sMoltresGfx21, 0x20
+ax_sprite_terminator
+sMoltresGfx22:
+.incbin "baserom.gba", 0xB5CFC0, 0x20
+sMoltresSprites22:
+ax_sprite sMoltresGfx22, 0x20
+ax_sprite_terminator
+sMoltresGfx23:
+.incbin "baserom.gba", 0xB5CFF0, 0x40
+sMoltresSprites23:
+ax_sprite sMoltresGfx23, 0x40
+ax_sprite_terminator
+sMoltresGfx24:
+.incbin "baserom.gba", 0xB5D040, 0x80
+sMoltresSprites24:
+ax_sprite sMoltresGfx24, 0x80
+ax_sprite_terminator
+sMoltresGfx25:
+.incbin "baserom.gba", 0xB5D0D0, 0x80
+sMoltresSprites25:
+ax_sprite sMoltresGfx25, 0x80
+ax_sprite_terminator
+sMoltresGfx26:
+.incbin "baserom.gba", 0xB5D160, 0x20
+sMoltresSprites26:
+ax_sprite sMoltresGfx26, 0x20
+ax_sprite_terminator
+sMoltresGfx27:
+.incbin "baserom.gba", 0xB5D190, 0x20
+sMoltresSprites27:
+ax_sprite sMoltresGfx27, 0x20
+ax_sprite_terminator
+sMoltresGfx28:
+.incbin "baserom.gba", 0xB5D1C0, 0x40
+sMoltresSprites28:
+ax_sprite sMoltresGfx28, 0x40
+ax_sprite_terminator
+sMoltresGfx29:
+.incbin "baserom.gba", 0xB5D210, 0x80
+sMoltresSprites29:
+ax_sprite sMoltresGfx29, 0x80
+ax_sprite_terminator
+sMoltresGfx30:
+.incbin "baserom.gba", 0xB5D2A0, 0x80
+sMoltresSprites30:
+ax_sprite sMoltresGfx30, 0x80
+ax_sprite_terminator
+sMoltresGfx31:
+.incbin "baserom.gba", 0xB5D330, 0x40
+sMoltresSprites31:
+ax_sprite sMoltresGfx31, 0x40
+ax_sprite_terminator
+sMoltresGfx32:
+.incbin "baserom.gba", 0xB5D380, 0x20
+sMoltresSprites32:
+ax_sprite sMoltresGfx32, 0x20
+ax_sprite_terminator
+sMoltresGfx33:
+.incbin "baserom.gba", 0xB5D3B0, 0x100
+sMoltresSprites33:
+ax_sprite sMoltresGfx33, 0x100
+ax_sprite_terminator
+sMoltresGfx34:
+.incbin "baserom.gba", 0xB5D4C0, 0x80
+sMoltresSprites34:
+ax_sprite sMoltresGfx34, 0x80
+ax_sprite_terminator
+sMoltresGfx35:
+.incbin "baserom.gba", 0xB5D550, 0x40
+sMoltresSprites35:
+ax_sprite sMoltresGfx35, 0x40
+ax_sprite_terminator
+sMoltresGfx36:
+.incbin "baserom.gba", 0xB5D5A0, 0x20
+sMoltresSprites36:
+ax_sprite sMoltresGfx36, 0x20
+ax_sprite_terminator
+sMoltresGfx37:
+.incbin "baserom.gba", 0xB5D5D0, 0x20
+sMoltresSprites37:
+ax_sprite sMoltresGfx37, 0x20
+ax_sprite_terminator
+sMoltresGfx38:
+.incbin "baserom.gba", 0xB5D600, 0x40
+sMoltresGfx38_1:
+.incbin "baserom.gba", 0xB5D640, 0x60
+sMoltresGfx38_2:
+.incbin "baserom.gba", 0xB5D6A0, 0x120
+sMoltresSprites38:
+ax_sprite sMoltresGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx38_2, 0x120
+ax_sprite_terminator
+sMoltresGfx39:
+.incbin "baserom.gba", 0xB5D7F0, 0xE0
+sMoltresSprites39:
+ax_sprite sMoltresGfx39, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx40:
+.incbin "baserom.gba", 0xB5D8E8, 0x40
+sMoltresSprites40:
+ax_sprite sMoltresGfx40, 0x40
+ax_sprite_terminator
+sMoltresGfx41:
+.incbin "baserom.gba", 0xB5D938, 0x40
+sMoltresSprites41:
+ax_sprite sMoltresGfx41, 0x40
+ax_sprite_terminator
+sMoltresGfx42:
+.incbin "baserom.gba", 0xB5D988, 0x40
+sMoltresSprites42:
+ax_sprite sMoltresGfx42, 0x40
+ax_sprite_terminator
+sMoltresGfx43:
+.incbin "baserom.gba", 0xB5D9D8, 0x80
+sMoltresSprites43:
+ax_sprite sMoltresGfx43, 0x80
+ax_sprite_terminator
+sMoltresGfx44:
+.incbin "baserom.gba", 0xB5DA68, 0x40
+sMoltresSprites44:
+ax_sprite sMoltresGfx44, 0x40
+ax_sprite_terminator
+sMoltresGfx45:
+.incbin "baserom.gba", 0xB5DAB8, 0x1C0
+sMoltresGfx45_1:
+.incbin "baserom.gba", 0xB5DC78, 0x20
+sMoltresSprites45:
+ax_sprite sMoltresGfx45, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx45_1, 0x20
+ax_sprite_terminator
+sMoltresGfx46:
+.incbin "baserom.gba", 0xB5DCB8, 0x20
+sMoltresGfx46_1:
+.incbin "baserom.gba", 0xB5DCD8, 0xC0
+sMoltresSprites46:
+ax_sprite sMoltresGfx46, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx46_1, 0xc0
+ax_sprite_terminator
+sMoltresGfx47:
+.incbin "baserom.gba", 0xB5DDB8, 0x200
+sMoltresSprites47:
+ax_sprite sMoltresGfx47, 0x200
+ax_sprite_terminator
+sMoltresGfx48:
+.incbin "baserom.gba", 0xB5DFC8, 0x40
+sMoltresSprites48:
+ax_sprite sMoltresGfx48, 0x40
+ax_sprite_terminator
+sMoltresGfx49:
+.incbin "baserom.gba", 0xB5E018, 0x40
+sMoltresSprites49:
+ax_sprite sMoltresGfx49, 0x40
+ax_sprite_terminator
+sMoltresGfx50:
+.incbin "baserom.gba", 0xB5E068, 0x20
+sMoltresSprites50:
+ax_sprite sMoltresGfx50, 0x20
+ax_sprite_terminator
+sMoltresGfx51:
+.incbin "baserom.gba", 0xB5E098, 0x40
+sMoltresSprites51:
+ax_sprite sMoltresGfx51, 0x40
+ax_sprite_terminator
+sMoltresGfx52:
+.incbin "baserom.gba", 0xB5E0E8, 0x20
+sMoltresSprites52:
+ax_sprite sMoltresGfx52, 0x20
+ax_sprite_terminator
+sMoltresGfx53:
+.incbin "baserom.gba", 0xB5E118, 0x20
+sMoltresSprites53:
+ax_sprite sMoltresGfx53, 0x20
+ax_sprite_terminator
+sMoltresGfx54:
+.incbin "baserom.gba", 0xB5E148, 0x80
+sMoltresSprites54:
+ax_sprite sMoltresGfx54, 0x80
+ax_sprite_terminator
+sMoltresGfx55:
+.incbin "baserom.gba", 0xB5E1D8, 0x20
+sMoltresSprites55:
+ax_sprite sMoltresGfx55, 0x20
+ax_sprite_terminator
+sMoltresGfx56:
+.incbin "baserom.gba", 0xB5E208, 0x200
+sMoltresSprites56:
+ax_sprite sMoltresGfx56, 0x200
+ax_sprite_terminator
+sMoltresGfx57:
+.incbin "baserom.gba", 0xB5E418, 0x80
+sMoltresSprites57:
+ax_sprite sMoltresGfx57, 0x80
+ax_sprite_terminator
+sMoltresGfx58:
+.incbin "baserom.gba", 0xB5E4A8, 0x100
+sMoltresSprites58:
+ax_sprite sMoltresGfx58, 0x100
+ax_sprite_terminator
+sMoltresGfx59:
+.incbin "baserom.gba", 0xB5E5B8, 0x40
+sMoltresSprites59:
+ax_sprite sMoltresGfx59, 0x40
+ax_sprite_terminator
+sMoltresGfx60:
+.incbin "baserom.gba", 0xB5E608, 0x20
+sMoltresSprites60:
+ax_sprite sMoltresGfx60, 0x20
+ax_sprite_terminator
+sMoltresGfx61:
+.incbin "baserom.gba", 0xB5E638, 0x180
+sMoltresGfx61_1:
+.incbin "baserom.gba", 0xB5E7B8, 0x60
+sMoltresSprites61:
+ax_sprite sMoltresGfx61, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx61_1, 0x60
+ax_sprite_terminator
+sMoltresGfx62:
+.incbin "baserom.gba", 0xB5E838, 0x80
+sMoltresSprites62:
+ax_sprite sMoltresGfx62, 0x80
+ax_sprite_terminator
+sMoltresGfx63:
+.incbin "baserom.gba", 0xB5E8C8, 0x80
+sMoltresSprites63:
+ax_sprite sMoltresGfx63, 0x80
+ax_sprite_terminator
+sMoltresGfx64:
+.incbin "baserom.gba", 0xB5E958, 0x100
+sMoltresSprites64:
+ax_sprite sMoltresGfx64, 0x100
+ax_sprite_terminator
+sMoltresGfx65:
+.incbin "baserom.gba", 0xB5EA68, 0x60
+sMoltresSprites65:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx65, 0x60
+ax_sprite_terminator
+sMoltresGfx66:
+.incbin "baserom.gba", 0xB5EAE0, 0x80
+sMoltresSprites66:
+ax_sprite sMoltresGfx66, 0x80
+ax_sprite_terminator
+sMoltresGfx67:
+.incbin "baserom.gba", 0xB5EB70, 0x40
+sMoltresSprites67:
+ax_sprite sMoltresGfx67, 0x40
+ax_sprite_terminator
+sMoltresGfx68:
+.incbin "baserom.gba", 0xB5EBC0, 0x40
+sMoltresSprites68:
+ax_sprite sMoltresGfx68, 0x40
+ax_sprite_terminator
+sMoltresGfx69:
+.incbin "baserom.gba", 0xB5EC10, 0x40
+sMoltresSprites69:
+ax_sprite sMoltresGfx69, 0x40
+ax_sprite_terminator
+sMoltresGfx70:
+.incbin "baserom.gba", 0xB5EC60, 0x40
+sMoltresSprites70:
+ax_sprite sMoltresGfx70, 0x40
+ax_sprite_terminator
+sMoltresGfx71:
+.incbin "baserom.gba", 0xB5ECB0, 0x20
+sMoltresSprites71:
+ax_sprite sMoltresGfx71, 0x20
+ax_sprite_terminator
+sMoltresGfx72:
+.incbin "baserom.gba", 0xB5ECE0, 0x20
+sMoltresSprites72:
+ax_sprite sMoltresGfx72, 0x20
+ax_sprite_terminator
+sMoltresGfx73:
+.incbin "baserom.gba", 0xB5ED10, 0x80
+sMoltresSprites73:
+ax_sprite sMoltresGfx73, 0x80
+ax_sprite_terminator
+sMoltresGfx74:
+.incbin "baserom.gba", 0xB5EDA0, 0x40
+sMoltresSprites74:
+ax_sprite sMoltresGfx74, 0x40
+ax_sprite_terminator
+sMoltresGfx75:
+.incbin "baserom.gba", 0xB5EDF0, 0xC0
+sMoltresGfx75_1:
+.incbin "baserom.gba", 0xB5EEB0, 0x20
+sMoltresSprites75:
+ax_sprite sMoltresGfx75, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx75_1, 0x20
+ax_sprite_terminator
+sMoltresGfx76:
+.incbin "baserom.gba", 0xB5EEF0, 0x80
+sMoltresSprites76:
+ax_sprite sMoltresGfx76, 0x80
+ax_sprite_terminator
+sMoltresGfx77:
+.incbin "baserom.gba", 0xB5EF80, 0x40
+sMoltresSprites77:
+ax_sprite sMoltresGfx77, 0x40
+ax_sprite_terminator
+sMoltresGfx78:
+.incbin "baserom.gba", 0xB5EFD0, 0x20
+sMoltresSprites78:
+ax_sprite sMoltresGfx78, 0x20
+ax_sprite_terminator
+sMoltresGfx79:
+.incbin "baserom.gba", 0xB5F000, 0x80
+sMoltresSprites79:
+ax_sprite sMoltresGfx79, 0x80
+ax_sprite_terminator
+sMoltresGfx80:
+.incbin "baserom.gba", 0xB5F090, 0x100
+sMoltresSprites80:
+ax_sprite sMoltresGfx80, 0x100
+ax_sprite_terminator
+sMoltresGfx81:
+.incbin "baserom.gba", 0xB5F1A0, 0x40
+sMoltresSprites81:
+ax_sprite sMoltresGfx81, 0x40
+ax_sprite_terminator
+sMoltresGfx82:
+.incbin "baserom.gba", 0xB5F1F0, 0x20
+sMoltresSprites82:
+ax_sprite sMoltresGfx82, 0x20
+ax_sprite_terminator
+sMoltresGfx83:
+.incbin "baserom.gba", 0xB5F220, 0x20
+sMoltresSprites83:
+ax_sprite sMoltresGfx83, 0x20
+ax_sprite_terminator
+sMoltresGfx84:
+.incbin "baserom.gba", 0xB5F250, 0x20
+sMoltresSprites84:
+ax_sprite sMoltresGfx84, 0x20
+ax_sprite_terminator
+sMoltresGfx85:
+.incbin "baserom.gba", 0xB5F280, 0x1E0
+sMoltresSprites85:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx85, 0x1e0
+ax_sprite_terminator
+sMoltresGfx86:
+.incbin "baserom.gba", 0xB5F478, 0xC0
+sMoltresSprites86:
+ax_sprite sMoltresGfx86, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMoltresGfx87:
+.incbin "baserom.gba", 0xB5F550, 0x80
+sMoltresSprites87:
+ax_sprite sMoltresGfx87, 0x80
+ax_sprite_terminator
+sMoltresGfx88:
+.incbin "baserom.gba", 0xB5F5E0, 0x100
+sMoltresSprites88:
+ax_sprite sMoltresGfx88, 0x100
+ax_sprite_terminator
+sMoltresGfx89:
+.incbin "baserom.gba", 0xB5F6F0, 0x40
+sMoltresSprites89:
+ax_sprite sMoltresGfx89, 0x40
+ax_sprite_terminator
+sMoltresGfx90:
+.incbin "baserom.gba", 0xB5F740, 0x20
+sMoltresSprites90:
+ax_sprite sMoltresGfx90, 0x20
+ax_sprite_terminator
+sMoltresGfx91:
+.incbin "baserom.gba", 0xB5F770, 0x20
+sMoltresSprites91:
+ax_sprite sMoltresGfx91, 0x20
+ax_sprite_terminator
+sMoltresGfx92:
+.incbin "baserom.gba", 0xB5F7A0, 0x40
+sMoltresSprites92:
+ax_sprite sMoltresGfx92, 0x40
+ax_sprite_terminator
+sMoltresGfx93:
+.incbin "baserom.gba", 0xB5F7F0, 0x40
+sMoltresSprites93:
+ax_sprite sMoltresGfx93, 0x40
+ax_sprite_terminator
+sMoltresGfx94:
+.incbin "baserom.gba", 0xB5F840, 0x20
+sMoltresSprites94:
+ax_sprite sMoltresGfx94, 0x20
+ax_sprite_terminator
+sMoltresGfx95:
+.incbin "baserom.gba", 0xB5F870, 0x40
+sMoltresSprites95:
+ax_sprite sMoltresGfx95, 0x40
+ax_sprite_terminator
+sMoltresGfx96:
+.incbin "baserom.gba", 0xB5F8C0, 0x20
+sMoltresSprites96:
+ax_sprite sMoltresGfx96, 0x20
+ax_sprite_terminator
+sMoltresGfx97:
+.incbin "baserom.gba", 0xB5F8F0, 0x80
+sMoltresSprites97:
+ax_sprite sMoltresGfx97, 0x80
+ax_sprite_terminator
+sMoltresGfx98:
+.incbin "baserom.gba", 0xB5F980, 0x80
+sMoltresSprites98:
+ax_sprite sMoltresGfx98, 0x80
+ax_sprite_terminator
+sMoltresGfx99:
+.incbin "baserom.gba", 0xB5FA10, 0x20
+sMoltresSprites99:
+ax_sprite sMoltresGfx99, 0x20
+ax_sprite_terminator
+sMoltresGfx100:
+.incbin "baserom.gba", 0xB5FA40, 0x20
+sMoltresSprites100:
+ax_sprite sMoltresGfx100, 0x20
+ax_sprite_terminator
+sMoltresGfx101:
+.incbin "baserom.gba", 0xB5FA70, 0x40
+sMoltresSprites101:
+ax_sprite sMoltresGfx101, 0x40
+ax_sprite_terminator
+sMoltresGfx102:
+.incbin "baserom.gba", 0xB5FAC0, 0x40
+sMoltresSprites102:
+ax_sprite sMoltresGfx102, 0x40
+ax_sprite_terminator
+sMoltresGfx103:
+.incbin "baserom.gba", 0xB5FB10, 0x100
+sMoltresSprites103:
+ax_sprite sMoltresGfx103, 0x100
+ax_sprite_terminator
+sMoltresGfx104:
+.incbin "baserom.gba", 0xB5FC20, 0x80
+sMoltresSprites104:
+ax_sprite sMoltresGfx104, 0x80
+ax_sprite_terminator
+sMoltresGfx105:
+.incbin "baserom.gba", 0xB5FCB0, 0x80
+sMoltresSprites105:
+ax_sprite sMoltresGfx105, 0x80
+ax_sprite_terminator
+sMoltresGfx106:
+.incbin "baserom.gba", 0xB5FD40, 0x40
+sMoltresSprites106:
+ax_sprite sMoltresGfx106, 0x40
+ax_sprite_terminator
+sMoltresGfx107:
+.incbin "baserom.gba", 0xB5FD90, 0x20
+sMoltresSprites107:
+ax_sprite sMoltresGfx107, 0x20
+ax_sprite_terminator
+sMoltresGfx108:
+.incbin "baserom.gba", 0xB5FDC0, 0x80
+sMoltresSprites108:
+ax_sprite sMoltresGfx108, 0x80
+ax_sprite_terminator
+sMoltresGfx109:
+.incbin "baserom.gba", 0xB5FE50, 0x40
+sMoltresSprites109:
+ax_sprite sMoltresGfx109, 0x40
+ax_sprite_terminator
+sMoltresGfx110:
+.incbin "baserom.gba", 0xB5FEA0, 0x20
+sMoltresSprites110:
+ax_sprite sMoltresGfx110, 0x20
+ax_sprite_terminator
+sMoltresGfx111:
+.incbin "baserom.gba", 0xB5FED0, 0x80
+sMoltresSprites111:
+ax_sprite sMoltresGfx111, 0x80
+ax_sprite_terminator
+sMoltresGfx112:
+.incbin "baserom.gba", 0xB5FF60, 0x80
+sMoltresSprites112:
+ax_sprite sMoltresGfx112, 0x80
+ax_sprite_terminator
+sMoltresGfx113:
+.incbin "baserom.gba", 0xB5FFF0, 0x100
+sMoltresSprites113:
+ax_sprite sMoltresGfx113, 0x100
+ax_sprite_terminator
+sMoltresGfx114:
+.incbin "baserom.gba", 0xB60100, 0x40
+sMoltresSprites114:
+ax_sprite sMoltresGfx114, 0x40
+ax_sprite_terminator
+sMoltresGfx115:
+.incbin "baserom.gba", 0xB60150, 0x40
+sMoltresSprites115:
+ax_sprite sMoltresGfx115, 0x40
+ax_sprite_terminator
+sMoltresGfx116:
+.incbin "baserom.gba", 0xB601A0, 0x80
+sMoltresSprites116:
+ax_sprite sMoltresGfx116, 0x80
+ax_sprite_terminator
+sMoltresGfx117:
+.incbin "baserom.gba", 0xB60230, 0x80
+sMoltresSprites117:
+ax_sprite sMoltresGfx117, 0x80
+ax_sprite_terminator
+sMoltresGfx118:
+.incbin "baserom.gba", 0xB602C0, 0x20
+sMoltresSprites118:
+ax_sprite sMoltresGfx118, 0x20
+ax_sprite_terminator
+sMoltresGfx119:
+.incbin "baserom.gba", 0xB602F0, 0x40
+sMoltresSprites119:
+ax_sprite sMoltresGfx119, 0x40
+ax_sprite_terminator
+sMoltresGfx120:
+.incbin "baserom.gba", 0xB60340, 0x20
+sMoltresSprites120:
+ax_sprite sMoltresGfx120, 0x20
+ax_sprite_terminator
+sMoltresGfx121:
+.incbin "baserom.gba", 0xB60370, 0x40
+sMoltresSprites121:
+ax_sprite sMoltresGfx121, 0x40
+ax_sprite_terminator
+sMoltresGfx122:
+.incbin "baserom.gba", 0xB603C0, 0x20
+sMoltresSprites122:
+ax_sprite sMoltresGfx122, 0x20
+ax_sprite_terminator
+sMoltresGfx123:
+.incbin "baserom.gba", 0xB603F0, 0x100
+sMoltresSprites123:
+ax_sprite sMoltresGfx123, 0x100
+ax_sprite_terminator
+sMoltresGfx124:
+.incbin "baserom.gba", 0xB60500, 0x40
+sMoltresGfx124_1:
+.incbin "baserom.gba", 0xB60540, 0x80
+sMoltresSprites124:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx124, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx124_1, 0x80
+ax_sprite_terminator
+sMoltresGfx125:
+.incbin "baserom.gba", 0xB605E8, 0x100
+sMoltresSprites125:
+ax_sprite sMoltresGfx125, 0x100
+ax_sprite_terminator
+sMoltresGfx126:
+.incbin "baserom.gba", 0xB606F8, 0x80
+sMoltresGfx126_1:
+.incbin "baserom.gba", 0xB60778, 0x60
+sMoltresSprites126:
+ax_sprite sMoltresGfx126, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx126_1, 0x60
+ax_sprite_terminator
+sMoltresGfx127:
+.incbin "baserom.gba", 0xB607F8, 0xE0
+sMoltresSprites127:
+ax_sprite sMoltresGfx127, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx128:
+.incbin "baserom.gba", 0xB608F0, 0x60
+sMoltresGfx128_1:
+.incbin "baserom.gba", 0xB60950, 0xA0
+sMoltresGfx128_2:
+.incbin "baserom.gba", 0xB609F0, 0x40
+sMoltresGfx128_3:
+.incbin "baserom.gba", 0xB60A30, 0xE0
+sMoltresGfx128_4:
+.incbin "baserom.gba", 0xB60B10, 0xC0
+sMoltresSprites128:
+ax_sprite sMoltresGfx128, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sMoltresGfx128_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx128_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx128_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx128_4, 0xc0
+ax_sprite_terminator
+sMoltresGfx129:
+.incbin "baserom.gba", 0xB60C20, 0x80
+sMoltresSprites129:
+ax_sprite sMoltresGfx129, 0x80
+ax_sprite_terminator
+sMoltresGfx130:
+.incbin "baserom.gba", 0xB60CB0, 0x60
+sMoltresSprites130:
+ax_sprite sMoltresGfx130, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx131:
+.incbin "baserom.gba", 0xB60D28, 0x60
+sMoltresGfx131_1:
+.incbin "baserom.gba", 0xB60D88, 0xE0
+sMoltresGfx131_2:
+.incbin "baserom.gba", 0xB60E68, 0xE0
+sMoltresGfx131_3:
+.incbin "baserom.gba", 0xB60F48, 0x100
+sMoltresSprites131:
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx131, 0x60
+ax_sprite 0, 0x60
+ax_sprite sMoltresGfx131_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx131_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx131_3, 0x100
+ax_sprite_terminator
+sMoltresGfx132:
+.incbin "baserom.gba", 0xB61090, 0x20
+sMoltresGfx132_1:
+.incbin "baserom.gba", 0xB610B0, 0x60
+sMoltresSprites132:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx132, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx132_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx133:
+.incbin "baserom.gba", 0xB61140, 0x60
+sMoltresSprites133:
+ax_sprite sMoltresGfx133, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx134:
+.incbin "baserom.gba", 0xB611B8, 0x2A0
+sMoltresGfx134_1:
+.incbin "baserom.gba", 0xB61458, 0xE0
+sMoltresSprites134:
+ax_sprite 0, 0x60
+ax_sprite sMoltresGfx134, 0x2a0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx134_1, 0xe0
+ax_sprite_terminator
+sMoltresGfx135:
+.incbin "baserom.gba", 0xB61560, 0x60
+sMoltresSprites135:
+ax_sprite sMoltresGfx135, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx136:
+.incbin "baserom.gba", 0xB615D8, 0x20
+sMoltresSprites136:
+ax_sprite sMoltresGfx136, 0x20
+ax_sprite_terminator
+sMoltresGfx137:
+.incbin "baserom.gba", 0xB61608, 0x100
+sMoltresSprites137:
+ax_sprite sMoltresGfx137, 0x100
+ax_sprite_terminator
+sMoltresGfx138:
+.incbin "baserom.gba", 0xB61718, 0x60
+sMoltresSprites138:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx138, 0x60
+ax_sprite_terminator
+sMoltresGfx139:
+.incbin "baserom.gba", 0xB61790, 0x40
+sMoltresGfx139_1:
+.incbin "baserom.gba", 0xB617D0, 0x180
+sMoltresSprites139:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx139, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx139_1, 0x180
+ax_sprite_terminator
+sMoltresGfx140:
+.incbin "baserom.gba", 0xB61978, 0x100
+sMoltresSprites140:
+ax_sprite sMoltresGfx140, 0x100
+ax_sprite_terminator
+sMoltresGfx141:
+.incbin "baserom.gba", 0xB61A88, 0x60
+sMoltresSprites141:
+ax_sprite sMoltresGfx141, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx142:
+.incbin "baserom.gba", 0xB61B00, 0x80
+sMoltresSprites142:
+ax_sprite sMoltresGfx142, 0x80
+ax_sprite_terminator
+sMoltresGfx143:
+.incbin "baserom.gba", 0xB61B90, 0x1A0
+sMoltresGfx143_1:
+.incbin "baserom.gba", 0xB61D30, 0x40
+sMoltresSprites143:
+ax_sprite sMoltresGfx143, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx143_1, 0x40
+ax_sprite_terminator
+sMoltresGfx144:
+.incbin "baserom.gba", 0xB61D90, 0xE0
+sMoltresSprites144:
+ax_sprite sMoltresGfx144, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx145:
+.incbin "baserom.gba", 0xB61E88, 0x1A0
+sMoltresGfx145_1:
+.incbin "baserom.gba", 0xB62028, 0x40
+sMoltresSprites145:
+ax_sprite sMoltresGfx145, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx145_1, 0x40
+ax_sprite_terminator
+sMoltresGfx146:
+.incbin "baserom.gba", 0xB62088, 0xE0
+sMoltresSprites146:
+ax_sprite sMoltresGfx146, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx147:
+.incbin "baserom.gba", 0xB62180, 0x100
+sMoltresSprites147:
+ax_sprite sMoltresGfx147, 0x100
+ax_sprite_terminator
+sMoltresGfx148:
+.incbin "baserom.gba", 0xB62290, 0x20
+sMoltresSprites148:
+ax_sprite sMoltresGfx148, 0x20
+ax_sprite_terminator
+sMoltresGfx149:
+.incbin "baserom.gba", 0xB622C0, 0x80
+sMoltresSprites149:
+ax_sprite sMoltresGfx149, 0x80
+ax_sprite_terminator
+sMoltresGfx150:
+.incbin "baserom.gba", 0xB62350, 0x80
+sMoltresSprites150:
+ax_sprite sMoltresGfx150, 0x80
+ax_sprite_terminator
+sMoltresGfx151:
+.incbin "baserom.gba", 0xB623E0, 0x80
+sMoltresSprites151:
+ax_sprite sMoltresGfx151, 0x80
+ax_sprite_terminator
+sMoltresGfx152:
+.incbin "baserom.gba", 0xB62470, 0x100
+sMoltresSprites152:
+ax_sprite sMoltresGfx152, 0x100
+ax_sprite_terminator
+sMoltresGfx153:
+.incbin "baserom.gba", 0xB62580, 0x40
+sMoltresSprites153:
+ax_sprite sMoltresGfx153, 0x40
+ax_sprite_terminator
+sMoltresGfx154:
+.incbin "baserom.gba", 0xB625D0, 0x200
+sMoltresSprites154:
+ax_sprite sMoltresGfx154, 0x200
+ax_sprite_terminator
+sMoltresGfx155:
+.incbin "baserom.gba", 0xB627E0, 0x40
+sMoltresSprites155:
+ax_sprite sMoltresGfx155, 0x40
+ax_sprite_terminator
+sMoltresGfx156:
+.incbin "baserom.gba", 0xB62830, 0x20
+sMoltresSprites156:
+ax_sprite sMoltresGfx156, 0x20
+ax_sprite_terminator
+sMoltresGfx157:
+.incbin "baserom.gba", 0xB62860, 0x40
+sMoltresSprites157:
+ax_sprite sMoltresGfx157, 0x40
+ax_sprite_terminator
+sMoltresGfx158:
+.incbin "baserom.gba", 0xB628B0, 0x40
+sMoltresSprites158:
+ax_sprite sMoltresGfx158, 0x40
+ax_sprite_terminator
+sMoltresGfx159:
+.incbin "baserom.gba", 0xB62900, 0x20
+sMoltresSprites159:
+ax_sprite sMoltresGfx159, 0x20
+ax_sprite_terminator
+sMoltresGfx160:
+.incbin "baserom.gba", 0xB62930, 0x20
+sMoltresSprites160:
+ax_sprite sMoltresGfx160, 0x20
+ax_sprite_terminator
+sMoltresGfx161:
+.incbin "baserom.gba", 0xB62960, 0x20
+sMoltresSprites161:
+ax_sprite sMoltresGfx161, 0x20
+ax_sprite_terminator
+sMoltresGfx162:
+.incbin "baserom.gba", 0xB62990, 0x40
+sMoltresSprites162:
+ax_sprite sMoltresGfx162, 0x40
+ax_sprite_terminator
+sMoltresGfx163:
+.incbin "baserom.gba", 0xB629E0, 0x40
+sMoltresSprites163:
+ax_sprite sMoltresGfx163, 0x40
+ax_sprite_terminator
+sMoltresGfx164:
+.incbin "baserom.gba", 0xB62A30, 0x20
+sMoltresSprites164:
+ax_sprite sMoltresGfx164, 0x20
+ax_sprite_terminator
+sMoltresGfx165:
+.incbin "baserom.gba", 0xB62A60, 0x200
+sMoltresSprites165:
+ax_sprite sMoltresGfx165, 0x200
+ax_sprite_terminator
+sMoltresGfx166:
+.incbin "baserom.gba", 0xB62C70, 0x20
+sMoltresSprites166:
+ax_sprite sMoltresGfx166, 0x20
+ax_sprite_terminator
+sMoltresGfx167:
+.incbin "baserom.gba", 0xB62CA0, 0x40
+sMoltresSprites167:
+ax_sprite sMoltresGfx167, 0x40
+ax_sprite_terminator
+sMoltresGfx168:
+.incbin "baserom.gba", 0xB62CF0, 0x100
+sMoltresSprites168:
+ax_sprite sMoltresGfx168, 0x100
+ax_sprite_terminator
+sMoltresGfx169:
+.incbin "baserom.gba", 0xB62E00, 0x60
+sMoltresSprites169:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx169, 0x60
+ax_sprite_terminator
+sMoltresGfx170:
+.incbin "baserom.gba", 0xB62E78, 0x1E0
+sMoltresSprites170:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx170, 0x1e0
+ax_sprite_terminator
+sMoltresGfx171:
+.incbin "baserom.gba", 0xB63070, 0x40
+sMoltresSprites171:
+ax_sprite sMoltresGfx171, 0x40
+ax_sprite_terminator
+sMoltresGfx172:
+.incbin "baserom.gba", 0xB630C0, 0x20
+sMoltresSprites172:
+ax_sprite sMoltresGfx172, 0x20
+ax_sprite_terminator
+sMoltresGfx173:
+.incbin "baserom.gba", 0xB630F0, 0x80
+sMoltresSprites173:
+ax_sprite sMoltresGfx173, 0x80
+ax_sprite_terminator
+sMoltresGfx174:
+.incbin "baserom.gba", 0xB63180, 0x20
+sMoltresSprites174:
+ax_sprite sMoltresGfx174, 0x20
+ax_sprite_terminator
+sMoltresGfx175:
+.incbin "baserom.gba", 0xB631B0, 0x100
+sMoltresSprites175:
+ax_sprite sMoltresGfx175, 0x100
+ax_sprite_terminator
+sMoltresGfx176:
+.incbin "baserom.gba", 0xB632C0, 0x60
+sMoltresGfx176_1:
+.incbin "baserom.gba", 0xB63320, 0x180
+sMoltresSprites176:
+ax_sprite sMoltresGfx176, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx176_1, 0x180
+ax_sprite_terminator
+sMoltresGfx177:
+.incbin "baserom.gba", 0xB634C0, 0x80
+sMoltresSprites177:
+ax_sprite sMoltresGfx177, 0x80
+ax_sprite_terminator
+sMoltresGfx178:
+.incbin "baserom.gba", 0xB63550, 0x40
+sMoltresSprites178:
+ax_sprite sMoltresGfx178, 0x40
+ax_sprite_terminator
+sMoltresGfx179:
+.incbin "baserom.gba", 0xB635A0, 0x40
+sMoltresSprites179:
+ax_sprite sMoltresGfx179, 0x40
+ax_sprite_terminator
+sMoltresGfx180:
+.incbin "baserom.gba", 0xB635F0, 0x100
+sMoltresSprites180:
+ax_sprite sMoltresGfx180, 0x100
+ax_sprite_terminator
+sMoltresGfx181:
+.incbin "baserom.gba", 0xB63700, 0x100
+sMoltresGfx181_1:
+.incbin "baserom.gba", 0xB63800, 0x40
+sMoltresGfx181_2:
+.incbin "baserom.gba", 0xB63840, 0x20
+sMoltresSprites181:
+ax_sprite sMoltresGfx181, 0x100
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx181_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sMoltresGfx181_2, 0x20
+ax_sprite_terminator
+sMoltresGfx182:
+.incbin "baserom.gba", 0xB63890, 0x40
+sMoltresGfx182_1:
+.incbin "baserom.gba", 0xB638D0, 0x180
+sMoltresSprites182:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx182, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx182_1, 0x180
+ax_sprite_terminator
+sMoltresGfx183:
+.incbin "baserom.gba", 0xB63A78, 0x80
+sMoltresGfx183_1:
+.incbin "baserom.gba", 0xB63AF8, 0x60
+sMoltresSprites183:
+ax_sprite sMoltresGfx183, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx183_1, 0x60
+ax_sprite_terminator
+sMoltresGfx184:
+.incbin "baserom.gba", 0xB63B78, 0x60
+sMoltresGfx184_1:
+.incbin "baserom.gba", 0xB63BD8, 0x80
+sMoltresSprites184:
+ax_sprite sMoltresGfx184, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx184_1, 0x80
+ax_sprite_terminator
+sMoltresGfx185:
+.incbin "baserom.gba", 0xB63C78, 0x80
+sMoltresSprites185:
+ax_sprite sMoltresGfx185, 0x80
+ax_sprite_terminator
+sMoltresGfx186:
+.incbin "baserom.gba", 0xB63D08, 0x40
+sMoltresSprites186:
+ax_sprite sMoltresGfx186, 0x40
+ax_sprite_terminator
+sMoltresGfx187:
+.incbin "baserom.gba", 0xB63D58, 0x40
+sMoltresSprites187:
+ax_sprite sMoltresGfx187, 0x40
+ax_sprite_terminator
+sMoltresGfx188:
+.incbin "baserom.gba", 0xB63DA8, 0x40
+sMoltresSprites188:
+ax_sprite sMoltresGfx188, 0x40
+ax_sprite_terminator
+sMoltresGfx189:
+.incbin "baserom.gba", 0xB63DF8, 0x40
+sMoltresSprites189:
+ax_sprite sMoltresGfx189, 0x40
+ax_sprite_terminator
+sMoltresSprites190:
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx191:
+.incbin "baserom.gba", 0xB63E58, 0x60
+sMoltresGfx191_1:
+.incbin "baserom.gba", 0xB63EB8, 0x80
+sMoltresSprites191:
+ax_sprite sMoltresGfx191, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx191_1, 0x80
+ax_sprite_terminator
+sMoltresGfx192:
+.incbin "baserom.gba", 0xB63F58, 0x20
+sMoltresSprites192:
+ax_sprite sMoltresGfx192, 0x20
+ax_sprite_terminator
+sMoltresGfx193:
+.incbin "baserom.gba", 0xB63F88, 0x40
+sMoltresSprites193:
+ax_sprite sMoltresGfx193, 0x40
+ax_sprite_terminator
+sMoltresGfx194:
+.incbin "baserom.gba", 0xB63FD8, 0x40
+sMoltresSprites194:
+ax_sprite sMoltresGfx194, 0x40
+ax_sprite_terminator
+sMoltresGfx195:
+.incbin "baserom.gba", 0xB64028, 0x40
+sMoltresSprites195:
+ax_sprite sMoltresGfx195, 0x40
+ax_sprite_terminator
+sMoltresGfx196:
+.incbin "baserom.gba", 0xB64078, 0x40
+sMoltresSprites196:
+ax_sprite sMoltresGfx196, 0x40
+ax_sprite_terminator
+sMoltresGfx197:
+.incbin "baserom.gba", 0xB640C8, 0x80
+sMoltresSprites197:
+ax_sprite sMoltresGfx197, 0x80
+ax_sprite_terminator
+sMoltresGfx198:
+.incbin "baserom.gba", 0xB64158, 0x100
+sMoltresSprites198:
+ax_sprite sMoltresGfx198, 0x100
+ax_sprite_terminator
+sMoltresGfx199:
+.incbin "baserom.gba", 0xB64268, 0x200
+sMoltresSprites199:
+ax_sprite sMoltresGfx199, 0x200
+ax_sprite_terminator
+sMoltresGfx200:
+.incbin "baserom.gba", 0xB64478, 0x20
+sMoltresSprites200:
+ax_sprite sMoltresGfx200, 0x20
+ax_sprite_terminator
+sMoltresGfx201:
+.incbin "baserom.gba", 0xB644A8, 0x80
+sMoltresSprites201:
+ax_sprite sMoltresGfx201, 0x80
+ax_sprite_terminator
+sMoltresGfx202:
+.incbin "baserom.gba", 0xB64538, 0x80
+sMoltresSprites202:
+ax_sprite sMoltresGfx202, 0x80
+ax_sprite_terminator
+sMoltresGfx203:
+.incbin "baserom.gba", 0xB645C8, 0x40
+sMoltresSprites203:
+ax_sprite sMoltresGfx203, 0x40
+ax_sprite_terminator
+sMoltresGfx204:
+.incbin "baserom.gba", 0xB64618, 0x40
+sMoltresSprites204:
+ax_sprite sMoltresGfx204, 0x40
+ax_sprite_terminator
+sMoltresGfx205:
+.incbin "baserom.gba", 0xB64668, 0x20
+sMoltresSprites205:
+ax_sprite sMoltresGfx205, 0x20
+ax_sprite_terminator
+sMoltresGfx206:
+.incbin "baserom.gba", 0xB64698, 0x20
+sMoltresSprites206:
+ax_sprite sMoltresGfx206, 0x20
+ax_sprite_terminator
+sMoltresGfx207:
+.incbin "baserom.gba", 0xB646C8, 0x100
+sMoltresSprites207:
+ax_sprite sMoltresGfx207, 0x100
+ax_sprite_terminator
+sMoltresGfx208:
+.incbin "baserom.gba", 0xB647D8, 0x20
+sMoltresGfx208_1:
+.incbin "baserom.gba", 0xB647F8, 0x60
+sMoltresGfx208_2:
+.incbin "baserom.gba", 0xB64858, 0x100
+sMoltresSprites208:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx208, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx208_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx208_2, 0x100
+ax_sprite_terminator
+sMoltresGfx209:
+.incbin "baserom.gba", 0xB64990, 0x80
+sMoltresSprites209:
+ax_sprite sMoltresGfx209, 0x80
+ax_sprite_terminator
+sMoltresGfx210:
+.incbin "baserom.gba", 0xB64A20, 0x20
+sMoltresSprites210:
+ax_sprite sMoltresGfx210, 0x20
+ax_sprite_terminator
+sMoltresGfx211:
+.incbin "baserom.gba", 0xB64A50, 0x100
+sMoltresSprites211:
+ax_sprite sMoltresGfx211, 0x100
+ax_sprite_terminator
+sMoltresGfx212:
+.incbin "baserom.gba", 0xB64B60, 0x20
+sMoltresGfx212_1:
+.incbin "baserom.gba", 0xB64B80, 0x180
+sMoltresSprites212:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx212, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx212_1, 0x180
+ax_sprite_terminator
+sMoltresGfx213:
+.incbin "baserom.gba", 0xB64D28, 0x80
+sMoltresSprites213:
+ax_sprite sMoltresGfx213, 0x80
+ax_sprite_terminator
+sMoltresGfx214:
+.incbin "baserom.gba", 0xB64DB8, 0x20
+sMoltresSprites214:
+ax_sprite sMoltresGfx214, 0x20
+ax_sprite_terminator
+sMoltresGfx215:
+.incbin "baserom.gba", 0xB64DE8, 0x60
+sMoltresGfx215_1:
+.incbin "baserom.gba", 0xB64E48, 0x60
+sMoltresSprites215:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx215, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx215_1, 0x60
+ax_sprite_terminator
+sMoltresGfx216:
+.incbin "baserom.gba", 0xB64ED0, 0x20
+sMoltresGfx216_1:
+.incbin "baserom.gba", 0xB64EF0, 0x180
+sMoltresSprites216:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx216, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx216_1, 0x180
+ax_sprite_terminator
+sMoltresGfx217:
+.incbin "baserom.gba", 0xB65098, 0x80
+sMoltresSprites217:
+ax_sprite sMoltresGfx217, 0x80
+ax_sprite_terminator
+sMoltresGfx218:
+.incbin "baserom.gba", 0xB65128, 0x100
+sMoltresSprites218:
+ax_sprite sMoltresGfx218, 0x100
+ax_sprite_terminator
+sMoltresGfx219:
+.incbin "baserom.gba", 0xB65238, 0x40
+sMoltresGfx219_1:
+.incbin "baserom.gba", 0xB65278, 0x160
+sMoltresSprites219:
+ax_sprite sMoltresGfx219, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx219_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx220:
+.incbin "baserom.gba", 0xB65400, 0x80
+sMoltresSprites220:
+ax_sprite sMoltresGfx220, 0x80
+ax_sprite_terminator
+sMoltresGfx221:
+.incbin "baserom.gba", 0xB65490, 0x40
+sMoltresSprites221:
+ax_sprite sMoltresGfx221, 0x40
+ax_sprite_terminator
+sMoltresGfx222:
+.incbin "baserom.gba", 0xB654E0, 0x20
+sMoltresGfx222_1:
+.incbin "baserom.gba", 0xB65500, 0x180
+sMoltresSprites222:
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx222, 0x20
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx222_1, 0x180
+ax_sprite_terminator
+sMoltresGfx223:
+.incbin "baserom.gba", 0xB656A8, 0xE0
+sMoltresSprites223:
+ax_sprite sMoltresGfx223, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx224:
+.incbin "baserom.gba", 0xB657A0, 0x80
+sMoltresSprites224:
+ax_sprite sMoltresGfx224, 0x80
+ax_sprite_terminator
+sMoltresGfx225:
+.incbin "baserom.gba", 0xB65830, 0x20
+sMoltresSprites225:
+ax_sprite sMoltresGfx225, 0x20
+ax_sprite_terminator
+sMoltresGfx226:
+.incbin "baserom.gba", 0xB65860, 0x60
+sMoltresSprites226:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx226, 0x60
+ax_sprite_terminator
+sMoltresGfx227:
+.incbin "baserom.gba", 0xB658D8, 0xE0
+sMoltresSprites227:
+ax_sprite sMoltresGfx227, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx228:
+.incbin "baserom.gba", 0xB659D0, 0x180
+sMoltresGfx228_1:
+.incbin "baserom.gba", 0xB65B50, 0x40
+sMoltresSprites228:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx228, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx228_1, 0x40
+ax_sprite_terminator
+sMoltresGfx229:
+.incbin "baserom.gba", 0xB65BB8, 0x20
+sMoltresSprites229:
+ax_sprite sMoltresGfx229, 0x20
+ax_sprite_terminator
+sMoltresGfx230:
+.incbin "baserom.gba", 0xB65BE8, 0x1C0
+sMoltresSprites230:
+ax_sprite 0, 0x40
+ax_sprite sMoltresGfx230, 0x1c0
+ax_sprite_terminator
+sMoltresGfx231:
+.incbin "baserom.gba", 0xB65DC0, 0x60
+sMoltresSprites231:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx231, 0x60
+ax_sprite_terminator
+sMoltresGfx232:
+.incbin "baserom.gba", 0xB65E38, 0x20
+sMoltresSprites232:
+ax_sprite sMoltresGfx232, 0x20
+ax_sprite_terminator
+sMoltresGfx233:
+.incbin "baserom.gba", 0xB65E68, 0x40
+sMoltresGfx233_1:
+.incbin "baserom.gba", 0xB65EA8, 0x160
+sMoltresSprites233:
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx233, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMoltresGfx233_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMoltresGfx234:
+.incbin "baserom.gba", 0xB66038, 0x20
+sMoltresSprites234:
+ax_sprite sMoltresGfx234, 0x20
+ax_sprite_terminator
+sAxPosesMoltres:
+.4byte sMoltresPose1
+.4byte sMoltresPose2
+.4byte sMoltresPose3
+.4byte sMoltresPose4
+.4byte sMoltresPose5
+.4byte sMoltresPose6
+.4byte sMoltresPose7
+.4byte sMoltresPose8
+.4byte sMoltresPose9
+.4byte sMoltresPose10
+.4byte sMoltresPose11
+.4byte sMoltresPose12
+.4byte sMoltresPose13
+.4byte sMoltresPose14
+.4byte sMoltresPose15
+.4byte sMoltresPose16
+.4byte sMoltresPose17
+.4byte sMoltresPose18
+.4byte sMoltresPose19
+.4byte sMoltresPose20
+.4byte sMoltresPose21
+.4byte sMoltresPose22
+.4byte sMoltresPose23
+.4byte sMoltresPose24
+.4byte sMoltresPose25
+.4byte sMoltresPose26
+.4byte sMoltresPose27
+.4byte sMoltresPose28
+.4byte sMoltresPose29
+.4byte sMoltresPose30
+.4byte sMoltresPose31
+.4byte sMoltresPose32
+.4byte sMoltresPose33
+.4byte sMoltresPose34
+.4byte sMoltresPose35
+.4byte sMoltresPose36
+.4byte sMoltresPose37
+.4byte sMoltresPose38
+.4byte sMoltresPose39
+.4byte sMoltresPose40
+.4byte sMoltresPose41
+.4byte sMoltresPose42
+.4byte sMoltresPose43
+.4byte sMoltresPose44
+.4byte sMoltresPose45
+.4byte sMoltresPose46
+.4byte sMoltresPose47
+.4byte sMoltresPose48
+.4byte sMoltresPose49
+.4byte sMoltresPose50
+.4byte sMoltresPose51
+.4byte sMoltresPose52
+.4byte sMoltresPose53
+.4byte sMoltresPose54
+.4byte sMoltresPose55
+.4byte sMoltresPose56
+.4byte sMoltresPose57
+.4byte sMoltresPose58
+.4byte sMoltresPose59
+.4byte sMoltresPose60
+.4byte sMoltresPose61
+.4byte sMoltresPose62
+.4byte sMoltresPose63
+.4byte sMoltresPose64
+.4byte sMoltresPose65
+.4byte sMoltresPose66
+.4byte sMoltresPose67
+.4byte sMoltresPose68
+.4byte sMoltresPose69
+.4byte sMoltresPose70
+.4byte sMoltresPose71
+.4byte sMoltresPose72
+.4byte sMoltresPose73
+.4byte sMoltresPose74
+.4byte sMoltresPose75
+.4byte sMoltresPose76
+.4byte sMoltresPose77
+.4byte sMoltresPose78
+.4byte sMoltresPose79
+.4byte sMoltresPose80
+.4byte sMoltresPose81
+.4byte sMoltresPose82
+.4byte sMoltresPose83
+.4byte sMoltresPose84
+.4byte sMoltresPose85
+.4byte sMoltresPose86
+.4byte sMoltresPose87
+.4byte sMoltresPose88
+.4byte sMoltresPose89
+.4byte sMoltresPose90
+.4byte sMoltresPose91
+.4byte sMoltresPose92
+.4byte sMoltresPose93
+.4byte sMoltresPose94
+.4byte sMoltresPose95
+.4byte sMoltresPose96
+.4byte sMoltresPose97
+.4byte sMoltresPose98
+.4byte sMoltresPose99
+.4byte sMoltresPose100
+.4byte sMoltresPose101
+.4byte sMoltresPose102
+.4byte sMoltresPose103
+.4byte sMoltresPose104
+.4byte sMoltresPose105
+.4byte sMoltresPose106
+.4byte sMoltresPose107
+.4byte sMoltresPose108
+.4byte sMoltresPose109
+.4byte sMoltresPose110
+.4byte sMoltresPose111
+.4byte sMoltresPose112
+.4byte sMoltresPose113
+.4byte sMoltresPose114
+.4byte sMoltresPose115
+.4byte sMoltresPose116
+.4byte sMoltresPose117
+.4byte sMoltresPose118
+.4byte sMoltresPose119
+.4byte sMoltresPose120
+.4byte sMoltresPose121
+.4byte sMoltresPose122
+.4byte sMoltresPose123
+.4byte sMoltresPose124
+.4byte sMoltresPose125
+.4byte sMoltresPose126
+.4byte sMoltresPose127
+.4byte sMoltresPose128
+.4byte sMoltresPose129
+.4byte sMoltresPose130
+.4byte sMoltresPose131
+.4byte sMoltresPose132
+.4byte sMoltresPose133
+.4byte sMoltresPose134
+.4byte sMoltresPose135
+.4byte sMoltresPose136
+.4byte sMoltresPose137
+.4byte sMoltresPose138
+.4byte sMoltresPose139
+.4byte sMoltresPose140
+.4byte sMoltresPose141
+.4byte sMoltresPose142
+.4byte sMoltresPose143
+.4byte sMoltresPose144
+.4byte sMoltresPose145
+.4byte sMoltresPose146
+.4byte sMoltresPose147
+.4byte sMoltresPose148
+.4byte sMoltresPose149
+.4byte sMoltresPose150
+.4byte sMoltresPose151
+.4byte sMoltresPose152
+.4byte sMoltresPose153
+.4byte sMoltresPose154
+.4byte sMoltresPose155
+.4byte sMoltresPose156
+.4byte sMoltresPose157
+.4byte sMoltresPose158
+.4byte sMoltresPose159
+.4byte sMoltresPose160
+.4byte sMoltresPose161
+.4byte sMoltresPose162
+.4byte sMoltresPose163
+.4byte sMoltresPose164
+.4byte sMoltresPose165
+.4byte sMoltresPose166
+.4byte sMoltresPose167
+.4byte sMoltresPose168
+.4byte sMoltresPose169
+.4byte sMoltresPose170
+.4byte sMoltresPose171
+.4byte sMoltresPose172
+.4byte sMoltresPose173
+.4byte sMoltresPose174
+.4byte sMoltresPose175
+.4byte sMoltresPose176
+.4byte sMoltresPose177
+.4byte sMoltresPose178
+.4byte sMoltresPose179
+.4byte sMoltresPose180
+.4byte sMoltresPose181
+.4byte sMoltresPose182
+.4byte sMoltresPose183
+.4byte sMoltresPose184
+.4byte sMoltresPose185
+.4byte sMoltresPose186
+.4byte sMoltresPose187
+.4byte sMoltresPose188
+.4byte sMoltresPose189
+.4byte sMoltresPose190
+.4byte sMoltresPose191
+.4byte sMoltresPose192
+.4byte sMoltresPose193
+.4byte sMoltresPose194
+.4byte sMoltresPose195
+.4byte sMoltresPose196
+.4byte sMoltresPose197
+.4byte sMoltresPose198
+.4byte sMoltresPose199
+.4byte sMoltresPose200
+.4byte sMoltresPose201
+.4byte sMoltresPose202
+.4byte sMoltresPose203
+.4byte sMoltresPose204
+.4byte sMoltresPose205
+.4byte sMoltresPose206
+.4byte sMoltresPose207
+.4byte sMoltresPose208
+.4byte sMoltresPose209
+.4byte sMoltresPose210
+.4byte sMoltresPose211
+.4byte sMoltresPose212
+.4byte sMoltresPose213
+.4byte sMoltresPose214
+.4byte sMoltresPose215
+.4byte sMoltresPose216
+.4byte sMoltresPose217
+.4byte sMoltresPose218
+.4byte sMoltresPose219
+.4byte sMoltresPose220
+.4byte sMoltresPose221
+.4byte sMoltresPose222
+.4byte sMoltresPose223
+.4byte sMoltresPose224
+.4byte sMoltresPose225
+.4byte sMoltresPose226
+.4byte sMoltresPose227
+.4byte sMoltresPose228
+.4byte sMoltresPose229
+.4byte sMoltresPose230
+.4byte sMoltresPose231
+.4byte sMoltresPose232
+.4byte sMoltresPose233
+.4byte sMoltresPose234
+.4byte sMoltresPose235
+.4byte sMoltresPose236
+.4byte sMoltresPose237
+.4byte sMoltresPose238
+.4byte sMoltresPose239
+.4byte sMoltresPose240
+.4byte sMoltresPose241
+.4byte sMoltresPose242
+.4byte sMoltresPose243
+.4byte sMoltresPose244
+sAxPositionsMoltres:
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   -1,  -25, 	 -22,    4, 	  20,    4, 	  -1,  -21
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -16, 	 -16,  -41, 	  11,  -44, 	   0,  -17
+.2byte   11,  -24, 	 -21,    2, 	  15,   -3, 	   2,  -19
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   20,  -26, 	  -6,    3, 	   6,   -6, 	   2,  -16
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   11,  -31, 	  19,   -4, 	 -16,  -15, 	   0,  -21
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte   -1,  -33, 	  16,  -16, 	 -18,  -16, 	  -1,  -21
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -12,  -31, 	  15,  -15, 	 -20,   -4, 	  -1,  -21
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -21,  -26, 	  -7,   -6, 	   5,    3, 	  -3,  -16
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -13,  -16, 	 -12,  -44, 	  15,  -41, 	  -1,  -17
+.2byte  -12,  -24, 	 -16,   -3, 	  20,    2, 	  -3,  -19
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   -1,  -25, 	 -22,    4, 	  20,    4, 	  -1,  -21
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -16, 	 -16,  -41, 	  11,  -44, 	   0,  -17
+.2byte   11,  -24, 	 -21,    2, 	  15,   -3, 	   2,  -19
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   20,  -26, 	  -6,    3, 	   6,   -6, 	   2,  -16
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   11,  -31, 	  19,   -4, 	 -16,  -15, 	   0,  -21
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte   -1,  -33, 	  16,  -16, 	 -18,  -16, 	  -1,  -21
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -12,  -31, 	  15,  -15, 	 -20,   -4, 	  -1,  -21
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -21,  -26, 	  -7,   -6, 	   5,    3, 	  -3,  -16
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -13,  -16, 	 -12,  -44, 	  15,  -41, 	  -1,  -17
+.2byte  -12,  -24, 	 -16,   -3, 	  20,    2, 	  -3,  -19
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   -1,  -25, 	 -22,    4, 	  20,    4, 	  -1,  -21
+.2byte   -1,  -18, 	 -37,  -36, 	  35,  -36, 	  -1,  -21
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -16, 	 -16,  -41, 	  11,  -44, 	   0,  -17
+.2byte   11,  -24, 	 -21,    2, 	  15,   -3, 	   2,  -19
+.2byte   12,  -18, 	 -38,  -33, 	  28,  -38, 	   2,  -18
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   20,  -26, 	  -6,    3, 	   6,   -6, 	   2,  -16
+.2byte   19,  -19, 	 -14,  -26, 	   3,  -45, 	  -1,  -20
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   11,  -31, 	  19,   -4, 	 -16,  -15, 	   0,  -21
+.2byte   12,  -25, 	  27,  -24, 	 -27,  -38, 	   0,  -20
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte   -1,  -33, 	  16,  -16, 	 -18,  -16, 	  -1,  -21
+.2byte   -1,  -27, 	  34,  -33, 	 -36,  -33, 	  -1,  -20
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -12,  -31, 	  15,  -15, 	 -20,   -4, 	  -1,  -21
+.2byte  -13,  -25, 	  26,  -38, 	 -28,  -24, 	  -1,  -20
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -21,  -26, 	  -7,   -6, 	   5,    3, 	  -3,  -16
+.2byte  -20,  -19, 	  -4,  -45, 	  13,  -26, 	   0,  -20
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -13,  -16, 	 -12,  -44, 	  15,  -41, 	  -1,  -17
+.2byte  -12,  -24, 	 -16,   -3, 	  20,    2, 	  -3,  -19
+.2byte  -13,  -18, 	 -29,  -38, 	  37,  -33, 	  -3,  -18
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   -1,  -25, 	 -22,    4, 	  20,    4, 	  -1,  -21
+.2byte   -1,  -18, 	 -37,  -36, 	  35,  -36, 	  -1,  -21
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -16, 	 -16,  -41, 	  11,  -44, 	   0,  -17
+.2byte   11,  -24, 	 -21,    2, 	  15,   -3, 	   2,  -19
+.2byte   12,  -18, 	 -38,  -33, 	  28,  -38, 	   2,  -18
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   20,  -26, 	  -6,    3, 	   6,   -6, 	   2,  -16
+.2byte   19,  -19, 	 -14,  -26, 	   3,  -45, 	  -1,  -20
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   11,  -31, 	  19,   -4, 	 -16,  -15, 	   0,  -21
+.2byte   12,  -25, 	  27,  -24, 	 -27,  -38, 	   0,  -20
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte   -1,  -33, 	  16,  -16, 	 -18,  -16, 	  -1,  -21
+.2byte   -1,  -27, 	  34,  -33, 	 -36,  -33, 	  -1,  -20
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -12,  -31, 	  15,  -15, 	 -20,   -4, 	  -1,  -21
+.2byte  -13,  -25, 	  26,  -38, 	 -28,  -24, 	  -1,  -20
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -21,  -26, 	  -7,   -6, 	   5,    3, 	  -3,  -16
+.2byte  -20,  -19, 	  -4,  -45, 	  13,  -26, 	   0,  -20
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -13,  -16, 	 -12,  -44, 	  15,  -41, 	  -1,  -17
+.2byte  -12,  -24, 	 -16,   -3, 	  20,    2, 	  -3,  -19
+.2byte  -13,  -18, 	 -29,  -38, 	  37,  -33, 	  -3,  -18
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   -1,  -25, 	 -22,    4, 	  20,    4, 	  -1,  -21
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -16, 	 -16,  -41, 	  11,  -44, 	   0,  -17
+.2byte   11,  -24, 	 -21,    2, 	  15,   -3, 	   2,  -19
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   20,  -26, 	  -6,    3, 	   6,   -6, 	   2,  -16
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   11,  -31, 	  19,   -4, 	 -16,  -15, 	   0,  -21
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte   -1,  -33, 	  16,  -16, 	 -18,  -16, 	  -1,  -21
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -12,  -31, 	  15,  -15, 	 -20,   -4, 	  -1,  -21
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -21,  -26, 	  -7,   -6, 	   5,    3, 	  -3,  -16
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -13,  -16, 	 -12,  -44, 	  15,  -41, 	  -1,  -17
+.2byte  -12,  -24, 	 -16,   -3, 	  20,    2, 	  -3,  -19
+.2byte  -22,   -1, 	  -7,  -16, 	   3,   -7, 	   2,  -13
+.2byte  -22,    0, 	  -6,  -16, 	   2,   -7, 	   2,  -13
+.2byte    0,  -32, 	 -13,  -42, 	  13,  -42, 	   0,  -18
+.2byte    6,  -37, 	 -19,  -40, 	  -2,  -49, 	   2,  -18
+.2byte    2,  -36, 	 -17,  -34, 	 -13,  -40, 	  -3,  -18
+.2byte    3,  -36, 	   9,  -35, 	 -12,  -38, 	  -2,  -17
+.2byte    0,  -35, 	  11,  -38, 	 -11,  -38, 	   0,  -16
+.2byte   -4,  -36, 	  11,  -38, 	 -10,  -35, 	   1,  -17
+.2byte   -3,  -36, 	  12,  -40, 	  16,  -34, 	   2,  -18
+.2byte   -7,  -37, 	   1,  -49, 	  18,  -40, 	  -3,  -18
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   -1,  -25, 	 -22,    4, 	  20,    4, 	  -1,  -21
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -16, 	 -16,  -41, 	  11,  -44, 	   0,  -17
+.2byte   11,  -24, 	 -21,    2, 	  15,   -3, 	   2,  -19
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   20,  -26, 	  -6,    3, 	   6,   -6, 	   2,  -16
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   11,  -31, 	  19,   -4, 	 -16,  -15, 	   0,  -21
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte   -1,  -33, 	  16,  -16, 	 -18,  -16, 	  -1,  -21
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -12,  -31, 	  15,  -15, 	 -20,   -4, 	  -1,  -21
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -21,  -26, 	  -7,   -6, 	   5,    3, 	  -3,  -16
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -13,  -16, 	 -12,  -44, 	  15,  -41, 	  -1,  -17
+.2byte  -12,  -24, 	 -16,   -3, 	  20,    2, 	  -3,  -19
+.2byte   -1,  -18, 	 -37,  -36, 	  35,  -36, 	  -1,  -21
+.2byte  -13,  -18, 	 -29,  -38, 	  37,  -33, 	  -3,  -18
+.2byte  -20,  -19, 	   0,  -45, 	  13,  -26, 	   0,  -20
+.2byte  -13,  -25, 	  30,  -38, 	 -28,  -24, 	  -1,  -20
+.2byte   -1,  -27, 	  34,  -33, 	 -36,  -33, 	  -1,  -20
+.2byte   12,  -25, 	  27,  -24, 	 -31,  -38, 	   0,  -20
+.2byte   19,  -19, 	 -14,  -26, 	  -1,  -45, 	  -1,  -20
+.2byte   12,  -18, 	 -38,  -33, 	  28,  -38, 	   2,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   14,  -16, 	 -14,  -41, 	  13,  -44, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -15,  -16, 	 -14,  -44, 	  13,  -41, 	  -3,  -17
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte   -1,  -19, 	 -20,  -45, 	  18,  -45, 	  -1,  -16
+.2byte   -1,  -25, 	 -22,    4, 	  20,    4, 	  -1,  -21
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -16, 	 -16,  -41, 	  11,  -44, 	   0,  -17
+.2byte   11,  -24, 	 -21,    2, 	  15,   -3, 	   2,  -19
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   20,  -20, 	 -10,  -39, 	   0,  -41, 	   4,  -18
+.2byte   20,  -26, 	  -6,    3, 	   6,   -6, 	   2,  -16
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   13,  -26, 	  21,  -37, 	 -13,  -45, 	   1,  -20
+.2byte   11,  -31, 	  19,   -4, 	 -16,  -15, 	   0,  -21
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   -1,  -24, 	  20,  -44, 	 -22,  -44, 	  -1,  -20
+.2byte   -1,  -33, 	  16,  -16, 	 -18,  -16, 	  -1,  -21
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte  -14,  -26, 	  12,  -45, 	 -22,  -37, 	  -2,  -20
+.2byte  -12,  -31, 	  15,  -15, 	 -20,   -4, 	  -1,  -21
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -21,  -20, 	  -1,  -41, 	   9,  -39, 	  -5,  -18
+.2byte  -21,  -26, 	  -7,   -6, 	   5,    3, 	  -3,  -16
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -13,  -16, 	 -12,  -44, 	  15,  -41, 	  -1,  -17
+.2byte  -12,  -24, 	 -16,   -3, 	  20,    2, 	  -3,  -19
+.2byte   -1,  -18, 	 -37,  -36, 	  35,  -36, 	  -1,  -21
+.2byte  -13,  -18, 	 -29,  -38, 	  37,  -33, 	  -3,  -18
+.2byte  -20,  -19, 	   0,  -45, 	  13,  -26, 	   0,  -20
+.2byte  -13,  -25, 	  30,  -38, 	 -28,  -24, 	  -1,  -20
+.2byte   -1,  -27, 	  34,  -33, 	 -36,  -33, 	  -1,  -20
+.2byte   12,  -25, 	  27,  -24, 	 -31,  -38, 	   0,  -20
+.2byte   19,  -19, 	 -14,  -26, 	  -1,  -45, 	  -1,  -20
+.2byte   12,  -18, 	 -38,  -33, 	  28,  -38, 	   2,  -18
+.2byte   -1,  -22, 	 -32,  -40, 	  30,  -40, 	  -1,  -18
+.2byte  -13,  -19, 	 -19,  -42, 	  27,  -36, 	   0,  -19
+.2byte  -21,  -23, 	   3,  -40, 	  14,  -34, 	  -3,  -17
+.2byte  -12,  -27, 	  17,  -41, 	 -25,  -32, 	  -2,  -19
+.2byte   -1,  -30, 	  15,  -33, 	 -16,  -32, 	  -1,  -22
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   12,  -19, 	 -28,  -36, 	  18,  -42, 	  -1,  -19
+.2byte   20,  -23, 	 -15,  -34, 	  -4,  -40, 	   2,  -17
+.2byte   11,  -27, 	  24,  -32, 	 -18,  -41, 	   1,  -19
+.2byte    0,   -1, 	 -27,   -3, 	  27,   -3, 	   0,   -9
+.2byte    0,    2, 	 -27,   -3, 	  27,   -3, 	   0,   -7
+.2byte    0,   -1, 	 -27,   -3, 	  27,   -3, 	   0,   -9
+.2byte    0,    2, 	 -27,   -3, 	  27,   -3, 	   0,   -7
+.2byte    0,   -8, 	 -23,   -5, 	  23,   -5, 	   0,   -9
+.2byte    0,  -13, 	 -23,  -20, 	  26,  -20, 	   0,  -10
+.2byte    0,  -19, 	 -21,  -36, 	  21,  -36, 	   0,  -14
+.2byte    0,  -19, 	 -21,  -36, 	  21,  -36, 	   0,  -14
+.2byte    0,  -16, 	 -20,  -12, 	  20,  -12, 	   0,  -12
+.2byte    0,  -14, 	 -14,   -7, 	  14,   -7, 	   0,  -11
+.2byte    0,  -15, 	  -8,   -8, 	   8,   -8, 	   0,  -11
+.2byte    0,  -13, 	 -23,  -20, 	  26,  -20, 	   0,  -10
+.2byte    0,  -19, 	 -21,  -36, 	  21,  -36, 	   0,  -14
+.2byte    0,  -14, 	 -14,   -7, 	  14,   -7, 	   0,  -11
+.2byte    0,  -15, 	  -8,   -8, 	   8,   -8, 	   0,  -11
+sMoltresAnimTable1:
+.4byte sMoltresAnims_1_1
+.4byte sMoltresAnims_1_2
+.4byte sMoltresAnims_1_3
+.4byte sMoltresAnims_1_4
+.4byte sMoltresAnims_1_5
+.4byte sMoltresAnims_1_6
+.4byte sMoltresAnims_1_7
+.4byte sMoltresAnims_1_8
+sMoltresAnimTable2:
+.4byte sMoltresAnims_2_1
+.4byte sMoltresAnims_2_2
+.4byte sMoltresAnims_2_3
+.4byte sMoltresAnims_2_4
+.4byte sMoltresAnims_2_5
+.4byte sMoltresAnims_2_6
+.4byte sMoltresAnims_2_7
+.4byte sMoltresAnims_2_8
+sMoltresAnimTable3:
+.4byte sMoltresAnims_3_1
+.4byte sMoltresAnims_3_2
+.4byte sMoltresAnims_3_3
+.4byte sMoltresAnims_3_4
+.4byte sMoltresAnims_3_5
+.4byte sMoltresAnims_3_6
+.4byte sMoltresAnims_3_7
+.4byte sMoltresAnims_3_8
+sMoltresAnimTable4:
+.4byte sMoltresAnims_4_1
+.4byte sMoltresAnims_4_2
+.4byte sMoltresAnims_4_3
+.4byte sMoltresAnims_4_4
+.4byte sMoltresAnims_4_5
+.4byte sMoltresAnims_4_6
+.4byte sMoltresAnims_4_7
+.4byte sMoltresAnims_4_8
+sMoltresAnimTable5:
+.4byte sMoltresAnims_5_1
+.4byte sMoltresAnims_5_2
+.4byte sMoltresAnims_5_3
+.4byte sMoltresAnims_5_4
+.4byte sMoltresAnims_5_5
+.4byte sMoltresAnims_5_6
+.4byte sMoltresAnims_5_7
+.4byte sMoltresAnims_5_8
+sMoltresAnimTable6:
+.4byte sMoltresAnims_6_1
+.4byte sMoltresAnims_6_1
+.4byte sMoltresAnims_6_1
+.4byte sMoltresAnims_6_1
+.4byte sMoltresAnims_6_1
+.4byte sMoltresAnims_6_1
+.4byte sMoltresAnims_6_1
+.4byte sMoltresAnims_6_1
+sMoltresAnimTable7:
+.4byte sMoltresAnims_7_1
+.4byte sMoltresAnims_7_2
+.4byte sMoltresAnims_7_3
+.4byte sMoltresAnims_7_4
+.4byte sMoltresAnims_7_5
+.4byte sMoltresAnims_7_6
+.4byte sMoltresAnims_7_7
+.4byte sMoltresAnims_7_8
+sMoltresAnimTable8:
+.4byte sMoltresAnims_8_1
+.4byte sMoltresAnims_8_2
+.4byte sMoltresAnims_8_3
+.4byte sMoltresAnims_8_4
+.4byte sMoltresAnims_8_5
+.4byte sMoltresAnims_8_6
+.4byte sMoltresAnims_8_7
+.4byte sMoltresAnims_8_8
+sMoltresAnimTable9:
+.4byte sMoltresAnims_9_1
+.4byte sMoltresAnims_9_2
+.4byte sMoltresAnims_9_3
+.4byte sMoltresAnims_9_4
+.4byte sMoltresAnims_9_5
+.4byte sMoltresAnims_9_6
+.4byte sMoltresAnims_9_7
+.4byte sMoltresAnims_9_8
+sMoltresAnimTable10:
+.4byte sMoltresAnims_10_1
+.4byte sMoltresAnims_10_2
+.4byte sMoltresAnims_10_3
+.4byte sMoltresAnims_10_4
+.4byte sMoltresAnims_10_5
+.4byte sMoltresAnims_10_6
+.4byte sMoltresAnims_10_7
+.4byte sMoltresAnims_10_8
+sMoltresAnimTable11:
+.4byte sMoltresAnims_11_1
+.4byte sMoltresAnims_11_2
+.4byte sMoltresAnims_11_3
+.4byte sMoltresAnims_11_4
+.4byte sMoltresAnims_11_5
+.4byte sMoltresAnims_11_6
+.4byte sMoltresAnims_11_7
+.4byte sMoltresAnims_11_8
+sMoltresAnimTable12:
+.4byte sMoltresAnims_12_1
+.4byte sMoltresAnims_12_2
+.4byte sMoltresAnims_12_3
+.4byte sMoltresAnims_12_4
+.4byte sMoltresAnims_12_5
+.4byte sMoltresAnims_12_6
+.4byte sMoltresAnims_12_7
+.4byte sMoltresAnims_12_8
+sMoltresAnimTable13:
+.4byte sMoltresAnims_13_1
+.4byte sMoltresAnims_13_2
+.4byte sMoltresAnims_13_3
+.4byte sMoltresAnims_13_4
+.4byte sMoltresAnims_13_5
+.4byte sMoltresAnims_13_6
+.4byte sMoltresAnims_13_7
+.4byte sMoltresAnims_13_8
+sMoltresAnimTable14:
+.4byte sMoltresAnims_14_1
+.4byte sMoltresAnims_14_2
+.4byte sMoltresAnims_14_3
+.4byte sMoltresAnims_14_4
+.4byte sMoltresAnims_14_5
+.4byte sMoltresAnims_14_6
+.4byte sMoltresAnims_14_7
+.4byte sMoltresAnims_14_8
+sMoltresAnimTable15:
+.4byte sMoltresAnims_15_1
+.4byte sMoltresAnims_15_2
+.4byte sMoltresAnims_15_3
+.4byte sMoltresAnims_15_4
+.4byte sMoltresAnims_15_5
+.4byte sMoltresAnims_15_6
+.4byte sMoltresAnims_15_7
+.4byte sMoltresAnims_15_8
+sMoltresAnimTable16:
+.4byte sMoltresAnims_16_1
+.4byte sMoltresAnims_16_2
+.4byte sMoltresAnims_16_3
+.4byte sMoltresAnims_16_4
+.4byte sMoltresAnims_16_5
+.4byte sMoltresAnims_16_6
+.4byte sMoltresAnims_16_7
+.4byte sMoltresAnims_16_8
+sMoltresAnimTable17:
+.4byte sMoltresAnims_17_1
+.4byte sMoltresAnims_17_2
+.4byte sMoltresAnims_17_3
+.4byte sMoltresAnims_17_4
+.4byte sMoltresAnims_17_5
+.4byte sMoltresAnims_17_6
+.4byte sMoltresAnims_17_7
+.4byte sMoltresAnims_17_8
+sAxAnimationsMoltres:
+.4byte sMoltresAnimTable1
+.4byte sMoltresAnimTable2
+.4byte sMoltresAnimTable3
+.4byte sMoltresAnimTable4
+.4byte sMoltresAnimTable5
+.4byte sMoltresAnimTable6
+.4byte sMoltresAnimTable7
+.4byte sMoltresAnimTable8
+.4byte sMoltresAnimTable9
+.4byte sMoltresAnimTable10
+.4byte sMoltresAnimTable11
+.4byte sMoltresAnimTable12
+.4byte sMoltresAnimTable13
+.4byte sMoltresAnimTable14
+.4byte sMoltresAnimTable15
+.4byte sMoltresAnimTable16
+.4byte sMoltresAnimTable17
+sAxSpritesMoltres:
+.4byte sMoltresSprites1
+.4byte sMoltresSprites2
+.4byte sMoltresSprites3
+.4byte sMoltresSprites4
+.4byte sMoltresSprites5
+.4byte sMoltresSprites6
+.4byte sMoltresSprites7
+.4byte sMoltresSprites8
+.4byte sMoltresSprites9
+.4byte sMoltresSprites10
+.4byte sMoltresSprites11
+.4byte sMoltresSprites12
+.4byte sMoltresSprites13
+.4byte sMoltresSprites14
+.4byte sMoltresSprites15
+.4byte sMoltresSprites16
+.4byte sMoltresSprites17
+.4byte sMoltresSprites18
+.4byte sMoltresSprites19
+.4byte sMoltresSprites20
+.4byte sMoltresSprites21
+.4byte sMoltresSprites22
+.4byte sMoltresSprites23
+.4byte sMoltresSprites24
+.4byte sMoltresSprites25
+.4byte sMoltresSprites26
+.4byte sMoltresSprites27
+.4byte sMoltresSprites28
+.4byte sMoltresSprites29
+.4byte sMoltresSprites30
+.4byte sMoltresSprites31
+.4byte sMoltresSprites32
+.4byte sMoltresSprites33
+.4byte sMoltresSprites34
+.4byte sMoltresSprites35
+.4byte sMoltresSprites36
+.4byte sMoltresSprites37
+.4byte sMoltresSprites38
+.4byte sMoltresSprites39
+.4byte sMoltresSprites40
+.4byte sMoltresSprites41
+.4byte sMoltresSprites42
+.4byte sMoltresSprites43
+.4byte sMoltresSprites44
+.4byte sMoltresSprites45
+.4byte sMoltresSprites46
+.4byte sMoltresSprites47
+.4byte sMoltresSprites48
+.4byte sMoltresSprites49
+.4byte sMoltresSprites50
+.4byte sMoltresSprites51
+.4byte sMoltresSprites52
+.4byte sMoltresSprites53
+.4byte sMoltresSprites54
+.4byte sMoltresSprites55
+.4byte sMoltresSprites56
+.4byte sMoltresSprites57
+.4byte sMoltresSprites58
+.4byte sMoltresSprites59
+.4byte sMoltresSprites60
+.4byte sMoltresSprites61
+.4byte sMoltresSprites62
+.4byte sMoltresSprites63
+.4byte sMoltresSprites64
+.4byte sMoltresSprites65
+.4byte sMoltresSprites66
+.4byte sMoltresSprites67
+.4byte sMoltresSprites68
+.4byte sMoltresSprites69
+.4byte sMoltresSprites70
+.4byte sMoltresSprites71
+.4byte sMoltresSprites72
+.4byte sMoltresSprites73
+.4byte sMoltresSprites74
+.4byte sMoltresSprites75
+.4byte sMoltresSprites76
+.4byte sMoltresSprites77
+.4byte sMoltresSprites78
+.4byte sMoltresSprites79
+.4byte sMoltresSprites80
+.4byte sMoltresSprites81
+.4byte sMoltresSprites82
+.4byte sMoltresSprites83
+.4byte sMoltresSprites84
+.4byte sMoltresSprites85
+.4byte sMoltresSprites86
+.4byte sMoltresSprites87
+.4byte sMoltresSprites88
+.4byte sMoltresSprites89
+.4byte sMoltresSprites90
+.4byte sMoltresSprites91
+.4byte sMoltresSprites92
+.4byte sMoltresSprites93
+.4byte sMoltresSprites94
+.4byte sMoltresSprites95
+.4byte sMoltresSprites96
+.4byte sMoltresSprites97
+.4byte sMoltresSprites98
+.4byte sMoltresSprites99
+.4byte sMoltresSprites100
+.4byte sMoltresSprites101
+.4byte sMoltresSprites102
+.4byte sMoltresSprites103
+.4byte sMoltresSprites104
+.4byte sMoltresSprites105
+.4byte sMoltresSprites106
+.4byte sMoltresSprites107
+.4byte sMoltresSprites108
+.4byte sMoltresSprites109
+.4byte sMoltresSprites110
+.4byte sMoltresSprites111
+.4byte sMoltresSprites112
+.4byte sMoltresSprites113
+.4byte sMoltresSprites114
+.4byte sMoltresSprites115
+.4byte sMoltresSprites116
+.4byte sMoltresSprites117
+.4byte sMoltresSprites118
+.4byte sMoltresSprites119
+.4byte sMoltresSprites120
+.4byte sMoltresSprites121
+.4byte sMoltresSprites122
+.4byte sMoltresSprites123
+.4byte sMoltresSprites124
+.4byte sMoltresSprites125
+.4byte sMoltresSprites126
+.4byte sMoltresSprites127
+.4byte sMoltresSprites128
+.4byte sMoltresSprites129
+.4byte sMoltresSprites130
+.4byte sMoltresSprites131
+.4byte sMoltresSprites132
+.4byte sMoltresSprites133
+.4byte sMoltresSprites134
+.4byte sMoltresSprites135
+.4byte sMoltresSprites136
+.4byte sMoltresSprites137
+.4byte sMoltresSprites138
+.4byte sMoltresSprites139
+.4byte sMoltresSprites140
+.4byte sMoltresSprites141
+.4byte sMoltresSprites142
+.4byte sMoltresSprites143
+.4byte sMoltresSprites144
+.4byte sMoltresSprites145
+.4byte sMoltresSprites146
+.4byte sMoltresSprites147
+.4byte sMoltresSprites148
+.4byte sMoltresSprites149
+.4byte sMoltresSprites150
+.4byte sMoltresSprites151
+.4byte sMoltresSprites152
+.4byte sMoltresSprites153
+.4byte sMoltresSprites154
+.4byte sMoltresSprites155
+.4byte sMoltresSprites156
+.4byte sMoltresSprites157
+.4byte sMoltresSprites158
+.4byte sMoltresSprites159
+.4byte sMoltresSprites160
+.4byte sMoltresSprites161
+.4byte sMoltresSprites162
+.4byte sMoltresSprites163
+.4byte sMoltresSprites164
+.4byte sMoltresSprites165
+.4byte sMoltresSprites166
+.4byte sMoltresSprites167
+.4byte sMoltresSprites168
+.4byte sMoltresSprites169
+.4byte sMoltresSprites170
+.4byte sMoltresSprites171
+.4byte sMoltresSprites172
+.4byte sMoltresSprites173
+.4byte sMoltresSprites174
+.4byte sMoltresSprites175
+.4byte sMoltresSprites176
+.4byte sMoltresSprites177
+.4byte sMoltresSprites178
+.4byte sMoltresSprites179
+.4byte sMoltresSprites180
+.4byte sMoltresSprites181
+.4byte sMoltresSprites182
+.4byte sMoltresSprites183
+.4byte sMoltresSprites184
+.4byte sMoltresSprites185
+.4byte sMoltresSprites186
+.4byte sMoltresSprites187
+.4byte sMoltresSprites188
+.4byte sMoltresSprites189
+.4byte sMoltresSprites190
+.4byte sMoltresSprites191
+.4byte sMoltresSprites192
+.4byte sMoltresSprites193
+.4byte sMoltresSprites194
+.4byte sMoltresSprites195
+.4byte sMoltresSprites196
+.4byte sMoltresSprites197
+.4byte sMoltresSprites198
+.4byte sMoltresSprites199
+.4byte sMoltresSprites200
+.4byte sMoltresSprites201
+.4byte sMoltresSprites202
+.4byte sMoltresSprites203
+.4byte sMoltresSprites204
+.4byte sMoltresSprites205
+.4byte sMoltresSprites206
+.4byte sMoltresSprites207
+.4byte sMoltresSprites208
+.4byte sMoltresSprites209
+.4byte sMoltresSprites210
+.4byte sMoltresSprites211
+.4byte sMoltresSprites212
+.4byte sMoltresSprites213
+.4byte sMoltresSprites214
+.4byte sMoltresSprites215
+.4byte sMoltresSprites216
+.4byte sMoltresSprites217
+.4byte sMoltresSprites218
+.4byte sMoltresSprites219
+.4byte sMoltresSprites220
+.4byte sMoltresSprites221
+.4byte sMoltresSprites222
+.4byte sMoltresSprites223
+.4byte sMoltresSprites224
+.4byte sMoltresSprites225
+.4byte sMoltresSprites226
+.4byte sMoltresSprites227
+.4byte sMoltresSprites228
+.4byte sMoltresSprites229
+.4byte sMoltresSprites230
+.4byte sMoltresSprites231
+.4byte sMoltresSprites232
+.4byte sMoltresSprites233
+.4byte sMoltresSprites234
+sAxMainMoltres:
+ax_main sAxPosesMoltres, sAxAnimationsMoltres, 17, sAxSpritesMoltres, sAxPositionsMoltres

--- a/data/ax/mrmime.inc
+++ b/data/ax/mrmime.inc
@@ -1,0 +1,2868 @@
+.global gAxMrMime
+gAxMrMime:
+ax_siro sAxMainMrMime
+sMrMimePose1:
+ax_pose 0, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose2:
+ax_pose 1, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose3:
+ax_pose 2, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose4:
+ax_pose 3, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose5:
+ax_pose 4, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose6:
+ax_pose 5, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose7:
+ax_pose 6, 0x81e4, 0x90f8, 0xbc00
+ax_pose_terminator
+sMrMimePose8:
+ax_pose 7, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose9:
+ax_pose 8, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose10:
+ax_pose 9, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose11:
+ax_pose 10, 0x01e4, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose12:
+ax_pose 11, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose13:
+ax_pose 12, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose14:
+ax_pose 13, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose15:
+ax_pose 14, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose16:
+ax_pose 9, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose17:
+ax_pose 10, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose18:
+ax_pose 11, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose19:
+ax_pose 6, 0x81e4, 0x80f8, 0xbc00
+ax_pose_terminator
+sMrMimePose20:
+ax_pose 7, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose21:
+ax_pose 8, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose22:
+ax_pose 3, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose23:
+ax_pose 4, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose24:
+ax_pose 5, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose25:
+ax_pose 0, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose26:
+ax_pose 1, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose27:
+ax_pose 2, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose28:
+ax_pose 3, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose29:
+ax_pose 4, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose30:
+ax_pose 5, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose31:
+ax_pose 6, 0x81e4, 0x90f8, 0xbc00
+ax_pose_terminator
+sMrMimePose32:
+ax_pose 7, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose33:
+ax_pose 8, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose34:
+ax_pose 9, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose35:
+ax_pose 10, 0x01e4, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose36:
+ax_pose 11, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose37:
+ax_pose 12, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose38:
+ax_pose 13, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose39:
+ax_pose 14, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose40:
+ax_pose 9, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose41:
+ax_pose 10, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose42:
+ax_pose 11, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose43:
+ax_pose 6, 0x81e4, 0x80f8, 0xbc00
+ax_pose_terminator
+sMrMimePose44:
+ax_pose 7, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose45:
+ax_pose 8, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose46:
+ax_pose 3, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose47:
+ax_pose 4, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose48:
+ax_pose 5, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose49:
+ax_pose 0, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose50:
+ax_pose 1, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose51:
+ax_pose 2, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose52:
+ax_pose 3, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose53:
+ax_pose 4, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose54:
+ax_pose 5, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose55:
+ax_pose 6, 0x81e4, 0x90f8, 0xbc00
+ax_pose_terminator
+sMrMimePose56:
+ax_pose 7, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose57:
+ax_pose 8, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose58:
+ax_pose 9, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose59:
+ax_pose 10, 0x01e4, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose60:
+ax_pose 11, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose61:
+ax_pose 12, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose62:
+ax_pose 13, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose63:
+ax_pose 14, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose64:
+ax_pose 9, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose65:
+ax_pose 10, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose66:
+ax_pose 11, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose67:
+ax_pose 6, 0x81e4, 0x80f8, 0xbc00
+ax_pose_terminator
+sMrMimePose68:
+ax_pose 7, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose69:
+ax_pose 8, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose70:
+ax_pose 3, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose71:
+ax_pose 4, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose72:
+ax_pose 5, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose73:
+ax_pose 15, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose74:
+ax_pose 16, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose75:
+ax_pose 17, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose76:
+ax_pose 18, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose77:
+ax_pose 0, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose78:
+ax_pose 19, 0x01e7, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose79:
+ax_pose 20, 0x01e7, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose80:
+ax_pose 21, 0x01e7, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose81:
+ax_pose 22, 0x01e7, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose82:
+ax_pose 3, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose83:
+ax_pose 23, 0x01e4, 0x90f5, 0xbc00
+ax_pose_terminator
+sMrMimePose84:
+ax_pose 24, 0x01e4, 0x90f5, 0xbc00
+ax_pose_terminator
+sMrMimePose85:
+ax_pose 25, 0x01e4, 0x90f5, 0xbc00
+ax_pose_terminator
+sMrMimePose86:
+ax_pose 26, 0x01e4, 0x90f5, 0xbc00
+ax_pose_terminator
+sMrMimePose87:
+ax_pose 6, 0x81e4, 0x90f8, 0xbc00
+ax_pose_terminator
+sMrMimePose88:
+ax_pose 27, 0x01e6, 0x90f6, 0xbc00
+ax_pose_terminator
+sMrMimePose89:
+ax_pose 28, 0x01e6, 0x90f6, 0xbc00
+ax_pose_terminator
+sMrMimePose90:
+ax_pose 29, 0x01e6, 0x90f6, 0xbc00
+ax_pose_terminator
+sMrMimePose91:
+ax_pose 30, 0x01e6, 0x90f6, 0xbc00
+ax_pose_terminator
+sMrMimePose92:
+ax_pose 9, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose93:
+ax_pose 31, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose94:
+ax_pose 32, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose95:
+ax_pose 33, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose96:
+ax_pose 34, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose97:
+ax_pose 12, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose98:
+ax_pose 27, 0x01e6, 0x80ea, 0xbc00
+ax_pose_terminator
+sMrMimePose99:
+ax_pose 28, 0x01e6, 0x80ea, 0xbc00
+ax_pose_terminator
+sMrMimePose100:
+ax_pose 29, 0x01e6, 0x80ea, 0xbc00
+ax_pose_terminator
+sMrMimePose101:
+ax_pose 30, 0x01e6, 0x80ea, 0xbc00
+ax_pose_terminator
+sMrMimePose102:
+ax_pose 9, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose103:
+ax_pose 23, 0x01e4, 0x80eb, 0xbc00
+ax_pose_terminator
+sMrMimePose104:
+ax_pose 24, 0x01e4, 0x80eb, 0xbc00
+ax_pose_terminator
+sMrMimePose105:
+ax_pose 25, 0x01e4, 0x80eb, 0xbc00
+ax_pose_terminator
+sMrMimePose106:
+ax_pose 26, 0x01e4, 0x80eb, 0xbc00
+ax_pose_terminator
+sMrMimePose107:
+ax_pose 6, 0x81e4, 0x80f8, 0xbc00
+ax_pose_terminator
+sMrMimePose108:
+ax_pose 19, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose109:
+ax_pose 20, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose110:
+ax_pose 21, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose111:
+ax_pose 22, 0x01e7, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose112:
+ax_pose 3, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose113:
+ax_pose 35, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose114:
+ax_pose 36, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sMrMimePose115:
+ax_pose 37, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose116:
+ax_pose 38, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose117:
+ax_pose 39, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose118:
+ax_pose 40, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose119:
+ax_pose 41, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose120:
+ax_pose 42, 0x01e4, 0x80f6, 0xbc00
+ax_pose_terminator
+sMrMimePose121:
+ax_pose 43, 0x01e9, 0x80f1, 0xbc00
+ax_pose_terminator
+sMrMimePose122:
+ax_pose 44, 0x01e9, 0x80f1, 0xbc00
+ax_pose_terminator
+sMrMimePose123:
+ax_pose 45, 0x01e2, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose124:
+ax_pose 46, 0x01e3, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose125:
+ax_pose 47, 0x01e3, 0x90ea, 0xbc00
+ax_pose_terminator
+sMrMimePose126:
+ax_pose 48, 0x01e3, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose127:
+ax_pose 49, 0x01e2, 0x80f1, 0xbc00
+ax_pose_terminator
+sMrMimePose128:
+ax_pose 48, 0x01e3, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose129:
+ax_pose 47, 0x01e3, 0x80f6, 0xbc00
+ax_pose_terminator
+sMrMimePose130:
+ax_pose 46, 0x01e3, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose131:
+ax_pose 35, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose132:
+ax_pose 36, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sMrMimePose133:
+ax_pose 37, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose134:
+ax_pose 38, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose135:
+ax_pose 39, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose136:
+ax_pose 40, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose137:
+ax_pose 41, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose138:
+ax_pose 42, 0x01e4, 0x80f6, 0xbc00
+ax_pose_terminator
+sMrMimePose139:
+ax_pose 50, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose140:
+ax_pose 51, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sMrMimePose141:
+ax_pose 52, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose142:
+ax_pose 53, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose143:
+ax_pose 54, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose144:
+ax_pose 55, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose145:
+ax_pose 56, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose146:
+ax_pose 57, 0x01e4, 0x80f6, 0xbc00
+ax_pose_terminator
+sMrMimePose147:
+ax_pose 18, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose148:
+ax_pose 22, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose149:
+ax_pose 26, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose150:
+ax_pose 30, 0x01e9, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose151:
+ax_pose 34, 0x01eb, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose152:
+ax_pose 30, 0x01e9, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose153:
+ax_pose 26, 0x01e5, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose154:
+ax_pose 22, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose155:
+ax_pose 35, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose156:
+ax_pose 42, 0x01e4, 0x80f6, 0xbc00
+ax_pose_terminator
+sMrMimePose157:
+ax_pose 41, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose158:
+ax_pose 40, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose159:
+ax_pose 39, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose160:
+ax_pose 38, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose161:
+ax_pose 37, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose162:
+ax_pose 36, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sMrMimePose163:
+ax_pose 0, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose164:
+ax_pose 1, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose165:
+ax_pose 2, 0x01ec, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose166:
+ax_pose 3, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose167:
+ax_pose 4, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose168:
+ax_pose 5, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose169:
+ax_pose 6, 0x81e4, 0x90f8, 0xbc00
+ax_pose_terminator
+sMrMimePose170:
+ax_pose 7, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose171:
+ax_pose 8, 0x01e4, 0x90ec, 0xbc00
+ax_pose_terminator
+sMrMimePose172:
+ax_pose 9, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose173:
+ax_pose 10, 0x01e4, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose174:
+ax_pose 11, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sMrMimePose175:
+ax_pose 12, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose176:
+ax_pose 13, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose177:
+ax_pose 14, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose178:
+ax_pose 9, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose179:
+ax_pose 10, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose180:
+ax_pose 11, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose181:
+ax_pose 6, 0x81e4, 0x80f8, 0xbc00
+ax_pose_terminator
+sMrMimePose182:
+ax_pose 7, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose183:
+ax_pose 8, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose184:
+ax_pose 3, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose185:
+ax_pose 4, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose186:
+ax_pose 5, 0x01e4, 0x80f5, 0xbc00
+ax_pose_terminator
+sMrMimePose187:
+ax_pose 18, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose188:
+ax_pose 22, 0x01e6, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose189:
+ax_pose 26, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose190:
+ax_pose 30, 0x01e9, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose191:
+ax_pose 34, 0x01eb, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose192:
+ax_pose 30, 0x01e9, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose193:
+ax_pose 26, 0x01e5, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose194:
+ax_pose 22, 0x01e6, 0x90f0, 0xbc00
+ax_pose_terminator
+sMrMimePose195:
+ax_pose 35, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose196:
+ax_pose 36, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sMrMimePose197:
+ax_pose 37, 0x01e4, 0x80f0, 0xbc00
+ax_pose_terminator
+sMrMimePose198:
+ax_pose 38, 0x01e4, 0x80f2, 0xbc00
+ax_pose_terminator
+sMrMimePose199:
+ax_pose 39, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose200:
+ax_pose 40, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose201:
+ax_pose 41, 0x01e4, 0x80f4, 0xbc00
+ax_pose_terminator
+sMrMimePose202:
+ax_pose 42, 0x01e4, 0x80f6, 0xbc00
+ax_pose_terminator
+.align 2
+sMrMimeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim 2, 0, 24, 0, 3, 0, 3,
+ax_anim_terminator
+sMrMimeAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim 2, 0, 27, 3, 3, 3, 3,
+ax_anim_terminator
+sMrMimeAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim 2, 0, 30, 3, 0, 3, 0,
+ax_anim_terminator
+sMrMimeAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim 2, 0, 33, 3, -3, 3, -3,
+ax_anim_terminator
+sMrMimeAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim 2, 0, 36, 0, -3, 0, -3,
+ax_anim_terminator
+sMrMimeAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim 2, 0, 39, -3, -3, -3, -3,
+ax_anim_terminator
+sMrMimeAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim 2, 0, 42, -3, 0, -3, 0,
+ax_anim_terminator
+sMrMimeAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim 2, 0, 45, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sMrMimeAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim 2, 0, 51, 3, 3, 3, 3,
+ax_anim_terminator
+sMrMimeAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim_terminator
+sMrMimeAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 1, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 0, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim 2, 0, 57, 3, -3, 3, -3,
+ax_anim_terminator
+sMrMimeAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 1, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 0, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim 2, 0, 60, 0, -3, 0, -3,
+ax_anim_terminator
+sMrMimeAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 1, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 0, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim 2, 0, 63, -3, -3, -3, -3,
+ax_anim_terminator
+sMrMimeAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim 2, 0, 66, -3, 0, -3, 0,
+ax_anim_terminator
+sMrMimeAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim 2, 0, 69, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_4_1:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 1, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 76, 0, 2, 0, 2,
+ax_anim_terminator
+sMrMimeAnims_4_2:
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 3, 3, 3, 3,
+ax_anim 2, 1, 80, 5, 5, 5, 5,
+ax_anim 2, 0, 80, 6, 4, 6, 4,
+ax_anim 2, 0, 80, 5, 5, 5, 5,
+ax_anim 2, 0, 80, 6, 4, 6, 4,
+ax_anim 2, 0, 81, 2, 2, 2, 2,
+ax_anim_terminator
+sMrMimeAnims_4_3:
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 3, 0, 3, 0,
+ax_anim 2, 1, 85, 5, 0, 5, 0,
+ax_anim 2, 0, 85, 5, -1, 5, -1,
+ax_anim 2, 0, 85, 5, 0, 5, 0,
+ax_anim 2, 0, 85, 5, -1, 5, -1,
+ax_anim 2, 0, 86, 2, 0, 2, 0,
+ax_anim_terminator
+sMrMimeAnims_4_4:
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 3, -3, 3, -3,
+ax_anim 2, 1, 90, 5, -5, 5, -5,
+ax_anim 2, 0, 90, 6, -4, 6, -4,
+ax_anim 2, 0, 90, 5, -5, 5, -5,
+ax_anim 2, 0, 90, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim_terminator
+sMrMimeAnims_4_5:
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, -3,
+ax_anim 2, 1, 95, 0, -5, 0, -5,
+ax_anim 2, 0, 95, 1, -5, 1, -5,
+ax_anim 2, 0, 95, 0, -5, 0, -5,
+ax_anim 2, 0, 95, 1, -5, 1, -5,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim_terminator
+sMrMimeAnims_4_6:
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 100, -3, -3, -3, -3,
+ax_anim 2, 1, 100, -5, -5, -5, -5,
+ax_anim 2, 0, 100, -6, -4, -6, -4,
+ax_anim 2, 0, 100, -5, -5, -5, -5,
+ax_anim 2, 0, 100, -6, -4, -6, -4,
+ax_anim 2, 0, 101, -2, -2, -2, -2,
+ax_anim_terminator
+sMrMimeAnims_4_7:
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 105, -3, 0, -3, 0,
+ax_anim 2, 1, 105, -5, 0, -5, 0,
+ax_anim 2, 0, 105, -5, -1, -5, -1,
+ax_anim 2, 0, 105, -5, 0, -5, 0,
+ax_anim 2, 0, 105, -5, -1, -5, -1,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim_terminator
+sMrMimeAnims_4_8:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 1, 110, -5, 5, -5, 5,
+ax_anim 2, 0, 110, -6, 4, -6, 4,
+ax_anim 2, 0, 110, -5, 5, -5, 5,
+ax_anim 2, 0, 110, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sMrMimeAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sMrMimeAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sMrMimeAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sMrMimeAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sMrMimeAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sMrMimeAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sMrMimeAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_8_1:
+ax_anim 20, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_8_2:
+ax_anim 20, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_8_3:
+ax_anim 20, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_8_4:
+ax_anim 20, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_8_5:
+ax_anim 20, 0, 134, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_8_6:
+ax_anim 20, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_8_7:
+ax_anim 20, 0, 132, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_8_8:
+ax_anim 20, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 15, 7, 15,
+ax_anim 3, 0, 150, 0, 18, 0, 18,
+ax_anim 2, 3, 151, -7, 15, -7, 15,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 19, 10, 19, 10,
+ax_anim 3, 0, 149, 19, 19, 19, 19,
+ax_anim 2, 3, 150, 11, 19, 11, 19,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 18, -5, 18, -5,
+ax_anim 3, 0, 148, 21, -2, 21, -2,
+ax_anim 2, 3, 149, 18, 4, 18, 4,
+ax_anim 2, 0, 150, 12, 4, 12, 4,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 3, -17, 3, -17,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 21, -22, 21, -22,
+ax_anim 2, 3, 148, 21, -14, 21, -14,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -7, -20, -7, -20,
+ax_anim 3, 0, 146, 0, -24, 0, -24,
+ax_anim 2, 3, 147, 7, -20, 7, -20,
+ax_anim 2, 0, 148, 9, -10, 9, -10,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -3, -17, -3, -17,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -21, -22, -21, -22,
+ax_anim 2, 3, 152, -21, -14, -21, -14,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -18, -5, -18, -5,
+ax_anim 3, 0, 152, -21, -2, -21, -2,
+ax_anim 2, 3, 151, -18, 4, -18, 4,
+ax_anim 2, 0, 150, -12, 4, -12, 4,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -19, 10, -19, 10,
+ax_anim 3, 0, 151, -19, 19, -19, 19,
+ax_anim 2, 3, 150, -11, 19, -11, 19,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMrMimeAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMrMimeGfx1:
+.incbin "baserom.gba", 0xA3C7B8, 0x200
+sMrMimeSprites1:
+ax_sprite sMrMimeGfx1, 0x200
+ax_sprite_terminator
+sMrMimeGfx2:
+.incbin "baserom.gba", 0xA3C9C8, 0x200
+sMrMimeSprites2:
+ax_sprite sMrMimeGfx2, 0x200
+ax_sprite_terminator
+sMrMimeGfx3:
+.incbin "baserom.gba", 0xA3CBD8, 0x200
+sMrMimeSprites3:
+ax_sprite sMrMimeGfx3, 0x200
+ax_sprite_terminator
+sMrMimeGfx4:
+.incbin "baserom.gba", 0xA3CDE8, 0x200
+sMrMimeSprites4:
+ax_sprite sMrMimeGfx4, 0x200
+ax_sprite_terminator
+sMrMimeGfx5:
+.incbin "baserom.gba", 0xA3CFF8, 0x200
+sMrMimeSprites5:
+ax_sprite sMrMimeGfx5, 0x200
+ax_sprite_terminator
+sMrMimeGfx6:
+.incbin "baserom.gba", 0xA3D208, 0x200
+sMrMimeSprites6:
+ax_sprite sMrMimeGfx6, 0x200
+ax_sprite_terminator
+sMrMimeGfx7:
+.incbin "baserom.gba", 0xA3D418, 0x100
+sMrMimeSprites7:
+ax_sprite sMrMimeGfx7, 0x100
+ax_sprite_terminator
+sMrMimeGfx8:
+.incbin "baserom.gba", 0xA3D528, 0x200
+sMrMimeSprites8:
+ax_sprite sMrMimeGfx8, 0x200
+ax_sprite_terminator
+sMrMimeGfx9:
+.incbin "baserom.gba", 0xA3D738, 0x200
+sMrMimeSprites9:
+ax_sprite sMrMimeGfx9, 0x200
+ax_sprite_terminator
+sMrMimeGfx10:
+.incbin "baserom.gba", 0xA3D948, 0x200
+sMrMimeSprites10:
+ax_sprite sMrMimeGfx10, 0x200
+ax_sprite_terminator
+sMrMimeGfx11:
+.incbin "baserom.gba", 0xA3DB58, 0x200
+sMrMimeSprites11:
+ax_sprite sMrMimeGfx11, 0x200
+ax_sprite_terminator
+sMrMimeGfx12:
+.incbin "baserom.gba", 0xA3DD68, 0x200
+sMrMimeSprites12:
+ax_sprite sMrMimeGfx12, 0x200
+ax_sprite_terminator
+sMrMimeGfx13:
+.incbin "baserom.gba", 0xA3DF78, 0x200
+sMrMimeSprites13:
+ax_sprite sMrMimeGfx13, 0x200
+ax_sprite_terminator
+sMrMimeGfx14:
+.incbin "baserom.gba", 0xA3E188, 0x200
+sMrMimeSprites14:
+ax_sprite sMrMimeGfx14, 0x200
+ax_sprite_terminator
+sMrMimeGfx15:
+.incbin "baserom.gba", 0xA3E398, 0x200
+sMrMimeSprites15:
+ax_sprite sMrMimeGfx15, 0x200
+ax_sprite_terminator
+sMrMimeGfx16:
+.incbin "baserom.gba", 0xA3E5A8, 0x40
+sMrMimeGfx16_1:
+.incbin "baserom.gba", 0xA3E5E8, 0x60
+sMrMimeGfx16_2:
+.incbin "baserom.gba", 0xA3E648, 0x100
+sMrMimeSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx16_2, 0x100
+ax_sprite_terminator
+sMrMimeGfx17:
+.incbin "baserom.gba", 0xA3E780, 0x40
+sMrMimeGfx17_1:
+.incbin "baserom.gba", 0xA3E7C0, 0x180
+sMrMimeSprites17:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx17_1, 0x180
+ax_sprite_terminator
+sMrMimeGfx18:
+.incbin "baserom.gba", 0xA3E968, 0x100
+sMrMimeGfx18_1:
+.incbin "baserom.gba", 0xA3EA68, 0xE0
+sMrMimeSprites18:
+ax_sprite sMrMimeGfx18, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx18_1, 0xe0
+ax_sprite_terminator
+sMrMimeGfx19:
+.incbin "baserom.gba", 0xA3EB68, 0x180
+sMrMimeSprites19:
+ax_sprite 0, 0x80
+ax_sprite sMrMimeGfx19, 0x180
+ax_sprite_terminator
+sMrMimeGfx20:
+.incbin "baserom.gba", 0xA3ED00, 0x40
+sMrMimeGfx20_1:
+.incbin "baserom.gba", 0xA3ED40, 0x60
+sMrMimeGfx20_2:
+.incbin "baserom.gba", 0xA3EDA0, 0x60
+sMrMimeGfx20_3:
+.incbin "baserom.gba", 0xA3EE00, 0x80
+sMrMimeSprites20:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx20_3, 0x80
+ax_sprite_terminator
+sMrMimeGfx21:
+.incbin "baserom.gba", 0xA3EEC8, 0x40
+sMrMimeGfx21_1:
+.incbin "baserom.gba", 0xA3EF08, 0x60
+sMrMimeGfx21_2:
+.incbin "baserom.gba", 0xA3EF68, 0x60
+sMrMimeGfx21_3:
+.incbin "baserom.gba", 0xA3EFC8, 0x80
+sMrMimeSprites21:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx21_3, 0x80
+ax_sprite_terminator
+sMrMimeGfx22:
+.incbin "baserom.gba", 0xA3F090, 0x40
+sMrMimeGfx22_1:
+.incbin "baserom.gba", 0xA3F0D0, 0x60
+sMrMimeGfx22_2:
+.incbin "baserom.gba", 0xA3F130, 0x60
+sMrMimeGfx22_3:
+.incbin "baserom.gba", 0xA3F190, 0x80
+sMrMimeSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx22_3, 0x80
+ax_sprite_terminator
+sMrMimeGfx23:
+.incbin "baserom.gba", 0xA3F258, 0xE0
+sMrMimeGfx23_1:
+.incbin "baserom.gba", 0xA3F338, 0x80
+sMrMimeSprites23:
+ax_sprite 0, 0x80
+ax_sprite sMrMimeGfx23, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx23_1, 0x80
+ax_sprite_terminator
+sMrMimeGfx24:
+.incbin "baserom.gba", 0xA3F3E0, 0x60
+sMrMimeGfx24_1:
+.incbin "baserom.gba", 0xA3F440, 0x60
+sMrMimeGfx24_2:
+.incbin "baserom.gba", 0xA3F4A0, 0x60
+sMrMimeSprites24:
+ax_sprite 0, 0x80
+ax_sprite sMrMimeGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMrMimeGfx24_2, 0x60
+ax_sprite_terminator
+sMrMimeGfx25:
+.incbin "baserom.gba", 0xA3F538, 0x20
+sMrMimeGfx25_1:
+.incbin "baserom.gba", 0xA3F558, 0x40
+sMrMimeGfx25_2:
+.incbin "baserom.gba", 0xA3F598, 0x60
+sMrMimeGfx25_3:
+.incbin "baserom.gba", 0xA3F5F8, 0x60
+sMrMimeSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx25, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMrMimeGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMrMimeGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx25_3, 0x60
+ax_sprite_terminator
+sMrMimeGfx26:
+.incbin "baserom.gba", 0xA3F6A0, 0x20
+sMrMimeGfx26_1:
+.incbin "baserom.gba", 0xA3F6C0, 0x60
+sMrMimeGfx26_2:
+.incbin "baserom.gba", 0xA3F720, 0x60
+sMrMimeGfx26_3:
+.incbin "baserom.gba", 0xA3F780, 0x60
+sMrMimeSprites26:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sMrMimeGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx26_3, 0x60
+ax_sprite_terminator
+sMrMimeGfx27:
+.incbin "baserom.gba", 0xA3F828, 0x60
+sMrMimeGfx27_1:
+.incbin "baserom.gba", 0xA3F888, 0x60
+sMrMimeGfx27_2:
+.incbin "baserom.gba", 0xA3F8E8, 0x80
+sMrMimeSprites27:
+ax_sprite 0, 0x80
+ax_sprite sMrMimeGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx27_2, 0x80
+ax_sprite_terminator
+sMrMimeGfx28:
+.incbin "baserom.gba", 0xA3F9A0, 0x60
+sMrMimeGfx28_1:
+.incbin "baserom.gba", 0xA3FA00, 0x60
+sMrMimeGfx28_2:
+.incbin "baserom.gba", 0xA3FA60, 0x60
+sMrMimeGfx28_3:
+.incbin "baserom.gba", 0xA3FAC0, 0x60
+sMrMimeSprites28:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx28_3, 0x60
+ax_sprite_terminator
+sMrMimeGfx29:
+.incbin "baserom.gba", 0xA3FB68, 0x60
+sMrMimeGfx29_1:
+.incbin "baserom.gba", 0xA3FBC8, 0x60
+sMrMimeGfx29_2:
+.incbin "baserom.gba", 0xA3FC28, 0x60
+sMrMimeGfx29_3:
+.incbin "baserom.gba", 0xA3FC88, 0x60
+sMrMimeSprites29:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx29_3, 0x60
+ax_sprite_terminator
+sMrMimeGfx30:
+.incbin "baserom.gba", 0xA3FD30, 0x60
+sMrMimeGfx30_1:
+.incbin "baserom.gba", 0xA3FD90, 0x60
+sMrMimeGfx30_2:
+.incbin "baserom.gba", 0xA3FDF0, 0x60
+sMrMimeGfx30_3:
+.incbin "baserom.gba", 0xA3FE50, 0x60
+sMrMimeSprites30:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx30_3, 0x60
+ax_sprite_terminator
+sMrMimeGfx31:
+.incbin "baserom.gba", 0xA3FEF8, 0x60
+sMrMimeGfx31_1:
+.incbin "baserom.gba", 0xA3FF58, 0x80
+sMrMimeGfx31_2:
+.incbin "baserom.gba", 0xA3FFD8, 0x60
+sMrMimeGfx31_3:
+.incbin "baserom.gba", 0xA40038, 0x40
+sMrMimeSprites31:
+ax_sprite sMrMimeGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx31_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx32:
+.incbin "baserom.gba", 0xA400C0, 0x20
+sMrMimeGfx32_1:
+.incbin "baserom.gba", 0xA400E0, 0x160
+sMrMimeSprites32:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx32, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMrMimeGfx32_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx33:
+.incbin "baserom.gba", 0xA40270, 0x60
+sMrMimeGfx33_1:
+.incbin "baserom.gba", 0xA402D0, 0xE0
+sMrMimeGfx33_2:
+.incbin "baserom.gba", 0xA403B0, 0x60
+sMrMimeSprites33:
+ax_sprite sMrMimeGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx33_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx34:
+.incbin "baserom.gba", 0xA40448, 0x60
+sMrMimeGfx34_1:
+.incbin "baserom.gba", 0xA404A8, 0xE0
+sMrMimeGfx34_2:
+.incbin "baserom.gba", 0xA40588, 0x60
+sMrMimeSprites34:
+ax_sprite sMrMimeGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx34_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx35:
+.incbin "baserom.gba", 0xA40620, 0x100
+sMrMimeGfx35_1:
+.incbin "baserom.gba", 0xA40720, 0x40
+sMrMimeGfx35_2:
+.incbin "baserom.gba", 0xA40760, 0x20
+sMrMimeSprites35:
+ax_sprite sMrMimeGfx35, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMrMimeGfx35_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMrMimeGfx36:
+.incbin "baserom.gba", 0xA407B8, 0x60
+sMrMimeGfx36_1:
+.incbin "baserom.gba", 0xA40818, 0x60
+sMrMimeGfx36_2:
+.incbin "baserom.gba", 0xA40878, 0x60
+sMrMimeGfx36_3:
+.incbin "baserom.gba", 0xA408D8, 0x60
+sMrMimeSprites36:
+ax_sprite sMrMimeGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx36_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx37:
+.incbin "baserom.gba", 0xA40980, 0x40
+sMrMimeGfx37_1:
+.incbin "baserom.gba", 0xA409C0, 0x60
+sMrMimeGfx37_2:
+.incbin "baserom.gba", 0xA40A20, 0x60
+sMrMimeGfx37_3:
+.incbin "baserom.gba", 0xA40A80, 0x60
+sMrMimeSprites37:
+ax_sprite sMrMimeGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMrMimeGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx38:
+.incbin "baserom.gba", 0xA40B28, 0x60
+sMrMimeGfx38_1:
+.incbin "baserom.gba", 0xA40B88, 0x60
+sMrMimeGfx38_2:
+.incbin "baserom.gba", 0xA40BE8, 0x60
+sMrMimeGfx38_3:
+.incbin "baserom.gba", 0xA40C48, 0x40
+sMrMimeSprites38:
+ax_sprite sMrMimeGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx38_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMrMimeGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx39:
+.incbin "baserom.gba", 0xA40CD0, 0x60
+sMrMimeGfx39_1:
+.incbin "baserom.gba", 0xA40D30, 0x60
+sMrMimeGfx39_2:
+.incbin "baserom.gba", 0xA40D90, 0x60
+sMrMimeGfx39_3:
+.incbin "baserom.gba", 0xA40DF0, 0x60
+sMrMimeSprites39:
+ax_sprite sMrMimeGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx40:
+.incbin "baserom.gba", 0xA40E98, 0x60
+sMrMimeGfx40_1:
+.incbin "baserom.gba", 0xA40EF8, 0x60
+sMrMimeGfx40_2:
+.incbin "baserom.gba", 0xA40F58, 0x60
+sMrMimeGfx40_3:
+.incbin "baserom.gba", 0xA40FB8, 0x60
+sMrMimeSprites40:
+ax_sprite sMrMimeGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx40_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx41:
+.incbin "baserom.gba", 0xA41060, 0x60
+sMrMimeGfx41_1:
+.incbin "baserom.gba", 0xA410C0, 0x60
+sMrMimeGfx41_2:
+.incbin "baserom.gba", 0xA41120, 0x60
+sMrMimeGfx41_3:
+.incbin "baserom.gba", 0xA41180, 0x60
+sMrMimeSprites41:
+ax_sprite sMrMimeGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx41_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx42:
+.incbin "baserom.gba", 0xA41228, 0x40
+sMrMimeGfx42_1:
+.incbin "baserom.gba", 0xA41268, 0x60
+sMrMimeGfx42_2:
+.incbin "baserom.gba", 0xA412C8, 0x60
+sMrMimeGfx42_3:
+.incbin "baserom.gba", 0xA41328, 0x20
+sMrMimeSprites42:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx42_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMrMimeGfx42_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMrMimeGfx43:
+.incbin "baserom.gba", 0xA41398, 0x40
+sMrMimeGfx43_1:
+.incbin "baserom.gba", 0xA413D8, 0x60
+sMrMimeGfx43_2:
+.incbin "baserom.gba", 0xA41438, 0x60
+sMrMimeGfx43_3:
+.incbin "baserom.gba", 0xA41498, 0x60
+sMrMimeSprites43:
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMrMimeGfx43_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMrMimeGfx44:
+.incbin "baserom.gba", 0xA41548, 0x200
+sMrMimeSprites44:
+ax_sprite sMrMimeGfx44, 0x200
+ax_sprite_terminator
+sMrMimeGfx45:
+.incbin "baserom.gba", 0xA41758, 0x200
+sMrMimeSprites45:
+ax_sprite sMrMimeGfx45, 0x200
+ax_sprite_terminator
+sMrMimeGfx46:
+.incbin "baserom.gba", 0xA41968, 0x200
+sMrMimeSprites46:
+ax_sprite sMrMimeGfx46, 0x200
+ax_sprite_terminator
+sMrMimeGfx47:
+.incbin "baserom.gba", 0xA41B78, 0x200
+sMrMimeSprites47:
+ax_sprite sMrMimeGfx47, 0x200
+ax_sprite_terminator
+sMrMimeGfx48:
+.incbin "baserom.gba", 0xA41D88, 0x200
+sMrMimeSprites48:
+ax_sprite sMrMimeGfx48, 0x200
+ax_sprite_terminator
+sMrMimeGfx49:
+.incbin "baserom.gba", 0xA41F98, 0x200
+sMrMimeSprites49:
+ax_sprite sMrMimeGfx49, 0x200
+ax_sprite_terminator
+sMrMimeGfx50:
+.incbin "baserom.gba", 0xA421A8, 0x200
+sMrMimeSprites50:
+ax_sprite sMrMimeGfx50, 0x200
+ax_sprite_terminator
+sMrMimeGfx51:
+.incbin "baserom.gba", 0xA423B8, 0x200
+sMrMimeSprites51:
+ax_sprite sMrMimeGfx51, 0x200
+ax_sprite_terminator
+sMrMimeGfx52:
+.incbin "baserom.gba", 0xA425C8, 0x200
+sMrMimeSprites52:
+ax_sprite sMrMimeGfx52, 0x200
+ax_sprite_terminator
+sMrMimeGfx53:
+.incbin "baserom.gba", 0xA427D8, 0x200
+sMrMimeSprites53:
+ax_sprite sMrMimeGfx53, 0x200
+ax_sprite_terminator
+sMrMimeGfx54:
+.incbin "baserom.gba", 0xA429E8, 0x200
+sMrMimeSprites54:
+ax_sprite sMrMimeGfx54, 0x200
+ax_sprite_terminator
+sMrMimeGfx55:
+.incbin "baserom.gba", 0xA42BF8, 0x200
+sMrMimeSprites55:
+ax_sprite sMrMimeGfx55, 0x200
+ax_sprite_terminator
+sMrMimeGfx56:
+.incbin "baserom.gba", 0xA42E08, 0x200
+sMrMimeSprites56:
+ax_sprite sMrMimeGfx56, 0x200
+ax_sprite_terminator
+sMrMimeGfx57:
+.incbin "baserom.gba", 0xA43018, 0x200
+sMrMimeSprites57:
+ax_sprite sMrMimeGfx57, 0x200
+ax_sprite_terminator
+sMrMimeGfx58:
+.incbin "baserom.gba", 0xA43228, 0x200
+sMrMimeSprites58:
+ax_sprite sMrMimeGfx58, 0x200
+ax_sprite_terminator
+sAxPosesMrMime:
+.4byte sMrMimePose1
+.4byte sMrMimePose2
+.4byte sMrMimePose3
+.4byte sMrMimePose4
+.4byte sMrMimePose5
+.4byte sMrMimePose6
+.4byte sMrMimePose7
+.4byte sMrMimePose8
+.4byte sMrMimePose9
+.4byte sMrMimePose10
+.4byte sMrMimePose11
+.4byte sMrMimePose12
+.4byte sMrMimePose13
+.4byte sMrMimePose14
+.4byte sMrMimePose15
+.4byte sMrMimePose16
+.4byte sMrMimePose17
+.4byte sMrMimePose18
+.4byte sMrMimePose19
+.4byte sMrMimePose20
+.4byte sMrMimePose21
+.4byte sMrMimePose22
+.4byte sMrMimePose23
+.4byte sMrMimePose24
+.4byte sMrMimePose25
+.4byte sMrMimePose26
+.4byte sMrMimePose27
+.4byte sMrMimePose28
+.4byte sMrMimePose29
+.4byte sMrMimePose30
+.4byte sMrMimePose31
+.4byte sMrMimePose32
+.4byte sMrMimePose33
+.4byte sMrMimePose34
+.4byte sMrMimePose35
+.4byte sMrMimePose36
+.4byte sMrMimePose37
+.4byte sMrMimePose38
+.4byte sMrMimePose39
+.4byte sMrMimePose40
+.4byte sMrMimePose41
+.4byte sMrMimePose42
+.4byte sMrMimePose43
+.4byte sMrMimePose44
+.4byte sMrMimePose45
+.4byte sMrMimePose46
+.4byte sMrMimePose47
+.4byte sMrMimePose48
+.4byte sMrMimePose49
+.4byte sMrMimePose50
+.4byte sMrMimePose51
+.4byte sMrMimePose52
+.4byte sMrMimePose53
+.4byte sMrMimePose54
+.4byte sMrMimePose55
+.4byte sMrMimePose56
+.4byte sMrMimePose57
+.4byte sMrMimePose58
+.4byte sMrMimePose59
+.4byte sMrMimePose60
+.4byte sMrMimePose61
+.4byte sMrMimePose62
+.4byte sMrMimePose63
+.4byte sMrMimePose64
+.4byte sMrMimePose65
+.4byte sMrMimePose66
+.4byte sMrMimePose67
+.4byte sMrMimePose68
+.4byte sMrMimePose69
+.4byte sMrMimePose70
+.4byte sMrMimePose71
+.4byte sMrMimePose72
+.4byte sMrMimePose73
+.4byte sMrMimePose74
+.4byte sMrMimePose75
+.4byte sMrMimePose76
+.4byte sMrMimePose77
+.4byte sMrMimePose78
+.4byte sMrMimePose79
+.4byte sMrMimePose80
+.4byte sMrMimePose81
+.4byte sMrMimePose82
+.4byte sMrMimePose83
+.4byte sMrMimePose84
+.4byte sMrMimePose85
+.4byte sMrMimePose86
+.4byte sMrMimePose87
+.4byte sMrMimePose88
+.4byte sMrMimePose89
+.4byte sMrMimePose90
+.4byte sMrMimePose91
+.4byte sMrMimePose92
+.4byte sMrMimePose93
+.4byte sMrMimePose94
+.4byte sMrMimePose95
+.4byte sMrMimePose96
+.4byte sMrMimePose97
+.4byte sMrMimePose98
+.4byte sMrMimePose99
+.4byte sMrMimePose100
+.4byte sMrMimePose101
+.4byte sMrMimePose102
+.4byte sMrMimePose103
+.4byte sMrMimePose104
+.4byte sMrMimePose105
+.4byte sMrMimePose106
+.4byte sMrMimePose107
+.4byte sMrMimePose108
+.4byte sMrMimePose109
+.4byte sMrMimePose110
+.4byte sMrMimePose111
+.4byte sMrMimePose112
+.4byte sMrMimePose113
+.4byte sMrMimePose114
+.4byte sMrMimePose115
+.4byte sMrMimePose116
+.4byte sMrMimePose117
+.4byte sMrMimePose118
+.4byte sMrMimePose119
+.4byte sMrMimePose120
+.4byte sMrMimePose121
+.4byte sMrMimePose122
+.4byte sMrMimePose123
+.4byte sMrMimePose124
+.4byte sMrMimePose125
+.4byte sMrMimePose126
+.4byte sMrMimePose127
+.4byte sMrMimePose128
+.4byte sMrMimePose129
+.4byte sMrMimePose130
+.4byte sMrMimePose131
+.4byte sMrMimePose132
+.4byte sMrMimePose133
+.4byte sMrMimePose134
+.4byte sMrMimePose135
+.4byte sMrMimePose136
+.4byte sMrMimePose137
+.4byte sMrMimePose138
+.4byte sMrMimePose139
+.4byte sMrMimePose140
+.4byte sMrMimePose141
+.4byte sMrMimePose142
+.4byte sMrMimePose143
+.4byte sMrMimePose144
+.4byte sMrMimePose145
+.4byte sMrMimePose146
+.4byte sMrMimePose147
+.4byte sMrMimePose148
+.4byte sMrMimePose149
+.4byte sMrMimePose150
+.4byte sMrMimePose151
+.4byte sMrMimePose152
+.4byte sMrMimePose153
+.4byte sMrMimePose154
+.4byte sMrMimePose155
+.4byte sMrMimePose156
+.4byte sMrMimePose157
+.4byte sMrMimePose158
+.4byte sMrMimePose159
+.4byte sMrMimePose160
+.4byte sMrMimePose161
+.4byte sMrMimePose162
+.4byte sMrMimePose163
+.4byte sMrMimePose164
+.4byte sMrMimePose165
+.4byte sMrMimePose166
+.4byte sMrMimePose167
+.4byte sMrMimePose168
+.4byte sMrMimePose169
+.4byte sMrMimePose170
+.4byte sMrMimePose171
+.4byte sMrMimePose172
+.4byte sMrMimePose173
+.4byte sMrMimePose174
+.4byte sMrMimePose175
+.4byte sMrMimePose176
+.4byte sMrMimePose177
+.4byte sMrMimePose178
+.4byte sMrMimePose179
+.4byte sMrMimePose180
+.4byte sMrMimePose181
+.4byte sMrMimePose182
+.4byte sMrMimePose183
+.4byte sMrMimePose184
+.4byte sMrMimePose185
+.4byte sMrMimePose186
+.4byte sMrMimePose187
+.4byte sMrMimePose188
+.4byte sMrMimePose189
+.4byte sMrMimePose190
+.4byte sMrMimePose191
+.4byte sMrMimePose192
+.4byte sMrMimePose193
+.4byte sMrMimePose194
+.4byte sMrMimePose195
+.4byte sMrMimePose196
+.4byte sMrMimePose197
+.4byte sMrMimePose198
+.4byte sMrMimePose199
+.4byte sMrMimePose200
+.4byte sMrMimePose201
+.4byte sMrMimePose202
+sAxPositionsMrMime:
+.2byte    1,  -10, 	 -10,   -3, 	  11,   -3, 	   1,   -9
+.2byte    1,   -9, 	  -9,   -4, 	   6,    0, 	   1,   -8
+.2byte    1,   -9, 	  -4,   -1, 	  10,   -4, 	   1,   -8
+.2byte    2,  -10, 	   9,   -4, 	  -8,    0, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,    1, 	   0,   -7
+.2byte    2,   -9, 	   8,    0, 	 -10,   -3, 	   0,   -7
+.2byte    5,  -13, 	   1,   -7, 	   1,    0, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -6, 	   6,   -2, 	  -2,   -9
+.2byte    5,  -12, 	   8,   -6, 	  -8,    0, 	  -2,   -9
+.2byte    3,  -14, 	  -4,   -7, 	  10,   -1, 	  -2,  -11
+.2byte    2,  -14, 	 -10,   -5, 	  11,   -7, 	  -2,  -10
+.2byte    2,  -14, 	  -1,   -9, 	   3,    2, 	  -2,  -10
+.2byte   -1,  -15, 	  10,   -5, 	 -11,   -5, 	  -1,  -12
+.2byte    0,  -14, 	   8,   -1, 	  -7,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -9,   -1, 	  -1,  -11
+.2byte   -4,  -14, 	   3,   -7, 	 -11,   -1, 	   1,  -11
+.2byte   -3,  -14, 	   9,   -5, 	 -12,   -7, 	   1,  -10
+.2byte   -3,  -14, 	   0,   -9, 	  -4,    2, 	   1,  -10
+.2byte   -6,  -13, 	  -2,   -7, 	  -2,    0, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -6, 	  -7,   -2, 	   1,   -9
+.2byte   -6,  -12, 	  -9,   -6, 	   7,    0, 	   1,   -9
+.2byte   -2,  -10, 	  -9,   -4, 	   8,    0, 	   0,   -9
+.2byte   -2,   -9, 	  -6,   -6, 	  -1,    1, 	   0,   -7
+.2byte   -2,   -9, 	  -8,    0, 	  10,   -3, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  11,   -3, 	   1,   -9
+.2byte    1,   -9, 	  -9,   -4, 	   6,    0, 	   1,   -8
+.2byte    1,   -9, 	  -4,   -1, 	  10,   -4, 	   1,   -8
+.2byte    2,  -10, 	   9,   -4, 	  -8,    0, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,    1, 	   0,   -7
+.2byte    2,   -9, 	   8,    0, 	 -10,   -3, 	   0,   -7
+.2byte    5,  -13, 	   1,   -7, 	   1,    0, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -6, 	   6,   -2, 	  -2,   -9
+.2byte    5,  -12, 	   8,   -6, 	  -8,    0, 	  -2,   -9
+.2byte    3,  -14, 	  -4,   -7, 	  10,   -1, 	  -2,  -11
+.2byte    2,  -14, 	 -10,   -5, 	  11,   -7, 	  -2,  -10
+.2byte    2,  -14, 	  -1,   -9, 	   3,    2, 	  -2,  -10
+.2byte   -1,  -15, 	  10,   -5, 	 -11,   -5, 	  -1,  -12
+.2byte    0,  -14, 	   8,   -1, 	  -7,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -9,   -1, 	  -1,  -11
+.2byte   -4,  -14, 	   3,   -7, 	 -11,   -1, 	   1,  -11
+.2byte   -3,  -14, 	   9,   -5, 	 -12,   -7, 	   1,  -10
+.2byte   -3,  -14, 	   0,   -9, 	  -4,    2, 	   1,  -10
+.2byte   -6,  -13, 	  -2,   -7, 	  -2,    0, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -6, 	  -7,   -2, 	   1,   -9
+.2byte   -6,  -12, 	  -9,   -6, 	   7,    0, 	   1,   -9
+.2byte   -2,  -10, 	  -9,   -4, 	   8,    0, 	   0,   -9
+.2byte   -2,   -9, 	  -6,   -6, 	  -1,    1, 	   0,   -7
+.2byte   -2,   -9, 	  -8,    0, 	  10,   -3, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  11,   -3, 	   1,   -9
+.2byte    1,   -9, 	  -9,   -4, 	   6,    0, 	   1,   -8
+.2byte    1,   -9, 	  -4,   -1, 	  10,   -4, 	   1,   -8
+.2byte    2,  -10, 	   9,   -4, 	  -8,    0, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,    1, 	   0,   -7
+.2byte    2,   -9, 	   8,    0, 	 -10,   -3, 	   0,   -7
+.2byte    5,  -13, 	   1,   -7, 	   1,    0, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -6, 	   6,   -2, 	  -2,   -9
+.2byte    5,  -12, 	   8,   -6, 	  -8,    0, 	  -2,   -9
+.2byte    3,  -14, 	  -4,   -7, 	  10,   -1, 	  -2,  -11
+.2byte    2,  -14, 	 -10,   -5, 	  11,   -7, 	  -2,  -10
+.2byte    2,  -14, 	  -1,   -9, 	   3,    2, 	  -2,  -10
+.2byte   -1,  -15, 	  10,   -5, 	 -11,   -5, 	  -1,  -12
+.2byte    0,  -14, 	   8,   -1, 	  -7,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -9,   -1, 	  -1,  -11
+.2byte   -4,  -14, 	   3,   -7, 	 -11,   -1, 	   1,  -11
+.2byte   -3,  -14, 	   9,   -5, 	 -12,   -7, 	   1,  -10
+.2byte   -3,  -14, 	   0,   -9, 	  -4,    2, 	   1,  -10
+.2byte   -6,  -13, 	  -2,   -7, 	  -2,    0, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -6, 	  -7,   -2, 	   1,   -9
+.2byte   -6,  -12, 	  -9,   -6, 	   7,    0, 	   1,   -9
+.2byte   -2,  -10, 	  -9,   -4, 	   8,    0, 	   0,   -9
+.2byte   -2,   -9, 	  -6,   -6, 	  -1,    1, 	   0,   -7
+.2byte   -2,   -9, 	  -8,    0, 	  10,   -3, 	   0,   -7
+.2byte   -2,  -10, 	   1,   -2, 	  -1,   -7, 	  -1,   -9
+.2byte   -1,  -10, 	   1,   -8, 	   3,   -5, 	  -1,   -9
+.2byte    0,  -10, 	   3,   -9, 	   5,   -4, 	   1,   -9
+.2byte    0,   -4, 	  -7,    0, 	   6,    0, 	   0,   -6
+.2byte    1,  -10, 	 -10,   -3, 	  11,   -3, 	   1,   -9
+.2byte    4,   -7, 	   4,    0, 	   4,   -5, 	   3,   -9
+.2byte    3,   -8, 	   1,   -6, 	   1,   -3, 	   2,  -10
+.2byte    3,   -8, 	   1,   -7, 	  -2,   -1, 	   0,   -9
+.2byte    2,   -5, 	  12,   -3, 	   2,    1, 	   0,   -6
+.2byte    2,  -10, 	   9,   -4, 	  -8,    0, 	   0,   -9
+.2byte    6,   -9, 	   8,   -2, 	  11,   -8, 	   2,  -10
+.2byte    5,  -10, 	   5,   -7, 	  10,   -5, 	   2,  -11
+.2byte    4,  -10, 	   9,   -8, 	   5,   -2, 	   1,  -11
+.2byte    7,   -8, 	  17,  -13, 	  17,   -7, 	   3,  -11
+.2byte    5,  -13, 	   1,   -7, 	   1,    0, 	  -2,  -10
+.2byte    2,  -12, 	   4,   -6, 	   2,  -13, 	  -1,  -11
+.2byte    2,  -13, 	   3,  -10, 	   5,   -8, 	  -1,  -12
+.2byte    3,  -12, 	   4,  -11, 	   3,   -7, 	  -1,  -12
+.2byte    6,  -11, 	   8,  -23, 	  18,  -19, 	   2,  -12
+.2byte    3,  -14, 	  -4,   -7, 	  10,   -1, 	  -2,  -11
+.2byte    1,  -14, 	   1,   -7, 	   0,  -12, 	   0,  -11
+.2byte    0,  -15, 	  -1,  -10, 	  -2,  -11, 	  -1,  -13
+.2byte   -1,  -15, 	  -1,  -11, 	  -3,   -9, 	  -2,  -12
+.2byte    0,  -16, 	   5,  -22, 	  -6,  -22, 	   0,  -13
+.2byte   -1,  -15, 	  10,   -5, 	 -11,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -5,   -6, 	  -3,  -13, 	   0,  -11
+.2byte   -3,  -13, 	  -4,  -10, 	  -6,   -8, 	   0,  -12
+.2byte   -4,  -12, 	  -5,  -11, 	  -4,   -7, 	   0,  -12
+.2byte   -7,  -11, 	  -9,  -23, 	 -19,  -19, 	  -3,  -12
+.2byte   -4,  -14, 	   3,   -7, 	 -11,   -1, 	   1,  -11
+.2byte   -7,   -9, 	  -9,   -2, 	 -12,   -8, 	  -3,  -10
+.2byte   -6,  -10, 	  -6,   -7, 	 -11,   -5, 	  -3,  -11
+.2byte   -5,  -10, 	 -10,   -8, 	  -6,   -2, 	  -2,  -11
+.2byte   -8,   -8, 	 -18,  -13, 	 -18,   -7, 	  -4,  -11
+.2byte   -6,  -13, 	  -2,   -7, 	  -2,    0, 	   1,  -10
+.2byte   -5,   -7, 	  -5,    0, 	  -5,   -5, 	  -4,   -9
+.2byte   -4,   -8, 	  -2,   -6, 	  -2,   -3, 	  -3,  -10
+.2byte   -4,   -8, 	  -2,   -7, 	   1,   -1, 	  -1,   -9
+.2byte   -3,   -5, 	 -13,   -3, 	  -3,    1, 	  -1,   -6
+.2byte   -2,  -10, 	  -9,   -4, 	   8,    0, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -3, 	   0,  -19, 	   1,   -9
+.2byte   -3,  -11, 	  -9,   -5, 	  -3,  -19, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,   -7, 	  -8,  -19, 	   1,  -10
+.2byte   -3,  -15, 	   0,   -8, 	  -7,  -23, 	   1,  -11
+.2byte    0,  -15, 	   2,   -8, 	  -1,  -22, 	   0,  -12
+.2byte    3,  -14, 	   2,   -9, 	   3,  -22, 	  -1,  -12
+.2byte    4,  -11, 	   9,   -8, 	   8,  -20, 	  -1,  -12
+.2byte    3,  -10, 	   2,   -4, 	   4,  -19, 	   0,  -10
+.2byte   -2,   -7, 	  -9,   -6, 	  10,    2, 	   0,   -6
+.2byte   -2,   -6, 	  -9,   -6, 	  10,    2, 	   0,   -6
+.2byte    0,  -13, 	   2,  -23, 	  -3,  -24, 	   0,   -9
+.2byte    0,  -13, 	  -5,  -23, 	  -1,  -24, 	  -2,  -10
+.2byte    4,  -13, 	   0,  -22, 	   1,  -23, 	  -1,  -11
+.2byte    2,  -15, 	   2,  -23, 	   1,  -22, 	  -1,  -10
+.2byte    1,  -14, 	  -1,  -25, 	   2,  -23, 	   1,  -11
+.2byte   -3,  -15, 	  -3,  -23, 	  -2,  -22, 	   0,  -10
+.2byte   -5,  -13, 	  -1,  -22, 	  -2,  -23, 	   0,  -11
+.2byte   -1,  -13, 	   4,  -23, 	   0,  -24, 	   1,  -10
+.2byte    0,  -10, 	  -3,   -3, 	   0,  -19, 	   1,   -9
+.2byte   -3,  -11, 	  -9,   -5, 	  -3,  -19, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,   -7, 	  -8,  -19, 	   1,  -10
+.2byte   -3,  -15, 	   0,   -8, 	  -7,  -23, 	   1,  -11
+.2byte    0,  -15, 	   2,   -8, 	  -1,  -22, 	   0,  -12
+.2byte    3,  -14, 	   2,   -9, 	   3,  -22, 	  -1,  -12
+.2byte    4,  -11, 	   9,   -8, 	   8,  -20, 	  -1,  -12
+.2byte    3,  -10, 	   2,   -4, 	   4,  -19, 	   0,  -10
+.2byte    0,   -9, 	  -2,   -2, 	  -1,  -18, 	   0,   -8
+.2byte   -2,  -10, 	  -8,   -4, 	  -4,  -18, 	  -1,   -9
+.2byte   -4,  -10, 	  -2,   -8, 	  -8,  -17, 	   1,   -9
+.2byte   -3,  -14, 	  -4,   -8, 	  -7,  -20, 	   0,  -10
+.2byte    0,  -14, 	  -2,   -8, 	   0,  -21, 	   0,  -11
+.2byte    3,  -14, 	   2,  -10, 	   5,  -20, 	  -2,  -11
+.2byte    4,  -10, 	   8,   -9, 	   9,  -18, 	  -1,  -11
+.2byte    4,  -10, 	   4,   -4, 	   3,  -18, 	   0,   -9
+.2byte    0,   -6, 	  -7,   -2, 	   6,   -2, 	   0,   -8
+.2byte   -3,   -6, 	 -13,   -4, 	  -3,    0, 	  -1,   -7
+.2byte   -3,   -7, 	 -13,  -12, 	 -13,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -3,  -20, 	 -13,  -16, 	   3,   -9
+.2byte    0,  -11, 	   5,  -17, 	  -6,  -17, 	   0,   -8
+.2byte    0,   -8, 	   2,  -20, 	  12,  -16, 	  -4,   -9
+.2byte    2,   -7, 	  12,  -12, 	  12,   -6, 	  -2,  -10
+.2byte    2,   -6, 	  12,   -4, 	   2,    0, 	   0,   -7
+.2byte    0,  -10, 	  -3,   -3, 	   0,  -19, 	   1,   -9
+.2byte    3,  -10, 	   2,   -4, 	   4,  -19, 	   0,  -10
+.2byte    4,  -11, 	   9,   -8, 	   8,  -20, 	  -1,  -12
+.2byte    3,  -14, 	   2,   -9, 	   3,  -22, 	  -1,  -12
+.2byte    0,  -15, 	   2,   -8, 	  -1,  -22, 	   0,  -12
+.2byte   -3,  -15, 	   0,   -8, 	  -7,  -23, 	   1,  -11
+.2byte   -4,  -12, 	  -3,   -7, 	  -8,  -19, 	   1,  -10
+.2byte   -3,  -11, 	  -9,   -5, 	  -3,  -19, 	  -1,  -10
+.2byte    1,  -10, 	 -10,   -3, 	  11,   -3, 	   1,   -9
+.2byte    1,   -9, 	  -9,   -4, 	   6,    0, 	   1,   -8
+.2byte    1,   -9, 	  -4,   -1, 	  10,   -4, 	   1,   -8
+.2byte    2,  -10, 	   9,   -4, 	  -8,    0, 	   0,   -9
+.2byte    2,   -9, 	   6,   -6, 	   1,    1, 	   0,   -7
+.2byte    2,   -9, 	   8,    0, 	 -10,   -3, 	   0,   -7
+.2byte    5,  -13, 	   1,   -7, 	   1,    0, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -6, 	   6,   -2, 	  -2,   -9
+.2byte    5,  -12, 	   8,   -6, 	  -8,    0, 	  -2,   -9
+.2byte    3,  -14, 	  -4,   -7, 	  10,   -1, 	  -2,  -11
+.2byte    2,  -14, 	 -10,   -5, 	  11,   -7, 	  -2,  -10
+.2byte    2,  -14, 	  -1,   -9, 	   3,    2, 	  -2,  -10
+.2byte   -1,  -15, 	  10,   -5, 	 -11,   -5, 	  -1,  -12
+.2byte    0,  -14, 	   8,   -1, 	  -7,   -7, 	   0,  -11
+.2byte   -1,  -14, 	   6,   -7, 	  -9,   -1, 	  -1,  -11
+.2byte   -4,  -14, 	   3,   -7, 	 -11,   -1, 	   1,  -11
+.2byte   -3,  -14, 	   9,   -5, 	 -12,   -7, 	   1,  -10
+.2byte   -3,  -14, 	   0,   -9, 	  -4,    2, 	   1,  -10
+.2byte   -6,  -13, 	  -2,   -7, 	  -2,    0, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -6, 	  -7,   -2, 	   1,   -9
+.2byte   -6,  -12, 	  -9,   -6, 	   7,    0, 	   1,   -9
+.2byte   -2,  -10, 	  -9,   -4, 	   8,    0, 	   0,   -9
+.2byte   -2,   -9, 	  -6,   -6, 	  -1,    1, 	   0,   -7
+.2byte   -2,   -9, 	  -8,    0, 	  10,   -3, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -2, 	   6,   -2, 	   0,   -8
+.2byte   -3,   -6, 	 -13,   -4, 	  -3,    0, 	  -1,   -7
+.2byte   -3,   -7, 	 -13,  -12, 	 -13,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -3,  -20, 	 -13,  -16, 	   3,   -9
+.2byte    0,  -11, 	   5,  -17, 	  -6,  -17, 	   0,   -8
+.2byte    0,   -8, 	   2,  -20, 	  12,  -16, 	  -4,   -9
+.2byte    2,   -7, 	  12,  -12, 	  12,   -6, 	  -2,  -10
+.2byte    2,   -6, 	  12,   -4, 	   2,    0, 	   0,   -7
+.2byte    0,  -10, 	  -3,   -3, 	   0,  -19, 	   1,   -9
+.2byte   -3,  -11, 	  -9,   -5, 	  -3,  -19, 	  -1,  -10
+.2byte   -4,  -12, 	  -3,   -7, 	  -8,  -19, 	   1,  -10
+.2byte   -3,  -15, 	   0,   -8, 	  -7,  -23, 	   1,  -11
+.2byte    0,  -15, 	   2,   -8, 	  -1,  -22, 	   0,  -12
+.2byte    3,  -14, 	   2,   -9, 	   3,  -22, 	  -1,  -12
+.2byte    4,  -11, 	   9,   -8, 	   8,  -20, 	  -1,  -12
+.2byte    3,  -10, 	   2,   -4, 	   4,  -19, 	   0,  -10
+sMrMimeAnimTable1:
+.4byte sMrMimeAnims_1_1
+.4byte sMrMimeAnims_1_2
+.4byte sMrMimeAnims_1_3
+.4byte sMrMimeAnims_1_4
+.4byte sMrMimeAnims_1_5
+.4byte sMrMimeAnims_1_6
+.4byte sMrMimeAnims_1_7
+.4byte sMrMimeAnims_1_8
+sMrMimeAnimTable2:
+.4byte sMrMimeAnims_2_1
+.4byte sMrMimeAnims_2_2
+.4byte sMrMimeAnims_2_3
+.4byte sMrMimeAnims_2_4
+.4byte sMrMimeAnims_2_5
+.4byte sMrMimeAnims_2_6
+.4byte sMrMimeAnims_2_7
+.4byte sMrMimeAnims_2_8
+sMrMimeAnimTable3:
+.4byte sMrMimeAnims_3_1
+.4byte sMrMimeAnims_3_2
+.4byte sMrMimeAnims_3_3
+.4byte sMrMimeAnims_3_4
+.4byte sMrMimeAnims_3_5
+.4byte sMrMimeAnims_3_6
+.4byte sMrMimeAnims_3_7
+.4byte sMrMimeAnims_3_8
+sMrMimeAnimTable4:
+.4byte sMrMimeAnims_4_1
+.4byte sMrMimeAnims_4_2
+.4byte sMrMimeAnims_4_3
+.4byte sMrMimeAnims_4_4
+.4byte sMrMimeAnims_4_5
+.4byte sMrMimeAnims_4_6
+.4byte sMrMimeAnims_4_7
+.4byte sMrMimeAnims_4_8
+sMrMimeAnimTable5:
+.4byte sMrMimeAnims_5_1
+.4byte sMrMimeAnims_5_2
+.4byte sMrMimeAnims_5_3
+.4byte sMrMimeAnims_5_4
+.4byte sMrMimeAnims_5_5
+.4byte sMrMimeAnims_5_6
+.4byte sMrMimeAnims_5_7
+.4byte sMrMimeAnims_5_8
+sMrMimeAnimTable6:
+.4byte sMrMimeAnims_6_1
+.4byte sMrMimeAnims_6_1
+.4byte sMrMimeAnims_6_1
+.4byte sMrMimeAnims_6_1
+.4byte sMrMimeAnims_6_1
+.4byte sMrMimeAnims_6_1
+.4byte sMrMimeAnims_6_1
+.4byte sMrMimeAnims_6_1
+sMrMimeAnimTable7:
+.4byte sMrMimeAnims_7_1
+.4byte sMrMimeAnims_7_2
+.4byte sMrMimeAnims_7_3
+.4byte sMrMimeAnims_7_4
+.4byte sMrMimeAnims_7_5
+.4byte sMrMimeAnims_7_6
+.4byte sMrMimeAnims_7_7
+.4byte sMrMimeAnims_7_8
+sMrMimeAnimTable8:
+.4byte sMrMimeAnims_8_1
+.4byte sMrMimeAnims_8_2
+.4byte sMrMimeAnims_8_3
+.4byte sMrMimeAnims_8_4
+.4byte sMrMimeAnims_8_5
+.4byte sMrMimeAnims_8_6
+.4byte sMrMimeAnims_8_7
+.4byte sMrMimeAnims_8_8
+sMrMimeAnimTable9:
+.4byte sMrMimeAnims_9_1
+.4byte sMrMimeAnims_9_2
+.4byte sMrMimeAnims_9_3
+.4byte sMrMimeAnims_9_4
+.4byte sMrMimeAnims_9_5
+.4byte sMrMimeAnims_9_6
+.4byte sMrMimeAnims_9_7
+.4byte sMrMimeAnims_9_8
+sMrMimeAnimTable10:
+.4byte sMrMimeAnims_10_1
+.4byte sMrMimeAnims_10_2
+.4byte sMrMimeAnims_10_3
+.4byte sMrMimeAnims_10_4
+.4byte sMrMimeAnims_10_5
+.4byte sMrMimeAnims_10_6
+.4byte sMrMimeAnims_10_7
+.4byte sMrMimeAnims_10_8
+sMrMimeAnimTable11:
+.4byte sMrMimeAnims_11_1
+.4byte sMrMimeAnims_11_2
+.4byte sMrMimeAnims_11_3
+.4byte sMrMimeAnims_11_4
+.4byte sMrMimeAnims_11_5
+.4byte sMrMimeAnims_11_6
+.4byte sMrMimeAnims_11_7
+.4byte sMrMimeAnims_11_8
+sMrMimeAnimTable12:
+.4byte sMrMimeAnims_12_1
+.4byte sMrMimeAnims_12_2
+.4byte sMrMimeAnims_12_3
+.4byte sMrMimeAnims_12_4
+.4byte sMrMimeAnims_12_5
+.4byte sMrMimeAnims_12_6
+.4byte sMrMimeAnims_12_7
+.4byte sMrMimeAnims_12_8
+sMrMimeAnimTable13:
+.4byte sMrMimeAnims_13_1
+.4byte sMrMimeAnims_13_2
+.4byte sMrMimeAnims_13_3
+.4byte sMrMimeAnims_13_4
+.4byte sMrMimeAnims_13_5
+.4byte sMrMimeAnims_13_6
+.4byte sMrMimeAnims_13_7
+.4byte sMrMimeAnims_13_8
+sAxAnimationsMrMime:
+.4byte sMrMimeAnimTable1
+.4byte sMrMimeAnimTable2
+.4byte sMrMimeAnimTable3
+.4byte sMrMimeAnimTable4
+.4byte sMrMimeAnimTable5
+.4byte sMrMimeAnimTable6
+.4byte sMrMimeAnimTable7
+.4byte sMrMimeAnimTable8
+.4byte sMrMimeAnimTable9
+.4byte sMrMimeAnimTable10
+.4byte sMrMimeAnimTable11
+.4byte sMrMimeAnimTable12
+.4byte sMrMimeAnimTable13
+sAxSpritesMrMime:
+.4byte sMrMimeSprites1
+.4byte sMrMimeSprites2
+.4byte sMrMimeSprites3
+.4byte sMrMimeSprites4
+.4byte sMrMimeSprites5
+.4byte sMrMimeSprites6
+.4byte sMrMimeSprites7
+.4byte sMrMimeSprites8
+.4byte sMrMimeSprites9
+.4byte sMrMimeSprites10
+.4byte sMrMimeSprites11
+.4byte sMrMimeSprites12
+.4byte sMrMimeSprites13
+.4byte sMrMimeSprites14
+.4byte sMrMimeSprites15
+.4byte sMrMimeSprites16
+.4byte sMrMimeSprites17
+.4byte sMrMimeSprites18
+.4byte sMrMimeSprites19
+.4byte sMrMimeSprites20
+.4byte sMrMimeSprites21
+.4byte sMrMimeSprites22
+.4byte sMrMimeSprites23
+.4byte sMrMimeSprites24
+.4byte sMrMimeSprites25
+.4byte sMrMimeSprites26
+.4byte sMrMimeSprites27
+.4byte sMrMimeSprites28
+.4byte sMrMimeSprites29
+.4byte sMrMimeSprites30
+.4byte sMrMimeSprites31
+.4byte sMrMimeSprites32
+.4byte sMrMimeSprites33
+.4byte sMrMimeSprites34
+.4byte sMrMimeSprites35
+.4byte sMrMimeSprites36
+.4byte sMrMimeSprites37
+.4byte sMrMimeSprites38
+.4byte sMrMimeSprites39
+.4byte sMrMimeSprites40
+.4byte sMrMimeSprites41
+.4byte sMrMimeSprites42
+.4byte sMrMimeSprites43
+.4byte sMrMimeSprites44
+.4byte sMrMimeSprites45
+.4byte sMrMimeSprites46
+.4byte sMrMimeSprites47
+.4byte sMrMimeSprites48
+.4byte sMrMimeSprites49
+.4byte sMrMimeSprites50
+.4byte sMrMimeSprites51
+.4byte sMrMimeSprites52
+.4byte sMrMimeSprites53
+.4byte sMrMimeSprites54
+.4byte sMrMimeSprites55
+.4byte sMrMimeSprites56
+.4byte sMrMimeSprites57
+.4byte sMrMimeSprites58
+sAxMainMrMime:
+ax_main sAxPosesMrMime, sAxAnimationsMrMime, 13, sAxSpritesMrMime, sAxPositionsMrMime

--- a/data/ax/mudkip.inc
+++ b/data/ax/mudkip.inc
@@ -1,0 +1,3957 @@
+.global gAxMudkip
+gAxMudkip:
+ax_siro sAxMainMudkip
+sMudkipPose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose3:
+ax_pose 2, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose4:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose5:
+ax_pose 4, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose6:
+ax_pose 5, 0x81ec, 0x90f9, 0x9c00
+ax_pose_terminator
+sMudkipPose7:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose8:
+ax_pose 7, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose9:
+ax_pose 8, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose10:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose11:
+ax_pose 10, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose12:
+ax_pose 11, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose16:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose17:
+ax_pose 10, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose18:
+ax_pose 11, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose19:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose21:
+ax_pose 8, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose22:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose23:
+ax_pose 4, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose24:
+ax_pose 5, 0x81ec, 0x80f6, 0x9c00
+ax_pose_terminator
+sMudkipPose25:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose26:
+ax_pose 1, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose27:
+ax_pose 2, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose28:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose29:
+ax_pose 4, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose30:
+ax_pose 5, 0x81ec, 0x90f9, 0x9c00
+ax_pose_terminator
+sMudkipPose31:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose32:
+ax_pose 7, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose33:
+ax_pose 8, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose34:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose35:
+ax_pose 10, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose36:
+ax_pose 11, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose37:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose38:
+ax_pose 13, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose39:
+ax_pose 14, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose40:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose41:
+ax_pose 10, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose42:
+ax_pose 11, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose43:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose44:
+ax_pose 7, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose45:
+ax_pose 8, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose46:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose47:
+ax_pose 4, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose48:
+ax_pose 5, 0x81ec, 0x80f6, 0x9c00
+ax_pose_terminator
+sMudkipPose49:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose50:
+ax_pose 1, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose51:
+ax_pose 2, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose52:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose53:
+ax_pose 4, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose54:
+ax_pose 5, 0x81ec, 0x90f9, 0x9c00
+ax_pose_terminator
+sMudkipPose55:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose56:
+ax_pose 7, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose57:
+ax_pose 8, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose58:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose59:
+ax_pose 10, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose60:
+ax_pose 11, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose61:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose62:
+ax_pose 13, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose63:
+ax_pose 14, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose64:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose65:
+ax_pose 10, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose66:
+ax_pose 11, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose67:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose68:
+ax_pose 7, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose69:
+ax_pose 8, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose70:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose71:
+ax_pose 4, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose72:
+ax_pose 5, 0x81ec, 0x80f6, 0x9c00
+ax_pose_terminator
+sMudkipPose73:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose74:
+ax_pose 15, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose75:
+ax_pose 16, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose76:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose77:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose78:
+ax_pose 18, 0x01e7, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose79:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose80:
+ax_pose 19, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sMudkipPose81:
+ax_pose 20, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose82:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose83:
+ax_pose 21, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose84:
+ax_pose 22, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose85:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose86:
+ax_pose 23, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose87:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose88:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose89:
+ax_pose 21, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose90:
+ax_pose 22, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose91:
+ax_pose 6, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sMudkipPose92:
+ax_pose 19, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose93:
+ax_pose 20, 0x01e8, 0x80f1, 0x9c00
+ax_pose_terminator
+sMudkipPose94:
+ax_pose 3, 0x01ec, 0x80f1, 0x9c00
+ax_pose_terminator
+sMudkipPose95:
+ax_pose 17, 0x01e8, 0x80f1, 0x9c00
+ax_pose_terminator
+sMudkipPose96:
+ax_pose 18, 0x01e7, 0x80f1, 0x9c00
+ax_pose_terminator
+sMudkipPose97:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose98:
+ax_pose 15, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose99:
+ax_pose 16, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose100:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose101:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose102:
+ax_pose 18, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose103:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose104:
+ax_pose 19, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sMudkipPose105:
+ax_pose 20, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sMudkipPose106:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose107:
+ax_pose 21, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose108:
+ax_pose 22, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose109:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose110:
+ax_pose 23, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose111:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose112:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose113:
+ax_pose 21, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose114:
+ax_pose 22, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose115:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose116:
+ax_pose 19, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose117:
+ax_pose 20, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose118:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose119:
+ax_pose 17, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose120:
+ax_pose 18, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose121:
+ax_pose 25, 0x01ed, 0x80f3, 0x9c00
+ax_pose_terminator
+sMudkipPose122:
+ax_pose 26, 0x01ed, 0x80f3, 0x9c00
+ax_pose_terminator
+sMudkipPose123:
+ax_pose 27, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose124:
+ax_pose 28, 0x01e4, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose125:
+ax_pose 29, 0x01e5, 0x90ea, 0x9c00
+ax_pose_terminator
+sMudkipPose126:
+ax_pose 30, 0x01ec, 0x90e8, 0x9c00
+ax_pose_terminator
+sMudkipPose127:
+ax_pose 31, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose128:
+ax_pose 30, 0x01eb, 0x80f7, 0x9c00
+ax_pose_terminator
+sMudkipPose129:
+ax_pose 29, 0x01e5, 0x80f6, 0x9c00
+ax_pose_terminator
+sMudkipPose130:
+ax_pose 28, 0x01e4, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose131:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose132:
+ax_pose 1, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose133:
+ax_pose 2, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose134:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose135:
+ax_pose 4, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose136:
+ax_pose 5, 0x81ec, 0x90f9, 0x9c00
+ax_pose_terminator
+sMudkipPose137:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose138:
+ax_pose 7, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose139:
+ax_pose 8, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose140:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose141:
+ax_pose 10, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose142:
+ax_pose 11, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose143:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose144:
+ax_pose 13, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose145:
+ax_pose 14, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose146:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose147:
+ax_pose 10, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose148:
+ax_pose 11, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose149:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose150:
+ax_pose 7, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose151:
+ax_pose 8, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose152:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose153:
+ax_pose 4, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose154:
+ax_pose 5, 0x81ec, 0x80f6, 0x9c00
+ax_pose_terminator
+sMudkipPose155:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose156:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose157:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose158:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose159:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose160:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose161:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose162:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose163:
+ax_pose 15, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose164:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose165:
+ax_pose 19, 0x01e8, 0x90ee, 0x9c00
+ax_pose_terminator
+sMudkipPose166:
+ax_pose 21, 0x01e9, 0x90ee, 0x9c00
+ax_pose_terminator
+sMudkipPose167:
+ax_pose 23, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose168:
+ax_pose 21, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sMudkipPose169:
+ax_pose 19, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sMudkipPose170:
+ax_pose 17, 0x01e8, 0x80f1, 0x9c00
+ax_pose_terminator
+sMudkipPose171:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose172:
+ax_pose 1, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose173:
+ax_pose 2, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose174:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose175:
+ax_pose 4, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose176:
+ax_pose 5, 0x81ec, 0x90f9, 0x9c00
+ax_pose_terminator
+sMudkipPose177:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose178:
+ax_pose 7, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose179:
+ax_pose 8, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose180:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose181:
+ax_pose 10, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose182:
+ax_pose 11, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose183:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose184:
+ax_pose 13, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose185:
+ax_pose 14, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose186:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose187:
+ax_pose 10, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose188:
+ax_pose 11, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose189:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose190:
+ax_pose 7, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose191:
+ax_pose 8, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose192:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose193:
+ax_pose 4, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose194:
+ax_pose 5, 0x81ec, 0x80f6, 0x9c00
+ax_pose_terminator
+sMudkipPose195:
+ax_pose 15, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose196:
+ax_pose 17, 0x01e8, 0x80f1, 0x9c00
+ax_pose_terminator
+sMudkipPose197:
+ax_pose 19, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sMudkipPose198:
+ax_pose 21, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sMudkipPose199:
+ax_pose 23, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose200:
+ax_pose 21, 0x01e9, 0x90ee, 0x9c00
+ax_pose_terminator
+sMudkipPose201:
+ax_pose 19, 0x01e8, 0x90ee, 0x9c00
+ax_pose_terminator
+sMudkipPose202:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose203:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose204:
+ax_pose 3, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose205:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose206:
+ax_pose 9, 0x81ec, 0x80f8, 0x9c00
+ax_pose_terminator
+sMudkipPose207:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose208:
+ax_pose 9, 0x81ec, 0x90f7, 0x9c00
+ax_pose_terminator
+sMudkipPose209:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose210:
+ax_pose 3, 0x01ec, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose211:
+ax_pose 32, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose212:
+ax_pose 33, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose213:
+ax_pose 32, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sMudkipPose214:
+ax_pose 33, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sMudkipPose215:
+ax_pose 32, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose216:
+ax_pose 34, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose217:
+ax_pose 35, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose218:
+ax_pose 36, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose219:
+ax_pose 6, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose220:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose221:
+ax_pose 37, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose222:
+ax_pose 38, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose223:
+ax_pose 39, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose224:
+ax_pose 40, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose225:
+ax_pose 39, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose226:
+ax_pose 40, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose227:
+ax_pose 41, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose228:
+ax_pose 42, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose229:
+ax_pose 43, 0x01ed, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose230:
+ax_pose 44, 0x01ed, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose231:
+ax_pose 45, 0x01ed, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose232:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose233:
+ax_pose 46, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose234:
+ax_pose 47, 0x41f2, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose235:
+ax_pose 12, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose236:
+ax_pose 48, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose237:
+ax_pose 49, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose238:
+ax_pose 0, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose239:
+ax_pose 50, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose240:
+ax_pose 51, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose241:
+ax_pose 6, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose242:
+ax_pose 52, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose243:
+ax_pose 6, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose244:
+ax_pose 52, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose245:
+ax_pose 53, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sMudkipPose246:
+ax_pose 54, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose247:
+ax_pose 55, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose248:
+ax_pose 56, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose249:
+ax_pose 57, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose250:
+ax_pose 58, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sMudkipPose251:
+ax_pose 54, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose252:
+ax_pose 55, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose253:
+ax_pose 56, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose254:
+ax_pose 57, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose255:
+ax_pose 58, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sMudkipPose256:
+ax_pose 59, 0x01ed, 0x90ef, 0x9c00
+ax_pose_terminator
+sMudkipPose257:
+ax_pose 32, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose258:
+ax_pose 33, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose259:
+ax_pose 32, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sMudkipPose260:
+ax_pose 33, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sMudkipPose261:
+ax_pose 32, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose262:
+ax_pose 33, 0x01ec, 0x90eb, 0x9c00
+ax_pose_terminator
+sMudkipPose263:
+ax_pose 32, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sMudkipPose264:
+ax_pose 33, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+.align 2
+sMudkipAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 1,
+ax_anim 4, 0, 2, 0, -2, 0, 2,
+ax_anim 6, 0, 2, 0, 0, 0, 3,
+ax_anim 6, 0, 2, 0, 3, 0, 3,
+ax_anim 4, 0, 0, 0, 2, 0, 2,
+ax_anim_terminator
+sMudkipAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 1,
+ax_anim 4, 0, 5, 3, -1, 3, 2,
+ax_anim 6, 0, 5, 4, 1, 4, 3,
+ax_anim 4, 0, 3, 2, 1, 2, 2,
+ax_anim_terminator
+sMudkipAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, 0, 0, 0,
+ax_anim 6, 0, 7, 2, -1, 2, 0,
+ax_anim 4, 0, 8, 3, -2, 3, 0,
+ax_anim 6, 0, 8, 4, 0, 3, 0,
+ax_anim 4, 0, 6, 2, 0, 2, 0,
+ax_anim_terminator
+sMudkipAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 10, 2, 0, 2, -1,
+ax_anim 4, 0, 11, 3, -3, 3, -2,
+ax_anim 6, 0, 11, 4, -2, 4, -3,
+ax_anim 4, 0, 9, 2, -1, 2, -2,
+ax_anim_terminator
+sMudkipAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -4, 0, -1,
+ax_anim 4, 0, 14, 0, -5, 0, -2,
+ax_anim 6, 0, 14, 0, -4, 0, -3,
+ax_anim 4, 0, 12, 0, -2, 0, -2,
+ax_anim_terminator
+sMudkipAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 16, -2, 0, -2, -1,
+ax_anim 4, 0, 17, -3, -3, -3, -2,
+ax_anim 6, 0, 17, -4, -2, -4, -3,
+ax_anim 4, 0, 15, -2, -1, -2, -2,
+ax_anim_terminator
+sMudkipAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, 0, 0, 0,
+ax_anim 6, 0, 19, -2, -1, -2, 0,
+ax_anim 4, 0, 20, -3, -2, -3, 0,
+ax_anim 6, 0, 20, -4, 0, -3, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim_terminator
+sMudkipAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -2, -1, -2, 1,
+ax_anim 4, 0, 23, -3, -1, -3, 2,
+ax_anim 6, 0, 23, -4, 1, -4, 3,
+ax_anim 4, 0, 21, -2, 1, -2, 2,
+ax_anim_terminator
+.align 2
+sMudkipAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, 2, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sMudkipAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 1, 4, 4,
+ax_anim 2, 2, 29, 12, 4, 10, 8,
+ax_anim 2, 0, 29, 21, 18, 21, 18,
+ax_anim 2, 1, 29, 22, 17, 22, 17,
+ax_anim 2, 0, 29, 21, 18, 21, 18,
+ax_anim 2, 0, 29, 22, 17, 22, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sMudkipAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 2, 0, 31, 4, -3, 4, 0,
+ax_anim 2, 2, 32, 10, -5, 10, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sMudkipAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 0, -3, 0, -1,
+ax_anim 2, 0, 34, 4, -10, 4, -6,
+ax_anim 2, 2, 35, 11, -20, 11, -15,
+ax_anim 2, 0, 35, 20, -25, 20, -25,
+ax_anim 2, 1, 35, 21, -24, 21, -24,
+ax_anim 2, 0, 35, 20, -25, 20, -25,
+ax_anim 2, 0, 35, 21, -24, 21, -24,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sMudkipAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -6, 0, -4,
+ax_anim 2, 2, 38, 0, -15, 0, -11,
+ax_anim 2, 0, 38, 0, -25, 0, -25,
+ax_anim 2, 1, 38, 1, -25, 1, -25,
+ax_anim 2, 0, 38, 0, -25, 0, -25,
+ax_anim 2, 0, 38, 1, -25, 1, -25,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sMudkipAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 0, -3, 0, -1,
+ax_anim 2, 0, 40, -4, -10, -4, -6,
+ax_anim 2, 2, 41, -11, -20, -11, -15,
+ax_anim 2, 0, 41, -20, -25, -20, -25,
+ax_anim 2, 1, 41, -21, -24, -21, -24,
+ax_anim 2, 0, 41, -20, -25, -20, -25,
+ax_anim 2, 0, 41, -21, -24, -21, -24,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sMudkipAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 0, -1, 0, 0,
+ax_anim 2, 0, 43, -4, -3, -4, 0,
+ax_anim 2, 2, 44, -10, -5, -10, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sMudkipAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 46, -4, 1, -4, 4,
+ax_anim 2, 2, 47, -12, 4, -10, 8,
+ax_anim 2, 0, 47, -21, 18, -21, 18,
+ax_anim 2, 1, 47, -22, 17, -22, 17,
+ax_anim 2, 0, 47, -21, 18, -21, 18,
+ax_anim 2, 0, 47, -22, 17, -22, 17,
+ax_anim 4, 0, 45, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sMudkipAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, 2, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sMudkipAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 4, 1, 4, 4,
+ax_anim 2, 2, 53, 12, 4, 10, 8,
+ax_anim 2, 0, 53, 21, 18, 21, 18,
+ax_anim 2, 1, 53, 22, 17, 22, 17,
+ax_anim 2, 0, 53, 21, 18, 21, 18,
+ax_anim 2, 0, 53, 22, 17, 22, 17,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sMudkipAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 0, -1, 0, 0,
+ax_anim 2, 0, 55, 4, -3, 4, 0,
+ax_anim 2, 2, 56, 10, -5, 10, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sMudkipAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 0, -3, 0, -1,
+ax_anim 2, 0, 58, 4, -10, 4, -6,
+ax_anim 2, 2, 59, 11, -20, 11, -15,
+ax_anim 2, 0, 59, 20, -25, 20, -25,
+ax_anim 2, 1, 59, 21, -24, 21, -24,
+ax_anim 2, 0, 59, 20, -25, 20, -25,
+ax_anim 2, 0, 59, 21, -24, 21, -24,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sMudkipAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -6, 0, -4,
+ax_anim 2, 2, 62, 0, -15, 0, -11,
+ax_anim 2, 0, 62, 0, -25, 0, -25,
+ax_anim 2, 1, 62, 1, -25, 1, -25,
+ax_anim 2, 0, 62, 0, -25, 0, -25,
+ax_anim 2, 0, 62, 1, -25, 1, -25,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sMudkipAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 0, -3, 0, -1,
+ax_anim 2, 0, 64, -4, -10, -4, -6,
+ax_anim 2, 2, 65, -11, -20, -11, -15,
+ax_anim 2, 0, 65, -20, -25, -20, -25,
+ax_anim 2, 1, 65, -21, -24, -21, -24,
+ax_anim 2, 0, 65, -20, -25, -20, -25,
+ax_anim 2, 0, 65, -21, -24, -21, -24,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sMudkipAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 0, -1, 0, 0,
+ax_anim 2, 0, 67, -4, -3, -4, 0,
+ax_anim 2, 2, 68, -10, -5, -10, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sMudkipAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 70, -4, 1, -4, 4,
+ax_anim 2, 2, 71, -12, 4, -10, 8,
+ax_anim 2, 0, 71, -21, 18, -21, 18,
+ax_anim 2, 1, 71, -22, 17, -22, 17,
+ax_anim 2, 0, 71, -21, 18, -21, 18,
+ax_anim 2, 0, 71, -22, 17, -22, 17,
+ax_anim 4, 0, 69, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sMudkipAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 3, 0, 72, 0, -5, 0, 0,
+ax_anim 4, 0, 72, 0, -6, 0, 0,
+ax_anim 2, 0, 72, 0, -3, 0, 0,
+ax_anim 6, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 1, 73, 1, 2, 1, 2,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 0, 73, 1, 2, 1, 2,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 0, 73, 1, 2, 1, 2,
+ax_anim_terminator
+sMudkipAnims_4_2:
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 3, 0, 75, 0, -5, 0, 0,
+ax_anim 4, 0, 75, 0, -6, 0, 0,
+ax_anim 2, 0, 75, 0, -3, 0, 0,
+ax_anim 6, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 1, 76, 3, 1, 3, 1,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 0, 76, 3, 1, 3, 1,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 0, 76, 3, 1, 3, 1,
+ax_anim_terminator
+sMudkipAnims_4_3:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 3, 0, 78, 0, -5, 0, 0,
+ax_anim 4, 0, 78, 0, -6, 0, 0,
+ax_anim 2, 0, 78, 0, -3, 0, 0,
+ax_anim 6, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 2, 0, 2, 0,
+ax_anim 2, 1, 79, 2, -1, 2, -1,
+ax_anim 2, 0, 79, 2, 0, 2, 0,
+ax_anim 2, 0, 79, 2, -1, 2, -1,
+ax_anim 2, 0, 79, 2, 0, 2, 0,
+ax_anim 2, 0, 79, 2, -1, 2, -1,
+ax_anim_terminator
+sMudkipAnims_4_4:
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 3, 0, 81, 0, -5, 0, 0,
+ax_anim 4, 0, 81, 0, -6, 0, 0,
+ax_anim 2, 0, 81, 0, -5, 0, 0,
+ax_anim 6, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 2, -2, 2, -2,
+ax_anim 2, 1, 82, 3, -1, 3, -1,
+ax_anim 2, 0, 82, 2, -2, 2, -2,
+ax_anim 2, 0, 82, 3, -1, 3, -1,
+ax_anim 2, 0, 82, 2, -2, 2, -2,
+ax_anim 2, 0, 82, 3, -1, 3, -1,
+ax_anim_terminator
+sMudkipAnims_4_5:
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 3, 0, 84, 0, -5, 0, 0,
+ax_anim 4, 0, 84, 0, -6, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 6, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, -2,
+ax_anim 2, 1, 85, 1, 0, 1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, -1,
+ax_anim 2, 0, 85, 1, 0, 1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, -1,
+ax_anim 2, 0, 85, 1, 0, 1, -1,
+ax_anim_terminator
+sMudkipAnims_4_6:
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 3, 0, 87, 0, -5, 0, 0,
+ax_anim 4, 0, 87, 0, -6, 0, 0,
+ax_anim 2, 0, 87, 0, -5, 0, 0,
+ax_anim 6, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -2, -2, -2, -2,
+ax_anim 2, 1, 88, -3, -1, -3, -1,
+ax_anim 2, 0, 88, -2, -2, -2, -2,
+ax_anim 2, 0, 88, -3, -1, -3, -1,
+ax_anim 2, 0, 88, -2, -2, -2, -2,
+ax_anim 2, 0, 88, -3, -1, -3, -1,
+ax_anim_terminator
+sMudkipAnims_4_7:
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 3, 0, 90, 0, -5, 0, 0,
+ax_anim 4, 0, 90, 0, -6, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 6, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 1, 91, -2, -1, -2, -1,
+ax_anim 2, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -2, -1, -2, -1,
+ax_anim 2, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -2, -1, -2, -1,
+ax_anim_terminator
+sMudkipAnims_4_8:
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 3, 0, 93, 0, -5, 0, 0,
+ax_anim 4, 0, 93, 0, -6, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 6, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 2, 1, 94, -3, 1, -3, 1,
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 2, 0, 94, -3, 1, -3, 1,
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 2, 0, 94, -3, 1, -3, 1,
+ax_anim_terminator
+.align 2
+sMudkipAnims_5_1:
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 1, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 2, 2, 98, 0, 2, 0, 2,
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 2, 0, 98, 0, 2, 0, 2,
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 2, 1, 98, 0, 2, 0, 2,
+ax_anim_terminator
+sMudkipAnims_5_2:
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 103, -1, -4, 0, 0,
+ax_anim 2, 0, 105, 1, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 112, 1, -6, 0, 0,
+ax_anim 2, 0, 115, 1, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 2, 2, 2, 2,
+ax_anim 2, 2, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 100, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 100, 2, 2, 2, 2,
+ax_anim 2, 1, 101, 2, 2, 2, 2,
+ax_anim_terminator
+sMudkipAnims_5_3:
+ax_anim 1, 0, 103, -1, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 1, -6, 0, 0,
+ax_anim 2, 0, 115, 1, -6, 0, 0,
+ax_anim 2, 0, 118, 1, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 2, 0, 2, 0,
+ax_anim 2, 2, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 103, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 103, 2, 0, 2, 0,
+ax_anim 2, 1, 104, 2, 0, 2, 0,
+ax_anim_terminator
+sMudkipAnims_5_4:
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 1, -5, 0, 0,
+ax_anim 2, 0, 115, 2, -7, 0, 0,
+ax_anim 2, 0, 118, 1, -7, 0, 0,
+ax_anim 2, 0, 97, 0, -7, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 1, -1, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 2, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 1, 107, 2, -2, 2, -2,
+ax_anim_terminator
+sMudkipAnims_5_5:
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 1, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -6, 0, 0,
+ax_anim 2, 0, 118, 1, -9, 0, 0,
+ax_anim 2, 0, 97, 0, -9, 0, 0,
+ax_anim 2, 0, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 103, -1, -4, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -2, 0, -2,
+ax_anim 2, 2, 110, 0, -2, 0, -2,
+ax_anim 2, 0, 109, 0, -2, 0, -2,
+ax_anim 2, 0, 110, 0, -2, 0, -2,
+ax_anim 2, 0, 109, 0, -2, 0, -2,
+ax_anim 2, 1, 110, 0, -2, 0, -2,
+ax_anim_terminator
+sMudkipAnims_5_6:
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 2, -5, 0, 0,
+ax_anim 2, 0, 117, 1, -6, 0, 0,
+ax_anim 2, 0, 97, 0, -9, 0, 0,
+ax_anim 2, 0, 100, -1, -9, 0, 0,
+ax_anim 2, 0, 103, -1, -6, 0, 0,
+ax_anim 2, 0, 105, 1, -4, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -2, -2, -2, -2,
+ax_anim 2, 2, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 112, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 112, -2, -2, -2, -2,
+ax_anim 2, 1, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sMudkipAnims_5_7:
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 2, -5, 0, 0,
+ax_anim 2, 0, 96, 1, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -8, 0, 0,
+ax_anim 2, 0, 103, -1, -8, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 108, 1, -4, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 2, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 1, 116, -2, 0, -2, 0,
+ax_anim_terminator
+sMudkipAnims_5_8:
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 1, -5, 0, 0,
+ax_anim 2, 0, 103, -1, -7, 0, 0,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 2, 0, 111, 1, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim 2, 2, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMudkipAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sMudkipAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sMudkipAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sMudkipAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sMudkipAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sMudkipAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sMudkipAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sMudkipAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMudkipAnims_8_1:
+ax_anim 38, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 5, 0, 131, 0, -3, 0, 0,
+ax_anim 3, 0, 132, 0, -3, 0, 0,
+ax_anim 3, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_8_2:
+ax_anim 38, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 5, 0, 134, 0, -3, 0, 0,
+ax_anim 3, 0, 135, 0, -4, 0, 0,
+ax_anim 3, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_8_3:
+ax_anim 38, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 5, 0, 137, 0, -3, 0, 0,
+ax_anim 3, 0, 138, 0, -3, 0, 0,
+ax_anim 3, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_8_4:
+ax_anim 38, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 5, 0, 140, 0, -3, 0, 0,
+ax_anim 3, 0, 141, 0, -3, 0, 0,
+ax_anim 3, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_8_5:
+ax_anim 38, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 5, 0, 143, 0, -3, 0, 0,
+ax_anim 3, 0, 144, 0, -3, 0, 0,
+ax_anim 3, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_8_6:
+ax_anim 38, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 5, 0, 146, 0, -3, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 3, 0, 147, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_8_7:
+ax_anim 38, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 5, 0, 149, 0, -3, 0, 0,
+ax_anim 3, 0, 150, 0, -3, 0, 0,
+ax_anim 3, 0, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_8_8:
+ax_anim 38, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 5, 0, 152, 0, -3, 0, 0,
+ax_anim 3, 0, 153, 0, -4, 0, 0,
+ax_anim 3, 0, 153, 0, -2, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 17, 7, 17,
+ax_anim 3, 0, 158, 0, 23, 0, 23,
+ax_anim 2, 3, 159, -7, 17, -7, 17,
+ax_anim 2, 0, 160, -8, 10, -8, 10,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 24, 9, 24, 9,
+ax_anim 3, 0, 157, 23, 21, 23, 21,
+ax_anim 2, 3, 158, 11, 21, 11, 21,
+ax_anim 2, 0, 159, 2, 12, 2, 12,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -4, 17, -4,
+ax_anim 3, 0, 156, 24, 1, 24, 1,
+ax_anim 2, 3, 157, 18, 6, 18, 6,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 9, -21, 9, -21,
+ax_anim 3, 0, 155, 21, -24, 21, -24,
+ax_anim 2, 3, 156, 19, -12, 19, -12,
+ax_anim 2, 0, 157, 16, -6, 16, -6,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -8, -10, -8, -10,
+ax_anim 2, 0, 161, -7, -21, -7, -21,
+ax_anim 3, 0, 154, 0, -27, 0, -27,
+ax_anim 2, 3, 155, 7, -21, 7, -21,
+ax_anim 2, 0, 156, 8, -8, 8, -8,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -11, -23, -11, -23,
+ax_anim 3, 0, 161, -21, -24, -21, -24,
+ax_anim 2, 3, 160, -20, -13, -20, -13,
+ax_anim 2, 0, 159, -16, -6, -16, -6,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -4, -17, -4,
+ax_anim 3, 0, 160, -24, 1, -24, 1,
+ax_anim 2, 3, 159, -18, 6, -18, 6,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -24, 9, -24, 9,
+ax_anim 3, 0, 159, -23, 21, -23, 16,
+ax_anim 2, 3, 158, -11, 21, -11, 16,
+ax_anim 2, 0, 157, -2, 12, -4, 12,
+ax_anim 1, 0, 156, 0, 7, -3, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_14_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_14_2:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_14_3:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_14_4:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_14_5:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_14_6:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_14_7:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_14_8:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_15_1:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_15_2:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_15_3:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_15_4:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_15_5:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_15_6:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_15_7:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_15_8:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 4, 0, 215, 0, 0, 0, 0,
+ax_anim 16, 0, 216, 0, 0, 0, 0,
+ax_anim 8, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_16_1:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_16_2:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_16_3:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_16_4:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_16_5:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_16_6:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_16_7:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_16_8:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_17_1:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sMudkipAnims_17_2:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sMudkipAnims_17_3:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sMudkipAnims_17_4:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sMudkipAnims_17_5:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sMudkipAnims_17_6:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sMudkipAnims_17_7:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sMudkipAnims_17_8:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_18_1:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_18_2:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_18_3:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_18_4:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_18_5:
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 3, 0, 227, 0, -3, 0, 0,
+ax_anim 2, 0, 227, 0, -2, 0, 0,
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_18_6:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_18_7:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_18_8:
+ax_anim 8, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -2, 0, 0,
+ax_anim 3, 0, 225, 0, -3, 0, 0,
+ax_anim 2, 0, 225, 0, -2, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_19_1:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_19_2:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_19_3:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_19_4:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_19_5:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_19_6:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_19_7:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_19_8:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 10, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_20_1:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 1, 0, 0,
+ax_anim 2, 0, 233, 1, 1, 1, 0,
+ax_anim 2, 0, 233, 0, 1, 0, 0,
+ax_anim 2, 0, 233, 1, 1, 1, 0,
+ax_anim 2, 0, 233, 0, 1, 0, 0,
+ax_anim 2, 0, 233, 1, 1, 1, 0,
+ax_anim_terminator
+sMudkipAnims_20_2:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sMudkipAnims_20_3:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sMudkipAnims_20_4:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sMudkipAnims_20_5:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sMudkipAnims_20_6:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sMudkipAnims_20_7:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+sMudkipAnims_20_8:
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -2, 0, 0,
+ax_anim 1, 0, 232, 0, -4, 0, 0,
+ax_anim 2, 0, 233, 0, -4, 0, 0,
+ax_anim 1, 0, 233, 0, -2, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_21_1:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_21_2:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_21_3:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_21_4:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_21_5:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_21_6:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_21_7:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_21_8:
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_22_1:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_22_2:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_22_3:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_22_4:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_22_5:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_22_6:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_22_7:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_22_8:
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 30, 0, 238, 0, 0, 0, 0,
+ax_anim 34, 0, 239, 0, 0, 0, 0,
+ax_anim 4, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_23_1:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_23_2:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_23_3:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_23_4:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_23_5:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_23_6:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_23_7:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_23_8:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_24_1:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_24_2:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_24_3:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_24_4:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_24_5:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_24_6:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_24_7:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_24_8:
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_25_1:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_25_2:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_25_3:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_25_4:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_25_5:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_25_6:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_25_7:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 10, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_25_8:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 10, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_26_1:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+sMudkipAnims_26_2:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+sMudkipAnims_26_3:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+sMudkipAnims_26_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+sMudkipAnims_26_5:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+sMudkipAnims_26_6:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+sMudkipAnims_26_7:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+sMudkipAnims_26_8:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sMudkipAnims_27_1:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 16, 0, 256, -1, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 1, 0, 0, 0,
+ax_anim 16, 0, 256, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMudkipAnims_28_1:
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_28_2:
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_28_3:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_28_4:
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_28_5:
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_28_6:
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_28_7:
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipAnims_28_8:
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sMudkipGfx1:
+.incbin "baserom.gba", 0x109BE2C, 0x200
+sMudkipSprites1:
+ax_sprite sMudkipGfx1, 0x200
+ax_sprite_terminator
+sMudkipGfx2:
+.incbin "baserom.gba", 0x109C03C, 0x200
+sMudkipSprites2:
+ax_sprite sMudkipGfx2, 0x200
+ax_sprite_terminator
+sMudkipGfx3:
+.incbin "baserom.gba", 0x109C24C, 0x200
+sMudkipSprites3:
+ax_sprite sMudkipGfx3, 0x200
+ax_sprite_terminator
+sMudkipGfx4:
+.incbin "baserom.gba", 0x109C45C, 0x200
+sMudkipSprites4:
+ax_sprite sMudkipGfx4, 0x200
+ax_sprite_terminator
+sMudkipGfx5:
+.incbin "baserom.gba", 0x109C66C, 0x200
+sMudkipSprites5:
+ax_sprite sMudkipGfx5, 0x200
+ax_sprite_terminator
+sMudkipGfx6:
+.incbin "baserom.gba", 0x109C87C, 0x100
+sMudkipSprites6:
+ax_sprite sMudkipGfx6, 0x100
+ax_sprite_terminator
+sMudkipGfx7:
+.incbin "baserom.gba", 0x109C98C, 0x200
+sMudkipSprites7:
+ax_sprite sMudkipGfx7, 0x200
+ax_sprite_terminator
+sMudkipGfx8:
+.incbin "baserom.gba", 0x109CB9C, 0x200
+sMudkipSprites8:
+ax_sprite sMudkipGfx8, 0x200
+ax_sprite_terminator
+sMudkipGfx9:
+.incbin "baserom.gba", 0x109CDAC, 0x200
+sMudkipSprites9:
+ax_sprite sMudkipGfx9, 0x200
+ax_sprite_terminator
+sMudkipGfx10:
+.incbin "baserom.gba", 0x109CFBC, 0x100
+sMudkipSprites10:
+ax_sprite sMudkipGfx10, 0x100
+ax_sprite_terminator
+sMudkipGfx11:
+.incbin "baserom.gba", 0x109D0CC, 0x100
+sMudkipSprites11:
+ax_sprite sMudkipGfx11, 0x100
+ax_sprite_terminator
+sMudkipGfx12:
+.incbin "baserom.gba", 0x109D1DC, 0x100
+sMudkipSprites12:
+ax_sprite sMudkipGfx12, 0x100
+ax_sprite_terminator
+sMudkipGfx13:
+.incbin "baserom.gba", 0x109D2EC, 0x200
+sMudkipSprites13:
+ax_sprite sMudkipGfx13, 0x200
+ax_sprite_terminator
+sMudkipGfx14:
+.incbin "baserom.gba", 0x109D4FC, 0x200
+sMudkipSprites14:
+ax_sprite sMudkipGfx14, 0x200
+ax_sprite_terminator
+sMudkipGfx15:
+.incbin "baserom.gba", 0x109D70C, 0x200
+sMudkipSprites15:
+ax_sprite sMudkipGfx15, 0x200
+ax_sprite_terminator
+sMudkipGfx16:
+.incbin "baserom.gba", 0x109D91C, 0x40
+sMudkipGfx16_1:
+.incbin "baserom.gba", 0x109D95C, 0x60
+sMudkipGfx16_2:
+.incbin "baserom.gba", 0x109D9BC, 0x40
+sMudkipSprites16:
+ax_sprite 0, 0xa0
+ax_sprite sMudkipGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx17:
+.incbin "baserom.gba", 0x109DA3C, 0x40
+sMudkipGfx17_1:
+.incbin "baserom.gba", 0x109DA7C, 0x60
+sMudkipGfx17_2:
+.incbin "baserom.gba", 0x109DADC, 0x40
+sMudkipSprites17:
+ax_sprite 0, 0xa0
+ax_sprite sMudkipGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx18:
+.incbin "baserom.gba", 0x109DB5C, 0x60
+sMudkipGfx18_1:
+.incbin "baserom.gba", 0x109DBBC, 0x60
+sMudkipGfx18_2:
+.incbin "baserom.gba", 0x109DC1C, 0x40
+sMudkipSprites18:
+ax_sprite 0, 0x80
+ax_sprite sMudkipGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx19:
+.incbin "baserom.gba", 0x109DC9C, 0x40
+sMudkipGfx19_1:
+.incbin "baserom.gba", 0x109DCDC, 0x60
+sMudkipGfx19_2:
+.incbin "baserom.gba", 0x109DD3C, 0x40
+sMudkipSprites19:
+ax_sprite 0, 0xa0
+ax_sprite sMudkipGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx19_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx20:
+.incbin "baserom.gba", 0x109DDBC, 0x60
+sMudkipGfx20_1:
+.incbin "baserom.gba", 0x109DE1C, 0x60
+sMudkipGfx20_2:
+.incbin "baserom.gba", 0x109DE7C, 0x40
+sMudkipSprites20:
+ax_sprite 0, 0x80
+ax_sprite sMudkipGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx21:
+.incbin "baserom.gba", 0x109DEFC, 0x60
+sMudkipGfx21_1:
+.incbin "baserom.gba", 0x109DF5C, 0x80
+sMudkipGfx21_2:
+.incbin "baserom.gba", 0x109DFDC, 0x40
+sMudkipSprites21:
+ax_sprite 0, 0x80
+ax_sprite sMudkipGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx21_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx22:
+.incbin "baserom.gba", 0x109E05C, 0x20
+sMudkipGfx22_1:
+.incbin "baserom.gba", 0x109E07C, 0x60
+sMudkipGfx22_2:
+.incbin "baserom.gba", 0x109E0DC, 0x60
+sMudkipGfx22_3:
+.incbin "baserom.gba", 0x109E13C, 0x40
+sMudkipSprites22:
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx23:
+.incbin "baserom.gba", 0x109E1CC, 0x40
+sMudkipGfx23_1:
+.incbin "baserom.gba", 0x109E20C, 0x60
+sMudkipGfx23_2:
+.incbin "baserom.gba", 0x109E26C, 0x40
+sMudkipSprites23:
+ax_sprite 0, 0xa0
+ax_sprite sMudkipGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx24:
+.incbin "baserom.gba", 0x109E2EC, 0x40
+sMudkipGfx24_1:
+.incbin "baserom.gba", 0x109E32C, 0x60
+sMudkipGfx24_2:
+.incbin "baserom.gba", 0x109E38C, 0x60
+sMudkipGfx24_3:
+.incbin "baserom.gba", 0x109E3EC, 0x40
+sMudkipSprites24:
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx25:
+.incbin "baserom.gba", 0x109E47C, 0x60
+sMudkipGfx25_1:
+.incbin "baserom.gba", 0x109E4DC, 0x60
+sMudkipGfx25_2:
+.incbin "baserom.gba", 0x109E53C, 0x40
+sMudkipSprites25:
+ax_sprite 0, 0x80
+ax_sprite sMudkipGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMudkipGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMudkipGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMudkipGfx26:
+.incbin "baserom.gba", 0x109E5BC, 0x200
+sMudkipSprites26:
+ax_sprite sMudkipGfx26, 0x200
+ax_sprite_terminator
+sMudkipGfx27:
+.incbin "baserom.gba", 0x109E7CC, 0x200
+sMudkipSprites27:
+ax_sprite sMudkipGfx27, 0x200
+ax_sprite_terminator
+sMudkipGfx28:
+.incbin "baserom.gba", 0x109E9DC, 0x200
+sMudkipSprites28:
+ax_sprite sMudkipGfx28, 0x200
+ax_sprite_terminator
+sMudkipGfx29:
+.incbin "baserom.gba", 0x109EBEC, 0x200
+sMudkipSprites29:
+ax_sprite sMudkipGfx29, 0x200
+ax_sprite_terminator
+sMudkipGfx30:
+.incbin "baserom.gba", 0x109EDFC, 0x200
+sMudkipSprites30:
+ax_sprite sMudkipGfx30, 0x200
+ax_sprite_terminator
+sMudkipGfx31:
+.incbin "baserom.gba", 0x109F00C, 0x200
+sMudkipSprites31:
+ax_sprite sMudkipGfx31, 0x200
+ax_sprite_terminator
+sMudkipGfx32:
+.incbin "baserom.gba", 0x109F21C, 0x200
+sMudkipSprites32:
+ax_sprite sMudkipGfx32, 0x200
+ax_sprite_terminator
+sMudkipGfx33:
+.incbin "baserom.gba", 0x109F42C, 0x200
+sMudkipSprites33:
+ax_sprite sMudkipGfx33, 0x200
+ax_sprite_terminator
+sMudkipGfx34:
+.incbin "baserom.gba", 0x109F63C, 0x200
+sMudkipSprites34:
+ax_sprite sMudkipGfx34, 0x200
+ax_sprite_terminator
+sMudkipGfx35:
+.incbin "baserom.gba", 0x109F84C, 0x200
+sMudkipSprites35:
+ax_sprite sMudkipGfx35, 0x200
+ax_sprite_terminator
+sMudkipGfx36:
+.incbin "baserom.gba", 0x109FA5C, 0x200
+sMudkipSprites36:
+ax_sprite sMudkipGfx36, 0x200
+ax_sprite_terminator
+sMudkipGfx37:
+.incbin "baserom.gba", 0x109FC6C, 0x200
+sMudkipSprites37:
+ax_sprite sMudkipGfx37, 0x200
+ax_sprite_terminator
+sMudkipGfx38:
+.incbin "baserom.gba", 0x109FE7C, 0x200
+sMudkipSprites38:
+ax_sprite sMudkipGfx38, 0x200
+ax_sprite_terminator
+sMudkipGfx39:
+.incbin "baserom.gba", 0x10A008C, 0x200
+sMudkipSprites39:
+ax_sprite sMudkipGfx39, 0x200
+ax_sprite_terminator
+sMudkipGfx40:
+.incbin "baserom.gba", 0x10A029C, 0x200
+sMudkipSprites40:
+ax_sprite sMudkipGfx40, 0x200
+ax_sprite_terminator
+sMudkipGfx41:
+.incbin "baserom.gba", 0x10A04AC, 0x200
+sMudkipSprites41:
+ax_sprite sMudkipGfx41, 0x200
+ax_sprite_terminator
+sMudkipGfx42:
+.incbin "baserom.gba", 0x10A06BC, 0x200
+sMudkipSprites42:
+ax_sprite sMudkipGfx42, 0x200
+ax_sprite_terminator
+sMudkipGfx43:
+.incbin "baserom.gba", 0x10A08CC, 0x200
+sMudkipSprites43:
+ax_sprite sMudkipGfx43, 0x200
+ax_sprite_terminator
+sMudkipGfx44:
+.incbin "baserom.gba", 0x10A0ADC, 0x200
+sMudkipSprites44:
+ax_sprite sMudkipGfx44, 0x200
+ax_sprite_terminator
+sMudkipGfx45:
+.incbin "baserom.gba", 0x10A0CEC, 0x200
+sMudkipSprites45:
+ax_sprite sMudkipGfx45, 0x200
+ax_sprite_terminator
+sMudkipGfx46:
+.incbin "baserom.gba", 0x10A0EFC, 0x200
+sMudkipSprites46:
+ax_sprite sMudkipGfx46, 0x200
+ax_sprite_terminator
+sMudkipGfx47:
+.incbin "baserom.gba", 0x10A110C, 0x200
+sMudkipSprites47:
+ax_sprite sMudkipGfx47, 0x200
+ax_sprite_terminator
+sMudkipGfx48:
+.incbin "baserom.gba", 0x10A131C, 0x100
+sMudkipSprites48:
+ax_sprite sMudkipGfx48, 0x100
+ax_sprite_terminator
+sMudkipGfx49:
+.incbin "baserom.gba", 0x10A142C, 0x200
+sMudkipSprites49:
+ax_sprite sMudkipGfx49, 0x200
+ax_sprite_terminator
+sMudkipGfx50:
+.incbin "baserom.gba", 0x10A163C, 0x200
+sMudkipSprites50:
+ax_sprite sMudkipGfx50, 0x200
+ax_sprite_terminator
+sMudkipGfx51:
+.incbin "baserom.gba", 0x10A184C, 0x200
+sMudkipSprites51:
+ax_sprite sMudkipGfx51, 0x200
+ax_sprite_terminator
+sMudkipGfx52:
+.incbin "baserom.gba", 0x10A1A5C, 0x200
+sMudkipSprites52:
+ax_sprite sMudkipGfx52, 0x200
+ax_sprite_terminator
+sMudkipGfx53:
+.incbin "baserom.gba", 0x10A1C6C, 0x200
+sMudkipSprites53:
+ax_sprite sMudkipGfx53, 0x200
+ax_sprite_terminator
+sMudkipGfx54:
+.incbin "baserom.gba", 0x10A1E7C, 0x200
+sMudkipSprites54:
+ax_sprite sMudkipGfx54, 0x200
+ax_sprite_terminator
+sMudkipGfx55:
+.incbin "baserom.gba", 0x10A208C, 0x200
+sMudkipSprites55:
+ax_sprite sMudkipGfx55, 0x200
+ax_sprite_terminator
+sMudkipGfx56:
+.incbin "baserom.gba", 0x10A229C, 0x200
+sMudkipSprites56:
+ax_sprite sMudkipGfx56, 0x200
+ax_sprite_terminator
+sMudkipGfx57:
+.incbin "baserom.gba", 0x10A24AC, 0x200
+sMudkipSprites57:
+ax_sprite sMudkipGfx57, 0x200
+ax_sprite_terminator
+sMudkipGfx58:
+.incbin "baserom.gba", 0x10A26BC, 0x200
+sMudkipSprites58:
+ax_sprite sMudkipGfx58, 0x200
+ax_sprite_terminator
+sMudkipGfx59:
+.incbin "baserom.gba", 0x10A28CC, 0x200
+sMudkipSprites59:
+ax_sprite sMudkipGfx59, 0x200
+ax_sprite_terminator
+sMudkipGfx60:
+.incbin "baserom.gba", 0x10A2ADC, 0x200
+sMudkipSprites60:
+ax_sprite sMudkipGfx60, 0x200
+ax_sprite_terminator
+sAxPosesMudkip:
+.4byte sMudkipPose1
+.4byte sMudkipPose2
+.4byte sMudkipPose3
+.4byte sMudkipPose4
+.4byte sMudkipPose5
+.4byte sMudkipPose6
+.4byte sMudkipPose7
+.4byte sMudkipPose8
+.4byte sMudkipPose9
+.4byte sMudkipPose10
+.4byte sMudkipPose11
+.4byte sMudkipPose12
+.4byte sMudkipPose13
+.4byte sMudkipPose14
+.4byte sMudkipPose15
+.4byte sMudkipPose16
+.4byte sMudkipPose17
+.4byte sMudkipPose18
+.4byte sMudkipPose19
+.4byte sMudkipPose20
+.4byte sMudkipPose21
+.4byte sMudkipPose22
+.4byte sMudkipPose23
+.4byte sMudkipPose24
+.4byte sMudkipPose25
+.4byte sMudkipPose26
+.4byte sMudkipPose27
+.4byte sMudkipPose28
+.4byte sMudkipPose29
+.4byte sMudkipPose30
+.4byte sMudkipPose31
+.4byte sMudkipPose32
+.4byte sMudkipPose33
+.4byte sMudkipPose34
+.4byte sMudkipPose35
+.4byte sMudkipPose36
+.4byte sMudkipPose37
+.4byte sMudkipPose38
+.4byte sMudkipPose39
+.4byte sMudkipPose40
+.4byte sMudkipPose41
+.4byte sMudkipPose42
+.4byte sMudkipPose43
+.4byte sMudkipPose44
+.4byte sMudkipPose45
+.4byte sMudkipPose46
+.4byte sMudkipPose47
+.4byte sMudkipPose48
+.4byte sMudkipPose49
+.4byte sMudkipPose50
+.4byte sMudkipPose51
+.4byte sMudkipPose52
+.4byte sMudkipPose53
+.4byte sMudkipPose54
+.4byte sMudkipPose55
+.4byte sMudkipPose56
+.4byte sMudkipPose57
+.4byte sMudkipPose58
+.4byte sMudkipPose59
+.4byte sMudkipPose60
+.4byte sMudkipPose61
+.4byte sMudkipPose62
+.4byte sMudkipPose63
+.4byte sMudkipPose64
+.4byte sMudkipPose65
+.4byte sMudkipPose66
+.4byte sMudkipPose67
+.4byte sMudkipPose68
+.4byte sMudkipPose69
+.4byte sMudkipPose70
+.4byte sMudkipPose71
+.4byte sMudkipPose72
+.4byte sMudkipPose73
+.4byte sMudkipPose74
+.4byte sMudkipPose75
+.4byte sMudkipPose76
+.4byte sMudkipPose77
+.4byte sMudkipPose78
+.4byte sMudkipPose79
+.4byte sMudkipPose80
+.4byte sMudkipPose81
+.4byte sMudkipPose82
+.4byte sMudkipPose83
+.4byte sMudkipPose84
+.4byte sMudkipPose85
+.4byte sMudkipPose86
+.4byte sMudkipPose87
+.4byte sMudkipPose88
+.4byte sMudkipPose89
+.4byte sMudkipPose90
+.4byte sMudkipPose91
+.4byte sMudkipPose92
+.4byte sMudkipPose93
+.4byte sMudkipPose94
+.4byte sMudkipPose95
+.4byte sMudkipPose96
+.4byte sMudkipPose97
+.4byte sMudkipPose98
+.4byte sMudkipPose99
+.4byte sMudkipPose100
+.4byte sMudkipPose101
+.4byte sMudkipPose102
+.4byte sMudkipPose103
+.4byte sMudkipPose104
+.4byte sMudkipPose105
+.4byte sMudkipPose106
+.4byte sMudkipPose107
+.4byte sMudkipPose108
+.4byte sMudkipPose109
+.4byte sMudkipPose110
+.4byte sMudkipPose111
+.4byte sMudkipPose112
+.4byte sMudkipPose113
+.4byte sMudkipPose114
+.4byte sMudkipPose115
+.4byte sMudkipPose116
+.4byte sMudkipPose117
+.4byte sMudkipPose118
+.4byte sMudkipPose119
+.4byte sMudkipPose120
+.4byte sMudkipPose121
+.4byte sMudkipPose122
+.4byte sMudkipPose123
+.4byte sMudkipPose124
+.4byte sMudkipPose125
+.4byte sMudkipPose126
+.4byte sMudkipPose127
+.4byte sMudkipPose128
+.4byte sMudkipPose129
+.4byte sMudkipPose130
+.4byte sMudkipPose131
+.4byte sMudkipPose132
+.4byte sMudkipPose133
+.4byte sMudkipPose134
+.4byte sMudkipPose135
+.4byte sMudkipPose136
+.4byte sMudkipPose137
+.4byte sMudkipPose138
+.4byte sMudkipPose139
+.4byte sMudkipPose140
+.4byte sMudkipPose141
+.4byte sMudkipPose142
+.4byte sMudkipPose143
+.4byte sMudkipPose144
+.4byte sMudkipPose145
+.4byte sMudkipPose146
+.4byte sMudkipPose147
+.4byte sMudkipPose148
+.4byte sMudkipPose149
+.4byte sMudkipPose150
+.4byte sMudkipPose151
+.4byte sMudkipPose152
+.4byte sMudkipPose153
+.4byte sMudkipPose154
+.4byte sMudkipPose155
+.4byte sMudkipPose156
+.4byte sMudkipPose157
+.4byte sMudkipPose158
+.4byte sMudkipPose159
+.4byte sMudkipPose160
+.4byte sMudkipPose161
+.4byte sMudkipPose162
+.4byte sMudkipPose163
+.4byte sMudkipPose164
+.4byte sMudkipPose165
+.4byte sMudkipPose166
+.4byte sMudkipPose167
+.4byte sMudkipPose168
+.4byte sMudkipPose169
+.4byte sMudkipPose170
+.4byte sMudkipPose171
+.4byte sMudkipPose172
+.4byte sMudkipPose173
+.4byte sMudkipPose174
+.4byte sMudkipPose175
+.4byte sMudkipPose176
+.4byte sMudkipPose177
+.4byte sMudkipPose178
+.4byte sMudkipPose179
+.4byte sMudkipPose180
+.4byte sMudkipPose181
+.4byte sMudkipPose182
+.4byte sMudkipPose183
+.4byte sMudkipPose184
+.4byte sMudkipPose185
+.4byte sMudkipPose186
+.4byte sMudkipPose187
+.4byte sMudkipPose188
+.4byte sMudkipPose189
+.4byte sMudkipPose190
+.4byte sMudkipPose191
+.4byte sMudkipPose192
+.4byte sMudkipPose193
+.4byte sMudkipPose194
+.4byte sMudkipPose195
+.4byte sMudkipPose196
+.4byte sMudkipPose197
+.4byte sMudkipPose198
+.4byte sMudkipPose199
+.4byte sMudkipPose200
+.4byte sMudkipPose201
+.4byte sMudkipPose202
+.4byte sMudkipPose203
+.4byte sMudkipPose204
+.4byte sMudkipPose205
+.4byte sMudkipPose206
+.4byte sMudkipPose207
+.4byte sMudkipPose208
+.4byte sMudkipPose209
+.4byte sMudkipPose210
+.4byte sMudkipPose211
+.4byte sMudkipPose212
+.4byte sMudkipPose213
+.4byte sMudkipPose214
+.4byte sMudkipPose215
+.4byte sMudkipPose216
+.4byte sMudkipPose217
+.4byte sMudkipPose218
+.4byte sMudkipPose219
+.4byte sMudkipPose220
+.4byte sMudkipPose221
+.4byte sMudkipPose222
+.4byte sMudkipPose223
+.4byte sMudkipPose224
+.4byte sMudkipPose225
+.4byte sMudkipPose226
+.4byte sMudkipPose227
+.4byte sMudkipPose228
+.4byte sMudkipPose229
+.4byte sMudkipPose230
+.4byte sMudkipPose231
+.4byte sMudkipPose232
+.4byte sMudkipPose233
+.4byte sMudkipPose234
+.4byte sMudkipPose235
+.4byte sMudkipPose236
+.4byte sMudkipPose237
+.4byte sMudkipPose238
+.4byte sMudkipPose239
+.4byte sMudkipPose240
+.4byte sMudkipPose241
+.4byte sMudkipPose242
+.4byte sMudkipPose243
+.4byte sMudkipPose244
+.4byte sMudkipPose245
+.4byte sMudkipPose246
+.4byte sMudkipPose247
+.4byte sMudkipPose248
+.4byte sMudkipPose249
+.4byte sMudkipPose250
+.4byte sMudkipPose251
+.4byte sMudkipPose252
+.4byte sMudkipPose253
+.4byte sMudkipPose254
+.4byte sMudkipPose255
+.4byte sMudkipPose256
+.4byte sMudkipPose257
+.4byte sMudkipPose258
+.4byte sMudkipPose259
+.4byte sMudkipPose260
+.4byte sMudkipPose261
+.4byte sMudkipPose262
+.4byte sMudkipPose263
+.4byte sMudkipPose264
+sAxPositionsMudkip:
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,   -4, 	   2,   -4, 	  -1,   -7
+.2byte   -1,   -2, 	  -2,    0, 	   0,    0, 	  -1,   -4
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    3,   -5, 	   4,   -4, 	   2,   -3, 	   0,   -7
+.2byte    3,   -2, 	   1,    1, 	  -1,    1, 	   1,   -4
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    6,   -8, 	   2,   -4, 	   3,   -4, 	   0,   -8
+.2byte    6,   -4, 	   0,    0, 	  -1,    1, 	  -1,   -5
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    1,  -10, 	   0,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -9
+.2byte   -1,   -9, 	   1,   -1, 	  -3,   -1, 	  -1,   -7
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -3,  -10, 	  -2,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -8,   -8, 	  -4,   -4, 	  -5,   -4, 	  -2,   -8
+.2byte   -8,   -4, 	  -2,    0, 	  -1,    1, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -5,   -5, 	  -6,   -4, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,   -2, 	  -3,    1, 	  -1,    1, 	  -3,   -4
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,   -4, 	   2,   -4, 	  -1,   -7
+.2byte   -1,   -2, 	  -2,    0, 	   0,    0, 	  -1,   -4
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    3,   -5, 	   4,   -4, 	   2,   -3, 	   0,   -7
+.2byte    3,   -2, 	   1,    1, 	  -1,    1, 	   1,   -4
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    6,   -8, 	   2,   -4, 	   3,   -4, 	   0,   -8
+.2byte    6,   -4, 	   0,    0, 	  -1,    1, 	  -1,   -5
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    1,  -10, 	   0,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -9
+.2byte   -1,   -9, 	   1,   -1, 	  -3,   -1, 	  -1,   -7
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -3,  -10, 	  -2,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -8,   -8, 	  -4,   -4, 	  -5,   -4, 	  -2,   -8
+.2byte   -8,   -4, 	  -2,    0, 	  -1,    1, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -5,   -5, 	  -6,   -4, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,   -2, 	  -3,    1, 	  -1,    1, 	  -3,   -4
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,   -4, 	   2,   -4, 	  -1,   -7
+.2byte   -1,   -2, 	  -2,    0, 	   0,    0, 	  -1,   -4
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    3,   -5, 	   4,   -4, 	   2,   -3, 	   0,   -7
+.2byte    3,   -2, 	   1,    1, 	  -1,    1, 	   1,   -4
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    6,   -8, 	   2,   -4, 	   3,   -4, 	   0,   -8
+.2byte    6,   -4, 	   0,    0, 	  -1,    1, 	  -1,   -5
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    1,  -10, 	   0,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -9
+.2byte   -1,   -9, 	   1,   -1, 	  -3,   -1, 	  -1,   -7
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -3,  -10, 	  -2,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -8,   -8, 	  -4,   -4, 	  -5,   -4, 	  -2,   -8
+.2byte   -8,   -4, 	  -2,    0, 	  -1,    1, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -5,   -5, 	  -6,   -4, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,   -2, 	  -3,    1, 	  -1,    1, 	  -3,   -4
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,    0, 	  -4,    1, 	   2,    1, 	  -1,   -4
+.2byte   -1,    1, 	  -4,    1, 	   2,    1, 	  -1,   -4
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    3,   -1, 	   2,    0, 	   0,    0, 	   3,   -5
+.2byte    3,   -1, 	   2,   -1, 	  -1,    0, 	   1,   -5
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    7,   -3, 	   3,   -1, 	   2,   -1, 	   4,   -6
+.2byte    6,   -2, 	   4,   -1, 	   2,   -1, 	   2,   -5
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    5,   -8, 	   0,   -4, 	   2,   -3, 	   1,   -8
+.2byte    4,   -6, 	   0,   -4, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   2,   -3, 	  -4,   -3, 	  -1,   -8
+.2byte   -1,   -8, 	   2,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -7,   -8, 	  -2,   -4, 	  -4,   -3, 	  -3,   -8
+.2byte   -6,   -6, 	  -2,   -4, 	  -4,   -2, 	  -1,   -7
+.2byte   -7,   -6, 	  -2,   -2, 	  -2,   -1, 	  -1,   -6
+.2byte   -8,   -3, 	  -4,   -1, 	  -3,   -1, 	  -5,   -6
+.2byte   -7,   -2, 	  -5,   -1, 	  -3,   -1, 	  -3,   -5
+.2byte   -4,   -3, 	  -2,   -1, 	   0,    0, 	  -2,   -5
+.2byte   -4,   -1, 	  -3,    0, 	  -1,    0, 	  -4,   -5
+.2byte   -4,   -1, 	  -3,   -1, 	   0,    0, 	  -2,   -5
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,    0, 	  -4,    1, 	   2,    1, 	  -1,   -4
+.2byte   -1,    1, 	  -4,    1, 	   2,    1, 	  -1,   -4
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    3,   -1, 	   2,    0, 	   0,    0, 	   3,   -5
+.2byte    3,    0, 	   2,    0, 	  -1,    1, 	   1,   -4
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    7,   -3, 	   3,   -1, 	   2,   -1, 	   4,   -6
+.2byte    7,   -2, 	   5,   -1, 	   3,   -1, 	   3,   -5
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    5,   -8, 	   0,   -4, 	   2,   -3, 	   1,   -8
+.2byte    4,   -6, 	   0,   -4, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   2,   -3, 	  -4,   -3, 	  -1,   -8
+.2byte   -1,   -8, 	   2,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -7,   -8, 	  -2,   -4, 	  -4,   -3, 	  -3,   -8
+.2byte   -6,   -6, 	  -2,   -4, 	  -4,   -2, 	  -1,   -7
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -8,   -3, 	  -4,   -1, 	  -3,   -1, 	  -5,   -6
+.2byte   -8,   -2, 	  -6,   -1, 	  -4,   -1, 	  -4,   -5
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -5,   -1, 	  -4,    0, 	  -2,    0, 	  -5,   -5
+.2byte   -5,    0, 	  -4,    0, 	  -1,    1, 	  -3,   -4
+.2byte   -5,   -2, 	  -4,    0, 	  -3,    0, 	  -2,   -5
+.2byte   -5,   -2, 	  -4,    0, 	  -3,    0, 	  -2,   -4
+.2byte   -1,   -9, 	  -4,   -7, 	   2,   -7, 	  -1,  -10
+.2byte    2,  -10, 	   3,   -6, 	   0,   -5, 	  -1,  -10
+.2byte    4,  -10, 	   5,   -8, 	   4,   -7, 	   0,  -10
+.2byte    0,  -11, 	  -1,   -7, 	   2,   -5, 	  -2,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -4,   -7, 	  -1,  -10
+.2byte   -2,  -12, 	  -1,   -8, 	  -4,   -6, 	   0,  -11
+.2byte   -5,  -10, 	  -6,   -8, 	  -5,   -7, 	  -1,  -10
+.2byte   -4,  -10, 	  -5,   -6, 	  -2,   -5, 	  -1,  -10
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,   -4, 	   2,   -4, 	  -1,   -7
+.2byte   -1,   -2, 	  -2,    0, 	   0,    0, 	  -1,   -4
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    3,   -5, 	   4,   -4, 	   2,   -3, 	   0,   -7
+.2byte    3,   -2, 	   1,    1, 	  -1,    1, 	   1,   -4
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    6,   -8, 	   2,   -4, 	   3,   -4, 	   0,   -8
+.2byte    6,   -4, 	   0,    0, 	  -1,    1, 	  -1,   -5
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    1,  -10, 	   0,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -9
+.2byte   -1,   -9, 	   1,   -1, 	  -3,   -1, 	  -1,   -7
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -3,  -10, 	  -2,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -8,   -8, 	  -4,   -4, 	  -5,   -4, 	  -2,   -8
+.2byte   -8,   -4, 	  -2,    0, 	  -1,    1, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -5,   -5, 	  -6,   -4, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,   -2, 	  -3,    1, 	  -1,    1, 	  -3,   -4
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte   -1,   -1, 	  -4,    0, 	   2,    0, 	  -1,   -5
+.2byte    3,   -1, 	   2,    0, 	   0,    0, 	   3,   -5
+.2byte    5,   -3, 	   1,   -1, 	   0,   -1, 	   2,   -6
+.2byte    4,   -7, 	  -1,   -3, 	   1,   -2, 	   0,   -7
+.2byte   -1,  -10, 	   2,   -2, 	  -4,   -2, 	  -1,   -7
+.2byte   -5,   -7, 	   0,   -3, 	  -2,   -2, 	  -1,   -7
+.2byte   -6,   -3, 	  -2,   -1, 	  -1,   -1, 	  -3,   -6
+.2byte   -4,   -1, 	  -3,    0, 	  -1,    0, 	  -4,   -5
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,   -4, 	   2,   -4, 	  -1,   -7
+.2byte   -1,   -2, 	  -2,    0, 	   0,    0, 	  -1,   -4
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    3,   -5, 	   4,   -4, 	   2,   -3, 	   0,   -7
+.2byte    3,   -2, 	   1,    1, 	  -1,    1, 	   1,   -4
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    6,   -8, 	   2,   -4, 	   3,   -4, 	   0,   -8
+.2byte    6,   -4, 	   0,    0, 	  -1,    1, 	  -1,   -5
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    1,  -10, 	   0,   -6, 	   1,   -5, 	  -3,   -9
+.2byte    2,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -9
+.2byte   -1,   -9, 	   1,   -1, 	  -3,   -1, 	  -1,   -7
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -3,  -10, 	  -2,   -6, 	  -3,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -1,   -2, 	  -1,    0, 	  -1,   -7
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -8,   -8, 	  -4,   -4, 	  -5,   -4, 	  -2,   -8
+.2byte   -8,   -4, 	  -2,    0, 	  -1,    1, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -5,   -5, 	  -6,   -4, 	  -4,   -3, 	  -2,   -7
+.2byte   -5,   -2, 	  -3,    1, 	  -1,    1, 	  -3,   -4
+.2byte   -1,   -1, 	  -4,    0, 	   2,    0, 	  -1,   -5
+.2byte   -4,   -1, 	  -3,    0, 	  -1,    0, 	  -4,   -5
+.2byte   -6,   -3, 	  -2,   -1, 	  -1,   -1, 	  -3,   -6
+.2byte   -5,   -7, 	   0,   -3, 	  -2,   -2, 	  -1,   -7
+.2byte   -1,  -10, 	   2,   -2, 	  -4,   -2, 	  -1,   -7
+.2byte    4,   -7, 	  -1,   -3, 	   1,   -2, 	   0,   -7
+.2byte    5,   -3, 	   1,   -1, 	   0,   -1, 	   2,   -6
+.2byte    3,   -1, 	   2,    0, 	   0,    0, 	   3,   -5
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -5,   -3, 	  -3,   -1, 	  -1,    0, 	  -3,   -5
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -5,   -8, 	   0,   -3, 	  -3,   -2, 	   0,   -7
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte    3,   -8, 	  -2,   -3, 	   1,   -2, 	  -2,   -7
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    3,   -3, 	   1,   -1, 	  -1,    0, 	   1,   -5
+.2byte    5,   -4, 	  -3,   -3, 	  -3,   -1, 	  -1,   -4
+.2byte    6,   -2, 	  -3,   -3, 	  -3,   -1, 	   0,   -4
+.2byte   -6,   -4, 	   2,   -3, 	   2,   -1, 	   0,   -4
+.2byte   -7,   -2, 	   2,   -3, 	   2,   -1, 	  -1,   -4
+.2byte    5,   -4, 	  -3,   -3, 	  -3,   -1, 	  -1,   -4
+.2byte    5,   -5, 	   3,   -2, 	   1,   -1, 	  -1,   -5
+.2byte    4,   -7, 	   3,   -3, 	   3,   -1, 	  -1,   -6
+.2byte    6,   -4, 	   4,   -2, 	   3,   -1, 	  -1,   -5
+.2byte    7,   -6, 	   2,   -2, 	   2,   -1, 	   1,   -6
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   2,   -3, 	  -4,   -3, 	  -1,   -7
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -7
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -1,   -9, 	   3,   -4, 	  -4,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,   -4, 	  -5,   -2, 	   3,   -2, 	  -1,   -5
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte   -1,   -3, 	  -5,   -1, 	   3,   -1, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -5,   -4, 	  -3,   -2, 	   1,   -4, 	   0,   -5
+.2byte   -5,   -5, 	  -2,   -1, 	   2,   -5, 	   0,   -4
+.2byte   -1,   -8, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,   -9, 	   3,   -3, 	  -5,   -3, 	  -1,   -6
+.2byte   -1,   -8, 	   4,   -2, 	  -6,   -2, 	  -1,   -4
+.2byte   -1,   -3, 	  -3,    0, 	   1,    0, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,    0, 	   2,    0, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,    0, 	   2,    0, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,   -2, 	  -3,   -1, 	  -2,   -6
+.2byte   -8,   -4, 	  -4,   -2, 	  -3,   -1, 	  -2,   -5
+.2byte    6,   -6, 	   1,   -2, 	   1,   -1, 	   0,   -6
+.2byte    6,   -4, 	   2,   -2, 	   1,   -1, 	   0,   -5
+.2byte   -1,   -8, 	   3,   -3, 	  -5,   -3, 	  -1,   -5
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -6
+.2byte   -4,   -4, 	  -7,   -3, 	  -2,   -1, 	  -1,   -5
+.2byte   -4,   -2, 	  -7,   -1, 	  -1,   -1, 	   0,   -4
+.2byte   -4,   -4, 	  -1,   -3, 	  -5,   -3, 	   1,   -6
+.2byte   -5,   -3, 	  -4,   -1, 	  -5,   -1, 	   0,   -5
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -6
+.2byte    3,   -4, 	   6,   -3, 	   1,   -1, 	   0,   -5
+.2byte    3,   -2, 	   6,   -1, 	   0,   -1, 	  -1,   -4
+.2byte    3,   -4, 	   0,   -3, 	   4,   -3, 	  -2,   -6
+.2byte    4,   -3, 	   3,   -1, 	   4,   -1, 	  -1,   -5
+.2byte    3,  -10, 	  -4,   -5, 	   2,   -4, 	  -2,   -5
+.2byte    5,   -4, 	  -3,   -3, 	  -3,   -1, 	  -1,   -4
+.2byte    6,   -2, 	  -3,   -3, 	  -3,   -1, 	   0,   -4
+.2byte   -6,   -4, 	   2,   -3, 	   2,   -1, 	   0,   -4
+.2byte   -7,   -2, 	   2,   -3, 	   2,   -1, 	  -1,   -4
+.2byte    5,   -4, 	  -3,   -3, 	  -3,   -1, 	  -1,   -4
+.2byte    6,   -2, 	  -3,   -3, 	  -3,   -1, 	   0,   -4
+.2byte   -6,   -4, 	   2,   -3, 	   2,   -1, 	   0,   -4
+.2byte   -7,   -2, 	   2,   -3, 	   2,   -1, 	  -1,   -4
+sMudkipAnimTable1:
+.4byte sMudkipAnims_1_1
+.4byte sMudkipAnims_1_2
+.4byte sMudkipAnims_1_3
+.4byte sMudkipAnims_1_4
+.4byte sMudkipAnims_1_5
+.4byte sMudkipAnims_1_6
+.4byte sMudkipAnims_1_7
+.4byte sMudkipAnims_1_8
+sMudkipAnimTable2:
+.4byte sMudkipAnims_2_1
+.4byte sMudkipAnims_2_2
+.4byte sMudkipAnims_2_3
+.4byte sMudkipAnims_2_4
+.4byte sMudkipAnims_2_5
+.4byte sMudkipAnims_2_6
+.4byte sMudkipAnims_2_7
+.4byte sMudkipAnims_2_8
+sMudkipAnimTable3:
+.4byte sMudkipAnims_3_1
+.4byte sMudkipAnims_3_2
+.4byte sMudkipAnims_3_3
+.4byte sMudkipAnims_3_4
+.4byte sMudkipAnims_3_5
+.4byte sMudkipAnims_3_6
+.4byte sMudkipAnims_3_7
+.4byte sMudkipAnims_3_8
+sMudkipAnimTable4:
+.4byte sMudkipAnims_4_1
+.4byte sMudkipAnims_4_2
+.4byte sMudkipAnims_4_3
+.4byte sMudkipAnims_4_4
+.4byte sMudkipAnims_4_5
+.4byte sMudkipAnims_4_6
+.4byte sMudkipAnims_4_7
+.4byte sMudkipAnims_4_8
+sMudkipAnimTable5:
+.4byte sMudkipAnims_5_1
+.4byte sMudkipAnims_5_2
+.4byte sMudkipAnims_5_3
+.4byte sMudkipAnims_5_4
+.4byte sMudkipAnims_5_5
+.4byte sMudkipAnims_5_6
+.4byte sMudkipAnims_5_7
+.4byte sMudkipAnims_5_8
+sMudkipAnimTable6:
+.4byte sMudkipAnims_6_1
+.4byte sMudkipAnims_6_1
+.4byte sMudkipAnims_6_1
+.4byte sMudkipAnims_6_1
+.4byte sMudkipAnims_6_1
+.4byte sMudkipAnims_6_1
+.4byte sMudkipAnims_6_1
+.4byte sMudkipAnims_6_1
+sMudkipAnimTable7:
+.4byte sMudkipAnims_7_1
+.4byte sMudkipAnims_7_2
+.4byte sMudkipAnims_7_3
+.4byte sMudkipAnims_7_4
+.4byte sMudkipAnims_7_5
+.4byte sMudkipAnims_7_6
+.4byte sMudkipAnims_7_7
+.4byte sMudkipAnims_7_8
+sMudkipAnimTable8:
+.4byte sMudkipAnims_8_1
+.4byte sMudkipAnims_8_2
+.4byte sMudkipAnims_8_3
+.4byte sMudkipAnims_8_4
+.4byte sMudkipAnims_8_5
+.4byte sMudkipAnims_8_6
+.4byte sMudkipAnims_8_7
+.4byte sMudkipAnims_8_8
+sMudkipAnimTable9:
+.4byte sMudkipAnims_9_1
+.4byte sMudkipAnims_9_2
+.4byte sMudkipAnims_9_3
+.4byte sMudkipAnims_9_4
+.4byte sMudkipAnims_9_5
+.4byte sMudkipAnims_9_6
+.4byte sMudkipAnims_9_7
+.4byte sMudkipAnims_9_8
+sMudkipAnimTable10:
+.4byte sMudkipAnims_10_1
+.4byte sMudkipAnims_10_2
+.4byte sMudkipAnims_10_3
+.4byte sMudkipAnims_10_4
+.4byte sMudkipAnims_10_5
+.4byte sMudkipAnims_10_6
+.4byte sMudkipAnims_10_7
+.4byte sMudkipAnims_10_8
+sMudkipAnimTable11:
+.4byte sMudkipAnims_11_1
+.4byte sMudkipAnims_11_2
+.4byte sMudkipAnims_11_3
+.4byte sMudkipAnims_11_4
+.4byte sMudkipAnims_11_5
+.4byte sMudkipAnims_11_6
+.4byte sMudkipAnims_11_7
+.4byte sMudkipAnims_11_8
+sMudkipAnimTable12:
+.4byte sMudkipAnims_12_1
+.4byte sMudkipAnims_12_2
+.4byte sMudkipAnims_12_3
+.4byte sMudkipAnims_12_4
+.4byte sMudkipAnims_12_5
+.4byte sMudkipAnims_12_6
+.4byte sMudkipAnims_12_7
+.4byte sMudkipAnims_12_8
+sMudkipAnimTable13:
+.4byte sMudkipAnims_13_1
+.4byte sMudkipAnims_13_2
+.4byte sMudkipAnims_13_3
+.4byte sMudkipAnims_13_4
+.4byte sMudkipAnims_13_5
+.4byte sMudkipAnims_13_6
+.4byte sMudkipAnims_13_7
+.4byte sMudkipAnims_13_8
+sMudkipAnimTable14:
+.4byte sMudkipAnims_14_1
+.4byte sMudkipAnims_14_2
+.4byte sMudkipAnims_14_3
+.4byte sMudkipAnims_14_4
+.4byte sMudkipAnims_14_5
+.4byte sMudkipAnims_14_6
+.4byte sMudkipAnims_14_7
+.4byte sMudkipAnims_14_8
+sMudkipAnimTable15:
+.4byte sMudkipAnims_15_1
+.4byte sMudkipAnims_15_2
+.4byte sMudkipAnims_15_3
+.4byte sMudkipAnims_15_4
+.4byte sMudkipAnims_15_5
+.4byte sMudkipAnims_15_6
+.4byte sMudkipAnims_15_7
+.4byte sMudkipAnims_15_8
+sMudkipAnimTable16:
+.4byte sMudkipAnims_16_1
+.4byte sMudkipAnims_16_2
+.4byte sMudkipAnims_16_3
+.4byte sMudkipAnims_16_4
+.4byte sMudkipAnims_16_5
+.4byte sMudkipAnims_16_6
+.4byte sMudkipAnims_16_7
+.4byte sMudkipAnims_16_8
+sMudkipAnimTable17:
+.4byte sMudkipAnims_17_1
+.4byte sMudkipAnims_17_2
+.4byte sMudkipAnims_17_3
+.4byte sMudkipAnims_17_4
+.4byte sMudkipAnims_17_5
+.4byte sMudkipAnims_17_6
+.4byte sMudkipAnims_17_7
+.4byte sMudkipAnims_17_8
+sMudkipAnimTable18:
+.4byte sMudkipAnims_18_1
+.4byte sMudkipAnims_18_2
+.4byte sMudkipAnims_18_3
+.4byte sMudkipAnims_18_4
+.4byte sMudkipAnims_18_5
+.4byte sMudkipAnims_18_6
+.4byte sMudkipAnims_18_7
+.4byte sMudkipAnims_18_8
+sMudkipAnimTable19:
+.4byte sMudkipAnims_19_1
+.4byte sMudkipAnims_19_2
+.4byte sMudkipAnims_19_3
+.4byte sMudkipAnims_19_4
+.4byte sMudkipAnims_19_5
+.4byte sMudkipAnims_19_6
+.4byte sMudkipAnims_19_7
+.4byte sMudkipAnims_19_8
+sMudkipAnimTable20:
+.4byte sMudkipAnims_20_1
+.4byte sMudkipAnims_20_2
+.4byte sMudkipAnims_20_3
+.4byte sMudkipAnims_20_4
+.4byte sMudkipAnims_20_5
+.4byte sMudkipAnims_20_6
+.4byte sMudkipAnims_20_7
+.4byte sMudkipAnims_20_8
+sMudkipAnimTable21:
+.4byte sMudkipAnims_21_1
+.4byte sMudkipAnims_21_2
+.4byte sMudkipAnims_21_3
+.4byte sMudkipAnims_21_4
+.4byte sMudkipAnims_21_5
+.4byte sMudkipAnims_21_6
+.4byte sMudkipAnims_21_7
+.4byte sMudkipAnims_21_8
+sMudkipAnimTable22:
+.4byte sMudkipAnims_22_1
+.4byte sMudkipAnims_22_2
+.4byte sMudkipAnims_22_3
+.4byte sMudkipAnims_22_4
+.4byte sMudkipAnims_22_5
+.4byte sMudkipAnims_22_6
+.4byte sMudkipAnims_22_7
+.4byte sMudkipAnims_22_8
+sMudkipAnimTable23:
+.4byte sMudkipAnims_23_1
+.4byte sMudkipAnims_23_2
+.4byte sMudkipAnims_23_3
+.4byte sMudkipAnims_23_4
+.4byte sMudkipAnims_23_5
+.4byte sMudkipAnims_23_6
+.4byte sMudkipAnims_23_7
+.4byte sMudkipAnims_23_8
+sMudkipAnimTable24:
+.4byte sMudkipAnims_24_1
+.4byte sMudkipAnims_24_2
+.4byte sMudkipAnims_24_3
+.4byte sMudkipAnims_24_4
+.4byte sMudkipAnims_24_5
+.4byte sMudkipAnims_24_6
+.4byte sMudkipAnims_24_7
+.4byte sMudkipAnims_24_8
+sMudkipAnimTable25:
+.4byte sMudkipAnims_25_1
+.4byte sMudkipAnims_25_2
+.4byte sMudkipAnims_25_3
+.4byte sMudkipAnims_25_4
+.4byte sMudkipAnims_25_5
+.4byte sMudkipAnims_25_6
+.4byte sMudkipAnims_25_7
+.4byte sMudkipAnims_25_8
+sMudkipAnimTable26:
+.4byte sMudkipAnims_26_1
+.4byte sMudkipAnims_26_2
+.4byte sMudkipAnims_26_3
+.4byte sMudkipAnims_26_4
+.4byte sMudkipAnims_26_5
+.4byte sMudkipAnims_26_6
+.4byte sMudkipAnims_26_7
+.4byte sMudkipAnims_26_8
+sMudkipAnimTable27:
+.4byte sMudkipAnims_27_1
+.4byte sMudkipAnims_27_1
+.4byte sMudkipAnims_27_1
+.4byte sMudkipAnims_27_1
+.4byte sMudkipAnims_27_1
+.4byte sMudkipAnims_27_1
+.4byte sMudkipAnims_27_1
+.4byte sMudkipAnims_27_1
+sMudkipAnimTable28:
+.4byte sMudkipAnims_28_1
+.4byte sMudkipAnims_28_2
+.4byte sMudkipAnims_28_3
+.4byte sMudkipAnims_28_4
+.4byte sMudkipAnims_28_5
+.4byte sMudkipAnims_28_6
+.4byte sMudkipAnims_28_7
+.4byte sMudkipAnims_28_8
+sAxAnimationsMudkip:
+.4byte sMudkipAnimTable1
+.4byte sMudkipAnimTable2
+.4byte sMudkipAnimTable3
+.4byte sMudkipAnimTable4
+.4byte sMudkipAnimTable5
+.4byte sMudkipAnimTable6
+.4byte sMudkipAnimTable7
+.4byte sMudkipAnimTable8
+.4byte sMudkipAnimTable9
+.4byte sMudkipAnimTable10
+.4byte sMudkipAnimTable11
+.4byte sMudkipAnimTable12
+.4byte sMudkipAnimTable13
+.4byte sMudkipAnimTable14
+.4byte sMudkipAnimTable15
+.4byte sMudkipAnimTable16
+.4byte sMudkipAnimTable17
+.4byte sMudkipAnimTable18
+.4byte sMudkipAnimTable19
+.4byte sMudkipAnimTable20
+.4byte sMudkipAnimTable21
+.4byte sMudkipAnimTable22
+.4byte sMudkipAnimTable23
+.4byte sMudkipAnimTable24
+.4byte sMudkipAnimTable25
+.4byte sMudkipAnimTable26
+.4byte sMudkipAnimTable27
+.4byte sMudkipAnimTable28
+sAxSpritesMudkip:
+.4byte sMudkipSprites1
+.4byte sMudkipSprites2
+.4byte sMudkipSprites3
+.4byte sMudkipSprites4
+.4byte sMudkipSprites5
+.4byte sMudkipSprites6
+.4byte sMudkipSprites7
+.4byte sMudkipSprites8
+.4byte sMudkipSprites9
+.4byte sMudkipSprites10
+.4byte sMudkipSprites11
+.4byte sMudkipSprites12
+.4byte sMudkipSprites13
+.4byte sMudkipSprites14
+.4byte sMudkipSprites15
+.4byte sMudkipSprites16
+.4byte sMudkipSprites17
+.4byte sMudkipSprites18
+.4byte sMudkipSprites19
+.4byte sMudkipSprites20
+.4byte sMudkipSprites21
+.4byte sMudkipSprites22
+.4byte sMudkipSprites23
+.4byte sMudkipSprites24
+.4byte sMudkipSprites25
+.4byte sMudkipSprites26
+.4byte sMudkipSprites27
+.4byte sMudkipSprites28
+.4byte sMudkipSprites29
+.4byte sMudkipSprites30
+.4byte sMudkipSprites31
+.4byte sMudkipSprites32
+.4byte sMudkipSprites33
+.4byte sMudkipSprites34
+.4byte sMudkipSprites35
+.4byte sMudkipSprites36
+.4byte sMudkipSprites37
+.4byte sMudkipSprites38
+.4byte sMudkipSprites39
+.4byte sMudkipSprites40
+.4byte sMudkipSprites41
+.4byte sMudkipSprites42
+.4byte sMudkipSprites43
+.4byte sMudkipSprites44
+.4byte sMudkipSprites45
+.4byte sMudkipSprites46
+.4byte sMudkipSprites47
+.4byte sMudkipSprites48
+.4byte sMudkipSprites49
+.4byte sMudkipSprites50
+.4byte sMudkipSprites51
+.4byte sMudkipSprites52
+.4byte sMudkipSprites53
+.4byte sMudkipSprites54
+.4byte sMudkipSprites55
+.4byte sMudkipSprites56
+.4byte sMudkipSprites57
+.4byte sMudkipSprites58
+.4byte sMudkipSprites59
+.4byte sMudkipSprites60
+sAxMainMudkip:
+ax_main sAxPosesMudkip, sAxAnimationsMudkip, 28, sAxSpritesMudkip, sAxPositionsMudkip

--- a/data/ax/muk.inc
+++ b/data/ax/muk.inc
@@ -1,0 +1,2743 @@
+.global gAxMuk
+gAxMuk:
+ax_siro sAxMainMuk
+sMukPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose4:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose5:
+ax_pose 4, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose6:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose7:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose8:
+ax_pose 7, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose9:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose10:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose11:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose12:
+ax_pose 11, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sMukPose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose14:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose15:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose16:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose17:
+ax_pose 16, 0x01eb, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose18:
+ax_pose 17, 0x01ea, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose19:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose20:
+ax_pose 19, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose21:
+ax_pose 20, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose22:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose23:
+ax_pose 22, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose24:
+ax_pose 23, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose26:
+ax_pose 24, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose27:
+ax_pose 25, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose28:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose29:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose30:
+ax_pose 26, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose31:
+ax_pose 27, 0x01ec, 0x90f4, 0x2c00
+ax_pose_terminator
+sMukPose32:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose33:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose34:
+ax_pose 28, 0x41f6, 0x90ed, 0x2c00
+ax_pose 29, 0x4206, 0x10f5, 0x2c08
+ax_pose 30, 0x01fc, 0x10e5, 0x2c0a
+ax_pose_terminator
+sMukPose35:
+ax_pose 31, 0x01ec, 0x90f6, 0x2c00
+ax_pose_terminator
+sMukPose36:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose37:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose38:
+ax_pose 32, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose39:
+ax_pose 33, 0x01e7, 0x90f3, 0x2c00
+ax_pose_terminator
+sMukPose40:
+ax_pose 11, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sMukPose41:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose42:
+ax_pose 34, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose43:
+ax_pose 35, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose44:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose45:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose46:
+ax_pose 32, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose47:
+ax_pose 33, 0x01e7, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose48:
+ax_pose 17, 0x01ea, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose49:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose50:
+ax_pose 28, 0x41f6, 0x80f2, 0x2c00
+ax_pose 29, 0x4206, 0x00fa, 0x2c08
+ax_pose 30, 0x01fc, 0x0112, 0x2c0a
+ax_pose_terminator
+sMukPose51:
+ax_pose 31, 0x01ec, 0x80e9, 0x2c00
+ax_pose_terminator
+sMukPose52:
+ax_pose 20, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose53:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose54:
+ax_pose 26, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose55:
+ax_pose 27, 0x01ec, 0x80eb, 0x2c00
+ax_pose_terminator
+sMukPose56:
+ax_pose 23, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose57:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose58:
+ax_pose 24, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose59:
+ax_pose 25, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose60:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose61:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose62:
+ax_pose 26, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose63:
+ax_pose 27, 0x01ec, 0x90f4, 0x2c00
+ax_pose_terminator
+sMukPose64:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose65:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose66:
+ax_pose 28, 0x41f6, 0x90ed, 0x2c00
+ax_pose 29, 0x4206, 0x10f5, 0x2c08
+ax_pose 30, 0x01fc, 0x10e5, 0x2c0a
+ax_pose_terminator
+sMukPose67:
+ax_pose 31, 0x01ec, 0x90f6, 0x2c00
+ax_pose_terminator
+sMukPose68:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose69:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose70:
+ax_pose 32, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose71:
+ax_pose 33, 0x01e7, 0x90f3, 0x2c00
+ax_pose_terminator
+sMukPose72:
+ax_pose 11, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sMukPose73:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose74:
+ax_pose 34, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose75:
+ax_pose 35, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose76:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose77:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose78:
+ax_pose 32, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose79:
+ax_pose 33, 0x01e7, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose80:
+ax_pose 17, 0x01ea, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose81:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose82:
+ax_pose 28, 0x41f6, 0x80f2, 0x2c00
+ax_pose 29, 0x4206, 0x00fa, 0x2c08
+ax_pose 30, 0x01fc, 0x0112, 0x2c0a
+ax_pose_terminator
+sMukPose83:
+ax_pose 31, 0x01ec, 0x80e9, 0x2c00
+ax_pose_terminator
+sMukPose84:
+ax_pose 20, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose85:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose86:
+ax_pose 26, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose87:
+ax_pose 27, 0x01ec, 0x80eb, 0x2c00
+ax_pose_terminator
+sMukPose88:
+ax_pose 23, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose89:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose90:
+ax_pose 24, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose91:
+ax_pose 25, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose92:
+ax_pose 36, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose93:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose94:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose95:
+ax_pose 26, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose96:
+ax_pose 27, 0x01ec, 0x90f4, 0x2c00
+ax_pose_terminator
+sMukPose97:
+ax_pose 37, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sMukPose98:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose99:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose100:
+ax_pose 28, 0x41f4, 0x90ed, 0x2c00
+ax_pose 29, 0x4204, 0x10f5, 0x2c08
+ax_pose 30, 0x01fa, 0x10e5, 0x2c0a
+ax_pose_terminator
+sMukPose101:
+ax_pose 31, 0x01ec, 0x90f6, 0x2c00
+ax_pose_terminator
+sMukPose102:
+ax_pose 38, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sMukPose103:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose104:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose105:
+ax_pose 32, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose106:
+ax_pose 33, 0x01e7, 0x90f3, 0x2c00
+ax_pose_terminator
+sMukPose107:
+ax_pose 39, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose108:
+ax_pose 11, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sMukPose109:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose110:
+ax_pose 34, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose111:
+ax_pose 35, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose112:
+ax_pose 40, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose113:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose114:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose115:
+ax_pose 32, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose116:
+ax_pose 33, 0x01e7, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose117:
+ax_pose 39, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose118:
+ax_pose 17, 0x01ea, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose119:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose120:
+ax_pose 28, 0x41f4, 0x80f2, 0x2c00
+ax_pose 29, 0x4204, 0x00fa, 0x2c08
+ax_pose 30, 0x01fa, 0x0112, 0x2c0a
+ax_pose_terminator
+sMukPose121:
+ax_pose 31, 0x01ec, 0x80e9, 0x2c00
+ax_pose_terminator
+sMukPose122:
+ax_pose 38, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose123:
+ax_pose 20, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose124:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose125:
+ax_pose 26, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose126:
+ax_pose 27, 0x01ec, 0x80eb, 0x2c00
+ax_pose_terminator
+sMukPose127:
+ax_pose 37, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sMukPose128:
+ax_pose 23, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose129:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose130:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose131:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose132:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose133:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose134:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose135:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose136:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose137:
+ax_pose 41, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose138:
+ax_pose 42, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose139:
+ax_pose 43, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose140:
+ax_pose 44, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sMukPose141:
+ax_pose 45, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sMukPose142:
+ax_pose 46, 0x01e4, 0x90f2, 0x2c00
+ax_pose_terminator
+sMukPose143:
+ax_pose 47, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sMukPose144:
+ax_pose 46, 0x01e4, 0x80ee, 0x2c00
+ax_pose_terminator
+sMukPose145:
+ax_pose 45, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose146:
+ax_pose 44, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose147:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose148:
+ax_pose 1, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose149:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose150:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose151:
+ax_pose 4, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose152:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose153:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose154:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose155:
+ax_pose 8, 0x01eb, 0x80ee, 0x2c00
+ax_pose_terminator
+sMukPose156:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose157:
+ax_pose 10, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose158:
+ax_pose 11, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sMukPose159:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose160:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose161:
+ax_pose 14, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose162:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose163:
+ax_pose 16, 0x01eb, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose164:
+ax_pose 17, 0x01eb, 0x80ed, 0x2c00
+ax_pose_terminator
+sMukPose165:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose166:
+ax_pose 19, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose167:
+ax_pose 20, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose168:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose169:
+ax_pose 22, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose170:
+ax_pose 23, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose171:
+ax_pose 24, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose172:
+ax_pose 26, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose173:
+ax_pose 28, 0x41f6, 0x80f2, 0x2c00
+ax_pose 29, 0x4206, 0x00fa, 0x2c08
+ax_pose 30, 0x01fc, 0x0112, 0x2c0a
+ax_pose_terminator
+sMukPose174:
+ax_pose 32, 0x01f1, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose175:
+ax_pose 34, 0x01f1, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose176:
+ax_pose 32, 0x01f1, 0x90f0, 0x2c00
+ax_pose_terminator
+sMukPose177:
+ax_pose 28, 0x41f6, 0x90ed, 0x2c00
+ax_pose 29, 0x4206, 0x10f5, 0x2c08
+ax_pose 30, 0x01fc, 0x10e5, 0x2c0a
+ax_pose_terminator
+sMukPose178:
+ax_pose 26, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sMukPose179:
+ax_pose 36, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose180:
+ax_pose 37, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sMukPose181:
+ax_pose 38, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose182:
+ax_pose 39, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sMukPose183:
+ax_pose 40, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose184:
+ax_pose 39, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose185:
+ax_pose 38, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose186:
+ax_pose 37, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sMukPose187:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose188:
+ax_pose 25, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sMukPose189:
+ax_pose 24, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose190:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose191:
+ax_pose 27, 0x01ec, 0x90f4, 0x2c00
+ax_pose_terminator
+sMukPose192:
+ax_pose 26, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose193:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose194:
+ax_pose 31, 0x01ec, 0x90f6, 0x2c00
+ax_pose_terminator
+sMukPose195:
+ax_pose 28, 0x41f4, 0x90ef, 0x2c00
+ax_pose 29, 0x4204, 0x10f7, 0x2c08
+ax_pose 30, 0x01fa, 0x10e7, 0x2c0a
+ax_pose_terminator
+sMukPose196:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose197:
+ax_pose 33, 0x01e7, 0x90f3, 0x2c00
+ax_pose_terminator
+sMukPose198:
+ax_pose 32, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sMukPose199:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose200:
+ax_pose 35, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose201:
+ax_pose 34, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose202:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose203:
+ax_pose 33, 0x01e7, 0x80ec, 0x2c00
+ax_pose_terminator
+sMukPose204:
+ax_pose 32, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose205:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose206:
+ax_pose 31, 0x01ec, 0x80e9, 0x2c00
+ax_pose_terminator
+sMukPose207:
+ax_pose 28, 0x41f4, 0x80f0, 0x2c00
+ax_pose 29, 0x4204, 0x00f8, 0x2c08
+ax_pose 30, 0x01fa, 0x0110, 0x2c0a
+ax_pose_terminator
+sMukPose208:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose209:
+ax_pose 27, 0x01ec, 0x80eb, 0x2c00
+ax_pose_terminator
+sMukPose210:
+ax_pose 26, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose211:
+ax_pose 25, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose212:
+ax_pose 27, 0x01ec, 0x80eb, 0x2c00
+ax_pose_terminator
+sMukPose213:
+ax_pose 31, 0x01ec, 0x80e9, 0x2c00
+ax_pose_terminator
+sMukPose214:
+ax_pose 33, 0x01e7, 0x80eb, 0x2c00
+ax_pose_terminator
+sMukPose215:
+ax_pose 35, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose216:
+ax_pose 33, 0x01e7, 0x90f4, 0x2c00
+ax_pose_terminator
+sMukPose217:
+ax_pose 31, 0x01ec, 0x90f6, 0x2c00
+ax_pose_terminator
+sMukPose218:
+ax_pose 27, 0x01ec, 0x90f4, 0x2c00
+ax_pose_terminator
+sMukPose219:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose220:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose221:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMukPose222:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose223:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMukPose224:
+ax_pose 9, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose225:
+ax_pose 6, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMukPose226:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+.align 2
+sMukAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 1,
+ax_anim 10, 0, 2, 0, 1, 0, 2,
+ax_anim 8, 0, 1, 0, 1, 0, 1,
+ax_anim_terminator
+sMukAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 1, 1, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 0, 0,
+ax_anim_terminator
+sMukAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 1, 0,
+ax_anim 10, 0, 8, 1, 0, 2, 0,
+ax_anim 8, 0, 7, 1, 0, 1, 0,
+ax_anim_terminator
+sMukAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 1, -1,
+ax_anim 6, 0, 11, 0, 0, 2, -2,
+ax_anim 10, 0, 11, 1, -1, 3, -3,
+ax_anim 8, 0, 10, 1, -1, 2, -2,
+ax_anim_terminator
+sMukAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, -1,
+ax_anim 6, 0, 14, 0, 0, 0, -2,
+ax_anim 10, 0, 14, 0, -1, 0, -3,
+ax_anim 8, 0, 13, 0, -1, 0, -2,
+ax_anim_terminator
+sMukAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, -1, -1,
+ax_anim 6, 0, 17, 0, 0, -2, -2,
+ax_anim 10, 0, 17, -1, -1, -3, -3,
+ax_anim 8, 0, 16, -1, -1, -2, -2,
+ax_anim_terminator
+sMukAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 0, -1, 0,
+ax_anim 10, 0, 20, -1, 0, -2, 0,
+ax_anim 8, 0, 19, -1, 0, -1, 0,
+ax_anim_terminator
+sMukAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 10, 0, 23, -1, 1, 0, 0,
+ax_anim 8, 0, 22, -1, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -3, 0, -3,
+ax_anim 1, 0, 27, 0, -1, 0, -1,
+ax_anim 1, 0, 25, 0, 2, 0, 2,
+ax_anim 2, 2, 25, 0, 7, 0, 7,
+ax_anim 2, 0, 25, 0, 14, 0, 14,
+ax_anim 2, 1, 25, 1, 14, 1, 14,
+ax_anim 2, 0, 25, 0, 14, 0, 14,
+ax_anim 2, 0, 25, 1, 14, 1, 14,
+ax_anim 2, 0, 25, 0, 14, 0, 14,
+ax_anim 2, 0, 27, 0, 13, 0, 13,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sMukAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 4, 0, 30, -3, -3, -3, -3,
+ax_anim 1, 0, 31, -1, -1, -1, -1,
+ax_anim 1, 0, 29, 2, 2, 2, 2,
+ax_anim 2, 2, 29, 7, 7, 7, 7,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 1, 29, 19, 16, 19, 16,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 0, 29, 19, 16, 19, 16,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 0, 31, 13, 13, 13, 13,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sMukAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -3, 0, -3, 0,
+ax_anim 1, 0, 35, -1, 0, -1, 0,
+ax_anim 1, 0, 33, 6, 0, 6, 0,
+ax_anim 2, 2, 33, 10, 0, 10, 0,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 1, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sMukAnims_2_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 4, 0, 38, -3, 3, -3, 3,
+ax_anim 1, 0, 39, -1, 1, -1, 1,
+ax_anim 1, 0, 37, 6, -8, 6, -8,
+ax_anim 2, 2, 37, 10, -13, 10, -13,
+ax_anim 2, 0, 37, 17, -24, 17, -24,
+ax_anim 2, 1, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 17, -24, 17, -24,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 17, -24, 17, -24,
+ax_anim 2, 0, 39, 10, -14, 10, -14,
+ax_anim 2, 0, 36, 4, -4, 4, -4,
+ax_anim_terminator
+sMukAnims_2_5:
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 4, 0, 42, 0, 3, 0, 3,
+ax_anim 1, 0, 43, 0, 3, 0, 3,
+ax_anim 1, 0, 41, 0, -10, 0, -10,
+ax_anim 2, 2, 41, 0, -13, 0, -13,
+ax_anim 2, 0, 41, 0, -24, 0, -24,
+ax_anim 2, 1, 41, 1, -24, 1, -24,
+ax_anim 2, 0, 41, 0, -24, 0, -24,
+ax_anim 2, 0, 41, 1, -24, 1, -24,
+ax_anim 2, 0, 41, 0, -24, 0, -24,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sMukAnims_2_6:
+ax_anim 2, 0, 46, 1, 1, 1, 1,
+ax_anim 4, 0, 46, 3, 3, 3, 3,
+ax_anim 1, 0, 47, 1, 1, 1, 1,
+ax_anim 1, 0, 45, -6, -8, -6, -8,
+ax_anim 2, 2, 45, -10, -13, -10, -13,
+ax_anim 2, 0, 45, -17, -24, -17, -24,
+ax_anim 2, 1, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -17, -24, -17, -24,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -17, -24, -17, -24,
+ax_anim 2, 0, 47, -10, -14, -10, -14,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim_terminator
+sMukAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 4, 0, 50, 3, 0, 3, 0,
+ax_anim 1, 0, 51, 1, 0, 1, 0,
+ax_anim 1, 0, 49, -6, 0, -6, 0,
+ax_anim 2, 2, 49, -10, 0, -10, 0,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 1, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sMukAnims_2_8:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 4, 0, 54, 3, -3, 3, -3,
+ax_anim 1, 0, 55, 1, -1, 1, -1,
+ax_anim 1, 0, 53, -2, 2, -2, 2,
+ax_anim 2, 2, 53, -7, 7, -7, 7,
+ax_anim 2, 0, 53, -18, 17, -18, 17,
+ax_anim 2, 1, 53, -19, 16, -19, 16,
+ax_anim 2, 0, 53, -18, 17, -18, 17,
+ax_anim 2, 0, 53, -19, 16, -19, 16,
+ax_anim 2, 0, 53, -18, 17, -18, 17,
+ax_anim 2, 0, 55, -13, 13, -13, 13,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMukAnims_3_1:
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 4, 0, 58, 0, -3, 0, -3,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 0, 57, 0, 2, 0, 2,
+ax_anim 2, 2, 57, 0, 7, 0, 7,
+ax_anim 2, 0, 57, 0, 14, 0, 14,
+ax_anim 2, 1, 57, 1, 14, 1, 14,
+ax_anim 2, 0, 57, 0, 14, 0, 14,
+ax_anim 2, 0, 57, 1, 14, 1, 14,
+ax_anim 2, 0, 57, 0, 14, 0, 14,
+ax_anim 2, 0, 59, 0, 13, 0, 13,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sMukAnims_3_2:
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 4, 0, 62, -3, -3, -3, -3,
+ax_anim 1, 0, 63, -1, -1, -1, -1,
+ax_anim 1, 0, 61, 2, 2, 2, 2,
+ax_anim 2, 2, 61, 7, 7, 7, 7,
+ax_anim 2, 0, 61, 18, 17, 18, 17,
+ax_anim 2, 1, 61, 19, 16, 19, 16,
+ax_anim 2, 0, 61, 18, 17, 18, 17,
+ax_anim 2, 0, 61, 19, 16, 19, 16,
+ax_anim 2, 0, 61, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 13, 13, 13, 13,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sMukAnims_3_3:
+ax_anim 2, 0, 66, -1, 0, -1, 0,
+ax_anim 4, 0, 66, -3, 0, -3, 0,
+ax_anim 1, 0, 67, -1, 0, -1, 0,
+ax_anim 1, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 2, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 1, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 0, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sMukAnims_3_4:
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim 4, 0, 70, -3, 3, -3, 3,
+ax_anim 1, 0, 71, -1, 1, -1, 1,
+ax_anim 1, 0, 69, 6, -8, 6, -8,
+ax_anim 2, 2, 69, 10, -13, 10, -13,
+ax_anim 2, 0, 69, 17, -24, 17, -24,
+ax_anim 2, 1, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 17, -24, 17, -24,
+ax_anim 2, 0, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 17, -24, 17, -24,
+ax_anim 2, 0, 71, 10, -14, 10, -14,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sMukAnims_3_5:
+ax_anim 2, 0, 74, 0, 1, 0, 1,
+ax_anim 4, 0, 74, 0, 3, 0, 3,
+ax_anim 1, 0, 75, 0, 3, 0, 3,
+ax_anim 1, 0, 73, 0, -10, 0, -10,
+ax_anim 2, 2, 73, 0, -13, 0, -13,
+ax_anim 2, 0, 73, 0, -24, 0, -24,
+ax_anim 2, 1, 73, 1, -24, 1, -24,
+ax_anim 2, 0, 73, 0, -24, 0, -24,
+ax_anim 2, 0, 73, 1, -24, 1, -24,
+ax_anim 2, 0, 73, 0, -24, 0, -24,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sMukAnims_3_6:
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim 4, 0, 78, 3, 3, 3, 3,
+ax_anim 1, 0, 79, 1, 1, 1, 1,
+ax_anim 1, 0, 77, -6, -8, -6, -8,
+ax_anim 2, 2, 77, -10, -13, -10, -13,
+ax_anim 2, 0, 77, -17, -24, -17, -24,
+ax_anim 2, 1, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -17, -24, -17, -24,
+ax_anim 2, 0, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -17, -24, -17, -24,
+ax_anim 2, 0, 79, -10, -14, -10, -14,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim_terminator
+sMukAnims_3_7:
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 4, 0, 82, 3, 0, 3, 0,
+ax_anim 1, 0, 83, 1, 0, 1, 0,
+ax_anim 1, 0, 81, -6, 0, -6, 0,
+ax_anim 2, 2, 81, -10, 0, -10, 0,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 1, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 0, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sMukAnims_3_8:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 4, 0, 86, 3, -3, 3, -3,
+ax_anim 1, 0, 87, 1, -1, 1, -1,
+ax_anim 1, 0, 85, -2, 2, -2, 2,
+ax_anim 2, 2, 85, -7, 7, -7, 7,
+ax_anim 2, 0, 85, -18, 17, -18, 17,
+ax_anim 2, 1, 85, -19, 16, -19, 16,
+ax_anim 2, 0, 85, -18, 17, -18, 17,
+ax_anim 2, 0, 85, -19, 16, -19, 16,
+ax_anim 2, 0, 85, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -13, 13, -13, 13,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sMukAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 6, 0, 88, 0, -4, 0, -4,
+ax_anim 1, 2, 92, 0, -3, 0, -3,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 0, 7, 0, 7,
+ax_anim 2, 0, 91, 1, 7, 1, 7,
+ax_anim 2, 1, 91, 0, 7, 0, 7,
+ax_anim 2, 0, 91, 1, 7, 1, 7,
+ax_anim 2, 0, 91, 0, 7, 0, 7,
+ax_anim 2, 0, 90, 0, 7, 0, 7,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sMukAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 0, 93, -4, -4, -4, -4,
+ax_anim 1, 2, 97, -3, -3, -3, -3,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 0, 96, 7, 7, 7, 7,
+ax_anim 2, 0, 96, 8, 6, 8, 6,
+ax_anim 2, 1, 96, 7, 7, 7, 7,
+ax_anim 2, 0, 96, 8, 6, 8, 6,
+ax_anim 2, 0, 96, 7, 7, 7, 7,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sMukAnims_4_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 6, 0, 98, -7, 0, -7, 0,
+ax_anim 1, 2, 102, -7, 0, -7, 0,
+ax_anim 1, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 99, 4, 0, 4, 0,
+ax_anim 2, 0, 101, 7, 0, 7, 0,
+ax_anim 2, 0, 101, 7, -1, 7, -1,
+ax_anim 2, 1, 101, 7, 0, 7, 0,
+ax_anim 2, 0, 101, 7, -1, 7, -1,
+ax_anim 2, 0, 101, 7, 0, 7, 0,
+ax_anim 2, 0, 100, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sMukAnims_4_4:
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 6, 0, 103, -6, 6, -6, 6,
+ax_anim 1, 2, 107, -5, 5, -5, 5,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 4, -4, 4, -4,
+ax_anim 2, 0, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 106, 8, -6, 8, -6,
+ax_anim 2, 1, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 106, 8, -6, 8, -6,
+ax_anim 2, 0, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 105, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sMukAnims_4_5:
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim 6, 0, 108, 0, 7, 0, 7,
+ax_anim 1, 2, 112, 0, 7, 0, 7,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, -4,
+ax_anim 2, 0, 111, 0, -7, 0, -7,
+ax_anim 2, 0, 111, 0, -6, 0, -6,
+ax_anim 2, 1, 111, 0, -7, 0, -7,
+ax_anim 2, 0, 111, 0, -6, 0, -6,
+ax_anim 2, 0, 111, 0, -7, 0, -7,
+ax_anim 2, 0, 110, 0, -5, 0, -5,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim_terminator
+sMukAnims_4_6:
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 6, 0, 113, 6, 6, 6, 6,
+ax_anim 1, 2, 117, 5, 5, 5, 5,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -4, -4, -4, -4,
+ax_anim 2, 0, 116, -7, -7, -7, -7,
+ax_anim 2, 0, 116, -8, -6, -8, -6,
+ax_anim 2, 1, 116, -7, -7, -7, -7,
+ax_anim 2, 0, 116, -8, -6, -8, -6,
+ax_anim 2, 0, 116, -7, -7, -7, -7,
+ax_anim 2, 0, 115, -5, -5, -5, -5,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sMukAnims_4_7:
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 6, 0, 118, 7, 0, 7, 0,
+ax_anim 1, 2, 122, 7, 0, 7, 0,
+ax_anim 1, 0, 119, -2, 0, -2, 0,
+ax_anim 2, 0, 119, -4, 0, -4, 0,
+ax_anim 2, 0, 121, -7, 0, -7, 0,
+ax_anim 2, 0, 121, -7, -1, -7, -1,
+ax_anim 2, 1, 121, -7, 0, -7, 0,
+ax_anim 2, 0, 121, -7, -1, -7, -1,
+ax_anim 2, 0, 121, -7, 0, -7, 0,
+ax_anim 2, 0, 120, -5, 0, -5, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sMukAnims_4_8:
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 6, 0, 123, 4, -4, 4, -4,
+ax_anim 1, 2, 127, 3, -3, 3, -3,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -4, 4, -4, 4,
+ax_anim 2, 0, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 126, -8, 6, -8, 6,
+ax_anim 2, 1, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 126, -8, 6, -8, 6,
+ax_anim 2, 0, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 125, -5, 5, -5, 5,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sMukAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sMukAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sMukAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sMukAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sMukAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sMukAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sMukAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sMukAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sMukAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 30, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 30, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 30, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 30, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 8, 8, 8,
+ax_anim 2, 0, 173, 7, 12, 7, 12,
+ax_anim 3, 0, 174, 0, 14, 0, 14,
+ax_anim 2, 3, 175, -7, 12, -7, 12,
+ax_anim 2, 0, 176, -8, 8, -8, 8,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 19, 10, 19, 10,
+ax_anim 3, 0, 173, 20, 15, 20, 15,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 18, -2, 18, -2,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -24, 11, -24,
+ax_anim 3, 0, 171, 20, -25, 20, -25,
+ax_anim 2, 3, 172, 20, -15, 20, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -21, -7, -21,
+ax_anim 3, 0, 170, 0, -26, 0, -26,
+ax_anim 2, 3, 171, 7, -21, 7, -21,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -24, -11, -24,
+ax_anim 3, 0, 177, -20, -25, -20, -25,
+ax_anim 2, 3, 176, -20, -15, -20, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -18, -2, -18, -2,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -19, 10, -19, 10,
+ax_anim 3, 0, 175, -20, 15, -20, 15,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -27, 0, 0,
+ax_anim 3, 0, 188, 0, -25, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -27, 0, 0,
+ax_anim 3, 0, 191, 0, -25, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -27, 0, 0,
+ax_anim 3, 0, 194, 0, -25, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -24, 0, 0,
+ax_anim 3, 0, 197, 0, -22, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -24, 0, 0,
+ax_anim 3, 0, 203, 0, -22, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -27, 0, 0,
+ax_anim 3, 0, 206, 0, -25, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -27, 0, 0,
+ax_anim 3, 0, 209, 0, -25, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMukAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sMukAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sMukGfx1:
+.incbin "baserom.gba", 0x8CCC90, 0x200
+sMukSprites1:
+ax_sprite sMukGfx1, 0x200
+ax_sprite_terminator
+sMukGfx2:
+.incbin "baserom.gba", 0x8CCEA0, 0x200
+sMukSprites2:
+ax_sprite sMukGfx2, 0x200
+ax_sprite_terminator
+sMukGfx3:
+.incbin "baserom.gba", 0x8CD0B0, 0x200
+sMukSprites3:
+ax_sprite sMukGfx3, 0x200
+ax_sprite_terminator
+sMukGfx4:
+.incbin "baserom.gba", 0x8CD2C0, 0x200
+sMukSprites4:
+ax_sprite sMukGfx4, 0x200
+ax_sprite_terminator
+sMukGfx5:
+.incbin "baserom.gba", 0x8CD4D0, 0x200
+sMukSprites5:
+ax_sprite sMukGfx5, 0x200
+ax_sprite_terminator
+sMukGfx6:
+.incbin "baserom.gba", 0x8CD6E0, 0x200
+sMukSprites6:
+ax_sprite sMukGfx6, 0x200
+ax_sprite_terminator
+sMukGfx7:
+.incbin "baserom.gba", 0x8CD8F0, 0x200
+sMukSprites7:
+ax_sprite sMukGfx7, 0x200
+ax_sprite_terminator
+sMukGfx8:
+.incbin "baserom.gba", 0x8CDB00, 0x200
+sMukSprites8:
+ax_sprite sMukGfx8, 0x200
+ax_sprite_terminator
+sMukGfx9:
+.incbin "baserom.gba", 0x8CDD10, 0x200
+sMukSprites9:
+ax_sprite sMukGfx9, 0x200
+ax_sprite_terminator
+sMukGfx10:
+.incbin "baserom.gba", 0x8CDF20, 0x200
+sMukSprites10:
+ax_sprite sMukGfx10, 0x200
+ax_sprite_terminator
+sMukGfx11:
+.incbin "baserom.gba", 0x8CE130, 0x200
+sMukSprites11:
+ax_sprite sMukGfx11, 0x200
+ax_sprite_terminator
+sMukGfx12:
+.incbin "baserom.gba", 0x8CE340, 0x200
+sMukSprites12:
+ax_sprite sMukGfx12, 0x200
+ax_sprite_terminator
+sMukGfx13:
+.incbin "baserom.gba", 0x8CE550, 0x200
+sMukSprites13:
+ax_sprite sMukGfx13, 0x200
+ax_sprite_terminator
+sMukGfx14:
+.incbin "baserom.gba", 0x8CE760, 0x200
+sMukSprites14:
+ax_sprite sMukGfx14, 0x200
+ax_sprite_terminator
+sMukGfx15:
+.incbin "baserom.gba", 0x8CE970, 0x200
+sMukSprites15:
+ax_sprite sMukGfx15, 0x200
+ax_sprite_terminator
+sMukGfx16:
+.incbin "baserom.gba", 0x8CEB80, 0x200
+sMukSprites16:
+ax_sprite sMukGfx16, 0x200
+ax_sprite_terminator
+sMukGfx17:
+.incbin "baserom.gba", 0x8CED90, 0x200
+sMukSprites17:
+ax_sprite sMukGfx17, 0x200
+ax_sprite_terminator
+sMukGfx18:
+.incbin "baserom.gba", 0x8CEFA0, 0x200
+sMukSprites18:
+ax_sprite sMukGfx18, 0x200
+ax_sprite_terminator
+sMukGfx19:
+.incbin "baserom.gba", 0x8CF1B0, 0x200
+sMukSprites19:
+ax_sprite sMukGfx19, 0x200
+ax_sprite_terminator
+sMukGfx20:
+.incbin "baserom.gba", 0x8CF3C0, 0x200
+sMukSprites20:
+ax_sprite sMukGfx20, 0x200
+ax_sprite_terminator
+sMukGfx21:
+.incbin "baserom.gba", 0x8CF5D0, 0x200
+sMukSprites21:
+ax_sprite sMukGfx21, 0x200
+ax_sprite_terminator
+sMukGfx22:
+.incbin "baserom.gba", 0x8CF7E0, 0x200
+sMukSprites22:
+ax_sprite sMukGfx22, 0x200
+ax_sprite_terminator
+sMukGfx23:
+.incbin "baserom.gba", 0x8CF9F0, 0x200
+sMukSprites23:
+ax_sprite sMukGfx23, 0x200
+ax_sprite_terminator
+sMukGfx24:
+.incbin "baserom.gba", 0x8CFC00, 0x200
+sMukSprites24:
+ax_sprite sMukGfx24, 0x200
+ax_sprite_terminator
+sMukGfx25:
+.incbin "baserom.gba", 0x8CFE10, 0x40
+sMukGfx25_1:
+.incbin "baserom.gba", 0x8CFE50, 0x40
+sMukGfx25_2:
+.incbin "baserom.gba", 0x8CFE90, 0x100
+sMukSprites25:
+ax_sprite 0, 0x20
+ax_sprite sMukGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMukGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMukGfx25_2, 0x100
+ax_sprite_terminator
+sMukGfx26:
+.incbin "baserom.gba", 0x8CFFC8, 0x160
+sMukGfx26_1:
+.incbin "baserom.gba", 0x8D0128, 0x40
+sMukSprites26:
+ax_sprite sMukGfx26, 0x160
+ax_sprite 0, 0x20
+ax_sprite sMukGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMukGfx27:
+.incbin "baserom.gba", 0x8D0190, 0x180
+sMukSprites27:
+ax_sprite 0, 0x80
+ax_sprite sMukGfx27, 0x180
+ax_sprite_terminator
+sMukGfx28:
+.incbin "baserom.gba", 0x8D0328, 0x100
+sMukGfx28_1:
+.incbin "baserom.gba", 0x8D0428, 0x60
+sMukGfx28_2:
+.incbin "baserom.gba", 0x8D0488, 0x20
+sMukSprites28:
+ax_sprite sMukGfx28, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMukGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMukGfx28_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMukGfx29:
+.incbin "baserom.gba", 0x8D04E0, 0x100
+sMukSprites29:
+ax_sprite sMukGfx29, 0x100
+ax_sprite_terminator
+sMukGfx30:
+.incbin "baserom.gba", 0x8D05F0, 0x40
+sMukSprites30:
+ax_sprite sMukGfx30, 0x40
+ax_sprite_terminator
+sMukGfx31:
+.incbin "baserom.gba", 0x8D0640, 0x20
+sMukSprites31:
+ax_sprite sMukGfx31, 0x20
+ax_sprite_terminator
+sMukGfx32:
+.incbin "baserom.gba", 0x8D0670, 0x60
+sMukGfx32_1:
+.incbin "baserom.gba", 0x8D06D0, 0x60
+sMukGfx32_2:
+.incbin "baserom.gba", 0x8D0730, 0x60
+sMukSprites32:
+ax_sprite 0, 0x20
+ax_sprite sMukGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMukGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMukGfx32_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMukGfx33:
+.incbin "baserom.gba", 0x8D07D0, 0x180
+sMukGfx33_1:
+.incbin "baserom.gba", 0x8D0950, 0x60
+sMukSprites33:
+ax_sprite sMukGfx33, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMukGfx33_1, 0x60
+ax_sprite_terminator
+sMukGfx34:
+.incbin "baserom.gba", 0x8D09D0, 0xC0
+sMukGfx34_1:
+.incbin "baserom.gba", 0x8D0A90, 0x60
+sMukGfx34_2:
+.incbin "baserom.gba", 0x8D0AF0, 0x60
+sMukSprites34:
+ax_sprite 0, 0x40
+ax_sprite sMukGfx34, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sMukGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMukGfx34_2, 0x60
+ax_sprite_terminator
+sMukGfx35:
+.incbin "baserom.gba", 0x8D0B88, 0x180
+sMukGfx35_1:
+.incbin "baserom.gba", 0x8D0D08, 0x40
+sMukSprites35:
+ax_sprite sMukGfx35, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMukGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMukGfx36:
+.incbin "baserom.gba", 0x8D0D70, 0x180
+sMukSprites36:
+ax_sprite 0, 0x80
+ax_sprite sMukGfx36, 0x180
+ax_sprite_terminator
+sMukGfx37:
+.incbin "baserom.gba", 0x8D0F08, 0x180
+sMukSprites37:
+ax_sprite 0, 0x80
+ax_sprite sMukGfx37, 0x180
+ax_sprite_terminator
+sMukGfx38:
+.incbin "baserom.gba", 0x8D10A0, 0x180
+sMukSprites38:
+ax_sprite 0, 0x80
+ax_sprite sMukGfx38, 0x180
+ax_sprite_terminator
+sMukGfx39:
+.incbin "baserom.gba", 0x8D1238, 0x60
+sMukGfx39_1:
+.incbin "baserom.gba", 0x8D1298, 0x100
+sMukGfx39_2:
+.incbin "baserom.gba", 0x8D1398, 0x40
+sMukSprites39:
+ax_sprite sMukGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMukGfx39_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMukGfx39_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMukGfx40:
+.incbin "baserom.gba", 0x8D1410, 0x60
+sMukGfx40_1:
+.incbin "baserom.gba", 0x8D1470, 0x100
+sMukGfx40_2:
+.incbin "baserom.gba", 0x8D1570, 0x60
+sMukSprites40:
+ax_sprite sMukGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMukGfx40_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMukGfx40_2, 0x60
+ax_sprite_terminator
+sMukGfx41:
+.incbin "baserom.gba", 0x8D1600, 0x180
+sMukGfx41_1:
+.incbin "baserom.gba", 0x8D1780, 0x40
+sMukSprites41:
+ax_sprite sMukGfx41, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMukGfx41_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMukGfx42:
+.incbin "baserom.gba", 0x8D17E8, 0x200
+sMukSprites42:
+ax_sprite sMukGfx42, 0x200
+ax_sprite_terminator
+sMukGfx43:
+.incbin "baserom.gba", 0x8D19F8, 0x200
+sMukSprites43:
+ax_sprite sMukGfx43, 0x200
+ax_sprite_terminator
+sMukGfx44:
+.incbin "baserom.gba", 0x8D1C08, 0x200
+sMukSprites44:
+ax_sprite sMukGfx44, 0x200
+ax_sprite_terminator
+sMukGfx45:
+.incbin "baserom.gba", 0x8D1E18, 0x200
+sMukSprites45:
+ax_sprite sMukGfx45, 0x200
+ax_sprite_terminator
+sMukGfx46:
+.incbin "baserom.gba", 0x8D2028, 0x200
+sMukSprites46:
+ax_sprite sMukGfx46, 0x200
+ax_sprite_terminator
+sMukGfx47:
+.incbin "baserom.gba", 0x8D2238, 0x200
+sMukSprites47:
+ax_sprite sMukGfx47, 0x200
+ax_sprite_terminator
+sMukGfx48:
+.incbin "baserom.gba", 0x8D2448, 0x200
+sMukSprites48:
+ax_sprite sMukGfx48, 0x200
+ax_sprite_terminator
+sAxPosesMuk:
+.4byte sMukPose1
+.4byte sMukPose2
+.4byte sMukPose3
+.4byte sMukPose4
+.4byte sMukPose5
+.4byte sMukPose6
+.4byte sMukPose7
+.4byte sMukPose8
+.4byte sMukPose9
+.4byte sMukPose10
+.4byte sMukPose11
+.4byte sMukPose12
+.4byte sMukPose13
+.4byte sMukPose14
+.4byte sMukPose15
+.4byte sMukPose16
+.4byte sMukPose17
+.4byte sMukPose18
+.4byte sMukPose19
+.4byte sMukPose20
+.4byte sMukPose21
+.4byte sMukPose22
+.4byte sMukPose23
+.4byte sMukPose24
+.4byte sMukPose25
+.4byte sMukPose26
+.4byte sMukPose27
+.4byte sMukPose28
+.4byte sMukPose29
+.4byte sMukPose30
+.4byte sMukPose31
+.4byte sMukPose32
+.4byte sMukPose33
+.4byte sMukPose34
+.4byte sMukPose35
+.4byte sMukPose36
+.4byte sMukPose37
+.4byte sMukPose38
+.4byte sMukPose39
+.4byte sMukPose40
+.4byte sMukPose41
+.4byte sMukPose42
+.4byte sMukPose43
+.4byte sMukPose44
+.4byte sMukPose45
+.4byte sMukPose46
+.4byte sMukPose47
+.4byte sMukPose48
+.4byte sMukPose49
+.4byte sMukPose50
+.4byte sMukPose51
+.4byte sMukPose52
+.4byte sMukPose53
+.4byte sMukPose54
+.4byte sMukPose55
+.4byte sMukPose56
+.4byte sMukPose57
+.4byte sMukPose58
+.4byte sMukPose59
+.4byte sMukPose60
+.4byte sMukPose61
+.4byte sMukPose62
+.4byte sMukPose63
+.4byte sMukPose64
+.4byte sMukPose65
+.4byte sMukPose66
+.4byte sMukPose67
+.4byte sMukPose68
+.4byte sMukPose69
+.4byte sMukPose70
+.4byte sMukPose71
+.4byte sMukPose72
+.4byte sMukPose73
+.4byte sMukPose74
+.4byte sMukPose75
+.4byte sMukPose76
+.4byte sMukPose77
+.4byte sMukPose78
+.4byte sMukPose79
+.4byte sMukPose80
+.4byte sMukPose81
+.4byte sMukPose82
+.4byte sMukPose83
+.4byte sMukPose84
+.4byte sMukPose85
+.4byte sMukPose86
+.4byte sMukPose87
+.4byte sMukPose88
+.4byte sMukPose89
+.4byte sMukPose90
+.4byte sMukPose91
+.4byte sMukPose92
+.4byte sMukPose93
+.4byte sMukPose94
+.4byte sMukPose95
+.4byte sMukPose96
+.4byte sMukPose97
+.4byte sMukPose98
+.4byte sMukPose99
+.4byte sMukPose100
+.4byte sMukPose101
+.4byte sMukPose102
+.4byte sMukPose103
+.4byte sMukPose104
+.4byte sMukPose105
+.4byte sMukPose106
+.4byte sMukPose107
+.4byte sMukPose108
+.4byte sMukPose109
+.4byte sMukPose110
+.4byte sMukPose111
+.4byte sMukPose112
+.4byte sMukPose113
+.4byte sMukPose114
+.4byte sMukPose115
+.4byte sMukPose116
+.4byte sMukPose117
+.4byte sMukPose118
+.4byte sMukPose119
+.4byte sMukPose120
+.4byte sMukPose121
+.4byte sMukPose122
+.4byte sMukPose123
+.4byte sMukPose124
+.4byte sMukPose125
+.4byte sMukPose126
+.4byte sMukPose127
+.4byte sMukPose128
+.4byte sMukPose129
+.4byte sMukPose130
+.4byte sMukPose131
+.4byte sMukPose132
+.4byte sMukPose133
+.4byte sMukPose134
+.4byte sMukPose135
+.4byte sMukPose136
+.4byte sMukPose137
+.4byte sMukPose138
+.4byte sMukPose139
+.4byte sMukPose140
+.4byte sMukPose141
+.4byte sMukPose142
+.4byte sMukPose143
+.4byte sMukPose144
+.4byte sMukPose145
+.4byte sMukPose146
+.4byte sMukPose147
+.4byte sMukPose148
+.4byte sMukPose149
+.4byte sMukPose150
+.4byte sMukPose151
+.4byte sMukPose152
+.4byte sMukPose153
+.4byte sMukPose154
+.4byte sMukPose155
+.4byte sMukPose156
+.4byte sMukPose157
+.4byte sMukPose158
+.4byte sMukPose159
+.4byte sMukPose160
+.4byte sMukPose161
+.4byte sMukPose162
+.4byte sMukPose163
+.4byte sMukPose164
+.4byte sMukPose165
+.4byte sMukPose166
+.4byte sMukPose167
+.4byte sMukPose168
+.4byte sMukPose169
+.4byte sMukPose170
+.4byte sMukPose171
+.4byte sMukPose172
+.4byte sMukPose173
+.4byte sMukPose174
+.4byte sMukPose175
+.4byte sMukPose176
+.4byte sMukPose177
+.4byte sMukPose178
+.4byte sMukPose179
+.4byte sMukPose180
+.4byte sMukPose181
+.4byte sMukPose182
+.4byte sMukPose183
+.4byte sMukPose184
+.4byte sMukPose185
+.4byte sMukPose186
+.4byte sMukPose187
+.4byte sMukPose188
+.4byte sMukPose189
+.4byte sMukPose190
+.4byte sMukPose191
+.4byte sMukPose192
+.4byte sMukPose193
+.4byte sMukPose194
+.4byte sMukPose195
+.4byte sMukPose196
+.4byte sMukPose197
+.4byte sMukPose198
+.4byte sMukPose199
+.4byte sMukPose200
+.4byte sMukPose201
+.4byte sMukPose202
+.4byte sMukPose203
+.4byte sMukPose204
+.4byte sMukPose205
+.4byte sMukPose206
+.4byte sMukPose207
+.4byte sMukPose208
+.4byte sMukPose209
+.4byte sMukPose210
+.4byte sMukPose211
+.4byte sMukPose212
+.4byte sMukPose213
+.4byte sMukPose214
+.4byte sMukPose215
+.4byte sMukPose216
+.4byte sMukPose217
+.4byte sMukPose218
+.4byte sMukPose219
+.4byte sMukPose220
+.4byte sMukPose221
+.4byte sMukPose222
+.4byte sMukPose223
+.4byte sMukPose224
+.4byte sMukPose225
+.4byte sMukPose226
+sAxPositionsMuk:
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,   -4, 	  -9,   -8, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -2, 	 -10,   -7, 	  10,    0, 	  -1,   -6
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+.2byte    2,   -5, 	  -7,   -8, 	  12,  -10, 	   1,   -8
+.2byte    3,   -4, 	  -6,   -6, 	  13,   -7, 	   3,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte    4,   -8, 	   0,   -5, 	   8,   -7, 	   1,   -9
+.2byte    6,   -8, 	   2,   -5, 	  11,   -7, 	   2,   -9
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    5,  -15, 	   5,   -6, 	  -2,  -13, 	   0,  -10
+.2byte    8,  -14, 	   6,   -7, 	   1,  -13, 	   2,  -11
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte   -1,  -16, 	   8,  -13, 	 -13,  -11, 	  -1,  -11
+.2byte   -1,  -19, 	   7,  -15, 	 -13,  -15, 	  -1,  -13
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -6,  -13, 	   4,   -9, 	 -14,   -9, 	  -1,  -10
+.2byte   -8,  -15, 	   3,  -10, 	 -17,  -12, 	  -3,  -10
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte   -6,   -8, 	  -3,   -9, 	  -6,   -4, 	  -1,   -8
+.2byte   -8,   -7, 	  -5,   -8, 	 -10,   -3, 	  -3,   -8
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -6,   -5, 	 -10,   -7, 	   2,   -3, 	  -2,   -7
+.2byte   -5,   -4, 	 -10,   -5, 	   2,    0, 	  -2,   -6
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,    7, 	 -12,    0, 	  11,    0, 	  -1,   -2
+.2byte   -1,   -7, 	 -12,  -10, 	  10,  -12, 	  -1,  -10
+.2byte   -1,   -2, 	 -10,   -7, 	  10,    0, 	  -1,   -6
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+.2byte    7,    3, 	   9,   -5, 	  -9,    2, 	   1,   -4
+.2byte    1,   -6, 	  10,  -13, 	  -8,  -10, 	  -1,   -7
+.2byte    3,   -4, 	  -6,   -6, 	  13,   -7, 	   3,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte   11,   -1, 	   2,   -8, 	   1,    6, 	  -1,   -2
+.2byte    2,   -5, 	   6,  -16, 	   3,   -9, 	  -2,   -7
+.2byte    6,   -8, 	   2,   -5, 	  11,   -7, 	   2,   -9
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    7,  -11, 	  -6,  -11, 	  10,   -4, 	   1,   -7
+.2byte    2,  -10, 	  -7,  -17, 	   9,  -12, 	  -3,   -9
+.2byte    8,  -14, 	   6,   -7, 	   1,  -13, 	   2,  -11
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   8,   -8, 	 -10,   -8, 	  -1,   -5
+.2byte   -1,  -14, 	   8,  -13, 	 -10,  -15, 	  -1,   -9
+.2byte   -1,  -19, 	   7,  -15, 	 -13,  -15, 	  -1,  -13
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -9,  -11, 	   4,  -11, 	 -12,   -4, 	  -3,   -7
+.2byte   -4,  -10, 	   5,  -17, 	 -11,  -12, 	   1,   -9
+.2byte   -8,  -15, 	   3,  -10, 	 -17,  -12, 	  -3,  -10
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte  -13,   -1, 	  -4,   -8, 	  -3,    6, 	  -1,   -2
+.2byte   -4,   -5, 	  -8,  -16, 	  -5,   -9, 	   0,   -7
+.2byte   -8,   -7, 	  -5,   -8, 	 -10,   -3, 	  -3,   -8
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -9,    3, 	 -11,   -5, 	   7,    2, 	  -3,   -4
+.2byte   -3,   -6, 	 -12,  -13, 	   6,  -10, 	  -1,   -7
+.2byte   -5,   -4, 	 -10,   -5, 	   2,    0, 	  -2,   -6
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,    7, 	 -12,    0, 	  11,    0, 	  -1,   -2
+.2byte   -1,   -7, 	 -12,  -10, 	  10,  -12, 	  -1,  -10
+.2byte   -1,   -2, 	 -10,   -7, 	  10,    0, 	  -1,   -6
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+.2byte    7,    3, 	   9,   -5, 	  -9,    2, 	   1,   -4
+.2byte    1,   -6, 	  10,  -13, 	  -8,  -10, 	  -1,   -7
+.2byte    3,   -4, 	  -6,   -6, 	  13,   -7, 	   3,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte   11,   -1, 	   2,   -8, 	   1,    6, 	  -1,   -2
+.2byte    2,   -5, 	   6,  -16, 	   3,   -9, 	  -2,   -7
+.2byte    6,   -8, 	   2,   -5, 	  11,   -7, 	   2,   -9
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    7,  -11, 	  -6,  -11, 	  10,   -4, 	   1,   -7
+.2byte    2,  -10, 	  -7,  -17, 	   9,  -12, 	  -3,   -9
+.2byte    8,  -14, 	   6,   -7, 	   1,  -13, 	   2,  -11
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   8,   -8, 	 -10,   -8, 	  -1,   -5
+.2byte   -1,  -14, 	   8,  -13, 	 -10,  -15, 	  -1,   -9
+.2byte   -1,  -19, 	   7,  -15, 	 -13,  -15, 	  -1,  -13
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -9,  -11, 	   4,  -11, 	 -12,   -4, 	  -3,   -7
+.2byte   -4,  -10, 	   5,  -17, 	 -11,  -12, 	   1,   -9
+.2byte   -8,  -15, 	   3,  -10, 	 -17,  -12, 	  -3,  -10
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte  -13,   -1, 	  -4,   -8, 	  -3,    6, 	  -1,   -2
+.2byte   -4,   -5, 	  -8,  -16, 	  -5,   -9, 	   0,   -7
+.2byte   -8,   -7, 	  -5,   -8, 	 -10,   -3, 	  -3,   -8
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -9,    3, 	 -11,   -5, 	   7,    2, 	  -3,   -4
+.2byte   -3,   -6, 	 -12,  -13, 	   6,  -10, 	  -1,   -7
+.2byte   -5,   -4, 	 -10,   -5, 	   2,    0, 	  -2,   -6
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,    7, 	 -12,    0, 	  11,    0, 	  -1,   -2
+.2byte   -1,   -7, 	 -12,  -10, 	  10,  -12, 	  -1,  -10
+.2byte   -1,    0, 	 -12,   -4, 	  10,   -4, 	  -1,   -4
+.2byte   -1,   -2, 	 -10,   -7, 	  10,    0, 	  -1,   -6
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+.2byte    7,    3, 	   9,   -5, 	  -9,    2, 	   1,   -4
+.2byte    1,   -6, 	  10,  -13, 	  -8,  -10, 	  -1,   -7
+.2byte    2,   -4, 	  12,  -11, 	  -7,   -3, 	   1,   -5
+.2byte    3,   -4, 	  -6,   -6, 	  13,   -7, 	   3,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte   11,   -3, 	   2,  -10, 	   1,    4, 	  -1,   -4
+.2byte    2,   -5, 	   6,  -16, 	   3,   -9, 	  -2,   -7
+.2byte    4,   -6, 	   5,  -18, 	   2,   -3, 	  -2,   -6
+.2byte    6,   -8, 	   2,   -5, 	  11,   -7, 	   2,   -9
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    7,  -11, 	  -6,  -11, 	  10,   -4, 	   1,   -7
+.2byte    2,  -10, 	  -7,  -17, 	   9,  -12, 	  -3,   -9
+.2byte    4,  -13, 	  -7,  -19, 	  10,   -9, 	  -2,  -11
+.2byte    8,  -14, 	   6,   -7, 	   1,  -13, 	   2,  -11
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   8,   -8, 	 -10,   -8, 	  -1,   -5
+.2byte   -1,  -14, 	   8,  -13, 	 -10,  -15, 	  -1,   -9
+.2byte   -1,  -18, 	  11,  -15, 	 -13,  -15, 	  -1,  -10
+.2byte   -1,  -19, 	   7,  -15, 	 -13,  -15, 	  -1,  -13
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -9,  -11, 	   4,  -11, 	 -12,   -4, 	  -3,   -7
+.2byte   -4,  -10, 	   5,  -17, 	 -11,  -12, 	   1,   -9
+.2byte   -6,  -13, 	   5,  -19, 	 -12,   -9, 	   0,  -11
+.2byte   -8,  -15, 	   3,  -10, 	 -17,  -12, 	  -3,  -10
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte  -13,   -3, 	  -4,  -10, 	  -3,    4, 	  -1,   -4
+.2byte   -4,   -5, 	  -8,  -16, 	  -5,   -9, 	   0,   -7
+.2byte   -6,   -6, 	  -7,  -18, 	  -4,   -3, 	   0,   -6
+.2byte   -8,   -7, 	  -5,   -8, 	 -10,   -3, 	  -3,   -8
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -9,    3, 	 -11,   -5, 	   7,    2, 	  -3,   -4
+.2byte   -3,   -6, 	 -12,  -13, 	   6,  -10, 	  -1,   -7
+.2byte   -4,   -4, 	 -14,  -11, 	   5,   -3, 	  -3,   -5
+.2byte   -5,   -4, 	 -10,   -5, 	   2,    0, 	  -2,   -6
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+.2byte   -1,   -2, 	 -10,   -5, 	  10,   -3, 	   0,   -5
+.2byte   -1,    0, 	 -10,   -5, 	  11,    0, 	   0,   -5
+.2byte    0,   -8, 	 -11,   -6, 	  12,  -21, 	   0,   -9
+.2byte    3,   -8, 	   9,   -6, 	 -13,  -17, 	  -1,   -7
+.2byte    5,   -6, 	   1,   -7, 	  -6,  -19, 	   0,   -5
+.2byte    2,  -11, 	  -8,   -8, 	   9,  -21, 	  -1,   -7
+.2byte    0,  -11, 	  12,   -6, 	 -11,  -21, 	   0,   -7
+.2byte   -3,  -11, 	   7,   -8, 	 -10,  -21, 	   0,   -7
+.2byte   -6,   -6, 	  -2,   -7, 	   5,  -19, 	  -1,   -5
+.2byte   -3,   -8, 	  -9,   -6, 	  13,  -17, 	   1,   -7
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,   -3, 	  -9,   -7, 	   8,   -2, 	  -1,   -7
+.2byte   -1,   -2, 	 -10,   -7, 	  10,    0, 	  -1,   -6
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+.2byte    2,   -5, 	  -7,   -8, 	  12,  -10, 	   1,   -8
+.2byte    3,   -4, 	  -6,   -6, 	  13,   -7, 	   3,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte    3,   -8, 	  -1,   -5, 	   7,   -7, 	   0,   -9
+.2byte    4,   -8, 	   0,   -5, 	   9,   -7, 	   0,   -9
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    4,  -15, 	   4,   -6, 	  -3,  -13, 	  -1,  -10
+.2byte    6,  -14, 	   4,   -7, 	  -1,  -13, 	   0,  -11
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte   -1,  -16, 	   8,  -13, 	 -13,  -11, 	  -1,  -11
+.2byte   -1,  -18, 	   7,  -14, 	 -13,  -14, 	  -1,  -12
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -6,  -13, 	   4,   -9, 	 -14,   -9, 	  -1,  -10
+.2byte   -7,  -14, 	   4,   -9, 	 -16,  -11, 	  -2,   -9
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte   -6,   -8, 	  -3,   -9, 	  -6,   -4, 	  -1,   -8
+.2byte   -7,   -7, 	  -4,   -8, 	  -9,   -3, 	  -2,   -8
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -6,   -5, 	 -10,   -7, 	   2,   -3, 	  -2,   -7
+.2byte   -5,   -4, 	 -10,   -5, 	   2,    0, 	  -2,   -6
+.2byte   -1,    7, 	 -12,    0, 	  11,    0, 	  -1,   -2
+.2byte   -8,    4, 	 -10,   -4, 	   8,    3, 	  -2,   -3
+.2byte  -13,   -1, 	  -4,   -8, 	  -3,    6, 	  -1,   -2
+.2byte   -8,   -8, 	   5,   -8, 	 -11,   -1, 	  -2,   -4
+.2byte   -1,   -9, 	   8,   -6, 	 -10,   -6, 	  -1,   -3
+.2byte    8,   -8, 	  -5,   -8, 	  11,   -1, 	   2,   -4
+.2byte   11,   -1, 	   2,   -8, 	   1,    6, 	  -1,   -2
+.2byte    6,    4, 	   8,   -4, 	 -10,    3, 	   0,   -3
+.2byte   -1,   -2, 	 -12,   -6, 	  10,   -6, 	  -1,   -6
+.2byte    2,   -4, 	  12,  -11, 	  -7,   -3, 	   1,   -5
+.2byte    6,   -6, 	   7,  -18, 	   4,   -3, 	   0,   -6
+.2byte    5,  -11, 	  -6,  -17, 	  11,   -7, 	  -1,   -9
+.2byte   -1,  -17, 	  11,  -14, 	 -13,  -14, 	  -1,   -9
+.2byte   -5,  -11, 	   6,  -17, 	 -11,   -7, 	   1,   -9
+.2byte   -7,   -6, 	  -8,  -18, 	  -5,   -3, 	  -1,   -6
+.2byte   -4,   -4, 	 -14,  -11, 	   5,   -3, 	  -3,   -5
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,   -7, 	 -12,  -10, 	  10,  -12, 	  -1,  -10
+.2byte   -1,    7, 	 -12,    0, 	  11,    0, 	  -1,   -2
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+.2byte    1,   -6, 	  10,  -13, 	  -8,  -10, 	  -1,   -7
+.2byte    7,    3, 	   9,   -5, 	  -9,    2, 	   1,   -4
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte    2,   -5, 	   6,  -16, 	   3,   -9, 	  -2,   -7
+.2byte   13,   -3, 	   4,  -10, 	   3,    4, 	   1,   -4
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    2,  -10, 	  -7,  -17, 	   9,  -12, 	  -3,   -9
+.2byte    7,  -11, 	  -6,  -11, 	  10,   -4, 	   1,   -7
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte   -1,  -14, 	   8,  -13, 	 -10,  -15, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -8, 	 -10,   -8, 	  -1,   -5
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -4,  -10, 	   5,  -17, 	 -11,  -12, 	   1,   -9
+.2byte   -9,  -11, 	   4,  -11, 	 -12,   -4, 	  -3,   -7
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte   -4,   -5, 	  -8,  -16, 	  -5,   -9, 	   0,   -7
+.2byte  -15,   -3, 	  -6,  -10, 	  -5,    4, 	  -3,   -4
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -3,   -6, 	 -12,  -13, 	   6,  -10, 	  -1,   -7
+.2byte   -9,    3, 	 -11,   -5, 	   7,    2, 	  -3,   -4
+.2byte    0,   -6, 	 -11,   -9, 	  11,  -11, 	   0,   -9
+.2byte   -3,   -6, 	 -12,  -13, 	   6,  -10, 	  -1,   -7
+.2byte   -4,   -5, 	  -8,  -16, 	  -5,   -9, 	   0,   -7
+.2byte   -5,  -10, 	   4,  -17, 	 -12,  -12, 	   0,   -9
+.2byte   -1,  -14, 	   8,  -13, 	 -10,  -15, 	  -1,   -9
+.2byte    3,  -10, 	  -6,  -17, 	  10,  -12, 	  -2,   -9
+.2byte    2,   -5, 	   6,  -16, 	   3,   -9, 	  -2,   -7
+.2byte    1,   -6, 	  10,  -13, 	  -8,  -10, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -4,   -6, 	 -10,   -8, 	   2,   -4, 	  -1,   -8
+.2byte   -5,   -8, 	  -2,   -8, 	  -4,   -4, 	   0,   -8
+.2byte   -7,  -11, 	   5,   -9, 	 -12,   -8, 	  -1,  -10
+.2byte   -1,  -15, 	   7,  -12, 	 -13,   -9, 	  -1,  -10
+.2byte    5,  -14, 	   4,   -6, 	  -5,  -13, 	  -2,   -9
+.2byte    2,   -8, 	  -2,   -5, 	   0,  -12, 	  -2,  -10
+.2byte    1,   -6, 	  -8,   -8, 	   9,  -10, 	   0,   -8
+sMukAnimTable1:
+.4byte sMukAnims_1_1
+.4byte sMukAnims_1_2
+.4byte sMukAnims_1_3
+.4byte sMukAnims_1_4
+.4byte sMukAnims_1_5
+.4byte sMukAnims_1_6
+.4byte sMukAnims_1_7
+.4byte sMukAnims_1_8
+sMukAnimTable2:
+.4byte sMukAnims_2_1
+.4byte sMukAnims_2_2
+.4byte sMukAnims_2_3
+.4byte sMukAnims_2_4
+.4byte sMukAnims_2_5
+.4byte sMukAnims_2_6
+.4byte sMukAnims_2_7
+.4byte sMukAnims_2_8
+sMukAnimTable3:
+.4byte sMukAnims_3_1
+.4byte sMukAnims_3_2
+.4byte sMukAnims_3_3
+.4byte sMukAnims_3_4
+.4byte sMukAnims_3_5
+.4byte sMukAnims_3_6
+.4byte sMukAnims_3_7
+.4byte sMukAnims_3_8
+sMukAnimTable4:
+.4byte sMukAnims_4_1
+.4byte sMukAnims_4_2
+.4byte sMukAnims_4_3
+.4byte sMukAnims_4_4
+.4byte sMukAnims_4_5
+.4byte sMukAnims_4_6
+.4byte sMukAnims_4_7
+.4byte sMukAnims_4_8
+sMukAnimTable5:
+.4byte sMukAnims_5_1
+.4byte sMukAnims_5_2
+.4byte sMukAnims_5_3
+.4byte sMukAnims_5_4
+.4byte sMukAnims_5_5
+.4byte sMukAnims_5_6
+.4byte sMukAnims_5_7
+.4byte sMukAnims_5_8
+sMukAnimTable6:
+.4byte sMukAnims_6_1
+.4byte sMukAnims_6_1
+.4byte sMukAnims_6_1
+.4byte sMukAnims_6_1
+.4byte sMukAnims_6_1
+.4byte sMukAnims_6_1
+.4byte sMukAnims_6_1
+.4byte sMukAnims_6_1
+sMukAnimTable7:
+.4byte sMukAnims_7_1
+.4byte sMukAnims_7_2
+.4byte sMukAnims_7_3
+.4byte sMukAnims_7_4
+.4byte sMukAnims_7_5
+.4byte sMukAnims_7_6
+.4byte sMukAnims_7_7
+.4byte sMukAnims_7_8
+sMukAnimTable8:
+.4byte sMukAnims_8_1
+.4byte sMukAnims_8_2
+.4byte sMukAnims_8_3
+.4byte sMukAnims_8_4
+.4byte sMukAnims_8_5
+.4byte sMukAnims_8_6
+.4byte sMukAnims_8_7
+.4byte sMukAnims_8_8
+sMukAnimTable9:
+.4byte sMukAnims_9_1
+.4byte sMukAnims_9_2
+.4byte sMukAnims_9_3
+.4byte sMukAnims_9_4
+.4byte sMukAnims_9_5
+.4byte sMukAnims_9_6
+.4byte sMukAnims_9_7
+.4byte sMukAnims_9_8
+sMukAnimTable10:
+.4byte sMukAnims_10_1
+.4byte sMukAnims_10_2
+.4byte sMukAnims_10_3
+.4byte sMukAnims_10_4
+.4byte sMukAnims_10_5
+.4byte sMukAnims_10_6
+.4byte sMukAnims_10_7
+.4byte sMukAnims_10_8
+sMukAnimTable11:
+.4byte sMukAnims_11_1
+.4byte sMukAnims_11_2
+.4byte sMukAnims_11_3
+.4byte sMukAnims_11_4
+.4byte sMukAnims_11_5
+.4byte sMukAnims_11_6
+.4byte sMukAnims_11_7
+.4byte sMukAnims_11_8
+sMukAnimTable12:
+.4byte sMukAnims_12_1
+.4byte sMukAnims_12_2
+.4byte sMukAnims_12_3
+.4byte sMukAnims_12_4
+.4byte sMukAnims_12_5
+.4byte sMukAnims_12_6
+.4byte sMukAnims_12_7
+.4byte sMukAnims_12_8
+sMukAnimTable13:
+.4byte sMukAnims_13_1
+.4byte sMukAnims_13_2
+.4byte sMukAnims_13_3
+.4byte sMukAnims_13_4
+.4byte sMukAnims_13_5
+.4byte sMukAnims_13_6
+.4byte sMukAnims_13_7
+.4byte sMukAnims_13_8
+sAxAnimationsMuk:
+.4byte sMukAnimTable1
+.4byte sMukAnimTable2
+.4byte sMukAnimTable3
+.4byte sMukAnimTable4
+.4byte sMukAnimTable5
+.4byte sMukAnimTable6
+.4byte sMukAnimTable7
+.4byte sMukAnimTable8
+.4byte sMukAnimTable9
+.4byte sMukAnimTable10
+.4byte sMukAnimTable11
+.4byte sMukAnimTable12
+.4byte sMukAnimTable13
+sAxSpritesMuk:
+.4byte sMukSprites1
+.4byte sMukSprites2
+.4byte sMukSprites3
+.4byte sMukSprites4
+.4byte sMukSprites5
+.4byte sMukSprites6
+.4byte sMukSprites7
+.4byte sMukSprites8
+.4byte sMukSprites9
+.4byte sMukSprites10
+.4byte sMukSprites11
+.4byte sMukSprites12
+.4byte sMukSprites13
+.4byte sMukSprites14
+.4byte sMukSprites15
+.4byte sMukSprites16
+.4byte sMukSprites17
+.4byte sMukSprites18
+.4byte sMukSprites19
+.4byte sMukSprites20
+.4byte sMukSprites21
+.4byte sMukSprites22
+.4byte sMukSprites23
+.4byte sMukSprites24
+.4byte sMukSprites25
+.4byte sMukSprites26
+.4byte sMukSprites27
+.4byte sMukSprites28
+.4byte sMukSprites29
+.4byte sMukSprites30
+.4byte sMukSprites31
+.4byte sMukSprites32
+.4byte sMukSprites33
+.4byte sMukSprites34
+.4byte sMukSprites35
+.4byte sMukSprites36
+.4byte sMukSprites37
+.4byte sMukSprites38
+.4byte sMukSprites39
+.4byte sMukSprites40
+.4byte sMukSprites41
+.4byte sMukSprites42
+.4byte sMukSprites43
+.4byte sMukSprites44
+.4byte sMukSprites45
+.4byte sMukSprites46
+.4byte sMukSprites47
+.4byte sMukSprites48
+sAxMainMuk:
+ax_main sAxPosesMuk, sAxAnimationsMuk, 13, sAxSpritesMuk, sAxPositionsMuk

--- a/data/ax/munchlax.inc
+++ b/data/ax/munchlax.inc
@@ -1,0 +1,3035 @@
+.global gAxMunchlax
+gAxMunchlax:
+ax_siro sAxMainMunchlax
+sMunchlaxPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose4:
+ax_pose 3, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose5:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose6:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose7:
+ax_pose 6, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose8:
+ax_pose 7, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose9:
+ax_pose 8, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose10:
+ax_pose 9, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose11:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose12:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose13:
+ax_pose 12, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose16:
+ax_pose 9, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose17:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose18:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose19:
+ax_pose 6, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose20:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose21:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose22:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose23:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose24:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose28:
+ax_pose 3, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose29:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose30:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose31:
+ax_pose 6, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose32:
+ax_pose 7, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose33:
+ax_pose 8, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose34:
+ax_pose 9, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose35:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose36:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose37:
+ax_pose 12, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose38:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose39:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose40:
+ax_pose 9, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose41:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose42:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose43:
+ax_pose 6, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose44:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose45:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose46:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose47:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose48:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose49:
+ax_pose 0, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose50:
+ax_pose 1, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose51:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose52:
+ax_pose 3, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose53:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose54:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose55:
+ax_pose 6, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose56:
+ax_pose 7, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose57:
+ax_pose 8, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose58:
+ax_pose 9, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose59:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose60:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose61:
+ax_pose 12, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose62:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose63:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose64:
+ax_pose 9, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose65:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose66:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose67:
+ax_pose 6, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose68:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose69:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose70:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose71:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose72:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose73:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose74:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose75:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose76:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose77:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose78:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose79:
+ax_pose 8, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose80:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose81:
+ax_pose 0, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose82:
+ax_pose 1, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose83:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose84:
+ax_pose 15, 0x01e2, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose85:
+ax_pose 16, 0x01f1, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose86:
+ax_pose 17, 0x01f1, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose87:
+ax_pose 3, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose88:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose89:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose90:
+ax_pose 6, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose91:
+ax_pose 7, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose92:
+ax_pose 8, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose93:
+ax_pose 18, 0x01e3, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose94:
+ax_pose 19, 0x41f2, 0x90f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose95:
+ax_pose 20, 0x41f2, 0x90f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose96:
+ax_pose 9, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose97:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose98:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose99:
+ax_pose 12, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose100:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose101:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose102:
+ax_pose 9, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose103:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose104:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose105:
+ax_pose 6, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose106:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose107:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose108:
+ax_pose 18, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose109:
+ax_pose 19, 0x41f2, 0x80f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose110:
+ax_pose 20, 0x41f2, 0x80f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose111:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose112:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose113:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose114:
+ax_pose 21, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose115:
+ax_pose 22, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose116:
+ax_pose 23, 0x01e5, 0x80f5, 0xcc00
+ax_pose_terminator
+sMunchlaxPose117:
+ax_pose 24, 0x01e4, 0x90e9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose118:
+ax_pose 25, 0x01e4, 0x90e8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose119:
+ax_pose 26, 0x01e5, 0x90ea, 0xcc00
+ax_pose_terminator
+sMunchlaxPose120:
+ax_pose 27, 0x01e6, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose121:
+ax_pose 26, 0x01e5, 0x80f6, 0xcc00
+ax_pose_terminator
+sMunchlaxPose122:
+ax_pose 25, 0x01e4, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose123:
+ax_pose 24, 0x01e4, 0x80f7, 0xcc00
+ax_pose_terminator
+sMunchlaxPose124:
+ax_pose 0, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose125:
+ax_pose 1, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose126:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose127:
+ax_pose 3, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose128:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose129:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose130:
+ax_pose 6, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose131:
+ax_pose 7, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose132:
+ax_pose 8, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose133:
+ax_pose 9, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose134:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose135:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose136:
+ax_pose 12, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose137:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose138:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose139:
+ax_pose 9, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose140:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose141:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose142:
+ax_pose 6, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose143:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose144:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose145:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose146:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose147:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose148:
+ax_pose 0, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose149:
+ax_pose 3, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose150:
+ax_pose 6, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose151:
+ax_pose 9, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose152:
+ax_pose 12, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose153:
+ax_pose 9, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose154:
+ax_pose 6, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose155:
+ax_pose 3, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose156:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose157:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose158:
+ax_pose 7, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose159:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose160:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose161:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose162:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose163:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose164:
+ax_pose 0, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose165:
+ax_pose 1, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose166:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose167:
+ax_pose 3, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose168:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose169:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose170:
+ax_pose 6, 0x01eb, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose171:
+ax_pose 7, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose172:
+ax_pose 8, 0x81eb, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose173:
+ax_pose 9, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose174:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose175:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose176:
+ax_pose 12, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose177:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose178:
+ax_pose 14, 0x01ec, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose179:
+ax_pose 9, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose180:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose181:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose182:
+ax_pose 6, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose183:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose184:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose185:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose186:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose187:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose188:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose189:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose190:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose191:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose192:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose193:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose194:
+ax_pose 8, 0x81ea, 0x90f9, 0xcc00
+ax_pose_terminator
+sMunchlaxPose195:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose196:
+ax_pose 0, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose197:
+ax_pose 3, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose198:
+ax_pose 6, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose199:
+ax_pose 9, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose200:
+ax_pose 12, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose201:
+ax_pose 9, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose202:
+ax_pose 6, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose203:
+ax_pose 3, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose204:
+ax_pose 28, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose205:
+ax_pose 29, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose206:
+ax_pose 30, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose207:
+ax_pose 29, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose208:
+ax_pose 30, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose209:
+ax_pose 31, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose210:
+ax_pose 32, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose211:
+ax_pose 33, 0x01e9, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose212:
+ax_pose 34, 0x01e9, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose213:
+ax_pose 35, 0x01e9, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose214:
+ax_pose 33, 0x01e9, 0x90f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose215:
+ax_pose 34, 0x01e9, 0x90f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose216:
+ax_pose 35, 0x01e9, 0x90f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose217:
+ax_pose 0, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose218:
+ax_pose 1, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose219:
+ax_pose 2, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose220:
+ax_pose 15, 0x01e2, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose221:
+ax_pose 16, 0x01f1, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose222:
+ax_pose 17, 0x01f1, 0x80f1, 0xcc00
+ax_pose_terminator
+sMunchlaxPose223:
+ax_pose 3, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose224:
+ax_pose 4, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose225:
+ax_pose 5, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose226:
+ax_pose 6, 0x01e9, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose227:
+ax_pose 7, 0x81ea, 0x90f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose228:
+ax_pose 8, 0x81ea, 0x90f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose229:
+ax_pose 18, 0x01e3, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose230:
+ax_pose 19, 0x41f2, 0x90f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose231:
+ax_pose 20, 0x41f2, 0x90f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose232:
+ax_pose 36, 0x01ea, 0x90f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose233:
+ax_pose 35, 0x01ea, 0x90ee, 0xcc00
+ax_pose_terminator
+sMunchlaxPose234:
+ax_pose 33, 0x01e9, 0x90f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose235:
+ax_pose 3, 0x01e9, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose236:
+ax_pose 4, 0x01ea, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose237:
+ax_pose 5, 0x01ea, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose238:
+ax_pose 9, 0x01e9, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose239:
+ax_pose 10, 0x01ea, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose240:
+ax_pose 11, 0x01ea, 0x90ec, 0xcc00
+ax_pose_terminator
+sMunchlaxPose241:
+ax_pose 9, 0x01e9, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose242:
+ax_pose 10, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose243:
+ax_pose 11, 0x01ea, 0x90ed, 0xcc00
+ax_pose_terminator
+sMunchlaxPose244:
+ax_pose 12, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose245:
+ax_pose 13, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose246:
+ax_pose 14, 0x01eb, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose247:
+ax_pose 9, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose248:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose249:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose250:
+ax_pose 6, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose251:
+ax_pose 7, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose252:
+ax_pose 8, 0x81ea, 0x80f8, 0xcc00
+ax_pose_terminator
+sMunchlaxPose253:
+ax_pose 18, 0x01e3, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose254:
+ax_pose 19, 0x41f2, 0x80f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose255:
+ax_pose 20, 0x41f2, 0x80f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose256:
+ax_pose 36, 0x01ea, 0x80f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose257:
+ax_pose 35, 0x01ea, 0x80f2, 0xcc00
+ax_pose_terminator
+sMunchlaxPose258:
+ax_pose 33, 0x01e9, 0x80f0, 0xcc00
+ax_pose_terminator
+sMunchlaxPose259:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose260:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose261:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose262:
+ax_pose 9, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose263:
+ax_pose 10, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose264:
+ax_pose 11, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose265:
+ax_pose 3, 0x01e9, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose266:
+ax_pose 4, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+sMunchlaxPose267:
+ax_pose 5, 0x01ea, 0x80f4, 0xcc00
+ax_pose_terminator
+.align 2
+sMunchlaxAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sMunchlaxAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 20, 20, 20, 20,
+ax_anim 2, 1, 27, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 20, 20, 20, 20,
+ax_anim 2, 0, 27, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim_terminator
+sMunchlaxAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sMunchlaxAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -3, 3, -3, 3,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 33, 12, -14, 12, -14,
+ax_anim 2, 0, 33, 19, -23, 19, -23,
+ax_anim 2, 1, 33, 20, -22, 20, -22,
+ax_anim 2, 0, 33, 19, -23, 19, -23,
+ax_anim 2, 0, 33, 20, -22, 20, -22,
+ax_anim 2, 0, 35, 8, -8, 8, -8,
+ax_anim_terminator
+sMunchlaxAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -14, 0, -14,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 1, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -21, 0, -21,
+ax_anim 2, 0, 36, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim_terminator
+sMunchlaxAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 3, 3, 3, 3,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -6, -6, -6, -6,
+ax_anim 1, 0, 39, -12, -14, -12, -14,
+ax_anim 2, 0, 39, -19, -23, -19, -23,
+ax_anim 2, 1, 39, -20, -22, -20, -22,
+ax_anim 2, 0, 39, -19, -23, -19, -23,
+ax_anim 2, 0, 39, -20, -22, -20, -22,
+ax_anim 2, 0, 41, -8, -8, -8, -8,
+ax_anim_terminator
+sMunchlaxAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -6, 0, -6, 0,
+ax_anim_terminator
+sMunchlaxAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -20, 20, -20, 20,
+ax_anim 2, 1, 45, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -20, 20, -20, 20,
+ax_anim 2, 0, 45, -21, 19, -21, 19,
+ax_anim 2, 0, 47, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 50, 0, 6, 0, 6,
+ax_anim_terminator
+sMunchlaxAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 20, 20, 20, 20,
+ax_anim 2, 1, 51, 21, 19, 21, 19,
+ax_anim 2, 0, 51, 20, 20, 20, 20,
+ax_anim 2, 0, 51, 21, 19, 21, 19,
+ax_anim 2, 0, 53, 8, 8, 8, 8,
+ax_anim_terminator
+sMunchlaxAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 6, 0, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 1, 54, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 0, 54, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim_terminator
+sMunchlaxAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -3, 3, -3, 3,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 6, -6, 6, -6,
+ax_anim 1, 0, 57, 12, -14, 12, -14,
+ax_anim 2, 0, 57, 19, -23, 19, -23,
+ax_anim 2, 1, 57, 20, -22, 20, -22,
+ax_anim 2, 0, 57, 19, -23, 19, -23,
+ax_anim 2, 0, 57, 20, -22, 20, -22,
+ax_anim 2, 0, 59, 8, -8, 8, -8,
+ax_anim_terminator
+sMunchlaxAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 3, 0, 3,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -14, 0, -14,
+ax_anim 2, 0, 60, 0, -21, 0, -21,
+ax_anim 2, 1, 60, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -21, 0, -21,
+ax_anim 2, 0, 60, 1, -21, 1, -21,
+ax_anim 2, 0, 62, 0, -6, 0, -6,
+ax_anim_terminator
+sMunchlaxAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 3, 3, 3, 3,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -6, -6, -6, -6,
+ax_anim 1, 0, 63, -12, -14, -12, -14,
+ax_anim 2, 0, 63, -19, -23, -19, -23,
+ax_anim 2, 1, 63, -20, -22, -20, -22,
+ax_anim 2, 0, 63, -19, -23, -19, -23,
+ax_anim 2, 0, 63, -20, -22, -20, -22,
+ax_anim 2, 0, 65, -8, -8, -8, -8,
+ax_anim_terminator
+sMunchlaxAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 6, 0, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 1, 66, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -6, 0, -6, 0,
+ax_anim_terminator
+sMunchlaxAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -20, 20, -20, 20,
+ax_anim 2, 1, 69, -21, 19, -21, 19,
+ax_anim 2, 0, 69, -20, 20, -20, 20,
+ax_anim 2, 0, 69, -21, 19, -21, 19,
+ax_anim 2, 0, 71, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_5_1:
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 1,
+ax_anim 4, 0, 83, 0, -2, 0, 2,
+ax_anim 4, 0, 83, 0, 0, 0, 3,
+ax_anim 3, 0, 83, 0, 5, 0, 5,
+ax_anim 4, 0, 84, 0, 9, 0, 9,
+ax_anim 2, 0, 84, 0, 11, 0, 11,
+ax_anim 6, 0, 84, 0, 12, 0, 12,
+ax_anim 20, 0, 85, 0, 12, 0, 12,
+ax_anim_terminator
+sMunchlaxAnims_5_2:
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -3, 1, 0,
+ax_anim 4, 0, 92, 3, -5, 3, 0,
+ax_anim 4, 0, 92, 5, -6, 5, 0,
+ax_anim 3, 0, 92, 9, -2, 9, 0,
+ax_anim 4, 0, 93, 13, 0, 13, 0,
+ax_anim 2, 0, 93, 15, 0, 15, 0,
+ax_anim 6, 0, 93, 16, 0, 16, 0,
+ax_anim 20, 0, 94, 16, 0, 16, 0,
+ax_anim_terminator
+sMunchlaxAnims_5_3:
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -3, 1, 0,
+ax_anim 4, 0, 92, 3, -5, 3, 0,
+ax_anim 4, 0, 92, 5, -6, 5, 0,
+ax_anim 3, 0, 92, 9, -2, 9, 0,
+ax_anim 4, 0, 93, 13, 0, 13, 0,
+ax_anim 2, 0, 93, 15, 0, 15, 0,
+ax_anim 6, 0, 93, 16, 0, 16, 0,
+ax_anim 20, 0, 94, 16, 0, 16, 0,
+ax_anim_terminator
+sMunchlaxAnims_5_4:
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -3, 1, 0,
+ax_anim 4, 0, 92, 3, -5, 3, 0,
+ax_anim 4, 0, 92, 5, -6, 5, 0,
+ax_anim 3, 0, 92, 9, -2, 9, 0,
+ax_anim 4, 0, 93, 13, 0, 13, 0,
+ax_anim 2, 0, 93, 15, 0, 15, 0,
+ax_anim 6, 0, 93, 16, 0, 16, 0,
+ax_anim 20, 0, 94, 16, 0, 16, 0,
+ax_anim_terminator
+sMunchlaxAnims_5_5:
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -3, 1, 0,
+ax_anim 4, 0, 92, 3, -5, 3, 0,
+ax_anim 4, 0, 92, 5, -6, 5, 0,
+ax_anim 3, 0, 92, 9, -2, 9, 0,
+ax_anim 4, 0, 93, 13, 0, 13, 0,
+ax_anim 2, 0, 93, 15, 0, 15, 0,
+ax_anim 6, 0, 93, 16, 0, 16, 0,
+ax_anim 20, 0, 94, 16, 0, 16, 0,
+ax_anim_terminator
+sMunchlaxAnims_5_6:
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -3, -1, 0,
+ax_anim 4, 0, 107, -3, -5, -3, 0,
+ax_anim 4, 0, 107, -5, -6, -5, 0,
+ax_anim 3, 0, 107, -9, -2, -9, 0,
+ax_anim 4, 0, 108, -13, 0, -13, 0,
+ax_anim 2, 0, 108, -15, 0, -15, 0,
+ax_anim 6, 0, 108, -16, 0, -16, 0,
+ax_anim 20, 0, 109, -16, 0, -16, 0,
+ax_anim_terminator
+sMunchlaxAnims_5_7:
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -3, -1, 0,
+ax_anim 4, 0, 107, -3, -5, -3, 0,
+ax_anim 4, 0, 107, -5, -6, -5, 0,
+ax_anim 3, 0, 107, -9, -2, -9, 0,
+ax_anim 4, 0, 108, -13, 0, -13, 0,
+ax_anim 2, 0, 108, -15, 0, -15, 0,
+ax_anim 6, 0, 108, -16, 0, -16, 0,
+ax_anim 20, 0, 109, -16, 0, -16, 0,
+ax_anim_terminator
+sMunchlaxAnims_5_8:
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -3, -1, 0,
+ax_anim 4, 0, 107, -3, -5, -3, 0,
+ax_anim 4, 0, 107, -5, -6, -5, 0,
+ax_anim 3, 0, 107, -9, -2, -9, 0,
+ax_anim 4, 0, 108, -13, 0, -13, 0,
+ax_anim 2, 0, 108, -15, 0, -15, 0,
+ax_anim 6, 0, 108, -16, 0, -16, 0,
+ax_anim 20, 0, 109, -16, 0, -16, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_6_1:
+ax_anim 30, 0, 113, 0, 0, 0, 0,
+ax_anim 35, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_7_1:
+ax_anim 2, 0, 115, 0, -3, 0, -3,
+ax_anim 8, 0, 115, 0, -4, 0, -4,
+ax_anim_terminator
+sMunchlaxAnims_7_2:
+ax_anim 2, 0, 116, -3, -3, -3, -3,
+ax_anim 8, 0, 116, -4, -4, -4, -4,
+ax_anim_terminator
+sMunchlaxAnims_7_3:
+ax_anim 2, 0, 117, -3, 0, -3, 0,
+ax_anim 8, 0, 117, -4, 0, -4, 0,
+ax_anim_terminator
+sMunchlaxAnims_7_4:
+ax_anim 2, 0, 118, -3, 3, -3, 3,
+ax_anim 8, 0, 118, -4, 4, -4, 4,
+ax_anim_terminator
+sMunchlaxAnims_7_5:
+ax_anim 2, 0, 119, 0, 3, 0, 3,
+ax_anim 8, 0, 119, 0, 4, 0, 4,
+ax_anim_terminator
+sMunchlaxAnims_7_6:
+ax_anim 2, 0, 120, 3, 3, 3, 3,
+ax_anim 8, 0, 120, 4, 4, 4, 4,
+ax_anim_terminator
+sMunchlaxAnims_7_7:
+ax_anim 2, 0, 121, 3, 0, 3, 0,
+ax_anim 8, 0, 121, 4, 0, 4, 0,
+ax_anim_terminator
+sMunchlaxAnims_7_8:
+ax_anim 2, 0, 122, 3, -3, 3, -3,
+ax_anim 8, 0, 122, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_8_1:
+ax_anim 40, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -3, 0, 0,
+ax_anim 4, 0, 124, 0, -4, 0, 0,
+ax_anim 4, 0, 123, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -3, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_8_2:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, -3, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 4, 0, 126, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -3, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_8_3:
+ax_anim 40, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, -3, 0, 0,
+ax_anim 4, 0, 130, 0, -4, 0, 0,
+ax_anim 4, 0, 129, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_8_4:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 0, 133, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_8_5:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, -3, 0, 0,
+ax_anim 4, 0, 136, 0, -4, 0, 0,
+ax_anim 4, 0, 135, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_8_6:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 139, 0, -4, 0, 0,
+ax_anim 4, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_8_7:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 141, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_8_8:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 4, 0, 145, 0, -4, 0, 0,
+ax_anim 4, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_9_1:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 6, 3, 6, 3,
+ax_anim 2, 0, 149, 8, 9, 8, 9,
+ax_anim 2, 0, 150, 7, 17, 7, 17,
+ax_anim 3, 0, 151, 0, 20, 0, 20,
+ax_anim 2, 3, 152, -7, 17, -7, 17,
+ax_anim 2, 0, 153, -8, 9, -8, 9,
+ax_anim 1, 0, 154, -6, 3, -6, 3,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_9_2:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 8, 0, 8, 0,
+ax_anim 2, 0, 148, 18, 3, 18, 3,
+ax_anim 2, 0, 149, 22, 13, 22, 13,
+ax_anim 3, 0, 150, 20, 20, 20, 20,
+ax_anim 2, 3, 151, 11, 20, 11, 20,
+ax_anim 2, 0, 152, 3, 15, 3, 15,
+ax_anim 1, 0, 153, 0, 7, 0, 7,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_9_3:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 3, -5, 3, -5,
+ax_anim 2, 0, 147, 11, -7, 11, -7,
+ax_anim 2, 0, 148, 19, -5, 19, -5,
+ax_anim 3, 0, 149, 22, -2, 22, -2,
+ax_anim 2, 3, 150, 18, 4, 18, 4,
+ax_anim 2, 0, 151, 12, 6, 12, 6,
+ax_anim 1, 0, 152, 4, 5, 4, 5,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_9_4:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, -1, -8, -1, -8,
+ax_anim 2, 0, 154, 4, -16, 4, -16,
+ax_anim 2, 0, 147, 12, -20, 12, -20,
+ax_anim 3, 0, 148, 20, -19, 20, -19,
+ax_anim 2, 3, 149, 20, -13, 20, -13,
+ax_anim 2, 0, 150, 16, -6, 16, -6,
+ax_anim 1, 0, 151, 7, -1, 7, -1,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_9_5:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -8, -4, -8, -4,
+ax_anim 2, 0, 153, -9, -12, -9, -12,
+ax_anim 2, 0, 154, -7, -18, -7, -18,
+ax_anim 3, 0, 147, 0, -20, 0, -20,
+ax_anim 2, 3, 148, 7, -18, 7, -18,
+ax_anim 2, 0, 149, 9, -10, 9, -10,
+ax_anim 1, 0, 150, 8, -4, 8, -4,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_9_6:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 1, -8, 1, -8,
+ax_anim 2, 0, 148, -4, -16, -4, -16,
+ax_anim 2, 0, 147, -12, -20, -12, -20,
+ax_anim 3, 0, 154, -20, -19, -20, -19,
+ax_anim 2, 3, 153, -20, -13, -20, -13,
+ax_anim 2, 0, 152, -16, -6, -16, -6,
+ax_anim 1, 0, 151, -7, -1, -7, -1,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_9_7:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, -3, -5, -3, -5,
+ax_anim 2, 0, 147, -11, -7, -11, -7,
+ax_anim 2, 0, 154, -19, -5, -19, -5,
+ax_anim 3, 0, 153, -22, -2, -22, -2,
+ax_anim 2, 3, 152, -18, 4, -18, 4,
+ax_anim 2, 0, 151, -12, 6, -12, 6,
+ax_anim 1, 0, 150, -4, 5, -4, 5,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_9_8:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -8, 0, -8, 0,
+ax_anim 2, 0, 154, -18, 3, -18, 3,
+ax_anim 2, 0, 153, -22, 13, -22, 13,
+ax_anim 3, 0, 152, -20, 20, -20, 20,
+ax_anim 2, 3, 151, -11, 20, -11, 20,
+ax_anim 2, 0, 150, -3, 15, -3, 15,
+ax_anim 1, 0, 149, 0, 7, 0, 7,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_10_1:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, 0, 6, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, 10, 0, 10, 0,
+ax_anim 2, 0, 155, -10, 0, -10, 0,
+ax_anim 2, 0, 155, 12, 0, 12, 0,
+ax_anim 3, 0, 155, -12, 0, -12, 0,
+ax_anim 3, 0, 155, 13, 0, 13, 0,
+ax_anim 3, 0, 155, -13, 0, -13, 0,
+ax_anim 2, 0, 155, 12, 0, 12, 0,
+ax_anim 3, 0, 155, -12, 0, -12, 0,
+ax_anim 2, 0, 155, 10, 0, 10, 0,
+ax_anim 2, 0, 155, -10, 0, -10, 0,
+ax_anim 2, 0, 155, 6, 0, 6, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_10_2:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 6, -6, 6, -6,
+ax_anim 2, 0, 156, -6, 6, -6, 6,
+ax_anim 2, 0, 156, 10, -10, 10, -10,
+ax_anim 2, 0, 156, -10, 10, -10, 10,
+ax_anim 2, 0, 156, 12, -12, 12, -12,
+ax_anim 3, 0, 156, -12, 12, -12, 12,
+ax_anim 3, 0, 156, 13, -13, 13, -13,
+ax_anim 3, 0, 156, -13, 13, -13, 13,
+ax_anim 2, 0, 156, 12, -12, 12, -12,
+ax_anim 3, 0, 156, -12, 12, -12, 12,
+ax_anim 2, 0, 156, 10, -10, 10, -10,
+ax_anim 2, 0, 156, -10, 10, -10, 10,
+ax_anim 2, 0, 156, 6, -6, 6, -6,
+ax_anim 2, 0, 156, -6, 6, -6, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_10_3:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, -6, 0, -6,
+ax_anim 2, 0, 157, 0, 6, 0, 6,
+ax_anim 2, 0, 157, 0, -10, 0, -10,
+ax_anim 2, 0, 157, 0, 10, 0, 10,
+ax_anim 2, 0, 157, 0, -12, 0, -12,
+ax_anim 3, 0, 157, 0, 12, 0, 12,
+ax_anim 3, 0, 157, 0, -13, 0, -13,
+ax_anim 3, 0, 157, 0, 13, 0, 13,
+ax_anim 2, 0, 157, 0, -12, 0, -12,
+ax_anim 3, 0, 157, 0, 12, 0, 12,
+ax_anim 2, 0, 157, 0, -10, 0, -10,
+ax_anim 2, 0, 157, 0, 10, 0, 10,
+ax_anim 2, 0, 157, 0, -6, 0, -6,
+ax_anim 2, 0, 157, 0, 6, 0, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_10_4:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -6, -6, -6, -6,
+ax_anim 2, 0, 158, 6, 6, 6, 6,
+ax_anim 2, 0, 158, -10, -10, -10, -10,
+ax_anim 2, 0, 158, 10, 10, 10, 10,
+ax_anim 2, 0, 158, -12, -12, -12, -12,
+ax_anim 3, 0, 158, 12, 12, 12, 12,
+ax_anim 3, 0, 158, -13, -13, -13, -13,
+ax_anim 3, 0, 158, 13, 13, 13, 13,
+ax_anim 2, 0, 158, -12, -12, -12, -12,
+ax_anim 3, 0, 158, 12, 12, 12, 12,
+ax_anim 2, 0, 158, -10, -10, -10, -10,
+ax_anim 2, 0, 158, 10, 10, 10, 10,
+ax_anim 2, 0, 158, -6, -6, -6, -6,
+ax_anim 2, 0, 158, 6, 6, 6, 6,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_10_5:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, 0, 6, 0,
+ax_anim 2, 0, 159, -6, 0, -6, 0,
+ax_anim 2, 0, 159, 10, 0, 10, 0,
+ax_anim 2, 0, 159, -10, 0, -10, 0,
+ax_anim 2, 0, 159, 12, 0, 12, 0,
+ax_anim 3, 0, 159, -12, 0, -12, 0,
+ax_anim 3, 0, 159, 13, 0, 13, 0,
+ax_anim 3, 0, 159, -13, 0, -13, 0,
+ax_anim 2, 0, 159, 12, 0, 12, 0,
+ax_anim 3, 0, 159, -12, 0, -12, 0,
+ax_anim 2, 0, 159, 10, 0, 10, 0,
+ax_anim 2, 0, 159, -10, 0, -10, 0,
+ax_anim 2, 0, 159, 6, 0, 6, 0,
+ax_anim 2, 0, 159, -6, 0, -6, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_10_6:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 6, -6, 6, -6,
+ax_anim 2, 0, 160, -6, 6, -6, 6,
+ax_anim 2, 0, 160, 10, -10, 10, -10,
+ax_anim 2, 0, 160, -10, 10, -10, 10,
+ax_anim 2, 0, 160, 12, -12, 12, -12,
+ax_anim 3, 0, 160, -12, 12, -12, 12,
+ax_anim 3, 0, 160, 13, -13, 13, -13,
+ax_anim 3, 0, 160, -13, 13, -13, 13,
+ax_anim 2, 0, 160, 12, -12, 12, -12,
+ax_anim 3, 0, 160, -12, 12, -12, 12,
+ax_anim 2, 0, 160, 10, -10, 10, -10,
+ax_anim 2, 0, 160, -10, 10, -10, 10,
+ax_anim 2, 0, 160, 6, -6, 6, -6,
+ax_anim 2, 0, 160, -6, 6, -6, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_10_7:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 3, 0, 161, 0, -13, 0, -13,
+ax_anim 3, 0, 161, 0, 13, 0, 13,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_10_8:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -6, -6, -6, -6,
+ax_anim 2, 0, 162, 6, 6, 6, 6,
+ax_anim 2, 0, 162, -10, -10, -10, -10,
+ax_anim 2, 0, 162, 10, 10, 10, 10,
+ax_anim 2, 0, 162, -12, -12, -12, -12,
+ax_anim 3, 0, 162, 12, 12, 12, 12,
+ax_anim 3, 0, 162, -13, -13, -13, -13,
+ax_anim 3, 0, 162, 13, 13, 13, 13,
+ax_anim 2, 0, 162, -12, -12, -12, -12,
+ax_anim 3, 0, 162, 12, 12, 12, 12,
+ax_anim 2, 0, 162, -10, -10, -10, -10,
+ax_anim 2, 0, 162, 10, 10, 10, 10,
+ax_anim 2, 0, 162, -6, -6, -6, -6,
+ax_anim 2, 0, 162, 6, 6, 6, 6,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_11_1:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_11_2:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 3, 0, 168, 0, -21, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_11_3:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_11_4:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 174, 0, -21, 0, 0,
+ax_anim 2, 0, 174, 0, -17, 0, 0,
+ax_anim 1, 0, 174, 0, -11, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_11_5:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_11_6:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -17, 0, 0,
+ax_anim 1, 0, 180, 0, -11, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_11_7:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_11_8:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_12_1:
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 1, 0, 1, 0,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_12_2:
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, -1, 1, -1,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_12_3:
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_12_4:
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, -1, -1, -1, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_12_5:
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 1, 0, 1, 0,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_12_6:
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, -1, 1, -1,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_12_7:
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_12_8:
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, -1, -1, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_13_1:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_13_2:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_13_3:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_13_4:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_13_5:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_13_6:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_13_7:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_13_8:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_14_1:
+ax_anim 10, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -4, 0, 0,
+ax_anim 1, 0, 203, 0, -5, 0, 0,
+ax_anim 4, 0, 203, 0, -6, 0, 0,
+ax_anim 2, 0, 203, 0, -5, 0, 0,
+ax_anim 1, 0, 203, 0, -4, 0, 0,
+ax_anim 15, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_15_1:
+ax_anim 4, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_16_1:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_16_2:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_16_3:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_16_4:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_16_5:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_16_6:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_16_7:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_16_8:
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 4, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_17_1:
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 211, 0, 0, 0, 0,
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_17_2:
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 211, 0, 0, 0, 0,
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_17_3:
+ax_anim 22, 0, 213, 0, 0, 0, 0,
+ax_anim 14, 0, 214, 0, 0, 0, 0,
+ax_anim 22, 0, 213, 0, 0, 0, 0,
+ax_anim 14, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_17_4:
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 211, 0, 0, 0, 0,
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_17_5:
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 211, 0, 0, 0, 0,
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_17_6:
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 211, 0, 0, 0, 0,
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_17_7:
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 211, 0, 0, 0, 0,
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_17_8:
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 211, 0, 0, 0, 0,
+ax_anim 22, 0, 210, 0, 0, 0, 0,
+ax_anim 14, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMunchlaxAnims_18_1:
+ax_anim 16, 0, 230, 16, 0, 16, 0,
+ax_anim 8, 0, 231, 16, 0, 16, 0,
+ax_anim 4, 0, 232, 13, 0, 13, 0,
+ax_anim 2, 0, 225, 8, -4, 8, 0,
+ax_anim 3, 0, 238, 7, -8, 7, 0,
+ax_anim 3, 0, 239, 6, -11, 6, 0,
+ax_anim 3, 0, 226, 5, -12, 5, 0,
+ax_anim 3, 0, 227, 4, -12, 4, 0,
+ax_anim 3, 0, 235, 3, -11, 3, 0,
+ax_anim 3, 0, 236, 2, -8, 2, 0,
+ax_anim 2, 0, 226, 1, -4, 1, 0,
+ax_anim 20, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_18_2:
+ax_anim 16, 0, 230, 16, 0, 16, 0,
+ax_anim 8, 0, 231, 16, 0, 16, 0,
+ax_anim 4, 0, 232, 13, 0, 13, 0,
+ax_anim 2, 0, 225, 8, -4, 8, 0,
+ax_anim 3, 0, 238, 7, -8, 7, 0,
+ax_anim 3, 0, 239, 6, -11, 6, 0,
+ax_anim 3, 0, 226, 5, -12, 5, 0,
+ax_anim 3, 0, 227, 4, -12, 4, 0,
+ax_anim 3, 0, 235, 3, -11, 3, 0,
+ax_anim 3, 0, 236, 2, -8, 2, 0,
+ax_anim 2, 0, 226, 1, -4, 1, 0,
+ax_anim 20, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_18_3:
+ax_anim 16, 0, 230, 16, 0, 16, 0,
+ax_anim 8, 0, 231, 16, 0, 16, 0,
+ax_anim 4, 0, 232, 13, 0, 13, 0,
+ax_anim 2, 0, 225, 8, -4, 8, 0,
+ax_anim 3, 0, 238, 7, -8, 7, 0,
+ax_anim 3, 0, 239, 6, -11, 6, 0,
+ax_anim 3, 0, 226, 5, -12, 5, 0,
+ax_anim 3, 0, 227, 4, -12, 4, 0,
+ax_anim 3, 0, 235, 3, -11, 3, 0,
+ax_anim 3, 0, 236, 2, -8, 2, 0,
+ax_anim 2, 0, 226, 1, -4, 1, 0,
+ax_anim 20, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_18_4:
+ax_anim 16, 0, 230, 16, 0, 16, 0,
+ax_anim 8, 0, 231, 16, 0, 16, 0,
+ax_anim 4, 0, 232, 13, 0, 13, 0,
+ax_anim 2, 0, 225, 8, -4, 8, 0,
+ax_anim 3, 0, 238, 7, -8, 7, 0,
+ax_anim 3, 0, 239, 6, -11, 6, 0,
+ax_anim 3, 0, 226, 5, -12, 5, 0,
+ax_anim 3, 0, 227, 4, -12, 4, 0,
+ax_anim 3, 0, 235, 3, -11, 3, 0,
+ax_anim 3, 0, 236, 2, -8, 2, 0,
+ax_anim 2, 0, 226, 1, -4, 1, 0,
+ax_anim 20, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_18_5:
+ax_anim 16, 0, 230, 16, 0, 16, 0,
+ax_anim 8, 0, 231, 16, 0, 16, 0,
+ax_anim 4, 0, 232, 13, 0, 13, 0,
+ax_anim 2, 0, 225, 8, -4, 8, 0,
+ax_anim 3, 0, 238, 7, -8, 7, 0,
+ax_anim 3, 0, 239, 6, -11, 6, 0,
+ax_anim 3, 0, 226, 5, -12, 5, 0,
+ax_anim 3, 0, 227, 4, -12, 4, 0,
+ax_anim 3, 0, 235, 3, -11, 3, 0,
+ax_anim 3, 0, 236, 2, -8, 2, 0,
+ax_anim 2, 0, 226, 1, -4, 1, 0,
+ax_anim 20, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_18_6:
+ax_anim 16, 0, 254, -16, 0, -16, 0,
+ax_anim 8, 0, 255, -16, 0, -16, 0,
+ax_anim 4, 0, 256, -13, 0, -13, 0,
+ax_anim 2, 0, 249, -8, -4, -8, 0,
+ax_anim 3, 0, 262, -7, -8, -7, 0,
+ax_anim 3, 0, 263, -6, -11, -6, 0,
+ax_anim 3, 0, 250, -5, -12, -5, 0,
+ax_anim 3, 0, 251, -4, -12, -4, 0,
+ax_anim 3, 0, 259, -3, -11, -3, 0,
+ax_anim 3, 0, 260, -2, -8, -2, 0,
+ax_anim 2, 0, 250, -1, -4, -1, 0,
+ax_anim 20, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_18_7:
+ax_anim 16, 0, 254, -16, 0, -16, 0,
+ax_anim 8, 0, 255, -16, 0, -16, 0,
+ax_anim 4, 0, 256, -13, 0, -13, 0,
+ax_anim 2, 0, 249, -8, -4, -8, 0,
+ax_anim 3, 0, 262, -7, -8, -7, 0,
+ax_anim 3, 0, 263, -6, -11, -6, 0,
+ax_anim 3, 0, 250, -5, -12, -5, 0,
+ax_anim 3, 0, 251, -4, -12, -4, 0,
+ax_anim 3, 0, 259, -3, -11, -3, 0,
+ax_anim 3, 0, 260, -2, -8, -2, 0,
+ax_anim 2, 0, 250, -1, -4, -1, 0,
+ax_anim 20, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxAnims_18_8:
+ax_anim 16, 0, 254, -16, 0, -16, 0,
+ax_anim 8, 0, 255, -16, 0, -16, 0,
+ax_anim 4, 0, 256, -13, 0, -13, 0,
+ax_anim 2, 0, 249, -8, -4, -8, 0,
+ax_anim 3, 0, 262, -7, -8, -7, 0,
+ax_anim 3, 0, 263, -6, -11, -6, 0,
+ax_anim 3, 0, 250, -5, -12, -5, 0,
+ax_anim 3, 0, 251, -4, -12, -4, 0,
+ax_anim 3, 0, 259, -3, -11, -3, 0,
+ax_anim 3, 0, 260, -2, -8, -2, 0,
+ax_anim 2, 0, 250, -1, -4, -1, 0,
+ax_anim 20, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sMunchlaxGfx1:
+.incbin "baserom.gba", 0x164CAFC, 0x200
+sMunchlaxSprites1:
+ax_sprite sMunchlaxGfx1, 0x200
+ax_sprite_terminator
+sMunchlaxGfx2:
+.incbin "baserom.gba", 0x164CD0C, 0x200
+sMunchlaxSprites2:
+ax_sprite sMunchlaxGfx2, 0x200
+ax_sprite_terminator
+sMunchlaxGfx3:
+.incbin "baserom.gba", 0x164CF1C, 0x200
+sMunchlaxSprites3:
+ax_sprite sMunchlaxGfx3, 0x200
+ax_sprite_terminator
+sMunchlaxGfx4:
+.incbin "baserom.gba", 0x164D12C, 0x200
+sMunchlaxSprites4:
+ax_sprite sMunchlaxGfx4, 0x200
+ax_sprite_terminator
+sMunchlaxGfx5:
+.incbin "baserom.gba", 0x164D33C, 0x200
+sMunchlaxSprites5:
+ax_sprite sMunchlaxGfx5, 0x200
+ax_sprite_terminator
+sMunchlaxGfx6:
+.incbin "baserom.gba", 0x164D54C, 0x200
+sMunchlaxSprites6:
+ax_sprite sMunchlaxGfx6, 0x200
+ax_sprite_terminator
+sMunchlaxGfx7:
+.incbin "baserom.gba", 0x164D75C, 0x200
+sMunchlaxSprites7:
+ax_sprite sMunchlaxGfx7, 0x200
+ax_sprite_terminator
+sMunchlaxGfx8:
+.incbin "baserom.gba", 0x164D96C, 0x100
+sMunchlaxSprites8:
+ax_sprite sMunchlaxGfx8, 0x100
+ax_sprite_terminator
+sMunchlaxGfx9:
+.incbin "baserom.gba", 0x164DA7C, 0x100
+sMunchlaxSprites9:
+ax_sprite sMunchlaxGfx9, 0x100
+ax_sprite_terminator
+sMunchlaxGfx10:
+.incbin "baserom.gba", 0x164DB8C, 0x200
+sMunchlaxSprites10:
+ax_sprite sMunchlaxGfx10, 0x200
+ax_sprite_terminator
+sMunchlaxGfx11:
+.incbin "baserom.gba", 0x164DD9C, 0x200
+sMunchlaxSprites11:
+ax_sprite sMunchlaxGfx11, 0x200
+ax_sprite_terminator
+sMunchlaxGfx12:
+.incbin "baserom.gba", 0x164DFAC, 0x200
+sMunchlaxSprites12:
+ax_sprite sMunchlaxGfx12, 0x200
+ax_sprite_terminator
+sMunchlaxGfx13:
+.incbin "baserom.gba", 0x164E1BC, 0x200
+sMunchlaxSprites13:
+ax_sprite sMunchlaxGfx13, 0x200
+ax_sprite_terminator
+sMunchlaxGfx14:
+.incbin "baserom.gba", 0x164E3CC, 0x200
+sMunchlaxSprites14:
+ax_sprite sMunchlaxGfx14, 0x200
+ax_sprite_terminator
+sMunchlaxGfx15:
+.incbin "baserom.gba", 0x164E5DC, 0x200
+sMunchlaxSprites15:
+ax_sprite sMunchlaxGfx15, 0x200
+ax_sprite_terminator
+sMunchlaxGfx16:
+.incbin "baserom.gba", 0x164E7EC, 0x40
+sMunchlaxGfx16_1:
+.incbin "baserom.gba", 0x164E82C, 0x40
+sMunchlaxGfx16_2:
+.incbin "baserom.gba", 0x164E86C, 0xE0
+sMunchlaxSprites16:
+ax_sprite 0, 0x20
+ax_sprite sMunchlaxGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMunchlaxGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMunchlaxGfx16_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMunchlaxGfx17:
+.incbin "baserom.gba", 0x164E98C, 0x180
+sMunchlaxSprites17:
+ax_sprite sMunchlaxGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMunchlaxGfx18:
+.incbin "baserom.gba", 0x164EB24, 0x40
+sMunchlaxGfx18_1:
+.incbin "baserom.gba", 0x164EB64, 0x100
+sMunchlaxSprites18:
+ax_sprite 0, 0x20
+ax_sprite sMunchlaxGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMunchlaxGfx18_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMunchlaxGfx19:
+.incbin "baserom.gba", 0x164EC94, 0x60
+sMunchlaxGfx19_1:
+.incbin "baserom.gba", 0x164ECF4, 0x60
+sMunchlaxGfx19_2:
+.incbin "baserom.gba", 0x164ED54, 0x60
+sMunchlaxGfx19_3:
+.incbin "baserom.gba", 0x164EDB4, 0x40
+sMunchlaxSprites19:
+ax_sprite sMunchlaxGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMunchlaxGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMunchlaxGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMunchlaxGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMunchlaxGfx20:
+.incbin "baserom.gba", 0x164EE3C, 0x100
+sMunchlaxSprites20:
+ax_sprite sMunchlaxGfx20, 0x100
+ax_sprite_terminator
+sMunchlaxGfx21:
+.incbin "baserom.gba", 0x164EF4C, 0x100
+sMunchlaxSprites21:
+ax_sprite sMunchlaxGfx21, 0x100
+ax_sprite_terminator
+sMunchlaxGfx22:
+.incbin "baserom.gba", 0x164F05C, 0x200
+sMunchlaxSprites22:
+ax_sprite sMunchlaxGfx22, 0x200
+ax_sprite_terminator
+sMunchlaxGfx23:
+.incbin "baserom.gba", 0x164F26C, 0x200
+sMunchlaxSprites23:
+ax_sprite sMunchlaxGfx23, 0x200
+ax_sprite_terminator
+sMunchlaxGfx24:
+.incbin "baserom.gba", 0x164F47C, 0x200
+sMunchlaxSprites24:
+ax_sprite sMunchlaxGfx24, 0x200
+ax_sprite_terminator
+sMunchlaxGfx25:
+.incbin "baserom.gba", 0x164F68C, 0x200
+sMunchlaxSprites25:
+ax_sprite sMunchlaxGfx25, 0x200
+ax_sprite_terminator
+sMunchlaxGfx26:
+.incbin "baserom.gba", 0x164F89C, 0x200
+sMunchlaxSprites26:
+ax_sprite sMunchlaxGfx26, 0x200
+ax_sprite_terminator
+sMunchlaxGfx27:
+.incbin "baserom.gba", 0x164FAAC, 0x200
+sMunchlaxSprites27:
+ax_sprite sMunchlaxGfx27, 0x200
+ax_sprite_terminator
+sMunchlaxGfx28:
+.incbin "baserom.gba", 0x164FCBC, 0x200
+sMunchlaxSprites28:
+ax_sprite sMunchlaxGfx28, 0x200
+ax_sprite_terminator
+sMunchlaxGfx29:
+.incbin "baserom.gba", 0x164FECC, 0x200
+sMunchlaxSprites29:
+ax_sprite sMunchlaxGfx29, 0x200
+ax_sprite_terminator
+sMunchlaxGfx30:
+.incbin "baserom.gba", 0x16500DC, 0x200
+sMunchlaxSprites30:
+ax_sprite sMunchlaxGfx30, 0x200
+ax_sprite_terminator
+sMunchlaxGfx31:
+.incbin "baserom.gba", 0x16502EC, 0x200
+sMunchlaxSprites31:
+ax_sprite sMunchlaxGfx31, 0x200
+ax_sprite_terminator
+sMunchlaxGfx32:
+.incbin "baserom.gba", 0x16504FC, 0x200
+sMunchlaxSprites32:
+ax_sprite sMunchlaxGfx32, 0x200
+ax_sprite_terminator
+sMunchlaxGfx33:
+.incbin "baserom.gba", 0x165070C, 0x200
+sMunchlaxSprites33:
+ax_sprite sMunchlaxGfx33, 0x200
+ax_sprite_terminator
+sMunchlaxGfx34:
+.incbin "baserom.gba", 0x165091C, 0x200
+sMunchlaxSprites34:
+ax_sprite sMunchlaxGfx34, 0x200
+ax_sprite_terminator
+sMunchlaxGfx35:
+.incbin "baserom.gba", 0x1650B2C, 0x200
+sMunchlaxSprites35:
+ax_sprite sMunchlaxGfx35, 0x200
+ax_sprite_terminator
+sMunchlaxGfx36:
+.incbin "baserom.gba", 0x1650D3C, 0x200
+sMunchlaxSprites36:
+ax_sprite sMunchlaxGfx36, 0x200
+ax_sprite_terminator
+sMunchlaxGfx37:
+.incbin "baserom.gba", 0x1650F4C, 0x200
+sMunchlaxSprites37:
+ax_sprite sMunchlaxGfx37, 0x200
+ax_sprite_terminator
+sAxPosesMunchlax:
+.4byte sMunchlaxPose1
+.4byte sMunchlaxPose2
+.4byte sMunchlaxPose3
+.4byte sMunchlaxPose4
+.4byte sMunchlaxPose5
+.4byte sMunchlaxPose6
+.4byte sMunchlaxPose7
+.4byte sMunchlaxPose8
+.4byte sMunchlaxPose9
+.4byte sMunchlaxPose10
+.4byte sMunchlaxPose11
+.4byte sMunchlaxPose12
+.4byte sMunchlaxPose13
+.4byte sMunchlaxPose14
+.4byte sMunchlaxPose15
+.4byte sMunchlaxPose16
+.4byte sMunchlaxPose17
+.4byte sMunchlaxPose18
+.4byte sMunchlaxPose19
+.4byte sMunchlaxPose20
+.4byte sMunchlaxPose21
+.4byte sMunchlaxPose22
+.4byte sMunchlaxPose23
+.4byte sMunchlaxPose24
+.4byte sMunchlaxPose25
+.4byte sMunchlaxPose26
+.4byte sMunchlaxPose27
+.4byte sMunchlaxPose28
+.4byte sMunchlaxPose29
+.4byte sMunchlaxPose30
+.4byte sMunchlaxPose31
+.4byte sMunchlaxPose32
+.4byte sMunchlaxPose33
+.4byte sMunchlaxPose34
+.4byte sMunchlaxPose35
+.4byte sMunchlaxPose36
+.4byte sMunchlaxPose37
+.4byte sMunchlaxPose38
+.4byte sMunchlaxPose39
+.4byte sMunchlaxPose40
+.4byte sMunchlaxPose41
+.4byte sMunchlaxPose42
+.4byte sMunchlaxPose43
+.4byte sMunchlaxPose44
+.4byte sMunchlaxPose45
+.4byte sMunchlaxPose46
+.4byte sMunchlaxPose47
+.4byte sMunchlaxPose48
+.4byte sMunchlaxPose49
+.4byte sMunchlaxPose50
+.4byte sMunchlaxPose51
+.4byte sMunchlaxPose52
+.4byte sMunchlaxPose53
+.4byte sMunchlaxPose54
+.4byte sMunchlaxPose55
+.4byte sMunchlaxPose56
+.4byte sMunchlaxPose57
+.4byte sMunchlaxPose58
+.4byte sMunchlaxPose59
+.4byte sMunchlaxPose60
+.4byte sMunchlaxPose61
+.4byte sMunchlaxPose62
+.4byte sMunchlaxPose63
+.4byte sMunchlaxPose64
+.4byte sMunchlaxPose65
+.4byte sMunchlaxPose66
+.4byte sMunchlaxPose67
+.4byte sMunchlaxPose68
+.4byte sMunchlaxPose69
+.4byte sMunchlaxPose70
+.4byte sMunchlaxPose71
+.4byte sMunchlaxPose72
+.4byte sMunchlaxPose73
+.4byte sMunchlaxPose74
+.4byte sMunchlaxPose75
+.4byte sMunchlaxPose76
+.4byte sMunchlaxPose77
+.4byte sMunchlaxPose78
+.4byte sMunchlaxPose79
+.4byte sMunchlaxPose80
+.4byte sMunchlaxPose81
+.4byte sMunchlaxPose82
+.4byte sMunchlaxPose83
+.4byte sMunchlaxPose84
+.4byte sMunchlaxPose85
+.4byte sMunchlaxPose86
+.4byte sMunchlaxPose87
+.4byte sMunchlaxPose88
+.4byte sMunchlaxPose89
+.4byte sMunchlaxPose90
+.4byte sMunchlaxPose91
+.4byte sMunchlaxPose92
+.4byte sMunchlaxPose93
+.4byte sMunchlaxPose94
+.4byte sMunchlaxPose95
+.4byte sMunchlaxPose96
+.4byte sMunchlaxPose97
+.4byte sMunchlaxPose98
+.4byte sMunchlaxPose99
+.4byte sMunchlaxPose100
+.4byte sMunchlaxPose101
+.4byte sMunchlaxPose102
+.4byte sMunchlaxPose103
+.4byte sMunchlaxPose104
+.4byte sMunchlaxPose105
+.4byte sMunchlaxPose106
+.4byte sMunchlaxPose107
+.4byte sMunchlaxPose108
+.4byte sMunchlaxPose109
+.4byte sMunchlaxPose110
+.4byte sMunchlaxPose111
+.4byte sMunchlaxPose112
+.4byte sMunchlaxPose113
+.4byte sMunchlaxPose114
+.4byte sMunchlaxPose115
+.4byte sMunchlaxPose116
+.4byte sMunchlaxPose117
+.4byte sMunchlaxPose118
+.4byte sMunchlaxPose119
+.4byte sMunchlaxPose120
+.4byte sMunchlaxPose121
+.4byte sMunchlaxPose122
+.4byte sMunchlaxPose123
+.4byte sMunchlaxPose124
+.4byte sMunchlaxPose125
+.4byte sMunchlaxPose126
+.4byte sMunchlaxPose127
+.4byte sMunchlaxPose128
+.4byte sMunchlaxPose129
+.4byte sMunchlaxPose130
+.4byte sMunchlaxPose131
+.4byte sMunchlaxPose132
+.4byte sMunchlaxPose133
+.4byte sMunchlaxPose134
+.4byte sMunchlaxPose135
+.4byte sMunchlaxPose136
+.4byte sMunchlaxPose137
+.4byte sMunchlaxPose138
+.4byte sMunchlaxPose139
+.4byte sMunchlaxPose140
+.4byte sMunchlaxPose141
+.4byte sMunchlaxPose142
+.4byte sMunchlaxPose143
+.4byte sMunchlaxPose144
+.4byte sMunchlaxPose145
+.4byte sMunchlaxPose146
+.4byte sMunchlaxPose147
+.4byte sMunchlaxPose148
+.4byte sMunchlaxPose149
+.4byte sMunchlaxPose150
+.4byte sMunchlaxPose151
+.4byte sMunchlaxPose152
+.4byte sMunchlaxPose153
+.4byte sMunchlaxPose154
+.4byte sMunchlaxPose155
+.4byte sMunchlaxPose156
+.4byte sMunchlaxPose157
+.4byte sMunchlaxPose158
+.4byte sMunchlaxPose159
+.4byte sMunchlaxPose160
+.4byte sMunchlaxPose161
+.4byte sMunchlaxPose162
+.4byte sMunchlaxPose163
+.4byte sMunchlaxPose164
+.4byte sMunchlaxPose165
+.4byte sMunchlaxPose166
+.4byte sMunchlaxPose167
+.4byte sMunchlaxPose168
+.4byte sMunchlaxPose169
+.4byte sMunchlaxPose170
+.4byte sMunchlaxPose171
+.4byte sMunchlaxPose172
+.4byte sMunchlaxPose173
+.4byte sMunchlaxPose174
+.4byte sMunchlaxPose175
+.4byte sMunchlaxPose176
+.4byte sMunchlaxPose177
+.4byte sMunchlaxPose178
+.4byte sMunchlaxPose179
+.4byte sMunchlaxPose180
+.4byte sMunchlaxPose181
+.4byte sMunchlaxPose182
+.4byte sMunchlaxPose183
+.4byte sMunchlaxPose184
+.4byte sMunchlaxPose185
+.4byte sMunchlaxPose186
+.4byte sMunchlaxPose187
+.4byte sMunchlaxPose188
+.4byte sMunchlaxPose189
+.4byte sMunchlaxPose190
+.4byte sMunchlaxPose191
+.4byte sMunchlaxPose192
+.4byte sMunchlaxPose193
+.4byte sMunchlaxPose194
+.4byte sMunchlaxPose195
+.4byte sMunchlaxPose196
+.4byte sMunchlaxPose197
+.4byte sMunchlaxPose198
+.4byte sMunchlaxPose199
+.4byte sMunchlaxPose200
+.4byte sMunchlaxPose201
+.4byte sMunchlaxPose202
+.4byte sMunchlaxPose203
+.4byte sMunchlaxPose204
+.4byte sMunchlaxPose205
+.4byte sMunchlaxPose206
+.4byte sMunchlaxPose207
+.4byte sMunchlaxPose208
+.4byte sMunchlaxPose209
+.4byte sMunchlaxPose210
+.4byte sMunchlaxPose211
+.4byte sMunchlaxPose212
+.4byte sMunchlaxPose213
+.4byte sMunchlaxPose214
+.4byte sMunchlaxPose215
+.4byte sMunchlaxPose216
+.4byte sMunchlaxPose217
+.4byte sMunchlaxPose218
+.4byte sMunchlaxPose219
+.4byte sMunchlaxPose220
+.4byte sMunchlaxPose221
+.4byte sMunchlaxPose222
+.4byte sMunchlaxPose223
+.4byte sMunchlaxPose224
+.4byte sMunchlaxPose225
+.4byte sMunchlaxPose226
+.4byte sMunchlaxPose227
+.4byte sMunchlaxPose228
+.4byte sMunchlaxPose229
+.4byte sMunchlaxPose230
+.4byte sMunchlaxPose231
+.4byte sMunchlaxPose232
+.4byte sMunchlaxPose233
+.4byte sMunchlaxPose234
+.4byte sMunchlaxPose235
+.4byte sMunchlaxPose236
+.4byte sMunchlaxPose237
+.4byte sMunchlaxPose238
+.4byte sMunchlaxPose239
+.4byte sMunchlaxPose240
+.4byte sMunchlaxPose241
+.4byte sMunchlaxPose242
+.4byte sMunchlaxPose243
+.4byte sMunchlaxPose244
+.4byte sMunchlaxPose245
+.4byte sMunchlaxPose246
+.4byte sMunchlaxPose247
+.4byte sMunchlaxPose248
+.4byte sMunchlaxPose249
+.4byte sMunchlaxPose250
+.4byte sMunchlaxPose251
+.4byte sMunchlaxPose252
+.4byte sMunchlaxPose253
+.4byte sMunchlaxPose254
+.4byte sMunchlaxPose255
+.4byte sMunchlaxPose256
+.4byte sMunchlaxPose257
+.4byte sMunchlaxPose258
+.4byte sMunchlaxPose259
+.4byte sMunchlaxPose260
+.4byte sMunchlaxPose261
+.4byte sMunchlaxPose262
+.4byte sMunchlaxPose263
+.4byte sMunchlaxPose264
+.4byte sMunchlaxPose265
+.4byte sMunchlaxPose266
+.4byte sMunchlaxPose267
+sAxPositionsMunchlax:
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -9, 	   8,   -9, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -9, 	   7,  -13, 	  -7,   -8, 	   0,   -6
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    3,   -9, 	  -2,  -10, 	  -3,   -7, 	   0,   -6
+.2byte    3,   -8, 	  -3,   -9, 	  -1,   -6, 	   0,   -5
+.2byte    3,   -8, 	   3,   -9, 	  -4,   -6, 	  -1,   -5
+.2byte    0,  -13, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -7
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -13, 	   7,  -13, 	  -5,   -8, 	   2,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	   2,  -10, 	   3,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -9, 	   8,   -9, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -9, 	   7,  -13, 	  -7,   -8, 	   0,   -6
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    3,   -9, 	  -2,  -10, 	  -3,   -7, 	   0,   -6
+.2byte    3,   -8, 	  -3,   -9, 	  -1,   -6, 	   0,   -5
+.2byte    3,   -8, 	   3,   -9, 	  -4,   -6, 	  -1,   -5
+.2byte    0,  -13, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -7
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -13, 	   7,  -13, 	  -5,   -8, 	   2,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	   2,  -10, 	   3,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -9, 	   8,   -9, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -9, 	   7,  -13, 	  -7,   -8, 	   0,   -6
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    3,   -9, 	  -2,  -10, 	  -3,   -7, 	   0,   -6
+.2byte    3,   -8, 	  -3,   -9, 	  -1,   -6, 	   0,   -5
+.2byte    3,   -8, 	   3,   -9, 	  -4,   -6, 	  -1,   -5
+.2byte    0,  -13, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -7
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -13, 	   7,  -13, 	  -5,   -8, 	   2,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	   2,  -10, 	   3,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    3,   -8, 	   3,   -9, 	  -4,   -6, 	  -1,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -9, 	   8,   -9, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    0,   -9, 	  -7,   -7, 	   9,   -9, 	   0,  -10
+.2byte    0,    3, 	  -9,    0, 	   9,    0, 	   0,   -4
+.2byte    0,    3, 	  -9,    0, 	   9,    0, 	   0,   -4
+.2byte    3,   -9, 	   7,  -13, 	  -7,   -8, 	   0,   -6
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    3,   -9, 	  -2,  -10, 	  -3,   -7, 	   0,   -6
+.2byte    3,   -8, 	  -3,   -9, 	  -1,   -6, 	   0,   -5
+.2byte    3,   -8, 	   3,   -9, 	  -4,   -6, 	  -1,   -5
+.2byte    4,  -10, 	   5,   -8, 	  -4,   -9, 	   0,   -9
+.2byte    5,   -1, 	   6,   -2, 	   4,    0, 	   0,   -4
+.2byte    5,   -1, 	   6,   -2, 	   4,    0, 	   0,   -4
+.2byte    0,  -13, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -7
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -13, 	   7,  -13, 	  -5,   -8, 	   2,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	   2,  -10, 	   3,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte   -4,  -10, 	  -5,   -8, 	   4,   -9, 	   0,   -9
+.2byte   -5,   -1, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte   -5,   -1, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte   -3,   -6, 	  -5,   -3, 	   3,   -1, 	   0,   -3
+.2byte   -3,   -5, 	  -5,   -3, 	   3,   -1, 	   0,   -3
+.2byte    0,   -5, 	  -8,  -10, 	   8,  -10, 	   0,   -6
+.2byte    4,   -6, 	   6,  -11, 	  -7,   -9, 	   0,   -6
+.2byte    2,   -6, 	  -3,  -11, 	  -7,   -7, 	  -2,   -6
+.2byte    2,  -10, 	  -9,   -9, 	   3,   -7, 	  -2,   -6
+.2byte    0,   -9, 	   9,   -7, 	  -8,   -7, 	   0,   -5
+.2byte   -3,  -10, 	   8,   -9, 	  -4,   -7, 	   1,   -6
+.2byte   -3,   -6, 	   2,  -11, 	   6,   -7, 	   1,   -6
+.2byte   -5,   -6, 	  -7,  -11, 	   6,   -9, 	  -1,   -6
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -9, 	   8,   -9, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -9, 	   7,  -13, 	  -7,   -8, 	   0,   -6
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    3,   -9, 	  -2,  -10, 	  -3,   -7, 	   0,   -6
+.2byte    3,   -8, 	  -3,   -9, 	  -1,   -6, 	   0,   -5
+.2byte    3,   -8, 	   3,   -9, 	  -4,   -6, 	  -1,   -5
+.2byte    0,  -13, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -7
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -13, 	   7,  -13, 	  -5,   -8, 	   2,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	   2,  -10, 	   3,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte    0,   -8, 	  -7,   -9, 	   8,   -9, 	   0,   -5
+.2byte   -3,   -8, 	  -7,  -12, 	   7,   -7, 	   0,   -5
+.2byte   -3,   -8, 	   2,   -9, 	   3,   -6, 	   0,   -5
+.2byte    0,  -12, 	   7,  -12, 	  -5,   -7, 	   2,   -6
+.2byte    0,  -11, 	   8,   -9, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -12, 	  -7,  -12, 	   5,   -7, 	  -2,   -6
+.2byte    3,   -8, 	  -2,   -9, 	  -3,   -6, 	   0,   -5
+.2byte    3,   -8, 	   7,  -12, 	  -7,   -7, 	   0,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	  -3,   -9, 	  -1,   -6, 	   0,   -5
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -9, 	   8,   -9, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -9, 	   7,  -13, 	  -7,   -8, 	   0,   -6
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    3,   -7, 	  -2,   -8, 	  -3,   -5, 	   0,   -4
+.2byte    3,   -8, 	  -3,   -9, 	  -1,   -6, 	   0,   -5
+.2byte    3,   -7, 	   3,   -8, 	  -4,   -5, 	  -1,   -4
+.2byte    0,  -12, 	  -7,  -12, 	   5,   -7, 	  -2,   -6
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    0,  -10, 	   8,   -8, 	  -8,   -8, 	   0,   -5
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -10, 	   7,   -9, 	  -8,   -8, 	   0,   -5
+.2byte    0,  -12, 	   7,  -12, 	  -5,   -7, 	   2,   -6
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	   2,  -10, 	   3,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    3,   -8, 	   3,   -9, 	  -4,   -6, 	  -1,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    0,   -8, 	  -7,   -9, 	   8,   -9, 	   0,   -5
+.2byte   -3,   -8, 	  -7,  -12, 	   7,   -7, 	   0,   -5
+.2byte   -3,   -8, 	   2,   -9, 	   3,   -6, 	   0,   -5
+.2byte    0,  -12, 	   7,  -12, 	  -5,   -7, 	   2,   -6
+.2byte    0,  -11, 	   8,   -9, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -12, 	  -7,  -12, 	   5,   -7, 	  -2,   -6
+.2byte    3,   -8, 	  -2,   -9, 	  -3,   -6, 	   0,   -5
+.2byte    3,   -8, 	   7,  -12, 	  -7,   -7, 	   0,   -5
+.2byte    0,   -7, 	  -5,   -4, 	   5,   -4, 	   0,   -4
+.2byte    0,   -8, 	  -6,   -6, 	   6,   -6, 	   0,   -5
+.2byte    0,   -8, 	  -6,   -6, 	   6,   -6, 	   0,   -5
+.2byte    0,   -8, 	  -6,   -6, 	   6,   -6, 	   0,   -5
+.2byte    0,   -8, 	  -6,   -6, 	   6,   -6, 	   0,   -5
+.2byte    0,   -9, 	  -8,   -9, 	   8,   -5, 	   0,   -5
+.2byte    0,   -8, 	  -7,   -5, 	   8,   -9, 	   0,   -4
+.2byte   -5,   -6, 	   1,   -6, 	   2,   -4, 	   0,   -5
+.2byte   -5,   -7, 	   1,   -7, 	   2,   -5, 	   0,   -6
+.2byte   -5,   -7, 	   1,   -7, 	   2,   -5, 	   0,   -6
+.2byte    5,   -6, 	  -1,   -6, 	  -2,   -4, 	   0,   -5
+.2byte    5,   -7, 	  -1,   -7, 	  -2,   -5, 	   0,   -6
+.2byte    5,   -7, 	  -1,   -7, 	  -2,   -5, 	   0,   -6
+.2byte    0,   -9, 	  -7,  -10, 	   8,  -10, 	   0,   -6
+.2byte    0,   -8, 	  -6,   -9, 	   8,   -9, 	   1,   -5
+.2byte    0,   -8, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    0,   -9, 	  -7,   -7, 	   9,   -9, 	   0,  -10
+.2byte    0,    3, 	  -9,    0, 	   9,    0, 	   0,   -4
+.2byte    0,    3, 	  -9,    0, 	   9,    0, 	   0,   -4
+.2byte    3,   -9, 	   7,  -13, 	  -7,   -8, 	   0,   -6
+.2byte    3,   -8, 	   5,  -10, 	  -6,   -6, 	   0,   -5
+.2byte    3,   -8, 	   8,  -11, 	  -7,   -7, 	  -1,   -5
+.2byte    2,   -9, 	  -3,  -10, 	  -4,   -7, 	  -1,   -6
+.2byte    2,   -8, 	  -4,   -9, 	  -2,   -6, 	  -1,   -5
+.2byte    2,   -8, 	   2,   -9, 	  -5,   -6, 	  -2,   -5
+.2byte    3,  -10, 	   4,   -8, 	  -5,   -9, 	  -1,   -9
+.2byte    4,   -1, 	   5,   -2, 	   3,    0, 	  -1,   -4
+.2byte    4,   -1, 	   5,   -2, 	   3,    0, 	  -1,   -4
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    3,   -6, 	  -3,   -6, 	  -4,   -4, 	  -2,   -5
+.2byte    5,   -6, 	  -1,   -6, 	  -2,   -4, 	   0,   -5
+.2byte    2,   -9, 	   6,  -13, 	  -8,   -8, 	  -1,   -6
+.2byte    2,   -8, 	   4,  -10, 	  -7,   -6, 	  -1,   -5
+.2byte    2,   -8, 	   7,  -11, 	  -8,   -7, 	  -2,   -5
+.2byte   -1,  -13, 	  -8,  -13, 	   4,   -8, 	  -3,   -7
+.2byte   -1,  -12, 	  -9,  -11, 	   5,   -8, 	  -3,   -6
+.2byte   -1,  -12, 	  -3,  -12, 	   3,   -7, 	  -3,   -6
+.2byte    0,  -13, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    0,  -12, 	  -8,  -11, 	   6,   -8, 	  -2,   -6
+.2byte    0,  -12, 	  -2,  -12, 	   4,   -7, 	  -2,   -6
+.2byte    0,  -12, 	   8,  -10, 	  -8,  -10, 	   0,   -7
+.2byte    0,  -11, 	   8,   -8, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -11, 	   7,  -10, 	  -8,   -9, 	   0,   -6
+.2byte    0,  -13, 	   7,  -13, 	  -5,   -8, 	   2,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	   2,  -10, 	   3,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   3,   -9, 	   1,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -3,   -9, 	   4,   -6, 	   1,   -5
+.2byte   -4,  -10, 	  -5,   -8, 	   4,   -9, 	   0,   -9
+.2byte   -5,   -1, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte   -5,   -1, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte   -4,   -6, 	   2,   -6, 	   3,   -4, 	   1,   -5
+.2byte   -6,   -6, 	   0,   -6, 	   1,   -4, 	  -1,   -5
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+.2byte    0,  -13, 	   7,  -13, 	  -5,   -8, 	   2,   -7
+.2byte    0,  -12, 	   8,  -11, 	  -6,   -8, 	   2,   -6
+.2byte    0,  -12, 	   2,  -12, 	  -4,   -7, 	   2,   -6
+.2byte   -3,   -9, 	  -7,  -13, 	   7,   -8, 	   0,   -6
+.2byte   -3,   -8, 	  -5,  -10, 	   6,   -6, 	   0,   -5
+.2byte   -3,   -8, 	  -8,  -11, 	   7,   -7, 	   1,   -5
+sMunchlaxAnimTable1:
+.4byte sMunchlaxAnims_1_1
+.4byte sMunchlaxAnims_1_2
+.4byte sMunchlaxAnims_1_3
+.4byte sMunchlaxAnims_1_4
+.4byte sMunchlaxAnims_1_5
+.4byte sMunchlaxAnims_1_6
+.4byte sMunchlaxAnims_1_7
+.4byte sMunchlaxAnims_1_8
+sMunchlaxAnimTable2:
+.4byte sMunchlaxAnims_2_1
+.4byte sMunchlaxAnims_2_2
+.4byte sMunchlaxAnims_2_3
+.4byte sMunchlaxAnims_2_4
+.4byte sMunchlaxAnims_2_5
+.4byte sMunchlaxAnims_2_6
+.4byte sMunchlaxAnims_2_7
+.4byte sMunchlaxAnims_2_8
+sMunchlaxAnimTable3:
+.4byte sMunchlaxAnims_3_1
+.4byte sMunchlaxAnims_3_2
+.4byte sMunchlaxAnims_3_3
+.4byte sMunchlaxAnims_3_4
+.4byte sMunchlaxAnims_3_5
+.4byte sMunchlaxAnims_3_6
+.4byte sMunchlaxAnims_3_7
+.4byte sMunchlaxAnims_3_8
+sMunchlaxAnimTable4:
+.4byte sMunchlaxAnims_4_1
+.4byte sMunchlaxAnims_4_2
+.4byte sMunchlaxAnims_4_3
+.4byte sMunchlaxAnims_4_4
+.4byte sMunchlaxAnims_4_5
+.4byte sMunchlaxAnims_4_6
+.4byte sMunchlaxAnims_4_7
+.4byte sMunchlaxAnims_4_8
+sMunchlaxAnimTable5:
+.4byte sMunchlaxAnims_5_1
+.4byte sMunchlaxAnims_5_2
+.4byte sMunchlaxAnims_5_3
+.4byte sMunchlaxAnims_5_4
+.4byte sMunchlaxAnims_5_5
+.4byte sMunchlaxAnims_5_6
+.4byte sMunchlaxAnims_5_7
+.4byte sMunchlaxAnims_5_8
+sMunchlaxAnimTable6:
+.4byte sMunchlaxAnims_6_1
+.4byte sMunchlaxAnims_6_1
+.4byte sMunchlaxAnims_6_1
+.4byte sMunchlaxAnims_6_1
+.4byte sMunchlaxAnims_6_1
+.4byte sMunchlaxAnims_6_1
+.4byte sMunchlaxAnims_6_1
+.4byte sMunchlaxAnims_6_1
+sMunchlaxAnimTable7:
+.4byte sMunchlaxAnims_7_1
+.4byte sMunchlaxAnims_7_2
+.4byte sMunchlaxAnims_7_3
+.4byte sMunchlaxAnims_7_4
+.4byte sMunchlaxAnims_7_5
+.4byte sMunchlaxAnims_7_6
+.4byte sMunchlaxAnims_7_7
+.4byte sMunchlaxAnims_7_8
+sMunchlaxAnimTable8:
+.4byte sMunchlaxAnims_8_1
+.4byte sMunchlaxAnims_8_2
+.4byte sMunchlaxAnims_8_3
+.4byte sMunchlaxAnims_8_4
+.4byte sMunchlaxAnims_8_5
+.4byte sMunchlaxAnims_8_6
+.4byte sMunchlaxAnims_8_7
+.4byte sMunchlaxAnims_8_8
+sMunchlaxAnimTable9:
+.4byte sMunchlaxAnims_9_1
+.4byte sMunchlaxAnims_9_2
+.4byte sMunchlaxAnims_9_3
+.4byte sMunchlaxAnims_9_4
+.4byte sMunchlaxAnims_9_5
+.4byte sMunchlaxAnims_9_6
+.4byte sMunchlaxAnims_9_7
+.4byte sMunchlaxAnims_9_8
+sMunchlaxAnimTable10:
+.4byte sMunchlaxAnims_10_1
+.4byte sMunchlaxAnims_10_2
+.4byte sMunchlaxAnims_10_3
+.4byte sMunchlaxAnims_10_4
+.4byte sMunchlaxAnims_10_5
+.4byte sMunchlaxAnims_10_6
+.4byte sMunchlaxAnims_10_7
+.4byte sMunchlaxAnims_10_8
+sMunchlaxAnimTable11:
+.4byte sMunchlaxAnims_11_1
+.4byte sMunchlaxAnims_11_2
+.4byte sMunchlaxAnims_11_3
+.4byte sMunchlaxAnims_11_4
+.4byte sMunchlaxAnims_11_5
+.4byte sMunchlaxAnims_11_6
+.4byte sMunchlaxAnims_11_7
+.4byte sMunchlaxAnims_11_8
+sMunchlaxAnimTable12:
+.4byte sMunchlaxAnims_12_1
+.4byte sMunchlaxAnims_12_2
+.4byte sMunchlaxAnims_12_3
+.4byte sMunchlaxAnims_12_4
+.4byte sMunchlaxAnims_12_5
+.4byte sMunchlaxAnims_12_6
+.4byte sMunchlaxAnims_12_7
+.4byte sMunchlaxAnims_12_8
+sMunchlaxAnimTable13:
+.4byte sMunchlaxAnims_13_1
+.4byte sMunchlaxAnims_13_2
+.4byte sMunchlaxAnims_13_3
+.4byte sMunchlaxAnims_13_4
+.4byte sMunchlaxAnims_13_5
+.4byte sMunchlaxAnims_13_6
+.4byte sMunchlaxAnims_13_7
+.4byte sMunchlaxAnims_13_8
+sMunchlaxAnimTable14:
+.4byte sMunchlaxAnims_14_1
+.4byte sMunchlaxAnims_14_1
+.4byte sMunchlaxAnims_14_1
+.4byte sMunchlaxAnims_14_1
+.4byte sMunchlaxAnims_14_1
+.4byte sMunchlaxAnims_14_1
+.4byte sMunchlaxAnims_14_1
+.4byte sMunchlaxAnims_14_1
+sMunchlaxAnimTable15:
+.4byte sMunchlaxAnims_15_1
+.4byte sMunchlaxAnims_15_1
+.4byte sMunchlaxAnims_15_1
+.4byte sMunchlaxAnims_15_1
+.4byte sMunchlaxAnims_15_1
+.4byte sMunchlaxAnims_15_1
+.4byte sMunchlaxAnims_15_1
+.4byte sMunchlaxAnims_15_1
+sMunchlaxAnimTable16:
+.4byte sMunchlaxAnims_16_1
+.4byte sMunchlaxAnims_16_2
+.4byte sMunchlaxAnims_16_3
+.4byte sMunchlaxAnims_16_4
+.4byte sMunchlaxAnims_16_5
+.4byte sMunchlaxAnims_16_6
+.4byte sMunchlaxAnims_16_7
+.4byte sMunchlaxAnims_16_8
+sMunchlaxAnimTable17:
+.4byte sMunchlaxAnims_17_1
+.4byte sMunchlaxAnims_17_2
+.4byte sMunchlaxAnims_17_3
+.4byte sMunchlaxAnims_17_4
+.4byte sMunchlaxAnims_17_5
+.4byte sMunchlaxAnims_17_6
+.4byte sMunchlaxAnims_17_7
+.4byte sMunchlaxAnims_17_8
+sMunchlaxAnimTable18:
+.4byte sMunchlaxAnims_18_1
+.4byte sMunchlaxAnims_18_2
+.4byte sMunchlaxAnims_18_3
+.4byte sMunchlaxAnims_18_4
+.4byte sMunchlaxAnims_18_5
+.4byte sMunchlaxAnims_18_6
+.4byte sMunchlaxAnims_18_7
+.4byte sMunchlaxAnims_18_8
+sAxAnimationsMunchlax:
+.4byte sMunchlaxAnimTable1
+.4byte sMunchlaxAnimTable2
+.4byte sMunchlaxAnimTable3
+.4byte sMunchlaxAnimTable4
+.4byte sMunchlaxAnimTable5
+.4byte sMunchlaxAnimTable6
+.4byte sMunchlaxAnimTable7
+.4byte sMunchlaxAnimTable8
+.4byte sMunchlaxAnimTable9
+.4byte sMunchlaxAnimTable10
+.4byte sMunchlaxAnimTable11
+.4byte sMunchlaxAnimTable12
+.4byte sMunchlaxAnimTable13
+.4byte sMunchlaxAnimTable14
+.4byte sMunchlaxAnimTable15
+.4byte sMunchlaxAnimTable16
+.4byte sMunchlaxAnimTable17
+.4byte sMunchlaxAnimTable18
+sAxSpritesMunchlax:
+.4byte sMunchlaxSprites1
+.4byte sMunchlaxSprites2
+.4byte sMunchlaxSprites3
+.4byte sMunchlaxSprites4
+.4byte sMunchlaxSprites5
+.4byte sMunchlaxSprites6
+.4byte sMunchlaxSprites7
+.4byte sMunchlaxSprites8
+.4byte sMunchlaxSprites9
+.4byte sMunchlaxSprites10
+.4byte sMunchlaxSprites11
+.4byte sMunchlaxSprites12
+.4byte sMunchlaxSprites13
+.4byte sMunchlaxSprites14
+.4byte sMunchlaxSprites15
+.4byte sMunchlaxSprites16
+.4byte sMunchlaxSprites17
+.4byte sMunchlaxSprites18
+.4byte sMunchlaxSprites19
+.4byte sMunchlaxSprites20
+.4byte sMunchlaxSprites21
+.4byte sMunchlaxSprites22
+.4byte sMunchlaxSprites23
+.4byte sMunchlaxSprites24
+.4byte sMunchlaxSprites25
+.4byte sMunchlaxSprites26
+.4byte sMunchlaxSprites27
+.4byte sMunchlaxSprites28
+.4byte sMunchlaxSprites29
+.4byte sMunchlaxSprites30
+.4byte sMunchlaxSprites31
+.4byte sMunchlaxSprites32
+.4byte sMunchlaxSprites33
+.4byte sMunchlaxSprites34
+.4byte sMunchlaxSprites35
+.4byte sMunchlaxSprites36
+.4byte sMunchlaxSprites37
+sAxMainMunchlax:
+ax_main sAxPosesMunchlax, sAxAnimationsMunchlax, 18, sAxSpritesMunchlax, sAxPositionsMunchlax

--- a/data/ax/murkrow.inc
+++ b/data/ax/murkrow.inc
@@ -1,0 +1,2402 @@
+.global gAxMurkrow
+gAxMurkrow:
+ax_siro sAxMainMurkrow
+sMurkrowPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose3:
+ax_pose 2, 0x01e7, 0x90e9, 0x2c00
+ax_pose_terminator
+sMurkrowPose4:
+ax_pose 3, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose5:
+ax_pose 4, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose6:
+ax_pose 5, 0x01e9, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose7:
+ax_pose 6, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose8:
+ax_pose 7, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose9:
+ax_pose 8, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose10:
+ax_pose 9, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose11:
+ax_pose 6, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose12:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose13:
+ax_pose 4, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose14:
+ax_pose 5, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose15:
+ax_pose 2, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sMurkrowPose16:
+ax_pose 3, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose17:
+ax_pose 0, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose18:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose19:
+ax_pose 10, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose20:
+ax_pose 2, 0x01e7, 0x90e9, 0x2c00
+ax_pose_terminator
+sMurkrowPose21:
+ax_pose 3, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose22:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose23:
+ax_pose 4, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose24:
+ax_pose 5, 0x01e9, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose25:
+ax_pose 12, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sMurkrowPose26:
+ax_pose 6, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose27:
+ax_pose 7, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose28:
+ax_pose 13, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose29:
+ax_pose 8, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose30:
+ax_pose 9, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose31:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose32:
+ax_pose 6, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose33:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose34:
+ax_pose 13, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose35:
+ax_pose 4, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose36:
+ax_pose 5, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose37:
+ax_pose 12, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose38:
+ax_pose 2, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sMurkrowPose39:
+ax_pose 3, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose40:
+ax_pose 11, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose41:
+ax_pose 0, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose42:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose43:
+ax_pose 10, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose44:
+ax_pose 2, 0x01e7, 0x90e9, 0x2c00
+ax_pose_terminator
+sMurkrowPose45:
+ax_pose 3, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose46:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose47:
+ax_pose 4, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose48:
+ax_pose 5, 0x01e9, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose49:
+ax_pose 12, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sMurkrowPose50:
+ax_pose 6, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose51:
+ax_pose 7, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose52:
+ax_pose 13, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose53:
+ax_pose 8, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose54:
+ax_pose 9, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose55:
+ax_pose 14, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose56:
+ax_pose 6, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose57:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose58:
+ax_pose 13, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose59:
+ax_pose 4, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose60:
+ax_pose 5, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose61:
+ax_pose 12, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose62:
+ax_pose 2, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sMurkrowPose63:
+ax_pose 3, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose64:
+ax_pose 11, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose65:
+ax_pose 15, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose66:
+ax_pose 16, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose67:
+ax_pose 17, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose68:
+ax_pose 18, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose69:
+ax_pose 19, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose70:
+ax_pose 20, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sMurkrowPose71:
+ax_pose 21, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose72:
+ax_pose 22, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose73:
+ax_pose 23, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose74:
+ax_pose 24, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose75:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose76:
+ax_pose 22, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose77:
+ax_pose 19, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose78:
+ax_pose 20, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose79:
+ax_pose 17, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose80:
+ax_pose 18, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose81:
+ax_pose 0, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose82:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose83:
+ax_pose 2, 0x01e7, 0x90e9, 0x2c00
+ax_pose_terminator
+sMurkrowPose84:
+ax_pose 3, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose85:
+ax_pose 4, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose86:
+ax_pose 5, 0x01e9, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose87:
+ax_pose 6, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose88:
+ax_pose 7, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose89:
+ax_pose 8, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose90:
+ax_pose 9, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose91:
+ax_pose 6, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose92:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose93:
+ax_pose 4, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose94:
+ax_pose 5, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose95:
+ax_pose 2, 0x01e7, 0x80f6, 0x2c00
+ax_pose_terminator
+sMurkrowPose96:
+ax_pose 3, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose97:
+ax_pose 25, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose98:
+ax_pose 26, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose99:
+ax_pose 27, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose100:
+ax_pose 28, 0x01e3, 0x90ea, 0x2c00
+ax_pose_terminator
+sMurkrowPose101:
+ax_pose 29, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sMurkrowPose102:
+ax_pose 30, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sMurkrowPose103:
+ax_pose 31, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose104:
+ax_pose 30, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose105:
+ax_pose 29, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sMurkrowPose106:
+ax_pose 28, 0x01e3, 0x80f6, 0x2c00
+ax_pose_terminator
+sMurkrowPose107:
+ax_pose 15, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose108:
+ax_pose 17, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose109:
+ax_pose 19, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose110:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose111:
+ax_pose 23, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose112:
+ax_pose 21, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose113:
+ax_pose 19, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose114:
+ax_pose 17, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose115:
+ax_pose 10, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose116:
+ax_pose 11, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose117:
+ax_pose 12, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose118:
+ax_pose 13, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose119:
+ax_pose 14, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose120:
+ax_pose 13, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sMurkrowPose121:
+ax_pose 12, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose122:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose123:
+ax_pose 16, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose124:
+ax_pose 18, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose125:
+ax_pose 20, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sMurkrowPose126:
+ax_pose 22, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose127:
+ax_pose 24, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose128:
+ax_pose 22, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose129:
+ax_pose 20, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose130:
+ax_pose 18, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose131:
+ax_pose 15, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose132:
+ax_pose 0, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose133:
+ax_pose 1, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose134:
+ax_pose 17, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose135:
+ax_pose 2, 0x01e9, 0x90ea, 0x2c00
+ax_pose_terminator
+sMurkrowPose136:
+ax_pose 3, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose137:
+ax_pose 19, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose138:
+ax_pose 4, 0x01eb, 0x90f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose139:
+ax_pose 5, 0x01e9, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose140:
+ax_pose 21, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose141:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose142:
+ax_pose 7, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sMurkrowPose143:
+ax_pose 23, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose144:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose145:
+ax_pose 9, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose146:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose147:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose148:
+ax_pose 7, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose149:
+ax_pose 19, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose150:
+ax_pose 4, 0x01eb, 0x80ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose151:
+ax_pose 5, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose152:
+ax_pose 17, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose153:
+ax_pose 2, 0x01ea, 0x80f7, 0x2c00
+ax_pose_terminator
+sMurkrowPose154:
+ax_pose 3, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sMurkrowPose155:
+ax_pose 16, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose156:
+ax_pose 18, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose157:
+ax_pose 20, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sMurkrowPose158:
+ax_pose 22, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose159:
+ax_pose 24, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sMurkrowPose160:
+ax_pose 22, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sMurkrowPose161:
+ax_pose 20, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sMurkrowPose162:
+ax_pose 18, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose163:
+ax_pose 15, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose164:
+ax_pose 17, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose165:
+ax_pose 19, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose166:
+ax_pose 21, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sMurkrowPose167:
+ax_pose 23, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sMurkrowPose168:
+ax_pose 21, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose169:
+ax_pose 19, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sMurkrowPose170:
+ax_pose 17, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+.align 2
+sMurkrowAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 17, 0, -2, 0, -2,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 0, 4, 0, 4,
+ax_anim 1, 0, 18, 0, 10, 0, 10,
+ax_anim 2, 0, 18, 0, 18, 0, 18,
+ax_anim 2, 1, 18, 1, 18, 1, 18,
+ax_anim 2, 0, 18, 0, 18, 0, 18,
+ax_anim 2, 0, 18, 1, 18, 1, 18,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sMurkrowAnims_2_2:
+ax_anim 2, 0, 19, -1, -1, -1, -1,
+ax_anim 4, 0, 20, -2, -2, -2, -2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, 4, 4, 4, 4,
+ax_anim 1, 0, 21, 10, 10, 10, 10,
+ax_anim 2, 0, 21, 18, 20, 18, 20,
+ax_anim 2, 1, 21, 19, 19, 19, 19,
+ax_anim 2, 0, 21, 18, 20, 18, 20,
+ax_anim 2, 0, 21, 19, 19, 19, 19,
+ax_anim 2, 0, 19, 6, 6, 6, 6,
+ax_anim_terminator
+sMurkrowAnims_2_3:
+ax_anim 2, 0, 22, -1, 0, -1, 0,
+ax_anim 4, 0, 23, -2, 0, -2, 0,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 4, 0, 4, 0,
+ax_anim 1, 0, 24, 10, 0, 10, 0,
+ax_anim 2, 0, 24, 17, 0, 17, 0,
+ax_anim 2, 1, 24, 17, 1, 17, 1,
+ax_anim 2, 0, 24, 17, 0, 17, 0,
+ax_anim 2, 0, 24, 17, 1, 17, 1,
+ax_anim 2, 0, 22, 6, 0, 6, 0,
+ax_anim_terminator
+sMurkrowAnims_2_4:
+ax_anim 2, 0, 25, -1, 1, -1, 1,
+ax_anim 4, 0, 26, -2, 2, -2, 2,
+ax_anim 1, 0, 27, 0, -1, 0, -1,
+ax_anim 1, 2, 27, 4, -6, 4, -6,
+ax_anim 1, 0, 27, 10, -13, 10, -13,
+ax_anim 2, 0, 27, 18, -19, 18, -23,
+ax_anim 2, 1, 27, 19, -18, 19, -22,
+ax_anim 2, 0, 27, 18, -19, 18, -23,
+ax_anim 2, 0, 27, 19, -18, 19, -22,
+ax_anim 2, 0, 25, 6, -6, 6, -6,
+ax_anim_terminator
+sMurkrowAnims_2_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 4, 0, 29, 0, 3, 0, 3,
+ax_anim 1, 0, 30, 0, 2, 0, 2,
+ax_anim 1, 2, 30, 0, -3, 0, -3,
+ax_anim 1, 0, 30, 0, -11, 0, -11,
+ax_anim 2, 0, 30, 0, -20, 0, -20,
+ax_anim 2, 1, 30, 1, -20, 1, -20,
+ax_anim 2, 0, 30, 0, -20, 0, -20,
+ax_anim 2, 0, 30, 1, -20, 1, -20,
+ax_anim 2, 0, 28, 0, -6, 0, -6,
+ax_anim_terminator
+sMurkrowAnims_2_6:
+ax_anim 2, 0, 31, 1, 1, 1, 1,
+ax_anim 4, 0, 32, 2, 2, 2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, -4, -6, -4, -6,
+ax_anim 1, 0, 33, -10, -13, -10, -13,
+ax_anim 2, 0, 33, -18, -19, -18, -23,
+ax_anim 2, 1, 33, -19, -18, -19, -22,
+ax_anim 2, 0, 33, -18, -19, -18, -23,
+ax_anim 2, 0, 33, -19, -18, -19, -22,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim_terminator
+sMurkrowAnims_2_7:
+ax_anim 2, 0, 34, 1, 0, 1, 0,
+ax_anim 4, 0, 35, 2, 0, 2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, -4, 0, -4, 0,
+ax_anim 1, 0, 36, -10, 0, -10, 0,
+ax_anim 2, 0, 36, -16, 0, -16, 0,
+ax_anim 2, 1, 36, -16, 1, -16, 1,
+ax_anim 2, 0, 36, -16, 0, -16, 0,
+ax_anim 2, 0, 36, -16, 1, -16, 1,
+ax_anim 2, 0, 34, -6, 0, -6, 0,
+ax_anim_terminator
+sMurkrowAnims_2_8:
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 4, 0, 38, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, -4, 4, -4, 4,
+ax_anim 1, 0, 39, -10, 10, -10, 10,
+ax_anim 2, 0, 39, -18, 20, -18, 20,
+ax_anim 2, 1, 39, -19, 19, -19, 19,
+ax_anim 2, 0, 39, -18, 20, -18, 20,
+ax_anim 2, 0, 39, -19, 19, -19, 19,
+ax_anim 2, 0, 37, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 4, 0, 41, 0, -2, 0, -2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, 4, 0, 4,
+ax_anim 1, 0, 42, 0, 10, 0, 10,
+ax_anim 2, 0, 42, 0, 18, 0, 18,
+ax_anim 2, 1, 42, 1, 18, 1, 18,
+ax_anim 2, 0, 42, 0, 18, 0, 18,
+ax_anim 2, 0, 42, 1, 18, 1, 18,
+ax_anim 2, 0, 40, 0, 6, 0, 6,
+ax_anim_terminator
+sMurkrowAnims_3_2:
+ax_anim 2, 0, 43, -1, -1, -1, -1,
+ax_anim 4, 0, 44, -2, -2, -2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 4, 4, 4, 4,
+ax_anim 1, 0, 45, 10, 10, 10, 10,
+ax_anim 2, 0, 45, 18, 20, 18, 20,
+ax_anim 2, 1, 45, 19, 19, 19, 19,
+ax_anim 2, 0, 45, 18, 20, 18, 20,
+ax_anim 2, 0, 45, 19, 19, 19, 19,
+ax_anim 2, 0, 43, 6, 6, 6, 6,
+ax_anim_terminator
+sMurkrowAnims_3_3:
+ax_anim 2, 0, 46, -1, 0, -1, 0,
+ax_anim 4, 0, 47, -2, 0, -2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 4, 0, 4, 0,
+ax_anim 1, 0, 48, 10, 0, 10, 0,
+ax_anim 2, 0, 48, 17, 0, 17, 0,
+ax_anim 2, 1, 48, 17, 1, 17, 1,
+ax_anim 2, 0, 48, 17, 0, 17, 0,
+ax_anim 2, 0, 48, 17, 1, 17, 1,
+ax_anim 2, 0, 46, 6, 0, 6, 0,
+ax_anim_terminator
+sMurkrowAnims_3_4:
+ax_anim 2, 0, 49, -1, 1, -1, 1,
+ax_anim 4, 0, 50, -2, 2, -2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 51, 4, -6, 4, -6,
+ax_anim 1, 0, 51, 10, -13, 10, -13,
+ax_anim 2, 0, 51, 18, -19, 18, -23,
+ax_anim 2, 1, 51, 19, -18, 19, -22,
+ax_anim 2, 0, 51, 18, -19, 18, -23,
+ax_anim 2, 0, 51, 19, -18, 19, -22,
+ax_anim 2, 0, 49, 6, -6, 6, -6,
+ax_anim_terminator
+sMurkrowAnims_3_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 4, 0, 53, 0, 3, 0, 3,
+ax_anim 1, 0, 54, 0, 2, 0, 2,
+ax_anim 1, 2, 54, 0, -3, 0, -3,
+ax_anim 1, 0, 54, 0, -11, 0, -11,
+ax_anim 2, 0, 54, 0, -20, 0, -20,
+ax_anim 2, 1, 54, 1, -20, 1, -20,
+ax_anim 2, 0, 54, 0, -20, 0, -20,
+ax_anim 2, 0, 54, 1, -20, 1, -20,
+ax_anim 2, 0, 52, 0, -6, 0, -6,
+ax_anim_terminator
+sMurkrowAnims_3_6:
+ax_anim 2, 0, 55, 1, 1, 1, 1,
+ax_anim 4, 0, 56, 2, 2, 2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, -4, -6, -4, -6,
+ax_anim 1, 0, 57, -10, -13, -10, -13,
+ax_anim 2, 0, 57, -18, -19, -18, -23,
+ax_anim 2, 1, 57, -19, -18, -19, -22,
+ax_anim 2, 0, 57, -18, -19, -18, -23,
+ax_anim 2, 0, 57, -19, -18, -19, -22,
+ax_anim 2, 0, 55, -6, -6, -6, -6,
+ax_anim_terminator
+sMurkrowAnims_3_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 4, 0, 59, 2, 0, 2, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 0, -4, 0,
+ax_anim 1, 0, 60, -10, 0, -10, 0,
+ax_anim 2, 0, 60, -16, 0, -16, 0,
+ax_anim 2, 1, 60, -16, 1, -16, 1,
+ax_anim 2, 0, 60, -16, 0, -16, 0,
+ax_anim 2, 0, 60, -16, 1, -16, 1,
+ax_anim 2, 0, 58, -6, 0, -6, 0,
+ax_anim_terminator
+sMurkrowAnims_3_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 4, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 63, -4, 4, -4, 4,
+ax_anim 1, 0, 63, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -18, 20, -18, 20,
+ax_anim 2, 1, 63, -19, 19, -19, 19,
+ax_anim 2, 0, 63, -18, 20, -18, 20,
+ax_anim 2, 0, 63, -19, 19, -19, 19,
+ax_anim 2, 0, 61, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_4_1:
+ax_anim 2, 0, 64, 0, -2, 0, 0,
+ax_anim 2, 0, 64, 0, -3, 0, 0,
+ax_anim 4, 0, 65, 0, -4, 0, 0,
+ax_anim 2, 2, 65, 0, -3, 0, 0,
+ax_anim 2, 0, 65, 0, -2, 0, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim 2, 1, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 1, 0, 1, 0,
+ax_anim_terminator
+sMurkrowAnims_4_2:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 66, 0, -3, 0, 0,
+ax_anim 4, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 2, 67, 0, -3, 0, 0,
+ax_anim 2, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 1, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim_terminator
+sMurkrowAnims_4_3:
+ax_anim 2, 0, 68, 0, -2, 0, 0,
+ax_anim 2, 0, 68, 0, -3, 0, 0,
+ax_anim 4, 0, 69, 0, -4, 0, 0,
+ax_anim 2, 2, 69, 0, -3, 0, 0,
+ax_anim 2, 0, 69, 0, -2, 0, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim 2, 1, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim_terminator
+sMurkrowAnims_4_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 70, 0, -3, 0, 0,
+ax_anim 4, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 2, 71, 0, -3, 0, 0,
+ax_anim 2, 0, 71, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, 1, 1, 1,
+ax_anim 2, 1, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, 1, 1, 1,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, 1, 1, 1,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, 1, 1, 1,
+ax_anim_terminator
+sMurkrowAnims_4_5:
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 72, 0, -3, 0, 0,
+ax_anim 4, 0, 73, 0, -4, 0, 0,
+ax_anim 2, 2, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 1, 0, 1, 0,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 1, 0, 1, 0,
+ax_anim_terminator
+sMurkrowAnims_4_6:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 4, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 2, 75, 0, -3, 0, 0,
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 1, -1, 1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 1, -1, 1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 1, -1, 1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 1, -1, 1,
+ax_anim_terminator
+sMurkrowAnims_4_7:
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 4, 0, 77, 0, -4, 0, 0,
+ax_anim 2, 2, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, -1,
+ax_anim_terminator
+sMurkrowAnims_4_8:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 78, 0, -3, 0, 0,
+ax_anim 4, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 2, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, -1, -1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, -1, -1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, -1, -1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_5_1:
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 2, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 1, 81, 0, -4, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_5_2:
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 2, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 1, 83, 0, -4, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_5_3:
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 2, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 1, 85, 0, -4, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_5_4:
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 2, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 1, 87, 0, -4, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_5_5:
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 2, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 1, 89, 0, -4, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_5_6:
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 2, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 1, 91, 0, -4, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_5_7:
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 2, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 1, 93, 0, -4, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_5_8:
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 2, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 1, 95, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_6_1:
+ax_anim 30, 0, 96, 0, 0, 0, 0,
+ax_anim 35, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_7_1:
+ax_anim 2, 0, 98, 0, -4, 0, -4,
+ax_anim 8, 0, 98, 0, -5, 0, -5,
+ax_anim_terminator
+sMurkrowAnims_7_2:
+ax_anim 2, 0, 99, -4, -4, -4, -4,
+ax_anim 8, 0, 99, -5, -5, -5, -5,
+ax_anim_terminator
+sMurkrowAnims_7_3:
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim 8, 0, 100, -5, 0, -5, 0,
+ax_anim_terminator
+sMurkrowAnims_7_4:
+ax_anim 2, 0, 101, -4, 4, -4, 4,
+ax_anim 8, 0, 101, -5, 5, -5, 5,
+ax_anim_terminator
+sMurkrowAnims_7_5:
+ax_anim 2, 0, 102, 0, 4, 0, 4,
+ax_anim 8, 0, 102, 0, 5, 0, 5,
+ax_anim_terminator
+sMurkrowAnims_7_6:
+ax_anim 2, 0, 103, 4, 4, 4, 4,
+ax_anim 8, 0, 103, 5, 5, 5, 5,
+ax_anim_terminator
+sMurkrowAnims_7_7:
+ax_anim 2, 0, 104, 4, 0, 4, 0,
+ax_anim 8, 0, 104, 5, 0, 5, 0,
+ax_anim_terminator
+sMurkrowAnims_7_8:
+ax_anim 2, 0, 105, 4, -4, 4, -4,
+ax_anim 8, 0, 105, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_8_1:
+ax_anim 46, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_8_2:
+ax_anim 46, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_8_3:
+ax_anim 46, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_8_4:
+ax_anim 46, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_8_5:
+ax_anim 46, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_8_6:
+ax_anim 46, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_8_7:
+ax_anim 46, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_8_8:
+ax_anim 46, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_9_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 6, 3, 6, 3,
+ax_anim 2, 0, 116, 8, 11, 8, 11,
+ax_anim 2, 0, 117, 7, 18, 7, 18,
+ax_anim 3, 0, 118, 0, 21, 0, 21,
+ax_anim 2, 3, 119, -7, 18, -7, 18,
+ax_anim 2, 0, 120, -8, 11, -8, 11,
+ax_anim 1, 0, 121, -6, 3, -6, 3,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_9_2:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 8, 0, 8, 0,
+ax_anim 2, 0, 115, 17, 3, 17, 3,
+ax_anim 2, 0, 116, 19, 10, 19, 10,
+ax_anim 3, 0, 117, 19, 20, 19, 20,
+ax_anim 2, 3, 118, 11, 21, 11, 21,
+ax_anim 2, 0, 119, 3, 15, 3, 15,
+ax_anim 1, 0, 120, 0, 7, 0, 7,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_9_3:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 3, -5, 3, -5,
+ax_anim 2, 0, 114, 10, -7, 10, -7,
+ax_anim 2, 0, 115, 17, -4, 17, -4,
+ax_anim 3, 0, 116, 19, 0, 19, 0,
+ax_anim 2, 3, 117, 16, 4, 16, 4,
+ax_anim 2, 0, 118, 12, 7, 12, 7,
+ax_anim 1, 0, 119, 4, 3, 4, 3,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_9_4:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, -1, -8, -1, -8,
+ax_anim 2, 0, 121, 4, -16, 4, -16,
+ax_anim 2, 0, 114, 12, -22, 12, -22,
+ax_anim 3, 0, 115, 19, -22, 19, -22,
+ax_anim 2, 3, 116, 20, -14, 20, -14,
+ax_anim 2, 0, 117, 17, -5, 17, -5,
+ax_anim 1, 0, 118, 7, -1, 7, -1,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_9_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, -8, -4, -8, -4,
+ax_anim 2, 0, 120, -9, -12, -9, -12,
+ax_anim 2, 0, 121, -7, -18, -7, -18,
+ax_anim 3, 0, 114, 0, -22, 0, -22,
+ax_anim 2, 3, 115, 7, -18, 7, -18,
+ax_anim 2, 0, 116, 9, -12, 9, -12,
+ax_anim 1, 0, 117, 8, -4, 8, -4,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_9_6:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 1, -8, 1, -8,
+ax_anim 2, 0, 115, -4, -16, -4, -16,
+ax_anim 2, 0, 114, -12, -22, -12, -22,
+ax_anim 3, 0, 121, -19, -22, -19, -22,
+ax_anim 2, 3, 120, -20, -14, -20, -14,
+ax_anim 2, 0, 119, -17, -5, -17, -5,
+ax_anim 1, 0, 118, -7, -1, -7, -1,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_9_7:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, -3, -5, -3, -5,
+ax_anim 2, 0, 114, -10, -7, -10, -7,
+ax_anim 2, 0, 121, -17, -4, -17, -4,
+ax_anim 3, 0, 120, -19, 0, -19, 0,
+ax_anim 2, 3, 119, -16, 4, -16, 4,
+ax_anim 2, 0, 118, -12, 7, -12, 7,
+ax_anim 1, 0, 117, -4, 3, -4, 3,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_9_8:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, -8, 0, -8, 0,
+ax_anim 2, 0, 121, -17, 3, -17, 3,
+ax_anim 2, 0, 120, -19, 10, -19, 10,
+ax_anim 3, 0, 119, -19, 20, -19, 20,
+ax_anim 2, 3, 118, -11, 21, -11, 21,
+ax_anim 2, 0, 117, -3, 15, -3, 15,
+ax_anim 1, 0, 116, 0, 7, 0, 7,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_10_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 3, 0, 122, 13, 0, 13, 0,
+ax_anim 3, 0, 122, -13, 0, -13, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_10_2:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 3, 0, 123, 13, -13, 13, -13,
+ax_anim 3, 0, 123, -13, 13, -13, 13,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_10_3:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 3, 0, 124, 0, -13, 0, -13,
+ax_anim 3, 0, 124, 0, 13, 0, 13,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_10_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 3, 0, 125, -13, -13, -13, -13,
+ax_anim 3, 0, 125, 13, 13, 13, 13,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_10_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 3, 0, 126, 13, 0, 13, 0,
+ax_anim 3, 0, 126, -13, 0, -13, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_10_6:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 3, 0, 127, 13, -13, 13, -13,
+ax_anim 3, 0, 127, -13, 13, -13, 13,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_10_7:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 3, 0, 128, 0, -13, 0, -13,
+ax_anim 3, 0, 128, 0, 13, 0, 13,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_10_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 3, 0, 129, -13, -13, -13, -13,
+ax_anim 3, 0, 129, 13, 13, 13, 13,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_11_1:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 2, 0, 132, 0, -16, 0, 0,
+ax_anim 3, 0, 132, 0, -20, 0, 0,
+ax_anim 4, 0, 132, 0, -21, 0, 0,
+ax_anim 4, 0, 131, 0, -24, 0, 0,
+ax_anim 3, 0, 131, 0, -22, 0, 0,
+ax_anim 2, 0, 131, 0, -18, 0, 0,
+ax_anim 1, 0, 131, 0, -12, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_11_2:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 2, 0, 135, 0, -16, 0, 0,
+ax_anim 3, 0, 135, 0, -20, 0, 0,
+ax_anim 4, 0, 135, 0, -21, 0, 0,
+ax_anim 4, 0, 134, 0, -21, 0, 0,
+ax_anim 3, 0, 134, 0, -20, 0, 0,
+ax_anim 2, 0, 134, 0, -18, 0, 0,
+ax_anim 1, 0, 134, 0, -12, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_11_3:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, -10, 0, 0,
+ax_anim 2, 0, 138, 0, -16, 0, 0,
+ax_anim 3, 0, 138, 0, -20, 0, 0,
+ax_anim 4, 0, 138, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -21, 0, 0,
+ax_anim 3, 0, 137, 0, -20, 0, 0,
+ax_anim 2, 0, 137, 0, -18, 0, 0,
+ax_anim 1, 0, 137, 0, -12, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_11_4:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -10, 0, 0,
+ax_anim 2, 0, 141, 0, -16, 0, 0,
+ax_anim 3, 0, 141, 0, -20, 0, 0,
+ax_anim 4, 0, 141, 0, -21, 0, 0,
+ax_anim 4, 0, 140, 0, -21, 0, 0,
+ax_anim 3, 0, 140, 0, -20, 0, 0,
+ax_anim 2, 0, 140, 0, -17, 0, 0,
+ax_anim 1, 0, 140, 0, -11, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_11_5:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -10, 0, 0,
+ax_anim 2, 0, 144, 0, -16, 0, 0,
+ax_anim 3, 0, 144, 0, -20, 0, 0,
+ax_anim 4, 0, 144, 0, -21, 0, 0,
+ax_anim 4, 0, 143, 0, -22, 0, 0,
+ax_anim 3, 0, 143, 0, -21, 0, 0,
+ax_anim 2, 0, 143, 0, -18, 0, 0,
+ax_anim 1, 0, 143, 0, -12, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_11_6:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -21, 0, 0,
+ax_anim 3, 0, 146, 0, -20, 0, 0,
+ax_anim 2, 0, 146, 0, -17, 0, 0,
+ax_anim 1, 0, 146, 0, -11, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_11_7:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 2, 0, 149, 0, -18, 0, 0,
+ax_anim 1, 0, 149, 0, -12, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_11_8:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_12_1:
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 1, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_12_2:
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 1, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_12_3:
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_12_4:
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 1, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_12_5:
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 1, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_12_6:
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 1, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_12_7:
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 1, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_12_8:
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 1, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sMurkrowAnims_13_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_13_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_13_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_13_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_13_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_13_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_13_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowAnims_13_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sMurkrowGfx1:
+.incbin "baserom.gba", 0xD789B0, 0x200
+sMurkrowSprites1:
+ax_sprite sMurkrowGfx1, 0x200
+ax_sprite_terminator
+sMurkrowGfx2:
+.incbin "baserom.gba", 0xD78BC0, 0x200
+sMurkrowSprites2:
+ax_sprite sMurkrowGfx2, 0x200
+ax_sprite_terminator
+sMurkrowGfx3:
+.incbin "baserom.gba", 0xD78DD0, 0x200
+sMurkrowSprites3:
+ax_sprite sMurkrowGfx3, 0x200
+ax_sprite_terminator
+sMurkrowGfx4:
+.incbin "baserom.gba", 0xD78FE0, 0x200
+sMurkrowSprites4:
+ax_sprite sMurkrowGfx4, 0x200
+ax_sprite_terminator
+sMurkrowGfx5:
+.incbin "baserom.gba", 0xD791F0, 0x200
+sMurkrowSprites5:
+ax_sprite sMurkrowGfx5, 0x200
+ax_sprite_terminator
+sMurkrowGfx6:
+.incbin "baserom.gba", 0xD79400, 0x200
+sMurkrowSprites6:
+ax_sprite sMurkrowGfx6, 0x200
+ax_sprite_terminator
+sMurkrowGfx7:
+.incbin "baserom.gba", 0xD79610, 0x200
+sMurkrowSprites7:
+ax_sprite sMurkrowGfx7, 0x200
+ax_sprite_terminator
+sMurkrowGfx8:
+.incbin "baserom.gba", 0xD79820, 0x200
+sMurkrowSprites8:
+ax_sprite sMurkrowGfx8, 0x200
+ax_sprite_terminator
+sMurkrowGfx9:
+.incbin "baserom.gba", 0xD79A30, 0x200
+sMurkrowSprites9:
+ax_sprite sMurkrowGfx9, 0x200
+ax_sprite_terminator
+sMurkrowGfx10:
+.incbin "baserom.gba", 0xD79C40, 0x200
+sMurkrowSprites10:
+ax_sprite sMurkrowGfx10, 0x200
+ax_sprite_terminator
+sMurkrowGfx11:
+.incbin "baserom.gba", 0xD79E50, 0x100
+sMurkrowGfx11_1:
+.incbin "baserom.gba", 0xD79F50, 0x40
+sMurkrowGfx11_2:
+.incbin "baserom.gba", 0xD79F90, 0x40
+sMurkrowSprites11:
+ax_sprite sMurkrowGfx11, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx11_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sMurkrowGfx11_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sMurkrowGfx12:
+.incbin "baserom.gba", 0xD7A008, 0x40
+sMurkrowGfx12_1:
+.incbin "baserom.gba", 0xD7A048, 0x100
+sMurkrowSprites12:
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx12, 0x40
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx12_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMurkrowGfx13:
+.incbin "baserom.gba", 0xD7A178, 0x160
+sMurkrowSprites13:
+ax_sprite sMurkrowGfx13, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx14:
+.incbin "baserom.gba", 0xD7A2F0, 0x60
+sMurkrowGfx14_1:
+.incbin "baserom.gba", 0xD7A350, 0x60
+sMurkrowGfx14_2:
+.incbin "baserom.gba", 0xD7A3B0, 0x40
+sMurkrowSprites14:
+ax_sprite sMurkrowGfx14, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx14_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMurkrowGfx14_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx15:
+.incbin "baserom.gba", 0xD7A428, 0x180
+sMurkrowSprites15:
+ax_sprite sMurkrowGfx15, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sMurkrowGfx16:
+.incbin "baserom.gba", 0xD7A5C0, 0xC0
+sMurkrowSprites16:
+ax_sprite sMurkrowGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMurkrowGfx17:
+.incbin "baserom.gba", 0xD7A698, 0x100
+sMurkrowGfx17_1:
+.incbin "baserom.gba", 0xD7A798, 0x40
+sMurkrowSprites17:
+ax_sprite sMurkrowGfx17, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx17_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx18:
+.incbin "baserom.gba", 0xD7A800, 0x60
+sMurkrowGfx18_1:
+.incbin "baserom.gba", 0xD7A860, 0x60
+sMurkrowGfx18_2:
+.incbin "baserom.gba", 0xD7A8C0, 0x60
+sMurkrowSprites18:
+ax_sprite sMurkrowGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx19:
+.incbin "baserom.gba", 0xD7A958, 0x60
+sMurkrowGfx19_1:
+.incbin "baserom.gba", 0xD7A9B8, 0x100
+sMurkrowGfx19_2:
+.incbin "baserom.gba", 0xD7AAB8, 0x20
+sMurkrowSprites19:
+ax_sprite sMurkrowGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx19_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx19_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMurkrowGfx20:
+.incbin "baserom.gba", 0xD7AB10, 0x60
+sMurkrowGfx20_1:
+.incbin "baserom.gba", 0xD7AB70, 0x60
+sMurkrowGfx20_2:
+.incbin "baserom.gba", 0xD7ABD0, 0x40
+sMurkrowSprites20:
+ax_sprite sMurkrowGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sMurkrowGfx20_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx21:
+.incbin "baserom.gba", 0xD7AC48, 0x180
+sMurkrowGfx21_1:
+.incbin "baserom.gba", 0xD7ADC8, 0x20
+sMurkrowSprites21:
+ax_sprite sMurkrowGfx21, 0x180
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx21_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMurkrowGfx22:
+.incbin "baserom.gba", 0xD7AE10, 0x60
+sMurkrowGfx22_1:
+.incbin "baserom.gba", 0xD7AE70, 0x60
+sMurkrowGfx22_2:
+.incbin "baserom.gba", 0xD7AED0, 0x60
+sMurkrowSprites22:
+ax_sprite sMurkrowGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx23:
+.incbin "baserom.gba", 0xD7AF68, 0xE0
+sMurkrowGfx23_1:
+.incbin "baserom.gba", 0xD7B048, 0x40
+sMurkrowSprites23:
+ax_sprite sMurkrowGfx23, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sMurkrowGfx23_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx24:
+.incbin "baserom.gba", 0xD7B0B0, 0xC0
+sMurkrowSprites24:
+ax_sprite sMurkrowGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sMurkrowGfx25:
+.incbin "baserom.gba", 0xD7B188, 0x100
+sMurkrowGfx25_1:
+.incbin "baserom.gba", 0xD7B288, 0x40
+sMurkrowSprites25:
+ax_sprite sMurkrowGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sMurkrowGfx25_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sMurkrowGfx26:
+.incbin "baserom.gba", 0xD7B2F0, 0x200
+sMurkrowSprites26:
+ax_sprite sMurkrowGfx26, 0x200
+ax_sprite_terminator
+sMurkrowGfx27:
+.incbin "baserom.gba", 0xD7B500, 0x200
+sMurkrowSprites27:
+ax_sprite sMurkrowGfx27, 0x200
+ax_sprite_terminator
+sMurkrowGfx28:
+.incbin "baserom.gba", 0xD7B710, 0x200
+sMurkrowSprites28:
+ax_sprite sMurkrowGfx28, 0x200
+ax_sprite_terminator
+sMurkrowGfx29:
+.incbin "baserom.gba", 0xD7B920, 0x200
+sMurkrowSprites29:
+ax_sprite sMurkrowGfx29, 0x200
+ax_sprite_terminator
+sMurkrowGfx30:
+.incbin "baserom.gba", 0xD7BB30, 0x200
+sMurkrowSprites30:
+ax_sprite sMurkrowGfx30, 0x200
+ax_sprite_terminator
+sMurkrowGfx31:
+.incbin "baserom.gba", 0xD7BD40, 0x200
+sMurkrowSprites31:
+ax_sprite sMurkrowGfx31, 0x200
+ax_sprite_terminator
+sMurkrowGfx32:
+.incbin "baserom.gba", 0xD7BF50, 0x200
+sMurkrowSprites32:
+ax_sprite sMurkrowGfx32, 0x200
+ax_sprite_terminator
+sAxPosesMurkrow:
+.4byte sMurkrowPose1
+.4byte sMurkrowPose2
+.4byte sMurkrowPose3
+.4byte sMurkrowPose4
+.4byte sMurkrowPose5
+.4byte sMurkrowPose6
+.4byte sMurkrowPose7
+.4byte sMurkrowPose8
+.4byte sMurkrowPose9
+.4byte sMurkrowPose10
+.4byte sMurkrowPose11
+.4byte sMurkrowPose12
+.4byte sMurkrowPose13
+.4byte sMurkrowPose14
+.4byte sMurkrowPose15
+.4byte sMurkrowPose16
+.4byte sMurkrowPose17
+.4byte sMurkrowPose18
+.4byte sMurkrowPose19
+.4byte sMurkrowPose20
+.4byte sMurkrowPose21
+.4byte sMurkrowPose22
+.4byte sMurkrowPose23
+.4byte sMurkrowPose24
+.4byte sMurkrowPose25
+.4byte sMurkrowPose26
+.4byte sMurkrowPose27
+.4byte sMurkrowPose28
+.4byte sMurkrowPose29
+.4byte sMurkrowPose30
+.4byte sMurkrowPose31
+.4byte sMurkrowPose32
+.4byte sMurkrowPose33
+.4byte sMurkrowPose34
+.4byte sMurkrowPose35
+.4byte sMurkrowPose36
+.4byte sMurkrowPose37
+.4byte sMurkrowPose38
+.4byte sMurkrowPose39
+.4byte sMurkrowPose40
+.4byte sMurkrowPose41
+.4byte sMurkrowPose42
+.4byte sMurkrowPose43
+.4byte sMurkrowPose44
+.4byte sMurkrowPose45
+.4byte sMurkrowPose46
+.4byte sMurkrowPose47
+.4byte sMurkrowPose48
+.4byte sMurkrowPose49
+.4byte sMurkrowPose50
+.4byte sMurkrowPose51
+.4byte sMurkrowPose52
+.4byte sMurkrowPose53
+.4byte sMurkrowPose54
+.4byte sMurkrowPose55
+.4byte sMurkrowPose56
+.4byte sMurkrowPose57
+.4byte sMurkrowPose58
+.4byte sMurkrowPose59
+.4byte sMurkrowPose60
+.4byte sMurkrowPose61
+.4byte sMurkrowPose62
+.4byte sMurkrowPose63
+.4byte sMurkrowPose64
+.4byte sMurkrowPose65
+.4byte sMurkrowPose66
+.4byte sMurkrowPose67
+.4byte sMurkrowPose68
+.4byte sMurkrowPose69
+.4byte sMurkrowPose70
+.4byte sMurkrowPose71
+.4byte sMurkrowPose72
+.4byte sMurkrowPose73
+.4byte sMurkrowPose74
+.4byte sMurkrowPose75
+.4byte sMurkrowPose76
+.4byte sMurkrowPose77
+.4byte sMurkrowPose78
+.4byte sMurkrowPose79
+.4byte sMurkrowPose80
+.4byte sMurkrowPose81
+.4byte sMurkrowPose82
+.4byte sMurkrowPose83
+.4byte sMurkrowPose84
+.4byte sMurkrowPose85
+.4byte sMurkrowPose86
+.4byte sMurkrowPose87
+.4byte sMurkrowPose88
+.4byte sMurkrowPose89
+.4byte sMurkrowPose90
+.4byte sMurkrowPose91
+.4byte sMurkrowPose92
+.4byte sMurkrowPose93
+.4byte sMurkrowPose94
+.4byte sMurkrowPose95
+.4byte sMurkrowPose96
+.4byte sMurkrowPose97
+.4byte sMurkrowPose98
+.4byte sMurkrowPose99
+.4byte sMurkrowPose100
+.4byte sMurkrowPose101
+.4byte sMurkrowPose102
+.4byte sMurkrowPose103
+.4byte sMurkrowPose104
+.4byte sMurkrowPose105
+.4byte sMurkrowPose106
+.4byte sMurkrowPose107
+.4byte sMurkrowPose108
+.4byte sMurkrowPose109
+.4byte sMurkrowPose110
+.4byte sMurkrowPose111
+.4byte sMurkrowPose112
+.4byte sMurkrowPose113
+.4byte sMurkrowPose114
+.4byte sMurkrowPose115
+.4byte sMurkrowPose116
+.4byte sMurkrowPose117
+.4byte sMurkrowPose118
+.4byte sMurkrowPose119
+.4byte sMurkrowPose120
+.4byte sMurkrowPose121
+.4byte sMurkrowPose122
+.4byte sMurkrowPose123
+.4byte sMurkrowPose124
+.4byte sMurkrowPose125
+.4byte sMurkrowPose126
+.4byte sMurkrowPose127
+.4byte sMurkrowPose128
+.4byte sMurkrowPose129
+.4byte sMurkrowPose130
+.4byte sMurkrowPose131
+.4byte sMurkrowPose132
+.4byte sMurkrowPose133
+.4byte sMurkrowPose134
+.4byte sMurkrowPose135
+.4byte sMurkrowPose136
+.4byte sMurkrowPose137
+.4byte sMurkrowPose138
+.4byte sMurkrowPose139
+.4byte sMurkrowPose140
+.4byte sMurkrowPose141
+.4byte sMurkrowPose142
+.4byte sMurkrowPose143
+.4byte sMurkrowPose144
+.4byte sMurkrowPose145
+.4byte sMurkrowPose146
+.4byte sMurkrowPose147
+.4byte sMurkrowPose148
+.4byte sMurkrowPose149
+.4byte sMurkrowPose150
+.4byte sMurkrowPose151
+.4byte sMurkrowPose152
+.4byte sMurkrowPose153
+.4byte sMurkrowPose154
+.4byte sMurkrowPose155
+.4byte sMurkrowPose156
+.4byte sMurkrowPose157
+.4byte sMurkrowPose158
+.4byte sMurkrowPose159
+.4byte sMurkrowPose160
+.4byte sMurkrowPose161
+.4byte sMurkrowPose162
+.4byte sMurkrowPose163
+.4byte sMurkrowPose164
+.4byte sMurkrowPose165
+.4byte sMurkrowPose166
+.4byte sMurkrowPose167
+.4byte sMurkrowPose168
+.4byte sMurkrowPose169
+.4byte sMurkrowPose170
+sAxPositionsMurkrow:
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -1, 	   8,   -1, 	  -1,   -7
+.2byte    7,   -7, 	   1,  -21, 	 -11,  -16, 	  -1,   -8
+.2byte    6,   -8, 	   8,   -4, 	  -3,    1, 	  -1,   -7
+.2byte    8,  -10, 	  -7,  -19, 	  -9,  -15, 	  -2,   -8
+.2byte    7,  -12, 	   4,   -5, 	   0,    0, 	  -1,   -7
+.2byte    5,  -12, 	  -9,  -16, 	   5,  -13, 	  -2,   -9
+.2byte    6,  -13, 	  -4,   -4, 	   6,   -1, 	  -1,   -8
+.2byte   -1,  -17, 	  10,  -14, 	 -11,  -14, 	  -1,   -7
+.2byte   -1,  -17, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -7,  -12, 	   7,  -16, 	  -7,  -13, 	   0,   -9
+.2byte   -8,  -13, 	   2,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte  -10,  -10, 	   5,  -19, 	   7,  -15, 	   0,   -8
+.2byte   -9,  -12, 	  -6,   -5, 	  -2,    0, 	  -1,   -7
+.2byte   -9,   -7, 	  -3,  -21, 	   9,  -16, 	  -1,   -8
+.2byte   -8,   -8, 	 -10,   -4, 	   1,    1, 	  -1,   -7
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -1,    1, 	 -12,  -13, 	  10,  -13, 	  -1,   -8
+.2byte    7,   -7, 	   1,  -21, 	 -11,  -16, 	  -1,   -8
+.2byte    6,   -8, 	   8,   -4, 	  -3,    1, 	  -1,   -7
+.2byte    6,   -1, 	   2,  -16, 	  -8,   -5, 	  -2,   -7
+.2byte    8,  -10, 	  -7,  -19, 	  -9,  -15, 	  -2,   -8
+.2byte    7,  -12, 	   4,   -5, 	   0,    0, 	  -1,   -7
+.2byte    9,   -6, 	  -4,  -20, 	  -6,  -12, 	  -1,   -9
+.2byte    5,  -12, 	  -9,  -16, 	   5,  -13, 	  -2,   -9
+.2byte    6,  -13, 	  -4,   -4, 	   6,   -1, 	  -1,   -8
+.2byte    8,  -12, 	  -8,  -17, 	   7,  -11, 	   0,   -9
+.2byte   -1,  -17, 	  10,  -14, 	 -11,  -14, 	  -1,   -7
+.2byte   -1,  -17, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -13, 	  10,  -13, 	 -11,  -13, 	  -1,   -8
+.2byte   -7,  -12, 	   7,  -16, 	  -7,  -13, 	   0,   -9
+.2byte   -8,  -13, 	   2,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte  -10,  -12, 	   6,  -17, 	  -9,  -11, 	  -2,   -9
+.2byte  -10,  -10, 	   5,  -19, 	   7,  -15, 	   0,   -8
+.2byte   -9,  -12, 	  -6,   -5, 	  -2,    0, 	  -1,   -7
+.2byte  -11,   -6, 	   2,  -20, 	   4,  -12, 	  -1,   -9
+.2byte   -9,   -7, 	  -3,  -21, 	   9,  -16, 	  -1,   -8
+.2byte   -8,   -8, 	 -10,   -4, 	   1,    1, 	  -1,   -7
+.2byte   -8,   -1, 	  -4,  -16, 	   6,   -5, 	   0,   -7
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -1, 	   8,   -1, 	  -1,   -7
+.2byte   -1,    1, 	 -12,  -13, 	  10,  -13, 	  -1,   -8
+.2byte    7,   -7, 	   1,  -21, 	 -11,  -16, 	  -1,   -8
+.2byte    6,   -8, 	   8,   -4, 	  -3,    1, 	  -1,   -7
+.2byte    6,   -1, 	   2,  -16, 	  -8,   -5, 	  -2,   -7
+.2byte    8,  -10, 	  -7,  -19, 	  -9,  -15, 	  -2,   -8
+.2byte    7,  -12, 	   4,   -5, 	   0,    0, 	  -1,   -7
+.2byte    9,   -6, 	  -4,  -20, 	  -6,  -12, 	  -1,   -9
+.2byte    5,  -12, 	  -9,  -16, 	   5,  -13, 	  -2,   -9
+.2byte    6,  -13, 	  -4,   -4, 	   6,   -1, 	  -1,   -8
+.2byte    8,  -12, 	  -8,  -17, 	   7,  -11, 	   0,   -9
+.2byte   -1,  -17, 	  10,  -14, 	 -11,  -14, 	  -1,   -7
+.2byte   -1,  -17, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -13, 	  10,  -13, 	 -11,  -13, 	  -1,   -8
+.2byte   -7,  -12, 	   7,  -16, 	  -7,  -13, 	   0,   -9
+.2byte   -8,  -13, 	   2,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte  -10,  -12, 	   6,  -17, 	  -9,  -11, 	  -2,   -9
+.2byte  -10,  -10, 	   5,  -19, 	   7,  -15, 	   0,   -8
+.2byte   -9,  -12, 	  -6,   -5, 	  -2,    0, 	  -1,   -7
+.2byte  -11,   -6, 	   2,  -20, 	   4,  -12, 	  -1,   -9
+.2byte   -9,   -7, 	  -3,  -21, 	   9,  -16, 	  -1,   -8
+.2byte   -8,   -8, 	 -10,   -4, 	   1,    1, 	  -1,   -7
+.2byte   -8,   -1, 	  -4,  -16, 	   6,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	 -12,  -14, 	  10,  -14, 	  -1,   -7
+.2byte    5,   -7, 	   1,   -6, 	  -3,   -5, 	  -1,   -5
+.2byte    3,   -7, 	   4,  -19, 	 -11,   -6, 	  -2,   -6
+.2byte    6,  -10, 	  -2,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    8,   -9, 	  -5,  -19, 	  -7,  -14, 	   0,   -7
+.2byte    3,  -12, 	  -4,   -5, 	   0,   -4, 	  -1,   -7
+.2byte    7,  -15, 	  -9,  -18, 	   8,  -11, 	  -1,   -8
+.2byte   -1,  -15, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -16, 	  10,  -14, 	 -11,  -14, 	  -1,   -8
+.2byte   -5,  -12, 	   2,   -5, 	  -2,   -4, 	  -1,   -7
+.2byte   -9,  -15, 	   7,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -8,  -10, 	   0,   -6, 	   0,   -5, 	   0,   -7
+.2byte  -10,   -9, 	   3,  -19, 	   5,  -14, 	  -2,   -7
+.2byte   -7,   -7, 	  -3,   -6, 	   1,   -5, 	  -1,   -5
+.2byte   -5,   -7, 	  -6,  -19, 	   9,   -6, 	   0,   -6
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,   -1, 	   8,   -1, 	  -1,   -7
+.2byte    7,   -7, 	   1,  -21, 	 -11,  -16, 	  -1,   -8
+.2byte    6,   -8, 	   8,   -4, 	  -3,    1, 	  -1,   -7
+.2byte    8,  -10, 	  -7,  -19, 	  -9,  -15, 	  -2,   -8
+.2byte    7,  -12, 	   4,   -5, 	   0,    0, 	  -1,   -7
+.2byte    5,  -12, 	  -9,  -16, 	   5,  -13, 	  -2,   -9
+.2byte    6,  -13, 	  -4,   -4, 	   6,   -1, 	  -1,   -8
+.2byte   -1,  -17, 	  10,  -14, 	 -11,  -14, 	  -1,   -7
+.2byte   -1,  -17, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -7,  -12, 	   7,  -16, 	  -7,  -13, 	   0,   -9
+.2byte   -8,  -13, 	   2,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte  -10,  -10, 	   5,  -19, 	   7,  -15, 	   0,   -8
+.2byte   -9,  -12, 	  -6,   -5, 	  -2,    0, 	  -1,   -7
+.2byte   -9,   -7, 	  -3,  -21, 	   9,  -16, 	  -1,   -8
+.2byte   -8,   -8, 	 -10,   -4, 	   1,    1, 	  -1,   -7
+.2byte   -6,   -6, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte   -6,   -5, 	  -1,   -4, 	   2,   -3, 	   0,   -5
+.2byte   -1,  -12, 	 -12,  -15, 	  10,  -15, 	  -1,   -9
+.2byte    0,  -11, 	   4,  -19, 	 -11,  -10, 	   0,   -7
+.2byte    1,  -12, 	  -6,  -13, 	  -9,  -10, 	  -1,   -7
+.2byte    3,  -13, 	  -9,  -13, 	   6,   -9, 	  -1,   -8
+.2byte    0,  -18, 	  11,  -13, 	 -11,  -13, 	   0,   -6
+.2byte   -4,  -13, 	   8,  -13, 	  -7,   -9, 	   0,   -8
+.2byte   -2,  -12, 	   5,  -13, 	   8,  -10, 	   0,   -7
+.2byte   -1,  -11, 	  -5,  -19, 	  10,  -10, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -7,   -7, 	  -3,   -6, 	   1,   -5, 	  -1,   -5
+.2byte   -8,  -10, 	   0,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -5,  -12, 	   2,   -5, 	  -2,   -4, 	  -1,   -7
+.2byte   -1,  -15, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte    3,  -12, 	  -4,   -5, 	   0,   -4, 	  -1,   -7
+.2byte    6,  -10, 	  -2,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    5,   -7, 	   1,   -6, 	  -3,   -5, 	  -1,   -5
+.2byte   -1,    1, 	 -12,  -13, 	  10,  -13, 	  -1,   -8
+.2byte   -8,   -1, 	  -4,  -16, 	   6,   -5, 	   0,   -7
+.2byte  -11,   -4, 	   2,  -18, 	   4,  -10, 	  -1,   -7
+.2byte   -8,  -10, 	   8,  -15, 	  -7,   -9, 	   0,   -7
+.2byte    0,  -12, 	  11,  -12, 	 -10,  -12, 	   0,   -7
+.2byte    7,  -10, 	  -9,  -15, 	   6,   -9, 	  -1,   -7
+.2byte   10,   -4, 	  -3,  -18, 	  -5,  -10, 	   0,   -7
+.2byte    6,   -1, 	   2,  -16, 	  -8,   -5, 	  -2,   -7
+.2byte   -1,   -6, 	 -12,  -14, 	  10,  -14, 	  -1,   -7
+.2byte    3,   -7, 	   4,  -19, 	 -11,   -6, 	  -2,   -6
+.2byte    8,   -9, 	  -5,  -19, 	  -7,  -14, 	   0,   -7
+.2byte    7,  -15, 	  -9,  -18, 	   8,  -11, 	  -1,   -8
+.2byte   -1,  -16, 	  10,  -14, 	 -11,  -14, 	  -1,   -8
+.2byte   -9,  -15, 	   7,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte  -10,   -9, 	   3,  -19, 	   5,  -14, 	  -2,   -7
+.2byte   -5,   -7, 	  -6,  -19, 	   9,   -6, 	   0,   -6
+.2byte   -1,   -6, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -1,   -4, 	 -12,  -13, 	  10,  -13, 	  -1,   -6
+.2byte   -1,   -8, 	 -10,   -1, 	   8,   -1, 	  -1,   -7
+.2byte    5,   -7, 	   1,   -6, 	  -3,   -5, 	  -1,   -5
+.2byte    8,   -5, 	   2,  -19, 	 -10,  -14, 	   0,   -6
+.2byte    6,   -8, 	   8,   -4, 	  -3,    1, 	  -1,   -7
+.2byte    6,  -10, 	  -2,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte   10,   -8, 	  -5,  -17, 	  -7,  -13, 	   0,   -6
+.2byte    7,  -12, 	   4,   -5, 	   0,    0, 	  -1,   -7
+.2byte    3,  -12, 	  -4,   -5, 	   0,   -4, 	  -1,   -7
+.2byte    6,   -9, 	  -8,  -13, 	   6,  -10, 	  -1,   -6
+.2byte    6,  -13, 	  -4,   -4, 	   6,   -1, 	  -1,   -8
+.2byte   -1,  -15, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -15, 	  10,  -12, 	 -11,  -12, 	  -1,   -5
+.2byte   -1,  -17, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -5,  -12, 	   2,   -5, 	  -2,   -4, 	  -1,   -7
+.2byte   -7,   -9, 	   7,  -13, 	  -7,  -10, 	   0,   -6
+.2byte   -8,  -13, 	   2,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte   -8,  -10, 	   0,   -6, 	   0,   -5, 	   0,   -7
+.2byte  -11,   -8, 	   4,  -17, 	   6,  -13, 	  -1,   -6
+.2byte   -9,  -12, 	  -6,   -5, 	  -2,    0, 	  -1,   -7
+.2byte   -7,   -7, 	  -3,   -6, 	   1,   -5, 	  -1,   -5
+.2byte   -8,   -4, 	  -2,  -18, 	  10,  -13, 	   0,   -5
+.2byte   -8,   -8, 	 -10,   -4, 	   1,    1, 	  -1,   -7
+.2byte   -1,   -6, 	 -12,  -14, 	  10,  -14, 	  -1,   -7
+.2byte   -5,   -7, 	  -6,  -19, 	   9,   -6, 	   0,   -6
+.2byte  -10,   -9, 	   3,  -19, 	   5,  -14, 	  -2,   -7
+.2byte   -9,  -15, 	   7,  -18, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -17, 	  10,  -15, 	 -11,  -15, 	  -1,   -9
+.2byte    7,  -15, 	  -9,  -18, 	   8,  -11, 	  -1,   -8
+.2byte    8,   -9, 	  -5,  -19, 	  -7,  -14, 	   0,   -7
+.2byte    3,   -7, 	   4,  -19, 	 -11,   -6, 	  -2,   -6
+.2byte   -1,   -6, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -7,   -7, 	  -3,   -6, 	   1,   -5, 	  -1,   -5
+.2byte   -8,  -10, 	   0,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -5,  -12, 	   2,   -5, 	  -2,   -4, 	  -1,   -7
+.2byte   -1,  -15, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte    3,  -12, 	  -4,   -5, 	   0,   -4, 	  -1,   -7
+.2byte    6,  -10, 	  -2,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte    5,   -7, 	   1,   -6, 	  -3,   -5, 	  -1,   -5
+sMurkrowAnimTable1:
+.4byte sMurkrowAnims_1_1
+.4byte sMurkrowAnims_1_2
+.4byte sMurkrowAnims_1_3
+.4byte sMurkrowAnims_1_4
+.4byte sMurkrowAnims_1_5
+.4byte sMurkrowAnims_1_6
+.4byte sMurkrowAnims_1_7
+.4byte sMurkrowAnims_1_8
+sMurkrowAnimTable2:
+.4byte sMurkrowAnims_2_1
+.4byte sMurkrowAnims_2_2
+.4byte sMurkrowAnims_2_3
+.4byte sMurkrowAnims_2_4
+.4byte sMurkrowAnims_2_5
+.4byte sMurkrowAnims_2_6
+.4byte sMurkrowAnims_2_7
+.4byte sMurkrowAnims_2_8
+sMurkrowAnimTable3:
+.4byte sMurkrowAnims_3_1
+.4byte sMurkrowAnims_3_2
+.4byte sMurkrowAnims_3_3
+.4byte sMurkrowAnims_3_4
+.4byte sMurkrowAnims_3_5
+.4byte sMurkrowAnims_3_6
+.4byte sMurkrowAnims_3_7
+.4byte sMurkrowAnims_3_8
+sMurkrowAnimTable4:
+.4byte sMurkrowAnims_4_1
+.4byte sMurkrowAnims_4_2
+.4byte sMurkrowAnims_4_3
+.4byte sMurkrowAnims_4_4
+.4byte sMurkrowAnims_4_5
+.4byte sMurkrowAnims_4_6
+.4byte sMurkrowAnims_4_7
+.4byte sMurkrowAnims_4_8
+sMurkrowAnimTable5:
+.4byte sMurkrowAnims_5_1
+.4byte sMurkrowAnims_5_2
+.4byte sMurkrowAnims_5_3
+.4byte sMurkrowAnims_5_4
+.4byte sMurkrowAnims_5_5
+.4byte sMurkrowAnims_5_6
+.4byte sMurkrowAnims_5_7
+.4byte sMurkrowAnims_5_8
+sMurkrowAnimTable6:
+.4byte sMurkrowAnims_6_1
+.4byte sMurkrowAnims_6_1
+.4byte sMurkrowAnims_6_1
+.4byte sMurkrowAnims_6_1
+.4byte sMurkrowAnims_6_1
+.4byte sMurkrowAnims_6_1
+.4byte sMurkrowAnims_6_1
+.4byte sMurkrowAnims_6_1
+sMurkrowAnimTable7:
+.4byte sMurkrowAnims_7_1
+.4byte sMurkrowAnims_7_2
+.4byte sMurkrowAnims_7_3
+.4byte sMurkrowAnims_7_4
+.4byte sMurkrowAnims_7_5
+.4byte sMurkrowAnims_7_6
+.4byte sMurkrowAnims_7_7
+.4byte sMurkrowAnims_7_8
+sMurkrowAnimTable8:
+.4byte sMurkrowAnims_8_1
+.4byte sMurkrowAnims_8_2
+.4byte sMurkrowAnims_8_3
+.4byte sMurkrowAnims_8_4
+.4byte sMurkrowAnims_8_5
+.4byte sMurkrowAnims_8_6
+.4byte sMurkrowAnims_8_7
+.4byte sMurkrowAnims_8_8
+sMurkrowAnimTable9:
+.4byte sMurkrowAnims_9_1
+.4byte sMurkrowAnims_9_2
+.4byte sMurkrowAnims_9_3
+.4byte sMurkrowAnims_9_4
+.4byte sMurkrowAnims_9_5
+.4byte sMurkrowAnims_9_6
+.4byte sMurkrowAnims_9_7
+.4byte sMurkrowAnims_9_8
+sMurkrowAnimTable10:
+.4byte sMurkrowAnims_10_1
+.4byte sMurkrowAnims_10_2
+.4byte sMurkrowAnims_10_3
+.4byte sMurkrowAnims_10_4
+.4byte sMurkrowAnims_10_5
+.4byte sMurkrowAnims_10_6
+.4byte sMurkrowAnims_10_7
+.4byte sMurkrowAnims_10_8
+sMurkrowAnimTable11:
+.4byte sMurkrowAnims_11_1
+.4byte sMurkrowAnims_11_2
+.4byte sMurkrowAnims_11_3
+.4byte sMurkrowAnims_11_4
+.4byte sMurkrowAnims_11_5
+.4byte sMurkrowAnims_11_6
+.4byte sMurkrowAnims_11_7
+.4byte sMurkrowAnims_11_8
+sMurkrowAnimTable12:
+.4byte sMurkrowAnims_12_1
+.4byte sMurkrowAnims_12_2
+.4byte sMurkrowAnims_12_3
+.4byte sMurkrowAnims_12_4
+.4byte sMurkrowAnims_12_5
+.4byte sMurkrowAnims_12_6
+.4byte sMurkrowAnims_12_7
+.4byte sMurkrowAnims_12_8
+sMurkrowAnimTable13:
+.4byte sMurkrowAnims_13_1
+.4byte sMurkrowAnims_13_2
+.4byte sMurkrowAnims_13_3
+.4byte sMurkrowAnims_13_4
+.4byte sMurkrowAnims_13_5
+.4byte sMurkrowAnims_13_6
+.4byte sMurkrowAnims_13_7
+.4byte sMurkrowAnims_13_8
+sAxAnimationsMurkrow:
+.4byte sMurkrowAnimTable1
+.4byte sMurkrowAnimTable2
+.4byte sMurkrowAnimTable3
+.4byte sMurkrowAnimTable4
+.4byte sMurkrowAnimTable5
+.4byte sMurkrowAnimTable6
+.4byte sMurkrowAnimTable7
+.4byte sMurkrowAnimTable8
+.4byte sMurkrowAnimTable9
+.4byte sMurkrowAnimTable10
+.4byte sMurkrowAnimTable11
+.4byte sMurkrowAnimTable12
+.4byte sMurkrowAnimTable13
+sAxSpritesMurkrow:
+.4byte sMurkrowSprites1
+.4byte sMurkrowSprites2
+.4byte sMurkrowSprites3
+.4byte sMurkrowSprites4
+.4byte sMurkrowSprites5
+.4byte sMurkrowSprites6
+.4byte sMurkrowSprites7
+.4byte sMurkrowSprites8
+.4byte sMurkrowSprites9
+.4byte sMurkrowSprites10
+.4byte sMurkrowSprites11
+.4byte sMurkrowSprites12
+.4byte sMurkrowSprites13
+.4byte sMurkrowSprites14
+.4byte sMurkrowSprites15
+.4byte sMurkrowSprites16
+.4byte sMurkrowSprites17
+.4byte sMurkrowSprites18
+.4byte sMurkrowSprites19
+.4byte sMurkrowSprites20
+.4byte sMurkrowSprites21
+.4byte sMurkrowSprites22
+.4byte sMurkrowSprites23
+.4byte sMurkrowSprites24
+.4byte sMurkrowSprites25
+.4byte sMurkrowSprites26
+.4byte sMurkrowSprites27
+.4byte sMurkrowSprites28
+.4byte sMurkrowSprites29
+.4byte sMurkrowSprites30
+.4byte sMurkrowSprites31
+.4byte sMurkrowSprites32
+sAxMainMurkrow:
+ax_main sAxPosesMurkrow, sAxAnimationsMurkrow, 13, sAxSpritesMurkrow, sAxPositionsMurkrow

--- a/data/ax/natu.inc
+++ b/data/ax/natu.inc
@@ -1,0 +1,2676 @@
+.global gAxNatu
+gAxNatu:
+ax_siro sAxMainNatu
+sNatuPose1:
+ax_pose 0, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose2:
+ax_pose 1, 0x81f1, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose3:
+ax_pose 2, 0x81f1, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose4:
+ax_pose 3, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose5:
+ax_pose 4, 0x81f2, 0x90f7, 0x3c00
+ax_pose_terminator
+sNatuPose6:
+ax_pose 5, 0x01f2, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose7:
+ax_pose 6, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose8:
+ax_pose 7, 0x41f3, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose9:
+ax_pose 8, 0x41f3, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose10:
+ax_pose 9, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose11:
+ax_pose 10, 0x01f3, 0x90e8, 0x3c00
+ax_pose_terminator
+sNatuPose12:
+ax_pose 11, 0x01f3, 0x50f7, 0x3c00
+ax_pose_terminator
+sNatuPose13:
+ax_pose 12, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose14:
+ax_pose 13, 0x01f5, 0x40f8, 0x3c00
+ax_pose_terminator
+sNatuPose15:
+ax_pose 14, 0x01f5, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose16:
+ax_pose 9, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose17:
+ax_pose 10, 0x01f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose18:
+ax_pose 11, 0x01f3, 0x40f8, 0x3c00
+ax_pose_terminator
+sNatuPose19:
+ax_pose 6, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose20:
+ax_pose 7, 0x41f3, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose21:
+ax_pose 8, 0x41f3, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose22:
+ax_pose 3, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose23:
+ax_pose 4, 0x81f2, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose24:
+ax_pose 5, 0x01f2, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose25:
+ax_pose 0, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose26:
+ax_pose 1, 0x81f1, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose27:
+ax_pose 2, 0x81f1, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose28:
+ax_pose 15, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose29:
+ax_pose 3, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose30:
+ax_pose 4, 0x81f2, 0x90f7, 0x3c00
+ax_pose_terminator
+sNatuPose31:
+ax_pose 5, 0x01f2, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose32:
+ax_pose 16, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose33:
+ax_pose 6, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose34:
+ax_pose 7, 0x41f3, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose35:
+ax_pose 8, 0x41f3, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose36:
+ax_pose 17, 0x41f3, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose37:
+ax_pose 9, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose38:
+ax_pose 10, 0x01f3, 0x90e8, 0x3c00
+ax_pose_terminator
+sNatuPose39:
+ax_pose 11, 0x01f3, 0x50f7, 0x3c00
+ax_pose_terminator
+sNatuPose40:
+ax_pose 18, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sNatuPose41:
+ax_pose 12, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose42:
+ax_pose 13, 0x01f5, 0x40f8, 0x3c00
+ax_pose_terminator
+sNatuPose43:
+ax_pose 14, 0x01f5, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose44:
+ax_pose 19, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose45:
+ax_pose 9, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose46:
+ax_pose 10, 0x01f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose47:
+ax_pose 11, 0x01f3, 0x40f8, 0x3c00
+ax_pose_terminator
+sNatuPose48:
+ax_pose 18, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sNatuPose49:
+ax_pose 6, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose50:
+ax_pose 7, 0x41f3, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose51:
+ax_pose 8, 0x41f3, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose52:
+ax_pose 17, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose53:
+ax_pose 3, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose54:
+ax_pose 4, 0x81f2, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose55:
+ax_pose 5, 0x01f2, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose56:
+ax_pose 16, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose57:
+ax_pose 0, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose58:
+ax_pose 1, 0x81f1, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose59:
+ax_pose 2, 0x81f1, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose60:
+ax_pose 20, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose61:
+ax_pose 21, 0x01f0, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose62:
+ax_pose 3, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose63:
+ax_pose 4, 0x81f2, 0x90f7, 0x3c00
+ax_pose_terminator
+sNatuPose64:
+ax_pose 5, 0x01f2, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose65:
+ax_pose 22, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose66:
+ax_pose 23, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose67:
+ax_pose 6, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose68:
+ax_pose 7, 0x41f3, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose69:
+ax_pose 8, 0x41f3, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose70:
+ax_pose 24, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose71:
+ax_pose 25, 0x41f3, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose72:
+ax_pose 9, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose73:
+ax_pose 10, 0x01f3, 0x90e8, 0x3c00
+ax_pose_terminator
+sNatuPose74:
+ax_pose 11, 0x01f3, 0x50f7, 0x3c00
+ax_pose_terminator
+sNatuPose75:
+ax_pose 26, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose76:
+ax_pose 27, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose77:
+ax_pose 12, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose78:
+ax_pose 13, 0x01f5, 0x40f8, 0x3c00
+ax_pose_terminator
+sNatuPose79:
+ax_pose 14, 0x01f5, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose80:
+ax_pose 28, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose81:
+ax_pose 29, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose82:
+ax_pose 9, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose83:
+ax_pose 10, 0x01f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose84:
+ax_pose 11, 0x01f3, 0x40f8, 0x3c00
+ax_pose_terminator
+sNatuPose85:
+ax_pose 26, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose86:
+ax_pose 27, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose87:
+ax_pose 6, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose88:
+ax_pose 7, 0x41f3, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose89:
+ax_pose 8, 0x41f3, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose90:
+ax_pose 24, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose91:
+ax_pose 25, 0x41f3, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose92:
+ax_pose 3, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose93:
+ax_pose 4, 0x81f2, 0x80f8, 0x3c00
+ax_pose_terminator
+sNatuPose94:
+ax_pose 5, 0x01f2, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose95:
+ax_pose 22, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose96:
+ax_pose 23, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose97:
+ax_pose 15, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose98:
+ax_pose 16, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose99:
+ax_pose 17, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose100:
+ax_pose 18, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sNatuPose101:
+ax_pose 19, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose102:
+ax_pose 18, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sNatuPose103:
+ax_pose 17, 0x41f3, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose104:
+ax_pose 16, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose105:
+ax_pose 0, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose106:
+ax_pose 30, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose107:
+ax_pose 31, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose108:
+ax_pose 3, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose109:
+ax_pose 32, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose110:
+ax_pose 33, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose111:
+ax_pose 6, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose112:
+ax_pose 34, 0x01f1, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose113:
+ax_pose 35, 0x01f1, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose114:
+ax_pose 9, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose115:
+ax_pose 36, 0x01f3, 0x90ec, 0x3c00
+ax_pose_terminator
+sNatuPose116:
+ax_pose 37, 0x41f3, 0x90ec, 0x3c00
+ax_pose_terminator
+sNatuPose117:
+ax_pose 12, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose118:
+ax_pose 38, 0x41f4, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose119:
+ax_pose 39, 0x41f4, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose120:
+ax_pose 9, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose121:
+ax_pose 36, 0x01f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose122:
+ax_pose 37, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose123:
+ax_pose 6, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose124:
+ax_pose 34, 0x01f1, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose125:
+ax_pose 35, 0x01f1, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose126:
+ax_pose 3, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose127:
+ax_pose 32, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose128:
+ax_pose 33, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose129:
+ax_pose 40, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose130:
+ax_pose 41, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose131:
+ax_pose 42, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sNatuPose132:
+ax_pose 43, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sNatuPose133:
+ax_pose 44, 0x01e7, 0x90eb, 0x3c00
+ax_pose_terminator
+sNatuPose134:
+ax_pose 45, 0x01e8, 0x90ed, 0x3c00
+ax_pose_terminator
+sNatuPose135:
+ax_pose 46, 0x01ea, 0x80f1, 0x3c00
+ax_pose_terminator
+sNatuPose136:
+ax_pose 45, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose137:
+ax_pose 44, 0x01e7, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose138:
+ax_pose 43, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose139:
+ax_pose 0, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose140:
+ax_pose 3, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose141:
+ax_pose 6, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose142:
+ax_pose 9, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose143:
+ax_pose 12, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose144:
+ax_pose 9, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose145:
+ax_pose 6, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose146:
+ax_pose 3, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose147:
+ax_pose 15, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose148:
+ax_pose 16, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose149:
+ax_pose 17, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose150:
+ax_pose 18, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sNatuPose151:
+ax_pose 19, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose152:
+ax_pose 18, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sNatuPose153:
+ax_pose 17, 0x41f3, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose154:
+ax_pose 16, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose155:
+ax_pose 15, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose156:
+ax_pose 16, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose157:
+ax_pose 17, 0x41f3, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose158:
+ax_pose 18, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sNatuPose159:
+ax_pose 19, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose160:
+ax_pose 18, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sNatuPose161:
+ax_pose 17, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose162:
+ax_pose 16, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose163:
+ax_pose 0, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose164:
+ax_pose 15, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose165:
+ax_pose 31, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose166:
+ax_pose 3, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose167:
+ax_pose 16, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose168:
+ax_pose 33, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose169:
+ax_pose 6, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose170:
+ax_pose 17, 0x41f3, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose171:
+ax_pose 35, 0x01f1, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose172:
+ax_pose 9, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose173:
+ax_pose 18, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sNatuPose174:
+ax_pose 37, 0x41f3, 0x90ec, 0x3c00
+ax_pose_terminator
+sNatuPose175:
+ax_pose 12, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose176:
+ax_pose 19, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose177:
+ax_pose 39, 0x41f4, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose178:
+ax_pose 9, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose179:
+ax_pose 18, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sNatuPose180:
+ax_pose 37, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose181:
+ax_pose 6, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose182:
+ax_pose 17, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose183:
+ax_pose 35, 0x01f1, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose184:
+ax_pose 3, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose185:
+ax_pose 16, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose186:
+ax_pose 33, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose187:
+ax_pose 15, 0x01f1, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose188:
+ax_pose 16, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose189:
+ax_pose 17, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sNatuPose190:
+ax_pose 18, 0x41f3, 0x80f4, 0x3c00
+ax_pose_terminator
+sNatuPose191:
+ax_pose 19, 0x41f3, 0x80f3, 0x3c00
+ax_pose_terminator
+sNatuPose192:
+ax_pose 18, 0x41f3, 0x90eb, 0x3c00
+ax_pose_terminator
+sNatuPose193:
+ax_pose 17, 0x41f3, 0x90ea, 0x3c00
+ax_pose_terminator
+sNatuPose194:
+ax_pose 16, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose195:
+ax_pose 0, 0x01f1, 0x80f0, 0x3c00
+ax_pose_terminator
+sNatuPose196:
+ax_pose 3, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose197:
+ax_pose 6, 0x01f1, 0x80f6, 0x3c00
+ax_pose_terminator
+sNatuPose198:
+ax_pose 9, 0x01f3, 0x40f7, 0x3c00
+ax_pose_terminator
+sNatuPose199:
+ax_pose 12, 0x41f3, 0x80f7, 0x3c00
+ax_pose_terminator
+sNatuPose200:
+ax_pose 9, 0x01f3, 0x50f8, 0x3c00
+ax_pose_terminator
+sNatuPose201:
+ax_pose 6, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+sNatuPose202:
+ax_pose 3, 0x01f1, 0x90e9, 0x3c00
+ax_pose_terminator
+.align 2
+sNatuAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNatuAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 5, 4, 5, 4,
+ax_anim 1, 0, 30, 12, 10, 12, 10,
+ax_anim 2, 0, 31, 21, 18, 21, 18,
+ax_anim 2, 1, 31, 22, 17, 22, 17,
+ax_anim 2, 0, 31, 21, 18, 21, 18,
+ax_anim 2, 0, 31, 22, 17, 22, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sNatuAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sNatuAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 1, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 0, 39, 20, -22, 20, -22,
+ax_anim 2, 0, 36, 6, -7, 6, -7,
+ax_anim_terminator
+sNatuAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -23, 0, -23,
+ax_anim 2, 1, 43, 1, -23, 1, -23,
+ax_anim 2, 0, 43, 0, -23, 0, -23,
+ax_anim 2, 0, 43, 1, -23, 1, -23,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sNatuAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -19, -23, -19, -23,
+ax_anim 2, 1, 47, -20, -22, -20, -22,
+ax_anim 2, 0, 47, -19, -23, -19, -23,
+ax_anim 2, 0, 47, -20, -22, -20, -22,
+ax_anim 2, 0, 44, -6, -7, -6, -7,
+ax_anim_terminator
+sNatuAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sNatuAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -5, 4, -5, 4,
+ax_anim 1, 0, 54, -12, 10, -12, 10,
+ax_anim 2, 0, 55, -21, 18, -21, 18,
+ax_anim 2, 1, 55, -22, 17, -22, 17,
+ax_anim 2, 0, 55, -21, 18, -21, 18,
+ax_anim 2, 0, 55, -22, 17, -22, 17,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNatuAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, -4, 0, -4,
+ax_anim 4, 0, 56, 0, -5, 0, -5,
+ax_anim 1, 0, 56, 0, 3, 0, 3,
+ax_anim 1, 0, 56, 0, 11, 0, 11,
+ax_anim 4, 2, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 60, 0, 17, 0, 17,
+ax_anim 2, 1, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 60, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 60, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 1, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sNatuAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim 4, 0, 61, -5, -5, -5, -5,
+ax_anim 1, 0, 61, 3, 3, 3, 3,
+ax_anim 1, 0, 61, 12, 11, 12, 11,
+ax_anim 4, 2, 64, 20, 18, 20, 18,
+ax_anim 2, 0, 65, 18, 16, 18, 16,
+ax_anim 2, 1, 64, 20, 18, 20, 18,
+ax_anim 2, 0, 65, 18, 16, 18, 16,
+ax_anim 2, 0, 64, 20, 18, 20, 18,
+ax_anim 2, 0, 65, 18, 16, 18, 16,
+ax_anim 2, 0, 64, 20, 18, 20, 18,
+ax_anim 1, 0, 61, 11, 10, 11, 10,
+ax_anim 2, 0, 61, 4, 4, 4, 4,
+ax_anim_terminator
+sNatuAnims_3_3:
+ax_anim 2, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 68, -4, 0, -4, 0,
+ax_anim 4, 0, 66, -5, 0, -5, 0,
+ax_anim 1, 0, 66, 3, 0, 3, 0,
+ax_anim 1, 0, 66, 12, 0, 12, 0,
+ax_anim 4, 2, 69, 19, 0, 19, 0,
+ax_anim 2, 0, 70, 17, 0, 17, 0,
+ax_anim 2, 1, 69, 19, 0, 19, 0,
+ax_anim 2, 0, 70, 17, 0, 17, 0,
+ax_anim 2, 0, 69, 19, 0, 19, 0,
+ax_anim 2, 0, 70, 17, 0, 17, 0,
+ax_anim 2, 0, 69, 19, 0, 19, 0,
+ax_anim 1, 0, 66, 11, 0, 11, 0,
+ax_anim 2, 0, 66, 4, 0, 4, 0,
+ax_anim_terminator
+sNatuAnims_3_4:
+ax_anim 2, 0, 72, -2, 2, -2, 2,
+ax_anim 2, 0, 73, -4, 4, -4, 4,
+ax_anim 4, 0, 71, -5, 5, -5, 5,
+ax_anim 1, 0, 71, 3, -4, 3, -4,
+ax_anim 1, 0, 71, 11, -13, 11, -13,
+ax_anim 4, 2, 74, 20, -24, 20, -24,
+ax_anim 2, 0, 75, 18, -22, 18, -22,
+ax_anim 2, 1, 74, 20, -24, 20, -24,
+ax_anim 2, 0, 75, 18, -22, 18, -22,
+ax_anim 2, 0, 74, 20, -24, 20, -24,
+ax_anim 2, 0, 75, 18, -22, 18, -22,
+ax_anim 2, 0, 74, 20, -24, 20, -24,
+ax_anim 1, 0, 71, 10, -12, 10, -12,
+ax_anim 2, 0, 71, 4, -5, 4, -5,
+ax_anim_terminator
+sNatuAnims_3_5:
+ax_anim 2, 0, 77, 0, 2, 0, 2,
+ax_anim 2, 0, 78, 0, 4, 0, 4,
+ax_anim 4, 0, 76, 0, 5, 0, 5,
+ax_anim 1, 0, 76, 0, -3, 0, -3,
+ax_anim 1, 0, 76, 0, -11, 0, -11,
+ax_anim 4, 2, 79, 0, -24, 0, -24,
+ax_anim 2, 0, 80, 0, -22, 0, -22,
+ax_anim 2, 1, 79, 0, -24, 0, -24,
+ax_anim 2, 0, 80, 0, -22, 0, -22,
+ax_anim 2, 0, 79, 0, -24, 0, -24,
+ax_anim 2, 0, 80, 0, -22, 0, -22,
+ax_anim 2, 0, 79, 0, -24, 0, -24,
+ax_anim 1, 0, 76, 0, -10, 0, -10,
+ax_anim 2, 0, 76, 0, -4, 0, -4,
+ax_anim_terminator
+sNatuAnims_3_6:
+ax_anim 2, 0, 82, 2, 2, 2, 2,
+ax_anim 2, 0, 83, 4, 4, 4, 4,
+ax_anim 4, 0, 81, 5, 5, 5, 5,
+ax_anim 1, 0, 81, -3, -4, -3, -4,
+ax_anim 1, 0, 81, -11, -13, -11, -13,
+ax_anim 4, 2, 84, -20, -24, -20, -24,
+ax_anim 2, 0, 85, -18, -22, -18, -22,
+ax_anim 2, 1, 84, -20, -24, -20, -24,
+ax_anim 2, 0, 85, -18, -22, -18, -22,
+ax_anim 2, 0, 84, -20, -24, -20, -24,
+ax_anim 2, 0, 85, -18, -22, -18, -22,
+ax_anim 2, 0, 84, -20, -24, -20, -24,
+ax_anim 1, 0, 81, -10, -12, -10, -12,
+ax_anim 2, 0, 81, -4, -5, -4, -5,
+ax_anim_terminator
+sNatuAnims_3_7:
+ax_anim 2, 0, 87, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 4, 0, 4, 0,
+ax_anim 4, 0, 86, 5, 0, 5, 0,
+ax_anim 1, 0, 86, -3, 0, -3, 0,
+ax_anim 1, 0, 86, -12, 0, -12, 0,
+ax_anim 4, 2, 89, -19, 0, -19, 0,
+ax_anim 2, 0, 90, -17, 0, -17, 0,
+ax_anim 2, 1, 89, -19, 0, -19, 0,
+ax_anim 2, 0, 90, -17, 0, -17, 0,
+ax_anim 2, 0, 89, -19, 0, -19, 0,
+ax_anim 2, 0, 90, -17, 0, -17, 0,
+ax_anim 2, 0, 89, -19, 0, -19, 0,
+ax_anim 1, 0, 86, -11, 0, -11, 0,
+ax_anim 2, 0, 86, -4, 0, -4, 0,
+ax_anim_terminator
+sNatuAnims_3_8:
+ax_anim 2, 0, 92, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 4, -4, 4, -4,
+ax_anim 4, 0, 91, 5, -5, 5, -5,
+ax_anim 1, 0, 91, -3, 3, -3, 3,
+ax_anim 1, 0, 91, -12, 11, -12, 11,
+ax_anim 4, 2, 94, -20, 18, -20, 18,
+ax_anim 2, 0, 95, -18, 16, -18, 16,
+ax_anim 2, 1, 94, -20, 18, -20, 18,
+ax_anim 2, 0, 95, -18, 16, -18, 16,
+ax_anim 2, 0, 94, -20, 18, -20, 18,
+ax_anim 2, 0, 95, -18, 16, -18, 16,
+ax_anim 2, 0, 94, -20, 18, -20, 18,
+ax_anim 1, 0, 91, -11, 10, -11, 10,
+ax_anim 2, 0, 91, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sNatuAnims_4_1:
+ax_anim 2, 2, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 1, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_4_2:
+ax_anim 2, 2, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 1, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_4_3:
+ax_anim 2, 2, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 1, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_4_4:
+ax_anim 2, 2, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 1, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_4_5:
+ax_anim 2, 2, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 1, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_4_6:
+ax_anim 2, 2, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 1, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_4_7:
+ax_anim 2, 2, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_4_8:
+ax_anim 2, 2, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 1, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_5_1:
+ax_anim 3, 0, 105, 0, -2, 0, 0,
+ax_anim 3, 0, 106, 0, -4, 0, 0,
+ax_anim 3, 0, 105, 0, -5, 0, 0,
+ax_anim 3, 0, 106, 0, -6, 0, 0,
+ax_anim 3, 0, 105, 0, -6, 0, 0,
+ax_anim 3, 0, 106, 0, -6, 0, 0,
+ax_anim 3, 2, 105, 0, -6, 0, 0,
+ax_anim 3, 0, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_5_2:
+ax_anim 3, 0, 108, 0, -2, 0, 0,
+ax_anim 3, 0, 109, 0, -4, 0, 0,
+ax_anim 3, 0, 108, 0, -5, 0, 0,
+ax_anim 3, 0, 109, 0, -6, 0, 0,
+ax_anim 3, 0, 108, 0, -6, 0, 0,
+ax_anim 3, 0, 109, 0, -6, 0, 0,
+ax_anim 3, 2, 108, 0, -6, 0, 0,
+ax_anim 3, 0, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_5_3:
+ax_anim 3, 0, 111, 0, -2, 0, 0,
+ax_anim 3, 0, 112, 0, -4, 0, 0,
+ax_anim 3, 0, 111, 0, -5, 0, 0,
+ax_anim 3, 0, 112, 0, -6, 0, 0,
+ax_anim 3, 0, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 112, 0, -6, 0, 0,
+ax_anim 3, 2, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 112, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_5_4:
+ax_anim 3, 0, 114, 0, -2, 0, 0,
+ax_anim 3, 0, 115, 0, -4, 0, 0,
+ax_anim 3, 0, 114, 0, -5, 0, 0,
+ax_anim 3, 0, 115, 0, -6, 0, 0,
+ax_anim 3, 0, 114, 0, -6, 0, 0,
+ax_anim 3, 0, 115, 0, -6, 0, 0,
+ax_anim 3, 2, 114, 0, -6, 0, 0,
+ax_anim 3, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_5_5:
+ax_anim 3, 0, 117, 0, -2, 0, 0,
+ax_anim 3, 0, 118, 0, -4, 0, 0,
+ax_anim 3, 0, 117, 0, -5, 0, 0,
+ax_anim 3, 0, 118, 0, -6, 0, 0,
+ax_anim 3, 0, 117, 0, -6, 0, 0,
+ax_anim 3, 0, 118, 0, -6, 0, 0,
+ax_anim 3, 2, 117, 0, -6, 0, 0,
+ax_anim 3, 0, 118, 0, -6, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_5_6:
+ax_anim 3, 0, 120, 0, -2, 0, 0,
+ax_anim 3, 0, 121, 0, -4, 0, 0,
+ax_anim 3, 0, 120, 0, -5, 0, 0,
+ax_anim 3, 0, 121, 0, -6, 0, 0,
+ax_anim 3, 0, 120, 0, -6, 0, 0,
+ax_anim 3, 0, 121, 0, -6, 0, 0,
+ax_anim 3, 2, 120, 0, -6, 0, 0,
+ax_anim 3, 0, 121, 0, -6, 0, 0,
+ax_anim 2, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_5_7:
+ax_anim 3, 0, 123, 0, -2, 0, 0,
+ax_anim 3, 0, 124, 0, -4, 0, 0,
+ax_anim 3, 0, 123, 0, -5, 0, 0,
+ax_anim 3, 0, 124, 0, -6, 0, 0,
+ax_anim 3, 0, 123, 0, -6, 0, 0,
+ax_anim 3, 0, 124, 0, -6, 0, 0,
+ax_anim 3, 2, 123, 0, -6, 0, 0,
+ax_anim 3, 0, 124, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_5_8:
+ax_anim 3, 0, 126, 0, -2, 0, 0,
+ax_anim 3, 0, 127, 0, -4, 0, 0,
+ax_anim 3, 0, 126, 0, -5, 0, 0,
+ax_anim 3, 0, 127, 0, -6, 0, 0,
+ax_anim 3, 0, 126, 0, -6, 0, 0,
+ax_anim 3, 0, 127, 0, -6, 0, 0,
+ax_anim 3, 2, 126, 0, -6, 0, 0,
+ax_anim 3, 0, 127, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sNatuAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sNatuAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sNatuAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sNatuAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sNatuAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sNatuAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sNatuAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sNatuAnims_8_1:
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, -1, 0, 0,
+ax_anim 8, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 138, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_8_2:
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -1, 0, 0,
+ax_anim 8, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_8_3:
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, -1, 0, 0,
+ax_anim 8, 0, 144, 0, -2, 0, 0,
+ax_anim 4, 0, 144, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_8_4:
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, -1, 0, 0,
+ax_anim 8, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_8_5:
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -1, 0, 0,
+ax_anim 8, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_8_6:
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, -1, 0, 0,
+ax_anim 8, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 0, 141, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_8_7:
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, -1, 0, 0,
+ax_anim 8, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sNatuAnims_8_8:
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -1, 0, 0,
+ax_anim 8, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 17, 7, 17,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 17, -7, 17,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 22, 9, 22, 9,
+ax_anim 3, 0, 149, 22, 19, 22, 19,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 3, 14, 3, 14,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 18, -4, 18, -4,
+ax_anim 3, 0, 148, 22, 1, 22, 1,
+ax_anim 2, 3, 149, 18, 5, 18, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -22, 11, -22,
+ax_anim 3, 0, 147, 19, -24, 19, -24,
+ax_anim 2, 3, 148, 21, -14, 21, -14,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -10, -8, -10,
+ax_anim 2, 0, 153, -7, -20, -7, -20,
+ax_anim 3, 0, 146, 0, -25, 0, -25,
+ax_anim 2, 3, 147, 7, -20, 7, -20,
+ax_anim 2, 0, 148, 8, -8, 8, -8,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -11, -22, -11, -22,
+ax_anim 3, 0, 153, -19, -24, -19, -24,
+ax_anim 2, 3, 152, -21, -14, -21, -14,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -18, -4, -18, -4,
+ax_anim 3, 0, 152, -22, 1, -22, 1,
+ax_anim 2, 3, 151, -18, 5, -18, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -22, 9, -22, 9,
+ax_anim 3, 0, 151, -22, 19, -22, 19,
+ax_anim 2, 3, 150, -11, 21, -11, 21,
+ax_anim 2, 0, 149, -3, 14, -3, 14,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNatuAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sNatuGfx1:
+.incbin "baserom.gba", 0xCAE150, 0x200
+sNatuSprites1:
+ax_sprite sNatuGfx1, 0x200
+ax_sprite_terminator
+sNatuGfx2:
+.incbin "baserom.gba", 0xCAE360, 0x100
+sNatuSprites2:
+ax_sprite sNatuGfx2, 0x100
+ax_sprite_terminator
+sNatuGfx3:
+.incbin "baserom.gba", 0xCAE470, 0x100
+sNatuSprites3:
+ax_sprite sNatuGfx3, 0x100
+ax_sprite_terminator
+sNatuGfx4:
+.incbin "baserom.gba", 0xCAE580, 0x200
+sNatuSprites4:
+ax_sprite sNatuGfx4, 0x200
+ax_sprite_terminator
+sNatuGfx5:
+.incbin "baserom.gba", 0xCAE790, 0x100
+sNatuSprites5:
+ax_sprite sNatuGfx5, 0x100
+ax_sprite_terminator
+sNatuGfx6:
+.incbin "baserom.gba", 0xCAE8A0, 0x200
+sNatuSprites6:
+ax_sprite sNatuGfx6, 0x200
+ax_sprite_terminator
+sNatuGfx7:
+.incbin "baserom.gba", 0xCAEAB0, 0x200
+sNatuSprites7:
+ax_sprite sNatuGfx7, 0x200
+ax_sprite_terminator
+sNatuGfx8:
+.incbin "baserom.gba", 0xCAECC0, 0x100
+sNatuSprites8:
+ax_sprite sNatuGfx8, 0x100
+ax_sprite_terminator
+sNatuGfx9:
+.incbin "baserom.gba", 0xCAEDD0, 0x100
+sNatuSprites9:
+ax_sprite sNatuGfx9, 0x100
+ax_sprite_terminator
+sNatuGfx10:
+.incbin "baserom.gba", 0xCAEEE0, 0x80
+sNatuSprites10:
+ax_sprite sNatuGfx10, 0x80
+ax_sprite_terminator
+sNatuGfx11:
+.incbin "baserom.gba", 0xCAEF70, 0x200
+sNatuSprites11:
+ax_sprite sNatuGfx11, 0x200
+ax_sprite_terminator
+sNatuGfx12:
+.incbin "baserom.gba", 0xCAF180, 0x80
+sNatuSprites12:
+ax_sprite sNatuGfx12, 0x80
+ax_sprite_terminator
+sNatuGfx13:
+.incbin "baserom.gba", 0xCAF210, 0x100
+sNatuSprites13:
+ax_sprite sNatuGfx13, 0x100
+ax_sprite_terminator
+sNatuGfx14:
+.incbin "baserom.gba", 0xCAF320, 0x80
+sNatuSprites14:
+ax_sprite sNatuGfx14, 0x80
+ax_sprite_terminator
+sNatuGfx15:
+.incbin "baserom.gba", 0xCAF3B0, 0x80
+sNatuSprites15:
+ax_sprite sNatuGfx15, 0x80
+ax_sprite_terminator
+sNatuGfx16:
+.incbin "baserom.gba", 0xCAF440, 0x60
+sNatuGfx16_1:
+.incbin "baserom.gba", 0xCAF4A0, 0x80
+sNatuGfx16_2:
+.incbin "baserom.gba", 0xCAF520, 0x40
+sNatuSprites16:
+ax_sprite sNatuGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx16_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNatuGfx17:
+.incbin "baserom.gba", 0xCAF598, 0x60
+sNatuGfx17_1:
+.incbin "baserom.gba", 0xCAF5F8, 0x60
+sNatuGfx17_2:
+.incbin "baserom.gba", 0xCAF658, 0x40
+sNatuSprites17:
+ax_sprite sNatuGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNatuGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNatuGfx18:
+.incbin "baserom.gba", 0xCAF6D0, 0x60
+sNatuGfx18_1:
+.incbin "baserom.gba", 0xCAF730, 0x60
+sNatuSprites18:
+ax_sprite sNatuGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNatuGfx19:
+.incbin "baserom.gba", 0xCAF7B8, 0x60
+sNatuGfx19_1:
+.incbin "baserom.gba", 0xCAF818, 0x60
+sNatuSprites19:
+ax_sprite sNatuGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNatuGfx20:
+.incbin "baserom.gba", 0xCAF8A0, 0x60
+sNatuGfx20_1:
+.incbin "baserom.gba", 0xCAF900, 0x80
+sNatuSprites20:
+ax_sprite sNatuGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx20_1, 0x80
+ax_sprite_terminator
+sNatuGfx21:
+.incbin "baserom.gba", 0xCAF9A0, 0x40
+sNatuGfx21_1:
+.incbin "baserom.gba", 0xCAF9E0, 0x60
+sNatuGfx21_2:
+.incbin "baserom.gba", 0xCAFA40, 0x40
+sNatuSprites21:
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNatuGfx21_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNatuGfx22:
+.incbin "baserom.gba", 0xCAFAC0, 0x40
+sNatuGfx22_1:
+.incbin "baserom.gba", 0xCAFB00, 0x60
+sNatuGfx22_2:
+.incbin "baserom.gba", 0xCAFB60, 0x40
+sNatuSprites22:
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNatuGfx22_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNatuGfx23:
+.incbin "baserom.gba", 0xCAFBE0, 0x60
+sNatuGfx23_1:
+.incbin "baserom.gba", 0xCAFC40, 0x60
+sNatuGfx23_2:
+.incbin "baserom.gba", 0xCAFCA0, 0x40
+sNatuSprites23:
+ax_sprite sNatuGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx23_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNatuGfx24:
+.incbin "baserom.gba", 0xCAFD18, 0x60
+sNatuGfx24_1:
+.incbin "baserom.gba", 0xCAFD78, 0x60
+sNatuGfx24_2:
+.incbin "baserom.gba", 0xCAFDD8, 0x20
+sNatuSprites24:
+ax_sprite sNatuGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNatuGfx24_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNatuGfx25:
+.incbin "baserom.gba", 0xCAFE30, 0x60
+sNatuGfx25_1:
+.incbin "baserom.gba", 0xCAFE90, 0x60
+sNatuGfx25_2:
+.incbin "baserom.gba", 0xCAFEF0, 0x40
+sNatuSprites25:
+ax_sprite sNatuGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx25_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNatuGfx26:
+.incbin "baserom.gba", 0xCAFF68, 0x60
+sNatuGfx26_1:
+.incbin "baserom.gba", 0xCAFFC8, 0x60
+sNatuSprites26:
+ax_sprite sNatuGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNatuGfx27:
+.incbin "baserom.gba", 0xCB0050, 0x80
+sNatuSprites27:
+ax_sprite sNatuGfx27, 0x80
+ax_sprite_terminator
+sNatuGfx28:
+.incbin "baserom.gba", 0xCB00E0, 0x80
+sNatuSprites28:
+ax_sprite sNatuGfx28, 0x80
+ax_sprite_terminator
+sNatuGfx29:
+.incbin "baserom.gba", 0xCB0170, 0x60
+sNatuGfx29_1:
+.incbin "baserom.gba", 0xCB01D0, 0x60
+sNatuSprites29:
+ax_sprite sNatuGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNatuGfx30:
+.incbin "baserom.gba", 0xCB0258, 0x40
+sNatuGfx30_1:
+.incbin "baserom.gba", 0xCB0298, 0x60
+sNatuSprites30:
+ax_sprite sNatuGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNatuGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNatuGfx31:
+.incbin "baserom.gba", 0xCB0320, 0x100
+sNatuGfx31_1:
+.incbin "baserom.gba", 0xCB0420, 0x40
+sNatuSprites31:
+ax_sprite sNatuGfx31, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx31_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNatuGfx32:
+.incbin "baserom.gba", 0xCB0488, 0x40
+sNatuGfx32_1:
+.incbin "baserom.gba", 0xCB04C8, 0x80
+sNatuGfx32_2:
+.incbin "baserom.gba", 0xCB0548, 0x40
+sNatuSprites32:
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx32_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx32_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNatuGfx33:
+.incbin "baserom.gba", 0xCB05C8, 0x60
+sNatuGfx33_1:
+.incbin "baserom.gba", 0xCB0628, 0x60
+sNatuGfx33_2:
+.incbin "baserom.gba", 0xCB0688, 0x40
+sNatuSprites33:
+ax_sprite sNatuGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx33_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNatuGfx34:
+.incbin "baserom.gba", 0xCB0700, 0x60
+sNatuGfx34_1:
+.incbin "baserom.gba", 0xCB0760, 0x60
+sNatuGfx34_2:
+.incbin "baserom.gba", 0xCB07C0, 0x40
+sNatuSprites34:
+ax_sprite sNatuGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNatuGfx34_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNatuGfx35:
+.incbin "baserom.gba", 0xCB0838, 0x60
+sNatuGfx35_1:
+.incbin "baserom.gba", 0xCB0898, 0x60
+sNatuGfx35_2:
+.incbin "baserom.gba", 0xCB08F8, 0x40
+sNatuSprites35:
+ax_sprite sNatuGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx35_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNatuGfx36:
+.incbin "baserom.gba", 0xCB0970, 0x60
+sNatuGfx36_1:
+.incbin "baserom.gba", 0xCB09D0, 0x60
+sNatuGfx36_2:
+.incbin "baserom.gba", 0xCB0A30, 0x40
+sNatuSprites36:
+ax_sprite sNatuGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx36_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNatuGfx37:
+.incbin "baserom.gba", 0xCB0AA8, 0x60
+sNatuGfx37_1:
+.incbin "baserom.gba", 0xCB0B08, 0x60
+sNatuGfx37_2:
+.incbin "baserom.gba", 0xCB0B68, 0x20
+sNatuSprites37:
+ax_sprite sNatuGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx37_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNatuGfx37_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNatuGfx38:
+.incbin "baserom.gba", 0xCB0BC0, 0x60
+sNatuGfx38_1:
+.incbin "baserom.gba", 0xCB0C20, 0x60
+sNatuSprites38:
+ax_sprite sNatuGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNatuGfx39:
+.incbin "baserom.gba", 0xCB0CA8, 0x100
+sNatuSprites39:
+ax_sprite sNatuGfx39, 0x100
+ax_sprite_terminator
+sNatuGfx40:
+.incbin "baserom.gba", 0xCB0DB8, 0x60
+sNatuGfx40_1:
+.incbin "baserom.gba", 0xCB0E18, 0x60
+sNatuSprites40:
+ax_sprite sNatuGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNatuGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNatuGfx41:
+.incbin "baserom.gba", 0xCB0EA0, 0x200
+sNatuSprites41:
+ax_sprite sNatuGfx41, 0x200
+ax_sprite_terminator
+sNatuGfx42:
+.incbin "baserom.gba", 0xCB10B0, 0x200
+sNatuSprites42:
+ax_sprite sNatuGfx42, 0x200
+ax_sprite_terminator
+sNatuGfx43:
+.incbin "baserom.gba", 0xCB12C0, 0x200
+sNatuSprites43:
+ax_sprite sNatuGfx43, 0x200
+ax_sprite_terminator
+sNatuGfx44:
+.incbin "baserom.gba", 0xCB14D0, 0x200
+sNatuSprites44:
+ax_sprite sNatuGfx44, 0x200
+ax_sprite_terminator
+sNatuGfx45:
+.incbin "baserom.gba", 0xCB16E0, 0x200
+sNatuSprites45:
+ax_sprite sNatuGfx45, 0x200
+ax_sprite_terminator
+sNatuGfx46:
+.incbin "baserom.gba", 0xCB18F0, 0x200
+sNatuSprites46:
+ax_sprite sNatuGfx46, 0x200
+ax_sprite_terminator
+sNatuGfx47:
+.incbin "baserom.gba", 0xCB1B00, 0x200
+sNatuSprites47:
+ax_sprite sNatuGfx47, 0x200
+ax_sprite_terminator
+sAxPosesNatu:
+.4byte sNatuPose1
+.4byte sNatuPose2
+.4byte sNatuPose3
+.4byte sNatuPose4
+.4byte sNatuPose5
+.4byte sNatuPose6
+.4byte sNatuPose7
+.4byte sNatuPose8
+.4byte sNatuPose9
+.4byte sNatuPose10
+.4byte sNatuPose11
+.4byte sNatuPose12
+.4byte sNatuPose13
+.4byte sNatuPose14
+.4byte sNatuPose15
+.4byte sNatuPose16
+.4byte sNatuPose17
+.4byte sNatuPose18
+.4byte sNatuPose19
+.4byte sNatuPose20
+.4byte sNatuPose21
+.4byte sNatuPose22
+.4byte sNatuPose23
+.4byte sNatuPose24
+.4byte sNatuPose25
+.4byte sNatuPose26
+.4byte sNatuPose27
+.4byte sNatuPose28
+.4byte sNatuPose29
+.4byte sNatuPose30
+.4byte sNatuPose31
+.4byte sNatuPose32
+.4byte sNatuPose33
+.4byte sNatuPose34
+.4byte sNatuPose35
+.4byte sNatuPose36
+.4byte sNatuPose37
+.4byte sNatuPose38
+.4byte sNatuPose39
+.4byte sNatuPose40
+.4byte sNatuPose41
+.4byte sNatuPose42
+.4byte sNatuPose43
+.4byte sNatuPose44
+.4byte sNatuPose45
+.4byte sNatuPose46
+.4byte sNatuPose47
+.4byte sNatuPose48
+.4byte sNatuPose49
+.4byte sNatuPose50
+.4byte sNatuPose51
+.4byte sNatuPose52
+.4byte sNatuPose53
+.4byte sNatuPose54
+.4byte sNatuPose55
+.4byte sNatuPose56
+.4byte sNatuPose57
+.4byte sNatuPose58
+.4byte sNatuPose59
+.4byte sNatuPose60
+.4byte sNatuPose61
+.4byte sNatuPose62
+.4byte sNatuPose63
+.4byte sNatuPose64
+.4byte sNatuPose65
+.4byte sNatuPose66
+.4byte sNatuPose67
+.4byte sNatuPose68
+.4byte sNatuPose69
+.4byte sNatuPose70
+.4byte sNatuPose71
+.4byte sNatuPose72
+.4byte sNatuPose73
+.4byte sNatuPose74
+.4byte sNatuPose75
+.4byte sNatuPose76
+.4byte sNatuPose77
+.4byte sNatuPose78
+.4byte sNatuPose79
+.4byte sNatuPose80
+.4byte sNatuPose81
+.4byte sNatuPose82
+.4byte sNatuPose83
+.4byte sNatuPose84
+.4byte sNatuPose85
+.4byte sNatuPose86
+.4byte sNatuPose87
+.4byte sNatuPose88
+.4byte sNatuPose89
+.4byte sNatuPose90
+.4byte sNatuPose91
+.4byte sNatuPose92
+.4byte sNatuPose93
+.4byte sNatuPose94
+.4byte sNatuPose95
+.4byte sNatuPose96
+.4byte sNatuPose97
+.4byte sNatuPose98
+.4byte sNatuPose99
+.4byte sNatuPose100
+.4byte sNatuPose101
+.4byte sNatuPose102
+.4byte sNatuPose103
+.4byte sNatuPose104
+.4byte sNatuPose105
+.4byte sNatuPose106
+.4byte sNatuPose107
+.4byte sNatuPose108
+.4byte sNatuPose109
+.4byte sNatuPose110
+.4byte sNatuPose111
+.4byte sNatuPose112
+.4byte sNatuPose113
+.4byte sNatuPose114
+.4byte sNatuPose115
+.4byte sNatuPose116
+.4byte sNatuPose117
+.4byte sNatuPose118
+.4byte sNatuPose119
+.4byte sNatuPose120
+.4byte sNatuPose121
+.4byte sNatuPose122
+.4byte sNatuPose123
+.4byte sNatuPose124
+.4byte sNatuPose125
+.4byte sNatuPose126
+.4byte sNatuPose127
+.4byte sNatuPose128
+.4byte sNatuPose129
+.4byte sNatuPose130
+.4byte sNatuPose131
+.4byte sNatuPose132
+.4byte sNatuPose133
+.4byte sNatuPose134
+.4byte sNatuPose135
+.4byte sNatuPose136
+.4byte sNatuPose137
+.4byte sNatuPose138
+.4byte sNatuPose139
+.4byte sNatuPose140
+.4byte sNatuPose141
+.4byte sNatuPose142
+.4byte sNatuPose143
+.4byte sNatuPose144
+.4byte sNatuPose145
+.4byte sNatuPose146
+.4byte sNatuPose147
+.4byte sNatuPose148
+.4byte sNatuPose149
+.4byte sNatuPose150
+.4byte sNatuPose151
+.4byte sNatuPose152
+.4byte sNatuPose153
+.4byte sNatuPose154
+.4byte sNatuPose155
+.4byte sNatuPose156
+.4byte sNatuPose157
+.4byte sNatuPose158
+.4byte sNatuPose159
+.4byte sNatuPose160
+.4byte sNatuPose161
+.4byte sNatuPose162
+.4byte sNatuPose163
+.4byte sNatuPose164
+.4byte sNatuPose165
+.4byte sNatuPose166
+.4byte sNatuPose167
+.4byte sNatuPose168
+.4byte sNatuPose169
+.4byte sNatuPose170
+.4byte sNatuPose171
+.4byte sNatuPose172
+.4byte sNatuPose173
+.4byte sNatuPose174
+.4byte sNatuPose175
+.4byte sNatuPose176
+.4byte sNatuPose177
+.4byte sNatuPose178
+.4byte sNatuPose179
+.4byte sNatuPose180
+.4byte sNatuPose181
+.4byte sNatuPose182
+.4byte sNatuPose183
+.4byte sNatuPose184
+.4byte sNatuPose185
+.4byte sNatuPose186
+.4byte sNatuPose187
+.4byte sNatuPose188
+.4byte sNatuPose189
+.4byte sNatuPose190
+.4byte sNatuPose191
+.4byte sNatuPose192
+.4byte sNatuPose193
+.4byte sNatuPose194
+.4byte sNatuPose195
+.4byte sNatuPose196
+.4byte sNatuPose197
+.4byte sNatuPose198
+.4byte sNatuPose199
+.4byte sNatuPose200
+.4byte sNatuPose201
+.4byte sNatuPose202
+sAxPositionsNatu:
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte    1,    1, 	  -7,   -4, 	   5,   -6, 	  -1,   -4
+.2byte   -3,    1, 	  -7,   -6, 	   5,   -4, 	  -1,   -4
+.2byte    4,   -1, 	   2,   -8, 	  -7,   -4, 	  -1,   -5
+.2byte    3,    0, 	   1,   -8, 	  -7,   -4, 	   0,   -4
+.2byte    5,    0, 	   0,   -8, 	  -6,   -2, 	  -1,   -4
+.2byte    6,   -4, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    5,   -2, 	  -4,   -7, 	  -6,   -1, 	  -2,   -4
+.2byte    6,   -4, 	  -3,   -7, 	  -4,   -1, 	  -1,   -4
+.2byte    5,   -6, 	  -6,   -5, 	   1,   -2, 	  -1,   -5
+.2byte    5,   -4, 	  -5,   -6, 	   0,   -1, 	  -2,   -4
+.2byte    4,   -6, 	  -6,   -4, 	   3,   -1, 	  -1,   -4
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	   6,   -4, 	  -6,   -1, 	  -1,   -3
+.2byte    1,   -8, 	   4,   -1, 	  -8,   -4, 	  -1,   -3
+.2byte   -7,   -6, 	   4,   -5, 	  -3,   -2, 	  -1,   -5
+.2byte   -7,   -4, 	   3,   -6, 	  -2,   -1, 	   0,   -4
+.2byte   -6,   -6, 	   4,   -4, 	  -5,   -1, 	  -1,   -4
+.2byte   -8,   -4, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -7,   -2, 	   2,   -7, 	   4,   -1, 	   0,   -4
+.2byte   -8,   -4, 	   1,   -7, 	   2,   -1, 	  -1,   -4
+.2byte   -6,   -1, 	  -4,   -8, 	   5,   -4, 	  -1,   -5
+.2byte   -5,    0, 	  -3,   -8, 	   5,   -4, 	  -2,   -4
+.2byte   -7,    0, 	  -2,   -8, 	   4,   -2, 	  -1,   -4
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte    1,    1, 	  -7,   -4, 	   5,   -6, 	  -1,   -4
+.2byte   -3,    1, 	  -7,   -6, 	   5,   -4, 	  -1,   -4
+.2byte   -1,   -1, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte    4,   -1, 	   2,   -8, 	  -7,   -4, 	  -1,   -5
+.2byte    3,    0, 	   1,   -8, 	  -7,   -4, 	   0,   -4
+.2byte    5,    0, 	   0,   -8, 	  -6,   -2, 	  -1,   -4
+.2byte    4,   -2, 	   0,   -5, 	  -8,    1, 	  -1,   -5
+.2byte    6,   -4, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    5,   -2, 	  -4,   -7, 	  -6,   -1, 	  -2,   -4
+.2byte    6,   -4, 	  -3,   -7, 	  -4,   -1, 	  -1,   -4
+.2byte    7,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte    5,   -6, 	  -6,   -5, 	   1,   -2, 	  -1,   -5
+.2byte    5,   -4, 	  -5,   -6, 	   0,   -1, 	  -2,   -4
+.2byte    4,   -6, 	  -6,   -4, 	   3,   -1, 	  -1,   -4
+.2byte    5,   -7, 	  -6,   -9, 	   9,   -3, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	   6,   -4, 	  -6,   -1, 	  -1,   -3
+.2byte    1,   -8, 	   4,   -1, 	  -8,   -4, 	  -1,   -3
+.2byte   -1,   -9, 	  10,   -4, 	 -12,   -4, 	  -1,   -5
+.2byte   -7,   -6, 	   4,   -5, 	  -3,   -2, 	  -1,   -5
+.2byte   -7,   -4, 	   3,   -6, 	  -2,   -1, 	   0,   -4
+.2byte   -6,   -6, 	   4,   -4, 	  -5,   -1, 	  -1,   -4
+.2byte   -7,   -7, 	   4,   -9, 	 -11,   -3, 	  -1,   -5
+.2byte   -8,   -4, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -7,   -2, 	   2,   -7, 	   4,   -1, 	   0,   -4
+.2byte   -8,   -4, 	   1,   -7, 	   2,   -1, 	  -1,   -4
+.2byte   -9,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte   -6,   -1, 	  -4,   -8, 	   5,   -4, 	  -1,   -5
+.2byte   -5,    0, 	  -3,   -8, 	   5,   -4, 	  -2,   -4
+.2byte   -7,    0, 	  -2,   -8, 	   4,   -2, 	  -1,   -4
+.2byte   -6,   -2, 	  -2,   -5, 	   6,    1, 	  -1,   -5
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte    1,    1, 	  -7,   -4, 	   5,   -6, 	  -1,   -4
+.2byte   -3,    1, 	  -7,   -6, 	   5,   -4, 	  -1,   -4
+.2byte   -1,    1, 	  -8,   -5, 	   6,   -5, 	  -1,   -4
+.2byte   -1,   -2, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte    4,   -1, 	   2,   -8, 	  -7,   -4, 	  -1,   -5
+.2byte    3,    0, 	   1,   -8, 	  -7,   -4, 	   0,   -4
+.2byte    5,    0, 	   0,   -8, 	  -6,   -2, 	  -1,   -4
+.2byte    4,    0, 	   1,   -9, 	  -7,   -4, 	  -1,   -5
+.2byte    4,   -2, 	   1,   -8, 	  -8,   -6, 	  -1,   -5
+.2byte    6,   -4, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    5,   -2, 	  -4,   -7, 	  -6,   -1, 	  -2,   -4
+.2byte    6,   -4, 	  -3,   -7, 	  -4,   -1, 	  -1,   -4
+.2byte    6,   -3, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    6,   -5, 	  -4,   -9, 	  -4,   -1, 	  -2,   -5
+.2byte    5,   -6, 	  -6,   -5, 	   1,   -2, 	  -1,   -5
+.2byte    5,   -4, 	  -5,   -6, 	   0,   -1, 	  -2,   -4
+.2byte    4,   -6, 	  -6,   -4, 	   3,   -1, 	  -1,   -4
+.2byte    5,   -5, 	  -6,   -7, 	   2,    0, 	  -1,   -5
+.2byte    5,   -7, 	  -6,   -6, 	   1,    0, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	   6,   -4, 	  -6,   -1, 	  -1,   -3
+.2byte    1,   -8, 	   4,   -1, 	  -8,   -4, 	  -1,   -3
+.2byte   -1,  -10, 	   6,   -5, 	  -7,   -5, 	  -1,   -5
+.2byte   -1,   -9, 	   6,   -3, 	  -7,   -3, 	  -1,   -4
+.2byte   -7,   -6, 	   4,   -5, 	  -3,   -2, 	  -1,   -5
+.2byte   -7,   -4, 	   3,   -6, 	  -2,   -1, 	   0,   -4
+.2byte   -6,   -6, 	   4,   -4, 	  -5,   -1, 	  -1,   -4
+.2byte   -7,   -5, 	   4,   -7, 	  -4,    0, 	  -1,   -5
+.2byte   -7,   -7, 	   4,   -6, 	  -3,    0, 	  -1,   -5
+.2byte   -8,   -4, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -7,   -2, 	   2,   -7, 	   4,   -1, 	   0,   -4
+.2byte   -8,   -4, 	   1,   -7, 	   2,   -1, 	  -1,   -4
+.2byte   -8,   -3, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -8,   -5, 	   2,   -9, 	   2,   -1, 	   0,   -5
+.2byte   -6,   -1, 	  -4,   -8, 	   5,   -4, 	  -1,   -5
+.2byte   -5,    0, 	  -3,   -8, 	   5,   -4, 	  -2,   -4
+.2byte   -7,    0, 	  -2,   -8, 	   4,   -2, 	  -1,   -4
+.2byte   -6,    0, 	  -3,   -9, 	   5,   -4, 	  -1,   -5
+.2byte   -6,   -2, 	  -3,   -8, 	   6,   -6, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte   -6,   -2, 	  -2,   -5, 	   6,    1, 	  -1,   -5
+.2byte   -9,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -7, 	   4,   -9, 	 -11,   -3, 	  -1,   -5
+.2byte   -1,   -9, 	  10,   -4, 	 -12,   -4, 	  -1,   -5
+.2byte    5,   -7, 	  -6,   -9, 	   9,   -3, 	  -1,   -5
+.2byte    7,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte    4,   -2, 	   0,   -5, 	  -8,    1, 	  -1,   -5
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte   -1,   -1, 	 -10,   -5, 	   8,   -5, 	  -1,   -5
+.2byte   -1,    0, 	 -11,   -3, 	   9,   -3, 	  -1,   -5
+.2byte    4,   -1, 	   2,   -8, 	  -7,   -4, 	  -1,   -5
+.2byte    4,   -2, 	   6,  -10, 	  -8,   -5, 	   0,   -5
+.2byte    4,   -1, 	   7,   -2, 	  -8,    0, 	  -1,   -5
+.2byte    6,   -4, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    6,   -5, 	   0,  -12, 	  -1,   -3, 	  -1,   -5
+.2byte    6,   -4, 	  -1,   -8, 	  -1,    2, 	  -1,   -4
+.2byte    5,   -6, 	  -6,   -5, 	   1,   -2, 	  -1,   -5
+.2byte    5,   -7, 	  -8,   -7, 	   9,   -4, 	  -1,   -4
+.2byte    5,   -7, 	  -7,   -5, 	   7,    1, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,   -5
+.2byte   -1,  -10, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -7,   -6, 	   4,   -5, 	  -3,   -2, 	  -1,   -5
+.2byte   -7,   -7, 	   6,   -7, 	 -11,   -4, 	  -1,   -4
+.2byte   -7,   -7, 	   5,   -5, 	  -9,    1, 	  -1,   -5
+.2byte   -8,   -4, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -8,   -5, 	  -2,  -12, 	  -1,   -3, 	  -1,   -5
+.2byte   -8,   -4, 	  -1,   -8, 	  -1,    2, 	  -1,   -4
+.2byte   -6,   -1, 	  -4,   -8, 	   5,   -4, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,  -10, 	   6,   -5, 	  -2,   -5
+.2byte   -6,   -1, 	  -9,   -2, 	   6,    0, 	  -1,   -5
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte   -1,    1, 	  -8,   -5, 	   6,   -5, 	  -1,   -4
+.2byte    0,   -7, 	  -8,   -4, 	   8,   -4, 	   0,   -6
+.2byte    5,   -9, 	   0,   -8, 	  -6,   -2, 	   0,   -7
+.2byte    5,   -9, 	  -4,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte    4,  -11, 	  -6,   -6, 	   5,   -1, 	  -1,   -6
+.2byte    0,  -11, 	   8,   -4, 	  -8,   -4, 	   0,   -4
+.2byte   -5,  -11, 	   5,   -6, 	  -6,   -1, 	   0,   -6
+.2byte   -6,   -9, 	   3,   -3, 	   4,   -1, 	   0,   -6
+.2byte   -6,   -9, 	  -1,   -8, 	   5,   -2, 	  -1,   -7
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte   -6,   -1, 	  -4,   -8, 	   5,   -4, 	  -1,   -5
+.2byte   -8,   -4, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -7,   -6, 	   4,   -5, 	  -3,   -2, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    5,   -6, 	  -6,   -5, 	   1,   -2, 	  -1,   -5
+.2byte    6,   -4, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    4,   -1, 	   2,   -8, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte   -6,   -2, 	  -2,   -5, 	   6,    1, 	  -1,   -5
+.2byte   -9,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -7, 	   4,   -9, 	 -11,   -3, 	  -1,   -5
+.2byte   -1,   -9, 	  10,   -4, 	 -12,   -4, 	  -1,   -5
+.2byte    5,   -7, 	  -6,   -9, 	   9,   -3, 	  -1,   -5
+.2byte    7,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte    4,   -2, 	   0,   -5, 	  -8,    1, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte    4,   -2, 	   0,   -5, 	  -8,    1, 	  -1,   -5
+.2byte    7,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte    5,   -7, 	  -6,   -9, 	   9,   -3, 	  -1,   -5
+.2byte   -1,   -9, 	  10,   -4, 	 -12,   -4, 	  -1,   -5
+.2byte   -7,   -7, 	   4,   -9, 	 -11,   -3, 	  -1,   -5
+.2byte   -9,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte   -6,   -2, 	  -2,   -5, 	   6,    1, 	  -1,   -5
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte   -1,   -1, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte   -1,    0, 	 -11,   -3, 	   9,   -3, 	  -1,   -5
+.2byte    4,   -1, 	   2,   -8, 	  -7,   -4, 	  -1,   -5
+.2byte    4,   -2, 	   0,   -5, 	  -8,    1, 	  -1,   -5
+.2byte    4,   -1, 	   7,   -2, 	  -8,    0, 	  -1,   -5
+.2byte    6,   -4, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    7,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte    6,   -4, 	  -1,   -8, 	  -1,    2, 	  -1,   -4
+.2byte    5,   -6, 	  -6,   -5, 	   1,   -2, 	  -1,   -5
+.2byte    5,   -7, 	  -6,   -9, 	   9,   -3, 	  -1,   -5
+.2byte    5,   -7, 	  -7,   -5, 	   7,    1, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	  10,   -4, 	 -12,   -4, 	  -1,   -5
+.2byte   -1,  -10, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -7,   -6, 	   4,   -5, 	  -3,   -2, 	  -1,   -5
+.2byte   -7,   -7, 	   4,   -9, 	 -11,   -3, 	  -1,   -5
+.2byte   -7,   -7, 	   5,   -5, 	  -9,    1, 	  -1,   -5
+.2byte   -8,   -4, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -9,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte   -8,   -4, 	  -1,   -8, 	  -1,    2, 	  -1,   -4
+.2byte   -6,   -1, 	  -4,   -8, 	   5,   -4, 	  -1,   -5
+.2byte   -6,   -2, 	  -2,   -5, 	   6,    1, 	  -1,   -5
+.2byte   -6,   -1, 	  -9,   -2, 	   6,    0, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,   -5, 	   9,   -5, 	  -1,   -5
+.2byte   -6,   -2, 	  -2,   -5, 	   6,    1, 	  -1,   -5
+.2byte   -9,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -7, 	   4,   -9, 	 -11,   -3, 	  -1,   -5
+.2byte   -1,   -9, 	  10,   -4, 	 -12,   -4, 	  -1,   -5
+.2byte    5,   -7, 	  -6,   -9, 	   9,   -3, 	  -1,   -5
+.2byte    7,   -4, 	  -1,   -8, 	  -1,    0, 	  -1,   -5
+.2byte    4,   -2, 	   0,   -5, 	  -8,    1, 	  -1,   -5
+.2byte   -1,    0, 	  -8,   -6, 	   6,   -6, 	  -1,   -4
+.2byte   -6,   -1, 	  -4,   -8, 	   5,   -4, 	  -1,   -5
+.2byte   -8,   -4, 	   2,   -8, 	   3,   -2, 	  -1,   -5
+.2byte   -7,   -6, 	   4,   -5, 	  -3,   -2, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    5,   -6, 	  -6,   -5, 	   1,   -2, 	  -1,   -5
+.2byte    6,   -4, 	  -4,   -8, 	  -5,   -2, 	  -1,   -5
+.2byte    4,   -1, 	   2,   -8, 	  -7,   -4, 	  -1,   -5
+sNatuAnimTable1:
+.4byte sNatuAnims_1_1
+.4byte sNatuAnims_1_2
+.4byte sNatuAnims_1_3
+.4byte sNatuAnims_1_4
+.4byte sNatuAnims_1_5
+.4byte sNatuAnims_1_6
+.4byte sNatuAnims_1_7
+.4byte sNatuAnims_1_8
+sNatuAnimTable2:
+.4byte sNatuAnims_2_1
+.4byte sNatuAnims_2_2
+.4byte sNatuAnims_2_3
+.4byte sNatuAnims_2_4
+.4byte sNatuAnims_2_5
+.4byte sNatuAnims_2_6
+.4byte sNatuAnims_2_7
+.4byte sNatuAnims_2_8
+sNatuAnimTable3:
+.4byte sNatuAnims_3_1
+.4byte sNatuAnims_3_2
+.4byte sNatuAnims_3_3
+.4byte sNatuAnims_3_4
+.4byte sNatuAnims_3_5
+.4byte sNatuAnims_3_6
+.4byte sNatuAnims_3_7
+.4byte sNatuAnims_3_8
+sNatuAnimTable4:
+.4byte sNatuAnims_4_1
+.4byte sNatuAnims_4_2
+.4byte sNatuAnims_4_3
+.4byte sNatuAnims_4_4
+.4byte sNatuAnims_4_5
+.4byte sNatuAnims_4_6
+.4byte sNatuAnims_4_7
+.4byte sNatuAnims_4_8
+sNatuAnimTable5:
+.4byte sNatuAnims_5_1
+.4byte sNatuAnims_5_2
+.4byte sNatuAnims_5_3
+.4byte sNatuAnims_5_4
+.4byte sNatuAnims_5_5
+.4byte sNatuAnims_5_6
+.4byte sNatuAnims_5_7
+.4byte sNatuAnims_5_8
+sNatuAnimTable6:
+.4byte sNatuAnims_6_1
+.4byte sNatuAnims_6_1
+.4byte sNatuAnims_6_1
+.4byte sNatuAnims_6_1
+.4byte sNatuAnims_6_1
+.4byte sNatuAnims_6_1
+.4byte sNatuAnims_6_1
+.4byte sNatuAnims_6_1
+sNatuAnimTable7:
+.4byte sNatuAnims_7_1
+.4byte sNatuAnims_7_2
+.4byte sNatuAnims_7_3
+.4byte sNatuAnims_7_4
+.4byte sNatuAnims_7_5
+.4byte sNatuAnims_7_6
+.4byte sNatuAnims_7_7
+.4byte sNatuAnims_7_8
+sNatuAnimTable8:
+.4byte sNatuAnims_8_1
+.4byte sNatuAnims_8_2
+.4byte sNatuAnims_8_3
+.4byte sNatuAnims_8_4
+.4byte sNatuAnims_8_5
+.4byte sNatuAnims_8_6
+.4byte sNatuAnims_8_7
+.4byte sNatuAnims_8_8
+sNatuAnimTable9:
+.4byte sNatuAnims_9_1
+.4byte sNatuAnims_9_2
+.4byte sNatuAnims_9_3
+.4byte sNatuAnims_9_4
+.4byte sNatuAnims_9_5
+.4byte sNatuAnims_9_6
+.4byte sNatuAnims_9_7
+.4byte sNatuAnims_9_8
+sNatuAnimTable10:
+.4byte sNatuAnims_10_1
+.4byte sNatuAnims_10_2
+.4byte sNatuAnims_10_3
+.4byte sNatuAnims_10_4
+.4byte sNatuAnims_10_5
+.4byte sNatuAnims_10_6
+.4byte sNatuAnims_10_7
+.4byte sNatuAnims_10_8
+sNatuAnimTable11:
+.4byte sNatuAnims_11_1
+.4byte sNatuAnims_11_2
+.4byte sNatuAnims_11_3
+.4byte sNatuAnims_11_4
+.4byte sNatuAnims_11_5
+.4byte sNatuAnims_11_6
+.4byte sNatuAnims_11_7
+.4byte sNatuAnims_11_8
+sNatuAnimTable12:
+.4byte sNatuAnims_12_1
+.4byte sNatuAnims_12_2
+.4byte sNatuAnims_12_3
+.4byte sNatuAnims_12_4
+.4byte sNatuAnims_12_5
+.4byte sNatuAnims_12_6
+.4byte sNatuAnims_12_7
+.4byte sNatuAnims_12_8
+sNatuAnimTable13:
+.4byte sNatuAnims_13_1
+.4byte sNatuAnims_13_2
+.4byte sNatuAnims_13_3
+.4byte sNatuAnims_13_4
+.4byte sNatuAnims_13_5
+.4byte sNatuAnims_13_6
+.4byte sNatuAnims_13_7
+.4byte sNatuAnims_13_8
+sAxAnimationsNatu:
+.4byte sNatuAnimTable1
+.4byte sNatuAnimTable2
+.4byte sNatuAnimTable3
+.4byte sNatuAnimTable4
+.4byte sNatuAnimTable5
+.4byte sNatuAnimTable6
+.4byte sNatuAnimTable7
+.4byte sNatuAnimTable8
+.4byte sNatuAnimTable9
+.4byte sNatuAnimTable10
+.4byte sNatuAnimTable11
+.4byte sNatuAnimTable12
+.4byte sNatuAnimTable13
+sAxSpritesNatu:
+.4byte sNatuSprites1
+.4byte sNatuSprites2
+.4byte sNatuSprites3
+.4byte sNatuSprites4
+.4byte sNatuSprites5
+.4byte sNatuSprites6
+.4byte sNatuSprites7
+.4byte sNatuSprites8
+.4byte sNatuSprites9
+.4byte sNatuSprites10
+.4byte sNatuSprites11
+.4byte sNatuSprites12
+.4byte sNatuSprites13
+.4byte sNatuSprites14
+.4byte sNatuSprites15
+.4byte sNatuSprites16
+.4byte sNatuSprites17
+.4byte sNatuSprites18
+.4byte sNatuSprites19
+.4byte sNatuSprites20
+.4byte sNatuSprites21
+.4byte sNatuSprites22
+.4byte sNatuSprites23
+.4byte sNatuSprites24
+.4byte sNatuSprites25
+.4byte sNatuSprites26
+.4byte sNatuSprites27
+.4byte sNatuSprites28
+.4byte sNatuSprites29
+.4byte sNatuSprites30
+.4byte sNatuSprites31
+.4byte sNatuSprites32
+.4byte sNatuSprites33
+.4byte sNatuSprites34
+.4byte sNatuSprites35
+.4byte sNatuSprites36
+.4byte sNatuSprites37
+.4byte sNatuSprites38
+.4byte sNatuSprites39
+.4byte sNatuSprites40
+.4byte sNatuSprites41
+.4byte sNatuSprites42
+.4byte sNatuSprites43
+.4byte sNatuSprites44
+.4byte sNatuSprites45
+.4byte sNatuSprites46
+.4byte sNatuSprites47
+sAxMainNatu:
+ax_main sAxPosesNatu, sAxAnimationsNatu, 13, sAxSpritesNatu, sAxPositionsNatu

--- a/data/ax/nidoking.inc
+++ b/data/ax/nidoking.inc
@@ -1,0 +1,2791 @@
+.global gAxNidoking
+gAxNidoking:
+ax_siro sAxMainNidoking
+sNidokingPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose5:
+ax_pose 4, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose8:
+ax_pose 7, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose10:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose11:
+ax_pose 10, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose12:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose16:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose17:
+ax_pose 10, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose18:
+ax_pose 11, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose20:
+ax_pose 7, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose28:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose29:
+ax_pose 4, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose30:
+ax_pose 5, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose31:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose32:
+ax_pose 7, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose33:
+ax_pose 8, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose34:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose35:
+ax_pose 10, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose36:
+ax_pose 11, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose37:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose38:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose39:
+ax_pose 14, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose40:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose41:
+ax_pose 10, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose42:
+ax_pose 11, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose43:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose44:
+ax_pose 7, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose45:
+ax_pose 8, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose46:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose47:
+ax_pose 4, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose48:
+ax_pose 5, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose50:
+ax_pose 1, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose51:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose52:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose53:
+ax_pose 4, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose54:
+ax_pose 5, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose55:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose56:
+ax_pose 7, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose57:
+ax_pose 8, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose58:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose59:
+ax_pose 10, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose60:
+ax_pose 11, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose61:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose62:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose63:
+ax_pose 14, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose64:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose65:
+ax_pose 10, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose66:
+ax_pose 11, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose67:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose68:
+ax_pose 7, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose69:
+ax_pose 8, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose70:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose71:
+ax_pose 4, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose72:
+ax_pose 5, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose73:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose74:
+ax_pose 1, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose75:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose76:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose77:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose78:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose79:
+ax_pose 4, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose80:
+ax_pose 5, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose81:
+ax_pose 17, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose82:
+ax_pose 18, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose83:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose84:
+ax_pose 7, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose85:
+ax_pose 8, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose86:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidokingPose87:
+ax_pose 20, 0x81e5, 0x90ff, 0x7c00
+ax_pose 21, 0x81e5, 0x50f7, 0x7c08
+ax_pose 22, 0x81f5, 0x10ef, 0x7c0c
+ax_pose 23, 0x01f5, 0x10e7, 0x7c0e
+ax_pose_terminator
+sNidokingPose88:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose89:
+ax_pose 10, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose90:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose91:
+ax_pose 24, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose92:
+ax_pose 25, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose93:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose94:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose95:
+ax_pose 14, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose96:
+ax_pose 26, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose97:
+ax_pose 27, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose98:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose99:
+ax_pose 10, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose100:
+ax_pose 11, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose101:
+ax_pose 24, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose102:
+ax_pose 25, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose103:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose104:
+ax_pose 7, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose105:
+ax_pose 8, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose106:
+ax_pose 19, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidokingPose107:
+ax_pose 20, 0x81e5, 0x80f1, 0x7c00
+ax_pose 21, 0x81e5, 0x4101, 0x7c08
+ax_pose 22, 0x81f5, 0x0109, 0x7c0c
+ax_pose 23, 0x01f5, 0x0111, 0x7c0e
+ax_pose_terminator
+sNidokingPose108:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose109:
+ax_pose 4, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose110:
+ax_pose 5, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose111:
+ax_pose 17, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose112:
+ax_pose 18, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose113:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose114:
+ax_pose 28, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose115:
+ax_pose 29, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose116:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose117:
+ax_pose 30, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose118:
+ax_pose 31, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose119:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose120:
+ax_pose 32, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidokingPose121:
+ax_pose 33, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose122:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose123:
+ax_pose 34, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose124:
+ax_pose 35, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose125:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose126:
+ax_pose 36, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose127:
+ax_pose 37, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose128:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose129:
+ax_pose 34, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose130:
+ax_pose 35, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose131:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose132:
+ax_pose 32, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidokingPose133:
+ax_pose 33, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose134:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose135:
+ax_pose 30, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose136:
+ax_pose 31, 0x01e4, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose137:
+ax_pose 38, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose138:
+ax_pose 39, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose139:
+ax_pose 40, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose140:
+ax_pose 41, 0x01e3, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidokingPose141:
+ax_pose 42, 0x01e3, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidokingPose142:
+ax_pose 43, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidokingPose143:
+ax_pose 44, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose144:
+ax_pose 43, 0x01e5, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidokingPose145:
+ax_pose 42, 0x01e3, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidokingPose146:
+ax_pose 41, 0x01e3, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidokingPose147:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose148:
+ax_pose 1, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose149:
+ax_pose 2, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose150:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose151:
+ax_pose 4, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose152:
+ax_pose 5, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose153:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose154:
+ax_pose 7, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose155:
+ax_pose 8, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose156:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose157:
+ax_pose 10, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose158:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose159:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose160:
+ax_pose 13, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose161:
+ax_pose 14, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose162:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose163:
+ax_pose 10, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose164:
+ax_pose 11, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose165:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose166:
+ax_pose 7, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose167:
+ax_pose 8, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose168:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose169:
+ax_pose 4, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose170:
+ax_pose 5, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose171:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose172:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose173:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose174:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose175:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose176:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose177:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose178:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose179:
+ax_pose 16, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose180:
+ax_pose 18, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose181:
+ax_pose 20, 0x81e5, 0x90ff, 0x7c00
+ax_pose 21, 0x81e5, 0x50f7, 0x7c08
+ax_pose 22, 0x81f5, 0x10ef, 0x7c0c
+ax_pose 23, 0x01f5, 0x10e7, 0x7c0e
+ax_pose_terminator
+sNidokingPose182:
+ax_pose 25, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidokingPose183:
+ax_pose 27, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose184:
+ax_pose 25, 0x01e5, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidokingPose185:
+ax_pose 20, 0x81e5, 0x80f1, 0x7c00
+ax_pose 21, 0x81e5, 0x4101, 0x7c08
+ax_pose 22, 0x81f5, 0x0109, 0x7c0c
+ax_pose 23, 0x01f5, 0x0111, 0x7c0e
+ax_pose_terminator
+sNidokingPose186:
+ax_pose 18, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose187:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose188:
+ax_pose 29, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose189:
+ax_pose 16, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose190:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose191:
+ax_pose 31, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose192:
+ax_pose 18, 0x01e4, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidokingPose193:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose194:
+ax_pose 33, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose195:
+ax_pose 20, 0x81e5, 0x90ff, 0x7c00
+ax_pose 21, 0x81e5, 0x50f7, 0x7c08
+ax_pose 22, 0x81f5, 0x10ef, 0x7c0c
+ax_pose 23, 0x01f5, 0x10e7, 0x7c0e
+ax_pose_terminator
+sNidokingPose196:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose197:
+ax_pose 35, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sNidokingPose198:
+ax_pose 25, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidokingPose199:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose200:
+ax_pose 37, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose201:
+ax_pose 27, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose202:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose203:
+ax_pose 35, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sNidokingPose204:
+ax_pose 25, 0x01e5, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidokingPose205:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose206:
+ax_pose 33, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose207:
+ax_pose 20, 0x81e5, 0x80f1, 0x7c00
+ax_pose 21, 0x81e5, 0x4101, 0x7c08
+ax_pose 22, 0x81f5, 0x0109, 0x7c0c
+ax_pose 23, 0x01f5, 0x0111, 0x7c0e
+ax_pose_terminator
+sNidokingPose208:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose209:
+ax_pose 31, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose210:
+ax_pose 18, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidokingPose211:
+ax_pose 29, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose212:
+ax_pose 31, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose213:
+ax_pose 33, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose214:
+ax_pose 35, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sNidokingPose215:
+ax_pose 37, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose216:
+ax_pose 35, 0x01e5, 0x90f2, 0x7c00
+ax_pose_terminator
+sNidokingPose217:
+ax_pose 33, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose218:
+ax_pose 31, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose219:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose220:
+ax_pose 3, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose221:
+ax_pose 6, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose222:
+ax_pose 9, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidokingPose223:
+ax_pose 12, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidokingPose224:
+ax_pose 9, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidokingPose225:
+ax_pose 6, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidokingPose226:
+ax_pose 3, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+.align 2
+sNidokingAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidokingAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 46, 0, -4, 0, -4,
+ax_anim 2, 0, 46, 0, -6, 0, -6,
+ax_anim 2, 0, 46, 1, -6, 1, -6,
+ax_anim 1, 2, 25, -1, -4, -1, -4,
+ax_anim 1, 0, 28, 0, 8, 0, 8,
+ax_anim 2, 0, 31, 0, 19, 0, 19,
+ax_anim 2, 1, 31, 1, 19, 1, 19,
+ax_anim 2, 0, 31, 0, 19, 0, 19,
+ax_anim 2, 0, 31, 1, 19, 1, 19,
+ax_anim 2, 0, 31, 0, 19, 0, 19,
+ax_anim 2, 0, 31, 1, 19, 1, 19,
+ax_anim 2, 0, 29, 1, 9, 1, 9,
+ax_anim_terminator
+sNidokingAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 25, -4, -4, -4, -4,
+ax_anim 2, 0, 25, -6, -6, -6, -6,
+ax_anim 2, 0, 25, -5, -7, -5, -7,
+ax_anim 1, 2, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 8, 10, 8, 10,
+ax_anim 2, 0, 34, 17, 19, 17, 19,
+ax_anim 2, 1, 34, 18, 18, 18, 18,
+ax_anim 2, 0, 34, 17, 19, 17, 19,
+ax_anim 2, 0, 34, 18, 18, 18, 18,
+ax_anim 2, 0, 34, 17, 19, 17, 19,
+ax_anim 2, 0, 34, 18, 18, 18, 18,
+ax_anim 2, 0, 32, 9, 9, 9, 9,
+ax_anim_terminator
+sNidokingAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 29, -4, 0, -4, 0,
+ax_anim 2, 0, 29, -6, 0, -6, 0,
+ax_anim 2, 0, 29, -6, -1, -6, -1,
+ax_anim 1, 2, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 7, 0, 7, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 9, 0, 9, 0,
+ax_anim_terminator
+sNidokingAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 32, -4, 4, -4, 4,
+ax_anim 2, 0, 32, -6, 6, -6, 6,
+ax_anim 2, 0, 32, -5, 7, -5, 7,
+ax_anim 1, 2, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 12, -8, 12, -8,
+ax_anim 2, 0, 41, 19, -17, 19, -17,
+ax_anim 2, 1, 41, 20, -16, 20, -16,
+ax_anim 2, 0, 41, 19, -17, 19, -17,
+ax_anim 2, 0, 41, 20, -16, 20, -16,
+ax_anim 2, 0, 41, 19, -17, 19, -17,
+ax_anim 2, 0, 41, 20, -16, 20, -16,
+ax_anim 2, 0, 38, 9, -9, 9, -9,
+ax_anim_terminator
+sNidokingAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 35, -1, 4, -1, 4,
+ax_anim 2, 0, 35, -1, 6, -1, 6,
+ax_anim 2, 0, 35, -2, 6, -2, 6,
+ax_anim 1, 2, 38, -1, 2, -1, 2,
+ax_anim 1, 0, 41, 3, -10, 3, -10,
+ax_anim 2, 0, 44, 0, -19, 0, -19,
+ax_anim 2, 1, 44, 1, -19, 1, -19,
+ax_anim 2, 0, 44, 0, -19, 0, -19,
+ax_anim 2, 0, 44, 1, -19, 1, -19,
+ax_anim 2, 0, 44, 0, -19, 0, -19,
+ax_anim 2, 0, 44, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 1, -9, 1, -9,
+ax_anim_terminator
+sNidokingAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 37, 4, 4, 4, 4,
+ax_anim 2, 0, 37, 6, 6, 6, 6,
+ax_anim 2, 0, 37, 6, 7, 6, 7,
+ax_anim 1, 2, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 44, -8, -10, -8, -10,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 1, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 44, -9, -9, -9, -9,
+ax_anim_terminator
+sNidokingAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 40, 4, 0, 4, 0,
+ax_anim 2, 0, 40, 6, 0, 6, 0,
+ax_anim 2, 0, 40, 6, -1, 6, -1,
+ax_anim 1, 2, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 47, -6, 0, -6, 0,
+ax_anim 2, 0, 26, -17, 0, -17, 0,
+ax_anim 2, 1, 26, -17, 1, -17, 1,
+ax_anim 2, 0, 26, -17, 0, -17, 0,
+ax_anim 2, 0, 26, -17, 1, -17, 1,
+ax_anim 2, 0, 26, -17, 0, -17, 0,
+ax_anim 2, 0, 26, -17, 1, -17, 1,
+ax_anim 2, 0, 47, -9, 0, -9, 0,
+ax_anim_terminator
+sNidokingAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 43, 4, -4, 4, -4,
+ax_anim 2, 0, 43, 6, -6, 6, -6,
+ax_anim 2, 0, 43, 5, -7, 5, -7,
+ax_anim 1, 2, 47, 0, -2, 0, -2,
+ax_anim 1, 0, 26, -10, 8, -10, 8,
+ax_anim 2, 0, 28, -17, 19, -17, 19,
+ax_anim 2, 1, 28, -16, 20, -16, 20,
+ax_anim 2, 0, 28, -17, 19, -17, 19,
+ax_anim 2, 0, 28, -16, 20, -16, 20,
+ax_anim 2, 0, 28, -17, 19, -17, 19,
+ax_anim 2, 0, 28, -16, 20, -16, 20,
+ax_anim 2, 0, 26, -9, 9, -9, 9,
+ax_anim_terminator
+.align 2
+sNidokingAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 70, 0, -4, 0, -4,
+ax_anim 2, 0, 70, 0, -6, 0, -6,
+ax_anim 2, 0, 70, 1, -6, 1, -6,
+ax_anim 1, 2, 49, -1, -4, -1, -4,
+ax_anim 1, 0, 52, 0, 8, 0, 8,
+ax_anim 2, 0, 55, 0, 19, 0, 19,
+ax_anim 2, 1, 55, 1, 19, 1, 19,
+ax_anim 2, 0, 55, 0, 19, 0, 19,
+ax_anim 2, 0, 55, 1, 19, 1, 19,
+ax_anim 2, 0, 55, 0, 19, 0, 19,
+ax_anim 2, 0, 55, 1, 19, 1, 19,
+ax_anim 2, 0, 53, 1, 9, 1, 9,
+ax_anim_terminator
+sNidokingAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim 2, 0, 49, -5, -7, -5, -7,
+ax_anim 1, 2, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 55, 8, 10, 8, 10,
+ax_anim 2, 0, 58, 17, 19, 17, 19,
+ax_anim 2, 1, 58, 18, 18, 18, 18,
+ax_anim 2, 0, 58, 17, 19, 17, 19,
+ax_anim 2, 0, 58, 18, 18, 18, 18,
+ax_anim 2, 0, 58, 17, 19, 17, 19,
+ax_anim 2, 0, 58, 18, 18, 18, 18,
+ax_anim 2, 0, 56, 9, 9, 9, 9,
+ax_anim_terminator
+sNidokingAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 2, 0, 53, -4, 0, -4, 0,
+ax_anim 2, 0, 53, -6, 0, -6, 0,
+ax_anim 2, 0, 53, -6, -1, -6, -1,
+ax_anim 1, 2, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 58, 7, 0, 7, 0,
+ax_anim 2, 0, 62, 18, 0, 18, 0,
+ax_anim 2, 1, 62, 18, 1, 18, 1,
+ax_anim 2, 0, 62, 18, 0, 18, 0,
+ax_anim 2, 0, 62, 18, 1, 18, 1,
+ax_anim 2, 0, 62, 18, 0, 18, 0,
+ax_anim 2, 0, 62, 18, 1, 18, 1,
+ax_anim 2, 0, 59, 9, 0, 9, 0,
+ax_anim_terminator
+sNidokingAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 2, 0, 56, -4, 4, -4, 4,
+ax_anim 2, 0, 56, -6, 6, -6, 6,
+ax_anim 2, 0, 56, -5, 7, -5, 7,
+ax_anim 1, 2, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 62, 12, -8, 12, -8,
+ax_anim 2, 0, 65, 19, -17, 19, -17,
+ax_anim 2, 1, 65, 20, -16, 20, -16,
+ax_anim 2, 0, 65, 19, -17, 19, -17,
+ax_anim 2, 0, 65, 20, -16, 20, -16,
+ax_anim 2, 0, 65, 19, -17, 19, -17,
+ax_anim 2, 0, 65, 20, -16, 20, -16,
+ax_anim 2, 0, 62, 9, -9, 9, -9,
+ax_anim_terminator
+sNidokingAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 59, -1, 4, -1, 4,
+ax_anim 2, 0, 59, -1, 6, -1, 6,
+ax_anim 2, 0, 59, -2, 6, -2, 6,
+ax_anim 1, 2, 62, -1, 2, -1, 2,
+ax_anim 1, 0, 65, 3, -10, 3, -10,
+ax_anim 2, 0, 68, 0, -19, 0, -19,
+ax_anim 2, 1, 68, 1, -19, 1, -19,
+ax_anim 2, 0, 68, 0, -19, 0, -19,
+ax_anim 2, 0, 68, 1, -19, 1, -19,
+ax_anim 2, 0, 68, 0, -19, 0, -19,
+ax_anim 2, 0, 68, 1, -19, 1, -19,
+ax_anim 2, 0, 65, 1, -9, 1, -9,
+ax_anim_terminator
+sNidokingAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 2, 0, 61, 4, 4, 4, 4,
+ax_anim 2, 0, 61, 6, 6, 6, 6,
+ax_anim 2, 0, 61, 6, 7, 6, 7,
+ax_anim 1, 2, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 68, -8, -10, -8, -10,
+ax_anim 2, 0, 71, -18, -17, -18, -17,
+ax_anim 2, 1, 71, -19, -16, -19, -16,
+ax_anim 2, 0, 71, -18, -17, -18, -17,
+ax_anim 2, 0, 71, -19, -16, -19, -16,
+ax_anim 2, 0, 71, -18, -17, -18, -17,
+ax_anim 2, 0, 71, -19, -16, -19, -16,
+ax_anim 2, 0, 68, -9, -9, -9, -9,
+ax_anim_terminator
+sNidokingAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim 2, 0, 64, 6, -1, 6, -1,
+ax_anim 1, 2, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 71, -6, 0, -6, 0,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 1, 50, -17, 1, -17, 1,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 0, 50, -17, 1, -17, 1,
+ax_anim 2, 0, 50, -17, 0, -17, 0,
+ax_anim 2, 0, 50, -17, 1, -17, 1,
+ax_anim 2, 0, 71, -9, 0, -9, 0,
+ax_anim_terminator
+sNidokingAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 4, -4, 4, -4,
+ax_anim 2, 0, 67, 6, -6, 6, -6,
+ax_anim 2, 0, 67, 5, -7, 5, -7,
+ax_anim 1, 2, 71, 0, -2, 0, -2,
+ax_anim 1, 0, 50, -10, 8, -10, 8,
+ax_anim 2, 0, 52, -17, 19, -17, 19,
+ax_anim 2, 1, 52, -16, 20, -16, 20,
+ax_anim 2, 0, 52, -17, 19, -17, 19,
+ax_anim 2, 0, 52, -16, 20, -16, 20,
+ax_anim 2, 0, 52, -17, 19, -17, 19,
+ax_anim 2, 0, 52, -16, 20, -16, 20,
+ax_anim 2, 0, 50, -9, 9, -9, 9,
+ax_anim_terminator
+.align 2
+sNidokingAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, -4, 0, -4,
+ax_anim 2, 0, 75, 0, -4, 0, -4,
+ax_anim 2, 0, 75, 1, -4, 1, -4,
+ax_anim 2, 0, 75, 0, -4, 0, -4,
+ax_anim 2, 0, 75, 1, -4, 1, -4,
+ax_anim 2, 2, 75, 0, -4, 0, -4,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 4, 0, 4,
+ax_anim 2, 0, 76, 1, 4, 1, 4,
+ax_anim 2, 1, 76, 0, 4, 0, 4,
+ax_anim 2, 0, 76, 1, 4, 1, 4,
+ax_anim 2, 0, 76, 0, 4, 0, 4,
+ax_anim 2, 0, 76, 1, 4, 1, 4,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sNidokingAnims_4_2:
+ax_anim 2, 0, 78, -2, -2, -2, -2,
+ax_anim 2, 0, 78, -4, -4, -4, -4,
+ax_anim 2, 0, 80, -4, -4, -4, -4,
+ax_anim 2, 0, 80, -3, -5, -3, -5,
+ax_anim 2, 0, 80, -4, -4, -4, -4,
+ax_anim 2, 0, 80, -3, -5, -3, -5,
+ax_anim 2, 2, 80, -4, -4, -4, -4,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 4, 4, 4, 4,
+ax_anim 2, 0, 81, 5, 3, 5, 3,
+ax_anim 2, 1, 81, 4, 4, 4, 4,
+ax_anim 2, 0, 81, 5, 3, 5, 3,
+ax_anim 2, 0, 81, 4, 4, 4, 4,
+ax_anim 2, 0, 81, 5, 3, 5, 3,
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim_terminator
+sNidokingAnims_4_3:
+ax_anim 2, 0, 83, -2, 0, -2, 0,
+ax_anim 2, 0, 83, -4, 0, -4, 0,
+ax_anim 2, 0, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 85, -4, 1, -4, 1,
+ax_anim 2, 0, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 85, -4, 1, -4, 1,
+ax_anim 2, 2, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 4, 0, 4, 0,
+ax_anim 2, 0, 86, 4, 1, 4, 1,
+ax_anim 2, 1, 86, 4, 0, 4, 0,
+ax_anim 2, 0, 86, 4, 1, 4, 1,
+ax_anim 2, 0, 86, 4, 0, 4, 0,
+ax_anim 2, 0, 86, 4, 1, 4, 1,
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim_terminator
+sNidokingAnims_4_4:
+ax_anim 2, 0, 88, -2, 2, -2, 2,
+ax_anim 2, 0, 88, -4, 4, -4, 4,
+ax_anim 2, 0, 90, -4, 4, -4, 4,
+ax_anim 2, 0, 90, -3, 5, -3, 5,
+ax_anim 2, 0, 90, -4, 4, -4, 4,
+ax_anim 2, 0, 90, -3, 5, -3, 5,
+ax_anim 2, 2, 90, -4, 4, -4, 4,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 4, -4, 4, -4,
+ax_anim 2, 0, 91, 5, -3, 5, -3,
+ax_anim 2, 1, 91, 4, -4, 4, -4,
+ax_anim 2, 0, 91, 5, -3, 5, -3,
+ax_anim 2, 0, 91, 4, -4, 4, -4,
+ax_anim 2, 0, 91, 5, -3, 5, -3,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim_terminator
+sNidokingAnims_4_5:
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 2, 0, 93, 0, 4, 0, 4,
+ax_anim 2, 0, 95, 0, 4, 0, 4,
+ax_anim 2, 0, 95, 1, 4, 1, 4,
+ax_anim 2, 0, 95, 0, 4, 0, 4,
+ax_anim 2, 0, 95, 1, 4, 1, 4,
+ax_anim 2, 2, 95, 0, 4, 0, 4,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, -4,
+ax_anim 2, 0, 96, -1, -4, -1, -4,
+ax_anim 2, 1, 96, 0, -4, 0, -4,
+ax_anim 2, 0, 96, -1, -4, -1, -4,
+ax_anim 2, 0, 96, 0, -4, 0, -4,
+ax_anim 2, 0, 96, -1, -4, -1, -4,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim_terminator
+sNidokingAnims_4_6:
+ax_anim 2, 0, 98, 2, 2, 2, 2,
+ax_anim 2, 0, 98, 4, 4, 4, 4,
+ax_anim 2, 0, 100, 4, 4, 4, 4,
+ax_anim 2, 0, 100, 3, 5, 3, 5,
+ax_anim 2, 0, 100, 4, 4, 4, 4,
+ax_anim 2, 0, 100, 3, 5, 3, 5,
+ax_anim 2, 2, 100, 4, 4, 4, 4,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -4, -4, -4, -4,
+ax_anim 2, 0, 101, -5, -3, -5, -3,
+ax_anim 2, 1, 101, -4, -4, -4, -4,
+ax_anim 2, 0, 101, -5, -3, -5, -3,
+ax_anim 2, 0, 101, -4, -4, -4, -4,
+ax_anim 2, 0, 101, -5, -3, -5, -3,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim_terminator
+sNidokingAnims_4_7:
+ax_anim 2, 0, 103, 2, 0, 2, 0,
+ax_anim 2, 0, 103, 4, 0, 4, 0,
+ax_anim 2, 0, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 105, 4, 1, 4, 1,
+ax_anim 2, 0, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 105, 4, 1, 4, 1,
+ax_anim 2, 2, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -4, 0, -4, 0,
+ax_anim 2, 0, 106, -4, 1, -4, 1,
+ax_anim 2, 1, 106, -4, 0, -4, 0,
+ax_anim 2, 0, 106, -4, 1, -4, 1,
+ax_anim 2, 0, 106, -4, 0, -4, 0,
+ax_anim 2, 0, 106, -4, 1, -4, 1,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim_terminator
+sNidokingAnims_4_8:
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim 2, 0, 108, 4, -4, 4, -4,
+ax_anim 2, 0, 110, 4, -4, 4, -4,
+ax_anim 2, 0, 110, 3, -5, 3, -5,
+ax_anim 2, 0, 110, 4, -4, 4, -4,
+ax_anim 2, 0, 110, 3, -5, 3, -5,
+ax_anim 2, 2, 110, 4, -4, 4, -4,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 1, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 107, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNidokingAnims_5_1:
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, -1, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_5_2:
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, -1, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_5_3:
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, -1, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_5_4:
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, -1, -1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_5_5:
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, 0, -1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_5_6:
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_5_7:
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, -1, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_5_8:
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, -1, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidokingAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidokingAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sNidokingAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sNidokingAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sNidokingAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sNidokingAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sNidokingAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sNidokingAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sNidokingAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNidokingAnims_8_1:
+ax_anim 35, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, -3, 0, -3,
+ax_anim_terminator
+sNidokingAnims_8_2:
+ax_anim 35, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, -2, -2, -2, -2,
+ax_anim_terminator
+sNidokingAnims_8_3:
+ax_anim 35, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, -2, 0, -2, 0,
+ax_anim_terminator
+sNidokingAnims_8_4:
+ax_anim 35, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, -1, 0, -1, 0,
+ax_anim_terminator
+sNidokingAnims_8_5:
+ax_anim 35, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 1, 0, 1,
+ax_anim_terminator
+sNidokingAnims_8_6:
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 1, 0, 1, 0,
+ax_anim_terminator
+sNidokingAnims_8_7:
+ax_anim 35, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 2, 0, 2, 0,
+ax_anim_terminator
+sNidokingAnims_8_8:
+ax_anim 35, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sNidokingAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 20, 10, 20, 10,
+ax_anim 3, 0, 173, 18, 20, 18, 20,
+ax_anim 2, 3, 174, 10, 19, 10, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 15, -5, 15, -5,
+ax_anim 3, 0, 172, 17, -2, 17, -2,
+ax_anim 2, 3, 173, 15, 4, 15, 4,
+ax_anim 2, 0, 174, 10, 5, 10, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 2, -14, 2, -14,
+ax_anim 2, 0, 170, 10, -20, 10, -20,
+ax_anim 3, 0, 171, 19, -17, 19, -17,
+ax_anim 2, 3, 172, 22, -11, 22, -11,
+ax_anim 2, 0, 173, 17, -3, 17, -3,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -16, -7, -16,
+ax_anim 3, 0, 170, 0, -17, 0, -17,
+ax_anim 2, 3, 171, 7, -16, 7, -16,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -2, -14, -2, -14,
+ax_anim 2, 0, 170, -10, -20, -10, -20,
+ax_anim 3, 0, 177, -19, -17, -19, -17,
+ax_anim 2, 3, 176, -22, -11, -22, -11,
+ax_anim 2, 0, 175, -17, -3, -17, -3,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -15, -5, -15, -5,
+ax_anim 3, 0, 176, -17, -2, -17, -2,
+ax_anim 2, 3, 175, -15, 4, -15, 4,
+ax_anim 2, 0, 174, -10, 5, -10, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -20, 10, -20, 10,
+ax_anim 3, 0, 175, -18, 20, -18, 20,
+ax_anim 2, 3, 174, -10, 19, -10, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidokingAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidokingAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -25, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -25, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -25, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -25, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -25, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidokingAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidokingAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sNidokingGfx1:
+.incbin "baserom.gba", 0x67D0B4, 0x200
+sNidokingSprites1:
+ax_sprite sNidokingGfx1, 0x200
+ax_sprite_terminator
+sNidokingGfx2:
+.incbin "baserom.gba", 0x67D2C4, 0x200
+sNidokingSprites2:
+ax_sprite sNidokingGfx2, 0x200
+ax_sprite_terminator
+sNidokingGfx3:
+.incbin "baserom.gba", 0x67D4D4, 0x200
+sNidokingSprites3:
+ax_sprite sNidokingGfx3, 0x200
+ax_sprite_terminator
+sNidokingGfx4:
+.incbin "baserom.gba", 0x67D6E4, 0x200
+sNidokingSprites4:
+ax_sprite sNidokingGfx4, 0x200
+ax_sprite_terminator
+sNidokingGfx5:
+.incbin "baserom.gba", 0x67D8F4, 0x200
+sNidokingSprites5:
+ax_sprite sNidokingGfx5, 0x200
+ax_sprite_terminator
+sNidokingGfx6:
+.incbin "baserom.gba", 0x67DB04, 0x200
+sNidokingSprites6:
+ax_sprite sNidokingGfx6, 0x200
+ax_sprite_terminator
+sNidokingGfx7:
+.incbin "baserom.gba", 0x67DD14, 0x200
+sNidokingSprites7:
+ax_sprite sNidokingGfx7, 0x200
+ax_sprite_terminator
+sNidokingGfx8:
+.incbin "baserom.gba", 0x67DF24, 0x200
+sNidokingSprites8:
+ax_sprite sNidokingGfx8, 0x200
+ax_sprite_terminator
+sNidokingGfx9:
+.incbin "baserom.gba", 0x67E134, 0x200
+sNidokingSprites9:
+ax_sprite sNidokingGfx9, 0x200
+ax_sprite_terminator
+sNidokingGfx10:
+.incbin "baserom.gba", 0x67E344, 0x200
+sNidokingSprites10:
+ax_sprite sNidokingGfx10, 0x200
+ax_sprite_terminator
+sNidokingGfx11:
+.incbin "baserom.gba", 0x67E554, 0x200
+sNidokingSprites11:
+ax_sprite sNidokingGfx11, 0x200
+ax_sprite_terminator
+sNidokingGfx12:
+.incbin "baserom.gba", 0x67E764, 0x200
+sNidokingSprites12:
+ax_sprite sNidokingGfx12, 0x200
+ax_sprite_terminator
+sNidokingGfx13:
+.incbin "baserom.gba", 0x67E974, 0x200
+sNidokingSprites13:
+ax_sprite sNidokingGfx13, 0x200
+ax_sprite_terminator
+sNidokingGfx14:
+.incbin "baserom.gba", 0x67EB84, 0x200
+sNidokingSprites14:
+ax_sprite sNidokingGfx14, 0x200
+ax_sprite_terminator
+sNidokingGfx15:
+.incbin "baserom.gba", 0x67ED94, 0x200
+sNidokingSprites15:
+ax_sprite sNidokingGfx15, 0x200
+ax_sprite_terminator
+sNidokingGfx16:
+.incbin "baserom.gba", 0x67EFA4, 0x40
+sNidokingGfx16_1:
+.incbin "baserom.gba", 0x67EFE4, 0x180
+sNidokingSprites16:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx16_1, 0x180
+ax_sprite_terminator
+sNidokingGfx17:
+.incbin "baserom.gba", 0x67F18C, 0x200
+sNidokingSprites17:
+ax_sprite sNidokingGfx17, 0x200
+ax_sprite_terminator
+sNidokingGfx18:
+.incbin "baserom.gba", 0x67F39C, 0x40
+sNidokingGfx18_1:
+.incbin "baserom.gba", 0x67F3DC, 0x180
+sNidokingSprites18:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx18_1, 0x180
+ax_sprite_terminator
+sNidokingGfx19:
+.incbin "baserom.gba", 0x67F584, 0x180
+sNidokingSprites19:
+ax_sprite 0, 0x80
+ax_sprite sNidokingGfx19, 0x180
+ax_sprite_terminator
+sNidokingGfx20:
+.incbin "baserom.gba", 0x67F71C, 0x40
+sNidokingGfx20_1:
+.incbin "baserom.gba", 0x67F75C, 0x60
+sNidokingGfx20_2:
+.incbin "baserom.gba", 0x67F7BC, 0xE0
+sNidokingSprites20:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx20_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidokingGfx21:
+.incbin "baserom.gba", 0x67F8DC, 0x100
+sNidokingSprites21:
+ax_sprite sNidokingGfx21, 0x100
+ax_sprite_terminator
+sNidokingGfx22:
+.incbin "baserom.gba", 0x67F9EC, 0x60
+sNidokingSprites22:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx22, 0x60
+ax_sprite_terminator
+sNidokingGfx23:
+.incbin "baserom.gba", 0x67FA64, 0x40
+sNidokingSprites23:
+ax_sprite sNidokingGfx23, 0x40
+ax_sprite_terminator
+sNidokingGfx24:
+.incbin "baserom.gba", 0x67FAB4, 0x20
+sNidokingSprites24:
+ax_sprite sNidokingGfx24, 0x20
+ax_sprite_terminator
+sNidokingGfx25:
+.incbin "baserom.gba", 0x67FAE4, 0x60
+sNidokingGfx25_1:
+.incbin "baserom.gba", 0x67FB44, 0x180
+sNidokingSprites25:
+ax_sprite sNidokingGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx25_1, 0x180
+ax_sprite_terminator
+sNidokingGfx26:
+.incbin "baserom.gba", 0x67FCE4, 0x60
+sNidokingGfx26_1:
+.incbin "baserom.gba", 0x67FD44, 0x60
+sNidokingGfx26_2:
+.incbin "baserom.gba", 0x67FDA4, 0x100
+sNidokingSprites26:
+ax_sprite sNidokingGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx26_2, 0x100
+ax_sprite_terminator
+sNidokingGfx27:
+.incbin "baserom.gba", 0x67FED4, 0x40
+sNidokingGfx27_1:
+.incbin "baserom.gba", 0x67FF14, 0x60
+sNidokingGfx27_2:
+.incbin "baserom.gba", 0x67FF74, 0x60
+sNidokingGfx27_3:
+.incbin "baserom.gba", 0x67FFD4, 0x80
+sNidokingSprites27:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx27_3, 0x80
+ax_sprite_terminator
+sNidokingGfx28:
+.incbin "baserom.gba", 0x68009C, 0x200
+sNidokingSprites28:
+ax_sprite sNidokingGfx28, 0x200
+ax_sprite_terminator
+sNidokingGfx29:
+.incbin "baserom.gba", 0x6802AC, 0x200
+sNidokingSprites29:
+ax_sprite sNidokingGfx29, 0x200
+ax_sprite_terminator
+sNidokingGfx30:
+.incbin "baserom.gba", 0x6804BC, 0x40
+sNidokingGfx30_1:
+.incbin "baserom.gba", 0x6804FC, 0x180
+sNidokingSprites30:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx30_1, 0x180
+ax_sprite_terminator
+sNidokingGfx31:
+.incbin "baserom.gba", 0x6806A4, 0x200
+sNidokingSprites31:
+ax_sprite sNidokingGfx31, 0x200
+ax_sprite_terminator
+sNidokingGfx32:
+.incbin "baserom.gba", 0x6808B4, 0x40
+sNidokingGfx32_1:
+.incbin "baserom.gba", 0x6808F4, 0x180
+sNidokingSprites32:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx32_1, 0x180
+ax_sprite_terminator
+sNidokingGfx33:
+.incbin "baserom.gba", 0x680A9C, 0x60
+sNidokingGfx33_1:
+.incbin "baserom.gba", 0x680AFC, 0x100
+sNidokingGfx33_2:
+.incbin "baserom.gba", 0x680BFC, 0x60
+sNidokingSprites33:
+ax_sprite sNidokingGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx33_2, 0x60
+ax_sprite_terminator
+sNidokingGfx34:
+.incbin "baserom.gba", 0x680C8C, 0x60
+sNidokingGfx34_1:
+.incbin "baserom.gba", 0x680CEC, 0x60
+sNidokingGfx34_2:
+.incbin "baserom.gba", 0x680D4C, 0x60
+sNidokingGfx34_3:
+.incbin "baserom.gba", 0x680DAC, 0x60
+sNidokingSprites34:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx34_3, 0x60
+ax_sprite_terminator
+sNidokingGfx35:
+.incbin "baserom.gba", 0x680E54, 0x1E0
+sNidokingSprites35:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx35, 0x1e0
+ax_sprite_terminator
+sNidokingGfx36:
+.incbin "baserom.gba", 0x68104C, 0x60
+sNidokingGfx36_1:
+.incbin "baserom.gba", 0x6810AC, 0x160
+sNidokingSprites36:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx36_1, 0x160
+ax_sprite_terminator
+sNidokingGfx37:
+.incbin "baserom.gba", 0x681234, 0x200
+sNidokingSprites37:
+ax_sprite sNidokingGfx37, 0x200
+ax_sprite_terminator
+sNidokingGfx38:
+.incbin "baserom.gba", 0x681444, 0x40
+sNidokingGfx38_1:
+.incbin "baserom.gba", 0x681484, 0x180
+sNidokingSprites38:
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidokingGfx38_1, 0x180
+ax_sprite_terminator
+sNidokingGfx39:
+.incbin "baserom.gba", 0x68162C, 0x200
+sNidokingSprites39:
+ax_sprite sNidokingGfx39, 0x200
+ax_sprite_terminator
+sNidokingGfx40:
+.incbin "baserom.gba", 0x68183C, 0x200
+sNidokingSprites40:
+ax_sprite sNidokingGfx40, 0x200
+ax_sprite_terminator
+sNidokingGfx41:
+.incbin "baserom.gba", 0x681A4C, 0x200
+sNidokingSprites41:
+ax_sprite sNidokingGfx41, 0x200
+ax_sprite_terminator
+sNidokingGfx42:
+.incbin "baserom.gba", 0x681C5C, 0x200
+sNidokingSprites42:
+ax_sprite sNidokingGfx42, 0x200
+ax_sprite_terminator
+sNidokingGfx43:
+.incbin "baserom.gba", 0x681E6C, 0x200
+sNidokingSprites43:
+ax_sprite sNidokingGfx43, 0x200
+ax_sprite_terminator
+sNidokingGfx44:
+.incbin "baserom.gba", 0x68207C, 0x200
+sNidokingSprites44:
+ax_sprite sNidokingGfx44, 0x200
+ax_sprite_terminator
+sNidokingGfx45:
+.incbin "baserom.gba", 0x68228C, 0x200
+sNidokingSprites45:
+ax_sprite sNidokingGfx45, 0x200
+ax_sprite_terminator
+sAxPosesNidoking:
+.4byte sNidokingPose1
+.4byte sNidokingPose2
+.4byte sNidokingPose3
+.4byte sNidokingPose4
+.4byte sNidokingPose5
+.4byte sNidokingPose6
+.4byte sNidokingPose7
+.4byte sNidokingPose8
+.4byte sNidokingPose9
+.4byte sNidokingPose10
+.4byte sNidokingPose11
+.4byte sNidokingPose12
+.4byte sNidokingPose13
+.4byte sNidokingPose14
+.4byte sNidokingPose15
+.4byte sNidokingPose16
+.4byte sNidokingPose17
+.4byte sNidokingPose18
+.4byte sNidokingPose19
+.4byte sNidokingPose20
+.4byte sNidokingPose21
+.4byte sNidokingPose22
+.4byte sNidokingPose23
+.4byte sNidokingPose24
+.4byte sNidokingPose25
+.4byte sNidokingPose26
+.4byte sNidokingPose27
+.4byte sNidokingPose28
+.4byte sNidokingPose29
+.4byte sNidokingPose30
+.4byte sNidokingPose31
+.4byte sNidokingPose32
+.4byte sNidokingPose33
+.4byte sNidokingPose34
+.4byte sNidokingPose35
+.4byte sNidokingPose36
+.4byte sNidokingPose37
+.4byte sNidokingPose38
+.4byte sNidokingPose39
+.4byte sNidokingPose40
+.4byte sNidokingPose41
+.4byte sNidokingPose42
+.4byte sNidokingPose43
+.4byte sNidokingPose44
+.4byte sNidokingPose45
+.4byte sNidokingPose46
+.4byte sNidokingPose47
+.4byte sNidokingPose48
+.4byte sNidokingPose49
+.4byte sNidokingPose50
+.4byte sNidokingPose51
+.4byte sNidokingPose52
+.4byte sNidokingPose53
+.4byte sNidokingPose54
+.4byte sNidokingPose55
+.4byte sNidokingPose56
+.4byte sNidokingPose57
+.4byte sNidokingPose58
+.4byte sNidokingPose59
+.4byte sNidokingPose60
+.4byte sNidokingPose61
+.4byte sNidokingPose62
+.4byte sNidokingPose63
+.4byte sNidokingPose64
+.4byte sNidokingPose65
+.4byte sNidokingPose66
+.4byte sNidokingPose67
+.4byte sNidokingPose68
+.4byte sNidokingPose69
+.4byte sNidokingPose70
+.4byte sNidokingPose71
+.4byte sNidokingPose72
+.4byte sNidokingPose73
+.4byte sNidokingPose74
+.4byte sNidokingPose75
+.4byte sNidokingPose76
+.4byte sNidokingPose77
+.4byte sNidokingPose78
+.4byte sNidokingPose79
+.4byte sNidokingPose80
+.4byte sNidokingPose81
+.4byte sNidokingPose82
+.4byte sNidokingPose83
+.4byte sNidokingPose84
+.4byte sNidokingPose85
+.4byte sNidokingPose86
+.4byte sNidokingPose87
+.4byte sNidokingPose88
+.4byte sNidokingPose89
+.4byte sNidokingPose90
+.4byte sNidokingPose91
+.4byte sNidokingPose92
+.4byte sNidokingPose93
+.4byte sNidokingPose94
+.4byte sNidokingPose95
+.4byte sNidokingPose96
+.4byte sNidokingPose97
+.4byte sNidokingPose98
+.4byte sNidokingPose99
+.4byte sNidokingPose100
+.4byte sNidokingPose101
+.4byte sNidokingPose102
+.4byte sNidokingPose103
+.4byte sNidokingPose104
+.4byte sNidokingPose105
+.4byte sNidokingPose106
+.4byte sNidokingPose107
+.4byte sNidokingPose108
+.4byte sNidokingPose109
+.4byte sNidokingPose110
+.4byte sNidokingPose111
+.4byte sNidokingPose112
+.4byte sNidokingPose113
+.4byte sNidokingPose114
+.4byte sNidokingPose115
+.4byte sNidokingPose116
+.4byte sNidokingPose117
+.4byte sNidokingPose118
+.4byte sNidokingPose119
+.4byte sNidokingPose120
+.4byte sNidokingPose121
+.4byte sNidokingPose122
+.4byte sNidokingPose123
+.4byte sNidokingPose124
+.4byte sNidokingPose125
+.4byte sNidokingPose126
+.4byte sNidokingPose127
+.4byte sNidokingPose128
+.4byte sNidokingPose129
+.4byte sNidokingPose130
+.4byte sNidokingPose131
+.4byte sNidokingPose132
+.4byte sNidokingPose133
+.4byte sNidokingPose134
+.4byte sNidokingPose135
+.4byte sNidokingPose136
+.4byte sNidokingPose137
+.4byte sNidokingPose138
+.4byte sNidokingPose139
+.4byte sNidokingPose140
+.4byte sNidokingPose141
+.4byte sNidokingPose142
+.4byte sNidokingPose143
+.4byte sNidokingPose144
+.4byte sNidokingPose145
+.4byte sNidokingPose146
+.4byte sNidokingPose147
+.4byte sNidokingPose148
+.4byte sNidokingPose149
+.4byte sNidokingPose150
+.4byte sNidokingPose151
+.4byte sNidokingPose152
+.4byte sNidokingPose153
+.4byte sNidokingPose154
+.4byte sNidokingPose155
+.4byte sNidokingPose156
+.4byte sNidokingPose157
+.4byte sNidokingPose158
+.4byte sNidokingPose159
+.4byte sNidokingPose160
+.4byte sNidokingPose161
+.4byte sNidokingPose162
+.4byte sNidokingPose163
+.4byte sNidokingPose164
+.4byte sNidokingPose165
+.4byte sNidokingPose166
+.4byte sNidokingPose167
+.4byte sNidokingPose168
+.4byte sNidokingPose169
+.4byte sNidokingPose170
+.4byte sNidokingPose171
+.4byte sNidokingPose172
+.4byte sNidokingPose173
+.4byte sNidokingPose174
+.4byte sNidokingPose175
+.4byte sNidokingPose176
+.4byte sNidokingPose177
+.4byte sNidokingPose178
+.4byte sNidokingPose179
+.4byte sNidokingPose180
+.4byte sNidokingPose181
+.4byte sNidokingPose182
+.4byte sNidokingPose183
+.4byte sNidokingPose184
+.4byte sNidokingPose185
+.4byte sNidokingPose186
+.4byte sNidokingPose187
+.4byte sNidokingPose188
+.4byte sNidokingPose189
+.4byte sNidokingPose190
+.4byte sNidokingPose191
+.4byte sNidokingPose192
+.4byte sNidokingPose193
+.4byte sNidokingPose194
+.4byte sNidokingPose195
+.4byte sNidokingPose196
+.4byte sNidokingPose197
+.4byte sNidokingPose198
+.4byte sNidokingPose199
+.4byte sNidokingPose200
+.4byte sNidokingPose201
+.4byte sNidokingPose202
+.4byte sNidokingPose203
+.4byte sNidokingPose204
+.4byte sNidokingPose205
+.4byte sNidokingPose206
+.4byte sNidokingPose207
+.4byte sNidokingPose208
+.4byte sNidokingPose209
+.4byte sNidokingPose210
+.4byte sNidokingPose211
+.4byte sNidokingPose212
+.4byte sNidokingPose213
+.4byte sNidokingPose214
+.4byte sNidokingPose215
+.4byte sNidokingPose216
+.4byte sNidokingPose217
+.4byte sNidokingPose218
+.4byte sNidokingPose219
+.4byte sNidokingPose220
+.4byte sNidokingPose221
+.4byte sNidokingPose222
+.4byte sNidokingPose223
+.4byte sNidokingPose224
+.4byte sNidokingPose225
+.4byte sNidokingPose226
+sAxPositionsNidoking:
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte    1,   -8, 	 -11,   -9, 	   8,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -8,   -6, 	  11,   -9, 	  -1,  -10
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    7,   -8, 	  10,   -8, 	  -1,   -2, 	   1,   -8
+.2byte    5,   -8, 	  12,   -6, 	  -6,   -4, 	  -1,   -8
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte   11,  -11, 	   5,  -12, 	   8,   -6, 	  -1,   -9
+.2byte   10,  -10, 	   9,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte    6,  -16, 	  -7,  -15, 	  13,  -13, 	  -1,  -13
+.2byte   10,  -15, 	  -2,  -17, 	  12,   -9, 	   0,  -12
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte   -1,  -16, 	  12,  -10, 	 -11,  -14, 	   0,  -13
+.2byte    1,  -16, 	  11,  -13, 	 -12,  -10, 	   0,  -13
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte   -7,  -16, 	   6,  -15, 	 -14,  -13, 	   0,  -13
+.2byte  -11,  -15, 	   1,  -17, 	 -13,   -9, 	  -1,  -12
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte  -12,  -11, 	  -6,  -12, 	  -9,   -6, 	   0,   -9
+.2byte  -11,  -10, 	 -10,  -10, 	  -5,   -6, 	   0,   -7
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte   -8,   -8, 	 -11,   -8, 	   0,   -2, 	  -2,   -8
+.2byte   -6,   -8, 	 -13,   -6, 	   5,   -4, 	   0,   -8
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte    1,   -8, 	 -11,   -9, 	   8,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -8,   -6, 	  11,   -9, 	  -1,  -10
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    7,   -8, 	  10,   -8, 	  -1,   -2, 	   1,   -8
+.2byte    5,   -8, 	  12,   -6, 	  -6,   -4, 	  -1,   -8
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte   11,  -11, 	   5,  -12, 	   8,   -6, 	  -1,   -9
+.2byte   10,  -10, 	   9,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte    6,  -16, 	  -7,  -15, 	  13,  -13, 	  -1,  -13
+.2byte    9,  -15, 	  -3,  -17, 	  11,   -9, 	  -1,  -12
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte   -1,  -16, 	  12,  -10, 	 -11,  -14, 	   0,  -13
+.2byte    1,  -16, 	  11,  -13, 	 -12,  -10, 	   0,  -13
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte   -7,  -16, 	   6,  -15, 	 -14,  -13, 	   0,  -13
+.2byte  -11,  -15, 	   1,  -17, 	 -13,   -9, 	  -1,  -12
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte  -12,  -11, 	  -6,  -12, 	  -9,   -6, 	   0,   -9
+.2byte  -11,  -10, 	 -10,  -10, 	  -5,   -6, 	   0,   -7
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte   -8,   -8, 	 -11,   -8, 	   0,   -2, 	  -2,   -8
+.2byte   -6,   -8, 	 -13,   -6, 	   5,   -4, 	   0,   -8
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte    1,   -8, 	 -11,   -9, 	   8,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -8,   -6, 	  11,   -9, 	  -1,  -10
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    7,   -8, 	  10,   -8, 	  -1,   -2, 	   1,   -8
+.2byte    5,   -8, 	  12,   -6, 	  -6,   -4, 	  -1,   -8
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte   11,  -11, 	   5,  -12, 	   8,   -6, 	  -1,   -9
+.2byte   10,  -10, 	   9,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte    6,  -16, 	  -7,  -15, 	  13,  -13, 	  -1,  -13
+.2byte    9,  -15, 	  -3,  -17, 	  11,   -9, 	  -1,  -12
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte   -1,  -16, 	  12,  -10, 	 -11,  -14, 	   0,  -13
+.2byte    1,  -16, 	  11,  -13, 	 -12,  -10, 	   0,  -13
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte   -7,  -16, 	   6,  -15, 	 -14,  -13, 	   0,  -13
+.2byte  -11,  -15, 	   1,  -17, 	 -13,   -9, 	  -1,  -12
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte  -12,  -11, 	  -6,  -12, 	  -9,   -6, 	   0,   -9
+.2byte  -11,  -10, 	 -10,  -10, 	  -5,   -6, 	   0,   -7
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte   -8,   -8, 	 -11,   -8, 	   0,   -2, 	  -2,   -8
+.2byte   -6,   -8, 	 -13,   -6, 	   5,   -4, 	   0,   -8
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte    1,   -8, 	 -11,   -9, 	   8,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -8,   -6, 	  11,   -9, 	  -1,  -10
+.2byte    2,  -23, 	  -5,  -12, 	  10,  -15, 	   0,  -12
+.2byte    0,   -8, 	  -9,   -6, 	  12,  -15, 	   0,  -11
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    7,   -8, 	  10,   -8, 	  -1,   -2, 	   1,   -8
+.2byte    5,   -8, 	  12,   -6, 	  -6,   -4, 	  -1,   -8
+.2byte   -2,  -24, 	   9,  -14, 	 -12,  -12, 	  -1,  -11
+.2byte    5,   -6, 	  13,   -6, 	 -12,  -10, 	   0,   -8
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte   11,  -11, 	   5,  -12, 	   8,   -6, 	  -1,   -9
+.2byte   10,  -10, 	   9,  -10, 	   4,   -6, 	  -1,   -7
+.2byte   -1,  -22, 	  12,  -16, 	  -5,   -7, 	   0,  -11
+.2byte    7,   -8, 	  11,   -9, 	  -6,   -3, 	  -3,  -10
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte    6,  -16, 	  -7,  -15, 	  13,  -13, 	  -1,  -13
+.2byte   10,  -15, 	  -2,  -17, 	  12,   -9, 	   0,  -12
+.2byte    4,  -21, 	  11,  -23, 	   7,   -6, 	   3,  -10
+.2byte   11,  -16, 	   9,  -18, 	   9,    0, 	   3,  -11
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte   -1,  -16, 	  12,  -10, 	 -11,  -14, 	   0,  -13
+.2byte    1,  -16, 	  11,  -13, 	 -12,  -10, 	   0,  -13
+.2byte   -6,  -23, 	   1,  -19, 	 -13,  -11, 	  -2,  -11
+.2byte    0,  -21, 	   8,  -17, 	 -11,   -8, 	   0,  -13
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte   -7,  -16, 	   6,  -15, 	 -14,  -13, 	   0,  -13
+.2byte  -11,  -15, 	   1,  -17, 	 -13,   -9, 	  -1,  -12
+.2byte   -5,  -21, 	 -12,  -23, 	  -8,   -6, 	  -4,  -10
+.2byte  -12,  -16, 	 -10,  -18, 	 -10,    0, 	  -4,  -11
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte  -12,  -11, 	  -6,  -12, 	  -9,   -6, 	   0,   -9
+.2byte  -11,  -10, 	 -10,  -10, 	  -5,   -6, 	   0,   -7
+.2byte    0,  -22, 	 -13,  -16, 	   4,   -7, 	  -1,  -11
+.2byte   -8,   -8, 	 -12,   -9, 	   5,   -3, 	   2,  -10
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte   -8,   -8, 	 -11,   -8, 	   0,   -2, 	  -2,   -8
+.2byte   -6,   -8, 	 -13,   -6, 	   5,   -4, 	   0,   -8
+.2byte    1,  -24, 	 -10,  -14, 	  11,  -12, 	   0,  -11
+.2byte   -6,   -6, 	 -14,   -6, 	  11,  -10, 	  -1,   -8
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte    0,  -12, 	 -13,  -17, 	  13,  -17, 	   0,  -11
+.2byte    0,  -19, 	 -12,  -10, 	  12,  -10, 	   0,  -12
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    3,  -13, 	  12,  -19, 	  -8,  -14, 	   0,  -10
+.2byte    2,  -19, 	  10,  -10, 	 -11,   -6, 	   0,  -11
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte    5,  -14, 	   8,  -21, 	   7,  -14, 	  -2,   -9
+.2byte    2,  -17, 	   2,   -7, 	  -1,   -3, 	  -2,   -8
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte    4,  -17, 	  -6,  -25, 	  11,  -17, 	  -2,  -12
+.2byte    2,  -15, 	  -8,  -10, 	   9,   -4, 	  -4,  -11
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    0,  -20, 	  13,  -21, 	 -13,  -21, 	   0,  -13
+.2byte    0,  -19, 	  12,  -13, 	 -12,  -13, 	   0,  -11
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte   -5,  -17, 	   5,  -25, 	 -12,  -17, 	   1,  -12
+.2byte   -3,  -15, 	   7,  -10, 	 -10,   -4, 	   3,  -11
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte   -6,  -14, 	  -9,  -21, 	  -8,  -14, 	   1,   -9
+.2byte   -3,  -17, 	  -3,   -7, 	   0,   -3, 	   1,   -8
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	 -13,  -19, 	   7,  -14, 	  -1,  -10
+.2byte   -3,  -19, 	 -11,  -10, 	  10,   -6, 	  -1,  -11
+.2byte   -6,   -7, 	 -11,   -4, 	   7,    0, 	   0,   -8
+.2byte   -6,   -6, 	 -11,   -3, 	   7,    0, 	   0,   -8
+.2byte    0,  -13, 	 -14,  -20, 	  12,  -22, 	   0,  -12
+.2byte    3,  -13, 	  11,  -21, 	 -12,  -20, 	  -2,  -11
+.2byte    3,  -14, 	   5,  -24, 	  -6,  -18, 	  -2,  -10
+.2byte    4,  -16, 	  -4,  -24, 	   7,  -20, 	  -3,  -12
+.2byte    0,  -18, 	  11,  -18, 	 -13,  -15, 	   0,  -12
+.2byte   -5,  -16, 	   3,  -24, 	  -8,  -20, 	   2,  -12
+.2byte   -4,  -14, 	  -6,  -24, 	   5,  -18, 	   1,  -10
+.2byte   -4,  -13, 	 -12,  -21, 	  11,  -20, 	   1,  -11
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte    1,   -8, 	 -11,   -9, 	   8,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -8,   -6, 	  11,   -9, 	  -1,  -10
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    7,   -8, 	  10,   -8, 	  -1,   -2, 	   1,   -8
+.2byte    5,   -8, 	  12,   -6, 	  -6,   -4, 	  -1,   -8
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte   11,  -11, 	   5,  -12, 	   8,   -6, 	  -1,   -9
+.2byte   10,  -10, 	   9,  -10, 	   4,   -6, 	  -1,   -7
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte    6,  -16, 	  -7,  -15, 	  13,  -13, 	  -1,  -13
+.2byte   10,  -15, 	  -2,  -17, 	  12,   -9, 	   0,  -12
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte   -1,  -16, 	  12,  -10, 	 -11,  -14, 	   0,  -13
+.2byte    1,  -16, 	  11,  -13, 	 -12,  -10, 	   0,  -13
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte   -7,  -16, 	   6,  -15, 	 -14,  -13, 	   0,  -13
+.2byte  -11,  -15, 	   1,  -17, 	 -13,   -9, 	  -1,  -12
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte  -12,  -11, 	  -6,  -12, 	  -9,   -6, 	   0,   -9
+.2byte  -11,  -10, 	 -10,  -10, 	  -5,   -6, 	   0,   -7
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte   -8,   -8, 	 -11,   -8, 	   0,   -2, 	  -2,   -8
+.2byte   -6,   -8, 	 -13,   -6, 	   5,   -4, 	   0,   -8
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    0,   -8, 	  -9,   -6, 	  12,  -15, 	   0,  -11
+.2byte    5,   -6, 	  13,   -6, 	 -12,  -10, 	   0,   -8
+.2byte    7,   -8, 	  11,   -9, 	  -6,   -3, 	  -3,  -10
+.2byte    8,  -16, 	   6,  -18, 	   6,    0, 	   0,  -11
+.2byte    0,  -21, 	   8,  -17, 	 -11,   -8, 	   0,  -13
+.2byte   -9,  -16, 	  -7,  -18, 	  -7,    0, 	  -1,  -11
+.2byte   -8,   -8, 	 -12,   -9, 	   5,   -3, 	   2,  -10
+.2byte   -6,   -6, 	 -14,   -6, 	  11,  -10, 	  -1,   -8
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte    0,  -19, 	 -12,  -10, 	  12,  -10, 	   0,  -12
+.2byte    0,   -7, 	  -9,   -5, 	  12,  -14, 	   0,  -10
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+.2byte    1,  -19, 	   9,  -10, 	 -12,   -6, 	  -1,  -11
+.2byte    4,   -6, 	  12,   -6, 	 -13,  -10, 	  -1,   -8
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte    2,  -17, 	   2,   -7, 	  -1,   -3, 	  -2,   -8
+.2byte    7,   -8, 	  11,   -9, 	  -6,   -3, 	  -3,  -10
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte    3,  -15, 	  -7,  -10, 	  10,   -4, 	  -3,  -11
+.2byte    8,  -16, 	   6,  -18, 	   6,    0, 	   0,  -11
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    0,  -19, 	  12,  -13, 	 -12,  -13, 	   0,  -11
+.2byte    0,  -21, 	   8,  -17, 	 -11,   -8, 	   0,  -13
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte   -4,  -15, 	   6,  -10, 	 -11,   -4, 	   2,  -11
+.2byte   -9,  -16, 	  -7,  -18, 	  -7,    0, 	  -1,  -11
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte   -3,  -17, 	  -3,   -7, 	   0,   -3, 	   1,   -8
+.2byte   -8,   -8, 	 -12,   -9, 	   5,   -3, 	   2,  -10
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte   -2,  -19, 	 -10,  -10, 	  11,   -6, 	   0,  -11
+.2byte   -5,   -6, 	 -13,   -6, 	  12,  -10, 	   0,   -8
+.2byte    0,  -19, 	 -12,  -10, 	  12,  -10, 	   0,  -12
+.2byte   -2,  -19, 	 -10,  -10, 	  11,   -6, 	   0,  -11
+.2byte   -3,  -17, 	  -3,   -7, 	   0,   -3, 	   1,   -8
+.2byte   -4,  -15, 	   6,  -10, 	 -11,   -4, 	   2,  -11
+.2byte    0,  -19, 	  12,  -13, 	 -12,  -13, 	   0,  -11
+.2byte    3,  -15, 	  -7,  -10, 	  10,   -4, 	  -3,  -11
+.2byte    2,  -17, 	   2,   -7, 	  -1,   -3, 	  -2,   -8
+.2byte    1,  -19, 	   9,  -10, 	 -12,   -6, 	  -1,  -11
+.2byte    0,  -10, 	 -10,   -9, 	  10,   -9, 	   0,  -11
+.2byte   -7,  -10, 	 -12,   -9, 	   4,   -4, 	  -1,  -10
+.2byte  -11,  -12, 	  -8,  -13, 	  -7,   -7, 	   0,   -9
+.2byte   -9,  -17, 	   4,  -17, 	 -14,  -11, 	  -1,  -14
+.2byte    0,  -18, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    8,  -17, 	  -5,  -17, 	  13,  -11, 	   0,  -14
+.2byte   10,  -12, 	   7,  -13, 	   6,   -7, 	  -1,   -9
+.2byte    6,  -10, 	  11,   -9, 	  -5,   -4, 	   0,  -10
+sNidokingAnimTable1:
+.4byte sNidokingAnims_1_1
+.4byte sNidokingAnims_1_2
+.4byte sNidokingAnims_1_3
+.4byte sNidokingAnims_1_4
+.4byte sNidokingAnims_1_5
+.4byte sNidokingAnims_1_6
+.4byte sNidokingAnims_1_7
+.4byte sNidokingAnims_1_8
+sNidokingAnimTable2:
+.4byte sNidokingAnims_2_1
+.4byte sNidokingAnims_2_2
+.4byte sNidokingAnims_2_3
+.4byte sNidokingAnims_2_4
+.4byte sNidokingAnims_2_5
+.4byte sNidokingAnims_2_6
+.4byte sNidokingAnims_2_7
+.4byte sNidokingAnims_2_8
+sNidokingAnimTable3:
+.4byte sNidokingAnims_3_1
+.4byte sNidokingAnims_3_2
+.4byte sNidokingAnims_3_3
+.4byte sNidokingAnims_3_4
+.4byte sNidokingAnims_3_5
+.4byte sNidokingAnims_3_6
+.4byte sNidokingAnims_3_7
+.4byte sNidokingAnims_3_8
+sNidokingAnimTable4:
+.4byte sNidokingAnims_4_1
+.4byte sNidokingAnims_4_2
+.4byte sNidokingAnims_4_3
+.4byte sNidokingAnims_4_4
+.4byte sNidokingAnims_4_5
+.4byte sNidokingAnims_4_6
+.4byte sNidokingAnims_4_7
+.4byte sNidokingAnims_4_8
+sNidokingAnimTable5:
+.4byte sNidokingAnims_5_1
+.4byte sNidokingAnims_5_2
+.4byte sNidokingAnims_5_3
+.4byte sNidokingAnims_5_4
+.4byte sNidokingAnims_5_5
+.4byte sNidokingAnims_5_6
+.4byte sNidokingAnims_5_7
+.4byte sNidokingAnims_5_8
+sNidokingAnimTable6:
+.4byte sNidokingAnims_6_1
+.4byte sNidokingAnims_6_1
+.4byte sNidokingAnims_6_1
+.4byte sNidokingAnims_6_1
+.4byte sNidokingAnims_6_1
+.4byte sNidokingAnims_6_1
+.4byte sNidokingAnims_6_1
+.4byte sNidokingAnims_6_1
+sNidokingAnimTable7:
+.4byte sNidokingAnims_7_1
+.4byte sNidokingAnims_7_2
+.4byte sNidokingAnims_7_3
+.4byte sNidokingAnims_7_4
+.4byte sNidokingAnims_7_5
+.4byte sNidokingAnims_7_6
+.4byte sNidokingAnims_7_7
+.4byte sNidokingAnims_7_8
+sNidokingAnimTable8:
+.4byte sNidokingAnims_8_1
+.4byte sNidokingAnims_8_2
+.4byte sNidokingAnims_8_3
+.4byte sNidokingAnims_8_4
+.4byte sNidokingAnims_8_5
+.4byte sNidokingAnims_8_6
+.4byte sNidokingAnims_8_7
+.4byte sNidokingAnims_8_8
+sNidokingAnimTable9:
+.4byte sNidokingAnims_9_1
+.4byte sNidokingAnims_9_2
+.4byte sNidokingAnims_9_3
+.4byte sNidokingAnims_9_4
+.4byte sNidokingAnims_9_5
+.4byte sNidokingAnims_9_6
+.4byte sNidokingAnims_9_7
+.4byte sNidokingAnims_9_8
+sNidokingAnimTable10:
+.4byte sNidokingAnims_10_1
+.4byte sNidokingAnims_10_2
+.4byte sNidokingAnims_10_3
+.4byte sNidokingAnims_10_4
+.4byte sNidokingAnims_10_5
+.4byte sNidokingAnims_10_6
+.4byte sNidokingAnims_10_7
+.4byte sNidokingAnims_10_8
+sNidokingAnimTable11:
+.4byte sNidokingAnims_11_1
+.4byte sNidokingAnims_11_2
+.4byte sNidokingAnims_11_3
+.4byte sNidokingAnims_11_4
+.4byte sNidokingAnims_11_5
+.4byte sNidokingAnims_11_6
+.4byte sNidokingAnims_11_7
+.4byte sNidokingAnims_11_8
+sNidokingAnimTable12:
+.4byte sNidokingAnims_12_1
+.4byte sNidokingAnims_12_2
+.4byte sNidokingAnims_12_3
+.4byte sNidokingAnims_12_4
+.4byte sNidokingAnims_12_5
+.4byte sNidokingAnims_12_6
+.4byte sNidokingAnims_12_7
+.4byte sNidokingAnims_12_8
+sNidokingAnimTable13:
+.4byte sNidokingAnims_13_1
+.4byte sNidokingAnims_13_2
+.4byte sNidokingAnims_13_3
+.4byte sNidokingAnims_13_4
+.4byte sNidokingAnims_13_5
+.4byte sNidokingAnims_13_6
+.4byte sNidokingAnims_13_7
+.4byte sNidokingAnims_13_8
+sAxAnimationsNidoking:
+.4byte sNidokingAnimTable1
+.4byte sNidokingAnimTable2
+.4byte sNidokingAnimTable3
+.4byte sNidokingAnimTable4
+.4byte sNidokingAnimTable5
+.4byte sNidokingAnimTable6
+.4byte sNidokingAnimTable7
+.4byte sNidokingAnimTable8
+.4byte sNidokingAnimTable9
+.4byte sNidokingAnimTable10
+.4byte sNidokingAnimTable11
+.4byte sNidokingAnimTable12
+.4byte sNidokingAnimTable13
+sAxSpritesNidoking:
+.4byte sNidokingSprites1
+.4byte sNidokingSprites2
+.4byte sNidokingSprites3
+.4byte sNidokingSprites4
+.4byte sNidokingSprites5
+.4byte sNidokingSprites6
+.4byte sNidokingSprites7
+.4byte sNidokingSprites8
+.4byte sNidokingSprites9
+.4byte sNidokingSprites10
+.4byte sNidokingSprites11
+.4byte sNidokingSprites12
+.4byte sNidokingSprites13
+.4byte sNidokingSprites14
+.4byte sNidokingSprites15
+.4byte sNidokingSprites16
+.4byte sNidokingSprites17
+.4byte sNidokingSprites18
+.4byte sNidokingSprites19
+.4byte sNidokingSprites20
+.4byte sNidokingSprites21
+.4byte sNidokingSprites22
+.4byte sNidokingSprites23
+.4byte sNidokingSprites24
+.4byte sNidokingSprites25
+.4byte sNidokingSprites26
+.4byte sNidokingSprites27
+.4byte sNidokingSprites28
+.4byte sNidokingSprites29
+.4byte sNidokingSprites30
+.4byte sNidokingSprites31
+.4byte sNidokingSprites32
+.4byte sNidokingSprites33
+.4byte sNidokingSprites34
+.4byte sNidokingSprites35
+.4byte sNidokingSprites36
+.4byte sNidokingSprites37
+.4byte sNidokingSprites38
+.4byte sNidokingSprites39
+.4byte sNidokingSprites40
+.4byte sNidokingSprites41
+.4byte sNidokingSprites42
+.4byte sNidokingSprites43
+.4byte sNidokingSprites44
+.4byte sNidokingSprites45
+sAxMainNidoking:
+ax_main sAxPosesNidoking, sAxAnimationsNidoking, 13, sAxSpritesNidoking, sAxPositionsNidoking

--- a/data/ax/nidoqueen.inc
+++ b/data/ax/nidoqueen.inc
@@ -1,0 +1,2919 @@
+.global gAxNidoqueen
+gAxNidoqueen:
+ax_siro sAxMainNidoqueen
+sNidoqueenPose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose4:
+ax_pose 3, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose5:
+ax_pose 4, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose6:
+ax_pose 5, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose7:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose8:
+ax_pose 7, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose9:
+ax_pose 8, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose10:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose11:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose12:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose22:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose23:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose24:
+ax_pose 5, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose25:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose28:
+ax_pose 16, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose29:
+ax_pose 4, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose30:
+ax_pose 5, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose31:
+ax_pose 17, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose32:
+ax_pose 7, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose33:
+ax_pose 8, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose34:
+ax_pose 18, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose35:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose36:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose37:
+ax_pose 19, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose38:
+ax_pose 13, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose39:
+ax_pose 14, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose40:
+ax_pose 18, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose41:
+ax_pose 10, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose42:
+ax_pose 11, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose43:
+ax_pose 17, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose44:
+ax_pose 7, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose45:
+ax_pose 8, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose46:
+ax_pose 16, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose47:
+ax_pose 4, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose48:
+ax_pose 5, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose49:
+ax_pose 0, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose52:
+ax_pose 20, 0x01eb, 0x80ee, 0x5c00
+ax_pose 21, 0x01eb, 0x80f0, 0x5c10
+ax_pose_terminator
+sNidoqueenPose53:
+ax_pose 21, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose54:
+ax_pose 22, 0x01eb, 0x80f1, 0x5c00
+ax_pose 23, 0x01eb, 0x80ef, 0x5c10
+ax_pose_terminator
+sNidoqueenPose55:
+ax_pose 23, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose56:
+ax_pose 3, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose57:
+ax_pose 4, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose58:
+ax_pose 5, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose59:
+ax_pose 24, 0x01e6, 0x90f4, 0x5c00
+ax_pose 25, 0x01e4, 0x90ef, 0x5c10
+ax_pose_terminator
+sNidoqueenPose60:
+ax_pose 25, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose61:
+ax_pose 26, 0x81e6, 0x9100, 0x5c00
+ax_pose 27, 0x01e4, 0x90ef, 0x5c08
+ax_pose_terminator
+sNidoqueenPose62:
+ax_pose 27, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose63:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose64:
+ax_pose 7, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose65:
+ax_pose 8, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose66:
+ax_pose 28, 0x01e4, 0x90f1, 0x5c00
+ax_pose 29, 0x01e4, 0x90ef, 0x5c10
+ax_pose_terminator
+sNidoqueenPose67:
+ax_pose 29, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose68:
+ax_pose 30, 0x01e4, 0x90f2, 0x5c00
+ax_pose 31, 0x01e4, 0x90ef, 0x5c10
+ax_pose_terminator
+sNidoqueenPose69:
+ax_pose 31, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose70:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose71:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose72:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose73:
+ax_pose 32, 0x81e3, 0x9104, 0x5c00
+ax_pose 33, 0x01e4, 0x90ef, 0x5c08
+ax_pose_terminator
+sNidoqueenPose74:
+ax_pose 33, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose75:
+ax_pose 34, 0x01e4, 0x90ef, 0x5c00
+ax_pose 35, 0x41e5, 0x90f1, 0x5c10
+ax_pose 36, 0x41f5, 0x1101, 0x5c18
+ax_pose_terminator
+sNidoqueenPose76:
+ax_pose 34, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose77:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose78:
+ax_pose 13, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose79:
+ax_pose 14, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose80:
+ax_pose 37, 0x01e4, 0x80f0, 0x5c00
+ax_pose 38, 0x01e4, 0x80f3, 0x5c10
+ax_pose_terminator
+sNidoqueenPose81:
+ax_pose 37, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose82:
+ax_pose 39, 0x01e4, 0x80f0, 0x5c00
+ax_pose 38, 0x01e4, 0x90ed, 0x5c10
+ax_pose_terminator
+sNidoqueenPose83:
+ax_pose 39, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose84:
+ax_pose 9, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose85:
+ax_pose 10, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose86:
+ax_pose 11, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose87:
+ax_pose 32, 0x81e3, 0x80ec, 0x5c00
+ax_pose 33, 0x01e4, 0x80f1, 0x5c08
+ax_pose_terminator
+sNidoqueenPose88:
+ax_pose 33, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose89:
+ax_pose 34, 0x01e4, 0x80f1, 0x5c00
+ax_pose 35, 0x41e5, 0x80ef, 0x5c10
+ax_pose 36, 0x41f5, 0x00ef, 0x5c18
+ax_pose_terminator
+sNidoqueenPose90:
+ax_pose 34, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose91:
+ax_pose 6, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose92:
+ax_pose 7, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose93:
+ax_pose 8, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose94:
+ax_pose 28, 0x01e4, 0x80ef, 0x5c00
+ax_pose 29, 0x01e4, 0x80f1, 0x5c10
+ax_pose_terminator
+sNidoqueenPose95:
+ax_pose 29, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose96:
+ax_pose 30, 0x01e4, 0x80ee, 0x5c00
+ax_pose 31, 0x01e4, 0x80f1, 0x5c10
+ax_pose_terminator
+sNidoqueenPose97:
+ax_pose 31, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose98:
+ax_pose 3, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose99:
+ax_pose 4, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose100:
+ax_pose 5, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose101:
+ax_pose 24, 0x01e6, 0x80ec, 0x5c00
+ax_pose 25, 0x01e4, 0x80f1, 0x5c10
+ax_pose_terminator
+sNidoqueenPose102:
+ax_pose 25, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose103:
+ax_pose 26, 0x81e6, 0x80f0, 0x5c00
+ax_pose 27, 0x01e4, 0x80f1, 0x5c08
+ax_pose_terminator
+sNidoqueenPose104:
+ax_pose 27, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose105:
+ax_pose 0, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose106:
+ax_pose 40, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose107:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose108:
+ax_pose 3, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose109:
+ax_pose 41, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose110:
+ax_pose 16, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose111:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose112:
+ax_pose 42, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose113:
+ax_pose 17, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose114:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose115:
+ax_pose 43, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose116:
+ax_pose 18, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose117:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose118:
+ax_pose 44, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose119:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose120:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose121:
+ax_pose 43, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose122:
+ax_pose 18, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose123:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose124:
+ax_pose 42, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose125:
+ax_pose 17, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose126:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose127:
+ax_pose 41, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose128:
+ax_pose 16, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose129:
+ax_pose 0, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose130:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose131:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose132:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose133:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose134:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose135:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose136:
+ax_pose 3, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose137:
+ax_pose 45, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sNidoqueenPose138:
+ax_pose 46, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sNidoqueenPose139:
+ax_pose 47, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose140:
+ax_pose 48, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sNidoqueenPose141:
+ax_pose 49, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sNidoqueenPose142:
+ax_pose 50, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose143:
+ax_pose 51, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose144:
+ax_pose 50, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose145:
+ax_pose 49, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sNidoqueenPose146:
+ax_pose 48, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sNidoqueenPose147:
+ax_pose 0, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose148:
+ax_pose 1, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose149:
+ax_pose 2, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose150:
+ax_pose 3, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose151:
+ax_pose 4, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose152:
+ax_pose 5, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose153:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose154:
+ax_pose 7, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose155:
+ax_pose 8, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose156:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose157:
+ax_pose 10, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose158:
+ax_pose 11, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose159:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose160:
+ax_pose 13, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose161:
+ax_pose 14, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose162:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose163:
+ax_pose 10, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose164:
+ax_pose 11, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose165:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose166:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose167:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose168:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose169:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose170:
+ax_pose 5, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose171:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose172:
+ax_pose 16, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose173:
+ax_pose 17, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose174:
+ax_pose 18, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose175:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose176:
+ax_pose 18, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose177:
+ax_pose 17, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose178:
+ax_pose 16, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose179:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose180:
+ax_pose 16, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose181:
+ax_pose 17, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sNidoqueenPose182:
+ax_pose 18, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose183:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose184:
+ax_pose 18, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose185:
+ax_pose 17, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sNidoqueenPose186:
+ax_pose 16, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose187:
+ax_pose 0, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose188:
+ax_pose 40, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose189:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose190:
+ax_pose 3, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose191:
+ax_pose 41, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose192:
+ax_pose 16, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sNidoqueenPose193:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose194:
+ax_pose 42, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose195:
+ax_pose 17, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sNidoqueenPose196:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose197:
+ax_pose 43, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose198:
+ax_pose 18, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sNidoqueenPose199:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose200:
+ax_pose 44, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose201:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose202:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose203:
+ax_pose 43, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose204:
+ax_pose 18, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sNidoqueenPose205:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose206:
+ax_pose 42, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose207:
+ax_pose 17, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sNidoqueenPose208:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose209:
+ax_pose 41, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose210:
+ax_pose 16, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sNidoqueenPose211:
+ax_pose 15, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose212:
+ax_pose 16, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose213:
+ax_pose 17, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sNidoqueenPose214:
+ax_pose 18, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose215:
+ax_pose 19, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose216:
+ax_pose 18, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose217:
+ax_pose 17, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sNidoqueenPose218:
+ax_pose 16, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose219:
+ax_pose 0, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose220:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose221:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose222:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose223:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sNidoqueenPose224:
+ax_pose 9, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose225:
+ax_pose 6, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sNidoqueenPose226:
+ax_pose 3, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+.align 2
+sNidoqueenAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sNidoqueenAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 10, 11, 10, 11,
+ax_anim 2, 0, 27, 18, 20, 18, 20,
+ax_anim 2, 1, 27, 19, 19, 19, 19,
+ax_anim 2, 0, 27, 18, 20, 18, 20,
+ax_anim 2, 0, 27, 19, 19, 19, 19,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sNidoqueenAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 6, 0, 6, 0,
+ax_anim_terminator
+sNidoqueenAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 2, 33, 4, -6, 4, -6,
+ax_anim 1, 0, 33, 11, -12, 11, -12,
+ax_anim 2, 0, 33, 19, -20, 19, -20,
+ax_anim 2, 1, 33, 20, -19, 20, -19,
+ax_anim 2, 0, 33, 19, -20, 19, -20,
+ax_anim 2, 0, 33, 20, -19, 20, -19,
+ax_anim 2, 0, 34, 6, -6, 6, -6,
+ax_anim_terminator
+sNidoqueenAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -20, 0, -20,
+ax_anim 2, 1, 36, 1, -20, 1, -20,
+ax_anim 2, 0, 36, 0, -20, 0, -20,
+ax_anim 2, 0, 36, 1, -20, 1, -20,
+ax_anim 2, 0, 37, 0, -6, 0, -6,
+ax_anim_terminator
+sNidoqueenAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 2, 39, -4, -6, -4, -6,
+ax_anim 1, 0, 39, -11, -12, -11, -12,
+ax_anim 2, 0, 39, -18, -20, -18, -20,
+ax_anim 2, 1, 39, -19, -19, -19, -19,
+ax_anim 2, 0, 39, -18, -20, -18, -20,
+ax_anim 2, 0, 39, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -6, -6, -6, -6,
+ax_anim_terminator
+sNidoqueenAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim_terminator
+sNidoqueenAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -10, 11, -10, 11,
+ax_anim 2, 0, 45, -18, 20, -18, 20,
+ax_anim 2, 1, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -18, 20, -18, 20,
+ax_anim 2, 0, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 46, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_3_1:
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 4, 0, 54, 0, -4, 0, -4,
+ax_anim 1, 0, 54, 0, -2, 0, -2,
+ax_anim 2, 2, 54, 0, 5, 0, 5,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 1, 52, -1, 18, -1, 18,
+ax_anim 2, 0, 53, 0, 17, 0, 17,
+ax_anim 2, 0, 54, 1, 18, 1, 18,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 52, -1, 18, -1, 18,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 1, 0, 50, 0, 4, 0, 4,
+ax_anim_terminator
+sNidoqueenAnims_3_2:
+ax_anim 2, 0, 57, -2, -2, -2, -2,
+ax_anim 4, 0, 61, -4, -4, -4, -4,
+ax_anim 1, 0, 61, -2, -2, -2, -2,
+ax_anim 2, 2, 61, 5, 5, 5, 5,
+ax_anim 2, 0, 58, 17, 17, 17, 17,
+ax_anim 2, 1, 59, 20, 17, 20, 17,
+ax_anim 2, 0, 60, 17, 17, 17, 17,
+ax_anim 2, 0, 61, 16, 18, 16, 18,
+ax_anim 2, 0, 58, 17, 17, 17, 17,
+ax_anim 2, 0, 59, 20, 17, 20, 17,
+ax_anim 1, 0, 56, 10, 10, 10, 10,
+ax_anim 1, 0, 57, 4, 4, 4, 4,
+ax_anim_terminator
+sNidoqueenAnims_3_3:
+ax_anim 2, 0, 64, -2, 0, -2, 0,
+ax_anim 4, 0, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -2, 0, -2, 0,
+ax_anim 2, 2, 68, 5, 0, 5, 0,
+ax_anim 2, 0, 65, 14, 0, 14, 0,
+ax_anim 2, 1, 66, 15, 0, 15, 0,
+ax_anim 2, 0, 67, 14, 0, 14, 0,
+ax_anim 2, 0, 68, 15, 1, 15, 1,
+ax_anim 2, 0, 65, 14, 0, 14, 0,
+ax_anim 2, 0, 66, 15, -1, 15, -1,
+ax_anim 1, 0, 63, 10, 0, 10, 0,
+ax_anim 1, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sNidoqueenAnims_3_4:
+ax_anim 2, 0, 71, -2, 2, -2, 2,
+ax_anim 4, 0, 75, -4, 4, -4, 4,
+ax_anim 1, 0, 75, -2, 2, -2, 2,
+ax_anim 2, 2, 75, 5, -5, 5, -5,
+ax_anim 2, 0, 72, 15, -17, 15, -17,
+ax_anim 2, 1, 73, 15, -19, 15, -19,
+ax_anim 2, 0, 74, 15, -17, 15, -17,
+ax_anim 2, 0, 75, 17, -17, 17, -17,
+ax_anim 2, 0, 72, 15, -17, 15, -17,
+ax_anim 2, 0, 73, 15, -19, 15, -19,
+ax_anim 1, 0, 70, 10, -10, 10, -10,
+ax_anim 1, 0, 71, 4, -4, 4, -4,
+ax_anim_terminator
+sNidoqueenAnims_3_5:
+ax_anim 2, 0, 78, 0, 2, 0, 2,
+ax_anim 4, 0, 82, 0, 4, 0, 4,
+ax_anim 1, 0, 82, 0, 2, 0, 2,
+ax_anim 2, 2, 82, 0, -5, 0, -5,
+ax_anim 2, 0, 79, 0, -13, 0, -13,
+ax_anim 2, 1, 80, 1, -14, 1, -14,
+ax_anim 2, 0, 81, 0, -13, 0, -13,
+ax_anim 2, 0, 82, -1, -14, -1, -14,
+ax_anim 2, 0, 79, 0, -13, 0, -13,
+ax_anim 2, 0, 80, 1, -14, 1, -14,
+ax_anim 1, 0, 77, 0, -10, 0, -10,
+ax_anim 1, 0, 78, 0, -4, 0, -4,
+ax_anim_terminator
+sNidoqueenAnims_3_6:
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 4, 0, 89, 4, 4, 4, 4,
+ax_anim 1, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 2, 89, -5, -5, -5, -5,
+ax_anim 2, 0, 86, -15, -17, -15, -17,
+ax_anim 2, 1, 87, -15, -19, -15, -19,
+ax_anim 2, 0, 88, -15, -17, -15, -17,
+ax_anim 2, 0, 89, -17, -17, -17, -17,
+ax_anim 2, 0, 86, -15, -17, -15, -17,
+ax_anim 2, 0, 87, -15, -19, -15, -19,
+ax_anim 1, 0, 84, -10, -10, -10, -10,
+ax_anim 1, 0, 85, -4, -4, -4, -4,
+ax_anim_terminator
+sNidoqueenAnims_3_7:
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 4, 0, 96, 4, 0, 4, 0,
+ax_anim 1, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 2, 96, -5, 0, -5, 0,
+ax_anim 2, 0, 93, -14, 0, -14, 0,
+ax_anim 2, 1, 94, -15, 0, -15, 0,
+ax_anim 2, 0, 95, -14, 0, -14, 0,
+ax_anim 2, 0, 96, -15, 1, -15, 1,
+ax_anim 2, 0, 93, -14, 0, -14, 0,
+ax_anim 2, 0, 94, -15, -1, -15, -1,
+ax_anim 1, 0, 91, -10, 0, -10, 0,
+ax_anim 1, 0, 92, -4, 0, -4, 0,
+ax_anim_terminator
+sNidoqueenAnims_3_8:
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 4, 0, 103, 4, -4, 4, -4,
+ax_anim 1, 0, 103, 2, -2, 2, -2,
+ax_anim 2, 2, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 100, -17, 17, -17, 17,
+ax_anim 2, 1, 101, -20, 17, -20, 17,
+ax_anim 2, 0, 102, -17, 17, -17, 17,
+ax_anim 2, 0, 103, -16, 18, -16, 18,
+ax_anim 2, 0, 100, -17, 17, -17, 17,
+ax_anim 2, 0, 101, -20, 17, -20, 17,
+ax_anim 1, 0, 98, -10, 10, -10, 10,
+ax_anim 1, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_4_1:
+ax_anim 2, 0, 105, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 4, 0, 105, 0, -4, 0, -4,
+ax_anim 1, 0, 105, 0, -3, 0, -3,
+ax_anim 1, 2, 106, 0, 2, 0, 2,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 1, 5, 1, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 1, 106, 1, 5, 1, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 1, 5, 1, 5,
+ax_anim 2, 0, 106, 0, 5, 0, 5,
+ax_anim 2, 0, 106, 1, 5, 1, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sNidoqueenAnims_4_2:
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 108, -3, -3, -3, -3,
+ax_anim 4, 0, 108, -4, -4, -4, -4,
+ax_anim 1, 0, 108, -3, -3, -3, -3,
+ax_anim 1, 2, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 1, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 109, 5, 5, 5, 5,
+ax_anim 2, 0, 109, 6, 4, 6, 4,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim_terminator
+sNidoqueenAnims_4_3:
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 4, 0, 111, -4, 0, -4, 0,
+ax_anim 1, 0, 111, -3, 0, -3, 0,
+ax_anim 1, 2, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 1, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 112, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 5, 1, 5, 1,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sNidoqueenAnims_4_4:
+ax_anim 2, 0, 114, -1, 1, -1, 1,
+ax_anim 2, 0, 114, -3, 3, -3, 3,
+ax_anim 4, 0, 114, -4, 4, -4, 4,
+ax_anim 1, 0, 114, -3, 3, -3, 3,
+ax_anim 1, 2, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 1, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 115, 5, -5, 5, -5,
+ax_anim 2, 0, 115, 6, -4, 6, -4,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim_terminator
+sNidoqueenAnims_4_5:
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 0, 117, 0, 3, 0, 3,
+ax_anim 4, 0, 117, 0, 4, 0, 4,
+ax_anim 1, 0, 117, 0, 3, 0, 3,
+ax_anim 1, 2, 118, 0, -2, 0, -2,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, 1, -5, 1, -5,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 1, 118, 1, -5, 1, -5,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, 1, -5, 1, -5,
+ax_anim 2, 0, 118, 0, -5, 0, -5,
+ax_anim 2, 0, 118, 1, -5, 1, -5,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sNidoqueenAnims_4_6:
+ax_anim 2, 0, 120, 1, 1, 1, 1,
+ax_anim 2, 0, 120, 3, 3, 3, 3,
+ax_anim 4, 0, 120, 4, 4, 4, 4,
+ax_anim 1, 0, 120, 3, 3, 3, 3,
+ax_anim 1, 2, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 1, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 121, -5, -5, -5, -5,
+ax_anim 2, 0, 121, -6, -4, -6, -4,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim_terminator
+sNidoqueenAnims_4_7:
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 123, 3, 0, 3, 0,
+ax_anim 4, 0, 123, 4, 0, 4, 0,
+ax_anim 1, 0, 123, 3, 0, 3, 0,
+ax_anim 1, 2, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 1, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 124, -5, 0, -5, 0,
+ax_anim 2, 0, 124, -5, 1, -5, 1,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sNidoqueenAnims_4_8:
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim 2, 0, 126, 3, -3, 3, -3,
+ax_anim 4, 0, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 126, 3, -3, 3, -3,
+ax_anim 1, 2, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 1, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -6, 4, -6, 4,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sNidoqueenAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sNidoqueenAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sNidoqueenAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sNidoqueenAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sNidoqueenAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sNidoqueenAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sNidoqueenAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_8_1:
+ax_anim 20, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, -1, 0, 0,
+ax_anim 6, 0, 147, 0, -2, 0, 0,
+ax_anim 6, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_8_2:
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, -1, 0, 0,
+ax_anim 6, 0, 151, 0, -2, 0, 0,
+ax_anim 6, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_8_3:
+ax_anim 20, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, -1, 0, 0,
+ax_anim 6, 0, 153, 0, -2, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_8_4:
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, -1, 0, 0,
+ax_anim 6, 0, 156, 0, -2, 0, 0,
+ax_anim 6, 0, 156, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_8_5:
+ax_anim 20, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, -1, 0, 0,
+ax_anim 6, 0, 160, 0, -2, 0, 0,
+ax_anim 6, 0, 160, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_8_6:
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 0, -1, 0, 0,
+ax_anim 6, 0, 162, 0, -2, 0, 0,
+ax_anim 6, 0, 162, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_8_7:
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, -1, 0, 0,
+ax_anim 6, 0, 165, 0, -2, 0, 0,
+ax_anim 6, 0, 165, 0, -1, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_8_8:
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 168, 0, -1, 0, 0,
+ax_anim 6, 0, 168, 0, -2, 0, 0,
+ax_anim 6, 0, 168, 0, -1, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 10, 11, 10, 11,
+ax_anim 2, 0, 173, 7, 19, 7, 19,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -7, 19, -7, 19,
+ax_anim 2, 0, 176, -10, 11, -10, 11,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 24, 9, 24, 9,
+ax_anim 3, 0, 173, 23, 21, 23, 21,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 0, 16, 0, 16,
+ax_anim 1, 0, 176, -2, 9, -2, 9,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 4, -6, 4, -6,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 19, -4, 19, -4,
+ax_anim 3, 0, 172, 23, 1, 23, 1,
+ax_anim 2, 3, 173, 19, 6, 19, 6,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 5, -18, 5, -18,
+ax_anim 2, 0, 170, 13, -20, 13, -20,
+ax_anim 3, 0, 171, 21, -22, 21, -22,
+ax_anim 2, 3, 172, 22, -11, 22, -11,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -7, -2, -7, -2,
+ax_anim 2, 0, 176, -11, -10, -11, -10,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -19, 0, -19,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 11, -10, 11, -10,
+ax_anim 1, 0, 173, 7, -2, 7, -2,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -5, -18, -5, -18,
+ax_anim 2, 0, 170, -13, -20, -13, -20,
+ax_anim 3, 0, 177, -21, -22, -21, -22,
+ax_anim 2, 3, 176, -22, -11, -22, -11,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -4, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -19, -4, -17, -4,
+ax_anim 3, 0, 176, -23, 1, -20, 1,
+ax_anim 2, 3, 175, -19, 5, -17, 5,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -24, 9, -24, 9,
+ax_anim 3, 0, 175, -23, 21, -23, 16,
+ax_anim 2, 3, 174, -11, 21, -11, 16,
+ax_anim 2, 0, 173, 0, 16, -4, 12,
+ax_anim 1, 0, 172, 2, 9, -3, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -27, 0, 0,
+ax_anim 3, 0, 188, 0, -25, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -25, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -25, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_12_2:
+ax_anim 2, 0, 211, 1, -1, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, 0,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_12_3:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_12_4:
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_12_6:
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_12_7:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_12_8:
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoqueenAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoqueenGfx1:
+.incbin "baserom.gba", 0x65E208, 0x200
+sNidoqueenSprites1:
+ax_sprite sNidoqueenGfx1, 0x200
+ax_sprite_terminator
+sNidoqueenGfx2:
+.incbin "baserom.gba", 0x65E418, 0x200
+sNidoqueenSprites2:
+ax_sprite sNidoqueenGfx2, 0x200
+ax_sprite_terminator
+sNidoqueenGfx3:
+.incbin "baserom.gba", 0x65E628, 0x200
+sNidoqueenSprites3:
+ax_sprite sNidoqueenGfx3, 0x200
+ax_sprite_terminator
+sNidoqueenGfx4:
+.incbin "baserom.gba", 0x65E838, 0x200
+sNidoqueenSprites4:
+ax_sprite sNidoqueenGfx4, 0x200
+ax_sprite_terminator
+sNidoqueenGfx5:
+.incbin "baserom.gba", 0x65EA48, 0x200
+sNidoqueenSprites5:
+ax_sprite sNidoqueenGfx5, 0x200
+ax_sprite_terminator
+sNidoqueenGfx6:
+.incbin "baserom.gba", 0x65EC58, 0x200
+sNidoqueenSprites6:
+ax_sprite sNidoqueenGfx6, 0x200
+ax_sprite_terminator
+sNidoqueenGfx7:
+.incbin "baserom.gba", 0x65EE68, 0x200
+sNidoqueenSprites7:
+ax_sprite sNidoqueenGfx7, 0x200
+ax_sprite_terminator
+sNidoqueenGfx8:
+.incbin "baserom.gba", 0x65F078, 0x200
+sNidoqueenSprites8:
+ax_sprite sNidoqueenGfx8, 0x200
+ax_sprite_terminator
+sNidoqueenGfx9:
+.incbin "baserom.gba", 0x65F288, 0x200
+sNidoqueenSprites9:
+ax_sprite sNidoqueenGfx9, 0x200
+ax_sprite_terminator
+sNidoqueenGfx10:
+.incbin "baserom.gba", 0x65F498, 0x200
+sNidoqueenSprites10:
+ax_sprite sNidoqueenGfx10, 0x200
+ax_sprite_terminator
+sNidoqueenGfx11:
+.incbin "baserom.gba", 0x65F6A8, 0x200
+sNidoqueenSprites11:
+ax_sprite sNidoqueenGfx11, 0x200
+ax_sprite_terminator
+sNidoqueenGfx12:
+.incbin "baserom.gba", 0x65F8B8, 0x200
+sNidoqueenSprites12:
+ax_sprite sNidoqueenGfx12, 0x200
+ax_sprite_terminator
+sNidoqueenGfx13:
+.incbin "baserom.gba", 0x65FAC8, 0x200
+sNidoqueenSprites13:
+ax_sprite sNidoqueenGfx13, 0x200
+ax_sprite_terminator
+sNidoqueenGfx14:
+.incbin "baserom.gba", 0x65FCD8, 0x200
+sNidoqueenSprites14:
+ax_sprite sNidoqueenGfx14, 0x200
+ax_sprite_terminator
+sNidoqueenGfx15:
+.incbin "baserom.gba", 0x65FEE8, 0x200
+sNidoqueenSprites15:
+ax_sprite sNidoqueenGfx15, 0x200
+ax_sprite_terminator
+sNidoqueenGfx16:
+.incbin "baserom.gba", 0x6600F8, 0x20
+sNidoqueenGfx16_1:
+.incbin "baserom.gba", 0x660118, 0x60
+sNidoqueenGfx16_2:
+.incbin "baserom.gba", 0x660178, 0x100
+sNidoqueenSprites16:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx16_2, 0x100
+ax_sprite_terminator
+sNidoqueenGfx17:
+.incbin "baserom.gba", 0x6602B0, 0x60
+sNidoqueenGfx17_1:
+.incbin "baserom.gba", 0x660310, 0x100
+sNidoqueenSprites17:
+ax_sprite 0, 0x80
+ax_sprite sNidoqueenGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx17_1, 0x100
+ax_sprite_terminator
+sNidoqueenGfx18:
+.incbin "baserom.gba", 0x660438, 0x20
+sNidoqueenGfx18_1:
+.incbin "baserom.gba", 0x660458, 0x60
+sNidoqueenGfx18_2:
+.incbin "baserom.gba", 0x6604B8, 0x80
+sNidoqueenGfx18_3:
+.incbin "baserom.gba", 0x660538, 0x40
+sNidoqueenSprites18:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx18_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoqueenGfx19:
+.incbin "baserom.gba", 0x6605C8, 0x40
+sNidoqueenGfx19_1:
+.incbin "baserom.gba", 0x660608, 0x60
+sNidoqueenGfx19_2:
+.incbin "baserom.gba", 0x660668, 0x100
+sNidoqueenSprites19:
+ax_sprite sNidoqueenGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx19_2, 0x100
+ax_sprite_terminator
+sNidoqueenGfx20:
+.incbin "baserom.gba", 0x660798, 0x200
+sNidoqueenSprites20:
+ax_sprite sNidoqueenGfx20, 0x200
+ax_sprite_terminator
+sNidoqueenGfx21:
+.incbin "baserom.gba", 0x6609A8, 0x20
+sNidoqueenGfx21_1:
+.incbin "baserom.gba", 0x6609C8, 0x20
+sNidoqueenGfx21_2:
+.incbin "baserom.gba", 0x6609E8, 0x60
+sNidoqueenGfx21_3:
+.incbin "baserom.gba", 0x660A48, 0x60
+sNidoqueenSprites21:
+ax_sprite 0, 0x60
+ax_sprite sNidoqueenGfx21, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidoqueenGfx21_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx21_3, 0x60
+ax_sprite_terminator
+sNidoqueenGfx22:
+.incbin "baserom.gba", 0x660AF0, 0x180
+sNidoqueenSprites22:
+ax_sprite sNidoqueenGfx22, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNidoqueenGfx23:
+.incbin "baserom.gba", 0x660C88, 0x40
+sNidoqueenGfx23_1:
+.incbin "baserom.gba", 0x660CC8, 0x40
+sNidoqueenGfx23_2:
+.incbin "baserom.gba", 0x660D08, 0x60
+sNidoqueenGfx23_3:
+.incbin "baserom.gba", 0x660D68, 0x60
+sNidoqueenSprites23:
+ax_sprite sNidoqueenGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoqueenGfx24:
+.incbin "baserom.gba", 0x660E10, 0x140
+sNidoqueenGfx24_1:
+.incbin "baserom.gba", 0x660F50, 0x20
+sNidoqueenSprites24:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx24, 0x140
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx24_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoqueenGfx25:
+.incbin "baserom.gba", 0x660FA0, 0x20
+sNidoqueenGfx25_1:
+.incbin "baserom.gba", 0x660FC0, 0x40
+sNidoqueenGfx25_2:
+.incbin "baserom.gba", 0x661000, 0x60
+sNidoqueenSprites25:
+ax_sprite 0, 0xe0
+ax_sprite sNidoqueenGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx25_2, 0x60
+ax_sprite_terminator
+sNidoqueenGfx26:
+.incbin "baserom.gba", 0x661098, 0x40
+sNidoqueenGfx26_1:
+.incbin "baserom.gba", 0x6610D8, 0x80
+sNidoqueenGfx26_2:
+.incbin "baserom.gba", 0x661158, 0x60
+sNidoqueenSprites26:
+ax_sprite 0, 0xa0
+ax_sprite sNidoqueenGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx26_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx26_2, 0x60
+ax_sprite_terminator
+sNidoqueenGfx27:
+.incbin "baserom.gba", 0x6611F0, 0x20
+sNidoqueenGfx27_1:
+.incbin "baserom.gba", 0x661210, 0x20
+sNidoqueenGfx27_2:
+.incbin "baserom.gba", 0x661230, 0x80
+sNidoqueenSprites27:
+ax_sprite sNidoqueenGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx27_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx27_2, 0x80
+ax_sprite_terminator
+sNidoqueenGfx28:
+.incbin "baserom.gba", 0x6612E0, 0x60
+sNidoqueenGfx28_1:
+.incbin "baserom.gba", 0x661340, 0xE0
+sNidoqueenSprites28:
+ax_sprite 0, 0x80
+ax_sprite sNidoqueenGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx28_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoqueenGfx29:
+.incbin "baserom.gba", 0x661450, 0x60
+sNidoqueenGfx29_1:
+.incbin "baserom.gba", 0x6614B0, 0x60
+sNidoqueenGfx29_2:
+.incbin "baserom.gba", 0x661510, 0x40
+sNidoqueenSprites29:
+ax_sprite 0, 0x80
+ax_sprite sNidoqueenGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoqueenGfx30:
+.incbin "baserom.gba", 0x661590, 0x60
+sNidoqueenGfx30_1:
+.incbin "baserom.gba", 0x6615F0, 0x80
+sNidoqueenGfx30_2:
+.incbin "baserom.gba", 0x661670, 0x60
+sNidoqueenSprites30:
+ax_sprite 0, 0x80
+ax_sprite sNidoqueenGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx30_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx30_2, 0x60
+ax_sprite_terminator
+sNidoqueenGfx31:
+.incbin "baserom.gba", 0x661708, 0x40
+sNidoqueenGfx31_1:
+.incbin "baserom.gba", 0x661748, 0x60
+sNidoqueenGfx31_2:
+.incbin "baserom.gba", 0x6617A8, 0x40
+sNidoqueenGfx31_3:
+.incbin "baserom.gba", 0x6617E8, 0x40
+sNidoqueenSprites31:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoqueenGfx32:
+.incbin "baserom.gba", 0x661878, 0x60
+sNidoqueenGfx32_1:
+.incbin "baserom.gba", 0x6618D8, 0x80
+sNidoqueenGfx32_2:
+.incbin "baserom.gba", 0x661958, 0x40
+sNidoqueenSprites32:
+ax_sprite 0, 0x80
+ax_sprite sNidoqueenGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx32_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoqueenGfx33:
+.incbin "baserom.gba", 0x6619D8, 0x20
+sNidoqueenGfx33_1:
+.incbin "baserom.gba", 0x6619F8, 0x80
+sNidoqueenSprites33:
+ax_sprite sNidoqueenGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx33_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoqueenGfx34:
+.incbin "baserom.gba", 0x661AA0, 0x60
+sNidoqueenGfx34_1:
+.incbin "baserom.gba", 0x661B00, 0x180
+sNidoqueenSprites34:
+ax_sprite sNidoqueenGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx34_1, 0x180
+ax_sprite_terminator
+sNidoqueenGfx35:
+.incbin "baserom.gba", 0x661CA0, 0x20
+sNidoqueenGfx35_1:
+.incbin "baserom.gba", 0x661CC0, 0x60
+sNidoqueenGfx35_2:
+.incbin "baserom.gba", 0x661D20, 0x80
+sNidoqueenGfx35_3:
+.incbin "baserom.gba", 0x661DA0, 0x60
+sNidoqueenSprites35:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx35, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx35_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx35_3, 0x60
+ax_sprite_terminator
+sNidoqueenGfx36:
+.incbin "baserom.gba", 0x661E48, 0x60
+sNidoqueenGfx36_1:
+.incbin "baserom.gba", 0x661EA8, 0x80
+sNidoqueenSprites36:
+ax_sprite sNidoqueenGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx36_1, 0x80
+ax_sprite_terminator
+sNidoqueenGfx37:
+.incbin "baserom.gba", 0x661F48, 0x40
+sNidoqueenSprites37:
+ax_sprite sNidoqueenGfx37, 0x40
+ax_sprite_terminator
+sNidoqueenGfx38:
+.incbin "baserom.gba", 0x661F98, 0x40
+sNidoqueenGfx38_1:
+.incbin "baserom.gba", 0x661FD8, 0x60
+sNidoqueenGfx38_2:
+.incbin "baserom.gba", 0x662038, 0xE0
+sNidoqueenSprites38:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx38_2, 0xe0
+ax_sprite_terminator
+sNidoqueenGfx39:
+.incbin "baserom.gba", 0x662150, 0x60
+sNidoqueenGfx39_1:
+.incbin "baserom.gba", 0x6621B0, 0x40
+sNidoqueenGfx39_2:
+.incbin "baserom.gba", 0x6621F0, 0x20
+sNidoqueenSprites39:
+ax_sprite sNidoqueenGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx39_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sNidoqueenGfx40:
+.incbin "baserom.gba", 0x662248, 0x40
+sNidoqueenGfx40_1:
+.incbin "baserom.gba", 0x662288, 0x60
+sNidoqueenGfx40_2:
+.incbin "baserom.gba", 0x6622E8, 0x60
+sNidoqueenGfx40_3:
+.incbin "baserom.gba", 0x662348, 0x80
+sNidoqueenSprites40:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx40_3, 0x80
+ax_sprite_terminator
+sNidoqueenGfx41:
+.incbin "baserom.gba", 0x662410, 0x40
+sNidoqueenGfx41_1:
+.incbin "baserom.gba", 0x662450, 0x180
+sNidoqueenSprites41:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx41_1, 0x180
+ax_sprite_terminator
+sNidoqueenGfx42:
+.incbin "baserom.gba", 0x6625F8, 0x40
+sNidoqueenGfx42_1:
+.incbin "baserom.gba", 0x662638, 0x160
+sNidoqueenSprites42:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx42_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoqueenGfx43:
+.incbin "baserom.gba", 0x6627C8, 0x40
+sNidoqueenGfx43_1:
+.incbin "baserom.gba", 0x662808, 0x60
+sNidoqueenGfx43_2:
+.incbin "baserom.gba", 0x662868, 0x60
+sNidoqueenGfx43_3:
+.incbin "baserom.gba", 0x6628C8, 0x60
+sNidoqueenSprites43:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoqueenGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx43_3, 0x60
+ax_sprite_terminator
+sNidoqueenGfx44:
+.incbin "baserom.gba", 0x662970, 0x40
+sNidoqueenGfx44_1:
+.incbin "baserom.gba", 0x6629B0, 0xE0
+sNidoqueenGfx44_2:
+.incbin "baserom.gba", 0x662A90, 0x80
+sNidoqueenSprites44:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx44_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx44_2, 0x80
+ax_sprite_terminator
+sNidoqueenGfx45:
+.incbin "baserom.gba", 0x662B48, 0x40
+sNidoqueenGfx45_1:
+.incbin "baserom.gba", 0x662B88, 0x180
+sNidoqueenSprites45:
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoqueenGfx45_1, 0x180
+ax_sprite_terminator
+sNidoqueenGfx46:
+.incbin "baserom.gba", 0x662D30, 0x200
+sNidoqueenSprites46:
+ax_sprite sNidoqueenGfx46, 0x200
+ax_sprite_terminator
+sNidoqueenGfx47:
+.incbin "baserom.gba", 0x662F40, 0x200
+sNidoqueenSprites47:
+ax_sprite sNidoqueenGfx47, 0x200
+ax_sprite_terminator
+sNidoqueenGfx48:
+.incbin "baserom.gba", 0x663150, 0x200
+sNidoqueenSprites48:
+ax_sprite sNidoqueenGfx48, 0x200
+ax_sprite_terminator
+sNidoqueenGfx49:
+.incbin "baserom.gba", 0x663360, 0x200
+sNidoqueenSprites49:
+ax_sprite sNidoqueenGfx49, 0x200
+ax_sprite_terminator
+sNidoqueenGfx50:
+.incbin "baserom.gba", 0x663570, 0x200
+sNidoqueenSprites50:
+ax_sprite sNidoqueenGfx50, 0x200
+ax_sprite_terminator
+sNidoqueenGfx51:
+.incbin "baserom.gba", 0x663780, 0x200
+sNidoqueenSprites51:
+ax_sprite sNidoqueenGfx51, 0x200
+ax_sprite_terminator
+sNidoqueenGfx52:
+.incbin "baserom.gba", 0x663990, 0x200
+sNidoqueenSprites52:
+ax_sprite sNidoqueenGfx52, 0x200
+ax_sprite_terminator
+sAxPosesNidoqueen:
+.4byte sNidoqueenPose1
+.4byte sNidoqueenPose2
+.4byte sNidoqueenPose3
+.4byte sNidoqueenPose4
+.4byte sNidoqueenPose5
+.4byte sNidoqueenPose6
+.4byte sNidoqueenPose7
+.4byte sNidoqueenPose8
+.4byte sNidoqueenPose9
+.4byte sNidoqueenPose10
+.4byte sNidoqueenPose11
+.4byte sNidoqueenPose12
+.4byte sNidoqueenPose13
+.4byte sNidoqueenPose14
+.4byte sNidoqueenPose15
+.4byte sNidoqueenPose16
+.4byte sNidoqueenPose17
+.4byte sNidoqueenPose18
+.4byte sNidoqueenPose19
+.4byte sNidoqueenPose20
+.4byte sNidoqueenPose21
+.4byte sNidoqueenPose22
+.4byte sNidoqueenPose23
+.4byte sNidoqueenPose24
+.4byte sNidoqueenPose25
+.4byte sNidoqueenPose26
+.4byte sNidoqueenPose27
+.4byte sNidoqueenPose28
+.4byte sNidoqueenPose29
+.4byte sNidoqueenPose30
+.4byte sNidoqueenPose31
+.4byte sNidoqueenPose32
+.4byte sNidoqueenPose33
+.4byte sNidoqueenPose34
+.4byte sNidoqueenPose35
+.4byte sNidoqueenPose36
+.4byte sNidoqueenPose37
+.4byte sNidoqueenPose38
+.4byte sNidoqueenPose39
+.4byte sNidoqueenPose40
+.4byte sNidoqueenPose41
+.4byte sNidoqueenPose42
+.4byte sNidoqueenPose43
+.4byte sNidoqueenPose44
+.4byte sNidoqueenPose45
+.4byte sNidoqueenPose46
+.4byte sNidoqueenPose47
+.4byte sNidoqueenPose48
+.4byte sNidoqueenPose49
+.4byte sNidoqueenPose50
+.4byte sNidoqueenPose51
+.4byte sNidoqueenPose52
+.4byte sNidoqueenPose53
+.4byte sNidoqueenPose54
+.4byte sNidoqueenPose55
+.4byte sNidoqueenPose56
+.4byte sNidoqueenPose57
+.4byte sNidoqueenPose58
+.4byte sNidoqueenPose59
+.4byte sNidoqueenPose60
+.4byte sNidoqueenPose61
+.4byte sNidoqueenPose62
+.4byte sNidoqueenPose63
+.4byte sNidoqueenPose64
+.4byte sNidoqueenPose65
+.4byte sNidoqueenPose66
+.4byte sNidoqueenPose67
+.4byte sNidoqueenPose68
+.4byte sNidoqueenPose69
+.4byte sNidoqueenPose70
+.4byte sNidoqueenPose71
+.4byte sNidoqueenPose72
+.4byte sNidoqueenPose73
+.4byte sNidoqueenPose74
+.4byte sNidoqueenPose75
+.4byte sNidoqueenPose76
+.4byte sNidoqueenPose77
+.4byte sNidoqueenPose78
+.4byte sNidoqueenPose79
+.4byte sNidoqueenPose80
+.4byte sNidoqueenPose81
+.4byte sNidoqueenPose82
+.4byte sNidoqueenPose83
+.4byte sNidoqueenPose84
+.4byte sNidoqueenPose85
+.4byte sNidoqueenPose86
+.4byte sNidoqueenPose87
+.4byte sNidoqueenPose88
+.4byte sNidoqueenPose89
+.4byte sNidoqueenPose90
+.4byte sNidoqueenPose91
+.4byte sNidoqueenPose92
+.4byte sNidoqueenPose93
+.4byte sNidoqueenPose94
+.4byte sNidoqueenPose95
+.4byte sNidoqueenPose96
+.4byte sNidoqueenPose97
+.4byte sNidoqueenPose98
+.4byte sNidoqueenPose99
+.4byte sNidoqueenPose100
+.4byte sNidoqueenPose101
+.4byte sNidoqueenPose102
+.4byte sNidoqueenPose103
+.4byte sNidoqueenPose104
+.4byte sNidoqueenPose105
+.4byte sNidoqueenPose106
+.4byte sNidoqueenPose107
+.4byte sNidoqueenPose108
+.4byte sNidoqueenPose109
+.4byte sNidoqueenPose110
+.4byte sNidoqueenPose111
+.4byte sNidoqueenPose112
+.4byte sNidoqueenPose113
+.4byte sNidoqueenPose114
+.4byte sNidoqueenPose115
+.4byte sNidoqueenPose116
+.4byte sNidoqueenPose117
+.4byte sNidoqueenPose118
+.4byte sNidoqueenPose119
+.4byte sNidoqueenPose120
+.4byte sNidoqueenPose121
+.4byte sNidoqueenPose122
+.4byte sNidoqueenPose123
+.4byte sNidoqueenPose124
+.4byte sNidoqueenPose125
+.4byte sNidoqueenPose126
+.4byte sNidoqueenPose127
+.4byte sNidoqueenPose128
+.4byte sNidoqueenPose129
+.4byte sNidoqueenPose130
+.4byte sNidoqueenPose131
+.4byte sNidoqueenPose132
+.4byte sNidoqueenPose133
+.4byte sNidoqueenPose134
+.4byte sNidoqueenPose135
+.4byte sNidoqueenPose136
+.4byte sNidoqueenPose137
+.4byte sNidoqueenPose138
+.4byte sNidoqueenPose139
+.4byte sNidoqueenPose140
+.4byte sNidoqueenPose141
+.4byte sNidoqueenPose142
+.4byte sNidoqueenPose143
+.4byte sNidoqueenPose144
+.4byte sNidoqueenPose145
+.4byte sNidoqueenPose146
+.4byte sNidoqueenPose147
+.4byte sNidoqueenPose148
+.4byte sNidoqueenPose149
+.4byte sNidoqueenPose150
+.4byte sNidoqueenPose151
+.4byte sNidoqueenPose152
+.4byte sNidoqueenPose153
+.4byte sNidoqueenPose154
+.4byte sNidoqueenPose155
+.4byte sNidoqueenPose156
+.4byte sNidoqueenPose157
+.4byte sNidoqueenPose158
+.4byte sNidoqueenPose159
+.4byte sNidoqueenPose160
+.4byte sNidoqueenPose161
+.4byte sNidoqueenPose162
+.4byte sNidoqueenPose163
+.4byte sNidoqueenPose164
+.4byte sNidoqueenPose165
+.4byte sNidoqueenPose166
+.4byte sNidoqueenPose167
+.4byte sNidoqueenPose168
+.4byte sNidoqueenPose169
+.4byte sNidoqueenPose170
+.4byte sNidoqueenPose171
+.4byte sNidoqueenPose172
+.4byte sNidoqueenPose173
+.4byte sNidoqueenPose174
+.4byte sNidoqueenPose175
+.4byte sNidoqueenPose176
+.4byte sNidoqueenPose177
+.4byte sNidoqueenPose178
+.4byte sNidoqueenPose179
+.4byte sNidoqueenPose180
+.4byte sNidoqueenPose181
+.4byte sNidoqueenPose182
+.4byte sNidoqueenPose183
+.4byte sNidoqueenPose184
+.4byte sNidoqueenPose185
+.4byte sNidoqueenPose186
+.4byte sNidoqueenPose187
+.4byte sNidoqueenPose188
+.4byte sNidoqueenPose189
+.4byte sNidoqueenPose190
+.4byte sNidoqueenPose191
+.4byte sNidoqueenPose192
+.4byte sNidoqueenPose193
+.4byte sNidoqueenPose194
+.4byte sNidoqueenPose195
+.4byte sNidoqueenPose196
+.4byte sNidoqueenPose197
+.4byte sNidoqueenPose198
+.4byte sNidoqueenPose199
+.4byte sNidoqueenPose200
+.4byte sNidoqueenPose201
+.4byte sNidoqueenPose202
+.4byte sNidoqueenPose203
+.4byte sNidoqueenPose204
+.4byte sNidoqueenPose205
+.4byte sNidoqueenPose206
+.4byte sNidoqueenPose207
+.4byte sNidoqueenPose208
+.4byte sNidoqueenPose209
+.4byte sNidoqueenPose210
+.4byte sNidoqueenPose211
+.4byte sNidoqueenPose212
+.4byte sNidoqueenPose213
+.4byte sNidoqueenPose214
+.4byte sNidoqueenPose215
+.4byte sNidoqueenPose216
+.4byte sNidoqueenPose217
+.4byte sNidoqueenPose218
+.4byte sNidoqueenPose219
+.4byte sNidoqueenPose220
+.4byte sNidoqueenPose221
+.4byte sNidoqueenPose222
+.4byte sNidoqueenPose223
+.4byte sNidoqueenPose224
+.4byte sNidoqueenPose225
+.4byte sNidoqueenPose226
+sAxPositionsNidoqueen:
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,  -10
+.2byte   -2,   -6, 	 -11,   -5, 	   8,   -4, 	  -1,   -8
+.2byte    0,   -6, 	 -10,   -4, 	   9,   -5, 	  -1,   -8
+.2byte    3,   -9, 	   9,   -9, 	  -5,   -4, 	  -1,   -9
+.2byte    2,   -7, 	   7,   -8, 	  -3,   -3, 	  -2,   -7
+.2byte    4,   -8, 	  10,   -6, 	  -6,   -4, 	   0,   -8
+.2byte    6,   -9, 	   5,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    6,   -7, 	   1,   -7, 	   6,   -5, 	  -2,   -8
+.2byte    7,   -8, 	   6,   -7, 	   2,   -5, 	  -1,   -8
+.2byte    3,  -15, 	  -4,  -14, 	   9,  -11, 	  -1,  -11
+.2byte    4,  -12, 	  -6,  -11, 	  10,  -10, 	  -1,  -10
+.2byte    2,  -14, 	  -1,  -13, 	   8,   -9, 	  -3,  -10
+.2byte   -1,  -16, 	   8,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -2,  -14, 	   8,  -11, 	  -9,  -13, 	  -2,  -10
+.2byte    0,  -14, 	   7,  -13, 	 -10,  -11, 	   0,  -10
+.2byte   -5,  -15, 	   2,  -14, 	 -11,  -11, 	  -1,  -11
+.2byte   -6,  -12, 	   4,  -11, 	 -12,  -10, 	  -1,  -10
+.2byte   -4,  -14, 	  -1,  -13, 	 -10,   -9, 	   1,  -10
+.2byte   -8,   -9, 	  -7,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -8,   -7, 	  -3,   -7, 	  -8,   -5, 	   0,   -8
+.2byte   -9,   -8, 	  -8,   -7, 	  -4,   -5, 	  -1,   -8
+.2byte   -5,   -9, 	 -11,   -9, 	   3,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -9,   -8, 	   1,   -3, 	   0,   -7
+.2byte   -6,   -8, 	 -12,   -6, 	   4,   -4, 	  -2,   -8
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte   -2,   -6, 	 -11,   -5, 	   8,   -4, 	  -1,   -8
+.2byte    0,   -6, 	 -10,   -4, 	   9,   -5, 	  -1,   -8
+.2byte    4,   -5, 	   2,   -9, 	 -10,   -5, 	  -1,   -8
+.2byte    2,   -7, 	   7,   -8, 	  -3,   -3, 	  -2,   -7
+.2byte    4,   -8, 	  10,   -6, 	  -6,   -4, 	   0,   -8
+.2byte    8,   -7, 	  -2,   -9, 	  -4,   -3, 	   2,   -8
+.2byte    6,   -7, 	   1,   -7, 	   6,   -5, 	  -2,   -8
+.2byte    7,   -8, 	   6,   -7, 	   2,   -5, 	  -1,   -8
+.2byte    6,  -13, 	  -7,   -8, 	   3,   -1, 	   1,  -10
+.2byte    4,  -12, 	  -6,  -11, 	  10,  -10, 	  -1,  -10
+.2byte    2,  -14, 	  -1,  -13, 	   8,   -9, 	  -3,  -10
+.2byte   -1,  -16, 	   9,   -6, 	 -11,   -6, 	  -1,  -11
+.2byte   -2,  -14, 	   8,  -11, 	  -9,  -13, 	  -2,  -10
+.2byte    0,  -14, 	   7,  -13, 	 -10,  -11, 	   0,  -10
+.2byte   -7,  -13, 	   6,   -8, 	  -4,   -1, 	  -2,  -10
+.2byte   -5,  -12, 	   5,  -11, 	 -11,  -10, 	   0,  -10
+.2byte   -3,  -14, 	   0,  -13, 	  -9,   -9, 	   2,  -10
+.2byte   -9,   -7, 	   1,   -9, 	   3,   -3, 	  -3,   -8
+.2byte   -7,   -7, 	  -2,   -7, 	  -7,   -5, 	   1,   -8
+.2byte   -8,   -8, 	  -7,   -7, 	  -3,   -5, 	   0,   -8
+.2byte   -5,   -5, 	  -3,   -9, 	   9,   -5, 	   0,   -8
+.2byte   -3,   -7, 	  -8,   -8, 	   2,   -3, 	   1,   -7
+.2byte   -5,   -8, 	 -11,   -6, 	   5,   -4, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,  -10
+.2byte   -2,   -6, 	 -11,   -5, 	   8,   -4, 	  -1,   -8
+.2byte    0,   -6, 	 -10,   -4, 	   9,   -5, 	  -1,   -8
+.2byte   -2,   -5, 	 -10,  -13, 	   0,    0, 	   0,   -8
+.2byte   -2,   -5, 	 -10,  -13, 	   0,    0, 	   0,   -8
+.2byte    1,   -5, 	   0,    0, 	   8,  -14, 	  -1,   -8
+.2byte    2,   -5, 	   1,    0, 	   9,  -14, 	   0,   -8
+.2byte    3,   -9, 	   9,   -9, 	  -5,   -4, 	  -1,   -9
+.2byte    2,   -7, 	   7,   -8, 	  -3,   -3, 	  -2,   -7
+.2byte    4,   -8, 	  10,   -6, 	  -6,   -4, 	   0,   -8
+.2byte    4,   -6, 	   3,  -13, 	   2,    0, 	  -2,   -7
+.2byte    4,   -6, 	   3,  -13, 	   2,    0, 	  -2,   -7
+.2byte    1,   -4, 	   1,    0, 	  -9,  -12, 	   1,   -7
+.2byte    1,   -4, 	   1,    0, 	  -9,  -12, 	   1,   -7
+.2byte    6,   -9, 	   5,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    6,   -7, 	   1,   -7, 	   6,   -5, 	  -2,   -8
+.2byte    7,   -8, 	   6,   -7, 	   2,   -5, 	  -1,   -8
+.2byte    6,   -9, 	  -6,  -17, 	   4,   -4, 	  -2,   -9
+.2byte    6,   -9, 	  -6,  -17, 	   4,   -4, 	  -2,   -9
+.2byte    6,   -9, 	   2,   -2, 	  -5,  -12, 	   0,   -8
+.2byte    6,   -9, 	   2,   -2, 	  -5,  -12, 	   0,   -8
+.2byte    3,  -15, 	  -4,  -14, 	   9,  -11, 	  -1,  -11
+.2byte    4,  -12, 	  -6,  -11, 	  10,  -10, 	  -1,  -10
+.2byte    2,  -14, 	  -1,  -13, 	   8,   -9, 	  -3,  -10
+.2byte    1,  -15, 	 -10,  -16, 	   5,  -10, 	  -1,  -12
+.2byte    1,  -15, 	 -10,  -16, 	   5,  -10, 	  -1,  -12
+.2byte    8,  -12, 	   9,   -8, 	   5,  -12, 	   0,  -11
+.2byte    8,  -12, 	   9,   -8, 	   5,  -12, 	   0,  -11
+.2byte   -1,  -16, 	   8,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -2,  -14, 	   8,  -11, 	  -9,  -13, 	  -2,  -10
+.2byte    0,  -14, 	   7,  -13, 	 -10,  -11, 	   0,  -10
+.2byte    5,  -14, 	  11,  -11, 	   4,  -10, 	   1,  -12
+.2byte    5,  -14, 	  11,  -11, 	   4,  -10, 	   1,  -12
+.2byte   -5,  -14, 	  -4,  -10, 	 -10,  -11, 	  -1,  -12
+.2byte   -5,  -14, 	  -4,  -10, 	 -10,  -11, 	  -1,  -12
+.2byte   -4,  -15, 	   3,  -14, 	 -10,  -11, 	   0,  -11
+.2byte   -5,  -12, 	   5,  -11, 	 -11,  -10, 	   0,  -10
+.2byte   -3,  -14, 	   0,  -13, 	  -9,   -9, 	   2,  -10
+.2byte   -2,  -15, 	   9,  -16, 	  -6,  -10, 	   0,  -12
+.2byte   -2,  -15, 	   9,  -16, 	  -6,  -10, 	   0,  -12
+.2byte   -9,  -12, 	 -10,   -8, 	  -6,  -12, 	  -1,  -11
+.2byte   -9,  -12, 	 -10,   -8, 	  -6,  -12, 	  -1,  -11
+.2byte   -7,   -9, 	  -6,   -8, 	  -6,   -6, 	   0,   -9
+.2byte   -7,   -7, 	  -2,   -7, 	  -7,   -5, 	   1,   -8
+.2byte   -8,   -8, 	  -7,   -7, 	  -3,   -5, 	   0,   -8
+.2byte   -7,   -9, 	   5,  -17, 	  -5,   -4, 	   1,   -9
+.2byte   -7,   -9, 	   5,  -17, 	  -5,   -4, 	   1,   -9
+.2byte   -7,   -9, 	  -3,   -2, 	   4,  -12, 	  -1,   -8
+.2byte   -7,   -9, 	  -3,   -2, 	   4,  -12, 	  -1,   -8
+.2byte   -4,   -9, 	 -10,   -9, 	   4,   -4, 	   0,   -9
+.2byte   -3,   -7, 	  -8,   -8, 	   2,   -3, 	   1,   -7
+.2byte   -5,   -8, 	 -11,   -6, 	   5,   -4, 	  -1,   -8
+.2byte   -5,   -6, 	  -4,  -13, 	  -3,    0, 	   1,   -7
+.2byte   -5,   -6, 	  -4,  -13, 	  -3,    0, 	   1,   -7
+.2byte   -2,   -4, 	  -2,    0, 	   8,  -12, 	  -2,   -7
+.2byte   -2,   -4, 	  -2,    0, 	   8,  -12, 	  -2,   -7
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,  -10
+.2byte   -1,  -19, 	  -7,  -12, 	   5,  -12, 	  -1,   -9
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    3,   -9, 	   9,   -9, 	  -5,   -4, 	  -1,   -9
+.2byte    0,  -18, 	   5,  -14, 	  -2,  -12, 	  -1,   -8
+.2byte    4,   -5, 	   2,   -9, 	 -10,   -5, 	  -1,   -8
+.2byte    6,   -9, 	   5,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    0,  -17, 	   4,  -16, 	   2,  -11, 	  -3,   -9
+.2byte    8,   -8, 	  -2,  -10, 	  -4,   -4, 	   2,   -9
+.2byte    3,  -15, 	  -4,  -14, 	   9,  -11, 	  -1,  -11
+.2byte    2,  -17, 	  -6,  -19, 	   5,  -16, 	  -4,  -10
+.2byte    6,  -15, 	  -7,  -10, 	   3,   -3, 	   1,  -12
+.2byte   -1,  -16, 	   8,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -1,  -21, 	   5,  -17, 	  -7,  -17, 	  -1,  -11
+.2byte   -1,  -18, 	   9,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -5,  -15, 	   2,  -14, 	 -11,  -11, 	  -1,  -11
+.2byte   -4,  -17, 	   4,  -19, 	  -7,  -16, 	   2,  -10
+.2byte   -8,  -15, 	   5,  -10, 	  -5,   -3, 	  -3,  -12
+.2byte   -8,   -9, 	  -7,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -2,  -17, 	  -6,  -16, 	  -4,  -11, 	   1,   -9
+.2byte  -10,   -8, 	   0,  -10, 	   2,   -4, 	  -4,   -9
+.2byte   -5,   -9, 	 -11,   -9, 	   3,   -4, 	  -1,   -9
+.2byte   -2,  -18, 	  -7,  -14, 	   0,  -12, 	  -1,   -8
+.2byte   -6,   -5, 	  -4,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,  -10
+.2byte   -5,   -9, 	 -11,   -9, 	   3,   -4, 	  -1,   -9
+.2byte   -8,   -9, 	  -7,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -5,  -15, 	   2,  -14, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -16, 	   8,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte    3,  -15, 	  -4,  -14, 	   9,  -11, 	  -1,  -11
+.2byte    6,   -9, 	   5,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    3,   -9, 	   9,   -9, 	  -5,   -4, 	  -1,   -9
+.2byte   -4,   -8, 	  -9,   -4, 	   4,   -1, 	  -1,   -8
+.2byte   -4,   -7, 	  -9,   -3, 	   4,    0, 	  -1,   -7
+.2byte    0,   -7, 	  -2,  -14, 	   2,  -14, 	   0,  -10
+.2byte    0,   -7, 	   5,  -15, 	  -1,  -14, 	  -2,   -8
+.2byte    3,   -8, 	   4,  -15, 	   3,  -14, 	  -2,   -8
+.2byte    3,  -13, 	  -1,  -18, 	   6,  -16, 	  -1,   -9
+.2byte    0,  -11, 	   5,  -16, 	  -5,  -16, 	   0,   -9
+.2byte   -4,  -13, 	   0,  -18, 	  -7,  -16, 	   0,   -9
+.2byte   -4,   -8, 	  -5,  -15, 	  -4,  -14, 	   1,   -8
+.2byte   -1,   -7, 	  -6,  -15, 	   0,  -14, 	   1,   -8
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,  -10
+.2byte   -2,   -6, 	 -11,   -5, 	   8,   -4, 	  -1,   -8
+.2byte    0,   -6, 	 -10,   -4, 	   9,   -5, 	  -1,   -8
+.2byte    3,   -9, 	   9,   -9, 	  -5,   -4, 	  -1,   -9
+.2byte    2,   -7, 	   7,   -8, 	  -3,   -3, 	  -2,   -7
+.2byte    4,   -8, 	  10,   -6, 	  -6,   -4, 	   0,   -8
+.2byte    6,   -9, 	   5,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    6,   -7, 	   1,   -7, 	   6,   -5, 	  -2,   -8
+.2byte    7,   -8, 	   6,   -7, 	   2,   -5, 	  -1,   -8
+.2byte    3,  -15, 	  -4,  -14, 	   9,  -11, 	  -1,  -11
+.2byte    4,  -12, 	  -6,  -11, 	  10,  -10, 	  -1,  -10
+.2byte    2,  -14, 	  -1,  -13, 	   8,   -9, 	  -3,  -10
+.2byte   -1,  -16, 	   8,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -2,  -14, 	   8,  -11, 	  -9,  -13, 	  -2,  -10
+.2byte    0,  -14, 	   7,  -13, 	 -10,  -11, 	   0,  -10
+.2byte   -5,  -15, 	   2,  -14, 	 -11,  -11, 	  -1,  -11
+.2byte   -6,  -12, 	   4,  -11, 	 -12,  -10, 	  -1,  -10
+.2byte   -4,  -14, 	  -1,  -13, 	 -10,   -9, 	   1,  -10
+.2byte   -8,   -9, 	  -7,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -8,   -7, 	  -3,   -7, 	  -8,   -5, 	   0,   -8
+.2byte   -9,   -8, 	  -8,   -7, 	  -4,   -5, 	  -1,   -8
+.2byte   -5,   -9, 	 -11,   -9, 	   3,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -9,   -8, 	   1,   -3, 	   0,   -7
+.2byte   -6,   -8, 	 -12,   -6, 	   4,   -4, 	  -2,   -8
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte   -6,   -5, 	  -4,   -9, 	   8,   -5, 	  -1,   -8
+.2byte  -10,   -8, 	   0,  -10, 	   2,   -4, 	  -4,   -9
+.2byte   -8,  -15, 	   5,  -10, 	  -5,   -3, 	  -3,  -12
+.2byte   -1,  -18, 	   9,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte    6,  -15, 	  -7,  -10, 	   3,   -3, 	   1,  -12
+.2byte    8,   -8, 	  -2,  -10, 	  -4,   -4, 	   2,   -9
+.2byte    4,   -5, 	   2,   -9, 	 -10,   -5, 	  -1,   -8
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    4,   -5, 	   2,   -9, 	 -10,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -4,  -10, 	  -6,   -4, 	   0,   -9
+.2byte    6,  -14, 	  -7,   -9, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -18, 	   9,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -8,  -14, 	   5,   -9, 	  -5,   -2, 	  -3,  -11
+.2byte   -8,   -8, 	   2,  -10, 	   4,   -4, 	  -2,   -9
+.2byte   -6,   -5, 	  -4,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,  -10
+.2byte   -1,  -19, 	  -7,  -12, 	   5,  -12, 	  -1,   -9
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    3,   -9, 	   9,   -9, 	  -5,   -4, 	  -1,   -9
+.2byte    0,  -18, 	   5,  -14, 	  -2,  -12, 	  -1,   -8
+.2byte    3,   -5, 	   1,   -9, 	 -11,   -5, 	  -2,   -8
+.2byte    6,   -9, 	   5,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    0,  -17, 	   4,  -16, 	   2,  -11, 	  -3,   -9
+.2byte    5,   -8, 	  -5,  -10, 	  -7,   -4, 	  -1,   -9
+.2byte    3,  -15, 	  -4,  -14, 	   9,  -11, 	  -1,  -11
+.2byte    2,  -17, 	  -6,  -19, 	   5,  -16, 	  -4,  -10
+.2byte    4,  -14, 	  -9,   -9, 	   1,   -2, 	  -1,  -11
+.2byte   -1,  -16, 	   8,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte   -1,  -21, 	   5,  -17, 	  -7,  -17, 	  -1,  -11
+.2byte   -1,  -18, 	   9,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -5,  -15, 	   2,  -14, 	 -11,  -11, 	  -1,  -11
+.2byte   -4,  -17, 	   4,  -19, 	  -7,  -16, 	   2,  -10
+.2byte   -6,  -14, 	   7,   -9, 	  -3,   -2, 	  -1,  -11
+.2byte   -8,   -9, 	  -7,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -2,  -17, 	  -6,  -16, 	  -4,  -11, 	   1,   -9
+.2byte   -7,   -8, 	   3,  -10, 	   5,   -4, 	  -1,   -9
+.2byte   -5,   -9, 	 -11,   -9, 	   3,   -4, 	  -1,   -9
+.2byte   -2,  -18, 	  -7,  -14, 	   0,  -12, 	  -1,   -8
+.2byte   -5,   -5, 	  -3,   -9, 	   9,   -5, 	   0,   -8
+.2byte   -1,   -4, 	 -11,   -8, 	   9,   -8, 	  -1,   -9
+.2byte    4,   -5, 	   2,   -9, 	 -10,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -4,  -10, 	  -6,   -4, 	   0,   -9
+.2byte    6,  -14, 	  -7,   -9, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -18, 	   9,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -8,  -14, 	   5,   -9, 	  -5,   -2, 	  -3,  -11
+.2byte   -8,   -8, 	   2,  -10, 	   4,   -4, 	  -2,   -9
+.2byte   -6,   -5, 	  -4,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -6, 	  10,   -6, 	  -1,  -10
+.2byte   -5,   -9, 	 -11,   -9, 	   3,   -4, 	  -1,   -9
+.2byte   -8,   -9, 	  -7,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -5,  -15, 	   2,  -14, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -16, 	   8,  -13, 	 -10,  -13, 	  -1,  -12
+.2byte    3,  -15, 	  -4,  -14, 	   9,  -11, 	  -1,  -11
+.2byte    6,   -9, 	   5,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    3,   -9, 	   9,   -9, 	  -5,   -4, 	  -1,   -9
+sNidoqueenAnimTable1:
+.4byte sNidoqueenAnims_1_1
+.4byte sNidoqueenAnims_1_2
+.4byte sNidoqueenAnims_1_3
+.4byte sNidoqueenAnims_1_4
+.4byte sNidoqueenAnims_1_5
+.4byte sNidoqueenAnims_1_6
+.4byte sNidoqueenAnims_1_7
+.4byte sNidoqueenAnims_1_8
+sNidoqueenAnimTable2:
+.4byte sNidoqueenAnims_2_1
+.4byte sNidoqueenAnims_2_2
+.4byte sNidoqueenAnims_2_3
+.4byte sNidoqueenAnims_2_4
+.4byte sNidoqueenAnims_2_5
+.4byte sNidoqueenAnims_2_6
+.4byte sNidoqueenAnims_2_7
+.4byte sNidoqueenAnims_2_8
+sNidoqueenAnimTable3:
+.4byte sNidoqueenAnims_3_1
+.4byte sNidoqueenAnims_3_2
+.4byte sNidoqueenAnims_3_3
+.4byte sNidoqueenAnims_3_4
+.4byte sNidoqueenAnims_3_5
+.4byte sNidoqueenAnims_3_6
+.4byte sNidoqueenAnims_3_7
+.4byte sNidoqueenAnims_3_8
+sNidoqueenAnimTable4:
+.4byte sNidoqueenAnims_4_1
+.4byte sNidoqueenAnims_4_2
+.4byte sNidoqueenAnims_4_3
+.4byte sNidoqueenAnims_4_4
+.4byte sNidoqueenAnims_4_5
+.4byte sNidoqueenAnims_4_6
+.4byte sNidoqueenAnims_4_7
+.4byte sNidoqueenAnims_4_8
+sNidoqueenAnimTable5:
+.4byte sNidoqueenAnims_5_1
+.4byte sNidoqueenAnims_5_2
+.4byte sNidoqueenAnims_5_3
+.4byte sNidoqueenAnims_5_4
+.4byte sNidoqueenAnims_5_5
+.4byte sNidoqueenAnims_5_6
+.4byte sNidoqueenAnims_5_7
+.4byte sNidoqueenAnims_5_8
+sNidoqueenAnimTable6:
+.4byte sNidoqueenAnims_6_1
+.4byte sNidoqueenAnims_6_1
+.4byte sNidoqueenAnims_6_1
+.4byte sNidoqueenAnims_6_1
+.4byte sNidoqueenAnims_6_1
+.4byte sNidoqueenAnims_6_1
+.4byte sNidoqueenAnims_6_1
+.4byte sNidoqueenAnims_6_1
+sNidoqueenAnimTable7:
+.4byte sNidoqueenAnims_7_1
+.4byte sNidoqueenAnims_7_2
+.4byte sNidoqueenAnims_7_3
+.4byte sNidoqueenAnims_7_4
+.4byte sNidoqueenAnims_7_5
+.4byte sNidoqueenAnims_7_6
+.4byte sNidoqueenAnims_7_7
+.4byte sNidoqueenAnims_7_8
+sNidoqueenAnimTable8:
+.4byte sNidoqueenAnims_8_1
+.4byte sNidoqueenAnims_8_2
+.4byte sNidoqueenAnims_8_3
+.4byte sNidoqueenAnims_8_4
+.4byte sNidoqueenAnims_8_5
+.4byte sNidoqueenAnims_8_6
+.4byte sNidoqueenAnims_8_7
+.4byte sNidoqueenAnims_8_8
+sNidoqueenAnimTable9:
+.4byte sNidoqueenAnims_9_1
+.4byte sNidoqueenAnims_9_2
+.4byte sNidoqueenAnims_9_3
+.4byte sNidoqueenAnims_9_4
+.4byte sNidoqueenAnims_9_5
+.4byte sNidoqueenAnims_9_6
+.4byte sNidoqueenAnims_9_7
+.4byte sNidoqueenAnims_9_8
+sNidoqueenAnimTable10:
+.4byte sNidoqueenAnims_10_1
+.4byte sNidoqueenAnims_10_2
+.4byte sNidoqueenAnims_10_3
+.4byte sNidoqueenAnims_10_4
+.4byte sNidoqueenAnims_10_5
+.4byte sNidoqueenAnims_10_6
+.4byte sNidoqueenAnims_10_7
+.4byte sNidoqueenAnims_10_8
+sNidoqueenAnimTable11:
+.4byte sNidoqueenAnims_11_1
+.4byte sNidoqueenAnims_11_2
+.4byte sNidoqueenAnims_11_3
+.4byte sNidoqueenAnims_11_4
+.4byte sNidoqueenAnims_11_5
+.4byte sNidoqueenAnims_11_6
+.4byte sNidoqueenAnims_11_7
+.4byte sNidoqueenAnims_11_8
+sNidoqueenAnimTable12:
+.4byte sNidoqueenAnims_12_1
+.4byte sNidoqueenAnims_12_2
+.4byte sNidoqueenAnims_12_3
+.4byte sNidoqueenAnims_12_4
+.4byte sNidoqueenAnims_12_5
+.4byte sNidoqueenAnims_12_6
+.4byte sNidoqueenAnims_12_7
+.4byte sNidoqueenAnims_12_8
+sNidoqueenAnimTable13:
+.4byte sNidoqueenAnims_13_1
+.4byte sNidoqueenAnims_13_2
+.4byte sNidoqueenAnims_13_3
+.4byte sNidoqueenAnims_13_4
+.4byte sNidoqueenAnims_13_5
+.4byte sNidoqueenAnims_13_6
+.4byte sNidoqueenAnims_13_7
+.4byte sNidoqueenAnims_13_8
+sAxAnimationsNidoqueen:
+.4byte sNidoqueenAnimTable1
+.4byte sNidoqueenAnimTable2
+.4byte sNidoqueenAnimTable3
+.4byte sNidoqueenAnimTable4
+.4byte sNidoqueenAnimTable5
+.4byte sNidoqueenAnimTable6
+.4byte sNidoqueenAnimTable7
+.4byte sNidoqueenAnimTable8
+.4byte sNidoqueenAnimTable9
+.4byte sNidoqueenAnimTable10
+.4byte sNidoqueenAnimTable11
+.4byte sNidoqueenAnimTable12
+.4byte sNidoqueenAnimTable13
+sAxSpritesNidoqueen:
+.4byte sNidoqueenSprites1
+.4byte sNidoqueenSprites2
+.4byte sNidoqueenSprites3
+.4byte sNidoqueenSprites4
+.4byte sNidoqueenSprites5
+.4byte sNidoqueenSprites6
+.4byte sNidoqueenSprites7
+.4byte sNidoqueenSprites8
+.4byte sNidoqueenSprites9
+.4byte sNidoqueenSprites10
+.4byte sNidoqueenSprites11
+.4byte sNidoqueenSprites12
+.4byte sNidoqueenSprites13
+.4byte sNidoqueenSprites14
+.4byte sNidoqueenSprites15
+.4byte sNidoqueenSprites16
+.4byte sNidoqueenSprites17
+.4byte sNidoqueenSprites18
+.4byte sNidoqueenSprites19
+.4byte sNidoqueenSprites20
+.4byte sNidoqueenSprites21
+.4byte sNidoqueenSprites22
+.4byte sNidoqueenSprites23
+.4byte sNidoqueenSprites24
+.4byte sNidoqueenSprites25
+.4byte sNidoqueenSprites26
+.4byte sNidoqueenSprites27
+.4byte sNidoqueenSprites28
+.4byte sNidoqueenSprites29
+.4byte sNidoqueenSprites30
+.4byte sNidoqueenSprites31
+.4byte sNidoqueenSprites32
+.4byte sNidoqueenSprites33
+.4byte sNidoqueenSprites34
+.4byte sNidoqueenSprites35
+.4byte sNidoqueenSprites36
+.4byte sNidoqueenSprites37
+.4byte sNidoqueenSprites38
+.4byte sNidoqueenSprites39
+.4byte sNidoqueenSprites40
+.4byte sNidoqueenSprites41
+.4byte sNidoqueenSprites42
+.4byte sNidoqueenSprites43
+.4byte sNidoqueenSprites44
+.4byte sNidoqueenSprites45
+.4byte sNidoqueenSprites46
+.4byte sNidoqueenSprites47
+.4byte sNidoqueenSprites48
+.4byte sNidoqueenSprites49
+.4byte sNidoqueenSprites50
+.4byte sNidoqueenSprites51
+.4byte sNidoqueenSprites52
+sAxMainNidoqueen:
+ax_main sAxPosesNidoqueen, sAxAnimationsNidoqueen, 13, sAxSpritesNidoqueen, sAxPositionsNidoqueen

--- a/data/ax/nidoranf.inc
+++ b/data/ax/nidoranf.inc
@@ -1,0 +1,2798 @@
+.global gAxNidoranF
+gAxNidoranF:
+ax_siro sAxMainNidoranF
+sNidoranFPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose4:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose5:
+ax_pose 4, 0x01ea, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose6:
+ax_pose 5, 0x01ee, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose8:
+ax_pose 7, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose9:
+ax_pose 8, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose10:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose11:
+ax_pose 10, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose12:
+ax_pose 11, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose13:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose14:
+ax_pose 13, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose15:
+ax_pose 14, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose16:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose17:
+ax_pose 10, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose18:
+ax_pose 11, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose22:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose23:
+ax_pose 4, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose24:
+ax_pose 5, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose28:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose29:
+ax_pose 4, 0x01ea, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose30:
+ax_pose 5, 0x01ee, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose31:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose32:
+ax_pose 7, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose33:
+ax_pose 8, 0x01eb, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidoranFPose34:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose35:
+ax_pose 10, 0x01ef, 0x90ed, 0x7c00
+ax_pose_terminator
+sNidoranFPose36:
+ax_pose 11, 0x01ed, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidoranFPose37:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose38:
+ax_pose 13, 0x81ec, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose39:
+ax_pose 14, 0x81ee, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose40:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose41:
+ax_pose 10, 0x01ef, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidoranFPose42:
+ax_pose 11, 0x01ed, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose43:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose44:
+ax_pose 7, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose45:
+ax_pose 8, 0x01eb, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidoranFPose46:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose47:
+ax_pose 4, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose48:
+ax_pose 5, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose50:
+ax_pose 15, 0x01ec, 0x80f4, 0x7c00
+ax_pose 16, 0x01ec, 0x80f4, 0x7c10
+ax_pose_terminator
+sNidoranFPose51:
+ax_pose 16, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose52:
+ax_pose 17, 0x81ec, 0x80fc, 0x7c00
+ax_pose 18, 0x01ec, 0x80f4, 0x7c08
+ax_pose_terminator
+sNidoranFPose53:
+ax_pose 18, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose54:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose55:
+ax_pose 19, 0x81eb, 0x90fe, 0x7c00
+ax_pose 20, 0x01ec, 0x90ef, 0x7c08
+ax_pose_terminator
+sNidoranFPose56:
+ax_pose 20, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose57:
+ax_pose 21, 0x01ec, 0x90ef, 0x7c00
+ax_pose 22, 0x01ec, 0x90ef, 0x7c10
+ax_pose_terminator
+sNidoranFPose58:
+ax_pose 22, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose59:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose60:
+ax_pose 23, 0x01eb, 0x90ef, 0x7c00
+ax_pose 24, 0x01eb, 0x90ef, 0x7c10
+ax_pose_terminator
+sNidoranFPose61:
+ax_pose 24, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose62:
+ax_pose 25, 0x41f6, 0x90ef, 0x7c00
+ax_pose 26, 0x01eb, 0x90ef, 0x7c08
+ax_pose_terminator
+sNidoranFPose63:
+ax_pose 26, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose64:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose65:
+ax_pose 27, 0x01eb, 0x90ef, 0x7c00
+ax_pose 28, 0x01eb, 0x90ef, 0x7c10
+ax_pose_terminator
+sNidoranFPose66:
+ax_pose 28, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose67:
+ax_pose 29, 0x81eb, 0x90ff, 0x7c00
+ax_pose 30, 0x01eb, 0x90ef, 0x7c08
+ax_pose_terminator
+sNidoranFPose68:
+ax_pose 30, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose69:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose70:
+ax_pose 31, 0x81ea, 0x80fc, 0x7c00
+ax_pose 32, 0x01ea, 0x80f0, 0x7c08
+ax_pose_terminator
+sNidoranFPose71:
+ax_pose 32, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose72:
+ax_pose 33, 0x81ea, 0x80f2, 0x7c00
+ax_pose 34, 0x01ea, 0x80f0, 0x7c08
+ax_pose_terminator
+sNidoranFPose73:
+ax_pose 34, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose74:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose75:
+ax_pose 27, 0x01eb, 0x80f0, 0x7c00
+ax_pose 28, 0x01eb, 0x80f0, 0x7c10
+ax_pose_terminator
+sNidoranFPose76:
+ax_pose 28, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose77:
+ax_pose 29, 0x81eb, 0x80f0, 0x7c00
+ax_pose 30, 0x01eb, 0x80f0, 0x7c08
+ax_pose_terminator
+sNidoranFPose78:
+ax_pose 30, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose79:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose80:
+ax_pose 23, 0x01eb, 0x80f0, 0x7c00
+ax_pose 24, 0x01eb, 0x80f0, 0x7c10
+ax_pose_terminator
+sNidoranFPose81:
+ax_pose 24, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose82:
+ax_pose 25, 0x41f6, 0x80f0, 0x7c00
+ax_pose 26, 0x01eb, 0x80f0, 0x7c08
+ax_pose_terminator
+sNidoranFPose83:
+ax_pose 26, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose84:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose85:
+ax_pose 19, 0x81eb, 0x80f1, 0x7c00
+ax_pose 20, 0x01ec, 0x80f0, 0x7c08
+ax_pose_terminator
+sNidoranFPose86:
+ax_pose 20, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose87:
+ax_pose 21, 0x01ec, 0x80f0, 0x7c00
+ax_pose 22, 0x01ec, 0x80f0, 0x7c10
+ax_pose_terminator
+sNidoranFPose88:
+ax_pose 22, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose89:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose90:
+ax_pose 35, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose91:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose92:
+ax_pose 36, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose93:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose94:
+ax_pose 37, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose95:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose96:
+ax_pose 38, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose97:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose98:
+ax_pose 39, 0x01ea, 0x80f7, 0x7c00
+ax_pose_terminator
+sNidoranFPose99:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose100:
+ax_pose 38, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose101:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose102:
+ax_pose 37, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose103:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose104:
+ax_pose 36, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose105:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose106:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose107:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose108:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose109:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose110:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose111:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose112:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose113:
+ax_pose 40, 0x81f0, 0x80f7, 0x7c00
+ax_pose_terminator
+sNidoranFPose114:
+ax_pose 41, 0x81f0, 0x80f7, 0x7c00
+ax_pose_terminator
+sNidoranFPose115:
+ax_pose 42, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose116:
+ax_pose 43, 0x01e7, 0x90f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose117:
+ax_pose 44, 0x01e5, 0x90ed, 0x7c00
+ax_pose_terminator
+sNidoranFPose118:
+ax_pose 45, 0x01e7, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidoranFPose119:
+ax_pose 46, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose120:
+ax_pose 45, 0x01e7, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidoranFPose121:
+ax_pose 44, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sNidoranFPose122:
+ax_pose 43, 0x01e7, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose123:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose124:
+ax_pose 1, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose125:
+ax_pose 2, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose126:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose127:
+ax_pose 4, 0x01ea, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose128:
+ax_pose 5, 0x01ee, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose129:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose130:
+ax_pose 7, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose131:
+ax_pose 8, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose132:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose133:
+ax_pose 10, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose134:
+ax_pose 11, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose135:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose136:
+ax_pose 13, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose137:
+ax_pose 14, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose138:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose139:
+ax_pose 10, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose140:
+ax_pose 11, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose141:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose142:
+ax_pose 7, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose143:
+ax_pose 8, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose144:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose145:
+ax_pose 4, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose146:
+ax_pose 5, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose147:
+ax_pose 35, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose148:
+ax_pose 36, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose149:
+ax_pose 37, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose150:
+ax_pose 38, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose151:
+ax_pose 39, 0x01ea, 0x80f7, 0x7c00
+ax_pose_terminator
+sNidoranFPose152:
+ax_pose 38, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose153:
+ax_pose 37, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose154:
+ax_pose 36, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose155:
+ax_pose 18, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose156:
+ax_pose 22, 0x01ec, 0x90ed, 0x7c00
+ax_pose_terminator
+sNidoranFPose157:
+ax_pose 26, 0x01ec, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidoranFPose158:
+ax_pose 30, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose159:
+ax_pose 34, 0x01ea, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose160:
+ax_pose 30, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose161:
+ax_pose 26, 0x01ec, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose162:
+ax_pose 22, 0x01ec, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidoranFPose163:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose164:
+ax_pose 1, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose165:
+ax_pose 2, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose166:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose167:
+ax_pose 4, 0x01ea, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidoranFPose168:
+ax_pose 5, 0x01ee, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose169:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose170:
+ax_pose 7, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose171:
+ax_pose 8, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose172:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose173:
+ax_pose 10, 0x01eb, 0x90ed, 0x7c00
+ax_pose_terminator
+sNidoranFPose174:
+ax_pose 11, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose175:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose176:
+ax_pose 13, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose177:
+ax_pose 14, 0x81e8, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose178:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose179:
+ax_pose 10, 0x01eb, 0x80f2, 0x7c00
+ax_pose_terminator
+sNidoranFPose180:
+ax_pose 11, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose181:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose182:
+ax_pose 7, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose183:
+ax_pose 8, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose184:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose185:
+ax_pose 4, 0x01ea, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose186:
+ax_pose 5, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose187:
+ax_pose 35, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose188:
+ax_pose 36, 0x01ec, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose189:
+ax_pose 37, 0x01eb, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose190:
+ax_pose 38, 0x01eb, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidoranFPose191:
+ax_pose 39, 0x01ea, 0x80f7, 0x7c00
+ax_pose_terminator
+sNidoranFPose192:
+ax_pose 38, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose193:
+ax_pose 37, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose194:
+ax_pose 36, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose195:
+ax_pose 0, 0x01ec, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidoranFPose196:
+ax_pose 3, 0x01ec, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose197:
+ax_pose 6, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose198:
+ax_pose 9, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidoranFPose199:
+ax_pose 12, 0x81ea, 0x80f8, 0x7c00
+ax_pose_terminator
+sNidoranFPose200:
+ax_pose 9, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose201:
+ax_pose 6, 0x01eb, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidoranFPose202:
+ax_pose 3, 0x01ec, 0x90ef, 0x7c00
+ax_pose_terminator
+.align 2
+sNidoranFAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, -1,
+ax_anim 4, 0, 1, 0, 3, 0, -1,
+ax_anim 4, 0, 1, 0, 5, 0, 1,
+ax_anim 4, 0, 2, 0, 8, 0, 5,
+ax_anim 4, 0, 2, 0, 6, 0, 5,
+ax_anim 4, 0, 2, 0, 3, 0, 2,
+ax_anim_terminator
+sNidoranFAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 3, -1, -1, -1, -1,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 2, 0, 2, 1,
+ax_anim 4, 0, 5, 3, -1, 3, 2,
+ax_anim 4, 0, 5, 3, 3, 3, 4,
+ax_anim 4, 0, 5, 2, 2, 1, 1,
+ax_anim_terminator
+sNidoranFAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 6, -1, 0, -1, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 2, -1, 2, 0,
+ax_anim 4, 0, 8, 4, -1, 4, 0,
+ax_anim 4, 0, 8, 3, 0, 3, 0,
+ax_anim 4, 0, 8, 1, 0, 1, 0,
+ax_anim_terminator
+sNidoranFAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 9, -1, 1, -1, 1,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 2, -2, 2, -2,
+ax_anim 4, 0, 11, 4, -4, 4, -4,
+ax_anim 4, 0, 11, 4, -1, 4, -2,
+ax_anim 4, 0, 11, 1, 1, 1, 0,
+ax_anim_terminator
+sNidoranFAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 13, 0, -1, 0, -1,
+ax_anim 4, 0, 13, 0, -4, 0, -6,
+ax_anim 4, 0, 14, 0, -2, 0, -5,
+ax_anim 4, 0, 14, 0, 0, 0, -4,
+ax_anim 4, 0, 14, 0, 4, 0, -2,
+ax_anim_terminator
+sNidoranFAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 1, 1, 1, 1,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -2, -2, -2, -2,
+ax_anim 4, 0, 17, -4, -4, -4, -4,
+ax_anim 4, 0, 17, -4, -1, -4, -2,
+ax_anim 4, 0, 17, -1, 1, -1, 0,
+ax_anim_terminator
+sNidoranFAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 18, 1, 0, 1, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -2, -1, -2, 0,
+ax_anim 4, 0, 20, -4, -1, -4, 0,
+ax_anim 4, 0, 20, -3, 0, -3, 0,
+ax_anim 4, 0, 20, -1, 0, -1, 0,
+ax_anim_terminator
+sNidoranFAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 21, 1, -1, 1, -1,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -2, -1, -2, 1,
+ax_anim 4, 0, 23, -3, -1, -3, 2,
+ax_anim 4, 0, 23, -3, 3, -3, 4,
+ax_anim 4, 0, 23, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 1, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 0, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNidoranFAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 2, 4, 4,
+ax_anim 1, 0, 28, 11, 7, 11, 11,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 1, 29, 19, 16, 19, 16,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 0, 29, 19, 16, 19, 16,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sNidoranFAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, -4, 4, 0,
+ax_anim 1, 0, 31, 10, -2, 10, 0,
+ax_anim 2, 0, 32, 17, 0, 18, 0,
+ax_anim 2, 1, 32, 17, 1, 18, 1,
+ax_anim 2, 0, 32, 17, 0, 18, 0,
+ax_anim 2, 0, 32, 17, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sNidoranFAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -3, 0, 0,
+ax_anim 1, 2, 34, 4, -10, 4, -6,
+ax_anim 1, 0, 34, 11, -19, 11, -14,
+ax_anim 2, 0, 35, 17, -21, 17, -21,
+ax_anim 2, 1, 35, 18, -20, 18, -20,
+ax_anim 2, 0, 35, 17, -21, 17, -21,
+ax_anim 2, 0, 35, 18, -20, 18, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sNidoranFAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, -1, 0, 0,
+ax_anim 1, 2, 37, 0, -10, 0, -6,
+ax_anim 1, 0, 37, 0, -17, 0, -13,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 1, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 0, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sNidoranFAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -3, 0, 0,
+ax_anim 1, 2, 40, -4, -10, -4, -6,
+ax_anim 1, 0, 40, -11, -19, -11, -14,
+ax_anim 2, 0, 41, -17, -21, -17, -21,
+ax_anim 2, 1, 41, -18, -20, -18, -20,
+ax_anim 2, 0, 41, -17, -21, -17, -21,
+ax_anim 2, 0, 41, -18, -20, -18, -20,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sNidoranFAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, -4, -4, 0,
+ax_anim 1, 0, 43, -10, -2, -10, 0,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 1, 44, -17, 1, -17, 1,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 44, -17, 1, -17, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sNidoranFAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 2, -4, 4,
+ax_anim 1, 0, 46, -11, 7, -11, 11,
+ax_anim 2, 0, 47, -18, 17, -18, 17,
+ax_anim 2, 1, 47, -19, 16, -19, 16,
+ax_anim 2, 0, 47, -18, 17, -18, 17,
+ax_anim 2, 0, 47, -18, 17, -18, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 52, 0, -3, 0, -3,
+ax_anim 1, 2, 52, 0, -1, 0, -1,
+ax_anim 1, 0, 52, 0, 5, 0, 5,
+ax_anim 2, 0, 49, 0, 16, 0, 16,
+ax_anim 2, 1, 50, 1, 17, 0, 16,
+ax_anim 1, 0, 50, 1, 14, 0, 14,
+ax_anim 4, 0, 50, 1, 12, 0, 12,
+ax_anim 2, 0, 51, 0, 16, 0, 16,
+ax_anim 2, 0, 52, -1, 17, 0, 16,
+ax_anim 2, 0, 48, 0, 10, 0, 0,
+ax_anim 2, 0, 48, 0, 3, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 4, 0, 57, -3, -3, -3, -3,
+ax_anim 1, 2, 57, -1, -1, -1, -1,
+ax_anim 1, 0, 57, 5, 5, 5, 5,
+ax_anim 2, 0, 54, 16, 16, 16, 16,
+ax_anim 2, 1, 55, 16, 17, 16, 17,
+ax_anim 1, 0, 55, 15, 16, 15, 16,
+ax_anim 4, 0, 55, 11, 12, 11, 12,
+ax_anim 2, 0, 56, 16, 16, 16, 16,
+ax_anim 2, 0, 57, 19, 17, 19, 17,
+ax_anim 2, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 3, 3, 3, 3,
+ax_anim_terminator
+sNidoranFAnims_3_3:
+ax_anim 2, 0, 58, -1, 0, -1, 0,
+ax_anim 4, 0, 62, -3, 0, -3, 0,
+ax_anim 1, 2, 62, -1, 0, -1, 0,
+ax_anim 1, 0, 62, 5, 0, 5, 0,
+ax_anim 2, 0, 59, 16, 0, 16, 0,
+ax_anim 2, 1, 60, 17, 1, 16, 0,
+ax_anim 1, 0, 60, 15, 1, 15, 0,
+ax_anim 4, 0, 60, 11, 1, 11, 0,
+ax_anim 2, 0, 61, 16, 0, 16, 0,
+ax_anim 2, 0, 62, 19, -1, 19, 0,
+ax_anim 2, 0, 58, 10, 0, 10, 0,
+ax_anim 2, 0, 58, 3, 0, 3, 0,
+ax_anim_terminator
+sNidoranFAnims_3_4:
+ax_anim 2, 0, 63, -1, 1, -1, 1,
+ax_anim 4, 0, 67, -3, 3, -3, 3,
+ax_anim 1, 2, 67, -1, 1, -1, 1,
+ax_anim 1, 0, 67, 5, -5, 5, -5,
+ax_anim 2, 0, 64, 16, -16, 16, -16,
+ax_anim 2, 1, 65, 18, -17, 18, -17,
+ax_anim 1, 0, 65, 17, -16, 17, -16,
+ax_anim 4, 0, 65, 13, -12, 13, -12,
+ax_anim 2, 0, 66, 16, -16, 16, -16,
+ax_anim 2, 0, 67, 18, -19, 18, -19,
+ax_anim 2, 0, 63, 10, -10, 10, -10,
+ax_anim 2, 0, 63, 3, -3, 3, -3,
+ax_anim_terminator
+sNidoranFAnims_3_5:
+ax_anim 2, 0, 68, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 3, 0, 3,
+ax_anim 1, 2, 72, 0, 1, 0, 1,
+ax_anim 1, 0, 72, 0, -5, 0, -5,
+ax_anim 2, 0, 69, 0, -16, 0, -16,
+ax_anim 2, 1, 70, -1, -17, -1, -17,
+ax_anim 1, 0, 70, -1, -16, -1, -16,
+ax_anim 4, 0, 70, -1, -12, -1, -12,
+ax_anim 2, 0, 71, 0, -16, 0, -16,
+ax_anim 2, 0, 72, 1, -19, 1, -19,
+ax_anim 2, 0, 68, 0, -10, 0, -10,
+ax_anim 2, 0, 68, 0, -3, 0, -3,
+ax_anim_terminator
+sNidoranFAnims_3_6:
+ax_anim 2, 0, 73, 1, 1, 1, 1,
+ax_anim 4, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 2, 77, 1, 1, 1, 1,
+ax_anim 1, 0, 77, -5, -5, -5, -5,
+ax_anim 2, 0, 74, -16, -16, -16, -16,
+ax_anim 2, 1, 75, -18, -17, -18, -17,
+ax_anim 1, 0, 75, -17, -16, -17, -16,
+ax_anim 4, 0, 75, -13, -12, -13, -12,
+ax_anim 2, 0, 76, -16, -16, -16, -16,
+ax_anim 2, 0, 77, -18, -19, -18, -19,
+ax_anim 2, 0, 73, -10, -10, -10, -10,
+ax_anim 2, 0, 73, -3, -3, -3, -3,
+ax_anim_terminator
+sNidoranFAnims_3_7:
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim 4, 0, 82, 3, 0, 3, 0,
+ax_anim 1, 2, 82, 1, 0, 1, 0,
+ax_anim 1, 0, 82, -5, 0, -5, 0,
+ax_anim 2, 0, 79, -16, 0, -16, 0,
+ax_anim 2, 1, 80, -17, 1, -16, 0,
+ax_anim 1, 0, 80, -15, 1, -15, 0,
+ax_anim 4, 0, 80, -11, 1, -11, 0,
+ax_anim 2, 0, 81, -16, 0, -16, 0,
+ax_anim 2, 0, 82, -19, -1, -19, 0,
+ax_anim 2, 0, 78, -10, 0, -10, 0,
+ax_anim 2, 0, 78, -3, 0, -3, 0,
+ax_anim_terminator
+sNidoranFAnims_3_8:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 4, 0, 87, 3, -3, 3, -3,
+ax_anim 1, 2, 87, 1, -1, 1, -1,
+ax_anim 1, 0, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 84, -16, 16, -16, 16,
+ax_anim 2, 1, 85, -16, 17, -16, 17,
+ax_anim 1, 0, 85, -15, 16, -15, 16,
+ax_anim 4, 0, 85, -11, 12, -11, 12,
+ax_anim 2, 0, 86, -16, 16, -16, 16,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 4, 0, 88, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 1, 0, 1,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 1, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sNidoranFAnims_4_2:
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 4, 0, 90, -3, -3, -3, -3,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 4, 2, 4, 2,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 1, 91, 4, 2, 4, 2,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 4, 2, 4, 2,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 4, 2, 4, 2,
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim_terminator
+sNidoranFAnims_4_3:
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 4, 0, 92, -3, 0, -3, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 1, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim_terminator
+sNidoranFAnims_4_4:
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 4, 0, 94, -3, 3, -3, 3,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 4, -2, 4, -2,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 1, 95, 4, -2, 4, -2,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 4, -2, 4, -2,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 4, -2, 4, -2,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim_terminator
+sNidoranFAnims_4_5:
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 4, 0, 96, 0, 3, 0, 3,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, -1, 0, -1,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 1, 97, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, 1, -3, 1, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim_terminator
+sNidoranFAnims_4_6:
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 4, 0, 98, 3, 3, 3, 3,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -4, -2, -4, -2,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim 2, 1, 99, -4, -2, -4, -2,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -4, -2, -4, -2,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -4, -2, -4, -2,
+ax_anim 2, 0, 98, -1, -1, -1, -1,
+ax_anim_terminator
+sNidoranFAnims_4_7:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 4, 0, 100, 3, 0, 3, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, -1, 0, -1, 0,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 2, 0, 101, -3, 1, -3, 1,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 2, 1, 101, -3, 1, -3, 1,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 2, 0, 101, -3, 1, -3, 1,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 2, 0, 101, -3, 1, -3, 1,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim_terminator
+sNidoranFAnims_4_8:
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 4, 0, 102, 3, -3, 3, -3,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 1, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sNidoranFAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sNidoranFAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sNidoranFAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sNidoranFAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sNidoranFAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sNidoranFAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sNidoranFAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_8_1:
+ax_anim 24, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, -2, 0, 0,
+ax_anim 6, 0, 122, 0, -3, 0, 0,
+ax_anim 6, 0, 122, 0, -2, 0, 0,
+ax_anim 6, 0, 124, 0, 1, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_8_2:
+ax_anim 24, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, -2, 0, 0,
+ax_anim 6, 0, 125, 0, -3, 0, 0,
+ax_anim 6, 0, 125, 0, -2, 0, 0,
+ax_anim 6, 0, 127, -2, 1, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_8_3:
+ax_anim 24, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, -2, 0, 0,
+ax_anim 6, 0, 128, 0, -3, 0, 0,
+ax_anim 6, 0, 128, 0, -2, 0, 0,
+ax_anim 6, 0, 130, -2, 2, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_8_4:
+ax_anim 24, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 131, 0, -3, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 133, -1, 4, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_8_5:
+ax_anim 24, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 134, 0, -3, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 136, 0, 7, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_8_6:
+ax_anim 24, 0, 137, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 137, 0, -3, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 139, 1, 4, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_8_7:
+ax_anim 24, 0, 140, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 140, 0, -3, 0, 0,
+ax_anim 6, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 142, 2, 2, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_8_8:
+ax_anim 24, 0, 143, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 143, 0, -3, 0, 0,
+ax_anim 6, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 145, 2, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 17, 7, 17,
+ax_anim 3, 0, 150, 0, 21, 0, 21,
+ax_anim 2, 3, 151, -7, 17, -7, 17,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 22, 11, 22, 11,
+ax_anim 3, 0, 149, 22, 19, 22, 19,
+ax_anim 2, 3, 150, 13, 21, 13, 21,
+ax_anim 2, 0, 151, 2, 12, 2, 12,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 19, -4, 19, -4,
+ax_anim 3, 0, 148, 22, 1, 22, 1,
+ax_anim 2, 3, 149, 19, 5, 19, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 2, -18, 2, -18,
+ax_anim 2, 0, 146, 12, -24, 12, -24,
+ax_anim 3, 0, 147, 22, -24, 22, -24,
+ax_anim 2, 3, 148, 21, -12, 21, -12,
+ax_anim 2, 0, 149, 16, -6, 16, -6,
+ax_anim 1, 0, 150, 8, -1, 8, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -10, -8, -10,
+ax_anim 2, 0, 153, -7, -19, -7, -19,
+ax_anim 3, 0, 146, 0, -24, 0, -24,
+ax_anim 2, 3, 147, 7, -19, 7, -19,
+ax_anim 2, 0, 148, 8, -8, 8, -8,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -2, -18, -2, -18,
+ax_anim 2, 0, 146, -12, -24, -12, -24,
+ax_anim 3, 0, 153, -22, -24, -22, -24,
+ax_anim 2, 3, 152, -21, -12, -21, -12,
+ax_anim 2, 0, 151, -16, -6, -16, -6,
+ax_anim 1, 0, 150, -8, -1, -8, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -19, -4, -19, -4,
+ax_anim 3, 0, 152, -22, 1, -22, 1,
+ax_anim 2, 3, 151, -19, 5, -19, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -22, 11, -22, 11,
+ax_anim 3, 0, 151, -22, 19, -22, 19,
+ax_anim 2, 3, 150, -13, 21, -13, 21,
+ax_anim 2, 0, 149, -2, 12, -2, 12,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranFAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranFGfx1:
+.incbin "baserom.gba", 0x64ABCC, 0x200
+sNidoranFSprites1:
+ax_sprite sNidoranFGfx1, 0x200
+ax_sprite_terminator
+sNidoranFGfx2:
+.incbin "baserom.gba", 0x64ADDC, 0x200
+sNidoranFSprites2:
+ax_sprite sNidoranFGfx2, 0x200
+ax_sprite_terminator
+sNidoranFGfx3:
+.incbin "baserom.gba", 0x64AFEC, 0x200
+sNidoranFSprites3:
+ax_sprite sNidoranFGfx3, 0x200
+ax_sprite_terminator
+sNidoranFGfx4:
+.incbin "baserom.gba", 0x64B1FC, 0x200
+sNidoranFSprites4:
+ax_sprite sNidoranFGfx4, 0x200
+ax_sprite_terminator
+sNidoranFGfx5:
+.incbin "baserom.gba", 0x64B40C, 0x200
+sNidoranFSprites5:
+ax_sprite sNidoranFGfx5, 0x200
+ax_sprite_terminator
+sNidoranFGfx6:
+.incbin "baserom.gba", 0x64B61C, 0x200
+sNidoranFSprites6:
+ax_sprite sNidoranFGfx6, 0x200
+ax_sprite_terminator
+sNidoranFGfx7:
+.incbin "baserom.gba", 0x64B82C, 0x200
+sNidoranFSprites7:
+ax_sprite sNidoranFGfx7, 0x200
+ax_sprite_terminator
+sNidoranFGfx8:
+.incbin "baserom.gba", 0x64BA3C, 0x200
+sNidoranFSprites8:
+ax_sprite sNidoranFGfx8, 0x200
+ax_sprite_terminator
+sNidoranFGfx9:
+.incbin "baserom.gba", 0x64BC4C, 0x200
+sNidoranFSprites9:
+ax_sprite sNidoranFGfx9, 0x200
+ax_sprite_terminator
+sNidoranFGfx10:
+.incbin "baserom.gba", 0x64BE5C, 0x200
+sNidoranFSprites10:
+ax_sprite sNidoranFGfx10, 0x200
+ax_sprite_terminator
+sNidoranFGfx11:
+.incbin "baserom.gba", 0x64C06C, 0x200
+sNidoranFSprites11:
+ax_sprite sNidoranFGfx11, 0x200
+ax_sprite_terminator
+sNidoranFGfx12:
+.incbin "baserom.gba", 0x64C27C, 0x200
+sNidoranFSprites12:
+ax_sprite sNidoranFGfx12, 0x200
+ax_sprite_terminator
+sNidoranFGfx13:
+.incbin "baserom.gba", 0x64C48C, 0x100
+sNidoranFSprites13:
+ax_sprite sNidoranFGfx13, 0x100
+ax_sprite_terminator
+sNidoranFGfx14:
+.incbin "baserom.gba", 0x64C59C, 0x100
+sNidoranFSprites14:
+ax_sprite sNidoranFGfx14, 0x100
+ax_sprite_terminator
+sNidoranFGfx15:
+.incbin "baserom.gba", 0x64C6AC, 0x100
+sNidoranFSprites15:
+ax_sprite sNidoranFGfx15, 0x100
+ax_sprite_terminator
+sNidoranFGfx16:
+.incbin "baserom.gba", 0x64C7BC, 0x20
+sNidoranFGfx16_1:
+.incbin "baserom.gba", 0x64C7DC, 0x20
+sNidoranFGfx16_2:
+.incbin "baserom.gba", 0x64C7FC, 0x60
+sNidoranFGfx16_3:
+.incbin "baserom.gba", 0x64C85C, 0x40
+sNidoranFSprites16:
+ax_sprite sNidoranFGfx16, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidoranFGfx16_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidoranFGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx16_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx17:
+.incbin "baserom.gba", 0x64C8E4, 0x40
+sNidoranFGfx17_1:
+.incbin "baserom.gba", 0x64C924, 0x60
+sNidoranFGfx17_2:
+.incbin "baserom.gba", 0x64C984, 0x60
+sNidoranFGfx17_3:
+.incbin "baserom.gba", 0x64C9E4, 0x40
+sNidoranFSprites17:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoranFGfx18:
+.incbin "baserom.gba", 0x64CA74, 0x20
+sNidoranFGfx18_1:
+.incbin "baserom.gba", 0x64CA94, 0xA0
+sNidoranFSprites18:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx18_1, 0xa0
+ax_sprite_terminator
+sNidoranFGfx19:
+.incbin "baserom.gba", 0x64CB5C, 0x60
+sNidoranFGfx19_1:
+.incbin "baserom.gba", 0x64CBBC, 0x60
+sNidoranFGfx19_2:
+.incbin "baserom.gba", 0x64CC1C, 0x60
+sNidoranFGfx19_3:
+.incbin "baserom.gba", 0x64CC7C, 0x20
+sNidoranFSprites19:
+ax_sprite sNidoranFGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx20:
+.incbin "baserom.gba", 0x64CCE4, 0xE0
+sNidoranFSprites20:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx20, 0xe0
+ax_sprite_terminator
+sNidoranFGfx21:
+.incbin "baserom.gba", 0x64CDDC, 0x60
+sNidoranFGfx21_1:
+.incbin "baserom.gba", 0x64CE3C, 0x100
+sNidoranFGfx21_2:
+.incbin "baserom.gba", 0x64CF3C, 0x40
+sNidoranFSprites21:
+ax_sprite sNidoranFGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoranFGfx22:
+.incbin "baserom.gba", 0x64CFB4, 0xA0
+sNidoranFGfx22_1:
+.incbin "baserom.gba", 0x64D054, 0x60
+sNidoranFSprites22:
+ax_sprite 0, 0xc0
+ax_sprite sNidoranFGfx22, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoranFGfx23:
+.incbin "baserom.gba", 0x64D0E4, 0x20
+sNidoranFGfx23_1:
+.incbin "baserom.gba", 0x64D104, 0x60
+sNidoranFGfx23_2:
+.incbin "baserom.gba", 0x64D164, 0x60
+sNidoranFGfx23_3:
+.incbin "baserom.gba", 0x64D1C4, 0x20
+sNidoranFSprites23:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx24:
+.incbin "baserom.gba", 0x64D234, 0x60
+sNidoranFGfx24_1:
+.incbin "baserom.gba", 0x64D294, 0x40
+sNidoranFGfx24_2:
+.incbin "baserom.gba", 0x64D2D4, 0x40
+sNidoranFSprites24:
+ax_sprite sNidoranFGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx24_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNidoranFGfx25:
+.incbin "baserom.gba", 0x64D34C, 0x40
+sNidoranFGfx25_1:
+.incbin "baserom.gba", 0x64D38C, 0x60
+sNidoranFGfx25_2:
+.incbin "baserom.gba", 0x64D3EC, 0x80
+sNidoranFSprites25:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx25_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNidoranFGfx26:
+.incbin "baserom.gba", 0x64D4AC, 0x60
+sNidoranFGfx26_1:
+.incbin "baserom.gba", 0x64D50C, 0x40
+sNidoranFSprites26:
+ax_sprite sNidoranFGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx27:
+.incbin "baserom.gba", 0x64D574, 0x60
+sNidoranFGfx27_1:
+.incbin "baserom.gba", 0x64D5D4, 0x60
+sNidoranFGfx27_2:
+.incbin "baserom.gba", 0x64D634, 0x60
+sNidoranFSprites27:
+ax_sprite sNidoranFGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranFGfx28:
+.incbin "baserom.gba", 0x64D6CC, 0x40
+sNidoranFGfx28_1:
+.incbin "baserom.gba", 0x64D70C, 0x40
+sNidoranFGfx28_2:
+.incbin "baserom.gba", 0x64D74C, 0x20
+sNidoranFSprites28:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx28, 0x40
+ax_sprite 0, 0x60
+ax_sprite sNidoranFGfx28_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sNidoranFGfx28_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNidoranFGfx29:
+.incbin "baserom.gba", 0x64D7AC, 0x40
+sNidoranFGfx29_1:
+.incbin "baserom.gba", 0x64D7EC, 0x60
+sNidoranFGfx29_2:
+.incbin "baserom.gba", 0x64D84C, 0x60
+sNidoranFGfx29_3:
+.incbin "baserom.gba", 0x64D8AC, 0x20
+sNidoranFSprites29:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx30:
+.incbin "baserom.gba", 0x64D91C, 0x20
+sNidoranFGfx30_1:
+.incbin "baserom.gba", 0x64D93C, 0x20
+sNidoranFGfx30_2:
+.incbin "baserom.gba", 0x64D95C, 0x40
+sNidoranFSprites30:
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx30, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx30_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx30_2, 0x40
+ax_sprite_terminator
+sNidoranFGfx31:
+.incbin "baserom.gba", 0x64D9D4, 0x60
+sNidoranFGfx31_1:
+.incbin "baserom.gba", 0x64DA34, 0x60
+sNidoranFGfx31_2:
+.incbin "baserom.gba", 0x64DA94, 0x40
+sNidoranFGfx31_3:
+.incbin "baserom.gba", 0x64DAD4, 0x40
+sNidoranFSprites31:
+ax_sprite sNidoranFGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoranFGfx32:
+.incbin "baserom.gba", 0x64DB5C, 0x40
+sNidoranFGfx32_1:
+.incbin "baserom.gba", 0x64DB9C, 0x20
+sNidoranFGfx32_2:
+.incbin "baserom.gba", 0x64DBBC, 0x20
+sNidoranFSprites32:
+ax_sprite sNidoranFGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx32_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx32_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx33:
+.incbin "baserom.gba", 0x64DC14, 0x40
+sNidoranFGfx33_1:
+.incbin "baserom.gba", 0x64DC54, 0x60
+sNidoranFGfx33_2:
+.incbin "baserom.gba", 0x64DCB4, 0x40
+sNidoranFGfx33_3:
+.incbin "baserom.gba", 0x64DCF4, 0x20
+sNidoranFSprites33:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx33_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx34:
+.incbin "baserom.gba", 0x64DD64, 0x60
+sNidoranFGfx34_1:
+.incbin "baserom.gba", 0x64DDC4, 0x20
+sNidoranFSprites34:
+ax_sprite sNidoranFGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx34_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sNidoranFGfx35:
+.incbin "baserom.gba", 0x64DE0C, 0x40
+sNidoranFGfx35_1:
+.incbin "baserom.gba", 0x64DE4C, 0x40
+sNidoranFGfx35_2:
+.incbin "baserom.gba", 0x64DE8C, 0x60
+sNidoranFGfx35_3:
+.incbin "baserom.gba", 0x64DEEC, 0x40
+sNidoranFSprites35:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidoranFGfx36:
+.incbin "baserom.gba", 0x64DF7C, 0x60
+sNidoranFGfx36_1:
+.incbin "baserom.gba", 0x64DFDC, 0x60
+sNidoranFGfx36_2:
+.incbin "baserom.gba", 0x64E03C, 0x60
+sNidoranFSprites36:
+ax_sprite sNidoranFGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranFGfx37:
+.incbin "baserom.gba", 0x64E0D4, 0x60
+sNidoranFGfx37_1:
+.incbin "baserom.gba", 0x64E134, 0x60
+sNidoranFGfx37_2:
+.incbin "baserom.gba", 0x64E194, 0x60
+sNidoranFGfx37_3:
+.incbin "baserom.gba", 0x64E1F4, 0x20
+sNidoranFSprites37:
+ax_sprite sNidoranFGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx37_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx37_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranFGfx38:
+.incbin "baserom.gba", 0x64E25C, 0x40
+sNidoranFGfx38_1:
+.incbin "baserom.gba", 0x64E29C, 0x60
+sNidoranFGfx38_2:
+.incbin "baserom.gba", 0x64E2FC, 0x60
+sNidoranFSprites38:
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranFGfx39:
+.incbin "baserom.gba", 0x64E39C, 0x60
+sNidoranFGfx39_1:
+.incbin "baserom.gba", 0x64E3FC, 0x60
+sNidoranFGfx39_2:
+.incbin "baserom.gba", 0x64E45C, 0x60
+sNidoranFSprites39:
+ax_sprite sNidoranFGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx39_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranFGfx40:
+.incbin "baserom.gba", 0x64E4F4, 0x40
+sNidoranFGfx40_1:
+.incbin "baserom.gba", 0x64E534, 0x60
+sNidoranFGfx40_2:
+.incbin "baserom.gba", 0x64E594, 0x60
+sNidoranFSprites40:
+ax_sprite sNidoranFGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoranFGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranFGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranFGfx41:
+.incbin "baserom.gba", 0x64E62C, 0x100
+sNidoranFSprites41:
+ax_sprite sNidoranFGfx41, 0x100
+ax_sprite_terminator
+sNidoranFGfx42:
+.incbin "baserom.gba", 0x64E73C, 0x100
+sNidoranFSprites42:
+ax_sprite sNidoranFGfx42, 0x100
+ax_sprite_terminator
+sNidoranFGfx43:
+.incbin "baserom.gba", 0x64E84C, 0x200
+sNidoranFSprites43:
+ax_sprite sNidoranFGfx43, 0x200
+ax_sprite_terminator
+sNidoranFGfx44:
+.incbin "baserom.gba", 0x64EA5C, 0x200
+sNidoranFSprites44:
+ax_sprite sNidoranFGfx44, 0x200
+ax_sprite_terminator
+sNidoranFGfx45:
+.incbin "baserom.gba", 0x64EC6C, 0x200
+sNidoranFSprites45:
+ax_sprite sNidoranFGfx45, 0x200
+ax_sprite_terminator
+sNidoranFGfx46:
+.incbin "baserom.gba", 0x64EE7C, 0x200
+sNidoranFSprites46:
+ax_sprite sNidoranFGfx46, 0x200
+ax_sprite_terminator
+sNidoranFGfx47:
+.incbin "baserom.gba", 0x64F08C, 0x200
+sNidoranFSprites47:
+ax_sprite sNidoranFGfx47, 0x200
+ax_sprite_terminator
+sAxPosesNidoranF:
+.4byte sNidoranFPose1
+.4byte sNidoranFPose2
+.4byte sNidoranFPose3
+.4byte sNidoranFPose4
+.4byte sNidoranFPose5
+.4byte sNidoranFPose6
+.4byte sNidoranFPose7
+.4byte sNidoranFPose8
+.4byte sNidoranFPose9
+.4byte sNidoranFPose10
+.4byte sNidoranFPose11
+.4byte sNidoranFPose12
+.4byte sNidoranFPose13
+.4byte sNidoranFPose14
+.4byte sNidoranFPose15
+.4byte sNidoranFPose16
+.4byte sNidoranFPose17
+.4byte sNidoranFPose18
+.4byte sNidoranFPose19
+.4byte sNidoranFPose20
+.4byte sNidoranFPose21
+.4byte sNidoranFPose22
+.4byte sNidoranFPose23
+.4byte sNidoranFPose24
+.4byte sNidoranFPose25
+.4byte sNidoranFPose26
+.4byte sNidoranFPose27
+.4byte sNidoranFPose28
+.4byte sNidoranFPose29
+.4byte sNidoranFPose30
+.4byte sNidoranFPose31
+.4byte sNidoranFPose32
+.4byte sNidoranFPose33
+.4byte sNidoranFPose34
+.4byte sNidoranFPose35
+.4byte sNidoranFPose36
+.4byte sNidoranFPose37
+.4byte sNidoranFPose38
+.4byte sNidoranFPose39
+.4byte sNidoranFPose40
+.4byte sNidoranFPose41
+.4byte sNidoranFPose42
+.4byte sNidoranFPose43
+.4byte sNidoranFPose44
+.4byte sNidoranFPose45
+.4byte sNidoranFPose46
+.4byte sNidoranFPose47
+.4byte sNidoranFPose48
+.4byte sNidoranFPose49
+.4byte sNidoranFPose50
+.4byte sNidoranFPose51
+.4byte sNidoranFPose52
+.4byte sNidoranFPose53
+.4byte sNidoranFPose54
+.4byte sNidoranFPose55
+.4byte sNidoranFPose56
+.4byte sNidoranFPose57
+.4byte sNidoranFPose58
+.4byte sNidoranFPose59
+.4byte sNidoranFPose60
+.4byte sNidoranFPose61
+.4byte sNidoranFPose62
+.4byte sNidoranFPose63
+.4byte sNidoranFPose64
+.4byte sNidoranFPose65
+.4byte sNidoranFPose66
+.4byte sNidoranFPose67
+.4byte sNidoranFPose68
+.4byte sNidoranFPose69
+.4byte sNidoranFPose70
+.4byte sNidoranFPose71
+.4byte sNidoranFPose72
+.4byte sNidoranFPose73
+.4byte sNidoranFPose74
+.4byte sNidoranFPose75
+.4byte sNidoranFPose76
+.4byte sNidoranFPose77
+.4byte sNidoranFPose78
+.4byte sNidoranFPose79
+.4byte sNidoranFPose80
+.4byte sNidoranFPose81
+.4byte sNidoranFPose82
+.4byte sNidoranFPose83
+.4byte sNidoranFPose84
+.4byte sNidoranFPose85
+.4byte sNidoranFPose86
+.4byte sNidoranFPose87
+.4byte sNidoranFPose88
+.4byte sNidoranFPose89
+.4byte sNidoranFPose90
+.4byte sNidoranFPose91
+.4byte sNidoranFPose92
+.4byte sNidoranFPose93
+.4byte sNidoranFPose94
+.4byte sNidoranFPose95
+.4byte sNidoranFPose96
+.4byte sNidoranFPose97
+.4byte sNidoranFPose98
+.4byte sNidoranFPose99
+.4byte sNidoranFPose100
+.4byte sNidoranFPose101
+.4byte sNidoranFPose102
+.4byte sNidoranFPose103
+.4byte sNidoranFPose104
+.4byte sNidoranFPose105
+.4byte sNidoranFPose106
+.4byte sNidoranFPose107
+.4byte sNidoranFPose108
+.4byte sNidoranFPose109
+.4byte sNidoranFPose110
+.4byte sNidoranFPose111
+.4byte sNidoranFPose112
+.4byte sNidoranFPose113
+.4byte sNidoranFPose114
+.4byte sNidoranFPose115
+.4byte sNidoranFPose116
+.4byte sNidoranFPose117
+.4byte sNidoranFPose118
+.4byte sNidoranFPose119
+.4byte sNidoranFPose120
+.4byte sNidoranFPose121
+.4byte sNidoranFPose122
+.4byte sNidoranFPose123
+.4byte sNidoranFPose124
+.4byte sNidoranFPose125
+.4byte sNidoranFPose126
+.4byte sNidoranFPose127
+.4byte sNidoranFPose128
+.4byte sNidoranFPose129
+.4byte sNidoranFPose130
+.4byte sNidoranFPose131
+.4byte sNidoranFPose132
+.4byte sNidoranFPose133
+.4byte sNidoranFPose134
+.4byte sNidoranFPose135
+.4byte sNidoranFPose136
+.4byte sNidoranFPose137
+.4byte sNidoranFPose138
+.4byte sNidoranFPose139
+.4byte sNidoranFPose140
+.4byte sNidoranFPose141
+.4byte sNidoranFPose142
+.4byte sNidoranFPose143
+.4byte sNidoranFPose144
+.4byte sNidoranFPose145
+.4byte sNidoranFPose146
+.4byte sNidoranFPose147
+.4byte sNidoranFPose148
+.4byte sNidoranFPose149
+.4byte sNidoranFPose150
+.4byte sNidoranFPose151
+.4byte sNidoranFPose152
+.4byte sNidoranFPose153
+.4byte sNidoranFPose154
+.4byte sNidoranFPose155
+.4byte sNidoranFPose156
+.4byte sNidoranFPose157
+.4byte sNidoranFPose158
+.4byte sNidoranFPose159
+.4byte sNidoranFPose160
+.4byte sNidoranFPose161
+.4byte sNidoranFPose162
+.4byte sNidoranFPose163
+.4byte sNidoranFPose164
+.4byte sNidoranFPose165
+.4byte sNidoranFPose166
+.4byte sNidoranFPose167
+.4byte sNidoranFPose168
+.4byte sNidoranFPose169
+.4byte sNidoranFPose170
+.4byte sNidoranFPose171
+.4byte sNidoranFPose172
+.4byte sNidoranFPose173
+.4byte sNidoranFPose174
+.4byte sNidoranFPose175
+.4byte sNidoranFPose176
+.4byte sNidoranFPose177
+.4byte sNidoranFPose178
+.4byte sNidoranFPose179
+.4byte sNidoranFPose180
+.4byte sNidoranFPose181
+.4byte sNidoranFPose182
+.4byte sNidoranFPose183
+.4byte sNidoranFPose184
+.4byte sNidoranFPose185
+.4byte sNidoranFPose186
+.4byte sNidoranFPose187
+.4byte sNidoranFPose188
+.4byte sNidoranFPose189
+.4byte sNidoranFPose190
+.4byte sNidoranFPose191
+.4byte sNidoranFPose192
+.4byte sNidoranFPose193
+.4byte sNidoranFPose194
+.4byte sNidoranFPose195
+.4byte sNidoranFPose196
+.4byte sNidoranFPose197
+.4byte sNidoranFPose198
+.4byte sNidoranFPose199
+.4byte sNidoranFPose200
+.4byte sNidoranFPose201
+.4byte sNidoranFPose202
+sAxPositionsNidoranF:
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -1, 	  -5,    0, 	   3,    0, 	  -1,   -6
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+.2byte    7,   -7, 	   9,   -5, 	   2,   -1, 	   0,   -8
+.2byte    7,    0, 	   7,    2, 	   2,    4, 	   0,   -4
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -7, 	   6,   -4, 	  -1,   -8
+.2byte    8,   -3, 	   6,   -2, 	   6,    0, 	   0,   -8
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    8,  -15, 	   2,  -11, 	   8,   -9, 	   1,  -12
+.2byte    7,  -11, 	   0,   -8, 	   7,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   3,  -14, 	  -5,  -14, 	  -1,  -13
+.2byte   -1,  -16, 	   3,  -12, 	  -5,  -12, 	  -1,  -13
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte  -10,  -15, 	  -4,  -11, 	 -10,   -9, 	  -3,  -12
+.2byte   -9,  -11, 	  -2,   -8, 	  -9,   -5, 	  -1,  -10
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -8, 	  -8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte  -10,   -3, 	  -8,   -2, 	  -8,    0, 	  -2,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -9,   -7, 	 -11,   -5, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,    0, 	  -9,    2, 	  -4,    4, 	  -2,   -4
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -1, 	  -5,    0, 	   3,    0, 	  -1,   -6
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+.2byte    7,   -7, 	   9,   -5, 	   2,   -1, 	   0,   -8
+.2byte    7,    0, 	   7,    2, 	   2,    4, 	   0,   -4
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -7, 	   6,   -4, 	  -1,   -8
+.2byte    7,   -3, 	   5,   -2, 	   5,    0, 	  -1,   -8
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    6,  -11, 	   0,   -7, 	   6,   -5, 	  -1,   -8
+.2byte    6,   -9, 	  -1,   -6, 	   6,   -3, 	  -2,   -8
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	   3,   -6, 	  -5,   -6, 	  -1,   -7
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte   -8,  -11, 	  -2,   -7, 	  -8,   -5, 	  -1,   -8
+.2byte   -8,   -9, 	  -1,   -6, 	  -8,   -3, 	   0,   -8
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -8, 	  -8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte   -8,   -3, 	  -6,   -2, 	  -6,    0, 	   0,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -9,   -7, 	 -11,   -5, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,    0, 	  -9,    2, 	  -4,    4, 	  -2,   -4
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte    2,   -2, 	   4,    1, 	   8,   -6, 	   0,   -3
+.2byte    2,   -2, 	   4,    1, 	   8,   -6, 	   0,   -3
+.2byte   -2,   -2, 	  -7,   -3, 	  -1,    2, 	   0,   -3
+.2byte   -2,   -2, 	  -7,   -3, 	  -1,    2, 	   0,   -3
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+.2byte    1,   -2, 	  -2,    1, 	  -8,   -4, 	  -2,   -4
+.2byte    1,   -2, 	  -2,    1, 	  -8,   -4, 	  -2,   -4
+.2byte    7,   -1, 	   6,   -6, 	   5,    1, 	   2,   -3
+.2byte    7,   -1, 	   6,   -6, 	   5,    1, 	   2,   -3
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    7,   -7, 	   2,    0, 	  -1,   -7, 	  -1,   -6
+.2byte    7,   -7, 	   2,    0, 	  -1,   -7, 	  -1,   -6
+.2byte    8,   -6, 	  -1,  -12, 	   7,   -4, 	   1,   -6
+.2byte    8,   -6, 	  -1,  -12, 	   7,   -4, 	   1,   -6
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -7, 	   3,   -5, 	   4,   -5, 	  -1,   -5
+.2byte    6,   -7, 	   3,   -5, 	   4,   -5, 	  -1,   -5
+.2byte    2,  -10, 	  -6,  -11, 	   1,   -8, 	   0,   -6
+.2byte    2,  -10, 	  -6,  -11, 	   1,   -8, 	   0,   -6
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -3,  -10, 	  -3,   -8, 	  -6,   -5, 	  -1,   -6
+.2byte   -3,  -10, 	  -3,   -8, 	  -6,   -5, 	  -1,   -6
+.2byte    0,  -10, 	   3,   -4, 	   0,   -8, 	  -3,   -7
+.2byte    0,  -10, 	   3,   -4, 	   0,   -8, 	  -3,   -7
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte   -8,   -7, 	  -5,   -5, 	  -6,   -5, 	  -1,   -5
+.2byte   -8,   -7, 	  -5,   -5, 	  -6,   -5, 	  -1,   -5
+.2byte   -4,  -10, 	   4,  -11, 	  -3,   -8, 	  -2,   -6
+.2byte   -4,  -10, 	   4,  -11, 	  -3,   -8, 	  -2,   -6
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -7, 	  -4,    0, 	  -1,   -7, 	  -1,   -6
+.2byte   -9,   -7, 	  -4,    0, 	  -1,   -7, 	  -1,   -6
+.2byte  -10,   -6, 	  -1,  -12, 	  -9,   -4, 	  -3,   -6
+.2byte  -10,   -6, 	  -1,  -12, 	  -9,   -4, 	  -3,   -6
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -3,   -2, 	   0,    1, 	   6,   -4, 	   0,   -4
+.2byte   -3,   -2, 	   0,    1, 	   6,   -4, 	   0,   -4
+.2byte   -9,   -1, 	  -8,   -6, 	  -7,    1, 	  -4,   -3
+.2byte   -9,   -1, 	  -8,   -6, 	  -7,    1, 	  -4,   -3
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -1,    1, 	  -5,    2, 	   3,    2, 	  -1,   -6
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+.2byte    5,   -1, 	   7,    1, 	   0,    2, 	   0,   -5
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    7,   -5, 	   5,   -3, 	   4,    0, 	  -1,   -7
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    7,   -8, 	   0,   -6, 	   6,   -4, 	  -1,   -8
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   3,   -7, 	  -5,   -7, 	  -1,   -7
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte   -9,   -8, 	  -2,   -6, 	  -8,   -4, 	  -1,   -8
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    0, 	  -1,   -7
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -7,   -1, 	  -9,    1, 	  -2,    2, 	  -2,   -5
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -6,   -1, 	  -8,    0, 	  -4,    2, 	   0,   -5
+.2byte   -6,    0, 	  -8,    0, 	  -4,    2, 	  -1,   -4
+.2byte    0,   -5, 	  -5,  -12, 	   5,  -12, 	   0,   -8
+.2byte    3,   -4, 	   4,  -12, 	  -2,  -10, 	  -1,   -6
+.2byte    4,   -7, 	   1,  -15, 	   0,  -13, 	  -1,   -6
+.2byte    6,  -10, 	   1,  -13, 	   6,  -11, 	   0,   -7
+.2byte   -1,  -11, 	   4,   -7, 	  -6,   -7, 	  -1,   -7
+.2byte   -7,  -10, 	  -2,  -13, 	  -7,  -11, 	  -1,   -7
+.2byte   -5,   -7, 	  -2,  -15, 	  -1,  -13, 	   0,   -6
+.2byte   -4,   -4, 	  -5,  -12, 	   1,  -10, 	   0,   -6
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -1, 	  -5,    0, 	   3,    0, 	  -1,   -6
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+.2byte    7,   -7, 	   9,   -5, 	   2,   -1, 	   0,   -8
+.2byte    7,    0, 	   7,    2, 	   2,    4, 	   0,   -4
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -7, 	   6,   -4, 	  -1,   -8
+.2byte    8,   -3, 	   6,   -2, 	   6,    0, 	   0,   -8
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    8,  -15, 	   2,  -11, 	   8,   -9, 	   1,  -12
+.2byte    7,  -11, 	   0,   -8, 	   7,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   3,  -14, 	  -5,  -14, 	  -1,  -13
+.2byte   -1,  -16, 	   3,  -12, 	  -5,  -12, 	  -1,  -13
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte  -10,  -15, 	  -4,  -11, 	 -10,   -9, 	  -3,  -12
+.2byte   -9,  -11, 	  -2,   -8, 	  -9,   -5, 	  -1,  -10
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -8, 	  -8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte  -10,   -3, 	  -8,   -2, 	  -8,    0, 	  -2,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -9,   -7, 	 -11,   -5, 	  -4,   -1, 	  -2,   -8
+.2byte   -9,    0, 	  -9,    2, 	  -4,    4, 	  -2,   -4
+.2byte   -1,    1, 	  -5,    2, 	   3,    2, 	  -1,   -6
+.2byte   -7,   -1, 	  -9,    1, 	  -2,    2, 	  -2,   -5
+.2byte   -9,   -5, 	  -7,   -3, 	  -6,    0, 	  -1,   -7
+.2byte   -9,   -8, 	  -2,   -6, 	  -8,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   3,   -7, 	  -5,   -7, 	  -1,   -7
+.2byte    7,   -8, 	   0,   -6, 	   6,   -4, 	  -1,   -8
+.2byte    7,   -5, 	   5,   -3, 	   4,    0, 	  -1,   -7
+.2byte    5,   -1, 	   7,    1, 	   0,    2, 	   0,   -5
+.2byte   -2,   -2, 	  -7,   -3, 	  -1,    2, 	   0,   -3
+.2byte    5,   -1, 	   4,   -6, 	   3,    1, 	   0,   -3
+.2byte    7,   -5, 	  -2,  -11, 	   6,   -3, 	   0,   -5
+.2byte    2,  -10, 	  -6,  -11, 	   1,   -8, 	   0,   -6
+.2byte    1,  -10, 	   4,   -4, 	   1,   -8, 	  -2,   -7
+.2byte   -4,  -10, 	   4,  -11, 	  -3,   -8, 	  -2,   -6
+.2byte   -9,   -5, 	   0,  -11, 	  -8,   -3, 	  -2,   -5
+.2byte   -7,   -1, 	  -6,   -6, 	  -5,    1, 	  -2,   -3
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -1,   -4, 	  -6,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -1, 	  -5,    0, 	   3,    0, 	  -1,   -6
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+.2byte    6,   -7, 	   8,   -5, 	   1,   -1, 	  -1,   -8
+.2byte    7,    0, 	   7,    2, 	   2,    4, 	   0,   -4
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -7, 	   6,   -4, 	  -1,   -8
+.2byte    8,   -3, 	   6,   -2, 	   6,    0, 	   0,   -8
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    6,  -15, 	   0,  -11, 	   6,   -9, 	  -1,  -12
+.2byte    7,  -11, 	   0,   -8, 	   7,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   3,  -14, 	  -5,  -14, 	  -1,  -13
+.2byte   -1,  -16, 	   3,  -12, 	  -5,  -12, 	  -1,  -13
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte   -8,  -15, 	  -2,  -11, 	  -8,   -9, 	  -1,  -12
+.2byte   -9,  -11, 	  -2,   -8, 	  -9,   -5, 	  -1,  -10
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -9,   -8, 	  -8,   -7, 	  -8,   -4, 	  -1,   -8
+.2byte  -10,   -3, 	  -8,   -2, 	  -8,    0, 	  -2,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -8,   -7, 	 -10,   -5, 	  -3,   -1, 	  -1,   -8
+.2byte   -9,    0, 	  -9,    2, 	  -4,    4, 	  -2,   -4
+.2byte   -1,    1, 	  -5,    2, 	   3,    2, 	  -1,   -6
+.2byte   -6,   -1, 	  -8,    1, 	  -1,    2, 	  -1,   -5
+.2byte   -8,   -5, 	  -6,   -3, 	  -5,    0, 	   0,   -7
+.2byte   -8,   -8, 	  -1,   -6, 	  -7,   -4, 	   0,   -8
+.2byte   -1,  -11, 	   3,   -7, 	  -5,   -7, 	  -1,   -7
+.2byte    7,   -8, 	   0,   -6, 	   6,   -4, 	  -1,   -8
+.2byte    7,   -5, 	   5,   -3, 	   4,    0, 	  -1,   -7
+.2byte    5,   -1, 	   7,    1, 	   0,    2, 	   0,   -5
+.2byte   -1,   -3, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -7,   -5, 	  -7,   -1, 	  -1,    2, 	  -1,   -6
+.2byte   -8,   -6, 	  -5,   -3, 	  -5,    0, 	  -1,   -7
+.2byte   -8,  -12, 	  -1,   -5, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -13, 	   3,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte    6,  -12, 	  -1,   -5, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -6, 	   3,   -3, 	   3,    0, 	  -1,   -7
+.2byte    5,   -5, 	   5,   -1, 	  -1,    2, 	  -1,   -6
+sNidoranFAnimTable1:
+.4byte sNidoranFAnims_1_1
+.4byte sNidoranFAnims_1_2
+.4byte sNidoranFAnims_1_3
+.4byte sNidoranFAnims_1_4
+.4byte sNidoranFAnims_1_5
+.4byte sNidoranFAnims_1_6
+.4byte sNidoranFAnims_1_7
+.4byte sNidoranFAnims_1_8
+sNidoranFAnimTable2:
+.4byte sNidoranFAnims_2_1
+.4byte sNidoranFAnims_2_2
+.4byte sNidoranFAnims_2_3
+.4byte sNidoranFAnims_2_4
+.4byte sNidoranFAnims_2_5
+.4byte sNidoranFAnims_2_6
+.4byte sNidoranFAnims_2_7
+.4byte sNidoranFAnims_2_8
+sNidoranFAnimTable3:
+.4byte sNidoranFAnims_3_1
+.4byte sNidoranFAnims_3_2
+.4byte sNidoranFAnims_3_3
+.4byte sNidoranFAnims_3_4
+.4byte sNidoranFAnims_3_5
+.4byte sNidoranFAnims_3_6
+.4byte sNidoranFAnims_3_7
+.4byte sNidoranFAnims_3_8
+sNidoranFAnimTable4:
+.4byte sNidoranFAnims_4_1
+.4byte sNidoranFAnims_4_2
+.4byte sNidoranFAnims_4_3
+.4byte sNidoranFAnims_4_4
+.4byte sNidoranFAnims_4_5
+.4byte sNidoranFAnims_4_6
+.4byte sNidoranFAnims_4_7
+.4byte sNidoranFAnims_4_8
+sNidoranFAnimTable5:
+.4byte sNidoranFAnims_5_1
+.4byte sNidoranFAnims_5_2
+.4byte sNidoranFAnims_5_3
+.4byte sNidoranFAnims_5_4
+.4byte sNidoranFAnims_5_5
+.4byte sNidoranFAnims_5_6
+.4byte sNidoranFAnims_5_7
+.4byte sNidoranFAnims_5_8
+sNidoranFAnimTable6:
+.4byte sNidoranFAnims_6_1
+.4byte sNidoranFAnims_6_1
+.4byte sNidoranFAnims_6_1
+.4byte sNidoranFAnims_6_1
+.4byte sNidoranFAnims_6_1
+.4byte sNidoranFAnims_6_1
+.4byte sNidoranFAnims_6_1
+.4byte sNidoranFAnims_6_1
+sNidoranFAnimTable7:
+.4byte sNidoranFAnims_7_1
+.4byte sNidoranFAnims_7_2
+.4byte sNidoranFAnims_7_3
+.4byte sNidoranFAnims_7_4
+.4byte sNidoranFAnims_7_5
+.4byte sNidoranFAnims_7_6
+.4byte sNidoranFAnims_7_7
+.4byte sNidoranFAnims_7_8
+sNidoranFAnimTable8:
+.4byte sNidoranFAnims_8_1
+.4byte sNidoranFAnims_8_2
+.4byte sNidoranFAnims_8_3
+.4byte sNidoranFAnims_8_4
+.4byte sNidoranFAnims_8_5
+.4byte sNidoranFAnims_8_6
+.4byte sNidoranFAnims_8_7
+.4byte sNidoranFAnims_8_8
+sNidoranFAnimTable9:
+.4byte sNidoranFAnims_9_1
+.4byte sNidoranFAnims_9_2
+.4byte sNidoranFAnims_9_3
+.4byte sNidoranFAnims_9_4
+.4byte sNidoranFAnims_9_5
+.4byte sNidoranFAnims_9_6
+.4byte sNidoranFAnims_9_7
+.4byte sNidoranFAnims_9_8
+sNidoranFAnimTable10:
+.4byte sNidoranFAnims_10_1
+.4byte sNidoranFAnims_10_2
+.4byte sNidoranFAnims_10_3
+.4byte sNidoranFAnims_10_4
+.4byte sNidoranFAnims_10_5
+.4byte sNidoranFAnims_10_6
+.4byte sNidoranFAnims_10_7
+.4byte sNidoranFAnims_10_8
+sNidoranFAnimTable11:
+.4byte sNidoranFAnims_11_1
+.4byte sNidoranFAnims_11_2
+.4byte sNidoranFAnims_11_3
+.4byte sNidoranFAnims_11_4
+.4byte sNidoranFAnims_11_5
+.4byte sNidoranFAnims_11_6
+.4byte sNidoranFAnims_11_7
+.4byte sNidoranFAnims_11_8
+sNidoranFAnimTable12:
+.4byte sNidoranFAnims_12_1
+.4byte sNidoranFAnims_12_2
+.4byte sNidoranFAnims_12_3
+.4byte sNidoranFAnims_12_4
+.4byte sNidoranFAnims_12_5
+.4byte sNidoranFAnims_12_6
+.4byte sNidoranFAnims_12_7
+.4byte sNidoranFAnims_12_8
+sNidoranFAnimTable13:
+.4byte sNidoranFAnims_13_1
+.4byte sNidoranFAnims_13_2
+.4byte sNidoranFAnims_13_3
+.4byte sNidoranFAnims_13_4
+.4byte sNidoranFAnims_13_5
+.4byte sNidoranFAnims_13_6
+.4byte sNidoranFAnims_13_7
+.4byte sNidoranFAnims_13_8
+sAxAnimationsNidoranF:
+.4byte sNidoranFAnimTable1
+.4byte sNidoranFAnimTable2
+.4byte sNidoranFAnimTable3
+.4byte sNidoranFAnimTable4
+.4byte sNidoranFAnimTable5
+.4byte sNidoranFAnimTable6
+.4byte sNidoranFAnimTable7
+.4byte sNidoranFAnimTable8
+.4byte sNidoranFAnimTable9
+.4byte sNidoranFAnimTable10
+.4byte sNidoranFAnimTable11
+.4byte sNidoranFAnimTable12
+.4byte sNidoranFAnimTable13
+sAxSpritesNidoranF:
+.4byte sNidoranFSprites1
+.4byte sNidoranFSprites2
+.4byte sNidoranFSprites3
+.4byte sNidoranFSprites4
+.4byte sNidoranFSprites5
+.4byte sNidoranFSprites6
+.4byte sNidoranFSprites7
+.4byte sNidoranFSprites8
+.4byte sNidoranFSprites9
+.4byte sNidoranFSprites10
+.4byte sNidoranFSprites11
+.4byte sNidoranFSprites12
+.4byte sNidoranFSprites13
+.4byte sNidoranFSprites14
+.4byte sNidoranFSprites15
+.4byte sNidoranFSprites16
+.4byte sNidoranFSprites17
+.4byte sNidoranFSprites18
+.4byte sNidoranFSprites19
+.4byte sNidoranFSprites20
+.4byte sNidoranFSprites21
+.4byte sNidoranFSprites22
+.4byte sNidoranFSprites23
+.4byte sNidoranFSprites24
+.4byte sNidoranFSprites25
+.4byte sNidoranFSprites26
+.4byte sNidoranFSprites27
+.4byte sNidoranFSprites28
+.4byte sNidoranFSprites29
+.4byte sNidoranFSprites30
+.4byte sNidoranFSprites31
+.4byte sNidoranFSprites32
+.4byte sNidoranFSprites33
+.4byte sNidoranFSprites34
+.4byte sNidoranFSprites35
+.4byte sNidoranFSprites36
+.4byte sNidoranFSprites37
+.4byte sNidoranFSprites38
+.4byte sNidoranFSprites39
+.4byte sNidoranFSprites40
+.4byte sNidoranFSprites41
+.4byte sNidoranFSprites42
+.4byte sNidoranFSprites43
+.4byte sNidoranFSprites44
+.4byte sNidoranFSprites45
+.4byte sNidoranFSprites46
+.4byte sNidoranFSprites47
+sAxMainNidoranF:
+ax_main sAxPosesNidoranF, sAxAnimationsNidoranF, 13, sAxSpritesNidoranF, sAxPositionsNidoranF

--- a/data/ax/nidoranm.inc
+++ b/data/ax/nidoranm.inc
@@ -1,0 +1,2691 @@
+.global gAxNidoranM
+gAxNidoranM:
+ax_siro sAxMainNidoranM
+sNidoranMPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose3:
+ax_pose 2, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose4:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose5:
+ax_pose 4, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose6:
+ax_pose 5, 0x01f0, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose7:
+ax_pose 6, 0x01ed, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose8:
+ax_pose 7, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose9:
+ax_pose 8, 0x01e9, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose10:
+ax_pose 9, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose11:
+ax_pose 10, 0x01ea, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose12:
+ax_pose 11, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose13:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose14:
+ax_pose 13, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose15:
+ax_pose 14, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose17:
+ax_pose 10, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose18:
+ax_pose 11, 0x01eb, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose19:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose20:
+ax_pose 7, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose21:
+ax_pose 8, 0x01e9, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose22:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose23:
+ax_pose 4, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose24:
+ax_pose 5, 0x01f0, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose26:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose27:
+ax_pose 2, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose28:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose29:
+ax_pose 4, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose30:
+ax_pose 5, 0x01f0, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose31:
+ax_pose 6, 0x01ed, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose32:
+ax_pose 7, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose33:
+ax_pose 8, 0x01eb, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose34:
+ax_pose 9, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose35:
+ax_pose 10, 0x01ea, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose36:
+ax_pose 11, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose37:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose38:
+ax_pose 13, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose39:
+ax_pose 14, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose40:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose41:
+ax_pose 10, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose42:
+ax_pose 11, 0x01eb, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose43:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose44:
+ax_pose 7, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose45:
+ax_pose 8, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose46:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose47:
+ax_pose 4, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose48:
+ax_pose 5, 0x01f0, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose49:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose50:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose51:
+ax_pose 2, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose52:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose53:
+ax_pose 4, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose54:
+ax_pose 5, 0x01f0, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose55:
+ax_pose 6, 0x01ed, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose56:
+ax_pose 7, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose57:
+ax_pose 8, 0x01eb, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose58:
+ax_pose 9, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose59:
+ax_pose 10, 0x01ea, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose60:
+ax_pose 11, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose61:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose62:
+ax_pose 13, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose63:
+ax_pose 14, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose64:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose65:
+ax_pose 10, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose66:
+ax_pose 11, 0x01eb, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose67:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose68:
+ax_pose 7, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose69:
+ax_pose 8, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose70:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose71:
+ax_pose 4, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose72:
+ax_pose 5, 0x01f0, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose73:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose74:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose75:
+ax_pose 2, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose76:
+ax_pose 15, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose77:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose78:
+ax_pose 4, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose79:
+ax_pose 5, 0x01f0, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose80:
+ax_pose 16, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose81:
+ax_pose 6, 0x01ed, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose82:
+ax_pose 7, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose83:
+ax_pose 8, 0x01e9, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose84:
+ax_pose 17, 0x01ec, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose85:
+ax_pose 9, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose86:
+ax_pose 10, 0x01ea, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose87:
+ax_pose 11, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose88:
+ax_pose 18, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose89:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose90:
+ax_pose 13, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose91:
+ax_pose 14, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose92:
+ax_pose 19, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose93:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose94:
+ax_pose 10, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose95:
+ax_pose 11, 0x01eb, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose96:
+ax_pose 18, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose97:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose98:
+ax_pose 7, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose99:
+ax_pose 8, 0x01e9, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose100:
+ax_pose 17, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose101:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose102:
+ax_pose 4, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose103:
+ax_pose 5, 0x01f0, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose104:
+ax_pose 16, 0x01ed, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose105:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose106:
+ax_pose 20, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose107:
+ax_pose 21, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose108:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose109:
+ax_pose 22, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose110:
+ax_pose 23, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose111:
+ax_pose 6, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose112:
+ax_pose 24, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose113:
+ax_pose 25, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose114:
+ax_pose 9, 0x01ed, 0x90eb, 0xac00
+ax_pose_terminator
+sNidoranMPose115:
+ax_pose 26, 0x01ed, 0x90eb, 0xac00
+ax_pose_terminator
+sNidoranMPose116:
+ax_pose 27, 0x01ed, 0x90eb, 0xac00
+ax_pose_terminator
+sNidoranMPose117:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose118:
+ax_pose 28, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose119:
+ax_pose 29, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose120:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose121:
+ax_pose 26, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose122:
+ax_pose 27, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose123:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose124:
+ax_pose 24, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose125:
+ax_pose 25, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose126:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose127:
+ax_pose 22, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose128:
+ax_pose 23, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose129:
+ax_pose 30, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose130:
+ax_pose 31, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose131:
+ax_pose 32, 0x01e7, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose132:
+ax_pose 33, 0x01e8, 0x90f0, 0xac00
+ax_pose_terminator
+sNidoranMPose133:
+ax_pose 34, 0x01e8, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose134:
+ax_pose 35, 0x01e7, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose135:
+ax_pose 36, 0x01e5, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose136:
+ax_pose 35, 0x01e7, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose137:
+ax_pose 34, 0x01e8, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose138:
+ax_pose 33, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sNidoranMPose139:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose140:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose141:
+ax_pose 2, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose142:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose143:
+ax_pose 4, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose144:
+ax_pose 5, 0x01f0, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose145:
+ax_pose 6, 0x01ed, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose146:
+ax_pose 7, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose147:
+ax_pose 8, 0x01e9, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose148:
+ax_pose 9, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose149:
+ax_pose 10, 0x01ea, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose150:
+ax_pose 11, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose151:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose152:
+ax_pose 13, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose153:
+ax_pose 14, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose154:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose155:
+ax_pose 10, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose156:
+ax_pose 11, 0x01eb, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose157:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose158:
+ax_pose 7, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose159:
+ax_pose 8, 0x01e9, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose160:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose161:
+ax_pose 4, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose162:
+ax_pose 5, 0x01f0, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose163:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose164:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose165:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose166:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose167:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose168:
+ax_pose 9, 0x01ed, 0x90eb, 0xac00
+ax_pose_terminator
+sNidoranMPose169:
+ax_pose 6, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose170:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose171:
+ax_pose 15, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose172:
+ax_pose 16, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose173:
+ax_pose 17, 0x01ec, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose174:
+ax_pose 18, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose175:
+ax_pose 19, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose176:
+ax_pose 18, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose177:
+ax_pose 17, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose178:
+ax_pose 16, 0x01ed, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose179:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose180:
+ax_pose 1, 0x01e9, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose181:
+ax_pose 2, 0x01f0, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose182:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose183:
+ax_pose 4, 0x01ea, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose184:
+ax_pose 5, 0x01f0, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose185:
+ax_pose 6, 0x01ed, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose186:
+ax_pose 7, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sNidoranMPose187:
+ax_pose 8, 0x01e9, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose188:
+ax_pose 9, 0x01ed, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose189:
+ax_pose 10, 0x01ea, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose190:
+ax_pose 11, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose191:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose192:
+ax_pose 13, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose193:
+ax_pose 14, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose194:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose195:
+ax_pose 10, 0x01ea, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose196:
+ax_pose 11, 0x01eb, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose197:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose198:
+ax_pose 7, 0x01e9, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose199:
+ax_pose 8, 0x01e9, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose200:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose201:
+ax_pose 4, 0x01ea, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose202:
+ax_pose 5, 0x01f0, 0x80f1, 0xac00
+ax_pose_terminator
+sNidoranMPose203:
+ax_pose 15, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose204:
+ax_pose 16, 0x01ed, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose205:
+ax_pose 17, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose206:
+ax_pose 18, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose207:
+ax_pose 19, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose208:
+ax_pose 18, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sNidoranMPose209:
+ax_pose 17, 0x01ec, 0x90ee, 0xac00
+ax_pose_terminator
+sNidoranMPose210:
+ax_pose 16, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose211:
+ax_pose 0, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose212:
+ax_pose 3, 0x01ee, 0x80f3, 0xac00
+ax_pose_terminator
+sNidoranMPose213:
+ax_pose 6, 0x01ed, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose214:
+ax_pose 9, 0x01ed, 0x80f4, 0xac00
+ax_pose_terminator
+sNidoranMPose215:
+ax_pose 12, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sNidoranMPose216:
+ax_pose 9, 0x01ed, 0x90eb, 0xac00
+ax_pose_terminator
+sNidoranMPose217:
+ax_pose 6, 0x01ed, 0x90ed, 0xac00
+ax_pose_terminator
+sNidoranMPose218:
+ax_pose 3, 0x01ee, 0x90ed, 0xac00
+ax_pose_terminator
+.align 2
+sNidoranMAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 2, 0, 0,
+ax_anim 5, 0, 1, 0, 5, 0, 1,
+ax_anim 6, 0, 2, 0, 3, 0, 3,
+ax_anim 6, 0, 2, 0, 4, 0, 4,
+ax_anim 4, 0, 0, 0, 4, 0, 2,
+ax_anim_terminator
+sNidoranMAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 2, 0, 1, 1,
+ax_anim 5, 0, 4, 3, 0, 2, 2,
+ax_anim 6, 0, 5, 3, -1, 3, 3,
+ax_anim 6, 0, 5, 3, 2, 2, 2,
+ax_anim 4, 0, 3, 2, 2, 2, 2,
+ax_anim_terminator
+sNidoranMAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 3, 0, 3, 0,
+ax_anim 5, 0, 7, 4, 0, 4, 0,
+ax_anim 6, 0, 8, 5, 0, 5, 0,
+ax_anim 6, 0, 8, 6, 3, 6, 0,
+ax_anim 4, 0, 6, 4, 0, 4, 0,
+ax_anim_terminator
+sNidoranMAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 2, -1, 1, -1,
+ax_anim 5, 0, 10, 3, -3, 3, -3,
+ax_anim 6, 0, 11, 4, -7, 4, -4,
+ax_anim 6, 0, 11, 5, -6, 5, -5,
+ax_anim 4, 0, 9, 3, -3, 3, -3,
+ax_anim_terminator
+sNidoranMAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, -1,
+ax_anim 5, 0, 13, 0, -2, 0, -2,
+ax_anim 6, 0, 14, 0, -2, 0, -3,
+ax_anim 6, 0, 14, 0, -3, 0, -4,
+ax_anim 4, 0, 12, 0, -3, 0, -3,
+ax_anim_terminator
+sNidoranMAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -2, -1, -1, -1,
+ax_anim 5, 0, 16, -3, -3, -3, -3,
+ax_anim 6, 0, 17, -4, -7, -4, -4,
+ax_anim 6, 0, 17, -5, -6, -5, -5,
+ax_anim 4, 0, 15, -3, -3, -3, -3,
+ax_anim_terminator
+sNidoranMAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -3, 0, -3, 0,
+ax_anim 5, 0, 19, -4, 0, -4, 0,
+ax_anim 6, 0, 20, -5, 0, -5, 0,
+ax_anim 6, 0, 20, -6, 3, -6, 0,
+ax_anim 4, 0, 18, -4, 0, -4, 0,
+ax_anim_terminator
+sNidoranMAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -2, 0, -1, 1,
+ax_anim 5, 0, 22, -3, 0, -2, 2,
+ax_anim 6, 0, 23, -3, -1, -3, 3,
+ax_anim 6, 0, 23, -3, 2, -2, 2,
+ax_anim 4, 0, 21, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 1, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 0, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNidoranMAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 2, 4, 4,
+ax_anim 1, 0, 28, 11, 7, 11, 11,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 1, 29, 19, 16, 19, 16,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 0, 29, 19, 16, 19, 16,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sNidoranMAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, -4, 4, 0,
+ax_anim 1, 0, 31, 10, -2, 10, 0,
+ax_anim 2, 0, 32, 17, 0, 18, 0,
+ax_anim 2, 1, 32, 17, 1, 18, 1,
+ax_anim 2, 0, 32, 17, 0, 18, 0,
+ax_anim 2, 0, 32, 17, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sNidoranMAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -3, 0, 0,
+ax_anim 1, 2, 34, 4, -10, 4, -6,
+ax_anim 1, 0, 34, 11, -19, 11, -14,
+ax_anim 2, 0, 35, 17, -21, 17, -21,
+ax_anim 2, 1, 35, 18, -20, 18, -20,
+ax_anim 2, 0, 35, 17, -21, 17, -21,
+ax_anim 2, 0, 35, 18, -20, 18, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sNidoranMAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, -1, 0, 0,
+ax_anim 1, 2, 37, 0, -10, 0, -6,
+ax_anim 1, 0, 37, 0, -17, 0, -13,
+ax_anim 2, 0, 38, 0, -20, 0, -20,
+ax_anim 2, 1, 38, 1, -20, 1, -20,
+ax_anim 2, 0, 38, 0, -20, 0, -20,
+ax_anim 2, 0, 38, 1, -20, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sNidoranMAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -3, 0, 0,
+ax_anim 1, 2, 40, -4, -10, -4, -6,
+ax_anim 1, 0, 40, -11, -19, -11, -14,
+ax_anim 2, 0, 41, -17, -21, -17, -21,
+ax_anim 2, 1, 41, -18, -20, -18, -20,
+ax_anim 2, 0, 41, -17, -21, -17, -21,
+ax_anim 2, 0, 41, -18, -20, -18, -20,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sNidoranMAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, -4, -4, 0,
+ax_anim 1, 0, 43, -10, -2, -10, 0,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 1, 44, -17, 1, -17, 1,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 44, -17, 1, -17, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sNidoranMAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 2, -4, 4,
+ax_anim 1, 0, 46, -11, 7, -11, 11,
+ax_anim 2, 0, 47, -18, 17, -18, 17,
+ax_anim 2, 1, 47, -19, 16, -19, 16,
+ax_anim 2, 0, 47, -18, 17, -18, 17,
+ax_anim 2, 0, 47, -18, 17, -18, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 1, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 0, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sNidoranMAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 2, 4, 4,
+ax_anim 1, 0, 52, 11, 7, 11, 11,
+ax_anim 2, 0, 53, 18, 17, 18, 17,
+ax_anim 2, 1, 53, 19, 16, 19, 16,
+ax_anim 2, 0, 53, 18, 17, 18, 17,
+ax_anim 2, 0, 53, 19, 16, 19, 16,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sNidoranMAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, -4, 4, 0,
+ax_anim 1, 0, 55, 10, -2, 10, 0,
+ax_anim 2, 0, 56, 17, 0, 18, 0,
+ax_anim 2, 1, 56, 17, 1, 18, 1,
+ax_anim 2, 0, 56, 17, 0, 18, 0,
+ax_anim 2, 0, 56, 17, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sNidoranMAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -3, 0, 0,
+ax_anim 1, 2, 58, 4, -10, 4, -6,
+ax_anim 1, 0, 58, 11, -19, 11, -14,
+ax_anim 2, 0, 59, 17, -21, 17, -21,
+ax_anim 2, 1, 59, 18, -20, 18, -20,
+ax_anim 2, 0, 59, 17, -21, 17, -21,
+ax_anim 2, 0, 59, 18, -20, 18, -20,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sNidoranMAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, -1, 0, 0,
+ax_anim 1, 2, 61, 0, -10, 0, -6,
+ax_anim 1, 0, 61, 0, -17, 0, -13,
+ax_anim 2, 0, 62, 0, -20, 0, -20,
+ax_anim 2, 1, 62, 1, -20, 1, -20,
+ax_anim 2, 0, 62, 0, -20, 0, -20,
+ax_anim 2, 0, 62, 1, -20, 1, -20,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sNidoranMAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -3, 0, 0,
+ax_anim 1, 2, 64, -4, -10, -4, -6,
+ax_anim 1, 0, 64, -11, -19, -11, -14,
+ax_anim 2, 0, 65, -17, -21, -17, -21,
+ax_anim 2, 1, 65, -18, -20, -18, -20,
+ax_anim 2, 0, 65, -17, -21, -17, -21,
+ax_anim 2, 0, 65, -18, -20, -18, -20,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sNidoranMAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, -4, -4, 0,
+ax_anim 1, 0, 67, -10, -2, -10, 0,
+ax_anim 2, 0, 68, -17, 0, -17, 0,
+ax_anim 2, 1, 68, -17, 1, -17, 1,
+ax_anim 2, 0, 68, -17, 0, -17, 0,
+ax_anim 2, 0, 68, -17, 1, -17, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sNidoranMAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 2, -4, 4,
+ax_anim 1, 0, 70, -11, 7, -11, 11,
+ax_anim 2, 0, 71, -18, 17, -18, 17,
+ax_anim 2, 1, 71, -19, 16, -19, 16,
+ax_anim 2, 0, 71, -18, 17, -18, 17,
+ax_anim 2, 0, 71, -18, 17, -18, 17,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 6, 0, 74, 0, -4, 0, -4,
+ax_anim 1, 2, 75, 0, -1, 0, -1,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 1, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sNidoranMAnims_4_2:
+ax_anim 2, 0, 77, -1, -2, -1, -1,
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 0, 78, -3, -4, -3, -3,
+ax_anim 1, 2, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 1, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 4, 6, 4,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sNidoranMAnims_4_3:
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim 6, 0, 82, -5, 0, -3, 0,
+ax_anim 1, 2, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, -1, 5, -1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 1, 83, 5, -1, 5, -1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, -1, 5, -1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, -1, 5, -1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sNidoranMAnims_4_4:
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 84, -2, 3, -2, 2,
+ax_anim 6, 0, 86, -4, 4, -3, 3,
+ax_anim 1, 2, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 1, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sNidoranMAnims_4_5:
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim 6, 0, 90, 0, 4, 0, 4,
+ax_anim 1, 2, 91, 0, 1, 0, 1,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 1, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sNidoranMAnims_4_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 92, 2, 3, 2, 2,
+ax_anim 6, 0, 94, 4, 4, 3, 3,
+ax_anim 1, 2, 95, -1, 1, -1, 1,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 1, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sNidoranMAnims_4_7:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 6, 0, 98, 5, 0, 3, 0,
+ax_anim 1, 2, 99, -1, 0, -1, 0,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, -1, -5, -1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 1, 99, -5, -1, -5, -1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, -1, -5, -1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, -1, -5, -1,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sNidoranMAnims_4_8:
+ax_anim 2, 0, 101, 1, -2, 1, -1,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 6, 0, 102, 3, -4, 3, -3,
+ax_anim 1, 2, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 1, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 4, -6, 4,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_5_1:
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 3, 0, 105, 0, -5, 0, 0,
+ax_anim 3, 2, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 1, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_5_2:
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 3, 0, 108, 0, -5, 0, 0,
+ax_anim 3, 2, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 1, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_5_3:
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 3, 0, 111, 0, -5, 0, 0,
+ax_anim 3, 2, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 1, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_5_4:
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 3, 0, 114, 0, -5, 0, 0,
+ax_anim 3, 2, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 1, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_5_5:
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 3, 0, 117, 0, -5, 0, 0,
+ax_anim 3, 2, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 1, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_5_6:
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 3, 0, 120, 0, -5, 0, 0,
+ax_anim 3, 2, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 1, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_5_7:
+ax_anim 2, 0, 122, 0, -1, 0, 0,
+ax_anim 2, 0, 122, 0, -3, 0, 0,
+ax_anim 3, 0, 123, 0, -5, 0, 0,
+ax_anim 3, 2, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 1, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_5_8:
+ax_anim 2, 0, 125, 0, -1, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 3, 0, 126, 0, -5, 0, 0,
+ax_anim 3, 2, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 1, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sNidoranMAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sNidoranMAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sNidoranMAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sNidoranMAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sNidoranMAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sNidoranMAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sNidoranMAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -1, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -1, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -1, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -1, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -1, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -1, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 20, 9, 20, 9,
+ax_anim 3, 0, 165, 20, 19, 20, 19,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 4, 15, 4, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 21, 1, 21, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 2, -14, 2, -14,
+ax_anim 2, 0, 162, 11, -20, 11, -20,
+ax_anim 3, 0, 163, 21, -22, 21, -22,
+ax_anim 2, 3, 164, 21, -12, 21, -12,
+ax_anim 2, 0, 165, 17, -5, 17, -5,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 8, -8, 8, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -2, -14, -2, -14,
+ax_anim 2, 0, 162, -11, -20, -11, -20,
+ax_anim 3, 0, 169, -21, -22, -21, -22,
+ax_anim 2, 3, 168, -21, -12, -21, -12,
+ax_anim 2, 0, 167, -17, -5, -17, -5,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -21, 1, -21, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -20, 9, -20, 9,
+ax_anim 3, 0, 167, -20, 19, -20, 19,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -4, 15, -4, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidoranMAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sNidoranMGfx1:
+.incbin "baserom.gba", 0x668FBC, 0x200
+sNidoranMSprites1:
+ax_sprite sNidoranMGfx1, 0x200
+ax_sprite_terminator
+sNidoranMGfx2:
+.incbin "baserom.gba", 0x6691CC, 0x200
+sNidoranMSprites2:
+ax_sprite sNidoranMGfx2, 0x200
+ax_sprite_terminator
+sNidoranMGfx3:
+.incbin "baserom.gba", 0x6693DC, 0x200
+sNidoranMSprites3:
+ax_sprite sNidoranMGfx3, 0x200
+ax_sprite_terminator
+sNidoranMGfx4:
+.incbin "baserom.gba", 0x6695EC, 0x200
+sNidoranMSprites4:
+ax_sprite sNidoranMGfx4, 0x200
+ax_sprite_terminator
+sNidoranMGfx5:
+.incbin "baserom.gba", 0x6697FC, 0x200
+sNidoranMSprites5:
+ax_sprite sNidoranMGfx5, 0x200
+ax_sprite_terminator
+sNidoranMGfx6:
+.incbin "baserom.gba", 0x669A0C, 0x200
+sNidoranMSprites6:
+ax_sprite sNidoranMGfx6, 0x200
+ax_sprite_terminator
+sNidoranMGfx7:
+.incbin "baserom.gba", 0x669C1C, 0x200
+sNidoranMSprites7:
+ax_sprite sNidoranMGfx7, 0x200
+ax_sprite_terminator
+sNidoranMGfx8:
+.incbin "baserom.gba", 0x669E2C, 0x200
+sNidoranMSprites8:
+ax_sprite sNidoranMGfx8, 0x200
+ax_sprite_terminator
+sNidoranMGfx9:
+.incbin "baserom.gba", 0x66A03C, 0x200
+sNidoranMSprites9:
+ax_sprite sNidoranMGfx9, 0x200
+ax_sprite_terminator
+sNidoranMGfx10:
+.incbin "baserom.gba", 0x66A24C, 0x200
+sNidoranMSprites10:
+ax_sprite sNidoranMGfx10, 0x200
+ax_sprite_terminator
+sNidoranMGfx11:
+.incbin "baserom.gba", 0x66A45C, 0x200
+sNidoranMSprites11:
+ax_sprite sNidoranMGfx11, 0x200
+ax_sprite_terminator
+sNidoranMGfx12:
+.incbin "baserom.gba", 0x66A66C, 0x200
+sNidoranMSprites12:
+ax_sprite sNidoranMGfx12, 0x200
+ax_sprite_terminator
+sNidoranMGfx13:
+.incbin "baserom.gba", 0x66A87C, 0x200
+sNidoranMSprites13:
+ax_sprite sNidoranMGfx13, 0x200
+ax_sprite_terminator
+sNidoranMGfx14:
+.incbin "baserom.gba", 0x66AA8C, 0x200
+sNidoranMSprites14:
+ax_sprite sNidoranMGfx14, 0x200
+ax_sprite_terminator
+sNidoranMGfx15:
+.incbin "baserom.gba", 0x66AC9C, 0x200
+sNidoranMSprites15:
+ax_sprite sNidoranMGfx15, 0x200
+ax_sprite_terminator
+sNidoranMGfx16:
+.incbin "baserom.gba", 0x66AEAC, 0x60
+sNidoranMGfx16_1:
+.incbin "baserom.gba", 0x66AF0C, 0x60
+sNidoranMGfx16_2:
+.incbin "baserom.gba", 0x66AF6C, 0x60
+sNidoranMSprites16:
+ax_sprite sNidoranMGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx17:
+.incbin "baserom.gba", 0x66B004, 0x60
+sNidoranMGfx17_1:
+.incbin "baserom.gba", 0x66B064, 0x60
+sNidoranMGfx17_2:
+.incbin "baserom.gba", 0x66B0C4, 0x60
+sNidoranMSprites17:
+ax_sprite sNidoranMGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx18:
+.incbin "baserom.gba", 0x66B15C, 0x60
+sNidoranMGfx18_1:
+.incbin "baserom.gba", 0x66B1BC, 0x60
+sNidoranMGfx18_2:
+.incbin "baserom.gba", 0x66B21C, 0x60
+sNidoranMSprites18:
+ax_sprite sNidoranMGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx19:
+.incbin "baserom.gba", 0x66B2B4, 0x60
+sNidoranMGfx19_1:
+.incbin "baserom.gba", 0x66B314, 0x60
+sNidoranMGfx19_2:
+.incbin "baserom.gba", 0x66B374, 0x60
+sNidoranMSprites19:
+ax_sprite sNidoranMGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx20:
+.incbin "baserom.gba", 0x66B40C, 0xE0
+sNidoranMGfx20_1:
+.incbin "baserom.gba", 0x66B4EC, 0x60
+sNidoranMSprites20:
+ax_sprite sNidoranMGfx20, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx20_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx21:
+.incbin "baserom.gba", 0x66B574, 0x60
+sNidoranMGfx21_1:
+.incbin "baserom.gba", 0x66B5D4, 0x60
+sNidoranMGfx21_2:
+.incbin "baserom.gba", 0x66B634, 0x60
+sNidoranMSprites21:
+ax_sprite sNidoranMGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx22:
+.incbin "baserom.gba", 0x66B6CC, 0x60
+sNidoranMGfx22_1:
+.incbin "baserom.gba", 0x66B72C, 0x60
+sNidoranMGfx22_2:
+.incbin "baserom.gba", 0x66B78C, 0x60
+sNidoranMSprites22:
+ax_sprite sNidoranMGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx23:
+.incbin "baserom.gba", 0x66B824, 0x60
+sNidoranMGfx23_1:
+.incbin "baserom.gba", 0x66B884, 0x60
+sNidoranMGfx23_2:
+.incbin "baserom.gba", 0x66B8E4, 0x60
+sNidoranMSprites23:
+ax_sprite sNidoranMGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx24:
+.incbin "baserom.gba", 0x66B97C, 0x60
+sNidoranMGfx24_1:
+.incbin "baserom.gba", 0x66B9DC, 0x60
+sNidoranMGfx24_2:
+.incbin "baserom.gba", 0x66BA3C, 0x60
+sNidoranMSprites24:
+ax_sprite sNidoranMGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx25:
+.incbin "baserom.gba", 0x66BAD4, 0x60
+sNidoranMGfx25_1:
+.incbin "baserom.gba", 0x66BB34, 0x60
+sNidoranMGfx25_2:
+.incbin "baserom.gba", 0x66BB94, 0x60
+sNidoranMSprites25:
+ax_sprite sNidoranMGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx26:
+.incbin "baserom.gba", 0x66BC2C, 0x60
+sNidoranMGfx26_1:
+.incbin "baserom.gba", 0x66BC8C, 0x60
+sNidoranMGfx26_2:
+.incbin "baserom.gba", 0x66BCEC, 0x60
+sNidoranMSprites26:
+ax_sprite sNidoranMGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx27:
+.incbin "baserom.gba", 0x66BD84, 0x40
+sNidoranMGfx27_1:
+.incbin "baserom.gba", 0x66BDC4, 0x60
+sNidoranMGfx27_2:
+.incbin "baserom.gba", 0x66BE24, 0x60
+sNidoranMSprites27:
+ax_sprite sNidoranMGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidoranMGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx28:
+.incbin "baserom.gba", 0x66BEBC, 0x60
+sNidoranMGfx28_1:
+.incbin "baserom.gba", 0x66BF1C, 0x60
+sNidoranMGfx28_2:
+.incbin "baserom.gba", 0x66BF7C, 0x60
+sNidoranMGfx28_3:
+.incbin "baserom.gba", 0x66BFDC, 0x20
+sNidoranMSprites28:
+ax_sprite sNidoranMGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidoranMGfx28_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidoranMGfx29:
+.incbin "baserom.gba", 0x66C044, 0x60
+sNidoranMGfx29_1:
+.incbin "baserom.gba", 0x66C0A4, 0x60
+sNidoranMGfx29_2:
+.incbin "baserom.gba", 0x66C104, 0x80
+sNidoranMSprites29:
+ax_sprite sNidoranMGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx29_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNidoranMGfx30:
+.incbin "baserom.gba", 0x66C1BC, 0x60
+sNidoranMGfx30_1:
+.incbin "baserom.gba", 0x66C21C, 0x60
+sNidoranMGfx30_2:
+.incbin "baserom.gba", 0x66C27C, 0x60
+sNidoranMSprites30:
+ax_sprite sNidoranMGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidoranMGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNidoranMGfx31:
+.incbin "baserom.gba", 0x66C314, 0x200
+sNidoranMSprites31:
+ax_sprite sNidoranMGfx31, 0x200
+ax_sprite_terminator
+sNidoranMGfx32:
+.incbin "baserom.gba", 0x66C524, 0x200
+sNidoranMSprites32:
+ax_sprite sNidoranMGfx32, 0x200
+ax_sprite_terminator
+sNidoranMGfx33:
+.incbin "baserom.gba", 0x66C734, 0x200
+sNidoranMSprites33:
+ax_sprite sNidoranMGfx33, 0x200
+ax_sprite_terminator
+sNidoranMGfx34:
+.incbin "baserom.gba", 0x66C944, 0x200
+sNidoranMSprites34:
+ax_sprite sNidoranMGfx34, 0x200
+ax_sprite_terminator
+sNidoranMGfx35:
+.incbin "baserom.gba", 0x66CB54, 0x200
+sNidoranMSprites35:
+ax_sprite sNidoranMGfx35, 0x200
+ax_sprite_terminator
+sNidoranMGfx36:
+.incbin "baserom.gba", 0x66CD64, 0x200
+sNidoranMSprites36:
+ax_sprite sNidoranMGfx36, 0x200
+ax_sprite_terminator
+sNidoranMGfx37:
+.incbin "baserom.gba", 0x66CF74, 0x200
+sNidoranMSprites37:
+ax_sprite sNidoranMGfx37, 0x200
+ax_sprite_terminator
+sAxPosesNidoranM:
+.4byte sNidoranMPose1
+.4byte sNidoranMPose2
+.4byte sNidoranMPose3
+.4byte sNidoranMPose4
+.4byte sNidoranMPose5
+.4byte sNidoranMPose6
+.4byte sNidoranMPose7
+.4byte sNidoranMPose8
+.4byte sNidoranMPose9
+.4byte sNidoranMPose10
+.4byte sNidoranMPose11
+.4byte sNidoranMPose12
+.4byte sNidoranMPose13
+.4byte sNidoranMPose14
+.4byte sNidoranMPose15
+.4byte sNidoranMPose16
+.4byte sNidoranMPose17
+.4byte sNidoranMPose18
+.4byte sNidoranMPose19
+.4byte sNidoranMPose20
+.4byte sNidoranMPose21
+.4byte sNidoranMPose22
+.4byte sNidoranMPose23
+.4byte sNidoranMPose24
+.4byte sNidoranMPose25
+.4byte sNidoranMPose26
+.4byte sNidoranMPose27
+.4byte sNidoranMPose28
+.4byte sNidoranMPose29
+.4byte sNidoranMPose30
+.4byte sNidoranMPose31
+.4byte sNidoranMPose32
+.4byte sNidoranMPose33
+.4byte sNidoranMPose34
+.4byte sNidoranMPose35
+.4byte sNidoranMPose36
+.4byte sNidoranMPose37
+.4byte sNidoranMPose38
+.4byte sNidoranMPose39
+.4byte sNidoranMPose40
+.4byte sNidoranMPose41
+.4byte sNidoranMPose42
+.4byte sNidoranMPose43
+.4byte sNidoranMPose44
+.4byte sNidoranMPose45
+.4byte sNidoranMPose46
+.4byte sNidoranMPose47
+.4byte sNidoranMPose48
+.4byte sNidoranMPose49
+.4byte sNidoranMPose50
+.4byte sNidoranMPose51
+.4byte sNidoranMPose52
+.4byte sNidoranMPose53
+.4byte sNidoranMPose54
+.4byte sNidoranMPose55
+.4byte sNidoranMPose56
+.4byte sNidoranMPose57
+.4byte sNidoranMPose58
+.4byte sNidoranMPose59
+.4byte sNidoranMPose60
+.4byte sNidoranMPose61
+.4byte sNidoranMPose62
+.4byte sNidoranMPose63
+.4byte sNidoranMPose64
+.4byte sNidoranMPose65
+.4byte sNidoranMPose66
+.4byte sNidoranMPose67
+.4byte sNidoranMPose68
+.4byte sNidoranMPose69
+.4byte sNidoranMPose70
+.4byte sNidoranMPose71
+.4byte sNidoranMPose72
+.4byte sNidoranMPose73
+.4byte sNidoranMPose74
+.4byte sNidoranMPose75
+.4byte sNidoranMPose76
+.4byte sNidoranMPose77
+.4byte sNidoranMPose78
+.4byte sNidoranMPose79
+.4byte sNidoranMPose80
+.4byte sNidoranMPose81
+.4byte sNidoranMPose82
+.4byte sNidoranMPose83
+.4byte sNidoranMPose84
+.4byte sNidoranMPose85
+.4byte sNidoranMPose86
+.4byte sNidoranMPose87
+.4byte sNidoranMPose88
+.4byte sNidoranMPose89
+.4byte sNidoranMPose90
+.4byte sNidoranMPose91
+.4byte sNidoranMPose92
+.4byte sNidoranMPose93
+.4byte sNidoranMPose94
+.4byte sNidoranMPose95
+.4byte sNidoranMPose96
+.4byte sNidoranMPose97
+.4byte sNidoranMPose98
+.4byte sNidoranMPose99
+.4byte sNidoranMPose100
+.4byte sNidoranMPose101
+.4byte sNidoranMPose102
+.4byte sNidoranMPose103
+.4byte sNidoranMPose104
+.4byte sNidoranMPose105
+.4byte sNidoranMPose106
+.4byte sNidoranMPose107
+.4byte sNidoranMPose108
+.4byte sNidoranMPose109
+.4byte sNidoranMPose110
+.4byte sNidoranMPose111
+.4byte sNidoranMPose112
+.4byte sNidoranMPose113
+.4byte sNidoranMPose114
+.4byte sNidoranMPose115
+.4byte sNidoranMPose116
+.4byte sNidoranMPose117
+.4byte sNidoranMPose118
+.4byte sNidoranMPose119
+.4byte sNidoranMPose120
+.4byte sNidoranMPose121
+.4byte sNidoranMPose122
+.4byte sNidoranMPose123
+.4byte sNidoranMPose124
+.4byte sNidoranMPose125
+.4byte sNidoranMPose126
+.4byte sNidoranMPose127
+.4byte sNidoranMPose128
+.4byte sNidoranMPose129
+.4byte sNidoranMPose130
+.4byte sNidoranMPose131
+.4byte sNidoranMPose132
+.4byte sNidoranMPose133
+.4byte sNidoranMPose134
+.4byte sNidoranMPose135
+.4byte sNidoranMPose136
+.4byte sNidoranMPose137
+.4byte sNidoranMPose138
+.4byte sNidoranMPose139
+.4byte sNidoranMPose140
+.4byte sNidoranMPose141
+.4byte sNidoranMPose142
+.4byte sNidoranMPose143
+.4byte sNidoranMPose144
+.4byte sNidoranMPose145
+.4byte sNidoranMPose146
+.4byte sNidoranMPose147
+.4byte sNidoranMPose148
+.4byte sNidoranMPose149
+.4byte sNidoranMPose150
+.4byte sNidoranMPose151
+.4byte sNidoranMPose152
+.4byte sNidoranMPose153
+.4byte sNidoranMPose154
+.4byte sNidoranMPose155
+.4byte sNidoranMPose156
+.4byte sNidoranMPose157
+.4byte sNidoranMPose158
+.4byte sNidoranMPose159
+.4byte sNidoranMPose160
+.4byte sNidoranMPose161
+.4byte sNidoranMPose162
+.4byte sNidoranMPose163
+.4byte sNidoranMPose164
+.4byte sNidoranMPose165
+.4byte sNidoranMPose166
+.4byte sNidoranMPose167
+.4byte sNidoranMPose168
+.4byte sNidoranMPose169
+.4byte sNidoranMPose170
+.4byte sNidoranMPose171
+.4byte sNidoranMPose172
+.4byte sNidoranMPose173
+.4byte sNidoranMPose174
+.4byte sNidoranMPose175
+.4byte sNidoranMPose176
+.4byte sNidoranMPose177
+.4byte sNidoranMPose178
+.4byte sNidoranMPose179
+.4byte sNidoranMPose180
+.4byte sNidoranMPose181
+.4byte sNidoranMPose182
+.4byte sNidoranMPose183
+.4byte sNidoranMPose184
+.4byte sNidoranMPose185
+.4byte sNidoranMPose186
+.4byte sNidoranMPose187
+.4byte sNidoranMPose188
+.4byte sNidoranMPose189
+.4byte sNidoranMPose190
+.4byte sNidoranMPose191
+.4byte sNidoranMPose192
+.4byte sNidoranMPose193
+.4byte sNidoranMPose194
+.4byte sNidoranMPose195
+.4byte sNidoranMPose196
+.4byte sNidoranMPose197
+.4byte sNidoranMPose198
+.4byte sNidoranMPose199
+.4byte sNidoranMPose200
+.4byte sNidoranMPose201
+.4byte sNidoranMPose202
+.4byte sNidoranMPose203
+.4byte sNidoranMPose204
+.4byte sNidoranMPose205
+.4byte sNidoranMPose206
+.4byte sNidoranMPose207
+.4byte sNidoranMPose208
+.4byte sNidoranMPose209
+.4byte sNidoranMPose210
+.4byte sNidoranMPose211
+.4byte sNidoranMPose212
+.4byte sNidoranMPose213
+.4byte sNidoranMPose214
+.4byte sNidoranMPose215
+.4byte sNidoranMPose216
+.4byte sNidoranMPose217
+.4byte sNidoranMPose218
+sAxPositionsNidoranM:
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	  -7,   -1, 	   5,   -1, 	  -1,   -9
+.2byte   -1,    5, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte    8,   -2, 	  11,   -6, 	   1,    0, 	  -2,  -10
+.2byte    8,    4, 	   8,    1, 	  -1,    4, 	   1,   -7
+.2byte    9,   -2, 	   7,   -2, 	   5,    1, 	  -1,   -6
+.2byte    9,   -6, 	   8,   -7, 	   7,   -3, 	  -2,  -10
+.2byte    8,   -3, 	   6,   -6, 	   4,   -2, 	   0,  -12
+.2byte    9,   -8, 	  -1,   -4, 	   7,   -1, 	  -2,   -7
+.2byte    9,  -11, 	   1,  -12, 	   9,   -7, 	  -3,   -8
+.2byte   10,   -7, 	   3,   -6, 	   9,   -3, 	   0,   -9
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -10
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte  -10,  -11, 	  -2,  -12, 	 -10,   -7, 	   2,   -8
+.2byte  -11,   -7, 	  -4,   -6, 	 -10,   -3, 	  -1,   -9
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -6, 	  -9,   -7, 	  -8,   -3, 	   1,  -10
+.2byte   -9,   -3, 	  -7,   -6, 	  -5,   -2, 	  -1,  -12
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -2, 	 -12,   -6, 	  -2,    0, 	   1,  -10
+.2byte   -9,    4, 	  -9,    1, 	   0,    4, 	  -2,   -7
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	  -7,   -1, 	   5,   -1, 	  -1,   -9
+.2byte   -1,    5, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte    8,   -2, 	  11,   -6, 	   1,    0, 	  -2,  -10
+.2byte    8,    4, 	   8,    1, 	  -1,    4, 	   1,   -7
+.2byte    9,   -2, 	   7,   -2, 	   5,    1, 	  -1,   -6
+.2byte    9,   -6, 	   8,   -7, 	   7,   -3, 	  -2,  -10
+.2byte    8,   -1, 	   6,   -4, 	   4,    0, 	   0,  -10
+.2byte    9,   -8, 	  -1,   -4, 	   7,   -1, 	  -2,   -7
+.2byte    9,  -11, 	   1,  -12, 	   9,   -7, 	  -3,   -8
+.2byte   10,   -7, 	   3,   -6, 	   9,   -3, 	   0,   -9
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -10
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte  -10,  -11, 	  -2,  -12, 	 -10,   -7, 	   2,   -8
+.2byte  -11,   -7, 	  -4,   -6, 	 -10,   -3, 	  -1,   -9
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -6, 	  -9,   -7, 	  -8,   -3, 	   1,  -10
+.2byte   -9,   -1, 	  -7,   -4, 	  -5,    0, 	  -1,  -10
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -2, 	 -12,   -6, 	  -2,    0, 	   1,  -10
+.2byte   -9,    4, 	  -9,    1, 	   0,    4, 	  -2,   -7
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	  -7,   -1, 	   5,   -1, 	  -1,   -9
+.2byte   -1,    5, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte    8,   -2, 	  11,   -6, 	   1,    0, 	  -2,  -10
+.2byte    8,    4, 	   8,    1, 	  -1,    4, 	   1,   -7
+.2byte    9,   -2, 	   7,   -2, 	   5,    1, 	  -1,   -6
+.2byte    9,   -6, 	   8,   -7, 	   7,   -3, 	  -2,  -10
+.2byte    8,   -1, 	   6,   -4, 	   4,    0, 	   0,  -10
+.2byte    9,   -8, 	  -1,   -4, 	   7,   -1, 	  -2,   -7
+.2byte    9,  -11, 	   1,  -12, 	   9,   -7, 	  -3,   -8
+.2byte   10,   -7, 	   3,   -6, 	   9,   -3, 	   0,   -9
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -10
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte  -10,  -11, 	  -2,  -12, 	 -10,   -7, 	   2,   -8
+.2byte  -11,   -7, 	  -4,   -6, 	 -10,   -3, 	  -1,   -9
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -6, 	  -9,   -7, 	  -8,   -3, 	   1,  -10
+.2byte   -9,   -1, 	  -7,   -4, 	  -5,    0, 	  -1,  -10
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -2, 	 -12,   -6, 	  -2,    0, 	   1,  -10
+.2byte   -9,    4, 	  -9,    1, 	   0,    4, 	  -2,   -7
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	  -7,   -1, 	   5,   -1, 	  -1,   -9
+.2byte   -1,    5, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte   -1,   -1, 	  -7,    2, 	   5,    2, 	  -1,   -7
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte    8,   -2, 	  11,   -6, 	   1,    0, 	  -2,  -10
+.2byte    8,    4, 	   8,    1, 	  -1,    4, 	   1,   -7
+.2byte    6,   -2, 	  10,   -2, 	  -2,    2, 	  -1,   -7
+.2byte    9,   -2, 	   7,   -2, 	   5,    1, 	  -1,   -6
+.2byte    9,   -6, 	   8,   -7, 	   7,   -3, 	  -2,  -10
+.2byte    8,   -3, 	   6,   -6, 	   4,   -2, 	   0,  -12
+.2byte    6,   -4, 	   4,   -2, 	   4,    1, 	  -2,   -6
+.2byte    9,   -8, 	  -1,   -4, 	   7,   -1, 	  -2,   -7
+.2byte    9,  -11, 	   1,  -12, 	   9,   -7, 	  -3,   -8
+.2byte   10,   -7, 	   3,   -6, 	   9,   -3, 	   0,   -9
+.2byte    8,   -9, 	   0,   -3, 	   7,    0, 	  -2,   -7
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -10
+.2byte   -1,  -12, 	   5,   -5, 	  -7,   -5, 	  -1,   -7
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte  -10,  -11, 	  -2,  -12, 	 -10,   -7, 	   2,   -8
+.2byte  -11,   -7, 	  -4,   -6, 	 -10,   -3, 	  -1,   -9
+.2byte   -9,   -9, 	  -1,   -3, 	  -8,    0, 	   1,   -7
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -6, 	  -9,   -7, 	  -8,   -3, 	   1,  -10
+.2byte   -9,   -3, 	  -7,   -6, 	  -5,   -2, 	  -1,  -12
+.2byte   -7,   -4, 	  -5,   -2, 	  -5,    1, 	   1,   -6
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -2, 	 -12,   -6, 	  -2,    0, 	   1,  -10
+.2byte   -9,    4, 	  -9,    1, 	   0,    4, 	  -2,   -7
+.2byte   -7,   -2, 	 -11,   -2, 	   1,    2, 	   0,   -7
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -1,    2, 	  -5,   -1, 	   3,   -1, 	  -1,   -8
+.2byte   -1,    1, 	  -5,   -4, 	   3,   -4, 	  -1,   -8
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte    7,    1, 	   6,   -3, 	  -3,   -1, 	  -1,   -7
+.2byte    6,    1, 	   3,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte    8,   -2, 	   6,   -2, 	   4,    1, 	  -2,   -6
+.2byte    7,   -2, 	  -1,   -2, 	  -2,    0, 	  -2,   -7
+.2byte    7,   -2, 	  -3,   -2, 	  -4,    0, 	  -2,   -7
+.2byte    8,   -8, 	  -2,   -4, 	   6,   -1, 	  -3,   -7
+.2byte    7,   -5, 	  -3,   -2, 	   1,    1, 	  -2,   -7
+.2byte    7,   -4, 	  -5,   -3, 	  -2,   -1, 	  -2,   -8
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -10, 	   3,   -4, 	  -5,   -4, 	  -1,   -7
+.2byte   -1,  -11, 	   3,   -4, 	  -5,   -4, 	  -1,   -8
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte   -9,   -5, 	   1,   -2, 	  -3,    1, 	   0,   -7
+.2byte   -9,   -4, 	   3,   -3, 	   0,   -1, 	   0,   -8
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte   -9,   -2, 	  -1,   -2, 	   0,    0, 	   0,   -7
+.2byte   -9,   -2, 	   1,   -2, 	   2,    0, 	   0,   -7
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte   -8,    1, 	  -7,   -3, 	   2,   -1, 	   0,   -7
+.2byte   -7,    1, 	  -4,   -4, 	   3,   -3, 	   0,   -8
+.2byte   -7,    1, 	  -7,    0, 	  -1,    1, 	   1,   -7
+.2byte   -7,    2, 	  -7,    0, 	  -2,    1, 	   0,   -6
+.2byte    0,    5, 	 -12,    0, 	  12,    0, 	   0,   -7
+.2byte    6,    6, 	  11,   -1, 	  -8,    2, 	  -1,   -6
+.2byte    8,    1, 	  11,   -4, 	  -2,    3, 	  -2,   -7
+.2byte   10,   -4, 	  -3,   -9, 	   9,    1, 	  -1,   -7
+.2byte    0,   -9, 	  10,   -6, 	 -10,   -6, 	   0,   -7
+.2byte  -11,   -4, 	   2,   -9, 	 -10,    1, 	   0,   -7
+.2byte   -9,    1, 	 -12,   -4, 	   1,    3, 	   1,   -7
+.2byte   -7,    6, 	 -12,   -1, 	   7,    2, 	   0,   -6
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	  -7,   -1, 	   5,   -1, 	  -1,   -9
+.2byte   -1,    5, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte    8,   -2, 	  11,   -6, 	   1,    0, 	  -2,  -10
+.2byte    8,    4, 	   8,    1, 	  -1,    4, 	   1,   -7
+.2byte    9,   -2, 	   7,   -2, 	   5,    1, 	  -1,   -6
+.2byte    9,   -6, 	   8,   -7, 	   7,   -3, 	  -2,  -10
+.2byte    8,   -3, 	   6,   -6, 	   4,   -2, 	   0,  -12
+.2byte    9,   -8, 	  -1,   -4, 	   7,   -1, 	  -2,   -7
+.2byte    9,  -11, 	   1,  -12, 	   9,   -7, 	  -3,   -8
+.2byte   10,   -7, 	   3,   -6, 	   9,   -3, 	   0,   -9
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -10
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte  -10,  -11, 	  -2,  -12, 	 -10,   -7, 	   2,   -8
+.2byte  -11,   -7, 	  -4,   -6, 	 -10,   -3, 	  -1,   -9
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -6, 	  -9,   -7, 	  -8,   -3, 	   1,  -10
+.2byte   -9,   -3, 	  -7,   -6, 	  -5,   -2, 	  -1,  -12
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -2, 	 -12,   -6, 	  -2,    0, 	   1,  -10
+.2byte   -9,    4, 	  -9,    1, 	   0,    4, 	  -2,   -7
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte    8,   -8, 	  -2,   -4, 	   6,   -1, 	  -3,   -7
+.2byte    8,   -2, 	   6,   -2, 	   4,    1, 	  -2,   -6
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte   -1,   -1, 	  -7,    2, 	   5,    2, 	  -1,   -7
+.2byte    6,   -2, 	  10,   -2, 	  -2,    2, 	  -1,   -7
+.2byte    6,   -4, 	   4,   -2, 	   4,    1, 	  -2,   -6
+.2byte    8,   -9, 	   0,   -3, 	   7,    0, 	  -2,   -7
+.2byte   -1,  -12, 	   5,   -5, 	  -7,   -5, 	  -1,   -7
+.2byte   -9,   -9, 	  -1,   -3, 	  -8,    0, 	   1,   -7
+.2byte   -7,   -4, 	  -5,   -2, 	  -5,    1, 	   1,   -6
+.2byte   -7,   -2, 	 -11,   -2, 	   1,    2, 	   0,   -7
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	  -7,   -1, 	   5,   -1, 	  -1,   -9
+.2byte   -1,    5, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+.2byte    8,   -2, 	  11,   -6, 	   1,    0, 	  -2,  -10
+.2byte    8,    4, 	   8,    1, 	  -1,    4, 	   1,   -7
+.2byte    9,   -2, 	   7,   -2, 	   5,    1, 	  -1,   -6
+.2byte    9,   -6, 	   8,   -7, 	   7,   -3, 	  -2,  -10
+.2byte    8,   -3, 	   6,   -6, 	   4,   -2, 	   0,  -12
+.2byte    9,   -8, 	  -1,   -4, 	   7,   -1, 	  -2,   -7
+.2byte    9,  -11, 	   1,  -12, 	   9,   -7, 	  -3,   -8
+.2byte   10,   -7, 	   3,   -6, 	   9,   -3, 	   0,   -9
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -10
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte  -10,  -11, 	  -2,  -12, 	 -10,   -7, 	   2,   -8
+.2byte  -11,   -7, 	  -4,   -6, 	 -10,   -3, 	  -1,   -9
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -6, 	  -9,   -7, 	  -8,   -3, 	   1,  -10
+.2byte   -9,   -3, 	  -7,   -6, 	  -5,   -2, 	  -1,  -12
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -2, 	 -12,   -6, 	  -2,    0, 	   1,  -10
+.2byte   -9,    4, 	  -9,    1, 	   0,    4, 	  -2,   -7
+.2byte   -1,   -1, 	  -7,    2, 	   5,    2, 	  -1,   -7
+.2byte   -7,   -2, 	 -11,   -2, 	   1,    2, 	   0,   -7
+.2byte   -7,   -4, 	  -5,   -2, 	  -5,    1, 	   1,   -6
+.2byte   -9,   -9, 	  -1,   -3, 	  -8,    0, 	   1,   -7
+.2byte   -1,  -12, 	   5,   -5, 	  -7,   -5, 	  -1,   -7
+.2byte    8,   -9, 	   0,   -3, 	   7,    0, 	  -2,   -7
+.2byte    6,   -4, 	   4,   -2, 	   4,    1, 	  -2,   -6
+.2byte    6,   -2, 	  10,   -2, 	  -2,    2, 	  -1,   -7
+.2byte   -1,    3, 	  -6,    2, 	   4,    2, 	  -1,   -6
+.2byte   -9,    2, 	 -12,   -2, 	   0,    2, 	  -1,   -7
+.2byte  -10,   -2, 	  -8,   -2, 	  -6,    1, 	   0,   -6
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -1, 	   1,   -7
+.2byte   -1,  -13, 	   5,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte    8,   -8, 	  -2,   -4, 	   6,   -1, 	  -3,   -7
+.2byte    8,   -2, 	   6,   -2, 	   4,    1, 	  -2,   -6
+.2byte    8,    2, 	  11,   -2, 	  -1,    2, 	   0,   -7
+sNidoranMAnimTable1:
+.4byte sNidoranMAnims_1_1
+.4byte sNidoranMAnims_1_2
+.4byte sNidoranMAnims_1_3
+.4byte sNidoranMAnims_1_4
+.4byte sNidoranMAnims_1_5
+.4byte sNidoranMAnims_1_6
+.4byte sNidoranMAnims_1_7
+.4byte sNidoranMAnims_1_8
+sNidoranMAnimTable2:
+.4byte sNidoranMAnims_2_1
+.4byte sNidoranMAnims_2_2
+.4byte sNidoranMAnims_2_3
+.4byte sNidoranMAnims_2_4
+.4byte sNidoranMAnims_2_5
+.4byte sNidoranMAnims_2_6
+.4byte sNidoranMAnims_2_7
+.4byte sNidoranMAnims_2_8
+sNidoranMAnimTable3:
+.4byte sNidoranMAnims_3_1
+.4byte sNidoranMAnims_3_2
+.4byte sNidoranMAnims_3_3
+.4byte sNidoranMAnims_3_4
+.4byte sNidoranMAnims_3_5
+.4byte sNidoranMAnims_3_6
+.4byte sNidoranMAnims_3_7
+.4byte sNidoranMAnims_3_8
+sNidoranMAnimTable4:
+.4byte sNidoranMAnims_4_1
+.4byte sNidoranMAnims_4_2
+.4byte sNidoranMAnims_4_3
+.4byte sNidoranMAnims_4_4
+.4byte sNidoranMAnims_4_5
+.4byte sNidoranMAnims_4_6
+.4byte sNidoranMAnims_4_7
+.4byte sNidoranMAnims_4_8
+sNidoranMAnimTable5:
+.4byte sNidoranMAnims_5_1
+.4byte sNidoranMAnims_5_2
+.4byte sNidoranMAnims_5_3
+.4byte sNidoranMAnims_5_4
+.4byte sNidoranMAnims_5_5
+.4byte sNidoranMAnims_5_6
+.4byte sNidoranMAnims_5_7
+.4byte sNidoranMAnims_5_8
+sNidoranMAnimTable6:
+.4byte sNidoranMAnims_6_1
+.4byte sNidoranMAnims_6_1
+.4byte sNidoranMAnims_6_1
+.4byte sNidoranMAnims_6_1
+.4byte sNidoranMAnims_6_1
+.4byte sNidoranMAnims_6_1
+.4byte sNidoranMAnims_6_1
+.4byte sNidoranMAnims_6_1
+sNidoranMAnimTable7:
+.4byte sNidoranMAnims_7_1
+.4byte sNidoranMAnims_7_2
+.4byte sNidoranMAnims_7_3
+.4byte sNidoranMAnims_7_4
+.4byte sNidoranMAnims_7_5
+.4byte sNidoranMAnims_7_6
+.4byte sNidoranMAnims_7_7
+.4byte sNidoranMAnims_7_8
+sNidoranMAnimTable8:
+.4byte sNidoranMAnims_8_1
+.4byte sNidoranMAnims_8_2
+.4byte sNidoranMAnims_8_3
+.4byte sNidoranMAnims_8_4
+.4byte sNidoranMAnims_8_5
+.4byte sNidoranMAnims_8_6
+.4byte sNidoranMAnims_8_7
+.4byte sNidoranMAnims_8_8
+sNidoranMAnimTable9:
+.4byte sNidoranMAnims_9_1
+.4byte sNidoranMAnims_9_2
+.4byte sNidoranMAnims_9_3
+.4byte sNidoranMAnims_9_4
+.4byte sNidoranMAnims_9_5
+.4byte sNidoranMAnims_9_6
+.4byte sNidoranMAnims_9_7
+.4byte sNidoranMAnims_9_8
+sNidoranMAnimTable10:
+.4byte sNidoranMAnims_10_1
+.4byte sNidoranMAnims_10_2
+.4byte sNidoranMAnims_10_3
+.4byte sNidoranMAnims_10_4
+.4byte sNidoranMAnims_10_5
+.4byte sNidoranMAnims_10_6
+.4byte sNidoranMAnims_10_7
+.4byte sNidoranMAnims_10_8
+sNidoranMAnimTable11:
+.4byte sNidoranMAnims_11_1
+.4byte sNidoranMAnims_11_2
+.4byte sNidoranMAnims_11_3
+.4byte sNidoranMAnims_11_4
+.4byte sNidoranMAnims_11_5
+.4byte sNidoranMAnims_11_6
+.4byte sNidoranMAnims_11_7
+.4byte sNidoranMAnims_11_8
+sNidoranMAnimTable12:
+.4byte sNidoranMAnims_12_1
+.4byte sNidoranMAnims_12_2
+.4byte sNidoranMAnims_12_3
+.4byte sNidoranMAnims_12_4
+.4byte sNidoranMAnims_12_5
+.4byte sNidoranMAnims_12_6
+.4byte sNidoranMAnims_12_7
+.4byte sNidoranMAnims_12_8
+sNidoranMAnimTable13:
+.4byte sNidoranMAnims_13_1
+.4byte sNidoranMAnims_13_2
+.4byte sNidoranMAnims_13_3
+.4byte sNidoranMAnims_13_4
+.4byte sNidoranMAnims_13_5
+.4byte sNidoranMAnims_13_6
+.4byte sNidoranMAnims_13_7
+.4byte sNidoranMAnims_13_8
+sAxAnimationsNidoranM:
+.4byte sNidoranMAnimTable1
+.4byte sNidoranMAnimTable2
+.4byte sNidoranMAnimTable3
+.4byte sNidoranMAnimTable4
+.4byte sNidoranMAnimTable5
+.4byte sNidoranMAnimTable6
+.4byte sNidoranMAnimTable7
+.4byte sNidoranMAnimTable8
+.4byte sNidoranMAnimTable9
+.4byte sNidoranMAnimTable10
+.4byte sNidoranMAnimTable11
+.4byte sNidoranMAnimTable12
+.4byte sNidoranMAnimTable13
+sAxSpritesNidoranM:
+.4byte sNidoranMSprites1
+.4byte sNidoranMSprites2
+.4byte sNidoranMSprites3
+.4byte sNidoranMSprites4
+.4byte sNidoranMSprites5
+.4byte sNidoranMSprites6
+.4byte sNidoranMSprites7
+.4byte sNidoranMSprites8
+.4byte sNidoranMSprites9
+.4byte sNidoranMSprites10
+.4byte sNidoranMSprites11
+.4byte sNidoranMSprites12
+.4byte sNidoranMSprites13
+.4byte sNidoranMSprites14
+.4byte sNidoranMSprites15
+.4byte sNidoranMSprites16
+.4byte sNidoranMSprites17
+.4byte sNidoranMSprites18
+.4byte sNidoranMSprites19
+.4byte sNidoranMSprites20
+.4byte sNidoranMSprites21
+.4byte sNidoranMSprites22
+.4byte sNidoranMSprites23
+.4byte sNidoranMSprites24
+.4byte sNidoranMSprites25
+.4byte sNidoranMSprites26
+.4byte sNidoranMSprites27
+.4byte sNidoranMSprites28
+.4byte sNidoranMSprites29
+.4byte sNidoranMSprites30
+.4byte sNidoranMSprites31
+.4byte sNidoranMSprites32
+.4byte sNidoranMSprites33
+.4byte sNidoranMSprites34
+.4byte sNidoranMSprites35
+.4byte sNidoranMSprites36
+.4byte sNidoranMSprites37
+sAxMainNidoranM:
+ax_main sAxPosesNidoranM, sAxAnimationsNidoranM, 13, sAxSpritesNidoranM, sAxPositionsNidoranM

--- a/data/ax/nidorina.inc
+++ b/data/ax/nidorina.inc
@@ -1,0 +1,2780 @@
+.global gAxNidorina
+gAxNidorina:
+ax_siro sAxMainNidorina
+sNidorinaPose1:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose2:
+ax_pose 1, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose3:
+ax_pose 2, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose4:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose5:
+ax_pose 4, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose6:
+ax_pose 5, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose7:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose8:
+ax_pose 7, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose9:
+ax_pose 8, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose10:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose11:
+ax_pose 10, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose12:
+ax_pose 11, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose13:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose14:
+ax_pose 13, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose15:
+ax_pose 14, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose16:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose17:
+ax_pose 10, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose18:
+ax_pose 11, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose19:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose20:
+ax_pose 7, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose21:
+ax_pose 8, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose22:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose23:
+ax_pose 4, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose24:
+ax_pose 5, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose25:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose26:
+ax_pose 1, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose27:
+ax_pose 2, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose28:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose29:
+ax_pose 4, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose30:
+ax_pose 5, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose31:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose32:
+ax_pose 7, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose33:
+ax_pose 8, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose34:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose35:
+ax_pose 10, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose36:
+ax_pose 11, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose37:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose38:
+ax_pose 13, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose39:
+ax_pose 14, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose40:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose41:
+ax_pose 10, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose42:
+ax_pose 11, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose43:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose44:
+ax_pose 7, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose45:
+ax_pose 8, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose46:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose47:
+ax_pose 4, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose48:
+ax_pose 5, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose49:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose50:
+ax_pose 1, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose51:
+ax_pose 2, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose52:
+ax_pose 15, 0x01e5, 0x80f1, 0x7c00
+ax_pose 16, 0x01e5, 0x80f1, 0x7c10
+ax_pose_terminator
+sNidorinaPose53:
+ax_pose 16, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidorinaPose54:
+ax_pose 17, 0x01e5, 0x80f1, 0x7c00
+ax_pose 18, 0x01e5, 0x80f1, 0x7c10
+ax_pose_terminator
+sNidorinaPose55:
+ax_pose 18, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sNidorinaPose56:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose57:
+ax_pose 4, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose58:
+ax_pose 5, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose59:
+ax_pose 19, 0x01e5, 0x90ee, 0x7c00
+ax_pose 20, 0x01e5, 0x90ee, 0x7c10
+ax_pose_terminator
+sNidorinaPose60:
+ax_pose 20, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidorinaPose61:
+ax_pose 21, 0x01e5, 0x90ee, 0x7c00
+ax_pose 22, 0x01e5, 0x90ee, 0x7c10
+ax_pose_terminator
+sNidorinaPose62:
+ax_pose 22, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sNidorinaPose63:
+ax_pose 6, 0x01ed, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose64:
+ax_pose 7, 0x01ed, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose65:
+ax_pose 8, 0x01ed, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose66:
+ax_pose 23, 0x01e5, 0x90ef, 0x7c00
+ax_pose 24, 0x01e5, 0x90ef, 0x7c10
+ax_pose_terminator
+sNidorinaPose67:
+ax_pose 24, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose68:
+ax_pose 25, 0x01e5, 0x90ef, 0x7c00
+ax_pose 26, 0x01e5, 0x90ef, 0x7c10
+ax_pose_terminator
+sNidorinaPose69:
+ax_pose 26, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose70:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose71:
+ax_pose 10, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose72:
+ax_pose 11, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose73:
+ax_pose 27, 0x81e5, 0x90ff, 0x7c00
+ax_pose 28, 0x01e5, 0x90ef, 0x7c08
+ax_pose_terminator
+sNidorinaPose74:
+ax_pose 28, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose75:
+ax_pose 29, 0x01e5, 0x90ef, 0x7c00
+ax_pose 30, 0x01e5, 0x90ef, 0x7c10
+ax_pose_terminator
+sNidorinaPose76:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose77:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose78:
+ax_pose 13, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose79:
+ax_pose 14, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose80:
+ax_pose 31, 0x81e6, 0x80f0, 0x7c00
+ax_pose 32, 0x01e6, 0x80f0, 0x7c08
+ax_pose_terminator
+sNidorinaPose81:
+ax_pose 32, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose82:
+ax_pose 33, 0x01e6, 0x80f0, 0x7c00
+ax_pose 34, 0x81e6, 0x80fd, 0x7c10
+ax_pose_terminator
+sNidorinaPose83:
+ax_pose 33, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose84:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose85:
+ax_pose 10, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose86:
+ax_pose 11, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose87:
+ax_pose 27, 0x81e5, 0x80f0, 0x7c00
+ax_pose 28, 0x01e5, 0x80f0, 0x7c08
+ax_pose_terminator
+sNidorinaPose88:
+ax_pose 28, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose89:
+ax_pose 29, 0x01e5, 0x80f0, 0x7c00
+ax_pose 30, 0x01e5, 0x80f0, 0x7c10
+ax_pose_terminator
+sNidorinaPose90:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose91:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose92:
+ax_pose 7, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose93:
+ax_pose 8, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose94:
+ax_pose 23, 0x01e6, 0x80f0, 0x7c00
+ax_pose 24, 0x01e6, 0x80f0, 0x7c10
+ax_pose_terminator
+sNidorinaPose95:
+ax_pose 24, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose96:
+ax_pose 25, 0x01e6, 0x80f0, 0x7c00
+ax_pose 26, 0x01e6, 0x80f0, 0x7c10
+ax_pose_terminator
+sNidorinaPose97:
+ax_pose 26, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose98:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose99:
+ax_pose 4, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose100:
+ax_pose 5, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose101:
+ax_pose 19, 0x01e5, 0x80ef, 0x7c00
+ax_pose 20, 0x01e5, 0x80ef, 0x7c10
+ax_pose_terminator
+sNidorinaPose102:
+ax_pose 20, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose103:
+ax_pose 21, 0x01e5, 0x80ef, 0x7c00
+ax_pose 22, 0x01e5, 0x80ef, 0x7c10
+ax_pose_terminator
+sNidorinaPose104:
+ax_pose 22, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose105:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose106:
+ax_pose 1, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose107:
+ax_pose 2, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose108:
+ax_pose 35, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose109:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose110:
+ax_pose 4, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose111:
+ax_pose 5, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose112:
+ax_pose 36, 0x01e7, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose113:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose114:
+ax_pose 7, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose115:
+ax_pose 8, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose116:
+ax_pose 37, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose117:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose118:
+ax_pose 10, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose119:
+ax_pose 11, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose120:
+ax_pose 38, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose121:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose122:
+ax_pose 13, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose123:
+ax_pose 14, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose124:
+ax_pose 39, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose125:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose126:
+ax_pose 10, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose127:
+ax_pose 11, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose128:
+ax_pose 38, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose129:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose130:
+ax_pose 7, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose131:
+ax_pose 8, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose132:
+ax_pose 37, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose133:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose134:
+ax_pose 4, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose135:
+ax_pose 5, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose136:
+ax_pose 36, 0x01e7, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose137:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose138:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose139:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose140:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose141:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose142:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose143:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose144:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose145:
+ax_pose 40, 0x01eb, 0x80f5, 0x7c00
+ax_pose_terminator
+sNidorinaPose146:
+ax_pose 41, 0x01eb, 0x80f5, 0x7c00
+ax_pose_terminator
+sNidorinaPose147:
+ax_pose 42, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose148:
+ax_pose 43, 0x01e2, 0x90ea, 0x7c00
+ax_pose_terminator
+sNidorinaPose149:
+ax_pose 44, 0x01e3, 0x90e7, 0x7c00
+ax_pose_terminator
+sNidorinaPose150:
+ax_pose 45, 0x01e6, 0x90e7, 0x7c00
+ax_pose_terminator
+sNidorinaPose151:
+ax_pose 46, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sNidorinaPose152:
+ax_pose 45, 0x01e6, 0x80f9, 0x7c00
+ax_pose_terminator
+sNidorinaPose153:
+ax_pose 44, 0x01e3, 0x80f9, 0x7c00
+ax_pose_terminator
+sNidorinaPose154:
+ax_pose 43, 0x01e2, 0x80f6, 0x7c00
+ax_pose_terminator
+sNidorinaPose155:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose156:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose157:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose158:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose159:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose160:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose161:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose162:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose163:
+ax_pose 35, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose164:
+ax_pose 36, 0x01e7, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose165:
+ax_pose 37, 0x01e6, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose166:
+ax_pose 38, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose167:
+ax_pose 39, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose168:
+ax_pose 38, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose169:
+ax_pose 37, 0x01e6, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose170:
+ax_pose 36, 0x01e7, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose171:
+ax_pose 35, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose172:
+ax_pose 36, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose173:
+ax_pose 37, 0x01e4, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose174:
+ax_pose 38, 0x01e5, 0x90f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose175:
+ax_pose 39, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose176:
+ax_pose 38, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose177:
+ax_pose 37, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose178:
+ax_pose 36, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose179:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose180:
+ax_pose 35, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose181:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose182:
+ax_pose 36, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose183:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose184:
+ax_pose 37, 0x01e6, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose185:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose186:
+ax_pose 38, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sNidorinaPose187:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose188:
+ax_pose 39, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose189:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose190:
+ax_pose 38, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose191:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose192:
+ax_pose 37, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose193:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose194:
+ax_pose 36, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sNidorinaPose195:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose196:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose197:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose198:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose199:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose200:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose201:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose202:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose203:
+ax_pose 0, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose204:
+ax_pose 3, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose205:
+ax_pose 6, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose206:
+ax_pose 9, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose207:
+ax_pose 12, 0x01ee, 0x80f4, 0x7c00
+ax_pose_terminator
+sNidorinaPose208:
+ax_pose 9, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose209:
+ax_pose 6, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+sNidorinaPose210:
+ax_pose 3, 0x01ee, 0x90eb, 0x7c00
+ax_pose_terminator
+.align 2
+sNidorinaAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNidorinaAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 1, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sNidorinaAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sNidorinaAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 20, -23, 20, -23,
+ax_anim 2, 1, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 34, 20, -23, 20, -23,
+ax_anim 2, 0, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sNidorinaAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 1, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 0, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sNidorinaAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sNidorinaAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -17, 0, -17, 0,
+ax_anim 2, 1, 43, -17, 1, -17, 1,
+ax_anim 2, 0, 43, -17, 0, -17, 0,
+ax_anim 2, 0, 43, -17, 1, -17, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sNidorinaAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -19, 19, -19, 19,
+ax_anim 2, 1, 46, -20, 18, -20, 18,
+ax_anim 2, 0, 46, -19, 19, -19, 19,
+ax_anim 2, 0, 46, -20, 18, -20, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, -4, 0, -4,
+ax_anim 4, 0, 54, 0, -4, 0, -4,
+ax_anim 1, 2, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 6, 0, 6,
+ax_anim 2, 0, 51, 0, 18, 0, 18,
+ax_anim 2, 1, 52, -1, 19, -1, 19,
+ax_anim 2, 0, 53, 0, 18, 0, 18,
+ax_anim 2, 0, 54, 1, 19, 1, 19,
+ax_anim 2, 0, 51, 0, 18, 0, 18,
+ax_anim 2, 0, 52, -1, 19, -1, 19,
+ax_anim 2, 0, 53, 0, 18, 0, 18,
+ax_anim 2, 0, 54, 1, 19, 1, 19,
+ax_anim 1, 0, 48, 0, 8, 0, 8,
+ax_anim 1, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sNidorinaAnims_3_2:
+ax_anim 2, 0, 56, -2, -2, -2, -2,
+ax_anim 2, 0, 57, -4, -4, -4, -4,
+ax_anim 4, 0, 61, -4, -4, -4, -4,
+ax_anim 1, 2, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 6, 6, 6, 6,
+ax_anim 2, 0, 58, 18, 18, 18, 18,
+ax_anim 2, 1, 59, 20, 19, 20, 19,
+ax_anim 2, 0, 60, 18, 18, 18, 18,
+ax_anim 2, 0, 61, 18, 19, 18, 19,
+ax_anim 2, 0, 58, 18, 18, 18, 18,
+ax_anim 2, 0, 59, 20, 19, 20, 19,
+ax_anim 2, 0, 60, 18, 18, 18, 18,
+ax_anim 2, 0, 61, 18, 19, 18, 19,
+ax_anim 1, 0, 55, 8, 8, 8, 8,
+ax_anim 1, 0, 55, 3, 3, 3, 3,
+ax_anim_terminator
+sNidorinaAnims_3_3:
+ax_anim 2, 0, 63, -2, 0, -2, 0,
+ax_anim 2, 0, 64, -4, 0, -4, 0,
+ax_anim 4, 0, 68, -4, 0, -4, 0,
+ax_anim 1, 2, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 6, 0, 6, 0,
+ax_anim 2, 0, 65, 15, 0, 15, 0,
+ax_anim 2, 1, 66, 16, -1, 16, -1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 68, 16, 1, 16, 1,
+ax_anim 2, 0, 65, 15, 0, 15, 0,
+ax_anim 2, 0, 66, 16, -1, 16, -1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 68, 16, 1, 16, 1,
+ax_anim 1, 0, 62, 8, 0, 8, 0,
+ax_anim 1, 0, 62, 3, 0, 3, 0,
+ax_anim_terminator
+sNidorinaAnims_3_4:
+ax_anim 2, 0, 70, -2, 2, -2, 2,
+ax_anim 2, 0, 71, -4, 4, -4, 4,
+ax_anim 4, 0, 75, -4, 4, -4, 4,
+ax_anim 1, 2, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 72, 18, -18, 18, -18,
+ax_anim 2, 1, 73, 18, -20, 19, -19,
+ax_anim 2, 0, 74, 18, -18, 18, -18,
+ax_anim 2, 0, 75, 20, -19, 19, -19,
+ax_anim 2, 0, 72, 18, -18, 18, -18,
+ax_anim 2, 0, 73, 18, -20, 19, -19,
+ax_anim 2, 0, 74, 18, -18, 18, -18,
+ax_anim 2, 0, 75, 20, -19, 19, -19,
+ax_anim 1, 0, 69, 8, -8, 8, -8,
+ax_anim 1, 0, 69, 3, -3, 3, -3,
+ax_anim_terminator
+sNidorinaAnims_3_5:
+ax_anim 2, 0, 77, 0, 1, 0, 1,
+ax_anim 2, 0, 78, 0, 3, 0, 3,
+ax_anim 4, 0, 82, 0, 5, 0, 5,
+ax_anim 1, 2, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, -6, 0, -6,
+ax_anim 2, 0, 79, 0, -18, 0, -18,
+ax_anim 2, 1, 80, 1, -19, 0, -19,
+ax_anim 2, 0, 81, 0, -18, 0, -18,
+ax_anim 2, 0, 82, -1, -19, 0, -19,
+ax_anim 2, 0, 79, 0, -18, 0, -18,
+ax_anim 2, 0, 80, 1, -19, 0, -19,
+ax_anim 2, 0, 81, 0, -18, 0, -18,
+ax_anim 2, 0, 82, -1, -19, 0, -19,
+ax_anim 1, 0, 76, 0, -8, 0, -8,
+ax_anim 1, 0, 76, 0, -3, 0, -3,
+ax_anim_terminator
+sNidorinaAnims_3_6:
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 4, 0, 89, 4, 4, 4, 4,
+ax_anim 1, 2, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 86, -18, -18, -18, -18,
+ax_anim 2, 1, 87, -18, -20, -19, -19,
+ax_anim 2, 0, 88, -18, -18, -18, -18,
+ax_anim 2, 0, 89, -20, -19, -19, -19,
+ax_anim 2, 0, 86, -18, -18, -18, -18,
+ax_anim 2, 0, 87, -18, -20, -19, -19,
+ax_anim 2, 0, 88, -18, -18, -18, -18,
+ax_anim 2, 0, 89, -20, -19, -19, -19,
+ax_anim 1, 0, 83, -8, -8, -8, -8,
+ax_anim 1, 0, 83, -3, -3, -3, -3,
+ax_anim_terminator
+sNidorinaAnims_3_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 4, 0, 4, 0,
+ax_anim 4, 0, 96, 4, 0, 4, 0,
+ax_anim 1, 2, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 96, -6, 0, -6, 0,
+ax_anim 2, 0, 93, -15, 0, -15, 0,
+ax_anim 2, 1, 94, -16, -1, -16, -1,
+ax_anim 2, 0, 95, -15, 0, -15, 0,
+ax_anim 2, 0, 96, -16, 1, -16, 1,
+ax_anim 2, 0, 93, -15, 0, -15, 0,
+ax_anim 2, 0, 94, -16, -1, -16, -1,
+ax_anim 2, 0, 95, -15, 0, -15, 0,
+ax_anim 2, 0, 96, -16, 1, -16, 1,
+ax_anim 1, 0, 90, -8, 0, -8, 0,
+ax_anim 1, 0, 90, -3, 0, -3, 0,
+ax_anim_terminator
+sNidorinaAnims_3_8:
+ax_anim 2, 0, 98, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 4, 0, 103, 4, -4, 4, -4,
+ax_anim 1, 2, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, -6, 6, -6, 6,
+ax_anim 2, 0, 100, -18, 18, -18, 18,
+ax_anim 2, 1, 101, -20, 19, -20, 19,
+ax_anim 2, 0, 102, -18, 18, -18, 18,
+ax_anim 2, 0, 103, -18, 19, -18, 19,
+ax_anim 2, 0, 100, -18, 18, -18, 18,
+ax_anim 2, 0, 101, -20, 19, -20, 19,
+ax_anim 2, 0, 102, -18, 18, -18, 18,
+ax_anim 2, 0, 103, -18, 19, -18, 19,
+ax_anim 1, 0, 97, -8, 8, -8, 8,
+ax_anim 1, 0, 97, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 6, 0, 106, 0, -4, 0, -4,
+ax_anim 1, 2, 107, 0, -1, 0, -1,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 1, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sNidorinaAnims_4_2:
+ax_anim 2, 0, 109, -1, -2, -1, -1,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 0, 110, -3, -4, -3, -3,
+ax_anim 1, 2, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 6, 4, 6, 4,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 1, 111, 6, 4, 6, 4,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 6, 4, 6, 4,
+ax_anim 2, 0, 111, 5, 5, 5, 5,
+ax_anim 2, 0, 111, 6, 4, 6, 4,
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim_terminator
+sNidorinaAnims_4_3:
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim 6, 0, 114, -5, 0, -3, 0,
+ax_anim 1, 2, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, -1, 5, -1,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 1, 115, 5, -1, 5, -1,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, -1, 5, -1,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, -1, 5, -1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim_terminator
+sNidorinaAnims_4_4:
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 2, 0, 116, -2, 3, -2, 2,
+ax_anim 6, 0, 118, -4, 4, -3, 3,
+ax_anim 1, 2, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 6, -4, 6, -4,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 1, 119, 6, -4, 6, -4,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 6, -4, 6, -4,
+ax_anim 2, 0, 119, 5, -5, 5, -5,
+ax_anim 2, 0, 119, 6, -4, 6, -4,
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim_terminator
+sNidorinaAnims_4_5:
+ax_anim 2, 0, 121, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 3, 0, 3,
+ax_anim 6, 0, 122, 0, 4, 0, 4,
+ax_anim 1, 2, 123, 0, 1, 0, 1,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 1, -5, 1, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 1, 123, 1, -5, 1, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 1, -5, 1, -5,
+ax_anim 2, 0, 123, 0, -5, 0, -5,
+ax_anim 2, 0, 123, 1, -5, 1, -5,
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim_terminator
+sNidorinaAnims_4_6:
+ax_anim 2, 0, 125, 1, 1, 1, 1,
+ax_anim 2, 0, 124, 2, 3, 2, 2,
+ax_anim 6, 0, 126, 4, 4, 3, 3,
+ax_anim 1, 2, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 1, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 127, -5, -5, -5, -5,
+ax_anim 2, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 124, -2, -2, -2, -2,
+ax_anim_terminator
+sNidorinaAnims_4_7:
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 6, 0, 130, 5, 0, 3, 0,
+ax_anim 1, 2, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, -1, -5, -1,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 1, 131, -5, -1, -5, -1,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, -1, -5, -1,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, -1, -5, -1,
+ax_anim 2, 0, 128, -2, 0, -2, 0,
+ax_anim_terminator
+sNidorinaAnims_4_8:
+ax_anim 2, 0, 133, 1, -2, 1, -1,
+ax_anim 2, 0, 132, 2, -2, 2, -2,
+ax_anim 6, 0, 134, 3, -4, 3, -3,
+ax_anim 1, 2, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 1, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim 2, 0, 135, -6, 4, -6, 4,
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_5_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_5_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_5_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_5_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sNidorinaAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sNidorinaAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sNidorinaAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sNidorinaAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sNidorinaAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sNidorinaAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sNidorinaAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_8_2:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_8_4:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 4, 0, 159, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, -1, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_8_6:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 0, 156, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_8_8:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 16, 7, 16,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 16, -7, 16,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 19, 3, 19, 3,
+ax_anim 2, 0, 164, 23, 10, 23, 10,
+ax_anim 3, 0, 165, 22, 20, 22, 20,
+ax_anim 2, 3, 166, 11, 19, 11, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 18, -5, 18, -5,
+ax_anim 3, 0, 164, 21, -2, 21, -2,
+ax_anim 2, 3, 165, 18, 4, 18, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 21, -25, 21, -25,
+ax_anim 2, 3, 164, 22, -15, 22, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -21, -25, -21, -25,
+ax_anim 2, 3, 168, -22, -15, -22, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -18, -5, -18, -5,
+ax_anim 3, 0, 168, -21, -2, -21, -2,
+ax_anim 2, 3, 167, -18, 4, -18, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -19, 3, -19, 3,
+ax_anim 2, 0, 168, -23, 10, -23, 10,
+ax_anim 3, 0, 167, -22, 20, -22, 20,
+ax_anim 2, 3, 166, -11, 19, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_11_2:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_11_3:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_11_4:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_11_5:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_11_6:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_11_7:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_11_8:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinaAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinaGfx1:
+.incbin "baserom.gba", 0x654464, 0x200
+sNidorinaSprites1:
+ax_sprite sNidorinaGfx1, 0x200
+ax_sprite_terminator
+sNidorinaGfx2:
+.incbin "baserom.gba", 0x654674, 0x200
+sNidorinaSprites2:
+ax_sprite sNidorinaGfx2, 0x200
+ax_sprite_terminator
+sNidorinaGfx3:
+.incbin "baserom.gba", 0x654884, 0x200
+sNidorinaSprites3:
+ax_sprite sNidorinaGfx3, 0x200
+ax_sprite_terminator
+sNidorinaGfx4:
+.incbin "baserom.gba", 0x654A94, 0x200
+sNidorinaSprites4:
+ax_sprite sNidorinaGfx4, 0x200
+ax_sprite_terminator
+sNidorinaGfx5:
+.incbin "baserom.gba", 0x654CA4, 0x200
+sNidorinaSprites5:
+ax_sprite sNidorinaGfx5, 0x200
+ax_sprite_terminator
+sNidorinaGfx6:
+.incbin "baserom.gba", 0x654EB4, 0x200
+sNidorinaSprites6:
+ax_sprite sNidorinaGfx6, 0x200
+ax_sprite_terminator
+sNidorinaGfx7:
+.incbin "baserom.gba", 0x6550C4, 0x200
+sNidorinaSprites7:
+ax_sprite sNidorinaGfx7, 0x200
+ax_sprite_terminator
+sNidorinaGfx8:
+.incbin "baserom.gba", 0x6552D4, 0x200
+sNidorinaSprites8:
+ax_sprite sNidorinaGfx8, 0x200
+ax_sprite_terminator
+sNidorinaGfx9:
+.incbin "baserom.gba", 0x6554E4, 0x200
+sNidorinaSprites9:
+ax_sprite sNidorinaGfx9, 0x200
+ax_sprite_terminator
+sNidorinaGfx10:
+.incbin "baserom.gba", 0x6556F4, 0x200
+sNidorinaSprites10:
+ax_sprite sNidorinaGfx10, 0x200
+ax_sprite_terminator
+sNidorinaGfx11:
+.incbin "baserom.gba", 0x655904, 0x200
+sNidorinaSprites11:
+ax_sprite sNidorinaGfx11, 0x200
+ax_sprite_terminator
+sNidorinaGfx12:
+.incbin "baserom.gba", 0x655B14, 0x200
+sNidorinaSprites12:
+ax_sprite sNidorinaGfx12, 0x200
+ax_sprite_terminator
+sNidorinaGfx13:
+.incbin "baserom.gba", 0x655D24, 0x200
+sNidorinaSprites13:
+ax_sprite sNidorinaGfx13, 0x200
+ax_sprite_terminator
+sNidorinaGfx14:
+.incbin "baserom.gba", 0x655F34, 0x200
+sNidorinaSprites14:
+ax_sprite sNidorinaGfx14, 0x200
+ax_sprite_terminator
+sNidorinaGfx15:
+.incbin "baserom.gba", 0x656144, 0x200
+sNidorinaSprites15:
+ax_sprite sNidorinaGfx15, 0x200
+ax_sprite_terminator
+sNidorinaGfx16:
+.incbin "baserom.gba", 0x656354, 0x20
+sNidorinaGfx16_1:
+.incbin "baserom.gba", 0x656374, 0x40
+sNidorinaGfx16_2:
+.incbin "baserom.gba", 0x6563B4, 0x60
+sNidorinaSprites16:
+ax_sprite 0, 0xe0
+ax_sprite sNidorinaGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx16_2, 0x60
+ax_sprite_terminator
+sNidorinaGfx17:
+.incbin "baserom.gba", 0x65644C, 0x60
+sNidorinaGfx17_1:
+.incbin "baserom.gba", 0x6564AC, 0x60
+sNidorinaGfx17_2:
+.incbin "baserom.gba", 0x65650C, 0x40
+sNidorinaSprites17:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx18:
+.incbin "baserom.gba", 0x65658C, 0x20
+sNidorinaGfx18_1:
+.incbin "baserom.gba", 0x6565AC, 0x20
+sNidorinaGfx18_2:
+.incbin "baserom.gba", 0x6565CC, 0x40
+sNidorinaSprites18:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx18, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidorinaGfx18_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidorinaGfx18_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidorinaGfx19:
+.incbin "baserom.gba", 0x65664C, 0x60
+sNidorinaGfx19_1:
+.incbin "baserom.gba", 0x6566AC, 0xE0
+sNidorinaSprites19:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx19_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx20:
+.incbin "baserom.gba", 0x6567BC, 0x20
+sNidorinaGfx20_1:
+.incbin "baserom.gba", 0x6567DC, 0xA0
+sNidorinaSprites20:
+ax_sprite 0, 0xe0
+ax_sprite sNidorinaGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx20_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx21:
+.incbin "baserom.gba", 0x6568AC, 0x40
+sNidorinaGfx21_1:
+.incbin "baserom.gba", 0x6568EC, 0x60
+sNidorinaGfx21_2:
+.incbin "baserom.gba", 0x65694C, 0x60
+sNidorinaSprites21:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx22:
+.incbin "baserom.gba", 0x6569EC, 0x60
+sNidorinaGfx22_1:
+.incbin "baserom.gba", 0x656A4C, 0x20
+sNidorinaGfx22_2:
+.incbin "baserom.gba", 0x656A6C, 0x40
+sNidorinaSprites22:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx22_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidorinaGfx22_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidorinaGfx23:
+.incbin "baserom.gba", 0x656AEC, 0x40
+sNidorinaGfx23_1:
+.incbin "baserom.gba", 0x656B2C, 0x60
+sNidorinaGfx23_2:
+.incbin "baserom.gba", 0x656B8C, 0x60
+sNidorinaSprites23:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx23_2, 0x60
+ax_sprite_terminator
+sNidorinaGfx24:
+.incbin "baserom.gba", 0x656C24, 0xC0
+sNidorinaGfx24_1:
+.incbin "baserom.gba", 0x656CE4, 0x40
+sNidorinaSprites24:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx24, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidorinaGfx25:
+.incbin "baserom.gba", 0x656D54, 0x40
+sNidorinaGfx25_1:
+.incbin "baserom.gba", 0x656D94, 0x80
+sNidorinaGfx25_2:
+.incbin "baserom.gba", 0x656E14, 0x40
+sNidorinaSprites25:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx25_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx26:
+.incbin "baserom.gba", 0x656E94, 0x60
+sNidorinaGfx26_1:
+.incbin "baserom.gba", 0x656EF4, 0x20
+sNidorinaGfx26_2:
+.incbin "baserom.gba", 0x656F14, 0x40
+sNidorinaSprites26:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx26_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidorinaGfx26_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNidorinaGfx27:
+.incbin "baserom.gba", 0x656F94, 0x40
+sNidorinaGfx27_1:
+.incbin "baserom.gba", 0x656FD4, 0x80
+sNidorinaGfx27_2:
+.incbin "baserom.gba", 0x657054, 0x60
+sNidorinaSprites27:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx27_2, 0x60
+ax_sprite_terminator
+sNidorinaGfx28:
+.incbin "baserom.gba", 0x6570EC, 0xC0
+sNidorinaSprites28:
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx28, 0xc0
+ax_sprite_terminator
+sNidorinaGfx29:
+.incbin "baserom.gba", 0x6571C4, 0x60
+sNidorinaGfx29_1:
+.incbin "baserom.gba", 0x657224, 0x60
+sNidorinaGfx29_2:
+.incbin "baserom.gba", 0x657284, 0x40
+sNidorinaSprites29:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx30:
+.incbin "baserom.gba", 0x657304, 0x40
+sNidorinaGfx30_1:
+.incbin "baserom.gba", 0x657344, 0x60
+sNidorinaGfx30_2:
+.incbin "baserom.gba", 0x6573A4, 0x20
+sNidorinaGfx30_3:
+.incbin "baserom.gba", 0x6573C4, 0x20
+sNidorinaSprites30:
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx30_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sNidorinaGfx30_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNidorinaGfx30_3, 0x20
+ax_sprite_terminator
+sNidorinaGfx31:
+.incbin "baserom.gba", 0x65742C, 0x40
+sNidorinaGfx31_1:
+.incbin "baserom.gba", 0x65746C, 0x40
+sNidorinaGfx31_2:
+.incbin "baserom.gba", 0x6574AC, 0x40
+sNidorinaSprites31:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx32:
+.incbin "baserom.gba", 0x65752C, 0x80
+sNidorinaGfx32_1:
+.incbin "baserom.gba", 0x6575AC, 0x20
+sNidorinaSprites32:
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx32, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx32_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx33:
+.incbin "baserom.gba", 0x6575FC, 0x60
+sNidorinaGfx33_1:
+.incbin "baserom.gba", 0x65765C, 0x60
+sNidorinaGfx33_2:
+.incbin "baserom.gba", 0x6576BC, 0x40
+sNidorinaSprites33:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx34:
+.incbin "baserom.gba", 0x65773C, 0x60
+sNidorinaGfx34_1:
+.incbin "baserom.gba", 0x65779C, 0x60
+sNidorinaGfx34_2:
+.incbin "baserom.gba", 0x6577FC, 0x40
+sNidorinaSprites34:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx35:
+.incbin "baserom.gba", 0x65787C, 0x40
+sNidorinaGfx35_1:
+.incbin "baserom.gba", 0x6578BC, 0x20
+sNidorinaGfx35_2:
+.incbin "baserom.gba", 0x6578DC, 0x20
+sNidorinaSprites35:
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx35_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx35_2, 0x20
+ax_sprite_terminator
+sNidorinaGfx36:
+.incbin "baserom.gba", 0x657934, 0x180
+sNidorinaSprites36:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx36, 0x180
+ax_sprite_terminator
+sNidorinaGfx37:
+.incbin "baserom.gba", 0x657ACC, 0x60
+sNidorinaGfx37_1:
+.incbin "baserom.gba", 0x657B2C, 0x60
+sNidorinaGfx37_2:
+.incbin "baserom.gba", 0x657B8C, 0x80
+sNidorinaSprites37:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx37_2, 0x80
+ax_sprite_terminator
+sNidorinaGfx38:
+.incbin "baserom.gba", 0x657C44, 0x20
+sNidorinaGfx38_1:
+.incbin "baserom.gba", 0x657C64, 0xE0
+sNidorinaSprites38:
+ax_sprite 0, 0xa0
+ax_sprite sNidorinaGfx38, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidorinaGfx38_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinaGfx39:
+.incbin "baserom.gba", 0x657D74, 0x60
+sNidorinaGfx39_1:
+.incbin "baserom.gba", 0x657DD4, 0x100
+sNidorinaSprites39:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinaGfx39_1, 0x100
+ax_sprite_terminator
+sNidorinaGfx40:
+.incbin "baserom.gba", 0x657EFC, 0x180
+sNidorinaSprites40:
+ax_sprite 0, 0x80
+ax_sprite sNidorinaGfx40, 0x180
+ax_sprite_terminator
+sNidorinaGfx41:
+.incbin "baserom.gba", 0x658094, 0x200
+sNidorinaSprites41:
+ax_sprite sNidorinaGfx41, 0x200
+ax_sprite_terminator
+sNidorinaGfx42:
+.incbin "baserom.gba", 0x6582A4, 0x200
+sNidorinaSprites42:
+ax_sprite sNidorinaGfx42, 0x200
+ax_sprite_terminator
+sNidorinaGfx43:
+.incbin "baserom.gba", 0x6584B4, 0x200
+sNidorinaSprites43:
+ax_sprite sNidorinaGfx43, 0x200
+ax_sprite_terminator
+sNidorinaGfx44:
+.incbin "baserom.gba", 0x6586C4, 0x200
+sNidorinaSprites44:
+ax_sprite sNidorinaGfx44, 0x200
+ax_sprite_terminator
+sNidorinaGfx45:
+.incbin "baserom.gba", 0x6588D4, 0x200
+sNidorinaSprites45:
+ax_sprite sNidorinaGfx45, 0x200
+ax_sprite_terminator
+sNidorinaGfx46:
+.incbin "baserom.gba", 0x658AE4, 0x200
+sNidorinaSprites46:
+ax_sprite sNidorinaGfx46, 0x200
+ax_sprite_terminator
+sNidorinaGfx47:
+.incbin "baserom.gba", 0x658CF4, 0x200
+sNidorinaSprites47:
+ax_sprite sNidorinaGfx47, 0x200
+ax_sprite_terminator
+sAxPosesNidorina:
+.4byte sNidorinaPose1
+.4byte sNidorinaPose2
+.4byte sNidorinaPose3
+.4byte sNidorinaPose4
+.4byte sNidorinaPose5
+.4byte sNidorinaPose6
+.4byte sNidorinaPose7
+.4byte sNidorinaPose8
+.4byte sNidorinaPose9
+.4byte sNidorinaPose10
+.4byte sNidorinaPose11
+.4byte sNidorinaPose12
+.4byte sNidorinaPose13
+.4byte sNidorinaPose14
+.4byte sNidorinaPose15
+.4byte sNidorinaPose16
+.4byte sNidorinaPose17
+.4byte sNidorinaPose18
+.4byte sNidorinaPose19
+.4byte sNidorinaPose20
+.4byte sNidorinaPose21
+.4byte sNidorinaPose22
+.4byte sNidorinaPose23
+.4byte sNidorinaPose24
+.4byte sNidorinaPose25
+.4byte sNidorinaPose26
+.4byte sNidorinaPose27
+.4byte sNidorinaPose28
+.4byte sNidorinaPose29
+.4byte sNidorinaPose30
+.4byte sNidorinaPose31
+.4byte sNidorinaPose32
+.4byte sNidorinaPose33
+.4byte sNidorinaPose34
+.4byte sNidorinaPose35
+.4byte sNidorinaPose36
+.4byte sNidorinaPose37
+.4byte sNidorinaPose38
+.4byte sNidorinaPose39
+.4byte sNidorinaPose40
+.4byte sNidorinaPose41
+.4byte sNidorinaPose42
+.4byte sNidorinaPose43
+.4byte sNidorinaPose44
+.4byte sNidorinaPose45
+.4byte sNidorinaPose46
+.4byte sNidorinaPose47
+.4byte sNidorinaPose48
+.4byte sNidorinaPose49
+.4byte sNidorinaPose50
+.4byte sNidorinaPose51
+.4byte sNidorinaPose52
+.4byte sNidorinaPose53
+.4byte sNidorinaPose54
+.4byte sNidorinaPose55
+.4byte sNidorinaPose56
+.4byte sNidorinaPose57
+.4byte sNidorinaPose58
+.4byte sNidorinaPose59
+.4byte sNidorinaPose60
+.4byte sNidorinaPose61
+.4byte sNidorinaPose62
+.4byte sNidorinaPose63
+.4byte sNidorinaPose64
+.4byte sNidorinaPose65
+.4byte sNidorinaPose66
+.4byte sNidorinaPose67
+.4byte sNidorinaPose68
+.4byte sNidorinaPose69
+.4byte sNidorinaPose70
+.4byte sNidorinaPose71
+.4byte sNidorinaPose72
+.4byte sNidorinaPose73
+.4byte sNidorinaPose74
+.4byte sNidorinaPose75
+.4byte sNidorinaPose76
+.4byte sNidorinaPose77
+.4byte sNidorinaPose78
+.4byte sNidorinaPose79
+.4byte sNidorinaPose80
+.4byte sNidorinaPose81
+.4byte sNidorinaPose82
+.4byte sNidorinaPose83
+.4byte sNidorinaPose84
+.4byte sNidorinaPose85
+.4byte sNidorinaPose86
+.4byte sNidorinaPose87
+.4byte sNidorinaPose88
+.4byte sNidorinaPose89
+.4byte sNidorinaPose90
+.4byte sNidorinaPose91
+.4byte sNidorinaPose92
+.4byte sNidorinaPose93
+.4byte sNidorinaPose94
+.4byte sNidorinaPose95
+.4byte sNidorinaPose96
+.4byte sNidorinaPose97
+.4byte sNidorinaPose98
+.4byte sNidorinaPose99
+.4byte sNidorinaPose100
+.4byte sNidorinaPose101
+.4byte sNidorinaPose102
+.4byte sNidorinaPose103
+.4byte sNidorinaPose104
+.4byte sNidorinaPose105
+.4byte sNidorinaPose106
+.4byte sNidorinaPose107
+.4byte sNidorinaPose108
+.4byte sNidorinaPose109
+.4byte sNidorinaPose110
+.4byte sNidorinaPose111
+.4byte sNidorinaPose112
+.4byte sNidorinaPose113
+.4byte sNidorinaPose114
+.4byte sNidorinaPose115
+.4byte sNidorinaPose116
+.4byte sNidorinaPose117
+.4byte sNidorinaPose118
+.4byte sNidorinaPose119
+.4byte sNidorinaPose120
+.4byte sNidorinaPose121
+.4byte sNidorinaPose122
+.4byte sNidorinaPose123
+.4byte sNidorinaPose124
+.4byte sNidorinaPose125
+.4byte sNidorinaPose126
+.4byte sNidorinaPose127
+.4byte sNidorinaPose128
+.4byte sNidorinaPose129
+.4byte sNidorinaPose130
+.4byte sNidorinaPose131
+.4byte sNidorinaPose132
+.4byte sNidorinaPose133
+.4byte sNidorinaPose134
+.4byte sNidorinaPose135
+.4byte sNidorinaPose136
+.4byte sNidorinaPose137
+.4byte sNidorinaPose138
+.4byte sNidorinaPose139
+.4byte sNidorinaPose140
+.4byte sNidorinaPose141
+.4byte sNidorinaPose142
+.4byte sNidorinaPose143
+.4byte sNidorinaPose144
+.4byte sNidorinaPose145
+.4byte sNidorinaPose146
+.4byte sNidorinaPose147
+.4byte sNidorinaPose148
+.4byte sNidorinaPose149
+.4byte sNidorinaPose150
+.4byte sNidorinaPose151
+.4byte sNidorinaPose152
+.4byte sNidorinaPose153
+.4byte sNidorinaPose154
+.4byte sNidorinaPose155
+.4byte sNidorinaPose156
+.4byte sNidorinaPose157
+.4byte sNidorinaPose158
+.4byte sNidorinaPose159
+.4byte sNidorinaPose160
+.4byte sNidorinaPose161
+.4byte sNidorinaPose162
+.4byte sNidorinaPose163
+.4byte sNidorinaPose164
+.4byte sNidorinaPose165
+.4byte sNidorinaPose166
+.4byte sNidorinaPose167
+.4byte sNidorinaPose168
+.4byte sNidorinaPose169
+.4byte sNidorinaPose170
+.4byte sNidorinaPose171
+.4byte sNidorinaPose172
+.4byte sNidorinaPose173
+.4byte sNidorinaPose174
+.4byte sNidorinaPose175
+.4byte sNidorinaPose176
+.4byte sNidorinaPose177
+.4byte sNidorinaPose178
+.4byte sNidorinaPose179
+.4byte sNidorinaPose180
+.4byte sNidorinaPose181
+.4byte sNidorinaPose182
+.4byte sNidorinaPose183
+.4byte sNidorinaPose184
+.4byte sNidorinaPose185
+.4byte sNidorinaPose186
+.4byte sNidorinaPose187
+.4byte sNidorinaPose188
+.4byte sNidorinaPose189
+.4byte sNidorinaPose190
+.4byte sNidorinaPose191
+.4byte sNidorinaPose192
+.4byte sNidorinaPose193
+.4byte sNidorinaPose194
+.4byte sNidorinaPose195
+.4byte sNidorinaPose196
+.4byte sNidorinaPose197
+.4byte sNidorinaPose198
+.4byte sNidorinaPose199
+.4byte sNidorinaPose200
+.4byte sNidorinaPose201
+.4byte sNidorinaPose202
+.4byte sNidorinaPose203
+.4byte sNidorinaPose204
+.4byte sNidorinaPose205
+.4byte sNidorinaPose206
+.4byte sNidorinaPose207
+.4byte sNidorinaPose208
+.4byte sNidorinaPose209
+.4byte sNidorinaPose210
+sAxPositionsNidorina:
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    0, 	   2,    1, 	  -1,   -6
+.2byte   -1,   -1, 	  -4,    1, 	   4,    0, 	  -1,   -6
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte    3,   -1, 	   3,   -2, 	   0,    1, 	  -2,   -4
+.2byte    3,   -1, 	   5,    0, 	  -2,    1, 	  -1,   -4
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    6,   -4, 	   2,   -2, 	   4,    0, 	  -2,   -4
+.2byte    6,   -4, 	   4,   -2, 	   2,    0, 	  -2,   -4
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    5,   -8, 	  -3,   -5, 	   7,   -4, 	  -2,   -5
+.2byte    5,   -8, 	   0,   -6, 	   6,   -2, 	  -3,   -5
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte   -1,   -8, 	   5,   -5, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -5, 	  -1,   -5
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -7,   -8, 	   1,   -5, 	  -9,   -4, 	   0,   -5
+.2byte   -7,   -8, 	  -2,   -6, 	  -8,   -2, 	   1,   -5
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -4, 	  -4,   -2, 	  -6,    0, 	   0,   -4
+.2byte   -8,   -4, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -5,   -1, 	  -5,   -2, 	  -2,    1, 	   0,   -4
+.2byte   -5,   -1, 	  -7,    0, 	   0,    1, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    0, 	   2,    1, 	  -1,   -6
+.2byte   -1,   -1, 	  -4,    1, 	   4,    0, 	  -1,   -6
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte    3,   -1, 	   3,   -2, 	   0,    1, 	  -2,   -4
+.2byte    3,   -1, 	   5,    0, 	  -2,    1, 	  -1,   -4
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    6,   -4, 	   2,   -2, 	   4,    0, 	  -2,   -4
+.2byte    6,   -4, 	   4,   -2, 	   2,    0, 	  -2,   -4
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    5,   -8, 	  -3,   -5, 	   7,   -4, 	  -2,   -5
+.2byte    5,   -8, 	   0,   -6, 	   6,   -2, 	  -3,   -5
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte   -1,   -8, 	   5,   -5, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -5, 	  -1,   -5
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -7,   -8, 	   1,   -5, 	  -9,   -4, 	   0,   -5
+.2byte   -7,   -8, 	  -2,   -6, 	  -8,   -2, 	   1,   -5
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -4, 	  -4,   -2, 	  -6,    0, 	   0,   -4
+.2byte   -8,   -4, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -5,   -1, 	  -5,   -2, 	  -2,    1, 	   0,   -4
+.2byte   -5,   -1, 	  -7,    0, 	   0,    1, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    0, 	   2,    1, 	  -1,   -6
+.2byte   -1,   -1, 	  -4,    1, 	   4,    0, 	  -1,   -6
+.2byte   -3,   -2, 	  -9,   -8, 	   0,    2, 	  -1,   -6
+.2byte   -3,   -2, 	  -9,   -8, 	   0,    2, 	  -1,   -6
+.2byte    1,   -2, 	  -2,    1, 	   7,   -8, 	   0,   -6
+.2byte    1,   -2, 	  -2,    1, 	   7,   -8, 	   0,   -6
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte    3,   -1, 	   3,   -2, 	   0,    1, 	  -2,   -4
+.2byte    3,   -1, 	   5,    0, 	  -2,    1, 	  -1,   -4
+.2byte    3,   -3, 	   4,   -9, 	   3,    1, 	  -2,   -6
+.2byte    3,   -3, 	   4,   -9, 	   3,    1, 	  -2,   -6
+.2byte    2,   -3, 	  -1,    1, 	  -7,   -6, 	  -2,   -6
+.2byte    2,   -3, 	  -1,    1, 	  -7,   -6, 	  -2,   -6
+.2byte    6,   -6, 	   3,   -4, 	   3,   -2, 	  -2,   -6
+.2byte    6,   -5, 	   2,   -3, 	   4,   -1, 	  -2,   -5
+.2byte    6,   -5, 	   4,   -3, 	   2,   -1, 	  -2,   -5
+.2byte    7,   -6, 	  -2,  -12, 	   4,    0, 	  -1,   -7
+.2byte    7,   -6, 	  -2,  -12, 	   4,    0, 	  -1,   -7
+.2byte    7,   -6, 	   2,    0, 	  -2,   -7, 	  -2,   -6
+.2byte    7,   -6, 	   2,    0, 	  -2,   -7, 	  -2,   -6
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    5,   -8, 	  -3,   -5, 	   7,   -4, 	  -2,   -5
+.2byte    5,   -8, 	   0,   -6, 	   6,   -2, 	  -3,   -5
+.2byte   -2,  -10, 	  -9,  -10, 	   1,   -7, 	  -3,   -7
+.2byte   -2,  -10, 	  -9,  -10, 	   1,   -7, 	  -3,   -7
+.2byte    2,  -11, 	  -1,   -7, 	   4,   -7, 	  -3,   -7
+.2byte    2,  -11, 	  -1,   -7, 	   4,   -7, 	  -3,   -7
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte   -1,   -8, 	   5,   -5, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -5, 	  -1,   -5
+.2byte    2,  -11, 	   7,   -5, 	   0,   -8, 	   1,   -6
+.2byte    2,  -11, 	   7,   -5, 	   0,   -8, 	   1,   -6
+.2byte   -3,  -11, 	  -1,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte   -3,  -11, 	  -1,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -7,   -8, 	   1,   -5, 	  -9,   -4, 	   0,   -5
+.2byte   -7,   -8, 	  -2,   -6, 	  -8,   -2, 	   1,   -5
+.2byte    0,  -10, 	   7,  -10, 	  -3,   -7, 	   1,   -7
+.2byte    0,  -10, 	   7,  -10, 	  -3,   -7, 	   1,   -7
+.2byte   -4,  -11, 	  -1,   -7, 	  -6,   -7, 	   1,   -7
+.2byte   -4,  -11, 	  -1,   -7, 	  -6,   -7, 	   1,   -7
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -4, 	  -4,   -2, 	  -6,    0, 	   0,   -4
+.2byte   -8,   -4, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte   -9,   -5, 	   0,  -11, 	  -6,    1, 	  -1,   -6
+.2byte   -9,   -5, 	   0,  -11, 	  -6,    1, 	  -1,   -6
+.2byte   -9,   -5, 	  -4,    1, 	   0,   -6, 	   0,   -5
+.2byte   -9,   -5, 	  -4,    1, 	   0,   -6, 	   0,   -5
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -5,   -1, 	  -5,   -2, 	  -2,    1, 	   0,   -4
+.2byte   -5,   -1, 	  -7,    0, 	   0,    1, 	  -1,   -4
+.2byte   -7,   -3, 	  -8,   -9, 	  -7,    1, 	  -2,   -6
+.2byte   -7,   -3, 	  -8,   -9, 	  -7,    1, 	  -2,   -6
+.2byte   -6,   -3, 	  -3,    1, 	   3,   -6, 	  -2,   -6
+.2byte   -6,   -3, 	  -3,    1, 	   3,   -6, 	  -2,   -6
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    0, 	   2,    1, 	  -1,   -6
+.2byte   -1,   -1, 	  -4,    1, 	   4,    0, 	  -1,   -6
+.2byte   -1,    1, 	  -7,    3, 	   5,    3, 	  -1,   -6
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte    3,   -1, 	   3,   -2, 	   0,    1, 	  -2,   -4
+.2byte    3,   -1, 	   5,    0, 	  -2,    1, 	  -1,   -4
+.2byte    4,    0, 	   6,    2, 	   0,    4, 	  -2,   -4
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    6,   -4, 	   2,   -2, 	   4,    0, 	  -2,   -4
+.2byte    6,   -4, 	   4,   -2, 	   2,    0, 	  -2,   -4
+.2byte    7,   -3, 	   6,    0, 	   5,    2, 	   0,   -5
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    5,   -8, 	  -3,   -5, 	   7,   -4, 	  -2,   -5
+.2byte    5,   -8, 	   0,   -6, 	   6,   -2, 	  -3,   -5
+.2byte    6,   -8, 	   0,   -5, 	   8,   -2, 	  -1,   -8
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte   -1,   -8, 	   5,   -5, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -5, 	  -1,   -5
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -6
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -7,   -8, 	   1,   -5, 	  -9,   -4, 	   0,   -5
+.2byte   -7,   -8, 	  -2,   -6, 	  -8,   -2, 	   1,   -5
+.2byte   -8,   -8, 	  -2,   -5, 	 -10,   -2, 	  -1,   -8
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -4, 	  -4,   -2, 	  -6,    0, 	   0,   -4
+.2byte   -8,   -4, 	  -6,   -2, 	  -4,    0, 	   0,   -4
+.2byte   -9,   -3, 	  -8,    0, 	  -7,    2, 	  -2,   -5
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -5,   -1, 	  -5,   -2, 	  -2,    1, 	   0,   -4
+.2byte   -5,   -1, 	  -7,    0, 	   0,    1, 	  -1,   -4
+.2byte   -6,    0, 	  -8,    2, 	  -2,    4, 	   0,   -4
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte   -3,   -6, 	  -6,   -4, 	   4,   -2, 	   0,   -7
+.2byte   -3,   -5, 	  -6,   -3, 	   4,   -2, 	   0,   -6
+.2byte    0,   -8, 	  -2,   -3, 	   2,   -3, 	   0,   -7
+.2byte   -3,   -9, 	   2,   -4, 	  -3,   -2, 	  -4,   -7
+.2byte   -1,   -9, 	   0,   -3, 	   0,   -2, 	  -6,   -7
+.2byte    0,   -7, 	  -3,   -2, 	   2,    0, 	  -6,   -3
+.2byte    0,   -6, 	   2,   -1, 	  -2,   -1, 	   0,   -2
+.2byte   -1,   -7, 	   2,   -2, 	  -3,    0, 	   5,   -3
+.2byte    0,   -9, 	  -1,   -3, 	  -1,   -2, 	   5,   -7
+.2byte    2,   -9, 	  -3,   -4, 	   2,   -2, 	   3,   -7
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte   -1,    1, 	  -7,    3, 	   5,    3, 	  -1,   -6
+.2byte   -6,    0, 	  -8,    2, 	  -2,    4, 	   0,   -4
+.2byte   -9,   -3, 	  -8,    0, 	  -7,    2, 	  -2,   -5
+.2byte   -8,   -8, 	  -2,   -5, 	 -10,   -2, 	  -1,   -8
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -6
+.2byte    6,   -8, 	   0,   -5, 	   8,   -2, 	  -1,   -8
+.2byte    7,   -3, 	   6,    0, 	   5,    2, 	   0,   -5
+.2byte    4,    0, 	   6,    2, 	   0,    4, 	  -2,   -4
+.2byte   -1,    1, 	  -7,    3, 	   5,    3, 	  -1,   -6
+.2byte    4,   -2, 	   6,    0, 	   0,    2, 	  -2,   -6
+.2byte    7,   -5, 	   6,   -2, 	   5,    0, 	   0,   -7
+.2byte    6,   -8, 	   0,   -5, 	   8,   -2, 	  -1,   -8
+.2byte   -1,  -11, 	   4,   -7, 	  -6,   -7, 	  -1,   -7
+.2byte   -7,   -8, 	  -1,   -5, 	  -9,   -2, 	   0,   -8
+.2byte   -8,   -5, 	  -7,   -2, 	  -6,    0, 	  -1,   -7
+.2byte   -6,   -2, 	  -8,    0, 	  -2,    2, 	   0,   -6
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -1,    1, 	  -7,    3, 	   5,    3, 	  -1,   -6
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte    3,   -2, 	   5,    0, 	  -1,    2, 	  -3,   -6
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    6,   -3, 	   5,    0, 	   4,    2, 	  -1,   -5
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    5,   -8, 	  -1,   -5, 	   7,   -2, 	  -2,   -8
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -6, 	  -6,   -6, 	  -1,   -6
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -7,   -8, 	  -1,   -5, 	  -9,   -2, 	   0,   -8
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -8,   -3, 	  -7,    0, 	  -6,    2, 	  -1,   -5
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -5,   -2, 	  -7,    0, 	  -1,    2, 	   1,   -6
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+.2byte   -1,   -2, 	  -5,    0, 	   3,    0, 	  -1,   -7
+.2byte   -5,   -2, 	  -7,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -8,   -5, 	  -5,   -3, 	  -5,   -1, 	   0,   -5
+.2byte   -7,   -9, 	   0,   -7, 	  -8,   -4, 	   0,   -6
+.2byte   -1,   -9, 	   5,   -7, 	  -7,   -7, 	  -1,   -6
+.2byte    5,   -9, 	  -2,   -7, 	   6,   -4, 	  -2,   -6
+.2byte    6,   -5, 	   3,   -3, 	   3,   -1, 	  -2,   -5
+.2byte    3,   -2, 	   5,   -2, 	  -1,    0, 	  -2,   -5
+sNidorinaAnimTable1:
+.4byte sNidorinaAnims_1_1
+.4byte sNidorinaAnims_1_2
+.4byte sNidorinaAnims_1_3
+.4byte sNidorinaAnims_1_4
+.4byte sNidorinaAnims_1_5
+.4byte sNidorinaAnims_1_6
+.4byte sNidorinaAnims_1_7
+.4byte sNidorinaAnims_1_8
+sNidorinaAnimTable2:
+.4byte sNidorinaAnims_2_1
+.4byte sNidorinaAnims_2_2
+.4byte sNidorinaAnims_2_3
+.4byte sNidorinaAnims_2_4
+.4byte sNidorinaAnims_2_5
+.4byte sNidorinaAnims_2_6
+.4byte sNidorinaAnims_2_7
+.4byte sNidorinaAnims_2_8
+sNidorinaAnimTable3:
+.4byte sNidorinaAnims_3_1
+.4byte sNidorinaAnims_3_2
+.4byte sNidorinaAnims_3_3
+.4byte sNidorinaAnims_3_4
+.4byte sNidorinaAnims_3_5
+.4byte sNidorinaAnims_3_6
+.4byte sNidorinaAnims_3_7
+.4byte sNidorinaAnims_3_8
+sNidorinaAnimTable4:
+.4byte sNidorinaAnims_4_1
+.4byte sNidorinaAnims_4_2
+.4byte sNidorinaAnims_4_3
+.4byte sNidorinaAnims_4_4
+.4byte sNidorinaAnims_4_5
+.4byte sNidorinaAnims_4_6
+.4byte sNidorinaAnims_4_7
+.4byte sNidorinaAnims_4_8
+sNidorinaAnimTable5:
+.4byte sNidorinaAnims_5_1
+.4byte sNidorinaAnims_5_2
+.4byte sNidorinaAnims_5_3
+.4byte sNidorinaAnims_5_4
+.4byte sNidorinaAnims_5_5
+.4byte sNidorinaAnims_5_6
+.4byte sNidorinaAnims_5_7
+.4byte sNidorinaAnims_5_8
+sNidorinaAnimTable6:
+.4byte sNidorinaAnims_6_1
+.4byte sNidorinaAnims_6_1
+.4byte sNidorinaAnims_6_1
+.4byte sNidorinaAnims_6_1
+.4byte sNidorinaAnims_6_1
+.4byte sNidorinaAnims_6_1
+.4byte sNidorinaAnims_6_1
+.4byte sNidorinaAnims_6_1
+sNidorinaAnimTable7:
+.4byte sNidorinaAnims_7_1
+.4byte sNidorinaAnims_7_2
+.4byte sNidorinaAnims_7_3
+.4byte sNidorinaAnims_7_4
+.4byte sNidorinaAnims_7_5
+.4byte sNidorinaAnims_7_6
+.4byte sNidorinaAnims_7_7
+.4byte sNidorinaAnims_7_8
+sNidorinaAnimTable8:
+.4byte sNidorinaAnims_8_1
+.4byte sNidorinaAnims_8_2
+.4byte sNidorinaAnims_8_3
+.4byte sNidorinaAnims_8_4
+.4byte sNidorinaAnims_8_5
+.4byte sNidorinaAnims_8_6
+.4byte sNidorinaAnims_8_7
+.4byte sNidorinaAnims_8_8
+sNidorinaAnimTable9:
+.4byte sNidorinaAnims_9_1
+.4byte sNidorinaAnims_9_2
+.4byte sNidorinaAnims_9_3
+.4byte sNidorinaAnims_9_4
+.4byte sNidorinaAnims_9_5
+.4byte sNidorinaAnims_9_6
+.4byte sNidorinaAnims_9_7
+.4byte sNidorinaAnims_9_8
+sNidorinaAnimTable10:
+.4byte sNidorinaAnims_10_1
+.4byte sNidorinaAnims_10_2
+.4byte sNidorinaAnims_10_3
+.4byte sNidorinaAnims_10_4
+.4byte sNidorinaAnims_10_5
+.4byte sNidorinaAnims_10_6
+.4byte sNidorinaAnims_10_7
+.4byte sNidorinaAnims_10_8
+sNidorinaAnimTable11:
+.4byte sNidorinaAnims_11_1
+.4byte sNidorinaAnims_11_2
+.4byte sNidorinaAnims_11_3
+.4byte sNidorinaAnims_11_4
+.4byte sNidorinaAnims_11_5
+.4byte sNidorinaAnims_11_6
+.4byte sNidorinaAnims_11_7
+.4byte sNidorinaAnims_11_8
+sNidorinaAnimTable12:
+.4byte sNidorinaAnims_12_1
+.4byte sNidorinaAnims_12_2
+.4byte sNidorinaAnims_12_3
+.4byte sNidorinaAnims_12_4
+.4byte sNidorinaAnims_12_5
+.4byte sNidorinaAnims_12_6
+.4byte sNidorinaAnims_12_7
+.4byte sNidorinaAnims_12_8
+sNidorinaAnimTable13:
+.4byte sNidorinaAnims_13_1
+.4byte sNidorinaAnims_13_2
+.4byte sNidorinaAnims_13_3
+.4byte sNidorinaAnims_13_4
+.4byte sNidorinaAnims_13_5
+.4byte sNidorinaAnims_13_6
+.4byte sNidorinaAnims_13_7
+.4byte sNidorinaAnims_13_8
+sAxAnimationsNidorina:
+.4byte sNidorinaAnimTable1
+.4byte sNidorinaAnimTable2
+.4byte sNidorinaAnimTable3
+.4byte sNidorinaAnimTable4
+.4byte sNidorinaAnimTable5
+.4byte sNidorinaAnimTable6
+.4byte sNidorinaAnimTable7
+.4byte sNidorinaAnimTable8
+.4byte sNidorinaAnimTable9
+.4byte sNidorinaAnimTable10
+.4byte sNidorinaAnimTable11
+.4byte sNidorinaAnimTable12
+.4byte sNidorinaAnimTable13
+sAxSpritesNidorina:
+.4byte sNidorinaSprites1
+.4byte sNidorinaSprites2
+.4byte sNidorinaSprites3
+.4byte sNidorinaSprites4
+.4byte sNidorinaSprites5
+.4byte sNidorinaSprites6
+.4byte sNidorinaSprites7
+.4byte sNidorinaSprites8
+.4byte sNidorinaSprites9
+.4byte sNidorinaSprites10
+.4byte sNidorinaSprites11
+.4byte sNidorinaSprites12
+.4byte sNidorinaSprites13
+.4byte sNidorinaSprites14
+.4byte sNidorinaSprites15
+.4byte sNidorinaSprites16
+.4byte sNidorinaSprites17
+.4byte sNidorinaSprites18
+.4byte sNidorinaSprites19
+.4byte sNidorinaSprites20
+.4byte sNidorinaSprites21
+.4byte sNidorinaSprites22
+.4byte sNidorinaSprites23
+.4byte sNidorinaSprites24
+.4byte sNidorinaSprites25
+.4byte sNidorinaSprites26
+.4byte sNidorinaSprites27
+.4byte sNidorinaSprites28
+.4byte sNidorinaSprites29
+.4byte sNidorinaSprites30
+.4byte sNidorinaSprites31
+.4byte sNidorinaSprites32
+.4byte sNidorinaSprites33
+.4byte sNidorinaSprites34
+.4byte sNidorinaSprites35
+.4byte sNidorinaSprites36
+.4byte sNidorinaSprites37
+.4byte sNidorinaSprites38
+.4byte sNidorinaSprites39
+.4byte sNidorinaSprites40
+.4byte sNidorinaSprites41
+.4byte sNidorinaSprites42
+.4byte sNidorinaSprites43
+.4byte sNidorinaSprites44
+.4byte sNidorinaSprites45
+.4byte sNidorinaSprites46
+.4byte sNidorinaSprites47
+sAxMainNidorina:
+ax_main sAxPosesNidorina, sAxAnimationsNidorina, 13, sAxSpritesNidorina, sAxPositionsNidorina

--- a/data/ax/nidorino.inc
+++ b/data/ax/nidorino.inc
@@ -1,0 +1,2763 @@
+.global gAxNidorino
+gAxNidorino:
+ax_siro sAxMainNidorino
+sNidorinoPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose4:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose5:
+ax_pose 4, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose6:
+ax_pose 5, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose7:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose8:
+ax_pose 7, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose9:
+ax_pose 8, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose10:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose11:
+ax_pose 10, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose12:
+ax_pose 11, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose14:
+ax_pose 13, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose15:
+ax_pose 14, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose16:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose17:
+ax_pose 10, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose18:
+ax_pose 11, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose19:
+ax_pose 6, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose20:
+ax_pose 7, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose21:
+ax_pose 8, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose22:
+ax_pose 3, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose23:
+ax_pose 4, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose24:
+ax_pose 5, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose26:
+ax_pose 1, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose27:
+ax_pose 2, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose28:
+ax_pose 15, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose29:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose30:
+ax_pose 4, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose31:
+ax_pose 5, 0x01e7, 0x90f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose32:
+ax_pose 16, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose33:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose34:
+ax_pose 7, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose35:
+ax_pose 8, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose36:
+ax_pose 17, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose37:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose38:
+ax_pose 10, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose39:
+ax_pose 11, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose40:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose41:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose42:
+ax_pose 13, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose43:
+ax_pose 14, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose44:
+ax_pose 19, 0x01e8, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose45:
+ax_pose 9, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose46:
+ax_pose 10, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose47:
+ax_pose 11, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose48:
+ax_pose 18, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose49:
+ax_pose 6, 0x01e7, 0x80ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose50:
+ax_pose 7, 0x01e7, 0x80ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose51:
+ax_pose 8, 0x01e7, 0x80ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose52:
+ax_pose 17, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose53:
+ax_pose 3, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose54:
+ax_pose 4, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose55:
+ax_pose 5, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose56:
+ax_pose 16, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose57:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose58:
+ax_pose 1, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose59:
+ax_pose 2, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose60:
+ax_pose 15, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose61:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose62:
+ax_pose 4, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose63:
+ax_pose 5, 0x01e7, 0x90f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose64:
+ax_pose 16, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose65:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose66:
+ax_pose 7, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose67:
+ax_pose 8, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose68:
+ax_pose 17, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose69:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose70:
+ax_pose 10, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose71:
+ax_pose 11, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose72:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose73:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose74:
+ax_pose 13, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose75:
+ax_pose 14, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose76:
+ax_pose 19, 0x01e8, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose77:
+ax_pose 9, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose78:
+ax_pose 10, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose79:
+ax_pose 11, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose80:
+ax_pose 18, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose81:
+ax_pose 6, 0x01e7, 0x80ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose82:
+ax_pose 7, 0x01e7, 0x80ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose83:
+ax_pose 8, 0x01e7, 0x80ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose84:
+ax_pose 17, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose85:
+ax_pose 3, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose86:
+ax_pose 4, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose87:
+ax_pose 5, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose88:
+ax_pose 16, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose89:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose90:
+ax_pose 20, 0x01e6, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose91:
+ax_pose 15, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose92:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose93:
+ax_pose 21, 0x01e3, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose94:
+ax_pose 16, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose95:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose96:
+ax_pose 22, 0x01e5, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose97:
+ax_pose 17, 0x01e7, 0x90f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose98:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose99:
+ax_pose 23, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose100:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose101:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose102:
+ax_pose 24, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose103:
+ax_pose 19, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose104:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose105:
+ax_pose 23, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose106:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose107:
+ax_pose 6, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose108:
+ax_pose 22, 0x01e5, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose109:
+ax_pose 17, 0x01e7, 0x80ec, 0x1c00
+ax_pose_terminator
+sNidorinoPose110:
+ax_pose 3, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose111:
+ax_pose 21, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose112:
+ax_pose 16, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose113:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose114:
+ax_pose 25, 0x01eb, 0x80f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose115:
+ax_pose 26, 0x01eb, 0x80f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose116:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose117:
+ax_pose 27, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose118:
+ax_pose 28, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose119:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose120:
+ax_pose 29, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose121:
+ax_pose 30, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose122:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose123:
+ax_pose 31, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose124:
+ax_pose 32, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose125:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose126:
+ax_pose 33, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose127:
+ax_pose 34, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose128:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose129:
+ax_pose 31, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose130:
+ax_pose 32, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose131:
+ax_pose 6, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose132:
+ax_pose 29, 0x01e7, 0x80ed, 0x1c00
+ax_pose_terminator
+sNidorinoPose133:
+ax_pose 30, 0x01e7, 0x80ed, 0x1c00
+ax_pose_terminator
+sNidorinoPose134:
+ax_pose 3, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose135:
+ax_pose 27, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose136:
+ax_pose 28, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose137:
+ax_pose 35, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose138:
+ax_pose 36, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose139:
+ax_pose 37, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose140:
+ax_pose 38, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose141:
+ax_pose 39, 0x01e5, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose142:
+ax_pose 40, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose143:
+ax_pose 41, 0x01e5, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose144:
+ax_pose 40, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose145:
+ax_pose 39, 0x01e5, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose146:
+ax_pose 38, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose147:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose148:
+ax_pose 1, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose149:
+ax_pose 2, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose150:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose151:
+ax_pose 4, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose152:
+ax_pose 5, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose153:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose154:
+ax_pose 7, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose155:
+ax_pose 8, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose156:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose157:
+ax_pose 10, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose158:
+ax_pose 11, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose159:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose160:
+ax_pose 13, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose161:
+ax_pose 14, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose162:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose163:
+ax_pose 10, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose164:
+ax_pose 11, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose165:
+ax_pose 6, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose166:
+ax_pose 7, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose167:
+ax_pose 8, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose168:
+ax_pose 3, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose169:
+ax_pose 4, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose170:
+ax_pose 5, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose171:
+ax_pose 15, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose172:
+ax_pose 16, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose173:
+ax_pose 17, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose174:
+ax_pose 18, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose175:
+ax_pose 19, 0x01e8, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose176:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose177:
+ax_pose 17, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose178:
+ax_pose 16, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose179:
+ax_pose 15, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose180:
+ax_pose 16, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose181:
+ax_pose 17, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose182:
+ax_pose 18, 0x01ea, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose183:
+ax_pose 19, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose184:
+ax_pose 18, 0x01ea, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose185:
+ax_pose 17, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose186:
+ax_pose 16, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose187:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose188:
+ax_pose 20, 0x01e6, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose189:
+ax_pose 15, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose190:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose191:
+ax_pose 21, 0x01e4, 0x90f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose192:
+ax_pose 16, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose193:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose194:
+ax_pose 22, 0x01e5, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose195:
+ax_pose 17, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose196:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose197:
+ax_pose 23, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose198:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose199:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose200:
+ax_pose 24, 0x01e7, 0x80ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose201:
+ax_pose 19, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose202:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose203:
+ax_pose 23, 0x01e7, 0x80ed, 0x1c00
+ax_pose_terminator
+sNidorinoPose204:
+ax_pose 18, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose205:
+ax_pose 6, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose206:
+ax_pose 22, 0x01e5, 0x80ed, 0x1c00
+ax_pose_terminator
+sNidorinoPose207:
+ax_pose 17, 0x01e7, 0x80ed, 0x1c00
+ax_pose_terminator
+sNidorinoPose208:
+ax_pose 3, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose209:
+ax_pose 21, 0x01e4, 0x80ed, 0x1c00
+ax_pose_terminator
+sNidorinoPose210:
+ax_pose 16, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose211:
+ax_pose 15, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sNidorinoPose212:
+ax_pose 16, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose213:
+ax_pose 17, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose214:
+ax_pose 18, 0x01ea, 0x80f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose215:
+ax_pose 19, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose216:
+ax_pose 18, 0x01ea, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose217:
+ax_pose 17, 0x01e7, 0x90f2, 0x1c00
+ax_pose_terminator
+sNidorinoPose218:
+ax_pose 16, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose219:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sNidorinoPose220:
+ax_pose 3, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose221:
+ax_pose 6, 0x01e7, 0x80ee, 0x1c00
+ax_pose_terminator
+sNidorinoPose222:
+ax_pose 9, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose223:
+ax_pose 12, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sNidorinoPose224:
+ax_pose 9, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sNidorinoPose225:
+ax_pose 6, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sNidorinoPose226:
+ax_pose 3, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+.align 2
+sNidorinoAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 26, -1, -4, -1, -4,
+ax_anim 1, 0, 25, -1, 0, -1, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim 2, 0, 24, 0, 3, 0, 3,
+ax_anim_terminator
+sNidorinoAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -5, -4, -5, -4,
+ax_anim 1, 0, 30, 1, -2, 1, -2,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sNidorinoAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 33, -4, 1, -4, 1,
+ax_anim 1, 0, 34, 2, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 1, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 0, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim_terminator
+sNidorinoAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 2, 1, 2, 1,
+ax_anim 1, 2, 39, 4, -2, 4, -2,
+ax_anim 1, 0, 39, 11, -14, 11, -14,
+ax_anim 2, 0, 39, 15, -20, 15, -20,
+ax_anim 2, 1, 39, 16, -19, 16, -19,
+ax_anim 2, 0, 39, 15, -20, 15, -20,
+ax_anim 2, 0, 39, 16, -19, 16, -19,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim 2, 0, 36, 3, -3, 3, -3,
+ax_anim_terminator
+sNidorinoAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 42, -1, 0, -1, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -14, 0, -14,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 1, 43, -1, -20, -1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, -1, -20, -1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim 2, 0, 40, 0, -3, 0, -3,
+ax_anim_terminator
+sNidorinoAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 46, -2, 1, -2, 1,
+ax_anim 1, 2, 47, -4, -2, -4, -2,
+ax_anim 1, 0, 47, -11, -14, -11, -14,
+ax_anim 2, 0, 47, -15, -20, -15, -20,
+ax_anim 2, 1, 47, -16, -19, -16, -19,
+ax_anim 2, 0, 47, -15, -20, -15, -20,
+ax_anim 2, 0, 47, -16, -19, -16, -19,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim 2, 0, 44, -3, -3, -3, -3,
+ax_anim_terminator
+sNidorinoAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 4, 1, 4, 1,
+ax_anim 1, 0, 50, -2, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 1, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim 2, 0, 48, -3, 0, -3, 0,
+ax_anim_terminator
+sNidorinoAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 5, -4, 5, -4,
+ax_anim 1, 0, 54, -1, -2, -1, -2,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 1, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 52, -8, 8, -8, 8,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 6, 0, 58, -1, -4, -1, -4,
+ax_anim 1, 0, 57, -1, 0, -1, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sNidorinoAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 6, 0, 61, -5, -4, -5, -4,
+ax_anim 1, 0, 62, 1, -2, 1, -2,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 1, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 60, 8, 8, 8, 8,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sNidorinoAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 6, 0, 65, -4, 1, -4, 1,
+ax_anim 1, 0, 66, 2, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 1, 67, 15, 1, 15, 1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 67, 15, 1, 15, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim 2, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sNidorinoAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 6, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 2, 1, 2, 1,
+ax_anim 1, 2, 71, 4, -2, 4, -2,
+ax_anim 1, 0, 71, 11, -14, 11, -14,
+ax_anim 2, 0, 71, 15, -20, 15, -20,
+ax_anim 2, 1, 71, 16, -19, 16, -19,
+ax_anim 2, 0, 71, 15, -20, 15, -20,
+ax_anim 2, 0, 71, 16, -19, 16, -19,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim 2, 0, 68, 3, -3, 3, -3,
+ax_anim_terminator
+sNidorinoAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 74, -1, 0, -1, 0,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -14, 0, -14,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 1, 75, -1, -20, -1, -20,
+ax_anim 2, 0, 75, 0, -20, 0, -20,
+ax_anim 2, 0, 75, -1, -20, -1, -20,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sNidorinoAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 6, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 78, -2, 1, -2, 1,
+ax_anim 1, 2, 79, -4, -2, -4, -2,
+ax_anim 1, 0, 79, -11, -14, -11, -14,
+ax_anim 2, 0, 79, -15, -20, -15, -20,
+ax_anim 2, 1, 79, -16, -19, -16, -19,
+ax_anim 2, 0, 79, -15, -20, -15, -20,
+ax_anim 2, 0, 79, -16, -19, -16, -19,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim 2, 0, 76, -3, -3, -3, -3,
+ax_anim_terminator
+sNidorinoAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 6, 0, 81, 4, 1, 4, 1,
+ax_anim 1, 0, 82, -2, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 1, 83, -15, 1, -15, 1,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 83, -15, 1, -15, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim 2, 0, 80, -3, 0, -3, 0,
+ax_anim_terminator
+sNidorinoAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 6, 0, 85, 5, -4, 5, -4,
+ax_anim 1, 0, 86, -1, -2, -1, -2,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 1, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 84, -8, 8, -8, 8,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 89, 0, -3, 0, -3,
+ax_anim 6, 2, 89, 0, -4, 0, -4,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 1, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sNidorinoAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim 6, 2, 92, -4, -4, -4, -4,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 1, 93, 6, 4, 6, 4,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 6, 4, 6, 4,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 6, 4, 6, 4,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim_terminator
+sNidorinoAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 6, 2, 95, -4, 0, -4, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 1, 96, 5, -1, 5, -1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, -1, 5, -1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, -1, 5, -1,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim_terminator
+sNidorinoAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim 6, 2, 98, -4, 4, -4, 4,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 1, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 6, -4, 6, -4,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim_terminator
+sNidorinoAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 2, 0, 101, 0, 3, 0, 3,
+ax_anim 6, 2, 101, 0, 4, 0, 4,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 1, 102, 1, -5, 1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 1, -5, 1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, 1, -5, 1, -5,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sNidorinoAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 2, 0, 104, 3, 3, 3, 3,
+ax_anim 6, 2, 104, 4, 4, 4, 4,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 1, 105, -6, -4, -6, -4,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -6, -4, -6, -4,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -6, -4, -6, -4,
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim_terminator
+sNidorinoAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 3, 0, 3, 0,
+ax_anim 6, 2, 107, 4, 0, 4, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 1, 108, -5, -1, -5, -1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, -1, -5, -1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, -1, -5, -1,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim_terminator
+sNidorinoAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 110, 3, -3, 3, -3,
+ax_anim 6, 2, 110, 4, -4, 4, -4,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 1, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_5_1:
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 3, 0, 112, 0, -5, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_5_2:
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 1, 0, 115, 0, -4, 0, 0,
+ax_anim 3, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_5_3:
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 1, 0, 118, 0, -4, 0, 0,
+ax_anim 3, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_5_4:
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 1, 0, 121, 0, -4, 0, 0,
+ax_anim 3, 0, 121, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_5_5:
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 1, 0, 124, 0, -4, 0, 0,
+ax_anim 3, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_5_6:
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 3, 0, 127, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -4, 0, 0,
+ax_anim 1, 0, 127, 0, -2, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_5_7:
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 3, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_5_8:
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 1, 0, 133, 0, -4, 0, 0,
+ax_anim 3, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sNidorinoAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sNidorinoAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sNidorinoAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sNidorinoAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sNidorinoAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sNidorinoAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sNidorinoAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 1, -3, 1, -3,
+ax_anim 2, 0, 147, 0, -3, 0, -3,
+ax_anim 2, 0, 147, 1, -3, 1, -3,
+ax_anim 2, 0, 147, 0, -3, 0, -3,
+ax_anim 2, 0, 147, 1, -3, 1, -3,
+ax_anim 2, 0, 147, 0, -3, 0, -3,
+ax_anim 2, 0, 147, 1, -3, 1, -3,
+ax_anim 2, 0, 147, 0, -3, 0, -3,
+ax_anim 6, 0, 147, 1, -3, 1, -3,
+ax_anim_terminator
+sNidorinoAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 10, 0, 150, -4, -2, -4, -2,
+ax_anim 2, 0, 150, -5, -2, -5, -2,
+ax_anim 2, 0, 150, -4, -2, -4, -2,
+ax_anim 2, 0, 150, -5, -2, -5, -2,
+ax_anim 2, 0, 150, -4, -2, -4, -2,
+ax_anim 2, 0, 150, -5, -2, -5, -2,
+ax_anim 2, 0, 150, -4, -2, -4, -2,
+ax_anim 2, 0, 150, -5, -2, -5, -2,
+ax_anim 6, 0, 150, -4, -2, -4, -2,
+ax_anim_terminator
+sNidorinoAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 10, 0, 153, -3, 1, -3, 1,
+ax_anim 2, 0, 153, -4, 1, -4, 1,
+ax_anim 2, 0, 153, -3, 1, -3, 1,
+ax_anim 2, 0, 153, -4, 1, -4, 1,
+ax_anim 2, 0, 153, -3, 1, -3, 1,
+ax_anim 2, 0, 153, -4, 1, -4, 1,
+ax_anim 2, 0, 153, -3, 1, -3, 1,
+ax_anim 2, 0, 153, -4, 1, -4, 1,
+ax_anim 6, 0, 153, -3, 1, -3, 1,
+ax_anim_terminator
+sNidorinoAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 6, 0, 156, -1, 0, -1, 0,
+ax_anim_terminator
+sNidorinoAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, 1, 0, 1,
+ax_anim 2, 0, 159, -1, 1, -1, 1,
+ax_anim 2, 0, 159, 0, 1, 0, 1,
+ax_anim 2, 0, 159, -1, 1, -1, 1,
+ax_anim 2, 0, 159, 0, 1, 0, 1,
+ax_anim 2, 0, 159, -1, 1, -1, 1,
+ax_anim 2, 0, 159, 0, 1, 0, 1,
+ax_anim 2, 0, 159, -1, 1, -1, 1,
+ax_anim 6, 0, 159, 0, 1, 0, 1,
+ax_anim_terminator
+sNidorinoAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 1, 0, 1, 0,
+ax_anim_terminator
+sNidorinoAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 3, 1, 3, 1,
+ax_anim 2, 0, 165, 2, 1, 2, 1,
+ax_anim 2, 0, 165, 3, 1, 3, 1,
+ax_anim 2, 0, 165, 2, 1, 2, 1,
+ax_anim 2, 0, 165, 3, 1, 3, 1,
+ax_anim 2, 0, 165, 2, 1, 2, 1,
+ax_anim 2, 0, 165, 3, 1, 3, 1,
+ax_anim 2, 0, 165, 2, 1, 2, 1,
+ax_anim 6, 0, 165, 3, 1, 3, 1,
+ax_anim_terminator
+sNidorinoAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 4, -2, 4, -2,
+ax_anim 2, 0, 168, 3, -2, 3, -2,
+ax_anim 2, 0, 168, 4, -2, 4, -2,
+ax_anim 2, 0, 168, 3, -2, 3, -2,
+ax_anim 2, 0, 168, 4, -2, 4, -2,
+ax_anim 2, 0, 168, 3, -2, 3, -2,
+ax_anim 2, 0, 168, 4, -2, 4, -2,
+ax_anim 2, 0, 168, 3, -2, 3, -2,
+ax_anim 6, 0, 168, 4, -2, 4, -2,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 15, 7, 15,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -7, 15, -7, 15,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 18, 3,
+ax_anim 2, 0, 172, 19, 10, 21, 10,
+ax_anim 3, 0, 173, 17, 19, 19, 20,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 18, -2, 18, -2,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 18, -22, 18, -22,
+ax_anim 2, 3, 172, 20, -15, 20, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -18, -22, -18, -22,
+ax_anim 2, 3, 176, -20, -15, -20, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -18, -2, -18, -2,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -19, 10, -19, 10,
+ax_anim 3, 0, 175, -17, 19, -17, 19,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_10_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 6, -6, 6, -6,
+ax_anim 2, 0, 185, -6, 6, -6, 6,
+ax_anim 2, 0, 185, 10, -10, 10, -10,
+ax_anim 2, 0, 185, -10, 10, -10, 10,
+ax_anim 2, 0, 185, 12, -12, 12, -12,
+ax_anim 3, 0, 185, -12, 12, -12, 12,
+ax_anim 3, 0, 185, 13, -13, 13, -13,
+ax_anim 3, 0, 185, -13, 13, -13, 13,
+ax_anim 2, 0, 185, 12, -12, 12, -12,
+ax_anim 3, 0, 185, -12, 12, -12, 12,
+ax_anim 2, 0, 185, 10, -10, 10, -10,
+ax_anim 2, 0, 185, -10, 10, -10, 10,
+ax_anim 2, 0, 185, 6, -6, 6, -6,
+ax_anim 2, 0, 185, -6, 6, -6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_10_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_10_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -6, -6, -6, -6,
+ax_anim 2, 0, 183, 6, 6, 6, 6,
+ax_anim 2, 0, 183, -10, -10, -10, -10,
+ax_anim 2, 0, 183, 10, 10, 10, 10,
+ax_anim 2, 0, 183, -12, -12, -12, -12,
+ax_anim 3, 0, 183, 12, 12, 12, 12,
+ax_anim 3, 0, 183, -13, -13, -13, -13,
+ax_anim 3, 0, 183, 13, 13, 13, 13,
+ax_anim 2, 0, 183, -12, -12, -12, -12,
+ax_anim 3, 0, 183, 12, 12, 12, 12,
+ax_anim 2, 0, 183, -10, -10, -10, -10,
+ax_anim 2, 0, 183, 10, 10, 10, 10,
+ax_anim 2, 0, 183, -6, -6, -6, -6,
+ax_anim 2, 0, 183, 6, 6, 6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_10_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 6, -6, 6, -6,
+ax_anim 2, 0, 181, -6, 6, -6, 6,
+ax_anim 2, 0, 181, 10, -10, 10, -10,
+ax_anim 2, 0, 181, -10, 10, -10, 10,
+ax_anim 2, 0, 181, 12, -12, 12, -12,
+ax_anim 3, 0, 181, -12, 12, -12, 12,
+ax_anim 3, 0, 181, 13, -13, 13, -13,
+ax_anim 3, 0, 181, -13, 13, -13, 13,
+ax_anim 2, 0, 181, 12, -12, 12, -12,
+ax_anim 3, 0, 181, -12, 12, -12, 12,
+ax_anim 2, 0, 181, 10, -10, 10, -10,
+ax_anim 2, 0, 181, -10, 10, -10, 10,
+ax_anim 2, 0, 181, 6, -6, 6, -6,
+ax_anim 2, 0, 181, -6, 6, -6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_10_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_10_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 3, 0, 179, -13, -13, -13, -13,
+ax_anim 3, 0, 179, 13, 13, 13, 13,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -25, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -26, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -26, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -26, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -26, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, 0,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNidorinoAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sNidorinoGfx1:
+.incbin "baserom.gba", 0x672684, 0x200
+sNidorinoSprites1:
+ax_sprite sNidorinoGfx1, 0x200
+ax_sprite_terminator
+sNidorinoGfx2:
+.incbin "baserom.gba", 0x672894, 0x200
+sNidorinoSprites2:
+ax_sprite sNidorinoGfx2, 0x200
+ax_sprite_terminator
+sNidorinoGfx3:
+.incbin "baserom.gba", 0x672AA4, 0x200
+sNidorinoSprites3:
+ax_sprite sNidorinoGfx3, 0x200
+ax_sprite_terminator
+sNidorinoGfx4:
+.incbin "baserom.gba", 0x672CB4, 0x200
+sNidorinoSprites4:
+ax_sprite sNidorinoGfx4, 0x200
+ax_sprite_terminator
+sNidorinoGfx5:
+.incbin "baserom.gba", 0x672EC4, 0x200
+sNidorinoSprites5:
+ax_sprite sNidorinoGfx5, 0x200
+ax_sprite_terminator
+sNidorinoGfx6:
+.incbin "baserom.gba", 0x6730D4, 0x200
+sNidorinoSprites6:
+ax_sprite sNidorinoGfx6, 0x200
+ax_sprite_terminator
+sNidorinoGfx7:
+.incbin "baserom.gba", 0x6732E4, 0x200
+sNidorinoSprites7:
+ax_sprite sNidorinoGfx7, 0x200
+ax_sprite_terminator
+sNidorinoGfx8:
+.incbin "baserom.gba", 0x6734F4, 0x200
+sNidorinoSprites8:
+ax_sprite sNidorinoGfx8, 0x200
+ax_sprite_terminator
+sNidorinoGfx9:
+.incbin "baserom.gba", 0x673704, 0x200
+sNidorinoSprites9:
+ax_sprite sNidorinoGfx9, 0x200
+ax_sprite_terminator
+sNidorinoGfx10:
+.incbin "baserom.gba", 0x673914, 0x200
+sNidorinoSprites10:
+ax_sprite sNidorinoGfx10, 0x200
+ax_sprite_terminator
+sNidorinoGfx11:
+.incbin "baserom.gba", 0x673B24, 0x200
+sNidorinoSprites11:
+ax_sprite sNidorinoGfx11, 0x200
+ax_sprite_terminator
+sNidorinoGfx12:
+.incbin "baserom.gba", 0x673D34, 0x200
+sNidorinoSprites12:
+ax_sprite sNidorinoGfx12, 0x200
+ax_sprite_terminator
+sNidorinoGfx13:
+.incbin "baserom.gba", 0x673F44, 0x200
+sNidorinoSprites13:
+ax_sprite sNidorinoGfx13, 0x200
+ax_sprite_terminator
+sNidorinoGfx14:
+.incbin "baserom.gba", 0x674154, 0x200
+sNidorinoSprites14:
+ax_sprite sNidorinoGfx14, 0x200
+ax_sprite_terminator
+sNidorinoGfx15:
+.incbin "baserom.gba", 0x674364, 0x200
+sNidorinoSprites15:
+ax_sprite sNidorinoGfx15, 0x200
+ax_sprite_terminator
+sNidorinoGfx16:
+.incbin "baserom.gba", 0x674574, 0x20
+sNidorinoGfx16_1:
+.incbin "baserom.gba", 0x674594, 0x60
+sNidorinoGfx16_2:
+.incbin "baserom.gba", 0x6745F4, 0x60
+sNidorinoGfx16_3:
+.incbin "baserom.gba", 0x674654, 0x60
+sNidorinoSprites16:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidorinoGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinoGfx17:
+.incbin "baserom.gba", 0x674704, 0x60
+sNidorinoGfx17_1:
+.incbin "baserom.gba", 0x674764, 0x180
+sNidorinoSprites17:
+ax_sprite sNidorinoGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx17_1, 0x180
+ax_sprite_terminator
+sNidorinoGfx18:
+.incbin "baserom.gba", 0x674904, 0x40
+sNidorinoGfx18_1:
+.incbin "baserom.gba", 0x674944, 0x180
+sNidorinoSprites18:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx18_1, 0x180
+ax_sprite_terminator
+sNidorinoGfx19:
+.incbin "baserom.gba", 0x674AEC, 0x60
+sNidorinoGfx19_1:
+.incbin "baserom.gba", 0x674B4C, 0x160
+sNidorinoSprites19:
+ax_sprite sNidorinoGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinoGfx20:
+.incbin "baserom.gba", 0x674CD4, 0x200
+sNidorinoSprites20:
+ax_sprite sNidorinoGfx20, 0x200
+ax_sprite_terminator
+sNidorinoGfx21:
+.incbin "baserom.gba", 0x674EE4, 0x60
+sNidorinoGfx21_1:
+.incbin "baserom.gba", 0x674F44, 0xE0
+sNidorinoGfx21_2:
+.incbin "baserom.gba", 0x675024, 0x60
+sNidorinoSprites21:
+ax_sprite sNidorinoGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx21_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinoGfx22:
+.incbin "baserom.gba", 0x6750BC, 0x40
+sNidorinoGfx22_1:
+.incbin "baserom.gba", 0x6750FC, 0x100
+sNidorinoGfx22_2:
+.incbin "baserom.gba", 0x6751FC, 0x60
+sNidorinoSprites22:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx22_2, 0x60
+ax_sprite_terminator
+sNidorinoGfx23:
+.incbin "baserom.gba", 0x675294, 0x40
+sNidorinoGfx23_1:
+.incbin "baserom.gba", 0x6752D4, 0xE0
+sNidorinoGfx23_2:
+.incbin "baserom.gba", 0x6753B4, 0x40
+sNidorinoSprites23:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNidorinoGfx23_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sNidorinoGfx23_2, 0x40
+ax_sprite_terminator
+sNidorinoGfx24:
+.incbin "baserom.gba", 0x67542C, 0xE0
+sNidorinoGfx24_1:
+.incbin "baserom.gba", 0x67550C, 0x60
+sNidorinoGfx24_2:
+.incbin "baserom.gba", 0x67556C, 0x60
+sNidorinoSprites24:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx24, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx24_2, 0x60
+ax_sprite_terminator
+sNidorinoGfx25:
+.incbin "baserom.gba", 0x675604, 0xE0
+sNidorinoGfx25_1:
+.incbin "baserom.gba", 0x6756E4, 0xE0
+sNidorinoSprites25:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx25, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx25_1, 0xe0
+ax_sprite_terminator
+sNidorinoGfx26:
+.incbin "baserom.gba", 0x6757EC, 0x40
+sNidorinoGfx26_1:
+.incbin "baserom.gba", 0x67582C, 0x60
+sNidorinoGfx26_2:
+.incbin "baserom.gba", 0x67588C, 0xE0
+sNidorinoSprites26:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx26_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinoGfx27:
+.incbin "baserom.gba", 0x6759AC, 0x60
+sNidorinoGfx27_1:
+.incbin "baserom.gba", 0x675A0C, 0x160
+sNidorinoSprites27:
+ax_sprite sNidorinoGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinoGfx28:
+.incbin "baserom.gba", 0x675B94, 0x60
+sNidorinoGfx28_1:
+.incbin "baserom.gba", 0x675BF4, 0x180
+sNidorinoSprites28:
+ax_sprite sNidorinoGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx28_1, 0x180
+ax_sprite_terminator
+sNidorinoGfx29:
+.incbin "baserom.gba", 0x675D94, 0x60
+sNidorinoGfx29_1:
+.incbin "baserom.gba", 0x675DF4, 0x180
+sNidorinoSprites29:
+ax_sprite sNidorinoGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx29_1, 0x180
+ax_sprite_terminator
+sNidorinoGfx30:
+.incbin "baserom.gba", 0x675F94, 0x20
+sNidorinoGfx30_1:
+.incbin "baserom.gba", 0x675FB4, 0x180
+sNidorinoSprites30:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNidorinoGfx30_1, 0x180
+ax_sprite_terminator
+sNidorinoGfx31:
+.incbin "baserom.gba", 0x67615C, 0x40
+sNidorinoGfx31_1:
+.incbin "baserom.gba", 0x67619C, 0x180
+sNidorinoSprites31:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx31_1, 0x180
+ax_sprite_terminator
+sNidorinoGfx32:
+.incbin "baserom.gba", 0x676344, 0x60
+sNidorinoGfx32_1:
+.incbin "baserom.gba", 0x6763A4, 0x160
+sNidorinoSprites32:
+ax_sprite sNidorinoGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx32_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinoGfx33:
+.incbin "baserom.gba", 0x67652C, 0x40
+sNidorinoGfx33_1:
+.incbin "baserom.gba", 0x67656C, 0x160
+sNidorinoSprites33:
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNidorinoGfx33_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNidorinoGfx34:
+.incbin "baserom.gba", 0x6766FC, 0x200
+sNidorinoSprites34:
+ax_sprite sNidorinoGfx34, 0x200
+ax_sprite_terminator
+sNidorinoGfx35:
+.incbin "baserom.gba", 0x67690C, 0x200
+sNidorinoSprites35:
+ax_sprite sNidorinoGfx35, 0x200
+ax_sprite_terminator
+sNidorinoGfx36:
+.incbin "baserom.gba", 0x676B1C, 0x200
+sNidorinoSprites36:
+ax_sprite sNidorinoGfx36, 0x200
+ax_sprite_terminator
+sNidorinoGfx37:
+.incbin "baserom.gba", 0x676D2C, 0x200
+sNidorinoSprites37:
+ax_sprite sNidorinoGfx37, 0x200
+ax_sprite_terminator
+sNidorinoGfx38:
+.incbin "baserom.gba", 0x676F3C, 0x200
+sNidorinoSprites38:
+ax_sprite sNidorinoGfx38, 0x200
+ax_sprite_terminator
+sNidorinoGfx39:
+.incbin "baserom.gba", 0x67714C, 0x200
+sNidorinoSprites39:
+ax_sprite sNidorinoGfx39, 0x200
+ax_sprite_terminator
+sNidorinoGfx40:
+.incbin "baserom.gba", 0x67735C, 0x200
+sNidorinoSprites40:
+ax_sprite sNidorinoGfx40, 0x200
+ax_sprite_terminator
+sNidorinoGfx41:
+.incbin "baserom.gba", 0x67756C, 0x200
+sNidorinoSprites41:
+ax_sprite sNidorinoGfx41, 0x200
+ax_sprite_terminator
+sNidorinoGfx42:
+.incbin "baserom.gba", 0x67777C, 0x200
+sNidorinoSprites42:
+ax_sprite sNidorinoGfx42, 0x200
+ax_sprite_terminator
+sAxPosesNidorino:
+.4byte sNidorinoPose1
+.4byte sNidorinoPose2
+.4byte sNidorinoPose3
+.4byte sNidorinoPose4
+.4byte sNidorinoPose5
+.4byte sNidorinoPose6
+.4byte sNidorinoPose7
+.4byte sNidorinoPose8
+.4byte sNidorinoPose9
+.4byte sNidorinoPose10
+.4byte sNidorinoPose11
+.4byte sNidorinoPose12
+.4byte sNidorinoPose13
+.4byte sNidorinoPose14
+.4byte sNidorinoPose15
+.4byte sNidorinoPose16
+.4byte sNidorinoPose17
+.4byte sNidorinoPose18
+.4byte sNidorinoPose19
+.4byte sNidorinoPose20
+.4byte sNidorinoPose21
+.4byte sNidorinoPose22
+.4byte sNidorinoPose23
+.4byte sNidorinoPose24
+.4byte sNidorinoPose25
+.4byte sNidorinoPose26
+.4byte sNidorinoPose27
+.4byte sNidorinoPose28
+.4byte sNidorinoPose29
+.4byte sNidorinoPose30
+.4byte sNidorinoPose31
+.4byte sNidorinoPose32
+.4byte sNidorinoPose33
+.4byte sNidorinoPose34
+.4byte sNidorinoPose35
+.4byte sNidorinoPose36
+.4byte sNidorinoPose37
+.4byte sNidorinoPose38
+.4byte sNidorinoPose39
+.4byte sNidorinoPose40
+.4byte sNidorinoPose41
+.4byte sNidorinoPose42
+.4byte sNidorinoPose43
+.4byte sNidorinoPose44
+.4byte sNidorinoPose45
+.4byte sNidorinoPose46
+.4byte sNidorinoPose47
+.4byte sNidorinoPose48
+.4byte sNidorinoPose49
+.4byte sNidorinoPose50
+.4byte sNidorinoPose51
+.4byte sNidorinoPose52
+.4byte sNidorinoPose53
+.4byte sNidorinoPose54
+.4byte sNidorinoPose55
+.4byte sNidorinoPose56
+.4byte sNidorinoPose57
+.4byte sNidorinoPose58
+.4byte sNidorinoPose59
+.4byte sNidorinoPose60
+.4byte sNidorinoPose61
+.4byte sNidorinoPose62
+.4byte sNidorinoPose63
+.4byte sNidorinoPose64
+.4byte sNidorinoPose65
+.4byte sNidorinoPose66
+.4byte sNidorinoPose67
+.4byte sNidorinoPose68
+.4byte sNidorinoPose69
+.4byte sNidorinoPose70
+.4byte sNidorinoPose71
+.4byte sNidorinoPose72
+.4byte sNidorinoPose73
+.4byte sNidorinoPose74
+.4byte sNidorinoPose75
+.4byte sNidorinoPose76
+.4byte sNidorinoPose77
+.4byte sNidorinoPose78
+.4byte sNidorinoPose79
+.4byte sNidorinoPose80
+.4byte sNidorinoPose81
+.4byte sNidorinoPose82
+.4byte sNidorinoPose83
+.4byte sNidorinoPose84
+.4byte sNidorinoPose85
+.4byte sNidorinoPose86
+.4byte sNidorinoPose87
+.4byte sNidorinoPose88
+.4byte sNidorinoPose89
+.4byte sNidorinoPose90
+.4byte sNidorinoPose91
+.4byte sNidorinoPose92
+.4byte sNidorinoPose93
+.4byte sNidorinoPose94
+.4byte sNidorinoPose95
+.4byte sNidorinoPose96
+.4byte sNidorinoPose97
+.4byte sNidorinoPose98
+.4byte sNidorinoPose99
+.4byte sNidorinoPose100
+.4byte sNidorinoPose101
+.4byte sNidorinoPose102
+.4byte sNidorinoPose103
+.4byte sNidorinoPose104
+.4byte sNidorinoPose105
+.4byte sNidorinoPose106
+.4byte sNidorinoPose107
+.4byte sNidorinoPose108
+.4byte sNidorinoPose109
+.4byte sNidorinoPose110
+.4byte sNidorinoPose111
+.4byte sNidorinoPose112
+.4byte sNidorinoPose113
+.4byte sNidorinoPose114
+.4byte sNidorinoPose115
+.4byte sNidorinoPose116
+.4byte sNidorinoPose117
+.4byte sNidorinoPose118
+.4byte sNidorinoPose119
+.4byte sNidorinoPose120
+.4byte sNidorinoPose121
+.4byte sNidorinoPose122
+.4byte sNidorinoPose123
+.4byte sNidorinoPose124
+.4byte sNidorinoPose125
+.4byte sNidorinoPose126
+.4byte sNidorinoPose127
+.4byte sNidorinoPose128
+.4byte sNidorinoPose129
+.4byte sNidorinoPose130
+.4byte sNidorinoPose131
+.4byte sNidorinoPose132
+.4byte sNidorinoPose133
+.4byte sNidorinoPose134
+.4byte sNidorinoPose135
+.4byte sNidorinoPose136
+.4byte sNidorinoPose137
+.4byte sNidorinoPose138
+.4byte sNidorinoPose139
+.4byte sNidorinoPose140
+.4byte sNidorinoPose141
+.4byte sNidorinoPose142
+.4byte sNidorinoPose143
+.4byte sNidorinoPose144
+.4byte sNidorinoPose145
+.4byte sNidorinoPose146
+.4byte sNidorinoPose147
+.4byte sNidorinoPose148
+.4byte sNidorinoPose149
+.4byte sNidorinoPose150
+.4byte sNidorinoPose151
+.4byte sNidorinoPose152
+.4byte sNidorinoPose153
+.4byte sNidorinoPose154
+.4byte sNidorinoPose155
+.4byte sNidorinoPose156
+.4byte sNidorinoPose157
+.4byte sNidorinoPose158
+.4byte sNidorinoPose159
+.4byte sNidorinoPose160
+.4byte sNidorinoPose161
+.4byte sNidorinoPose162
+.4byte sNidorinoPose163
+.4byte sNidorinoPose164
+.4byte sNidorinoPose165
+.4byte sNidorinoPose166
+.4byte sNidorinoPose167
+.4byte sNidorinoPose168
+.4byte sNidorinoPose169
+.4byte sNidorinoPose170
+.4byte sNidorinoPose171
+.4byte sNidorinoPose172
+.4byte sNidorinoPose173
+.4byte sNidorinoPose174
+.4byte sNidorinoPose175
+.4byte sNidorinoPose176
+.4byte sNidorinoPose177
+.4byte sNidorinoPose178
+.4byte sNidorinoPose179
+.4byte sNidorinoPose180
+.4byte sNidorinoPose181
+.4byte sNidorinoPose182
+.4byte sNidorinoPose183
+.4byte sNidorinoPose184
+.4byte sNidorinoPose185
+.4byte sNidorinoPose186
+.4byte sNidorinoPose187
+.4byte sNidorinoPose188
+.4byte sNidorinoPose189
+.4byte sNidorinoPose190
+.4byte sNidorinoPose191
+.4byte sNidorinoPose192
+.4byte sNidorinoPose193
+.4byte sNidorinoPose194
+.4byte sNidorinoPose195
+.4byte sNidorinoPose196
+.4byte sNidorinoPose197
+.4byte sNidorinoPose198
+.4byte sNidorinoPose199
+.4byte sNidorinoPose200
+.4byte sNidorinoPose201
+.4byte sNidorinoPose202
+.4byte sNidorinoPose203
+.4byte sNidorinoPose204
+.4byte sNidorinoPose205
+.4byte sNidorinoPose206
+.4byte sNidorinoPose207
+.4byte sNidorinoPose208
+.4byte sNidorinoPose209
+.4byte sNidorinoPose210
+.4byte sNidorinoPose211
+.4byte sNidorinoPose212
+.4byte sNidorinoPose213
+.4byte sNidorinoPose214
+.4byte sNidorinoPose215
+.4byte sNidorinoPose216
+.4byte sNidorinoPose217
+.4byte sNidorinoPose218
+.4byte sNidorinoPose219
+.4byte sNidorinoPose220
+.4byte sNidorinoPose221
+.4byte sNidorinoPose222
+.4byte sNidorinoPose223
+.4byte sNidorinoPose224
+.4byte sNidorinoPose225
+.4byte sNidorinoPose226
+sAxPositionsNidorino:
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -2,    4, 	  -9,    0, 	   7,    4, 	  -2,   -7
+.2byte    1,    4, 	  -9,    4, 	   8,    0, 	   1,   -8
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+.2byte    8,    1, 	   3,   -3, 	   2,    4, 	   0,  -10
+.2byte    5,    1, 	   6,    1, 	  -4,    2, 	  -2,   -9
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    8,   -5, 	  -2,   -3, 	   5,    0, 	  -3,   -9
+.2byte    7,   -3, 	   6,   -2, 	  -1,    1, 	  -2,   -9
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte   11,   -9, 	  -5,   -5, 	   9,   -3, 	  -1,  -10
+.2byte   10,  -10, 	   0,  -10, 	   5,   -2, 	  -2,  -10
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   7,   -6, 	 -10,   -8, 	  -1,   -9
+.2byte   -3,  -12, 	   8,   -8, 	  -8,   -8, 	  -1,   -9
+.2byte  -12,  -10, 	   1,   -8, 	 -10,   -3, 	  -1,  -11
+.2byte  -13,   -9, 	   3,   -5, 	 -11,   -3, 	  -1,  -10
+.2byte  -12,  -10, 	  -2,  -10, 	  -7,   -2, 	   0,  -10
+.2byte  -10,   -4, 	  -5,   -3, 	  -4,    1, 	   0,   -9
+.2byte  -10,   -5, 	   0,   -3, 	  -7,    0, 	   1,   -9
+.2byte   -9,   -3, 	  -8,   -2, 	  -1,    1, 	   0,   -9
+.2byte   -9,    0, 	  -9,   -2, 	   0,    2, 	  -1,  -10
+.2byte  -10,    1, 	  -5,   -3, 	  -4,    4, 	  -2,  -10
+.2byte   -7,    1, 	  -8,    1, 	   2,    2, 	   0,   -9
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -2,    4, 	  -9,    0, 	   7,    4, 	  -2,   -7
+.2byte    1,    4, 	  -9,    4, 	   8,    0, 	   1,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -6
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+.2byte    8,    1, 	   3,   -3, 	   2,    4, 	   0,  -10
+.2byte    6,    1, 	   7,    1, 	  -3,    2, 	  -1,   -9
+.2byte    6,    0, 	   8,   -1, 	  -3,    2, 	   0,   -8
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    8,   -5, 	  -2,   -3, 	   5,    0, 	  -3,   -9
+.2byte    7,   -3, 	   6,   -2, 	  -1,    1, 	  -2,   -9
+.2byte    8,   -3, 	   4,   -2, 	   1,    1, 	  -2,   -8
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte   11,   -9, 	  -5,   -5, 	   9,   -3, 	  -1,  -10
+.2byte   10,  -10, 	   0,  -10, 	   5,   -2, 	  -2,  -10
+.2byte   11,  -12, 	  -2,   -7, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   7,   -6, 	 -10,   -8, 	  -1,   -9
+.2byte   -3,  -12, 	   8,   -8, 	  -8,   -8, 	  -1,   -9
+.2byte   -1,  -16, 	   8,   -6, 	 -10,   -6, 	  -1,  -10
+.2byte  -11,  -10, 	   2,   -8, 	  -9,   -3, 	   0,  -11
+.2byte  -12,   -9, 	   4,   -5, 	 -10,   -3, 	   0,  -10
+.2byte  -11,  -10, 	  -1,  -10, 	  -6,   -2, 	   1,  -10
+.2byte  -12,  -12, 	   1,   -7, 	  -9,   -3, 	   0,  -11
+.2byte   -9,   -4, 	  -4,   -3, 	  -3,    1, 	   1,   -9
+.2byte   -9,   -5, 	   1,   -3, 	  -6,    0, 	   2,   -9
+.2byte   -8,   -3, 	  -7,   -2, 	   0,    1, 	   1,   -9
+.2byte   -9,   -3, 	  -5,   -2, 	  -2,    1, 	   1,   -8
+.2byte   -8,    0, 	  -8,   -2, 	   1,    2, 	   0,  -10
+.2byte   -9,    1, 	  -4,   -3, 	  -3,    4, 	  -1,  -10
+.2byte   -7,    1, 	  -8,    1, 	   2,    2, 	   0,   -9
+.2byte   -7,    0, 	  -9,   -1, 	   2,    2, 	  -1,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -2,    4, 	  -9,    0, 	   7,    4, 	  -2,   -7
+.2byte    1,    4, 	  -9,    4, 	   8,    0, 	   1,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -6
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+.2byte    8,    1, 	   3,   -3, 	   2,    4, 	   0,  -10
+.2byte    6,    1, 	   7,    1, 	  -3,    2, 	  -1,   -9
+.2byte    6,    0, 	   8,   -1, 	  -3,    2, 	   0,   -8
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    8,   -5, 	  -2,   -3, 	   5,    0, 	  -3,   -9
+.2byte    7,   -3, 	   6,   -2, 	  -1,    1, 	  -2,   -9
+.2byte    8,   -3, 	   4,   -2, 	   1,    1, 	  -2,   -8
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte   11,   -9, 	  -5,   -5, 	   9,   -3, 	  -1,  -10
+.2byte   10,  -10, 	   0,  -10, 	   5,   -2, 	  -2,  -10
+.2byte   11,  -12, 	  -2,   -7, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   7,   -6, 	 -10,   -8, 	  -1,   -9
+.2byte   -3,  -12, 	   8,   -8, 	  -8,   -8, 	  -1,   -9
+.2byte   -1,  -16, 	   8,   -6, 	 -10,   -6, 	  -1,  -10
+.2byte  -11,  -10, 	   2,   -8, 	  -9,   -3, 	   0,  -11
+.2byte  -12,   -9, 	   4,   -5, 	 -10,   -3, 	   0,  -10
+.2byte  -11,  -10, 	  -1,  -10, 	  -6,   -2, 	   1,  -10
+.2byte  -12,  -12, 	   1,   -7, 	  -9,   -3, 	   0,  -11
+.2byte   -9,   -4, 	  -4,   -3, 	  -3,    1, 	   1,   -9
+.2byte   -9,   -5, 	   1,   -3, 	  -6,    0, 	   2,   -9
+.2byte   -8,   -3, 	  -7,   -2, 	   0,    1, 	   1,   -9
+.2byte   -9,   -3, 	  -5,   -2, 	  -2,    1, 	   1,   -8
+.2byte   -8,    0, 	  -8,   -2, 	   1,    2, 	   0,  -10
+.2byte   -9,    1, 	  -4,   -3, 	  -3,    4, 	  -1,  -10
+.2byte   -7,    1, 	  -8,    1, 	   2,    2, 	   0,   -9
+.2byte   -7,    0, 	  -9,   -1, 	   2,    2, 	  -1,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -6,  -21, 	 -11,   -9, 	   1,  -10, 	  -1,  -10
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -6
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+.2byte   -1,  -24, 	   6,  -14, 	  -1,   -8, 	  -6,  -12
+.2byte    6,    0, 	   8,   -1, 	  -3,    2, 	   0,   -8
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    2,  -20, 	  -6,  -14, 	   6,   -7, 	  -7,  -11
+.2byte    9,   -3, 	   5,   -2, 	   2,    1, 	  -1,   -8
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte   -4,  -23, 	  -9,  -18, 	   5,  -15, 	  -6,  -10
+.2byte   11,  -12, 	  -2,   -7, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte    8,  -19, 	  11,   -8, 	  -1,  -11, 	   0,   -8
+.2byte   -1,  -17, 	   8,   -7, 	 -10,   -7, 	  -1,  -11
+.2byte  -12,  -10, 	   1,   -8, 	 -10,   -3, 	  -1,  -11
+.2byte    2,  -23, 	   7,  -18, 	  -7,  -15, 	   4,  -10
+.2byte  -13,  -12, 	   0,   -7, 	 -10,   -3, 	  -1,  -11
+.2byte  -10,   -4, 	  -5,   -3, 	  -4,    1, 	   0,   -9
+.2byte   -4,  -20, 	   4,  -14, 	  -8,   -7, 	   5,  -11
+.2byte  -11,   -3, 	  -7,   -2, 	  -4,    1, 	  -1,   -8
+.2byte   -9,    0, 	  -9,   -2, 	   0,    2, 	  -1,  -10
+.2byte   -1,  -24, 	  -8,  -14, 	  -1,   -8, 	   4,  -12
+.2byte   -8,    0, 	 -10,   -1, 	   1,    2, 	  -2,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -1,    4, 	 -11,    1, 	   9,    1, 	  -2,   -7
+.2byte   -2,    4, 	 -11,    1, 	   9,    1, 	  -1,   -7
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+.2byte    7,    2, 	   8,   -1, 	  -4,    2, 	  -2,  -10
+.2byte    7,    1, 	   8,   -1, 	  -4,    2, 	  -1,   -9
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    9,   -2, 	   4,   -2, 	   1,    2, 	  -2,   -8
+.2byte    8,   -1, 	   4,   -1, 	   1,    2, 	  -2,   -8
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte   10,   -8, 	  -3,   -7, 	   9,   -2, 	  -1,  -10
+.2byte    9,   -6, 	  -1,   -7, 	   9,   -2, 	  -1,  -10
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte   -2,  -10, 	   9,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte    1,  -10, 	   9,   -7, 	 -11,   -7, 	   0,   -9
+.2byte  -12,  -10, 	   1,   -8, 	 -10,   -3, 	  -1,  -11
+.2byte  -12,   -8, 	   1,   -7, 	 -11,   -2, 	  -1,  -10
+.2byte  -11,   -6, 	  -1,   -7, 	 -11,   -2, 	  -1,  -10
+.2byte  -10,   -4, 	  -5,   -3, 	  -4,    1, 	   0,   -9
+.2byte  -11,   -2, 	  -6,   -2, 	  -3,    2, 	   0,   -8
+.2byte  -10,   -1, 	  -6,   -1, 	  -3,    2, 	   0,   -8
+.2byte   -9,    0, 	  -9,   -2, 	   0,    2, 	  -1,  -10
+.2byte   -9,    2, 	 -10,   -1, 	   2,    2, 	   0,  -10
+.2byte   -9,    1, 	 -10,   -1, 	   2,    2, 	  -1,   -9
+.2byte   -8,    1, 	 -11,    0, 	  -7,    2, 	  -1,   -7
+.2byte   -8,    2, 	 -11,    0, 	  -7,    2, 	  -1,   -6
+.2byte    0,    5, 	  -9,    2, 	   9,    2, 	   0,   -8
+.2byte    3,    1, 	  11,   -1, 	   1,    3, 	   0,   -8
+.2byte    6,    0, 	   3,   -1, 	   0,    1, 	  -2,   -8
+.2byte   10,   -6, 	   1,   -6, 	  10,   -1, 	   1,   -8
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -7
+.2byte   -9,   -6, 	   0,   -6, 	  -9,   -1, 	   0,   -8
+.2byte   -7,    0, 	  -4,   -1, 	  -1,    1, 	   1,   -8
+.2byte   -4,    1, 	 -12,   -1, 	  -2,    3, 	  -1,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -2,    4, 	  -9,    0, 	   7,    4, 	  -2,   -7
+.2byte    1,    4, 	  -9,    4, 	   8,    0, 	   1,   -8
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+.2byte    8,    1, 	   3,   -3, 	   2,    4, 	   0,  -10
+.2byte    5,    1, 	   6,    1, 	  -4,    2, 	  -2,   -9
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    8,   -5, 	  -2,   -3, 	   5,    0, 	  -3,   -9
+.2byte    7,   -3, 	   6,   -2, 	  -1,    1, 	  -2,   -9
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte   11,   -9, 	  -5,   -5, 	   9,   -3, 	  -1,  -10
+.2byte   10,  -10, 	   0,  -10, 	   5,   -2, 	  -2,  -10
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte    1,  -12, 	   7,   -6, 	 -10,   -8, 	  -1,   -9
+.2byte   -3,  -12, 	   8,   -8, 	  -8,   -8, 	  -1,   -9
+.2byte  -12,  -10, 	   1,   -8, 	 -10,   -3, 	  -1,  -11
+.2byte  -13,   -9, 	   3,   -5, 	 -11,   -3, 	  -1,  -10
+.2byte  -12,  -10, 	  -2,  -10, 	  -7,   -2, 	   0,  -10
+.2byte  -10,   -4, 	  -5,   -3, 	  -4,    1, 	   0,   -9
+.2byte  -10,   -5, 	   0,   -3, 	  -7,    0, 	   1,   -9
+.2byte   -9,   -3, 	  -8,   -2, 	  -1,    1, 	   0,   -9
+.2byte   -9,    0, 	  -9,   -2, 	   0,    2, 	  -1,  -10
+.2byte  -10,    1, 	  -5,   -3, 	  -4,    4, 	  -2,  -10
+.2byte   -7,    1, 	  -8,    1, 	   2,    2, 	   0,   -9
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -6
+.2byte   -7,    0, 	  -9,   -1, 	   2,    2, 	  -1,   -8
+.2byte   -9,   -3, 	  -5,   -2, 	  -2,    1, 	   1,   -8
+.2byte  -12,  -12, 	   1,   -7, 	  -9,   -3, 	   0,  -11
+.2byte   -1,  -16, 	   8,   -6, 	 -10,   -6, 	  -1,  -10
+.2byte   11,  -12, 	  -2,   -7, 	   8,   -3, 	  -1,  -11
+.2byte    8,   -3, 	   4,   -2, 	   1,    1, 	  -2,   -8
+.2byte    6,    0, 	   8,   -1, 	  -3,    2, 	   0,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -6
+.2byte   -7,    0, 	  -9,   -1, 	   2,    2, 	  -1,   -8
+.2byte   -9,   -3, 	  -5,   -2, 	  -2,    1, 	   1,   -8
+.2byte  -12,   -9, 	   1,   -4, 	  -9,    0, 	   0,   -8
+.2byte   -1,  -14, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte   11,   -9, 	  -2,   -4, 	   8,    0, 	  -1,   -8
+.2byte    8,   -3, 	   4,   -2, 	   1,    1, 	  -2,   -8
+.2byte    6,    0, 	   8,   -1, 	  -3,    2, 	   0,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -6,  -21, 	 -11,   -9, 	   1,  -10, 	  -1,  -10
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -6
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+.2byte    4,  -23, 	  11,  -13, 	   4,   -7, 	  -1,  -11
+.2byte    6,    0, 	   8,   -1, 	  -3,    2, 	   0,   -8
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    5,  -20, 	  -3,  -14, 	   9,   -7, 	  -4,  -11
+.2byte    8,   -3, 	   4,   -2, 	   1,    1, 	  -2,   -8
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -23, 	  -6,  -18, 	   8,  -15, 	  -3,  -10
+.2byte   11,  -12, 	  -2,   -7, 	   8,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte    7,  -19, 	  10,   -8, 	  -2,  -11, 	  -1,   -8
+.2byte   -1,  -17, 	   8,   -7, 	 -10,   -7, 	  -1,  -11
+.2byte  -12,  -10, 	   1,   -8, 	 -10,   -3, 	  -1,  -11
+.2byte   -1,  -23, 	   4,  -18, 	 -10,  -15, 	   1,  -10
+.2byte  -13,  -12, 	   0,   -7, 	 -10,   -3, 	  -1,  -11
+.2byte  -10,   -4, 	  -5,   -3, 	  -4,    1, 	   0,   -9
+.2byte   -7,  -20, 	   1,  -14, 	 -11,   -7, 	   2,  -11
+.2byte  -10,   -3, 	  -6,   -2, 	  -3,    1, 	   0,   -8
+.2byte   -9,    0, 	  -9,   -2, 	   0,    2, 	  -1,  -10
+.2byte   -4,  -23, 	 -11,  -13, 	  -4,   -7, 	   1,  -11
+.2byte   -8,    0, 	 -10,   -1, 	   1,    2, 	  -2,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -6
+.2byte   -7,    0, 	  -9,   -1, 	   2,    2, 	  -1,   -8
+.2byte   -9,   -3, 	  -5,   -2, 	  -2,    1, 	   1,   -8
+.2byte  -12,   -9, 	   1,   -4, 	  -9,    0, 	   0,   -8
+.2byte   -1,  -14, 	   8,   -4, 	 -10,   -4, 	  -1,   -8
+.2byte   11,   -9, 	  -2,   -4, 	   8,    0, 	  -1,   -8
+.2byte    8,   -3, 	   4,   -2, 	   1,    1, 	  -2,   -8
+.2byte    6,    0, 	   8,   -1, 	  -3,    2, 	   0,   -8
+.2byte   -1,    3, 	 -10,    1, 	   8,    1, 	  -1,   -9
+.2byte   -9,    0, 	  -9,   -2, 	   0,    2, 	  -1,  -10
+.2byte  -10,   -4, 	  -5,   -3, 	  -4,    1, 	   0,   -9
+.2byte  -12,  -10, 	   1,   -8, 	 -10,   -3, 	  -1,  -11
+.2byte   -1,  -13, 	   8,   -7, 	 -10,   -7, 	  -1,  -10
+.2byte   10,  -10, 	  -3,   -8, 	   8,   -3, 	  -1,  -11
+.2byte    8,   -4, 	   3,   -3, 	   2,    1, 	  -2,   -9
+.2byte    7,    0, 	   7,   -2, 	  -2,    2, 	  -1,  -10
+sNidorinoAnimTable1:
+.4byte sNidorinoAnims_1_1
+.4byte sNidorinoAnims_1_2
+.4byte sNidorinoAnims_1_3
+.4byte sNidorinoAnims_1_4
+.4byte sNidorinoAnims_1_5
+.4byte sNidorinoAnims_1_6
+.4byte sNidorinoAnims_1_7
+.4byte sNidorinoAnims_1_8
+sNidorinoAnimTable2:
+.4byte sNidorinoAnims_2_1
+.4byte sNidorinoAnims_2_2
+.4byte sNidorinoAnims_2_3
+.4byte sNidorinoAnims_2_4
+.4byte sNidorinoAnims_2_5
+.4byte sNidorinoAnims_2_6
+.4byte sNidorinoAnims_2_7
+.4byte sNidorinoAnims_2_8
+sNidorinoAnimTable3:
+.4byte sNidorinoAnims_3_1
+.4byte sNidorinoAnims_3_2
+.4byte sNidorinoAnims_3_3
+.4byte sNidorinoAnims_3_4
+.4byte sNidorinoAnims_3_5
+.4byte sNidorinoAnims_3_6
+.4byte sNidorinoAnims_3_7
+.4byte sNidorinoAnims_3_8
+sNidorinoAnimTable4:
+.4byte sNidorinoAnims_4_1
+.4byte sNidorinoAnims_4_2
+.4byte sNidorinoAnims_4_3
+.4byte sNidorinoAnims_4_4
+.4byte sNidorinoAnims_4_5
+.4byte sNidorinoAnims_4_6
+.4byte sNidorinoAnims_4_7
+.4byte sNidorinoAnims_4_8
+sNidorinoAnimTable5:
+.4byte sNidorinoAnims_5_1
+.4byte sNidorinoAnims_5_2
+.4byte sNidorinoAnims_5_3
+.4byte sNidorinoAnims_5_4
+.4byte sNidorinoAnims_5_5
+.4byte sNidorinoAnims_5_6
+.4byte sNidorinoAnims_5_7
+.4byte sNidorinoAnims_5_8
+sNidorinoAnimTable6:
+.4byte sNidorinoAnims_6_1
+.4byte sNidorinoAnims_6_1
+.4byte sNidorinoAnims_6_1
+.4byte sNidorinoAnims_6_1
+.4byte sNidorinoAnims_6_1
+.4byte sNidorinoAnims_6_1
+.4byte sNidorinoAnims_6_1
+.4byte sNidorinoAnims_6_1
+sNidorinoAnimTable7:
+.4byte sNidorinoAnims_7_1
+.4byte sNidorinoAnims_7_2
+.4byte sNidorinoAnims_7_3
+.4byte sNidorinoAnims_7_4
+.4byte sNidorinoAnims_7_5
+.4byte sNidorinoAnims_7_6
+.4byte sNidorinoAnims_7_7
+.4byte sNidorinoAnims_7_8
+sNidorinoAnimTable8:
+.4byte sNidorinoAnims_8_1
+.4byte sNidorinoAnims_8_2
+.4byte sNidorinoAnims_8_3
+.4byte sNidorinoAnims_8_4
+.4byte sNidorinoAnims_8_5
+.4byte sNidorinoAnims_8_6
+.4byte sNidorinoAnims_8_7
+.4byte sNidorinoAnims_8_8
+sNidorinoAnimTable9:
+.4byte sNidorinoAnims_9_1
+.4byte sNidorinoAnims_9_2
+.4byte sNidorinoAnims_9_3
+.4byte sNidorinoAnims_9_4
+.4byte sNidorinoAnims_9_5
+.4byte sNidorinoAnims_9_6
+.4byte sNidorinoAnims_9_7
+.4byte sNidorinoAnims_9_8
+sNidorinoAnimTable10:
+.4byte sNidorinoAnims_10_1
+.4byte sNidorinoAnims_10_2
+.4byte sNidorinoAnims_10_3
+.4byte sNidorinoAnims_10_4
+.4byte sNidorinoAnims_10_5
+.4byte sNidorinoAnims_10_6
+.4byte sNidorinoAnims_10_7
+.4byte sNidorinoAnims_10_8
+sNidorinoAnimTable11:
+.4byte sNidorinoAnims_11_1
+.4byte sNidorinoAnims_11_2
+.4byte sNidorinoAnims_11_3
+.4byte sNidorinoAnims_11_4
+.4byte sNidorinoAnims_11_5
+.4byte sNidorinoAnims_11_6
+.4byte sNidorinoAnims_11_7
+.4byte sNidorinoAnims_11_8
+sNidorinoAnimTable12:
+.4byte sNidorinoAnims_12_1
+.4byte sNidorinoAnims_12_2
+.4byte sNidorinoAnims_12_3
+.4byte sNidorinoAnims_12_4
+.4byte sNidorinoAnims_12_5
+.4byte sNidorinoAnims_12_6
+.4byte sNidorinoAnims_12_7
+.4byte sNidorinoAnims_12_8
+sNidorinoAnimTable13:
+.4byte sNidorinoAnims_13_1
+.4byte sNidorinoAnims_13_2
+.4byte sNidorinoAnims_13_3
+.4byte sNidorinoAnims_13_4
+.4byte sNidorinoAnims_13_5
+.4byte sNidorinoAnims_13_6
+.4byte sNidorinoAnims_13_7
+.4byte sNidorinoAnims_13_8
+sAxAnimationsNidorino:
+.4byte sNidorinoAnimTable1
+.4byte sNidorinoAnimTable2
+.4byte sNidorinoAnimTable3
+.4byte sNidorinoAnimTable4
+.4byte sNidorinoAnimTable5
+.4byte sNidorinoAnimTable6
+.4byte sNidorinoAnimTable7
+.4byte sNidorinoAnimTable8
+.4byte sNidorinoAnimTable9
+.4byte sNidorinoAnimTable10
+.4byte sNidorinoAnimTable11
+.4byte sNidorinoAnimTable12
+.4byte sNidorinoAnimTable13
+sAxSpritesNidorino:
+.4byte sNidorinoSprites1
+.4byte sNidorinoSprites2
+.4byte sNidorinoSprites3
+.4byte sNidorinoSprites4
+.4byte sNidorinoSprites5
+.4byte sNidorinoSprites6
+.4byte sNidorinoSprites7
+.4byte sNidorinoSprites8
+.4byte sNidorinoSprites9
+.4byte sNidorinoSprites10
+.4byte sNidorinoSprites11
+.4byte sNidorinoSprites12
+.4byte sNidorinoSprites13
+.4byte sNidorinoSprites14
+.4byte sNidorinoSprites15
+.4byte sNidorinoSprites16
+.4byte sNidorinoSprites17
+.4byte sNidorinoSprites18
+.4byte sNidorinoSprites19
+.4byte sNidorinoSprites20
+.4byte sNidorinoSprites21
+.4byte sNidorinoSprites22
+.4byte sNidorinoSprites23
+.4byte sNidorinoSprites24
+.4byte sNidorinoSprites25
+.4byte sNidorinoSprites26
+.4byte sNidorinoSprites27
+.4byte sNidorinoSprites28
+.4byte sNidorinoSprites29
+.4byte sNidorinoSprites30
+.4byte sNidorinoSprites31
+.4byte sNidorinoSprites32
+.4byte sNidorinoSprites33
+.4byte sNidorinoSprites34
+.4byte sNidorinoSprites35
+.4byte sNidorinoSprites36
+.4byte sNidorinoSprites37
+.4byte sNidorinoSprites38
+.4byte sNidorinoSprites39
+.4byte sNidorinoSprites40
+.4byte sNidorinoSprites41
+.4byte sNidorinoSprites42
+sAxMainNidorino:
+ax_main sAxPosesNidorino, sAxAnimationsNidorino, 13, sAxSpritesNidorino, sAxPositionsNidorino

--- a/data/ax/nincada.inc
+++ b/data/ax/nincada.inc
@@ -1,0 +1,2803 @@
+.global gAxNincada
+gAxNincada:
+ax_siro sAxMainNincada
+sNincadaPose1:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose2:
+ax_pose 1, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose3:
+ax_pose 2, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose4:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose5:
+ax_pose 4, 0x01f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose6:
+ax_pose 5, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose7:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose8:
+ax_pose 7, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose9:
+ax_pose 8, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose10:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose11:
+ax_pose 10, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose12:
+ax_pose 11, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose13:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose14:
+ax_pose 13, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose15:
+ax_pose 14, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose16:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose17:
+ax_pose 10, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose18:
+ax_pose 11, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose19:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose20:
+ax_pose 7, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose21:
+ax_pose 8, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose22:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose23:
+ax_pose 4, 0x01f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose24:
+ax_pose 5, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose25:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose26:
+ax_pose 1, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose27:
+ax_pose 2, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose28:
+ax_pose 15, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose29:
+ax_pose 16, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose30:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose31:
+ax_pose 4, 0x01f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose32:
+ax_pose 5, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose33:
+ax_pose 17, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose34:
+ax_pose 18, 0x41f5, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose35:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose36:
+ax_pose 7, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose37:
+ax_pose 8, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose38:
+ax_pose 19, 0x41f3, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose39:
+ax_pose 20, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose40:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose41:
+ax_pose 10, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose42:
+ax_pose 11, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose43:
+ax_pose 21, 0x41f6, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose44:
+ax_pose 22, 0x41f5, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose45:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose46:
+ax_pose 13, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose47:
+ax_pose 14, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose48:
+ax_pose 23, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose49:
+ax_pose 24, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose50:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose51:
+ax_pose 10, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose52:
+ax_pose 11, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose53:
+ax_pose 21, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose54:
+ax_pose 22, 0x41f5, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose55:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose56:
+ax_pose 7, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose57:
+ax_pose 8, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose58:
+ax_pose 19, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose59:
+ax_pose 20, 0x41f3, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose60:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose61:
+ax_pose 4, 0x01f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose62:
+ax_pose 5, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose63:
+ax_pose 17, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose64:
+ax_pose 18, 0x41f5, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose65:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose66:
+ax_pose 1, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose67:
+ax_pose 2, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose68:
+ax_pose 25, 0x01f6, 0x80f0, 0xac00
+ax_pose 26, 0x41f6, 0x80f4, 0xac10
+ax_pose_terminator
+sNincadaPose69:
+ax_pose 26, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose70:
+ax_pose 25, 0x01f6, 0x90f0, 0xac00
+ax_pose 26, 0x41f6, 0x90ec, 0xac10
+ax_pose_terminator
+sNincadaPose71:
+ax_pose 26, 0x41f6, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose72:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose73:
+ax_pose 4, 0x01f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose74:
+ax_pose 5, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose75:
+ax_pose 27, 0x81ee, 0x90ff, 0xac00
+ax_pose 28, 0x41f3, 0x90ee, 0xac08
+ax_pose_terminator
+sNincadaPose76:
+ax_pose 28, 0x41f3, 0x90ee, 0xac00
+ax_pose_terminator
+sNincadaPose77:
+ax_pose 29, 0x01f2, 0x90ee, 0xac00
+ax_pose 30, 0x41f2, 0x90ee, 0xac10
+ax_pose_terminator
+sNincadaPose78:
+ax_pose 30, 0x41f2, 0x90ee, 0xac00
+ax_pose_terminator
+sNincadaPose79:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose80:
+ax_pose 7, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose81:
+ax_pose 8, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose82:
+ax_pose 31, 0x41f1, 0x90ef, 0xac00
+ax_pose 32, 0x41f3, 0x90ef, 0xac08
+ax_pose_terminator
+sNincadaPose83:
+ax_pose 32, 0x41f3, 0x90ef, 0xac00
+ax_pose_terminator
+sNincadaPose84:
+ax_pose 33, 0x41f3, 0x90f2, 0xac00
+ax_pose 34, 0x01f1, 0x90ef, 0xac08
+ax_pose_terminator
+sNincadaPose85:
+ax_pose 34, 0x01f1, 0x90ef, 0xac00
+ax_pose_terminator
+sNincadaPose86:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose87:
+ax_pose 10, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose88:
+ax_pose 11, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose89:
+ax_pose 35, 0x41f3, 0x90ee, 0xac00
+ax_pose 36, 0x0203, 0x10fe, 0xac08
+ax_pose 37, 0x41ef, 0x90ef, 0xac09
+ax_pose_terminator
+sNincadaPose90:
+ax_pose 35, 0x41f3, 0x90ee, 0xac00
+ax_pose 36, 0x0203, 0x10fe, 0xac08
+ax_pose_terminator
+sNincadaPose91:
+ax_pose 38, 0x81f2, 0x9100, 0xac00
+ax_pose 39, 0x41f3, 0x90f0, 0xac08
+ax_pose 40, 0x4203, 0x10f8, 0xac10
+ax_pose_terminator
+sNincadaPose92:
+ax_pose 39, 0x41f3, 0x90f0, 0xac00
+ax_pose 40, 0x4203, 0x10f8, 0xac08
+ax_pose_terminator
+sNincadaPose93:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose94:
+ax_pose 13, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose95:
+ax_pose 14, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose96:
+ax_pose 41, 0x01f0, 0x80f9, 0xac00
+ax_pose 42, 0x41f6, 0x80f3, 0xac10
+ax_pose_terminator
+sNincadaPose97:
+ax_pose 42, 0x41f6, 0x80f3, 0xac00
+ax_pose_terminator
+sNincadaPose98:
+ax_pose 41, 0x01f0, 0x90e7, 0xac00
+ax_pose 42, 0x41f6, 0x90ed, 0xac10
+ax_pose_terminator
+sNincadaPose99:
+ax_pose 42, 0x41f6, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose100:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose101:
+ax_pose 10, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose102:
+ax_pose 11, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose103:
+ax_pose 35, 0x41f3, 0x80f3, 0xac00
+ax_pose 36, 0x0203, 0x00fb, 0xac08
+ax_pose 37, 0x41ef, 0x80f3, 0xac09
+ax_pose_terminator
+sNincadaPose104:
+ax_pose 35, 0x41f3, 0x80f3, 0xac00
+ax_pose 36, 0x0203, 0x00fb, 0xac08
+ax_pose_terminator
+sNincadaPose105:
+ax_pose 38, 0x81f2, 0x80f1, 0xac00
+ax_pose 39, 0x41f3, 0x80f1, 0xac08
+ax_pose 40, 0x4203, 0x00f9, 0xac10
+ax_pose_terminator
+sNincadaPose106:
+ax_pose 39, 0x41f3, 0x80f1, 0xac00
+ax_pose 40, 0x4203, 0x00f9, 0xac08
+ax_pose_terminator
+sNincadaPose107:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose108:
+ax_pose 7, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose109:
+ax_pose 8, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose110:
+ax_pose 31, 0x41f1, 0x80f2, 0xac00
+ax_pose 32, 0x41f3, 0x80f2, 0xac08
+ax_pose_terminator
+sNincadaPose111:
+ax_pose 32, 0x41f3, 0x80f2, 0xac00
+ax_pose_terminator
+sNincadaPose112:
+ax_pose 33, 0x41f3, 0x80f0, 0xac00
+ax_pose 34, 0x01f1, 0x80f2, 0xac08
+ax_pose_terminator
+sNincadaPose113:
+ax_pose 34, 0x01f1, 0x80f2, 0xac00
+ax_pose_terminator
+sNincadaPose114:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose115:
+ax_pose 4, 0x01f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose116:
+ax_pose 5, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose117:
+ax_pose 27, 0x81ee, 0x80f2, 0xac00
+ax_pose 28, 0x41f3, 0x80f3, 0xac08
+ax_pose_terminator
+sNincadaPose118:
+ax_pose 28, 0x41f3, 0x80f3, 0xac00
+ax_pose_terminator
+sNincadaPose119:
+ax_pose 29, 0x01f2, 0x80f3, 0xac00
+ax_pose 30, 0x41f2, 0x80f3, 0xac10
+ax_pose_terminator
+sNincadaPose120:
+ax_pose 30, 0x41f2, 0x80f3, 0xac00
+ax_pose_terminator
+sNincadaPose121:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose122:
+ax_pose 16, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose123:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose124:
+ax_pose 18, 0x41f5, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose125:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose126:
+ax_pose 20, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose127:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose128:
+ax_pose 22, 0x41f5, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose129:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose130:
+ax_pose 24, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose131:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose132:
+ax_pose 22, 0x41f5, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose133:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose134:
+ax_pose 20, 0x41f3, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose135:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose136:
+ax_pose 18, 0x41f5, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose137:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose138:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose139:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose140:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose141:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose142:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose143:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose144:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose145:
+ax_pose 43, 0x01f5, 0x80f3, 0xac00
+ax_pose_terminator
+sNincadaPose146:
+ax_pose 44, 0x01f5, 0x80f3, 0xac00
+ax_pose_terminator
+sNincadaPose147:
+ax_pose 45, 0x01e1, 0x80f1, 0xac00
+ax_pose_terminator
+sNincadaPose148:
+ax_pose 46, 0x01e5, 0x90f0, 0xac00
+ax_pose_terminator
+sNincadaPose149:
+ax_pose 47, 0x01e4, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose150:
+ax_pose 48, 0x01e7, 0x90eb, 0xac00
+ax_pose_terminator
+sNincadaPose151:
+ax_pose 49, 0x01e1, 0x80f1, 0xac00
+ax_pose_terminator
+sNincadaPose152:
+ax_pose 48, 0x01e7, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose153:
+ax_pose 47, 0x01e4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose154:
+ax_pose 46, 0x01e5, 0x80f1, 0xac00
+ax_pose_terminator
+sNincadaPose155:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose156:
+ax_pose 1, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose157:
+ax_pose 2, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose158:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose159:
+ax_pose 4, 0x01f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose160:
+ax_pose 5, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose161:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose162:
+ax_pose 7, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose163:
+ax_pose 8, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose164:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose165:
+ax_pose 10, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose166:
+ax_pose 11, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose167:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose168:
+ax_pose 13, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose169:
+ax_pose 14, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose170:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose171:
+ax_pose 10, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose172:
+ax_pose 11, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose173:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose174:
+ax_pose 7, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose175:
+ax_pose 8, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose176:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose177:
+ax_pose 4, 0x01f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose178:
+ax_pose 5, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose179:
+ax_pose 15, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose180:
+ax_pose 17, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose181:
+ax_pose 19, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose182:
+ax_pose 21, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose183:
+ax_pose 23, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose184:
+ax_pose 21, 0x41f6, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose185:
+ax_pose 19, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose186:
+ax_pose 17, 0x41f6, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose187:
+ax_pose 15, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose188:
+ax_pose 17, 0x41f6, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose189:
+ax_pose 19, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose190:
+ax_pose 21, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose191:
+ax_pose 23, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose192:
+ax_pose 21, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose193:
+ax_pose 19, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose194:
+ax_pose 17, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose195:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose196:
+ax_pose 16, 0x41f3, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose197:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose198:
+ax_pose 18, 0x41f5, 0x90eb, 0xac00
+ax_pose_terminator
+sNincadaPose199:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose200:
+ax_pose 20, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose201:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose202:
+ax_pose 22, 0x41f5, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose203:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose204:
+ax_pose 24, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose205:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose206:
+ax_pose 22, 0x41f5, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose207:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose208:
+ax_pose 20, 0x41f3, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose209:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose210:
+ax_pose 18, 0x41f5, 0x80f6, 0xac00
+ax_pose_terminator
+sNincadaPose211:
+ax_pose 16, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose212:
+ax_pose 18, 0x41f5, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose213:
+ax_pose 20, 0x41f3, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose214:
+ax_pose 22, 0x41f5, 0x80f5, 0xac00
+ax_pose_terminator
+sNincadaPose215:
+ax_pose 24, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose216:
+ax_pose 22, 0x41f5, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose217:
+ax_pose 20, 0x41f3, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose218:
+ax_pose 18, 0x41f5, 0x90ec, 0xac00
+ax_pose_terminator
+sNincadaPose219:
+ax_pose 0, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose220:
+ax_pose 3, 0x41f5, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose221:
+ax_pose 6, 0x41f4, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose222:
+ax_pose 9, 0x41f7, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose223:
+ax_pose 12, 0x41f6, 0x80f4, 0xac00
+ax_pose_terminator
+sNincadaPose224:
+ax_pose 9, 0x41f7, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose225:
+ax_pose 6, 0x41f4, 0x90ed, 0xac00
+ax_pose_terminator
+sNincadaPose226:
+ax_pose 3, 0x41f5, 0x90ed, 0xac00
+ax_pose_terminator
+.align 2
+sNincadaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, -3, 0, 0,
+ax_anim 2, 2, 27, 0, 1, 0, 4,
+ax_anim 2, 0, 27, 0, 8, 0, 10,
+ax_anim 2, 1, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNincadaAnims_2_2:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 32, 6, -2, 6, 5,
+ax_anim 2, 2, 32, 13, 4, 13, 11,
+ax_anim 2, 0, 32, 17, 10, 17, 15,
+ax_anim 2, 1, 32, 20, 18, 20, 18,
+ax_anim 2, 0, 32, 21, 17, 21, 17,
+ax_anim 2, 0, 32, 20, 18, 20, 18,
+ax_anim 2, 0, 32, 21, 17, 21, 17,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim_terminator
+sNincadaAnims_2_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 37, 3, -3, 3, 0,
+ax_anim 2, 2, 37, 9, -5, 9, -1,
+ax_anim 2, 0, 37, 13, -5, 13, -1,
+ax_anim 2, 1, 37, 18, -1, 18, -1,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 37, 18, -1, 18, -1,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sNincadaAnims_2_4:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 42, 1, -8, 1, -2,
+ax_anim 2, 2, 42, 7, -18, 7, -9,
+ax_anim 2, 0, 42, 12, -23, 12, -16,
+ax_anim 2, 1, 42, 20, -25, 20, -25,
+ax_anim 2, 0, 42, 21, -24, 21, -24,
+ax_anim 2, 0, 42, 20, -25, 20, -25,
+ax_anim 2, 0, 42, 21, -24, 21, -24,
+ax_anim 2, 0, 39, 8, -10, 8, -10,
+ax_anim_terminator
+sNincadaAnims_2_5:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 47, 0, -7, 0, -4,
+ax_anim 2, 2, 47, 0, -14, 0, -9,
+ax_anim 2, 0, 47, 0, -20, 0, -17,
+ax_anim 2, 1, 47, 0, -25, 0, -25,
+ax_anim 2, 0, 47, 1, -25, 1, -25,
+ax_anim 2, 0, 47, 0, -25, 0, -25,
+ax_anim 2, 0, 47, 1, -25, 1, -25,
+ax_anim 2, 0, 44, 0, -7, 0, -7,
+ax_anim_terminator
+sNincadaAnims_2_6:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 4, 0, 49, 2, 2, 2, 2,
+ax_anim 1, 0, 52, -1, -8, -1, -2,
+ax_anim 2, 2, 52, -7, -18, -7, -9,
+ax_anim 2, 0, 52, -12, -23, -12, -16,
+ax_anim 2, 1, 52, -20, -25, -20, -25,
+ax_anim 2, 0, 52, -21, -24, -21, -24,
+ax_anim 2, 0, 52, -20, -25, -20, -25,
+ax_anim 2, 0, 52, -21, -24, -21, -24,
+ax_anim 2, 0, 49, -8, -10, -8, -10,
+ax_anim_terminator
+sNincadaAnims_2_7:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 4, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 0, 57, -3, -3, -3, 0,
+ax_anim 2, 2, 57, -9, -5, -9, -1,
+ax_anim 2, 0, 57, -13, -5, -13, -1,
+ax_anim 2, 1, 57, -18, -1, -18, -1,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 0, 57, -18, -1, -18, -1,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sNincadaAnims_2_8:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 4, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 62, -6, -2, -6, 5,
+ax_anim 2, 2, 62, -13, 4, -13, 11,
+ax_anim 2, 0, 62, -17, 10, -17, 15,
+ax_anim 2, 1, 62, -20, 18, -20, 18,
+ax_anim 2, 0, 62, -21, 17, -21, 17,
+ax_anim 2, 0, 62, -20, 18, -20, 18,
+ax_anim 2, 0, 62, -21, 17, -21, 17,
+ax_anim 2, 0, 59, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sNincadaAnims_3_1:
+ax_anim 2, 0, 70, 0, -4, 0, -4,
+ax_anim 6, 0, 119, 0, -6, 0, -6,
+ax_anim 1, 2, 119, 0, -3, 0, -3,
+ax_anim 1, 0, 70, 0, 3, 0, 3,
+ax_anim 2, 0, 67, 2, 12, 0, 12,
+ax_anim 2, 1, 68, 3, 13, 1, 13,
+ax_anim 2, 0, 77, 1, 9, 1, 9,
+ax_anim 4, 0, 68, 1, 8, 1, 8,
+ax_anim 2, 0, 69, -2, 12, 0, 12,
+ax_anim 2, 0, 119, -2, 13, -1, 13,
+ax_anim 2, 0, 70, -1, 9, -1, 9,
+ax_anim 2, 0, 65, 0, 5, 0, 5,
+ax_anim_terminator
+sNincadaAnims_3_2:
+ax_anim 2, 0, 77, -4, -4, -4, -4,
+ax_anim 6, 0, 84, -6, -6, -6, -6,
+ax_anim 1, 2, 84, -3, -3, -3, -3,
+ax_anim 1, 0, 77, 6, 6, 6, 6,
+ax_anim 2, 0, 74, 19, 18, 19, 18,
+ax_anim 2, 1, 75, 18, 19, 18, 19,
+ax_anim 2, 0, 70, 17, 16, 17, 16,
+ax_anim 4, 0, 75, 17, 19, 17, 19,
+ax_anim 2, 0, 76, 21, 21, 21, 21,
+ax_anim 2, 0, 84, 22, 21, 22, 21,
+ax_anim 2, 0, 77, 16, 16, 16, 16,
+ax_anim 2, 0, 72, 11, 11, 11, 11,
+ax_anim_terminator
+sNincadaAnims_3_3:
+ax_anim 2, 0, 84, -4, 0, -4, 0,
+ax_anim 6, 0, 91, -6, 2, -6, 0,
+ax_anim 1, 2, 91, -3, 2, -3, 0,
+ax_anim 1, 0, 84, 6, 0, 6, 0,
+ax_anim 2, 0, 81, 16, 0, 16, 0,
+ax_anim 2, 1, 75, 17, 1, 17, 1,
+ax_anim 2, 0, 75, 14, 2, 14, 2,
+ax_anim 4, 0, 82, 14, 1, 14, 1,
+ax_anim 2, 0, 83, 16, 0, 16, 0,
+ax_anim 2, 0, 91, 17, 1, 15, -1,
+ax_anim 2, 0, 84, 10, 0, 10, 0,
+ax_anim 2, 0, 79, 6, 0, 6, 0,
+ax_anim_terminator
+sNincadaAnims_3_4:
+ax_anim 2, 0, 91, -4, 4, -4, 4,
+ax_anim 6, 0, 96, -3, 7, -3, 7,
+ax_anim 1, 2, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 6, -6, 6, -6,
+ax_anim 2, 0, 88, 17, -15, 17, -15,
+ax_anim 2, 1, 82, 19, -16, 19, -16,
+ax_anim 2, 0, 82, 18, -15, 18, -15,
+ax_anim 4, 0, 89, 18, -14, 18, -14,
+ax_anim 2, 0, 90, 16, -16, 16, -16,
+ax_anim 2, 0, 96, 17, -19, 17, -19,
+ax_anim 2, 0, 91, 10, -10, 10, -10,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim_terminator
+sNincadaAnims_3_5:
+ax_anim 2, 0, 98, 0, 4, 0, 4,
+ax_anim 6, 0, 89, 0, 6, 0, 6,
+ax_anim 1, 2, 89, 0, 3, 0, 3,
+ax_anim 1, 0, 98, 0, -7, 0, -7,
+ax_anim 2, 0, 95, -4, -17, -4, -10,
+ax_anim 2, 1, 103, -5, -17, -5, -10,
+ax_anim 2, 0, 103, -5, -16, -5, -9,
+ax_anim 4, 0, 96, -3, -16, -3, -9,
+ax_anim 2, 0, 97, 0, -19, 0, -12,
+ax_anim 2, 0, 89, 0, -22, 0, -15,
+ax_anim 2, 0, 98, 1, -12, 1, -12,
+ax_anim 2, 0, 93, 0, -9, 0, -9,
+ax_anim_terminator
+sNincadaAnims_3_6:
+ax_anim 2, 0, 105, 4, 4, 4, 4,
+ax_anim 6, 0, 98, 6, 6, 6, 6,
+ax_anim 1, 2, 98, 3, 3, 3, 3,
+ax_anim 1, 0, 105, -9, -9, -9, -9,
+ax_anim 2, 0, 102, -17, -16, -17, -16,
+ax_anim 2, 1, 110, -19, -18, -19, -18,
+ax_anim 2, 0, 110, -17, -16, -17, -16,
+ax_anim 4, 0, 103, -18, -15, -18, -15,
+ax_anim 2, 0, 104, -18, -18, -18, -18,
+ax_anim 2, 0, 98, -16, -19, -16, -19,
+ax_anim 2, 0, 105, -12, -12, -12, -12,
+ax_anim 2, 0, 100, -8, -8, -8, -8,
+ax_anim_terminator
+sNincadaAnims_3_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 6, 0, 105, 6, 1, 6, 0,
+ax_anim 1, 2, 105, 3, 1, 3, 0,
+ax_anim 1, 0, 112, -6, 0, -6, 0,
+ax_anim 2, 0, 109, -14, 0, -16, 0,
+ax_anim 2, 1, 117, -16, 1, -18, 1,
+ax_anim 2, 0, 117, -13, 1, -15, 1,
+ax_anim 4, 0, 110, -9, 0, -11, 0,
+ax_anim 2, 0, 111, -14, -1, -16, 0,
+ax_anim 2, 0, 105, -17, 1, -19, -1,
+ax_anim 2, 0, 112, -8, 0, -10, 0,
+ax_anim 2, 0, 107, -6, 0, -6, 0,
+ax_anim_terminator
+sNincadaAnims_3_8:
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 6, 0, 112, 7, -6, 7, -6,
+ax_anim 1, 2, 112, 4, -3, 4, -3,
+ax_anim 1, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 116, -14, 18, -14, 18,
+ax_anim 2, 1, 68, -14, 19, -14, 19,
+ax_anim 2, 0, 68, -13, 17, -13, 17,
+ax_anim 4, 0, 117, -13, 16, -13, 16,
+ax_anim 2, 0, 118, -19, 17, -19, 17,
+ax_anim 2, 0, 112, -17, 15, -17, 15,
+ax_anim 2, 0, 119, -11, 11, -11, 11,
+ax_anim 2, 0, 114, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sNincadaAnims_4_1:
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim 6, 2, 120, 0, -3, 0, -3,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 1, 121, 0, 3, 0, 2,
+ax_anim 2, 0, 121, 1, 3, 1, 2,
+ax_anim 2, 0, 121, 0, 3, 0, 2,
+ax_anim 2, 0, 121, 1, 3, 1, 2,
+ax_anim 2, 0, 121, 0, 3, 0, 2,
+ax_anim 2, 0, 121, 1, 3, 1, 2,
+ax_anim 2, 0, 121, 0, 3, 0, 2,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sNincadaAnims_4_2:
+ax_anim 2, 0, 122, -2, -2, -2, -2,
+ax_anim 6, 2, 122, -3, -3, -3, -3,
+ax_anim 2, 0, 122, -1, -1, -1, -1,
+ax_anim 2, 1, 123, 2, 2, 1, 1,
+ax_anim 2, 0, 123, 3, 1, 2, 0,
+ax_anim 2, 0, 123, 2, 2, 1, 1,
+ax_anim 2, 0, 123, 3, 1, 2, 0,
+ax_anim 2, 0, 123, 2, 2, 1, 1,
+ax_anim 2, 0, 123, 3, 1, 2, 0,
+ax_anim 2, 0, 123, 2, 2, 1, 1,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim_terminator
+sNincadaAnims_4_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 6, 2, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 1, 125, 2, 0, 2, 0,
+ax_anim 2, 0, 125, 2, 1, 2, 1,
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim 2, 0, 125, 2, 1, 2, 1,
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim 2, 0, 125, 2, 1, 2, 1,
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim_terminator
+sNincadaAnims_4_4:
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim 6, 2, 126, -3, 3, -3, 3,
+ax_anim 2, 0, 126, -1, 1, -1, 1,
+ax_anim 2, 1, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 127, 3, -1, 2, 0,
+ax_anim 2, 0, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 127, 3, -1, 2, 0,
+ax_anim 2, 0, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 127, 3, -1, 2, 0,
+ax_anim 2, 0, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim_terminator
+sNincadaAnims_4_5:
+ax_anim 2, 0, 128, 0, 2, 0, 2,
+ax_anim 6, 2, 128, 0, 3, 0, 3,
+ax_anim 2, 0, 128, 0, 1, 0, 1,
+ax_anim 2, 1, 129, 0, -3, 0, -2,
+ax_anim 2, 0, 129, 1, -3, 1, -2,
+ax_anim 2, 0, 129, 0, -3, 0, -2,
+ax_anim 2, 0, 129, 1, -3, 1, -2,
+ax_anim 2, 0, 129, 0, -3, 0, -2,
+ax_anim 2, 0, 129, 1, -3, 1, -2,
+ax_anim 2, 0, 129, 0, -3, 0, -2,
+ax_anim 2, 0, 128, 0, -1, 0, -1,
+ax_anim_terminator
+sNincadaAnims_4_6:
+ax_anim 2, 0, 130, 2, 2, 2, 2,
+ax_anim 6, 2, 130, 3, 3, 3, 3,
+ax_anim 2, 0, 130, 1, 1, 1, 1,
+ax_anim 2, 1, 131, -2, -2, -1, -1,
+ax_anim 2, 0, 131, -3, -1, -2, 0,
+ax_anim 2, 0, 131, -2, -2, -1, -1,
+ax_anim 2, 0, 131, -3, -1, -2, 0,
+ax_anim 2, 0, 131, -2, -2, -1, -1,
+ax_anim 2, 0, 131, -3, -1, -2, 0,
+ax_anim 2, 0, 131, -2, -2, -1, -1,
+ax_anim 2, 0, 130, -1, -1, -1, -1,
+ax_anim_terminator
+sNincadaAnims_4_7:
+ax_anim 2, 0, 132, 2, 0, 2, 0,
+ax_anim 6, 2, 132, 3, 0, 3, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 1, 133, -2, 0, -2, 0,
+ax_anim 2, 0, 133, -2, 1, -2, 1,
+ax_anim 2, 0, 133, -2, 0, -2, 0,
+ax_anim 2, 0, 133, -2, 1, -2, 1,
+ax_anim 2, 0, 133, -2, 0, -2, 0,
+ax_anim 2, 0, 133, -2, 1, -2, 1,
+ax_anim 2, 0, 133, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -1, 0, -1, 0,
+ax_anim_terminator
+sNincadaAnims_4_8:
+ax_anim 2, 0, 134, 2, -2, 2, -2,
+ax_anim 6, 2, 134, 3, -3, 3, -3,
+ax_anim 2, 0, 134, 1, -1, 1, -1,
+ax_anim 2, 1, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 135, -3, 1, -2, 0,
+ax_anim 2, 0, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 135, -3, 1, -2, 0,
+ax_anim 2, 0, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 135, -3, 1, -2, 0,
+ax_anim 2, 0, 135, -2, 2, -1, 1,
+ax_anim 2, 0, 134, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNincadaAnims_5_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_5_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_5_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_5_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sNincadaAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sNincadaAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sNincadaAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sNincadaAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sNincadaAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sNincadaAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sNincadaAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sNincadaAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sNincadaAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sNincadaAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, 0,
+ax_anim 4, 0, 162, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, 0,
+ax_anim_terminator
+sNincadaAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, 0,
+ax_anim 4, 0, 165, 0, -2, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sNincadaAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, -2, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sNincadaAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -3, 0, 0,
+ax_anim 2, 0, 169, 0, -1, 0, 0,
+ax_anim 4, 0, 171, 0, -2, 0, 0,
+ax_anim 2, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+sNincadaAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -3, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, -2, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, 0,
+ax_anim_terminator
+sNincadaAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 2, 0, 175, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim 2, 0, 175, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 7, 3, 7, 3,
+ax_anim 2, 0, 180, 10, 9, 10, 9,
+ax_anim 2, 0, 181, 8, 16, 8, 16,
+ax_anim 3, 0, 182, 0, 18, 0, 18,
+ax_anim 2, 3, 183, -8, 16, -8, 16,
+ax_anim 2, 0, 184, -10, 9, -10, 9,
+ax_anim 1, 0, 185, -7, 3, -7, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 9, 1, 9, 1,
+ax_anim 2, 0, 179, 20, 5, 20, 5,
+ax_anim 2, 0, 180, 24, 13, 24, 13,
+ax_anim 3, 0, 181, 22, 18, 22, 18,
+ax_anim 2, 3, 182, 13, 18, 13, 18,
+ax_anim 2, 0, 183, 4, 14, 4, 14,
+ax_anim 1, 0, 184, 1, 7, 1, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 2, -4, 2, -4,
+ax_anim 2, 0, 178, 10, -6, 10, -6,
+ax_anim 2, 0, 179, 18, -4, 18, -4,
+ax_anim 3, 0, 180, 22, 0, 22, 0,
+ax_anim 2, 3, 181, 19, 5, 19, 5,
+ax_anim 2, 0, 182, 10, 7, 10, 7,
+ax_anim 1, 0, 183, 3, 5, 3, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 1, -9, 1, -9,
+ax_anim 2, 0, 185, 4, -21, 4, -21,
+ax_anim 2, 0, 178, 13, -28, 13, -28,
+ax_anim 3, 0, 179, 22, -26, 22, -26,
+ax_anim 2, 3, 180, 24, -17, 24, -17,
+ax_anim 2, 0, 181, 19, -7, 19, -7,
+ax_anim 1, 0, 182, 9, -2, 9, -2,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -12, -13, -12, -13,
+ax_anim 2, 0, 185, -9, -23, -9, -23,
+ax_anim 3, 0, 178, 0, -28, 0, -28,
+ax_anim 2, 3, 179, 9, -23, 9, -23,
+ax_anim 2, 0, 180, 12, -13, 12, -13,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -1, -9, -1, -9,
+ax_anim 2, 0, 179, -4, -21, -4, -21,
+ax_anim 2, 0, 178, -13, -28, -13, -28,
+ax_anim 3, 0, 185, -22, -26, -22, -26,
+ax_anim 2, 3, 184, -24, -17, -24, -17,
+ax_anim 2, 0, 183, -19, -7, -19, -7,
+ax_anim 1, 0, 182, -9, -2, -9, -2,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -2, -4, -2, -4,
+ax_anim 2, 0, 178, -10, -6, -10, -6,
+ax_anim 2, 0, 185, -18, -4, -18, -4,
+ax_anim 3, 0, 184, -22, 0, -22, 0,
+ax_anim 2, 3, 183, -19, 5, -19, 5,
+ax_anim 2, 0, 182, -10, 7, -10, 7,
+ax_anim 1, 0, 181, -3, 5, -3, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -9, 1, -9, 1,
+ax_anim 2, 0, 185, -20, 5, -20, 5,
+ax_anim 2, 0, 184, -24, 13, -24, 13,
+ax_anim 3, 0, 183, -22, 18, -22, 18,
+ax_anim 2, 3, 182, -13, 18, -13, 18,
+ax_anim 2, 0, 181, -4, 14, -4, 14,
+ax_anim 1, 0, 180, -1, 7, -1, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_11_2:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_11_3:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -9, 0, 0,
+ax_anim 2, 0, 199, 0, -15, 0, 0,
+ax_anim 3, 0, 199, 0, -19, 0, 0,
+ax_anim 4, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_11_4:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -9, 0, 0,
+ax_anim 2, 0, 201, 0, -15, 0, 0,
+ax_anim 3, 0, 201, 0, -19, 0, 0,
+ax_anim 4, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -17, 0, 0,
+ax_anim 1, 0, 200, 0, -11, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_11_5:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_11_6:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -9, 0, 0,
+ax_anim 2, 0, 205, 0, -15, 0, 0,
+ax_anim 3, 0, 205, 0, -19, 0, 0,
+ax_anim 4, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 1, 0, 204, 0, -11, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_11_7:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -9, 0, 0,
+ax_anim 2, 0, 207, 0, -15, 0, 0,
+ax_anim 3, 0, 207, 0, -19, 0, 0,
+ax_anim 4, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_11_8:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNincadaAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sNincadaGfx1:
+.incbin "baserom.gba", 0x11D0748, 0x100
+sNincadaSprites1:
+ax_sprite sNincadaGfx1, 0x100
+ax_sprite_terminator
+sNincadaGfx2:
+.incbin "baserom.gba", 0x11D0858, 0x100
+sNincadaSprites2:
+ax_sprite sNincadaGfx2, 0x100
+ax_sprite_terminator
+sNincadaGfx3:
+.incbin "baserom.gba", 0x11D0968, 0x100
+sNincadaSprites3:
+ax_sprite sNincadaGfx3, 0x100
+ax_sprite_terminator
+sNincadaGfx4:
+.incbin "baserom.gba", 0x11D0A78, 0x100
+sNincadaSprites4:
+ax_sprite sNincadaGfx4, 0x100
+ax_sprite_terminator
+sNincadaGfx5:
+.incbin "baserom.gba", 0x11D0B88, 0x200
+sNincadaSprites5:
+ax_sprite sNincadaGfx5, 0x200
+ax_sprite_terminator
+sNincadaGfx6:
+.incbin "baserom.gba", 0x11D0D98, 0x100
+sNincadaSprites6:
+ax_sprite sNincadaGfx6, 0x100
+ax_sprite_terminator
+sNincadaGfx7:
+.incbin "baserom.gba", 0x11D0EA8, 0x100
+sNincadaSprites7:
+ax_sprite sNincadaGfx7, 0x100
+ax_sprite_terminator
+sNincadaGfx8:
+.incbin "baserom.gba", 0x11D0FB8, 0x100
+sNincadaSprites8:
+ax_sprite sNincadaGfx8, 0x100
+ax_sprite_terminator
+sNincadaGfx9:
+.incbin "baserom.gba", 0x11D10C8, 0x100
+sNincadaSprites9:
+ax_sprite sNincadaGfx9, 0x100
+ax_sprite_terminator
+sNincadaGfx10:
+.incbin "baserom.gba", 0x11D11D8, 0x100
+sNincadaSprites10:
+ax_sprite sNincadaGfx10, 0x100
+ax_sprite_terminator
+sNincadaGfx11:
+.incbin "baserom.gba", 0x11D12E8, 0x100
+sNincadaSprites11:
+ax_sprite sNincadaGfx11, 0x100
+ax_sprite_terminator
+sNincadaGfx12:
+.incbin "baserom.gba", 0x11D13F8, 0x100
+sNincadaSprites12:
+ax_sprite sNincadaGfx12, 0x100
+ax_sprite_terminator
+sNincadaGfx13:
+.incbin "baserom.gba", 0x11D1508, 0x100
+sNincadaSprites13:
+ax_sprite sNincadaGfx13, 0x100
+ax_sprite_terminator
+sNincadaGfx14:
+.incbin "baserom.gba", 0x11D1618, 0x100
+sNincadaSprites14:
+ax_sprite sNincadaGfx14, 0x100
+ax_sprite_terminator
+sNincadaGfx15:
+.incbin "baserom.gba", 0x11D1728, 0x100
+sNincadaSprites15:
+ax_sprite sNincadaGfx15, 0x100
+ax_sprite_terminator
+sNincadaGfx16:
+.incbin "baserom.gba", 0x11D1838, 0x60
+sNincadaGfx16_1:
+.incbin "baserom.gba", 0x11D1898, 0x60
+sNincadaSprites16:
+ax_sprite sNincadaGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx17:
+.incbin "baserom.gba", 0x11D1920, 0x60
+sNincadaGfx17_1:
+.incbin "baserom.gba", 0x11D1980, 0x60
+sNincadaSprites17:
+ax_sprite sNincadaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx18:
+.incbin "baserom.gba", 0x11D1A08, 0x60
+sNincadaGfx18_1:
+.incbin "baserom.gba", 0x11D1A68, 0x60
+sNincadaSprites18:
+ax_sprite sNincadaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx19:
+.incbin "baserom.gba", 0x11D1AF0, 0x60
+sNincadaGfx19_1:
+.incbin "baserom.gba", 0x11D1B50, 0x60
+sNincadaSprites19:
+ax_sprite sNincadaGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx20:
+.incbin "baserom.gba", 0x11D1BD8, 0x60
+sNincadaGfx20_1:
+.incbin "baserom.gba", 0x11D1C38, 0x60
+sNincadaSprites20:
+ax_sprite sNincadaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx21:
+.incbin "baserom.gba", 0x11D1CC0, 0x60
+sNincadaGfx21_1:
+.incbin "baserom.gba", 0x11D1D20, 0x60
+sNincadaSprites21:
+ax_sprite sNincadaGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx22:
+.incbin "baserom.gba", 0x11D1DA8, 0x60
+sNincadaGfx22_1:
+.incbin "baserom.gba", 0x11D1E08, 0x60
+sNincadaSprites22:
+ax_sprite sNincadaGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx23:
+.incbin "baserom.gba", 0x11D1E90, 0x60
+sNincadaGfx23_1:
+.incbin "baserom.gba", 0x11D1EF0, 0x60
+sNincadaSprites23:
+ax_sprite sNincadaGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx24:
+.incbin "baserom.gba", 0x11D1F78, 0x60
+sNincadaGfx24_1:
+.incbin "baserom.gba", 0x11D1FD8, 0x60
+sNincadaSprites24:
+ax_sprite sNincadaGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx25:
+.incbin "baserom.gba", 0x11D2060, 0x60
+sNincadaGfx25_1:
+.incbin "baserom.gba", 0x11D20C0, 0x60
+sNincadaSprites25:
+ax_sprite sNincadaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx26:
+.incbin "baserom.gba", 0x11D2148, 0x20
+sNincadaGfx26_1:
+.incbin "baserom.gba", 0x11D2168, 0x60
+sNincadaGfx26_2:
+.incbin "baserom.gba", 0x11D21C8, 0x60
+sNincadaSprites26:
+ax_sprite sNincadaGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNincadaGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNincadaGfx27:
+.incbin "baserom.gba", 0x11D2260, 0xE0
+sNincadaSprites27:
+ax_sprite sNincadaGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx28:
+.incbin "baserom.gba", 0x11D2358, 0xC0
+sNincadaSprites28:
+ax_sprite sNincadaGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNincadaGfx29:
+.incbin "baserom.gba", 0x11D2430, 0x60
+sNincadaGfx29_1:
+.incbin "baserom.gba", 0x11D2490, 0x40
+sNincadaSprites29:
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx30:
+.incbin "baserom.gba", 0x11D2500, 0xA0
+sNincadaGfx30_1:
+.incbin "baserom.gba", 0x11D25A0, 0x40
+sNincadaSprites30:
+ax_sprite 0, 0x40
+ax_sprite sNincadaGfx30, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx30_1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNincadaGfx31:
+.incbin "baserom.gba", 0x11D2610, 0x60
+sNincadaGfx31_1:
+.incbin "baserom.gba", 0x11D2670, 0x60
+sNincadaSprites31:
+ax_sprite sNincadaGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx32:
+.incbin "baserom.gba", 0x11D26F8, 0x60
+sNincadaGfx32_1:
+.incbin "baserom.gba", 0x11D2758, 0x40
+sNincadaSprites32:
+ax_sprite sNincadaGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNincadaGfx33:
+.incbin "baserom.gba", 0x11D27C0, 0x40
+sNincadaGfx33_1:
+.incbin "baserom.gba", 0x11D2800, 0x60
+sNincadaSprites33:
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx34:
+.incbin "baserom.gba", 0x11D2890, 0xC0
+sNincadaSprites34:
+ax_sprite sNincadaGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNincadaGfx35:
+.incbin "baserom.gba", 0x11D2968, 0x60
+sNincadaGfx35_1:
+.incbin "baserom.gba", 0x11D29C8, 0x60
+sNincadaGfx35_2:
+.incbin "baserom.gba", 0x11D2A28, 0x20
+sNincadaSprites35:
+ax_sprite sNincadaGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx35_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNincadaGfx35_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNincadaGfx36:
+.incbin "baserom.gba", 0x11D2A80, 0x60
+sNincadaGfx36_1:
+.incbin "baserom.gba", 0x11D2AE0, 0x60
+sNincadaSprites36:
+ax_sprite sNincadaGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx37:
+.incbin "baserom.gba", 0x11D2B68, 0x20
+sNincadaSprites37:
+ax_sprite sNincadaGfx37, 0x20
+ax_sprite_terminator
+sNincadaGfx38:
+.incbin "baserom.gba", 0x11D2B98, 0x60
+sNincadaGfx38_1:
+.incbin "baserom.gba", 0x11D2BF8, 0x40
+sNincadaGfx38_2:
+.incbin "baserom.gba", 0x11D2C38, 0x20
+sNincadaSprites38:
+ax_sprite sNincadaGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx38_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx38_2, 0x20
+ax_sprite_terminator
+sNincadaGfx39:
+.incbin "baserom.gba", 0x11D2C88, 0x60
+sNincadaGfx39_1:
+.incbin "baserom.gba", 0x11D2CE8, 0x40
+sNincadaSprites39:
+ax_sprite sNincadaGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNincadaGfx40:
+.incbin "baserom.gba", 0x11D2D50, 0x40
+sNincadaGfx40_1:
+.incbin "baserom.gba", 0x11D2D90, 0x60
+sNincadaSprites40:
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx41:
+.incbin "baserom.gba", 0x11D2E20, 0x40
+sNincadaSprites41:
+ax_sprite sNincadaGfx41, 0x40
+ax_sprite_terminator
+sNincadaGfx42:
+.incbin "baserom.gba", 0x11D2E70, 0x60
+sNincadaGfx42_1:
+.incbin "baserom.gba", 0x11D2ED0, 0x40
+sNincadaGfx42_2:
+.incbin "baserom.gba", 0x11D2F10, 0x20
+sNincadaSprites42:
+ax_sprite sNincadaGfx42, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNincadaGfx42_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sNincadaGfx42_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNincadaGfx43:
+.incbin "baserom.gba", 0x11D2F68, 0x60
+sNincadaGfx43_1:
+.incbin "baserom.gba", 0x11D2FC8, 0x60
+sNincadaSprites43:
+ax_sprite sNincadaGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNincadaGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNincadaGfx44:
+.incbin "baserom.gba", 0x11D3050, 0x200
+sNincadaSprites44:
+ax_sprite sNincadaGfx44, 0x200
+ax_sprite_terminator
+sNincadaGfx45:
+.incbin "baserom.gba", 0x11D3260, 0x200
+sNincadaSprites45:
+ax_sprite sNincadaGfx45, 0x200
+ax_sprite_terminator
+sNincadaGfx46:
+.incbin "baserom.gba", 0x11D3470, 0x200
+sNincadaSprites46:
+ax_sprite sNincadaGfx46, 0x200
+ax_sprite_terminator
+sNincadaGfx47:
+.incbin "baserom.gba", 0x11D3680, 0x200
+sNincadaSprites47:
+ax_sprite sNincadaGfx47, 0x200
+ax_sprite_terminator
+sNincadaGfx48:
+.incbin "baserom.gba", 0x11D3890, 0x200
+sNincadaSprites48:
+ax_sprite sNincadaGfx48, 0x200
+ax_sprite_terminator
+sNincadaGfx49:
+.incbin "baserom.gba", 0x11D3AA0, 0x200
+sNincadaSprites49:
+ax_sprite sNincadaGfx49, 0x200
+ax_sprite_terminator
+sNincadaGfx50:
+.incbin "baserom.gba", 0x11D3CB0, 0x200
+sNincadaSprites50:
+ax_sprite sNincadaGfx50, 0x200
+ax_sprite_terminator
+sAxPosesNincada:
+.4byte sNincadaPose1
+.4byte sNincadaPose2
+.4byte sNincadaPose3
+.4byte sNincadaPose4
+.4byte sNincadaPose5
+.4byte sNincadaPose6
+.4byte sNincadaPose7
+.4byte sNincadaPose8
+.4byte sNincadaPose9
+.4byte sNincadaPose10
+.4byte sNincadaPose11
+.4byte sNincadaPose12
+.4byte sNincadaPose13
+.4byte sNincadaPose14
+.4byte sNincadaPose15
+.4byte sNincadaPose16
+.4byte sNincadaPose17
+.4byte sNincadaPose18
+.4byte sNincadaPose19
+.4byte sNincadaPose20
+.4byte sNincadaPose21
+.4byte sNincadaPose22
+.4byte sNincadaPose23
+.4byte sNincadaPose24
+.4byte sNincadaPose25
+.4byte sNincadaPose26
+.4byte sNincadaPose27
+.4byte sNincadaPose28
+.4byte sNincadaPose29
+.4byte sNincadaPose30
+.4byte sNincadaPose31
+.4byte sNincadaPose32
+.4byte sNincadaPose33
+.4byte sNincadaPose34
+.4byte sNincadaPose35
+.4byte sNincadaPose36
+.4byte sNincadaPose37
+.4byte sNincadaPose38
+.4byte sNincadaPose39
+.4byte sNincadaPose40
+.4byte sNincadaPose41
+.4byte sNincadaPose42
+.4byte sNincadaPose43
+.4byte sNincadaPose44
+.4byte sNincadaPose45
+.4byte sNincadaPose46
+.4byte sNincadaPose47
+.4byte sNincadaPose48
+.4byte sNincadaPose49
+.4byte sNincadaPose50
+.4byte sNincadaPose51
+.4byte sNincadaPose52
+.4byte sNincadaPose53
+.4byte sNincadaPose54
+.4byte sNincadaPose55
+.4byte sNincadaPose56
+.4byte sNincadaPose57
+.4byte sNincadaPose58
+.4byte sNincadaPose59
+.4byte sNincadaPose60
+.4byte sNincadaPose61
+.4byte sNincadaPose62
+.4byte sNincadaPose63
+.4byte sNincadaPose64
+.4byte sNincadaPose65
+.4byte sNincadaPose66
+.4byte sNincadaPose67
+.4byte sNincadaPose68
+.4byte sNincadaPose69
+.4byte sNincadaPose70
+.4byte sNincadaPose71
+.4byte sNincadaPose72
+.4byte sNincadaPose73
+.4byte sNincadaPose74
+.4byte sNincadaPose75
+.4byte sNincadaPose76
+.4byte sNincadaPose77
+.4byte sNincadaPose78
+.4byte sNincadaPose79
+.4byte sNincadaPose80
+.4byte sNincadaPose81
+.4byte sNincadaPose82
+.4byte sNincadaPose83
+.4byte sNincadaPose84
+.4byte sNincadaPose85
+.4byte sNincadaPose86
+.4byte sNincadaPose87
+.4byte sNincadaPose88
+.4byte sNincadaPose89
+.4byte sNincadaPose90
+.4byte sNincadaPose91
+.4byte sNincadaPose92
+.4byte sNincadaPose93
+.4byte sNincadaPose94
+.4byte sNincadaPose95
+.4byte sNincadaPose96
+.4byte sNincadaPose97
+.4byte sNincadaPose98
+.4byte sNincadaPose99
+.4byte sNincadaPose100
+.4byte sNincadaPose101
+.4byte sNincadaPose102
+.4byte sNincadaPose103
+.4byte sNincadaPose104
+.4byte sNincadaPose105
+.4byte sNincadaPose106
+.4byte sNincadaPose107
+.4byte sNincadaPose108
+.4byte sNincadaPose109
+.4byte sNincadaPose110
+.4byte sNincadaPose111
+.4byte sNincadaPose112
+.4byte sNincadaPose113
+.4byte sNincadaPose114
+.4byte sNincadaPose115
+.4byte sNincadaPose116
+.4byte sNincadaPose117
+.4byte sNincadaPose118
+.4byte sNincadaPose119
+.4byte sNincadaPose120
+.4byte sNincadaPose121
+.4byte sNincadaPose122
+.4byte sNincadaPose123
+.4byte sNincadaPose124
+.4byte sNincadaPose125
+.4byte sNincadaPose126
+.4byte sNincadaPose127
+.4byte sNincadaPose128
+.4byte sNincadaPose129
+.4byte sNincadaPose130
+.4byte sNincadaPose131
+.4byte sNincadaPose132
+.4byte sNincadaPose133
+.4byte sNincadaPose134
+.4byte sNincadaPose135
+.4byte sNincadaPose136
+.4byte sNincadaPose137
+.4byte sNincadaPose138
+.4byte sNincadaPose139
+.4byte sNincadaPose140
+.4byte sNincadaPose141
+.4byte sNincadaPose142
+.4byte sNincadaPose143
+.4byte sNincadaPose144
+.4byte sNincadaPose145
+.4byte sNincadaPose146
+.4byte sNincadaPose147
+.4byte sNincadaPose148
+.4byte sNincadaPose149
+.4byte sNincadaPose150
+.4byte sNincadaPose151
+.4byte sNincadaPose152
+.4byte sNincadaPose153
+.4byte sNincadaPose154
+.4byte sNincadaPose155
+.4byte sNincadaPose156
+.4byte sNincadaPose157
+.4byte sNincadaPose158
+.4byte sNincadaPose159
+.4byte sNincadaPose160
+.4byte sNincadaPose161
+.4byte sNincadaPose162
+.4byte sNincadaPose163
+.4byte sNincadaPose164
+.4byte sNincadaPose165
+.4byte sNincadaPose166
+.4byte sNincadaPose167
+.4byte sNincadaPose168
+.4byte sNincadaPose169
+.4byte sNincadaPose170
+.4byte sNincadaPose171
+.4byte sNincadaPose172
+.4byte sNincadaPose173
+.4byte sNincadaPose174
+.4byte sNincadaPose175
+.4byte sNincadaPose176
+.4byte sNincadaPose177
+.4byte sNincadaPose178
+.4byte sNincadaPose179
+.4byte sNincadaPose180
+.4byte sNincadaPose181
+.4byte sNincadaPose182
+.4byte sNincadaPose183
+.4byte sNincadaPose184
+.4byte sNincadaPose185
+.4byte sNincadaPose186
+.4byte sNincadaPose187
+.4byte sNincadaPose188
+.4byte sNincadaPose189
+.4byte sNincadaPose190
+.4byte sNincadaPose191
+.4byte sNincadaPose192
+.4byte sNincadaPose193
+.4byte sNincadaPose194
+.4byte sNincadaPose195
+.4byte sNincadaPose196
+.4byte sNincadaPose197
+.4byte sNincadaPose198
+.4byte sNincadaPose199
+.4byte sNincadaPose200
+.4byte sNincadaPose201
+.4byte sNincadaPose202
+.4byte sNincadaPose203
+.4byte sNincadaPose204
+.4byte sNincadaPose205
+.4byte sNincadaPose206
+.4byte sNincadaPose207
+.4byte sNincadaPose208
+.4byte sNincadaPose209
+.4byte sNincadaPose210
+.4byte sNincadaPose211
+.4byte sNincadaPose212
+.4byte sNincadaPose213
+.4byte sNincadaPose214
+.4byte sNincadaPose215
+.4byte sNincadaPose216
+.4byte sNincadaPose217
+.4byte sNincadaPose218
+.4byte sNincadaPose219
+.4byte sNincadaPose220
+.4byte sNincadaPose221
+.4byte sNincadaPose222
+.4byte sNincadaPose223
+.4byte sNincadaPose224
+.4byte sNincadaPose225
+.4byte sNincadaPose226
+sAxPositionsNincada:
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte    0,    0, 	  -6,    4, 	   6,    1, 	   0,   -3
+.2byte    0,    0, 	  -6,    1, 	   6,    4, 	   0,   -3
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+.2byte    4,    0, 	   7,   -2, 	   1,    5, 	   0,   -4
+.2byte    4,    0, 	   9,    1, 	  -1,    3, 	   0,   -4
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    6,   -2, 	   1,   -1, 	   6,    1, 	   1,   -4
+.2byte    6,   -2, 	   8,   -1, 	   3,    1, 	   1,   -4
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    5,   -3, 	  -3,   -2, 	   8,   -1, 	   0,   -4
+.2byte    5,   -2, 	   0,   -5, 	   6,    1, 	   0,   -4
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -5, 	   5,   -5, 	  -5,   -2, 	   0,   -4
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -5, 	   0,   -4
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte   -5,   -3, 	   3,   -2, 	  -8,   -1, 	   0,   -4
+.2byte   -5,   -2, 	   0,   -5, 	  -6,    1, 	   0,   -4
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -6,   -2, 	  -1,   -1, 	  -6,    1, 	  -1,   -4
+.2byte   -6,   -2, 	  -8,   -1, 	  -3,    1, 	  -1,   -4
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -4,    0, 	  -7,   -2, 	  -1,    5, 	   0,   -4
+.2byte   -4,    0, 	  -9,    1, 	   1,    3, 	   0,   -4
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte    0,    0, 	  -6,    4, 	   6,    1, 	   0,   -3
+.2byte    0,    0, 	  -6,    1, 	   6,    4, 	   0,   -3
+.2byte    0,    4, 	  -6,   -2, 	   6,   -2, 	   0,   -1
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -3
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+.2byte    4,    0, 	   7,   -2, 	   1,    5, 	   0,   -4
+.2byte    4,    0, 	   9,    1, 	  -1,    3, 	   0,   -4
+.2byte    5,    1, 	   1,   -8, 	  -6,   -3, 	   2,   -5
+.2byte    6,   -2, 	   7,   -1, 	  -1,    2, 	   2,   -6
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    6,   -2, 	   1,   -1, 	   6,    1, 	   1,   -4
+.2byte    6,   -2, 	   8,   -1, 	   3,    1, 	   1,   -4
+.2byte    6,   -1, 	  -3,   -4, 	  -2,    1, 	   1,   -6
+.2byte    7,   -4, 	   4,   -8, 	   3,    1, 	   1,   -5
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    5,   -3, 	  -3,   -2, 	   8,   -1, 	   0,   -4
+.2byte    5,   -2, 	   0,   -5, 	   6,    1, 	   0,   -4
+.2byte    6,   -4, 	  -3,   -5, 	   5,    1, 	   1,   -6
+.2byte    5,   -7, 	  -3,   -5, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -5, 	   5,   -5, 	  -5,   -2, 	   0,   -4
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -5, 	   0,   -4
+.2byte    0,   -7, 	   5,   -2, 	  -5,   -2, 	   0,   -6
+.2byte    0,   -6, 	   5,   -2, 	  -5,   -2, 	   0,   -5
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte   -5,   -3, 	   3,   -2, 	  -8,   -1, 	   0,   -4
+.2byte   -5,   -2, 	   0,   -5, 	  -6,    1, 	   0,   -4
+.2byte   -6,   -4, 	   3,   -5, 	  -5,    1, 	  -1,   -6
+.2byte   -5,   -7, 	   3,   -5, 	  -6,   -1, 	   0,   -5
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -6,   -2, 	  -1,   -1, 	  -6,    1, 	  -1,   -4
+.2byte   -6,   -2, 	  -8,   -1, 	  -3,    1, 	  -1,   -4
+.2byte   -6,   -1, 	   3,   -4, 	   2,    1, 	  -1,   -6
+.2byte   -7,   -4, 	  -4,   -8, 	  -3,    1, 	  -1,   -5
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -4,    0, 	  -7,   -2, 	  -1,    5, 	   0,   -4
+.2byte   -4,    0, 	  -9,    1, 	   1,    3, 	   0,   -4
+.2byte   -5,    1, 	  -1,   -8, 	   6,   -3, 	  -2,   -5
+.2byte   -6,   -2, 	  -7,   -1, 	   1,    2, 	  -2,   -6
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte    0,    0, 	  -6,    4, 	   6,    1, 	   0,   -3
+.2byte    0,    0, 	  -6,    1, 	   6,    4, 	   0,   -3
+.2byte    2,   -2, 	   2,    4, 	  10,   -7, 	   1,   -4
+.2byte    2,   -2, 	   2,    4, 	  10,   -7, 	   1,   -4
+.2byte   -3,   -2, 	  -3,    4, 	 -11,   -7, 	  -2,   -4
+.2byte   -3,   -2, 	  -3,    4, 	 -11,   -7, 	  -2,   -4
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+.2byte    4,    0, 	   7,   -2, 	   1,    5, 	   0,   -4
+.2byte    4,    0, 	   9,    1, 	  -1,    3, 	   0,   -4
+.2byte    1,   -6, 	   2,    1, 	 -10,   -9, 	  -2,   -5
+.2byte    1,   -6, 	   2,    1, 	 -10,   -9, 	  -2,   -5
+.2byte    4,   -7, 	   7,  -13, 	   6,    0, 	   0,   -6
+.2byte    4,   -7, 	   7,  -13, 	   6,    0, 	   0,   -6
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    6,   -2, 	   1,   -1, 	   6,    1, 	   1,   -4
+.2byte    6,   -2, 	   8,   -1, 	   3,    1, 	   1,   -4
+.2byte    4,   -7, 	   6,   -2, 	  -3,  -10, 	  -1,   -7
+.2byte    4,   -7, 	   6,   -2, 	  -3,  -10, 	  -1,   -7
+.2byte    5,   -7, 	   3,  -14, 	  10,   -5, 	   1,   -7
+.2byte    5,   -7, 	   3,  -14, 	  10,   -5, 	   1,   -7
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    5,   -3, 	  -3,   -2, 	   8,   -1, 	   0,   -4
+.2byte    5,   -2, 	   0,   -5, 	   6,    1, 	   0,   -4
+.2byte    3,   -6, 	   6,   -3, 	   5,   -6, 	  -1,   -5
+.2byte    3,   -6, 	   6,   -3, 	   5,   -6, 	  -1,   -5
+.2byte    3,   -7, 	  -4,  -11, 	   5,   -9, 	   0,   -6
+.2byte    3,   -7, 	  -4,  -11, 	   5,   -9, 	   0,   -6
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -5, 	   5,   -5, 	  -5,   -2, 	   0,   -4
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -5, 	   0,   -4
+.2byte   -3,   -5, 	  -5,   -9, 	 -10,   -2, 	   0,   -3
+.2byte   -3,   -5, 	  -5,   -9, 	 -10,   -2, 	   0,   -3
+.2byte    2,   -5, 	   4,   -9, 	   9,   -2, 	  -1,   -3
+.2byte    2,   -5, 	   4,   -9, 	   9,   -2, 	  -1,   -3
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte   -5,   -3, 	   3,   -2, 	  -8,   -1, 	   0,   -4
+.2byte   -5,   -2, 	   0,   -5, 	  -6,    1, 	   0,   -4
+.2byte   -3,   -6, 	  -6,   -3, 	  -5,   -6, 	   1,   -5
+.2byte   -3,   -6, 	  -6,   -3, 	  -5,   -6, 	   1,   -5
+.2byte   -3,   -7, 	   4,  -11, 	  -5,   -9, 	   0,   -6
+.2byte   -3,   -7, 	   4,  -11, 	  -5,   -9, 	   0,   -6
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -6,   -2, 	  -1,   -1, 	  -6,    1, 	  -1,   -4
+.2byte   -6,   -2, 	  -8,   -1, 	  -3,    1, 	  -1,   -4
+.2byte   -4,   -7, 	  -6,   -2, 	   3,  -10, 	   1,   -7
+.2byte   -4,   -7, 	  -6,   -2, 	   3,  -10, 	   1,   -7
+.2byte   -5,   -7, 	  -3,  -14, 	 -10,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,  -14, 	 -10,   -5, 	  -1,   -7
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -4,    0, 	  -7,   -2, 	  -1,    5, 	   0,   -4
+.2byte   -4,    0, 	  -9,    1, 	   1,    3, 	   0,   -4
+.2byte   -1,   -6, 	  -2,    1, 	  10,   -9, 	   2,   -5
+.2byte   -1,   -6, 	  -2,    1, 	  10,   -9, 	   2,   -5
+.2byte   -4,   -7, 	  -7,  -13, 	  -6,    0, 	   0,   -6
+.2byte   -4,   -7, 	  -7,  -13, 	  -6,    0, 	   0,   -6
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -3
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+.2byte    6,   -2, 	   7,   -1, 	  -1,    2, 	   2,   -6
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    7,   -4, 	   4,   -8, 	   3,    1, 	   1,   -5
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    5,   -7, 	  -3,   -5, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -6, 	   5,   -2, 	  -5,   -2, 	   0,   -5
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte   -5,   -7, 	   3,   -5, 	  -6,   -1, 	   0,   -5
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -7,   -4, 	  -4,   -8, 	  -3,    1, 	  -1,   -5
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -6,   -2, 	  -7,   -1, 	   1,    2, 	  -2,   -6
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -5,    1, 	  -8,   -2, 	   0,    2, 	  -1,   -5
+.2byte   -5,    0, 	  -8,   -2, 	   0,    2, 	  -1,   -6
+.2byte    0,  -13, 	  -7,  -14, 	   7,  -14, 	   0,   -9
+.2byte    3,  -13, 	   4,  -18, 	  -6,  -14, 	   0,   -9
+.2byte    0,  -13, 	   4,  -15, 	   2,  -12, 	  -3,   -8
+.2byte    0,  -13, 	  -4,  -14, 	   5,  -12, 	  -2,   -7
+.2byte    0,  -13, 	   6,  -11, 	  -6,  -11, 	   0,   -8
+.2byte   -1,  -13, 	   3,  -14, 	  -6,  -12, 	   1,   -7
+.2byte   -1,  -13, 	  -5,  -15, 	  -3,  -12, 	   2,   -8
+.2byte   -3,  -13, 	  -4,  -18, 	   6,  -14, 	   0,   -9
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte    0,    0, 	  -6,    4, 	   6,    1, 	   0,   -3
+.2byte    0,    0, 	  -6,    1, 	   6,    4, 	   0,   -3
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+.2byte    4,    0, 	   7,   -2, 	   1,    5, 	   0,   -4
+.2byte    4,    0, 	   9,    1, 	  -1,    3, 	   0,   -4
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    6,   -2, 	   1,   -1, 	   6,    1, 	   1,   -4
+.2byte    6,   -2, 	   8,   -1, 	   3,    1, 	   1,   -4
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    5,   -3, 	  -3,   -2, 	   8,   -1, 	   0,   -4
+.2byte    5,   -2, 	   0,   -5, 	   6,    1, 	   0,   -4
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -5, 	   5,   -5, 	  -5,   -2, 	   0,   -4
+.2byte    0,   -5, 	   5,   -2, 	  -5,   -5, 	   0,   -4
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte   -5,   -3, 	   3,   -2, 	  -8,   -1, 	   0,   -4
+.2byte   -5,   -2, 	   0,   -5, 	  -6,    1, 	   0,   -4
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -6,   -2, 	  -1,   -1, 	  -6,    1, 	  -1,   -4
+.2byte   -6,   -2, 	  -8,   -1, 	  -3,    1, 	  -1,   -4
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -4,    0, 	  -7,   -2, 	  -1,    5, 	   0,   -4
+.2byte   -4,    0, 	  -9,    1, 	   1,    3, 	   0,   -4
+.2byte    0,    3, 	  -6,   -3, 	   6,   -3, 	   0,   -2
+.2byte   -5,    2, 	  -1,   -7, 	   6,   -2, 	  -2,   -4
+.2byte   -6,    0, 	   3,   -3, 	   2,    2, 	  -1,   -5
+.2byte   -6,   -4, 	   3,   -5, 	  -5,    1, 	  -1,   -6
+.2byte    0,   -7, 	   5,   -2, 	  -5,   -2, 	   0,   -6
+.2byte    6,   -4, 	  -3,   -5, 	   5,    1, 	   1,   -6
+.2byte    6,    0, 	  -3,   -3, 	  -2,    2, 	   1,   -5
+.2byte    5,    2, 	   1,   -7, 	  -6,   -2, 	   2,   -4
+.2byte    0,    3, 	  -6,   -3, 	   6,   -3, 	   0,   -2
+.2byte    5,    2, 	   1,   -7, 	  -6,   -2, 	   2,   -4
+.2byte    6,    1, 	  -3,   -2, 	  -2,    3, 	   1,   -4
+.2byte    6,   -3, 	  -3,   -4, 	   5,    2, 	   1,   -5
+.2byte    0,   -6, 	   5,   -1, 	  -5,   -1, 	   0,   -5
+.2byte   -6,   -3, 	   3,   -4, 	  -5,    2, 	  -1,   -5
+.2byte   -6,    1, 	   3,   -2, 	   2,    3, 	  -1,   -4
+.2byte   -5,    2, 	  -1,   -7, 	   6,   -2, 	  -2,   -4
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte    0,   -1, 	  -6,    0, 	   6,    0, 	   0,   -6
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+.2byte    5,   -2, 	   6,   -1, 	  -2,    2, 	   1,   -6
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    7,   -4, 	   4,   -8, 	   3,    1, 	   1,   -5
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    5,   -7, 	  -3,   -5, 	   6,   -1, 	   0,   -5
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    0,   -6, 	   5,   -2, 	  -5,   -2, 	   0,   -5
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte   -5,   -7, 	   3,   -5, 	  -6,   -1, 	   0,   -5
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -7,   -4, 	  -4,   -8, 	  -3,    1, 	  -1,   -5
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -5,   -2, 	  -6,   -1, 	   2,    2, 	  -1,   -6
+.2byte    0,    1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte   -6,   -2, 	  -7,   -1, 	   1,    2, 	  -2,   -6
+.2byte   -7,   -4, 	  -4,   -8, 	  -3,    1, 	  -1,   -5
+.2byte   -5,   -7, 	   3,   -5, 	  -6,   -1, 	   0,   -5
+.2byte    0,   -6, 	   5,   -2, 	  -5,   -2, 	   0,   -5
+.2byte    5,   -7, 	  -3,   -5, 	   6,   -1, 	   0,   -5
+.2byte    7,   -4, 	   4,   -8, 	   3,    1, 	   1,   -5
+.2byte    6,   -2, 	   7,   -1, 	  -1,    2, 	   2,   -6
+.2byte    0,   -1, 	  -6,    2, 	   6,    2, 	   0,   -4
+.2byte   -4,   -1, 	  -8,   -1, 	   0,    3, 	   0,   -5
+.2byte   -6,   -3, 	  -6,   -4, 	  -5,    1, 	  -1,   -5
+.2byte   -5,   -4, 	   3,   -5, 	  -7,   -1, 	   0,   -5
+.2byte    0,   -6, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte    5,   -4, 	  -3,   -5, 	   7,   -1, 	   0,   -5
+.2byte    6,   -3, 	   6,   -4, 	   5,    1, 	   1,   -5
+.2byte    4,   -1, 	   8,   -1, 	   0,    3, 	   0,   -5
+sNincadaAnimTable1:
+.4byte sNincadaAnims_1_1
+.4byte sNincadaAnims_1_2
+.4byte sNincadaAnims_1_3
+.4byte sNincadaAnims_1_4
+.4byte sNincadaAnims_1_5
+.4byte sNincadaAnims_1_6
+.4byte sNincadaAnims_1_7
+.4byte sNincadaAnims_1_8
+sNincadaAnimTable2:
+.4byte sNincadaAnims_2_1
+.4byte sNincadaAnims_2_2
+.4byte sNincadaAnims_2_3
+.4byte sNincadaAnims_2_4
+.4byte sNincadaAnims_2_5
+.4byte sNincadaAnims_2_6
+.4byte sNincadaAnims_2_7
+.4byte sNincadaAnims_2_8
+sNincadaAnimTable3:
+.4byte sNincadaAnims_3_1
+.4byte sNincadaAnims_3_2
+.4byte sNincadaAnims_3_3
+.4byte sNincadaAnims_3_4
+.4byte sNincadaAnims_3_5
+.4byte sNincadaAnims_3_6
+.4byte sNincadaAnims_3_7
+.4byte sNincadaAnims_3_8
+sNincadaAnimTable4:
+.4byte sNincadaAnims_4_1
+.4byte sNincadaAnims_4_2
+.4byte sNincadaAnims_4_3
+.4byte sNincadaAnims_4_4
+.4byte sNincadaAnims_4_5
+.4byte sNincadaAnims_4_6
+.4byte sNincadaAnims_4_7
+.4byte sNincadaAnims_4_8
+sNincadaAnimTable5:
+.4byte sNincadaAnims_5_1
+.4byte sNincadaAnims_5_2
+.4byte sNincadaAnims_5_3
+.4byte sNincadaAnims_5_4
+.4byte sNincadaAnims_5_5
+.4byte sNincadaAnims_5_6
+.4byte sNincadaAnims_5_7
+.4byte sNincadaAnims_5_8
+sNincadaAnimTable6:
+.4byte sNincadaAnims_6_1
+.4byte sNincadaAnims_6_1
+.4byte sNincadaAnims_6_1
+.4byte sNincadaAnims_6_1
+.4byte sNincadaAnims_6_1
+.4byte sNincadaAnims_6_1
+.4byte sNincadaAnims_6_1
+.4byte sNincadaAnims_6_1
+sNincadaAnimTable7:
+.4byte sNincadaAnims_7_1
+.4byte sNincadaAnims_7_2
+.4byte sNincadaAnims_7_3
+.4byte sNincadaAnims_7_4
+.4byte sNincadaAnims_7_5
+.4byte sNincadaAnims_7_6
+.4byte sNincadaAnims_7_7
+.4byte sNincadaAnims_7_8
+sNincadaAnimTable8:
+.4byte sNincadaAnims_8_1
+.4byte sNincadaAnims_8_2
+.4byte sNincadaAnims_8_3
+.4byte sNincadaAnims_8_4
+.4byte sNincadaAnims_8_5
+.4byte sNincadaAnims_8_6
+.4byte sNincadaAnims_8_7
+.4byte sNincadaAnims_8_8
+sNincadaAnimTable9:
+.4byte sNincadaAnims_9_1
+.4byte sNincadaAnims_9_2
+.4byte sNincadaAnims_9_3
+.4byte sNincadaAnims_9_4
+.4byte sNincadaAnims_9_5
+.4byte sNincadaAnims_9_6
+.4byte sNincadaAnims_9_7
+.4byte sNincadaAnims_9_8
+sNincadaAnimTable10:
+.4byte sNincadaAnims_10_1
+.4byte sNincadaAnims_10_2
+.4byte sNincadaAnims_10_3
+.4byte sNincadaAnims_10_4
+.4byte sNincadaAnims_10_5
+.4byte sNincadaAnims_10_6
+.4byte sNincadaAnims_10_7
+.4byte sNincadaAnims_10_8
+sNincadaAnimTable11:
+.4byte sNincadaAnims_11_1
+.4byte sNincadaAnims_11_2
+.4byte sNincadaAnims_11_3
+.4byte sNincadaAnims_11_4
+.4byte sNincadaAnims_11_5
+.4byte sNincadaAnims_11_6
+.4byte sNincadaAnims_11_7
+.4byte sNincadaAnims_11_8
+sNincadaAnimTable12:
+.4byte sNincadaAnims_12_1
+.4byte sNincadaAnims_12_2
+.4byte sNincadaAnims_12_3
+.4byte sNincadaAnims_12_4
+.4byte sNincadaAnims_12_5
+.4byte sNincadaAnims_12_6
+.4byte sNincadaAnims_12_7
+.4byte sNincadaAnims_12_8
+sNincadaAnimTable13:
+.4byte sNincadaAnims_13_1
+.4byte sNincadaAnims_13_2
+.4byte sNincadaAnims_13_3
+.4byte sNincadaAnims_13_4
+.4byte sNincadaAnims_13_5
+.4byte sNincadaAnims_13_6
+.4byte sNincadaAnims_13_7
+.4byte sNincadaAnims_13_8
+sAxAnimationsNincada:
+.4byte sNincadaAnimTable1
+.4byte sNincadaAnimTable2
+.4byte sNincadaAnimTable3
+.4byte sNincadaAnimTable4
+.4byte sNincadaAnimTable5
+.4byte sNincadaAnimTable6
+.4byte sNincadaAnimTable7
+.4byte sNincadaAnimTable8
+.4byte sNincadaAnimTable9
+.4byte sNincadaAnimTable10
+.4byte sNincadaAnimTable11
+.4byte sNincadaAnimTable12
+.4byte sNincadaAnimTable13
+sAxSpritesNincada:
+.4byte sNincadaSprites1
+.4byte sNincadaSprites2
+.4byte sNincadaSprites3
+.4byte sNincadaSprites4
+.4byte sNincadaSprites5
+.4byte sNincadaSprites6
+.4byte sNincadaSprites7
+.4byte sNincadaSprites8
+.4byte sNincadaSprites9
+.4byte sNincadaSprites10
+.4byte sNincadaSprites11
+.4byte sNincadaSprites12
+.4byte sNincadaSprites13
+.4byte sNincadaSprites14
+.4byte sNincadaSprites15
+.4byte sNincadaSprites16
+.4byte sNincadaSprites17
+.4byte sNincadaSprites18
+.4byte sNincadaSprites19
+.4byte sNincadaSprites20
+.4byte sNincadaSprites21
+.4byte sNincadaSprites22
+.4byte sNincadaSprites23
+.4byte sNincadaSprites24
+.4byte sNincadaSprites25
+.4byte sNincadaSprites26
+.4byte sNincadaSprites27
+.4byte sNincadaSprites28
+.4byte sNincadaSprites29
+.4byte sNincadaSprites30
+.4byte sNincadaSprites31
+.4byte sNincadaSprites32
+.4byte sNincadaSprites33
+.4byte sNincadaSprites34
+.4byte sNincadaSprites35
+.4byte sNincadaSprites36
+.4byte sNincadaSprites37
+.4byte sNincadaSprites38
+.4byte sNincadaSprites39
+.4byte sNincadaSprites40
+.4byte sNincadaSprites41
+.4byte sNincadaSprites42
+.4byte sNincadaSprites43
+.4byte sNincadaSprites44
+.4byte sNincadaSprites45
+.4byte sNincadaSprites46
+.4byte sNincadaSprites47
+.4byte sNincadaSprites48
+.4byte sNincadaSprites49
+.4byte sNincadaSprites50
+sAxMainNincada:
+ax_main sAxPosesNincada, sAxAnimationsNincada, 13, sAxSpritesNincada, sAxPositionsNincada

--- a/data/ax/ninetales.inc
+++ b/data/ax/ninetales.inc
@@ -1,0 +1,3257 @@
+.global gAxNinetales
+gAxNinetales:
+ax_siro sAxMainNinetales
+sNinetalesPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose3:
+ax_pose 2, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose4:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose5:
+ax_pose 4, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose6:
+ax_pose 5, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose7:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose8:
+ax_pose 7, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose9:
+ax_pose 8, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose10:
+ax_pose 9, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose11:
+ax_pose 10, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose12:
+ax_pose 11, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose13:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose14:
+ax_pose 13, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose15:
+ax_pose 14, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose16:
+ax_pose 9, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose17:
+ax_pose 10, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose18:
+ax_pose 11, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose19:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose20:
+ax_pose 7, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose21:
+ax_pose 8, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose22:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose23:
+ax_pose 4, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose24:
+ax_pose 5, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose25:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose27:
+ax_pose 2, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose28:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose29:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose30:
+ax_pose 4, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose31:
+ax_pose 5, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose32:
+ax_pose 16, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose33:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose34:
+ax_pose 7, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose35:
+ax_pose 8, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose36:
+ax_pose 17, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sNinetalesPose37:
+ax_pose 9, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose38:
+ax_pose 10, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose39:
+ax_pose 11, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose40:
+ax_pose 18, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose41:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose42:
+ax_pose 13, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose43:
+ax_pose 14, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose44:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose45:
+ax_pose 9, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose46:
+ax_pose 10, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose47:
+ax_pose 11, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose48:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose49:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose50:
+ax_pose 7, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose51:
+ax_pose 8, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose52:
+ax_pose 17, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sNinetalesPose53:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose54:
+ax_pose 4, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose55:
+ax_pose 5, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose56:
+ax_pose 16, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose57:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose58:
+ax_pose 1, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose59:
+ax_pose 2, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose60:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose61:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose62:
+ax_pose 4, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose63:
+ax_pose 5, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose64:
+ax_pose 16, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose65:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose66:
+ax_pose 7, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose67:
+ax_pose 8, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose68:
+ax_pose 17, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sNinetalesPose69:
+ax_pose 9, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose70:
+ax_pose 10, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose71:
+ax_pose 11, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose72:
+ax_pose 18, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose73:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose74:
+ax_pose 13, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose75:
+ax_pose 14, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose76:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose77:
+ax_pose 9, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose78:
+ax_pose 10, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose79:
+ax_pose 11, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose80:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose81:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose82:
+ax_pose 7, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose83:
+ax_pose 8, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose84:
+ax_pose 17, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sNinetalesPose85:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose86:
+ax_pose 4, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose87:
+ax_pose 5, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose88:
+ax_pose 16, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose89:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose90:
+ax_pose 1, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose91:
+ax_pose 2, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose92:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose93:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose94:
+ax_pose 4, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose95:
+ax_pose 5, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose96:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose97:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose98:
+ax_pose 7, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose99:
+ax_pose 8, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose100:
+ax_pose 22, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose101:
+ax_pose 9, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose102:
+ax_pose 10, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose103:
+ax_pose 11, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose104:
+ax_pose 23, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose105:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose106:
+ax_pose 13, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose107:
+ax_pose 14, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose108:
+ax_pose 24, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose109:
+ax_pose 9, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose110:
+ax_pose 10, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose111:
+ax_pose 11, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose112:
+ax_pose 23, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose113:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose114:
+ax_pose 7, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose115:
+ax_pose 8, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose116:
+ax_pose 22, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose117:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose118:
+ax_pose 4, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose119:
+ax_pose 5, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose120:
+ax_pose 21, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose121:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose122:
+ax_pose 25, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose123:
+ax_pose 26, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose124:
+ax_pose 27, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose125:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose126:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose127:
+ax_pose 28, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose128:
+ax_pose 29, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose129:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose130:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose131:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose132:
+ax_pose 31, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose133:
+ax_pose 32, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose134:
+ax_pose 33, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose135:
+ax_pose 22, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose136:
+ax_pose 9, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose137:
+ax_pose 34, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose138:
+ax_pose 35, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose139:
+ax_pose 36, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose140:
+ax_pose 23, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose141:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose142:
+ax_pose 37, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose143:
+ax_pose 38, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose144:
+ax_pose 39, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose145:
+ax_pose 24, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose146:
+ax_pose 9, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose147:
+ax_pose 34, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose148:
+ax_pose 35, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose149:
+ax_pose 36, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose150:
+ax_pose 23, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose151:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose152:
+ax_pose 31, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose153:
+ax_pose 32, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose154:
+ax_pose 33, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose155:
+ax_pose 22, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose156:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose157:
+ax_pose 28, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose158:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose159:
+ax_pose 30, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose160:
+ax_pose 21, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose161:
+ax_pose 40, 0x01ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sNinetalesPose162:
+ax_pose 41, 0x01ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sNinetalesPose163:
+ax_pose 42, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose164:
+ax_pose 43, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNinetalesPose165:
+ax_pose 44, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNinetalesPose166:
+ax_pose 45, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sNinetalesPose167:
+ax_pose 46, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose168:
+ax_pose 45, 0x01e6, 0x80f5, 0x4c00
+ax_pose_terminator
+sNinetalesPose169:
+ax_pose 44, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNinetalesPose170:
+ax_pose 43, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNinetalesPose171:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose172:
+ax_pose 1, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose173:
+ax_pose 2, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose174:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose175:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose176:
+ax_pose 4, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose177:
+ax_pose 5, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose178:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose179:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose180:
+ax_pose 7, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose181:
+ax_pose 8, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose182:
+ax_pose 22, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose183:
+ax_pose 9, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose184:
+ax_pose 10, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose185:
+ax_pose 11, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose186:
+ax_pose 23, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose187:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose188:
+ax_pose 13, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose189:
+ax_pose 14, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose190:
+ax_pose 24, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose191:
+ax_pose 9, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose192:
+ax_pose 10, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose193:
+ax_pose 11, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose194:
+ax_pose 23, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose195:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose196:
+ax_pose 7, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose197:
+ax_pose 8, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose198:
+ax_pose 22, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose199:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose200:
+ax_pose 4, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose201:
+ax_pose 5, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose202:
+ax_pose 21, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose203:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose204:
+ax_pose 16, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose205:
+ax_pose 17, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose206:
+ax_pose 18, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sNinetalesPose207:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose208:
+ax_pose 18, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sNinetalesPose209:
+ax_pose 17, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose210:
+ax_pose 16, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose211:
+ax_pose 25, 0x01e8, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose212:
+ax_pose 28, 0x01e9, 0x90f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose213:
+ax_pose 31, 0x01e9, 0x90f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose214:
+ax_pose 34, 0x01ea, 0x90f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose215:
+ax_pose 37, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose216:
+ax_pose 34, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose217:
+ax_pose 31, 0x01e9, 0x80ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose218:
+ax_pose 28, 0x01e8, 0x80ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose219:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose220:
+ax_pose 26, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose221:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose222:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose223:
+ax_pose 29, 0x01e6, 0x90f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose224:
+ax_pose 16, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose225:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose226:
+ax_pose 32, 0x01e9, 0x90f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose227:
+ax_pose 17, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sNinetalesPose228:
+ax_pose 9, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose229:
+ax_pose 35, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose230:
+ax_pose 18, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sNinetalesPose231:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose232:
+ax_pose 38, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose233:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose234:
+ax_pose 24, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose235:
+ax_pose 9, 0x01ee, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose236:
+ax_pose 35, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose237:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sNinetalesPose238:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose239:
+ax_pose 32, 0x01e9, 0x80ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose240:
+ax_pose 17, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sNinetalesPose241:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose242:
+ax_pose 29, 0x01e6, 0x80ee, 0x4c00
+ax_pose_terminator
+sNinetalesPose243:
+ax_pose 16, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sNinetalesPose244:
+ax_pose 20, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose245:
+ax_pose 21, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose246:
+ax_pose 22, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose247:
+ax_pose 23, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sNinetalesPose248:
+ax_pose 24, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose249:
+ax_pose 23, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sNinetalesPose250:
+ax_pose 22, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose251:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose252:
+ax_pose 0, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose253:
+ax_pose 3, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose254:
+ax_pose 6, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose255:
+ax_pose 9, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose256:
+ax_pose 12, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose257:
+ax_pose 9, 0x01ee, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose258:
+ax_pose 6, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose259:
+ax_pose 3, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sNinetalesPose260:
+ax_pose 47, 0x41ea, 0x80f2, 0x4c00
+ax_pose 48, 0x41fa, 0x40f2, 0x4c08
+ax_pose 49, 0x01f2, 0x0112, 0x4c0c
+ax_pose_terminator
+sNinetalesPose261:
+ax_pose 47, 0x41ea, 0x90ee, 0x4c00
+ax_pose 48, 0x41fa, 0x50ee, 0x4c08
+ax_pose 49, 0x01f2, 0x10e6, 0x4c0c
+ax_pose_terminator
+sNinetalesPose262:
+ax_pose 47, 0x41ea, 0x80f2, 0x4c00
+ax_pose 48, 0x41fa, 0x40f2, 0x4c08
+ax_pose 49, 0x01f2, 0x0112, 0x4c0c
+ax_pose_terminator
+sNinetalesPose263:
+ax_pose 50, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sNinetalesPose264:
+ax_pose 47, 0x41ea, 0x90ee, 0x4c00
+ax_pose 48, 0x41fa, 0x50ee, 0x4c08
+ax_pose 49, 0x01f2, 0x10e6, 0x4c0c
+ax_pose_terminator
+sNinetalesPose265:
+ax_pose 50, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+.align 2
+sNinetalesAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 4, 0, 26, 0, -5, 0, -5,
+ax_anim 1, 2, 27, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 7, 0, 7,
+ax_anim 2, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 1, 27, 1, 14, 1, 14,
+ax_anim 2, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 0, 27, 1, 14, 1, 14,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNinetalesAnims_2_2:
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 4, 0, 30, -5, -5, -5, -5,
+ax_anim 1, 2, 31, 2, 2, 2, 2,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 17, 18, 17,
+ax_anim 2, 1, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 31, 18, 17, 18, 17,
+ax_anim 2, 0, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sNinetalesAnims_2_3:
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 4, 0, 34, -5, 0, -5, 0,
+ax_anim 1, 2, 35, 2, 0, 2, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, -1, 18, -1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, -1, 18, -1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sNinetalesAnims_2_4:
+ax_anim 2, 0, 38, -2, 2, -2, 2,
+ax_anim 4, 0, 38, -5, 5, -5, 5,
+ax_anim 1, 2, 39, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 1, 39, 17, -18, 17, -18,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 39, 17, -18, 17, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sNinetalesAnims_2_5:
+ax_anim 2, 0, 42, 0, 2, 0, 2,
+ax_anim 4, 0, 42, 0, 5, 0, 5,
+ax_anim 1, 2, 43, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, -7, 0, -7,
+ax_anim 2, 0, 43, 0, -14, 0, -14,
+ax_anim 2, 1, 43, 1, -14, 1, -14,
+ax_anim 2, 0, 43, 0, -14, 0, -14,
+ax_anim 2, 0, 43, 1, -14, 1, -14,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sNinetalesAnims_2_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 4, 0, 46, 5, 5, 5, 5,
+ax_anim 1, 2, 47, -2, -2, -2, -2,
+ax_anim 1, 0, 47, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 1, 47, -17, -18, -17, -18,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 47, -17, -18, -17, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sNinetalesAnims_2_7:
+ax_anim 2, 0, 50, 2, 0, 2, 0,
+ax_anim 4, 0, 50, 5, 0, 5, 0,
+ax_anim 1, 2, 51, -2, 0, -2, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, -1, -18, -1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, -1, -18, -1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sNinetalesAnims_2_8:
+ax_anim 2, 0, 54, 2, -2, 2, -2,
+ax_anim 4, 0, 54, 5, -5, 5, -5,
+ax_anim 1, 2, 55, -2, 2, -2, 2,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 17, -18, 17,
+ax_anim 2, 1, 55, -17, 18, -17, 18,
+ax_anim 2, 0, 55, -18, 17, -18, 17,
+ax_anim 2, 0, 55, -17, 18, -17, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 4, 0, 58, 0, -5, 0, -5,
+ax_anim 1, 2, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 2, 0, 59, 0, 14, 0, 14,
+ax_anim 2, 1, 59, 1, 14, 1, 14,
+ax_anim 2, 0, 59, 0, 14, 0, 14,
+ax_anim 2, 0, 59, 1, 14, 1, 14,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sNinetalesAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 4, 0, 62, -5, -5, -5, -5,
+ax_anim 1, 2, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 1, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sNinetalesAnims_3_3:
+ax_anim 2, 0, 66, -2, 0, -2, 0,
+ax_anim 4, 0, 66, -5, 0, -5, 0,
+ax_anim 1, 2, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, -1, 18, -1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, -1, 18, -1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sNinetalesAnims_3_4:
+ax_anim 2, 0, 70, -2, 2, -2, 2,
+ax_anim 4, 0, 70, -5, 5, -5, 5,
+ax_anim 1, 2, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 18, -17, 18, -17,
+ax_anim 2, 1, 71, 17, -18, 17, -18,
+ax_anim 2, 0, 71, 18, -17, 18, -17,
+ax_anim 2, 0, 71, 17, -18, 17, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sNinetalesAnims_3_5:
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 4, 0, 74, 0, 5, 0, 5,
+ax_anim 1, 2, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -7, 0, -7,
+ax_anim 2, 0, 75, 0, -14, 0, -14,
+ax_anim 2, 1, 75, 1, -14, 1, -14,
+ax_anim 2, 0, 75, 0, -14, 0, -14,
+ax_anim 2, 0, 75, 1, -14, 1, -14,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sNinetalesAnims_3_6:
+ax_anim 2, 0, 78, 2, 2, 2, 2,
+ax_anim 4, 0, 78, 5, 5, 5, 5,
+ax_anim 1, 2, 79, -2, -2, -2, -2,
+ax_anim 1, 0, 79, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -18, -17, -18, -17,
+ax_anim 2, 1, 79, -17, -18, -17, -18,
+ax_anim 2, 0, 79, -18, -17, -18, -17,
+ax_anim 2, 0, 79, -17, -18, -17, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sNinetalesAnims_3_7:
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim 4, 0, 82, 5, 0, 5, 0,
+ax_anim 1, 2, 83, -2, 0, -2, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, -1, -18, -1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, -1, -18, -1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sNinetalesAnims_3_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 4, 0, 86, 5, -5, 5, -5,
+ax_anim 1, 2, 87, -2, 2, -2, 2,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 1, 87, -17, 18, -17, 18,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -17, 18, -17, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_4_1:
+ax_anim 2, 0, 89, 0, -4, 0, -4,
+ax_anim 4, 0, 89, 0, -5, 0, -5,
+ax_anim 1, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 2, 91, 0, 2, 0, 2,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 1, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sNinetalesAnims_4_2:
+ax_anim 2, 0, 93, -4, -4, -4, -4,
+ax_anim 4, 0, 93, -5, -5, -5, -5,
+ax_anim 1, 0, 92, -1, -1, -1, -1,
+ax_anim 2, 2, 95, 2, 2, 2, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 1, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sNinetalesAnims_4_3:
+ax_anim 2, 0, 97, -4, 0, -4, 0,
+ax_anim 4, 0, 97, -5, 0, -5, 0,
+ax_anim 1, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 2, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 1, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sNinetalesAnims_4_4:
+ax_anim 2, 0, 101, -4, 4, -4, 4,
+ax_anim 4, 0, 101, -5, 5, -5, 5,
+ax_anim 1, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 2, 103, 2, -2, 2, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 1, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim_terminator
+sNinetalesAnims_4_5:
+ax_anim 2, 0, 105, 0, 4, 0, 4,
+ax_anim 4, 0, 105, 0, 5, 0, 5,
+ax_anim 1, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 2, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 1, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim_terminator
+sNinetalesAnims_4_6:
+ax_anim 2, 0, 109, 4, 4, 4, 4,
+ax_anim 4, 0, 109, 5, 5, 5, 5,
+ax_anim 1, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 2, 111, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 1, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim_terminator
+sNinetalesAnims_4_7:
+ax_anim 2, 0, 113, 4, 0, 4, 0,
+ax_anim 4, 0, 113, 5, 0, 5, 0,
+ax_anim 1, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 2, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 1, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim_terminator
+sNinetalesAnims_4_8:
+ax_anim 2, 0, 117, 4, -4, 4, -4,
+ax_anim 4, 0, 117, 5, -5, 5, -5,
+ax_anim 1, 0, 116, 1, -1, 1, -1,
+ax_anim 2, 2, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 1, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_5_1:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 3, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_5_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 3, 0, 126, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -2, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 3, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_5_4:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 3, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_5_5:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 3, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_5_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 3, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 2, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_5_7:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 3, 0, 151, 0, -3, 0, 0,
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 2, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_5_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 2, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sNinetalesAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sNinetalesAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sNinetalesAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sNinetalesAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sNinetalesAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sNinetalesAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sNinetalesAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_8_1:
+ax_anim 60, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_8_2:
+ax_anim 60, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -1, 0, -1, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_8_3:
+ax_anim 60, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_8_4:
+ax_anim 60, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_8_5:
+ax_anim 60, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_8_6:
+ax_anim 60, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, 0, -1, 0,
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_8_7:
+ax_anim 60, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_8_8:
+ax_anim 60, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, 0, -1, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 4, 6, 4,
+ax_anim 2, 0, 204, 8, 9, 8, 9,
+ax_anim 2, 0, 205, 7, 16, 7, 19,
+ax_anim 3, 0, 206, 0, 20, 0, 24,
+ax_anim 2, 3, 207, -7, 16, -7, 19,
+ax_anim 2, 0, 208, -8, 9, -8, 9,
+ax_anim 1, 0, 209, -6, 4, -6, 4,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 18, 1, 18, 1,
+ax_anim 2, 0, 204, 22, 9, 22, 9,
+ax_anim 3, 0, 205, 20, 19, 20, 19,
+ax_anim 2, 3, 206, 11, 21, 11, 21,
+ax_anim 2, 0, 207, 2, 12, 2, 12,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -4, 3, -4,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 17, -4, 17, -4,
+ax_anim 3, 0, 204, 17, 1, 17, 1,
+ax_anim 2, 3, 205, 17, 5, 17, 5,
+ax_anim 2, 0, 206, 12, 7, 12, 7,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -6, -1, -6,
+ax_anim 2, 0, 209, 4, -16, 4, -16,
+ax_anim 2, 0, 202, 11, -20, 11, -20,
+ax_anim 3, 0, 203, 16, -20, 16, -20,
+ax_anim 2, 3, 204, 18, -12, 18, -12,
+ax_anim 2, 0, 205, 16, -6, 16, -6,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -6, -4, -6, -4,
+ax_anim 2, 0, 208, -8, -10, -8, -10,
+ax_anim 2, 0, 209, -7, -18, -7, -18,
+ax_anim 3, 0, 202, 0, -18, 0, -18,
+ax_anim 2, 3, 203, 7, -18, 7, -18,
+ax_anim 2, 0, 204, 8, -8, 8, -8,
+ax_anim 1, 0, 205, 6, -4, 6, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -6, 1, -6,
+ax_anim 2, 0, 203, -4, -16, -4, -16,
+ax_anim 2, 0, 202, -11, -20, -11, -20,
+ax_anim 3, 0, 209, -16, -20, -16, -20,
+ax_anim 2, 3, 208, -18, -12, -18, -12,
+ax_anim 2, 0, 207, -16, -6, -16, -6,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -4, -3, -4,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -17, -4, -17, -4,
+ax_anim 3, 0, 208, -17, 1, -17, 1,
+ax_anim 2, 3, 207, -17, 5, -17, 5,
+ax_anim 2, 0, 206, -12, 7, -12, 7,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -18, 1, -18, 1,
+ax_anim 2, 0, 208, -22, 9, -22, 9,
+ax_anim 3, 0, 207, -20, 19, -20, 19,
+ax_anim 2, 3, 206, -11, 21, -11, 21,
+ax_anim 2, 0, 205, -2, 12, -2, 12,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 3, 0, 218, 0, -29, 0, 0,
+ax_anim 3, 0, 220, 0, -26, 0, 0,
+ax_anim 3, 0, 220, 0, -24, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 3, 0, 221, 2, -28, 0, 0,
+ax_anim 3, 0, 223, 0, -26, 0, 0,
+ax_anim 3, 0, 223, 0, -24, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 3, 0, 224, 0, -28, 0, 0,
+ax_anim 3, 0, 226, 0, -26, 0, 0,
+ax_anim 3, 0, 226, 0, -24, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 3, 0, 228, 0, -21, 0, 0,
+ax_anim 3, 0, 227, 0, -28, 0, 0,
+ax_anim 3, 0, 229, 0, -26, 0, 0,
+ax_anim 3, 0, 229, 0, -24, 0, 0,
+ax_anim 2, 0, 229, 0, -18, 0, 0,
+ax_anim 1, 0, 229, 0, -12, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 3, 0, 231, 0, -21, 0, 0,
+ax_anim 3, 0, 232, 0, -26, 0, 0,
+ax_anim 3, 0, 233, 0, -26, 0, 0,
+ax_anim 3, 0, 233, 0, -24, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_11_6:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 3, 0, 234, 0, -28, 0, 0,
+ax_anim 3, 0, 236, 0, -26, 0, 0,
+ax_anim 3, 0, 236, 0, -24, 0, 0,
+ax_anim 2, 0, 236, 0, -18, 0, 0,
+ax_anim 1, 0, 236, 0, -12, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_11_7:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 0, -10, 0, 0,
+ax_anim 2, 0, 238, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 3, 0, 238, 0, -21, 0, 0,
+ax_anim 3, 0, 237, 0, -28, 0, 0,
+ax_anim 3, 0, 239, 0, -26, 0, 0,
+ax_anim 3, 0, 239, 0, -24, 0, 0,
+ax_anim 2, 0, 239, 0, -18, 0, 0,
+ax_anim 1, 0, 239, 0, -12, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_11_8:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 3, 0, 241, 0, -21, 0, 0,
+ax_anim 3, 0, 240, -2, -28, 0, 0,
+ax_anim 3, 0, 242, 0, -26, 0, 0,
+ax_anim 3, 0, 242, 0, -24, 0, 0,
+ax_anim 2, 0, 242, 0, -18, 0, 0,
+ax_anim 1, 0, 242, 0, -12, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_12_1:
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 1, 0, 1, 0,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_12_2:
+ax_anim 2, 0, 250, 1, -1, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_12_3:
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_12_4:
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_12_5:
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_12_6:
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, -1, 1, -1,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_12_7:
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, -1, 0, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_12_8:
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, -1, -1, -1, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_13_1:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_13_2:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_13_3:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_13_4:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_13_5:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_13_6:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_13_7:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_13_8:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_14_1:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 1, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_14_2:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 1, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_14_3:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 1, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_14_4:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 1, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_14_5:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 1, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_14_6:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 1, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_14_7:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 1, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_14_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinetalesAnims_15_1:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_15_2:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_15_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 1, 0, 1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 1, 0, 1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 1, 0, 1,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_15_4:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_15_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_15_6:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_15_7:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesAnims_15_8:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 1, 0, 1,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sNinetalesGfx1:
+.incbin "baserom.gba", 0x6A72F4, 0x200
+sNinetalesSprites1:
+ax_sprite sNinetalesGfx1, 0x200
+ax_sprite_terminator
+sNinetalesGfx2:
+.incbin "baserom.gba", 0x6A7504, 0x200
+sNinetalesSprites2:
+ax_sprite sNinetalesGfx2, 0x200
+ax_sprite_terminator
+sNinetalesGfx3:
+.incbin "baserom.gba", 0x6A7714, 0x200
+sNinetalesSprites3:
+ax_sprite sNinetalesGfx3, 0x200
+ax_sprite_terminator
+sNinetalesGfx4:
+.incbin "baserom.gba", 0x6A7924, 0x200
+sNinetalesSprites4:
+ax_sprite sNinetalesGfx4, 0x200
+ax_sprite_terminator
+sNinetalesGfx5:
+.incbin "baserom.gba", 0x6A7B34, 0x200
+sNinetalesSprites5:
+ax_sprite sNinetalesGfx5, 0x200
+ax_sprite_terminator
+sNinetalesGfx6:
+.incbin "baserom.gba", 0x6A7D44, 0x200
+sNinetalesSprites6:
+ax_sprite sNinetalesGfx6, 0x200
+ax_sprite_terminator
+sNinetalesGfx7:
+.incbin "baserom.gba", 0x6A7F54, 0x200
+sNinetalesSprites7:
+ax_sprite sNinetalesGfx7, 0x200
+ax_sprite_terminator
+sNinetalesGfx8:
+.incbin "baserom.gba", 0x6A8164, 0x200
+sNinetalesSprites8:
+ax_sprite sNinetalesGfx8, 0x200
+ax_sprite_terminator
+sNinetalesGfx9:
+.incbin "baserom.gba", 0x6A8374, 0x200
+sNinetalesSprites9:
+ax_sprite sNinetalesGfx9, 0x200
+ax_sprite_terminator
+sNinetalesGfx10:
+.incbin "baserom.gba", 0x6A8584, 0x200
+sNinetalesSprites10:
+ax_sprite sNinetalesGfx10, 0x200
+ax_sprite_terminator
+sNinetalesGfx11:
+.incbin "baserom.gba", 0x6A8794, 0x200
+sNinetalesSprites11:
+ax_sprite sNinetalesGfx11, 0x200
+ax_sprite_terminator
+sNinetalesGfx12:
+.incbin "baserom.gba", 0x6A89A4, 0x200
+sNinetalesSprites12:
+ax_sprite sNinetalesGfx12, 0x200
+ax_sprite_terminator
+sNinetalesGfx13:
+.incbin "baserom.gba", 0x6A8BB4, 0x200
+sNinetalesSprites13:
+ax_sprite sNinetalesGfx13, 0x200
+ax_sprite_terminator
+sNinetalesGfx14:
+.incbin "baserom.gba", 0x6A8DC4, 0x200
+sNinetalesSprites14:
+ax_sprite sNinetalesGfx14, 0x200
+ax_sprite_terminator
+sNinetalesGfx15:
+.incbin "baserom.gba", 0x6A8FD4, 0x200
+sNinetalesSprites15:
+ax_sprite sNinetalesGfx15, 0x200
+ax_sprite_terminator
+sNinetalesGfx16:
+.incbin "baserom.gba", 0x6A91E4, 0x180
+sNinetalesGfx16_1:
+.incbin "baserom.gba", 0x6A9364, 0x40
+sNinetalesSprites16:
+ax_sprite sNinetalesGfx16, 0x180
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx17:
+.incbin "baserom.gba", 0x6A93CC, 0x1C0
+sNinetalesSprites17:
+ax_sprite sNinetalesGfx17, 0x1c0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNinetalesGfx18:
+.incbin "baserom.gba", 0x6A95A4, 0x180
+sNinetalesSprites18:
+ax_sprite sNinetalesGfx18, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNinetalesGfx19:
+.incbin "baserom.gba", 0x6A973C, 0x40
+sNinetalesGfx19_1:
+.incbin "baserom.gba", 0x6A977C, 0xE0
+sNinetalesSprites19:
+ax_sprite sNinetalesGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNinetalesGfx19_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sNinetalesGfx20:
+.incbin "baserom.gba", 0x6A9884, 0x40
+sNinetalesGfx20_1:
+.incbin "baserom.gba", 0x6A98C4, 0x180
+sNinetalesSprites20:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx20_1, 0x180
+ax_sprite_terminator
+sNinetalesGfx21:
+.incbin "baserom.gba", 0x6A9A6C, 0x180
+sNinetalesGfx21_1:
+.incbin "baserom.gba", 0x6A9BEC, 0x40
+sNinetalesSprites21:
+ax_sprite sNinetalesGfx21, 0x180
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx21_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx22:
+.incbin "baserom.gba", 0x6A9C54, 0x160
+sNinetalesGfx22_1:
+.incbin "baserom.gba", 0x6A9DB4, 0x20
+sNinetalesSprites22:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx22, 0x160
+ax_sprite 0, 0x40
+ax_sprite sNinetalesGfx22_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx23:
+.incbin "baserom.gba", 0x6A9E04, 0x100
+sNinetalesGfx23_1:
+.incbin "baserom.gba", 0x6A9F04, 0x60
+sNinetalesSprites23:
+ax_sprite sNinetalesGfx23, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx23_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNinetalesGfx24:
+.incbin "baserom.gba", 0x6A9F8C, 0x180
+sNinetalesSprites24:
+ax_sprite sNinetalesGfx24, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNinetalesGfx25:
+.incbin "baserom.gba", 0x6AA124, 0x40
+sNinetalesGfx25_1:
+.incbin "baserom.gba", 0x6AA164, 0x100
+sNinetalesGfx25_2:
+.incbin "baserom.gba", 0x6AA264, 0x40
+sNinetalesSprites25:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx26:
+.incbin "baserom.gba", 0x6AA2E4, 0x180
+sNinetalesGfx26_1:
+.incbin "baserom.gba", 0x6AA464, 0x20
+sNinetalesGfx26_2:
+.incbin "baserom.gba", 0x6AA484, 0x20
+sNinetalesSprites26:
+ax_sprite sNinetalesGfx26, 0x180
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx26_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx26_2, 0x20
+ax_sprite_terminator
+sNinetalesGfx27:
+.incbin "baserom.gba", 0x6AA4D4, 0x180
+sNinetalesGfx27_1:
+.incbin "baserom.gba", 0x6AA654, 0x20
+sNinetalesSprites27:
+ax_sprite sNinetalesGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx27_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNinetalesGfx28:
+.incbin "baserom.gba", 0x6AA69C, 0x1C0
+sNinetalesSprites28:
+ax_sprite sNinetalesGfx28, 0x1c0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNinetalesGfx29:
+.incbin "baserom.gba", 0x6AA874, 0x60
+sNinetalesGfx29_1:
+.incbin "baserom.gba", 0x6AA8D4, 0x60
+sNinetalesGfx29_2:
+.incbin "baserom.gba", 0x6AA934, 0x60
+sNinetalesGfx29_3:
+.incbin "baserom.gba", 0x6AA994, 0x20
+sNinetalesGfx29_4:
+.incbin "baserom.gba", 0x6AA9B4, 0x20
+sNinetalesSprites29:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx29_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx29_4, 0x20
+ax_sprite_terminator
+sNinetalesGfx30:
+.incbin "baserom.gba", 0x6AAA2C, 0xE0
+sNinetalesGfx30_1:
+.incbin "baserom.gba", 0x6AAB0C, 0x60
+sNinetalesGfx30_2:
+.incbin "baserom.gba", 0x6AAB6C, 0x20
+sNinetalesSprites30:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx30, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx30_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNinetalesGfx31:
+.incbin "baserom.gba", 0x6AABCC, 0x160
+sNinetalesGfx31_1:
+.incbin "baserom.gba", 0x6AAD2C, 0x20
+sNinetalesSprites31:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx31, 0x160
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx31_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNinetalesGfx32:
+.incbin "baserom.gba", 0x6AAD7C, 0x60
+sNinetalesGfx32_1:
+.incbin "baserom.gba", 0x6AADDC, 0x60
+sNinetalesGfx32_2:
+.incbin "baserom.gba", 0x6AAE3C, 0x60
+sNinetalesGfx32_3:
+.incbin "baserom.gba", 0x6AAE9C, 0x20
+sNinetalesSprites32:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNinetalesGfx32_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx33:
+.incbin "baserom.gba", 0x6AAF0C, 0x60
+sNinetalesGfx33_1:
+.incbin "baserom.gba", 0x6AAF6C, 0x60
+sNinetalesGfx33_2:
+.incbin "baserom.gba", 0x6AAFCC, 0x60
+sNinetalesGfx33_3:
+.incbin "baserom.gba", 0x6AB02C, 0x20
+sNinetalesSprites33:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNinetalesGfx33_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx34:
+.incbin "baserom.gba", 0x6AB09C, 0x60
+sNinetalesGfx34_1:
+.incbin "baserom.gba", 0x6AB0FC, 0x60
+sNinetalesGfx34_2:
+.incbin "baserom.gba", 0x6AB15C, 0x60
+sNinetalesGfx34_3:
+.incbin "baserom.gba", 0x6AB1BC, 0x60
+sNinetalesSprites34:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx34_3, 0x60
+ax_sprite_terminator
+sNinetalesGfx35:
+.incbin "baserom.gba", 0x6AB264, 0x40
+sNinetalesGfx35_1:
+.incbin "baserom.gba", 0x6AB2A4, 0x60
+sNinetalesGfx35_2:
+.incbin "baserom.gba", 0x6AB304, 0x60
+sNinetalesGfx35_3:
+.incbin "baserom.gba", 0x6AB364, 0x20
+sNinetalesSprites35:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNinetalesGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNinetalesGfx35_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx36:
+.incbin "baserom.gba", 0x6AB3D4, 0x40
+sNinetalesGfx36_1:
+.incbin "baserom.gba", 0x6AB414, 0x60
+sNinetalesGfx36_2:
+.incbin "baserom.gba", 0x6AB474, 0x60
+sNinetalesGfx36_3:
+.incbin "baserom.gba", 0x6AB4D4, 0x40
+sNinetalesSprites36:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNinetalesGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx37:
+.incbin "baserom.gba", 0x6AB564, 0x60
+sNinetalesGfx37_1:
+.incbin "baserom.gba", 0x6AB5C4, 0x60
+sNinetalesGfx37_2:
+.incbin "baserom.gba", 0x6AB624, 0x60
+sNinetalesGfx37_3:
+.incbin "baserom.gba", 0x6AB684, 0x40
+sNinetalesSprites37:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinetalesGfx38:
+.incbin "baserom.gba", 0x6AB714, 0x40
+sNinetalesGfx38_1:
+.incbin "baserom.gba", 0x6AB754, 0x100
+sNinetalesSprites38:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx38_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNinetalesGfx39:
+.incbin "baserom.gba", 0x6AB884, 0x40
+sNinetalesGfx39_1:
+.incbin "baserom.gba", 0x6AB8C4, 0x100
+sNinetalesSprites39:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx39_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNinetalesGfx40:
+.incbin "baserom.gba", 0x6AB9F4, 0x40
+sNinetalesGfx40_1:
+.incbin "baserom.gba", 0x6ABA34, 0x100
+sNinetalesSprites40:
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNinetalesGfx40_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNinetalesGfx41:
+.incbin "baserom.gba", 0x6ABB64, 0x200
+sNinetalesSprites41:
+ax_sprite sNinetalesGfx41, 0x200
+ax_sprite_terminator
+sNinetalesGfx42:
+.incbin "baserom.gba", 0x6ABD74, 0x200
+sNinetalesSprites42:
+ax_sprite sNinetalesGfx42, 0x200
+ax_sprite_terminator
+sNinetalesGfx43:
+.incbin "baserom.gba", 0x6ABF84, 0x200
+sNinetalesSprites43:
+ax_sprite sNinetalesGfx43, 0x200
+ax_sprite_terminator
+sNinetalesGfx44:
+.incbin "baserom.gba", 0x6AC194, 0x200
+sNinetalesSprites44:
+ax_sprite sNinetalesGfx44, 0x200
+ax_sprite_terminator
+sNinetalesGfx45:
+.incbin "baserom.gba", 0x6AC3A4, 0x200
+sNinetalesSprites45:
+ax_sprite sNinetalesGfx45, 0x200
+ax_sprite_terminator
+sNinetalesGfx46:
+.incbin "baserom.gba", 0x6AC5B4, 0x200
+sNinetalesSprites46:
+ax_sprite sNinetalesGfx46, 0x200
+ax_sprite_terminator
+sNinetalesGfx47:
+.incbin "baserom.gba", 0x6AC7C4, 0x200
+sNinetalesSprites47:
+ax_sprite sNinetalesGfx47, 0x200
+ax_sprite_terminator
+sNinetalesGfx48:
+.incbin "baserom.gba", 0x6AC9D4, 0x100
+sNinetalesSprites48:
+ax_sprite sNinetalesGfx48, 0x100
+ax_sprite_terminator
+sNinetalesGfx49:
+.incbin "baserom.gba", 0x6ACAE4, 0x80
+sNinetalesSprites49:
+ax_sprite sNinetalesGfx49, 0x80
+ax_sprite_terminator
+sNinetalesGfx50:
+.incbin "baserom.gba", 0x6ACB74, 0x20
+sNinetalesSprites50:
+ax_sprite sNinetalesGfx50, 0x20
+ax_sprite_terminator
+sNinetalesGfx51:
+.incbin "baserom.gba", 0x6ACBA4, 0x200
+sNinetalesSprites51:
+ax_sprite sNinetalesGfx51, 0x200
+ax_sprite_terminator
+sAxPosesNinetales:
+.4byte sNinetalesPose1
+.4byte sNinetalesPose2
+.4byte sNinetalesPose3
+.4byte sNinetalesPose4
+.4byte sNinetalesPose5
+.4byte sNinetalesPose6
+.4byte sNinetalesPose7
+.4byte sNinetalesPose8
+.4byte sNinetalesPose9
+.4byte sNinetalesPose10
+.4byte sNinetalesPose11
+.4byte sNinetalesPose12
+.4byte sNinetalesPose13
+.4byte sNinetalesPose14
+.4byte sNinetalesPose15
+.4byte sNinetalesPose16
+.4byte sNinetalesPose17
+.4byte sNinetalesPose18
+.4byte sNinetalesPose19
+.4byte sNinetalesPose20
+.4byte sNinetalesPose21
+.4byte sNinetalesPose22
+.4byte sNinetalesPose23
+.4byte sNinetalesPose24
+.4byte sNinetalesPose25
+.4byte sNinetalesPose26
+.4byte sNinetalesPose27
+.4byte sNinetalesPose28
+.4byte sNinetalesPose29
+.4byte sNinetalesPose30
+.4byte sNinetalesPose31
+.4byte sNinetalesPose32
+.4byte sNinetalesPose33
+.4byte sNinetalesPose34
+.4byte sNinetalesPose35
+.4byte sNinetalesPose36
+.4byte sNinetalesPose37
+.4byte sNinetalesPose38
+.4byte sNinetalesPose39
+.4byte sNinetalesPose40
+.4byte sNinetalesPose41
+.4byte sNinetalesPose42
+.4byte sNinetalesPose43
+.4byte sNinetalesPose44
+.4byte sNinetalesPose45
+.4byte sNinetalesPose46
+.4byte sNinetalesPose47
+.4byte sNinetalesPose48
+.4byte sNinetalesPose49
+.4byte sNinetalesPose50
+.4byte sNinetalesPose51
+.4byte sNinetalesPose52
+.4byte sNinetalesPose53
+.4byte sNinetalesPose54
+.4byte sNinetalesPose55
+.4byte sNinetalesPose56
+.4byte sNinetalesPose57
+.4byte sNinetalesPose58
+.4byte sNinetalesPose59
+.4byte sNinetalesPose60
+.4byte sNinetalesPose61
+.4byte sNinetalesPose62
+.4byte sNinetalesPose63
+.4byte sNinetalesPose64
+.4byte sNinetalesPose65
+.4byte sNinetalesPose66
+.4byte sNinetalesPose67
+.4byte sNinetalesPose68
+.4byte sNinetalesPose69
+.4byte sNinetalesPose70
+.4byte sNinetalesPose71
+.4byte sNinetalesPose72
+.4byte sNinetalesPose73
+.4byte sNinetalesPose74
+.4byte sNinetalesPose75
+.4byte sNinetalesPose76
+.4byte sNinetalesPose77
+.4byte sNinetalesPose78
+.4byte sNinetalesPose79
+.4byte sNinetalesPose80
+.4byte sNinetalesPose81
+.4byte sNinetalesPose82
+.4byte sNinetalesPose83
+.4byte sNinetalesPose84
+.4byte sNinetalesPose85
+.4byte sNinetalesPose86
+.4byte sNinetalesPose87
+.4byte sNinetalesPose88
+.4byte sNinetalesPose89
+.4byte sNinetalesPose90
+.4byte sNinetalesPose91
+.4byte sNinetalesPose92
+.4byte sNinetalesPose93
+.4byte sNinetalesPose94
+.4byte sNinetalesPose95
+.4byte sNinetalesPose96
+.4byte sNinetalesPose97
+.4byte sNinetalesPose98
+.4byte sNinetalesPose99
+.4byte sNinetalesPose100
+.4byte sNinetalesPose101
+.4byte sNinetalesPose102
+.4byte sNinetalesPose103
+.4byte sNinetalesPose104
+.4byte sNinetalesPose105
+.4byte sNinetalesPose106
+.4byte sNinetalesPose107
+.4byte sNinetalesPose108
+.4byte sNinetalesPose109
+.4byte sNinetalesPose110
+.4byte sNinetalesPose111
+.4byte sNinetalesPose112
+.4byte sNinetalesPose113
+.4byte sNinetalesPose114
+.4byte sNinetalesPose115
+.4byte sNinetalesPose116
+.4byte sNinetalesPose117
+.4byte sNinetalesPose118
+.4byte sNinetalesPose119
+.4byte sNinetalesPose120
+.4byte sNinetalesPose121
+.4byte sNinetalesPose122
+.4byte sNinetalesPose123
+.4byte sNinetalesPose124
+.4byte sNinetalesPose125
+.4byte sNinetalesPose126
+.4byte sNinetalesPose127
+.4byte sNinetalesPose128
+.4byte sNinetalesPose129
+.4byte sNinetalesPose130
+.4byte sNinetalesPose131
+.4byte sNinetalesPose132
+.4byte sNinetalesPose133
+.4byte sNinetalesPose134
+.4byte sNinetalesPose135
+.4byte sNinetalesPose136
+.4byte sNinetalesPose137
+.4byte sNinetalesPose138
+.4byte sNinetalesPose139
+.4byte sNinetalesPose140
+.4byte sNinetalesPose141
+.4byte sNinetalesPose142
+.4byte sNinetalesPose143
+.4byte sNinetalesPose144
+.4byte sNinetalesPose145
+.4byte sNinetalesPose146
+.4byte sNinetalesPose147
+.4byte sNinetalesPose148
+.4byte sNinetalesPose149
+.4byte sNinetalesPose150
+.4byte sNinetalesPose151
+.4byte sNinetalesPose152
+.4byte sNinetalesPose153
+.4byte sNinetalesPose154
+.4byte sNinetalesPose155
+.4byte sNinetalesPose156
+.4byte sNinetalesPose157
+.4byte sNinetalesPose158
+.4byte sNinetalesPose159
+.4byte sNinetalesPose160
+.4byte sNinetalesPose161
+.4byte sNinetalesPose162
+.4byte sNinetalesPose163
+.4byte sNinetalesPose164
+.4byte sNinetalesPose165
+.4byte sNinetalesPose166
+.4byte sNinetalesPose167
+.4byte sNinetalesPose168
+.4byte sNinetalesPose169
+.4byte sNinetalesPose170
+.4byte sNinetalesPose171
+.4byte sNinetalesPose172
+.4byte sNinetalesPose173
+.4byte sNinetalesPose174
+.4byte sNinetalesPose175
+.4byte sNinetalesPose176
+.4byte sNinetalesPose177
+.4byte sNinetalesPose178
+.4byte sNinetalesPose179
+.4byte sNinetalesPose180
+.4byte sNinetalesPose181
+.4byte sNinetalesPose182
+.4byte sNinetalesPose183
+.4byte sNinetalesPose184
+.4byte sNinetalesPose185
+.4byte sNinetalesPose186
+.4byte sNinetalesPose187
+.4byte sNinetalesPose188
+.4byte sNinetalesPose189
+.4byte sNinetalesPose190
+.4byte sNinetalesPose191
+.4byte sNinetalesPose192
+.4byte sNinetalesPose193
+.4byte sNinetalesPose194
+.4byte sNinetalesPose195
+.4byte sNinetalesPose196
+.4byte sNinetalesPose197
+.4byte sNinetalesPose198
+.4byte sNinetalesPose199
+.4byte sNinetalesPose200
+.4byte sNinetalesPose201
+.4byte sNinetalesPose202
+.4byte sNinetalesPose203
+.4byte sNinetalesPose204
+.4byte sNinetalesPose205
+.4byte sNinetalesPose206
+.4byte sNinetalesPose207
+.4byte sNinetalesPose208
+.4byte sNinetalesPose209
+.4byte sNinetalesPose210
+.4byte sNinetalesPose211
+.4byte sNinetalesPose212
+.4byte sNinetalesPose213
+.4byte sNinetalesPose214
+.4byte sNinetalesPose215
+.4byte sNinetalesPose216
+.4byte sNinetalesPose217
+.4byte sNinetalesPose218
+.4byte sNinetalesPose219
+.4byte sNinetalesPose220
+.4byte sNinetalesPose221
+.4byte sNinetalesPose222
+.4byte sNinetalesPose223
+.4byte sNinetalesPose224
+.4byte sNinetalesPose225
+.4byte sNinetalesPose226
+.4byte sNinetalesPose227
+.4byte sNinetalesPose228
+.4byte sNinetalesPose229
+.4byte sNinetalesPose230
+.4byte sNinetalesPose231
+.4byte sNinetalesPose232
+.4byte sNinetalesPose233
+.4byte sNinetalesPose234
+.4byte sNinetalesPose235
+.4byte sNinetalesPose236
+.4byte sNinetalesPose237
+.4byte sNinetalesPose238
+.4byte sNinetalesPose239
+.4byte sNinetalesPose240
+.4byte sNinetalesPose241
+.4byte sNinetalesPose242
+.4byte sNinetalesPose243
+.4byte sNinetalesPose244
+.4byte sNinetalesPose245
+.4byte sNinetalesPose246
+.4byte sNinetalesPose247
+.4byte sNinetalesPose248
+.4byte sNinetalesPose249
+.4byte sNinetalesPose250
+.4byte sNinetalesPose251
+.4byte sNinetalesPose252
+.4byte sNinetalesPose253
+.4byte sNinetalesPose254
+.4byte sNinetalesPose255
+.4byte sNinetalesPose256
+.4byte sNinetalesPose257
+.4byte sNinetalesPose258
+.4byte sNinetalesPose259
+.4byte sNinetalesPose260
+.4byte sNinetalesPose261
+.4byte sNinetalesPose262
+.4byte sNinetalesPose263
+.4byte sNinetalesPose264
+.4byte sNinetalesPose265
+sAxPositionsNinetales:
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,   -3, 	  -4,    4, 	   3,    0, 	   0,   -7
+.2byte   -1,   -3, 	  -5,    0, 	   2,    4, 	  -1,   -7
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    5,   -4, 	   9,    1, 	  -3,    1, 	  -2,   -9
+.2byte    6,   -4, 	   4,   -3, 	   2,    4, 	  -1,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    8,   -7, 	   9,   -3, 	   1,    0, 	  -5,   -8
+.2byte    8,   -7, 	   1,   -3, 	   7,    0, 	  -4,  -10
+.2byte    7,  -12, 	  -2,   -4, 	   5,   -4, 	  -2,  -10
+.2byte    7,  -11, 	  -3,   -3, 	   1,   -3, 	  -2,   -8
+.2byte    7,  -11, 	   3,   -9, 	   7,   -6, 	  -4,   -8
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte    0,  -13, 	   2,  -10, 	  -2,   -7, 	   0,   -9
+.2byte    0,  -14, 	   2,   -6, 	  -1,   -9, 	   2,   -9
+.2byte   -8,  -12, 	   1,   -4, 	  -6,   -4, 	   1,  -10
+.2byte   -8,  -11, 	   2,   -3, 	  -2,   -3, 	   1,   -8
+.2byte   -8,  -11, 	  -4,   -9, 	  -8,   -6, 	   3,   -8
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -9,   -7, 	 -10,   -3, 	  -2,    0, 	   4,   -8
+.2byte   -9,   -7, 	  -2,   -3, 	  -8,    0, 	   3,  -10
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte   -6,   -4, 	 -10,    1, 	   2,    1, 	   1,   -9
+.2byte   -7,   -4, 	  -5,   -3, 	  -3,    4, 	   0,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,   -3, 	  -4,    4, 	   3,    0, 	   0,   -7
+.2byte   -1,   -3, 	  -5,    0, 	   2,    4, 	  -1,   -7
+.2byte   -1,    1, 	  -5,    5, 	   3,    5, 	  -1,   -9
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    5,   -4, 	   9,    1, 	  -3,    1, 	  -2,   -9
+.2byte    6,   -4, 	   4,   -3, 	   2,    4, 	  -1,  -10
+.2byte    5,   -1, 	   8,    0, 	   2,    2, 	   0,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    8,   -7, 	   9,   -3, 	   1,    0, 	  -5,   -8
+.2byte    8,   -7, 	   1,   -3, 	   7,    0, 	  -4,  -10
+.2byte    7,   -6, 	   4,   -4, 	   7,   -1, 	  -2,   -8
+.2byte    7,  -12, 	  -2,   -4, 	   5,   -4, 	  -2,  -10
+.2byte    7,  -11, 	  -3,   -3, 	   1,   -3, 	  -2,   -8
+.2byte    7,  -11, 	   3,   -9, 	   7,   -6, 	  -4,   -8
+.2byte    5,  -14, 	   4,  -10, 	   7,   -7, 	  -2,   -7
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte    0,  -13, 	   2,  -10, 	  -2,   -7, 	   0,   -9
+.2byte    0,  -14, 	   2,   -6, 	  -1,   -9, 	   2,   -9
+.2byte    0,  -17, 	   1,   -2, 	  -1,   -2, 	   0,   -8
+.2byte   -8,  -12, 	   1,   -4, 	  -6,   -4, 	   1,  -10
+.2byte   -8,  -11, 	   2,   -3, 	  -2,   -3, 	   1,   -8
+.2byte   -8,  -11, 	  -4,   -9, 	  -8,   -6, 	   3,   -8
+.2byte   -6,  -14, 	  -5,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -9,   -7, 	 -10,   -3, 	  -2,    0, 	   4,   -8
+.2byte   -9,   -7, 	  -2,   -3, 	  -8,    0, 	   3,  -10
+.2byte   -8,   -6, 	  -5,   -4, 	  -8,   -1, 	   1,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte   -6,   -4, 	 -10,    1, 	   2,    1, 	   1,   -9
+.2byte   -7,   -4, 	  -5,   -3, 	  -3,    4, 	   0,  -10
+.2byte   -6,   -1, 	  -9,    0, 	  -3,    2, 	  -1,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,   -3, 	  -4,    4, 	   3,    0, 	   0,   -7
+.2byte   -1,   -3, 	  -5,    0, 	   2,    4, 	  -1,   -7
+.2byte   -1,    1, 	  -5,    5, 	   3,    5, 	  -1,   -9
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    5,   -4, 	   9,    1, 	  -3,    1, 	  -2,   -9
+.2byte    6,   -4, 	   4,   -3, 	   2,    4, 	  -1,  -10
+.2byte    5,   -1, 	   8,    0, 	   2,    2, 	   0,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    8,   -7, 	   9,   -3, 	   1,    0, 	  -5,   -8
+.2byte    8,   -7, 	   1,   -3, 	   7,    0, 	  -4,  -10
+.2byte    7,   -6, 	   4,   -4, 	   7,   -1, 	  -2,   -8
+.2byte    7,  -12, 	  -2,   -4, 	   5,   -4, 	  -2,  -10
+.2byte    7,  -11, 	  -3,   -3, 	   1,   -3, 	  -2,   -8
+.2byte    7,  -11, 	   3,   -9, 	   7,   -6, 	  -4,   -8
+.2byte    5,  -14, 	   4,  -10, 	   7,   -7, 	  -2,   -7
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte    0,  -13, 	   2,  -10, 	  -2,   -7, 	   0,   -9
+.2byte    0,  -14, 	   2,   -6, 	  -1,   -9, 	   2,   -9
+.2byte    0,  -17, 	   1,   -2, 	  -1,   -2, 	   0,   -8
+.2byte   -8,  -12, 	   1,   -4, 	  -6,   -4, 	   1,  -10
+.2byte   -8,  -11, 	   2,   -3, 	  -2,   -3, 	   1,   -8
+.2byte   -8,  -11, 	  -4,   -9, 	  -8,   -6, 	   3,   -8
+.2byte   -6,  -14, 	  -5,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -9,   -7, 	 -10,   -3, 	  -2,    0, 	   4,   -8
+.2byte   -9,   -7, 	  -2,   -3, 	  -8,    0, 	   3,  -10
+.2byte   -8,   -6, 	  -5,   -4, 	  -8,   -1, 	   1,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte   -6,   -4, 	 -10,    1, 	   2,    1, 	   1,   -9
+.2byte   -7,   -4, 	  -5,   -3, 	  -3,    4, 	   0,  -10
+.2byte   -6,   -1, 	  -9,    0, 	  -3,    2, 	  -1,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,   -3, 	  -4,    4, 	   3,    0, 	   0,   -7
+.2byte   -1,   -3, 	  -5,    0, 	   2,    4, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	   0,  -11
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    5,   -4, 	   9,    1, 	  -3,    1, 	  -2,   -9
+.2byte    6,   -4, 	   4,   -3, 	   2,    4, 	  -1,  -10
+.2byte    6,   -3, 	   5,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    8,   -7, 	   9,   -3, 	   1,    0, 	  -5,   -8
+.2byte    8,   -7, 	   1,   -3, 	   7,    0, 	  -4,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -1,   -9
+.2byte    7,  -12, 	  -2,   -4, 	   5,   -4, 	  -2,  -10
+.2byte    7,  -11, 	  -3,   -3, 	   1,   -3, 	  -2,   -8
+.2byte    7,  -11, 	   3,   -9, 	   7,   -6, 	  -4,   -8
+.2byte    9,  -13, 	   1,   -7, 	   5,   -6, 	   0,   -9
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte    0,  -13, 	   2,  -10, 	  -2,   -7, 	   0,   -9
+.2byte    0,  -14, 	   2,   -6, 	  -1,   -9, 	   2,   -9
+.2byte    0,  -16, 	   2,  -10, 	  -2,  -10, 	   0,  -12
+.2byte   -8,  -12, 	   1,   -4, 	  -6,   -4, 	   1,  -10
+.2byte   -8,  -11, 	   2,   -3, 	  -2,   -3, 	   1,   -8
+.2byte   -8,  -11, 	  -4,   -9, 	  -8,   -6, 	   3,   -8
+.2byte  -10,  -13, 	  -2,   -7, 	  -6,   -6, 	  -1,   -9
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -9,   -7, 	 -10,   -3, 	  -2,    0, 	   4,   -8
+.2byte   -9,   -7, 	  -2,   -3, 	  -8,    0, 	   3,  -10
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   0,   -9
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte   -6,   -4, 	 -10,    1, 	   2,    1, 	   1,   -9
+.2byte   -7,   -4, 	  -5,   -3, 	  -3,    4, 	   0,  -10
+.2byte   -7,   -3, 	  -6,   -1, 	   0,    2, 	   0,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,  -16, 	  -4,  -16, 	   0,   -8, 	   0,  -14
+.2byte   -2,  -16, 	  -4,  -13, 	   0,  -12, 	  -1,  -14
+.2byte   -3,  -17, 	  -3,   -9, 	   0,  -18, 	  -2,  -13
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	   0,  -11
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -18, 	  -1,   -9, 	  -5,  -12
+.2byte   -1,  -15, 	   4,  -14, 	   0,  -12, 	  -3,  -12
+.2byte    2,  -18, 	   4,   -8, 	   1,  -17, 	  -2,  -12
+.2byte    6,   -3, 	   5,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    1,  -14, 	   4,  -17, 	   4,   -8, 	  -5,   -9
+.2byte    0,  -15, 	   5,  -14, 	  -2,  -10, 	  -6,   -9
+.2byte   -3,  -14, 	   3,   -7, 	   1,  -15, 	  -7,   -9
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -1,   -9
+.2byte    8,  -12, 	  -1,   -4, 	   6,   -4, 	  -1,  -10
+.2byte    3,  -15, 	   5,  -19, 	   5,   -9, 	  -3,   -9
+.2byte    2,  -16, 	  -2,  -13, 	   5,  -13, 	  -4,  -11
+.2byte    3,  -15, 	  -1,  -12, 	   4,  -17, 	  -5,  -11
+.2byte    9,  -13, 	   1,   -7, 	   5,   -6, 	   0,   -9
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte   -1,  -17, 	   0,  -14, 	  -3,  -14, 	  -2,  -10
+.2byte   -1,  -16, 	   4,  -15, 	  -6,  -15, 	  -1,  -11
+.2byte    0,  -15, 	   4,  -11, 	  -5,  -17, 	   0,  -10
+.2byte    0,  -16, 	   2,  -10, 	  -2,  -10, 	   0,  -12
+.2byte   -9,  -12, 	   0,   -4, 	  -7,   -4, 	   0,  -10
+.2byte   -4,  -15, 	  -6,  -19, 	  -6,   -9, 	   2,   -9
+.2byte   -3,  -16, 	   1,  -13, 	  -6,  -13, 	   3,  -11
+.2byte   -4,  -15, 	   0,  -12, 	  -5,  -17, 	   4,  -11
+.2byte  -10,  -13, 	  -2,   -7, 	  -6,   -6, 	  -1,   -9
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -2,  -14, 	  -5,  -17, 	  -5,   -8, 	   4,   -9
+.2byte   -1,  -15, 	  -6,  -14, 	   1,  -10, 	   5,   -9
+.2byte    2,  -14, 	  -4,   -7, 	  -2,  -15, 	   6,   -9
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   0,   -9
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte    1,  -15, 	  -3,  -18, 	   0,   -9, 	   4,  -12
+.2byte    0,  -15, 	  -5,  -14, 	  -1,  -12, 	   2,  -12
+.2byte   -3,  -18, 	  -5,   -8, 	  -2,  -17, 	   1,  -12
+.2byte   -7,   -3, 	  -6,   -1, 	   0,    2, 	   0,  -10
+.2byte   -7,   -3, 	  -4,    0, 	  -2,    0, 	   4,   -9
+.2byte   -6,   -1, 	  -3,    0, 	  -1,    0, 	   4,   -9
+.2byte    0,    0, 	  -5,    2, 	   5,    2, 	   0,   -7
+.2byte    7,   -1, 	   9,    0, 	   3,    4, 	  -1,  -10
+.2byte    8,   -4, 	  11,   -3, 	  10,    0, 	  -2,   -9
+.2byte    8,  -11, 	   4,   -7, 	   8,   -5, 	  -2,   -9
+.2byte    0,  -15, 	   4,  -11, 	  -6,  -11, 	  -1,   -8
+.2byte   -9,  -11, 	  -5,   -7, 	  -9,   -5, 	   1,   -9
+.2byte   -9,   -4, 	 -12,   -3, 	 -11,    0, 	   1,   -9
+.2byte   -8,   -1, 	 -10,    0, 	  -4,    4, 	   0,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -1,   -3, 	  -4,    4, 	   3,    0, 	   0,   -7
+.2byte   -1,   -3, 	  -5,    0, 	   2,    4, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	   0,  -11
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    5,   -4, 	   9,    1, 	  -3,    1, 	  -2,   -9
+.2byte    6,   -4, 	   4,   -3, 	   2,    4, 	  -1,  -10
+.2byte    6,   -3, 	   5,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    8,   -7, 	   9,   -3, 	   1,    0, 	  -5,   -8
+.2byte    8,   -7, 	   1,   -3, 	   7,    0, 	  -4,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -1,   -9
+.2byte    7,  -12, 	  -2,   -4, 	   5,   -4, 	  -2,  -10
+.2byte    7,  -11, 	  -3,   -3, 	   1,   -3, 	  -2,   -8
+.2byte    7,  -11, 	   3,   -9, 	   7,   -6, 	  -4,   -8
+.2byte    9,  -13, 	   1,   -7, 	   5,   -6, 	   0,   -9
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte    0,  -13, 	   2,  -10, 	  -2,   -7, 	   0,   -9
+.2byte    0,  -14, 	   2,   -6, 	  -1,   -9, 	   2,   -9
+.2byte    0,  -16, 	   2,  -10, 	  -2,  -10, 	   0,  -12
+.2byte   -8,  -12, 	   1,   -4, 	  -6,   -4, 	   1,  -10
+.2byte   -8,  -11, 	   2,   -3, 	  -2,   -3, 	   1,   -8
+.2byte   -8,  -11, 	  -4,   -9, 	  -8,   -6, 	   3,   -8
+.2byte  -10,  -13, 	  -2,   -7, 	  -6,   -6, 	  -1,   -9
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -9,   -7, 	 -10,   -3, 	  -2,    0, 	   4,   -8
+.2byte   -9,   -7, 	  -2,   -3, 	  -8,    0, 	   3,  -10
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   0,   -9
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte   -6,   -4, 	 -10,    1, 	   2,    1, 	   1,   -9
+.2byte   -7,   -4, 	  -5,   -3, 	  -3,    4, 	   0,  -10
+.2byte   -7,   -3, 	  -6,   -1, 	   0,    2, 	   0,  -10
+.2byte   -1,    1, 	  -5,    5, 	   3,    5, 	  -1,   -9
+.2byte   -6,    1, 	  -9,    2, 	  -3,    4, 	  -1,   -8
+.2byte   -9,   -5, 	  -6,   -3, 	  -9,    0, 	   0,   -7
+.2byte   -7,  -13, 	  -6,   -9, 	  -9,   -6, 	   0,   -6
+.2byte    0,  -17, 	   1,   -2, 	  -1,   -2, 	   0,   -8
+.2byte    6,  -13, 	   5,   -9, 	   8,   -6, 	  -1,   -6
+.2byte    8,   -5, 	   5,   -3, 	   8,    0, 	  -1,   -7
+.2byte    5,    1, 	   8,    2, 	   2,    4, 	   0,   -8
+.2byte   -1,  -12, 	  -4,  -12, 	   0,   -4, 	   0,  -10
+.2byte    0,  -12, 	   4,  -15, 	   1,   -6, 	  -3,   -9
+.2byte    3,  -14, 	   6,  -17, 	   6,   -8, 	  -3,   -9
+.2byte    4,  -15, 	   6,  -19, 	   6,   -9, 	  -2,   -9
+.2byte   -1,  -17, 	   0,  -14, 	  -3,  -14, 	  -2,  -10
+.2byte   -5,  -15, 	  -7,  -19, 	  -7,   -9, 	   1,   -9
+.2byte   -4,  -14, 	  -7,  -17, 	  -7,   -8, 	   2,   -9
+.2byte   -1,  -13, 	  -5,  -16, 	  -2,   -7, 	   2,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -2,  -16, 	  -4,  -13, 	   0,  -12, 	  -1,  -14
+.2byte   -1,    1, 	  -5,    5, 	   3,    5, 	  -1,   -9
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte    1,  -15, 	   6,  -14, 	   2,  -12, 	  -1,  -12
+.2byte    5,   -1, 	   8,    0, 	   2,    2, 	   0,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    2,  -15, 	   7,  -14, 	   0,  -10, 	  -4,   -9
+.2byte    7,   -6, 	   4,   -4, 	   7,   -1, 	  -2,   -8
+.2byte    7,  -12, 	  -2,   -4, 	   5,   -4, 	  -2,  -10
+.2byte    2,  -16, 	  -2,  -13, 	   5,  -13, 	  -4,  -11
+.2byte    5,  -14, 	   4,  -10, 	   7,   -7, 	  -2,   -7
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte   -1,  -16, 	   4,  -15, 	  -6,  -15, 	  -1,  -11
+.2byte    0,  -17, 	   1,   -2, 	  -1,   -2, 	   0,   -8
+.2byte    0,  -13, 	   2,   -7, 	  -2,   -7, 	   0,   -9
+.2byte   -8,  -12, 	   1,   -4, 	  -6,   -4, 	   1,  -10
+.2byte   -3,  -16, 	   1,  -13, 	  -6,  -13, 	   3,  -11
+.2byte   -6,  -14, 	  -5,  -10, 	  -8,   -7, 	   1,   -7
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -3,  -15, 	  -8,  -14, 	  -1,  -10, 	   3,   -9
+.2byte   -8,   -6, 	  -5,   -4, 	  -8,   -1, 	   1,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte   -2,  -15, 	  -7,  -14, 	  -3,  -12, 	   0,  -12
+.2byte   -6,   -1, 	  -9,    0, 	  -3,    2, 	  -1,  -10
+.2byte   -1,   -1, 	  -6,    1, 	   4,    1, 	   0,  -11
+.2byte   -7,   -3, 	  -6,   -1, 	   0,    2, 	   0,  -10
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   0,   -9
+.2byte   -8,  -13, 	   0,   -7, 	  -4,   -6, 	   1,   -9
+.2byte    0,  -16, 	   2,  -10, 	  -2,  -10, 	   0,  -12
+.2byte    7,  -13, 	  -1,   -7, 	   3,   -6, 	  -2,   -9
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -1,   -9
+.2byte    6,   -3, 	   5,   -1, 	  -1,    2, 	  -1,  -10
+.2byte   -1,   -4, 	  -6,    1, 	   4,    1, 	  -1,   -8
+.2byte   -7,   -5, 	  -7,   -1, 	   0,    2, 	   0,  -10
+.2byte   -9,   -8, 	  -6,   -3, 	  -5,    0, 	   2,  -10
+.2byte   -9,  -12, 	   0,   -4, 	  -7,   -4, 	   0,  -10
+.2byte   -1,  -15, 	   1,   -8, 	  -2,   -8, 	   0,  -10
+.2byte    8,  -12, 	  -1,   -4, 	   6,   -4, 	  -1,  -10
+.2byte    8,   -8, 	   5,   -3, 	   4,    0, 	  -3,  -10
+.2byte    6,   -5, 	   6,   -1, 	  -1,    2, 	  -1,  -10
+.2byte  -11,  -10, 	 -13,   -7, 	 -12,   -5, 	   1,  -10
+.2byte   10,  -10, 	  12,   -7, 	  11,   -5, 	  -2,  -10
+.2byte  -11,  -10, 	 -13,   -7, 	 -12,   -5, 	   1,  -10
+.2byte  -10,   -5, 	  -9,   -2, 	  -2,    1, 	   2,   -8
+.2byte   10,  -10, 	  12,   -7, 	  11,   -5, 	  -2,  -10
+.2byte    9,   -5, 	   8,   -2, 	   1,    1, 	  -3,   -8
+sNinetalesAnimTable1:
+.4byte sNinetalesAnims_1_1
+.4byte sNinetalesAnims_1_2
+.4byte sNinetalesAnims_1_3
+.4byte sNinetalesAnims_1_4
+.4byte sNinetalesAnims_1_5
+.4byte sNinetalesAnims_1_6
+.4byte sNinetalesAnims_1_7
+.4byte sNinetalesAnims_1_8
+sNinetalesAnimTable2:
+.4byte sNinetalesAnims_2_1
+.4byte sNinetalesAnims_2_2
+.4byte sNinetalesAnims_2_3
+.4byte sNinetalesAnims_2_4
+.4byte sNinetalesAnims_2_5
+.4byte sNinetalesAnims_2_6
+.4byte sNinetalesAnims_2_7
+.4byte sNinetalesAnims_2_8
+sNinetalesAnimTable3:
+.4byte sNinetalesAnims_3_1
+.4byte sNinetalesAnims_3_2
+.4byte sNinetalesAnims_3_3
+.4byte sNinetalesAnims_3_4
+.4byte sNinetalesAnims_3_5
+.4byte sNinetalesAnims_3_6
+.4byte sNinetalesAnims_3_7
+.4byte sNinetalesAnims_3_8
+sNinetalesAnimTable4:
+.4byte sNinetalesAnims_4_1
+.4byte sNinetalesAnims_4_2
+.4byte sNinetalesAnims_4_3
+.4byte sNinetalesAnims_4_4
+.4byte sNinetalesAnims_4_5
+.4byte sNinetalesAnims_4_6
+.4byte sNinetalesAnims_4_7
+.4byte sNinetalesAnims_4_8
+sNinetalesAnimTable5:
+.4byte sNinetalesAnims_5_1
+.4byte sNinetalesAnims_5_2
+.4byte sNinetalesAnims_5_3
+.4byte sNinetalesAnims_5_4
+.4byte sNinetalesAnims_5_5
+.4byte sNinetalesAnims_5_6
+.4byte sNinetalesAnims_5_7
+.4byte sNinetalesAnims_5_8
+sNinetalesAnimTable6:
+.4byte sNinetalesAnims_6_1
+.4byte sNinetalesAnims_6_1
+.4byte sNinetalesAnims_6_1
+.4byte sNinetalesAnims_6_1
+.4byte sNinetalesAnims_6_1
+.4byte sNinetalesAnims_6_1
+.4byte sNinetalesAnims_6_1
+.4byte sNinetalesAnims_6_1
+sNinetalesAnimTable7:
+.4byte sNinetalesAnims_7_1
+.4byte sNinetalesAnims_7_2
+.4byte sNinetalesAnims_7_3
+.4byte sNinetalesAnims_7_4
+.4byte sNinetalesAnims_7_5
+.4byte sNinetalesAnims_7_6
+.4byte sNinetalesAnims_7_7
+.4byte sNinetalesAnims_7_8
+sNinetalesAnimTable8:
+.4byte sNinetalesAnims_8_1
+.4byte sNinetalesAnims_8_2
+.4byte sNinetalesAnims_8_3
+.4byte sNinetalesAnims_8_4
+.4byte sNinetalesAnims_8_5
+.4byte sNinetalesAnims_8_6
+.4byte sNinetalesAnims_8_7
+.4byte sNinetalesAnims_8_8
+sNinetalesAnimTable9:
+.4byte sNinetalesAnims_9_1
+.4byte sNinetalesAnims_9_2
+.4byte sNinetalesAnims_9_3
+.4byte sNinetalesAnims_9_4
+.4byte sNinetalesAnims_9_5
+.4byte sNinetalesAnims_9_6
+.4byte sNinetalesAnims_9_7
+.4byte sNinetalesAnims_9_8
+sNinetalesAnimTable10:
+.4byte sNinetalesAnims_10_1
+.4byte sNinetalesAnims_10_2
+.4byte sNinetalesAnims_10_3
+.4byte sNinetalesAnims_10_4
+.4byte sNinetalesAnims_10_5
+.4byte sNinetalesAnims_10_6
+.4byte sNinetalesAnims_10_7
+.4byte sNinetalesAnims_10_8
+sNinetalesAnimTable11:
+.4byte sNinetalesAnims_11_1
+.4byte sNinetalesAnims_11_2
+.4byte sNinetalesAnims_11_3
+.4byte sNinetalesAnims_11_4
+.4byte sNinetalesAnims_11_5
+.4byte sNinetalesAnims_11_6
+.4byte sNinetalesAnims_11_7
+.4byte sNinetalesAnims_11_8
+sNinetalesAnimTable12:
+.4byte sNinetalesAnims_12_1
+.4byte sNinetalesAnims_12_2
+.4byte sNinetalesAnims_12_3
+.4byte sNinetalesAnims_12_4
+.4byte sNinetalesAnims_12_5
+.4byte sNinetalesAnims_12_6
+.4byte sNinetalesAnims_12_7
+.4byte sNinetalesAnims_12_8
+sNinetalesAnimTable13:
+.4byte sNinetalesAnims_13_1
+.4byte sNinetalesAnims_13_2
+.4byte sNinetalesAnims_13_3
+.4byte sNinetalesAnims_13_4
+.4byte sNinetalesAnims_13_5
+.4byte sNinetalesAnims_13_6
+.4byte sNinetalesAnims_13_7
+.4byte sNinetalesAnims_13_8
+sNinetalesAnimTable14:
+.4byte sNinetalesAnims_14_1
+.4byte sNinetalesAnims_14_2
+.4byte sNinetalesAnims_14_3
+.4byte sNinetalesAnims_14_4
+.4byte sNinetalesAnims_14_5
+.4byte sNinetalesAnims_14_6
+.4byte sNinetalesAnims_14_7
+.4byte sNinetalesAnims_14_8
+sNinetalesAnimTable15:
+.4byte sNinetalesAnims_15_1
+.4byte sNinetalesAnims_15_2
+.4byte sNinetalesAnims_15_3
+.4byte sNinetalesAnims_15_4
+.4byte sNinetalesAnims_15_5
+.4byte sNinetalesAnims_15_6
+.4byte sNinetalesAnims_15_7
+.4byte sNinetalesAnims_15_8
+sAxAnimationsNinetales:
+.4byte sNinetalesAnimTable1
+.4byte sNinetalesAnimTable2
+.4byte sNinetalesAnimTable3
+.4byte sNinetalesAnimTable4
+.4byte sNinetalesAnimTable5
+.4byte sNinetalesAnimTable6
+.4byte sNinetalesAnimTable7
+.4byte sNinetalesAnimTable8
+.4byte sNinetalesAnimTable9
+.4byte sNinetalesAnimTable10
+.4byte sNinetalesAnimTable11
+.4byte sNinetalesAnimTable12
+.4byte sNinetalesAnimTable13
+.4byte sNinetalesAnimTable14
+.4byte sNinetalesAnimTable15
+sAxSpritesNinetales:
+.4byte sNinetalesSprites1
+.4byte sNinetalesSprites2
+.4byte sNinetalesSprites3
+.4byte sNinetalesSprites4
+.4byte sNinetalesSprites5
+.4byte sNinetalesSprites6
+.4byte sNinetalesSprites7
+.4byte sNinetalesSprites8
+.4byte sNinetalesSprites9
+.4byte sNinetalesSprites10
+.4byte sNinetalesSprites11
+.4byte sNinetalesSprites12
+.4byte sNinetalesSprites13
+.4byte sNinetalesSprites14
+.4byte sNinetalesSprites15
+.4byte sNinetalesSprites16
+.4byte sNinetalesSprites17
+.4byte sNinetalesSprites18
+.4byte sNinetalesSprites19
+.4byte sNinetalesSprites20
+.4byte sNinetalesSprites21
+.4byte sNinetalesSprites22
+.4byte sNinetalesSprites23
+.4byte sNinetalesSprites24
+.4byte sNinetalesSprites25
+.4byte sNinetalesSprites26
+.4byte sNinetalesSprites27
+.4byte sNinetalesSprites28
+.4byte sNinetalesSprites29
+.4byte sNinetalesSprites30
+.4byte sNinetalesSprites31
+.4byte sNinetalesSprites32
+.4byte sNinetalesSprites33
+.4byte sNinetalesSprites34
+.4byte sNinetalesSprites35
+.4byte sNinetalesSprites36
+.4byte sNinetalesSprites37
+.4byte sNinetalesSprites38
+.4byte sNinetalesSprites39
+.4byte sNinetalesSprites40
+.4byte sNinetalesSprites41
+.4byte sNinetalesSprites42
+.4byte sNinetalesSprites43
+.4byte sNinetalesSprites44
+.4byte sNinetalesSprites45
+.4byte sNinetalesSprites46
+.4byte sNinetalesSprites47
+.4byte sNinetalesSprites48
+.4byte sNinetalesSprites49
+.4byte sNinetalesSprites50
+.4byte sNinetalesSprites51
+sAxMainNinetales:
+ax_main sAxPosesNinetales, sAxAnimationsNinetales, 15, sAxSpritesNinetales, sAxPositionsNinetales

--- a/data/ax/ninjask.inc
+++ b/data/ax/ninjask.inc
@@ -1,0 +1,3177 @@
+.global gAxNinjask
+gAxNinjask:
+ax_siro sAxMainNinjask
+sNinjaskPose1:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose2:
+ax_pose 1, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose3:
+ax_pose 2, 0x41ed, 0x80f0, 0x5c00
+ax_pose 3, 0x01e5, 0x0100, 0x5c08
+ax_pose -1, 0x01e5, 0x10f7, 0x5c08
+ax_pose 4, 0x01eb, 0x00e8, 0x5c09
+ax_pose -1, 0x01eb, 0x110f, 0x5c09
+ax_pose_terminator
+sNinjaskPose4:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose5:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose6:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose7:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose8:
+ax_pose 9, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose9:
+ax_pose 10, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose10:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose11:
+ax_pose 12, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose12:
+ax_pose 13, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose13:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose14:
+ax_pose 15, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose15:
+ax_pose 16, 0x41eb, 0x80f0, 0x5c00
+ax_pose 17, 0x01fb, 0x00fc, 0x5c08
+ax_pose 18, 0x01eb, 0x0110, 0x5c09
+ax_pose -1, 0x01eb, 0x10e9, 0x5c09
+ax_pose_terminator
+sNinjaskPose16:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose17:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose18:
+ax_pose 13, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose19:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose20:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose21:
+ax_pose 10, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose22:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose23:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose24:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose25:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose26:
+ax_pose 1, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose27:
+ax_pose 2, 0x41ed, 0x80f0, 0x5c00
+ax_pose 3, 0x01e5, 0x0100, 0x5c08
+ax_pose -1, 0x01e5, 0x10f7, 0x5c08
+ax_pose 4, 0x01eb, 0x00e8, 0x5c09
+ax_pose -1, 0x01eb, 0x110f, 0x5c09
+ax_pose_terminator
+sNinjaskPose28:
+ax_pose 19, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sNinjaskPose29:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose30:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose31:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose32:
+ax_pose 20, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose33:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose34:
+ax_pose 9, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose35:
+ax_pose 10, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose36:
+ax_pose 21, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose37:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose38:
+ax_pose 12, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose39:
+ax_pose 13, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose40:
+ax_pose 22, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sNinjaskPose41:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose42:
+ax_pose 15, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose43:
+ax_pose 16, 0x41eb, 0x80f0, 0x5c00
+ax_pose 17, 0x01fb, 0x00fc, 0x5c08
+ax_pose 18, 0x01eb, 0x0110, 0x5c09
+ax_pose -1, 0x01eb, 0x10e9, 0x5c09
+ax_pose_terminator
+sNinjaskPose44:
+ax_pose 23, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sNinjaskPose45:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose46:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose47:
+ax_pose 13, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose48:
+ax_pose 24, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose49:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose50:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose51:
+ax_pose 10, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose52:
+ax_pose 25, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose53:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose54:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose55:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose56:
+ax_pose 20, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose57:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose58:
+ax_pose 1, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose59:
+ax_pose 2, 0x41ed, 0x80f0, 0x5c00
+ax_pose 3, 0x01e5, 0x0100, 0x5c08
+ax_pose -1, 0x01e5, 0x10f7, 0x5c08
+ax_pose 4, 0x01eb, 0x00e8, 0x5c09
+ax_pose -1, 0x01eb, 0x110f, 0x5c09
+ax_pose_terminator
+sNinjaskPose60:
+ax_pose 26, 0x01e6, 0x80ef, 0x5c00
+ax_pose 19, 0x01e2, 0x80ef, 0x5c10
+ax_pose_terminator
+sNinjaskPose61:
+ax_pose 19, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sNinjaskPose62:
+ax_pose 26, 0x01e6, 0x90f1, 0x5c00
+ax_pose 19, 0x01e2, 0x90f1, 0x5c10
+ax_pose_terminator
+sNinjaskPose63:
+ax_pose 19, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose64:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose65:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose66:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose67:
+ax_pose 27, 0x01e3, 0x90f2, 0x5c00
+ax_pose 20, 0x01e2, 0x90f1, 0x5c10
+ax_pose_terminator
+sNinjaskPose68:
+ax_pose 20, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose69:
+ax_pose 28, 0x41f5, 0x90ef, 0x5c00
+ax_pose 29, 0x01e2, 0x90ef, 0x5c08
+ax_pose_terminator
+sNinjaskPose70:
+ax_pose 29, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sNinjaskPose71:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose72:
+ax_pose 9, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose73:
+ax_pose 10, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose74:
+ax_pose 30, 0x01e2, 0x90f3, 0x5c00
+ax_pose 25, 0x01e2, 0x90f1, 0x5c10
+ax_pose_terminator
+sNinjaskPose75:
+ax_pose 25, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose76:
+ax_pose 31, 0x41f2, 0x90f1, 0x5c00
+ax_pose 21, 0x01e2, 0x90f1, 0x5c08
+ax_pose_terminator
+sNinjaskPose77:
+ax_pose 21, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose78:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose79:
+ax_pose 12, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose80:
+ax_pose 13, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose81:
+ax_pose 32, 0x01e2, 0x90f1, 0x5c00
+ax_pose 24, 0x01e2, 0x90f1, 0x5c10
+ax_pose_terminator
+sNinjaskPose82:
+ax_pose 24, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose83:
+ax_pose 33, 0x41ed, 0x1103, 0x5c00
+ax_pose 22, 0x01e2, 0x90ef, 0x5c02
+ax_pose_terminator
+sNinjaskPose84:
+ax_pose 22, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose85:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose86:
+ax_pose 15, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose87:
+ax_pose 16, 0x41eb, 0x80f0, 0x5c00
+ax_pose 17, 0x01fb, 0x00fc, 0x5c08
+ax_pose 18, 0x01eb, 0x0110, 0x5c09
+ax_pose -1, 0x01eb, 0x10e9, 0x5c09
+ax_pose_terminator
+sNinjaskPose88:
+ax_pose 23, 0x01e2, 0x80f1, 0x5c00
+ax_pose 34, 0x01e2, 0x80f1, 0x5c10
+ax_pose_terminator
+sNinjaskPose89:
+ax_pose 23, 0x01e2, 0x80ee, 0x5c00
+ax_pose_terminator
+sNinjaskPose90:
+ax_pose 23, 0x01e2, 0x90ef, 0x5c00
+ax_pose 34, 0x01e2, 0x90ef, 0x5c10
+ax_pose_terminator
+sNinjaskPose91:
+ax_pose 23, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose92:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose93:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose94:
+ax_pose 13, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose95:
+ax_pose 32, 0x01e2, 0x80f0, 0x5c00
+ax_pose 24, 0x01e2, 0x80f0, 0x5c10
+ax_pose_terminator
+sNinjaskPose96:
+ax_pose 24, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose97:
+ax_pose 33, 0x41ed, 0x00ee, 0x5c00
+ax_pose 22, 0x01e2, 0x80f2, 0x5c02
+ax_pose_terminator
+sNinjaskPose98:
+ax_pose 22, 0x01e2, 0x80f2, 0x5c00
+ax_pose_terminator
+sNinjaskPose99:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose100:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose101:
+ax_pose 10, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose102:
+ax_pose 30, 0x01e2, 0x80ee, 0x5c00
+ax_pose 25, 0x01e2, 0x80f0, 0x5c10
+ax_pose_terminator
+sNinjaskPose103:
+ax_pose 25, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose104:
+ax_pose 31, 0x41f2, 0x80f0, 0x5c00
+ax_pose 21, 0x01e2, 0x80f0, 0x5c08
+ax_pose_terminator
+sNinjaskPose105:
+ax_pose 21, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose106:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose107:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose108:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose109:
+ax_pose 27, 0x01e3, 0x80ef, 0x5c00
+ax_pose 20, 0x01e2, 0x80f0, 0x5c10
+ax_pose_terminator
+sNinjaskPose110:
+ax_pose 20, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose111:
+ax_pose 28, 0x41f5, 0x80f2, 0x5c00
+ax_pose 29, 0x01e2, 0x80f2, 0x5c08
+ax_pose_terminator
+sNinjaskPose112:
+ax_pose 29, 0x01e2, 0x80f2, 0x5c00
+ax_pose_terminator
+sNinjaskPose113:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose114:
+ax_pose 1, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose115:
+ax_pose 2, 0x41ed, 0x80f0, 0x5c00
+ax_pose 3, 0x01e5, 0x0100, 0x5c08
+ax_pose -1, 0x01e5, 0x10f7, 0x5c08
+ax_pose 4, 0x01eb, 0x00e8, 0x5c09
+ax_pose -1, 0x01eb, 0x110f, 0x5c09
+ax_pose_terminator
+sNinjaskPose116:
+ax_pose 35, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose117:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose118:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose119:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose120:
+ax_pose 36, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose121:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose122:
+ax_pose 9, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose123:
+ax_pose 10, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose124:
+ax_pose 37, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose125:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose126:
+ax_pose 12, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose127:
+ax_pose 13, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose128:
+ax_pose 38, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose129:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose130:
+ax_pose 15, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose131:
+ax_pose 16, 0x41eb, 0x80f0, 0x5c00
+ax_pose 17, 0x01fb, 0x00fc, 0x5c08
+ax_pose 18, 0x01eb, 0x0110, 0x5c09
+ax_pose -1, 0x01eb, 0x10e9, 0x5c09
+ax_pose_terminator
+sNinjaskPose132:
+ax_pose 39, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose133:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose134:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose135:
+ax_pose 13, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose136:
+ax_pose 38, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose137:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose138:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose139:
+ax_pose 10, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose140:
+ax_pose 37, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose141:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose142:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose143:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose144:
+ax_pose 36, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose145:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose146:
+ax_pose 1, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose147:
+ax_pose 2, 0x41ef, 0x80f0, 0x5c00
+ax_pose 3, 0x01e7, 0x0100, 0x5c08
+ax_pose -1, 0x01e7, 0x10f7, 0x5c08
+ax_pose 4, 0x01ed, 0x00e8, 0x5c09
+ax_pose -1, 0x01ed, 0x110f, 0x5c09
+ax_pose_terminator
+sNinjaskPose148:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose149:
+ax_pose 6, 0x01e1, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose150:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose151:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose152:
+ax_pose 9, 0x01e1, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose153:
+ax_pose 10, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose154:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose155:
+ax_pose 12, 0x01e1, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose156:
+ax_pose 13, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose157:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose158:
+ax_pose 15, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose159:
+ax_pose 16, 0x41ec, 0x80f0, 0x5c00
+ax_pose 17, 0x01fc, 0x00fc, 0x5c08
+ax_pose 18, 0x01ec, 0x0110, 0x5c09
+ax_pose -1, 0x01ec, 0x10e9, 0x5c09
+ax_pose_terminator
+sNinjaskPose160:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose161:
+ax_pose 12, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose162:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose163:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose164:
+ax_pose 9, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose165:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose166:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose167:
+ax_pose 6, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose168:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose169:
+ax_pose 40, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose170:
+ax_pose 41, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose171:
+ax_pose 42, 0x01dd, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose172:
+ax_pose 43, 0x01df, 0x90eb, 0x5c00
+ax_pose_terminator
+sNinjaskPose173:
+ax_pose 44, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sNinjaskPose174:
+ax_pose 45, 0x01e9, 0x90ea, 0x5c00
+ax_pose_terminator
+sNinjaskPose175:
+ax_pose 46, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose176:
+ax_pose 45, 0x01e9, 0x80f6, 0x5c00
+ax_pose_terminator
+sNinjaskPose177:
+ax_pose 44, 0x01ea, 0x80f6, 0x5c00
+ax_pose_terminator
+sNinjaskPose178:
+ax_pose 43, 0x01df, 0x80f5, 0x5c00
+ax_pose_terminator
+sNinjaskPose179:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose180:
+ax_pose 1, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose181:
+ax_pose 2, 0x41ed, 0x80f0, 0x5c00
+ax_pose 3, 0x01e5, 0x0100, 0x5c08
+ax_pose -1, 0x01e5, 0x10f7, 0x5c08
+ax_pose 4, 0x01eb, 0x00e8, 0x5c09
+ax_pose -1, 0x01eb, 0x110f, 0x5c09
+ax_pose_terminator
+sNinjaskPose182:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose183:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose184:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose185:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose186:
+ax_pose 9, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose187:
+ax_pose 10, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose188:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose189:
+ax_pose 12, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose190:
+ax_pose 13, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose191:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose192:
+ax_pose 15, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose193:
+ax_pose 16, 0x41eb, 0x80f0, 0x5c00
+ax_pose 17, 0x01fb, 0x00fc, 0x5c08
+ax_pose 18, 0x01eb, 0x0110, 0x5c09
+ax_pose -1, 0x01eb, 0x10e9, 0x5c09
+ax_pose_terminator
+sNinjaskPose194:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose195:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose196:
+ax_pose 13, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose197:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose198:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose199:
+ax_pose 10, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose200:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose201:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose202:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose203:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose204:
+ax_pose 5, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose205:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose206:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose207:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose208:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose209:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose210:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose211:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose212:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose213:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose214:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose215:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose216:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose217:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose218:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose219:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose220:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose221:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose222:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose223:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose224:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose225:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose226:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose227:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose228:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose229:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose230:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose231:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose232:
+ax_pose 5, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose233:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose234:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose235:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose236:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose237:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose238:
+ax_pose 5, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose239:
+ax_pose 35, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose240:
+ax_pose 36, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sNinjaskPose241:
+ax_pose 37, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose242:
+ax_pose 38, 0x01e3, 0x90f2, 0x5c00
+ax_pose_terminator
+sNinjaskPose243:
+ax_pose 39, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose244:
+ax_pose 38, 0x01e3, 0x80ef, 0x5c00
+ax_pose_terminator
+sNinjaskPose245:
+ax_pose 37, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose246:
+ax_pose 36, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sNinjaskPose247:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose248:
+ax_pose 1, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose249:
+ax_pose 2, 0x41ef, 0x80f0, 0x5c00
+ax_pose 3, 0x01e7, 0x0100, 0x5c08
+ax_pose -1, 0x01e7, 0x10f7, 0x5c08
+ax_pose 4, 0x01ed, 0x00e8, 0x5c09
+ax_pose -1, 0x01ed, 0x110f, 0x5c09
+ax_pose_terminator
+sNinjaskPose250:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose251:
+ax_pose 6, 0x01e1, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose252:
+ax_pose 7, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose253:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose254:
+ax_pose 9, 0x01e1, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose255:
+ax_pose 10, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose256:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose257:
+ax_pose 12, 0x01e1, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose258:
+ax_pose 13, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose259:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose260:
+ax_pose 15, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose261:
+ax_pose 16, 0x41ec, 0x80f0, 0x5c00
+ax_pose 17, 0x01fc, 0x00fc, 0x5c08
+ax_pose 18, 0x01ec, 0x0110, 0x5c09
+ax_pose -1, 0x01ec, 0x10e9, 0x5c09
+ax_pose_terminator
+sNinjaskPose262:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose263:
+ax_pose 12, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose264:
+ax_pose 13, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose265:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose266:
+ax_pose 9, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose267:
+ax_pose 10, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose268:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose269:
+ax_pose 6, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose270:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose271:
+ax_pose 1, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose272:
+ax_pose 6, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose273:
+ax_pose 9, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose274:
+ax_pose 12, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose275:
+ax_pose 15, 0x01e1, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose276:
+ax_pose 12, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose277:
+ax_pose 9, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose278:
+ax_pose 6, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose279:
+ax_pose 0, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose280:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose281:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose282:
+ax_pose 11, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose283:
+ax_pose 14, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sNinjaskPose284:
+ax_pose 11, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose285:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sNinjaskPose286:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+.align 2
+sNinjaskAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 1,
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 1,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 1,
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 1,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 1,
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 1,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 1,
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 1,
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 0, 0, -1,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 8,
+ax_anim 2, 0, 27, 0, 24, 0, 22,
+ax_anim 2, 1, 27, 1, 24, 1, 22,
+ax_anim 2, 0, 27, 0, 24, 0, 22,
+ax_anim 2, 0, 27, 1, 24, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNinjaskAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 3, 5, 5, 5,
+ax_anim 1, 0, 31, 8, 12, 10, 11,
+ax_anim 2, 0, 31, 16, 24, 20, 21,
+ax_anim 2, 1, 31, 17, 23, 21, 20,
+ax_anim 2, 0, 31, 16, 24, 20, 21,
+ax_anim 2, 0, 31, 17, 23, 21, 20,
+ax_anim 2, 0, 28, 5, 8, 7, 8,
+ax_anim_terminator
+sNinjaskAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 4, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 1, 10, 0,
+ax_anim 2, 0, 35, 18, 2, 18, 0,
+ax_anim 2, 1, 35, 18, 3, 18, 1,
+ax_anim 2, 0, 35, 18, 2, 18, 0,
+ax_anim 2, 0, 35, 18, 3, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sNinjaskAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 5, -6, 5, -7,
+ax_anim 1, 0, 39, 12, -12, 12, -15,
+ax_anim 2, 0, 39, 18, -16, 18, -21,
+ax_anim 2, 1, 39, 19, -15, 19, -20,
+ax_anim 2, 0, 39, 18, -16, 18, -21,
+ax_anim 2, 0, 39, 19, -15, 19, -20,
+ax_anim 2, 0, 36, 6, -6, 6, -8,
+ax_anim_terminator
+sNinjaskAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 4, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -12,
+ax_anim 2, 0, 43, 0, -18, 0, -22,
+ax_anim 2, 1, 43, 1, -18, 1, -22,
+ax_anim 2, 0, 43, 0, -18, 0, -22,
+ax_anim 2, 0, 43, 1, -18, 1, -22,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sNinjaskAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 4, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -5, -6, -5, -7,
+ax_anim 1, 0, 47, -12, -12, -12, -15,
+ax_anim 2, 0, 47, -18, -16, -18, -21,
+ax_anim 2, 1, 47, -19, -15, -19, -20,
+ax_anim 2, 0, 47, -18, -16, -18, -21,
+ax_anim 2, 0, 47, -19, -15, -19, -20,
+ax_anim 2, 0, 44, -6, -6, -6, -8,
+ax_anim_terminator
+sNinjaskAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 4, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 1, -10, 0,
+ax_anim 2, 0, 51, -18, 2, -18, 0,
+ax_anim 2, 1, 51, -18, 3, -18, 1,
+ax_anim 2, 0, 51, -18, 2, -18, 0,
+ax_anim 2, 0, 51, -18, 3, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sNinjaskAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -3, 5, -5, 5,
+ax_anim 1, 0, 55, -8, 12, -10, 11,
+ax_anim 2, 0, 55, -16, 24, -20, 21,
+ax_anim 2, 1, 55, -17, 23, -21, 20,
+ax_anim 2, 0, 55, -16, 24, -20, 21,
+ax_anim 2, 0, 55, -17, 23, -21, 20,
+ax_anim 2, 0, 52, -5, 8, -7, 8,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_3_1:
+ax_anim 2, 0, 62, 0, -4, 0, -4,
+ax_anim 6, 0, 111, 0, -6, 0, -6,
+ax_anim 1, 2, 111, 0, -3, 0, -3,
+ax_anim 1, 0, 62, 0, 3, 0, 3,
+ax_anim 2, 0, 59, 2, 16, 0, 12,
+ax_anim 2, 1, 60, 3, 17, 1, 13,
+ax_anim 2, 0, 69, 1, 13, 1, 9,
+ax_anim 4, 0, 60, 1, 12, 1, 8,
+ax_anim 2, 0, 61, -2, 16, 0, 12,
+ax_anim 2, 0, 111, -2, 17, -1, 13,
+ax_anim 2, 0, 62, -1, 9, -1, 9,
+ax_anim 2, 0, 57, 0, 5, 0, 5,
+ax_anim_terminator
+sNinjaskAnims_3_2:
+ax_anim 2, 0, 69, -4, -4, -4, -4,
+ax_anim 6, 0, 76, -6, -6, -6, -6,
+ax_anim 1, 2, 76, -3, -3, -3, -3,
+ax_anim 1, 0, 69, 6, 6, 6, 6,
+ax_anim 2, 0, 66, 19, 18, 19, 18,
+ax_anim 2, 1, 67, 18, 19, 18, 19,
+ax_anim 2, 0, 62, 17, 16, 17, 16,
+ax_anim 4, 0, 67, 17, 19, 17, 19,
+ax_anim 2, 0, 68, 21, 21, 21, 21,
+ax_anim 2, 0, 76, 22, 21, 22, 21,
+ax_anim 2, 0, 69, 16, 16, 16, 16,
+ax_anim 2, 0, 64, 11, 11, 11, 11,
+ax_anim_terminator
+sNinjaskAnims_3_3:
+ax_anim 2, 0, 76, -4, 0, -4, 0,
+ax_anim 6, 0, 83, -6, 2, -6, 0,
+ax_anim 1, 2, 83, -3, 2, -3, 0,
+ax_anim 1, 0, 76, 6, 0, 6, 0,
+ax_anim 2, 0, 73, 16, 0, 16, 0,
+ax_anim 2, 1, 67, 17, 1, 17, 1,
+ax_anim 2, 0, 67, 14, 2, 14, 2,
+ax_anim 4, 0, 74, 14, 1, 14, 1,
+ax_anim 2, 0, 75, 16, 0, 16, 0,
+ax_anim 2, 0, 83, 17, 1, 15, -1,
+ax_anim 2, 0, 76, 10, 0, 10, 0,
+ax_anim 2, 0, 71, 6, 0, 6, 0,
+ax_anim_terminator
+sNinjaskAnims_3_4:
+ax_anim 2, 0, 83, -4, 4, -4, 4,
+ax_anim 6, 0, 88, -3, 7, -3, 7,
+ax_anim 1, 2, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 80, 17, -15, 17, -15,
+ax_anim 2, 1, 74, 19, -16, 19, -16,
+ax_anim 2, 0, 74, 18, -15, 18, -15,
+ax_anim 4, 0, 81, 18, -14, 18, -14,
+ax_anim 2, 0, 82, 16, -16, 16, -16,
+ax_anim 2, 0, 88, 17, -19, 17, -19,
+ax_anim 2, 0, 83, 10, -10, 10, -10,
+ax_anim 2, 0, 78, 5, -5, 5, -5,
+ax_anim_terminator
+sNinjaskAnims_3_5:
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 6, 0, 81, 0, 6, 0, 6,
+ax_anim 1, 2, 81, 0, 3, 0, 3,
+ax_anim 1, 0, 90, 0, -7, 0, -7,
+ax_anim 2, 0, 87, -4, -10, -4, -10,
+ax_anim 2, 1, 95, -5, -10, -5, -10,
+ax_anim 2, 0, 95, -5, -9, -5, -9,
+ax_anim 4, 0, 88, -3, -9, -3, -9,
+ax_anim 2, 0, 89, 0, -12, 0, -12,
+ax_anim 2, 0, 81, 0, -15, 0, -15,
+ax_anim 2, 0, 90, 1, -12, 1, -12,
+ax_anim 2, 0, 85, 0, -9, 0, -9,
+ax_anim_terminator
+sNinjaskAnims_3_6:
+ax_anim 2, 0, 97, 4, 4, 4, 4,
+ax_anim 6, 0, 90, 6, 6, 6, 6,
+ax_anim 1, 2, 90, 3, 3, 3, 3,
+ax_anim 1, 0, 97, -9, -9, -9, -9,
+ax_anim 2, 0, 94, -17, -16, -17, -16,
+ax_anim 2, 1, 102, -19, -18, -19, -18,
+ax_anim 2, 0, 102, -17, -16, -17, -16,
+ax_anim 4, 0, 95, -18, -15, -18, -15,
+ax_anim 2, 0, 96, -18, -18, -18, -18,
+ax_anim 2, 0, 90, -16, -19, -16, -19,
+ax_anim 2, 0, 97, -12, -12, -12, -12,
+ax_anim 2, 0, 92, -8, -8, -8, -8,
+ax_anim_terminator
+sNinjaskAnims_3_7:
+ax_anim 2, 0, 104, 4, 0, 4, 0,
+ax_anim 6, 0, 97, 6, 1, 6, 0,
+ax_anim 1, 2, 97, 3, 1, 3, 0,
+ax_anim 1, 0, 104, -6, 0, -6, 0,
+ax_anim 2, 0, 101, -14, 0, -16, 0,
+ax_anim 2, 1, 109, -16, 1, -18, 1,
+ax_anim 2, 0, 109, -13, 1, -15, 1,
+ax_anim 4, 0, 102, -9, 0, -11, 0,
+ax_anim 2, 0, 103, -14, -1, -16, 0,
+ax_anim 2, 0, 97, -17, 1, -19, -1,
+ax_anim 2, 0, 104, -8, 0, -10, 0,
+ax_anim 2, 0, 99, -6, 0, -6, 0,
+ax_anim_terminator
+sNinjaskAnims_3_8:
+ax_anim 2, 0, 111, 4, -4, 4, -4,
+ax_anim 6, 0, 104, 7, -6, 7, -6,
+ax_anim 1, 2, 104, 4, -3, 4, -3,
+ax_anim 1, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 108, -14, 18, -14, 18,
+ax_anim 2, 1, 60, -14, 19, -14, 19,
+ax_anim 2, 0, 60, -13, 17, -13, 17,
+ax_anim 4, 0, 109, -13, 16, -13, 16,
+ax_anim 2, 0, 110, -19, 17, -19, 17,
+ax_anim 2, 0, 104, -17, 15, -17, 15,
+ax_anim 2, 0, 111, -11, 11, -11, 11,
+ax_anim 2, 0, 106, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_4_1:
+ax_anim 2, 0, 113, 0, -2, 0, -2,
+ax_anim 6, 2, 113, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 1, 115, 0, 3, 0, 2,
+ax_anim 2, 0, 115, 1, 3, 1, 2,
+ax_anim 2, 0, 115, 0, 3, 0, 2,
+ax_anim 2, 0, 115, 1, 3, 1, 2,
+ax_anim 2, 0, 115, 0, 3, 0, 2,
+ax_anim 2, 0, 115, 1, 3, 1, 2,
+ax_anim 2, 0, 115, 0, 3, 0, 2,
+ax_anim 2, 0, 113, 0, 1, 0, 1,
+ax_anim_terminator
+sNinjaskAnims_4_2:
+ax_anim 2, 0, 117, -2, -2, -2, -2,
+ax_anim 6, 2, 117, -3, -3, -3, -3,
+ax_anim 2, 0, 116, -1, -1, -1, -1,
+ax_anim 2, 1, 119, 2, 2, 1, 1,
+ax_anim 2, 0, 119, 3, 1, 2, 0,
+ax_anim 2, 0, 119, 2, 2, 1, 1,
+ax_anim 2, 0, 119, 3, 1, 2, 0,
+ax_anim 2, 0, 119, 2, 2, 1, 1,
+ax_anim 2, 0, 119, 3, 1, 2, 0,
+ax_anim 2, 0, 119, 2, 2, 1, 1,
+ax_anim 2, 0, 117, 1, 1, 1, 1,
+ax_anim_terminator
+sNinjaskAnims_4_3:
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 6, 2, 121, -3, 0, -3, 0,
+ax_anim 2, 0, 120, -1, 0, -1, 0,
+ax_anim 2, 1, 123, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 2, 1, 2, 1,
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 2, 1, 2, 1,
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 2, 1, 2, 1,
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim_terminator
+sNinjaskAnims_4_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 6, 2, 125, -3, 3, -3, 3,
+ax_anim 2, 0, 124, -1, 1, -1, 1,
+ax_anim 2, 1, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 127, 3, -1, 2, 0,
+ax_anim 2, 0, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 127, 3, -1, 2, 0,
+ax_anim 2, 0, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 127, 3, -1, 2, 0,
+ax_anim 2, 0, 127, 2, -2, 1, -1,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim_terminator
+sNinjaskAnims_4_5:
+ax_anim 2, 0, 129, 0, 2, 0, 2,
+ax_anim 6, 2, 129, 0, 3, 0, 3,
+ax_anim 2, 0, 128, 0, 1, 0, 1,
+ax_anim 2, 1, 131, 0, -3, 0, -2,
+ax_anim 2, 0, 131, 1, -3, 1, -2,
+ax_anim 2, 0, 131, 0, -3, 0, -2,
+ax_anim 2, 0, 131, 1, -3, 1, -2,
+ax_anim 2, 0, 131, 0, -3, 0, -2,
+ax_anim 2, 0, 131, 1, -3, 1, -2,
+ax_anim 2, 0, 131, 0, -3, 0, -2,
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_4_6:
+ax_anim 2, 0, 133, 2, 2, 2, 2,
+ax_anim 6, 2, 133, 3, 3, 3, 3,
+ax_anim 2, 0, 132, 1, 1, 1, 1,
+ax_anim 2, 1, 135, -2, -2, -1, -1,
+ax_anim 2, 0, 135, -3, -1, -2, 0,
+ax_anim 2, 0, 135, -2, -2, -1, -1,
+ax_anim 2, 0, 135, -3, -1, -2, 0,
+ax_anim 2, 0, 135, -2, -2, -1, -1,
+ax_anim 2, 0, 135, -3, -1, -2, 0,
+ax_anim 2, 0, 135, -2, -2, -1, -1,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim_terminator
+sNinjaskAnims_4_7:
+ax_anim 2, 0, 137, 2, 0, 2, 0,
+ax_anim 6, 2, 137, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 1, 139, -2, 0, -2, 0,
+ax_anim 2, 0, 139, -2, 1, -2, 1,
+ax_anim 2, 0, 139, -2, 0, -2, 0,
+ax_anim 2, 0, 139, -2, 1, -2, 1,
+ax_anim 2, 0, 139, -2, 0, -2, 0,
+ax_anim 2, 0, 139, -2, 1, -2, 1,
+ax_anim 2, 0, 139, -2, 0, -2, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim_terminator
+sNinjaskAnims_4_8:
+ax_anim 2, 0, 141, 2, -2, 2, -2,
+ax_anim 6, 2, 141, 3, -3, 3, -3,
+ax_anim 2, 0, 140, 1, -1, 1, -1,
+ax_anim 2, 1, 143, -2, 2, -1, 1,
+ax_anim 2, 0, 143, -3, 1, -2, 0,
+ax_anim 2, 0, 143, -2, 2, -1, 1,
+ax_anim 2, 0, 143, -3, 1, -2, 0,
+ax_anim 2, 0, 143, -2, 2, -1, 1,
+ax_anim 2, 0, 143, -3, 1, -2, 0,
+ax_anim 2, 0, 143, -2, 2, -1, 1,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_5_1:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -1, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 2, 146, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 145, 0, -1, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_5_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 2, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_5_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, -1, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 152, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 0,
+ax_anim 2, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 0,
+ax_anim 2, 2, 152, 0, -4, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 0,
+ax_anim 2, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 0,
+ax_anim 2, 0, 152, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 151, 0, -1, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_5_4:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 0, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 2, 155, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 0, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_5_5:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -4, 0, 0,
+ax_anim 2, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 156, 0, -4, 0, 0,
+ax_anim 2, 2, 158, 0, -4, 0, 0,
+ax_anim 2, 0, 156, 0, -4, 0, 0,
+ax_anim 2, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 156, 0, -4, 0, 0,
+ax_anim 2, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_5_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 0, 160, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 2, 161, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 0, 160, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_5_7:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, 0,
+ax_anim 2, 0, 162, 0, -2, 0, 0,
+ax_anim 2, 0, 164, 0, -3, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 2, 2, 164, 0, -4, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 2, 0, 164, 0, -3, 0, 0,
+ax_anim 2, 0, 162, 0, -2, 0, 0,
+ax_anim 2, 0, 163, 0, -1, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_5_8:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, 0,
+ax_anim 2, 0, 165, 0, -2, 0, 0,
+ax_anim 2, 0, 167, 0, -3, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim 2, 2, 167, 0, -4, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim 2, 0, 167, 0, -3, 0, 0,
+ax_anim 2, 0, 165, 0, -2, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_6_1:
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, -1, 0, 0,
+ax_anim 26, 0, 168, 0, -2, 0, 0,
+ax_anim 8, 0, 169, 0, -2, 0, 0,
+ax_anim 8, 0, 169, 0, -1, 0, 0,
+ax_anim 26, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_7_1:
+ax_anim 2, 0, 170, 0, -4, 0, -4,
+ax_anim 8, 0, 170, 0, -5, 0, -5,
+ax_anim_terminator
+sNinjaskAnims_7_2:
+ax_anim 2, 0, 171, -4, -4, -4, -4,
+ax_anim 8, 0, 171, -5, -5, -5, -5,
+ax_anim_terminator
+sNinjaskAnims_7_3:
+ax_anim 2, 0, 172, -4, 0, -4, 0,
+ax_anim 8, 0, 172, -5, 0, -5, 0,
+ax_anim_terminator
+sNinjaskAnims_7_4:
+ax_anim 2, 0, 173, -4, 4, -4, 4,
+ax_anim 8, 0, 173, -5, 5, -5, 5,
+ax_anim_terminator
+sNinjaskAnims_7_5:
+ax_anim 2, 0, 174, 0, 4, 0, 4,
+ax_anim 8, 0, 174, 0, 5, 0, 5,
+ax_anim_terminator
+sNinjaskAnims_7_6:
+ax_anim 2, 0, 175, 4, 4, 4, 4,
+ax_anim 8, 0, 175, 5, 5, 5, 5,
+ax_anim_terminator
+sNinjaskAnims_7_7:
+ax_anim 2, 0, 176, 4, 0, 4, 0,
+ax_anim 8, 0, 176, 5, 0, 5, 0,
+ax_anim_terminator
+sNinjaskAnims_7_8:
+ax_anim 2, 0, 177, 4, -4, 4, -4,
+ax_anim 8, 0, 177, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_8_1:
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 1,
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim 9, 0, 180, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_8_2:
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 182, 0, 0, 0, 1,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 9, 0, 183, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_8_3:
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 1,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 9, 0, 186, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_8_4:
+ax_anim 8, 0, 187, 0, 0, 0, 0,
+ax_anim 8, 0, 188, 0, 0, 0, 1,
+ax_anim 8, 0, 187, 0, 0, 0, 0,
+ax_anim 9, 0, 189, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_8_5:
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim 8, 0, 191, 0, 0, 0, 1,
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim 9, 0, 192, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_8_6:
+ax_anim 8, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 1,
+ax_anim 8, 0, 193, 0, 0, 0, 0,
+ax_anim 9, 0, 195, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_8_7:
+ax_anim 8, 0, 196, 0, 0, 0, 0,
+ax_anim 8, 0, 197, 0, 0, 0, 1,
+ax_anim 8, 0, 196, 0, 0, 0, 0,
+ax_anim 9, 0, 198, 0, 0, 0, -1,
+ax_anim_terminator
+sNinjaskAnims_8_8:
+ax_anim 8, 0, 199, 0, 0, 0, 0,
+ax_anim 8, 0, 200, 0, 0, 0, 1,
+ax_anim 8, 0, 199, 0, 0, 0, 0,
+ax_anim 9, 0, 201, 0, 0, 0, -1,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 4, 6, 4,
+ax_anim 2, 0, 204, 10, 11, 10, 11,
+ax_anim 2, 0, 205, 7, 23, 7, 22,
+ax_anim 3, 0, 206, 0, 25, 0, 23,
+ax_anim 2, 3, 207, -7, 23, -7, 22,
+ax_anim 2, 0, 208, -10, 11, -10, 11,
+ax_anim 1, 0, 209, -6, 4, -6, 4,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 11, 0, 11, 0,
+ax_anim 2, 0, 203, 20, 6, 20, 6,
+ax_anim 2, 0, 204, 23, 16, 23, 16,
+ax_anim 3, 0, 205, 21, 26, 21, 23,
+ax_anim 2, 3, 206, 13, 26, 13, 24,
+ax_anim 2, 0, 207, 3, 22, 3, 22,
+ax_anim 1, 0, 208, -3, 10, -3, 10,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 5, -4, 5, -4,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 17, -2, 17, -2,
+ax_anim 3, 0, 204, 21, 6, 21, 6,
+ax_anim 2, 3, 205, 17, 12, 17, 12,
+ax_anim 2, 0, 206, 10, 13, 10, 13,
+ax_anim 1, 0, 207, 2, 10, 2, 10,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -3, -8, -3, -8,
+ax_anim 2, 0, 209, 5, -19, 5, -19,
+ax_anim 2, 0, 202, 14, -22, 14, -22,
+ax_anim 3, 0, 203, 22, -20, 22, -20,
+ax_anim 2, 3, 204, 26, -12, 26, -12,
+ax_anim 2, 0, 205, 19, -2, 19, -2,
+ax_anim 1, 0, 206, 8, 1, 8, 1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -2, -8, -2,
+ax_anim 2, 0, 208, -11, -10, -11, -10,
+ax_anim 2, 0, 209, -9, -18, -9, -18,
+ax_anim 3, 0, 202, 0, -21, 0, -21,
+ax_anim 2, 3, 203, 9, -18, 9, -18,
+ax_anim 2, 0, 204, 13, -10, 13, -10,
+ax_anim 1, 0, 205, 8, -1, 8, -1,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 3, -8, 3, -8,
+ax_anim 2, 0, 203, -5, -19, -5, -19,
+ax_anim 2, 0, 202, -14, -22, -14, -22,
+ax_anim 3, 0, 209, -22, -20, -22, -20,
+ax_anim 2, 3, 208, -26, -12, -26, -12,
+ax_anim 2, 0, 207, -19, -2, -19, -2,
+ax_anim 1, 0, 206, -8, 1, -8, 1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -5, -4, -5, -4,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -17, -2, -17, -2,
+ax_anim 3, 0, 208, -21, 6, -21, 6,
+ax_anim 2, 3, 207, -17, 12, -17, 12,
+ax_anim 2, 0, 206, -10, 13, -10, 13,
+ax_anim 1, 0, 205, -2, 10, -2, 10,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -11, 0, -11, 0,
+ax_anim 2, 0, 209, -20, 6, -20, 6,
+ax_anim 2, 0, 208, -23, 16, -23, 16,
+ax_anim 3, 0, 207, -21, 26, -21, 23,
+ax_anim 2, 3, 206, -13, 26, -13, 24,
+ax_anim 2, 0, 205, -3, 22, -3, 22,
+ax_anim 1, 0, 204, 3, 10, 3, 10,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_10_1:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 3, 0, 238, 13, 0, 13, 0,
+ax_anim 3, 0, 238, -13, 0, -13, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_10_2:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 3, 0, 239, 13, -13, 13, -13,
+ax_anim 3, 0, 239, -13, 13, -13, 13,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_10_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 3, 0, 240, 0, -13, 0, -13,
+ax_anim 3, 0, 240, 0, 13, 0, 13,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_10_4:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 3, 0, 241, -13, -13, -13, -13,
+ax_anim 3, 0, 241, 13, 13, 13, 13,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_10_5:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 3, 0, 242, 13, 0, 13, 0,
+ax_anim 3, 0, 242, -13, 0, -13, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_10_6:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 3, 0, 243, 13, -13, 13, -13,
+ax_anim 3, 0, 243, -13, 13, -13, 13,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_10_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 3, 0, 244, 0, -13, 0, -13,
+ax_anim 3, 0, 244, 0, 13, 0, 13,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_10_8:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 3, 0, 245, -13, -13, -13, -13,
+ax_anim 3, 0, 245, 13, 13, 13, 13,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_11_1:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -10, 0, 0,
+ax_anim 2, 0, 248, 0, -16, 0, 0,
+ax_anim 3, 0, 248, 0, -20, 0, 0,
+ax_anim 4, 0, 248, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -23, 0, 0,
+ax_anim 3, 0, 247, 0, -22, 0, 0,
+ax_anim 2, 0, 247, 0, -18, 0, 0,
+ax_anim 1, 0, 247, 0, -12, 0, 0,
+ax_anim 2, 2, 246, 0, 4, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_11_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -10, 0, 0,
+ax_anim 2, 0, 251, 0, -16, 0, 0,
+ax_anim 3, 0, 251, 0, -20, 0, 0,
+ax_anim 4, 0, 251, 0, -21, 0, 0,
+ax_anim 4, 0, 249, 0, -23, 0, 0,
+ax_anim 3, 0, 250, 0, -22, 0, 0,
+ax_anim 2, 0, 250, 0, -18, 0, 0,
+ax_anim 1, 0, 250, 0, -12, 0, 0,
+ax_anim 2, 2, 249, 0, 4, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_11_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 254, 0, -10, 0, 0,
+ax_anim 2, 0, 254, 0, -16, 0, 0,
+ax_anim 3, 0, 254, 0, -20, 0, 0,
+ax_anim 4, 0, 254, 0, -21, 0, 0,
+ax_anim 4, 0, 252, 0, -23, 0, 0,
+ax_anim 3, 0, 253, 0, -22, 0, 0,
+ax_anim 2, 0, 253, 0, -18, 0, 0,
+ax_anim 1, 0, 253, 0, -12, 0, 0,
+ax_anim 2, 2, 252, 0, 5, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_11_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 0, -10, 0, 0,
+ax_anim 2, 0, 257, 0, -16, 0, 0,
+ax_anim 3, 0, 257, 0, -20, 0, 0,
+ax_anim 4, 0, 257, 0, -21, 0, 0,
+ax_anim 4, 0, 255, 0, -22, 0, 0,
+ax_anim 3, 0, 256, 0, -21, 0, 0,
+ax_anim 2, 0, 256, 0, -17, 0, 0,
+ax_anim 1, 0, 256, 0, -11, 0, 0,
+ax_anim 2, 2, 255, 0, 4, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_11_5:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -10, 0, 0,
+ax_anim 2, 0, 260, 0, -16, 0, 0,
+ax_anim 3, 0, 260, 0, -20, 0, 0,
+ax_anim 4, 0, 260, 0, -21, 0, 0,
+ax_anim 4, 0, 258, 0, -23, 0, 0,
+ax_anim 3, 0, 259, 0, -22, 0, 0,
+ax_anim 2, 0, 259, 0, -18, 0, 0,
+ax_anim 1, 0, 259, 0, -12, 0, 0,
+ax_anim 2, 2, 258, 0, 3, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_11_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 261, 0, -22, 0, 0,
+ax_anim 3, 0, 262, 0, -21, 0, 0,
+ax_anim 2, 0, 262, 0, -17, 0, 0,
+ax_anim 1, 0, 262, 0, -11, 0, 0,
+ax_anim 2, 2, 261, 0, 4, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_11_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 264, 0, -23, 0, 0,
+ax_anim 3, 0, 265, 0, -22, 0, 0,
+ax_anim 2, 0, 265, 0, -18, 0, 0,
+ax_anim 1, 0, 265, 0, -12, 0, 0,
+ax_anim 2, 2, 264, 0, 5, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_11_8:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 267, 0, -23, 0, 0,
+ax_anim 3, 0, 268, 0, -22, 0, 0,
+ax_anim 2, 0, 268, 0, -18, 0, 0,
+ax_anim 1, 0, 268, 0, -12, 0, 0,
+ax_anim 2, 2, 267, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_12_1:
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 1, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_12_2:
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 1, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_12_3:
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 1, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_12_4:
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 1, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_12_5:
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 1, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_12_6:
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 1, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_12_7:
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 1, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_12_8:
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 1, 271, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNinjaskAnims_13_1:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_13_2:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_13_3:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_13_4:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_13_5:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_13_6:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_13_7:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskAnims_13_8:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sNinjaskGfx1:
+.incbin "baserom.gba", 0x11D9AE0, 0x200
+sNinjaskSprites1:
+ax_sprite sNinjaskGfx1, 0x200
+ax_sprite_terminator
+sNinjaskGfx2:
+.incbin "baserom.gba", 0x11D9CF0, 0x200
+sNinjaskSprites2:
+ax_sprite sNinjaskGfx2, 0x200
+ax_sprite_terminator
+sNinjaskGfx3:
+.incbin "baserom.gba", 0x11D9F00, 0x100
+sNinjaskSprites3:
+ax_sprite sNinjaskGfx3, 0x100
+ax_sprite_terminator
+sNinjaskGfx4:
+.incbin "baserom.gba", 0x11DA010, 0x20
+sNinjaskSprites4:
+ax_sprite sNinjaskGfx4, 0x20
+ax_sprite_terminator
+sNinjaskGfx5:
+.incbin "baserom.gba", 0x11DA040, 0x20
+sNinjaskSprites5:
+ax_sprite sNinjaskGfx5, 0x20
+ax_sprite_terminator
+sNinjaskGfx6:
+.incbin "baserom.gba", 0x11DA070, 0x200
+sNinjaskSprites6:
+ax_sprite sNinjaskGfx6, 0x200
+ax_sprite_terminator
+sNinjaskGfx7:
+.incbin "baserom.gba", 0x11DA280, 0x200
+sNinjaskSprites7:
+ax_sprite sNinjaskGfx7, 0x200
+ax_sprite_terminator
+sNinjaskGfx8:
+.incbin "baserom.gba", 0x11DA490, 0x200
+sNinjaskSprites8:
+ax_sprite sNinjaskGfx8, 0x200
+ax_sprite_terminator
+sNinjaskGfx9:
+.incbin "baserom.gba", 0x11DA6A0, 0x200
+sNinjaskSprites9:
+ax_sprite sNinjaskGfx9, 0x200
+ax_sprite_terminator
+sNinjaskGfx10:
+.incbin "baserom.gba", 0x11DA8B0, 0x200
+sNinjaskSprites10:
+ax_sprite sNinjaskGfx10, 0x200
+ax_sprite_terminator
+sNinjaskGfx11:
+.incbin "baserom.gba", 0x11DAAC0, 0x200
+sNinjaskSprites11:
+ax_sprite sNinjaskGfx11, 0x200
+ax_sprite_terminator
+sNinjaskGfx12:
+.incbin "baserom.gba", 0x11DACD0, 0x200
+sNinjaskSprites12:
+ax_sprite sNinjaskGfx12, 0x200
+ax_sprite_terminator
+sNinjaskGfx13:
+.incbin "baserom.gba", 0x11DAEE0, 0x200
+sNinjaskSprites13:
+ax_sprite sNinjaskGfx13, 0x200
+ax_sprite_terminator
+sNinjaskGfx14:
+.incbin "baserom.gba", 0x11DB0F0, 0x200
+sNinjaskSprites14:
+ax_sprite sNinjaskGfx14, 0x200
+ax_sprite_terminator
+sNinjaskGfx15:
+.incbin "baserom.gba", 0x11DB300, 0x200
+sNinjaskSprites15:
+ax_sprite sNinjaskGfx15, 0x200
+ax_sprite_terminator
+sNinjaskGfx16:
+.incbin "baserom.gba", 0x11DB510, 0x200
+sNinjaskSprites16:
+ax_sprite sNinjaskGfx16, 0x200
+ax_sprite_terminator
+sNinjaskGfx17:
+.incbin "baserom.gba", 0x11DB720, 0x100
+sNinjaskSprites17:
+ax_sprite sNinjaskGfx17, 0x100
+ax_sprite_terminator
+sNinjaskGfx18:
+.incbin "baserom.gba", 0x11DB830, 0x20
+sNinjaskSprites18:
+ax_sprite sNinjaskGfx18, 0x20
+ax_sprite_terminator
+sNinjaskGfx19:
+.incbin "baserom.gba", 0x11DB860, 0x20
+sNinjaskSprites19:
+ax_sprite sNinjaskGfx19, 0x20
+ax_sprite_terminator
+sNinjaskGfx20:
+.incbin "baserom.gba", 0x11DB890, 0x20
+sNinjaskGfx20_1:
+.incbin "baserom.gba", 0x11DB8B0, 0xE0
+sNinjaskGfx20_2:
+.incbin "baserom.gba", 0x11DB990, 0x40
+sNinjaskSprites20:
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx20, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx20_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx21:
+.incbin "baserom.gba", 0x11DBA10, 0x20
+sNinjaskGfx21_1:
+.incbin "baserom.gba", 0x11DBA30, 0x20
+sNinjaskGfx21_2:
+.incbin "baserom.gba", 0x11DBA50, 0x100
+sNinjaskGfx21_3:
+.incbin "baserom.gba", 0x11DBB50, 0x40
+sNinjaskSprites21:
+ax_sprite sNinjaskGfx21, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx21_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx21_2, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx22:
+.incbin "baserom.gba", 0x11DBBD8, 0x20
+sNinjaskGfx22_1:
+.incbin "baserom.gba", 0x11DBBF8, 0x140
+sNinjaskSprites22:
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx22_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx23:
+.incbin "baserom.gba", 0x11DBD68, 0x40
+sNinjaskGfx23_1:
+.incbin "baserom.gba", 0x11DBDA8, 0xE0
+sNinjaskGfx23_2:
+.incbin "baserom.gba", 0x11DBE88, 0x40
+sNinjaskSprites23:
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx23_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx24:
+.incbin "baserom.gba", 0x11DBF08, 0xE0
+sNinjaskGfx24_1:
+.incbin "baserom.gba", 0x11DBFE8, 0x40
+sNinjaskSprites24:
+ax_sprite 0, 0xa0
+ax_sprite sNinjaskGfx24, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx25:
+.incbin "baserom.gba", 0x11DC058, 0x40
+sNinjaskGfx25_1:
+.incbin "baserom.gba", 0x11DC098, 0xE0
+sNinjaskGfx25_2:
+.incbin "baserom.gba", 0x11DC178, 0x40
+sNinjaskSprites25:
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx25_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx26:
+.incbin "baserom.gba", 0x11DC1F8, 0x40
+sNinjaskGfx26_1:
+.incbin "baserom.gba", 0x11DC238, 0xE0
+sNinjaskGfx26_2:
+.incbin "baserom.gba", 0x11DC318, 0x40
+sNinjaskSprites26:
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx26_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx27:
+.incbin "baserom.gba", 0x11DC398, 0x20
+sNinjaskGfx27_1:
+.incbin "baserom.gba", 0x11DC3B8, 0x20
+sNinjaskGfx27_2:
+.incbin "baserom.gba", 0x11DC3D8, 0x20
+sNinjaskGfx27_3:
+.incbin "baserom.gba", 0x11DC3F8, 0x60
+sNinjaskSprites27:
+ax_sprite 0, 0x80
+ax_sprite sNinjaskGfx27, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNinjaskGfx27_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx27_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx28:
+.incbin "baserom.gba", 0x11DC4A8, 0x20
+sNinjaskGfx28_1:
+.incbin "baserom.gba", 0x11DC4C8, 0x20
+sNinjaskGfx28_2:
+.incbin "baserom.gba", 0x11DC4E8, 0x60
+sNinjaskSprites28:
+ax_sprite 0, 0x80
+ax_sprite sNinjaskGfx28, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNinjaskGfx28_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNinjaskGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx29:
+.incbin "baserom.gba", 0x11DC588, 0x100
+sNinjaskSprites29:
+ax_sprite sNinjaskGfx29, 0x100
+ax_sprite_terminator
+sNinjaskGfx30:
+.incbin "baserom.gba", 0x11DC698, 0x20
+sNinjaskGfx30_1:
+.incbin "baserom.gba", 0x11DC6B8, 0x160
+sNinjaskSprites30:
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx30, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx30_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx31:
+.incbin "baserom.gba", 0x11DC848, 0x40
+sNinjaskGfx31_1:
+.incbin "baserom.gba", 0x11DC888, 0x20
+sNinjaskGfx31_2:
+.incbin "baserom.gba", 0x11DC8A8, 0x60
+sNinjaskSprites31:
+ax_sprite 0, 0x80
+ax_sprite sNinjaskGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx31_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNinjaskGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx32:
+.incbin "baserom.gba", 0x11DC948, 0xE0
+sNinjaskSprites32:
+ax_sprite sNinjaskGfx32, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx33:
+.incbin "baserom.gba", 0x11DCA40, 0x120
+sNinjaskSprites33:
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx33, 0x120
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sNinjaskGfx34:
+.incbin "baserom.gba", 0x11DCB80, 0x40
+sNinjaskSprites34:
+ax_sprite sNinjaskGfx34, 0x40
+ax_sprite_terminator
+sNinjaskGfx35:
+.incbin "baserom.gba", 0x11DCBD0, 0x60
+sNinjaskGfx35_1:
+.incbin "baserom.gba", 0x11DCC30, 0x60
+sNinjaskGfx35_2:
+.incbin "baserom.gba", 0x11DCC90, 0x20
+sNinjaskGfx35_3:
+.incbin "baserom.gba", 0x11DCCB0, 0x20
+sNinjaskSprites35:
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx35_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sNinjaskGfx35_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNinjaskGfx35_3, 0x20
+ax_sprite_terminator
+sNinjaskGfx36:
+.incbin "baserom.gba", 0x11DCD18, 0x20
+sNinjaskGfx36_1:
+.incbin "baserom.gba", 0x11DCD38, 0x180
+sNinjaskSprites36:
+ax_sprite sNinjaskGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx36_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx37:
+.incbin "baserom.gba", 0x11DCEE0, 0x40
+sNinjaskGfx37_1:
+.incbin "baserom.gba", 0x11DCF20, 0x160
+sNinjaskSprites37:
+ax_sprite sNinjaskGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx37_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx38:
+.incbin "baserom.gba", 0x11DD0A8, 0x20
+sNinjaskGfx38_1:
+.incbin "baserom.gba", 0x11DD0C8, 0x60
+sNinjaskGfx38_2:
+.incbin "baserom.gba", 0x11DD128, 0x60
+sNinjaskGfx38_3:
+.incbin "baserom.gba", 0x11DD188, 0x40
+sNinjaskSprites38:
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx38, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx38_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx39:
+.incbin "baserom.gba", 0x11DD218, 0x140
+sNinjaskGfx39_1:
+.incbin "baserom.gba", 0x11DD358, 0x40
+sNinjaskSprites39:
+ax_sprite 0, 0x40
+ax_sprite sNinjaskGfx39, 0x140
+ax_sprite 0, 0x20
+ax_sprite sNinjaskGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNinjaskGfx40:
+.incbin "baserom.gba", 0x11DD3C8, 0x180
+sNinjaskSprites40:
+ax_sprite 0, 0x80
+ax_sprite sNinjaskGfx40, 0x180
+ax_sprite_terminator
+sNinjaskGfx41:
+.incbin "baserom.gba", 0x11DD560, 0x200
+sNinjaskSprites41:
+ax_sprite sNinjaskGfx41, 0x200
+ax_sprite_terminator
+sNinjaskGfx42:
+.incbin "baserom.gba", 0x11DD770, 0x200
+sNinjaskSprites42:
+ax_sprite sNinjaskGfx42, 0x200
+ax_sprite_terminator
+sNinjaskGfx43:
+.incbin "baserom.gba", 0x11DD980, 0x200
+sNinjaskSprites43:
+ax_sprite sNinjaskGfx43, 0x200
+ax_sprite_terminator
+sNinjaskGfx44:
+.incbin "baserom.gba", 0x11DDB90, 0x200
+sNinjaskSprites44:
+ax_sprite sNinjaskGfx44, 0x200
+ax_sprite_terminator
+sNinjaskGfx45:
+.incbin "baserom.gba", 0x11DDDA0, 0x200
+sNinjaskSprites45:
+ax_sprite sNinjaskGfx45, 0x200
+ax_sprite_terminator
+sNinjaskGfx46:
+.incbin "baserom.gba", 0x11DDFB0, 0x200
+sNinjaskSprites46:
+ax_sprite sNinjaskGfx46, 0x200
+ax_sprite_terminator
+sNinjaskGfx47:
+.incbin "baserom.gba", 0x11DE1C0, 0x200
+sNinjaskSprites47:
+ax_sprite sNinjaskGfx47, 0x200
+ax_sprite_terminator
+sAxPosesNinjask:
+.4byte sNinjaskPose1
+.4byte sNinjaskPose2
+.4byte sNinjaskPose3
+.4byte sNinjaskPose4
+.4byte sNinjaskPose5
+.4byte sNinjaskPose6
+.4byte sNinjaskPose7
+.4byte sNinjaskPose8
+.4byte sNinjaskPose9
+.4byte sNinjaskPose10
+.4byte sNinjaskPose11
+.4byte sNinjaskPose12
+.4byte sNinjaskPose13
+.4byte sNinjaskPose14
+.4byte sNinjaskPose15
+.4byte sNinjaskPose16
+.4byte sNinjaskPose17
+.4byte sNinjaskPose18
+.4byte sNinjaskPose19
+.4byte sNinjaskPose20
+.4byte sNinjaskPose21
+.4byte sNinjaskPose22
+.4byte sNinjaskPose23
+.4byte sNinjaskPose24
+.4byte sNinjaskPose25
+.4byte sNinjaskPose26
+.4byte sNinjaskPose27
+.4byte sNinjaskPose28
+.4byte sNinjaskPose29
+.4byte sNinjaskPose30
+.4byte sNinjaskPose31
+.4byte sNinjaskPose32
+.4byte sNinjaskPose33
+.4byte sNinjaskPose34
+.4byte sNinjaskPose35
+.4byte sNinjaskPose36
+.4byte sNinjaskPose37
+.4byte sNinjaskPose38
+.4byte sNinjaskPose39
+.4byte sNinjaskPose40
+.4byte sNinjaskPose41
+.4byte sNinjaskPose42
+.4byte sNinjaskPose43
+.4byte sNinjaskPose44
+.4byte sNinjaskPose45
+.4byte sNinjaskPose46
+.4byte sNinjaskPose47
+.4byte sNinjaskPose48
+.4byte sNinjaskPose49
+.4byte sNinjaskPose50
+.4byte sNinjaskPose51
+.4byte sNinjaskPose52
+.4byte sNinjaskPose53
+.4byte sNinjaskPose54
+.4byte sNinjaskPose55
+.4byte sNinjaskPose56
+.4byte sNinjaskPose57
+.4byte sNinjaskPose58
+.4byte sNinjaskPose59
+.4byte sNinjaskPose60
+.4byte sNinjaskPose61
+.4byte sNinjaskPose62
+.4byte sNinjaskPose63
+.4byte sNinjaskPose64
+.4byte sNinjaskPose65
+.4byte sNinjaskPose66
+.4byte sNinjaskPose67
+.4byte sNinjaskPose68
+.4byte sNinjaskPose69
+.4byte sNinjaskPose70
+.4byte sNinjaskPose71
+.4byte sNinjaskPose72
+.4byte sNinjaskPose73
+.4byte sNinjaskPose74
+.4byte sNinjaskPose75
+.4byte sNinjaskPose76
+.4byte sNinjaskPose77
+.4byte sNinjaskPose78
+.4byte sNinjaskPose79
+.4byte sNinjaskPose80
+.4byte sNinjaskPose81
+.4byte sNinjaskPose82
+.4byte sNinjaskPose83
+.4byte sNinjaskPose84
+.4byte sNinjaskPose85
+.4byte sNinjaskPose86
+.4byte sNinjaskPose87
+.4byte sNinjaskPose88
+.4byte sNinjaskPose89
+.4byte sNinjaskPose90
+.4byte sNinjaskPose91
+.4byte sNinjaskPose92
+.4byte sNinjaskPose93
+.4byte sNinjaskPose94
+.4byte sNinjaskPose95
+.4byte sNinjaskPose96
+.4byte sNinjaskPose97
+.4byte sNinjaskPose98
+.4byte sNinjaskPose99
+.4byte sNinjaskPose100
+.4byte sNinjaskPose101
+.4byte sNinjaskPose102
+.4byte sNinjaskPose103
+.4byte sNinjaskPose104
+.4byte sNinjaskPose105
+.4byte sNinjaskPose106
+.4byte sNinjaskPose107
+.4byte sNinjaskPose108
+.4byte sNinjaskPose109
+.4byte sNinjaskPose110
+.4byte sNinjaskPose111
+.4byte sNinjaskPose112
+.4byte sNinjaskPose113
+.4byte sNinjaskPose114
+.4byte sNinjaskPose115
+.4byte sNinjaskPose116
+.4byte sNinjaskPose117
+.4byte sNinjaskPose118
+.4byte sNinjaskPose119
+.4byte sNinjaskPose120
+.4byte sNinjaskPose121
+.4byte sNinjaskPose122
+.4byte sNinjaskPose123
+.4byte sNinjaskPose124
+.4byte sNinjaskPose125
+.4byte sNinjaskPose126
+.4byte sNinjaskPose127
+.4byte sNinjaskPose128
+.4byte sNinjaskPose129
+.4byte sNinjaskPose130
+.4byte sNinjaskPose131
+.4byte sNinjaskPose132
+.4byte sNinjaskPose133
+.4byte sNinjaskPose134
+.4byte sNinjaskPose135
+.4byte sNinjaskPose136
+.4byte sNinjaskPose137
+.4byte sNinjaskPose138
+.4byte sNinjaskPose139
+.4byte sNinjaskPose140
+.4byte sNinjaskPose141
+.4byte sNinjaskPose142
+.4byte sNinjaskPose143
+.4byte sNinjaskPose144
+.4byte sNinjaskPose145
+.4byte sNinjaskPose146
+.4byte sNinjaskPose147
+.4byte sNinjaskPose148
+.4byte sNinjaskPose149
+.4byte sNinjaskPose150
+.4byte sNinjaskPose151
+.4byte sNinjaskPose152
+.4byte sNinjaskPose153
+.4byte sNinjaskPose154
+.4byte sNinjaskPose155
+.4byte sNinjaskPose156
+.4byte sNinjaskPose157
+.4byte sNinjaskPose158
+.4byte sNinjaskPose159
+.4byte sNinjaskPose160
+.4byte sNinjaskPose161
+.4byte sNinjaskPose162
+.4byte sNinjaskPose163
+.4byte sNinjaskPose164
+.4byte sNinjaskPose165
+.4byte sNinjaskPose166
+.4byte sNinjaskPose167
+.4byte sNinjaskPose168
+.4byte sNinjaskPose169
+.4byte sNinjaskPose170
+.4byte sNinjaskPose171
+.4byte sNinjaskPose172
+.4byte sNinjaskPose173
+.4byte sNinjaskPose174
+.4byte sNinjaskPose175
+.4byte sNinjaskPose176
+.4byte sNinjaskPose177
+.4byte sNinjaskPose178
+.4byte sNinjaskPose179
+.4byte sNinjaskPose180
+.4byte sNinjaskPose181
+.4byte sNinjaskPose182
+.4byte sNinjaskPose183
+.4byte sNinjaskPose184
+.4byte sNinjaskPose185
+.4byte sNinjaskPose186
+.4byte sNinjaskPose187
+.4byte sNinjaskPose188
+.4byte sNinjaskPose189
+.4byte sNinjaskPose190
+.4byte sNinjaskPose191
+.4byte sNinjaskPose192
+.4byte sNinjaskPose193
+.4byte sNinjaskPose194
+.4byte sNinjaskPose195
+.4byte sNinjaskPose196
+.4byte sNinjaskPose197
+.4byte sNinjaskPose198
+.4byte sNinjaskPose199
+.4byte sNinjaskPose200
+.4byte sNinjaskPose201
+.4byte sNinjaskPose202
+.4byte sNinjaskPose203
+.4byte sNinjaskPose204
+.4byte sNinjaskPose205
+.4byte sNinjaskPose206
+.4byte sNinjaskPose207
+.4byte sNinjaskPose208
+.4byte sNinjaskPose209
+.4byte sNinjaskPose210
+.4byte sNinjaskPose211
+.4byte sNinjaskPose212
+.4byte sNinjaskPose213
+.4byte sNinjaskPose214
+.4byte sNinjaskPose215
+.4byte sNinjaskPose216
+.4byte sNinjaskPose217
+.4byte sNinjaskPose218
+.4byte sNinjaskPose219
+.4byte sNinjaskPose220
+.4byte sNinjaskPose221
+.4byte sNinjaskPose222
+.4byte sNinjaskPose223
+.4byte sNinjaskPose224
+.4byte sNinjaskPose225
+.4byte sNinjaskPose226
+.4byte sNinjaskPose227
+.4byte sNinjaskPose228
+.4byte sNinjaskPose229
+.4byte sNinjaskPose230
+.4byte sNinjaskPose231
+.4byte sNinjaskPose232
+.4byte sNinjaskPose233
+.4byte sNinjaskPose234
+.4byte sNinjaskPose235
+.4byte sNinjaskPose236
+.4byte sNinjaskPose237
+.4byte sNinjaskPose238
+.4byte sNinjaskPose239
+.4byte sNinjaskPose240
+.4byte sNinjaskPose241
+.4byte sNinjaskPose242
+.4byte sNinjaskPose243
+.4byte sNinjaskPose244
+.4byte sNinjaskPose245
+.4byte sNinjaskPose246
+.4byte sNinjaskPose247
+.4byte sNinjaskPose248
+.4byte sNinjaskPose249
+.4byte sNinjaskPose250
+.4byte sNinjaskPose251
+.4byte sNinjaskPose252
+.4byte sNinjaskPose253
+.4byte sNinjaskPose254
+.4byte sNinjaskPose255
+.4byte sNinjaskPose256
+.4byte sNinjaskPose257
+.4byte sNinjaskPose258
+.4byte sNinjaskPose259
+.4byte sNinjaskPose260
+.4byte sNinjaskPose261
+.4byte sNinjaskPose262
+.4byte sNinjaskPose263
+.4byte sNinjaskPose264
+.4byte sNinjaskPose265
+.4byte sNinjaskPose266
+.4byte sNinjaskPose267
+.4byte sNinjaskPose268
+.4byte sNinjaskPose269
+.4byte sNinjaskPose270
+.4byte sNinjaskPose271
+.4byte sNinjaskPose272
+.4byte sNinjaskPose273
+.4byte sNinjaskPose274
+.4byte sNinjaskPose275
+.4byte sNinjaskPose276
+.4byte sNinjaskPose277
+.4byte sNinjaskPose278
+.4byte sNinjaskPose279
+.4byte sNinjaskPose280
+.4byte sNinjaskPose281
+.4byte sNinjaskPose282
+.4byte sNinjaskPose283
+.4byte sNinjaskPose284
+.4byte sNinjaskPose285
+.4byte sNinjaskPose286
+sAxPositionsNinjask:
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -2, 	   3,   -2, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,  -12
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,   -9, 	   9,   -7, 	   1,   -2, 	   4,  -11
+.2byte    5,  -11, 	   9,   -9, 	   1,   -4, 	   4,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -11, 	   7,  -13, 	   7,   -5, 	   2,  -10
+.2byte    9,  -13, 	   7,  -15, 	   7,   -7, 	   2,  -12
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    3,  -15, 	  -2,  -13, 	   8,  -11, 	   0,  -12
+.2byte    3,  -17, 	  -2,  -15, 	   8,  -11, 	   0,  -14
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -14, 	   4,   -9, 	  -4,   -9, 	   0,  -12
+.2byte    0,  -16, 	   4,  -10, 	  -4,  -10, 	   0,  -14
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte   -3,  -15, 	   2,  -13, 	  -8,  -11, 	   0,  -12
+.2byte   -3,  -17, 	   2,  -15, 	  -8,  -11, 	   0,  -14
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -11, 	  -7,  -13, 	  -7,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	  -7,  -15, 	  -7,   -7, 	  -2,  -12
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,   -9, 	  -9,   -7, 	  -1,   -2, 	  -4,  -11
+.2byte   -5,  -11, 	  -9,   -9, 	  -1,   -4, 	  -4,  -13
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -2, 	   3,   -2, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,  -12
+.2byte    2,   -7, 	   4,   -4, 	  10,  -17, 	   0,  -10
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,   -9, 	   9,   -7, 	   1,   -2, 	   4,  -11
+.2byte    5,  -11, 	   9,   -9, 	   1,   -4, 	   4,  -13
+.2byte    2,   -7, 	   1,   -4, 	  -9,  -12, 	   3,  -11
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -11, 	   7,  -13, 	   7,   -5, 	   2,  -10
+.2byte    9,  -13, 	   7,  -15, 	   7,   -7, 	   2,  -12
+.2byte    9,   -8, 	   6,  -19, 	  11,   -7, 	   1,  -10
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    3,  -15, 	  -2,  -13, 	   8,  -11, 	   0,  -12
+.2byte    3,  -17, 	  -2,  -15, 	   8,  -11, 	   0,  -14
+.2byte    0,  -15, 	  -9,  -22, 	   1,  -15, 	   1,  -14
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -14, 	   4,   -9, 	  -4,   -9, 	   0,  -12
+.2byte    0,  -16, 	   4,  -10, 	  -4,  -10, 	   0,  -14
+.2byte   -4,  -14, 	  -7,  -17, 	  -9,  -11, 	   0,  -12
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte   -3,  -15, 	   2,  -13, 	  -8,  -11, 	   0,  -12
+.2byte   -3,  -17, 	   2,  -15, 	  -8,  -11, 	   0,  -14
+.2byte   -4,  -14, 	  -8,  -10, 	  -4,  -17, 	   0,  -14
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -11, 	  -7,  -13, 	  -7,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	  -7,  -15, 	  -7,   -7, 	  -2,  -12
+.2byte   -6,   -7, 	  -2,   -3, 	   4,  -13, 	  -1,   -9
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,   -9, 	  -9,   -7, 	  -1,   -2, 	  -4,  -11
+.2byte   -5,  -11, 	  -9,   -9, 	  -1,   -4, 	  -4,  -13
+.2byte   -2,   -7, 	  -1,   -4, 	   9,  -12, 	  -3,  -11
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -2, 	   3,   -2, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,  -12
+.2byte    2,   -7, 	   4,   -4, 	  10,  -17, 	   0,  -10
+.2byte    2,   -7, 	   4,   -4, 	  10,  -17, 	   0,  -10
+.2byte   -3,   -7, 	  -5,   -4, 	 -11,  -17, 	  -1,  -10
+.2byte   -3,   -7, 	  -5,   -4, 	 -11,  -17, 	  -1,  -10
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,   -9, 	   9,   -7, 	   1,   -2, 	   4,  -11
+.2byte    5,  -11, 	   9,   -9, 	   1,   -4, 	   4,  -13
+.2byte    2,   -7, 	   1,   -4, 	  -9,  -12, 	   3,  -11
+.2byte    2,   -7, 	   1,   -4, 	  -9,  -12, 	   3,  -11
+.2byte    4,   -9, 	   7,  -19, 	   8,   -7, 	   2,  -11
+.2byte    4,   -9, 	   7,  -19, 	   8,   -7, 	   2,  -11
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -11, 	   7,  -13, 	   7,   -5, 	   2,  -10
+.2byte    9,  -13, 	   7,  -15, 	   7,   -7, 	   2,  -12
+.2byte    6,   -7, 	   2,   -3, 	  -4,  -13, 	   1,   -9
+.2byte    6,   -7, 	   2,   -3, 	  -4,  -13, 	   1,   -9
+.2byte    9,   -8, 	   6,  -19, 	  11,   -7, 	   1,  -10
+.2byte    9,   -8, 	   6,  -19, 	  11,   -7, 	   1,  -10
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    3,  -15, 	  -2,  -13, 	   8,  -11, 	   0,  -12
+.2byte    3,  -17, 	  -2,  -15, 	   8,  -11, 	   0,  -14
+.2byte    4,  -14, 	   8,  -10, 	   4,  -17, 	   0,  -14
+.2byte    4,  -14, 	   8,  -10, 	   4,  -17, 	   0,  -14
+.2byte    0,  -15, 	  -9,  -22, 	   1,  -15, 	   1,  -14
+.2byte    2,  -15, 	  -7,  -22, 	   3,  -15, 	   3,  -14
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -14, 	   4,   -9, 	  -4,   -9, 	   0,  -12
+.2byte    0,  -16, 	   4,  -10, 	  -4,  -10, 	   0,  -14
+.2byte   -2,  -14, 	  -5,  -17, 	  -7,  -11, 	   2,  -12
+.2byte   -5,  -14, 	  -8,  -17, 	 -10,  -11, 	  -1,  -12
+.2byte    1,  -14, 	   4,  -17, 	   6,  -11, 	  -3,  -12
+.2byte    3,  -14, 	   6,  -17, 	   8,  -11, 	  -1,  -12
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte   -3,  -15, 	   2,  -13, 	  -8,  -11, 	   0,  -12
+.2byte   -3,  -17, 	   2,  -15, 	  -8,  -11, 	   0,  -14
+.2byte   -4,  -14, 	  -8,  -10, 	  -4,  -17, 	   0,  -14
+.2byte   -4,  -14, 	  -8,  -10, 	  -4,  -17, 	   0,  -14
+.2byte    0,  -15, 	   9,  -22, 	  -1,  -15, 	  -1,  -14
+.2byte    0,  -15, 	   9,  -22, 	  -1,  -15, 	  -1,  -14
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -11, 	  -7,  -13, 	  -7,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	  -7,  -15, 	  -7,   -7, 	  -2,  -12
+.2byte   -6,   -7, 	  -2,   -3, 	   4,  -13, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,   -3, 	   4,  -13, 	  -1,   -9
+.2byte   -9,   -8, 	  -6,  -19, 	 -11,   -7, 	  -1,  -10
+.2byte   -9,   -8, 	  -6,  -19, 	 -11,   -7, 	  -1,  -10
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,   -9, 	  -9,   -7, 	  -1,   -2, 	  -4,  -11
+.2byte   -5,  -11, 	  -9,   -9, 	  -1,   -4, 	  -4,  -13
+.2byte   -2,   -7, 	  -1,   -4, 	   9,  -12, 	  -3,  -11
+.2byte   -2,   -7, 	  -1,   -4, 	   9,  -12, 	  -3,  -11
+.2byte   -4,   -9, 	  -7,  -19, 	  -8,   -7, 	  -2,  -11
+.2byte   -4,   -9, 	  -7,  -19, 	  -8,   -7, 	  -2,  -11
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -2, 	   3,   -2, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,  -12
+.2byte   -1,  -10, 	 -13,  -11, 	  11,  -11, 	  -1,  -11
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,   -9, 	   9,   -7, 	   1,   -2, 	   4,  -11
+.2byte    5,  -11, 	   9,   -9, 	   1,   -4, 	   4,  -13
+.2byte    4,  -11, 	  13,  -16, 	  -6,   -9, 	   3,  -14
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -11, 	   7,  -13, 	   7,   -5, 	   2,  -10
+.2byte    9,  -13, 	   7,  -15, 	   7,   -7, 	   2,  -12
+.2byte    8,  -13, 	   6,  -21, 	   4,   -8, 	   0,  -14
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    3,  -15, 	  -2,  -13, 	   8,  -11, 	   0,  -12
+.2byte    3,  -17, 	  -2,  -15, 	   8,  -11, 	   0,  -14
+.2byte    2,  -16, 	  -5,  -22, 	  10,  -16, 	  -2,  -14
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -14, 	   4,   -9, 	  -4,   -9, 	   0,  -12
+.2byte    0,  -16, 	   4,  -10, 	  -4,  -10, 	   0,  -14
+.2byte    0,  -13, 	  10,  -18, 	 -10,  -18, 	   0,  -11
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte   -3,  -15, 	   2,  -13, 	  -8,  -11, 	   0,  -12
+.2byte   -3,  -17, 	   2,  -15, 	  -8,  -11, 	   0,  -14
+.2byte   -2,  -16, 	   5,  -22, 	 -10,  -16, 	   2,  -14
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -11, 	  -7,  -13, 	  -7,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	  -7,  -15, 	  -7,   -7, 	  -2,  -12
+.2byte   -8,  -13, 	  -6,  -21, 	  -4,   -8, 	   0,  -14
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,   -9, 	  -9,   -7, 	  -1,   -2, 	  -4,  -11
+.2byte   -5,  -11, 	  -9,   -9, 	  -1,   -4, 	  -4,  -13
+.2byte   -4,  -11, 	 -13,  -16, 	   6,   -9, 	  -3,  -14
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -12, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -10, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -15, 	   4,   -9, 	  -4,   -9, 	   0,  -13
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -12, 	   0,  -13
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -10, 	   0,  -13
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -8, 	  -6,   -2, 	   4,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	  -4,  -13, 	   2,  -13, 	  -1,  -14
+.2byte    2,  -13, 	   4,  -14, 	  -1,  -12, 	   1,  -11
+.2byte    3,  -13, 	   3,  -17, 	   2,  -10, 	   0,   -9
+.2byte    1,  -16, 	   0,  -18, 	   5,  -15, 	  -1,   -9
+.2byte   -1,  -13, 	   3,  -14, 	  -5,  -14, 	  -1,  -10
+.2byte   -2,  -16, 	  -1,  -18, 	  -6,  -15, 	   0,   -9
+.2byte   -4,  -13, 	  -4,  -17, 	  -3,  -10, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -14, 	   0,  -12, 	  -2,  -11
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -2, 	   3,   -2, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,  -12
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,   -9, 	   9,   -7, 	   1,   -2, 	   4,  -11
+.2byte    5,  -11, 	   9,   -9, 	   1,   -4, 	   4,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -11, 	   7,  -13, 	   7,   -5, 	   2,  -10
+.2byte    9,  -13, 	   7,  -15, 	   7,   -7, 	   2,  -12
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    3,  -15, 	  -2,  -13, 	   8,  -11, 	   0,  -12
+.2byte    3,  -17, 	  -2,  -15, 	   8,  -11, 	   0,  -14
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -14, 	   4,   -9, 	  -4,   -9, 	   0,  -12
+.2byte    0,  -16, 	   4,  -10, 	  -4,  -10, 	   0,  -14
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte   -3,  -15, 	   2,  -13, 	  -8,  -11, 	   0,  -12
+.2byte   -3,  -17, 	   2,  -15, 	  -8,  -11, 	   0,  -14
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -11, 	  -7,  -13, 	  -7,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	  -7,  -15, 	  -7,   -7, 	  -2,  -12
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,   -9, 	  -9,   -7, 	  -1,   -2, 	  -4,  -11
+.2byte   -5,  -11, 	  -9,   -9, 	  -1,   -4, 	  -4,  -13
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -4,  -10, 	  -8,   -8, 	   0,   -3, 	  -3,  -12
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte   -4,  -10, 	  -8,   -8, 	   0,   -3, 	  -3,  -12
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    4,  -10, 	   8,   -8, 	   0,   -3, 	   3,  -12
+.2byte   -1,  -10, 	 -13,  -11, 	  11,  -11, 	  -1,  -11
+.2byte    3,  -10, 	  12,  -15, 	  -7,   -8, 	   2,  -13
+.2byte    8,  -12, 	   6,  -20, 	   4,   -7, 	   0,  -13
+.2byte    3,  -15, 	  -4,  -21, 	  11,  -15, 	  -1,  -13
+.2byte    0,  -15, 	  10,  -20, 	 -10,  -20, 	   0,  -13
+.2byte   -3,  -15, 	   4,  -21, 	 -11,  -15, 	   1,  -13
+.2byte   -8,  -12, 	  -6,  -20, 	  -4,   -7, 	   0,  -13
+.2byte   -3,  -10, 	 -12,  -15, 	   7,   -8, 	  -2,  -13
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -12, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -10, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    0,  -15, 	   4,   -9, 	  -4,   -9, 	   0,  -13
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -12, 	   0,  -13
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -10, 	   0,  -13
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -1,   -8, 	  -5,   -2, 	   3,   -2, 	  -1,   -9
+.2byte   -4,   -9, 	  -8,   -7, 	   0,   -2, 	  -3,  -11
+.2byte   -9,  -11, 	  -7,  -13, 	  -7,   -5, 	  -2,  -10
+.2byte   -3,  -15, 	   2,  -13, 	  -8,  -11, 	   0,  -12
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    3,  -15, 	  -2,  -13, 	   8,  -11, 	   0,  -12
+.2byte    9,  -11, 	   7,  -13, 	   7,   -5, 	   2,  -10
+.2byte    4,   -9, 	   8,   -7, 	   0,   -2, 	   3,  -11
+.2byte   -1,   -9, 	  -5,   -3, 	   3,   -3, 	  -1,  -10
+.2byte   -5,  -10, 	  -9,   -8, 	  -1,   -3, 	  -4,  -12
+.2byte   -9,  -12, 	  -7,  -14, 	  -7,   -6, 	  -2,  -11
+.2byte   -3,  -16, 	   2,  -14, 	  -8,  -11, 	   0,  -13
+.2byte    0,  -15, 	   4,  -10, 	  -4,  -10, 	   0,  -13
+.2byte    3,  -16, 	  -2,  -14, 	   8,  -11, 	   0,  -13
+.2byte    9,  -12, 	   7,  -14, 	   7,   -6, 	   2,  -11
+.2byte    5,  -10, 	   9,   -8, 	   1,   -3, 	   4,  -12
+sNinjaskAnimTable1:
+.4byte sNinjaskAnims_1_1
+.4byte sNinjaskAnims_1_2
+.4byte sNinjaskAnims_1_3
+.4byte sNinjaskAnims_1_4
+.4byte sNinjaskAnims_1_5
+.4byte sNinjaskAnims_1_6
+.4byte sNinjaskAnims_1_7
+.4byte sNinjaskAnims_1_8
+sNinjaskAnimTable2:
+.4byte sNinjaskAnims_2_1
+.4byte sNinjaskAnims_2_2
+.4byte sNinjaskAnims_2_3
+.4byte sNinjaskAnims_2_4
+.4byte sNinjaskAnims_2_5
+.4byte sNinjaskAnims_2_6
+.4byte sNinjaskAnims_2_7
+.4byte sNinjaskAnims_2_8
+sNinjaskAnimTable3:
+.4byte sNinjaskAnims_3_1
+.4byte sNinjaskAnims_3_2
+.4byte sNinjaskAnims_3_3
+.4byte sNinjaskAnims_3_4
+.4byte sNinjaskAnims_3_5
+.4byte sNinjaskAnims_3_6
+.4byte sNinjaskAnims_3_7
+.4byte sNinjaskAnims_3_8
+sNinjaskAnimTable4:
+.4byte sNinjaskAnims_4_1
+.4byte sNinjaskAnims_4_2
+.4byte sNinjaskAnims_4_3
+.4byte sNinjaskAnims_4_4
+.4byte sNinjaskAnims_4_5
+.4byte sNinjaskAnims_4_6
+.4byte sNinjaskAnims_4_7
+.4byte sNinjaskAnims_4_8
+sNinjaskAnimTable5:
+.4byte sNinjaskAnims_5_1
+.4byte sNinjaskAnims_5_2
+.4byte sNinjaskAnims_5_3
+.4byte sNinjaskAnims_5_4
+.4byte sNinjaskAnims_5_5
+.4byte sNinjaskAnims_5_6
+.4byte sNinjaskAnims_5_7
+.4byte sNinjaskAnims_5_8
+sNinjaskAnimTable6:
+.4byte sNinjaskAnims_6_1
+.4byte sNinjaskAnims_6_1
+.4byte sNinjaskAnims_6_1
+.4byte sNinjaskAnims_6_1
+.4byte sNinjaskAnims_6_1
+.4byte sNinjaskAnims_6_1
+.4byte sNinjaskAnims_6_1
+.4byte sNinjaskAnims_6_1
+sNinjaskAnimTable7:
+.4byte sNinjaskAnims_7_1
+.4byte sNinjaskAnims_7_2
+.4byte sNinjaskAnims_7_3
+.4byte sNinjaskAnims_7_4
+.4byte sNinjaskAnims_7_5
+.4byte sNinjaskAnims_7_6
+.4byte sNinjaskAnims_7_7
+.4byte sNinjaskAnims_7_8
+sNinjaskAnimTable8:
+.4byte sNinjaskAnims_8_1
+.4byte sNinjaskAnims_8_2
+.4byte sNinjaskAnims_8_3
+.4byte sNinjaskAnims_8_4
+.4byte sNinjaskAnims_8_5
+.4byte sNinjaskAnims_8_6
+.4byte sNinjaskAnims_8_7
+.4byte sNinjaskAnims_8_8
+sNinjaskAnimTable9:
+.4byte sNinjaskAnims_9_1
+.4byte sNinjaskAnims_9_2
+.4byte sNinjaskAnims_9_3
+.4byte sNinjaskAnims_9_4
+.4byte sNinjaskAnims_9_5
+.4byte sNinjaskAnims_9_6
+.4byte sNinjaskAnims_9_7
+.4byte sNinjaskAnims_9_8
+sNinjaskAnimTable10:
+.4byte sNinjaskAnims_10_1
+.4byte sNinjaskAnims_10_2
+.4byte sNinjaskAnims_10_3
+.4byte sNinjaskAnims_10_4
+.4byte sNinjaskAnims_10_5
+.4byte sNinjaskAnims_10_6
+.4byte sNinjaskAnims_10_7
+.4byte sNinjaskAnims_10_8
+sNinjaskAnimTable11:
+.4byte sNinjaskAnims_11_1
+.4byte sNinjaskAnims_11_2
+.4byte sNinjaskAnims_11_3
+.4byte sNinjaskAnims_11_4
+.4byte sNinjaskAnims_11_5
+.4byte sNinjaskAnims_11_6
+.4byte sNinjaskAnims_11_7
+.4byte sNinjaskAnims_11_8
+sNinjaskAnimTable12:
+.4byte sNinjaskAnims_12_1
+.4byte sNinjaskAnims_12_2
+.4byte sNinjaskAnims_12_3
+.4byte sNinjaskAnims_12_4
+.4byte sNinjaskAnims_12_5
+.4byte sNinjaskAnims_12_6
+.4byte sNinjaskAnims_12_7
+.4byte sNinjaskAnims_12_8
+sNinjaskAnimTable13:
+.4byte sNinjaskAnims_13_1
+.4byte sNinjaskAnims_13_2
+.4byte sNinjaskAnims_13_3
+.4byte sNinjaskAnims_13_4
+.4byte sNinjaskAnims_13_5
+.4byte sNinjaskAnims_13_6
+.4byte sNinjaskAnims_13_7
+.4byte sNinjaskAnims_13_8
+sAxAnimationsNinjask:
+.4byte sNinjaskAnimTable1
+.4byte sNinjaskAnimTable2
+.4byte sNinjaskAnimTable3
+.4byte sNinjaskAnimTable4
+.4byte sNinjaskAnimTable5
+.4byte sNinjaskAnimTable6
+.4byte sNinjaskAnimTable7
+.4byte sNinjaskAnimTable8
+.4byte sNinjaskAnimTable9
+.4byte sNinjaskAnimTable10
+.4byte sNinjaskAnimTable11
+.4byte sNinjaskAnimTable12
+.4byte sNinjaskAnimTable13
+sAxSpritesNinjask:
+.4byte sNinjaskSprites1
+.4byte sNinjaskSprites2
+.4byte sNinjaskSprites3
+.4byte sNinjaskSprites4
+.4byte sNinjaskSprites5
+.4byte sNinjaskSprites6
+.4byte sNinjaskSprites7
+.4byte sNinjaskSprites8
+.4byte sNinjaskSprites9
+.4byte sNinjaskSprites10
+.4byte sNinjaskSprites11
+.4byte sNinjaskSprites12
+.4byte sNinjaskSprites13
+.4byte sNinjaskSprites14
+.4byte sNinjaskSprites15
+.4byte sNinjaskSprites16
+.4byte sNinjaskSprites17
+.4byte sNinjaskSprites18
+.4byte sNinjaskSprites19
+.4byte sNinjaskSprites20
+.4byte sNinjaskSprites21
+.4byte sNinjaskSprites22
+.4byte sNinjaskSprites23
+.4byte sNinjaskSprites24
+.4byte sNinjaskSprites25
+.4byte sNinjaskSprites26
+.4byte sNinjaskSprites27
+.4byte sNinjaskSprites28
+.4byte sNinjaskSprites29
+.4byte sNinjaskSprites30
+.4byte sNinjaskSprites31
+.4byte sNinjaskSprites32
+.4byte sNinjaskSprites33
+.4byte sNinjaskSprites34
+.4byte sNinjaskSprites35
+.4byte sNinjaskSprites36
+.4byte sNinjaskSprites37
+.4byte sNinjaskSprites38
+.4byte sNinjaskSprites39
+.4byte sNinjaskSprites40
+.4byte sNinjaskSprites41
+.4byte sNinjaskSprites42
+.4byte sNinjaskSprites43
+.4byte sNinjaskSprites44
+.4byte sNinjaskSprites45
+.4byte sNinjaskSprites46
+.4byte sNinjaskSprites47
+sAxMainNinjask:
+ax_main sAxPosesNinjask, sAxAnimationsNinjask, 13, sAxSpritesNinjask, sAxPositionsNinjask

--- a/data/ax/noctowl.inc
+++ b/data/ax/noctowl.inc
@@ -1,0 +1,2947 @@
+.global gAxNoctowl
+gAxNoctowl:
+ax_siro sAxMainNoctowl
+sNoctowlPose1:
+ax_pose 0, 0x41e8, 0x80f0, 0x4c00
+ax_pose 1, 0x41f8, 0x40f0, 0x4c08
+ax_pose 2, 0x01ee, 0x00e8, 0x4c0c
+ax_pose 3, 0x01ee, 0x0110, 0x4c0d
+ax_pose_terminator
+sNoctowlPose2:
+ax_pose 4, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose3:
+ax_pose 5, 0x41f1, 0x80f0, 0x4c00
+ax_pose 6, 0x41e9, 0x00f8, 0x4c08
+ax_pose 7, 0x01fb, 0x00e8, 0x4c0a
+ax_pose_terminator
+sNoctowlPose4:
+ax_pose 8, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose5:
+ax_pose 9, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose6:
+ax_pose 10, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose7:
+ax_pose 11, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose8:
+ax_pose 12, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose9:
+ax_pose 13, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose10:
+ax_pose 14, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose11:
+ax_pose 15, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose12:
+ax_pose 16, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose13:
+ax_pose 17, 0x81e6, 0x80f8, 0x4c00
+ax_pose 18, 0x81ee, 0x00f0, 0x4c08
+ax_pose 19, 0x01ef, 0x00e8, 0x4c0a
+ax_pose 20, 0x01ee, 0x0110, 0x4c0b
+ax_pose 21, 0x81ee, 0x0108, 0x4c0c
+ax_pose_terminator
+sNoctowlPose14:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose15:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose16:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose17:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose18:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose19:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose20:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose21:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose22:
+ax_pose 8, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose23:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose24:
+ax_pose 10, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose25:
+ax_pose 0, 0x41e8, 0x80f0, 0x4c00
+ax_pose 1, 0x41f8, 0x40f0, 0x4c08
+ax_pose 2, 0x01ee, 0x00e8, 0x4c0c
+ax_pose 3, 0x01ee, 0x0110, 0x4c0d
+ax_pose_terminator
+sNoctowlPose26:
+ax_pose 4, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose27:
+ax_pose 5, 0x41f1, 0x80f0, 0x4c00
+ax_pose 6, 0x41e9, 0x00f8, 0x4c08
+ax_pose 7, 0x01fb, 0x00e8, 0x4c0a
+ax_pose_terminator
+sNoctowlPose28:
+ax_pose 8, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose29:
+ax_pose 9, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose30:
+ax_pose 10, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose31:
+ax_pose 11, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose32:
+ax_pose 12, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose33:
+ax_pose 13, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose34:
+ax_pose 14, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose35:
+ax_pose 15, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose36:
+ax_pose 16, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose37:
+ax_pose 17, 0x81e6, 0x80f8, 0x4c00
+ax_pose 18, 0x81ee, 0x00f0, 0x4c08
+ax_pose 19, 0x01ef, 0x00e8, 0x4c0a
+ax_pose 20, 0x01ee, 0x0110, 0x4c0b
+ax_pose 21, 0x81ee, 0x0108, 0x4c0c
+ax_pose_terminator
+sNoctowlPose38:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose39:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose40:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose41:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose42:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose43:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose44:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose45:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose46:
+ax_pose 8, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose47:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose48:
+ax_pose 10, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose49:
+ax_pose 0, 0x41e8, 0x80f0, 0x4c00
+ax_pose 1, 0x41f8, 0x40f0, 0x4c08
+ax_pose 2, 0x01ee, 0x00e8, 0x4c0c
+ax_pose 3, 0x01ee, 0x0110, 0x4c0d
+ax_pose_terminator
+sNoctowlPose50:
+ax_pose 4, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose51:
+ax_pose 5, 0x41f1, 0x80f0, 0x4c00
+ax_pose 6, 0x41e9, 0x00f8, 0x4c08
+ax_pose 7, 0x01fb, 0x00e8, 0x4c0a
+ax_pose_terminator
+sNoctowlPose52:
+ax_pose 8, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose53:
+ax_pose 9, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose54:
+ax_pose 10, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose55:
+ax_pose 11, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose56:
+ax_pose 12, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose57:
+ax_pose 13, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose58:
+ax_pose 14, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose59:
+ax_pose 15, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose60:
+ax_pose 16, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose61:
+ax_pose 17, 0x81e6, 0x80f8, 0x4c00
+ax_pose 18, 0x81ee, 0x00f0, 0x4c08
+ax_pose 19, 0x01ef, 0x00e8, 0x4c0a
+ax_pose 20, 0x01ee, 0x0110, 0x4c0b
+ax_pose 21, 0x81ee, 0x0108, 0x4c0c
+ax_pose_terminator
+sNoctowlPose62:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose63:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose64:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose65:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose66:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose67:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose68:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose69:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose70:
+ax_pose 8, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose71:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose72:
+ax_pose 10, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose73:
+ax_pose 0, 0x41e8, 0x80f0, 0x4c00
+ax_pose 1, 0x41f8, 0x40f0, 0x4c08
+ax_pose 2, 0x01ee, 0x00e8, 0x4c0c
+ax_pose 3, 0x01ee, 0x0110, 0x4c0d
+ax_pose_terminator
+sNoctowlPose74:
+ax_pose 4, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose75:
+ax_pose 5, 0x41f1, 0x80f0, 0x4c00
+ax_pose 6, 0x41e9, 0x00f8, 0x4c08
+ax_pose 7, 0x01fb, 0x00e8, 0x4c0a
+ax_pose_terminator
+sNoctowlPose76:
+ax_pose 8, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose77:
+ax_pose 9, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose78:
+ax_pose 10, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose79:
+ax_pose 11, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose80:
+ax_pose 12, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose81:
+ax_pose 13, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose82:
+ax_pose 14, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose83:
+ax_pose 15, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose84:
+ax_pose 16, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose85:
+ax_pose 17, 0x81e6, 0x80f8, 0x4c00
+ax_pose 18, 0x81ee, 0x00f0, 0x4c08
+ax_pose 19, 0x01ef, 0x00e8, 0x4c0a
+ax_pose 20, 0x01ee, 0x0110, 0x4c0b
+ax_pose 21, 0x81ee, 0x0108, 0x4c0c
+ax_pose_terminator
+sNoctowlPose86:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose87:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose88:
+ax_pose 14, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose89:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose90:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose91:
+ax_pose 11, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose92:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose93:
+ax_pose 13, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose94:
+ax_pose 8, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose95:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose96:
+ax_pose 10, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose97:
+ax_pose 24, 0x01e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose98:
+ax_pose 0, 0x41ea, 0x80f0, 0x4c00
+ax_pose 1, 0x41fa, 0x40f0, 0x4c08
+ax_pose 2, 0x01f0, 0x00e8, 0x4c0c
+ax_pose 3, 0x01f0, 0x0110, 0x4c0d
+ax_pose_terminator
+sNoctowlPose99:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose100:
+ax_pose 5, 0x41f2, 0x80f0, 0x4c00
+ax_pose 6, 0x41ea, 0x00f8, 0x4c08
+ax_pose 7, 0x01fc, 0x00e8, 0x4c0a
+ax_pose_terminator
+sNoctowlPose101:
+ax_pose 25, 0x41f7, 0x40ef, 0x4c00
+ax_pose 26, 0x41e7, 0x80ef, 0x4c04
+ax_pose 27, 0x41ff, 0x00f7, 0x4c0c
+ax_pose 28, 0x01ea, 0x010f, 0x4c0e
+ax_pose_terminator
+sNoctowlPose102:
+ax_pose 29, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sNoctowlPose103:
+ax_pose 8, 0x01ea, 0x90f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose104:
+ax_pose 9, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose105:
+ax_pose 10, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sNoctowlPose106:
+ax_pose 30, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sNoctowlPose107:
+ax_pose 31, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose108:
+ax_pose 11, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose109:
+ax_pose 12, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose110:
+ax_pose 13, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose111:
+ax_pose 32, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose112:
+ax_pose 33, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose113:
+ax_pose 14, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose114:
+ax_pose 15, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose115:
+ax_pose 16, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose116:
+ax_pose 34, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose117:
+ax_pose 35, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose118:
+ax_pose 17, 0x81e6, 0x80f8, 0x4c00
+ax_pose 18, 0x81ee, 0x00f0, 0x4c08
+ax_pose 19, 0x01ef, 0x00e8, 0x4c0a
+ax_pose 20, 0x01ee, 0x0110, 0x4c0b
+ax_pose 21, 0x81ee, 0x0108, 0x4c0c
+ax_pose_terminator
+sNoctowlPose119:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose120:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose121:
+ax_pose 36, 0x41e5, 0x80f1, 0x4c00
+ax_pose 37, 0x41f5, 0x40f1, 0x4c08
+ax_pose 38, 0x41fd, 0x00f9, 0x4c0c
+ax_pose 39, 0x01e9, 0x00e9, 0x4c0e
+ax_pose_terminator
+sNoctowlPose122:
+ax_pose 33, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose123:
+ax_pose 14, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose124:
+ax_pose 15, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose125:
+ax_pose 16, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose126:
+ax_pose 34, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose127:
+ax_pose 31, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose128:
+ax_pose 11, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose129:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose130:
+ax_pose 13, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose131:
+ax_pose 32, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose132:
+ax_pose 29, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose133:
+ax_pose 8, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose134:
+ax_pose 9, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose135:
+ax_pose 10, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose136:
+ax_pose 30, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose137:
+ax_pose 40, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose138:
+ax_pose 41, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose139:
+ax_pose 42, 0x01e1, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose140:
+ax_pose 43, 0x01e3, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose141:
+ax_pose 44, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose142:
+ax_pose 45, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose143:
+ax_pose 46, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose144:
+ax_pose 45, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose145:
+ax_pose 44, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose146:
+ax_pose 43, 0x01e3, 0x80f6, 0x4c00
+ax_pose_terminator
+sNoctowlPose147:
+ax_pose 24, 0x01e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose148:
+ax_pose 0, 0x41e6, 0x80f0, 0x4c00
+ax_pose 1, 0x41f6, 0x40f0, 0x4c08
+ax_pose 2, 0x01ec, 0x00e8, 0x4c0c
+ax_pose 3, 0x01ec, 0x0110, 0x4c0d
+ax_pose_terminator
+sNoctowlPose149:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose150:
+ax_pose 5, 0x41ef, 0x80f0, 0x4c00
+ax_pose 6, 0x41e7, 0x00f8, 0x4c08
+ax_pose 7, 0x01f9, 0x00e8, 0x4c0a
+ax_pose_terminator
+sNoctowlPose151:
+ax_pose 29, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sNoctowlPose152:
+ax_pose 8, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sNoctowlPose153:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sNoctowlPose154:
+ax_pose 10, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose155:
+ax_pose 31, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose156:
+ax_pose 11, 0x01e9, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose157:
+ax_pose 12, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose158:
+ax_pose 13, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose159:
+ax_pose 33, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose160:
+ax_pose 14, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose161:
+ax_pose 15, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose162:
+ax_pose 16, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose163:
+ax_pose 35, 0x81e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose164:
+ax_pose 17, 0x81e6, 0x80f8, 0x4c00
+ax_pose 18, 0x81ee, 0x00f0, 0x4c08
+ax_pose 19, 0x01ef, 0x00e8, 0x4c0a
+ax_pose 20, 0x01ee, 0x0110, 0x4c0b
+ax_pose 21, 0x81ee, 0x0108, 0x4c0c
+ax_pose_terminator
+sNoctowlPose165:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose166:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose167:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose168:
+ax_pose 14, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose169:
+ax_pose 15, 0x01e5, 0x80f5, 0x4c00
+ax_pose_terminator
+sNoctowlPose170:
+ax_pose 16, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose171:
+ax_pose 31, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose172:
+ax_pose 11, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose173:
+ax_pose 12, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose174:
+ax_pose 13, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose175:
+ax_pose 29, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose176:
+ax_pose 8, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose177:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sNoctowlPose178:
+ax_pose 10, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose179:
+ax_pose 4, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose180:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose181:
+ax_pose 12, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose182:
+ax_pose 15, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose183:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose184:
+ax_pose 15, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose185:
+ax_pose 12, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose186:
+ax_pose 9, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose187:
+ax_pose 25, 0x41f7, 0x40ef, 0x4c00
+ax_pose 26, 0x41e7, 0x80ef, 0x4c04
+ax_pose 27, 0x41ff, 0x00f7, 0x4c0c
+ax_pose 28, 0x01ea, 0x010f, 0x4c0e
+ax_pose_terminator
+sNoctowlPose188:
+ax_pose 30, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sNoctowlPose189:
+ax_pose 32, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose190:
+ax_pose 34, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose191:
+ax_pose 36, 0x41e5, 0x80f1, 0x4c00
+ax_pose 37, 0x41f5, 0x40f1, 0x4c08
+ax_pose 38, 0x41fd, 0x00f9, 0x4c0c
+ax_pose 39, 0x01e9, 0x00e9, 0x4c0e
+ax_pose_terminator
+sNoctowlPose192:
+ax_pose 34, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose193:
+ax_pose 32, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose194:
+ax_pose 30, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose195:
+ax_pose 47, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose196:
+ax_pose 0, 0x41e8, 0x80f0, 0x4c00
+ax_pose 1, 0x41f8, 0x40f0, 0x4c08
+ax_pose 2, 0x01ee, 0x00e8, 0x4c0c
+ax_pose 3, 0x01ee, 0x0110, 0x4c0d
+ax_pose_terminator
+sNoctowlPose197:
+ax_pose 4, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose198:
+ax_pose 5, 0x41f3, 0x80f0, 0x4c00
+ax_pose 6, 0x41eb, 0x00f8, 0x4c08
+ax_pose 7, 0x01fd, 0x00e8, 0x4c0a
+ax_pose_terminator
+sNoctowlPose199:
+ax_pose 29, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose200:
+ax_pose 8, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose201:
+ax_pose 9, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sNoctowlPose202:
+ax_pose 10, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose203:
+ax_pose 31, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose204:
+ax_pose 11, 0x01e9, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose205:
+ax_pose 12, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose206:
+ax_pose 13, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose207:
+ax_pose 33, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose208:
+ax_pose 14, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose209:
+ax_pose 15, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sNoctowlPose210:
+ax_pose 16, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose211:
+ax_pose 35, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose212:
+ax_pose 17, 0x81e6, 0x80f8, 0x4c00
+ax_pose 18, 0x81ee, 0x00f0, 0x4c08
+ax_pose 19, 0x01ef, 0x00e8, 0x4c0a
+ax_pose 20, 0x01ee, 0x0110, 0x4c0b
+ax_pose 21, 0x81ee, 0x0108, 0x4c0c
+ax_pose_terminator
+sNoctowlPose213:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose214:
+ax_pose 23, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose215:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose216:
+ax_pose 14, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose217:
+ax_pose 15, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose218:
+ax_pose 16, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose219:
+ax_pose 31, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose220:
+ax_pose 11, 0x01e9, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose221:
+ax_pose 12, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose222:
+ax_pose 13, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose223:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose224:
+ax_pose 8, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose225:
+ax_pose 9, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sNoctowlPose226:
+ax_pose 10, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose227:
+ax_pose 25, 0x41f7, 0x40ef, 0x4c00
+ax_pose 26, 0x41e7, 0x80ef, 0x4c04
+ax_pose 27, 0x41ff, 0x00f7, 0x4c0c
+ax_pose 28, 0x01ea, 0x010f, 0x4c0e
+ax_pose_terminator
+sNoctowlPose228:
+ax_pose 30, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sNoctowlPose229:
+ax_pose 32, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose230:
+ax_pose 34, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose231:
+ax_pose 36, 0x41e5, 0x80f1, 0x4c00
+ax_pose 37, 0x41f5, 0x40f1, 0x4c08
+ax_pose 38, 0x41fd, 0x00f9, 0x4c0c
+ax_pose 39, 0x01e9, 0x00e9, 0x4c0e
+ax_pose_terminator
+sNoctowlPose232:
+ax_pose 34, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sNoctowlPose233:
+ax_pose 32, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sNoctowlPose234:
+ax_pose 30, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose235:
+ax_pose 47, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose236:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose237:
+ax_pose 31, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sNoctowlPose238:
+ax_pose 33, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sNoctowlPose239:
+ax_pose 35, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sNoctowlPose240:
+ax_pose 33, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sNoctowlPose241:
+ax_pose 31, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sNoctowlPose242:
+ax_pose 29, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+.align 2
+sNoctowlAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 1, 25, 1, 22, 1, 22,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 0, 25, 1, 22, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNoctowlAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 22, 22, 22, 22,
+ax_anim 2, 1, 28, 23, 21, 23, 21,
+ax_anim 2, 0, 28, 22, 22, 22, 22,
+ax_anim 2, 0, 28, 23, 21, 23, 21,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sNoctowlAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sNoctowlAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 4, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 34, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 22, -17, 22, -17,
+ax_anim 2, 1, 34, 23, -16, 23, -16,
+ax_anim 2, 0, 34, 22, -17, 22, -17,
+ax_anim 2, 0, 34, 23, -16, 23, -16,
+ax_anim 2, 0, 33, 5, -6, 5, -6,
+ax_anim_terminator
+sNoctowlAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 4, 0, 38, 0, 4, 0, 4,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 1, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 0, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sNoctowlAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 4, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 40, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -22, -17, -22, -17,
+ax_anim 2, 1, 40, -23, -16, -23, -16,
+ax_anim 2, 0, 40, -22, -17, -22, -17,
+ax_anim 2, 0, 40, -23, -16, -23, -16,
+ax_anim 2, 0, 39, -5, -6, -5, -6,
+ax_anim_terminator
+sNoctowlAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 4, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sNoctowlAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -22, 22, -22, 22,
+ax_anim 2, 1, 46, -23, 21, -23, 21,
+ax_anim 2, 0, 46, -22, 22, -22, 22,
+ax_anim 2, 0, 46, -23, 21, -23, 21,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 1, 49, 1, 22, 1, 22,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 49, 1, 22, 1, 22,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sNoctowlAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 4, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 22, 22, 22, 22,
+ax_anim 2, 1, 52, 23, 21, 23, 21,
+ax_anim 2, 0, 52, 22, 22, 22, 22,
+ax_anim 2, 0, 52, 23, 21, 23, 21,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sNoctowlAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 4, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sNoctowlAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 4, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 5, -6, 5, -6,
+ax_anim 1, 0, 58, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 22, -17, 22, -17,
+ax_anim 2, 1, 58, 23, -16, 23, -16,
+ax_anim 2, 0, 58, 22, -17, 22, -17,
+ax_anim 2, 0, 58, 23, -16, 23, -16,
+ax_anim 2, 0, 57, 5, -6, 5, -6,
+ax_anim_terminator
+sNoctowlAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 4, 0, 62, 0, 4, 0, 4,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -17, 0, -17,
+ax_anim 2, 1, 61, 1, -17, 1, -17,
+ax_anim 2, 0, 61, 0, -17, 0, -17,
+ax_anim 2, 0, 61, 1, -17, 1, -17,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sNoctowlAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 4, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -5, -6, -5, -6,
+ax_anim 1, 0, 64, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -22, -17, -22, -17,
+ax_anim 2, 1, 64, -23, -16, -23, -16,
+ax_anim 2, 0, 64, -22, -17, -22, -17,
+ax_anim 2, 0, 64, -23, -16, -23, -16,
+ax_anim 2, 0, 63, -5, -6, -5, -6,
+ax_anim_terminator
+sNoctowlAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 4, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sNoctowlAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 4, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -22, 22, -22, 22,
+ax_anim 2, 1, 70, -23, 21, -23, 21,
+ax_anim 2, 0, 70, -22, 22, -22, 22,
+ax_anim 2, 0, 70, -23, 21, -23, 21,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_4_1:
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_4_2:
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_4_3:
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_4_4:
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_4_5:
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_4_6:
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_4_7:
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_4_8:
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_5_1:
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 1, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim_terminator
+sNoctowlAnims_5_2:
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 8, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim_terminator
+sNoctowlAnims_5_3:
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 8, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, -1,
+ax_anim_terminator
+sNoctowlAnims_5_4:
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 8, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim_terminator
+sNoctowlAnims_5_5:
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 8, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim_terminator
+sNoctowlAnims_5_6:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 8, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim_terminator
+sNoctowlAnims_5_7:
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 1, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim_terminator
+sNoctowlAnims_5_8:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sNoctowlAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sNoctowlAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sNoctowlAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sNoctowlAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sNoctowlAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sNoctowlAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sNoctowlAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 3, 0, 0,
+ax_anim 2, 0, 147, 0, 3, 0, 0,
+ax_anim 6, 0, 148, 0, 3, 0, 0,
+ax_anim 1, 0, 149, 0, 1, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 3, 0, 147, 0, -5, 0, 0,
+ax_anim 6, 0, 148, 0, -7, 0, 0,
+ax_anim 3, 0, 147, 0, -5, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, 0,
+ax_anim 2, 0, 149, 0, -8, 0, 0,
+ax_anim 2, 0, 149, 0, -9, 0, 0,
+ax_anim 3, 0, 147, 0, -9, 0, 0,
+ax_anim 3, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -6, 0, 0,
+ax_anim 2, 0, 147, 0, -4, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_8_2:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 3, 0, 0,
+ax_anim 2, 0, 151, 0, 3, 0, 0,
+ax_anim 6, 0, 152, 0, 3, 0, 0,
+ax_anim 1, 0, 153, 0, 1, 0, 0,
+ax_anim 2, 0, 153, 0, -3, 0, 0,
+ax_anim 3, 0, 151, 0, -5, 0, 0,
+ax_anim 6, 0, 152, 0, -7, 0, 0,
+ax_anim 3, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 153, 0, -6, 0, 0,
+ax_anim 2, 0, 153, 0, -8, 0, 0,
+ax_anim 2, 0, 153, 0, -9, 0, 0,
+ax_anim 3, 0, 151, 0, -9, 0, 0,
+ax_anim 3, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -6, 0, 0,
+ax_anim 2, 0, 151, 0, -4, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_8_3:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 3, 0, 0,
+ax_anim 2, 0, 155, 0, 3, 0, 0,
+ax_anim 6, 0, 156, 0, 3, 0, 0,
+ax_anim 1, 0, 157, 0, 1, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 3, 0, 155, 0, -5, 0, 0,
+ax_anim 6, 0, 156, 0, -7, 0, 0,
+ax_anim 3, 0, 155, 0, -5, 0, 0,
+ax_anim 2, 0, 157, 0, -6, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -9, 0, 0,
+ax_anim 3, 0, 155, 0, -9, 0, 0,
+ax_anim 3, 0, 155, 0, -8, 0, 0,
+ax_anim 2, 0, 155, 0, -6, 0, 0,
+ax_anim 2, 0, 155, 0, -4, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_8_4:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 3, 0, 0,
+ax_anim 2, 0, 159, 0, 3, 0, 0,
+ax_anim 6, 0, 160, 0, 3, 0, 0,
+ax_anim 1, 0, 161, 0, 1, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 3, 0, 159, 0, -5, 0, 0,
+ax_anim 6, 0, 160, 0, -7, 0, 0,
+ax_anim 3, 0, 159, 0, -5, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -9, 0, 0,
+ax_anim 3, 0, 159, 0, -9, 0, 0,
+ax_anim 3, 0, 159, 0, -8, 0, 0,
+ax_anim 2, 0, 159, 0, -6, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_8_5:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 3, 0, 0,
+ax_anim 2, 0, 163, 0, 3, 0, 0,
+ax_anim 6, 0, 164, 0, 3, 0, 0,
+ax_anim 1, 0, 165, 0, 1, 0, 0,
+ax_anim 2, 0, 165, 0, -3, 0, 0,
+ax_anim 3, 0, 163, 0, -5, 0, 0,
+ax_anim 6, 0, 164, 0, -7, 0, 0,
+ax_anim 3, 0, 163, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -6, 0, 0,
+ax_anim 2, 0, 165, 0, -8, 0, 0,
+ax_anim 2, 0, 165, 0, -9, 0, 0,
+ax_anim 3, 0, 163, 0, -9, 0, 0,
+ax_anim 3, 0, 163, 0, -8, 0, 0,
+ax_anim 2, 0, 163, 0, -6, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_8_6:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 3, 0, 0,
+ax_anim 2, 0, 167, 0, 3, 0, 0,
+ax_anim 6, 0, 168, 0, 3, 0, 0,
+ax_anim 1, 0, 169, 0, 1, 0, 0,
+ax_anim 2, 0, 169, 0, -3, 0, 0,
+ax_anim 3, 0, 167, 0, -5, 0, 0,
+ax_anim 6, 0, 168, 0, -7, 0, 0,
+ax_anim 3, 0, 167, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -6, 0, 0,
+ax_anim 2, 0, 169, 0, -8, 0, 0,
+ax_anim 2, 0, 169, 0, -9, 0, 0,
+ax_anim 3, 0, 167, 0, -9, 0, 0,
+ax_anim 3, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -6, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_8_7:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 3, 0, 0,
+ax_anim 2, 0, 171, 0, 3, 0, 0,
+ax_anim 6, 0, 172, 0, 3, 0, 0,
+ax_anim 1, 0, 173, 0, 1, 0, 0,
+ax_anim 2, 0, 173, 0, -3, 0, 0,
+ax_anim 3, 0, 171, 0, -5, 0, 0,
+ax_anim 6, 0, 172, 0, -7, 0, 0,
+ax_anim 3, 0, 171, 0, -5, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, 0,
+ax_anim 2, 0, 173, 0, -8, 0, 0,
+ax_anim 2, 0, 173, 0, -9, 0, 0,
+ax_anim 3, 0, 171, 0, -9, 0, 0,
+ax_anim 3, 0, 171, 0, -8, 0, 0,
+ax_anim 2, 0, 171, 0, -6, 0, 0,
+ax_anim 2, 0, 171, 0, -4, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_8_8:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 3, 0, 0,
+ax_anim 2, 0, 175, 0, 3, 0, 0,
+ax_anim 6, 0, 176, 0, 3, 0, 0,
+ax_anim 1, 0, 177, 0, 1, 0, 0,
+ax_anim 2, 0, 177, 0, -3, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 6, 0, 176, 0, -7, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 177, 0, -6, 0, 0,
+ax_anim 2, 0, 177, 0, -8, 0, 0,
+ax_anim 2, 0, 177, 0, -9, 0, 0,
+ax_anim 3, 0, 175, 0, -9, 0, 0,
+ax_anim 3, 0, 175, 0, -8, 0, 0,
+ax_anim 2, 0, 175, 0, -6, 0, 0,
+ax_anim 2, 0, 175, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 17, 7, 17,
+ax_anim 3, 0, 182, 0, 21, 0, 21,
+ax_anim 2, 3, 183, -7, 17, -7, 17,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 18, 5, 18, 5,
+ax_anim 2, 0, 180, 20, 13, 20, 13,
+ax_anim 3, 0, 181, 21, 22, 21, 22,
+ax_anim 2, 3, 182, 13, 22, 13, 22,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 16, -5, 16, -5,
+ax_anim 3, 0, 180, 20, 0, 20, 0,
+ax_anim 2, 3, 181, 18, 4, 18, 4,
+ax_anim 2, 0, 182, 12, 5, 12, 5,
+ax_anim 1, 0, 183, 4, 3, 4, 3,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -8, -1, -8,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 22, -18, 22, -18,
+ax_anim 2, 3, 180, 20, -12, 20, -12,
+ax_anim 2, 0, 181, 17, -4, 17, -4,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -12, -9, -12,
+ax_anim 2, 0, 185, -7, -17, -7, -17,
+ax_anim 3, 0, 178, 0, -19, 0, -19,
+ax_anim 2, 3, 179, 7, -17, 7, -17,
+ax_anim 2, 0, 180, 9, -12, 9, -12,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -8, 1, -8,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -22, -18, -22, -18,
+ax_anim 2, 3, 184, -20, -12, -20, -12,
+ax_anim 2, 0, 183, -17, -4, -17, -4,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -16, -5, -16, -5,
+ax_anim 3, 0, 184, -20, 0, -20, 0,
+ax_anim 2, 3, 183, -18, 4, -18, 4,
+ax_anim 2, 0, 182, -12, 5, -12, 5,
+ax_anim 1, 0, 181, -4, 3, -4, 3,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -18, 5, -18, 5,
+ax_anim 2, 0, 184, -20, 13, -20, 13,
+ax_anim 3, 0, 183, -21, 22, -21, 22,
+ax_anim 2, 3, 182, -13, 22, -13, 22,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 2, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_11_2:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 3, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_11_3:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 2, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_11_4:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -17, 0, 0,
+ax_anim 1, 0, 208, 0, -11, 0, 0,
+ax_anim 2, 2, 208, 0, 2, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_11_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 2, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_11_6:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -17, 0, 0,
+ax_anim 1, 0, 216, 0, -11, 0, 0,
+ax_anim 2, 2, 216, 0, 2, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_11_7:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 3, 0, 220, 0, -21, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 2, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_11_8:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_12_2:
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_12_3:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_12_4:
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_12_6:
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_12_7:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_12_8:
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNoctowlAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sNoctowlGfx1:
+.incbin "baserom.gba", 0xC34B80, 0x100
+sNoctowlSprites1:
+ax_sprite sNoctowlGfx1, 0x100
+ax_sprite_terminator
+sNoctowlGfx2:
+.incbin "baserom.gba", 0xC34C90, 0x80
+sNoctowlSprites2:
+ax_sprite sNoctowlGfx2, 0x80
+ax_sprite_terminator
+sNoctowlGfx3:
+.incbin "baserom.gba", 0xC34D20, 0x20
+sNoctowlSprites3:
+ax_sprite sNoctowlGfx3, 0x20
+ax_sprite_terminator
+sNoctowlGfx4:
+.incbin "baserom.gba", 0xC34D50, 0x20
+sNoctowlSprites4:
+ax_sprite sNoctowlGfx4, 0x20
+ax_sprite_terminator
+sNoctowlGfx5:
+.incbin "baserom.gba", 0xC34D80, 0x200
+sNoctowlSprites5:
+ax_sprite sNoctowlGfx5, 0x200
+ax_sprite_terminator
+sNoctowlGfx6:
+.incbin "baserom.gba", 0xC34F90, 0x100
+sNoctowlSprites6:
+ax_sprite sNoctowlGfx6, 0x100
+ax_sprite_terminator
+sNoctowlGfx7:
+.incbin "baserom.gba", 0xC350A0, 0x40
+sNoctowlSprites7:
+ax_sprite sNoctowlGfx7, 0x40
+ax_sprite_terminator
+sNoctowlGfx8:
+.incbin "baserom.gba", 0xC350F0, 0x20
+sNoctowlSprites8:
+ax_sprite sNoctowlGfx8, 0x20
+ax_sprite_terminator
+sNoctowlGfx9:
+.incbin "baserom.gba", 0xC35120, 0x200
+sNoctowlSprites9:
+ax_sprite sNoctowlGfx9, 0x200
+ax_sprite_terminator
+sNoctowlGfx10:
+.incbin "baserom.gba", 0xC35330, 0x200
+sNoctowlSprites10:
+ax_sprite sNoctowlGfx10, 0x200
+ax_sprite_terminator
+sNoctowlGfx11:
+.incbin "baserom.gba", 0xC35540, 0x200
+sNoctowlSprites11:
+ax_sprite sNoctowlGfx11, 0x200
+ax_sprite_terminator
+sNoctowlGfx12:
+.incbin "baserom.gba", 0xC35750, 0x200
+sNoctowlSprites12:
+ax_sprite sNoctowlGfx12, 0x200
+ax_sprite_terminator
+sNoctowlGfx13:
+.incbin "baserom.gba", 0xC35960, 0x200
+sNoctowlSprites13:
+ax_sprite sNoctowlGfx13, 0x200
+ax_sprite_terminator
+sNoctowlGfx14:
+.incbin "baserom.gba", 0xC35B70, 0x200
+sNoctowlSprites14:
+ax_sprite sNoctowlGfx14, 0x200
+ax_sprite_terminator
+sNoctowlGfx15:
+.incbin "baserom.gba", 0xC35D80, 0x200
+sNoctowlSprites15:
+ax_sprite sNoctowlGfx15, 0x200
+ax_sprite_terminator
+sNoctowlGfx16:
+.incbin "baserom.gba", 0xC35F90, 0x200
+sNoctowlSprites16:
+ax_sprite sNoctowlGfx16, 0x200
+ax_sprite_terminator
+sNoctowlGfx17:
+.incbin "baserom.gba", 0xC361A0, 0x200
+sNoctowlSprites17:
+ax_sprite sNoctowlGfx17, 0x200
+ax_sprite_terminator
+sNoctowlGfx18:
+.incbin "baserom.gba", 0xC363B0, 0x100
+sNoctowlSprites18:
+ax_sprite sNoctowlGfx18, 0x100
+ax_sprite_terminator
+sNoctowlGfx19:
+.incbin "baserom.gba", 0xC364C0, 0x40
+sNoctowlSprites19:
+ax_sprite sNoctowlGfx19, 0x40
+ax_sprite_terminator
+sNoctowlGfx20:
+.incbin "baserom.gba", 0xC36510, 0x20
+sNoctowlSprites20:
+ax_sprite sNoctowlGfx20, 0x20
+ax_sprite_terminator
+sNoctowlGfx21:
+.incbin "baserom.gba", 0xC36540, 0x20
+sNoctowlSprites21:
+ax_sprite sNoctowlGfx21, 0x20
+ax_sprite_terminator
+sNoctowlGfx22:
+.incbin "baserom.gba", 0xC36570, 0x40
+sNoctowlSprites22:
+ax_sprite sNoctowlGfx22, 0x40
+ax_sprite_terminator
+sNoctowlGfx23:
+.incbin "baserom.gba", 0xC365C0, 0x200
+sNoctowlSprites23:
+ax_sprite sNoctowlGfx23, 0x200
+ax_sprite_terminator
+sNoctowlGfx24:
+.incbin "baserom.gba", 0xC367D0, 0x200
+sNoctowlSprites24:
+ax_sprite sNoctowlGfx24, 0x200
+ax_sprite_terminator
+sNoctowlGfx25:
+.incbin "baserom.gba", 0xC369E0, 0x40
+sNoctowlGfx25_1:
+.incbin "baserom.gba", 0xC36A20, 0x40
+sNoctowlGfx25_2:
+.incbin "baserom.gba", 0xC36A60, 0x40
+sNoctowlGfx25_3:
+.incbin "baserom.gba", 0xC36AA0, 0x40
+sNoctowlSprites25:
+ax_sprite sNoctowlGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx25_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx25_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNoctowlGfx26:
+.incbin "baserom.gba", 0xC36B28, 0x80
+sNoctowlSprites26:
+ax_sprite sNoctowlGfx26, 0x80
+ax_sprite_terminator
+sNoctowlGfx27:
+.incbin "baserom.gba", 0xC36BB8, 0x100
+sNoctowlSprites27:
+ax_sprite sNoctowlGfx27, 0x100
+ax_sprite_terminator
+sNoctowlGfx28:
+.incbin "baserom.gba", 0xC36CC8, 0x40
+sNoctowlSprites28:
+ax_sprite sNoctowlGfx28, 0x40
+ax_sprite_terminator
+sNoctowlGfx29:
+.incbin "baserom.gba", 0xC36D18, 0x20
+sNoctowlSprites29:
+ax_sprite sNoctowlGfx29, 0x20
+ax_sprite_terminator
+sNoctowlGfx30:
+.incbin "baserom.gba", 0xC36D48, 0x60
+sNoctowlGfx30_1:
+.incbin "baserom.gba", 0xC36DA8, 0x60
+sNoctowlGfx30_2:
+.incbin "baserom.gba", 0xC36E08, 0x40
+sNoctowlGfx30_3:
+.incbin "baserom.gba", 0xC36E48, 0x40
+sNoctowlSprites30:
+ax_sprite sNoctowlGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNoctowlGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx30_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNoctowlGfx31:
+.incbin "baserom.gba", 0xC36ED0, 0x180
+sNoctowlGfx31_1:
+.incbin "baserom.gba", 0xC37050, 0x40
+sNoctowlSprites31:
+ax_sprite sNoctowlGfx31, 0x180
+ax_sprite 0, 0x20
+ax_sprite sNoctowlGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNoctowlGfx32:
+.incbin "baserom.gba", 0xC370B8, 0x60
+sNoctowlGfx32_1:
+.incbin "baserom.gba", 0xC37118, 0x60
+sNoctowlGfx32_2:
+.incbin "baserom.gba", 0xC37178, 0x40
+sNoctowlGfx32_3:
+.incbin "baserom.gba", 0xC371B8, 0x60
+sNoctowlSprites32:
+ax_sprite sNoctowlGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNoctowlGfx32_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNoctowlGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNoctowlGfx33:
+.incbin "baserom.gba", 0xC37260, 0x180
+sNoctowlGfx33_1:
+.incbin "baserom.gba", 0xC373E0, 0x40
+sNoctowlSprites33:
+ax_sprite sNoctowlGfx33, 0x180
+ax_sprite 0, 0x20
+ax_sprite sNoctowlGfx33_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNoctowlGfx34:
+.incbin "baserom.gba", 0xC37448, 0x40
+sNoctowlGfx34_1:
+.incbin "baserom.gba", 0xC37488, 0x60
+sNoctowlGfx34_2:
+.incbin "baserom.gba", 0xC374E8, 0x40
+sNoctowlGfx34_3:
+.incbin "baserom.gba", 0xC37528, 0x40
+sNoctowlSprites34:
+ax_sprite 0, 0x20
+ax_sprite sNoctowlGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNoctowlGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNoctowlGfx35:
+.incbin "baserom.gba", 0xC375B8, 0x160
+sNoctowlGfx35_1:
+.incbin "baserom.gba", 0xC37718, 0x40
+sNoctowlSprites35:
+ax_sprite sNoctowlGfx35, 0x160
+ax_sprite 0, 0x40
+ax_sprite sNoctowlGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNoctowlGfx36:
+.incbin "baserom.gba", 0xC37780, 0x100
+sNoctowlSprites36:
+ax_sprite sNoctowlGfx36, 0x100
+ax_sprite_terminator
+sNoctowlGfx37:
+.incbin "baserom.gba", 0xC37890, 0x100
+sNoctowlSprites37:
+ax_sprite sNoctowlGfx37, 0x100
+ax_sprite_terminator
+sNoctowlGfx38:
+.incbin "baserom.gba", 0xC379A0, 0x80
+sNoctowlSprites38:
+ax_sprite sNoctowlGfx38, 0x80
+ax_sprite_terminator
+sNoctowlGfx39:
+.incbin "baserom.gba", 0xC37A30, 0x40
+sNoctowlSprites39:
+ax_sprite sNoctowlGfx39, 0x40
+ax_sprite_terminator
+sNoctowlGfx40:
+.incbin "baserom.gba", 0xC37A80, 0x20
+sNoctowlSprites40:
+ax_sprite sNoctowlGfx40, 0x20
+ax_sprite_terminator
+sNoctowlGfx41:
+.incbin "baserom.gba", 0xC37AB0, 0x200
+sNoctowlSprites41:
+ax_sprite sNoctowlGfx41, 0x200
+ax_sprite_terminator
+sNoctowlGfx42:
+.incbin "baserom.gba", 0xC37CC0, 0x200
+sNoctowlSprites42:
+ax_sprite sNoctowlGfx42, 0x200
+ax_sprite_terminator
+sNoctowlGfx43:
+.incbin "baserom.gba", 0xC37ED0, 0x200
+sNoctowlSprites43:
+ax_sprite sNoctowlGfx43, 0x200
+ax_sprite_terminator
+sNoctowlGfx44:
+.incbin "baserom.gba", 0xC380E0, 0x200
+sNoctowlSprites44:
+ax_sprite sNoctowlGfx44, 0x200
+ax_sprite_terminator
+sNoctowlGfx45:
+.incbin "baserom.gba", 0xC382F0, 0x200
+sNoctowlSprites45:
+ax_sprite sNoctowlGfx45, 0x200
+ax_sprite_terminator
+sNoctowlGfx46:
+.incbin "baserom.gba", 0xC38500, 0x200
+sNoctowlSprites46:
+ax_sprite sNoctowlGfx46, 0x200
+ax_sprite_terminator
+sNoctowlGfx47:
+.incbin "baserom.gba", 0xC38710, 0x200
+sNoctowlSprites47:
+ax_sprite sNoctowlGfx47, 0x200
+ax_sprite_terminator
+sNoctowlGfx48:
+.incbin "baserom.gba", 0xC38920, 0x100
+sNoctowlSprites48:
+ax_sprite sNoctowlGfx48, 0x100
+ax_sprite_terminator
+sAxPosesNoctowl:
+.4byte sNoctowlPose1
+.4byte sNoctowlPose2
+.4byte sNoctowlPose3
+.4byte sNoctowlPose4
+.4byte sNoctowlPose5
+.4byte sNoctowlPose6
+.4byte sNoctowlPose7
+.4byte sNoctowlPose8
+.4byte sNoctowlPose9
+.4byte sNoctowlPose10
+.4byte sNoctowlPose11
+.4byte sNoctowlPose12
+.4byte sNoctowlPose13
+.4byte sNoctowlPose14
+.4byte sNoctowlPose15
+.4byte sNoctowlPose16
+.4byte sNoctowlPose17
+.4byte sNoctowlPose18
+.4byte sNoctowlPose19
+.4byte sNoctowlPose20
+.4byte sNoctowlPose21
+.4byte sNoctowlPose22
+.4byte sNoctowlPose23
+.4byte sNoctowlPose24
+.4byte sNoctowlPose25
+.4byte sNoctowlPose26
+.4byte sNoctowlPose27
+.4byte sNoctowlPose28
+.4byte sNoctowlPose29
+.4byte sNoctowlPose30
+.4byte sNoctowlPose31
+.4byte sNoctowlPose32
+.4byte sNoctowlPose33
+.4byte sNoctowlPose34
+.4byte sNoctowlPose35
+.4byte sNoctowlPose36
+.4byte sNoctowlPose37
+.4byte sNoctowlPose38
+.4byte sNoctowlPose39
+.4byte sNoctowlPose40
+.4byte sNoctowlPose41
+.4byte sNoctowlPose42
+.4byte sNoctowlPose43
+.4byte sNoctowlPose44
+.4byte sNoctowlPose45
+.4byte sNoctowlPose46
+.4byte sNoctowlPose47
+.4byte sNoctowlPose48
+.4byte sNoctowlPose49
+.4byte sNoctowlPose50
+.4byte sNoctowlPose51
+.4byte sNoctowlPose52
+.4byte sNoctowlPose53
+.4byte sNoctowlPose54
+.4byte sNoctowlPose55
+.4byte sNoctowlPose56
+.4byte sNoctowlPose57
+.4byte sNoctowlPose58
+.4byte sNoctowlPose59
+.4byte sNoctowlPose60
+.4byte sNoctowlPose61
+.4byte sNoctowlPose62
+.4byte sNoctowlPose63
+.4byte sNoctowlPose64
+.4byte sNoctowlPose65
+.4byte sNoctowlPose66
+.4byte sNoctowlPose67
+.4byte sNoctowlPose68
+.4byte sNoctowlPose69
+.4byte sNoctowlPose70
+.4byte sNoctowlPose71
+.4byte sNoctowlPose72
+.4byte sNoctowlPose73
+.4byte sNoctowlPose74
+.4byte sNoctowlPose75
+.4byte sNoctowlPose76
+.4byte sNoctowlPose77
+.4byte sNoctowlPose78
+.4byte sNoctowlPose79
+.4byte sNoctowlPose80
+.4byte sNoctowlPose81
+.4byte sNoctowlPose82
+.4byte sNoctowlPose83
+.4byte sNoctowlPose84
+.4byte sNoctowlPose85
+.4byte sNoctowlPose86
+.4byte sNoctowlPose87
+.4byte sNoctowlPose88
+.4byte sNoctowlPose89
+.4byte sNoctowlPose90
+.4byte sNoctowlPose91
+.4byte sNoctowlPose92
+.4byte sNoctowlPose93
+.4byte sNoctowlPose94
+.4byte sNoctowlPose95
+.4byte sNoctowlPose96
+.4byte sNoctowlPose97
+.4byte sNoctowlPose98
+.4byte sNoctowlPose99
+.4byte sNoctowlPose100
+.4byte sNoctowlPose101
+.4byte sNoctowlPose102
+.4byte sNoctowlPose103
+.4byte sNoctowlPose104
+.4byte sNoctowlPose105
+.4byte sNoctowlPose106
+.4byte sNoctowlPose107
+.4byte sNoctowlPose108
+.4byte sNoctowlPose109
+.4byte sNoctowlPose110
+.4byte sNoctowlPose111
+.4byte sNoctowlPose112
+.4byte sNoctowlPose113
+.4byte sNoctowlPose114
+.4byte sNoctowlPose115
+.4byte sNoctowlPose116
+.4byte sNoctowlPose117
+.4byte sNoctowlPose118
+.4byte sNoctowlPose119
+.4byte sNoctowlPose120
+.4byte sNoctowlPose121
+.4byte sNoctowlPose122
+.4byte sNoctowlPose123
+.4byte sNoctowlPose124
+.4byte sNoctowlPose125
+.4byte sNoctowlPose126
+.4byte sNoctowlPose127
+.4byte sNoctowlPose128
+.4byte sNoctowlPose129
+.4byte sNoctowlPose130
+.4byte sNoctowlPose131
+.4byte sNoctowlPose132
+.4byte sNoctowlPose133
+.4byte sNoctowlPose134
+.4byte sNoctowlPose135
+.4byte sNoctowlPose136
+.4byte sNoctowlPose137
+.4byte sNoctowlPose138
+.4byte sNoctowlPose139
+.4byte sNoctowlPose140
+.4byte sNoctowlPose141
+.4byte sNoctowlPose142
+.4byte sNoctowlPose143
+.4byte sNoctowlPose144
+.4byte sNoctowlPose145
+.4byte sNoctowlPose146
+.4byte sNoctowlPose147
+.4byte sNoctowlPose148
+.4byte sNoctowlPose149
+.4byte sNoctowlPose150
+.4byte sNoctowlPose151
+.4byte sNoctowlPose152
+.4byte sNoctowlPose153
+.4byte sNoctowlPose154
+.4byte sNoctowlPose155
+.4byte sNoctowlPose156
+.4byte sNoctowlPose157
+.4byte sNoctowlPose158
+.4byte sNoctowlPose159
+.4byte sNoctowlPose160
+.4byte sNoctowlPose161
+.4byte sNoctowlPose162
+.4byte sNoctowlPose163
+.4byte sNoctowlPose164
+.4byte sNoctowlPose165
+.4byte sNoctowlPose166
+.4byte sNoctowlPose167
+.4byte sNoctowlPose168
+.4byte sNoctowlPose169
+.4byte sNoctowlPose170
+.4byte sNoctowlPose171
+.4byte sNoctowlPose172
+.4byte sNoctowlPose173
+.4byte sNoctowlPose174
+.4byte sNoctowlPose175
+.4byte sNoctowlPose176
+.4byte sNoctowlPose177
+.4byte sNoctowlPose178
+.4byte sNoctowlPose179
+.4byte sNoctowlPose180
+.4byte sNoctowlPose181
+.4byte sNoctowlPose182
+.4byte sNoctowlPose183
+.4byte sNoctowlPose184
+.4byte sNoctowlPose185
+.4byte sNoctowlPose186
+.4byte sNoctowlPose187
+.4byte sNoctowlPose188
+.4byte sNoctowlPose189
+.4byte sNoctowlPose190
+.4byte sNoctowlPose191
+.4byte sNoctowlPose192
+.4byte sNoctowlPose193
+.4byte sNoctowlPose194
+.4byte sNoctowlPose195
+.4byte sNoctowlPose196
+.4byte sNoctowlPose197
+.4byte sNoctowlPose198
+.4byte sNoctowlPose199
+.4byte sNoctowlPose200
+.4byte sNoctowlPose201
+.4byte sNoctowlPose202
+.4byte sNoctowlPose203
+.4byte sNoctowlPose204
+.4byte sNoctowlPose205
+.4byte sNoctowlPose206
+.4byte sNoctowlPose207
+.4byte sNoctowlPose208
+.4byte sNoctowlPose209
+.4byte sNoctowlPose210
+.4byte sNoctowlPose211
+.4byte sNoctowlPose212
+.4byte sNoctowlPose213
+.4byte sNoctowlPose214
+.4byte sNoctowlPose215
+.4byte sNoctowlPose216
+.4byte sNoctowlPose217
+.4byte sNoctowlPose218
+.4byte sNoctowlPose219
+.4byte sNoctowlPose220
+.4byte sNoctowlPose221
+.4byte sNoctowlPose222
+.4byte sNoctowlPose223
+.4byte sNoctowlPose224
+.4byte sNoctowlPose225
+.4byte sNoctowlPose226
+.4byte sNoctowlPose227
+.4byte sNoctowlPose228
+.4byte sNoctowlPose229
+.4byte sNoctowlPose230
+.4byte sNoctowlPose231
+.4byte sNoctowlPose232
+.4byte sNoctowlPose233
+.4byte sNoctowlPose234
+.4byte sNoctowlPose235
+.4byte sNoctowlPose236
+.4byte sNoctowlPose237
+.4byte sNoctowlPose238
+.4byte sNoctowlPose239
+.4byte sNoctowlPose240
+.4byte sNoctowlPose241
+.4byte sNoctowlPose242
+sAxPositionsNoctowl:
+.2byte   -1,   -9, 	 -17,  -15, 	  15,  -15, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,  -20, 	  10,  -20, 	  -1,   -9
+.2byte   -1,  -10, 	 -15,   -3, 	  13,   -3, 	  -1,   -8
+.2byte    5,   -9, 	  12,  -18, 	 -14,  -15, 	  -1,   -7
+.2byte    5,   -8, 	   7,  -23, 	 -11,  -20, 	  -1,   -8
+.2byte    5,  -10, 	   9,   -3, 	 -11,    0, 	   0,   -9
+.2byte   12,   -9, 	   0,  -20, 	  -5,  -14, 	   1,   -8
+.2byte   12,   -8, 	   0,  -23, 	  -4,  -18, 	   1,   -7
+.2byte   12,  -10, 	  -2,   -2, 	  -4,    2, 	   0,   -8
+.2byte    3,  -15, 	 -14,  -19, 	  11,   -9, 	  -3,   -9
+.2byte    3,  -13, 	 -10,  -24, 	   7,  -18, 	  -3,  -10
+.2byte    2,  -15, 	 -14,   -7, 	   7,    1, 	  -3,   -9
+.2byte   -1,  -14, 	  15,  -14, 	 -17,  -14, 	  -1,   -9
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte   -1,  -15, 	  12,   -1, 	 -14,   -1, 	  -1,   -8
+.2byte   -5,  -15, 	  12,  -19, 	 -13,   -9, 	   1,   -9
+.2byte   -5,  -13, 	   8,  -24, 	  -9,  -18, 	   1,  -10
+.2byte   -4,  -15, 	  12,   -7, 	  -9,    1, 	   1,   -9
+.2byte  -14,   -9, 	  -2,  -20, 	   3,  -14, 	  -3,   -8
+.2byte  -14,   -8, 	  -2,  -23, 	   2,  -18, 	  -3,   -7
+.2byte  -14,  -10, 	   0,   -2, 	   2,    2, 	  -2,   -8
+.2byte   -7,   -9, 	 -14,  -18, 	  12,  -15, 	  -1,   -7
+.2byte   -7,   -8, 	  -9,  -23, 	   9,  -20, 	  -1,   -8
+.2byte   -7,  -10, 	 -11,   -3, 	   9,    0, 	  -2,   -9
+.2byte   -1,   -9, 	 -17,  -15, 	  15,  -15, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,  -20, 	  10,  -20, 	  -1,   -9
+.2byte   -1,  -10, 	 -15,   -3, 	  13,   -3, 	  -1,   -8
+.2byte    5,   -9, 	  12,  -18, 	 -14,  -15, 	  -1,   -7
+.2byte    5,   -8, 	   7,  -23, 	 -11,  -20, 	  -1,   -8
+.2byte    5,  -10, 	   9,   -3, 	 -11,    0, 	   0,   -9
+.2byte   12,   -9, 	   0,  -20, 	  -5,  -14, 	   1,   -8
+.2byte   12,   -8, 	   0,  -23, 	  -4,  -18, 	   1,   -7
+.2byte   12,  -10, 	  -2,   -2, 	  -4,    2, 	   0,   -8
+.2byte    3,  -15, 	 -14,  -19, 	  11,   -9, 	  -3,   -9
+.2byte    3,  -13, 	 -10,  -24, 	   7,  -18, 	  -3,  -10
+.2byte    2,  -15, 	 -14,   -7, 	   7,    1, 	  -3,   -9
+.2byte   -1,  -14, 	  15,  -14, 	 -17,  -14, 	  -1,   -9
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte   -1,  -15, 	  12,   -1, 	 -14,   -1, 	  -1,   -8
+.2byte   -5,  -15, 	  12,  -19, 	 -13,   -9, 	   1,   -9
+.2byte   -5,  -13, 	   8,  -24, 	  -9,  -18, 	   1,  -10
+.2byte   -4,  -15, 	  12,   -7, 	  -9,    1, 	   1,   -9
+.2byte  -14,   -9, 	  -2,  -20, 	   3,  -14, 	  -3,   -8
+.2byte  -14,   -8, 	  -2,  -23, 	   2,  -18, 	  -3,   -7
+.2byte  -14,  -10, 	   0,   -2, 	   2,    2, 	  -2,   -8
+.2byte   -7,   -9, 	 -14,  -18, 	  12,  -15, 	  -1,   -7
+.2byte   -7,   -8, 	  -9,  -23, 	   9,  -20, 	  -1,   -8
+.2byte   -7,  -10, 	 -11,   -3, 	   9,    0, 	  -2,   -9
+.2byte   -1,   -9, 	 -17,  -15, 	  15,  -15, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,  -20, 	  10,  -20, 	  -1,   -9
+.2byte   -1,  -10, 	 -15,   -3, 	  13,   -3, 	  -1,   -8
+.2byte    5,   -9, 	  12,  -18, 	 -14,  -15, 	  -1,   -7
+.2byte    5,   -8, 	   7,  -23, 	 -11,  -20, 	  -1,   -8
+.2byte    5,  -10, 	   9,   -3, 	 -11,    0, 	   0,   -9
+.2byte   12,   -9, 	   0,  -20, 	  -5,  -14, 	   1,   -8
+.2byte   12,   -8, 	   0,  -23, 	  -4,  -18, 	   1,   -7
+.2byte   12,  -10, 	  -2,   -2, 	  -4,    2, 	   0,   -8
+.2byte    3,  -15, 	 -14,  -19, 	  11,   -9, 	  -3,   -9
+.2byte    3,  -13, 	 -10,  -24, 	   7,  -18, 	  -3,  -10
+.2byte    2,  -15, 	 -14,   -7, 	   7,    1, 	  -3,   -9
+.2byte   -1,  -14, 	  15,  -14, 	 -17,  -14, 	  -1,   -9
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte   -1,  -15, 	  12,   -1, 	 -14,   -1, 	  -1,   -8
+.2byte   -5,  -15, 	  12,  -19, 	 -13,   -9, 	   1,   -9
+.2byte   -5,  -13, 	   8,  -24, 	  -9,  -18, 	   1,  -10
+.2byte   -4,  -15, 	  12,   -7, 	  -9,    1, 	   1,   -9
+.2byte  -14,   -9, 	  -2,  -20, 	   3,  -14, 	  -3,   -8
+.2byte  -14,   -8, 	  -2,  -23, 	   2,  -18, 	  -3,   -7
+.2byte  -14,  -10, 	   0,   -2, 	   2,    2, 	  -2,   -8
+.2byte   -7,   -9, 	 -14,  -18, 	  12,  -15, 	  -1,   -7
+.2byte   -7,   -8, 	  -9,  -23, 	   9,  -20, 	  -1,   -8
+.2byte   -7,  -10, 	 -11,   -3, 	   9,    0, 	  -2,   -9
+.2byte   -1,   -9, 	 -17,  -15, 	  15,  -15, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,  -20, 	  10,  -20, 	  -1,   -9
+.2byte   -1,  -10, 	 -15,   -3, 	  13,   -3, 	  -1,   -8
+.2byte    5,   -9, 	  12,  -18, 	 -14,  -15, 	  -1,   -7
+.2byte    5,   -8, 	   7,  -23, 	 -11,  -20, 	  -1,   -8
+.2byte    5,  -10, 	   9,   -3, 	 -11,    0, 	   0,   -9
+.2byte   12,   -9, 	   0,  -20, 	  -5,  -14, 	   1,   -8
+.2byte   12,   -8, 	   0,  -23, 	  -4,  -18, 	   1,   -7
+.2byte   12,  -10, 	  -2,   -2, 	  -4,    2, 	   0,   -8
+.2byte    3,  -15, 	 -14,  -19, 	  11,   -9, 	  -3,   -9
+.2byte    3,  -13, 	 -10,  -24, 	   7,  -18, 	  -3,  -10
+.2byte    2,  -15, 	 -14,   -7, 	   7,    1, 	  -3,   -9
+.2byte   -1,  -14, 	  15,  -14, 	 -17,  -14, 	  -1,   -9
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte   -1,  -15, 	  12,   -1, 	 -14,   -1, 	  -1,   -8
+.2byte   -5,  -15, 	  12,  -19, 	 -13,   -9, 	   1,   -9
+.2byte   -5,  -13, 	   8,  -24, 	  -9,  -18, 	   1,  -10
+.2byte   -4,  -15, 	  12,   -7, 	  -9,    1, 	   1,   -9
+.2byte  -14,   -9, 	  -2,  -20, 	   3,  -14, 	  -3,   -8
+.2byte  -14,   -8, 	  -2,  -23, 	   2,  -18, 	  -3,   -7
+.2byte  -14,  -10, 	   0,   -2, 	   2,    2, 	  -2,   -8
+.2byte   -7,   -9, 	 -14,  -18, 	  12,  -15, 	  -1,   -7
+.2byte   -7,   -8, 	  -9,  -23, 	   9,  -20, 	  -1,   -8
+.2byte   -7,  -10, 	 -11,   -3, 	   9,    0, 	  -2,   -9
+.2byte   -1,  -12, 	  -6,   -5, 	   4,   -5, 	  -1,   -8
+.2byte   -1,   -7, 	 -17,  -13, 	  15,  -13, 	  -1,   -6
+.2byte   -1,   -5, 	 -12,  -17, 	  10,  -17, 	  -1,   -6
+.2byte   -1,   -9, 	 -15,   -2, 	  13,   -2, 	  -1,   -7
+.2byte   -1,  -11, 	 -15,  -19, 	  13,  -19, 	  -1,   -8
+.2byte    2,  -11, 	   0,   -5, 	  -8,   -4, 	  -1,   -7
+.2byte    7,   -7, 	  14,  -16, 	 -12,  -13, 	   1,   -5
+.2byte    7,   -5, 	   9,  -20, 	  -9,  -17, 	   1,   -5
+.2byte    7,   -9, 	  11,   -2, 	  -9,    1, 	   2,   -8
+.2byte    3,  -11, 	   7,  -23, 	 -15,  -17, 	   0,   -8
+.2byte    5,  -12, 	  -5,   -5, 	  -6,   -3, 	  -2,   -8
+.2byte   12,  -10, 	   0,  -21, 	  -5,  -15, 	   1,   -9
+.2byte   10,   -9, 	  -2,  -24, 	  -6,  -19, 	  -1,   -8
+.2byte   10,  -11, 	  -4,   -3, 	  -6,    1, 	  -2,   -9
+.2byte    6,  -12, 	  -9,  -20, 	 -12,  -15, 	   0,   -8
+.2byte    2,  -14, 	  -6,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte    5,  -16, 	 -12,  -20, 	  13,  -10, 	  -1,  -10
+.2byte    5,  -14, 	  -8,  -25, 	   9,  -19, 	  -1,  -11
+.2byte    4,  -16, 	 -12,   -8, 	   9,    0, 	  -1,  -10
+.2byte    3,  -16, 	 -10,  -25, 	  12,  -18, 	  -1,   -9
+.2byte   -1,  -17, 	   1,   -4, 	  -3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  15,  -14, 	 -17,  -14, 	  -1,   -9
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte   -1,  -15, 	  12,   -1, 	 -14,   -1, 	  -1,   -8
+.2byte   -1,  -17, 	  14,  -20, 	 -16,  -20, 	  -1,  -10
+.2byte   -3,  -14, 	   5,   -5, 	   1,   -3, 	   1,   -8
+.2byte   -6,  -16, 	  11,  -20, 	 -14,  -10, 	   0,  -10
+.2byte   -6,  -14, 	   7,  -25, 	 -10,  -19, 	   0,  -11
+.2byte   -5,  -16, 	  11,   -8, 	 -10,    0, 	   0,  -10
+.2byte   -4,  -16, 	   9,  -25, 	 -13,  -18, 	   0,   -9
+.2byte   -6,  -12, 	   4,   -5, 	   5,   -3, 	   1,   -8
+.2byte  -13,  -10, 	  -1,  -21, 	   4,  -15, 	  -2,   -9
+.2byte  -11,   -9, 	   1,  -24, 	   5,  -19, 	   0,   -8
+.2byte  -11,  -11, 	   3,   -3, 	   5,    1, 	   1,   -9
+.2byte   -7,  -12, 	   8,  -20, 	  11,  -15, 	  -1,   -8
+.2byte   -3,  -11, 	  -1,   -5, 	   7,   -4, 	   0,   -7
+.2byte   -8,   -7, 	 -15,  -16, 	  11,  -13, 	  -2,   -5
+.2byte   -8,   -5, 	 -10,  -20, 	   8,  -17, 	  -2,   -5
+.2byte   -8,   -9, 	 -12,   -2, 	   8,    1, 	  -3,   -8
+.2byte   -4,  -11, 	  -8,  -23, 	  14,  -17, 	  -1,   -8
+.2byte   -1,   -9, 	  -6,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -7, 	  -6,   -2, 	   4,   -2, 	  -1,   -5
+.2byte    2,  -18, 	 -10,  -24, 	  13,  -19, 	   0,  -10
+.2byte   -1,  -15, 	   5,  -24, 	 -14,  -16, 	   1,   -8
+.2byte    3,  -18, 	  -3,  -25, 	  -8,  -18, 	  -1,   -8
+.2byte    5,  -20, 	  -4,  -24, 	  10,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	  10,  -18, 	 -11,  -14, 	   0,   -6
+.2byte   -4,  -20, 	   5,  -24, 	  -9,  -13, 	   2,   -9
+.2byte   -4,  -17, 	   2,  -24, 	   7,  -17, 	   0,   -7
+.2byte    1,  -15, 	  -5,  -24, 	  14,  -16, 	  -1,   -8
+.2byte   -1,  -12, 	  -6,   -5, 	   4,   -5, 	  -1,   -8
+.2byte   -1,  -11, 	 -17,  -17, 	  15,  -17, 	  -1,  -10
+.2byte   -1,  -10, 	 -12,  -22, 	  10,  -22, 	  -1,  -11
+.2byte   -1,  -12, 	 -15,   -5, 	  13,   -5, 	  -1,  -10
+.2byte    2,  -11, 	   0,   -5, 	  -8,   -4, 	  -1,   -7
+.2byte    4,   -9, 	  11,  -18, 	 -15,  -15, 	  -2,   -7
+.2byte    4,   -8, 	   6,  -23, 	 -12,  -20, 	  -2,   -8
+.2byte    4,  -10, 	   8,   -3, 	 -12,    0, 	  -1,   -9
+.2byte    6,  -11, 	  -4,   -4, 	  -5,   -2, 	  -1,   -7
+.2byte   10,   -9, 	  -2,  -20, 	  -7,  -14, 	  -1,   -8
+.2byte   10,   -8, 	  -2,  -23, 	  -6,  -18, 	  -1,   -7
+.2byte   10,  -10, 	  -4,   -2, 	  -6,    2, 	  -2,   -8
+.2byte    2,  -14, 	  -6,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte    4,  -16, 	 -13,  -20, 	  12,  -10, 	  -2,  -10
+.2byte    4,  -14, 	  -9,  -25, 	   8,  -19, 	  -2,  -11
+.2byte    3,  -17, 	 -13,   -9, 	   8,   -1, 	  -2,  -11
+.2byte   -1,  -17, 	   1,   -4, 	  -3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  15,  -14, 	 -17,  -14, 	  -1,   -9
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte   -1,  -15, 	  12,   -1, 	 -14,   -1, 	  -1,   -8
+.2byte   -4,  -14, 	   4,   -5, 	   0,   -3, 	   0,   -8
+.2byte   -4,  -16, 	  13,  -20, 	 -12,  -10, 	   2,  -10
+.2byte   -4,  -14, 	   9,  -25, 	  -8,  -19, 	   2,  -11
+.2byte   -3,  -17, 	  13,   -9, 	  -8,   -1, 	   2,  -11
+.2byte   -8,  -12, 	   2,   -5, 	   3,   -3, 	  -1,   -8
+.2byte  -11,  -10, 	   1,  -21, 	   6,  -15, 	   0,   -9
+.2byte  -11,   -9, 	   1,  -24, 	   5,  -19, 	   0,   -8
+.2byte  -11,  -11, 	   3,   -3, 	   5,    1, 	   1,   -9
+.2byte   -4,  -11, 	  -2,   -5, 	   6,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	 -13,  -18, 	  13,  -15, 	   0,   -7
+.2byte   -6,   -8, 	  -8,  -23, 	  10,  -20, 	   0,   -8
+.2byte   -6,  -10, 	 -10,   -3, 	  10,    0, 	  -1,   -9
+.2byte   -1,   -8, 	 -12,  -20, 	  10,  -20, 	  -1,   -9
+.2byte   -7,   -8, 	  -9,  -23, 	   9,  -20, 	  -1,   -8
+.2byte  -12,   -8, 	   0,  -23, 	   4,  -18, 	  -1,   -7
+.2byte   -7,  -13, 	   6,  -24, 	 -11,  -18, 	  -1,  -10
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte    5,  -13, 	  -8,  -24, 	   9,  -18, 	  -1,  -10
+.2byte   10,   -8, 	  -2,  -23, 	  -6,  -18, 	  -1,   -7
+.2byte    5,   -8, 	   7,  -23, 	 -11,  -20, 	  -1,   -8
+.2byte   -1,  -11, 	 -15,  -19, 	  13,  -19, 	  -1,   -8
+.2byte    3,  -11, 	   7,  -23, 	 -15,  -17, 	   0,   -8
+.2byte    7,  -12, 	  -8,  -20, 	 -11,  -15, 	   1,   -8
+.2byte    3,  -16, 	 -10,  -25, 	  12,  -18, 	  -1,   -9
+.2byte   -1,  -17, 	  14,  -20, 	 -16,  -20, 	  -1,  -10
+.2byte   -4,  -16, 	   9,  -25, 	 -13,  -18, 	   0,   -9
+.2byte   -8,  -12, 	   7,  -20, 	  10,  -15, 	  -2,   -8
+.2byte   -4,  -11, 	  -8,  -23, 	  14,  -17, 	  -1,   -8
+.2byte   -1,  -11, 	  -6,   -4, 	   4,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	 -17,  -15, 	  15,  -15, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,  -20, 	  10,  -20, 	  -1,   -9
+.2byte   -1,   -8, 	 -15,   -1, 	  13,   -1, 	  -1,   -6
+.2byte    3,  -11, 	   1,   -5, 	  -7,   -4, 	   0,   -7
+.2byte    5,   -9, 	  12,  -18, 	 -14,  -15, 	  -1,   -7
+.2byte    5,   -8, 	   7,  -23, 	 -11,  -20, 	  -1,   -8
+.2byte    5,   -8, 	   9,   -1, 	 -11,    2, 	   0,   -7
+.2byte    6,  -12, 	  -4,   -5, 	  -5,   -3, 	  -1,   -8
+.2byte   10,   -9, 	  -2,  -20, 	  -7,  -14, 	  -1,   -8
+.2byte   10,   -8, 	  -2,  -23, 	  -6,  -18, 	  -1,   -7
+.2byte   10,   -8, 	  -4,    0, 	  -6,    4, 	  -2,   -6
+.2byte    2,  -14, 	  -6,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte    4,  -15, 	 -13,  -19, 	  12,   -9, 	  -2,   -9
+.2byte    4,  -13, 	  -9,  -24, 	   8,  -18, 	  -2,  -10
+.2byte    3,  -14, 	 -13,   -6, 	   8,    2, 	  -2,   -8
+.2byte   -1,  -16, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -14, 	  15,  -14, 	 -17,  -14, 	  -1,   -9
+.2byte   -1,  -13, 	  11,  -21, 	 -13,  -21, 	  -1,   -9
+.2byte   -1,  -13, 	  12,    1, 	 -14,    1, 	  -1,   -6
+.2byte   -4,  -14, 	   4,   -5, 	   0,   -3, 	   0,   -8
+.2byte   -6,  -15, 	  11,  -19, 	 -14,   -9, 	   0,   -9
+.2byte   -6,  -13, 	   7,  -24, 	 -10,  -18, 	   0,  -10
+.2byte   -5,  -14, 	  11,   -6, 	 -10,    2, 	   0,   -8
+.2byte   -8,  -12, 	   2,   -5, 	   3,   -3, 	  -1,   -8
+.2byte  -12,   -9, 	   0,  -20, 	   5,  -14, 	  -1,   -8
+.2byte  -12,   -8, 	   0,  -23, 	   4,  -18, 	  -1,   -7
+.2byte  -12,   -8, 	   2,    0, 	   4,    4, 	   0,   -6
+.2byte   -5,  -11, 	  -3,   -5, 	   5,   -4, 	  -2,   -7
+.2byte   -7,   -9, 	 -14,  -18, 	  12,  -15, 	  -1,   -7
+.2byte   -7,   -8, 	  -9,  -23, 	   9,  -20, 	  -1,   -8
+.2byte   -7,   -8, 	 -11,   -1, 	   9,    2, 	  -2,   -7
+.2byte   -1,  -11, 	 -15,  -19, 	  13,  -19, 	  -1,   -8
+.2byte    3,  -11, 	   7,  -23, 	 -15,  -17, 	   0,   -8
+.2byte    7,  -12, 	  -8,  -20, 	 -11,  -15, 	   1,   -8
+.2byte    3,  -16, 	 -10,  -25, 	  12,  -18, 	  -1,   -9
+.2byte   -1,  -17, 	  14,  -20, 	 -16,  -20, 	  -1,  -10
+.2byte   -4,  -16, 	   9,  -25, 	 -13,  -18, 	   0,   -9
+.2byte   -8,  -12, 	   7,  -20, 	  10,  -15, 	  -2,   -8
+.2byte   -4,  -11, 	  -8,  -23, 	  14,  -17, 	  -1,   -8
+.2byte   -1,  -11, 	  -6,   -4, 	   4,   -4, 	  -1,   -7
+.2byte   -5,  -11, 	  -3,   -5, 	   5,   -4, 	  -2,   -7
+.2byte   -8,  -12, 	   2,   -5, 	   3,   -3, 	  -1,   -8
+.2byte   -4,  -14, 	   4,   -5, 	   0,   -3, 	   0,   -8
+.2byte   -1,  -16, 	   1,   -3, 	  -3,   -3, 	  -1,   -9
+.2byte    2,  -14, 	  -6,   -5, 	  -2,   -3, 	  -2,   -8
+.2byte    6,  -12, 	  -4,   -5, 	  -5,   -3, 	  -1,   -8
+.2byte    3,  -11, 	   1,   -5, 	  -7,   -4, 	   0,   -7
+sNoctowlAnimTable1:
+.4byte sNoctowlAnims_1_1
+.4byte sNoctowlAnims_1_2
+.4byte sNoctowlAnims_1_3
+.4byte sNoctowlAnims_1_4
+.4byte sNoctowlAnims_1_5
+.4byte sNoctowlAnims_1_6
+.4byte sNoctowlAnims_1_7
+.4byte sNoctowlAnims_1_8
+sNoctowlAnimTable2:
+.4byte sNoctowlAnims_2_1
+.4byte sNoctowlAnims_2_2
+.4byte sNoctowlAnims_2_3
+.4byte sNoctowlAnims_2_4
+.4byte sNoctowlAnims_2_5
+.4byte sNoctowlAnims_2_6
+.4byte sNoctowlAnims_2_7
+.4byte sNoctowlAnims_2_8
+sNoctowlAnimTable3:
+.4byte sNoctowlAnims_3_1
+.4byte sNoctowlAnims_3_2
+.4byte sNoctowlAnims_3_3
+.4byte sNoctowlAnims_3_4
+.4byte sNoctowlAnims_3_5
+.4byte sNoctowlAnims_3_6
+.4byte sNoctowlAnims_3_7
+.4byte sNoctowlAnims_3_8
+sNoctowlAnimTable4:
+.4byte sNoctowlAnims_4_1
+.4byte sNoctowlAnims_4_2
+.4byte sNoctowlAnims_4_3
+.4byte sNoctowlAnims_4_4
+.4byte sNoctowlAnims_4_5
+.4byte sNoctowlAnims_4_6
+.4byte sNoctowlAnims_4_7
+.4byte sNoctowlAnims_4_8
+sNoctowlAnimTable5:
+.4byte sNoctowlAnims_5_1
+.4byte sNoctowlAnims_5_2
+.4byte sNoctowlAnims_5_3
+.4byte sNoctowlAnims_5_4
+.4byte sNoctowlAnims_5_5
+.4byte sNoctowlAnims_5_6
+.4byte sNoctowlAnims_5_7
+.4byte sNoctowlAnims_5_8
+sNoctowlAnimTable6:
+.4byte sNoctowlAnims_6_1
+.4byte sNoctowlAnims_6_1
+.4byte sNoctowlAnims_6_1
+.4byte sNoctowlAnims_6_1
+.4byte sNoctowlAnims_6_1
+.4byte sNoctowlAnims_6_1
+.4byte sNoctowlAnims_6_1
+.4byte sNoctowlAnims_6_1
+sNoctowlAnimTable7:
+.4byte sNoctowlAnims_7_1
+.4byte sNoctowlAnims_7_2
+.4byte sNoctowlAnims_7_3
+.4byte sNoctowlAnims_7_4
+.4byte sNoctowlAnims_7_5
+.4byte sNoctowlAnims_7_6
+.4byte sNoctowlAnims_7_7
+.4byte sNoctowlAnims_7_8
+sNoctowlAnimTable8:
+.4byte sNoctowlAnims_8_1
+.4byte sNoctowlAnims_8_2
+.4byte sNoctowlAnims_8_3
+.4byte sNoctowlAnims_8_4
+.4byte sNoctowlAnims_8_5
+.4byte sNoctowlAnims_8_6
+.4byte sNoctowlAnims_8_7
+.4byte sNoctowlAnims_8_8
+sNoctowlAnimTable9:
+.4byte sNoctowlAnims_9_1
+.4byte sNoctowlAnims_9_2
+.4byte sNoctowlAnims_9_3
+.4byte sNoctowlAnims_9_4
+.4byte sNoctowlAnims_9_5
+.4byte sNoctowlAnims_9_6
+.4byte sNoctowlAnims_9_7
+.4byte sNoctowlAnims_9_8
+sNoctowlAnimTable10:
+.4byte sNoctowlAnims_10_1
+.4byte sNoctowlAnims_10_2
+.4byte sNoctowlAnims_10_3
+.4byte sNoctowlAnims_10_4
+.4byte sNoctowlAnims_10_5
+.4byte sNoctowlAnims_10_6
+.4byte sNoctowlAnims_10_7
+.4byte sNoctowlAnims_10_8
+sNoctowlAnimTable11:
+.4byte sNoctowlAnims_11_1
+.4byte sNoctowlAnims_11_2
+.4byte sNoctowlAnims_11_3
+.4byte sNoctowlAnims_11_4
+.4byte sNoctowlAnims_11_5
+.4byte sNoctowlAnims_11_6
+.4byte sNoctowlAnims_11_7
+.4byte sNoctowlAnims_11_8
+sNoctowlAnimTable12:
+.4byte sNoctowlAnims_12_1
+.4byte sNoctowlAnims_12_2
+.4byte sNoctowlAnims_12_3
+.4byte sNoctowlAnims_12_4
+.4byte sNoctowlAnims_12_5
+.4byte sNoctowlAnims_12_6
+.4byte sNoctowlAnims_12_7
+.4byte sNoctowlAnims_12_8
+sNoctowlAnimTable13:
+.4byte sNoctowlAnims_13_1
+.4byte sNoctowlAnims_13_2
+.4byte sNoctowlAnims_13_3
+.4byte sNoctowlAnims_13_4
+.4byte sNoctowlAnims_13_5
+.4byte sNoctowlAnims_13_6
+.4byte sNoctowlAnims_13_7
+.4byte sNoctowlAnims_13_8
+sAxAnimationsNoctowl:
+.4byte sNoctowlAnimTable1
+.4byte sNoctowlAnimTable2
+.4byte sNoctowlAnimTable3
+.4byte sNoctowlAnimTable4
+.4byte sNoctowlAnimTable5
+.4byte sNoctowlAnimTable6
+.4byte sNoctowlAnimTable7
+.4byte sNoctowlAnimTable8
+.4byte sNoctowlAnimTable9
+.4byte sNoctowlAnimTable10
+.4byte sNoctowlAnimTable11
+.4byte sNoctowlAnimTable12
+.4byte sNoctowlAnimTable13
+sAxSpritesNoctowl:
+.4byte sNoctowlSprites1
+.4byte sNoctowlSprites2
+.4byte sNoctowlSprites3
+.4byte sNoctowlSprites4
+.4byte sNoctowlSprites5
+.4byte sNoctowlSprites6
+.4byte sNoctowlSprites7
+.4byte sNoctowlSprites8
+.4byte sNoctowlSprites9
+.4byte sNoctowlSprites10
+.4byte sNoctowlSprites11
+.4byte sNoctowlSprites12
+.4byte sNoctowlSprites13
+.4byte sNoctowlSprites14
+.4byte sNoctowlSprites15
+.4byte sNoctowlSprites16
+.4byte sNoctowlSprites17
+.4byte sNoctowlSprites18
+.4byte sNoctowlSprites19
+.4byte sNoctowlSprites20
+.4byte sNoctowlSprites21
+.4byte sNoctowlSprites22
+.4byte sNoctowlSprites23
+.4byte sNoctowlSprites24
+.4byte sNoctowlSprites25
+.4byte sNoctowlSprites26
+.4byte sNoctowlSprites27
+.4byte sNoctowlSprites28
+.4byte sNoctowlSprites29
+.4byte sNoctowlSprites30
+.4byte sNoctowlSprites31
+.4byte sNoctowlSprites32
+.4byte sNoctowlSprites33
+.4byte sNoctowlSprites34
+.4byte sNoctowlSprites35
+.4byte sNoctowlSprites36
+.4byte sNoctowlSprites37
+.4byte sNoctowlSprites38
+.4byte sNoctowlSprites39
+.4byte sNoctowlSprites40
+.4byte sNoctowlSprites41
+.4byte sNoctowlSprites42
+.4byte sNoctowlSprites43
+.4byte sNoctowlSprites44
+.4byte sNoctowlSprites45
+.4byte sNoctowlSprites46
+.4byte sNoctowlSprites47
+.4byte sNoctowlSprites48
+sAxMainNoctowl:
+ax_main sAxPosesNoctowl, sAxAnimationsNoctowl, 13, sAxSpritesNoctowl, sAxPositionsNoctowl

--- a/data/ax/nosepass.inc
+++ b/data/ax/nosepass.inc
@@ -1,0 +1,2671 @@
+.global gAxNosepass
+gAxNosepass:
+ax_siro sAxMainNosepass
+sNosepassPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose3:
+ax_pose 2, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sNosepassPose4:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose5:
+ax_pose 4, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose6:
+ax_pose 5, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose7:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose8:
+ax_pose 7, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose9:
+ax_pose 8, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose10:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose11:
+ax_pose 10, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose12:
+ax_pose 11, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose16:
+ax_pose 9, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose17:
+ax_pose 10, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose18:
+ax_pose 11, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose19:
+ax_pose 6, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose20:
+ax_pose 7, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose21:
+ax_pose 8, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose22:
+ax_pose 3, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose23:
+ax_pose 4, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose24:
+ax_pose 5, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose26:
+ax_pose 15, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose27:
+ax_pose 16, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose28:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose29:
+ax_pose 17, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sNosepassPose30:
+ax_pose 18, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose31:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose32:
+ax_pose 19, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose33:
+ax_pose 20, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose34:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose35:
+ax_pose 21, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sNosepassPose36:
+ax_pose 22, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose37:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose38:
+ax_pose 23, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose39:
+ax_pose 24, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose40:
+ax_pose 9, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose41:
+ax_pose 21, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose42:
+ax_pose 22, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose43:
+ax_pose 6, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose44:
+ax_pose 19, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose45:
+ax_pose 20, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose46:
+ax_pose 3, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose47:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose48:
+ax_pose 18, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose49:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose50:
+ax_pose 15, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose51:
+ax_pose 16, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose52:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose53:
+ax_pose 17, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sNosepassPose54:
+ax_pose 18, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose55:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose56:
+ax_pose 19, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose57:
+ax_pose 20, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose58:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose59:
+ax_pose 21, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sNosepassPose60:
+ax_pose 22, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose61:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose62:
+ax_pose 23, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose63:
+ax_pose 24, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose64:
+ax_pose 9, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose65:
+ax_pose 21, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose66:
+ax_pose 22, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose67:
+ax_pose 6, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose68:
+ax_pose 19, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose69:
+ax_pose 20, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose70:
+ax_pose 3, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose71:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose72:
+ax_pose 18, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose73:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose74:
+ax_pose 15, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose75:
+ax_pose 25, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose76:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose77:
+ax_pose 17, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sNosepassPose78:
+ax_pose 26, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose79:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose80:
+ax_pose 19, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose81:
+ax_pose 27, 0x01ea, 0x90f2, 0x0c00
+ax_pose_terminator
+sNosepassPose82:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose83:
+ax_pose 21, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose84:
+ax_pose 28, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose85:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose86:
+ax_pose 23, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose87:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose88:
+ax_pose 9, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose89:
+ax_pose 21, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose90:
+ax_pose 28, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose91:
+ax_pose 6, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose92:
+ax_pose 19, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose93:
+ax_pose 27, 0x01ea, 0x80ef, 0x0c00
+ax_pose_terminator
+sNosepassPose94:
+ax_pose 3, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose95:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose96:
+ax_pose 26, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose97:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose98:
+ax_pose 16, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose99:
+ax_pose 25, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose100:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose101:
+ax_pose 18, 0x01e9, 0x90ed, 0x0c00
+ax_pose_terminator
+sNosepassPose102:
+ax_pose 26, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose103:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose104:
+ax_pose 20, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose105:
+ax_pose 27, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose106:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose107:
+ax_pose 22, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose108:
+ax_pose 28, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose109:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose110:
+ax_pose 24, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose111:
+ax_pose 29, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose112:
+ax_pose 9, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose113:
+ax_pose 22, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose114:
+ax_pose 28, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose115:
+ax_pose 6, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose116:
+ax_pose 20, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose117:
+ax_pose 27, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose118:
+ax_pose 3, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose119:
+ax_pose 18, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose120:
+ax_pose 26, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose121:
+ax_pose 30, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sNosepassPose122:
+ax_pose 31, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sNosepassPose123:
+ax_pose 32, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose124:
+ax_pose 33, 0x01e4, 0x90e9, 0x0c00
+ax_pose_terminator
+sNosepassPose125:
+ax_pose 34, 0x01e6, 0x90e8, 0x0c00
+ax_pose_terminator
+sNosepassPose126:
+ax_pose 35, 0x01e8, 0x90e9, 0x0c00
+ax_pose_terminator
+sNosepassPose127:
+ax_pose 36, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose128:
+ax_pose 35, 0x01e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sNosepassPose129:
+ax_pose 34, 0x01e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sNosepassPose130:
+ax_pose 33, 0x01e4, 0x80f7, 0x0c00
+ax_pose_terminator
+sNosepassPose131:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose132:
+ax_pose 15, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose133:
+ax_pose 16, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose134:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose135:
+ax_pose 17, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sNosepassPose136:
+ax_pose 18, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose137:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose138:
+ax_pose 19, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose139:
+ax_pose 20, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose140:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose141:
+ax_pose 21, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose142:
+ax_pose 22, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose143:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose144:
+ax_pose 23, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose145:
+ax_pose 24, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose146:
+ax_pose 9, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose147:
+ax_pose 21, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose148:
+ax_pose 22, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose149:
+ax_pose 6, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose150:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose151:
+ax_pose 20, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose152:
+ax_pose 3, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose153:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose154:
+ax_pose 18, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose155:
+ax_pose 25, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose156:
+ax_pose 26, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose157:
+ax_pose 27, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose158:
+ax_pose 28, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose159:
+ax_pose 29, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose160:
+ax_pose 28, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose161:
+ax_pose 27, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose162:
+ax_pose 26, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sNosepassPose163:
+ax_pose 25, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose164:
+ax_pose 26, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sNosepassPose165:
+ax_pose 27, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose166:
+ax_pose 28, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose167:
+ax_pose 29, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose168:
+ax_pose 28, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose169:
+ax_pose 27, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose170:
+ax_pose 26, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose171:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose172:
+ax_pose 15, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose173:
+ax_pose 25, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose174:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose175:
+ax_pose 17, 0x01e9, 0x90f2, 0x0c00
+ax_pose_terminator
+sNosepassPose176:
+ax_pose 26, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose177:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose178:
+ax_pose 19, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sNosepassPose179:
+ax_pose 27, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose180:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose181:
+ax_pose 21, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose182:
+ax_pose 28, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose183:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose184:
+ax_pose 23, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose185:
+ax_pose 29, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose186:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose187:
+ax_pose 21, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose188:
+ax_pose 28, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose189:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose190:
+ax_pose 19, 0x01ea, 0x80ef, 0x0c00
+ax_pose_terminator
+sNosepassPose191:
+ax_pose 27, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose192:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose193:
+ax_pose 17, 0x01e9, 0x80ee, 0x0c00
+ax_pose_terminator
+sNosepassPose194:
+ax_pose 26, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose195:
+ax_pose 15, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sNosepassPose196:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose197:
+ax_pose 19, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose198:
+ax_pose 21, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose199:
+ax_pose 23, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sNosepassPose200:
+ax_pose 21, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose201:
+ax_pose 19, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sNosepassPose202:
+ax_pose 17, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sNosepassPose203:
+ax_pose 0, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose204:
+ax_pose 3, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose205:
+ax_pose 6, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sNosepassPose206:
+ax_pose 9, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sNosepassPose207:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sNosepassPose208:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sNosepassPose209:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sNosepassPose210:
+ax_pose 3, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sNosepassAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNosepassAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 18, 19, 18, 19,
+ax_anim 2, 1, 29, 19, 18, 19, 18,
+ax_anim 2, 0, 29, 18, 19, 18, 19,
+ax_anim 2, 0, 29, 19, 18, 19, 18,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sNosepassAnims_2_3:
+ax_anim 2, 0, 31, -3, 0, -3, 0,
+ax_anim 6, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 0, 32, 1, 0, 1, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sNosepassAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 5, -5, 5, -5,
+ax_anim 1, 0, 35, 12, -11, 12, -11,
+ax_anim 2, 0, 35, 18, -16, 18, -16,
+ax_anim 2, 1, 35, 19, -15, 19, -15,
+ax_anim 2, 0, 35, 18, -16, 18, -16,
+ax_anim 2, 0, 35, 19, -15, 19, -15,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sNosepassAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 0, -17, 0, -17,
+ax_anim 2, 1, 38, 1, -17, 1, -17,
+ax_anim 2, 0, 38, 0, -17, 0, -17,
+ax_anim 2, 0, 38, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sNosepassAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -5, -5, -5, -5,
+ax_anim 1, 0, 41, -12, -11, -12, -11,
+ax_anim 2, 0, 41, -18, -16, -18, -16,
+ax_anim 2, 1, 41, -19, -15, -19, -15,
+ax_anim 2, 0, 41, -18, -16, -18, -16,
+ax_anim 2, 0, 41, -19, -15, -19, -15,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sNosepassAnims_2_7:
+ax_anim 2, 0, 43, 3, 0, 3, 0,
+ax_anim 6, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 0, 44, -1, 0, -1, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sNosepassAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 47, -18, 19, -18, 19,
+ax_anim 2, 1, 47, -19, 18, -19, 18,
+ax_anim 2, 0, 47, -18, 19, -18, 19,
+ax_anim 2, 0, 47, -19, 18, -19, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNosepassAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 1, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 0, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sNosepassAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 18, 19, 18, 19,
+ax_anim 2, 1, 53, 19, 18, 19, 18,
+ax_anim 2, 0, 53, 18, 19, 18, 19,
+ax_anim 2, 0, 53, 19, 18, 19, 18,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sNosepassAnims_3_3:
+ax_anim 2, 0, 55, -3, 0, -3, 0,
+ax_anim 6, 0, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 56, 1, 0, 1, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sNosepassAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 59, 5, -5, 5, -5,
+ax_anim 1, 0, 59, 12, -11, 12, -11,
+ax_anim 2, 0, 59, 18, -16, 18, -16,
+ax_anim 2, 1, 59, 19, -15, 19, -15,
+ax_anim 2, 0, 59, 18, -16, 18, -16,
+ax_anim 2, 0, 59, 19, -15, 19, -15,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sNosepassAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 62, 0, -17, 0, -17,
+ax_anim 2, 1, 62, 1, -17, 1, -17,
+ax_anim 2, 0, 62, 0, -17, 0, -17,
+ax_anim 2, 0, 62, 1, -17, 1, -17,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sNosepassAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 65, -5, -5, -5, -5,
+ax_anim 1, 0, 65, -12, -11, -12, -11,
+ax_anim 2, 0, 65, -18, -16, -18, -16,
+ax_anim 2, 1, 65, -19, -15, -19, -15,
+ax_anim 2, 0, 65, -18, -16, -18, -16,
+ax_anim 2, 0, 65, -19, -15, -19, -15,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sNosepassAnims_3_7:
+ax_anim 2, 0, 67, 3, 0, 3, 0,
+ax_anim 6, 0, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 68, -1, 0, -1, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sNosepassAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -18, 19, -18, 19,
+ax_anim 2, 1, 71, -19, 18, -19, 18,
+ax_anim 2, 0, 71, -18, 19, -18, 19,
+ax_anim 2, 0, 71, -19, 18, -19, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNosepassAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sNosepassAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sNosepassAnims_4_3:
+ax_anim 2, 0, 79, -3, 0, -3, 0,
+ax_anim 6, 2, 79, -4, 0, -4, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 1, 4, 1,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sNosepassAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sNosepassAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sNosepassAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sNosepassAnims_4_7:
+ax_anim 2, 0, 91, 3, 0, 3, 0,
+ax_anim 6, 2, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 1, -4, 1,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sNosepassAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNosepassAnims_5_1:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 4, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 6, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_5_2:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 4, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 6, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 1, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_5_3:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 4, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 6, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 1, 104, 0, 1, 0, 1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_5_4:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 4, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 6, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_5_5:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 4, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 6, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_5_6:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 4, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 6, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 113, 1, -1, 1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_5_7:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, -3, 0, 0,
+ax_anim 4, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -3, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 6, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 1, 116, 0, 1, 0, 1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_5_8:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 4, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 6, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sNosepassAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sNosepassAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sNosepassAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sNosepassAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sNosepassAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sNosepassAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sNosepassAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNosepassAnims_8_1:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 1, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 4, 0, 131, 0, -7, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 6, 0, 132, 0, 1, 0, 0,
+ax_anim_terminator
+sNosepassAnims_8_2:
+ax_anim 30, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 1, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -6, 0, 0,
+ax_anim 4, 0, 134, 0, -7, 0, 0,
+ax_anim 4, 0, 134, 0, -6, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 6, 0, 135, 0, 1, 0, 0,
+ax_anim_terminator
+sNosepassAnims_8_3:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 0, 1, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 4, 0, 137, 0, -7, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 6, 0, 138, 0, 1, 0, 0,
+ax_anim_terminator
+sNosepassAnims_8_4:
+ax_anim 30, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 141, 0, 1, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -6, 0, 0,
+ax_anim 4, 0, 140, 0, -7, 0, 0,
+ax_anim 4, 0, 140, 0, -6, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 6, 0, 141, 0, 1, 0, 0,
+ax_anim_terminator
+sNosepassAnims_8_5:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 144, 0, 1, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -6, 0, 0,
+ax_anim 4, 0, 143, 0, -7, 0, 0,
+ax_anim 4, 0, 143, 0, -6, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 6, 0, 144, 0, 1, 0, 0,
+ax_anim_terminator
+sNosepassAnims_8_6:
+ax_anim 30, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 1, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -6, 0, 0,
+ax_anim 4, 0, 146, 0, -7, 0, 0,
+ax_anim 4, 0, 146, 0, -6, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 6, 0, 147, 0, 1, 0, 0,
+ax_anim_terminator
+sNosepassAnims_8_7:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 1, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -6, 0, 0,
+ax_anim 4, 0, 149, 0, -7, 0, 0,
+ax_anim 4, 0, 149, 0, -6, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 6, 0, 150, 0, 1, 0, 0,
+ax_anim_terminator
+sNosepassAnims_8_8:
+ax_anim 30, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 1, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -6, 0, 0,
+ax_anim 4, 0, 152, 0, -7, 0, 0,
+ax_anim 4, 0, 152, 0, -6, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 6, 0, 153, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 7, 3, 7, 3,
+ax_anim 2, 0, 156, 11, 10, 11, 10,
+ax_anim 2, 0, 157, 10, 17, 10, 17,
+ax_anim 3, 0, 158, 0, 21, 0, 21,
+ax_anim 2, 3, 159, -10, 17, -10, 17,
+ax_anim 2, 0, 160, -11, 10, -11, 10,
+ax_anim 1, 0, 161, -7, 3, -7, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 16, 4, 16, 4,
+ax_anim 2, 0, 156, 21, 12, 21, 12,
+ax_anim 3, 0, 157, 22, 19, 22, 19,
+ax_anim 2, 3, 158, 10, 20, 10, 20,
+ax_anim 2, 0, 159, 4, 15, 4, 15,
+ax_anim 1, 0, 160, 1, 8, 1, 8,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 6, -5, 6, -5,
+ax_anim 2, 0, 154, 13, -7, 13, -7,
+ax_anim 2, 0, 155, 19, -5, 19, -5,
+ax_anim 3, 0, 156, 22, -1, 22, -1,
+ax_anim 2, 3, 157, 21, 4, 21, 4,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 5, 5, 5, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -9, -1, -9,
+ax_anim 2, 0, 161, 4, -17, 4, -17,
+ax_anim 2, 0, 154, 10, -21, 10, -21,
+ax_anim 3, 0, 155, 20, -23, 20, -23,
+ax_anim 2, 3, 156, 21, -15, 21, -15,
+ax_anim 2, 0, 157, 19, -10, 19, -10,
+ax_anim 1, 0, 158, 11, -3, 11, -3,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -9, -4, -9, -4,
+ax_anim 2, 0, 160, -11, -10, -11, -10,
+ax_anim 2, 0, 161, -8, -19, -8, -19,
+ax_anim 3, 0, 154, 0, -23, 0, -23,
+ax_anim 2, 3, 155, 8, -19, 8, -19,
+ax_anim 2, 0, 156, 11, -10, 11, -10,
+ax_anim 1, 0, 157, 9, -4, 9, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -9, 1, -9,
+ax_anim 2, 0, 155, -4, -17, -4, -17,
+ax_anim 2, 0, 154, -10, -21, -10, -21,
+ax_anim 3, 0, 161, -20, -23, -20, -23,
+ax_anim 2, 3, 160, -21, -15, -21, -15,
+ax_anim 2, 0, 159, -19, -10, -19, -10,
+ax_anim 1, 0, 158, -11, -3, -11, -3,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -6, -5, -6, -5,
+ax_anim 2, 0, 154, -13, -7, -13, -7,
+ax_anim 2, 0, 161, -19, -5, -19, -5,
+ax_anim 3, 0, 160, -22, -1, -22, -1,
+ax_anim 2, 3, 159, -21, 4, -21, 4,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -5, 5, -5, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -16, 4, -16, 4,
+ax_anim 2, 0, 160, -21, 12, -21, 12,
+ax_anim 3, 0, 159, -22, 19, -22, 19,
+ax_anim 2, 3, 158, -10, 20, -10, 20,
+ax_anim 2, 0, 157, -4, 15, -4, 15,
+ax_anim 1, 0, 156, -1, 8, -1, 8,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 2, 0, 178, 0, -17, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 184, 0, -21, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -17, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNosepassAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sNosepassGfx1:
+.incbin "baserom.gba", 0x1224B70, 0x200
+sNosepassSprites1:
+ax_sprite sNosepassGfx1, 0x200
+ax_sprite_terminator
+sNosepassGfx2:
+.incbin "baserom.gba", 0x1224D80, 0x200
+sNosepassSprites2:
+ax_sprite sNosepassGfx2, 0x200
+ax_sprite_terminator
+sNosepassGfx3:
+.incbin "baserom.gba", 0x1224F90, 0x200
+sNosepassSprites3:
+ax_sprite sNosepassGfx3, 0x200
+ax_sprite_terminator
+sNosepassGfx4:
+.incbin "baserom.gba", 0x12251A0, 0x200
+sNosepassSprites4:
+ax_sprite sNosepassGfx4, 0x200
+ax_sprite_terminator
+sNosepassGfx5:
+.incbin "baserom.gba", 0x12253B0, 0x200
+sNosepassSprites5:
+ax_sprite sNosepassGfx5, 0x200
+ax_sprite_terminator
+sNosepassGfx6:
+.incbin "baserom.gba", 0x12255C0, 0x200
+sNosepassSprites6:
+ax_sprite sNosepassGfx6, 0x200
+ax_sprite_terminator
+sNosepassGfx7:
+.incbin "baserom.gba", 0x12257D0, 0x200
+sNosepassSprites7:
+ax_sprite sNosepassGfx7, 0x200
+ax_sprite_terminator
+sNosepassGfx8:
+.incbin "baserom.gba", 0x12259E0, 0x200
+sNosepassSprites8:
+ax_sprite sNosepassGfx8, 0x200
+ax_sprite_terminator
+sNosepassGfx9:
+.incbin "baserom.gba", 0x1225BF0, 0x200
+sNosepassSprites9:
+ax_sprite sNosepassGfx9, 0x200
+ax_sprite_terminator
+sNosepassGfx10:
+.incbin "baserom.gba", 0x1225E00, 0x200
+sNosepassSprites10:
+ax_sprite sNosepassGfx10, 0x200
+ax_sprite_terminator
+sNosepassGfx11:
+.incbin "baserom.gba", 0x1226010, 0x200
+sNosepassSprites11:
+ax_sprite sNosepassGfx11, 0x200
+ax_sprite_terminator
+sNosepassGfx12:
+.incbin "baserom.gba", 0x1226220, 0x200
+sNosepassSprites12:
+ax_sprite sNosepassGfx12, 0x200
+ax_sprite_terminator
+sNosepassGfx13:
+.incbin "baserom.gba", 0x1226430, 0x200
+sNosepassSprites13:
+ax_sprite sNosepassGfx13, 0x200
+ax_sprite_terminator
+sNosepassGfx14:
+.incbin "baserom.gba", 0x1226640, 0x200
+sNosepassSprites14:
+ax_sprite sNosepassGfx14, 0x200
+ax_sprite_terminator
+sNosepassGfx15:
+.incbin "baserom.gba", 0x1226850, 0x200
+sNosepassSprites15:
+ax_sprite sNosepassGfx15, 0x200
+ax_sprite_terminator
+sNosepassGfx16:
+.incbin "baserom.gba", 0x1226A60, 0x40
+sNosepassGfx16_1:
+.incbin "baserom.gba", 0x1226AA0, 0x60
+sNosepassGfx16_2:
+.incbin "baserom.gba", 0x1226B00, 0x60
+sNosepassGfx16_3:
+.incbin "baserom.gba", 0x1226B60, 0x40
+sNosepassSprites16:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNosepassGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx17:
+.incbin "baserom.gba", 0x1226BF0, 0x40
+sNosepassGfx17_1:
+.incbin "baserom.gba", 0x1226C30, 0x60
+sNosepassGfx17_2:
+.incbin "baserom.gba", 0x1226C90, 0x60
+sNosepassGfx17_3:
+.incbin "baserom.gba", 0x1226CF0, 0x60
+sNosepassSprites17:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx18:
+.incbin "baserom.gba", 0x1226DA0, 0x160
+sNosepassGfx18_1:
+.incbin "baserom.gba", 0x1226F00, 0x40
+sNosepassSprites18:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx18, 0x160
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx19:
+.incbin "baserom.gba", 0x1226F70, 0x60
+sNosepassGfx19_1:
+.incbin "baserom.gba", 0x1226FD0, 0x60
+sNosepassGfx19_2:
+.incbin "baserom.gba", 0x1227030, 0x60
+sNosepassGfx19_3:
+.incbin "baserom.gba", 0x1227090, 0x40
+sNosepassSprites19:
+ax_sprite sNosepassGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNosepassGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx20:
+.incbin "baserom.gba", 0x1227118, 0x100
+sNosepassGfx20_1:
+.incbin "baserom.gba", 0x1227218, 0x60
+sNosepassGfx20_2:
+.incbin "baserom.gba", 0x1227278, 0x20
+sNosepassSprites20:
+ax_sprite sNosepassGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx20_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNosepassGfx21:
+.incbin "baserom.gba", 0x12272D0, 0x60
+sNosepassGfx21_1:
+.incbin "baserom.gba", 0x1227330, 0x60
+sNosepassGfx21_2:
+.incbin "baserom.gba", 0x1227390, 0x60
+sNosepassGfx21_3:
+.incbin "baserom.gba", 0x12273F0, 0x40
+sNosepassSprites21:
+ax_sprite sNosepassGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNosepassGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx22:
+.incbin "baserom.gba", 0x1227478, 0x40
+sNosepassGfx22_1:
+.incbin "baserom.gba", 0x12274B8, 0x160
+sNosepassSprites22:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx23:
+.incbin "baserom.gba", 0x1227648, 0x60
+sNosepassGfx23_1:
+.incbin "baserom.gba", 0x12276A8, 0x60
+sNosepassGfx23_2:
+.incbin "baserom.gba", 0x1227708, 0x60
+sNosepassGfx23_3:
+.incbin "baserom.gba", 0x1227768, 0x40
+sNosepassSprites23:
+ax_sprite sNosepassGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNosepassGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx24:
+.incbin "baserom.gba", 0x12277F0, 0x40
+sNosepassGfx24_1:
+.incbin "baserom.gba", 0x1227830, 0x100
+sNosepassGfx24_2:
+.incbin "baserom.gba", 0x1227930, 0x40
+sNosepassSprites24:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx25:
+.incbin "baserom.gba", 0x12279B0, 0x40
+sNosepassGfx25_1:
+.incbin "baserom.gba", 0x12279F0, 0x100
+sNosepassGfx25_2:
+.incbin "baserom.gba", 0x1227AF0, 0x40
+sNosepassSprites25:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx26:
+.incbin "baserom.gba", 0x1227B70, 0x40
+sNosepassGfx26_1:
+.incbin "baserom.gba", 0x1227BB0, 0x100
+sNosepassGfx26_2:
+.incbin "baserom.gba", 0x1227CB0, 0x40
+sNosepassSprites26:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx27:
+.incbin "baserom.gba", 0x1227D30, 0x60
+sNosepassGfx27_1:
+.incbin "baserom.gba", 0x1227D90, 0x60
+sNosepassGfx27_2:
+.incbin "baserom.gba", 0x1227DF0, 0x80
+sNosepassGfx27_3:
+.incbin "baserom.gba", 0x1227E70, 0x20
+sNosepassSprites27:
+ax_sprite sNosepassGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx27_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sNosepassGfx27_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx28:
+.incbin "baserom.gba", 0x1227ED8, 0x60
+sNosepassGfx28_1:
+.incbin "baserom.gba", 0x1227F38, 0x100
+sNosepassSprites28:
+ax_sprite sNosepassGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx28_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNosepassGfx29:
+.incbin "baserom.gba", 0x1228060, 0x60
+sNosepassGfx29_1:
+.incbin "baserom.gba", 0x12280C0, 0xE0
+sNosepassGfx29_2:
+.incbin "baserom.gba", 0x12281A0, 0x40
+sNosepassSprites29:
+ax_sprite sNosepassGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx29_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sNosepassGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx30:
+.incbin "baserom.gba", 0x1228218, 0x40
+sNosepassGfx30_1:
+.incbin "baserom.gba", 0x1228258, 0x100
+sNosepassGfx30_2:
+.incbin "baserom.gba", 0x1228358, 0x40
+sNosepassSprites30:
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNosepassGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNosepassGfx31:
+.incbin "baserom.gba", 0x12283D8, 0x200
+sNosepassSprites31:
+ax_sprite sNosepassGfx31, 0x200
+ax_sprite_terminator
+sNosepassGfx32:
+.incbin "baserom.gba", 0x12285E8, 0x200
+sNosepassSprites32:
+ax_sprite sNosepassGfx32, 0x200
+ax_sprite_terminator
+sNosepassGfx33:
+.incbin "baserom.gba", 0x12287F8, 0x200
+sNosepassSprites33:
+ax_sprite sNosepassGfx33, 0x200
+ax_sprite_terminator
+sNosepassGfx34:
+.incbin "baserom.gba", 0x1228A08, 0x200
+sNosepassSprites34:
+ax_sprite sNosepassGfx34, 0x200
+ax_sprite_terminator
+sNosepassGfx35:
+.incbin "baserom.gba", 0x1228C18, 0x200
+sNosepassSprites35:
+ax_sprite sNosepassGfx35, 0x200
+ax_sprite_terminator
+sNosepassGfx36:
+.incbin "baserom.gba", 0x1228E28, 0x200
+sNosepassSprites36:
+ax_sprite sNosepassGfx36, 0x200
+ax_sprite_terminator
+sNosepassGfx37:
+.incbin "baserom.gba", 0x1229038, 0x200
+sNosepassSprites37:
+ax_sprite sNosepassGfx37, 0x200
+ax_sprite_terminator
+sAxPosesNosepass:
+.4byte sNosepassPose1
+.4byte sNosepassPose2
+.4byte sNosepassPose3
+.4byte sNosepassPose4
+.4byte sNosepassPose5
+.4byte sNosepassPose6
+.4byte sNosepassPose7
+.4byte sNosepassPose8
+.4byte sNosepassPose9
+.4byte sNosepassPose10
+.4byte sNosepassPose11
+.4byte sNosepassPose12
+.4byte sNosepassPose13
+.4byte sNosepassPose14
+.4byte sNosepassPose15
+.4byte sNosepassPose16
+.4byte sNosepassPose17
+.4byte sNosepassPose18
+.4byte sNosepassPose19
+.4byte sNosepassPose20
+.4byte sNosepassPose21
+.4byte sNosepassPose22
+.4byte sNosepassPose23
+.4byte sNosepassPose24
+.4byte sNosepassPose25
+.4byte sNosepassPose26
+.4byte sNosepassPose27
+.4byte sNosepassPose28
+.4byte sNosepassPose29
+.4byte sNosepassPose30
+.4byte sNosepassPose31
+.4byte sNosepassPose32
+.4byte sNosepassPose33
+.4byte sNosepassPose34
+.4byte sNosepassPose35
+.4byte sNosepassPose36
+.4byte sNosepassPose37
+.4byte sNosepassPose38
+.4byte sNosepassPose39
+.4byte sNosepassPose40
+.4byte sNosepassPose41
+.4byte sNosepassPose42
+.4byte sNosepassPose43
+.4byte sNosepassPose44
+.4byte sNosepassPose45
+.4byte sNosepassPose46
+.4byte sNosepassPose47
+.4byte sNosepassPose48
+.4byte sNosepassPose49
+.4byte sNosepassPose50
+.4byte sNosepassPose51
+.4byte sNosepassPose52
+.4byte sNosepassPose53
+.4byte sNosepassPose54
+.4byte sNosepassPose55
+.4byte sNosepassPose56
+.4byte sNosepassPose57
+.4byte sNosepassPose58
+.4byte sNosepassPose59
+.4byte sNosepassPose60
+.4byte sNosepassPose61
+.4byte sNosepassPose62
+.4byte sNosepassPose63
+.4byte sNosepassPose64
+.4byte sNosepassPose65
+.4byte sNosepassPose66
+.4byte sNosepassPose67
+.4byte sNosepassPose68
+.4byte sNosepassPose69
+.4byte sNosepassPose70
+.4byte sNosepassPose71
+.4byte sNosepassPose72
+.4byte sNosepassPose73
+.4byte sNosepassPose74
+.4byte sNosepassPose75
+.4byte sNosepassPose76
+.4byte sNosepassPose77
+.4byte sNosepassPose78
+.4byte sNosepassPose79
+.4byte sNosepassPose80
+.4byte sNosepassPose81
+.4byte sNosepassPose82
+.4byte sNosepassPose83
+.4byte sNosepassPose84
+.4byte sNosepassPose85
+.4byte sNosepassPose86
+.4byte sNosepassPose87
+.4byte sNosepassPose88
+.4byte sNosepassPose89
+.4byte sNosepassPose90
+.4byte sNosepassPose91
+.4byte sNosepassPose92
+.4byte sNosepassPose93
+.4byte sNosepassPose94
+.4byte sNosepassPose95
+.4byte sNosepassPose96
+.4byte sNosepassPose97
+.4byte sNosepassPose98
+.4byte sNosepassPose99
+.4byte sNosepassPose100
+.4byte sNosepassPose101
+.4byte sNosepassPose102
+.4byte sNosepassPose103
+.4byte sNosepassPose104
+.4byte sNosepassPose105
+.4byte sNosepassPose106
+.4byte sNosepassPose107
+.4byte sNosepassPose108
+.4byte sNosepassPose109
+.4byte sNosepassPose110
+.4byte sNosepassPose111
+.4byte sNosepassPose112
+.4byte sNosepassPose113
+.4byte sNosepassPose114
+.4byte sNosepassPose115
+.4byte sNosepassPose116
+.4byte sNosepassPose117
+.4byte sNosepassPose118
+.4byte sNosepassPose119
+.4byte sNosepassPose120
+.4byte sNosepassPose121
+.4byte sNosepassPose122
+.4byte sNosepassPose123
+.4byte sNosepassPose124
+.4byte sNosepassPose125
+.4byte sNosepassPose126
+.4byte sNosepassPose127
+.4byte sNosepassPose128
+.4byte sNosepassPose129
+.4byte sNosepassPose130
+.4byte sNosepassPose131
+.4byte sNosepassPose132
+.4byte sNosepassPose133
+.4byte sNosepassPose134
+.4byte sNosepassPose135
+.4byte sNosepassPose136
+.4byte sNosepassPose137
+.4byte sNosepassPose138
+.4byte sNosepassPose139
+.4byte sNosepassPose140
+.4byte sNosepassPose141
+.4byte sNosepassPose142
+.4byte sNosepassPose143
+.4byte sNosepassPose144
+.4byte sNosepassPose145
+.4byte sNosepassPose146
+.4byte sNosepassPose147
+.4byte sNosepassPose148
+.4byte sNosepassPose149
+.4byte sNosepassPose150
+.4byte sNosepassPose151
+.4byte sNosepassPose152
+.4byte sNosepassPose153
+.4byte sNosepassPose154
+.4byte sNosepassPose155
+.4byte sNosepassPose156
+.4byte sNosepassPose157
+.4byte sNosepassPose158
+.4byte sNosepassPose159
+.4byte sNosepassPose160
+.4byte sNosepassPose161
+.4byte sNosepassPose162
+.4byte sNosepassPose163
+.4byte sNosepassPose164
+.4byte sNosepassPose165
+.4byte sNosepassPose166
+.4byte sNosepassPose167
+.4byte sNosepassPose168
+.4byte sNosepassPose169
+.4byte sNosepassPose170
+.4byte sNosepassPose171
+.4byte sNosepassPose172
+.4byte sNosepassPose173
+.4byte sNosepassPose174
+.4byte sNosepassPose175
+.4byte sNosepassPose176
+.4byte sNosepassPose177
+.4byte sNosepassPose178
+.4byte sNosepassPose179
+.4byte sNosepassPose180
+.4byte sNosepassPose181
+.4byte sNosepassPose182
+.4byte sNosepassPose183
+.4byte sNosepassPose184
+.4byte sNosepassPose185
+.4byte sNosepassPose186
+.4byte sNosepassPose187
+.4byte sNosepassPose188
+.4byte sNosepassPose189
+.4byte sNosepassPose190
+.4byte sNosepassPose191
+.4byte sNosepassPose192
+.4byte sNosepassPose193
+.4byte sNosepassPose194
+.4byte sNosepassPose195
+.4byte sNosepassPose196
+.4byte sNosepassPose197
+.4byte sNosepassPose198
+.4byte sNosepassPose199
+.4byte sNosepassPose200
+.4byte sNosepassPose201
+.4byte sNosepassPose202
+.4byte sNosepassPose203
+.4byte sNosepassPose204
+.4byte sNosepassPose205
+.4byte sNosepassPose206
+.4byte sNosepassPose207
+.4byte sNosepassPose208
+.4byte sNosepassPose209
+.4byte sNosepassPose210
+sAxPositionsNosepass:
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte   -1,   -8, 	 -10,   -5, 	   8,   -4, 	  -1,   -9
+.2byte    1,   -8, 	  -8,   -4, 	  10,   -5, 	   1,   -9
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+.2byte    6,   -8, 	  11,  -11, 	  -1,    0, 	   2,   -8
+.2byte    4,   -8, 	   9,   -6, 	  -2,   -5, 	   0,   -8
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    9,  -11, 	  10,  -12, 	   9,   -9, 	   1,   -8
+.2byte    9,  -11, 	   9,  -12, 	   8,   -1, 	   0,   -8
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    6,  -14, 	  -1,  -18, 	   9,  -11, 	   0,   -9
+.2byte    5,  -14, 	  -3,  -10, 	   9,   -5, 	  -1,   -9
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    1,  -11, 	   8,  -12, 	  -8,   -6, 	   1,   -8
+.2byte   -2,  -11, 	   8,   -6, 	  -8,  -12, 	  -1,   -8
+.2byte   -5,  -15, 	   1,  -16, 	  -9,  -10, 	   1,   -9
+.2byte   -6,  -14, 	   1,  -18, 	  -9,  -11, 	   0,   -9
+.2byte   -5,  -14, 	   3,  -10, 	  -9,   -5, 	   1,   -9
+.2byte   -9,  -12, 	 -10,  -12, 	  -9,   -6, 	  -1,   -9
+.2byte   -9,  -11, 	 -10,  -12, 	  -9,   -9, 	  -1,   -8
+.2byte   -9,  -11, 	  -9,  -12, 	  -8,   -1, 	   0,   -8
+.2byte   -5,   -9, 	 -10,   -9, 	   1,   -3, 	  -1,   -9
+.2byte   -6,   -8, 	 -11,  -11, 	   1,    0, 	  -2,   -8
+.2byte   -4,   -8, 	  -9,   -6, 	   2,   -5, 	   0,   -8
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte    0,  -12, 	  -6,  -10, 	   6,  -10, 	   0,  -13
+.2byte    0,   -3, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+.2byte    3,  -12, 	  10,  -11, 	   1,   -8, 	  -1,  -11
+.2byte    6,   -6, 	  10,   -3, 	   3,   -1, 	   0,   -8
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    3,  -14, 	   8,  -15, 	   7,  -10, 	  -3,   -9
+.2byte   10,   -7, 	   9,   -9, 	   8,   -2, 	   1,   -9
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    1,  -16, 	  -1,  -17, 	   7,  -13, 	  -4,   -7
+.2byte    9,  -10, 	  -5,  -11, 	   8,   -4, 	   2,  -11
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   5,  -12, 	  -6,  -12, 	  -1,   -6
+.2byte   -1,  -14, 	   5,   -7, 	  -5,   -7, 	   0,  -12
+.2byte   -5,  -15, 	   1,  -16, 	  -9,  -10, 	   1,   -9
+.2byte   -1,  -16, 	   1,  -17, 	  -7,  -13, 	   4,   -7
+.2byte   -9,  -10, 	   5,  -11, 	  -8,   -4, 	  -2,  -11
+.2byte   -9,  -12, 	 -10,  -12, 	  -9,   -6, 	  -1,   -9
+.2byte   -3,  -14, 	  -8,  -15, 	  -7,  -10, 	   3,   -9
+.2byte  -10,   -7, 	  -9,   -9, 	  -8,   -2, 	  -1,   -9
+.2byte   -5,   -9, 	 -10,   -9, 	   1,   -3, 	  -1,   -9
+.2byte   -3,  -12, 	 -10,  -11, 	  -1,   -8, 	   1,  -11
+.2byte   -6,   -6, 	 -10,   -3, 	  -3,   -1, 	   0,   -8
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte    0,  -12, 	  -6,  -10, 	   6,  -10, 	   0,  -13
+.2byte    0,   -3, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+.2byte    3,  -12, 	  10,  -11, 	   1,   -8, 	  -1,  -11
+.2byte    6,   -6, 	  10,   -3, 	   3,   -1, 	   0,   -8
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    3,  -14, 	   8,  -15, 	   7,  -10, 	  -3,   -9
+.2byte   10,   -7, 	   9,   -9, 	   8,   -2, 	   1,   -9
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    1,  -16, 	  -1,  -17, 	   7,  -13, 	  -4,   -7
+.2byte    9,  -10, 	  -5,  -11, 	   8,   -4, 	   2,  -11
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   5,  -12, 	  -6,  -12, 	  -1,   -6
+.2byte   -1,  -14, 	   5,   -7, 	  -5,   -7, 	   0,  -12
+.2byte   -5,  -15, 	   1,  -16, 	  -9,  -10, 	   1,   -9
+.2byte   -1,  -16, 	   1,  -17, 	  -7,  -13, 	   4,   -7
+.2byte   -9,  -10, 	   5,  -11, 	  -8,   -4, 	  -2,  -11
+.2byte   -9,  -12, 	 -10,  -12, 	  -9,   -6, 	  -1,   -9
+.2byte   -3,  -14, 	  -8,  -15, 	  -7,  -10, 	   3,   -9
+.2byte  -10,   -7, 	  -9,   -9, 	  -8,   -2, 	  -1,   -9
+.2byte   -5,   -9, 	 -10,   -9, 	   1,   -3, 	  -1,   -9
+.2byte   -3,  -12, 	 -10,  -11, 	  -1,   -8, 	   1,  -11
+.2byte   -6,   -6, 	 -10,   -3, 	  -3,   -1, 	   0,   -8
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte    0,  -11, 	  -6,   -9, 	   6,   -9, 	   0,  -12
+.2byte    0,   -6, 	 -12,   -8, 	  12,   -8, 	   0,   -8
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+.2byte    3,  -12, 	  10,  -11, 	   1,   -8, 	  -1,  -11
+.2byte    6,   -7, 	  10,  -12, 	 -11,   -2, 	  -1,   -8
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    2,  -14, 	   7,  -15, 	   6,  -10, 	  -4,   -9
+.2byte   10,  -11, 	  -1,  -11, 	  -1,   -2, 	   2,  -10
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    3,  -16, 	   1,  -17, 	   9,  -13, 	  -2,   -7
+.2byte    8,  -14, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   5,  -12, 	  -6,  -12, 	  -1,   -6
+.2byte   -1,  -15, 	  12,   -8, 	 -13,   -8, 	   0,  -10
+.2byte   -5,  -15, 	   1,  -16, 	  -9,  -10, 	   1,   -9
+.2byte   -3,  -16, 	  -1,  -17, 	  -9,  -13, 	   2,   -7
+.2byte   -8,  -14, 	  10,  -10, 	  -8,   -2, 	   0,   -9
+.2byte   -9,  -12, 	 -10,  -12, 	  -9,   -6, 	  -1,   -9
+.2byte   -2,  -14, 	  -7,  -15, 	  -6,  -10, 	   4,   -9
+.2byte  -10,  -11, 	   1,  -11, 	   1,   -2, 	  -2,  -10
+.2byte   -5,   -9, 	 -10,   -9, 	   1,   -3, 	  -1,   -9
+.2byte   -3,  -12, 	 -10,  -11, 	  -1,   -8, 	   1,  -11
+.2byte   -6,   -7, 	 -10,  -12, 	  11,   -2, 	   1,   -8
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte    0,   -3, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    0,   -6, 	 -12,   -8, 	  12,   -8, 	   0,   -8
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+.2byte    5,   -6, 	   9,   -3, 	   2,   -1, 	  -1,   -8
+.2byte    6,   -7, 	  10,  -12, 	 -11,   -2, 	  -1,   -8
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    9,   -7, 	   8,   -9, 	   7,   -2, 	   0,   -9
+.2byte    8,  -11, 	  -3,  -11, 	  -3,   -2, 	   0,  -10
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    9,  -10, 	  -5,  -11, 	   8,   -4, 	   2,  -11
+.2byte    8,  -14, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -14, 	   5,   -7, 	  -5,   -7, 	   0,  -12
+.2byte   -1,  -15, 	  12,   -8, 	 -13,   -8, 	   0,  -10
+.2byte   -5,  -15, 	   1,  -16, 	  -9,  -10, 	   1,   -9
+.2byte   -9,  -10, 	   5,  -11, 	  -8,   -4, 	  -2,  -11
+.2byte   -8,  -14, 	  10,  -10, 	  -8,   -2, 	   0,   -9
+.2byte   -9,  -12, 	 -10,  -12, 	  -9,   -6, 	  -1,   -9
+.2byte   -9,   -7, 	  -8,   -9, 	  -7,   -2, 	   0,   -9
+.2byte   -8,  -11, 	   3,  -11, 	   3,   -2, 	   0,  -10
+.2byte   -5,   -9, 	 -10,   -9, 	   1,   -3, 	  -1,   -9
+.2byte   -5,   -6, 	  -9,   -3, 	  -2,   -1, 	   1,   -8
+.2byte   -6,   -7, 	 -10,  -12, 	  11,   -2, 	   1,   -8
+.2byte    1,  -11, 	   4,  -11, 	  -2,    0, 	   0,   -7
+.2byte    1,  -11, 	   4,  -11, 	  -2,    0, 	   0,   -7
+.2byte    0,  -11, 	  -6,  -13, 	   6,  -13, 	   0,  -12
+.2byte    1,  -10, 	   2,  -15, 	  -9,  -10, 	  -3,   -9
+.2byte    1,  -13, 	  -4,  -15, 	  -4,  -10, 	  -5,   -7
+.2byte    1,  -11, 	  -5,  -12, 	   2,   -8, 	  -3,   -5
+.2byte    0,   -9, 	   7,   -8, 	  -7,   -8, 	   0,   -4
+.2byte   -2,  -11, 	   4,  -12, 	  -3,   -8, 	   2,   -5
+.2byte   -2,  -13, 	   3,  -15, 	   3,  -10, 	   4,   -7
+.2byte   -2,  -10, 	  -3,  -15, 	   8,  -10, 	   2,   -9
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte    0,  -11, 	  -6,   -9, 	   6,   -9, 	   0,  -12
+.2byte    0,   -3, 	  -4,    0, 	   4,    0, 	   0,   -7
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+.2byte    3,  -12, 	  10,  -11, 	   1,   -8, 	  -1,  -11
+.2byte    6,   -6, 	  10,   -3, 	   3,   -1, 	   0,   -8
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    3,  -14, 	   8,  -15, 	   7,  -10, 	  -3,   -9
+.2byte   10,   -7, 	   9,   -9, 	   8,   -2, 	   1,   -9
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    4,  -16, 	   2,  -17, 	  10,  -13, 	  -1,   -7
+.2byte    9,  -10, 	  -5,  -11, 	   8,   -4, 	   2,  -11
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -18, 	   5,  -16, 	  -6,  -16, 	  -1,  -10
+.2byte   -1,  -12, 	   5,   -5, 	  -5,   -5, 	   0,  -10
+.2byte   -5,  -15, 	   1,  -16, 	  -9,  -10, 	   1,   -9
+.2byte   -4,  -16, 	  -2,  -17, 	 -10,  -13, 	   1,   -7
+.2byte   -9,  -10, 	   5,  -11, 	  -8,   -4, 	  -2,  -11
+.2byte   -9,  -12, 	 -10,  -12, 	  -9,   -6, 	  -1,   -9
+.2byte   -5,  -14, 	 -10,  -15, 	  -9,  -10, 	   1,   -9
+.2byte   -9,   -7, 	  -8,   -9, 	  -7,   -2, 	   0,   -9
+.2byte   -5,   -9, 	 -10,   -9, 	   1,   -3, 	  -1,   -9
+.2byte   -3,  -12, 	 -10,  -11, 	  -1,   -8, 	   1,  -11
+.2byte   -6,   -6, 	 -10,   -3, 	  -3,   -1, 	   0,   -8
+.2byte    0,   -6, 	 -12,   -8, 	  12,   -8, 	   0,   -8
+.2byte   -6,   -7, 	 -10,  -12, 	  11,   -2, 	   1,   -8
+.2byte   -8,  -10, 	   3,  -10, 	   3,   -1, 	   0,   -9
+.2byte   -8,  -13, 	  10,   -9, 	  -8,   -1, 	   0,   -8
+.2byte   -1,  -14, 	  12,   -7, 	 -13,   -7, 	   0,   -9
+.2byte    7,  -13, 	 -11,   -9, 	   7,   -1, 	  -1,   -8
+.2byte    7,  -10, 	  -4,  -10, 	  -4,   -1, 	  -1,   -9
+.2byte    5,   -7, 	   9,  -12, 	 -12,   -2, 	  -2,   -8
+.2byte    0,   -6, 	 -12,   -8, 	  12,   -8, 	   0,   -8
+.2byte    5,   -7, 	   9,  -12, 	 -12,   -2, 	  -2,   -8
+.2byte    7,  -10, 	  -4,  -10, 	  -4,   -1, 	  -1,   -9
+.2byte    7,  -13, 	 -11,   -9, 	   7,   -1, 	  -1,   -8
+.2byte   -1,  -14, 	  12,   -7, 	 -13,   -7, 	   0,   -9
+.2byte   -8,  -13, 	  10,   -9, 	  -8,   -1, 	   0,   -8
+.2byte   -8,  -10, 	   3,  -10, 	   3,   -1, 	   0,   -9
+.2byte   -6,   -7, 	 -10,  -12, 	  11,   -2, 	   1,   -8
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte    0,  -11, 	  -6,   -9, 	   6,   -9, 	   0,  -12
+.2byte    0,   -6, 	 -12,   -8, 	  12,   -8, 	   0,   -8
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+.2byte    4,  -11, 	  11,  -10, 	   2,   -7, 	   0,  -10
+.2byte    6,   -7, 	  10,  -12, 	 -11,   -2, 	  -1,   -8
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    5,  -14, 	  10,  -15, 	   9,  -10, 	  -1,   -9
+.2byte    8,  -11, 	  -3,  -11, 	  -3,   -2, 	   0,  -10
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    4,  -17, 	   2,  -18, 	  10,  -14, 	  -1,   -8
+.2byte    8,  -14, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -1,  -16, 	   5,  -14, 	  -6,  -14, 	  -1,   -8
+.2byte   -1,  -14, 	  12,   -7, 	 -13,   -7, 	   0,   -9
+.2byte   -6,  -15, 	   0,  -16, 	 -10,  -10, 	   0,   -9
+.2byte   -5,  -17, 	  -3,  -18, 	 -11,  -14, 	   0,   -8
+.2byte   -9,  -14, 	   9,  -10, 	  -9,   -2, 	  -1,   -9
+.2byte  -10,  -12, 	 -11,  -12, 	 -10,   -6, 	  -2,   -9
+.2byte   -6,  -14, 	 -11,  -15, 	 -10,  -10, 	   0,   -9
+.2byte   -9,  -11, 	   2,  -11, 	   2,   -2, 	  -1,  -10
+.2byte   -6,   -9, 	 -11,   -9, 	   0,   -3, 	  -2,   -9
+.2byte   -5,  -11, 	 -12,  -10, 	  -3,   -7, 	  -1,  -10
+.2byte   -7,   -7, 	 -11,  -12, 	  10,   -2, 	   0,   -8
+.2byte    0,  -12, 	  -6,  -10, 	   6,  -10, 	   0,  -13
+.2byte   -3,  -12, 	 -10,  -11, 	  -1,   -8, 	   1,  -11
+.2byte   -4,  -14, 	  -9,  -15, 	  -8,  -10, 	   2,   -9
+.2byte   -4,  -16, 	  -2,  -17, 	 -10,  -13, 	   1,   -7
+.2byte   -1,  -16, 	   5,  -14, 	  -6,  -14, 	  -1,   -8
+.2byte    3,  -16, 	   1,  -17, 	   9,  -13, 	  -2,   -7
+.2byte    3,  -14, 	   8,  -15, 	   7,  -10, 	  -3,   -9
+.2byte    3,  -12, 	  10,  -11, 	   1,   -8, 	  -1,  -11
+.2byte    0,   -9, 	  -9,   -5, 	   9,   -5, 	   0,  -10
+.2byte   -5,   -9, 	 -10,   -9, 	   1,   -3, 	  -1,   -9
+.2byte   -9,  -12, 	 -10,  -12, 	  -9,   -6, 	  -1,   -9
+.2byte   -5,  -15, 	   1,  -16, 	  -9,  -10, 	   1,   -9
+.2byte    0,  -12, 	   8,   -8, 	  -8,   -8, 	   0,   -9
+.2byte    5,  -15, 	  -1,  -16, 	   9,  -10, 	  -1,   -9
+.2byte    9,  -12, 	  10,  -12, 	   9,   -6, 	   1,   -9
+.2byte    5,   -9, 	  10,   -9, 	  -1,   -3, 	   1,   -9
+sNosepassAnimTable1:
+.4byte sNosepassAnims_1_1
+.4byte sNosepassAnims_1_2
+.4byte sNosepassAnims_1_3
+.4byte sNosepassAnims_1_4
+.4byte sNosepassAnims_1_5
+.4byte sNosepassAnims_1_6
+.4byte sNosepassAnims_1_7
+.4byte sNosepassAnims_1_8
+sNosepassAnimTable2:
+.4byte sNosepassAnims_2_1
+.4byte sNosepassAnims_2_2
+.4byte sNosepassAnims_2_3
+.4byte sNosepassAnims_2_4
+.4byte sNosepassAnims_2_5
+.4byte sNosepassAnims_2_6
+.4byte sNosepassAnims_2_7
+.4byte sNosepassAnims_2_8
+sNosepassAnimTable3:
+.4byte sNosepassAnims_3_1
+.4byte sNosepassAnims_3_2
+.4byte sNosepassAnims_3_3
+.4byte sNosepassAnims_3_4
+.4byte sNosepassAnims_3_5
+.4byte sNosepassAnims_3_6
+.4byte sNosepassAnims_3_7
+.4byte sNosepassAnims_3_8
+sNosepassAnimTable4:
+.4byte sNosepassAnims_4_1
+.4byte sNosepassAnims_4_2
+.4byte sNosepassAnims_4_3
+.4byte sNosepassAnims_4_4
+.4byte sNosepassAnims_4_5
+.4byte sNosepassAnims_4_6
+.4byte sNosepassAnims_4_7
+.4byte sNosepassAnims_4_8
+sNosepassAnimTable5:
+.4byte sNosepassAnims_5_1
+.4byte sNosepassAnims_5_2
+.4byte sNosepassAnims_5_3
+.4byte sNosepassAnims_5_4
+.4byte sNosepassAnims_5_5
+.4byte sNosepassAnims_5_6
+.4byte sNosepassAnims_5_7
+.4byte sNosepassAnims_5_8
+sNosepassAnimTable6:
+.4byte sNosepassAnims_6_1
+.4byte sNosepassAnims_6_1
+.4byte sNosepassAnims_6_1
+.4byte sNosepassAnims_6_1
+.4byte sNosepassAnims_6_1
+.4byte sNosepassAnims_6_1
+.4byte sNosepassAnims_6_1
+.4byte sNosepassAnims_6_1
+sNosepassAnimTable7:
+.4byte sNosepassAnims_7_1
+.4byte sNosepassAnims_7_2
+.4byte sNosepassAnims_7_3
+.4byte sNosepassAnims_7_4
+.4byte sNosepassAnims_7_5
+.4byte sNosepassAnims_7_6
+.4byte sNosepassAnims_7_7
+.4byte sNosepassAnims_7_8
+sNosepassAnimTable8:
+.4byte sNosepassAnims_8_1
+.4byte sNosepassAnims_8_2
+.4byte sNosepassAnims_8_3
+.4byte sNosepassAnims_8_4
+.4byte sNosepassAnims_8_5
+.4byte sNosepassAnims_8_6
+.4byte sNosepassAnims_8_7
+.4byte sNosepassAnims_8_8
+sNosepassAnimTable9:
+.4byte sNosepassAnims_9_1
+.4byte sNosepassAnims_9_2
+.4byte sNosepassAnims_9_3
+.4byte sNosepassAnims_9_4
+.4byte sNosepassAnims_9_5
+.4byte sNosepassAnims_9_6
+.4byte sNosepassAnims_9_7
+.4byte sNosepassAnims_9_8
+sNosepassAnimTable10:
+.4byte sNosepassAnims_10_1
+.4byte sNosepassAnims_10_2
+.4byte sNosepassAnims_10_3
+.4byte sNosepassAnims_10_4
+.4byte sNosepassAnims_10_5
+.4byte sNosepassAnims_10_6
+.4byte sNosepassAnims_10_7
+.4byte sNosepassAnims_10_8
+sNosepassAnimTable11:
+.4byte sNosepassAnims_11_1
+.4byte sNosepassAnims_11_2
+.4byte sNosepassAnims_11_3
+.4byte sNosepassAnims_11_4
+.4byte sNosepassAnims_11_5
+.4byte sNosepassAnims_11_6
+.4byte sNosepassAnims_11_7
+.4byte sNosepassAnims_11_8
+sNosepassAnimTable12:
+.4byte sNosepassAnims_12_1
+.4byte sNosepassAnims_12_2
+.4byte sNosepassAnims_12_3
+.4byte sNosepassAnims_12_4
+.4byte sNosepassAnims_12_5
+.4byte sNosepassAnims_12_6
+.4byte sNosepassAnims_12_7
+.4byte sNosepassAnims_12_8
+sNosepassAnimTable13:
+.4byte sNosepassAnims_13_1
+.4byte sNosepassAnims_13_2
+.4byte sNosepassAnims_13_3
+.4byte sNosepassAnims_13_4
+.4byte sNosepassAnims_13_5
+.4byte sNosepassAnims_13_6
+.4byte sNosepassAnims_13_7
+.4byte sNosepassAnims_13_8
+sAxAnimationsNosepass:
+.4byte sNosepassAnimTable1
+.4byte sNosepassAnimTable2
+.4byte sNosepassAnimTable3
+.4byte sNosepassAnimTable4
+.4byte sNosepassAnimTable5
+.4byte sNosepassAnimTable6
+.4byte sNosepassAnimTable7
+.4byte sNosepassAnimTable8
+.4byte sNosepassAnimTable9
+.4byte sNosepassAnimTable10
+.4byte sNosepassAnimTable11
+.4byte sNosepassAnimTable12
+.4byte sNosepassAnimTable13
+sAxSpritesNosepass:
+.4byte sNosepassSprites1
+.4byte sNosepassSprites2
+.4byte sNosepassSprites3
+.4byte sNosepassSprites4
+.4byte sNosepassSprites5
+.4byte sNosepassSprites6
+.4byte sNosepassSprites7
+.4byte sNosepassSprites8
+.4byte sNosepassSprites9
+.4byte sNosepassSprites10
+.4byte sNosepassSprites11
+.4byte sNosepassSprites12
+.4byte sNosepassSprites13
+.4byte sNosepassSprites14
+.4byte sNosepassSprites15
+.4byte sNosepassSprites16
+.4byte sNosepassSprites17
+.4byte sNosepassSprites18
+.4byte sNosepassSprites19
+.4byte sNosepassSprites20
+.4byte sNosepassSprites21
+.4byte sNosepassSprites22
+.4byte sNosepassSprites23
+.4byte sNosepassSprites24
+.4byte sNosepassSprites25
+.4byte sNosepassSprites26
+.4byte sNosepassSprites27
+.4byte sNosepassSprites28
+.4byte sNosepassSprites29
+.4byte sNosepassSprites30
+.4byte sNosepassSprites31
+.4byte sNosepassSprites32
+.4byte sNosepassSprites33
+.4byte sNosepassSprites34
+.4byte sNosepassSprites35
+.4byte sNosepassSprites36
+.4byte sNosepassSprites37
+sAxMainNosepass:
+ax_main sAxPosesNosepass, sAxAnimationsNosepass, 13, sAxSpritesNosepass, sAxPositionsNosepass

--- a/data/ax/numel.inc
+++ b/data/ax/numel.inc
@@ -1,0 +1,2590 @@
+.global gAxNumel
+gAxNumel:
+ax_siro sAxMainNumel
+sNumelPose1:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose2:
+ax_pose 1, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose3:
+ax_pose 2, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose4:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose5:
+ax_pose 4, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose6:
+ax_pose 5, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose7:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose8:
+ax_pose 7, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose9:
+ax_pose 8, 0x01ec, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose10:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose12:
+ax_pose 11, 0x01ed, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose13:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose14:
+ax_pose 13, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose15:
+ax_pose 14, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose16:
+ax_pose 9, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose17:
+ax_pose 10, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose18:
+ax_pose 11, 0x01ed, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose21:
+ax_pose 8, 0x01ec, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose22:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose23:
+ax_pose 4, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose24:
+ax_pose 5, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose25:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose26:
+ax_pose 15, 0x81ea, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose27:
+ax_pose 16, 0x81ed, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose28:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose29:
+ax_pose 17, 0x01e9, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose30:
+ax_pose 18, 0x01ea, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose31:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose32:
+ax_pose 19, 0x01e7, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose33:
+ax_pose 20, 0x01e8, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose34:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose35:
+ax_pose 21, 0x01e7, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose36:
+ax_pose 22, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose37:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose38:
+ax_pose 23, 0x81e8, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose39:
+ax_pose 24, 0x81e9, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose40:
+ax_pose 9, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose41:
+ax_pose 21, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose42:
+ax_pose 22, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose43:
+ax_pose 6, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose44:
+ax_pose 19, 0x01e7, 0x80ee, 0x8c00
+ax_pose_terminator
+sNumelPose45:
+ax_pose 20, 0x01e8, 0x80ee, 0x8c00
+ax_pose_terminator
+sNumelPose46:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose47:
+ax_pose 17, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose48:
+ax_pose 18, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose49:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose50:
+ax_pose 15, 0x81ea, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose51:
+ax_pose 16, 0x81ed, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose52:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose53:
+ax_pose 17, 0x01e9, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose54:
+ax_pose 18, 0x01ea, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose55:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose56:
+ax_pose 19, 0x01e7, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose57:
+ax_pose 20, 0x01e8, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose58:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose59:
+ax_pose 21, 0x01e7, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose60:
+ax_pose 22, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose61:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose62:
+ax_pose 23, 0x81e8, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose63:
+ax_pose 24, 0x81e9, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose64:
+ax_pose 9, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose65:
+ax_pose 21, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose66:
+ax_pose 22, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose67:
+ax_pose 6, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose68:
+ax_pose 19, 0x01e7, 0x80ee, 0x8c00
+ax_pose_terminator
+sNumelPose69:
+ax_pose 20, 0x01e8, 0x80ee, 0x8c00
+ax_pose_terminator
+sNumelPose70:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose71:
+ax_pose 17, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose72:
+ax_pose 18, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose73:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose74:
+ax_pose 25, 0x81ec, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose75:
+ax_pose 16, 0x81ed, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose76:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose77:
+ax_pose 26, 0x01ea, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose78:
+ax_pose 18, 0x01ea, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose79:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose80:
+ax_pose 27, 0x01e8, 0x90ea, 0x8c00
+ax_pose_terminator
+sNumelPose81:
+ax_pose 20, 0x01e8, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose82:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose83:
+ax_pose 28, 0x01e8, 0x90e9, 0x8c00
+ax_pose_terminator
+sNumelPose84:
+ax_pose 22, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose85:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose86:
+ax_pose 29, 0x81e8, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose87:
+ax_pose 24, 0x81e9, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose88:
+ax_pose 9, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose89:
+ax_pose 28, 0x01e8, 0x80f6, 0x8c00
+ax_pose_terminator
+sNumelPose90:
+ax_pose 22, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose91:
+ax_pose 6, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose92:
+ax_pose 27, 0x01e8, 0x80f5, 0x8c00
+ax_pose_terminator
+sNumelPose93:
+ax_pose 20, 0x01e8, 0x80ee, 0x8c00
+ax_pose_terminator
+sNumelPose94:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose95:
+ax_pose 26, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose96:
+ax_pose 18, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose97:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose98:
+ax_pose 25, 0x81ec, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose99:
+ax_pose 30, 0x81ec, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose100:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose101:
+ax_pose 26, 0x01ea, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose102:
+ax_pose 31, 0x01ea, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose103:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose104:
+ax_pose 27, 0x01e8, 0x90ea, 0x8c00
+ax_pose_terminator
+sNumelPose105:
+ax_pose 32, 0x01e8, 0x90ea, 0x8c00
+ax_pose_terminator
+sNumelPose106:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose107:
+ax_pose 28, 0x01e8, 0x90e9, 0x8c00
+ax_pose_terminator
+sNumelPose108:
+ax_pose 33, 0x01e8, 0x90e9, 0x8c00
+ax_pose_terminator
+sNumelPose109:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose110:
+ax_pose 29, 0x81e8, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose111:
+ax_pose 34, 0x81e8, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose112:
+ax_pose 9, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose113:
+ax_pose 28, 0x01e8, 0x80f6, 0x8c00
+ax_pose_terminator
+sNumelPose114:
+ax_pose 33, 0x01e8, 0x80f6, 0x8c00
+ax_pose_terminator
+sNumelPose115:
+ax_pose 6, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose116:
+ax_pose 27, 0x01e8, 0x80f5, 0x8c00
+ax_pose_terminator
+sNumelPose117:
+ax_pose 32, 0x01e8, 0x80f5, 0x8c00
+ax_pose_terminator
+sNumelPose118:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose119:
+ax_pose 26, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose120:
+ax_pose 31, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose121:
+ax_pose 35, 0x01f0, 0x80f3, 0x8c00
+ax_pose_terminator
+sNumelPose122:
+ax_pose 36, 0x01f0, 0x80f3, 0x8c00
+ax_pose_terminator
+sNumelPose123:
+ax_pose 37, 0x01e0, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose124:
+ax_pose 38, 0x01e1, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose125:
+ax_pose 39, 0x01e2, 0x90ea, 0x8c00
+ax_pose_terminator
+sNumelPose126:
+ax_pose 40, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sNumelPose127:
+ax_pose 41, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose128:
+ax_pose 40, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sNumelPose129:
+ax_pose 39, 0x01e2, 0x80f6, 0x8c00
+ax_pose_terminator
+sNumelPose130:
+ax_pose 38, 0x01e1, 0x80f3, 0x8c00
+ax_pose_terminator
+sNumelPose131:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose132:
+ax_pose 16, 0x81ed, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose133:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose134:
+ax_pose 18, 0x01ea, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose135:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose136:
+ax_pose 20, 0x01e8, 0x90f2, 0x8c00
+ax_pose_terminator
+sNumelPose137:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose138:
+ax_pose 22, 0x01e8, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose139:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose140:
+ax_pose 24, 0x81e9, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose141:
+ax_pose 9, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose142:
+ax_pose 22, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose143:
+ax_pose 6, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose144:
+ax_pose 20, 0x01e8, 0x80ed, 0x8c00
+ax_pose_terminator
+sNumelPose145:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose146:
+ax_pose 18, 0x01ea, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose147:
+ax_pose 16, 0x81ec, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose148:
+ax_pose 18, 0x01ea, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose149:
+ax_pose 20, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose150:
+ax_pose 22, 0x01ea, 0x80f3, 0x8c00
+ax_pose_terminator
+sNumelPose151:
+ax_pose 24, 0x81eb, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose152:
+ax_pose 22, 0x01ea, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose153:
+ax_pose 20, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose154:
+ax_pose 18, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose155:
+ax_pose 16, 0x81ec, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose156:
+ax_pose 18, 0x01ea, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose157:
+ax_pose 20, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose158:
+ax_pose 22, 0x01ea, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose159:
+ax_pose 24, 0x81eb, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose160:
+ax_pose 22, 0x01ea, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose161:
+ax_pose 20, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose162:
+ax_pose 18, 0x01ea, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose163:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose164:
+ax_pose 25, 0x81ef, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose165:
+ax_pose 16, 0x81eb, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose166:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+sNumelPose167:
+ax_pose 26, 0x01ed, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose168:
+ax_pose 18, 0x01ea, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose169:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose170:
+ax_pose 27, 0x01ea, 0x90ec, 0x8c00
+ax_pose_terminator
+sNumelPose171:
+ax_pose 20, 0x01e8, 0x90f1, 0x8c00
+ax_pose_terminator
+sNumelPose172:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose173:
+ax_pose 28, 0x01e9, 0x90eb, 0x8c00
+ax_pose_terminator
+sNumelPose174:
+ax_pose 22, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose175:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose176:
+ax_pose 29, 0x81ea, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose177:
+ax_pose 24, 0x81ea, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose178:
+ax_pose 9, 0x01ec, 0x80f3, 0x8c00
+ax_pose_terminator
+sNumelPose179:
+ax_pose 28, 0x01e9, 0x80f5, 0x8c00
+ax_pose_terminator
+sNumelPose180:
+ax_pose 22, 0x01e9, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose181:
+ax_pose 6, 0x01ec, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose182:
+ax_pose 27, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNumelPose183:
+ax_pose 20, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose184:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose185:
+ax_pose 26, 0x01ed, 0x80ef, 0x8c00
+ax_pose_terminator
+sNumelPose186:
+ax_pose 18, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose187:
+ax_pose 15, 0x81ea, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose188:
+ax_pose 17, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose189:
+ax_pose 19, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose190:
+ax_pose 21, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sNumelPose191:
+ax_pose 23, 0x81e9, 0x80f7, 0x8c00
+ax_pose_terminator
+sNumelPose192:
+ax_pose 21, 0x01e7, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose193:
+ax_pose 19, 0x01e7, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose194:
+ax_pose 17, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sNumelPose195:
+ax_pose 0, 0x81ee, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose196:
+ax_pose 3, 0x01ee, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose197:
+ax_pose 6, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sNumelPose198:
+ax_pose 9, 0x01ec, 0x80f2, 0x8c00
+ax_pose_terminator
+sNumelPose199:
+ax_pose 12, 0x81ed, 0x80f8, 0x8c00
+ax_pose_terminator
+sNumelPose200:
+ax_pose 9, 0x01ec, 0x90ed, 0x8c00
+ax_pose_terminator
+sNumelPose201:
+ax_pose 6, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sNumelPose202:
+ax_pose 3, 0x01ee, 0x90ee, 0x8c00
+ax_pose_terminator
+.align 2
+sNumelAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNumelAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -3, 0, 1,
+ax_anim 2, 0, 25, 0, 1, 0, 4,
+ax_anim 2, 2, 25, 0, 10, 0, 12,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 1, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 0, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNumelAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 3, -1, 3, 3,
+ax_anim 2, 0, 28, 9, 4, 9, 9,
+ax_anim 2, 2, 28, 15, 14, 15, 16,
+ax_anim 2, 0, 29, 17, 18, 17, 18,
+ax_anim 2, 1, 29, 18, 17, 18, 17,
+ax_anim 2, 0, 29, 17, 18, 17, 18,
+ax_anim 2, 0, 29, 18, 17, 18, 17,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sNumelAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 4, -3, 4, 0,
+ax_anim 2, 0, 31, 9, -5, 9, 0,
+ax_anim 2, 2, 31, 13, -4, 13, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, -1,
+ax_anim_terminator
+sNumelAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 3, -9, 3, -3,
+ax_anim 2, 0, 34, 8, -17, 8, -8,
+ax_anim 2, 2, 34, 16, -20, 16, -16,
+ax_anim 2, 0, 35, 19, -21, 19, -19,
+ax_anim 2, 1, 35, 20, -20, 20, -18,
+ax_anim 2, 0, 35, 19, -21, 19, -19,
+ax_anim 2, 0, 35, 20, -20, 20, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sNumelAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, -5, 0, -1,
+ax_anim 2, 0, 37, 0, -11, 0, -6,
+ax_anim 2, 2, 37, 0, -16, 0, -13,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 1, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 0, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sNumelAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, -3, -9, -3, -3,
+ax_anim 2, 0, 40, -8, -17, -8, -8,
+ax_anim 2, 2, 40, -16, -20, -16, -16,
+ax_anim 2, 0, 41, -19, -21, -19, -19,
+ax_anim 2, 1, 41, -20, -20, -20, -18,
+ax_anim 2, 0, 41, -19, -21, -19, -19,
+ax_anim 2, 0, 41, -20, -20, -20, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sNumelAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, -4, -3, -4, 0,
+ax_anim 2, 0, 43, -9, -5, -9, 0,
+ax_anim 2, 2, 43, -13, -4, -13, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, -1,
+ax_anim_terminator
+sNumelAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, -3, -1, -3, 3,
+ax_anim 2, 0, 46, -9, 4, -9, 9,
+ax_anim 2, 2, 46, -15, 14, -15, 16,
+ax_anim 2, 0, 47, -17, 18, -17, 18,
+ax_anim 2, 1, 47, -18, 17, -18, 17,
+ax_anim 2, 0, 47, -17, 18, -17, 18,
+ax_anim 2, 0, 47, -18, 17, -18, 17,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sNumelAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, -3, 0, 1,
+ax_anim 2, 0, 49, 0, 1, 0, 4,
+ax_anim 2, 2, 49, 0, 10, 0, 12,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 1, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 0, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sNumelAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 3, -1, 3, 3,
+ax_anim 2, 0, 52, 9, 4, 9, 9,
+ax_anim 2, 2, 52, 15, 14, 15, 16,
+ax_anim 2, 0, 53, 17, 18, 17, 18,
+ax_anim 2, 1, 53, 18, 17, 18, 17,
+ax_anim 2, 0, 53, 17, 18, 17, 18,
+ax_anim 2, 0, 53, 18, 17, 18, 17,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sNumelAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 4, -3, 4, 0,
+ax_anim 2, 0, 55, 9, -5, 9, 0,
+ax_anim 2, 2, 55, 13, -4, 13, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, -1,
+ax_anim_terminator
+sNumelAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 3, -9, 3, -3,
+ax_anim 2, 0, 58, 8, -17, 8, -8,
+ax_anim 2, 2, 58, 16, -20, 16, -16,
+ax_anim 2, 0, 59, 19, -21, 19, -19,
+ax_anim 2, 1, 59, 20, -20, 20, -18,
+ax_anim 2, 0, 59, 19, -21, 19, -19,
+ax_anim 2, 0, 59, 20, -20, 20, -18,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sNumelAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, -5, 0, -1,
+ax_anim 2, 0, 61, 0, -11, 0, -6,
+ax_anim 2, 2, 61, 0, -16, 0, -13,
+ax_anim 2, 0, 62, 0, -19, 0, -19,
+ax_anim 2, 1, 62, 1, -19, 1, -19,
+ax_anim 2, 0, 62, 0, -19, 0, -19,
+ax_anim 2, 0, 62, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sNumelAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, -3, -9, -3, -3,
+ax_anim 2, 0, 64, -8, -17, -8, -8,
+ax_anim 2, 2, 64, -16, -20, -16, -16,
+ax_anim 2, 0, 65, -19, -21, -19, -19,
+ax_anim 2, 1, 65, -20, -20, -20, -18,
+ax_anim 2, 0, 65, -19, -21, -19, -19,
+ax_anim 2, 0, 65, -20, -20, -20, -18,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sNumelAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, -4, -3, -4, 0,
+ax_anim 2, 0, 67, -9, -5, -9, 0,
+ax_anim 2, 2, 67, -13, -4, -13, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, -1,
+ax_anim_terminator
+sNumelAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, -3, -1, -3, 3,
+ax_anim 2, 0, 70, -9, 4, -9, 9,
+ax_anim 2, 2, 70, -15, 14, -15, 16,
+ax_anim 2, 0, 71, -17, 18, -17, 18,
+ax_anim 2, 1, 71, -18, 17, -18, 17,
+ax_anim 2, 0, 71, -17, 18, -17, 18,
+ax_anim 2, 0, 71, -18, 17, -18, 17,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sNumelAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sNumelAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sNumelAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sNumelAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sNumelAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sNumelAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sNumelAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sNumelAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNumelAnims_5_1:
+ax_anim 6, 2, 97, 0, 0, 0, 0,
+ax_anim 3, 0, 97, 0, 3, 0, 3,
+ax_anim 3, 0, 98, 1, 3, 1, 3,
+ax_anim 3, 0, 97, 0, 3, 0, 3,
+ax_anim 3, 1, 98, 1, 3, 1, 3,
+ax_anim 3, 0, 97, 0, 3, 0, 3,
+ax_anim 3, 0, 98, 1, 3, 1, 3,
+ax_anim 3, 0, 97, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim_terminator
+sNumelAnims_5_2:
+ax_anim 6, 2, 100, 1, 1, 1, 1,
+ax_anim 3, 0, 100, 3, 3, 3, 3,
+ax_anim 3, 0, 101, 4, 2, 4, 2,
+ax_anim 3, 0, 100, 3, 3, 3, 3,
+ax_anim 3, 1, 101, 4, 2, 4, 2,
+ax_anim 3, 0, 100, 3, 3, 3, 3,
+ax_anim 3, 0, 101, 4, 2, 4, 2,
+ax_anim 3, 0, 100, 3, 3, 3, 3,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sNumelAnims_5_3:
+ax_anim 6, 2, 103, -1, 0, -1, 0,
+ax_anim 3, 0, 103, 3, 0, 3, 0,
+ax_anim 3, 0, 104, 3, 1, 3, 1,
+ax_anim 3, 0, 103, 3, 0, 3, 0,
+ax_anim 3, 1, 104, 3, 1, 3, 1,
+ax_anim 3, 0, 103, 3, 0, 3, 0,
+ax_anim 3, 0, 104, 3, 1, 3, 1,
+ax_anim 3, 0, 103, 3, 0, 3, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim_terminator
+sNumelAnims_5_4:
+ax_anim 6, 2, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 3, -3, 3, -3,
+ax_anim 3, 0, 107, 4, -2, 4, -2,
+ax_anim 3, 0, 106, 3, -3, 3, -3,
+ax_anim 3, 1, 107, 4, -2, 4, -2,
+ax_anim 3, 0, 106, 3, -3, 3, -3,
+ax_anim 3, 0, 107, 4, -2, 4, -2,
+ax_anim 3, 0, 106, 3, -3, 3, -3,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim_terminator
+sNumelAnims_5_5:
+ax_anim 6, 2, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, -3, 0, -3,
+ax_anim 3, 0, 110, 1, -3, 1, -3,
+ax_anim 3, 0, 109, 0, -3, 0, -3,
+ax_anim 3, 1, 110, 1, -3, 1, -3,
+ax_anim 3, 0, 109, 0, -3, 0, -3,
+ax_anim 3, 0, 110, 1, -3, 1, -3,
+ax_anim 3, 0, 109, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sNumelAnims_5_6:
+ax_anim 6, 2, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 112, -3, -3, -3, -3,
+ax_anim 3, 0, 113, -4, -2, -4, -2,
+ax_anim 3, 0, 112, -3, -3, -3, -3,
+ax_anim 3, 1, 113, -4, -2, -4, -2,
+ax_anim 3, 0, 112, -3, -3, -3, -3,
+ax_anim 3, 0, 113, -4, -2, -4, -2,
+ax_anim 3, 0, 112, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+sNumelAnims_5_7:
+ax_anim 6, 2, 115, 1, 0, 1, 0,
+ax_anim 3, 0, 115, -3, 0, -3, 0,
+ax_anim 3, 0, 116, -3, 1, -3, 1,
+ax_anim 3, 0, 115, -3, 0, -3, 0,
+ax_anim 3, 1, 116, -3, 1, -3, 1,
+ax_anim 3, 0, 115, -3, 0, -3, 0,
+ax_anim 3, 0, 116, -3, 1, -3, 1,
+ax_anim 3, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim_terminator
+sNumelAnims_5_8:
+ax_anim 6, 2, 118, -1, 1, -1, 1,
+ax_anim 3, 0, 118, -3, 3, -3, 3,
+ax_anim 3, 0, 119, -4, 2, -4, 2,
+ax_anim 3, 0, 118, -3, 3, -3, 3,
+ax_anim 3, 1, 119, -4, 2, -4, 2,
+ax_anim 3, 0, 118, -3, 3, -3, 3,
+ax_anim 3, 0, 119, -4, 2, -4, 2,
+ax_anim 3, 0, 118, -3, 3, -3, 3,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sNumelAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNumelAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sNumelAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sNumelAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sNumelAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sNumelAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sNumelAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sNumelAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sNumelAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sNumelAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 12, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_8_2:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_8_3:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 12, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_8_4:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_8_5:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 12, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_8_6:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_8_7:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 12, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_8_8:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNumelAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 8, 3, 8, 3,
+ax_anim 2, 0, 148, 11, 10, 11, 10,
+ax_anim 2, 0, 149, 7, 16, 7, 16,
+ax_anim 3, 0, 150, 0, 19, 0, 19,
+ax_anim 2, 3, 151, -7, 16, -7, 16,
+ax_anim 2, 0, 152, -11, 10, -11, 10,
+ax_anim 1, 0, 153, -8, 3, -8, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 22, 10, 22, 10,
+ax_anim 3, 0, 149, 20, 18, 20, 18,
+ax_anim 2, 3, 150, 10, 19, 10, 19,
+ax_anim 2, 0, 151, 3, 14, 3, 14,
+ax_anim 1, 0, 152, -1, 7, -1, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 4, -5, 4, -5,
+ax_anim 2, 0, 146, 12, -7, 12, -7,
+ax_anim 2, 0, 147, 20, -5, 20, -5,
+ax_anim 3, 0, 148, 22, -1, 22, -1,
+ax_anim 2, 3, 149, 17, 4, 17, 4,
+ax_anim 2, 0, 150, 11, 5, 11, 5,
+ax_anim 1, 0, 151, 5, 4, 5, 4,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -9, -1, -9,
+ax_anim 2, 0, 153, 2, -17, 2, -17,
+ax_anim 2, 0, 146, 11, -22, 11, -22,
+ax_anim 3, 0, 147, 21, -25, 21, -25,
+ax_anim 2, 3, 148, 24, -16, 24, -16,
+ax_anim 2, 0, 149, 17, -6, 17, -6,
+ax_anim 1, 0, 150, 10, -1, 10, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -3, -8, -3,
+ax_anim 2, 0, 152, -11, -12, -11, -12,
+ax_anim 2, 0, 153, -8, -22, -8, -22,
+ax_anim 3, 0, 146, 0, -25, 0, -25,
+ax_anim 2, 3, 147, 8, -22, 8, -22,
+ax_anim 2, 0, 148, 11, -12, 11, -12,
+ax_anim 1, 0, 149, 8, -3, 8, -3,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -2, -17, -2, -17,
+ax_anim 2, 0, 146, -11, -22, -11, -22,
+ax_anim 3, 0, 153, -21, -25, -21, -25,
+ax_anim 2, 3, 152, -24, -16, -24, -16,
+ax_anim 2, 0, 151, -17, -6, -17, -6,
+ax_anim 1, 0, 150, -10, -1, -10, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -4, -5, -4, -5,
+ax_anim 2, 0, 146, -12, -7, -12, -7,
+ax_anim 2, 0, 153, -20, -5, -20, -5,
+ax_anim 3, 0, 152, -22, -1, -22, -1,
+ax_anim 2, 3, 151, -17, 4, -17, 4,
+ax_anim 2, 0, 150, -11, 5, -11, 5,
+ax_anim 1, 0, 149, -5, 4, -5, 4,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -22, 10, -22, 10,
+ax_anim 3, 0, 151, -20, 18, -20, 18,
+ax_anim 2, 3, 150, -10, 19, -10, 19,
+ax_anim 2, 0, 149, -3, 14, -3, 14,
+ax_anim 1, 0, 148, 1, 7, 1, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNumelAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNumelAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 2, 0, 164, 0, -17, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 167, 0, -21, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -22, 0, 0,
+ax_anim 3, 0, 170, 0, -21, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -19, 0, 0,
+ax_anim 4, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 3, 0, 173, 0, -19, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -19, 0, 0,
+ax_anim 4, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -19, 0, 0,
+ax_anim 4, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 3, 0, 179, 0, -19, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 182, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNumelAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNumelAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sNumelGfx1:
+.incbin "baserom.gba", 0x1325918, 0x100
+sNumelSprites1:
+ax_sprite sNumelGfx1, 0x100
+ax_sprite_terminator
+sNumelGfx2:
+.incbin "baserom.gba", 0x1325A28, 0x100
+sNumelSprites2:
+ax_sprite sNumelGfx2, 0x100
+ax_sprite_terminator
+sNumelGfx3:
+.incbin "baserom.gba", 0x1325B38, 0x100
+sNumelSprites3:
+ax_sprite sNumelGfx3, 0x100
+ax_sprite_terminator
+sNumelGfx4:
+.incbin "baserom.gba", 0x1325C48, 0x200
+sNumelSprites4:
+ax_sprite sNumelGfx4, 0x200
+ax_sprite_terminator
+sNumelGfx5:
+.incbin "baserom.gba", 0x1325E58, 0x200
+sNumelSprites5:
+ax_sprite sNumelGfx5, 0x200
+ax_sprite_terminator
+sNumelGfx6:
+.incbin "baserom.gba", 0x1326068, 0x200
+sNumelSprites6:
+ax_sprite sNumelGfx6, 0x200
+ax_sprite_terminator
+sNumelGfx7:
+.incbin "baserom.gba", 0x1326278, 0x200
+sNumelSprites7:
+ax_sprite sNumelGfx7, 0x200
+ax_sprite_terminator
+sNumelGfx8:
+.incbin "baserom.gba", 0x1326488, 0x200
+sNumelSprites8:
+ax_sprite sNumelGfx8, 0x200
+ax_sprite_terminator
+sNumelGfx9:
+.incbin "baserom.gba", 0x1326698, 0x200
+sNumelSprites9:
+ax_sprite sNumelGfx9, 0x200
+ax_sprite_terminator
+sNumelGfx10:
+.incbin "baserom.gba", 0x13268A8, 0x200
+sNumelSprites10:
+ax_sprite sNumelGfx10, 0x200
+ax_sprite_terminator
+sNumelGfx11:
+.incbin "baserom.gba", 0x1326AB8, 0x200
+sNumelSprites11:
+ax_sprite sNumelGfx11, 0x200
+ax_sprite_terminator
+sNumelGfx12:
+.incbin "baserom.gba", 0x1326CC8, 0x200
+sNumelSprites12:
+ax_sprite sNumelGfx12, 0x200
+ax_sprite_terminator
+sNumelGfx13:
+.incbin "baserom.gba", 0x1326ED8, 0x100
+sNumelSprites13:
+ax_sprite sNumelGfx13, 0x100
+ax_sprite_terminator
+sNumelGfx14:
+.incbin "baserom.gba", 0x1326FE8, 0x100
+sNumelSprites14:
+ax_sprite sNumelGfx14, 0x100
+ax_sprite_terminator
+sNumelGfx15:
+.incbin "baserom.gba", 0x13270F8, 0x100
+sNumelSprites15:
+ax_sprite sNumelGfx15, 0x100
+ax_sprite_terminator
+sNumelGfx16:
+.incbin "baserom.gba", 0x1327208, 0xC0
+sNumelSprites16:
+ax_sprite sNumelGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNumelGfx17:
+.incbin "baserom.gba", 0x13272E0, 0xC0
+sNumelSprites17:
+ax_sprite sNumelGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNumelGfx18:
+.incbin "baserom.gba", 0x13273B8, 0x40
+sNumelGfx18_1:
+.incbin "baserom.gba", 0x13273F8, 0x100
+sNumelGfx18_2:
+.incbin "baserom.gba", 0x13274F8, 0x20
+sNumelSprites18:
+ax_sprite sNumelGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx18_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx18_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNumelGfx19:
+.incbin "baserom.gba", 0x1327550, 0x60
+sNumelGfx19_1:
+.incbin "baserom.gba", 0x13275B0, 0x80
+sNumelGfx19_2:
+.incbin "baserom.gba", 0x1327630, 0x40
+sNumelSprites19:
+ax_sprite 0, 0x80
+ax_sprite sNumelGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx19_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNumelGfx20:
+.incbin "baserom.gba", 0x13276B0, 0x40
+sNumelGfx20_1:
+.incbin "baserom.gba", 0x13276F0, 0x100
+sNumelGfx20_2:
+.incbin "baserom.gba", 0x13277F0, 0x60
+sNumelSprites20:
+ax_sprite sNumelGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx20_2, 0x60
+ax_sprite_terminator
+sNumelGfx21:
+.incbin "baserom.gba", 0x1327880, 0x100
+sNumelGfx21_1:
+.incbin "baserom.gba", 0x1327980, 0x60
+sNumelSprites21:
+ax_sprite 0, 0x80
+ax_sprite sNumelGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx21_1, 0x60
+ax_sprite_terminator
+sNumelGfx22:
+.incbin "baserom.gba", 0x1327A08, 0x40
+sNumelGfx22_1:
+.incbin "baserom.gba", 0x1327A48, 0x60
+sNumelGfx22_2:
+.incbin "baserom.gba", 0x1327AA8, 0x80
+sNumelGfx22_3:
+.incbin "baserom.gba", 0x1327B28, 0x40
+sNumelSprites22:
+ax_sprite sNumelGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx22_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNumelGfx23:
+.incbin "baserom.gba", 0x1327BB0, 0x40
+sNumelGfx23_1:
+.incbin "baserom.gba", 0x1327BF0, 0x60
+sNumelGfx23_2:
+.incbin "baserom.gba", 0x1327C50, 0x60
+sNumelGfx23_3:
+.incbin "baserom.gba", 0x1327CB0, 0x40
+sNumelSprites23:
+ax_sprite sNumelGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNumelGfx24:
+.incbin "baserom.gba", 0x1327D38, 0x100
+sNumelSprites24:
+ax_sprite sNumelGfx24, 0x100
+ax_sprite_terminator
+sNumelGfx25:
+.incbin "baserom.gba", 0x1327E48, 0x100
+sNumelSprites25:
+ax_sprite sNumelGfx25, 0x100
+ax_sprite_terminator
+sNumelGfx26:
+.incbin "baserom.gba", 0x1327F58, 0xC0
+sNumelSprites26:
+ax_sprite sNumelGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNumelGfx27:
+.incbin "baserom.gba", 0x1328030, 0x60
+sNumelGfx27_1:
+.incbin "baserom.gba", 0x1328090, 0x80
+sNumelGfx27_2:
+.incbin "baserom.gba", 0x1328110, 0x60
+sNumelSprites27:
+ax_sprite sNumelGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx27_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNumelGfx28:
+.incbin "baserom.gba", 0x13281A8, 0x40
+sNumelGfx28_1:
+.incbin "baserom.gba", 0x13281E8, 0x60
+sNumelGfx28_2:
+.incbin "baserom.gba", 0x1328248, 0x60
+sNumelGfx28_3:
+.incbin "baserom.gba", 0x13282A8, 0x20
+sNumelSprites28:
+ax_sprite sNumelGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx28_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNumelGfx29:
+.incbin "baserom.gba", 0x1328310, 0x40
+sNumelGfx29_1:
+.incbin "baserom.gba", 0x1328350, 0x60
+sNumelGfx29_2:
+.incbin "baserom.gba", 0x13283B0, 0x60
+sNumelGfx29_3:
+.incbin "baserom.gba", 0x1328410, 0x60
+sNumelSprites29:
+ax_sprite sNumelGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNumelGfx30:
+.incbin "baserom.gba", 0x13284B8, 0x100
+sNumelSprites30:
+ax_sprite sNumelGfx30, 0x100
+ax_sprite_terminator
+sNumelGfx31:
+.incbin "baserom.gba", 0x13285C8, 0xC0
+sNumelSprites31:
+ax_sprite sNumelGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNumelGfx32:
+.incbin "baserom.gba", 0x13286A0, 0x60
+sNumelGfx32_1:
+.incbin "baserom.gba", 0x1328700, 0x80
+sNumelGfx32_2:
+.incbin "baserom.gba", 0x1328780, 0x60
+sNumelSprites32:
+ax_sprite sNumelGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx32_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx32_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sNumelGfx33:
+.incbin "baserom.gba", 0x1328818, 0x40
+sNumelGfx33_1:
+.incbin "baserom.gba", 0x1328858, 0x60
+sNumelGfx33_2:
+.incbin "baserom.gba", 0x13288B8, 0x60
+sNumelGfx33_3:
+.incbin "baserom.gba", 0x1328918, 0x20
+sNumelSprites33:
+ax_sprite sNumelGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx33_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNumelGfx34:
+.incbin "baserom.gba", 0x1328980, 0x40
+sNumelGfx34_1:
+.incbin "baserom.gba", 0x13289C0, 0x60
+sNumelGfx34_2:
+.incbin "baserom.gba", 0x1328A20, 0x60
+sNumelGfx34_3:
+.incbin "baserom.gba", 0x1328A80, 0x60
+sNumelSprites34:
+ax_sprite sNumelGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNumelGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNumelGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNumelGfx35:
+.incbin "baserom.gba", 0x1328B28, 0x100
+sNumelSprites35:
+ax_sprite sNumelGfx35, 0x100
+ax_sprite_terminator
+sNumelGfx36:
+.incbin "baserom.gba", 0x1328C38, 0x200
+sNumelSprites36:
+ax_sprite sNumelGfx36, 0x200
+ax_sprite_terminator
+sNumelGfx37:
+.incbin "baserom.gba", 0x1328E48, 0x200
+sNumelSprites37:
+ax_sprite sNumelGfx37, 0x200
+ax_sprite_terminator
+sNumelGfx38:
+.incbin "baserom.gba", 0x1329058, 0x200
+sNumelSprites38:
+ax_sprite sNumelGfx38, 0x200
+ax_sprite_terminator
+sNumelGfx39:
+.incbin "baserom.gba", 0x1329268, 0x200
+sNumelSprites39:
+ax_sprite sNumelGfx39, 0x200
+ax_sprite_terminator
+sNumelGfx40:
+.incbin "baserom.gba", 0x1329478, 0x200
+sNumelSprites40:
+ax_sprite sNumelGfx40, 0x200
+ax_sprite_terminator
+sNumelGfx41:
+.incbin "baserom.gba", 0x1329688, 0x200
+sNumelSprites41:
+ax_sprite sNumelGfx41, 0x200
+ax_sprite_terminator
+sNumelGfx42:
+.incbin "baserom.gba", 0x1329898, 0x200
+sNumelSprites42:
+ax_sprite sNumelGfx42, 0x200
+ax_sprite_terminator
+sAxPosesNumel:
+.4byte sNumelPose1
+.4byte sNumelPose2
+.4byte sNumelPose3
+.4byte sNumelPose4
+.4byte sNumelPose5
+.4byte sNumelPose6
+.4byte sNumelPose7
+.4byte sNumelPose8
+.4byte sNumelPose9
+.4byte sNumelPose10
+.4byte sNumelPose11
+.4byte sNumelPose12
+.4byte sNumelPose13
+.4byte sNumelPose14
+.4byte sNumelPose15
+.4byte sNumelPose16
+.4byte sNumelPose17
+.4byte sNumelPose18
+.4byte sNumelPose19
+.4byte sNumelPose20
+.4byte sNumelPose21
+.4byte sNumelPose22
+.4byte sNumelPose23
+.4byte sNumelPose24
+.4byte sNumelPose25
+.4byte sNumelPose26
+.4byte sNumelPose27
+.4byte sNumelPose28
+.4byte sNumelPose29
+.4byte sNumelPose30
+.4byte sNumelPose31
+.4byte sNumelPose32
+.4byte sNumelPose33
+.4byte sNumelPose34
+.4byte sNumelPose35
+.4byte sNumelPose36
+.4byte sNumelPose37
+.4byte sNumelPose38
+.4byte sNumelPose39
+.4byte sNumelPose40
+.4byte sNumelPose41
+.4byte sNumelPose42
+.4byte sNumelPose43
+.4byte sNumelPose44
+.4byte sNumelPose45
+.4byte sNumelPose46
+.4byte sNumelPose47
+.4byte sNumelPose48
+.4byte sNumelPose49
+.4byte sNumelPose50
+.4byte sNumelPose51
+.4byte sNumelPose52
+.4byte sNumelPose53
+.4byte sNumelPose54
+.4byte sNumelPose55
+.4byte sNumelPose56
+.4byte sNumelPose57
+.4byte sNumelPose58
+.4byte sNumelPose59
+.4byte sNumelPose60
+.4byte sNumelPose61
+.4byte sNumelPose62
+.4byte sNumelPose63
+.4byte sNumelPose64
+.4byte sNumelPose65
+.4byte sNumelPose66
+.4byte sNumelPose67
+.4byte sNumelPose68
+.4byte sNumelPose69
+.4byte sNumelPose70
+.4byte sNumelPose71
+.4byte sNumelPose72
+.4byte sNumelPose73
+.4byte sNumelPose74
+.4byte sNumelPose75
+.4byte sNumelPose76
+.4byte sNumelPose77
+.4byte sNumelPose78
+.4byte sNumelPose79
+.4byte sNumelPose80
+.4byte sNumelPose81
+.4byte sNumelPose82
+.4byte sNumelPose83
+.4byte sNumelPose84
+.4byte sNumelPose85
+.4byte sNumelPose86
+.4byte sNumelPose87
+.4byte sNumelPose88
+.4byte sNumelPose89
+.4byte sNumelPose90
+.4byte sNumelPose91
+.4byte sNumelPose92
+.4byte sNumelPose93
+.4byte sNumelPose94
+.4byte sNumelPose95
+.4byte sNumelPose96
+.4byte sNumelPose97
+.4byte sNumelPose98
+.4byte sNumelPose99
+.4byte sNumelPose100
+.4byte sNumelPose101
+.4byte sNumelPose102
+.4byte sNumelPose103
+.4byte sNumelPose104
+.4byte sNumelPose105
+.4byte sNumelPose106
+.4byte sNumelPose107
+.4byte sNumelPose108
+.4byte sNumelPose109
+.4byte sNumelPose110
+.4byte sNumelPose111
+.4byte sNumelPose112
+.4byte sNumelPose113
+.4byte sNumelPose114
+.4byte sNumelPose115
+.4byte sNumelPose116
+.4byte sNumelPose117
+.4byte sNumelPose118
+.4byte sNumelPose119
+.4byte sNumelPose120
+.4byte sNumelPose121
+.4byte sNumelPose122
+.4byte sNumelPose123
+.4byte sNumelPose124
+.4byte sNumelPose125
+.4byte sNumelPose126
+.4byte sNumelPose127
+.4byte sNumelPose128
+.4byte sNumelPose129
+.4byte sNumelPose130
+.4byte sNumelPose131
+.4byte sNumelPose132
+.4byte sNumelPose133
+.4byte sNumelPose134
+.4byte sNumelPose135
+.4byte sNumelPose136
+.4byte sNumelPose137
+.4byte sNumelPose138
+.4byte sNumelPose139
+.4byte sNumelPose140
+.4byte sNumelPose141
+.4byte sNumelPose142
+.4byte sNumelPose143
+.4byte sNumelPose144
+.4byte sNumelPose145
+.4byte sNumelPose146
+.4byte sNumelPose147
+.4byte sNumelPose148
+.4byte sNumelPose149
+.4byte sNumelPose150
+.4byte sNumelPose151
+.4byte sNumelPose152
+.4byte sNumelPose153
+.4byte sNumelPose154
+.4byte sNumelPose155
+.4byte sNumelPose156
+.4byte sNumelPose157
+.4byte sNumelPose158
+.4byte sNumelPose159
+.4byte sNumelPose160
+.4byte sNumelPose161
+.4byte sNumelPose162
+.4byte sNumelPose163
+.4byte sNumelPose164
+.4byte sNumelPose165
+.4byte sNumelPose166
+.4byte sNumelPose167
+.4byte sNumelPose168
+.4byte sNumelPose169
+.4byte sNumelPose170
+.4byte sNumelPose171
+.4byte sNumelPose172
+.4byte sNumelPose173
+.4byte sNumelPose174
+.4byte sNumelPose175
+.4byte sNumelPose176
+.4byte sNumelPose177
+.4byte sNumelPose178
+.4byte sNumelPose179
+.4byte sNumelPose180
+.4byte sNumelPose181
+.4byte sNumelPose182
+.4byte sNumelPose183
+.4byte sNumelPose184
+.4byte sNumelPose185
+.4byte sNumelPose186
+.4byte sNumelPose187
+.4byte sNumelPose188
+.4byte sNumelPose189
+.4byte sNumelPose190
+.4byte sNumelPose191
+.4byte sNumelPose192
+.4byte sNumelPose193
+.4byte sNumelPose194
+.4byte sNumelPose195
+.4byte sNumelPose196
+.4byte sNumelPose197
+.4byte sNumelPose198
+.4byte sNumelPose199
+.4byte sNumelPose200
+.4byte sNumelPose201
+.4byte sNumelPose202
+sAxPositionsNumel:
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte    0,    0, 	  -5,    4, 	   4,    1, 	   0,   -5
+.2byte   -2,    0, 	  -5,    1, 	   3,    4, 	  -1,   -5
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+.2byte    9,   -2, 	   6,    1, 	  -3,    2, 	   0,   -6
+.2byte   11,   -2, 	   1,   -3, 	   2,    3, 	  -1,   -6
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte   11,   -6, 	   6,   -1, 	   0,    1, 	  -2,   -6
+.2byte   11,   -7, 	   0,   -2, 	   5,    1, 	  -2,   -6
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    9,  -10, 	  -1,   -5, 	   3,   -1, 	  -2,   -7
+.2byte    7,  -10, 	  -1,   -4, 	   6,   -3, 	  -2,   -7
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte    0,  -12, 	   4,   -5, 	  -6,   -6, 	  -1,   -5
+.2byte   -2,  -12, 	   3,   -5, 	  -5,   -4, 	  -1,   -5
+.2byte  -10,  -11, 	  -1,   -5, 	  -7,   -2, 	   0,   -7
+.2byte  -11,  -10, 	  -1,   -5, 	  -5,   -1, 	   0,   -7
+.2byte   -9,  -10, 	  -1,   -4, 	  -8,   -3, 	   0,   -7
+.2byte  -14,   -7, 	  -6,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -13,   -6, 	  -8,   -1, 	  -2,    1, 	   0,   -6
+.2byte  -13,   -7, 	  -2,   -2, 	  -7,    1, 	   0,   -6
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte  -10,   -2, 	  -7,    1, 	   2,    2, 	  -1,   -6
+.2byte  -12,   -2, 	  -2,   -3, 	  -3,    3, 	   0,   -6
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte   -1,   -6, 	  -5,   -1, 	   3,   -1, 	  -1,   -7
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -3
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+.2byte   11,   -5, 	   5,   -3, 	   0,   -1, 	   0,   -7
+.2byte   12,   -1, 	   5,    0, 	  -1,    3, 	   1,   -4
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte   12,   -9, 	   6,   -5, 	   2,   -3, 	  -1,   -7
+.2byte   12,   -4, 	   4,   -2, 	   0,    1, 	  -2,   -5
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    7,  -12, 	   0,   -9, 	   6,   -5, 	  -2,   -8
+.2byte    9,  -10, 	   1,   -6, 	   4,   -1, 	  -2,   -6
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte   -1,  -15, 	   3,   -9, 	  -5,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   4,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte  -10,  -11, 	  -1,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -9,  -12, 	  -2,   -9, 	  -8,   -5, 	   0,   -8
+.2byte  -11,  -10, 	  -3,   -6, 	  -6,   -1, 	   0,   -6
+.2byte  -14,   -7, 	  -6,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -14,   -9, 	  -8,   -5, 	  -4,   -3, 	  -1,   -7
+.2byte  -14,   -4, 	  -6,   -2, 	  -2,    1, 	   0,   -5
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte  -12,   -5, 	  -6,   -3, 	  -1,   -1, 	  -1,   -7
+.2byte  -13,   -1, 	  -6,    0, 	   0,    3, 	  -2,   -4
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte   -1,   -6, 	  -5,   -1, 	   3,   -1, 	  -1,   -7
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -3
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+.2byte   11,   -5, 	   5,   -3, 	   0,   -1, 	   0,   -7
+.2byte   12,   -1, 	   5,    0, 	  -1,    3, 	   1,   -4
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte   12,   -9, 	   6,   -5, 	   2,   -3, 	  -1,   -7
+.2byte   12,   -4, 	   4,   -2, 	   0,    1, 	  -2,   -5
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    7,  -12, 	   0,   -9, 	   6,   -5, 	  -2,   -8
+.2byte    9,  -10, 	   1,   -6, 	   4,   -1, 	  -2,   -6
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte   -1,  -15, 	   3,   -9, 	  -5,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   4,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte  -10,  -11, 	  -1,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -9,  -12, 	  -2,   -9, 	  -8,   -5, 	   0,   -8
+.2byte  -11,  -10, 	  -3,   -6, 	  -6,   -1, 	   0,   -6
+.2byte  -14,   -7, 	  -6,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -14,   -9, 	  -8,   -5, 	  -4,   -3, 	  -1,   -7
+.2byte  -14,   -4, 	  -6,   -2, 	  -2,    1, 	   0,   -5
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte  -12,   -5, 	  -6,   -3, 	  -1,   -1, 	  -1,   -7
+.2byte  -13,   -1, 	  -6,    0, 	   0,    3, 	  -2,   -4
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -5, 	   3,   -2, 	  -1,   -7
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -3
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+.2byte    8,   -8, 	   4,   -6, 	   1,   -3, 	  -2,   -8
+.2byte   12,   -1, 	   5,    0, 	  -1,    3, 	   1,   -4
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte    7,  -13, 	   4,  -11, 	   5,   -7, 	  -4,   -8
+.2byte   12,   -4, 	   4,   -2, 	   0,    1, 	  -2,   -5
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    4,  -14, 	  -2,   -9, 	   5,   -7, 	  -4,   -6
+.2byte    9,  -10, 	   1,   -6, 	   4,   -1, 	  -2,   -6
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte   -1,  -16, 	   5,  -14, 	  -7,  -12, 	  -1,   -7
+.2byte   -1,  -15, 	   4,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte  -10,  -11, 	  -1,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -6,  -14, 	   0,   -9, 	  -7,   -7, 	   2,   -6
+.2byte  -11,  -10, 	  -3,   -6, 	  -6,   -1, 	   0,   -6
+.2byte  -14,   -7, 	  -6,   -2, 	  -4,    0, 	   0,   -7
+.2byte   -9,  -13, 	  -6,  -11, 	  -7,   -7, 	   2,   -8
+.2byte  -14,   -4, 	  -6,   -2, 	  -2,    1, 	   0,   -5
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -8, 	  -5,   -6, 	  -2,   -3, 	   1,   -8
+.2byte  -13,   -1, 	  -6,    0, 	   0,    3, 	  -2,   -4
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -5, 	   3,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,   -2, 	   4,   -6, 	  -1,   -8
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+.2byte    8,   -8, 	   4,   -6, 	   1,   -3, 	  -2,   -8
+.2byte    8,   -8, 	   5,   -4, 	   3,   -7, 	  -1,   -7
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte    7,  -13, 	   4,  -11, 	   5,   -7, 	  -4,   -8
+.2byte    8,  -14, 	   5,   -5, 	   5,  -11, 	  -4,   -8
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    4,  -14, 	  -2,   -9, 	   5,   -7, 	  -4,   -6
+.2byte    4,  -14, 	  -3,  -11, 	   5,  -10, 	  -3,   -6
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte   -1,  -16, 	   5,  -14, 	  -7,  -12, 	  -1,   -7
+.2byte   -1,  -16, 	   5,  -12, 	  -7,  -14, 	  -1,   -7
+.2byte  -10,  -11, 	  -1,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -6,  -14, 	   0,   -9, 	  -7,   -7, 	   2,   -6
+.2byte   -6,  -14, 	   1,  -11, 	  -7,  -10, 	   1,   -6
+.2byte  -14,   -7, 	  -6,   -2, 	  -4,    0, 	   0,   -7
+.2byte   -9,  -13, 	  -6,  -11, 	  -7,   -7, 	   2,   -8
+.2byte  -10,  -14, 	  -7,   -5, 	  -7,  -11, 	   2,   -8
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte   -9,   -8, 	  -5,   -6, 	  -2,   -3, 	   1,   -8
+.2byte   -9,   -8, 	  -6,   -4, 	  -4,   -7, 	   0,   -7
+.2byte  -10,    0, 	  -5,    0, 	  -1,    2, 	   1,   -5
+.2byte  -10,    0, 	  -5,    0, 	  -1,    2, 	   1,   -4
+.2byte    0,  -12, 	  -7,   -9, 	   7,   -8, 	   0,   -8
+.2byte    8,  -16, 	   7,  -11, 	   0,   -7, 	  -2,   -9
+.2byte    8,  -19, 	   2,  -10, 	   4,   -7, 	  -4,   -8
+.2byte    7,  -20, 	   0,  -10, 	   7,   -9, 	  -2,   -7
+.2byte    0,  -17, 	   8,  -11, 	  -8,  -11, 	   0,   -7
+.2byte   -8,  -20, 	  -1,  -10, 	  -8,   -9, 	   1,   -7
+.2byte   -9,  -19, 	  -3,  -10, 	  -5,   -7, 	   3,   -8
+.2byte   -9,  -16, 	  -8,  -11, 	  -1,   -7, 	   1,   -9
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -3
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+.2byte   12,   -1, 	   5,    0, 	  -1,    3, 	   1,   -4
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte   13,   -4, 	   5,   -2, 	   1,    1, 	  -1,   -5
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte   10,  -11, 	   2,   -7, 	   5,   -2, 	  -1,   -7
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte   -1,  -15, 	   4,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte  -10,  -11, 	  -1,   -5, 	  -7,   -2, 	   0,   -7
+.2byte  -12,  -11, 	  -4,   -7, 	  -7,   -2, 	  -1,   -7
+.2byte  -14,   -7, 	  -6,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -15,   -4, 	  -7,   -2, 	  -3,    1, 	  -1,   -5
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte  -13,   -1, 	  -6,    0, 	   0,    3, 	  -2,   -4
+.2byte    0,    2, 	  -5,    2, 	   5,    2, 	   0,   -4
+.2byte  -11,   -1, 	  -4,    0, 	   2,    3, 	   0,   -4
+.2byte  -12,   -3, 	  -4,   -1, 	   0,    2, 	   2,   -4
+.2byte   -8,   -9, 	   0,   -5, 	  -3,    0, 	   3,   -5
+.2byte    0,  -13, 	   5,   -6, 	  -4,   -6, 	   0,   -8
+.2byte    7,   -9, 	  -1,   -5, 	   2,    0, 	  -4,   -5
+.2byte   11,   -3, 	   3,   -1, 	  -1,    2, 	  -3,   -4
+.2byte   10,   -1, 	   3,    0, 	  -3,    3, 	  -1,   -4
+.2byte    0,    2, 	  -5,    2, 	   5,    2, 	   0,   -4
+.2byte   10,   -1, 	   3,    0, 	  -3,    3, 	  -1,   -4
+.2byte   11,   -3, 	   3,   -1, 	  -1,    2, 	  -3,   -4
+.2byte    8,   -9, 	   0,   -5, 	   3,    0, 	  -3,   -5
+.2byte    0,  -13, 	   5,   -6, 	  -4,   -6, 	   0,   -8
+.2byte   -9,   -9, 	  -1,   -5, 	  -4,    0, 	   2,   -5
+.2byte  -12,   -3, 	  -4,   -1, 	   0,    2, 	   2,   -4
+.2byte  -11,   -1, 	  -4,    0, 	   2,    3, 	   0,   -4
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte   -1,   -3, 	  -6,   -2, 	   3,    1, 	  -1,   -4
+.2byte   -1,    1, 	  -6,    1, 	   4,    1, 	  -1,   -5
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+.2byte    9,   -5, 	   5,   -3, 	   2,    0, 	  -1,   -5
+.2byte   11,   -1, 	   4,    0, 	  -2,    3, 	   0,   -4
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte    9,  -11, 	   6,   -9, 	   7,   -5, 	  -2,   -6
+.2byte   12,   -4, 	   4,   -2, 	   0,    1, 	  -2,   -5
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    6,  -13, 	   0,   -8, 	   7,   -6, 	  -2,   -5
+.2byte    9,  -10, 	   1,   -6, 	   4,   -1, 	  -2,   -6
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte   -1,  -14, 	   5,  -12, 	  -7,  -10, 	  -1,   -5
+.2byte   -1,  -14, 	   4,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -9,  -11, 	   0,   -5, 	  -6,   -2, 	   1,   -7
+.2byte   -7,  -13, 	  -1,   -8, 	  -8,   -6, 	   1,   -5
+.2byte  -10,  -10, 	  -2,   -6, 	  -5,   -1, 	   1,   -6
+.2byte  -13,   -7, 	  -5,   -2, 	  -3,    0, 	   1,   -7
+.2byte  -10,  -11, 	  -7,   -9, 	  -8,   -5, 	   1,   -6
+.2byte  -13,   -4, 	  -5,   -2, 	  -1,    1, 	   1,   -5
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte  -10,   -5, 	  -6,   -3, 	  -3,    0, 	   0,   -5
+.2byte  -12,   -1, 	  -5,    0, 	   1,    3, 	  -1,   -4
+.2byte   -1,   -6, 	  -5,   -1, 	   3,   -1, 	  -1,   -7
+.2byte  -11,   -5, 	  -5,   -3, 	   0,   -1, 	   0,   -7
+.2byte  -12,   -9, 	  -6,   -5, 	  -2,   -3, 	   1,   -7
+.2byte   -8,  -12, 	  -1,   -9, 	  -7,   -5, 	   1,   -8
+.2byte   -1,  -14, 	   3,   -8, 	  -5,   -8, 	  -1,   -8
+.2byte    7,  -12, 	   0,   -9, 	   6,   -5, 	  -2,   -8
+.2byte   11,   -9, 	   5,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   10,   -5, 	   4,   -3, 	  -1,   -1, 	  -1,   -7
+.2byte   -1,   -1, 	  -5,    2, 	   3,    2, 	  -1,   -5
+.2byte  -11,   -3, 	  -5,    0, 	   0,    2, 	  -1,   -7
+.2byte  -14,   -7, 	  -6,   -2, 	  -4,    0, 	   0,   -7
+.2byte  -10,  -11, 	  -1,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -1,  -13, 	   4,   -5, 	  -6,   -5, 	  -1,   -6
+.2byte    8,  -11, 	  -1,   -5, 	   5,   -2, 	  -2,   -7
+.2byte   12,   -7, 	   4,   -2, 	   2,    0, 	  -2,   -7
+.2byte   10,   -3, 	   4,    0, 	  -1,    2, 	   0,   -7
+sNumelAnimTable1:
+.4byte sNumelAnims_1_1
+.4byte sNumelAnims_1_2
+.4byte sNumelAnims_1_3
+.4byte sNumelAnims_1_4
+.4byte sNumelAnims_1_5
+.4byte sNumelAnims_1_6
+.4byte sNumelAnims_1_7
+.4byte sNumelAnims_1_8
+sNumelAnimTable2:
+.4byte sNumelAnims_2_1
+.4byte sNumelAnims_2_2
+.4byte sNumelAnims_2_3
+.4byte sNumelAnims_2_4
+.4byte sNumelAnims_2_5
+.4byte sNumelAnims_2_6
+.4byte sNumelAnims_2_7
+.4byte sNumelAnims_2_8
+sNumelAnimTable3:
+.4byte sNumelAnims_3_1
+.4byte sNumelAnims_3_2
+.4byte sNumelAnims_3_3
+.4byte sNumelAnims_3_4
+.4byte sNumelAnims_3_5
+.4byte sNumelAnims_3_6
+.4byte sNumelAnims_3_7
+.4byte sNumelAnims_3_8
+sNumelAnimTable4:
+.4byte sNumelAnims_4_1
+.4byte sNumelAnims_4_2
+.4byte sNumelAnims_4_3
+.4byte sNumelAnims_4_4
+.4byte sNumelAnims_4_5
+.4byte sNumelAnims_4_6
+.4byte sNumelAnims_4_7
+.4byte sNumelAnims_4_8
+sNumelAnimTable5:
+.4byte sNumelAnims_5_1
+.4byte sNumelAnims_5_2
+.4byte sNumelAnims_5_3
+.4byte sNumelAnims_5_4
+.4byte sNumelAnims_5_5
+.4byte sNumelAnims_5_6
+.4byte sNumelAnims_5_7
+.4byte sNumelAnims_5_8
+sNumelAnimTable6:
+.4byte sNumelAnims_6_1
+.4byte sNumelAnims_6_1
+.4byte sNumelAnims_6_1
+.4byte sNumelAnims_6_1
+.4byte sNumelAnims_6_1
+.4byte sNumelAnims_6_1
+.4byte sNumelAnims_6_1
+.4byte sNumelAnims_6_1
+sNumelAnimTable7:
+.4byte sNumelAnims_7_1
+.4byte sNumelAnims_7_2
+.4byte sNumelAnims_7_3
+.4byte sNumelAnims_7_4
+.4byte sNumelAnims_7_5
+.4byte sNumelAnims_7_6
+.4byte sNumelAnims_7_7
+.4byte sNumelAnims_7_8
+sNumelAnimTable8:
+.4byte sNumelAnims_8_1
+.4byte sNumelAnims_8_2
+.4byte sNumelAnims_8_3
+.4byte sNumelAnims_8_4
+.4byte sNumelAnims_8_5
+.4byte sNumelAnims_8_6
+.4byte sNumelAnims_8_7
+.4byte sNumelAnims_8_8
+sNumelAnimTable9:
+.4byte sNumelAnims_9_1
+.4byte sNumelAnims_9_2
+.4byte sNumelAnims_9_3
+.4byte sNumelAnims_9_4
+.4byte sNumelAnims_9_5
+.4byte sNumelAnims_9_6
+.4byte sNumelAnims_9_7
+.4byte sNumelAnims_9_8
+sNumelAnimTable10:
+.4byte sNumelAnims_10_1
+.4byte sNumelAnims_10_2
+.4byte sNumelAnims_10_3
+.4byte sNumelAnims_10_4
+.4byte sNumelAnims_10_5
+.4byte sNumelAnims_10_6
+.4byte sNumelAnims_10_7
+.4byte sNumelAnims_10_8
+sNumelAnimTable11:
+.4byte sNumelAnims_11_1
+.4byte sNumelAnims_11_2
+.4byte sNumelAnims_11_3
+.4byte sNumelAnims_11_4
+.4byte sNumelAnims_11_5
+.4byte sNumelAnims_11_6
+.4byte sNumelAnims_11_7
+.4byte sNumelAnims_11_8
+sNumelAnimTable12:
+.4byte sNumelAnims_12_1
+.4byte sNumelAnims_12_2
+.4byte sNumelAnims_12_3
+.4byte sNumelAnims_12_4
+.4byte sNumelAnims_12_5
+.4byte sNumelAnims_12_6
+.4byte sNumelAnims_12_7
+.4byte sNumelAnims_12_8
+sNumelAnimTable13:
+.4byte sNumelAnims_13_1
+.4byte sNumelAnims_13_2
+.4byte sNumelAnims_13_3
+.4byte sNumelAnims_13_4
+.4byte sNumelAnims_13_5
+.4byte sNumelAnims_13_6
+.4byte sNumelAnims_13_7
+.4byte sNumelAnims_13_8
+sAxAnimationsNumel:
+.4byte sNumelAnimTable1
+.4byte sNumelAnimTable2
+.4byte sNumelAnimTable3
+.4byte sNumelAnimTable4
+.4byte sNumelAnimTable5
+.4byte sNumelAnimTable6
+.4byte sNumelAnimTable7
+.4byte sNumelAnimTable8
+.4byte sNumelAnimTable9
+.4byte sNumelAnimTable10
+.4byte sNumelAnimTable11
+.4byte sNumelAnimTable12
+.4byte sNumelAnimTable13
+sAxSpritesNumel:
+.4byte sNumelSprites1
+.4byte sNumelSprites2
+.4byte sNumelSprites3
+.4byte sNumelSprites4
+.4byte sNumelSprites5
+.4byte sNumelSprites6
+.4byte sNumelSprites7
+.4byte sNumelSprites8
+.4byte sNumelSprites9
+.4byte sNumelSprites10
+.4byte sNumelSprites11
+.4byte sNumelSprites12
+.4byte sNumelSprites13
+.4byte sNumelSprites14
+.4byte sNumelSprites15
+.4byte sNumelSprites16
+.4byte sNumelSprites17
+.4byte sNumelSprites18
+.4byte sNumelSprites19
+.4byte sNumelSprites20
+.4byte sNumelSprites21
+.4byte sNumelSprites22
+.4byte sNumelSprites23
+.4byte sNumelSprites24
+.4byte sNumelSprites25
+.4byte sNumelSprites26
+.4byte sNumelSprites27
+.4byte sNumelSprites28
+.4byte sNumelSprites29
+.4byte sNumelSprites30
+.4byte sNumelSprites31
+.4byte sNumelSprites32
+.4byte sNumelSprites33
+.4byte sNumelSprites34
+.4byte sNumelSprites35
+.4byte sNumelSprites36
+.4byte sNumelSprites37
+.4byte sNumelSprites38
+.4byte sNumelSprites39
+.4byte sNumelSprites40
+.4byte sNumelSprites41
+.4byte sNumelSprites42
+sAxMainNumel:
+ax_main sAxPosesNumel, sAxAnimationsNumel, 13, sAxSpritesNumel, sAxPositionsNumel

--- a/data/ax/nuzleaf.inc
+++ b/data/ax/nuzleaf.inc
@@ -1,0 +1,2962 @@
+.global gAxNuzleaf
+gAxNuzleaf:
+ax_siro sAxMainNuzleaf
+sNuzleafPose1:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose2:
+ax_pose 1, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose3:
+ax_pose 2, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose4:
+ax_pose 3, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose5:
+ax_pose 4, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose6:
+ax_pose 5, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose7:
+ax_pose 6, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose8:
+ax_pose 7, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose9:
+ax_pose 8, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose10:
+ax_pose 9, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose11:
+ax_pose 10, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose12:
+ax_pose 11, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose13:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose16:
+ax_pose 9, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose17:
+ax_pose 10, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose18:
+ax_pose 11, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose22:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose23:
+ax_pose 4, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose24:
+ax_pose 5, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose25:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose26:
+ax_pose 1, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose27:
+ax_pose 2, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose28:
+ax_pose 3, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose29:
+ax_pose 4, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose30:
+ax_pose 5, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose31:
+ax_pose 6, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose32:
+ax_pose 7, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose33:
+ax_pose 8, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose34:
+ax_pose 9, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose35:
+ax_pose 10, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose36:
+ax_pose 11, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose37:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose38:
+ax_pose 13, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose39:
+ax_pose 14, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose40:
+ax_pose 9, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose41:
+ax_pose 10, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose42:
+ax_pose 11, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose43:
+ax_pose 6, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose44:
+ax_pose 7, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose45:
+ax_pose 8, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose46:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose47:
+ax_pose 4, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose48:
+ax_pose 5, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose49:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose50:
+ax_pose 1, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose51:
+ax_pose 2, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose52:
+ax_pose 3, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose53:
+ax_pose 4, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose54:
+ax_pose 5, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose55:
+ax_pose 6, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose56:
+ax_pose 7, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose57:
+ax_pose 8, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose58:
+ax_pose 9, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose59:
+ax_pose 10, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose60:
+ax_pose 11, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose61:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose62:
+ax_pose 13, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose63:
+ax_pose 14, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose64:
+ax_pose 9, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose65:
+ax_pose 10, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose66:
+ax_pose 11, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose67:
+ax_pose 6, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose68:
+ax_pose 7, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose69:
+ax_pose 8, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose70:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose71:
+ax_pose 4, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose72:
+ax_pose 5, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose73:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose74:
+ax_pose 15, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose75:
+ax_pose 16, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose76:
+ax_pose 17, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose77:
+ax_pose 18, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose78:
+ax_pose 3, 0x01e4, 0x90ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose79:
+ax_pose 19, 0x01e4, 0x90f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose80:
+ax_pose 20, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose81:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose82:
+ax_pose 22, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose83:
+ax_pose 6, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose84:
+ax_pose 23, 0x01e4, 0x90f6, 0x8c00
+ax_pose_terminator
+sNuzleafPose85:
+ax_pose 24, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose86:
+ax_pose 25, 0x01e4, 0x90f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose87:
+ax_pose 26, 0x01e4, 0x90f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose88:
+ax_pose 9, 0x01e4, 0x90eb, 0x8c00
+ax_pose_terminator
+sNuzleafPose89:
+ax_pose 27, 0x01e4, 0x90f3, 0x8c00
+ax_pose_terminator
+sNuzleafPose90:
+ax_pose 28, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose91:
+ax_pose 29, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sNuzleafPose92:
+ax_pose 30, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sNuzleafPose93:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose94:
+ax_pose 31, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose95:
+ax_pose 32, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose96:
+ax_pose 33, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose97:
+ax_pose 34, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose98:
+ax_pose 9, 0x01e4, 0x80f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose99:
+ax_pose 27, 0x01e4, 0x80ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose100:
+ax_pose 28, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose101:
+ax_pose 29, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose102:
+ax_pose 30, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose103:
+ax_pose 6, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose104:
+ax_pose 23, 0x01e4, 0x80ea, 0x8c00
+ax_pose_terminator
+sNuzleafPose105:
+ax_pose 24, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose106:
+ax_pose 25, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose107:
+ax_pose 26, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose108:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose109:
+ax_pose 19, 0x01e4, 0x80ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose110:
+ax_pose 20, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose111:
+ax_pose 21, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose112:
+ax_pose 22, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose113:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose114:
+ax_pose 15, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose115:
+ax_pose 16, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose116:
+ax_pose 17, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose117:
+ax_pose 18, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose118:
+ax_pose 3, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose119:
+ax_pose 19, 0x01e4, 0x90f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose120:
+ax_pose 20, 0x01e4, 0x90f2, 0x8c00
+ax_pose_terminator
+sNuzleafPose121:
+ax_pose 21, 0x01e4, 0x90f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose122:
+ax_pose 22, 0x01e4, 0x90f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose123:
+ax_pose 6, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose124:
+ax_pose 23, 0x01e4, 0x90f9, 0x8c00
+ax_pose_terminator
+sNuzleafPose125:
+ax_pose 24, 0x01e4, 0x90f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose126:
+ax_pose 25, 0x01e4, 0x90f2, 0x8c00
+ax_pose_terminator
+sNuzleafPose127:
+ax_pose 26, 0x01e4, 0x90f2, 0x8c00
+ax_pose_terminator
+sNuzleafPose128:
+ax_pose 9, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose129:
+ax_pose 27, 0x01e4, 0x90f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose130:
+ax_pose 28, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose131:
+ax_pose 29, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sNuzleafPose132:
+ax_pose 30, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sNuzleafPose133:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose134:
+ax_pose 31, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose135:
+ax_pose 32, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose136:
+ax_pose 33, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose137:
+ax_pose 34, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose138:
+ax_pose 9, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose139:
+ax_pose 27, 0x01e4, 0x80ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose140:
+ax_pose 28, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose141:
+ax_pose 29, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sNuzleafPose142:
+ax_pose 30, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sNuzleafPose143:
+ax_pose 6, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose144:
+ax_pose 23, 0x01e4, 0x80e8, 0x8c00
+ax_pose_terminator
+sNuzleafPose145:
+ax_pose 24, 0x01e4, 0x80ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose146:
+ax_pose 25, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose147:
+ax_pose 26, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose148:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose149:
+ax_pose 19, 0x01e4, 0x80ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose150:
+ax_pose 20, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose151:
+ax_pose 21, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose152:
+ax_pose 22, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose153:
+ax_pose 35, 0x01e4, 0x80f6, 0x8c00
+ax_pose_terminator
+sNuzleafPose154:
+ax_pose 36, 0x01e4, 0x80f6, 0x8c00
+ax_pose_terminator
+sNuzleafPose155:
+ax_pose 37, 0x01e0, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose156:
+ax_pose 38, 0x01e3, 0x90eb, 0x8c00
+ax_pose_terminator
+sNuzleafPose157:
+ax_pose 39, 0x01e4, 0x90ea, 0x8c00
+ax_pose_terminator
+sNuzleafPose158:
+ax_pose 40, 0x01e9, 0x90eb, 0x8c00
+ax_pose_terminator
+sNuzleafPose159:
+ax_pose 41, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose160:
+ax_pose 40, 0x01e9, 0x80f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose161:
+ax_pose 39, 0x01e4, 0x80f6, 0x8c00
+ax_pose_terminator
+sNuzleafPose162:
+ax_pose 38, 0x01e3, 0x80f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose163:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose164:
+ax_pose 1, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose165:
+ax_pose 2, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose166:
+ax_pose 3, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose167:
+ax_pose 4, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose168:
+ax_pose 5, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose169:
+ax_pose 6, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose170:
+ax_pose 7, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose171:
+ax_pose 8, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose172:
+ax_pose 9, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose173:
+ax_pose 10, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose174:
+ax_pose 11, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose175:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose176:
+ax_pose 13, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose177:
+ax_pose 14, 0x01ea, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose178:
+ax_pose 9, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose179:
+ax_pose 10, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose180:
+ax_pose 11, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose181:
+ax_pose 6, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose182:
+ax_pose 7, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose183:
+ax_pose 8, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose184:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose185:
+ax_pose 4, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose186:
+ax_pose 5, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose187:
+ax_pose 18, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose188:
+ax_pose 22, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose189:
+ax_pose 26, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose190:
+ax_pose 30, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose191:
+ax_pose 34, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose192:
+ax_pose 30, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose193:
+ax_pose 26, 0x01e4, 0x90f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose194:
+ax_pose 22, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose195:
+ax_pose 16, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose196:
+ax_pose 20, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose197:
+ax_pose 24, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose198:
+ax_pose 28, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sNuzleafPose199:
+ax_pose 32, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose200:
+ax_pose 28, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sNuzleafPose201:
+ax_pose 24, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose202:
+ax_pose 20, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose203:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose204:
+ax_pose 16, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose205:
+ax_pose 18, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose206:
+ax_pose 3, 0x01e4, 0x90ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose207:
+ax_pose 20, 0x01e4, 0x90f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose208:
+ax_pose 22, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sNuzleafPose209:
+ax_pose 6, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose210:
+ax_pose 24, 0x01e7, 0x90ef, 0x8c00
+ax_pose_terminator
+sNuzleafPose211:
+ax_pose 26, 0x01e4, 0x90ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose212:
+ax_pose 9, 0x01e4, 0x90eb, 0x8c00
+ax_pose_terminator
+sNuzleafPose213:
+ax_pose 28, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose214:
+ax_pose 30, 0x01e5, 0x90ea, 0x8c00
+ax_pose_terminator
+sNuzleafPose215:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose216:
+ax_pose 32, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose217:
+ax_pose 34, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose218:
+ax_pose 9, 0x01e4, 0x80f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose219:
+ax_pose 28, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sNuzleafPose220:
+ax_pose 30, 0x01e5, 0x80f6, 0x8c00
+ax_pose_terminator
+sNuzleafPose221:
+ax_pose 6, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose222:
+ax_pose 24, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose223:
+ax_pose 26, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose224:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose225:
+ax_pose 20, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose226:
+ax_pose 22, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sNuzleafPose227:
+ax_pose 15, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose228:
+ax_pose 19, 0x01e4, 0x80ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose229:
+ax_pose 23, 0x01e4, 0x80ec, 0x8c00
+ax_pose_terminator
+sNuzleafPose230:
+ax_pose 27, 0x01e4, 0x80ee, 0x8c00
+ax_pose_terminator
+sNuzleafPose231:
+ax_pose 31, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose232:
+ax_pose 27, 0x01e4, 0x90f2, 0x8c00
+ax_pose_terminator
+sNuzleafPose233:
+ax_pose 23, 0x01e4, 0x90f5, 0x8c00
+ax_pose_terminator
+sNuzleafPose234:
+ax_pose 19, 0x01e4, 0x90f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose235:
+ax_pose 0, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose236:
+ax_pose 3, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose237:
+ax_pose 6, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sNuzleafPose238:
+ax_pose 9, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose239:
+ax_pose 12, 0x01e4, 0x80f4, 0x8c00
+ax_pose_terminator
+sNuzleafPose240:
+ax_pose 9, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+sNuzleafPose241:
+ax_pose 6, 0x01e4, 0x90f1, 0x8c00
+ax_pose_terminator
+sNuzleafPose242:
+ax_pose 3, 0x01e4, 0x90ed, 0x8c00
+ax_pose_terminator
+.align 2
+sNuzleafAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_2_1:
+ax_anim 2, 0, 25, 0, -3, 0, -1,
+ax_anim 4, 0, 25, 0, -4, 0, -2,
+ax_anim 1, 0, 26, 0, -6, 0, 1,
+ax_anim 1, 0, 26, 0, -3, 0, 1,
+ax_anim 2, 0, 26, 0, 2, 0, 7,
+ax_anim 2, 2, 26, 0, 8, 0, 12,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 1, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 0, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sNuzleafAnims_2_2:
+ax_anim 2, 0, 28, -3, -3, -3, -3,
+ax_anim 4, 0, 28, -4, -4, -4, -4,
+ax_anim 1, 0, 29, -1, -5, -2, -2,
+ax_anim 1, 0, 29, 3, -3, 2, 2,
+ax_anim 2, 0, 29, 8, 1, 6, 6,
+ax_anim 2, 2, 29, 13, 7, 11, 12,
+ax_anim 2, 0, 29, 18, 20, 18, 20,
+ax_anim 2, 1, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 29, 18, 20, 18, 20,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sNuzleafAnims_2_3:
+ax_anim 2, 0, 31, -3, 0, -3, 0,
+ax_anim 4, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 0, 32, -1, -3, -1, 0,
+ax_anim 1, 0, 32, 3, -7, 3, 0,
+ax_anim 2, 0, 32, 8, -7, 8, 0,
+ax_anim 2, 2, 32, 13, -4, 13, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, -1, 18, -1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, -1, 18, -1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sNuzleafAnims_2_4:
+ax_anim 2, 0, 34, -3, 3, -3, 3,
+ax_anim 4, 0, 34, -4, 4, -4, 4,
+ax_anim 1, 0, 35, -1, -5, -1, -1,
+ax_anim 1, 0, 35, 3, -11, 3, -3,
+ax_anim 2, 0, 35, 8, -15, 8, -8,
+ax_anim 2, 2, 35, 13, -18, 13, -13,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 1, 35, 17, -19, 17, -19,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 0, 35, 17, -19, 17, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sNuzleafAnims_2_5:
+ax_anim 2, 0, 37, 0, 3, 0, 3,
+ax_anim 4, 0, 37, 0, 4, 0, 4,
+ax_anim 1, 0, 38, 0, -5, 0, -5,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 0, -17, 0, -15,
+ax_anim 2, 2, 38, 0, -20, 0, -18,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 1, 38, -1, -18, -1, -18,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 0, 38, -1, -18, -1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sNuzleafAnims_2_6:
+ax_anim 2, 0, 40, 3, 3, 3, 3,
+ax_anim 4, 0, 40, 4, 4, 4, 4,
+ax_anim 1, 0, 41, 1, -5, 1, -1,
+ax_anim 1, 0, 41, -3, -11, -3, -3,
+ax_anim 2, 0, 41, -8, -15, -8, -8,
+ax_anim 2, 2, 41, -13, -18, -13, -13,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 1, 41, -17, -19, -17, -19,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 0, 41, -17, -19, -17, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sNuzleafAnims_2_7:
+ax_anim 2, 0, 43, 3, 0, 3, 0,
+ax_anim 4, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 0, 44, 1, -3, 1, 0,
+ax_anim 1, 0, 44, -3, -7, -3, 0,
+ax_anim 2, 0, 44, -8, -7, -8, 0,
+ax_anim 2, 2, 44, -13, -4, -13, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, -1, -18, -1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, -1, -18, -1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sNuzleafAnims_2_8:
+ax_anim 2, 0, 46, 3, -3, 3, -3,
+ax_anim 4, 0, 46, 4, -4, 4, -4,
+ax_anim 1, 0, 47, 1, -5, 2, -2,
+ax_anim 1, 0, 47, -3, -3, -2, 2,
+ax_anim 2, 0, 47, -8, 1, -6, 6,
+ax_anim 2, 2, 47, -13, 7, -11, 12,
+ax_anim 2, 0, 47, -18, 20, -18, 20,
+ax_anim 2, 1, 47, -19, 19, -19, 19,
+ax_anim 2, 0, 47, -18, 20, -18, 20,
+ax_anim 2, 0, 47, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 2,
+ax_anim 1, 2, 50, 0, 12, 0, 16,
+ax_anim 1, 0, 50, 0, 26, 0, 30,
+ax_anim 2, 0, 50, 0, 45, 0, 45,
+ax_anim 2, 1, 50, 1, 45, 1, 45,
+ax_anim 2, 0, 50, 0, 45, 0, 45,
+ax_anim 2, 0, 50, 1, 45, 1, 45,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sNuzleafAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 2, 53, 12, 7, 12, 12,
+ax_anim 1, 0, 53, 26, 21, 26, 26,
+ax_anim 2, 0, 53, 41, 44, 41, 42,
+ax_anim 2, 1, 53, 42, 43, 42, 41,
+ax_anim 2, 0, 53, 41, 44, 41, 42,
+ax_anim 2, 0, 53, 42, 43, 42, 41,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sNuzleafAnims_3_3:
+ax_anim 2, 0, 55, -2, 0, -2, 0,
+ax_anim 4, 0, 55, -3, 0, -3, 0,
+ax_anim 1, 0, 56, 0, -3, 0, 0,
+ax_anim 1, 2, 56, 12, -5, 12, 0,
+ax_anim 1, 0, 56, 26, -3, 26, 0,
+ax_anim 2, 0, 56, 42, 0, 42, 0,
+ax_anim 2, 1, 56, 42, 1, 42, 1,
+ax_anim 2, 0, 56, 42, 0, 42, 0,
+ax_anim 2, 0, 56, 42, 1, 42, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sNuzleafAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 4, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -3, 0, -1,
+ax_anim 1, 2, 59, 12, -19, 12, -13,
+ax_anim 1, 0, 59, 27, -34, 27, -29,
+ax_anim 2, 0, 59, 42, -45, 42, -45,
+ax_anim 2, 1, 59, 43, -44, 43, -44,
+ax_anim 2, 0, 59, 42, -45, 42, -45,
+ax_anim 2, 0, 59, 43, -44, 43, -44,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sNuzleafAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -12, 0, -10,
+ax_anim 1, 0, 62, 0, -27, 0, -23,
+ax_anim 2, 0, 62, 0, -43, 0, -43,
+ax_anim 2, 1, 62, 1, -43, 1, -43,
+ax_anim 2, 0, 62, 0, -43, 0, -43,
+ax_anim 2, 0, 62, 1, -43, 1, -43,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sNuzleafAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -3, 0, -1,
+ax_anim 1, 2, 64, -12, -19, -12, -13,
+ax_anim 1, 0, 65, -27, -34, -27, -29,
+ax_anim 2, 0, 64, -42, -45, -42, -47,
+ax_anim 2, 1, 64, -43, -44, -43, -46,
+ax_anim 2, 0, 64, -42, -45, -42, -47,
+ax_anim 2, 0, 64, -43, -44, -43, -46,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sNuzleafAnims_3_7:
+ax_anim 2, 0, 66, 2, 0, 2, 0,
+ax_anim 4, 0, 66, 3, 0, 3, 0,
+ax_anim 1, 0, 68, 0, -3, 0, 0,
+ax_anim 1, 2, 67, -12, -5, -12, 0,
+ax_anim 1, 0, 68, -26, -3, -26, 0,
+ax_anim 2, 0, 67, -42, 0, -42, 0,
+ax_anim 2, 1, 67, -42, 1, -42, 1,
+ax_anim 2, 0, 67, -42, 0, -42, 0,
+ax_anim 2, 0, 67, -42, 1, -42, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sNuzleafAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 4, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, -2, 0, 0,
+ax_anim 1, 2, 71, -12, 9, -12, 12,
+ax_anim 1, 0, 71, -26, 21, -26, 26,
+ax_anim 2, 0, 71, -41, 44, -41, 42,
+ax_anim 2, 1, 71, -42, 43, -42, 41,
+ax_anim 2, 0, 71, -41, 44, -41, 42,
+ax_anim 2, 0, 71, -42, 43, -42, 41,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_4_1:
+ax_anim 6, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 3, 0, 72, 0, -3, 0, 0,
+ax_anim 2, 2, 72, 0, -4, 0, 1,
+ax_anim 2, 0, 72, 0, -3, 0, 1,
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 0, 76, -1, 2, -1, 2,
+ax_anim 2, 1, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 76, -1, 2, -1, 2,
+ax_anim 2, 0, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 76, -1, 2, -1, 2,
+ax_anim_terminator
+sNuzleafAnims_4_2:
+ax_anim 6, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 3, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 2, 77, 1, -4, 1, 1,
+ax_anim 2, 0, 77, 1, -3, 1, 1,
+ax_anim 2, 0, 80, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 1, 3, 1,
+ax_anim 2, 1, 81, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 1, 3, 1,
+ax_anim 2, 0, 81, 2, 2, 2, 2,
+ax_anim 2, 0, 81, 3, 1, 3, 1,
+ax_anim_terminator
+sNuzleafAnims_4_3:
+ax_anim 6, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 3, 0, 82, 1, -3, 0, 0,
+ax_anim 2, 2, 82, 1, -4, 1, 0,
+ax_anim 2, 0, 82, 1, -5, 1, 0,
+ax_anim 2, 0, 85, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 2, -1, 2, -1,
+ax_anim 2, 1, 86, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 2, -1, 2, -1,
+ax_anim 2, 0, 86, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 2, -1, 2, -1,
+ax_anim_terminator
+sNuzleafAnims_4_4:
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 3, 0, 87, 0, -3, 0, 0,
+ax_anim 2, 2, 87, 1, -4, 1, -1,
+ax_anim 2, 0, 87, 1, -3, 2, -1,
+ax_anim 2, 0, 90, 3, -2, 3, -2,
+ax_anim 2, 0, 91, 4, -1, 4, -1,
+ax_anim 2, 1, 91, 3, -2, 3, -2,
+ax_anim 2, 0, 91, 4, -1, 4, -1,
+ax_anim 2, 0, 91, 3, -2, 3, -2,
+ax_anim 2, 0, 91, 4, -1, 4, -1,
+ax_anim_terminator
+sNuzleafAnims_4_5:
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 3, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 2, 92, 0, -5, 0, -1,
+ax_anim 2, 0, 92, 0, -4, 0, -1,
+ax_anim 2, 0, 95, 0, -2, 0, -2,
+ax_anim 2, 0, 96, -1, -2, -1, -2,
+ax_anim 2, 1, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, -1, -2, -1, -2,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, -1, -2, -1, -2,
+ax_anim_terminator
+sNuzleafAnims_4_6:
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 3, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 2, 97, -1, -4, -1, -1,
+ax_anim 2, 0, 97, -1, -3, -2, -1,
+ax_anim 2, 0, 100, -3, -2, -3, -2,
+ax_anim 2, 0, 101, -4, -1, -4, -1,
+ax_anim 2, 1, 101, -3, -2, -3, -2,
+ax_anim 2, 0, 101, -4, -1, -4, -1,
+ax_anim 2, 0, 101, -3, -2, -3, -2,
+ax_anim 2, 0, 101, -4, -1, -4, -1,
+ax_anim_terminator
+sNuzleafAnims_4_7:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 3, 0, 102, -1, -3, 0, 0,
+ax_anim 2, 2, 102, -1, -4, -1, 0,
+ax_anim 2, 0, 102, -1, -5, -1, 0,
+ax_anim 2, 0, 105, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -2, -1, -2, -1,
+ax_anim 2, 1, 106, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -2, -1, -2, -1,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -2, -1, -2, -1,
+ax_anim_terminator
+sNuzleafAnims_4_8:
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 3, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 2, 107, -1, -4, -1, 1,
+ax_anim 2, 0, 107, -1, -3, -1, 1,
+ax_anim 2, 0, 110, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_5_1:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 2, 0, 3,
+ax_anim 3, 0, 114, 0, 6, 0, 5,
+ax_anim 6, 2, 115, 0, 12, 0, 12,
+ax_anim 2, 0, 115, -1, 12, 0, 11,
+ax_anim 2, 0, 115, 0, 12, 0, 12,
+ax_anim 2, 0, 115, -1, 12, 0, 11,
+ax_anim 2, 0, 115, 0, 12, 0, 12,
+ax_anim 2, 1, 115, -1, 12, 0, 11,
+ax_anim 2, 0, 115, 0, 8, 0, 8,
+ax_anim 2, 0, 112, 0, 4, 0, 4,
+ax_anim_terminator
+sNuzleafAnims_5_2:
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 4, 3, 4, 4,
+ax_anim 3, 0, 119, 8, 5, 8, 8,
+ax_anim 6, 2, 120, 12, 12, 12, 12,
+ax_anim 2, 0, 120, 13, 11, 13, 11,
+ax_anim 2, 0, 120, 12, 12, 12, 12,
+ax_anim 2, 0, 120, 13, 11, 13, 11,
+ax_anim 2, 0, 120, 12, 12, 12, 12,
+ax_anim 2, 1, 120, 13, 11, 13, 11,
+ax_anim 2, 0, 120, 8, 8, 8, 8,
+ax_anim 2, 0, 117, 4, 4, 4, 4,
+ax_anim_terminator
+sNuzleafAnims_5_3:
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 4, -1, 4, 0,
+ax_anim 3, 0, 124, 8, -1, 8, 0,
+ax_anim 6, 2, 125, 12, 0, 12, 0,
+ax_anim 2, 0, 125, 12, -1, 12, -1,
+ax_anim 2, 0, 125, 12, 0, 12, 0,
+ax_anim 2, 0, 125, 12, -1, 12, -1,
+ax_anim 2, 0, 125, 12, 0, 12, 0,
+ax_anim 2, 1, 125, 12, -1, 12, -1,
+ax_anim 2, 0, 125, 8, 0, 8, 0,
+ax_anim 2, 0, 122, 4, 0, 4, 0,
+ax_anim_terminator
+sNuzleafAnims_5_4:
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 4, -6, 4, -4,
+ax_anim 3, 0, 129, 8, -11, 8, -8,
+ax_anim 6, 2, 130, 12, -12, 12, -12,
+ax_anim 2, 0, 130, 13, -11, 13, -11,
+ax_anim 2, 0, 130, 12, -12, 12, -12,
+ax_anim 2, 0, 130, 13, -11, 13, -11,
+ax_anim 2, 0, 130, 12, -12, 12, -12,
+ax_anim 2, 1, 130, 13, -11, 13, -11,
+ax_anim 2, 0, 130, 8, -8, 8, -8,
+ax_anim 2, 0, 127, 4, -4, 4, -4,
+ax_anim_terminator
+sNuzleafAnims_5_5:
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, -6, 0, -6,
+ax_anim 3, 0, 134, 0, -9, 0, -11,
+ax_anim 6, 2, 135, 0, -12, 0, -12,
+ax_anim 2, 0, 135, -1, -12, -1, -12,
+ax_anim 2, 0, 135, 0, -12, 0, -12,
+ax_anim 2, 0, 135, -1, -12, -1, -12,
+ax_anim 2, 0, 135, 0, -12, 0, -12,
+ax_anim 2, 1, 135, -1, -12, -1, -12,
+ax_anim 2, 0, 135, 0, -8, 0, -8,
+ax_anim 2, 0, 132, 0, -4, 0, -4,
+ax_anim_terminator
+sNuzleafAnims_5_6:
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 139, -4, -6, -4, -4,
+ax_anim 3, 0, 139, -8, -11, -8, -8,
+ax_anim 6, 2, 140, -12, -12, -12, -12,
+ax_anim 2, 0, 140, -13, -11, -13, -11,
+ax_anim 2, 0, 140, -12, -12, -12, -12,
+ax_anim 2, 0, 140, -13, -11, -13, -11,
+ax_anim 2, 0, 140, -12, -12, -12, -12,
+ax_anim 2, 1, 140, -13, -11, -13, -11,
+ax_anim 2, 0, 140, -8, -8, -8, -8,
+ax_anim 2, 0, 137, -4, -4, -4, -4,
+ax_anim_terminator
+sNuzleafAnims_5_7:
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 144, -4, -1, -4, 0,
+ax_anim 3, 0, 144, -8, -1, -8, 0,
+ax_anim 6, 2, 145, -12, 0, -12, 0,
+ax_anim 2, 0, 145, -12, -1, -12, -1,
+ax_anim 2, 0, 145, -12, 0, -12, 0,
+ax_anim 2, 0, 145, -12, -1, -12, -1,
+ax_anim 2, 0, 145, -12, 0, -12, 0,
+ax_anim 2, 1, 145, -12, -1, -12, -1,
+ax_anim 2, 0, 145, -8, 0, -8, 0,
+ax_anim 2, 0, 142, -4, 0, -4, 0,
+ax_anim_terminator
+sNuzleafAnims_5_8:
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 149, -4, 3, -4, 4,
+ax_anim 3, 0, 149, -8, 5, -8, 8,
+ax_anim 6, 2, 150, -12, 12, -12, 12,
+ax_anim 2, 0, 150, -13, 11, -13, 11,
+ax_anim 2, 0, 150, -12, 12, -12, 12,
+ax_anim 2, 0, 150, -13, 11, -13, 11,
+ax_anim 2, 0, 150, -12, 12, -12, 12,
+ax_anim 2, 1, 150, -13, 11, -13, 11,
+ax_anim 2, 0, 150, -8, 8, -8, 8,
+ax_anim 2, 0, 147, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sNuzleafAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sNuzleafAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sNuzleafAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sNuzleafAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sNuzleafAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sNuzleafAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sNuzleafAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_8_1:
+ax_anim 60, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, -1, 0, -1, 0,
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_8_2:
+ax_anim 60, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_8_3:
+ax_anim 60, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, -1, 0, -1, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_8_4:
+ax_anim 60, 0, 171, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 172, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 172, -1, 0, -1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -1, 0, -1, 0,
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_8_5:
+ax_anim 60, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_8_6:
+ax_anim 60, 0, 177, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_8_7:
+ax_anim 60, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_8_8:
+ax_anim 60, 0, 183, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 184, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 184, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 8, 4, 8, 4,
+ax_anim 2, 0, 188, 10, 10, 10, 10,
+ax_anim 2, 0, 189, 10, 18, 10, 18,
+ax_anim 3, 0, 190, 0, 21, 0, 21,
+ax_anim 2, 3, 191, -10, 18, -10, 18,
+ax_anim 2, 0, 192, -10, 10, -10, 10,
+ax_anim 1, 0, 193, -8, 4, -8, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 9, 0, 9, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 22, 10, 22, 10,
+ax_anim 3, 0, 189, 22, 21, 22, 21,
+ax_anim 2, 3, 190, 11, 21, 11, 21,
+ax_anim 2, 0, 191, 1, 16, 1, 16,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 12, -7, 12, -7,
+ax_anim 2, 0, 187, 21, -5, 21, -5,
+ax_anim 3, 0, 188, 23, 0, 23, 0,
+ax_anim 2, 3, 189, 21, 6, 21, 6,
+ax_anim 2, 0, 190, 12, 9, 12, 9,
+ax_anim 1, 0, 191, 3, 7, 3, 7,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 2, -16, 2, -16,
+ax_anim 2, 0, 186, 12, -23, 12, -23,
+ax_anim 3, 0, 187, 23, -25, 23, -25,
+ax_anim 2, 3, 188, 26, -17, 26, -17,
+ax_anim 2, 0, 189, 22, -6, 22, -6,
+ax_anim 1, 0, 190, 11, 0, 11, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -9, -2, -9, -2,
+ax_anim 2, 0, 192, -11, -11, -11, -11,
+ax_anim 2, 0, 193, -9, -18, -9, -18,
+ax_anim 3, 0, 186, 0, -24, 0, -24,
+ax_anim 2, 3, 187, 9, -18, 9, -18,
+ax_anim 2, 0, 188, 11, -11, 11, -11,
+ax_anim 1, 0, 189, 9, -2, 9, -2,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -2, -16, -2, -16,
+ax_anim 2, 0, 186, -12, -23, -12, -23,
+ax_anim 3, 0, 193, -23, -25, -23, -25,
+ax_anim 2, 3, 192, -26, -17, -26, -17,
+ax_anim 2, 0, 191, -22, -6, -22, -6,
+ax_anim 1, 0, 190, -11, 0, -11, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -12, -7, -12, -7,
+ax_anim 2, 0, 193, -21, -5, -21, -5,
+ax_anim 3, 0, 192, -23, 0, -23, 0,
+ax_anim 2, 3, 191, -21, 6, -21, 6,
+ax_anim 2, 0, 190, -12, 9, -12, 9,
+ax_anim 1, 0, 189, -3, 7, -3, 7,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -9, 0, -9, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -22, 10, -22, 10,
+ax_anim 3, 0, 191, -22, 21, -22, 21,
+ax_anim 2, 3, 190, -11, 21, -11, 21,
+ax_anim 2, 0, 189, -3, 18, -3, 18,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -25, 0, 0,
+ax_anim 3, 0, 204, 0, -30, 0, 0,
+ax_anim 2, 0, 204, 0, -26, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -32, 0, 0,
+ax_anim 3, 0, 207, 0, -31, 0, 0,
+ax_anim 2, 0, 207, 0, -26, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -28, 0, 0,
+ax_anim 3, 0, 210, 0, -27, 0, 0,
+ax_anim 2, 0, 210, 0, -20, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -24, 0, 0,
+ax_anim 3, 0, 213, 0, -23, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -24, 0, 0,
+ax_anim 3, 0, 216, 0, -27, 0, 0,
+ax_anim 2, 0, 216, 0, -20, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -24, 0, 0,
+ax_anim 3, 0, 219, 0, -23, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -28, 0, 0,
+ax_anim 3, 0, 222, 0, -27, 0, 0,
+ax_anim 2, 0, 222, 0, -20, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -32, 0, 0,
+ax_anim 3, 0, 225, 0, -31, 0, 0,
+ax_anim 2, 0, 225, 0, -26, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sNuzleafAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sNuzleafGfx1:
+.incbin "baserom.gba", 0x113306C, 0x200
+sNuzleafSprites1:
+ax_sprite sNuzleafGfx1, 0x200
+ax_sprite_terminator
+sNuzleafGfx2:
+.incbin "baserom.gba", 0x113327C, 0x200
+sNuzleafSprites2:
+ax_sprite sNuzleafGfx2, 0x200
+ax_sprite_terminator
+sNuzleafGfx3:
+.incbin "baserom.gba", 0x113348C, 0x200
+sNuzleafSprites3:
+ax_sprite sNuzleafGfx3, 0x200
+ax_sprite_terminator
+sNuzleafGfx4:
+.incbin "baserom.gba", 0x113369C, 0x200
+sNuzleafSprites4:
+ax_sprite sNuzleafGfx4, 0x200
+ax_sprite_terminator
+sNuzleafGfx5:
+.incbin "baserom.gba", 0x11338AC, 0x200
+sNuzleafSprites5:
+ax_sprite sNuzleafGfx5, 0x200
+ax_sprite_terminator
+sNuzleafGfx6:
+.incbin "baserom.gba", 0x1133ABC, 0x200
+sNuzleafSprites6:
+ax_sprite sNuzleafGfx6, 0x200
+ax_sprite_terminator
+sNuzleafGfx7:
+.incbin "baserom.gba", 0x1133CCC, 0x200
+sNuzleafSprites7:
+ax_sprite sNuzleafGfx7, 0x200
+ax_sprite_terminator
+sNuzleafGfx8:
+.incbin "baserom.gba", 0x1133EDC, 0x200
+sNuzleafSprites8:
+ax_sprite sNuzleafGfx8, 0x200
+ax_sprite_terminator
+sNuzleafGfx9:
+.incbin "baserom.gba", 0x11340EC, 0x200
+sNuzleafSprites9:
+ax_sprite sNuzleafGfx9, 0x200
+ax_sprite_terminator
+sNuzleafGfx10:
+.incbin "baserom.gba", 0x11342FC, 0x200
+sNuzleafSprites10:
+ax_sprite sNuzleafGfx10, 0x200
+ax_sprite_terminator
+sNuzleafGfx11:
+.incbin "baserom.gba", 0x113450C, 0x200
+sNuzleafSprites11:
+ax_sprite sNuzleafGfx11, 0x200
+ax_sprite_terminator
+sNuzleafGfx12:
+.incbin "baserom.gba", 0x113471C, 0x200
+sNuzleafSprites12:
+ax_sprite sNuzleafGfx12, 0x200
+ax_sprite_terminator
+sNuzleafGfx13:
+.incbin "baserom.gba", 0x113492C, 0x200
+sNuzleafSprites13:
+ax_sprite sNuzleafGfx13, 0x200
+ax_sprite_terminator
+sNuzleafGfx14:
+.incbin "baserom.gba", 0x1134B3C, 0x200
+sNuzleafSprites14:
+ax_sprite sNuzleafGfx14, 0x200
+ax_sprite_terminator
+sNuzleafGfx15:
+.incbin "baserom.gba", 0x1134D4C, 0x200
+sNuzleafSprites15:
+ax_sprite sNuzleafGfx15, 0x200
+ax_sprite_terminator
+sNuzleafGfx16:
+.incbin "baserom.gba", 0x1134F5C, 0x40
+sNuzleafGfx16_1:
+.incbin "baserom.gba", 0x1134F9C, 0x40
+sNuzleafGfx16_2:
+.incbin "baserom.gba", 0x1134FDC, 0x100
+sNuzleafSprites16:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx16_2, 0x100
+ax_sprite_terminator
+sNuzleafGfx17:
+.incbin "baserom.gba", 0x1135114, 0x40
+sNuzleafGfx17_1:
+.incbin "baserom.gba", 0x1135154, 0x40
+sNuzleafGfx17_2:
+.incbin "baserom.gba", 0x1135194, 0x40
+sNuzleafGfx17_3:
+.incbin "baserom.gba", 0x11351D4, 0x20
+sNuzleafSprites17:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx17_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sNuzleafGfx17_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx18:
+.incbin "baserom.gba", 0x1135244, 0x40
+sNuzleafGfx18_1:
+.incbin "baserom.gba", 0x1135284, 0x100
+sNuzleafSprites18:
+ax_sprite 0, 0xa0
+ax_sprite sNuzleafGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx18_1, 0x100
+ax_sprite_terminator
+sNuzleafGfx19:
+.incbin "baserom.gba", 0x11353AC, 0x20
+sNuzleafGfx19_1:
+.incbin "baserom.gba", 0x11353CC, 0x40
+sNuzleafGfx19_2:
+.incbin "baserom.gba", 0x113540C, 0x100
+sNuzleafSprites19:
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx19_2, 0x100
+ax_sprite_terminator
+sNuzleafGfx20:
+.incbin "baserom.gba", 0x1135544, 0x20
+sNuzleafGfx20_1:
+.incbin "baserom.gba", 0x1135564, 0x40
+sNuzleafGfx20_2:
+.incbin "baserom.gba", 0x11355A4, 0x60
+sNuzleafGfx20_3:
+.incbin "baserom.gba", 0x1135604, 0x60
+sNuzleafSprites20:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx20, 0x20
+ax_sprite 0, 0x60
+ax_sprite sNuzleafGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx20_3, 0x60
+ax_sprite_terminator
+sNuzleafGfx21:
+.incbin "baserom.gba", 0x11356AC, 0xC0
+sNuzleafGfx21_1:
+.incbin "baserom.gba", 0x113576C, 0x60
+sNuzleafGfx21_2:
+.incbin "baserom.gba", 0x11357CC, 0x40
+sNuzleafSprites21:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx21_2, 0x40
+ax_sprite_terminator
+sNuzleafGfx22:
+.incbin "baserom.gba", 0x1135844, 0x60
+sNuzleafGfx22_1:
+.incbin "baserom.gba", 0x11358A4, 0xE0
+sNuzleafSprites22:
+ax_sprite 0, 0x80
+ax_sprite sNuzleafGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx23:
+.incbin "baserom.gba", 0x11359B4, 0x20
+sNuzleafGfx23_1:
+.incbin "baserom.gba", 0x11359D4, 0x60
+sNuzleafGfx23_2:
+.incbin "baserom.gba", 0x1135A34, 0xE0
+sNuzleafSprites23:
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx23_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx24:
+.incbin "baserom.gba", 0x1135B54, 0x40
+sNuzleafGfx24_1:
+.incbin "baserom.gba", 0x1135B94, 0x40
+sNuzleafGfx24_2:
+.incbin "baserom.gba", 0x1135BD4, 0x60
+sNuzleafGfx24_3:
+.incbin "baserom.gba", 0x1135C34, 0x60
+sNuzleafSprites24:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx24_3, 0x60
+ax_sprite_terminator
+sNuzleafGfx25:
+.incbin "baserom.gba", 0x1135CDC, 0x100
+sNuzleafGfx25_1:
+.incbin "baserom.gba", 0x1135DDC, 0x60
+sNuzleafGfx25_2:
+.incbin "baserom.gba", 0x1135E3C, 0x40
+sNuzleafSprites25:
+ax_sprite sNuzleafGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx25_2, 0x40
+ax_sprite_terminator
+sNuzleafGfx26:
+.incbin "baserom.gba", 0x1135EAC, 0x60
+sNuzleafGfx26_1:
+.incbin "baserom.gba", 0x1135F0C, 0x60
+sNuzleafGfx26_2:
+.incbin "baserom.gba", 0x1135F6C, 0x60
+sNuzleafSprites26:
+ax_sprite 0, 0x80
+ax_sprite sNuzleafGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx27:
+.incbin "baserom.gba", 0x113600C, 0x60
+sNuzleafGfx27_1:
+.incbin "baserom.gba", 0x113606C, 0x60
+sNuzleafGfx27_2:
+.incbin "baserom.gba", 0x11360CC, 0x60
+sNuzleafSprites27:
+ax_sprite 0, 0x80
+ax_sprite sNuzleafGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx28:
+.incbin "baserom.gba", 0x113616C, 0x40
+sNuzleafGfx28_1:
+.incbin "baserom.gba", 0x11361AC, 0x40
+sNuzleafGfx28_2:
+.incbin "baserom.gba", 0x11361EC, 0x60
+sNuzleafGfx28_3:
+.incbin "baserom.gba", 0x113624C, 0x60
+sNuzleafSprites28:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx28_3, 0x60
+ax_sprite_terminator
+sNuzleafGfx29:
+.incbin "baserom.gba", 0x11362F4, 0x60
+sNuzleafGfx29_1:
+.incbin "baserom.gba", 0x1136354, 0x60
+sNuzleafGfx29_2:
+.incbin "baserom.gba", 0x11363B4, 0x40
+sNuzleafGfx29_3:
+.incbin "baserom.gba", 0x11363F4, 0x40
+sNuzleafSprites29:
+ax_sprite sNuzleafGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx30:
+.incbin "baserom.gba", 0x113647C, 0x60
+sNuzleafGfx30_1:
+.incbin "baserom.gba", 0x11364DC, 0x60
+sNuzleafGfx30_2:
+.incbin "baserom.gba", 0x113653C, 0x60
+sNuzleafGfx30_3:
+.incbin "baserom.gba", 0x113659C, 0x60
+sNuzleafSprites30:
+ax_sprite sNuzleafGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx31:
+.incbin "baserom.gba", 0x1136644, 0x60
+sNuzleafGfx31_1:
+.incbin "baserom.gba", 0x11366A4, 0x60
+sNuzleafGfx31_2:
+.incbin "baserom.gba", 0x1136704, 0x60
+sNuzleafGfx31_3:
+.incbin "baserom.gba", 0x1136764, 0x60
+sNuzleafSprites31:
+ax_sprite sNuzleafGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx32:
+.incbin "baserom.gba", 0x113680C, 0x40
+sNuzleafGfx32_1:
+.incbin "baserom.gba", 0x113684C, 0x40
+sNuzleafGfx32_2:
+.incbin "baserom.gba", 0x113688C, 0x60
+sNuzleafGfx32_3:
+.incbin "baserom.gba", 0x11368EC, 0x40
+sNuzleafSprites32:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx33:
+.incbin "baserom.gba", 0x113697C, 0x40
+sNuzleafGfx33_1:
+.incbin "baserom.gba", 0x11369BC, 0x40
+sNuzleafGfx33_2:
+.incbin "baserom.gba", 0x11369FC, 0x40
+sNuzleafGfx33_3:
+.incbin "baserom.gba", 0x1136A3C, 0x20
+sNuzleafSprites33:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx33_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sNuzleafGfx33_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sNuzleafGfx34:
+.incbin "baserom.gba", 0x1136AAC, 0x40
+sNuzleafGfx34_1:
+.incbin "baserom.gba", 0x1136AEC, 0x100
+sNuzleafGfx34_2:
+.incbin "baserom.gba", 0x1136BEC, 0x40
+sNuzleafSprites34:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx35:
+.incbin "baserom.gba", 0x1136C6C, 0x40
+sNuzleafGfx35_1:
+.incbin "baserom.gba", 0x1136CAC, 0x100
+sNuzleafGfx35_2:
+.incbin "baserom.gba", 0x1136DAC, 0x40
+sNuzleafSprites35:
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sNuzleafGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sNuzleafGfx36:
+.incbin "baserom.gba", 0x1136E2C, 0x200
+sNuzleafSprites36:
+ax_sprite sNuzleafGfx36, 0x200
+ax_sprite_terminator
+sNuzleafGfx37:
+.incbin "baserom.gba", 0x113703C, 0x200
+sNuzleafSprites37:
+ax_sprite sNuzleafGfx37, 0x200
+ax_sprite_terminator
+sNuzleafGfx38:
+.incbin "baserom.gba", 0x113724C, 0x200
+sNuzleafSprites38:
+ax_sprite sNuzleafGfx38, 0x200
+ax_sprite_terminator
+sNuzleafGfx39:
+.incbin "baserom.gba", 0x113745C, 0x200
+sNuzleafSprites39:
+ax_sprite sNuzleafGfx39, 0x200
+ax_sprite_terminator
+sNuzleafGfx40:
+.incbin "baserom.gba", 0x113766C, 0x200
+sNuzleafSprites40:
+ax_sprite sNuzleafGfx40, 0x200
+ax_sprite_terminator
+sNuzleafGfx41:
+.incbin "baserom.gba", 0x113787C, 0x200
+sNuzleafSprites41:
+ax_sprite sNuzleafGfx41, 0x200
+ax_sprite_terminator
+sNuzleafGfx42:
+.incbin "baserom.gba", 0x1137A8C, 0x200
+sNuzleafSprites42:
+ax_sprite sNuzleafGfx42, 0x200
+ax_sprite_terminator
+sAxPosesNuzleaf:
+.4byte sNuzleafPose1
+.4byte sNuzleafPose2
+.4byte sNuzleafPose3
+.4byte sNuzleafPose4
+.4byte sNuzleafPose5
+.4byte sNuzleafPose6
+.4byte sNuzleafPose7
+.4byte sNuzleafPose8
+.4byte sNuzleafPose9
+.4byte sNuzleafPose10
+.4byte sNuzleafPose11
+.4byte sNuzleafPose12
+.4byte sNuzleafPose13
+.4byte sNuzleafPose14
+.4byte sNuzleafPose15
+.4byte sNuzleafPose16
+.4byte sNuzleafPose17
+.4byte sNuzleafPose18
+.4byte sNuzleafPose19
+.4byte sNuzleafPose20
+.4byte sNuzleafPose21
+.4byte sNuzleafPose22
+.4byte sNuzleafPose23
+.4byte sNuzleafPose24
+.4byte sNuzleafPose25
+.4byte sNuzleafPose26
+.4byte sNuzleafPose27
+.4byte sNuzleafPose28
+.4byte sNuzleafPose29
+.4byte sNuzleafPose30
+.4byte sNuzleafPose31
+.4byte sNuzleafPose32
+.4byte sNuzleafPose33
+.4byte sNuzleafPose34
+.4byte sNuzleafPose35
+.4byte sNuzleafPose36
+.4byte sNuzleafPose37
+.4byte sNuzleafPose38
+.4byte sNuzleafPose39
+.4byte sNuzleafPose40
+.4byte sNuzleafPose41
+.4byte sNuzleafPose42
+.4byte sNuzleafPose43
+.4byte sNuzleafPose44
+.4byte sNuzleafPose45
+.4byte sNuzleafPose46
+.4byte sNuzleafPose47
+.4byte sNuzleafPose48
+.4byte sNuzleafPose49
+.4byte sNuzleafPose50
+.4byte sNuzleafPose51
+.4byte sNuzleafPose52
+.4byte sNuzleafPose53
+.4byte sNuzleafPose54
+.4byte sNuzleafPose55
+.4byte sNuzleafPose56
+.4byte sNuzleafPose57
+.4byte sNuzleafPose58
+.4byte sNuzleafPose59
+.4byte sNuzleafPose60
+.4byte sNuzleafPose61
+.4byte sNuzleafPose62
+.4byte sNuzleafPose63
+.4byte sNuzleafPose64
+.4byte sNuzleafPose65
+.4byte sNuzleafPose66
+.4byte sNuzleafPose67
+.4byte sNuzleafPose68
+.4byte sNuzleafPose69
+.4byte sNuzleafPose70
+.4byte sNuzleafPose71
+.4byte sNuzleafPose72
+.4byte sNuzleafPose73
+.4byte sNuzleafPose74
+.4byte sNuzleafPose75
+.4byte sNuzleafPose76
+.4byte sNuzleafPose77
+.4byte sNuzleafPose78
+.4byte sNuzleafPose79
+.4byte sNuzleafPose80
+.4byte sNuzleafPose81
+.4byte sNuzleafPose82
+.4byte sNuzleafPose83
+.4byte sNuzleafPose84
+.4byte sNuzleafPose85
+.4byte sNuzleafPose86
+.4byte sNuzleafPose87
+.4byte sNuzleafPose88
+.4byte sNuzleafPose89
+.4byte sNuzleafPose90
+.4byte sNuzleafPose91
+.4byte sNuzleafPose92
+.4byte sNuzleafPose93
+.4byte sNuzleafPose94
+.4byte sNuzleafPose95
+.4byte sNuzleafPose96
+.4byte sNuzleafPose97
+.4byte sNuzleafPose98
+.4byte sNuzleafPose99
+.4byte sNuzleafPose100
+.4byte sNuzleafPose101
+.4byte sNuzleafPose102
+.4byte sNuzleafPose103
+.4byte sNuzleafPose104
+.4byte sNuzleafPose105
+.4byte sNuzleafPose106
+.4byte sNuzleafPose107
+.4byte sNuzleafPose108
+.4byte sNuzleafPose109
+.4byte sNuzleafPose110
+.4byte sNuzleafPose111
+.4byte sNuzleafPose112
+.4byte sNuzleafPose113
+.4byte sNuzleafPose114
+.4byte sNuzleafPose115
+.4byte sNuzleafPose116
+.4byte sNuzleafPose117
+.4byte sNuzleafPose118
+.4byte sNuzleafPose119
+.4byte sNuzleafPose120
+.4byte sNuzleafPose121
+.4byte sNuzleafPose122
+.4byte sNuzleafPose123
+.4byte sNuzleafPose124
+.4byte sNuzleafPose125
+.4byte sNuzleafPose126
+.4byte sNuzleafPose127
+.4byte sNuzleafPose128
+.4byte sNuzleafPose129
+.4byte sNuzleafPose130
+.4byte sNuzleafPose131
+.4byte sNuzleafPose132
+.4byte sNuzleafPose133
+.4byte sNuzleafPose134
+.4byte sNuzleafPose135
+.4byte sNuzleafPose136
+.4byte sNuzleafPose137
+.4byte sNuzleafPose138
+.4byte sNuzleafPose139
+.4byte sNuzleafPose140
+.4byte sNuzleafPose141
+.4byte sNuzleafPose142
+.4byte sNuzleafPose143
+.4byte sNuzleafPose144
+.4byte sNuzleafPose145
+.4byte sNuzleafPose146
+.4byte sNuzleafPose147
+.4byte sNuzleafPose148
+.4byte sNuzleafPose149
+.4byte sNuzleafPose150
+.4byte sNuzleafPose151
+.4byte sNuzleafPose152
+.4byte sNuzleafPose153
+.4byte sNuzleafPose154
+.4byte sNuzleafPose155
+.4byte sNuzleafPose156
+.4byte sNuzleafPose157
+.4byte sNuzleafPose158
+.4byte sNuzleafPose159
+.4byte sNuzleafPose160
+.4byte sNuzleafPose161
+.4byte sNuzleafPose162
+.4byte sNuzleafPose163
+.4byte sNuzleafPose164
+.4byte sNuzleafPose165
+.4byte sNuzleafPose166
+.4byte sNuzleafPose167
+.4byte sNuzleafPose168
+.4byte sNuzleafPose169
+.4byte sNuzleafPose170
+.4byte sNuzleafPose171
+.4byte sNuzleafPose172
+.4byte sNuzleafPose173
+.4byte sNuzleafPose174
+.4byte sNuzleafPose175
+.4byte sNuzleafPose176
+.4byte sNuzleafPose177
+.4byte sNuzleafPose178
+.4byte sNuzleafPose179
+.4byte sNuzleafPose180
+.4byte sNuzleafPose181
+.4byte sNuzleafPose182
+.4byte sNuzleafPose183
+.4byte sNuzleafPose184
+.4byte sNuzleafPose185
+.4byte sNuzleafPose186
+.4byte sNuzleafPose187
+.4byte sNuzleafPose188
+.4byte sNuzleafPose189
+.4byte sNuzleafPose190
+.4byte sNuzleafPose191
+.4byte sNuzleafPose192
+.4byte sNuzleafPose193
+.4byte sNuzleafPose194
+.4byte sNuzleafPose195
+.4byte sNuzleafPose196
+.4byte sNuzleafPose197
+.4byte sNuzleafPose198
+.4byte sNuzleafPose199
+.4byte sNuzleafPose200
+.4byte sNuzleafPose201
+.4byte sNuzleafPose202
+.4byte sNuzleafPose203
+.4byte sNuzleafPose204
+.4byte sNuzleafPose205
+.4byte sNuzleafPose206
+.4byte sNuzleafPose207
+.4byte sNuzleafPose208
+.4byte sNuzleafPose209
+.4byte sNuzleafPose210
+.4byte sNuzleafPose211
+.4byte sNuzleafPose212
+.4byte sNuzleafPose213
+.4byte sNuzleafPose214
+.4byte sNuzleafPose215
+.4byte sNuzleafPose216
+.4byte sNuzleafPose217
+.4byte sNuzleafPose218
+.4byte sNuzleafPose219
+.4byte sNuzleafPose220
+.4byte sNuzleafPose221
+.4byte sNuzleafPose222
+.4byte sNuzleafPose223
+.4byte sNuzleafPose224
+.4byte sNuzleafPose225
+.4byte sNuzleafPose226
+.4byte sNuzleafPose227
+.4byte sNuzleafPose228
+.4byte sNuzleafPose229
+.4byte sNuzleafPose230
+.4byte sNuzleafPose231
+.4byte sNuzleafPose232
+.4byte sNuzleafPose233
+.4byte sNuzleafPose234
+.4byte sNuzleafPose235
+.4byte sNuzleafPose236
+.4byte sNuzleafPose237
+.4byte sNuzleafPose238
+.4byte sNuzleafPose239
+.4byte sNuzleafPose240
+.4byte sNuzleafPose241
+.4byte sNuzleafPose242
+sAxPositionsNuzleaf:
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte    0,   -6, 	 -10,   -9, 	  10,   -9, 	   0,   -7
+.2byte    0,   -6, 	  -8,  -10, 	   8,  -10, 	   0,   -7
+.2byte    5,   -8, 	   1,  -13, 	  -8,   -9, 	   1,   -9
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -6, 	   2,   -7
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -8, 	   2,   -7
+.2byte    7,  -10, 	  -4,  -13, 	  -5,   -6, 	   2,   -8
+.2byte    9,   -9, 	  -2,  -13, 	  -4,   -4, 	   3,   -7
+.2byte    9,   -9, 	  -2,  -11, 	  -4,   -7, 	   2,   -7
+.2byte    7,  -13, 	  -7,  -10, 	   4,   -5, 	   1,  -10
+.2byte    9,  -13, 	  -6,  -11, 	   6,   -5, 	   2,  -10
+.2byte    9,  -13, 	  -6,   -9, 	   2,   -5, 	   2,  -11
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    0,  -12, 	   9,   -7, 	  -9,   -7, 	   0,  -10
+.2byte    0,  -12, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte   -7,  -13, 	   7,  -10, 	  -4,   -5, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -11, 	  -6,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	   6,   -9, 	  -2,   -5, 	  -2,  -11
+.2byte   -7,  -10, 	   4,  -13, 	   5,   -6, 	  -2,   -8
+.2byte   -9,   -9, 	   2,  -13, 	   4,   -4, 	  -3,   -7
+.2byte   -9,   -9, 	   2,  -11, 	   4,   -7, 	  -2,   -7
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -6, 	  -2,   -7
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -8, 	  -2,   -7
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte    0,   -6, 	 -10,   -9, 	  10,   -9, 	   0,   -7
+.2byte    0,   -6, 	  -8,  -10, 	   8,  -10, 	   0,   -7
+.2byte    5,   -8, 	   1,  -13, 	  -8,   -9, 	   1,   -9
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -6, 	   2,   -7
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -8, 	   2,   -7
+.2byte    7,  -10, 	  -4,  -13, 	  -5,   -6, 	   2,   -8
+.2byte    9,   -9, 	  -2,  -13, 	  -4,   -4, 	   3,   -7
+.2byte    9,   -9, 	  -2,  -11, 	  -4,   -7, 	   2,   -7
+.2byte    7,  -13, 	  -7,  -10, 	   4,   -5, 	   1,  -10
+.2byte    9,  -13, 	  -6,  -11, 	   6,   -5, 	   2,  -10
+.2byte    9,  -13, 	  -6,   -9, 	   2,   -5, 	   2,  -11
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    0,  -12, 	   9,   -7, 	  -9,   -7, 	   0,  -10
+.2byte    0,  -12, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte   -7,  -13, 	   7,  -10, 	  -4,   -5, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -11, 	  -6,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	   6,   -9, 	  -2,   -5, 	  -2,  -11
+.2byte   -7,  -10, 	   4,  -13, 	   5,   -6, 	  -2,   -8
+.2byte   -9,   -9, 	   2,  -13, 	   4,   -4, 	  -3,   -7
+.2byte   -9,   -9, 	   2,  -11, 	   4,   -7, 	  -2,   -7
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -6, 	  -2,   -7
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -8, 	  -2,   -7
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte    0,   -6, 	 -10,   -9, 	  10,   -9, 	   0,   -7
+.2byte    0,   -6, 	  -8,  -10, 	   8,  -10, 	   0,   -7
+.2byte    5,   -8, 	   1,  -13, 	  -8,   -9, 	   1,   -9
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -6, 	   2,   -7
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -8, 	   2,   -7
+.2byte    7,  -10, 	  -4,  -13, 	  -5,   -6, 	   2,   -8
+.2byte    9,   -9, 	  -2,  -13, 	  -4,   -4, 	   3,   -7
+.2byte    9,   -9, 	  -2,  -11, 	  -4,   -7, 	   2,   -7
+.2byte    7,  -13, 	  -7,  -10, 	   4,   -5, 	   1,  -10
+.2byte    9,  -13, 	  -6,  -11, 	   6,   -5, 	   2,  -10
+.2byte    9,  -13, 	  -6,   -9, 	   2,   -5, 	   2,  -11
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    0,  -12, 	   9,   -7, 	  -9,   -7, 	   0,  -10
+.2byte    0,  -12, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte   -7,  -13, 	   7,  -10, 	  -4,   -5, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -11, 	  -6,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	   6,   -9, 	  -2,   -5, 	  -2,  -11
+.2byte   -7,  -10, 	   4,  -13, 	   5,   -6, 	  -2,   -8
+.2byte   -9,   -9, 	   2,  -13, 	   4,   -4, 	  -3,   -7
+.2byte   -9,   -9, 	   2,  -11, 	   4,   -7, 	  -2,   -7
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -6, 	  -2,   -7
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -8, 	  -2,   -7
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte    0,   -4, 	  -7,   -5, 	   7,   -5, 	   0,   -7
+.2byte    0,  -15, 	  -4,  -14, 	   4,  -14, 	   0,  -13
+.2byte    0,   -2, 	 -12,   -7, 	  12,   -7, 	   0,   -5
+.2byte    0,    0, 	 -12,   -7, 	  12,   -7, 	   0,   -5
+.2byte    4,   -8, 	   0,  -13, 	  -9,   -9, 	   0,   -9
+.2byte    0,   -2, 	   8,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte    6,  -14, 	   7,  -13, 	   3,  -12, 	   0,  -10
+.2byte    7,   -3, 	   1,   -9, 	  -8,   -4, 	   0,   -4
+.2byte    7,   -2, 	   1,   -9, 	  -8,   -4, 	   0,   -4
+.2byte    5,  -10, 	  -6,  -13, 	  -7,   -6, 	   0,   -8
+.2byte    5,   -4, 	   4,   -7, 	   3,   -3, 	   1,   -5
+.2byte    9,  -17, 	   6,  -20, 	   9,  -15, 	   1,  -11
+.2byte    9,   -5, 	  -2,  -12, 	  -4,   -5, 	   0,   -4
+.2byte    9,   -4, 	  -2,  -12, 	  -4,   -5, 	   0,   -4
+.2byte    5,  -13, 	  -9,  -10, 	   2,   -5, 	  -1,  -10
+.2byte    5,   -5, 	   0,  -10, 	   6,   -5, 	  -2,   -6
+.2byte    7,  -21, 	   0,  -20, 	   8,  -17, 	  -1,  -13
+.2byte    7,  -14, 	 -10,  -13, 	   7,   -5, 	  -1,   -9
+.2byte    7,  -13, 	 -10,  -13, 	   7,   -5, 	  -1,   -9
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    0,   -8, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte    0,  -19, 	   3,  -17, 	  -3,  -17, 	   0,  -14
+.2byte    0,  -10, 	  11,  -11, 	 -11,  -11, 	   0,   -9
+.2byte    0,  -10, 	  11,  -11, 	 -11,  -11, 	   0,   -9
+.2byte   -6,  -13, 	   8,  -10, 	  -3,   -5, 	   0,  -10
+.2byte   -6,   -5, 	  -1,  -10, 	  -7,   -5, 	   1,   -6
+.2byte   -8,  -21, 	  -1,  -20, 	  -9,  -17, 	   0,  -13
+.2byte   -8,  -14, 	   9,  -13, 	  -8,   -5, 	   0,   -9
+.2byte   -8,  -13, 	   9,  -13, 	  -8,   -5, 	   0,   -9
+.2byte   -6,  -10, 	   5,  -13, 	   6,   -6, 	  -1,   -8
+.2byte   -6,   -4, 	  -5,   -7, 	  -4,   -3, 	  -2,   -5
+.2byte  -10,  -17, 	  -7,  -20, 	 -10,  -15, 	  -2,  -11
+.2byte  -10,   -5, 	   1,  -12, 	   3,   -5, 	  -1,   -4
+.2byte  -10,   -4, 	   1,  -12, 	   3,   -5, 	  -1,   -4
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -2, 	  -9,   -4, 	   3,   -4, 	   0,   -6
+.2byte   -7,  -14, 	  -8,  -13, 	  -4,  -12, 	  -1,  -10
+.2byte   -8,   -3, 	  -2,   -9, 	   7,   -4, 	  -1,   -4
+.2byte   -8,   -2, 	  -2,   -9, 	   7,   -4, 	  -1,   -4
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte    0,   -4, 	  -7,   -5, 	   7,   -5, 	   0,   -7
+.2byte    0,  -15, 	  -4,  -14, 	   4,  -14, 	   0,  -13
+.2byte    0,   -2, 	 -12,   -7, 	  12,   -7, 	   0,   -5
+.2byte    0,    0, 	 -12,   -7, 	  12,   -7, 	   0,   -5
+.2byte    5,   -8, 	   1,  -13, 	  -8,   -9, 	   1,   -9
+.2byte    1,   -2, 	   9,   -4, 	  -3,   -4, 	   0,   -6
+.2byte    7,  -14, 	   8,  -13, 	   4,  -12, 	   1,  -10
+.2byte    8,   -3, 	   2,   -9, 	  -7,   -4, 	   1,   -4
+.2byte    8,   -2, 	   2,   -9, 	  -7,   -4, 	   1,   -4
+.2byte    7,  -10, 	  -4,  -13, 	  -5,   -6, 	   2,   -8
+.2byte    8,   -4, 	   7,   -7, 	   6,   -3, 	   4,   -5
+.2byte   12,  -17, 	   9,  -20, 	  12,  -15, 	   4,  -11
+.2byte   11,   -5, 	   0,  -12, 	  -2,   -5, 	   2,   -4
+.2byte   11,   -4, 	   0,  -12, 	  -2,   -5, 	   2,   -4
+.2byte    7,  -13, 	  -7,  -10, 	   4,   -5, 	   1,  -10
+.2byte    7,   -5, 	   2,  -10, 	   8,   -5, 	   0,   -6
+.2byte    9,  -21, 	   2,  -20, 	  10,  -17, 	   1,  -13
+.2byte   10,  -15, 	  -7,  -14, 	  10,   -6, 	   2,  -10
+.2byte   10,  -14, 	  -7,  -14, 	  10,   -6, 	   2,  -10
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    0,   -8, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte    0,  -19, 	   3,  -17, 	  -3,  -17, 	   0,  -14
+.2byte    0,  -10, 	  11,  -11, 	 -11,  -11, 	   0,   -9
+.2byte    0,  -10, 	  11,  -11, 	 -11,  -11, 	   0,   -9
+.2byte   -7,  -13, 	   7,  -10, 	  -4,   -5, 	  -1,  -10
+.2byte   -7,   -5, 	  -2,  -10, 	  -8,   -5, 	   0,   -6
+.2byte   -9,  -21, 	  -2,  -20, 	 -10,  -17, 	  -1,  -13
+.2byte  -10,  -15, 	   7,  -14, 	 -10,   -6, 	  -2,  -10
+.2byte  -10,  -14, 	   7,  -14, 	 -10,   -6, 	  -2,  -10
+.2byte   -7,  -10, 	   4,  -13, 	   5,   -6, 	  -2,   -8
+.2byte   -8,   -4, 	  -7,   -7, 	  -6,   -3, 	  -4,   -5
+.2byte  -12,  -17, 	  -9,  -20, 	 -12,  -15, 	  -4,  -11
+.2byte  -11,   -5, 	   0,  -12, 	   2,   -5, 	  -2,   -4
+.2byte  -11,   -4, 	   0,  -12, 	   2,   -5, 	  -2,   -4
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -2, 	  -9,   -4, 	   3,   -4, 	   0,   -6
+.2byte   -7,  -14, 	  -8,  -13, 	  -4,  -12, 	  -1,  -10
+.2byte   -8,   -3, 	  -2,   -9, 	   7,   -4, 	  -1,   -4
+.2byte   -8,   -2, 	  -2,   -9, 	   7,   -4, 	  -1,   -4
+.2byte   -3,   -7, 	  -5,   -2, 	   7,    0, 	   1,   -7
+.2byte   -4,   -6, 	  -5,   -2, 	   7,    0, 	   0,   -6
+.2byte    0,  -12, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte   -1,  -11, 	   7,   -9, 	 -10,   -2, 	  -1,   -9
+.2byte   -2,  -11, 	   2,  -12, 	  -5,   -1, 	  -1,   -8
+.2byte    0,  -10, 	 -12,   -8, 	   4,    0, 	   1,   -8
+.2byte    0,  -11, 	  10,   -5, 	 -10,   -5, 	   0,   -7
+.2byte   -1,  -10, 	  11,   -8, 	  -5,    0, 	  -2,   -8
+.2byte    1,  -11, 	  -3,  -12, 	   4,   -1, 	   0,   -8
+.2byte    0,  -11, 	  -8,   -9, 	   9,   -2, 	   0,   -9
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte    0,   -6, 	 -10,   -9, 	  10,   -9, 	   0,   -7
+.2byte    0,   -6, 	  -8,  -10, 	   8,  -10, 	   0,   -7
+.2byte    5,   -8, 	   1,  -13, 	  -8,   -9, 	   1,   -9
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -6, 	   2,   -7
+.2byte    6,   -6, 	   2,  -11, 	  -7,   -8, 	   2,   -7
+.2byte    7,  -10, 	  -4,  -13, 	  -5,   -6, 	   2,   -8
+.2byte    9,   -9, 	  -2,  -13, 	  -4,   -4, 	   3,   -7
+.2byte    9,   -9, 	  -2,  -11, 	  -4,   -7, 	   2,   -7
+.2byte    7,  -13, 	  -7,  -10, 	   4,   -5, 	   1,  -10
+.2byte    9,  -13, 	  -6,  -11, 	   6,   -5, 	   2,  -10
+.2byte    9,  -13, 	  -6,   -9, 	   2,   -5, 	   2,  -11
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    0,  -12, 	   9,   -7, 	  -9,   -7, 	   0,  -10
+.2byte    0,  -12, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte   -7,  -13, 	   7,  -10, 	  -4,   -5, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -11, 	  -6,   -5, 	  -2,  -10
+.2byte   -9,  -13, 	   6,   -9, 	  -2,   -5, 	  -2,  -11
+.2byte   -7,  -10, 	   4,  -13, 	   5,   -6, 	  -2,   -8
+.2byte   -9,   -9, 	   2,  -13, 	   4,   -4, 	  -3,   -7
+.2byte   -9,   -9, 	   2,  -11, 	   4,   -7, 	  -2,   -7
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -6, 	  -2,   -7
+.2byte   -6,   -6, 	  -2,  -11, 	   7,   -8, 	  -2,   -7
+.2byte    0,    0, 	 -12,   -7, 	  12,   -7, 	   0,   -5
+.2byte   -8,   -2, 	  -2,   -9, 	   7,   -4, 	  -1,   -4
+.2byte  -10,   -4, 	   1,  -12, 	   3,   -5, 	  -1,   -4
+.2byte   -9,  -12, 	   8,  -12, 	  -9,   -4, 	  -1,   -8
+.2byte    0,   -9, 	  11,  -10, 	 -11,  -10, 	   0,   -8
+.2byte    8,  -12, 	  -9,  -12, 	   8,   -4, 	   0,   -8
+.2byte    9,   -4, 	  -2,  -12, 	  -4,   -5, 	   0,   -4
+.2byte    7,   -2, 	   1,   -9, 	  -8,   -4, 	   0,   -4
+.2byte    0,  -14, 	  -4,  -13, 	   4,  -13, 	   0,  -12
+.2byte    6,  -14, 	   7,  -13, 	   3,  -12, 	   0,  -10
+.2byte    9,  -17, 	   6,  -20, 	   9,  -15, 	   1,  -11
+.2byte    6,  -19, 	  -1,  -18, 	   7,  -15, 	  -2,  -11
+.2byte    0,  -16, 	   3,  -14, 	  -3,  -14, 	   0,  -11
+.2byte   -7,  -19, 	   0,  -18, 	  -8,  -15, 	   1,  -11
+.2byte  -10,  -17, 	  -7,  -20, 	 -10,  -15, 	  -2,  -11
+.2byte   -7,  -14, 	  -8,  -13, 	  -4,  -12, 	  -1,  -10
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte    0,  -12, 	  -4,  -11, 	   4,  -11, 	   0,  -10
+.2byte    0,    0, 	 -12,   -7, 	  12,   -7, 	   0,   -5
+.2byte    4,   -8, 	   0,  -13, 	  -9,   -9, 	   0,   -9
+.2byte    5,  -14, 	   6,  -13, 	   2,  -12, 	  -1,  -10
+.2byte    6,   -2, 	   0,   -9, 	  -9,   -4, 	  -1,   -4
+.2byte    5,  -10, 	  -6,  -13, 	  -7,   -6, 	   0,   -8
+.2byte    7,  -14, 	   4,  -17, 	   7,  -12, 	  -1,   -8
+.2byte    5,   -4, 	  -6,  -12, 	  -8,   -5, 	  -4,   -4
+.2byte    5,  -13, 	  -9,  -10, 	   2,   -5, 	  -1,  -10
+.2byte    5,  -19, 	  -2,  -18, 	   6,  -15, 	  -3,  -11
+.2byte    6,  -13, 	 -11,  -13, 	   6,   -5, 	  -2,   -9
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    0,  -16, 	   3,  -14, 	  -3,  -14, 	   0,  -11
+.2byte    0,  -10, 	  11,  -11, 	 -11,  -11, 	   0,   -9
+.2byte   -6,  -13, 	   8,  -10, 	  -3,   -5, 	   0,  -10
+.2byte   -6,  -19, 	   1,  -18, 	  -7,  -15, 	   2,  -11
+.2byte   -7,  -13, 	  10,  -13, 	  -7,   -5, 	   1,   -9
+.2byte   -6,  -10, 	   5,  -13, 	   6,   -6, 	  -1,   -8
+.2byte   -8,  -15, 	  -5,  -18, 	  -8,  -13, 	   0,   -9
+.2byte   -6,   -4, 	   5,  -12, 	   7,   -5, 	   3,   -4
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -6,  -14, 	  -7,  -13, 	  -3,  -12, 	   0,  -10
+.2byte   -7,   -2, 	  -1,   -9, 	   8,   -4, 	   0,   -4
+.2byte    0,   -4, 	  -7,   -5, 	   7,   -5, 	   0,   -7
+.2byte    0,   -2, 	  -8,   -4, 	   4,   -4, 	   1,   -6
+.2byte   -4,   -4, 	  -3,   -7, 	  -2,   -3, 	   0,   -5
+.2byte   -5,   -5, 	   0,  -10, 	  -6,   -5, 	   2,   -6
+.2byte    0,   -8, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte    4,   -5, 	  -1,  -10, 	   5,   -5, 	  -3,   -6
+.2byte    4,   -4, 	   3,   -7, 	   2,   -3, 	   0,   -5
+.2byte    0,   -2, 	   8,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte    0,   -8, 	  -9,  -11, 	   9,  -11, 	   0,   -9
+.2byte   -5,   -8, 	  -1,  -13, 	   8,   -9, 	  -1,   -9
+.2byte   -7,  -10, 	   4,  -13, 	   5,   -6, 	  -2,   -8
+.2byte   -7,  -13, 	   7,  -10, 	  -4,   -5, 	  -1,  -10
+.2byte    0,  -13, 	   9,   -6, 	  -9,   -6, 	   0,  -11
+.2byte    7,  -13, 	  -7,  -10, 	   4,   -5, 	   1,  -10
+.2byte    7,  -10, 	  -4,  -13, 	  -5,   -6, 	   2,   -8
+.2byte    5,   -8, 	   1,  -13, 	  -8,   -9, 	   1,   -9
+sNuzleafAnimTable1:
+.4byte sNuzleafAnims_1_1
+.4byte sNuzleafAnims_1_2
+.4byte sNuzleafAnims_1_3
+.4byte sNuzleafAnims_1_4
+.4byte sNuzleafAnims_1_5
+.4byte sNuzleafAnims_1_6
+.4byte sNuzleafAnims_1_7
+.4byte sNuzleafAnims_1_8
+sNuzleafAnimTable2:
+.4byte sNuzleafAnims_2_1
+.4byte sNuzleafAnims_2_2
+.4byte sNuzleafAnims_2_3
+.4byte sNuzleafAnims_2_4
+.4byte sNuzleafAnims_2_5
+.4byte sNuzleafAnims_2_6
+.4byte sNuzleafAnims_2_7
+.4byte sNuzleafAnims_2_8
+sNuzleafAnimTable3:
+.4byte sNuzleafAnims_3_1
+.4byte sNuzleafAnims_3_2
+.4byte sNuzleafAnims_3_3
+.4byte sNuzleafAnims_3_4
+.4byte sNuzleafAnims_3_5
+.4byte sNuzleafAnims_3_6
+.4byte sNuzleafAnims_3_7
+.4byte sNuzleafAnims_3_8
+sNuzleafAnimTable4:
+.4byte sNuzleafAnims_4_1
+.4byte sNuzleafAnims_4_2
+.4byte sNuzleafAnims_4_3
+.4byte sNuzleafAnims_4_4
+.4byte sNuzleafAnims_4_5
+.4byte sNuzleafAnims_4_6
+.4byte sNuzleafAnims_4_7
+.4byte sNuzleafAnims_4_8
+sNuzleafAnimTable5:
+.4byte sNuzleafAnims_5_1
+.4byte sNuzleafAnims_5_2
+.4byte sNuzleafAnims_5_3
+.4byte sNuzleafAnims_5_4
+.4byte sNuzleafAnims_5_5
+.4byte sNuzleafAnims_5_6
+.4byte sNuzleafAnims_5_7
+.4byte sNuzleafAnims_5_8
+sNuzleafAnimTable6:
+.4byte sNuzleafAnims_6_1
+.4byte sNuzleafAnims_6_1
+.4byte sNuzleafAnims_6_1
+.4byte sNuzleafAnims_6_1
+.4byte sNuzleafAnims_6_1
+.4byte sNuzleafAnims_6_1
+.4byte sNuzleafAnims_6_1
+.4byte sNuzleafAnims_6_1
+sNuzleafAnimTable7:
+.4byte sNuzleafAnims_7_1
+.4byte sNuzleafAnims_7_2
+.4byte sNuzleafAnims_7_3
+.4byte sNuzleafAnims_7_4
+.4byte sNuzleafAnims_7_5
+.4byte sNuzleafAnims_7_6
+.4byte sNuzleafAnims_7_7
+.4byte sNuzleafAnims_7_8
+sNuzleafAnimTable8:
+.4byte sNuzleafAnims_8_1
+.4byte sNuzleafAnims_8_2
+.4byte sNuzleafAnims_8_3
+.4byte sNuzleafAnims_8_4
+.4byte sNuzleafAnims_8_5
+.4byte sNuzleafAnims_8_6
+.4byte sNuzleafAnims_8_7
+.4byte sNuzleafAnims_8_8
+sNuzleafAnimTable9:
+.4byte sNuzleafAnims_9_1
+.4byte sNuzleafAnims_9_2
+.4byte sNuzleafAnims_9_3
+.4byte sNuzleafAnims_9_4
+.4byte sNuzleafAnims_9_5
+.4byte sNuzleafAnims_9_6
+.4byte sNuzleafAnims_9_7
+.4byte sNuzleafAnims_9_8
+sNuzleafAnimTable10:
+.4byte sNuzleafAnims_10_1
+.4byte sNuzleafAnims_10_2
+.4byte sNuzleafAnims_10_3
+.4byte sNuzleafAnims_10_4
+.4byte sNuzleafAnims_10_5
+.4byte sNuzleafAnims_10_6
+.4byte sNuzleafAnims_10_7
+.4byte sNuzleafAnims_10_8
+sNuzleafAnimTable11:
+.4byte sNuzleafAnims_11_1
+.4byte sNuzleafAnims_11_2
+.4byte sNuzleafAnims_11_3
+.4byte sNuzleafAnims_11_4
+.4byte sNuzleafAnims_11_5
+.4byte sNuzleafAnims_11_6
+.4byte sNuzleafAnims_11_7
+.4byte sNuzleafAnims_11_8
+sNuzleafAnimTable12:
+.4byte sNuzleafAnims_12_1
+.4byte sNuzleafAnims_12_2
+.4byte sNuzleafAnims_12_3
+.4byte sNuzleafAnims_12_4
+.4byte sNuzleafAnims_12_5
+.4byte sNuzleafAnims_12_6
+.4byte sNuzleafAnims_12_7
+.4byte sNuzleafAnims_12_8
+sNuzleafAnimTable13:
+.4byte sNuzleafAnims_13_1
+.4byte sNuzleafAnims_13_2
+.4byte sNuzleafAnims_13_3
+.4byte sNuzleafAnims_13_4
+.4byte sNuzleafAnims_13_5
+.4byte sNuzleafAnims_13_6
+.4byte sNuzleafAnims_13_7
+.4byte sNuzleafAnims_13_8
+sAxAnimationsNuzleaf:
+.4byte sNuzleafAnimTable1
+.4byte sNuzleafAnimTable2
+.4byte sNuzleafAnimTable3
+.4byte sNuzleafAnimTable4
+.4byte sNuzleafAnimTable5
+.4byte sNuzleafAnimTable6
+.4byte sNuzleafAnimTable7
+.4byte sNuzleafAnimTable8
+.4byte sNuzleafAnimTable9
+.4byte sNuzleafAnimTable10
+.4byte sNuzleafAnimTable11
+.4byte sNuzleafAnimTable12
+.4byte sNuzleafAnimTable13
+sAxSpritesNuzleaf:
+.4byte sNuzleafSprites1
+.4byte sNuzleafSprites2
+.4byte sNuzleafSprites3
+.4byte sNuzleafSprites4
+.4byte sNuzleafSprites5
+.4byte sNuzleafSprites6
+.4byte sNuzleafSprites7
+.4byte sNuzleafSprites8
+.4byte sNuzleafSprites9
+.4byte sNuzleafSprites10
+.4byte sNuzleafSprites11
+.4byte sNuzleafSprites12
+.4byte sNuzleafSprites13
+.4byte sNuzleafSprites14
+.4byte sNuzleafSprites15
+.4byte sNuzleafSprites16
+.4byte sNuzleafSprites17
+.4byte sNuzleafSprites18
+.4byte sNuzleafSprites19
+.4byte sNuzleafSprites20
+.4byte sNuzleafSprites21
+.4byte sNuzleafSprites22
+.4byte sNuzleafSprites23
+.4byte sNuzleafSprites24
+.4byte sNuzleafSprites25
+.4byte sNuzleafSprites26
+.4byte sNuzleafSprites27
+.4byte sNuzleafSprites28
+.4byte sNuzleafSprites29
+.4byte sNuzleafSprites30
+.4byte sNuzleafSprites31
+.4byte sNuzleafSprites32
+.4byte sNuzleafSprites33
+.4byte sNuzleafSprites34
+.4byte sNuzleafSprites35
+.4byte sNuzleafSprites36
+.4byte sNuzleafSprites37
+.4byte sNuzleafSprites38
+.4byte sNuzleafSprites39
+.4byte sNuzleafSprites40
+.4byte sNuzleafSprites41
+.4byte sNuzleafSprites42
+sAxMainNuzleaf:
+ax_main sAxPosesNuzleaf, sAxAnimationsNuzleaf, 13, sAxSpritesNuzleaf, sAxPositionsNuzleaf

--- a/data/ax/octillery.inc
+++ b/data/ax/octillery.inc
@@ -1,0 +1,2754 @@
+.global gAxOctillery
+gAxOctillery:
+ax_siro sAxMainOctillery
+sOctilleryPose1:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose3:
+ax_pose 2, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sOctilleryPose4:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose5:
+ax_pose 4, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose6:
+ax_pose 5, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose7:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose8:
+ax_pose 7, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose9:
+ax_pose 8, 0x01ef, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose10:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose11:
+ax_pose 10, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose12:
+ax_pose 11, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose16:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose17:
+ax_pose 10, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose18:
+ax_pose 11, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose21:
+ax_pose 8, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose22:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose23:
+ax_pose 4, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose24:
+ax_pose 5, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose25:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose26:
+ax_pose 1, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose27:
+ax_pose 2, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sOctilleryPose28:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose29:
+ax_pose 4, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose30:
+ax_pose 5, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose31:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose32:
+ax_pose 7, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose33:
+ax_pose 8, 0x01ef, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose34:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose35:
+ax_pose 10, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose36:
+ax_pose 11, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose40:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose41:
+ax_pose 10, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose42:
+ax_pose 11, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose43:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose44:
+ax_pose 7, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose45:
+ax_pose 8, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose46:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose47:
+ax_pose 4, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose48:
+ax_pose 5, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose49:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose50:
+ax_pose 1, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose51:
+ax_pose 2, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sOctilleryPose52:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose53:
+ax_pose 4, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose54:
+ax_pose 5, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose55:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose56:
+ax_pose 7, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose57:
+ax_pose 8, 0x01ef, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose58:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose59:
+ax_pose 10, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose60:
+ax_pose 11, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose61:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose62:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose63:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose64:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose65:
+ax_pose 10, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose66:
+ax_pose 11, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose67:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose68:
+ax_pose 7, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose69:
+ax_pose 8, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose70:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose71:
+ax_pose 4, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose72:
+ax_pose 5, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose73:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose74:
+ax_pose 15, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose75:
+ax_pose 16, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose76:
+ax_pose 17, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose77:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose78:
+ax_pose 18, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose79:
+ax_pose 19, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose80:
+ax_pose 20, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose81:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose82:
+ax_pose 21, 0x01ec, 0x5100, 0x2c00
+ax_pose 22, 0x81ec, 0x10f8, 0x2c04
+ax_pose 23, 0x01f7, 0x1110, 0x2c06
+ax_pose 24, 0x41fc, 0x90f0, 0x2c07
+ax_pose 25, 0x01f4, 0x10f0, 0x2c0f
+ax_pose_terminator
+sOctilleryPose83:
+ax_pose 26, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose84:
+ax_pose 27, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose85:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose86:
+ax_pose 28, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose87:
+ax_pose 29, 0x01ed, 0x90ee, 0x2c00
+ax_pose_terminator
+sOctilleryPose88:
+ax_pose 30, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose89:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose90:
+ax_pose 31, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose91:
+ax_pose 32, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose92:
+ax_pose 33, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose93:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose94:
+ax_pose 28, 0x01ec, 0x80ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose95:
+ax_pose 29, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose96:
+ax_pose 30, 0x01ec, 0x80ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose97:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose98:
+ax_pose 21, 0x01ec, 0x40f0, 0x2c00
+ax_pose 22, 0x81ec, 0x0100, 0x2c04
+ax_pose 23, 0x01f7, 0x00e8, 0x2c06
+ax_pose 24, 0x41fc, 0x80f0, 0x2c07
+ax_pose 25, 0x01f4, 0x0108, 0x2c0f
+ax_pose_terminator
+sOctilleryPose99:
+ax_pose 26, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose100:
+ax_pose 27, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose101:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose102:
+ax_pose 18, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose103:
+ax_pose 19, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose104:
+ax_pose 20, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose105:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose106:
+ax_pose 17, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose107:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose108:
+ax_pose 20, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose109:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose110:
+ax_pose 27, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose111:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose112:
+ax_pose 30, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose113:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose114:
+ax_pose 33, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose115:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose116:
+ax_pose 30, 0x01ec, 0x80ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose117:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose118:
+ax_pose 27, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose119:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose120:
+ax_pose 20, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose121:
+ax_pose 34, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose122:
+ax_pose 35, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose123:
+ax_pose 36, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sOctilleryPose124:
+ax_pose 37, 0x01e1, 0x90ee, 0x2c00
+ax_pose_terminator
+sOctilleryPose125:
+ax_pose 38, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sOctilleryPose126:
+ax_pose 39, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sOctilleryPose127:
+ax_pose 40, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose128:
+ax_pose 39, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sOctilleryPose129:
+ax_pose 38, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose130:
+ax_pose 37, 0x01e1, 0x80f2, 0x2c00
+ax_pose_terminator
+sOctilleryPose131:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose132:
+ax_pose 1, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose133:
+ax_pose 2, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sOctilleryPose134:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose135:
+ax_pose 4, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose136:
+ax_pose 5, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose137:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose138:
+ax_pose 7, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose139:
+ax_pose 8, 0x01ef, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose140:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose141:
+ax_pose 10, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose142:
+ax_pose 11, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose143:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose144:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose145:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose146:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose147:
+ax_pose 10, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose148:
+ax_pose 11, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose149:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose150:
+ax_pose 7, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose151:
+ax_pose 8, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose152:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose153:
+ax_pose 4, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose154:
+ax_pose 5, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose155:
+ax_pose 15, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose156:
+ax_pose 18, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sOctilleryPose157:
+ax_pose 21, 0x01ec, 0x40f0, 0x2c00
+ax_pose 22, 0x81ec, 0x0100, 0x2c04
+ax_pose 23, 0x01f7, 0x00e8, 0x2c06
+ax_pose 24, 0x41fc, 0x80f0, 0x2c07
+ax_pose 25, 0x01f4, 0x0108, 0x2c0f
+ax_pose_terminator
+sOctilleryPose158:
+ax_pose 28, 0x01ec, 0x80f1, 0x2c00
+ax_pose_terminator
+sOctilleryPose159:
+ax_pose 31, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose160:
+ax_pose 28, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose161:
+ax_pose 21, 0x01ec, 0x5100, 0x2c00
+ax_pose 22, 0x81ec, 0x10f8, 0x2c04
+ax_pose 23, 0x01f7, 0x1110, 0x2c06
+ax_pose 24, 0x41fc, 0x90f0, 0x2c07
+ax_pose 25, 0x01f4, 0x10f0, 0x2c0f
+ax_pose_terminator
+sOctilleryPose162:
+ax_pose 18, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose163:
+ax_pose 17, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose164:
+ax_pose 20, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose165:
+ax_pose 27, 0x01eb, 0x90f2, 0x2c00
+ax_pose_terminator
+sOctilleryPose166:
+ax_pose 30, 0x01ea, 0x90f1, 0x2c00
+ax_pose_terminator
+sOctilleryPose167:
+ax_pose 33, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose168:
+ax_pose 30, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose169:
+ax_pose 27, 0x01eb, 0x80ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose170:
+ax_pose 20, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose171:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose172:
+ax_pose 15, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose173:
+ax_pose 17, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose174:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose175:
+ax_pose 18, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose176:
+ax_pose 20, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose177:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose178:
+ax_pose 21, 0x01ec, 0x5100, 0x2c00
+ax_pose 22, 0x81ec, 0x10f8, 0x2c04
+ax_pose 23, 0x01f7, 0x1110, 0x2c06
+ax_pose 24, 0x41fc, 0x90f0, 0x2c07
+ax_pose 25, 0x01f4, 0x10f0, 0x2c0f
+ax_pose_terminator
+sOctilleryPose179:
+ax_pose 27, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose180:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose181:
+ax_pose 28, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose182:
+ax_pose 30, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose183:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose184:
+ax_pose 31, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose185:
+ax_pose 33, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose186:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose187:
+ax_pose 28, 0x01ec, 0x80ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose188:
+ax_pose 30, 0x01ec, 0x80ef, 0x2c00
+ax_pose_terminator
+sOctilleryPose189:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose190:
+ax_pose 21, 0x01ec, 0x40f0, 0x2c00
+ax_pose 22, 0x81ec, 0x0100, 0x2c04
+ax_pose 23, 0x01f7, 0x00e8, 0x2c06
+ax_pose 24, 0x41fc, 0x80f0, 0x2c07
+ax_pose 25, 0x01f4, 0x0108, 0x2c0f
+ax_pose_terminator
+sOctilleryPose191:
+ax_pose 27, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose192:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose193:
+ax_pose 18, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose194:
+ax_pose 20, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose195:
+ax_pose 16, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose196:
+ax_pose 19, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose197:
+ax_pose 26, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose198:
+ax_pose 29, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sOctilleryPose199:
+ax_pose 32, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose200:
+ax_pose 29, 0x01ec, 0x90ee, 0x2c00
+ax_pose_terminator
+sOctilleryPose201:
+ax_pose 26, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose202:
+ax_pose 19, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose203:
+ax_pose 0, 0x01ef, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose204:
+ax_pose 3, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose205:
+ax_pose 6, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose206:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose207:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sOctilleryPose208:
+ax_pose 9, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose209:
+ax_pose 6, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose210:
+ax_pose 3, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose211:
+ax_pose 41, 0x01ec, 0x80ec, 0x2c00
+ax_pose_terminator
+sOctilleryPose212:
+ax_pose 41, 0x01ec, 0x80ec, 0x2c00
+ax_pose_terminator
+sOctilleryPose213:
+ax_pose 42, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sOctilleryPose214:
+ax_pose 43, 0x01ec, 0x80ee, 0x2c00
+ax_pose_terminator
+sOctilleryPose215:
+ax_pose 44, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sOctilleryPose216:
+ax_pose 9, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+.align 2
+sOctilleryAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 2, 0, 2,
+ax_anim 8, 0, 2, 0, 4, 0, 4,
+ax_anim 16, 0, 2, 0, 5, 0, 5,
+ax_anim 8, 0, 0, 0, 3, 0, 3,
+ax_anim_terminator
+sOctilleryAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 5, 4, 4, 4, 4,
+ax_anim 16, 0, 5, 5, 5, 5, 5,
+ax_anim 8, 0, 3, 2, 2, 2, 2,
+ax_anim_terminator
+sOctilleryAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 8, 5, 0, 5, 0,
+ax_anim 16, 0, 8, 6, 0, 6, 0,
+ax_anim 8, 0, 6, 2, 0, 2, 0,
+ax_anim_terminator
+sOctilleryAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 11, 4, -4, 4, -4,
+ax_anim 16, 0, 11, 5, -5, 5, -5,
+ax_anim 8, 0, 9, 2, -2, 2, -2,
+ax_anim_terminator
+sOctilleryAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, -1, 0, -1,
+ax_anim 8, 0, 14, 0, -3, 0, -3,
+ax_anim 16, 0, 14, 0, -4, 0, -4,
+ax_anim 8, 0, 12, 0, -1, 0, -1,
+ax_anim_terminator
+sOctilleryAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 17, -4, -4, -4, -4,
+ax_anim 16, 0, 17, -5, -5, -5, -5,
+ax_anim 8, 0, 15, -2, -2, -2, -2,
+ax_anim_terminator
+sOctilleryAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, -1, 0, -1, 0,
+ax_anim 8, 0, 20, -5, 0, -5, 0,
+ax_anim 16, 0, 20, -6, 0, -6, 0,
+ax_anim 8, 0, 18, -2, 0, -2, 0,
+ax_anim_terminator
+sOctilleryAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 23, -4, 4, -4, 4,
+ax_anim 16, 0, 23, -5, 5, -5, 5,
+ax_anim 8, 0, 21, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sOctilleryAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sOctilleryAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sOctilleryAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sOctilleryAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 1, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 0, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sOctilleryAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sOctilleryAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sOctilleryAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 1, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sOctilleryAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sOctilleryAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sOctilleryAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 1, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 0, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sOctilleryAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -24, 0, -24,
+ax_anim 2, 1, 61, 1, -24, 1, -24,
+ax_anim 2, 0, 61, 0, -24, 0, -24,
+ax_anim 2, 0, 61, 1, -24, 1, -24,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sOctilleryAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 1, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 0, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sOctilleryAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sOctilleryAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -18, 18, -18, 18,
+ax_anim 2, 1, 70, -19, 17, -19, 17,
+ax_anim 2, 0, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -19, 17, -19, 17,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_4_1:
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 3, 0, 73, 0, 4, 0, 4,
+ax_anim 8, 2, 73, 0, 5, 0, 5,
+ax_anim 1, 1, 74, 0, -5, 0, -5,
+ax_anim 1, 0, 74, 0, -7, 0, -7,
+ax_anim 1, 0, 75, 0, -9, 0, -9,
+ax_anim 8, 0, 75, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sOctilleryAnims_4_2:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 3, 0, 77, 4, 4, 4, 4,
+ax_anim 8, 2, 77, 5, 5, 5, 5,
+ax_anim 1, 1, 78, -5, -5, -5, -5,
+ax_anim 1, 0, 78, -7, -7, -7, -7,
+ax_anim 1, 0, 79, -9, -9, -9, -9,
+ax_anim 8, 0, 79, -10, -10, -10, -10,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim_terminator
+sOctilleryAnims_4_3:
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 3, 0, 81, 4, 0, 4, 0,
+ax_anim 8, 2, 81, 5, 0, 5, 0,
+ax_anim 1, 1, 82, -5, 0, -5, 0,
+ax_anim 1, 0, 82, -7, 0, -7, 0,
+ax_anim 1, 0, 83, -9, 0, -9, 0,
+ax_anim 8, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sOctilleryAnims_4_4:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 3, 0, 85, 4, -4, 4, -4,
+ax_anim 8, 2, 85, 5, -5, 5, -5,
+ax_anim 1, 1, 86, -5, 5, -5, 5,
+ax_anim 1, 0, 86, -7, 7, -7, 7,
+ax_anim 1, 0, 87, -9, 9, -9, 9,
+ax_anim 8, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+sOctilleryAnims_4_5:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 3, 0, 89, 0, -4, 0, -4,
+ax_anim 8, 2, 89, 0, -5, 0, -5,
+ax_anim 1, 1, 90, 0, 5, 0, 5,
+ax_anim 1, 0, 90, 0, 7, 0, 7,
+ax_anim 1, 0, 91, 0, 9, 0, 9,
+ax_anim 8, 0, 91, 0, 10, 0, 10,
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim_terminator
+sOctilleryAnims_4_6:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 3, 0, 93, -4, -4, -4, -4,
+ax_anim 8, 2, 93, -5, -5, -5, -5,
+ax_anim 1, 1, 94, 5, 5, 5, 5,
+ax_anim 1, 0, 94, 7, 7, 7, 7,
+ax_anim 1, 0, 95, 9, 9, 9, 9,
+ax_anim 8, 0, 95, 10, 10, 10, 10,
+ax_anim 2, 0, 92, 4, 4, 4, 4,
+ax_anim_terminator
+sOctilleryAnims_4_7:
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim 3, 0, 97, -4, 0, -4, 0,
+ax_anim 8, 2, 97, -5, 0, -5, 0,
+ax_anim 1, 1, 98, 5, 0, 5, 0,
+ax_anim 1, 0, 98, 7, 0, 7, 0,
+ax_anim 1, 0, 99, 9, 0, 9, 0,
+ax_anim 8, 0, 99, 10, 0, 10, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim_terminator
+sOctilleryAnims_4_8:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 3, 0, 101, -4, 4, -4, 4,
+ax_anim 8, 2, 101, -5, 5, -5, 5,
+ax_anim 1, 1, 102, 5, -5, 5, -5,
+ax_anim 1, 0, 102, 7, -7, 7, -7,
+ax_anim 1, 0, 103, 9, -9, 9, -9,
+ax_anim 8, 0, 103, 10, -10, 10, -10,
+ax_anim 2, 0, 100, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_5_1:
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 1, 0, 1, 0,
+ax_anim_terminator
+sOctilleryAnims_5_2:
+ax_anim 8, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, -1, 1, -1,
+ax_anim_terminator
+sOctilleryAnims_5_3:
+ax_anim 8, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sOctilleryAnims_5_4:
+ax_anim 8, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -1, -1, -1, -1,
+ax_anim_terminator
+sOctilleryAnims_5_5:
+ax_anim 8, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim_terminator
+sOctilleryAnims_5_6:
+ax_anim 8, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim_terminator
+sOctilleryAnims_5_7:
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sOctilleryAnims_5_8:
+ax_anim 8, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sOctilleryAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sOctilleryAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sOctilleryAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sOctilleryAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sOctilleryAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sOctilleryAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sOctilleryAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_8_1:
+ax_anim 24, 0, 130, 0, 0, 0, 0,
+ax_anim 20, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_8_2:
+ax_anim 24, 0, 133, 0, 0, 0, 0,
+ax_anim 20, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_8_3:
+ax_anim 24, 0, 136, 0, 0, 0, 0,
+ax_anim 20, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_8_4:
+ax_anim 24, 0, 139, 0, 0, 0, 0,
+ax_anim 20, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_8_5:
+ax_anim 24, 0, 142, 0, 0, 0, 0,
+ax_anim 20, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_8_6:
+ax_anim 24, 0, 145, 0, 0, 0, 0,
+ax_anim 20, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_8_7:
+ax_anim 24, 0, 148, 0, 0, 0, 0,
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_8_8:
+ax_anim 24, 0, 151, 0, 0, 0, 0,
+ax_anim 20, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 10, 9, 10, 9,
+ax_anim 2, 0, 157, 7, 13, 7, 13,
+ax_anim 3, 0, 158, 0, 15, 0, 15,
+ax_anim 2, 3, 159, -7, 13, -7, 13,
+ax_anim 2, 0, 160, -10, 9, -10, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 15, 4, 15, 4,
+ax_anim 2, 0, 156, 21, 10, 21, 10,
+ax_anim 3, 0, 157, 19, 16, 19, 16,
+ax_anim 2, 3, 158, 11, 17, 11, 17,
+ax_anim 2, 0, 159, 1, 15, 1, 15,
+ax_anim 1, 0, 160, -3, 7, -3, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -8, 11, -8,
+ax_anim 2, 0, 155, 16, -5, 16, -5,
+ax_anim 3, 0, 156, 18, -2, 18, -2,
+ax_anim 2, 3, 157, 16, 4, 16, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -23, 12, -23,
+ax_anim 3, 0, 155, 18, -24, 18, -24,
+ax_anim 2, 3, 156, 23, -14, 23, -14,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -11, -12, -11, -12,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -24, 0, -24,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 11, -12, 11, -12,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -23, -12, -23,
+ax_anim 3, 0, 161, -18, -24, -18, -24,
+ax_anim 2, 3, 160, -23, -14, -23, -14,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -8, -11, -8,
+ax_anim 2, 0, 161, -16, -5, -16, -5,
+ax_anim 3, 0, 160, -18, -2, -18, -2,
+ax_anim 2, 3, 159, -16, 4, -16, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -15, 4, -15, 4,
+ax_anim 2, 0, 160, -21, 10, -21, 10,
+ax_anim 3, 0, 159, -19, 16, -19, 16,
+ax_anim 2, 3, 158, -11, 17, -11, 17,
+ax_anim 2, 0, 157, -1, 15, -1, 15,
+ax_anim 1, 0, 156, 3, 7, 3, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -17, 0, 0,
+ax_anim 1, 0, 180, 0, -11, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -17, 0, 0,
+ax_anim 1, 0, 186, 0, -11, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_14_1:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_14_2:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_14_3:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_14_4:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_14_5:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_14_6:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_14_7:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_14_8:
+ax_anim 4, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOctilleryAnims_15_1:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_15_2:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_15_3:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_15_4:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_15_5:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_15_6:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_15_7:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryAnims_15_8:
+ax_anim 10, 0, 211, 0, 0, 0, 0,
+ax_anim 8, 0, 212, 0, 0, 0, 0,
+ax_anim 20, 0, 213, 0, 0, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOctilleryGfx1:
+.incbin "baserom.gba", 0xF11E58, 0x200
+sOctillerySprites1:
+ax_sprite sOctilleryGfx1, 0x200
+ax_sprite_terminator
+sOctilleryGfx2:
+.incbin "baserom.gba", 0xF12068, 0x200
+sOctillerySprites2:
+ax_sprite sOctilleryGfx2, 0x200
+ax_sprite_terminator
+sOctilleryGfx3:
+.incbin "baserom.gba", 0xF12278, 0x200
+sOctillerySprites3:
+ax_sprite sOctilleryGfx3, 0x200
+ax_sprite_terminator
+sOctilleryGfx4:
+.incbin "baserom.gba", 0xF12488, 0x200
+sOctillerySprites4:
+ax_sprite sOctilleryGfx4, 0x200
+ax_sprite_terminator
+sOctilleryGfx5:
+.incbin "baserom.gba", 0xF12698, 0x200
+sOctillerySprites5:
+ax_sprite sOctilleryGfx5, 0x200
+ax_sprite_terminator
+sOctilleryGfx6:
+.incbin "baserom.gba", 0xF128A8, 0x200
+sOctillerySprites6:
+ax_sprite sOctilleryGfx6, 0x200
+ax_sprite_terminator
+sOctilleryGfx7:
+.incbin "baserom.gba", 0xF12AB8, 0x200
+sOctillerySprites7:
+ax_sprite sOctilleryGfx7, 0x200
+ax_sprite_terminator
+sOctilleryGfx8:
+.incbin "baserom.gba", 0xF12CC8, 0x200
+sOctillerySprites8:
+ax_sprite sOctilleryGfx8, 0x200
+ax_sprite_terminator
+sOctilleryGfx9:
+.incbin "baserom.gba", 0xF12ED8, 0x200
+sOctillerySprites9:
+ax_sprite sOctilleryGfx9, 0x200
+ax_sprite_terminator
+sOctilleryGfx10:
+.incbin "baserom.gba", 0xF130E8, 0x200
+sOctillerySprites10:
+ax_sprite sOctilleryGfx10, 0x200
+ax_sprite_terminator
+sOctilleryGfx11:
+.incbin "baserom.gba", 0xF132F8, 0x200
+sOctillerySprites11:
+ax_sprite sOctilleryGfx11, 0x200
+ax_sprite_terminator
+sOctilleryGfx12:
+.incbin "baserom.gba", 0xF13508, 0x200
+sOctillerySprites12:
+ax_sprite sOctilleryGfx12, 0x200
+ax_sprite_terminator
+sOctilleryGfx13:
+.incbin "baserom.gba", 0xF13718, 0x200
+sOctillerySprites13:
+ax_sprite sOctilleryGfx13, 0x200
+ax_sprite_terminator
+sOctilleryGfx14:
+.incbin "baserom.gba", 0xF13928, 0x200
+sOctillerySprites14:
+ax_sprite sOctilleryGfx14, 0x200
+ax_sprite_terminator
+sOctilleryGfx15:
+.incbin "baserom.gba", 0xF13B38, 0x200
+sOctillerySprites15:
+ax_sprite sOctilleryGfx15, 0x200
+ax_sprite_terminator
+sOctilleryGfx16:
+.incbin "baserom.gba", 0xF13D48, 0x40
+sOctilleryGfx16_1:
+.incbin "baserom.gba", 0xF13D88, 0x180
+sOctillerySprites16:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx16_1, 0x180
+ax_sprite_terminator
+sOctilleryGfx17:
+.incbin "baserom.gba", 0xF13F30, 0x40
+sOctilleryGfx17_1:
+.incbin "baserom.gba", 0xF13F70, 0x180
+sOctillerySprites17:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx17_1, 0x180
+ax_sprite_terminator
+sOctilleryGfx18:
+.incbin "baserom.gba", 0xF14118, 0x40
+sOctilleryGfx18_1:
+.incbin "baserom.gba", 0xF14158, 0x100
+sOctilleryGfx18_2:
+.incbin "baserom.gba", 0xF14258, 0x40
+sOctillerySprites18:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx19:
+.incbin "baserom.gba", 0xF142D8, 0x40
+sOctilleryGfx19_1:
+.incbin "baserom.gba", 0xF14318, 0x160
+sOctillerySprites19:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx20:
+.incbin "baserom.gba", 0xF144A8, 0x40
+sOctilleryGfx20_1:
+.incbin "baserom.gba", 0xF144E8, 0x140
+sOctillerySprites20:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOctilleryGfx20_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx21:
+.incbin "baserom.gba", 0xF14658, 0x40
+sOctilleryGfx21_1:
+.incbin "baserom.gba", 0xF14698, 0x100
+sOctilleryGfx21_2:
+.incbin "baserom.gba", 0xF14798, 0x40
+sOctillerySprites21:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx22:
+.incbin "baserom.gba", 0xF14818, 0x80
+sOctillerySprites22:
+ax_sprite sOctilleryGfx22, 0x80
+ax_sprite_terminator
+sOctilleryGfx23:
+.incbin "baserom.gba", 0xF148A8, 0x40
+sOctillerySprites23:
+ax_sprite sOctilleryGfx23, 0x40
+ax_sprite_terminator
+sOctilleryGfx24:
+.incbin "baserom.gba", 0xF148F8, 0x20
+sOctillerySprites24:
+ax_sprite sOctilleryGfx24, 0x20
+ax_sprite_terminator
+sOctilleryGfx25:
+.incbin "baserom.gba", 0xF14928, 0x100
+sOctillerySprites25:
+ax_sprite sOctilleryGfx25, 0x100
+ax_sprite_terminator
+sOctilleryGfx26:
+.incbin "baserom.gba", 0xF14A38, 0x20
+sOctillerySprites26:
+ax_sprite sOctilleryGfx26, 0x20
+ax_sprite_terminator
+sOctilleryGfx27:
+.incbin "baserom.gba", 0xF14A68, 0x1A0
+sOctilleryGfx27_1:
+.incbin "baserom.gba", 0xF14C08, 0x20
+sOctillerySprites27:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx27, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx27_1, 0x20
+ax_sprite_terminator
+sOctilleryGfx28:
+.incbin "baserom.gba", 0xF14C50, 0x1A0
+sOctilleryGfx28_1:
+.incbin "baserom.gba", 0xF14DF0, 0x20
+sOctillerySprites28:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx28, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx28_1, 0x20
+ax_sprite_terminator
+sOctilleryGfx29:
+.incbin "baserom.gba", 0xF14E38, 0x60
+sOctilleryGfx29_1:
+.incbin "baserom.gba", 0xF14E98, 0x60
+sOctilleryGfx29_2:
+.incbin "baserom.gba", 0xF14EF8, 0x80
+sOctilleryGfx29_3:
+.incbin "baserom.gba", 0xF14F78, 0x60
+sOctillerySprites29:
+ax_sprite sOctilleryGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx29_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx29_3, 0x60
+ax_sprite_terminator
+sOctilleryGfx30:
+.incbin "baserom.gba", 0xF15018, 0x40
+sOctilleryGfx30_1:
+.incbin "baserom.gba", 0xF15058, 0x100
+sOctilleryGfx30_2:
+.incbin "baserom.gba", 0xF15158, 0x40
+sOctillerySprites30:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx31:
+.incbin "baserom.gba", 0xF151D8, 0x40
+sOctilleryGfx31_1:
+.incbin "baserom.gba", 0xF15218, 0x100
+sOctilleryGfx31_2:
+.incbin "baserom.gba", 0xF15318, 0x60
+sOctillerySprites31:
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx31_2, 0x60
+ax_sprite_terminator
+sOctilleryGfx32:
+.incbin "baserom.gba", 0xF153B0, 0x60
+sOctilleryGfx32_1:
+.incbin "baserom.gba", 0xF15410, 0x60
+sOctilleryGfx32_2:
+.incbin "baserom.gba", 0xF15470, 0x60
+sOctilleryGfx32_3:
+.incbin "baserom.gba", 0xF154D0, 0x60
+sOctillerySprites32:
+ax_sprite sOctilleryGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx33:
+.incbin "baserom.gba", 0xF15578, 0x60
+sOctilleryGfx33_1:
+.incbin "baserom.gba", 0xF155D8, 0x60
+sOctilleryGfx33_2:
+.incbin "baserom.gba", 0xF15638, 0x60
+sOctilleryGfx33_3:
+.incbin "baserom.gba", 0xF15698, 0x60
+sOctillerySprites33:
+ax_sprite sOctilleryGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx33_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx34:
+.incbin "baserom.gba", 0xF15740, 0x60
+sOctilleryGfx34_1:
+.incbin "baserom.gba", 0xF157A0, 0x60
+sOctilleryGfx34_2:
+.incbin "baserom.gba", 0xF15800, 0x60
+sOctilleryGfx34_3:
+.incbin "baserom.gba", 0xF15860, 0x60
+sOctillerySprites34:
+ax_sprite sOctilleryGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOctilleryGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOctilleryGfx35:
+.incbin "baserom.gba", 0xF15908, 0x200
+sOctillerySprites35:
+ax_sprite sOctilleryGfx35, 0x200
+ax_sprite_terminator
+sOctilleryGfx36:
+.incbin "baserom.gba", 0xF15B18, 0x200
+sOctillerySprites36:
+ax_sprite sOctilleryGfx36, 0x200
+ax_sprite_terminator
+sOctilleryGfx37:
+.incbin "baserom.gba", 0xF15D28, 0x200
+sOctillerySprites37:
+ax_sprite sOctilleryGfx37, 0x200
+ax_sprite_terminator
+sOctilleryGfx38:
+.incbin "baserom.gba", 0xF15F38, 0x200
+sOctillerySprites38:
+ax_sprite sOctilleryGfx38, 0x200
+ax_sprite_terminator
+sOctilleryGfx39:
+.incbin "baserom.gba", 0xF16148, 0x200
+sOctillerySprites39:
+ax_sprite sOctilleryGfx39, 0x200
+ax_sprite_terminator
+sOctilleryGfx40:
+.incbin "baserom.gba", 0xF16358, 0x200
+sOctillerySprites40:
+ax_sprite sOctilleryGfx40, 0x200
+ax_sprite_terminator
+sOctilleryGfx41:
+.incbin "baserom.gba", 0xF16568, 0x200
+sOctillerySprites41:
+ax_sprite sOctilleryGfx41, 0x200
+ax_sprite_terminator
+sOctilleryGfx42:
+.incbin "baserom.gba", 0xF16778, 0x200
+sOctillerySprites42:
+ax_sprite sOctilleryGfx42, 0x200
+ax_sprite_terminator
+sOctilleryGfx43:
+.incbin "baserom.gba", 0xF16988, 0x200
+sOctillerySprites43:
+ax_sprite sOctilleryGfx43, 0x200
+ax_sprite_terminator
+sOctilleryGfx44:
+.incbin "baserom.gba", 0xF16B98, 0x200
+sOctillerySprites44:
+ax_sprite sOctilleryGfx44, 0x200
+ax_sprite_terminator
+sOctilleryGfx45:
+.incbin "baserom.gba", 0xF16DA8, 0x200
+sOctillerySprites45:
+ax_sprite sOctilleryGfx45, 0x200
+ax_sprite_terminator
+sAxPosesOctillery:
+.4byte sOctilleryPose1
+.4byte sOctilleryPose2
+.4byte sOctilleryPose3
+.4byte sOctilleryPose4
+.4byte sOctilleryPose5
+.4byte sOctilleryPose6
+.4byte sOctilleryPose7
+.4byte sOctilleryPose8
+.4byte sOctilleryPose9
+.4byte sOctilleryPose10
+.4byte sOctilleryPose11
+.4byte sOctilleryPose12
+.4byte sOctilleryPose13
+.4byte sOctilleryPose14
+.4byte sOctilleryPose15
+.4byte sOctilleryPose16
+.4byte sOctilleryPose17
+.4byte sOctilleryPose18
+.4byte sOctilleryPose19
+.4byte sOctilleryPose20
+.4byte sOctilleryPose21
+.4byte sOctilleryPose22
+.4byte sOctilleryPose23
+.4byte sOctilleryPose24
+.4byte sOctilleryPose25
+.4byte sOctilleryPose26
+.4byte sOctilleryPose27
+.4byte sOctilleryPose28
+.4byte sOctilleryPose29
+.4byte sOctilleryPose30
+.4byte sOctilleryPose31
+.4byte sOctilleryPose32
+.4byte sOctilleryPose33
+.4byte sOctilleryPose34
+.4byte sOctilleryPose35
+.4byte sOctilleryPose36
+.4byte sOctilleryPose37
+.4byte sOctilleryPose38
+.4byte sOctilleryPose39
+.4byte sOctilleryPose40
+.4byte sOctilleryPose41
+.4byte sOctilleryPose42
+.4byte sOctilleryPose43
+.4byte sOctilleryPose44
+.4byte sOctilleryPose45
+.4byte sOctilleryPose46
+.4byte sOctilleryPose47
+.4byte sOctilleryPose48
+.4byte sOctilleryPose49
+.4byte sOctilleryPose50
+.4byte sOctilleryPose51
+.4byte sOctilleryPose52
+.4byte sOctilleryPose53
+.4byte sOctilleryPose54
+.4byte sOctilleryPose55
+.4byte sOctilleryPose56
+.4byte sOctilleryPose57
+.4byte sOctilleryPose58
+.4byte sOctilleryPose59
+.4byte sOctilleryPose60
+.4byte sOctilleryPose61
+.4byte sOctilleryPose62
+.4byte sOctilleryPose63
+.4byte sOctilleryPose64
+.4byte sOctilleryPose65
+.4byte sOctilleryPose66
+.4byte sOctilleryPose67
+.4byte sOctilleryPose68
+.4byte sOctilleryPose69
+.4byte sOctilleryPose70
+.4byte sOctilleryPose71
+.4byte sOctilleryPose72
+.4byte sOctilleryPose73
+.4byte sOctilleryPose74
+.4byte sOctilleryPose75
+.4byte sOctilleryPose76
+.4byte sOctilleryPose77
+.4byte sOctilleryPose78
+.4byte sOctilleryPose79
+.4byte sOctilleryPose80
+.4byte sOctilleryPose81
+.4byte sOctilleryPose82
+.4byte sOctilleryPose83
+.4byte sOctilleryPose84
+.4byte sOctilleryPose85
+.4byte sOctilleryPose86
+.4byte sOctilleryPose87
+.4byte sOctilleryPose88
+.4byte sOctilleryPose89
+.4byte sOctilleryPose90
+.4byte sOctilleryPose91
+.4byte sOctilleryPose92
+.4byte sOctilleryPose93
+.4byte sOctilleryPose94
+.4byte sOctilleryPose95
+.4byte sOctilleryPose96
+.4byte sOctilleryPose97
+.4byte sOctilleryPose98
+.4byte sOctilleryPose99
+.4byte sOctilleryPose100
+.4byte sOctilleryPose101
+.4byte sOctilleryPose102
+.4byte sOctilleryPose103
+.4byte sOctilleryPose104
+.4byte sOctilleryPose105
+.4byte sOctilleryPose106
+.4byte sOctilleryPose107
+.4byte sOctilleryPose108
+.4byte sOctilleryPose109
+.4byte sOctilleryPose110
+.4byte sOctilleryPose111
+.4byte sOctilleryPose112
+.4byte sOctilleryPose113
+.4byte sOctilleryPose114
+.4byte sOctilleryPose115
+.4byte sOctilleryPose116
+.4byte sOctilleryPose117
+.4byte sOctilleryPose118
+.4byte sOctilleryPose119
+.4byte sOctilleryPose120
+.4byte sOctilleryPose121
+.4byte sOctilleryPose122
+.4byte sOctilleryPose123
+.4byte sOctilleryPose124
+.4byte sOctilleryPose125
+.4byte sOctilleryPose126
+.4byte sOctilleryPose127
+.4byte sOctilleryPose128
+.4byte sOctilleryPose129
+.4byte sOctilleryPose130
+.4byte sOctilleryPose131
+.4byte sOctilleryPose132
+.4byte sOctilleryPose133
+.4byte sOctilleryPose134
+.4byte sOctilleryPose135
+.4byte sOctilleryPose136
+.4byte sOctilleryPose137
+.4byte sOctilleryPose138
+.4byte sOctilleryPose139
+.4byte sOctilleryPose140
+.4byte sOctilleryPose141
+.4byte sOctilleryPose142
+.4byte sOctilleryPose143
+.4byte sOctilleryPose144
+.4byte sOctilleryPose145
+.4byte sOctilleryPose146
+.4byte sOctilleryPose147
+.4byte sOctilleryPose148
+.4byte sOctilleryPose149
+.4byte sOctilleryPose150
+.4byte sOctilleryPose151
+.4byte sOctilleryPose152
+.4byte sOctilleryPose153
+.4byte sOctilleryPose154
+.4byte sOctilleryPose155
+.4byte sOctilleryPose156
+.4byte sOctilleryPose157
+.4byte sOctilleryPose158
+.4byte sOctilleryPose159
+.4byte sOctilleryPose160
+.4byte sOctilleryPose161
+.4byte sOctilleryPose162
+.4byte sOctilleryPose163
+.4byte sOctilleryPose164
+.4byte sOctilleryPose165
+.4byte sOctilleryPose166
+.4byte sOctilleryPose167
+.4byte sOctilleryPose168
+.4byte sOctilleryPose169
+.4byte sOctilleryPose170
+.4byte sOctilleryPose171
+.4byte sOctilleryPose172
+.4byte sOctilleryPose173
+.4byte sOctilleryPose174
+.4byte sOctilleryPose175
+.4byte sOctilleryPose176
+.4byte sOctilleryPose177
+.4byte sOctilleryPose178
+.4byte sOctilleryPose179
+.4byte sOctilleryPose180
+.4byte sOctilleryPose181
+.4byte sOctilleryPose182
+.4byte sOctilleryPose183
+.4byte sOctilleryPose184
+.4byte sOctilleryPose185
+.4byte sOctilleryPose186
+.4byte sOctilleryPose187
+.4byte sOctilleryPose188
+.4byte sOctilleryPose189
+.4byte sOctilleryPose190
+.4byte sOctilleryPose191
+.4byte sOctilleryPose192
+.4byte sOctilleryPose193
+.4byte sOctilleryPose194
+.4byte sOctilleryPose195
+.4byte sOctilleryPose196
+.4byte sOctilleryPose197
+.4byte sOctilleryPose198
+.4byte sOctilleryPose199
+.4byte sOctilleryPose200
+.4byte sOctilleryPose201
+.4byte sOctilleryPose202
+.4byte sOctilleryPose203
+.4byte sOctilleryPose204
+.4byte sOctilleryPose205
+.4byte sOctilleryPose206
+.4byte sOctilleryPose207
+.4byte sOctilleryPose208
+.4byte sOctilleryPose209
+.4byte sOctilleryPose210
+.4byte sOctilleryPose211
+.4byte sOctilleryPose212
+.4byte sOctilleryPose213
+.4byte sOctilleryPose214
+.4byte sOctilleryPose215
+.4byte sOctilleryPose216
+sAxPositionsOctillery:
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte    0,   -3, 	  -8,    7, 	   7,    7, 	   0,   -6
+.2byte    0,   -2, 	  -9,    4, 	   8,    4, 	   0,   -5
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte    4,   -5, 	  13,    2, 	   2,    8, 	  -1,   -3
+.2byte    4,   -3, 	  11,    1, 	  -1,    5, 	  -2,   -4
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte    8,   -9, 	  13,   -6, 	  11,    3, 	  -2,   -3
+.2byte    9,   -8, 	  10,   -5, 	   8,    4, 	  -2,   -3
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte    6,  -14, 	   1,   -8, 	  12,   -4, 	  -2,   -2
+.2byte    6,  -13, 	   0,   -5, 	  10,   -2, 	  -2,   -2
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte    0,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,   -1
+.2byte    0,   -9, 	   8,   -4, 	  -9,   -4, 	  -1,   -1
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte   -7,  -14, 	  -2,   -8, 	 -13,   -4, 	   1,   -2
+.2byte   -7,  -13, 	  -1,   -5, 	 -11,   -2, 	   1,   -2
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte   -9,   -9, 	 -14,   -6, 	 -12,    3, 	   1,   -3
+.2byte  -10,   -8, 	 -11,   -5, 	  -9,    4, 	   1,   -3
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte   -5,   -5, 	 -14,    2, 	  -3,    8, 	   0,   -3
+.2byte   -5,   -3, 	 -12,    1, 	   0,    5, 	   1,   -4
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte    0,   -3, 	  -8,    7, 	   7,    7, 	   0,   -6
+.2byte    0,   -2, 	  -9,    4, 	   8,    4, 	   0,   -5
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte    4,   -5, 	  13,    2, 	   2,    8, 	  -1,   -3
+.2byte    4,   -3, 	  11,    1, 	  -1,    5, 	  -2,   -4
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte    8,   -9, 	  13,   -6, 	  11,    3, 	  -2,   -3
+.2byte    9,   -8, 	  10,   -5, 	   8,    4, 	  -2,   -3
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte    6,  -14, 	   1,   -8, 	  12,   -4, 	  -2,   -2
+.2byte    6,  -13, 	   0,   -5, 	  10,   -2, 	  -2,   -2
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte    0,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,   -1
+.2byte    0,   -9, 	   8,   -4, 	  -9,   -4, 	  -1,   -1
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte   -7,  -14, 	  -2,   -8, 	 -13,   -4, 	   1,   -2
+.2byte   -7,  -13, 	  -1,   -5, 	 -11,   -2, 	   1,   -2
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte   -9,   -9, 	 -14,   -6, 	 -12,    3, 	   1,   -3
+.2byte  -10,   -8, 	 -11,   -5, 	  -9,    4, 	   1,   -3
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte   -5,   -5, 	 -14,    2, 	  -3,    8, 	   0,   -3
+.2byte   -5,   -3, 	 -12,    1, 	   0,    5, 	   1,   -4
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte    0,   -3, 	  -8,    7, 	   7,    7, 	   0,   -6
+.2byte    0,   -2, 	  -9,    4, 	   8,    4, 	   0,   -5
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte    4,   -5, 	  13,    2, 	   2,    8, 	  -1,   -3
+.2byte    4,   -3, 	  11,    1, 	  -1,    5, 	  -2,   -4
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte    8,   -9, 	  13,   -6, 	  11,    3, 	  -2,   -3
+.2byte    9,   -8, 	  10,   -5, 	   8,    4, 	  -2,   -3
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte    6,  -14, 	   1,   -8, 	  12,   -4, 	  -2,   -2
+.2byte    6,  -13, 	   0,   -5, 	  10,   -2, 	  -2,   -2
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte    0,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,   -1
+.2byte    0,   -9, 	   8,   -4, 	  -9,   -4, 	  -1,   -1
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte   -7,  -14, 	  -2,   -8, 	 -13,   -4, 	   1,   -2
+.2byte   -7,  -13, 	  -1,   -5, 	 -11,   -2, 	   1,   -2
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte   -9,   -9, 	 -14,   -6, 	 -12,    3, 	   1,   -3
+.2byte  -10,   -8, 	 -11,   -5, 	  -9,    4, 	   1,   -3
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte   -5,   -5, 	 -14,    2, 	  -3,    8, 	   0,   -3
+.2byte   -5,   -3, 	 -12,    1, 	   0,    5, 	   1,   -4
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte    0,    1, 	  -8,    7, 	   7,    7, 	   0,   -6
+.2byte   -1,   -4, 	  -8,    6, 	   7,    6, 	   0,   -2
+.2byte   -1,   -5, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte   10,   -2, 	  13,    2, 	   2,    8, 	  -1,   -4
+.2byte    4,   -7, 	  12,    2, 	   2,    7, 	  -1,   -4
+.2byte    4,   -7, 	   8,   -3, 	   0,    2, 	  -1,   -3
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte   15,   -8, 	  13,   -3, 	  10,    3, 	  -1,   -3
+.2byte    7,  -10, 	  12,   -3, 	   9,    3, 	  -3,   -3
+.2byte    6,  -11, 	   7,  -10, 	   6,   -2, 	  -3,   -2
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte   11,  -16, 	   2,   -8, 	  11,   -4, 	  -1,   -2
+.2byte    4,  -13, 	   0,   -7, 	  10,   -4, 	  -3,   -1
+.2byte    4,  -13, 	  -1,   -9, 	   5,   -6, 	  -3,   -2
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte    0,  -17, 	   8,   -8, 	  -9,   -8, 	  -1,   -3
+.2byte    0,  -12, 	   8,   -8, 	  -9,   -8, 	  -1,   -1
+.2byte   -1,   -9, 	   7,  -11, 	  -8,  -11, 	   0,   -1
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte  -14,  -16, 	  -5,   -8, 	 -14,   -4, 	  -2,   -2
+.2byte   -7,  -13, 	  -3,   -7, 	 -13,   -4, 	   0,   -1
+.2byte   -7,  -13, 	  -2,   -9, 	  -8,   -6, 	   0,   -2
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte  -16,   -8, 	 -14,   -3, 	 -11,    3, 	   0,   -3
+.2byte   -8,  -10, 	 -13,   -3, 	 -10,    3, 	   2,   -3
+.2byte   -7,  -11, 	  -8,  -10, 	  -7,   -2, 	   2,   -2
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte  -11,   -2, 	 -14,    2, 	  -3,    8, 	   0,   -4
+.2byte   -5,   -7, 	 -13,    2, 	  -3,    7, 	   0,   -4
+.2byte   -5,   -7, 	  -9,   -3, 	  -1,    2, 	   0,   -3
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte    4,   -7, 	   8,   -3, 	   0,    2, 	  -1,   -3
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte    6,  -11, 	   7,  -10, 	   6,   -2, 	  -3,   -2
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte    4,  -13, 	  -1,   -9, 	   5,   -6, 	  -3,   -2
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte   -1,   -9, 	   7,  -11, 	  -8,  -11, 	   0,   -1
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte   -7,  -13, 	  -2,   -9, 	  -8,   -6, 	   0,   -2
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte   -7,  -11, 	  -8,  -10, 	  -7,   -2, 	   2,   -2
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte   -5,   -7, 	  -9,   -3, 	  -1,    2, 	   0,   -3
+.2byte   -6,   -1, 	 -13,    1, 	  -2,    6, 	   1,   -2
+.2byte   -7,   -1, 	 -14,    2, 	  -3,    8, 	   1,   -3
+.2byte    1,  -12, 	  -8,  -15, 	   9,  -15, 	   1,  -10
+.2byte    5,  -14, 	   9,  -20, 	  -1,  -13, 	  -1,  -10
+.2byte    8,  -17, 	   7,  -20, 	   8,  -16, 	   1,  -10
+.2byte    4,  -18, 	   2,  -22, 	   8,  -17, 	  -1,   -9
+.2byte    0,  -19, 	   8,  -17, 	  -9,  -17, 	   0,   -7
+.2byte   -5,  -18, 	  -3,  -22, 	  -9,  -17, 	   0,   -9
+.2byte   -9,  -17, 	  -8,  -20, 	  -9,  -16, 	  -2,  -10
+.2byte   -6,  -14, 	 -10,  -20, 	   0,  -13, 	   0,  -10
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte    0,   -3, 	  -8,    7, 	   7,    7, 	   0,   -6
+.2byte    0,   -2, 	  -9,    4, 	   8,    4, 	   0,   -5
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte    4,   -5, 	  13,    2, 	   2,    8, 	  -1,   -3
+.2byte    4,   -3, 	  11,    1, 	  -1,    5, 	  -2,   -4
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte    8,   -9, 	  13,   -6, 	  11,    3, 	  -2,   -3
+.2byte    9,   -8, 	  10,   -5, 	   8,    4, 	  -2,   -3
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte    6,  -14, 	   1,   -8, 	  12,   -4, 	  -2,   -2
+.2byte    6,  -13, 	   0,   -5, 	  10,   -2, 	  -2,   -2
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte    0,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,   -1
+.2byte    0,   -9, 	   8,   -4, 	  -9,   -4, 	  -1,   -1
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte   -7,  -14, 	  -2,   -8, 	 -13,   -4, 	   1,   -2
+.2byte   -7,  -13, 	  -1,   -5, 	 -11,   -2, 	   1,   -2
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte   -9,   -9, 	 -14,   -6, 	 -12,    3, 	   1,   -3
+.2byte  -10,   -8, 	 -11,   -5, 	  -9,    4, 	   1,   -3
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte   -5,   -5, 	 -14,    2, 	  -3,    8, 	   0,   -3
+.2byte   -5,   -3, 	 -12,    1, 	   0,    5, 	   1,   -4
+.2byte    0,    2, 	  -8,    8, 	   7,    8, 	   0,   -5
+.2byte  -10,   -2, 	 -13,    2, 	  -2,    8, 	   1,   -4
+.2byte  -16,   -8, 	 -14,   -3, 	 -11,    3, 	   0,   -3
+.2byte  -12,  -16, 	  -3,   -8, 	 -12,   -4, 	   0,   -2
+.2byte    0,  -16, 	   8,   -7, 	  -9,   -7, 	  -1,   -2
+.2byte   11,  -16, 	   2,   -8, 	  11,   -4, 	  -1,   -2
+.2byte   15,   -8, 	  13,   -3, 	  10,    3, 	  -1,   -3
+.2byte    9,   -2, 	  12,    2, 	   1,    8, 	  -2,   -4
+.2byte   -1,   -5, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    4,   -8, 	   8,   -4, 	   0,    1, 	  -1,   -4
+.2byte    8,  -12, 	   9,  -11, 	   8,   -3, 	  -1,   -3
+.2byte    6,  -15, 	   1,  -11, 	   7,   -8, 	  -1,   -4
+.2byte   -1,  -11, 	   7,  -13, 	  -8,  -13, 	   0,   -3
+.2byte   -7,  -15, 	  -2,  -11, 	  -8,   -8, 	   0,   -4
+.2byte   -8,  -12, 	  -9,  -11, 	  -8,   -3, 	   1,   -3
+.2byte   -5,   -8, 	  -9,   -4, 	  -1,    1, 	   0,   -4
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte    0,    1, 	  -8,    7, 	   7,    7, 	   0,   -6
+.2byte   -1,   -5, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte   10,   -2, 	  13,    2, 	   2,    8, 	  -1,   -4
+.2byte    4,   -7, 	   8,   -3, 	   0,    2, 	  -1,   -3
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte   15,   -8, 	  13,   -3, 	  10,    3, 	  -1,   -3
+.2byte    6,  -11, 	   7,  -10, 	   6,   -2, 	  -3,   -2
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte   11,  -16, 	   2,   -8, 	  11,   -4, 	  -1,   -2
+.2byte    4,  -13, 	  -1,   -9, 	   5,   -6, 	  -3,   -2
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte    0,  -17, 	   8,   -8, 	  -9,   -8, 	  -1,   -3
+.2byte   -1,   -9, 	   7,  -11, 	  -8,  -11, 	   0,   -1
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte  -14,  -16, 	  -5,   -8, 	 -14,   -4, 	  -2,   -2
+.2byte   -7,  -13, 	  -2,   -9, 	  -8,   -6, 	   0,   -2
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte  -16,   -8, 	 -14,   -3, 	 -11,    3, 	   0,   -3
+.2byte   -7,  -11, 	  -8,  -10, 	  -7,   -2, 	   2,   -2
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte  -11,   -2, 	 -14,    2, 	  -3,    8, 	   0,   -4
+.2byte   -5,   -7, 	  -9,   -3, 	  -1,    2, 	   0,   -3
+.2byte   -1,   -4, 	  -8,    6, 	   7,    6, 	   0,   -2
+.2byte   -5,   -7, 	 -13,    2, 	  -3,    7, 	   0,   -4
+.2byte   -8,  -10, 	 -13,   -3, 	 -10,    3, 	   2,   -3
+.2byte   -5,  -14, 	  -1,   -8, 	 -11,   -5, 	   2,   -2
+.2byte    0,  -12, 	   8,   -8, 	  -9,   -8, 	  -1,   -1
+.2byte    4,  -14, 	   0,   -8, 	  10,   -5, 	  -3,   -2
+.2byte    7,  -10, 	  12,   -3, 	   9,    3, 	  -3,   -3
+.2byte    4,   -7, 	  12,    2, 	   2,    7, 	  -1,   -4
+.2byte   -1,   -1, 	  -8,   -1, 	   7,   -1, 	  -1,   -4
+.2byte   -6,   -3, 	 -11,   -5, 	   0,    2, 	   1,   -3
+.2byte  -11,   -8, 	  -9,  -11, 	  -8,   -1, 	   1,   -3
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+.2byte   -1,   -8, 	   9,  -10, 	 -10,  -10, 	   0,   -2
+.2byte    8,  -13, 	   2,   -9, 	  10,   -6, 	  -1,   -3
+.2byte   10,   -8, 	   8,  -11, 	   7,   -1, 	  -2,   -3
+.2byte    5,   -3, 	  10,   -5, 	  -1,    2, 	  -2,   -3
+.2byte  -10,   -5, 	  -7,   -7, 	 -18,   -3, 	  -3,   -4
+.2byte  -10,   -5, 	  -7,   -7, 	 -18,   -3, 	  -3,   -4
+.2byte  -10,   -4, 	  -5,   -7, 	 -17,   -3, 	  -2,   -3
+.2byte  -10,   -5, 	  -5,   -6, 	 -16,   -3, 	  -1,   -3
+.2byte  -10,  -10, 	  -3,   -8, 	 -14,   -5, 	   0,   -4
+.2byte   -9,  -13, 	  -3,   -9, 	 -11,   -6, 	   0,   -3
+sOctilleryAnimTable1:
+.4byte sOctilleryAnims_1_1
+.4byte sOctilleryAnims_1_2
+.4byte sOctilleryAnims_1_3
+.4byte sOctilleryAnims_1_4
+.4byte sOctilleryAnims_1_5
+.4byte sOctilleryAnims_1_6
+.4byte sOctilleryAnims_1_7
+.4byte sOctilleryAnims_1_8
+sOctilleryAnimTable2:
+.4byte sOctilleryAnims_2_1
+.4byte sOctilleryAnims_2_2
+.4byte sOctilleryAnims_2_3
+.4byte sOctilleryAnims_2_4
+.4byte sOctilleryAnims_2_5
+.4byte sOctilleryAnims_2_6
+.4byte sOctilleryAnims_2_7
+.4byte sOctilleryAnims_2_8
+sOctilleryAnimTable3:
+.4byte sOctilleryAnims_3_1
+.4byte sOctilleryAnims_3_2
+.4byte sOctilleryAnims_3_3
+.4byte sOctilleryAnims_3_4
+.4byte sOctilleryAnims_3_5
+.4byte sOctilleryAnims_3_6
+.4byte sOctilleryAnims_3_7
+.4byte sOctilleryAnims_3_8
+sOctilleryAnimTable4:
+.4byte sOctilleryAnims_4_1
+.4byte sOctilleryAnims_4_2
+.4byte sOctilleryAnims_4_3
+.4byte sOctilleryAnims_4_4
+.4byte sOctilleryAnims_4_5
+.4byte sOctilleryAnims_4_6
+.4byte sOctilleryAnims_4_7
+.4byte sOctilleryAnims_4_8
+sOctilleryAnimTable5:
+.4byte sOctilleryAnims_5_1
+.4byte sOctilleryAnims_5_2
+.4byte sOctilleryAnims_5_3
+.4byte sOctilleryAnims_5_4
+.4byte sOctilleryAnims_5_5
+.4byte sOctilleryAnims_5_6
+.4byte sOctilleryAnims_5_7
+.4byte sOctilleryAnims_5_8
+sOctilleryAnimTable6:
+.4byte sOctilleryAnims_6_1
+.4byte sOctilleryAnims_6_1
+.4byte sOctilleryAnims_6_1
+.4byte sOctilleryAnims_6_1
+.4byte sOctilleryAnims_6_1
+.4byte sOctilleryAnims_6_1
+.4byte sOctilleryAnims_6_1
+.4byte sOctilleryAnims_6_1
+sOctilleryAnimTable7:
+.4byte sOctilleryAnims_7_1
+.4byte sOctilleryAnims_7_2
+.4byte sOctilleryAnims_7_3
+.4byte sOctilleryAnims_7_4
+.4byte sOctilleryAnims_7_5
+.4byte sOctilleryAnims_7_6
+.4byte sOctilleryAnims_7_7
+.4byte sOctilleryAnims_7_8
+sOctilleryAnimTable8:
+.4byte sOctilleryAnims_8_1
+.4byte sOctilleryAnims_8_2
+.4byte sOctilleryAnims_8_3
+.4byte sOctilleryAnims_8_4
+.4byte sOctilleryAnims_8_5
+.4byte sOctilleryAnims_8_6
+.4byte sOctilleryAnims_8_7
+.4byte sOctilleryAnims_8_8
+sOctilleryAnimTable9:
+.4byte sOctilleryAnims_9_1
+.4byte sOctilleryAnims_9_2
+.4byte sOctilleryAnims_9_3
+.4byte sOctilleryAnims_9_4
+.4byte sOctilleryAnims_9_5
+.4byte sOctilleryAnims_9_6
+.4byte sOctilleryAnims_9_7
+.4byte sOctilleryAnims_9_8
+sOctilleryAnimTable10:
+.4byte sOctilleryAnims_10_1
+.4byte sOctilleryAnims_10_2
+.4byte sOctilleryAnims_10_3
+.4byte sOctilleryAnims_10_4
+.4byte sOctilleryAnims_10_5
+.4byte sOctilleryAnims_10_6
+.4byte sOctilleryAnims_10_7
+.4byte sOctilleryAnims_10_8
+sOctilleryAnimTable11:
+.4byte sOctilleryAnims_11_1
+.4byte sOctilleryAnims_11_2
+.4byte sOctilleryAnims_11_3
+.4byte sOctilleryAnims_11_4
+.4byte sOctilleryAnims_11_5
+.4byte sOctilleryAnims_11_6
+.4byte sOctilleryAnims_11_7
+.4byte sOctilleryAnims_11_8
+sOctilleryAnimTable12:
+.4byte sOctilleryAnims_12_1
+.4byte sOctilleryAnims_12_2
+.4byte sOctilleryAnims_12_3
+.4byte sOctilleryAnims_12_4
+.4byte sOctilleryAnims_12_5
+.4byte sOctilleryAnims_12_6
+.4byte sOctilleryAnims_12_7
+.4byte sOctilleryAnims_12_8
+sOctilleryAnimTable13:
+.4byte sOctilleryAnims_13_1
+.4byte sOctilleryAnims_13_2
+.4byte sOctilleryAnims_13_3
+.4byte sOctilleryAnims_13_4
+.4byte sOctilleryAnims_13_5
+.4byte sOctilleryAnims_13_6
+.4byte sOctilleryAnims_13_7
+.4byte sOctilleryAnims_13_8
+sOctilleryAnimTable14:
+.4byte sOctilleryAnims_14_1
+.4byte sOctilleryAnims_14_2
+.4byte sOctilleryAnims_14_3
+.4byte sOctilleryAnims_14_4
+.4byte sOctilleryAnims_14_5
+.4byte sOctilleryAnims_14_6
+.4byte sOctilleryAnims_14_7
+.4byte sOctilleryAnims_14_8
+sOctilleryAnimTable15:
+.4byte sOctilleryAnims_15_1
+.4byte sOctilleryAnims_15_2
+.4byte sOctilleryAnims_15_3
+.4byte sOctilleryAnims_15_4
+.4byte sOctilleryAnims_15_5
+.4byte sOctilleryAnims_15_6
+.4byte sOctilleryAnims_15_7
+.4byte sOctilleryAnims_15_8
+sAxAnimationsOctillery:
+.4byte sOctilleryAnimTable1
+.4byte sOctilleryAnimTable2
+.4byte sOctilleryAnimTable3
+.4byte sOctilleryAnimTable4
+.4byte sOctilleryAnimTable5
+.4byte sOctilleryAnimTable6
+.4byte sOctilleryAnimTable7
+.4byte sOctilleryAnimTable8
+.4byte sOctilleryAnimTable9
+.4byte sOctilleryAnimTable10
+.4byte sOctilleryAnimTable11
+.4byte sOctilleryAnimTable12
+.4byte sOctilleryAnimTable13
+.4byte sOctilleryAnimTable14
+.4byte sOctilleryAnimTable15
+sAxSpritesOctillery:
+.4byte sOctillerySprites1
+.4byte sOctillerySprites2
+.4byte sOctillerySprites3
+.4byte sOctillerySprites4
+.4byte sOctillerySprites5
+.4byte sOctillerySprites6
+.4byte sOctillerySprites7
+.4byte sOctillerySprites8
+.4byte sOctillerySprites9
+.4byte sOctillerySprites10
+.4byte sOctillerySprites11
+.4byte sOctillerySprites12
+.4byte sOctillerySprites13
+.4byte sOctillerySprites14
+.4byte sOctillerySprites15
+.4byte sOctillerySprites16
+.4byte sOctillerySprites17
+.4byte sOctillerySprites18
+.4byte sOctillerySprites19
+.4byte sOctillerySprites20
+.4byte sOctillerySprites21
+.4byte sOctillerySprites22
+.4byte sOctillerySprites23
+.4byte sOctillerySprites24
+.4byte sOctillerySprites25
+.4byte sOctillerySprites26
+.4byte sOctillerySprites27
+.4byte sOctillerySprites28
+.4byte sOctillerySprites29
+.4byte sOctillerySprites30
+.4byte sOctillerySprites31
+.4byte sOctillerySprites32
+.4byte sOctillerySprites33
+.4byte sOctillerySprites34
+.4byte sOctillerySprites35
+.4byte sOctillerySprites36
+.4byte sOctillerySprites37
+.4byte sOctillerySprites38
+.4byte sOctillerySprites39
+.4byte sOctillerySprites40
+.4byte sOctillerySprites41
+.4byte sOctillerySprites42
+.4byte sOctillerySprites43
+.4byte sOctillerySprites44
+.4byte sOctillerySprites45
+sAxMainOctillery:
+ax_main sAxPosesOctillery, sAxAnimationsOctillery, 15, sAxSpritesOctillery, sAxPositionsOctillery

--- a/data/ax/oddish.inc
+++ b/data/ax/oddish.inc
@@ -1,0 +1,2836 @@
+.global gAxOddish
+gAxOddish:
+ax_siro sAxMainOddish
+sOddishPose1:
+ax_pose 0, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose2:
+ax_pose 1, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose3:
+ax_pose 2, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose4:
+ax_pose 3, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose5:
+ax_pose 4, 0x81e8, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose6:
+ax_pose 5, 0x81e8, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose7:
+ax_pose 6, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose8:
+ax_pose 7, 0x01e8, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose9:
+ax_pose 8, 0x01e8, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose10:
+ax_pose 9, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose11:
+ax_pose 10, 0x81e8, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose12:
+ax_pose 11, 0x81e8, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose13:
+ax_pose 12, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose14:
+ax_pose 13, 0x81e8, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose15:
+ax_pose 14, 0x01e8, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose16:
+ax_pose 9, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose17:
+ax_pose 10, 0x81e8, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose18:
+ax_pose 11, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose19:
+ax_pose 6, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose20:
+ax_pose 7, 0x01e8, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose21:
+ax_pose 8, 0x01e8, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose22:
+ax_pose 3, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose23:
+ax_pose 4, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose24:
+ax_pose 5, 0x81e8, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose25:
+ax_pose 0, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose26:
+ax_pose 1, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose27:
+ax_pose 2, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose28:
+ax_pose 3, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose29:
+ax_pose 4, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose30:
+ax_pose 5, 0x81ea, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose31:
+ax_pose 6, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose32:
+ax_pose 7, 0x01ea, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose33:
+ax_pose 8, 0x01ea, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose34:
+ax_pose 9, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose35:
+ax_pose 10, 0x81ea, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose36:
+ax_pose 11, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose37:
+ax_pose 12, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose38:
+ax_pose 13, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose39:
+ax_pose 14, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose40:
+ax_pose 9, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose41:
+ax_pose 10, 0x81ea, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose42:
+ax_pose 11, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose43:
+ax_pose 6, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose44:
+ax_pose 7, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose45:
+ax_pose 8, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose46:
+ax_pose 3, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose47:
+ax_pose 4, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose48:
+ax_pose 5, 0x81ea, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose49:
+ax_pose 0, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose50:
+ax_pose 1, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose51:
+ax_pose 2, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose52:
+ax_pose 3, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose53:
+ax_pose 4, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose54:
+ax_pose 5, 0x81ea, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose55:
+ax_pose 6, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose56:
+ax_pose 7, 0x01ea, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose57:
+ax_pose 8, 0x01ea, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose58:
+ax_pose 9, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose59:
+ax_pose 10, 0x81ea, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose60:
+ax_pose 11, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose61:
+ax_pose 12, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose62:
+ax_pose 13, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose63:
+ax_pose 14, 0x01ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose64:
+ax_pose 9, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose65:
+ax_pose 10, 0x81ea, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose66:
+ax_pose 11, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose67:
+ax_pose 6, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose68:
+ax_pose 7, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose69:
+ax_pose 8, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose70:
+ax_pose 3, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose71:
+ax_pose 4, 0x81ea, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose72:
+ax_pose 5, 0x81ea, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose73:
+ax_pose 0, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose74:
+ax_pose 15, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose75:
+ax_pose 16, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose76:
+ax_pose 3, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose77:
+ax_pose 17, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose78:
+ax_pose 18, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose79:
+ax_pose 6, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose80:
+ax_pose 19, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sOddishPose81:
+ax_pose 20, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sOddishPose82:
+ax_pose 9, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose83:
+ax_pose 21, 0x01e9, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose84:
+ax_pose 22, 0x01e9, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose85:
+ax_pose 12, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose86:
+ax_pose 23, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sOddishPose87:
+ax_pose 24, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sOddishPose88:
+ax_pose 9, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose89:
+ax_pose 21, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose90:
+ax_pose 22, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose91:
+ax_pose 6, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose92:
+ax_pose 19, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose93:
+ax_pose 20, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose94:
+ax_pose 3, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose95:
+ax_pose 17, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose96:
+ax_pose 18, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose97:
+ax_pose 25, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose98:
+ax_pose 26, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose99:
+ax_pose 27, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose100:
+ax_pose 28, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose101:
+ax_pose 29, 0x01ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose102:
+ax_pose 28, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose103:
+ax_pose 27, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose104:
+ax_pose 26, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose105:
+ax_pose 30, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose106:
+ax_pose 31, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sOddishPose107:
+ax_pose 32, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sOddishPose108:
+ax_pose 33, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sOddishPose109:
+ax_pose 34, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose110:
+ax_pose 33, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sOddishPose111:
+ax_pose 32, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sOddishPose112:
+ax_pose 31, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sOddishPose113:
+ax_pose 35, 0x01f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose114:
+ax_pose 36, 0x01f0, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose115:
+ax_pose 37, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sOddishPose116:
+ax_pose 38, 0x01e8, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose117:
+ax_pose 39, 0x01e8, 0x90e7, 0x3c00
+ax_pose_terminator
+sOddishPose118:
+ax_pose 40, 0x01e7, 0x90e9, 0x3c00
+ax_pose_terminator
+sOddishPose119:
+ax_pose 41, 0x01e8, 0x80f1, 0x3c00
+ax_pose_terminator
+sOddishPose120:
+ax_pose 40, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sOddishPose121:
+ax_pose 39, 0x01e8, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose122:
+ax_pose 38, 0x01e8, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose123:
+ax_pose 0, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose124:
+ax_pose 1, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose125:
+ax_pose 2, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose126:
+ax_pose 3, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose127:
+ax_pose 4, 0x81e8, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose128:
+ax_pose 5, 0x81e8, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose129:
+ax_pose 6, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose130:
+ax_pose 7, 0x01e8, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose131:
+ax_pose 8, 0x01e8, 0x90e8, 0x3c00
+ax_pose_terminator
+sOddishPose132:
+ax_pose 9, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose133:
+ax_pose 10, 0x81e8, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose134:
+ax_pose 11, 0x81e8, 0x90f7, 0x3c00
+ax_pose_terminator
+sOddishPose135:
+ax_pose 12, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose136:
+ax_pose 13, 0x81e8, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose137:
+ax_pose 14, 0x01e8, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose138:
+ax_pose 9, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose139:
+ax_pose 10, 0x81e8, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose140:
+ax_pose 11, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose141:
+ax_pose 6, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose142:
+ax_pose 7, 0x01e8, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose143:
+ax_pose 8, 0x01e8, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose144:
+ax_pose 3, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose145:
+ax_pose 4, 0x81e8, 0x80f9, 0x3c00
+ax_pose_terminator
+sOddishPose146:
+ax_pose 5, 0x81e8, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose147:
+ax_pose 16, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose148:
+ax_pose 18, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sOddishPose149:
+ax_pose 20, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose150:
+ax_pose 22, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose151:
+ax_pose 24, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sOddishPose152:
+ax_pose 22, 0x01e9, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose153:
+ax_pose 20, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose154:
+ax_pose 18, 0x01e8, 0x90ed, 0x3c00
+ax_pose_terminator
+sOddishPose155:
+ax_pose 0, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose156:
+ax_pose 3, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose157:
+ax_pose 6, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose158:
+ax_pose 9, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose159:
+ax_pose 12, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose160:
+ax_pose 9, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose161:
+ax_pose 6, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose162:
+ax_pose 3, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose163:
+ax_pose 0, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose164:
+ax_pose 15, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose165:
+ax_pose 16, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose166:
+ax_pose 3, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose167:
+ax_pose 17, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose168:
+ax_pose 18, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose169:
+ax_pose 6, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose170:
+ax_pose 19, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sOddishPose171:
+ax_pose 20, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sOddishPose172:
+ax_pose 9, 0x81ec, 0x90f6, 0x3c00
+ax_pose_terminator
+sOddishPose173:
+ax_pose 21, 0x01e9, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose174:
+ax_pose 22, 0x01e9, 0x90ee, 0x3c00
+ax_pose_terminator
+sOddishPose175:
+ax_pose 12, 0x81ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose176:
+ax_pose 23, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sOddishPose177:
+ax_pose 24, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sOddishPose178:
+ax_pose 9, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose179:
+ax_pose 21, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose180:
+ax_pose 22, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose181:
+ax_pose 6, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose182:
+ax_pose 19, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose183:
+ax_pose 20, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sOddishPose184:
+ax_pose 3, 0x81ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose185:
+ax_pose 17, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose186:
+ax_pose 18, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sOddishPose187:
+ax_pose 25, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose188:
+ax_pose 26, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose189:
+ax_pose 27, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose190:
+ax_pose 28, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose191:
+ax_pose 29, 0x01ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose192:
+ax_pose 28, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose193:
+ax_pose 27, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose194:
+ax_pose 26, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose195:
+ax_pose 25, 0x01ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sOddishPose196:
+ax_pose 26, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose197:
+ax_pose 27, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose198:
+ax_pose 28, 0x01ec, 0x80fa, 0x3c00
+ax_pose_terminator
+sOddishPose199:
+ax_pose 29, 0x01ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sOddishPose200:
+ax_pose 28, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose201:
+ax_pose 27, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+sOddishPose202:
+ax_pose 26, 0x01ec, 0x90e6, 0x3c00
+ax_pose_terminator
+.align 2
+sOddishAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_2_1:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 14, 0, 14,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 1, 25, 1, 22, 1, 22,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 0, 25, 1, 22, 1, 22,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sOddishAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 14, 14, 14, 14,
+ax_anim 2, 0, 28, 23, 22, 23, 22,
+ax_anim 2, 1, 28, 24, 21, 24, 21,
+ax_anim 2, 0, 28, 23, 22, 23, 22,
+ax_anim 2, 0, 28, 24, 21, 24, 21,
+ax_anim 2, 0, 28, 23, 22, 23, 22,
+ax_anim 2, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 4, 4, 4, 4,
+ax_anim_terminator
+sOddishAnims_2_3:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 14, 0, 14, 0,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 1, 31, 22, 1, 22, 1,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 0, 31, 22, 1, 22, 1,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 4, 0, 4, 0,
+ax_anim_terminator
+sOddishAnims_2_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 2, 0, 35, -2, 2, -2, 2,
+ax_anim 2, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 4, -4, 4, -4,
+ax_anim 2, 2, 34, 13, -14, 13, -14,
+ax_anim 2, 0, 35, 21, -23, 21, -23,
+ax_anim 2, 1, 35, 22, -22, 22, -22,
+ax_anim 2, 0, 35, 21, -23, 21, -23,
+ax_anim 2, 0, 35, 22, -22, 22, -22,
+ax_anim 2, 0, 35, 21, -23, 21, -23,
+ax_anim 2, 0, 33, 10, -10, 10, -10,
+ax_anim 2, 0, 33, 4, -4, 4, -4,
+ax_anim_terminator
+sOddishAnims_2_5:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, -4, 0, -4,
+ax_anim 2, 2, 37, 0, -14, 0, -14,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 1, 38, 1, -24, 1, -24,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 0, 38, 1, -24, 1, -24,
+ax_anim 2, 0, 38, 0, -24, 0, -24,
+ax_anim 2, 0, 36, 0, -10, 0, -10,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sOddishAnims_2_6:
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 2, 0, 41, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, -4, -4, -4, -4,
+ax_anim 2, 2, 40, -13, -14, -13, -14,
+ax_anim 2, 0, 41, -21, -23, -21, -23,
+ax_anim 2, 1, 41, -22, -22, -22, -22,
+ax_anim 2, 0, 41, -21, -23, -21, -23,
+ax_anim 2, 0, 41, -22, -22, -22, -22,
+ax_anim 2, 0, 41, -21, -23, -21, -23,
+ax_anim 2, 0, 39, -10, -10, -10, -10,
+ax_anim 2, 0, 39, -4, -4, -4, -4,
+ax_anim_terminator
+sOddishAnims_2_7:
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 43, 2, 0, 2, 0,
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -14, 0, -14, 0,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 1, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 0, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -4, 0, -4, 0,
+ax_anim_terminator
+sOddishAnims_2_8:
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 2, 0, 46, 2, -2, 2, -2,
+ax_anim 2, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -14, 14, -14, 14,
+ax_anim 2, 0, 46, -23, 22, -23, 22,
+ax_anim 2, 1, 46, -24, 21, -24, 21,
+ax_anim 2, 0, 46, -23, 22, -23, 22,
+ax_anim 2, 0, 46, -24, 21, -24, 21,
+ax_anim 2, 0, 46, -23, 22, -23, 22,
+ax_anim 2, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sOddishAnims_3_1:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 14, 0, 14,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 1, 49, 1, 22, 1, 22,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 49, 1, 22, 1, 22,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sOddishAnims_3_2:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 2, 0, 52, -2, -2, -2, -2,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 4, 4, 4, 4,
+ax_anim 2, 2, 53, 14, 14, 14, 14,
+ax_anim 2, 0, 52, 23, 22, 23, 22,
+ax_anim 2, 1, 52, 24, 21, 24, 21,
+ax_anim 2, 0, 52, 23, 22, 23, 22,
+ax_anim 2, 0, 52, 24, 21, 24, 21,
+ax_anim 2, 0, 52, 23, 22, 23, 22,
+ax_anim 2, 0, 51, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 4, 4, 4, 4,
+ax_anim_terminator
+sOddishAnims_3_3:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 2, 0, 55, -2, 0, -2, 0,
+ax_anim 2, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 14, 0, 14, 0,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 1, 55, 22, 1, 22, 1,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 0, 55, 22, 1, 22, 1,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 0, 54, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim_terminator
+sOddishAnims_3_4:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 2, 0, 59, -2, 2, -2, 2,
+ax_anim 2, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 4, -4, 4, -4,
+ax_anim 2, 2, 58, 13, -14, 13, -14,
+ax_anim 2, 0, 59, 21, -23, 21, -23,
+ax_anim 2, 1, 59, 22, -22, 22, -22,
+ax_anim 2, 0, 59, 21, -23, 21, -23,
+ax_anim 2, 0, 59, 22, -22, 22, -22,
+ax_anim 2, 0, 59, 21, -23, 21, -23,
+ax_anim 2, 0, 57, 10, -10, 10, -10,
+ax_anim 2, 0, 57, 4, -4, 4, -4,
+ax_anim_terminator
+sOddishAnims_3_5:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, -4, 0, -4,
+ax_anim 2, 2, 61, 0, -14, 0, -14,
+ax_anim 2, 0, 62, 0, -24, 0, -24,
+ax_anim 2, 1, 62, 1, -24, 1, -24,
+ax_anim 2, 0, 62, 0, -24, 0, -24,
+ax_anim 2, 0, 62, 1, -24, 1, -24,
+ax_anim 2, 0, 62, 0, -24, 0, -24,
+ax_anim 2, 0, 60, 0, -10, 0, -10,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sOddishAnims_3_6:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 2, 0, 65, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 65, -4, -4, -4, -4,
+ax_anim 2, 2, 64, -13, -14, -13, -14,
+ax_anim 2, 0, 65, -21, -23, -21, -23,
+ax_anim 2, 1, 65, -22, -22, -22, -22,
+ax_anim 2, 0, 65, -21, -23, -21, -23,
+ax_anim 2, 0, 65, -22, -22, -22, -22,
+ax_anim 2, 0, 65, -21, -23, -21, -23,
+ax_anim 2, 0, 63, -10, -10, -10, -10,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim_terminator
+sOddishAnims_3_7:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 2, 0, 67, 2, 0, 2, 0,
+ax_anim 2, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -14, 0, -14, 0,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 1, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 0, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 0, 66, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -4, 0, -4, 0,
+ax_anim_terminator
+sOddishAnims_3_8:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 70, 2, -2, 2, -2,
+ax_anim 2, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 70, -4, 4, -4, 4,
+ax_anim 2, 2, 71, -14, 14, -14, 14,
+ax_anim 2, 0, 70, -23, 22, -23, 22,
+ax_anim 2, 1, 70, -24, 21, -24, 21,
+ax_anim 2, 0, 70, -23, 22, -23, 22,
+ax_anim 2, 0, 70, -24, 21, -24, 21,
+ax_anim 2, 0, 70, -23, 22, -23, 22,
+ax_anim 2, 0, 69, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sOddishAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 1, 74, 0, 6, 0, 6,
+ax_anim 2, 0, 74, -1, 6, -1, 6,
+ax_anim 2, 0, 74, 0, 6, 0, 6,
+ax_anim 2, 0, 74, -1, 6, -1, 6,
+ax_anim 2, 0, 74, 0, 6, 0, 6,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sOddishAnims_4_2:
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 0, 75, -3, -3, -3, -3,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 1, 77, 6, 6, 6, 6,
+ax_anim 2, 0, 77, 5, 7, 5, 7,
+ax_anim 2, 0, 77, 6, 6, 6, 6,
+ax_anim 2, 0, 77, 5, 7, 5, 7,
+ax_anim 2, 0, 77, 6, 6, 6, 6,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim_terminator
+sOddishAnims_4_3:
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 0, 78, -3, 0, -3, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 1, 80, 6, 0, 6, 0,
+ax_anim 2, 0, 80, 6, 1, 6, 1,
+ax_anim 2, 0, 80, 6, 0, 6, 0,
+ax_anim 2, 0, 80, 6, 1, 6, 1,
+ax_anim 2, 0, 80, 6, 0, 6, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sOddishAnims_4_4:
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 81, -3, 3, -3, 3,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 1, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 83, 5, -7, 5, -7,
+ax_anim 2, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 83, 5, -7, 5, -7,
+ax_anim 2, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 81, 2, -2, 2, -2,
+ax_anim_terminator
+sOddishAnims_4_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 0, 84, 0, 3, 0, 3,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 86, 0, -6, 0, -6,
+ax_anim 2, 0, 86, 1, -6, 1, -6,
+ax_anim 2, 0, 86, 0, -6, 0, -6,
+ax_anim 2, 0, 86, 1, -6, 1, -6,
+ax_anim 2, 0, 86, 0, -6, 0, -6,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim_terminator
+sOddishAnims_4_6:
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, 3, 3, 3, 3,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 1, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 89, -5, -7, -5, -7,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 89, -5, -7, -5, -7,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim_terminator
+sOddishAnims_4_7:
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 90, 3, 0, 3, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 92, -6, 0, -6, 0,
+ax_anim 2, 0, 92, -6, 1, -6, 1,
+ax_anim 2, 0, 92, -6, 0, -6, 0,
+ax_anim 2, 0, 92, -6, 1, -6, 1,
+ax_anim 2, 0, 92, -6, 0, -6, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sOddishAnims_4_8:
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 0, 93, 3, -3, 3, -3,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 1, 95, -6, 6, -6, 6,
+ax_anim 2, 0, 95, -5, 7, -5, 7,
+ax_anim 2, 0, 95, -6, 6, -6, 6,
+ax_anim 2, 0, 95, -5, 7, -5, 7,
+ax_anim 2, 0, 95, -6, 6, -6, 6,
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sOddishAnims_5_1:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 0, 100, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -10, 0, 0,
+ax_anim 1, 2, 96, 0, -10, 0, 0,
+ax_anim 1, 0, 103, 0, -10, 0, 0,
+ax_anim 1, 0, 102, 0, -9, 0, 0,
+ax_anim 1, 0, 101, 0, -8, 0, 0,
+ax_anim 1, 0, 100, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -6, 0, 0,
+ax_anim 1, 1, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_5_2:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 1, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 97, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -6, 0, 0,
+ax_anim 1, 0, 99, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -10, 0, 0,
+ax_anim 1, 2, 103, 0, -10, 0, 0,
+ax_anim 1, 0, 96, 0, -10, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 98, 0, -8, 0, 0,
+ax_anim 1, 0, 99, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -6, 0, 0,
+ax_anim 1, 1, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_5_3:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -5, 0, 0,
+ax_anim 1, 0, 97, 0, -6, 0, 0,
+ax_anim 1, 0, 98, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -8, 0, 0,
+ax_anim 1, 0, 100, 0, -9, 0, 0,
+ax_anim 1, 0, 101, 0, -10, 0, 0,
+ax_anim 1, 2, 102, 0, -10, 0, 0,
+ax_anim 1, 0, 103, 0, -10, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -8, 0, 0,
+ax_anim 1, 0, 98, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -6, 0, 0,
+ax_anim 1, 1, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_5_4:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 1, 0, 102, 0, -4, 0, 0,
+ax_anim 1, 0, 103, 0, -5, 0, 0,
+ax_anim 1, 0, 96, 0, -6, 0, 0,
+ax_anim 1, 0, 97, 0, -7, 0, 0,
+ax_anim 1, 0, 98, 0, -8, 0, 0,
+ax_anim 1, 0, 99, 0, -9, 0, 0,
+ax_anim 1, 0, 100, 0, -10, 0, 0,
+ax_anim 1, 2, 101, 0, -10, 0, 0,
+ax_anim 1, 0, 102, 0, -10, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -8, 0, 0,
+ax_anim 1, 0, 97, 0, -7, 0, 0,
+ax_anim 1, 0, 98, 0, -6, 0, 0,
+ax_anim 1, 1, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_5_5:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 1, 0, 99, 0, -4, 0, 0,
+ax_anim 1, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 97, 0, -6, 0, 0,
+ax_anim 1, 0, 96, 0, -7, 0, 0,
+ax_anim 1, 0, 103, 0, -8, 0, 0,
+ax_anim 1, 0, 102, 0, -9, 0, 0,
+ax_anim 1, 0, 101, 0, -10, 0, 0,
+ax_anim 1, 2, 100, 0, -10, 0, 0,
+ax_anim 1, 0, 99, 0, -10, 0, 0,
+ax_anim 1, 0, 98, 0, -9, 0, 0,
+ax_anim 1, 0, 97, 0, -8, 0, 0,
+ax_anim 1, 0, 96, 0, -7, 0, 0,
+ax_anim 1, 0, 103, 0, -6, 0, 0,
+ax_anim 1, 1, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 1, 0, 98, 0, -4, 0, 0,
+ax_anim 1, 0, 97, 0, -5, 0, 0,
+ax_anim 1, 0, 96, 0, -6, 0, 0,
+ax_anim 1, 0, 103, 0, -7, 0, 0,
+ax_anim 1, 0, 102, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -9, 0, 0,
+ax_anim 1, 0, 100, 0, -10, 0, 0,
+ax_anim 1, 2, 99, 0, -10, 0, 0,
+ax_anim 1, 0, 98, 0, -10, 0, 0,
+ax_anim 1, 0, 97, 0, -9, 0, 0,
+ax_anim 1, 0, 96, 0, -8, 0, 0,
+ax_anim 1, 0, 103, 0, -7, 0, 0,
+ax_anim 1, 0, 102, 0, -6, 0, 0,
+ax_anim 1, 1, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_5_7:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 1, 0, 97, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -5, 0, 0,
+ax_anim 1, 0, 103, 0, -6, 0, 0,
+ax_anim 1, 0, 102, 0, -7, 0, 0,
+ax_anim 1, 0, 101, 0, -8, 0, 0,
+ax_anim 1, 0, 100, 0, -9, 0, 0,
+ax_anim 1, 0, 99, 0, -10, 0, 0,
+ax_anim 1, 2, 98, 0, -10, 0, 0,
+ax_anim 1, 0, 97, 0, -10, 0, 0,
+ax_anim 1, 0, 96, 0, -9, 0, 0,
+ax_anim 1, 0, 103, 0, -8, 0, 0,
+ax_anim 1, 0, 102, 0, -7, 0, 0,
+ax_anim 1, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 1, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_5_8:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 1, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 103, 0, -5, 0, 0,
+ax_anim 1, 0, 102, 0, -6, 0, 0,
+ax_anim 1, 0, 101, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -8, 0, 0,
+ax_anim 1, 0, 99, 0, -9, 0, 0,
+ax_anim 1, 0, 98, 0, -10, 0, 0,
+ax_anim 1, 2, 97, 0, -10, 0, 0,
+ax_anim 1, 0, 96, 0, -10, 0, 0,
+ax_anim 1, 0, 103, 0, -9, 0, 0,
+ax_anim 1, 0, 102, 0, -8, 0, 0,
+ax_anim 1, 0, 101, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -6, 0, 0,
+ax_anim 1, 1, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sOddishAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sOddishAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sOddishAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sOddishAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sOddishAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sOddishAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sOddishAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sOddishAnims_8_1:
+ax_anim 30, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 1, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_8_2:
+ax_anim 30, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 1, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_8_3:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 1, 0, 0,
+ax_anim 4, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_8_4:
+ax_anim 30, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 1, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_8_5:
+ax_anim 30, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 1, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_8_6:
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 1, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 1, 0, 0,
+ax_anim_terminator
+sOddishAnims_8_7:
+ax_anim 30, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 1, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sOddishAnims_8_8:
+ax_anim 30, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 1, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 16, 7, 16,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 16, -7, 16,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 19, 3, 19, 3,
+ax_anim 2, 0, 148, 23, 10, 23, 10,
+ax_anim 3, 0, 149, 24, 20, 24, 20,
+ax_anim 2, 3, 150, 13, 19, 13, 19,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -8, 11, -8,
+ax_anim 2, 0, 147, 18, -5, 18, -5,
+ax_anim 3, 0, 148, 24, -2, 24, -2,
+ax_anim 2, 3, 149, 18, 4, 18, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 3, -18, 3, -18,
+ax_anim 2, 0, 146, 10, -24, 10, -24,
+ax_anim 3, 0, 147, 23, -26, 23, -26,
+ax_anim 2, 3, 148, 23, -15, 23, -15,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -7, -20, -7, -20,
+ax_anim 3, 0, 146, 0, -28, 0, -28,
+ax_anim 2, 3, 147, 7, -20, 7, -20,
+ax_anim 2, 0, 148, 9, -10, 9, -10,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -3, -18, -3, -18,
+ax_anim 2, 0, 146, -10, -24, -10, -24,
+ax_anim 3, 0, 153, -23, -26, -23, -26,
+ax_anim 2, 3, 152, -23, -15, -23, -15,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -8, -11, -8,
+ax_anim 2, 0, 153, -18, -5, -18, -5,
+ax_anim 3, 0, 152, -24, -2, -24, -2,
+ax_anim 2, 3, 151, -18, 4, -18, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -19, 3, -19, 3,
+ax_anim 2, 0, 152, -23, 10, -23, 10,
+ax_anim 3, 0, 151, -24, 20, -24, 20,
+ax_anim 2, 3, 150, -13, 19, -13, 19,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -17, 0, 0,
+ax_anim 1, 0, 177, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOddishAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sOddishGfx1:
+.incbin "baserom.gba", 0x6D5C00, 0x100
+sOddishSprites1:
+ax_sprite sOddishGfx1, 0x100
+ax_sprite_terminator
+sOddishGfx2:
+.incbin "baserom.gba", 0x6D5D10, 0x100
+sOddishSprites2:
+ax_sprite sOddishGfx2, 0x100
+ax_sprite_terminator
+sOddishGfx3:
+.incbin "baserom.gba", 0x6D5E20, 0x100
+sOddishSprites3:
+ax_sprite sOddishGfx3, 0x100
+ax_sprite_terminator
+sOddishGfx4:
+.incbin "baserom.gba", 0x6D5F30, 0x100
+sOddishSprites4:
+ax_sprite sOddishGfx4, 0x100
+ax_sprite_terminator
+sOddishGfx5:
+.incbin "baserom.gba", 0x6D6040, 0x100
+sOddishSprites5:
+ax_sprite sOddishGfx5, 0x100
+ax_sprite_terminator
+sOddishGfx6:
+.incbin "baserom.gba", 0x6D6150, 0x100
+sOddishSprites6:
+ax_sprite sOddishGfx6, 0x100
+ax_sprite_terminator
+sOddishGfx7:
+.incbin "baserom.gba", 0x6D6260, 0x100
+sOddishSprites7:
+ax_sprite sOddishGfx7, 0x100
+ax_sprite_terminator
+sOddishGfx8:
+.incbin "baserom.gba", 0x6D6370, 0x200
+sOddishSprites8:
+ax_sprite sOddishGfx8, 0x200
+ax_sprite_terminator
+sOddishGfx9:
+.incbin "baserom.gba", 0x6D6580, 0x200
+sOddishSprites9:
+ax_sprite sOddishGfx9, 0x200
+ax_sprite_terminator
+sOddishGfx10:
+.incbin "baserom.gba", 0x6D6790, 0x100
+sOddishSprites10:
+ax_sprite sOddishGfx10, 0x100
+ax_sprite_terminator
+sOddishGfx11:
+.incbin "baserom.gba", 0x6D68A0, 0x100
+sOddishSprites11:
+ax_sprite sOddishGfx11, 0x100
+ax_sprite_terminator
+sOddishGfx12:
+.incbin "baserom.gba", 0x6D69B0, 0x100
+sOddishSprites12:
+ax_sprite sOddishGfx12, 0x100
+ax_sprite_terminator
+sOddishGfx13:
+.incbin "baserom.gba", 0x6D6AC0, 0x100
+sOddishSprites13:
+ax_sprite sOddishGfx13, 0x100
+ax_sprite_terminator
+sOddishGfx14:
+.incbin "baserom.gba", 0x6D6BD0, 0x100
+sOddishSprites14:
+ax_sprite sOddishGfx14, 0x100
+ax_sprite_terminator
+sOddishGfx15:
+.incbin "baserom.gba", 0x6D6CE0, 0x200
+sOddishSprites15:
+ax_sprite sOddishGfx15, 0x200
+ax_sprite_terminator
+sOddishGfx16:
+.incbin "baserom.gba", 0x6D6EF0, 0x40
+sOddishGfx16_1:
+.incbin "baserom.gba", 0x6D6F30, 0x80
+sOddishGfx16_2:
+.incbin "baserom.gba", 0x6D6FB0, 0x40
+sOddishSprites16:
+ax_sprite 0, 0xa0
+ax_sprite sOddishGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx17:
+.incbin "baserom.gba", 0x6D7030, 0x40
+sOddishGfx17_1:
+.incbin "baserom.gba", 0x6D7070, 0x60
+sOddishGfx17_2:
+.incbin "baserom.gba", 0x6D70D0, 0x40
+sOddishSprites17:
+ax_sprite 0, 0xa0
+ax_sprite sOddishGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx18:
+.incbin "baserom.gba", 0x6D7150, 0x60
+sOddishGfx18_1:
+.incbin "baserom.gba", 0x6D71B0, 0x60
+sOddishGfx18_2:
+.incbin "baserom.gba", 0x6D7210, 0x40
+sOddishSprites18:
+ax_sprite 0, 0xa0
+ax_sprite sOddishGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx19:
+.incbin "baserom.gba", 0x6D7290, 0x60
+sOddishGfx19_1:
+.incbin "baserom.gba", 0x6D72F0, 0x60
+sOddishGfx19_2:
+.incbin "baserom.gba", 0x6D7350, 0x60
+sOddishSprites19:
+ax_sprite 0, 0x80
+ax_sprite sOddishGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx20:
+.incbin "baserom.gba", 0x6D73F0, 0x60
+sOddishGfx20_1:
+.incbin "baserom.gba", 0x6D7450, 0x60
+sOddishGfx20_2:
+.incbin "baserom.gba", 0x6D74B0, 0x20
+sOddishSprites20:
+ax_sprite 0, 0xa0
+ax_sprite sOddishGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx20_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOddishGfx21:
+.incbin "baserom.gba", 0x6D7510, 0x60
+sOddishGfx21_1:
+.incbin "baserom.gba", 0x6D7570, 0x60
+sOddishGfx21_2:
+.incbin "baserom.gba", 0x6D75D0, 0x60
+sOddishSprites21:
+ax_sprite 0, 0x80
+ax_sprite sOddishGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx22:
+.incbin "baserom.gba", 0x6D7670, 0x60
+sOddishGfx22_1:
+.incbin "baserom.gba", 0x6D76D0, 0x60
+sOddishGfx22_2:
+.incbin "baserom.gba", 0x6D7730, 0x40
+sOddishSprites22:
+ax_sprite 0, 0xa0
+ax_sprite sOddishGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx23:
+.incbin "baserom.gba", 0x6D77B0, 0x40
+sOddishGfx23_1:
+.incbin "baserom.gba", 0x6D77F0, 0x60
+sOddishGfx23_2:
+.incbin "baserom.gba", 0x6D7850, 0x60
+sOddishSprites23:
+ax_sprite sOddishGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOddishGfx24:
+.incbin "baserom.gba", 0x6D78E8, 0x40
+sOddishGfx24_1:
+.incbin "baserom.gba", 0x6D7928, 0x60
+sOddishGfx24_2:
+.incbin "baserom.gba", 0x6D7988, 0x40
+sOddishSprites24:
+ax_sprite 0, 0xa0
+ax_sprite sOddishGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx25:
+.incbin "baserom.gba", 0x6D7A08, 0x40
+sOddishGfx25_1:
+.incbin "baserom.gba", 0x6D7A48, 0x60
+sOddishGfx25_2:
+.incbin "baserom.gba", 0x6D7AA8, 0x40
+sOddishSprites25:
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOddishGfx26:
+.incbin "baserom.gba", 0x6D7B28, 0x40
+sOddishGfx26_1:
+.incbin "baserom.gba", 0x6D7B68, 0x40
+sOddishGfx26_2:
+.incbin "baserom.gba", 0x6D7BA8, 0x40
+sOddishSprites26:
+ax_sprite sOddishGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx26_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sOddishGfx27:
+.incbin "baserom.gba", 0x6D7C20, 0x40
+sOddishGfx27_1:
+.incbin "baserom.gba", 0x6D7C60, 0x40
+sOddishGfx27_2:
+.incbin "baserom.gba", 0x6D7CA0, 0x40
+sOddishSprites27:
+ax_sprite sOddishGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx27_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sOddishGfx28:
+.incbin "baserom.gba", 0x6D7D18, 0x40
+sOddishGfx28_1:
+.incbin "baserom.gba", 0x6D7D58, 0x40
+sOddishGfx28_2:
+.incbin "baserom.gba", 0x6D7D98, 0x40
+sOddishSprites28:
+ax_sprite sOddishGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx28_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sOddishGfx29:
+.incbin "baserom.gba", 0x6D7E10, 0x40
+sOddishGfx29_1:
+.incbin "baserom.gba", 0x6D7E50, 0x40
+sOddishGfx29_2:
+.incbin "baserom.gba", 0x6D7E90, 0x40
+sOddishSprites29:
+ax_sprite sOddishGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx29_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx29_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sOddishGfx30:
+.incbin "baserom.gba", 0x6D7F08, 0x40
+sOddishGfx30_1:
+.incbin "baserom.gba", 0x6D7F48, 0x40
+sOddishGfx30_2:
+.incbin "baserom.gba", 0x6D7F88, 0x40
+sOddishSprites30:
+ax_sprite sOddishGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx30_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sOddishGfx31:
+.incbin "baserom.gba", 0x6D8000, 0x60
+sOddishGfx31_1:
+.incbin "baserom.gba", 0x6D8060, 0x60
+sOddishGfx31_2:
+.incbin "baserom.gba", 0x6D80C0, 0x40
+sOddishSprites31:
+ax_sprite 0, 0x80
+ax_sprite sOddishGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx32:
+.incbin "baserom.gba", 0x6D8140, 0x60
+sOddishGfx32_1:
+.incbin "baserom.gba", 0x6D81A0, 0x60
+sOddishGfx32_2:
+.incbin "baserom.gba", 0x6D8200, 0x20
+sOddishSprites32:
+ax_sprite 0, 0x80
+ax_sprite sOddishGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx32_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx32_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOddishGfx33:
+.incbin "baserom.gba", 0x6D8260, 0x60
+sOddishGfx33_1:
+.incbin "baserom.gba", 0x6D82C0, 0x60
+sOddishGfx33_2:
+.incbin "baserom.gba", 0x6D8320, 0x60
+sOddishSprites33:
+ax_sprite 0, 0x80
+ax_sprite sOddishGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx34:
+.incbin "baserom.gba", 0x6D83C0, 0x20
+sOddishGfx34_1:
+.incbin "baserom.gba", 0x6D83E0, 0x60
+sOddishGfx34_2:
+.incbin "baserom.gba", 0x6D8440, 0x60
+sOddishGfx34_3:
+.incbin "baserom.gba", 0x6D84A0, 0x60
+sOddishSprites34:
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx34, 0x20
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx35:
+.incbin "baserom.gba", 0x6D8550, 0x40
+sOddishGfx35_1:
+.incbin "baserom.gba", 0x6D8590, 0x60
+sOddishGfx35_2:
+.incbin "baserom.gba", 0x6D85F0, 0x60
+sOddishGfx35_3:
+.incbin "baserom.gba", 0x6D8650, 0x40
+sOddishSprites35:
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOddishGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOddishGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOddishGfx36:
+.incbin "baserom.gba", 0x6D86E0, 0x200
+sOddishSprites36:
+ax_sprite sOddishGfx36, 0x200
+ax_sprite_terminator
+sOddishGfx37:
+.incbin "baserom.gba", 0x6D88F0, 0x200
+sOddishSprites37:
+ax_sprite sOddishGfx37, 0x200
+ax_sprite_terminator
+sOddishGfx38:
+.incbin "baserom.gba", 0x6D8B00, 0x200
+sOddishSprites38:
+ax_sprite sOddishGfx38, 0x200
+ax_sprite_terminator
+sOddishGfx39:
+.incbin "baserom.gba", 0x6D8D10, 0x200
+sOddishSprites39:
+ax_sprite sOddishGfx39, 0x200
+ax_sprite_terminator
+sOddishGfx40:
+.incbin "baserom.gba", 0x6D8F20, 0x200
+sOddishSprites40:
+ax_sprite sOddishGfx40, 0x200
+ax_sprite_terminator
+sOddishGfx41:
+.incbin "baserom.gba", 0x6D9130, 0x200
+sOddishSprites41:
+ax_sprite sOddishGfx41, 0x200
+ax_sprite_terminator
+sOddishGfx42:
+.incbin "baserom.gba", 0x6D9340, 0x200
+sOddishSprites42:
+ax_sprite sOddishGfx42, 0x200
+ax_sprite_terminator
+sAxPosesOddish:
+.4byte sOddishPose1
+.4byte sOddishPose2
+.4byte sOddishPose3
+.4byte sOddishPose4
+.4byte sOddishPose5
+.4byte sOddishPose6
+.4byte sOddishPose7
+.4byte sOddishPose8
+.4byte sOddishPose9
+.4byte sOddishPose10
+.4byte sOddishPose11
+.4byte sOddishPose12
+.4byte sOddishPose13
+.4byte sOddishPose14
+.4byte sOddishPose15
+.4byte sOddishPose16
+.4byte sOddishPose17
+.4byte sOddishPose18
+.4byte sOddishPose19
+.4byte sOddishPose20
+.4byte sOddishPose21
+.4byte sOddishPose22
+.4byte sOddishPose23
+.4byte sOddishPose24
+.4byte sOddishPose25
+.4byte sOddishPose26
+.4byte sOddishPose27
+.4byte sOddishPose28
+.4byte sOddishPose29
+.4byte sOddishPose30
+.4byte sOddishPose31
+.4byte sOddishPose32
+.4byte sOddishPose33
+.4byte sOddishPose34
+.4byte sOddishPose35
+.4byte sOddishPose36
+.4byte sOddishPose37
+.4byte sOddishPose38
+.4byte sOddishPose39
+.4byte sOddishPose40
+.4byte sOddishPose41
+.4byte sOddishPose42
+.4byte sOddishPose43
+.4byte sOddishPose44
+.4byte sOddishPose45
+.4byte sOddishPose46
+.4byte sOddishPose47
+.4byte sOddishPose48
+.4byte sOddishPose49
+.4byte sOddishPose50
+.4byte sOddishPose51
+.4byte sOddishPose52
+.4byte sOddishPose53
+.4byte sOddishPose54
+.4byte sOddishPose55
+.4byte sOddishPose56
+.4byte sOddishPose57
+.4byte sOddishPose58
+.4byte sOddishPose59
+.4byte sOddishPose60
+.4byte sOddishPose61
+.4byte sOddishPose62
+.4byte sOddishPose63
+.4byte sOddishPose64
+.4byte sOddishPose65
+.4byte sOddishPose66
+.4byte sOddishPose67
+.4byte sOddishPose68
+.4byte sOddishPose69
+.4byte sOddishPose70
+.4byte sOddishPose71
+.4byte sOddishPose72
+.4byte sOddishPose73
+.4byte sOddishPose74
+.4byte sOddishPose75
+.4byte sOddishPose76
+.4byte sOddishPose77
+.4byte sOddishPose78
+.4byte sOddishPose79
+.4byte sOddishPose80
+.4byte sOddishPose81
+.4byte sOddishPose82
+.4byte sOddishPose83
+.4byte sOddishPose84
+.4byte sOddishPose85
+.4byte sOddishPose86
+.4byte sOddishPose87
+.4byte sOddishPose88
+.4byte sOddishPose89
+.4byte sOddishPose90
+.4byte sOddishPose91
+.4byte sOddishPose92
+.4byte sOddishPose93
+.4byte sOddishPose94
+.4byte sOddishPose95
+.4byte sOddishPose96
+.4byte sOddishPose97
+.4byte sOddishPose98
+.4byte sOddishPose99
+.4byte sOddishPose100
+.4byte sOddishPose101
+.4byte sOddishPose102
+.4byte sOddishPose103
+.4byte sOddishPose104
+.4byte sOddishPose105
+.4byte sOddishPose106
+.4byte sOddishPose107
+.4byte sOddishPose108
+.4byte sOddishPose109
+.4byte sOddishPose110
+.4byte sOddishPose111
+.4byte sOddishPose112
+.4byte sOddishPose113
+.4byte sOddishPose114
+.4byte sOddishPose115
+.4byte sOddishPose116
+.4byte sOddishPose117
+.4byte sOddishPose118
+.4byte sOddishPose119
+.4byte sOddishPose120
+.4byte sOddishPose121
+.4byte sOddishPose122
+.4byte sOddishPose123
+.4byte sOddishPose124
+.4byte sOddishPose125
+.4byte sOddishPose126
+.4byte sOddishPose127
+.4byte sOddishPose128
+.4byte sOddishPose129
+.4byte sOddishPose130
+.4byte sOddishPose131
+.4byte sOddishPose132
+.4byte sOddishPose133
+.4byte sOddishPose134
+.4byte sOddishPose135
+.4byte sOddishPose136
+.4byte sOddishPose137
+.4byte sOddishPose138
+.4byte sOddishPose139
+.4byte sOddishPose140
+.4byte sOddishPose141
+.4byte sOddishPose142
+.4byte sOddishPose143
+.4byte sOddishPose144
+.4byte sOddishPose145
+.4byte sOddishPose146
+.4byte sOddishPose147
+.4byte sOddishPose148
+.4byte sOddishPose149
+.4byte sOddishPose150
+.4byte sOddishPose151
+.4byte sOddishPose152
+.4byte sOddishPose153
+.4byte sOddishPose154
+.4byte sOddishPose155
+.4byte sOddishPose156
+.4byte sOddishPose157
+.4byte sOddishPose158
+.4byte sOddishPose159
+.4byte sOddishPose160
+.4byte sOddishPose161
+.4byte sOddishPose162
+.4byte sOddishPose163
+.4byte sOddishPose164
+.4byte sOddishPose165
+.4byte sOddishPose166
+.4byte sOddishPose167
+.4byte sOddishPose168
+.4byte sOddishPose169
+.4byte sOddishPose170
+.4byte sOddishPose171
+.4byte sOddishPose172
+.4byte sOddishPose173
+.4byte sOddishPose174
+.4byte sOddishPose175
+.4byte sOddishPose176
+.4byte sOddishPose177
+.4byte sOddishPose178
+.4byte sOddishPose179
+.4byte sOddishPose180
+.4byte sOddishPose181
+.4byte sOddishPose182
+.4byte sOddishPose183
+.4byte sOddishPose184
+.4byte sOddishPose185
+.4byte sOddishPose186
+.4byte sOddishPose187
+.4byte sOddishPose188
+.4byte sOddishPose189
+.4byte sOddishPose190
+.4byte sOddishPose191
+.4byte sOddishPose192
+.4byte sOddishPose193
+.4byte sOddishPose194
+.4byte sOddishPose195
+.4byte sOddishPose196
+.4byte sOddishPose197
+.4byte sOddishPose198
+.4byte sOddishPose199
+.4byte sOddishPose200
+.4byte sOddishPose201
+.4byte sOddishPose202
+sAxPositionsOddish:
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte    0,   -8, 	  -4,   -9, 	   3,   -9, 	   0,  -10
+.2byte    0,   -8, 	  -4,   -9, 	   3,   -9, 	   0,  -10
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -8, 	  -1,  -10
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -8, 	  -1,  -10
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    3,   -8, 	  -1,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte    3,   -8, 	  -1,   -9, 	  -2,   -7, 	  -1,  -11
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -9, 	  -4,   -9, 	   3,   -8, 	  -1,  -10
+.2byte    1,   -9, 	  -4,   -8, 	   3,   -8, 	  -1,  -11
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -8, 	   3,   -8, 	  -4,   -7, 	   0,   -9
+.2byte   -1,   -8, 	   3,   -7, 	  -4,   -8, 	   0,   -9
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -9, 	  -4,   -8, 	   0,  -10
+.2byte   -2,   -9, 	   3,   -8, 	  -4,   -8, 	   0,  -11
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	   0,   -9, 	   1,   -7, 	   0,  -10
+.2byte   -4,   -8, 	   0,   -9, 	   1,   -7, 	   0,  -11
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -2,   -8, 	  -3,   -9, 	   3,   -8, 	   0,  -10
+.2byte   -2,   -8, 	  -3,   -9, 	   3,   -8, 	   0,  -10
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte    0,   -6, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    1,   -6, 	   2,   -7, 	  -4,   -6, 	  -1,   -8
+.2byte    1,   -6, 	   2,   -7, 	  -4,   -6, 	  -1,   -8
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    3,   -6, 	  -1,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte    3,   -6, 	  -1,   -7, 	  -2,   -5, 	  -1,   -9
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -7, 	  -4,   -7, 	   3,   -6, 	  -1,   -8
+.2byte    1,   -7, 	  -4,   -6, 	   3,   -6, 	  -1,   -9
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -1,   -6, 	   3,   -5, 	  -4,   -6, 	   0,   -7
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -2,   -7, 	   3,   -7, 	  -4,   -6, 	   0,   -8
+.2byte   -2,   -7, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -4,   -6, 	   0,   -7, 	   1,   -5, 	   0,   -8
+.2byte   -4,   -6, 	   0,   -7, 	   1,   -5, 	   0,   -9
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -2,   -6, 	  -3,   -7, 	   3,   -6, 	   0,   -8
+.2byte   -2,   -6, 	  -3,   -7, 	   3,   -6, 	   0,   -8
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte    0,   -6, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    1,   -6, 	   2,   -7, 	  -4,   -6, 	  -1,   -8
+.2byte    1,   -6, 	   2,   -7, 	  -4,   -6, 	  -1,   -8
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    3,   -6, 	  -1,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte    3,   -6, 	  -1,   -7, 	  -2,   -5, 	  -1,   -9
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -7, 	  -4,   -7, 	   3,   -6, 	  -1,   -8
+.2byte    1,   -7, 	  -4,   -6, 	   3,   -6, 	  -1,   -9
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -1,   -6, 	   3,   -5, 	  -4,   -6, 	   0,   -7
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -2,   -7, 	   3,   -7, 	  -4,   -6, 	   0,   -8
+.2byte   -2,   -7, 	   3,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -4,   -6, 	   0,   -7, 	   1,   -5, 	   0,   -8
+.2byte   -4,   -6, 	   0,   -7, 	   1,   -5, 	   0,   -9
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -2,   -6, 	  -3,   -7, 	   3,   -6, 	   0,   -8
+.2byte   -2,   -6, 	  -3,   -7, 	   3,   -6, 	   0,   -8
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte    0,   -7, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    0,    0, 	  -3,   -3, 	   3,   -3, 	   0,   -4
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    0,   -8, 	   1,   -8, 	  -4,   -7, 	  -2,   -9
+.2byte    1,   -2, 	   3,   -5, 	  -2,   -4, 	   1,   -6
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    2,   -9, 	  -1,   -9, 	  -3,   -7, 	  -3,   -9
+.2byte    3,   -2, 	   2,   -8, 	   1,   -5, 	   3,   -7
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -9, 	  -3,   -8, 	   2,   -6, 	  -4,   -7
+.2byte    1,   -4, 	  -3,   -7, 	   2,   -6, 	   1,   -8
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    0,  -10, 	   3,   -6, 	  -4,   -6, 	   0,   -5
+.2byte    0,   -6, 	   5,   -9, 	  -6,   -9, 	   0,   -7
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   2,   -8, 	  -3,   -6, 	   3,   -7
+.2byte   -2,   -4, 	   2,   -7, 	  -3,   -6, 	  -2,   -8
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	   0,   -9, 	   2,   -7, 	   2,   -9
+.2byte   -4,   -2, 	  -3,   -8, 	  -2,   -5, 	  -4,   -7
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -1,   -8, 	  -2,   -8, 	   3,   -7, 	   1,   -9
+.2byte   -2,   -2, 	  -4,   -5, 	   1,   -4, 	  -2,   -6
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte   -4,   -2, 	  -2,   -6, 	  -1,   -4, 	  -1,   -5
+.2byte   -2,   -3, 	   2,   -6, 	  -3,   -4, 	  -1,   -7
+.2byte   -2,   -5, 	   2,   -6, 	  -4,   -4, 	  -2,   -7
+.2byte    0,   -4, 	   3,   -5, 	  -3,   -5, 	   0,   -8
+.2byte    4,   -4, 	   0,   -3, 	  -1,   -5, 	   0,   -6
+.2byte   -1,   -4, 	  -4,   -5, 	   2,   -5, 	  -1,   -8
+.2byte    1,   -5, 	  -3,   -6, 	   3,   -4, 	   1,   -7
+.2byte    1,   -3, 	  -3,   -6, 	   2,   -4, 	   0,   -7
+.2byte   -2,   -3, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte   -2,   -2, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -2, 	  -4,   -3, 	   3,   -3, 	   0,   -6
+.2byte    0,   -4, 	   0,   -5, 	  -6,   -3, 	  -3,   -6
+.2byte    0,   -4, 	  -2,   -5, 	  -4,   -3, 	  -6,   -8
+.2byte    0,   -4, 	  -4,   -2, 	   0,   -1, 	  -3,   -7
+.2byte   -1,   -4, 	   3,   -1, 	  -4,   -1, 	   0,   -3
+.2byte   -2,   -4, 	   2,   -2, 	  -2,   -1, 	   1,   -7
+.2byte   -3,   -4, 	  -1,   -5, 	   1,   -3, 	   3,   -8
+.2byte   -2,   -4, 	  -2,   -5, 	   4,   -3, 	   1,   -6
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte    0,   -8, 	  -4,   -9, 	   3,   -9, 	   0,  -10
+.2byte    0,   -8, 	  -4,   -9, 	   3,   -9, 	   0,  -10
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -8, 	  -1,  -10
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -8, 	  -1,  -10
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    3,   -8, 	  -1,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte    3,   -8, 	  -1,   -9, 	  -2,   -7, 	  -1,  -11
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -9, 	  -4,   -9, 	   3,   -8, 	  -1,  -10
+.2byte    1,   -9, 	  -4,   -8, 	   3,   -8, 	  -1,  -11
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -8, 	   3,   -8, 	  -4,   -7, 	   0,   -9
+.2byte   -1,   -8, 	   3,   -7, 	  -4,   -8, 	   0,   -9
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -9, 	  -4,   -8, 	   0,  -10
+.2byte   -2,   -9, 	   3,   -8, 	  -4,   -8, 	   0,  -11
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -4,   -8, 	   0,   -9, 	   1,   -7, 	   0,  -10
+.2byte   -4,   -8, 	   0,   -9, 	   1,   -7, 	   0,  -11
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -2,   -8, 	  -3,   -9, 	   3,   -8, 	   0,  -10
+.2byte   -2,   -8, 	  -3,   -9, 	   3,   -8, 	   0,  -10
+.2byte    0,    0, 	  -3,   -3, 	   3,   -3, 	   0,   -4
+.2byte   -1,   -2, 	  -3,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -2,   -2, 	  -1,   -8, 	   0,   -5, 	  -2,   -7
+.2byte   -2,   -4, 	   2,   -7, 	  -3,   -6, 	  -2,   -8
+.2byte    0,   -6, 	   5,   -9, 	  -6,   -9, 	   0,   -7
+.2byte    1,   -4, 	  -3,   -7, 	   2,   -6, 	   1,   -8
+.2byte    1,   -2, 	   0,   -8, 	  -1,   -5, 	   1,   -7
+.2byte    0,   -2, 	   2,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte    0,   -7, 	  -4,   -7, 	   3,   -7, 	   0,   -8
+.2byte    0,    0, 	  -3,   -3, 	   3,   -3, 	   0,   -4
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    0,   -8, 	   1,   -8, 	  -4,   -7, 	  -2,   -9
+.2byte    1,   -2, 	   3,   -5, 	  -2,   -4, 	   1,   -6
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    2,   -9, 	  -1,   -9, 	  -3,   -7, 	  -3,   -9
+.2byte    3,   -2, 	   2,   -8, 	   1,   -5, 	   3,   -7
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    1,   -9, 	  -3,   -8, 	   2,   -6, 	  -4,   -7
+.2byte    1,   -4, 	  -3,   -7, 	   2,   -6, 	   1,   -8
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    0,  -10, 	   3,   -6, 	  -4,   -6, 	   0,   -5
+.2byte    0,   -6, 	   5,   -9, 	  -6,   -9, 	   0,   -7
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   2,   -8, 	  -3,   -6, 	   3,   -7
+.2byte   -2,   -4, 	   2,   -7, 	  -3,   -6, 	  -2,   -8
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	   0,   -9, 	   2,   -7, 	   2,   -9
+.2byte   -4,   -2, 	  -3,   -8, 	  -2,   -5, 	  -4,   -7
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -1,   -8, 	  -2,   -8, 	   3,   -7, 	   1,   -9
+.2byte   -2,   -2, 	  -4,   -5, 	   1,   -4, 	  -2,   -6
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+.2byte    0,   -5, 	  -4,   -6, 	   3,   -6, 	   0,   -7
+.2byte   -2,   -5, 	  -3,   -6, 	   3,   -5, 	   0,   -7
+.2byte   -4,   -5, 	  -1,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -2,   -6, 	   3,   -6, 	  -4,   -5, 	   0,   -7
+.2byte    0,   -5, 	   3,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    1,   -6, 	  -4,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    3,   -5, 	   0,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    1,   -5, 	   2,   -6, 	  -4,   -5, 	  -1,   -7
+sOddishAnimTable1:
+.4byte sOddishAnims_1_1
+.4byte sOddishAnims_1_2
+.4byte sOddishAnims_1_3
+.4byte sOddishAnims_1_4
+.4byte sOddishAnims_1_5
+.4byte sOddishAnims_1_6
+.4byte sOddishAnims_1_7
+.4byte sOddishAnims_1_8
+sOddishAnimTable2:
+.4byte sOddishAnims_2_1
+.4byte sOddishAnims_2_2
+.4byte sOddishAnims_2_3
+.4byte sOddishAnims_2_4
+.4byte sOddishAnims_2_5
+.4byte sOddishAnims_2_6
+.4byte sOddishAnims_2_7
+.4byte sOddishAnims_2_8
+sOddishAnimTable3:
+.4byte sOddishAnims_3_1
+.4byte sOddishAnims_3_2
+.4byte sOddishAnims_3_3
+.4byte sOddishAnims_3_4
+.4byte sOddishAnims_3_5
+.4byte sOddishAnims_3_6
+.4byte sOddishAnims_3_7
+.4byte sOddishAnims_3_8
+sOddishAnimTable4:
+.4byte sOddishAnims_4_1
+.4byte sOddishAnims_4_2
+.4byte sOddishAnims_4_3
+.4byte sOddishAnims_4_4
+.4byte sOddishAnims_4_5
+.4byte sOddishAnims_4_6
+.4byte sOddishAnims_4_7
+.4byte sOddishAnims_4_8
+sOddishAnimTable5:
+.4byte sOddishAnims_5_1
+.4byte sOddishAnims_5_2
+.4byte sOddishAnims_5_3
+.4byte sOddishAnims_5_4
+.4byte sOddishAnims_5_5
+.4byte sOddishAnims_5_6
+.4byte sOddishAnims_5_7
+.4byte sOddishAnims_5_8
+sOddishAnimTable6:
+.4byte sOddishAnims_6_1
+.4byte sOddishAnims_6_1
+.4byte sOddishAnims_6_1
+.4byte sOddishAnims_6_1
+.4byte sOddishAnims_6_1
+.4byte sOddishAnims_6_1
+.4byte sOddishAnims_6_1
+.4byte sOddishAnims_6_1
+sOddishAnimTable7:
+.4byte sOddishAnims_7_1
+.4byte sOddishAnims_7_2
+.4byte sOddishAnims_7_3
+.4byte sOddishAnims_7_4
+.4byte sOddishAnims_7_5
+.4byte sOddishAnims_7_6
+.4byte sOddishAnims_7_7
+.4byte sOddishAnims_7_8
+sOddishAnimTable8:
+.4byte sOddishAnims_8_1
+.4byte sOddishAnims_8_2
+.4byte sOddishAnims_8_3
+.4byte sOddishAnims_8_4
+.4byte sOddishAnims_8_5
+.4byte sOddishAnims_8_6
+.4byte sOddishAnims_8_7
+.4byte sOddishAnims_8_8
+sOddishAnimTable9:
+.4byte sOddishAnims_9_1
+.4byte sOddishAnims_9_2
+.4byte sOddishAnims_9_3
+.4byte sOddishAnims_9_4
+.4byte sOddishAnims_9_5
+.4byte sOddishAnims_9_6
+.4byte sOddishAnims_9_7
+.4byte sOddishAnims_9_8
+sOddishAnimTable10:
+.4byte sOddishAnims_10_1
+.4byte sOddishAnims_10_2
+.4byte sOddishAnims_10_3
+.4byte sOddishAnims_10_4
+.4byte sOddishAnims_10_5
+.4byte sOddishAnims_10_6
+.4byte sOddishAnims_10_7
+.4byte sOddishAnims_10_8
+sOddishAnimTable11:
+.4byte sOddishAnims_11_1
+.4byte sOddishAnims_11_2
+.4byte sOddishAnims_11_3
+.4byte sOddishAnims_11_4
+.4byte sOddishAnims_11_5
+.4byte sOddishAnims_11_6
+.4byte sOddishAnims_11_7
+.4byte sOddishAnims_11_8
+sOddishAnimTable12:
+.4byte sOddishAnims_12_1
+.4byte sOddishAnims_12_2
+.4byte sOddishAnims_12_3
+.4byte sOddishAnims_12_4
+.4byte sOddishAnims_12_5
+.4byte sOddishAnims_12_6
+.4byte sOddishAnims_12_7
+.4byte sOddishAnims_12_8
+sOddishAnimTable13:
+.4byte sOddishAnims_13_1
+.4byte sOddishAnims_13_2
+.4byte sOddishAnims_13_3
+.4byte sOddishAnims_13_4
+.4byte sOddishAnims_13_5
+.4byte sOddishAnims_13_6
+.4byte sOddishAnims_13_7
+.4byte sOddishAnims_13_8
+sAxAnimationsOddish:
+.4byte sOddishAnimTable1
+.4byte sOddishAnimTable2
+.4byte sOddishAnimTable3
+.4byte sOddishAnimTable4
+.4byte sOddishAnimTable5
+.4byte sOddishAnimTable6
+.4byte sOddishAnimTable7
+.4byte sOddishAnimTable8
+.4byte sOddishAnimTable9
+.4byte sOddishAnimTable10
+.4byte sOddishAnimTable11
+.4byte sOddishAnimTable12
+.4byte sOddishAnimTable13
+sAxSpritesOddish:
+.4byte sOddishSprites1
+.4byte sOddishSprites2
+.4byte sOddishSprites3
+.4byte sOddishSprites4
+.4byte sOddishSprites5
+.4byte sOddishSprites6
+.4byte sOddishSprites7
+.4byte sOddishSprites8
+.4byte sOddishSprites9
+.4byte sOddishSprites10
+.4byte sOddishSprites11
+.4byte sOddishSprites12
+.4byte sOddishSprites13
+.4byte sOddishSprites14
+.4byte sOddishSprites15
+.4byte sOddishSprites16
+.4byte sOddishSprites17
+.4byte sOddishSprites18
+.4byte sOddishSprites19
+.4byte sOddishSprites20
+.4byte sOddishSprites21
+.4byte sOddishSprites22
+.4byte sOddishSprites23
+.4byte sOddishSprites24
+.4byte sOddishSprites25
+.4byte sOddishSprites26
+.4byte sOddishSprites27
+.4byte sOddishSprites28
+.4byte sOddishSprites29
+.4byte sOddishSprites30
+.4byte sOddishSprites31
+.4byte sOddishSprites32
+.4byte sOddishSprites33
+.4byte sOddishSprites34
+.4byte sOddishSprites35
+.4byte sOddishSprites36
+.4byte sOddishSprites37
+.4byte sOddishSprites38
+.4byte sOddishSprites39
+.4byte sOddishSprites40
+.4byte sOddishSprites41
+.4byte sOddishSprites42
+sAxMainOddish:
+ax_main sAxPosesOddish, sAxAnimationsOddish, 13, sAxSpritesOddish, sAxPositionsOddish

--- a/data/ax/omanyte.inc
+++ b/data/ax/omanyte.inc
@@ -1,0 +1,2658 @@
+.global gAxOmanyte
+gAxOmanyte:
+ax_siro sAxMainOmanyte
+sOmanytePose1:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose2:
+ax_pose 2, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose3:
+ax_pose 3, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose4:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose5:
+ax_pose 5, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose6:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose7:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose8:
+ax_pose 8, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose9:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sOmanytePose10:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose11:
+ax_pose 11, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose12:
+ax_pose 12, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose13:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose14:
+ax_pose 14, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose15:
+ax_pose 15, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose16:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose17:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose18:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose19:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose20:
+ax_pose 8, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose21:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmanytePose22:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose23:
+ax_pose 5, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose24:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose25:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose26:
+ax_pose 2, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose27:
+ax_pose 3, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose28:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose29:
+ax_pose 5, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose30:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose31:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose32:
+ax_pose 8, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose33:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sOmanytePose34:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose35:
+ax_pose 11, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose36:
+ax_pose 12, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose37:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose38:
+ax_pose 14, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose39:
+ax_pose 15, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose40:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose41:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose42:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose43:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose44:
+ax_pose 8, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose45:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmanytePose46:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose47:
+ax_pose 5, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose48:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose49:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose50:
+ax_pose 2, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose51:
+ax_pose 3, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose52:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose53:
+ax_pose 5, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose54:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose55:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose56:
+ax_pose 8, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose57:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sOmanytePose58:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose59:
+ax_pose 11, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose60:
+ax_pose 12, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose61:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose62:
+ax_pose 14, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose63:
+ax_pose 15, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose64:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose65:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose66:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose67:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose68:
+ax_pose 8, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose69:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmanytePose70:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose71:
+ax_pose 5, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose72:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose73:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose74:
+ax_pose 2, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose75:
+ax_pose 3, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose76:
+ax_pose 16, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose77:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose78:
+ax_pose 5, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose79:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose80:
+ax_pose 17, 0x01f1, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmanytePose81:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose82:
+ax_pose 8, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose83:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose84:
+ax_pose 18, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmanytePose85:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose86:
+ax_pose 11, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose87:
+ax_pose 12, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose88:
+ax_pose 19, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose89:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose90:
+ax_pose 14, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose91:
+ax_pose 15, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose92:
+ax_pose 20, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose93:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose94:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose95:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose96:
+ax_pose 19, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose97:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose98:
+ax_pose 8, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmanytePose99:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmanytePose100:
+ax_pose 18, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmanytePose101:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose102:
+ax_pose 5, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose103:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose104:
+ax_pose 17, 0x01f1, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmanytePose105:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose106:
+ax_pose 21, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose107:
+ax_pose 22, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose108:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose109:
+ax_pose 23, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose110:
+ax_pose 24, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose111:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose112:
+ax_pose 25, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose113:
+ax_pose 26, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose114:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose115:
+ax_pose 27, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose116:
+ax_pose 28, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose117:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose118:
+ax_pose 29, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose119:
+ax_pose 30, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose120:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose121:
+ax_pose 27, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose122:
+ax_pose 28, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose123:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose124:
+ax_pose 25, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose125:
+ax_pose 26, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose126:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose127:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose128:
+ax_pose 24, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose129:
+ax_pose 31, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmanytePose130:
+ax_pose 32, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmanytePose131:
+ax_pose 33, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmanytePose132:
+ax_pose 34, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose133:
+ax_pose 35, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose134:
+ax_pose 36, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose135:
+ax_pose 37, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmanytePose136:
+ax_pose 36, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmanytePose137:
+ax_pose 35, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmanytePose138:
+ax_pose 34, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmanytePose139:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose140:
+ax_pose 2, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose141:
+ax_pose 3, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose142:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose143:
+ax_pose 5, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose144:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose145:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose146:
+ax_pose 8, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose147:
+ax_pose 9, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sOmanytePose148:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose149:
+ax_pose 11, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose150:
+ax_pose 12, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose151:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose152:
+ax_pose 14, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose153:
+ax_pose 15, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose154:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose155:
+ax_pose 11, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose156:
+ax_pose 12, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose157:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose158:
+ax_pose 8, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose159:
+ax_pose 9, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmanytePose160:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose161:
+ax_pose 5, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose162:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose163:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose164:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose165:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose166:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose167:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose168:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose169:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose170:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose171:
+ax_pose 16, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose172:
+ax_pose 17, 0x01f1, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmanytePose173:
+ax_pose 18, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmanytePose174:
+ax_pose 19, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose175:
+ax_pose 20, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose176:
+ax_pose 19, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose177:
+ax_pose 18, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmanytePose178:
+ax_pose 17, 0x01f1, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmanytePose179:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose180:
+ax_pose 16, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose181:
+ax_pose 2, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose182:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose183:
+ax_pose 17, 0x01f1, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmanytePose184:
+ax_pose 5, 0x01ee, 0x90ec, 0x0c00
+ax_pose_terminator
+sOmanytePose185:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose186:
+ax_pose 18, 0x01ef, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmanytePose187:
+ax_pose 8, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose188:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose189:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose190:
+ax_pose 19, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose191:
+ax_pose 11, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sOmanytePose192:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose193:
+ax_pose 20, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose194:
+ax_pose 14, 0x81ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmanytePose195:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose196:
+ax_pose 19, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose197:
+ax_pose 11, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmanytePose198:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose199:
+ax_pose 18, 0x01ef, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmanytePose200:
+ax_pose 8, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmanytePose201:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose202:
+ax_pose 17, 0x01f1, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmanytePose203:
+ax_pose 5, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmanytePose204:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose205:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose206:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose207:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose208:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose209:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose210:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose211:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose212:
+ax_pose 0, 0x01fa, 0x0108, 0x0c00
+ax_pose 1, 0x81ee, 0x80f8, 0x0c01
+ax_pose_terminator
+sOmanytePose213:
+ax_pose 4, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose214:
+ax_pose 7, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose215:
+ax_pose 10, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose216:
+ax_pose 13, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmanytePose217:
+ax_pose 10, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose218:
+ax_pose 7, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmanytePose219:
+ax_pose 4, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sOmanyteAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 21, 0, 21,
+ax_anim 2, 1, 25, 1, 21, 1, 21,
+ax_anim 2, 0, 25, 0, 21, 0, 21,
+ax_anim 2, 0, 25, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sOmanyteAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 9, 11, 9, 11,
+ax_anim 2, 0, 28, 19, 22, 19, 22,
+ax_anim 2, 1, 28, 20, 21, 20, 21,
+ax_anim 2, 0, 28, 19, 22, 19, 22,
+ax_anim 2, 0, 28, 20, 21, 20, 21,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sOmanyteAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 1, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 0, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sOmanyteAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 12, -12, 12, -12,
+ax_anim 2, 0, 34, 21, -22, 21, -22,
+ax_anim 2, 1, 34, 22, -21, 22, -21,
+ax_anim 2, 0, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 34, 22, -21, 22, -21,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sOmanyteAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 1, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 0, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sOmanyteAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 41, -11, -13, -11, -13,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 1, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 0, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sOmanyteAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 1, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 0, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sOmanyteAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -11, 10, -11, 10,
+ax_anim 2, 0, 46, -24, 20, -24, 20,
+ax_anim 2, 1, 46, -25, 19, -25, 19,
+ax_anim 2, 0, 46, -24, 20, -24, 20,
+ax_anim 2, 0, 46, -25, 19, -25, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 21, 0, 21,
+ax_anim 2, 1, 49, 1, 21, 1, 21,
+ax_anim 2, 0, 49, 0, 21, 0, 21,
+ax_anim 2, 0, 49, 1, 21, 1, 21,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sOmanyteAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 9, 11, 9, 11,
+ax_anim 2, 0, 52, 19, 22, 19, 22,
+ax_anim 2, 1, 52, 20, 21, 20, 21,
+ax_anim 2, 0, 52, 19, 22, 19, 22,
+ax_anim 2, 0, 52, 20, 21, 20, 21,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sOmanyteAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 1, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 0, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sOmanyteAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 5, -6, 5, -6,
+ax_anim 1, 0, 59, 12, -12, 12, -12,
+ax_anim 2, 0, 58, 21, -22, 21, -22,
+ax_anim 2, 1, 58, 22, -21, 22, -21,
+ax_anim 2, 0, 58, 21, -22, 21, -22,
+ax_anim 2, 0, 58, 22, -21, 22, -21,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sOmanyteAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 1, 61, 1, -22, 1, -22,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 0, 61, 1, -22, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sOmanyteAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -5, -6, -5, -6,
+ax_anim 1, 0, 65, -11, -13, -11, -13,
+ax_anim 2, 0, 64, -18, -24, -18, -24,
+ax_anim 2, 1, 64, -19, -23, -19, -23,
+ax_anim 2, 0, 64, -18, -24, -18, -24,
+ax_anim 2, 0, 64, -19, -23, -19, -23,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sOmanyteAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 1, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 0, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sOmanyteAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -11, 10, -11, 10,
+ax_anim 2, 0, 70, -24, 20, -24, 20,
+ax_anim 2, 1, 70, -25, 19, -25, 19,
+ax_anim 2, 0, 70, -24, 20, -24, 20,
+ax_anim 2, 0, 70, -25, 19, -25, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_4_1:
+ax_anim 1, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 2, 2, 72, 0, -5, 0, 0,
+ax_anim 2, 0, 72, 0, -4, 0, 0,
+ax_anim 1, 0, 72, 0, -2, 0, 0,
+ax_anim 6, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 75, -1, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_4_2:
+ax_anim 1, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 2, 2, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 1, 0, 76, 0, -2, 0, 0,
+ax_anim 6, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 1, 79, -1, 1, -1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, 1, -1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, 1, -1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_4_3:
+ax_anim 1, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 2, 2, 80, 0, -5, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 1, 0, 80, 0, -2, 0, 0,
+ax_anim 6, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 1, 83, 0, 1, 0, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 1, 0, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 1, 0, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_4_4:
+ax_anim 1, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 2, 2, 84, 0, -5, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 6, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 87, -1, -1, -1, 1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, -1, -1, 1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, -1, -1, 1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_4_5:
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 2, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 1, 0, 88, 0, -2, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 1, 91, -1, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_4_6:
+ax_anim 1, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 2, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 95, 1, -1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_4_7:
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 2, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 1, 99, 0, 1, 0, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 1, 0, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 1, 0, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_4_8:
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 2, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 1, 103, 1, 1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_5_1:
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 106, 0, -3, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_5_2:
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 109, 0, -3, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_5_3:
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 112, 0, -3, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_5_4:
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 114, 0, -6, 0, 0,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim 2, 0, 113, 0, -5, 0, 0,
+ax_anim 1, 0, 115, 0, -3, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_5_5:
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 1, 0, 118, 0, -3, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_5_6:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_5_7:
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_5_8:
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sOmanyteAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sOmanyteAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sOmanyteAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sOmanyteAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sOmanyteAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sOmanyteAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sOmanyteAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 11, 8, 11,
+ax_anim 2, 0, 165, 7, 19, 7, 19,
+ax_anim 2, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 19, -7, 19,
+ax_anim 2, 0, 168, -8, 11, -8, 11,
+ax_anim 2, 0, 169, -6, 3, -6, 3,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 12, 22, 12,
+ax_anim 2, 0, 165, 22, 22, 22, 22,
+ax_anim 2, 3, 166, 17, 23, 17, 23,
+ax_anim 2, 0, 167, 6, 19, 6, 19,
+ax_anim 2, 0, 168, 0, 7, 0, 7,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 18, -5, 18, -5,
+ax_anim 2, 0, 164, 22, 0, 22, 0,
+ax_anim 2, 3, 165, 18, 6, 18, 6,
+ax_anim 2, 0, 166, 12, 6, 12, 6,
+ax_anim 2, 0, 167, 4, 5, 4, 5,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -8, 0, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 2, 0, 163, 23, -23, 23, -23,
+ax_anim 2, 3, 164, 23, -14, 23, -14,
+ax_anim 2, 0, 165, 18, -5, 18, -5,
+ax_anim 2, 0, 166, 7, -1, 7, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -7, -3, -7, -3,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 2, 0, 162, 0, -23, 0, -23,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 2, 0, 165, 7, -3, 7, -3,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -8, 0, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 2, 0, 169, -23, -23, -23, -23,
+ax_anim 2, 3, 168, -23, -14, -23, -14,
+ax_anim 2, 0, 167, -18, -5, -18, -5,
+ax_anim 2, 0, 166, -7, -1, -7, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -18, -5, -18, -5,
+ax_anim 2, 0, 168, -22, 0, -22, 0,
+ax_anim 2, 3, 167, -18, 6, -18, 6,
+ax_anim 2, 0, 166, -12, 6, -12, 6,
+ax_anim 2, 0, 165, -4, 5, -4, 5,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 12, -22, 12,
+ax_anim 2, 0, 167, -22, 22, -22, 22,
+ax_anim 2, 3, 166, -17, 23, -17, 23,
+ax_anim 2, 0, 165, -6, 19, -6, 19,
+ax_anim 2, 0, 164, 0, 7, 0, 7,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_11_4:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -17, 0, 0,
+ax_anim 1, 0, 190, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_11_5:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_11_6:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_11_7:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_12_1:
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_12_2:
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, -1,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_12_3:
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_12_4:
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_12_5:
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_12_6:
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_12_7:
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_12_8:
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmanyteAnims_13_1:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_13_2:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_13_3:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_13_4:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_13_5:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_13_6:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_13_7:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteAnims_13_8:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sOmanyteGfx1:
+.incbin "baserom.gba", 0xAF7024, 0x20
+sOmanyteSprites1:
+ax_sprite sOmanyteGfx1, 0x20
+ax_sprite_terminator
+sOmanyteGfx2:
+.incbin "baserom.gba", 0xAF7054, 0x100
+sOmanyteSprites2:
+ax_sprite sOmanyteGfx2, 0x100
+ax_sprite_terminator
+sOmanyteGfx3:
+.incbin "baserom.gba", 0xAF7164, 0x100
+sOmanyteSprites3:
+ax_sprite sOmanyteGfx3, 0x100
+ax_sprite_terminator
+sOmanyteGfx4:
+.incbin "baserom.gba", 0xAF7274, 0x100
+sOmanyteSprites4:
+ax_sprite sOmanyteGfx4, 0x100
+ax_sprite_terminator
+sOmanyteGfx5:
+.incbin "baserom.gba", 0xAF7384, 0x200
+sOmanyteSprites5:
+ax_sprite sOmanyteGfx5, 0x200
+ax_sprite_terminator
+sOmanyteGfx6:
+.incbin "baserom.gba", 0xAF7594, 0x200
+sOmanyteSprites6:
+ax_sprite sOmanyteGfx6, 0x200
+ax_sprite_terminator
+sOmanyteGfx7:
+.incbin "baserom.gba", 0xAF77A4, 0x200
+sOmanyteSprites7:
+ax_sprite sOmanyteGfx7, 0x200
+ax_sprite_terminator
+sOmanyteGfx8:
+.incbin "baserom.gba", 0xAF79B4, 0x200
+sOmanyteSprites8:
+ax_sprite sOmanyteGfx8, 0x200
+ax_sprite_terminator
+sOmanyteGfx9:
+.incbin "baserom.gba", 0xAF7BC4, 0x200
+sOmanyteSprites9:
+ax_sprite sOmanyteGfx9, 0x200
+ax_sprite_terminator
+sOmanyteGfx10:
+.incbin "baserom.gba", 0xAF7DD4, 0x200
+sOmanyteSprites10:
+ax_sprite sOmanyteGfx10, 0x200
+ax_sprite_terminator
+sOmanyteGfx11:
+.incbin "baserom.gba", 0xAF7FE4, 0x200
+sOmanyteSprites11:
+ax_sprite sOmanyteGfx11, 0x200
+ax_sprite_terminator
+sOmanyteGfx12:
+.incbin "baserom.gba", 0xAF81F4, 0x200
+sOmanyteSprites12:
+ax_sprite sOmanyteGfx12, 0x200
+ax_sprite_terminator
+sOmanyteGfx13:
+.incbin "baserom.gba", 0xAF8404, 0x200
+sOmanyteSprites13:
+ax_sprite sOmanyteGfx13, 0x200
+ax_sprite_terminator
+sOmanyteGfx14:
+.incbin "baserom.gba", 0xAF8614, 0x200
+sOmanyteSprites14:
+ax_sprite sOmanyteGfx14, 0x200
+ax_sprite_terminator
+sOmanyteGfx15:
+.incbin "baserom.gba", 0xAF8824, 0x100
+sOmanyteSprites15:
+ax_sprite sOmanyteGfx15, 0x100
+ax_sprite_terminator
+sOmanyteGfx16:
+.incbin "baserom.gba", 0xAF8934, 0x200
+sOmanyteSprites16:
+ax_sprite sOmanyteGfx16, 0x200
+ax_sprite_terminator
+sOmanyteGfx17:
+.incbin "baserom.gba", 0xAF8B44, 0xC0
+sOmanyteSprites17:
+ax_sprite sOmanyteGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmanyteGfx18:
+.incbin "baserom.gba", 0xAF8C1C, 0x60
+sOmanyteGfx18_1:
+.incbin "baserom.gba", 0xAF8C7C, 0x60
+sOmanyteGfx18_2:
+.incbin "baserom.gba", 0xAF8CDC, 0x40
+sOmanyteSprites18:
+ax_sprite sOmanyteGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx19:
+.incbin "baserom.gba", 0xAF8D54, 0x100
+sOmanyteGfx19_1:
+.incbin "baserom.gba", 0xAF8E54, 0x40
+sOmanyteSprites19:
+ax_sprite sOmanyteGfx19, 0x100
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx19_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx20:
+.incbin "baserom.gba", 0xAF8EBC, 0x60
+sOmanyteGfx20_1:
+.incbin "baserom.gba", 0xAF8F1C, 0x60
+sOmanyteGfx20_2:
+.incbin "baserom.gba", 0xAF8F7C, 0x40
+sOmanyteSprites20:
+ax_sprite sOmanyteGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx20_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx21:
+.incbin "baserom.gba", 0xAF8FF4, 0x60
+sOmanyteGfx21_1:
+.incbin "baserom.gba", 0xAF9054, 0x60
+sOmanyteGfx21_2:
+.incbin "baserom.gba", 0xAF90B4, 0x40
+sOmanyteSprites21:
+ax_sprite sOmanyteGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx21_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx22:
+.incbin "baserom.gba", 0xAF912C, 0x100
+sOmanyteSprites22:
+ax_sprite sOmanyteGfx22, 0x100
+ax_sprite_terminator
+sOmanyteGfx23:
+.incbin "baserom.gba", 0xAF923C, 0xC0
+sOmanyteSprites23:
+ax_sprite sOmanyteGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmanyteGfx24:
+.incbin "baserom.gba", 0xAF9314, 0x60
+sOmanyteGfx24_1:
+.incbin "baserom.gba", 0xAF9374, 0x60
+sOmanyteGfx24_2:
+.incbin "baserom.gba", 0xAF93D4, 0x60
+sOmanyteSprites24:
+ax_sprite sOmanyteGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx25:
+.incbin "baserom.gba", 0xAF946C, 0x40
+sOmanyteGfx25_1:
+.incbin "baserom.gba", 0xAF94AC, 0x60
+sOmanyteGfx25_2:
+.incbin "baserom.gba", 0xAF950C, 0x40
+sOmanyteSprites25:
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx26:
+.incbin "baserom.gba", 0xAF958C, 0x60
+sOmanyteGfx26_1:
+.incbin "baserom.gba", 0xAF95EC, 0x60
+sOmanyteGfx26_2:
+.incbin "baserom.gba", 0xAF964C, 0x60
+sOmanyteGfx26_3:
+.incbin "baserom.gba", 0xAF96AC, 0x20
+sOmanyteSprites26:
+ax_sprite sOmanyteGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmanyteGfx27:
+.incbin "baserom.gba", 0xAF9714, 0x60
+sOmanyteGfx27_1:
+.incbin "baserom.gba", 0xAF9774, 0x60
+sOmanyteGfx27_2:
+.incbin "baserom.gba", 0xAF97D4, 0x40
+sOmanyteSprites27:
+ax_sprite sOmanyteGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx28:
+.incbin "baserom.gba", 0xAF984C, 0x40
+sOmanyteGfx28_1:
+.incbin "baserom.gba", 0xAF988C, 0x60
+sOmanyteGfx28_2:
+.incbin "baserom.gba", 0xAF98EC, 0x60
+sOmanyteSprites28:
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx29:
+.incbin "baserom.gba", 0xAF998C, 0x60
+sOmanyteGfx29_1:
+.incbin "baserom.gba", 0xAF99EC, 0x60
+sOmanyteGfx29_2:
+.incbin "baserom.gba", 0xAF9A4C, 0x40
+sOmanyteSprites29:
+ax_sprite sOmanyteGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx29_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx30:
+.incbin "baserom.gba", 0xAF9AC4, 0x40
+sOmanyteGfx30_1:
+.incbin "baserom.gba", 0xAF9B04, 0x60
+sOmanyteGfx30_2:
+.incbin "baserom.gba", 0xAF9B64, 0x40
+sOmanyteSprites30:
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOmanyteGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOmanyteGfx30_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmanyteGfx31:
+.incbin "baserom.gba", 0xAF9BE4, 0xC0
+sOmanyteSprites31:
+ax_sprite sOmanyteGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmanyteGfx32:
+.incbin "baserom.gba", 0xAF9CBC, 0x200
+sOmanyteSprites32:
+ax_sprite sOmanyteGfx32, 0x200
+ax_sprite_terminator
+sOmanyteGfx33:
+.incbin "baserom.gba", 0xAF9ECC, 0x200
+sOmanyteSprites33:
+ax_sprite sOmanyteGfx33, 0x200
+ax_sprite_terminator
+sOmanyteGfx34:
+.incbin "baserom.gba", 0xAFA0DC, 0x200
+sOmanyteSprites34:
+ax_sprite sOmanyteGfx34, 0x200
+ax_sprite_terminator
+sOmanyteGfx35:
+.incbin "baserom.gba", 0xAFA2EC, 0x200
+sOmanyteSprites35:
+ax_sprite sOmanyteGfx35, 0x200
+ax_sprite_terminator
+sOmanyteGfx36:
+.incbin "baserom.gba", 0xAFA4FC, 0x200
+sOmanyteSprites36:
+ax_sprite sOmanyteGfx36, 0x200
+ax_sprite_terminator
+sOmanyteGfx37:
+.incbin "baserom.gba", 0xAFA70C, 0x200
+sOmanyteSprites37:
+ax_sprite sOmanyteGfx37, 0x200
+ax_sprite_terminator
+sOmanyteGfx38:
+.incbin "baserom.gba", 0xAFA91C, 0x200
+sOmanyteSprites38:
+ax_sprite sOmanyteGfx38, 0x200
+ax_sprite_terminator
+sAxPosesOmanyte:
+.4byte sOmanytePose1
+.4byte sOmanytePose2
+.4byte sOmanytePose3
+.4byte sOmanytePose4
+.4byte sOmanytePose5
+.4byte sOmanytePose6
+.4byte sOmanytePose7
+.4byte sOmanytePose8
+.4byte sOmanytePose9
+.4byte sOmanytePose10
+.4byte sOmanytePose11
+.4byte sOmanytePose12
+.4byte sOmanytePose13
+.4byte sOmanytePose14
+.4byte sOmanytePose15
+.4byte sOmanytePose16
+.4byte sOmanytePose17
+.4byte sOmanytePose18
+.4byte sOmanytePose19
+.4byte sOmanytePose20
+.4byte sOmanytePose21
+.4byte sOmanytePose22
+.4byte sOmanytePose23
+.4byte sOmanytePose24
+.4byte sOmanytePose25
+.4byte sOmanytePose26
+.4byte sOmanytePose27
+.4byte sOmanytePose28
+.4byte sOmanytePose29
+.4byte sOmanytePose30
+.4byte sOmanytePose31
+.4byte sOmanytePose32
+.4byte sOmanytePose33
+.4byte sOmanytePose34
+.4byte sOmanytePose35
+.4byte sOmanytePose36
+.4byte sOmanytePose37
+.4byte sOmanytePose38
+.4byte sOmanytePose39
+.4byte sOmanytePose40
+.4byte sOmanytePose41
+.4byte sOmanytePose42
+.4byte sOmanytePose43
+.4byte sOmanytePose44
+.4byte sOmanytePose45
+.4byte sOmanytePose46
+.4byte sOmanytePose47
+.4byte sOmanytePose48
+.4byte sOmanytePose49
+.4byte sOmanytePose50
+.4byte sOmanytePose51
+.4byte sOmanytePose52
+.4byte sOmanytePose53
+.4byte sOmanytePose54
+.4byte sOmanytePose55
+.4byte sOmanytePose56
+.4byte sOmanytePose57
+.4byte sOmanytePose58
+.4byte sOmanytePose59
+.4byte sOmanytePose60
+.4byte sOmanytePose61
+.4byte sOmanytePose62
+.4byte sOmanytePose63
+.4byte sOmanytePose64
+.4byte sOmanytePose65
+.4byte sOmanytePose66
+.4byte sOmanytePose67
+.4byte sOmanytePose68
+.4byte sOmanytePose69
+.4byte sOmanytePose70
+.4byte sOmanytePose71
+.4byte sOmanytePose72
+.4byte sOmanytePose73
+.4byte sOmanytePose74
+.4byte sOmanytePose75
+.4byte sOmanytePose76
+.4byte sOmanytePose77
+.4byte sOmanytePose78
+.4byte sOmanytePose79
+.4byte sOmanytePose80
+.4byte sOmanytePose81
+.4byte sOmanytePose82
+.4byte sOmanytePose83
+.4byte sOmanytePose84
+.4byte sOmanytePose85
+.4byte sOmanytePose86
+.4byte sOmanytePose87
+.4byte sOmanytePose88
+.4byte sOmanytePose89
+.4byte sOmanytePose90
+.4byte sOmanytePose91
+.4byte sOmanytePose92
+.4byte sOmanytePose93
+.4byte sOmanytePose94
+.4byte sOmanytePose95
+.4byte sOmanytePose96
+.4byte sOmanytePose97
+.4byte sOmanytePose98
+.4byte sOmanytePose99
+.4byte sOmanytePose100
+.4byte sOmanytePose101
+.4byte sOmanytePose102
+.4byte sOmanytePose103
+.4byte sOmanytePose104
+.4byte sOmanytePose105
+.4byte sOmanytePose106
+.4byte sOmanytePose107
+.4byte sOmanytePose108
+.4byte sOmanytePose109
+.4byte sOmanytePose110
+.4byte sOmanytePose111
+.4byte sOmanytePose112
+.4byte sOmanytePose113
+.4byte sOmanytePose114
+.4byte sOmanytePose115
+.4byte sOmanytePose116
+.4byte sOmanytePose117
+.4byte sOmanytePose118
+.4byte sOmanytePose119
+.4byte sOmanytePose120
+.4byte sOmanytePose121
+.4byte sOmanytePose122
+.4byte sOmanytePose123
+.4byte sOmanytePose124
+.4byte sOmanytePose125
+.4byte sOmanytePose126
+.4byte sOmanytePose127
+.4byte sOmanytePose128
+.4byte sOmanytePose129
+.4byte sOmanytePose130
+.4byte sOmanytePose131
+.4byte sOmanytePose132
+.4byte sOmanytePose133
+.4byte sOmanytePose134
+.4byte sOmanytePose135
+.4byte sOmanytePose136
+.4byte sOmanytePose137
+.4byte sOmanytePose138
+.4byte sOmanytePose139
+.4byte sOmanytePose140
+.4byte sOmanytePose141
+.4byte sOmanytePose142
+.4byte sOmanytePose143
+.4byte sOmanytePose144
+.4byte sOmanytePose145
+.4byte sOmanytePose146
+.4byte sOmanytePose147
+.4byte sOmanytePose148
+.4byte sOmanytePose149
+.4byte sOmanytePose150
+.4byte sOmanytePose151
+.4byte sOmanytePose152
+.4byte sOmanytePose153
+.4byte sOmanytePose154
+.4byte sOmanytePose155
+.4byte sOmanytePose156
+.4byte sOmanytePose157
+.4byte sOmanytePose158
+.4byte sOmanytePose159
+.4byte sOmanytePose160
+.4byte sOmanytePose161
+.4byte sOmanytePose162
+.4byte sOmanytePose163
+.4byte sOmanytePose164
+.4byte sOmanytePose165
+.4byte sOmanytePose166
+.4byte sOmanytePose167
+.4byte sOmanytePose168
+.4byte sOmanytePose169
+.4byte sOmanytePose170
+.4byte sOmanytePose171
+.4byte sOmanytePose172
+.4byte sOmanytePose173
+.4byte sOmanytePose174
+.4byte sOmanytePose175
+.4byte sOmanytePose176
+.4byte sOmanytePose177
+.4byte sOmanytePose178
+.4byte sOmanytePose179
+.4byte sOmanytePose180
+.4byte sOmanytePose181
+.4byte sOmanytePose182
+.4byte sOmanytePose183
+.4byte sOmanytePose184
+.4byte sOmanytePose185
+.4byte sOmanytePose186
+.4byte sOmanytePose187
+.4byte sOmanytePose188
+.4byte sOmanytePose189
+.4byte sOmanytePose190
+.4byte sOmanytePose191
+.4byte sOmanytePose192
+.4byte sOmanytePose193
+.4byte sOmanytePose194
+.4byte sOmanytePose195
+.4byte sOmanytePose196
+.4byte sOmanytePose197
+.4byte sOmanytePose198
+.4byte sOmanytePose199
+.4byte sOmanytePose200
+.4byte sOmanytePose201
+.4byte sOmanytePose202
+.4byte sOmanytePose203
+.4byte sOmanytePose204
+.4byte sOmanytePose205
+.4byte sOmanytePose206
+.4byte sOmanytePose207
+.4byte sOmanytePose208
+.4byte sOmanytePose209
+.4byte sOmanytePose210
+.4byte sOmanytePose211
+.4byte sOmanytePose212
+.4byte sOmanytePose213
+.4byte sOmanytePose214
+.4byte sOmanytePose215
+.4byte sOmanytePose216
+.4byte sOmanytePose217
+.4byte sOmanytePose218
+.4byte sOmanytePose219
+sAxPositionsOmanyte:
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -8
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    7,   -1, 	  12,   -2, 	   1,    2, 	   1,   -8
+.2byte    5,   -3, 	   8,   -7, 	  -2,   -4, 	  -1,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    9,   -3, 	  12,   -4, 	   8,   -1, 	   0,   -7
+.2byte    7,   -3, 	   6,   -8, 	   2,   -4, 	  -3,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    6,   -7, 	   4,   -7, 	  11,   -6, 	   1,   -9
+.2byte    4,   -7, 	   3,  -11, 	   8,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte   -1,   -7, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	   6,  -10, 	  -8,  -10, 	  -1,   -8
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,   -7, 	  -5,   -7, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,   -7, 	  -4,  -11, 	  -9,   -9, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte  -10,   -3, 	 -13,   -4, 	  -9,   -1, 	  -1,   -7
+.2byte   -8,   -3, 	  -7,   -8, 	  -3,   -4, 	   2,   -7
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -8,   -1, 	 -13,   -2, 	  -2,    2, 	  -2,   -8
+.2byte   -6,   -3, 	  -9,   -7, 	   1,   -4, 	   0,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -8
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    7,   -1, 	  12,   -2, 	   1,    2, 	   1,   -8
+.2byte    5,   -3, 	   8,   -7, 	  -2,   -4, 	  -1,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    9,   -3, 	  12,   -4, 	   8,   -1, 	   0,   -7
+.2byte    7,   -3, 	   6,   -8, 	   2,   -4, 	  -3,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    6,   -7, 	   4,   -7, 	  11,   -6, 	   1,   -9
+.2byte    4,   -7, 	   3,  -11, 	   8,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte   -1,   -7, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	   6,  -10, 	  -8,  -10, 	  -1,   -8
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,   -7, 	  -5,   -7, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,   -7, 	  -4,  -11, 	  -9,   -9, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte  -10,   -3, 	 -13,   -4, 	  -9,   -1, 	  -1,   -7
+.2byte   -8,   -3, 	  -7,   -8, 	  -3,   -4, 	   2,   -7
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -8,   -1, 	 -13,   -2, 	  -2,    2, 	  -2,   -8
+.2byte   -6,   -3, 	  -9,   -7, 	   1,   -4, 	   0,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -8
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    7,   -1, 	  12,   -2, 	   1,    2, 	   1,   -8
+.2byte    5,   -3, 	   8,   -7, 	  -2,   -4, 	  -1,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    9,   -3, 	  12,   -4, 	   8,   -1, 	   0,   -7
+.2byte    7,   -3, 	   6,   -8, 	   2,   -4, 	  -3,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    6,   -7, 	   4,   -7, 	  11,   -6, 	   1,   -9
+.2byte    4,   -7, 	   3,  -11, 	   8,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte   -1,   -7, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	   6,  -10, 	  -8,  -10, 	  -1,   -8
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,   -7, 	  -5,   -7, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,   -7, 	  -4,  -11, 	  -9,   -9, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte  -10,   -3, 	 -13,   -4, 	  -9,   -1, 	  -1,   -7
+.2byte   -8,   -3, 	  -7,   -8, 	  -3,   -4, 	   2,   -7
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -8,   -1, 	 -13,   -2, 	  -2,    2, 	  -2,   -8
+.2byte   -6,   -3, 	  -9,   -7, 	   1,   -4, 	   0,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -8
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    7,   -1, 	  12,   -2, 	   1,    2, 	   1,   -8
+.2byte    5,   -3, 	   8,   -7, 	  -2,   -4, 	  -1,   -8
+.2byte    6,   -2, 	   8,   -7, 	  -2,   -3, 	  -2,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    8,   -3, 	  11,   -4, 	   7,   -1, 	  -1,   -7
+.2byte    8,   -3, 	   7,   -8, 	   3,   -4, 	  -2,   -7
+.2byte    8,   -6, 	   7,   -9, 	   2,   -6, 	  -3,   -6
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    6,   -7, 	   4,   -7, 	  11,   -6, 	   1,   -9
+.2byte    4,   -7, 	   3,  -11, 	   8,   -9, 	  -1,   -8
+.2byte    5,   -9, 	   1,  -12, 	   6,  -11, 	  -1,   -7
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte   -1,   -7, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	   6,  -10, 	  -8,  -10, 	  -1,   -8
+.2byte   -1,   -9, 	   6,  -12, 	  -8,  -12, 	  -1,   -8
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,   -7, 	  -5,   -7, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,   -7, 	  -4,  -11, 	  -9,   -9, 	   0,   -8
+.2byte   -6,   -9, 	  -2,  -12, 	  -7,  -11, 	   0,   -7
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte   -9,   -3, 	 -12,   -4, 	  -8,   -1, 	   0,   -7
+.2byte   -9,   -3, 	  -8,   -8, 	  -4,   -4, 	   1,   -7
+.2byte   -9,   -6, 	  -8,   -9, 	  -3,   -6, 	   2,   -6
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -8,   -1, 	 -13,   -2, 	  -2,    2, 	  -2,   -8
+.2byte   -6,   -3, 	  -9,   -7, 	   1,   -4, 	   0,   -8
+.2byte   -7,   -2, 	  -9,   -7, 	   1,   -3, 	   1,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte    0,    0, 	  -6,    0, 	   6,    0, 	   0,  -13
+.2byte    0,   -2, 	  -4,   -2, 	   4,   -2, 	   0,  -10
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    5,   -2, 	   8,   -2, 	  -2,   -3, 	  -1,  -12
+.2byte    2,   -4, 	   5,   -4, 	  -1,   -3, 	  -1,   -9
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    7,   -2, 	   8,   -3, 	   4,    1, 	  -2,  -12
+.2byte    4,   -4, 	   5,   -6, 	   4,   -3, 	  -2,   -8
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    5,   -3, 	   3,   -2, 	   7,    0, 	   0,  -10
+.2byte    3,   -6, 	   0,   -8, 	   4,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte   -1,   -5, 	   6,   -4, 	  -8,   -4, 	  -1,  -10
+.2byte   -1,   -6, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -6,   -3, 	  -4,   -2, 	  -8,    0, 	  -1,  -10
+.2byte   -4,   -6, 	  -1,   -8, 	  -5,   -5, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte   -8,   -2, 	  -9,   -3, 	  -5,    1, 	   1,  -12
+.2byte   -5,   -4, 	  -6,   -6, 	  -5,   -3, 	   1,   -8
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -6,   -2, 	  -9,   -2, 	   1,   -3, 	   0,  -12
+.2byte   -3,   -4, 	  -6,   -4, 	   0,   -3, 	   0,   -9
+.2byte   -4,   -2, 	  -7,   -2, 	  -2,    0, 	   1,   -7
+.2byte   -4,   -2, 	  -8,   -1, 	  -4,    1, 	   0,   -6
+.2byte    0,   -4, 	  -6,   -9, 	   6,   -9, 	   0,  -11
+.2byte    5,   -6, 	   8,  -12, 	  -2,   -8, 	  -3,   -9
+.2byte    8,   -6, 	   7,  -10, 	   3,   -9, 	  -3,   -7
+.2byte    4,   -9, 	   2,  -13, 	   7,  -11, 	  -1,   -8
+.2byte    0,  -11, 	   5,  -14, 	  -6,  -14, 	   0,   -9
+.2byte   -5,   -9, 	  -3,  -13, 	  -8,  -11, 	   0,   -8
+.2byte   -9,   -6, 	  -8,  -10, 	  -4,   -9, 	   2,   -7
+.2byte   -6,   -6, 	  -9,  -12, 	   1,   -8, 	   2,   -9
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -8
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    7,   -1, 	  12,   -2, 	   1,    2, 	   1,   -8
+.2byte    5,   -3, 	   8,   -7, 	  -2,   -4, 	  -1,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    9,   -3, 	  12,   -4, 	   8,   -1, 	   0,   -7
+.2byte    7,   -3, 	   6,   -8, 	   2,   -4, 	  -3,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    6,   -7, 	   4,   -7, 	  11,   -6, 	   1,   -9
+.2byte    4,   -7, 	   3,  -11, 	   8,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte   -1,   -7, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	   6,  -10, 	  -8,  -10, 	  -1,   -8
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -7,   -7, 	  -5,   -7, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,   -7, 	  -4,  -11, 	  -9,   -9, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte  -10,   -3, 	 -13,   -4, 	  -9,   -1, 	  -1,   -7
+.2byte   -8,   -3, 	  -7,   -8, 	  -3,   -4, 	   2,   -7
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -8,   -1, 	 -13,   -2, 	  -2,    2, 	  -2,   -8
+.2byte   -6,   -3, 	  -9,   -7, 	   1,   -4, 	   0,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    6,   -2, 	   8,   -7, 	  -2,   -3, 	  -2,   -8
+.2byte    8,   -6, 	   7,   -9, 	   2,   -6, 	  -3,   -6
+.2byte    5,   -9, 	   1,  -12, 	   6,  -11, 	  -1,   -7
+.2byte   -1,   -9, 	   6,  -12, 	  -8,  -12, 	  -1,   -8
+.2byte   -6,   -9, 	  -2,  -12, 	  -7,  -11, 	   0,   -7
+.2byte   -9,   -6, 	  -8,   -9, 	  -3,   -6, 	   2,   -6
+.2byte   -7,   -2, 	  -9,   -7, 	   1,   -3, 	   1,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte    0,   -1, 	  -6,   -4, 	   6,   -4, 	   0,  -10
+.2byte    0,    2, 	  -6,    3, 	   6,    3, 	   0,   -8
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    6,   -2, 	   8,   -7, 	  -2,   -3, 	  -2,   -8
+.2byte    5,   -1, 	  10,   -2, 	  -1,    2, 	  -1,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    8,   -6, 	   7,   -9, 	   2,   -6, 	  -3,   -6
+.2byte    8,   -3, 	  11,   -4, 	   7,   -1, 	  -1,   -7
+.2byte    8,   -3, 	   7,   -8, 	   3,   -4, 	  -2,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    5,   -9, 	   1,  -12, 	   6,  -11, 	  -1,   -7
+.2byte    5,   -7, 	   3,   -7, 	  10,   -6, 	   0,   -9
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte   -1,   -9, 	   6,  -12, 	  -8,  -12, 	  -1,   -8
+.2byte   -1,   -7, 	   5,  -10, 	  -7,  -10, 	  -1,   -8
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -6,   -9, 	  -2,  -12, 	  -7,  -11, 	   0,   -7
+.2byte   -6,   -7, 	  -4,   -7, 	 -11,   -6, 	  -1,   -9
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte   -9,   -6, 	  -8,   -9, 	  -3,   -6, 	   2,   -6
+.2byte   -9,   -3, 	 -12,   -4, 	  -8,   -1, 	   0,   -7
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -7,   -2, 	  -9,   -7, 	   1,   -3, 	   1,   -8
+.2byte   -6,   -1, 	 -11,   -2, 	   0,    2, 	   0,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+.2byte    0,    0, 	  -7,   -3, 	   7,   -3, 	   0,   -9
+.2byte   -7,   -1, 	 -10,   -6, 	   1,   -2, 	   0,   -8
+.2byte   -9,   -3, 	  -9,   -7, 	  -5,   -4, 	   0,   -7
+.2byte   -6,   -6, 	  -5,  -11, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   6,  -11, 	  -8,  -11, 	  -1,   -7
+.2byte    5,   -6, 	   4,  -11, 	   9,   -9, 	   0,   -8
+.2byte    8,   -3, 	   8,   -7, 	   4,   -4, 	  -1,   -7
+.2byte    6,   -1, 	   9,   -6, 	  -2,   -2, 	  -1,   -8
+sOmanyteAnimTable1:
+.4byte sOmanyteAnims_1_1
+.4byte sOmanyteAnims_1_2
+.4byte sOmanyteAnims_1_3
+.4byte sOmanyteAnims_1_4
+.4byte sOmanyteAnims_1_5
+.4byte sOmanyteAnims_1_6
+.4byte sOmanyteAnims_1_7
+.4byte sOmanyteAnims_1_8
+sOmanyteAnimTable2:
+.4byte sOmanyteAnims_2_1
+.4byte sOmanyteAnims_2_2
+.4byte sOmanyteAnims_2_3
+.4byte sOmanyteAnims_2_4
+.4byte sOmanyteAnims_2_5
+.4byte sOmanyteAnims_2_6
+.4byte sOmanyteAnims_2_7
+.4byte sOmanyteAnims_2_8
+sOmanyteAnimTable3:
+.4byte sOmanyteAnims_3_1
+.4byte sOmanyteAnims_3_2
+.4byte sOmanyteAnims_3_3
+.4byte sOmanyteAnims_3_4
+.4byte sOmanyteAnims_3_5
+.4byte sOmanyteAnims_3_6
+.4byte sOmanyteAnims_3_7
+.4byte sOmanyteAnims_3_8
+sOmanyteAnimTable4:
+.4byte sOmanyteAnims_4_1
+.4byte sOmanyteAnims_4_2
+.4byte sOmanyteAnims_4_3
+.4byte sOmanyteAnims_4_4
+.4byte sOmanyteAnims_4_5
+.4byte sOmanyteAnims_4_6
+.4byte sOmanyteAnims_4_7
+.4byte sOmanyteAnims_4_8
+sOmanyteAnimTable5:
+.4byte sOmanyteAnims_5_1
+.4byte sOmanyteAnims_5_2
+.4byte sOmanyteAnims_5_3
+.4byte sOmanyteAnims_5_4
+.4byte sOmanyteAnims_5_5
+.4byte sOmanyteAnims_5_6
+.4byte sOmanyteAnims_5_7
+.4byte sOmanyteAnims_5_8
+sOmanyteAnimTable6:
+.4byte sOmanyteAnims_6_1
+.4byte sOmanyteAnims_6_1
+.4byte sOmanyteAnims_6_1
+.4byte sOmanyteAnims_6_1
+.4byte sOmanyteAnims_6_1
+.4byte sOmanyteAnims_6_1
+.4byte sOmanyteAnims_6_1
+.4byte sOmanyteAnims_6_1
+sOmanyteAnimTable7:
+.4byte sOmanyteAnims_7_1
+.4byte sOmanyteAnims_7_2
+.4byte sOmanyteAnims_7_3
+.4byte sOmanyteAnims_7_4
+.4byte sOmanyteAnims_7_5
+.4byte sOmanyteAnims_7_6
+.4byte sOmanyteAnims_7_7
+.4byte sOmanyteAnims_7_8
+sOmanyteAnimTable8:
+.4byte sOmanyteAnims_8_1
+.4byte sOmanyteAnims_8_2
+.4byte sOmanyteAnims_8_3
+.4byte sOmanyteAnims_8_4
+.4byte sOmanyteAnims_8_5
+.4byte sOmanyteAnims_8_6
+.4byte sOmanyteAnims_8_7
+.4byte sOmanyteAnims_8_8
+sOmanyteAnimTable9:
+.4byte sOmanyteAnims_9_1
+.4byte sOmanyteAnims_9_2
+.4byte sOmanyteAnims_9_3
+.4byte sOmanyteAnims_9_4
+.4byte sOmanyteAnims_9_5
+.4byte sOmanyteAnims_9_6
+.4byte sOmanyteAnims_9_7
+.4byte sOmanyteAnims_9_8
+sOmanyteAnimTable10:
+.4byte sOmanyteAnims_10_1
+.4byte sOmanyteAnims_10_2
+.4byte sOmanyteAnims_10_3
+.4byte sOmanyteAnims_10_4
+.4byte sOmanyteAnims_10_5
+.4byte sOmanyteAnims_10_6
+.4byte sOmanyteAnims_10_7
+.4byte sOmanyteAnims_10_8
+sOmanyteAnimTable11:
+.4byte sOmanyteAnims_11_1
+.4byte sOmanyteAnims_11_2
+.4byte sOmanyteAnims_11_3
+.4byte sOmanyteAnims_11_4
+.4byte sOmanyteAnims_11_5
+.4byte sOmanyteAnims_11_6
+.4byte sOmanyteAnims_11_7
+.4byte sOmanyteAnims_11_8
+sOmanyteAnimTable12:
+.4byte sOmanyteAnims_12_1
+.4byte sOmanyteAnims_12_2
+.4byte sOmanyteAnims_12_3
+.4byte sOmanyteAnims_12_4
+.4byte sOmanyteAnims_12_5
+.4byte sOmanyteAnims_12_6
+.4byte sOmanyteAnims_12_7
+.4byte sOmanyteAnims_12_8
+sOmanyteAnimTable13:
+.4byte sOmanyteAnims_13_1
+.4byte sOmanyteAnims_13_2
+.4byte sOmanyteAnims_13_3
+.4byte sOmanyteAnims_13_4
+.4byte sOmanyteAnims_13_5
+.4byte sOmanyteAnims_13_6
+.4byte sOmanyteAnims_13_7
+.4byte sOmanyteAnims_13_8
+sAxAnimationsOmanyte:
+.4byte sOmanyteAnimTable1
+.4byte sOmanyteAnimTable2
+.4byte sOmanyteAnimTable3
+.4byte sOmanyteAnimTable4
+.4byte sOmanyteAnimTable5
+.4byte sOmanyteAnimTable6
+.4byte sOmanyteAnimTable7
+.4byte sOmanyteAnimTable8
+.4byte sOmanyteAnimTable9
+.4byte sOmanyteAnimTable10
+.4byte sOmanyteAnimTable11
+.4byte sOmanyteAnimTable12
+.4byte sOmanyteAnimTable13
+sAxSpritesOmanyte:
+.4byte sOmanyteSprites1
+.4byte sOmanyteSprites2
+.4byte sOmanyteSprites3
+.4byte sOmanyteSprites4
+.4byte sOmanyteSprites5
+.4byte sOmanyteSprites6
+.4byte sOmanyteSprites7
+.4byte sOmanyteSprites8
+.4byte sOmanyteSprites9
+.4byte sOmanyteSprites10
+.4byte sOmanyteSprites11
+.4byte sOmanyteSprites12
+.4byte sOmanyteSprites13
+.4byte sOmanyteSprites14
+.4byte sOmanyteSprites15
+.4byte sOmanyteSprites16
+.4byte sOmanyteSprites17
+.4byte sOmanyteSprites18
+.4byte sOmanyteSprites19
+.4byte sOmanyteSprites20
+.4byte sOmanyteSprites21
+.4byte sOmanyteSprites22
+.4byte sOmanyteSprites23
+.4byte sOmanyteSprites24
+.4byte sOmanyteSprites25
+.4byte sOmanyteSprites26
+.4byte sOmanyteSprites27
+.4byte sOmanyteSprites28
+.4byte sOmanyteSprites29
+.4byte sOmanyteSprites30
+.4byte sOmanyteSprites31
+.4byte sOmanyteSprites32
+.4byte sOmanyteSprites33
+.4byte sOmanyteSprites34
+.4byte sOmanyteSprites35
+.4byte sOmanyteSprites36
+.4byte sOmanyteSprites37
+.4byte sOmanyteSprites38
+sAxMainOmanyte:
+ax_main sAxPosesOmanyte, sAxAnimationsOmanyte, 13, sAxSpritesOmanyte, sAxPositionsOmanyte

--- a/data/ax/omastar.inc
+++ b/data/ax/omastar.inc
@@ -1,0 +1,2569 @@
+.global gAxOmastar
+gAxOmastar:
+ax_siro sAxMainOmastar
+sOmastarPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose4:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose5:
+ax_pose 4, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose6:
+ax_pose 5, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose8:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose9:
+ax_pose 8, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose10:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose11:
+ax_pose 10, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose12:
+ax_pose 11, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose15:
+ax_pose 14, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sOmastarPose16:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose17:
+ax_pose 10, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose18:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose19:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose21:
+ax_pose 8, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose22:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose24:
+ax_pose 5, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose28:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose29:
+ax_pose 4, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose30:
+ax_pose 5, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose31:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose32:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose33:
+ax_pose 8, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose34:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose35:
+ax_pose 10, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose36:
+ax_pose 11, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose37:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose38:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose39:
+ax_pose 14, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sOmastarPose40:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose41:
+ax_pose 10, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose42:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose43:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose44:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose45:
+ax_pose 8, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose46:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose47:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose48:
+ax_pose 5, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose52:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose53:
+ax_pose 4, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose54:
+ax_pose 5, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose55:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose56:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose57:
+ax_pose 8, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose58:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose59:
+ax_pose 10, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose60:
+ax_pose 11, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose61:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose62:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose63:
+ax_pose 14, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sOmastarPose64:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose65:
+ax_pose 10, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose66:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose67:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose68:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose69:
+ax_pose 8, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose70:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose71:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose72:
+ax_pose 5, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose73:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose74:
+ax_pose 1, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose75:
+ax_pose 2, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose76:
+ax_pose 15, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose77:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose78:
+ax_pose 4, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose79:
+ax_pose 5, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose80:
+ax_pose 16, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose81:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose82:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose83:
+ax_pose 8, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose84:
+ax_pose 17, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose85:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose86:
+ax_pose 10, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose87:
+ax_pose 11, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose88:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose89:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose90:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose91:
+ax_pose 14, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sOmastarPose92:
+ax_pose 19, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose93:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose94:
+ax_pose 10, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose95:
+ax_pose 11, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose96:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose97:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose98:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose99:
+ax_pose 8, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose100:
+ax_pose 17, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose101:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose102:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose103:
+ax_pose 5, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose104:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose105:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose106:
+ax_pose 20, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose107:
+ax_pose 21, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmastarPose108:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose109:
+ax_pose 22, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose110:
+ax_pose 23, 0x01ed, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose111:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose112:
+ax_pose 24, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose113:
+ax_pose 25, 0x01ed, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose114:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose115:
+ax_pose 26, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose116:
+ax_pose 27, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose117:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose118:
+ax_pose 28, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose119:
+ax_pose 29, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sOmastarPose120:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose121:
+ax_pose 26, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose122:
+ax_pose 27, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose123:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose124:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose125:
+ax_pose 25, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose126:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose127:
+ax_pose 22, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose128:
+ax_pose 23, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose129:
+ax_pose 30, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmastarPose130:
+ax_pose 31, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmastarPose131:
+ax_pose 32, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose132:
+ax_pose 33, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose133:
+ax_pose 34, 0x01e2, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmastarPose134:
+ax_pose 35, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose135:
+ax_pose 36, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose136:
+ax_pose 35, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose137:
+ax_pose 34, 0x01e2, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose138:
+ax_pose 33, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose139:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose140:
+ax_pose 20, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose141:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose142:
+ax_pose 22, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose143:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose144:
+ax_pose 24, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose145:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose146:
+ax_pose 26, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose147:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose148:
+ax_pose 28, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose149:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose150:
+ax_pose 26, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose151:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose152:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose153:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose154:
+ax_pose 22, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose155:
+ax_pose 20, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose156:
+ax_pose 22, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose157:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose158:
+ax_pose 26, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose159:
+ax_pose 28, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose160:
+ax_pose 26, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose161:
+ax_pose 24, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose162:
+ax_pose 22, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose163:
+ax_pose 15, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose164:
+ax_pose 16, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose165:
+ax_pose 17, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose166:
+ax_pose 18, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmastarPose167:
+ax_pose 19, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose168:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose169:
+ax_pose 17, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose170:
+ax_pose 16, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose171:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose172:
+ax_pose 20, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose173:
+ax_pose 1, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose174:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose175:
+ax_pose 22, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose176:
+ax_pose 4, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose177:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose178:
+ax_pose 24, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose179:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sOmastarPose180:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose181:
+ax_pose 26, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose182:
+ax_pose 10, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose183:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose184:
+ax_pose 28, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose185:
+ax_pose 13, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose186:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose187:
+ax_pose 26, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose188:
+ax_pose 10, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose189:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose190:
+ax_pose 24, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose191:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose192:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose193:
+ax_pose 22, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose194:
+ax_pose 4, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sOmastarPose195:
+ax_pose 20, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose196:
+ax_pose 22, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sOmastarPose197:
+ax_pose 24, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose198:
+ax_pose 26, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sOmastarPose199:
+ax_pose 28, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose200:
+ax_pose 26, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sOmastarPose201:
+ax_pose 24, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose202:
+ax_pose 22, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sOmastarPose203:
+ax_pose 0, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose204:
+ax_pose 3, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose205:
+ax_pose 6, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose206:
+ax_pose 9, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sOmastarPose207:
+ax_pose 12, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sOmastarPose208:
+ax_pose 9, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose209:
+ax_pose 6, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sOmastarPose210:
+ax_pose 3, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+.align 2
+sOmastarAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 21, 0, 21,
+ax_anim 2, 1, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 25, 0, 21, 0, 21,
+ax_anim 2, 0, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sOmastarAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 9, 11, 9, 11,
+ax_anim 2, 0, 28, 19, 22, 19, 22,
+ax_anim 2, 1, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 28, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sOmastarAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 1, 32, 23, 1, 23, 1,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 0, 32, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sOmastarAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 12, -12, 12, -12,
+ax_anim 2, 0, 34, 21, -22, 21, -22,
+ax_anim 2, 1, 35, 22, -21, 22, -21,
+ax_anim 2, 0, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 35, 22, -21, 22, -21,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sOmastarAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 1, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 0, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sOmastarAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 41, -11, -13, -11, -13,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 1, 41, -19, -23, -19, -23,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 0, 41, -19, -23, -19, -23,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sOmastarAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 1, 44, -22, 1, -22, 1,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 0, 44, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sOmastarAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -11, 10, -11, 10,
+ax_anim 2, 0, 46, -24, 20, -24, 20,
+ax_anim 2, 1, 47, -25, 19, -25, 19,
+ax_anim 2, 0, 46, -24, 20, -24, 20,
+ax_anim 2, 0, 47, -25, 19, -25, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOmastarAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 21, 0, 21,
+ax_anim 2, 1, 50, 1, 21, 1, 21,
+ax_anim 2, 0, 49, 0, 21, 0, 21,
+ax_anim 2, 0, 50, 1, 21, 1, 21,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sOmastarAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 9, 11, 9, 11,
+ax_anim 2, 0, 52, 19, 22, 19, 22,
+ax_anim 2, 1, 53, 20, 21, 20, 21,
+ax_anim 2, 0, 52, 19, 22, 19, 22,
+ax_anim 2, 0, 53, 20, 21, 20, 21,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sOmastarAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 1, 56, 23, 1, 23, 1,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 0, 56, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sOmastarAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 5, -6, 5, -6,
+ax_anim 1, 0, 59, 12, -12, 12, -12,
+ax_anim 2, 0, 58, 21, -22, 21, -22,
+ax_anim 2, 1, 59, 22, -21, 22, -21,
+ax_anim 2, 0, 58, 21, -22, 21, -22,
+ax_anim 2, 0, 59, 22, -21, 22, -21,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sOmastarAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 1, 62, 1, -22, 1, -22,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 0, 62, 1, -22, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sOmastarAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -5, -6, -5, -6,
+ax_anim 1, 0, 65, -11, -13, -11, -13,
+ax_anim 2, 0, 64, -18, -24, -18, -24,
+ax_anim 2, 1, 65, -19, -23, -19, -23,
+ax_anim 2, 0, 64, -18, -24, -18, -24,
+ax_anim 2, 0, 65, -19, -23, -19, -23,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sOmastarAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 1, 68, -22, 1, -22, 1,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 0, 68, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sOmastarAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -11, 10, -11, 10,
+ax_anim 2, 0, 70, -24, 20, -24, 20,
+ax_anim 2, 1, 71, -25, 19, -25, 19,
+ax_anim 2, 0, 70, -24, 20, -24, 20,
+ax_anim 2, 0, 71, -25, 19, -25, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOmastarAnims_4_1:
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, -3, 0, -3,
+ax_anim 6, 2, 72, 0, -3, 0, -3,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 1, 75, -1, 4, -1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, -1, 4, -1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, -1, 4, -1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sOmastarAnims_4_2:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 78, -3, -3, -3, -3,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 1, 79, 3, 5, 3, 5,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 3, 5, 3, 5,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 3, 5, 3, 5,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sOmastarAnims_4_3:
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 2, 0, 82, -3, 0, -3, 0,
+ax_anim 6, 2, 80, -3, 0, -3, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 1, 83, 4, 1, 4, 1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, 1, 4, 1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, 1, 4, 1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sOmastarAnims_4_4:
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 86, -3, 3, -3, 3,
+ax_anim 6, 2, 84, -3, 3, -3, 3,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 1, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sOmastarAnims_4_5:
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 6, 2, 88, 0, 3, 0, 3,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 1, 91, -1, -4, -1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, -1, -4, -1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, -1, -4, -1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sOmastarAnims_4_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 94, 3, 3, 3, 3,
+ax_anim 6, 2, 92, 3, 3, 3, 3,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 1, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sOmastarAnims_4_7:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 3, 0, 3, 0,
+ax_anim 6, 2, 96, 3, 0, 3, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 1, 99, -4, 1, -4, 1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, 1, -4, 1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, 1, -4, 1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sOmastarAnims_4_8:
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 102, 3, -3, 3, -3,
+ax_anim 6, 2, 100, 3, -3, 3, -3,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 1, 103, -3, 5, -3, 5,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -3, 5, -3, 5,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -3, 5, -3, 5,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sOmastarAnims_5_1:
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 0, -8, 0, 0,
+ax_anim 2, 0, 104, 0, -8, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 1, 0, 106, 0, -3, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_5_2:
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -6, 0, 0,
+ax_anim 2, 0, 108, 0, -8, 0, 0,
+ax_anim 2, 0, 107, 0, -8, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 1, 0, 109, 0, -3, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_5_3:
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 111, 0, -8, 0, 0,
+ax_anim 2, 0, 110, 0, -8, 0, 0,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 1, 0, 112, 0, -3, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_5_4:
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -6, 0, 0,
+ax_anim 2, 0, 114, 0, -8, 0, 0,
+ax_anim 2, 0, 113, 0, -8, 0, 0,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim 1, 0, 115, 0, -3, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_5_5:
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 2, 0, 117, 0, -8, 0, 0,
+ax_anim 2, 0, 116, 0, -8, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, 0,
+ax_anim 1, 0, 118, 0, -3, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_5_6:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 0, 120, 0, -8, 0, 0,
+ax_anim 2, 0, 119, 0, -8, 0, 0,
+ax_anim 2, 0, 119, 0, -6, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_5_7:
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 123, 0, -6, 0, 0,
+ax_anim 2, 0, 123, 0, -8, 0, 0,
+ax_anim 2, 0, 122, 0, -8, 0, 0,
+ax_anim 2, 0, 122, 0, -6, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_5_8:
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, 0,
+ax_anim 2, 0, 126, 0, -8, 0, 0,
+ax_anim 2, 0, 125, 0, -8, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sOmastarAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sOmastarAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sOmastarAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sOmastarAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sOmastarAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sOmastarAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sOmastarAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sOmastarAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 20, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_8_2:
+ax_anim 30, 0, 140, 0, 0, 0, 0,
+ax_anim 20, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_8_3:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 20, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_8_4:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 20, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_8_5:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 20, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_8_6:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 20, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_8_7:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 20, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_8_8:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 20, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 19, 7, 19,
+ax_anim 3, 0, 158, 0, 23, 0, 23,
+ax_anim 2, 3, 159, -7, 19, -7, 19,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 18, 4, 18, 4,
+ax_anim 2, 0, 156, 23, 14, 23, 14,
+ax_anim 3, 0, 157, 21, 23, 21, 23,
+ax_anim 2, 3, 158, 14, 25, 14, 25,
+ax_anim 2, 0, 159, 5, 17, 5, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -5, 17, -5,
+ax_anim 3, 0, 156, 21, 0, 21, 0,
+ax_anim 2, 3, 157, 17, 5, 17, 5,
+ax_anim 2, 0, 158, 10, 7, 10, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -23, 12, -23,
+ax_anim 3, 0, 155, 20, -20, 20, -20,
+ax_anim 2, 3, 156, 23, -15, 23, -15,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 8, 0, 8, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -10, -12, -10, -12,
+ax_anim 2, 0, 161, -8, -19, -8, -19,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 8, -19, 8, -19,
+ax_anim 2, 0, 156, 10, -10, 10, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -23, -12, -23,
+ax_anim 3, 0, 161, -20, -20, -20, -20,
+ax_anim 2, 3, 160, -23, -15, -23, -15,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -8, 0, -8, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -5, -17, -5,
+ax_anim 3, 0, 160, -21, 0, -21, 0,
+ax_anim 2, 3, 159, -17, 5, -17, 5,
+ax_anim 2, 0, 158, -10, 7, -10, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -18, 4, -18, 4,
+ax_anim 2, 0, 160, -23, 14, -23, 14,
+ax_anim 3, 0, 159, -21, 23, -21, 23,
+ax_anim 2, 3, 158, -14, 25, -14, 25,
+ax_anim 2, 0, 157, -5, 17, -5, 17,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOmastarAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sOmastarGfx1:
+.incbin "baserom.gba", 0xAFFCC4, 0x200
+sOmastarSprites1:
+ax_sprite sOmastarGfx1, 0x200
+ax_sprite_terminator
+sOmastarGfx2:
+.incbin "baserom.gba", 0xAFFED4, 0x200
+sOmastarSprites2:
+ax_sprite sOmastarGfx2, 0x200
+ax_sprite_terminator
+sOmastarGfx3:
+.incbin "baserom.gba", 0xB000E4, 0x200
+sOmastarSprites3:
+ax_sprite sOmastarGfx3, 0x200
+ax_sprite_terminator
+sOmastarGfx4:
+.incbin "baserom.gba", 0xB002F4, 0x200
+sOmastarSprites4:
+ax_sprite sOmastarGfx4, 0x200
+ax_sprite_terminator
+sOmastarGfx5:
+.incbin "baserom.gba", 0xB00504, 0x200
+sOmastarSprites5:
+ax_sprite sOmastarGfx5, 0x200
+ax_sprite_terminator
+sOmastarGfx6:
+.incbin "baserom.gba", 0xB00714, 0x200
+sOmastarSprites6:
+ax_sprite sOmastarGfx6, 0x200
+ax_sprite_terminator
+sOmastarGfx7:
+.incbin "baserom.gba", 0xB00924, 0x200
+sOmastarSprites7:
+ax_sprite sOmastarGfx7, 0x200
+ax_sprite_terminator
+sOmastarGfx8:
+.incbin "baserom.gba", 0xB00B34, 0x200
+sOmastarSprites8:
+ax_sprite sOmastarGfx8, 0x200
+ax_sprite_terminator
+sOmastarGfx9:
+.incbin "baserom.gba", 0xB00D44, 0x200
+sOmastarSprites9:
+ax_sprite sOmastarGfx9, 0x200
+ax_sprite_terminator
+sOmastarGfx10:
+.incbin "baserom.gba", 0xB00F54, 0x200
+sOmastarSprites10:
+ax_sprite sOmastarGfx10, 0x200
+ax_sprite_terminator
+sOmastarGfx11:
+.incbin "baserom.gba", 0xB01164, 0x200
+sOmastarSprites11:
+ax_sprite sOmastarGfx11, 0x200
+ax_sprite_terminator
+sOmastarGfx12:
+.incbin "baserom.gba", 0xB01374, 0x200
+sOmastarSprites12:
+ax_sprite sOmastarGfx12, 0x200
+ax_sprite_terminator
+sOmastarGfx13:
+.incbin "baserom.gba", 0xB01584, 0x200
+sOmastarSprites13:
+ax_sprite sOmastarGfx13, 0x200
+ax_sprite_terminator
+sOmastarGfx14:
+.incbin "baserom.gba", 0xB01794, 0x200
+sOmastarSprites14:
+ax_sprite sOmastarGfx14, 0x200
+ax_sprite_terminator
+sOmastarGfx15:
+.incbin "baserom.gba", 0xB019A4, 0x200
+sOmastarSprites15:
+ax_sprite sOmastarGfx15, 0x200
+ax_sprite_terminator
+sOmastarGfx16:
+.incbin "baserom.gba", 0xB01BB4, 0x60
+sOmastarGfx16_1:
+.incbin "baserom.gba", 0xB01C14, 0xE0
+sOmastarSprites16:
+ax_sprite sOmastarGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx16_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx17:
+.incbin "baserom.gba", 0xB01D1C, 0x140
+sOmastarGfx17_1:
+.incbin "baserom.gba", 0xB01E5C, 0x20
+sOmastarSprites17:
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx17, 0x140
+ax_sprite 0, 0x40
+ax_sprite sOmastarGfx17_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmastarGfx18:
+.incbin "baserom.gba", 0xB01EAC, 0x180
+sOmastarSprites18:
+ax_sprite sOmastarGfx18, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sOmastarGfx19:
+.incbin "baserom.gba", 0xB02044, 0x60
+sOmastarGfx19_1:
+.incbin "baserom.gba", 0xB020A4, 0x60
+sOmastarGfx19_2:
+.incbin "baserom.gba", 0xB02104, 0x60
+sOmastarSprites19:
+ax_sprite sOmastarGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx20:
+.incbin "baserom.gba", 0xB0219C, 0x60
+sOmastarGfx20_1:
+.incbin "baserom.gba", 0xB021FC, 0xE0
+sOmastarSprites20:
+ax_sprite sOmastarGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx20_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx21:
+.incbin "baserom.gba", 0xB02304, 0x60
+sOmastarGfx21_1:
+.incbin "baserom.gba", 0xB02364, 0xE0
+sOmastarSprites21:
+ax_sprite sOmastarGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx21_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx22:
+.incbin "baserom.gba", 0xB0246C, 0xC0
+sOmastarSprites22:
+ax_sprite sOmastarGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmastarGfx23:
+.incbin "baserom.gba", 0xB02544, 0x160
+sOmastarGfx23_1:
+.incbin "baserom.gba", 0xB026A4, 0x20
+sOmastarSprites23:
+ax_sprite sOmastarGfx23, 0x160
+ax_sprite 0, 0x60
+ax_sprite sOmastarGfx23_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOmastarGfx24:
+.incbin "baserom.gba", 0xB026EC, 0x40
+sOmastarGfx24_1:
+.incbin "baserom.gba", 0xB0272C, 0xE0
+sOmastarSprites24:
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx24_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx25:
+.incbin "baserom.gba", 0xB0283C, 0x180
+sOmastarGfx25_1:
+.incbin "baserom.gba", 0xB029BC, 0x20
+sOmastarSprites25:
+ax_sprite sOmastarGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx25_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmastarGfx26:
+.incbin "baserom.gba", 0xB02A04, 0x100
+sOmastarGfx26_1:
+.incbin "baserom.gba", 0xB02B04, 0x60
+sOmastarSprites26:
+ax_sprite sOmastarGfx26, 0x100
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx26_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sOmastarGfx27:
+.incbin "baserom.gba", 0xB02B8C, 0x60
+sOmastarGfx27_1:
+.incbin "baserom.gba", 0xB02BEC, 0x60
+sOmastarGfx27_2:
+.incbin "baserom.gba", 0xB02C4C, 0x60
+sOmastarSprites27:
+ax_sprite sOmastarGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx28:
+.incbin "baserom.gba", 0xB02CE4, 0x60
+sOmastarGfx28_1:
+.incbin "baserom.gba", 0xB02D44, 0x60
+sOmastarGfx28_2:
+.incbin "baserom.gba", 0xB02DA4, 0x60
+sOmastarSprites28:
+ax_sprite sOmastarGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx29:
+.incbin "baserom.gba", 0xB02E3C, 0x60
+sOmastarGfx29_1:
+.incbin "baserom.gba", 0xB02E9C, 0xE0
+sOmastarSprites29:
+ax_sprite sOmastarGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOmastarGfx29_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOmastarGfx30:
+.incbin "baserom.gba", 0xB02FA4, 0xC0
+sOmastarSprites30:
+ax_sprite sOmastarGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOmastarGfx31:
+.incbin "baserom.gba", 0xB0307C, 0x200
+sOmastarSprites31:
+ax_sprite sOmastarGfx31, 0x200
+ax_sprite_terminator
+sOmastarGfx32:
+.incbin "baserom.gba", 0xB0328C, 0x200
+sOmastarSprites32:
+ax_sprite sOmastarGfx32, 0x200
+ax_sprite_terminator
+sOmastarGfx33:
+.incbin "baserom.gba", 0xB0349C, 0x200
+sOmastarSprites33:
+ax_sprite sOmastarGfx33, 0x200
+ax_sprite_terminator
+sOmastarGfx34:
+.incbin "baserom.gba", 0xB036AC, 0x200
+sOmastarSprites34:
+ax_sprite sOmastarGfx34, 0x200
+ax_sprite_terminator
+sOmastarGfx35:
+.incbin "baserom.gba", 0xB038BC, 0x200
+sOmastarSprites35:
+ax_sprite sOmastarGfx35, 0x200
+ax_sprite_terminator
+sOmastarGfx36:
+.incbin "baserom.gba", 0xB03ACC, 0x200
+sOmastarSprites36:
+ax_sprite sOmastarGfx36, 0x200
+ax_sprite_terminator
+sOmastarGfx37:
+.incbin "baserom.gba", 0xB03CDC, 0x200
+sOmastarSprites37:
+ax_sprite sOmastarGfx37, 0x200
+ax_sprite_terminator
+sAxPosesOmastar:
+.4byte sOmastarPose1
+.4byte sOmastarPose2
+.4byte sOmastarPose3
+.4byte sOmastarPose4
+.4byte sOmastarPose5
+.4byte sOmastarPose6
+.4byte sOmastarPose7
+.4byte sOmastarPose8
+.4byte sOmastarPose9
+.4byte sOmastarPose10
+.4byte sOmastarPose11
+.4byte sOmastarPose12
+.4byte sOmastarPose13
+.4byte sOmastarPose14
+.4byte sOmastarPose15
+.4byte sOmastarPose16
+.4byte sOmastarPose17
+.4byte sOmastarPose18
+.4byte sOmastarPose19
+.4byte sOmastarPose20
+.4byte sOmastarPose21
+.4byte sOmastarPose22
+.4byte sOmastarPose23
+.4byte sOmastarPose24
+.4byte sOmastarPose25
+.4byte sOmastarPose26
+.4byte sOmastarPose27
+.4byte sOmastarPose28
+.4byte sOmastarPose29
+.4byte sOmastarPose30
+.4byte sOmastarPose31
+.4byte sOmastarPose32
+.4byte sOmastarPose33
+.4byte sOmastarPose34
+.4byte sOmastarPose35
+.4byte sOmastarPose36
+.4byte sOmastarPose37
+.4byte sOmastarPose38
+.4byte sOmastarPose39
+.4byte sOmastarPose40
+.4byte sOmastarPose41
+.4byte sOmastarPose42
+.4byte sOmastarPose43
+.4byte sOmastarPose44
+.4byte sOmastarPose45
+.4byte sOmastarPose46
+.4byte sOmastarPose47
+.4byte sOmastarPose48
+.4byte sOmastarPose49
+.4byte sOmastarPose50
+.4byte sOmastarPose51
+.4byte sOmastarPose52
+.4byte sOmastarPose53
+.4byte sOmastarPose54
+.4byte sOmastarPose55
+.4byte sOmastarPose56
+.4byte sOmastarPose57
+.4byte sOmastarPose58
+.4byte sOmastarPose59
+.4byte sOmastarPose60
+.4byte sOmastarPose61
+.4byte sOmastarPose62
+.4byte sOmastarPose63
+.4byte sOmastarPose64
+.4byte sOmastarPose65
+.4byte sOmastarPose66
+.4byte sOmastarPose67
+.4byte sOmastarPose68
+.4byte sOmastarPose69
+.4byte sOmastarPose70
+.4byte sOmastarPose71
+.4byte sOmastarPose72
+.4byte sOmastarPose73
+.4byte sOmastarPose74
+.4byte sOmastarPose75
+.4byte sOmastarPose76
+.4byte sOmastarPose77
+.4byte sOmastarPose78
+.4byte sOmastarPose79
+.4byte sOmastarPose80
+.4byte sOmastarPose81
+.4byte sOmastarPose82
+.4byte sOmastarPose83
+.4byte sOmastarPose84
+.4byte sOmastarPose85
+.4byte sOmastarPose86
+.4byte sOmastarPose87
+.4byte sOmastarPose88
+.4byte sOmastarPose89
+.4byte sOmastarPose90
+.4byte sOmastarPose91
+.4byte sOmastarPose92
+.4byte sOmastarPose93
+.4byte sOmastarPose94
+.4byte sOmastarPose95
+.4byte sOmastarPose96
+.4byte sOmastarPose97
+.4byte sOmastarPose98
+.4byte sOmastarPose99
+.4byte sOmastarPose100
+.4byte sOmastarPose101
+.4byte sOmastarPose102
+.4byte sOmastarPose103
+.4byte sOmastarPose104
+.4byte sOmastarPose105
+.4byte sOmastarPose106
+.4byte sOmastarPose107
+.4byte sOmastarPose108
+.4byte sOmastarPose109
+.4byte sOmastarPose110
+.4byte sOmastarPose111
+.4byte sOmastarPose112
+.4byte sOmastarPose113
+.4byte sOmastarPose114
+.4byte sOmastarPose115
+.4byte sOmastarPose116
+.4byte sOmastarPose117
+.4byte sOmastarPose118
+.4byte sOmastarPose119
+.4byte sOmastarPose120
+.4byte sOmastarPose121
+.4byte sOmastarPose122
+.4byte sOmastarPose123
+.4byte sOmastarPose124
+.4byte sOmastarPose125
+.4byte sOmastarPose126
+.4byte sOmastarPose127
+.4byte sOmastarPose128
+.4byte sOmastarPose129
+.4byte sOmastarPose130
+.4byte sOmastarPose131
+.4byte sOmastarPose132
+.4byte sOmastarPose133
+.4byte sOmastarPose134
+.4byte sOmastarPose135
+.4byte sOmastarPose136
+.4byte sOmastarPose137
+.4byte sOmastarPose138
+.4byte sOmastarPose139
+.4byte sOmastarPose140
+.4byte sOmastarPose141
+.4byte sOmastarPose142
+.4byte sOmastarPose143
+.4byte sOmastarPose144
+.4byte sOmastarPose145
+.4byte sOmastarPose146
+.4byte sOmastarPose147
+.4byte sOmastarPose148
+.4byte sOmastarPose149
+.4byte sOmastarPose150
+.4byte sOmastarPose151
+.4byte sOmastarPose152
+.4byte sOmastarPose153
+.4byte sOmastarPose154
+.4byte sOmastarPose155
+.4byte sOmastarPose156
+.4byte sOmastarPose157
+.4byte sOmastarPose158
+.4byte sOmastarPose159
+.4byte sOmastarPose160
+.4byte sOmastarPose161
+.4byte sOmastarPose162
+.4byte sOmastarPose163
+.4byte sOmastarPose164
+.4byte sOmastarPose165
+.4byte sOmastarPose166
+.4byte sOmastarPose167
+.4byte sOmastarPose168
+.4byte sOmastarPose169
+.4byte sOmastarPose170
+.4byte sOmastarPose171
+.4byte sOmastarPose172
+.4byte sOmastarPose173
+.4byte sOmastarPose174
+.4byte sOmastarPose175
+.4byte sOmastarPose176
+.4byte sOmastarPose177
+.4byte sOmastarPose178
+.4byte sOmastarPose179
+.4byte sOmastarPose180
+.4byte sOmastarPose181
+.4byte sOmastarPose182
+.4byte sOmastarPose183
+.4byte sOmastarPose184
+.4byte sOmastarPose185
+.4byte sOmastarPose186
+.4byte sOmastarPose187
+.4byte sOmastarPose188
+.4byte sOmastarPose189
+.4byte sOmastarPose190
+.4byte sOmastarPose191
+.4byte sOmastarPose192
+.4byte sOmastarPose193
+.4byte sOmastarPose194
+.4byte sOmastarPose195
+.4byte sOmastarPose196
+.4byte sOmastarPose197
+.4byte sOmastarPose198
+.4byte sOmastarPose199
+.4byte sOmastarPose200
+.4byte sOmastarPose201
+.4byte sOmastarPose202
+.4byte sOmastarPose203
+.4byte sOmastarPose204
+.4byte sOmastarPose205
+.4byte sOmastarPose206
+.4byte sOmastarPose207
+.4byte sOmastarPose208
+.4byte sOmastarPose209
+.4byte sOmastarPose210
+sAxPositionsOmastar:
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte    0,   -1, 	  -9,   -6, 	   7,  -10, 	   0,  -10
+.2byte    0,   -1, 	  -7,  -10, 	   9,   -6, 	   0,  -10
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    6,   -2, 	  14,   -8, 	  -5,   -7, 	   1,  -10
+.2byte    6,   -2, 	   8,  -14, 	   0,   -1, 	   0,  -10
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte   10,   -6, 	  15,  -11, 	   3,   -7, 	   1,   -9
+.2byte   10,   -7, 	   8,  -13, 	  13,   -5, 	   1,   -8
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte    6,   -8, 	   5,  -16, 	   9,  -12, 	   1,   -9
+.2byte    7,   -9, 	   5,  -14, 	  13,   -8, 	   1,   -9
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,   -8, 	   8,  -11, 	  -7,  -13, 	   0,  -11
+.2byte    0,   -8, 	   7,  -13, 	  -8,  -14, 	   0,  -11
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte   -6,   -8, 	  -5,  -16, 	  -9,  -12, 	  -1,   -9
+.2byte   -7,   -9, 	  -5,  -14, 	 -13,   -8, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,   -6, 	 -15,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -13, 	 -13,   -5, 	  -1,   -8
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte   -6,   -2, 	 -14,   -8, 	   5,   -7, 	  -1,  -10
+.2byte   -6,   -2, 	  -8,  -14, 	   0,   -1, 	   0,  -10
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte    0,   -1, 	  -9,   -6, 	   7,  -10, 	   0,  -10
+.2byte    0,   -1, 	  -7,  -10, 	   9,   -6, 	   0,  -10
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    6,   -2, 	  14,   -8, 	  -5,   -7, 	   1,  -10
+.2byte    6,   -2, 	   8,  -14, 	   0,   -1, 	   0,  -10
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte   10,   -6, 	  15,  -11, 	   3,   -7, 	   1,   -9
+.2byte   10,   -7, 	   8,  -13, 	  13,   -5, 	   1,   -8
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte    6,   -8, 	   5,  -16, 	   9,  -12, 	   1,   -9
+.2byte    7,   -9, 	   5,  -14, 	  13,   -8, 	   1,   -9
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,   -8, 	   8,  -11, 	  -7,  -13, 	   0,  -11
+.2byte    0,   -8, 	   7,  -13, 	  -8,  -14, 	   0,  -11
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte   -6,   -8, 	  -5,  -16, 	  -9,  -12, 	  -1,   -9
+.2byte   -7,   -9, 	  -5,  -14, 	 -13,   -8, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,   -6, 	 -15,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -13, 	 -13,   -5, 	  -1,   -8
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte   -6,   -2, 	 -14,   -8, 	   5,   -7, 	  -1,  -10
+.2byte   -6,   -2, 	  -8,  -14, 	   0,   -1, 	   0,  -10
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte    0,   -1, 	  -9,   -6, 	   7,  -10, 	   0,  -10
+.2byte    0,   -1, 	  -7,  -10, 	   9,   -6, 	   0,  -10
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    6,   -2, 	  14,   -8, 	  -5,   -7, 	   1,  -10
+.2byte    6,   -2, 	   8,  -14, 	   0,   -1, 	   0,  -10
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte   10,   -6, 	  15,  -11, 	   3,   -7, 	   1,   -9
+.2byte   10,   -7, 	   8,  -13, 	  13,   -5, 	   1,   -8
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte    6,   -8, 	   5,  -16, 	   9,  -12, 	   1,   -9
+.2byte    7,   -9, 	   5,  -14, 	  13,   -8, 	   1,   -9
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,   -8, 	   8,  -11, 	  -7,  -13, 	   0,  -11
+.2byte    0,   -8, 	   7,  -13, 	  -8,  -14, 	   0,  -11
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte   -6,   -8, 	  -5,  -16, 	  -9,  -12, 	  -1,   -9
+.2byte   -7,   -9, 	  -5,  -14, 	 -13,   -8, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,   -6, 	 -15,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -13, 	 -13,   -5, 	  -1,   -8
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte   -6,   -2, 	 -14,   -8, 	   5,   -7, 	  -1,  -10
+.2byte   -6,   -2, 	  -8,  -14, 	   0,   -1, 	   0,  -10
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte    0,   -1, 	  -9,   -6, 	   7,  -10, 	   0,  -10
+.2byte    0,   -1, 	  -7,  -10, 	   9,   -6, 	   0,  -10
+.2byte    0,   -2, 	  -9,   -2, 	   9,   -2, 	   0,   -9
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    6,   -2, 	  14,   -8, 	  -5,   -7, 	   1,  -10
+.2byte    6,   -2, 	   8,  -14, 	   0,   -1, 	   0,  -10
+.2byte    5,   -3, 	  14,   -7, 	   2,    0, 	   0,   -9
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte   10,   -6, 	  15,  -11, 	   3,   -7, 	   1,   -9
+.2byte   10,   -7, 	   8,  -13, 	  13,   -5, 	   1,   -8
+.2byte   11,   -6, 	  15,  -10, 	  13,   -2, 	   2,   -8
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte    6,   -8, 	   5,  -16, 	   9,  -12, 	   1,   -9
+.2byte    7,   -9, 	   5,  -14, 	  13,   -8, 	   1,   -9
+.2byte    6,   -8, 	   5,  -15, 	  13,  -10, 	   2,   -8
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,   -8, 	   8,  -11, 	  -7,  -13, 	   0,  -11
+.2byte    0,   -8, 	   7,  -13, 	  -8,  -14, 	   0,  -11
+.2byte    0,   -7, 	  11,  -12, 	 -11,  -12, 	   0,  -12
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte   -6,   -8, 	  -5,  -16, 	  -9,  -12, 	  -1,   -9
+.2byte   -7,   -9, 	  -5,  -14, 	 -13,   -8, 	  -1,   -9
+.2byte   -6,   -8, 	  -5,  -15, 	 -13,  -10, 	  -2,   -8
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,   -6, 	 -15,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -13, 	 -13,   -5, 	  -1,   -8
+.2byte  -11,   -6, 	 -15,  -10, 	 -13,   -2, 	  -2,   -8
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte   -6,   -2, 	 -14,   -8, 	   5,   -7, 	  -1,  -10
+.2byte   -6,   -2, 	  -8,  -14, 	   0,   -1, 	   0,  -10
+.2byte   -5,   -3, 	 -14,   -7, 	  -2,    0, 	   0,   -9
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte    0,   -4, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte    0,   -1, 	  -4,   -5, 	   4,   -5, 	   0,   -9
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    6,   -5, 	   9,  -16, 	  -1,  -11, 	  -2,  -10
+.2byte    2,   -2, 	   7,   -5, 	   1,   -3, 	  -1,   -8
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte   10,   -8, 	   9,  -18, 	   6,  -11, 	   1,   -9
+.2byte    4,   -2, 	   7,  -10, 	   7,   -7, 	   0,   -7
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte    6,   -8, 	   2,  -19, 	  11,  -16, 	   2,   -9
+.2byte    3,   -4, 	   2,  -11, 	   6,   -9, 	   2,   -8
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,   -8, 	   7,  -18, 	  -7,  -18, 	   0,  -12
+.2byte    0,   -4, 	   4,   -6, 	  -4,   -6, 	   0,  -10
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte   -6,   -8, 	  -2,  -19, 	 -11,  -16, 	  -2,   -9
+.2byte   -3,   -4, 	  -2,  -11, 	  -6,   -9, 	  -2,   -8
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,   -8, 	  -9,  -18, 	  -6,  -11, 	  -1,   -9
+.2byte   -4,   -2, 	  -7,  -10, 	  -7,   -7, 	   0,   -7
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte   -6,   -5, 	  -9,  -16, 	   1,  -11, 	   2,  -10
+.2byte   -2,   -2, 	  -7,   -5, 	  -1,   -3, 	   1,   -8
+.2byte   -5,   -1, 	 -10,   -1, 	  -3,    3, 	   0,   -7
+.2byte   -5,   -1, 	 -10,   -1, 	  -3,    3, 	  -1,   -8
+.2byte    0,   -4, 	  -9,   -8, 	   8,  -13, 	   0,  -10
+.2byte    5,   -6, 	  12,  -11, 	  -4,  -11, 	  -1,  -11
+.2byte    8,   -8, 	  11,  -16, 	   1,  -13, 	  -2,   -9
+.2byte    3,   -7, 	   1,  -17, 	   7,  -15, 	  -2,   -9
+.2byte    0,   -6, 	   9,  -13, 	  -8,  -17, 	   0,   -9
+.2byte   -4,   -7, 	  -2,  -17, 	  -8,  -15, 	   1,   -9
+.2byte   -9,   -8, 	 -12,  -16, 	  -2,  -13, 	   1,   -9
+.2byte   -6,   -6, 	 -13,  -11, 	   3,  -11, 	   0,  -11
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte    0,   -4, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    6,   -4, 	   9,  -15, 	  -1,  -10, 	  -2,   -9
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte   10,   -8, 	   9,  -18, 	   6,  -11, 	   1,   -9
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte    6,   -8, 	   2,  -19, 	  11,  -16, 	   2,   -9
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,   -8, 	   7,  -18, 	  -7,  -18, 	   0,  -12
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte   -6,   -8, 	  -2,  -19, 	 -11,  -16, 	  -2,   -9
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,   -8, 	  -9,  -18, 	  -6,  -11, 	  -1,   -9
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte   -6,   -4, 	  -9,  -15, 	   1,  -10, 	   2,   -9
+.2byte    0,   -4, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte   -6,   -5, 	  -9,  -16, 	   1,  -11, 	   2,  -10
+.2byte  -10,   -8, 	  -9,  -18, 	  -6,  -11, 	  -1,   -9
+.2byte   -6,   -8, 	  -2,  -19, 	 -11,  -16, 	  -2,   -9
+.2byte    0,   -8, 	   7,  -18, 	  -7,  -18, 	   0,  -12
+.2byte    6,   -8, 	   2,  -19, 	  11,  -16, 	   2,   -9
+.2byte   10,   -8, 	   9,  -18, 	   6,  -11, 	   1,   -9
+.2byte    6,   -5, 	   9,  -16, 	  -1,  -11, 	  -2,  -10
+.2byte    0,   -2, 	  -9,   -2, 	   9,   -2, 	   0,   -9
+.2byte    5,   -3, 	  14,   -7, 	   2,    0, 	   0,   -9
+.2byte    9,   -6, 	  13,  -10, 	  11,   -2, 	   0,   -8
+.2byte    5,   -8, 	   4,  -15, 	  12,  -10, 	   1,   -8
+.2byte    0,   -5, 	  11,  -10, 	 -11,  -10, 	   0,  -10
+.2byte   -6,   -8, 	  -5,  -15, 	 -13,  -10, 	  -2,   -8
+.2byte   -9,   -6, 	 -13,  -10, 	 -11,   -2, 	   0,   -8
+.2byte   -5,   -3, 	 -14,   -7, 	  -2,    0, 	   0,   -9
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte    0,   -5, 	  -7,  -13, 	   7,  -13, 	   0,  -11
+.2byte    0,   -1, 	  -9,   -6, 	   7,  -10, 	   0,  -10
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    6,   -5, 	   9,  -16, 	  -1,  -11, 	  -2,  -10
+.2byte    6,   -2, 	  14,   -8, 	  -5,   -7, 	   1,  -10
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte   10,   -8, 	   9,  -18, 	   6,  -11, 	   1,   -9
+.2byte   10,   -6, 	  15,  -11, 	   3,   -7, 	   1,   -9
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte    6,   -8, 	   2,  -19, 	  11,  -16, 	   2,   -9
+.2byte    6,   -8, 	   5,  -16, 	   9,  -12, 	   1,   -9
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,   -8, 	   7,  -18, 	  -7,  -18, 	   0,  -12
+.2byte    0,   -8, 	   8,  -11, 	  -7,  -13, 	   0,  -11
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte   -6,   -8, 	  -2,  -19, 	 -11,  -16, 	  -2,   -9
+.2byte   -6,   -8, 	  -5,  -16, 	  -9,  -12, 	  -1,   -9
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte  -10,   -8, 	  -9,  -18, 	  -6,  -11, 	  -1,   -9
+.2byte  -10,   -6, 	 -15,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte   -6,   -5, 	  -9,  -16, 	   1,  -11, 	   2,  -10
+.2byte   -6,   -2, 	 -14,   -8, 	   5,   -7, 	  -1,  -10
+.2byte    0,   -4, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte   -6,   -5, 	  -9,  -16, 	   1,  -11, 	   2,  -10
+.2byte   -8,   -8, 	  -7,  -18, 	  -4,  -11, 	   1,   -9
+.2byte   -5,   -8, 	  -1,  -19, 	 -10,  -16, 	  -1,   -9
+.2byte    0,   -8, 	   7,  -18, 	  -7,  -18, 	   0,  -12
+.2byte    5,   -8, 	   1,  -19, 	  10,  -16, 	   1,   -9
+.2byte    8,   -8, 	   7,  -18, 	   4,  -11, 	  -1,   -9
+.2byte    6,   -5, 	   9,  -16, 	  -1,  -11, 	  -2,  -10
+.2byte    0,   -2, 	  -8,  -10, 	   8,  -10, 	   0,   -9
+.2byte   -6,   -3, 	 -10,  -13, 	   3,   -8, 	   0,  -10
+.2byte  -10,   -7, 	  -8,  -16, 	  -5,   -8, 	  -1,   -8
+.2byte   -6,   -7, 	  -4,  -17, 	 -12,  -12, 	  -2,   -9
+.2byte    0,   -8, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    6,   -7, 	   4,  -17, 	  12,  -12, 	   2,   -9
+.2byte   10,   -7, 	   8,  -16, 	   5,   -8, 	   1,   -8
+.2byte    6,   -3, 	  10,  -13, 	  -3,   -8, 	   0,  -10
+sOmastarAnimTable1:
+.4byte sOmastarAnims_1_1
+.4byte sOmastarAnims_1_2
+.4byte sOmastarAnims_1_3
+.4byte sOmastarAnims_1_4
+.4byte sOmastarAnims_1_5
+.4byte sOmastarAnims_1_6
+.4byte sOmastarAnims_1_7
+.4byte sOmastarAnims_1_8
+sOmastarAnimTable2:
+.4byte sOmastarAnims_2_1
+.4byte sOmastarAnims_2_2
+.4byte sOmastarAnims_2_3
+.4byte sOmastarAnims_2_4
+.4byte sOmastarAnims_2_5
+.4byte sOmastarAnims_2_6
+.4byte sOmastarAnims_2_7
+.4byte sOmastarAnims_2_8
+sOmastarAnimTable3:
+.4byte sOmastarAnims_3_1
+.4byte sOmastarAnims_3_2
+.4byte sOmastarAnims_3_3
+.4byte sOmastarAnims_3_4
+.4byte sOmastarAnims_3_5
+.4byte sOmastarAnims_3_6
+.4byte sOmastarAnims_3_7
+.4byte sOmastarAnims_3_8
+sOmastarAnimTable4:
+.4byte sOmastarAnims_4_1
+.4byte sOmastarAnims_4_2
+.4byte sOmastarAnims_4_3
+.4byte sOmastarAnims_4_4
+.4byte sOmastarAnims_4_5
+.4byte sOmastarAnims_4_6
+.4byte sOmastarAnims_4_7
+.4byte sOmastarAnims_4_8
+sOmastarAnimTable5:
+.4byte sOmastarAnims_5_1
+.4byte sOmastarAnims_5_2
+.4byte sOmastarAnims_5_3
+.4byte sOmastarAnims_5_4
+.4byte sOmastarAnims_5_5
+.4byte sOmastarAnims_5_6
+.4byte sOmastarAnims_5_7
+.4byte sOmastarAnims_5_8
+sOmastarAnimTable6:
+.4byte sOmastarAnims_6_1
+.4byte sOmastarAnims_6_1
+.4byte sOmastarAnims_6_1
+.4byte sOmastarAnims_6_1
+.4byte sOmastarAnims_6_1
+.4byte sOmastarAnims_6_1
+.4byte sOmastarAnims_6_1
+.4byte sOmastarAnims_6_1
+sOmastarAnimTable7:
+.4byte sOmastarAnims_7_1
+.4byte sOmastarAnims_7_2
+.4byte sOmastarAnims_7_3
+.4byte sOmastarAnims_7_4
+.4byte sOmastarAnims_7_5
+.4byte sOmastarAnims_7_6
+.4byte sOmastarAnims_7_7
+.4byte sOmastarAnims_7_8
+sOmastarAnimTable8:
+.4byte sOmastarAnims_8_1
+.4byte sOmastarAnims_8_2
+.4byte sOmastarAnims_8_3
+.4byte sOmastarAnims_8_4
+.4byte sOmastarAnims_8_5
+.4byte sOmastarAnims_8_6
+.4byte sOmastarAnims_8_7
+.4byte sOmastarAnims_8_8
+sOmastarAnimTable9:
+.4byte sOmastarAnims_9_1
+.4byte sOmastarAnims_9_2
+.4byte sOmastarAnims_9_3
+.4byte sOmastarAnims_9_4
+.4byte sOmastarAnims_9_5
+.4byte sOmastarAnims_9_6
+.4byte sOmastarAnims_9_7
+.4byte sOmastarAnims_9_8
+sOmastarAnimTable10:
+.4byte sOmastarAnims_10_1
+.4byte sOmastarAnims_10_2
+.4byte sOmastarAnims_10_3
+.4byte sOmastarAnims_10_4
+.4byte sOmastarAnims_10_5
+.4byte sOmastarAnims_10_6
+.4byte sOmastarAnims_10_7
+.4byte sOmastarAnims_10_8
+sOmastarAnimTable11:
+.4byte sOmastarAnims_11_1
+.4byte sOmastarAnims_11_2
+.4byte sOmastarAnims_11_3
+.4byte sOmastarAnims_11_4
+.4byte sOmastarAnims_11_5
+.4byte sOmastarAnims_11_6
+.4byte sOmastarAnims_11_7
+.4byte sOmastarAnims_11_8
+sOmastarAnimTable12:
+.4byte sOmastarAnims_12_1
+.4byte sOmastarAnims_12_2
+.4byte sOmastarAnims_12_3
+.4byte sOmastarAnims_12_4
+.4byte sOmastarAnims_12_5
+.4byte sOmastarAnims_12_6
+.4byte sOmastarAnims_12_7
+.4byte sOmastarAnims_12_8
+sOmastarAnimTable13:
+.4byte sOmastarAnims_13_1
+.4byte sOmastarAnims_13_2
+.4byte sOmastarAnims_13_3
+.4byte sOmastarAnims_13_4
+.4byte sOmastarAnims_13_5
+.4byte sOmastarAnims_13_6
+.4byte sOmastarAnims_13_7
+.4byte sOmastarAnims_13_8
+sAxAnimationsOmastar:
+.4byte sOmastarAnimTable1
+.4byte sOmastarAnimTable2
+.4byte sOmastarAnimTable3
+.4byte sOmastarAnimTable4
+.4byte sOmastarAnimTable5
+.4byte sOmastarAnimTable6
+.4byte sOmastarAnimTable7
+.4byte sOmastarAnimTable8
+.4byte sOmastarAnimTable9
+.4byte sOmastarAnimTable10
+.4byte sOmastarAnimTable11
+.4byte sOmastarAnimTable12
+.4byte sOmastarAnimTable13
+sAxSpritesOmastar:
+.4byte sOmastarSprites1
+.4byte sOmastarSprites2
+.4byte sOmastarSprites3
+.4byte sOmastarSprites4
+.4byte sOmastarSprites5
+.4byte sOmastarSprites6
+.4byte sOmastarSprites7
+.4byte sOmastarSprites8
+.4byte sOmastarSprites9
+.4byte sOmastarSprites10
+.4byte sOmastarSprites11
+.4byte sOmastarSprites12
+.4byte sOmastarSprites13
+.4byte sOmastarSprites14
+.4byte sOmastarSprites15
+.4byte sOmastarSprites16
+.4byte sOmastarSprites17
+.4byte sOmastarSprites18
+.4byte sOmastarSprites19
+.4byte sOmastarSprites20
+.4byte sOmastarSprites21
+.4byte sOmastarSprites22
+.4byte sOmastarSprites23
+.4byte sOmastarSprites24
+.4byte sOmastarSprites25
+.4byte sOmastarSprites26
+.4byte sOmastarSprites27
+.4byte sOmastarSprites28
+.4byte sOmastarSprites29
+.4byte sOmastarSprites30
+.4byte sOmastarSprites31
+.4byte sOmastarSprites32
+.4byte sOmastarSprites33
+.4byte sOmastarSprites34
+.4byte sOmastarSprites35
+.4byte sOmastarSprites36
+.4byte sOmastarSprites37
+sAxMainOmastar:
+ax_main sAxPosesOmastar, sAxAnimationsOmastar, 13, sAxSpritesOmastar, sAxPositionsOmastar

--- a/data/ax/onix.inc
+++ b/data/ax/onix.inc
@@ -1,0 +1,3204 @@
+.global gAxOnix
+gAxOnix:
+ax_siro sAxMainOnix
+sOnixPose1:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose2:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose3:
+ax_pose 2, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose4:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose5:
+ax_pose 4, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose6:
+ax_pose 5, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose7:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose8:
+ax_pose 7, 0x41c6, 0xd0f0, 0x5c00
+ax_pose 8, 0x41e6, 0x9110, 0x5c20
+ax_pose 9, 0x01e6, 0x90f0, 0x5c28
+ax_pose 10, 0x41f0, 0x90d0, 0x5c38
+ax_pose_terminator
+sOnixPose9:
+ax_pose 11, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose10:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose11:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose12:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose13:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose14:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose15:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose16:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose17:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose18:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose19:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose20:
+ax_pose 7, 0x41c6, 0xc0d0, 0x5c00
+ax_pose 8, 0x41e6, 0x80d0, 0x5c20
+ax_pose 9, 0x01e6, 0x80f0, 0x5c28
+ax_pose 10, 0x41f0, 0x8110, 0x5c38
+ax_pose_terminator
+sOnixPose21:
+ax_pose 11, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose22:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose23:
+ax_pose 4, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose24:
+ax_pose 5, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose25:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose26:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose27:
+ax_pose 2, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose28:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose29:
+ax_pose 4, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose30:
+ax_pose 5, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose31:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose32:
+ax_pose 7, 0x41c6, 0xd0f0, 0x5c00
+ax_pose 8, 0x41e6, 0x9110, 0x5c20
+ax_pose 9, 0x01e6, 0x90f0, 0x5c28
+ax_pose 10, 0x41f0, 0x90d0, 0x5c38
+ax_pose_terminator
+sOnixPose33:
+ax_pose 11, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose34:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose35:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose36:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose37:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose38:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose39:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose40:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose41:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose42:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose43:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose44:
+ax_pose 7, 0x41c6, 0xc0d0, 0x5c00
+ax_pose 8, 0x41e6, 0x80d0, 0x5c20
+ax_pose 9, 0x01e6, 0x80f0, 0x5c28
+ax_pose 10, 0x41f0, 0x8110, 0x5c38
+ax_pose_terminator
+sOnixPose45:
+ax_pose 11, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose46:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose47:
+ax_pose 4, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose48:
+ax_pose 5, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose49:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose50:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose51:
+ax_pose 2, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose52:
+ax_pose 18, 0x81c8, 0xc0ec, 0x5c00
+ax_pose_terminator
+sOnixPose53:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose54:
+ax_pose 4, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose55:
+ax_pose 5, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose56:
+ax_pose 19, 0x41dd, 0xd0e3, 0x5c00
+ax_pose 20, 0x41d5, 0x10da, 0x5c20
+ax_pose 21, 0x01dd, 0x10db, 0x5c22
+ax_pose_terminator
+sOnixPose57:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose58:
+ax_pose 7, 0x41c6, 0xd0f0, 0x5c00
+ax_pose 8, 0x41e6, 0x9110, 0x5c20
+ax_pose 9, 0x01e6, 0x90f0, 0x5c28
+ax_pose 10, 0x41f0, 0x90d0, 0x5c38
+ax_pose_terminator
+sOnixPose59:
+ax_pose 11, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose60:
+ax_pose 22, 0x41d9, 0xd0ec, 0x5c00
+ax_pose 23, 0x41f3, 0x90cc, 0x5c20
+ax_pose 24, 0x41eb, 0x10cc, 0x5c28
+ax_pose 25, 0x41f9, 0x10ec, 0x5c2a
+ax_pose_terminator
+sOnixPose61:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose62:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose63:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose64:
+ax_pose 26, 0x41c6, 0xd0e2, 0x5c00
+ax_pose 27, 0x01e6, 0x90e3, 0x5c20
+ax_pose_terminator
+sOnixPose65:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose66:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose67:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose68:
+ax_pose 28, 0x81c9, 0xc0ec, 0x5c00
+ax_pose_terminator
+sOnixPose69:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose70:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose71:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose72:
+ax_pose 26, 0x41c6, 0xc0de, 0x5c00
+ax_pose 27, 0x01e6, 0x80fd, 0x5c20
+ax_pose_terminator
+sOnixPose73:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose74:
+ax_pose 7, 0x41c6, 0xc0d0, 0x5c00
+ax_pose 8, 0x41e6, 0x80d0, 0x5c20
+ax_pose 9, 0x01e6, 0x80f0, 0x5c28
+ax_pose 10, 0x41f0, 0x8110, 0x5c38
+ax_pose_terminator
+sOnixPose75:
+ax_pose 11, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose76:
+ax_pose 22, 0x41d9, 0xc0d4, 0x5c00
+ax_pose 23, 0x41f3, 0x8114, 0x5c20
+ax_pose 24, 0x41eb, 0x0124, 0x5c28
+ax_pose 25, 0x41f9, 0x0104, 0x5c2a
+ax_pose_terminator
+sOnixPose77:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose78:
+ax_pose 4, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose79:
+ax_pose 5, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose80:
+ax_pose 19, 0x41dd, 0xc0dd, 0x5c00
+ax_pose 20, 0x41d5, 0x0116, 0x5c20
+ax_pose 21, 0x01dd, 0x011d, 0x5c22
+ax_pose_terminator
+sOnixPose81:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose82:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose83:
+ax_pose 2, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose84:
+ax_pose 18, 0x81c8, 0xc0ec, 0x5c00
+ax_pose_terminator
+sOnixPose85:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose86:
+ax_pose 4, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose87:
+ax_pose 5, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose88:
+ax_pose 19, 0x41dd, 0xd0e3, 0x5c00
+ax_pose 20, 0x41d5, 0x10da, 0x5c20
+ax_pose 21, 0x01dd, 0x10db, 0x5c22
+ax_pose_terminator
+sOnixPose89:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose90:
+ax_pose 7, 0x41c6, 0xd0f0, 0x5c00
+ax_pose 8, 0x41e6, 0x9110, 0x5c20
+ax_pose 9, 0x01e6, 0x90f0, 0x5c28
+ax_pose 10, 0x41f0, 0x90d0, 0x5c38
+ax_pose_terminator
+sOnixPose91:
+ax_pose 11, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose92:
+ax_pose 22, 0x41d9, 0xd0ec, 0x5c00
+ax_pose 23, 0x41f3, 0x90cc, 0x5c20
+ax_pose 24, 0x41eb, 0x10cc, 0x5c28
+ax_pose 25, 0x41f9, 0x10ec, 0x5c2a
+ax_pose_terminator
+sOnixPose93:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose94:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose95:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose96:
+ax_pose 26, 0x41c6, 0xd0e2, 0x5c00
+ax_pose 27, 0x01e6, 0x90e3, 0x5c20
+ax_pose_terminator
+sOnixPose97:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose98:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose99:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose100:
+ax_pose 28, 0x81c9, 0xc0ec, 0x5c00
+ax_pose_terminator
+sOnixPose101:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose102:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose103:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose104:
+ax_pose 26, 0x41c6, 0xc0de, 0x5c00
+ax_pose 27, 0x01e6, 0x80fd, 0x5c20
+ax_pose_terminator
+sOnixPose105:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose106:
+ax_pose 7, 0x41c6, 0xc0d0, 0x5c00
+ax_pose 8, 0x41e6, 0x80d0, 0x5c20
+ax_pose 9, 0x01e6, 0x80f0, 0x5c28
+ax_pose 10, 0x41f0, 0x8110, 0x5c38
+ax_pose_terminator
+sOnixPose107:
+ax_pose 11, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose108:
+ax_pose 22, 0x41d9, 0xc0d4, 0x5c00
+ax_pose 23, 0x41f3, 0x8114, 0x5c20
+ax_pose 24, 0x41eb, 0x0124, 0x5c28
+ax_pose 25, 0x41f9, 0x0104, 0x5c2a
+ax_pose_terminator
+sOnixPose109:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose110:
+ax_pose 4, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose111:
+ax_pose 5, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose112:
+ax_pose 19, 0x41dd, 0xc0dd, 0x5c00
+ax_pose 20, 0x41d5, 0x0116, 0x5c20
+ax_pose 21, 0x01dd, 0x011d, 0x5c22
+ax_pose_terminator
+sOnixPose113:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose114:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose115:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose116:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose117:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose118:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose119:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose120:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose121:
+ax_pose 29, 0x01db, 0x80ed, 0x5c00
+ax_pose 30, 0x81eb, 0x410d, 0x5c10
+ax_pose 31, 0x41fb, 0x80ed, 0x5c14
+ax_pose_terminator
+sOnixPose122:
+ax_pose 32, 0x01db, 0x80ed, 0x5c00
+ax_pose 33, 0x81eb, 0x410d, 0x5c10
+ax_pose 34, 0x41fb, 0x80ed, 0x5c14
+ax_pose_terminator
+sOnixPose123:
+ax_pose 35, 0x41f1, 0x80f0, 0x5c00
+ax_pose 36, 0x01d1, 0x80f0, 0x5c08
+ax_pose_terminator
+sOnixPose124:
+ax_pose 37, 0x41d6, 0xd0e2, 0x5c00
+ax_pose 38, 0x41f6, 0x5102, 0x5c20
+ax_pose 39, 0x41f6, 0x50e2, 0x5c24
+ax_pose_terminator
+sOnixPose125:
+ax_pose 40, 0x41f3, 0x90e7, 0x5c00
+ax_pose 41, 0x81e3, 0x50df, 0x5c08
+ax_pose 42, 0x41d3, 0xd0e7, 0x5c0c
+ax_pose_terminator
+sOnixPose126:
+ax_pose 43, 0x01f1, 0x90e1, 0x5c00
+ax_pose 44, 0x41d1, 0xd0e1, 0x5c10
+ax_pose_terminator
+sOnixPose127:
+ax_pose 45, 0x81cf, 0xc0f1, 0x5c00
+ax_pose_terminator
+sOnixPose128:
+ax_pose 43, 0x01f1, 0x80ff, 0x5c00
+ax_pose 44, 0x41d1, 0xc0df, 0x5c10
+ax_pose_terminator
+sOnixPose129:
+ax_pose 40, 0x41f3, 0x80f9, 0x5c00
+ax_pose 41, 0x81e3, 0x4119, 0x5c08
+ax_pose 42, 0x41d3, 0xc0d9, 0x5c0c
+ax_pose_terminator
+sOnixPose130:
+ax_pose 37, 0x41d6, 0xc0e2, 0x5c00
+ax_pose 38, 0x41f6, 0x40e2, 0x5c20
+ax_pose 39, 0x41f6, 0x4102, 0x5c24
+ax_pose_terminator
+sOnixPose131:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose132:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose133:
+ax_pose 2, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose134:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose135:
+ax_pose 4, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose136:
+ax_pose 5, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose137:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose138:
+ax_pose 7, 0x41c6, 0xd0f0, 0x5c00
+ax_pose 8, 0x41e6, 0x9110, 0x5c20
+ax_pose 9, 0x01e6, 0x90f0, 0x5c28
+ax_pose 10, 0x41f0, 0x90d0, 0x5c38
+ax_pose_terminator
+sOnixPose139:
+ax_pose 11, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose140:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose141:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose142:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose143:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose144:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose145:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose146:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose147:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose148:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose149:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose150:
+ax_pose 7, 0x41c6, 0xc0d0, 0x5c00
+ax_pose 8, 0x41e6, 0x80d0, 0x5c20
+ax_pose 9, 0x01e6, 0x80f0, 0x5c28
+ax_pose 10, 0x41f0, 0x8110, 0x5c38
+ax_pose_terminator
+sOnixPose151:
+ax_pose 11, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose152:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose153:
+ax_pose 4, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose154:
+ax_pose 5, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose155:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose156:
+ax_pose 4, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose157:
+ax_pose 7, 0x41c6, 0xc0d0, 0x5c00
+ax_pose 8, 0x41e6, 0x80d0, 0x5c20
+ax_pose 9, 0x01e6, 0x80f0, 0x5c28
+ax_pose 10, 0x41f0, 0x8110, 0x5c38
+ax_pose_terminator
+sOnixPose158:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose159:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose160:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose161:
+ax_pose 7, 0x41c6, 0xd0f0, 0x5c00
+ax_pose 8, 0x41e6, 0x9110, 0x5c20
+ax_pose 9, 0x01e6, 0x90f0, 0x5c28
+ax_pose 10, 0x41f0, 0x90d0, 0x5c38
+ax_pose_terminator
+sOnixPose162:
+ax_pose 4, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose163:
+ax_pose 18, 0x81c8, 0xc0ec, 0x5c00
+ax_pose_terminator
+sOnixPose164:
+ax_pose 19, 0x41dd, 0xd0e3, 0x5c00
+ax_pose 20, 0x41d5, 0x10da, 0x5c20
+ax_pose 21, 0x01dd, 0x10db, 0x5c22
+ax_pose_terminator
+sOnixPose165:
+ax_pose 22, 0x41d9, 0xd0ec, 0x5c00
+ax_pose 23, 0x41f3, 0x90cc, 0x5c20
+ax_pose 24, 0x41eb, 0x10cc, 0x5c28
+ax_pose 25, 0x41f9, 0x10ec, 0x5c2a
+ax_pose_terminator
+sOnixPose166:
+ax_pose 26, 0x41c6, 0xd0e2, 0x5c00
+ax_pose 27, 0x01e6, 0x90e3, 0x5c20
+ax_pose_terminator
+sOnixPose167:
+ax_pose 28, 0x81c9, 0xc0ec, 0x5c00
+ax_pose_terminator
+sOnixPose168:
+ax_pose 26, 0x41c6, 0xc0de, 0x5c00
+ax_pose 27, 0x01e6, 0x80fd, 0x5c20
+ax_pose_terminator
+sOnixPose169:
+ax_pose 22, 0x41d9, 0xc0d4, 0x5c00
+ax_pose 23, 0x41f3, 0x8114, 0x5c20
+ax_pose 24, 0x41eb, 0x0124, 0x5c28
+ax_pose 25, 0x41f9, 0x0104, 0x5c2a
+ax_pose_terminator
+sOnixPose170:
+ax_pose 19, 0x41dd, 0xc0dd, 0x5c00
+ax_pose 20, 0x41d5, 0x0116, 0x5c20
+ax_pose 21, 0x01dd, 0x011d, 0x5c22
+ax_pose_terminator
+sOnixPose171:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose172:
+ax_pose 2, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose173:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose174:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose175:
+ax_pose 5, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose176:
+ax_pose 4, 0x01c6, 0xd0de, 0x5c00
+ax_pose_terminator
+sOnixPose177:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose178:
+ax_pose 11, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose179:
+ax_pose 7, 0x41c6, 0xd0f0, 0x5c00
+ax_pose 8, 0x41e6, 0x9110, 0x5c20
+ax_pose 9, 0x01e6, 0x90f0, 0x5c28
+ax_pose 10, 0x41f0, 0x90d0, 0x5c38
+ax_pose_terminator
+sOnixPose180:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose181:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose182:
+ax_pose 13, 0x01c6, 0xd0dc, 0x5c00
+ax_pose_terminator
+sOnixPose183:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose184:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose185:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose186:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose187:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose188:
+ax_pose 13, 0x01c6, 0xc0e4, 0x5c00
+ax_pose_terminator
+sOnixPose189:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose190:
+ax_pose 11, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose191:
+ax_pose 7, 0x41c6, 0xc0d0, 0x5c00
+ax_pose 8, 0x41e6, 0x80d0, 0x5c20
+ax_pose 9, 0x01e6, 0x80f0, 0x5c28
+ax_pose 10, 0x41f0, 0x8110, 0x5c38
+ax_pose_terminator
+sOnixPose192:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose193:
+ax_pose 5, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose194:
+ax_pose 4, 0x01c6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sOnixPose195:
+ax_pose 2, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose196:
+ax_pose 5, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose197:
+ax_pose 11, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose198:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose199:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose200:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose201:
+ax_pose 11, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose202:
+ax_pose 5, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose203:
+ax_pose 0, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose204:
+ax_pose 3, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose205:
+ax_pose 6, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose206:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose207:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sOnixPose208:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose209:
+ax_pose 6, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sOnixPose210:
+ax_pose 3, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+.align 2
+sOnixAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 25, 0, 25,
+ax_anim 2, 1, 25, 1, 25, 1, 25,
+ax_anim 2, 0, 25, 0, 25, 0, 25,
+ax_anim 2, 0, 25, 1, 25, 1, 25,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sOnixAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 23, 23, 23, 23,
+ax_anim 2, 1, 28, 22, 24, 22, 24,
+ax_anim 2, 0, 28, 23, 23, 23, 23,
+ax_anim 2, 0, 28, 22, 24, 22, 24,
+ax_anim 2, 0, 27, 12, 12, 12, 12,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sOnixAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 1, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 0, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 12, 0, 12, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sOnixAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 34, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 22, -20, 22, -20,
+ax_anim 2, 1, 34, 21, -21, 21, -21,
+ax_anim 2, 0, 34, 22, -20, 22, -20,
+ax_anim 2, 0, 34, 21, -21, 21, -21,
+ax_anim 2, 0, 33, 12, -12, 12, -12,
+ax_anim 2, 0, 35, 6, -6, 6, -6,
+ax_anim_terminator
+sOnixAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 1, 37, -1, -20, 0, -21,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 0, 37, -1, -20, 0, -21,
+ax_anim 2, 0, 36, 0, -12, 0, -6,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim_terminator
+sOnixAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 40, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -22, -20, -22, -20,
+ax_anim 2, 1, 40, -21, -21, -21, -21,
+ax_anim 2, 0, 40, -22, -20, -22, -20,
+ax_anim 2, 0, 40, -21, -21, -21, -21,
+ax_anim 2, 0, 39, -12, -12, -12, -12,
+ax_anim 2, 0, 41, -6, -6, -6, -6,
+ax_anim_terminator
+sOnixAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 1, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 0, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -12, 0, -12, 0,
+ax_anim 2, 0, 44, -6, 0, -6, 0,
+ax_anim_terminator
+sOnixAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -23, 23, -23, 23,
+ax_anim 2, 1, 46, -22, 24, -22, 24,
+ax_anim 2, 0, 46, -23, 23, -23, 23,
+ax_anim 2, 0, 46, -22, 24, -22, 24,
+ax_anim 2, 0, 45, -12, 12, -12, 12,
+ax_anim 2, 0, 47, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOnixAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 6, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 25, 0, 25,
+ax_anim 2, 1, 49, 1, 25, 1, 25,
+ax_anim 2, 0, 49, 0, 25, 0, 25,
+ax_anim 2, 0, 49, 1, 25, 1, 25,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 6, 0, 6,
+ax_anim_terminator
+sOnixAnims_3_2:
+ax_anim 2, 0, 54, -1, -1, -1, -1,
+ax_anim 6, 0, 54, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 23, 23, 23, 23,
+ax_anim 2, 1, 53, 22, 24, 22, 24,
+ax_anim 2, 0, 53, 23, 23, 23, 23,
+ax_anim 2, 0, 53, 22, 24, 22, 24,
+ax_anim 2, 0, 52, 12, 12, 12, 12,
+ax_anim 2, 0, 54, 6, 6, 6, 6,
+ax_anim_terminator
+sOnixAnims_3_3:
+ax_anim 2, 0, 58, -1, 0, -1, 0,
+ax_anim 6, 0, 58, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 4, 0, 4, 0,
+ax_anim 1, 0, 57, 10, 0, 10, 0,
+ax_anim 2, 0, 57, 23, 0, 23, 0,
+ax_anim 2, 1, 57, 23, 1, 23, 1,
+ax_anim 2, 0, 57, 23, 0, 23, 0,
+ax_anim 2, 0, 57, 23, 1, 23, 1,
+ax_anim 2, 0, 56, 12, 0, 12, 0,
+ax_anim 2, 0, 58, 6, 0, 6, 0,
+ax_anim_terminator
+sOnixAnims_3_4:
+ax_anim 2, 0, 62, -1, 1, -1, 1,
+ax_anim 6, 0, 62, -2, 2, -2, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, -4, 4, -4,
+ax_anim 1, 0, 61, 10, -10, 10, -10,
+ax_anim 2, 0, 61, 22, -20, 22, -20,
+ax_anim 2, 1, 61, 21, -21, 21, -21,
+ax_anim 2, 0, 61, 22, -20, 22, -20,
+ax_anim 2, 0, 61, 21, -21, 21, -21,
+ax_anim 2, 0, 60, 12, -12, 12, -12,
+ax_anim 2, 0, 62, 6, -6, 6, -6,
+ax_anim_terminator
+sOnixAnims_3_5:
+ax_anim 2, 0, 66, 0, 1, 0, 1,
+ax_anim 6, 0, 66, 0, 2, 0, 2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, -4, 0, -4,
+ax_anim 1, 0, 65, 0, -10, 0, -10,
+ax_anim 2, 0, 65, 0, -20, 0, -20,
+ax_anim 2, 1, 65, -1, -20, 0, -21,
+ax_anim 2, 0, 65, 0, -20, 0, -20,
+ax_anim 2, 0, 65, -1, -20, 0, -21,
+ax_anim 2, 0, 64, 0, -12, 0, -6,
+ax_anim 2, 0, 66, 0, -6, 0, -6,
+ax_anim_terminator
+sOnixAnims_3_6:
+ax_anim 2, 0, 70, 1, 1, 1, 1,
+ax_anim 6, 0, 70, 2, 2, 2, 2,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, -4, -4, -4,
+ax_anim 1, 0, 69, -10, -10, -10, -10,
+ax_anim 2, 0, 69, -22, -20, -22, -20,
+ax_anim 2, 1, 69, -21, -21, -21, -21,
+ax_anim 2, 0, 69, -22, -20, -22, -20,
+ax_anim 2, 0, 69, -21, -21, -21, -21,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 2, 0, 70, -6, -6, -6, -6,
+ax_anim_terminator
+sOnixAnims_3_7:
+ax_anim 2, 0, 74, 1, 0, 1, 0,
+ax_anim 6, 0, 74, 2, 0, 2, 0,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 73, -4, 0, -4, 0,
+ax_anim 1, 0, 73, -10, 0, -10, 0,
+ax_anim 2, 0, 73, -23, 0, -23, 0,
+ax_anim 2, 1, 73, -23, 1, -23, 1,
+ax_anim 2, 0, 73, -23, 0, -23, 0,
+ax_anim 2, 0, 73, -23, 1, -23, 1,
+ax_anim 2, 0, 72, -12, 0, -12, 0,
+ax_anim 2, 0, 74, -6, 0, -6, 0,
+ax_anim_terminator
+sOnixAnims_3_8:
+ax_anim 2, 0, 78, 1, -1, 1, -1,
+ax_anim 6, 0, 78, 2, -2, 2, -2,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 77, -4, 4, -4, 4,
+ax_anim 1, 0, 77, -10, 10, -10, 10,
+ax_anim 2, 0, 77, -23, 23, -23, 23,
+ax_anim 2, 1, 77, -22, 24, -22, 24,
+ax_anim 2, 0, 77, -23, 23, -23, 23,
+ax_anim 2, 0, 77, -22, 24, -22, 24,
+ax_anim 2, 0, 76, -12, 12, -12, 12,
+ax_anim 2, 0, 78, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sOnixAnims_4_1:
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim 2, 0, 82, 0, -5, 0, -5,
+ax_anim 6, 2, 82, 0, -6, 0, -6,
+ax_anim 2, 0, 83, 0, 1, 0, 1,
+ax_anim 2, 1, 83, -1, 3, -1, 3,
+ax_anim 2, 0, 83, 0, 3, 0, 3,
+ax_anim 2, 0, 83, -1, 3, -1, 3,
+ax_anim 2, 0, 83, 0, 3, 0, 3,
+ax_anim 2, 0, 83, -1, 3, -1, 3,
+ax_anim 2, 0, 80, 0, 3, 0, 3,
+ax_anim_terminator
+sOnixAnims_4_2:
+ax_anim 2, 0, 84, -2, -2, -2, -2,
+ax_anim 2, 0, 86, -5, -5, -5, -5,
+ax_anim 6, 2, 86, -6, -6, -6, -6,
+ax_anim 2, 0, 87, 3, 3, 3, 1,
+ax_anim 2, 1, 87, 2, 4, 2, 2,
+ax_anim 2, 0, 87, 3, 3, 3, 1,
+ax_anim 2, 0, 87, 2, 4, 2, 2,
+ax_anim 2, 0, 87, 3, 3, 3, 1,
+ax_anim 2, 0, 87, 2, 4, 2, 2,
+ax_anim 2, 0, 84, 3, 3, 3, 1,
+ax_anim_terminator
+sOnixAnims_4_3:
+ax_anim 2, 0, 88, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -5, 0, -5, 0,
+ax_anim 6, 2, 90, -6, 0, -6, 0,
+ax_anim 2, 0, 91, 3, 0, 3, 0,
+ax_anim 2, 1, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 91, 3, -1, 3, -1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim_terminator
+sOnixAnims_4_4:
+ax_anim 2, 0, 92, -2, 2, -2, 2,
+ax_anim 2, 0, 94, -5, 5, -5, 5,
+ax_anim 6, 2, 94, -6, 6, -6, 6,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 1, 95, 2, -4, 2, -4,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 2, -4, 2, -4,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 2, -4, 2, -4,
+ax_anim 2, 0, 92, 3, -3, 3, -3,
+ax_anim_terminator
+sOnixAnims_4_5:
+ax_anim 2, 0, 96, 0, 2, 0, 2,
+ax_anim 2, 0, 98, 0, 5, 0, 5,
+ax_anim 6, 2, 98, 0, 6, 0, 6,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 2, 1, 99, -1, -3, -1, -3,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 2, 0, 99, -1, -3, -1, -3,
+ax_anim 2, 0, 99, 0, -3, 0, -3,
+ax_anim 2, 0, 99, -1, -3, -1, -3,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim_terminator
+sOnixAnims_4_6:
+ax_anim 2, 0, 100, 2, 2, 2, 2,
+ax_anim 2, 0, 102, 5, 5, 5, 5,
+ax_anim 6, 2, 102, 6, 6, 6, 6,
+ax_anim 2, 0, 103, -3, -3, -3, -3,
+ax_anim 2, 1, 103, -2, -4, -2, -4,
+ax_anim 2, 0, 103, -3, -3, -3, -3,
+ax_anim 2, 0, 103, -2, -4, -2, -4,
+ax_anim 2, 0, 103, -3, -3, -3, -3,
+ax_anim 2, 0, 103, -2, -4, -2, -4,
+ax_anim 2, 0, 100, -3, -3, -3, -3,
+ax_anim_terminator
+sOnixAnims_4_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 106, 5, 0, 5, 0,
+ax_anim 6, 2, 106, 6, 0, 6, 0,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 1, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, -1, -3, -1,
+ax_anim 2, 0, 104, -3, 0, -3, 0,
+ax_anim_terminator
+sOnixAnims_4_8:
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim 2, 0, 110, 5, -5, 5, -5,
+ax_anim 6, 2, 110, 6, -6, 6, -6,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 1, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 108, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sOnixAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sOnixAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sOnixAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sOnixAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sOnixAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sOnixAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sOnixAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sOnixAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sOnixAnims_8_1:
+ax_anim 16, 0, 130, 0, 0, 0, 0,
+ax_anim 16, 0, 131, 0, 3, 0, 0,
+ax_anim 16, 0, 130, 0, 0, 0, 0,
+ax_anim 16, 0, 132, 0, -3, 0, 0,
+ax_anim_terminator
+sOnixAnims_8_2:
+ax_anim 16, 0, 133, 0, 0, 0, 0,
+ax_anim 16, 0, 134, 5, 1, 0, 0,
+ax_anim 16, 0, 133, 0, 0, 0, 0,
+ax_anim 16, 0, 135, -2, -3, 0, 0,
+ax_anim_terminator
+sOnixAnims_8_3:
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 16, 0, 137, 5, 1, 0, 0,
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 16, 0, 138, -2, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_8_4:
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim 16, 0, 140, 2, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim 16, 0, 141, -2, 1, 0, 0,
+ax_anim_terminator
+sOnixAnims_8_5:
+ax_anim 16, 0, 142, 0, 3, 0, 0,
+ax_anim 16, 0, 143, 0, 2, 0, 0,
+ax_anim 16, 0, 142, 0, 3, 0, 0,
+ax_anim 16, 0, 144, 0, 3, 0, 0,
+ax_anim_terminator
+sOnixAnims_8_6:
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim 16, 0, 146, -2, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 2, 1, 0, 0,
+ax_anim_terminator
+sOnixAnims_8_7:
+ax_anim 16, 0, 148, 0, 0, 0, 0,
+ax_anim 16, 0, 149, -5, 1, 0, 0,
+ax_anim 16, 0, 148, 0, 0, 0, 0,
+ax_anim 16, 0, 150, 2, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_8_8:
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim 16, 0, 152, -5, 1, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 2, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 17, 7, 17,
+ax_anim 3, 0, 158, 0, 21, 0, 21,
+ax_anim 2, 3, 159, -7, 17, -7, 17,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 18, 3,
+ax_anim 2, 0, 156, 19, 10, 21, 10,
+ax_anim 3, 0, 157, 17, 19, 19, 20,
+ax_anim 2, 3, 158, 11, 21, 11, 21,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 12, -5, 12, -5,
+ax_anim 3, 0, 156, 14, -2, 14, -2,
+ax_anim 2, 3, 157, 12, 4, 12, 4,
+ax_anim 2, 0, 158, 10, 7, 10, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -16, 12, -16,
+ax_anim 3, 0, 155, 14, -15, 14, -15,
+ax_anim 2, 3, 156, 16, -12, 16, -12,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, 2, 7, 2,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -8, -9, -8,
+ax_anim 2, 0, 161, -7, -13, -7, -13,
+ax_anim 3, 0, 154, 0, -13, 0, -13,
+ax_anim 2, 3, 155, 7, -13, 7, -13,
+ax_anim 2, 0, 156, 9, -6, 9, -6,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -16, -12, -16,
+ax_anim 3, 0, 161, -14, -15, -14, -15,
+ax_anim 2, 3, 160, -16, -12, -16, -12,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, 2, -7, 2,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -12, -5, -12, -5,
+ax_anim 3, 0, 160, -14, -2, -14, -2,
+ax_anim 2, 3, 159, -12, 4, -12, 4,
+ax_anim 2, 0, 158, -10, 7, -10, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -19, 10, -19, 10,
+ax_anim 3, 0, 159, -17, 19, -17, 19,
+ax_anim 2, 3, 158, -11, 21, -11, 21,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 4, 0, 0,
+ax_anim_terminator
+sOnixAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 4, 0, 0,
+ax_anim_terminator
+sOnixAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 3, 0, 0,
+ax_anim_terminator
+sOnixAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 3, 0, 0,
+ax_anim_terminator
+sOnixAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sOnixAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sOnixGfx1:
+.incbin "baserom.gba", 0x90AE00, 0x40
+sOnixGfx1_1:
+.incbin "baserom.gba", 0x90AE40, 0x40
+sOnixGfx1_2:
+.incbin "baserom.gba", 0x90AE80, 0x80
+sOnixGfx1_3:
+.incbin "baserom.gba", 0x90AF00, 0x80
+sOnixGfx1_4:
+.incbin "baserom.gba", 0x90AF80, 0x80
+sOnixGfx1_5:
+.incbin "baserom.gba", 0x90B000, 0x60
+sOnixGfx1_6:
+.incbin "baserom.gba", 0x90B060, 0x40
+sOnixSprites1:
+ax_sprite 0, 0x160
+ax_sprite sOnixGfx1, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx1_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx1_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx1_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx1_4, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx1_5, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx1_6, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sOnixGfx2:
+.incbin "baserom.gba", 0x90B120, 0x40
+sOnixGfx2_1:
+.incbin "baserom.gba", 0x90B160, 0x40
+sOnixGfx2_2:
+.incbin "baserom.gba", 0x90B1A0, 0x80
+sOnixGfx2_3:
+.incbin "baserom.gba", 0x90B220, 0x80
+sOnixGfx2_4:
+.incbin "baserom.gba", 0x90B2A0, 0x80
+sOnixGfx2_5:
+.incbin "baserom.gba", 0x90B320, 0x60
+sOnixSprites2:
+ax_sprite 0, 0x160
+ax_sprite sOnixGfx2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx2_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx2_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx2_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx2_4, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx2_5, 0x60
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sOnixGfx3:
+.incbin "baserom.gba", 0x90B3F0, 0x40
+sOnixGfx3_1:
+.incbin "baserom.gba", 0x90B430, 0x80
+sOnixGfx3_2:
+.incbin "baserom.gba", 0x90B4B0, 0x80
+sOnixGfx3_3:
+.incbin "baserom.gba", 0x90B530, 0x80
+sOnixGfx3_4:
+.incbin "baserom.gba", 0x90B5B0, 0x60
+sOnixGfx3_5:
+.incbin "baserom.gba", 0x90B610, 0x60
+sOnixGfx3_6:
+.incbin "baserom.gba", 0x90B670, 0x40
+sOnixSprites3:
+ax_sprite 0, 0x160
+ax_sprite sOnixGfx3, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx3_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx3_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx3_3, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx3_4, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx3_5, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx3_6, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sOnixGfx4:
+.incbin "baserom.gba", 0x90B730, 0x60
+sOnixGfx4_1:
+.incbin "baserom.gba", 0x90B790, 0xA0
+sOnixGfx4_2:
+.incbin "baserom.gba", 0x90B830, 0xE0
+sOnixGfx4_3:
+.incbin "baserom.gba", 0x90B910, 0xE0
+sOnixGfx4_4:
+.incbin "baserom.gba", 0x90B9F0, 0xC0
+sOnixGfx4_5:
+.incbin "baserom.gba", 0x90BAB0, 0x80
+sOnixGfx4_6:
+.incbin "baserom.gba", 0x90BB30, 0x40
+sOnixSprites4:
+ax_sprite 0, 0x140
+ax_sprite sOnixGfx4, 0x60
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx4_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx4_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx4_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx4_4, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx4_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx4_6, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sOnixGfx5:
+.incbin "baserom.gba", 0x90BBF0, 0x60
+sOnixGfx5_1:
+.incbin "baserom.gba", 0x90BC50, 0x2E0
+sOnixGfx5_2:
+.incbin "baserom.gba", 0x90BF30, 0x40
+sOnixGfx5_3:
+.incbin "baserom.gba", 0x90BF70, 0x80
+sOnixSprites5:
+ax_sprite 0, 0x240
+ax_sprite sOnixGfx5, 0x60
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx5_1, 0x2e0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx5_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx5_3, 0x80
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sOnixGfx6:
+.incbin "baserom.gba", 0x90C040, 0x60
+sOnixGfx6_1:
+.incbin "baserom.gba", 0x90C0A0, 0xC0
+sOnixGfx6_2:
+.incbin "baserom.gba", 0x90C160, 0xC0
+sOnixGfx6_3:
+.incbin "baserom.gba", 0x90C220, 0xC0
+sOnixGfx6_4:
+.incbin "baserom.gba", 0x90C2E0, 0x80
+sOnixGfx6_5:
+.incbin "baserom.gba", 0x90C360, 0x80
+sOnixGfx6_6:
+.incbin "baserom.gba", 0x90C3E0, 0x60
+sOnixSprites6:
+ax_sprite 0, 0x140
+ax_sprite sOnixGfx6, 0x60
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx6_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx6_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx6_3, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx6_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx6_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx6_6, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOnixGfx7:
+.incbin "baserom.gba", 0x90C4C0, 0xA0
+sOnixGfx7_1:
+.incbin "baserom.gba", 0x90C560, 0xC0
+sOnixGfx7_2:
+.incbin "baserom.gba", 0x90C620, 0xC0
+sOnixGfx7_3:
+.incbin "baserom.gba", 0x90C6E0, 0xC0
+sOnixGfx7_4:
+.incbin "baserom.gba", 0x90C7A0, 0x20
+sOnixGfx7_5:
+.incbin "baserom.gba", 0x90C7C0, 0xA0
+sOnixGfx7_6:
+.incbin "baserom.gba", 0x90C860, 0xA0
+sOnixGfx7_7:
+.incbin "baserom.gba", 0x90C900, 0x60
+sOnixSprites7:
+ax_sprite 0, 0x100
+ax_sprite sOnixGfx7, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx7_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx7_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx7_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx7_4, 0x20
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx7_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx7_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx7_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx8:
+.incbin "baserom.gba", 0x90C9F0, 0x60
+sOnixGfx8_1:
+.incbin "baserom.gba", 0x90CA50, 0xE0
+sOnixGfx8_2:
+.incbin "baserom.gba", 0x90CB30, 0x100
+sOnixSprites8:
+ax_sprite 0, 0x140
+ax_sprite sOnixGfx8, 0x60
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx8_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx8_2, 0x100
+ax_sprite_terminator
+sOnixGfx9:
+.incbin "baserom.gba", 0x90CC68, 0x60
+sOnixSprites9:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx9, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sOnixGfx10:
+.incbin "baserom.gba", 0x90CCE8, 0x80
+sOnixGfx10_1:
+.incbin "baserom.gba", 0x90CD68, 0x60
+sOnixGfx10_2:
+.incbin "baserom.gba", 0x90CDC8, 0x60
+sOnixGfx10_3:
+.incbin "baserom.gba", 0x90CE28, 0x40
+sOnixSprites10:
+ax_sprite sOnixGfx10, 0x80
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx10_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx10_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx10_3, 0x40
+ax_sprite_terminator
+sOnixGfx11:
+.incbin "baserom.gba", 0x90CEA8, 0x60
+sOnixGfx11_1:
+.incbin "baserom.gba", 0x90CF08, 0x60
+sOnixSprites11:
+ax_sprite sOnixGfx11, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx11_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx12:
+.incbin "baserom.gba", 0x90CF90, 0x20
+sOnixGfx12_1:
+.incbin "baserom.gba", 0x90CFB0, 0xA0
+sOnixGfx12_2:
+.incbin "baserom.gba", 0x90D050, 0xA0
+sOnixGfx12_3:
+.incbin "baserom.gba", 0x90D0F0, 0xC0
+sOnixGfx12_4:
+.incbin "baserom.gba", 0x90D1B0, 0xC0
+sOnixGfx12_5:
+.incbin "baserom.gba", 0x90D270, 0xA0
+sOnixGfx12_6:
+.incbin "baserom.gba", 0x90D310, 0xA0
+sOnixGfx12_7:
+.incbin "baserom.gba", 0x90D3B0, 0x80
+sOnixSprites12:
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx12, 0x20
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx12_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx12_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx12_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx12_4, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx12_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx12_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx12_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx13:
+.incbin "baserom.gba", 0x90D4C0, 0x40
+sOnixGfx13_1:
+.incbin "baserom.gba", 0x90D500, 0x80
+sOnixGfx13_2:
+.incbin "baserom.gba", 0x90D580, 0xA0
+sOnixGfx13_3:
+.incbin "baserom.gba", 0x90D620, 0xA0
+sOnixGfx13_4:
+.incbin "baserom.gba", 0x90D6C0, 0x60
+sOnixGfx13_5:
+.incbin "baserom.gba", 0x90D720, 0x80
+sOnixGfx13_6:
+.incbin "baserom.gba", 0x90D7A0, 0x80
+sOnixGfx13_7:
+.incbin "baserom.gba", 0x90D820, 0x80
+sOnixSprites13:
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx13, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx13_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx13_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx13_3, 0xa0
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx13_4, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx13_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx13_6, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx13_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx14:
+.incbin "baserom.gba", 0x90D930, 0x60
+sOnixGfx14_1:
+.incbin "baserom.gba", 0x90D990, 0xA0
+sOnixGfx14_2:
+.incbin "baserom.gba", 0x90DA30, 0xA0
+sOnixGfx14_3:
+.incbin "baserom.gba", 0x90DAD0, 0xC0
+sOnixGfx14_4:
+.incbin "baserom.gba", 0x90DB90, 0x60
+sOnixGfx14_5:
+.incbin "baserom.gba", 0x90DBF0, 0xA0
+sOnixGfx14_6:
+.incbin "baserom.gba", 0x90DC90, 0xA0
+sOnixGfx14_7:
+.incbin "baserom.gba", 0x90DD30, 0x80
+sOnixSprites14:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx14, 0x60
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx14_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx14_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx14_3, 0xc0
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx14_4, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx14_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx14_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx14_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx15:
+.incbin "baserom.gba", 0x90DE40, 0x60
+sOnixGfx15_1:
+.incbin "baserom.gba", 0x90DEA0, 0x80
+sOnixGfx15_2:
+.incbin "baserom.gba", 0x90DF20, 0xA0
+sOnixGfx15_3:
+.incbin "baserom.gba", 0x90DFC0, 0xA0
+sOnixGfx15_4:
+.incbin "baserom.gba", 0x90E060, 0x60
+sOnixGfx15_5:
+.incbin "baserom.gba", 0x90E0C0, 0x80
+sOnixGfx15_6:
+.incbin "baserom.gba", 0x90E140, 0xA0
+sOnixGfx15_7:
+.incbin "baserom.gba", 0x90E1E0, 0x80
+sOnixSprites15:
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx15, 0x60
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx15_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx15_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx15_3, 0xa0
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx15_4, 0x60
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx15_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx15_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx15_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx16:
+.incbin "baserom.gba", 0x90E2F0, 0x40
+sOnixGfx16_1:
+.incbin "baserom.gba", 0x90E330, 0x80
+sOnixGfx16_2:
+.incbin "baserom.gba", 0x90E3B0, 0x80
+sOnixGfx16_3:
+.incbin "baserom.gba", 0x90E430, 0x80
+sOnixGfx16_4:
+.incbin "baserom.gba", 0x90E4B0, 0x40
+sOnixGfx16_5:
+.incbin "baserom.gba", 0x90E4F0, 0x40
+sOnixGfx16_6:
+.incbin "baserom.gba", 0x90E530, 0x60
+sOnixGfx16_7:
+.incbin "baserom.gba", 0x90E590, 0x40
+sOnixSprites16:
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx16, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx16_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx16_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx16_3, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx16_4, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx16_5, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx16_6, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx16_7, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sOnixGfx17:
+.incbin "baserom.gba", 0x90E660, 0x40
+sOnixGfx17_1:
+.incbin "baserom.gba", 0x90E6A0, 0x80
+sOnixGfx17_2:
+.incbin "baserom.gba", 0x90E720, 0x80
+sOnixGfx17_3:
+.incbin "baserom.gba", 0x90E7A0, 0x40
+sOnixGfx17_4:
+.incbin "baserom.gba", 0x90E7E0, 0x40
+sOnixGfx17_5:
+.incbin "baserom.gba", 0x90E820, 0x60
+sOnixGfx17_6:
+.incbin "baserom.gba", 0x90E880, 0x60
+sOnixGfx17_7:
+.incbin "baserom.gba", 0x90E8E0, 0x40
+sOnixSprites17:
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx17, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx17_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx17_2, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx17_3, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx17_4, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx17_5, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx17_6, 0x60
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx17_7, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sOnixGfx18:
+.incbin "baserom.gba", 0x90E9B0, 0x40
+sOnixGfx18_1:
+.incbin "baserom.gba", 0x90E9F0, 0x80
+sOnixGfx18_2:
+.incbin "baserom.gba", 0x90EA70, 0x80
+sOnixGfx18_3:
+.incbin "baserom.gba", 0x90EAF0, 0x80
+sOnixGfx18_4:
+.incbin "baserom.gba", 0x90EB70, 0x40
+sOnixGfx18_5:
+.incbin "baserom.gba", 0x90EBB0, 0x40
+sOnixGfx18_6:
+.incbin "baserom.gba", 0x90EBF0, 0x40
+sOnixGfx18_7:
+.incbin "baserom.gba", 0x90EC30, 0x40
+sOnixSprites18:
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx18, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx18_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx18_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx18_3, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx18_4, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx18_5, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx18_6, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sOnixGfx18_7, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sOnixGfx19:
+.incbin "baserom.gba", 0x90ED00, 0x20
+sOnixGfx19_1:
+.incbin "baserom.gba", 0x90ED20, 0x60
+sOnixGfx19_2:
+.incbin "baserom.gba", 0x90ED80, 0x60
+sOnixGfx19_3:
+.incbin "baserom.gba", 0x90EDE0, 0x60
+sOnixGfx19_4:
+.incbin "baserom.gba", 0x90EE40, 0x60
+sOnixGfx19_5:
+.incbin "baserom.gba", 0x90EEA0, 0x60
+sOnixGfx19_6:
+.incbin "baserom.gba", 0x90EF00, 0x60
+sOnixSprites19:
+ax_sprite 0, 0xe0
+ax_sprite sOnixGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx19_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx19_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx19_6, 0x60
+ax_sprite_terminator
+sOnixGfx20:
+.incbin "baserom.gba", 0x90EFD8, 0xA0
+sOnixGfx20_1:
+.incbin "baserom.gba", 0x90F078, 0x280
+sOnixGfx20_2:
+.incbin "baserom.gba", 0x90F2F8, 0x80
+sOnixSprites20:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx20, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx20_1, 0x280
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx20_2, 0x80
+ax_sprite_terminator
+sOnixGfx21:
+.incbin "baserom.gba", 0x90F3B0, 0x40
+sOnixSprites21:
+ax_sprite sOnixGfx21, 0x40
+ax_sprite_terminator
+sOnixGfx22:
+.incbin "baserom.gba", 0x90F400, 0x20
+sOnixSprites22:
+ax_sprite sOnixGfx22, 0x20
+ax_sprite_terminator
+sOnixGfx23:
+.incbin "baserom.gba", 0x90F430, 0xC0
+sOnixGfx23_1:
+.incbin "baserom.gba", 0x90F4F0, 0xE0
+sOnixGfx23_2:
+.incbin "baserom.gba", 0x90F5D0, 0x160
+sOnixGfx23_3:
+.incbin "baserom.gba", 0x90F730, 0x60
+sOnixSprites23:
+ax_sprite sOnixGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx23_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx23_2, 0x160
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx23_3, 0x60
+ax_sprite_terminator
+sOnixGfx24:
+.incbin "baserom.gba", 0x90F7D0, 0xC0
+sOnixSprites24:
+ax_sprite sOnixGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOnixGfx25:
+.incbin "baserom.gba", 0x90F8A8, 0x40
+sOnixSprites25:
+ax_sprite sOnixGfx25, 0x40
+ax_sprite_terminator
+sOnixGfx26:
+.incbin "baserom.gba", 0x90F8F8, 0x40
+sOnixSprites26:
+ax_sprite sOnixGfx26, 0x40
+ax_sprite_terminator
+sOnixGfx27:
+.incbin "baserom.gba", 0x90F948, 0x40
+sOnixGfx27_1:
+.incbin "baserom.gba", 0x90F988, 0x80
+sOnixGfx27_2:
+.incbin "baserom.gba", 0x90FA08, 0xC0
+sOnixGfx27_3:
+.incbin "baserom.gba", 0x90FAC8, 0xC0
+sOnixSprites27:
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx27, 0x40
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx27_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sOnixGfx27_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx27_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOnixGfx28:
+.incbin "baserom.gba", 0x90FBD8, 0x40
+sOnixGfx28_1:
+.incbin "baserom.gba", 0x90FC18, 0x40
+sOnixGfx28_2:
+.incbin "baserom.gba", 0x90FC58, 0x100
+sOnixSprites28:
+ax_sprite sOnixGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx28_2, 0x100
+ax_sprite_terminator
+sOnixGfx29:
+.incbin "baserom.gba", 0x90FD88, 0x60
+sOnixGfx29_1:
+.incbin "baserom.gba", 0x90FDE8, 0x60
+sOnixGfx29_2:
+.incbin "baserom.gba", 0x90FE48, 0x60
+sOnixGfx29_3:
+.incbin "baserom.gba", 0x90FEA8, 0x60
+sOnixGfx29_4:
+.incbin "baserom.gba", 0x90FF08, 0x60
+sOnixGfx29_5:
+.incbin "baserom.gba", 0x90FF68, 0x60
+sOnixGfx29_6:
+.incbin "baserom.gba", 0x90FFC8, 0x60
+sOnixGfx29_7:
+.incbin "baserom.gba", 0x910028, 0x40
+sOnixSprites29:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29_6, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx29_7, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx30:
+.incbin "baserom.gba", 0x9100F8, 0x40
+sOnixGfx30_1:
+.incbin "baserom.gba", 0x910138, 0x160
+sOnixSprites30:
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx30_1, 0x160
+ax_sprite_terminator
+sOnixGfx31:
+.incbin "baserom.gba", 0x9102C0, 0x80
+sOnixSprites31:
+ax_sprite sOnixGfx31, 0x80
+ax_sprite_terminator
+sOnixGfx32:
+.incbin "baserom.gba", 0x910350, 0x100
+sOnixSprites32:
+ax_sprite sOnixGfx32, 0x100
+ax_sprite_terminator
+sOnixGfx33:
+.incbin "baserom.gba", 0x910460, 0x40
+sOnixGfx33_1:
+.incbin "baserom.gba", 0x9104A0, 0x160
+sOnixSprites33:
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx33_1, 0x160
+ax_sprite_terminator
+sOnixGfx34:
+.incbin "baserom.gba", 0x910628, 0x80
+sOnixSprites34:
+ax_sprite sOnixGfx34, 0x80
+ax_sprite_terminator
+sOnixGfx35:
+.incbin "baserom.gba", 0x9106B8, 0x100
+sOnixSprites35:
+ax_sprite sOnixGfx35, 0x100
+ax_sprite_terminator
+sOnixGfx36:
+.incbin "baserom.gba", 0x9107C8, 0x80
+sOnixGfx36_1:
+.incbin "baserom.gba", 0x910848, 0x40
+sOnixSprites36:
+ax_sprite sOnixGfx36, 0x80
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx36_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx37:
+.incbin "baserom.gba", 0x9108B0, 0x40
+sOnixGfx37_1:
+.incbin "baserom.gba", 0x9108F0, 0x40
+sOnixGfx37_2:
+.incbin "baserom.gba", 0x910930, 0x100
+sOnixSprites37:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx37_2, 0x100
+ax_sprite_terminator
+sOnixGfx38:
+.incbin "baserom.gba", 0x910A68, 0x60
+sOnixGfx38_1:
+.incbin "baserom.gba", 0x910AC8, 0xE0
+sOnixGfx38_2:
+.incbin "baserom.gba", 0x910BA8, 0x1E0
+sOnixSprites38:
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx38, 0x60
+ax_sprite 0, 0x60
+ax_sprite sOnixGfx38_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx38_2, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx39:
+.incbin "baserom.gba", 0x910DC8, 0x80
+sOnixSprites39:
+ax_sprite sOnixGfx39, 0x80
+ax_sprite_terminator
+sOnixGfx40:
+.incbin "baserom.gba", 0x910E58, 0x60
+sOnixSprites40:
+ax_sprite sOnixGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx41:
+.incbin "baserom.gba", 0x910ED0, 0x80
+sOnixGfx41_1:
+.incbin "baserom.gba", 0x910F50, 0x60
+sOnixSprites41:
+ax_sprite sOnixGfx41, 0x80
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx41_1, 0x60
+ax_sprite_terminator
+sOnixGfx42:
+.incbin "baserom.gba", 0x910FD0, 0x80
+sOnixSprites42:
+ax_sprite sOnixGfx42, 0x80
+ax_sprite_terminator
+sOnixGfx43:
+.incbin "baserom.gba", 0x911060, 0xA0
+sOnixGfx43_1:
+.incbin "baserom.gba", 0x911100, 0xE0
+sOnixGfx43_2:
+.incbin "baserom.gba", 0x9111E0, 0xE0
+sOnixGfx43_3:
+.incbin "baserom.gba", 0x9112C0, 0xE0
+sOnixSprites43:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx43, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx43_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx43_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx43_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sOnixGfx44:
+.incbin "baserom.gba", 0x9113F0, 0x160
+sOnixSprites44:
+ax_sprite sOnixGfx44, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sOnixGfx45:
+.incbin "baserom.gba", 0x911568, 0x40
+sOnixGfx45_1:
+.incbin "baserom.gba", 0x9115A8, 0xC0
+sOnixGfx45_2:
+.incbin "baserom.gba", 0x911668, 0xC0
+sOnixGfx45_3:
+.incbin "baserom.gba", 0x911728, 0xC0
+sOnixSprites45:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx45, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sOnixGfx45_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx45_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx45_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sOnixGfx46:
+.incbin "baserom.gba", 0x911838, 0x40
+sOnixGfx46_1:
+.incbin "baserom.gba", 0x911878, 0x180
+sOnixGfx46_2:
+.incbin "baserom.gba", 0x9119F8, 0x40
+sOnixGfx46_3:
+.incbin "baserom.gba", 0x911A38, 0x60
+sOnixGfx46_4:
+.incbin "baserom.gba", 0x911A98, 0x60
+sOnixGfx46_5:
+.incbin "baserom.gba", 0x911AF8, 0x40
+sOnixSprites46:
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx46_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx46_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx46_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sOnixGfx46_4, 0x60
+ax_sprite 0, 0x40
+ax_sprite sOnixGfx46_5, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sAxPosesOnix:
+.4byte sOnixPose1
+.4byte sOnixPose2
+.4byte sOnixPose3
+.4byte sOnixPose4
+.4byte sOnixPose5
+.4byte sOnixPose6
+.4byte sOnixPose7
+.4byte sOnixPose8
+.4byte sOnixPose9
+.4byte sOnixPose10
+.4byte sOnixPose11
+.4byte sOnixPose12
+.4byte sOnixPose13
+.4byte sOnixPose14
+.4byte sOnixPose15
+.4byte sOnixPose16
+.4byte sOnixPose17
+.4byte sOnixPose18
+.4byte sOnixPose19
+.4byte sOnixPose20
+.4byte sOnixPose21
+.4byte sOnixPose22
+.4byte sOnixPose23
+.4byte sOnixPose24
+.4byte sOnixPose25
+.4byte sOnixPose26
+.4byte sOnixPose27
+.4byte sOnixPose28
+.4byte sOnixPose29
+.4byte sOnixPose30
+.4byte sOnixPose31
+.4byte sOnixPose32
+.4byte sOnixPose33
+.4byte sOnixPose34
+.4byte sOnixPose35
+.4byte sOnixPose36
+.4byte sOnixPose37
+.4byte sOnixPose38
+.4byte sOnixPose39
+.4byte sOnixPose40
+.4byte sOnixPose41
+.4byte sOnixPose42
+.4byte sOnixPose43
+.4byte sOnixPose44
+.4byte sOnixPose45
+.4byte sOnixPose46
+.4byte sOnixPose47
+.4byte sOnixPose48
+.4byte sOnixPose49
+.4byte sOnixPose50
+.4byte sOnixPose51
+.4byte sOnixPose52
+.4byte sOnixPose53
+.4byte sOnixPose54
+.4byte sOnixPose55
+.4byte sOnixPose56
+.4byte sOnixPose57
+.4byte sOnixPose58
+.4byte sOnixPose59
+.4byte sOnixPose60
+.4byte sOnixPose61
+.4byte sOnixPose62
+.4byte sOnixPose63
+.4byte sOnixPose64
+.4byte sOnixPose65
+.4byte sOnixPose66
+.4byte sOnixPose67
+.4byte sOnixPose68
+.4byte sOnixPose69
+.4byte sOnixPose70
+.4byte sOnixPose71
+.4byte sOnixPose72
+.4byte sOnixPose73
+.4byte sOnixPose74
+.4byte sOnixPose75
+.4byte sOnixPose76
+.4byte sOnixPose77
+.4byte sOnixPose78
+.4byte sOnixPose79
+.4byte sOnixPose80
+.4byte sOnixPose81
+.4byte sOnixPose82
+.4byte sOnixPose83
+.4byte sOnixPose84
+.4byte sOnixPose85
+.4byte sOnixPose86
+.4byte sOnixPose87
+.4byte sOnixPose88
+.4byte sOnixPose89
+.4byte sOnixPose90
+.4byte sOnixPose91
+.4byte sOnixPose92
+.4byte sOnixPose93
+.4byte sOnixPose94
+.4byte sOnixPose95
+.4byte sOnixPose96
+.4byte sOnixPose97
+.4byte sOnixPose98
+.4byte sOnixPose99
+.4byte sOnixPose100
+.4byte sOnixPose101
+.4byte sOnixPose102
+.4byte sOnixPose103
+.4byte sOnixPose104
+.4byte sOnixPose105
+.4byte sOnixPose106
+.4byte sOnixPose107
+.4byte sOnixPose108
+.4byte sOnixPose109
+.4byte sOnixPose110
+.4byte sOnixPose111
+.4byte sOnixPose112
+.4byte sOnixPose113
+.4byte sOnixPose114
+.4byte sOnixPose115
+.4byte sOnixPose116
+.4byte sOnixPose117
+.4byte sOnixPose118
+.4byte sOnixPose119
+.4byte sOnixPose120
+.4byte sOnixPose121
+.4byte sOnixPose122
+.4byte sOnixPose123
+.4byte sOnixPose124
+.4byte sOnixPose125
+.4byte sOnixPose126
+.4byte sOnixPose127
+.4byte sOnixPose128
+.4byte sOnixPose129
+.4byte sOnixPose130
+.4byte sOnixPose131
+.4byte sOnixPose132
+.4byte sOnixPose133
+.4byte sOnixPose134
+.4byte sOnixPose135
+.4byte sOnixPose136
+.4byte sOnixPose137
+.4byte sOnixPose138
+.4byte sOnixPose139
+.4byte sOnixPose140
+.4byte sOnixPose141
+.4byte sOnixPose142
+.4byte sOnixPose143
+.4byte sOnixPose144
+.4byte sOnixPose145
+.4byte sOnixPose146
+.4byte sOnixPose147
+.4byte sOnixPose148
+.4byte sOnixPose149
+.4byte sOnixPose150
+.4byte sOnixPose151
+.4byte sOnixPose152
+.4byte sOnixPose153
+.4byte sOnixPose154
+.4byte sOnixPose155
+.4byte sOnixPose156
+.4byte sOnixPose157
+.4byte sOnixPose158
+.4byte sOnixPose159
+.4byte sOnixPose160
+.4byte sOnixPose161
+.4byte sOnixPose162
+.4byte sOnixPose163
+.4byte sOnixPose164
+.4byte sOnixPose165
+.4byte sOnixPose166
+.4byte sOnixPose167
+.4byte sOnixPose168
+.4byte sOnixPose169
+.4byte sOnixPose170
+.4byte sOnixPose171
+.4byte sOnixPose172
+.4byte sOnixPose173
+.4byte sOnixPose174
+.4byte sOnixPose175
+.4byte sOnixPose176
+.4byte sOnixPose177
+.4byte sOnixPose178
+.4byte sOnixPose179
+.4byte sOnixPose180
+.4byte sOnixPose181
+.4byte sOnixPose182
+.4byte sOnixPose183
+.4byte sOnixPose184
+.4byte sOnixPose185
+.4byte sOnixPose186
+.4byte sOnixPose187
+.4byte sOnixPose188
+.4byte sOnixPose189
+.4byte sOnixPose190
+.4byte sOnixPose191
+.4byte sOnixPose192
+.4byte sOnixPose193
+.4byte sOnixPose194
+.4byte sOnixPose195
+.4byte sOnixPose196
+.4byte sOnixPose197
+.4byte sOnixPose198
+.4byte sOnixPose199
+.4byte sOnixPose200
+.4byte sOnixPose201
+.4byte sOnixPose202
+.4byte sOnixPose203
+.4byte sOnixPose204
+.4byte sOnixPose205
+.4byte sOnixPose206
+.4byte sOnixPose207
+.4byte sOnixPose208
+.4byte sOnixPose209
+.4byte sOnixPose210
+sAxPositionsOnix:
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte    0,   -9, 	  -8,  -22, 	   6,  -22, 	   0,  -26
+.2byte    0,  -16, 	  -6,  -29, 	   7,  -29, 	   0,  -26
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+.2byte   23,  -14, 	   7,  -35, 	   3,  -27, 	  -4,  -17
+.2byte   11,  -23, 	  -3,  -40, 	  -9,  -31, 	  -4,  -19
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   32,  -25, 	  14,  -39, 	  12,  -30, 	  -6,  -23
+.2byte   14,  -30, 	  -5,  -43, 	  -5,  -34, 	  -4,  -22
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   22,  -38, 	   0,  -42, 	   8,  -37, 	  -4,  -22
+.2byte   13,  -41, 	  -9,  -40, 	   1,  -35, 	  -3,  -20
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte   -1,  -50, 	   6,  -39, 	  -7,  -39, 	   0,  -23
+.2byte    0,  -47, 	   5,  -35, 	  -6,  -35, 	  -1,  -24
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte  -23,  -38, 	  -1,  -42, 	  -9,  -37, 	   3,  -22
+.2byte  -14,  -41, 	   8,  -40, 	  -2,  -35, 	   2,  -20
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -33,  -25, 	 -15,  -39, 	 -13,  -30, 	   5,  -23
+.2byte  -15,  -30, 	   4,  -43, 	   4,  -34, 	   3,  -22
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -24,  -14, 	  -8,  -35, 	  -4,  -27, 	   3,  -17
+.2byte  -12,  -23, 	   2,  -40, 	   8,  -31, 	   3,  -19
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte    0,   -9, 	  -8,  -22, 	   6,  -22, 	   0,  -26
+.2byte    0,  -16, 	  -6,  -29, 	   7,  -29, 	   0,  -26
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+.2byte   23,  -14, 	   7,  -35, 	   3,  -27, 	  -4,  -17
+.2byte   11,  -23, 	  -3,  -40, 	  -9,  -31, 	  -4,  -19
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   32,  -25, 	  14,  -39, 	  12,  -30, 	  -6,  -23
+.2byte   14,  -30, 	  -5,  -43, 	  -5,  -34, 	  -4,  -22
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   22,  -38, 	   0,  -42, 	   8,  -37, 	  -4,  -22
+.2byte   13,  -41, 	  -9,  -40, 	   1,  -35, 	  -3,  -20
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte   -1,  -50, 	   6,  -39, 	  -7,  -39, 	   0,  -23
+.2byte    0,  -47, 	   5,  -35, 	  -6,  -35, 	  -1,  -24
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte  -23,  -38, 	  -1,  -42, 	  -9,  -37, 	   3,  -22
+.2byte  -14,  -41, 	   8,  -40, 	  -2,  -35, 	   2,  -20
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -33,  -25, 	 -15,  -39, 	 -13,  -30, 	   5,  -23
+.2byte  -15,  -30, 	   4,  -43, 	   4,  -34, 	   3,  -22
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -24,  -14, 	  -8,  -35, 	  -4,  -27, 	   3,  -17
+.2byte  -12,  -23, 	   2,  -40, 	   8,  -31, 	   3,  -19
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte    0,   -9, 	  -8,  -22, 	   6,  -22, 	   0,  -26
+.2byte    0,  -16, 	  -6,  -29, 	   7,  -29, 	   0,  -26
+.2byte    0,   -6, 	 -10,  -15, 	   8,  -16, 	   0,  -27
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+.2byte   23,  -14, 	   7,  -35, 	   3,  -27, 	  -4,  -17
+.2byte   11,  -23, 	  -3,  -40, 	  -9,  -31, 	  -4,  -19
+.2byte   22,  -11, 	  12,  -31, 	   5,  -24, 	  -4,  -18
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   32,  -25, 	  14,  -39, 	  12,  -30, 	  -6,  -23
+.2byte   14,  -30, 	  -5,  -43, 	  -5,  -34, 	  -4,  -22
+.2byte   31,  -17, 	  15,  -31, 	  14,  -24, 	  -5,  -25
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   22,  -38, 	   0,  -42, 	   8,  -37, 	  -4,  -22
+.2byte   13,  -41, 	  -9,  -40, 	   1,  -35, 	  -3,  -20
+.2byte   22,  -34, 	   5,  -40, 	  12,  -35, 	  -3,  -23
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte   -1,  -50, 	   6,  -39, 	  -7,  -39, 	   0,  -23
+.2byte    0,  -47, 	   5,  -35, 	  -6,  -35, 	  -1,  -24
+.2byte    0,  -50, 	   6,  -39, 	  -6,  -39, 	   0,  -25
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte  -23,  -38, 	  -1,  -42, 	  -9,  -37, 	   3,  -22
+.2byte  -14,  -41, 	   8,  -40, 	  -2,  -35, 	   2,  -20
+.2byte  -23,  -34, 	  -6,  -40, 	 -13,  -35, 	   2,  -23
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -33,  -25, 	 -15,  -39, 	 -13,  -30, 	   5,  -23
+.2byte  -15,  -30, 	   4,  -43, 	   4,  -34, 	   3,  -22
+.2byte  -32,  -17, 	 -16,  -31, 	 -15,  -24, 	   4,  -25
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -24,  -14, 	  -8,  -35, 	  -4,  -27, 	   3,  -17
+.2byte  -12,  -23, 	   2,  -40, 	   8,  -31, 	   3,  -19
+.2byte  -23,  -11, 	 -13,  -31, 	  -6,  -24, 	   3,  -18
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte    0,   -9, 	  -8,  -22, 	   6,  -22, 	   0,  -26
+.2byte    0,  -16, 	  -6,  -29, 	   7,  -29, 	   0,  -26
+.2byte    0,   -6, 	 -10,  -15, 	   8,  -16, 	   0,  -27
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+.2byte   23,  -14, 	   7,  -35, 	   3,  -27, 	  -4,  -17
+.2byte   11,  -23, 	  -3,  -40, 	  -9,  -31, 	  -4,  -19
+.2byte   22,  -11, 	  12,  -31, 	   5,  -24, 	  -4,  -18
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   32,  -25, 	  14,  -39, 	  12,  -30, 	  -6,  -23
+.2byte   14,  -30, 	  -5,  -43, 	  -5,  -34, 	  -4,  -22
+.2byte   31,  -17, 	  15,  -31, 	  14,  -24, 	  -5,  -25
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   22,  -38, 	   0,  -42, 	   8,  -37, 	  -4,  -22
+.2byte   13,  -41, 	  -9,  -40, 	   1,  -35, 	  -3,  -20
+.2byte   22,  -34, 	   5,  -40, 	  12,  -35, 	  -3,  -23
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte   -1,  -50, 	   6,  -39, 	  -7,  -39, 	   0,  -23
+.2byte    0,  -47, 	   5,  -35, 	  -6,  -35, 	  -1,  -24
+.2byte    0,  -50, 	   6,  -39, 	  -6,  -39, 	   0,  -25
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte  -23,  -38, 	  -1,  -42, 	  -9,  -37, 	   3,  -22
+.2byte  -14,  -41, 	   8,  -40, 	  -2,  -35, 	   2,  -20
+.2byte  -23,  -34, 	  -6,  -40, 	 -13,  -35, 	   2,  -23
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -33,  -25, 	 -15,  -39, 	 -13,  -30, 	   5,  -23
+.2byte  -15,  -30, 	   4,  -43, 	   4,  -34, 	   3,  -22
+.2byte  -32,  -17, 	 -16,  -31, 	 -15,  -24, 	   4,  -25
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -24,  -14, 	  -8,  -35, 	  -4,  -27, 	   3,  -17
+.2byte  -12,  -23, 	   2,  -40, 	   8,  -31, 	   3,  -19
+.2byte  -23,  -11, 	 -13,  -31, 	  -6,  -24, 	   3,  -18
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+.2byte   -7,   -8, 	  -6,  -24, 	   5,  -17, 	   3,  -11
+.2byte   -7,   -4, 	  -6,  -24, 	   5,  -15, 	   2,   -9
+.2byte    0,   -2, 	  -7,  -26, 	   6,  -26, 	   0,  -21
+.2byte   23,   -9, 	  12,  -36, 	   3,  -31, 	   1,  -21
+.2byte   30,  -19, 	  11,  -39, 	  10,  -32, 	  -4,  -23
+.2byte   23,  -24, 	   2,  -37, 	   9,  -30, 	  -6,  -18
+.2byte    1,  -36, 	   7,  -29, 	  -5,  -29, 	   0,  -18
+.2byte  -24,  -24, 	  -3,  -37, 	 -10,  -30, 	   5,  -18
+.2byte  -31,  -19, 	 -12,  -39, 	 -11,  -32, 	   3,  -23
+.2byte  -20,   -9, 	  -9,  -36, 	   0,  -31, 	   2,  -21
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte    0,   -9, 	  -8,  -22, 	   6,  -22, 	   0,  -26
+.2byte    0,  -16, 	  -6,  -29, 	   7,  -29, 	   0,  -26
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+.2byte   23,  -14, 	   7,  -35, 	   3,  -27, 	  -4,  -17
+.2byte   11,  -23, 	  -3,  -40, 	  -9,  -31, 	  -4,  -19
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   32,  -25, 	  14,  -39, 	  12,  -30, 	  -6,  -23
+.2byte   14,  -30, 	  -5,  -43, 	  -5,  -34, 	  -4,  -22
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   22,  -38, 	   0,  -42, 	   8,  -37, 	  -4,  -22
+.2byte   13,  -41, 	  -9,  -40, 	   1,  -35, 	  -3,  -20
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte   -1,  -50, 	   6,  -39, 	  -7,  -39, 	   0,  -23
+.2byte    0,  -47, 	   5,  -35, 	  -6,  -35, 	  -1,  -24
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte  -23,  -38, 	  -1,  -42, 	  -9,  -37, 	   3,  -22
+.2byte  -14,  -41, 	   8,  -40, 	  -2,  -35, 	   2,  -20
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -33,  -25, 	 -15,  -39, 	 -13,  -30, 	   5,  -23
+.2byte  -15,  -30, 	   4,  -43, 	   4,  -34, 	   3,  -22
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -24,  -14, 	  -8,  -35, 	  -4,  -27, 	   3,  -17
+.2byte  -12,  -23, 	   2,  -40, 	   8,  -31, 	   3,  -19
+.2byte    0,   -9, 	  -8,  -22, 	   6,  -22, 	   0,  -26
+.2byte  -24,  -14, 	  -8,  -35, 	  -4,  -27, 	   3,  -17
+.2byte  -33,  -25, 	 -15,  -39, 	 -13,  -30, 	   5,  -23
+.2byte  -23,  -38, 	  -1,  -42, 	  -9,  -37, 	   3,  -22
+.2byte   -1,  -50, 	   6,  -39, 	  -7,  -39, 	   0,  -23
+.2byte   22,  -38, 	   0,  -42, 	   8,  -37, 	  -4,  -22
+.2byte   32,  -25, 	  14,  -39, 	  12,  -30, 	  -6,  -23
+.2byte   23,  -14, 	   7,  -35, 	   3,  -27, 	  -4,  -17
+.2byte    0,   -6, 	 -10,  -15, 	   8,  -16, 	   0,  -27
+.2byte   22,  -11, 	  12,  -31, 	   5,  -24, 	  -4,  -18
+.2byte   31,  -17, 	  15,  -31, 	  14,  -24, 	  -5,  -25
+.2byte   22,  -34, 	   5,  -40, 	  12,  -35, 	  -3,  -23
+.2byte    0,  -50, 	   6,  -39, 	  -6,  -39, 	   0,  -25
+.2byte  -23,  -34, 	  -6,  -40, 	 -13,  -35, 	   2,  -23
+.2byte  -32,  -17, 	 -16,  -31, 	 -15,  -24, 	   4,  -25
+.2byte  -23,  -11, 	 -13,  -31, 	  -6,  -24, 	   3,  -18
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte    0,  -16, 	  -6,  -29, 	   7,  -29, 	   0,  -26
+.2byte    0,   -9, 	  -8,  -22, 	   6,  -22, 	   0,  -26
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+.2byte   11,  -23, 	  -3,  -40, 	  -9,  -31, 	  -4,  -19
+.2byte   21,  -14, 	   5,  -35, 	   1,  -27, 	  -6,  -17
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   14,  -30, 	  -5,  -43, 	  -5,  -34, 	  -4,  -22
+.2byte   32,  -25, 	  14,  -39, 	  12,  -30, 	  -6,  -23
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   13,  -41, 	  -9,  -40, 	   1,  -35, 	  -3,  -20
+.2byte   18,  -38, 	  -4,  -42, 	   4,  -37, 	  -8,  -22
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte    0,  -47, 	   5,  -35, 	  -6,  -35, 	  -1,  -24
+.2byte   -1,  -50, 	   6,  -39, 	  -7,  -39, 	   0,  -23
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte  -14,  -41, 	   8,  -40, 	  -2,  -35, 	   2,  -20
+.2byte  -19,  -38, 	   3,  -42, 	  -5,  -37, 	   7,  -22
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -15,  -30, 	   4,  -43, 	   4,  -34, 	   3,  -22
+.2byte  -33,  -25, 	 -15,  -39, 	 -13,  -30, 	   5,  -23
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -12,  -23, 	   2,  -40, 	   8,  -31, 	   3,  -19
+.2byte  -22,  -14, 	  -6,  -35, 	  -2,  -27, 	   5,  -17
+.2byte    0,  -16, 	  -6,  -29, 	   7,  -29, 	   0,  -26
+.2byte  -12,  -23, 	   2,  -40, 	   8,  -31, 	   3,  -19
+.2byte  -15,  -30, 	   4,  -43, 	   4,  -34, 	   3,  -22
+.2byte  -14,  -41, 	   8,  -40, 	  -2,  -35, 	   2,  -20
+.2byte    0,  -47, 	   5,  -35, 	  -6,  -35, 	  -1,  -24
+.2byte   13,  -41, 	  -9,  -40, 	   1,  -35, 	  -3,  -20
+.2byte   14,  -30, 	  -5,  -43, 	  -5,  -34, 	  -4,  -22
+.2byte   11,  -23, 	  -3,  -40, 	  -9,  -31, 	  -4,  -19
+.2byte    0,  -13, 	  -8,  -24, 	   7,  -24, 	   0,  -26
+.2byte  -19,  -20, 	  -4,  -39, 	   0,  -31, 	   4,  -20
+.2byte  -25,  -28, 	  -4,  -42, 	  -3,  -32, 	   4,  -21
+.2byte  -18,  -38, 	   4,  -40, 	  -5,  -34, 	   3,  -19
+.2byte   -1,  -48, 	   6,  -37, 	  -7,  -37, 	   0,  -24
+.2byte   17,  -38, 	  -5,  -40, 	   4,  -34, 	  -4,  -19
+.2byte   24,  -28, 	   3,  -42, 	   2,  -32, 	  -5,  -21
+.2byte   18,  -20, 	   3,  -39, 	  -1,  -31, 	  -5,  -20
+sOnixAnimTable1:
+.4byte sOnixAnims_1_1
+.4byte sOnixAnims_1_2
+.4byte sOnixAnims_1_3
+.4byte sOnixAnims_1_4
+.4byte sOnixAnims_1_5
+.4byte sOnixAnims_1_6
+.4byte sOnixAnims_1_7
+.4byte sOnixAnims_1_8
+sOnixAnimTable2:
+.4byte sOnixAnims_2_1
+.4byte sOnixAnims_2_2
+.4byte sOnixAnims_2_3
+.4byte sOnixAnims_2_4
+.4byte sOnixAnims_2_5
+.4byte sOnixAnims_2_6
+.4byte sOnixAnims_2_7
+.4byte sOnixAnims_2_8
+sOnixAnimTable3:
+.4byte sOnixAnims_3_1
+.4byte sOnixAnims_3_2
+.4byte sOnixAnims_3_3
+.4byte sOnixAnims_3_4
+.4byte sOnixAnims_3_5
+.4byte sOnixAnims_3_6
+.4byte sOnixAnims_3_7
+.4byte sOnixAnims_3_8
+sOnixAnimTable4:
+.4byte sOnixAnims_4_1
+.4byte sOnixAnims_4_2
+.4byte sOnixAnims_4_3
+.4byte sOnixAnims_4_4
+.4byte sOnixAnims_4_5
+.4byte sOnixAnims_4_6
+.4byte sOnixAnims_4_7
+.4byte sOnixAnims_4_8
+sOnixAnimTable5:
+.4byte sOnixAnims_5_1
+.4byte sOnixAnims_5_2
+.4byte sOnixAnims_5_3
+.4byte sOnixAnims_5_4
+.4byte sOnixAnims_5_5
+.4byte sOnixAnims_5_6
+.4byte sOnixAnims_5_7
+.4byte sOnixAnims_5_8
+sOnixAnimTable6:
+.4byte sOnixAnims_6_1
+.4byte sOnixAnims_6_1
+.4byte sOnixAnims_6_1
+.4byte sOnixAnims_6_1
+.4byte sOnixAnims_6_1
+.4byte sOnixAnims_6_1
+.4byte sOnixAnims_6_1
+.4byte sOnixAnims_6_1
+sOnixAnimTable7:
+.4byte sOnixAnims_7_1
+.4byte sOnixAnims_7_2
+.4byte sOnixAnims_7_3
+.4byte sOnixAnims_7_4
+.4byte sOnixAnims_7_5
+.4byte sOnixAnims_7_6
+.4byte sOnixAnims_7_7
+.4byte sOnixAnims_7_8
+sOnixAnimTable8:
+.4byte sOnixAnims_8_1
+.4byte sOnixAnims_8_2
+.4byte sOnixAnims_8_3
+.4byte sOnixAnims_8_4
+.4byte sOnixAnims_8_5
+.4byte sOnixAnims_8_6
+.4byte sOnixAnims_8_7
+.4byte sOnixAnims_8_8
+sOnixAnimTable9:
+.4byte sOnixAnims_9_1
+.4byte sOnixAnims_9_2
+.4byte sOnixAnims_9_3
+.4byte sOnixAnims_9_4
+.4byte sOnixAnims_9_5
+.4byte sOnixAnims_9_6
+.4byte sOnixAnims_9_7
+.4byte sOnixAnims_9_8
+sOnixAnimTable10:
+.4byte sOnixAnims_10_1
+.4byte sOnixAnims_10_2
+.4byte sOnixAnims_10_3
+.4byte sOnixAnims_10_4
+.4byte sOnixAnims_10_5
+.4byte sOnixAnims_10_6
+.4byte sOnixAnims_10_7
+.4byte sOnixAnims_10_8
+sOnixAnimTable11:
+.4byte sOnixAnims_11_1
+.4byte sOnixAnims_11_2
+.4byte sOnixAnims_11_3
+.4byte sOnixAnims_11_4
+.4byte sOnixAnims_11_5
+.4byte sOnixAnims_11_6
+.4byte sOnixAnims_11_7
+.4byte sOnixAnims_11_8
+sOnixAnimTable12:
+.4byte sOnixAnims_12_1
+.4byte sOnixAnims_12_2
+.4byte sOnixAnims_12_3
+.4byte sOnixAnims_12_4
+.4byte sOnixAnims_12_5
+.4byte sOnixAnims_12_6
+.4byte sOnixAnims_12_7
+.4byte sOnixAnims_12_8
+sOnixAnimTable13:
+.4byte sOnixAnims_13_1
+.4byte sOnixAnims_13_2
+.4byte sOnixAnims_13_3
+.4byte sOnixAnims_13_4
+.4byte sOnixAnims_13_5
+.4byte sOnixAnims_13_6
+.4byte sOnixAnims_13_7
+.4byte sOnixAnims_13_8
+sAxAnimationsOnix:
+.4byte sOnixAnimTable1
+.4byte sOnixAnimTable2
+.4byte sOnixAnimTable3
+.4byte sOnixAnimTable4
+.4byte sOnixAnimTable5
+.4byte sOnixAnimTable6
+.4byte sOnixAnimTable7
+.4byte sOnixAnimTable8
+.4byte sOnixAnimTable9
+.4byte sOnixAnimTable10
+.4byte sOnixAnimTable11
+.4byte sOnixAnimTable12
+.4byte sOnixAnimTable13
+sAxSpritesOnix:
+.4byte sOnixSprites1
+.4byte sOnixSprites2
+.4byte sOnixSprites3
+.4byte sOnixSprites4
+.4byte sOnixSprites5
+.4byte sOnixSprites6
+.4byte sOnixSprites7
+.4byte sOnixSprites8
+.4byte sOnixSprites9
+.4byte sOnixSprites10
+.4byte sOnixSprites11
+.4byte sOnixSprites12
+.4byte sOnixSprites13
+.4byte sOnixSprites14
+.4byte sOnixSprites15
+.4byte sOnixSprites16
+.4byte sOnixSprites17
+.4byte sOnixSprites18
+.4byte sOnixSprites19
+.4byte sOnixSprites20
+.4byte sOnixSprites21
+.4byte sOnixSprites22
+.4byte sOnixSprites23
+.4byte sOnixSprites24
+.4byte sOnixSprites25
+.4byte sOnixSprites26
+.4byte sOnixSprites27
+.4byte sOnixSprites28
+.4byte sOnixSprites29
+.4byte sOnixSprites30
+.4byte sOnixSprites31
+.4byte sOnixSprites32
+.4byte sOnixSprites33
+.4byte sOnixSprites34
+.4byte sOnixSprites35
+.4byte sOnixSprites36
+.4byte sOnixSprites37
+.4byte sOnixSprites38
+.4byte sOnixSprites39
+.4byte sOnixSprites40
+.4byte sOnixSprites41
+.4byte sOnixSprites42
+.4byte sOnixSprites43
+.4byte sOnixSprites44
+.4byte sOnixSprites45
+.4byte sOnixSprites46
+sAxMainOnix:
+ax_main sAxPosesOnix, sAxAnimationsOnix, 13, sAxSpritesOnix, sAxPositionsOnix

--- a/data/ax/paras.inc
+++ b/data/ax/paras.inc
@@ -1,0 +1,2994 @@
+.global gAxParas
+gAxParas:
+ax_siro sAxMainParas
+sParasPose1:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose2:
+ax_pose 1, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose3:
+ax_pose 2, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose4:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose5:
+ax_pose 4, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose6:
+ax_pose 5, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose7:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose8:
+ax_pose 7, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose9:
+ax_pose 8, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose10:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose11:
+ax_pose 10, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose12:
+ax_pose 11, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose13:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose14:
+ax_pose 13, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose15:
+ax_pose 14, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose16:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose17:
+ax_pose 10, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose18:
+ax_pose 11, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose19:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose20:
+ax_pose 7, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose21:
+ax_pose 8, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose22:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose23:
+ax_pose 4, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose24:
+ax_pose 5, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose25:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose26:
+ax_pose 1, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose27:
+ax_pose 2, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose28:
+ax_pose 15, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose29:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose30:
+ax_pose 4, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose31:
+ax_pose 5, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose32:
+ax_pose 16, 0x01ee, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose33:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose34:
+ax_pose 7, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose35:
+ax_pose 8, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose36:
+ax_pose 17, 0x01ed, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose37:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose38:
+ax_pose 10, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose39:
+ax_pose 11, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose40:
+ax_pose 18, 0x01ee, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose41:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose42:
+ax_pose 13, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose43:
+ax_pose 14, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose44:
+ax_pose 19, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose45:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose46:
+ax_pose 10, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose47:
+ax_pose 11, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose48:
+ax_pose 18, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose49:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose50:
+ax_pose 7, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose51:
+ax_pose 8, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose52:
+ax_pose 17, 0x01ed, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose53:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose54:
+ax_pose 4, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose55:
+ax_pose 5, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose56:
+ax_pose 16, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose57:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose58:
+ax_pose 1, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose59:
+ax_pose 2, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose60:
+ax_pose 20, 0x01e9, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose61:
+ax_pose 21, 0x01e9, 0x80f0, 0x0c00
+ax_pose 22, 0x01e9, 0x80ee, 0x0c10
+ax_pose_terminator
+sParasPose62:
+ax_pose 22, 0x01e9, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose63:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose64:
+ax_pose 4, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose65:
+ax_pose 5, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose66:
+ax_pose 23, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose67:
+ax_pose 24, 0x01e8, 0x90f2, 0x0c00
+ax_pose 25, 0x01e8, 0x90f2, 0x0c10
+ax_pose_terminator
+sParasPose68:
+ax_pose 25, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose69:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose70:
+ax_pose 7, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose71:
+ax_pose 8, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose72:
+ax_pose 26, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose73:
+ax_pose 27, 0x01e8, 0x90f2, 0x0c00
+ax_pose 28, 0x01e8, 0x90f2, 0x0c10
+ax_pose_terminator
+sParasPose74:
+ax_pose 28, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose75:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose76:
+ax_pose 10, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose77:
+ax_pose 11, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose78:
+ax_pose 29, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose79:
+ax_pose 30, 0x81e9, 0x90ff, 0x0c00
+ax_pose 31, 0x01e8, 0x90f2, 0x0c08
+ax_pose_terminator
+sParasPose80:
+ax_pose 31, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose81:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose82:
+ax_pose 13, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose83:
+ax_pose 14, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose84:
+ax_pose 32, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose85:
+ax_pose 33, 0x01ea, 0x40ee, 0x0c00
+ax_pose 34, 0x01e8, 0x80ee, 0x0c04
+ax_pose_terminator
+sParasPose86:
+ax_pose 34, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose87:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose88:
+ax_pose 10, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose89:
+ax_pose 11, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose90:
+ax_pose 29, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose91:
+ax_pose 30, 0x81e9, 0x80f1, 0x0c00
+ax_pose 31, 0x01e8, 0x80ee, 0x0c08
+ax_pose_terminator
+sParasPose92:
+ax_pose 31, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose93:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose94:
+ax_pose 7, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose95:
+ax_pose 8, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose96:
+ax_pose 26, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose97:
+ax_pose 27, 0x01e8, 0x80ee, 0x0c00
+ax_pose 28, 0x01e8, 0x80ee, 0x0c10
+ax_pose_terminator
+sParasPose98:
+ax_pose 28, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose99:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose100:
+ax_pose 4, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose101:
+ax_pose 5, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose102:
+ax_pose 23, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose103:
+ax_pose 24, 0x01e8, 0x80ee, 0x0c00
+ax_pose 25, 0x01e8, 0x80ee, 0x0c10
+ax_pose_terminator
+sParasPose104:
+ax_pose 25, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose105:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose106:
+ax_pose 35, 0x01e9, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose107:
+ax_pose 36, 0x01e9, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose108:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose109:
+ax_pose 37, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose110:
+ax_pose 38, 0x01e8, 0x90f4, 0x0c00
+ax_pose_terminator
+sParasPose111:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose112:
+ax_pose 39, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose113:
+ax_pose 40, 0x01e8, 0x90f3, 0x0c00
+ax_pose_terminator
+sParasPose114:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose115:
+ax_pose 41, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose116:
+ax_pose 42, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose117:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose118:
+ax_pose 43, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose119:
+ax_pose 44, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose120:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose121:
+ax_pose 41, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose122:
+ax_pose 42, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose123:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose124:
+ax_pose 39, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose125:
+ax_pose 40, 0x01e8, 0x80ed, 0x0c00
+ax_pose_terminator
+sParasPose126:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose127:
+ax_pose 37, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose128:
+ax_pose 38, 0x01e8, 0x80ec, 0x0c00
+ax_pose_terminator
+sParasPose129:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose130:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose131:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose132:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose133:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose134:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose135:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose136:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose137:
+ax_pose 45, 0x41f4, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose138:
+ax_pose 46, 0x41f5, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose139:
+ax_pose 47, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasPose140:
+ax_pose 48, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasPose141:
+ax_pose 49, 0x01e8, 0x90ef, 0x0c00
+ax_pose_terminator
+sParasPose142:
+ax_pose 50, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sParasPose143:
+ax_pose 51, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasPose144:
+ax_pose 50, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sParasPose145:
+ax_pose 49, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasPose146:
+ax_pose 48, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasPose147:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose148:
+ax_pose 1, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose149:
+ax_pose 2, 0x41f5, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose150:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose151:
+ax_pose 4, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose152:
+ax_pose 5, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose153:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose154:
+ax_pose 7, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasPose155:
+ax_pose 8, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose156:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose157:
+ax_pose 10, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose158:
+ax_pose 11, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose159:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose160:
+ax_pose 13, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose161:
+ax_pose 14, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose162:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose163:
+ax_pose 10, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose164:
+ax_pose 11, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose165:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose166:
+ax_pose 7, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose167:
+ax_pose 8, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose168:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose169:
+ax_pose 4, 0x01f2, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasPose170:
+ax_pose 5, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose171:
+ax_pose 36, 0x01ec, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose172:
+ax_pose 38, 0x01ea, 0x80ec, 0x0c00
+ax_pose_terminator
+sParasPose173:
+ax_pose 40, 0x01e9, 0x80ed, 0x0c00
+ax_pose_terminator
+sParasPose174:
+ax_pose 42, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose175:
+ax_pose 44, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose176:
+ax_pose 42, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose177:
+ax_pose 40, 0x01e9, 0x90f3, 0x0c00
+ax_pose_terminator
+sParasPose178:
+ax_pose 38, 0x01ea, 0x90f4, 0x0c00
+ax_pose_terminator
+sParasPose179:
+ax_pose 36, 0x01ec, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose180:
+ax_pose 38, 0x01ea, 0x80ec, 0x0c00
+ax_pose_terminator
+sParasPose181:
+ax_pose 40, 0x01e9, 0x80ed, 0x0c00
+ax_pose_terminator
+sParasPose182:
+ax_pose 42, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose183:
+ax_pose 44, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose184:
+ax_pose 42, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose185:
+ax_pose 40, 0x01e9, 0x90f3, 0x0c00
+ax_pose_terminator
+sParasPose186:
+ax_pose 38, 0x01ea, 0x90f4, 0x0c00
+ax_pose_terminator
+sParasPose187:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose188:
+ax_pose 15, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose189:
+ax_pose 36, 0x01eb, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose190:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose191:
+ax_pose 16, 0x01ee, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose192:
+ax_pose 38, 0x01e9, 0x90f4, 0x0c00
+ax_pose_terminator
+sParasPose193:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose194:
+ax_pose 17, 0x01ed, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose195:
+ax_pose 40, 0x01e8, 0x90f4, 0x0c00
+ax_pose_terminator
+sParasPose196:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose197:
+ax_pose 18, 0x01ee, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose198:
+ax_pose 42, 0x01e8, 0x90f3, 0x0c00
+ax_pose_terminator
+sParasPose199:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose200:
+ax_pose 19, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose201:
+ax_pose 44, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose202:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose203:
+ax_pose 18, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose204:
+ax_pose 42, 0x01e8, 0x80ed, 0x0c00
+ax_pose_terminator
+sParasPose205:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose206:
+ax_pose 17, 0x01ed, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose207:
+ax_pose 40, 0x01e8, 0x80ec, 0x0c00
+ax_pose_terminator
+sParasPose208:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose209:
+ax_pose 16, 0x01ee, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose210:
+ax_pose 38, 0x01e9, 0x80ec, 0x0c00
+ax_pose_terminator
+sParasPose211:
+ax_pose 35, 0x01e9, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose212:
+ax_pose 37, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose213:
+ax_pose 39, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose214:
+ax_pose 41, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose215:
+ax_pose 43, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasPose216:
+ax_pose 41, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose217:
+ax_pose 39, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose218:
+ax_pose 37, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasPose219:
+ax_pose 0, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose220:
+ax_pose 3, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose221:
+ax_pose 6, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose222:
+ax_pose 9, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose223:
+ax_pose 12, 0x41f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasPose224:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose225:
+ax_pose 6, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasPose226:
+ax_pose 3, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+.align 2
+sParasAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_2_1:
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, -5, 0, -5,
+ax_anim 4, 0, 24, 0, -6, 0, -6,
+ax_anim 1, 2, 27, 0, -3, 0, -3,
+ax_anim 3, 0, 27, 0, 0, 0, 0,
+ax_anim 3, 0, 27, 0, 8, 0, 10,
+ax_anim 2, 0, 24, 0, 19, 0, 19,
+ax_anim 2, 1, 24, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 19, 0, 19,
+ax_anim 2, 0, 24, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 19, 0, 19,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 3, 0, 3,
+ax_anim_terminator
+sParasAnims_2_2:
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 2, 0, 30, -5, -5, -5, -5,
+ax_anim 4, 0, 28, -6, -6, -6, -6,
+ax_anim 1, 2, 31, 0, -3, 0, 0,
+ax_anim 3, 0, 31, 6, 0, 6, 5,
+ax_anim 3, 0, 31, 14, 10, 14, 14,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 1, 28, 19, 20, 20, 20,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 19, 20, 20, 20,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 3, 3, 3, 3,
+ax_anim_terminator
+sParasAnims_2_3:
+ax_anim 2, 0, 33, -3, 0, -3, 0,
+ax_anim 2, 0, 34, -5, 0, -5, 0,
+ax_anim 4, 0, 32, -6, 0, -6, 0,
+ax_anim 1, 2, 35, -2, -2, -2, 0,
+ax_anim 3, 0, 35, 4, -6, 4, 0,
+ax_anim 3, 0, 35, 14, -2, 14, 0,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 1, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim_terminator
+sParasAnims_2_4:
+ax_anim 2, 0, 37, -3, 3, -3, 3,
+ax_anim 2, 0, 38, -5, 5, -5, 5,
+ax_anim 4, 0, 36, -6, 6, -6, 6,
+ax_anim 1, 2, 39, -2, -1, -2, 2,
+ax_anim 3, 0, 39, 4, -12, 4, -6,
+ax_anim 3, 0, 39, 14, -22, 14, -19,
+ax_anim 2, 0, 36, 19, -25, 19, -25,
+ax_anim 2, 1, 36, 20, -24, 20, -24,
+ax_anim 2, 0, 36, 19, -25, 19, -25,
+ax_anim 2, 0, 36, 20, -24, 20, -24,
+ax_anim 2, 0, 36, 19, -25, 19, -25,
+ax_anim 2, 0, 36, 10, -12, 10, -12,
+ax_anim 2, 0, 36, 3, -4, 3, -4,
+ax_anim_terminator
+sParasAnims_2_5:
+ax_anim 2, 0, 41, 0, 3, 0, 3,
+ax_anim 2, 0, 42, 0, 5, 0, 5,
+ax_anim 4, 0, 40, 0, 7, 0, 7,
+ax_anim 1, 2, 43, 0, 1, 0, -1,
+ax_anim 3, 0, 43, 0, -14, 0, -12,
+ax_anim 3, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 40, 0, -25, 0, -25,
+ax_anim 2, 1, 40, 1, -25, 1, -25,
+ax_anim 2, 0, 40, 0, -25, 0, -25,
+ax_anim 2, 0, 40, 1, -25, 1, -25,
+ax_anim 2, 0, 40, 0, -25, 0, -25,
+ax_anim 2, 0, 40, 0, -12, 0, -12,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sParasAnims_2_6:
+ax_anim 2, 0, 45, 3, 3, 3, 3,
+ax_anim 2, 0, 46, 5, 5, 5, 5,
+ax_anim 4, 0, 44, 6, 6, 6, 6,
+ax_anim 1, 2, 47, 2, -1, 2, 2,
+ax_anim 3, 0, 47, -4, -12, -4, -6,
+ax_anim 3, 0, 47, -14, -22, -14, -19,
+ax_anim 2, 0, 44, -19, -25, -19, -25,
+ax_anim 2, 1, 44, -20, -24, -20, -24,
+ax_anim 2, 0, 44, -19, -25, -19, -25,
+ax_anim 2, 0, 44, -20, -24, -20, -24,
+ax_anim 2, 0, 44, -19, -25, -19, -25,
+ax_anim 2, 0, 44, -10, -12, -10, -12,
+ax_anim 2, 0, 44, -3, -4, -3, -4,
+ax_anim_terminator
+sParasAnims_2_7:
+ax_anim 2, 0, 49, 3, 0, 3, 0,
+ax_anim 2, 0, 50, 5, 0, 5, 0,
+ax_anim 4, 0, 48, 6, 0, 6, 0,
+ax_anim 1, 2, 51, 2, -2, 2, 0,
+ax_anim 3, 0, 51, -4, -6, -4, 0,
+ax_anim 3, 0, 51, -14, -2, -14, 0,
+ax_anim 2, 0, 48, -19, 0, -19, 0,
+ax_anim 2, 1, 48, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -19, 0, -19, 0,
+ax_anim 2, 0, 48, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -19, 0, -19, 0,
+ax_anim 2, 0, 48, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -3, 0, -3, 0,
+ax_anim_terminator
+sParasAnims_2_8:
+ax_anim 2, 0, 53, 3, -3, 3, -3,
+ax_anim 2, 0, 54, 5, -5, 5, -5,
+ax_anim 4, 0, 52, 6, -6, 6, -6,
+ax_anim 1, 2, 55, 0, -3, 0, 0,
+ax_anim 3, 0, 55, -6, 0, -6, 5,
+ax_anim 3, 0, 55, -14, 10, -14, 14,
+ax_anim 2, 0, 52, -20, 19, -20, 19,
+ax_anim 2, 1, 52, -19, 20, -20, 20,
+ax_anim 2, 0, 52, -20, 19, -20, 19,
+ax_anim 2, 0, 52, -19, 20, -20, 20,
+ax_anim 2, 0, 52, -20, 19, -20, 19,
+ax_anim 2, 0, 52, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sParasAnims_3_1:
+ax_anim 2, 0, 57, 0, -3, 0, -3,
+ax_anim 2, 0, 58, 0, -5, 0, -5,
+ax_anim 6, 0, 59, 0, -6, 0, -6,
+ax_anim 1, 2, 59, 0, -3, 0, -3,
+ax_anim 1, 0, 59, 0, 6, 0, 6,
+ax_anim 2, 0, 60, 0, 14, 0, 14,
+ax_anim 2, 1, 103, 0, 17, 0, 17,
+ax_anim 2, 0, 103, 1, 17, 1, 17,
+ax_anim 2, 0, 103, 0, 17, 0, 17,
+ax_anim 2, 0, 103, 1, 17, 1, 17,
+ax_anim 2, 0, 103, 0, 17, 0, 17,
+ax_anim 2, 0, 56, 0, 8, 0, 8,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sParasAnims_3_2:
+ax_anim 2, 0, 63, -3, -3, -3, -3,
+ax_anim 2, 0, 64, -5, -5, -5, -5,
+ax_anim 6, 0, 65, -6, -6, -6, -6,
+ax_anim 1, 2, 65, -3, -3, -3, -3,
+ax_anim 1, 0, 65, 6, 6, 6, 6,
+ax_anim 2, 0, 66, 14, 14, 14, 14,
+ax_anim 2, 1, 73, 18, 16, 18, 16,
+ax_anim 2, 0, 73, 19, 15, 19, 15,
+ax_anim 2, 0, 73, 18, 16, 18, 16,
+ax_anim 2, 0, 73, 19, 15, 19, 15,
+ax_anim 2, 0, 73, 18, 16, 18, 16,
+ax_anim 2, 0, 62, 8, 8, 8, 8,
+ax_anim 2, 0, 62, 3, 3, 3, 3,
+ax_anim_terminator
+sParasAnims_3_3:
+ax_anim 2, 0, 69, -3, 0, -3, 0,
+ax_anim 2, 0, 70, -5, 0, -5, 0,
+ax_anim 6, 0, 71, -6, 0, -6, 0,
+ax_anim 1, 2, 71, -3, 0, -3, 0,
+ax_anim 1, 0, 71, 6, 0, 6, 0,
+ax_anim 2, 0, 72, 12, 0, 12, 0,
+ax_anim 2, 1, 79, 15, 0, 15, 0,
+ax_anim 2, 0, 79, 15, 1, 15, 1,
+ax_anim 2, 0, 79, 15, 0, 15, 0,
+ax_anim 2, 0, 79, 15, 1, 15, 1,
+ax_anim 2, 0, 79, 15, 0, 15, 0,
+ax_anim 2, 0, 68, 8, 0, 8, 0,
+ax_anim 2, 0, 68, 3, 0, 3, 0,
+ax_anim_terminator
+sParasAnims_3_4:
+ax_anim 2, 0, 75, -3, 3, -3, 3,
+ax_anim 2, 0, 76, -5, 5, -5, 5,
+ax_anim 6, 0, 77, -6, 6, -6, 6,
+ax_anim 1, 2, 77, -3, 3, -3, 3,
+ax_anim 1, 0, 77, 5, -8, 5, -8,
+ax_anim 2, 0, 78, 13, -18, 13, -18,
+ax_anim 2, 1, 85, 14, -21, 14, -21,
+ax_anim 2, 0, 85, 15, -20, 15, -20,
+ax_anim 2, 0, 85, 14, -21, 14, -21,
+ax_anim 2, 0, 85, 15, -20, 15, -20,
+ax_anim 2, 0, 85, 14, -21, 14, -21,
+ax_anim 2, 0, 74, 7, -10, 7, -10,
+ax_anim 2, 0, 74, 2, -4, 2, -4,
+ax_anim_terminator
+sParasAnims_3_5:
+ax_anim 2, 0, 81, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 0, 5, 0, 5,
+ax_anim 6, 0, 83, 0, 6, 0, 6,
+ax_anim 1, 2, 83, 0, 3, 0, 3,
+ax_anim 1, 0, 83, 0, -8, 0, -8,
+ax_anim 2, 0, 84, 0, -16, 0, -16,
+ax_anim 2, 1, 79, 0, -21, 0, -25,
+ax_anim 2, 0, 79, 1, -21, 1, -25,
+ax_anim 2, 0, 79, 0, -21, 0, -25,
+ax_anim 2, 0, 79, 1, -21, 1, -25,
+ax_anim 2, 0, 79, 0, -21, 0, -25,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sParasAnims_3_6:
+ax_anim 2, 0, 87, 3, 3, 3, 3,
+ax_anim 2, 0, 88, 5, 5, 5, 5,
+ax_anim 6, 0, 89, 6, 6, 6, 6,
+ax_anim 1, 2, 89, 3, 3, 3, 3,
+ax_anim 1, 0, 89, -5, -8, -5, -8,
+ax_anim 2, 0, 90, -13, -18, -13, -18,
+ax_anim 2, 1, 85, -16, -21, -16, -21,
+ax_anim 2, 0, 85, -17, -20, -17, -20,
+ax_anim 2, 0, 85, -16, -21, -16, -21,
+ax_anim 2, 0, 85, -17, -20, -17, -20,
+ax_anim 2, 0, 85, -16, -21, -16, -21,
+ax_anim 2, 0, 86, -7, -10, -7, -10,
+ax_anim 2, 0, 86, -2, -4, -2, -4,
+ax_anim_terminator
+sParasAnims_3_7:
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 5, 0, 5, 0,
+ax_anim 6, 0, 95, 6, 0, 6, 0,
+ax_anim 1, 2, 95, 3, 0, 3, 0,
+ax_anim 1, 0, 95, -6, 0, -6, 0,
+ax_anim 2, 0, 96, -12, 0, -12, 0,
+ax_anim 2, 1, 91, -15, 0, -15, 0,
+ax_anim 2, 0, 91, -15, 1, -15, 1,
+ax_anim 2, 0, 91, -15, 0, -15, 0,
+ax_anim 2, 0, 91, -15, 1, -15, 1,
+ax_anim 2, 0, 91, -15, 0, -15, 0,
+ax_anim 2, 0, 92, -8, 0, -8, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim_terminator
+sParasAnims_3_8:
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 100, 5, -5, 5, -5,
+ax_anim 6, 0, 101, 6, -6, 6, -6,
+ax_anim 1, 2, 101, 3, -3, 3, -3,
+ax_anim 1, 0, 101, -6, 6, -6, 6,
+ax_anim 2, 0, 102, -14, 14, -14, 14,
+ax_anim 2, 1, 97, -18, 16, -18, 16,
+ax_anim 2, 0, 97, -19, 15, -19, 15,
+ax_anim 2, 0, 97, -18, 16, -18, 16,
+ax_anim 2, 0, 97, -19, 15, -19, 15,
+ax_anim 2, 0, 97, -18, 16, -18, 16,
+ax_anim 2, 0, 98, -8, 8, -8, 8,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sParasAnims_4_1:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 1, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_4_2:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, -1, 1, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, -1, 1, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 1, -1, 1, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 1, 109, 0, -6, 0, 0,
+ax_anim 2, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_4_3:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 1, 0, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 1, 0, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 1, 0, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, -1, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -7, 0, 0,
+ax_anim 2, 1, 112, 0, -8, 0, 0,
+ax_anim 2, 0, 112, 0, -7, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_4_4:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 1, 1, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 1, 1, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 1, 1, 1, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -7, 0, 0,
+ax_anim 2, 1, 115, 0, -8, 0, 0,
+ax_anim 2, 0, 115, 0, -7, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_4_5:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -7, 0, 0,
+ax_anim 2, 1, 118, 0, -8, 0, 0,
+ax_anim 2, 0, 118, 0, -7, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_4_6:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, -1, 1, -1, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, -1, 1, -1, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 120, -1, 1, -1, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -7, 0, 0,
+ax_anim 2, 1, 121, 0, -8, 0, 0,
+ax_anim 2, 0, 121, 0, -7, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_4_7:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 1, 0, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 1, 0, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 1, 0, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 1, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -7, 0, 0,
+ax_anim 2, 1, 124, 0, -8, 0, 0,
+ax_anim 2, 0, 124, 0, -7, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_4_8:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, -1, -1, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, -1, -1, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 126, -1, -1, -1, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 1, 127, 0, -6, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sParasAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sParasAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sParasAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sParasAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sParasAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sParasAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sParasAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sParasAnims_8_1:
+ax_anim 24, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_8_2:
+ax_anim 24, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_8_3:
+ax_anim 24, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_8_4:
+ax_anim 24, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_8_5:
+ax_anim 24, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_8_6:
+ax_anim 24, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_8_7:
+ax_anim 24, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 166, 0, 0, 0, 0,
+ax_anim 6, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_8_8:
+ax_anim 24, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim 6, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 3, 19, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 22, 20, 22, 20,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 23, -2, 23, -2,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 22, -23, 22, -23,
+ax_anim 2, 3, 172, 22, -15, 22, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -24, 0, -24,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -22, -23, -22, -23,
+ax_anim 2, 3, 176, -22, -15, -22, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -23, -2, -23, -2,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 3, -19, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -22, 20, -22, 20,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_10_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 6, -6, 6, -6,
+ax_anim 2, 0, 185, -6, 6, -6, 6,
+ax_anim 2, 0, 185, 10, -10, 10, -10,
+ax_anim 2, 0, 185, -10, 10, -10, 10,
+ax_anim 2, 0, 185, 12, -12, 12, -12,
+ax_anim 3, 0, 185, -12, 12, -12, 12,
+ax_anim 3, 0, 185, 13, -13, 13, -13,
+ax_anim 3, 0, 185, -13, 13, -13, 13,
+ax_anim 2, 0, 185, 12, -12, 12, -12,
+ax_anim 3, 0, 185, -12, 12, -12, 12,
+ax_anim 2, 0, 185, 10, -10, 10, -10,
+ax_anim 2, 0, 185, -10, 10, -10, 10,
+ax_anim 2, 0, 185, 6, -6, 6, -6,
+ax_anim 2, 0, 185, -6, 6, -6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_10_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_10_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -6, -6, -6, -6,
+ax_anim 2, 0, 183, 6, 6, 6, 6,
+ax_anim 2, 0, 183, -10, -10, -10, -10,
+ax_anim 2, 0, 183, 10, 10, 10, 10,
+ax_anim 2, 0, 183, -12, -12, -12, -12,
+ax_anim 3, 0, 183, 12, 12, 12, 12,
+ax_anim 3, 0, 183, -13, -13, -13, -13,
+ax_anim 3, 0, 183, 13, 13, 13, 13,
+ax_anim 2, 0, 183, -12, -12, -12, -12,
+ax_anim 3, 0, 183, 12, 12, 12, 12,
+ax_anim 2, 0, 183, -10, -10, -10, -10,
+ax_anim 2, 0, 183, 10, 10, 10, 10,
+ax_anim 2, 0, 183, -6, -6, -6, -6,
+ax_anim 2, 0, 183, 6, 6, 6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_10_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 6, -6, 6, -6,
+ax_anim 2, 0, 181, -6, 6, -6, 6,
+ax_anim 2, 0, 181, 10, -10, 10, -10,
+ax_anim 2, 0, 181, -10, 10, -10, 10,
+ax_anim 2, 0, 181, 12, -12, 12, -12,
+ax_anim 3, 0, 181, -12, 12, -12, 12,
+ax_anim 3, 0, 181, 13, -13, 13, -13,
+ax_anim 3, 0, 181, -13, 13, -13, 13,
+ax_anim 2, 0, 181, 12, -12, 12, -12,
+ax_anim 3, 0, 181, -12, 12, -12, 12,
+ax_anim 2, 0, 181, 10, -10, 10, -10,
+ax_anim 2, 0, 181, -10, 10, -10, 10,
+ax_anim 2, 0, 181, 6, -6, 6, -6,
+ax_anim 2, 0, 181, -6, 6, -6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_10_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_10_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 3, 0, 179, -13, -13, -13, -13,
+ax_anim 3, 0, 179, 13, 13, 13, 13,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -25, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -24, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -24, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -25, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -24, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -24, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sParasAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sParasGfx1:
+.incbin "baserom.gba", 0x6F2CB8, 0x100
+sParasSprites1:
+ax_sprite sParasGfx1, 0x100
+ax_sprite_terminator
+sParasGfx2:
+.incbin "baserom.gba", 0x6F2DC8, 0x100
+sParasSprites2:
+ax_sprite sParasGfx2, 0x100
+ax_sprite_terminator
+sParasGfx3:
+.incbin "baserom.gba", 0x6F2ED8, 0x100
+sParasSprites3:
+ax_sprite sParasGfx3, 0x100
+ax_sprite_terminator
+sParasGfx4:
+.incbin "baserom.gba", 0x6F2FE8, 0x200
+sParasSprites4:
+ax_sprite sParasGfx4, 0x200
+ax_sprite_terminator
+sParasGfx5:
+.incbin "baserom.gba", 0x6F31F8, 0x200
+sParasSprites5:
+ax_sprite sParasGfx5, 0x200
+ax_sprite_terminator
+sParasGfx6:
+.incbin "baserom.gba", 0x6F3408, 0x200
+sParasSprites6:
+ax_sprite sParasGfx6, 0x200
+ax_sprite_terminator
+sParasGfx7:
+.incbin "baserom.gba", 0x6F3618, 0x200
+sParasSprites7:
+ax_sprite sParasGfx7, 0x200
+ax_sprite_terminator
+sParasGfx8:
+.incbin "baserom.gba", 0x6F3828, 0x200
+sParasSprites8:
+ax_sprite sParasGfx8, 0x200
+ax_sprite_terminator
+sParasGfx9:
+.incbin "baserom.gba", 0x6F3A38, 0x200
+sParasSprites9:
+ax_sprite sParasGfx9, 0x200
+ax_sprite_terminator
+sParasGfx10:
+.incbin "baserom.gba", 0x6F3C48, 0x200
+sParasSprites10:
+ax_sprite sParasGfx10, 0x200
+ax_sprite_terminator
+sParasGfx11:
+.incbin "baserom.gba", 0x6F3E58, 0x200
+sParasSprites11:
+ax_sprite sParasGfx11, 0x200
+ax_sprite_terminator
+sParasGfx12:
+.incbin "baserom.gba", 0x6F4068, 0x200
+sParasSprites12:
+ax_sprite sParasGfx12, 0x200
+ax_sprite_terminator
+sParasGfx13:
+.incbin "baserom.gba", 0x6F4278, 0x100
+sParasSprites13:
+ax_sprite sParasGfx13, 0x100
+ax_sprite_terminator
+sParasGfx14:
+.incbin "baserom.gba", 0x6F4388, 0x100
+sParasSprites14:
+ax_sprite sParasGfx14, 0x100
+ax_sprite_terminator
+sParasGfx15:
+.incbin "baserom.gba", 0x6F4498, 0x100
+sParasSprites15:
+ax_sprite sParasGfx15, 0x100
+ax_sprite_terminator
+sParasGfx16:
+.incbin "baserom.gba", 0x6F45A8, 0x60
+sParasGfx16_1:
+.incbin "baserom.gba", 0x6F4608, 0x60
+sParasGfx16_2:
+.incbin "baserom.gba", 0x6F4668, 0x60
+sParasSprites16:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx16_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasGfx17:
+.incbin "baserom.gba", 0x6F4708, 0x60
+sParasGfx17_1:
+.incbin "baserom.gba", 0x6F4768, 0x60
+sParasGfx17_2:
+.incbin "baserom.gba", 0x6F47C8, 0x60
+sParasSprites17:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx17_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasGfx18:
+.incbin "baserom.gba", 0x6F4868, 0x60
+sParasGfx18_1:
+.incbin "baserom.gba", 0x6F48C8, 0x60
+sParasGfx18_2:
+.incbin "baserom.gba", 0x6F4928, 0x40
+sParasSprites18:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sParasGfx19:
+.incbin "baserom.gba", 0x6F49A8, 0x60
+sParasGfx19_1:
+.incbin "baserom.gba", 0x6F4A08, 0x60
+sParasGfx19_2:
+.incbin "baserom.gba", 0x6F4A68, 0x60
+sParasSprites19:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx19_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasGfx20:
+.incbin "baserom.gba", 0x6F4B08, 0x60
+sParasGfx20_1:
+.incbin "baserom.gba", 0x6F4B68, 0x60
+sParasGfx20_2:
+.incbin "baserom.gba", 0x6F4BC8, 0x60
+sParasSprites20:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx20_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasGfx21:
+.incbin "baserom.gba", 0x6F4C68, 0x60
+sParasGfx21_1:
+.incbin "baserom.gba", 0x6F4CC8, 0x60
+sParasGfx21_2:
+.incbin "baserom.gba", 0x6F4D28, 0x20
+sParasSprites21:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx21_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasGfx22:
+.incbin "baserom.gba", 0x6F4D88, 0x20
+sParasGfx22_1:
+.incbin "baserom.gba", 0x6F4DA8, 0x40
+sParasGfx22_2:
+.incbin "baserom.gba", 0x6F4DE8, 0x40
+sParasSprites22:
+ax_sprite 0, 0xe0
+ax_sprite sParasGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sParasGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx23:
+.incbin "baserom.gba", 0x6F4E68, 0x60
+sParasGfx23_1:
+.incbin "baserom.gba", 0x6F4EC8, 0x60
+sParasGfx23_2:
+.incbin "baserom.gba", 0x6F4F28, 0x60
+sParasSprites23:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx23_2, 0x60
+ax_sprite_terminator
+sParasGfx24:
+.incbin "baserom.gba", 0x6F4FC0, 0xE0
+sParasGfx24_1:
+.incbin "baserom.gba", 0x6F50A0, 0x40
+sParasSprites24:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx24, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sParasGfx24_1, 0x40
+ax_sprite_terminator
+sParasGfx25:
+.incbin "baserom.gba", 0x6F5108, 0x40
+sParasGfx25_1:
+.incbin "baserom.gba", 0x6F5148, 0x60
+sParasGfx25_2:
+.incbin "baserom.gba", 0x6F51A8, 0x40
+sParasSprites25:
+ax_sprite 0, 0xc0
+ax_sprite sParasGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx26:
+.incbin "baserom.gba", 0x6F5228, 0x40
+sParasGfx26_1:
+.incbin "baserom.gba", 0x6F5268, 0x80
+sParasGfx26_2:
+.incbin "baserom.gba", 0x6F52E8, 0x40
+sParasSprites26:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasGfx26_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sParasGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx27:
+.incbin "baserom.gba", 0x6F5368, 0x40
+sParasGfx27_1:
+.incbin "baserom.gba", 0x6F53A8, 0x60
+sParasGfx27_2:
+.incbin "baserom.gba", 0x6F5408, 0x40
+sParasSprites27:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sParasGfx27_2, 0x40
+ax_sprite_terminator
+sParasGfx28:
+.incbin "baserom.gba", 0x6F5480, 0x60
+sParasGfx28_1:
+.incbin "baserom.gba", 0x6F54E0, 0x20
+sParasGfx28_2:
+.incbin "baserom.gba", 0x6F5500, 0x20
+sParasSprites28:
+ax_sprite 0, 0x80
+ax_sprite sParasGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx28_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sParasGfx28_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sParasGfx29:
+.incbin "baserom.gba", 0x6F5560, 0x40
+sParasGfx29_1:
+.incbin "baserom.gba", 0x6F55A0, 0x100
+sParasSprites29:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasGfx29_1, 0x100
+ax_sprite_terminator
+sParasGfx30:
+.incbin "baserom.gba", 0x6F56C8, 0x80
+sParasGfx30_1:
+.incbin "baserom.gba", 0x6F5748, 0x60
+sParasGfx30_2:
+.incbin "baserom.gba", 0x6F57A8, 0x40
+sParasSprites30:
+ax_sprite 0, 0x80
+ax_sprite sParasGfx30, 0x80
+ax_sprite 0, 0x20
+ax_sprite sParasGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx31:
+.incbin "baserom.gba", 0x6F5828, 0x20
+sParasGfx31_1:
+.incbin "baserom.gba", 0x6F5848, 0x80
+sParasSprites31:
+ax_sprite sParasGfx31, 0x20
+ax_sprite 0, 0x20
+ax_sprite sParasGfx31_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasGfx32:
+.incbin "baserom.gba", 0x6F58F0, 0x60
+sParasGfx32_1:
+.incbin "baserom.gba", 0x6F5950, 0x60
+sParasGfx32_2:
+.incbin "baserom.gba", 0x6F59B0, 0x40
+sParasSprites32:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx33:
+.incbin "baserom.gba", 0x6F5A30, 0x40
+sParasGfx33_1:
+.incbin "baserom.gba", 0x6F5A70, 0x80
+sParasGfx33_2:
+.incbin "baserom.gba", 0x6F5AF0, 0x60
+sParasGfx33_3:
+.incbin "baserom.gba", 0x6F5B50, 0x20
+sParasGfx33_4:
+.incbin "baserom.gba", 0x6F5B70, 0x20
+sParasSprites33:
+ax_sprite sParasGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasGfx33_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sParasGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx33_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sParasGfx33_4, 0x20
+ax_sprite_terminator
+sParasGfx34:
+.incbin "baserom.gba", 0x6F5BE0, 0x80
+sParasSprites34:
+ax_sprite sParasGfx34, 0x80
+ax_sprite_terminator
+sParasGfx35:
+.incbin "baserom.gba", 0x6F5C70, 0x60
+sParasGfx35_1:
+.incbin "baserom.gba", 0x6F5CD0, 0x60
+sParasGfx35_2:
+.incbin "baserom.gba", 0x6F5D30, 0x60
+sParasSprites35:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx35_2, 0x60
+ax_sprite_terminator
+sParasGfx36:
+.incbin "baserom.gba", 0x6F5DC8, 0x60
+sParasGfx36_1:
+.incbin "baserom.gba", 0x6F5E28, 0x60
+sParasGfx36_2:
+.incbin "baserom.gba", 0x6F5E88, 0x40
+sParasSprites36:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx37:
+.incbin "baserom.gba", 0x6F5F08, 0xE0
+sParasGfx37_1:
+.incbin "baserom.gba", 0x6F5FE8, 0x60
+sParasSprites37:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx37, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sParasGfx37_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasGfx38:
+.incbin "baserom.gba", 0x6F6078, 0x40
+sParasGfx38_1:
+.incbin "baserom.gba", 0x6F60B8, 0x60
+sParasGfx38_2:
+.incbin "baserom.gba", 0x6F6118, 0x60
+sParasSprites38:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx38_2, 0x60
+ax_sprite_terminator
+sParasGfx39:
+.incbin "baserom.gba", 0x6F61B0, 0x20
+sParasGfx39_1:
+.incbin "baserom.gba", 0x6F61D0, 0x80
+sParasGfx39_2:
+.incbin "baserom.gba", 0x6F6250, 0x60
+sParasGfx39_3:
+.incbin "baserom.gba", 0x6F62B0, 0x40
+sParasSprites39:
+ax_sprite 0, 0x40
+ax_sprite sParasGfx39, 0x20
+ax_sprite 0, 0x20
+ax_sprite sParasGfx39_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sParasGfx39_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sParasGfx39_3, 0x40
+ax_sprite_terminator
+sParasGfx40:
+.incbin "baserom.gba", 0x6F6338, 0x40
+sParasGfx40_1:
+.incbin "baserom.gba", 0x6F6378, 0x80
+sParasGfx40_2:
+.incbin "baserom.gba", 0x6F63F8, 0x60
+sParasSprites40:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasGfx40_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sParasGfx40_2, 0x60
+ax_sprite_terminator
+sParasGfx41:
+.incbin "baserom.gba", 0x6F6490, 0x40
+sParasGfx41_1:
+.incbin "baserom.gba", 0x6F64D0, 0x60
+sParasGfx41_2:
+.incbin "baserom.gba", 0x6F6530, 0x60
+sParasGfx41_3:
+.incbin "baserom.gba", 0x6F6590, 0x40
+sParasSprites41:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx41_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sParasGfx41_3, 0x40
+ax_sprite_terminator
+sParasGfx42:
+.incbin "baserom.gba", 0x6F6618, 0x40
+sParasGfx42_1:
+.incbin "baserom.gba", 0x6F6658, 0x80
+sParasGfx42_2:
+.incbin "baserom.gba", 0x6F66D8, 0x40
+sParasSprites42:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasGfx42_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sParasGfx42_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx43:
+.incbin "baserom.gba", 0x6F6758, 0x20
+sParasGfx43_1:
+.incbin "baserom.gba", 0x6F6778, 0x100
+sParasGfx43_2:
+.incbin "baserom.gba", 0x6F6878, 0x40
+sParasSprites43:
+ax_sprite 0, 0x40
+ax_sprite sParasGfx43, 0x20
+ax_sprite 0, 0x20
+ax_sprite sParasGfx43_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sParasGfx43_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasGfx44:
+.incbin "baserom.gba", 0x6F68F8, 0x60
+sParasGfx44_1:
+.incbin "baserom.gba", 0x6F6958, 0x60
+sParasGfx44_2:
+.incbin "baserom.gba", 0x6F69B8, 0x20
+sParasGfx44_3:
+.incbin "baserom.gba", 0x6F69D8, 0x20
+sParasSprites44:
+ax_sprite 0, 0xa0
+ax_sprite sParasGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx44_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sParasGfx44_3, 0x20
+ax_sprite_terminator
+sParasGfx45:
+.incbin "baserom.gba", 0x6F6A40, 0x20
+sParasGfx45_1:
+.incbin "baserom.gba", 0x6F6A60, 0xA0
+sParasGfx45_2:
+.incbin "baserom.gba", 0x6F6B00, 0x60
+sParasGfx45_3:
+.incbin "baserom.gba", 0x6F6B60, 0x60
+sParasSprites45:
+ax_sprite 0, 0x20
+ax_sprite sParasGfx45, 0x20
+ax_sprite 0, 0x20
+ax_sprite sParasGfx45_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sParasGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasGfx45_3, 0x60
+ax_sprite_terminator
+sParasGfx46:
+.incbin "baserom.gba", 0x6F6C08, 0x100
+sParasSprites46:
+ax_sprite sParasGfx46, 0x100
+ax_sprite_terminator
+sParasGfx47:
+.incbin "baserom.gba", 0x6F6D18, 0x100
+sParasSprites47:
+ax_sprite sParasGfx47, 0x100
+ax_sprite_terminator
+sParasGfx48:
+.incbin "baserom.gba", 0x6F6E28, 0x200
+sParasSprites48:
+ax_sprite sParasGfx48, 0x200
+ax_sprite_terminator
+sParasGfx49:
+.incbin "baserom.gba", 0x6F7038, 0x200
+sParasSprites49:
+ax_sprite sParasGfx49, 0x200
+ax_sprite_terminator
+sParasGfx50:
+.incbin "baserom.gba", 0x6F7248, 0x200
+sParasSprites50:
+ax_sprite sParasGfx50, 0x200
+ax_sprite_terminator
+sParasGfx51:
+.incbin "baserom.gba", 0x6F7458, 0x200
+sParasSprites51:
+ax_sprite sParasGfx51, 0x200
+ax_sprite_terminator
+sParasGfx52:
+.incbin "baserom.gba", 0x6F7668, 0x200
+sParasSprites52:
+ax_sprite sParasGfx52, 0x200
+ax_sprite_terminator
+sAxPosesParas:
+.4byte sParasPose1
+.4byte sParasPose2
+.4byte sParasPose3
+.4byte sParasPose4
+.4byte sParasPose5
+.4byte sParasPose6
+.4byte sParasPose7
+.4byte sParasPose8
+.4byte sParasPose9
+.4byte sParasPose10
+.4byte sParasPose11
+.4byte sParasPose12
+.4byte sParasPose13
+.4byte sParasPose14
+.4byte sParasPose15
+.4byte sParasPose16
+.4byte sParasPose17
+.4byte sParasPose18
+.4byte sParasPose19
+.4byte sParasPose20
+.4byte sParasPose21
+.4byte sParasPose22
+.4byte sParasPose23
+.4byte sParasPose24
+.4byte sParasPose25
+.4byte sParasPose26
+.4byte sParasPose27
+.4byte sParasPose28
+.4byte sParasPose29
+.4byte sParasPose30
+.4byte sParasPose31
+.4byte sParasPose32
+.4byte sParasPose33
+.4byte sParasPose34
+.4byte sParasPose35
+.4byte sParasPose36
+.4byte sParasPose37
+.4byte sParasPose38
+.4byte sParasPose39
+.4byte sParasPose40
+.4byte sParasPose41
+.4byte sParasPose42
+.4byte sParasPose43
+.4byte sParasPose44
+.4byte sParasPose45
+.4byte sParasPose46
+.4byte sParasPose47
+.4byte sParasPose48
+.4byte sParasPose49
+.4byte sParasPose50
+.4byte sParasPose51
+.4byte sParasPose52
+.4byte sParasPose53
+.4byte sParasPose54
+.4byte sParasPose55
+.4byte sParasPose56
+.4byte sParasPose57
+.4byte sParasPose58
+.4byte sParasPose59
+.4byte sParasPose60
+.4byte sParasPose61
+.4byte sParasPose62
+.4byte sParasPose63
+.4byte sParasPose64
+.4byte sParasPose65
+.4byte sParasPose66
+.4byte sParasPose67
+.4byte sParasPose68
+.4byte sParasPose69
+.4byte sParasPose70
+.4byte sParasPose71
+.4byte sParasPose72
+.4byte sParasPose73
+.4byte sParasPose74
+.4byte sParasPose75
+.4byte sParasPose76
+.4byte sParasPose77
+.4byte sParasPose78
+.4byte sParasPose79
+.4byte sParasPose80
+.4byte sParasPose81
+.4byte sParasPose82
+.4byte sParasPose83
+.4byte sParasPose84
+.4byte sParasPose85
+.4byte sParasPose86
+.4byte sParasPose87
+.4byte sParasPose88
+.4byte sParasPose89
+.4byte sParasPose90
+.4byte sParasPose91
+.4byte sParasPose92
+.4byte sParasPose93
+.4byte sParasPose94
+.4byte sParasPose95
+.4byte sParasPose96
+.4byte sParasPose97
+.4byte sParasPose98
+.4byte sParasPose99
+.4byte sParasPose100
+.4byte sParasPose101
+.4byte sParasPose102
+.4byte sParasPose103
+.4byte sParasPose104
+.4byte sParasPose105
+.4byte sParasPose106
+.4byte sParasPose107
+.4byte sParasPose108
+.4byte sParasPose109
+.4byte sParasPose110
+.4byte sParasPose111
+.4byte sParasPose112
+.4byte sParasPose113
+.4byte sParasPose114
+.4byte sParasPose115
+.4byte sParasPose116
+.4byte sParasPose117
+.4byte sParasPose118
+.4byte sParasPose119
+.4byte sParasPose120
+.4byte sParasPose121
+.4byte sParasPose122
+.4byte sParasPose123
+.4byte sParasPose124
+.4byte sParasPose125
+.4byte sParasPose126
+.4byte sParasPose127
+.4byte sParasPose128
+.4byte sParasPose129
+.4byte sParasPose130
+.4byte sParasPose131
+.4byte sParasPose132
+.4byte sParasPose133
+.4byte sParasPose134
+.4byte sParasPose135
+.4byte sParasPose136
+.4byte sParasPose137
+.4byte sParasPose138
+.4byte sParasPose139
+.4byte sParasPose140
+.4byte sParasPose141
+.4byte sParasPose142
+.4byte sParasPose143
+.4byte sParasPose144
+.4byte sParasPose145
+.4byte sParasPose146
+.4byte sParasPose147
+.4byte sParasPose148
+.4byte sParasPose149
+.4byte sParasPose150
+.4byte sParasPose151
+.4byte sParasPose152
+.4byte sParasPose153
+.4byte sParasPose154
+.4byte sParasPose155
+.4byte sParasPose156
+.4byte sParasPose157
+.4byte sParasPose158
+.4byte sParasPose159
+.4byte sParasPose160
+.4byte sParasPose161
+.4byte sParasPose162
+.4byte sParasPose163
+.4byte sParasPose164
+.4byte sParasPose165
+.4byte sParasPose166
+.4byte sParasPose167
+.4byte sParasPose168
+.4byte sParasPose169
+.4byte sParasPose170
+.4byte sParasPose171
+.4byte sParasPose172
+.4byte sParasPose173
+.4byte sParasPose174
+.4byte sParasPose175
+.4byte sParasPose176
+.4byte sParasPose177
+.4byte sParasPose178
+.4byte sParasPose179
+.4byte sParasPose180
+.4byte sParasPose181
+.4byte sParasPose182
+.4byte sParasPose183
+.4byte sParasPose184
+.4byte sParasPose185
+.4byte sParasPose186
+.4byte sParasPose187
+.4byte sParasPose188
+.4byte sParasPose189
+.4byte sParasPose190
+.4byte sParasPose191
+.4byte sParasPose192
+.4byte sParasPose193
+.4byte sParasPose194
+.4byte sParasPose195
+.4byte sParasPose196
+.4byte sParasPose197
+.4byte sParasPose198
+.4byte sParasPose199
+.4byte sParasPose200
+.4byte sParasPose201
+.4byte sParasPose202
+.4byte sParasPose203
+.4byte sParasPose204
+.4byte sParasPose205
+.4byte sParasPose206
+.4byte sParasPose207
+.4byte sParasPose208
+.4byte sParasPose209
+.4byte sParasPose210
+.4byte sParasPose211
+.4byte sParasPose212
+.4byte sParasPose213
+.4byte sParasPose214
+.4byte sParasPose215
+.4byte sParasPose216
+.4byte sParasPose217
+.4byte sParasPose218
+.4byte sParasPose219
+.4byte sParasPose220
+.4byte sParasPose221
+.4byte sParasPose222
+.4byte sParasPose223
+.4byte sParasPose224
+.4byte sParasPose225
+.4byte sParasPose226
+sAxPositionsParas:
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte    0,    1, 	  -6,    3, 	   5,    1, 	   0,   -4
+.2byte    0,    1, 	  -5,    2, 	   5,    3, 	   0,   -4
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+.2byte    4,    0, 	  11,    0, 	   1,    3, 	   0,   -4
+.2byte    4,    0, 	   8,   -1, 	   3,    4, 	   0,   -4
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -3, 	  11,   -3, 	   6,    2, 	   0,   -5
+.2byte    9,   -2, 	   8,   -2, 	   9,    1, 	   0,   -5
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    4,   -7, 	   1,   -8, 	   7,   -4, 	   0,   -5
+.2byte    5,   -7, 	  -1,   -8, 	  10,   -6, 	   0,   -5
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte    0,   -8, 	   2,   -9, 	  -6,   -6, 	   0,   -6
+.2byte    0,   -8, 	   4,   -7, 	  -2,   -9, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -4, 	  -1,   -5
+.2byte   -6,   -7, 	   0,   -8, 	 -11,   -6, 	  -1,   -5
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -3, 	 -12,   -3, 	  -7,    2, 	  -1,   -5
+.2byte  -10,   -2, 	  -9,   -2, 	 -10,    1, 	  -1,   -5
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -5,    0, 	 -12,    0, 	  -2,    3, 	  -1,   -4
+.2byte   -5,    0, 	  -9,   -1, 	  -4,    4, 	  -1,   -4
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte    0,    1, 	  -6,    3, 	   5,    1, 	   0,   -4
+.2byte    0,    1, 	  -5,    2, 	   5,    3, 	   0,   -4
+.2byte    0,   -6, 	  -5,    0, 	   4,    0, 	   0,  -11
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+.2byte    4,    0, 	  11,    0, 	   1,    3, 	   0,   -4
+.2byte    4,    0, 	   8,   -1, 	   3,    4, 	   0,   -4
+.2byte    4,   -6, 	   7,   -2, 	  -1,    1, 	   0,   -9
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -3, 	  11,   -3, 	   6,    2, 	   0,   -5
+.2byte    9,   -2, 	   8,   -2, 	   9,    1, 	   0,   -5
+.2byte    8,   -8, 	   3,    1, 	   3,    2, 	   0,  -11
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    4,   -7, 	   1,   -8, 	   7,   -4, 	   0,   -5
+.2byte    5,   -7, 	  -1,   -8, 	  10,   -6, 	   0,   -5
+.2byte    5,  -12, 	  -2,   -5, 	   5,   -2, 	   0,   -9
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte    0,   -8, 	   2,   -9, 	  -6,   -6, 	   0,   -6
+.2byte    0,   -8, 	   4,   -7, 	  -2,   -9, 	   0,   -6
+.2byte    0,  -13, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -4, 	  -1,   -5
+.2byte   -6,   -7, 	   0,   -8, 	 -11,   -6, 	  -1,   -5
+.2byte   -6,  -12, 	   1,   -5, 	  -6,   -2, 	  -1,   -9
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -3, 	 -12,   -3, 	  -7,    2, 	  -1,   -5
+.2byte  -10,   -2, 	  -9,   -2, 	 -10,    1, 	  -1,   -5
+.2byte   -9,   -8, 	  -4,    1, 	  -4,    2, 	  -1,  -11
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -5,    0, 	 -12,    0, 	  -2,    3, 	  -1,   -4
+.2byte   -5,    0, 	  -9,   -1, 	  -4,    4, 	  -1,   -4
+.2byte   -5,   -6, 	  -8,   -2, 	   0,    1, 	  -1,   -9
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte    0,    1, 	  -6,    3, 	   5,    1, 	   0,   -4
+.2byte    0,    1, 	  -5,    2, 	   5,    3, 	   0,   -4
+.2byte    0,   -3, 	  -6,    1, 	  11,  -13, 	   0,   -8
+.2byte   -2,    0, 	  -6,    1, 	  -3,    4, 	   0,   -5
+.2byte   -2,    0, 	  -6,    1, 	  -3,    4, 	   0,   -5
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+.2byte    4,    0, 	  11,    0, 	   1,    3, 	   0,   -4
+.2byte    4,    0, 	   8,   -1, 	   3,    4, 	   0,   -4
+.2byte    4,   -2, 	   9,   -2, 	  -8,  -12, 	   0,   -7
+.2byte    5,   -2, 	   9,   -3, 	   8,    1, 	   1,   -6
+.2byte    5,   -2, 	   9,   -3, 	   8,    1, 	   1,   -6
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -3, 	  11,   -3, 	   6,    2, 	   0,   -5
+.2byte    9,   -2, 	   8,   -2, 	   9,    1, 	   0,   -5
+.2byte    8,   -5, 	   8,   -4, 	   0,  -14, 	  -1,   -7
+.2byte    7,   -4, 	   7,   -5, 	  11,   -3, 	   0,   -6
+.2byte    7,   -4, 	   7,   -5, 	  11,   -3, 	   0,   -6
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    4,   -7, 	   1,   -8, 	   7,   -4, 	   0,   -5
+.2byte    5,   -7, 	  -1,   -8, 	  10,   -6, 	   0,   -5
+.2byte    3,   -9, 	   1,  -10, 	  11,  -14, 	   0,   -8
+.2byte    2,   -8, 	  -2,   -8, 	   3,   -8, 	  -1,   -6
+.2byte    2,   -8, 	  -2,   -8, 	   3,   -8, 	  -1,   -6
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte    0,   -8, 	   2,   -9, 	  -6,   -6, 	   0,   -6
+.2byte    0,   -8, 	   4,   -7, 	  -2,   -9, 	   0,   -6
+.2byte    0,  -10, 	   2,  -11, 	 -12,  -17, 	   0,   -7
+.2byte    1,   -9, 	   2,  -10, 	  -1,  -10, 	   0,   -6
+.2byte    1,   -9, 	   2,  -10, 	  -1,  -10, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -4, 	  -1,   -5
+.2byte   -6,   -7, 	   0,   -8, 	 -11,   -6, 	  -1,   -5
+.2byte   -4,   -9, 	  -2,  -10, 	 -12,  -14, 	  -1,   -8
+.2byte   -3,   -8, 	   1,   -8, 	  -4,   -8, 	   0,   -6
+.2byte   -3,   -8, 	   1,   -8, 	  -4,   -8, 	   0,   -6
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -3, 	 -12,   -3, 	  -7,    2, 	  -1,   -5
+.2byte  -10,   -2, 	  -9,   -2, 	 -10,    1, 	  -1,   -5
+.2byte   -9,   -5, 	  -9,   -4, 	  -1,  -14, 	   0,   -7
+.2byte   -8,   -4, 	  -8,   -5, 	 -12,   -3, 	  -1,   -6
+.2byte   -8,   -4, 	  -8,   -5, 	 -12,   -3, 	  -1,   -6
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -5,    0, 	 -12,    0, 	  -2,    3, 	  -1,   -4
+.2byte   -5,    0, 	  -9,   -1, 	  -4,    4, 	  -1,   -4
+.2byte   -5,   -2, 	 -10,   -2, 	   7,  -12, 	  -1,   -7
+.2byte   -6,   -2, 	 -10,   -3, 	  -9,    1, 	  -2,   -6
+.2byte   -6,   -2, 	 -10,   -3, 	  -9,    1, 	  -2,   -6
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte   -1,    0, 	   0,    2, 	   0,    0, 	   0,   -5
+.2byte    0,   -5, 	 -11,  -12, 	  10,  -12, 	   0,   -9
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+.2byte    5,    0, 	   6,    1, 	   4,    0, 	   1,   -5
+.2byte    4,   -6, 	  11,  -15, 	  -6,   -7, 	  -1,   -9
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    8,   -4, 	  10,   -3, 	   8,   -3, 	   1,   -5
+.2byte    5,  -10, 	   5,  -18, 	   6,   -7, 	  -1,   -8
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    4,   -8, 	   2,  -10, 	   6,   -8, 	   0,   -7
+.2byte    2,  -11, 	  -4,  -19, 	  12,  -12, 	  -2,   -7
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte   -1,   -9, 	   1,   -9, 	  -2,   -9, 	   0,   -6
+.2byte   -1,  -11, 	   9,  -16, 	 -10,  -16, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte   -5,   -8, 	  -3,  -10, 	  -7,   -8, 	  -1,   -7
+.2byte   -3,  -11, 	   3,  -19, 	 -13,  -12, 	   1,   -7
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte   -9,   -4, 	 -11,   -3, 	  -9,   -3, 	  -2,   -5
+.2byte   -6,  -10, 	  -6,  -18, 	  -7,   -7, 	   0,   -8
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -6,    0, 	  -7,    1, 	  -5,    0, 	  -2,   -5
+.2byte   -5,   -6, 	 -12,  -15, 	   5,   -7, 	   0,   -9
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+.2byte   -5,    1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -5,    2, 	  -9,    0, 	  -4,    3, 	  -1,   -4
+.2byte    0,    2, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte    3,    1, 	   5,   -6, 	  -3,   -3, 	  -1,   -5
+.2byte    8,   -1, 	   6,   -8, 	   4,   -5, 	  -1,   -5
+.2byte    4,   -7, 	   0,  -10, 	   7,   -6, 	  -1,   -4
+.2byte    0,   -6, 	   2,   -7, 	  -3,   -7, 	   0,   -4
+.2byte   -5,   -7, 	  -1,  -10, 	  -8,   -6, 	   0,   -4
+.2byte   -8,   -1, 	  -6,   -8, 	  -4,   -5, 	   1,   -5
+.2byte   -4,    1, 	  -6,   -6, 	   2,   -3, 	   0,   -5
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte    0,    1, 	  -6,    3, 	   5,    1, 	   0,   -4
+.2byte    0,    1, 	  -5,    2, 	   5,    3, 	   0,   -4
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+.2byte    4,    0, 	  11,    0, 	   1,    3, 	   0,   -4
+.2byte    4,    0, 	   8,   -1, 	   3,    4, 	   0,   -4
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -3, 	  11,   -3, 	   6,    2, 	   0,   -5
+.2byte    9,   -2, 	   8,   -2, 	   9,    1, 	   0,   -5
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    4,   -7, 	   1,   -8, 	   7,   -4, 	   0,   -5
+.2byte    5,   -7, 	  -1,   -8, 	  10,   -6, 	   0,   -5
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte    0,   -8, 	   2,   -9, 	  -6,   -6, 	   0,   -6
+.2byte    0,   -8, 	   4,   -7, 	  -2,   -9, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte   -5,   -7, 	  -2,   -8, 	  -8,   -4, 	  -1,   -5
+.2byte   -6,   -7, 	   0,   -8, 	 -11,   -6, 	  -1,   -5
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -3, 	 -12,   -3, 	  -7,    2, 	  -1,   -5
+.2byte  -10,   -2, 	  -9,   -2, 	 -10,    1, 	  -1,   -5
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -5,    0, 	 -12,    0, 	  -2,    3, 	  -1,   -4
+.2byte   -5,    0, 	  -9,   -1, 	  -4,    4, 	  -1,   -4
+.2byte    0,   -2, 	 -11,   -9, 	  10,   -9, 	   0,   -6
+.2byte   -5,   -4, 	 -12,  -13, 	   5,   -5, 	   0,   -7
+.2byte   -6,   -9, 	  -6,  -17, 	  -7,   -6, 	   0,   -7
+.2byte   -3,  -11, 	   3,  -19, 	 -13,  -12, 	   1,   -7
+.2byte   -1,  -11, 	   9,  -16, 	 -10,  -16, 	   0,   -6
+.2byte    2,  -11, 	  -4,  -19, 	  12,  -12, 	  -2,   -7
+.2byte    5,   -9, 	   5,  -17, 	   6,   -6, 	  -1,   -7
+.2byte    4,   -4, 	  11,  -13, 	  -6,   -5, 	  -1,   -7
+.2byte    0,   -2, 	 -11,   -9, 	  10,   -9, 	   0,   -6
+.2byte   -5,   -4, 	 -12,  -13, 	   5,   -5, 	   0,   -7
+.2byte   -6,   -9, 	  -6,  -17, 	  -7,   -6, 	   0,   -7
+.2byte   -3,  -11, 	   3,  -19, 	 -13,  -12, 	   1,   -7
+.2byte   -1,  -11, 	   9,  -16, 	 -10,  -16, 	   0,   -6
+.2byte    2,  -11, 	  -4,  -19, 	  12,  -12, 	  -2,   -7
+.2byte    5,   -9, 	   5,  -17, 	   6,   -6, 	  -1,   -7
+.2byte    4,   -4, 	  11,  -13, 	  -6,   -5, 	  -1,   -7
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte    0,   -6, 	  -5,    0, 	   4,    0, 	   0,  -11
+.2byte    0,   -3, 	 -11,  -10, 	  10,  -10, 	   0,   -7
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+.2byte    4,   -6, 	   7,   -2, 	  -1,    1, 	   0,   -9
+.2byte    4,   -5, 	  11,  -14, 	  -6,   -6, 	  -1,   -8
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    8,   -8, 	   3,    1, 	   3,    2, 	   0,  -11
+.2byte    6,  -10, 	   6,  -18, 	   7,   -7, 	   0,   -8
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    5,  -12, 	  -2,   -5, 	   5,   -2, 	   0,   -9
+.2byte    3,  -11, 	  -3,  -19, 	  13,  -12, 	  -1,   -7
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte    0,  -13, 	   4,   -4, 	  -5,   -4, 	   0,  -10
+.2byte   -1,  -11, 	   9,  -16, 	 -10,  -16, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte   -6,  -12, 	   1,   -5, 	  -6,   -2, 	  -1,   -9
+.2byte   -4,  -11, 	   2,  -19, 	 -14,  -12, 	   0,   -7
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte   -9,   -8, 	  -4,    1, 	  -4,    2, 	  -1,  -11
+.2byte   -7,  -10, 	  -7,  -18, 	  -8,   -7, 	  -1,   -8
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -5,   -6, 	  -8,   -2, 	   0,    1, 	  -1,   -9
+.2byte   -5,   -5, 	 -12,  -14, 	   5,   -6, 	   0,   -8
+.2byte   -1,    0, 	   0,    2, 	   0,    0, 	   0,   -5
+.2byte   -6,    0, 	  -7,    1, 	  -5,    0, 	  -2,   -5
+.2byte   -9,   -4, 	 -11,   -3, 	  -9,   -3, 	  -2,   -5
+.2byte   -5,   -8, 	  -3,  -10, 	  -7,   -8, 	  -1,   -7
+.2byte   -1,   -9, 	   1,   -9, 	  -2,   -9, 	   0,   -6
+.2byte    4,   -8, 	   2,  -10, 	   6,   -8, 	   0,   -7
+.2byte    8,   -4, 	  10,   -3, 	   8,   -3, 	   1,   -5
+.2byte    5,    0, 	   6,    1, 	   4,    0, 	   1,   -5
+.2byte    0,    0, 	  -5,    1, 	   4,    1, 	   0,   -5
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	  -1,   -5
+.2byte   -9,   -3, 	  -9,   -1, 	  -8,    0, 	  -1,   -6
+.2byte   -5,   -7, 	  -1,   -9, 	  -9,   -5, 	  -1,   -7
+.2byte    0,   -9, 	   3,   -9, 	  -4,   -9, 	   0,   -7
+.2byte    4,   -7, 	   0,   -9, 	   8,   -5, 	   0,   -7
+.2byte    8,   -3, 	   8,   -1, 	   7,    0, 	   0,   -6
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	   0,   -5
+sParasAnimTable1:
+.4byte sParasAnims_1_1
+.4byte sParasAnims_1_2
+.4byte sParasAnims_1_3
+.4byte sParasAnims_1_4
+.4byte sParasAnims_1_5
+.4byte sParasAnims_1_6
+.4byte sParasAnims_1_7
+.4byte sParasAnims_1_8
+sParasAnimTable2:
+.4byte sParasAnims_2_1
+.4byte sParasAnims_2_2
+.4byte sParasAnims_2_3
+.4byte sParasAnims_2_4
+.4byte sParasAnims_2_5
+.4byte sParasAnims_2_6
+.4byte sParasAnims_2_7
+.4byte sParasAnims_2_8
+sParasAnimTable3:
+.4byte sParasAnims_3_1
+.4byte sParasAnims_3_2
+.4byte sParasAnims_3_3
+.4byte sParasAnims_3_4
+.4byte sParasAnims_3_5
+.4byte sParasAnims_3_6
+.4byte sParasAnims_3_7
+.4byte sParasAnims_3_8
+sParasAnimTable4:
+.4byte sParasAnims_4_1
+.4byte sParasAnims_4_2
+.4byte sParasAnims_4_3
+.4byte sParasAnims_4_4
+.4byte sParasAnims_4_5
+.4byte sParasAnims_4_6
+.4byte sParasAnims_4_7
+.4byte sParasAnims_4_8
+sParasAnimTable5:
+.4byte sParasAnims_5_1
+.4byte sParasAnims_5_2
+.4byte sParasAnims_5_3
+.4byte sParasAnims_5_4
+.4byte sParasAnims_5_5
+.4byte sParasAnims_5_6
+.4byte sParasAnims_5_7
+.4byte sParasAnims_5_8
+sParasAnimTable6:
+.4byte sParasAnims_6_1
+.4byte sParasAnims_6_1
+.4byte sParasAnims_6_1
+.4byte sParasAnims_6_1
+.4byte sParasAnims_6_1
+.4byte sParasAnims_6_1
+.4byte sParasAnims_6_1
+.4byte sParasAnims_6_1
+sParasAnimTable7:
+.4byte sParasAnims_7_1
+.4byte sParasAnims_7_2
+.4byte sParasAnims_7_3
+.4byte sParasAnims_7_4
+.4byte sParasAnims_7_5
+.4byte sParasAnims_7_6
+.4byte sParasAnims_7_7
+.4byte sParasAnims_7_8
+sParasAnimTable8:
+.4byte sParasAnims_8_1
+.4byte sParasAnims_8_2
+.4byte sParasAnims_8_3
+.4byte sParasAnims_8_4
+.4byte sParasAnims_8_5
+.4byte sParasAnims_8_6
+.4byte sParasAnims_8_7
+.4byte sParasAnims_8_8
+sParasAnimTable9:
+.4byte sParasAnims_9_1
+.4byte sParasAnims_9_2
+.4byte sParasAnims_9_3
+.4byte sParasAnims_9_4
+.4byte sParasAnims_9_5
+.4byte sParasAnims_9_6
+.4byte sParasAnims_9_7
+.4byte sParasAnims_9_8
+sParasAnimTable10:
+.4byte sParasAnims_10_1
+.4byte sParasAnims_10_2
+.4byte sParasAnims_10_3
+.4byte sParasAnims_10_4
+.4byte sParasAnims_10_5
+.4byte sParasAnims_10_6
+.4byte sParasAnims_10_7
+.4byte sParasAnims_10_8
+sParasAnimTable11:
+.4byte sParasAnims_11_1
+.4byte sParasAnims_11_2
+.4byte sParasAnims_11_3
+.4byte sParasAnims_11_4
+.4byte sParasAnims_11_5
+.4byte sParasAnims_11_6
+.4byte sParasAnims_11_7
+.4byte sParasAnims_11_8
+sParasAnimTable12:
+.4byte sParasAnims_12_1
+.4byte sParasAnims_12_2
+.4byte sParasAnims_12_3
+.4byte sParasAnims_12_4
+.4byte sParasAnims_12_5
+.4byte sParasAnims_12_6
+.4byte sParasAnims_12_7
+.4byte sParasAnims_12_8
+sParasAnimTable13:
+.4byte sParasAnims_13_1
+.4byte sParasAnims_13_2
+.4byte sParasAnims_13_3
+.4byte sParasAnims_13_4
+.4byte sParasAnims_13_5
+.4byte sParasAnims_13_6
+.4byte sParasAnims_13_7
+.4byte sParasAnims_13_8
+sAxAnimationsParas:
+.4byte sParasAnimTable1
+.4byte sParasAnimTable2
+.4byte sParasAnimTable3
+.4byte sParasAnimTable4
+.4byte sParasAnimTable5
+.4byte sParasAnimTable6
+.4byte sParasAnimTable7
+.4byte sParasAnimTable8
+.4byte sParasAnimTable9
+.4byte sParasAnimTable10
+.4byte sParasAnimTable11
+.4byte sParasAnimTable12
+.4byte sParasAnimTable13
+sAxSpritesParas:
+.4byte sParasSprites1
+.4byte sParasSprites2
+.4byte sParasSprites3
+.4byte sParasSprites4
+.4byte sParasSprites5
+.4byte sParasSprites6
+.4byte sParasSprites7
+.4byte sParasSprites8
+.4byte sParasSprites9
+.4byte sParasSprites10
+.4byte sParasSprites11
+.4byte sParasSprites12
+.4byte sParasSprites13
+.4byte sParasSprites14
+.4byte sParasSprites15
+.4byte sParasSprites16
+.4byte sParasSprites17
+.4byte sParasSprites18
+.4byte sParasSprites19
+.4byte sParasSprites20
+.4byte sParasSprites21
+.4byte sParasSprites22
+.4byte sParasSprites23
+.4byte sParasSprites24
+.4byte sParasSprites25
+.4byte sParasSprites26
+.4byte sParasSprites27
+.4byte sParasSprites28
+.4byte sParasSprites29
+.4byte sParasSprites30
+.4byte sParasSprites31
+.4byte sParasSprites32
+.4byte sParasSprites33
+.4byte sParasSprites34
+.4byte sParasSprites35
+.4byte sParasSprites36
+.4byte sParasSprites37
+.4byte sParasSprites38
+.4byte sParasSprites39
+.4byte sParasSprites40
+.4byte sParasSprites41
+.4byte sParasSprites42
+.4byte sParasSprites43
+.4byte sParasSprites44
+.4byte sParasSprites45
+.4byte sParasSprites46
+.4byte sParasSprites47
+.4byte sParasSprites48
+.4byte sParasSprites49
+.4byte sParasSprites50
+.4byte sParasSprites51
+.4byte sParasSprites52
+sAxMainParas:
+ax_main sAxPosesParas, sAxAnimationsParas, 13, sAxSpritesParas, sAxPositionsParas

--- a/data/ax/parasect.inc
+++ b/data/ax/parasect.inc
@@ -1,0 +1,3122 @@
+.global gAxParasect
+gAxParasect:
+ax_siro sAxMainParasect
+sParasectPose1:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose2:
+ax_pose 1, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose3:
+ax_pose 2, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose4:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose5:
+ax_pose 4, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose6:
+ax_pose 5, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose7:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose8:
+ax_pose 7, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose9:
+ax_pose 8, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose10:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose11:
+ax_pose 10, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose12:
+ax_pose 11, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose13:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose14:
+ax_pose 13, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose15:
+ax_pose 14, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose16:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose17:
+ax_pose 10, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose18:
+ax_pose 11, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose19:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose20:
+ax_pose 7, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose21:
+ax_pose 8, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose22:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose23:
+ax_pose 4, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose24:
+ax_pose 5, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose25:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose26:
+ax_pose 15, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose27:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose28:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose29:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose30:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose31:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose32:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose33:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose34:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose35:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose36:
+ax_pose 21, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose37:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose38:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose39:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose40:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose41:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose42:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose43:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose44:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose45:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose46:
+ax_pose 22, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose47:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose48:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose49:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose50:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose51:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose52:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose53:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose54:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose55:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose56:
+ax_pose 23, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose57:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose58:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose59:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose60:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose61:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose62:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose63:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose64:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose65:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose66:
+ax_pose 24, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose67:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose68:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose69:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose70:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose71:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose72:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose73:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose74:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose75:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose76:
+ax_pose 23, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose77:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose78:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose79:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose80:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose81:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose82:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose83:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose84:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose85:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose86:
+ax_pose 22, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose87:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose88:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose89:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose90:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose91:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose92:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose93:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose94:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose95:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose96:
+ax_pose 21, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose97:
+ax_pose 16, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose98:
+ax_pose 17, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose99:
+ax_pose 18, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose100:
+ax_pose 19, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose101:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose102:
+ax_pose 19, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose103:
+ax_pose 18, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose104:
+ax_pose 17, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose105:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose106:
+ax_pose 1, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose107:
+ax_pose 2, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose108:
+ax_pose 25, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose109:
+ax_pose 26, 0x01e8, 0x80f0, 0x0c00
+ax_pose 27, 0x01e8, 0x80f0, 0x0c10
+ax_pose_terminator
+sParasectPose110:
+ax_pose 27, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose111:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose112:
+ax_pose 4, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose113:
+ax_pose 5, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose114:
+ax_pose 28, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose115:
+ax_pose 29, 0x01e9, 0x90f2, 0x0c00
+ax_pose 30, 0x01e8, 0x90f1, 0x0c10
+ax_pose_terminator
+sParasectPose116:
+ax_pose 30, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose117:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose118:
+ax_pose 7, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose119:
+ax_pose 8, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose120:
+ax_pose 31, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose121:
+ax_pose 32, 0x01e7, 0x90f7, 0x0c00
+ax_pose 33, 0x01e8, 0x90f2, 0x0c10
+ax_pose_terminator
+sParasectPose122:
+ax_pose 33, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose123:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose124:
+ax_pose 10, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose125:
+ax_pose 11, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sParasectPose126:
+ax_pose 34, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose127:
+ax_pose 35, 0x01e5, 0x90fa, 0x0c00
+ax_pose 36, 0x01e8, 0x90f1, 0x0c10
+ax_pose_terminator
+sParasectPose128:
+ax_pose 36, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose129:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose130:
+ax_pose 13, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose131:
+ax_pose 14, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose132:
+ax_pose 37, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose133:
+ax_pose 38, 0x01e8, 0x80f0, 0x0c00
+ax_pose 39, 0x01df, 0x80f0, 0x0c10
+ax_pose_terminator
+sParasectPose134:
+ax_pose 38, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose135:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose136:
+ax_pose 10, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose137:
+ax_pose 11, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose138:
+ax_pose 34, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose139:
+ax_pose 35, 0x01e4, 0x80e7, 0x0c00
+ax_pose 36, 0x01e8, 0x80ef, 0x0c10
+ax_pose_terminator
+sParasectPose140:
+ax_pose 36, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose141:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose142:
+ax_pose 7, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose143:
+ax_pose 8, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose144:
+ax_pose 31, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose145:
+ax_pose 32, 0x01e7, 0x80e9, 0x0c00
+ax_pose 33, 0x01e8, 0x80ee, 0x0c10
+ax_pose_terminator
+sParasectPose146:
+ax_pose 33, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose147:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose148:
+ax_pose 4, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose149:
+ax_pose 5, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose150:
+ax_pose 28, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose151:
+ax_pose 29, 0x01e9, 0x80ee, 0x0c00
+ax_pose 30, 0x01e8, 0x80ef, 0x0c10
+ax_pose_terminator
+sParasectPose152:
+ax_pose 30, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose153:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose154:
+ax_pose 15, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose155:
+ax_pose 40, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose156:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose157:
+ax_pose 21, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose158:
+ax_pose 41, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose159:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose160:
+ax_pose 22, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose161:
+ax_pose 42, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose162:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose163:
+ax_pose 23, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose164:
+ax_pose 43, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose165:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose166:
+ax_pose 24, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose167:
+ax_pose 44, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose168:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose169:
+ax_pose 23, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose170:
+ax_pose 43, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose171:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose172:
+ax_pose 22, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose173:
+ax_pose 42, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose174:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose175:
+ax_pose 21, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose176:
+ax_pose 41, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose177:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose178:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose179:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose180:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose181:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose182:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose183:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose184:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose185:
+ax_pose 45, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose186:
+ax_pose 46, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose187:
+ax_pose 47, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose188:
+ax_pose 48, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasectPose189:
+ax_pose 49, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sParasectPose190:
+ax_pose 50, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose191:
+ax_pose 51, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose192:
+ax_pose 50, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose193:
+ax_pose 49, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose194:
+ax_pose 48, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose195:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose196:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose197:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose198:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose199:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose200:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose201:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose202:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose203:
+ax_pose 40, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose204:
+ax_pose 41, 0x01ea, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose205:
+ax_pose 42, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose206:
+ax_pose 43, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose207:
+ax_pose 44, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose208:
+ax_pose 43, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose209:
+ax_pose 42, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose210:
+ax_pose 41, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose211:
+ax_pose 40, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose212:
+ax_pose 41, 0x01ea, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose213:
+ax_pose 42, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose214:
+ax_pose 43, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose215:
+ax_pose 44, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose216:
+ax_pose 43, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose217:
+ax_pose 42, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose218:
+ax_pose 41, 0x01ea, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose219:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose220:
+ax_pose 40, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose221:
+ax_pose 15, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose222:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose223:
+ax_pose 41, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose224:
+ax_pose 21, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose225:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose226:
+ax_pose 42, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose227:
+ax_pose 22, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose228:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose229:
+ax_pose 43, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose230:
+ax_pose 23, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose231:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose232:
+ax_pose 44, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose233:
+ax_pose 24, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose234:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose235:
+ax_pose 43, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose236:
+ax_pose 23, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose237:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose238:
+ax_pose 42, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose239:
+ax_pose 22, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose240:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose241:
+ax_pose 41, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose242:
+ax_pose 21, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose243:
+ax_pose 15, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose244:
+ax_pose 21, 0x01e9, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose245:
+ax_pose 22, 0x01e8, 0x80ee, 0x0c00
+ax_pose_terminator
+sParasectPose246:
+ax_pose 23, 0x01e9, 0x80ef, 0x0c00
+ax_pose_terminator
+sParasectPose247:
+ax_pose 24, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sParasectPose248:
+ax_pose 23, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose249:
+ax_pose 22, 0x01e8, 0x90f2, 0x0c00
+ax_pose_terminator
+sParasectPose250:
+ax_pose 21, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sParasectPose251:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose252:
+ax_pose 3, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose253:
+ax_pose 6, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sParasectPose254:
+ax_pose 9, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sParasectPose255:
+ax_pose 12, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sParasectPose256:
+ax_pose 9, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sParasectPose257:
+ax_pose 6, 0x01ee, 0x90ee, 0x0c00
+ax_pose_terminator
+sParasectPose258:
+ax_pose 3, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+.align 2
+sParasectAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_2_1:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, -4, 0, 0,
+ax_anim 1, 0, 27, 0, -6, 0, 0,
+ax_anim 1, 0, 28, 0, -7, 0, 0,
+ax_anim 1, 0, 29, 0, -7, 0, 0,
+ax_anim 1, 2, 30, 0, -1, 0, -1,
+ax_anim 1, 0, 31, 0, 13, 0, 13,
+ax_anim 2, 0, 32, 0, 20, 0, 20,
+ax_anim 2, 1, 33, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 1, 0, 29, 0, 12, 0, 12,
+ax_anim 1, 0, 30, 0, 3, 0, 3,
+ax_anim 2, 0, 31, 0, -5, 0, 0,
+ax_anim 2, 0, 32, 0, -5, 0, 0,
+ax_anim 2, 0, 33, 0, -5, 0, 0,
+ax_anim 2, 0, 24, 0, -5, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_2_2:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, -4, 0, 0,
+ax_anim 1, 0, 36, 0, -6, 0, 0,
+ax_anim 1, 0, 37, 0, -7, 0, 0,
+ax_anim 1, 0, 38, 0, -7, 0, 0,
+ax_anim 1, 2, 39, 1, -5, 1, -1,
+ax_anim 1, 0, 40, 13, 10, 13, 13,
+ax_anim 2, 0, 41, 20, 20, 20, 20,
+ax_anim 2, 1, 42, 19, 21, 19, 21,
+ax_anim 2, 0, 43, 20, 20, 20, 20,
+ax_anim 2, 0, 36, 19, 21, 19, 21,
+ax_anim 2, 0, 37, 20, 20, 20, 20,
+ax_anim 1, 0, 38, 12, 10, 12, 12,
+ax_anim 1, 0, 39, 3, -1, 3, 3,
+ax_anim 2, 0, 40, 0, -5, 0, 0,
+ax_anim 2, 0, 41, 0, -5, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 2, 0, 34, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_2_3:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 0, -4, 0, 0,
+ax_anim 1, 0, 53, 0, -6, 0, 0,
+ax_anim 1, 0, 46, 0, -7, 0, 0,
+ax_anim 1, 0, 47, 0, -7, 0, 0,
+ax_anim 1, 2, 48, 1, -6, 1, 0,
+ax_anim 1, 0, 49, 13, -3, 13, 0,
+ax_anim 2, 0, 50, 20, -2, 20, 0,
+ax_anim 2, 1, 51, 20, -1, 20, 1,
+ax_anim 2, 0, 52, 20, -2, 20, 0,
+ax_anim 2, 0, 53, 20, -1, 20, 1,
+ax_anim 2, 0, 46, 20, -2, 20, 0,
+ax_anim 1, 0, 47, 12, -2, 12, 0,
+ax_anim 1, 0, 48, 3, -3, 3, 0,
+ax_anim 2, 0, 49, 0, -5, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 2, 0, 51, 0, -5, 0, 0,
+ax_anim 2, 0, 44, 0, -5, 0, 0,
+ax_anim 2, 0, 44, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_2_4:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 0, -4, 0, 0,
+ax_anim 1, 0, 62, 0, -6, 0, 0,
+ax_anim 1, 0, 63, 0, -7, 0, 0,
+ax_anim 1, 0, 56, 0, -7, 0, 0,
+ax_anim 1, 2, 57, 1, -8, 1, -1,
+ax_anim 1, 0, 58, 13, -20, 13, -16,
+ax_anim 2, 0, 59, 20, -25, 20, -25,
+ax_anim 2, 1, 60, 20, -24, 20, -24,
+ax_anim 2, 0, 61, 20, -25, 20, -25,
+ax_anim 2, 0, 62, 20, -24, 20, -24,
+ax_anim 2, 0, 63, 20, -25, 20, -25,
+ax_anim 1, 0, 56, 12, -16, 12, -15,
+ax_anim 1, 0, 57, 3, -8, 3, -4,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 2, 0, 59, 0, -5, 0, 0,
+ax_anim 2, 0, 60, 0, -5, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 2, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_2_5:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 70, 0, -4, 0, 0,
+ax_anim 1, 0, 71, 0, -6, 0, 0,
+ax_anim 1, 0, 72, 0, -7, 0, 0,
+ax_anim 1, 0, 73, 0, -7, 0, 0,
+ax_anim 1, 2, 66, 0, -8, 0, -3,
+ax_anim 1, 0, 67, 0, -20, 0, -17,
+ax_anim 2, 0, 68, 0, -25, 0, -25,
+ax_anim 2, 1, 69, 1, -25, 1, -25,
+ax_anim 2, 0, 70, 0, -25, 0, -25,
+ax_anim 2, 0, 71, 1, -25, 1, -25,
+ax_anim 2, 0, 72, 0, -25, 0, -25,
+ax_anim 1, 0, 73, 0, -16, 0, -14,
+ax_anim 1, 0, 66, 0, -8, 0, -4,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 68, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 64, 0, -5, 0, 0,
+ax_anim 2, 0, 64, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_2_6:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -4, 0, 0,
+ax_anim 1, 0, 80, 0, -6, 0, 0,
+ax_anim 1, 0, 81, 0, -7, 0, 0,
+ax_anim 1, 0, 82, 0, -7, 0, 0,
+ax_anim 1, 2, 83, -1, -8, -1, -1,
+ax_anim 1, 0, 76, -13, -20, -13, -16,
+ax_anim 2, 0, 77, -20, -25, -20, -25,
+ax_anim 2, 1, 78, -20, -24, -20, -24,
+ax_anim 2, 0, 79, -20, -25, -20, -25,
+ax_anim 2, 0, 80, -20, -24, -20, -24,
+ax_anim 2, 0, 81, -20, -25, -20, -25,
+ax_anim 1, 0, 82, -12, -16, -12, -15,
+ax_anim 1, 0, 83, -3, -8, -3, -4,
+ax_anim 2, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_2_7:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -4, 0, 0,
+ax_anim 1, 0, 89, 0, -6, 0, 0,
+ax_anim 1, 0, 90, 0, -7, 0, 0,
+ax_anim 1, 0, 91, 0, -7, 0, 0,
+ax_anim 1, 2, 92, -1, -6, -1, 0,
+ax_anim 1, 0, 93, -13, -3, -13, 0,
+ax_anim 2, 0, 86, -20, -2, -20, 0,
+ax_anim 2, 1, 87, -20, -1, -20, 1,
+ax_anim 2, 0, 88, -20, -2, -20, 0,
+ax_anim 2, 0, 89, -20, -1, -20, 1,
+ax_anim 2, 0, 90, -20, -2, -20, 0,
+ax_anim 1, 0, 91, -12, -2, -12, 0,
+ax_anim 1, 0, 92, -3, -3, -3, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 84, 0, -5, 0, 0,
+ax_anim 2, 0, 84, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_2_8:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -4, 0, 0,
+ax_anim 1, 0, 98, 0, -6, 0, 0,
+ax_anim 1, 0, 99, 0, -7, 0, 0,
+ax_anim 1, 0, 100, 0, -7, 0, 0,
+ax_anim 1, 2, 101, -1, -5, -1, -1,
+ax_anim 1, 0, 102, -13, 10, -13, 13,
+ax_anim 2, 0, 103, -20, 20, -20, 20,
+ax_anim 2, 1, 96, -19, 21, -19, 21,
+ax_anim 2, 0, 97, -20, 20, -20, 20,
+ax_anim 2, 0, 98, -19, 21, -19, 21,
+ax_anim 2, 0, 99, -20, 20, -20, 20,
+ax_anim 1, 0, 100, -12, 10, -12, 12,
+ax_anim 1, 0, 101, -3, -1, -3, 3,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_3_1:
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 0, -5, 0, -5,
+ax_anim 6, 0, 107, 0, -6, 0, -6,
+ax_anim 1, 2, 107, 0, -3, 0, -3,
+ax_anim 1, 0, 107, 0, 6, 0, 6,
+ax_anim 2, 0, 108, 0, 14, 0, 14,
+ax_anim 2, 1, 151, 0, 17, 0, 17,
+ax_anim 2, 0, 151, 1, 17, 1, 17,
+ax_anim 2, 0, 151, 0, 17, 0, 17,
+ax_anim 2, 0, 151, 1, 17, 1, 17,
+ax_anim 2, 0, 151, 0, 17, 0, 17,
+ax_anim 2, 0, 104, 0, 8, 0, 8,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim_terminator
+sParasectAnims_3_2:
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 112, -5, -5, -5, -5,
+ax_anim 6, 0, 113, -6, -6, -6, -6,
+ax_anim 1, 2, 113, -3, -3, -3, -3,
+ax_anim 1, 0, 113, 6, 6, 6, 6,
+ax_anim 2, 0, 114, 14, 14, 14, 14,
+ax_anim 2, 1, 121, 18, 16, 18, 16,
+ax_anim 2, 0, 121, 19, 15, 19, 15,
+ax_anim 2, 0, 121, 18, 16, 18, 16,
+ax_anim 2, 0, 121, 19, 15, 19, 15,
+ax_anim 2, 0, 121, 18, 16, 18, 16,
+ax_anim 2, 0, 110, 8, 8, 8, 8,
+ax_anim 2, 0, 110, 3, 3, 3, 3,
+ax_anim_terminator
+sParasectAnims_3_3:
+ax_anim 2, 0, 117, -3, 0, -3, 0,
+ax_anim 2, 0, 118, -5, 0, -5, 0,
+ax_anim 6, 0, 119, -6, 0, -6, 0,
+ax_anim 1, 2, 119, -3, 0, -3, 0,
+ax_anim 1, 0, 119, 6, 0, 6, 0,
+ax_anim 2, 0, 120, 12, 0, 12, 0,
+ax_anim 2, 1, 127, 15, 0, 15, 0,
+ax_anim 2, 0, 127, 15, 1, 15, 1,
+ax_anim 2, 0, 127, 15, 0, 15, 0,
+ax_anim 2, 0, 127, 15, 1, 15, 1,
+ax_anim 2, 0, 127, 15, 0, 15, 0,
+ax_anim 2, 0, 116, 8, 0, 8, 0,
+ax_anim 2, 0, 116, 3, 0, 3, 0,
+ax_anim_terminator
+sParasectAnims_3_4:
+ax_anim 2, 0, 123, -3, 3, -3, 3,
+ax_anim 2, 0, 124, -5, 5, -5, 5,
+ax_anim 6, 0, 125, -6, 6, -6, 6,
+ax_anim 1, 2, 125, -3, 3, -3, 3,
+ax_anim 1, 0, 125, 5, -8, 5, -8,
+ax_anim 2, 0, 126, 13, -18, 13, -18,
+ax_anim 2, 1, 133, 14, -21, 14, -21,
+ax_anim 2, 0, 133, 15, -20, 15, -20,
+ax_anim 2, 0, 133, 14, -21, 14, -21,
+ax_anim 2, 0, 133, 15, -20, 15, -20,
+ax_anim 2, 0, 133, 14, -21, 14, -21,
+ax_anim 2, 0, 122, 7, -10, 7, -10,
+ax_anim 2, 0, 122, 2, -4, 2, -4,
+ax_anim_terminator
+sParasectAnims_3_5:
+ax_anim 2, 0, 129, 0, 3, 0, 3,
+ax_anim 2, 0, 130, 0, 5, 0, 5,
+ax_anim 6, 0, 131, 0, 6, 0, 6,
+ax_anim 1, 2, 131, 0, 3, 0, 3,
+ax_anim 1, 0, 131, 0, -8, 0, -8,
+ax_anim 2, 0, 132, 0, -16, 0, -16,
+ax_anim 2, 1, 127, 0, -21, 0, -25,
+ax_anim 2, 0, 127, 1, -21, 1, -25,
+ax_anim 2, 0, 127, 0, -21, 0, -25,
+ax_anim 2, 0, 127, 1, -21, 1, -25,
+ax_anim 2, 0, 127, 0, -21, 0, -25,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim_terminator
+sParasectAnims_3_6:
+ax_anim 2, 0, 135, 3, 3, 3, 3,
+ax_anim 2, 0, 136, 5, 5, 5, 5,
+ax_anim 6, 0, 137, 6, 6, 6, 6,
+ax_anim 1, 2, 137, 3, 3, 3, 3,
+ax_anim 1, 0, 137, -5, -8, -5, -8,
+ax_anim 2, 0, 138, -13, -18, -13, -18,
+ax_anim 2, 1, 133, -16, -21, -16, -21,
+ax_anim 2, 0, 133, -17, -20, -17, -20,
+ax_anim 2, 0, 133, -16, -21, -16, -21,
+ax_anim 2, 0, 133, -17, -20, -17, -20,
+ax_anim 2, 0, 133, -16, -21, -16, -21,
+ax_anim 2, 0, 134, -7, -10, -7, -10,
+ax_anim 2, 0, 134, -2, -4, -2, -4,
+ax_anim_terminator
+sParasectAnims_3_7:
+ax_anim 2, 0, 141, 3, 0, 3, 0,
+ax_anim 2, 0, 142, 5, 0, 5, 0,
+ax_anim 6, 0, 143, 6, 0, 6, 0,
+ax_anim 1, 2, 143, 3, 0, 3, 0,
+ax_anim 1, 0, 143, -6, 0, -6, 0,
+ax_anim 2, 0, 144, -12, 0, -12, 0,
+ax_anim 2, 1, 139, -15, 0, -15, 0,
+ax_anim 2, 0, 139, -15, 1, -15, 1,
+ax_anim 2, 0, 139, -15, 0, -15, 0,
+ax_anim 2, 0, 139, -15, 1, -15, 1,
+ax_anim 2, 0, 139, -15, 0, -15, 0,
+ax_anim 2, 0, 140, -8, 0, -8, 0,
+ax_anim 2, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sParasectAnims_3_8:
+ax_anim 2, 0, 147, 3, -3, 3, -3,
+ax_anim 2, 0, 148, 5, -5, 5, -5,
+ax_anim 6, 0, 149, 6, -6, 6, -6,
+ax_anim 1, 2, 149, 3, -3, 3, -3,
+ax_anim 1, 0, 149, -6, 6, -6, 6,
+ax_anim 2, 0, 150, -14, 14, -14, 14,
+ax_anim 2, 1, 145, -18, 16, -18, 16,
+ax_anim 2, 0, 145, -19, 15, -19, 15,
+ax_anim 2, 0, 145, -18, 16, -18, 16,
+ax_anim 2, 0, 145, -19, 15, -19, 15,
+ax_anim 2, 0, 145, -18, 16, -18, 16,
+ax_anim 2, 0, 146, -8, 8, -8, 8,
+ax_anim 2, 0, 146, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sParasectAnims_4_1:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 1, 0, 1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 1, 0, 1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 2, 153, 1, 0, 1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -3, 0, 0,
+ax_anim 2, 0, 154, 0, -5, 0, 0,
+ax_anim 2, 1, 154, 0, -6, 0, 0,
+ax_anim 2, 0, 154, 0, -5, 0, 0,
+ax_anim 2, 0, 154, 0, -3, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_4_2:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 1, -1, 1, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 1, -1, 1, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 2, 156, 1, -1, 1, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 2, 0, 157, 0, -5, 0, 0,
+ax_anim 2, 1, 157, 0, -6, 0, 0,
+ax_anim 2, 0, 157, 0, -5, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_4_3:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 1, 0, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 1, 0, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 2, 159, 0, 1, 0, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -4, 0, 0,
+ax_anim 2, 0, 160, 0, -7, 0, 0,
+ax_anim 2, 1, 160, 0, -8, 0, 0,
+ax_anim 2, 0, 160, 0, -7, 0, 0,
+ax_anim 2, 0, 160, 0, -4, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_4_4:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 1, 1, 1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 1, 1, 1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 2, 162, 1, 1, 1, 1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 163, 0, -7, 0, 0,
+ax_anim 2, 1, 163, 0, -8, 0, 0,
+ax_anim 2, 0, 163, 0, -7, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_4_5:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 2, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 2, 0, 166, 0, -7, 0, 0,
+ax_anim 2, 1, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -7, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_4_6:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, -1, 1, -1, 1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, -1, 1, -1, 1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 2, 168, -1, 1, -1, 1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, -4, 0, 0,
+ax_anim 2, 0, 169, 0, -7, 0, 0,
+ax_anim 2, 1, 169, 0, -8, 0, 0,
+ax_anim 2, 0, 169, 0, -7, 0, 0,
+ax_anim 2, 0, 169, 0, -4, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_4_7:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 1, 0, 1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 1, 0, 1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 1, 0, 1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -4, 0, 0,
+ax_anim 2, 0, 172, 0, -7, 0, 0,
+ax_anim 2, 1, 172, 0, -8, 0, 0,
+ax_anim 2, 0, 172, 0, -7, 0, 0,
+ax_anim 2, 0, 172, 0, -4, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_4_8:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, -1, -1, -1, -1,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, -1, -1, -1, -1,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 174, -1, -1, -1, -1,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, -3, 0, 0,
+ax_anim 2, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 1, 175, 0, -6, 0, 0,
+ax_anim 2, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 0, -3, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_5_1:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_5_2:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_5_3:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_5_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_5_5:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_5_6:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_5_7:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_5_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_6_1:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 35, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_7_1:
+ax_anim 2, 0, 186, 0, -4, 0, -4,
+ax_anim 8, 0, 186, 0, -5, 0, -5,
+ax_anim_terminator
+sParasectAnims_7_2:
+ax_anim 2, 0, 187, -4, -4, -4, -4,
+ax_anim 8, 0, 187, -5, -5, -5, -5,
+ax_anim_terminator
+sParasectAnims_7_3:
+ax_anim 2, 0, 188, -4, 0, -4, 0,
+ax_anim 8, 0, 188, -5, 0, -5, 0,
+ax_anim_terminator
+sParasectAnims_7_4:
+ax_anim 2, 0, 189, -4, 4, -4, 4,
+ax_anim 8, 0, 189, -5, 5, -5, 5,
+ax_anim_terminator
+sParasectAnims_7_5:
+ax_anim 2, 0, 190, 0, 4, 0, 4,
+ax_anim 8, 0, 190, 0, 5, 0, 5,
+ax_anim_terminator
+sParasectAnims_7_6:
+ax_anim 2, 0, 191, 4, 4, 4, 4,
+ax_anim 8, 0, 191, 5, 5, 5, 5,
+ax_anim_terminator
+sParasectAnims_7_7:
+ax_anim 2, 0, 192, 4, 0, 4, 0,
+ax_anim 8, 0, 192, 5, 0, 5, 0,
+ax_anim_terminator
+sParasectAnims_7_8:
+ax_anim 2, 0, 193, 4, -4, 4, -4,
+ax_anim 8, 0, 193, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sParasectAnims_8_1:
+ax_anim 40, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 194, 0, -2, 0, 0,
+ax_anim 2, 0, 194, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_8_2:
+ax_anim 40, 0, 201, 0, 0, 0, 0,
+ax_anim 4, 0, 201, 0, -2, 0, 0,
+ax_anim 2, 0, 201, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_8_3:
+ax_anim 40, 0, 200, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, -2, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_8_4:
+ax_anim 40, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 199, 0, -2, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_8_5:
+ax_anim 40, 0, 198, 0, 0, 0, 0,
+ax_anim 4, 0, 198, 0, -2, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_8_6:
+ax_anim 40, 0, 197, 0, 0, 0, 0,
+ax_anim 4, 0, 197, 0, -2, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_8_7:
+ax_anim 40, 0, 196, 0, 0, 0, 0,
+ax_anim 4, 0, 196, 0, -2, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, 0,
+ax_anim_terminator
+sParasectAnims_8_8:
+ax_anim 40, 0, 195, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, -2, 0, 0,
+ax_anim 2, 0, 195, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 3, 6, 3,
+ax_anim 2, 0, 204, 8, 9, 8, 9,
+ax_anim 2, 0, 205, 7, 16, 7, 16,
+ax_anim 3, 0, 206, 0, 20, 0, 20,
+ax_anim 2, 3, 207, -7, 16, -7, 16,
+ax_anim 2, 0, 208, -8, 9, -8, 9,
+ax_anim 1, 0, 209, -6, 3, -6, 3,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 19, 3, 19, 3,
+ax_anim 2, 0, 204, 23, 10, 23, 10,
+ax_anim 3, 0, 205, 19, 20, 19, 20,
+ax_anim 2, 3, 206, 11, 19, 11, 19,
+ax_anim 2, 0, 207, 3, 15, 3, 15,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -5, 3, -5,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 18, -5, 18, -5,
+ax_anim 3, 0, 204, 20, -2, 20, -2,
+ax_anim 2, 3, 205, 18, 4, 18, 4,
+ax_anim 2, 0, 206, 12, 5, 12, 5,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -6, -1, -6,
+ax_anim 2, 0, 209, 4, -16, 4, -16,
+ax_anim 2, 0, 202, 12, -22, 12, -22,
+ax_anim 3, 0, 203, 20, -21, 20, -21,
+ax_anim 2, 3, 204, 22, -13, 22, -13,
+ax_anim 2, 0, 205, 17, -4, 17, -4,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -4, -8, -4,
+ax_anim 2, 0, 208, -9, -12, -9, -12,
+ax_anim 2, 0, 209, -7, -17, -7, -17,
+ax_anim 3, 0, 202, 0, -21, 0, -22,
+ax_anim 2, 3, 203, 7, -17, 7, -17,
+ax_anim 2, 0, 204, 9, -10, 9, -10,
+ax_anim 1, 0, 205, 8, -4, 8, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -6, 1, -6,
+ax_anim 2, 0, 203, -4, -16, -4, -16,
+ax_anim 2, 0, 202, -12, -22, -12, -22,
+ax_anim 3, 0, 209, -20, -21, -20, -21,
+ax_anim 2, 3, 208, -22, -13, -22, -13,
+ax_anim 2, 0, 207, -17, -4, -17, -4,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -5, -3, -5,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -18, -5, -18, -5,
+ax_anim 3, 0, 208, -20, -2, -20, -2,
+ax_anim 2, 3, 207, -18, 4, -18, 4,
+ax_anim 2, 0, 206, -12, 5, -12, 5,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -19, 3, -19, 3,
+ax_anim 2, 0, 208, -23, 10, -23, 10,
+ax_anim 3, 0, 207, -19, 20, -19, 20,
+ax_anim 2, 3, 206, -11, 19, -11, 19,
+ax_anim 2, 0, 205, -3, 15, -3, 15,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -25, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -25, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -24, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -24, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -24, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -24, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -24, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -25, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sParasectAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sParasectGfx1:
+.incbin "baserom.gba", 0x6FD2A4, 0x200
+sParasectSprites1:
+ax_sprite sParasectGfx1, 0x200
+ax_sprite_terminator
+sParasectGfx2:
+.incbin "baserom.gba", 0x6FD4B4, 0x200
+sParasectSprites2:
+ax_sprite sParasectGfx2, 0x200
+ax_sprite_terminator
+sParasectGfx3:
+.incbin "baserom.gba", 0x6FD6C4, 0x200
+sParasectSprites3:
+ax_sprite sParasectGfx3, 0x200
+ax_sprite_terminator
+sParasectGfx4:
+.incbin "baserom.gba", 0x6FD8D4, 0x200
+sParasectSprites4:
+ax_sprite sParasectGfx4, 0x200
+ax_sprite_terminator
+sParasectGfx5:
+.incbin "baserom.gba", 0x6FDAE4, 0x200
+sParasectSprites5:
+ax_sprite sParasectGfx5, 0x200
+ax_sprite_terminator
+sParasectGfx6:
+.incbin "baserom.gba", 0x6FDCF4, 0x200
+sParasectSprites6:
+ax_sprite sParasectGfx6, 0x200
+ax_sprite_terminator
+sParasectGfx7:
+.incbin "baserom.gba", 0x6FDF04, 0x200
+sParasectSprites7:
+ax_sprite sParasectGfx7, 0x200
+ax_sprite_terminator
+sParasectGfx8:
+.incbin "baserom.gba", 0x6FE114, 0x200
+sParasectSprites8:
+ax_sprite sParasectGfx8, 0x200
+ax_sprite_terminator
+sParasectGfx9:
+.incbin "baserom.gba", 0x6FE324, 0x200
+sParasectSprites9:
+ax_sprite sParasectGfx9, 0x200
+ax_sprite_terminator
+sParasectGfx10:
+.incbin "baserom.gba", 0x6FE534, 0x200
+sParasectSprites10:
+ax_sprite sParasectGfx10, 0x200
+ax_sprite_terminator
+sParasectGfx11:
+.incbin "baserom.gba", 0x6FE744, 0x200
+sParasectSprites11:
+ax_sprite sParasectGfx11, 0x200
+ax_sprite_terminator
+sParasectGfx12:
+.incbin "baserom.gba", 0x6FE954, 0x200
+sParasectSprites12:
+ax_sprite sParasectGfx12, 0x200
+ax_sprite_terminator
+sParasectGfx13:
+.incbin "baserom.gba", 0x6FEB64, 0x200
+sParasectSprites13:
+ax_sprite sParasectGfx13, 0x200
+ax_sprite_terminator
+sParasectGfx14:
+.incbin "baserom.gba", 0x6FED74, 0x200
+sParasectSprites14:
+ax_sprite sParasectGfx14, 0x200
+ax_sprite_terminator
+sParasectGfx15:
+.incbin "baserom.gba", 0x6FEF84, 0x200
+sParasectSprites15:
+ax_sprite sParasectGfx15, 0x200
+ax_sprite_terminator
+sParasectGfx16:
+.incbin "baserom.gba", 0x6FF194, 0x40
+sParasectGfx16_1:
+.incbin "baserom.gba", 0x6FF1D4, 0x100
+sParasectGfx16_2:
+.incbin "baserom.gba", 0x6FF2D4, 0x40
+sParasectSprites16:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasectGfx17:
+.incbin "baserom.gba", 0x6FF354, 0x100
+sParasectSprites17:
+ax_sprite 0, 0x80
+ax_sprite sParasectGfx17, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasectGfx18:
+.incbin "baserom.gba", 0x6FF474, 0x100
+sParasectGfx18_1:
+.incbin "baserom.gba", 0x6FF574, 0x40
+sParasectSprites18:
+ax_sprite 0, 0x80
+ax_sprite sParasectGfx18, 0x100
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasectGfx19:
+.incbin "baserom.gba", 0x6FF5E4, 0x100
+sParasectGfx19_1:
+.incbin "baserom.gba", 0x6FF6E4, 0x40
+sParasectSprites19:
+ax_sprite 0, 0x80
+ax_sprite sParasectGfx19, 0x100
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasectGfx20:
+.incbin "baserom.gba", 0x6FF754, 0x100
+sParasectGfx20_1:
+.incbin "baserom.gba", 0x6FF854, 0x20
+sParasectSprites20:
+ax_sprite 0, 0x80
+ax_sprite sParasectGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx20_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasectGfx21:
+.incbin "baserom.gba", 0x6FF8A4, 0x100
+sParasectSprites21:
+ax_sprite 0, 0x80
+ax_sprite sParasectGfx21, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasectGfx22:
+.incbin "baserom.gba", 0x6FF9C4, 0x40
+sParasectGfx22_1:
+.incbin "baserom.gba", 0x6FFA04, 0x160
+sParasectSprites22:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx22_1, 0x160
+ax_sprite_terminator
+sParasectGfx23:
+.incbin "baserom.gba", 0x6FFB8C, 0x40
+sParasectGfx23_1:
+.incbin "baserom.gba", 0x6FFBCC, 0xE0
+sParasectGfx23_2:
+.incbin "baserom.gba", 0x6FFCAC, 0x60
+sParasectSprites23:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx23_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx23_2, 0x60
+ax_sprite_terminator
+sParasectGfx24:
+.incbin "baserom.gba", 0x6FFD44, 0x40
+sParasectGfx24_1:
+.incbin "baserom.gba", 0x6FFD84, 0xE0
+sParasectGfx24_2:
+.incbin "baserom.gba", 0x6FFE64, 0x20
+sParasectSprites24:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx24_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx24_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasectGfx25:
+.incbin "baserom.gba", 0x6FFEC4, 0x40
+sParasectGfx25_1:
+.incbin "baserom.gba", 0x6FFF04, 0x180
+sParasectSprites25:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx25_1, 0x180
+ax_sprite_terminator
+sParasectGfx26:
+.incbin "baserom.gba", 0x7000AC, 0x1A0
+sParasectSprites26:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx26, 0x1a0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasectGfx27:
+.incbin "baserom.gba", 0x70026C, 0x20
+sParasectGfx27_1:
+.incbin "baserom.gba", 0x70028C, 0x40
+sParasectGfx27_2:
+.incbin "baserom.gba", 0x7002CC, 0x40
+sParasectGfx27_3:
+.incbin "baserom.gba", 0x70030C, 0x40
+sParasectSprites27:
+ax_sprite 0, 0x60
+ax_sprite sParasectGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasectGfx28:
+.incbin "baserom.gba", 0x70039C, 0x40
+sParasectGfx28_1:
+.incbin "baserom.gba", 0x7003DC, 0x160
+sParasectSprites28:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx28_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasectGfx29:
+.incbin "baserom.gba", 0x70056C, 0x40
+sParasectGfx29_1:
+.incbin "baserom.gba", 0x7005AC, 0x100
+sParasectGfx29_2:
+.incbin "baserom.gba", 0x7006AC, 0x40
+sParasectSprites29:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx29_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx29_2, 0x40
+ax_sprite_terminator
+sParasectGfx30:
+.incbin "baserom.gba", 0x700724, 0x40
+sParasectGfx30_1:
+.incbin "baserom.gba", 0x700764, 0x40
+sParasectGfx30_2:
+.incbin "baserom.gba", 0x7007A4, 0x40
+sParasectGfx30_3:
+.incbin "baserom.gba", 0x7007E4, 0x40
+sParasectSprites30:
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx30_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasectGfx31:
+.incbin "baserom.gba", 0x700874, 0x40
+sParasectGfx31_1:
+.incbin "baserom.gba", 0x7008B4, 0x180
+sParasectSprites31:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx31_1, 0x180
+ax_sprite_terminator
+sParasectGfx32:
+.incbin "baserom.gba", 0x700A5C, 0x40
+sParasectGfx32_1:
+.incbin "baserom.gba", 0x700A9C, 0xE0
+sParasectGfx32_2:
+.incbin "baserom.gba", 0x700B7C, 0x40
+sParasectSprites32:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx32_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx32_2, 0x40
+ax_sprite_terminator
+sParasectGfx33:
+.incbin "baserom.gba", 0x700BF4, 0x40
+sParasectGfx33_1:
+.incbin "baserom.gba", 0x700C34, 0x60
+sParasectGfx33_2:
+.incbin "baserom.gba", 0x700C94, 0x20
+sParasectGfx33_3:
+.incbin "baserom.gba", 0x700CB4, 0x20
+sParasectSprites33:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx33_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sParasectGfx33_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sParasectGfx34:
+.incbin "baserom.gba", 0x700D24, 0x40
+sParasectGfx34_1:
+.incbin "baserom.gba", 0x700D64, 0x160
+sParasectSprites34:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx34_1, 0x160
+ax_sprite_terminator
+sParasectGfx35:
+.incbin "baserom.gba", 0x700EEC, 0x60
+sParasectGfx35_1:
+.incbin "baserom.gba", 0x700F4C, 0x100
+sParasectGfx35_2:
+.incbin "baserom.gba", 0x70104C, 0x20
+sParasectSprites35:
+ax_sprite sParasectGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx35_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasectGfx36:
+.incbin "baserom.gba", 0x7010A4, 0x40
+sParasectGfx36_1:
+.incbin "baserom.gba", 0x7010E4, 0x60
+sParasectGfx36_2:
+.incbin "baserom.gba", 0x701144, 0x40
+sParasectSprites36:
+ax_sprite sParasectGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx36_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx36_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sParasectGfx37:
+.incbin "baserom.gba", 0x7011BC, 0x40
+sParasectGfx37_1:
+.incbin "baserom.gba", 0x7011FC, 0x100
+sParasectGfx37_2:
+.incbin "baserom.gba", 0x7012FC, 0x20
+sParasectSprites37:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx37_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx37_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sParasectGfx38:
+.incbin "baserom.gba", 0x70135C, 0x60
+sParasectGfx38_1:
+.incbin "baserom.gba", 0x7013BC, 0x180
+sParasectSprites38:
+ax_sprite sParasectGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx38_1, 0x180
+ax_sprite_terminator
+sParasectGfx39:
+.incbin "baserom.gba", 0x70155C, 0x40
+sParasectGfx39_1:
+.incbin "baserom.gba", 0x70159C, 0x180
+sParasectSprites39:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx39_1, 0x180
+ax_sprite_terminator
+sParasectGfx40:
+.incbin "baserom.gba", 0x701744, 0x40
+sParasectGfx40_1:
+.incbin "baserom.gba", 0x701784, 0x60
+sParasectGfx40_2:
+.incbin "baserom.gba", 0x7017E4, 0x60
+sParasectSprites40:
+ax_sprite sParasectGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sParasectGfx41:
+.incbin "baserom.gba", 0x70187C, 0x180
+sParasectSprites41:
+ax_sprite sParasectGfx41, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sParasectGfx42:
+.incbin "baserom.gba", 0x701A14, 0x180
+sParasectGfx42_1:
+.incbin "baserom.gba", 0x701B94, 0x40
+sParasectSprites42:
+ax_sprite sParasectGfx42, 0x180
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx42_1, 0x40
+ax_sprite_terminator
+sParasectGfx43:
+.incbin "baserom.gba", 0x701BF4, 0xE0
+sParasectGfx43_1:
+.incbin "baserom.gba", 0x701CD4, 0x60
+sParasectGfx43_2:
+.incbin "baserom.gba", 0x701D34, 0x40
+sParasectSprites43:
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx43, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx43_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sParasectGfx43_2, 0x40
+ax_sprite_terminator
+sParasectGfx44:
+.incbin "baserom.gba", 0x701DAC, 0x60
+sParasectGfx44_1:
+.incbin "baserom.gba", 0x701E0C, 0x80
+sParasectGfx44_2:
+.incbin "baserom.gba", 0x701E8C, 0x60
+sParasectGfx44_3:
+.incbin "baserom.gba", 0x701EEC, 0x40
+sParasectSprites44:
+ax_sprite sParasectGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx44_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sParasectGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sParasectGfx45:
+.incbin "baserom.gba", 0x701F74, 0x200
+sParasectSprites45:
+ax_sprite sParasectGfx45, 0x200
+ax_sprite_terminator
+sParasectGfx46:
+.incbin "baserom.gba", 0x702184, 0x200
+sParasectSprites46:
+ax_sprite sParasectGfx46, 0x200
+ax_sprite_terminator
+sParasectGfx47:
+.incbin "baserom.gba", 0x702394, 0x200
+sParasectSprites47:
+ax_sprite sParasectGfx47, 0x200
+ax_sprite_terminator
+sParasectGfx48:
+.incbin "baserom.gba", 0x7025A4, 0x200
+sParasectSprites48:
+ax_sprite sParasectGfx48, 0x200
+ax_sprite_terminator
+sParasectGfx49:
+.incbin "baserom.gba", 0x7027B4, 0x200
+sParasectSprites49:
+ax_sprite sParasectGfx49, 0x200
+ax_sprite_terminator
+sParasectGfx50:
+.incbin "baserom.gba", 0x7029C4, 0x200
+sParasectSprites50:
+ax_sprite sParasectGfx50, 0x200
+ax_sprite_terminator
+sParasectGfx51:
+.incbin "baserom.gba", 0x702BD4, 0x200
+sParasectSprites51:
+ax_sprite sParasectGfx51, 0x200
+ax_sprite_terminator
+sParasectGfx52:
+.incbin "baserom.gba", 0x702DE4, 0x200
+sParasectSprites52:
+ax_sprite sParasectGfx52, 0x200
+ax_sprite_terminator
+sAxPosesParasect:
+.4byte sParasectPose1
+.4byte sParasectPose2
+.4byte sParasectPose3
+.4byte sParasectPose4
+.4byte sParasectPose5
+.4byte sParasectPose6
+.4byte sParasectPose7
+.4byte sParasectPose8
+.4byte sParasectPose9
+.4byte sParasectPose10
+.4byte sParasectPose11
+.4byte sParasectPose12
+.4byte sParasectPose13
+.4byte sParasectPose14
+.4byte sParasectPose15
+.4byte sParasectPose16
+.4byte sParasectPose17
+.4byte sParasectPose18
+.4byte sParasectPose19
+.4byte sParasectPose20
+.4byte sParasectPose21
+.4byte sParasectPose22
+.4byte sParasectPose23
+.4byte sParasectPose24
+.4byte sParasectPose25
+.4byte sParasectPose26
+.4byte sParasectPose27
+.4byte sParasectPose28
+.4byte sParasectPose29
+.4byte sParasectPose30
+.4byte sParasectPose31
+.4byte sParasectPose32
+.4byte sParasectPose33
+.4byte sParasectPose34
+.4byte sParasectPose35
+.4byte sParasectPose36
+.4byte sParasectPose37
+.4byte sParasectPose38
+.4byte sParasectPose39
+.4byte sParasectPose40
+.4byte sParasectPose41
+.4byte sParasectPose42
+.4byte sParasectPose43
+.4byte sParasectPose44
+.4byte sParasectPose45
+.4byte sParasectPose46
+.4byte sParasectPose47
+.4byte sParasectPose48
+.4byte sParasectPose49
+.4byte sParasectPose50
+.4byte sParasectPose51
+.4byte sParasectPose52
+.4byte sParasectPose53
+.4byte sParasectPose54
+.4byte sParasectPose55
+.4byte sParasectPose56
+.4byte sParasectPose57
+.4byte sParasectPose58
+.4byte sParasectPose59
+.4byte sParasectPose60
+.4byte sParasectPose61
+.4byte sParasectPose62
+.4byte sParasectPose63
+.4byte sParasectPose64
+.4byte sParasectPose65
+.4byte sParasectPose66
+.4byte sParasectPose67
+.4byte sParasectPose68
+.4byte sParasectPose69
+.4byte sParasectPose70
+.4byte sParasectPose71
+.4byte sParasectPose72
+.4byte sParasectPose73
+.4byte sParasectPose74
+.4byte sParasectPose75
+.4byte sParasectPose76
+.4byte sParasectPose77
+.4byte sParasectPose78
+.4byte sParasectPose79
+.4byte sParasectPose80
+.4byte sParasectPose81
+.4byte sParasectPose82
+.4byte sParasectPose83
+.4byte sParasectPose84
+.4byte sParasectPose85
+.4byte sParasectPose86
+.4byte sParasectPose87
+.4byte sParasectPose88
+.4byte sParasectPose89
+.4byte sParasectPose90
+.4byte sParasectPose91
+.4byte sParasectPose92
+.4byte sParasectPose93
+.4byte sParasectPose94
+.4byte sParasectPose95
+.4byte sParasectPose96
+.4byte sParasectPose97
+.4byte sParasectPose98
+.4byte sParasectPose99
+.4byte sParasectPose100
+.4byte sParasectPose101
+.4byte sParasectPose102
+.4byte sParasectPose103
+.4byte sParasectPose104
+.4byte sParasectPose105
+.4byte sParasectPose106
+.4byte sParasectPose107
+.4byte sParasectPose108
+.4byte sParasectPose109
+.4byte sParasectPose110
+.4byte sParasectPose111
+.4byte sParasectPose112
+.4byte sParasectPose113
+.4byte sParasectPose114
+.4byte sParasectPose115
+.4byte sParasectPose116
+.4byte sParasectPose117
+.4byte sParasectPose118
+.4byte sParasectPose119
+.4byte sParasectPose120
+.4byte sParasectPose121
+.4byte sParasectPose122
+.4byte sParasectPose123
+.4byte sParasectPose124
+.4byte sParasectPose125
+.4byte sParasectPose126
+.4byte sParasectPose127
+.4byte sParasectPose128
+.4byte sParasectPose129
+.4byte sParasectPose130
+.4byte sParasectPose131
+.4byte sParasectPose132
+.4byte sParasectPose133
+.4byte sParasectPose134
+.4byte sParasectPose135
+.4byte sParasectPose136
+.4byte sParasectPose137
+.4byte sParasectPose138
+.4byte sParasectPose139
+.4byte sParasectPose140
+.4byte sParasectPose141
+.4byte sParasectPose142
+.4byte sParasectPose143
+.4byte sParasectPose144
+.4byte sParasectPose145
+.4byte sParasectPose146
+.4byte sParasectPose147
+.4byte sParasectPose148
+.4byte sParasectPose149
+.4byte sParasectPose150
+.4byte sParasectPose151
+.4byte sParasectPose152
+.4byte sParasectPose153
+.4byte sParasectPose154
+.4byte sParasectPose155
+.4byte sParasectPose156
+.4byte sParasectPose157
+.4byte sParasectPose158
+.4byte sParasectPose159
+.4byte sParasectPose160
+.4byte sParasectPose161
+.4byte sParasectPose162
+.4byte sParasectPose163
+.4byte sParasectPose164
+.4byte sParasectPose165
+.4byte sParasectPose166
+.4byte sParasectPose167
+.4byte sParasectPose168
+.4byte sParasectPose169
+.4byte sParasectPose170
+.4byte sParasectPose171
+.4byte sParasectPose172
+.4byte sParasectPose173
+.4byte sParasectPose174
+.4byte sParasectPose175
+.4byte sParasectPose176
+.4byte sParasectPose177
+.4byte sParasectPose178
+.4byte sParasectPose179
+.4byte sParasectPose180
+.4byte sParasectPose181
+.4byte sParasectPose182
+.4byte sParasectPose183
+.4byte sParasectPose184
+.4byte sParasectPose185
+.4byte sParasectPose186
+.4byte sParasectPose187
+.4byte sParasectPose188
+.4byte sParasectPose189
+.4byte sParasectPose190
+.4byte sParasectPose191
+.4byte sParasectPose192
+.4byte sParasectPose193
+.4byte sParasectPose194
+.4byte sParasectPose195
+.4byte sParasectPose196
+.4byte sParasectPose197
+.4byte sParasectPose198
+.4byte sParasectPose199
+.4byte sParasectPose200
+.4byte sParasectPose201
+.4byte sParasectPose202
+.4byte sParasectPose203
+.4byte sParasectPose204
+.4byte sParasectPose205
+.4byte sParasectPose206
+.4byte sParasectPose207
+.4byte sParasectPose208
+.4byte sParasectPose209
+.4byte sParasectPose210
+.4byte sParasectPose211
+.4byte sParasectPose212
+.4byte sParasectPose213
+.4byte sParasectPose214
+.4byte sParasectPose215
+.4byte sParasectPose216
+.4byte sParasectPose217
+.4byte sParasectPose218
+.4byte sParasectPose219
+.4byte sParasectPose220
+.4byte sParasectPose221
+.4byte sParasectPose222
+.4byte sParasectPose223
+.4byte sParasectPose224
+.4byte sParasectPose225
+.4byte sParasectPose226
+.4byte sParasectPose227
+.4byte sParasectPose228
+.4byte sParasectPose229
+.4byte sParasectPose230
+.4byte sParasectPose231
+.4byte sParasectPose232
+.4byte sParasectPose233
+.4byte sParasectPose234
+.4byte sParasectPose235
+.4byte sParasectPose236
+.4byte sParasectPose237
+.4byte sParasectPose238
+.4byte sParasectPose239
+.4byte sParasectPose240
+.4byte sParasectPose241
+.4byte sParasectPose242
+.4byte sParasectPose243
+.4byte sParasectPose244
+.4byte sParasectPose245
+.4byte sParasectPose246
+.4byte sParasectPose247
+.4byte sParasectPose248
+.4byte sParasectPose249
+.4byte sParasectPose250
+.4byte sParasectPose251
+.4byte sParasectPose252
+.4byte sParasectPose253
+.4byte sParasectPose254
+.4byte sParasectPose255
+.4byte sParasectPose256
+.4byte sParasectPose257
+.4byte sParasectPose258
+sAxPositionsParasect:
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte    1,   -1, 	  -5,    5, 	   6,    2, 	   0,   -8
+.2byte   -1,   -1, 	  -7,    2, 	   4,    5, 	  -1,   -8
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+.2byte    4,   -1, 	  11,    0, 	   0,    4, 	   0,   -8
+.2byte    6,   -2, 	  10,   -3, 	   3,    5, 	  -1,   -8
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    8,   -1, 	  12,   -1, 	   7,    3, 	  -1,   -8
+.2byte    9,   -3, 	   6,   -1, 	  11,    3, 	   0,   -8
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    5,   -6, 	   1,   -5, 	  10,   -1, 	  -1,   -8
+.2byte    4,   -8, 	   0,   -4, 	  12,   -3, 	  -1,   -8
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,   -9, 	   5,   -8, 	  -8,  -12, 	   0,   -8
+.2byte    0,   -9, 	   7,  -12, 	  -7,   -8, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -6,   -6, 	  -2,   -5, 	 -11,   -1, 	   0,   -8
+.2byte   -5,   -8, 	  -1,   -4, 	 -13,   -3, 	   0,   -8
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte   -9,   -1, 	 -13,   -1, 	  -8,    3, 	   0,   -8
+.2byte  -10,   -3, 	  -7,   -1, 	 -12,    3, 	  -1,   -8
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte   -5,   -1, 	 -12,    0, 	  -1,    4, 	  -1,   -8
+.2byte   -7,   -2, 	 -11,   -3, 	  -4,    5, 	   0,   -8
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte    0,   -2, 	   1,    0, 	  -3,   -1, 	   0,   -8
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+.2byte    5,   -2, 	   5,   -1, 	   7,   -2, 	   0,   -8
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    8,   -2, 	   8,   -1, 	   9,   -4, 	   1,   -8
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    2,   -6, 	   4,   -6, 	   0,   -7, 	  -1,   -9
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,   -6, 	  -4,   -6, 	   1,   -6, 	   0,  -10
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -3,   -6, 	  -5,   -6, 	  -1,   -7, 	   0,   -9
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte   -9,   -2, 	  -9,   -1, 	 -10,   -4, 	  -2,   -8
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte   -6,   -2, 	  -6,   -1, 	  -8,   -2, 	  -1,   -8
+.2byte    0,   -2, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte   -7,   -3, 	 -10,   -4, 	  -5,   -2, 	   0,   -8
+.2byte  -11,   -4, 	 -11,   -7, 	 -11,   -5, 	   1,   -8
+.2byte   -5,   -8, 	  -3,   -9, 	  -8,   -8, 	   1,   -8
+.2byte    0,   -7, 	   3,   -9, 	  -3,   -9, 	   0,   -8
+.2byte    4,   -8, 	   2,   -9, 	   7,   -8, 	  -2,   -8
+.2byte   10,   -4, 	  10,   -7, 	  10,   -5, 	  -2,   -8
+.2byte    6,   -3, 	   9,   -4, 	   4,   -2, 	  -1,   -8
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte    1,   -1, 	  -5,    5, 	   6,    2, 	   0,   -8
+.2byte   -1,   -1, 	  -7,    2, 	   4,    5, 	  -1,   -8
+.2byte   -1,   -4, 	  -5,    1, 	  10,  -19, 	  -2,  -11
+.2byte   -3,   -1, 	  -7,    2, 	  -5,    5, 	   0,   -9
+.2byte   -3,   -1, 	  -7,    2, 	  -5,    5, 	   0,   -9
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+.2byte    4,   -1, 	  11,    0, 	   0,    4, 	   0,   -8
+.2byte    6,   -2, 	  10,   -3, 	   3,    5, 	  -1,   -8
+.2byte    4,   -4, 	   9,   -2, 	  -3,  -17, 	   0,  -11
+.2byte    6,   -2, 	  10,   -2, 	   9,    2, 	   0,   -9
+.2byte    6,   -2, 	  10,   -2, 	   9,    2, 	   0,   -9
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    8,   -1, 	  12,   -1, 	   7,    3, 	  -1,   -8
+.2byte    9,   -3, 	   6,   -1, 	  11,    3, 	   0,   -8
+.2byte    9,   -4, 	   9,   -3, 	   5,  -16, 	   0,  -10
+.2byte   11,   -2, 	  11,   -3, 	  15,   -1, 	   1,   -9
+.2byte   11,   -2, 	  11,   -3, 	  15,   -1, 	   1,   -9
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    5,   -6, 	   1,   -5, 	  10,   -1, 	  -1,   -8
+.2byte    4,   -8, 	   0,   -4, 	  12,   -3, 	  -1,   -8
+.2byte    2,   -7, 	  -1,   -8, 	  10,  -18, 	  -2,  -11
+.2byte    3,   -7, 	   2,   -7, 	   5,   -8, 	   0,  -11
+.2byte    3,   -7, 	   2,   -7, 	   5,   -8, 	   0,  -11
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,   -9, 	   5,   -8, 	  -8,  -12, 	   0,   -8
+.2byte    0,   -9, 	   7,  -12, 	  -7,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	   5,  -11, 	 -11,  -20, 	   1,  -10
+.2byte    3,  -10, 	   2,  -11, 	   5,  -10, 	  -1,  -10
+.2byte    3,  -10, 	   2,  -11, 	   5,  -10, 	  -1,  -10
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -6,   -6, 	  -2,   -5, 	 -11,   -1, 	   0,   -8
+.2byte   -5,   -8, 	  -1,   -4, 	 -13,   -3, 	   0,   -8
+.2byte   -3,   -7, 	   0,   -8, 	 -11,  -18, 	   1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	  -6,   -8, 	  -1,  -11
+.2byte   -4,   -7, 	  -3,   -7, 	  -6,   -8, 	  -1,  -11
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte   -9,   -1, 	 -13,   -1, 	  -8,    3, 	   0,   -8
+.2byte  -10,   -3, 	  -7,   -1, 	 -12,    3, 	  -1,   -8
+.2byte  -10,   -4, 	 -10,   -3, 	  -6,  -16, 	  -1,  -10
+.2byte  -12,   -2, 	 -12,   -3, 	 -16,   -1, 	  -2,   -9
+.2byte  -12,   -2, 	 -12,   -3, 	 -16,   -1, 	  -2,   -9
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte   -5,   -1, 	 -12,    0, 	  -1,    4, 	  -1,   -8
+.2byte   -7,   -2, 	 -11,   -3, 	  -4,    5, 	   0,   -8
+.2byte   -5,   -4, 	 -10,   -2, 	   2,  -17, 	  -1,  -11
+.2byte   -7,   -2, 	 -11,   -2, 	 -10,    2, 	  -1,   -9
+.2byte   -7,   -2, 	 -11,   -2, 	 -10,    2, 	  -1,   -9
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte    0,   -2, 	   1,    0, 	  -3,   -1, 	   0,   -8
+.2byte    0,   -7, 	 -10,  -19, 	   9,  -19, 	   0,  -15
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+.2byte    5,   -2, 	   5,   -1, 	   7,   -2, 	   0,   -8
+.2byte    5,   -8, 	  12,  -21, 	  -1,  -16, 	  -2,  -13
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    8,   -2, 	   8,   -1, 	   9,   -4, 	   1,   -8
+.2byte    9,  -10, 	   6,  -22, 	   8,  -16, 	  -2,  -10
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    2,   -6, 	   4,   -6, 	   0,   -7, 	  -1,   -9
+.2byte    3,  -15, 	  -5,  -23, 	  12,  -20, 	  -2,  -10
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,   -6, 	  -4,   -6, 	   1,   -6, 	   0,  -10
+.2byte    0,  -15, 	  10,  -21, 	 -11,  -21, 	   0,  -10
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -3,   -6, 	  -5,   -6, 	  -1,   -7, 	   0,   -9
+.2byte   -4,  -15, 	   4,  -23, 	 -13,  -20, 	   1,  -10
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte   -9,   -2, 	  -9,   -1, 	 -10,   -4, 	  -2,   -8
+.2byte  -10,  -10, 	  -7,  -22, 	  -9,  -16, 	   1,  -10
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte   -6,   -2, 	  -6,   -1, 	  -8,   -2, 	  -1,   -8
+.2byte   -6,   -8, 	 -13,  -21, 	   0,  -16, 	   1,  -13
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+.2byte    0,    0, 	  -3,    1, 	   2,    1, 	   0,   -7
+.2byte    0,    1, 	  -3,    1, 	   2,    1, 	   0,   -6
+.2byte    0,  -17, 	 -11,  -23, 	  10,  -23, 	   0,  -11
+.2byte   -3,  -14, 	   3,  -22, 	 -12,  -20, 	  -1,   -9
+.2byte   -6,  -13, 	  -8,  -23, 	 -12,  -14, 	   0,   -9
+.2byte   -4,   -9, 	 -13,  -16, 	   3,  -15, 	  -1,  -10
+.2byte    0,   -8, 	  10,  -16, 	 -11,  -16, 	   0,  -11
+.2byte    3,   -9, 	  12,  -16, 	  -4,  -15, 	   0,  -10
+.2byte    5,  -13, 	   7,  -23, 	  11,  -14, 	  -1,   -9
+.2byte    2,  -14, 	  -4,  -22, 	  11,  -20, 	   0,   -9
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+.2byte    0,   -5, 	 -10,  -17, 	   9,  -17, 	   0,  -13
+.2byte   -6,   -6, 	 -13,  -19, 	   0,  -14, 	   1,  -11
+.2byte  -10,  -10, 	  -7,  -22, 	  -9,  -16, 	   1,  -10
+.2byte   -4,  -15, 	   4,  -23, 	 -13,  -20, 	   1,  -10
+.2byte    0,  -15, 	  10,  -21, 	 -11,  -21, 	   0,  -10
+.2byte    3,  -15, 	  -5,  -23, 	  12,  -20, 	  -2,  -10
+.2byte    9,  -10, 	   6,  -22, 	   8,  -16, 	  -2,  -10
+.2byte    5,   -6, 	  12,  -19, 	  -1,  -14, 	  -2,  -11
+.2byte    0,   -5, 	 -10,  -17, 	   9,  -17, 	   0,  -13
+.2byte    5,   -6, 	  12,  -19, 	  -1,  -14, 	  -2,  -11
+.2byte    9,  -10, 	   6,  -22, 	   8,  -16, 	  -2,  -10
+.2byte    3,  -15, 	  -5,  -23, 	  12,  -20, 	  -2,  -10
+.2byte    0,  -15, 	  10,  -21, 	 -11,  -21, 	   0,  -10
+.2byte   -4,  -15, 	   4,  -23, 	 -13,  -20, 	   1,  -10
+.2byte  -10,  -10, 	  -7,  -22, 	  -9,  -16, 	   1,  -10
+.2byte   -6,   -6, 	 -13,  -19, 	   0,  -14, 	   1,  -11
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte    0,   -6, 	 -10,  -18, 	   9,  -18, 	   0,  -14
+.2byte    0,   -1, 	   1,    1, 	  -3,    0, 	   0,   -7
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+.2byte    5,   -8, 	  12,  -21, 	  -1,  -16, 	  -2,  -13
+.2byte    5,   -2, 	   5,   -1, 	   7,   -2, 	   0,   -8
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    9,  -10, 	   6,  -22, 	   8,  -16, 	  -2,  -10
+.2byte    8,   -2, 	   8,   -1, 	   9,   -4, 	   1,   -8
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    3,  -15, 	  -5,  -23, 	  12,  -20, 	  -2,  -10
+.2byte    2,   -6, 	   4,   -6, 	   0,   -7, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  10,  -21, 	 -11,  -21, 	   0,  -10
+.2byte   -1,   -6, 	  -4,   -6, 	   1,   -6, 	   0,  -10
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -4,  -15, 	   4,  -23, 	 -13,  -20, 	   1,  -10
+.2byte   -3,   -6, 	  -5,   -6, 	  -1,   -7, 	   0,   -9
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte  -10,  -10, 	  -7,  -22, 	  -9,  -16, 	   1,  -10
+.2byte   -9,   -2, 	  -9,   -1, 	 -10,   -4, 	  -2,   -8
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte   -6,   -8, 	 -13,  -21, 	   0,  -16, 	   1,  -13
+.2byte   -6,   -2, 	  -6,   -1, 	  -8,   -2, 	  -1,   -8
+.2byte    0,   -1, 	   1,    1, 	  -3,    0, 	   0,   -7
+.2byte   -6,   -1, 	  -6,    0, 	  -8,   -1, 	  -1,   -7
+.2byte   -9,   -2, 	  -9,   -1, 	 -10,   -4, 	  -2,   -8
+.2byte   -3,   -5, 	  -5,   -5, 	  -1,   -6, 	   0,   -8
+.2byte   -1,   -5, 	  -4,   -5, 	   1,   -5, 	   0,   -9
+.2byte    2,   -5, 	   4,   -5, 	   0,   -6, 	  -1,   -8
+.2byte    8,   -2, 	   8,   -1, 	   9,   -4, 	   1,   -8
+.2byte    5,   -1, 	   5,    0, 	   7,   -1, 	   0,   -7
+.2byte    0,   -2, 	  -6,    2, 	   5,    2, 	  -1,   -9
+.2byte   -6,   -2, 	 -11,   -2, 	  -2,    3, 	  -1,   -9
+.2byte  -10,   -3, 	  -9,   -2, 	  -9,    2, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,   -5, 	 -11,   -2, 	   0,   -9
+.2byte   -1,  -10, 	   6,  -11, 	  -7,  -11, 	  -1,   -9
+.2byte    5,   -7, 	   1,   -5, 	  10,   -2, 	  -1,   -9
+.2byte    9,   -3, 	   8,   -2, 	   8,    2, 	   0,   -9
+.2byte    5,   -2, 	  10,   -2, 	   1,    3, 	   0,   -9
+sParasectAnimTable1:
+.4byte sParasectAnims_1_1
+.4byte sParasectAnims_1_2
+.4byte sParasectAnims_1_3
+.4byte sParasectAnims_1_4
+.4byte sParasectAnims_1_5
+.4byte sParasectAnims_1_6
+.4byte sParasectAnims_1_7
+.4byte sParasectAnims_1_8
+sParasectAnimTable2:
+.4byte sParasectAnims_2_1
+.4byte sParasectAnims_2_2
+.4byte sParasectAnims_2_3
+.4byte sParasectAnims_2_4
+.4byte sParasectAnims_2_5
+.4byte sParasectAnims_2_6
+.4byte sParasectAnims_2_7
+.4byte sParasectAnims_2_8
+sParasectAnimTable3:
+.4byte sParasectAnims_3_1
+.4byte sParasectAnims_3_2
+.4byte sParasectAnims_3_3
+.4byte sParasectAnims_3_4
+.4byte sParasectAnims_3_5
+.4byte sParasectAnims_3_6
+.4byte sParasectAnims_3_7
+.4byte sParasectAnims_3_8
+sParasectAnimTable4:
+.4byte sParasectAnims_4_1
+.4byte sParasectAnims_4_2
+.4byte sParasectAnims_4_3
+.4byte sParasectAnims_4_4
+.4byte sParasectAnims_4_5
+.4byte sParasectAnims_4_6
+.4byte sParasectAnims_4_7
+.4byte sParasectAnims_4_8
+sParasectAnimTable5:
+.4byte sParasectAnims_5_1
+.4byte sParasectAnims_5_2
+.4byte sParasectAnims_5_3
+.4byte sParasectAnims_5_4
+.4byte sParasectAnims_5_5
+.4byte sParasectAnims_5_6
+.4byte sParasectAnims_5_7
+.4byte sParasectAnims_5_8
+sParasectAnimTable6:
+.4byte sParasectAnims_6_1
+.4byte sParasectAnims_6_1
+.4byte sParasectAnims_6_1
+.4byte sParasectAnims_6_1
+.4byte sParasectAnims_6_1
+.4byte sParasectAnims_6_1
+.4byte sParasectAnims_6_1
+.4byte sParasectAnims_6_1
+sParasectAnimTable7:
+.4byte sParasectAnims_7_1
+.4byte sParasectAnims_7_2
+.4byte sParasectAnims_7_3
+.4byte sParasectAnims_7_4
+.4byte sParasectAnims_7_5
+.4byte sParasectAnims_7_6
+.4byte sParasectAnims_7_7
+.4byte sParasectAnims_7_8
+sParasectAnimTable8:
+.4byte sParasectAnims_8_1
+.4byte sParasectAnims_8_2
+.4byte sParasectAnims_8_3
+.4byte sParasectAnims_8_4
+.4byte sParasectAnims_8_5
+.4byte sParasectAnims_8_6
+.4byte sParasectAnims_8_7
+.4byte sParasectAnims_8_8
+sParasectAnimTable9:
+.4byte sParasectAnims_9_1
+.4byte sParasectAnims_9_2
+.4byte sParasectAnims_9_3
+.4byte sParasectAnims_9_4
+.4byte sParasectAnims_9_5
+.4byte sParasectAnims_9_6
+.4byte sParasectAnims_9_7
+.4byte sParasectAnims_9_8
+sParasectAnimTable10:
+.4byte sParasectAnims_10_1
+.4byte sParasectAnims_10_2
+.4byte sParasectAnims_10_3
+.4byte sParasectAnims_10_4
+.4byte sParasectAnims_10_5
+.4byte sParasectAnims_10_6
+.4byte sParasectAnims_10_7
+.4byte sParasectAnims_10_8
+sParasectAnimTable11:
+.4byte sParasectAnims_11_1
+.4byte sParasectAnims_11_2
+.4byte sParasectAnims_11_3
+.4byte sParasectAnims_11_4
+.4byte sParasectAnims_11_5
+.4byte sParasectAnims_11_6
+.4byte sParasectAnims_11_7
+.4byte sParasectAnims_11_8
+sParasectAnimTable12:
+.4byte sParasectAnims_12_1
+.4byte sParasectAnims_12_2
+.4byte sParasectAnims_12_3
+.4byte sParasectAnims_12_4
+.4byte sParasectAnims_12_5
+.4byte sParasectAnims_12_6
+.4byte sParasectAnims_12_7
+.4byte sParasectAnims_12_8
+sParasectAnimTable13:
+.4byte sParasectAnims_13_1
+.4byte sParasectAnims_13_2
+.4byte sParasectAnims_13_3
+.4byte sParasectAnims_13_4
+.4byte sParasectAnims_13_5
+.4byte sParasectAnims_13_6
+.4byte sParasectAnims_13_7
+.4byte sParasectAnims_13_8
+sAxAnimationsParasect:
+.4byte sParasectAnimTable1
+.4byte sParasectAnimTable2
+.4byte sParasectAnimTable3
+.4byte sParasectAnimTable4
+.4byte sParasectAnimTable5
+.4byte sParasectAnimTable6
+.4byte sParasectAnimTable7
+.4byte sParasectAnimTable8
+.4byte sParasectAnimTable9
+.4byte sParasectAnimTable10
+.4byte sParasectAnimTable11
+.4byte sParasectAnimTable12
+.4byte sParasectAnimTable13
+sAxSpritesParasect:
+.4byte sParasectSprites1
+.4byte sParasectSprites2
+.4byte sParasectSprites3
+.4byte sParasectSprites4
+.4byte sParasectSprites5
+.4byte sParasectSprites6
+.4byte sParasectSprites7
+.4byte sParasectSprites8
+.4byte sParasectSprites9
+.4byte sParasectSprites10
+.4byte sParasectSprites11
+.4byte sParasectSprites12
+.4byte sParasectSprites13
+.4byte sParasectSprites14
+.4byte sParasectSprites15
+.4byte sParasectSprites16
+.4byte sParasectSprites17
+.4byte sParasectSprites18
+.4byte sParasectSprites19
+.4byte sParasectSprites20
+.4byte sParasectSprites21
+.4byte sParasectSprites22
+.4byte sParasectSprites23
+.4byte sParasectSprites24
+.4byte sParasectSprites25
+.4byte sParasectSprites26
+.4byte sParasectSprites27
+.4byte sParasectSprites28
+.4byte sParasectSprites29
+.4byte sParasectSprites30
+.4byte sParasectSprites31
+.4byte sParasectSprites32
+.4byte sParasectSprites33
+.4byte sParasectSprites34
+.4byte sParasectSprites35
+.4byte sParasectSprites36
+.4byte sParasectSprites37
+.4byte sParasectSprites38
+.4byte sParasectSprites39
+.4byte sParasectSprites40
+.4byte sParasectSprites41
+.4byte sParasectSprites42
+.4byte sParasectSprites43
+.4byte sParasectSprites44
+.4byte sParasectSprites45
+.4byte sParasectSprites46
+.4byte sParasectSprites47
+.4byte sParasectSprites48
+.4byte sParasectSprites49
+.4byte sParasectSprites50
+.4byte sParasectSprites51
+.4byte sParasectSprites52
+sAxMainParasect:
+ax_main sAxPosesParasect, sAxAnimationsParasect, 13, sAxSpritesParasect, sAxPositionsParasect

--- a/data/ax/pelipper.inc
+++ b/data/ax/pelipper.inc
@@ -1,0 +1,3196 @@
+.global gAxPelipper
+gAxPelipper:
+ax_siro sAxMainPelipper
+sPelipperPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose4:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose5:
+ax_pose 4, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose6:
+ax_pose 5, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose7:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose8:
+ax_pose 7, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose9:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose10:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose11:
+ax_pose 10, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose12:
+ax_pose 11, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose13:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose14:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose15:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose16:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose17:
+ax_pose 10, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose18:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose19:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose20:
+ax_pose 7, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose21:
+ax_pose 8, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose22:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose23:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose24:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose28:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose29:
+ax_pose 4, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose30:
+ax_pose 5, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose31:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose32:
+ax_pose 7, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose33:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose34:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose35:
+ax_pose 10, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose36:
+ax_pose 11, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose37:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose38:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose39:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose40:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose41:
+ax_pose 10, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose42:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose43:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose44:
+ax_pose 7, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose45:
+ax_pose 8, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose46:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose47:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose48:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose49:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose50:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose51:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose52:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose53:
+ax_pose 4, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose54:
+ax_pose 5, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose55:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose56:
+ax_pose 7, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose57:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose58:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose59:
+ax_pose 10, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose60:
+ax_pose 11, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose61:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose62:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose63:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose64:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose65:
+ax_pose 10, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose66:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose67:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose68:
+ax_pose 7, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose69:
+ax_pose 8, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose70:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose71:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose72:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose73:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose74:
+ax_pose 15, 0x41f0, 0x80f0, 0x5c00
+ax_pose 16, 0x41e8, 0x40f0, 0x5c08
+ax_pose 17, 0x01e0, 0x00f0, 0x5c0c
+ax_pose 18, 0x01e8, 0x0110, 0x5c0d
+ax_pose 19, 0x01e0, 0x0108, 0x5c0e
+ax_pose_terminator
+sPelipperPose75:
+ax_pose 20, 0x81e6, 0x80f0, 0x5c00
+ax_pose 21, 0x81e6, 0x4100, 0x5c08
+ax_pose 22, 0x01f6, 0x0110, 0x5c0c
+ax_pose 23, 0x81ee, 0x0108, 0x5c0d
+ax_pose_terminator
+sPelipperPose76:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose77:
+ax_pose 24, 0x01e1, 0x90ee, 0x5c00
+ax_pose_terminator
+sPelipperPose78:
+ax_pose 25, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose79:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose80:
+ax_pose 26, 0x01e2, 0x90ee, 0x5c00
+ax_pose_terminator
+sPelipperPose81:
+ax_pose 27, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose82:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose83:
+ax_pose 28, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sPelipperPose84:
+ax_pose 29, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose85:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose86:
+ax_pose 30, 0x81e2, 0x80f0, 0x5c00
+ax_pose 31, 0x81e2, 0x4100, 0x5c08
+ax_pose 32, 0x81e2, 0x0108, 0x5c0c
+ax_pose 33, 0x01f2, 0x0108, 0x5c0e
+ax_pose 34, 0x01ea, 0x0110, 0x5c0f
+ax_pose_terminator
+sPelipperPose87:
+ax_pose 35, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose88:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose89:
+ax_pose 28, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sPelipperPose90:
+ax_pose 29, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose91:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose92:
+ax_pose 26, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sPelipperPose93:
+ax_pose 27, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose94:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose95:
+ax_pose 24, 0x01e1, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose96:
+ax_pose 25, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose97:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose98:
+ax_pose 15, 0x41f0, 0x80f0, 0x5c00
+ax_pose 16, 0x41e8, 0x40f0, 0x5c08
+ax_pose 17, 0x01e0, 0x00f0, 0x5c0c
+ax_pose 18, 0x01e8, 0x0110, 0x5c0d
+ax_pose 19, 0x01e0, 0x0108, 0x5c0e
+ax_pose_terminator
+sPelipperPose99:
+ax_pose 20, 0x81e6, 0x80f0, 0x5c00
+ax_pose 21, 0x81e6, 0x4100, 0x5c08
+ax_pose 22, 0x01f6, 0x0110, 0x5c0c
+ax_pose 23, 0x81ee, 0x0108, 0x5c0d
+ax_pose_terminator
+sPelipperPose100:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose101:
+ax_pose 24, 0x01e1, 0x90ee, 0x5c00
+ax_pose_terminator
+sPelipperPose102:
+ax_pose 25, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose103:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose104:
+ax_pose 26, 0x01e2, 0x90ee, 0x5c00
+ax_pose_terminator
+sPelipperPose105:
+ax_pose 27, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose106:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose107:
+ax_pose 28, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sPelipperPose108:
+ax_pose 29, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose109:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose110:
+ax_pose 30, 0x81e2, 0x80f0, 0x5c00
+ax_pose 31, 0x81e2, 0x4100, 0x5c08
+ax_pose 32, 0x81e2, 0x0108, 0x5c0c
+ax_pose 33, 0x01f2, 0x0108, 0x5c0e
+ax_pose 34, 0x01ea, 0x0110, 0x5c0f
+ax_pose_terminator
+sPelipperPose111:
+ax_pose 35, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose112:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose113:
+ax_pose 28, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sPelipperPose114:
+ax_pose 29, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose115:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose116:
+ax_pose 26, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sPelipperPose117:
+ax_pose 27, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose118:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose119:
+ax_pose 24, 0x01e1, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose120:
+ax_pose 25, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose121:
+ax_pose 36, 0x01ed, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose122:
+ax_pose 37, 0x01ed, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose123:
+ax_pose 38, 0x01dd, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose124:
+ax_pose 39, 0x01de, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose125:
+ax_pose 40, 0x01de, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose126:
+ax_pose 41, 0x01e0, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose127:
+ax_pose 42, 0x01df, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose128:
+ax_pose 41, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose129:
+ax_pose 40, 0x01de, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose130:
+ax_pose 39, 0x01de, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose131:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose132:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose133:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose134:
+ax_pose 5, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose135:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose136:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose137:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose138:
+ax_pose 11, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose139:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose140:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose141:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose142:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose143:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose144:
+ax_pose 8, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose145:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose146:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose147:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose148:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose149:
+ax_pose 8, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose150:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose151:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose152:
+ax_pose 11, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose153:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose154:
+ax_pose 5, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose155:
+ax_pose 20, 0x81e6, 0x80f0, 0x5c00
+ax_pose 21, 0x81e6, 0x4100, 0x5c08
+ax_pose 22, 0x01f6, 0x0110, 0x5c0c
+ax_pose 23, 0x81ee, 0x0108, 0x5c0d
+ax_pose_terminator
+sPelipperPose156:
+ax_pose 25, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose157:
+ax_pose 27, 0x01e3, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose158:
+ax_pose 29, 0x01e5, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose159:
+ax_pose 35, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose160:
+ax_pose 29, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose161:
+ax_pose 27, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose162:
+ax_pose 25, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose163:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose164:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose165:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose166:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose167:
+ax_pose 4, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose168:
+ax_pose 5, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose169:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose170:
+ax_pose 7, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose171:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose172:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose173:
+ax_pose 10, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose174:
+ax_pose 11, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose175:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose176:
+ax_pose 13, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose177:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose178:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose179:
+ax_pose 10, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose180:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose181:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose182:
+ax_pose 7, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose183:
+ax_pose 8, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose184:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose185:
+ax_pose 4, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose186:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose187:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose188:
+ax_pose 5, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose189:
+ax_pose 8, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose190:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose191:
+ax_pose 14, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose192:
+ax_pose 11, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose193:
+ax_pose 8, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose194:
+ax_pose 5, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose195:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose196:
+ax_pose 3, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose197:
+ax_pose 6, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose198:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose199:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose200:
+ax_pose 9, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sPelipperPose201:
+ax_pose 6, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose202:
+ax_pose 3, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose203:
+ax_pose 43, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose204:
+ax_pose 44, 0x41eb, 0x80ef, 0x5c00
+ax_pose 45, 0x41fb, 0x40ef, 0x5c08
+ax_pose 46, 0x41f9, 0x00f8, 0x5c0c
+ax_pose_terminator
+sPelipperPose205:
+ax_pose 47, 0x41eb, 0x80ef, 0x5c00
+ax_pose 48, 0x41fb, 0x40ef, 0x5c08
+ax_pose 46, 0x41f9, 0x00f8, 0x5c0c
+ax_pose_terminator
+sPelipperPose206:
+ax_pose 49, 0x41eb, 0x80ef, 0x5c00
+ax_pose 50, 0x41fb, 0x40ef, 0x5c08
+ax_pose 46, 0x41f9, 0x00f8, 0x5c0c
+ax_pose_terminator
+sPelipperPose207:
+ax_pose 51, 0x01eb, 0x80ef, 0x5c00
+ax_pose_terminator
+sPelipperPose208:
+ax_pose 6, 0x01be, 0x80f3, 0x5c00
+ax_pose_terminator
+sPelipperPose209:
+ax_pose 7, 0x01bf, 0x80f3, 0x5c00
+ax_pose_terminator
+sPelipperPose210:
+ax_pose 8, 0x01c0, 0x80f3, 0x5c00
+ax_pose_terminator
+sPelipperPose211:
+ax_pose 52, 0x01be, 0x80f2, 0x5c00
+ax_pose_terminator
+sPelipperPose212:
+ax_pose 53, 0x01be, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose213:
+ax_pose 54, 0x01be, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose214:
+ax_pose 55, 0x01be, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose215:
+ax_pose 13, 0x01bf, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose216:
+ax_pose 55, 0x01be, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose217:
+ax_pose 54, 0x01be, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose218:
+ax_pose 53, 0x01be, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose219:
+ax_pose 52, 0x01be, 0x90ef, 0x5c00
+ax_pose_terminator
+sPelipperPose220:
+ax_pose 56, 0x01bd, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose221:
+ax_pose 4, 0x01bf, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose222:
+ax_pose 57, 0x01bd, 0x90f0, 0x5c00
+ax_pose_terminator
+sPelipperPose223:
+ax_pose 1, 0x01be, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose224:
+ax_pose 57, 0x01bd, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose225:
+ax_pose 4, 0x01bf, 0x80f0, 0x5c00
+ax_pose_terminator
+sPelipperPose226:
+ax_pose 56, 0x01bd, 0x80f1, 0x5c00
+ax_pose_terminator
+sPelipperPose227:
+ax_pose 6, 0x01be, 0x90ed, 0x5c00
+ax_pose_terminator
+sPelipperPose228:
+ax_pose 7, 0x01bf, 0x90ed, 0x5c00
+ax_pose_terminator
+sPelipperPose229:
+ax_pose 8, 0x01c0, 0x90ed, 0x5c00
+ax_pose_terminator
+.align 2
+sPelipperAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim 8, 0, 16, 0, 1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 18, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim 8, 0, 19, 0, 1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 21, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim 8, 0, 22, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_2_1:
+ax_anim 3, 0, 24, 0, -1, 0, -1,
+ax_anim 3, 0, 26, 0, -2, 0, -2,
+ax_anim 3, 0, 24, 0, -2, 0, -2,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 1, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 25, 0, 23, 0, 23,
+ax_anim 2, 0, 25, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPelipperAnims_2_2:
+ax_anim 3, 0, 27, -1, -1, -1, -1,
+ax_anim 3, 0, 29, -2, -2, -2, -2,
+ax_anim 3, 0, 27, -2, -2, -2, -2,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 5, 4, 5,
+ax_anim 1, 0, 28, 10, 12, 10, 12,
+ax_anim 2, 0, 28, 19, 24, 19, 22,
+ax_anim 2, 1, 28, 20, 23, 20, 21,
+ax_anim 2, 0, 28, 19, 24, 19, 22,
+ax_anim 2, 0, 28, 20, 23, 20, 21,
+ax_anim 2, 0, 27, 6, 8, 6, 8,
+ax_anim_terminator
+sPelipperAnims_2_3:
+ax_anim 3, 0, 30, -1, 0, -1, 0,
+ax_anim 3, 0, 32, -2, 0, -2, 0,
+ax_anim 3, 0, 30, -2, 0, -2, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 2, 1, 2, 0,
+ax_anim 1, 0, 31, 8, 2, 8, 0,
+ax_anim 2, 0, 31, 16, 3, 16, 0,
+ax_anim 2, 1, 31, 16, 4, 16, 1,
+ax_anim 2, 0, 31, 16, 3, 16, 0,
+ax_anim 2, 0, 31, 16, 4, 16, 1,
+ax_anim 2, 0, 30, 6, 1, 6, 0,
+ax_anim_terminator
+sPelipperAnims_2_4:
+ax_anim 3, 0, 33, -1, 1, -1, 1,
+ax_anim 3, 0, 35, -2, 2, -2, 2,
+ax_anim 3, 0, 33, -2, 2, -2, 2,
+ax_anim 4, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -5, 5, -5,
+ax_anim 1, 0, 34, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 17, -17, 17, -17,
+ax_anim 2, 1, 34, 18, -16, 18, -16,
+ax_anim 2, 0, 34, 17, -17, 17, -17,
+ax_anim 2, 0, 34, 18, -16, 18, -16,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sPelipperAnims_2_5:
+ax_anim 3, 0, 36, 0, 1, 0, 1,
+ax_anim 3, 0, 38, 0, 2, 0, 2,
+ax_anim 3, 0, 36, 0, 2, 0, 2,
+ax_anim 4, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -2, 0, -2,
+ax_anim 1, 0, 37, 0, -8, 0, -8,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 1, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 0, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sPelipperAnims_2_6:
+ax_anim 3, 0, 39, 1, 1, 1, 1,
+ax_anim 3, 0, 41, 2, 2, 2, 2,
+ax_anim 3, 0, 39, 2, 2, 2, 2,
+ax_anim 4, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -5, -5, -5,
+ax_anim 1, 0, 40, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -17, -17, -17, -17,
+ax_anim 2, 1, 40, -18, -16, -18, -16,
+ax_anim 2, 0, 40, -17, -17, -17, -17,
+ax_anim 2, 0, 40, -18, -16, -18, -16,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sPelipperAnims_2_7:
+ax_anim 3, 0, 42, 1, 0, 1, 0,
+ax_anim 3, 0, 44, 2, 0, 2, 0,
+ax_anim 3, 0, 42, 2, 0, 2, 0,
+ax_anim 4, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -2, 1, -2, 0,
+ax_anim 1, 0, 43, -8, 2, -8, 0,
+ax_anim 2, 0, 43, -16, 3, -16, 0,
+ax_anim 2, 1, 43, -16, 4, -16, 1,
+ax_anim 2, 0, 43, -16, 3, -16, 0,
+ax_anim 2, 0, 43, -16, 4, -16, 1,
+ax_anim 2, 0, 42, -6, 1, -6, 0,
+ax_anim_terminator
+sPelipperAnims_2_8:
+ax_anim 3, 0, 45, 1, -1, 1, -1,
+ax_anim 3, 0, 47, 2, -2, 2, -2,
+ax_anim 3, 0, 45, 2, -2, 2, -2,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 5, -4, 5,
+ax_anim 1, 0, 46, -10, 12, -10, 12,
+ax_anim 2, 0, 46, -19, 24, -19, 22,
+ax_anim 2, 1, 46, -20, 23, -20, 21,
+ax_anim 2, 0, 46, -19, 24, -19, 22,
+ax_anim 2, 0, 46, -20, 23, -20, 21,
+ax_anim 2, 0, 45, -6, 8, -6, 8,
+ax_anim_terminator
+.align 2
+sPelipperAnims_3_1:
+ax_anim 3, 0, 48, 0, -1, 0, -1,
+ax_anim 3, 0, 50, 0, -2, 0, -2,
+ax_anim 3, 0, 48, 0, -2, 0, -2,
+ax_anim 4, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 12, 0, 12,
+ax_anim 1, 0, 49, 0, 26, 0, 26,
+ax_anim 2, 0, 49, 0, 47, 0, 47,
+ax_anim 2, 1, 49, 1, 47, 1, 47,
+ax_anim 2, 0, 49, 0, 47, 0, 47,
+ax_anim 2, 0, 49, 1, 47, 1, 47,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sPelipperAnims_3_2:
+ax_anim 3, 0, 51, -1, -1, -1, -1,
+ax_anim 3, 0, 53, -2, -2, -2, -2,
+ax_anim 3, 0, 51, -2, -2, -2, -2,
+ax_anim 4, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 12, 13, 12, 13,
+ax_anim 1, 0, 52, 26, 28, 26, 28,
+ax_anim 2, 0, 52, 43, 48, 43, 48,
+ax_anim 2, 1, 52, 44, 47, 44, 47,
+ax_anim 2, 0, 52, 43, 48, 43, 48,
+ax_anim 2, 0, 52, 44, 47, 44, 47,
+ax_anim 2, 0, 51, 6, 8, 6, 8,
+ax_anim_terminator
+sPelipperAnims_3_3:
+ax_anim 3, 0, 54, -1, 0, -1, 0,
+ax_anim 3, 0, 56, -2, 0, -2, 0,
+ax_anim 3, 0, 54, -2, 0, -2, 0,
+ax_anim 4, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 10, 1, 10, 1,
+ax_anim 1, 0, 55, 24, 2, 24, 2,
+ax_anim 2, 0, 55, 40, 3, 40, 3,
+ax_anim 2, 1, 55, 40, 4, 40, 4,
+ax_anim 2, 0, 55, 40, 3, 40, 3,
+ax_anim 2, 0, 55, 40, 4, 40, 4,
+ax_anim 2, 0, 54, 6, 1, 6, 1,
+ax_anim_terminator
+sPelipperAnims_3_4:
+ax_anim 3, 0, 57, -1, 1, -1, 1,
+ax_anim 3, 0, 59, -2, 2, -2, 2,
+ax_anim 3, 0, 57, -2, 2, -2, 2,
+ax_anim 4, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 13, -13, 13, -13,
+ax_anim 1, 0, 58, 27, -28, 27, -28,
+ax_anim 2, 0, 58, 41, -41, 41, -41,
+ax_anim 2, 1, 58, 42, -40, 42, -40,
+ax_anim 2, 0, 58, 41, -41, 41, -41,
+ax_anim 2, 0, 58, 42, -40, 42, -40,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sPelipperAnims_3_5:
+ax_anim 3, 0, 60, 0, 1, 0, 1,
+ax_anim 3, 0, 62, 0, 2, 0, 2,
+ax_anim 3, 0, 60, 0, 2, 0, 2,
+ax_anim 4, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -10, 0, -10,
+ax_anim 1, 0, 61, 0, -24, 0, -24,
+ax_anim 2, 0, 61, 0, -41, 0, -41,
+ax_anim 2, 1, 61, 1, -41, 1, -41,
+ax_anim 2, 0, 61, 0, -41, 0, -41,
+ax_anim 2, 0, 61, 1, -41, 1, -41,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sPelipperAnims_3_6:
+ax_anim 3, 0, 63, 1, 1, 1, 1,
+ax_anim 3, 0, 65, 2, 2, 2, 2,
+ax_anim 3, 0, 63, 2, 2, 2, 2,
+ax_anim 4, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -13, -13, -13, -13,
+ax_anim 1, 0, 64, -27, -28, -27, -28,
+ax_anim 2, 0, 64, -41, -41, -41, -41,
+ax_anim 2, 1, 64, -42, -40, -42, -40,
+ax_anim 2, 0, 64, -41, -41, -41, -41,
+ax_anim 2, 0, 64, -42, -40, -42, -40,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sPelipperAnims_3_7:
+ax_anim 3, 0, 66, 1, 0, 1, 0,
+ax_anim 3, 0, 68, 2, 0, 2, 0,
+ax_anim 3, 0, 66, 2, 0, 2, 0,
+ax_anim 4, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -10, 1, -10, 0,
+ax_anim 1, 0, 67, -24, 2, -24, 0,
+ax_anim 2, 0, 67, -40, 3, -40, 0,
+ax_anim 2, 1, 67, -40, 4, -40, 1,
+ax_anim 2, 0, 67, -40, 3, -40, 0,
+ax_anim 2, 0, 67, -40, 4, -40, 1,
+ax_anim 2, 0, 66, -6, 1, -6, 0,
+ax_anim_terminator
+sPelipperAnims_3_8:
+ax_anim 3, 0, 69, 1, -1, 1, -1,
+ax_anim 3, 0, 71, 2, -2, 2, -2,
+ax_anim 3, 0, 69, 2, -2, 2, -2,
+ax_anim 4, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -12, 13, -12, 13,
+ax_anim 1, 0, 70, -26, 28, -26, 28,
+ax_anim 2, 0, 70, -43, 48, -43, 46,
+ax_anim 2, 1, 70, -44, 47, -44, 45,
+ax_anim 2, 0, 70, -43, 48, -43, 46,
+ax_anim 2, 0, 70, -44, 47, -44, 45,
+ax_anim 2, 0, 69, -6, 8, -6, 8,
+ax_anim_terminator
+.align 2
+sPelipperAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 2,
+ax_anim 2, 0, 74, 1, 3, 1, 2,
+ax_anim 2, 0, 74, 0, 3, 0, 2,
+ax_anim 2, 0, 74, 1, 3, 1, 2,
+ax_anim 2, 0, 74, 0, 3, 0, 2,
+ax_anim 2, 0, 74, 1, 3, 1, 2,
+ax_anim 2, 0, 74, 0, 3, 0, 2,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sPelipperAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 1, 1,
+ax_anim 2, 0, 77, 3, 1, 2, 0,
+ax_anim 2, 0, 77, 2, 2, 1, 1,
+ax_anim 2, 0, 77, 3, 1, 2, 0,
+ax_anim 2, 0, 77, 2, 2, 1, 1,
+ax_anim 2, 0, 77, 3, 1, 2, 0,
+ax_anim 2, 0, 77, 2, 2, 1, 1,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sPelipperAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sPelipperAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 1, -1,
+ax_anim 2, 0, 83, 3, -1, 2, 0,
+ax_anim 2, 0, 83, 2, -2, 1, -1,
+ax_anim 2, 0, 83, 3, -1, 2, 0,
+ax_anim 2, 0, 83, 2, -2, 1, -1,
+ax_anim 2, 0, 83, 3, -1, 2, 0,
+ax_anim 2, 0, 83, 2, -2, 1, -1,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sPelipperAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 86, 1, -3, 1, -2,
+ax_anim 2, 0, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 86, 1, -3, 1, -2,
+ax_anim 2, 0, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 86, 1, -3, 1, -2,
+ax_anim 2, 0, 86, 0, -3, 0, -2,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sPelipperAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -1, -1,
+ax_anim 2, 0, 89, -3, -1, -2, 0,
+ax_anim 2, 0, 89, -2, -2, -1, -1,
+ax_anim 2, 0, 89, -3, -1, -2, 0,
+ax_anim 2, 0, 89, -2, -2, -1, -1,
+ax_anim 2, 0, 89, -3, -1, -2, 0,
+ax_anim 2, 0, 89, -2, -2, -1, -1,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sPelipperAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sPelipperAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -1, 1,
+ax_anim 2, 0, 95, -3, 1, -2, 0,
+ax_anim 2, 0, 95, -2, 2, -1, 1,
+ax_anim 2, 0, 95, -3, 1, -2, 0,
+ax_anim 2, 0, 95, -2, 2, -1, 1,
+ax_anim 2, 0, 95, -3, 1, -2, 0,
+ax_anim 2, 0, 95, -2, 2, -1, 1,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sPelipperAnims_5_1:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, -3, 0, -3,
+ax_anim 2, 2, 98, 0, -4, 0, -4,
+ax_anim 2, 0, 98, -1, -4, -1, -4,
+ax_anim 2, 0, 98, 0, -4, 0, -4,
+ax_anim 2, 0, 98, -1, -4, -1, -4,
+ax_anim 2, 0, 98, 0, -4, 0, -4,
+ax_anim 2, 0, 98, -1, -4, -1, -4,
+ax_anim 4, 1, 97, 0, -4, 0, -4,
+ax_anim 3, 0, 97, 0, -6, 0, -4,
+ax_anim 2, 0, 97, 0, -5, 0, -3,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim_terminator
+sPelipperAnims_5_2:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 2, 101, -4, -4, -4, -4,
+ax_anim 2, 0, 101, -5, -3, -5, -3,
+ax_anim 2, 0, 101, -4, -4, -4, -4,
+ax_anim 2, 0, 101, -5, -3, -5, -3,
+ax_anim 2, 0, 101, -4, -4, -4, -4,
+ax_anim 2, 0, 101, -5, -3, -5, -3,
+ax_anim 4, 1, 100, -4, -4, -4, -4,
+ax_anim 3, 0, 100, -4, -6, -4, -4,
+ax_anim 2, 0, 100, -4, -5, -4, -4,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim_terminator
+sPelipperAnims_5_3:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, -1, 0, -1, 0,
+ax_anim 2, 0, 104, -3, 0, -3, 0,
+ax_anim 2, 2, 104, -4, 0, -4, 0,
+ax_anim 2, 0, 104, -5, 0, -5, 0,
+ax_anim 2, 0, 104, -4, 0, -4, 0,
+ax_anim 2, 0, 104, -5, 0, -5, 0,
+ax_anim 2, 0, 104, -4, 0, -4, 0,
+ax_anim 2, 0, 104, -5, 0, -5, 0,
+ax_anim 4, 1, 103, -4, 0, -4, 0,
+ax_anim 3, 0, 103, -4, -2, -4, 0,
+ax_anim 2, 0, 103, -4, -1, -4, 0,
+ax_anim 2, 0, 102, -2, 0, -2, 0,
+ax_anim_terminator
+sPelipperAnims_5_4:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 1, -1, 1,
+ax_anim 2, 0, 107, -3, 3, -3, 3,
+ax_anim 2, 2, 107, -4, 4, -4, 4,
+ax_anim 2, 0, 107, -5, 3, -5, 3,
+ax_anim 2, 0, 107, -4, 4, -4, 4,
+ax_anim 2, 0, 107, -5, 3, -5, 3,
+ax_anim 2, 0, 107, -4, 4, -4, 4,
+ax_anim 2, 0, 107, -5, 3, -5, 3,
+ax_anim 4, 1, 106, -4, 4, -4, 4,
+ax_anim 3, 0, 106, -4, 2, -4, 4,
+ax_anim 2, 0, 106, -4, 3, -4, 4,
+ax_anim 2, 0, 105, -2, 2, -2, 2,
+ax_anim_terminator
+sPelipperAnims_5_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 1,
+ax_anim 2, 0, 110, 0, 3, 0, 3,
+ax_anim 2, 2, 110, 0, 4, 0, 4,
+ax_anim 2, 0, 110, -1, 4, -1, 4,
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 2, 0, 110, -1, 4, -1, 4,
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 2, 0, 110, -1, 4, -1, 4,
+ax_anim 4, 1, 109, 0, 4, 0, 4,
+ax_anim 3, 0, 109, 0, 2, 0, 4,
+ax_anim 2, 0, 109, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim_terminator
+sPelipperAnims_5_6:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 1, 1, 1,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 2, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 3, 5, 3,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 3, 5, 3,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 3, 5, 3,
+ax_anim 4, 1, 112, 4, 4, 4, 4,
+ax_anim 3, 0, 112, 4, 2, 4, 4,
+ax_anim 2, 0, 112, 4, 3, 4, 4,
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim_terminator
+sPelipperAnims_5_7:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 3, 0, 3, 0,
+ax_anim 2, 2, 116, 4, 0, 4, 0,
+ax_anim 2, 0, 116, 5, 0, 5, 0,
+ax_anim 2, 0, 116, 4, 0, 4, 0,
+ax_anim 2, 0, 116, 5, 0, 5, 0,
+ax_anim 2, 0, 116, 4, 0, 4, 0,
+ax_anim 2, 0, 116, 5, 0, 5, 0,
+ax_anim 4, 1, 115, 4, 0, 4, 0,
+ax_anim 3, 0, 115, 4, -2, 4, 0,
+ax_anim 2, 0, 115, 4, -1, 4, 0,
+ax_anim 2, 0, 114, 2, 0, 2, 0,
+ax_anim_terminator
+sPelipperAnims_5_8:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 3, -3, 3, -3,
+ax_anim 2, 2, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 5, -3, 5, -3,
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 5, -3, 5, -3,
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 5, -3, 5, -3,
+ax_anim 4, 1, 118, 4, -4, 4, -4,
+ax_anim 3, 0, 118, 4, -6, 4, -4,
+ax_anim 2, 0, 118, 4, -5, 4, -4,
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sPelipperAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sPelipperAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sPelipperAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sPelipperAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sPelipperAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sPelipperAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sPelipperAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sPelipperAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPelipperAnims_8_1:
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 10, 0, 130, 0, -1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_8_2:
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_8_3:
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_8_4:
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 10, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_8_5:
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 138, 0, -1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_8_6:
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_8_7:
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 10, 0, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sPelipperAnims_8_8:
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 10, 9, 10, 9,
+ax_anim 2, 0, 149, 9, 19, 9, 19,
+ax_anim 3, 0, 150, 0, 23, 0, 23,
+ax_anim 2, 3, 151, -9, 19, -9, 19,
+ax_anim 2, 0, 152, -10, 9, -10, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 1, 8, 1,
+ax_anim 2, 0, 147, 19, 7, 19, 7,
+ax_anim 2, 0, 148, 23, 15, 23, 15,
+ax_anim 3, 0, 149, 20, 24, 20, 24,
+ax_anim 2, 3, 150, 11, 25, 11, 25,
+ax_anim 2, 0, 151, 3, 18, 3, 18,
+ax_anim 1, 0, 152, -2, 7, -2, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 19, -4, 19, -4,
+ax_anim 3, 0, 148, 21, 2, 21, 2,
+ax_anim 2, 3, 149, 16, 6, 16, 6,
+ax_anim 2, 0, 150, 10, 6, 10, 6,
+ax_anim 1, 0, 151, 5, 5, 5, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 12, -20, 12, -20,
+ax_anim 3, 0, 147, 22, -19, 22, -19,
+ax_anim 2, 3, 148, 23, -13, 23, -13,
+ax_anim 2, 0, 149, 17, -6, 17, -6,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -13, -12, -13, -12,
+ax_anim 2, 0, 153, -8, -17, -8, -17,
+ax_anim 3, 0, 146, 0, -20, 0, -20,
+ax_anim 2, 3, 147, 8, -17, 8, -17,
+ax_anim 2, 0, 148, 13, -10, 13, -10,
+ax_anim 1, 0, 149, 7, -4, 7, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -20, -12, -20,
+ax_anim 3, 0, 153, -22, -19, -22, -19,
+ax_anim 2, 3, 152, -23, -13, -23, -13,
+ax_anim 2, 0, 151, -17, -6, -17, -6,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -19, -4, -19, -4,
+ax_anim 3, 0, 152, -21, 2, -21, 2,
+ax_anim 2, 3, 151, -16, 6, -16, 6,
+ax_anim 2, 0, 150, -10, 6, -10, 6,
+ax_anim 1, 0, 149, -5, 5, -5, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 1, -8, 1,
+ax_anim 2, 0, 153, -19, 7, -19, 7,
+ax_anim 2, 0, 152, -23, 15, -23, 15,
+ax_anim 3, 0, 151, -20, 24, -20, 24,
+ax_anim 2, 3, 150, -11, 25, -11, 25,
+ax_anim 2, 0, 149, -3, 18, -3, 18,
+ax_anim 1, 0, 148, 2, 7, 2, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -22, 0, 0,
+ax_anim 3, 0, 164, 0, -21, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 4, 0, 0,
+ax_anim_terminator
+sPelipperAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -22, 0, 0,
+ax_anim 3, 0, 167, 0, -21, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 4, 0, 0,
+ax_anim_terminator
+sPelipperAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 3, 0, 170, 0, -21, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 4, 0, 0,
+ax_anim_terminator
+sPelipperAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 4, 0, 0,
+ax_anim_terminator
+sPelipperAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 176, 0, -21, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 4, 0, 0,
+ax_anim_terminator
+sPelipperAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 4, 0, 0,
+ax_anim_terminator
+sPelipperAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 182, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 4, 0, 0,
+ax_anim_terminator
+sPelipperAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_14_1:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_14_2:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_14_3:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_14_4:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_14_5:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_14_6:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_14_7:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_14_8:
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 14, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 3, 0, 203, 0, 0, 0, 0,
+ax_anim 20, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPelipperAnims_15_1:
+ax_anim 3, 0, 207, 128, -8, 128, -8,
+ax_anim 3, 0, 207, 126, -8, 126, -8,
+ax_anim 3, 0, 207, 124, -8, 124, -8,
+ax_anim 3, 0, 208, 122, -8, 122, -8,
+ax_anim 3, 0, 208, 120, -8, 120, -8,
+ax_anim 3, 0, 208, 118, -8, 118, -8,
+ax_anim 3, 0, 209, 116, -8, 116, -8,
+ax_anim 3, 0, 209, 114, -8, 114, -8,
+ax_anim 3, 0, 209, 112, -8, 112, -8,
+ax_anim 3, 0, 208, 110, -8, 110, -8,
+ax_anim 3, 0, 208, 108, -8, 108, -8,
+ax_anim 3, 0, 207, 106, -8, 106, -8,
+ax_anim 3, 0, 207, 104, -8, 104, -8,
+ax_anim 3, 0, 207, 102, -8, 102, -8,
+ax_anim 3, 0, 208, 100, -8, 100, -8,
+ax_anim 3, 0, 208, 98, -8, 98, -8,
+ax_anim 3, 0, 208, 96, -8, 96, -8,
+ax_anim 3, 0, 209, 94, -8, 94, -8,
+ax_anim 3, 0, 209, 92, -8, 92, -8,
+ax_anim 3, 0, 209, 90, -8, 90, -8,
+ax_anim 3, 0, 208, 88, -8, 88, -8,
+ax_anim 3, 0, 208, 86, -8, 86, -8,
+ax_anim 3, 0, 207, 84, -8, 84, -8,
+ax_anim 3, 0, 207, 82, -8, 82, -8,
+ax_anim 3, 0, 207, 80, -8, 80, -8,
+ax_anim 3, 0, 208, 78, -8, 78, -8,
+ax_anim 3, 0, 208, 76, -8, 76, -8,
+ax_anim 3, 0, 208, 74, -8, 74, -8,
+ax_anim 3, 0, 209, 72, -8, 72, -8,
+ax_anim 3, 0, 209, 70, -8, 70, -8,
+ax_anim 3, 0, 209, 68, -8, 68, -8,
+ax_anim 3, 0, 208, 66, -8, 66, -8,
+ax_anim 3, 0, 208, 64, -8, 64, -8,
+ax_anim 3, 0, 207, 62, -8, 62, -8,
+ax_anim 3, 0, 207, 60, -8, 60, -8,
+ax_anim 3, 0, 207, 58, -8, 58, -8,
+ax_anim 3, 0, 208, 56, -8, 56, -8,
+ax_anim 3, 0, 208, 54, -8, 54, -8,
+ax_anim 3, 0, 208, 52, -8, 52, -8,
+ax_anim 3, 0, 209, 50, -8, 50, -8,
+ax_anim 3, 0, 209, 48, -8, 48, -8,
+ax_anim 3, 0, 209, 46, -8, 46, -8,
+ax_anim 3, 0, 208, 44, -8, 44, -8,
+ax_anim 3, 0, 208, 42, -8, 42, -8,
+ax_anim 3, 0, 207, 40, -8, 40, -8,
+ax_anim 3, 0, 207, 38, -8, 38, -8,
+ax_anim 3, 0, 207, 36, -8, 36, -8,
+ax_anim 3, 0, 208, 34, -8, 34, -8,
+ax_anim 3, 0, 208, 32, -8, 32, -8,
+ax_anim 3, 0, 208, 30, -8, 30, -8,
+ax_anim 3, 0, 209, 28, -8, 28, -8,
+ax_anim 3, 0, 209, 26, -8, 26, -8,
+ax_anim 3, 0, 209, 24, -8, 24, -8,
+ax_anim 3, 0, 208, 22, -8, 22, -8,
+ax_anim 3, 0, 208, 20, -8, 20, -8,
+ax_anim 3, 0, 207, 18, -8, 18, -8,
+ax_anim 3, 0, 207, 16, -9, 16, -8,
+ax_anim 3, 0, 207, 14, -10, 14, -8,
+ax_anim 3, 0, 208, 12, -10, 12, -8,
+ax_anim 3, 0, 208, 10, -10, 10, -8,
+ax_anim 3, 0, 208, 8, -9, 8, -8,
+ax_anim 3, 0, 210, 6, -9, 6, -8,
+ax_anim 3, 0, 210, 4, -9, 4, -8,
+ax_anim 3, 0, 210, 2, -9, 2, -8,
+ax_anim 3, 0, 210, 0, -8, 0, -8,
+ax_anim 3, 0, 210, -2, -8, -2, -8,
+ax_anim 3, 0, 210, -4, -8, -4, -8,
+ax_anim 3, 0, 210, -6, -8, -6, -8,
+ax_anim 3, 0, 210, -8, -8, -8, -8,
+ax_anim 3, 0, 210, -10, -8, -10, -8,
+ax_anim 3, 0, 210, -12, -8, -12, -8,
+ax_anim 3, 0, 210, -14, -8, -14, -8,
+ax_anim 3, 0, 210, -16, -8, -16, -8,
+ax_anim 3, 0, 210, -18, -8, -18, -8,
+ax_anim 3, 0, 210, -20, -8, -20, -8,
+ax_anim 3, 0, 210, -22, -8, -22, -8,
+ax_anim 3, 0, 210, -24, -8, -24, -8,
+ax_anim 3, 0, 210, -26, -8, -26, -8,
+ax_anim 3, 0, 211, -28, -8, -28, -8,
+ax_anim 3, 0, 211, -30, -9, -30, -9,
+ax_anim 3, 0, 211, -32, -10, -32, -10,
+ax_anim 3, 0, 212, -34, -11, -34, -11,
+ax_anim 3, 0, 212, -36, -12, -36, -12,
+ax_anim 3, 0, 212, -38, -13, -38, -13,
+ax_anim 3, 0, 213, -40, -14, -40, -14,
+ax_anim 3, 0, 213, -42, -16, -42, -16,
+ax_anim 3, 0, 213, -43, -18, -43, -18,
+ax_anim 3, 0, 214, -44, -20, -44, -20,
+ax_anim 3, 0, 214, -45, -22, -45, -22,
+ax_anim 3, 0, 214, -45, -24, -45, -24,
+ax_anim 3, 0, 214, -45, -26, -45, -26,
+ax_anim 3, 0, 215, -44, -28, -44, -28,
+ax_anim 3, 0, 215, -43, -30, -43, -30,
+ax_anim 3, 0, 215, -42, -32, -42, -32,
+ax_anim 3, 0, 216, -40, -34, -40, -34,
+ax_anim 3, 0, 216, -38, -36, -38, -36,
+ax_anim 3, 0, 216, -36, -38, -36, -38,
+ax_anim 3, 0, 217, -33, -39, -33, -39,
+ax_anim 3, 0, 217, -31, -40, -31, -40,
+ax_anim 3, 0, 217, -29, -41, -29, -41,
+ax_anim_terminator
+sPelipperAnims_15_2:
+ax_anim 3, 0, 218, -26, -42, -26, -42,
+ax_anim 3, 0, 218, -24, -43, -24, -43,
+ax_anim 3, 0, 218, -22, -43, -22, -43,
+ax_anim 3, 0, 228, -20, -43, -20, -43,
+ax_anim 3, 0, 228, -18, -42, -18, -43,
+ax_anim 3, 0, 228, -16, -41, -16, -43,
+ax_anim 3, 0, 227, -14, -39, -14, -43,
+ax_anim 3, 0, 227, -12, -38, -12, -43,
+ax_anim 3, 0, 226, -10, -38, -10, -43,
+ax_anim 3, 0, 226, -8, -39, -8, -43,
+ax_anim 3, 0, 226, -6, -40, -6, -43,
+ax_anim 3, 0, 226, -4, -41, -4, -43,
+ax_anim 3, 0, 226, -2, -42, -2, -43,
+ax_anim 3, 0, 227, 0, -44, 0, -43,
+ax_anim 3, 0, 227, 2, -44, 2, -43,
+ax_anim 3, 0, 218, 4, -43, 4, -43,
+ax_anim 3, 0, 218, 6, -43, 6, -43,
+ax_anim 3, 0, 218, 8, -42, 8, -42,
+ax_anim 3, 0, 218, 10, -42, 10, -42,
+ax_anim 3, 0, 218, 12, -42, 12, -42,
+ax_anim 3, 0, 218, 14, -42, 14, -42,
+ax_anim 3, 0, 218, 16, -42, 16, -42,
+ax_anim 3, 0, 218, 18, -41, 18, -41,
+ax_anim 3, 0, 218, 20, -41, 20, -41,
+ax_anim 3, 0, 218, 22, -41, 22, -41,
+ax_anim 3, 0, 218, 24, -41, 24, -41,
+ax_anim 3, 0, 218, 26, -41, 26, -41,
+ax_anim 3, 0, 219, 28, -40, 28, -40,
+ax_anim 3, 0, 219, 30, -39, 30, -39,
+ax_anim 3, 0, 219, 32, -38, 32, -38,
+ax_anim 3, 0, 220, 34, -37, 34, -37,
+ax_anim 3, 0, 220, 36, -36, 36, -36,
+ax_anim 3, 0, 220, 38, -34, 38, -34,
+ax_anim 3, 0, 221, 40, -32, 40, -32,
+ax_anim 3, 0, 221, 41, -30, 41, -30,
+ax_anim 3, 0, 221, 42, -28, 42, -28,
+ax_anim 3, 0, 222, 43, -26, 43, -26,
+ax_anim 3, 0, 222, 44, -24, 44, -24,
+ax_anim 3, 0, 222, 44, -22, 44, -22,
+ax_anim 3, 0, 222, 43, -20, 43, -20,
+ax_anim 3, 0, 223, 43, -18, 43, -18,
+ax_anim 3, 0, 223, 42, -16, 42, -16,
+ax_anim 3, 0, 223, 41, -14, 41, -14,
+ax_anim 3, 0, 224, 40, -13, 40, -13,
+ax_anim 3, 0, 224, 38, -12, 38, -12,
+ax_anim 3, 0, 224, 36, -11, 36, -11,
+ax_anim 3, 0, 225, 34, -9, 34, -9,
+ax_anim 3, 0, 225, 32, -8, 32, -8,
+ax_anim 3, 0, 225, 30, -7, 30, -7,
+ax_anim 3, 0, 210, 28, -6, 28, -6,
+ax_anim 3, 0, 210, 26, -5, 26, -5,
+ax_anim 3, 0, 210, 24, -5, 24, -5,
+ax_anim 3, 0, 210, 22, -5, 22, -5,
+ax_anim 3, 0, 209, 20, -5, 20, -5,
+ax_anim 3, 0, 209, 18, -5, 18, -5,
+ax_anim 3, 0, 209, 16, -5, 16, -5,
+ax_anim 3, 0, 208, 14, -5, 14, -5,
+ax_anim 3, 0, 208, 12, -5, 12, -5,
+ax_anim 3, 0, 207, 10, -5, 10, -5,
+ax_anim 3, 0, 207, 8, -5, 8, -5,
+ax_anim 3, 0, 207, 6, -5, 6, -5,
+ax_anim 3, 0, 208, 4, -5, 4, -5,
+ax_anim 3, 0, 208, 2, -5, 2, -5,
+ax_anim 3, 0, 208, 0, -5, 0, -5,
+ax_anim 3, 0, 209, -2, -5, -2, -5,
+ax_anim 3, 0, 209, -4, -5, -4, -5,
+ax_anim 3, 0, 209, -6, -5, -6, -5,
+ax_anim 3, 0, 208, -8, -5, -8, -5,
+ax_anim 3, 0, 208, -10, -5, -10, -5,
+ax_anim 3, 0, 207, -12, -5, -12, -5,
+ax_anim 3, 0, 207, -14, -5, -14, -5,
+ax_anim 3, 0, 207, -16, -5, -16, -5,
+ax_anim 3, 0, 208, -18, -5, -18, -5,
+ax_anim 3, 0, 208, -20, -5, -20, -5,
+ax_anim 3, 0, 208, -22, -5, -22, -5,
+ax_anim 3, 0, 209, -24, -5, -24, -5,
+ax_anim 3, 0, 209, -26, -5, -26, -5,
+ax_anim 3, 0, 209, -28, -5, -28, -5,
+ax_anim 3, 0, 208, -30, -5, -30, -5,
+ax_anim 3, 0, 208, -32, -5, -32, -5,
+ax_anim 3, 0, 207, -34, -5, -34, -5,
+ax_anim 3, 0, 207, -36, -5, -36, -5,
+ax_anim 3, 0, 207, -38, -5, -38, -5,
+ax_anim 3, 0, 208, -40, -5, -40, -5,
+ax_anim 3, 0, 208, -42, -5, -42, -5,
+ax_anim 3, 0, 208, -44, -5, -44, -5,
+ax_anim 3, 0, 209, -46, -5, -46, -5,
+ax_anim 3, 0, 209, -48, -5, -48, -5,
+ax_anim 3, 0, 209, -50, -5, -50, -5,
+ax_anim 3, 0, 208, -52, -5, -52, -5,
+ax_anim 3, 0, 208, -54, -5, -54, -5,
+ax_anim 3, 0, 207, -56, -5, -56, -5,
+ax_anim 3, 0, 207, -58, -5, -58, -5,
+ax_anim 3, 0, 207, -60, -5, -60, -5,
+ax_anim 3, 0, 208, -62, -5, -62, -5,
+ax_anim 3, 0, 208, -64, -5, -64, -5,
+ax_anim 3, 0, 208, -66, -5, -66, -5,
+ax_anim 3, 0, 209, -68, -5, -68, -5,
+ax_anim 3, 0, 209, -70, -5, -70, -5,
+ax_anim 3, 0, 209, -72, -5, -72, -5,
+ax_anim_terminator
+sPelipperAnims_15_3:
+ax_anim 3, 0, 208, -74, -5, -74, -5,
+ax_anim 3, 0, 208, -76, -5, -76, -5,
+ax_anim 3, 0, 207, -78, -5, -78, -5,
+ax_anim 3, 0, 207, -80, -5, -80, -5,
+ax_anim 3, 0, 207, -82, -5, -82, -5,
+ax_anim 3, 0, 208, -84, -5, -84, -5,
+ax_anim 3, 0, 208, -86, -5, -86, -5,
+ax_anim 3, 0, 208, -88, -5, -88, -5,
+ax_anim 3, 0, 209, -90, -5, -90, -5,
+ax_anim 3, 0, 209, -92, -5, -92, -5,
+ax_anim 3, 0, 209, -94, -5, -94, -5,
+ax_anim 3, 0, 208, -96, -5, -96, -5,
+ax_anim 3, 0, 208, -98, -5, -98, -5,
+ax_anim 3, 0, 207, -100, -5, -100, -5,
+ax_anim 3, 0, 207, -102, -5, -102, -5,
+ax_anim 3, 0, 207, -104, -5, -104, -5,
+ax_anim 3, 0, 208, -106, -5, -106, -5,
+ax_anim 3, 0, 208, -108, -5, -108, -5,
+ax_anim 3, 0, 208, -110, -5, -110, -5,
+ax_anim 3, 0, 209, -112, -5, -112, -5,
+ax_anim 3, 0, 209, -114, -5, -114, -5,
+ax_anim 3, 0, 209, -116, -5, -116, -5,
+ax_anim 3, 0, 208, -118, -5, -118, -5,
+ax_anim 3, 0, 208, -120, -5, -120, -5,
+ax_anim 3, 0, 207, -122, -5, -122, -5,
+ax_anim 3, 0, 207, -124, -5, -124, -5,
+ax_anim 3, 0, 207, -126, -5, -126, -5,
+ax_anim 3, 0, 208, -128, -5, -128, -5,
+ax_anim 3, 0, 208, -130, -5, -130, -5,
+ax_anim 3, 0, 208, -132, -5, -132, -5,
+ax_anim 3, 0, 209, -134, -5, -134, -5,
+ax_anim 3, 0, 209, -136, -5, -136, -5,
+ax_anim 3, 0, 209, -138, -5, -138, -5,
+ax_anim_terminator
+sPelipperAnims_15_4:
+ax_anim 4, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_15_5:
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 6, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 6, 0, 211, 0, 0, 0, 0,
+ax_anim 6, 0, 212, 0, 0, 0, 0,
+ax_anim 6, 0, 213, 0, 0, 0, 0,
+ax_anim 6, 0, 214, 0, 0, 0, 0,
+ax_anim 6, 0, 215, 0, 0, 0, 0,
+ax_anim 6, 0, 216, 0, 0, 0, 0,
+ax_anim 6, 0, 217, 0, 0, 0, 0,
+ax_anim 6, 0, 218, 0, 0, 0, 0,
+ax_anim 6, 0, 219, 0, 0, 0, 0,
+ax_anim 6, 0, 220, 0, 0, 0, 0,
+ax_anim 6, 0, 221, 0, 0, 0, 0,
+ax_anim 6, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_15_6:
+ax_anim 4, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_15_7:
+ax_anim 4, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperAnims_15_8:
+ax_anim 4, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPelipperGfx1:
+.incbin "baserom.gba", 0x1167EF4, 0x200
+sPelipperSprites1:
+ax_sprite sPelipperGfx1, 0x200
+ax_sprite_terminator
+sPelipperGfx2:
+.incbin "baserom.gba", 0x1168104, 0x200
+sPelipperSprites2:
+ax_sprite sPelipperGfx2, 0x200
+ax_sprite_terminator
+sPelipperGfx3:
+.incbin "baserom.gba", 0x1168314, 0x200
+sPelipperSprites3:
+ax_sprite sPelipperGfx3, 0x200
+ax_sprite_terminator
+sPelipperGfx4:
+.incbin "baserom.gba", 0x1168524, 0x200
+sPelipperSprites4:
+ax_sprite sPelipperGfx4, 0x200
+ax_sprite_terminator
+sPelipperGfx5:
+.incbin "baserom.gba", 0x1168734, 0x200
+sPelipperSprites5:
+ax_sprite sPelipperGfx5, 0x200
+ax_sprite_terminator
+sPelipperGfx6:
+.incbin "baserom.gba", 0x1168944, 0x200
+sPelipperSprites6:
+ax_sprite sPelipperGfx6, 0x200
+ax_sprite_terminator
+sPelipperGfx7:
+.incbin "baserom.gba", 0x1168B54, 0x200
+sPelipperSprites7:
+ax_sprite sPelipperGfx7, 0x200
+ax_sprite_terminator
+sPelipperGfx8:
+.incbin "baserom.gba", 0x1168D64, 0x200
+sPelipperSprites8:
+ax_sprite sPelipperGfx8, 0x200
+ax_sprite_terminator
+sPelipperGfx9:
+.incbin "baserom.gba", 0x1168F74, 0x200
+sPelipperSprites9:
+ax_sprite sPelipperGfx9, 0x200
+ax_sprite_terminator
+sPelipperGfx10:
+.incbin "baserom.gba", 0x1169184, 0x200
+sPelipperSprites10:
+ax_sprite sPelipperGfx10, 0x200
+ax_sprite_terminator
+sPelipperGfx11:
+.incbin "baserom.gba", 0x1169394, 0x200
+sPelipperSprites11:
+ax_sprite sPelipperGfx11, 0x200
+ax_sprite_terminator
+sPelipperGfx12:
+.incbin "baserom.gba", 0x11695A4, 0x200
+sPelipperSprites12:
+ax_sprite sPelipperGfx12, 0x200
+ax_sprite_terminator
+sPelipperGfx13:
+.incbin "baserom.gba", 0x11697B4, 0x200
+sPelipperSprites13:
+ax_sprite sPelipperGfx13, 0x200
+ax_sprite_terminator
+sPelipperGfx14:
+.incbin "baserom.gba", 0x11699C4, 0x200
+sPelipperSprites14:
+ax_sprite sPelipperGfx14, 0x200
+ax_sprite_terminator
+sPelipperGfx15:
+.incbin "baserom.gba", 0x1169BD4, 0x200
+sPelipperSprites15:
+ax_sprite sPelipperGfx15, 0x200
+ax_sprite_terminator
+sPelipperGfx16:
+.incbin "baserom.gba", 0x1169DE4, 0x100
+sPelipperSprites16:
+ax_sprite sPelipperGfx16, 0x100
+ax_sprite_terminator
+sPelipperGfx17:
+.incbin "baserom.gba", 0x1169EF4, 0x80
+sPelipperSprites17:
+ax_sprite sPelipperGfx17, 0x80
+ax_sprite_terminator
+sPelipperGfx18:
+.incbin "baserom.gba", 0x1169F84, 0x20
+sPelipperSprites18:
+ax_sprite sPelipperGfx18, 0x20
+ax_sprite_terminator
+sPelipperGfx19:
+.incbin "baserom.gba", 0x1169FB4, 0x20
+sPelipperSprites19:
+ax_sprite sPelipperGfx19, 0x20
+ax_sprite_terminator
+sPelipperGfx20:
+.incbin "baserom.gba", 0x1169FE4, 0x20
+sPelipperSprites20:
+ax_sprite sPelipperGfx20, 0x20
+ax_sprite_terminator
+sPelipperGfx21:
+.incbin "baserom.gba", 0x116A014, 0xA0
+sPelipperGfx21_1:
+.incbin "baserom.gba", 0x116A0B4, 0x20
+sPelipperSprites21:
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx21, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx21_1, 0x20
+ax_sprite_terminator
+sPelipperGfx22:
+.incbin "baserom.gba", 0x116A0FC, 0x80
+sPelipperSprites22:
+ax_sprite sPelipperGfx22, 0x80
+ax_sprite_terminator
+sPelipperGfx23:
+.incbin "baserom.gba", 0x116A18C, 0x20
+sPelipperSprites23:
+ax_sprite sPelipperGfx23, 0x20
+ax_sprite_terminator
+sPelipperGfx24:
+.incbin "baserom.gba", 0x116A1BC, 0x40
+sPelipperSprites24:
+ax_sprite sPelipperGfx24, 0x40
+ax_sprite_terminator
+sPelipperGfx25:
+.incbin "baserom.gba", 0x116A20C, 0x20
+sPelipperGfx25_1:
+.incbin "baserom.gba", 0x116A22C, 0x160
+sPelipperSprites25:
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPelipperGfx25_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPelipperGfx26:
+.incbin "baserom.gba", 0x116A3BC, 0x40
+sPelipperGfx26_1:
+.incbin "baserom.gba", 0x116A3FC, 0x60
+sPelipperGfx26_2:
+.incbin "baserom.gba", 0x116A45C, 0x100
+sPelipperSprites26:
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx26_2, 0x100
+ax_sprite_terminator
+sPelipperGfx27:
+.incbin "baserom.gba", 0x116A594, 0x1E0
+sPelipperSprites27:
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx27, 0x1e0
+ax_sprite_terminator
+sPelipperGfx28:
+.incbin "baserom.gba", 0x116A78C, 0x40
+sPelipperGfx28_1:
+.incbin "baserom.gba", 0x116A7CC, 0x180
+sPelipperSprites28:
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx28_1, 0x180
+ax_sprite_terminator
+sPelipperGfx29:
+.incbin "baserom.gba", 0x116A974, 0x160
+sPelipperGfx29_1:
+.incbin "baserom.gba", 0x116AAD4, 0x40
+sPelipperSprites29:
+ax_sprite sPelipperGfx29, 0x160
+ax_sprite 0, 0x40
+ax_sprite sPelipperGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPelipperGfx30:
+.incbin "baserom.gba", 0x116AB3C, 0x60
+sPelipperGfx30_1:
+.incbin "baserom.gba", 0x116AB9C, 0x100
+sPelipperGfx30_2:
+.incbin "baserom.gba", 0x116AC9C, 0x40
+sPelipperSprites30:
+ax_sprite sPelipperGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPelipperGfx31:
+.incbin "baserom.gba", 0x116AD14, 0xC0
+sPelipperGfx31_1:
+.incbin "baserom.gba", 0x116ADD4, 0x20
+sPelipperSprites31:
+ax_sprite sPelipperGfx31, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx31_1, 0x20
+ax_sprite_terminator
+sPelipperGfx32:
+.incbin "baserom.gba", 0x116AE14, 0x80
+sPelipperSprites32:
+ax_sprite sPelipperGfx32, 0x80
+ax_sprite_terminator
+sPelipperGfx33:
+.incbin "baserom.gba", 0x116AEA4, 0x40
+sPelipperSprites33:
+ax_sprite sPelipperGfx33, 0x40
+ax_sprite_terminator
+sPelipperGfx34:
+.incbin "baserom.gba", 0x116AEF4, 0x20
+sPelipperSprites34:
+ax_sprite sPelipperGfx34, 0x20
+ax_sprite_terminator
+sPelipperGfx35:
+.incbin "baserom.gba", 0x116AF24, 0x20
+sPelipperSprites35:
+ax_sprite sPelipperGfx35, 0x20
+ax_sprite_terminator
+sPelipperGfx36:
+.incbin "baserom.gba", 0x116AF54, 0x40
+sPelipperGfx36_1:
+.incbin "baserom.gba", 0x116AF94, 0x180
+sPelipperSprites36:
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPelipperGfx36_1, 0x180
+ax_sprite_terminator
+sPelipperGfx37:
+.incbin "baserom.gba", 0x116B13C, 0x200
+sPelipperSprites37:
+ax_sprite sPelipperGfx37, 0x200
+ax_sprite_terminator
+sPelipperGfx38:
+.incbin "baserom.gba", 0x116B34C, 0x200
+sPelipperSprites38:
+ax_sprite sPelipperGfx38, 0x200
+ax_sprite_terminator
+sPelipperGfx39:
+.incbin "baserom.gba", 0x116B55C, 0x200
+sPelipperSprites39:
+ax_sprite sPelipperGfx39, 0x200
+ax_sprite_terminator
+sPelipperGfx40:
+.incbin "baserom.gba", 0x116B76C, 0x200
+sPelipperSprites40:
+ax_sprite sPelipperGfx40, 0x200
+ax_sprite_terminator
+sPelipperGfx41:
+.incbin "baserom.gba", 0x116B97C, 0x200
+sPelipperSprites41:
+ax_sprite sPelipperGfx41, 0x200
+ax_sprite_terminator
+sPelipperGfx42:
+.incbin "baserom.gba", 0x116BB8C, 0x200
+sPelipperSprites42:
+ax_sprite sPelipperGfx42, 0x200
+ax_sprite_terminator
+sPelipperGfx43:
+.incbin "baserom.gba", 0x116BD9C, 0x200
+sPelipperSprites43:
+ax_sprite sPelipperGfx43, 0x200
+ax_sprite_terminator
+sPelipperGfx44:
+.incbin "baserom.gba", 0x116BFAC, 0x200
+sPelipperSprites44:
+ax_sprite sPelipperGfx44, 0x200
+ax_sprite_terminator
+sPelipperGfx45:
+.incbin "baserom.gba", 0x116C1BC, 0x100
+sPelipperSprites45:
+ax_sprite sPelipperGfx45, 0x100
+ax_sprite_terminator
+sPelipperGfx46:
+.incbin "baserom.gba", 0x116C2CC, 0x80
+sPelipperSprites46:
+ax_sprite sPelipperGfx46, 0x80
+ax_sprite_terminator
+sPelipperGfx47:
+.incbin "baserom.gba", 0x116C35C, 0x40
+sPelipperSprites47:
+ax_sprite sPelipperGfx47, 0x40
+ax_sprite_terminator
+sPelipperGfx48:
+.incbin "baserom.gba", 0x116C3AC, 0x100
+sPelipperSprites48:
+ax_sprite sPelipperGfx48, 0x100
+ax_sprite_terminator
+sPelipperGfx49:
+.incbin "baserom.gba", 0x116C4BC, 0x80
+sPelipperSprites49:
+ax_sprite sPelipperGfx49, 0x80
+ax_sprite_terminator
+sPelipperGfx50:
+.incbin "baserom.gba", 0x116C54C, 0x100
+sPelipperSprites50:
+ax_sprite sPelipperGfx50, 0x100
+ax_sprite_terminator
+sPelipperGfx51:
+.incbin "baserom.gba", 0x116C65C, 0x80
+sPelipperSprites51:
+ax_sprite sPelipperGfx51, 0x80
+ax_sprite_terminator
+sPelipperGfx52:
+.incbin "baserom.gba", 0x116C6EC, 0x200
+sPelipperSprites52:
+ax_sprite sPelipperGfx52, 0x200
+ax_sprite_terminator
+sPelipperGfx53:
+.incbin "baserom.gba", 0x116C8FC, 0x200
+sPelipperSprites53:
+ax_sprite sPelipperGfx53, 0x200
+ax_sprite_terminator
+sPelipperGfx54:
+.incbin "baserom.gba", 0x116CB0C, 0x200
+sPelipperSprites54:
+ax_sprite sPelipperGfx54, 0x200
+ax_sprite_terminator
+sPelipperGfx55:
+.incbin "baserom.gba", 0x116CD1C, 0x200
+sPelipperSprites55:
+ax_sprite sPelipperGfx55, 0x200
+ax_sprite_terminator
+sPelipperGfx56:
+.incbin "baserom.gba", 0x116CF2C, 0x200
+sPelipperSprites56:
+ax_sprite sPelipperGfx56, 0x200
+ax_sprite_terminator
+sPelipperGfx57:
+.incbin "baserom.gba", 0x116D13C, 0x200
+sPelipperSprites57:
+ax_sprite sPelipperGfx57, 0x200
+ax_sprite_terminator
+sPelipperGfx58:
+.incbin "baserom.gba", 0x116D34C, 0x200
+sPelipperSprites58:
+ax_sprite sPelipperGfx58, 0x200
+ax_sprite_terminator
+sAxPosesPelipper:
+.4byte sPelipperPose1
+.4byte sPelipperPose2
+.4byte sPelipperPose3
+.4byte sPelipperPose4
+.4byte sPelipperPose5
+.4byte sPelipperPose6
+.4byte sPelipperPose7
+.4byte sPelipperPose8
+.4byte sPelipperPose9
+.4byte sPelipperPose10
+.4byte sPelipperPose11
+.4byte sPelipperPose12
+.4byte sPelipperPose13
+.4byte sPelipperPose14
+.4byte sPelipperPose15
+.4byte sPelipperPose16
+.4byte sPelipperPose17
+.4byte sPelipperPose18
+.4byte sPelipperPose19
+.4byte sPelipperPose20
+.4byte sPelipperPose21
+.4byte sPelipperPose22
+.4byte sPelipperPose23
+.4byte sPelipperPose24
+.4byte sPelipperPose25
+.4byte sPelipperPose26
+.4byte sPelipperPose27
+.4byte sPelipperPose28
+.4byte sPelipperPose29
+.4byte sPelipperPose30
+.4byte sPelipperPose31
+.4byte sPelipperPose32
+.4byte sPelipperPose33
+.4byte sPelipperPose34
+.4byte sPelipperPose35
+.4byte sPelipperPose36
+.4byte sPelipperPose37
+.4byte sPelipperPose38
+.4byte sPelipperPose39
+.4byte sPelipperPose40
+.4byte sPelipperPose41
+.4byte sPelipperPose42
+.4byte sPelipperPose43
+.4byte sPelipperPose44
+.4byte sPelipperPose45
+.4byte sPelipperPose46
+.4byte sPelipperPose47
+.4byte sPelipperPose48
+.4byte sPelipperPose49
+.4byte sPelipperPose50
+.4byte sPelipperPose51
+.4byte sPelipperPose52
+.4byte sPelipperPose53
+.4byte sPelipperPose54
+.4byte sPelipperPose55
+.4byte sPelipperPose56
+.4byte sPelipperPose57
+.4byte sPelipperPose58
+.4byte sPelipperPose59
+.4byte sPelipperPose60
+.4byte sPelipperPose61
+.4byte sPelipperPose62
+.4byte sPelipperPose63
+.4byte sPelipperPose64
+.4byte sPelipperPose65
+.4byte sPelipperPose66
+.4byte sPelipperPose67
+.4byte sPelipperPose68
+.4byte sPelipperPose69
+.4byte sPelipperPose70
+.4byte sPelipperPose71
+.4byte sPelipperPose72
+.4byte sPelipperPose73
+.4byte sPelipperPose74
+.4byte sPelipperPose75
+.4byte sPelipperPose76
+.4byte sPelipperPose77
+.4byte sPelipperPose78
+.4byte sPelipperPose79
+.4byte sPelipperPose80
+.4byte sPelipperPose81
+.4byte sPelipperPose82
+.4byte sPelipperPose83
+.4byte sPelipperPose84
+.4byte sPelipperPose85
+.4byte sPelipperPose86
+.4byte sPelipperPose87
+.4byte sPelipperPose88
+.4byte sPelipperPose89
+.4byte sPelipperPose90
+.4byte sPelipperPose91
+.4byte sPelipperPose92
+.4byte sPelipperPose93
+.4byte sPelipperPose94
+.4byte sPelipperPose95
+.4byte sPelipperPose96
+.4byte sPelipperPose97
+.4byte sPelipperPose98
+.4byte sPelipperPose99
+.4byte sPelipperPose100
+.4byte sPelipperPose101
+.4byte sPelipperPose102
+.4byte sPelipperPose103
+.4byte sPelipperPose104
+.4byte sPelipperPose105
+.4byte sPelipperPose106
+.4byte sPelipperPose107
+.4byte sPelipperPose108
+.4byte sPelipperPose109
+.4byte sPelipperPose110
+.4byte sPelipperPose111
+.4byte sPelipperPose112
+.4byte sPelipperPose113
+.4byte sPelipperPose114
+.4byte sPelipperPose115
+.4byte sPelipperPose116
+.4byte sPelipperPose117
+.4byte sPelipperPose118
+.4byte sPelipperPose119
+.4byte sPelipperPose120
+.4byte sPelipperPose121
+.4byte sPelipperPose122
+.4byte sPelipperPose123
+.4byte sPelipperPose124
+.4byte sPelipperPose125
+.4byte sPelipperPose126
+.4byte sPelipperPose127
+.4byte sPelipperPose128
+.4byte sPelipperPose129
+.4byte sPelipperPose130
+.4byte sPelipperPose131
+.4byte sPelipperPose132
+.4byte sPelipperPose133
+.4byte sPelipperPose134
+.4byte sPelipperPose135
+.4byte sPelipperPose136
+.4byte sPelipperPose137
+.4byte sPelipperPose138
+.4byte sPelipperPose139
+.4byte sPelipperPose140
+.4byte sPelipperPose141
+.4byte sPelipperPose142
+.4byte sPelipperPose143
+.4byte sPelipperPose144
+.4byte sPelipperPose145
+.4byte sPelipperPose146
+.4byte sPelipperPose147
+.4byte sPelipperPose148
+.4byte sPelipperPose149
+.4byte sPelipperPose150
+.4byte sPelipperPose151
+.4byte sPelipperPose152
+.4byte sPelipperPose153
+.4byte sPelipperPose154
+.4byte sPelipperPose155
+.4byte sPelipperPose156
+.4byte sPelipperPose157
+.4byte sPelipperPose158
+.4byte sPelipperPose159
+.4byte sPelipperPose160
+.4byte sPelipperPose161
+.4byte sPelipperPose162
+.4byte sPelipperPose163
+.4byte sPelipperPose164
+.4byte sPelipperPose165
+.4byte sPelipperPose166
+.4byte sPelipperPose167
+.4byte sPelipperPose168
+.4byte sPelipperPose169
+.4byte sPelipperPose170
+.4byte sPelipperPose171
+.4byte sPelipperPose172
+.4byte sPelipperPose173
+.4byte sPelipperPose174
+.4byte sPelipperPose175
+.4byte sPelipperPose176
+.4byte sPelipperPose177
+.4byte sPelipperPose178
+.4byte sPelipperPose179
+.4byte sPelipperPose180
+.4byte sPelipperPose181
+.4byte sPelipperPose182
+.4byte sPelipperPose183
+.4byte sPelipperPose184
+.4byte sPelipperPose185
+.4byte sPelipperPose186
+.4byte sPelipperPose187
+.4byte sPelipperPose188
+.4byte sPelipperPose189
+.4byte sPelipperPose190
+.4byte sPelipperPose191
+.4byte sPelipperPose192
+.4byte sPelipperPose193
+.4byte sPelipperPose194
+.4byte sPelipperPose195
+.4byte sPelipperPose196
+.4byte sPelipperPose197
+.4byte sPelipperPose198
+.4byte sPelipperPose199
+.4byte sPelipperPose200
+.4byte sPelipperPose201
+.4byte sPelipperPose202
+.4byte sPelipperPose203
+.4byte sPelipperPose204
+.4byte sPelipperPose205
+.4byte sPelipperPose206
+.4byte sPelipperPose207
+.4byte sPelipperPose208
+.4byte sPelipperPose209
+.4byte sPelipperPose210
+.4byte sPelipperPose211
+.4byte sPelipperPose212
+.4byte sPelipperPose213
+.4byte sPelipperPose214
+.4byte sPelipperPose215
+.4byte sPelipperPose216
+.4byte sPelipperPose217
+.4byte sPelipperPose218
+.4byte sPelipperPose219
+.4byte sPelipperPose220
+.4byte sPelipperPose221
+.4byte sPelipperPose222
+.4byte sPelipperPose223
+.4byte sPelipperPose224
+.4byte sPelipperPose225
+.4byte sPelipperPose226
+.4byte sPelipperPose227
+.4byte sPelipperPose228
+.4byte sPelipperPose229
+sAxPositionsPelipper:
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -10, 	  12,  -10, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -14, 	  12,  -14, 	   0,  -12
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    6,  -11, 	  10,  -14, 	 -10,   -8, 	   1,  -11
+.2byte    6,  -11, 	  10,  -18, 	 -11,  -13, 	   1,  -11
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    8,  -13, 	  -2,  -13, 	  -3,   -9, 	   3,  -12
+.2byte    8,  -13, 	  -3,  -16, 	  -4,  -13, 	   3,  -12
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -13, 	   6,   -6, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -15, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    0,  -16, 	  10,  -10, 	 -10,  -10, 	   0,  -12
+.2byte    0,  -16, 	  10,  -14, 	 -10,  -14, 	   0,  -12
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -13, 	  -6,   -6, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -15, 	  -8,  -10, 	   1,  -12
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -8,  -13, 	   2,  -13, 	   3,   -9, 	  -3,  -12
+.2byte   -8,  -13, 	   3,  -16, 	   4,  -13, 	  -3,  -12
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -14, 	   9,   -8, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -18, 	  10,  -13, 	  -2,  -11
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -10, 	  12,  -10, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -14, 	  12,  -14, 	   0,  -12
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    6,  -11, 	  10,  -14, 	 -10,   -8, 	   1,  -11
+.2byte    6,  -11, 	  10,  -18, 	 -11,  -13, 	   1,  -11
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    8,  -13, 	  -2,  -13, 	  -3,   -9, 	   3,  -12
+.2byte    8,  -13, 	  -3,  -16, 	  -4,  -13, 	   3,  -12
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -13, 	   6,   -6, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -15, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    0,  -16, 	  10,  -10, 	 -10,  -10, 	   0,  -12
+.2byte    0,  -16, 	  10,  -14, 	 -10,  -14, 	   0,  -12
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -13, 	  -6,   -6, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -15, 	  -8,  -10, 	   1,  -12
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -8,  -13, 	   2,  -13, 	   3,   -9, 	  -3,  -12
+.2byte   -8,  -13, 	   3,  -16, 	   4,  -13, 	  -3,  -12
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -14, 	   9,   -8, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -18, 	  10,  -13, 	  -2,  -11
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -10, 	  12,  -10, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -14, 	  12,  -14, 	   0,  -12
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    6,  -11, 	  10,  -14, 	 -10,   -8, 	   1,  -11
+.2byte    6,  -11, 	  10,  -18, 	 -11,  -13, 	   1,  -11
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    8,  -13, 	  -2,  -13, 	  -3,   -9, 	   3,  -12
+.2byte    8,  -13, 	  -3,  -16, 	  -4,  -13, 	   3,  -12
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -13, 	   6,   -6, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -15, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    0,  -16, 	  10,  -10, 	 -10,  -10, 	   0,  -12
+.2byte    0,  -16, 	  10,  -14, 	 -10,  -14, 	   0,  -12
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -13, 	  -6,   -6, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -15, 	  -8,  -10, 	   1,  -12
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -8,  -13, 	   2,  -13, 	   3,   -9, 	  -3,  -12
+.2byte   -8,  -13, 	   3,  -16, 	   4,  -13, 	  -3,  -12
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -14, 	   9,   -8, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -18, 	  10,  -13, 	  -2,  -11
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte    0,  -15, 	 -13,  -22, 	  13,  -22, 	   0,  -13
+.2byte    0,   -6, 	 -14,   -6, 	  14,   -6, 	   0,   -9
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    3,  -16, 	   2,  -25, 	 -14,  -17, 	   1,  -11
+.2byte    3,  -10, 	   6,  -10, 	 -11,   -7, 	   0,   -9
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    4,  -17, 	 -10,  -26, 	 -16,  -19, 	  -1,  -13
+.2byte    5,  -12, 	 -10,  -13, 	  -8,   -7, 	   1,  -13
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    3,  -18, 	 -15,  -18, 	  -5,  -12, 	   0,  -12
+.2byte    6,  -14, 	 -13,   -9, 	   1,    0, 	  -1,  -11
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    0,  -26, 	  11,  -18, 	 -11,  -18, 	  -1,  -14
+.2byte    0,  -17, 	  11,   -6, 	 -11,   -6, 	   0,  -15
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte   -3,  -18, 	  15,  -18, 	   5,  -12, 	   0,  -12
+.2byte   -6,  -14, 	  13,   -9, 	  -1,    0, 	   1,  -11
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -4,  -17, 	  10,  -26, 	  16,  -19, 	   1,  -13
+.2byte   -5,  -12, 	  10,  -13, 	   8,   -7, 	  -1,  -13
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -4,  -16, 	  -3,  -25, 	  13,  -17, 	  -2,  -11
+.2byte   -4,  -10, 	  -7,  -10, 	  10,   -7, 	  -1,   -9
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte    0,  -15, 	 -13,  -22, 	  13,  -22, 	   0,  -13
+.2byte    0,   -6, 	 -14,   -6, 	  14,   -6, 	   0,   -9
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    3,  -16, 	   2,  -25, 	 -14,  -17, 	   1,  -11
+.2byte    3,  -10, 	   6,  -10, 	 -11,   -7, 	   0,   -9
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    4,  -17, 	 -10,  -26, 	 -16,  -19, 	  -1,  -13
+.2byte    5,  -12, 	 -10,  -13, 	  -8,   -7, 	   1,  -13
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    3,  -18, 	 -15,  -18, 	  -5,  -12, 	   0,  -12
+.2byte    6,  -14, 	 -13,   -9, 	   1,    0, 	  -1,  -11
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    0,  -26, 	  11,  -18, 	 -11,  -18, 	  -1,  -14
+.2byte    0,  -17, 	  11,   -6, 	 -11,   -6, 	   0,  -15
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte   -3,  -18, 	  15,  -18, 	   5,  -12, 	   0,  -12
+.2byte   -6,  -14, 	  13,   -9, 	  -1,    0, 	   1,  -11
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -4,  -17, 	  10,  -26, 	  16,  -19, 	   1,  -13
+.2byte   -5,  -12, 	  10,  -13, 	   8,   -7, 	  -1,  -13
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -4,  -16, 	  -3,  -25, 	  13,  -17, 	  -2,  -11
+.2byte   -4,  -10, 	  -7,  -10, 	  10,   -7, 	  -1,   -9
+.2byte   -6,   -6, 	  -9,   -4, 	   9,    0, 	   1,   -6
+.2byte   -7,   -5, 	  -9,   -3, 	   8,    0, 	  -1,   -5
+.2byte    0,   -9, 	  -4,  -19, 	   9,  -23, 	   0,  -12
+.2byte    6,   -9, 	   7,  -19, 	  -8,  -20, 	  -2,  -11
+.2byte    4,   -9, 	   9,  -19, 	  -5,  -23, 	  -1,  -12
+.2byte    5,  -11, 	   5,  -19, 	   8,  -15, 	   0,  -12
+.2byte    0,   -8, 	   3,  -19, 	 -11,  -18, 	   0,  -13
+.2byte   -6,  -11, 	  -6,  -19, 	  -9,  -15, 	  -1,  -12
+.2byte   -4,   -9, 	  -9,  -19, 	   5,  -23, 	   1,  -12
+.2byte   -7,   -9, 	  -8,  -19, 	   7,  -20, 	   1,  -11
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -14, 	  12,  -14, 	   0,  -12
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    6,  -11, 	  10,  -18, 	 -11,  -13, 	   1,  -11
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    8,  -13, 	  -3,  -16, 	  -4,  -13, 	   3,  -12
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -15, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    0,  -16, 	  10,  -14, 	 -10,  -14, 	   0,  -12
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -15, 	  -8,  -10, 	   1,  -12
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -8,  -13, 	   3,  -16, 	   4,  -13, 	  -3,  -12
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -18, 	  10,  -13, 	  -2,  -11
+.2byte    0,  -10, 	 -12,  -14, 	  12,  -14, 	   0,  -12
+.2byte   -7,  -11, 	 -11,  -18, 	  10,  -13, 	  -2,  -11
+.2byte   -8,  -13, 	   3,  -16, 	   4,  -13, 	  -3,  -12
+.2byte   -7,  -14, 	   9,  -15, 	  -8,  -10, 	   1,  -12
+.2byte    0,  -16, 	  10,  -14, 	 -10,  -14, 	   0,  -12
+.2byte    7,  -14, 	  -9,  -15, 	   8,  -10, 	  -1,  -12
+.2byte    8,  -13, 	  -3,  -16, 	  -4,  -13, 	   3,  -12
+.2byte    6,  -11, 	  10,  -18, 	 -11,  -13, 	   1,  -11
+.2byte    0,   -6, 	 -14,   -6, 	  14,   -6, 	   0,   -9
+.2byte    3,  -10, 	   6,  -10, 	 -11,   -7, 	   0,   -9
+.2byte    5,  -11, 	 -10,  -12, 	  -8,   -6, 	   1,  -12
+.2byte    6,  -15, 	 -13,  -10, 	   1,   -1, 	  -1,  -12
+.2byte    0,  -15, 	  11,   -4, 	 -11,   -4, 	   0,  -13
+.2byte   -6,  -15, 	  13,  -10, 	  -1,   -1, 	   1,  -12
+.2byte   -5,  -11, 	  10,  -12, 	   8,   -6, 	  -1,  -12
+.2byte   -4,  -10, 	  -7,  -10, 	  10,   -7, 	  -1,   -9
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -10, 	  12,  -10, 	   0,  -12
+.2byte    0,  -10, 	 -12,  -14, 	  12,  -14, 	   0,  -12
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    6,  -11, 	  10,  -14, 	 -10,   -8, 	   1,  -11
+.2byte    6,  -11, 	  10,  -18, 	 -11,  -13, 	   1,  -11
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    8,  -13, 	  -2,  -13, 	  -3,   -9, 	   3,  -12
+.2byte    8,  -13, 	  -3,  -16, 	  -4,  -13, 	   3,  -12
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -13, 	   6,   -6, 	  -1,  -12
+.2byte    7,  -14, 	  -9,  -15, 	   8,  -10, 	  -1,  -12
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    0,  -16, 	  10,  -10, 	 -10,  -10, 	   0,  -12
+.2byte    0,  -16, 	  10,  -14, 	 -10,  -14, 	   0,  -12
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -13, 	  -6,   -6, 	   1,  -12
+.2byte   -7,  -14, 	   9,  -15, 	  -8,  -10, 	   1,  -12
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -8,  -13, 	   2,  -13, 	   3,   -9, 	  -3,  -12
+.2byte   -8,  -13, 	   3,  -16, 	   4,  -13, 	  -3,  -12
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -14, 	   9,   -8, 	  -2,  -11
+.2byte   -7,  -11, 	 -11,  -18, 	  10,  -13, 	  -2,  -11
+.2byte    0,  -10, 	 -12,  -14, 	  12,  -14, 	   0,  -12
+.2byte   -7,  -11, 	 -11,  -18, 	  10,  -13, 	  -2,  -11
+.2byte   -8,  -13, 	   3,  -16, 	   4,  -13, 	  -3,  -12
+.2byte   -7,  -14, 	   9,  -15, 	  -8,  -10, 	   1,  -12
+.2byte    0,  -16, 	  10,  -14, 	 -10,  -14, 	   0,  -12
+.2byte    7,  -14, 	  -9,  -15, 	   8,  -10, 	  -1,  -12
+.2byte    8,  -13, 	  -3,  -16, 	  -4,  -13, 	   3,  -12
+.2byte    6,  -11, 	  10,  -18, 	 -11,  -13, 	   1,  -11
+.2byte    0,  -10, 	 -10,   -6, 	  10,   -6, 	   0,  -12
+.2byte   -7,  -11, 	 -10,  -11, 	   7,   -5, 	  -2,  -11
+.2byte   -8,  -13, 	   3,   -9, 	   3,   -5, 	  -3,  -12
+.2byte   -7,  -14, 	   9,  -10, 	  -5,   -5, 	   1,  -12
+.2byte    0,  -16, 	   9,   -6, 	  -9,   -6, 	   0,  -12
+.2byte    7,  -14, 	  -9,  -10, 	   5,   -5, 	  -1,  -12
+.2byte    8,  -13, 	  -3,   -9, 	  -3,   -5, 	   3,  -12
+.2byte    6,  -11, 	   9,  -11, 	  -8,   -5, 	   1,  -11
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -7, 	 -10,   -7, 	  10,   -7, 	   0,   -9
+.2byte    0,   -4, 	 -10,  -10, 	  10,  -10, 	   0,   -7
+.2byte    0,    0, 	 -10,  -12, 	  10,  -12, 	   0,   -4
+.2byte    0,    1, 	  -9,  -13, 	   9,  -13, 	   0,   -5
+.2byte   -7,  -54, 	   4,  -50, 	   4,  -46, 	  -2,  -53
+.2byte   -7,  -53, 	   3,  -53, 	   4,  -49, 	  -2,  -52
+.2byte   -7,  -52, 	   4,  -55, 	   5,  -52, 	  -2,  -51
+.2byte   -7,  -53, 	   4,  -52, 	   5,  -48, 	  -2,  -52
+.2byte  -10,  -53, 	   6,  -54, 	  -4,  -47, 	  -1,  -51
+.2byte   -9,  -54, 	   7,  -54, 	  -7,  -48, 	   0,  -52
+.2byte   -6,  -55, 	  10,  -52, 	 -11,  -48, 	   0,  -51
+.2byte    0,  -57, 	  10,  -51, 	 -10,  -51, 	   0,  -53
+.2byte    6,  -55, 	 -10,  -52, 	  11,  -48, 	   0,  -51
+.2byte    9,  -54, 	  -7,  -54, 	   7,  -48, 	   0,  -52
+.2byte   10,  -53, 	  -6,  -54, 	   4,  -47, 	   1,  -51
+.2byte    7,  -53, 	  -4,  -52, 	  -5,  -48, 	   2,  -52
+.2byte    8,  -52, 	  -6,  -53, 	  -7,  -48, 	   3,  -52
+.2byte    6,  -51, 	  10,  -54, 	 -10,  -48, 	   1,  -51
+.2byte    4,  -50, 	  10,  -54, 	 -12,  -49, 	  -1,  -50
+.2byte    0,  -50, 	 -12,  -50, 	  12,  -50, 	   0,  -52
+.2byte   -5,  -50, 	 -11,  -54, 	  11,  -49, 	   0,  -50
+.2byte   -7,  -51, 	 -11,  -54, 	   9,  -48, 	  -2,  -51
+.2byte   -8,  -52, 	   6,  -53, 	   7,  -48, 	  -3,  -52
+.2byte    6,  -54, 	  -5,  -50, 	  -5,  -46, 	   1,  -53
+.2byte    6,  -53, 	  -4,  -53, 	  -5,  -49, 	   1,  -52
+.2byte    6,  -52, 	  -5,  -55, 	  -6,  -52, 	   1,  -51
+sPelipperAnimTable1:
+.4byte sPelipperAnims_1_1
+.4byte sPelipperAnims_1_2
+.4byte sPelipperAnims_1_3
+.4byte sPelipperAnims_1_4
+.4byte sPelipperAnims_1_5
+.4byte sPelipperAnims_1_6
+.4byte sPelipperAnims_1_7
+.4byte sPelipperAnims_1_8
+sPelipperAnimTable2:
+.4byte sPelipperAnims_2_1
+.4byte sPelipperAnims_2_2
+.4byte sPelipperAnims_2_3
+.4byte sPelipperAnims_2_4
+.4byte sPelipperAnims_2_5
+.4byte sPelipperAnims_2_6
+.4byte sPelipperAnims_2_7
+.4byte sPelipperAnims_2_8
+sPelipperAnimTable3:
+.4byte sPelipperAnims_3_1
+.4byte sPelipperAnims_3_2
+.4byte sPelipperAnims_3_3
+.4byte sPelipperAnims_3_4
+.4byte sPelipperAnims_3_5
+.4byte sPelipperAnims_3_6
+.4byte sPelipperAnims_3_7
+.4byte sPelipperAnims_3_8
+sPelipperAnimTable4:
+.4byte sPelipperAnims_4_1
+.4byte sPelipperAnims_4_2
+.4byte sPelipperAnims_4_3
+.4byte sPelipperAnims_4_4
+.4byte sPelipperAnims_4_5
+.4byte sPelipperAnims_4_6
+.4byte sPelipperAnims_4_7
+.4byte sPelipperAnims_4_8
+sPelipperAnimTable5:
+.4byte sPelipperAnims_5_1
+.4byte sPelipperAnims_5_2
+.4byte sPelipperAnims_5_3
+.4byte sPelipperAnims_5_4
+.4byte sPelipperAnims_5_5
+.4byte sPelipperAnims_5_6
+.4byte sPelipperAnims_5_7
+.4byte sPelipperAnims_5_8
+sPelipperAnimTable6:
+.4byte sPelipperAnims_6_1
+.4byte sPelipperAnims_6_1
+.4byte sPelipperAnims_6_1
+.4byte sPelipperAnims_6_1
+.4byte sPelipperAnims_6_1
+.4byte sPelipperAnims_6_1
+.4byte sPelipperAnims_6_1
+.4byte sPelipperAnims_6_1
+sPelipperAnimTable7:
+.4byte sPelipperAnims_7_1
+.4byte sPelipperAnims_7_2
+.4byte sPelipperAnims_7_3
+.4byte sPelipperAnims_7_4
+.4byte sPelipperAnims_7_5
+.4byte sPelipperAnims_7_6
+.4byte sPelipperAnims_7_7
+.4byte sPelipperAnims_7_8
+sPelipperAnimTable8:
+.4byte sPelipperAnims_8_1
+.4byte sPelipperAnims_8_2
+.4byte sPelipperAnims_8_3
+.4byte sPelipperAnims_8_4
+.4byte sPelipperAnims_8_5
+.4byte sPelipperAnims_8_6
+.4byte sPelipperAnims_8_7
+.4byte sPelipperAnims_8_8
+sPelipperAnimTable9:
+.4byte sPelipperAnims_9_1
+.4byte sPelipperAnims_9_2
+.4byte sPelipperAnims_9_3
+.4byte sPelipperAnims_9_4
+.4byte sPelipperAnims_9_5
+.4byte sPelipperAnims_9_6
+.4byte sPelipperAnims_9_7
+.4byte sPelipperAnims_9_8
+sPelipperAnimTable10:
+.4byte sPelipperAnims_10_1
+.4byte sPelipperAnims_10_2
+.4byte sPelipperAnims_10_3
+.4byte sPelipperAnims_10_4
+.4byte sPelipperAnims_10_5
+.4byte sPelipperAnims_10_6
+.4byte sPelipperAnims_10_7
+.4byte sPelipperAnims_10_8
+sPelipperAnimTable11:
+.4byte sPelipperAnims_11_1
+.4byte sPelipperAnims_11_2
+.4byte sPelipperAnims_11_3
+.4byte sPelipperAnims_11_4
+.4byte sPelipperAnims_11_5
+.4byte sPelipperAnims_11_6
+.4byte sPelipperAnims_11_7
+.4byte sPelipperAnims_11_8
+sPelipperAnimTable12:
+.4byte sPelipperAnims_12_1
+.4byte sPelipperAnims_12_2
+.4byte sPelipperAnims_12_3
+.4byte sPelipperAnims_12_4
+.4byte sPelipperAnims_12_5
+.4byte sPelipperAnims_12_6
+.4byte sPelipperAnims_12_7
+.4byte sPelipperAnims_12_8
+sPelipperAnimTable13:
+.4byte sPelipperAnims_13_1
+.4byte sPelipperAnims_13_2
+.4byte sPelipperAnims_13_3
+.4byte sPelipperAnims_13_4
+.4byte sPelipperAnims_13_5
+.4byte sPelipperAnims_13_6
+.4byte sPelipperAnims_13_7
+.4byte sPelipperAnims_13_8
+sPelipperAnimTable14:
+.4byte sPelipperAnims_14_1
+.4byte sPelipperAnims_14_2
+.4byte sPelipperAnims_14_3
+.4byte sPelipperAnims_14_4
+.4byte sPelipperAnims_14_5
+.4byte sPelipperAnims_14_6
+.4byte sPelipperAnims_14_7
+.4byte sPelipperAnims_14_8
+sPelipperAnimTable15:
+.4byte sPelipperAnims_15_1
+.4byte sPelipperAnims_15_2
+.4byte sPelipperAnims_15_3
+.4byte sPelipperAnims_15_4
+.4byte sPelipperAnims_15_5
+.4byte sPelipperAnims_15_6
+.4byte sPelipperAnims_15_7
+.4byte sPelipperAnims_15_8
+sAxAnimationsPelipper:
+.4byte sPelipperAnimTable1
+.4byte sPelipperAnimTable2
+.4byte sPelipperAnimTable3
+.4byte sPelipperAnimTable4
+.4byte sPelipperAnimTable5
+.4byte sPelipperAnimTable6
+.4byte sPelipperAnimTable7
+.4byte sPelipperAnimTable8
+.4byte sPelipperAnimTable9
+.4byte sPelipperAnimTable10
+.4byte sPelipperAnimTable11
+.4byte sPelipperAnimTable12
+.4byte sPelipperAnimTable13
+.4byte sPelipperAnimTable14
+.4byte sPelipperAnimTable15
+sAxSpritesPelipper:
+.4byte sPelipperSprites1
+.4byte sPelipperSprites2
+.4byte sPelipperSprites3
+.4byte sPelipperSprites4
+.4byte sPelipperSprites5
+.4byte sPelipperSprites6
+.4byte sPelipperSprites7
+.4byte sPelipperSprites8
+.4byte sPelipperSprites9
+.4byte sPelipperSprites10
+.4byte sPelipperSprites11
+.4byte sPelipperSprites12
+.4byte sPelipperSprites13
+.4byte sPelipperSprites14
+.4byte sPelipperSprites15
+.4byte sPelipperSprites16
+.4byte sPelipperSprites17
+.4byte sPelipperSprites18
+.4byte sPelipperSprites19
+.4byte sPelipperSprites20
+.4byte sPelipperSprites21
+.4byte sPelipperSprites22
+.4byte sPelipperSprites23
+.4byte sPelipperSprites24
+.4byte sPelipperSprites25
+.4byte sPelipperSprites26
+.4byte sPelipperSprites27
+.4byte sPelipperSprites28
+.4byte sPelipperSprites29
+.4byte sPelipperSprites30
+.4byte sPelipperSprites31
+.4byte sPelipperSprites32
+.4byte sPelipperSprites33
+.4byte sPelipperSprites34
+.4byte sPelipperSprites35
+.4byte sPelipperSprites36
+.4byte sPelipperSprites37
+.4byte sPelipperSprites38
+.4byte sPelipperSprites39
+.4byte sPelipperSprites40
+.4byte sPelipperSprites41
+.4byte sPelipperSprites42
+.4byte sPelipperSprites43
+.4byte sPelipperSprites44
+.4byte sPelipperSprites45
+.4byte sPelipperSprites46
+.4byte sPelipperSprites47
+.4byte sPelipperSprites48
+.4byte sPelipperSprites49
+.4byte sPelipperSprites50
+.4byte sPelipperSprites51
+.4byte sPelipperSprites52
+.4byte sPelipperSprites53
+.4byte sPelipperSprites54
+.4byte sPelipperSprites55
+.4byte sPelipperSprites56
+.4byte sPelipperSprites57
+.4byte sPelipperSprites58
+sAxMainPelipper:
+ax_main sAxPosesPelipper, sAxAnimationsPelipper, 15, sAxSpritesPelipper, sAxPositionsPelipper

--- a/data/ax/persian.inc
+++ b/data/ax/persian.inc
@@ -1,0 +1,3131 @@
+.global gAxPersian
+gAxPersian:
+ax_siro sAxMainPersian
+sPersianPose1:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose3:
+ax_pose 2, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose4:
+ax_pose 3, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose5:
+ax_pose 4, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose6:
+ax_pose 5, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose7:
+ax_pose 6, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose8:
+ax_pose 7, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose9:
+ax_pose 8, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose10:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose11:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose12:
+ax_pose 11, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose14:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose15:
+ax_pose 14, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose16:
+ax_pose 9, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose17:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose18:
+ax_pose 11, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose22:
+ax_pose 3, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose23:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose24:
+ax_pose 5, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose25:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose26:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose27:
+ax_pose 2, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose28:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose29:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose30:
+ax_pose 3, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose31:
+ax_pose 4, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose32:
+ax_pose 5, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose33:
+ax_pose 17, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose34:
+ax_pose 18, 0x01e7, 0x90f1, 0x4c00
+ax_pose_terminator
+sPersianPose35:
+ax_pose 6, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose36:
+ax_pose 7, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose37:
+ax_pose 8, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose38:
+ax_pose 19, 0x01e2, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose39:
+ax_pose 20, 0x41e4, 0x90ef, 0x4c00
+ax_pose 21, 0x41f4, 0x50ef, 0x4c08
+ax_pose 22, 0x01f1, 0x10e7, 0x4c0c
+ax_pose_terminator
+sPersianPose40:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose41:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose42:
+ax_pose 11, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose43:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPersianPose44:
+ax_pose 24, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose45:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose46:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose47:
+ax_pose 14, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose48:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose49:
+ax_pose 26, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose50:
+ax_pose 9, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose51:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose52:
+ax_pose 11, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose53:
+ax_pose 23, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sPersianPose54:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose55:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose56:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose57:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose58:
+ax_pose 19, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose59:
+ax_pose 20, 0x41e4, 0x80f1, 0x4c00
+ax_pose 21, 0x41f4, 0x40f1, 0x4c08
+ax_pose 22, 0x01f1, 0x0111, 0x4c0c
+ax_pose_terminator
+sPersianPose60:
+ax_pose 3, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose61:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose62:
+ax_pose 5, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose63:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose64:
+ax_pose 18, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPersianPose65:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose66:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose67:
+ax_pose 2, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose68:
+ax_pose 27, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose69:
+ax_pose 28, 0x01e9, 0x80f3, 0x4c00
+ax_pose 29, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sPersianPose70:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose71:
+ax_pose 3, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose72:
+ax_pose 4, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose73:
+ax_pose 5, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose74:
+ax_pose 30, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose75:
+ax_pose 31, 0x81eb, 0x9104, 0x4c00
+ax_pose 32, 0x01e7, 0x90f0, 0x4c08
+ax_pose_terminator
+sPersianPose76:
+ax_pose 32, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose77:
+ax_pose 6, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose78:
+ax_pose 7, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose79:
+ax_pose 8, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose80:
+ax_pose 33, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose81:
+ax_pose 34, 0x81e9, 0x910a, 0x4c00
+ax_pose 35, 0x01e9, 0x1102, 0x4c08
+ax_pose 36, 0x01e7, 0x90f0, 0x4c09
+ax_pose_terminator
+sPersianPose82:
+ax_pose 36, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose83:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose84:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose85:
+ax_pose 11, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose86:
+ax_pose 37, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose87:
+ax_pose 38, 0x01e7, 0x90f0, 0x4c00
+ax_pose 39, 0x01e4, 0x90ef, 0x4c10
+ax_pose_terminator
+sPersianPose88:
+ax_pose 38, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose89:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose90:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose91:
+ax_pose 14, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose92:
+ax_pose 40, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose93:
+ax_pose 41, 0x01e7, 0x80f0, 0x4c00
+ax_pose 42, 0x01e4, 0x80f2, 0x4c10
+ax_pose_terminator
+sPersianPose94:
+ax_pose 41, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose95:
+ax_pose 9, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose96:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose97:
+ax_pose 11, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose98:
+ax_pose 37, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose99:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose 39, 0x01e4, 0x80f3, 0x4c10
+ax_pose_terminator
+sPersianPose100:
+ax_pose 38, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose101:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose102:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose103:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose104:
+ax_pose 33, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose105:
+ax_pose 34, 0x81e9, 0x80e6, 0x4c00
+ax_pose 35, 0x01e9, 0x00f6, 0x4c08
+ax_pose 36, 0x01e7, 0x80f0, 0x4c09
+ax_pose_terminator
+sPersianPose106:
+ax_pose 36, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose107:
+ax_pose 3, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose108:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose109:
+ax_pose 5, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose110:
+ax_pose 30, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose111:
+ax_pose 31, 0x81ed, 0x80ed, 0x4c00
+ax_pose 32, 0x01e7, 0x80f0, 0x4c08
+ax_pose_terminator
+sPersianPose112:
+ax_pose 32, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose113:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose114:
+ax_pose 43, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose115:
+ax_pose 44, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose116:
+ax_pose 4, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose117:
+ax_pose 45, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose118:
+ax_pose 46, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose119:
+ax_pose 7, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose120:
+ax_pose 47, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose121:
+ax_pose 48, 0x41ef, 0x90f3, 0x4c00
+ax_pose 49, 0x41ff, 0x50f3, 0x4c08
+ax_pose 50, 0x01f5, 0x10eb, 0x4c0c
+ax_pose_terminator
+sPersianPose122:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose123:
+ax_pose 51, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose124:
+ax_pose 52, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose125:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose126:
+ax_pose 53, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose127:
+ax_pose 54, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose128:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose129:
+ax_pose 51, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose130:
+ax_pose 52, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose131:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose132:
+ax_pose 47, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose133:
+ax_pose 48, 0x41ef, 0x80ed, 0x4c00
+ax_pose 49, 0x41ff, 0x40ed, 0x4c08
+ax_pose 50, 0x01f5, 0x010d, 0x4c0c
+ax_pose_terminator
+sPersianPose134:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose135:
+ax_pose 45, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose136:
+ax_pose 46, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose137:
+ax_pose 55, 0x81e8, 0x80f8, 0x4c00
+ax_pose 56, 0x01f0, 0x00f0, 0x4c08
+ax_pose_terminator
+sPersianPose138:
+ax_pose 57, 0x01e9, 0x80ef, 0x4c00
+ax_pose_terminator
+sPersianPose139:
+ax_pose 58, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose140:
+ax_pose 59, 0x01e8, 0x80ef, 0x4c00
+ax_pose_terminator
+sPersianPose141:
+ax_pose 60, 0x81e7, 0x80f8, 0x4c00
+ax_pose 61, 0x81e7, 0x00f0, 0x4c08
+ax_pose_terminator
+sPersianPose142:
+ax_pose 59, 0x01e8, 0x90f1, 0x4c00
+ax_pose_terminator
+sPersianPose143:
+ax_pose 58, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose144:
+ax_pose 57, 0x01e9, 0x90f1, 0x4c00
+ax_pose_terminator
+sPersianPose145:
+ax_pose 62, 0x41f4, 0x80f2, 0x4c00
+ax_pose_terminator
+sPersianPose146:
+ax_pose 63, 0x41f4, 0x80f2, 0x4c00
+ax_pose_terminator
+sPersianPose147:
+ax_pose 64, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sPersianPose148:
+ax_pose 65, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sPersianPose149:
+ax_pose 66, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sPersianPose150:
+ax_pose 67, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPersianPose151:
+ax_pose 68, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose152:
+ax_pose 67, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPersianPose153:
+ax_pose 66, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sPersianPose154:
+ax_pose 65, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sPersianPose155:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose156:
+ax_pose 55, 0x81e8, 0x80f8, 0x4c00
+ax_pose 56, 0x01f0, 0x00f0, 0x4c08
+ax_pose_terminator
+sPersianPose157:
+ax_pose 4, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose158:
+ax_pose 57, 0x01e8, 0x90f1, 0x4c00
+ax_pose_terminator
+sPersianPose159:
+ax_pose 7, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose160:
+ax_pose 58, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPersianPose161:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose162:
+ax_pose 59, 0x01e8, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose163:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose164:
+ax_pose 60, 0x81e7, 0x80f8, 0x4c00
+ax_pose 61, 0x81e7, 0x00f0, 0x4c08
+ax_pose_terminator
+sPersianPose165:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose166:
+ax_pose 59, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose167:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose168:
+ax_pose 58, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose169:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose170:
+ax_pose 57, 0x01e8, 0x80ef, 0x4c00
+ax_pose_terminator
+sPersianPose171:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose172:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose173:
+ax_pose 19, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose174:
+ax_pose 23, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sPersianPose175:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose176:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPersianPose177:
+ax_pose 19, 0x01e2, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose178:
+ax_pose 17, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose179:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose180:
+ax_pose 17, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose181:
+ax_pose 19, 0x01e2, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose182:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPersianPose183:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose184:
+ax_pose 23, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sPersianPose185:
+ax_pose 19, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose186:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose187:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose188:
+ax_pose 43, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose189:
+ax_pose 44, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose190:
+ax_pose 4, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose191:
+ax_pose 45, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose192:
+ax_pose 46, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose193:
+ax_pose 7, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose194:
+ax_pose 47, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose195:
+ax_pose 48, 0x41ef, 0x90f3, 0x4c00
+ax_pose 49, 0x41ff, 0x50f3, 0x4c08
+ax_pose 50, 0x01f5, 0x10eb, 0x4c0c
+ax_pose_terminator
+sPersianPose196:
+ax_pose 10, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose197:
+ax_pose 51, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose198:
+ax_pose 52, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose199:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose200:
+ax_pose 53, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose201:
+ax_pose 54, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose202:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose203:
+ax_pose 51, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose204:
+ax_pose 52, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose205:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose206:
+ax_pose 47, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose207:
+ax_pose 48, 0x41ef, 0x80ed, 0x4c00
+ax_pose 49, 0x41ff, 0x40ed, 0x4c08
+ax_pose 50, 0x01f5, 0x010d, 0x4c0c
+ax_pose_terminator
+sPersianPose208:
+ax_pose 4, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose209:
+ax_pose 45, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose210:
+ax_pose 46, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose211:
+ax_pose 55, 0x81e8, 0x80f8, 0x4c00
+ax_pose 56, 0x01f0, 0x00f0, 0x4c08
+ax_pose_terminator
+sPersianPose212:
+ax_pose 57, 0x01e9, 0x80ef, 0x4c00
+ax_pose_terminator
+sPersianPose213:
+ax_pose 58, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose214:
+ax_pose 59, 0x01e8, 0x80ef, 0x4c00
+ax_pose_terminator
+sPersianPose215:
+ax_pose 60, 0x81e7, 0x80f8, 0x4c00
+ax_pose 61, 0x81e7, 0x00f0, 0x4c08
+ax_pose_terminator
+sPersianPose216:
+ax_pose 59, 0x01e8, 0x90f1, 0x4c00
+ax_pose_terminator
+sPersianPose217:
+ax_pose 58, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose218:
+ax_pose 57, 0x01e9, 0x90f1, 0x4c00
+ax_pose_terminator
+sPersianPose219:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose220:
+ax_pose 3, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose221:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose222:
+ax_pose 9, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose223:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPersianPose224:
+ax_pose 9, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose225:
+ax_pose 6, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPersianPose226:
+ax_pose 3, 0x01ed, 0x90f0, 0x4c00
+ax_pose_terminator
+.align 2
+sPersianAnims_1_1:
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_1_2:
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_1_3:
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_1_4:
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_1_5:
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_1_6:
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_1_7:
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_1_8:
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 6, 0, 27, 0, -6, 0, -6,
+ax_anim 2, 0, 27, 1, -6, 1, -6,
+ax_anim 2, 0, 27, 0, -6, 0, -6,
+ax_anim 1, 2, 28, 0, -7, 0, -3,
+ax_anim 2, 0, 28, 0, -2, 0, 2,
+ax_anim 2, 0, 25, 0, 3, 0, 10,
+ax_anim 1, 0, 27, 0, 12, 0, 15,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 25, 0, 9, 0, 9,
+ax_anim 2, 0, 25, 0, 3, 0, 3,
+ax_anim_terminator
+sPersianAnims_2_2:
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -4, -4, -4, -4,
+ax_anim 6, 0, 32, -6, -6, -6, -6,
+ax_anim 2, 0, 32, -5, -7, -5, -7,
+ax_anim 2, 0, 32, -6, -6, -6, -6,
+ax_anim 1, 2, 33, 0, -5, -2, -2,
+ax_anim 2, 0, 33, 5, -1, 4, 4,
+ax_anim 2, 0, 31, 11, -2, 9, 9,
+ax_anim 1, 0, 32, 15, 5, 13, 13,
+ax_anim 2, 0, 32, 17, 17, 17, 17,
+ax_anim 2, 1, 32, 18, 16, 18, 16,
+ax_anim 2, 0, 32, 17, 17, 17, 17,
+ax_anim 2, 0, 32, 18, 16, 18, 16,
+ax_anim 2, 0, 32, 17, 17, 17, 17,
+ax_anim 2, 0, 30, 9, 9, 9, 9,
+ax_anim 2, 0, 30, 3, 3, 3, 3,
+ax_anim_terminator
+sPersianAnims_2_3:
+ax_anim 2, 0, 35, -2, 0, -2, 0,
+ax_anim 2, 0, 36, -4, 0, -4, 0,
+ax_anim 6, 0, 37, -6, 0, -6, 0,
+ax_anim 2, 0, 37, -6, -1, -6, -1,
+ax_anim 2, 0, 37, -6, 0, -6, 0,
+ax_anim 1, 2, 38, -1, 2, 0, 0,
+ax_anim 2, 0, 38, 3, -1, 7, 0,
+ax_anim 2, 0, 36, 4, -8, 7, 0,
+ax_anim 1, 0, 37, 11, -5, 7, 0,
+ax_anim 2, 0, 37, 15, 0, 15, 0,
+ax_anim 2, 1, 37, 15, -1, 15, -1,
+ax_anim 2, 0, 37, 15, 0, 15, 0,
+ax_anim 2, 0, 37, 15, -1, 15, -1,
+ax_anim 2, 0, 37, 15, 0, 15, 0,
+ax_anim 2, 0, 34, 9, 0, 9, 0,
+ax_anim 2, 0, 36, 3, 0, 3, 0,
+ax_anim_terminator
+sPersianAnims_2_4:
+ax_anim 2, 0, 40, -2, 2, -2, 2,
+ax_anim 2, 0, 41, -4, 4, -4, 4,
+ax_anim 6, 0, 42, -6, 6, -6, 6,
+ax_anim 2, 0, 42, -5, 7, -5, 7,
+ax_anim 2, 0, 42, -6, 6, -6, 6,
+ax_anim 1, 2, 43, -1, -3, 1, -1,
+ax_anim 2, 0, 43, 2, -10, 6, -6,
+ax_anim 2, 0, 41, 7, -19, 9, -9,
+ax_anim 1, 0, 42, 13, -23, 16, -16,
+ax_anim 2, 0, 42, 17, -23, 17, -23,
+ax_anim 2, 1, 42, 18, -22, 18, -22,
+ax_anim 2, 0, 42, 17, -23, 17, -23,
+ax_anim 2, 0, 42, 18, -22, 18, -22,
+ax_anim 2, 0, 42, 17, -23, 17, -23,
+ax_anim 2, 0, 40, 8, -11, 8, -11,
+ax_anim 2, 0, 40, 3, -4, 3, -4,
+ax_anim_terminator
+sPersianAnims_2_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 2, 0, 46, 0, 4, 0, 4,
+ax_anim 6, 0, 47, 0, 6, 0, 6,
+ax_anim 2, 0, 47, 0, 7, 0, 7,
+ax_anim 2, 0, 47, 0, 6, 0, 6,
+ax_anim 1, 2, 48, 0, -3, 0, -1,
+ax_anim 2, 0, 48, 0, -10, 0, -6,
+ax_anim 2, 0, 46, 0, -19, 0, -9,
+ax_anim 1, 0, 47, 0, -23, 0, -16,
+ax_anim 2, 0, 47, 0, -23, 0, -23,
+ax_anim 2, 1, 47, 0, -22, 0, -22,
+ax_anim 2, 0, 47, 0, -23, 0, -23,
+ax_anim 2, 0, 47, 0, -22, 0, -22,
+ax_anim 2, 0, 47, 0, -23, 0, -23,
+ax_anim 2, 0, 45, 0, -11, 0, -11,
+ax_anim 2, 0, 45, 0, -4, 0, -4,
+ax_anim_terminator
+sPersianAnims_2_6:
+ax_anim 2, 0, 50, 2, 2, 2, 2,
+ax_anim 2, 0, 51, 4, 4, 4, 4,
+ax_anim 6, 0, 52, 6, 6, 6, 6,
+ax_anim 2, 0, 52, 5, 7, 5, 7,
+ax_anim 2, 0, 52, 6, 6, 6, 6,
+ax_anim 1, 2, 53, 1, -3, -1, -1,
+ax_anim 2, 0, 53, -2, -10, -6, -6,
+ax_anim 2, 0, 51, -7, -19, -9, -9,
+ax_anim 1, 0, 52, -13, -23, -16, -16,
+ax_anim 2, 0, 52, -17, -23, -17, -23,
+ax_anim 2, 1, 52, -18, -22, -18, -22,
+ax_anim 2, 0, 52, -17, -23, -17, -23,
+ax_anim 2, 0, 52, -18, -22, -18, -22,
+ax_anim 2, 0, 52, -17, -23, -17, -23,
+ax_anim 2, 0, 50, -8, -11, -8, -11,
+ax_anim 2, 0, 50, -3, -4, -3, -4,
+ax_anim_terminator
+sPersianAnims_2_7:
+ax_anim 2, 0, 55, 2, 0, 2, 0,
+ax_anim 2, 0, 56, 4, 0, 4, 0,
+ax_anim 6, 0, 57, 6, 0, 6, 0,
+ax_anim 2, 0, 57, 6, -1, 6, -1,
+ax_anim 2, 0, 57, 6, 0, 6, 0,
+ax_anim 1, 2, 58, 1, 2, 0, 0,
+ax_anim 2, 0, 58, -3, -1, -7, 0,
+ax_anim 2, 0, 56, -4, -8, -7, 0,
+ax_anim 1, 0, 57, -11, -5, -7, 0,
+ax_anim 2, 0, 57, -15, 0, -15, 0,
+ax_anim 2, 1, 57, -15, -1, -15, -1,
+ax_anim 2, 0, 57, -15, 0, -15, 0,
+ax_anim 2, 0, 57, -15, -1, -15, -1,
+ax_anim 2, 0, 57, -15, 0, -15, 0,
+ax_anim 2, 0, 54, -9, 0, -9, 0,
+ax_anim 2, 0, 56, -3, 0, -3, 0,
+ax_anim_terminator
+sPersianAnims_2_8:
+ax_anim 2, 0, 60, 2, -2, 2, -2,
+ax_anim 2, 0, 59, 4, -4, 4, -4,
+ax_anim 6, 0, 62, 6, -6, 6, -6,
+ax_anim 2, 0, 62, 5, -7, 5, -7,
+ax_anim 2, 0, 62, 6, -6, 6, -6,
+ax_anim 1, 2, 63, 0, -5, 2, -2,
+ax_anim 2, 0, 63, -5, -1, -4, 4,
+ax_anim 2, 0, 61, -11, -2, -9, 9,
+ax_anim 1, 0, 62, -15, 5, -13, 13,
+ax_anim 2, 0, 62, -17, 17, -17, 17,
+ax_anim 2, 1, 62, -18, 16, -18, 16,
+ax_anim 2, 0, 62, -17, 17, -17, 17,
+ax_anim 2, 0, 62, -18, 16, -18, 16,
+ax_anim 2, 0, 62, -17, 17, -17, 17,
+ax_anim 2, 0, 60, -9, 9, -9, 9,
+ax_anim 2, 0, 60, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPersianAnims_3_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 66, 0, -4, 0, -4,
+ax_anim 4, 0, 67, 0, -5, 0, -5,
+ax_anim 1, 2, 67, 0, -2, 0, -2,
+ax_anim 2, 0, 67, 0, 4, 0, 4,
+ax_anim 2, 0, 68, 0, 13, 0, 13,
+ax_anim 2, 1, 69, 0, 14, 0, 14,
+ax_anim 2, 0, 69, 1, 14, 1, 14,
+ax_anim 2, 0, 69, 0, 14, 0, 14,
+ax_anim 2, 0, 69, 1, 14, 1, 14,
+ax_anim 2, 0, 69, 0, 14, 0, 14,
+ax_anim 2, 0, 65, 0, 8, 0, 8,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim_terminator
+sPersianAnims_3_2:
+ax_anim 2, 0, 70, -2, -2, -2, -2,
+ax_anim 2, 0, 72, -4, -4, -4, -4,
+ax_anim 4, 0, 73, -5, -5, -5, -5,
+ax_anim 1, 2, 73, -2, -2, -2, -2,
+ax_anim 2, 0, 73, 4, 4, 4, 4,
+ax_anim 2, 0, 74, 14, 16, 14, 16,
+ax_anim 2, 1, 75, 15, 17, 15, 17,
+ax_anim 2, 0, 75, 16, 16, 16, 16,
+ax_anim 2, 0, 75, 15, 17, 15, 17,
+ax_anim 2, 0, 75, 16, 16, 16, 16,
+ax_anim 2, 0, 75, 15, 17, 15, 17,
+ax_anim 2, 0, 71, 8, 8, 8, 8,
+ax_anim 2, 0, 71, 3, 3, 3, 3,
+ax_anim_terminator
+sPersianAnims_3_3:
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 2, 0, 78, -4, 0, -4, 0,
+ax_anim 4, 0, 79, -5, 0, -5, 0,
+ax_anim 1, 2, 79, -2, 0, -2, 0,
+ax_anim 2, 0, 79, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 10, 0, 10, 0,
+ax_anim 2, 1, 81, 11, 0, 11, 0,
+ax_anim 2, 0, 81, 11, 1, 11, 1,
+ax_anim 2, 0, 81, 11, 0, 11, 0,
+ax_anim 2, 0, 81, 11, 1, 11, 1,
+ax_anim 2, 0, 81, 11, 0, 11, 0,
+ax_anim 2, 0, 77, 6, 0, 6, 0,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim_terminator
+sPersianAnims_3_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim 4, 0, 85, -5, 5, -5, 5,
+ax_anim 1, 2, 85, -2, 2, -2, 2,
+ax_anim 2, 0, 85, 4, -7, 4, -7,
+ax_anim 2, 0, 86, 14, -21, 14, -21,
+ax_anim 2, 1, 87, 15, -22, 15, -22,
+ax_anim 2, 0, 87, 16, -21, 16, -21,
+ax_anim 2, 0, 87, 15, -22, 15, -22,
+ax_anim 2, 0, 87, 16, -21, 16, -21,
+ax_anim 2, 0, 87, 15, -22, 15, -22,
+ax_anim 2, 0, 83, 7, -10, 7, -10,
+ax_anim 2, 0, 83, 3, -4, 3, -4,
+ax_anim_terminator
+sPersianAnims_3_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 4, 0, 91, 0, 5, 0, 5,
+ax_anim 1, 2, 91, 0, 2, 0, 2,
+ax_anim 2, 0, 91, 0, -7, 0, -7,
+ax_anim 2, 0, 92, 0, -19, 0, -19,
+ax_anim 2, 1, 93, 0, -20, 0, -20,
+ax_anim 2, 0, 93, 1, -20, 1, -20,
+ax_anim 2, 0, 93, 0, -20, 0, -20,
+ax_anim 2, 0, 93, 1, -20, 1, -20,
+ax_anim 2, 0, 93, 0, -20, 0, -20,
+ax_anim 2, 0, 89, 0, -10, 0, -10,
+ax_anim 2, 0, 89, 0, -4, 0, -4,
+ax_anim_terminator
+sPersianAnims_3_6:
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim 2, 0, 96, 4, 4, 4, 4,
+ax_anim 4, 0, 97, 5, 5, 5, 5,
+ax_anim 1, 2, 97, 2, 2, 2, 2,
+ax_anim 2, 0, 97, -4, -7, -4, -7,
+ax_anim 2, 0, 98, -14, -21, -14, -21,
+ax_anim 2, 1, 99, -15, -22, -15, -22,
+ax_anim 2, 0, 99, -16, -21, -16, -21,
+ax_anim 2, 0, 99, -15, -22, -15, -22,
+ax_anim 2, 0, 99, -16, -21, -16, -21,
+ax_anim 2, 0, 99, -15, -22, -15, -22,
+ax_anim 2, 0, 95, -7, -10, -7, -10,
+ax_anim 2, 0, 95, -3, -4, -3, -4,
+ax_anim_terminator
+sPersianAnims_3_7:
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 4, 0, 4, 0,
+ax_anim 4, 0, 103, 5, 0, 5, 0,
+ax_anim 1, 2, 103, 2, 0, 2, 0,
+ax_anim 2, 0, 103, -4, 0, -4, 0,
+ax_anim 2, 0, 104, -10, 0, -10, 0,
+ax_anim 2, 1, 105, -11, 0, -11, 0,
+ax_anim 2, 0, 105, -11, 1, -11, 1,
+ax_anim 2, 0, 105, -11, 0, -11, 0,
+ax_anim 2, 0, 105, -11, 1, -11, 1,
+ax_anim 2, 0, 105, -11, 0, -11, 0,
+ax_anim 2, 0, 101, -6, 0, -6, 0,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim_terminator
+sPersianAnims_3_8:
+ax_anim 2, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 108, 4, -4, 4, -4,
+ax_anim 4, 0, 109, 5, -5, 5, -5,
+ax_anim 1, 2, 109, 2, -2, 2, -2,
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 2, 0, 110, -14, 16, -14, 16,
+ax_anim 2, 1, 111, -15, 17, -15, 17,
+ax_anim 2, 0, 111, -16, 16, -16, 16,
+ax_anim 2, 0, 111, -15, 17, -15, 17,
+ax_anim 2, 0, 111, -16, 16, -16, 16,
+ax_anim 2, 0, 111, -15, 17, -15, 17,
+ax_anim 2, 0, 107, -8, 8, -8, 8,
+ax_anim 2, 0, 107, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPersianAnims_4_1:
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim 2, 0, 113, 0, -3, 0, -3,
+ax_anim 4, 2, 113, 0, -4, 0, -4,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 4, 0, 4,
+ax_anim 2, 1, 114, 1, 4, 1, 4,
+ax_anim 2, 0, 114, 0, 4, 0, 4,
+ax_anim 2, 0, 114, 1, 4, 1, 4,
+ax_anim 2, 0, 114, 0, 4, 0, 4,
+ax_anim 2, 0, 114, 1, 4, 1, 4,
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim_terminator
+sPersianAnims_4_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 2, 0, 116, -3, -3, -3, -3,
+ax_anim 4, 2, 116, -4, -4, -4, -4,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 4, 4, 4, 4,
+ax_anim 2, 1, 117, 5, 3, 5, 3,
+ax_anim 2, 0, 117, 4, 4, 4, 4,
+ax_anim 2, 0, 117, 5, 3, 5, 3,
+ax_anim 2, 0, 117, 4, 4, 4, 4,
+ax_anim 2, 0, 117, 5, 3, 5, 3,
+ax_anim 2, 0, 115, 2, 2, 2, 2,
+ax_anim_terminator
+sPersianAnims_4_3:
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim 2, 0, 119, -3, 0, -3, 0,
+ax_anim 4, 2, 119, -4, 0, -4, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 2, 1, 120, 4, 1, 4, 1,
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 2, 0, 120, 4, 1, 4, 1,
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 2, 0, 120, 4, 1, 4, 1,
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim_terminator
+sPersianAnims_4_4:
+ax_anim 2, 0, 121, -2, 2, -2, 2,
+ax_anim 2, 0, 122, -3, 3, -3, 3,
+ax_anim 4, 2, 122, -4, 4, -4, 4,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 5, -5, 5, -5,
+ax_anim 2, 1, 123, 6, -4, 6, -4,
+ax_anim 2, 0, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 123, 6, -4, 6, -4,
+ax_anim 2, 0, 123, 5, -5, 5, -5,
+ax_anim 2, 0, 123, 6, -4, 6, -4,
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim_terminator
+sPersianAnims_4_5:
+ax_anim 2, 0, 124, 0, 2, 0, 2,
+ax_anim 2, 0, 125, 0, 3, 0, 3,
+ax_anim 4, 2, 125, 0, 4, 0, 4,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, -5,
+ax_anim 2, 1, 126, 1, -5, 1, -5,
+ax_anim 2, 0, 126, 0, -5, 0, -5,
+ax_anim 2, 0, 126, 1, -5, 1, -5,
+ax_anim 2, 0, 126, 0, -5, 0, -5,
+ax_anim 2, 0, 126, 1, -5, 1, -5,
+ax_anim 2, 0, 124, 0, -2, 0, -2,
+ax_anim_terminator
+sPersianAnims_4_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 2, 0, 128, 3, 3, 3, 3,
+ax_anim 4, 2, 128, 4, 4, 4, 4,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -5, -5, -5, -5,
+ax_anim 2, 1, 129, -6, -4, -6, -4,
+ax_anim 2, 0, 129, -5, -5, -5, -5,
+ax_anim 2, 0, 129, -6, -4, -6, -4,
+ax_anim 2, 0, 129, -5, -5, -5, -5,
+ax_anim 2, 0, 129, -6, -4, -6, -4,
+ax_anim 2, 0, 127, -2, -2, -2, -2,
+ax_anim_terminator
+sPersianAnims_4_7:
+ax_anim 2, 0, 130, 2, 0, 2, 0,
+ax_anim 2, 0, 131, 3, 0, 3, 0,
+ax_anim 4, 2, 131, 4, 0, 4, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 2, 1, 132, -4, 1, -4, 1,
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 2, 0, 132, -4, 1, -4, 1,
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 2, 0, 132, -4, 1, -4, 1,
+ax_anim 2, 0, 130, -2, 0, -2, 0,
+ax_anim_terminator
+sPersianAnims_4_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 134, 3, -3, 3, -3,
+ax_anim 4, 2, 134, 4, -4, 4, -4,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -4, 4, -4, 4,
+ax_anim 2, 1, 135, -5, 3, -5, 3,
+ax_anim 2, 0, 135, -4, 4, -4, 4,
+ax_anim 2, 0, 135, -5, 3, -5, 3,
+ax_anim 2, 0, 135, -4, 4, -4, 4,
+ax_anim 2, 0, 135, -5, 3, -5, 3,
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPersianAnims_5_1:
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 1, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_5_2:
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_5_3:
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_5_4:
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, -1, -1, -1,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_5_5:
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 1, 0, 1, 0,
+ax_anim 2, 1, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_5_6:
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_5_7:
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_5_8:
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 1, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sPersianAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sPersianAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sPersianAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sPersianAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sPersianAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sPersianAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sPersianAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPersianAnims_8_1:
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_8_2:
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_8_3:
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_8_4:
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_8_5:
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_8_6:
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_8_7:
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_8_8:
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 14, 7, 14,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -7, 14, -7, 14,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 16, 3, 16, 3,
+ax_anim 2, 0, 172, 20, 12, 20, 12,
+ax_anim 3, 0, 173, 18, 19, 18, 19,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, -1, 9, -1, 9,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -7, 17, -7,
+ax_anim 3, 0, 172, 19, -2, 19, -2,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -20, 12, -20,
+ax_anim 3, 0, 171, 19, -20, 19, -20,
+ax_anim 2, 3, 172, 22, -12, 22, -12,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, 1, 7, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -20, -12, -20,
+ax_anim 3, 0, 177, -19, -20, -19, -20,
+ax_anim 2, 3, 176, -22, -12, -22, -12,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -7, -17, -7,
+ax_anim 3, 0, 176, -19, -2, -19, -2,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -16, 3, -16, 3,
+ax_anim 2, 0, 176, -20, 12, -20, 12,
+ax_anim 3, 0, 175, -18, 19, -18, 19,
+ax_anim 2, 3, 174, -11, 21, -11, 21,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 1, 9, 1, 9,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPersianAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sPersianGfx1:
+.incbin "baserom.gba", 0x748C84, 0x200
+sPersianSprites1:
+ax_sprite sPersianGfx1, 0x200
+ax_sprite_terminator
+sPersianGfx2:
+.incbin "baserom.gba", 0x748E94, 0x200
+sPersianSprites2:
+ax_sprite sPersianGfx2, 0x200
+ax_sprite_terminator
+sPersianGfx3:
+.incbin "baserom.gba", 0x7490A4, 0x200
+sPersianSprites3:
+ax_sprite sPersianGfx3, 0x200
+ax_sprite_terminator
+sPersianGfx4:
+.incbin "baserom.gba", 0x7492B4, 0x200
+sPersianSprites4:
+ax_sprite sPersianGfx4, 0x200
+ax_sprite_terminator
+sPersianGfx5:
+.incbin "baserom.gba", 0x7494C4, 0x200
+sPersianSprites5:
+ax_sprite sPersianGfx5, 0x200
+ax_sprite_terminator
+sPersianGfx6:
+.incbin "baserom.gba", 0x7496D4, 0x200
+sPersianSprites6:
+ax_sprite sPersianGfx6, 0x200
+ax_sprite_terminator
+sPersianGfx7:
+.incbin "baserom.gba", 0x7498E4, 0x200
+sPersianSprites7:
+ax_sprite sPersianGfx7, 0x200
+ax_sprite_terminator
+sPersianGfx8:
+.incbin "baserom.gba", 0x749AF4, 0x200
+sPersianSprites8:
+ax_sprite sPersianGfx8, 0x200
+ax_sprite_terminator
+sPersianGfx9:
+.incbin "baserom.gba", 0x749D04, 0x200
+sPersianSprites9:
+ax_sprite sPersianGfx9, 0x200
+ax_sprite_terminator
+sPersianGfx10:
+.incbin "baserom.gba", 0x749F14, 0x200
+sPersianSprites10:
+ax_sprite sPersianGfx10, 0x200
+ax_sprite_terminator
+sPersianGfx11:
+.incbin "baserom.gba", 0x74A124, 0x200
+sPersianSprites11:
+ax_sprite sPersianGfx11, 0x200
+ax_sprite_terminator
+sPersianGfx12:
+.incbin "baserom.gba", 0x74A334, 0x200
+sPersianSprites12:
+ax_sprite sPersianGfx12, 0x200
+ax_sprite_terminator
+sPersianGfx13:
+.incbin "baserom.gba", 0x74A544, 0x200
+sPersianSprites13:
+ax_sprite sPersianGfx13, 0x200
+ax_sprite_terminator
+sPersianGfx14:
+.incbin "baserom.gba", 0x74A754, 0x200
+sPersianSprites14:
+ax_sprite sPersianGfx14, 0x200
+ax_sprite_terminator
+sPersianGfx15:
+.incbin "baserom.gba", 0x74A964, 0x200
+sPersianSprites15:
+ax_sprite sPersianGfx15, 0x200
+ax_sprite_terminator
+sPersianGfx16:
+.incbin "baserom.gba", 0x74AB74, 0x40
+sPersianGfx16_1:
+.incbin "baserom.gba", 0x74ABB4, 0x40
+sPersianGfx16_2:
+.incbin "baserom.gba", 0x74ABF4, 0x60
+sPersianGfx16_3:
+.incbin "baserom.gba", 0x74AC54, 0x60
+sPersianSprites16:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx17:
+.incbin "baserom.gba", 0x74AD04, 0x40
+sPersianGfx17_1:
+.incbin "baserom.gba", 0x74AD44, 0x40
+sPersianGfx17_2:
+.incbin "baserom.gba", 0x74AD84, 0x60
+sPersianSprites17:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPersianGfx18:
+.incbin "baserom.gba", 0x74AE24, 0x1C0
+sPersianSprites18:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx18, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx19:
+.incbin "baserom.gba", 0x74B004, 0x40
+sPersianGfx19_1:
+.incbin "baserom.gba", 0x74B044, 0x100
+sPersianSprites19:
+ax_sprite sPersianGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx19_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPersianGfx20:
+.incbin "baserom.gba", 0x74B16C, 0x40
+sPersianGfx20_1:
+.incbin "baserom.gba", 0x74B1AC, 0x140
+sPersianSprites20:
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx20_1, 0x140
+ax_sprite_terminator
+sPersianGfx21:
+.incbin "baserom.gba", 0x74B314, 0x40
+sPersianGfx21_1:
+.incbin "baserom.gba", 0x74B354, 0x80
+sPersianSprites21:
+ax_sprite sPersianGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx21_1, 0x80
+ax_sprite_terminator
+sPersianGfx22:
+.incbin "baserom.gba", 0x74B3F4, 0x80
+sPersianSprites22:
+ax_sprite sPersianGfx22, 0x80
+ax_sprite_terminator
+sPersianGfx23:
+.incbin "baserom.gba", 0x74B484, 0x20
+sPersianSprites23:
+ax_sprite sPersianGfx23, 0x20
+ax_sprite_terminator
+sPersianGfx24:
+.incbin "baserom.gba", 0x74B4B4, 0x1A0
+sPersianSprites24:
+ax_sprite 0, 0x60
+ax_sprite sPersianGfx24, 0x1a0
+ax_sprite_terminator
+sPersianGfx25:
+.incbin "baserom.gba", 0x74B66C, 0x60
+sPersianGfx25_1:
+.incbin "baserom.gba", 0x74B6CC, 0x80
+sPersianGfx25_2:
+.incbin "baserom.gba", 0x74B74C, 0x60
+sPersianGfx25_3:
+.incbin "baserom.gba", 0x74B7AC, 0x40
+sPersianSprites25:
+ax_sprite sPersianGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx25_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx25_3, 0x40
+ax_sprite_terminator
+sPersianGfx26:
+.incbin "baserom.gba", 0x74B82C, 0x60
+sPersianGfx26_1:
+.incbin "baserom.gba", 0x74B88C, 0x40
+sPersianGfx26_2:
+.incbin "baserom.gba", 0x74B8CC, 0x40
+sPersianSprites26:
+ax_sprite 0, 0x80
+ax_sprite sPersianGfx26, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx27:
+.incbin "baserom.gba", 0x74B94C, 0x60
+sPersianGfx27_1:
+.incbin "baserom.gba", 0x74B9AC, 0x40
+sPersianGfx27_2:
+.incbin "baserom.gba", 0x74B9EC, 0x40
+sPersianGfx27_3:
+.incbin "baserom.gba", 0x74BA2C, 0x40
+sPersianSprites27:
+ax_sprite sPersianGfx27, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx27_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx28:
+.incbin "baserom.gba", 0x74BAB4, 0x60
+sPersianGfx28_1:
+.incbin "baserom.gba", 0x74BB14, 0x60
+sPersianGfx28_2:
+.incbin "baserom.gba", 0x74BB74, 0x40
+sPersianSprites28:
+ax_sprite 0, 0x80
+ax_sprite sPersianGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx29:
+.incbin "baserom.gba", 0x74BBF4, 0x20
+sPersianGfx29_1:
+.incbin "baserom.gba", 0x74BC14, 0x20
+sPersianGfx29_2:
+.incbin "baserom.gba", 0x74BC34, 0x40
+sPersianGfx29_3:
+.incbin "baserom.gba", 0x74BC74, 0x60
+sPersianSprites29:
+ax_sprite sPersianGfx29, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPersianGfx29_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPersianGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx30:
+.incbin "baserom.gba", 0x74BD1C, 0x40
+sPersianGfx30_1:
+.incbin "baserom.gba", 0x74BD5C, 0x40
+sPersianGfx30_2:
+.incbin "baserom.gba", 0x74BD9C, 0x40
+sPersianGfx30_3:
+.incbin "baserom.gba", 0x74BDDC, 0x40
+sPersianSprites30:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx30_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx31:
+.incbin "baserom.gba", 0x74BE6C, 0x40
+sPersianGfx31_1:
+.incbin "baserom.gba", 0x74BEAC, 0x100
+sPersianGfx31_2:
+.incbin "baserom.gba", 0x74BFAC, 0x20
+sPersianSprites31:
+ax_sprite sPersianGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx31_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPersianGfx32:
+.incbin "baserom.gba", 0x74C004, 0x60
+sPersianGfx32_1:
+.incbin "baserom.gba", 0x74C064, 0x80
+sPersianSprites32:
+ax_sprite sPersianGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx32_1, 0x80
+ax_sprite_terminator
+sPersianGfx33:
+.incbin "baserom.gba", 0x74C104, 0x160
+sPersianSprites33:
+ax_sprite 0, 0x80
+ax_sprite sPersianGfx33, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx34:
+.incbin "baserom.gba", 0x74C284, 0x40
+sPersianGfx34_1:
+.incbin "baserom.gba", 0x74C2C4, 0x80
+sPersianGfx34_2:
+.incbin "baserom.gba", 0x74C344, 0x60
+sPersianGfx34_3:
+.incbin "baserom.gba", 0x74C3A4, 0x40
+sPersianSprites34:
+ax_sprite sPersianGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx34_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx34_3, 0x40
+ax_sprite_terminator
+sPersianGfx35:
+.incbin "baserom.gba", 0x74C424, 0x100
+sPersianSprites35:
+ax_sprite sPersianGfx35, 0x100
+ax_sprite_terminator
+sPersianGfx36:
+.incbin "baserom.gba", 0x74C534, 0x20
+sPersianSprites36:
+ax_sprite sPersianGfx36, 0x20
+ax_sprite_terminator
+sPersianGfx37:
+.incbin "baserom.gba", 0x74C564, 0x180
+sPersianSprites37:
+ax_sprite 0, 0x80
+ax_sprite sPersianGfx37, 0x180
+ax_sprite_terminator
+sPersianGfx38:
+.incbin "baserom.gba", 0x74C6FC, 0x60
+sPersianGfx38_1:
+.incbin "baserom.gba", 0x74C75C, 0x40
+sPersianGfx38_2:
+.incbin "baserom.gba", 0x74C79C, 0x60
+sPersianGfx38_3:
+.incbin "baserom.gba", 0x74C7FC, 0x60
+sPersianSprites38:
+ax_sprite sPersianGfx38, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx38_3, 0x60
+ax_sprite_terminator
+sPersianGfx39:
+.incbin "baserom.gba", 0x74C89C, 0x60
+sPersianGfx39_1:
+.incbin "baserom.gba", 0x74C8FC, 0x100
+sPersianSprites39:
+ax_sprite 0, 0x80
+ax_sprite sPersianGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx39_1, 0x100
+ax_sprite_terminator
+sPersianGfx40:
+.incbin "baserom.gba", 0x74CA24, 0x60
+sPersianGfx40_1:
+.incbin "baserom.gba", 0x74CA84, 0xA0
+sPersianGfx40_2:
+.incbin "baserom.gba", 0x74CB24, 0x20
+sPersianSprites40:
+ax_sprite sPersianGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx40_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sPersianGfx40_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sPersianGfx41:
+.incbin "baserom.gba", 0x74CB7C, 0x40
+sPersianGfx41_1:
+.incbin "baserom.gba", 0x74CBBC, 0x60
+sPersianGfx41_2:
+.incbin "baserom.gba", 0x74CC1C, 0x60
+sPersianGfx41_3:
+.incbin "baserom.gba", 0x74CC7C, 0x40
+sPersianSprites41:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx41_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx42:
+.incbin "baserom.gba", 0x74CD0C, 0x60
+sPersianGfx42_1:
+.incbin "baserom.gba", 0x74CD6C, 0x60
+sPersianGfx42_2:
+.incbin "baserom.gba", 0x74CDCC, 0x40
+sPersianSprites42:
+ax_sprite 0, 0x80
+ax_sprite sPersianGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx42_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx42_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx43:
+.incbin "baserom.gba", 0x74CE4C, 0x120
+sPersianGfx43_1:
+.incbin "baserom.gba", 0x74CF6C, 0x40
+sPersianSprites43:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx43, 0x120
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx43_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sPersianGfx44:
+.incbin "baserom.gba", 0x74CFDC, 0x40
+sPersianGfx44_1:
+.incbin "baserom.gba", 0x74D01C, 0x60
+sPersianGfx44_2:
+.incbin "baserom.gba", 0x74D07C, 0x40
+sPersianGfx44_3:
+.incbin "baserom.gba", 0x74D0BC, 0x40
+sPersianSprites44:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx44_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx44_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx45:
+.incbin "baserom.gba", 0x74D14C, 0x40
+sPersianGfx45_1:
+.incbin "baserom.gba", 0x74D18C, 0x40
+sPersianGfx45_2:
+.incbin "baserom.gba", 0x74D1CC, 0x60
+sPersianGfx45_3:
+.incbin "baserom.gba", 0x74D22C, 0x60
+sPersianSprites45:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx45_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx45_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx46:
+.incbin "baserom.gba", 0x74D2DC, 0xE0
+sPersianGfx46_1:
+.incbin "baserom.gba", 0x74D3BC, 0x60
+sPersianGfx46_2:
+.incbin "baserom.gba", 0x74D41C, 0x40
+sPersianSprites46:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx46, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx46_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx47:
+.incbin "baserom.gba", 0x74D49C, 0x140
+sPersianSprites47:
+ax_sprite 0, 0xa0
+ax_sprite sPersianGfx47, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx48:
+.incbin "baserom.gba", 0x74D5FC, 0x100
+sPersianGfx48_1:
+.incbin "baserom.gba", 0x74D6FC, 0x60
+sPersianGfx48_2:
+.incbin "baserom.gba", 0x74D75C, 0x60
+sPersianSprites48:
+ax_sprite sPersianGfx48, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx48_2, 0x60
+ax_sprite_terminator
+sPersianGfx49:
+.incbin "baserom.gba", 0x74D7EC, 0x100
+sPersianSprites49:
+ax_sprite sPersianGfx49, 0x100
+ax_sprite_terminator
+sPersianGfx50:
+.incbin "baserom.gba", 0x74D8FC, 0x80
+sPersianSprites50:
+ax_sprite sPersianGfx50, 0x80
+ax_sprite_terminator
+sPersianGfx51:
+.incbin "baserom.gba", 0x74D98C, 0x20
+sPersianSprites51:
+ax_sprite sPersianGfx51, 0x20
+ax_sprite_terminator
+sPersianGfx52:
+.incbin "baserom.gba", 0x74D9BC, 0x40
+sPersianGfx52_1:
+.incbin "baserom.gba", 0x74D9FC, 0x80
+sPersianGfx52_2:
+.incbin "baserom.gba", 0x74DA7C, 0x60
+sPersianGfx52_3:
+.incbin "baserom.gba", 0x74DADC, 0x60
+sPersianSprites52:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx52, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx52_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx52_3, 0x60
+ax_sprite_terminator
+sPersianGfx53:
+.incbin "baserom.gba", 0x74DB84, 0x100
+sPersianGfx53_1:
+.incbin "baserom.gba", 0x74DC84, 0x60
+sPersianSprites53:
+ax_sprite 0, 0x80
+ax_sprite sPersianGfx53, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx53_1, 0x60
+ax_sprite_terminator
+sPersianGfx54:
+.incbin "baserom.gba", 0x74DD0C, 0x40
+sPersianGfx54_1:
+.incbin "baserom.gba", 0x74DD4C, 0x60
+sPersianGfx54_2:
+.incbin "baserom.gba", 0x74DDAC, 0x40
+sPersianGfx54_3:
+.incbin "baserom.gba", 0x74DDEC, 0x40
+sPersianSprites54:
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx54, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx54_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx54_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx54_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx55:
+.incbin "baserom.gba", 0x74DE7C, 0x40
+sPersianGfx55_1:
+.incbin "baserom.gba", 0x74DEBC, 0x40
+sPersianGfx55_2:
+.incbin "baserom.gba", 0x74DEFC, 0x40
+sPersianSprites55:
+ax_sprite 0, 0xa0
+ax_sprite sPersianGfx55, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx55_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx55_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPersianGfx56:
+.incbin "baserom.gba", 0x74DF7C, 0x100
+sPersianSprites56:
+ax_sprite sPersianGfx56, 0x100
+ax_sprite_terminator
+sPersianGfx57:
+.incbin "baserom.gba", 0x74E08C, 0x20
+sPersianSprites57:
+ax_sprite sPersianGfx57, 0x20
+ax_sprite_terminator
+sPersianGfx58:
+.incbin "baserom.gba", 0x74E0BC, 0x60
+sPersianGfx58_1:
+.incbin "baserom.gba", 0x74E11C, 0x60
+sPersianGfx58_2:
+.incbin "baserom.gba", 0x74E17C, 0x60
+sPersianGfx58_3:
+.incbin "baserom.gba", 0x74E1DC, 0x60
+sPersianSprites58:
+ax_sprite sPersianGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx58_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx58_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx58_3, 0x60
+ax_sprite_terminator
+sPersianGfx59:
+.incbin "baserom.gba", 0x74E27C, 0x40
+sPersianGfx59_1:
+.incbin "baserom.gba", 0x74E2BC, 0x60
+sPersianGfx59_2:
+.incbin "baserom.gba", 0x74E31C, 0x60
+sPersianGfx59_3:
+.incbin "baserom.gba", 0x74E37C, 0x60
+sPersianSprites59:
+ax_sprite sPersianGfx59, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx59_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx59_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx59_3, 0x60
+ax_sprite_terminator
+sPersianGfx60:
+.incbin "baserom.gba", 0x74E41C, 0x60
+sPersianGfx60_1:
+.incbin "baserom.gba", 0x74E47C, 0x60
+sPersianGfx60_2:
+.incbin "baserom.gba", 0x74E4DC, 0x60
+sPersianGfx60_3:
+.incbin "baserom.gba", 0x74E53C, 0x60
+sPersianSprites60:
+ax_sprite sPersianGfx60, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx60_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPersianGfx60_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPersianGfx60_3, 0x60
+ax_sprite_terminator
+sPersianGfx61:
+.incbin "baserom.gba", 0x74E5DC, 0x100
+sPersianSprites61:
+ax_sprite sPersianGfx61, 0x100
+ax_sprite_terminator
+sPersianGfx62:
+.incbin "baserom.gba", 0x74E6EC, 0x40
+sPersianSprites62:
+ax_sprite sPersianGfx62, 0x40
+ax_sprite_terminator
+sPersianGfx63:
+.incbin "baserom.gba", 0x74E73C, 0x100
+sPersianSprites63:
+ax_sprite sPersianGfx63, 0x100
+ax_sprite_terminator
+sPersianGfx64:
+.incbin "baserom.gba", 0x74E84C, 0x100
+sPersianSprites64:
+ax_sprite sPersianGfx64, 0x100
+ax_sprite_terminator
+sPersianGfx65:
+.incbin "baserom.gba", 0x74E95C, 0x200
+sPersianSprites65:
+ax_sprite sPersianGfx65, 0x200
+ax_sprite_terminator
+sPersianGfx66:
+.incbin "baserom.gba", 0x74EB6C, 0x200
+sPersianSprites66:
+ax_sprite sPersianGfx66, 0x200
+ax_sprite_terminator
+sPersianGfx67:
+.incbin "baserom.gba", 0x74ED7C, 0x200
+sPersianSprites67:
+ax_sprite sPersianGfx67, 0x200
+ax_sprite_terminator
+sPersianGfx68:
+.incbin "baserom.gba", 0x74EF8C, 0x200
+sPersianSprites68:
+ax_sprite sPersianGfx68, 0x200
+ax_sprite_terminator
+sPersianGfx69:
+.incbin "baserom.gba", 0x74F19C, 0x200
+sPersianSprites69:
+ax_sprite sPersianGfx69, 0x200
+ax_sprite_terminator
+sAxPosesPersian:
+.4byte sPersianPose1
+.4byte sPersianPose2
+.4byte sPersianPose3
+.4byte sPersianPose4
+.4byte sPersianPose5
+.4byte sPersianPose6
+.4byte sPersianPose7
+.4byte sPersianPose8
+.4byte sPersianPose9
+.4byte sPersianPose10
+.4byte sPersianPose11
+.4byte sPersianPose12
+.4byte sPersianPose13
+.4byte sPersianPose14
+.4byte sPersianPose15
+.4byte sPersianPose16
+.4byte sPersianPose17
+.4byte sPersianPose18
+.4byte sPersianPose19
+.4byte sPersianPose20
+.4byte sPersianPose21
+.4byte sPersianPose22
+.4byte sPersianPose23
+.4byte sPersianPose24
+.4byte sPersianPose25
+.4byte sPersianPose26
+.4byte sPersianPose27
+.4byte sPersianPose28
+.4byte sPersianPose29
+.4byte sPersianPose30
+.4byte sPersianPose31
+.4byte sPersianPose32
+.4byte sPersianPose33
+.4byte sPersianPose34
+.4byte sPersianPose35
+.4byte sPersianPose36
+.4byte sPersianPose37
+.4byte sPersianPose38
+.4byte sPersianPose39
+.4byte sPersianPose40
+.4byte sPersianPose41
+.4byte sPersianPose42
+.4byte sPersianPose43
+.4byte sPersianPose44
+.4byte sPersianPose45
+.4byte sPersianPose46
+.4byte sPersianPose47
+.4byte sPersianPose48
+.4byte sPersianPose49
+.4byte sPersianPose50
+.4byte sPersianPose51
+.4byte sPersianPose52
+.4byte sPersianPose53
+.4byte sPersianPose54
+.4byte sPersianPose55
+.4byte sPersianPose56
+.4byte sPersianPose57
+.4byte sPersianPose58
+.4byte sPersianPose59
+.4byte sPersianPose60
+.4byte sPersianPose61
+.4byte sPersianPose62
+.4byte sPersianPose63
+.4byte sPersianPose64
+.4byte sPersianPose65
+.4byte sPersianPose66
+.4byte sPersianPose67
+.4byte sPersianPose68
+.4byte sPersianPose69
+.4byte sPersianPose70
+.4byte sPersianPose71
+.4byte sPersianPose72
+.4byte sPersianPose73
+.4byte sPersianPose74
+.4byte sPersianPose75
+.4byte sPersianPose76
+.4byte sPersianPose77
+.4byte sPersianPose78
+.4byte sPersianPose79
+.4byte sPersianPose80
+.4byte sPersianPose81
+.4byte sPersianPose82
+.4byte sPersianPose83
+.4byte sPersianPose84
+.4byte sPersianPose85
+.4byte sPersianPose86
+.4byte sPersianPose87
+.4byte sPersianPose88
+.4byte sPersianPose89
+.4byte sPersianPose90
+.4byte sPersianPose91
+.4byte sPersianPose92
+.4byte sPersianPose93
+.4byte sPersianPose94
+.4byte sPersianPose95
+.4byte sPersianPose96
+.4byte sPersianPose97
+.4byte sPersianPose98
+.4byte sPersianPose99
+.4byte sPersianPose100
+.4byte sPersianPose101
+.4byte sPersianPose102
+.4byte sPersianPose103
+.4byte sPersianPose104
+.4byte sPersianPose105
+.4byte sPersianPose106
+.4byte sPersianPose107
+.4byte sPersianPose108
+.4byte sPersianPose109
+.4byte sPersianPose110
+.4byte sPersianPose111
+.4byte sPersianPose112
+.4byte sPersianPose113
+.4byte sPersianPose114
+.4byte sPersianPose115
+.4byte sPersianPose116
+.4byte sPersianPose117
+.4byte sPersianPose118
+.4byte sPersianPose119
+.4byte sPersianPose120
+.4byte sPersianPose121
+.4byte sPersianPose122
+.4byte sPersianPose123
+.4byte sPersianPose124
+.4byte sPersianPose125
+.4byte sPersianPose126
+.4byte sPersianPose127
+.4byte sPersianPose128
+.4byte sPersianPose129
+.4byte sPersianPose130
+.4byte sPersianPose131
+.4byte sPersianPose132
+.4byte sPersianPose133
+.4byte sPersianPose134
+.4byte sPersianPose135
+.4byte sPersianPose136
+.4byte sPersianPose137
+.4byte sPersianPose138
+.4byte sPersianPose139
+.4byte sPersianPose140
+.4byte sPersianPose141
+.4byte sPersianPose142
+.4byte sPersianPose143
+.4byte sPersianPose144
+.4byte sPersianPose145
+.4byte sPersianPose146
+.4byte sPersianPose147
+.4byte sPersianPose148
+.4byte sPersianPose149
+.4byte sPersianPose150
+.4byte sPersianPose151
+.4byte sPersianPose152
+.4byte sPersianPose153
+.4byte sPersianPose154
+.4byte sPersianPose155
+.4byte sPersianPose156
+.4byte sPersianPose157
+.4byte sPersianPose158
+.4byte sPersianPose159
+.4byte sPersianPose160
+.4byte sPersianPose161
+.4byte sPersianPose162
+.4byte sPersianPose163
+.4byte sPersianPose164
+.4byte sPersianPose165
+.4byte sPersianPose166
+.4byte sPersianPose167
+.4byte sPersianPose168
+.4byte sPersianPose169
+.4byte sPersianPose170
+.4byte sPersianPose171
+.4byte sPersianPose172
+.4byte sPersianPose173
+.4byte sPersianPose174
+.4byte sPersianPose175
+.4byte sPersianPose176
+.4byte sPersianPose177
+.4byte sPersianPose178
+.4byte sPersianPose179
+.4byte sPersianPose180
+.4byte sPersianPose181
+.4byte sPersianPose182
+.4byte sPersianPose183
+.4byte sPersianPose184
+.4byte sPersianPose185
+.4byte sPersianPose186
+.4byte sPersianPose187
+.4byte sPersianPose188
+.4byte sPersianPose189
+.4byte sPersianPose190
+.4byte sPersianPose191
+.4byte sPersianPose192
+.4byte sPersianPose193
+.4byte sPersianPose194
+.4byte sPersianPose195
+.4byte sPersianPose196
+.4byte sPersianPose197
+.4byte sPersianPose198
+.4byte sPersianPose199
+.4byte sPersianPose200
+.4byte sPersianPose201
+.4byte sPersianPose202
+.4byte sPersianPose203
+.4byte sPersianPose204
+.4byte sPersianPose205
+.4byte sPersianPose206
+.4byte sPersianPose207
+.4byte sPersianPose208
+.4byte sPersianPose209
+.4byte sPersianPose210
+.4byte sPersianPose211
+.4byte sPersianPose212
+.4byte sPersianPose213
+.4byte sPersianPose214
+.4byte sPersianPose215
+.4byte sPersianPose216
+.4byte sPersianPose217
+.4byte sPersianPose218
+.4byte sPersianPose219
+.4byte sPersianPose220
+.4byte sPersianPose221
+.4byte sPersianPose222
+.4byte sPersianPose223
+.4byte sPersianPose224
+.4byte sPersianPose225
+.4byte sPersianPose226
+sAxPositionsPersian:
+.2byte    0,   -2, 	  -4,    3, 	   2,    0, 	   0,   -9
+.2byte   -1,   -1, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte   -2,   -2, 	  -4,    0, 	   2,    3, 	  -1,   -9
+.2byte    7,   -3, 	   8,    3, 	  -1,    1, 	  -1,  -10
+.2byte    8,   -2, 	   7,    2, 	   1,    2, 	  -1,  -10
+.2byte    8,   -3, 	   2,   -1, 	   3,    3, 	  -1,  -10
+.2byte   12,   -5, 	  10,   -1, 	   3,    0, 	  -1,   -9
+.2byte   13,   -4, 	   6,   -2, 	   5,    0, 	  -1,  -10
+.2byte   13,   -5, 	   2,   -2, 	   8,    0, 	  -1,   -9
+.2byte    7,  -10, 	   5,   -7, 	   3,   -1, 	  -1,   -8
+.2byte    7,   -9, 	   1,   -4, 	   6,   -2, 	  -1,   -8
+.2byte    6,  -11, 	  -1,   -2, 	   8,   -3, 	  -1,   -8
+.2byte   -2,  -14, 	   4,   -9, 	  -4,   -4, 	  -1,  -11
+.2byte   -1,  -14, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -4, 	  -6,   -9, 	  -1,  -11
+.2byte   -8,  -10, 	  -6,   -7, 	  -4,   -1, 	   0,   -8
+.2byte   -8,   -9, 	  -2,   -4, 	  -7,   -2, 	   0,   -8
+.2byte   -7,  -11, 	   0,   -2, 	  -9,   -3, 	   0,   -8
+.2byte  -13,   -5, 	 -11,   -1, 	  -4,    0, 	   0,   -9
+.2byte  -14,   -4, 	  -7,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -14,   -5, 	  -3,   -2, 	  -9,    0, 	   0,   -9
+.2byte   -8,   -3, 	  -9,    3, 	   0,    1, 	   0,  -10
+.2byte   -9,   -2, 	  -8,    2, 	  -2,    2, 	   0,  -10
+.2byte   -9,   -3, 	  -3,   -1, 	  -4,    3, 	   0,  -10
+.2byte    0,   -2, 	  -4,    3, 	   2,    0, 	   0,   -9
+.2byte   -1,   -1, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte   -2,   -2, 	  -4,    0, 	   2,    3, 	  -1,   -9
+.2byte   -1,    0, 	  -6,    3, 	   4,    3, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,   -5, 	   5,   -5, 	  -1,   -9
+.2byte    7,   -3, 	   8,    3, 	  -1,    1, 	  -1,  -10
+.2byte    8,   -2, 	   7,    2, 	   1,    2, 	  -1,  -10
+.2byte    8,   -3, 	   2,   -1, 	   3,    3, 	  -1,  -10
+.2byte    6,    1, 	  10,    3, 	   1,    5, 	   0,  -10
+.2byte   10,  -10, 	  15,   -9, 	   8,   -5, 	  -1,  -12
+.2byte   12,   -5, 	  10,   -1, 	   3,    0, 	  -1,   -9
+.2byte   13,   -4, 	   6,   -2, 	   5,    0, 	  -1,  -10
+.2byte   13,   -5, 	   2,   -2, 	   8,    0, 	  -1,   -9
+.2byte   10,   -3, 	   9,   -2, 	   8,    0, 	  -1,   -9
+.2byte   12,  -14, 	  13,  -16, 	  13,  -12, 	  -1,  -16
+.2byte    7,  -10, 	   5,   -7, 	   3,   -1, 	  -1,   -8
+.2byte    7,   -9, 	   1,   -4, 	   6,   -2, 	  -1,   -8
+.2byte    6,  -11, 	  -1,   -2, 	   8,   -3, 	  -1,   -8
+.2byte    6,   -7, 	   2,   -6, 	   8,   -3, 	  -1,  -10
+.2byte    5,  -14, 	   3,  -18, 	  11,  -15, 	  -1,  -12
+.2byte   -2,  -14, 	   4,   -9, 	  -4,   -4, 	  -1,  -11
+.2byte   -1,  -14, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -4, 	  -6,   -9, 	  -1,  -11
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -7
+.2byte   -1,  -19, 	   4,  -18, 	  -6,  -18, 	  -1,  -13
+.2byte   -8,  -10, 	  -6,   -7, 	  -4,   -1, 	   0,   -8
+.2byte   -8,   -9, 	  -2,   -4, 	  -7,   -2, 	   0,   -8
+.2byte   -7,  -11, 	   0,   -2, 	  -9,   -3, 	   0,   -8
+.2byte   -7,   -7, 	  -3,   -6, 	  -9,   -3, 	   0,  -10
+.2byte   -6,  -14, 	  -4,  -18, 	 -12,  -15, 	   0,  -12
+.2byte  -13,   -5, 	 -11,   -1, 	  -4,    0, 	   0,   -9
+.2byte  -14,   -4, 	  -7,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -14,   -5, 	  -3,   -2, 	  -9,    0, 	   0,   -9
+.2byte  -11,   -3, 	 -10,   -2, 	  -9,    0, 	   0,   -9
+.2byte  -13,  -14, 	 -14,  -16, 	 -14,  -12, 	   0,  -16
+.2byte   -8,   -3, 	  -9,    3, 	   0,    1, 	   0,  -10
+.2byte   -9,   -2, 	  -8,    2, 	  -2,    2, 	   0,  -10
+.2byte   -9,   -3, 	  -3,   -1, 	  -4,    3, 	   0,  -10
+.2byte   -7,    1, 	 -11,    3, 	  -2,    5, 	  -1,  -10
+.2byte  -11,  -10, 	 -16,   -9, 	  -9,   -5, 	   0,  -12
+.2byte    0,   -2, 	  -4,    3, 	   2,    0, 	   0,   -9
+.2byte   -1,   -1, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte   -2,   -2, 	  -4,    0, 	   2,    3, 	  -1,   -9
+.2byte   -3,   -8, 	 -12,  -10, 	   2,   -1, 	  -2,  -11
+.2byte    0,    0, 	   3,    4, 	   1,    1, 	   0,   -7
+.2byte    0,    0, 	   3,    4, 	   1,    1, 	   0,   -7
+.2byte    7,   -3, 	   8,    3, 	  -1,    1, 	  -1,  -10
+.2byte    8,   -2, 	   7,    2, 	   1,    2, 	  -1,  -10
+.2byte    8,   -3, 	   2,   -1, 	   3,    3, 	  -1,  -10
+.2byte    8,   -9, 	  11,   -9, 	   1,   -1, 	  -2,  -11
+.2byte    9,   -1, 	   4,    5, 	   2,    2, 	   0,   -9
+.2byte    9,   -1, 	   4,    5, 	   2,    2, 	   0,   -9
+.2byte   12,   -5, 	  10,   -1, 	   3,    0, 	  -1,   -9
+.2byte   13,   -4, 	   6,   -2, 	   5,    0, 	  -1,  -10
+.2byte   13,   -5, 	   2,   -2, 	   8,    0, 	  -1,   -9
+.2byte   10,  -13, 	   4,  -19, 	   4,   -4, 	  -2,  -12
+.2byte   13,   -3, 	  11,    2, 	   4,    0, 	   0,  -10
+.2byte   13,   -3, 	  11,    2, 	   4,    0, 	   0,  -10
+.2byte    7,  -10, 	   5,   -7, 	   3,   -1, 	  -1,   -8
+.2byte    7,   -9, 	   1,   -4, 	   6,   -2, 	  -1,   -8
+.2byte    6,  -11, 	  -1,   -2, 	   8,   -3, 	  -1,   -8
+.2byte    2,  -19, 	  -4,  -18, 	   6,   -5, 	  -1,   -9
+.2byte    7,   -9, 	  10,   -3, 	   6,   -2, 	   0,   -8
+.2byte    7,   -9, 	  10,   -3, 	   6,   -2, 	   0,   -8
+.2byte   -2,  -14, 	   4,   -9, 	  -4,   -4, 	  -1,  -11
+.2byte   -1,  -14, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -4, 	  -6,   -9, 	  -1,  -11
+.2byte    2,  -15, 	   9,  -14, 	  -2,  -10, 	  -1,  -10
+.2byte   -2,   -9, 	  -7,   -7, 	  -4,   -5, 	  -2,   -8
+.2byte   -2,   -9, 	  -7,   -7, 	  -4,   -5, 	  -2,   -8
+.2byte   -8,  -10, 	  -6,   -7, 	  -4,   -1, 	   0,   -8
+.2byte   -8,   -9, 	  -2,   -4, 	  -7,   -2, 	   0,   -8
+.2byte   -7,  -11, 	   0,   -2, 	  -9,   -3, 	   0,   -8
+.2byte   -3,  -19, 	   3,  -18, 	  -7,   -5, 	   0,   -9
+.2byte   -8,   -9, 	 -11,   -3, 	  -7,   -2, 	  -1,   -8
+.2byte   -8,   -9, 	 -11,   -3, 	  -7,   -2, 	  -1,   -8
+.2byte  -13,   -5, 	 -11,   -1, 	  -4,    0, 	   0,   -9
+.2byte  -14,   -4, 	  -7,   -2, 	  -6,    0, 	   0,  -10
+.2byte  -14,   -5, 	  -3,   -2, 	  -9,    0, 	   0,   -9
+.2byte  -11,  -13, 	  -5,  -19, 	  -5,   -4, 	   1,  -12
+.2byte  -14,   -3, 	 -12,    2, 	  -5,    0, 	  -1,  -10
+.2byte  -14,   -3, 	 -12,    2, 	  -5,    0, 	  -1,  -10
+.2byte   -8,   -3, 	  -9,    3, 	   0,    1, 	   0,  -10
+.2byte   -9,   -2, 	  -8,    2, 	  -2,    2, 	   0,  -10
+.2byte   -9,   -3, 	  -3,   -1, 	  -4,    3, 	   0,  -10
+.2byte   -9,   -9, 	 -12,   -9, 	  -2,   -1, 	   1,  -11
+.2byte  -10,   -1, 	  -5,    5, 	  -3,    2, 	  -1,   -9
+.2byte  -10,   -1, 	  -5,    5, 	  -3,    2, 	  -1,   -9
+.2byte   -1,   -1, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte   -1,  -14, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -1,    1, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte    8,   -2, 	   7,    2, 	   1,    2, 	  -1,  -10
+.2byte    6,  -13, 	   6,    1, 	   1,    2, 	  -1,  -11
+.2byte    8,    2, 	   7,    0, 	   1,    2, 	   2,   -9
+.2byte   13,   -4, 	   6,   -2, 	   5,    0, 	  -1,  -10
+.2byte    6,  -18, 	   5,   -3, 	   4,    0, 	  -2,  -10
+.2byte   15,   -4, 	   6,   -2, 	   5,    0, 	   3,  -10
+.2byte    7,   -9, 	   1,   -4, 	   6,   -2, 	  -1,   -8
+.2byte    5,  -17, 	   1,   -3, 	   6,   -1, 	  -2,   -8
+.2byte    8,   -7, 	   1,   -4, 	   6,   -1, 	   0,   -8
+.2byte   -1,  -14, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -20, 	  -4,    2, 	   2,    2, 	  -1,   -9
+.2byte   -1,   -9, 	   5,   -6, 	  -7,   -6, 	  -1,   -7
+.2byte   -8,   -9, 	  -2,   -4, 	  -7,   -2, 	   0,   -8
+.2byte   -6,  -17, 	  -2,   -3, 	  -7,   -1, 	   1,   -8
+.2byte   -9,   -7, 	  -2,   -4, 	  -7,   -1, 	  -1,   -8
+.2byte  -14,   -4, 	  -7,   -2, 	  -6,    0, 	   0,  -10
+.2byte   -7,  -18, 	  -6,   -3, 	  -5,    0, 	   1,  -10
+.2byte  -16,   -4, 	  -7,   -2, 	  -6,    0, 	  -4,  -10
+.2byte   -9,   -2, 	  -8,    2, 	  -2,    2, 	   0,  -10
+.2byte   -7,  -13, 	  -7,    1, 	  -2,    2, 	   0,  -11
+.2byte   -9,    2, 	  -8,    0, 	  -2,    2, 	  -3,   -9
+.2byte   -1,  -10, 	  -3,    2, 	   1,    2, 	  -1,   -7
+.2byte   -5,  -12, 	  -6,    2, 	  -3,    3, 	   0,   -7
+.2byte   -9,  -14, 	  -7,   -2, 	  -6,    0, 	   1,  -10
+.2byte   -5,  -16, 	  -3,   -4, 	  -7,   -3, 	   1,  -10
+.2byte   -1,  -17, 	   4,   -5, 	  -6,   -5, 	  -1,   -9
+.2byte    4,  -16, 	   2,   -4, 	   6,   -3, 	  -2,  -10
+.2byte    8,  -14, 	   6,   -2, 	   5,    0, 	  -2,  -10
+.2byte    4,  -12, 	   5,    2, 	   2,    3, 	  -1,   -7
+.2byte   -6,   -1, 	 -11,    0, 	  -5,    2, 	   1,   -6
+.2byte   -6,   -1, 	 -11,    0, 	  -5,    2, 	   1,   -6
+.2byte    0,   -1, 	  -5,    3, 	   5,    3, 	   0,   -8
+.2byte    6,   -2, 	  11,    0, 	   4,    2, 	  -1,  -10
+.2byte    9,   -2, 	  13,   -2, 	  11,    1, 	  -2,   -7
+.2byte    6,   -5, 	   7,   -8, 	  12,   -6, 	  -2,   -4
+.2byte   -1,   -9, 	   5,  -10, 	  -7,  -10, 	  -1,   -4
+.2byte   -7,   -5, 	  -8,   -8, 	 -13,   -6, 	   1,   -4
+.2byte  -10,   -2, 	 -14,   -2, 	 -12,    1, 	   1,   -7
+.2byte   -5,   -2, 	 -10,    0, 	  -3,    2, 	   2,  -10
+.2byte   -1,   -1, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte   -1,  -10, 	  -3,    2, 	   1,    2, 	  -1,   -7
+.2byte    8,   -2, 	   7,    2, 	   1,    2, 	  -1,  -10
+.2byte    4,  -13, 	   5,    1, 	   2,    2, 	  -1,   -8
+.2byte   13,   -4, 	   6,   -2, 	   5,    0, 	  -1,  -10
+.2byte    7,  -14, 	   5,   -2, 	   4,    0, 	  -3,  -10
+.2byte    7,   -9, 	   1,   -4, 	   6,   -2, 	  -1,   -8
+.2byte    3,  -16, 	   1,   -4, 	   5,   -3, 	  -3,  -10
+.2byte   -1,  -14, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -17, 	   4,   -5, 	  -6,   -5, 	  -1,   -9
+.2byte   -8,   -9, 	  -2,   -4, 	  -7,   -2, 	   0,   -8
+.2byte   -4,  -16, 	  -2,   -4, 	  -6,   -3, 	   2,  -10
+.2byte  -14,   -4, 	  -7,   -2, 	  -6,    0, 	   0,  -10
+.2byte   -9,  -14, 	  -7,   -2, 	  -6,    0, 	   1,  -10
+.2byte   -9,   -2, 	  -8,    2, 	  -2,    2, 	   0,  -10
+.2byte   -5,  -13, 	  -6,    1, 	  -3,    2, 	   0,   -8
+.2byte   -1,    0, 	  -6,    3, 	   4,    3, 	  -1,  -10
+.2byte   -7,    1, 	 -11,    3, 	  -2,    5, 	  -1,  -10
+.2byte  -11,   -3, 	 -10,   -2, 	  -9,    0, 	   0,   -9
+.2byte   -7,   -7, 	  -3,   -6, 	  -9,   -3, 	   0,  -10
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -7
+.2byte    6,   -7, 	   2,   -6, 	   8,   -3, 	  -1,  -10
+.2byte   10,   -3, 	   9,   -2, 	   8,    0, 	  -1,   -9
+.2byte    6,    1, 	  10,    3, 	   1,    5, 	   0,  -10
+.2byte   -1,    0, 	  -6,    3, 	   4,    3, 	  -1,  -10
+.2byte    6,    1, 	  10,    3, 	   1,    5, 	   0,  -10
+.2byte   10,   -3, 	   9,   -2, 	   8,    0, 	  -1,   -9
+.2byte    6,   -7, 	   2,   -6, 	   8,   -3, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -7
+.2byte   -7,   -7, 	  -3,   -6, 	  -9,   -3, 	   0,  -10
+.2byte  -11,   -3, 	 -10,   -2, 	  -9,    0, 	   0,   -9
+.2byte   -7,    1, 	 -11,    3, 	  -2,    5, 	  -1,  -10
+.2byte   -1,   -1, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte   -1,  -14, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -1,    1, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte    8,   -2, 	   7,    2, 	   1,    2, 	  -1,  -10
+.2byte    6,  -13, 	   6,    1, 	   1,    2, 	  -1,  -11
+.2byte    8,    2, 	   7,    0, 	   1,    2, 	   2,   -9
+.2byte   13,   -4, 	   6,   -2, 	   5,    0, 	  -1,  -10
+.2byte    6,  -18, 	   5,   -3, 	   4,    0, 	  -2,  -10
+.2byte   15,   -4, 	   6,   -2, 	   5,    0, 	   3,  -10
+.2byte    7,   -9, 	   1,   -4, 	   6,   -2, 	  -1,   -8
+.2byte    5,  -17, 	   1,   -3, 	   6,   -1, 	  -2,   -8
+.2byte    8,   -7, 	   1,   -4, 	   6,   -1, 	   0,   -8
+.2byte   -1,  -14, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -20, 	  -4,    2, 	   2,    2, 	  -1,   -9
+.2byte   -1,   -9, 	   5,   -6, 	  -7,   -6, 	  -1,   -7
+.2byte   -8,   -9, 	  -2,   -4, 	  -7,   -2, 	   0,   -8
+.2byte   -6,  -17, 	  -2,   -3, 	  -7,   -1, 	   1,   -8
+.2byte   -9,   -7, 	  -2,   -4, 	  -7,   -1, 	  -1,   -8
+.2byte  -14,   -4, 	  -7,   -2, 	  -6,    0, 	   0,  -10
+.2byte   -7,  -18, 	  -6,   -3, 	  -5,    0, 	   1,  -10
+.2byte  -16,   -4, 	  -7,   -2, 	  -6,    0, 	  -4,  -10
+.2byte   -9,   -2, 	  -8,    2, 	  -2,    2, 	   0,  -10
+.2byte   -7,  -13, 	  -7,    1, 	  -2,    2, 	   0,  -11
+.2byte   -9,    2, 	  -8,    0, 	  -2,    2, 	  -3,   -9
+.2byte   -1,  -10, 	  -3,    2, 	   1,    2, 	  -1,   -7
+.2byte   -5,  -12, 	  -6,    2, 	  -3,    3, 	   0,   -7
+.2byte   -9,  -14, 	  -7,   -2, 	  -6,    0, 	   1,  -10
+.2byte   -5,  -16, 	  -3,   -4, 	  -7,   -3, 	   1,  -10
+.2byte   -1,  -17, 	   4,   -5, 	  -6,   -5, 	  -1,   -9
+.2byte    4,  -16, 	   2,   -4, 	   6,   -3, 	  -2,  -10
+.2byte    8,  -14, 	   6,   -2, 	   5,    0, 	  -2,  -10
+.2byte    4,  -12, 	   5,    2, 	   2,    3, 	  -1,   -7
+.2byte    0,   -2, 	  -4,    3, 	   2,    0, 	   0,   -9
+.2byte   -8,   -3, 	  -9,    3, 	   0,    1, 	   0,  -10
+.2byte  -13,   -5, 	 -11,   -1, 	  -4,    0, 	   0,   -9
+.2byte   -8,  -10, 	  -6,   -7, 	  -4,   -1, 	   0,   -8
+.2byte   -2,  -14, 	   4,   -9, 	  -4,   -4, 	  -1,  -11
+.2byte    7,  -10, 	   5,   -7, 	   3,   -1, 	  -1,   -8
+.2byte   12,   -5, 	  10,   -1, 	   3,    0, 	  -1,   -9
+.2byte    7,   -3, 	   8,    3, 	  -1,    1, 	  -1,  -10
+sPersianAnimTable1:
+.4byte sPersianAnims_1_1
+.4byte sPersianAnims_1_2
+.4byte sPersianAnims_1_3
+.4byte sPersianAnims_1_4
+.4byte sPersianAnims_1_5
+.4byte sPersianAnims_1_6
+.4byte sPersianAnims_1_7
+.4byte sPersianAnims_1_8
+sPersianAnimTable2:
+.4byte sPersianAnims_2_1
+.4byte sPersianAnims_2_2
+.4byte sPersianAnims_2_3
+.4byte sPersianAnims_2_4
+.4byte sPersianAnims_2_5
+.4byte sPersianAnims_2_6
+.4byte sPersianAnims_2_7
+.4byte sPersianAnims_2_8
+sPersianAnimTable3:
+.4byte sPersianAnims_3_1
+.4byte sPersianAnims_3_2
+.4byte sPersianAnims_3_3
+.4byte sPersianAnims_3_4
+.4byte sPersianAnims_3_5
+.4byte sPersianAnims_3_6
+.4byte sPersianAnims_3_7
+.4byte sPersianAnims_3_8
+sPersianAnimTable4:
+.4byte sPersianAnims_4_1
+.4byte sPersianAnims_4_2
+.4byte sPersianAnims_4_3
+.4byte sPersianAnims_4_4
+.4byte sPersianAnims_4_5
+.4byte sPersianAnims_4_6
+.4byte sPersianAnims_4_7
+.4byte sPersianAnims_4_8
+sPersianAnimTable5:
+.4byte sPersianAnims_5_1
+.4byte sPersianAnims_5_2
+.4byte sPersianAnims_5_3
+.4byte sPersianAnims_5_4
+.4byte sPersianAnims_5_5
+.4byte sPersianAnims_5_6
+.4byte sPersianAnims_5_7
+.4byte sPersianAnims_5_8
+sPersianAnimTable6:
+.4byte sPersianAnims_6_1
+.4byte sPersianAnims_6_1
+.4byte sPersianAnims_6_1
+.4byte sPersianAnims_6_1
+.4byte sPersianAnims_6_1
+.4byte sPersianAnims_6_1
+.4byte sPersianAnims_6_1
+.4byte sPersianAnims_6_1
+sPersianAnimTable7:
+.4byte sPersianAnims_7_1
+.4byte sPersianAnims_7_2
+.4byte sPersianAnims_7_3
+.4byte sPersianAnims_7_4
+.4byte sPersianAnims_7_5
+.4byte sPersianAnims_7_6
+.4byte sPersianAnims_7_7
+.4byte sPersianAnims_7_8
+sPersianAnimTable8:
+.4byte sPersianAnims_8_1
+.4byte sPersianAnims_8_2
+.4byte sPersianAnims_8_3
+.4byte sPersianAnims_8_4
+.4byte sPersianAnims_8_5
+.4byte sPersianAnims_8_6
+.4byte sPersianAnims_8_7
+.4byte sPersianAnims_8_8
+sPersianAnimTable9:
+.4byte sPersianAnims_9_1
+.4byte sPersianAnims_9_2
+.4byte sPersianAnims_9_3
+.4byte sPersianAnims_9_4
+.4byte sPersianAnims_9_5
+.4byte sPersianAnims_9_6
+.4byte sPersianAnims_9_7
+.4byte sPersianAnims_9_8
+sPersianAnimTable10:
+.4byte sPersianAnims_10_1
+.4byte sPersianAnims_10_2
+.4byte sPersianAnims_10_3
+.4byte sPersianAnims_10_4
+.4byte sPersianAnims_10_5
+.4byte sPersianAnims_10_6
+.4byte sPersianAnims_10_7
+.4byte sPersianAnims_10_8
+sPersianAnimTable11:
+.4byte sPersianAnims_11_1
+.4byte sPersianAnims_11_2
+.4byte sPersianAnims_11_3
+.4byte sPersianAnims_11_4
+.4byte sPersianAnims_11_5
+.4byte sPersianAnims_11_6
+.4byte sPersianAnims_11_7
+.4byte sPersianAnims_11_8
+sPersianAnimTable12:
+.4byte sPersianAnims_12_1
+.4byte sPersianAnims_12_2
+.4byte sPersianAnims_12_3
+.4byte sPersianAnims_12_4
+.4byte sPersianAnims_12_5
+.4byte sPersianAnims_12_6
+.4byte sPersianAnims_12_7
+.4byte sPersianAnims_12_8
+sPersianAnimTable13:
+.4byte sPersianAnims_13_1
+.4byte sPersianAnims_13_2
+.4byte sPersianAnims_13_3
+.4byte sPersianAnims_13_4
+.4byte sPersianAnims_13_5
+.4byte sPersianAnims_13_6
+.4byte sPersianAnims_13_7
+.4byte sPersianAnims_13_8
+sAxAnimationsPersian:
+.4byte sPersianAnimTable1
+.4byte sPersianAnimTable2
+.4byte sPersianAnimTable3
+.4byte sPersianAnimTable4
+.4byte sPersianAnimTable5
+.4byte sPersianAnimTable6
+.4byte sPersianAnimTable7
+.4byte sPersianAnimTable8
+.4byte sPersianAnimTable9
+.4byte sPersianAnimTable10
+.4byte sPersianAnimTable11
+.4byte sPersianAnimTable12
+.4byte sPersianAnimTable13
+sAxSpritesPersian:
+.4byte sPersianSprites1
+.4byte sPersianSprites2
+.4byte sPersianSprites3
+.4byte sPersianSprites4
+.4byte sPersianSprites5
+.4byte sPersianSprites6
+.4byte sPersianSprites7
+.4byte sPersianSprites8
+.4byte sPersianSprites9
+.4byte sPersianSprites10
+.4byte sPersianSprites11
+.4byte sPersianSprites12
+.4byte sPersianSprites13
+.4byte sPersianSprites14
+.4byte sPersianSprites15
+.4byte sPersianSprites16
+.4byte sPersianSprites17
+.4byte sPersianSprites18
+.4byte sPersianSprites19
+.4byte sPersianSprites20
+.4byte sPersianSprites21
+.4byte sPersianSprites22
+.4byte sPersianSprites23
+.4byte sPersianSprites24
+.4byte sPersianSprites25
+.4byte sPersianSprites26
+.4byte sPersianSprites27
+.4byte sPersianSprites28
+.4byte sPersianSprites29
+.4byte sPersianSprites30
+.4byte sPersianSprites31
+.4byte sPersianSprites32
+.4byte sPersianSprites33
+.4byte sPersianSprites34
+.4byte sPersianSprites35
+.4byte sPersianSprites36
+.4byte sPersianSprites37
+.4byte sPersianSprites38
+.4byte sPersianSprites39
+.4byte sPersianSprites40
+.4byte sPersianSprites41
+.4byte sPersianSprites42
+.4byte sPersianSprites43
+.4byte sPersianSprites44
+.4byte sPersianSprites45
+.4byte sPersianSprites46
+.4byte sPersianSprites47
+.4byte sPersianSprites48
+.4byte sPersianSprites49
+.4byte sPersianSprites50
+.4byte sPersianSprites51
+.4byte sPersianSprites52
+.4byte sPersianSprites53
+.4byte sPersianSprites54
+.4byte sPersianSprites55
+.4byte sPersianSprites56
+.4byte sPersianSprites57
+.4byte sPersianSprites58
+.4byte sPersianSprites59
+.4byte sPersianSprites60
+.4byte sPersianSprites61
+.4byte sPersianSprites62
+.4byte sPersianSprites63
+.4byte sPersianSprites64
+.4byte sPersianSprites65
+.4byte sPersianSprites66
+.4byte sPersianSprites67
+.4byte sPersianSprites68
+.4byte sPersianSprites69
+sAxMainPersian:
+ax_main sAxPosesPersian, sAxAnimationsPersian, 13, sAxSpritesPersian, sAxPositionsPersian

--- a/data/ax/phanpy.inc
+++ b/data/ax/phanpy.inc
@@ -1,0 +1,2728 @@
+.global gAxPhanpy
+gAxPhanpy:
+ax_siro sAxMainPhanpy
+sPhanpyPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose4:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose5:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose6:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose7:
+ax_pose 6, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose8:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose9:
+ax_pose 8, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose10:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose11:
+ax_pose 10, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose12:
+ax_pose 11, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose16:
+ax_pose 9, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose17:
+ax_pose 10, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose18:
+ax_pose 11, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose22:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose23:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose24:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose28:
+ax_pose 15, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose29:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose30:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose31:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose32:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose33:
+ax_pose 6, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose34:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose35:
+ax_pose 8, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose36:
+ax_pose 17, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose37:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose38:
+ax_pose 10, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose39:
+ax_pose 11, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose40:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose42:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose43:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose44:
+ax_pose 19, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose45:
+ax_pose 9, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose46:
+ax_pose 10, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose47:
+ax_pose 11, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose48:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose49:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose50:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose51:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose52:
+ax_pose 17, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose53:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose54:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose55:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose56:
+ax_pose 16, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose57:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose58:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose59:
+ax_pose 2, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose60:
+ax_pose 15, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose61:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose62:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose63:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose64:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose65:
+ax_pose 6, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose66:
+ax_pose 7, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose67:
+ax_pose 8, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose68:
+ax_pose 17, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose69:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose70:
+ax_pose 10, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose71:
+ax_pose 11, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose72:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose74:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose75:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose76:
+ax_pose 19, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose77:
+ax_pose 9, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose78:
+ax_pose 10, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose79:
+ax_pose 11, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose80:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose81:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose82:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose83:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose84:
+ax_pose 17, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose85:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose86:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose87:
+ax_pose 5, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose88:
+ax_pose 16, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose89:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose90:
+ax_pose 20, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose91:
+ax_pose 15, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose92:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose93:
+ax_pose 21, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose94:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose95:
+ax_pose 6, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose96:
+ax_pose 22, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose97:
+ax_pose 17, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose98:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose99:
+ax_pose 23, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose100:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose102:
+ax_pose 24, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose103:
+ax_pose 19, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose104:
+ax_pose 9, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose105:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose106:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose107:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose108:
+ax_pose 22, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose109:
+ax_pose 17, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose110:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose111:
+ax_pose 21, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose112:
+ax_pose 16, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose113:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose114:
+ax_pose 15, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose115:
+ax_pose 25, 0x41f3, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose116:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose117:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose118:
+ax_pose 26, 0x41f3, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose119:
+ax_pose 6, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose120:
+ax_pose 17, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose121:
+ax_pose 27, 0x41f2, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose122:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose123:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose124:
+ax_pose 28, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose125:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose126:
+ax_pose 19, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose127:
+ax_pose 29, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose128:
+ax_pose 9, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose129:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose130:
+ax_pose 28, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose131:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose132:
+ax_pose 17, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose133:
+ax_pose 27, 0x41f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose134:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose135:
+ax_pose 16, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose136:
+ax_pose 26, 0x41f3, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose137:
+ax_pose 30, 0x01f0, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose138:
+ax_pose 31, 0x01f0, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose139:
+ax_pose 32, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sPhanpyPose140:
+ax_pose 33, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose141:
+ax_pose 34, 0x01e2, 0x90e8, 0x0c00
+ax_pose_terminator
+sPhanpyPose142:
+ax_pose 35, 0x01e2, 0x90e7, 0x0c00
+ax_pose_terminator
+sPhanpyPose143:
+ax_pose 36, 0x01e4, 0x80f5, 0x0c00
+ax_pose_terminator
+sPhanpyPose144:
+ax_pose 35, 0x01e2, 0x80f9, 0x0c00
+ax_pose_terminator
+sPhanpyPose145:
+ax_pose 34, 0x01e2, 0x80f8, 0x0c00
+ax_pose_terminator
+sPhanpyPose146:
+ax_pose 33, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose147:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose148:
+ax_pose 20, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose149:
+ax_pose 15, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose150:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose151:
+ax_pose 21, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose152:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose153:
+ax_pose 6, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose154:
+ax_pose 22, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose155:
+ax_pose 17, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose156:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose157:
+ax_pose 23, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose158:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose159:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose160:
+ax_pose 24, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose161:
+ax_pose 19, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose162:
+ax_pose 9, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose163:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose164:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose165:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose166:
+ax_pose 22, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose167:
+ax_pose 17, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose168:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose169:
+ax_pose 21, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose170:
+ax_pose 16, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose171:
+ax_pose 20, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose172:
+ax_pose 21, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose173:
+ax_pose 22, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose174:
+ax_pose 23, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose175:
+ax_pose 24, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose176:
+ax_pose 23, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose177:
+ax_pose 22, 0x01ec, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose178:
+ax_pose 21, 0x01ed, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose179:
+ax_pose 15, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose180:
+ax_pose 16, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sPhanpyPose181:
+ax_pose 17, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose182:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose183:
+ax_pose 19, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose184:
+ax_pose 18, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose185:
+ax_pose 17, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose186:
+ax_pose 16, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose187:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose188:
+ax_pose 20, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose189:
+ax_pose 15, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose190:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose191:
+ax_pose 21, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose192:
+ax_pose 16, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPhanpyPose193:
+ax_pose 6, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose194:
+ax_pose 22, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose195:
+ax_pose 17, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose196:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose197:
+ax_pose 23, 0x01e9, 0x90f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose198:
+ax_pose 18, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose199:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose200:
+ax_pose 24, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose201:
+ax_pose 19, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose202:
+ax_pose 9, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose203:
+ax_pose 23, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose204:
+ax_pose 18, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose205:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose206:
+ax_pose 22, 0x01eb, 0x80ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose207:
+ax_pose 17, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose208:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose209:
+ax_pose 21, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose210:
+ax_pose 16, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose211:
+ax_pose 25, 0x41f3, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose212:
+ax_pose 26, 0x41f3, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose213:
+ax_pose 27, 0x41f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose214:
+ax_pose 28, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose215:
+ax_pose 29, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose216:
+ax_pose 28, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose217:
+ax_pose 27, 0x41f2, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose218:
+ax_pose 26, 0x41f3, 0x90ee, 0x0c00
+ax_pose_terminator
+sPhanpyPose219:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose220:
+ax_pose 3, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPhanpyPose221:
+ax_pose 6, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sPhanpyPose222:
+ax_pose 9, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sPhanpyPose223:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPhanpyPose224:
+ax_pose 9, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sPhanpyPose225:
+ax_pose 6, 0x01eb, 0x90f1, 0x0c00
+ax_pose_terminator
+sPhanpyPose226:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sPhanpyAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 3, 0, 24, 0, -3, 0, -3,
+ax_anim 3, 0, 26, 0, -3, 0, -3,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 19, 0, 19,
+ax_anim 2, 1, 24, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 19, 0, 19,
+ax_anim 2, 0, 24, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sPhanpyAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 3, 0, 28, -3, -3, -3, -3,
+ax_anim 3, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 28, -3, -3, -3, -3,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 20, 18, 20,
+ax_anim 2, 1, 28, 19, 19, 19, 19,
+ax_anim 2, 0, 28, 18, 20, 18, 20,
+ax_anim 2, 0, 28, 19, 19, 19, 19,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sPhanpyAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 3, 0, 32, -3, 0, -3, 0,
+ax_anim 3, 0, 34, -3, 0, -3, 0,
+ax_anim 2, 0, 32, -3, 0, -3, 0,
+ax_anim 2, 0, 33, -3, 0, -3, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 33, 6, 0, 6, 0,
+ax_anim_terminator
+sPhanpyAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 3, 0, 36, -3, 3, -3, 3,
+ax_anim 3, 0, 38, -3, 3, -3, 3,
+ax_anim 2, 0, 36, -3, 3, -3, 3,
+ax_anim 2, 0, 37, -3, 3, -3, 3,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 12, -13, 12, -13,
+ax_anim 2, 0, 36, 19, -21, 19, -21,
+ax_anim 2, 1, 36, 20, -20, 20, -20,
+ax_anim 2, 0, 36, 19, -21, 19, -21,
+ax_anim 2, 0, 36, 20, -20, 20, -20,
+ax_anim 2, 0, 37, 6, -6, 6, -6,
+ax_anim_terminator
+sPhanpyAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 3, 0, 40, 0, 3, 0, 3,
+ax_anim 3, 0, 42, 0, 3, 0, 3,
+ax_anim 2, 0, 40, 0, 3, 0, 3,
+ax_anim 2, 0, 41, 0, 3, 0, 3,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -19, 0, -19,
+ax_anim 2, 1, 40, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -19, 0, -19,
+ax_anim 2, 0, 40, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -6, 0, -6,
+ax_anim_terminator
+sPhanpyAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 3, 0, 44, 3, 3, 3, 3,
+ax_anim 3, 0, 46, 3, 3, 3, 3,
+ax_anim 2, 0, 44, 3, 3, 3, 3,
+ax_anim 2, 0, 45, 3, 3, 3, 3,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -12, -13, -12, -13,
+ax_anim 2, 0, 44, -19, -21, -19, -21,
+ax_anim 2, 1, 44, -20, -20, -20, -20,
+ax_anim 2, 0, 44, -19, -21, -19, -21,
+ax_anim 2, 0, 44, -20, -20, -20, -20,
+ax_anim 2, 0, 45, -6, -6, -6, -6,
+ax_anim_terminator
+sPhanpyAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 3, 0, 48, 3, 0, 3, 0,
+ax_anim 3, 0, 50, 3, 0, 3, 0,
+ax_anim 2, 0, 48, 3, 0, 3, 0,
+ax_anim 2, 0, 49, 3, 0, 3, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -18, 0, -18, 0,
+ax_anim 2, 1, 48, -18, 1, -18, 1,
+ax_anim 2, 0, 48, -18, 0, -18, 0,
+ax_anim 2, 0, 48, -18, 1, -18, 1,
+ax_anim 2, 0, 49, -6, 0, -6, 0,
+ax_anim_terminator
+sPhanpyAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 3, 0, 52, 3, -3, 3, -3,
+ax_anim 3, 0, 54, 3, -3, 3, -3,
+ax_anim 2, 0, 52, 3, -3, 3, -3,
+ax_anim 2, 0, 53, 3, -3, 3, -3,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -18, 20, -18, 20,
+ax_anim 2, 1, 52, -19, 19, -19, 19,
+ax_anim 2, 0, 52, -18, 20, -18, 20,
+ax_anim 2, 0, 52, -19, 19, -19, 19,
+ax_anim 2, 0, 53, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 3, 0, 56, 0, -3, 0, -3,
+ax_anim 3, 0, 58, 0, -3, 0, -3,
+ax_anim 2, 0, 56, 0, -3, 0, -3,
+ax_anim 2, 0, 57, 0, -3, 0, -3,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 19, 0, 19,
+ax_anim 2, 1, 56, 1, 19, 1, 19,
+ax_anim 2, 0, 56, 0, 19, 0, 19,
+ax_anim 2, 0, 56, 1, 19, 1, 19,
+ax_anim 2, 0, 57, 0, 6, 0, 6,
+ax_anim_terminator
+sPhanpyAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 3, 0, 60, -3, -3, -3, -3,
+ax_anim 3, 0, 62, -3, -3, -3, -3,
+ax_anim 2, 0, 60, -3, -3, -3, -3,
+ax_anim 2, 0, 61, -3, -3, -3, -3,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 18, 20, 18, 20,
+ax_anim 2, 1, 60, 19, 19, 19, 19,
+ax_anim 2, 0, 60, 18, 20, 18, 20,
+ax_anim 2, 0, 60, 19, 19, 19, 19,
+ax_anim 2, 0, 61, 6, 6, 6, 6,
+ax_anim_terminator
+sPhanpyAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 3, 0, 64, -3, 0, -3, 0,
+ax_anim 3, 0, 66, -3, 0, -3, 0,
+ax_anim 2, 0, 64, -3, 0, -3, 0,
+ax_anim 2, 0, 65, -3, 0, -3, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 18, 0, 18, 0,
+ax_anim 2, 1, 64, 18, 1, 18, 1,
+ax_anim 2, 0, 64, 18, 0, 18, 0,
+ax_anim 2, 0, 64, 18, 1, 18, 1,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim_terminator
+sPhanpyAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 3, 0, 68, -3, 3, -3, 3,
+ax_anim 3, 0, 70, -3, 3, -3, 3,
+ax_anim 2, 0, 68, -3, 3, -3, 3,
+ax_anim 2, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 5, -6, 5, -6,
+ax_anim 1, 0, 70, 12, -13, 12, -13,
+ax_anim 2, 0, 68, 19, -21, 19, -21,
+ax_anim 2, 1, 68, 20, -20, 20, -20,
+ax_anim 2, 0, 68, 19, -21, 19, -21,
+ax_anim 2, 0, 68, 20, -20, 20, -20,
+ax_anim 2, 0, 69, 6, -6, 6, -6,
+ax_anim_terminator
+sPhanpyAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 3, 0, 72, 0, 3, 0, 3,
+ax_anim 3, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 72, 0, -19, 0, -19,
+ax_anim 2, 1, 72, 1, -19, 1, -19,
+ax_anim 2, 0, 72, 0, -19, 0, -19,
+ax_anim 2, 0, 72, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -6, 0, -6,
+ax_anim_terminator
+sPhanpyAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 3, 0, 76, 3, 3, 3, 3,
+ax_anim 3, 0, 78, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -5, -6, -5, -6,
+ax_anim 1, 0, 78, -12, -13, -12, -13,
+ax_anim 2, 0, 76, -19, -21, -19, -21,
+ax_anim 2, 1, 76, -20, -20, -20, -20,
+ax_anim 2, 0, 76, -19, -21, -19, -21,
+ax_anim 2, 0, 76, -20, -20, -20, -20,
+ax_anim 2, 0, 77, -6, -6, -6, -6,
+ax_anim_terminator
+sPhanpyAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 3, 0, 80, 3, 0, 3, 0,
+ax_anim 3, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 81, 3, 0, 3, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -18, 0, -18, 0,
+ax_anim 2, 1, 80, -18, 1, -18, 1,
+ax_anim 2, 0, 80, -18, 0, -18, 0,
+ax_anim 2, 0, 80, -18, 1, -18, 1,
+ax_anim 2, 0, 81, -6, 0, -6, 0,
+ax_anim_terminator
+sPhanpyAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 3, 0, 84, 3, -3, 3, -3,
+ax_anim 3, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 84, 3, -3, 3, -3,
+ax_anim 2, 0, 85, 3, -3, 3, -3,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 84, -18, 20, -18, 20,
+ax_anim 2, 1, 84, -19, 19, -19, 19,
+ax_anim 2, 0, 84, -18, 20, -18, 20,
+ax_anim 2, 0, 84, -19, 19, -19, 19,
+ax_anim 2, 0, 85, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 3, 0, 89, 0, -3, 0, -3,
+ax_anim 5, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 1, 90, -1, 2, -1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 90, -1, 2, -1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 90, -1, 2, -1, 2,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_4_2:
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 3, 0, 92, -3, -3, -3, -3,
+ax_anim 5, 2, 92, -3, -3, -3, -3,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 1, 93, 1, 3, 1, 3,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 1, 3, 1, 3,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 1, 3, 1, 3,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sPhanpyAnims_4_3:
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 3, 0, 95, -3, 0, -3, 0,
+ax_anim 5, 2, 95, -3, 0, -3, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 1, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sPhanpyAnims_4_4:
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 3, 0, 98, -3, 3, -3, 3,
+ax_anim 5, 2, 98, -3, 3, -3, 3,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 1, 99, 1, -3, 1, -3,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 1, -3, 1, -3,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 1, -3, 1, -3,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sPhanpyAnims_4_5:
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 3, 0, 101, 0, 3, 0, 3,
+ax_anim 5, 2, 101, 0, 3, 0, 3,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 1, 102, -1, -2, -1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, -1, -2, -1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, -1, -2, -1, -2,
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_4_6:
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 3, 0, 104, 3, 3, 3, 3,
+ax_anim 5, 2, 104, 3, 3, 3, 3,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 1, 105, -1, -3, -1, -3,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -1, -3, -1, -3,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -1, -3, -1, -3,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sPhanpyAnims_4_7:
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 3, 0, 107, 3, 0, 3, 0,
+ax_anim 5, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 1, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sPhanpyAnims_4_8:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 3, 0, 110, 3, -3, 3, -3,
+ax_anim 5, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 1, 111, -1, 3, -1, 3,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -1, 3, -1, 3,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -1, 3, -1, 3,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_5_1:
+ax_anim 1, 0, 113, 0, -2, 0, -2,
+ax_anim 2, 0, 113, 0, -3, 0, -3,
+ax_anim 4, 2, 113, 0, -4, 0, -4,
+ax_anim 2, 0, 113, 0, -3, 0, -3,
+ax_anim 1, 0, 112, 0, -2, 0, -2,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sPhanpyAnims_5_2:
+ax_anim 1, 0, 116, 0, -2, 0, -2,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 4, 2, 116, 0, -4, 0, -4,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 1, 0, 115, 0, -2, 0, -2,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim_terminator
+sPhanpyAnims_5_3:
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 4, 2, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sPhanpyAnims_5_4:
+ax_anim 1, 0, 122, 0, -2, 0, -2,
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 4, 2, 122, 0, -4, 0, -4,
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 1, 0, 121, 0, -2, 0, -2,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 1, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim_terminator
+sPhanpyAnims_5_5:
+ax_anim 1, 0, 125, 0, -2, 0, -2,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 4, 2, 125, 0, -4, 0, -4,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 1, 0, 124, 0, -1, 0, -2,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim_terminator
+sPhanpyAnims_5_6:
+ax_anim 1, 0, 128, 0, -2, 0, -2,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 4, 2, 128, 0, -4, 0, -4,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 1, 0, 127, 0, -2, 0, -2,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 1, 129, -1, 1, -1, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 1, -1, 1,
+ax_anim_terminator
+sPhanpyAnims_5_7:
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 2, 131, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 1, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 1, 0, 1,
+ax_anim_terminator
+sPhanpyAnims_5_8:
+ax_anim 1, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 4, 2, 134, 0, -4, 0, -4,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 1, 0, 133, 0, -2, 0, -2,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sPhanpyAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sPhanpyAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sPhanpyAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sPhanpyAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sPhanpyAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sPhanpyAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sPhanpyAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 20, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim 20, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 20, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 20, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 20, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 4, 6, 4,
+ax_anim 2, 0, 172, 9, 12, 9, 12,
+ax_anim 2, 0, 173, 5, 18, 5, 18,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -5, 18, -5, 18,
+ax_anim 2, 0, 176, -9, 12, -9, 12,
+ax_anim 1, 0, 177, -6, 4, -6, 4,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 11, -1, 11, -1,
+ax_anim 2, 0, 171, 19, 5, 19, 5,
+ax_anim 2, 0, 172, 22, 13, 22, 13,
+ax_anim 3, 0, 173, 20, 19, 20, 19,
+ax_anim 2, 3, 174, 11, 20, 11, 20,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, -1, 8, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 4, -5, 4, -5,
+ax_anim 2, 0, 170, 11, -8, 11, -8,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 19, 0, 19, 0,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 5, 4, 5, 4,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 3, -17, 3, -17,
+ax_anim 2, 0, 170, 11, -24, 11, -24,
+ax_anim 3, 0, 171, 19, -22, 19, -22,
+ax_anim 2, 3, 172, 20, -15, 20, -15,
+ax_anim 2, 0, 173, 17, -7, 17, -7,
+ax_anim 1, 0, 174, 8, 0, 8, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -6, -4, -6, -4,
+ax_anim 2, 0, 176, -10, -12, -10, -12,
+ax_anim 2, 0, 177, -7, -20, -7, -20,
+ax_anim 3, 0, 170, 0, -24, 0, -24,
+ax_anim 2, 3, 171, 7, -20, 7, -20,
+ax_anim 2, 0, 172, 10, -12, 10, -12,
+ax_anim 1, 0, 173, 6, -4, 6, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -3, -17, -3, -17,
+ax_anim 2, 0, 170, -11, -24, -11, -24,
+ax_anim 3, 0, 177, -19, -22, -19, -22,
+ax_anim 2, 3, 176, -20, -15, -20, -15,
+ax_anim 2, 0, 175, -17, -7, -17, -7,
+ax_anim 1, 0, 174, -8, 0, -8, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -4, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -8, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -16, -5,
+ax_anim 3, 0, 176, -19, 0, -18, -2,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -5, 4, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -11, -1, -11, -1,
+ax_anim 2, 0, 177, -19, 5, -19, 5,
+ax_anim 2, 0, 176, -22, 13, -22, 13,
+ax_anim 3, 0, 175, -20, 19, -20, 19,
+ax_anim 2, 3, 174, -11, 20, -11, 20,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 1, 8, 1, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 3, 0, 196, 0, -19, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 3, 0, 202, 0, -19, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPhanpyAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sPhanpyGfx1:
+.incbin "baserom.gba", 0xF5FDBC, 0x200
+sPhanpySprites1:
+ax_sprite sPhanpyGfx1, 0x200
+ax_sprite_terminator
+sPhanpyGfx2:
+.incbin "baserom.gba", 0xF5FFCC, 0x200
+sPhanpySprites2:
+ax_sprite sPhanpyGfx2, 0x200
+ax_sprite_terminator
+sPhanpyGfx3:
+.incbin "baserom.gba", 0xF601DC, 0x200
+sPhanpySprites3:
+ax_sprite sPhanpyGfx3, 0x200
+ax_sprite_terminator
+sPhanpyGfx4:
+.incbin "baserom.gba", 0xF603EC, 0x200
+sPhanpySprites4:
+ax_sprite sPhanpyGfx4, 0x200
+ax_sprite_terminator
+sPhanpyGfx5:
+.incbin "baserom.gba", 0xF605FC, 0x200
+sPhanpySprites5:
+ax_sprite sPhanpyGfx5, 0x200
+ax_sprite_terminator
+sPhanpyGfx6:
+.incbin "baserom.gba", 0xF6080C, 0x200
+sPhanpySprites6:
+ax_sprite sPhanpyGfx6, 0x200
+ax_sprite_terminator
+sPhanpyGfx7:
+.incbin "baserom.gba", 0xF60A1C, 0x200
+sPhanpySprites7:
+ax_sprite sPhanpyGfx7, 0x200
+ax_sprite_terminator
+sPhanpyGfx8:
+.incbin "baserom.gba", 0xF60C2C, 0x200
+sPhanpySprites8:
+ax_sprite sPhanpyGfx8, 0x200
+ax_sprite_terminator
+sPhanpyGfx9:
+.incbin "baserom.gba", 0xF60E3C, 0x200
+sPhanpySprites9:
+ax_sprite sPhanpyGfx9, 0x200
+ax_sprite_terminator
+sPhanpyGfx10:
+.incbin "baserom.gba", 0xF6104C, 0x200
+sPhanpySprites10:
+ax_sprite sPhanpyGfx10, 0x200
+ax_sprite_terminator
+sPhanpyGfx11:
+.incbin "baserom.gba", 0xF6125C, 0x200
+sPhanpySprites11:
+ax_sprite sPhanpyGfx11, 0x200
+ax_sprite_terminator
+sPhanpyGfx12:
+.incbin "baserom.gba", 0xF6146C, 0x200
+sPhanpySprites12:
+ax_sprite sPhanpyGfx12, 0x200
+ax_sprite_terminator
+sPhanpyGfx13:
+.incbin "baserom.gba", 0xF6167C, 0x200
+sPhanpySprites13:
+ax_sprite sPhanpyGfx13, 0x200
+ax_sprite_terminator
+sPhanpyGfx14:
+.incbin "baserom.gba", 0xF6188C, 0x200
+sPhanpySprites14:
+ax_sprite sPhanpyGfx14, 0x200
+ax_sprite_terminator
+sPhanpyGfx15:
+.incbin "baserom.gba", 0xF61A9C, 0x200
+sPhanpySprites15:
+ax_sprite sPhanpyGfx15, 0x200
+ax_sprite_terminator
+sPhanpyGfx16:
+.incbin "baserom.gba", 0xF61CAC, 0x60
+sPhanpyGfx16_1:
+.incbin "baserom.gba", 0xF61D0C, 0x60
+sPhanpyGfx16_2:
+.incbin "baserom.gba", 0xF61D6C, 0x60
+sPhanpySprites16:
+ax_sprite sPhanpyGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx17:
+.incbin "baserom.gba", 0xF61E04, 0x60
+sPhanpyGfx17_1:
+.incbin "baserom.gba", 0xF61E64, 0x60
+sPhanpyGfx17_2:
+.incbin "baserom.gba", 0xF61EC4, 0x60
+sPhanpySprites17:
+ax_sprite sPhanpyGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx18:
+.incbin "baserom.gba", 0xF61F5C, 0x60
+sPhanpyGfx18_1:
+.incbin "baserom.gba", 0xF61FBC, 0x80
+sPhanpyGfx18_2:
+.incbin "baserom.gba", 0xF6203C, 0x40
+sPhanpySprites18:
+ax_sprite sPhanpyGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx19:
+.incbin "baserom.gba", 0xF620B4, 0x60
+sPhanpyGfx19_1:
+.incbin "baserom.gba", 0xF62114, 0x60
+sPhanpyGfx19_2:
+.incbin "baserom.gba", 0xF62174, 0x60
+sPhanpyGfx19_3:
+.incbin "baserom.gba", 0xF621D4, 0x20
+sPhanpySprites19:
+ax_sprite sPhanpyGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPhanpyGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPhanpyGfx20:
+.incbin "baserom.gba", 0xF6223C, 0x60
+sPhanpyGfx20_1:
+.incbin "baserom.gba", 0xF6229C, 0x60
+sPhanpyGfx20_2:
+.incbin "baserom.gba", 0xF622FC, 0x60
+sPhanpySprites20:
+ax_sprite sPhanpyGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx21:
+.incbin "baserom.gba", 0xF62394, 0x40
+sPhanpyGfx21_1:
+.incbin "baserom.gba", 0xF623D4, 0x60
+sPhanpyGfx21_2:
+.incbin "baserom.gba", 0xF62434, 0x60
+sPhanpySprites21:
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx22:
+.incbin "baserom.gba", 0xF624D4, 0x60
+sPhanpyGfx22_1:
+.incbin "baserom.gba", 0xF62534, 0x60
+sPhanpyGfx22_2:
+.incbin "baserom.gba", 0xF62594, 0x60
+sPhanpySprites22:
+ax_sprite sPhanpyGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx23:
+.incbin "baserom.gba", 0xF6262C, 0x40
+sPhanpyGfx23_1:
+.incbin "baserom.gba", 0xF6266C, 0x100
+sPhanpySprites23:
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx23_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPhanpyGfx24:
+.incbin "baserom.gba", 0xF6279C, 0x60
+sPhanpyGfx24_1:
+.incbin "baserom.gba", 0xF627FC, 0x60
+sPhanpyGfx24_2:
+.incbin "baserom.gba", 0xF6285C, 0x40
+sPhanpySprites24:
+ax_sprite 0, 0x80
+ax_sprite sPhanpyGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPhanpyGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPhanpyGfx25:
+.incbin "baserom.gba", 0xF628DC, 0x20
+sPhanpyGfx25_1:
+.incbin "baserom.gba", 0xF628FC, 0x60
+sPhanpyGfx25_2:
+.incbin "baserom.gba", 0xF6295C, 0x60
+sPhanpySprites25:
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPhanpyGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx26:
+.incbin "baserom.gba", 0xF629FC, 0x60
+sPhanpyGfx26_1:
+.incbin "baserom.gba", 0xF62A5C, 0x60
+sPhanpySprites26:
+ax_sprite sPhanpyGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPhanpyGfx27:
+.incbin "baserom.gba", 0xF62AE4, 0x60
+sPhanpyGfx27_1:
+.incbin "baserom.gba", 0xF62B44, 0x60
+sPhanpySprites27:
+ax_sprite sPhanpyGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPhanpyGfx28:
+.incbin "baserom.gba", 0xF62BCC, 0x100
+sPhanpySprites28:
+ax_sprite sPhanpyGfx28, 0x100
+ax_sprite_terminator
+sPhanpyGfx29:
+.incbin "baserom.gba", 0xF62CDC, 0x20
+sPhanpyGfx29_1:
+.incbin "baserom.gba", 0xF62CFC, 0x60
+sPhanpyGfx29_2:
+.incbin "baserom.gba", 0xF62D5C, 0x60
+sPhanpySprites29:
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPhanpyGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx30:
+.incbin "baserom.gba", 0xF62DFC, 0x20
+sPhanpyGfx30_1:
+.incbin "baserom.gba", 0xF62E1C, 0x60
+sPhanpyGfx30_2:
+.incbin "baserom.gba", 0xF62E7C, 0x60
+sPhanpySprites30:
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPhanpyGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPhanpyGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPhanpyGfx31:
+.incbin "baserom.gba", 0xF62F1C, 0x200
+sPhanpySprites31:
+ax_sprite sPhanpyGfx31, 0x200
+ax_sprite_terminator
+sPhanpyGfx32:
+.incbin "baserom.gba", 0xF6312C, 0x200
+sPhanpySprites32:
+ax_sprite sPhanpyGfx32, 0x200
+ax_sprite_terminator
+sPhanpyGfx33:
+.incbin "baserom.gba", 0xF6333C, 0x200
+sPhanpySprites33:
+ax_sprite sPhanpyGfx33, 0x200
+ax_sprite_terminator
+sPhanpyGfx34:
+.incbin "baserom.gba", 0xF6354C, 0x200
+sPhanpySprites34:
+ax_sprite sPhanpyGfx34, 0x200
+ax_sprite_terminator
+sPhanpyGfx35:
+.incbin "baserom.gba", 0xF6375C, 0x200
+sPhanpySprites35:
+ax_sprite sPhanpyGfx35, 0x200
+ax_sprite_terminator
+sPhanpyGfx36:
+.incbin "baserom.gba", 0xF6396C, 0x200
+sPhanpySprites36:
+ax_sprite sPhanpyGfx36, 0x200
+ax_sprite_terminator
+sPhanpyGfx37:
+.incbin "baserom.gba", 0xF63B7C, 0x200
+sPhanpySprites37:
+ax_sprite sPhanpyGfx37, 0x200
+ax_sprite_terminator
+sAxPosesPhanpy:
+.4byte sPhanpyPose1
+.4byte sPhanpyPose2
+.4byte sPhanpyPose3
+.4byte sPhanpyPose4
+.4byte sPhanpyPose5
+.4byte sPhanpyPose6
+.4byte sPhanpyPose7
+.4byte sPhanpyPose8
+.4byte sPhanpyPose9
+.4byte sPhanpyPose10
+.4byte sPhanpyPose11
+.4byte sPhanpyPose12
+.4byte sPhanpyPose13
+.4byte sPhanpyPose14
+.4byte sPhanpyPose15
+.4byte sPhanpyPose16
+.4byte sPhanpyPose17
+.4byte sPhanpyPose18
+.4byte sPhanpyPose19
+.4byte sPhanpyPose20
+.4byte sPhanpyPose21
+.4byte sPhanpyPose22
+.4byte sPhanpyPose23
+.4byte sPhanpyPose24
+.4byte sPhanpyPose25
+.4byte sPhanpyPose26
+.4byte sPhanpyPose27
+.4byte sPhanpyPose28
+.4byte sPhanpyPose29
+.4byte sPhanpyPose30
+.4byte sPhanpyPose31
+.4byte sPhanpyPose32
+.4byte sPhanpyPose33
+.4byte sPhanpyPose34
+.4byte sPhanpyPose35
+.4byte sPhanpyPose36
+.4byte sPhanpyPose37
+.4byte sPhanpyPose38
+.4byte sPhanpyPose39
+.4byte sPhanpyPose40
+.4byte sPhanpyPose41
+.4byte sPhanpyPose42
+.4byte sPhanpyPose43
+.4byte sPhanpyPose44
+.4byte sPhanpyPose45
+.4byte sPhanpyPose46
+.4byte sPhanpyPose47
+.4byte sPhanpyPose48
+.4byte sPhanpyPose49
+.4byte sPhanpyPose50
+.4byte sPhanpyPose51
+.4byte sPhanpyPose52
+.4byte sPhanpyPose53
+.4byte sPhanpyPose54
+.4byte sPhanpyPose55
+.4byte sPhanpyPose56
+.4byte sPhanpyPose57
+.4byte sPhanpyPose58
+.4byte sPhanpyPose59
+.4byte sPhanpyPose60
+.4byte sPhanpyPose61
+.4byte sPhanpyPose62
+.4byte sPhanpyPose63
+.4byte sPhanpyPose64
+.4byte sPhanpyPose65
+.4byte sPhanpyPose66
+.4byte sPhanpyPose67
+.4byte sPhanpyPose68
+.4byte sPhanpyPose69
+.4byte sPhanpyPose70
+.4byte sPhanpyPose71
+.4byte sPhanpyPose72
+.4byte sPhanpyPose73
+.4byte sPhanpyPose74
+.4byte sPhanpyPose75
+.4byte sPhanpyPose76
+.4byte sPhanpyPose77
+.4byte sPhanpyPose78
+.4byte sPhanpyPose79
+.4byte sPhanpyPose80
+.4byte sPhanpyPose81
+.4byte sPhanpyPose82
+.4byte sPhanpyPose83
+.4byte sPhanpyPose84
+.4byte sPhanpyPose85
+.4byte sPhanpyPose86
+.4byte sPhanpyPose87
+.4byte sPhanpyPose88
+.4byte sPhanpyPose89
+.4byte sPhanpyPose90
+.4byte sPhanpyPose91
+.4byte sPhanpyPose92
+.4byte sPhanpyPose93
+.4byte sPhanpyPose94
+.4byte sPhanpyPose95
+.4byte sPhanpyPose96
+.4byte sPhanpyPose97
+.4byte sPhanpyPose98
+.4byte sPhanpyPose99
+.4byte sPhanpyPose100
+.4byte sPhanpyPose101
+.4byte sPhanpyPose102
+.4byte sPhanpyPose103
+.4byte sPhanpyPose104
+.4byte sPhanpyPose105
+.4byte sPhanpyPose106
+.4byte sPhanpyPose107
+.4byte sPhanpyPose108
+.4byte sPhanpyPose109
+.4byte sPhanpyPose110
+.4byte sPhanpyPose111
+.4byte sPhanpyPose112
+.4byte sPhanpyPose113
+.4byte sPhanpyPose114
+.4byte sPhanpyPose115
+.4byte sPhanpyPose116
+.4byte sPhanpyPose117
+.4byte sPhanpyPose118
+.4byte sPhanpyPose119
+.4byte sPhanpyPose120
+.4byte sPhanpyPose121
+.4byte sPhanpyPose122
+.4byte sPhanpyPose123
+.4byte sPhanpyPose124
+.4byte sPhanpyPose125
+.4byte sPhanpyPose126
+.4byte sPhanpyPose127
+.4byte sPhanpyPose128
+.4byte sPhanpyPose129
+.4byte sPhanpyPose130
+.4byte sPhanpyPose131
+.4byte sPhanpyPose132
+.4byte sPhanpyPose133
+.4byte sPhanpyPose134
+.4byte sPhanpyPose135
+.4byte sPhanpyPose136
+.4byte sPhanpyPose137
+.4byte sPhanpyPose138
+.4byte sPhanpyPose139
+.4byte sPhanpyPose140
+.4byte sPhanpyPose141
+.4byte sPhanpyPose142
+.4byte sPhanpyPose143
+.4byte sPhanpyPose144
+.4byte sPhanpyPose145
+.4byte sPhanpyPose146
+.4byte sPhanpyPose147
+.4byte sPhanpyPose148
+.4byte sPhanpyPose149
+.4byte sPhanpyPose150
+.4byte sPhanpyPose151
+.4byte sPhanpyPose152
+.4byte sPhanpyPose153
+.4byte sPhanpyPose154
+.4byte sPhanpyPose155
+.4byte sPhanpyPose156
+.4byte sPhanpyPose157
+.4byte sPhanpyPose158
+.4byte sPhanpyPose159
+.4byte sPhanpyPose160
+.4byte sPhanpyPose161
+.4byte sPhanpyPose162
+.4byte sPhanpyPose163
+.4byte sPhanpyPose164
+.4byte sPhanpyPose165
+.4byte sPhanpyPose166
+.4byte sPhanpyPose167
+.4byte sPhanpyPose168
+.4byte sPhanpyPose169
+.4byte sPhanpyPose170
+.4byte sPhanpyPose171
+.4byte sPhanpyPose172
+.4byte sPhanpyPose173
+.4byte sPhanpyPose174
+.4byte sPhanpyPose175
+.4byte sPhanpyPose176
+.4byte sPhanpyPose177
+.4byte sPhanpyPose178
+.4byte sPhanpyPose179
+.4byte sPhanpyPose180
+.4byte sPhanpyPose181
+.4byte sPhanpyPose182
+.4byte sPhanpyPose183
+.4byte sPhanpyPose184
+.4byte sPhanpyPose185
+.4byte sPhanpyPose186
+.4byte sPhanpyPose187
+.4byte sPhanpyPose188
+.4byte sPhanpyPose189
+.4byte sPhanpyPose190
+.4byte sPhanpyPose191
+.4byte sPhanpyPose192
+.4byte sPhanpyPose193
+.4byte sPhanpyPose194
+.4byte sPhanpyPose195
+.4byte sPhanpyPose196
+.4byte sPhanpyPose197
+.4byte sPhanpyPose198
+.4byte sPhanpyPose199
+.4byte sPhanpyPose200
+.4byte sPhanpyPose201
+.4byte sPhanpyPose202
+.4byte sPhanpyPose203
+.4byte sPhanpyPose204
+.4byte sPhanpyPose205
+.4byte sPhanpyPose206
+.4byte sPhanpyPose207
+.4byte sPhanpyPose208
+.4byte sPhanpyPose209
+.4byte sPhanpyPose210
+.4byte sPhanpyPose211
+.4byte sPhanpyPose212
+.4byte sPhanpyPose213
+.4byte sPhanpyPose214
+.4byte sPhanpyPose215
+.4byte sPhanpyPose216
+.4byte sPhanpyPose217
+.4byte sPhanpyPose218
+.4byte sPhanpyPose219
+.4byte sPhanpyPose220
+.4byte sPhanpyPose221
+.4byte sPhanpyPose222
+.4byte sPhanpyPose223
+.4byte sPhanpyPose224
+.4byte sPhanpyPose225
+.4byte sPhanpyPose226
+sAxPositionsPhanpy:
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -4, 	  -4,   -1, 	   3,    2, 	   0,   -6
+.2byte    0,   -3, 	  -3,    2, 	   4,   -1, 	   0,   -4
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    5,   -5, 	   5,   -2, 	   3,    0, 	  -1,   -8
+.2byte    4,   -5, 	   8,   -1, 	  -1,    0, 	   1,   -7
+.2byte    8,   -7, 	   5,   -3, 	   4,   -1, 	   0,   -7
+.2byte    8,   -8, 	   3,   -2, 	   7,   -3, 	  -1,   -8
+.2byte    7,   -7, 	   8,   -4, 	   3,   -1, 	   0,   -8
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    7,  -12, 	  -1,   -4, 	   6,   -5, 	   1,   -9
+.2byte    6,  -10, 	   1,   -4, 	   4,   -1, 	   1,   -8
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -12, 	   3,   -3, 	  -3,   -4, 	   0,   -9
+.2byte    0,  -13, 	   3,   -4, 	  -3,   -3, 	   0,   -9
+.2byte   -7,  -10, 	   1,   -3, 	  -4,   -2, 	  -1,   -8
+.2byte   -7,  -12, 	   1,   -4, 	  -6,   -5, 	  -1,   -9
+.2byte   -6,  -10, 	  -1,   -4, 	  -4,   -1, 	  -1,   -8
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -8,   -8, 	  -3,   -2, 	  -7,   -3, 	   1,   -8
+.2byte   -7,   -7, 	  -8,   -4, 	  -3,   -1, 	   0,   -8
+.2byte   -5,   -4, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -5,   -5, 	  -5,   -2, 	  -3,    0, 	   1,   -8
+.2byte   -4,   -5, 	  -8,   -1, 	   1,    0, 	  -1,   -7
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -4, 	  -4,   -1, 	   3,    2, 	   0,   -6
+.2byte    0,   -3, 	  -3,    2, 	   4,   -1, 	   0,   -4
+.2byte    0,   -7, 	  -4,    1, 	   4,    1, 	   0,   -6
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    5,   -5, 	   5,   -2, 	   3,    0, 	  -1,   -8
+.2byte    4,   -5, 	   8,   -1, 	  -1,    0, 	   1,   -7
+.2byte    8,   -9, 	   6,   -1, 	   2,    1, 	   2,   -6
+.2byte    8,   -7, 	   5,   -3, 	   4,   -1, 	   0,   -7
+.2byte    8,   -8, 	   3,   -2, 	   7,   -3, 	  -1,   -8
+.2byte    7,   -7, 	   8,   -4, 	   3,   -1, 	   0,   -8
+.2byte   10,  -10, 	   5,   -3, 	   5,   -1, 	   2,   -7
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    7,  -12, 	  -1,   -4, 	   6,   -5, 	   1,   -9
+.2byte    6,  -10, 	   1,   -4, 	   4,   -1, 	   1,   -8
+.2byte    6,  -14, 	   0,   -4, 	   4,   -2, 	   0,   -8
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -12, 	   3,   -3, 	  -3,   -4, 	   0,   -9
+.2byte    0,  -13, 	   3,   -4, 	  -3,   -3, 	   0,   -9
+.2byte    0,  -13, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   1,   -3, 	  -4,   -2, 	  -1,   -8
+.2byte   -7,  -12, 	   1,   -4, 	  -6,   -5, 	  -1,   -9
+.2byte   -6,  -10, 	  -1,   -4, 	  -4,   -1, 	  -1,   -8
+.2byte   -6,  -14, 	   0,   -4, 	  -4,   -2, 	   0,   -8
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -8,   -8, 	  -3,   -2, 	  -7,   -3, 	   1,   -8
+.2byte   -7,   -7, 	  -8,   -4, 	  -3,   -1, 	   0,   -8
+.2byte  -10,  -10, 	  -5,   -3, 	  -5,   -1, 	  -2,   -7
+.2byte   -5,   -4, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -5,   -5, 	  -5,   -2, 	  -3,    0, 	   1,   -8
+.2byte   -4,   -5, 	  -8,   -1, 	   1,    0, 	  -1,   -7
+.2byte   -8,   -9, 	  -6,   -1, 	  -2,    1, 	  -2,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -4, 	  -4,   -1, 	   3,    2, 	   0,   -6
+.2byte    0,   -3, 	  -3,    2, 	   4,   -1, 	   0,   -4
+.2byte    0,   -7, 	  -4,    1, 	   4,    1, 	   0,   -6
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    5,   -5, 	   5,   -2, 	   3,    0, 	  -1,   -8
+.2byte    4,   -5, 	   8,   -1, 	  -1,    0, 	   1,   -7
+.2byte    8,   -9, 	   6,   -1, 	   2,    1, 	   2,   -6
+.2byte    8,   -7, 	   5,   -3, 	   4,   -1, 	   0,   -7
+.2byte    8,   -8, 	   3,   -2, 	   7,   -3, 	  -1,   -8
+.2byte    7,   -7, 	   8,   -4, 	   3,   -1, 	   0,   -8
+.2byte   10,  -10, 	   5,   -3, 	   5,   -1, 	   2,   -7
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    7,  -12, 	  -1,   -4, 	   6,   -5, 	   1,   -9
+.2byte    6,  -10, 	   1,   -4, 	   4,   -1, 	   1,   -8
+.2byte    6,  -14, 	   0,   -4, 	   4,   -2, 	   0,   -8
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -12, 	   3,   -3, 	  -3,   -4, 	   0,   -9
+.2byte    0,  -13, 	   3,   -4, 	  -3,   -3, 	   0,   -9
+.2byte    0,  -13, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   1,   -3, 	  -4,   -2, 	  -1,   -8
+.2byte   -7,  -12, 	   1,   -4, 	  -6,   -5, 	  -1,   -9
+.2byte   -6,  -10, 	  -1,   -4, 	  -4,   -1, 	  -1,   -8
+.2byte   -6,  -14, 	   0,   -4, 	  -4,   -2, 	   0,   -8
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -8,   -8, 	  -3,   -2, 	  -7,   -3, 	   1,   -8
+.2byte   -7,   -7, 	  -8,   -4, 	  -3,   -1, 	   0,   -8
+.2byte  -10,  -10, 	  -5,   -3, 	  -5,   -1, 	  -2,   -7
+.2byte   -5,   -4, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -5,   -5, 	  -5,   -2, 	  -3,    0, 	   1,   -8
+.2byte   -4,   -5, 	  -8,   -1, 	   1,    0, 	  -1,   -7
+.2byte   -8,   -9, 	  -6,   -1, 	  -2,    1, 	  -2,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    0,   -7, 	  -4,    1, 	   4,    1, 	   0,   -6
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    5,   -3, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    8,   -9, 	   6,   -1, 	   2,    1, 	   2,   -6
+.2byte    8,   -7, 	   5,   -3, 	   4,   -1, 	   0,   -7
+.2byte    7,   -5, 	   6,   -4, 	   4,   -1, 	   0,   -7
+.2byte   10,  -10, 	   5,   -3, 	   5,   -1, 	   2,   -7
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -4, 	   4,   -2, 	   0,   -6
+.2byte    6,  -14, 	   0,   -4, 	   4,   -2, 	   0,   -8
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,   -9, 	   3,   -2, 	  -3,   -2, 	   0,   -7
+.2byte    0,  -13, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   1,   -3, 	  -4,   -2, 	  -1,   -8
+.2byte   -5,   -7, 	   1,   -4, 	  -4,   -2, 	   0,   -6
+.2byte   -6,  -14, 	   0,   -4, 	  -4,   -2, 	   0,   -8
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -7,   -5, 	  -6,   -4, 	  -4,   -1, 	   0,   -7
+.2byte  -10,  -10, 	  -5,   -3, 	  -5,   -1, 	  -2,   -7
+.2byte   -5,   -4, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -5,   -3, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -8,   -9, 	  -6,   -1, 	  -2,    1, 	  -2,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -7, 	  -4,    1, 	   4,    1, 	   0,   -6
+.2byte    0,    0, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    8,   -9, 	   6,   -1, 	   2,    1, 	   2,   -6
+.2byte    4,   -1, 	   6,   -1, 	   1,    1, 	   2,   -7
+.2byte    8,   -7, 	   5,   -3, 	   4,   -1, 	   0,   -7
+.2byte    9,  -10, 	   4,   -3, 	   4,   -1, 	   1,   -7
+.2byte    7,   -3, 	   6,   -3, 	   4,   -1, 	   1,   -7
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    6,  -14, 	   0,   -4, 	   4,   -2, 	   0,   -8
+.2byte    5,   -8, 	  -1,   -4, 	   5,   -2, 	   1,   -7
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -13, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -7
+.2byte   -7,  -10, 	   1,   -3, 	  -4,   -2, 	  -1,   -8
+.2byte   -6,  -14, 	   0,   -4, 	  -4,   -2, 	   0,   -8
+.2byte   -5,   -8, 	   1,   -4, 	  -5,   -2, 	  -1,   -7
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -9,  -10, 	  -4,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -7,   -3, 	  -6,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -5,   -4, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -8,   -9, 	  -6,   -1, 	  -2,    1, 	  -2,   -6
+.2byte   -4,   -1, 	  -6,   -1, 	  -1,    1, 	  -2,   -7
+.2byte   -6,    0, 	 -10,   -2, 	   1,    3, 	  -1,   -5
+.2byte   -6,    1, 	 -10,   -1, 	   1,    3, 	  -1,   -5
+.2byte    0,   -9, 	  -5,   -7, 	   5,   -7, 	   0,   -5
+.2byte    2,  -10, 	   6,  -10, 	   0,   -9, 	  -1,   -5
+.2byte    3,  -11, 	   6,  -11, 	   5,   -8, 	  -1,   -6
+.2byte    3,  -14, 	  -2,   -9, 	   3,   -8, 	  -2,   -6
+.2byte    0,  -14, 	   3,   -8, 	  -3,   -8, 	   0,   -8
+.2byte   -4,  -14, 	   1,   -9, 	  -4,   -8, 	   1,   -6
+.2byte   -4,  -11, 	  -7,  -11, 	  -6,   -8, 	   0,   -6
+.2byte   -3,  -10, 	  -7,  -10, 	  -1,   -9, 	   0,   -5
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    0,   -7, 	  -4,    1, 	   4,    1, 	   0,   -6
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    5,   -3, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    8,   -9, 	   6,   -1, 	   2,    1, 	   2,   -6
+.2byte    8,   -7, 	   5,   -3, 	   4,   -1, 	   0,   -7
+.2byte    7,   -5, 	   6,   -4, 	   4,   -1, 	   0,   -7
+.2byte   10,  -10, 	   5,   -3, 	   5,   -1, 	   2,   -7
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    5,   -7, 	  -1,   -4, 	   4,   -2, 	   0,   -6
+.2byte    6,  -14, 	   0,   -4, 	   4,   -2, 	   0,   -8
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,   -9, 	   3,   -2, 	  -3,   -2, 	   0,   -7
+.2byte    0,  -13, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte   -7,  -10, 	   1,   -3, 	  -4,   -2, 	  -1,   -8
+.2byte   -5,   -7, 	   1,   -4, 	  -4,   -2, 	   0,   -6
+.2byte   -6,  -14, 	   0,   -4, 	  -4,   -2, 	   0,   -8
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -7,   -5, 	  -6,   -4, 	  -4,   -1, 	   0,   -7
+.2byte  -10,  -10, 	  -5,   -3, 	  -5,   -1, 	  -2,   -7
+.2byte   -5,   -4, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -5,   -3, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -8,   -9, 	  -6,   -1, 	  -2,    1, 	  -2,   -6
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte   -5,   -2, 	  -6,    0, 	  -1,    2, 	   0,   -5
+.2byte   -7,   -4, 	  -6,   -3, 	  -4,    0, 	   0,   -6
+.2byte   -5,   -7, 	   1,   -4, 	  -4,   -2, 	   0,   -6
+.2byte    0,   -8, 	   3,   -1, 	  -3,   -1, 	   0,   -6
+.2byte    5,   -7, 	  -1,   -4, 	   4,   -2, 	   0,   -6
+.2byte    7,   -4, 	   6,   -3, 	   4,    0, 	   0,   -6
+.2byte    5,   -2, 	   6,    0, 	   1,    2, 	   0,   -5
+.2byte    0,   -7, 	  -4,    1, 	   4,    1, 	   0,   -6
+.2byte    7,   -9, 	   5,   -1, 	   1,    1, 	   1,   -6
+.2byte    9,  -10, 	   4,   -3, 	   4,   -1, 	   1,   -7
+.2byte    6,  -14, 	   0,   -4, 	   4,   -2, 	   0,   -8
+.2byte    0,  -12, 	   3,   -2, 	  -3,   -2, 	   0,   -7
+.2byte   -6,  -14, 	   0,   -4, 	  -4,   -2, 	   0,   -8
+.2byte   -9,  -10, 	  -4,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -7,   -9, 	  -5,   -1, 	  -1,    1, 	  -1,   -6
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    0,   -7, 	  -4,    1, 	   4,    1, 	   0,   -6
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+.2byte    6,   -3, 	   7,   -1, 	   2,    1, 	   1,   -6
+.2byte    6,   -9, 	   4,   -1, 	   0,    1, 	   0,   -6
+.2byte    7,   -7, 	   4,   -3, 	   3,   -1, 	  -1,   -7
+.2byte    7,   -5, 	   6,   -4, 	   4,   -1, 	   0,   -7
+.2byte    8,  -10, 	   3,   -3, 	   3,   -1, 	   0,   -7
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    6,   -8, 	   0,   -5, 	   5,   -3, 	   1,   -7
+.2byte    6,  -14, 	   0,   -4, 	   4,   -2, 	   0,   -8
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,   -9, 	   3,   -2, 	  -3,   -2, 	   0,   -7
+.2byte    0,  -13, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte   -8,  -10, 	   0,   -3, 	  -5,   -2, 	  -2,   -8
+.2byte   -7,   -8, 	  -1,   -5, 	  -6,   -3, 	  -2,   -7
+.2byte   -7,  -14, 	  -1,   -4, 	  -5,   -2, 	  -1,   -8
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -8,   -5, 	  -7,   -4, 	  -5,   -1, 	  -1,   -7
+.2byte   -9,  -10, 	  -4,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -6,   -4, 	  -7,   -1, 	  -2,    1, 	  -1,   -6
+.2byte   -7,   -3, 	  -8,   -1, 	  -3,    1, 	  -2,   -6
+.2byte   -7,   -9, 	  -5,   -1, 	  -1,    1, 	  -1,   -6
+.2byte    0,    0, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte   -4,   -1, 	  -6,   -1, 	  -1,    1, 	  -2,   -7
+.2byte   -7,   -3, 	  -6,   -3, 	  -4,   -1, 	  -1,   -7
+.2byte   -5,   -8, 	   1,   -4, 	  -5,   -2, 	  -1,   -7
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -7
+.2byte    5,   -8, 	  -1,   -4, 	   5,   -2, 	   1,   -7
+.2byte    7,   -3, 	   6,   -3, 	   4,   -1, 	   1,   -7
+.2byte    4,   -1, 	   6,   -1, 	   1,    1, 	   2,   -7
+.2byte    0,   -2, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte   -5,   -4, 	  -6,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -8,   -7, 	  -5,   -3, 	  -4,   -1, 	   0,   -7
+.2byte   -7,  -10, 	   1,   -3, 	  -4,   -2, 	  -1,   -8
+.2byte    0,  -11, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    7,  -10, 	  -1,   -3, 	   4,   -2, 	   1,   -8
+.2byte    8,   -7, 	   5,   -3, 	   4,   -1, 	   0,   -7
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	   0,   -6
+sPhanpyAnimTable1:
+.4byte sPhanpyAnims_1_1
+.4byte sPhanpyAnims_1_2
+.4byte sPhanpyAnims_1_3
+.4byte sPhanpyAnims_1_4
+.4byte sPhanpyAnims_1_5
+.4byte sPhanpyAnims_1_6
+.4byte sPhanpyAnims_1_7
+.4byte sPhanpyAnims_1_8
+sPhanpyAnimTable2:
+.4byte sPhanpyAnims_2_1
+.4byte sPhanpyAnims_2_2
+.4byte sPhanpyAnims_2_3
+.4byte sPhanpyAnims_2_4
+.4byte sPhanpyAnims_2_5
+.4byte sPhanpyAnims_2_6
+.4byte sPhanpyAnims_2_7
+.4byte sPhanpyAnims_2_8
+sPhanpyAnimTable3:
+.4byte sPhanpyAnims_3_1
+.4byte sPhanpyAnims_3_2
+.4byte sPhanpyAnims_3_3
+.4byte sPhanpyAnims_3_4
+.4byte sPhanpyAnims_3_5
+.4byte sPhanpyAnims_3_6
+.4byte sPhanpyAnims_3_7
+.4byte sPhanpyAnims_3_8
+sPhanpyAnimTable4:
+.4byte sPhanpyAnims_4_1
+.4byte sPhanpyAnims_4_2
+.4byte sPhanpyAnims_4_3
+.4byte sPhanpyAnims_4_4
+.4byte sPhanpyAnims_4_5
+.4byte sPhanpyAnims_4_6
+.4byte sPhanpyAnims_4_7
+.4byte sPhanpyAnims_4_8
+sPhanpyAnimTable5:
+.4byte sPhanpyAnims_5_1
+.4byte sPhanpyAnims_5_2
+.4byte sPhanpyAnims_5_3
+.4byte sPhanpyAnims_5_4
+.4byte sPhanpyAnims_5_5
+.4byte sPhanpyAnims_5_6
+.4byte sPhanpyAnims_5_7
+.4byte sPhanpyAnims_5_8
+sPhanpyAnimTable6:
+.4byte sPhanpyAnims_6_1
+.4byte sPhanpyAnims_6_1
+.4byte sPhanpyAnims_6_1
+.4byte sPhanpyAnims_6_1
+.4byte sPhanpyAnims_6_1
+.4byte sPhanpyAnims_6_1
+.4byte sPhanpyAnims_6_1
+.4byte sPhanpyAnims_6_1
+sPhanpyAnimTable7:
+.4byte sPhanpyAnims_7_1
+.4byte sPhanpyAnims_7_2
+.4byte sPhanpyAnims_7_3
+.4byte sPhanpyAnims_7_4
+.4byte sPhanpyAnims_7_5
+.4byte sPhanpyAnims_7_6
+.4byte sPhanpyAnims_7_7
+.4byte sPhanpyAnims_7_8
+sPhanpyAnimTable8:
+.4byte sPhanpyAnims_8_1
+.4byte sPhanpyAnims_8_2
+.4byte sPhanpyAnims_8_3
+.4byte sPhanpyAnims_8_4
+.4byte sPhanpyAnims_8_5
+.4byte sPhanpyAnims_8_6
+.4byte sPhanpyAnims_8_7
+.4byte sPhanpyAnims_8_8
+sPhanpyAnimTable9:
+.4byte sPhanpyAnims_9_1
+.4byte sPhanpyAnims_9_2
+.4byte sPhanpyAnims_9_3
+.4byte sPhanpyAnims_9_4
+.4byte sPhanpyAnims_9_5
+.4byte sPhanpyAnims_9_6
+.4byte sPhanpyAnims_9_7
+.4byte sPhanpyAnims_9_8
+sPhanpyAnimTable10:
+.4byte sPhanpyAnims_10_1
+.4byte sPhanpyAnims_10_2
+.4byte sPhanpyAnims_10_3
+.4byte sPhanpyAnims_10_4
+.4byte sPhanpyAnims_10_5
+.4byte sPhanpyAnims_10_6
+.4byte sPhanpyAnims_10_7
+.4byte sPhanpyAnims_10_8
+sPhanpyAnimTable11:
+.4byte sPhanpyAnims_11_1
+.4byte sPhanpyAnims_11_2
+.4byte sPhanpyAnims_11_3
+.4byte sPhanpyAnims_11_4
+.4byte sPhanpyAnims_11_5
+.4byte sPhanpyAnims_11_6
+.4byte sPhanpyAnims_11_7
+.4byte sPhanpyAnims_11_8
+sPhanpyAnimTable12:
+.4byte sPhanpyAnims_12_1
+.4byte sPhanpyAnims_12_2
+.4byte sPhanpyAnims_12_3
+.4byte sPhanpyAnims_12_4
+.4byte sPhanpyAnims_12_5
+.4byte sPhanpyAnims_12_6
+.4byte sPhanpyAnims_12_7
+.4byte sPhanpyAnims_12_8
+sPhanpyAnimTable13:
+.4byte sPhanpyAnims_13_1
+.4byte sPhanpyAnims_13_2
+.4byte sPhanpyAnims_13_3
+.4byte sPhanpyAnims_13_4
+.4byte sPhanpyAnims_13_5
+.4byte sPhanpyAnims_13_6
+.4byte sPhanpyAnims_13_7
+.4byte sPhanpyAnims_13_8
+sAxAnimationsPhanpy:
+.4byte sPhanpyAnimTable1
+.4byte sPhanpyAnimTable2
+.4byte sPhanpyAnimTable3
+.4byte sPhanpyAnimTable4
+.4byte sPhanpyAnimTable5
+.4byte sPhanpyAnimTable6
+.4byte sPhanpyAnimTable7
+.4byte sPhanpyAnimTable8
+.4byte sPhanpyAnimTable9
+.4byte sPhanpyAnimTable10
+.4byte sPhanpyAnimTable11
+.4byte sPhanpyAnimTable12
+.4byte sPhanpyAnimTable13
+sAxSpritesPhanpy:
+.4byte sPhanpySprites1
+.4byte sPhanpySprites2
+.4byte sPhanpySprites3
+.4byte sPhanpySprites4
+.4byte sPhanpySprites5
+.4byte sPhanpySprites6
+.4byte sPhanpySprites7
+.4byte sPhanpySprites8
+.4byte sPhanpySprites9
+.4byte sPhanpySprites10
+.4byte sPhanpySprites11
+.4byte sPhanpySprites12
+.4byte sPhanpySprites13
+.4byte sPhanpySprites14
+.4byte sPhanpySprites15
+.4byte sPhanpySprites16
+.4byte sPhanpySprites17
+.4byte sPhanpySprites18
+.4byte sPhanpySprites19
+.4byte sPhanpySprites20
+.4byte sPhanpySprites21
+.4byte sPhanpySprites22
+.4byte sPhanpySprites23
+.4byte sPhanpySprites24
+.4byte sPhanpySprites25
+.4byte sPhanpySprites26
+.4byte sPhanpySprites27
+.4byte sPhanpySprites28
+.4byte sPhanpySprites29
+.4byte sPhanpySprites30
+.4byte sPhanpySprites31
+.4byte sPhanpySprites32
+.4byte sPhanpySprites33
+.4byte sPhanpySprites34
+.4byte sPhanpySprites35
+.4byte sPhanpySprites36
+.4byte sPhanpySprites37
+sAxMainPhanpy:
+ax_main sAxPosesPhanpy, sAxAnimationsPhanpy, 13, sAxSpritesPhanpy, sAxPositionsPhanpy

--- a/data/ax/pichu.inc
+++ b/data/ax/pichu.inc
@@ -1,0 +1,3111 @@
+.global gAxPichu
+gAxPichu:
+ax_siro sAxMainPichu
+sPichuPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose2:
+ax_pose 1, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose3:
+ax_pose 2, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose4:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose5:
+ax_pose 4, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose6:
+ax_pose 5, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPichuPose7:
+ax_pose 6, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose8:
+ax_pose 7, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose9:
+ax_pose 8, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose10:
+ax_pose 9, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sPichuPose11:
+ax_pose 10, 0x81ec, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose12:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose15:
+ax_pose 14, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose16:
+ax_pose 9, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sPichuPose17:
+ax_pose 10, 0x81ec, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose18:
+ax_pose 11, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose19:
+ax_pose 6, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose20:
+ax_pose 7, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose21:
+ax_pose 8, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose22:
+ax_pose 3, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose23:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose24:
+ax_pose 5, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose26:
+ax_pose 1, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose27:
+ax_pose 2, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose28:
+ax_pose 15, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose29:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose30:
+ax_pose 4, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose31:
+ax_pose 5, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPichuPose32:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose33:
+ax_pose 6, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose34:
+ax_pose 7, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose35:
+ax_pose 8, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose36:
+ax_pose 17, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose37:
+ax_pose 9, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sPichuPose38:
+ax_pose 10, 0x81ec, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose39:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose40:
+ax_pose 18, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose41:
+ax_pose 12, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose42:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose43:
+ax_pose 14, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose44:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose45:
+ax_pose 9, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sPichuPose46:
+ax_pose 10, 0x81ec, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose47:
+ax_pose 11, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose48:
+ax_pose 18, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose49:
+ax_pose 6, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose50:
+ax_pose 7, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose51:
+ax_pose 8, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose52:
+ax_pose 17, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose53:
+ax_pose 3, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose54:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose55:
+ax_pose 5, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose56:
+ax_pose 16, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose57:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose58:
+ax_pose 1, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose59:
+ax_pose 2, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose60:
+ax_pose 15, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose61:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose62:
+ax_pose 4, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose63:
+ax_pose 5, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPichuPose64:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose65:
+ax_pose 6, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose66:
+ax_pose 7, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose67:
+ax_pose 8, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose68:
+ax_pose 17, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose69:
+ax_pose 9, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sPichuPose70:
+ax_pose 10, 0x81ec, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose71:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose72:
+ax_pose 18, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose73:
+ax_pose 12, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose74:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose75:
+ax_pose 14, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose76:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose77:
+ax_pose 9, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sPichuPose78:
+ax_pose 10, 0x81ec, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose79:
+ax_pose 11, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose80:
+ax_pose 18, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose81:
+ax_pose 6, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose82:
+ax_pose 7, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose83:
+ax_pose 8, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose84:
+ax_pose 17, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose85:
+ax_pose 3, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose86:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose87:
+ax_pose 5, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose88:
+ax_pose 16, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose89:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose90:
+ax_pose 20, 0x01e1, 0x80ef, 0x0c00
+ax_pose 15, 0x01e3, 0x80ef, 0x0c10
+ax_pose_terminator
+sPichuPose91:
+ax_pose 21, 0x01e4, 0x80f0, 0x0c00
+ax_pose 22, 0x01e2, 0x80ef, 0x0c10
+ax_pose_terminator
+sPichuPose92:
+ax_pose 15, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose93:
+ax_pose 22, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose94:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose95:
+ax_pose 23, 0x01e5, 0x90ef, 0x0c00
+ax_pose 16, 0x01e5, 0x90ed, 0x0c10
+ax_pose_terminator
+sPichuPose96:
+ax_pose 24, 0x01e4, 0x90ef, 0x0c00
+ax_pose 25, 0x01e5, 0x90ed, 0x0c10
+ax_pose_terminator
+sPichuPose97:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose98:
+ax_pose 25, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose99:
+ax_pose 6, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose100:
+ax_pose 26, 0x01e3, 0x90f0, 0x0c00
+ax_pose 17, 0x01e6, 0x90f0, 0x0c10
+ax_pose_terminator
+sPichuPose101:
+ax_pose 21, 0x01e3, 0x90f0, 0x0c00
+ax_pose 27, 0x01e6, 0x90f0, 0x0c10
+ax_pose_terminator
+sPichuPose102:
+ax_pose 17, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose103:
+ax_pose 27, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose104:
+ax_pose 9, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sPichuPose105:
+ax_pose 28, 0x01e3, 0x90f1, 0x0c00
+ax_pose 18, 0x01e7, 0x90f0, 0x0c10
+ax_pose_terminator
+sPichuPose106:
+ax_pose 24, 0x01e3, 0x80f1, 0x0c00
+ax_pose 29, 0x01e7, 0x90f0, 0x0c10
+ax_pose_terminator
+sPichuPose107:
+ax_pose 18, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose108:
+ax_pose 29, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose109:
+ax_pose 12, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose110:
+ax_pose 30, 0x01e6, 0x80f0, 0x0c00
+ax_pose 19, 0x01e6, 0x80f0, 0x0c10
+ax_pose_terminator
+sPichuPose111:
+ax_pose 21, 0x01e3, 0x80f0, 0x0c00
+ax_pose 31, 0x01e6, 0x80f0, 0x0c10
+ax_pose_terminator
+sPichuPose112:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose113:
+ax_pose 31, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose114:
+ax_pose 9, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sPichuPose115:
+ax_pose 28, 0x01e3, 0x80ee, 0x0c00
+ax_pose 18, 0x01e7, 0x80ef, 0x0c10
+ax_pose_terminator
+sPichuPose116:
+ax_pose 24, 0x01e3, 0x90ee, 0x0c00
+ax_pose 29, 0x01e7, 0x80ef, 0x0c10
+ax_pose_terminator
+sPichuPose117:
+ax_pose 18, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose118:
+ax_pose 29, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose119:
+ax_pose 6, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose120:
+ax_pose 26, 0x01e3, 0x80f0, 0x0c00
+ax_pose 17, 0x01e6, 0x80f0, 0x0c10
+ax_pose_terminator
+sPichuPose121:
+ax_pose 21, 0x01e3, 0x80f0, 0x0c00
+ax_pose 27, 0x01e6, 0x80f0, 0x0c10
+ax_pose_terminator
+sPichuPose122:
+ax_pose 17, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose123:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose124:
+ax_pose 3, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose125:
+ax_pose 23, 0x01e5, 0x80f0, 0x0c00
+ax_pose 16, 0x01e5, 0x80f2, 0x0c10
+ax_pose_terminator
+sPichuPose126:
+ax_pose 24, 0x01e4, 0x80f0, 0x0c00
+ax_pose 25, 0x01e5, 0x80f2, 0x0c10
+ax_pose_terminator
+sPichuPose127:
+ax_pose 16, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose128:
+ax_pose 25, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose129:
+ax_pose 32, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose130:
+ax_pose 33, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose131:
+ax_pose 34, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose132:
+ax_pose 35, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose133:
+ax_pose 36, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose134:
+ax_pose 37, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose135:
+ax_pose 38, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sPichuPose136:
+ax_pose 39, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sPichuPose137:
+ax_pose 40, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sPichuPose138:
+ax_pose 41, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sPichuPose139:
+ax_pose 42, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sPichuPose140:
+ax_pose 43, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sPichuPose141:
+ax_pose 44, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose142:
+ax_pose 45, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose143:
+ax_pose 46, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose144:
+ax_pose 41, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sPichuPose145:
+ax_pose 42, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sPichuPose146:
+ax_pose 43, 0x01e7, 0x80ee, 0x0c00
+ax_pose_terminator
+sPichuPose147:
+ax_pose 38, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose148:
+ax_pose 39, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose149:
+ax_pose 40, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose150:
+ax_pose 35, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose151:
+ax_pose 36, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose152:
+ax_pose 37, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose153:
+ax_pose 47, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPichuPose154:
+ax_pose 48, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPichuPose155:
+ax_pose 49, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sPichuPose156:
+ax_pose 50, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose157:
+ax_pose 51, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose158:
+ax_pose 52, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose159:
+ax_pose 53, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sPichuPose160:
+ax_pose 52, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sPichuPose161:
+ax_pose 51, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose162:
+ax_pose 50, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sPichuPose163:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose164:
+ax_pose 1, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose165:
+ax_pose 2, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose166:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose167:
+ax_pose 4, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose168:
+ax_pose 5, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPichuPose169:
+ax_pose 6, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose170:
+ax_pose 7, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose171:
+ax_pose 8, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose172:
+ax_pose 9, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sPichuPose173:
+ax_pose 10, 0x81ec, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose174:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose175:
+ax_pose 12, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose176:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose177:
+ax_pose 14, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose178:
+ax_pose 9, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sPichuPose179:
+ax_pose 10, 0x81ec, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose180:
+ax_pose 11, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose181:
+ax_pose 6, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose182:
+ax_pose 7, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose183:
+ax_pose 8, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose184:
+ax_pose 3, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose185:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose186:
+ax_pose 5, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose187:
+ax_pose 33, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose188:
+ax_pose 36, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sPichuPose189:
+ax_pose 39, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sPichuPose190:
+ax_pose 42, 0x01e7, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose191:
+ax_pose 45, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose192:
+ax_pose 42, 0x01e7, 0x90f1, 0x0c00
+ax_pose_terminator
+sPichuPose193:
+ax_pose 39, 0x01e6, 0x90ee, 0x0c00
+ax_pose_terminator
+sPichuPose194:
+ax_pose 36, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose195:
+ax_pose 15, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose196:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose197:
+ax_pose 17, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sPichuPose198:
+ax_pose 18, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose199:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose200:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose201:
+ax_pose 17, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sPichuPose202:
+ax_pose 16, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPichuPose203:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose204:
+ax_pose 1, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose205:
+ax_pose 2, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose206:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose207:
+ax_pose 4, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose208:
+ax_pose 5, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPichuPose209:
+ax_pose 6, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose210:
+ax_pose 7, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose211:
+ax_pose 8, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose212:
+ax_pose 9, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sPichuPose213:
+ax_pose 10, 0x81ec, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose214:
+ax_pose 11, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPichuPose215:
+ax_pose 12, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose216:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose217:
+ax_pose 14, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose218:
+ax_pose 9, 0x81e7, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose219:
+ax_pose 10, 0x81ec, 0x80fa, 0x0c00
+ax_pose_terminator
+sPichuPose220:
+ax_pose 11, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose221:
+ax_pose 6, 0x81ea, 0x80fa, 0x0c00
+ax_pose_terminator
+sPichuPose222:
+ax_pose 7, 0x81ea, 0x80fa, 0x0c00
+ax_pose_terminator
+sPichuPose223:
+ax_pose 8, 0x81e9, 0x80fa, 0x0c00
+ax_pose_terminator
+sPichuPose224:
+ax_pose 3, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose225:
+ax_pose 4, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPichuPose226:
+ax_pose 5, 0x01e8, 0x80f6, 0x0c00
+ax_pose_terminator
+sPichuPose227:
+ax_pose 15, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sPichuPose228:
+ax_pose 16, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPichuPose229:
+ax_pose 17, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sPichuPose230:
+ax_pose 18, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose231:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose232:
+ax_pose 18, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sPichuPose233:
+ax_pose 17, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sPichuPose234:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPichuPose235:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose236:
+ax_pose 3, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPichuPose237:
+ax_pose 6, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPichuPose238:
+ax_pose 9, 0x81e7, 0x80f8, 0x0c00
+ax_pose_terminator
+sPichuPose239:
+ax_pose 12, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPichuPose240:
+ax_pose 9, 0x81e7, 0x90f7, 0x0c00
+ax_pose_terminator
+sPichuPose241:
+ax_pose 6, 0x81ea, 0x90f6, 0x0c00
+ax_pose_terminator
+sPichuPose242:
+ax_pose 3, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+.align 2
+sPichuAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPichuAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 22, 20, 22, 20,
+ax_anim 2, 1, 31, 23, 19, 23, 19,
+ax_anim 2, 0, 31, 22, 20, 22, 20,
+ax_anim 2, 0, 31, 23, 19, 23, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sPichuAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 22, 0, 22, 0,
+ax_anim 2, 1, 35, 22, 1, 22, 1,
+ax_anim 2, 0, 35, 22, 0, 22, 0,
+ax_anim 2, 0, 35, 22, 1, 22, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sPichuAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -12, 11, -12,
+ax_anim 2, 0, 39, 21, -22, 21, -22,
+ax_anim 2, 1, 39, 22, -21, 22, -21,
+ax_anim 2, 0, 39, 21, -22, 21, -22,
+ax_anim 2, 0, 39, 22, -21, 22, -21,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sPichuAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -22, 0, -22,
+ax_anim 2, 1, 43, 1, -22, 1, -22,
+ax_anim 2, 0, 43, 0, -22, 0, -22,
+ax_anim 2, 0, 43, 1, -22, 1, -22,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sPichuAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -12, -11, -12,
+ax_anim 2, 0, 47, -21, -22, -21, -22,
+ax_anim 2, 1, 47, -22, -21, -22, -21,
+ax_anim 2, 0, 47, -21, -22, -21, -22,
+ax_anim 2, 0, 47, -22, -21, -22, -21,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sPichuAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -22, 0, -22, 0,
+ax_anim 2, 1, 51, -22, 1, -22, 1,
+ax_anim 2, 0, 51, -22, 0, -22, 0,
+ax_anim 2, 0, 51, -22, 1, -22, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sPichuAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -22, 20, -22, 20,
+ax_anim 2, 1, 55, -23, 19, -23, 19,
+ax_anim 2, 0, 55, -22, 20, -22, 20,
+ax_anim 2, 0, 55, -23, 19, -23, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPichuAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 1, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 0, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sPichuAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 22, 20, 22, 20,
+ax_anim 2, 1, 63, 23, 19, 23, 19,
+ax_anim 2, 0, 63, 22, 20, 22, 20,
+ax_anim 2, 0, 63, 23, 19, 23, 19,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sPichuAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 22, 0, 22, 0,
+ax_anim 2, 1, 67, 22, 1, 22, 1,
+ax_anim 2, 0, 67, 22, 0, 22, 0,
+ax_anim 2, 0, 67, 22, 1, 22, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sPichuAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 11, -12, 11, -12,
+ax_anim 2, 0, 71, 21, -22, 21, -22,
+ax_anim 2, 1, 71, 22, -21, 22, -21,
+ax_anim 2, 0, 71, 21, -22, 21, -22,
+ax_anim 2, 0, 71, 22, -21, 22, -21,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sPichuAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -22, 0, -22,
+ax_anim 2, 1, 75, 1, -22, 1, -22,
+ax_anim 2, 0, 75, 0, -22, 0, -22,
+ax_anim 2, 0, 75, 1, -22, 1, -22,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sPichuAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -11, -12, -11, -12,
+ax_anim 2, 0, 79, -21, -22, -21, -22,
+ax_anim 2, 1, 79, -22, -21, -22, -21,
+ax_anim 2, 0, 79, -21, -22, -21, -22,
+ax_anim 2, 0, 79, -22, -21, -22, -21,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sPichuAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -22, 0, -22, 0,
+ax_anim 2, 1, 83, -22, 1, -22, 1,
+ax_anim 2, 0, 83, -22, 0, -22, 0,
+ax_anim 2, 0, 83, -22, 1, -22, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sPichuAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -22, 20, -22, 20,
+ax_anim 2, 1, 87, -23, 19, -23, 19,
+ax_anim 2, 0, 87, -22, 20, -22, 20,
+ax_anim 2, 0, 87, -23, 19, -23, 19,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPichuAnims_4_1:
+ax_anim 8, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 2, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 1, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_4_2:
+ax_anim 8, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 2, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 1, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_4_3:
+ax_anim 8, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 1, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_4_4:
+ax_anim 8, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 2, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 1, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_4_5:
+ax_anim 8, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 2, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 1, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_4_6:
+ax_anim 8, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 1, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_4_7:
+ax_anim 8, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 2, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 1, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_4_8:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 2, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 1, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_5_1:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 1, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_5_2:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 1, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_5_3:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 1, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_5_4:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_5_5:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_5_6:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 1, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_5_7:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 1, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_5_8:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 1, 151, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sPichuAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sPichuAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sPichuAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sPichuAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sPichuAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sPichuAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sPichuAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPichuAnims_8_1:
+ax_anim 32, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 163, 0, -1, 0, 0,
+ax_anim 6, 0, 163, 0, -2, 0, 0,
+ax_anim 6, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sPichuAnims_8_2:
+ax_anim 32, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, -1, 0, 0,
+ax_anim 6, 0, 166, 0, -2, 0, 0,
+ax_anim 6, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sPichuAnims_8_3:
+ax_anim 32, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, -1, 0, 0,
+ax_anim 6, 0, 169, 0, -2, 0, 0,
+ax_anim 6, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+sPichuAnims_8_4:
+ax_anim 32, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, -1, 0, 0,
+ax_anim 6, 0, 172, 0, -2, 0, 0,
+ax_anim 6, 0, 172, 0, -1, 0, 0,
+ax_anim_terminator
+sPichuAnims_8_5:
+ax_anim 32, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, -2, 0, 0,
+ax_anim 6, 0, 175, 0, -3, 0, 0,
+ax_anim 6, 0, 175, 0, -2, 0, 0,
+ax_anim_terminator
+sPichuAnims_8_6:
+ax_anim 32, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, -1, 0, 0,
+ax_anim 6, 0, 178, 0, -2, 0, 0,
+ax_anim 6, 0, 178, 0, -1, 0, 0,
+ax_anim_terminator
+sPichuAnims_8_7:
+ax_anim 32, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, -1, 0, 0,
+ax_anim 6, 0, 181, 0, -2, 0, 0,
+ax_anim 6, 0, 181, 0, -1, 0, 0,
+ax_anim_terminator
+sPichuAnims_8_8:
+ax_anim 32, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, -1, 0, 0,
+ax_anim 6, 0, 184, 0, -2, 0, 0,
+ax_anim 6, 0, 184, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 18, 7, 18,
+ax_anim 3, 0, 190, 0, 19, 0, 19,
+ax_anim 2, 3, 191, -7, 18, -7, 18,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 9, -1, 8, 0,
+ax_anim 2, 0, 187, 21, 4, 21, 4,
+ax_anim 2, 0, 188, 26, 12, 26, 12,
+ax_anim 3, 0, 189, 25, 20, 25, 20,
+ax_anim 2, 3, 190, 14, 20, 14, 20,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 4, -3, 4, -3,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 21, -5, 21, -5,
+ax_anim 3, 0, 188, 24, -1, 24, -1,
+ax_anim 2, 3, 189, 19, 5, 19, 5,
+ax_anim 2, 0, 190, 12, 6, 12, 6,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, -8,
+ax_anim 2, 0, 193, 2, -15, 2, -15,
+ax_anim 2, 0, 186, 12, -21, 12, -21,
+ax_anim 3, 0, 187, 23, -21, 23, -21,
+ax_anim 2, 3, 188, 25, -15, 25, -15,
+ax_anim 2, 0, 189, 20, -6, 20, -6,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -7, -3, -7, -3,
+ax_anim 2, 0, 192, -9, -13, -9, -13,
+ax_anim 2, 0, 193, -7, -19, -7, -19,
+ax_anim 3, 0, 186, 0, -21, 0, -21,
+ax_anim 2, 3, 187, 7, -19, 7, -19,
+ax_anim 2, 0, 188, 9, -11, 9, -11,
+ax_anim 1, 0, 189, 7, -3, 7, -3,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -2, -15, -2, -15,
+ax_anim 2, 0, 186, -12, -21, -12, -21,
+ax_anim 3, 0, 193, -23, -21, -23, -21,
+ax_anim 2, 3, 192, -25, -15, -25, -15,
+ax_anim 2, 0, 191, -20, -6, -20, -6,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -4, -3, -4, -3,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -21, -5, -21, -5,
+ax_anim 3, 0, 192, -24, -1, -24, -1,
+ax_anim 2, 3, 191, -19, 5, -19, 5,
+ax_anim 2, 0, 190, -12, 6, -12, 6,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -9, -1, -9, -1,
+ax_anim 2, 0, 193, -21, 4, -21, 4,
+ax_anim 2, 0, 192, -26, 12, -26, 12,
+ax_anim 3, 0, 191, -25, 20, -25, 20,
+ax_anim 2, 3, 190, -14, 20, -14, 20,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -21, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPichuAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sPichuGfx1:
+.incbin "baserom.gba", 0xC83910, 0x200
+sPichuSprites1:
+ax_sprite sPichuGfx1, 0x200
+ax_sprite_terminator
+sPichuGfx2:
+.incbin "baserom.gba", 0xC83B20, 0x200
+sPichuSprites2:
+ax_sprite sPichuGfx2, 0x200
+ax_sprite_terminator
+sPichuGfx3:
+.incbin "baserom.gba", 0xC83D30, 0x200
+sPichuSprites3:
+ax_sprite sPichuGfx3, 0x200
+ax_sprite_terminator
+sPichuGfx4:
+.incbin "baserom.gba", 0xC83F40, 0x200
+sPichuSprites4:
+ax_sprite sPichuGfx4, 0x200
+ax_sprite_terminator
+sPichuGfx5:
+.incbin "baserom.gba", 0xC84150, 0x200
+sPichuSprites5:
+ax_sprite sPichuGfx5, 0x200
+ax_sprite_terminator
+sPichuGfx6:
+.incbin "baserom.gba", 0xC84360, 0x200
+sPichuSprites6:
+ax_sprite sPichuGfx6, 0x200
+ax_sprite_terminator
+sPichuGfx7:
+.incbin "baserom.gba", 0xC84570, 0x100
+sPichuSprites7:
+ax_sprite sPichuGfx7, 0x100
+ax_sprite_terminator
+sPichuGfx8:
+.incbin "baserom.gba", 0xC84680, 0x100
+sPichuSprites8:
+ax_sprite sPichuGfx8, 0x100
+ax_sprite_terminator
+sPichuGfx9:
+.incbin "baserom.gba", 0xC84790, 0x100
+sPichuSprites9:
+ax_sprite sPichuGfx9, 0x100
+ax_sprite_terminator
+sPichuGfx10:
+.incbin "baserom.gba", 0xC848A0, 0x100
+sPichuSprites10:
+ax_sprite sPichuGfx10, 0x100
+ax_sprite_terminator
+sPichuGfx11:
+.incbin "baserom.gba", 0xC849B0, 0x100
+sPichuSprites11:
+ax_sprite sPichuGfx11, 0x100
+ax_sprite_terminator
+sPichuGfx12:
+.incbin "baserom.gba", 0xC84AC0, 0x200
+sPichuSprites12:
+ax_sprite sPichuGfx12, 0x200
+ax_sprite_terminator
+sPichuGfx13:
+.incbin "baserom.gba", 0xC84CD0, 0x200
+sPichuSprites13:
+ax_sprite sPichuGfx13, 0x200
+ax_sprite_terminator
+sPichuGfx14:
+.incbin "baserom.gba", 0xC84EE0, 0x200
+sPichuSprites14:
+ax_sprite sPichuGfx14, 0x200
+ax_sprite_terminator
+sPichuGfx15:
+.incbin "baserom.gba", 0xC850F0, 0x200
+sPichuSprites15:
+ax_sprite sPichuGfx15, 0x200
+ax_sprite_terminator
+sPichuGfx16:
+.incbin "baserom.gba", 0xC85300, 0x80
+sPichuGfx16_1:
+.incbin "baserom.gba", 0xC85380, 0x60
+sPichuGfx16_2:
+.incbin "baserom.gba", 0xC853E0, 0x40
+sPichuSprites16:
+ax_sprite 0, 0x80
+ax_sprite sPichuGfx16, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx17:
+.incbin "baserom.gba", 0xC85460, 0x40
+sPichuGfx17_1:
+.incbin "baserom.gba", 0xC854A0, 0xE0
+sPichuGfx17_2:
+.incbin "baserom.gba", 0xC85580, 0x20
+sPichuSprites17:
+ax_sprite sPichuGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx17_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx17_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPichuGfx18:
+.incbin "baserom.gba", 0xC855D8, 0x40
+sPichuGfx18_1:
+.incbin "baserom.gba", 0xC85618, 0x40
+sPichuGfx18_2:
+.incbin "baserom.gba", 0xC85658, 0x60
+sPichuGfx18_3:
+.incbin "baserom.gba", 0xC856B8, 0x40
+sPichuSprites18:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx18_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx19:
+.incbin "baserom.gba", 0xC85748, 0x40
+sPichuGfx19_1:
+.incbin "baserom.gba", 0xC85788, 0x40
+sPichuGfx19_2:
+.incbin "baserom.gba", 0xC857C8, 0x40
+sPichuGfx19_3:
+.incbin "baserom.gba", 0xC85808, 0x40
+sPichuSprites19:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx19_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx19_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx20:
+.incbin "baserom.gba", 0xC85898, 0x80
+sPichuGfx20_1:
+.incbin "baserom.gba", 0xC85918, 0x40
+sPichuGfx20_2:
+.incbin "baserom.gba", 0xC85958, 0x40
+sPichuSprites20:
+ax_sprite 0, 0x80
+ax_sprite sPichuGfx20, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx21:
+.incbin "baserom.gba", 0xC859D8, 0x40
+sPichuGfx21_1:
+.incbin "baserom.gba", 0xC85A18, 0x180
+sPichuSprites21:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx21_1, 0x180
+ax_sprite_terminator
+sPichuGfx22:
+.incbin "baserom.gba", 0xC85BC0, 0x120
+sPichuGfx22_1:
+.incbin "baserom.gba", 0xC85CE0, 0xA0
+sPichuSprites22:
+ax_sprite sPichuGfx22, 0x120
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx22_1, 0xa0
+ax_sprite_terminator
+sPichuGfx23:
+.incbin "baserom.gba", 0xC85DA0, 0x80
+sPichuGfx23_1:
+.incbin "baserom.gba", 0xC85E20, 0x60
+sPichuGfx23_2:
+.incbin "baserom.gba", 0xC85E80, 0x40
+sPichuSprites23:
+ax_sprite 0, 0x80
+ax_sprite sPichuGfx23, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx24:
+.incbin "baserom.gba", 0xC85F00, 0x1E0
+sPichuSprites24:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx24, 0x1e0
+ax_sprite_terminator
+sPichuGfx25:
+.incbin "baserom.gba", 0xC860F8, 0x120
+sPichuGfx25_1:
+.incbin "baserom.gba", 0xC86218, 0xA0
+sPichuSprites25:
+ax_sprite sPichuGfx25, 0x120
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx25_1, 0xa0
+ax_sprite_terminator
+sPichuGfx26:
+.incbin "baserom.gba", 0xC862D8, 0x40
+sPichuGfx26_1:
+.incbin "baserom.gba", 0xC86318, 0xE0
+sPichuGfx26_2:
+.incbin "baserom.gba", 0xC863F8, 0x20
+sPichuSprites26:
+ax_sprite sPichuGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx26_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx26_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPichuGfx27:
+.incbin "baserom.gba", 0xC86450, 0x200
+sPichuSprites27:
+ax_sprite sPichuGfx27, 0x200
+ax_sprite_terminator
+sPichuGfx28:
+.incbin "baserom.gba", 0xC86660, 0x40
+sPichuGfx28_1:
+.incbin "baserom.gba", 0xC866A0, 0x40
+sPichuGfx28_2:
+.incbin "baserom.gba", 0xC866E0, 0x60
+sPichuGfx28_3:
+.incbin "baserom.gba", 0xC86740, 0x40
+sPichuSprites28:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx29:
+.incbin "baserom.gba", 0xC867D0, 0x140
+sPichuGfx29_1:
+.incbin "baserom.gba", 0xC86910, 0xA0
+sPichuSprites29:
+ax_sprite sPichuGfx29, 0x140
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx29_1, 0xa0
+ax_sprite_terminator
+sPichuGfx30:
+.incbin "baserom.gba", 0xC869D0, 0x40
+sPichuGfx30_1:
+.incbin "baserom.gba", 0xC86A10, 0x40
+sPichuGfx30_2:
+.incbin "baserom.gba", 0xC86A50, 0x40
+sPichuGfx30_3:
+.incbin "baserom.gba", 0xC86A90, 0x40
+sPichuSprites30:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx30_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx31:
+.incbin "baserom.gba", 0xC86B20, 0x180
+sPichuGfx31_1:
+.incbin "baserom.gba", 0xC86CA0, 0x20
+sPichuSprites31:
+ax_sprite sPichuGfx31, 0x180
+ax_sprite 0, 0x60
+ax_sprite sPichuGfx31_1, 0x20
+ax_sprite_terminator
+sPichuGfx32:
+.incbin "baserom.gba", 0xC86CE0, 0x80
+sPichuGfx32_1:
+.incbin "baserom.gba", 0xC86D60, 0x40
+sPichuGfx32_2:
+.incbin "baserom.gba", 0xC86DA0, 0x40
+sPichuSprites32:
+ax_sprite 0, 0x80
+ax_sprite sPichuGfx32, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx33:
+.incbin "baserom.gba", 0xC86E20, 0x20
+sPichuGfx33_1:
+.incbin "baserom.gba", 0xC86E40, 0xE0
+sPichuGfx33_2:
+.incbin "baserom.gba", 0xC86F20, 0x40
+sPichuSprites33:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx33, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPichuGfx33_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx34:
+.incbin "baserom.gba", 0xC86FA0, 0x40
+sPichuGfx34_1:
+.incbin "baserom.gba", 0xC86FE0, 0x80
+sPichuGfx34_2:
+.incbin "baserom.gba", 0xC87060, 0x40
+sPichuGfx34_3:
+.incbin "baserom.gba", 0xC870A0, 0x40
+sPichuSprites34:
+ax_sprite sPichuGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx34_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx35:
+.incbin "baserom.gba", 0xC87128, 0x20
+sPichuGfx35_1:
+.incbin "baserom.gba", 0xC87148, 0x60
+sPichuGfx35_2:
+.incbin "baserom.gba", 0xC871A8, 0x60
+sPichuGfx35_3:
+.incbin "baserom.gba", 0xC87208, 0x40
+sPichuSprites35:
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx35, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx36:
+.incbin "baserom.gba", 0xC87298, 0x20
+sPichuGfx36_1:
+.incbin "baserom.gba", 0xC872B8, 0x40
+sPichuGfx36_2:
+.incbin "baserom.gba", 0xC872F8, 0x60
+sPichuGfx36_3:
+.incbin "baserom.gba", 0xC87358, 0x40
+sPichuSprites36:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx36_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx37:
+.incbin "baserom.gba", 0xC873E8, 0x40
+sPichuGfx37_1:
+.incbin "baserom.gba", 0xC87428, 0x60
+sPichuGfx37_2:
+.incbin "baserom.gba", 0xC87488, 0x60
+sPichuGfx37_3:
+.incbin "baserom.gba", 0xC874E8, 0x20
+sPichuSprites37:
+ax_sprite sPichuGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx37_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx37_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPichuGfx38:
+.incbin "baserom.gba", 0xC87550, 0x60
+sPichuGfx38_1:
+.incbin "baserom.gba", 0xC875B0, 0x60
+sPichuGfx38_2:
+.incbin "baserom.gba", 0xC87610, 0x60
+sPichuGfx38_3:
+.incbin "baserom.gba", 0xC87670, 0x40
+sPichuSprites38:
+ax_sprite sPichuGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx38_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx39:
+.incbin "baserom.gba", 0xC876F8, 0x20
+sPichuGfx39_1:
+.incbin "baserom.gba", 0xC87718, 0x60
+sPichuGfx39_2:
+.incbin "baserom.gba", 0xC87778, 0x60
+sPichuGfx39_3:
+.incbin "baserom.gba", 0xC877D8, 0x40
+sPichuSprites39:
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx39, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx39_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx40:
+.incbin "baserom.gba", 0xC87868, 0x20
+sPichuGfx40_1:
+.incbin "baserom.gba", 0xC87888, 0x60
+sPichuGfx40_2:
+.incbin "baserom.gba", 0xC878E8, 0x80
+sPichuGfx40_3:
+.incbin "baserom.gba", 0xC87968, 0x40
+sPichuSprites40:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx40, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx40_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx40_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx41:
+.incbin "baserom.gba", 0xC879F8, 0x40
+sPichuGfx41_1:
+.incbin "baserom.gba", 0xC87A38, 0xE0
+sPichuGfx41_2:
+.incbin "baserom.gba", 0xC87B18, 0x40
+sPichuSprites41:
+ax_sprite sPichuGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx41_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx41_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx42:
+.incbin "baserom.gba", 0xC87B90, 0x20
+sPichuGfx42_1:
+.incbin "baserom.gba", 0xC87BB0, 0x60
+sPichuGfx42_2:
+.incbin "baserom.gba", 0xC87C10, 0x80
+sPichuGfx42_3:
+.incbin "baserom.gba", 0xC87C90, 0x40
+sPichuSprites42:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx42, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx42_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx42_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx43:
+.incbin "baserom.gba", 0xC87D20, 0x40
+sPichuGfx43_1:
+.incbin "baserom.gba", 0xC87D60, 0x40
+sPichuGfx43_2:
+.incbin "baserom.gba", 0xC87DA0, 0x40
+sPichuGfx43_3:
+.incbin "baserom.gba", 0xC87DE0, 0x40
+sPichuSprites43:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx43_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx43_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx43_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx44:
+.incbin "baserom.gba", 0xC87E70, 0x60
+sPichuGfx44_1:
+.incbin "baserom.gba", 0xC87ED0, 0x60
+sPichuGfx44_2:
+.incbin "baserom.gba", 0xC87F30, 0x40
+sPichuGfx44_3:
+.incbin "baserom.gba", 0xC87F70, 0x40
+sPichuSprites44:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx44_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx45:
+.incbin "baserom.gba", 0xC88000, 0x40
+sPichuGfx45_1:
+.incbin "baserom.gba", 0xC88040, 0x60
+sPichuGfx45_2:
+.incbin "baserom.gba", 0xC880A0, 0x40
+sPichuGfx45_3:
+.incbin "baserom.gba", 0xC880E0, 0x40
+sPichuSprites45:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx45_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx45_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx45_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx46:
+.incbin "baserom.gba", 0xC88170, 0x100
+sPichuGfx46_1:
+.incbin "baserom.gba", 0xC88270, 0x40
+sPichuGfx46_2:
+.incbin "baserom.gba", 0xC882B0, 0x40
+sPichuSprites46:
+ax_sprite sPichuGfx46, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx46_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx46_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx47:
+.incbin "baserom.gba", 0xC88328, 0x40
+sPichuGfx47_1:
+.incbin "baserom.gba", 0xC88368, 0xC0
+sPichuGfx47_2:
+.incbin "baserom.gba", 0xC88428, 0x40
+sPichuSprites47:
+ax_sprite 0, 0x20
+ax_sprite sPichuGfx47, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx47_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sPichuGfx47_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPichuGfx48:
+.incbin "baserom.gba", 0xC884A8, 0x200
+sPichuSprites48:
+ax_sprite sPichuGfx48, 0x200
+ax_sprite_terminator
+sPichuGfx49:
+.incbin "baserom.gba", 0xC886B8, 0x200
+sPichuSprites49:
+ax_sprite sPichuGfx49, 0x200
+ax_sprite_terminator
+sPichuGfx50:
+.incbin "baserom.gba", 0xC888C8, 0x200
+sPichuSprites50:
+ax_sprite sPichuGfx50, 0x200
+ax_sprite_terminator
+sPichuGfx51:
+.incbin "baserom.gba", 0xC88AD8, 0x200
+sPichuSprites51:
+ax_sprite sPichuGfx51, 0x200
+ax_sprite_terminator
+sPichuGfx52:
+.incbin "baserom.gba", 0xC88CE8, 0x200
+sPichuSprites52:
+ax_sprite sPichuGfx52, 0x200
+ax_sprite_terminator
+sPichuGfx53:
+.incbin "baserom.gba", 0xC88EF8, 0x200
+sPichuSprites53:
+ax_sprite sPichuGfx53, 0x200
+ax_sprite_terminator
+sPichuGfx54:
+.incbin "baserom.gba", 0xC89108, 0x200
+sPichuSprites54:
+ax_sprite sPichuGfx54, 0x200
+ax_sprite_terminator
+sAxPosesPichu:
+.4byte sPichuPose1
+.4byte sPichuPose2
+.4byte sPichuPose3
+.4byte sPichuPose4
+.4byte sPichuPose5
+.4byte sPichuPose6
+.4byte sPichuPose7
+.4byte sPichuPose8
+.4byte sPichuPose9
+.4byte sPichuPose10
+.4byte sPichuPose11
+.4byte sPichuPose12
+.4byte sPichuPose13
+.4byte sPichuPose14
+.4byte sPichuPose15
+.4byte sPichuPose16
+.4byte sPichuPose17
+.4byte sPichuPose18
+.4byte sPichuPose19
+.4byte sPichuPose20
+.4byte sPichuPose21
+.4byte sPichuPose22
+.4byte sPichuPose23
+.4byte sPichuPose24
+.4byte sPichuPose25
+.4byte sPichuPose26
+.4byte sPichuPose27
+.4byte sPichuPose28
+.4byte sPichuPose29
+.4byte sPichuPose30
+.4byte sPichuPose31
+.4byte sPichuPose32
+.4byte sPichuPose33
+.4byte sPichuPose34
+.4byte sPichuPose35
+.4byte sPichuPose36
+.4byte sPichuPose37
+.4byte sPichuPose38
+.4byte sPichuPose39
+.4byte sPichuPose40
+.4byte sPichuPose41
+.4byte sPichuPose42
+.4byte sPichuPose43
+.4byte sPichuPose44
+.4byte sPichuPose45
+.4byte sPichuPose46
+.4byte sPichuPose47
+.4byte sPichuPose48
+.4byte sPichuPose49
+.4byte sPichuPose50
+.4byte sPichuPose51
+.4byte sPichuPose52
+.4byte sPichuPose53
+.4byte sPichuPose54
+.4byte sPichuPose55
+.4byte sPichuPose56
+.4byte sPichuPose57
+.4byte sPichuPose58
+.4byte sPichuPose59
+.4byte sPichuPose60
+.4byte sPichuPose61
+.4byte sPichuPose62
+.4byte sPichuPose63
+.4byte sPichuPose64
+.4byte sPichuPose65
+.4byte sPichuPose66
+.4byte sPichuPose67
+.4byte sPichuPose68
+.4byte sPichuPose69
+.4byte sPichuPose70
+.4byte sPichuPose71
+.4byte sPichuPose72
+.4byte sPichuPose73
+.4byte sPichuPose74
+.4byte sPichuPose75
+.4byte sPichuPose76
+.4byte sPichuPose77
+.4byte sPichuPose78
+.4byte sPichuPose79
+.4byte sPichuPose80
+.4byte sPichuPose81
+.4byte sPichuPose82
+.4byte sPichuPose83
+.4byte sPichuPose84
+.4byte sPichuPose85
+.4byte sPichuPose86
+.4byte sPichuPose87
+.4byte sPichuPose88
+.4byte sPichuPose89
+.4byte sPichuPose90
+.4byte sPichuPose91
+.4byte sPichuPose92
+.4byte sPichuPose93
+.4byte sPichuPose94
+.4byte sPichuPose95
+.4byte sPichuPose96
+.4byte sPichuPose97
+.4byte sPichuPose98
+.4byte sPichuPose99
+.4byte sPichuPose100
+.4byte sPichuPose101
+.4byte sPichuPose102
+.4byte sPichuPose103
+.4byte sPichuPose104
+.4byte sPichuPose105
+.4byte sPichuPose106
+.4byte sPichuPose107
+.4byte sPichuPose108
+.4byte sPichuPose109
+.4byte sPichuPose110
+.4byte sPichuPose111
+.4byte sPichuPose112
+.4byte sPichuPose113
+.4byte sPichuPose114
+.4byte sPichuPose115
+.4byte sPichuPose116
+.4byte sPichuPose117
+.4byte sPichuPose118
+.4byte sPichuPose119
+.4byte sPichuPose120
+.4byte sPichuPose121
+.4byte sPichuPose122
+.4byte sPichuPose123
+.4byte sPichuPose124
+.4byte sPichuPose125
+.4byte sPichuPose126
+.4byte sPichuPose127
+.4byte sPichuPose128
+.4byte sPichuPose129
+.4byte sPichuPose130
+.4byte sPichuPose131
+.4byte sPichuPose132
+.4byte sPichuPose133
+.4byte sPichuPose134
+.4byte sPichuPose135
+.4byte sPichuPose136
+.4byte sPichuPose137
+.4byte sPichuPose138
+.4byte sPichuPose139
+.4byte sPichuPose140
+.4byte sPichuPose141
+.4byte sPichuPose142
+.4byte sPichuPose143
+.4byte sPichuPose144
+.4byte sPichuPose145
+.4byte sPichuPose146
+.4byte sPichuPose147
+.4byte sPichuPose148
+.4byte sPichuPose149
+.4byte sPichuPose150
+.4byte sPichuPose151
+.4byte sPichuPose152
+.4byte sPichuPose153
+.4byte sPichuPose154
+.4byte sPichuPose155
+.4byte sPichuPose156
+.4byte sPichuPose157
+.4byte sPichuPose158
+.4byte sPichuPose159
+.4byte sPichuPose160
+.4byte sPichuPose161
+.4byte sPichuPose162
+.4byte sPichuPose163
+.4byte sPichuPose164
+.4byte sPichuPose165
+.4byte sPichuPose166
+.4byte sPichuPose167
+.4byte sPichuPose168
+.4byte sPichuPose169
+.4byte sPichuPose170
+.4byte sPichuPose171
+.4byte sPichuPose172
+.4byte sPichuPose173
+.4byte sPichuPose174
+.4byte sPichuPose175
+.4byte sPichuPose176
+.4byte sPichuPose177
+.4byte sPichuPose178
+.4byte sPichuPose179
+.4byte sPichuPose180
+.4byte sPichuPose181
+.4byte sPichuPose182
+.4byte sPichuPose183
+.4byte sPichuPose184
+.4byte sPichuPose185
+.4byte sPichuPose186
+.4byte sPichuPose187
+.4byte sPichuPose188
+.4byte sPichuPose189
+.4byte sPichuPose190
+.4byte sPichuPose191
+.4byte sPichuPose192
+.4byte sPichuPose193
+.4byte sPichuPose194
+.4byte sPichuPose195
+.4byte sPichuPose196
+.4byte sPichuPose197
+.4byte sPichuPose198
+.4byte sPichuPose199
+.4byte sPichuPose200
+.4byte sPichuPose201
+.4byte sPichuPose202
+.4byte sPichuPose203
+.4byte sPichuPose204
+.4byte sPichuPose205
+.4byte sPichuPose206
+.4byte sPichuPose207
+.4byte sPichuPose208
+.4byte sPichuPose209
+.4byte sPichuPose210
+.4byte sPichuPose211
+.4byte sPichuPose212
+.4byte sPichuPose213
+.4byte sPichuPose214
+.4byte sPichuPose215
+.4byte sPichuPose216
+.4byte sPichuPose217
+.4byte sPichuPose218
+.4byte sPichuPose219
+.4byte sPichuPose220
+.4byte sPichuPose221
+.4byte sPichuPose222
+.4byte sPichuPose223
+.4byte sPichuPose224
+.4byte sPichuPose225
+.4byte sPichuPose226
+.4byte sPichuPose227
+.4byte sPichuPose228
+.4byte sPichuPose229
+.4byte sPichuPose230
+.4byte sPichuPose231
+.4byte sPichuPose232
+.4byte sPichuPose233
+.4byte sPichuPose234
+.4byte sPichuPose235
+.4byte sPichuPose236
+.4byte sPichuPose237
+.4byte sPichuPose238
+.4byte sPichuPose239
+.4byte sPichuPose240
+.4byte sPichuPose241
+.4byte sPichuPose242
+sAxPositionsPichu:
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -2,   -9, 	  -6,   -6, 	   4,   -9, 	  -1,   -8
+.2byte    0,   -9, 	  -6,   -9, 	   4,   -6, 	   0,   -8
+.2byte    1,   -7, 	   4,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -10, 	   4,   -7, 	  -5,   -8, 	   0,   -9
+.2byte    0,   -8, 	   4,   -9, 	  -2,   -5, 	   1,   -7
+.2byte    3,   -7, 	   0,   -3, 	  -1,   -2, 	   0,   -4
+.2byte    3,  -10, 	   3,   -7, 	  -2,   -8, 	   0,   -7
+.2byte    3,   -8, 	  -1,   -8, 	   1,   -5, 	   0,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   3,   -3, 	  -2,   -4
+.2byte    1,  -11, 	  -6,   -8, 	   2,   -8, 	  -1,   -7
+.2byte    1,  -10, 	  -4,  -10, 	   3,   -5, 	  -2,   -7
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte    0,  -10, 	   3,   -5, 	  -5,   -8, 	  -1,   -6
+.2byte   -2,   -9, 	   3,   -8, 	  -5,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,   -5, 	  -5,   -3, 	   0,   -4
+.2byte   -3,  -11, 	   4,   -8, 	  -4,   -8, 	  -1,   -7
+.2byte   -3,  -10, 	   2,  -10, 	  -5,   -5, 	   0,   -7
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -2, 	  -2,   -4
+.2byte   -5,  -10, 	  -5,   -7, 	   0,   -8, 	  -2,   -7
+.2byte   -5,   -6, 	  -1,   -6, 	  -3,   -3, 	  -2,   -4
+.2byte   -3,   -7, 	  -6,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -3,  -10, 	  -6,   -7, 	   3,   -8, 	  -2,   -9
+.2byte   -2,   -8, 	  -6,   -9, 	   0,   -5, 	  -3,   -7
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -2,   -9, 	  -6,   -6, 	   4,   -9, 	  -1,   -8
+.2byte    0,   -9, 	  -6,   -9, 	   4,   -6, 	   0,   -8
+.2byte   -1,   -9, 	  -6,   -7, 	   4,   -7, 	  -1,   -5
+.2byte    1,   -7, 	   4,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -10, 	   4,   -7, 	  -5,   -8, 	   0,   -9
+.2byte    0,   -8, 	   4,   -9, 	  -2,   -5, 	   1,   -7
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -5
+.2byte    3,   -7, 	   0,   -3, 	  -1,   -2, 	   0,   -4
+.2byte    3,  -10, 	   3,   -7, 	  -2,   -8, 	   0,   -7
+.2byte    3,   -8, 	  -1,   -8, 	   1,   -5, 	   0,   -6
+.2byte    6,  -10, 	   3,   -9, 	   1,   -7, 	   1,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   3,   -3, 	  -2,   -4
+.2byte    1,  -11, 	  -6,   -8, 	   2,   -8, 	  -1,   -7
+.2byte    1,  -10, 	  -4,  -10, 	   3,   -5, 	  -2,   -7
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -6
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte    0,  -10, 	   3,   -5, 	  -5,   -8, 	  -1,   -6
+.2byte   -2,   -9, 	   3,   -8, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -6
+.2byte   -2,   -8, 	   3,   -5, 	  -5,   -3, 	   0,   -4
+.2byte   -3,  -11, 	   4,   -8, 	  -4,   -8, 	  -1,   -7
+.2byte   -3,  -10, 	   2,  -10, 	  -5,   -5, 	   0,   -7
+.2byte   -6,  -11, 	   1,   -9, 	  -6,   -7, 	  -2,   -6
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -2, 	  -2,   -4
+.2byte   -5,  -10, 	  -5,   -7, 	   0,   -8, 	  -2,   -7
+.2byte   -5,   -6, 	  -1,   -6, 	  -3,   -3, 	  -2,   -4
+.2byte   -7,  -10, 	  -4,   -9, 	  -2,   -7, 	  -2,   -6
+.2byte   -3,   -7, 	  -6,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -3,  -10, 	  -6,   -7, 	   3,   -8, 	  -2,   -9
+.2byte   -2,   -8, 	  -6,   -9, 	   0,   -5, 	  -3,   -7
+.2byte   -4,   -9, 	  -6,   -9, 	   2,   -6, 	  -2,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -2,   -9, 	  -6,   -6, 	   4,   -9, 	  -1,   -8
+.2byte    0,   -9, 	  -6,   -9, 	   4,   -6, 	   0,   -8
+.2byte   -1,   -9, 	  -6,   -7, 	   4,   -7, 	  -1,   -5
+.2byte    1,   -7, 	   4,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -10, 	   4,   -7, 	  -5,   -8, 	   0,   -9
+.2byte    0,   -8, 	   4,   -9, 	  -2,   -5, 	   1,   -7
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -5
+.2byte    3,   -7, 	   0,   -3, 	  -1,   -2, 	   0,   -4
+.2byte    3,  -10, 	   3,   -7, 	  -2,   -8, 	   0,   -7
+.2byte    3,   -8, 	  -1,   -8, 	   1,   -5, 	   0,   -6
+.2byte    6,  -10, 	   3,   -9, 	   1,   -7, 	   1,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   3,   -3, 	  -2,   -4
+.2byte    1,  -11, 	  -6,   -8, 	   2,   -8, 	  -1,   -7
+.2byte    1,  -10, 	  -4,  -10, 	   3,   -5, 	  -2,   -7
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -6
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte    0,  -10, 	   3,   -5, 	  -5,   -8, 	  -1,   -6
+.2byte   -2,   -9, 	   3,   -8, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -6
+.2byte   -2,   -8, 	   3,   -5, 	  -5,   -3, 	   0,   -4
+.2byte   -3,  -11, 	   4,   -8, 	  -4,   -8, 	  -1,   -7
+.2byte   -3,  -10, 	   2,  -10, 	  -5,   -5, 	   0,   -7
+.2byte   -6,  -11, 	   1,   -9, 	  -6,   -7, 	  -2,   -6
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -2, 	  -2,   -4
+.2byte   -5,  -10, 	  -5,   -7, 	   0,   -8, 	  -2,   -7
+.2byte   -5,   -6, 	  -1,   -6, 	  -3,   -3, 	  -2,   -4
+.2byte   -7,  -10, 	  -4,   -9, 	  -2,   -7, 	  -2,   -6
+.2byte   -3,   -7, 	  -6,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -3,  -10, 	  -6,   -7, 	   3,   -8, 	  -2,   -9
+.2byte   -2,   -8, 	  -6,   -9, 	   0,   -5, 	  -3,   -7
+.2byte   -4,   -9, 	  -6,   -9, 	   2,   -6, 	  -2,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -1,   -9, 	  -6,   -7, 	   4,   -7, 	  -1,   -5
+.2byte   -1,  -11, 	   4,   -8, 	  -6,   -8, 	  -1,   -8
+.2byte   -1,   -9, 	  -6,   -7, 	   4,   -7, 	  -1,   -5
+.2byte   -1,  -10, 	   4,   -7, 	  -6,   -7, 	  -1,   -7
+.2byte    1,   -7, 	   4,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -5
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -6
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -5
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -6
+.2byte    3,   -7, 	   0,   -3, 	  -1,   -2, 	   0,   -4
+.2byte    6,  -10, 	   3,   -9, 	   1,   -7, 	   1,   -6
+.2byte    6,  -10, 	   3,   -9, 	   1,   -7, 	   1,   -6
+.2byte    6,  -10, 	   3,   -9, 	   1,   -7, 	   1,   -6
+.2byte    6,  -10, 	   3,   -9, 	   1,   -7, 	   1,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   3,   -3, 	  -2,   -4
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -6
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -8
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -6
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -8
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -7
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -7
+.2byte   -2,   -8, 	   3,   -5, 	  -5,   -3, 	   0,   -4
+.2byte   -6,  -11, 	   1,   -9, 	  -6,   -7, 	  -2,   -6
+.2byte   -6,  -11, 	   1,   -9, 	  -6,   -7, 	  -2,   -8
+.2byte   -6,  -11, 	   1,   -9, 	  -6,   -7, 	  -2,   -6
+.2byte   -6,  -11, 	   1,   -9, 	  -6,   -7, 	  -2,   -8
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -2, 	  -2,   -4
+.2byte   -7,  -10, 	  -4,   -9, 	  -2,   -7, 	  -2,   -6
+.2byte   -7,  -10, 	  -4,   -9, 	  -2,   -7, 	  -2,   -6
+.2byte   -7,  -10, 	  -4,   -9, 	  -2,   -7, 	  -2,   -6
+.2byte   -7,  -10, 	  -4,   -9, 	  -2,   -7, 	  -2,   -6
+.2byte   -3,   -7, 	  -6,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -4,   -9, 	  -6,   -9, 	   2,   -6, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -9, 	   2,   -6, 	  -2,   -6
+.2byte   -4,   -9, 	  -6,   -9, 	   2,   -6, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -9, 	   2,   -6, 	  -2,   -6
+.2byte   -6,  -10, 	  -5,   -5, 	  -3,   -5, 	  -3,   -6
+.2byte   -1,   -9, 	  -3,   -4, 	   1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   1,   -5, 	   3,   -5, 	   1,   -6
+.2byte    7,  -10, 	   4,   -6, 	   4,   -5, 	   2,   -6
+.2byte    4,   -9, 	   4,   -5, 	   2,   -4, 	   1,   -5
+.2byte   -1,   -8, 	   0,   -3, 	  -2,   -3, 	  -1,   -5
+.2byte    5,  -10, 	   0,   -6, 	   5,   -5, 	   1,   -6
+.2byte    7,   -9, 	   4,   -5, 	   4,   -4, 	   2,   -5
+.2byte    2,   -8, 	   4,   -4, 	   1,   -3, 	   1,   -4
+.2byte    8,   -9, 	   1,   -5, 	   5,   -4, 	   2,   -6
+.2byte    4,  -10, 	   0,   -6, 	   2,   -5, 	   1,   -7
+.2byte    0,  -11, 	  -1,   -6, 	   2,   -6, 	   1,   -7
+.2byte   -4,  -10, 	  -1,   -6, 	  -4,   -6, 	  -2,   -6
+.2byte   -1,  -10, 	   0,   -5, 	  -2,   -5, 	  -1,   -5
+.2byte    2,  -10, 	   2,   -5, 	   0,   -6, 	   1,   -5
+.2byte  -10,   -9, 	  -3,   -5, 	  -7,   -4, 	  -4,   -6
+.2byte   -6,  -10, 	  -2,   -6, 	  -4,   -5, 	  -3,   -7
+.2byte   -2,  -11, 	  -1,   -6, 	  -4,   -6, 	  -3,   -7
+.2byte   -7,  -10, 	  -2,   -6, 	  -7,   -5, 	  -3,   -6
+.2byte   -9,   -9, 	  -6,   -5, 	  -6,   -4, 	  -4,   -5
+.2byte   -4,   -8, 	  -6,   -4, 	  -3,   -3, 	  -3,   -4
+.2byte   -9,  -10, 	  -6,   -6, 	  -6,   -5, 	  -4,   -6
+.2byte   -6,   -9, 	  -6,   -5, 	  -4,   -4, 	  -3,   -5
+.2byte   -1,   -8, 	  -2,   -3, 	   0,   -3, 	  -1,   -5
+.2byte   -2,   -6, 	  -3,   -4, 	   0,   -3, 	  -1,   -4
+.2byte   -2,   -5, 	  -3,   -3, 	  -1,   -3, 	  -2,   -4
+.2byte    0,   -6, 	  -5,   -4, 	   5,   -4, 	   0,   -5
+.2byte    1,   -6, 	   3,   -5, 	  -4,   -3, 	   0,   -6
+.2byte    3,   -7, 	   1,   -5, 	   0,   -4, 	   0,   -5
+.2byte    1,   -8, 	  -1,   -5, 	   3,   -4, 	   0,   -5
+.2byte    0,   -8, 	   5,   -3, 	  -5,   -3, 	   0,   -5
+.2byte   -2,   -8, 	   0,   -5, 	  -4,   -4, 	  -1,   -5
+.2byte   -4,   -7, 	  -2,   -5, 	  -1,   -4, 	  -1,   -5
+.2byte   -2,   -6, 	  -4,   -5, 	   3,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -2,   -9, 	  -6,   -6, 	   4,   -9, 	  -1,   -8
+.2byte    0,   -9, 	  -6,   -9, 	   4,   -6, 	   0,   -8
+.2byte    1,   -7, 	   4,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -10, 	   4,   -7, 	  -5,   -8, 	   0,   -9
+.2byte    0,   -8, 	   4,   -9, 	  -2,   -5, 	   1,   -7
+.2byte    3,   -7, 	   0,   -3, 	  -1,   -2, 	   0,   -4
+.2byte    3,  -10, 	   3,   -7, 	  -2,   -8, 	   0,   -7
+.2byte    3,   -8, 	  -1,   -8, 	   1,   -5, 	   0,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   3,   -3, 	  -2,   -4
+.2byte    1,  -11, 	  -6,   -8, 	   2,   -8, 	  -1,   -7
+.2byte    1,  -10, 	  -4,  -10, 	   3,   -5, 	  -2,   -7
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte    0,  -10, 	   3,   -5, 	  -5,   -8, 	  -1,   -6
+.2byte   -2,   -9, 	   3,   -8, 	  -5,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	   3,   -5, 	  -5,   -3, 	   0,   -4
+.2byte   -3,  -11, 	   4,   -8, 	  -4,   -8, 	  -1,   -7
+.2byte   -3,  -10, 	   2,  -10, 	  -5,   -5, 	   0,   -7
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -2, 	  -2,   -4
+.2byte   -5,  -10, 	  -5,   -7, 	   0,   -8, 	  -2,   -7
+.2byte   -5,   -6, 	  -1,   -6, 	  -3,   -3, 	  -2,   -4
+.2byte   -3,   -7, 	  -6,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -3,  -10, 	  -6,   -7, 	   3,   -8, 	  -2,   -9
+.2byte   -2,   -8, 	  -6,   -9, 	   0,   -5, 	  -3,   -7
+.2byte   -1,   -9, 	  -3,   -4, 	   1,   -4, 	  -1,   -6
+.2byte   -5,   -9, 	  -5,   -5, 	  -3,   -4, 	  -2,   -5
+.2byte   -7,   -9, 	  -4,   -5, 	  -4,   -4, 	  -2,   -5
+.2byte   -5,  -10, 	  -1,   -6, 	  -3,   -5, 	  -2,   -7
+.2byte   -1,  -11, 	   0,   -6, 	  -2,   -6, 	  -1,   -6
+.2byte    4,  -10, 	   0,   -6, 	   2,   -5, 	   1,   -7
+.2byte    6,   -9, 	   3,   -5, 	   3,   -4, 	   1,   -5
+.2byte    4,   -9, 	   4,   -5, 	   2,   -4, 	   1,   -5
+.2byte   -1,   -9, 	  -6,   -7, 	   4,   -7, 	  -1,   -5
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -5
+.2byte    5,  -10, 	   2,   -9, 	   0,   -7, 	   0,   -6
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -6
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -6
+.2byte   -5,  -11, 	   2,   -9, 	  -5,   -7, 	  -1,   -6
+.2byte   -6,  -10, 	  -3,   -9, 	  -1,   -7, 	  -1,   -6
+.2byte   -3,   -9, 	  -5,   -9, 	   3,   -6, 	  -1,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -2,   -9, 	  -6,   -6, 	   4,   -9, 	  -1,   -8
+.2byte    0,   -9, 	  -6,   -9, 	   4,   -6, 	   0,   -8
+.2byte    1,   -7, 	   4,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -10, 	   4,   -7, 	  -5,   -8, 	   0,   -9
+.2byte    0,   -8, 	   4,   -9, 	  -2,   -5, 	   1,   -7
+.2byte    3,   -7, 	   0,   -3, 	  -1,   -2, 	   0,   -4
+.2byte    3,  -10, 	   3,   -7, 	  -2,   -8, 	   0,   -7
+.2byte    3,   -8, 	  -1,   -8, 	   1,   -5, 	   0,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   3,   -3, 	  -2,   -4
+.2byte    1,  -11, 	  -6,   -8, 	   2,   -8, 	  -1,   -7
+.2byte    1,  -10, 	  -4,  -10, 	   3,   -5, 	  -2,   -7
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte    0,  -10, 	   3,   -5, 	  -5,   -8, 	  -1,   -6
+.2byte   -2,   -9, 	   3,   -8, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	   4,   -5, 	  -4,   -3, 	   1,   -4
+.2byte   -2,  -11, 	   5,   -8, 	  -3,   -8, 	   0,   -7
+.2byte   -2,  -10, 	   3,  -10, 	  -4,   -5, 	   1,   -7
+.2byte   -4,   -7, 	  -1,   -3, 	   0,   -2, 	  -1,   -4
+.2byte   -4,  -10, 	  -4,   -7, 	   1,   -8, 	  -1,   -7
+.2byte   -4,   -8, 	   0,   -8, 	  -2,   -5, 	  -1,   -6
+.2byte   -2,   -7, 	  -5,   -6, 	   4,   -3, 	  -1,   -6
+.2byte   -2,  -10, 	  -5,   -7, 	   4,   -8, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -9, 	   1,   -5, 	  -2,   -7
+.2byte   -1,   -9, 	  -6,   -7, 	   4,   -7, 	  -1,   -5
+.2byte   -3,   -9, 	  -5,   -9, 	   3,   -6, 	  -1,   -5
+.2byte   -6,  -10, 	  -3,   -9, 	  -1,   -7, 	  -1,   -6
+.2byte   -5,  -11, 	   2,   -9, 	  -5,   -7, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -8, 	  -6,   -8, 	  -1,   -6
+.2byte    4,  -11, 	  -3,   -9, 	   4,   -7, 	   0,   -6
+.2byte    5,  -10, 	   2,   -9, 	   0,   -7, 	   0,   -6
+.2byte    2,   -9, 	   4,   -9, 	  -4,   -6, 	   0,   -5
+.2byte   -1,   -7, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -3,   -7, 	  -6,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -2, 	  -2,   -4
+.2byte   -2,   -8, 	   3,   -5, 	  -5,   -3, 	   0,   -4
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   3,   -3, 	  -2,   -4
+.2byte    3,   -7, 	   0,   -3, 	  -1,   -2, 	   0,   -4
+.2byte    1,   -7, 	   4,   -6, 	  -5,   -3, 	   0,   -6
+sPichuAnimTable1:
+.4byte sPichuAnims_1_1
+.4byte sPichuAnims_1_2
+.4byte sPichuAnims_1_3
+.4byte sPichuAnims_1_4
+.4byte sPichuAnims_1_5
+.4byte sPichuAnims_1_6
+.4byte sPichuAnims_1_7
+.4byte sPichuAnims_1_8
+sPichuAnimTable2:
+.4byte sPichuAnims_2_1
+.4byte sPichuAnims_2_2
+.4byte sPichuAnims_2_3
+.4byte sPichuAnims_2_4
+.4byte sPichuAnims_2_5
+.4byte sPichuAnims_2_6
+.4byte sPichuAnims_2_7
+.4byte sPichuAnims_2_8
+sPichuAnimTable3:
+.4byte sPichuAnims_3_1
+.4byte sPichuAnims_3_2
+.4byte sPichuAnims_3_3
+.4byte sPichuAnims_3_4
+.4byte sPichuAnims_3_5
+.4byte sPichuAnims_3_6
+.4byte sPichuAnims_3_7
+.4byte sPichuAnims_3_8
+sPichuAnimTable4:
+.4byte sPichuAnims_4_1
+.4byte sPichuAnims_4_2
+.4byte sPichuAnims_4_3
+.4byte sPichuAnims_4_4
+.4byte sPichuAnims_4_5
+.4byte sPichuAnims_4_6
+.4byte sPichuAnims_4_7
+.4byte sPichuAnims_4_8
+sPichuAnimTable5:
+.4byte sPichuAnims_5_1
+.4byte sPichuAnims_5_2
+.4byte sPichuAnims_5_3
+.4byte sPichuAnims_5_4
+.4byte sPichuAnims_5_5
+.4byte sPichuAnims_5_6
+.4byte sPichuAnims_5_7
+.4byte sPichuAnims_5_8
+sPichuAnimTable6:
+.4byte sPichuAnims_6_1
+.4byte sPichuAnims_6_1
+.4byte sPichuAnims_6_1
+.4byte sPichuAnims_6_1
+.4byte sPichuAnims_6_1
+.4byte sPichuAnims_6_1
+.4byte sPichuAnims_6_1
+.4byte sPichuAnims_6_1
+sPichuAnimTable7:
+.4byte sPichuAnims_7_1
+.4byte sPichuAnims_7_2
+.4byte sPichuAnims_7_3
+.4byte sPichuAnims_7_4
+.4byte sPichuAnims_7_5
+.4byte sPichuAnims_7_6
+.4byte sPichuAnims_7_7
+.4byte sPichuAnims_7_8
+sPichuAnimTable8:
+.4byte sPichuAnims_8_1
+.4byte sPichuAnims_8_2
+.4byte sPichuAnims_8_3
+.4byte sPichuAnims_8_4
+.4byte sPichuAnims_8_5
+.4byte sPichuAnims_8_6
+.4byte sPichuAnims_8_7
+.4byte sPichuAnims_8_8
+sPichuAnimTable9:
+.4byte sPichuAnims_9_1
+.4byte sPichuAnims_9_2
+.4byte sPichuAnims_9_3
+.4byte sPichuAnims_9_4
+.4byte sPichuAnims_9_5
+.4byte sPichuAnims_9_6
+.4byte sPichuAnims_9_7
+.4byte sPichuAnims_9_8
+sPichuAnimTable10:
+.4byte sPichuAnims_10_1
+.4byte sPichuAnims_10_2
+.4byte sPichuAnims_10_3
+.4byte sPichuAnims_10_4
+.4byte sPichuAnims_10_5
+.4byte sPichuAnims_10_6
+.4byte sPichuAnims_10_7
+.4byte sPichuAnims_10_8
+sPichuAnimTable11:
+.4byte sPichuAnims_11_1
+.4byte sPichuAnims_11_2
+.4byte sPichuAnims_11_3
+.4byte sPichuAnims_11_4
+.4byte sPichuAnims_11_5
+.4byte sPichuAnims_11_6
+.4byte sPichuAnims_11_7
+.4byte sPichuAnims_11_8
+sPichuAnimTable12:
+.4byte sPichuAnims_12_1
+.4byte sPichuAnims_12_2
+.4byte sPichuAnims_12_3
+.4byte sPichuAnims_12_4
+.4byte sPichuAnims_12_5
+.4byte sPichuAnims_12_6
+.4byte sPichuAnims_12_7
+.4byte sPichuAnims_12_8
+sPichuAnimTable13:
+.4byte sPichuAnims_13_1
+.4byte sPichuAnims_13_2
+.4byte sPichuAnims_13_3
+.4byte sPichuAnims_13_4
+.4byte sPichuAnims_13_5
+.4byte sPichuAnims_13_6
+.4byte sPichuAnims_13_7
+.4byte sPichuAnims_13_8
+sAxAnimationsPichu:
+.4byte sPichuAnimTable1
+.4byte sPichuAnimTable2
+.4byte sPichuAnimTable3
+.4byte sPichuAnimTable4
+.4byte sPichuAnimTable5
+.4byte sPichuAnimTable6
+.4byte sPichuAnimTable7
+.4byte sPichuAnimTable8
+.4byte sPichuAnimTable9
+.4byte sPichuAnimTable10
+.4byte sPichuAnimTable11
+.4byte sPichuAnimTable12
+.4byte sPichuAnimTable13
+sAxSpritesPichu:
+.4byte sPichuSprites1
+.4byte sPichuSprites2
+.4byte sPichuSprites3
+.4byte sPichuSprites4
+.4byte sPichuSprites5
+.4byte sPichuSprites6
+.4byte sPichuSprites7
+.4byte sPichuSprites8
+.4byte sPichuSprites9
+.4byte sPichuSprites10
+.4byte sPichuSprites11
+.4byte sPichuSprites12
+.4byte sPichuSprites13
+.4byte sPichuSprites14
+.4byte sPichuSprites15
+.4byte sPichuSprites16
+.4byte sPichuSprites17
+.4byte sPichuSprites18
+.4byte sPichuSprites19
+.4byte sPichuSprites20
+.4byte sPichuSprites21
+.4byte sPichuSprites22
+.4byte sPichuSprites23
+.4byte sPichuSprites24
+.4byte sPichuSprites25
+.4byte sPichuSprites26
+.4byte sPichuSprites27
+.4byte sPichuSprites28
+.4byte sPichuSprites29
+.4byte sPichuSprites30
+.4byte sPichuSprites31
+.4byte sPichuSprites32
+.4byte sPichuSprites33
+.4byte sPichuSprites34
+.4byte sPichuSprites35
+.4byte sPichuSprites36
+.4byte sPichuSprites37
+.4byte sPichuSprites38
+.4byte sPichuSprites39
+.4byte sPichuSprites40
+.4byte sPichuSprites41
+.4byte sPichuSprites42
+.4byte sPichuSprites43
+.4byte sPichuSprites44
+.4byte sPichuSprites45
+.4byte sPichuSprites46
+.4byte sPichuSprites47
+.4byte sPichuSprites48
+.4byte sPichuSprites49
+.4byte sPichuSprites50
+.4byte sPichuSprites51
+.4byte sPichuSprites52
+.4byte sPichuSprites53
+.4byte sPichuSprites54
+sAxMainPichu:
+ax_main sAxPosesPichu, sAxAnimationsPichu, 13, sAxSpritesPichu, sAxPositionsPichu

--- a/data/ax/pidgeot.inc
+++ b/data/ax/pidgeot.inc
@@ -1,0 +1,2733 @@
+.global gAxPidgeot
+gAxPidgeot:
+ax_siro sAxMainPidgeot
+sPidgeotPose1:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose2:
+ax_pose 1, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose3:
+ax_pose 2, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose4:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose5:
+ax_pose 4, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose6:
+ax_pose 5, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose7:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose8:
+ax_pose 7, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose9:
+ax_pose 8, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose10:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose11:
+ax_pose 10, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose12:
+ax_pose 11, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose13:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose14:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose15:
+ax_pose 14, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose16:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose17:
+ax_pose 10, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose18:
+ax_pose 11, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose19:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose20:
+ax_pose 7, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose21:
+ax_pose 8, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose22:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose23:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose24:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose25:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose26:
+ax_pose 15, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose27:
+ax_pose 16, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose28:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose29:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose30:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose31:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose32:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose33:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose34:
+ax_pose 21, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose35:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose36:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose37:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose38:
+ax_pose 24, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sPidgeotPose39:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose40:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose41:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose42:
+ax_pose 27, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose43:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose44:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose45:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose46:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose47:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose48:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose49:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose50:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose51:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose52:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose53:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose54:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose55:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose56:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose57:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose58:
+ax_pose 15, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose59:
+ax_pose 16, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose60:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose61:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose62:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose63:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose64:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose65:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose66:
+ax_pose 21, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose67:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose68:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose69:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose70:
+ax_pose 24, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sPidgeotPose71:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose72:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose73:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose74:
+ax_pose 27, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose75:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose76:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose77:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose78:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose79:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose80:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose81:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose82:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose83:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose84:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose85:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose86:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose87:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose88:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose89:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose90:
+ax_pose 16, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose91:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose92:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose93:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose94:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose95:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose96:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose97:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose98:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose99:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose100:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose101:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose102:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose103:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose104:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose105:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose106:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose107:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose108:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose109:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose110:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose111:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose112:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose113:
+ax_pose 16, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose114:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose115:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose116:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose117:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose118:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose119:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose120:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose121:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose122:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose123:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose124:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose125:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose126:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose127:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose128:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose129:
+ax_pose 30, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeotPose130:
+ax_pose 31, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeotPose131:
+ax_pose 32, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose132:
+ax_pose 33, 0x01e1, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeotPose133:
+ax_pose 34, 0x01e1, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeotPose134:
+ax_pose 35, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose135:
+ax_pose 36, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose136:
+ax_pose 35, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose137:
+ax_pose 34, 0x01e1, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose138:
+ax_pose 33, 0x01e1, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose139:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose140:
+ax_pose 1, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose141:
+ax_pose 2, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose142:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose143:
+ax_pose 4, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose144:
+ax_pose 5, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose145:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose146:
+ax_pose 7, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose147:
+ax_pose 8, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose148:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose149:
+ax_pose 10, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose150:
+ax_pose 11, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose151:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose152:
+ax_pose 13, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose153:
+ax_pose 14, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose154:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose155:
+ax_pose 10, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose156:
+ax_pose 11, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose157:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose158:
+ax_pose 7, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose159:
+ax_pose 8, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose160:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose161:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose162:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose163:
+ax_pose 15, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose164:
+ax_pose 18, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeotPose165:
+ax_pose 21, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeotPose166:
+ax_pose 24, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeotPose167:
+ax_pose 27, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose168:
+ax_pose 24, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sPidgeotPose169:
+ax_pose 21, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose170:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose171:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose172:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose173:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose174:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose175:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose176:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose177:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose178:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose179:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose180:
+ax_pose 16, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose181:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose182:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeotPose183:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose184:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose185:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose186:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose187:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose188:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose189:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose190:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose191:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose192:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose193:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose194:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose195:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose196:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose197:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose198:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose199:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose200:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose201:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose202:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose203:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose204:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose205:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose206:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose207:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose208:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose209:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose210:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose211:
+ax_pose 0, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeotPose212:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeotPose213:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose214:
+ax_pose 9, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeotPose215:
+ax_pose 12, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeotPose216:
+ax_pose 9, 0x01e7, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeotPose217:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeotPose218:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+.align 2
+sPidgeotAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, 0,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 4, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 5, 0, 5,
+ax_anim_terminator
+sPidgeotAnims_2_2:
+ax_anim 2, 0, 30, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 4, 0, 31, 0, -5, 0, 0,
+ax_anim 1, 2, 29, 2, -1, 2, 2,
+ax_anim 1, 0, 29, 10, 10, 10, 12,
+ax_anim 2, 0, 29, 16, 20, 16, 20,
+ax_anim 2, 1, 29, 17, 19, 17, 19,
+ax_anim 2, 0, 29, 16, 20, 16, 20,
+ax_anim 2, 0, 29, 17, 19, 17, 19,
+ax_anim 2, 0, 29, 16, 20, 16, 20,
+ax_anim 2, 0, 29, 17, 19, 17, 19,
+ax_anim 2, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 5, 5, 5, 5,
+ax_anim_terminator
+sPidgeotAnims_2_3:
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 4, 0, 35, 0, -5, 0, 0,
+ax_anim 1, 2, 33, 2, -5, 2, 2,
+ax_anim 1, 0, 33, 10, -3, 10, 0,
+ax_anim 2, 0, 33, 15, 0, 15, 0,
+ax_anim 2, 1, 33, 15, -1, 15, -1,
+ax_anim 2, 0, 33, 15, 0, 15, 0,
+ax_anim 2, 0, 33, 15, -1, 15, -1,
+ax_anim 2, 0, 33, 15, 0, 15, 0,
+ax_anim 2, 0, 33, 15, -1, 15, -1,
+ax_anim 2, 0, 35, 12, -2, 12, 0,
+ax_anim 2, 0, 35, 5, -3, 5, 0,
+ax_anim_terminator
+sPidgeotAnims_2_4:
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 2, 0, 39, 0, -4, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 4, 0, 39, 0, -5, 0, 0,
+ax_anim 1, 2, 37, 2, -4, 2, -2,
+ax_anim 1, 0, 37, 10, -11, 10, -10,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 1, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 39, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 5, -5, 5, -5,
+ax_anim_terminator
+sPidgeotAnims_2_5:
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 4, 0, 43, 0, -5, 0, 0,
+ax_anim 1, 2, 41, 0, -8, 0, -2,
+ax_anim 1, 0, 41, 0, -12, 0, -8,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 1, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 43, 0, -5, 0, -5,
+ax_anim_terminator
+sPidgeotAnims_2_6:
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 4, 0, 47, 0, -5, 0, 0,
+ax_anim 1, 2, 45, -2, -4, -2, -2,
+ax_anim 1, 0, 45, -10, -11, -10, -10,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 1, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 47, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -5, -5, -5, -5,
+ax_anim_terminator
+sPidgeotAnims_2_7:
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 49, -2, -5, -2, 2,
+ax_anim 1, 0, 49, -10, -3, -10, 0,
+ax_anim 2, 0, 49, -15, 0, -15, 0,
+ax_anim 2, 1, 49, -15, -1, -15, -1,
+ax_anim 2, 0, 49, -15, 0, -15, 0,
+ax_anim 2, 0, 49, -15, -1, -15, -1,
+ax_anim 2, 0, 49, -15, 0, -15, 0,
+ax_anim 2, 0, 49, -15, -1, -15, -1,
+ax_anim 2, 0, 51, -12, -2, -12, 0,
+ax_anim 2, 0, 51, -5, -3, -5, 0,
+ax_anim_terminator
+sPidgeotAnims_2_8:
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 4, 0, 55, 0, -5, 0, 0,
+ax_anim 1, 2, 53, -2, -1, -2, 2,
+ax_anim 1, 0, 53, -10, 10, -10, 12,
+ax_anim 2, 0, 53, -16, 20, -16, 20,
+ax_anim 2, 1, 53, -17, 19, -17, 19,
+ax_anim 2, 0, 53, -16, 20, -16, 20,
+ax_anim 2, 0, 53, -17, 19, -17, 19,
+ax_anim 2, 0, 53, -16, 20, -16, 20,
+ax_anim 2, 0, 53, -17, 19, -17, 19,
+ax_anim 2, 0, 55, -12, 12, -12, 12,
+ax_anim 2, 0, 55, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 4, 0, 59, 0, -5, 0, 0,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 1, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 5, 0, 5,
+ax_anim_terminator
+sPidgeotAnims_3_2:
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 63, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -5, 0, 0,
+ax_anim 4, 0, 63, 0, -5, 0, 0,
+ax_anim 1, 2, 61, 2, -1, 2, 2,
+ax_anim 1, 0, 61, 10, 10, 10, 12,
+ax_anim 2, 0, 61, 16, 20, 16, 20,
+ax_anim 2, 1, 61, 17, 19, 17, 19,
+ax_anim 2, 0, 61, 16, 20, 16, 20,
+ax_anim 2, 0, 61, 17, 19, 17, 19,
+ax_anim 2, 0, 61, 16, 20, 16, 20,
+ax_anim 2, 0, 61, 17, 19, 17, 19,
+ax_anim 2, 0, 63, 12, 12, 12, 12,
+ax_anim 2, 0, 63, 5, 5, 5, 5,
+ax_anim_terminator
+sPidgeotAnims_3_3:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 4, 0, 67, 0, -5, 0, 0,
+ax_anim 1, 2, 65, 2, -5, 2, 2,
+ax_anim 1, 0, 65, 10, -3, 10, 0,
+ax_anim 2, 0, 65, 15, 0, 15, 0,
+ax_anim 2, 1, 65, 15, -1, 15, -1,
+ax_anim 2, 0, 65, 15, 0, 15, 0,
+ax_anim 2, 0, 65, 15, -1, 15, -1,
+ax_anim 2, 0, 65, 15, 0, 15, 0,
+ax_anim 2, 0, 65, 15, -1, 15, -1,
+ax_anim 2, 0, 67, 12, -2, 12, 0,
+ax_anim 2, 0, 67, 5, -3, 5, 0,
+ax_anim_terminator
+sPidgeotAnims_3_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 4, 0, 71, 0, -5, 0, 0,
+ax_anim 1, 2, 69, 2, -4, 2, -2,
+ax_anim 1, 0, 69, 10, -11, 10, -10,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 1, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 0, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 0, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 71, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 5, -5, 5, -5,
+ax_anim_terminator
+sPidgeotAnims_3_5:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 4, 0, 75, 0, -5, 0, 0,
+ax_anim 1, 2, 73, 0, -8, 0, -2,
+ax_anim 1, 0, 73, 0, -12, 0, -8,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 1, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 75, 0, -12, 0, -12,
+ax_anim 2, 0, 75, 0, -5, 0, -5,
+ax_anim_terminator
+sPidgeotAnims_3_6:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 4, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 2, 77, -2, -4, -2, -2,
+ax_anim 1, 0, 77, -10, -11, -10, -10,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 1, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 0, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 0, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 79, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -5, -5, -5, -5,
+ax_anim_terminator
+sPidgeotAnims_3_7:
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 0, 83, 0, -5, 0, 0,
+ax_anim 1, 2, 81, -2, -5, -2, 2,
+ax_anim 1, 0, 81, -10, -3, -10, 0,
+ax_anim 2, 0, 81, -15, 0, -15, 0,
+ax_anim 2, 1, 81, -15, -1, -15, -1,
+ax_anim 2, 0, 81, -15, 0, -15, 0,
+ax_anim 2, 0, 81, -15, -1, -15, -1,
+ax_anim 2, 0, 81, -15, 0, -15, 0,
+ax_anim 2, 0, 81, -15, -1, -15, -1,
+ax_anim 2, 0, 83, -12, -2, -12, 0,
+ax_anim 2, 0, 83, -5, -3, -5, 0,
+ax_anim_terminator
+sPidgeotAnims_3_8:
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 4, 0, 87, 0, -5, 0, 0,
+ax_anim 1, 2, 85, -2, -1, -2, 2,
+ax_anim 1, 0, 85, -10, 10, -10, 12,
+ax_anim 2, 0, 85, -16, 20, -16, 20,
+ax_anim 2, 1, 85, -17, 19, -17, 19,
+ax_anim 2, 0, 85, -16, 20, -16, 20,
+ax_anim 2, 0, 85, -17, 19, -17, 19,
+ax_anim 2, 0, 85, -16, 20, -16, 20,
+ax_anim 2, 0, 85, -17, 19, -17, 19,
+ax_anim 2, 0, 87, -12, 12, -12, 12,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_4_1:
+ax_anim 3, 0, 89, 0, -2, 0, 0,
+ax_anim 3, 0, 90, 0, -4, 0, 0,
+ax_anim 3, 0, 89, 0, -5, 0, 0,
+ax_anim 3, 2, 90, 0, -7, 0, 0,
+ax_anim 3, 0, 89, 0, -8, 0, 0,
+ax_anim 3, 0, 90, 0, -8, 0, 0,
+ax_anim 3, 1, 89, 0, -8, 0, 0,
+ax_anim 3, 0, 90, 0, -8, 0, 0,
+ax_anim 3, 0, 89, 0, -8, 0, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_4_2:
+ax_anim 3, 0, 92, 0, -2, 0, 0,
+ax_anim 3, 0, 93, 0, -4, 0, 0,
+ax_anim 3, 0, 92, 0, -5, 0, 0,
+ax_anim 3, 2, 93, 0, -7, 0, 0,
+ax_anim 3, 0, 92, 0, -8, 0, 0,
+ax_anim 3, 0, 93, 0, -8, 0, 0,
+ax_anim 3, 1, 92, 0, -8, 0, 0,
+ax_anim 3, 0, 93, 0, -8, 0, 0,
+ax_anim 3, 0, 92, 0, -8, 0, 0,
+ax_anim 2, 0, 92, 0, -6, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_4_3:
+ax_anim 3, 0, 95, 0, -2, 0, 0,
+ax_anim 3, 0, 96, 0, -4, 0, 0,
+ax_anim 3, 0, 95, 0, -5, 0, 0,
+ax_anim 3, 2, 96, 0, -7, 0, 0,
+ax_anim 3, 0, 95, 0, -8, 0, 0,
+ax_anim 3, 0, 96, 0, -8, 0, 0,
+ax_anim 3, 1, 95, 0, -8, 0, 0,
+ax_anim 3, 0, 96, 0, -8, 0, 0,
+ax_anim 3, 0, 95, 0, -8, 0, 0,
+ax_anim 2, 0, 95, 0, -6, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_4_4:
+ax_anim 3, 0, 98, 0, -2, 0, 0,
+ax_anim 3, 0, 99, 0, -4, 0, 0,
+ax_anim 3, 0, 98, 0, -5, 0, 0,
+ax_anim 3, 2, 99, 0, -7, 0, 0,
+ax_anim 3, 0, 98, 0, -8, 0, 0,
+ax_anim 3, 0, 99, 0, -8, 0, 0,
+ax_anim 3, 1, 98, 0, -8, 0, 0,
+ax_anim 3, 0, 99, 0, -8, 0, 0,
+ax_anim 3, 0, 98, 0, -8, 0, 0,
+ax_anim 2, 0, 98, 0, -6, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_4_5:
+ax_anim 3, 0, 101, 0, -2, 0, 0,
+ax_anim 3, 0, 102, 0, -4, 0, 0,
+ax_anim 3, 0, 101, 0, -5, 0, 0,
+ax_anim 3, 2, 102, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 3, 0, 102, 0, -8, 0, 0,
+ax_anim 3, 1, 101, 0, -8, 0, 0,
+ax_anim 3, 0, 102, 0, -8, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_4_6:
+ax_anim 3, 0, 104, 0, -2, 0, 0,
+ax_anim 3, 0, 105, 0, -4, 0, 0,
+ax_anim 3, 0, 104, 0, -5, 0, 0,
+ax_anim 3, 2, 105, 0, -7, 0, 0,
+ax_anim 3, 0, 104, 0, -8, 0, 0,
+ax_anim 3, 0, 105, 0, -8, 0, 0,
+ax_anim 3, 1, 104, 0, -8, 0, 0,
+ax_anim 3, 0, 105, 0, -8, 0, 0,
+ax_anim 3, 0, 104, 0, -8, 0, 0,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_4_7:
+ax_anim 3, 0, 107, 0, -2, 0, 0,
+ax_anim 3, 0, 108, 0, -4, 0, 0,
+ax_anim 3, 0, 107, 0, -5, 0, 0,
+ax_anim 3, 2, 108, 0, -7, 0, 0,
+ax_anim 3, 0, 107, 0, -8, 0, 0,
+ax_anim 3, 0, 108, 0, -8, 0, 0,
+ax_anim 3, 1, 107, 0, -8, 0, 0,
+ax_anim 3, 0, 108, 0, -8, 0, 0,
+ax_anim 3, 0, 107, 0, -8, 0, 0,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_4_8:
+ax_anim 3, 0, 110, 0, -2, 0, 0,
+ax_anim 3, 0, 111, 0, -4, 0, 0,
+ax_anim 3, 0, 110, 0, -5, 0, 0,
+ax_anim 3, 2, 111, 0, -7, 0, 0,
+ax_anim 3, 0, 110, 0, -8, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 1, 110, 0, -8, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 0, 110, 0, -8, 0, 0,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_5_1:
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 2, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 1, 113, 0, -4, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_5_2:
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 2, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 1, 115, 0, -4, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_5_3:
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 2, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 1, 117, 0, -4, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_5_4:
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 2, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 1, 119, 0, -4, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_5_5:
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 2, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 1, 121, 0, -4, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_5_6:
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 2, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 1, 123, 0, -4, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_5_7:
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 2, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 1, 125, 0, -4, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_5_8:
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 2, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 1, 127, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sPidgeotAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sPidgeotAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sPidgeotAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sPidgeotAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sPidgeotAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sPidgeotAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sPidgeotAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_8_2:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 4, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_8_4:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_8_5:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 4, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_8_6:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 4, 0, 153, 0, -3, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 0, 156, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_8_8:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 4, 0, 159, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 10, 9, 10, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -10, 9, -10, 9,
+ax_anim 1, 0, 169, -7, 3, -7, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, 0, 9, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 9, 22, 9,
+ax_anim 3, 0, 165, 20, 19, 20, 19,
+ax_anim 2, 3, 166, 12, 20, 12, 20,
+ax_anim 2, 0, 167, 4, 14, 4, 14,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 20, 1, 20, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 13, -20, 13, -20,
+ax_anim 3, 0, 163, 18, -20, 18, -20,
+ax_anim 2, 3, 164, 18, -12, 18, -12,
+ax_anim 2, 0, 165, 16, -6, 16, -6,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -10, -10, -10, -10,
+ax_anim 2, 0, 169, -7, -15, -7, -15,
+ax_anim 3, 0, 162, 0, -18, 0, -18,
+ax_anim 2, 3, 163, 7, -15, 7, -15,
+ax_anim 2, 0, 164, 10, -8, 10, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -13, -20, -13, -20,
+ax_anim 3, 0, 169, -18, -20, -18, -20,
+ax_anim 2, 3, 168, -18, -12, -18, -12,
+ax_anim 2, 0, 167, -16, -6, -16, -6,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -20, 1, -20, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, 0, -9, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 9, -22, 9,
+ax_anim 3, 0, 167, -20, 19, -20, 19,
+ax_anim 2, 3, 166, -12, 20, -12, 20,
+ax_anim 2, 0, 165, -4, 14, -4, 14,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeotAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeotGfx1:
+.incbin "baserom.gba", 0x5D08FC, 0x200
+sPidgeotSprites1:
+ax_sprite sPidgeotGfx1, 0x200
+ax_sprite_terminator
+sPidgeotGfx2:
+.incbin "baserom.gba", 0x5D0B0C, 0x200
+sPidgeotSprites2:
+ax_sprite sPidgeotGfx2, 0x200
+ax_sprite_terminator
+sPidgeotGfx3:
+.incbin "baserom.gba", 0x5D0D1C, 0x200
+sPidgeotSprites3:
+ax_sprite sPidgeotGfx3, 0x200
+ax_sprite_terminator
+sPidgeotGfx4:
+.incbin "baserom.gba", 0x5D0F2C, 0x200
+sPidgeotSprites4:
+ax_sprite sPidgeotGfx4, 0x200
+ax_sprite_terminator
+sPidgeotGfx5:
+.incbin "baserom.gba", 0x5D113C, 0x200
+sPidgeotSprites5:
+ax_sprite sPidgeotGfx5, 0x200
+ax_sprite_terminator
+sPidgeotGfx6:
+.incbin "baserom.gba", 0x5D134C, 0x200
+sPidgeotSprites6:
+ax_sprite sPidgeotGfx6, 0x200
+ax_sprite_terminator
+sPidgeotGfx7:
+.incbin "baserom.gba", 0x5D155C, 0x200
+sPidgeotSprites7:
+ax_sprite sPidgeotGfx7, 0x200
+ax_sprite_terminator
+sPidgeotGfx8:
+.incbin "baserom.gba", 0x5D176C, 0x200
+sPidgeotSprites8:
+ax_sprite sPidgeotGfx8, 0x200
+ax_sprite_terminator
+sPidgeotGfx9:
+.incbin "baserom.gba", 0x5D197C, 0x200
+sPidgeotSprites9:
+ax_sprite sPidgeotGfx9, 0x200
+ax_sprite_terminator
+sPidgeotGfx10:
+.incbin "baserom.gba", 0x5D1B8C, 0x200
+sPidgeotSprites10:
+ax_sprite sPidgeotGfx10, 0x200
+ax_sprite_terminator
+sPidgeotGfx11:
+.incbin "baserom.gba", 0x5D1D9C, 0x200
+sPidgeotSprites11:
+ax_sprite sPidgeotGfx11, 0x200
+ax_sprite_terminator
+sPidgeotGfx12:
+.incbin "baserom.gba", 0x5D1FAC, 0x200
+sPidgeotSprites12:
+ax_sprite sPidgeotGfx12, 0x200
+ax_sprite_terminator
+sPidgeotGfx13:
+.incbin "baserom.gba", 0x5D21BC, 0x200
+sPidgeotSprites13:
+ax_sprite sPidgeotGfx13, 0x200
+ax_sprite_terminator
+sPidgeotGfx14:
+.incbin "baserom.gba", 0x5D23CC, 0x200
+sPidgeotSprites14:
+ax_sprite sPidgeotGfx14, 0x200
+ax_sprite_terminator
+sPidgeotGfx15:
+.incbin "baserom.gba", 0x5D25DC, 0x200
+sPidgeotSprites15:
+ax_sprite sPidgeotGfx15, 0x200
+ax_sprite_terminator
+sPidgeotGfx16:
+.incbin "baserom.gba", 0x5D27EC, 0x40
+sPidgeotGfx16_1:
+.incbin "baserom.gba", 0x5D282C, 0x100
+sPidgeotGfx16_2:
+.incbin "baserom.gba", 0x5D292C, 0x40
+sPidgeotSprites16:
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx17:
+.incbin "baserom.gba", 0x5D29AC, 0x40
+sPidgeotGfx17_1:
+.incbin "baserom.gba", 0x5D29EC, 0x40
+sPidgeotGfx17_2:
+.incbin "baserom.gba", 0x5D2A2C, 0x100
+sPidgeotSprites17:
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeotGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx17_2, 0x100
+ax_sprite_terminator
+sPidgeotGfx18:
+.incbin "baserom.gba", 0x5D2B64, 0x180
+sPidgeotGfx18_1:
+.incbin "baserom.gba", 0x5D2CE4, 0x40
+sPidgeotSprites18:
+ax_sprite sPidgeotGfx18, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx19:
+.incbin "baserom.gba", 0x5D2D4C, 0x20
+sPidgeotGfx19_1:
+.incbin "baserom.gba", 0x5D2D6C, 0x180
+sPidgeotSprites19:
+ax_sprite sPidgeotGfx19, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPidgeotGfx19_1, 0x180
+ax_sprite_terminator
+sPidgeotGfx20:
+.incbin "baserom.gba", 0x5D2F0C, 0x60
+sPidgeotGfx20_1:
+.incbin "baserom.gba", 0x5D2F6C, 0x160
+sPidgeotSprites20:
+ax_sprite sPidgeotGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx20_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx21:
+.incbin "baserom.gba", 0x5D30F4, 0x100
+sPidgeotGfx21_1:
+.incbin "baserom.gba", 0x5D31F4, 0x60
+sPidgeotGfx21_2:
+.incbin "baserom.gba", 0x5D3254, 0x40
+sPidgeotSprites21:
+ax_sprite sPidgeotGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx22:
+.incbin "baserom.gba", 0x5D32CC, 0x40
+sPidgeotGfx22_1:
+.incbin "baserom.gba", 0x5D330C, 0x160
+sPidgeotSprites22:
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx23:
+.incbin "baserom.gba", 0x5D349C, 0x60
+sPidgeotGfx23_1:
+.incbin "baserom.gba", 0x5D34FC, 0x60
+sPidgeotGfx23_2:
+.incbin "baserom.gba", 0x5D355C, 0xE0
+sPidgeotSprites23:
+ax_sprite sPidgeotGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx23_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx24:
+.incbin "baserom.gba", 0x5D3674, 0x100
+sPidgeotGfx24_1:
+.incbin "baserom.gba", 0x5D3774, 0x60
+sPidgeotGfx24_2:
+.incbin "baserom.gba", 0x5D37D4, 0x40
+sPidgeotSprites24:
+ax_sprite sPidgeotGfx24, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx25:
+.incbin "baserom.gba", 0x5D384C, 0x180
+sPidgeotSprites25:
+ax_sprite 0, 0x80
+ax_sprite sPidgeotGfx25, 0x180
+ax_sprite_terminator
+sPidgeotGfx26:
+.incbin "baserom.gba", 0x5D39E4, 0x40
+sPidgeotGfx26_1:
+.incbin "baserom.gba", 0x5D3A24, 0x60
+sPidgeotGfx26_2:
+.incbin "baserom.gba", 0x5D3A84, 0x100
+sPidgeotSprites26:
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx26_2, 0x100
+ax_sprite_terminator
+sPidgeotGfx27:
+.incbin "baserom.gba", 0x5D3BBC, 0x180
+sPidgeotGfx27_1:
+.incbin "baserom.gba", 0x5D3D3C, 0x40
+sPidgeotSprites27:
+ax_sprite sPidgeotGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx28:
+.incbin "baserom.gba", 0x5D3DA4, 0x40
+sPidgeotGfx28_1:
+.incbin "baserom.gba", 0x5D3DE4, 0x100
+sPidgeotGfx28_2:
+.incbin "baserom.gba", 0x5D3EE4, 0x40
+sPidgeotSprites28:
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx28_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx29:
+.incbin "baserom.gba", 0x5D3F64, 0x40
+sPidgeotGfx29_1:
+.incbin "baserom.gba", 0x5D3FA4, 0x40
+sPidgeotGfx29_2:
+.incbin "baserom.gba", 0x5D3FE4, 0x100
+sPidgeotSprites29:
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeotGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx29_2, 0x100
+ax_sprite_terminator
+sPidgeotGfx30:
+.incbin "baserom.gba", 0x5D411C, 0x180
+sPidgeotGfx30_1:
+.incbin "baserom.gba", 0x5D429C, 0x40
+sPidgeotSprites30:
+ax_sprite sPidgeotGfx30, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPidgeotGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeotGfx31:
+.incbin "baserom.gba", 0x5D4304, 0x200
+sPidgeotSprites31:
+ax_sprite sPidgeotGfx31, 0x200
+ax_sprite_terminator
+sPidgeotGfx32:
+.incbin "baserom.gba", 0x5D4514, 0x200
+sPidgeotSprites32:
+ax_sprite sPidgeotGfx32, 0x200
+ax_sprite_terminator
+sPidgeotGfx33:
+.incbin "baserom.gba", 0x5D4724, 0x200
+sPidgeotSprites33:
+ax_sprite sPidgeotGfx33, 0x200
+ax_sprite_terminator
+sPidgeotGfx34:
+.incbin "baserom.gba", 0x5D4934, 0x200
+sPidgeotSprites34:
+ax_sprite sPidgeotGfx34, 0x200
+ax_sprite_terminator
+sPidgeotGfx35:
+.incbin "baserom.gba", 0x5D4B44, 0x200
+sPidgeotSprites35:
+ax_sprite sPidgeotGfx35, 0x200
+ax_sprite_terminator
+sPidgeotGfx36:
+.incbin "baserom.gba", 0x5D4D54, 0x200
+sPidgeotSprites36:
+ax_sprite sPidgeotGfx36, 0x200
+ax_sprite_terminator
+sPidgeotGfx37:
+.incbin "baserom.gba", 0x5D4F64, 0x200
+sPidgeotSprites37:
+ax_sprite sPidgeotGfx37, 0x200
+ax_sprite_terminator
+sAxPosesPidgeot:
+.4byte sPidgeotPose1
+.4byte sPidgeotPose2
+.4byte sPidgeotPose3
+.4byte sPidgeotPose4
+.4byte sPidgeotPose5
+.4byte sPidgeotPose6
+.4byte sPidgeotPose7
+.4byte sPidgeotPose8
+.4byte sPidgeotPose9
+.4byte sPidgeotPose10
+.4byte sPidgeotPose11
+.4byte sPidgeotPose12
+.4byte sPidgeotPose13
+.4byte sPidgeotPose14
+.4byte sPidgeotPose15
+.4byte sPidgeotPose16
+.4byte sPidgeotPose17
+.4byte sPidgeotPose18
+.4byte sPidgeotPose19
+.4byte sPidgeotPose20
+.4byte sPidgeotPose21
+.4byte sPidgeotPose22
+.4byte sPidgeotPose23
+.4byte sPidgeotPose24
+.4byte sPidgeotPose25
+.4byte sPidgeotPose26
+.4byte sPidgeotPose27
+.4byte sPidgeotPose28
+.4byte sPidgeotPose29
+.4byte sPidgeotPose30
+.4byte sPidgeotPose31
+.4byte sPidgeotPose32
+.4byte sPidgeotPose33
+.4byte sPidgeotPose34
+.4byte sPidgeotPose35
+.4byte sPidgeotPose36
+.4byte sPidgeotPose37
+.4byte sPidgeotPose38
+.4byte sPidgeotPose39
+.4byte sPidgeotPose40
+.4byte sPidgeotPose41
+.4byte sPidgeotPose42
+.4byte sPidgeotPose43
+.4byte sPidgeotPose44
+.4byte sPidgeotPose45
+.4byte sPidgeotPose46
+.4byte sPidgeotPose47
+.4byte sPidgeotPose48
+.4byte sPidgeotPose49
+.4byte sPidgeotPose50
+.4byte sPidgeotPose51
+.4byte sPidgeotPose52
+.4byte sPidgeotPose53
+.4byte sPidgeotPose54
+.4byte sPidgeotPose55
+.4byte sPidgeotPose56
+.4byte sPidgeotPose57
+.4byte sPidgeotPose58
+.4byte sPidgeotPose59
+.4byte sPidgeotPose60
+.4byte sPidgeotPose61
+.4byte sPidgeotPose62
+.4byte sPidgeotPose63
+.4byte sPidgeotPose64
+.4byte sPidgeotPose65
+.4byte sPidgeotPose66
+.4byte sPidgeotPose67
+.4byte sPidgeotPose68
+.4byte sPidgeotPose69
+.4byte sPidgeotPose70
+.4byte sPidgeotPose71
+.4byte sPidgeotPose72
+.4byte sPidgeotPose73
+.4byte sPidgeotPose74
+.4byte sPidgeotPose75
+.4byte sPidgeotPose76
+.4byte sPidgeotPose77
+.4byte sPidgeotPose78
+.4byte sPidgeotPose79
+.4byte sPidgeotPose80
+.4byte sPidgeotPose81
+.4byte sPidgeotPose82
+.4byte sPidgeotPose83
+.4byte sPidgeotPose84
+.4byte sPidgeotPose85
+.4byte sPidgeotPose86
+.4byte sPidgeotPose87
+.4byte sPidgeotPose88
+.4byte sPidgeotPose89
+.4byte sPidgeotPose90
+.4byte sPidgeotPose91
+.4byte sPidgeotPose92
+.4byte sPidgeotPose93
+.4byte sPidgeotPose94
+.4byte sPidgeotPose95
+.4byte sPidgeotPose96
+.4byte sPidgeotPose97
+.4byte sPidgeotPose98
+.4byte sPidgeotPose99
+.4byte sPidgeotPose100
+.4byte sPidgeotPose101
+.4byte sPidgeotPose102
+.4byte sPidgeotPose103
+.4byte sPidgeotPose104
+.4byte sPidgeotPose105
+.4byte sPidgeotPose106
+.4byte sPidgeotPose107
+.4byte sPidgeotPose108
+.4byte sPidgeotPose109
+.4byte sPidgeotPose110
+.4byte sPidgeotPose111
+.4byte sPidgeotPose112
+.4byte sPidgeotPose113
+.4byte sPidgeotPose114
+.4byte sPidgeotPose115
+.4byte sPidgeotPose116
+.4byte sPidgeotPose117
+.4byte sPidgeotPose118
+.4byte sPidgeotPose119
+.4byte sPidgeotPose120
+.4byte sPidgeotPose121
+.4byte sPidgeotPose122
+.4byte sPidgeotPose123
+.4byte sPidgeotPose124
+.4byte sPidgeotPose125
+.4byte sPidgeotPose126
+.4byte sPidgeotPose127
+.4byte sPidgeotPose128
+.4byte sPidgeotPose129
+.4byte sPidgeotPose130
+.4byte sPidgeotPose131
+.4byte sPidgeotPose132
+.4byte sPidgeotPose133
+.4byte sPidgeotPose134
+.4byte sPidgeotPose135
+.4byte sPidgeotPose136
+.4byte sPidgeotPose137
+.4byte sPidgeotPose138
+.4byte sPidgeotPose139
+.4byte sPidgeotPose140
+.4byte sPidgeotPose141
+.4byte sPidgeotPose142
+.4byte sPidgeotPose143
+.4byte sPidgeotPose144
+.4byte sPidgeotPose145
+.4byte sPidgeotPose146
+.4byte sPidgeotPose147
+.4byte sPidgeotPose148
+.4byte sPidgeotPose149
+.4byte sPidgeotPose150
+.4byte sPidgeotPose151
+.4byte sPidgeotPose152
+.4byte sPidgeotPose153
+.4byte sPidgeotPose154
+.4byte sPidgeotPose155
+.4byte sPidgeotPose156
+.4byte sPidgeotPose157
+.4byte sPidgeotPose158
+.4byte sPidgeotPose159
+.4byte sPidgeotPose160
+.4byte sPidgeotPose161
+.4byte sPidgeotPose162
+.4byte sPidgeotPose163
+.4byte sPidgeotPose164
+.4byte sPidgeotPose165
+.4byte sPidgeotPose166
+.4byte sPidgeotPose167
+.4byte sPidgeotPose168
+.4byte sPidgeotPose169
+.4byte sPidgeotPose170
+.4byte sPidgeotPose171
+.4byte sPidgeotPose172
+.4byte sPidgeotPose173
+.4byte sPidgeotPose174
+.4byte sPidgeotPose175
+.4byte sPidgeotPose176
+.4byte sPidgeotPose177
+.4byte sPidgeotPose178
+.4byte sPidgeotPose179
+.4byte sPidgeotPose180
+.4byte sPidgeotPose181
+.4byte sPidgeotPose182
+.4byte sPidgeotPose183
+.4byte sPidgeotPose184
+.4byte sPidgeotPose185
+.4byte sPidgeotPose186
+.4byte sPidgeotPose187
+.4byte sPidgeotPose188
+.4byte sPidgeotPose189
+.4byte sPidgeotPose190
+.4byte sPidgeotPose191
+.4byte sPidgeotPose192
+.4byte sPidgeotPose193
+.4byte sPidgeotPose194
+.4byte sPidgeotPose195
+.4byte sPidgeotPose196
+.4byte sPidgeotPose197
+.4byte sPidgeotPose198
+.4byte sPidgeotPose199
+.4byte sPidgeotPose200
+.4byte sPidgeotPose201
+.4byte sPidgeotPose202
+.4byte sPidgeotPose203
+.4byte sPidgeotPose204
+.4byte sPidgeotPose205
+.4byte sPidgeotPose206
+.4byte sPidgeotPose207
+.4byte sPidgeotPose208
+.4byte sPidgeotPose209
+.4byte sPidgeotPose210
+.4byte sPidgeotPose211
+.4byte sPidgeotPose212
+.4byte sPidgeotPose213
+.4byte sPidgeotPose214
+.4byte sPidgeotPose215
+.4byte sPidgeotPose216
+.4byte sPidgeotPose217
+.4byte sPidgeotPose218
+sAxPositionsPidgeot:
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	  -7,   -5, 	   6,   -8, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   5,   -5, 	  -1,   -6
+.2byte    7,  -12, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    8,  -11, 	  -3,   -8, 	  -9,   -7, 	  -2,   -8
+.2byte    8,  -11, 	   0,   -6, 	  -6,   -5, 	  -1,   -7
+.2byte   10,  -15, 	  -5,   -9, 	  -5,   -4, 	   0,   -8
+.2byte   11,  -14, 	  -5,   -7, 	  -6,   -4, 	  -1,   -7
+.2byte   11,  -14, 	  -6,   -7, 	  -3,   -4, 	   0,   -7
+.2byte    7,  -17, 	  -7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    8,  -16, 	  -7,   -7, 	  -2,   -3, 	   0,   -9
+.2byte    8,  -16, 	  -6,   -5, 	   2,   -3, 	   0,   -9
+.2byte   -1,  -19, 	   4,   -4, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   4,   -5, 	  -5,   -3, 	  -1,   -8
+.2byte   -1,  -17, 	   3,   -3, 	  -7,   -6, 	  -1,   -8
+.2byte   -9,  -17, 	   5,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte  -10,  -16, 	   5,   -7, 	   0,   -3, 	  -2,   -9
+.2byte  -10,  -16, 	   4,   -5, 	  -4,   -3, 	  -2,   -9
+.2byte  -12,  -15, 	   3,   -9, 	   3,   -4, 	  -2,   -8
+.2byte  -13,  -14, 	   3,   -7, 	   4,   -4, 	  -1,   -7
+.2byte  -13,  -14, 	   4,   -7, 	   1,   -4, 	  -2,   -7
+.2byte   -9,  -12, 	   0,   -7, 	   5,   -6, 	  -1,   -8
+.2byte  -10,  -11, 	   1,   -8, 	   7,   -7, 	   0,   -8
+.2byte  -10,  -11, 	  -2,   -6, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    0, 	 -14,  -10, 	  12,  -10, 	  -1,  -11
+.2byte   -1,   -9, 	 -11,   -3, 	   9,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -13,  -21, 	  11,  -21, 	  -1,   -8
+.2byte    7,  -12, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   10,   -3, 	   8,  -17, 	 -11,   -3, 	   1,   -9
+.2byte    7,  -12, 	  11,   -3, 	  -1,    1, 	   1,   -9
+.2byte    7,  -12, 	   8,  -22, 	 -13,  -19, 	  -1,   -9
+.2byte   10,  -15, 	  -5,   -9, 	  -5,   -4, 	   0,   -8
+.2byte   13,   -8, 	  -1,  -18, 	  -1,    3, 	   0,   -9
+.2byte   10,  -15, 	   7,   -9, 	   6,   -1, 	   0,  -10
+.2byte   10,  -15, 	  -2,  -23, 	  -8,  -19, 	  -1,  -12
+.2byte    7,  -17, 	  -7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    7,  -12, 	 -13,  -13, 	   9,   -2, 	  -2,   -8
+.2byte    7,  -17, 	  -4,   -6, 	   9,   -2, 	   0,  -11
+.2byte    6,  -18, 	 -10,  -22, 	   7,  -19, 	  -2,  -12
+.2byte   -1,  -19, 	   4,   -4, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,  -15, 	  13,   -5, 	 -15,   -5, 	  -1,  -10
+.2byte   -1,  -19, 	   8,   -1, 	 -10,   -1, 	  -1,   -9
+.2byte   -1,  -19, 	  10,  -21, 	 -12,  -21, 	  -1,  -12
+.2byte   -9,  -17, 	   5,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte  -11,  -12, 	   9,  -13, 	 -13,   -2, 	  -2,   -8
+.2byte   -9,  -17, 	   2,   -6, 	 -11,   -2, 	  -2,  -11
+.2byte   -8,  -18, 	   8,  -22, 	  -9,  -19, 	   0,  -12
+.2byte  -12,  -15, 	   3,   -9, 	   3,   -4, 	  -2,   -8
+.2byte  -15,   -8, 	  -1,  -18, 	  -1,    3, 	  -2,   -9
+.2byte  -12,  -15, 	  -9,   -9, 	  -8,   -1, 	  -2,  -10
+.2byte  -12,  -15, 	   0,  -23, 	   6,  -19, 	  -1,  -12
+.2byte   -9,  -12, 	   0,   -7, 	   5,   -6, 	  -1,   -8
+.2byte  -12,   -3, 	 -10,  -17, 	   9,   -3, 	  -3,   -9
+.2byte   -9,  -12, 	 -13,   -3, 	  -1,    1, 	  -3,   -9
+.2byte   -9,  -12, 	 -10,  -22, 	  11,  -19, 	  -1,   -9
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,    0, 	 -14,  -10, 	  12,  -10, 	  -1,  -11
+.2byte   -1,   -9, 	 -11,   -3, 	   9,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -13,  -21, 	  11,  -21, 	  -1,   -8
+.2byte    7,  -12, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   10,   -3, 	   8,  -17, 	 -11,   -3, 	   1,   -9
+.2byte    7,  -12, 	  11,   -3, 	  -1,    1, 	   1,   -9
+.2byte    7,  -12, 	   8,  -22, 	 -13,  -19, 	  -1,   -9
+.2byte   10,  -15, 	  -5,   -9, 	  -5,   -4, 	   0,   -8
+.2byte   13,   -8, 	  -1,  -18, 	  -1,    3, 	   0,   -9
+.2byte   10,  -15, 	   7,   -9, 	   6,   -1, 	   0,  -10
+.2byte   10,  -15, 	  -2,  -23, 	  -8,  -19, 	  -1,  -12
+.2byte    7,  -17, 	  -7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    7,  -12, 	 -13,  -13, 	   9,   -2, 	  -2,   -8
+.2byte    7,  -17, 	  -4,   -6, 	   9,   -2, 	   0,  -11
+.2byte    6,  -18, 	 -10,  -22, 	   7,  -19, 	  -2,  -12
+.2byte   -1,  -19, 	   4,   -4, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,  -15, 	  13,   -5, 	 -15,   -5, 	  -1,  -10
+.2byte   -1,  -19, 	   8,   -1, 	 -10,   -1, 	  -1,   -9
+.2byte   -1,  -19, 	  10,  -21, 	 -12,  -21, 	  -1,  -12
+.2byte   -9,  -17, 	   5,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte  -11,  -12, 	   9,  -13, 	 -13,   -2, 	  -2,   -8
+.2byte   -9,  -17, 	   2,   -6, 	 -11,   -2, 	  -2,  -11
+.2byte   -8,  -18, 	   8,  -22, 	  -9,  -19, 	   0,  -12
+.2byte  -12,  -15, 	   3,   -9, 	   3,   -4, 	  -2,   -8
+.2byte  -15,   -8, 	  -1,  -18, 	  -1,    3, 	  -2,   -9
+.2byte  -12,  -15, 	  -9,   -9, 	  -8,   -1, 	  -2,  -10
+.2byte  -12,  -15, 	   0,  -23, 	   6,  -19, 	  -1,  -12
+.2byte   -9,  -12, 	   0,   -7, 	   5,   -6, 	  -1,   -8
+.2byte  -12,   -3, 	 -10,  -17, 	   9,   -3, 	  -3,   -9
+.2byte   -9,  -12, 	 -13,   -3, 	  -1,    1, 	  -3,   -9
+.2byte   -9,  -12, 	 -10,  -22, 	  11,  -19, 	  -1,   -9
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	 -11,   -3, 	   9,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -13,  -21, 	  11,  -21, 	  -1,   -8
+.2byte    7,  -12, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    7,  -12, 	  11,   -3, 	  -1,    1, 	   1,   -9
+.2byte    7,  -12, 	   8,  -22, 	 -13,  -19, 	  -1,   -9
+.2byte   10,  -15, 	  -5,   -9, 	  -5,   -4, 	   0,   -8
+.2byte   10,  -15, 	   7,   -9, 	   6,   -1, 	   0,  -10
+.2byte   10,  -15, 	  -2,  -23, 	  -8,  -19, 	  -1,  -12
+.2byte    7,  -17, 	  -7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    7,  -17, 	  -4,   -6, 	   9,   -2, 	   0,  -11
+.2byte    6,  -18, 	 -10,  -22, 	   7,  -19, 	  -2,  -12
+.2byte   -1,  -19, 	   4,   -4, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,  -19, 	   8,   -1, 	 -10,   -1, 	  -1,   -9
+.2byte   -1,  -19, 	  10,  -21, 	 -12,  -21, 	  -1,  -12
+.2byte   -9,  -17, 	   5,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte   -9,  -17, 	   2,   -6, 	 -11,   -2, 	  -2,  -11
+.2byte   -8,  -18, 	   8,  -22, 	  -9,  -19, 	   0,  -12
+.2byte  -12,  -15, 	   3,   -9, 	   3,   -4, 	  -2,   -8
+.2byte  -12,  -15, 	  -9,   -9, 	  -8,   -1, 	  -2,  -10
+.2byte  -12,  -15, 	   0,  -23, 	   6,  -19, 	  -1,  -12
+.2byte   -9,  -12, 	   0,   -7, 	   5,   -6, 	  -1,   -8
+.2byte   -9,  -12, 	 -13,   -3, 	  -1,    1, 	  -3,   -9
+.2byte   -9,  -12, 	 -10,  -22, 	  11,  -19, 	  -1,   -9
+.2byte   -1,   -9, 	 -11,   -3, 	   9,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -13,  -21, 	  11,  -21, 	  -1,   -8
+.2byte    7,  -12, 	  11,   -3, 	  -1,    1, 	   1,   -9
+.2byte    7,  -12, 	   8,  -22, 	 -13,  -19, 	  -1,   -9
+.2byte   10,  -15, 	   7,   -9, 	   6,   -1, 	   0,  -10
+.2byte   10,  -15, 	  -2,  -23, 	  -8,  -19, 	  -1,  -12
+.2byte    7,  -17, 	  -4,   -6, 	   9,   -2, 	   0,  -11
+.2byte    6,  -18, 	 -10,  -22, 	   7,  -19, 	  -2,  -12
+.2byte   -1,  -19, 	   8,   -1, 	 -10,   -1, 	  -1,   -9
+.2byte   -1,  -19, 	  10,  -21, 	 -12,  -21, 	  -1,  -12
+.2byte   -9,  -17, 	   2,   -6, 	 -11,   -2, 	  -2,  -11
+.2byte   -8,  -18, 	   8,  -22, 	  -9,  -19, 	   0,  -12
+.2byte  -12,  -15, 	  -9,   -9, 	  -8,   -1, 	  -2,  -10
+.2byte  -12,  -15, 	   0,  -23, 	   6,  -19, 	  -1,  -12
+.2byte   -9,  -12, 	 -13,   -3, 	  -1,    1, 	  -3,   -9
+.2byte   -9,  -12, 	 -10,  -22, 	  11,  -19, 	  -1,   -9
+.2byte    8,  -10, 	  -2,   -8, 	  -7,   -7, 	  -1,   -9
+.2byte    8,   -7, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   -1,  -18, 	 -13,  -20, 	  11,  -20, 	  -1,  -12
+.2byte    4,  -20, 	   6,  -22, 	 -12,  -17, 	  -1,  -11
+.2byte    5,  -21, 	  -7,  -24, 	 -10,  -19, 	  -2,  -13
+.2byte    5,  -19, 	 -10,  -19, 	  10,  -15, 	  -2,  -12
+.2byte    0,  -21, 	  11,  -17, 	 -11,  -17, 	   0,  -11
+.2byte   -6,  -19, 	   9,  -19, 	 -11,  -15, 	   1,  -12
+.2byte   -6,  -21, 	   6,  -24, 	   9,  -19, 	   1,  -13
+.2byte   -5,  -20, 	  -7,  -22, 	  11,  -17, 	   0,  -11
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,   -7, 	  -7,   -5, 	   6,   -8, 	  -1,   -6
+.2byte   -1,   -7, 	  -8,   -8, 	   5,   -5, 	  -1,   -6
+.2byte    7,  -12, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    8,  -11, 	  -3,   -8, 	  -9,   -7, 	  -2,   -8
+.2byte    8,  -11, 	   0,   -6, 	  -6,   -5, 	  -1,   -7
+.2byte   10,  -15, 	  -5,   -9, 	  -5,   -4, 	   0,   -8
+.2byte   11,  -14, 	  -5,   -7, 	  -6,   -4, 	  -1,   -7
+.2byte   11,  -14, 	  -6,   -7, 	  -3,   -4, 	   0,   -7
+.2byte    7,  -17, 	  -7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    8,  -16, 	  -7,   -7, 	  -2,   -3, 	   0,   -9
+.2byte    8,  -16, 	  -6,   -5, 	   2,   -3, 	   0,   -9
+.2byte   -1,  -19, 	   4,   -4, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   4,   -5, 	  -5,   -3, 	  -1,   -8
+.2byte   -1,  -17, 	   3,   -3, 	  -7,   -6, 	  -1,   -8
+.2byte   -9,  -17, 	   5,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte  -10,  -16, 	   5,   -7, 	   0,   -3, 	  -2,   -9
+.2byte  -10,  -16, 	   4,   -5, 	  -4,   -3, 	  -2,   -9
+.2byte  -12,  -15, 	   3,   -9, 	   3,   -4, 	  -2,   -8
+.2byte  -13,  -14, 	   3,   -7, 	   4,   -4, 	  -1,   -7
+.2byte  -13,  -14, 	   4,   -7, 	   1,   -4, 	  -2,   -7
+.2byte   -9,  -12, 	   0,   -7, 	   5,   -6, 	  -1,   -8
+.2byte  -10,  -11, 	   1,   -8, 	   7,   -7, 	   0,   -8
+.2byte  -10,  -11, 	  -2,   -6, 	   4,   -5, 	  -1,   -7
+.2byte   -1,    0, 	 -14,  -10, 	  12,  -10, 	  -1,  -11
+.2byte  -11,   -3, 	  -9,  -17, 	  10,   -3, 	  -2,   -9
+.2byte  -14,   -8, 	   0,  -18, 	   0,    3, 	  -1,   -9
+.2byte  -10,  -12, 	  10,  -13, 	 -12,   -2, 	  -1,   -8
+.2byte   -1,  -15, 	  13,   -5, 	 -15,   -5, 	  -1,  -10
+.2byte    8,  -12, 	 -12,  -13, 	  10,   -2, 	  -1,   -8
+.2byte   13,   -8, 	  -1,  -18, 	  -1,    3, 	   0,   -9
+.2byte   10,   -3, 	   8,  -17, 	 -11,   -3, 	   1,   -9
+.2byte   -1,   -9, 	 -13,  -21, 	  11,  -21, 	  -1,   -8
+.2byte    7,  -12, 	   8,  -22, 	 -13,  -19, 	  -1,   -9
+.2byte   10,  -15, 	  -2,  -23, 	  -8,  -19, 	  -1,  -12
+.2byte    6,  -18, 	 -10,  -22, 	   7,  -19, 	  -2,  -12
+.2byte   -1,  -19, 	  10,  -21, 	 -12,  -21, 	  -1,  -12
+.2byte   -8,  -18, 	   8,  -22, 	  -9,  -19, 	   0,  -12
+.2byte  -12,  -15, 	   0,  -23, 	   6,  -19, 	  -1,  -12
+.2byte   -9,  -12, 	 -10,  -22, 	  11,  -19, 	  -1,   -9
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	 -11,   -3, 	   9,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	 -13,  -21, 	  11,  -21, 	  -1,   -8
+.2byte    7,  -12, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    7,  -12, 	  11,   -3, 	  -1,    1, 	   1,   -9
+.2byte    7,  -12, 	   8,  -22, 	 -13,  -19, 	  -1,   -9
+.2byte   10,  -15, 	  -5,   -9, 	  -5,   -4, 	   0,   -8
+.2byte   10,  -15, 	   7,   -9, 	   6,   -1, 	   0,  -10
+.2byte   10,  -15, 	  -2,  -23, 	  -8,  -19, 	  -1,  -12
+.2byte    7,  -17, 	  -7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte    7,  -17, 	  -4,   -6, 	   9,   -2, 	   0,  -11
+.2byte    6,  -18, 	 -10,  -22, 	   7,  -19, 	  -2,  -12
+.2byte   -1,  -19, 	   4,   -4, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,  -19, 	   8,   -1, 	 -10,   -1, 	  -1,   -9
+.2byte   -1,  -19, 	  10,  -21, 	 -12,  -21, 	  -1,  -12
+.2byte   -9,  -17, 	   5,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte   -9,  -17, 	   2,   -6, 	 -11,   -2, 	  -2,  -11
+.2byte   -8,  -18, 	   8,  -22, 	  -9,  -19, 	   0,  -12
+.2byte  -12,  -15, 	   3,   -9, 	   3,   -4, 	  -2,   -8
+.2byte  -12,  -15, 	  -9,   -9, 	  -8,   -1, 	  -2,  -10
+.2byte  -12,  -15, 	   0,  -23, 	   6,  -19, 	  -1,  -12
+.2byte   -9,  -12, 	   0,   -7, 	   5,   -6, 	  -1,   -8
+.2byte   -9,  -12, 	 -13,   -3, 	  -1,    1, 	  -3,   -9
+.2byte   -9,  -12, 	 -10,  -22, 	  11,  -19, 	  -1,   -9
+.2byte   -1,   -9, 	 -13,  -21, 	  11,  -21, 	  -1,   -8
+.2byte   -9,  -12, 	 -10,  -22, 	  11,  -19, 	  -1,   -9
+.2byte  -12,  -15, 	   0,  -23, 	   6,  -19, 	  -1,  -12
+.2byte   -8,  -18, 	   8,  -22, 	  -9,  -19, 	   0,  -12
+.2byte   -1,  -19, 	  10,  -21, 	 -12,  -21, 	  -1,  -12
+.2byte    6,  -18, 	 -10,  -22, 	   7,  -19, 	  -2,  -12
+.2byte   10,  -15, 	  -2,  -23, 	  -8,  -19, 	  -1,  -12
+.2byte    7,  -12, 	   8,  -22, 	 -13,  -19, 	  -1,   -9
+.2byte   -1,   -9, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -9,  -12, 	   0,   -7, 	   5,   -6, 	  -1,   -8
+.2byte  -12,  -15, 	   3,   -9, 	   3,   -4, 	  -2,   -8
+.2byte   -9,  -17, 	   5,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte   -1,  -19, 	   4,   -4, 	  -6,   -4, 	  -1,   -9
+.2byte    7,  -17, 	  -7,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte   10,  -15, 	  -5,   -9, 	  -5,   -4, 	   0,   -8
+.2byte    7,  -12, 	  -2,   -7, 	  -7,   -6, 	  -1,   -8
+sPidgeotAnimTable1:
+.4byte sPidgeotAnims_1_1
+.4byte sPidgeotAnims_1_2
+.4byte sPidgeotAnims_1_3
+.4byte sPidgeotAnims_1_4
+.4byte sPidgeotAnims_1_5
+.4byte sPidgeotAnims_1_6
+.4byte sPidgeotAnims_1_7
+.4byte sPidgeotAnims_1_8
+sPidgeotAnimTable2:
+.4byte sPidgeotAnims_2_1
+.4byte sPidgeotAnims_2_2
+.4byte sPidgeotAnims_2_3
+.4byte sPidgeotAnims_2_4
+.4byte sPidgeotAnims_2_5
+.4byte sPidgeotAnims_2_6
+.4byte sPidgeotAnims_2_7
+.4byte sPidgeotAnims_2_8
+sPidgeotAnimTable3:
+.4byte sPidgeotAnims_3_1
+.4byte sPidgeotAnims_3_2
+.4byte sPidgeotAnims_3_3
+.4byte sPidgeotAnims_3_4
+.4byte sPidgeotAnims_3_5
+.4byte sPidgeotAnims_3_6
+.4byte sPidgeotAnims_3_7
+.4byte sPidgeotAnims_3_8
+sPidgeotAnimTable4:
+.4byte sPidgeotAnims_4_1
+.4byte sPidgeotAnims_4_2
+.4byte sPidgeotAnims_4_3
+.4byte sPidgeotAnims_4_4
+.4byte sPidgeotAnims_4_5
+.4byte sPidgeotAnims_4_6
+.4byte sPidgeotAnims_4_7
+.4byte sPidgeotAnims_4_8
+sPidgeotAnimTable5:
+.4byte sPidgeotAnims_5_1
+.4byte sPidgeotAnims_5_2
+.4byte sPidgeotAnims_5_3
+.4byte sPidgeotAnims_5_4
+.4byte sPidgeotAnims_5_5
+.4byte sPidgeotAnims_5_6
+.4byte sPidgeotAnims_5_7
+.4byte sPidgeotAnims_5_8
+sPidgeotAnimTable6:
+.4byte sPidgeotAnims_6_1
+.4byte sPidgeotAnims_6_1
+.4byte sPidgeotAnims_6_1
+.4byte sPidgeotAnims_6_1
+.4byte sPidgeotAnims_6_1
+.4byte sPidgeotAnims_6_1
+.4byte sPidgeotAnims_6_1
+.4byte sPidgeotAnims_6_1
+sPidgeotAnimTable7:
+.4byte sPidgeotAnims_7_1
+.4byte sPidgeotAnims_7_2
+.4byte sPidgeotAnims_7_3
+.4byte sPidgeotAnims_7_4
+.4byte sPidgeotAnims_7_5
+.4byte sPidgeotAnims_7_6
+.4byte sPidgeotAnims_7_7
+.4byte sPidgeotAnims_7_8
+sPidgeotAnimTable8:
+.4byte sPidgeotAnims_8_1
+.4byte sPidgeotAnims_8_2
+.4byte sPidgeotAnims_8_3
+.4byte sPidgeotAnims_8_4
+.4byte sPidgeotAnims_8_5
+.4byte sPidgeotAnims_8_6
+.4byte sPidgeotAnims_8_7
+.4byte sPidgeotAnims_8_8
+sPidgeotAnimTable9:
+.4byte sPidgeotAnims_9_1
+.4byte sPidgeotAnims_9_2
+.4byte sPidgeotAnims_9_3
+.4byte sPidgeotAnims_9_4
+.4byte sPidgeotAnims_9_5
+.4byte sPidgeotAnims_9_6
+.4byte sPidgeotAnims_9_7
+.4byte sPidgeotAnims_9_8
+sPidgeotAnimTable10:
+.4byte sPidgeotAnims_10_1
+.4byte sPidgeotAnims_10_2
+.4byte sPidgeotAnims_10_3
+.4byte sPidgeotAnims_10_4
+.4byte sPidgeotAnims_10_5
+.4byte sPidgeotAnims_10_6
+.4byte sPidgeotAnims_10_7
+.4byte sPidgeotAnims_10_8
+sPidgeotAnimTable11:
+.4byte sPidgeotAnims_11_1
+.4byte sPidgeotAnims_11_2
+.4byte sPidgeotAnims_11_3
+.4byte sPidgeotAnims_11_4
+.4byte sPidgeotAnims_11_5
+.4byte sPidgeotAnims_11_6
+.4byte sPidgeotAnims_11_7
+.4byte sPidgeotAnims_11_8
+sPidgeotAnimTable12:
+.4byte sPidgeotAnims_12_1
+.4byte sPidgeotAnims_12_2
+.4byte sPidgeotAnims_12_3
+.4byte sPidgeotAnims_12_4
+.4byte sPidgeotAnims_12_5
+.4byte sPidgeotAnims_12_6
+.4byte sPidgeotAnims_12_7
+.4byte sPidgeotAnims_12_8
+sPidgeotAnimTable13:
+.4byte sPidgeotAnims_13_1
+.4byte sPidgeotAnims_13_2
+.4byte sPidgeotAnims_13_3
+.4byte sPidgeotAnims_13_4
+.4byte sPidgeotAnims_13_5
+.4byte sPidgeotAnims_13_6
+.4byte sPidgeotAnims_13_7
+.4byte sPidgeotAnims_13_8
+sAxAnimationsPidgeot:
+.4byte sPidgeotAnimTable1
+.4byte sPidgeotAnimTable2
+.4byte sPidgeotAnimTable3
+.4byte sPidgeotAnimTable4
+.4byte sPidgeotAnimTable5
+.4byte sPidgeotAnimTable6
+.4byte sPidgeotAnimTable7
+.4byte sPidgeotAnimTable8
+.4byte sPidgeotAnimTable9
+.4byte sPidgeotAnimTable10
+.4byte sPidgeotAnimTable11
+.4byte sPidgeotAnimTable12
+.4byte sPidgeotAnimTable13
+sAxSpritesPidgeot:
+.4byte sPidgeotSprites1
+.4byte sPidgeotSprites2
+.4byte sPidgeotSprites3
+.4byte sPidgeotSprites4
+.4byte sPidgeotSprites5
+.4byte sPidgeotSprites6
+.4byte sPidgeotSprites7
+.4byte sPidgeotSprites8
+.4byte sPidgeotSprites9
+.4byte sPidgeotSprites10
+.4byte sPidgeotSprites11
+.4byte sPidgeotSprites12
+.4byte sPidgeotSprites13
+.4byte sPidgeotSprites14
+.4byte sPidgeotSprites15
+.4byte sPidgeotSprites16
+.4byte sPidgeotSprites17
+.4byte sPidgeotSprites18
+.4byte sPidgeotSprites19
+.4byte sPidgeotSprites20
+.4byte sPidgeotSprites21
+.4byte sPidgeotSprites22
+.4byte sPidgeotSprites23
+.4byte sPidgeotSprites24
+.4byte sPidgeotSprites25
+.4byte sPidgeotSprites26
+.4byte sPidgeotSprites27
+.4byte sPidgeotSprites28
+.4byte sPidgeotSprites29
+.4byte sPidgeotSprites30
+.4byte sPidgeotSprites31
+.4byte sPidgeotSprites32
+.4byte sPidgeotSprites33
+.4byte sPidgeotSprites34
+.4byte sPidgeotSprites35
+.4byte sPidgeotSprites36
+.4byte sPidgeotSprites37
+sAxMainPidgeot:
+ax_main sAxPosesPidgeot, sAxAnimationsPidgeot, 13, sAxSpritesPidgeot, sAxPositionsPidgeot

--- a/data/ax/pidgeotto.inc
+++ b/data/ax/pidgeotto.inc
@@ -1,0 +1,2679 @@
+.global gAxPidgeotto
+gAxPidgeotto:
+ax_siro sAxMainPidgeotto
+sPidgeottoPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose4:
+ax_pose 3, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose5:
+ax_pose 4, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose6:
+ax_pose 5, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose8:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose9:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose13:
+ax_pose 12, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose14:
+ax_pose 13, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeottoPose15:
+ax_pose 14, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose26:
+ax_pose 15, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose27:
+ax_pose 16, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose28:
+ax_pose 17, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose29:
+ax_pose 3, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose30:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose31:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose32:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose33:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose34:
+ax_pose 21, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose35:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose36:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose37:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose38:
+ax_pose 24, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose39:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose40:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose41:
+ax_pose 12, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose42:
+ax_pose 27, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose43:
+ax_pose 28, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose44:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose45:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose46:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose47:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose48:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose49:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose50:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose51:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose52:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose53:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose54:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose55:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose56:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose57:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose58:
+ax_pose 15, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose59:
+ax_pose 16, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose60:
+ax_pose 17, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose61:
+ax_pose 3, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose62:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose63:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose64:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose65:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose66:
+ax_pose 21, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose67:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose68:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose69:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose70:
+ax_pose 24, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose71:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose72:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose73:
+ax_pose 12, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose74:
+ax_pose 27, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose75:
+ax_pose 28, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose76:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose77:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose78:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose79:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose80:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose81:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose82:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose83:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose84:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose85:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose86:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose87:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose88:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose89:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose90:
+ax_pose 16, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose91:
+ax_pose 17, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose92:
+ax_pose 3, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose93:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose94:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose95:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose96:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose97:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose98:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose99:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose100:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose101:
+ax_pose 12, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose102:
+ax_pose 28, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose103:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose104:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose105:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose106:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose107:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose108:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose109:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose110:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose111:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose112:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose113:
+ax_pose 16, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose114:
+ax_pose 17, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose115:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose116:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose117:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose118:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose119:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose120:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose121:
+ax_pose 28, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose122:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose123:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose124:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose125:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose126:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose127:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose128:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose129:
+ax_pose 30, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose130:
+ax_pose 31, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose131:
+ax_pose 32, 0x01e2, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose132:
+ax_pose 33, 0x01e2, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeottoPose133:
+ax_pose 34, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeottoPose134:
+ax_pose 35, 0x01e2, 0x90ea, 0x4c00
+ax_pose_terminator
+sPidgeottoPose135:
+ax_pose 36, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeottoPose136:
+ax_pose 35, 0x01e2, 0x80f6, 0x4c00
+ax_pose_terminator
+sPidgeottoPose137:
+ax_pose 34, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose138:
+ax_pose 33, 0x01e2, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose139:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose140:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose141:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose142:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose143:
+ax_pose 12, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose144:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose145:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose146:
+ax_pose 3, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose147:
+ax_pose 15, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose148:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose149:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose150:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose151:
+ax_pose 27, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose152:
+ax_pose 24, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose153:
+ax_pose 21, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose154:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose155:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose156:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose157:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose158:
+ax_pose 26, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose159:
+ax_pose 29, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose160:
+ax_pose 26, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose161:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose162:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose163:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose164:
+ax_pose 16, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose165:
+ax_pose 17, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose166:
+ax_pose 3, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose167:
+ax_pose 19, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose168:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose169:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose170:
+ax_pose 22, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose171:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose172:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose173:
+ax_pose 25, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose174:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose175:
+ax_pose 12, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose176:
+ax_pose 28, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose177:
+ax_pose 29, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose178:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose179:
+ax_pose 25, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose180:
+ax_pose 26, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose181:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose182:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose183:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose184:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose185:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose186:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose187:
+ax_pose 17, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose188:
+ax_pose 20, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose189:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose190:
+ax_pose 26, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose191:
+ax_pose 29, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose192:
+ax_pose 26, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose193:
+ax_pose 23, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose194:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose195:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose196:
+ax_pose 3, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose197:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeottoPose198:
+ax_pose 9, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeottoPose199:
+ax_pose 12, 0x81e7, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeottoPose200:
+ax_pose 9, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeottoPose201:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeottoPose202:
+ax_pose 3, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+.align 2
+sPidgeottoAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, 0,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 4, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 5, 0, 5,
+ax_anim_terminator
+sPidgeottoAnims_2_2:
+ax_anim 2, 0, 30, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 4, 0, 31, 0, -5, 0, 0,
+ax_anim 1, 2, 29, 2, -1, 2, 2,
+ax_anim 1, 0, 29, 10, 10, 10, 12,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 1, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 5, 5, 5, 5,
+ax_anim_terminator
+sPidgeottoAnims_2_3:
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 4, 0, 35, 0, -5, 0, 0,
+ax_anim 1, 2, 33, 2, -5, 2, 2,
+ax_anim 1, 0, 33, 10, -3, 10, 0,
+ax_anim 2, 0, 33, 17, 0, 17, 0,
+ax_anim 2, 1, 33, 17, -1, 17, -1,
+ax_anim 2, 0, 33, 17, 0, 17, 0,
+ax_anim 2, 0, 33, 17, -1, 17, -1,
+ax_anim 2, 0, 33, 17, 0, 17, 0,
+ax_anim 2, 0, 33, 17, -1, 17, -1,
+ax_anim 2, 0, 35, 12, -2, 12, 0,
+ax_anim 2, 0, 35, 5, -3, 5, 0,
+ax_anim_terminator
+sPidgeottoAnims_2_4:
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 2, 0, 39, 0, -4, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 4, 0, 39, 0, -5, 0, 0,
+ax_anim 1, 2, 37, 2, -4, 2, -2,
+ax_anim 1, 0, 37, 10, -11, 10, -10,
+ax_anim 2, 0, 37, 19, -20, 19, -20,
+ax_anim 2, 1, 37, 18, -21, 18, -21,
+ax_anim 2, 0, 37, 19, -20, 19, -20,
+ax_anim 2, 0, 37, 18, -21, 18, -21,
+ax_anim 2, 0, 37, 19, -20, 19, -20,
+ax_anim 2, 0, 37, 18, -21, 18, -21,
+ax_anim 2, 0, 39, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 5, -5, 5, -5,
+ax_anim_terminator
+sPidgeottoAnims_2_5:
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 4, 0, 43, 0, -5, 0, 0,
+ax_anim 1, 2, 41, 0, -8, 0, -2,
+ax_anim 1, 0, 41, 0, -12, 0, -8,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 1, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 43, 0, -5, 0, -5,
+ax_anim_terminator
+sPidgeottoAnims_2_6:
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 4, 0, 47, 0, -5, 0, 0,
+ax_anim 1, 2, 45, -2, -4, -2, -2,
+ax_anim 1, 0, 45, -10, -11, -10, -10,
+ax_anim 2, 0, 45, -19, -20, -19, -20,
+ax_anim 2, 1, 45, -18, -21, -18, -21,
+ax_anim 2, 0, 45, -19, -20, -19, -20,
+ax_anim 2, 0, 45, -18, -21, -18, -21,
+ax_anim 2, 0, 45, -19, -20, -19, -20,
+ax_anim 2, 0, 45, -18, -21, -18, -21,
+ax_anim 2, 0, 47, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -5, -5, -5, -5,
+ax_anim_terminator
+sPidgeottoAnims_2_7:
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 49, -2, -5, -2, 2,
+ax_anim 1, 0, 49, -10, -3, -10, 0,
+ax_anim 2, 0, 49, -17, 0, -17, 0,
+ax_anim 2, 1, 49, -17, -1, -17, -1,
+ax_anim 2, 0, 49, -17, 0, -17, 0,
+ax_anim 2, 0, 49, -17, -1, -17, -1,
+ax_anim 2, 0, 49, -17, 0, -17, 0,
+ax_anim 2, 0, 49, -17, -1, -17, -1,
+ax_anim 2, 0, 51, -12, -2, -12, 0,
+ax_anim 2, 0, 51, -5, -3, -5, 0,
+ax_anim_terminator
+sPidgeottoAnims_2_8:
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 4, 0, 55, 0, -5, 0, 0,
+ax_anim 1, 2, 53, -2, -3, -2, 2,
+ax_anim 1, 0, 53, -10, 9, -10, 12,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 1, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 0, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 0, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 55, -12, 12, -12, 12,
+ax_anim 2, 0, 55, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 4, 0, 59, 0, -5, 0, 0,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 1, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 5, 0, 5,
+ax_anim_terminator
+sPidgeottoAnims_3_2:
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 63, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -5, 0, 0,
+ax_anim 4, 0, 63, 0, -5, 0, 0,
+ax_anim 1, 2, 61, 2, -1, 2, 2,
+ax_anim 1, 0, 61, 10, 10, 10, 12,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 1, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 0, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 0, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 63, 12, 12, 12, 12,
+ax_anim 2, 0, 63, 5, 5, 5, 5,
+ax_anim_terminator
+sPidgeottoAnims_3_3:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 4, 0, 67, 0, -5, 0, 0,
+ax_anim 1, 2, 65, 2, -5, 2, 2,
+ax_anim 1, 0, 65, 10, -3, 10, 0,
+ax_anim 2, 0, 65, 17, 0, 17, 0,
+ax_anim 2, 1, 65, 17, -1, 17, -1,
+ax_anim 2, 0, 65, 17, 0, 17, 0,
+ax_anim 2, 0, 65, 17, -1, 17, -1,
+ax_anim 2, 0, 65, 17, 0, 17, 0,
+ax_anim 2, 0, 65, 17, -1, 17, -1,
+ax_anim 2, 0, 67, 12, -2, 12, 0,
+ax_anim 2, 0, 67, 5, -3, 5, 0,
+ax_anim_terminator
+sPidgeottoAnims_3_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 4, 0, 71, 0, -5, 0, 0,
+ax_anim 1, 2, 69, 2, -4, 2, -2,
+ax_anim 1, 0, 69, 10, -11, 10, -10,
+ax_anim 2, 0, 69, 19, -20, 19, -20,
+ax_anim 2, 1, 69, 18, -21, 18, -21,
+ax_anim 2, 0, 69, 19, -20, 19, -20,
+ax_anim 2, 0, 69, 18, -21, 18, -21,
+ax_anim 2, 0, 69, 19, -20, 19, -20,
+ax_anim 2, 0, 69, 18, -21, 18, -21,
+ax_anim 2, 0, 71, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 5, -5, 5, -5,
+ax_anim_terminator
+sPidgeottoAnims_3_5:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 4, 0, 75, 0, -5, 0, 0,
+ax_anim 1, 2, 73, 0, -8, 0, -2,
+ax_anim 1, 0, 73, 0, -12, 0, -8,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 1, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 75, 0, -12, 0, -12,
+ax_anim 2, 0, 75, 0, -5, 0, -5,
+ax_anim_terminator
+sPidgeottoAnims_3_6:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 4, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 2, 77, -2, -4, -2, -2,
+ax_anim 1, 0, 77, -10, -11, -10, -10,
+ax_anim 2, 0, 77, -19, -20, -19, -20,
+ax_anim 2, 1, 77, -18, -21, -18, -21,
+ax_anim 2, 0, 77, -19, -20, -19, -20,
+ax_anim 2, 0, 77, -18, -21, -18, -21,
+ax_anim 2, 0, 77, -19, -20, -19, -20,
+ax_anim 2, 0, 77, -18, -21, -18, -21,
+ax_anim 2, 0, 79, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -5, -5, -5, -5,
+ax_anim_terminator
+sPidgeottoAnims_3_7:
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 0, 83, 0, -5, 0, 0,
+ax_anim 1, 2, 81, -2, -5, -2, 2,
+ax_anim 1, 0, 81, -10, -3, -10, 0,
+ax_anim 2, 0, 81, -17, 0, -17, 0,
+ax_anim 2, 1, 81, -17, -1, -17, -1,
+ax_anim 2, 0, 81, -17, 0, -17, 0,
+ax_anim 2, 0, 81, -17, -1, -17, -1,
+ax_anim 2, 0, 81, -17, 0, -17, 0,
+ax_anim 2, 0, 81, -17, -1, -17, -1,
+ax_anim 2, 0, 83, -12, -2, -12, 0,
+ax_anim 2, 0, 83, -5, -3, -5, 0,
+ax_anim_terminator
+sPidgeottoAnims_3_8:
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 4, 0, 87, 0, -5, 0, 0,
+ax_anim 1, 2, 85, -2, -3, -2, 2,
+ax_anim 1, 0, 85, -10, 9, -10, 12,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 1, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 0, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 0, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 87, -12, 12, -12, 12,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_4_1:
+ax_anim 3, 0, 89, 0, -2, 0, 0,
+ax_anim 3, 0, 90, 0, -4, 0, 0,
+ax_anim 3, 0, 89, 0, -5, 0, 0,
+ax_anim 3, 2, 90, 0, -6, 0, 0,
+ax_anim 3, 0, 89, 0, -7, 0, 0,
+ax_anim 3, 0, 90, 0, -7, 0, 0,
+ax_anim 3, 1, 89, 0, -7, 0, 0,
+ax_anim 3, 0, 90, 0, -7, 0, 0,
+ax_anim 3, 0, 89, 0, -7, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_4_2:
+ax_anim 3, 0, 92, 0, -2, 0, 0,
+ax_anim 3, 0, 93, 0, -4, 0, 0,
+ax_anim 3, 0, 92, 0, -5, 0, 0,
+ax_anim 3, 2, 93, 0, -6, 0, 0,
+ax_anim 3, 0, 92, 0, -7, 0, 0,
+ax_anim 3, 0, 93, 0, -7, 0, 0,
+ax_anim 3, 1, 92, 0, -7, 0, 0,
+ax_anim 3, 0, 93, 0, -7, 0, 0,
+ax_anim 3, 0, 92, 0, -7, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_4_3:
+ax_anim 3, 0, 95, 0, -2, 0, 0,
+ax_anim 3, 0, 96, 0, -4, 0, 0,
+ax_anim 3, 0, 95, 0, -5, 0, 0,
+ax_anim 3, 2, 96, 0, -6, 0, 0,
+ax_anim 3, 0, 95, 0, -7, 0, 0,
+ax_anim 3, 0, 96, 0, -7, 0, 0,
+ax_anim 3, 1, 95, 0, -7, 0, 0,
+ax_anim 3, 0, 96, 0, -7, 0, 0,
+ax_anim 3, 0, 95, 0, -7, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_4_4:
+ax_anim 3, 0, 98, 0, -2, 0, 0,
+ax_anim 3, 0, 99, 0, -4, 0, 0,
+ax_anim 3, 0, 98, 0, -5, 0, 0,
+ax_anim 3, 2, 99, 0, -6, 0, 0,
+ax_anim 3, 0, 98, 0, -7, 0, 0,
+ax_anim 3, 0, 99, 0, -7, 0, 0,
+ax_anim 3, 1, 98, 0, -7, 0, 0,
+ax_anim 3, 0, 99, 0, -7, 0, 0,
+ax_anim 3, 0, 98, 0, -7, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_4_5:
+ax_anim 3, 0, 101, 0, -2, 0, 0,
+ax_anim 3, 0, 102, 0, -4, 0, 0,
+ax_anim 3, 0, 101, 0, -5, 0, 0,
+ax_anim 3, 2, 102, 0, -6, 0, 0,
+ax_anim 3, 0, 101, 0, -7, 0, 0,
+ax_anim 3, 0, 102, 0, -7, 0, 0,
+ax_anim 3, 1, 101, 0, -7, 0, 0,
+ax_anim 3, 0, 102, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_4_6:
+ax_anim 3, 0, 104, 0, -2, 0, 0,
+ax_anim 3, 0, 105, 0, -4, 0, 0,
+ax_anim 3, 0, 104, 0, -5, 0, 0,
+ax_anim 3, 2, 105, 0, -6, 0, 0,
+ax_anim 3, 0, 104, 0, -7, 0, 0,
+ax_anim 3, 0, 105, 0, -7, 0, 0,
+ax_anim 3, 1, 104, 0, -7, 0, 0,
+ax_anim 3, 0, 105, 0, -7, 0, 0,
+ax_anim 3, 0, 104, 0, -7, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_4_7:
+ax_anim 3, 0, 107, 0, -2, 0, 0,
+ax_anim 3, 0, 108, 0, -4, 0, 0,
+ax_anim 3, 0, 107, 0, -5, 0, 0,
+ax_anim 3, 2, 108, 0, -6, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 108, 0, -7, 0, 0,
+ax_anim 3, 1, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 108, 0, -7, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_4_8:
+ax_anim 3, 0, 110, 0, -2, 0, 0,
+ax_anim 3, 0, 111, 0, -4, 0, 0,
+ax_anim 3, 0, 110, 0, -5, 0, 0,
+ax_anim 3, 2, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 110, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -7, 0, 0,
+ax_anim 3, 1, 110, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -7, 0, 0,
+ax_anim 3, 0, 110, 0, -7, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_5_1:
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 2, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 1, 113, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_5_2:
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 2, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 1, 115, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_5_3:
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 2, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 1, 117, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_5_4:
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 2, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 1, 119, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_5_5:
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 2, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 1, 121, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_5_6:
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 2, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 1, 123, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_5_7:
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 2, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 1, 125, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_5_8:
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 2, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 1, 127, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sPidgeottoAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sPidgeottoAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sPidgeottoAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sPidgeottoAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sPidgeottoAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sPidgeottoAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sPidgeottoAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_8_2:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 4, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_8_4:
+ax_anim 40, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_8_6:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_8_7:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_8_8:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 19, 7, 19,
+ax_anim 3, 0, 150, 0, 22, 0, 22,
+ax_anim 2, 3, 151, -7, 19, -7, 19,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 9, -1, 9, -1,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 22, 9, 22, 9,
+ax_anim 3, 0, 149, 20, 22, 20, 22,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 2, 15, 2, 15,
+ax_anim 1, 0, 152, -1, 9, -1, 9,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 17, -4, 17, -4,
+ax_anim 3, 0, 148, 20, 1, 20, 1,
+ax_anim 2, 3, 149, 17, 5, 17, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -20, 11, -20,
+ax_anim 3, 0, 147, 18, -20, 18, -20,
+ax_anim 2, 3, 148, 20, -11, 20, -11,
+ax_anim 2, 0, 149, 16, -6, 16, -6,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -8, -8, -8,
+ax_anim 2, 0, 153, -7, -16, -7, -16,
+ax_anim 3, 0, 146, 0, -19, 0, -19,
+ax_anim 2, 3, 147, 7, -16, 7, -16,
+ax_anim 2, 0, 148, 8, -6, 8, -6,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -11, -20, -11, -20,
+ax_anim 3, 0, 153, -18, -20, -18, -20,
+ax_anim 2, 3, 152, -20, -11, -20, -11,
+ax_anim 2, 0, 151, -16, -6, -16, -6,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -17, -4, -17, -4,
+ax_anim 3, 0, 152, -20, 1, -20, 1,
+ax_anim 2, 3, 151, -17, 5, -17, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -9, -1, -9, -1,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -22, 9, -22, 9,
+ax_anim 3, 0, 151, -20, 22, -20, 22,
+ax_anim 2, 3, 150, -11, 21, -11, 21,
+ax_anim 2, 0, 149, -2, 15, -2, 15,
+ax_anim 1, 0, 148, 1, 9, 1, 9,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeottoAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeottoGfx1:
+.incbin "baserom.gba", 0x5C6EE4, 0x200
+sPidgeottoSprites1:
+ax_sprite sPidgeottoGfx1, 0x200
+ax_sprite_terminator
+sPidgeottoGfx2:
+.incbin "baserom.gba", 0x5C70F4, 0x200
+sPidgeottoSprites2:
+ax_sprite sPidgeottoGfx2, 0x200
+ax_sprite_terminator
+sPidgeottoGfx3:
+.incbin "baserom.gba", 0x5C7304, 0x200
+sPidgeottoSprites3:
+ax_sprite sPidgeottoGfx3, 0x200
+ax_sprite_terminator
+sPidgeottoGfx4:
+.incbin "baserom.gba", 0x5C7514, 0x200
+sPidgeottoSprites4:
+ax_sprite sPidgeottoGfx4, 0x200
+ax_sprite_terminator
+sPidgeottoGfx5:
+.incbin "baserom.gba", 0x5C7724, 0x200
+sPidgeottoSprites5:
+ax_sprite sPidgeottoGfx5, 0x200
+ax_sprite_terminator
+sPidgeottoGfx6:
+.incbin "baserom.gba", 0x5C7934, 0x200
+sPidgeottoSprites6:
+ax_sprite sPidgeottoGfx6, 0x200
+ax_sprite_terminator
+sPidgeottoGfx7:
+.incbin "baserom.gba", 0x5C7B44, 0x200
+sPidgeottoSprites7:
+ax_sprite sPidgeottoGfx7, 0x200
+ax_sprite_terminator
+sPidgeottoGfx8:
+.incbin "baserom.gba", 0x5C7D54, 0x200
+sPidgeottoSprites8:
+ax_sprite sPidgeottoGfx8, 0x200
+ax_sprite_terminator
+sPidgeottoGfx9:
+.incbin "baserom.gba", 0x5C7F64, 0x200
+sPidgeottoSprites9:
+ax_sprite sPidgeottoGfx9, 0x200
+ax_sprite_terminator
+sPidgeottoGfx10:
+.incbin "baserom.gba", 0x5C8174, 0x200
+sPidgeottoSprites10:
+ax_sprite sPidgeottoGfx10, 0x200
+ax_sprite_terminator
+sPidgeottoGfx11:
+.incbin "baserom.gba", 0x5C8384, 0x200
+sPidgeottoSprites11:
+ax_sprite sPidgeottoGfx11, 0x200
+ax_sprite_terminator
+sPidgeottoGfx12:
+.incbin "baserom.gba", 0x5C8594, 0x200
+sPidgeottoSprites12:
+ax_sprite sPidgeottoGfx12, 0x200
+ax_sprite_terminator
+sPidgeottoGfx13:
+.incbin "baserom.gba", 0x5C87A4, 0x100
+sPidgeottoSprites13:
+ax_sprite sPidgeottoGfx13, 0x100
+ax_sprite_terminator
+sPidgeottoGfx14:
+.incbin "baserom.gba", 0x5C88B4, 0x100
+sPidgeottoSprites14:
+ax_sprite sPidgeottoGfx14, 0x100
+ax_sprite_terminator
+sPidgeottoGfx15:
+.incbin "baserom.gba", 0x5C89C4, 0x100
+sPidgeottoSprites15:
+ax_sprite sPidgeottoGfx15, 0x100
+ax_sprite_terminator
+sPidgeottoGfx16:
+.incbin "baserom.gba", 0x5C8AD4, 0x40
+sPidgeottoGfx16_1:
+.incbin "baserom.gba", 0x5C8B14, 0x100
+sPidgeottoGfx16_2:
+.incbin "baserom.gba", 0x5C8C14, 0x40
+sPidgeottoSprites16:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx17:
+.incbin "baserom.gba", 0x5C8C94, 0x40
+sPidgeottoGfx17_1:
+.incbin "baserom.gba", 0x5C8CD4, 0x40
+sPidgeottoGfx17_2:
+.incbin "baserom.gba", 0x5C8D14, 0x100
+sPidgeottoSprites17:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeottoGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx17_2, 0x100
+ax_sprite_terminator
+sPidgeottoGfx18:
+.incbin "baserom.gba", 0x5C8E4C, 0x180
+sPidgeottoGfx18_1:
+.incbin "baserom.gba", 0x5C8FCC, 0x40
+sPidgeottoSprites18:
+ax_sprite sPidgeottoGfx18, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx19:
+.incbin "baserom.gba", 0x5C9034, 0x20
+sPidgeottoGfx19_1:
+.incbin "baserom.gba", 0x5C9054, 0x100
+sPidgeottoGfx19_2:
+.incbin "baserom.gba", 0x5C9154, 0x20
+sPidgeottoSprites19:
+ax_sprite 0, 0x40
+ax_sprite sPidgeottoGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx19_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sPidgeottoGfx19_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx20:
+.incbin "baserom.gba", 0x5C91B4, 0x40
+sPidgeottoGfx20_1:
+.incbin "baserom.gba", 0x5C91F4, 0x160
+sPidgeottoSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx20_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx21:
+.incbin "baserom.gba", 0x5C9384, 0x60
+sPidgeottoGfx21_1:
+.incbin "baserom.gba", 0x5C93E4, 0x100
+sPidgeottoGfx21_2:
+.incbin "baserom.gba", 0x5C94E4, 0x40
+sPidgeottoSprites21:
+ax_sprite sPidgeottoGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx22:
+.incbin "baserom.gba", 0x5C955C, 0x160
+sPidgeottoGfx22_1:
+.incbin "baserom.gba", 0x5C96BC, 0x40
+sPidgeottoSprites22:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx22, 0x160
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx23:
+.incbin "baserom.gba", 0x5C972C, 0x20
+sPidgeottoGfx23_1:
+.incbin "baserom.gba", 0x5C974C, 0x80
+sPidgeottoGfx23_2:
+.incbin "baserom.gba", 0x5C97CC, 0x60
+sPidgeottoGfx23_3:
+.incbin "baserom.gba", 0x5C982C, 0x60
+sPidgeottoSprites23:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPidgeottoGfx23_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx23_3, 0x60
+ax_sprite_terminator
+sPidgeottoGfx24:
+.incbin "baserom.gba", 0x5C98D4, 0x40
+sPidgeottoGfx24_1:
+.incbin "baserom.gba", 0x5C9914, 0x80
+sPidgeottoGfx24_2:
+.incbin "baserom.gba", 0x5C9994, 0x60
+sPidgeottoGfx24_3:
+.incbin "baserom.gba", 0x5C99F4, 0x40
+sPidgeottoSprites24:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx25:
+.incbin "baserom.gba", 0x5C9A84, 0x20
+sPidgeottoGfx25_1:
+.incbin "baserom.gba", 0x5C9AA4, 0x120
+sPidgeottoGfx25_2:
+.incbin "baserom.gba", 0x5C9BC4, 0x20
+sPidgeottoSprites25:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPidgeottoGfx25_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx25_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx26:
+.incbin "baserom.gba", 0x5C9C24, 0x40
+sPidgeottoGfx26_1:
+.incbin "baserom.gba", 0x5C9C64, 0x60
+sPidgeottoGfx26_2:
+.incbin "baserom.gba", 0x5C9CC4, 0xE0
+sPidgeottoSprites26:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx26_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx27:
+.incbin "baserom.gba", 0x5C9DE4, 0x180
+sPidgeottoGfx27_1:
+.incbin "baserom.gba", 0x5C9F64, 0x40
+sPidgeottoSprites27:
+ax_sprite sPidgeottoGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx28:
+.incbin "baserom.gba", 0x5C9FCC, 0x40
+sPidgeottoGfx28_1:
+.incbin "baserom.gba", 0x5CA00C, 0x100
+sPidgeottoGfx28_2:
+.incbin "baserom.gba", 0x5CA10C, 0x40
+sPidgeottoSprites28:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx28_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx29:
+.incbin "baserom.gba", 0x5CA18C, 0x40
+sPidgeottoGfx29_1:
+.incbin "baserom.gba", 0x5CA1CC, 0x40
+sPidgeottoGfx29_2:
+.incbin "baserom.gba", 0x5CA20C, 0x100
+sPidgeottoSprites29:
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeottoGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx29_2, 0x100
+ax_sprite_terminator
+sPidgeottoGfx30:
+.incbin "baserom.gba", 0x5CA344, 0x180
+sPidgeottoGfx30_1:
+.incbin "baserom.gba", 0x5CA4C4, 0x40
+sPidgeottoSprites30:
+ax_sprite sPidgeottoGfx30, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPidgeottoGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeottoGfx31:
+.incbin "baserom.gba", 0x5CA52C, 0x200
+sPidgeottoSprites31:
+ax_sprite sPidgeottoGfx31, 0x200
+ax_sprite_terminator
+sPidgeottoGfx32:
+.incbin "baserom.gba", 0x5CA73C, 0x200
+sPidgeottoSprites32:
+ax_sprite sPidgeottoGfx32, 0x200
+ax_sprite_terminator
+sPidgeottoGfx33:
+.incbin "baserom.gba", 0x5CA94C, 0x200
+sPidgeottoSprites33:
+ax_sprite sPidgeottoGfx33, 0x200
+ax_sprite_terminator
+sPidgeottoGfx34:
+.incbin "baserom.gba", 0x5CAB5C, 0x200
+sPidgeottoSprites34:
+ax_sprite sPidgeottoGfx34, 0x200
+ax_sprite_terminator
+sPidgeottoGfx35:
+.incbin "baserom.gba", 0x5CAD6C, 0x200
+sPidgeottoSprites35:
+ax_sprite sPidgeottoGfx35, 0x200
+ax_sprite_terminator
+sPidgeottoGfx36:
+.incbin "baserom.gba", 0x5CAF7C, 0x200
+sPidgeottoSprites36:
+ax_sprite sPidgeottoGfx36, 0x200
+ax_sprite_terminator
+sPidgeottoGfx37:
+.incbin "baserom.gba", 0x5CB18C, 0x200
+sPidgeottoSprites37:
+ax_sprite sPidgeottoGfx37, 0x200
+ax_sprite_terminator
+sAxPosesPidgeotto:
+.4byte sPidgeottoPose1
+.4byte sPidgeottoPose2
+.4byte sPidgeottoPose3
+.4byte sPidgeottoPose4
+.4byte sPidgeottoPose5
+.4byte sPidgeottoPose6
+.4byte sPidgeottoPose7
+.4byte sPidgeottoPose8
+.4byte sPidgeottoPose9
+.4byte sPidgeottoPose10
+.4byte sPidgeottoPose11
+.4byte sPidgeottoPose12
+.4byte sPidgeottoPose13
+.4byte sPidgeottoPose14
+.4byte sPidgeottoPose15
+.4byte sPidgeottoPose16
+.4byte sPidgeottoPose17
+.4byte sPidgeottoPose18
+.4byte sPidgeottoPose19
+.4byte sPidgeottoPose20
+.4byte sPidgeottoPose21
+.4byte sPidgeottoPose22
+.4byte sPidgeottoPose23
+.4byte sPidgeottoPose24
+.4byte sPidgeottoPose25
+.4byte sPidgeottoPose26
+.4byte sPidgeottoPose27
+.4byte sPidgeottoPose28
+.4byte sPidgeottoPose29
+.4byte sPidgeottoPose30
+.4byte sPidgeottoPose31
+.4byte sPidgeottoPose32
+.4byte sPidgeottoPose33
+.4byte sPidgeottoPose34
+.4byte sPidgeottoPose35
+.4byte sPidgeottoPose36
+.4byte sPidgeottoPose37
+.4byte sPidgeottoPose38
+.4byte sPidgeottoPose39
+.4byte sPidgeottoPose40
+.4byte sPidgeottoPose41
+.4byte sPidgeottoPose42
+.4byte sPidgeottoPose43
+.4byte sPidgeottoPose44
+.4byte sPidgeottoPose45
+.4byte sPidgeottoPose46
+.4byte sPidgeottoPose47
+.4byte sPidgeottoPose48
+.4byte sPidgeottoPose49
+.4byte sPidgeottoPose50
+.4byte sPidgeottoPose51
+.4byte sPidgeottoPose52
+.4byte sPidgeottoPose53
+.4byte sPidgeottoPose54
+.4byte sPidgeottoPose55
+.4byte sPidgeottoPose56
+.4byte sPidgeottoPose57
+.4byte sPidgeottoPose58
+.4byte sPidgeottoPose59
+.4byte sPidgeottoPose60
+.4byte sPidgeottoPose61
+.4byte sPidgeottoPose62
+.4byte sPidgeottoPose63
+.4byte sPidgeottoPose64
+.4byte sPidgeottoPose65
+.4byte sPidgeottoPose66
+.4byte sPidgeottoPose67
+.4byte sPidgeottoPose68
+.4byte sPidgeottoPose69
+.4byte sPidgeottoPose70
+.4byte sPidgeottoPose71
+.4byte sPidgeottoPose72
+.4byte sPidgeottoPose73
+.4byte sPidgeottoPose74
+.4byte sPidgeottoPose75
+.4byte sPidgeottoPose76
+.4byte sPidgeottoPose77
+.4byte sPidgeottoPose78
+.4byte sPidgeottoPose79
+.4byte sPidgeottoPose80
+.4byte sPidgeottoPose81
+.4byte sPidgeottoPose82
+.4byte sPidgeottoPose83
+.4byte sPidgeottoPose84
+.4byte sPidgeottoPose85
+.4byte sPidgeottoPose86
+.4byte sPidgeottoPose87
+.4byte sPidgeottoPose88
+.4byte sPidgeottoPose89
+.4byte sPidgeottoPose90
+.4byte sPidgeottoPose91
+.4byte sPidgeottoPose92
+.4byte sPidgeottoPose93
+.4byte sPidgeottoPose94
+.4byte sPidgeottoPose95
+.4byte sPidgeottoPose96
+.4byte sPidgeottoPose97
+.4byte sPidgeottoPose98
+.4byte sPidgeottoPose99
+.4byte sPidgeottoPose100
+.4byte sPidgeottoPose101
+.4byte sPidgeottoPose102
+.4byte sPidgeottoPose103
+.4byte sPidgeottoPose104
+.4byte sPidgeottoPose105
+.4byte sPidgeottoPose106
+.4byte sPidgeottoPose107
+.4byte sPidgeottoPose108
+.4byte sPidgeottoPose109
+.4byte sPidgeottoPose110
+.4byte sPidgeottoPose111
+.4byte sPidgeottoPose112
+.4byte sPidgeottoPose113
+.4byte sPidgeottoPose114
+.4byte sPidgeottoPose115
+.4byte sPidgeottoPose116
+.4byte sPidgeottoPose117
+.4byte sPidgeottoPose118
+.4byte sPidgeottoPose119
+.4byte sPidgeottoPose120
+.4byte sPidgeottoPose121
+.4byte sPidgeottoPose122
+.4byte sPidgeottoPose123
+.4byte sPidgeottoPose124
+.4byte sPidgeottoPose125
+.4byte sPidgeottoPose126
+.4byte sPidgeottoPose127
+.4byte sPidgeottoPose128
+.4byte sPidgeottoPose129
+.4byte sPidgeottoPose130
+.4byte sPidgeottoPose131
+.4byte sPidgeottoPose132
+.4byte sPidgeottoPose133
+.4byte sPidgeottoPose134
+.4byte sPidgeottoPose135
+.4byte sPidgeottoPose136
+.4byte sPidgeottoPose137
+.4byte sPidgeottoPose138
+.4byte sPidgeottoPose139
+.4byte sPidgeottoPose140
+.4byte sPidgeottoPose141
+.4byte sPidgeottoPose142
+.4byte sPidgeottoPose143
+.4byte sPidgeottoPose144
+.4byte sPidgeottoPose145
+.4byte sPidgeottoPose146
+.4byte sPidgeottoPose147
+.4byte sPidgeottoPose148
+.4byte sPidgeottoPose149
+.4byte sPidgeottoPose150
+.4byte sPidgeottoPose151
+.4byte sPidgeottoPose152
+.4byte sPidgeottoPose153
+.4byte sPidgeottoPose154
+.4byte sPidgeottoPose155
+.4byte sPidgeottoPose156
+.4byte sPidgeottoPose157
+.4byte sPidgeottoPose158
+.4byte sPidgeottoPose159
+.4byte sPidgeottoPose160
+.4byte sPidgeottoPose161
+.4byte sPidgeottoPose162
+.4byte sPidgeottoPose163
+.4byte sPidgeottoPose164
+.4byte sPidgeottoPose165
+.4byte sPidgeottoPose166
+.4byte sPidgeottoPose167
+.4byte sPidgeottoPose168
+.4byte sPidgeottoPose169
+.4byte sPidgeottoPose170
+.4byte sPidgeottoPose171
+.4byte sPidgeottoPose172
+.4byte sPidgeottoPose173
+.4byte sPidgeottoPose174
+.4byte sPidgeottoPose175
+.4byte sPidgeottoPose176
+.4byte sPidgeottoPose177
+.4byte sPidgeottoPose178
+.4byte sPidgeottoPose179
+.4byte sPidgeottoPose180
+.4byte sPidgeottoPose181
+.4byte sPidgeottoPose182
+.4byte sPidgeottoPose183
+.4byte sPidgeottoPose184
+.4byte sPidgeottoPose185
+.4byte sPidgeottoPose186
+.4byte sPidgeottoPose187
+.4byte sPidgeottoPose188
+.4byte sPidgeottoPose189
+.4byte sPidgeottoPose190
+.4byte sPidgeottoPose191
+.4byte sPidgeottoPose192
+.4byte sPidgeottoPose193
+.4byte sPidgeottoPose194
+.4byte sPidgeottoPose195
+.4byte sPidgeottoPose196
+.4byte sPidgeottoPose197
+.4byte sPidgeottoPose198
+.4byte sPidgeottoPose199
+.4byte sPidgeottoPose200
+.4byte sPidgeottoPose201
+.4byte sPidgeottoPose202
+sAxPositionsPidgeotto:
+.2byte   -1,   -6, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,   -4, 	  -7,   -6, 	   5,   -8, 	  -1,   -6
+.2byte   -1,   -4, 	  -7,   -8, 	   5,   -6, 	  -1,   -6
+.2byte    7,   -9, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+.2byte    8,   -8, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+.2byte    8,   -8, 	  -2,   -8, 	  -6,   -5, 	  -1,   -7
+.2byte   10,  -13, 	  -4,   -9, 	  -5,   -4, 	  -1,   -8
+.2byte   11,  -12, 	  -5,   -8, 	  -6,   -4, 	  -2,   -7
+.2byte   11,  -12, 	  -4,   -8, 	  -4,   -3, 	  -1,   -6
+.2byte    7,  -15, 	  -6,   -7, 	   0,   -4, 	  -1,   -9
+.2byte    8,  -14, 	  -6,   -6, 	  -2,   -3, 	  -1,   -8
+.2byte    8,  -14, 	  -5,   -7, 	   1,   -4, 	   0,   -8
+.2byte   -1,  -18, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -16, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -16, 	   2,   -5, 	  -7,   -7, 	  -1,   -9
+.2byte   -9,  -15, 	   4,   -7, 	  -2,   -4, 	  -1,   -9
+.2byte  -10,  -14, 	   4,   -6, 	   0,   -3, 	  -1,   -8
+.2byte  -10,  -14, 	   3,   -7, 	  -3,   -4, 	  -2,   -8
+.2byte  -12,  -13, 	   2,   -9, 	   3,   -4, 	  -1,   -8
+.2byte  -13,  -12, 	   3,   -8, 	   4,   -4, 	   0,   -7
+.2byte  -13,  -12, 	   2,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -9,   -9, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte  -10,   -8, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte  -10,   -8, 	   0,   -8, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    0, 	 -12,   -8, 	  10,   -8, 	  -1,   -9
+.2byte   -1,   -7, 	 -10,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -8
+.2byte    7,   -9, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+.2byte    8,   -4, 	   6,  -15, 	 -11,   -6, 	  -2,  -10
+.2byte    6,  -10, 	   8,   -5, 	  -4,    0, 	  -2,   -9
+.2byte    6,  -10, 	   6,  -21, 	 -12,  -15, 	  -3,   -9
+.2byte   10,  -13, 	  -4,   -9, 	  -5,   -4, 	  -1,   -8
+.2byte   12,  -11, 	  -2,  -18, 	  -1,   -2, 	  -1,  -10
+.2byte    9,  -14, 	   3,   -8, 	   2,    0, 	  -2,   -9
+.2byte    9,  -14, 	  -4,  -21, 	  -9,  -15, 	  -3,  -10
+.2byte    7,  -15, 	  -6,   -7, 	   0,   -4, 	  -1,   -9
+.2byte    8,  -14, 	 -10,  -13, 	   7,   -5, 	  -1,  -11
+.2byte    6,  -16, 	  -7,   -5, 	   6,   -2, 	  -2,  -10
+.2byte    6,  -16, 	 -11,  -21, 	   7,  -16, 	  -3,  -11
+.2byte   -1,  -18, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -17, 	  10,  -11, 	 -12,  -11, 	  -1,  -10
+.2byte   -1,  -18, 	   7,   -4, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -18, 	   9,  -18, 	 -11,  -18, 	  -1,   -9
+.2byte   -9,  -15, 	   4,   -7, 	  -2,   -4, 	  -1,   -9
+.2byte  -10,  -14, 	   8,  -13, 	  -9,   -5, 	  -1,  -11
+.2byte   -8,  -16, 	   5,   -5, 	  -8,   -2, 	   0,  -10
+.2byte   -8,  -16, 	   9,  -21, 	  -9,  -16, 	   1,  -11
+.2byte  -12,  -13, 	   2,   -9, 	   3,   -4, 	  -1,   -8
+.2byte  -14,  -11, 	   0,  -18, 	  -1,   -2, 	  -1,  -10
+.2byte  -11,  -14, 	  -5,   -8, 	  -4,    0, 	   0,   -9
+.2byte  -11,  -14, 	   2,  -21, 	   7,  -15, 	   1,  -10
+.2byte   -9,   -9, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte  -10,   -4, 	  -8,  -15, 	   9,   -6, 	   0,  -10
+.2byte   -8,  -10, 	 -10,   -5, 	   2,    0, 	   0,   -9
+.2byte   -8,  -10, 	  -8,  -21, 	  10,  -15, 	   1,   -9
+.2byte   -1,   -6, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,    0, 	 -12,   -8, 	  10,   -8, 	  -1,   -9
+.2byte   -1,   -7, 	 -10,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -8
+.2byte    7,   -9, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+.2byte    8,   -4, 	   6,  -15, 	 -11,   -6, 	  -2,  -10
+.2byte    6,  -10, 	   8,   -5, 	  -4,    0, 	  -2,   -9
+.2byte    6,  -10, 	   6,  -21, 	 -12,  -15, 	  -3,   -9
+.2byte   10,  -13, 	  -4,   -9, 	  -5,   -4, 	  -1,   -8
+.2byte   12,  -11, 	  -2,  -18, 	  -1,   -2, 	  -1,  -10
+.2byte    9,  -14, 	   3,   -8, 	   2,    0, 	  -2,   -9
+.2byte    9,  -14, 	  -4,  -21, 	  -9,  -15, 	  -3,  -10
+.2byte    7,  -15, 	  -6,   -7, 	   0,   -4, 	  -1,   -9
+.2byte    8,  -14, 	 -10,  -13, 	   7,   -5, 	  -1,  -11
+.2byte    6,  -16, 	  -7,   -5, 	   6,   -2, 	  -2,  -10
+.2byte    6,  -16, 	 -11,  -21, 	   7,  -16, 	  -3,  -11
+.2byte   -1,  -18, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -17, 	  10,  -11, 	 -12,  -11, 	  -1,  -10
+.2byte   -1,  -18, 	   7,   -4, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -18, 	   9,  -18, 	 -11,  -18, 	  -1,   -9
+.2byte   -9,  -15, 	   4,   -7, 	  -2,   -4, 	  -1,   -9
+.2byte  -10,  -14, 	   8,  -13, 	  -9,   -5, 	  -1,  -11
+.2byte   -8,  -16, 	   5,   -5, 	  -8,   -2, 	   0,  -10
+.2byte   -8,  -16, 	   9,  -21, 	  -9,  -16, 	   1,  -11
+.2byte  -12,  -13, 	   2,   -9, 	   3,   -4, 	  -1,   -8
+.2byte  -14,  -11, 	   0,  -18, 	  -1,   -2, 	  -1,  -10
+.2byte  -11,  -14, 	  -5,   -8, 	  -4,    0, 	   0,   -9
+.2byte  -11,  -14, 	   2,  -21, 	   7,  -15, 	   1,  -10
+.2byte   -9,   -9, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte  -10,   -4, 	  -8,  -15, 	   9,   -6, 	   0,  -10
+.2byte   -8,  -10, 	 -10,   -5, 	   2,    0, 	   0,   -9
+.2byte   -8,  -10, 	  -8,  -21, 	  10,  -15, 	   1,   -9
+.2byte   -1,   -6, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	 -10,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -8
+.2byte    7,   -9, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+.2byte    6,  -10, 	   8,   -5, 	  -4,    0, 	  -2,   -9
+.2byte    6,  -10, 	   6,  -21, 	 -12,  -15, 	  -3,   -9
+.2byte   10,  -13, 	  -4,   -9, 	  -5,   -4, 	  -1,   -8
+.2byte    9,  -14, 	   3,   -8, 	   2,    0, 	  -2,   -9
+.2byte    9,  -14, 	  -4,  -21, 	  -9,  -15, 	  -3,  -10
+.2byte    7,  -15, 	  -6,   -7, 	   0,   -4, 	  -1,   -9
+.2byte    6,  -16, 	  -7,   -5, 	   6,   -2, 	  -2,  -10
+.2byte    6,  -16, 	 -11,  -21, 	   7,  -16, 	  -3,  -11
+.2byte   -1,  -18, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -18, 	   7,   -4, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -18, 	   9,  -18, 	 -11,  -18, 	  -1,   -9
+.2byte   -9,  -15, 	   4,   -7, 	  -2,   -4, 	  -1,   -9
+.2byte   -8,  -16, 	   5,   -5, 	  -8,   -2, 	   0,  -10
+.2byte   -8,  -16, 	   9,  -21, 	  -9,  -16, 	   1,  -11
+.2byte  -12,  -13, 	   2,   -9, 	   3,   -4, 	  -1,   -8
+.2byte  -11,  -14, 	  -5,   -8, 	  -4,    0, 	   0,   -9
+.2byte  -11,  -14, 	   2,  -21, 	   7,  -15, 	   1,  -10
+.2byte   -9,   -9, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte   -8,  -10, 	 -10,   -5, 	   2,    0, 	   0,   -9
+.2byte   -8,  -10, 	  -8,  -21, 	  10,  -15, 	   1,   -9
+.2byte   -1,   -7, 	 -10,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -8
+.2byte    6,  -10, 	   8,   -5, 	  -4,    0, 	  -2,   -9
+.2byte    6,  -10, 	   6,  -21, 	 -12,  -15, 	  -3,   -9
+.2byte    9,  -14, 	   3,   -8, 	   2,    0, 	  -2,   -9
+.2byte    9,  -14, 	  -4,  -21, 	  -9,  -15, 	  -3,  -10
+.2byte    6,  -16, 	  -7,   -5, 	   6,   -2, 	  -2,  -10
+.2byte    6,  -16, 	 -11,  -21, 	   7,  -16, 	  -3,  -11
+.2byte   -1,  -18, 	   7,   -4, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -18, 	   9,  -18, 	 -11,  -18, 	  -1,   -9
+.2byte   -8,  -16, 	   5,   -5, 	  -8,   -2, 	   0,  -10
+.2byte   -8,  -16, 	   9,  -21, 	  -9,  -16, 	   1,  -11
+.2byte  -11,  -14, 	  -5,   -8, 	  -4,    0, 	   0,   -9
+.2byte  -11,  -14, 	   2,  -21, 	   7,  -15, 	   1,  -10
+.2byte   -8,  -10, 	 -10,   -5, 	   2,    0, 	   0,   -9
+.2byte   -8,  -10, 	  -8,  -21, 	  10,  -15, 	   1,   -9
+.2byte   -9,   -8, 	  -2,   -9, 	   5,   -6, 	   1,   -7
+.2byte   -9,   -6, 	  -2,   -8, 	   5,   -5, 	   1,   -6
+.2byte   -1,  -20, 	 -13,   -6, 	   6,  -22, 	  -1,  -10
+.2byte    4,  -20, 	   5,   -5, 	  -8,  -21, 	   0,  -10
+.2byte    1,  -21, 	  -2,   -5, 	  -9,  -18, 	   0,   -9
+.2byte    1,  -21, 	  -8,   -6, 	   5,  -22, 	  -2,  -10
+.2byte   -1,  -20, 	  -7,  -22, 	  12,   -8, 	   0,   -9
+.2byte   -2,  -21, 	   7,   -6, 	  -6,  -22, 	   1,  -10
+.2byte   -2,  -21, 	   1,   -5, 	   8,  -18, 	  -1,   -9
+.2byte   -5,  -20, 	  -6,   -5, 	   7,  -21, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -9,   -9, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte  -12,  -13, 	   2,   -9, 	   3,   -4, 	  -1,   -8
+.2byte   -9,  -15, 	   4,   -7, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,  -18, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte    7,  -15, 	  -6,   -7, 	   0,   -4, 	  -1,   -9
+.2byte   10,  -13, 	  -4,   -9, 	  -5,   -4, 	  -1,   -8
+.2byte    7,   -9, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+.2byte   -1,    0, 	 -12,   -8, 	  10,   -8, 	  -1,   -9
+.2byte  -10,   -4, 	  -8,  -15, 	   9,   -6, 	   0,  -10
+.2byte  -14,  -11, 	   0,  -18, 	  -1,   -2, 	  -1,  -10
+.2byte  -10,  -14, 	   8,  -13, 	  -9,   -5, 	  -1,  -11
+.2byte   -1,  -17, 	  10,  -11, 	 -12,  -11, 	  -1,  -10
+.2byte    8,  -14, 	 -10,  -13, 	   7,   -5, 	  -1,  -11
+.2byte   12,  -11, 	  -2,  -18, 	  -1,   -2, 	  -1,  -10
+.2byte    8,   -4, 	   6,  -15, 	 -11,   -6, 	  -2,  -10
+.2byte   -1,   -8, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte    6,  -10, 	   6,  -21, 	 -12,  -15, 	  -3,   -9
+.2byte    9,  -14, 	  -4,  -21, 	  -9,  -15, 	  -3,  -10
+.2byte    7,  -16, 	 -10,  -21, 	   8,  -16, 	  -2,  -11
+.2byte   -1,  -19, 	   9,  -19, 	 -11,  -19, 	  -1,  -10
+.2byte   -9,  -16, 	   8,  -21, 	 -10,  -16, 	   0,  -11
+.2byte  -11,  -14, 	   2,  -21, 	   7,  -15, 	   1,  -10
+.2byte   -8,  -10, 	  -8,  -21, 	  10,  -15, 	   1,   -9
+.2byte   -1,   -6, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	 -10,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -7, 	 -12,  -16, 	  10,  -16, 	  -1,   -8
+.2byte    7,   -9, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+.2byte    6,  -10, 	   8,   -5, 	  -4,    0, 	  -2,   -9
+.2byte    6,  -10, 	   6,  -21, 	 -12,  -15, 	  -3,   -9
+.2byte   10,  -13, 	  -4,   -9, 	  -5,   -4, 	  -1,   -8
+.2byte    9,  -14, 	   3,   -8, 	   2,    0, 	  -2,   -9
+.2byte    9,  -14, 	  -4,  -21, 	  -9,  -15, 	  -3,  -10
+.2byte    7,  -15, 	  -6,   -7, 	   0,   -4, 	  -1,   -9
+.2byte    6,  -16, 	  -7,   -5, 	   6,   -2, 	  -2,  -10
+.2byte    6,  -16, 	 -11,  -21, 	   7,  -16, 	  -3,  -11
+.2byte   -1,  -18, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte   -1,  -18, 	   7,   -4, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -18, 	   9,  -18, 	 -11,  -18, 	  -1,   -9
+.2byte   -9,  -15, 	   4,   -7, 	  -2,   -4, 	  -1,   -9
+.2byte   -8,  -16, 	   5,   -5, 	  -8,   -2, 	   0,  -10
+.2byte   -8,  -16, 	   9,  -21, 	  -9,  -16, 	   1,  -11
+.2byte  -12,  -13, 	   2,   -9, 	   3,   -4, 	  -1,   -8
+.2byte  -11,  -14, 	  -5,   -8, 	  -4,    0, 	   0,   -9
+.2byte  -11,  -14, 	   2,  -21, 	   7,  -15, 	   1,  -10
+.2byte   -9,   -9, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte   -8,  -10, 	 -10,   -5, 	   2,    0, 	   0,   -9
+.2byte   -8,  -10, 	  -8,  -21, 	  10,  -15, 	   1,   -9
+.2byte   -1,   -8, 	 -12,  -17, 	  10,  -17, 	  -1,   -9
+.2byte   -8,  -10, 	  -8,  -21, 	  10,  -15, 	   1,   -9
+.2byte  -11,  -14, 	   2,  -21, 	   7,  -15, 	   1,  -10
+.2byte   -9,  -16, 	   8,  -21, 	 -10,  -16, 	   0,  -11
+.2byte   -1,  -19, 	   9,  -19, 	 -11,  -19, 	  -1,  -10
+.2byte    7,  -16, 	 -10,  -21, 	   8,  -16, 	  -2,  -11
+.2byte    9,  -14, 	  -4,  -21, 	  -9,  -15, 	  -3,  -10
+.2byte    6,  -10, 	   6,  -21, 	 -12,  -15, 	  -3,   -9
+.2byte   -1,   -6, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -9,   -9, 	  -1,   -9, 	   5,   -6, 	   0,   -8
+.2byte  -12,  -13, 	   2,   -9, 	   3,   -4, 	  -1,   -8
+.2byte   -9,  -15, 	   4,   -7, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,  -18, 	   4,   -7, 	  -6,   -7, 	  -1,  -11
+.2byte    7,  -15, 	  -6,   -7, 	   0,   -4, 	  -1,   -9
+.2byte   10,  -13, 	  -4,   -9, 	  -5,   -4, 	  -1,   -8
+.2byte    7,   -9, 	  -1,   -9, 	  -7,   -6, 	  -2,   -8
+sPidgeottoAnimTable1:
+.4byte sPidgeottoAnims_1_1
+.4byte sPidgeottoAnims_1_2
+.4byte sPidgeottoAnims_1_3
+.4byte sPidgeottoAnims_1_4
+.4byte sPidgeottoAnims_1_5
+.4byte sPidgeottoAnims_1_6
+.4byte sPidgeottoAnims_1_7
+.4byte sPidgeottoAnims_1_8
+sPidgeottoAnimTable2:
+.4byte sPidgeottoAnims_2_1
+.4byte sPidgeottoAnims_2_2
+.4byte sPidgeottoAnims_2_3
+.4byte sPidgeottoAnims_2_4
+.4byte sPidgeottoAnims_2_5
+.4byte sPidgeottoAnims_2_6
+.4byte sPidgeottoAnims_2_7
+.4byte sPidgeottoAnims_2_8
+sPidgeottoAnimTable3:
+.4byte sPidgeottoAnims_3_1
+.4byte sPidgeottoAnims_3_2
+.4byte sPidgeottoAnims_3_3
+.4byte sPidgeottoAnims_3_4
+.4byte sPidgeottoAnims_3_5
+.4byte sPidgeottoAnims_3_6
+.4byte sPidgeottoAnims_3_7
+.4byte sPidgeottoAnims_3_8
+sPidgeottoAnimTable4:
+.4byte sPidgeottoAnims_4_1
+.4byte sPidgeottoAnims_4_2
+.4byte sPidgeottoAnims_4_3
+.4byte sPidgeottoAnims_4_4
+.4byte sPidgeottoAnims_4_5
+.4byte sPidgeottoAnims_4_6
+.4byte sPidgeottoAnims_4_7
+.4byte sPidgeottoAnims_4_8
+sPidgeottoAnimTable5:
+.4byte sPidgeottoAnims_5_1
+.4byte sPidgeottoAnims_5_2
+.4byte sPidgeottoAnims_5_3
+.4byte sPidgeottoAnims_5_4
+.4byte sPidgeottoAnims_5_5
+.4byte sPidgeottoAnims_5_6
+.4byte sPidgeottoAnims_5_7
+.4byte sPidgeottoAnims_5_8
+sPidgeottoAnimTable6:
+.4byte sPidgeottoAnims_6_1
+.4byte sPidgeottoAnims_6_1
+.4byte sPidgeottoAnims_6_1
+.4byte sPidgeottoAnims_6_1
+.4byte sPidgeottoAnims_6_1
+.4byte sPidgeottoAnims_6_1
+.4byte sPidgeottoAnims_6_1
+.4byte sPidgeottoAnims_6_1
+sPidgeottoAnimTable7:
+.4byte sPidgeottoAnims_7_1
+.4byte sPidgeottoAnims_7_2
+.4byte sPidgeottoAnims_7_3
+.4byte sPidgeottoAnims_7_4
+.4byte sPidgeottoAnims_7_5
+.4byte sPidgeottoAnims_7_6
+.4byte sPidgeottoAnims_7_7
+.4byte sPidgeottoAnims_7_8
+sPidgeottoAnimTable8:
+.4byte sPidgeottoAnims_8_1
+.4byte sPidgeottoAnims_8_2
+.4byte sPidgeottoAnims_8_3
+.4byte sPidgeottoAnims_8_4
+.4byte sPidgeottoAnims_8_5
+.4byte sPidgeottoAnims_8_6
+.4byte sPidgeottoAnims_8_7
+.4byte sPidgeottoAnims_8_8
+sPidgeottoAnimTable9:
+.4byte sPidgeottoAnims_9_1
+.4byte sPidgeottoAnims_9_2
+.4byte sPidgeottoAnims_9_3
+.4byte sPidgeottoAnims_9_4
+.4byte sPidgeottoAnims_9_5
+.4byte sPidgeottoAnims_9_6
+.4byte sPidgeottoAnims_9_7
+.4byte sPidgeottoAnims_9_8
+sPidgeottoAnimTable10:
+.4byte sPidgeottoAnims_10_1
+.4byte sPidgeottoAnims_10_2
+.4byte sPidgeottoAnims_10_3
+.4byte sPidgeottoAnims_10_4
+.4byte sPidgeottoAnims_10_5
+.4byte sPidgeottoAnims_10_6
+.4byte sPidgeottoAnims_10_7
+.4byte sPidgeottoAnims_10_8
+sPidgeottoAnimTable11:
+.4byte sPidgeottoAnims_11_1
+.4byte sPidgeottoAnims_11_2
+.4byte sPidgeottoAnims_11_3
+.4byte sPidgeottoAnims_11_4
+.4byte sPidgeottoAnims_11_5
+.4byte sPidgeottoAnims_11_6
+.4byte sPidgeottoAnims_11_7
+.4byte sPidgeottoAnims_11_8
+sPidgeottoAnimTable12:
+.4byte sPidgeottoAnims_12_1
+.4byte sPidgeottoAnims_12_2
+.4byte sPidgeottoAnims_12_3
+.4byte sPidgeottoAnims_12_4
+.4byte sPidgeottoAnims_12_5
+.4byte sPidgeottoAnims_12_6
+.4byte sPidgeottoAnims_12_7
+.4byte sPidgeottoAnims_12_8
+sPidgeottoAnimTable13:
+.4byte sPidgeottoAnims_13_1
+.4byte sPidgeottoAnims_13_2
+.4byte sPidgeottoAnims_13_3
+.4byte sPidgeottoAnims_13_4
+.4byte sPidgeottoAnims_13_5
+.4byte sPidgeottoAnims_13_6
+.4byte sPidgeottoAnims_13_7
+.4byte sPidgeottoAnims_13_8
+sAxAnimationsPidgeotto:
+.4byte sPidgeottoAnimTable1
+.4byte sPidgeottoAnimTable2
+.4byte sPidgeottoAnimTable3
+.4byte sPidgeottoAnimTable4
+.4byte sPidgeottoAnimTable5
+.4byte sPidgeottoAnimTable6
+.4byte sPidgeottoAnimTable7
+.4byte sPidgeottoAnimTable8
+.4byte sPidgeottoAnimTable9
+.4byte sPidgeottoAnimTable10
+.4byte sPidgeottoAnimTable11
+.4byte sPidgeottoAnimTable12
+.4byte sPidgeottoAnimTable13
+sAxSpritesPidgeotto:
+.4byte sPidgeottoSprites1
+.4byte sPidgeottoSprites2
+.4byte sPidgeottoSprites3
+.4byte sPidgeottoSprites4
+.4byte sPidgeottoSprites5
+.4byte sPidgeottoSprites6
+.4byte sPidgeottoSprites7
+.4byte sPidgeottoSprites8
+.4byte sPidgeottoSprites9
+.4byte sPidgeottoSprites10
+.4byte sPidgeottoSprites11
+.4byte sPidgeottoSprites12
+.4byte sPidgeottoSprites13
+.4byte sPidgeottoSprites14
+.4byte sPidgeottoSprites15
+.4byte sPidgeottoSprites16
+.4byte sPidgeottoSprites17
+.4byte sPidgeottoSprites18
+.4byte sPidgeottoSprites19
+.4byte sPidgeottoSprites20
+.4byte sPidgeottoSprites21
+.4byte sPidgeottoSprites22
+.4byte sPidgeottoSprites23
+.4byte sPidgeottoSprites24
+.4byte sPidgeottoSprites25
+.4byte sPidgeottoSprites26
+.4byte sPidgeottoSprites27
+.4byte sPidgeottoSprites28
+.4byte sPidgeottoSprites29
+.4byte sPidgeottoSprites30
+.4byte sPidgeottoSprites31
+.4byte sPidgeottoSprites32
+.4byte sPidgeottoSprites33
+.4byte sPidgeottoSprites34
+.4byte sPidgeottoSprites35
+.4byte sPidgeottoSprites36
+.4byte sPidgeottoSprites37
+sAxMainPidgeotto:
+ax_main sAxPosesPidgeotto, sAxAnimationsPidgeotto, 13, sAxSpritesPidgeotto, sAxPositionsPidgeotto

--- a/data/ax/pidgey.inc
+++ b/data/ax/pidgey.inc
@@ -1,0 +1,2781 @@
+.global gAxPidgey
+gAxPidgey:
+ax_siro sAxMainPidgey
+sPidgeyPose1:
+ax_pose 0, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose2:
+ax_pose 1, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose3:
+ax_pose 2, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose4:
+ax_pose 3, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose5:
+ax_pose 4, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose6:
+ax_pose 5, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose7:
+ax_pose 6, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose8:
+ax_pose 7, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose9:
+ax_pose 8, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sPidgeyPose10:
+ax_pose 9, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose11:
+ax_pose 10, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose12:
+ax_pose 11, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose13:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose14:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose15:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose19:
+ax_pose 6, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose20:
+ax_pose 7, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose21:
+ax_pose 8, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeyPose22:
+ax_pose 3, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose23:
+ax_pose 4, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose24:
+ax_pose 5, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose25:
+ax_pose 0, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose26:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose27:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose28:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose29:
+ax_pose 3, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose30:
+ax_pose 18, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose31:
+ax_pose 19, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose32:
+ax_pose 20, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose33:
+ax_pose 6, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose34:
+ax_pose 21, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose35:
+ax_pose 22, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose36:
+ax_pose 23, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose37:
+ax_pose 9, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose38:
+ax_pose 24, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose39:
+ax_pose 25, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose40:
+ax_pose 26, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose41:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose42:
+ax_pose 27, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose43:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose44:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose45:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose46:
+ax_pose 24, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose47:
+ax_pose 25, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose48:
+ax_pose 26, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose49:
+ax_pose 6, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose50:
+ax_pose 21, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose51:
+ax_pose 22, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose52:
+ax_pose 23, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose53:
+ax_pose 3, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose54:
+ax_pose 18, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose55:
+ax_pose 19, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose56:
+ax_pose 20, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose57:
+ax_pose 0, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose58:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose59:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose60:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose61:
+ax_pose 3, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose62:
+ax_pose 18, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose63:
+ax_pose 19, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose64:
+ax_pose 20, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose65:
+ax_pose 6, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose66:
+ax_pose 21, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose67:
+ax_pose 22, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose68:
+ax_pose 23, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose69:
+ax_pose 9, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose70:
+ax_pose 24, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose71:
+ax_pose 25, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose72:
+ax_pose 26, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose73:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose74:
+ax_pose 27, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose75:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose76:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose77:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose78:
+ax_pose 24, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose79:
+ax_pose 25, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose80:
+ax_pose 26, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose81:
+ax_pose 6, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose82:
+ax_pose 21, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose83:
+ax_pose 22, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose84:
+ax_pose 23, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose85:
+ax_pose 3, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose86:
+ax_pose 18, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose87:
+ax_pose 19, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose88:
+ax_pose 20, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose89:
+ax_pose 0, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose90:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose91:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose92:
+ax_pose 3, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose93:
+ax_pose 19, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose94:
+ax_pose 20, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose95:
+ax_pose 6, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose96:
+ax_pose 22, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose97:
+ax_pose 23, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose98:
+ax_pose 9, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose99:
+ax_pose 25, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose100:
+ax_pose 26, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose101:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose102:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose103:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose104:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose105:
+ax_pose 25, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose106:
+ax_pose 26, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose107:
+ax_pose 6, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose108:
+ax_pose 22, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose109:
+ax_pose 23, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose110:
+ax_pose 3, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose111:
+ax_pose 19, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose112:
+ax_pose 20, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose113:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose114:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose115:
+ax_pose 19, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose116:
+ax_pose 20, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose117:
+ax_pose 22, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose118:
+ax_pose 23, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose119:
+ax_pose 25, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose120:
+ax_pose 26, 0x01e9, 0x90f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose121:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose122:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose123:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose124:
+ax_pose 26, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose125:
+ax_pose 22, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose126:
+ax_pose 23, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose127:
+ax_pose 19, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose128:
+ax_pose 20, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose129:
+ax_pose 30, 0x01f3, 0x40f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose130:
+ax_pose 31, 0x01f3, 0x40f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose131:
+ax_pose 32, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeyPose132:
+ax_pose 33, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose133:
+ax_pose 34, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeyPose134:
+ax_pose 35, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeyPose135:
+ax_pose 36, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose136:
+ax_pose 35, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeyPose137:
+ax_pose 34, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeyPose138:
+ax_pose 33, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose139:
+ax_pose 0, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose140:
+ax_pose 1, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose141:
+ax_pose 2, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose142:
+ax_pose 3, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose143:
+ax_pose 4, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose144:
+ax_pose 5, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose145:
+ax_pose 6, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose146:
+ax_pose 7, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose147:
+ax_pose 8, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sPidgeyPose148:
+ax_pose 9, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose149:
+ax_pose 10, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose150:
+ax_pose 11, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose151:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose152:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose153:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose154:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose155:
+ax_pose 10, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose156:
+ax_pose 11, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose157:
+ax_pose 6, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose158:
+ax_pose 7, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose159:
+ax_pose 8, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sPidgeyPose160:
+ax_pose 3, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose161:
+ax_pose 4, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose162:
+ax_pose 5, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose163:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose164:
+ax_pose 18, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose165:
+ax_pose 21, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose166:
+ax_pose 24, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose167:
+ax_pose 27, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose168:
+ax_pose 24, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose169:
+ax_pose 21, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose170:
+ax_pose 18, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose171:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose172:
+ax_pose 20, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose173:
+ax_pose 23, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose174:
+ax_pose 26, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose175:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose176:
+ax_pose 26, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose177:
+ax_pose 23, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose178:
+ax_pose 20, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose179:
+ax_pose 2, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose180:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose181:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose182:
+ax_pose 5, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sPidgeyPose183:
+ax_pose 19, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose184:
+ax_pose 20, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose185:
+ax_pose 8, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeyPose186:
+ax_pose 22, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose187:
+ax_pose 23, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose188:
+ax_pose 11, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sPidgeyPose189:
+ax_pose 25, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose190:
+ax_pose 26, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose191:
+ax_pose 14, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose192:
+ax_pose 28, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose193:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose194:
+ax_pose 11, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeyPose195:
+ax_pose 25, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose196:
+ax_pose 26, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose197:
+ax_pose 8, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sPidgeyPose198:
+ax_pose 22, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose199:
+ax_pose 23, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose200:
+ax_pose 5, 0x81ed, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose201:
+ax_pose 19, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose202:
+ax_pose 20, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose203:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose204:
+ax_pose 20, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose205:
+ax_pose 23, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose206:
+ax_pose 26, 0x01e9, 0x80f1, 0x4c00
+ax_pose_terminator
+sPidgeyPose207:
+ax_pose 29, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sPidgeyPose208:
+ax_pose 26, 0x01e9, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose209:
+ax_pose 23, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose210:
+ax_pose 20, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sPidgeyPose211:
+ax_pose 0, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose212:
+ax_pose 3, 0x81ee, 0x80f7, 0x4c00
+ax_pose_terminator
+sPidgeyPose213:
+ax_pose 6, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose214:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sPidgeyPose215:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sPidgeyPose216:
+ax_pose 9, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose217:
+ax_pose 6, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sPidgeyPose218:
+ax_pose 3, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+.align 2
+sPidgeyAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 1,
+ax_anim 4, 0, 1, 0, 1, 0, 2,
+ax_anim 4, 0, 2, 0, 1, 0, 1,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 1, 0, 1, 1,
+ax_anim 4, 0, 4, 2, -1, 2, 2,
+ax_anim 4, 0, 5, 1, 1, 2, 2,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 2, -2, 2, 0,
+ax_anim 4, 0, 8, 1, -1, 1, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, -1,
+ax_anim 4, 0, 10, 2, -2, 3, -3,
+ax_anim 4, 0, 11, 1, -1, 2, -1,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, -1,
+ax_anim 4, 0, 13, 0, -1, 0, -3,
+ax_anim 4, 0, 14, 0, -1, 0, -1,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, -1,
+ax_anim 4, 0, 16, -2, -2, -3, -3,
+ax_anim 4, 0, 17, -1, -1, -2, -1,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -2, -2, -2, 0,
+ax_anim 4, 0, 20, -1, -1, -1, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -1, 0, -1, 1,
+ax_anim 4, 0, 22, -2, -1, -2, 2,
+ax_anim 4, 0, 23, -1, 1, -2, 2,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, 0,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 4, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 5, 0, 5,
+ax_anim_terminator
+sPidgeyAnims_2_2:
+ax_anim 2, 0, 30, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 4, 0, 31, 0, -5, 0, 0,
+ax_anim 1, 2, 29, 2, -1, 2, 2,
+ax_anim 1, 0, 29, 10, 10, 10, 12,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 1, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 5, 5, 5, 5,
+ax_anim_terminator
+sPidgeyAnims_2_3:
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 4, 0, 35, 0, -5, 0, 0,
+ax_anim 1, 2, 33, 2, -5, 2, 2,
+ax_anim 1, 0, 33, 10, -3, 10, 0,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 1, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 35, 12, -2, 12, 0,
+ax_anim 2, 0, 35, 5, -3, 5, 0,
+ax_anim_terminator
+sPidgeyAnims_2_4:
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 2, 0, 39, 0, -4, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 4, 0, 39, 0, -5, 0, 0,
+ax_anim 1, 2, 37, 2, -4, 2, -2,
+ax_anim 1, 0, 37, 10, -11, 10, -10,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 1, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 39, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 5, -5, 5, -5,
+ax_anim_terminator
+sPidgeyAnims_2_5:
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 4, 0, 43, 0, -5, 0, 0,
+ax_anim 1, 2, 41, 0, -8, 0, -2,
+ax_anim 1, 0, 41, 0, -12, 0, -8,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 1, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 43, 0, -5, 0, -5,
+ax_anim_terminator
+sPidgeyAnims_2_6:
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 4, 0, 47, 0, -5, 0, 0,
+ax_anim 1, 2, 45, -2, -4, -2, -2,
+ax_anim 1, 0, 45, -10, -11, -10, -10,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 1, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 47, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -5, -5, -5, -5,
+ax_anim_terminator
+sPidgeyAnims_2_7:
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 49, -2, -5, -2, 2,
+ax_anim 1, 0, 49, -10, -3, -10, 0,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 1, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 51, -12, -2, -12, 0,
+ax_anim 2, 0, 51, -5, -3, -5, 0,
+ax_anim_terminator
+sPidgeyAnims_2_8:
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 4, 0, 55, 0, -5, 0, 0,
+ax_anim 1, 2, 53, -2, -3, -2, 2,
+ax_anim 1, 0, 53, -10, 9, -10, 12,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 1, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 0, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 0, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 55, -12, 12, -12, 12,
+ax_anim 2, 0, 55, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 4, 0, 59, 0, -5, 0, 0,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 1, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 5, 0, 5,
+ax_anim_terminator
+sPidgeyAnims_3_2:
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 63, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -5, 0, 0,
+ax_anim 4, 0, 63, 0, -5, 0, 0,
+ax_anim 1, 2, 61, 2, -1, 2, 2,
+ax_anim 1, 0, 61, 10, 10, 10, 12,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 1, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 0, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 0, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 63, 12, 12, 12, 12,
+ax_anim 2, 0, 63, 5, 5, 5, 5,
+ax_anim_terminator
+sPidgeyAnims_3_3:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 4, 0, 67, 0, -5, 0, 0,
+ax_anim 1, 2, 65, 2, -5, 2, 2,
+ax_anim 1, 0, 65, 10, -3, 10, 0,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 1, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 0, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 0, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 67, 12, -2, 12, 0,
+ax_anim 2, 0, 67, 5, -3, 5, 0,
+ax_anim_terminator
+sPidgeyAnims_3_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 4, 0, 71, 0, -5, 0, 0,
+ax_anim 1, 2, 69, 2, -4, 2, -2,
+ax_anim 1, 0, 69, 10, -11, 10, -10,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 1, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 0, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 0, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 71, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 5, -5, 5, -5,
+ax_anim_terminator
+sPidgeyAnims_3_5:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 4, 0, 75, 0, -5, 0, 0,
+ax_anim 1, 2, 73, 0, -8, 0, -2,
+ax_anim 1, 0, 73, 0, -12, 0, -8,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 1, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 75, 0, -12, 0, -12,
+ax_anim 2, 0, 75, 0, -5, 0, -5,
+ax_anim_terminator
+sPidgeyAnims_3_6:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 4, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 2, 77, -2, -4, -2, -2,
+ax_anim 1, 0, 77, -10, -11, -10, -10,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 1, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 0, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 0, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 79, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -5, -5, -5, -5,
+ax_anim_terminator
+sPidgeyAnims_3_7:
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 0, 83, 0, -5, 0, 0,
+ax_anim 1, 2, 81, -2, -5, -2, 2,
+ax_anim 1, 0, 81, -10, -3, -10, 0,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 1, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 0, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 0, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 83, -12, -2, -12, 0,
+ax_anim 2, 0, 83, -5, -3, -5, 0,
+ax_anim_terminator
+sPidgeyAnims_3_8:
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 4, 0, 87, 0, -5, 0, 0,
+ax_anim 1, 2, 85, -2, -3, -2, 2,
+ax_anim 1, 0, 85, -10, 9, -10, 12,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 1, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 0, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 0, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 87, -12, 12, -12, 12,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_4_1:
+ax_anim 3, 0, 89, 0, -2, 0, 0,
+ax_anim 3, 0, 90, 0, -4, 0, 0,
+ax_anim 3, 0, 89, 0, -5, 0, 0,
+ax_anim 3, 2, 90, 0, -6, 0, 0,
+ax_anim 3, 0, 89, 0, -7, 0, 0,
+ax_anim 3, 0, 90, 0, -7, 0, 0,
+ax_anim 3, 1, 89, 0, -7, 0, 0,
+ax_anim 3, 0, 90, 0, -7, 0, 0,
+ax_anim 3, 0, 89, 0, -7, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_4_2:
+ax_anim 3, 0, 92, 0, -2, 0, 0,
+ax_anim 3, 0, 93, 0, -4, 0, 0,
+ax_anim 3, 0, 92, 0, -5, 0, 0,
+ax_anim 3, 2, 93, 0, -6, 0, 0,
+ax_anim 3, 0, 92, 0, -7, 0, 0,
+ax_anim 3, 0, 93, 0, -7, 0, 0,
+ax_anim 3, 1, 92, 0, -7, 0, 0,
+ax_anim 3, 0, 93, 0, -7, 0, 0,
+ax_anim 3, 0, 92, 0, -7, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_4_3:
+ax_anim 3, 0, 95, 0, -2, 0, 0,
+ax_anim 3, 0, 96, 0, -4, 0, 0,
+ax_anim 3, 0, 95, 0, -5, 0, 0,
+ax_anim 3, 2, 96, 0, -6, 0, 0,
+ax_anim 3, 0, 95, 0, -7, 0, 0,
+ax_anim 3, 0, 96, 0, -7, 0, 0,
+ax_anim 3, 1, 95, 0, -7, 0, 0,
+ax_anim 3, 0, 96, 0, -7, 0, 0,
+ax_anim 3, 0, 95, 0, -7, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_4_4:
+ax_anim 3, 0, 98, 0, -2, 0, 0,
+ax_anim 3, 0, 99, 0, -4, 0, 0,
+ax_anim 3, 0, 98, 0, -5, 0, 0,
+ax_anim 3, 2, 99, 0, -6, 0, 0,
+ax_anim 3, 0, 98, 0, -7, 0, 0,
+ax_anim 3, 0, 99, 0, -7, 0, 0,
+ax_anim 3, 1, 98, 0, -7, 0, 0,
+ax_anim 3, 0, 99, 0, -7, 0, 0,
+ax_anim 3, 0, 98, 0, -7, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_4_5:
+ax_anim 3, 0, 101, 0, -2, 0, 0,
+ax_anim 3, 0, 102, 0, -4, 0, 0,
+ax_anim 3, 0, 101, 0, -5, 0, 0,
+ax_anim 3, 2, 102, 0, -6, 0, 0,
+ax_anim 3, 0, 101, 0, -7, 0, 0,
+ax_anim 3, 0, 102, 0, -7, 0, 0,
+ax_anim 3, 1, 101, 0, -7, 0, 0,
+ax_anim 3, 0, 102, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_4_6:
+ax_anim 3, 0, 104, 0, -2, 0, 0,
+ax_anim 3, 0, 105, 0, -4, 0, 0,
+ax_anim 3, 0, 104, 0, -5, 0, 0,
+ax_anim 3, 2, 105, 0, -6, 0, 0,
+ax_anim 3, 0, 104, 0, -7, 0, 0,
+ax_anim 3, 0, 105, 0, -7, 0, 0,
+ax_anim 3, 1, 104, 0, -7, 0, 0,
+ax_anim 3, 0, 105, 0, -7, 0, 0,
+ax_anim 3, 0, 104, 0, -7, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_4_7:
+ax_anim 3, 0, 107, 0, -2, 0, 0,
+ax_anim 3, 0, 108, 0, -4, 0, 0,
+ax_anim 3, 0, 107, 0, -5, 0, 0,
+ax_anim 3, 2, 108, 0, -6, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 108, 0, -7, 0, 0,
+ax_anim 3, 1, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 108, 0, -7, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_4_8:
+ax_anim 3, 0, 110, 0, -2, 0, 0,
+ax_anim 3, 0, 111, 0, -4, 0, 0,
+ax_anim 3, 0, 110, 0, -5, 0, 0,
+ax_anim 3, 2, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 110, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -7, 0, 0,
+ax_anim 3, 1, 110, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -7, 0, 0,
+ax_anim 3, 0, 110, 0, -7, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_5_1:
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 2, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 1, 113, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_5_2:
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 2, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 1, 115, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_5_3:
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 2, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 1, 117, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_5_4:
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 2, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 1, 119, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_5_5:
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 2, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 1, 121, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_5_6:
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 2, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 1, 123, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_5_7:
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 2, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 1, 125, 0, -3, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_5_8:
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 2, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 1, 127, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_6_1:
+ax_anim 35, 0, 128, 0, 0, 0, 0,
+ax_anim 30, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_7_1:
+ax_anim 2, 0, 130, 0, -3, 0, -3,
+ax_anim 8, 0, 130, 0, -4, 0, -4,
+ax_anim_terminator
+sPidgeyAnims_7_2:
+ax_anim 2, 0, 131, -3, -3, -3, -3,
+ax_anim 8, 0, 131, -4, -4, -4, -4,
+ax_anim_terminator
+sPidgeyAnims_7_3:
+ax_anim 2, 0, 132, -3, 0, -3, 0,
+ax_anim 8, 0, 132, -4, 0, -4, 0,
+ax_anim_terminator
+sPidgeyAnims_7_4:
+ax_anim 2, 0, 133, -3, 3, -3, 3,
+ax_anim 8, 0, 133, -4, 4, -4, 4,
+ax_anim_terminator
+sPidgeyAnims_7_5:
+ax_anim 2, 0, 134, 0, 3, 0, 3,
+ax_anim 8, 0, 134, 0, 4, 0, 4,
+ax_anim_terminator
+sPidgeyAnims_7_6:
+ax_anim 2, 0, 135, 3, 3, 3, 3,
+ax_anim 8, 0, 135, 4, 4, 4, 4,
+ax_anim_terminator
+sPidgeyAnims_7_7:
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 8, 0, 136, 4, 0, 4, 0,
+ax_anim_terminator
+sPidgeyAnims_7_8:
+ax_anim 2, 0, 137, 3, -3, 3, -3,
+ax_anim 8, 0, 137, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -1, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -1, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -1, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -1, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -1, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -1, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -1, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -1, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -1, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -1, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -1, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 19, 7, 19,
+ax_anim 3, 0, 166, 0, 22, 0, 22,
+ax_anim 2, 3, 167, -7, 19, -7, 19,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 9, 22, 9,
+ax_anim 3, 0, 165, 21, 21, 21, 21,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 12, 2, 12,
+ax_anim 1, 0, 168, -1, 8, -1, 8,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 4, -4, 4, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 22, 1, 22, 1,
+ax_anim 2, 3, 165, 18, 7, 18, 7,
+ax_anim 2, 0, 166, 10, 7, 10, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 2, -16, 2, -16,
+ax_anim 2, 0, 162, 11, -23, 11, -23,
+ax_anim 3, 0, 163, 21, -23, 21, -23,
+ax_anim 2, 3, 164, 21, -12, 21, -12,
+ax_anim 2, 0, 165, 16, -4, 16, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -24, 0, -22,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 8, -8, 8, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -2, -16, -2, -16,
+ax_anim 2, 0, 162, -11, -23, -11, -23,
+ax_anim 3, 0, 169, -21, -23, -21, -23,
+ax_anim 2, 3, 168, -21, -12, -21, -12,
+ax_anim 2, 0, 167, -16, -4, -16, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -4, -4, -4, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -22, 1, -22, 1,
+ax_anim 2, 3, 167, -18, 7, -18, 7,
+ax_anim 2, 0, 166, -10, 7, -10, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 9, -24, 9,
+ax_anim 3, 0, 167, -21, 21, -23, 16,
+ax_anim 2, 3, 166, -11, 21, -11, 16,
+ax_anim 2, 0, 165, -2, 12, -4, 12,
+ax_anim 1, 0, 164, 1, 8, -3, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPidgeyAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sPidgeyGfx1:
+.incbin "baserom.gba", 0x5BE45C, 0x100
+sPidgeySprites1:
+ax_sprite sPidgeyGfx1, 0x100
+ax_sprite_terminator
+sPidgeyGfx2:
+.incbin "baserom.gba", 0x5BE56C, 0x100
+sPidgeySprites2:
+ax_sprite sPidgeyGfx2, 0x100
+ax_sprite_terminator
+sPidgeyGfx3:
+.incbin "baserom.gba", 0x5BE67C, 0x100
+sPidgeySprites3:
+ax_sprite sPidgeyGfx3, 0x100
+ax_sprite_terminator
+sPidgeyGfx4:
+.incbin "baserom.gba", 0x5BE78C, 0x100
+sPidgeySprites4:
+ax_sprite sPidgeyGfx4, 0x100
+ax_sprite_terminator
+sPidgeyGfx5:
+.incbin "baserom.gba", 0x5BE89C, 0x100
+sPidgeySprites5:
+ax_sprite sPidgeyGfx5, 0x100
+ax_sprite_terminator
+sPidgeyGfx6:
+.incbin "baserom.gba", 0x5BE9AC, 0x100
+sPidgeySprites6:
+ax_sprite sPidgeyGfx6, 0x100
+ax_sprite_terminator
+sPidgeyGfx7:
+.incbin "baserom.gba", 0x5BEABC, 0x200
+sPidgeySprites7:
+ax_sprite sPidgeyGfx7, 0x200
+ax_sprite_terminator
+sPidgeyGfx8:
+.incbin "baserom.gba", 0x5BECCC, 0x200
+sPidgeySprites8:
+ax_sprite sPidgeyGfx8, 0x200
+ax_sprite_terminator
+sPidgeyGfx9:
+.incbin "baserom.gba", 0x5BEEDC, 0x200
+sPidgeySprites9:
+ax_sprite sPidgeyGfx9, 0x200
+ax_sprite_terminator
+sPidgeyGfx10:
+.incbin "baserom.gba", 0x5BF0EC, 0x200
+sPidgeySprites10:
+ax_sprite sPidgeyGfx10, 0x200
+ax_sprite_terminator
+sPidgeyGfx11:
+.incbin "baserom.gba", 0x5BF2FC, 0x200
+sPidgeySprites11:
+ax_sprite sPidgeyGfx11, 0x200
+ax_sprite_terminator
+sPidgeyGfx12:
+.incbin "baserom.gba", 0x5BF50C, 0x200
+sPidgeySprites12:
+ax_sprite sPidgeyGfx12, 0x200
+ax_sprite_terminator
+sPidgeyGfx13:
+.incbin "baserom.gba", 0x5BF71C, 0x100
+sPidgeySprites13:
+ax_sprite sPidgeyGfx13, 0x100
+ax_sprite_terminator
+sPidgeyGfx14:
+.incbin "baserom.gba", 0x5BF82C, 0x100
+sPidgeySprites14:
+ax_sprite sPidgeyGfx14, 0x100
+ax_sprite_terminator
+sPidgeyGfx15:
+.incbin "baserom.gba", 0x5BF93C, 0x100
+sPidgeySprites15:
+ax_sprite sPidgeyGfx15, 0x100
+ax_sprite_terminator
+sPidgeyGfx16:
+.incbin "baserom.gba", 0x5BFA4C, 0x100
+sPidgeyGfx16_1:
+.incbin "baserom.gba", 0x5BFB4C, 0x40
+sPidgeySprites16:
+ax_sprite 0, 0x80
+ax_sprite sPidgeyGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeyGfx17:
+.incbin "baserom.gba", 0x5BFBBC, 0x40
+sPidgeyGfx17_1:
+.incbin "baserom.gba", 0x5BFBFC, 0x40
+sPidgeyGfx17_2:
+.incbin "baserom.gba", 0x5BFC3C, 0x60
+sPidgeyGfx17_3:
+.incbin "baserom.gba", 0x5BFC9C, 0x60
+sPidgeySprites17:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeyGfx18:
+.incbin "baserom.gba", 0x5BFD4C, 0x40
+sPidgeyGfx18_1:
+.incbin "baserom.gba", 0x5BFD8C, 0x100
+sPidgeyGfx18_2:
+.incbin "baserom.gba", 0x5BFE8C, 0x40
+sPidgeySprites18:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeyGfx19:
+.incbin "baserom.gba", 0x5BFF0C, 0x60
+sPidgeyGfx19_1:
+.incbin "baserom.gba", 0x5BFF6C, 0x80
+sPidgeySprites19:
+ax_sprite 0, 0x80
+ax_sprite sPidgeyGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx19_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPidgeyGfx20:
+.incbin "baserom.gba", 0x5C001C, 0x20
+sPidgeyGfx20_1:
+.incbin "baserom.gba", 0x5C003C, 0x40
+sPidgeyGfx20_2:
+.incbin "baserom.gba", 0x5C007C, 0x60
+sPidgeyGfx20_3:
+.incbin "baserom.gba", 0x5C00DC, 0x40
+sPidgeySprites20:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx20, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPidgeyGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeyGfx21:
+.incbin "baserom.gba", 0x5C016C, 0x40
+sPidgeyGfx21_1:
+.incbin "baserom.gba", 0x5C01AC, 0x80
+sPidgeyGfx21_2:
+.incbin "baserom.gba", 0x5C022C, 0x60
+sPidgeyGfx21_3:
+.incbin "baserom.gba", 0x5C028C, 0x20
+sPidgeySprites21:
+ax_sprite sPidgeyGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx21_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPidgeyGfx22:
+.incbin "baserom.gba", 0x5C02F4, 0x60
+sPidgeyGfx22_1:
+.incbin "baserom.gba", 0x5C0354, 0x60
+sPidgeyGfx22_2:
+.incbin "baserom.gba", 0x5C03B4, 0x40
+sPidgeySprites22:
+ax_sprite 0, 0x80
+ax_sprite sPidgeyGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeyGfx23:
+.incbin "baserom.gba", 0x5C0434, 0x20
+sPidgeyGfx23_1:
+.incbin "baserom.gba", 0x5C0454, 0x60
+sPidgeyGfx23_2:
+.incbin "baserom.gba", 0x5C04B4, 0x40
+sPidgeySprites23:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPidgeyGfx24:
+.incbin "baserom.gba", 0x5C0534, 0x40
+sPidgeyGfx24_1:
+.incbin "baserom.gba", 0x5C0574, 0x60
+sPidgeyGfx24_2:
+.incbin "baserom.gba", 0x5C05D4, 0x40
+sPidgeySprites24:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPidgeyGfx25:
+.incbin "baserom.gba", 0x5C0654, 0x160
+sPidgeySprites25:
+ax_sprite 0, 0x80
+ax_sprite sPidgeyGfx25, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeyGfx26:
+.incbin "baserom.gba", 0x5C07D4, 0x40
+sPidgeyGfx26_1:
+.incbin "baserom.gba", 0x5C0814, 0x40
+sPidgeyGfx26_2:
+.incbin "baserom.gba", 0x5C0854, 0x60
+sPidgeySprites26:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPidgeyGfx27:
+.incbin "baserom.gba", 0x5C08F4, 0x40
+sPidgeyGfx27_1:
+.incbin "baserom.gba", 0x5C0934, 0x60
+sPidgeyGfx27_2:
+.incbin "baserom.gba", 0x5C0994, 0x40
+sPidgeySprites27:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPidgeyGfx28:
+.incbin "baserom.gba", 0x5C0A14, 0x100
+sPidgeyGfx28_1:
+.incbin "baserom.gba", 0x5C0B14, 0x40
+sPidgeySprites28:
+ax_sprite 0, 0x80
+ax_sprite sPidgeyGfx28, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPidgeyGfx29:
+.incbin "baserom.gba", 0x5C0B84, 0x40
+sPidgeyGfx29_1:
+.incbin "baserom.gba", 0x5C0BC4, 0x40
+sPidgeyGfx29_2:
+.incbin "baserom.gba", 0x5C0C04, 0x60
+sPidgeySprites29:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPidgeyGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPidgeyGfx30:
+.incbin "baserom.gba", 0x5C0CA4, 0x40
+sPidgeyGfx30_1:
+.incbin "baserom.gba", 0x5C0CE4, 0x100
+sPidgeySprites30:
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPidgeyGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPidgeyGfx31:
+.incbin "baserom.gba", 0x5C0E14, 0x80
+sPidgeySprites31:
+ax_sprite sPidgeyGfx31, 0x80
+ax_sprite_terminator
+sPidgeyGfx32:
+.incbin "baserom.gba", 0x5C0EA4, 0x80
+sPidgeySprites32:
+ax_sprite sPidgeyGfx32, 0x80
+ax_sprite_terminator
+sPidgeyGfx33:
+.incbin "baserom.gba", 0x5C0F34, 0x200
+sPidgeySprites33:
+ax_sprite sPidgeyGfx33, 0x200
+ax_sprite_terminator
+sPidgeyGfx34:
+.incbin "baserom.gba", 0x5C1144, 0x200
+sPidgeySprites34:
+ax_sprite sPidgeyGfx34, 0x200
+ax_sprite_terminator
+sPidgeyGfx35:
+.incbin "baserom.gba", 0x5C1354, 0x200
+sPidgeySprites35:
+ax_sprite sPidgeyGfx35, 0x200
+ax_sprite_terminator
+sPidgeyGfx36:
+.incbin "baserom.gba", 0x5C1564, 0x200
+sPidgeySprites36:
+ax_sprite sPidgeyGfx36, 0x200
+ax_sprite_terminator
+sPidgeyGfx37:
+.incbin "baserom.gba", 0x5C1774, 0x200
+sPidgeySprites37:
+ax_sprite sPidgeyGfx37, 0x200
+ax_sprite_terminator
+sAxPosesPidgey:
+.4byte sPidgeyPose1
+.4byte sPidgeyPose2
+.4byte sPidgeyPose3
+.4byte sPidgeyPose4
+.4byte sPidgeyPose5
+.4byte sPidgeyPose6
+.4byte sPidgeyPose7
+.4byte sPidgeyPose8
+.4byte sPidgeyPose9
+.4byte sPidgeyPose10
+.4byte sPidgeyPose11
+.4byte sPidgeyPose12
+.4byte sPidgeyPose13
+.4byte sPidgeyPose14
+.4byte sPidgeyPose15
+.4byte sPidgeyPose16
+.4byte sPidgeyPose17
+.4byte sPidgeyPose18
+.4byte sPidgeyPose19
+.4byte sPidgeyPose20
+.4byte sPidgeyPose21
+.4byte sPidgeyPose22
+.4byte sPidgeyPose23
+.4byte sPidgeyPose24
+.4byte sPidgeyPose25
+.4byte sPidgeyPose26
+.4byte sPidgeyPose27
+.4byte sPidgeyPose28
+.4byte sPidgeyPose29
+.4byte sPidgeyPose30
+.4byte sPidgeyPose31
+.4byte sPidgeyPose32
+.4byte sPidgeyPose33
+.4byte sPidgeyPose34
+.4byte sPidgeyPose35
+.4byte sPidgeyPose36
+.4byte sPidgeyPose37
+.4byte sPidgeyPose38
+.4byte sPidgeyPose39
+.4byte sPidgeyPose40
+.4byte sPidgeyPose41
+.4byte sPidgeyPose42
+.4byte sPidgeyPose43
+.4byte sPidgeyPose44
+.4byte sPidgeyPose45
+.4byte sPidgeyPose46
+.4byte sPidgeyPose47
+.4byte sPidgeyPose48
+.4byte sPidgeyPose49
+.4byte sPidgeyPose50
+.4byte sPidgeyPose51
+.4byte sPidgeyPose52
+.4byte sPidgeyPose53
+.4byte sPidgeyPose54
+.4byte sPidgeyPose55
+.4byte sPidgeyPose56
+.4byte sPidgeyPose57
+.4byte sPidgeyPose58
+.4byte sPidgeyPose59
+.4byte sPidgeyPose60
+.4byte sPidgeyPose61
+.4byte sPidgeyPose62
+.4byte sPidgeyPose63
+.4byte sPidgeyPose64
+.4byte sPidgeyPose65
+.4byte sPidgeyPose66
+.4byte sPidgeyPose67
+.4byte sPidgeyPose68
+.4byte sPidgeyPose69
+.4byte sPidgeyPose70
+.4byte sPidgeyPose71
+.4byte sPidgeyPose72
+.4byte sPidgeyPose73
+.4byte sPidgeyPose74
+.4byte sPidgeyPose75
+.4byte sPidgeyPose76
+.4byte sPidgeyPose77
+.4byte sPidgeyPose78
+.4byte sPidgeyPose79
+.4byte sPidgeyPose80
+.4byte sPidgeyPose81
+.4byte sPidgeyPose82
+.4byte sPidgeyPose83
+.4byte sPidgeyPose84
+.4byte sPidgeyPose85
+.4byte sPidgeyPose86
+.4byte sPidgeyPose87
+.4byte sPidgeyPose88
+.4byte sPidgeyPose89
+.4byte sPidgeyPose90
+.4byte sPidgeyPose91
+.4byte sPidgeyPose92
+.4byte sPidgeyPose93
+.4byte sPidgeyPose94
+.4byte sPidgeyPose95
+.4byte sPidgeyPose96
+.4byte sPidgeyPose97
+.4byte sPidgeyPose98
+.4byte sPidgeyPose99
+.4byte sPidgeyPose100
+.4byte sPidgeyPose101
+.4byte sPidgeyPose102
+.4byte sPidgeyPose103
+.4byte sPidgeyPose104
+.4byte sPidgeyPose105
+.4byte sPidgeyPose106
+.4byte sPidgeyPose107
+.4byte sPidgeyPose108
+.4byte sPidgeyPose109
+.4byte sPidgeyPose110
+.4byte sPidgeyPose111
+.4byte sPidgeyPose112
+.4byte sPidgeyPose113
+.4byte sPidgeyPose114
+.4byte sPidgeyPose115
+.4byte sPidgeyPose116
+.4byte sPidgeyPose117
+.4byte sPidgeyPose118
+.4byte sPidgeyPose119
+.4byte sPidgeyPose120
+.4byte sPidgeyPose121
+.4byte sPidgeyPose122
+.4byte sPidgeyPose123
+.4byte sPidgeyPose124
+.4byte sPidgeyPose125
+.4byte sPidgeyPose126
+.4byte sPidgeyPose127
+.4byte sPidgeyPose128
+.4byte sPidgeyPose129
+.4byte sPidgeyPose130
+.4byte sPidgeyPose131
+.4byte sPidgeyPose132
+.4byte sPidgeyPose133
+.4byte sPidgeyPose134
+.4byte sPidgeyPose135
+.4byte sPidgeyPose136
+.4byte sPidgeyPose137
+.4byte sPidgeyPose138
+.4byte sPidgeyPose139
+.4byte sPidgeyPose140
+.4byte sPidgeyPose141
+.4byte sPidgeyPose142
+.4byte sPidgeyPose143
+.4byte sPidgeyPose144
+.4byte sPidgeyPose145
+.4byte sPidgeyPose146
+.4byte sPidgeyPose147
+.4byte sPidgeyPose148
+.4byte sPidgeyPose149
+.4byte sPidgeyPose150
+.4byte sPidgeyPose151
+.4byte sPidgeyPose152
+.4byte sPidgeyPose153
+.4byte sPidgeyPose154
+.4byte sPidgeyPose155
+.4byte sPidgeyPose156
+.4byte sPidgeyPose157
+.4byte sPidgeyPose158
+.4byte sPidgeyPose159
+.4byte sPidgeyPose160
+.4byte sPidgeyPose161
+.4byte sPidgeyPose162
+.4byte sPidgeyPose163
+.4byte sPidgeyPose164
+.4byte sPidgeyPose165
+.4byte sPidgeyPose166
+.4byte sPidgeyPose167
+.4byte sPidgeyPose168
+.4byte sPidgeyPose169
+.4byte sPidgeyPose170
+.4byte sPidgeyPose171
+.4byte sPidgeyPose172
+.4byte sPidgeyPose173
+.4byte sPidgeyPose174
+.4byte sPidgeyPose175
+.4byte sPidgeyPose176
+.4byte sPidgeyPose177
+.4byte sPidgeyPose178
+.4byte sPidgeyPose179
+.4byte sPidgeyPose180
+.4byte sPidgeyPose181
+.4byte sPidgeyPose182
+.4byte sPidgeyPose183
+.4byte sPidgeyPose184
+.4byte sPidgeyPose185
+.4byte sPidgeyPose186
+.4byte sPidgeyPose187
+.4byte sPidgeyPose188
+.4byte sPidgeyPose189
+.4byte sPidgeyPose190
+.4byte sPidgeyPose191
+.4byte sPidgeyPose192
+.4byte sPidgeyPose193
+.4byte sPidgeyPose194
+.4byte sPidgeyPose195
+.4byte sPidgeyPose196
+.4byte sPidgeyPose197
+.4byte sPidgeyPose198
+.4byte sPidgeyPose199
+.4byte sPidgeyPose200
+.4byte sPidgeyPose201
+.4byte sPidgeyPose202
+.4byte sPidgeyPose203
+.4byte sPidgeyPose204
+.4byte sPidgeyPose205
+.4byte sPidgeyPose206
+.4byte sPidgeyPose207
+.4byte sPidgeyPose208
+.4byte sPidgeyPose209
+.4byte sPidgeyPose210
+.4byte sPidgeyPose211
+.4byte sPidgeyPose212
+.4byte sPidgeyPose213
+.4byte sPidgeyPose214
+.4byte sPidgeyPose215
+.4byte sPidgeyPose216
+.4byte sPidgeyPose217
+.4byte sPidgeyPose218
+sAxPositionsPidgey:
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -1,    0, 	  -6,   -2, 	   4,   -2, 	  -1,   -2
+.2byte    6,   -5, 	   3,   -6, 	  -4,   -4, 	   1,   -6
+.2byte    7,   -7, 	   3,  -10, 	  -6,   -8, 	   1,   -7
+.2byte    7,   -3, 	   4,   -7, 	  -5,   -4, 	   1,   -4
+.2byte    8,   -7, 	  -3,   -6, 	  -5,   -3, 	   1,   -6
+.2byte    9,  -10, 	  -3,   -8, 	  -5,   -5, 	   1,   -8
+.2byte   11,   -4, 	  -1,   -5, 	  -3,   -2, 	   2,   -4
+.2byte    6,  -10, 	  -6,   -4, 	  -1,   -2, 	   0,   -7
+.2byte    7,  -12, 	  -6,   -6, 	  -1,   -4, 	   0,   -8
+.2byte    8,   -9, 	  -4,   -6, 	  -1,   -1, 	   1,   -6
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -14, 	   2,   -6, 	  -4,   -6, 	  -1,   -8
+.2byte   -1,   -8, 	   3,   -3, 	  -5,   -3, 	  -1,   -6
+.2byte   -7,  -10, 	   5,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -8,  -12, 	   5,   -6, 	   0,   -4, 	  -1,   -8
+.2byte   -9,   -9, 	   3,   -6, 	   0,   -1, 	  -2,   -6
+.2byte   -9,   -7, 	   2,   -6, 	   4,   -3, 	  -2,   -6
+.2byte  -10,  -10, 	   2,   -8, 	   4,   -5, 	  -2,   -8
+.2byte  -12,   -4, 	   0,   -5, 	   2,   -2, 	  -3,   -4
+.2byte   -7,   -5, 	  -4,   -6, 	   3,   -4, 	  -2,   -6
+.2byte   -8,   -7, 	  -4,  -10, 	   5,   -8, 	  -2,   -7
+.2byte   -8,   -3, 	  -5,   -7, 	   4,   -4, 	  -2,   -4
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,    0, 	 -11,   -7, 	   9,   -7, 	  -1,   -5
+.2byte   -1,   -6, 	  -8,   -2, 	   6,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,  -15, 	   7,  -15, 	  -1,   -7
+.2byte    6,   -5, 	   3,   -6, 	  -4,   -4, 	   1,   -6
+.2byte    7,   -3, 	   9,  -12, 	  -7,   -3, 	   0,   -8
+.2byte    4,   -7, 	   8,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -16, 	  -9,  -11, 	  -1,   -7
+.2byte    8,   -7, 	  -3,   -6, 	  -5,   -3, 	   1,   -6
+.2byte    9,   -6, 	   0,  -14, 	   0,   -1, 	   0,   -8
+.2byte    5,   -9, 	   4,   -7, 	   4,   -4, 	   0,   -8
+.2byte    7,  -10, 	  -4,  -17, 	  -6,  -10, 	  -2,   -9
+.2byte    6,  -10, 	  -6,   -4, 	  -1,   -2, 	   0,   -7
+.2byte    6,  -13, 	  -8,  -11, 	   7,   -4, 	  -1,   -9
+.2byte    4,  -14, 	  -6,   -7, 	   6,   -5, 	  -1,   -9
+.2byte    3,  -14, 	  -7,  -14, 	   5,  -11, 	  -2,   -8
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -8, 	 -10,   -8, 	  -1,   -8
+.2byte   -1,  -13, 	   6,   -5, 	  -8,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte   -7,  -10, 	   5,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -7,  -13, 	   7,  -11, 	  -8,   -4, 	   0,   -9
+.2byte   -5,  -14, 	   5,   -7, 	  -7,   -5, 	   0,   -9
+.2byte   -4,  -14, 	   6,  -14, 	  -6,  -11, 	   1,   -8
+.2byte   -9,   -7, 	   2,   -6, 	   4,   -3, 	  -2,   -6
+.2byte  -10,   -6, 	  -1,  -14, 	  -1,   -1, 	  -1,   -8
+.2byte   -6,   -9, 	  -5,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,  -10, 	   3,  -17, 	   5,  -10, 	   1,   -9
+.2byte   -7,   -5, 	  -4,   -6, 	   3,   -4, 	  -2,   -6
+.2byte   -8,   -3, 	 -10,  -12, 	   6,   -3, 	  -1,   -8
+.2byte   -5,   -7, 	  -9,   -4, 	   1,   -2, 	   0,   -7
+.2byte   -5,   -7, 	  -7,  -16, 	   8,  -11, 	   0,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,    0, 	 -11,   -7, 	   9,   -7, 	  -1,   -5
+.2byte   -1,   -6, 	  -8,   -2, 	   6,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,  -15, 	   7,  -15, 	  -1,   -7
+.2byte    6,   -5, 	   3,   -6, 	  -4,   -4, 	   1,   -6
+.2byte    7,   -3, 	   9,  -12, 	  -7,   -3, 	   0,   -8
+.2byte    4,   -7, 	   8,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -16, 	  -9,  -11, 	  -1,   -7
+.2byte    8,   -7, 	  -3,   -6, 	  -5,   -3, 	   1,   -6
+.2byte    9,   -6, 	   0,  -14, 	   0,   -1, 	   0,   -8
+.2byte    5,   -9, 	   4,   -7, 	   4,   -4, 	   0,   -8
+.2byte    7,  -10, 	  -4,  -17, 	  -6,  -10, 	  -2,   -9
+.2byte    6,  -10, 	  -6,   -4, 	  -1,   -2, 	   0,   -7
+.2byte    6,  -13, 	  -8,  -11, 	   7,   -4, 	  -1,   -9
+.2byte    4,  -14, 	  -6,   -7, 	   6,   -5, 	  -1,   -9
+.2byte    3,  -14, 	  -7,  -14, 	   5,  -11, 	  -2,   -8
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -8, 	 -10,   -8, 	  -1,   -8
+.2byte   -1,  -13, 	   6,   -5, 	  -8,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte   -7,  -10, 	   5,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -7,  -13, 	   7,  -11, 	  -8,   -4, 	   0,   -9
+.2byte   -5,  -14, 	   5,   -7, 	  -7,   -5, 	   0,   -9
+.2byte   -4,  -14, 	   6,  -14, 	  -6,  -11, 	   1,   -8
+.2byte   -9,   -7, 	   2,   -6, 	   4,   -3, 	  -2,   -6
+.2byte  -10,   -6, 	  -1,  -14, 	  -1,   -1, 	  -1,   -8
+.2byte   -6,   -9, 	  -5,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,  -10, 	   3,  -17, 	   5,  -10, 	   1,   -9
+.2byte   -7,   -5, 	  -4,   -6, 	   3,   -4, 	  -2,   -6
+.2byte   -8,   -3, 	 -10,  -12, 	   6,   -3, 	  -1,   -8
+.2byte   -5,   -7, 	  -9,   -4, 	   1,   -2, 	   0,   -7
+.2byte   -5,   -7, 	  -7,  -16, 	   8,  -11, 	   0,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -8,   -2, 	   6,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,  -15, 	   7,  -15, 	  -1,   -7
+.2byte    6,   -5, 	   3,   -6, 	  -4,   -4, 	   1,   -6
+.2byte    4,   -7, 	   8,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -16, 	  -9,  -11, 	  -1,   -7
+.2byte    8,   -7, 	  -3,   -6, 	  -5,   -3, 	   1,   -6
+.2byte    5,   -9, 	   4,   -7, 	   4,   -4, 	   0,   -8
+.2byte    7,  -10, 	  -4,  -17, 	  -6,  -10, 	  -2,   -9
+.2byte    6,  -10, 	  -6,   -4, 	  -1,   -2, 	   0,   -7
+.2byte    4,  -14, 	  -6,   -7, 	   6,   -5, 	  -1,   -9
+.2byte    3,  -14, 	  -7,  -14, 	   5,  -11, 	  -2,   -8
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -13, 	   6,   -5, 	  -8,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte   -7,  -10, 	   5,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -5,  -14, 	   5,   -7, 	  -7,   -5, 	   0,   -9
+.2byte   -4,  -14, 	   6,  -14, 	  -6,  -11, 	   1,   -8
+.2byte   -9,   -7, 	   2,   -6, 	   4,   -3, 	  -2,   -6
+.2byte   -6,   -9, 	  -5,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,  -10, 	   3,  -17, 	   5,  -10, 	   1,   -9
+.2byte   -7,   -5, 	  -4,   -6, 	   3,   -4, 	  -2,   -6
+.2byte   -5,   -7, 	  -9,   -4, 	   1,   -2, 	   0,   -7
+.2byte   -5,   -7, 	  -7,  -16, 	   8,  -11, 	   0,   -7
+.2byte   -1,   -6, 	  -8,   -2, 	   6,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,  -15, 	   7,  -15, 	  -1,   -7
+.2byte    4,   -7, 	   8,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -16, 	  -9,  -11, 	  -1,   -7
+.2byte    5,   -9, 	   4,   -7, 	   4,   -4, 	   0,   -8
+.2byte    7,  -10, 	  -4,  -17, 	  -6,  -10, 	  -2,   -9
+.2byte    5,  -14, 	  -5,   -7, 	   7,   -5, 	   0,   -9
+.2byte    4,  -14, 	  -6,  -14, 	   6,  -11, 	  -1,   -8
+.2byte   -1,  -13, 	   6,   -5, 	  -8,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte   -6,  -14, 	   4,   -7, 	  -8,   -5, 	  -1,   -9
+.2byte   -5,  -14, 	   5,  -14, 	  -7,  -11, 	   0,   -8
+.2byte   -6,   -9, 	  -5,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,  -10, 	   3,  -17, 	   5,  -10, 	   1,   -9
+.2byte   -5,   -7, 	  -9,   -4, 	   1,   -2, 	   0,   -7
+.2byte   -5,   -7, 	  -7,  -16, 	   8,  -11, 	   0,   -7
+.2byte   -8,   -3, 	  -3,   -6, 	   3,   -4, 	   0,   -5
+.2byte   -8,   -1, 	  -3,   -5, 	   3,   -3, 	   0,   -4
+.2byte    0,    2, 	  -7,   -9, 	   7,   -9, 	   0,   -5
+.2byte    5,    1, 	   6,  -11, 	  -8,   -9, 	  -1,   -6
+.2byte    8,   -3, 	  -3,  -11, 	  -6,   -9, 	  -1,   -6
+.2byte    6,   -7, 	  -8,   -8, 	  -1,   -3, 	  -1,   -4
+.2byte    0,   -4, 	   7,   -6, 	  -7,   -6, 	   0,   -5
+.2byte   -7,   -7, 	   7,   -8, 	   0,   -3, 	   0,   -4
+.2byte   -9,   -3, 	   2,  -11, 	   5,   -9, 	   0,   -6
+.2byte   -6,    1, 	  -7,  -11, 	   7,   -9, 	   0,   -6
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -1,    0, 	  -6,   -2, 	   4,   -2, 	  -1,   -2
+.2byte    6,   -5, 	   3,   -6, 	  -4,   -4, 	   1,   -6
+.2byte    7,   -7, 	   3,  -10, 	  -6,   -8, 	   1,   -7
+.2byte    7,   -3, 	   4,   -7, 	  -5,   -4, 	   1,   -4
+.2byte    8,   -7, 	  -3,   -6, 	  -5,   -3, 	   1,   -6
+.2byte    9,  -10, 	  -3,   -8, 	  -5,   -5, 	   1,   -8
+.2byte   11,   -4, 	  -1,   -5, 	  -3,   -2, 	   2,   -4
+.2byte    6,  -10, 	  -6,   -4, 	  -1,   -2, 	   0,   -7
+.2byte    7,  -12, 	  -6,   -6, 	  -1,   -4, 	   0,   -8
+.2byte    8,   -9, 	  -4,   -6, 	  -1,   -1, 	   1,   -6
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -14, 	   2,   -6, 	  -4,   -6, 	  -1,   -8
+.2byte   -1,   -8, 	   3,   -3, 	  -5,   -3, 	  -1,   -6
+.2byte   -7,  -10, 	   5,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -8,  -12, 	   5,   -6, 	   0,   -4, 	  -1,   -8
+.2byte   -9,   -9, 	   3,   -6, 	   0,   -1, 	  -2,   -6
+.2byte   -9,   -7, 	   2,   -6, 	   4,   -3, 	  -2,   -6
+.2byte  -10,  -10, 	   2,   -8, 	   4,   -5, 	  -2,   -8
+.2byte  -12,   -4, 	   0,   -5, 	   2,   -2, 	  -3,   -4
+.2byte   -7,   -5, 	  -4,   -6, 	   3,   -4, 	  -2,   -6
+.2byte   -8,   -7, 	  -4,  -10, 	   5,   -8, 	  -2,   -7
+.2byte   -8,   -3, 	  -5,   -7, 	   4,   -4, 	  -2,   -4
+.2byte   -1,    0, 	 -11,   -7, 	   9,   -7, 	  -1,   -5
+.2byte   -8,   -3, 	 -10,  -12, 	   6,   -3, 	  -1,   -8
+.2byte  -10,   -6, 	  -1,  -14, 	  -1,   -1, 	  -1,   -8
+.2byte   -7,  -13, 	   7,  -11, 	  -8,   -4, 	   0,   -9
+.2byte   -1,  -11, 	   7,   -8, 	 -10,   -8, 	  -1,   -8
+.2byte    6,  -13, 	  -8,  -11, 	   7,   -4, 	  -1,   -9
+.2byte    9,   -6, 	   0,  -14, 	   0,   -1, 	   0,   -8
+.2byte    7,   -3, 	   9,  -12, 	  -7,   -3, 	   0,   -8
+.2byte   -1,   -6, 	  -9,  -15, 	   7,  -15, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -16, 	  -9,  -11, 	  -1,   -7
+.2byte    7,  -10, 	  -4,  -17, 	  -6,  -10, 	  -2,   -9
+.2byte    3,  -14, 	  -7,  -14, 	   5,  -11, 	  -2,   -8
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte   -4,  -14, 	   6,  -14, 	  -6,  -11, 	   1,   -8
+.2byte   -8,  -10, 	   3,  -17, 	   5,  -10, 	   1,   -9
+.2byte   -5,   -7, 	  -7,  -16, 	   8,  -11, 	   0,   -7
+.2byte   -1,    0, 	  -6,   -2, 	   4,   -2, 	  -1,   -2
+.2byte   -1,   -6, 	  -8,   -2, 	   6,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,  -15, 	   7,  -15, 	  -1,   -7
+.2byte    7,   -4, 	   4,   -8, 	  -5,   -5, 	   1,   -5
+.2byte    4,   -7, 	   8,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -16, 	  -9,  -11, 	  -1,   -7
+.2byte    9,   -4, 	  -3,   -5, 	  -5,   -2, 	   0,   -4
+.2byte    5,   -9, 	   4,   -7, 	   4,   -4, 	   0,   -8
+.2byte    7,  -10, 	  -4,  -17, 	  -6,  -10, 	  -2,   -9
+.2byte    7,   -9, 	  -5,   -6, 	  -2,   -1, 	   0,   -6
+.2byte    4,  -14, 	  -6,   -7, 	   6,   -5, 	  -1,   -9
+.2byte    3,  -14, 	  -7,  -14, 	   5,  -11, 	  -2,   -8
+.2byte   -1,   -7, 	   3,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -1,  -13, 	   6,   -5, 	  -8,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte   -8,   -9, 	   4,   -6, 	   1,   -1, 	  -1,   -6
+.2byte   -5,  -14, 	   5,   -7, 	  -7,   -5, 	   0,   -9
+.2byte   -4,  -14, 	   6,  -14, 	  -6,  -11, 	   1,   -8
+.2byte  -10,   -4, 	   2,   -5, 	   4,   -2, 	  -1,   -4
+.2byte   -6,   -9, 	  -5,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -8,  -10, 	   3,  -17, 	   5,  -10, 	   1,   -9
+.2byte   -8,   -4, 	  -5,   -8, 	   4,   -5, 	  -2,   -5
+.2byte   -5,   -7, 	  -9,   -4, 	   1,   -2, 	   0,   -7
+.2byte   -5,   -7, 	  -7,  -16, 	   8,  -11, 	   0,   -7
+.2byte   -1,   -6, 	  -9,  -15, 	   7,  -15, 	  -1,   -7
+.2byte   -5,   -7, 	  -7,  -16, 	   8,  -11, 	   0,   -7
+.2byte   -8,  -10, 	   3,  -17, 	   5,  -10, 	   1,   -9
+.2byte   -4,  -14, 	   6,  -14, 	  -6,  -11, 	   1,   -8
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte    3,  -14, 	  -7,  -14, 	   5,  -11, 	  -2,   -8
+.2byte    7,  -10, 	  -4,  -17, 	  -6,  -10, 	  -2,   -9
+.2byte    4,   -7, 	   6,  -16, 	  -9,  -11, 	  -1,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -7,   -5, 	  -4,   -6, 	   3,   -4, 	  -2,   -6
+.2byte   -9,   -7, 	   2,   -6, 	   4,   -3, 	  -2,   -6
+.2byte   -7,  -10, 	   5,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -6
+.2byte    6,  -10, 	  -6,   -4, 	  -1,   -2, 	   0,   -7
+.2byte    8,   -7, 	  -3,   -6, 	  -5,   -3, 	   1,   -6
+.2byte    6,   -5, 	   3,   -6, 	  -4,   -4, 	   1,   -6
+sPidgeyAnimTable1:
+.4byte sPidgeyAnims_1_1
+.4byte sPidgeyAnims_1_2
+.4byte sPidgeyAnims_1_3
+.4byte sPidgeyAnims_1_4
+.4byte sPidgeyAnims_1_5
+.4byte sPidgeyAnims_1_6
+.4byte sPidgeyAnims_1_7
+.4byte sPidgeyAnims_1_8
+sPidgeyAnimTable2:
+.4byte sPidgeyAnims_2_1
+.4byte sPidgeyAnims_2_2
+.4byte sPidgeyAnims_2_3
+.4byte sPidgeyAnims_2_4
+.4byte sPidgeyAnims_2_5
+.4byte sPidgeyAnims_2_6
+.4byte sPidgeyAnims_2_7
+.4byte sPidgeyAnims_2_8
+sPidgeyAnimTable3:
+.4byte sPidgeyAnims_3_1
+.4byte sPidgeyAnims_3_2
+.4byte sPidgeyAnims_3_3
+.4byte sPidgeyAnims_3_4
+.4byte sPidgeyAnims_3_5
+.4byte sPidgeyAnims_3_6
+.4byte sPidgeyAnims_3_7
+.4byte sPidgeyAnims_3_8
+sPidgeyAnimTable4:
+.4byte sPidgeyAnims_4_1
+.4byte sPidgeyAnims_4_2
+.4byte sPidgeyAnims_4_3
+.4byte sPidgeyAnims_4_4
+.4byte sPidgeyAnims_4_5
+.4byte sPidgeyAnims_4_6
+.4byte sPidgeyAnims_4_7
+.4byte sPidgeyAnims_4_8
+sPidgeyAnimTable5:
+.4byte sPidgeyAnims_5_1
+.4byte sPidgeyAnims_5_2
+.4byte sPidgeyAnims_5_3
+.4byte sPidgeyAnims_5_4
+.4byte sPidgeyAnims_5_5
+.4byte sPidgeyAnims_5_6
+.4byte sPidgeyAnims_5_7
+.4byte sPidgeyAnims_5_8
+sPidgeyAnimTable6:
+.4byte sPidgeyAnims_6_1
+.4byte sPidgeyAnims_6_1
+.4byte sPidgeyAnims_6_1
+.4byte sPidgeyAnims_6_1
+.4byte sPidgeyAnims_6_1
+.4byte sPidgeyAnims_6_1
+.4byte sPidgeyAnims_6_1
+.4byte sPidgeyAnims_6_1
+sPidgeyAnimTable7:
+.4byte sPidgeyAnims_7_1
+.4byte sPidgeyAnims_7_2
+.4byte sPidgeyAnims_7_3
+.4byte sPidgeyAnims_7_4
+.4byte sPidgeyAnims_7_5
+.4byte sPidgeyAnims_7_6
+.4byte sPidgeyAnims_7_7
+.4byte sPidgeyAnims_7_8
+sPidgeyAnimTable8:
+.4byte sPidgeyAnims_8_1
+.4byte sPidgeyAnims_8_2
+.4byte sPidgeyAnims_8_3
+.4byte sPidgeyAnims_8_4
+.4byte sPidgeyAnims_8_5
+.4byte sPidgeyAnims_8_6
+.4byte sPidgeyAnims_8_7
+.4byte sPidgeyAnims_8_8
+sPidgeyAnimTable9:
+.4byte sPidgeyAnims_9_1
+.4byte sPidgeyAnims_9_2
+.4byte sPidgeyAnims_9_3
+.4byte sPidgeyAnims_9_4
+.4byte sPidgeyAnims_9_5
+.4byte sPidgeyAnims_9_6
+.4byte sPidgeyAnims_9_7
+.4byte sPidgeyAnims_9_8
+sPidgeyAnimTable10:
+.4byte sPidgeyAnims_10_1
+.4byte sPidgeyAnims_10_2
+.4byte sPidgeyAnims_10_3
+.4byte sPidgeyAnims_10_4
+.4byte sPidgeyAnims_10_5
+.4byte sPidgeyAnims_10_6
+.4byte sPidgeyAnims_10_7
+.4byte sPidgeyAnims_10_8
+sPidgeyAnimTable11:
+.4byte sPidgeyAnims_11_1
+.4byte sPidgeyAnims_11_2
+.4byte sPidgeyAnims_11_3
+.4byte sPidgeyAnims_11_4
+.4byte sPidgeyAnims_11_5
+.4byte sPidgeyAnims_11_6
+.4byte sPidgeyAnims_11_7
+.4byte sPidgeyAnims_11_8
+sPidgeyAnimTable12:
+.4byte sPidgeyAnims_12_1
+.4byte sPidgeyAnims_12_2
+.4byte sPidgeyAnims_12_3
+.4byte sPidgeyAnims_12_4
+.4byte sPidgeyAnims_12_5
+.4byte sPidgeyAnims_12_6
+.4byte sPidgeyAnims_12_7
+.4byte sPidgeyAnims_12_8
+sPidgeyAnimTable13:
+.4byte sPidgeyAnims_13_1
+.4byte sPidgeyAnims_13_2
+.4byte sPidgeyAnims_13_3
+.4byte sPidgeyAnims_13_4
+.4byte sPidgeyAnims_13_5
+.4byte sPidgeyAnims_13_6
+.4byte sPidgeyAnims_13_7
+.4byte sPidgeyAnims_13_8
+sAxAnimationsPidgey:
+.4byte sPidgeyAnimTable1
+.4byte sPidgeyAnimTable2
+.4byte sPidgeyAnimTable3
+.4byte sPidgeyAnimTable4
+.4byte sPidgeyAnimTable5
+.4byte sPidgeyAnimTable6
+.4byte sPidgeyAnimTable7
+.4byte sPidgeyAnimTable8
+.4byte sPidgeyAnimTable9
+.4byte sPidgeyAnimTable10
+.4byte sPidgeyAnimTable11
+.4byte sPidgeyAnimTable12
+.4byte sPidgeyAnimTable13
+sAxSpritesPidgey:
+.4byte sPidgeySprites1
+.4byte sPidgeySprites2
+.4byte sPidgeySprites3
+.4byte sPidgeySprites4
+.4byte sPidgeySprites5
+.4byte sPidgeySprites6
+.4byte sPidgeySprites7
+.4byte sPidgeySprites8
+.4byte sPidgeySprites9
+.4byte sPidgeySprites10
+.4byte sPidgeySprites11
+.4byte sPidgeySprites12
+.4byte sPidgeySprites13
+.4byte sPidgeySprites14
+.4byte sPidgeySprites15
+.4byte sPidgeySprites16
+.4byte sPidgeySprites17
+.4byte sPidgeySprites18
+.4byte sPidgeySprites19
+.4byte sPidgeySprites20
+.4byte sPidgeySprites21
+.4byte sPidgeySprites22
+.4byte sPidgeySprites23
+.4byte sPidgeySprites24
+.4byte sPidgeySprites25
+.4byte sPidgeySprites26
+.4byte sPidgeySprites27
+.4byte sPidgeySprites28
+.4byte sPidgeySprites29
+.4byte sPidgeySprites30
+.4byte sPidgeySprites31
+.4byte sPidgeySprites32
+.4byte sPidgeySprites33
+.4byte sPidgeySprites34
+.4byte sPidgeySprites35
+.4byte sPidgeySprites36
+.4byte sPidgeySprites37
+sAxMainPidgey:
+ax_main sAxPosesPidgey, sAxAnimationsPidgey, 13, sAxSpritesPidgey, sAxPositionsPidgey

--- a/data/ax/pikachu.inc
+++ b/data/ax/pikachu.inc
@@ -1,0 +1,4482 @@
+.global gAxPikachu
+gAxPikachu:
+ax_siro sAxMainPikachu
+sPikachuPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose4:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose5:
+ax_pose 4, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose6:
+ax_pose 5, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose7:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose8:
+ax_pose 7, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose9:
+ax_pose 8, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose10:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose11:
+ax_pose 10, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose12:
+ax_pose 11, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose13:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose14:
+ax_pose 13, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose15:
+ax_pose 14, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose16:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose17:
+ax_pose 10, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose19:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose20:
+ax_pose 7, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose21:
+ax_pose 8, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose22:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose23:
+ax_pose 4, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose24:
+ax_pose 5, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose26:
+ax_pose 1, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose27:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose28:
+ax_pose 15, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose29:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose30:
+ax_pose 4, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose31:
+ax_pose 5, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose32:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPikachuPose33:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose34:
+ax_pose 7, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose35:
+ax_pose 8, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose36:
+ax_pose 17, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose37:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose38:
+ax_pose 10, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose39:
+ax_pose 11, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose40:
+ax_pose 18, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose41:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose42:
+ax_pose 13, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose43:
+ax_pose 14, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose44:
+ax_pose 19, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose45:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose46:
+ax_pose 10, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose47:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose48:
+ax_pose 18, 0x01e9, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose49:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose50:
+ax_pose 7, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose51:
+ax_pose 8, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose52:
+ax_pose 17, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose53:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose54:
+ax_pose 4, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose55:
+ax_pose 5, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose56:
+ax_pose 16, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose57:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose58:
+ax_pose 1, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose59:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose60:
+ax_pose 15, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose61:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose62:
+ax_pose 4, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose63:
+ax_pose 5, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose64:
+ax_pose 16, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPikachuPose65:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose66:
+ax_pose 7, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose67:
+ax_pose 8, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose68:
+ax_pose 17, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose69:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose70:
+ax_pose 10, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose71:
+ax_pose 11, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose72:
+ax_pose 18, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose73:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose74:
+ax_pose 13, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose75:
+ax_pose 14, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose76:
+ax_pose 19, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose77:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose78:
+ax_pose 10, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose79:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose80:
+ax_pose 18, 0x01e9, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose81:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose82:
+ax_pose 7, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose83:
+ax_pose 8, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose84:
+ax_pose 17, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose85:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose86:
+ax_pose 4, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose87:
+ax_pose 5, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose88:
+ax_pose 16, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose89:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose90:
+ax_pose 20, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose91:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose92:
+ax_pose 21, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose93:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose94:
+ax_pose 22, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose95:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose96:
+ax_pose 23, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose97:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose98:
+ax_pose 24, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose99:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose100:
+ax_pose 23, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose101:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose102:
+ax_pose 22, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose103:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose104:
+ax_pose 21, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose105:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose106:
+ax_pose 20, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose107:
+ax_pose 25, 0x01de, 0x80eb, 0x0c00
+ax_pose 26, 0x81de, 0x410b, 0x0c10
+ax_pose 27, 0x41fe, 0x40eb, 0x0c14
+ax_pose 28, 0x01e5, 0x80f4, 0x0c18
+ax_pose_terminator
+sPikachuPose108:
+ax_pose 29, 0x01de, 0x80eb, 0x0c00
+ax_pose 30, 0x81de, 0x410b, 0x0c10
+ax_pose 31, 0x41fe, 0x00eb, 0x0c14
+ax_pose 32, 0x41fe, 0x0103, 0x0c16
+ax_pose 33, 0x01e5, 0x80f4, 0x0c18
+ax_pose_terminator
+sPikachuPose109:
+ax_pose 28, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose110:
+ax_pose 33, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose111:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose112:
+ax_pose 21, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose113:
+ax_pose 34, 0x01dd, 0x90f5, 0x0c00
+ax_pose 35, 0x81dd, 0x50ed, 0x0c10
+ax_pose 36, 0x41fd, 0x10ed, 0x0c14
+ax_pose 37, 0x01e5, 0x90ea, 0x0c16
+ax_pose_terminator
+sPikachuPose114:
+ax_pose 38, 0x01dd, 0x90f5, 0x0c00
+ax_pose 39, 0x81dd, 0x50ed, 0x0c10
+ax_pose 40, 0x41fd, 0x10ed, 0x0c14
+ax_pose 41, 0x01e5, 0x90ea, 0x0c16
+ax_pose_terminator
+sPikachuPose115:
+ax_pose 37, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose116:
+ax_pose 41, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose117:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose118:
+ax_pose 22, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose119:
+ax_pose 42, 0x01df, 0x90f3, 0x0c00
+ax_pose 43, 0x81df, 0x50eb, 0x0c10
+ax_pose 44, 0x01ff, 0x10f3, 0x0c14
+ax_pose 45, 0x01e9, 0x90ea, 0x0c15
+ax_pose_terminator
+sPikachuPose120:
+ax_pose 29, 0x01df, 0x90f3, 0x0c00
+ax_pose 30, 0x81df, 0x50eb, 0x0c10
+ax_pose 31, 0x41ff, 0x1103, 0x0c14
+ax_pose 32, 0x41ff, 0x10eb, 0x0c16
+ax_pose 46, 0x01e9, 0x90ea, 0x0c18
+ax_pose_terminator
+sPikachuPose121:
+ax_pose 45, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose122:
+ax_pose 46, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose123:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose124:
+ax_pose 23, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose125:
+ax_pose 47, 0x01dc, 0x90f3, 0x0c00
+ax_pose 48, 0x81dc, 0x50eb, 0x0c10
+ax_pose 49, 0x41fc, 0x1103, 0x0c14
+ax_pose 50, 0x01e7, 0x90eb, 0x0c16
+ax_pose_terminator
+sPikachuPose126:
+ax_pose 38, 0x01dd, 0x80ea, 0x0c00
+ax_pose 39, 0x81dd, 0x410a, 0x0c10
+ax_pose 40, 0x41fd, 0x0102, 0x0c14
+ax_pose 51, 0x01e7, 0x90eb, 0x0c16
+ax_pose_terminator
+sPikachuPose127:
+ax_pose 50, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose128:
+ax_pose 51, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose129:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose130:
+ax_pose 24, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose131:
+ax_pose 52, 0x01e2, 0x80eb, 0x0c00
+ax_pose 53, 0x81e2, 0x410b, 0x0c10
+ax_pose 54, 0x01ea, 0x80f3, 0x0c14
+ax_pose_terminator
+sPikachuPose132:
+ax_pose 29, 0x01df, 0x80eb, 0x0c00
+ax_pose 32, 0x41ff, 0x0103, 0x0c10
+ax_pose 31, 0x41ff, 0x00eb, 0x0c12
+ax_pose 30, 0x81df, 0x410b, 0x0c14
+ax_pose 55, 0x01ea, 0x80f3, 0x0c18
+ax_pose_terminator
+sPikachuPose133:
+ax_pose 54, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose134:
+ax_pose 55, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose135:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose136:
+ax_pose 23, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose137:
+ax_pose 47, 0x01dc, 0x80ed, 0x0c00
+ax_pose 48, 0x81dc, 0x410d, 0x0c10
+ax_pose 49, 0x41fc, 0x00ed, 0x0c14
+ax_pose 50, 0x01e7, 0x80f5, 0x0c16
+ax_pose_terminator
+sPikachuPose138:
+ax_pose 38, 0x01dd, 0x90f5, 0x0c00
+ax_pose 39, 0x81dd, 0x50ed, 0x0c10
+ax_pose 40, 0x41fd, 0x10ed, 0x0c14
+ax_pose 51, 0x01e7, 0x80f5, 0x0c16
+ax_pose_terminator
+sPikachuPose139:
+ax_pose 50, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose140:
+ax_pose 51, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose141:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose142:
+ax_pose 22, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose143:
+ax_pose 42, 0x01df, 0x80ed, 0x0c00
+ax_pose 43, 0x81df, 0x410d, 0x0c10
+ax_pose 44, 0x01ff, 0x0105, 0x0c14
+ax_pose 45, 0x01e9, 0x80f6, 0x0c15
+ax_pose_terminator
+sPikachuPose144:
+ax_pose 29, 0x01df, 0x90f6, 0x0c00
+ax_pose 30, 0x81df, 0x50ee, 0x0c10
+ax_pose 31, 0x41ff, 0x1106, 0x0c14
+ax_pose 32, 0x41ff, 0x10ee, 0x0c16
+ax_pose 46, 0x01e9, 0x80f6, 0x0c18
+ax_pose_terminator
+sPikachuPose145:
+ax_pose 45, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose146:
+ax_pose 46, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose147:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose148:
+ax_pose 21, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose149:
+ax_pose 34, 0x01dd, 0x80eb, 0x0c00
+ax_pose 35, 0x81dd, 0x410b, 0x0c10
+ax_pose 36, 0x41fd, 0x0103, 0x0c14
+ax_pose 37, 0x01e5, 0x80f6, 0x0c16
+ax_pose_terminator
+sPikachuPose150:
+ax_pose 38, 0x01dd, 0x80ec, 0x0c00
+ax_pose 39, 0x81dd, 0x410c, 0x0c10
+ax_pose 40, 0x41fd, 0x0104, 0x0c14
+ax_pose 41, 0x01e5, 0x80f6, 0x0c16
+ax_pose_terminator
+sPikachuPose151:
+ax_pose 37, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose152:
+ax_pose 41, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose153:
+ax_pose 56, 0x01eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPikachuPose154:
+ax_pose 57, 0x01eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPikachuPose155:
+ax_pose 58, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose156:
+ax_pose 59, 0x01e3, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose157:
+ax_pose 60, 0x01e3, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose158:
+ax_pose 61, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose159:
+ax_pose 62, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sPikachuPose160:
+ax_pose 61, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose161:
+ax_pose 60, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose162:
+ax_pose 59, 0x01e3, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose163:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose164:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose165:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose166:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose167:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose168:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose169:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose170:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose171:
+ax_pose 15, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose172:
+ax_pose 16, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose173:
+ax_pose 17, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose174:
+ax_pose 18, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose175:
+ax_pose 19, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose176:
+ax_pose 18, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose177:
+ax_pose 17, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose178:
+ax_pose 16, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose179:
+ax_pose 28, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose180:
+ax_pose 37, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose181:
+ax_pose 45, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose182:
+ax_pose 50, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose183:
+ax_pose 54, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose184:
+ax_pose 50, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose185:
+ax_pose 45, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose186:
+ax_pose 37, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose187:
+ax_pose 20, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose188:
+ax_pose 21, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose189:
+ax_pose 22, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose190:
+ax_pose 23, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose191:
+ax_pose 24, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose192:
+ax_pose 23, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose193:
+ax_pose 22, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose194:
+ax_pose 21, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose195:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose196:
+ax_pose 1, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose197:
+ax_pose 2, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose198:
+ax_pose 15, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose199:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose200:
+ax_pose 4, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose201:
+ax_pose 5, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose202:
+ax_pose 16, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sPikachuPose203:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose204:
+ax_pose 7, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose205:
+ax_pose 8, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose206:
+ax_pose 17, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose207:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose208:
+ax_pose 10, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose209:
+ax_pose 11, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose210:
+ax_pose 18, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose211:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose212:
+ax_pose 13, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose213:
+ax_pose 14, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose214:
+ax_pose 19, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose215:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose216:
+ax_pose 10, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose217:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose218:
+ax_pose 18, 0x01e9, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose219:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose220:
+ax_pose 7, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose221:
+ax_pose 8, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose222:
+ax_pose 17, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose223:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose224:
+ax_pose 4, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose225:
+ax_pose 5, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose226:
+ax_pose 16, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose227:
+ax_pose 20, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose228:
+ax_pose 21, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose229:
+ax_pose 22, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose230:
+ax_pose 23, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose231:
+ax_pose 24, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose232:
+ax_pose 23, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose233:
+ax_pose 22, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sPikachuPose234:
+ax_pose 21, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose235:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose236:
+ax_pose 3, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose237:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose238:
+ax_pose 9, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose239:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose240:
+ax_pose 9, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose241:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose242:
+ax_pose 3, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose243:
+ax_pose 63, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose244:
+ax_pose 64, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose245:
+ax_pose 63, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose246:
+ax_pose 64, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose247:
+ax_pose 63, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose248:
+ax_pose 65, 0x01ea, 0x80ee, 0x0c00
+ax_pose_terminator
+sPikachuPose249:
+ax_pose 66, 0x01ea, 0x80ee, 0x0c00
+ax_pose_terminator
+sPikachuPose250:
+ax_pose 67, 0x01ea, 0x80ee, 0x0c00
+ax_pose_terminator
+sPikachuPose251:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose252:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose253:
+ax_pose 68, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose254:
+ax_pose 69, 0x01e9, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose255:
+ax_pose 28, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose256:
+ax_pose 70, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose257:
+ax_pose 71, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose258:
+ax_pose 72, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose259:
+ax_pose 73, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose260:
+ax_pose 74, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sPikachuPose261:
+ax_pose 75, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sPikachuPose262:
+ax_pose 75, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sPikachuPose263:
+ax_pose 76, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose264:
+ax_pose 77, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose265:
+ax_pose 78, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose266:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose267:
+ax_pose 79, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sPikachuPose268:
+ax_pose 80, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose269:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose270:
+ax_pose 81, 0x01ee, 0x80f2, 0x0c00
+ax_pose_terminator
+sPikachuPose271:
+ax_pose 82, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sPikachuPose272:
+ax_pose 0, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose273:
+ax_pose 70, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose274:
+ax_pose 83, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose275:
+ax_pose 6, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sPikachuPose276:
+ax_pose 84, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sPikachuPose277:
+ax_pose 6, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose278:
+ax_pose 84, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sPikachuPose279:
+ax_pose 12, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose280:
+ax_pose 85, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sPikachuPose281:
+ax_pose 86, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose282:
+ax_pose 87, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose283:
+ax_pose 88, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose284:
+ax_pose 89, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose285:
+ax_pose 90, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPikachuPose286:
+ax_pose 86, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sPikachuPose287:
+ax_pose 87, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sPikachuPose288:
+ax_pose 88, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sPikachuPose289:
+ax_pose 89, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sPikachuPose290:
+ax_pose 90, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sPikachuPose291:
+ax_pose 91, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sPikachuPose292:
+ax_pose 63, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose293:
+ax_pose 64, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose294:
+ax_pose 63, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose295:
+ax_pose 64, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose296:
+ax_pose 63, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose297:
+ax_pose 64, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPikachuPose298:
+ax_pose 63, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sPikachuPose299:
+ax_pose 64, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+.align 2
+sPikachuAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 2, 0, 2,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 11,
+ax_anim 2, 0, 27, 0, 24, 0, 20,
+ax_anim 2, 1, 27, 1, 24, 1, 20,
+ax_anim 2, 0, 27, 0, 24, 0, 20,
+ax_anim 2, 0, 27, 1, 24, 1, 20,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPikachuAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 31, 4, 1, 4, 4,
+ax_anim 1, 0, 31, 12, 7, 10, 8,
+ax_anim 2, 0, 31, 23, 20, 23, 20,
+ax_anim 2, 1, 31, 24, 19, 24, 19,
+ax_anim 2, 0, 31, 23, 20, 23, 20,
+ax_anim 2, 0, 31, 24, 19, 24, 19,
+ax_anim 4, 0, 28, 8, 8, 6, 6,
+ax_anim_terminator
+sPikachuAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, -1, 0, 0,
+ax_anim 1, 2, 35, 4, -3, 4, 0,
+ax_anim 1, 0, 35, 10, -5, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 4, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sPikachuAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -3, 0, -1,
+ax_anim 1, 2, 39, 5, -10, 5, -6,
+ax_anim 1, 0, 39, 13, -20, 13, -15,
+ax_anim 2, 0, 39, 18, -20, 18, -20,
+ax_anim 2, 1, 39, 19, -19, 19, -19,
+ax_anim 2, 0, 39, 18, -20, 18, -20,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 4, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sPikachuAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -6, 0, -4,
+ax_anim 1, 0, 43, 0, -15, 0, -11,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 4, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sPikachuAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -3, 0, -1,
+ax_anim 1, 2, 47, -5, -10, -5, -6,
+ax_anim 1, 0, 47, -13, -20, -13, -15,
+ax_anim 2, 0, 47, -18, -20, -18, -20,
+ax_anim 2, 1, 47, -19, -19, -19, -19,
+ax_anim 2, 0, 47, -18, -20, -18, -20,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 4, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sPikachuAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, -1, 0, 0,
+ax_anim 1, 2, 51, -4, -3, -4, 0,
+ax_anim 1, 0, 51, -10, -5, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 4, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sPikachuAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 1, 2, 55, -4, 1, -4, 4,
+ax_anim 1, 0, 55, -12, 7, -10, 8,
+ax_anim 2, 0, 55, -23, 20, -23, 20,
+ax_anim 2, 1, 55, -24, 19, -24, 19,
+ax_anim 2, 0, 55, -23, 20, -23, 20,
+ax_anim 2, 0, 55, -24, 19, -24, 19,
+ax_anim 4, 0, 52, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sPikachuAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 2, 0, 2,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 11,
+ax_anim 2, 0, 59, 0, 24, 0, 20,
+ax_anim 2, 1, 59, 1, 24, 1, 20,
+ax_anim 2, 0, 59, 0, 24, 0, 20,
+ax_anim 2, 0, 59, 1, 24, 1, 20,
+ax_anim 4, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sPikachuAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, -1, 0, 0,
+ax_anim 1, 2, 63, 4, 1, 4, 4,
+ax_anim 1, 0, 63, 12, 7, 10, 8,
+ax_anim 2, 0, 63, 23, 20, 23, 20,
+ax_anim 2, 1, 63, 24, 19, 24, 19,
+ax_anim 2, 0, 63, 23, 20, 23, 20,
+ax_anim 2, 0, 63, 24, 19, 24, 19,
+ax_anim 4, 0, 60, 8, 8, 6, 6,
+ax_anim_terminator
+sPikachuAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, -1, 0, 0,
+ax_anim 1, 2, 67, 4, -3, 4, 0,
+ax_anim 1, 0, 67, 10, -5, 10, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 4, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sPikachuAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -3, 0, -1,
+ax_anim 1, 2, 71, 5, -10, 5, -6,
+ax_anim 1, 0, 71, 13, -20, 13, -15,
+ax_anim 2, 0, 71, 18, -20, 18, -20,
+ax_anim 2, 1, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 71, 18, -20, 18, -20,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 4, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sPikachuAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -6, 0, -4,
+ax_anim 1, 0, 75, 0, -15, 0, -11,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 4, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sPikachuAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -3, 0, -1,
+ax_anim 1, 2, 79, -5, -10, -5, -6,
+ax_anim 1, 0, 79, -13, -20, -13, -15,
+ax_anim 2, 0, 79, -18, -20, -18, -20,
+ax_anim 2, 1, 79, -19, -19, -19, -19,
+ax_anim 2, 0, 79, -18, -20, -18, -20,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 4, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sPikachuAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, -1, 0, 0,
+ax_anim 1, 2, 83, -4, -3, -4, 0,
+ax_anim 1, 0, 83, -10, -5, -10, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 4, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sPikachuAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, -1, 0, 0,
+ax_anim 1, 2, 87, -4, 1, -4, 4,
+ax_anim 1, 0, 87, -12, 7, -10, 8,
+ax_anim 2, 0, 87, -23, 20, -23, 20,
+ax_anim 2, 1, 87, -24, 19, -24, 19,
+ax_anim 2, 0, 87, -23, 20, -23, 20,
+ax_anim 2, 0, 87, -24, 19, -24, 19,
+ax_anim 4, 0, 84, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sPikachuAnims_4_1:
+ax_anim 1, 0, 88, 0, -2, 0, -1,
+ax_anim 2, 0, 88, 0, -3, 0, -2,
+ax_anim 6, 2, 88, 0, -4, 0, -4,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim_terminator
+sPikachuAnims_4_2:
+ax_anim 1, 0, 90, -2, -4, -2, -2,
+ax_anim 2, 0, 90, -3, -5, -3, -3,
+ax_anim 6, 2, 90, -4, -4, -4, -4,
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 1, 91, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 2, 4, 2, 4,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 2, 4, 2, 4,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 0, 91, 2, 4, 2, 4,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim_terminator
+sPikachuAnims_4_3:
+ax_anim 1, 0, 92, -2, -1, -2, 0,
+ax_anim 2, 0, 92, -3, -2, -3, 0,
+ax_anim 6, 2, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 2, 1, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim_terminator
+sPikachuAnims_4_4:
+ax_anim 1, 0, 94, -2, 1, -2, 2,
+ax_anim 2, 0, 94, -3, 2, -3, 3,
+ax_anim 6, 2, 94, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 1, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 2, -4, 2, -4,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 2, -4, 2, -4,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 2, -4, 2, -4,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim_terminator
+sPikachuAnims_4_5:
+ax_anim 1, 0, 96, 0, 2, 0, 2,
+ax_anim 2, 0, 96, 0, 3, 0, 3,
+ax_anim 6, 2, 96, 0, 4, 0, 4,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 2, 1, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 97, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 0, -3, 0, -3,
+ax_anim_terminator
+sPikachuAnims_4_6:
+ax_anim 1, 0, 98, 2, 1, 2, 2,
+ax_anim 2, 0, 98, 3, 2, 3, 3,
+ax_anim 6, 2, 98, 4, 4, 4, 4,
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 2, 1, 99, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -2, -4, -2, -4,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -2, -4, -2, -4,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -2, -4, -2, -4,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sPikachuAnims_4_7:
+ax_anim 1, 0, 100, 2, -1, 2, 0,
+ax_anim 2, 0, 100, 3, -2, 3, 0,
+ax_anim 6, 2, 100, 4, 0, 4, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 1, 101, -3, 0, -3, 0,
+ax_anim 2, 0, 101, -3, 1, -3, 1,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 2, 0, 101, -3, 1, -3, 1,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim 2, 0, 101, -3, 1, -3, 1,
+ax_anim 2, 0, 101, -3, 0, -3, 0,
+ax_anim_terminator
+sPikachuAnims_4_8:
+ax_anim 1, 0, 102, 2, -4, 2, -2,
+ax_anim 2, 0, 102, 3, -5, 3, -3,
+ax_anim 6, 2, 102, 4, -4, 4, -4,
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPikachuAnims_5_1:
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 2, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 1, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_5_2:
+ax_anim 8, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 2, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 1, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_5_3:
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 2, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 1, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_5_4:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 2, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 1, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_5_5:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 1, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_5_6:
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 2, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 1, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_5_7:
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 2, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 1, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_5_8:
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 2, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 1, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_7_1:
+ax_anim 2, 0, 154, 0, -3, 0, -3,
+ax_anim 8, 0, 154, 0, -4, 0, -4,
+ax_anim_terminator
+sPikachuAnims_7_2:
+ax_anim 2, 0, 155, -3, -3, -3, -3,
+ax_anim 8, 0, 155, -4, -4, -4, -4,
+ax_anim_terminator
+sPikachuAnims_7_3:
+ax_anim 2, 0, 156, -3, 0, -3, 0,
+ax_anim 8, 0, 156, -4, 0, -4, 0,
+ax_anim_terminator
+sPikachuAnims_7_4:
+ax_anim 2, 0, 157, -3, 3, -3, 3,
+ax_anim 8, 0, 157, -4, 4, -4, 4,
+ax_anim_terminator
+sPikachuAnims_7_5:
+ax_anim 2, 0, 158, 0, 3, 0, 3,
+ax_anim 8, 0, 158, 0, 4, 0, 4,
+ax_anim_terminator
+sPikachuAnims_7_6:
+ax_anim 2, 0, 159, 3, 3, 3, 3,
+ax_anim 8, 0, 159, 4, 4, 4, 4,
+ax_anim_terminator
+sPikachuAnims_7_7:
+ax_anim 2, 0, 160, 3, 0, 3, 0,
+ax_anim 8, 0, 160, 4, 0, 4, 0,
+ax_anim_terminator
+sPikachuAnims_7_8:
+ax_anim 2, 0, 161, 3, -3, 3, -3,
+ax_anim 8, 0, 161, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sPikachuAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -2, 0, 0,
+ax_anim 3, 0, 170, 0, -3, 0, 0,
+ax_anim 3, 0, 170, 0, -4, 0, 0,
+ax_anim 3, 0, 170, 0, -3, 0, 0,
+ax_anim 2, 0, 170, 0, -2, 0, 0,
+ax_anim_terminator
+sPikachuAnims_8_2:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 2, -3, 0, 0,
+ax_anim 3, 0, 177, 2, -4, 0, 0,
+ax_anim 3, 0, 177, 2, -5, 0, 0,
+ax_anim 3, 0, 177, 2, -4, 0, 0,
+ax_anim 2, 0, 177, 2, -3, 0, 0,
+ax_anim_terminator
+sPikachuAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -4, 0, 0,
+ax_anim 3, 0, 176, 0, -5, 0, 0,
+ax_anim 3, 0, 176, 0, -6, 0, 0,
+ax_anim 3, 0, 176, 0, -5, 0, 0,
+ax_anim 2, 0, 176, 0, -4, 0, 0,
+ax_anim_terminator
+sPikachuAnims_8_4:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, -4, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 3, 0, 175, 0, -6, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 0, -4, 0, 0,
+ax_anim_terminator
+sPikachuAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, -4, 0, 0,
+ax_anim 3, 0, 174, 0, -5, 0, 0,
+ax_anim 3, 0, 174, 0, -6, 0, 0,
+ax_anim 3, 0, 174, 0, -5, 0, 0,
+ax_anim 2, 0, 174, 0, -4, 0, 0,
+ax_anim_terminator
+sPikachuAnims_8_6:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -4, 0, 0,
+ax_anim 3, 0, 173, 0, -5, 0, 0,
+ax_anim 3, 0, 173, 0, -6, 0, 0,
+ax_anim 3, 0, 173, 0, -5, 0, 0,
+ax_anim 2, 0, 173, 0, -4, 0, 0,
+ax_anim_terminator
+sPikachuAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -4, 0, 0,
+ax_anim 3, 0, 172, 0, -5, 0, 0,
+ax_anim 3, 0, 172, 0, -6, 0, 0,
+ax_anim 3, 0, 172, 0, -5, 0, 0,
+ax_anim 2, 0, 172, 0, -4, 0, 0,
+ax_anim_terminator
+sPikachuAnims_8_8:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -2, -3, 0, 0,
+ax_anim 3, 0, 171, -2, -4, 0, 0,
+ax_anim 3, 0, 171, -2, -5, 0, 0,
+ax_anim 3, 0, 171, -2, -4, 0, 0,
+ax_anim 2, 0, 171, -2, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 18, 7, 18,
+ax_anim 3, 0, 182, 0, 21, 0, 21,
+ax_anim 2, 3, 183, -7, 18, -7, 18,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 24, 9, 24, 9,
+ax_anim 3, 0, 181, 23, 21, 23, 21,
+ax_anim 2, 3, 182, 11, 21, 11, 21,
+ax_anim 2, 0, 183, 2, 12, 2, 12,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 18, -4, 17, -4,
+ax_anim 3, 0, 180, 22, 1, 22, 1,
+ax_anim 2, 3, 181, 18, 5, 18, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 2, -16, 2, -16,
+ax_anim 2, 0, 178, 11, -22, 11, -22,
+ax_anim 3, 0, 179, 20, -22, 20, -22,
+ax_anim 2, 3, 180, 21, -12, 21, -12,
+ax_anim 2, 0, 181, 16, -6, 16, -6,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -8, -10, -8, -10,
+ax_anim 2, 0, 185, -7, -19, -7, -19,
+ax_anim 3, 0, 178, 0, -24, 0, -24,
+ax_anim 2, 3, 179, 7, -19, 7, -19,
+ax_anim 2, 0, 180, 8, -8, 8, -8,
+ax_anim 1, 0, 181, 6, -4, 6, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -2, -16, -2, -16,
+ax_anim 2, 0, 178, -11, -22, -11, -22,
+ax_anim 3, 0, 185, -20, -22, -20, -22,
+ax_anim 2, 3, 184, -21, -12, -21, -12,
+ax_anim 2, 0, 183, -16, -6, -16, -6,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -18, -4, -18, -4,
+ax_anim 3, 0, 184, -22, 1, -22, 1,
+ax_anim 2, 3, 183, -18, 5, -18, 5,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -24, 9, -24, 9,
+ax_anim 3, 0, 183, -23, 21, -23, 16,
+ax_anim 2, 3, 182, -11, 21, -11, 16,
+ax_anim 2, 0, 181, -2, 12, -4, 12,
+ax_anim 1, 0, 180, 0, 7, -3, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 197, 0, -22, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_11_2:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_11_3:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_11_4:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -17, 0, 0,
+ax_anim 1, 0, 209, 0, -11, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_11_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_11_6:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -17, 0, 0,
+ax_anim 1, 0, 217, 0, -11, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_11_7:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 221, 0, -22, 0, 0,
+ax_anim 2, 0, 221, 0, -18, 0, 0,
+ax_anim 1, 0, 221, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_11_8:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_14_1:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_14_2:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_14_3:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_14_4:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_14_5:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_14_6:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_14_7:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_14_8:
+ax_anim 30, 0, 242, 0, 0, 0, 0,
+ax_anim 35, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_15_1:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_15_2:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_15_3:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_15_4:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_15_5:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_15_6:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_15_7:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_15_8:
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 6, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim 14, 0, 249, 0, 0, 0, 0,
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_16_1:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_16_2:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_16_3:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_16_4:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_16_5:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_16_6:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_16_7:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_16_8:
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 3, 0, 252, 0, 0, 0, 0,
+ax_anim 8, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_17_1:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+sPikachuAnims_17_2:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+sPikachuAnims_17_3:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+sPikachuAnims_17_4:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+sPikachuAnims_17_5:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+sPikachuAnims_17_6:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+sPikachuAnims_17_7:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+sPikachuAnims_17_8:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_18_1:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_18_2:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_18_3:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_18_4:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_18_5:
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_18_6:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_18_7:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_18_8:
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_19_1:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_19_2:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_19_3:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_19_4:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_19_5:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_19_6:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_19_7:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_19_8:
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 10, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_20_1:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 1, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 0,
+ax_anim 2, 0, 267, 0, 1, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 0,
+ax_anim 2, 0, 267, 0, 1, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 0,
+ax_anim_terminator
+sPikachuAnims_20_2:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim_terminator
+sPikachuAnims_20_3:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim_terminator
+sPikachuAnims_20_4:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim_terminator
+sPikachuAnims_20_5:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim_terminator
+sPikachuAnims_20_6:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim_terminator
+sPikachuAnims_20_7:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim_terminator
+sPikachuAnims_20_8:
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -2, 0, 0,
+ax_anim 1, 0, 266, 0, -4, 0, 0,
+ax_anim 2, 0, 267, 0, -4, 0, 0,
+ax_anim 1, 0, 267, 0, -2, 0, 0,
+ax_anim 4, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_21_1:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_21_2:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_21_3:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_21_4:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_21_5:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_21_6:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_21_7:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_21_8:
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 269, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_22_1:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_22_2:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_22_3:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_22_4:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_22_5:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_22_6:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_22_7:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_22_8:
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 30, 0, 272, 0, 0, 0, 0,
+ax_anim 34, 0, 273, 0, 0, 0, 0,
+ax_anim 4, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_23_1:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 4, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_23_2:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 4, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_23_3:
+ax_anim 10, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 12, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 4, 0, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_23_4:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 4, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_23_5:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 4, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_23_6:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 4, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_23_7:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 4, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_23_8:
+ax_anim 10, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim 8, 0, 275, 0, 0, 0, 0,
+ax_anim 4, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_24_1:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_24_2:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_24_3:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_24_4:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_24_5:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_24_6:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_24_7:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_24_8:
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_25_1:
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 286, 0, 0, 0, 0,
+ax_anim 12, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_25_2:
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 286, 0, 0, 0, 0,
+ax_anim 12, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_25_3:
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 286, 0, 0, 0, 0,
+ax_anim 12, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_25_4:
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 286, 0, 0, 0, 0,
+ax_anim 12, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_25_5:
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 286, 0, 0, 0, 0,
+ax_anim 12, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_25_6:
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 286, 0, 0, 0, 0,
+ax_anim 12, 0, 287, 0, 0, 0, 0,
+ax_anim 10, 0, 285, 0, 0, 0, 0,
+ax_anim 8, 0, 288, 0, 0, 0, 0,
+ax_anim 12, 0, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_25_7:
+ax_anim 10, 0, 280, 0, 0, 0, 0,
+ax_anim 8, 0, 281, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 10, 0, 280, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_25_8:
+ax_anim 10, 0, 280, 0, 0, 0, 0,
+ax_anim 8, 0, 281, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 10, 0, 280, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 284, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_26_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+sPikachuAnims_26_2:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+sPikachuAnims_26_3:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+sPikachuAnims_26_4:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+sPikachuAnims_26_5:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+sPikachuAnims_26_6:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+sPikachuAnims_26_7:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+sPikachuAnims_26_8:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sPikachuAnims_27_1:
+ax_anim 12, 0, 291, 0, 0, 0, 0,
+ax_anim 12, 0, 291, 0, 0, 0, 0,
+ax_anim 16, 0, 291, -1, 0, 0, 0,
+ax_anim 12, 0, 291, 0, 0, 0, 0,
+ax_anim 12, 0, 291, 1, 0, 0, 0,
+ax_anim 16, 0, 291, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPikachuAnims_28_1:
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_28_2:
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_28_3:
+ax_anim 12, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_28_4:
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_28_5:
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_28_6:
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_28_7:
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuAnims_28_8:
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sPikachuGfx1:
+.incbin "baserom.gba", 0x61BC70, 0x200
+sPikachuSprites1:
+ax_sprite sPikachuGfx1, 0x200
+ax_sprite_terminator
+sPikachuGfx2:
+.incbin "baserom.gba", 0x61BE80, 0x200
+sPikachuSprites2:
+ax_sprite sPikachuGfx2, 0x200
+ax_sprite_terminator
+sPikachuGfx3:
+.incbin "baserom.gba", 0x61C090, 0x200
+sPikachuSprites3:
+ax_sprite sPikachuGfx3, 0x200
+ax_sprite_terminator
+sPikachuGfx4:
+.incbin "baserom.gba", 0x61C2A0, 0x200
+sPikachuSprites4:
+ax_sprite sPikachuGfx4, 0x200
+ax_sprite_terminator
+sPikachuGfx5:
+.incbin "baserom.gba", 0x61C4B0, 0x200
+sPikachuSprites5:
+ax_sprite sPikachuGfx5, 0x200
+ax_sprite_terminator
+sPikachuGfx6:
+.incbin "baserom.gba", 0x61C6C0, 0x200
+sPikachuSprites6:
+ax_sprite sPikachuGfx6, 0x200
+ax_sprite_terminator
+sPikachuGfx7:
+.incbin "baserom.gba", 0x61C8D0, 0x200
+sPikachuSprites7:
+ax_sprite sPikachuGfx7, 0x200
+ax_sprite_terminator
+sPikachuGfx8:
+.incbin "baserom.gba", 0x61CAE0, 0x200
+sPikachuSprites8:
+ax_sprite sPikachuGfx8, 0x200
+ax_sprite_terminator
+sPikachuGfx9:
+.incbin "baserom.gba", 0x61CCF0, 0x200
+sPikachuSprites9:
+ax_sprite sPikachuGfx9, 0x200
+ax_sprite_terminator
+sPikachuGfx10:
+.incbin "baserom.gba", 0x61CF00, 0x200
+sPikachuSprites10:
+ax_sprite sPikachuGfx10, 0x200
+ax_sprite_terminator
+sPikachuGfx11:
+.incbin "baserom.gba", 0x61D110, 0x200
+sPikachuSprites11:
+ax_sprite sPikachuGfx11, 0x200
+ax_sprite_terminator
+sPikachuGfx12:
+.incbin "baserom.gba", 0x61D320, 0x200
+sPikachuSprites12:
+ax_sprite sPikachuGfx12, 0x200
+ax_sprite_terminator
+sPikachuGfx13:
+.incbin "baserom.gba", 0x61D530, 0x200
+sPikachuSprites13:
+ax_sprite sPikachuGfx13, 0x200
+ax_sprite_terminator
+sPikachuGfx14:
+.incbin "baserom.gba", 0x61D740, 0x200
+sPikachuSprites14:
+ax_sprite sPikachuGfx14, 0x200
+ax_sprite_terminator
+sPikachuGfx15:
+.incbin "baserom.gba", 0x61D950, 0x200
+sPikachuSprites15:
+ax_sprite sPikachuGfx15, 0x200
+ax_sprite_terminator
+sPikachuGfx16:
+.incbin "baserom.gba", 0x61DB60, 0x60
+sPikachuGfx16_1:
+.incbin "baserom.gba", 0x61DBC0, 0x60
+sPikachuGfx16_2:
+.incbin "baserom.gba", 0x61DC20, 0x60
+sPikachuSprites16:
+ax_sprite sPikachuGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPikachuGfx17:
+.incbin "baserom.gba", 0x61DCB8, 0x40
+sPikachuGfx17_1:
+.incbin "baserom.gba", 0x61DCF8, 0x100
+sPikachuGfx17_2:
+.incbin "baserom.gba", 0x61DDF8, 0x40
+sPikachuSprites17:
+ax_sprite sPikachuGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPikachuGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPikachuGfx18:
+.incbin "baserom.gba", 0x61DE70, 0x160
+sPikachuSprites18:
+ax_sprite sPikachuGfx18, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPikachuGfx19:
+.incbin "baserom.gba", 0x61DFE8, 0x60
+sPikachuGfx19_1:
+.incbin "baserom.gba", 0x61E048, 0xE0
+sPikachuSprites19:
+ax_sprite sPikachuGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx19_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPikachuGfx20:
+.incbin "baserom.gba", 0x61E150, 0x60
+sPikachuGfx20_1:
+.incbin "baserom.gba", 0x61E1B0, 0x60
+sPikachuGfx20_2:
+.incbin "baserom.gba", 0x61E210, 0x60
+sPikachuGfx20_3:
+.incbin "baserom.gba", 0x61E270, 0x20
+sPikachuSprites20:
+ax_sprite sPikachuGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx20_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sPikachuGfx21:
+.incbin "baserom.gba", 0x61E2D8, 0x60
+sPikachuGfx21_1:
+.incbin "baserom.gba", 0x61E338, 0x60
+sPikachuGfx21_2:
+.incbin "baserom.gba", 0x61E398, 0x60
+sPikachuGfx21_3:
+.incbin "baserom.gba", 0x61E3F8, 0x60
+sPikachuSprites21:
+ax_sprite sPikachuGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPikachuGfx22:
+.incbin "baserom.gba", 0x61E4A0, 0x40
+sPikachuGfx22_1:
+.incbin "baserom.gba", 0x61E4E0, 0xE0
+sPikachuGfx22_2:
+.incbin "baserom.gba", 0x61E5C0, 0x40
+sPikachuSprites22:
+ax_sprite sPikachuGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPikachuGfx22_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx22_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx23:
+.incbin "baserom.gba", 0x61E638, 0x160
+sPikachuSprites23:
+ax_sprite sPikachuGfx23, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPikachuGfx24:
+.incbin "baserom.gba", 0x61E7B0, 0x60
+sPikachuGfx24_1:
+.incbin "baserom.gba", 0x61E810, 0x100
+sPikachuSprites24:
+ax_sprite sPikachuGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx24_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPikachuGfx25:
+.incbin "baserom.gba", 0x61E938, 0x60
+sPikachuGfx25_1:
+.incbin "baserom.gba", 0x61E998, 0x60
+sPikachuGfx25_2:
+.incbin "baserom.gba", 0x61E9F8, 0x60
+sPikachuGfx25_3:
+.incbin "baserom.gba", 0x61EA58, 0x20
+sPikachuSprites25:
+ax_sprite sPikachuGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPikachuGfx25_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx26:
+.incbin "baserom.gba", 0x61EAC0, 0x120
+sPikachuGfx26_1:
+.incbin "baserom.gba", 0x61EBE0, 0x60
+sPikachuGfx26_2:
+.incbin "baserom.gba", 0x61EC40, 0x20
+sPikachuSprites26:
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx26, 0x120
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx26_2, 0x20
+ax_sprite_terminator
+sPikachuGfx27:
+.incbin "baserom.gba", 0x61EC98, 0x80
+sPikachuSprites27:
+ax_sprite sPikachuGfx27, 0x80
+ax_sprite_terminator
+sPikachuGfx28:
+.incbin "baserom.gba", 0x61ED28, 0x20
+sPikachuGfx28_1:
+.incbin "baserom.gba", 0x61ED48, 0x20
+sPikachuSprites28:
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx28_1, 0x20
+ax_sprite_terminator
+sPikachuGfx29:
+.incbin "baserom.gba", 0x61ED90, 0x60
+sPikachuGfx29_1:
+.incbin "baserom.gba", 0x61EDF0, 0x60
+sPikachuGfx29_2:
+.incbin "baserom.gba", 0x61EE50, 0x60
+sPikachuGfx29_3:
+.incbin "baserom.gba", 0x61EEB0, 0x60
+sPikachuSprites29:
+ax_sprite sPikachuGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPikachuGfx30:
+.incbin "baserom.gba", 0x61EF58, 0x140
+sPikachuGfx30_1:
+.incbin "baserom.gba", 0x61F098, 0x40
+sPikachuGfx30_2:
+.incbin "baserom.gba", 0x61F0D8, 0x20
+sPikachuSprites30:
+ax_sprite sPikachuGfx30, 0x140
+ax_sprite 0, 0x40
+ax_sprite sPikachuGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx30_2, 0x20
+ax_sprite_terminator
+sPikachuGfx31:
+.incbin "baserom.gba", 0x61F128, 0x80
+sPikachuSprites31:
+ax_sprite sPikachuGfx31, 0x80
+ax_sprite_terminator
+sPikachuGfx32:
+.incbin "baserom.gba", 0x61F1B8, 0x40
+sPikachuSprites32:
+ax_sprite sPikachuGfx32, 0x40
+ax_sprite_terminator
+sPikachuGfx33:
+.incbin "baserom.gba", 0x61F208, 0x40
+sPikachuSprites33:
+ax_sprite sPikachuGfx33, 0x40
+ax_sprite_terminator
+sPikachuGfx34:
+.incbin "baserom.gba", 0x61F258, 0x60
+sPikachuGfx34_1:
+.incbin "baserom.gba", 0x61F2B8, 0x60
+sPikachuGfx34_2:
+.incbin "baserom.gba", 0x61F318, 0x60
+sPikachuGfx34_3:
+.incbin "baserom.gba", 0x61F378, 0x60
+sPikachuSprites34:
+ax_sprite sPikachuGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPikachuGfx35:
+.incbin "baserom.gba", 0x61F420, 0x40
+sPikachuGfx35_1:
+.incbin "baserom.gba", 0x61F460, 0xA0
+sPikachuGfx35_2:
+.incbin "baserom.gba", 0x61F500, 0x80
+sPikachuSprites35:
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPikachuGfx35_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sPikachuGfx35_2, 0x80
+ax_sprite_terminator
+sPikachuGfx36:
+.incbin "baserom.gba", 0x61F5B8, 0x80
+sPikachuSprites36:
+ax_sprite sPikachuGfx36, 0x80
+ax_sprite_terminator
+sPikachuGfx37:
+.incbin "baserom.gba", 0x61F648, 0x40
+sPikachuSprites37:
+ax_sprite sPikachuGfx37, 0x40
+ax_sprite_terminator
+sPikachuGfx38:
+.incbin "baserom.gba", 0x61F698, 0x20
+sPikachuGfx38_1:
+.incbin "baserom.gba", 0x61F6B8, 0x20
+sPikachuGfx38_2:
+.incbin "baserom.gba", 0x61F6D8, 0x60
+sPikachuGfx38_3:
+.incbin "baserom.gba", 0x61F738, 0x60
+sPikachuGfx38_4:
+.incbin "baserom.gba", 0x61F798, 0x40
+sPikachuSprites38:
+ax_sprite sPikachuGfx38, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx38_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx38_4, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx39:
+.incbin "baserom.gba", 0x61F830, 0x140
+sPikachuGfx39_1:
+.incbin "baserom.gba", 0x61F970, 0x60
+sPikachuGfx39_2:
+.incbin "baserom.gba", 0x61F9D0, 0x20
+sPikachuSprites39:
+ax_sprite sPikachuGfx39, 0x140
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx39_2, 0x20
+ax_sprite_terminator
+sPikachuGfx40:
+.incbin "baserom.gba", 0x61FA20, 0x80
+sPikachuSprites40:
+ax_sprite sPikachuGfx40, 0x80
+ax_sprite_terminator
+sPikachuGfx41:
+.incbin "baserom.gba", 0x61FAB0, 0x40
+sPikachuSprites41:
+ax_sprite sPikachuGfx41, 0x40
+ax_sprite_terminator
+sPikachuGfx42:
+.incbin "baserom.gba", 0x61FB00, 0x20
+sPikachuGfx42_1:
+.incbin "baserom.gba", 0x61FB20, 0x20
+sPikachuGfx42_2:
+.incbin "baserom.gba", 0x61FB40, 0x60
+sPikachuGfx42_3:
+.incbin "baserom.gba", 0x61FBA0, 0x60
+sPikachuGfx42_4:
+.incbin "baserom.gba", 0x61FC00, 0x40
+sPikachuSprites42:
+ax_sprite sPikachuGfx42, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx42_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx42_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx42_4, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx43:
+.incbin "baserom.gba", 0x61FC98, 0x100
+sPikachuGfx43_1:
+.incbin "baserom.gba", 0x61FD98, 0xC0
+sPikachuSprites43:
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx43, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx43_1, 0xc0
+ax_sprite_terminator
+sPikachuGfx44:
+.incbin "baserom.gba", 0x61FE80, 0x60
+sPikachuSprites44:
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx44, 0x60
+ax_sprite_terminator
+sPikachuGfx45:
+.incbin "baserom.gba", 0x61FEF8, 0x20
+sPikachuSprites45:
+ax_sprite sPikachuGfx45, 0x20
+ax_sprite_terminator
+sPikachuGfx46:
+.incbin "baserom.gba", 0x61FF28, 0x60
+sPikachuGfx46_1:
+.incbin "baserom.gba", 0x61FF88, 0x60
+sPikachuGfx46_2:
+.incbin "baserom.gba", 0x61FFE8, 0x60
+sPikachuGfx46_3:
+.incbin "baserom.gba", 0x620048, 0x40
+sPikachuSprites46:
+ax_sprite sPikachuGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx46_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx47:
+.incbin "baserom.gba", 0x6200D0, 0x60
+sPikachuGfx47_1:
+.incbin "baserom.gba", 0x620130, 0x60
+sPikachuGfx47_2:
+.incbin "baserom.gba", 0x620190, 0x60
+sPikachuGfx47_3:
+.incbin "baserom.gba", 0x6201F0, 0x40
+sPikachuSprites47:
+ax_sprite sPikachuGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx47_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx47_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx48:
+.incbin "baserom.gba", 0x620278, 0x1A0
+sPikachuGfx48_1:
+.incbin "baserom.gba", 0x620418, 0x20
+sPikachuSprites48:
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx48, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx48_1, 0x20
+ax_sprite_terminator
+sPikachuGfx49:
+.incbin "baserom.gba", 0x620460, 0x60
+sPikachuSprites49:
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx49, 0x60
+ax_sprite_terminator
+sPikachuGfx50:
+.incbin "baserom.gba", 0x6204D8, 0x40
+sPikachuSprites50:
+ax_sprite sPikachuGfx50, 0x40
+ax_sprite_terminator
+sPikachuGfx51:
+.incbin "baserom.gba", 0x620528, 0x60
+sPikachuGfx51_1:
+.incbin "baserom.gba", 0x620588, 0x60
+sPikachuGfx51_2:
+.incbin "baserom.gba", 0x6205E8, 0x60
+sPikachuGfx51_3:
+.incbin "baserom.gba", 0x620648, 0x40
+sPikachuSprites51:
+ax_sprite sPikachuGfx51, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx51_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx51_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx51_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx52:
+.incbin "baserom.gba", 0x6206D0, 0x60
+sPikachuGfx52_1:
+.incbin "baserom.gba", 0x620730, 0x60
+sPikachuGfx52_2:
+.incbin "baserom.gba", 0x620790, 0x60
+sPikachuGfx52_3:
+.incbin "baserom.gba", 0x6207F0, 0x40
+sPikachuSprites52:
+ax_sprite sPikachuGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx52_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPikachuGfx53:
+.incbin "baserom.gba", 0x620878, 0xC0
+sPikachuGfx53_1:
+.incbin "baserom.gba", 0x620938, 0x60
+sPikachuGfx53_2:
+.incbin "baserom.gba", 0x620998, 0x60
+sPikachuGfx53_3:
+.incbin "baserom.gba", 0x6209F8, 0x20
+sPikachuSprites53:
+ax_sprite sPikachuGfx53, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx53_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx53_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx53_3, 0x20
+ax_sprite_terminator
+sPikachuGfx54:
+.incbin "baserom.gba", 0x620A58, 0x80
+sPikachuSprites54:
+ax_sprite sPikachuGfx54, 0x80
+ax_sprite_terminator
+sPikachuGfx55:
+.incbin "baserom.gba", 0x620AE8, 0x60
+sPikachuGfx55_1:
+.incbin "baserom.gba", 0x620B48, 0x60
+sPikachuGfx55_2:
+.incbin "baserom.gba", 0x620BA8, 0x60
+sPikachuSprites55:
+ax_sprite sPikachuGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx55_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPikachuGfx56:
+.incbin "baserom.gba", 0x620C40, 0x60
+sPikachuGfx56_1:
+.incbin "baserom.gba", 0x620CA0, 0x60
+sPikachuGfx56_2:
+.incbin "baserom.gba", 0x620D00, 0x60
+sPikachuSprites56:
+ax_sprite sPikachuGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPikachuGfx56_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPikachuGfx57:
+.incbin "baserom.gba", 0x620D98, 0x200
+sPikachuSprites57:
+ax_sprite sPikachuGfx57, 0x200
+ax_sprite_terminator
+sPikachuGfx58:
+.incbin "baserom.gba", 0x620FA8, 0x200
+sPikachuSprites58:
+ax_sprite sPikachuGfx58, 0x200
+ax_sprite_terminator
+sPikachuGfx59:
+.incbin "baserom.gba", 0x6211B8, 0x200
+sPikachuSprites59:
+ax_sprite sPikachuGfx59, 0x200
+ax_sprite_terminator
+sPikachuGfx60:
+.incbin "baserom.gba", 0x6213C8, 0x200
+sPikachuSprites60:
+ax_sprite sPikachuGfx60, 0x200
+ax_sprite_terminator
+sPikachuGfx61:
+.incbin "baserom.gba", 0x6215D8, 0x200
+sPikachuSprites61:
+ax_sprite sPikachuGfx61, 0x200
+ax_sprite_terminator
+sPikachuGfx62:
+.incbin "baserom.gba", 0x6217E8, 0x200
+sPikachuSprites62:
+ax_sprite sPikachuGfx62, 0x200
+ax_sprite_terminator
+sPikachuGfx63:
+.incbin "baserom.gba", 0x6219F8, 0x200
+sPikachuSprites63:
+ax_sprite sPikachuGfx63, 0x200
+ax_sprite_terminator
+sPikachuGfx64:
+.incbin "baserom.gba", 0x621C08, 0x200
+sPikachuSprites64:
+ax_sprite sPikachuGfx64, 0x200
+ax_sprite_terminator
+sPikachuGfx65:
+.incbin "baserom.gba", 0x621E18, 0x200
+sPikachuSprites65:
+ax_sprite sPikachuGfx65, 0x200
+ax_sprite_terminator
+sPikachuGfx66:
+.incbin "baserom.gba", 0x622028, 0x200
+sPikachuSprites66:
+ax_sprite sPikachuGfx66, 0x200
+ax_sprite_terminator
+sPikachuGfx67:
+.incbin "baserom.gba", 0x622238, 0x200
+sPikachuSprites67:
+ax_sprite sPikachuGfx67, 0x200
+ax_sprite_terminator
+sPikachuGfx68:
+.incbin "baserom.gba", 0x622448, 0x200
+sPikachuSprites68:
+ax_sprite sPikachuGfx68, 0x200
+ax_sprite_terminator
+sPikachuGfx69:
+.incbin "baserom.gba", 0x622658, 0x200
+sPikachuSprites69:
+ax_sprite sPikachuGfx69, 0x200
+ax_sprite_terminator
+sPikachuGfx70:
+.incbin "baserom.gba", 0x622868, 0x200
+sPikachuSprites70:
+ax_sprite sPikachuGfx70, 0x200
+ax_sprite_terminator
+sPikachuGfx71:
+.incbin "baserom.gba", 0x622A78, 0x200
+sPikachuSprites71:
+ax_sprite sPikachuGfx71, 0x200
+ax_sprite_terminator
+sPikachuGfx72:
+.incbin "baserom.gba", 0x622C88, 0x200
+sPikachuSprites72:
+ax_sprite sPikachuGfx72, 0x200
+ax_sprite_terminator
+sPikachuGfx73:
+.incbin "baserom.gba", 0x622E98, 0x200
+sPikachuSprites73:
+ax_sprite sPikachuGfx73, 0x200
+ax_sprite_terminator
+sPikachuGfx74:
+.incbin "baserom.gba", 0x6230A8, 0x200
+sPikachuSprites74:
+ax_sprite sPikachuGfx74, 0x200
+ax_sprite_terminator
+sPikachuGfx75:
+.incbin "baserom.gba", 0x6232B8, 0x200
+sPikachuSprites75:
+ax_sprite sPikachuGfx75, 0x200
+ax_sprite_terminator
+sPikachuGfx76:
+.incbin "baserom.gba", 0x6234C8, 0x200
+sPikachuSprites76:
+ax_sprite sPikachuGfx76, 0x200
+ax_sprite_terminator
+sPikachuGfx77:
+.incbin "baserom.gba", 0x6236D8, 0x200
+sPikachuSprites77:
+ax_sprite sPikachuGfx77, 0x200
+ax_sprite_terminator
+sPikachuGfx78:
+.incbin "baserom.gba", 0x6238E8, 0x200
+sPikachuSprites78:
+ax_sprite sPikachuGfx78, 0x200
+ax_sprite_terminator
+sPikachuGfx79:
+.incbin "baserom.gba", 0x623AF8, 0x200
+sPikachuSprites79:
+ax_sprite sPikachuGfx79, 0x200
+ax_sprite_terminator
+sPikachuGfx80:
+.incbin "baserom.gba", 0x623D08, 0x200
+sPikachuSprites80:
+ax_sprite sPikachuGfx80, 0x200
+ax_sprite_terminator
+sPikachuGfx81:
+.incbin "baserom.gba", 0x623F18, 0x200
+sPikachuSprites81:
+ax_sprite sPikachuGfx81, 0x200
+ax_sprite_terminator
+sPikachuGfx82:
+.incbin "baserom.gba", 0x624128, 0x200
+sPikachuSprites82:
+ax_sprite sPikachuGfx82, 0x200
+ax_sprite_terminator
+sPikachuGfx83:
+.incbin "baserom.gba", 0x624338, 0x200
+sPikachuSprites83:
+ax_sprite sPikachuGfx83, 0x200
+ax_sprite_terminator
+sPikachuGfx84:
+.incbin "baserom.gba", 0x624548, 0x200
+sPikachuSprites84:
+ax_sprite sPikachuGfx84, 0x200
+ax_sprite_terminator
+sPikachuGfx85:
+.incbin "baserom.gba", 0x624758, 0x200
+sPikachuSprites85:
+ax_sprite sPikachuGfx85, 0x200
+ax_sprite_terminator
+sPikachuGfx86:
+.incbin "baserom.gba", 0x624968, 0x200
+sPikachuSprites86:
+ax_sprite sPikachuGfx86, 0x200
+ax_sprite_terminator
+sPikachuGfx87:
+.incbin "baserom.gba", 0x624B78, 0x200
+sPikachuSprites87:
+ax_sprite sPikachuGfx87, 0x200
+ax_sprite_terminator
+sPikachuGfx88:
+.incbin "baserom.gba", 0x624D88, 0x200
+sPikachuSprites88:
+ax_sprite sPikachuGfx88, 0x200
+ax_sprite_terminator
+sPikachuGfx89:
+.incbin "baserom.gba", 0x624F98, 0x200
+sPikachuSprites89:
+ax_sprite sPikachuGfx89, 0x200
+ax_sprite_terminator
+sPikachuGfx90:
+.incbin "baserom.gba", 0x6251A8, 0x200
+sPikachuSprites90:
+ax_sprite sPikachuGfx90, 0x200
+ax_sprite_terminator
+sPikachuGfx91:
+.incbin "baserom.gba", 0x6253B8, 0x200
+sPikachuSprites91:
+ax_sprite sPikachuGfx91, 0x200
+ax_sprite_terminator
+sPikachuGfx92:
+.incbin "baserom.gba", 0x6255C8, 0x200
+sPikachuSprites92:
+ax_sprite sPikachuGfx92, 0x200
+ax_sprite_terminator
+sAxPosesPikachu:
+.4byte sPikachuPose1
+.4byte sPikachuPose2
+.4byte sPikachuPose3
+.4byte sPikachuPose4
+.4byte sPikachuPose5
+.4byte sPikachuPose6
+.4byte sPikachuPose7
+.4byte sPikachuPose8
+.4byte sPikachuPose9
+.4byte sPikachuPose10
+.4byte sPikachuPose11
+.4byte sPikachuPose12
+.4byte sPikachuPose13
+.4byte sPikachuPose14
+.4byte sPikachuPose15
+.4byte sPikachuPose16
+.4byte sPikachuPose17
+.4byte sPikachuPose18
+.4byte sPikachuPose19
+.4byte sPikachuPose20
+.4byte sPikachuPose21
+.4byte sPikachuPose22
+.4byte sPikachuPose23
+.4byte sPikachuPose24
+.4byte sPikachuPose25
+.4byte sPikachuPose26
+.4byte sPikachuPose27
+.4byte sPikachuPose28
+.4byte sPikachuPose29
+.4byte sPikachuPose30
+.4byte sPikachuPose31
+.4byte sPikachuPose32
+.4byte sPikachuPose33
+.4byte sPikachuPose34
+.4byte sPikachuPose35
+.4byte sPikachuPose36
+.4byte sPikachuPose37
+.4byte sPikachuPose38
+.4byte sPikachuPose39
+.4byte sPikachuPose40
+.4byte sPikachuPose41
+.4byte sPikachuPose42
+.4byte sPikachuPose43
+.4byte sPikachuPose44
+.4byte sPikachuPose45
+.4byte sPikachuPose46
+.4byte sPikachuPose47
+.4byte sPikachuPose48
+.4byte sPikachuPose49
+.4byte sPikachuPose50
+.4byte sPikachuPose51
+.4byte sPikachuPose52
+.4byte sPikachuPose53
+.4byte sPikachuPose54
+.4byte sPikachuPose55
+.4byte sPikachuPose56
+.4byte sPikachuPose57
+.4byte sPikachuPose58
+.4byte sPikachuPose59
+.4byte sPikachuPose60
+.4byte sPikachuPose61
+.4byte sPikachuPose62
+.4byte sPikachuPose63
+.4byte sPikachuPose64
+.4byte sPikachuPose65
+.4byte sPikachuPose66
+.4byte sPikachuPose67
+.4byte sPikachuPose68
+.4byte sPikachuPose69
+.4byte sPikachuPose70
+.4byte sPikachuPose71
+.4byte sPikachuPose72
+.4byte sPikachuPose73
+.4byte sPikachuPose74
+.4byte sPikachuPose75
+.4byte sPikachuPose76
+.4byte sPikachuPose77
+.4byte sPikachuPose78
+.4byte sPikachuPose79
+.4byte sPikachuPose80
+.4byte sPikachuPose81
+.4byte sPikachuPose82
+.4byte sPikachuPose83
+.4byte sPikachuPose84
+.4byte sPikachuPose85
+.4byte sPikachuPose86
+.4byte sPikachuPose87
+.4byte sPikachuPose88
+.4byte sPikachuPose89
+.4byte sPikachuPose90
+.4byte sPikachuPose91
+.4byte sPikachuPose92
+.4byte sPikachuPose93
+.4byte sPikachuPose94
+.4byte sPikachuPose95
+.4byte sPikachuPose96
+.4byte sPikachuPose97
+.4byte sPikachuPose98
+.4byte sPikachuPose99
+.4byte sPikachuPose100
+.4byte sPikachuPose101
+.4byte sPikachuPose102
+.4byte sPikachuPose103
+.4byte sPikachuPose104
+.4byte sPikachuPose105
+.4byte sPikachuPose106
+.4byte sPikachuPose107
+.4byte sPikachuPose108
+.4byte sPikachuPose109
+.4byte sPikachuPose110
+.4byte sPikachuPose111
+.4byte sPikachuPose112
+.4byte sPikachuPose113
+.4byte sPikachuPose114
+.4byte sPikachuPose115
+.4byte sPikachuPose116
+.4byte sPikachuPose117
+.4byte sPikachuPose118
+.4byte sPikachuPose119
+.4byte sPikachuPose120
+.4byte sPikachuPose121
+.4byte sPikachuPose122
+.4byte sPikachuPose123
+.4byte sPikachuPose124
+.4byte sPikachuPose125
+.4byte sPikachuPose126
+.4byte sPikachuPose127
+.4byte sPikachuPose128
+.4byte sPikachuPose129
+.4byte sPikachuPose130
+.4byte sPikachuPose131
+.4byte sPikachuPose132
+.4byte sPikachuPose133
+.4byte sPikachuPose134
+.4byte sPikachuPose135
+.4byte sPikachuPose136
+.4byte sPikachuPose137
+.4byte sPikachuPose138
+.4byte sPikachuPose139
+.4byte sPikachuPose140
+.4byte sPikachuPose141
+.4byte sPikachuPose142
+.4byte sPikachuPose143
+.4byte sPikachuPose144
+.4byte sPikachuPose145
+.4byte sPikachuPose146
+.4byte sPikachuPose147
+.4byte sPikachuPose148
+.4byte sPikachuPose149
+.4byte sPikachuPose150
+.4byte sPikachuPose151
+.4byte sPikachuPose152
+.4byte sPikachuPose153
+.4byte sPikachuPose154
+.4byte sPikachuPose155
+.4byte sPikachuPose156
+.4byte sPikachuPose157
+.4byte sPikachuPose158
+.4byte sPikachuPose159
+.4byte sPikachuPose160
+.4byte sPikachuPose161
+.4byte sPikachuPose162
+.4byte sPikachuPose163
+.4byte sPikachuPose164
+.4byte sPikachuPose165
+.4byte sPikachuPose166
+.4byte sPikachuPose167
+.4byte sPikachuPose168
+.4byte sPikachuPose169
+.4byte sPikachuPose170
+.4byte sPikachuPose171
+.4byte sPikachuPose172
+.4byte sPikachuPose173
+.4byte sPikachuPose174
+.4byte sPikachuPose175
+.4byte sPikachuPose176
+.4byte sPikachuPose177
+.4byte sPikachuPose178
+.4byte sPikachuPose179
+.4byte sPikachuPose180
+.4byte sPikachuPose181
+.4byte sPikachuPose182
+.4byte sPikachuPose183
+.4byte sPikachuPose184
+.4byte sPikachuPose185
+.4byte sPikachuPose186
+.4byte sPikachuPose187
+.4byte sPikachuPose188
+.4byte sPikachuPose189
+.4byte sPikachuPose190
+.4byte sPikachuPose191
+.4byte sPikachuPose192
+.4byte sPikachuPose193
+.4byte sPikachuPose194
+.4byte sPikachuPose195
+.4byte sPikachuPose196
+.4byte sPikachuPose197
+.4byte sPikachuPose198
+.4byte sPikachuPose199
+.4byte sPikachuPose200
+.4byte sPikachuPose201
+.4byte sPikachuPose202
+.4byte sPikachuPose203
+.4byte sPikachuPose204
+.4byte sPikachuPose205
+.4byte sPikachuPose206
+.4byte sPikachuPose207
+.4byte sPikachuPose208
+.4byte sPikachuPose209
+.4byte sPikachuPose210
+.4byte sPikachuPose211
+.4byte sPikachuPose212
+.4byte sPikachuPose213
+.4byte sPikachuPose214
+.4byte sPikachuPose215
+.4byte sPikachuPose216
+.4byte sPikachuPose217
+.4byte sPikachuPose218
+.4byte sPikachuPose219
+.4byte sPikachuPose220
+.4byte sPikachuPose221
+.4byte sPikachuPose222
+.4byte sPikachuPose223
+.4byte sPikachuPose224
+.4byte sPikachuPose225
+.4byte sPikachuPose226
+.4byte sPikachuPose227
+.4byte sPikachuPose228
+.4byte sPikachuPose229
+.4byte sPikachuPose230
+.4byte sPikachuPose231
+.4byte sPikachuPose232
+.4byte sPikachuPose233
+.4byte sPikachuPose234
+.4byte sPikachuPose235
+.4byte sPikachuPose236
+.4byte sPikachuPose237
+.4byte sPikachuPose238
+.4byte sPikachuPose239
+.4byte sPikachuPose240
+.4byte sPikachuPose241
+.4byte sPikachuPose242
+.4byte sPikachuPose243
+.4byte sPikachuPose244
+.4byte sPikachuPose245
+.4byte sPikachuPose246
+.4byte sPikachuPose247
+.4byte sPikachuPose248
+.4byte sPikachuPose249
+.4byte sPikachuPose250
+.4byte sPikachuPose251
+.4byte sPikachuPose252
+.4byte sPikachuPose253
+.4byte sPikachuPose254
+.4byte sPikachuPose255
+.4byte sPikachuPose256
+.4byte sPikachuPose257
+.4byte sPikachuPose258
+.4byte sPikachuPose259
+.4byte sPikachuPose260
+.4byte sPikachuPose261
+.4byte sPikachuPose262
+.4byte sPikachuPose263
+.4byte sPikachuPose264
+.4byte sPikachuPose265
+.4byte sPikachuPose266
+.4byte sPikachuPose267
+.4byte sPikachuPose268
+.4byte sPikachuPose269
+.4byte sPikachuPose270
+.4byte sPikachuPose271
+.4byte sPikachuPose272
+.4byte sPikachuPose273
+.4byte sPikachuPose274
+.4byte sPikachuPose275
+.4byte sPikachuPose276
+.4byte sPikachuPose277
+.4byte sPikachuPose278
+.4byte sPikachuPose279
+.4byte sPikachuPose280
+.4byte sPikachuPose281
+.4byte sPikachuPose282
+.4byte sPikachuPose283
+.4byte sPikachuPose284
+.4byte sPikachuPose285
+.4byte sPikachuPose286
+.4byte sPikachuPose287
+.4byte sPikachuPose288
+.4byte sPikachuPose289
+.4byte sPikachuPose290
+.4byte sPikachuPose291
+.4byte sPikachuPose292
+.4byte sPikachuPose293
+.4byte sPikachuPose294
+.4byte sPikachuPose295
+.4byte sPikachuPose296
+.4byte sPikachuPose297
+.4byte sPikachuPose298
+.4byte sPikachuPose299
+sAxPositionsPikachu:
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -5, 	   7,   -6, 	  -1,   -6
+.2byte   -1,   -9, 	  -9,   -7, 	   3,   -5, 	  -1,   -6
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte    3,   -9, 	   5,   -6, 	  -7,   -4, 	  -1,   -5
+.2byte    3,   -9, 	   7,   -8, 	  -1,   -4, 	  -1,   -7
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    5,   -8, 	  -1,   -6, 	   5,   -3, 	  -1,   -8
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    3,  -12, 	  -2,   -9, 	   4,   -2, 	   0,   -6
+.2byte    3,  -13, 	  -7,  -10, 	   8,   -6, 	  -1,   -6
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte   -2,  -13, 	   8,   -6, 	  -8,   -9, 	  -1,   -6
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -4,  -12, 	   1,   -9, 	  -5,   -2, 	  -1,   -6
+.2byte   -4,  -13, 	   6,  -10, 	  -9,   -6, 	   0,   -6
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -7,   -6, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -8, 	   0,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -4,   -9, 	  -6,   -6, 	   6,   -4, 	   0,   -5
+.2byte   -4,   -9, 	  -8,   -8, 	   0,   -4, 	   0,   -7
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	  -5,   -9, 	   7,  -10, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte    3,   -9, 	   5,   -6, 	  -7,   -4, 	  -1,   -5
+.2byte    3,   -9, 	   7,   -8, 	  -1,   -4, 	  -1,   -7
+.2byte    6,  -10, 	  11,  -11, 	   0,   -7, 	  -1,   -9
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    5,   -8, 	  -1,   -6, 	   5,   -3, 	  -1,   -8
+.2byte    8,   -9, 	   5,  -11, 	   5,   -6, 	   0,   -9
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    3,  -12, 	  -2,   -9, 	   4,   -2, 	   0,   -6
+.2byte    3,  -13, 	  -7,  -10, 	   8,   -6, 	  -1,   -6
+.2byte    7,  -15, 	   0,  -15, 	   8,  -11, 	  -1,  -10
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte   -2,  -13, 	   8,   -6, 	  -8,   -9, 	  -1,   -6
+.2byte   -1,  -17, 	   7,  -14, 	  -9,  -14, 	  -1,  -11
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -4,  -12, 	   1,   -9, 	  -5,   -2, 	  -1,   -6
+.2byte   -4,  -13, 	   6,  -10, 	  -9,   -6, 	   0,   -6
+.2byte   -8,  -15, 	  -1,  -15, 	  -9,  -11, 	   0,  -10
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -7,   -6, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -8, 	   0,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -9,   -9, 	  -6,  -11, 	  -6,   -6, 	  -1,   -9
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -4,   -9, 	  -6,   -6, 	   6,   -4, 	   0,   -5
+.2byte   -4,   -9, 	  -8,   -8, 	   0,   -4, 	   0,   -7
+.2byte   -7,  -10, 	 -12,  -11, 	  -1,   -7, 	   0,   -9
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	  -5,   -9, 	   7,  -10, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte    3,   -9, 	   5,   -6, 	  -7,   -4, 	  -1,   -5
+.2byte    3,   -9, 	   7,   -8, 	  -1,   -4, 	  -1,   -7
+.2byte    6,  -10, 	  11,  -11, 	   0,   -7, 	  -1,   -9
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    5,   -8, 	  -1,   -6, 	   5,   -3, 	  -1,   -8
+.2byte    8,   -9, 	   5,  -11, 	   5,   -6, 	   0,   -9
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    3,  -12, 	  -2,   -9, 	   4,   -2, 	   0,   -6
+.2byte    3,  -13, 	  -7,  -10, 	   8,   -6, 	  -1,   -6
+.2byte    7,  -15, 	   0,  -15, 	   8,  -11, 	  -1,  -10
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte   -2,  -13, 	   8,   -6, 	  -8,   -9, 	  -1,   -6
+.2byte   -1,  -17, 	   7,  -14, 	  -9,  -14, 	  -1,  -11
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -4,  -12, 	   1,   -9, 	  -5,   -2, 	  -1,   -6
+.2byte   -4,  -13, 	   6,  -10, 	  -9,   -6, 	   0,   -6
+.2byte   -8,  -15, 	  -1,  -15, 	  -9,  -11, 	   0,  -10
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -7,   -6, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -8, 	   0,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -9,   -9, 	  -6,  -11, 	  -6,   -6, 	  -1,   -9
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -4,   -9, 	  -6,   -6, 	   6,   -4, 	   0,   -5
+.2byte   -4,   -9, 	  -8,   -8, 	   0,   -4, 	   0,   -7
+.2byte   -7,  -10, 	 -12,  -11, 	  -1,   -7, 	   0,   -9
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte    4,  -11, 	   5,   -9, 	  -6,   -7, 	  -1,   -7
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    7,  -10, 	  -1,  -10, 	  -2,   -7, 	   1,   -8
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    5,  -14, 	  -6,  -11, 	   4,   -5, 	   0,   -9
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -2,  -15, 	   7,   -7, 	  -8,   -6, 	  -1,   -7
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -6,  -14, 	   5,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -8,  -10, 	   0,  -10, 	   1,   -7, 	  -2,   -8
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -5,  -11, 	  -6,   -9, 	   5,   -7, 	   0,   -7
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,   -8, 	  -4,   -6, 	   2,   -6, 	  -1,   -9
+.2byte   -1,   -8, 	  -4,   -6, 	   2,   -6, 	  -1,   -9
+.2byte   -1,   -8, 	  -4,   -6, 	   2,   -6, 	  -1,   -9
+.2byte   -1,   -8, 	  -4,   -6, 	   2,   -6, 	  -1,   -9
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte    4,  -11, 	   5,   -9, 	  -6,   -7, 	  -1,   -7
+.2byte    4,   -9, 	   7,   -7, 	   0,   -6, 	   0,   -7
+.2byte    4,   -9, 	   7,   -7, 	   0,   -6, 	   0,   -7
+.2byte    4,   -9, 	   7,   -7, 	   0,   -6, 	   0,   -7
+.2byte    4,   -9, 	   7,   -7, 	   0,   -6, 	   0,   -7
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    7,  -10, 	  -1,  -10, 	  -2,   -7, 	   1,   -8
+.2byte    6,   -7, 	   3,   -8, 	   2,   -5, 	   0,   -7
+.2byte    6,   -7, 	   3,   -8, 	   2,   -5, 	   0,   -7
+.2byte    6,   -7, 	   3,   -8, 	   2,   -5, 	   0,   -7
+.2byte    6,   -7, 	   3,   -8, 	   2,   -5, 	   0,   -7
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    5,  -14, 	  -6,  -11, 	   4,   -5, 	   0,   -9
+.2byte    3,  -12, 	   0,  -11, 	   6,   -7, 	  -1,   -7
+.2byte    3,  -12, 	   0,  -11, 	   6,   -7, 	  -1,   -7
+.2byte    3,  -12, 	   0,  -11, 	   6,   -7, 	  -1,   -7
+.2byte    3,  -12, 	   0,  -11, 	   6,   -7, 	  -1,   -7
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -2,  -15, 	   7,   -7, 	  -8,   -6, 	  -1,   -7
+.2byte   -2,  -13, 	   2,   -9, 	  -5,   -9, 	  -1,   -7
+.2byte   -2,  -13, 	   2,   -9, 	  -5,   -9, 	  -1,   -7
+.2byte   -2,  -13, 	   2,   -9, 	  -5,   -9, 	  -1,   -7
+.2byte   -2,  -13, 	   2,   -9, 	  -5,   -9, 	  -1,   -7
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -6,  -14, 	   5,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -1,  -11, 	  -7,   -7, 	   0,   -7
+.2byte   -4,  -12, 	  -1,  -11, 	  -7,   -7, 	   0,   -7
+.2byte   -4,  -12, 	  -1,  -11, 	  -7,   -7, 	   0,   -7
+.2byte   -4,  -12, 	  -1,  -11, 	  -7,   -7, 	   0,   -7
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -8,  -10, 	   0,  -10, 	   1,   -7, 	  -2,   -8
+.2byte   -7,   -7, 	  -4,   -8, 	  -3,   -5, 	  -1,   -7
+.2byte   -7,   -7, 	  -4,   -8, 	  -3,   -5, 	  -1,   -7
+.2byte   -7,   -7, 	  -4,   -8, 	  -3,   -5, 	  -1,   -7
+.2byte   -7,   -7, 	  -4,   -8, 	  -3,   -5, 	  -1,   -7
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -5,  -11, 	  -6,   -9, 	   5,   -7, 	   0,   -7
+.2byte   -5,   -9, 	  -8,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte   -5,   -9, 	  -8,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte   -5,   -9, 	  -8,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte   -5,   -9, 	  -8,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte   -3,   -7, 	  -5,   -5, 	   4,   -2, 	   1,   -6
+.2byte   -2,   -8, 	  -5,   -5, 	   3,   -3, 	   3,   -6
+.2byte   -1,  -11, 	  -9,  -10, 	   7,  -10, 	  -1,   -7
+.2byte    2,  -12, 	   5,  -12, 	  -9,  -10, 	  -1,   -8
+.2byte    4,  -10, 	  -3,  -12, 	  -4,   -9, 	  -1,   -7
+.2byte    2,  -13, 	  -5,  -12, 	   6,   -8, 	  -2,   -6
+.2byte   -2,  -13, 	   8,   -6, 	 -11,   -6, 	  -1,   -7
+.2byte   -3,  -13, 	   4,  -12, 	  -7,   -8, 	   1,   -6
+.2byte   -5,  -10, 	   2,  -12, 	   3,   -9, 	   0,   -7
+.2byte   -3,  -12, 	  -6,  -12, 	   8,  -10, 	   0,   -8
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte   -4,  -10, 	  -9,  -11, 	   2,   -7, 	   3,   -9
+.2byte   -8,   -9, 	  -5,  -11, 	  -5,   -6, 	   0,   -9
+.2byte   -7,  -14, 	   0,  -14, 	  -8,  -10, 	   1,   -9
+.2byte   -1,  -16, 	   7,  -13, 	  -9,  -13, 	  -1,  -10
+.2byte    6,  -14, 	  -1,  -14, 	   7,  -10, 	  -2,   -9
+.2byte    7,   -9, 	   4,  -11, 	   4,   -6, 	  -1,   -9
+.2byte    3,  -10, 	   8,  -11, 	  -3,   -7, 	  -4,   -9
+.2byte   -1,   -8, 	  -4,   -6, 	   2,   -6, 	  -1,   -9
+.2byte   -5,   -9, 	  -8,   -7, 	  -1,   -6, 	  -1,   -7
+.2byte   -7,   -7, 	  -4,   -8, 	  -3,   -5, 	  -1,   -7
+.2byte   -4,  -12, 	  -1,  -11, 	  -7,   -7, 	   0,   -7
+.2byte   -2,  -13, 	   2,   -9, 	  -5,   -9, 	  -1,   -7
+.2byte    3,  -12, 	   0,  -11, 	   6,   -7, 	  -1,   -7
+.2byte    6,   -7, 	   3,   -8, 	   2,   -5, 	   0,   -7
+.2byte    4,   -9, 	   7,   -7, 	   0,   -6, 	   0,   -7
+.2byte   -1,  -12, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte    4,  -11, 	   5,   -9, 	  -6,   -7, 	  -1,   -7
+.2byte    7,  -10, 	  -1,  -10, 	  -2,   -7, 	   1,   -8
+.2byte    5,  -14, 	  -6,  -11, 	   4,   -5, 	   0,   -9
+.2byte   -2,  -15, 	   7,   -7, 	  -8,   -6, 	  -1,   -7
+.2byte   -6,  -14, 	   5,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -8,  -10, 	   0,  -10, 	   1,   -7, 	  -2,   -8
+.2byte   -5,  -11, 	  -6,   -9, 	   5,   -7, 	   0,   -7
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	  -5,   -9, 	   7,  -10, 	  -1,  -10
+.2byte   -1,   -9, 	  -9,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte    3,   -9, 	   5,   -6, 	  -7,   -4, 	  -1,   -5
+.2byte    3,   -9, 	   7,   -8, 	  -1,   -4, 	  -1,   -7
+.2byte    5,  -10, 	  10,  -11, 	  -1,   -7, 	  -2,   -9
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    5,   -8, 	   6,   -6, 	  -2,   -3, 	   0,   -6
+.2byte    5,   -8, 	  -1,   -6, 	   5,   -3, 	  -1,   -8
+.2byte    7,   -9, 	   4,  -11, 	   4,   -6, 	  -1,   -9
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    3,  -12, 	  -2,   -9, 	   4,   -2, 	   0,   -6
+.2byte    3,  -13, 	  -7,  -10, 	   8,   -6, 	  -1,   -6
+.2byte    7,  -15, 	   0,  -15, 	   8,  -11, 	  -1,  -10
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte   -2,  -13, 	   8,   -6, 	  -8,   -9, 	  -1,   -6
+.2byte   -1,  -17, 	   7,  -14, 	  -9,  -14, 	  -1,  -11
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -4,  -12, 	   1,   -9, 	  -5,   -2, 	  -1,   -6
+.2byte   -4,  -13, 	   6,  -10, 	  -9,   -6, 	   0,   -6
+.2byte   -8,  -15, 	  -1,  -15, 	  -9,  -11, 	   0,  -10
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -7,   -6, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -8, 	   0,   -6, 	  -6,   -3, 	   0,   -8
+.2byte   -8,   -9, 	  -5,  -11, 	  -5,   -6, 	   0,   -9
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -4,   -9, 	  -6,   -6, 	   6,   -4, 	   0,   -5
+.2byte   -4,   -9, 	  -8,   -8, 	   0,   -4, 	   0,   -7
+.2byte   -6,  -10, 	 -11,  -11, 	   0,   -7, 	   1,   -9
+.2byte   -1,  -12, 	  -8,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,  -11, 	  -6,   -9, 	   5,   -7, 	   0,   -7
+.2byte   -8,  -10, 	   0,  -10, 	   1,   -7, 	  -2,   -8
+.2byte   -6,  -14, 	   5,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -2,  -15, 	   7,   -7, 	  -8,   -6, 	  -1,   -7
+.2byte    5,  -14, 	  -6,  -11, 	   4,   -5, 	   0,   -9
+.2byte    7,  -10, 	  -1,  -10, 	  -2,   -7, 	   1,   -8
+.2byte    4,  -11, 	   5,   -9, 	  -6,   -7, 	  -1,   -7
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -4,  -10, 	  -7,   -6, 	   2,   -4, 	  -1,   -6
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -5,  -13, 	   3,   -9, 	  -7,   -4, 	   0,   -6
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte    4,  -13, 	  -4,   -9, 	   6,   -4, 	  -1,   -6
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    3,  -10, 	   6,   -6, 	  -3,   -4, 	   0,   -6
+.2byte   -1,   -9, 	  -3,    1, 	   0,   -7, 	  -1,   -3
+.2byte   -2,   -9, 	  -3,    1, 	   0,   -7, 	  -1,   -3
+.2byte    0,   -9, 	   2,    1, 	  -1,   -7, 	   0,   -3
+.2byte    1,   -9, 	   2,    1, 	  -1,   -7, 	   0,   -3
+.2byte   -1,   -9, 	  -3,    1, 	   0,   -7, 	  -1,   -3
+.2byte    2,   -7, 	   1,   -5, 	   5,   -8, 	  -1,   -5
+.2byte    7,   -6, 	   3,   -3, 	   5,   -4, 	   0,   -7
+.2byte    8,   -7, 	   4,   -3, 	   4,   -4, 	   1,   -8
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -1,  -11, 	   7,   -7, 	  -9,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   8,  -10, 	 -11,  -10, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -6, 	   2,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	  -9,  -11, 	   7,  -11, 	  -1,  -10
+.2byte   -3,   -8, 	  -8,   -6, 	   3,   -5, 	  -1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    1,  -11, 	  -7,  -14, 	   8,   -6, 	   1,   -8
+.2byte    2,  -11, 	   7,   -9, 	  -6,   -9, 	   0,   -7
+.2byte   -2,  -13, 	   8,  -15, 	  -9,   -6, 	   1,   -9
+.2byte   -2,  -13, 	   8,  -15, 	  -9,   -6, 	   1,   -9
+.2byte   -1,   -9, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -4,  -12, 	  -7,  -11, 	  -2,   -7, 	   1,   -8
+.2byte   -2,  -11, 	  -7,  -11, 	   6,   -6, 	   2,   -6
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -3,  -10, 	   5,   -5, 	  -7,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -10, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,  -14, 	  -9,  -11, 	   7,  -11, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -4, 	   2,   -4, 	  -1,   -7
+.2byte   -6,   -9, 	  -3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -6,   -4, 	   0,   -6, 	   1,   -5, 	  -2,   -8
+.2byte    5,   -9, 	   2,   -6, 	   1,   -4, 	  -1,   -7
+.2byte    5,   -4, 	  -1,   -6, 	  -2,   -5, 	   1,   -8
+.2byte   -2,  -13, 	   4,   -6, 	  -7,   -7, 	  -2,   -7
+.2byte   -1,   -8, 	   7,   -8, 	 -10,   -8, 	  -1,   -6
+.2byte   -6,   -7, 	   3,   -5, 	   2,   -7, 	  -1,   -8
+.2byte   -6,   -9, 	  -7,   -8, 	   3,   -6, 	   0,   -8
+.2byte  -10,   -7, 	  -6,   -6, 	  -1,   -6, 	  -3,   -7
+.2byte   -5,   -9, 	  -1,   -7, 	  -2,   -6, 	   0,   -9
+.2byte   -8,   -6, 	  -1,   -6, 	  -2,   -5, 	  -3,   -7
+.2byte    5,   -7, 	  -4,   -5, 	  -3,   -7, 	   0,   -8
+.2byte    5,   -9, 	   6,   -8, 	  -4,   -6, 	  -1,   -8
+.2byte    9,   -7, 	   5,   -6, 	   0,   -6, 	   2,   -7
+.2byte    4,   -9, 	   0,   -7, 	   1,   -6, 	  -1,   -9
+.2byte    7,   -6, 	   0,   -6, 	   1,   -5, 	   2,   -7
+.2byte    1,   -9, 	  -1,   -8, 	   5,   -9, 	  -2,   -9
+.2byte   -1,   -9, 	  -3,    1, 	   0,   -7, 	  -1,   -3
+.2byte   -2,   -9, 	  -3,    1, 	   0,   -7, 	  -1,   -3
+.2byte    0,   -9, 	   2,    1, 	  -1,   -7, 	   0,   -3
+.2byte    1,   -9, 	   2,    1, 	  -1,   -7, 	   0,   -3
+.2byte   -1,   -9, 	  -3,    1, 	   0,   -7, 	  -1,   -3
+.2byte   -2,   -9, 	  -3,    1, 	   0,   -7, 	  -1,   -3
+.2byte    0,   -9, 	   2,    1, 	  -1,   -7, 	   0,   -3
+.2byte    1,   -9, 	   2,    1, 	  -1,   -7, 	   0,   -3
+sPikachuAnimTable1:
+.4byte sPikachuAnims_1_1
+.4byte sPikachuAnims_1_2
+.4byte sPikachuAnims_1_3
+.4byte sPikachuAnims_1_4
+.4byte sPikachuAnims_1_5
+.4byte sPikachuAnims_1_6
+.4byte sPikachuAnims_1_7
+.4byte sPikachuAnims_1_8
+sPikachuAnimTable2:
+.4byte sPikachuAnims_2_1
+.4byte sPikachuAnims_2_2
+.4byte sPikachuAnims_2_3
+.4byte sPikachuAnims_2_4
+.4byte sPikachuAnims_2_5
+.4byte sPikachuAnims_2_6
+.4byte sPikachuAnims_2_7
+.4byte sPikachuAnims_2_8
+sPikachuAnimTable3:
+.4byte sPikachuAnims_3_1
+.4byte sPikachuAnims_3_2
+.4byte sPikachuAnims_3_3
+.4byte sPikachuAnims_3_4
+.4byte sPikachuAnims_3_5
+.4byte sPikachuAnims_3_6
+.4byte sPikachuAnims_3_7
+.4byte sPikachuAnims_3_8
+sPikachuAnimTable4:
+.4byte sPikachuAnims_4_1
+.4byte sPikachuAnims_4_2
+.4byte sPikachuAnims_4_3
+.4byte sPikachuAnims_4_4
+.4byte sPikachuAnims_4_5
+.4byte sPikachuAnims_4_6
+.4byte sPikachuAnims_4_7
+.4byte sPikachuAnims_4_8
+sPikachuAnimTable5:
+.4byte sPikachuAnims_5_1
+.4byte sPikachuAnims_5_2
+.4byte sPikachuAnims_5_3
+.4byte sPikachuAnims_5_4
+.4byte sPikachuAnims_5_5
+.4byte sPikachuAnims_5_6
+.4byte sPikachuAnims_5_7
+.4byte sPikachuAnims_5_8
+sPikachuAnimTable6:
+.4byte sPikachuAnims_6_1
+.4byte sPikachuAnims_6_1
+.4byte sPikachuAnims_6_1
+.4byte sPikachuAnims_6_1
+.4byte sPikachuAnims_6_1
+.4byte sPikachuAnims_6_1
+.4byte sPikachuAnims_6_1
+.4byte sPikachuAnims_6_1
+sPikachuAnimTable7:
+.4byte sPikachuAnims_7_1
+.4byte sPikachuAnims_7_2
+.4byte sPikachuAnims_7_3
+.4byte sPikachuAnims_7_4
+.4byte sPikachuAnims_7_5
+.4byte sPikachuAnims_7_6
+.4byte sPikachuAnims_7_7
+.4byte sPikachuAnims_7_8
+sPikachuAnimTable8:
+.4byte sPikachuAnims_8_1
+.4byte sPikachuAnims_8_2
+.4byte sPikachuAnims_8_3
+.4byte sPikachuAnims_8_4
+.4byte sPikachuAnims_8_5
+.4byte sPikachuAnims_8_6
+.4byte sPikachuAnims_8_7
+.4byte sPikachuAnims_8_8
+sPikachuAnimTable9:
+.4byte sPikachuAnims_9_1
+.4byte sPikachuAnims_9_2
+.4byte sPikachuAnims_9_3
+.4byte sPikachuAnims_9_4
+.4byte sPikachuAnims_9_5
+.4byte sPikachuAnims_9_6
+.4byte sPikachuAnims_9_7
+.4byte sPikachuAnims_9_8
+sPikachuAnimTable10:
+.4byte sPikachuAnims_10_1
+.4byte sPikachuAnims_10_2
+.4byte sPikachuAnims_10_3
+.4byte sPikachuAnims_10_4
+.4byte sPikachuAnims_10_5
+.4byte sPikachuAnims_10_6
+.4byte sPikachuAnims_10_7
+.4byte sPikachuAnims_10_8
+sPikachuAnimTable11:
+.4byte sPikachuAnims_11_1
+.4byte sPikachuAnims_11_2
+.4byte sPikachuAnims_11_3
+.4byte sPikachuAnims_11_4
+.4byte sPikachuAnims_11_5
+.4byte sPikachuAnims_11_6
+.4byte sPikachuAnims_11_7
+.4byte sPikachuAnims_11_8
+sPikachuAnimTable12:
+.4byte sPikachuAnims_12_1
+.4byte sPikachuAnims_12_2
+.4byte sPikachuAnims_12_3
+.4byte sPikachuAnims_12_4
+.4byte sPikachuAnims_12_5
+.4byte sPikachuAnims_12_6
+.4byte sPikachuAnims_12_7
+.4byte sPikachuAnims_12_8
+sPikachuAnimTable13:
+.4byte sPikachuAnims_13_1
+.4byte sPikachuAnims_13_2
+.4byte sPikachuAnims_13_3
+.4byte sPikachuAnims_13_4
+.4byte sPikachuAnims_13_5
+.4byte sPikachuAnims_13_6
+.4byte sPikachuAnims_13_7
+.4byte sPikachuAnims_13_8
+sPikachuAnimTable14:
+.4byte sPikachuAnims_14_1
+.4byte sPikachuAnims_14_2
+.4byte sPikachuAnims_14_3
+.4byte sPikachuAnims_14_4
+.4byte sPikachuAnims_14_5
+.4byte sPikachuAnims_14_6
+.4byte sPikachuAnims_14_7
+.4byte sPikachuAnims_14_8
+sPikachuAnimTable15:
+.4byte sPikachuAnims_15_1
+.4byte sPikachuAnims_15_2
+.4byte sPikachuAnims_15_3
+.4byte sPikachuAnims_15_4
+.4byte sPikachuAnims_15_5
+.4byte sPikachuAnims_15_6
+.4byte sPikachuAnims_15_7
+.4byte sPikachuAnims_15_8
+sPikachuAnimTable16:
+.4byte sPikachuAnims_16_1
+.4byte sPikachuAnims_16_2
+.4byte sPikachuAnims_16_3
+.4byte sPikachuAnims_16_4
+.4byte sPikachuAnims_16_5
+.4byte sPikachuAnims_16_6
+.4byte sPikachuAnims_16_7
+.4byte sPikachuAnims_16_8
+sPikachuAnimTable17:
+.4byte sPikachuAnims_17_1
+.4byte sPikachuAnims_17_2
+.4byte sPikachuAnims_17_3
+.4byte sPikachuAnims_17_4
+.4byte sPikachuAnims_17_5
+.4byte sPikachuAnims_17_6
+.4byte sPikachuAnims_17_7
+.4byte sPikachuAnims_17_8
+sPikachuAnimTable18:
+.4byte sPikachuAnims_18_1
+.4byte sPikachuAnims_18_2
+.4byte sPikachuAnims_18_3
+.4byte sPikachuAnims_18_4
+.4byte sPikachuAnims_18_5
+.4byte sPikachuAnims_18_6
+.4byte sPikachuAnims_18_7
+.4byte sPikachuAnims_18_8
+sPikachuAnimTable19:
+.4byte sPikachuAnims_19_1
+.4byte sPikachuAnims_19_2
+.4byte sPikachuAnims_19_3
+.4byte sPikachuAnims_19_4
+.4byte sPikachuAnims_19_5
+.4byte sPikachuAnims_19_6
+.4byte sPikachuAnims_19_7
+.4byte sPikachuAnims_19_8
+sPikachuAnimTable20:
+.4byte sPikachuAnims_20_1
+.4byte sPikachuAnims_20_2
+.4byte sPikachuAnims_20_3
+.4byte sPikachuAnims_20_4
+.4byte sPikachuAnims_20_5
+.4byte sPikachuAnims_20_6
+.4byte sPikachuAnims_20_7
+.4byte sPikachuAnims_20_8
+sPikachuAnimTable21:
+.4byte sPikachuAnims_21_1
+.4byte sPikachuAnims_21_2
+.4byte sPikachuAnims_21_3
+.4byte sPikachuAnims_21_4
+.4byte sPikachuAnims_21_5
+.4byte sPikachuAnims_21_6
+.4byte sPikachuAnims_21_7
+.4byte sPikachuAnims_21_8
+sPikachuAnimTable22:
+.4byte sPikachuAnims_22_1
+.4byte sPikachuAnims_22_2
+.4byte sPikachuAnims_22_3
+.4byte sPikachuAnims_22_4
+.4byte sPikachuAnims_22_5
+.4byte sPikachuAnims_22_6
+.4byte sPikachuAnims_22_7
+.4byte sPikachuAnims_22_8
+sPikachuAnimTable23:
+.4byte sPikachuAnims_23_1
+.4byte sPikachuAnims_23_2
+.4byte sPikachuAnims_23_3
+.4byte sPikachuAnims_23_4
+.4byte sPikachuAnims_23_5
+.4byte sPikachuAnims_23_6
+.4byte sPikachuAnims_23_7
+.4byte sPikachuAnims_23_8
+sPikachuAnimTable24:
+.4byte sPikachuAnims_24_1
+.4byte sPikachuAnims_24_2
+.4byte sPikachuAnims_24_3
+.4byte sPikachuAnims_24_4
+.4byte sPikachuAnims_24_5
+.4byte sPikachuAnims_24_6
+.4byte sPikachuAnims_24_7
+.4byte sPikachuAnims_24_8
+sPikachuAnimTable25:
+.4byte sPikachuAnims_25_1
+.4byte sPikachuAnims_25_2
+.4byte sPikachuAnims_25_3
+.4byte sPikachuAnims_25_4
+.4byte sPikachuAnims_25_5
+.4byte sPikachuAnims_25_6
+.4byte sPikachuAnims_25_7
+.4byte sPikachuAnims_25_8
+sPikachuAnimTable26:
+.4byte sPikachuAnims_26_1
+.4byte sPikachuAnims_26_2
+.4byte sPikachuAnims_26_3
+.4byte sPikachuAnims_26_4
+.4byte sPikachuAnims_26_5
+.4byte sPikachuAnims_26_6
+.4byte sPikachuAnims_26_7
+.4byte sPikachuAnims_26_8
+sPikachuAnimTable27:
+.4byte sPikachuAnims_27_1
+.4byte sPikachuAnims_27_1
+.4byte sPikachuAnims_27_1
+.4byte sPikachuAnims_27_1
+.4byte sPikachuAnims_27_1
+.4byte sPikachuAnims_27_1
+.4byte sPikachuAnims_27_1
+.4byte sPikachuAnims_27_1
+sPikachuAnimTable28:
+.4byte sPikachuAnims_28_1
+.4byte sPikachuAnims_28_2
+.4byte sPikachuAnims_28_3
+.4byte sPikachuAnims_28_4
+.4byte sPikachuAnims_28_5
+.4byte sPikachuAnims_28_6
+.4byte sPikachuAnims_28_7
+.4byte sPikachuAnims_28_8
+sAxAnimationsPikachu:
+.4byte sPikachuAnimTable1
+.4byte sPikachuAnimTable2
+.4byte sPikachuAnimTable3
+.4byte sPikachuAnimTable4
+.4byte sPikachuAnimTable5
+.4byte sPikachuAnimTable6
+.4byte sPikachuAnimTable7
+.4byte sPikachuAnimTable8
+.4byte sPikachuAnimTable9
+.4byte sPikachuAnimTable10
+.4byte sPikachuAnimTable11
+.4byte sPikachuAnimTable12
+.4byte sPikachuAnimTable13
+.4byte sPikachuAnimTable14
+.4byte sPikachuAnimTable15
+.4byte sPikachuAnimTable16
+.4byte sPikachuAnimTable17
+.4byte sPikachuAnimTable18
+.4byte sPikachuAnimTable19
+.4byte sPikachuAnimTable20
+.4byte sPikachuAnimTable21
+.4byte sPikachuAnimTable22
+.4byte sPikachuAnimTable23
+.4byte sPikachuAnimTable24
+.4byte sPikachuAnimTable25
+.4byte sPikachuAnimTable26
+.4byte sPikachuAnimTable27
+.4byte sPikachuAnimTable28
+sAxSpritesPikachu:
+.4byte sPikachuSprites1
+.4byte sPikachuSprites2
+.4byte sPikachuSprites3
+.4byte sPikachuSprites4
+.4byte sPikachuSprites5
+.4byte sPikachuSprites6
+.4byte sPikachuSprites7
+.4byte sPikachuSprites8
+.4byte sPikachuSprites9
+.4byte sPikachuSprites10
+.4byte sPikachuSprites11
+.4byte sPikachuSprites12
+.4byte sPikachuSprites13
+.4byte sPikachuSprites14
+.4byte sPikachuSprites15
+.4byte sPikachuSprites16
+.4byte sPikachuSprites17
+.4byte sPikachuSprites18
+.4byte sPikachuSprites19
+.4byte sPikachuSprites20
+.4byte sPikachuSprites21
+.4byte sPikachuSprites22
+.4byte sPikachuSprites23
+.4byte sPikachuSprites24
+.4byte sPikachuSprites25
+.4byte sPikachuSprites26
+.4byte sPikachuSprites27
+.4byte sPikachuSprites28
+.4byte sPikachuSprites29
+.4byte sPikachuSprites30
+.4byte sPikachuSprites31
+.4byte sPikachuSprites32
+.4byte sPikachuSprites33
+.4byte sPikachuSprites34
+.4byte sPikachuSprites35
+.4byte sPikachuSprites36
+.4byte sPikachuSprites37
+.4byte sPikachuSprites38
+.4byte sPikachuSprites39
+.4byte sPikachuSprites40
+.4byte sPikachuSprites41
+.4byte sPikachuSprites42
+.4byte sPikachuSprites43
+.4byte sPikachuSprites44
+.4byte sPikachuSprites45
+.4byte sPikachuSprites46
+.4byte sPikachuSprites47
+.4byte sPikachuSprites48
+.4byte sPikachuSprites49
+.4byte sPikachuSprites50
+.4byte sPikachuSprites51
+.4byte sPikachuSprites52
+.4byte sPikachuSprites53
+.4byte sPikachuSprites54
+.4byte sPikachuSprites55
+.4byte sPikachuSprites56
+.4byte sPikachuSprites57
+.4byte sPikachuSprites58
+.4byte sPikachuSprites59
+.4byte sPikachuSprites60
+.4byte sPikachuSprites61
+.4byte sPikachuSprites62
+.4byte sPikachuSprites63
+.4byte sPikachuSprites64
+.4byte sPikachuSprites65
+.4byte sPikachuSprites66
+.4byte sPikachuSprites67
+.4byte sPikachuSprites68
+.4byte sPikachuSprites69
+.4byte sPikachuSprites70
+.4byte sPikachuSprites71
+.4byte sPikachuSprites72
+.4byte sPikachuSprites73
+.4byte sPikachuSprites74
+.4byte sPikachuSprites75
+.4byte sPikachuSprites76
+.4byte sPikachuSprites77
+.4byte sPikachuSprites78
+.4byte sPikachuSprites79
+.4byte sPikachuSprites80
+.4byte sPikachuSprites81
+.4byte sPikachuSprites82
+.4byte sPikachuSprites83
+.4byte sPikachuSprites84
+.4byte sPikachuSprites85
+.4byte sPikachuSprites86
+.4byte sPikachuSprites87
+.4byte sPikachuSprites88
+.4byte sPikachuSprites89
+.4byte sPikachuSprites90
+.4byte sPikachuSprites91
+.4byte sPikachuSprites92
+sAxMainPikachu:
+ax_main sAxPosesPikachu, sAxAnimationsPikachu, 28, sAxSpritesPikachu, sAxPositionsPikachu

--- a/data/ax/piloswine.inc
+++ b/data/ax/piloswine.inc
@@ -1,0 +1,2398 @@
+.global gAxPiloswine
+gAxPiloswine:
+ax_siro sAxMainPiloswine
+sPiloswinePose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose4:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose5:
+ax_pose 4, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose6:
+ax_pose 5, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose7:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose8:
+ax_pose 7, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose9:
+ax_pose 8, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose10:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose12:
+ax_pose 11, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose28:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose29:
+ax_pose 4, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose30:
+ax_pose 5, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose31:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose32:
+ax_pose 7, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose33:
+ax_pose 8, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose34:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose35:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose36:
+ax_pose 11, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose41:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose43:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose44:
+ax_pose 7, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose45:
+ax_pose 8, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose47:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose48:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose50:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose51:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose52:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose53:
+ax_pose 4, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose54:
+ax_pose 5, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose55:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose56:
+ax_pose 7, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose57:
+ax_pose 8, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose58:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose59:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose60:
+ax_pose 11, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose61:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose62:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose63:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose64:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose65:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose66:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose67:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose68:
+ax_pose 7, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose69:
+ax_pose 8, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose71:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose72:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose73:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose74:
+ax_pose 15, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose75:
+ax_pose 16, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose76:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose77:
+ax_pose 17, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose78:
+ax_pose 18, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose79:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose80:
+ax_pose 19, 0x01e6, 0x90f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose81:
+ax_pose 20, 0x01e6, 0x90f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose82:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose83:
+ax_pose 21, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose84:
+ax_pose 22, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose85:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose86:
+ax_pose 23, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose87:
+ax_pose 24, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose88:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose89:
+ax_pose 21, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose90:
+ax_pose 22, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose91:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose92:
+ax_pose 19, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose93:
+ax_pose 20, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose94:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose95:
+ax_pose 17, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose96:
+ax_pose 18, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose97:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose98:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose99:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose100:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose102:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose103:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose104:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose105:
+ax_pose 25, 0x01ed, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose106:
+ax_pose 26, 0x01ed, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose107:
+ax_pose 27, 0x01e0, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose108:
+ax_pose 28, 0x01e2, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose109:
+ax_pose 29, 0x01e2, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose110:
+ax_pose 30, 0x01e4, 0x90ee, 0x1c00
+ax_pose_terminator
+sPiloswinePose111:
+ax_pose 31, 0x01e5, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose112:
+ax_pose 30, 0x01e4, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose113:
+ax_pose 29, 0x01e2, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose114:
+ax_pose 28, 0x01e2, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose115:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose116:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose117:
+ax_pose 2, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose118:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose119:
+ax_pose 4, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose120:
+ax_pose 5, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose121:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose122:
+ax_pose 7, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose123:
+ax_pose 8, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose124:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose125:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose126:
+ax_pose 11, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose127:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose128:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose129:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose130:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose131:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose132:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose133:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose134:
+ax_pose 7, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose135:
+ax_pose 8, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose136:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose137:
+ax_pose 4, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose138:
+ax_pose 5, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose139:
+ax_pose 16, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose140:
+ax_pose 18, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose141:
+ax_pose 20, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose142:
+ax_pose 22, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose143:
+ax_pose 24, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose144:
+ax_pose 22, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose145:
+ax_pose 20, 0x01e6, 0x90f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose146:
+ax_pose 18, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose147:
+ax_pose 15, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose148:
+ax_pose 17, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose149:
+ax_pose 19, 0x01e6, 0x90f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose150:
+ax_pose 21, 0x01e6, 0x90ee, 0x1c00
+ax_pose_terminator
+sPiloswinePose151:
+ax_pose 23, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose152:
+ax_pose 21, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose153:
+ax_pose 19, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose154:
+ax_pose 17, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose155:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose156:
+ax_pose 15, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose157:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose158:
+ax_pose 17, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose159:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose160:
+ax_pose 19, 0x01e7, 0x90f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose161:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose162:
+ax_pose 21, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose163:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose164:
+ax_pose 23, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose165:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose166:
+ax_pose 21, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose167:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose168:
+ax_pose 19, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose169:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose170:
+ax_pose 17, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose171:
+ax_pose 16, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose172:
+ax_pose 18, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose173:
+ax_pose 20, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose174:
+ax_pose 22, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose175:
+ax_pose 24, 0x01e8, 0x80f2, 0x1c00
+ax_pose_terminator
+sPiloswinePose176:
+ax_pose 22, 0x01e7, 0x90ee, 0x1c00
+ax_pose_terminator
+sPiloswinePose177:
+ax_pose 20, 0x01e6, 0x90f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose178:
+ax_pose 18, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sPiloswinePose179:
+ax_pose 0, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose180:
+ax_pose 3, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose181:
+ax_pose 6, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPiloswinePose182:
+ax_pose 9, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose183:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPiloswinePose184:
+ax_pose 9, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPiloswinePose185:
+ax_pose 6, 0x01ec, 0x90f1, 0x1c00
+ax_pose_terminator
+sPiloswinePose186:
+ax_pose 3, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+.align 2
+sPiloswineAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPiloswineAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 18, 20, 18, 20,
+ax_anim 2, 1, 27, 19, 19, 19, 19,
+ax_anim 2, 0, 27, 18, 20, 18, 20,
+ax_anim 2, 0, 27, 19, 19, 19, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sPiloswineAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sPiloswineAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 33, 19, -20, 19, -20,
+ax_anim 2, 1, 33, 20, -19, 20, -19,
+ax_anim 2, 0, 33, 19, -20, 19, -20,
+ax_anim 2, 0, 33, 20, -19, 20, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sPiloswineAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 1, 36, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 0, 36, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sPiloswineAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -9, -10, -9, -10,
+ax_anim 2, 0, 39, -17, -20, -17, -20,
+ax_anim 2, 1, 39, -18, -19, -18, -19,
+ax_anim 2, 0, 39, -17, -20, -17, -20,
+ax_anim 2, 0, 39, -18, -19, -18, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sPiloswineAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sPiloswineAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -18, 20, -18, 20,
+ax_anim 2, 1, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -18, 20, -18, 20,
+ax_anim 2, 0, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sPiloswineAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 18, 20, 18, 20,
+ax_anim 2, 1, 51, 19, 19, 19, 19,
+ax_anim 2, 0, 51, 18, 20, 18, 20,
+ax_anim 2, 0, 51, 19, 19, 19, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sPiloswineAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 1, 54, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 18, 0, 18, 0,
+ax_anim 2, 0, 54, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sPiloswineAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -4, 4, -4,
+ax_anim 1, 0, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 57, 19, -20, 19, -20,
+ax_anim 2, 1, 57, 20, -19, 20, -19,
+ax_anim 2, 0, 57, 19, -20, 19, -20,
+ax_anim 2, 0, 57, 20, -19, 20, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sPiloswineAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 60, 0, -19, 0, -19,
+ax_anim 2, 1, 60, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -19, 0, -19,
+ax_anim 2, 0, 60, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sPiloswineAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -4, -4, -4,
+ax_anim 1, 0, 65, -9, -10, -9, -10,
+ax_anim 2, 0, 63, -17, -20, -17, -20,
+ax_anim 2, 1, 63, -18, -19, -18, -19,
+ax_anim 2, 0, 63, -17, -20, -17, -20,
+ax_anim 2, 0, 63, -18, -19, -18, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sPiloswineAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 1, 66, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sPiloswineAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -18, 20, -18, 20,
+ax_anim 2, 1, 69, -19, 19, -19, 19,
+ax_anim 2, 0, 69, -18, 20, -18, 20,
+ax_anim 2, 0, 69, -19, 19, -19, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_4_1:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 73, -1, 0, -1, 0,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, -1, 0, -1, 0,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_4_2:
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 76, -1, 1, -1, 1,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, -1, 1, -1, 1,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_4_3:
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 2, 79, -1, 0, -1, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, -1, 0, -1, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_4_4:
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -1, -1, -1, -1,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 82, -1, -1, -1, -1,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_4_5:
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -1, 0, -1, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 85, -1, 0, -1, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_4_6:
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 2, 88, 1, -1, 1, -1,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 1, -1, 1, -1,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_4_7:
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 2, 91, 1, 0, 1, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 1, 0, 1, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_4_8:
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 2, 94, 1, 1, 1, 1,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 1, 1, 1, 1,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sPiloswineAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sPiloswineAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sPiloswineAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sPiloswineAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sPiloswineAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sPiloswineAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sPiloswineAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_8_1:
+ax_anim 40, 0, 114, 0, 0, 0, 0,
+ax_anim 8, 0, 115, 0, -1, 0, 0,
+ax_anim 8, 0, 116, 0, -1, 0, 0,
+ax_anim 8, 0, 115, 0, -1, 0, 0,
+ax_anim 8, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_8_2:
+ax_anim 40, 0, 117, 0, 0, 0, 0,
+ax_anim 8, 0, 118, 0, -1, 0, 0,
+ax_anim 8, 0, 119, 0, -1, 0, 0,
+ax_anim 8, 0, 118, 0, -1, 0, 0,
+ax_anim 8, 0, 119, 0, -1, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_8_3:
+ax_anim 40, 0, 120, 0, 0, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim 8, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_8_4:
+ax_anim 40, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim 8, 0, 125, 0, -1, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim 8, 0, 125, 0, -1, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_8_5:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_8_6:
+ax_anim 40, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, -1, 0, 0,
+ax_anim 8, 0, 131, 0, -1, 0, 0,
+ax_anim 8, 0, 130, 0, -1, 0, 0,
+ax_anim 8, 0, 131, 0, -1, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_8_7:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim 8, 0, 133, 0, -1, 0, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_8_8:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 8, 4, 8, 4,
+ax_anim 2, 0, 140, 12, 10, 12, 10,
+ax_anim 2, 0, 141, 9, 19, 9, 19,
+ax_anim 3, 0, 142, 0, 22, 0, 22,
+ax_anim 2, 3, 143, -9, 18, -9, 18,
+ax_anim 2, 0, 144, -12, 10, -12, 10,
+ax_anim 1, 0, 145, -8, 4, -8, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 21, 11, 21, 11,
+ax_anim 3, 0, 141, 20, 20, 20, 20,
+ax_anim 2, 3, 142, 8, 21, 8, 21,
+ax_anim 2, 0, 143, 1, 15, 1, 15,
+ax_anim 1, 0, 144, -1, 7, -1, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 10, -7, 10, -7,
+ax_anim 2, 0, 139, 17, -3, 17, -3,
+ax_anim 3, 0, 140, 20, 2, 20, 2,
+ax_anim 2, 3, 141, 16, 6, 16, 6,
+ax_anim 2, 0, 142, 11, 7, 11, 7,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 2, -15, 2, -15,
+ax_anim 2, 0, 138, 11, -20, 11, -20,
+ax_anim 3, 0, 139, 20, -20, 20, -20,
+ax_anim 2, 3, 140, 21, -14, 21, -14,
+ax_anim 2, 0, 141, 16, -4, 16, -4,
+ax_anim 1, 0, 142, 8, 0, 8, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -9, -3, -9, -3,
+ax_anim 2, 0, 144, -12, -11, -12, -11,
+ax_anim 2, 0, 145, -8, -19, -8, -19,
+ax_anim 3, 0, 138, 0, -21, 0, -21,
+ax_anim 2, 3, 139, 8, -19, 8, -19,
+ax_anim 2, 0, 140, 12, -11, 12, -11,
+ax_anim 1, 0, 141, 9, -3, 9, -3,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -2, -15, -2, -15,
+ax_anim 2, 0, 138, -11, -20, -11, -20,
+ax_anim 3, 0, 145, -20, -20, -20, -20,
+ax_anim 2, 3, 144, -21, -14, -21, -14,
+ax_anim 2, 0, 143, -16, -4, -16, -4,
+ax_anim 1, 0, 142, -8, 0, -8, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -10, -7, -10, -7,
+ax_anim 2, 0, 145, -17, -3, -17, -3,
+ax_anim 3, 0, 144, -20, 2, -20, 2,
+ax_anim 2, 3, 143, -16, 6, -16, 6,
+ax_anim 2, 0, 142, -11, 7, -11, 7,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -21, 11, -21, 11,
+ax_anim 3, 0, 143, -20, 20, -20, 20,
+ax_anim 2, 3, 142, -8, 21, -8, 21,
+ax_anim 2, 0, 141, -1, 15, -1, 15,
+ax_anim 1, 0, 140, 1, 7, 1, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 155, 0, -22, 0, 0,
+ax_anim 3, 0, 155, 0, -21, 0, 0,
+ax_anim 2, 0, 155, 0, -18, 0, 0,
+ax_anim 1, 0, 155, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_11_2:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -21, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_11_3:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -22, 0, 0,
+ax_anim 3, 0, 159, 0, -21, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_11_4:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -22, 0, 0,
+ax_anim 3, 0, 161, 0, -21, 0, 0,
+ax_anim 2, 0, 161, 0, -17, 0, 0,
+ax_anim 1, 0, 161, 0, -11, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_11_5:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -21, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_11_6:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_11_7:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -22, 0, 0,
+ax_anim 3, 0, 167, 0, -21, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_11_8:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPiloswineAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPiloswineGfx1:
+.incbin "baserom.gba", 0xEF790C, 0x200
+sPiloswineSprites1:
+ax_sprite sPiloswineGfx1, 0x200
+ax_sprite_terminator
+sPiloswineGfx2:
+.incbin "baserom.gba", 0xEF7B1C, 0x200
+sPiloswineSprites2:
+ax_sprite sPiloswineGfx2, 0x200
+ax_sprite_terminator
+sPiloswineGfx3:
+.incbin "baserom.gba", 0xEF7D2C, 0x200
+sPiloswineSprites3:
+ax_sprite sPiloswineGfx3, 0x200
+ax_sprite_terminator
+sPiloswineGfx4:
+.incbin "baserom.gba", 0xEF7F3C, 0x200
+sPiloswineSprites4:
+ax_sprite sPiloswineGfx4, 0x200
+ax_sprite_terminator
+sPiloswineGfx5:
+.incbin "baserom.gba", 0xEF814C, 0x200
+sPiloswineSprites5:
+ax_sprite sPiloswineGfx5, 0x200
+ax_sprite_terminator
+sPiloswineGfx6:
+.incbin "baserom.gba", 0xEF835C, 0x200
+sPiloswineSprites6:
+ax_sprite sPiloswineGfx6, 0x200
+ax_sprite_terminator
+sPiloswineGfx7:
+.incbin "baserom.gba", 0xEF856C, 0x200
+sPiloswineSprites7:
+ax_sprite sPiloswineGfx7, 0x200
+ax_sprite_terminator
+sPiloswineGfx8:
+.incbin "baserom.gba", 0xEF877C, 0x200
+sPiloswineSprites8:
+ax_sprite sPiloswineGfx8, 0x200
+ax_sprite_terminator
+sPiloswineGfx9:
+.incbin "baserom.gba", 0xEF898C, 0x200
+sPiloswineSprites9:
+ax_sprite sPiloswineGfx9, 0x200
+ax_sprite_terminator
+sPiloswineGfx10:
+.incbin "baserom.gba", 0xEF8B9C, 0x200
+sPiloswineSprites10:
+ax_sprite sPiloswineGfx10, 0x200
+ax_sprite_terminator
+sPiloswineGfx11:
+.incbin "baserom.gba", 0xEF8DAC, 0x200
+sPiloswineSprites11:
+ax_sprite sPiloswineGfx11, 0x200
+ax_sprite_terminator
+sPiloswineGfx12:
+.incbin "baserom.gba", 0xEF8FBC, 0x200
+sPiloswineSprites12:
+ax_sprite sPiloswineGfx12, 0x200
+ax_sprite_terminator
+sPiloswineGfx13:
+.incbin "baserom.gba", 0xEF91CC, 0x200
+sPiloswineSprites13:
+ax_sprite sPiloswineGfx13, 0x200
+ax_sprite_terminator
+sPiloswineGfx14:
+.incbin "baserom.gba", 0xEF93DC, 0x200
+sPiloswineSprites14:
+ax_sprite sPiloswineGfx14, 0x200
+ax_sprite_terminator
+sPiloswineGfx15:
+.incbin "baserom.gba", 0xEF95EC, 0x200
+sPiloswineSprites15:
+ax_sprite sPiloswineGfx15, 0x200
+ax_sprite_terminator
+sPiloswineGfx16:
+.incbin "baserom.gba", 0xEF97FC, 0x40
+sPiloswineGfx16_1:
+.incbin "baserom.gba", 0xEF983C, 0x180
+sPiloswineSprites16:
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx16_1, 0x180
+ax_sprite_terminator
+sPiloswineGfx17:
+.incbin "baserom.gba", 0xEF99E4, 0x200
+sPiloswineSprites17:
+ax_sprite sPiloswineGfx17, 0x200
+ax_sprite_terminator
+sPiloswineGfx18:
+.incbin "baserom.gba", 0xEF9BF4, 0x40
+sPiloswineGfx18_1:
+.incbin "baserom.gba", 0xEF9C34, 0x60
+sPiloswineGfx18_2:
+.incbin "baserom.gba", 0xEF9C94, 0xE0
+sPiloswineSprites18:
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx18_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPiloswineGfx19:
+.incbin "baserom.gba", 0xEF9DB4, 0x60
+sPiloswineGfx19_1:
+.incbin "baserom.gba", 0xEF9E14, 0x60
+sPiloswineGfx19_2:
+.incbin "baserom.gba", 0xEF9E74, 0xE0
+sPiloswineSprites19:
+ax_sprite sPiloswineGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx19_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPiloswineGfx20:
+.incbin "baserom.gba", 0xEF9F8C, 0x40
+sPiloswineGfx20_1:
+.incbin "baserom.gba", 0xEF9FCC, 0x180
+sPiloswineSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx20_1, 0x180
+ax_sprite_terminator
+sPiloswineGfx21:
+.incbin "baserom.gba", 0xEFA174, 0x60
+sPiloswineGfx21_1:
+.incbin "baserom.gba", 0xEFA1D4, 0x160
+sPiloswineSprites21:
+ax_sprite sPiloswineGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPiloswineGfx22:
+.incbin "baserom.gba", 0xEFA35C, 0x1C0
+sPiloswineSprites22:
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx22, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPiloswineGfx23:
+.incbin "baserom.gba", 0xEFA53C, 0xE0
+sPiloswineGfx23_1:
+.incbin "baserom.gba", 0xEFA61C, 0x80
+sPiloswineGfx23_2:
+.incbin "baserom.gba", 0xEFA69C, 0x40
+sPiloswineSprites23:
+ax_sprite sPiloswineGfx23, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx23_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPiloswineGfx24:
+.incbin "baserom.gba", 0xEFA714, 0x40
+sPiloswineGfx24_1:
+.incbin "baserom.gba", 0xEFA754, 0x160
+sPiloswineSprites24:
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx24_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPiloswineGfx25:
+.incbin "baserom.gba", 0xEFA8E4, 0x180
+sPiloswineGfx25_1:
+.incbin "baserom.gba", 0xEFAA64, 0x40
+sPiloswineSprites25:
+ax_sprite sPiloswineGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPiloswineGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPiloswineGfx26:
+.incbin "baserom.gba", 0xEFAACC, 0x200
+sPiloswineSprites26:
+ax_sprite sPiloswineGfx26, 0x200
+ax_sprite_terminator
+sPiloswineGfx27:
+.incbin "baserom.gba", 0xEFACDC, 0x200
+sPiloswineSprites27:
+ax_sprite sPiloswineGfx27, 0x200
+ax_sprite_terminator
+sPiloswineGfx28:
+.incbin "baserom.gba", 0xEFAEEC, 0x200
+sPiloswineSprites28:
+ax_sprite sPiloswineGfx28, 0x200
+ax_sprite_terminator
+sPiloswineGfx29:
+.incbin "baserom.gba", 0xEFB0FC, 0x200
+sPiloswineSprites29:
+ax_sprite sPiloswineGfx29, 0x200
+ax_sprite_terminator
+sPiloswineGfx30:
+.incbin "baserom.gba", 0xEFB30C, 0x200
+sPiloswineSprites30:
+ax_sprite sPiloswineGfx30, 0x200
+ax_sprite_terminator
+sPiloswineGfx31:
+.incbin "baserom.gba", 0xEFB51C, 0x200
+sPiloswineSprites31:
+ax_sprite sPiloswineGfx31, 0x200
+ax_sprite_terminator
+sPiloswineGfx32:
+.incbin "baserom.gba", 0xEFB72C, 0x200
+sPiloswineSprites32:
+ax_sprite sPiloswineGfx32, 0x200
+ax_sprite_terminator
+sAxPosesPiloswine:
+.4byte sPiloswinePose1
+.4byte sPiloswinePose2
+.4byte sPiloswinePose3
+.4byte sPiloswinePose4
+.4byte sPiloswinePose5
+.4byte sPiloswinePose6
+.4byte sPiloswinePose7
+.4byte sPiloswinePose8
+.4byte sPiloswinePose9
+.4byte sPiloswinePose10
+.4byte sPiloswinePose11
+.4byte sPiloswinePose12
+.4byte sPiloswinePose13
+.4byte sPiloswinePose14
+.4byte sPiloswinePose15
+.4byte sPiloswinePose16
+.4byte sPiloswinePose17
+.4byte sPiloswinePose18
+.4byte sPiloswinePose19
+.4byte sPiloswinePose20
+.4byte sPiloswinePose21
+.4byte sPiloswinePose22
+.4byte sPiloswinePose23
+.4byte sPiloswinePose24
+.4byte sPiloswinePose25
+.4byte sPiloswinePose26
+.4byte sPiloswinePose27
+.4byte sPiloswinePose28
+.4byte sPiloswinePose29
+.4byte sPiloswinePose30
+.4byte sPiloswinePose31
+.4byte sPiloswinePose32
+.4byte sPiloswinePose33
+.4byte sPiloswinePose34
+.4byte sPiloswinePose35
+.4byte sPiloswinePose36
+.4byte sPiloswinePose37
+.4byte sPiloswinePose38
+.4byte sPiloswinePose39
+.4byte sPiloswinePose40
+.4byte sPiloswinePose41
+.4byte sPiloswinePose42
+.4byte sPiloswinePose43
+.4byte sPiloswinePose44
+.4byte sPiloswinePose45
+.4byte sPiloswinePose46
+.4byte sPiloswinePose47
+.4byte sPiloswinePose48
+.4byte sPiloswinePose49
+.4byte sPiloswinePose50
+.4byte sPiloswinePose51
+.4byte sPiloswinePose52
+.4byte sPiloswinePose53
+.4byte sPiloswinePose54
+.4byte sPiloswinePose55
+.4byte sPiloswinePose56
+.4byte sPiloswinePose57
+.4byte sPiloswinePose58
+.4byte sPiloswinePose59
+.4byte sPiloswinePose60
+.4byte sPiloswinePose61
+.4byte sPiloswinePose62
+.4byte sPiloswinePose63
+.4byte sPiloswinePose64
+.4byte sPiloswinePose65
+.4byte sPiloswinePose66
+.4byte sPiloswinePose67
+.4byte sPiloswinePose68
+.4byte sPiloswinePose69
+.4byte sPiloswinePose70
+.4byte sPiloswinePose71
+.4byte sPiloswinePose72
+.4byte sPiloswinePose73
+.4byte sPiloswinePose74
+.4byte sPiloswinePose75
+.4byte sPiloswinePose76
+.4byte sPiloswinePose77
+.4byte sPiloswinePose78
+.4byte sPiloswinePose79
+.4byte sPiloswinePose80
+.4byte sPiloswinePose81
+.4byte sPiloswinePose82
+.4byte sPiloswinePose83
+.4byte sPiloswinePose84
+.4byte sPiloswinePose85
+.4byte sPiloswinePose86
+.4byte sPiloswinePose87
+.4byte sPiloswinePose88
+.4byte sPiloswinePose89
+.4byte sPiloswinePose90
+.4byte sPiloswinePose91
+.4byte sPiloswinePose92
+.4byte sPiloswinePose93
+.4byte sPiloswinePose94
+.4byte sPiloswinePose95
+.4byte sPiloswinePose96
+.4byte sPiloswinePose97
+.4byte sPiloswinePose98
+.4byte sPiloswinePose99
+.4byte sPiloswinePose100
+.4byte sPiloswinePose101
+.4byte sPiloswinePose102
+.4byte sPiloswinePose103
+.4byte sPiloswinePose104
+.4byte sPiloswinePose105
+.4byte sPiloswinePose106
+.4byte sPiloswinePose107
+.4byte sPiloswinePose108
+.4byte sPiloswinePose109
+.4byte sPiloswinePose110
+.4byte sPiloswinePose111
+.4byte sPiloswinePose112
+.4byte sPiloswinePose113
+.4byte sPiloswinePose114
+.4byte sPiloswinePose115
+.4byte sPiloswinePose116
+.4byte sPiloswinePose117
+.4byte sPiloswinePose118
+.4byte sPiloswinePose119
+.4byte sPiloswinePose120
+.4byte sPiloswinePose121
+.4byte sPiloswinePose122
+.4byte sPiloswinePose123
+.4byte sPiloswinePose124
+.4byte sPiloswinePose125
+.4byte sPiloswinePose126
+.4byte sPiloswinePose127
+.4byte sPiloswinePose128
+.4byte sPiloswinePose129
+.4byte sPiloswinePose130
+.4byte sPiloswinePose131
+.4byte sPiloswinePose132
+.4byte sPiloswinePose133
+.4byte sPiloswinePose134
+.4byte sPiloswinePose135
+.4byte sPiloswinePose136
+.4byte sPiloswinePose137
+.4byte sPiloswinePose138
+.4byte sPiloswinePose139
+.4byte sPiloswinePose140
+.4byte sPiloswinePose141
+.4byte sPiloswinePose142
+.4byte sPiloswinePose143
+.4byte sPiloswinePose144
+.4byte sPiloswinePose145
+.4byte sPiloswinePose146
+.4byte sPiloswinePose147
+.4byte sPiloswinePose148
+.4byte sPiloswinePose149
+.4byte sPiloswinePose150
+.4byte sPiloswinePose151
+.4byte sPiloswinePose152
+.4byte sPiloswinePose153
+.4byte sPiloswinePose154
+.4byte sPiloswinePose155
+.4byte sPiloswinePose156
+.4byte sPiloswinePose157
+.4byte sPiloswinePose158
+.4byte sPiloswinePose159
+.4byte sPiloswinePose160
+.4byte sPiloswinePose161
+.4byte sPiloswinePose162
+.4byte sPiloswinePose163
+.4byte sPiloswinePose164
+.4byte sPiloswinePose165
+.4byte sPiloswinePose166
+.4byte sPiloswinePose167
+.4byte sPiloswinePose168
+.4byte sPiloswinePose169
+.4byte sPiloswinePose170
+.4byte sPiloswinePose171
+.4byte sPiloswinePose172
+.4byte sPiloswinePose173
+.4byte sPiloswinePose174
+.4byte sPiloswinePose175
+.4byte sPiloswinePose176
+.4byte sPiloswinePose177
+.4byte sPiloswinePose178
+.4byte sPiloswinePose179
+.4byte sPiloswinePose180
+.4byte sPiloswinePose181
+.4byte sPiloswinePose182
+.4byte sPiloswinePose183
+.4byte sPiloswinePose184
+.4byte sPiloswinePose185
+.4byte sPiloswinePose186
+sAxPositionsPiloswine:
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    1,    0, 	  -2,    2, 	   5,    2, 	   1,   -4
+.2byte   -1,    0, 	  -5,    2, 	   2,    2, 	  -1,   -4
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+.2byte    7,    0, 	   6,   -2, 	   1,    0, 	  -1,   -2
+.2byte    9,    0, 	   8,   -1, 	   4,    0, 	  -1,   -4
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   10,   -3, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   11,   -3, 	   7,   -4, 	   6,   -1, 	  -1,   -4
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte    5,   -6, 	  -1,   -5, 	   3,   -3, 	   0,   -5
+.2byte    6,   -8, 	   2,   -5, 	   6,   -3, 	   0,   -5
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    0,  -11, 	   3,   -4, 	  -3,   -4, 	   0,   -7
+.2byte    1,  -11, 	   5,   -4, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -6, 	   1,   -5, 	  -3,   -3, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -5, 	  -6,   -3, 	   0,   -5
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -10,   -3, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -11,   -3, 	  -7,   -4, 	  -6,   -1, 	   1,   -4
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte   -7,    0, 	  -6,   -2, 	  -1,    0, 	   1,   -2
+.2byte   -9,    0, 	  -8,   -1, 	  -4,    0, 	   1,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    1,    0, 	  -2,    2, 	   5,    2, 	   1,   -4
+.2byte   -1,    0, 	  -5,    2, 	   2,    2, 	  -1,   -4
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+.2byte    7,    0, 	   6,   -2, 	   1,    0, 	  -1,   -2
+.2byte    9,    0, 	   8,   -1, 	   4,    0, 	  -1,   -4
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   10,   -3, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   11,   -3, 	   7,   -4, 	   6,   -1, 	  -1,   -4
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte    5,   -6, 	  -1,   -5, 	   3,   -3, 	   0,   -5
+.2byte    6,   -8, 	   2,   -5, 	   6,   -3, 	   0,   -5
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    0,  -11, 	   3,   -4, 	  -3,   -4, 	   0,   -7
+.2byte    1,  -11, 	   5,   -4, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -6, 	   1,   -5, 	  -3,   -3, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -5, 	  -6,   -3, 	   0,   -5
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -10,   -3, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -11,   -3, 	  -7,   -4, 	  -6,   -1, 	   1,   -4
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte   -7,    0, 	  -6,   -2, 	  -1,    0, 	   1,   -2
+.2byte   -9,    0, 	  -8,   -1, 	  -4,    0, 	   1,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    1,    0, 	  -2,    2, 	   5,    2, 	   1,   -4
+.2byte   -1,    0, 	  -5,    2, 	   2,    2, 	  -1,   -4
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+.2byte    7,    0, 	   6,   -2, 	   1,    0, 	  -1,   -2
+.2byte    9,    0, 	   8,   -1, 	   4,    0, 	  -1,   -4
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   10,   -3, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   11,   -3, 	   7,   -4, 	   6,   -1, 	  -1,   -4
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte    5,   -6, 	  -1,   -5, 	   3,   -3, 	   0,   -5
+.2byte    6,   -8, 	   2,   -5, 	   6,   -3, 	   0,   -5
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    0,  -11, 	   3,   -4, 	  -3,   -4, 	   0,   -7
+.2byte    1,  -11, 	   5,   -4, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -6, 	   1,   -5, 	  -3,   -3, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -5, 	  -6,   -3, 	   0,   -5
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -10,   -3, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -11,   -3, 	  -7,   -4, 	  -6,   -1, 	   1,   -4
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte   -7,    0, 	  -6,   -2, 	  -1,    0, 	   1,   -2
+.2byte   -9,    0, 	  -8,   -1, 	  -4,    0, 	   1,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    0,   -2, 	  -5,    1, 	   5,    1, 	   0,   -8
+.2byte    0,   -3, 	  -5,    1, 	   5,    1, 	   0,   -8
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+.2byte    8,   -2, 	   7,   -1, 	   1,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,   -1, 	   1,    1, 	   0,   -8
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   10,   -5, 	   6,   -3, 	   6,    0, 	   0,   -6
+.2byte   11,   -7, 	   7,   -3, 	   7,    0, 	   1,   -9
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte    5,  -10, 	   0,   -8, 	   6,   -6, 	   0,   -9
+.2byte    6,  -11, 	  -1,   -9, 	   5,   -8, 	   0,  -11
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    0,  -11, 	   4,   -6, 	  -4,   -6, 	   0,   -9
+.2byte    0,  -13, 	   4,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,  -10, 	   0,   -8, 	  -6,   -6, 	   0,   -9
+.2byte   -6,  -11, 	   1,   -9, 	  -5,   -8, 	   0,  -11
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -10,   -5, 	  -6,   -3, 	  -6,    0, 	   0,   -6
+.2byte  -11,   -7, 	  -7,   -3, 	  -7,    0, 	  -1,   -9
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte   -8,   -2, 	  -7,   -1, 	  -1,    1, 	   0,   -7
+.2byte   -7,   -4, 	  -7,   -1, 	  -1,    1, 	   0,   -8
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+.2byte   -8,    0, 	  -8,   -2, 	  -3,    0, 	   0,   -5
+.2byte   -8,    1, 	  -7,   -1, 	  -3,    0, 	   0,   -5
+.2byte    0,   -6, 	  -5,   -2, 	   5,   -2, 	   0,   -9
+.2byte    7,   -6, 	   6,   -3, 	   0,   -1, 	  -1,   -8
+.2byte   10,   -8, 	   7,   -5, 	   6,   -2, 	  -1,   -7
+.2byte    5,  -12, 	  -1,  -10, 	   4,   -8, 	  -1,   -7
+.2byte    0,  -11, 	   3,   -7, 	  -3,   -7, 	   0,   -8
+.2byte   -6,  -12, 	   0,  -10, 	  -5,   -8, 	   0,   -7
+.2byte  -11,   -8, 	  -8,   -5, 	  -7,   -2, 	   0,   -7
+.2byte   -8,   -6, 	  -7,   -3, 	  -1,   -1, 	   0,   -8
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    1,    0, 	  -2,    2, 	   5,    2, 	   1,   -4
+.2byte   -1,    0, 	  -5,    2, 	   2,    2, 	  -1,   -4
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+.2byte    7,    0, 	   6,   -2, 	   1,    0, 	  -1,   -2
+.2byte    9,    0, 	   8,   -1, 	   4,    0, 	  -1,   -4
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   10,   -3, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   11,   -3, 	   7,   -4, 	   6,   -1, 	  -1,   -4
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte    5,   -6, 	  -1,   -5, 	   3,   -3, 	   0,   -5
+.2byte    6,   -8, 	   2,   -5, 	   6,   -3, 	   0,   -5
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    0,  -11, 	   3,   -4, 	  -3,   -4, 	   0,   -7
+.2byte    1,  -11, 	   5,   -4, 	  -1,   -4, 	   0,   -7
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -6, 	   1,   -5, 	  -3,   -3, 	   0,   -5
+.2byte   -6,   -8, 	  -2,   -5, 	  -6,   -3, 	   0,   -5
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -10,   -3, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -11,   -3, 	  -7,   -4, 	  -6,   -1, 	   1,   -4
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte   -7,    0, 	  -6,   -2, 	  -1,    0, 	   1,   -2
+.2byte   -9,    0, 	  -8,   -1, 	  -4,    0, 	   1,   -4
+.2byte    0,   -3, 	  -5,    1, 	   5,    1, 	   0,   -8
+.2byte   -7,   -4, 	  -7,   -1, 	  -1,    1, 	   0,   -8
+.2byte  -11,   -7, 	  -7,   -3, 	  -7,    0, 	  -1,   -9
+.2byte   -6,  -11, 	   1,   -9, 	  -5,   -8, 	   0,  -11
+.2byte    0,  -13, 	   4,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    6,  -11, 	  -1,   -9, 	   5,   -8, 	   0,  -11
+.2byte   11,   -7, 	   7,   -3, 	   7,    0, 	   1,   -9
+.2byte    7,   -4, 	   7,   -1, 	   1,    1, 	   0,   -8
+.2byte    0,   -2, 	  -5,    1, 	   5,    1, 	   0,   -8
+.2byte    8,   -2, 	   7,   -1, 	   1,    1, 	   0,   -7
+.2byte   10,   -5, 	   6,   -3, 	   6,    0, 	   0,   -6
+.2byte    4,  -10, 	  -1,   -8, 	   5,   -6, 	  -1,   -9
+.2byte    0,  -11, 	   4,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -5,  -10, 	   0,   -8, 	  -6,   -6, 	   0,   -9
+.2byte  -11,   -5, 	  -7,   -3, 	  -7,    0, 	  -1,   -6
+.2byte   -9,   -2, 	  -8,   -1, 	  -2,    1, 	  -1,   -7
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte    0,   -1, 	  -5,    2, 	   5,    2, 	   0,   -7
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+.2byte    8,   -1, 	   7,    0, 	   1,    2, 	   0,   -6
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte   10,   -4, 	   6,   -2, 	   6,    1, 	   0,   -5
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte    5,   -9, 	   0,   -7, 	   6,   -5, 	   0,   -8
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte   -5,   -9, 	   0,   -7, 	  -6,   -5, 	   0,   -8
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte  -10,   -4, 	  -6,   -2, 	  -6,    1, 	   0,   -5
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte   -8,   -1, 	  -7,    0, 	  -1,    2, 	   0,   -6
+.2byte    0,   -3, 	  -5,    1, 	   5,    1, 	   0,   -8
+.2byte   -7,   -4, 	  -7,   -1, 	  -1,    1, 	   0,   -8
+.2byte  -11,   -7, 	  -7,   -3, 	  -7,    0, 	  -1,   -9
+.2byte   -6,  -10, 	   1,   -8, 	  -5,   -7, 	   0,  -10
+.2byte    0,  -11, 	   4,   -5, 	  -4,   -5, 	   0,   -8
+.2byte    5,  -10, 	  -2,   -8, 	   4,   -7, 	  -1,  -10
+.2byte   11,   -7, 	   7,   -3, 	   7,    0, 	   1,   -9
+.2byte    7,   -4, 	   7,   -1, 	   1,    1, 	   0,   -8
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -5
+.2byte   -8,   -1, 	  -6,   -2, 	  -2,   -1, 	   1,   -4
+.2byte  -11,   -4, 	  -6,   -4, 	  -6,   -1, 	   0,   -4
+.2byte   -6,   -8, 	  -2,   -6, 	  -6,   -4, 	   0,   -6
+.2byte    0,  -12, 	   3,   -5, 	  -3,   -5, 	   0,   -7
+.2byte    6,   -8, 	   2,   -6, 	   6,   -4, 	   0,   -6
+.2byte   11,   -4, 	   6,   -4, 	   6,   -1, 	   0,   -4
+.2byte    8,   -1, 	   6,   -2, 	   2,   -1, 	  -1,   -4
+sPiloswineAnimTable1:
+.4byte sPiloswineAnims_1_1
+.4byte sPiloswineAnims_1_2
+.4byte sPiloswineAnims_1_3
+.4byte sPiloswineAnims_1_4
+.4byte sPiloswineAnims_1_5
+.4byte sPiloswineAnims_1_6
+.4byte sPiloswineAnims_1_7
+.4byte sPiloswineAnims_1_8
+sPiloswineAnimTable2:
+.4byte sPiloswineAnims_2_1
+.4byte sPiloswineAnims_2_2
+.4byte sPiloswineAnims_2_3
+.4byte sPiloswineAnims_2_4
+.4byte sPiloswineAnims_2_5
+.4byte sPiloswineAnims_2_6
+.4byte sPiloswineAnims_2_7
+.4byte sPiloswineAnims_2_8
+sPiloswineAnimTable3:
+.4byte sPiloswineAnims_3_1
+.4byte sPiloswineAnims_3_2
+.4byte sPiloswineAnims_3_3
+.4byte sPiloswineAnims_3_4
+.4byte sPiloswineAnims_3_5
+.4byte sPiloswineAnims_3_6
+.4byte sPiloswineAnims_3_7
+.4byte sPiloswineAnims_3_8
+sPiloswineAnimTable4:
+.4byte sPiloswineAnims_4_1
+.4byte sPiloswineAnims_4_2
+.4byte sPiloswineAnims_4_3
+.4byte sPiloswineAnims_4_4
+.4byte sPiloswineAnims_4_5
+.4byte sPiloswineAnims_4_6
+.4byte sPiloswineAnims_4_7
+.4byte sPiloswineAnims_4_8
+sPiloswineAnimTable5:
+.4byte sPiloswineAnims_5_1
+.4byte sPiloswineAnims_5_2
+.4byte sPiloswineAnims_5_3
+.4byte sPiloswineAnims_5_4
+.4byte sPiloswineAnims_5_5
+.4byte sPiloswineAnims_5_6
+.4byte sPiloswineAnims_5_7
+.4byte sPiloswineAnims_5_8
+sPiloswineAnimTable6:
+.4byte sPiloswineAnims_6_1
+.4byte sPiloswineAnims_6_1
+.4byte sPiloswineAnims_6_1
+.4byte sPiloswineAnims_6_1
+.4byte sPiloswineAnims_6_1
+.4byte sPiloswineAnims_6_1
+.4byte sPiloswineAnims_6_1
+.4byte sPiloswineAnims_6_1
+sPiloswineAnimTable7:
+.4byte sPiloswineAnims_7_1
+.4byte sPiloswineAnims_7_2
+.4byte sPiloswineAnims_7_3
+.4byte sPiloswineAnims_7_4
+.4byte sPiloswineAnims_7_5
+.4byte sPiloswineAnims_7_6
+.4byte sPiloswineAnims_7_7
+.4byte sPiloswineAnims_7_8
+sPiloswineAnimTable8:
+.4byte sPiloswineAnims_8_1
+.4byte sPiloswineAnims_8_2
+.4byte sPiloswineAnims_8_3
+.4byte sPiloswineAnims_8_4
+.4byte sPiloswineAnims_8_5
+.4byte sPiloswineAnims_8_6
+.4byte sPiloswineAnims_8_7
+.4byte sPiloswineAnims_8_8
+sPiloswineAnimTable9:
+.4byte sPiloswineAnims_9_1
+.4byte sPiloswineAnims_9_2
+.4byte sPiloswineAnims_9_3
+.4byte sPiloswineAnims_9_4
+.4byte sPiloswineAnims_9_5
+.4byte sPiloswineAnims_9_6
+.4byte sPiloswineAnims_9_7
+.4byte sPiloswineAnims_9_8
+sPiloswineAnimTable10:
+.4byte sPiloswineAnims_10_1
+.4byte sPiloswineAnims_10_2
+.4byte sPiloswineAnims_10_3
+.4byte sPiloswineAnims_10_4
+.4byte sPiloswineAnims_10_5
+.4byte sPiloswineAnims_10_6
+.4byte sPiloswineAnims_10_7
+.4byte sPiloswineAnims_10_8
+sPiloswineAnimTable11:
+.4byte sPiloswineAnims_11_1
+.4byte sPiloswineAnims_11_2
+.4byte sPiloswineAnims_11_3
+.4byte sPiloswineAnims_11_4
+.4byte sPiloswineAnims_11_5
+.4byte sPiloswineAnims_11_6
+.4byte sPiloswineAnims_11_7
+.4byte sPiloswineAnims_11_8
+sPiloswineAnimTable12:
+.4byte sPiloswineAnims_12_1
+.4byte sPiloswineAnims_12_2
+.4byte sPiloswineAnims_12_3
+.4byte sPiloswineAnims_12_4
+.4byte sPiloswineAnims_12_5
+.4byte sPiloswineAnims_12_6
+.4byte sPiloswineAnims_12_7
+.4byte sPiloswineAnims_12_8
+sPiloswineAnimTable13:
+.4byte sPiloswineAnims_13_1
+.4byte sPiloswineAnims_13_2
+.4byte sPiloswineAnims_13_3
+.4byte sPiloswineAnims_13_4
+.4byte sPiloswineAnims_13_5
+.4byte sPiloswineAnims_13_6
+.4byte sPiloswineAnims_13_7
+.4byte sPiloswineAnims_13_8
+sAxAnimationsPiloswine:
+.4byte sPiloswineAnimTable1
+.4byte sPiloswineAnimTable2
+.4byte sPiloswineAnimTable3
+.4byte sPiloswineAnimTable4
+.4byte sPiloswineAnimTable5
+.4byte sPiloswineAnimTable6
+.4byte sPiloswineAnimTable7
+.4byte sPiloswineAnimTable8
+.4byte sPiloswineAnimTable9
+.4byte sPiloswineAnimTable10
+.4byte sPiloswineAnimTable11
+.4byte sPiloswineAnimTable12
+.4byte sPiloswineAnimTable13
+sAxSpritesPiloswine:
+.4byte sPiloswineSprites1
+.4byte sPiloswineSprites2
+.4byte sPiloswineSprites3
+.4byte sPiloswineSprites4
+.4byte sPiloswineSprites5
+.4byte sPiloswineSprites6
+.4byte sPiloswineSprites7
+.4byte sPiloswineSprites8
+.4byte sPiloswineSprites9
+.4byte sPiloswineSprites10
+.4byte sPiloswineSprites11
+.4byte sPiloswineSprites12
+.4byte sPiloswineSprites13
+.4byte sPiloswineSprites14
+.4byte sPiloswineSprites15
+.4byte sPiloswineSprites16
+.4byte sPiloswineSprites17
+.4byte sPiloswineSprites18
+.4byte sPiloswineSprites19
+.4byte sPiloswineSprites20
+.4byte sPiloswineSprites21
+.4byte sPiloswineSprites22
+.4byte sPiloswineSprites23
+.4byte sPiloswineSprites24
+.4byte sPiloswineSprites25
+.4byte sPiloswineSprites26
+.4byte sPiloswineSprites27
+.4byte sPiloswineSprites28
+.4byte sPiloswineSprites29
+.4byte sPiloswineSprites30
+.4byte sPiloswineSprites31
+.4byte sPiloswineSprites32
+sAxMainPiloswine:
+ax_main sAxPosesPiloswine, sAxAnimationsPiloswine, 13, sAxSpritesPiloswine, sAxPositionsPiloswine

--- a/data/ax/pineco.inc
+++ b/data/ax/pineco.inc
@@ -1,0 +1,2342 @@
+.global gAxPineco
+gAxPineco:
+ax_siro sAxMainPineco
+sPinecoPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose4:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose5:
+ax_pose 4, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose6:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose7:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose8:
+ax_pose 7, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose9:
+ax_pose 8, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose10:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose11:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose12:
+ax_pose 11, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose28:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose29:
+ax_pose 4, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose30:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose31:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose32:
+ax_pose 7, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose33:
+ax_pose 8, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose34:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose35:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose36:
+ax_pose 11, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose37:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose38:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose39:
+ax_pose 14, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose40:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose41:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose42:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose43:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose44:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose45:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose46:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose47:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose48:
+ax_pose 5, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose50:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose51:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose52:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose53:
+ax_pose 4, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose54:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose55:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose56:
+ax_pose 7, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose57:
+ax_pose 8, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose58:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose59:
+ax_pose 10, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose60:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose61:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose62:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose63:
+ax_pose 14, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose64:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose65:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose66:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose67:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose68:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose69:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose70:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose71:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose72:
+ax_pose 5, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose73:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose74:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose75:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose76:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose77:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose78:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose79:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose80:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose81:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose82:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose83:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose84:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose85:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose86:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose87:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose88:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose89:
+ax_pose 15, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sPinecoPose90:
+ax_pose 16, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sPinecoPose91:
+ax_pose 17, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sPinecoPose92:
+ax_pose 18, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sPinecoPose93:
+ax_pose 19, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sPinecoPose94:
+ax_pose 18, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sPinecoPose95:
+ax_pose 17, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sPinecoPose96:
+ax_pose 16, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sPinecoPose97:
+ax_pose 20, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose98:
+ax_pose 21, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose99:
+ax_pose 22, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sPinecoPose100:
+ax_pose 23, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sPinecoPose101:
+ax_pose 24, 0x01e3, 0x90ec, 0x2c00
+ax_pose_terminator
+sPinecoPose102:
+ax_pose 25, 0x01e5, 0x90e8, 0x2c00
+ax_pose_terminator
+sPinecoPose103:
+ax_pose 26, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sPinecoPose104:
+ax_pose 25, 0x01e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sPinecoPose105:
+ax_pose 24, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose106:
+ax_pose 23, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose107:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose108:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose109:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose110:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose111:
+ax_pose 4, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose112:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose113:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose114:
+ax_pose 7, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose115:
+ax_pose 8, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose116:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose117:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose118:
+ax_pose 11, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose119:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose120:
+ax_pose 13, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose121:
+ax_pose 14, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose122:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose123:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose124:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose125:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose126:
+ax_pose 7, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose127:
+ax_pose 8, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose128:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose129:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose130:
+ax_pose 5, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose131:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose132:
+ax_pose 5, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose133:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose134:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose135:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose136:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose137:
+ax_pose 8, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose138:
+ax_pose 5, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose139:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose140:
+ax_pose 5, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose141:
+ax_pose 8, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose142:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose143:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose144:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose145:
+ax_pose 8, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose146:
+ax_pose 5, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose147:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose148:
+ax_pose 1, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose149:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose150:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose151:
+ax_pose 4, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose152:
+ax_pose 5, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose153:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose154:
+ax_pose 7, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose155:
+ax_pose 8, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose156:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose157:
+ax_pose 10, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose158:
+ax_pose 11, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose159:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose160:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose161:
+ax_pose 14, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose162:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose163:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose164:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose165:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose166:
+ax_pose 7, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose167:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose168:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose169:
+ax_pose 4, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose170:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose171:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose172:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose173:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose174:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose175:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose176:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose177:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose178:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose179:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose180:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose181:
+ax_pose 6, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose182:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose183:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPinecoPose184:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose185:
+ax_pose 6, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPinecoPose186:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sPinecoAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 21, 0, 21,
+ax_anim 2, 1, 24, -1, 21, -1, 21,
+ax_anim 2, 0, 24, 0, 21, 0, 21,
+ax_anim 2, 0, 24, -1, 21, -1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPinecoAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 20, 21, 20, 21,
+ax_anim 2, 1, 27, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 20, 21, 20, 21,
+ax_anim 2, 0, 27, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sPinecoAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 20, 0, 20, 0,
+ax_anim 2, 1, 30, 20, -1, 20, -1,
+ax_anim 2, 0, 30, 20, 0, 20, 0,
+ax_anim 2, 0, 30, 20, -1, 20, -1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sPinecoAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 6, -6, 6, -6,
+ax_anim 1, 0, 35, 12, -11, 12, -11,
+ax_anim 2, 0, 33, 20, -19, 20, -19,
+ax_anim 2, 1, 33, 21, -18, 21, -18,
+ax_anim 2, 0, 33, 20, -19, 20, -19,
+ax_anim 2, 0, 33, 21, -18, 21, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sPinecoAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 1, 36, -1, -19, -1, -19,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 0, 36, -1, -19, -1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sPinecoAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -6, -6, -6, -6,
+ax_anim 1, 0, 41, -12, -11, -12, -11,
+ax_anim 2, 0, 39, -20, -19, -20, -19,
+ax_anim 2, 1, 39, -21, -18, -21, -18,
+ax_anim 2, 0, 39, -20, -19, -20, -19,
+ax_anim 2, 0, 39, -21, -18, -21, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sPinecoAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -20, 0, -20, 0,
+ax_anim 2, 1, 42, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -20, 0, -20, 0,
+ax_anim 2, 0, 42, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sPinecoAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -20, 21, -20, 21,
+ax_anim 2, 1, 45, -21, 20, -21, 20,
+ax_anim 2, 0, 45, -20, 21, -20, 21,
+ax_anim 2, 0, 45, -21, 20, -21, 20,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPinecoAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 6, 0, 48, 0, -4, 0, -2,
+ax_anim 1, 2, 48, 0, 3, 0, 3,
+ax_anim 1, 0, 48, 0, 16, 0, 16,
+ax_anim 1, 0, 48, 0, 21, 0, 21,
+ax_anim 1, 0, 51, 0, 21, 0, 21,
+ax_anim 1, 1, 54, -1, 21, -1, 21,
+ax_anim 1, 0, 57, -1, 21, -1, 21,
+ax_anim 1, 0, 60, 0, 21, 0, 21,
+ax_anim 1, 0, 63, 0, 21, 0, 21,
+ax_anim 1, 0, 66, -1, 21, -1, 21,
+ax_anim 1, 0, 69, -1, 21, -1, 21,
+ax_anim 1, 0, 48, 0, 21, 0, 21,
+ax_anim 2, 0, 48, 0, 11, 0, 11,
+ax_anim 2, 0, 48, 0, 5, 0, 5,
+ax_anim_terminator
+sPinecoAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 51, -3, -5, -3, -3,
+ax_anim 1, 2, 51, 3, 3, 3, 3,
+ax_anim 1, 0, 51, 16, 16, 16, 16,
+ax_anim 1, 0, 51, 21, 21, 21, 21,
+ax_anim 1, 0, 54, 21, 21, 21, 21,
+ax_anim 1, 1, 57, 22, 20, 22, 20,
+ax_anim 1, 0, 60, 22, 20, 22, 20,
+ax_anim 1, 0, 63, 21, 21, 21, 21,
+ax_anim 1, 0, 66, 21, 21, 21, 21,
+ax_anim 1, 0, 69, 22, 20, 22, 20,
+ax_anim 1, 0, 48, 22, 20, 22, 20,
+ax_anim 1, 0, 51, 21, 21, 21, 21,
+ax_anim 2, 0, 51, 11, 11, 11, 11,
+ax_anim 2, 0, 51, 5, 5, 5, 5,
+ax_anim_terminator
+sPinecoAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 2, 0, 56, -2, 0, -2, 0,
+ax_anim 6, 0, 54, -3, 0, -3, 0,
+ax_anim 1, 2, 54, 3, 0, 3, 0,
+ax_anim 1, 0, 54, 16, 0, 16, 0,
+ax_anim 1, 0, 54, 21, 0, 21, 0,
+ax_anim 1, 0, 57, 21, 0, 21, 0,
+ax_anim 1, 1, 60, 21, 1, 21, 1,
+ax_anim 1, 0, 63, 21, 1, 21, 1,
+ax_anim 1, 0, 66, 21, 0, 21, 0,
+ax_anim 1, 0, 69, 21, 0, 21, 0,
+ax_anim 1, 0, 48, 21, 1, 21, 1,
+ax_anim 1, 0, 51, 21, 1, 21, 1,
+ax_anim 1, 0, 54, 21, 0, 21, 0,
+ax_anim 2, 0, 54, 11, 0, 11, 0,
+ax_anim 2, 0, 54, 5, 0, 5, 0,
+ax_anim_terminator
+sPinecoAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 2, 0, 59, -2, 2, -2, 2,
+ax_anim 6, 0, 57, -3, 1, -3, 3,
+ax_anim 1, 2, 57, 3, -3, 3, -3,
+ax_anim 1, 0, 57, 16, -16, 16, -16,
+ax_anim 1, 0, 57, 21, -21, 21, -21,
+ax_anim 1, 0, 60, 21, -21, 21, -21,
+ax_anim 1, 1, 63, 22, -20, 22, -20,
+ax_anim 1, 0, 66, 22, -20, 22, -20,
+ax_anim 1, 0, 69, 21, -21, 21, -21,
+ax_anim 1, 0, 48, 21, -21, 21, -21,
+ax_anim 1, 0, 51, 22, -20, 22, -20,
+ax_anim 1, 0, 54, 22, -20, 22, -20,
+ax_anim 1, 0, 57, 21, -21, 21, -21,
+ax_anim 2, 0, 57, 11, -11, 11, -11,
+ax_anim 2, 0, 57, 5, -5, 5, -5,
+ax_anim_terminator
+sPinecoAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 6, 0, 60, 0, 2, 0, 3,
+ax_anim 1, 2, 60, 0, -3, 0, -3,
+ax_anim 1, 0, 60, 0, -16, 0, -16,
+ax_anim 1, 0, 60, 0, -21, 0, -21,
+ax_anim 1, 0, 63, 0, -21, 0, -21,
+ax_anim 1, 1, 66, -1, -21, -1, -21,
+ax_anim 1, 0, 69, -1, -21, -1, -21,
+ax_anim 1, 0, 48, 0, -21, 0, -21,
+ax_anim 1, 0, 51, 0, -21, 0, -21,
+ax_anim 1, 0, 54, -1, -21, -1, -21,
+ax_anim 1, 0, 57, -1, -21, -1, -21,
+ax_anim 1, 0, 60, 0, -21, 0, -21,
+ax_anim 2, 0, 60, 0, -11, 0, -11,
+ax_anim 2, 0, 60, 0, -5, 0, -5,
+ax_anim_terminator
+sPinecoAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 2, 0, 65, 2, 2, 2, 2,
+ax_anim 6, 0, 63, 3, 1, 3, 3,
+ax_anim 1, 2, 63, -3, -3, -3, -3,
+ax_anim 1, 0, 63, -16, -16, -16, -16,
+ax_anim 1, 0, 63, -21, -21, -21, -21,
+ax_anim 1, 0, 66, -21, -21, -21, -21,
+ax_anim 1, 1, 69, -22, -20, -22, -20,
+ax_anim 1, 0, 48, -22, -20, -22, -20,
+ax_anim 1, 0, 51, -21, -21, -21, -21,
+ax_anim 1, 0, 54, -21, -21, -21, -21,
+ax_anim 1, 0, 57, -22, -20, -22, -20,
+ax_anim 1, 0, 60, -22, -20, -22, -20,
+ax_anim 1, 0, 63, -21, -21, -21, -21,
+ax_anim 2, 0, 63, -11, -11, -11, -11,
+ax_anim 2, 0, 63, -5, -5, -5, -5,
+ax_anim_terminator
+sPinecoAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 68, 2, 0, 2, 0,
+ax_anim 6, 0, 66, 3, 0, 3, 0,
+ax_anim 1, 2, 66, -3, 0, -3, 0,
+ax_anim 1, 0, 66, -16, 0, -16, 0,
+ax_anim 1, 0, 66, -21, 0, -21, 0,
+ax_anim 1, 0, 69, -21, 0, -21, 0,
+ax_anim 1, 1, 48, -21, 1, -21, 1,
+ax_anim 1, 0, 51, -21, 1, -21, 1,
+ax_anim 1, 0, 54, -21, 0, -21, 0,
+ax_anim 1, 0, 57, -21, 0, -21, 0,
+ax_anim 1, 0, 60, -21, 1, -21, 1,
+ax_anim 1, 0, 63, -21, 1, -21, 1,
+ax_anim 1, 0, 66, -21, 0, -21, 0,
+ax_anim 2, 0, 66, -11, 0, -11, 0,
+ax_anim 2, 0, 66, -5, 0, -5, 0,
+ax_anim_terminator
+sPinecoAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 2, -2, 2, -2,
+ax_anim 6, 0, 69, 3, -5, 3, -3,
+ax_anim 1, 2, 69, -3, 3, -3, 3,
+ax_anim 1, 0, 69, -16, 16, -16, 16,
+ax_anim 1, 0, 69, -21, 21, -21, 21,
+ax_anim 1, 0, 48, -21, 21, -21, 21,
+ax_anim 1, 1, 51, -22, 20, -22, 20,
+ax_anim 1, 0, 54, -22, 20, -22, 20,
+ax_anim 1, 0, 57, -21, 21, -21, 21,
+ax_anim 1, 0, 60, -21, 21, -21, 21,
+ax_anim 1, 0, 63, -22, 20, -22, 20,
+ax_anim 1, 0, 66, -22, 20, -22, 20,
+ax_anim 1, 0, 69, -21, 21, -21, 21,
+ax_anim 2, 0, 69, -11, 11, -11, 11,
+ax_anim 2, 0, 69, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPinecoAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_5_1:
+ax_anim 3, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 80, 0, 0, 0, 0,
+ax_anim 3, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 80, 0, 0, 0, 0,
+ax_anim 3, 2, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_5_2:
+ax_anim 3, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 0, 87, 0, 0, 0, 0,
+ax_anim 3, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 0, 87, 0, 0, 0, 0,
+ax_anim 3, 2, 95, 0, 0, 0, 0,
+ax_anim 6, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_5_3:
+ax_anim 3, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 86, 0, 0, 0, 0,
+ax_anim 3, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 86, 0, 0, 0, 0,
+ax_anim 3, 2, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_5_4:
+ax_anim 3, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim 3, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim 3, 2, 93, 0, 0, 0, 0,
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_5_5:
+ax_anim 3, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 84, 0, 0, 0, 0,
+ax_anim 3, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 84, 0, 0, 0, 0,
+ax_anim 3, 2, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_5_6:
+ax_anim 3, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 0, 83, 0, 0, 0, 0,
+ax_anim 3, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 0, 83, 0, 0, 0, 0,
+ax_anim 3, 2, 91, 0, 0, 0, 0,
+ax_anim 6, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_5_7:
+ax_anim 3, 0, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 82, 0, 0, 0, 0,
+ax_anim 3, 0, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 82, 0, 0, 0, 0,
+ax_anim 3, 2, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_5_8:
+ax_anim 3, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 0, 81, 0, 0, 0, 0,
+ax_anim 3, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 0, 81, 0, 0, 0, 0,
+ax_anim 3, 2, 89, 0, 0, 0, 0,
+ax_anim 6, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_6_1:
+ax_anim 8, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 0, 96, 0, -1, 0, 0,
+ax_anim 26, 0, 96, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -1, 0, 0,
+ax_anim 26, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sPinecoAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sPinecoAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sPinecoAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sPinecoAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sPinecoAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sPinecoAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sPinecoAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPinecoAnims_8_1:
+ax_anim 26, 0, 106, 0, 0, 0, 0,
+ax_anim 22, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_8_2:
+ax_anim 26, 0, 109, 0, 0, 0, 0,
+ax_anim 22, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_8_3:
+ax_anim 26, 0, 112, 0, 0, 0, 0,
+ax_anim 22, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_8_4:
+ax_anim 26, 0, 115, 0, 0, 0, 0,
+ax_anim 22, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_8_5:
+ax_anim 26, 0, 118, 0, 0, 0, 0,
+ax_anim 22, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_8_6:
+ax_anim 26, 0, 121, 0, 0, 0, 0,
+ax_anim 22, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_8_7:
+ax_anim 26, 0, 124, 0, 0, 0, 0,
+ax_anim 22, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_8_8:
+ax_anim 26, 0, 127, 0, 0, 0, 0,
+ax_anim 22, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 3, 6, 3,
+ax_anim 2, 0, 132, 8, 10, 8, 10,
+ax_anim 2, 0, 133, 7, 18, 7, 18,
+ax_anim 3, 0, 134, 0, 21, 0, 21,
+ax_anim 2, 3, 135, -7, 18, -7, 18,
+ax_anim 2, 0, 136, -8, 10, -8, 10,
+ax_anim 1, 0, 137, -6, 3, -6, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 8, 0, 8, 0,
+ax_anim 2, 0, 131, 17, 5, 17, 5,
+ax_anim 2, 0, 132, 20, 12, 20, 12,
+ax_anim 3, 0, 133, 22, 21, 22, 21,
+ax_anim 2, 3, 134, 13, 23, 13, 23,
+ax_anim 2, 0, 135, 5, 17, 5, 17,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -5, 3, -5,
+ax_anim 2, 0, 130, 11, -6, 11, -6,
+ax_anim 2, 0, 131, 16, -5, 16, -5,
+ax_anim 3, 0, 132, 22, 0, 22, 0,
+ax_anim 2, 3, 133, 18, 6, 18, 6,
+ax_anim 2, 0, 134, 12, 7, 12, 7,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 4, -16, 4, -16,
+ax_anim 2, 0, 130, 13, -21, 13, -21,
+ax_anim 3, 0, 131, 22, -18, 22, -18,
+ax_anim 2, 3, 132, 22, -12, 22, -12,
+ax_anim 2, 0, 133, 17, -4, 17, -4,
+ax_anim 1, 0, 134, 7, -1, 7, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -8, -4, -8, -4,
+ax_anim 2, 0, 136, -9, -11, -9, -11,
+ax_anim 2, 0, 137, -7, -16, -7, -16,
+ax_anim 3, 0, 130, 0, -19, 0, -19,
+ax_anim 2, 3, 131, 7, -16, 7, -16,
+ax_anim 2, 0, 132, 9, -11, 9, -11,
+ax_anim 1, 0, 133, 8, -4, 8, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -8, 1, -8,
+ax_anim 2, 0, 131, -4, -16, -4, -16,
+ax_anim 2, 0, 130, -13, -21, -13, -21,
+ax_anim 3, 0, 137, -22, -18, -22, -18,
+ax_anim 2, 3, 136, -22, -12, -22, -12,
+ax_anim 2, 0, 135, -17, -4, -17, -4,
+ax_anim 1, 0, 134, -7, -1, -7, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -5, -3, -5,
+ax_anim 2, 0, 130, -11, -6, -11, -6,
+ax_anim 2, 0, 137, -16, -5, -16, -5,
+ax_anim 3, 0, 136, -22, 0, -22, 0,
+ax_anim 2, 3, 135, -18, 6, -18, 6,
+ax_anim 2, 0, 134, -12, 7, -12, 7,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -8, 0, -8, 0,
+ax_anim 2, 0, 137, -17, 5, -17, 5,
+ax_anim 2, 0, 136, -20, 12, -20, 12,
+ax_anim 3, 0, 135, -22, 21, -22, 21,
+ax_anim 2, 3, 134, -13, 23, -13, 23,
+ax_anim 2, 0, 133, -5, 17, -5, 17,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -22, 0, 0,
+ax_anim 3, 0, 148, 0, -21, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 151, 0, -22, 0, 0,
+ax_anim 3, 0, 151, 0, -21, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 154, 0, -21, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -21, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -22, 0, 0,
+ax_anim 3, 0, 160, 0, -21, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -21, 0, 0,
+ax_anim 2, 0, 163, 0, -17, 0, 0,
+ax_anim 1, 0, 163, 0, -11, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -22, 0, 0,
+ax_anim 3, 0, 166, 0, -21, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinecoAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPinecoGfx1:
+.incbin "baserom.gba", 0xE4079C, 0x200
+sPinecoSprites1:
+ax_sprite sPinecoGfx1, 0x200
+ax_sprite_terminator
+sPinecoGfx2:
+.incbin "baserom.gba", 0xE409AC, 0x200
+sPinecoSprites2:
+ax_sprite sPinecoGfx2, 0x200
+ax_sprite_terminator
+sPinecoGfx3:
+.incbin "baserom.gba", 0xE40BBC, 0x200
+sPinecoSprites3:
+ax_sprite sPinecoGfx3, 0x200
+ax_sprite_terminator
+sPinecoGfx4:
+.incbin "baserom.gba", 0xE40DCC, 0x200
+sPinecoSprites4:
+ax_sprite sPinecoGfx4, 0x200
+ax_sprite_terminator
+sPinecoGfx5:
+.incbin "baserom.gba", 0xE40FDC, 0x200
+sPinecoSprites5:
+ax_sprite sPinecoGfx5, 0x200
+ax_sprite_terminator
+sPinecoGfx6:
+.incbin "baserom.gba", 0xE411EC, 0x200
+sPinecoSprites6:
+ax_sprite sPinecoGfx6, 0x200
+ax_sprite_terminator
+sPinecoGfx7:
+.incbin "baserom.gba", 0xE413FC, 0x200
+sPinecoSprites7:
+ax_sprite sPinecoGfx7, 0x200
+ax_sprite_terminator
+sPinecoGfx8:
+.incbin "baserom.gba", 0xE4160C, 0x200
+sPinecoSprites8:
+ax_sprite sPinecoGfx8, 0x200
+ax_sprite_terminator
+sPinecoGfx9:
+.incbin "baserom.gba", 0xE4181C, 0x200
+sPinecoSprites9:
+ax_sprite sPinecoGfx9, 0x200
+ax_sprite_terminator
+sPinecoGfx10:
+.incbin "baserom.gba", 0xE41A2C, 0x200
+sPinecoSprites10:
+ax_sprite sPinecoGfx10, 0x200
+ax_sprite_terminator
+sPinecoGfx11:
+.incbin "baserom.gba", 0xE41C3C, 0x200
+sPinecoSprites11:
+ax_sprite sPinecoGfx11, 0x200
+ax_sprite_terminator
+sPinecoGfx12:
+.incbin "baserom.gba", 0xE41E4C, 0x200
+sPinecoSprites12:
+ax_sprite sPinecoGfx12, 0x200
+ax_sprite_terminator
+sPinecoGfx13:
+.incbin "baserom.gba", 0xE4205C, 0x200
+sPinecoSprites13:
+ax_sprite sPinecoGfx13, 0x200
+ax_sprite_terminator
+sPinecoGfx14:
+.incbin "baserom.gba", 0xE4226C, 0x200
+sPinecoSprites14:
+ax_sprite sPinecoGfx14, 0x200
+ax_sprite_terminator
+sPinecoGfx15:
+.incbin "baserom.gba", 0xE4247C, 0x200
+sPinecoSprites15:
+ax_sprite sPinecoGfx15, 0x200
+ax_sprite_terminator
+sPinecoGfx16:
+.incbin "baserom.gba", 0xE4268C, 0x40
+sPinecoGfx16_1:
+.incbin "baserom.gba", 0xE426CC, 0x100
+sPinecoGfx16_2:
+.incbin "baserom.gba", 0xE427CC, 0x40
+sPinecoSprites16:
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinecoGfx17:
+.incbin "baserom.gba", 0xE4284C, 0x40
+sPinecoGfx17_1:
+.incbin "baserom.gba", 0xE4288C, 0x100
+sPinecoGfx17_2:
+.incbin "baserom.gba", 0xE4298C, 0x40
+sPinecoSprites17:
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinecoGfx18:
+.incbin "baserom.gba", 0xE42A0C, 0x40
+sPinecoGfx18_1:
+.incbin "baserom.gba", 0xE42A4C, 0x100
+sPinecoGfx18_2:
+.incbin "baserom.gba", 0xE42B4C, 0x40
+sPinecoSprites18:
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinecoGfx19:
+.incbin "baserom.gba", 0xE42BCC, 0x40
+sPinecoGfx19_1:
+.incbin "baserom.gba", 0xE42C0C, 0x100
+sPinecoGfx19_2:
+.incbin "baserom.gba", 0xE42D0C, 0x40
+sPinecoSprites19:
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx19_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx19_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinecoGfx20:
+.incbin "baserom.gba", 0xE42D8C, 0x40
+sPinecoGfx20_1:
+.incbin "baserom.gba", 0xE42DCC, 0x100
+sPinecoGfx20_2:
+.incbin "baserom.gba", 0xE42ECC, 0x40
+sPinecoSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPinecoGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinecoGfx21:
+.incbin "baserom.gba", 0xE42F4C, 0x200
+sPinecoSprites21:
+ax_sprite sPinecoGfx21, 0x200
+ax_sprite_terminator
+sPinecoGfx22:
+.incbin "baserom.gba", 0xE4315C, 0x200
+sPinecoSprites22:
+ax_sprite sPinecoGfx22, 0x200
+ax_sprite_terminator
+sPinecoGfx23:
+.incbin "baserom.gba", 0xE4336C, 0x200
+sPinecoSprites23:
+ax_sprite sPinecoGfx23, 0x200
+ax_sprite_terminator
+sPinecoGfx24:
+.incbin "baserom.gba", 0xE4357C, 0x200
+sPinecoSprites24:
+ax_sprite sPinecoGfx24, 0x200
+ax_sprite_terminator
+sPinecoGfx25:
+.incbin "baserom.gba", 0xE4378C, 0x200
+sPinecoSprites25:
+ax_sprite sPinecoGfx25, 0x200
+ax_sprite_terminator
+sPinecoGfx26:
+.incbin "baserom.gba", 0xE4399C, 0x200
+sPinecoSprites26:
+ax_sprite sPinecoGfx26, 0x200
+ax_sprite_terminator
+sPinecoGfx27:
+.incbin "baserom.gba", 0xE43BAC, 0x200
+sPinecoSprites27:
+ax_sprite sPinecoGfx27, 0x200
+ax_sprite_terminator
+sAxPosesPineco:
+.4byte sPinecoPose1
+.4byte sPinecoPose2
+.4byte sPinecoPose3
+.4byte sPinecoPose4
+.4byte sPinecoPose5
+.4byte sPinecoPose6
+.4byte sPinecoPose7
+.4byte sPinecoPose8
+.4byte sPinecoPose9
+.4byte sPinecoPose10
+.4byte sPinecoPose11
+.4byte sPinecoPose12
+.4byte sPinecoPose13
+.4byte sPinecoPose14
+.4byte sPinecoPose15
+.4byte sPinecoPose16
+.4byte sPinecoPose17
+.4byte sPinecoPose18
+.4byte sPinecoPose19
+.4byte sPinecoPose20
+.4byte sPinecoPose21
+.4byte sPinecoPose22
+.4byte sPinecoPose23
+.4byte sPinecoPose24
+.4byte sPinecoPose25
+.4byte sPinecoPose26
+.4byte sPinecoPose27
+.4byte sPinecoPose28
+.4byte sPinecoPose29
+.4byte sPinecoPose30
+.4byte sPinecoPose31
+.4byte sPinecoPose32
+.4byte sPinecoPose33
+.4byte sPinecoPose34
+.4byte sPinecoPose35
+.4byte sPinecoPose36
+.4byte sPinecoPose37
+.4byte sPinecoPose38
+.4byte sPinecoPose39
+.4byte sPinecoPose40
+.4byte sPinecoPose41
+.4byte sPinecoPose42
+.4byte sPinecoPose43
+.4byte sPinecoPose44
+.4byte sPinecoPose45
+.4byte sPinecoPose46
+.4byte sPinecoPose47
+.4byte sPinecoPose48
+.4byte sPinecoPose49
+.4byte sPinecoPose50
+.4byte sPinecoPose51
+.4byte sPinecoPose52
+.4byte sPinecoPose53
+.4byte sPinecoPose54
+.4byte sPinecoPose55
+.4byte sPinecoPose56
+.4byte sPinecoPose57
+.4byte sPinecoPose58
+.4byte sPinecoPose59
+.4byte sPinecoPose60
+.4byte sPinecoPose61
+.4byte sPinecoPose62
+.4byte sPinecoPose63
+.4byte sPinecoPose64
+.4byte sPinecoPose65
+.4byte sPinecoPose66
+.4byte sPinecoPose67
+.4byte sPinecoPose68
+.4byte sPinecoPose69
+.4byte sPinecoPose70
+.4byte sPinecoPose71
+.4byte sPinecoPose72
+.4byte sPinecoPose73
+.4byte sPinecoPose74
+.4byte sPinecoPose75
+.4byte sPinecoPose76
+.4byte sPinecoPose77
+.4byte sPinecoPose78
+.4byte sPinecoPose79
+.4byte sPinecoPose80
+.4byte sPinecoPose81
+.4byte sPinecoPose82
+.4byte sPinecoPose83
+.4byte sPinecoPose84
+.4byte sPinecoPose85
+.4byte sPinecoPose86
+.4byte sPinecoPose87
+.4byte sPinecoPose88
+.4byte sPinecoPose89
+.4byte sPinecoPose90
+.4byte sPinecoPose91
+.4byte sPinecoPose92
+.4byte sPinecoPose93
+.4byte sPinecoPose94
+.4byte sPinecoPose95
+.4byte sPinecoPose96
+.4byte sPinecoPose97
+.4byte sPinecoPose98
+.4byte sPinecoPose99
+.4byte sPinecoPose100
+.4byte sPinecoPose101
+.4byte sPinecoPose102
+.4byte sPinecoPose103
+.4byte sPinecoPose104
+.4byte sPinecoPose105
+.4byte sPinecoPose106
+.4byte sPinecoPose107
+.4byte sPinecoPose108
+.4byte sPinecoPose109
+.4byte sPinecoPose110
+.4byte sPinecoPose111
+.4byte sPinecoPose112
+.4byte sPinecoPose113
+.4byte sPinecoPose114
+.4byte sPinecoPose115
+.4byte sPinecoPose116
+.4byte sPinecoPose117
+.4byte sPinecoPose118
+.4byte sPinecoPose119
+.4byte sPinecoPose120
+.4byte sPinecoPose121
+.4byte sPinecoPose122
+.4byte sPinecoPose123
+.4byte sPinecoPose124
+.4byte sPinecoPose125
+.4byte sPinecoPose126
+.4byte sPinecoPose127
+.4byte sPinecoPose128
+.4byte sPinecoPose129
+.4byte sPinecoPose130
+.4byte sPinecoPose131
+.4byte sPinecoPose132
+.4byte sPinecoPose133
+.4byte sPinecoPose134
+.4byte sPinecoPose135
+.4byte sPinecoPose136
+.4byte sPinecoPose137
+.4byte sPinecoPose138
+.4byte sPinecoPose139
+.4byte sPinecoPose140
+.4byte sPinecoPose141
+.4byte sPinecoPose142
+.4byte sPinecoPose143
+.4byte sPinecoPose144
+.4byte sPinecoPose145
+.4byte sPinecoPose146
+.4byte sPinecoPose147
+.4byte sPinecoPose148
+.4byte sPinecoPose149
+.4byte sPinecoPose150
+.4byte sPinecoPose151
+.4byte sPinecoPose152
+.4byte sPinecoPose153
+.4byte sPinecoPose154
+.4byte sPinecoPose155
+.4byte sPinecoPose156
+.4byte sPinecoPose157
+.4byte sPinecoPose158
+.4byte sPinecoPose159
+.4byte sPinecoPose160
+.4byte sPinecoPose161
+.4byte sPinecoPose162
+.4byte sPinecoPose163
+.4byte sPinecoPose164
+.4byte sPinecoPose165
+.4byte sPinecoPose166
+.4byte sPinecoPose167
+.4byte sPinecoPose168
+.4byte sPinecoPose169
+.4byte sPinecoPose170
+.4byte sPinecoPose171
+.4byte sPinecoPose172
+.4byte sPinecoPose173
+.4byte sPinecoPose174
+.4byte sPinecoPose175
+.4byte sPinecoPose176
+.4byte sPinecoPose177
+.4byte sPinecoPose178
+.4byte sPinecoPose179
+.4byte sPinecoPose180
+.4byte sPinecoPose181
+.4byte sPinecoPose182
+.4byte sPinecoPose183
+.4byte sPinecoPose184
+.4byte sPinecoPose185
+.4byte sPinecoPose186
+sAxPositionsPineco:
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte    0,   -7, 	  -7,  -10, 	   7,  -10, 	   0,  -10
+.2byte    0,   -8, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    2,   -7, 	   7,  -10, 	  -6,   -9, 	   0,   -9
+.2byte    2,   -8, 	   7,  -12, 	  -5,  -11, 	   0,  -10
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -8, 	   0,  -14, 	   0,   -7, 	   0,   -9
+.2byte    4,   -9, 	   0,  -15, 	   0,   -9, 	   0,  -10
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    1,  -10, 	  -4,  -11, 	   5,   -9, 	   0,   -9
+.2byte    1,  -11, 	  -4,  -14, 	   6,  -11, 	   0,  -10
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    0,  -10, 	   7,  -10, 	  -7,  -10, 	   0,   -9
+.2byte    0,  -11, 	   7,  -12, 	  -7,  -12, 	   0,  -10
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte   -1,  -10, 	   4,  -11, 	  -5,   -9, 	   0,   -9
+.2byte   -1,  -11, 	   4,  -14, 	  -6,  -11, 	   0,  -10
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -8, 	   0,  -14, 	   0,   -7, 	   0,   -9
+.2byte   -4,   -9, 	   0,  -15, 	   0,   -9, 	   0,  -10
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -2,   -7, 	  -7,  -10, 	   6,   -9, 	   0,   -9
+.2byte   -2,   -8, 	  -7,  -12, 	   5,  -11, 	   0,  -10
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte    0,   -7, 	  -7,  -10, 	   7,  -10, 	   0,  -10
+.2byte    0,   -8, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    2,   -7, 	   7,  -10, 	  -6,   -9, 	   0,   -9
+.2byte    2,   -8, 	   7,  -12, 	  -5,  -11, 	   0,  -10
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -7, 	   0,   -8
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    1,  -10, 	  -4,  -11, 	   5,   -9, 	   0,   -9
+.2byte    1,  -11, 	  -4,  -14, 	   6,  -11, 	   0,  -10
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    0,  -10, 	   7,  -10, 	  -7,  -10, 	   0,   -9
+.2byte    0,  -11, 	   7,  -12, 	  -7,  -12, 	   0,  -10
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte   -1,  -10, 	   4,  -11, 	  -5,   -9, 	   0,   -9
+.2byte   -1,  -11, 	   4,  -14, 	  -6,  -11, 	   0,  -10
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -7, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -2,   -7, 	  -7,  -10, 	   6,   -9, 	   0,   -9
+.2byte   -2,   -8, 	  -7,  -12, 	   5,  -11, 	   0,  -10
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte    0,   -7, 	  -7,  -10, 	   7,  -10, 	   0,  -10
+.2byte    0,   -8, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    2,   -7, 	   7,  -10, 	  -6,   -9, 	   0,   -9
+.2byte    2,   -8, 	   7,  -12, 	  -5,  -11, 	   0,  -10
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -7, 	   0,   -8
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    1,   -9, 	  -4,  -10, 	   5,   -8, 	   0,   -8
+.2byte    1,  -10, 	  -4,  -13, 	   6,  -10, 	   0,   -9
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    0,  -10, 	   7,  -10, 	  -7,  -10, 	   0,   -9
+.2byte    0,  -11, 	   7,  -12, 	  -7,  -12, 	   0,  -10
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte   -1,   -9, 	   4,  -10, 	  -5,   -8, 	   0,   -8
+.2byte   -1,  -10, 	   4,  -13, 	  -6,  -10, 	   0,   -9
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -7, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -2,   -7, 	  -7,  -10, 	   6,   -9, 	   0,   -9
+.2byte   -2,   -8, 	  -7,  -12, 	   5,  -11, 	   0,  -10
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -9,  -11, 	   9,  -11, 	   0,  -10
+.2byte   -3,   -6, 	  -9,  -11, 	   7,   -9, 	   0,  -10
+.2byte   -6,   -8, 	   0,  -17, 	   0,   -8, 	   0,  -10
+.2byte   -3,  -11, 	   5,  -16, 	  -7,   -9, 	   0,  -10
+.2byte    0,  -10, 	   9,  -10, 	  -9,  -10, 	   0,   -8
+.2byte    3,  -11, 	  -5,  -16, 	   7,   -9, 	   0,  -10
+.2byte    6,   -8, 	   0,  -17, 	   0,   -8, 	   0,  -10
+.2byte    3,   -6, 	   9,  -11, 	  -7,   -9, 	   0,  -10
+.2byte    0,   -8, 	   7,  -11, 	  -7,  -11, 	   0,  -11
+.2byte    0,   -7, 	   7,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    0,   -4, 	  -7,   -6, 	   7,   -7, 	   0,   -7
+.2byte    1,   -6, 	   4,  -12, 	  -7,   -6, 	  -2,   -7
+.2byte    3,   -9, 	  -2,  -11, 	   0,   -7, 	  -1,   -8
+.2byte    0,  -10, 	  -7,  -12, 	   2,   -6, 	  -3,   -7
+.2byte    0,  -10, 	   7,   -8, 	  -7,   -8, 	   0,   -9
+.2byte   -1,  -10, 	   6,  -12, 	  -3,   -6, 	   2,   -7
+.2byte   -4,   -8, 	   1,  -10, 	  -1,   -6, 	   0,   -7
+.2byte   -2,   -6, 	  -5,  -12, 	   6,   -6, 	   1,   -7
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte    0,   -7, 	  -7,  -10, 	   7,  -10, 	   0,  -10
+.2byte    0,   -8, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    2,   -7, 	   7,  -10, 	  -6,   -9, 	   0,   -9
+.2byte    2,   -8, 	   7,  -12, 	  -5,  -11, 	   0,  -10
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -8, 	   0,  -14, 	   0,   -7, 	   0,   -9
+.2byte    4,   -9, 	   0,  -15, 	   0,   -9, 	   0,  -10
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    1,  -10, 	  -4,  -11, 	   5,   -9, 	   0,   -9
+.2byte    1,  -11, 	  -4,  -14, 	   6,  -11, 	   0,  -10
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    0,  -10, 	   7,  -10, 	  -7,  -10, 	   0,   -9
+.2byte    0,  -11, 	   7,  -12, 	  -7,  -12, 	   0,  -10
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte   -1,  -10, 	   4,  -11, 	  -5,   -9, 	   0,   -9
+.2byte   -1,  -11, 	   4,  -14, 	  -6,  -11, 	   0,  -10
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -8, 	   0,  -14, 	   0,   -7, 	   0,   -9
+.2byte   -4,   -9, 	   0,  -15, 	   0,   -9, 	   0,  -10
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -2,   -7, 	  -7,  -10, 	   6,   -9, 	   0,   -9
+.2byte   -2,   -8, 	  -7,  -12, 	   5,  -11, 	   0,  -10
+.2byte    0,   -7, 	  -7,  -11, 	   7,  -11, 	   0,   -9
+.2byte   -2,   -7, 	  -7,  -11, 	   5,  -10, 	   0,   -9
+.2byte   -4,   -8, 	   0,  -14, 	   0,   -8, 	   0,   -9
+.2byte   -1,  -10, 	   4,  -13, 	  -6,  -10, 	   0,   -9
+.2byte    0,  -10, 	   7,  -11, 	  -7,  -11, 	   0,   -9
+.2byte    1,  -10, 	  -4,  -13, 	   6,  -10, 	   0,   -9
+.2byte    4,   -8, 	   0,  -14, 	   0,   -8, 	   0,   -9
+.2byte    2,   -7, 	   7,  -11, 	  -5,  -10, 	   0,   -9
+.2byte    0,   -7, 	  -7,  -11, 	   7,  -11, 	   0,   -9
+.2byte    2,   -7, 	   7,  -11, 	  -5,  -10, 	   0,   -9
+.2byte    4,   -8, 	   0,  -14, 	   0,   -8, 	   0,   -9
+.2byte    1,  -10, 	  -4,  -13, 	   6,  -10, 	   0,   -9
+.2byte    0,  -10, 	   7,  -11, 	  -7,  -11, 	   0,   -9
+.2byte   -1,  -10, 	   4,  -13, 	  -6,  -10, 	   0,   -9
+.2byte   -4,   -8, 	   0,  -14, 	   0,   -8, 	   0,   -9
+.2byte   -2,   -7, 	  -7,  -11, 	   5,  -10, 	   0,   -9
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -9
+.2byte    0,   -6, 	  -7,  -10, 	   7,  -10, 	   0,   -8
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -8, 	   0,   -8
+.2byte    2,   -6, 	   7,  -10, 	  -5,   -9, 	   0,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -7, 	   0,   -8
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    1,   -9, 	  -4,  -10, 	   5,   -8, 	   0,   -8
+.2byte    1,   -9, 	  -4,  -12, 	   6,   -9, 	   0,   -8
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    0,   -9, 	   7,   -9, 	  -7,   -9, 	   0,   -8
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -8
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte   -1,   -9, 	   4,  -10, 	  -5,   -8, 	   0,   -8
+.2byte   -1,   -9, 	   4,  -12, 	  -6,   -9, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -7, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -8, 	   0,   -8
+.2byte   -2,   -6, 	  -7,  -10, 	   5,   -9, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -9, 	   7,   -9, 	   0,   -8
+.2byte   -2,   -6, 	  -7,   -9, 	   6,   -7, 	   0,   -8
+.2byte   -4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -8, 	   1,   -8
+.2byte    0,   -8, 	   7,   -9, 	  -7,   -9, 	   0,   -9
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -8, 	  -1,   -8
+.2byte    4,   -7, 	   0,  -13, 	   0,   -6, 	   0,   -8
+.2byte    2,   -6, 	   7,   -9, 	  -6,   -7, 	   0,   -8
+sPinecoAnimTable1:
+.4byte sPinecoAnims_1_1
+.4byte sPinecoAnims_1_2
+.4byte sPinecoAnims_1_3
+.4byte sPinecoAnims_1_4
+.4byte sPinecoAnims_1_5
+.4byte sPinecoAnims_1_6
+.4byte sPinecoAnims_1_7
+.4byte sPinecoAnims_1_8
+sPinecoAnimTable2:
+.4byte sPinecoAnims_2_1
+.4byte sPinecoAnims_2_2
+.4byte sPinecoAnims_2_3
+.4byte sPinecoAnims_2_4
+.4byte sPinecoAnims_2_5
+.4byte sPinecoAnims_2_6
+.4byte sPinecoAnims_2_7
+.4byte sPinecoAnims_2_8
+sPinecoAnimTable3:
+.4byte sPinecoAnims_3_1
+.4byte sPinecoAnims_3_2
+.4byte sPinecoAnims_3_3
+.4byte sPinecoAnims_3_4
+.4byte sPinecoAnims_3_5
+.4byte sPinecoAnims_3_6
+.4byte sPinecoAnims_3_7
+.4byte sPinecoAnims_3_8
+sPinecoAnimTable4:
+.4byte sPinecoAnims_4_1
+.4byte sPinecoAnims_4_2
+.4byte sPinecoAnims_4_3
+.4byte sPinecoAnims_4_4
+.4byte sPinecoAnims_4_5
+.4byte sPinecoAnims_4_6
+.4byte sPinecoAnims_4_7
+.4byte sPinecoAnims_4_8
+sPinecoAnimTable5:
+.4byte sPinecoAnims_5_1
+.4byte sPinecoAnims_5_2
+.4byte sPinecoAnims_5_3
+.4byte sPinecoAnims_5_4
+.4byte sPinecoAnims_5_5
+.4byte sPinecoAnims_5_6
+.4byte sPinecoAnims_5_7
+.4byte sPinecoAnims_5_8
+sPinecoAnimTable6:
+.4byte sPinecoAnims_6_1
+.4byte sPinecoAnims_6_1
+.4byte sPinecoAnims_6_1
+.4byte sPinecoAnims_6_1
+.4byte sPinecoAnims_6_1
+.4byte sPinecoAnims_6_1
+.4byte sPinecoAnims_6_1
+.4byte sPinecoAnims_6_1
+sPinecoAnimTable7:
+.4byte sPinecoAnims_7_1
+.4byte sPinecoAnims_7_2
+.4byte sPinecoAnims_7_3
+.4byte sPinecoAnims_7_4
+.4byte sPinecoAnims_7_5
+.4byte sPinecoAnims_7_6
+.4byte sPinecoAnims_7_7
+.4byte sPinecoAnims_7_8
+sPinecoAnimTable8:
+.4byte sPinecoAnims_8_1
+.4byte sPinecoAnims_8_2
+.4byte sPinecoAnims_8_3
+.4byte sPinecoAnims_8_4
+.4byte sPinecoAnims_8_5
+.4byte sPinecoAnims_8_6
+.4byte sPinecoAnims_8_7
+.4byte sPinecoAnims_8_8
+sPinecoAnimTable9:
+.4byte sPinecoAnims_9_1
+.4byte sPinecoAnims_9_2
+.4byte sPinecoAnims_9_3
+.4byte sPinecoAnims_9_4
+.4byte sPinecoAnims_9_5
+.4byte sPinecoAnims_9_6
+.4byte sPinecoAnims_9_7
+.4byte sPinecoAnims_9_8
+sPinecoAnimTable10:
+.4byte sPinecoAnims_10_1
+.4byte sPinecoAnims_10_2
+.4byte sPinecoAnims_10_3
+.4byte sPinecoAnims_10_4
+.4byte sPinecoAnims_10_5
+.4byte sPinecoAnims_10_6
+.4byte sPinecoAnims_10_7
+.4byte sPinecoAnims_10_8
+sPinecoAnimTable11:
+.4byte sPinecoAnims_11_1
+.4byte sPinecoAnims_11_2
+.4byte sPinecoAnims_11_3
+.4byte sPinecoAnims_11_4
+.4byte sPinecoAnims_11_5
+.4byte sPinecoAnims_11_6
+.4byte sPinecoAnims_11_7
+.4byte sPinecoAnims_11_8
+sPinecoAnimTable12:
+.4byte sPinecoAnims_12_1
+.4byte sPinecoAnims_12_2
+.4byte sPinecoAnims_12_3
+.4byte sPinecoAnims_12_4
+.4byte sPinecoAnims_12_5
+.4byte sPinecoAnims_12_6
+.4byte sPinecoAnims_12_7
+.4byte sPinecoAnims_12_8
+sPinecoAnimTable13:
+.4byte sPinecoAnims_13_1
+.4byte sPinecoAnims_13_2
+.4byte sPinecoAnims_13_3
+.4byte sPinecoAnims_13_4
+.4byte sPinecoAnims_13_5
+.4byte sPinecoAnims_13_6
+.4byte sPinecoAnims_13_7
+.4byte sPinecoAnims_13_8
+sAxAnimationsPineco:
+.4byte sPinecoAnimTable1
+.4byte sPinecoAnimTable2
+.4byte sPinecoAnimTable3
+.4byte sPinecoAnimTable4
+.4byte sPinecoAnimTable5
+.4byte sPinecoAnimTable6
+.4byte sPinecoAnimTable7
+.4byte sPinecoAnimTable8
+.4byte sPinecoAnimTable9
+.4byte sPinecoAnimTable10
+.4byte sPinecoAnimTable11
+.4byte sPinecoAnimTable12
+.4byte sPinecoAnimTable13
+sAxSpritesPineco:
+.4byte sPinecoSprites1
+.4byte sPinecoSprites2
+.4byte sPinecoSprites3
+.4byte sPinecoSprites4
+.4byte sPinecoSprites5
+.4byte sPinecoSprites6
+.4byte sPinecoSprites7
+.4byte sPinecoSprites8
+.4byte sPinecoSprites9
+.4byte sPinecoSprites10
+.4byte sPinecoSprites11
+.4byte sPinecoSprites12
+.4byte sPinecoSprites13
+.4byte sPinecoSprites14
+.4byte sPinecoSprites15
+.4byte sPinecoSprites16
+.4byte sPinecoSprites17
+.4byte sPinecoSprites18
+.4byte sPinecoSprites19
+.4byte sPinecoSprites20
+.4byte sPinecoSprites21
+.4byte sPinecoSprites22
+.4byte sPinecoSprites23
+.4byte sPinecoSprites24
+.4byte sPinecoSprites25
+.4byte sPinecoSprites26
+.4byte sPinecoSprites27
+sAxMainPineco:
+ax_main sAxPosesPineco, sAxAnimationsPineco, 13, sAxSpritesPineco, sAxPositionsPineco

--- a/data/ax/pinsir.inc
+++ b/data/ax/pinsir.inc
@@ -1,0 +1,2430 @@
+.global gAxPinsir
+gAxPinsir:
+ax_siro sAxMainPinsir
+sPinsirPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose4:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose5:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose6:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose9:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose10:
+ax_pose 9, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose11:
+ax_pose 10, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose12:
+ax_pose 11, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose16:
+ax_pose 9, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose17:
+ax_pose 10, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose18:
+ax_pose 11, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose22:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose23:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose24:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose28:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose29:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose30:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose31:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose32:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose33:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose34:
+ax_pose 9, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose35:
+ax_pose 10, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose36:
+ax_pose 11, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose37:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose38:
+ax_pose 13, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose39:
+ax_pose 14, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose40:
+ax_pose 9, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose41:
+ax_pose 10, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose42:
+ax_pose 11, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose43:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose44:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose45:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose46:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose47:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose48:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose50:
+ax_pose 1, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose51:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose52:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose53:
+ax_pose 16, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose54:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose55:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose56:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose57:
+ax_pose 17, 0x01ea, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose58:
+ax_pose 18, 0x01ea, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose59:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose60:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose61:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose62:
+ax_pose 19, 0x01e5, 0x90f4, 0x6c00
+ax_pose_terminator
+sPinsirPose63:
+ax_pose 20, 0x01e5, 0x90f4, 0x6c00
+ax_pose_terminator
+sPinsirPose64:
+ax_pose 9, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose65:
+ax_pose 10, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose66:
+ax_pose 11, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose67:
+ax_pose 21, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose68:
+ax_pose 22, 0x01e5, 0x90f2, 0x6c00
+ax_pose_terminator
+sPinsirPose69:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose70:
+ax_pose 13, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose71:
+ax_pose 14, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose72:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose73:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose74:
+ax_pose 9, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose75:
+ax_pose 10, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose76:
+ax_pose 11, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose77:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sPinsirPose78:
+ax_pose 22, 0x01e5, 0x80ed, 0x6c00
+ax_pose_terminator
+sPinsirPose79:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose80:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose81:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose82:
+ax_pose 19, 0x01e5, 0x80eb, 0x6c00
+ax_pose_terminator
+sPinsirPose83:
+ax_pose 20, 0x01e5, 0x80eb, 0x6c00
+ax_pose_terminator
+sPinsirPose84:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose85:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose86:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose87:
+ax_pose 17, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sPinsirPose88:
+ax_pose 18, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sPinsirPose89:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose90:
+ax_pose 17, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sPinsirPose91:
+ax_pose 19, 0x01e6, 0x80eb, 0x6c00
+ax_pose_terminator
+sPinsirPose92:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sPinsirPose93:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose94:
+ax_pose 21, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose95:
+ax_pose 19, 0x01e6, 0x90f4, 0x6c00
+ax_pose_terminator
+sPinsirPose96:
+ax_pose 17, 0x01ea, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose97:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose98:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose99:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose100:
+ax_pose 9, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose101:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose102:
+ax_pose 9, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose103:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose104:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose105:
+ax_pose 25, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose106:
+ax_pose 26, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose107:
+ax_pose 27, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sPinsirPose108:
+ax_pose 28, 0x01e2, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose109:
+ax_pose 29, 0x01e2, 0x90f0, 0x6c00
+ax_pose_terminator
+sPinsirPose110:
+ax_pose 30, 0x01e1, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose111:
+ax_pose 31, 0x01e0, 0x80f1, 0x6c00
+ax_pose_terminator
+sPinsirPose112:
+ax_pose 30, 0x01e1, 0x80f1, 0x6c00
+ax_pose_terminator
+sPinsirPose113:
+ax_pose 29, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose114:
+ax_pose 28, 0x01e2, 0x80f1, 0x6c00
+ax_pose_terminator
+sPinsirPose115:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose116:
+ax_pose 1, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose117:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose118:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose119:
+ax_pose 4, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose120:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose121:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose122:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose123:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose124:
+ax_pose 9, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose125:
+ax_pose 10, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose126:
+ax_pose 11, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose127:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose128:
+ax_pose 13, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose129:
+ax_pose 14, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose130:
+ax_pose 9, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose131:
+ax_pose 10, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose132:
+ax_pose 11, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose133:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose134:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose135:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose136:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose137:
+ax_pose 4, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose138:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose139:
+ax_pose 2, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose140:
+ax_pose 4, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose141:
+ax_pose 7, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose142:
+ax_pose 10, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose143:
+ax_pose 13, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose144:
+ax_pose 11, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sPinsirPose145:
+ax_pose 8, 0x01e4, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose146:
+ax_pose 5, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sPinsirPose147:
+ax_pose 2, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose148:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose149:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose150:
+ax_pose 11, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose151:
+ax_pose 14, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose152:
+ax_pose 11, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose153:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose154:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose155:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose156:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose157:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose158:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose159:
+ax_pose 5, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose160:
+ax_pose 17, 0x01ea, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose161:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose162:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose163:
+ax_pose 19, 0x01e5, 0x90f3, 0x6c00
+ax_pose_terminator
+sPinsirPose164:
+ax_pose 9, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose165:
+ax_pose 11, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose166:
+ax_pose 21, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sPinsirPose167:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose168:
+ax_pose 14, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose169:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose170:
+ax_pose 9, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sPinsirPose171:
+ax_pose 11, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sPinsirPose172:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose173:
+ax_pose 6, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sPinsirPose174:
+ax_pose 8, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sPinsirPose175:
+ax_pose 19, 0x01e5, 0x80ed, 0x6c00
+ax_pose_terminator
+sPinsirPose176:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sPinsirPose177:
+ax_pose 5, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sPinsirPose178:
+ax_pose 17, 0x01ea, 0x80ef, 0x6c00
+ax_pose_terminator
+sPinsirPose179:
+ax_pose 15, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose180:
+ax_pose 17, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sPinsirPose181:
+ax_pose 19, 0x01e6, 0x80eb, 0x6c00
+ax_pose_terminator
+sPinsirPose182:
+ax_pose 21, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sPinsirPose183:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose184:
+ax_pose 21, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose185:
+ax_pose 19, 0x01e6, 0x90f4, 0x6c00
+ax_pose_terminator
+sPinsirPose186:
+ax_pose 17, 0x01ea, 0x90f1, 0x6c00
+ax_pose_terminator
+sPinsirPose187:
+ax_pose 0, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose188:
+ax_pose 3, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose189:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose190:
+ax_pose 9, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sPinsirPose191:
+ax_pose 12, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sPinsirPose192:
+ax_pose 9, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sPinsirPose193:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sPinsirPose194:
+ax_pose 3, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+.align 2
+sPinsirAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_2_1:
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 4, 0, 46, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 2, 0, 2,
+ax_anim 1, 2, 25, 0, 7, 0, 7,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 8, 0, 8,
+ax_anim_terminator
+sPinsirAnims_2_2:
+ax_anim 2, 0, 26, -1, -1, -1, -1,
+ax_anim 4, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 2, 2, 2, 2,
+ax_anim 1, 2, 28, 6, 6, 6, 6,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 1, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sPinsirAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 4, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 2, 0, 0, 0,
+ax_anim 1, 2, 31, 9, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 10, 0,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 1, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 0, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 31, 6, 0, 6, 0,
+ax_anim_terminator
+sPinsirAnims_2_4:
+ax_anim 2, 0, 32, -1, 1, -1, 1,
+ax_anim 4, 0, 32, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 2, -2, 2, -2,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 35, 10, -11, 10, -11,
+ax_anim 2, 0, 37, 18, -20, 18, -20,
+ax_anim 2, 1, 37, 19, -19, 19, -19,
+ax_anim 2, 0, 37, 18, -20, 18, -20,
+ax_anim 2, 0, 37, 19, -19, 19, -19,
+ax_anim 2, 0, 34, 8, -8, 8, -8,
+ax_anim_terminator
+sPinsirAnims_2_5:
+ax_anim 2, 0, 35, 0, 1, 0, 1,
+ax_anim 4, 0, 35, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, -2, 0, -2,
+ax_anim 1, 2, 38, 0, -6, 0, -6,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -19, 0, -19,
+ax_anim 2, 1, 40, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -19, 0, -19,
+ax_anim 2, 0, 40, 1, -19, 1, -19,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim_terminator
+sPinsirAnims_2_6:
+ax_anim 2, 0, 37, 1, 1, 1, 1,
+ax_anim 4, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -11, -10, -11,
+ax_anim 2, 0, 40, -18, -20, -18, -20,
+ax_anim 2, 1, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 40, -18, -20, -18, -20,
+ax_anim 2, 0, 40, -19, -19, -19, -19,
+ax_anim 2, 0, 41, -6, -6, -6, -6,
+ax_anim_terminator
+sPinsirAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 4, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 43, -2, -1, -2, -1,
+ax_anim 1, 2, 44, -5, -1, -5, -1,
+ax_anim 1, 0, 43, -11, -1, -11, -1,
+ax_anim 2, 0, 46, -18, 0, -18, 0,
+ax_anim 2, 1, 46, -18, 1, -18, 1,
+ax_anim 2, 0, 46, -18, 0, -18, 0,
+ax_anim 2, 0, 46, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim_terminator
+sPinsirAnims_2_8:
+ax_anim 2, 0, 44, 3, -3, 3, -3,
+ax_anim 4, 0, 44, 4, -4, 4, -4,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 25, -18, 19, -18, 19,
+ax_anim 2, 1, 25, -19, 18, -19, 18,
+ax_anim 2, 0, 25, -18, 19, -18, 19,
+ax_anim 2, 0, 25, -19, 18, -19, 18,
+ax_anim 2, 0, 47, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPinsirAnims_3_1:
+ax_anim 2, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, -5, 0, -5,
+ax_anim 4, 0, 49, 0, -6, 0, -6,
+ax_anim 1, 0, 50, 0, 1, 0, 1,
+ax_anim 1, 2, 51, 0, 6, 0, 6,
+ax_anim 4, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 52, 0, 17, 0, 17,
+ax_anim 2, 1, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 52, 0, 17, 0, 17,
+ax_anim 2, 0, 51, 0, 17, 0, 17,
+ax_anim 2, 0, 52, 0, 17, 0, 17,
+ax_anim 2, 0, 49, 0, 8, 0, 8,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sPinsirAnims_3_2:
+ax_anim 2, 0, 54, -3, -3, -3, -3,
+ax_anim 2, 0, 54, -5, -5, -5, -5,
+ax_anim 4, 0, 54, -6, -6, -6, -6,
+ax_anim 1, 0, 55, 1, 1, 1, 1,
+ax_anim 1, 2, 56, 6, 6, 6, 6,
+ax_anim 4, 0, 56, 16, 16, 16, 16,
+ax_anim 2, 0, 57, 16, 16, 16, 16,
+ax_anim 2, 1, 56, 16, 16, 16, 16,
+ax_anim 2, 0, 57, 16, 16, 16, 16,
+ax_anim 2, 0, 56, 16, 16, 16, 16,
+ax_anim 2, 0, 57, 16, 16, 16, 16,
+ax_anim 2, 0, 54, 8, 8, 8, 8,
+ax_anim 2, 0, 53, 4, 4, 4, 4,
+ax_anim_terminator
+sPinsirAnims_3_3:
+ax_anim 2, 0, 59, -3, 0, -3, 0,
+ax_anim 2, 0, 59, -5, 0, -5, 0,
+ax_anim 4, 0, 59, -6, 0, -6, 0,
+ax_anim 1, 0, 60, 1, 0, 1, 0,
+ax_anim 1, 2, 61, 8, 0, 8, 0,
+ax_anim 4, 0, 61, 14, 0, 14, 0,
+ax_anim 2, 0, 62, 14, 0, 14, 0,
+ax_anim 2, 1, 61, 14, 0, 14, 0,
+ax_anim 2, 0, 62, 14, 0, 14, 0,
+ax_anim 2, 0, 61, 14, 0, 14, 0,
+ax_anim 2, 0, 62, 14, 0, 14, 0,
+ax_anim 2, 0, 58, 8, 0, 8, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim_terminator
+sPinsirAnims_3_4:
+ax_anim 2, 0, 64, -3, 3, -3, 3,
+ax_anim 2, 0, 64, -5, 5, -5, 5,
+ax_anim 4, 0, 64, -6, 6, -6, 6,
+ax_anim 1, 0, 65, 1, -1, 1, -1,
+ax_anim 1, 2, 66, 6, -6, 6, -6,
+ax_anim 4, 0, 66, 16, -16, 16, -16,
+ax_anim 2, 0, 67, 16, -16, 16, -16,
+ax_anim 2, 1, 66, 16, -16, 16, -16,
+ax_anim 2, 0, 67, 16, -16, 16, -16,
+ax_anim 2, 0, 66, 16, -16, 16, -16,
+ax_anim 2, 0, 67, 16, -16, 16, -16,
+ax_anim 2, 0, 64, 8, -8, 8, -8,
+ax_anim 2, 0, 63, 4, -4, 4, -4,
+ax_anim_terminator
+sPinsirAnims_3_5:
+ax_anim 2, 0, 69, 0, 3, 0, 3,
+ax_anim 2, 0, 69, 0, 5, 0, 5,
+ax_anim 4, 0, 69, 0, 6, 0, 6,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 71, 0, -6, 0, -6,
+ax_anim 4, 0, 71, 0, -16, 0, -16,
+ax_anim 2, 0, 72, 0, -16, 0, -16,
+ax_anim 2, 1, 71, 0, -16, 0, -16,
+ax_anim 2, 0, 72, 0, -16, 0, -16,
+ax_anim 2, 0, 71, 0, -16, 0, -16,
+ax_anim 2, 0, 72, 0, -16, 0, -16,
+ax_anim 2, 0, 69, 0, -8, 0, -8,
+ax_anim 2, 0, 68, 0, -4, 0, -4,
+ax_anim_terminator
+sPinsirAnims_3_6:
+ax_anim 2, 0, 74, 3, 3, 3, 3,
+ax_anim 2, 0, 74, 5, 5, 5, 5,
+ax_anim 4, 0, 74, 6, 6, 6, 6,
+ax_anim 1, 0, 75, -1, -1, -1, -1,
+ax_anim 1, 2, 76, -6, -6, -6, -6,
+ax_anim 4, 0, 76, -16, -16, -16, -16,
+ax_anim 2, 0, 77, -16, -16, -16, -16,
+ax_anim 2, 1, 76, -16, -16, -16, -16,
+ax_anim 2, 0, 77, -16, -16, -16, -16,
+ax_anim 2, 0, 76, -16, -16, -16, -16,
+ax_anim 2, 0, 77, -16, -16, -16, -16,
+ax_anim 2, 0, 74, -8, -8, -8, -8,
+ax_anim 2, 0, 73, -4, -4, -4, -4,
+ax_anim_terminator
+sPinsirAnims_3_7:
+ax_anim 2, 0, 79, 3, 0, 3, 0,
+ax_anim 2, 0, 79, 5, 0, 5, 0,
+ax_anim 4, 0, 79, 6, 0, 6, 0,
+ax_anim 1, 0, 80, -1, 0, -1, 0,
+ax_anim 1, 2, 81, -8, 0, -8, 0,
+ax_anim 4, 0, 81, -14, 0, -14, 0,
+ax_anim 2, 0, 82, -14, 0, -14, 0,
+ax_anim 2, 1, 81, -14, 0, -14, 0,
+ax_anim 2, 0, 82, -14, 0, -14, 0,
+ax_anim 2, 0, 81, -14, 0, -14, 0,
+ax_anim 2, 0, 82, -14, 0, -14, 0,
+ax_anim 2, 0, 78, -8, 0, -8, 0,
+ax_anim 2, 0, 78, -4, 0, -4, 0,
+ax_anim_terminator
+sPinsirAnims_3_8:
+ax_anim 2, 0, 84, 3, -3, 3, -3,
+ax_anim 2, 0, 84, 5, -5, 5, -5,
+ax_anim 4, 0, 84, 6, -6, 6, -6,
+ax_anim 1, 0, 85, -1, 1, -1, 1,
+ax_anim 1, 2, 86, -6, 6, -6, 6,
+ax_anim 4, 0, 86, -16, 16, -16, 16,
+ax_anim 2, 0, 87, -16, 16, -16, 16,
+ax_anim 2, 1, 86, -16, 16, -16, 16,
+ax_anim 2, 0, 87, -16, 16, -16, 16,
+ax_anim 2, 0, 86, -16, 16, -16, 16,
+ax_anim 2, 0, 87, -16, 16, -16, 16,
+ax_anim 2, 0, 84, -8, 8, -8, 8,
+ax_anim 2, 0, 83, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sPinsirAnims_4_1:
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_4_2:
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_4_3:
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_4_4:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_4_5:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_4_6:
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_4_7:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_4_8:
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sPinsirAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sPinsirAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sPinsirAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sPinsirAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sPinsirAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sPinsirAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sPinsirAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPinsirAnims_8_1:
+ax_anim 40, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 6, 0, 116, 0, -4, 0, 0,
+ax_anim 3, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sPinsirAnims_8_2:
+ax_anim 40, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 6, 0, 118, 0, -4, 0, 0,
+ax_anim 3, 0, 118, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim_terminator
+sPinsirAnims_8_3:
+ax_anim 40, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 6, 0, 121, 0, -4, 0, 0,
+ax_anim 3, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim_terminator
+sPinsirAnims_8_4:
+ax_anim 40, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 6, 0, 125, 0, -4, 0, 0,
+ax_anim 3, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, 0,
+ax_anim_terminator
+sPinsirAnims_8_5:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -3, 0, 0,
+ax_anim 6, 0, 128, 0, -4, 0, 0,
+ax_anim 3, 0, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 128, 0, -1, 0, 0,
+ax_anim_terminator
+sPinsirAnims_8_6:
+ax_anim 40, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 6, 0, 131, 0, -4, 0, 0,
+ax_anim 3, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, 0,
+ax_anim_terminator
+sPinsirAnims_8_7:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 6, 0, 133, 0, -4, 0, 0,
+ax_anim 3, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -1, 0, 0,
+ax_anim_terminator
+sPinsirAnims_8_8:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -3, 0, 0,
+ax_anim 6, 0, 136, 0, -4, 0, 0,
+ax_anim 3, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 17, 7, 17,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -7, 17, -7, 17,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 19, 3, 19, 3,
+ax_anim 2, 0, 140, 23, 12, 23, 12,
+ax_anim 3, 0, 141, 22, 18, 22, 18,
+ax_anim 2, 3, 142, 15, 21, 15, 21,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 12, -8, 12, -8,
+ax_anim 2, 0, 139, 20, -5, 20, -5,
+ax_anim 3, 0, 140, 22, 0, 22, 0,
+ax_anim 2, 3, 141, 20, 4, 20, 4,
+ax_anim 2, 0, 142, 14, 7, 14, 7,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -8, 0, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -21, 12, -21,
+ax_anim 3, 0, 139, 20, -20, 20, -20,
+ax_anim 2, 3, 140, 21, -13, 21, -13,
+ax_anim 2, 0, 141, 18, -5, 18, -5,
+ax_anim 1, 0, 142, 11, 0, 11, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -7, -4, -7, -4,
+ax_anim 2, 0, 144, -10, -12, -10, -12,
+ax_anim 2, 0, 145, -9, -18, -9, -18,
+ax_anim 3, 0, 138, 0, -20, 0, -20,
+ax_anim 2, 3, 139, 8, -17, 8, -17,
+ax_anim 2, 0, 140, 10, -10, 10, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -8, 0, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -21, -12, -21,
+ax_anim 3, 0, 145, -20, -20, -20, -20,
+ax_anim 2, 3, 144, -21, -13, -21, -13,
+ax_anim 2, 0, 143, -18, -5, -18, -5,
+ax_anim 1, 0, 142, -11, 0, -11, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -12, -8, -12, -8,
+ax_anim 2, 0, 145, -20, -5, -20, -5,
+ax_anim 3, 0, 144, -22, 0, -22, 0,
+ax_anim 2, 3, 143, -20, 4, -20, 4,
+ax_anim 2, 0, 142, -14, 7, -14, 7,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -19, 3, -19, 3,
+ax_anim 2, 0, 144, -23, 12, -23, 12,
+ax_anim 3, 0, 143, -22, 18, -22, 18,
+ax_anim 2, 3, 142, -15, 21, -15, 21,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -19, 0, 0,
+ax_anim 4, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 156, 0, -24, 0, 0,
+ax_anim 2, 0, 156, 0, -21, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 3, 0, 159, 0, -24, 0, 0,
+ax_anim 2, 0, 159, 0, -22, 0, 0,
+ax_anim 1, 0, 159, 0, -14, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -19, 0, 0,
+ax_anim 4, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -20, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -22, 0, 0,
+ax_anim 4, 0, 163, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -19, 0, 0,
+ax_anim 4, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 4, 0, 169, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -19, 0, 0,
+ax_anim 4, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -20, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 3, 0, 177, 0, -24, 0, 0,
+ax_anim 2, 0, 177, 0, -22, 0, 0,
+ax_anim 1, 0, 177, 0, -14, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPinsirAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sPinsirGfx1:
+.incbin "baserom.gba", 0xA75BA4, 0x200
+sPinsirSprites1:
+ax_sprite sPinsirGfx1, 0x200
+ax_sprite_terminator
+sPinsirGfx2:
+.incbin "baserom.gba", 0xA75DB4, 0x200
+sPinsirSprites2:
+ax_sprite sPinsirGfx2, 0x200
+ax_sprite_terminator
+sPinsirGfx3:
+.incbin "baserom.gba", 0xA75FC4, 0x200
+sPinsirSprites3:
+ax_sprite sPinsirGfx3, 0x200
+ax_sprite_terminator
+sPinsirGfx4:
+.incbin "baserom.gba", 0xA761D4, 0x200
+sPinsirSprites4:
+ax_sprite sPinsirGfx4, 0x200
+ax_sprite_terminator
+sPinsirGfx5:
+.incbin "baserom.gba", 0xA763E4, 0x200
+sPinsirSprites5:
+ax_sprite sPinsirGfx5, 0x200
+ax_sprite_terminator
+sPinsirGfx6:
+.incbin "baserom.gba", 0xA765F4, 0x200
+sPinsirSprites6:
+ax_sprite sPinsirGfx6, 0x200
+ax_sprite_terminator
+sPinsirGfx7:
+.incbin "baserom.gba", 0xA76804, 0x200
+sPinsirSprites7:
+ax_sprite sPinsirGfx7, 0x200
+ax_sprite_terminator
+sPinsirGfx8:
+.incbin "baserom.gba", 0xA76A14, 0x200
+sPinsirSprites8:
+ax_sprite sPinsirGfx8, 0x200
+ax_sprite_terminator
+sPinsirGfx9:
+.incbin "baserom.gba", 0xA76C24, 0x200
+sPinsirSprites9:
+ax_sprite sPinsirGfx9, 0x200
+ax_sprite_terminator
+sPinsirGfx10:
+.incbin "baserom.gba", 0xA76E34, 0x200
+sPinsirSprites10:
+ax_sprite sPinsirGfx10, 0x200
+ax_sprite_terminator
+sPinsirGfx11:
+.incbin "baserom.gba", 0xA77044, 0x200
+sPinsirSprites11:
+ax_sprite sPinsirGfx11, 0x200
+ax_sprite_terminator
+sPinsirGfx12:
+.incbin "baserom.gba", 0xA77254, 0x200
+sPinsirSprites12:
+ax_sprite sPinsirGfx12, 0x200
+ax_sprite_terminator
+sPinsirGfx13:
+.incbin "baserom.gba", 0xA77464, 0x200
+sPinsirSprites13:
+ax_sprite sPinsirGfx13, 0x200
+ax_sprite_terminator
+sPinsirGfx14:
+.incbin "baserom.gba", 0xA77674, 0x200
+sPinsirSprites14:
+ax_sprite sPinsirGfx14, 0x200
+ax_sprite_terminator
+sPinsirGfx15:
+.incbin "baserom.gba", 0xA77884, 0x200
+sPinsirSprites15:
+ax_sprite sPinsirGfx15, 0x200
+ax_sprite_terminator
+sPinsirGfx16:
+.incbin "baserom.gba", 0xA77A94, 0x140
+sPinsirSprites16:
+ax_sprite 0, 0xa0
+ax_sprite sPinsirGfx16, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx17:
+.incbin "baserom.gba", 0xA77BF4, 0x140
+sPinsirSprites17:
+ax_sprite 0, 0xa0
+ax_sprite sPinsirGfx17, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx18:
+.incbin "baserom.gba", 0xA77D54, 0x140
+sPinsirSprites18:
+ax_sprite 0, 0xa0
+ax_sprite sPinsirGfx18, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx19:
+.incbin "baserom.gba", 0xA77EB4, 0x140
+sPinsirSprites19:
+ax_sprite 0, 0xa0
+ax_sprite sPinsirGfx19, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx20:
+.incbin "baserom.gba", 0xA78014, 0x100
+sPinsirGfx20_1:
+.incbin "baserom.gba", 0xA78114, 0x60
+sPinsirSprites20:
+ax_sprite 0, 0x80
+ax_sprite sPinsirGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx20_1, 0x60
+ax_sprite_terminator
+sPinsirGfx21:
+.incbin "baserom.gba", 0xA7819C, 0x100
+sPinsirGfx21_1:
+.incbin "baserom.gba", 0xA7829C, 0x60
+sPinsirSprites21:
+ax_sprite 0, 0x80
+ax_sprite sPinsirGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx21_1, 0x60
+ax_sprite_terminator
+sPinsirGfx22:
+.incbin "baserom.gba", 0xA78324, 0x40
+sPinsirGfx22_1:
+.incbin "baserom.gba", 0xA78364, 0x60
+sPinsirGfx22_2:
+.incbin "baserom.gba", 0xA783C4, 0x80
+sPinsirGfx22_3:
+.incbin "baserom.gba", 0xA78444, 0x40
+sPinsirSprites22:
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx22_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx23:
+.incbin "baserom.gba", 0xA784D4, 0x60
+sPinsirGfx23_1:
+.incbin "baserom.gba", 0xA78534, 0x60
+sPinsirGfx23_2:
+.incbin "baserom.gba", 0xA78594, 0x80
+sPinsirGfx23_3:
+.incbin "baserom.gba", 0xA78614, 0x40
+sPinsirSprites23:
+ax_sprite sPinsirGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx23_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx24:
+.incbin "baserom.gba", 0xA7869C, 0x160
+sPinsirGfx24_1:
+.incbin "baserom.gba", 0xA787FC, 0x60
+sPinsirSprites24:
+ax_sprite sPinsirGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx25:
+.incbin "baserom.gba", 0xA78884, 0x40
+sPinsirGfx25_1:
+.incbin "baserom.gba", 0xA788C4, 0x40
+sPinsirGfx25_2:
+.incbin "baserom.gba", 0xA78904, 0x60
+sPinsirGfx25_3:
+.incbin "baserom.gba", 0xA78964, 0x60
+sPinsirSprites25:
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPinsirGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPinsirGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPinsirGfx26:
+.incbin "baserom.gba", 0xA78A14, 0x200
+sPinsirSprites26:
+ax_sprite sPinsirGfx26, 0x200
+ax_sprite_terminator
+sPinsirGfx27:
+.incbin "baserom.gba", 0xA78C24, 0x200
+sPinsirSprites27:
+ax_sprite sPinsirGfx27, 0x200
+ax_sprite_terminator
+sPinsirGfx28:
+.incbin "baserom.gba", 0xA78E34, 0x200
+sPinsirSprites28:
+ax_sprite sPinsirGfx28, 0x200
+ax_sprite_terminator
+sPinsirGfx29:
+.incbin "baserom.gba", 0xA79044, 0x200
+sPinsirSprites29:
+ax_sprite sPinsirGfx29, 0x200
+ax_sprite_terminator
+sPinsirGfx30:
+.incbin "baserom.gba", 0xA79254, 0x200
+sPinsirSprites30:
+ax_sprite sPinsirGfx30, 0x200
+ax_sprite_terminator
+sPinsirGfx31:
+.incbin "baserom.gba", 0xA79464, 0x200
+sPinsirSprites31:
+ax_sprite sPinsirGfx31, 0x200
+ax_sprite_terminator
+sPinsirGfx32:
+.incbin "baserom.gba", 0xA79674, 0x200
+sPinsirSprites32:
+ax_sprite sPinsirGfx32, 0x200
+ax_sprite_terminator
+sAxPosesPinsir:
+.4byte sPinsirPose1
+.4byte sPinsirPose2
+.4byte sPinsirPose3
+.4byte sPinsirPose4
+.4byte sPinsirPose5
+.4byte sPinsirPose6
+.4byte sPinsirPose7
+.4byte sPinsirPose8
+.4byte sPinsirPose9
+.4byte sPinsirPose10
+.4byte sPinsirPose11
+.4byte sPinsirPose12
+.4byte sPinsirPose13
+.4byte sPinsirPose14
+.4byte sPinsirPose15
+.4byte sPinsirPose16
+.4byte sPinsirPose17
+.4byte sPinsirPose18
+.4byte sPinsirPose19
+.4byte sPinsirPose20
+.4byte sPinsirPose21
+.4byte sPinsirPose22
+.4byte sPinsirPose23
+.4byte sPinsirPose24
+.4byte sPinsirPose25
+.4byte sPinsirPose26
+.4byte sPinsirPose27
+.4byte sPinsirPose28
+.4byte sPinsirPose29
+.4byte sPinsirPose30
+.4byte sPinsirPose31
+.4byte sPinsirPose32
+.4byte sPinsirPose33
+.4byte sPinsirPose34
+.4byte sPinsirPose35
+.4byte sPinsirPose36
+.4byte sPinsirPose37
+.4byte sPinsirPose38
+.4byte sPinsirPose39
+.4byte sPinsirPose40
+.4byte sPinsirPose41
+.4byte sPinsirPose42
+.4byte sPinsirPose43
+.4byte sPinsirPose44
+.4byte sPinsirPose45
+.4byte sPinsirPose46
+.4byte sPinsirPose47
+.4byte sPinsirPose48
+.4byte sPinsirPose49
+.4byte sPinsirPose50
+.4byte sPinsirPose51
+.4byte sPinsirPose52
+.4byte sPinsirPose53
+.4byte sPinsirPose54
+.4byte sPinsirPose55
+.4byte sPinsirPose56
+.4byte sPinsirPose57
+.4byte sPinsirPose58
+.4byte sPinsirPose59
+.4byte sPinsirPose60
+.4byte sPinsirPose61
+.4byte sPinsirPose62
+.4byte sPinsirPose63
+.4byte sPinsirPose64
+.4byte sPinsirPose65
+.4byte sPinsirPose66
+.4byte sPinsirPose67
+.4byte sPinsirPose68
+.4byte sPinsirPose69
+.4byte sPinsirPose70
+.4byte sPinsirPose71
+.4byte sPinsirPose72
+.4byte sPinsirPose73
+.4byte sPinsirPose74
+.4byte sPinsirPose75
+.4byte sPinsirPose76
+.4byte sPinsirPose77
+.4byte sPinsirPose78
+.4byte sPinsirPose79
+.4byte sPinsirPose80
+.4byte sPinsirPose81
+.4byte sPinsirPose82
+.4byte sPinsirPose83
+.4byte sPinsirPose84
+.4byte sPinsirPose85
+.4byte sPinsirPose86
+.4byte sPinsirPose87
+.4byte sPinsirPose88
+.4byte sPinsirPose89
+.4byte sPinsirPose90
+.4byte sPinsirPose91
+.4byte sPinsirPose92
+.4byte sPinsirPose93
+.4byte sPinsirPose94
+.4byte sPinsirPose95
+.4byte sPinsirPose96
+.4byte sPinsirPose97
+.4byte sPinsirPose98
+.4byte sPinsirPose99
+.4byte sPinsirPose100
+.4byte sPinsirPose101
+.4byte sPinsirPose102
+.4byte sPinsirPose103
+.4byte sPinsirPose104
+.4byte sPinsirPose105
+.4byte sPinsirPose106
+.4byte sPinsirPose107
+.4byte sPinsirPose108
+.4byte sPinsirPose109
+.4byte sPinsirPose110
+.4byte sPinsirPose111
+.4byte sPinsirPose112
+.4byte sPinsirPose113
+.4byte sPinsirPose114
+.4byte sPinsirPose115
+.4byte sPinsirPose116
+.4byte sPinsirPose117
+.4byte sPinsirPose118
+.4byte sPinsirPose119
+.4byte sPinsirPose120
+.4byte sPinsirPose121
+.4byte sPinsirPose122
+.4byte sPinsirPose123
+.4byte sPinsirPose124
+.4byte sPinsirPose125
+.4byte sPinsirPose126
+.4byte sPinsirPose127
+.4byte sPinsirPose128
+.4byte sPinsirPose129
+.4byte sPinsirPose130
+.4byte sPinsirPose131
+.4byte sPinsirPose132
+.4byte sPinsirPose133
+.4byte sPinsirPose134
+.4byte sPinsirPose135
+.4byte sPinsirPose136
+.4byte sPinsirPose137
+.4byte sPinsirPose138
+.4byte sPinsirPose139
+.4byte sPinsirPose140
+.4byte sPinsirPose141
+.4byte sPinsirPose142
+.4byte sPinsirPose143
+.4byte sPinsirPose144
+.4byte sPinsirPose145
+.4byte sPinsirPose146
+.4byte sPinsirPose147
+.4byte sPinsirPose148
+.4byte sPinsirPose149
+.4byte sPinsirPose150
+.4byte sPinsirPose151
+.4byte sPinsirPose152
+.4byte sPinsirPose153
+.4byte sPinsirPose154
+.4byte sPinsirPose155
+.4byte sPinsirPose156
+.4byte sPinsirPose157
+.4byte sPinsirPose158
+.4byte sPinsirPose159
+.4byte sPinsirPose160
+.4byte sPinsirPose161
+.4byte sPinsirPose162
+.4byte sPinsirPose163
+.4byte sPinsirPose164
+.4byte sPinsirPose165
+.4byte sPinsirPose166
+.4byte sPinsirPose167
+.4byte sPinsirPose168
+.4byte sPinsirPose169
+.4byte sPinsirPose170
+.4byte sPinsirPose171
+.4byte sPinsirPose172
+.4byte sPinsirPose173
+.4byte sPinsirPose174
+.4byte sPinsirPose175
+.4byte sPinsirPose176
+.4byte sPinsirPose177
+.4byte sPinsirPose178
+.4byte sPinsirPose179
+.4byte sPinsirPose180
+.4byte sPinsirPose181
+.4byte sPinsirPose182
+.4byte sPinsirPose183
+.4byte sPinsirPose184
+.4byte sPinsirPose185
+.4byte sPinsirPose186
+.4byte sPinsirPose187
+.4byte sPinsirPose188
+.4byte sPinsirPose189
+.4byte sPinsirPose190
+.4byte sPinsirPose191
+.4byte sPinsirPose192
+.4byte sPinsirPose193
+.4byte sPinsirPose194
+sAxPositionsPinsir:
+.2byte   -1,   -7, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -2, 	   9,   -5, 	  -1,   -7
+.2byte   -2,   -6, 	 -11,   -4, 	   7,   -2, 	  -1,   -7
+.2byte    3,   -8, 	  10,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte    1,   -7, 	  10,   -4, 	  -7,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   8,   -6, 	  -4,   -2, 	  -1,   -7
+.2byte    4,   -8, 	   6,   -7, 	   2,   -2, 	  -1,   -9
+.2byte    4,   -7, 	   7,   -6, 	   0,   -1, 	  -1,   -7
+.2byte    4,   -7, 	   5,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    1,  -11, 	  -3,  -15, 	   8,   -5, 	  -3,   -9
+.2byte    0,  -10, 	   0,  -14, 	   6,   -4, 	  -3,   -9
+.2byte   -1,  -11, 	  -5,  -11, 	  10,   -5, 	  -2,   -8
+.2byte   -1,  -12, 	   9,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,  -11, 	   8,   -8, 	 -10,   -5, 	   0,   -6
+.2byte   -1,  -11, 	   9,   -5, 	 -10,   -8, 	  -1,   -6
+.2byte   -3,  -11, 	   1,  -15, 	 -10,   -5, 	   1,   -9
+.2byte   -2,  -10, 	  -2,  -14, 	  -8,   -4, 	   1,   -9
+.2byte   -1,  -11, 	   3,  -11, 	 -12,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -8,   -7, 	  -4,   -2, 	  -1,   -9
+.2byte   -6,   -7, 	  -9,   -6, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -7, 	  -7,   -6, 	  -7,   -2, 	  -1,   -7
+.2byte   -5,   -8, 	 -12,   -6, 	   4,   -3, 	  -1,   -8
+.2byte   -3,   -7, 	 -12,   -4, 	   5,   -2, 	  -1,   -7
+.2byte   -6,   -7, 	 -10,   -6, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -7, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -2, 	   9,   -5, 	  -1,   -7
+.2byte   -2,   -6, 	 -11,   -4, 	   7,   -2, 	  -1,   -7
+.2byte    3,   -8, 	  10,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte    1,   -7, 	  10,   -4, 	  -7,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   8,   -6, 	  -4,   -2, 	  -1,   -7
+.2byte    4,   -8, 	   6,   -7, 	   2,   -2, 	  -1,   -9
+.2byte    4,   -7, 	   7,   -6, 	   0,   -1, 	  -1,   -7
+.2byte    4,   -7, 	   5,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    1,  -11, 	  -3,  -15, 	   8,   -5, 	  -3,   -9
+.2byte    0,  -10, 	   0,  -14, 	   6,   -4, 	  -3,   -9
+.2byte   -1,  -11, 	  -5,  -11, 	  10,   -5, 	  -2,   -8
+.2byte   -1,  -12, 	   9,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,  -11, 	   8,   -8, 	 -10,   -5, 	   0,   -6
+.2byte   -1,  -11, 	   9,   -5, 	 -10,   -8, 	  -1,   -6
+.2byte   -3,  -11, 	   1,  -15, 	 -10,   -5, 	   1,   -9
+.2byte   -2,  -10, 	  -2,  -14, 	  -8,   -4, 	   1,   -9
+.2byte   -1,  -11, 	   3,  -11, 	 -12,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -8,   -7, 	  -4,   -2, 	  -1,   -9
+.2byte   -6,   -7, 	  -9,   -6, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -7, 	  -7,   -6, 	  -7,   -2, 	  -1,   -7
+.2byte   -5,   -8, 	 -12,   -6, 	   4,   -3, 	  -1,   -8
+.2byte   -3,   -7, 	 -12,   -4, 	   5,   -2, 	  -1,   -7
+.2byte   -6,   -7, 	 -10,   -6, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -7, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -2, 	   9,   -5, 	  -1,   -7
+.2byte   -2,   -6, 	 -11,   -4, 	   7,   -2, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -1, 	  10,   -9, 	  -1,   -7
+.2byte   -1,   -1, 	  -6,    0, 	  10,   -9, 	  -1,   -5
+.2byte    3,   -8, 	  10,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte    1,   -7, 	  10,   -4, 	  -7,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   8,   -6, 	  -4,   -2, 	  -1,   -7
+.2byte   -1,    0, 	   5,   -1, 	 -10,   -1, 	  -1,   -5
+.2byte    0,    0, 	   7,   -1, 	 -10,   -3, 	  -1,   -4
+.2byte    4,   -8, 	   6,   -7, 	   2,   -2, 	  -1,   -9
+.2byte    4,   -7, 	   7,   -6, 	   0,   -1, 	  -1,   -7
+.2byte    4,   -7, 	   5,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    4,   -6, 	   8,   -3, 	  -6,   -5, 	   1,   -8
+.2byte    4,   -5, 	   8,   -1, 	  -7,   -5, 	   1,   -7
+.2byte    1,  -11, 	  -3,  -15, 	   8,   -5, 	  -3,   -9
+.2byte    0,  -10, 	   0,  -14, 	   6,   -4, 	  -3,   -9
+.2byte   -1,  -11, 	  -5,  -11, 	  10,   -5, 	  -2,   -8
+.2byte    1,   -9, 	   2,  -14, 	   4,    0, 	  -1,   -8
+.2byte    4,   -8, 	   4,  -14, 	   3,   -1, 	   0,   -9
+.2byte   -1,  -12, 	   9,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,  -11, 	   8,   -8, 	 -10,   -5, 	   0,   -6
+.2byte   -1,  -11, 	   9,   -5, 	 -10,   -8, 	  -1,   -6
+.2byte    0,  -12, 	   2,  -13, 	 -11,   -5, 	   0,   -9
+.2byte    0,  -13, 	   1,  -15, 	 -10,   -5, 	   0,  -10
+.2byte   -3,  -11, 	   1,  -15, 	 -10,   -5, 	   1,   -9
+.2byte   -2,  -10, 	  -2,  -14, 	  -8,   -4, 	   1,   -9
+.2byte   -1,  -11, 	   3,  -11, 	 -12,   -5, 	   0,   -8
+.2byte   -3,   -9, 	  -4,  -14, 	  -6,    0, 	  -1,   -8
+.2byte   -6,   -8, 	  -6,  -14, 	  -5,   -1, 	  -2,   -9
+.2byte   -6,   -8, 	  -8,   -7, 	  -4,   -2, 	  -1,   -9
+.2byte   -6,   -7, 	  -9,   -6, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -7, 	  -7,   -6, 	  -7,   -2, 	  -1,   -7
+.2byte   -6,   -6, 	 -10,   -3, 	   4,   -5, 	  -3,   -8
+.2byte   -6,   -5, 	 -10,   -1, 	   5,   -5, 	  -3,   -7
+.2byte   -5,   -8, 	 -12,   -6, 	   4,   -3, 	  -1,   -8
+.2byte   -3,   -7, 	 -12,   -4, 	   5,   -2, 	  -1,   -7
+.2byte   -6,   -7, 	 -10,   -6, 	   2,   -2, 	  -1,   -7
+.2byte   -1,    0, 	  -7,   -1, 	   8,   -1, 	  -1,   -5
+.2byte   -2,    0, 	  -9,   -1, 	   8,   -3, 	  -1,   -4
+.2byte   -1,   -2, 	  -7,   -1, 	  10,   -9, 	  -1,   -7
+.2byte   -1,    0, 	  -7,   -1, 	   8,   -1, 	  -1,   -5
+.2byte   -6,   -5, 	 -10,   -2, 	   4,   -4, 	  -3,   -7
+.2byte   -3,   -9, 	  -4,  -14, 	  -6,    0, 	  -1,   -8
+.2byte    0,  -12, 	   2,  -13, 	 -11,   -5, 	   0,   -9
+.2byte    1,   -9, 	   2,  -14, 	   4,    0, 	  -1,   -8
+.2byte    4,   -5, 	   8,   -2, 	  -6,   -4, 	   1,   -7
+.2byte   -1,    0, 	   5,   -1, 	 -10,   -1, 	  -1,   -5
+.2byte   -1,   -7, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte   -5,   -8, 	 -12,   -6, 	   4,   -3, 	  -1,   -8
+.2byte   -6,   -8, 	  -8,   -7, 	  -4,   -2, 	  -1,   -9
+.2byte   -3,  -11, 	   1,  -15, 	 -10,   -5, 	   1,   -9
+.2byte   -1,  -12, 	   9,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    1,  -11, 	  -3,  -15, 	   8,   -5, 	  -3,   -9
+.2byte    4,   -8, 	   6,   -7, 	   2,   -2, 	  -1,   -9
+.2byte    3,   -8, 	  10,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte   -2,   -2, 	 -10,   -2, 	   6,    6, 	   1,   -6
+.2byte   -2,   -2, 	 -10,   -2, 	   6,    6, 	   2,   -6
+.2byte   -1,   -9, 	 -12,  -19, 	   9,  -18, 	   0,  -10
+.2byte    2,   -9, 	   8,  -17, 	  -9,  -15, 	  -2,  -10
+.2byte    3,  -10, 	   3,  -19, 	   1,  -17, 	  -2,  -10
+.2byte    0,  -13, 	  -5,  -20, 	   9,  -15, 	  -2,  -12
+.2byte    0,  -13, 	  10,  -18, 	 -10,  -18, 	   0,   -9
+.2byte   -1,  -13, 	   4,  -20, 	 -10,  -15, 	   1,  -12
+.2byte   -4,  -10, 	  -4,  -19, 	  -2,  -17, 	   1,  -10
+.2byte   -3,   -9, 	  -9,  -17, 	   8,  -15, 	   1,  -10
+.2byte   -1,   -7, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -2, 	   9,   -5, 	  -1,   -7
+.2byte   -2,   -6, 	 -11,   -4, 	   7,   -2, 	  -1,   -7
+.2byte    3,   -8, 	  10,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte    1,   -7, 	  10,   -4, 	  -7,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   8,   -6, 	  -4,   -2, 	  -1,   -7
+.2byte    4,   -8, 	   6,   -7, 	   2,   -2, 	  -1,   -9
+.2byte    4,   -7, 	   7,   -6, 	   0,   -1, 	  -1,   -7
+.2byte    4,   -7, 	   5,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    1,  -11, 	  -3,  -15, 	   8,   -5, 	  -3,   -9
+.2byte    0,  -10, 	   0,  -14, 	   6,   -4, 	  -3,   -9
+.2byte   -1,  -11, 	  -5,  -11, 	  10,   -5, 	  -2,   -8
+.2byte   -1,  -12, 	   9,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    0,  -11, 	   8,   -8, 	 -10,   -5, 	   0,   -6
+.2byte   -1,  -11, 	   9,   -5, 	 -10,   -8, 	  -1,   -6
+.2byte   -3,  -11, 	   1,  -15, 	 -10,   -5, 	   1,   -9
+.2byte   -2,  -10, 	  -2,  -14, 	  -8,   -4, 	   1,   -9
+.2byte   -1,  -11, 	   3,  -11, 	 -12,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -8,   -7, 	  -4,   -2, 	  -1,   -9
+.2byte   -6,   -7, 	  -9,   -6, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -7, 	  -7,   -6, 	  -7,   -2, 	  -1,   -7
+.2byte   -5,   -8, 	 -12,   -6, 	   4,   -3, 	  -1,   -8
+.2byte   -3,   -7, 	 -12,   -4, 	   5,   -2, 	  -1,   -7
+.2byte   -6,   -7, 	 -10,   -6, 	   2,   -2, 	  -1,   -7
+.2byte   -2,   -8, 	 -11,   -6, 	   7,   -4, 	  -1,   -9
+.2byte   -3,   -8, 	 -12,   -5, 	   5,   -3, 	  -1,   -8
+.2byte   -6,   -8, 	  -9,   -7, 	  -2,   -2, 	  -1,   -8
+.2byte   -2,  -10, 	  -2,  -14, 	  -8,   -4, 	   1,   -9
+.2byte    0,  -13, 	   8,  -10, 	 -10,   -7, 	   0,   -8
+.2byte    0,  -12, 	  -4,  -12, 	  11,   -6, 	  -1,   -9
+.2byte    4,   -8, 	   5,   -7, 	   5,   -3, 	  -1,   -8
+.2byte    5,   -8, 	   9,   -7, 	  -3,   -3, 	   0,   -8
+.2byte   -2,   -6, 	 -11,   -4, 	   7,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   8,   -6, 	  -4,   -2, 	  -1,   -7
+.2byte    4,   -7, 	   5,   -6, 	   5,   -2, 	  -1,   -7
+.2byte   -1,  -11, 	  -5,  -11, 	  10,   -5, 	  -2,   -8
+.2byte   -1,  -11, 	   9,   -5, 	 -10,   -8, 	  -1,   -6
+.2byte   -1,  -11, 	   3,  -11, 	 -12,   -5, 	   0,   -8
+.2byte   -6,   -7, 	  -7,   -6, 	  -7,   -2, 	  -1,   -7
+.2byte   -6,   -7, 	 -10,   -6, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -7, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte   -2,   -7, 	 -11,   -5, 	   7,   -3, 	  -1,   -8
+.2byte   -1,   -2, 	  -7,   -1, 	  10,   -9, 	  -1,   -7
+.2byte    3,   -8, 	  10,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte    4,   -7, 	   8,   -6, 	  -4,   -2, 	  -1,   -7
+.2byte   -1,    0, 	   5,   -1, 	 -10,   -1, 	  -1,   -5
+.2byte    4,   -8, 	   6,   -7, 	   2,   -2, 	  -1,   -9
+.2byte    4,   -7, 	   5,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    3,   -6, 	   7,   -3, 	  -7,   -5, 	   0,   -8
+.2byte    1,  -11, 	  -3,  -15, 	   8,   -5, 	  -3,   -9
+.2byte   -1,  -11, 	  -5,  -11, 	  10,   -5, 	  -2,   -8
+.2byte    0,   -9, 	   1,  -14, 	   3,    0, 	  -2,   -8
+.2byte   -1,  -12, 	   9,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte   -1,  -11, 	   9,   -5, 	 -10,   -8, 	  -1,   -6
+.2byte    0,  -12, 	   2,  -13, 	 -11,   -5, 	   0,   -9
+.2byte   -2,  -11, 	   2,  -15, 	  -9,   -5, 	   2,   -9
+.2byte    0,  -11, 	   4,  -11, 	 -11,   -5, 	   1,   -8
+.2byte   -1,   -9, 	  -2,  -14, 	  -4,    0, 	   1,   -8
+.2byte   -5,   -8, 	  -7,   -7, 	  -3,   -2, 	   0,   -9
+.2byte   -5,   -7, 	  -6,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -4,   -6, 	  -8,   -3, 	   6,   -5, 	  -1,   -8
+.2byte   -4,   -8, 	 -11,   -6, 	   5,   -3, 	   0,   -8
+.2byte   -5,   -7, 	  -9,   -6, 	   3,   -2, 	   0,   -7
+.2byte    0,    0, 	  -6,   -1, 	   9,   -1, 	   0,   -5
+.2byte   -1,   -2, 	  -7,   -1, 	  10,   -9, 	  -1,   -7
+.2byte   -1,    0, 	  -7,   -1, 	   8,   -1, 	  -1,   -5
+.2byte   -6,   -5, 	 -10,   -2, 	   4,   -4, 	  -3,   -7
+.2byte   -3,   -9, 	  -4,  -14, 	  -6,    0, 	  -1,   -8
+.2byte    0,  -12, 	   2,  -13, 	 -11,   -5, 	   0,   -9
+.2byte    1,   -9, 	   2,  -14, 	   4,    0, 	  -1,   -8
+.2byte    4,   -5, 	   8,   -2, 	  -6,   -4, 	   1,   -7
+.2byte   -1,    0, 	   5,   -1, 	 -10,   -1, 	  -1,   -5
+.2byte   -1,   -7, 	 -11,   -4, 	   9,   -4, 	  -1,   -8
+.2byte   -5,   -8, 	 -12,   -6, 	   4,   -3, 	  -1,   -8
+.2byte   -6,   -8, 	  -8,   -7, 	  -4,   -2, 	  -1,   -9
+.2byte   -3,  -11, 	   1,  -15, 	 -10,   -5, 	   1,   -9
+.2byte   -1,  -12, 	   9,   -7, 	 -11,   -7, 	  -1,   -8
+.2byte    1,  -11, 	  -3,  -15, 	   8,   -5, 	  -3,   -9
+.2byte    4,   -8, 	   6,   -7, 	   2,   -2, 	  -1,   -9
+.2byte    3,   -8, 	  10,   -6, 	  -6,   -3, 	  -1,   -8
+sPinsirAnimTable1:
+.4byte sPinsirAnims_1_1
+.4byte sPinsirAnims_1_2
+.4byte sPinsirAnims_1_3
+.4byte sPinsirAnims_1_4
+.4byte sPinsirAnims_1_5
+.4byte sPinsirAnims_1_6
+.4byte sPinsirAnims_1_7
+.4byte sPinsirAnims_1_8
+sPinsirAnimTable2:
+.4byte sPinsirAnims_2_1
+.4byte sPinsirAnims_2_2
+.4byte sPinsirAnims_2_3
+.4byte sPinsirAnims_2_4
+.4byte sPinsirAnims_2_5
+.4byte sPinsirAnims_2_6
+.4byte sPinsirAnims_2_7
+.4byte sPinsirAnims_2_8
+sPinsirAnimTable3:
+.4byte sPinsirAnims_3_1
+.4byte sPinsirAnims_3_2
+.4byte sPinsirAnims_3_3
+.4byte sPinsirAnims_3_4
+.4byte sPinsirAnims_3_5
+.4byte sPinsirAnims_3_6
+.4byte sPinsirAnims_3_7
+.4byte sPinsirAnims_3_8
+sPinsirAnimTable4:
+.4byte sPinsirAnims_4_1
+.4byte sPinsirAnims_4_2
+.4byte sPinsirAnims_4_3
+.4byte sPinsirAnims_4_4
+.4byte sPinsirAnims_4_5
+.4byte sPinsirAnims_4_6
+.4byte sPinsirAnims_4_7
+.4byte sPinsirAnims_4_8
+sPinsirAnimTable5:
+.4byte sPinsirAnims_5_1
+.4byte sPinsirAnims_5_2
+.4byte sPinsirAnims_5_3
+.4byte sPinsirAnims_5_4
+.4byte sPinsirAnims_5_5
+.4byte sPinsirAnims_5_6
+.4byte sPinsirAnims_5_7
+.4byte sPinsirAnims_5_8
+sPinsirAnimTable6:
+.4byte sPinsirAnims_6_1
+.4byte sPinsirAnims_6_1
+.4byte sPinsirAnims_6_1
+.4byte sPinsirAnims_6_1
+.4byte sPinsirAnims_6_1
+.4byte sPinsirAnims_6_1
+.4byte sPinsirAnims_6_1
+.4byte sPinsirAnims_6_1
+sPinsirAnimTable7:
+.4byte sPinsirAnims_7_1
+.4byte sPinsirAnims_7_2
+.4byte sPinsirAnims_7_3
+.4byte sPinsirAnims_7_4
+.4byte sPinsirAnims_7_5
+.4byte sPinsirAnims_7_6
+.4byte sPinsirAnims_7_7
+.4byte sPinsirAnims_7_8
+sPinsirAnimTable8:
+.4byte sPinsirAnims_8_1
+.4byte sPinsirAnims_8_2
+.4byte sPinsirAnims_8_3
+.4byte sPinsirAnims_8_4
+.4byte sPinsirAnims_8_5
+.4byte sPinsirAnims_8_6
+.4byte sPinsirAnims_8_7
+.4byte sPinsirAnims_8_8
+sPinsirAnimTable9:
+.4byte sPinsirAnims_9_1
+.4byte sPinsirAnims_9_2
+.4byte sPinsirAnims_9_3
+.4byte sPinsirAnims_9_4
+.4byte sPinsirAnims_9_5
+.4byte sPinsirAnims_9_6
+.4byte sPinsirAnims_9_7
+.4byte sPinsirAnims_9_8
+sPinsirAnimTable10:
+.4byte sPinsirAnims_10_1
+.4byte sPinsirAnims_10_2
+.4byte sPinsirAnims_10_3
+.4byte sPinsirAnims_10_4
+.4byte sPinsirAnims_10_5
+.4byte sPinsirAnims_10_6
+.4byte sPinsirAnims_10_7
+.4byte sPinsirAnims_10_8
+sPinsirAnimTable11:
+.4byte sPinsirAnims_11_1
+.4byte sPinsirAnims_11_2
+.4byte sPinsirAnims_11_3
+.4byte sPinsirAnims_11_4
+.4byte sPinsirAnims_11_5
+.4byte sPinsirAnims_11_6
+.4byte sPinsirAnims_11_7
+.4byte sPinsirAnims_11_8
+sPinsirAnimTable12:
+.4byte sPinsirAnims_12_1
+.4byte sPinsirAnims_12_2
+.4byte sPinsirAnims_12_3
+.4byte sPinsirAnims_12_4
+.4byte sPinsirAnims_12_5
+.4byte sPinsirAnims_12_6
+.4byte sPinsirAnims_12_7
+.4byte sPinsirAnims_12_8
+sPinsirAnimTable13:
+.4byte sPinsirAnims_13_1
+.4byte sPinsirAnims_13_2
+.4byte sPinsirAnims_13_3
+.4byte sPinsirAnims_13_4
+.4byte sPinsirAnims_13_5
+.4byte sPinsirAnims_13_6
+.4byte sPinsirAnims_13_7
+.4byte sPinsirAnims_13_8
+sAxAnimationsPinsir:
+.4byte sPinsirAnimTable1
+.4byte sPinsirAnimTable2
+.4byte sPinsirAnimTable3
+.4byte sPinsirAnimTable4
+.4byte sPinsirAnimTable5
+.4byte sPinsirAnimTable6
+.4byte sPinsirAnimTable7
+.4byte sPinsirAnimTable8
+.4byte sPinsirAnimTable9
+.4byte sPinsirAnimTable10
+.4byte sPinsirAnimTable11
+.4byte sPinsirAnimTable12
+.4byte sPinsirAnimTable13
+sAxSpritesPinsir:
+.4byte sPinsirSprites1
+.4byte sPinsirSprites2
+.4byte sPinsirSprites3
+.4byte sPinsirSprites4
+.4byte sPinsirSprites5
+.4byte sPinsirSprites6
+.4byte sPinsirSprites7
+.4byte sPinsirSprites8
+.4byte sPinsirSprites9
+.4byte sPinsirSprites10
+.4byte sPinsirSprites11
+.4byte sPinsirSprites12
+.4byte sPinsirSprites13
+.4byte sPinsirSprites14
+.4byte sPinsirSprites15
+.4byte sPinsirSprites16
+.4byte sPinsirSprites17
+.4byte sPinsirSprites18
+.4byte sPinsirSprites19
+.4byte sPinsirSprites20
+.4byte sPinsirSprites21
+.4byte sPinsirSprites22
+.4byte sPinsirSprites23
+.4byte sPinsirSprites24
+.4byte sPinsirSprites25
+.4byte sPinsirSprites26
+.4byte sPinsirSprites27
+.4byte sPinsirSprites28
+.4byte sPinsirSprites29
+.4byte sPinsirSprites30
+.4byte sPinsirSprites31
+.4byte sPinsirSprites32
+sAxMainPinsir:
+ax_main sAxPosesPinsir, sAxAnimationsPinsir, 13, sAxSpritesPinsir, sAxPositionsPinsir

--- a/data/ax/plusle.inc
+++ b/data/ax/plusle.inc
@@ -1,0 +1,2906 @@
+.global gAxPlusle
+gAxPlusle:
+ax_siro sAxMainPlusle
+sPluslePose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose4:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose5:
+ax_pose 4, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose6:
+ax_pose 5, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPluslePose7:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose8:
+ax_pose 7, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose9:
+ax_pose 8, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose10:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose11:
+ax_pose 10, 0x81ea, 0x90f5, 0x0c00
+ax_pose_terminator
+sPluslePose12:
+ax_pose 11, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose16:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose17:
+ax_pose 10, 0x81ea, 0x80fb, 0x0c00
+ax_pose_terminator
+sPluslePose18:
+ax_pose 11, 0x81ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose19:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose20:
+ax_pose 7, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose21:
+ax_pose 8, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose22:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose23:
+ax_pose 4, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose24:
+ax_pose 5, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose26:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose27:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose28:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sPluslePose29:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose30:
+ax_pose 4, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose31:
+ax_pose 5, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPluslePose32:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose33:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose34:
+ax_pose 7, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose35:
+ax_pose 8, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose36:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose37:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose38:
+ax_pose 10, 0x81ea, 0x90f5, 0x0c00
+ax_pose_terminator
+sPluslePose39:
+ax_pose 11, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose40:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose41:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose42:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose43:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose44:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose45:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose46:
+ax_pose 10, 0x81ea, 0x80fb, 0x0c00
+ax_pose_terminator
+sPluslePose47:
+ax_pose 11, 0x81ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose48:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose49:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose50:
+ax_pose 7, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose51:
+ax_pose 8, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose52:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose53:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose54:
+ax_pose 4, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose55:
+ax_pose 5, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose56:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose57:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose58:
+ax_pose 1, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose59:
+ax_pose 2, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose60:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sPluslePose61:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose62:
+ax_pose 4, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose63:
+ax_pose 5, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPluslePose64:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose65:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose66:
+ax_pose 7, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose67:
+ax_pose 8, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose68:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose69:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose70:
+ax_pose 10, 0x81ea, 0x90f5, 0x0c00
+ax_pose_terminator
+sPluslePose71:
+ax_pose 11, 0x81ea, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose72:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose73:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose74:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose75:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose76:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose77:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose78:
+ax_pose 10, 0x81ea, 0x80fb, 0x0c00
+ax_pose_terminator
+sPluslePose79:
+ax_pose 11, 0x81ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose80:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose81:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose82:
+ax_pose 7, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose83:
+ax_pose 8, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose84:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose85:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose86:
+ax_pose 4, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose87:
+ax_pose 5, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose88:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose89:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose90:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose91:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sPluslePose92:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose93:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose94:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose95:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose96:
+ax_pose 24, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sPluslePose97:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose98:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose99:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sPluslePose100:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose101:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose102:
+ax_pose 27, 0x81ec, 0x80f9, 0x0c00
+ax_pose 28, 0x01ec, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose103:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose104:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose105:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sPluslePose106:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose107:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose108:
+ax_pose 24, 0x81e9, 0x80fa, 0x0c00
+ax_pose_terminator
+sPluslePose109:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose110:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose111:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose112:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose113:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose114:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose115:
+ax_pose 29, 0x01e7, 0x80f0, 0x0c00
+ax_pose 15, 0x81e7, 0x80f8, 0x0c10
+ax_pose 16, 0x01ef, 0x0108, 0x0c18
+ax_pose_terminator
+sPluslePose116:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose 31, 0x01e7, 0x80f0, 0x0c10
+ax_pose_terminator
+sPluslePose117:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sPluslePose118:
+ax_pose 30, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sPluslePose119:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose120:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose121:
+ax_pose 32, 0x01e8, 0x90f1, 0x0c00
+ax_pose 17, 0x81e8, 0x90f9, 0x0c10
+ax_pose_terminator
+sPluslePose122:
+ax_pose 33, 0x01e8, 0x90f1, 0x0c00
+ax_pose 31, 0x01e8, 0x90f1, 0x0c10
+ax_pose_terminator
+sPluslePose123:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose124:
+ax_pose 33, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sPluslePose125:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose126:
+ax_pose 24, 0x81e9, 0x90f6, 0x0c00
+ax_pose_terminator
+sPluslePose127:
+ax_pose 34, 0x01e8, 0x90f0, 0x0c00
+ax_pose 18, 0x81e8, 0x90f8, 0x0c10
+ax_pose_terminator
+sPluslePose128:
+ax_pose 35, 0x01e8, 0x90f0, 0x0c00
+ax_pose 36, 0x01e8, 0x90f0, 0x0c10
+ax_pose_terminator
+sPluslePose129:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose130:
+ax_pose 35, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sPluslePose131:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose132:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sPluslePose133:
+ax_pose 32, 0x01e8, 0x90f2, 0x0c00
+ax_pose 19, 0x81e8, 0x90f9, 0x0c10
+ax_pose_terminator
+sPluslePose134:
+ax_pose 37, 0x01e8, 0x90f1, 0x0c00
+ax_pose 38, 0x01e7, 0x90f1, 0x0c10
+ax_pose_terminator
+sPluslePose135:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose136:
+ax_pose 37, 0x01e8, 0x90f1, 0x0c00
+ax_pose_terminator
+sPluslePose137:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose138:
+ax_pose 27, 0x81ec, 0x80f9, 0x0c00
+ax_pose 28, 0x01ec, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose139:
+ax_pose 29, 0x01e7, 0x80f0, 0x0c00
+ax_pose 20, 0x81e9, 0x80f8, 0x0c10
+ax_pose_terminator
+sPluslePose140:
+ax_pose 39, 0x01e9, 0x80f0, 0x0c00
+ax_pose 31, 0x01e7, 0x80f0, 0x0c10
+ax_pose_terminator
+sPluslePose141:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose142:
+ax_pose 39, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sPluslePose143:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose144:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sPluslePose145:
+ax_pose 32, 0x01e8, 0x80ee, 0x0c00
+ax_pose 19, 0x81e8, 0x80f7, 0x0c10
+ax_pose_terminator
+sPluslePose146:
+ax_pose 37, 0x01e8, 0x80ef, 0x0c00
+ax_pose 38, 0x01e7, 0x80ef, 0x0c10
+ax_pose_terminator
+sPluslePose147:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose148:
+ax_pose 37, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sPluslePose149:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose150:
+ax_pose 24, 0x81e9, 0x80fa, 0x0c00
+ax_pose_terminator
+sPluslePose151:
+ax_pose 34, 0x01e8, 0x80f0, 0x0c00
+ax_pose 18, 0x81e8, 0x80f8, 0x0c10
+ax_pose_terminator
+sPluslePose152:
+ax_pose 35, 0x01e8, 0x80f0, 0x0c00
+ax_pose 36, 0x01e8, 0x80f0, 0x0c10
+ax_pose_terminator
+sPluslePose153:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose154:
+ax_pose 35, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPluslePose155:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose156:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose157:
+ax_pose 32, 0x01e8, 0x80ef, 0x0c00
+ax_pose 17, 0x81e8, 0x80f7, 0x0c10
+ax_pose_terminator
+sPluslePose158:
+ax_pose 33, 0x01e8, 0x80ef, 0x0c00
+ax_pose 31, 0x01e8, 0x80ef, 0x0c10
+ax_pose_terminator
+sPluslePose159:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose160:
+ax_pose 33, 0x01e8, 0x80ef, 0x0c00
+ax_pose_terminator
+sPluslePose161:
+ax_pose 40, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose162:
+ax_pose 41, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose163:
+ax_pose 42, 0x01e1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPluslePose164:
+ax_pose 43, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sPluslePose165:
+ax_pose 44, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sPluslePose166:
+ax_pose 45, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPluslePose167:
+ax_pose 46, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sPluslePose168:
+ax_pose 45, 0x01e8, 0x80f6, 0x0c00
+ax_pose_terminator
+sPluslePose169:
+ax_pose 44, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose170:
+ax_pose 43, 0x01e4, 0x80f3, 0x0c00
+ax_pose_terminator
+sPluslePose171:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose172:
+ax_pose 1, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPluslePose173:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose174:
+ax_pose 4, 0x81ed, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose175:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose176:
+ax_pose 7, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose177:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose178:
+ax_pose 10, 0x81ec, 0x90f5, 0x0c00
+ax_pose_terminator
+sPluslePose179:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose180:
+ax_pose 13, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose181:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose182:
+ax_pose 10, 0x81ec, 0x80fb, 0x0c00
+ax_pose_terminator
+sPluslePose183:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose184:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose185:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose186:
+ax_pose 4, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose187:
+ax_pose 15, 0x81e7, 0x80f8, 0x0c00
+ax_pose 16, 0x01ef, 0x0108, 0x0c08
+ax_pose_terminator
+sPluslePose188:
+ax_pose 17, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose189:
+ax_pose 18, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose190:
+ax_pose 19, 0x81e8, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose191:
+ax_pose 20, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose192:
+ax_pose 19, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose193:
+ax_pose 18, 0x81e8, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose194:
+ax_pose 17, 0x81e8, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose195:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose196:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose197:
+ax_pose 24, 0x81e9, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose198:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sPluslePose199:
+ax_pose 27, 0x81ed, 0x80f9, 0x0c00
+ax_pose 28, 0x01ed, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose200:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sPluslePose201:
+ax_pose 24, 0x81e9, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose202:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose203:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose204:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose205:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose206:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose207:
+ax_pose 4, 0x81ed, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose208:
+ax_pose 5, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sPluslePose209:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose210:
+ax_pose 7, 0x81ed, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose211:
+ax_pose 8, 0x81ed, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose212:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose213:
+ax_pose 10, 0x81ed, 0x90f5, 0x0c00
+ax_pose_terminator
+sPluslePose214:
+ax_pose 11, 0x81ed, 0x90f9, 0x0c00
+ax_pose_terminator
+sPluslePose215:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose216:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose217:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose218:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose219:
+ax_pose 10, 0x81ed, 0x80fb, 0x0c00
+ax_pose_terminator
+sPluslePose220:
+ax_pose 11, 0x81ed, 0x80f7, 0x0c00
+ax_pose_terminator
+sPluslePose221:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose222:
+ax_pose 7, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose223:
+ax_pose 8, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose224:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose225:
+ax_pose 4, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose226:
+ax_pose 5, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose227:
+ax_pose 21, 0x81e7, 0x80f9, 0x0c00
+ax_pose 22, 0x01ef, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose228:
+ax_pose 23, 0x81e8, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose229:
+ax_pose 24, 0x81e9, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose230:
+ax_pose 25, 0x81eb, 0x80f9, 0x0c00
+ax_pose 26, 0x01eb, 0x0109, 0x0c08
+ax_pose_terminator
+sPluslePose231:
+ax_pose 27, 0x81ed, 0x80f9, 0x0c00
+ax_pose 28, 0x01ed, 0x00f1, 0x0c08
+ax_pose_terminator
+sPluslePose232:
+ax_pose 25, 0x81eb, 0x90f7, 0x0c00
+ax_pose 26, 0x01eb, 0x10ef, 0x0c08
+ax_pose_terminator
+sPluslePose233:
+ax_pose 24, 0x81e9, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose234:
+ax_pose 23, 0x81e8, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose235:
+ax_pose 0, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose236:
+ax_pose 3, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose237:
+ax_pose 6, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPluslePose238:
+ax_pose 9, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sPluslePose239:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sPluslePose240:
+ax_pose 9, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sPluslePose241:
+ax_pose 6, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sPluslePose242:
+ax_pose 3, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+.align 2
+sPlusleAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 1, 0, 0,
+ax_anim_terminator
+sPlusleAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 1, 0, 0,
+ax_anim_terminator
+sPlusleAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sPlusleAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 1, 0, 0,
+ax_anim_terminator
+sPlusleAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 1, 0, 0,
+ax_anim_terminator
+sPlusleAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, 1, 0, 0,
+ax_anim_terminator
+sPlusleAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sPlusleAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, -1,
+ax_anim 2, 2, 25, 0, 4, 0, 7,
+ax_anim 2, 0, 25, 0, 11, 0, 13,
+ax_anim 2, 1, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPlusleAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 2, 29, 7, 1, 7, 6,
+ax_anim 2, 0, 29, 15, 8, 15, 13,
+ax_anim 2, 1, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 23, 18, 23, 18,
+ax_anim 2, 0, 31, 22, 19, 22, 19,
+ax_anim 2, 0, 31, 23, 18, 23, 18,
+ax_anim 2, 0, 28, 8, 7, 8, 7,
+ax_anim_terminator
+sPlusleAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 7, -4, 7, 0,
+ax_anim 2, 0, 33, 15, -4, 15, 0,
+ax_anim 2, 1, 35, 23, 0, 23, 0,
+ax_anim 2, 0, 35, 23, -1, 23, -1,
+ax_anim 2, 0, 35, 23, 0, 23, 0,
+ax_anim 2, 0, 35, 23, -1, 23, -1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sPlusleAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 2, -2, 2, -2,
+ax_anim 2, 2, 37, 7, -12, 7, -8,
+ax_anim 2, 0, 37, 13, -18, 13, -14,
+ax_anim 2, 1, 39, 21, -23, 21, -23,
+ax_anim 2, 0, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 39, 21, -23, 21, -23,
+ax_anim 2, 0, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sPlusleAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 2, 41, 0, -7, 0, -5,
+ax_anim 2, 0, 41, 0, -15, 0, -11,
+ax_anim 2, 1, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sPlusleAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, -2, -2, -2, -2,
+ax_anim 2, 2, 45, -7, -12, -7, -8,
+ax_anim 2, 0, 45, -13, -18, -13, -14,
+ax_anim 2, 1, 47, -21, -23, -21, -23,
+ax_anim 2, 0, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 47, -21, -23, -21, -23,
+ax_anim 2, 0, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sPlusleAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 49, -7, -4, -7, 0,
+ax_anim 2, 0, 49, -15, -4, -15, 0,
+ax_anim 2, 1, 51, -23, 0, -23, 0,
+ax_anim 2, 0, 51, -23, -1, -23, -1,
+ax_anim 2, 0, 51, -23, 0, -23, 0,
+ax_anim 2, 0, 51, -23, -1, -23, -1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sPlusleAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 2, 53, -7, 1, -7, 6,
+ax_anim 2, 0, 53, -15, 8, -15, 13,
+ax_anim 2, 1, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -23, 18, -23, 18,
+ax_anim 2, 0, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -23, 18, -23, 18,
+ax_anim 2, 0, 52, -8, 7, -8, 7,
+ax_anim_terminator
+.align 2
+sPlusleAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, -1,
+ax_anim 2, 2, 57, 0, 20, 0, 15,
+ax_anim 2, 0, 57, 0, 35, 0, 29,
+ax_anim 2, 1, 59, 0, 44, 0, 44,
+ax_anim 2, 0, 59, 1, 44, 1, 44,
+ax_anim 2, 0, 59, 0, 44, 0, 44,
+ax_anim 2, 0, 59, 1, 44, 1, 44,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sPlusleAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, -1, 0, 0,
+ax_anim 2, 2, 61, 15, 9, 15, 14,
+ax_anim 2, 0, 61, 31, 24, 31, 29,
+ax_anim 2, 1, 63, 46, 43, 46, 43,
+ax_anim 2, 0, 63, 47, 42, 47, 42,
+ax_anim 2, 0, 63, 46, 43, 46, 43,
+ax_anim 2, 0, 63, 47, 42, 47, 42,
+ax_anim 2, 0, 60, 8, 7, 8, 7,
+ax_anim_terminator
+sPlusleAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 65, 15, -4, 15, 0,
+ax_anim 2, 0, 65, 31, -4, 31, 0,
+ax_anim 2, 1, 67, 47, 0, 47, 0,
+ax_anim 2, 0, 67, 47, -1, 47, -1,
+ax_anim 2, 0, 67, 47, 0, 47, 0,
+ax_anim 2, 0, 67, 47, -1, 47, -1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sPlusleAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 2, 69, 15, -20, 15, -16,
+ax_anim 2, 0, 69, 29, -34, 29, -30,
+ax_anim 2, 1, 71, 45, -47, 45, -47,
+ax_anim 2, 0, 71, 46, -46, 46, -46,
+ax_anim 2, 0, 71, 45, -47, 45, -47,
+ax_anim 2, 0, 71, 46, -46, 46, -46,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sPlusleAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 0, -15, 0, -13,
+ax_anim 2, 0, 73, 0, -31, 0, -27,
+ax_anim 2, 1, 75, 0, -48, 0, -48,
+ax_anim 2, 0, 75, 1, -48, 1, -48,
+ax_anim 2, 0, 75, 0, -48, 0, -48,
+ax_anim 2, 0, 75, 1, -48, 1, -48,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sPlusleAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 2, 77, -15, -20, -15, -16,
+ax_anim 2, 0, 77, -29, -34, -29, -30,
+ax_anim 2, 1, 79, -45, -47, -45, -39,
+ax_anim 2, 0, 79, -46, -46, -46, -38,
+ax_anim 2, 0, 79, -45, -47, -45, -39,
+ax_anim 2, 0, 79, -46, -46, -46, -38,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sPlusleAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 81, -15, -4, -15, 0,
+ax_anim 2, 0, 81, -31, -4, -31, 0,
+ax_anim 2, 1, 83, -47, 0, -47, 0,
+ax_anim 2, 0, 83, -47, -1, -47, -1,
+ax_anim 2, 0, 83, -47, 0, -47, 0,
+ax_anim 2, 0, 83, -47, -1, -47, -1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sPlusleAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 2, 85, -15, 9, -15, 14,
+ax_anim 2, 0, 85, -31, 24, -31, 29,
+ax_anim 2, 1, 87, -46, 43, -46, 35,
+ax_anim 2, 0, 87, -47, 42, -47, 34,
+ax_anim 2, 0, 87, -46, 43, -46, 35,
+ax_anim 2, 0, 87, -47, 42, -47, 34,
+ax_anim 2, 0, 84, -8, 7, -8, 7,
+ax_anim_terminator
+.align 2
+sPlusleAnims_4_1:
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 4, 2, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 1, -6, 1, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 1, 89, 1, -6, 1, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 1, -6, 1, 0,
+ax_anim 4, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_4_2:
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 4, 2, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 1, -7, 1, -1,
+ax_anim 2, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 1, 92, 1, -7, 1, -1,
+ax_anim 2, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 1, -7, 1, -1,
+ax_anim 4, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_4_3:
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 4, 2, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -7, 0, -1,
+ax_anim 2, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 1, 95, 0, -7, 0, -1,
+ax_anim 2, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -7, 0, -1,
+ax_anim 4, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_4_4:
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 4, 2, 98, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 1, -5, 1, 1,
+ax_anim 2, 0, 98, 0, -6, 0, 0,
+ax_anim 2, 1, 98, 1, -5, 1, 1,
+ax_anim 2, 0, 98, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 1, -5, 1, 1,
+ax_anim 4, 0, 98, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_4_5:
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 4, 2, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 1, -6, 1, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 1, 101, 1, -6, 1, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 1, -6, 1, 0,
+ax_anim 4, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_4_6:
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 4, 2, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, -1, -5, -1, 1,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 1, 104, -1, -5, -1, 1,
+ax_anim 2, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, -1, -5, -1, 1,
+ax_anim 4, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_4_7:
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 4, 2, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -7, 0, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 1, 107, 0, -7, 0, -1,
+ax_anim 2, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -7, 0, -1,
+ax_anim 4, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_4_8:
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 4, 2, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, -1, -7, -1, -1,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 1, 110, -1, -7, -1, -1,
+ax_anim 2, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, -1, -7, -1, -1,
+ax_anim 4, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_5_1:
+ax_anim 8, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 2, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 1, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_5_2:
+ax_anim 8, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 2, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 1, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_5_3:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 2, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 1, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_5_4:
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 2, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 1, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_5_5:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 2, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 1, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_5_6:
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 2, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 1, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_5_7:
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 2, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 1, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_5_8:
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 2, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 1, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sPlusleAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sPlusleAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sPlusleAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sPlusleAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sPlusleAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sPlusleAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sPlusleAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPlusleAnims_8_1:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 6, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_8_2:
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 6, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_8_3:
+ax_anim 30, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 6, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_8_4:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim 6, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_8_5:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_8_6:
+ax_anim 30, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 6, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_8_7:
+ax_anim 30, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim 6, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_8_8:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 7, 4, 7, 4,
+ax_anim 2, 0, 188, 10, 12, 10, 12,
+ax_anim 2, 0, 189, 7, 20, 7, 20,
+ax_anim 3, 0, 190, 0, 21, 0, 21,
+ax_anim 2, 3, 191, -7, 20, -7, 20,
+ax_anim 2, 0, 192, -10, 12, -10, 12,
+ax_anim 1, 0, 193, -7, 4, -7, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 11, 2, 11, 2,
+ax_anim 2, 0, 187, 21, 6, 21, 6,
+ax_anim 2, 0, 188, 26, 14, 26, 14,
+ax_anim 3, 0, 189, 24, 21, 24, 21,
+ax_anim 2, 3, 190, 14, 21, 14, 21,
+ax_anim 2, 0, 191, 5, 16, 5, 16,
+ax_anim 1, 0, 192, 2, 7, 2, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 4, -4, 4, -4,
+ax_anim 2, 0, 186, 10, -5, 10, -5,
+ax_anim 2, 0, 187, 18, -4, 18, -4,
+ax_anim 3, 0, 188, 22, 0, 22, 0,
+ax_anim 2, 3, 189, 20, 6, 20, 6,
+ax_anim 2, 0, 190, 12, 8, 12, 8,
+ax_anim 1, 0, 191, 5, 6, 5, 6,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 1, -8, 1, -8,
+ax_anim 2, 0, 193, 4, -18, 4, -18,
+ax_anim 2, 0, 186, 12, -23, 12, -23,
+ax_anim 3, 0, 187, 23, -23, 23, -23,
+ax_anim 2, 3, 188, 27, -15, 27, -15,
+ax_anim 2, 0, 189, 23, -7, 23, -7,
+ax_anim 1, 0, 190, 11, -2, 11, -2,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -7, -4, -7, -4,
+ax_anim 2, 0, 192, -10, -13, -10, -13,
+ax_anim 2, 0, 193, -8, -19, -8, -19,
+ax_anim 3, 0, 186, 0, -23, 0, -23,
+ax_anim 2, 3, 187, 8, -19, 8, -19,
+ax_anim 2, 0, 188, 10, -13, 10, -13,
+ax_anim 1, 0, 189, 7, -4, 7, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -18, -4, -18,
+ax_anim 2, 0, 186, -12, -23, -12, -23,
+ax_anim 3, 0, 193, -23, -23, -23, -23,
+ax_anim 2, 3, 192, -27, -15, -27, -15,
+ax_anim 2, 0, 191, -23, -7, -23, -7,
+ax_anim 1, 0, 190, -11, -2, -11, -2,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -4, -4, -4, -4,
+ax_anim 2, 0, 186, -10, -5, -10, -5,
+ax_anim 2, 0, 193, -18, -4, -18, -4,
+ax_anim 3, 0, 192, -22, 0, -22, 0,
+ax_anim 2, 3, 191, -20, 6, -20, 6,
+ax_anim 2, 0, 190, -12, 8, -12, 8,
+ax_anim 1, 0, 189, -5, 6, -5, 6,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -11, 2, -11, 2,
+ax_anim 2, 0, 193, -21, 6, -21, 6,
+ax_anim 2, 0, 192, -26, 14, -26, 14,
+ax_anim 3, 0, 191, -24, 21, -24, 21,
+ax_anim 2, 3, 190, -14, 21, -14, 21,
+ax_anim 2, 0, 189, -5, 16, -5, 16,
+ax_anim 1, 0, 188, -2, 7, -2, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 210, 0, -21, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -22, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -22, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPlusleAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sPlusleGfx1:
+.incbin "baserom.gba", 0x12AB074, 0x200
+sPlusleSprites1:
+ax_sprite sPlusleGfx1, 0x200
+ax_sprite_terminator
+sPlusleGfx2:
+.incbin "baserom.gba", 0x12AB284, 0x200
+sPlusleSprites2:
+ax_sprite sPlusleGfx2, 0x200
+ax_sprite_terminator
+sPlusleGfx3:
+.incbin "baserom.gba", 0x12AB494, 0x200
+sPlusleSprites3:
+ax_sprite sPlusleGfx3, 0x200
+ax_sprite_terminator
+sPlusleGfx4:
+.incbin "baserom.gba", 0x12AB6A4, 0x100
+sPlusleSprites4:
+ax_sprite sPlusleGfx4, 0x100
+ax_sprite_terminator
+sPlusleGfx5:
+.incbin "baserom.gba", 0x12AB7B4, 0x100
+sPlusleSprites5:
+ax_sprite sPlusleGfx5, 0x100
+ax_sprite_terminator
+sPlusleGfx6:
+.incbin "baserom.gba", 0x12AB8C4, 0x200
+sPlusleSprites6:
+ax_sprite sPlusleGfx6, 0x200
+ax_sprite_terminator
+sPlusleGfx7:
+.incbin "baserom.gba", 0x12ABAD4, 0x100
+sPlusleSprites7:
+ax_sprite sPlusleGfx7, 0x100
+ax_sprite_terminator
+sPlusleGfx8:
+.incbin "baserom.gba", 0x12ABBE4, 0x100
+sPlusleSprites8:
+ax_sprite sPlusleGfx8, 0x100
+ax_sprite_terminator
+sPlusleGfx9:
+.incbin "baserom.gba", 0x12ABCF4, 0x100
+sPlusleSprites9:
+ax_sprite sPlusleGfx9, 0x100
+ax_sprite_terminator
+sPlusleGfx10:
+.incbin "baserom.gba", 0x12ABE04, 0x100
+sPlusleSprites10:
+ax_sprite sPlusleGfx10, 0x100
+ax_sprite_terminator
+sPlusleGfx11:
+.incbin "baserom.gba", 0x12ABF14, 0x100
+sPlusleSprites11:
+ax_sprite sPlusleGfx11, 0x100
+ax_sprite_terminator
+sPlusleGfx12:
+.incbin "baserom.gba", 0x12AC024, 0x100
+sPlusleSprites12:
+ax_sprite sPlusleGfx12, 0x100
+ax_sprite_terminator
+sPlusleGfx13:
+.incbin "baserom.gba", 0x12AC134, 0x200
+sPlusleSprites13:
+ax_sprite sPlusleGfx13, 0x200
+ax_sprite_terminator
+sPlusleGfx14:
+.incbin "baserom.gba", 0x12AC344, 0x200
+sPlusleSprites14:
+ax_sprite sPlusleGfx14, 0x200
+ax_sprite_terminator
+sPlusleGfx15:
+.incbin "baserom.gba", 0x12AC554, 0x200
+sPlusleSprites15:
+ax_sprite sPlusleGfx15, 0x200
+ax_sprite_terminator
+sPlusleGfx16:
+.incbin "baserom.gba", 0x12AC764, 0xC0
+sPlusleSprites16:
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx16, 0xc0
+ax_sprite_terminator
+sPlusleGfx17:
+.incbin "baserom.gba", 0x12AC83C, 0x20
+sPlusleSprites17:
+ax_sprite sPlusleGfx17, 0x20
+ax_sprite_terminator
+sPlusleGfx18:
+.incbin "baserom.gba", 0x12AC86C, 0x20
+sPlusleGfx18_1:
+.incbin "baserom.gba", 0x12AC88C, 0xC0
+sPlusleSprites18:
+ax_sprite sPlusleGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx18_1, 0xc0
+ax_sprite_terminator
+sPlusleGfx19:
+.incbin "baserom.gba", 0x12AC96C, 0x20
+sPlusleGfx19_1:
+.incbin "baserom.gba", 0x12AC98C, 0xC0
+sPlusleSprites19:
+ax_sprite sPlusleGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx19_1, 0xc0
+ax_sprite_terminator
+sPlusleGfx20:
+.incbin "baserom.gba", 0x12ACA6C, 0xE0
+sPlusleSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx20, 0xe0
+ax_sprite_terminator
+sPlusleGfx21:
+.incbin "baserom.gba", 0x12ACB64, 0xC0
+sPlusleGfx21_1:
+.incbin "baserom.gba", 0x12ACC24, 0x20
+sPlusleSprites21:
+ax_sprite sPlusleGfx21, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx21_1, 0x20
+ax_sprite_terminator
+sPlusleGfx22:
+.incbin "baserom.gba", 0x12ACC64, 0x100
+sPlusleSprites22:
+ax_sprite sPlusleGfx22, 0x100
+ax_sprite_terminator
+sPlusleGfx23:
+.incbin "baserom.gba", 0x12ACD74, 0x20
+sPlusleSprites23:
+ax_sprite sPlusleGfx23, 0x20
+ax_sprite_terminator
+sPlusleGfx24:
+.incbin "baserom.gba", 0x12ACDA4, 0x100
+sPlusleSprites24:
+ax_sprite sPlusleGfx24, 0x100
+ax_sprite_terminator
+sPlusleGfx25:
+.incbin "baserom.gba", 0x12ACEB4, 0x100
+sPlusleSprites25:
+ax_sprite sPlusleGfx25, 0x100
+ax_sprite_terminator
+sPlusleGfx26:
+.incbin "baserom.gba", 0x12ACFC4, 0xC0
+sPlusleSprites26:
+ax_sprite sPlusleGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPlusleGfx27:
+.incbin "baserom.gba", 0x12AD09C, 0x20
+sPlusleSprites27:
+ax_sprite sPlusleGfx27, 0x20
+ax_sprite_terminator
+sPlusleGfx28:
+.incbin "baserom.gba", 0x12AD0CC, 0xC0
+sPlusleSprites28:
+ax_sprite sPlusleGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPlusleGfx29:
+.incbin "baserom.gba", 0x12AD1A4, 0x20
+sPlusleSprites29:
+ax_sprite sPlusleGfx29, 0x20
+ax_sprite_terminator
+sPlusleGfx30:
+.incbin "baserom.gba", 0x12AD1D4, 0x200
+sPlusleSprites30:
+ax_sprite sPlusleGfx30, 0x200
+ax_sprite_terminator
+sPlusleGfx31:
+.incbin "baserom.gba", 0x12AD3E4, 0x60
+sPlusleGfx31_1:
+.incbin "baserom.gba", 0x12AD444, 0x40
+sPlusleGfx31_2:
+.incbin "baserom.gba", 0x12AD484, 0x40
+sPlusleSprites31:
+ax_sprite 0, 0xa0
+ax_sprite sPlusleGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPlusleGfx32:
+.incbin "baserom.gba", 0x12AD504, 0x200
+sPlusleSprites32:
+ax_sprite sPlusleGfx32, 0x200
+ax_sprite_terminator
+sPlusleGfx33:
+.incbin "baserom.gba", 0x12AD714, 0x200
+sPlusleSprites33:
+ax_sprite sPlusleGfx33, 0x200
+ax_sprite_terminator
+sPlusleGfx34:
+.incbin "baserom.gba", 0x12AD924, 0x20
+sPlusleGfx34_1:
+.incbin "baserom.gba", 0x12AD944, 0x40
+sPlusleGfx34_2:
+.incbin "baserom.gba", 0x12AD984, 0x40
+sPlusleGfx34_3:
+.incbin "baserom.gba", 0x12AD9C4, 0x40
+sPlusleSprites34:
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx34, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPlusleGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPlusleGfx35:
+.incbin "baserom.gba", 0x12ADA54, 0x40
+sPlusleGfx35_1:
+.incbin "baserom.gba", 0x12ADA94, 0x100
+sPlusleGfx35_2:
+.incbin "baserom.gba", 0x12ADB94, 0x60
+sPlusleSprites35:
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx35_2, 0x60
+ax_sprite_terminator
+sPlusleGfx36:
+.incbin "baserom.gba", 0x12ADC2C, 0x20
+sPlusleGfx36_1:
+.incbin "baserom.gba", 0x12ADC4C, 0x40
+sPlusleGfx36_2:
+.incbin "baserom.gba", 0x12ADC8C, 0x40
+sPlusleGfx36_3:
+.incbin "baserom.gba", 0x12ADCCC, 0x40
+sPlusleSprites36:
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx36, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPlusleGfx36_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx36_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPlusleGfx37:
+.incbin "baserom.gba", 0x12ADD5C, 0x60
+sPlusleGfx37_1:
+.incbin "baserom.gba", 0x12ADDBC, 0x60
+sPlusleGfx37_2:
+.incbin "baserom.gba", 0x12ADE1C, 0xE0
+sPlusleSprites37:
+ax_sprite sPlusleGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx37_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPlusleGfx38:
+.incbin "baserom.gba", 0x12ADF34, 0x20
+sPlusleGfx38_1:
+.incbin "baserom.gba", 0x12ADF54, 0x40
+sPlusleGfx38_2:
+.incbin "baserom.gba", 0x12ADF94, 0x40
+sPlusleGfx38_3:
+.incbin "baserom.gba", 0x12ADFD4, 0x40
+sPlusleSprites38:
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx38, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPlusleGfx39:
+.incbin "baserom.gba", 0x12AE064, 0x200
+sPlusleSprites39:
+ax_sprite sPlusleGfx39, 0x200
+ax_sprite_terminator
+sPlusleGfx40:
+.incbin "baserom.gba", 0x12AE274, 0x40
+sPlusleGfx40_1:
+.incbin "baserom.gba", 0x12AE2B4, 0x40
+sPlusleGfx40_2:
+.incbin "baserom.gba", 0x12AE2F4, 0x40
+sPlusleGfx40_3:
+.incbin "baserom.gba", 0x12AE334, 0x20
+sPlusleSprites40:
+ax_sprite 0, 0x20
+ax_sprite sPlusleGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx40_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPlusleGfx40_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sPlusleGfx40_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPlusleGfx41:
+.incbin "baserom.gba", 0x12AE3A4, 0x100
+sPlusleSprites41:
+ax_sprite sPlusleGfx41, 0x100
+ax_sprite_terminator
+sPlusleGfx42:
+.incbin "baserom.gba", 0x12AE4B4, 0x100
+sPlusleSprites42:
+ax_sprite sPlusleGfx42, 0x100
+ax_sprite_terminator
+sPlusleGfx43:
+.incbin "baserom.gba", 0x12AE5C4, 0x200
+sPlusleSprites43:
+ax_sprite sPlusleGfx43, 0x200
+ax_sprite_terminator
+sPlusleGfx44:
+.incbin "baserom.gba", 0x12AE7D4, 0x200
+sPlusleSprites44:
+ax_sprite sPlusleGfx44, 0x200
+ax_sprite_terminator
+sPlusleGfx45:
+.incbin "baserom.gba", 0x12AE9E4, 0x200
+sPlusleSprites45:
+ax_sprite sPlusleGfx45, 0x200
+ax_sprite_terminator
+sPlusleGfx46:
+.incbin "baserom.gba", 0x12AEBF4, 0x200
+sPlusleSprites46:
+ax_sprite sPlusleGfx46, 0x200
+ax_sprite_terminator
+sPlusleGfx47:
+.incbin "baserom.gba", 0x12AEE04, 0x200
+sPlusleSprites47:
+ax_sprite sPlusleGfx47, 0x200
+ax_sprite_terminator
+sAxPosesPlusle:
+.4byte sPluslePose1
+.4byte sPluslePose2
+.4byte sPluslePose3
+.4byte sPluslePose4
+.4byte sPluslePose5
+.4byte sPluslePose6
+.4byte sPluslePose7
+.4byte sPluslePose8
+.4byte sPluslePose9
+.4byte sPluslePose10
+.4byte sPluslePose11
+.4byte sPluslePose12
+.4byte sPluslePose13
+.4byte sPluslePose14
+.4byte sPluslePose15
+.4byte sPluslePose16
+.4byte sPluslePose17
+.4byte sPluslePose18
+.4byte sPluslePose19
+.4byte sPluslePose20
+.4byte sPluslePose21
+.4byte sPluslePose22
+.4byte sPluslePose23
+.4byte sPluslePose24
+.4byte sPluslePose25
+.4byte sPluslePose26
+.4byte sPluslePose27
+.4byte sPluslePose28
+.4byte sPluslePose29
+.4byte sPluslePose30
+.4byte sPluslePose31
+.4byte sPluslePose32
+.4byte sPluslePose33
+.4byte sPluslePose34
+.4byte sPluslePose35
+.4byte sPluslePose36
+.4byte sPluslePose37
+.4byte sPluslePose38
+.4byte sPluslePose39
+.4byte sPluslePose40
+.4byte sPluslePose41
+.4byte sPluslePose42
+.4byte sPluslePose43
+.4byte sPluslePose44
+.4byte sPluslePose45
+.4byte sPluslePose46
+.4byte sPluslePose47
+.4byte sPluslePose48
+.4byte sPluslePose49
+.4byte sPluslePose50
+.4byte sPluslePose51
+.4byte sPluslePose52
+.4byte sPluslePose53
+.4byte sPluslePose54
+.4byte sPluslePose55
+.4byte sPluslePose56
+.4byte sPluslePose57
+.4byte sPluslePose58
+.4byte sPluslePose59
+.4byte sPluslePose60
+.4byte sPluslePose61
+.4byte sPluslePose62
+.4byte sPluslePose63
+.4byte sPluslePose64
+.4byte sPluslePose65
+.4byte sPluslePose66
+.4byte sPluslePose67
+.4byte sPluslePose68
+.4byte sPluslePose69
+.4byte sPluslePose70
+.4byte sPluslePose71
+.4byte sPluslePose72
+.4byte sPluslePose73
+.4byte sPluslePose74
+.4byte sPluslePose75
+.4byte sPluslePose76
+.4byte sPluslePose77
+.4byte sPluslePose78
+.4byte sPluslePose79
+.4byte sPluslePose80
+.4byte sPluslePose81
+.4byte sPluslePose82
+.4byte sPluslePose83
+.4byte sPluslePose84
+.4byte sPluslePose85
+.4byte sPluslePose86
+.4byte sPluslePose87
+.4byte sPluslePose88
+.4byte sPluslePose89
+.4byte sPluslePose90
+.4byte sPluslePose91
+.4byte sPluslePose92
+.4byte sPluslePose93
+.4byte sPluslePose94
+.4byte sPluslePose95
+.4byte sPluslePose96
+.4byte sPluslePose97
+.4byte sPluslePose98
+.4byte sPluslePose99
+.4byte sPluslePose100
+.4byte sPluslePose101
+.4byte sPluslePose102
+.4byte sPluslePose103
+.4byte sPluslePose104
+.4byte sPluslePose105
+.4byte sPluslePose106
+.4byte sPluslePose107
+.4byte sPluslePose108
+.4byte sPluslePose109
+.4byte sPluslePose110
+.4byte sPluslePose111
+.4byte sPluslePose112
+.4byte sPluslePose113
+.4byte sPluslePose114
+.4byte sPluslePose115
+.4byte sPluslePose116
+.4byte sPluslePose117
+.4byte sPluslePose118
+.4byte sPluslePose119
+.4byte sPluslePose120
+.4byte sPluslePose121
+.4byte sPluslePose122
+.4byte sPluslePose123
+.4byte sPluslePose124
+.4byte sPluslePose125
+.4byte sPluslePose126
+.4byte sPluslePose127
+.4byte sPluslePose128
+.4byte sPluslePose129
+.4byte sPluslePose130
+.4byte sPluslePose131
+.4byte sPluslePose132
+.4byte sPluslePose133
+.4byte sPluslePose134
+.4byte sPluslePose135
+.4byte sPluslePose136
+.4byte sPluslePose137
+.4byte sPluslePose138
+.4byte sPluslePose139
+.4byte sPluslePose140
+.4byte sPluslePose141
+.4byte sPluslePose142
+.4byte sPluslePose143
+.4byte sPluslePose144
+.4byte sPluslePose145
+.4byte sPluslePose146
+.4byte sPluslePose147
+.4byte sPluslePose148
+.4byte sPluslePose149
+.4byte sPluslePose150
+.4byte sPluslePose151
+.4byte sPluslePose152
+.4byte sPluslePose153
+.4byte sPluslePose154
+.4byte sPluslePose155
+.4byte sPluslePose156
+.4byte sPluslePose157
+.4byte sPluslePose158
+.4byte sPluslePose159
+.4byte sPluslePose160
+.4byte sPluslePose161
+.4byte sPluslePose162
+.4byte sPluslePose163
+.4byte sPluslePose164
+.4byte sPluslePose165
+.4byte sPluslePose166
+.4byte sPluslePose167
+.4byte sPluslePose168
+.4byte sPluslePose169
+.4byte sPluslePose170
+.4byte sPluslePose171
+.4byte sPluslePose172
+.4byte sPluslePose173
+.4byte sPluslePose174
+.4byte sPluslePose175
+.4byte sPluslePose176
+.4byte sPluslePose177
+.4byte sPluslePose178
+.4byte sPluslePose179
+.4byte sPluslePose180
+.4byte sPluslePose181
+.4byte sPluslePose182
+.4byte sPluslePose183
+.4byte sPluslePose184
+.4byte sPluslePose185
+.4byte sPluslePose186
+.4byte sPluslePose187
+.4byte sPluslePose188
+.4byte sPluslePose189
+.4byte sPluslePose190
+.4byte sPluslePose191
+.4byte sPluslePose192
+.4byte sPluslePose193
+.4byte sPluslePose194
+.4byte sPluslePose195
+.4byte sPluslePose196
+.4byte sPluslePose197
+.4byte sPluslePose198
+.4byte sPluslePose199
+.4byte sPluslePose200
+.4byte sPluslePose201
+.4byte sPluslePose202
+.4byte sPluslePose203
+.4byte sPluslePose204
+.4byte sPluslePose205
+.4byte sPluslePose206
+.4byte sPluslePose207
+.4byte sPluslePose208
+.4byte sPluslePose209
+.4byte sPluslePose210
+.4byte sPluslePose211
+.4byte sPluslePose212
+.4byte sPluslePose213
+.4byte sPluslePose214
+.4byte sPluslePose215
+.4byte sPluslePose216
+.4byte sPluslePose217
+.4byte sPluslePose218
+.4byte sPluslePose219
+.4byte sPluslePose220
+.4byte sPluslePose221
+.4byte sPluslePose222
+.4byte sPluslePose223
+.4byte sPluslePose224
+.4byte sPluslePose225
+.4byte sPluslePose226
+.4byte sPluslePose227
+.4byte sPluslePose228
+.4byte sPluslePose229
+.4byte sPluslePose230
+.4byte sPluslePose231
+.4byte sPluslePose232
+.4byte sPluslePose233
+.4byte sPluslePose234
+.4byte sPluslePose235
+.4byte sPluslePose236
+.4byte sPluslePose237
+.4byte sPluslePose238
+.4byte sPluslePose239
+.4byte sPluslePose240
+.4byte sPluslePose241
+.4byte sPluslePose242
+sAxPositionsPlusle:
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -9, 	  -5,   -7, 	   3,   -8, 	  -1,   -8
+.2byte    0,   -9, 	  -4,   -8, 	   4,   -7, 	   0,   -8
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -8, 	  -2,   -8, 	   2,   -8
+.2byte    1,   -9, 	   3,   -8, 	  -4,   -6, 	   0,   -8
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,  -10, 	   1,   -6, 	   0,   -7, 	  -1,   -6
+.2byte    4,  -10, 	   2,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,  -11, 	  -5,   -8, 	   3,   -8, 	  -1,   -7
+.2byte    3,  -10, 	  -5,   -9, 	   5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -12, 	   5,   -8, 	  -5,   -9, 	   1,   -9
+.2byte   -2,  -12, 	   4,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -4,  -10, 	   4,   -9, 	  -6,   -8, 	  -1,   -7
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,  -10, 	  -2,   -6, 	  -1,   -7, 	   0,   -6
+.2byte   -5,  -10, 	  -3,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -8, 	   1,   -8, 	  -3,   -8
+.2byte   -2,   -9, 	  -4,   -8, 	   3,   -6, 	  -1,   -8
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -9, 	  -5,   -7, 	   3,   -8, 	  -1,   -8
+.2byte    0,   -9, 	  -4,   -8, 	   4,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -8, 	  -2,   -8, 	   2,   -8
+.2byte    1,   -9, 	   3,   -8, 	  -4,   -6, 	   0,   -8
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,  -10, 	   1,   -6, 	   0,   -7, 	  -1,   -6
+.2byte    4,  -10, 	   2,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,  -11, 	  -5,   -8, 	   3,   -8, 	  -1,   -7
+.2byte    3,  -10, 	  -5,   -9, 	   5,   -8, 	   0,   -7
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -12, 	   5,   -8, 	  -5,   -9, 	   1,   -9
+.2byte   -2,  -12, 	   4,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -4,  -10, 	   4,   -9, 	  -6,   -8, 	  -1,   -7
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,  -10, 	  -2,   -6, 	  -1,   -7, 	   0,   -6
+.2byte   -5,  -10, 	  -3,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -8, 	   1,   -8, 	  -3,   -8
+.2byte   -2,   -9, 	  -4,   -8, 	   3,   -6, 	  -1,   -8
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -9, 	  -5,   -7, 	   3,   -8, 	  -1,   -8
+.2byte    0,   -9, 	  -4,   -8, 	   4,   -7, 	   0,   -8
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -8, 	  -2,   -8, 	   2,   -8
+.2byte    1,   -9, 	   3,   -8, 	  -4,   -6, 	   0,   -8
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,  -10, 	   1,   -6, 	   0,   -7, 	  -1,   -6
+.2byte    4,  -10, 	   2,   -9, 	  -2,   -6, 	   0,   -6
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,  -11, 	  -5,   -8, 	   3,   -8, 	  -1,   -7
+.2byte    3,  -10, 	  -5,   -9, 	   5,   -8, 	   0,   -7
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -12, 	   5,   -8, 	  -5,   -9, 	   1,   -9
+.2byte   -2,  -12, 	   4,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,  -11, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -4,  -10, 	   4,   -9, 	  -6,   -8, 	  -1,   -7
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,  -10, 	  -2,   -6, 	  -1,   -7, 	   0,   -6
+.2byte   -5,  -10, 	  -3,   -9, 	   1,   -6, 	  -1,   -6
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -6,   -8, 	   1,   -8, 	  -3,   -8
+.2byte   -2,   -9, 	  -4,   -8, 	   3,   -6, 	  -1,   -8
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    3,   -7, 	  -3,   -5, 	  -3,   -3, 	  -1,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    0,  -11, 	   4,   -5, 	  -5,   -5, 	   0,   -7
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -4,   -7, 	   2,   -5, 	   2,   -3, 	   0,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    3,   -4, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    3,   -4, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    3,   -7, 	  -3,   -5, 	  -3,   -3, 	  -1,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   1,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   1,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    4,   -5, 	  -2,   -3, 	   3,   -1, 	   1,   -5
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    4,   -5, 	  -2,   -3, 	   3,   -1, 	   1,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    0,  -11, 	   4,   -5, 	  -5,   -5, 	   0,   -7
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    0,   -5, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    0,   -5, 	   4,   -2, 	  -5,   -2, 	  -1,   -5
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -5, 	   1,   -3, 	  -4,   -1, 	  -2,   -5
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte   -5,   -5, 	   1,   -3, 	  -4,   -1, 	  -2,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -4,   -7, 	   2,   -5, 	   2,   -3, 	   0,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -2,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -2,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -4,   -4, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -4,   -4, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -4,   -5, 	  -4,   -2, 	   1,   -1, 	  -2,   -3
+.2byte   -4,   -4, 	  -4,   -2, 	   1,   -1, 	  -2,   -3
+.2byte    0,   -7, 	  -5,   -7, 	   4,   -7, 	  -1,   -7
+.2byte    1,   -8, 	   3,   -7, 	  -3,   -7, 	   0,   -7
+.2byte    3,   -9, 	   2,   -9, 	  -1,   -8, 	   0,   -5
+.2byte    1,   -8, 	   0,   -9, 	   5,   -8, 	   0,   -6
+.2byte   -1,  -10, 	   4,   -4, 	  -5,   -4, 	   0,   -6
+.2byte   -2,   -8, 	  -1,   -9, 	  -6,   -8, 	  -1,   -6
+.2byte   -4,   -9, 	  -3,   -9, 	   0,   -8, 	  -1,   -5
+.2byte   -2,   -8, 	  -4,   -7, 	   2,   -7, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -2,   -6, 	  -6,   -4, 	   2,   -5, 	  -2,   -5
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -6, 	   5,   -5, 	  -2,   -5, 	   2,   -5
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,   -8, 	   1,   -4, 	   0,   -5, 	  -1,   -4
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,   -9, 	  -5,   -6, 	   3,   -6, 	  -1,   -5
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,  -10, 	   5,   -6, 	  -5,   -7, 	   1,   -7
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,   -9, 	   4,   -6, 	  -4,   -6, 	   0,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,   -8, 	  -2,   -4, 	  -1,   -5, 	   0,   -4
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -5, 	  -3,   -5
+.2byte   -1,   -3, 	  -5,   -2, 	   4,   -2, 	   0,   -3
+.2byte   -4,   -3, 	  -5,   -2, 	   2,   -1, 	  -2,   -6
+.2byte   -5,   -3, 	  -3,   -2, 	  -2,   -1, 	  -1,   -4
+.2byte   -4,   -5, 	   0,   -2, 	  -4,   -1, 	  -1,   -5
+.2byte    0,   -6, 	   4,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    3,   -5, 	  -1,   -2, 	   3,   -1, 	   0,   -5
+.2byte    4,   -3, 	   2,   -2, 	   1,   -1, 	   0,   -4
+.2byte    3,   -3, 	   4,   -2, 	  -3,   -1, 	   1,   -6
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte    4,   -7, 	  -2,   -5, 	  -2,   -3, 	   0,   -4
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    0,  -10, 	   4,   -4, 	  -5,   -4, 	   0,   -6
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte   -5,   -7, 	   1,   -5, 	   1,   -3, 	  -1,   -4
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   3,   -5, 	  -1,   -5
+.2byte    0,   -6, 	  -4,   -5, 	   4,   -4, 	   0,   -5
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+.2byte    3,   -6, 	   5,   -5, 	  -2,   -5, 	   2,   -5
+.2byte    1,   -6, 	   3,   -5, 	  -4,   -3, 	   0,   -5
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    4,   -7, 	   1,   -3, 	   0,   -4, 	  -1,   -3
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -3
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    1,   -8, 	  -5,   -5, 	   3,   -5, 	  -1,   -4
+.2byte    3,   -7, 	  -5,   -6, 	   5,   -5, 	   0,   -4
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,   -9, 	   5,   -5, 	  -5,   -6, 	   1,   -6
+.2byte   -2,   -9, 	   4,   -6, 	  -6,   -5, 	  -2,   -6
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte   -2,   -8, 	   4,   -5, 	  -4,   -5, 	   0,   -4
+.2byte   -4,   -7, 	   4,   -6, 	  -6,   -5, 	  -1,   -4
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -5,   -7, 	  -2,   -3, 	  -1,   -4, 	   0,   -3
+.2byte   -5,   -7, 	  -3,   -6, 	   1,   -3, 	  -1,   -3
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -5, 	  -3,   -5
+.2byte   -2,   -6, 	  -4,   -5, 	   3,   -3, 	  -1,   -5
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte   -3,   -7, 	  -4,   -5, 	   2,   -3, 	  -1,   -4
+.2byte   -5,   -7, 	   1,   -5, 	   1,   -3, 	  -1,   -4
+.2byte   -2,   -7, 	   3,   -4, 	  -4,   -3, 	   0,   -5
+.2byte    0,  -10, 	   4,   -4, 	  -5,   -4, 	   0,   -6
+.2byte    1,   -7, 	  -4,   -4, 	   3,   -3, 	  -1,   -5
+.2byte    4,   -7, 	  -2,   -5, 	  -2,   -3, 	   0,   -4
+.2byte    2,   -7, 	   3,   -5, 	  -3,   -3, 	   0,   -4
+.2byte   -1,   -5, 	  -5,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -3,   -6, 	  -4,   -4, 	   2,   -3, 	  -2,   -5
+.2byte   -5,   -7, 	  -1,   -4, 	   0,   -2, 	   1,   -4
+.2byte   -2,   -8, 	   2,   -3, 	  -4,   -2, 	   0,   -3
+.2byte    0,  -10, 	   4,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    1,   -8, 	  -3,   -3, 	   3,   -2, 	  -1,   -3
+.2byte    4,   -7, 	   0,   -4, 	  -1,   -2, 	  -2,   -4
+.2byte    2,   -6, 	   3,   -4, 	  -3,   -3, 	   1,   -5
+sPlusleAnimTable1:
+.4byte sPlusleAnims_1_1
+.4byte sPlusleAnims_1_2
+.4byte sPlusleAnims_1_3
+.4byte sPlusleAnims_1_4
+.4byte sPlusleAnims_1_5
+.4byte sPlusleAnims_1_6
+.4byte sPlusleAnims_1_7
+.4byte sPlusleAnims_1_8
+sPlusleAnimTable2:
+.4byte sPlusleAnims_2_1
+.4byte sPlusleAnims_2_2
+.4byte sPlusleAnims_2_3
+.4byte sPlusleAnims_2_4
+.4byte sPlusleAnims_2_5
+.4byte sPlusleAnims_2_6
+.4byte sPlusleAnims_2_7
+.4byte sPlusleAnims_2_8
+sPlusleAnimTable3:
+.4byte sPlusleAnims_3_1
+.4byte sPlusleAnims_3_2
+.4byte sPlusleAnims_3_3
+.4byte sPlusleAnims_3_4
+.4byte sPlusleAnims_3_5
+.4byte sPlusleAnims_3_6
+.4byte sPlusleAnims_3_7
+.4byte sPlusleAnims_3_8
+sPlusleAnimTable4:
+.4byte sPlusleAnims_4_1
+.4byte sPlusleAnims_4_2
+.4byte sPlusleAnims_4_3
+.4byte sPlusleAnims_4_4
+.4byte sPlusleAnims_4_5
+.4byte sPlusleAnims_4_6
+.4byte sPlusleAnims_4_7
+.4byte sPlusleAnims_4_8
+sPlusleAnimTable5:
+.4byte sPlusleAnims_5_1
+.4byte sPlusleAnims_5_2
+.4byte sPlusleAnims_5_3
+.4byte sPlusleAnims_5_4
+.4byte sPlusleAnims_5_5
+.4byte sPlusleAnims_5_6
+.4byte sPlusleAnims_5_7
+.4byte sPlusleAnims_5_8
+sPlusleAnimTable6:
+.4byte sPlusleAnims_6_1
+.4byte sPlusleAnims_6_1
+.4byte sPlusleAnims_6_1
+.4byte sPlusleAnims_6_1
+.4byte sPlusleAnims_6_1
+.4byte sPlusleAnims_6_1
+.4byte sPlusleAnims_6_1
+.4byte sPlusleAnims_6_1
+sPlusleAnimTable7:
+.4byte sPlusleAnims_7_1
+.4byte sPlusleAnims_7_2
+.4byte sPlusleAnims_7_3
+.4byte sPlusleAnims_7_4
+.4byte sPlusleAnims_7_5
+.4byte sPlusleAnims_7_6
+.4byte sPlusleAnims_7_7
+.4byte sPlusleAnims_7_8
+sPlusleAnimTable8:
+.4byte sPlusleAnims_8_1
+.4byte sPlusleAnims_8_2
+.4byte sPlusleAnims_8_3
+.4byte sPlusleAnims_8_4
+.4byte sPlusleAnims_8_5
+.4byte sPlusleAnims_8_6
+.4byte sPlusleAnims_8_7
+.4byte sPlusleAnims_8_8
+sPlusleAnimTable9:
+.4byte sPlusleAnims_9_1
+.4byte sPlusleAnims_9_2
+.4byte sPlusleAnims_9_3
+.4byte sPlusleAnims_9_4
+.4byte sPlusleAnims_9_5
+.4byte sPlusleAnims_9_6
+.4byte sPlusleAnims_9_7
+.4byte sPlusleAnims_9_8
+sPlusleAnimTable10:
+.4byte sPlusleAnims_10_1
+.4byte sPlusleAnims_10_2
+.4byte sPlusleAnims_10_3
+.4byte sPlusleAnims_10_4
+.4byte sPlusleAnims_10_5
+.4byte sPlusleAnims_10_6
+.4byte sPlusleAnims_10_7
+.4byte sPlusleAnims_10_8
+sPlusleAnimTable11:
+.4byte sPlusleAnims_11_1
+.4byte sPlusleAnims_11_2
+.4byte sPlusleAnims_11_3
+.4byte sPlusleAnims_11_4
+.4byte sPlusleAnims_11_5
+.4byte sPlusleAnims_11_6
+.4byte sPlusleAnims_11_7
+.4byte sPlusleAnims_11_8
+sPlusleAnimTable12:
+.4byte sPlusleAnims_12_1
+.4byte sPlusleAnims_12_2
+.4byte sPlusleAnims_12_3
+.4byte sPlusleAnims_12_4
+.4byte sPlusleAnims_12_5
+.4byte sPlusleAnims_12_6
+.4byte sPlusleAnims_12_7
+.4byte sPlusleAnims_12_8
+sPlusleAnimTable13:
+.4byte sPlusleAnims_13_1
+.4byte sPlusleAnims_13_2
+.4byte sPlusleAnims_13_3
+.4byte sPlusleAnims_13_4
+.4byte sPlusleAnims_13_5
+.4byte sPlusleAnims_13_6
+.4byte sPlusleAnims_13_7
+.4byte sPlusleAnims_13_8
+sAxAnimationsPlusle:
+.4byte sPlusleAnimTable1
+.4byte sPlusleAnimTable2
+.4byte sPlusleAnimTable3
+.4byte sPlusleAnimTable4
+.4byte sPlusleAnimTable5
+.4byte sPlusleAnimTable6
+.4byte sPlusleAnimTable7
+.4byte sPlusleAnimTable8
+.4byte sPlusleAnimTable9
+.4byte sPlusleAnimTable10
+.4byte sPlusleAnimTable11
+.4byte sPlusleAnimTable12
+.4byte sPlusleAnimTable13
+sAxSpritesPlusle:
+.4byte sPlusleSprites1
+.4byte sPlusleSprites2
+.4byte sPlusleSprites3
+.4byte sPlusleSprites4
+.4byte sPlusleSprites5
+.4byte sPlusleSprites6
+.4byte sPlusleSprites7
+.4byte sPlusleSprites8
+.4byte sPlusleSprites9
+.4byte sPlusleSprites10
+.4byte sPlusleSprites11
+.4byte sPlusleSprites12
+.4byte sPlusleSprites13
+.4byte sPlusleSprites14
+.4byte sPlusleSprites15
+.4byte sPlusleSprites16
+.4byte sPlusleSprites17
+.4byte sPlusleSprites18
+.4byte sPlusleSprites19
+.4byte sPlusleSprites20
+.4byte sPlusleSprites21
+.4byte sPlusleSprites22
+.4byte sPlusleSprites23
+.4byte sPlusleSprites24
+.4byte sPlusleSprites25
+.4byte sPlusleSprites26
+.4byte sPlusleSprites27
+.4byte sPlusleSprites28
+.4byte sPlusleSprites29
+.4byte sPlusleSprites30
+.4byte sPlusleSprites31
+.4byte sPlusleSprites32
+.4byte sPlusleSprites33
+.4byte sPlusleSprites34
+.4byte sPlusleSprites35
+.4byte sPlusleSprites36
+.4byte sPlusleSprites37
+.4byte sPlusleSprites38
+.4byte sPlusleSprites39
+.4byte sPlusleSprites40
+.4byte sPlusleSprites41
+.4byte sPlusleSprites42
+.4byte sPlusleSprites43
+.4byte sPlusleSprites44
+.4byte sPlusleSprites45
+.4byte sPlusleSprites46
+.4byte sPlusleSprites47
+sAxMainPlusle:
+ax_main sAxPosesPlusle, sAxAnimationsPlusle, 13, sAxSpritesPlusle, sAxPositionsPlusle

--- a/data/ax/politoed.inc
+++ b/data/ax/politoed.inc
@@ -1,0 +1,2907 @@
+.global gAxPolitoed
+gAxPolitoed:
+ax_siro sAxMainPolitoed
+sPolitoedPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sPolitoedPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose4:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose5:
+ax_pose 4, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose6:
+ax_pose 5, 0x01eb, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose7:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose8:
+ax_pose 7, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose9:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose10:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose11:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose12:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose14:
+ax_pose 13, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose17:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose20:
+ax_pose 7, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose22:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose23:
+ax_pose 16, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose24:
+ax_pose 17, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sPolitoedPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose28:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose29:
+ax_pose 4, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose30:
+ax_pose 5, 0x01eb, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose31:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose32:
+ax_pose 7, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose33:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose34:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose35:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose36:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose37:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose38:
+ax_pose 13, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose39:
+ax_pose 14, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose40:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose41:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose42:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose43:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose44:
+ax_pose 7, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose45:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose46:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose47:
+ax_pose 16, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose48:
+ax_pose 17, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose49:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose50:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sPolitoedPose51:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose52:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose53:
+ax_pose 4, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose54:
+ax_pose 5, 0x01eb, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose55:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose56:
+ax_pose 7, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose57:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose58:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose59:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose60:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose61:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose62:
+ax_pose 13, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose63:
+ax_pose 14, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose64:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose65:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose66:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose67:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose68:
+ax_pose 7, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose69:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose70:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose71:
+ax_pose 16, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose72:
+ax_pose 17, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose73:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose74:
+ax_pose 18, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose75:
+ax_pose 19, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose76:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose77:
+ax_pose 20, 0x01e5, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose78:
+ax_pose 21, 0x01e5, 0x80f6, 0x3c00
+ax_pose_terminator
+sPolitoedPose79:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose80:
+ax_pose 22, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sPolitoedPose81:
+ax_pose 23, 0x01e5, 0x90f8, 0x3c00
+ax_pose_terminator
+sPolitoedPose82:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose83:
+ax_pose 24, 0x01e2, 0x90ef, 0x3c00
+ax_pose_terminator
+sPolitoedPose84:
+ax_pose 25, 0x01e2, 0x90f7, 0x3c00
+ax_pose_terminator
+sPolitoedPose85:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose86:
+ax_pose 26, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose87:
+ax_pose 27, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose88:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose89:
+ax_pose 24, 0x01e2, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose90:
+ax_pose 25, 0x01e2, 0x80ea, 0x3c00
+ax_pose_terminator
+sPolitoedPose91:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose92:
+ax_pose 22, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose93:
+ax_pose 23, 0x01e5, 0x80e9, 0x3c00
+ax_pose_terminator
+sPolitoedPose94:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose95:
+ax_pose 28, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose96:
+ax_pose 29, 0x01e5, 0x80eb, 0x3c00
+ax_pose_terminator
+sPolitoedPose97:
+ax_pose 30, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose98:
+ax_pose 31, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose99:
+ax_pose 32, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose100:
+ax_pose 33, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose101:
+ax_pose 34, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose102:
+ax_pose 35, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose103:
+ax_pose 36, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose104:
+ax_pose 37, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose105:
+ax_pose 38, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose106:
+ax_pose 39, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose107:
+ax_pose 36, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose108:
+ax_pose 37, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose109:
+ax_pose 34, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose110:
+ax_pose 35, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose111:
+ax_pose 40, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose112:
+ax_pose 33, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose113:
+ax_pose 41, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose114:
+ax_pose 42, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose115:
+ax_pose 43, 0x01e0, 0x80f1, 0x3c00
+ax_pose_terminator
+sPolitoedPose116:
+ax_pose 44, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose117:
+ax_pose 45, 0x01e1, 0x90ec, 0x3c00
+ax_pose_terminator
+sPolitoedPose118:
+ax_pose 46, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sPolitoedPose119:
+ax_pose 47, 0x01e1, 0x80f1, 0x3c00
+ax_pose_terminator
+sPolitoedPose120:
+ax_pose 46, 0x01e0, 0x80f5, 0x3c00
+ax_pose_terminator
+sPolitoedPose121:
+ax_pose 45, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose122:
+ax_pose 48, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose123:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose124:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sPolitoedPose125:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose126:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose127:
+ax_pose 4, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose128:
+ax_pose 5, 0x01eb, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose129:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose130:
+ax_pose 7, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose131:
+ax_pose 8, 0x01eb, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose132:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose133:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose134:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose135:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose136:
+ax_pose 13, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose137:
+ax_pose 14, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose138:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose139:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose140:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose141:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose142:
+ax_pose 7, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose143:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose144:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose145:
+ax_pose 16, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose146:
+ax_pose 17, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose147:
+ax_pose 19, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose148:
+ax_pose 29, 0x01e6, 0x80ec, 0x3c00
+ax_pose_terminator
+sPolitoedPose149:
+ax_pose 23, 0x01e7, 0x80e9, 0x3c00
+ax_pose_terminator
+sPolitoedPose150:
+ax_pose 25, 0x01e5, 0x80ea, 0x3c00
+ax_pose_terminator
+sPolitoedPose151:
+ax_pose 27, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose152:
+ax_pose 25, 0x01e5, 0x90f6, 0x3c00
+ax_pose_terminator
+sPolitoedPose153:
+ax_pose 23, 0x01e7, 0x90f7, 0x3c00
+ax_pose_terminator
+sPolitoedPose154:
+ax_pose 21, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose155:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose156:
+ax_pose 18, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose157:
+ax_pose 19, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose158:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose159:
+ax_pose 20, 0x01e5, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose160:
+ax_pose 21, 0x01e5, 0x80f6, 0x3c00
+ax_pose_terminator
+sPolitoedPose161:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose162:
+ax_pose 22, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sPolitoedPose163:
+ax_pose 23, 0x01e5, 0x90f8, 0x3c00
+ax_pose_terminator
+sPolitoedPose164:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose165:
+ax_pose 24, 0x01e2, 0x90ef, 0x3c00
+ax_pose_terminator
+sPolitoedPose166:
+ax_pose 25, 0x01e2, 0x90f7, 0x3c00
+ax_pose_terminator
+sPolitoedPose167:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose168:
+ax_pose 26, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose169:
+ax_pose 27, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose170:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose171:
+ax_pose 24, 0x01e2, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose172:
+ax_pose 25, 0x01e2, 0x80ea, 0x3c00
+ax_pose_terminator
+sPolitoedPose173:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose174:
+ax_pose 22, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose175:
+ax_pose 23, 0x01e5, 0x80e9, 0x3c00
+ax_pose_terminator
+sPolitoedPose176:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose177:
+ax_pose 28, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose178:
+ax_pose 29, 0x01e5, 0x80eb, 0x3c00
+ax_pose_terminator
+sPolitoedPose179:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose180:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sPolitoedPose181:
+ax_pose 19, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose182:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose183:
+ax_pose 4, 0x01e4, 0x80ee, 0x3c00
+ax_pose_terminator
+sPolitoedPose184:
+ax_pose 21, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose185:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose186:
+ax_pose 7, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose187:
+ax_pose 23, 0x01e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sPolitoedPose188:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose189:
+ax_pose 10, 0x01e2, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose190:
+ax_pose 25, 0x01e5, 0x90f5, 0x3c00
+ax_pose_terminator
+sPolitoedPose191:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose192:
+ax_pose 13, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose193:
+ax_pose 27, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose194:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose195:
+ax_pose 10, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose196:
+ax_pose 25, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sPolitoedPose197:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose198:
+ax_pose 7, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose199:
+ax_pose 23, 0x01e7, 0x80eb, 0x3c00
+ax_pose_terminator
+sPolitoedPose200:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose201:
+ax_pose 16, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sPolitoedPose202:
+ax_pose 29, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose203:
+ax_pose 18, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose204:
+ax_pose 28, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose205:
+ax_pose 22, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose206:
+ax_pose 24, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sPolitoedPose207:
+ax_pose 26, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose208:
+ax_pose 24, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sPolitoedPose209:
+ax_pose 22, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sPolitoedPose210:
+ax_pose 20, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose211:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose212:
+ax_pose 15, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose213:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose214:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose215:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sPolitoedPose216:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose217:
+ax_pose 6, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sPolitoedPose218:
+ax_pose 3, 0x01e5, 0x80ed, 0x3c00
+ax_pose_terminator
+.align 2
+sPolitoedAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -6, 0, 0,
+ax_anim 4, 0, 1, 0, -8, 0, 1,
+ax_anim 4, 0, 1, 0, -9, 0, 2,
+ax_anim 4, 0, 1, 0, -8, 0, 1,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 2, -2, 0, 0,
+ax_anim 4, 0, 4, 3, -6, 1, 1,
+ax_anim 4, 0, 4, 5, -7, 2, 2,
+ax_anim 4, 0, 4, 5, -6, 2, 2,
+ax_anim 4, 0, 3, 2, -2, 1, 1,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 2, -2, 0, 0,
+ax_anim 4, 0, 7, 4, -6, 1, 0,
+ax_anim 4, 0, 7, 5, -7, 2, 0,
+ax_anim 4, 0, 7, 7, -6, 3, 0,
+ax_anim 4, 0, 6, 3, -2, 2, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 2, -1, 1, -1,
+ax_anim 4, 0, 10, 4, -6, 2, -2,
+ax_anim 4, 0, 10, 5, -8, 3, -3,
+ax_anim 4, 0, 10, 5, -6, 3, -3,
+ax_anim 4, 0, 9, 1, -2, 1, -1,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -4, 0, -1,
+ax_anim 4, 0, 13, 0, -5, 0, -2,
+ax_anim 4, 0, 13, 0, -4, 0, -1,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -2, -1, -1, -1,
+ax_anim 4, 0, 16, -4, -6, -2, -2,
+ax_anim 4, 0, 16, -5, -8, -3, -3,
+ax_anim 4, 0, 16, -5, -6, -3, -3,
+ax_anim 4, 0, 15, -1, -2, -1, -1,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -2, -2, 0, 0,
+ax_anim 4, 0, 19, -4, -6, -1, 0,
+ax_anim 4, 0, 19, -5, -7, -2, 0,
+ax_anim 4, 0, 19, -7, -6, -3, 0,
+ax_anim 4, 0, 18, -3, -2, -2, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -2, -2, 0, 0,
+ax_anim 4, 0, 22, -3, -6, -1, 1,
+ax_anim 4, 0, 22, -5, -7, -2, 2,
+ax_anim 4, 0, 22, -5, -6, -2, 2,
+ax_anim 4, 0, 21, -2, -2, -1, 1,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -7, 0, 0,
+ax_anim 2, 0, 25, 0, -9, 0, 0,
+ax_anim 2, 0, 25, 0, -7, 0, 7,
+ax_anim 2, 0, 25, 0, -2, 0, 7,
+ax_anim 2, 2, 25, 0, 9, 0, 15,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 1, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 26, 0, 20, 0, 20,
+ax_anim 2, 0, 26, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 3, 0, 3,
+ax_anim_terminator
+sPolitoedAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 3, -7, 3, 3,
+ax_anim 2, 0, 28, 6, -9, 6, 6,
+ax_anim 2, 0, 28, 9, -7, 9, 9,
+ax_anim 2, 0, 28, 13, -2, 13, 13,
+ax_anim 2, 2, 28, 17, 9, 17, 17,
+ax_anim 2, 0, 29, 20, 20, 20, 20,
+ax_anim 2, 1, 29, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 20, 20, 20, 20,
+ax_anim 2, 0, 29, 21, 19, 21, 19,
+ax_anim 2, 0, 27, 10, 6, 10, 10,
+ax_anim 2, 0, 27, 3, 3, 3, 3,
+ax_anim_terminator
+sPolitoedAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 3, -5, 3, 0,
+ax_anim 2, 0, 31, 6, -8, 6, 0,
+ax_anim 2, 0, 31, 9, -9, 9, 0,
+ax_anim 2, 0, 31, 13, -8, 13, 0,
+ax_anim 2, 2, 31, 17, -6, 17, 0,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 1, 32, 20, -1, 20, -1,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 20, -1, 20, -1,
+ax_anim 2, 0, 30, 10, -6, 10, 0,
+ax_anim 2, 0, 30, 3, -3, 3, 0,
+ax_anim_terminator
+sPolitoedAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 3, -8, 3, -3,
+ax_anim 2, 0, 34, 6, -14, 6, -6,
+ax_anim 2, 0, 34, 9, -18, 9, -9,
+ax_anim 2, 0, 34, 13, -23, 13, -13,
+ax_anim 2, 2, 34, 17, -24, 17, -17,
+ax_anim 2, 0, 35, 20, -20, 20, -20,
+ax_anim 2, 1, 35, 19, -21, 19, -21,
+ax_anim 2, 0, 35, 20, -20, 20, -20,
+ax_anim 2, 0, 35, 19, -21, 19, -21,
+ax_anim 2, 0, 33, 10, -16, 10, -10,
+ax_anim 2, 0, 33, 3, -6, 3, -3,
+ax_anim_terminator
+sPolitoedAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -8, 0, -3,
+ax_anim 2, 0, 37, 0, -14, 0, -6,
+ax_anim 2, 0, 37, 0, -18, 0, -9,
+ax_anim 2, 0, 37, 0, -23, 0, -13,
+ax_anim 2, 2, 37, 0, -24, 0, -17,
+ax_anim 2, 0, 38, 0, -20, 0, -20,
+ax_anim 2, 1, 38, -1, -20, -1, -20,
+ax_anim 2, 0, 38, 0, -20, 0, -20,
+ax_anim 2, 0, 38, -1, -20, -1, -20,
+ax_anim 2, 0, 36, 0, -16, 0, -10,
+ax_anim 2, 0, 36, 0, -6, 0, -3,
+ax_anim_terminator
+sPolitoedAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 40, -3, -8, -3, -3,
+ax_anim 2, 0, 40, -6, -14, -6, -6,
+ax_anim 2, 0, 40, -9, -18, -9, -9,
+ax_anim 2, 0, 40, -13, -23, -13, -13,
+ax_anim 2, 2, 40, -17, -24, -17, -17,
+ax_anim 2, 0, 41, -20, -20, -20, -20,
+ax_anim 2, 1, 41, -19, -21, -19, -21,
+ax_anim 2, 0, 41, -20, -20, -20, -20,
+ax_anim 2, 0, 41, -19, -21, -19, -21,
+ax_anim 2, 0, 39, -10, -16, -10, -10,
+ax_anim 2, 0, 39, -3, -6, -3, -3,
+ax_anim_terminator
+sPolitoedAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -3, -5, -3, 0,
+ax_anim 2, 0, 43, -6, -8, -6, 0,
+ax_anim 2, 0, 43, -9, -9, -9, 0,
+ax_anim 2, 0, 43, -13, -8, -13, 0,
+ax_anim 2, 2, 43, -17, -6, -17, 0,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 1, 44, -20, -1, -20, -1,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -20, -1, -20, -1,
+ax_anim 2, 0, 42, -10, -6, -10, 0,
+ax_anim 2, 0, 42, -3, -3, -3, 0,
+ax_anim_terminator
+sPolitoedAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, -3, -7, -3, 3,
+ax_anim 2, 0, 46, -6, -9, -6, 6,
+ax_anim 2, 0, 46, -9, -7, -9, 9,
+ax_anim 2, 0, 46, -13, -2, -13, 13,
+ax_anim 2, 2, 46, -17, 9, -17, 17,
+ax_anim 2, 0, 47, -20, 20, -20, 20,
+ax_anim 2, 1, 47, -21, 19, -21, 19,
+ax_anim 2, 0, 47, -20, 20, -20, 20,
+ax_anim 2, 0, 47, -21, 19, -21, 19,
+ax_anim 2, 0, 45, -10, 6, -10, 10,
+ax_anim 2, 0, 45, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, -7, 0, 0,
+ax_anim 2, 0, 49, 0, -9, 0, 0,
+ax_anim 2, 0, 49, 0, -7, 0, 7,
+ax_anim 2, 0, 49, 0, -2, 0, 7,
+ax_anim 2, 2, 49, 0, 9, 0, 15,
+ax_anim 2, 0, 50, 0, 20, 0, 20,
+ax_anim 2, 1, 50, 1, 20, 1, 20,
+ax_anim 2, 0, 50, 0, 20, 0, 20,
+ax_anim 2, 0, 50, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sPolitoedAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 3, -7, 3, 3,
+ax_anim 2, 0, 52, 6, -9, 6, 6,
+ax_anim 2, 0, 52, 9, -7, 9, 9,
+ax_anim 2, 0, 52, 13, -2, 13, 13,
+ax_anim 2, 2, 52, 17, 9, 17, 17,
+ax_anim 2, 0, 53, 20, 20, 20, 20,
+ax_anim 2, 1, 53, 21, 19, 21, 19,
+ax_anim 2, 0, 53, 20, 20, 20, 20,
+ax_anim 2, 0, 53, 21, 19, 21, 19,
+ax_anim 2, 0, 51, 10, 6, 10, 10,
+ax_anim 2, 0, 51, 3, 3, 3, 3,
+ax_anim_terminator
+sPolitoedAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 3, -5, 3, 0,
+ax_anim 2, 0, 55, 6, -8, 6, 0,
+ax_anim 2, 0, 55, 9, -9, 9, 0,
+ax_anim 2, 0, 55, 13, -8, 13, 0,
+ax_anim 2, 2, 55, 17, -6, 17, 0,
+ax_anim 2, 0, 56, 20, 0, 20, 0,
+ax_anim 2, 1, 56, 20, -1, 20, -1,
+ax_anim 2, 0, 56, 20, 0, 20, 0,
+ax_anim 2, 0, 56, 20, -1, 20, -1,
+ax_anim 2, 0, 54, 10, -6, 10, 0,
+ax_anim 2, 0, 54, 3, -3, 3, 0,
+ax_anim_terminator
+sPolitoedAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 3, -8, 3, -3,
+ax_anim 2, 0, 58, 6, -14, 6, -6,
+ax_anim 2, 0, 58, 9, -18, 9, -9,
+ax_anim 2, 0, 58, 13, -23, 13, -13,
+ax_anim 2, 2, 58, 17, -24, 17, -17,
+ax_anim 2, 0, 59, 20, -20, 20, -20,
+ax_anim 2, 1, 59, 19, -21, 19, -21,
+ax_anim 2, 0, 59, 20, -20, 20, -20,
+ax_anim 2, 0, 59, 19, -21, 19, -21,
+ax_anim 2, 0, 57, 10, -16, 10, -10,
+ax_anim 2, 0, 57, 3, -6, 3, -3,
+ax_anim_terminator
+sPolitoedAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -8, 0, -3,
+ax_anim 2, 0, 61, 0, -14, 0, -6,
+ax_anim 2, 0, 61, 0, -18, 0, -9,
+ax_anim 2, 0, 61, 0, -23, 0, -13,
+ax_anim 2, 2, 61, 0, -24, 0, -17,
+ax_anim 2, 0, 62, 0, -20, 0, -20,
+ax_anim 2, 1, 62, -1, -20, -1, -20,
+ax_anim 2, 0, 62, 0, -20, 0, -20,
+ax_anim 2, 0, 62, -1, -20, -1, -20,
+ax_anim 2, 0, 60, 0, -16, 0, -10,
+ax_anim 2, 0, 60, 0, -6, 0, -3,
+ax_anim_terminator
+sPolitoedAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -3, -8, -3, -3,
+ax_anim 2, 0, 64, -6, -14, -6, -6,
+ax_anim 2, 0, 64, -9, -18, -9, -9,
+ax_anim 2, 0, 64, -13, -23, -13, -13,
+ax_anim 2, 2, 64, -17, -24, -17, -17,
+ax_anim 2, 0, 65, -20, -20, -20, -20,
+ax_anim 2, 1, 65, -19, -21, -19, -21,
+ax_anim 2, 0, 65, -20, -20, -20, -20,
+ax_anim 2, 0, 65, -19, -21, -19, -21,
+ax_anim 2, 0, 63, -10, -16, -10, -10,
+ax_anim 2, 0, 63, -3, -6, -3, -3,
+ax_anim_terminator
+sPolitoedAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -3, -5, -3, 0,
+ax_anim 2, 0, 67, -6, -8, -6, 0,
+ax_anim 2, 0, 67, -9, -9, -9, 0,
+ax_anim 2, 0, 67, -13, -8, -13, 0,
+ax_anim 2, 2, 67, -17, -6, -17, 0,
+ax_anim 2, 0, 68, -20, 0, -20, 0,
+ax_anim 2, 1, 68, -20, -1, -20, -1,
+ax_anim 2, 0, 68, -20, 0, -20, 0,
+ax_anim 2, 0, 68, -20, -1, -20, -1,
+ax_anim 2, 0, 66, -10, -6, -10, 0,
+ax_anim 2, 0, 66, -3, -3, -3, 0,
+ax_anim_terminator
+sPolitoedAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, -3, -7, -3, 3,
+ax_anim 2, 0, 70, -6, -9, -6, 6,
+ax_anim 2, 0, 70, -9, -7, -9, 9,
+ax_anim 2, 0, 70, -13, -2, -13, 13,
+ax_anim 2, 2, 70, -17, 9, -17, 17,
+ax_anim 2, 0, 71, -20, 20, -20, 20,
+ax_anim 2, 1, 71, -21, 19, -21, 19,
+ax_anim 2, 0, 71, -20, 20, -20, 20,
+ax_anim 2, 0, 71, -21, 19, -21, 19,
+ax_anim 2, 0, 69, -10, 6, -10, 10,
+ax_anim 2, 0, 69, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_4_1:
+ax_anim 1, 0, 72, 0, -3, 0, -3,
+ax_anim 1, 0, 72, 0, -5, 0, -5,
+ax_anim 2, 0, 72, 0, -5, 0, -5,
+ax_anim 6, 2, 73, 0, -5, 0, -5,
+ax_anim 1, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 1, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 74, 1, 5, 1, 5,
+ax_anim 2, 0, 74, 0, 5, 0, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sPolitoedAnims_4_2:
+ax_anim 1, 0, 75, -3, -3, -3, -3,
+ax_anim 1, 0, 75, -5, -5, -5, -5,
+ax_anim 2, 0, 75, -5, -5, -5, -5,
+ax_anim 6, 2, 76, -5, -5, -5, -5,
+ax_anim 1, 0, 76, -2, -2, -2, -2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 1, 77, 5, 5, 5, 5,
+ax_anim 2, 0, 77, 6, 4, 6, 4,
+ax_anim 2, 0, 77, 5, 5, 5, 5,
+ax_anim 2, 0, 77, 6, 4, 6, 4,
+ax_anim 2, 0, 77, 5, 5, 5, 5,
+ax_anim 2, 0, 77, 6, 4, 6, 4,
+ax_anim 2, 0, 77, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim_terminator
+sPolitoedAnims_4_3:
+ax_anim 1, 0, 78, -3, 0, -3, 0,
+ax_anim 1, 0, 78, -5, 0, -5, 0,
+ax_anim 2, 0, 78, -7, 0, -7, 0,
+ax_anim 6, 2, 79, -7, 0, -7, 0,
+ax_anim 1, 0, 79, -4, 0, -4, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 1, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 5, 0, 5, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sPolitoedAnims_4_4:
+ax_anim 1, 0, 81, -3, 3, -3, 3,
+ax_anim 1, 0, 81, -4, 4, -4, 4,
+ax_anim 2, 0, 81, -6, 6, -6, 6,
+ax_anim 6, 2, 82, -6, 6, -6, 6,
+ax_anim 1, 0, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 1, 83, 5, -5, 5, -5,
+ax_anim 2, 0, 83, 6, -4, 6, -4,
+ax_anim 2, 0, 83, 5, -5, 5, -5,
+ax_anim 2, 0, 83, 6, -4, 6, -4,
+ax_anim 2, 0, 83, 5, -5, 5, -5,
+ax_anim 2, 0, 83, 6, -4, 6, -4,
+ax_anim 2, 0, 83, 5, -5, 5, -5,
+ax_anim 2, 0, 81, 2, -2, 2, -2,
+ax_anim_terminator
+sPolitoedAnims_4_5:
+ax_anim 1, 0, 84, 0, 3, 0, 3,
+ax_anim 1, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, 0, 7, 0, 7,
+ax_anim 6, 2, 85, 0, 6, 0, 6,
+ax_anim 1, 0, 85, 0, 2, 0, 2,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 1, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 86, -1, -5, -1, -5,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 86, -1, -5, -1, -5,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 86, -1, -5, -1, -5,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim_terminator
+sPolitoedAnims_4_6:
+ax_anim 1, 0, 87, 3, 3, 3, 3,
+ax_anim 1, 0, 87, 4, 4, 4, 4,
+ax_anim 2, 0, 87, 6, 6, 6, 6,
+ax_anim 6, 2, 88, 6, 6, 6, 6,
+ax_anim 1, 0, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 1, 89, -5, -5, -5, -5,
+ax_anim 2, 0, 89, -6, -4, -6, -4,
+ax_anim 2, 0, 89, -5, -5, -5, -5,
+ax_anim 2, 0, 89, -6, -4, -6, -4,
+ax_anim 2, 0, 89, -5, -5, -5, -5,
+ax_anim 2, 0, 89, -6, -4, -6, -4,
+ax_anim 2, 0, 89, -5, -5, -5, -5,
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim_terminator
+sPolitoedAnims_4_7:
+ax_anim 1, 0, 90, 3, 0, 3, 0,
+ax_anim 1, 0, 90, 5, 0, 5, 0,
+ax_anim 2, 0, 90, 7, 0, 7, 0,
+ax_anim 6, 2, 91, 7, 0, 7, 0,
+ax_anim 1, 0, 91, 4, 0, 4, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 1, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 92, -5, 1, -5, 1,
+ax_anim 2, 0, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 92, -5, 1, -5, 1,
+ax_anim 2, 0, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 92, -5, 1, -5, 1,
+ax_anim 2, 0, 92, -5, 0, -5, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sPolitoedAnims_4_8:
+ax_anim 1, 0, 93, 3, -3, 3, -3,
+ax_anim 1, 0, 93, 5, -5, 5, -5,
+ax_anim 2, 0, 93, 5, -5, 5, -5,
+ax_anim 6, 2, 94, 5, -5, 5, -5,
+ax_anim 1, 0, 94, 2, -2, 2, -2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 1, 95, -5, 5, -5, 5,
+ax_anim 2, 0, 95, -6, 4, -6, 4,
+ax_anim 2, 0, 95, -5, 5, -5, 5,
+ax_anim 2, 0, 95, -6, 4, -6, 4,
+ax_anim 2, 0, 95, -5, 5, -5, 5,
+ax_anim 2, 0, 95, -6, 4, -6, 4,
+ax_anim 2, 0, 95, -5, 5, -5, 5,
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_5_1:
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 2, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 1, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_5_2:
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 2, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 1, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_5_3:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 2, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 1, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_5_4:
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 2, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 1, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_5_5:
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 2, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 1, 104, 0, 0, 0, 0,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_5_6:
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 2, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 1, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_5_7:
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 2, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 1, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_5_8:
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 6, 2, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 1, 110, 0, 0, 0, 0,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sPolitoedAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sPolitoedAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sPolitoedAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sPolitoedAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sPolitoedAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sPolitoedAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sPolitoedAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, -7, 0, 0,
+ax_anim 5, 0, 123, 0, -8, 0, 1,
+ax_anim 3, 0, 123, 0, -7, 0, 1,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_8_2:
+ax_anim 40, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, -5, 0, 0,
+ax_anim 5, 0, 126, 0, -6, 0, 1,
+ax_anim 3, 0, 126, 0, -5, 0, 1,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_8_3:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, -4, 0, 0,
+ax_anim 5, 0, 129, 0, -5, 0, 1,
+ax_anim 3, 0, 129, 0, -4, 0, 1,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_8_4:
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, -4, 0, 0,
+ax_anim 5, 0, 132, 0, -5, 0, 1,
+ax_anim 3, 0, 132, 0, -4, 0, 1,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_8_5:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, -2, 0, 0,
+ax_anim 5, 0, 135, 0, -3, 0, 1,
+ax_anim 3, 0, 135, 0, -2, 0, 1,
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_8_6:
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 138, 0, -4, 0, 0,
+ax_anim 5, 0, 138, 0, -5, 0, 1,
+ax_anim 3, 0, 138, 0, -4, 0, 1,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_8_7:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, -4, 0, 0,
+ax_anim 5, 0, 141, 0, -5, 0, 1,
+ax_anim 3, 0, 141, 0, -4, 0, 1,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_8_8:
+ax_anim 40, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, -5, 0, 0,
+ax_anim 5, 0, 144, 0, -6, 0, 1,
+ax_anim 3, 0, 144, 0, -5, 0, 1,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 9, 10, 9, 10,
+ax_anim 2, 0, 149, 9, 16, 9, 16,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -9, 16, -9, 16,
+ax_anim 2, 0, 152, -9, 10, -9, 10,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 9, 0, 9, 0,
+ax_anim 2, 0, 147, 17, 4, 17, 4,
+ax_anim 2, 0, 148, 22, 12, 22, 12,
+ax_anim 3, 0, 149, 20, 20, 20, 20,
+ax_anim 2, 3, 150, 11, 20, 11, 20,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 16, -5, 16, -5,
+ax_anim 3, 0, 148, 22, 0, 22, 0,
+ax_anim 2, 3, 149, 19, 5, 19, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 21, -21, 21, -21,
+ax_anim 2, 3, 148, 21, -14, 21, -14,
+ax_anim 2, 0, 149, 17, -6, 17, -6,
+ax_anim 1, 0, 150, 9, -1, 9, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -12, -11, -12, -11,
+ax_anim 2, 0, 153, -8, -18, -8, -18,
+ax_anim 3, 0, 146, 0, -22, 0, -22,
+ax_anim 2, 3, 147, 8, -18, 8, -18,
+ax_anim 2, 0, 148, 12, -11, 12, -11,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -21, -21, -21, -21,
+ax_anim 2, 3, 152, -21, -14, -21, -14,
+ax_anim 2, 0, 151, -17, -6, -17, -6,
+ax_anim 1, 0, 150, -9, -1, -9, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -16, -5, -16, -5,
+ax_anim 3, 0, 152, -22, 0, -22, 0,
+ax_anim 2, 3, 151, -19, 5, -19, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -9, 0, -9, 0,
+ax_anim 2, 0, 153, -17, 4, -17, 4,
+ax_anim 2, 0, 152, -22, 12, -22, 12,
+ax_anim 3, 0, 151, -20, 20, -20, 20,
+ax_anim 2, 3, 150, -11, 20, -11, 20,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_10_1:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, 0, 6, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, 10, 0, 10, 0,
+ax_anim 2, 0, 155, -10, 0, -10, 0,
+ax_anim 2, 0, 155, 12, 0, 12, 0,
+ax_anim 3, 0, 155, -12, 0, -12, 0,
+ax_anim 3, 0, 155, 13, 0, 13, 0,
+ax_anim 3, 0, 155, -13, 0, -13, 0,
+ax_anim 2, 0, 155, 12, 0, 12, 0,
+ax_anim 3, 0, 155, -12, 0, -12, 0,
+ax_anim 2, 0, 155, 10, 0, 10, 0,
+ax_anim 2, 0, 155, -10, 0, -10, 0,
+ax_anim 2, 0, 155, 6, 0, 6, 0,
+ax_anim 2, 0, 155, -6, 0, -6, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_10_2:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, -6, 6, -6,
+ax_anim 2, 0, 158, -6, 6, -6, 6,
+ax_anim 2, 0, 158, 10, -10, 10, -10,
+ax_anim 2, 0, 158, -10, 10, -10, 10,
+ax_anim 2, 0, 158, 12, -12, 12, -12,
+ax_anim 3, 0, 158, -12, 12, -12, 12,
+ax_anim 3, 0, 158, 13, -13, 13, -13,
+ax_anim 3, 0, 158, -13, 13, -13, 13,
+ax_anim 2, 0, 158, 12, -12, 12, -12,
+ax_anim 3, 0, 158, -12, 12, -12, 12,
+ax_anim 2, 0, 158, 10, -10, 10, -10,
+ax_anim 2, 0, 158, -10, 10, -10, 10,
+ax_anim 2, 0, 158, 6, -6, 6, -6,
+ax_anim 2, 0, 158, -6, 6, -6, 6,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_10_3:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 3, 0, 161, 0, -13, 0, -13,
+ax_anim 3, 0, 161, 0, 13, 0, 13,
+ax_anim 2, 0, 161, 0, -12, 0, -12,
+ax_anim 3, 0, 161, 0, 12, 0, 12,
+ax_anim 2, 0, 161, 0, -10, 0, -10,
+ax_anim 2, 0, 161, 0, 10, 0, 10,
+ax_anim 2, 0, 161, 0, -6, 0, -6,
+ax_anim 2, 0, 161, 0, 6, 0, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_10_4:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, -6, -6, -6, -6,
+ax_anim 2, 0, 164, 6, 6, 6, 6,
+ax_anim 2, 0, 164, -10, -10, -10, -10,
+ax_anim 2, 0, 164, 10, 10, 10, 10,
+ax_anim 2, 0, 164, -12, -12, -12, -12,
+ax_anim 3, 0, 164, 12, 12, 12, 12,
+ax_anim 3, 0, 164, -13, -13, -13, -13,
+ax_anim 3, 0, 164, 13, 13, 13, 13,
+ax_anim 2, 0, 164, -12, -12, -12, -12,
+ax_anim 3, 0, 164, 12, 12, 12, 12,
+ax_anim 2, 0, 164, -10, -10, -10, -10,
+ax_anim 2, 0, 164, 10, 10, 10, 10,
+ax_anim 2, 0, 164, -6, -6, -6, -6,
+ax_anim 2, 0, 164, 6, 6, 6, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_10_5:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, 0, 6, 0,
+ax_anim 2, 0, 167, -6, 0, -6, 0,
+ax_anim 2, 0, 167, 10, 0, 10, 0,
+ax_anim 2, 0, 167, -10, 0, -10, 0,
+ax_anim 2, 0, 167, 12, 0, 12, 0,
+ax_anim 3, 0, 167, -12, 0, -12, 0,
+ax_anim 3, 0, 167, 13, 0, 13, 0,
+ax_anim 3, 0, 167, -13, 0, -13, 0,
+ax_anim 2, 0, 167, 12, 0, 12, 0,
+ax_anim 3, 0, 167, -12, 0, -12, 0,
+ax_anim 2, 0, 167, 10, 0, 10, 0,
+ax_anim 2, 0, 167, -10, 0, -10, 0,
+ax_anim 2, 0, 167, 6, 0, 6, 0,
+ax_anim 2, 0, 167, -6, 0, -6, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_10_6:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, -6, 6, -6,
+ax_anim 2, 0, 170, -6, 6, -6, 6,
+ax_anim 2, 0, 170, 10, -10, 10, -10,
+ax_anim 2, 0, 170, -10, 10, -10, 10,
+ax_anim 2, 0, 170, 12, -12, 12, -12,
+ax_anim 3, 0, 170, -12, 12, -12, 12,
+ax_anim 3, 0, 170, 13, -13, 13, -13,
+ax_anim 3, 0, 170, -13, 13, -13, 13,
+ax_anim 2, 0, 170, 12, -12, 12, -12,
+ax_anim 3, 0, 170, -12, 12, -12, 12,
+ax_anim 2, 0, 170, 10, -10, 10, -10,
+ax_anim 2, 0, 170, -10, 10, -10, 10,
+ax_anim 2, 0, 170, 6, -6, 6, -6,
+ax_anim 2, 0, 170, -6, 6, -6, 6,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_10_7:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 3, 0, 173, 0, -13, 0, -13,
+ax_anim 3, 0, 173, 0, 13, 0, 13,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_10_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -6, -6, -6, -6,
+ax_anim 2, 0, 176, 6, 6, 6, 6,
+ax_anim 2, 0, 176, -10, -10, -10, -10,
+ax_anim 2, 0, 176, 10, 10, 10, 10,
+ax_anim 2, 0, 176, -12, -12, -12, -12,
+ax_anim 3, 0, 176, 12, 12, 12, 12,
+ax_anim 3, 0, 176, -13, -13, -13, -13,
+ax_anim 3, 0, 176, 13, 13, 13, 13,
+ax_anim 2, 0, 176, -12, -12, -12, -12,
+ax_anim 3, 0, 176, 12, 12, 12, 12,
+ax_anim 2, 0, 176, -10, -10, -10, -10,
+ax_anim 2, 0, 176, 10, 10, 10, 10,
+ax_anim 2, 0, 176, -6, -6, -6, -6,
+ax_anim 2, 0, 176, 6, 6, 6, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -28, 0, 0,
+ax_anim 3, 0, 180, 0, -27, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -27, 0, 0,
+ax_anim 3, 0, 183, 0, -26, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -7, 0, 0,
+ax_anim 2, 0, 185, 0, -13, 0, 0,
+ax_anim 3, 0, 185, 0, -17, 0, 0,
+ax_anim 4, 0, 185, 0, -18, 0, 0,
+ax_anim 4, 0, 186, 0, -25, 0, 0,
+ax_anim 3, 0, 186, 0, -24, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -8, 0, 0,
+ax_anim 2, 0, 188, 0, -14, 0, 0,
+ax_anim 3, 0, 188, 0, -18, 0, 0,
+ax_anim 4, 0, 188, 0, -19, 0, 0,
+ax_anim 4, 0, 189, 0, -24, 0, 0,
+ax_anim 3, 0, 189, 0, -23, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -6, 0, 0,
+ax_anim 2, 0, 191, 0, -12, 0, 0,
+ax_anim 3, 0, 191, 0, -16, 0, 0,
+ax_anim 4, 0, 191, 0, -17, 0, 0,
+ax_anim 4, 0, 192, 0, -27, 0, 0,
+ax_anim 3, 0, 192, 0, -26, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -8, 0, 0,
+ax_anim 2, 0, 194, 0, -14, 0, 0,
+ax_anim 3, 0, 194, 0, -18, 0, 0,
+ax_anim 4, 0, 194, 0, -19, 0, 0,
+ax_anim 4, 0, 195, 0, -24, 0, 0,
+ax_anim 3, 0, 195, 0, -23, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -7, 0, 0,
+ax_anim 2, 0, 197, 0, -13, 0, 0,
+ax_anim 3, 0, 197, 0, -17, 0, 0,
+ax_anim 4, 0, 197, 0, -18, 0, 0,
+ax_anim 4, 0, 198, 0, -25, 0, 0,
+ax_anim 3, 0, 198, 0, -24, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -27, 0, 0,
+ax_anim 3, 0, 201, 0, -26, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPolitoedAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sPolitoedGfx1:
+.incbin "baserom.gba", 0xD0801C, 0x200
+sPolitoedSprites1:
+ax_sprite sPolitoedGfx1, 0x200
+ax_sprite_terminator
+sPolitoedGfx2:
+.incbin "baserom.gba", 0xD0822C, 0x200
+sPolitoedSprites2:
+ax_sprite sPolitoedGfx2, 0x200
+ax_sprite_terminator
+sPolitoedGfx3:
+.incbin "baserom.gba", 0xD0843C, 0x200
+sPolitoedSprites3:
+ax_sprite sPolitoedGfx3, 0x200
+ax_sprite_terminator
+sPolitoedGfx4:
+.incbin "baserom.gba", 0xD0864C, 0x200
+sPolitoedSprites4:
+ax_sprite sPolitoedGfx4, 0x200
+ax_sprite_terminator
+sPolitoedGfx5:
+.incbin "baserom.gba", 0xD0885C, 0x200
+sPolitoedSprites5:
+ax_sprite sPolitoedGfx5, 0x200
+ax_sprite_terminator
+sPolitoedGfx6:
+.incbin "baserom.gba", 0xD08A6C, 0x200
+sPolitoedSprites6:
+ax_sprite sPolitoedGfx6, 0x200
+ax_sprite_terminator
+sPolitoedGfx7:
+.incbin "baserom.gba", 0xD08C7C, 0x200
+sPolitoedSprites7:
+ax_sprite sPolitoedGfx7, 0x200
+ax_sprite_terminator
+sPolitoedGfx8:
+.incbin "baserom.gba", 0xD08E8C, 0x200
+sPolitoedSprites8:
+ax_sprite sPolitoedGfx8, 0x200
+ax_sprite_terminator
+sPolitoedGfx9:
+.incbin "baserom.gba", 0xD0909C, 0x200
+sPolitoedSprites9:
+ax_sprite sPolitoedGfx9, 0x200
+ax_sprite_terminator
+sPolitoedGfx10:
+.incbin "baserom.gba", 0xD092AC, 0x200
+sPolitoedSprites10:
+ax_sprite sPolitoedGfx10, 0x200
+ax_sprite_terminator
+sPolitoedGfx11:
+.incbin "baserom.gba", 0xD094BC, 0x200
+sPolitoedSprites11:
+ax_sprite sPolitoedGfx11, 0x200
+ax_sprite_terminator
+sPolitoedGfx12:
+.incbin "baserom.gba", 0xD096CC, 0x200
+sPolitoedSprites12:
+ax_sprite sPolitoedGfx12, 0x200
+ax_sprite_terminator
+sPolitoedGfx13:
+.incbin "baserom.gba", 0xD098DC, 0x200
+sPolitoedSprites13:
+ax_sprite sPolitoedGfx13, 0x200
+ax_sprite_terminator
+sPolitoedGfx14:
+.incbin "baserom.gba", 0xD09AEC, 0x200
+sPolitoedSprites14:
+ax_sprite sPolitoedGfx14, 0x200
+ax_sprite_terminator
+sPolitoedGfx15:
+.incbin "baserom.gba", 0xD09CFC, 0x200
+sPolitoedSprites15:
+ax_sprite sPolitoedGfx15, 0x200
+ax_sprite_terminator
+sPolitoedGfx16:
+.incbin "baserom.gba", 0xD09F0C, 0x200
+sPolitoedSprites16:
+ax_sprite sPolitoedGfx16, 0x200
+ax_sprite_terminator
+sPolitoedGfx17:
+.incbin "baserom.gba", 0xD0A11C, 0x200
+sPolitoedSprites17:
+ax_sprite sPolitoedGfx17, 0x200
+ax_sprite_terminator
+sPolitoedGfx18:
+.incbin "baserom.gba", 0xD0A32C, 0x200
+sPolitoedSprites18:
+ax_sprite sPolitoedGfx18, 0x200
+ax_sprite_terminator
+sPolitoedGfx19:
+.incbin "baserom.gba", 0xD0A53C, 0x40
+sPolitoedGfx19_1:
+.incbin "baserom.gba", 0xD0A57C, 0x60
+sPolitoedGfx19_2:
+.incbin "baserom.gba", 0xD0A5DC, 0xE0
+sPolitoedSprites19:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx19_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx20:
+.incbin "baserom.gba", 0xD0A6FC, 0x40
+sPolitoedGfx20_1:
+.incbin "baserom.gba", 0xD0A73C, 0xE0
+sPolitoedSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx20_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPolitoedGfx21:
+.incbin "baserom.gba", 0xD0A84C, 0x40
+sPolitoedGfx21_1:
+.incbin "baserom.gba", 0xD0A88C, 0x60
+sPolitoedGfx21_2:
+.incbin "baserom.gba", 0xD0A8EC, 0x60
+sPolitoedGfx21_3:
+.incbin "baserom.gba", 0xD0A94C, 0x60
+sPolitoedSprites21:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx21_3, 0x60
+ax_sprite_terminator
+sPolitoedGfx22:
+.incbin "baserom.gba", 0xD0A9F4, 0x40
+sPolitoedGfx22_1:
+.incbin "baserom.gba", 0xD0AA34, 0x60
+sPolitoedGfx22_2:
+.incbin "baserom.gba", 0xD0AA94, 0x60
+sPolitoedGfx22_3:
+.incbin "baserom.gba", 0xD0AAF4, 0x60
+sPolitoedSprites22:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx23:
+.incbin "baserom.gba", 0xD0ABA4, 0x40
+sPolitoedGfx23_1:
+.incbin "baserom.gba", 0xD0ABE4, 0x60
+sPolitoedGfx23_2:
+.incbin "baserom.gba", 0xD0AC44, 0x60
+sPolitoedGfx23_3:
+.incbin "baserom.gba", 0xD0ACA4, 0x40
+sPolitoedSprites23:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx24:
+.incbin "baserom.gba", 0xD0AD34, 0x40
+sPolitoedGfx24_1:
+.incbin "baserom.gba", 0xD0AD74, 0x60
+sPolitoedGfx24_2:
+.incbin "baserom.gba", 0xD0ADD4, 0x60
+sPolitoedGfx24_3:
+.incbin "baserom.gba", 0xD0AE34, 0x40
+sPolitoedSprites24:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx24_3, 0x40
+ax_sprite_terminator
+sPolitoedGfx25:
+.incbin "baserom.gba", 0xD0AEBC, 0x40
+sPolitoedGfx25_1:
+.incbin "baserom.gba", 0xD0AEFC, 0x60
+sPolitoedGfx25_2:
+.incbin "baserom.gba", 0xD0AF5C, 0x60
+sPolitoedGfx25_3:
+.incbin "baserom.gba", 0xD0AFBC, 0x60
+sPolitoedSprites25:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx26:
+.incbin "baserom.gba", 0xD0B06C, 0x40
+sPolitoedGfx26_1:
+.incbin "baserom.gba", 0xD0B0AC, 0x60
+sPolitoedGfx26_2:
+.incbin "baserom.gba", 0xD0B10C, 0x60
+sPolitoedGfx26_3:
+.incbin "baserom.gba", 0xD0B16C, 0x60
+sPolitoedSprites26:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx26_3, 0x60
+ax_sprite_terminator
+sPolitoedGfx27:
+.incbin "baserom.gba", 0xD0B214, 0x20
+sPolitoedGfx27_1:
+.incbin "baserom.gba", 0xD0B234, 0x60
+sPolitoedGfx27_2:
+.incbin "baserom.gba", 0xD0B294, 0x60
+sPolitoedGfx27_3:
+.incbin "baserom.gba", 0xD0B2F4, 0x60
+sPolitoedSprites27:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx28:
+.incbin "baserom.gba", 0xD0B3A4, 0x20
+sPolitoedGfx28_1:
+.incbin "baserom.gba", 0xD0B3C4, 0x60
+sPolitoedGfx28_2:
+.incbin "baserom.gba", 0xD0B424, 0x100
+sPolitoedSprites28:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx28_2, 0x100
+ax_sprite_terminator
+sPolitoedGfx29:
+.incbin "baserom.gba", 0xD0B55C, 0x40
+sPolitoedGfx29_1:
+.incbin "baserom.gba", 0xD0B59C, 0x60
+sPolitoedGfx29_2:
+.incbin "baserom.gba", 0xD0B5FC, 0x60
+sPolitoedGfx29_3:
+.incbin "baserom.gba", 0xD0B65C, 0x60
+sPolitoedSprites29:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx30:
+.incbin "baserom.gba", 0xD0B70C, 0x40
+sPolitoedGfx30_1:
+.incbin "baserom.gba", 0xD0B74C, 0x60
+sPolitoedGfx30_2:
+.incbin "baserom.gba", 0xD0B7AC, 0x60
+sPolitoedGfx30_3:
+.incbin "baserom.gba", 0xD0B80C, 0x60
+sPolitoedSprites30:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx30_3, 0x60
+ax_sprite_terminator
+sPolitoedGfx31:
+.incbin "baserom.gba", 0xD0B8B4, 0x140
+sPolitoedGfx31_1:
+.incbin "baserom.gba", 0xD0B9F4, 0x20
+sPolitoedGfx31_2:
+.incbin "baserom.gba", 0xD0BA14, 0x20
+sPolitoedSprites31:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx31, 0x140
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx31_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx31_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx32:
+.incbin "baserom.gba", 0xD0BA74, 0x60
+sPolitoedGfx32_1:
+.incbin "baserom.gba", 0xD0BAD4, 0x60
+sPolitoedGfx32_2:
+.incbin "baserom.gba", 0xD0BB34, 0x60
+sPolitoedGfx32_3:
+.incbin "baserom.gba", 0xD0BB94, 0x20
+sPolitoedGfx32_4:
+.incbin "baserom.gba", 0xD0BBB4, 0x20
+sPolitoedSprites32:
+ax_sprite sPolitoedGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx32_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx32_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx33:
+.incbin "baserom.gba", 0xD0BC2C, 0x20
+sPolitoedGfx33_1:
+.incbin "baserom.gba", 0xD0BC4C, 0x100
+sPolitoedGfx33_2:
+.incbin "baserom.gba", 0xD0BD4C, 0x60
+sPolitoedSprites33:
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx33_2, 0x60
+ax_sprite_terminator
+sPolitoedGfx34:
+.incbin "baserom.gba", 0xD0BDE4, 0x40
+sPolitoedGfx34_1:
+.incbin "baserom.gba", 0xD0BE24, 0x60
+sPolitoedGfx34_2:
+.incbin "baserom.gba", 0xD0BE84, 0x60
+sPolitoedGfx34_3:
+.incbin "baserom.gba", 0xD0BEE4, 0x60
+sPolitoedSprites34:
+ax_sprite sPolitoedGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx35:
+.incbin "baserom.gba", 0xD0BF8C, 0x40
+sPolitoedGfx35_1:
+.incbin "baserom.gba", 0xD0BFCC, 0x60
+sPolitoedGfx35_2:
+.incbin "baserom.gba", 0xD0C02C, 0x60
+sPolitoedGfx35_3:
+.incbin "baserom.gba", 0xD0C08C, 0x60
+sPolitoedSprites35:
+ax_sprite sPolitoedGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx36:
+.incbin "baserom.gba", 0xD0C134, 0x40
+sPolitoedGfx36_1:
+.incbin "baserom.gba", 0xD0C174, 0x60
+sPolitoedGfx36_2:
+.incbin "baserom.gba", 0xD0C1D4, 0x60
+sPolitoedGfx36_3:
+.incbin "baserom.gba", 0xD0C234, 0x60
+sPolitoedSprites36:
+ax_sprite sPolitoedGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx36_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx37:
+.incbin "baserom.gba", 0xD0C2DC, 0x40
+sPolitoedGfx37_1:
+.incbin "baserom.gba", 0xD0C31C, 0x60
+sPolitoedGfx37_2:
+.incbin "baserom.gba", 0xD0C37C, 0x60
+sPolitoedGfx37_3:
+.incbin "baserom.gba", 0xD0C3DC, 0x60
+sPolitoedSprites37:
+ax_sprite sPolitoedGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx38:
+.incbin "baserom.gba", 0xD0C484, 0x40
+sPolitoedGfx38_1:
+.incbin "baserom.gba", 0xD0C4C4, 0x60
+sPolitoedGfx38_2:
+.incbin "baserom.gba", 0xD0C524, 0x60
+sPolitoedGfx38_3:
+.incbin "baserom.gba", 0xD0C584, 0x60
+sPolitoedSprites38:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx38_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx39:
+.incbin "baserom.gba", 0xD0C634, 0x20
+sPolitoedGfx39_1:
+.incbin "baserom.gba", 0xD0C654, 0x60
+sPolitoedGfx39_2:
+.incbin "baserom.gba", 0xD0C6B4, 0x60
+sPolitoedGfx39_3:
+.incbin "baserom.gba", 0xD0C714, 0x60
+sPolitoedSprites39:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx39, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx40:
+.incbin "baserom.gba", 0xD0C7C4, 0x40
+sPolitoedGfx40_1:
+.incbin "baserom.gba", 0xD0C804, 0xE0
+sPolitoedGfx40_2:
+.incbin "baserom.gba", 0xD0C8E4, 0x60
+sPolitoedSprites40:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx40_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx41:
+.incbin "baserom.gba", 0xD0C984, 0x20
+sPolitoedGfx41_1:
+.incbin "baserom.gba", 0xD0C9A4, 0x160
+sPolitoedSprites41:
+ax_sprite 0, 0x20
+ax_sprite sPolitoedGfx41, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPolitoedGfx41_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPolitoedGfx42:
+.incbin "baserom.gba", 0xD0CB34, 0x200
+sPolitoedSprites42:
+ax_sprite sPolitoedGfx42, 0x200
+ax_sprite_terminator
+sPolitoedGfx43:
+.incbin "baserom.gba", 0xD0CD44, 0x200
+sPolitoedSprites43:
+ax_sprite sPolitoedGfx43, 0x200
+ax_sprite_terminator
+sPolitoedGfx44:
+.incbin "baserom.gba", 0xD0CF54, 0x200
+sPolitoedSprites44:
+ax_sprite sPolitoedGfx44, 0x200
+ax_sprite_terminator
+sPolitoedGfx45:
+.incbin "baserom.gba", 0xD0D164, 0x200
+sPolitoedSprites45:
+ax_sprite sPolitoedGfx45, 0x200
+ax_sprite_terminator
+sPolitoedGfx46:
+.incbin "baserom.gba", 0xD0D374, 0x200
+sPolitoedSprites46:
+ax_sprite sPolitoedGfx46, 0x200
+ax_sprite_terminator
+sPolitoedGfx47:
+.incbin "baserom.gba", 0xD0D584, 0x200
+sPolitoedSprites47:
+ax_sprite sPolitoedGfx47, 0x200
+ax_sprite_terminator
+sPolitoedGfx48:
+.incbin "baserom.gba", 0xD0D794, 0x200
+sPolitoedSprites48:
+ax_sprite sPolitoedGfx48, 0x200
+ax_sprite_terminator
+sPolitoedGfx49:
+.incbin "baserom.gba", 0xD0D9A4, 0x200
+sPolitoedSprites49:
+ax_sprite sPolitoedGfx49, 0x200
+ax_sprite_terminator
+sAxPosesPolitoed:
+.4byte sPolitoedPose1
+.4byte sPolitoedPose2
+.4byte sPolitoedPose3
+.4byte sPolitoedPose4
+.4byte sPolitoedPose5
+.4byte sPolitoedPose6
+.4byte sPolitoedPose7
+.4byte sPolitoedPose8
+.4byte sPolitoedPose9
+.4byte sPolitoedPose10
+.4byte sPolitoedPose11
+.4byte sPolitoedPose12
+.4byte sPolitoedPose13
+.4byte sPolitoedPose14
+.4byte sPolitoedPose15
+.4byte sPolitoedPose16
+.4byte sPolitoedPose17
+.4byte sPolitoedPose18
+.4byte sPolitoedPose19
+.4byte sPolitoedPose20
+.4byte sPolitoedPose21
+.4byte sPolitoedPose22
+.4byte sPolitoedPose23
+.4byte sPolitoedPose24
+.4byte sPolitoedPose25
+.4byte sPolitoedPose26
+.4byte sPolitoedPose27
+.4byte sPolitoedPose28
+.4byte sPolitoedPose29
+.4byte sPolitoedPose30
+.4byte sPolitoedPose31
+.4byte sPolitoedPose32
+.4byte sPolitoedPose33
+.4byte sPolitoedPose34
+.4byte sPolitoedPose35
+.4byte sPolitoedPose36
+.4byte sPolitoedPose37
+.4byte sPolitoedPose38
+.4byte sPolitoedPose39
+.4byte sPolitoedPose40
+.4byte sPolitoedPose41
+.4byte sPolitoedPose42
+.4byte sPolitoedPose43
+.4byte sPolitoedPose44
+.4byte sPolitoedPose45
+.4byte sPolitoedPose46
+.4byte sPolitoedPose47
+.4byte sPolitoedPose48
+.4byte sPolitoedPose49
+.4byte sPolitoedPose50
+.4byte sPolitoedPose51
+.4byte sPolitoedPose52
+.4byte sPolitoedPose53
+.4byte sPolitoedPose54
+.4byte sPolitoedPose55
+.4byte sPolitoedPose56
+.4byte sPolitoedPose57
+.4byte sPolitoedPose58
+.4byte sPolitoedPose59
+.4byte sPolitoedPose60
+.4byte sPolitoedPose61
+.4byte sPolitoedPose62
+.4byte sPolitoedPose63
+.4byte sPolitoedPose64
+.4byte sPolitoedPose65
+.4byte sPolitoedPose66
+.4byte sPolitoedPose67
+.4byte sPolitoedPose68
+.4byte sPolitoedPose69
+.4byte sPolitoedPose70
+.4byte sPolitoedPose71
+.4byte sPolitoedPose72
+.4byte sPolitoedPose73
+.4byte sPolitoedPose74
+.4byte sPolitoedPose75
+.4byte sPolitoedPose76
+.4byte sPolitoedPose77
+.4byte sPolitoedPose78
+.4byte sPolitoedPose79
+.4byte sPolitoedPose80
+.4byte sPolitoedPose81
+.4byte sPolitoedPose82
+.4byte sPolitoedPose83
+.4byte sPolitoedPose84
+.4byte sPolitoedPose85
+.4byte sPolitoedPose86
+.4byte sPolitoedPose87
+.4byte sPolitoedPose88
+.4byte sPolitoedPose89
+.4byte sPolitoedPose90
+.4byte sPolitoedPose91
+.4byte sPolitoedPose92
+.4byte sPolitoedPose93
+.4byte sPolitoedPose94
+.4byte sPolitoedPose95
+.4byte sPolitoedPose96
+.4byte sPolitoedPose97
+.4byte sPolitoedPose98
+.4byte sPolitoedPose99
+.4byte sPolitoedPose100
+.4byte sPolitoedPose101
+.4byte sPolitoedPose102
+.4byte sPolitoedPose103
+.4byte sPolitoedPose104
+.4byte sPolitoedPose105
+.4byte sPolitoedPose106
+.4byte sPolitoedPose107
+.4byte sPolitoedPose108
+.4byte sPolitoedPose109
+.4byte sPolitoedPose110
+.4byte sPolitoedPose111
+.4byte sPolitoedPose112
+.4byte sPolitoedPose113
+.4byte sPolitoedPose114
+.4byte sPolitoedPose115
+.4byte sPolitoedPose116
+.4byte sPolitoedPose117
+.4byte sPolitoedPose118
+.4byte sPolitoedPose119
+.4byte sPolitoedPose120
+.4byte sPolitoedPose121
+.4byte sPolitoedPose122
+.4byte sPolitoedPose123
+.4byte sPolitoedPose124
+.4byte sPolitoedPose125
+.4byte sPolitoedPose126
+.4byte sPolitoedPose127
+.4byte sPolitoedPose128
+.4byte sPolitoedPose129
+.4byte sPolitoedPose130
+.4byte sPolitoedPose131
+.4byte sPolitoedPose132
+.4byte sPolitoedPose133
+.4byte sPolitoedPose134
+.4byte sPolitoedPose135
+.4byte sPolitoedPose136
+.4byte sPolitoedPose137
+.4byte sPolitoedPose138
+.4byte sPolitoedPose139
+.4byte sPolitoedPose140
+.4byte sPolitoedPose141
+.4byte sPolitoedPose142
+.4byte sPolitoedPose143
+.4byte sPolitoedPose144
+.4byte sPolitoedPose145
+.4byte sPolitoedPose146
+.4byte sPolitoedPose147
+.4byte sPolitoedPose148
+.4byte sPolitoedPose149
+.4byte sPolitoedPose150
+.4byte sPolitoedPose151
+.4byte sPolitoedPose152
+.4byte sPolitoedPose153
+.4byte sPolitoedPose154
+.4byte sPolitoedPose155
+.4byte sPolitoedPose156
+.4byte sPolitoedPose157
+.4byte sPolitoedPose158
+.4byte sPolitoedPose159
+.4byte sPolitoedPose160
+.4byte sPolitoedPose161
+.4byte sPolitoedPose162
+.4byte sPolitoedPose163
+.4byte sPolitoedPose164
+.4byte sPolitoedPose165
+.4byte sPolitoedPose166
+.4byte sPolitoedPose167
+.4byte sPolitoedPose168
+.4byte sPolitoedPose169
+.4byte sPolitoedPose170
+.4byte sPolitoedPose171
+.4byte sPolitoedPose172
+.4byte sPolitoedPose173
+.4byte sPolitoedPose174
+.4byte sPolitoedPose175
+.4byte sPolitoedPose176
+.4byte sPolitoedPose177
+.4byte sPolitoedPose178
+.4byte sPolitoedPose179
+.4byte sPolitoedPose180
+.4byte sPolitoedPose181
+.4byte sPolitoedPose182
+.4byte sPolitoedPose183
+.4byte sPolitoedPose184
+.4byte sPolitoedPose185
+.4byte sPolitoedPose186
+.4byte sPolitoedPose187
+.4byte sPolitoedPose188
+.4byte sPolitoedPose189
+.4byte sPolitoedPose190
+.4byte sPolitoedPose191
+.4byte sPolitoedPose192
+.4byte sPolitoedPose193
+.4byte sPolitoedPose194
+.4byte sPolitoedPose195
+.4byte sPolitoedPose196
+.4byte sPolitoedPose197
+.4byte sPolitoedPose198
+.4byte sPolitoedPose199
+.4byte sPolitoedPose200
+.4byte sPolitoedPose201
+.4byte sPolitoedPose202
+.4byte sPolitoedPose203
+.4byte sPolitoedPose204
+.4byte sPolitoedPose205
+.4byte sPolitoedPose206
+.4byte sPolitoedPose207
+.4byte sPolitoedPose208
+.4byte sPolitoedPose209
+.4byte sPolitoedPose210
+.4byte sPolitoedPose211
+.4byte sPolitoedPose212
+.4byte sPolitoedPose213
+.4byte sPolitoedPose214
+.4byte sPolitoedPose215
+.4byte sPolitoedPose216
+.4byte sPolitoedPose217
+.4byte sPolitoedPose218
+sAxPositionsPolitoed:
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte    0,   -7, 	 -11,   -9, 	  11,   -9, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -4, 	   9,   -4, 	   0,   -7
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+.2byte    5,  -14, 	  -7,  -12, 	  11,  -16, 	   1,  -13
+.2byte    6,   -6, 	  -3,   -3, 	  10,   -7, 	   1,   -8
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    8,  -15, 	   6,  -15, 	   5,  -11, 	  -1,  -15
+.2byte    8,   -8, 	   4,   -5, 	   2,   -2, 	  -1,  -10
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    3,  -17, 	   1,  -18, 	  10,  -14, 	  -1,  -16
+.2byte    4,  -11, 	  -1,  -11, 	   7,   -5, 	   0,  -10
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    0,  -21, 	   9,  -19, 	  -9,  -19, 	   0,  -17
+.2byte    0,  -13, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte   -3,  -17, 	  -1,  -18, 	 -10,  -14, 	   1,  -16
+.2byte   -4,  -11, 	   1,  -11, 	  -7,   -5, 	   0,  -10
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -8,  -15, 	  -6,  -15, 	  -5,  -11, 	   1,  -15
+.2byte   -8,   -8, 	  -4,   -5, 	  -2,   -2, 	   1,  -10
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	 -11,  -16, 	   7,  -12, 	   0,  -13
+.2byte   -5,   -5, 	 -10,   -7, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte    0,   -7, 	 -11,   -9, 	  11,   -9, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -4, 	   9,   -4, 	   0,   -7
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+.2byte    5,  -14, 	  -7,  -12, 	  11,  -16, 	   1,  -13
+.2byte    6,   -6, 	  -3,   -3, 	  10,   -7, 	   1,   -8
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    8,  -15, 	   6,  -15, 	   5,  -11, 	  -1,  -15
+.2byte    8,   -8, 	   4,   -5, 	   2,   -2, 	  -1,  -10
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    3,  -17, 	   1,  -18, 	  10,  -14, 	  -1,  -16
+.2byte    4,  -11, 	  -1,  -11, 	   7,   -5, 	   0,  -10
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    0,  -21, 	   9,  -19, 	  -9,  -19, 	   0,  -17
+.2byte    0,  -13, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte   -3,  -17, 	  -1,  -18, 	 -10,  -14, 	   1,  -16
+.2byte   -4,  -11, 	   1,  -11, 	  -7,   -5, 	   0,  -10
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -8,  -15, 	  -6,  -15, 	  -5,  -11, 	   1,  -15
+.2byte   -8,   -8, 	  -4,   -5, 	  -2,   -2, 	   1,  -10
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	 -11,  -16, 	   7,  -12, 	   0,  -13
+.2byte   -5,   -5, 	 -10,   -7, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte    0,   -7, 	 -11,   -9, 	  11,   -9, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -4, 	   9,   -4, 	   0,   -7
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+.2byte    5,  -14, 	  -7,  -12, 	  11,  -16, 	   1,  -13
+.2byte    6,   -6, 	  -3,   -3, 	  10,   -7, 	   1,   -8
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    8,  -15, 	   6,  -15, 	   5,  -11, 	  -1,  -15
+.2byte    8,   -8, 	   4,   -5, 	   2,   -2, 	  -1,  -10
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    3,  -17, 	   1,  -18, 	  10,  -14, 	  -1,  -16
+.2byte    4,  -11, 	  -1,  -11, 	   7,   -5, 	   0,  -10
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    0,  -21, 	   9,  -19, 	  -9,  -19, 	   0,  -17
+.2byte    0,  -13, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte   -3,  -17, 	  -1,  -18, 	 -10,  -14, 	   1,  -16
+.2byte   -4,  -11, 	   1,  -11, 	  -7,   -5, 	   0,  -10
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -8,  -15, 	  -6,  -15, 	  -5,  -11, 	   1,  -15
+.2byte   -8,   -8, 	  -4,   -5, 	  -2,   -2, 	   1,  -10
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	 -11,  -16, 	   7,  -12, 	   0,  -13
+.2byte   -5,   -5, 	 -10,   -7, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte    0,  -12, 	  -7,   -6, 	   7,   -6, 	   0,   -9
+.2byte    0,   -7, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+.2byte    4,  -14, 	  -2,   -5, 	   8,   -9, 	   1,  -10
+.2byte    7,  -10, 	  -7,   -7, 	  11,  -12, 	   4,   -9
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    7,  -16, 	   3,   -9, 	   2,   -6, 	  -2,  -10
+.2byte    8,  -10, 	  -4,  -15, 	  -5,   -7, 	   1,  -11
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    4,  -16, 	  -1,  -12, 	   6,   -9, 	  -1,  -11
+.2byte    8,  -14, 	  -7,  -14, 	   3,   -8, 	   0,  -12
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    0,  -11, 	   4,  -11, 	  -4,  -11, 	   0,   -9
+.2byte    0,  -14, 	  11,   -9, 	 -11,   -9, 	   0,  -11
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte   -4,  -16, 	   1,  -12, 	  -6,   -9, 	   1,  -11
+.2byte   -8,  -14, 	   7,  -14, 	  -3,   -8, 	   0,  -12
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -7,  -16, 	  -3,   -9, 	  -2,   -6, 	   2,  -10
+.2byte   -8,  -10, 	   4,  -15, 	   5,   -7, 	  -1,  -11
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -4,  -13, 	  -8,   -9, 	   2,   -6, 	   0,   -9
+.2byte   -7,  -10, 	 -10,  -12, 	   7,   -7, 	  -2,   -9
+.2byte    1,   -7, 	  -4,   -4, 	  11,  -13, 	   1,   -9
+.2byte   -1,   -7, 	 -11,  -13, 	   4,   -4, 	  -1,   -8
+.2byte    4,   -8, 	 -10,  -13, 	   6,   -5, 	   1,   -8
+.2byte    6,   -9, 	   9,  -18, 	   0,   -6, 	   2,  -11
+.2byte    7,   -8, 	   7,   -5, 	  -6,  -13, 	   0,   -7
+.2byte    7,  -10, 	   0,  -21, 	   3,   -5, 	  -1,  -10
+.2byte    5,  -12, 	   2,   -9, 	  11,  -13, 	   2,  -10
+.2byte    4,  -13, 	  -7,  -21, 	   5,   -8, 	  -1,  -11
+.2byte   -1,  -12, 	   3,   -9, 	 -10,  -16, 	  -1,  -10
+.2byte    1,  -13, 	  10,  -16, 	  -3,   -9, 	   1,  -10
+.2byte   -5,  -12, 	  -2,   -9, 	 -11,  -13, 	  -2,  -10
+.2byte   -4,  -13, 	   7,  -21, 	  -5,   -8, 	   1,  -11
+.2byte   -7,   -8, 	  -7,   -5, 	   6,  -13, 	   0,   -7
+.2byte   -7,  -10, 	   0,  -21, 	  -3,   -5, 	   1,  -10
+.2byte   -4,   -7, 	  -6,   -5, 	   9,  -12, 	   0,   -9
+.2byte   -6,   -9, 	  -9,  -18, 	   0,   -6, 	  -2,  -11
+.2byte   -3,   -6, 	  -6,   -6, 	   7,   -1, 	   2,   -8
+.2byte   -4,   -5, 	  -6,   -5, 	   6,   -1, 	   0,   -7
+.2byte    0,  -13, 	  -8,  -16, 	   8,  -16, 	   0,   -9
+.2byte   -1,  -13, 	 -10,  -13, 	   5,  -16, 	   0,  -11
+.2byte    5,  -15, 	   0,  -17, 	  -3,  -14, 	  -2,  -10
+.2byte    0,  -13, 	  -5,  -16, 	   4,  -13, 	  -2,   -9
+.2byte    0,  -14, 	   7,  -14, 	  -7,  -14, 	   0,  -10
+.2byte   -1,  -13, 	   4,  -16, 	  -5,  -13, 	   1,   -9
+.2byte   -6,  -15, 	  -1,  -17, 	   2,  -14, 	   1,  -10
+.2byte   -1,  -13, 	  -6,  -16, 	   9,  -13, 	   0,  -10
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte    0,   -7, 	 -11,   -9, 	  11,   -9, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -4, 	   9,   -4, 	   0,   -7
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+.2byte    5,  -14, 	  -7,  -12, 	  11,  -16, 	   1,  -13
+.2byte    6,   -6, 	  -3,   -3, 	  10,   -7, 	   1,   -8
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    9,  -15, 	   7,  -15, 	   6,  -11, 	   0,  -15
+.2byte    8,   -8, 	   4,   -5, 	   2,   -2, 	  -1,  -10
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    3,  -17, 	   1,  -18, 	  10,  -14, 	  -1,  -16
+.2byte    4,  -11, 	  -1,  -11, 	   7,   -5, 	   0,  -10
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    0,  -21, 	   9,  -19, 	  -9,  -19, 	   0,  -17
+.2byte    0,  -13, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte   -3,  -17, 	  -1,  -18, 	 -10,  -14, 	   1,  -16
+.2byte   -4,  -11, 	   1,  -11, 	  -7,   -5, 	   0,  -10
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -9,  -15, 	  -7,  -15, 	  -6,  -11, 	   0,  -15
+.2byte   -8,   -8, 	  -4,   -5, 	  -2,   -2, 	   1,  -10
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	 -11,  -16, 	   7,  -12, 	   0,  -13
+.2byte   -5,   -5, 	 -10,   -7, 	   3,   -3, 	  -1,   -8
+.2byte    0,   -7, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte   -6,   -9, 	  -9,  -11, 	   8,   -6, 	  -1,   -8
+.2byte   -8,   -8, 	   4,  -13, 	   5,   -5, 	  -1,   -9
+.2byte   -8,  -11, 	   7,  -11, 	  -3,   -5, 	   0,   -9
+.2byte    0,  -12, 	  11,   -7, 	 -11,   -7, 	   0,   -9
+.2byte    7,  -11, 	  -8,  -11, 	   2,   -5, 	  -1,   -9
+.2byte    7,   -8, 	  -5,  -13, 	  -6,   -5, 	   0,   -9
+.2byte    5,   -9, 	  -9,   -6, 	   9,  -11, 	   2,   -8
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte    0,  -12, 	  -7,   -6, 	   7,   -6, 	   0,   -9
+.2byte    0,   -7, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+.2byte    4,  -14, 	  -2,   -5, 	   8,   -9, 	   1,  -10
+.2byte    7,  -10, 	  -7,   -7, 	  11,  -12, 	   4,   -9
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    7,  -16, 	   3,   -9, 	   2,   -6, 	  -2,  -10
+.2byte    8,  -10, 	  -4,  -15, 	  -5,   -7, 	   1,  -11
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    4,  -16, 	  -1,  -12, 	   6,   -9, 	  -1,  -11
+.2byte    8,  -14, 	  -7,  -14, 	   3,   -8, 	   0,  -12
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    0,  -11, 	   4,  -11, 	  -4,  -11, 	   0,   -9
+.2byte    0,  -14, 	  11,   -9, 	 -11,   -9, 	   0,  -11
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte   -4,  -16, 	   1,  -12, 	  -6,   -9, 	   1,  -11
+.2byte   -8,  -14, 	   7,  -14, 	  -3,   -8, 	   0,  -12
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -7,  -16, 	  -3,   -9, 	  -2,   -6, 	   2,  -10
+.2byte   -8,  -10, 	   4,  -15, 	   5,   -7, 	  -1,  -11
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -4,  -13, 	  -8,   -9, 	   2,   -6, 	   0,   -9
+.2byte   -7,  -10, 	 -10,  -12, 	   7,   -7, 	  -2,   -9
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte    0,  -11, 	 -11,  -13, 	  11,  -13, 	   0,  -12
+.2byte    0,   -7, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+.2byte    5,  -14, 	  -7,  -12, 	  11,  -16, 	   1,  -13
+.2byte    5,  -10, 	  -9,   -7, 	   9,  -12, 	   2,   -9
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    8,  -15, 	   6,  -15, 	   5,  -11, 	  -1,  -15
+.2byte    6,   -8, 	  -6,  -13, 	  -7,   -5, 	  -1,   -9
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    3,  -17, 	   1,  -18, 	  10,  -14, 	  -1,  -16
+.2byte    6,  -11, 	  -9,  -11, 	   1,   -5, 	  -2,   -9
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    0,  -21, 	   9,  -19, 	  -9,  -19, 	   0,  -17
+.2byte    0,  -12, 	  11,   -7, 	 -11,   -7, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte   -3,  -17, 	  -1,  -18, 	 -10,  -14, 	   1,  -16
+.2byte   -6,  -11, 	   9,  -11, 	  -1,   -5, 	   2,   -9
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -8,  -15, 	  -6,  -15, 	  -5,  -11, 	   1,  -15
+.2byte   -6,   -8, 	   6,  -13, 	   7,   -5, 	   1,   -9
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -5,  -13, 	 -11,  -16, 	   7,  -12, 	   0,  -13
+.2byte   -5,  -10, 	  -8,  -12, 	   9,   -7, 	   0,   -9
+.2byte    0,  -12, 	  -7,   -6, 	   7,   -6, 	   0,   -9
+.2byte   -3,  -13, 	  -7,   -9, 	   3,   -6, 	   1,   -9
+.2byte   -7,  -16, 	  -3,   -9, 	  -2,   -6, 	   2,  -10
+.2byte   -4,  -15, 	   1,  -11, 	  -6,   -8, 	   1,  -10
+.2byte    0,  -11, 	   4,  -11, 	  -4,  -11, 	   0,   -9
+.2byte    4,  -15, 	  -1,  -11, 	   6,   -8, 	  -1,  -10
+.2byte    7,  -16, 	   3,   -9, 	   2,   -6, 	  -2,  -10
+.2byte    3,  -14, 	  -3,   -5, 	   7,   -9, 	   0,  -10
+.2byte    0,   -7, 	  -9,   -5, 	   9,   -5, 	   0,   -8
+.2byte   -5,   -8, 	 -10,   -9, 	   4,   -4, 	  -1,   -9
+.2byte   -7,   -9, 	  -4,  -10, 	  -2,   -4, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -12, 	  -8,   -6, 	   1,  -10
+.2byte    0,  -13, 	   5,   -9, 	  -5,   -9, 	   0,  -10
+.2byte    4,  -12, 	   1,  -12, 	   8,   -6, 	  -1,  -10
+.2byte    7,   -9, 	   4,  -10, 	   2,   -4, 	   0,   -9
+.2byte    5,   -8, 	  -4,   -4, 	  10,   -9, 	   1,   -9
+sPolitoedAnimTable1:
+.4byte sPolitoedAnims_1_1
+.4byte sPolitoedAnims_1_2
+.4byte sPolitoedAnims_1_3
+.4byte sPolitoedAnims_1_4
+.4byte sPolitoedAnims_1_5
+.4byte sPolitoedAnims_1_6
+.4byte sPolitoedAnims_1_7
+.4byte sPolitoedAnims_1_8
+sPolitoedAnimTable2:
+.4byte sPolitoedAnims_2_1
+.4byte sPolitoedAnims_2_2
+.4byte sPolitoedAnims_2_3
+.4byte sPolitoedAnims_2_4
+.4byte sPolitoedAnims_2_5
+.4byte sPolitoedAnims_2_6
+.4byte sPolitoedAnims_2_7
+.4byte sPolitoedAnims_2_8
+sPolitoedAnimTable3:
+.4byte sPolitoedAnims_3_1
+.4byte sPolitoedAnims_3_2
+.4byte sPolitoedAnims_3_3
+.4byte sPolitoedAnims_3_4
+.4byte sPolitoedAnims_3_5
+.4byte sPolitoedAnims_3_6
+.4byte sPolitoedAnims_3_7
+.4byte sPolitoedAnims_3_8
+sPolitoedAnimTable4:
+.4byte sPolitoedAnims_4_1
+.4byte sPolitoedAnims_4_2
+.4byte sPolitoedAnims_4_3
+.4byte sPolitoedAnims_4_4
+.4byte sPolitoedAnims_4_5
+.4byte sPolitoedAnims_4_6
+.4byte sPolitoedAnims_4_7
+.4byte sPolitoedAnims_4_8
+sPolitoedAnimTable5:
+.4byte sPolitoedAnims_5_1
+.4byte sPolitoedAnims_5_2
+.4byte sPolitoedAnims_5_3
+.4byte sPolitoedAnims_5_4
+.4byte sPolitoedAnims_5_5
+.4byte sPolitoedAnims_5_6
+.4byte sPolitoedAnims_5_7
+.4byte sPolitoedAnims_5_8
+sPolitoedAnimTable6:
+.4byte sPolitoedAnims_6_1
+.4byte sPolitoedAnims_6_1
+.4byte sPolitoedAnims_6_1
+.4byte sPolitoedAnims_6_1
+.4byte sPolitoedAnims_6_1
+.4byte sPolitoedAnims_6_1
+.4byte sPolitoedAnims_6_1
+.4byte sPolitoedAnims_6_1
+sPolitoedAnimTable7:
+.4byte sPolitoedAnims_7_1
+.4byte sPolitoedAnims_7_2
+.4byte sPolitoedAnims_7_3
+.4byte sPolitoedAnims_7_4
+.4byte sPolitoedAnims_7_5
+.4byte sPolitoedAnims_7_6
+.4byte sPolitoedAnims_7_7
+.4byte sPolitoedAnims_7_8
+sPolitoedAnimTable8:
+.4byte sPolitoedAnims_8_1
+.4byte sPolitoedAnims_8_2
+.4byte sPolitoedAnims_8_3
+.4byte sPolitoedAnims_8_4
+.4byte sPolitoedAnims_8_5
+.4byte sPolitoedAnims_8_6
+.4byte sPolitoedAnims_8_7
+.4byte sPolitoedAnims_8_8
+sPolitoedAnimTable9:
+.4byte sPolitoedAnims_9_1
+.4byte sPolitoedAnims_9_2
+.4byte sPolitoedAnims_9_3
+.4byte sPolitoedAnims_9_4
+.4byte sPolitoedAnims_9_5
+.4byte sPolitoedAnims_9_6
+.4byte sPolitoedAnims_9_7
+.4byte sPolitoedAnims_9_8
+sPolitoedAnimTable10:
+.4byte sPolitoedAnims_10_1
+.4byte sPolitoedAnims_10_2
+.4byte sPolitoedAnims_10_3
+.4byte sPolitoedAnims_10_4
+.4byte sPolitoedAnims_10_5
+.4byte sPolitoedAnims_10_6
+.4byte sPolitoedAnims_10_7
+.4byte sPolitoedAnims_10_8
+sPolitoedAnimTable11:
+.4byte sPolitoedAnims_11_1
+.4byte sPolitoedAnims_11_2
+.4byte sPolitoedAnims_11_3
+.4byte sPolitoedAnims_11_4
+.4byte sPolitoedAnims_11_5
+.4byte sPolitoedAnims_11_6
+.4byte sPolitoedAnims_11_7
+.4byte sPolitoedAnims_11_8
+sPolitoedAnimTable12:
+.4byte sPolitoedAnims_12_1
+.4byte sPolitoedAnims_12_2
+.4byte sPolitoedAnims_12_3
+.4byte sPolitoedAnims_12_4
+.4byte sPolitoedAnims_12_5
+.4byte sPolitoedAnims_12_6
+.4byte sPolitoedAnims_12_7
+.4byte sPolitoedAnims_12_8
+sPolitoedAnimTable13:
+.4byte sPolitoedAnims_13_1
+.4byte sPolitoedAnims_13_2
+.4byte sPolitoedAnims_13_3
+.4byte sPolitoedAnims_13_4
+.4byte sPolitoedAnims_13_5
+.4byte sPolitoedAnims_13_6
+.4byte sPolitoedAnims_13_7
+.4byte sPolitoedAnims_13_8
+sAxAnimationsPolitoed:
+.4byte sPolitoedAnimTable1
+.4byte sPolitoedAnimTable2
+.4byte sPolitoedAnimTable3
+.4byte sPolitoedAnimTable4
+.4byte sPolitoedAnimTable5
+.4byte sPolitoedAnimTable6
+.4byte sPolitoedAnimTable7
+.4byte sPolitoedAnimTable8
+.4byte sPolitoedAnimTable9
+.4byte sPolitoedAnimTable10
+.4byte sPolitoedAnimTable11
+.4byte sPolitoedAnimTable12
+.4byte sPolitoedAnimTable13
+sAxSpritesPolitoed:
+.4byte sPolitoedSprites1
+.4byte sPolitoedSprites2
+.4byte sPolitoedSprites3
+.4byte sPolitoedSprites4
+.4byte sPolitoedSprites5
+.4byte sPolitoedSprites6
+.4byte sPolitoedSprites7
+.4byte sPolitoedSprites8
+.4byte sPolitoedSprites9
+.4byte sPolitoedSprites10
+.4byte sPolitoedSprites11
+.4byte sPolitoedSprites12
+.4byte sPolitoedSprites13
+.4byte sPolitoedSprites14
+.4byte sPolitoedSprites15
+.4byte sPolitoedSprites16
+.4byte sPolitoedSprites17
+.4byte sPolitoedSprites18
+.4byte sPolitoedSprites19
+.4byte sPolitoedSprites20
+.4byte sPolitoedSprites21
+.4byte sPolitoedSprites22
+.4byte sPolitoedSprites23
+.4byte sPolitoedSprites24
+.4byte sPolitoedSprites25
+.4byte sPolitoedSprites26
+.4byte sPolitoedSprites27
+.4byte sPolitoedSprites28
+.4byte sPolitoedSprites29
+.4byte sPolitoedSprites30
+.4byte sPolitoedSprites31
+.4byte sPolitoedSprites32
+.4byte sPolitoedSprites33
+.4byte sPolitoedSprites34
+.4byte sPolitoedSprites35
+.4byte sPolitoedSprites36
+.4byte sPolitoedSprites37
+.4byte sPolitoedSprites38
+.4byte sPolitoedSprites39
+.4byte sPolitoedSprites40
+.4byte sPolitoedSprites41
+.4byte sPolitoedSprites42
+.4byte sPolitoedSprites43
+.4byte sPolitoedSprites44
+.4byte sPolitoedSprites45
+.4byte sPolitoedSprites46
+.4byte sPolitoedSprites47
+.4byte sPolitoedSprites48
+.4byte sPolitoedSprites49
+sAxMainPolitoed:
+ax_main sAxPosesPolitoed, sAxAnimationsPolitoed, 13, sAxSpritesPolitoed, sAxPositionsPolitoed

--- a/data/ax/poliwag.inc
+++ b/data/ax/poliwag.inc
@@ -1,0 +1,2526 @@
+.global gAxPoliwag
+gAxPoliwag:
+ax_siro sAxMainPoliwag
+sPoliwagPose1:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose2:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose3:
+ax_pose 2, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose4:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose5:
+ax_pose 4, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose6:
+ax_pose 5, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose7:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose8:
+ax_pose 7, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose9:
+ax_pose 8, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose10:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose11:
+ax_pose 10, 0x01ed, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose12:
+ax_pose 11, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose13:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose14:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose15:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose16:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose17:
+ax_pose 10, 0x01ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose18:
+ax_pose 11, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose19:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose20:
+ax_pose 7, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose21:
+ax_pose 8, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose22:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose23:
+ax_pose 16, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose24:
+ax_pose 17, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose25:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose26:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose27:
+ax_pose 2, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose28:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose29:
+ax_pose 4, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose30:
+ax_pose 5, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose31:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose32:
+ax_pose 7, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose33:
+ax_pose 8, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose34:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose35:
+ax_pose 10, 0x01ed, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose36:
+ax_pose 11, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose37:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose38:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose39:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose40:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose41:
+ax_pose 10, 0x01ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose42:
+ax_pose 11, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose43:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose44:
+ax_pose 7, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose45:
+ax_pose 8, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose46:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose47:
+ax_pose 16, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose48:
+ax_pose 17, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose49:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose50:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose51:
+ax_pose 2, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose52:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose53:
+ax_pose 4, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose54:
+ax_pose 5, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose55:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose56:
+ax_pose 7, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose57:
+ax_pose 8, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose58:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose59:
+ax_pose 10, 0x01ed, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose60:
+ax_pose 11, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose61:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose62:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose63:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose64:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose65:
+ax_pose 10, 0x01ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose66:
+ax_pose 11, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose67:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose68:
+ax_pose 7, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose69:
+ax_pose 8, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose70:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose71:
+ax_pose 16, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose72:
+ax_pose 17, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose73:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose74:
+ax_pose 18, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose75:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose76:
+ax_pose 19, 0x01ea, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose77:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose78:
+ax_pose 20, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwagPose79:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose80:
+ax_pose 21, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sPoliwagPose81:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose82:
+ax_pose 22, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose83:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose84:
+ax_pose 21, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sPoliwagPose85:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose86:
+ax_pose 20, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwagPose87:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose88:
+ax_pose 23, 0x01ea, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose89:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose90:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose91:
+ax_pose 2, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose92:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose93:
+ax_pose 4, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose94:
+ax_pose 5, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose95:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose96:
+ax_pose 7, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose97:
+ax_pose 8, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose98:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose99:
+ax_pose 10, 0x01ed, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose100:
+ax_pose 11, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose101:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose102:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose103:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose104:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose105:
+ax_pose 10, 0x01ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose106:
+ax_pose 11, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose107:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose108:
+ax_pose 7, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose109:
+ax_pose 8, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose110:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose111:
+ax_pose 16, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose112:
+ax_pose 17, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose113:
+ax_pose 24, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose114:
+ax_pose 25, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose115:
+ax_pose 26, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwagPose116:
+ax_pose 27, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose117:
+ax_pose 28, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose118:
+ax_pose 29, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sPoliwagPose119:
+ax_pose 30, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwagPose120:
+ax_pose 29, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwagPose121:
+ax_pose 28, 0x01e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose122:
+ax_pose 27, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose123:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose124:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose125:
+ax_pose 2, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose126:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose127:
+ax_pose 4, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose128:
+ax_pose 5, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose129:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose130:
+ax_pose 7, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose131:
+ax_pose 8, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose132:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose133:
+ax_pose 10, 0x01ed, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose134:
+ax_pose 11, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose135:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose136:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose137:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose138:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose139:
+ax_pose 10, 0x01ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose140:
+ax_pose 11, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose141:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose142:
+ax_pose 7, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose143:
+ax_pose 8, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose144:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose145:
+ax_pose 16, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose146:
+ax_pose 17, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose147:
+ax_pose 18, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose148:
+ax_pose 23, 0x01ea, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose149:
+ax_pose 20, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sPoliwagPose150:
+ax_pose 21, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose151:
+ax_pose 22, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose152:
+ax_pose 21, 0x01ec, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose153:
+ax_pose 20, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sPoliwagPose154:
+ax_pose 19, 0x01ea, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose155:
+ax_pose 18, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose156:
+ax_pose 19, 0x01ea, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose157:
+ax_pose 20, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sPoliwagPose158:
+ax_pose 21, 0x01ec, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose159:
+ax_pose 22, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose160:
+ax_pose 21, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose161:
+ax_pose 20, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sPoliwagPose162:
+ax_pose 23, 0x01ea, 0x80f7, 0x2c00
+ax_pose_terminator
+sPoliwagPose163:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose164:
+ax_pose 1, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose165:
+ax_pose 2, 0x81e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose166:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose167:
+ax_pose 4, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose168:
+ax_pose 5, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose169:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose170:
+ax_pose 7, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose171:
+ax_pose 8, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sPoliwagPose172:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose173:
+ax_pose 10, 0x01ed, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose174:
+ax_pose 11, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose175:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose176:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose177:
+ax_pose 14, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose178:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose179:
+ax_pose 10, 0x01ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose180:
+ax_pose 11, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose181:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose182:
+ax_pose 7, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose183:
+ax_pose 8, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose184:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose185:
+ax_pose 16, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose186:
+ax_pose 17, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose187:
+ax_pose 1, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose188:
+ax_pose 16, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose189:
+ax_pose 7, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose190:
+ax_pose 10, 0x01ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose191:
+ax_pose 13, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose192:
+ax_pose 10, 0x01ed, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose193:
+ax_pose 7, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose194:
+ax_pose 4, 0x01ec, 0x80ea, 0x2c00
+ax_pose_terminator
+sPoliwagPose195:
+ax_pose 0, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose196:
+ax_pose 15, 0x01eb, 0x80f6, 0x2c00
+ax_pose_terminator
+sPoliwagPose197:
+ax_pose 6, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose198:
+ax_pose 9, 0x01eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose199:
+ax_pose 12, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sPoliwagPose200:
+ax_pose 9, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose201:
+ax_pose 6, 0x01eb, 0x90e8, 0x2c00
+ax_pose_terminator
+sPoliwagPose202:
+ax_pose 3, 0x01eb, 0x80ea, 0x2c00
+ax_pose_terminator
+.align 2
+sPoliwagAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 1,
+ax_anim 6, 0, 1, 0, 2, 0, 2,
+ax_anim 6, 0, 2, 0, 2, 0, 2,
+ax_anim_terminator
+sPoliwagAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 0, 1, 1,
+ax_anim 6, 0, 4, 2, 0, 2, 2,
+ax_anim 6, 0, 4, 3, 1, 3, 3,
+ax_anim 6, 0, 5, 2, 2, 2, 2,
+ax_anim_terminator
+sPoliwagAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, -2, 1, 0,
+ax_anim 6, 0, 7, 2, -3, 2, 0,
+ax_anim 6, 0, 7, 2, -2, 2, 0,
+ax_anim 6, 0, 8, 2, -1, 2, 0,
+ax_anim_terminator
+sPoliwagAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, -1, 1, -1,
+ax_anim 6, 0, 10, 2, -3, 2, -2,
+ax_anim 6, 0, 10, 3, -3, 3, -3,
+ax_anim 6, 0, 11, 2, -2, 3, -3,
+ax_anim_terminator
+sPoliwagAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -4, 0, -1,
+ax_anim 6, 0, 13, 0, -5, 0, -2,
+ax_anim 6, 0, 13, 0, -4, 0, -3,
+ax_anim 6, 0, 14, 0, -2, 0, -2,
+ax_anim_terminator
+sPoliwagAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -1, -1, -1,
+ax_anim 6, 0, 16, -2, -3, -2, -2,
+ax_anim 6, 0, 16, -3, -3, -3, -3,
+ax_anim 6, 0, 17, -2, -2, -3, -3,
+ax_anim_terminator
+sPoliwagAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, -2, -1, 0,
+ax_anim 6, 0, 19, -2, -3, -2, 0,
+ax_anim 6, 0, 19, -2, -2, -2, 0,
+ax_anim 6, 0, 20, -2, -1, -2, 0,
+ax_anim_terminator
+sPoliwagAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 0, -1, 1,
+ax_anim 6, 0, 22, -2, 0, -2, 2,
+ax_anim 6, 0, 22, -3, 1, -3, 3,
+ax_anim 6, 0, 23, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -2, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 12,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 3, 0, 3,
+ax_anim_terminator
+sPoliwagAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 5, 0, 5, 5,
+ax_anim 2, 2, 29, 12, 4, 12, 12,
+ax_anim 2, 0, 29, 21, 20, 21, 20,
+ax_anim 2, 1, 29, 22, 19, 22, 19,
+ax_anim 2, 0, 29, 21, 20, 21, 20,
+ax_anim 2, 0, 29, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 3, 3, 3, 3,
+ax_anim_terminator
+sPoliwagAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 5, -4, 5, 0,
+ax_anim 2, 2, 32, 12, -6, 12, 0,
+ax_anim 2, 0, 32, 21, 0, 21, 0,
+ax_anim 2, 1, 32, 21, -1, 21, -1,
+ax_anim 2, 0, 32, 21, 0, 21, 0,
+ax_anim 2, 0, 32, 21, -1, 21, -1,
+ax_anim 2, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 3, 0, 3, 0,
+ax_anim_terminator
+sPoliwagAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 5, -12, 5, -5,
+ax_anim 2, 2, 35, 12, -21, 12, -13,
+ax_anim 2, 0, 35, 21, -23, 21, -23,
+ax_anim 2, 1, 35, 21, -24, 21, -24,
+ax_anim 2, 0, 35, 21, -23, 21, -23,
+ax_anim 2, 0, 35, 21, -24, 21, -24,
+ax_anim 2, 0, 33, 10, -10, 10, -10,
+ax_anim 2, 0, 33, 3, -3, 3, -3,
+ax_anim_terminator
+sPoliwagAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, -4, 0, -2,
+ax_anim 2, 0, 37, 0, -12, 0, -9,
+ax_anim 2, 2, 38, 0, -21, 0, -18,
+ax_anim 2, 0, 38, 0, -23, 0, -23,
+ax_anim 2, 1, 38, -1, -23, -1, -23,
+ax_anim 2, 0, 38, 0, -23, 0, -23,
+ax_anim 2, 0, 38, -1, -23, -1, -23,
+ax_anim 2, 0, 36, 0, -10, 0, -10,
+ax_anim 2, 0, 36, 0, -3, 0, -3,
+ax_anim_terminator
+sPoliwagAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 0, -4, 0, 0,
+ax_anim 2, 0, 40, -5, -12, -5, -5,
+ax_anim 2, 2, 41, -12, -21, -12, -13,
+ax_anim 2, 0, 41, -21, -23, -21, -23,
+ax_anim 2, 1, 41, -21, -24, -21, -24,
+ax_anim 2, 0, 41, -21, -23, -21, -23,
+ax_anim 2, 0, 41, -21, -24, -21, -24,
+ax_anim 2, 0, 39, -10, -10, -10, -10,
+ax_anim 2, 0, 39, -3, -3, -3, -3,
+ax_anim_terminator
+sPoliwagAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 0, -2, 0, 0,
+ax_anim 2, 0, 43, -5, -4, -5, 0,
+ax_anim 2, 2, 44, -12, -6, -12, 0,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 1, 44, -21, -1, -21, -1,
+ax_anim 2, 0, 44, -21, 0, -21, 0,
+ax_anim 2, 0, 44, -21, -1, -21, -1,
+ax_anim 2, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -3, 0, -3, 0,
+ax_anim_terminator
+sPoliwagAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 46, -5, 0, -5, 5,
+ax_anim 2, 2, 47, -12, 4, -12, 12,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 1, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 47, -21, 20, -21, 20,
+ax_anim 2, 0, 47, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 12,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 1, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 50, 0, 19, 0, 19,
+ax_anim 2, 0, 50, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sPoliwagAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 5, 0, 5, 5,
+ax_anim 2, 2, 53, 12, 4, 12, 12,
+ax_anim 2, 0, 53, 21, 20, 21, 20,
+ax_anim 2, 1, 53, 22, 19, 22, 19,
+ax_anim 2, 0, 53, 21, 20, 21, 20,
+ax_anim 2, 0, 53, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 3, 3, 3, 3,
+ax_anim_terminator
+sPoliwagAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 5, -4, 5, 0,
+ax_anim 2, 2, 56, 12, -6, 12, 0,
+ax_anim 2, 0, 56, 21, 0, 21, 0,
+ax_anim 2, 1, 56, 21, -1, 21, -1,
+ax_anim 2, 0, 56, 21, 0, 21, 0,
+ax_anim 2, 0, 56, 21, -1, 21, -1,
+ax_anim 2, 0, 54, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim_terminator
+sPoliwagAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 5, -12, 5, -5,
+ax_anim 2, 2, 59, 12, -21, 12, -13,
+ax_anim 2, 0, 59, 21, -23, 21, -23,
+ax_anim 2, 1, 59, 21, -24, 21, -24,
+ax_anim 2, 0, 59, 21, -23, 21, -23,
+ax_anim 2, 0, 59, 21, -24, 21, -24,
+ax_anim 2, 0, 57, 10, -10, 10, -10,
+ax_anim 2, 0, 57, 3, -3, 3, -3,
+ax_anim_terminator
+sPoliwagAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, -4, 0, -2,
+ax_anim 2, 0, 61, 0, -12, 0, -9,
+ax_anim 2, 2, 62, 0, -21, 0, -18,
+ax_anim 2, 0, 62, 0, -23, 0, -23,
+ax_anim 2, 1, 62, -1, -23, -1, -23,
+ax_anim 2, 0, 62, 0, -23, 0, -23,
+ax_anim 2, 0, 62, -1, -23, -1, -23,
+ax_anim 2, 0, 60, 0, -10, 0, -10,
+ax_anim 2, 0, 60, 0, -3, 0, -3,
+ax_anim_terminator
+sPoliwagAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 0, -4, 0, 0,
+ax_anim 2, 0, 64, -5, -12, -5, -5,
+ax_anim 2, 2, 65, -12, -21, -12, -13,
+ax_anim 2, 0, 65, -21, -23, -21, -23,
+ax_anim 2, 1, 65, -21, -24, -21, -24,
+ax_anim 2, 0, 65, -21, -23, -21, -23,
+ax_anim 2, 0, 65, -21, -24, -21, -24,
+ax_anim 2, 0, 63, -10, -10, -10, -10,
+ax_anim 2, 0, 63, -3, -3, -3, -3,
+ax_anim_terminator
+sPoliwagAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 67, -5, -4, -5, 0,
+ax_anim 2, 2, 68, -12, -6, -12, 0,
+ax_anim 2, 0, 68, -21, 0, -21, 0,
+ax_anim 2, 1, 68, -21, -1, -21, -1,
+ax_anim 2, 0, 68, -21, 0, -21, 0,
+ax_anim 2, 0, 68, -21, -1, -21, -1,
+ax_anim 2, 0, 66, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -3, 0, -3, 0,
+ax_anim_terminator
+sPoliwagAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 70, -5, 0, -5, 5,
+ax_anim 2, 2, 71, -12, 4, -12, 12,
+ax_anim 2, 0, 71, -21, 20, -21, 20,
+ax_anim 2, 1, 71, -22, 19, -22, 19,
+ax_anim 2, 0, 71, -21, 20, -21, 20,
+ax_anim 2, 0, 71, -22, 19, -22, 19,
+ax_anim 2, 0, 69, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 4, 0, 72, 0, -3, 0, -3,
+ax_anim 1, 2, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 2, 0, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 2, 1, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 2, 0, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 2, 0, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sPoliwagAnims_4_2:
+ax_anim 2, 0, 74, -1, -1, -1, -1,
+ax_anim 4, 0, 74, -3, -3, -3, -3,
+ax_anim 1, 2, 75, 1, 1, 1, 1,
+ax_anim 2, 0, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 6, 4, 6, 4,
+ax_anim 2, 0, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 6, 4, 6, 4,
+ax_anim 2, 1, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 6, 4, 6, 4,
+ax_anim 2, 0, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 6, 4, 6, 4,
+ax_anim 2, 0, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim_terminator
+sPoliwagAnims_4_3:
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 4, 0, 76, -3, 0, -3, 0,
+ax_anim 1, 2, 77, 1, 0, 1, 0,
+ax_anim 2, 0, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 5, -1, 5, -1,
+ax_anim 2, 0, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 5, -1, 5, -1,
+ax_anim 2, 1, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 5, -1, 5, -1,
+ax_anim 2, 0, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 5, -1, 5, -1,
+ax_anim 2, 0, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 76, 2, 0, 2, 0,
+ax_anim_terminator
+sPoliwagAnims_4_4:
+ax_anim 2, 0, 78, -1, 1, -1, 0,
+ax_anim 4, 0, 78, -3, 3, -3, 3,
+ax_anim 1, 2, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 6, -4, 6, -4,
+ax_anim 2, 0, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 6, -4, 6, -4,
+ax_anim 2, 1, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 6, -4, 6, -4,
+ax_anim 2, 0, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 6, -4, 6, -4,
+ax_anim 2, 0, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 78, 2, -2, 2, -2,
+ax_anim_terminator
+sPoliwagAnims_4_5:
+ax_anim 2, 0, 80, 0, 1, 0, -1,
+ax_anim 4, 0, 80, 0, 3, 0, 3,
+ax_anim 1, 2, 81, 0, -1, 0, -1,
+ax_anim 2, 0, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 81, -1, -5, -1, -5,
+ax_anim 2, 0, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 81, -1, -5, -1, -5,
+ax_anim 2, 1, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 81, -1, -5, -1, -5,
+ax_anim 2, 0, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 81, -1, -5, -1, -5,
+ax_anim 2, 0, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim_terminator
+sPoliwagAnims_4_6:
+ax_anim 2, 0, 82, -1, 1, -1, 0,
+ax_anim 4, 0, 82, 3, 3, 3, 3,
+ax_anim 1, 2, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 83, -6, -4, -6, -4,
+ax_anim 2, 0, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 83, -6, -4, -6, -4,
+ax_anim 2, 1, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 83, -6, -4, -6, -4,
+ax_anim 2, 0, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 83, -6, -4, -6, -4,
+ax_anim 2, 0, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 82, -2, -2, -2, -2,
+ax_anim_terminator
+sPoliwagAnims_4_7:
+ax_anim 2, 0, 84, 1, 0, -1, 0,
+ax_anim 4, 0, 84, 3, 0, 3, 0,
+ax_anim 1, 2, 85, -1, 0, -1, 0,
+ax_anim 2, 0, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 85, -5, -1, -5, -1,
+ax_anim 2, 0, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 85, -5, -1, -5, -1,
+ax_anim 2, 1, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 85, -5, -1, -5, -1,
+ax_anim 2, 0, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 85, -5, -1, -5, -1,
+ax_anim 2, 0, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim_terminator
+sPoliwagAnims_4_8:
+ax_anim 2, 0, 86, 1, -1, -1, -1,
+ax_anim 4, 0, 86, 3, -3, 3, -3,
+ax_anim 1, 2, 87, -1, 1, -1, 1,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 87, -6, 4, -6, 4,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 87, -6, 4, -6, 4,
+ax_anim 2, 1, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 87, -6, 4, -6, 4,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 87, -6, 4, -6, 4,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 86, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_5_1:
+ax_anim 1, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 4, 0, 88, 0, -8, 0, 0,
+ax_anim 2, 0, 90, 0, -7, 0, 0,
+ax_anim 1, 0, 90, 0, -4, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 4, 0, 88, 0, -8, 0, 0,
+ax_anim 2, 0, 90, 0, -7, 0, 0,
+ax_anim 1, 0, 90, 0, -4, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 4, 2, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_5_2:
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 4, 0, 91, 0, -8, 0, 0,
+ax_anim 2, 0, 93, 0, -7, 0, 0,
+ax_anim 1, 0, 93, 0, -4, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 4, 0, 91, 0, -8, 0, 0,
+ax_anim 2, 0, 93, 0, -7, 0, 0,
+ax_anim 1, 0, 93, 0, -4, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_5_3:
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 4, 0, 94, 0, -8, 0, 0,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 1, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 4, 0, 94, 0, -8, 0, 0,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 1, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 4, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_5_4:
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 4, 0, 97, 0, -8, 0, 0,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 4, 0, 97, 0, -8, 0, 0,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 1, 0, 99, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 4, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_5_5:
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 4, 0, 100, 0, -8, 0, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 1, 0, 102, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 4, 0, 100, 0, -8, 0, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 1, 0, 102, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 4, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_5_6:
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 4, 0, 103, 0, -8, 0, 0,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 1, 0, 105, 0, -4, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 4, 0, 103, 0, -8, 0, 0,
+ax_anim 2, 0, 105, 0, -7, 0, 0,
+ax_anim 1, 0, 105, 0, -4, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 4, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_5_7:
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 4, 0, 106, 0, -8, 0, 0,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 1, 0, 108, 0, -4, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 4, 0, 106, 0, -8, 0, 0,
+ax_anim 2, 0, 108, 0, -7, 0, 0,
+ax_anim 1, 0, 108, 0, -4, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 4, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_5_8:
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 0, 109, 0, -8, 0, 0,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 0, 109, 0, -8, 0, 0,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 1, 0, 111, 0, -4, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 4, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sPoliwagAnims_7_2:
+ax_anim 2, 0, 115, 0, 0, -2, -2,
+ax_anim 8, 0, 115, -1, -1, -3, -3,
+ax_anim_terminator
+sPoliwagAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sPoliwagAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sPoliwagAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sPoliwagAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sPoliwagAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sPoliwagAnims_7_8:
+ax_anim 2, 0, 121, 0, 0, 2, -2,
+ax_anim 8, 0, 121, 1, -1, 3, -3,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_8_1:
+ax_anim 30, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, -2, 0, 0,
+ax_anim 4, 0, 122, 0, -6, 0, 0,
+ax_anim 4, 0, 124, 0, -5, 0, 0,
+ax_anim 4, 0, 124, 0, -2, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_8_2:
+ax_anim 30, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, -2, 0, 0,
+ax_anim 4, 0, 125, 0, -6, 0, 0,
+ax_anim 4, 0, 127, 0, -5, 0, 0,
+ax_anim 4, 0, 127, 0, -2, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_8_3:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, -2, 0, 0,
+ax_anim 4, 0, 128, 0, -6, 0, 0,
+ax_anim 4, 0, 130, 0, -5, 0, 0,
+ax_anim 4, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_8_4:
+ax_anim 30, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 4, 0, 133, 0, -5, 0, 0,
+ax_anim 4, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_8_5:
+ax_anim 30, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, -2, 0, 0,
+ax_anim 4, 0, 134, 0, -6, 0, 0,
+ax_anim 4, 0, 136, 0, -5, 0, 0,
+ax_anim 4, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_8_6:
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 4, 0, 139, 0, -5, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_8_7:
+ax_anim 30, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -6, 0, 0,
+ax_anim 4, 0, 142, 0, -5, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_8_8:
+ax_anim 30, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 0, 144, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -6, 0, 0,
+ax_anim 4, 0, 145, 0, -5, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 16, 7, 16,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 16, -7, 16,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 19, 3, 19, 3,
+ax_anim 2, 0, 148, 23, 10, 23, 10,
+ax_anim 3, 0, 149, 21, 20, 21, 20,
+ax_anim 2, 3, 150, 11, 19, 11, 19,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 18, -5, 18, -5,
+ax_anim 3, 0, 148, 22, -2, 22, -2,
+ax_anim 2, 3, 149, 18, 4, 18, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 21, -25, 21, -25,
+ax_anim 2, 3, 148, 22, -15, 22, -15,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -7, -18, -7, -18,
+ax_anim 3, 0, 146, 0, -25, 0, -22,
+ax_anim 2, 3, 147, 7, -18, 7, -18,
+ax_anim 2, 0, 148, 9, -10, 9, -10,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -21, -25, -21, -25,
+ax_anim 2, 3, 152, -22, -15, -22, -15,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -18, -5, -18, -5,
+ax_anim 3, 0, 152, -22, -2, -22, -2,
+ax_anim 2, 3, 151, -18, 4, -18, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -19, 3, -19, 3,
+ax_anim 2, 0, 152, -23, 10, -23, 10,
+ax_anim 3, 0, 151, -21, 20, -21, 20,
+ax_anim 2, 3, 150, -11, 19, -11, 19,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -26, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -26, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -25, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -25, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -25, 0, 0,
+ax_anim 3, 0, 176, 0, -23, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -25, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -25, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -26, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwagAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwagGfx1:
+.incbin "baserom.gba", 0x79CF00, 0x100
+sPoliwagSprites1:
+ax_sprite sPoliwagGfx1, 0x100
+ax_sprite_terminator
+sPoliwagGfx2:
+.incbin "baserom.gba", 0x79D010, 0x100
+sPoliwagSprites2:
+ax_sprite sPoliwagGfx2, 0x100
+ax_sprite_terminator
+sPoliwagGfx3:
+.incbin "baserom.gba", 0x79D120, 0x100
+sPoliwagSprites3:
+ax_sprite sPoliwagGfx3, 0x100
+ax_sprite_terminator
+sPoliwagGfx4:
+.incbin "baserom.gba", 0x79D230, 0x200
+sPoliwagSprites4:
+ax_sprite sPoliwagGfx4, 0x200
+ax_sprite_terminator
+sPoliwagGfx5:
+.incbin "baserom.gba", 0x79D440, 0x200
+sPoliwagSprites5:
+ax_sprite sPoliwagGfx5, 0x200
+ax_sprite_terminator
+sPoliwagGfx6:
+.incbin "baserom.gba", 0x79D650, 0x200
+sPoliwagSprites6:
+ax_sprite sPoliwagGfx6, 0x200
+ax_sprite_terminator
+sPoliwagGfx7:
+.incbin "baserom.gba", 0x79D860, 0x200
+sPoliwagSprites7:
+ax_sprite sPoliwagGfx7, 0x200
+ax_sprite_terminator
+sPoliwagGfx8:
+.incbin "baserom.gba", 0x79DA70, 0x200
+sPoliwagSprites8:
+ax_sprite sPoliwagGfx8, 0x200
+ax_sprite_terminator
+sPoliwagGfx9:
+.incbin "baserom.gba", 0x79DC80, 0x200
+sPoliwagSprites9:
+ax_sprite sPoliwagGfx9, 0x200
+ax_sprite_terminator
+sPoliwagGfx10:
+.incbin "baserom.gba", 0x79DE90, 0x200
+sPoliwagSprites10:
+ax_sprite sPoliwagGfx10, 0x200
+ax_sprite_terminator
+sPoliwagGfx11:
+.incbin "baserom.gba", 0x79E0A0, 0x200
+sPoliwagSprites11:
+ax_sprite sPoliwagGfx11, 0x200
+ax_sprite_terminator
+sPoliwagGfx12:
+.incbin "baserom.gba", 0x79E2B0, 0x200
+sPoliwagSprites12:
+ax_sprite sPoliwagGfx12, 0x200
+ax_sprite_terminator
+sPoliwagGfx13:
+.incbin "baserom.gba", 0x79E4C0, 0x100
+sPoliwagSprites13:
+ax_sprite sPoliwagGfx13, 0x100
+ax_sprite_terminator
+sPoliwagGfx14:
+.incbin "baserom.gba", 0x79E5D0, 0x100
+sPoliwagSprites14:
+ax_sprite sPoliwagGfx14, 0x100
+ax_sprite_terminator
+sPoliwagGfx15:
+.incbin "baserom.gba", 0x79E6E0, 0x100
+sPoliwagSprites15:
+ax_sprite sPoliwagGfx15, 0x100
+ax_sprite_terminator
+sPoliwagGfx16:
+.incbin "baserom.gba", 0x79E7F0, 0x200
+sPoliwagSprites16:
+ax_sprite sPoliwagGfx16, 0x200
+ax_sprite_terminator
+sPoliwagGfx17:
+.incbin "baserom.gba", 0x79EA00, 0x200
+sPoliwagSprites17:
+ax_sprite sPoliwagGfx17, 0x200
+ax_sprite_terminator
+sPoliwagGfx18:
+.incbin "baserom.gba", 0x79EC10, 0x200
+sPoliwagSprites18:
+ax_sprite sPoliwagGfx18, 0x200
+ax_sprite_terminator
+sPoliwagGfx19:
+.incbin "baserom.gba", 0x79EE20, 0x100
+sPoliwagSprites19:
+ax_sprite sPoliwagGfx19, 0x100
+ax_sprite_terminator
+sPoliwagGfx20:
+.incbin "baserom.gba", 0x79EF30, 0x40
+sPoliwagGfx20_1:
+.incbin "baserom.gba", 0x79EF70, 0x60
+sPoliwagGfx20_2:
+.incbin "baserom.gba", 0x79EFD0, 0x60
+sPoliwagSprites20:
+ax_sprite 0, 0x40
+ax_sprite sPoliwagGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPoliwagGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwagGfx20_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPoliwagGfx21:
+.incbin "baserom.gba", 0x79F070, 0x40
+sPoliwagGfx21_1:
+.incbin "baserom.gba", 0x79F0B0, 0x100
+sPoliwagSprites21:
+ax_sprite sPoliwagGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwagGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPoliwagGfx22:
+.incbin "baserom.gba", 0x79F1D8, 0x40
+sPoliwagGfx22_1:
+.incbin "baserom.gba", 0x79F218, 0x40
+sPoliwagGfx22_2:
+.incbin "baserom.gba", 0x79F258, 0x60
+sPoliwagGfx22_3:
+.incbin "baserom.gba", 0x79F2B8, 0x20
+sPoliwagSprites22:
+ax_sprite sPoliwagGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwagGfx22_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwagGfx22_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sPoliwagGfx22_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwagGfx23:
+.incbin "baserom.gba", 0x79F320, 0xC0
+sPoliwagSprites23:
+ax_sprite sPoliwagGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoliwagGfx24:
+.incbin "baserom.gba", 0x79F3F8, 0x40
+sPoliwagGfx24_1:
+.incbin "baserom.gba", 0x79F438, 0x60
+sPoliwagGfx24_2:
+.incbin "baserom.gba", 0x79F498, 0x60
+sPoliwagSprites24:
+ax_sprite sPoliwagGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwagGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwagGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPoliwagGfx25:
+.incbin "baserom.gba", 0x79F530, 0x200
+sPoliwagSprites25:
+ax_sprite sPoliwagGfx25, 0x200
+ax_sprite_terminator
+sPoliwagGfx26:
+.incbin "baserom.gba", 0x79F740, 0x200
+sPoliwagSprites26:
+ax_sprite sPoliwagGfx26, 0x200
+ax_sprite_terminator
+sPoliwagGfx27:
+.incbin "baserom.gba", 0x79F950, 0x200
+sPoliwagSprites27:
+ax_sprite sPoliwagGfx27, 0x200
+ax_sprite_terminator
+sPoliwagGfx28:
+.incbin "baserom.gba", 0x79FB60, 0x200
+sPoliwagSprites28:
+ax_sprite sPoliwagGfx28, 0x200
+ax_sprite_terminator
+sPoliwagGfx29:
+.incbin "baserom.gba", 0x79FD70, 0x200
+sPoliwagSprites29:
+ax_sprite sPoliwagGfx29, 0x200
+ax_sprite_terminator
+sPoliwagGfx30:
+.incbin "baserom.gba", 0x79FF80, 0x200
+sPoliwagSprites30:
+ax_sprite sPoliwagGfx30, 0x200
+ax_sprite_terminator
+sPoliwagGfx31:
+.incbin "baserom.gba", 0x7A0190, 0x200
+sPoliwagSprites31:
+ax_sprite sPoliwagGfx31, 0x200
+ax_sprite_terminator
+sAxPosesPoliwag:
+.4byte sPoliwagPose1
+.4byte sPoliwagPose2
+.4byte sPoliwagPose3
+.4byte sPoliwagPose4
+.4byte sPoliwagPose5
+.4byte sPoliwagPose6
+.4byte sPoliwagPose7
+.4byte sPoliwagPose8
+.4byte sPoliwagPose9
+.4byte sPoliwagPose10
+.4byte sPoliwagPose11
+.4byte sPoliwagPose12
+.4byte sPoliwagPose13
+.4byte sPoliwagPose14
+.4byte sPoliwagPose15
+.4byte sPoliwagPose16
+.4byte sPoliwagPose17
+.4byte sPoliwagPose18
+.4byte sPoliwagPose19
+.4byte sPoliwagPose20
+.4byte sPoliwagPose21
+.4byte sPoliwagPose22
+.4byte sPoliwagPose23
+.4byte sPoliwagPose24
+.4byte sPoliwagPose25
+.4byte sPoliwagPose26
+.4byte sPoliwagPose27
+.4byte sPoliwagPose28
+.4byte sPoliwagPose29
+.4byte sPoliwagPose30
+.4byte sPoliwagPose31
+.4byte sPoliwagPose32
+.4byte sPoliwagPose33
+.4byte sPoliwagPose34
+.4byte sPoliwagPose35
+.4byte sPoliwagPose36
+.4byte sPoliwagPose37
+.4byte sPoliwagPose38
+.4byte sPoliwagPose39
+.4byte sPoliwagPose40
+.4byte sPoliwagPose41
+.4byte sPoliwagPose42
+.4byte sPoliwagPose43
+.4byte sPoliwagPose44
+.4byte sPoliwagPose45
+.4byte sPoliwagPose46
+.4byte sPoliwagPose47
+.4byte sPoliwagPose48
+.4byte sPoliwagPose49
+.4byte sPoliwagPose50
+.4byte sPoliwagPose51
+.4byte sPoliwagPose52
+.4byte sPoliwagPose53
+.4byte sPoliwagPose54
+.4byte sPoliwagPose55
+.4byte sPoliwagPose56
+.4byte sPoliwagPose57
+.4byte sPoliwagPose58
+.4byte sPoliwagPose59
+.4byte sPoliwagPose60
+.4byte sPoliwagPose61
+.4byte sPoliwagPose62
+.4byte sPoliwagPose63
+.4byte sPoliwagPose64
+.4byte sPoliwagPose65
+.4byte sPoliwagPose66
+.4byte sPoliwagPose67
+.4byte sPoliwagPose68
+.4byte sPoliwagPose69
+.4byte sPoliwagPose70
+.4byte sPoliwagPose71
+.4byte sPoliwagPose72
+.4byte sPoliwagPose73
+.4byte sPoliwagPose74
+.4byte sPoliwagPose75
+.4byte sPoliwagPose76
+.4byte sPoliwagPose77
+.4byte sPoliwagPose78
+.4byte sPoliwagPose79
+.4byte sPoliwagPose80
+.4byte sPoliwagPose81
+.4byte sPoliwagPose82
+.4byte sPoliwagPose83
+.4byte sPoliwagPose84
+.4byte sPoliwagPose85
+.4byte sPoliwagPose86
+.4byte sPoliwagPose87
+.4byte sPoliwagPose88
+.4byte sPoliwagPose89
+.4byte sPoliwagPose90
+.4byte sPoliwagPose91
+.4byte sPoliwagPose92
+.4byte sPoliwagPose93
+.4byte sPoliwagPose94
+.4byte sPoliwagPose95
+.4byte sPoliwagPose96
+.4byte sPoliwagPose97
+.4byte sPoliwagPose98
+.4byte sPoliwagPose99
+.4byte sPoliwagPose100
+.4byte sPoliwagPose101
+.4byte sPoliwagPose102
+.4byte sPoliwagPose103
+.4byte sPoliwagPose104
+.4byte sPoliwagPose105
+.4byte sPoliwagPose106
+.4byte sPoliwagPose107
+.4byte sPoliwagPose108
+.4byte sPoliwagPose109
+.4byte sPoliwagPose110
+.4byte sPoliwagPose111
+.4byte sPoliwagPose112
+.4byte sPoliwagPose113
+.4byte sPoliwagPose114
+.4byte sPoliwagPose115
+.4byte sPoliwagPose116
+.4byte sPoliwagPose117
+.4byte sPoliwagPose118
+.4byte sPoliwagPose119
+.4byte sPoliwagPose120
+.4byte sPoliwagPose121
+.4byte sPoliwagPose122
+.4byte sPoliwagPose123
+.4byte sPoliwagPose124
+.4byte sPoliwagPose125
+.4byte sPoliwagPose126
+.4byte sPoliwagPose127
+.4byte sPoliwagPose128
+.4byte sPoliwagPose129
+.4byte sPoliwagPose130
+.4byte sPoliwagPose131
+.4byte sPoliwagPose132
+.4byte sPoliwagPose133
+.4byte sPoliwagPose134
+.4byte sPoliwagPose135
+.4byte sPoliwagPose136
+.4byte sPoliwagPose137
+.4byte sPoliwagPose138
+.4byte sPoliwagPose139
+.4byte sPoliwagPose140
+.4byte sPoliwagPose141
+.4byte sPoliwagPose142
+.4byte sPoliwagPose143
+.4byte sPoliwagPose144
+.4byte sPoliwagPose145
+.4byte sPoliwagPose146
+.4byte sPoliwagPose147
+.4byte sPoliwagPose148
+.4byte sPoliwagPose149
+.4byte sPoliwagPose150
+.4byte sPoliwagPose151
+.4byte sPoliwagPose152
+.4byte sPoliwagPose153
+.4byte sPoliwagPose154
+.4byte sPoliwagPose155
+.4byte sPoliwagPose156
+.4byte sPoliwagPose157
+.4byte sPoliwagPose158
+.4byte sPoliwagPose159
+.4byte sPoliwagPose160
+.4byte sPoliwagPose161
+.4byte sPoliwagPose162
+.4byte sPoliwagPose163
+.4byte sPoliwagPose164
+.4byte sPoliwagPose165
+.4byte sPoliwagPose166
+.4byte sPoliwagPose167
+.4byte sPoliwagPose168
+.4byte sPoliwagPose169
+.4byte sPoliwagPose170
+.4byte sPoliwagPose171
+.4byte sPoliwagPose172
+.4byte sPoliwagPose173
+.4byte sPoliwagPose174
+.4byte sPoliwagPose175
+.4byte sPoliwagPose176
+.4byte sPoliwagPose177
+.4byte sPoliwagPose178
+.4byte sPoliwagPose179
+.4byte sPoliwagPose180
+.4byte sPoliwagPose181
+.4byte sPoliwagPose182
+.4byte sPoliwagPose183
+.4byte sPoliwagPose184
+.4byte sPoliwagPose185
+.4byte sPoliwagPose186
+.4byte sPoliwagPose187
+.4byte sPoliwagPose188
+.4byte sPoliwagPose189
+.4byte sPoliwagPose190
+.4byte sPoliwagPose191
+.4byte sPoliwagPose192
+.4byte sPoliwagPose193
+.4byte sPoliwagPose194
+.4byte sPoliwagPose195
+.4byte sPoliwagPose196
+.4byte sPoliwagPose197
+.4byte sPoliwagPose198
+.4byte sPoliwagPose199
+.4byte sPoliwagPose200
+.4byte sPoliwagPose201
+.4byte sPoliwagPose202
+sAxPositionsPoliwag:
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -10, 	   6,  -10, 	   0,  -11
+.2byte    0,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -6
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+.2byte    3,  -12, 	  -6,  -10, 	   5,  -13, 	   0,  -11
+.2byte    3,   -6, 	  -6,   -6, 	   5,   -8, 	   1,   -7
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte    5,  -14, 	   0,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    7,   -7, 	   0,   -8, 	  -2,   -5, 	  -1,   -7
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    2,  -13, 	  -5,  -12, 	   4,   -8, 	  -1,  -10
+.2byte    2,   -9, 	  -5,   -9, 	   4,   -5, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte   -3,  -13, 	   4,  -12, 	  -5,   -8, 	   0,  -10
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -7
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte   -6,  -14, 	  -1,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -5, 	   0,   -7
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -4,  -12, 	  -5,  -13, 	   4,   -9, 	   0,  -11
+.2byte   -5,   -6, 	  -5,   -9, 	   4,   -5, 	   0,   -7
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -10, 	   6,  -10, 	   0,  -11
+.2byte    0,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -6
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+.2byte    3,  -12, 	  -6,  -10, 	   5,  -13, 	   0,  -11
+.2byte    3,   -6, 	  -6,   -6, 	   5,   -8, 	   1,   -7
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte    5,  -14, 	   0,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    7,   -7, 	   0,   -8, 	  -2,   -5, 	  -1,   -7
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    2,  -13, 	  -5,  -12, 	   4,   -8, 	  -1,  -10
+.2byte    2,   -9, 	  -5,   -9, 	   4,   -5, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte   -3,  -13, 	   4,  -12, 	  -5,   -8, 	   0,  -10
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -7
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte   -6,  -14, 	  -1,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -5, 	   0,   -7
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -4,  -12, 	  -5,  -13, 	   4,   -9, 	   0,  -11
+.2byte   -5,   -6, 	  -5,   -9, 	   4,   -5, 	   0,   -7
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -10, 	   6,  -10, 	   0,  -11
+.2byte    0,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -6
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+.2byte    3,  -12, 	  -6,  -10, 	   5,  -13, 	   0,  -11
+.2byte    3,   -6, 	  -6,   -6, 	   5,   -8, 	   1,   -7
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte    5,  -14, 	   0,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    7,   -7, 	   0,   -8, 	  -2,   -5, 	  -1,   -7
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    2,  -13, 	  -5,  -12, 	   4,   -8, 	  -1,  -10
+.2byte    2,   -9, 	  -5,   -9, 	   4,   -5, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte   -3,  -13, 	   4,  -12, 	  -5,   -8, 	   0,  -10
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -7
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte   -6,  -14, 	  -1,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -5, 	   0,   -7
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -4,  -12, 	  -5,  -13, 	   4,   -9, 	   0,  -11
+.2byte   -5,   -6, 	  -5,   -9, 	   4,   -5, 	   0,   -7
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,   -6, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+.2byte    6,   -8, 	  -3,   -5, 	   5,   -9, 	   1,   -7
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte   11,  -11, 	   4,  -10, 	   1,   -7, 	   3,   -9
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    8,  -16, 	  -2,  -13, 	   8,   -9, 	   2,  -10
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -20, 	   6,  -12, 	  -7,  -12, 	   0,  -12
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte   -9,  -16, 	   1,  -13, 	  -9,   -9, 	  -3,  -10
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte  -12,  -11, 	  -5,  -10, 	  -2,   -7, 	  -4,   -9
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -7,   -8, 	  -6,   -9, 	   2,   -5, 	  -2,   -7
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -10, 	   6,  -10, 	   0,  -11
+.2byte    0,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -6
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+.2byte    3,  -12, 	  -6,  -10, 	   5,  -13, 	   0,  -11
+.2byte    3,   -6, 	  -6,   -6, 	   5,   -8, 	   1,   -7
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte    5,  -14, 	   0,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    7,   -7, 	   0,   -8, 	  -2,   -5, 	  -1,   -7
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    2,  -13, 	  -5,  -12, 	   4,   -8, 	  -1,  -10
+.2byte    2,   -9, 	  -5,   -9, 	   4,   -5, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte   -3,  -13, 	   4,  -12, 	  -5,   -8, 	   0,  -10
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -7
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte   -6,  -14, 	  -1,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -5, 	   0,   -7
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -4,  -12, 	  -5,  -13, 	   4,   -9, 	   0,  -11
+.2byte   -5,   -6, 	  -5,   -9, 	   4,   -5, 	   0,   -7
+.2byte   -3,   -6, 	  -3,   -7, 	   5,   -4, 	   2,   -5
+.2byte   -3,   -5, 	  -3,   -6, 	   4,   -3, 	   1,   -5
+.2byte    0,   -4, 	  -7,   -4, 	   6,   -4, 	   0,   -5
+.2byte    1,   -3, 	   4,   -7, 	  -8,   -3, 	  -2,   -5
+.2byte    5,   -6, 	  -2,   -6, 	  -4,   -4, 	  -3,   -5
+.2byte    1,   -6, 	  -6,   -6, 	   3,   -2, 	  -2,   -4
+.2byte   -1,   -3, 	   5,   -5, 	  -8,   -5, 	  -1,   -4
+.2byte   -2,   -6, 	   5,   -6, 	  -4,   -2, 	   1,   -4
+.2byte   -6,   -6, 	   1,   -6, 	   3,   -4, 	   2,   -5
+.2byte   -2,   -3, 	  -5,   -7, 	   7,   -3, 	   1,   -5
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -10, 	   6,  -10, 	   0,  -11
+.2byte    0,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -6
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+.2byte    3,  -12, 	  -6,  -10, 	   5,  -13, 	   0,  -11
+.2byte    3,   -6, 	  -6,   -6, 	   5,   -8, 	   1,   -7
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte    5,  -14, 	   0,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    7,   -7, 	   0,   -8, 	  -2,   -5, 	  -1,   -7
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    2,  -13, 	  -5,  -12, 	   4,   -8, 	  -1,  -10
+.2byte    2,   -9, 	  -5,   -9, 	   4,   -5, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte   -3,  -13, 	   4,  -12, 	  -5,   -8, 	   0,  -10
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -7
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte   -6,  -14, 	  -1,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -8,   -7, 	  -1,   -8, 	   1,   -5, 	   0,   -7
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -4,  -12, 	  -5,  -13, 	   4,   -9, 	   0,  -11
+.2byte   -5,   -6, 	  -5,   -9, 	   4,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -6,   -8, 	  -5,   -9, 	   3,   -5, 	  -1,   -7
+.2byte  -10,  -11, 	  -3,  -10, 	   0,   -7, 	  -2,   -9
+.2byte   -7,  -15, 	   3,  -12, 	  -7,   -8, 	  -1,   -9
+.2byte    0,  -18, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    6,  -15, 	  -4,  -12, 	   6,   -8, 	   0,   -9
+.2byte    9,  -11, 	   2,  -10, 	  -1,   -7, 	   1,   -9
+.2byte    6,   -8, 	  -3,   -5, 	   5,   -9, 	   1,   -7
+.2byte    0,   -6, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    6,   -8, 	  -3,   -5, 	   5,   -9, 	   1,   -7
+.2byte    9,  -11, 	   2,  -10, 	  -1,   -7, 	   1,   -9
+.2byte    6,  -15, 	  -4,  -12, 	   6,   -8, 	   0,   -9
+.2byte    0,  -18, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte   -7,  -15, 	   3,  -12, 	  -7,   -8, 	  -1,   -9
+.2byte  -10,  -11, 	  -3,  -10, 	   0,   -7, 	  -2,   -9
+.2byte   -6,   -8, 	  -5,   -9, 	   3,   -5, 	  -1,   -7
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -10, 	   6,  -10, 	   0,  -11
+.2byte    0,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -6
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+.2byte    3,  -12, 	  -6,  -10, 	   5,  -13, 	   0,  -11
+.2byte    3,   -6, 	  -6,   -6, 	   5,   -8, 	   1,   -7
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte    5,  -14, 	   0,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    7,   -7, 	   0,   -8, 	  -2,   -5, 	  -1,   -7
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    2,  -13, 	  -5,  -12, 	   4,   -8, 	  -1,  -10
+.2byte    2,   -9, 	  -5,   -9, 	   4,   -5, 	  -1,   -7
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte   -3,  -13, 	   4,  -12, 	  -5,   -8, 	   0,  -10
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -7
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte   -6,  -14, 	  -1,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -7,   -7, 	   0,   -8, 	   2,   -5, 	   1,   -7
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -4,  -12, 	  -5,  -13, 	   4,   -9, 	   0,  -11
+.2byte   -5,   -6, 	  -5,   -9, 	   4,   -5, 	   0,   -7
+.2byte    0,  -11, 	  -7,   -9, 	   6,   -9, 	   0,  -10
+.2byte   -4,  -11, 	  -5,  -12, 	   4,   -8, 	   0,  -10
+.2byte   -6,  -14, 	  -1,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -3,  -13, 	   4,  -12, 	  -5,   -8, 	   0,  -10
+.2byte    0,  -15, 	   6,  -10, 	  -7,  -10, 	   0,  -10
+.2byte    2,  -13, 	  -5,  -12, 	   4,   -8, 	  -1,  -10
+.2byte    5,  -14, 	   0,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    3,  -11, 	  -6,   -9, 	   5,  -12, 	   0,  -10
+.2byte    0,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -9
+.2byte   -4,   -8, 	  -5,  -11, 	   4,   -7, 	   0,   -8
+.2byte   -7,  -10, 	  -1,   -9, 	   1,   -6, 	   0,   -8
+.2byte   -4,  -12, 	   4,  -10, 	  -5,   -6, 	   0,   -8
+.2byte    0,  -11, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    3,  -12, 	  -5,  -10, 	   4,   -6, 	  -1,   -8
+.2byte    6,  -10, 	   0,   -9, 	  -2,   -6, 	  -1,   -8
+.2byte    3,   -8, 	  -6,   -7, 	   5,  -10, 	  -1,   -8
+sPoliwagAnimTable1:
+.4byte sPoliwagAnims_1_1
+.4byte sPoliwagAnims_1_2
+.4byte sPoliwagAnims_1_3
+.4byte sPoliwagAnims_1_4
+.4byte sPoliwagAnims_1_5
+.4byte sPoliwagAnims_1_6
+.4byte sPoliwagAnims_1_7
+.4byte sPoliwagAnims_1_8
+sPoliwagAnimTable2:
+.4byte sPoliwagAnims_2_1
+.4byte sPoliwagAnims_2_2
+.4byte sPoliwagAnims_2_3
+.4byte sPoliwagAnims_2_4
+.4byte sPoliwagAnims_2_5
+.4byte sPoliwagAnims_2_6
+.4byte sPoliwagAnims_2_7
+.4byte sPoliwagAnims_2_8
+sPoliwagAnimTable3:
+.4byte sPoliwagAnims_3_1
+.4byte sPoliwagAnims_3_2
+.4byte sPoliwagAnims_3_3
+.4byte sPoliwagAnims_3_4
+.4byte sPoliwagAnims_3_5
+.4byte sPoliwagAnims_3_6
+.4byte sPoliwagAnims_3_7
+.4byte sPoliwagAnims_3_8
+sPoliwagAnimTable4:
+.4byte sPoliwagAnims_4_1
+.4byte sPoliwagAnims_4_2
+.4byte sPoliwagAnims_4_3
+.4byte sPoliwagAnims_4_4
+.4byte sPoliwagAnims_4_5
+.4byte sPoliwagAnims_4_6
+.4byte sPoliwagAnims_4_7
+.4byte sPoliwagAnims_4_8
+sPoliwagAnimTable5:
+.4byte sPoliwagAnims_5_1
+.4byte sPoliwagAnims_5_2
+.4byte sPoliwagAnims_5_3
+.4byte sPoliwagAnims_5_4
+.4byte sPoliwagAnims_5_5
+.4byte sPoliwagAnims_5_6
+.4byte sPoliwagAnims_5_7
+.4byte sPoliwagAnims_5_8
+sPoliwagAnimTable6:
+.4byte sPoliwagAnims_6_1
+.4byte sPoliwagAnims_6_1
+.4byte sPoliwagAnims_6_1
+.4byte sPoliwagAnims_6_1
+.4byte sPoliwagAnims_6_1
+.4byte sPoliwagAnims_6_1
+.4byte sPoliwagAnims_6_1
+.4byte sPoliwagAnims_6_1
+sPoliwagAnimTable7:
+.4byte sPoliwagAnims_7_1
+.4byte sPoliwagAnims_7_2
+.4byte sPoliwagAnims_7_3
+.4byte sPoliwagAnims_7_4
+.4byte sPoliwagAnims_7_5
+.4byte sPoliwagAnims_7_6
+.4byte sPoliwagAnims_7_7
+.4byte sPoliwagAnims_7_8
+sPoliwagAnimTable8:
+.4byte sPoliwagAnims_8_1
+.4byte sPoliwagAnims_8_2
+.4byte sPoliwagAnims_8_3
+.4byte sPoliwagAnims_8_4
+.4byte sPoliwagAnims_8_5
+.4byte sPoliwagAnims_8_6
+.4byte sPoliwagAnims_8_7
+.4byte sPoliwagAnims_8_8
+sPoliwagAnimTable9:
+.4byte sPoliwagAnims_9_1
+.4byte sPoliwagAnims_9_2
+.4byte sPoliwagAnims_9_3
+.4byte sPoliwagAnims_9_4
+.4byte sPoliwagAnims_9_5
+.4byte sPoliwagAnims_9_6
+.4byte sPoliwagAnims_9_7
+.4byte sPoliwagAnims_9_8
+sPoliwagAnimTable10:
+.4byte sPoliwagAnims_10_1
+.4byte sPoliwagAnims_10_2
+.4byte sPoliwagAnims_10_3
+.4byte sPoliwagAnims_10_4
+.4byte sPoliwagAnims_10_5
+.4byte sPoliwagAnims_10_6
+.4byte sPoliwagAnims_10_7
+.4byte sPoliwagAnims_10_8
+sPoliwagAnimTable11:
+.4byte sPoliwagAnims_11_1
+.4byte sPoliwagAnims_11_2
+.4byte sPoliwagAnims_11_3
+.4byte sPoliwagAnims_11_4
+.4byte sPoliwagAnims_11_5
+.4byte sPoliwagAnims_11_6
+.4byte sPoliwagAnims_11_7
+.4byte sPoliwagAnims_11_8
+sPoliwagAnimTable12:
+.4byte sPoliwagAnims_12_1
+.4byte sPoliwagAnims_12_2
+.4byte sPoliwagAnims_12_3
+.4byte sPoliwagAnims_12_4
+.4byte sPoliwagAnims_12_5
+.4byte sPoliwagAnims_12_6
+.4byte sPoliwagAnims_12_7
+.4byte sPoliwagAnims_12_8
+sPoliwagAnimTable13:
+.4byte sPoliwagAnims_13_1
+.4byte sPoliwagAnims_13_2
+.4byte sPoliwagAnims_13_3
+.4byte sPoliwagAnims_13_4
+.4byte sPoliwagAnims_13_5
+.4byte sPoliwagAnims_13_6
+.4byte sPoliwagAnims_13_7
+.4byte sPoliwagAnims_13_8
+sAxAnimationsPoliwag:
+.4byte sPoliwagAnimTable1
+.4byte sPoliwagAnimTable2
+.4byte sPoliwagAnimTable3
+.4byte sPoliwagAnimTable4
+.4byte sPoliwagAnimTable5
+.4byte sPoliwagAnimTable6
+.4byte sPoliwagAnimTable7
+.4byte sPoliwagAnimTable8
+.4byte sPoliwagAnimTable9
+.4byte sPoliwagAnimTable10
+.4byte sPoliwagAnimTable11
+.4byte sPoliwagAnimTable12
+.4byte sPoliwagAnimTable13
+sAxSpritesPoliwag:
+.4byte sPoliwagSprites1
+.4byte sPoliwagSprites2
+.4byte sPoliwagSprites3
+.4byte sPoliwagSprites4
+.4byte sPoliwagSprites5
+.4byte sPoliwagSprites6
+.4byte sPoliwagSprites7
+.4byte sPoliwagSprites8
+.4byte sPoliwagSprites9
+.4byte sPoliwagSprites10
+.4byte sPoliwagSprites11
+.4byte sPoliwagSprites12
+.4byte sPoliwagSprites13
+.4byte sPoliwagSprites14
+.4byte sPoliwagSprites15
+.4byte sPoliwagSprites16
+.4byte sPoliwagSprites17
+.4byte sPoliwagSprites18
+.4byte sPoliwagSprites19
+.4byte sPoliwagSprites20
+.4byte sPoliwagSprites21
+.4byte sPoliwagSprites22
+.4byte sPoliwagSprites23
+.4byte sPoliwagSprites24
+.4byte sPoliwagSprites25
+.4byte sPoliwagSprites26
+.4byte sPoliwagSprites27
+.4byte sPoliwagSprites28
+.4byte sPoliwagSprites29
+.4byte sPoliwagSprites30
+.4byte sPoliwagSprites31
+sAxMainPoliwag:
+ax_main sAxPosesPoliwag, sAxAnimationsPoliwag, 13, sAxSpritesPoliwag, sAxPositionsPoliwag

--- a/data/ax/poliwhirl.inc
+++ b/data/ax/poliwhirl.inc
@@ -1,0 +1,2954 @@
+.global gAxPoliwhirl
+gAxPoliwhirl:
+ax_siro sAxMainPoliwhirl
+sPoliwhirlPose1:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose2:
+ax_pose 1, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose4:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose5:
+ax_pose 4, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose6:
+ax_pose 5, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose7:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose8:
+ax_pose 7, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose9:
+ax_pose 8, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose10:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose11:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose12:
+ax_pose 11, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose13:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose14:
+ax_pose 13, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose15:
+ax_pose 14, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose18:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose19:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose20:
+ax_pose 7, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose21:
+ax_pose 8, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose22:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose23:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose24:
+ax_pose 17, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose25:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose26:
+ax_pose 1, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose27:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose28:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose29:
+ax_pose 4, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose30:
+ax_pose 5, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose31:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose32:
+ax_pose 7, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose33:
+ax_pose 8, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose34:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose35:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose36:
+ax_pose 11, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose37:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose38:
+ax_pose 13, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose39:
+ax_pose 14, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose40:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose41:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose42:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose43:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose44:
+ax_pose 7, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose45:
+ax_pose 8, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose46:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose47:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose48:
+ax_pose 17, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose49:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose50:
+ax_pose 1, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose51:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose52:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose53:
+ax_pose 4, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose54:
+ax_pose 5, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose55:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose56:
+ax_pose 7, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose57:
+ax_pose 8, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose58:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose59:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose60:
+ax_pose 11, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose61:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose62:
+ax_pose 13, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose63:
+ax_pose 14, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose64:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose65:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose66:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose67:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose68:
+ax_pose 7, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose69:
+ax_pose 8, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose70:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose71:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose72:
+ax_pose 17, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose73:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose74:
+ax_pose 1, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose75:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose76:
+ax_pose 18, 0x41e3, 0x80ef, 0x2c00
+ax_pose 19, 0x41f3, 0x40ef, 0x2c08
+ax_pose 20, 0x01e3, 0x010f, 0x2c0c
+ax_pose 21, 0x41fb, 0x00f7, 0x2c0d
+ax_pose 22, 0x01fb, 0x0107, 0x2c0f
+ax_pose_terminator
+sPoliwhirlPose77:
+ax_pose 23, 0x41ea, 0x40ee, 0x2c00
+ax_pose 24, 0x41f2, 0x80ee, 0x2c04
+ax_pose 25, 0x01f5, 0x010e, 0x2c0c
+ax_pose_terminator
+sPoliwhirlPose78:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose79:
+ax_pose 4, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose80:
+ax_pose 5, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose81:
+ax_pose 26, 0x41e4, 0x80ed, 0x2c00
+ax_pose 27, 0x41f4, 0x40ed, 0x2c08
+ax_pose 28, 0x41fc, 0x00fd, 0x2c0c
+ax_pose 29, 0x01fc, 0x00f5, 0x2c0e
+ax_pose 30, 0x01dc, 0x00ff, 0x2c0f
+ax_pose_terminator
+sPoliwhirlPose82:
+ax_pose 31, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose83:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose84:
+ax_pose 7, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose85:
+ax_pose 8, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose86:
+ax_pose 32, 0x41e5, 0x80ed, 0x2c00
+ax_pose 33, 0x41f5, 0x40ed, 0x2c08
+ax_pose 34, 0x41fd, 0x00fd, 0x2c0c
+ax_pose 35, 0x01fd, 0x00f5, 0x2c0e
+ax_pose 36, 0x01dd, 0x00f4, 0x2c0f
+ax_pose_terminator
+sPoliwhirlPose87:
+ax_pose 37, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose88:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose89:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose90:
+ax_pose 11, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose91:
+ax_pose 38, 0x41e3, 0x90ed, 0x2c00
+ax_pose 39, 0x41f3, 0x50ed, 0x2c08
+ax_pose 40, 0x41fb, 0x10fd, 0x2c0c
+ax_pose 41, 0x01fb, 0x10f5, 0x2c0e
+ax_pose 42, 0x01db, 0x10ef, 0x2c0f
+ax_pose_terminator
+sPoliwhirlPose92:
+ax_pose 43, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose93:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose94:
+ax_pose 13, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose95:
+ax_pose 14, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose96:
+ax_pose 44, 0x41ea, 0x80ef, 0x2c00
+ax_pose 45, 0x41fa, 0x40ef, 0x2c08
+ax_pose 46, 0x01e2, 0x00f0, 0x2c0c
+ax_pose 47, 0x01e2, 0x0109, 0x2c0d
+ax_pose 48, 0x01ea, 0x010f, 0x2c0e
+ax_pose_terminator
+sPoliwhirlPose97:
+ax_pose 49, 0x41eb, 0x80ef, 0x2c00
+ax_pose 50, 0x41fb, 0x40ef, 0x2c08
+ax_pose 51, 0x01f8, 0x010f, 0x2c0c
+ax_pose_terminator
+sPoliwhirlPose98:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose99:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose100:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose101:
+ax_pose 38, 0x41e3, 0x80f4, 0x2c00
+ax_pose 39, 0x41f3, 0x40f4, 0x2c08
+ax_pose 40, 0x41fb, 0x00f4, 0x2c0c
+ax_pose 41, 0x01fb, 0x0104, 0x2c0e
+ax_pose 42, 0x01db, 0x010a, 0x2c0f
+ax_pose_terminator
+sPoliwhirlPose102:
+ax_pose 43, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose103:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose104:
+ax_pose 7, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose105:
+ax_pose 8, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose106:
+ax_pose 52, 0x41e5, 0x80f4, 0x2c00
+ax_pose 53, 0x41f5, 0x40f4, 0x2c08
+ax_pose 54, 0x41fd, 0x00f4, 0x2c0c
+ax_pose 55, 0x01fd, 0x0104, 0x2c0e
+ax_pose 56, 0x01dd, 0x0105, 0x2c0f
+ax_pose_terminator
+sPoliwhirlPose107:
+ax_pose 37, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose108:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose109:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose110:
+ax_pose 17, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose111:
+ax_pose 57, 0x41e4, 0x80f4, 0x2c00
+ax_pose 58, 0x41f4, 0x40f4, 0x2c08
+ax_pose 59, 0x41fc, 0x00f4, 0x2c0c
+ax_pose 60, 0x01fc, 0x0104, 0x2c0e
+ax_pose 61, 0x01dc, 0x00fa, 0x2c0f
+ax_pose_terminator
+sPoliwhirlPose112:
+ax_pose 31, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose113:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose114:
+ax_pose 62, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose115:
+ax_pose 63, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose116:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose117:
+ax_pose 64, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose118:
+ax_pose 65, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose119:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose120:
+ax_pose 66, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose121:
+ax_pose 67, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose122:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose123:
+ax_pose 68, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose124:
+ax_pose 69, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose125:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose126:
+ax_pose 70, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose127:
+ax_pose 71, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose128:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose129:
+ax_pose 68, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose130:
+ax_pose 69, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose131:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose132:
+ax_pose 66, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose133:
+ax_pose 67, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose134:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose135:
+ax_pose 72, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose136:
+ax_pose 65, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose137:
+ax_pose 73, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose138:
+ax_pose 74, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose139:
+ax_pose 75, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose140:
+ax_pose 76, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose141:
+ax_pose 77, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose142:
+ax_pose 78, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose143:
+ax_pose 79, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose144:
+ax_pose 78, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose145:
+ax_pose 77, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose146:
+ax_pose 80, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose147:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose148:
+ax_pose 1, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose149:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose150:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose151:
+ax_pose 4, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose152:
+ax_pose 5, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose153:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose154:
+ax_pose 7, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose155:
+ax_pose 8, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose156:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose157:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose158:
+ax_pose 11, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose159:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose160:
+ax_pose 13, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose161:
+ax_pose 14, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose162:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose163:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose164:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose165:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose166:
+ax_pose 7, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose167:
+ax_pose 8, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose168:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose169:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose170:
+ax_pose 17, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose171:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose172:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose173:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose174:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose175:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose176:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose177:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose178:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose179:
+ax_pose 62, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose180:
+ax_pose 64, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose181:
+ax_pose 66, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose182:
+ax_pose 68, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose183:
+ax_pose 70, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose184:
+ax_pose 68, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose185:
+ax_pose 66, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose186:
+ax_pose 72, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose187:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose188:
+ax_pose 1, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose189:
+ax_pose 2, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose190:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose191:
+ax_pose 4, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose192:
+ax_pose 5, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose193:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose194:
+ax_pose 7, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose195:
+ax_pose 8, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose196:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose197:
+ax_pose 10, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose198:
+ax_pose 11, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose199:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose200:
+ax_pose 13, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose201:
+ax_pose 14, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose202:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose203:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose204:
+ax_pose 11, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose205:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose206:
+ax_pose 7, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose207:
+ax_pose 8, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose208:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose209:
+ax_pose 16, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose210:
+ax_pose 17, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose211:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose212:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose213:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose214:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose215:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose216:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose217:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose218:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose219:
+ax_pose 0, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose220:
+ax_pose 15, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose221:
+ax_pose 6, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose222:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose223:
+ax_pose 12, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose224:
+ax_pose 9, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose225:
+ax_pose 6, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwhirlPose226:
+ax_pose 3, 0x01ec, 0x80ed, 0x2c00
+ax_pose_terminator
+.align 2
+sPoliwhirlAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_2_1:
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 6, 0, 46, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPoliwhirlAnims_2_2:
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 6, 0, 25, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sPoliwhirlAnims_2_3:
+ax_anim 2, 0, 28, -1, 0, -1, 0,
+ax_anim 6, 0, 28, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 18, 0, 18, 0,
+ax_anim 2, 1, 34, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sPoliwhirlAnims_2_4:
+ax_anim 2, 0, 31, -1, 1, -1, 1,
+ax_anim 6, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 1, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sPoliwhirlAnims_2_5:
+ax_anim 2, 0, 34, 0, 1, 0, 1,
+ax_anim 6, 0, 34, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 40, 0, -21, 0, -21,
+ax_anim 2, 1, 40, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -21, 0, -21,
+ax_anim 2, 0, 40, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sPoliwhirlAnims_2_6:
+ax_anim 2, 0, 37, 1, 1, 1, 1,
+ax_anim 6, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 43, -18, -23, -18, -23,
+ax_anim 2, 1, 43, -19, -22, -19, -22,
+ax_anim 2, 0, 43, -18, -23, -18, -23,
+ax_anim 2, 0, 43, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sPoliwhirlAnims_2_7:
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 6, 0, 40, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 46, -18, 0, -18, 0,
+ax_anim 2, 1, 46, -18, 1, -18, 1,
+ax_anim 2, 0, 46, -18, 0, -18, 0,
+ax_anim 2, 0, 46, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sPoliwhirlAnims_2_8:
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 6, 0, 43, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 25, -18, 18, -18, 18,
+ax_anim 2, 1, 25, -19, 17, -19, 17,
+ax_anim 2, 0, 25, -18, 18, -18, 18,
+ax_anim 2, 0, 25, -19, 17, -19, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_3_1:
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 6, 0, 70, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 52, 0, 18, 0, 18,
+ax_anim 2, 1, 52, 1, 18, 1, 18,
+ax_anim 2, 0, 52, 0, 18, 0, 18,
+ax_anim 2, 0, 52, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sPoliwhirlAnims_3_2:
+ax_anim 2, 0, 49, -1, -1, -1, -1,
+ax_anim 6, 0, 49, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 55, 18, 18, 18, 18,
+ax_anim 2, 1, 55, 19, 17, 19, 17,
+ax_anim 2, 0, 55, 18, 18, 18, 18,
+ax_anim 2, 0, 55, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sPoliwhirlAnims_3_3:
+ax_anim 2, 0, 52, -1, 0, -1, 0,
+ax_anim 6, 0, 52, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 58, 18, 0, 18, 0,
+ax_anim 2, 1, 58, 18, 1, 18, 1,
+ax_anim 2, 0, 58, 18, 0, 18, 0,
+ax_anim 2, 0, 58, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sPoliwhirlAnims_3_4:
+ax_anim 2, 0, 55, -1, 1, -1, 1,
+ax_anim 6, 0, 55, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 61, 18, -23, 18, -23,
+ax_anim 2, 1, 61, 19, -22, 19, -22,
+ax_anim 2, 0, 61, 18, -23, 18, -23,
+ax_anim 2, 0, 61, 19, -22, 19, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sPoliwhirlAnims_3_5:
+ax_anim 2, 0, 58, 0, 1, 0, 1,
+ax_anim 6, 0, 58, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 64, 0, -21, 0, -21,
+ax_anim 2, 1, 64, 1, -21, 1, -21,
+ax_anim 2, 0, 64, 0, -21, 0, -21,
+ax_anim 2, 0, 64, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sPoliwhirlAnims_3_6:
+ax_anim 2, 0, 61, 1, 1, 1, 1,
+ax_anim 6, 0, 61, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 67, -18, -23, -18, -23,
+ax_anim 2, 1, 67, -19, -22, -19, -22,
+ax_anim 2, 0, 67, -18, -23, -18, -23,
+ax_anim 2, 0, 67, -19, -22, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sPoliwhirlAnims_3_7:
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 6, 0, 64, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 70, -18, 0, -18, 0,
+ax_anim 2, 1, 70, -18, 1, -18, 1,
+ax_anim 2, 0, 70, -18, 0, -18, 0,
+ax_anim 2, 0, 70, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sPoliwhirlAnims_3_8:
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 6, 0, 67, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 49, -18, 18, -18, 18,
+ax_anim 2, 1, 49, -19, 17, -19, 17,
+ax_anim 2, 0, 49, -18, 18, -18, 18,
+ax_anim 2, 0, 49, -19, 17, -19, 17,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_4_1:
+ax_anim 1, 0, 73, 0, -3, 0, -3,
+ax_anim 1, 0, 74, 0, -5, 0, -5,
+ax_anim 2, 0, 72, 0, -5, 0, -5,
+ax_anim 6, 2, 75, 0, -5, 0, -5,
+ax_anim 1, 0, 75, 0, -2, 0, -2,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 0, 5, 0, 5,
+ax_anim 2, 1, 76, 1, 5, 1, 5,
+ax_anim 2, 0, 76, 0, 5, 0, 5,
+ax_anim 2, 0, 76, 1, 5, 1, 5,
+ax_anim 2, 0, 76, 0, 5, 0, 5,
+ax_anim 2, 0, 76, 1, 5, 1, 5,
+ax_anim 2, 0, 76, 0, 5, 0, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sPoliwhirlAnims_4_2:
+ax_anim 1, 0, 78, -3, -3, -3, -3,
+ax_anim 1, 0, 79, -5, -5, -5, -5,
+ax_anim 2, 0, 77, -5, -5, -5, -5,
+ax_anim 6, 2, 80, -5, -5, -5, -5,
+ax_anim 1, 0, 80, -2, -2, -2, -2,
+ax_anim 2, 0, 81, 3, 3, 3, 3,
+ax_anim 2, 0, 81, 5, 5, 5, 5,
+ax_anim 2, 1, 81, 6, 4, 6, 4,
+ax_anim 2, 0, 81, 5, 5, 5, 5,
+ax_anim 2, 0, 81, 6, 4, 6, 4,
+ax_anim 2, 0, 81, 5, 5, 5, 5,
+ax_anim 2, 0, 81, 6, 4, 6, 4,
+ax_anim 2, 0, 81, 5, 5, 5, 5,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim_terminator
+sPoliwhirlAnims_4_3:
+ax_anim 1, 0, 83, -3, 0, -3, 0,
+ax_anim 1, 0, 84, -5, 0, -5, 0,
+ax_anim 2, 0, 82, -7, 0, -7, 0,
+ax_anim 6, 2, 85, -7, 0, -7, 0,
+ax_anim 1, 0, 85, -4, 0, -4, 0,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 2, 0, 86, 5, 0, 5, 0,
+ax_anim 2, 1, 86, 5, 1, 5, 1,
+ax_anim 2, 0, 86, 5, 0, 5, 0,
+ax_anim 2, 0, 86, 5, 1, 5, 1,
+ax_anim 2, 0, 86, 5, 0, 5, 0,
+ax_anim 2, 0, 86, 5, 1, 5, 1,
+ax_anim 2, 0, 86, 5, 0, 5, 0,
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim_terminator
+sPoliwhirlAnims_4_4:
+ax_anim 1, 0, 88, -3, 3, -3, 3,
+ax_anim 1, 0, 89, -4, 4, -4, 4,
+ax_anim 2, 0, 87, -6, 6, -6, 6,
+ax_anim 6, 2, 90, -6, 6, -6, 6,
+ax_anim 1, 0, 90, -3, 3, -3, 3,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 1, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 91, 6, -4, 6, -4,
+ax_anim 2, 0, 91, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim_terminator
+sPoliwhirlAnims_4_5:
+ax_anim 1, 0, 93, 0, 3, 0, 3,
+ax_anim 1, 0, 94, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 0, 7, 0, 7,
+ax_anim 6, 2, 95, 0, 6, 0, 6,
+ax_anim 1, 0, 95, 0, 2, 0, 2,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -5, 0, -5,
+ax_anim 2, 1, 96, -1, -5, -1, -5,
+ax_anim 2, 0, 96, 0, -5, 0, -5,
+ax_anim 2, 0, 96, -1, -5, -1, -5,
+ax_anim 2, 0, 96, 0, -5, 0, -5,
+ax_anim 2, 0, 96, -1, -5, -1, -5,
+ax_anim 2, 0, 96, 0, -5, 0, -5,
+ax_anim 2, 0, 92, 0, -2, 0, -2,
+ax_anim_terminator
+sPoliwhirlAnims_4_6:
+ax_anim 1, 0, 98, 3, 3, 3, 3,
+ax_anim 1, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 0, 97, 6, 6, 6, 6,
+ax_anim 6, 2, 100, 6, 6, 6, 6,
+ax_anim 1, 0, 100, 3, 3, 3, 3,
+ax_anim 2, 0, 101, -3, -3, -3, -3,
+ax_anim 2, 0, 101, -5, -5, -5, -5,
+ax_anim 2, 1, 101, -6, -4, -6, -4,
+ax_anim 2, 0, 101, -5, -5, -5, -5,
+ax_anim 2, 0, 101, -6, -4, -6, -4,
+ax_anim 2, 0, 101, -5, -5, -5, -5,
+ax_anim 2, 0, 101, -6, -4, -6, -4,
+ax_anim 2, 0, 101, -5, -5, -5, -5,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim_terminator
+sPoliwhirlAnims_4_7:
+ax_anim 1, 0, 103, 3, 0, 3, 0,
+ax_anim 1, 0, 104, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 7, 0, 7, 0,
+ax_anim 6, 2, 105, 7, 0, 7, 0,
+ax_anim 1, 0, 105, 4, 0, 4, 0,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -5, 0, -5, 0,
+ax_anim 2, 1, 106, -5, 1, -5, 1,
+ax_anim 2, 0, 106, -5, 0, -5, 0,
+ax_anim 2, 0, 106, -5, 1, -5, 1,
+ax_anim 2, 0, 106, -5, 0, -5, 0,
+ax_anim 2, 0, 106, -5, 1, -5, 1,
+ax_anim 2, 0, 106, -5, 0, -5, 0,
+ax_anim 2, 0, 102, -2, 0, -2, 0,
+ax_anim_terminator
+sPoliwhirlAnims_4_8:
+ax_anim 1, 0, 108, 3, -3, 3, -3,
+ax_anim 1, 0, 109, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 6, 2, 110, 5, -5, 5, -5,
+ax_anim 1, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 1, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -6, 4, -6, 4,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 107, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_5_1:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 2, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 1, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_5_2:
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 2, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 1, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_5_3:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 2, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 1, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_5_4:
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 2, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 1, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_5_5:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 2, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 1, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_5_6:
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 2, 129, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 1, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_5_7:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 2, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 1, 131, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_5_8:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 2, 135, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 1, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sPoliwhirlAnims_7_2:
+ax_anim 2, 0, 139, -1, -1, -2, -2,
+ax_anim 8, 0, 139, -2, -2, -3, -3,
+ax_anim_terminator
+sPoliwhirlAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sPoliwhirlAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sPoliwhirlAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sPoliwhirlAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sPoliwhirlAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sPoliwhirlAnims_7_8:
+ax_anim 2, 0, 145, 1, -1, 2, -2,
+ax_anim 8, 0, 145, 2, -2, 3, -3,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 150, 0, -4, 0, 0,
+ax_anim 4, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 153, 0, -4, 0, 0,
+ax_anim 4, 0, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 156, 0, -4, 0, 0,
+ax_anim 4, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 159, 0, -4, 0, 0,
+ax_anim 4, 0, 160, 0, -4, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 162, 0, -4, 0, 0,
+ax_anim 4, 0, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -2, 0, 0,
+ax_anim 4, 0, 165, 0, -4, 0, 0,
+ax_anim 4, 0, 166, 0, -4, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 4, 0, 168, 0, -4, 0, 0,
+ax_anim 4, 0, 169, 0, -4, 0, 0,
+ax_anim 2, 0, 167, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 3, 19, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 20, 20, 20, 20,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 21, -2, 21, -2,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 20, -21, 20, -21,
+ax_anim 2, 3, 172, 22, -15, 22, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -20, -21, -20, -21,
+ax_anim 2, 3, 176, -22, -15, -22, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -21, -2, -21, -2,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 3, -19, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -20, 20, -20, 20,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -22, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwhirlAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwhirlGfx1:
+.incbin "baserom.gba", 0x7A54F8, 0x200
+sPoliwhirlSprites1:
+ax_sprite sPoliwhirlGfx1, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx2:
+.incbin "baserom.gba", 0x7A5708, 0x200
+sPoliwhirlSprites2:
+ax_sprite sPoliwhirlGfx2, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx3:
+.incbin "baserom.gba", 0x7A5918, 0x200
+sPoliwhirlSprites3:
+ax_sprite sPoliwhirlGfx3, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx4:
+.incbin "baserom.gba", 0x7A5B28, 0x200
+sPoliwhirlSprites4:
+ax_sprite sPoliwhirlGfx4, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx5:
+.incbin "baserom.gba", 0x7A5D38, 0x200
+sPoliwhirlSprites5:
+ax_sprite sPoliwhirlGfx5, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx6:
+.incbin "baserom.gba", 0x7A5F48, 0x200
+sPoliwhirlSprites6:
+ax_sprite sPoliwhirlGfx6, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx7:
+.incbin "baserom.gba", 0x7A6158, 0x200
+sPoliwhirlSprites7:
+ax_sprite sPoliwhirlGfx7, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx8:
+.incbin "baserom.gba", 0x7A6368, 0x200
+sPoliwhirlSprites8:
+ax_sprite sPoliwhirlGfx8, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx9:
+.incbin "baserom.gba", 0x7A6578, 0x200
+sPoliwhirlSprites9:
+ax_sprite sPoliwhirlGfx9, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx10:
+.incbin "baserom.gba", 0x7A6788, 0x200
+sPoliwhirlSprites10:
+ax_sprite sPoliwhirlGfx10, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx11:
+.incbin "baserom.gba", 0x7A6998, 0x200
+sPoliwhirlSprites11:
+ax_sprite sPoliwhirlGfx11, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx12:
+.incbin "baserom.gba", 0x7A6BA8, 0x200
+sPoliwhirlSprites12:
+ax_sprite sPoliwhirlGfx12, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx13:
+.incbin "baserom.gba", 0x7A6DB8, 0x200
+sPoliwhirlSprites13:
+ax_sprite sPoliwhirlGfx13, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx14:
+.incbin "baserom.gba", 0x7A6FC8, 0x200
+sPoliwhirlSprites14:
+ax_sprite sPoliwhirlGfx14, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx15:
+.incbin "baserom.gba", 0x7A71D8, 0x200
+sPoliwhirlSprites15:
+ax_sprite sPoliwhirlGfx15, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx16:
+.incbin "baserom.gba", 0x7A73E8, 0x200
+sPoliwhirlSprites16:
+ax_sprite sPoliwhirlGfx16, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx17:
+.incbin "baserom.gba", 0x7A75F8, 0x200
+sPoliwhirlSprites17:
+ax_sprite sPoliwhirlGfx17, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx18:
+.incbin "baserom.gba", 0x7A7808, 0x200
+sPoliwhirlSprites18:
+ax_sprite sPoliwhirlGfx18, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx19:
+.incbin "baserom.gba", 0x7A7A18, 0x100
+sPoliwhirlSprites19:
+ax_sprite sPoliwhirlGfx19, 0x100
+ax_sprite_terminator
+sPoliwhirlGfx20:
+.incbin "baserom.gba", 0x7A7B28, 0x80
+sPoliwhirlSprites20:
+ax_sprite sPoliwhirlGfx20, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx21:
+.incbin "baserom.gba", 0x7A7BB8, 0x20
+sPoliwhirlSprites21:
+ax_sprite sPoliwhirlGfx21, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx22:
+.incbin "baserom.gba", 0x7A7BE8, 0x40
+sPoliwhirlSprites22:
+ax_sprite sPoliwhirlGfx22, 0x40
+ax_sprite_terminator
+sPoliwhirlGfx23:
+.incbin "baserom.gba", 0x7A7C38, 0x20
+sPoliwhirlSprites23:
+ax_sprite sPoliwhirlGfx23, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx24:
+.incbin "baserom.gba", 0x7A7C68, 0x60
+sPoliwhirlSprites24:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx24, 0x60
+ax_sprite_terminator
+sPoliwhirlGfx25:
+.incbin "baserom.gba", 0x7A7CE0, 0x100
+sPoliwhirlSprites25:
+ax_sprite sPoliwhirlGfx25, 0x100
+ax_sprite_terminator
+sPoliwhirlGfx26:
+.incbin "baserom.gba", 0x7A7DF0, 0x20
+sPoliwhirlSprites26:
+ax_sprite sPoliwhirlGfx26, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx27:
+.incbin "baserom.gba", 0x7A7E20, 0x100
+sPoliwhirlSprites27:
+ax_sprite sPoliwhirlGfx27, 0x100
+ax_sprite_terminator
+sPoliwhirlGfx28:
+.incbin "baserom.gba", 0x7A7F30, 0x80
+sPoliwhirlSprites28:
+ax_sprite sPoliwhirlGfx28, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx29:
+.incbin "baserom.gba", 0x7A7FC0, 0x40
+sPoliwhirlSprites29:
+ax_sprite sPoliwhirlGfx29, 0x40
+ax_sprite_terminator
+sPoliwhirlGfx30:
+.incbin "baserom.gba", 0x7A8010, 0x20
+sPoliwhirlSprites30:
+ax_sprite sPoliwhirlGfx30, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx31:
+.incbin "baserom.gba", 0x7A8040, 0x20
+sPoliwhirlSprites31:
+ax_sprite sPoliwhirlGfx31, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx32:
+.incbin "baserom.gba", 0x7A8070, 0x40
+sPoliwhirlGfx32_1:
+.incbin "baserom.gba", 0x7A80B0, 0xE0
+sPoliwhirlGfx32_2:
+.incbin "baserom.gba", 0x7A8190, 0x60
+sPoliwhirlSprites32:
+ax_sprite sPoliwhirlGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwhirlGfx32_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx33:
+.incbin "baserom.gba", 0x7A8228, 0x60
+sPoliwhirlGfx33_1:
+.incbin "baserom.gba", 0x7A8288, 0x80
+sPoliwhirlSprites33:
+ax_sprite sPoliwhirlGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx33_1, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx34:
+.incbin "baserom.gba", 0x7A8328, 0x80
+sPoliwhirlSprites34:
+ax_sprite sPoliwhirlGfx34, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx35:
+.incbin "baserom.gba", 0x7A83B8, 0x20
+sPoliwhirlSprites35:
+ax_sprite sPoliwhirlGfx35, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx36:
+.incbin "baserom.gba", 0x7A83F0, 0x20
+sPoliwhirlSprites36:
+ax_sprite sPoliwhirlGfx36, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx37:
+.incbin "baserom.gba", 0x7A8420, 0x20
+sPoliwhirlSprites37:
+ax_sprite sPoliwhirlGfx37, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx38:
+.incbin "baserom.gba", 0x7A8450, 0x60
+sPoliwhirlGfx38_1:
+.incbin "baserom.gba", 0x7A84B0, 0x60
+sPoliwhirlGfx38_2:
+.incbin "baserom.gba", 0x7A8510, 0x60
+sPoliwhirlGfx38_3:
+.incbin "baserom.gba", 0x7A8570, 0x40
+sPoliwhirlSprites38:
+ax_sprite sPoliwhirlGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx38_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoliwhirlGfx39:
+.incbin "baserom.gba", 0x7A85F8, 0x100
+sPoliwhirlSprites39:
+ax_sprite sPoliwhirlGfx39, 0x100
+ax_sprite_terminator
+sPoliwhirlGfx40:
+.incbin "baserom.gba", 0x7A8708, 0x80
+sPoliwhirlSprites40:
+ax_sprite sPoliwhirlGfx40, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx41:
+.incbin "baserom.gba", 0x7A8798, 0x40
+sPoliwhirlSprites41:
+ax_sprite sPoliwhirlGfx41, 0x40
+ax_sprite_terminator
+sPoliwhirlGfx42:
+.incbin "baserom.gba", 0x7A87E8, 0x20
+sPoliwhirlSprites42:
+ax_sprite sPoliwhirlGfx42, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx43:
+.incbin "baserom.gba", 0x7A8818, 0x20
+sPoliwhirlSprites43:
+ax_sprite sPoliwhirlGfx43, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx44:
+.incbin "baserom.gba", 0x7A8848, 0x160
+sPoliwhirlGfx44_1:
+.incbin "baserom.gba", 0x7A89A8, 0x40
+sPoliwhirlSprites44:
+ax_sprite sPoliwhirlGfx44, 0x160
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx44_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoliwhirlGfx45:
+.incbin "baserom.gba", 0x7A8A10, 0x100
+sPoliwhirlSprites45:
+ax_sprite sPoliwhirlGfx45, 0x100
+ax_sprite_terminator
+sPoliwhirlGfx46:
+.incbin "baserom.gba", 0x7A8B20, 0x80
+sPoliwhirlSprites46:
+ax_sprite sPoliwhirlGfx46, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx47:
+.incbin "baserom.gba", 0x7A8BB0, 0x20
+sPoliwhirlSprites47:
+ax_sprite sPoliwhirlGfx47, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx48:
+.incbin "baserom.gba", 0x7A8BE0, 0x20
+sPoliwhirlSprites48:
+ax_sprite sPoliwhirlGfx48, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx49:
+.incbin "baserom.gba", 0x7A8C10, 0x20
+sPoliwhirlSprites49:
+ax_sprite sPoliwhirlGfx49, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx50:
+.incbin "baserom.gba", 0x7A8C40, 0x100
+sPoliwhirlSprites50:
+ax_sprite sPoliwhirlGfx50, 0x100
+ax_sprite_terminator
+sPoliwhirlGfx51:
+.incbin "baserom.gba", 0x7A8D50, 0x80
+sPoliwhirlSprites51:
+ax_sprite sPoliwhirlGfx51, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx52:
+.incbin "baserom.gba", 0x7A8DE0, 0x20
+sPoliwhirlSprites52:
+ax_sprite sPoliwhirlGfx52, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx53:
+.incbin "baserom.gba", 0x7A8E10, 0xE0
+sPoliwhirlSprites53:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx53, 0xe0
+ax_sprite_terminator
+sPoliwhirlGfx54:
+.incbin "baserom.gba", 0x7A8F08, 0x80
+sPoliwhirlSprites54:
+ax_sprite sPoliwhirlGfx54, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx55:
+.incbin "baserom.gba", 0x7A8F98, 0x20
+sPoliwhirlSprites55:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx55, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx56:
+.incbin "baserom.gba", 0x7A8FD0, 0x20
+sPoliwhirlSprites56:
+ax_sprite sPoliwhirlGfx56, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx57:
+.incbin "baserom.gba", 0x7A9000, 0x20
+sPoliwhirlSprites57:
+ax_sprite sPoliwhirlGfx57, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx58:
+.incbin "baserom.gba", 0x7A9030, 0x100
+sPoliwhirlSprites58:
+ax_sprite sPoliwhirlGfx58, 0x100
+ax_sprite_terminator
+sPoliwhirlGfx59:
+.incbin "baserom.gba", 0x7A9140, 0x80
+sPoliwhirlSprites59:
+ax_sprite sPoliwhirlGfx59, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx60:
+.incbin "baserom.gba", 0x7A91D0, 0x40
+sPoliwhirlSprites60:
+ax_sprite sPoliwhirlGfx60, 0x40
+ax_sprite_terminator
+sPoliwhirlGfx61:
+.incbin "baserom.gba", 0x7A9220, 0x20
+sPoliwhirlSprites61:
+ax_sprite sPoliwhirlGfx61, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx62:
+.incbin "baserom.gba", 0x7A9250, 0x20
+sPoliwhirlSprites62:
+ax_sprite sPoliwhirlGfx62, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx63:
+.incbin "baserom.gba", 0x7A9280, 0x160
+sPoliwhirlSprites63:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx63, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx64:
+.incbin "baserom.gba", 0x7A9400, 0x60
+sPoliwhirlGfx64_1:
+.incbin "baserom.gba", 0x7A9460, 0x100
+sPoliwhirlSprites64:
+ax_sprite sPoliwhirlGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx64_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx65:
+.incbin "baserom.gba", 0x7A9588, 0x180
+sPoliwhirlGfx65_1:
+.incbin "baserom.gba", 0x7A9708, 0x60
+sPoliwhirlSprites65:
+ax_sprite sPoliwhirlGfx65, 0x180
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx65_1, 0x60
+ax_sprite_terminator
+sPoliwhirlGfx66:
+.incbin "baserom.gba", 0x7A9788, 0x40
+sPoliwhirlGfx66_1:
+.incbin "baserom.gba", 0x7A97C8, 0x60
+sPoliwhirlGfx66_2:
+.incbin "baserom.gba", 0x7A9828, 0x60
+sPoliwhirlGfx66_3:
+.incbin "baserom.gba", 0x7A9888, 0x60
+sPoliwhirlSprites66:
+ax_sprite sPoliwhirlGfx66, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwhirlGfx66_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx66_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx66_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx67:
+.incbin "baserom.gba", 0x7A9930, 0x20
+sPoliwhirlGfx67_1:
+.incbin "baserom.gba", 0x7A9950, 0x60
+sPoliwhirlGfx67_2:
+.incbin "baserom.gba", 0x7A99B0, 0x60
+sPoliwhirlGfx67_3:
+.incbin "baserom.gba", 0x7A9A10, 0x60
+sPoliwhirlSprites67:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx67, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPoliwhirlGfx67_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx67_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx67_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx68:
+.incbin "baserom.gba", 0x7A9AC0, 0x40
+sPoliwhirlGfx68_1:
+.incbin "baserom.gba", 0x7A9B00, 0x60
+sPoliwhirlGfx68_2:
+.incbin "baserom.gba", 0x7A9B60, 0x60
+sPoliwhirlGfx68_3:
+.incbin "baserom.gba", 0x7A9BC0, 0x40
+sPoliwhirlSprites68:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx68, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx68_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx68_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoliwhirlGfx68_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx69:
+.incbin "baserom.gba", 0x7A9C50, 0x60
+sPoliwhirlGfx69_1:
+.incbin "baserom.gba", 0x7A9CB0, 0x60
+sPoliwhirlGfx69_2:
+.incbin "baserom.gba", 0x7A9D10, 0x60
+sPoliwhirlGfx69_3:
+.incbin "baserom.gba", 0x7A9D70, 0x60
+sPoliwhirlSprites69:
+ax_sprite sPoliwhirlGfx69, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx69_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx69_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx69_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx70:
+.incbin "baserom.gba", 0x7A9E18, 0x140
+sPoliwhirlGfx70_1:
+.incbin "baserom.gba", 0x7A9F58, 0x60
+sPoliwhirlSprites70:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx70, 0x140
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx70_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx71:
+.incbin "baserom.gba", 0x7A9FE8, 0x60
+sPoliwhirlGfx71_1:
+.incbin "baserom.gba", 0x7AA048, 0x100
+sPoliwhirlSprites71:
+ax_sprite sPoliwhirlGfx71, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx71_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx72:
+.incbin "baserom.gba", 0x7AA170, 0x160
+sPoliwhirlSprites72:
+ax_sprite 0, 0x20
+ax_sprite sPoliwhirlGfx72, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPoliwhirlGfx73:
+.incbin "baserom.gba", 0x7AA2F0, 0x1E0
+sPoliwhirlSprites73:
+ax_sprite sPoliwhirlGfx73, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwhirlGfx74:
+.incbin "baserom.gba", 0x7AA4E8, 0x200
+sPoliwhirlSprites74:
+ax_sprite sPoliwhirlGfx74, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx75:
+.incbin "baserom.gba", 0x7AA6F8, 0x200
+sPoliwhirlSprites75:
+ax_sprite sPoliwhirlGfx75, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx76:
+.incbin "baserom.gba", 0x7AA908, 0x200
+sPoliwhirlSprites76:
+ax_sprite sPoliwhirlGfx76, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx77:
+.incbin "baserom.gba", 0x7AAB18, 0x200
+sPoliwhirlSprites77:
+ax_sprite sPoliwhirlGfx77, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx78:
+.incbin "baserom.gba", 0x7AAD28, 0x200
+sPoliwhirlSprites78:
+ax_sprite sPoliwhirlGfx78, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx79:
+.incbin "baserom.gba", 0x7AAF38, 0x200
+sPoliwhirlSprites79:
+ax_sprite sPoliwhirlGfx79, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx80:
+.incbin "baserom.gba", 0x7AB148, 0x200
+sPoliwhirlSprites80:
+ax_sprite sPoliwhirlGfx80, 0x200
+ax_sprite_terminator
+sPoliwhirlGfx81:
+.incbin "baserom.gba", 0x7AB358, 0x200
+sPoliwhirlSprites81:
+ax_sprite sPoliwhirlGfx81, 0x200
+ax_sprite_terminator
+sAxPosesPoliwhirl:
+.4byte sPoliwhirlPose1
+.4byte sPoliwhirlPose2
+.4byte sPoliwhirlPose3
+.4byte sPoliwhirlPose4
+.4byte sPoliwhirlPose5
+.4byte sPoliwhirlPose6
+.4byte sPoliwhirlPose7
+.4byte sPoliwhirlPose8
+.4byte sPoliwhirlPose9
+.4byte sPoliwhirlPose10
+.4byte sPoliwhirlPose11
+.4byte sPoliwhirlPose12
+.4byte sPoliwhirlPose13
+.4byte sPoliwhirlPose14
+.4byte sPoliwhirlPose15
+.4byte sPoliwhirlPose16
+.4byte sPoliwhirlPose17
+.4byte sPoliwhirlPose18
+.4byte sPoliwhirlPose19
+.4byte sPoliwhirlPose20
+.4byte sPoliwhirlPose21
+.4byte sPoliwhirlPose22
+.4byte sPoliwhirlPose23
+.4byte sPoliwhirlPose24
+.4byte sPoliwhirlPose25
+.4byte sPoliwhirlPose26
+.4byte sPoliwhirlPose27
+.4byte sPoliwhirlPose28
+.4byte sPoliwhirlPose29
+.4byte sPoliwhirlPose30
+.4byte sPoliwhirlPose31
+.4byte sPoliwhirlPose32
+.4byte sPoliwhirlPose33
+.4byte sPoliwhirlPose34
+.4byte sPoliwhirlPose35
+.4byte sPoliwhirlPose36
+.4byte sPoliwhirlPose37
+.4byte sPoliwhirlPose38
+.4byte sPoliwhirlPose39
+.4byte sPoliwhirlPose40
+.4byte sPoliwhirlPose41
+.4byte sPoliwhirlPose42
+.4byte sPoliwhirlPose43
+.4byte sPoliwhirlPose44
+.4byte sPoliwhirlPose45
+.4byte sPoliwhirlPose46
+.4byte sPoliwhirlPose47
+.4byte sPoliwhirlPose48
+.4byte sPoliwhirlPose49
+.4byte sPoliwhirlPose50
+.4byte sPoliwhirlPose51
+.4byte sPoliwhirlPose52
+.4byte sPoliwhirlPose53
+.4byte sPoliwhirlPose54
+.4byte sPoliwhirlPose55
+.4byte sPoliwhirlPose56
+.4byte sPoliwhirlPose57
+.4byte sPoliwhirlPose58
+.4byte sPoliwhirlPose59
+.4byte sPoliwhirlPose60
+.4byte sPoliwhirlPose61
+.4byte sPoliwhirlPose62
+.4byte sPoliwhirlPose63
+.4byte sPoliwhirlPose64
+.4byte sPoliwhirlPose65
+.4byte sPoliwhirlPose66
+.4byte sPoliwhirlPose67
+.4byte sPoliwhirlPose68
+.4byte sPoliwhirlPose69
+.4byte sPoliwhirlPose70
+.4byte sPoliwhirlPose71
+.4byte sPoliwhirlPose72
+.4byte sPoliwhirlPose73
+.4byte sPoliwhirlPose74
+.4byte sPoliwhirlPose75
+.4byte sPoliwhirlPose76
+.4byte sPoliwhirlPose77
+.4byte sPoliwhirlPose78
+.4byte sPoliwhirlPose79
+.4byte sPoliwhirlPose80
+.4byte sPoliwhirlPose81
+.4byte sPoliwhirlPose82
+.4byte sPoliwhirlPose83
+.4byte sPoliwhirlPose84
+.4byte sPoliwhirlPose85
+.4byte sPoliwhirlPose86
+.4byte sPoliwhirlPose87
+.4byte sPoliwhirlPose88
+.4byte sPoliwhirlPose89
+.4byte sPoliwhirlPose90
+.4byte sPoliwhirlPose91
+.4byte sPoliwhirlPose92
+.4byte sPoliwhirlPose93
+.4byte sPoliwhirlPose94
+.4byte sPoliwhirlPose95
+.4byte sPoliwhirlPose96
+.4byte sPoliwhirlPose97
+.4byte sPoliwhirlPose98
+.4byte sPoliwhirlPose99
+.4byte sPoliwhirlPose100
+.4byte sPoliwhirlPose101
+.4byte sPoliwhirlPose102
+.4byte sPoliwhirlPose103
+.4byte sPoliwhirlPose104
+.4byte sPoliwhirlPose105
+.4byte sPoliwhirlPose106
+.4byte sPoliwhirlPose107
+.4byte sPoliwhirlPose108
+.4byte sPoliwhirlPose109
+.4byte sPoliwhirlPose110
+.4byte sPoliwhirlPose111
+.4byte sPoliwhirlPose112
+.4byte sPoliwhirlPose113
+.4byte sPoliwhirlPose114
+.4byte sPoliwhirlPose115
+.4byte sPoliwhirlPose116
+.4byte sPoliwhirlPose117
+.4byte sPoliwhirlPose118
+.4byte sPoliwhirlPose119
+.4byte sPoliwhirlPose120
+.4byte sPoliwhirlPose121
+.4byte sPoliwhirlPose122
+.4byte sPoliwhirlPose123
+.4byte sPoliwhirlPose124
+.4byte sPoliwhirlPose125
+.4byte sPoliwhirlPose126
+.4byte sPoliwhirlPose127
+.4byte sPoliwhirlPose128
+.4byte sPoliwhirlPose129
+.4byte sPoliwhirlPose130
+.4byte sPoliwhirlPose131
+.4byte sPoliwhirlPose132
+.4byte sPoliwhirlPose133
+.4byte sPoliwhirlPose134
+.4byte sPoliwhirlPose135
+.4byte sPoliwhirlPose136
+.4byte sPoliwhirlPose137
+.4byte sPoliwhirlPose138
+.4byte sPoliwhirlPose139
+.4byte sPoliwhirlPose140
+.4byte sPoliwhirlPose141
+.4byte sPoliwhirlPose142
+.4byte sPoliwhirlPose143
+.4byte sPoliwhirlPose144
+.4byte sPoliwhirlPose145
+.4byte sPoliwhirlPose146
+.4byte sPoliwhirlPose147
+.4byte sPoliwhirlPose148
+.4byte sPoliwhirlPose149
+.4byte sPoliwhirlPose150
+.4byte sPoliwhirlPose151
+.4byte sPoliwhirlPose152
+.4byte sPoliwhirlPose153
+.4byte sPoliwhirlPose154
+.4byte sPoliwhirlPose155
+.4byte sPoliwhirlPose156
+.4byte sPoliwhirlPose157
+.4byte sPoliwhirlPose158
+.4byte sPoliwhirlPose159
+.4byte sPoliwhirlPose160
+.4byte sPoliwhirlPose161
+.4byte sPoliwhirlPose162
+.4byte sPoliwhirlPose163
+.4byte sPoliwhirlPose164
+.4byte sPoliwhirlPose165
+.4byte sPoliwhirlPose166
+.4byte sPoliwhirlPose167
+.4byte sPoliwhirlPose168
+.4byte sPoliwhirlPose169
+.4byte sPoliwhirlPose170
+.4byte sPoliwhirlPose171
+.4byte sPoliwhirlPose172
+.4byte sPoliwhirlPose173
+.4byte sPoliwhirlPose174
+.4byte sPoliwhirlPose175
+.4byte sPoliwhirlPose176
+.4byte sPoliwhirlPose177
+.4byte sPoliwhirlPose178
+.4byte sPoliwhirlPose179
+.4byte sPoliwhirlPose180
+.4byte sPoliwhirlPose181
+.4byte sPoliwhirlPose182
+.4byte sPoliwhirlPose183
+.4byte sPoliwhirlPose184
+.4byte sPoliwhirlPose185
+.4byte sPoliwhirlPose186
+.4byte sPoliwhirlPose187
+.4byte sPoliwhirlPose188
+.4byte sPoliwhirlPose189
+.4byte sPoliwhirlPose190
+.4byte sPoliwhirlPose191
+.4byte sPoliwhirlPose192
+.4byte sPoliwhirlPose193
+.4byte sPoliwhirlPose194
+.4byte sPoliwhirlPose195
+.4byte sPoliwhirlPose196
+.4byte sPoliwhirlPose197
+.4byte sPoliwhirlPose198
+.4byte sPoliwhirlPose199
+.4byte sPoliwhirlPose200
+.4byte sPoliwhirlPose201
+.4byte sPoliwhirlPose202
+.4byte sPoliwhirlPose203
+.4byte sPoliwhirlPose204
+.4byte sPoliwhirlPose205
+.4byte sPoliwhirlPose206
+.4byte sPoliwhirlPose207
+.4byte sPoliwhirlPose208
+.4byte sPoliwhirlPose209
+.4byte sPoliwhirlPose210
+.4byte sPoliwhirlPose211
+.4byte sPoliwhirlPose212
+.4byte sPoliwhirlPose213
+.4byte sPoliwhirlPose214
+.4byte sPoliwhirlPose215
+.4byte sPoliwhirlPose216
+.4byte sPoliwhirlPose217
+.4byte sPoliwhirlPose218
+.4byte sPoliwhirlPose219
+.4byte sPoliwhirlPose220
+.4byte sPoliwhirlPose221
+.4byte sPoliwhirlPose222
+.4byte sPoliwhirlPose223
+.4byte sPoliwhirlPose224
+.4byte sPoliwhirlPose225
+.4byte sPoliwhirlPose226
+sAxPositionsPoliwhirl:
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  10,   -8, 	   1,   -6
+.2byte   -1,  -10, 	 -10,   -8, 	  10,   -3, 	   0,   -6
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    3,  -11, 	 -11,   -5, 	  13,   -9, 	   1,   -9
+.2byte    1,  -10, 	  -4,   -1, 	   4,  -11, 	   1,   -9
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    5,  -12, 	   9,   -7, 	  -4,   -2, 	  -1,   -8
+.2byte    5,  -12, 	  -3,   -6, 	   5,   -2, 	   0,   -8
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    4,  -15, 	  -2,  -12, 	   4,   -2, 	   0,   -9
+.2byte    3,  -15, 	 -11,  -10, 	  12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  11,  -12, 	  -9,   -6, 	   0,  -10
+.2byte    2,  -14, 	   9,   -6, 	 -10,  -12, 	   1,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte   -4,  -15, 	   2,  -12, 	  -4,   -2, 	   0,   -9
+.2byte   -3,  -15, 	  11,  -10, 	 -12,   -7, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -5,  -12, 	  -9,   -7, 	   4,   -2, 	   1,   -8
+.2byte   -5,  -12, 	   3,   -6, 	  -5,   -2, 	   0,   -8
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -3,  -11, 	 -13,   -9, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -1, 	   0,   -8
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  10,   -8, 	   1,   -6
+.2byte   -1,  -10, 	 -10,   -8, 	  10,   -3, 	   0,   -6
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    3,  -11, 	 -11,   -5, 	  13,   -9, 	   1,   -9
+.2byte    1,  -10, 	  -4,   -1, 	   4,  -11, 	   1,   -9
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    5,  -12, 	   9,   -7, 	  -4,   -2, 	  -1,   -8
+.2byte    5,  -12, 	  -3,   -6, 	   5,   -2, 	   0,   -8
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    4,  -15, 	  -2,  -12, 	   4,   -2, 	   0,   -9
+.2byte    3,  -15, 	 -11,  -10, 	  12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  11,  -12, 	  -9,   -6, 	   0,  -10
+.2byte    2,  -14, 	   9,   -6, 	 -10,  -12, 	   1,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte   -4,  -15, 	   2,  -12, 	  -4,   -2, 	   0,   -9
+.2byte   -3,  -15, 	  11,  -10, 	 -12,   -7, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -5,  -12, 	  -9,   -7, 	   4,   -2, 	   1,   -8
+.2byte   -5,  -12, 	   3,   -6, 	  -5,   -2, 	   0,   -8
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -3,  -11, 	 -13,   -9, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -1, 	   0,   -8
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  10,   -8, 	   1,   -6
+.2byte   -1,  -10, 	 -10,   -8, 	  10,   -3, 	   0,   -6
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    3,  -11, 	 -11,   -5, 	  13,   -9, 	   1,   -9
+.2byte    1,  -10, 	  -4,   -1, 	   4,  -11, 	   1,   -9
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    5,  -12, 	   9,   -7, 	  -4,   -2, 	  -1,   -8
+.2byte    5,  -12, 	  -3,   -6, 	   5,   -2, 	   0,   -8
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    4,  -15, 	  -2,  -12, 	   4,   -2, 	   0,   -9
+.2byte    3,  -15, 	 -11,  -10, 	  12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  11,  -12, 	  -9,   -6, 	   0,  -10
+.2byte    2,  -14, 	   9,   -6, 	 -10,  -12, 	   1,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte   -4,  -15, 	   2,  -12, 	  -4,   -2, 	   0,   -9
+.2byte   -3,  -15, 	  11,  -10, 	 -12,   -7, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -5,  -12, 	  -9,   -7, 	   4,   -2, 	   1,   -8
+.2byte   -5,  -12, 	   3,   -6, 	  -5,   -2, 	   0,   -8
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -3,  -11, 	 -13,   -9, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -1, 	   0,   -8
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  10,   -8, 	   1,   -6
+.2byte   -1,  -10, 	 -10,   -8, 	  10,   -3, 	   0,   -6
+.2byte    0,  -19, 	 -13,  -26, 	  13,  -26, 	   0,  -12
+.2byte    0,   -6, 	 -15,   -6, 	  15,   -6, 	   0,   -8
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    3,  -11, 	 -11,   -5, 	  13,   -9, 	   1,   -9
+.2byte    1,  -10, 	  -4,   -1, 	   4,  -11, 	   1,   -9
+.2byte   -1,  -19, 	   2,  -32, 	 -15,  -25, 	  -1,  -13
+.2byte    6,  -10, 	   5,  -23, 	 -12,  -14, 	   3,  -12
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    5,  -12, 	   9,   -7, 	  -4,   -2, 	  -1,   -8
+.2byte    5,  -12, 	  -3,   -6, 	   5,   -2, 	   0,   -8
+.2byte   -1,  -19, 	  -9,  -28, 	 -11,  -13, 	  -3,  -11
+.2byte    9,  -12, 	  -4,  -20, 	  -5,   -6, 	   3,   -9
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    4,  -15, 	  -2,  -12, 	   4,   -2, 	   0,   -9
+.2byte    3,  -15, 	 -11,  -10, 	  12,   -7, 	   0,   -9
+.2byte   -2,  -21, 	 -14,  -31, 	   6,  -20, 	  -3,  -11
+.2byte    8,  -17, 	 -12,  -15, 	   2,   -5, 	   2,  -12
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  11,  -12, 	  -9,   -6, 	   0,  -10
+.2byte    2,  -14, 	   9,   -6, 	 -10,  -12, 	   1,   -9
+.2byte    0,  -18, 	  13,  -22, 	 -13,  -22, 	   0,  -10
+.2byte    0,  -18, 	  14,   -5, 	 -14,   -5, 	   0,  -12
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte   -4,  -15, 	   2,  -12, 	  -4,   -2, 	   0,   -9
+.2byte   -3,  -15, 	  11,  -10, 	 -12,   -7, 	   0,   -9
+.2byte    2,  -21, 	  14,  -31, 	  -6,  -20, 	   3,  -11
+.2byte   -8,  -17, 	  12,  -15, 	  -2,   -5, 	  -2,  -12
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -5,  -12, 	  -9,   -7, 	   4,   -2, 	   1,   -8
+.2byte   -5,  -12, 	   3,   -6, 	  -5,   -2, 	   0,   -8
+.2byte    1,  -19, 	  10,  -29, 	  12,  -13, 	   3,  -11
+.2byte   -9,  -12, 	   4,  -20, 	   5,   -6, 	  -3,   -9
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -3,  -11, 	 -13,   -9, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -1, 	   0,   -8
+.2byte    1,  -19, 	  -2,  -32, 	  16,  -25, 	   2,  -13
+.2byte   -6,  -10, 	  -5,  -23, 	  12,  -14, 	  -3,  -12
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte    1,  -11, 	  -4,   -6, 	  13,  -18, 	   1,   -9
+.2byte   -1,  -11, 	 -12,  -18, 	   4,   -6, 	   0,   -9
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    1,  -10, 	   8,   -8, 	 -10,  -17, 	   0,   -9
+.2byte    3,  -12, 	   7,  -24, 	   0,   -7, 	   2,  -10
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    5,  -12, 	   8,  -11, 	  -4,  -13, 	   0,   -7
+.2byte    5,  -15, 	  -1,  -24, 	   6,   -7, 	  -1,   -9
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    5,  -13, 	   2,  -12, 	  11,  -17, 	   1,   -9
+.2byte    2,  -16, 	  -7,  -25, 	  10,  -10, 	  -1,  -11
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -1,  -15, 	   3,  -11, 	 -11,  -20, 	  -1,  -10
+.2byte    2,  -15, 	  11,  -20, 	  -2,  -11, 	   2,  -10
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte   -5,  -13, 	  -2,  -12, 	 -11,  -17, 	  -1,   -9
+.2byte   -2,  -16, 	   7,  -25, 	 -10,  -10, 	   1,  -11
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -5,  -12, 	  -8,  -11, 	   4,  -13, 	   0,   -7
+.2byte   -5,  -15, 	   1,  -24, 	  -6,   -7, 	   1,   -9
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -1,  -10, 	  -8,   -8, 	  11,  -16, 	   2,   -9
+.2byte   -3,  -12, 	  -7,  -24, 	   0,   -7, 	  -2,  -10
+.2byte   -1,   -9, 	  -8,   -8, 	  10,    1, 	   1,   -8
+.2byte   -1,   -8, 	  -8,   -7, 	   9,    1, 	   1,   -7
+.2byte    0,  -10, 	 -10,   -5, 	  13,   -7, 	   0,   -7
+.2byte    4,   -8, 	 -11,   -5, 	  10,   -4, 	   0,   -8
+.2byte    4,   -9, 	   8,   -8, 	  -5,    0, 	  -2,   -8
+.2byte    3,  -11, 	  -4,   -9, 	   4,   -1, 	  -2,   -6
+.2byte    0,  -11, 	  10,   -3, 	 -12,   -4, 	   0,   -6
+.2byte   -4,  -11, 	   3,   -9, 	  -5,   -1, 	   1,   -6
+.2byte   -5,   -9, 	  -9,   -8, 	   4,    0, 	   1,   -8
+.2byte   -5,   -8, 	 -11,   -4, 	  10,   -5, 	  -1,   -6
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  10,   -8, 	   1,   -6
+.2byte   -1,  -10, 	 -10,   -8, 	  10,   -3, 	   0,   -6
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    3,  -11, 	 -11,   -5, 	  13,   -9, 	   1,   -9
+.2byte    1,  -10, 	  -4,   -1, 	   4,  -11, 	   1,   -9
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    5,  -12, 	   9,   -7, 	  -4,   -2, 	  -1,   -8
+.2byte    5,  -12, 	  -3,   -6, 	   5,   -2, 	   0,   -8
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    4,  -15, 	  -2,  -12, 	   4,   -2, 	   0,   -9
+.2byte    3,  -15, 	 -11,  -10, 	  12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  11,  -12, 	  -9,   -6, 	   0,  -10
+.2byte    2,  -14, 	   9,   -6, 	 -10,  -12, 	   1,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte   -4,  -15, 	   2,  -12, 	  -4,   -2, 	   0,   -9
+.2byte   -3,  -15, 	  11,  -10, 	 -12,   -7, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -5,  -12, 	  -9,   -7, 	   4,   -2, 	   1,   -8
+.2byte   -5,  -12, 	   3,   -6, 	  -5,   -2, 	   0,   -8
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -3,  -11, 	 -13,   -9, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -1, 	   0,   -8
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    1,  -11, 	  -4,   -6, 	  13,  -18, 	   1,   -9
+.2byte    1,  -10, 	   8,   -8, 	 -10,  -17, 	   0,   -9
+.2byte    5,  -12, 	   8,  -11, 	  -4,  -13, 	   0,   -7
+.2byte    4,  -13, 	   1,  -12, 	  10,  -17, 	   0,   -9
+.2byte   -1,  -15, 	   3,  -11, 	 -11,  -20, 	  -1,  -10
+.2byte   -4,  -13, 	  -1,  -12, 	 -10,  -17, 	   0,   -9
+.2byte   -5,  -12, 	  -8,  -11, 	   4,  -13, 	   0,   -7
+.2byte   -1,  -10, 	  -8,   -8, 	  11,  -16, 	   2,   -9
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -3, 	  10,   -8, 	   1,   -6
+.2byte   -1,  -10, 	 -10,   -8, 	  10,   -3, 	   0,   -6
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    3,  -11, 	 -11,   -5, 	  13,   -9, 	   1,   -9
+.2byte    1,  -10, 	  -4,   -1, 	   4,  -11, 	   1,   -9
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    5,  -12, 	   9,   -7, 	  -4,   -2, 	  -1,   -8
+.2byte    5,  -12, 	  -3,   -6, 	   5,   -2, 	   0,   -8
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    4,  -15, 	  -2,  -12, 	   4,   -2, 	   0,   -9
+.2byte    3,  -15, 	 -11,  -10, 	  12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  11,  -12, 	  -9,   -6, 	   0,  -10
+.2byte    2,  -14, 	   9,   -6, 	 -10,  -12, 	   1,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte   -4,  -15, 	   2,  -12, 	  -4,   -2, 	   0,   -9
+.2byte   -3,  -15, 	  11,  -10, 	 -12,   -7, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -5,  -12, 	  -9,   -7, 	   4,   -2, 	   1,   -8
+.2byte   -5,  -12, 	   3,   -6, 	  -5,   -2, 	   0,   -8
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -3,  -11, 	 -13,   -9, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -11, 	  -4,  -11, 	   4,   -1, 	   0,   -8
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+.2byte    0,  -11, 	 -11,   -5, 	  11,   -5, 	   0,   -7
+.2byte   -2,  -12, 	 -10,  -10, 	   8,   -2, 	   0,   -9
+.2byte   -5,  -13, 	  -3,   -9, 	  -1,   -1, 	   0,   -9
+.2byte   -4,  -16, 	   8,  -11, 	 -10,   -4, 	   0,  -10
+.2byte    0,  -15, 	  10,   -7, 	 -10,   -7, 	   0,  -10
+.2byte    4,  -16, 	  -8,  -11, 	  10,   -4, 	   0,  -10
+.2byte    5,  -13, 	   3,   -9, 	   1,   -1, 	   0,   -9
+.2byte    2,  -11, 	  -8,   -2, 	  10,  -10, 	   1,   -9
+sPoliwhirlAnimTable1:
+.4byte sPoliwhirlAnims_1_1
+.4byte sPoliwhirlAnims_1_2
+.4byte sPoliwhirlAnims_1_3
+.4byte sPoliwhirlAnims_1_4
+.4byte sPoliwhirlAnims_1_5
+.4byte sPoliwhirlAnims_1_6
+.4byte sPoliwhirlAnims_1_7
+.4byte sPoliwhirlAnims_1_8
+sPoliwhirlAnimTable2:
+.4byte sPoliwhirlAnims_2_1
+.4byte sPoliwhirlAnims_2_2
+.4byte sPoliwhirlAnims_2_3
+.4byte sPoliwhirlAnims_2_4
+.4byte sPoliwhirlAnims_2_5
+.4byte sPoliwhirlAnims_2_6
+.4byte sPoliwhirlAnims_2_7
+.4byte sPoliwhirlAnims_2_8
+sPoliwhirlAnimTable3:
+.4byte sPoliwhirlAnims_3_1
+.4byte sPoliwhirlAnims_3_2
+.4byte sPoliwhirlAnims_3_3
+.4byte sPoliwhirlAnims_3_4
+.4byte sPoliwhirlAnims_3_5
+.4byte sPoliwhirlAnims_3_6
+.4byte sPoliwhirlAnims_3_7
+.4byte sPoliwhirlAnims_3_8
+sPoliwhirlAnimTable4:
+.4byte sPoliwhirlAnims_4_1
+.4byte sPoliwhirlAnims_4_2
+.4byte sPoliwhirlAnims_4_3
+.4byte sPoliwhirlAnims_4_4
+.4byte sPoliwhirlAnims_4_5
+.4byte sPoliwhirlAnims_4_6
+.4byte sPoliwhirlAnims_4_7
+.4byte sPoliwhirlAnims_4_8
+sPoliwhirlAnimTable5:
+.4byte sPoliwhirlAnims_5_1
+.4byte sPoliwhirlAnims_5_2
+.4byte sPoliwhirlAnims_5_3
+.4byte sPoliwhirlAnims_5_4
+.4byte sPoliwhirlAnims_5_5
+.4byte sPoliwhirlAnims_5_6
+.4byte sPoliwhirlAnims_5_7
+.4byte sPoliwhirlAnims_5_8
+sPoliwhirlAnimTable6:
+.4byte sPoliwhirlAnims_6_1
+.4byte sPoliwhirlAnims_6_1
+.4byte sPoliwhirlAnims_6_1
+.4byte sPoliwhirlAnims_6_1
+.4byte sPoliwhirlAnims_6_1
+.4byte sPoliwhirlAnims_6_1
+.4byte sPoliwhirlAnims_6_1
+.4byte sPoliwhirlAnims_6_1
+sPoliwhirlAnimTable7:
+.4byte sPoliwhirlAnims_7_1
+.4byte sPoliwhirlAnims_7_2
+.4byte sPoliwhirlAnims_7_3
+.4byte sPoliwhirlAnims_7_4
+.4byte sPoliwhirlAnims_7_5
+.4byte sPoliwhirlAnims_7_6
+.4byte sPoliwhirlAnims_7_7
+.4byte sPoliwhirlAnims_7_8
+sPoliwhirlAnimTable8:
+.4byte sPoliwhirlAnims_8_1
+.4byte sPoliwhirlAnims_8_2
+.4byte sPoliwhirlAnims_8_3
+.4byte sPoliwhirlAnims_8_4
+.4byte sPoliwhirlAnims_8_5
+.4byte sPoliwhirlAnims_8_6
+.4byte sPoliwhirlAnims_8_7
+.4byte sPoliwhirlAnims_8_8
+sPoliwhirlAnimTable9:
+.4byte sPoliwhirlAnims_9_1
+.4byte sPoliwhirlAnims_9_2
+.4byte sPoliwhirlAnims_9_3
+.4byte sPoliwhirlAnims_9_4
+.4byte sPoliwhirlAnims_9_5
+.4byte sPoliwhirlAnims_9_6
+.4byte sPoliwhirlAnims_9_7
+.4byte sPoliwhirlAnims_9_8
+sPoliwhirlAnimTable10:
+.4byte sPoliwhirlAnims_10_1
+.4byte sPoliwhirlAnims_10_2
+.4byte sPoliwhirlAnims_10_3
+.4byte sPoliwhirlAnims_10_4
+.4byte sPoliwhirlAnims_10_5
+.4byte sPoliwhirlAnims_10_6
+.4byte sPoliwhirlAnims_10_7
+.4byte sPoliwhirlAnims_10_8
+sPoliwhirlAnimTable11:
+.4byte sPoliwhirlAnims_11_1
+.4byte sPoliwhirlAnims_11_2
+.4byte sPoliwhirlAnims_11_3
+.4byte sPoliwhirlAnims_11_4
+.4byte sPoliwhirlAnims_11_5
+.4byte sPoliwhirlAnims_11_6
+.4byte sPoliwhirlAnims_11_7
+.4byte sPoliwhirlAnims_11_8
+sPoliwhirlAnimTable12:
+.4byte sPoliwhirlAnims_12_1
+.4byte sPoliwhirlAnims_12_2
+.4byte sPoliwhirlAnims_12_3
+.4byte sPoliwhirlAnims_12_4
+.4byte sPoliwhirlAnims_12_5
+.4byte sPoliwhirlAnims_12_6
+.4byte sPoliwhirlAnims_12_7
+.4byte sPoliwhirlAnims_12_8
+sPoliwhirlAnimTable13:
+.4byte sPoliwhirlAnims_13_1
+.4byte sPoliwhirlAnims_13_2
+.4byte sPoliwhirlAnims_13_3
+.4byte sPoliwhirlAnims_13_4
+.4byte sPoliwhirlAnims_13_5
+.4byte sPoliwhirlAnims_13_6
+.4byte sPoliwhirlAnims_13_7
+.4byte sPoliwhirlAnims_13_8
+sAxAnimationsPoliwhirl:
+.4byte sPoliwhirlAnimTable1
+.4byte sPoliwhirlAnimTable2
+.4byte sPoliwhirlAnimTable3
+.4byte sPoliwhirlAnimTable4
+.4byte sPoliwhirlAnimTable5
+.4byte sPoliwhirlAnimTable6
+.4byte sPoliwhirlAnimTable7
+.4byte sPoliwhirlAnimTable8
+.4byte sPoliwhirlAnimTable9
+.4byte sPoliwhirlAnimTable10
+.4byte sPoliwhirlAnimTable11
+.4byte sPoliwhirlAnimTable12
+.4byte sPoliwhirlAnimTable13
+sAxSpritesPoliwhirl:
+.4byte sPoliwhirlSprites1
+.4byte sPoliwhirlSprites2
+.4byte sPoliwhirlSprites3
+.4byte sPoliwhirlSprites4
+.4byte sPoliwhirlSprites5
+.4byte sPoliwhirlSprites6
+.4byte sPoliwhirlSprites7
+.4byte sPoliwhirlSprites8
+.4byte sPoliwhirlSprites9
+.4byte sPoliwhirlSprites10
+.4byte sPoliwhirlSprites11
+.4byte sPoliwhirlSprites12
+.4byte sPoliwhirlSprites13
+.4byte sPoliwhirlSprites14
+.4byte sPoliwhirlSprites15
+.4byte sPoliwhirlSprites16
+.4byte sPoliwhirlSprites17
+.4byte sPoliwhirlSprites18
+.4byte sPoliwhirlSprites19
+.4byte sPoliwhirlSprites20
+.4byte sPoliwhirlSprites21
+.4byte sPoliwhirlSprites22
+.4byte sPoliwhirlSprites23
+.4byte sPoliwhirlSprites24
+.4byte sPoliwhirlSprites25
+.4byte sPoliwhirlSprites26
+.4byte sPoliwhirlSprites27
+.4byte sPoliwhirlSprites28
+.4byte sPoliwhirlSprites29
+.4byte sPoliwhirlSprites30
+.4byte sPoliwhirlSprites31
+.4byte sPoliwhirlSprites32
+.4byte sPoliwhirlSprites33
+.4byte sPoliwhirlSprites34
+.4byte sPoliwhirlSprites35
+.4byte sPoliwhirlSprites36
+.4byte sPoliwhirlSprites37
+.4byte sPoliwhirlSprites38
+.4byte sPoliwhirlSprites39
+.4byte sPoliwhirlSprites40
+.4byte sPoliwhirlSprites41
+.4byte sPoliwhirlSprites42
+.4byte sPoliwhirlSprites43
+.4byte sPoliwhirlSprites44
+.4byte sPoliwhirlSprites45
+.4byte sPoliwhirlSprites46
+.4byte sPoliwhirlSprites47
+.4byte sPoliwhirlSprites48
+.4byte sPoliwhirlSprites49
+.4byte sPoliwhirlSprites50
+.4byte sPoliwhirlSprites51
+.4byte sPoliwhirlSprites52
+.4byte sPoliwhirlSprites53
+.4byte sPoliwhirlSprites54
+.4byte sPoliwhirlSprites55
+.4byte sPoliwhirlSprites56
+.4byte sPoliwhirlSprites57
+.4byte sPoliwhirlSprites58
+.4byte sPoliwhirlSprites59
+.4byte sPoliwhirlSprites60
+.4byte sPoliwhirlSprites61
+.4byte sPoliwhirlSprites62
+.4byte sPoliwhirlSprites63
+.4byte sPoliwhirlSprites64
+.4byte sPoliwhirlSprites65
+.4byte sPoliwhirlSprites66
+.4byte sPoliwhirlSprites67
+.4byte sPoliwhirlSprites68
+.4byte sPoliwhirlSprites69
+.4byte sPoliwhirlSprites70
+.4byte sPoliwhirlSprites71
+.4byte sPoliwhirlSprites72
+.4byte sPoliwhirlSprites73
+.4byte sPoliwhirlSprites74
+.4byte sPoliwhirlSprites75
+.4byte sPoliwhirlSprites76
+.4byte sPoliwhirlSprites77
+.4byte sPoliwhirlSprites78
+.4byte sPoliwhirlSprites79
+.4byte sPoliwhirlSprites80
+.4byte sPoliwhirlSprites81
+sAxMainPoliwhirl:
+ax_main sAxPosesPoliwhirl, sAxAnimationsPoliwhirl, 13, sAxSpritesPoliwhirl, sAxPositionsPoliwhirl

--- a/data/ax/poliwrath.inc
+++ b/data/ax/poliwrath.inc
@@ -1,0 +1,2823 @@
+.global gAxPoliwrath
+gAxPoliwrath:
+ax_siro sAxMainPoliwrath
+sPoliwrathPose1:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose4:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose5:
+ax_pose 4, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose6:
+ax_pose 5, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose7:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose8:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose9:
+ax_pose 8, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose10:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose11:
+ax_pose 10, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose12:
+ax_pose 11, 0x01e6, 0x90f2, 0x2c00
+ax_pose_terminator
+sPoliwrathPose13:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose16:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose17:
+ax_pose 10, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose18:
+ax_pose 11, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sPoliwrathPose19:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose20:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose21:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose22:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose23:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose24:
+ax_pose 17, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwrathPose25:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose28:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose29:
+ax_pose 4, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose30:
+ax_pose 5, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose31:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose32:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose33:
+ax_pose 8, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose34:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose35:
+ax_pose 10, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose36:
+ax_pose 11, 0x01e6, 0x90f2, 0x2c00
+ax_pose_terminator
+sPoliwrathPose37:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose39:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose40:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose41:
+ax_pose 10, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose42:
+ax_pose 11, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sPoliwrathPose43:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose44:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose45:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose46:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose47:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose48:
+ax_pose 17, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwrathPose49:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose50:
+ax_pose 1, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose51:
+ax_pose 2, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose52:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose53:
+ax_pose 4, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose54:
+ax_pose 5, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose55:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose56:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose57:
+ax_pose 8, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose58:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose59:
+ax_pose 10, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose60:
+ax_pose 11, 0x01e6, 0x90f2, 0x2c00
+ax_pose_terminator
+sPoliwrathPose61:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose62:
+ax_pose 13, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose63:
+ax_pose 14, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose64:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose65:
+ax_pose 10, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose66:
+ax_pose 11, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sPoliwrathPose67:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose68:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose69:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose70:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose71:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose72:
+ax_pose 17, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwrathPose73:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose74:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose75:
+ax_pose 19, 0x41e9, 0x80ec, 0x2c00
+ax_pose 20, 0x01f9, 0x00f4, 0x2c08
+ax_pose 21, 0x41f9, 0x00fc, 0x2c09
+ax_pose 22, 0x0201, 0x00f4, 0x2c0b
+ax_pose 23, 0x0201, 0x0104, 0x2c0c
+ax_pose 24, 0x01e9, 0x0114, 0x2c0d
+ax_pose 25, 0x81e9, 0x010c, 0x2c0e
+ax_pose_terminator
+sPoliwrathPose76:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose77:
+ax_pose 26, 0x81e3, 0x80fb, 0x2c00
+ax_pose 27, 0x81e3, 0x40f3, 0x2c08
+ax_pose 28, 0x01db, 0x0102, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose78:
+ax_pose 29, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose79:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose80:
+ax_pose 30, 0x81e6, 0x90fd, 0x2c00
+ax_pose 31, 0x81e6, 0x50f5, 0x2c08
+ax_pose 32, 0x01de, 0x10fd, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose81:
+ax_pose 33, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose82:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose83:
+ax_pose 34, 0x81e4, 0x50f6, 0x2c00
+ax_pose 35, 0x81e4, 0x90fe, 0x2c04
+ax_pose 36, 0x01e4, 0x10ee, 0x2c0c
+ax_pose 37, 0x01dc, 0x10f4, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose84:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose85:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose86:
+ax_pose 39, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose87:
+ax_pose 40, 0x41ea, 0x80ec, 0x2c00
+ax_pose 41, 0x81ea, 0x010c, 0x2c08
+ax_pose 42, 0x01fa, 0x00f4, 0x2c0a
+ax_pose 43, 0x41fa, 0x00fc, 0x2c0b
+ax_pose 44, 0x01ea, 0x0114, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose88:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose89:
+ax_pose 34, 0x81e4, 0x4102, 0x2c00
+ax_pose 35, 0x81e4, 0x80f2, 0x2c04
+ax_pose 36, 0x01e4, 0x010a, 0x2c0c
+ax_pose 37, 0x01dc, 0x0104, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose90:
+ax_pose 38, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose91:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose92:
+ax_pose 30, 0x81e6, 0x80f3, 0x2c00
+ax_pose 31, 0x81e6, 0x4103, 0x2c08
+ax_pose 32, 0x01de, 0x00fb, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose93:
+ax_pose 33, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose94:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose95:
+ax_pose 45, 0x81e3, 0x80f6, 0x2c00
+ax_pose 46, 0x81e3, 0x4106, 0x2c08
+ax_pose 47, 0x01db, 0x00f7, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose96:
+ax_pose 48, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose97:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose98:
+ax_pose 49, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose99:
+ax_pose 50, 0x01e2, 0x80ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose100:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose101:
+ax_pose 51, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose102:
+ax_pose 52, 0x81e6, 0x90fe, 0x2c00
+ax_pose 53, 0x81e6, 0x50f6, 0x2c08
+ax_pose 54, 0x01de, 0x1106, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose103:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose104:
+ax_pose 55, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose105:
+ax_pose 56, 0x81e6, 0x90fd, 0x2c00
+ax_pose 57, 0x81e6, 0x50f5, 0x2c08
+ax_pose 58, 0x01de, 0x10fb, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose106:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose107:
+ax_pose 59, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose108:
+ax_pose 60, 0x81e6, 0x90f3, 0x2c00
+ax_pose 61, 0x81e6, 0x5103, 0x2c08
+ax_pose 62, 0x81ee, 0x110b, 0x2c0c
+ax_pose 63, 0x01de, 0x10f4, 0x2c0e
+ax_pose_terminator
+sPoliwrathPose109:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose110:
+ax_pose 64, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose111:
+ax_pose 65, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose112:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose113:
+ax_pose 59, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose114:
+ax_pose 60, 0x81e6, 0x80fd, 0x2c00
+ax_pose 61, 0x81e6, 0x40f5, 0x2c08
+ax_pose 62, 0x81ee, 0x00ed, 0x2c0c
+ax_pose 63, 0x01de, 0x0104, 0x2c0e
+ax_pose_terminator
+sPoliwrathPose115:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose116:
+ax_pose 55, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose117:
+ax_pose 56, 0x81e6, 0x80f3, 0x2c00
+ax_pose 57, 0x81e6, 0x4103, 0x2c08
+ax_pose 58, 0x01de, 0x00fd, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose118:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose119:
+ax_pose 66, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose120:
+ax_pose 52, 0x81e6, 0x80f3, 0x2c00
+ax_pose 53, 0x81e6, 0x4103, 0x2c08
+ax_pose 54, 0x01de, 0x00f3, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose121:
+ax_pose 67, 0x01ef, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose122:
+ax_pose 68, 0x01ef, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose123:
+ax_pose 69, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose124:
+ax_pose 70, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose125:
+ax_pose 71, 0x81e4, 0x90fd, 0x2c00
+ax_pose 72, 0x81e4, 0x50f5, 0x2c08
+ax_pose 73, 0x81e4, 0x10ed, 0x2c0c
+ax_pose 74, 0x01f4, 0x10ed, 0x2c0e
+ax_pose 75, 0x01dc, 0x1102, 0x2c0f
+ax_pose_terminator
+sPoliwrathPose126:
+ax_pose 76, 0x01de, 0x10ff, 0x2c00
+ax_pose 77, 0x01f6, 0x10ef, 0x2c01
+ax_pose 78, 0x81e6, 0x10ef, 0x2c02
+ax_pose 79, 0x81e6, 0x50f7, 0x2c04
+ax_pose 80, 0x81e6, 0x90ff, 0x2c08
+ax_pose_terminator
+sPoliwrathPose127:
+ax_pose 81, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose128:
+ax_pose 76, 0x01de, 0x00f9, 0x2c00
+ax_pose 77, 0x01f6, 0x0109, 0x2c01
+ax_pose 78, 0x81e6, 0x0109, 0x2c02
+ax_pose 79, 0x81e6, 0x4101, 0x2c04
+ax_pose 80, 0x81e6, 0x80f1, 0x2c08
+ax_pose_terminator
+sPoliwrathPose129:
+ax_pose 71, 0x81e4, 0x80f3, 0x2c00
+ax_pose 72, 0x81e4, 0x4103, 0x2c08
+ax_pose 73, 0x81e4, 0x010b, 0x2c0c
+ax_pose 74, 0x01f4, 0x010b, 0x2c0e
+ax_pose 75, 0x01dc, 0x00f6, 0x2c0f
+ax_pose_terminator
+sPoliwrathPose130:
+ax_pose 82, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose131:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose132:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose133:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose134:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose135:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose136:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose137:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose138:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose139:
+ax_pose 19, 0x41e9, 0x80ec, 0x2c00
+ax_pose 20, 0x01f9, 0x00f4, 0x2c08
+ax_pose 21, 0x41f9, 0x00fc, 0x2c09
+ax_pose 22, 0x0201, 0x00f4, 0x2c0b
+ax_pose 23, 0x0201, 0x0104, 0x2c0c
+ax_pose 24, 0x01e9, 0x0114, 0x2c0d
+ax_pose 25, 0x81e9, 0x010c, 0x2c0e
+ax_pose_terminator
+sPoliwrathPose140:
+ax_pose 48, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwrathPose141:
+ax_pose 33, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwrathPose142:
+ax_pose 38, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose143:
+ax_pose 40, 0x41ea, 0x80ec, 0x2c00
+ax_pose 41, 0x81ea, 0x010c, 0x2c08
+ax_pose 42, 0x01fa, 0x00f4, 0x2c0a
+ax_pose 43, 0x41fa, 0x00fc, 0x2c0b
+ax_pose 44, 0x01ea, 0x0114, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose144:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose145:
+ax_pose 33, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sPoliwrathPose146:
+ax_pose 29, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose147:
+ax_pose 19, 0x41e9, 0x80ec, 0x2c00
+ax_pose 20, 0x01f9, 0x00f4, 0x2c08
+ax_pose 21, 0x41f9, 0x00fc, 0x2c09
+ax_pose 22, 0x0201, 0x00f4, 0x2c0b
+ax_pose 23, 0x0201, 0x0104, 0x2c0c
+ax_pose 24, 0x01e9, 0x0114, 0x2c0d
+ax_pose 25, 0x81e9, 0x010c, 0x2c0e
+ax_pose_terminator
+sPoliwrathPose148:
+ax_pose 29, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose149:
+ax_pose 33, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sPoliwrathPose150:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose151:
+ax_pose 40, 0x41ea, 0x80ec, 0x2c00
+ax_pose 41, 0x81ea, 0x010c, 0x2c08
+ax_pose 42, 0x01fa, 0x00f4, 0x2c0a
+ax_pose 43, 0x41fa, 0x00fc, 0x2c0b
+ax_pose 44, 0x01ea, 0x0114, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose152:
+ax_pose 38, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose153:
+ax_pose 33, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sPoliwrathPose154:
+ax_pose 48, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sPoliwrathPose155:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose156:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose157:
+ax_pose 19, 0x41e9, 0x80ec, 0x2c00
+ax_pose 20, 0x01f9, 0x00f4, 0x2c08
+ax_pose 21, 0x41f9, 0x00fc, 0x2c09
+ax_pose 22, 0x0201, 0x00f4, 0x2c0b
+ax_pose 23, 0x0201, 0x0104, 0x2c0c
+ax_pose 24, 0x01e9, 0x0114, 0x2c0d
+ax_pose 25, 0x81e9, 0x010c, 0x2c0e
+ax_pose_terminator
+sPoliwrathPose158:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose159:
+ax_pose 26, 0x81e3, 0x80fb, 0x2c00
+ax_pose 27, 0x81e3, 0x40f3, 0x2c08
+ax_pose 28, 0x01db, 0x0102, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose160:
+ax_pose 29, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose161:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose162:
+ax_pose 30, 0x81e6, 0x90fd, 0x2c00
+ax_pose 31, 0x81e6, 0x50f5, 0x2c08
+ax_pose 32, 0x01de, 0x10fd, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose163:
+ax_pose 33, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose164:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose165:
+ax_pose 34, 0x81e4, 0x50f6, 0x2c00
+ax_pose 35, 0x81e4, 0x90fe, 0x2c04
+ax_pose 36, 0x01e4, 0x10ee, 0x2c0c
+ax_pose 37, 0x01dc, 0x10f4, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose166:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose167:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose168:
+ax_pose 39, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose169:
+ax_pose 40, 0x41ea, 0x80ec, 0x2c00
+ax_pose 41, 0x81ea, 0x010c, 0x2c08
+ax_pose 42, 0x01fa, 0x00f4, 0x2c0a
+ax_pose 43, 0x41fa, 0x00fc, 0x2c0b
+ax_pose 44, 0x01ea, 0x0114, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose170:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose171:
+ax_pose 34, 0x81e4, 0x4102, 0x2c00
+ax_pose 35, 0x81e4, 0x80f2, 0x2c04
+ax_pose 36, 0x01e4, 0x010a, 0x2c0c
+ax_pose 37, 0x01dc, 0x0104, 0x2c0d
+ax_pose_terminator
+sPoliwrathPose172:
+ax_pose 38, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose173:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose174:
+ax_pose 30, 0x81e6, 0x80f3, 0x2c00
+ax_pose 31, 0x81e6, 0x4103, 0x2c08
+ax_pose 32, 0x01de, 0x00fb, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose175:
+ax_pose 33, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose176:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose177:
+ax_pose 45, 0x81e3, 0x80f6, 0x2c00
+ax_pose 46, 0x81e3, 0x4106, 0x2c08
+ax_pose 47, 0x01db, 0x00f7, 0x2c0c
+ax_pose_terminator
+sPoliwrathPose178:
+ax_pose 48, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose179:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose180:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose181:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose182:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose183:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose184:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose185:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose186:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose187:
+ax_pose 0, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose188:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose189:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sPoliwrathPose190:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sPoliwrathPose191:
+ax_pose 12, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sPoliwrathPose192:
+ax_pose 9, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sPoliwrathPose193:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sPoliwrathPose194:
+ax_pose 3, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+.align 2
+sPoliwrathAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_2_1:
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 6, 0, 46, 0, -2, 0, -2,
+ax_anim 1, 2, 26, 0, 2, 0, 2,
+ax_anim 1, 0, 29, 0, 8, 0, 8,
+ax_anim 2, 0, 30, 0, 18, 0, 18,
+ax_anim 2, 1, 30, 1, 18, 1, 18,
+ax_anim 2, 0, 30, 0, 18, 0, 18,
+ax_anim 2, 0, 30, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 11, 0, 11,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sPoliwrathAnims_2_2:
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 6, 0, 25, -2, -2, -2, -2,
+ax_anim 1, 2, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 32, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 16, 18, 16, 18,
+ax_anim 2, 1, 33, 17, 17, 17, 17,
+ax_anim 2, 0, 33, 16, 18, 16, 18,
+ax_anim 2, 0, 33, 17, 17, 17, 17,
+ax_anim 2, 0, 30, 11, 11, 11, 11,
+ax_anim 2, 0, 27, 4, 4, 4, 4,
+ax_anim_terminator
+sPoliwrathAnims_2_3:
+ax_anim 2, 0, 28, -1, 0, -1, 0,
+ax_anim 6, 0, 28, -2, 0, -2, 0,
+ax_anim 1, 2, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 6, 0, 6, 0,
+ax_anim 2, 0, 36, 14, 0, 14, 0,
+ax_anim 2, 1, 36, 14, 1, 14, 1,
+ax_anim 2, 0, 36, 14, 0, 14, 0,
+ax_anim 2, 0, 36, 14, 1, 14, 1,
+ax_anim 2, 0, 33, 9, 0, 9, 0,
+ax_anim 2, 0, 30, 3, 0, 3, 0,
+ax_anim_terminator
+sPoliwrathAnims_2_4:
+ax_anim 2, 0, 31, -1, 1, -1, 1,
+ax_anim 6, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 2, 35, 0, -1, 0, -1,
+ax_anim 1, 0, 38, 8, -8, 8, -8,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 1, 39, 19, -17, 19, -17,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 39, 19, -17, 19, -17,
+ax_anim 2, 0, 36, 11, -11, 11, -11,
+ax_anim 2, 0, 33, 4, -4, 4, -4,
+ax_anim_terminator
+sPoliwrathAnims_2_5:
+ax_anim 2, 0, 34, 0, 1, 0, 1,
+ax_anim 6, 0, 34, 0, 2, 0, 2,
+ax_anim 1, 2, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 41, 0, -11, 0, -11,
+ax_anim 2, 0, 42, 0, -18, 0, -18,
+ax_anim 2, 1, 42, 1, -18, 1, -18,
+ax_anim 2, 0, 42, 0, -18, 0, -18,
+ax_anim 2, 0, 42, 1, -18, 1, -18,
+ax_anim 2, 0, 39, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sPoliwrathAnims_2_6:
+ax_anim 2, 0, 37, 1, 1, 1, 1,
+ax_anim 6, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 2, 41, 0, -1, 0, -1,
+ax_anim 1, 0, 44, -8, -10, -8, -10,
+ax_anim 2, 0, 45, -18, -18, -18, -18,
+ax_anim 2, 1, 45, -19, -17, -19, -17,
+ax_anim 2, 0, 45, -18, -18, -18, -18,
+ax_anim 2, 0, 45, -19, -17, -19, -17,
+ax_anim 2, 0, 42, -11, -11, -11, -11,
+ax_anim 2, 0, 39, -4, -4, -4, -4,
+ax_anim_terminator
+sPoliwrathAnims_2_7:
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 6, 0, 40, 2, 0, 2, 0,
+ax_anim 1, 2, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 47, -6, 0, -6, 0,
+ax_anim 2, 0, 24, -14, 0, -14, 0,
+ax_anim 2, 1, 24, -14, 1, -14, 1,
+ax_anim 2, 0, 24, -14, 0, -14, 0,
+ax_anim 2, 0, 24, -14, 1, -14, 1,
+ax_anim 2, 0, 45, -9, 0, -9, 0,
+ax_anim 2, 0, 42, -3, 0, -3, 0,
+ax_anim_terminator
+sPoliwrathAnims_2_8:
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 6, 0, 43, 2, -2, 2, -2,
+ax_anim 1, 2, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 26, -8, 8, -8, 8,
+ax_anim 2, 0, 27, -16, 18, -16, 18,
+ax_anim 2, 1, 27, -17, 17, -17, 17,
+ax_anim 2, 0, 27, -16, 18, -16, 18,
+ax_anim 2, 0, 27, -17, 17, -17, 17,
+ax_anim 2, 0, 24, -11, 11, -11, 11,
+ax_anim 2, 0, 45, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_3_1:
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 6, 0, 70, 0, -2, 0, -2,
+ax_anim 1, 2, 50, 0, 2, 0, 2,
+ax_anim 1, 0, 53, 0, 8, 0, 8,
+ax_anim 2, 0, 54, 0, 18, 0, 18,
+ax_anim 2, 1, 54, 1, 18, 1, 18,
+ax_anim 2, 0, 54, 0, 18, 0, 18,
+ax_anim 2, 0, 54, 1, 18, 1, 18,
+ax_anim 2, 0, 51, 0, 11, 0, 11,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sPoliwrathAnims_3_2:
+ax_anim 2, 0, 49, -1, -1, -1, -1,
+ax_anim 6, 0, 49, -2, -2, -2, -2,
+ax_anim 1, 2, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 56, 10, 10, 10, 10,
+ax_anim 2, 0, 57, 16, 18, 16, 18,
+ax_anim 2, 1, 57, 17, 17, 17, 17,
+ax_anim 2, 0, 57, 16, 18, 16, 18,
+ax_anim 2, 0, 57, 17, 17, 17, 17,
+ax_anim 2, 0, 54, 11, 11, 11, 11,
+ax_anim 2, 0, 51, 4, 4, 4, 4,
+ax_anim_terminator
+sPoliwrathAnims_3_3:
+ax_anim 2, 0, 52, -1, 0, -1, 0,
+ax_anim 6, 0, 52, -2, 0, -2, 0,
+ax_anim 1, 2, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 6, 0, 6, 0,
+ax_anim 2, 0, 60, 14, 0, 14, 0,
+ax_anim 2, 1, 60, 14, 1, 14, 1,
+ax_anim 2, 0, 60, 14, 0, 14, 0,
+ax_anim 2, 0, 60, 14, 1, 14, 1,
+ax_anim 2, 0, 57, 9, 0, 9, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim_terminator
+sPoliwrathAnims_3_4:
+ax_anim 2, 0, 55, -1, 1, -1, 1,
+ax_anim 6, 0, 55, -2, 2, -2, 2,
+ax_anim 1, 2, 59, 0, -1, 0, -1,
+ax_anim 1, 0, 62, 8, -8, 8, -8,
+ax_anim 2, 0, 63, 18, -18, 18, -18,
+ax_anim 2, 1, 63, 19, -17, 19, -17,
+ax_anim 2, 0, 63, 18, -18, 18, -18,
+ax_anim 2, 0, 63, 19, -17, 19, -17,
+ax_anim 2, 0, 60, 11, -11, 11, -11,
+ax_anim 2, 0, 57, 4, -4, 4, -4,
+ax_anim_terminator
+sPoliwrathAnims_3_5:
+ax_anim 2, 0, 58, 0, 1, 0, 1,
+ax_anim 6, 0, 58, 0, 2, 0, 2,
+ax_anim 1, 2, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 65, 0, -11, 0, -11,
+ax_anim 2, 0, 66, 0, -18, 0, -18,
+ax_anim 2, 1, 66, 1, -18, 1, -18,
+ax_anim 2, 0, 66, 0, -18, 0, -18,
+ax_anim 2, 0, 66, 1, -18, 1, -18,
+ax_anim 2, 0, 63, 0, -11, 0, -11,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sPoliwrathAnims_3_6:
+ax_anim 2, 0, 61, 1, 1, 1, 1,
+ax_anim 6, 0, 61, 2, 2, 2, 2,
+ax_anim 1, 2, 65, 0, -1, 0, -1,
+ax_anim 1, 0, 68, -8, -10, -8, -10,
+ax_anim 2, 0, 69, -18, -18, -18, -18,
+ax_anim 2, 1, 69, -19, -17, -19, -17,
+ax_anim 2, 0, 69, -18, -18, -18, -18,
+ax_anim 2, 0, 69, -19, -17, -19, -17,
+ax_anim 2, 0, 66, -11, -11, -11, -11,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim_terminator
+sPoliwrathAnims_3_7:
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 6, 0, 64, 2, 0, 2, 0,
+ax_anim 1, 2, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 71, -6, 0, -6, 0,
+ax_anim 2, 0, 48, -14, 0, -14, 0,
+ax_anim 2, 1, 48, -14, 1, -14, 1,
+ax_anim 2, 0, 48, -14, 0, -14, 0,
+ax_anim 2, 0, 48, -14, 1, -14, 1,
+ax_anim 2, 0, 69, -9, 0, -9, 0,
+ax_anim 2, 0, 66, -3, 0, -3, 0,
+ax_anim_terminator
+sPoliwrathAnims_3_8:
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 6, 0, 67, 2, -2, 2, -2,
+ax_anim 1, 2, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 50, -8, 8, -8, 8,
+ax_anim 2, 0, 51, -16, 18, -16, 18,
+ax_anim 2, 1, 51, -17, 17, -17, 17,
+ax_anim 2, 0, 51, -16, 18, -16, 18,
+ax_anim 2, 0, 51, -17, 17, -17, 17,
+ax_anim 2, 0, 48, -11, 11, -11, 11,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_4_1:
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -4, 0, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -4, 0, 0,
+ax_anim 1, 2, 73, 0, -3, 0, 0,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 6, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 1, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_4_2:
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 1, 2, 76, 0, -3, 0, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 6, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 1, 77, -1, 1, -1, 1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_4_3:
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 1, 2, 79, 0, -3, 0, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 6, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 1, 80, 0, 1, 0, 1,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_4_4:
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 1, 2, 82, 0, -3, 0, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 6, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 1, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_4_5:
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 1, 2, 85, 0, -3, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 6, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 1, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_4_6:
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 1, 2, 88, 0, -3, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 1, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_4_7:
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 1, 2, 91, 0, -3, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 1, 92, 0, 1, 0, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_4_8:
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 1, 2, 94, 0, -3, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 95, 1, 1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_5_1:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 2, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 1, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_5_2:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 2, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 1, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_5_3:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 2, 104, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 6, 1, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_5_4:
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 2, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 1, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_5_5:
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 2, 110, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 6, 1, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_5_6:
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 2, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 1, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_5_7:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 2, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 1, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_5_8:
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 2, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 1, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sPoliwrathAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sPoliwrathAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sPoliwrathAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sPoliwrathAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sPoliwrathAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sPoliwrathAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sPoliwrathAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_8_2:
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_8_4:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 4, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_8_5:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_8_6:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_8_7:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 4, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_8_8:
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 10, 9, 10, 9,
+ax_anim 2, 0, 141, 7, 15, 7, 15,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -7, 15, -7, 15,
+ax_anim 2, 0, 144, -10, 9, -10, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 24, 10, 24, 10,
+ax_anim 3, 0, 141, 21, 20, 21, 20,
+ax_anim 2, 3, 142, 11, 21, 11, 21,
+ax_anim 2, 0, 143, 2, 16, 2, 16,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 16, -5, 16, -5,
+ax_anim 3, 0, 140, 21, -1, 21, -1,
+ax_anim 2, 3, 141, 18, 4, 18, 4,
+ax_anim 2, 0, 142, 12, 5, 12, 5,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -6, -1, -6,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -22, 12, -22,
+ax_anim 3, 0, 139, 20, -21, 20, -21,
+ax_anim 2, 3, 140, 22, -12, 22, -12,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -10, -11, -10, -11,
+ax_anim 2, 0, 145, -7, -19, -7, -19,
+ax_anim 3, 0, 138, 0, -23, 0, -23,
+ax_anim 2, 3, 139, 7, -19, 7, -19,
+ax_anim 2, 0, 140, 13, -12, 13, -12,
+ax_anim 1, 0, 141, 10, -4, 10, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -8, 0, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -21, -12, -21,
+ax_anim 3, 0, 145, -18, -19, -18, -19,
+ax_anim 2, 3, 144, -20, -12, -20, -12,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -16, -5, -16, -5,
+ax_anim 3, 0, 144, -18, -1, -18, -1,
+ax_anim 2, 3, 143, -16, 4, -16, 4,
+ax_anim 2, 0, 142, -11, 6, -11, 6,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -15, 3, -15, 3,
+ax_anim 2, 0, 144, -21, 11, -21, 11,
+ax_anim 3, 0, 143, -19, 20, -19, 20,
+ax_anim 2, 3, 142, -9, 20, -9, 20,
+ax_anim 2, 0, 141, -2, 14, -2, 14,
+ax_anim 1, 0, 140, 2, 7, 2, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -25, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -25, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -24, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -24, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -24, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -25, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoliwrathAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sPoliwrathGfx1:
+.incbin "baserom.gba", 0x7B08EC, 0x200
+sPoliwrathSprites1:
+ax_sprite sPoliwrathGfx1, 0x200
+ax_sprite_terminator
+sPoliwrathGfx2:
+.incbin "baserom.gba", 0x7B0AFC, 0x200
+sPoliwrathSprites2:
+ax_sprite sPoliwrathGfx2, 0x200
+ax_sprite_terminator
+sPoliwrathGfx3:
+.incbin "baserom.gba", 0x7B0D0C, 0x200
+sPoliwrathSprites3:
+ax_sprite sPoliwrathGfx3, 0x200
+ax_sprite_terminator
+sPoliwrathGfx4:
+.incbin "baserom.gba", 0x7B0F1C, 0x200
+sPoliwrathSprites4:
+ax_sprite sPoliwrathGfx4, 0x200
+ax_sprite_terminator
+sPoliwrathGfx5:
+.incbin "baserom.gba", 0x7B112C, 0x200
+sPoliwrathSprites5:
+ax_sprite sPoliwrathGfx5, 0x200
+ax_sprite_terminator
+sPoliwrathGfx6:
+.incbin "baserom.gba", 0x7B133C, 0x200
+sPoliwrathSprites6:
+ax_sprite sPoliwrathGfx6, 0x200
+ax_sprite_terminator
+sPoliwrathGfx7:
+.incbin "baserom.gba", 0x7B154C, 0x200
+sPoliwrathSprites7:
+ax_sprite sPoliwrathGfx7, 0x200
+ax_sprite_terminator
+sPoliwrathGfx8:
+.incbin "baserom.gba", 0x7B175C, 0x200
+sPoliwrathSprites8:
+ax_sprite sPoliwrathGfx8, 0x200
+ax_sprite_terminator
+sPoliwrathGfx9:
+.incbin "baserom.gba", 0x7B196C, 0x200
+sPoliwrathSprites9:
+ax_sprite sPoliwrathGfx9, 0x200
+ax_sprite_terminator
+sPoliwrathGfx10:
+.incbin "baserom.gba", 0x7B1B7C, 0x200
+sPoliwrathSprites10:
+ax_sprite sPoliwrathGfx10, 0x200
+ax_sprite_terminator
+sPoliwrathGfx11:
+.incbin "baserom.gba", 0x7B1D8C, 0x200
+sPoliwrathSprites11:
+ax_sprite sPoliwrathGfx11, 0x200
+ax_sprite_terminator
+sPoliwrathGfx12:
+.incbin "baserom.gba", 0x7B1F9C, 0x200
+sPoliwrathSprites12:
+ax_sprite sPoliwrathGfx12, 0x200
+ax_sprite_terminator
+sPoliwrathGfx13:
+.incbin "baserom.gba", 0x7B21AC, 0x200
+sPoliwrathSprites13:
+ax_sprite sPoliwrathGfx13, 0x200
+ax_sprite_terminator
+sPoliwrathGfx14:
+.incbin "baserom.gba", 0x7B23BC, 0x200
+sPoliwrathSprites14:
+ax_sprite sPoliwrathGfx14, 0x200
+ax_sprite_terminator
+sPoliwrathGfx15:
+.incbin "baserom.gba", 0x7B25CC, 0x200
+sPoliwrathSprites15:
+ax_sprite sPoliwrathGfx15, 0x200
+ax_sprite_terminator
+sPoliwrathGfx16:
+.incbin "baserom.gba", 0x7B27DC, 0x200
+sPoliwrathSprites16:
+ax_sprite sPoliwrathGfx16, 0x200
+ax_sprite_terminator
+sPoliwrathGfx17:
+.incbin "baserom.gba", 0x7B29EC, 0x200
+sPoliwrathSprites17:
+ax_sprite sPoliwrathGfx17, 0x200
+ax_sprite_terminator
+sPoliwrathGfx18:
+.incbin "baserom.gba", 0x7B2BFC, 0x200
+sPoliwrathSprites18:
+ax_sprite sPoliwrathGfx18, 0x200
+ax_sprite_terminator
+sPoliwrathGfx19:
+.incbin "baserom.gba", 0x7B2E0C, 0x200
+sPoliwrathSprites19:
+ax_sprite sPoliwrathGfx19, 0x200
+ax_sprite_terminator
+sPoliwrathGfx20:
+.incbin "baserom.gba", 0x7B301C, 0x100
+sPoliwrathSprites20:
+ax_sprite sPoliwrathGfx20, 0x100
+ax_sprite_terminator
+sPoliwrathGfx21:
+.incbin "baserom.gba", 0x7B312C, 0x20
+sPoliwrathSprites21:
+ax_sprite sPoliwrathGfx21, 0x20
+ax_sprite_terminator
+sPoliwrathGfx22:
+.incbin "baserom.gba", 0x7B315C, 0x40
+sPoliwrathSprites22:
+ax_sprite sPoliwrathGfx22, 0x40
+ax_sprite_terminator
+sPoliwrathGfx23:
+.incbin "baserom.gba", 0x7B31AC, 0x20
+sPoliwrathSprites23:
+ax_sprite sPoliwrathGfx23, 0x20
+ax_sprite_terminator
+sPoliwrathGfx24:
+.incbin "baserom.gba", 0x7B31DC, 0x20
+sPoliwrathSprites24:
+ax_sprite sPoliwrathGfx24, 0x20
+ax_sprite_terminator
+sPoliwrathGfx25:
+.incbin "baserom.gba", 0x7B320C, 0x20
+sPoliwrathSprites25:
+ax_sprite sPoliwrathGfx25, 0x20
+ax_sprite_terminator
+sPoliwrathGfx26:
+.incbin "baserom.gba", 0x7B323C, 0x40
+sPoliwrathSprites26:
+ax_sprite sPoliwrathGfx26, 0x40
+ax_sprite_terminator
+sPoliwrathGfx27:
+.incbin "baserom.gba", 0x7B328C, 0x100
+sPoliwrathSprites27:
+ax_sprite sPoliwrathGfx27, 0x100
+ax_sprite_terminator
+sPoliwrathGfx28:
+.incbin "baserom.gba", 0x7B339C, 0x80
+sPoliwrathSprites28:
+ax_sprite sPoliwrathGfx28, 0x80
+ax_sprite_terminator
+sPoliwrathGfx29:
+.incbin "baserom.gba", 0x7B342C, 0x20
+sPoliwrathSprites29:
+ax_sprite sPoliwrathGfx29, 0x20
+ax_sprite_terminator
+sPoliwrathGfx30:
+.incbin "baserom.gba", 0x7B345C, 0x160
+sPoliwrathGfx30_1:
+.incbin "baserom.gba", 0x7B35BC, 0x60
+sPoliwrathSprites30:
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx30, 0x160
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx30_1, 0x60
+ax_sprite_terminator
+sPoliwrathGfx31:
+.incbin "baserom.gba", 0x7B3644, 0xC0
+sPoliwrathGfx31_1:
+.incbin "baserom.gba", 0x7B3704, 0x20
+sPoliwrathSprites31:
+ax_sprite sPoliwrathGfx31, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx31_1, 0x20
+ax_sprite_terminator
+sPoliwrathGfx32:
+.incbin "baserom.gba", 0x7B3744, 0x60
+sPoliwrathSprites32:
+ax_sprite sPoliwrathGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwrathGfx33:
+.incbin "baserom.gba", 0x7B37BC, 0x20
+sPoliwrathSprites33:
+ax_sprite sPoliwrathGfx33, 0x20
+ax_sprite_terminator
+sPoliwrathGfx34:
+.incbin "baserom.gba", 0x7B37EC, 0x40
+sPoliwrathGfx34_1:
+.incbin "baserom.gba", 0x7B382C, 0x60
+sPoliwrathGfx34_2:
+.incbin "baserom.gba", 0x7B388C, 0x60
+sPoliwrathGfx34_3:
+.incbin "baserom.gba", 0x7B38EC, 0x60
+sPoliwrathSprites34:
+ax_sprite sPoliwrathGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwrathGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwrathGfx35:
+.incbin "baserom.gba", 0x7B3994, 0x80
+sPoliwrathSprites35:
+ax_sprite sPoliwrathGfx35, 0x80
+ax_sprite_terminator
+sPoliwrathGfx36:
+.incbin "baserom.gba", 0x7B3A24, 0x100
+sPoliwrathSprites36:
+ax_sprite sPoliwrathGfx36, 0x100
+ax_sprite_terminator
+sPoliwrathGfx37:
+.incbin "baserom.gba", 0x7B3B34, 0x20
+sPoliwrathSprites37:
+ax_sprite sPoliwrathGfx37, 0x20
+ax_sprite_terminator
+sPoliwrathGfx38:
+.incbin "baserom.gba", 0x7B3B64, 0x20
+sPoliwrathSprites38:
+ax_sprite sPoliwrathGfx38, 0x20
+ax_sprite_terminator
+sPoliwrathGfx39:
+.incbin "baserom.gba", 0x7B3B94, 0x1C0
+sPoliwrathSprites39:
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx39, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwrathGfx40:
+.incbin "baserom.gba", 0x7B3D74, 0x200
+sPoliwrathSprites40:
+ax_sprite sPoliwrathGfx40, 0x200
+ax_sprite_terminator
+sPoliwrathGfx41:
+.incbin "baserom.gba", 0x7B3F84, 0x100
+sPoliwrathSprites41:
+ax_sprite sPoliwrathGfx41, 0x100
+ax_sprite_terminator
+sPoliwrathGfx42:
+.incbin "baserom.gba", 0x7B4094, 0x40
+sPoliwrathSprites42:
+ax_sprite sPoliwrathGfx42, 0x40
+ax_sprite_terminator
+sPoliwrathGfx43:
+.incbin "baserom.gba", 0x7B40E4, 0x20
+sPoliwrathSprites43:
+ax_sprite sPoliwrathGfx43, 0x20
+ax_sprite_terminator
+sPoliwrathGfx44:
+.incbin "baserom.gba", 0x7B4114, 0x40
+sPoliwrathSprites44:
+ax_sprite sPoliwrathGfx44, 0x40
+ax_sprite_terminator
+sPoliwrathGfx45:
+.incbin "baserom.gba", 0x7B4164, 0x20
+sPoliwrathSprites45:
+ax_sprite sPoliwrathGfx45, 0x20
+ax_sprite_terminator
+sPoliwrathGfx46:
+.incbin "baserom.gba", 0x7B4194, 0x100
+sPoliwrathSprites46:
+ax_sprite sPoliwrathGfx46, 0x100
+ax_sprite_terminator
+sPoliwrathGfx47:
+.incbin "baserom.gba", 0x7B42A4, 0x80
+sPoliwrathSprites47:
+ax_sprite sPoliwrathGfx47, 0x80
+ax_sprite_terminator
+sPoliwrathGfx48:
+.incbin "baserom.gba", 0x7B4334, 0x20
+sPoliwrathSprites48:
+ax_sprite sPoliwrathGfx48, 0x20
+ax_sprite_terminator
+sPoliwrathGfx49:
+.incbin "baserom.gba", 0x7B4364, 0x60
+sPoliwrathGfx49_1:
+.incbin "baserom.gba", 0x7B43C4, 0x160
+sPoliwrathSprites49:
+ax_sprite sPoliwrathGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx49_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwrathGfx50:
+.incbin "baserom.gba", 0x7B454C, 0x1C0
+sPoliwrathSprites50:
+ax_sprite 0, 0x40
+ax_sprite sPoliwrathGfx50, 0x1c0
+ax_sprite_terminator
+sPoliwrathGfx51:
+.incbin "baserom.gba", 0x7B4724, 0x40
+sPoliwrathGfx51_1:
+.incbin "baserom.gba", 0x7B4764, 0x100
+sPoliwrathGfx51_2:
+.incbin "baserom.gba", 0x7B4864, 0x60
+sPoliwrathSprites51:
+ax_sprite sPoliwrathGfx51, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwrathGfx51_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx51_2, 0x60
+ax_sprite_terminator
+sPoliwrathGfx52:
+.incbin "baserom.gba", 0x7B48F4, 0x60
+sPoliwrathGfx52_1:
+.incbin "baserom.gba", 0x7B4954, 0x100
+sPoliwrathGfx52_2:
+.incbin "baserom.gba", 0x7B4A54, 0x60
+sPoliwrathSprites52:
+ax_sprite sPoliwrathGfx52, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx52_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx52_2, 0x60
+ax_sprite_terminator
+sPoliwrathGfx53:
+.incbin "baserom.gba", 0x7B4AE4, 0x100
+sPoliwrathSprites53:
+ax_sprite sPoliwrathGfx53, 0x100
+ax_sprite_terminator
+sPoliwrathGfx54:
+.incbin "baserom.gba", 0x7B4BF4, 0x80
+sPoliwrathSprites54:
+ax_sprite sPoliwrathGfx54, 0x80
+ax_sprite_terminator
+sPoliwrathGfx55:
+.incbin "baserom.gba", 0x7B4C84, 0x20
+sPoliwrathSprites55:
+ax_sprite sPoliwrathGfx55, 0x20
+ax_sprite_terminator
+sPoliwrathGfx56:
+.incbin "baserom.gba", 0x7B4CB4, 0x60
+sPoliwrathGfx56_1:
+.incbin "baserom.gba", 0x7B4D14, 0x60
+sPoliwrathGfx56_2:
+.incbin "baserom.gba", 0x7B4D74, 0x60
+sPoliwrathGfx56_3:
+.incbin "baserom.gba", 0x7B4DD4, 0x20
+sPoliwrathSprites56:
+ax_sprite sPoliwrathGfx56, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx56_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoliwrathGfx56_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoliwrathGfx57:
+.incbin "baserom.gba", 0x7B4E3C, 0xC0
+sPoliwrathGfx57_1:
+.incbin "baserom.gba", 0x7B4EFC, 0x20
+sPoliwrathSprites57:
+ax_sprite sPoliwrathGfx57, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx57_1, 0x20
+ax_sprite_terminator
+sPoliwrathGfx58:
+.incbin "baserom.gba", 0x7B4F3C, 0x60
+sPoliwrathSprites58:
+ax_sprite sPoliwrathGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwrathGfx59:
+.incbin "baserom.gba", 0x7B4FB4, 0x20
+sPoliwrathSprites59:
+ax_sprite sPoliwrathGfx59, 0x20
+ax_sprite_terminator
+sPoliwrathGfx60:
+.incbin "baserom.gba", 0x7B4FE4, 0x60
+sPoliwrathGfx60_1:
+.incbin "baserom.gba", 0x7B5044, 0x160
+sPoliwrathSprites60:
+ax_sprite sPoliwrathGfx60, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx60_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwrathGfx61:
+.incbin "baserom.gba", 0x7B51CC, 0x100
+sPoliwrathSprites61:
+ax_sprite sPoliwrathGfx61, 0x100
+ax_sprite_terminator
+sPoliwrathGfx62:
+.incbin "baserom.gba", 0x7B52DC, 0x80
+sPoliwrathSprites62:
+ax_sprite sPoliwrathGfx62, 0x80
+ax_sprite_terminator
+sPoliwrathGfx63:
+.incbin "baserom.gba", 0x7B536C, 0x40
+sPoliwrathSprites63:
+ax_sprite sPoliwrathGfx63, 0x40
+ax_sprite_terminator
+sPoliwrathGfx64:
+.incbin "baserom.gba", 0x7B53BC, 0x20
+sPoliwrathSprites64:
+ax_sprite sPoliwrathGfx64, 0x20
+ax_sprite_terminator
+sPoliwrathGfx65:
+.incbin "baserom.gba", 0x7B53EC, 0x40
+sPoliwrathGfx65_1:
+.incbin "baserom.gba", 0x7B542C, 0x180
+sPoliwrathSprites65:
+ax_sprite sPoliwrathGfx65, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoliwrathGfx65_1, 0x180
+ax_sprite_terminator
+sPoliwrathGfx66:
+.incbin "baserom.gba", 0x7B55CC, 0x1C0
+sPoliwrathSprites66:
+ax_sprite 0, 0x40
+ax_sprite sPoliwrathGfx66, 0x1c0
+ax_sprite_terminator
+sPoliwrathGfx67:
+.incbin "baserom.gba", 0x7B57A4, 0x1C0
+sPoliwrathSprites67:
+ax_sprite 0, 0x20
+ax_sprite sPoliwrathGfx67, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoliwrathGfx68:
+.incbin "baserom.gba", 0x7B5984, 0x200
+sPoliwrathSprites68:
+ax_sprite sPoliwrathGfx68, 0x200
+ax_sprite_terminator
+sPoliwrathGfx69:
+.incbin "baserom.gba", 0x7B5B94, 0x200
+sPoliwrathSprites69:
+ax_sprite sPoliwrathGfx69, 0x200
+ax_sprite_terminator
+sPoliwrathGfx70:
+.incbin "baserom.gba", 0x7B5DA4, 0x200
+sPoliwrathSprites70:
+ax_sprite sPoliwrathGfx70, 0x200
+ax_sprite_terminator
+sPoliwrathGfx71:
+.incbin "baserom.gba", 0x7B5FB4, 0x200
+sPoliwrathSprites71:
+ax_sprite sPoliwrathGfx71, 0x200
+ax_sprite_terminator
+sPoliwrathGfx72:
+.incbin "baserom.gba", 0x7B61C4, 0x100
+sPoliwrathSprites72:
+ax_sprite sPoliwrathGfx72, 0x100
+ax_sprite_terminator
+sPoliwrathGfx73:
+.incbin "baserom.gba", 0x7B62D4, 0x80
+sPoliwrathSprites73:
+ax_sprite sPoliwrathGfx73, 0x80
+ax_sprite_terminator
+sPoliwrathGfx74:
+.incbin "baserom.gba", 0x7B6364, 0x40
+sPoliwrathSprites74:
+ax_sprite sPoliwrathGfx74, 0x40
+ax_sprite_terminator
+sPoliwrathGfx75:
+.incbin "baserom.gba", 0x7B63B4, 0x20
+sPoliwrathSprites75:
+ax_sprite sPoliwrathGfx75, 0x20
+ax_sprite_terminator
+sPoliwrathGfx76:
+.incbin "baserom.gba", 0x7B63E4, 0x20
+sPoliwrathSprites76:
+ax_sprite sPoliwrathGfx76, 0x20
+ax_sprite_terminator
+sPoliwrathGfx77:
+.incbin "baserom.gba", 0x7B6414, 0x20
+sPoliwrathSprites77:
+ax_sprite sPoliwrathGfx77, 0x20
+ax_sprite_terminator
+sPoliwrathGfx78:
+.incbin "baserom.gba", 0x7B6444, 0x20
+sPoliwrathSprites78:
+ax_sprite sPoliwrathGfx78, 0x20
+ax_sprite_terminator
+sPoliwrathGfx79:
+.incbin "baserom.gba", 0x7B6474, 0x40
+sPoliwrathSprites79:
+ax_sprite sPoliwrathGfx79, 0x40
+ax_sprite_terminator
+sPoliwrathGfx80:
+.incbin "baserom.gba", 0x7B64C4, 0x80
+sPoliwrathSprites80:
+ax_sprite sPoliwrathGfx80, 0x80
+ax_sprite_terminator
+sPoliwrathGfx81:
+.incbin "baserom.gba", 0x7B6554, 0x100
+sPoliwrathSprites81:
+ax_sprite sPoliwrathGfx81, 0x100
+ax_sprite_terminator
+sPoliwrathGfx82:
+.incbin "baserom.gba", 0x7B6664, 0x200
+sPoliwrathSprites82:
+ax_sprite sPoliwrathGfx82, 0x200
+ax_sprite_terminator
+sPoliwrathGfx83:
+.incbin "baserom.gba", 0x7B6874, 0x200
+sPoliwrathSprites83:
+ax_sprite sPoliwrathGfx83, 0x200
+ax_sprite_terminator
+sAxPosesPoliwrath:
+.4byte sPoliwrathPose1
+.4byte sPoliwrathPose2
+.4byte sPoliwrathPose3
+.4byte sPoliwrathPose4
+.4byte sPoliwrathPose5
+.4byte sPoliwrathPose6
+.4byte sPoliwrathPose7
+.4byte sPoliwrathPose8
+.4byte sPoliwrathPose9
+.4byte sPoliwrathPose10
+.4byte sPoliwrathPose11
+.4byte sPoliwrathPose12
+.4byte sPoliwrathPose13
+.4byte sPoliwrathPose14
+.4byte sPoliwrathPose15
+.4byte sPoliwrathPose16
+.4byte sPoliwrathPose17
+.4byte sPoliwrathPose18
+.4byte sPoliwrathPose19
+.4byte sPoliwrathPose20
+.4byte sPoliwrathPose21
+.4byte sPoliwrathPose22
+.4byte sPoliwrathPose23
+.4byte sPoliwrathPose24
+.4byte sPoliwrathPose25
+.4byte sPoliwrathPose26
+.4byte sPoliwrathPose27
+.4byte sPoliwrathPose28
+.4byte sPoliwrathPose29
+.4byte sPoliwrathPose30
+.4byte sPoliwrathPose31
+.4byte sPoliwrathPose32
+.4byte sPoliwrathPose33
+.4byte sPoliwrathPose34
+.4byte sPoliwrathPose35
+.4byte sPoliwrathPose36
+.4byte sPoliwrathPose37
+.4byte sPoliwrathPose38
+.4byte sPoliwrathPose39
+.4byte sPoliwrathPose40
+.4byte sPoliwrathPose41
+.4byte sPoliwrathPose42
+.4byte sPoliwrathPose43
+.4byte sPoliwrathPose44
+.4byte sPoliwrathPose45
+.4byte sPoliwrathPose46
+.4byte sPoliwrathPose47
+.4byte sPoliwrathPose48
+.4byte sPoliwrathPose49
+.4byte sPoliwrathPose50
+.4byte sPoliwrathPose51
+.4byte sPoliwrathPose52
+.4byte sPoliwrathPose53
+.4byte sPoliwrathPose54
+.4byte sPoliwrathPose55
+.4byte sPoliwrathPose56
+.4byte sPoliwrathPose57
+.4byte sPoliwrathPose58
+.4byte sPoliwrathPose59
+.4byte sPoliwrathPose60
+.4byte sPoliwrathPose61
+.4byte sPoliwrathPose62
+.4byte sPoliwrathPose63
+.4byte sPoliwrathPose64
+.4byte sPoliwrathPose65
+.4byte sPoliwrathPose66
+.4byte sPoliwrathPose67
+.4byte sPoliwrathPose68
+.4byte sPoliwrathPose69
+.4byte sPoliwrathPose70
+.4byte sPoliwrathPose71
+.4byte sPoliwrathPose72
+.4byte sPoliwrathPose73
+.4byte sPoliwrathPose74
+.4byte sPoliwrathPose75
+.4byte sPoliwrathPose76
+.4byte sPoliwrathPose77
+.4byte sPoliwrathPose78
+.4byte sPoliwrathPose79
+.4byte sPoliwrathPose80
+.4byte sPoliwrathPose81
+.4byte sPoliwrathPose82
+.4byte sPoliwrathPose83
+.4byte sPoliwrathPose84
+.4byte sPoliwrathPose85
+.4byte sPoliwrathPose86
+.4byte sPoliwrathPose87
+.4byte sPoliwrathPose88
+.4byte sPoliwrathPose89
+.4byte sPoliwrathPose90
+.4byte sPoliwrathPose91
+.4byte sPoliwrathPose92
+.4byte sPoliwrathPose93
+.4byte sPoliwrathPose94
+.4byte sPoliwrathPose95
+.4byte sPoliwrathPose96
+.4byte sPoliwrathPose97
+.4byte sPoliwrathPose98
+.4byte sPoliwrathPose99
+.4byte sPoliwrathPose100
+.4byte sPoliwrathPose101
+.4byte sPoliwrathPose102
+.4byte sPoliwrathPose103
+.4byte sPoliwrathPose104
+.4byte sPoliwrathPose105
+.4byte sPoliwrathPose106
+.4byte sPoliwrathPose107
+.4byte sPoliwrathPose108
+.4byte sPoliwrathPose109
+.4byte sPoliwrathPose110
+.4byte sPoliwrathPose111
+.4byte sPoliwrathPose112
+.4byte sPoliwrathPose113
+.4byte sPoliwrathPose114
+.4byte sPoliwrathPose115
+.4byte sPoliwrathPose116
+.4byte sPoliwrathPose117
+.4byte sPoliwrathPose118
+.4byte sPoliwrathPose119
+.4byte sPoliwrathPose120
+.4byte sPoliwrathPose121
+.4byte sPoliwrathPose122
+.4byte sPoliwrathPose123
+.4byte sPoliwrathPose124
+.4byte sPoliwrathPose125
+.4byte sPoliwrathPose126
+.4byte sPoliwrathPose127
+.4byte sPoliwrathPose128
+.4byte sPoliwrathPose129
+.4byte sPoliwrathPose130
+.4byte sPoliwrathPose131
+.4byte sPoliwrathPose132
+.4byte sPoliwrathPose133
+.4byte sPoliwrathPose134
+.4byte sPoliwrathPose135
+.4byte sPoliwrathPose136
+.4byte sPoliwrathPose137
+.4byte sPoliwrathPose138
+.4byte sPoliwrathPose139
+.4byte sPoliwrathPose140
+.4byte sPoliwrathPose141
+.4byte sPoliwrathPose142
+.4byte sPoliwrathPose143
+.4byte sPoliwrathPose144
+.4byte sPoliwrathPose145
+.4byte sPoliwrathPose146
+.4byte sPoliwrathPose147
+.4byte sPoliwrathPose148
+.4byte sPoliwrathPose149
+.4byte sPoliwrathPose150
+.4byte sPoliwrathPose151
+.4byte sPoliwrathPose152
+.4byte sPoliwrathPose153
+.4byte sPoliwrathPose154
+.4byte sPoliwrathPose155
+.4byte sPoliwrathPose156
+.4byte sPoliwrathPose157
+.4byte sPoliwrathPose158
+.4byte sPoliwrathPose159
+.4byte sPoliwrathPose160
+.4byte sPoliwrathPose161
+.4byte sPoliwrathPose162
+.4byte sPoliwrathPose163
+.4byte sPoliwrathPose164
+.4byte sPoliwrathPose165
+.4byte sPoliwrathPose166
+.4byte sPoliwrathPose167
+.4byte sPoliwrathPose168
+.4byte sPoliwrathPose169
+.4byte sPoliwrathPose170
+.4byte sPoliwrathPose171
+.4byte sPoliwrathPose172
+.4byte sPoliwrathPose173
+.4byte sPoliwrathPose174
+.4byte sPoliwrathPose175
+.4byte sPoliwrathPose176
+.4byte sPoliwrathPose177
+.4byte sPoliwrathPose178
+.4byte sPoliwrathPose179
+.4byte sPoliwrathPose180
+.4byte sPoliwrathPose181
+.4byte sPoliwrathPose182
+.4byte sPoliwrathPose183
+.4byte sPoliwrathPose184
+.4byte sPoliwrathPose185
+.4byte sPoliwrathPose186
+.4byte sPoliwrathPose187
+.4byte sPoliwrathPose188
+.4byte sPoliwrathPose189
+.4byte sPoliwrathPose190
+.4byte sPoliwrathPose191
+.4byte sPoliwrathPose192
+.4byte sPoliwrathPose193
+.4byte sPoliwrathPose194
+sAxPositionsPoliwrath:
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte    2,  -12, 	  -9,   -5, 	  12,   -9, 	   2,   -9
+.2byte   -2,  -12, 	 -12,   -9, 	  10,   -4, 	  -1,   -9
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    2,  -13, 	 -10,   -9, 	  12,   -9, 	   2,  -10
+.2byte    3,  -13, 	  -4,   -4, 	   9,  -14, 	   2,  -10
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    6,  -13, 	  10,  -14, 	  -1,   -4, 	  -2,  -10
+.2byte    6,  -14, 	   2,  -12, 	   9,   -6, 	   0,  -10
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    5,  -16, 	  -2,  -16, 	   9,   -5, 	   0,  -12
+.2byte    1,  -17, 	 -11,   -9, 	  15,  -11, 	  -1,  -12
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte   -1,  -17, 	   9,  -17, 	 -13,  -10, 	   0,  -12
+.2byte    1,  -17, 	  13,  -10, 	  -9,  -17, 	   0,  -12
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte   -6,  -16, 	   1,  -16, 	 -10,   -5, 	  -1,  -12
+.2byte   -2,  -17, 	  10,   -9, 	 -16,  -11, 	   0,  -12
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -7,  -13, 	 -11,  -14, 	   0,   -4, 	   1,  -10
+.2byte   -7,  -14, 	  -3,  -12, 	 -10,   -6, 	  -1,  -10
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -2,  -13, 	 -12,   -9, 	  10,   -8, 	   0,  -10
+.2byte   -3,  -13, 	  -9,  -15, 	   4,   -3, 	   1,  -10
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte    2,  -12, 	  -9,   -5, 	  12,   -9, 	   2,   -9
+.2byte   -2,  -12, 	 -12,   -9, 	  10,   -4, 	  -1,   -9
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    2,  -13, 	 -10,   -9, 	  12,   -9, 	   2,  -10
+.2byte    3,  -13, 	  -4,   -4, 	   9,  -14, 	   2,  -10
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    6,  -13, 	  10,  -14, 	  -1,   -4, 	  -2,  -10
+.2byte    6,  -14, 	   2,  -12, 	   9,   -6, 	   0,  -10
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    5,  -16, 	  -2,  -16, 	   9,   -5, 	   0,  -12
+.2byte    1,  -17, 	 -11,   -9, 	  15,  -11, 	  -1,  -12
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte   -1,  -17, 	   9,  -17, 	 -13,  -10, 	   0,  -12
+.2byte    1,  -17, 	  13,  -10, 	  -9,  -17, 	   0,  -12
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte   -6,  -16, 	   1,  -16, 	 -10,   -5, 	  -1,  -12
+.2byte   -2,  -17, 	  10,   -9, 	 -16,  -11, 	   0,  -12
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -7,  -13, 	 -11,  -14, 	   0,   -4, 	   1,  -10
+.2byte   -7,  -14, 	  -3,  -12, 	 -10,   -6, 	  -1,  -10
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -2,  -13, 	 -12,   -9, 	  10,   -8, 	   0,  -10
+.2byte   -3,  -13, 	  -9,  -15, 	   4,   -3, 	   1,  -10
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte    2,  -12, 	  -9,   -5, 	  12,   -9, 	   2,   -9
+.2byte   -2,  -12, 	 -12,   -9, 	  10,   -4, 	  -1,   -9
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    2,  -13, 	 -10,   -9, 	  12,   -9, 	   2,  -10
+.2byte    3,  -13, 	  -4,   -4, 	   9,  -14, 	   2,  -10
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    6,  -13, 	  10,  -14, 	  -1,   -4, 	  -2,  -10
+.2byte    6,  -14, 	   2,  -12, 	   9,   -6, 	   0,  -10
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    5,  -16, 	  -2,  -16, 	   9,   -5, 	   0,  -12
+.2byte    1,  -17, 	 -11,   -9, 	  15,  -11, 	  -1,  -12
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte   -1,  -17, 	   9,  -17, 	 -13,  -10, 	   0,  -12
+.2byte    1,  -17, 	  13,  -10, 	  -9,  -17, 	   0,  -12
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte   -6,  -16, 	   1,  -16, 	 -10,   -5, 	  -1,  -12
+.2byte   -2,  -17, 	  10,   -9, 	 -16,  -11, 	   0,  -12
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -7,  -13, 	 -11,  -14, 	   0,   -4, 	   1,  -10
+.2byte   -7,  -14, 	  -3,  -12, 	 -10,   -6, 	  -1,  -10
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -2,  -13, 	 -12,   -9, 	  10,   -8, 	   0,  -10
+.2byte   -3,  -13, 	  -9,  -15, 	   4,   -3, 	   1,  -10
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte    0,  -15, 	 -10,  -27, 	  10,  -27, 	   0,  -13
+.2byte    0,  -11, 	 -16,  -20, 	  16,  -20, 	   0,   -9
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    1,  -16, 	  -8,  -26, 	   6,  -31, 	   0,  -13
+.2byte    2,  -13, 	 -12,  -16, 	  11,  -25, 	   1,  -10
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    5,  -16, 	   0,  -29, 	  -3,  -23, 	   0,  -12
+.2byte    5,  -13, 	   2,  -24, 	  -4,  -10, 	   0,   -9
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    3,  -18, 	  -9,  -29, 	   9,  -24, 	   0,  -13
+.2byte    3,  -15, 	 -10,  -23, 	  12,  -15, 	  -1,  -11
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte    0,  -18, 	  11,  -27, 	 -11,  -27, 	   0,  -14
+.2byte    0,  -16, 	  16,  -20, 	 -16,  -20, 	   0,  -11
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte   -4,  -18, 	   8,  -29, 	 -10,  -24, 	  -1,  -13
+.2byte   -4,  -15, 	   9,  -23, 	 -13,  -15, 	   0,  -11
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -6,  -16, 	  -1,  -29, 	   2,  -23, 	  -1,  -12
+.2byte   -6,  -13, 	  -3,  -24, 	   3,  -10, 	  -1,   -9
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -1,  -16, 	  -6,  -31, 	   8,  -26, 	   1,  -13
+.2byte   -2,  -13, 	 -11,  -25, 	  12,  -16, 	   0,  -10
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte    1,  -13, 	  -4,   -7, 	  13,  -26, 	   1,  -11
+.2byte   -1,  -13, 	 -13,  -26, 	   4,   -7, 	  -1,  -11
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    1,  -13, 	 -12,  -24, 	   6,   -8, 	   0,  -10
+.2byte    3,  -15, 	  10,  -30, 	   1,   -8, 	   1,  -12
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    6,  -14, 	  10,  -10, 	  -3,  -21, 	   0,  -10
+.2byte    6,  -16, 	  -2,  -28, 	   9,   -7, 	  -1,  -12
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    4,  -15, 	   3,  -13, 	  11,  -22, 	   1,  -12
+.2byte    1,  -17, 	  -9,  -29, 	  10,  -14, 	  -2,  -13
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte   -1,  -17, 	   3,  -14, 	 -12,  -26, 	  -1,  -13
+.2byte    2,  -17, 	  12,  -26, 	  -2,  -14, 	   2,  -13
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte   -5,  -15, 	  -4,  -13, 	 -12,  -22, 	  -2,  -12
+.2byte   -2,  -17, 	   8,  -29, 	 -11,  -14, 	   1,  -13
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -7,  -14, 	 -11,  -10, 	   2,  -21, 	  -1,  -10
+.2byte   -7,  -16, 	   1,  -28, 	 -10,   -7, 	   0,  -12
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -1,  -13, 	  -6,   -8, 	  12,  -24, 	   1,  -10
+.2byte   -3,  -15, 	 -10,  -30, 	  -1,   -8, 	  -1,  -12
+.2byte    6,  -14, 	   0,  -10, 	  -3,    1, 	   1,   -7
+.2byte    6,  -13, 	   0,   -9, 	  -2,    2, 	   1,   -6
+.2byte    2,  -16, 	 -11,  -22, 	  13,  -13, 	   2,  -12
+.2byte   -1,  -15, 	  -4,  -12, 	  10,  -25, 	   0,  -13
+.2byte    0,  -16, 	   5,  -28, 	   4,  -10, 	  -4,  -11
+.2byte    2,  -14, 	   3,  -26, 	  11,  -12, 	  -2,   -9
+.2byte   -3,  -14, 	   4,  -25, 	 -13,  -15, 	   0,  -10
+.2byte   -3,  -14, 	  -4,  -26, 	 -12,  -12, 	   1,   -9
+.2byte   -1,  -16, 	  -6,  -28, 	  -5,  -10, 	   3,  -11
+.2byte    0,  -15, 	 -11,  -25, 	   3,  -12, 	   2,  -12
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    0,  -11, 	 -16,  -20, 	  16,  -20, 	   0,   -9
+.2byte   -1,  -12, 	 -10,  -24, 	  13,  -15, 	   1,   -9
+.2byte   -5,  -13, 	  -2,  -24, 	   4,  -10, 	   0,   -9
+.2byte   -4,  -15, 	   9,  -23, 	 -13,  -15, 	   0,  -11
+.2byte    0,  -16, 	  16,  -20, 	 -16,  -20, 	   0,  -11
+.2byte    3,  -15, 	 -10,  -23, 	  12,  -15, 	  -1,  -11
+.2byte    4,  -13, 	   1,  -24, 	  -5,  -10, 	  -1,   -9
+.2byte    1,  -13, 	 -13,  -16, 	  10,  -25, 	   0,  -10
+.2byte    0,  -11, 	 -16,  -20, 	  16,  -20, 	   0,   -9
+.2byte    1,  -13, 	 -13,  -16, 	  10,  -25, 	   0,  -10
+.2byte    4,  -13, 	   1,  -24, 	  -5,  -10, 	  -1,   -9
+.2byte    3,  -15, 	 -10,  -23, 	  12,  -15, 	  -1,  -11
+.2byte    0,  -16, 	  16,  -20, 	 -16,  -20, 	   0,  -11
+.2byte   -4,  -15, 	   9,  -23, 	 -13,  -15, 	   0,  -11
+.2byte   -5,  -13, 	  -2,  -24, 	   4,  -10, 	   0,   -9
+.2byte   -1,  -12, 	 -10,  -24, 	  13,  -15, 	   1,   -9
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte    0,  -15, 	 -10,  -27, 	  10,  -27, 	   0,  -13
+.2byte    0,  -11, 	 -16,  -20, 	  16,  -20, 	   0,   -9
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    1,  -16, 	  -8,  -26, 	   6,  -31, 	   0,  -13
+.2byte    2,  -13, 	 -12,  -16, 	  11,  -25, 	   1,  -10
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    5,  -16, 	   0,  -29, 	  -3,  -23, 	   0,  -12
+.2byte    5,  -13, 	   2,  -24, 	  -4,  -10, 	   0,   -9
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    3,  -18, 	  -9,  -29, 	   9,  -24, 	   0,  -13
+.2byte    3,  -15, 	 -10,  -23, 	  12,  -15, 	  -1,  -11
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte    0,  -18, 	  11,  -27, 	 -11,  -27, 	   0,  -14
+.2byte    0,  -16, 	  16,  -20, 	 -16,  -20, 	   0,  -11
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte   -4,  -18, 	   8,  -29, 	 -10,  -24, 	  -1,  -13
+.2byte   -4,  -15, 	   9,  -23, 	 -13,  -15, 	   0,  -11
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -6,  -16, 	  -1,  -29, 	   2,  -23, 	  -1,  -12
+.2byte   -6,  -13, 	  -3,  -24, 	   3,  -10, 	  -1,   -9
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -1,  -16, 	  -6,  -31, 	   8,  -26, 	   1,  -13
+.2byte   -2,  -13, 	 -11,  -25, 	  12,  -16, 	   0,  -10
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,   -9
+.2byte   -2,  -14, 	 -12,  -12, 	   8,   -5, 	   0,  -11
+.2byte   -6,  -15, 	  -7,  -15, 	  -6,   -5, 	   0,  -11
+.2byte   -5,  -17, 	   3,  -15, 	 -14,   -7, 	  -1,  -13
+.2byte    0,  -18, 	  13,  -14, 	 -13,  -14, 	   0,  -13
+.2byte    4,  -17, 	  -4,  -15, 	  13,   -7, 	   0,  -13
+.2byte    5,  -15, 	   6,  -15, 	   5,   -5, 	  -1,  -11
+.2byte    2,  -14, 	  -8,   -6, 	  12,  -12, 	   1,  -12
+sPoliwrathAnimTable1:
+.4byte sPoliwrathAnims_1_1
+.4byte sPoliwrathAnims_1_2
+.4byte sPoliwrathAnims_1_3
+.4byte sPoliwrathAnims_1_4
+.4byte sPoliwrathAnims_1_5
+.4byte sPoliwrathAnims_1_6
+.4byte sPoliwrathAnims_1_7
+.4byte sPoliwrathAnims_1_8
+sPoliwrathAnimTable2:
+.4byte sPoliwrathAnims_2_1
+.4byte sPoliwrathAnims_2_2
+.4byte sPoliwrathAnims_2_3
+.4byte sPoliwrathAnims_2_4
+.4byte sPoliwrathAnims_2_5
+.4byte sPoliwrathAnims_2_6
+.4byte sPoliwrathAnims_2_7
+.4byte sPoliwrathAnims_2_8
+sPoliwrathAnimTable3:
+.4byte sPoliwrathAnims_3_1
+.4byte sPoliwrathAnims_3_2
+.4byte sPoliwrathAnims_3_3
+.4byte sPoliwrathAnims_3_4
+.4byte sPoliwrathAnims_3_5
+.4byte sPoliwrathAnims_3_6
+.4byte sPoliwrathAnims_3_7
+.4byte sPoliwrathAnims_3_8
+sPoliwrathAnimTable4:
+.4byte sPoliwrathAnims_4_1
+.4byte sPoliwrathAnims_4_2
+.4byte sPoliwrathAnims_4_3
+.4byte sPoliwrathAnims_4_4
+.4byte sPoliwrathAnims_4_5
+.4byte sPoliwrathAnims_4_6
+.4byte sPoliwrathAnims_4_7
+.4byte sPoliwrathAnims_4_8
+sPoliwrathAnimTable5:
+.4byte sPoliwrathAnims_5_1
+.4byte sPoliwrathAnims_5_2
+.4byte sPoliwrathAnims_5_3
+.4byte sPoliwrathAnims_5_4
+.4byte sPoliwrathAnims_5_5
+.4byte sPoliwrathAnims_5_6
+.4byte sPoliwrathAnims_5_7
+.4byte sPoliwrathAnims_5_8
+sPoliwrathAnimTable6:
+.4byte sPoliwrathAnims_6_1
+.4byte sPoliwrathAnims_6_1
+.4byte sPoliwrathAnims_6_1
+.4byte sPoliwrathAnims_6_1
+.4byte sPoliwrathAnims_6_1
+.4byte sPoliwrathAnims_6_1
+.4byte sPoliwrathAnims_6_1
+.4byte sPoliwrathAnims_6_1
+sPoliwrathAnimTable7:
+.4byte sPoliwrathAnims_7_1
+.4byte sPoliwrathAnims_7_2
+.4byte sPoliwrathAnims_7_3
+.4byte sPoliwrathAnims_7_4
+.4byte sPoliwrathAnims_7_5
+.4byte sPoliwrathAnims_7_6
+.4byte sPoliwrathAnims_7_7
+.4byte sPoliwrathAnims_7_8
+sPoliwrathAnimTable8:
+.4byte sPoliwrathAnims_8_1
+.4byte sPoliwrathAnims_8_2
+.4byte sPoliwrathAnims_8_3
+.4byte sPoliwrathAnims_8_4
+.4byte sPoliwrathAnims_8_5
+.4byte sPoliwrathAnims_8_6
+.4byte sPoliwrathAnims_8_7
+.4byte sPoliwrathAnims_8_8
+sPoliwrathAnimTable9:
+.4byte sPoliwrathAnims_9_1
+.4byte sPoliwrathAnims_9_2
+.4byte sPoliwrathAnims_9_3
+.4byte sPoliwrathAnims_9_4
+.4byte sPoliwrathAnims_9_5
+.4byte sPoliwrathAnims_9_6
+.4byte sPoliwrathAnims_9_7
+.4byte sPoliwrathAnims_9_8
+sPoliwrathAnimTable10:
+.4byte sPoliwrathAnims_10_1
+.4byte sPoliwrathAnims_10_2
+.4byte sPoliwrathAnims_10_3
+.4byte sPoliwrathAnims_10_4
+.4byte sPoliwrathAnims_10_5
+.4byte sPoliwrathAnims_10_6
+.4byte sPoliwrathAnims_10_7
+.4byte sPoliwrathAnims_10_8
+sPoliwrathAnimTable11:
+.4byte sPoliwrathAnims_11_1
+.4byte sPoliwrathAnims_11_2
+.4byte sPoliwrathAnims_11_3
+.4byte sPoliwrathAnims_11_4
+.4byte sPoliwrathAnims_11_5
+.4byte sPoliwrathAnims_11_6
+.4byte sPoliwrathAnims_11_7
+.4byte sPoliwrathAnims_11_8
+sPoliwrathAnimTable12:
+.4byte sPoliwrathAnims_12_1
+.4byte sPoliwrathAnims_12_2
+.4byte sPoliwrathAnims_12_3
+.4byte sPoliwrathAnims_12_4
+.4byte sPoliwrathAnims_12_5
+.4byte sPoliwrathAnims_12_6
+.4byte sPoliwrathAnims_12_7
+.4byte sPoliwrathAnims_12_8
+sPoliwrathAnimTable13:
+.4byte sPoliwrathAnims_13_1
+.4byte sPoliwrathAnims_13_2
+.4byte sPoliwrathAnims_13_3
+.4byte sPoliwrathAnims_13_4
+.4byte sPoliwrathAnims_13_5
+.4byte sPoliwrathAnims_13_6
+.4byte sPoliwrathAnims_13_7
+.4byte sPoliwrathAnims_13_8
+sAxAnimationsPoliwrath:
+.4byte sPoliwrathAnimTable1
+.4byte sPoliwrathAnimTable2
+.4byte sPoliwrathAnimTable3
+.4byte sPoliwrathAnimTable4
+.4byte sPoliwrathAnimTable5
+.4byte sPoliwrathAnimTable6
+.4byte sPoliwrathAnimTable7
+.4byte sPoliwrathAnimTable8
+.4byte sPoliwrathAnimTable9
+.4byte sPoliwrathAnimTable10
+.4byte sPoliwrathAnimTable11
+.4byte sPoliwrathAnimTable12
+.4byte sPoliwrathAnimTable13
+sAxSpritesPoliwrath:
+.4byte sPoliwrathSprites1
+.4byte sPoliwrathSprites2
+.4byte sPoliwrathSprites3
+.4byte sPoliwrathSprites4
+.4byte sPoliwrathSprites5
+.4byte sPoliwrathSprites6
+.4byte sPoliwrathSprites7
+.4byte sPoliwrathSprites8
+.4byte sPoliwrathSprites9
+.4byte sPoliwrathSprites10
+.4byte sPoliwrathSprites11
+.4byte sPoliwrathSprites12
+.4byte sPoliwrathSprites13
+.4byte sPoliwrathSprites14
+.4byte sPoliwrathSprites15
+.4byte sPoliwrathSprites16
+.4byte sPoliwrathSprites17
+.4byte sPoliwrathSprites18
+.4byte sPoliwrathSprites19
+.4byte sPoliwrathSprites20
+.4byte sPoliwrathSprites21
+.4byte sPoliwrathSprites22
+.4byte sPoliwrathSprites23
+.4byte sPoliwrathSprites24
+.4byte sPoliwrathSprites25
+.4byte sPoliwrathSprites26
+.4byte sPoliwrathSprites27
+.4byte sPoliwrathSprites28
+.4byte sPoliwrathSprites29
+.4byte sPoliwrathSprites30
+.4byte sPoliwrathSprites31
+.4byte sPoliwrathSprites32
+.4byte sPoliwrathSprites33
+.4byte sPoliwrathSprites34
+.4byte sPoliwrathSprites35
+.4byte sPoliwrathSprites36
+.4byte sPoliwrathSprites37
+.4byte sPoliwrathSprites38
+.4byte sPoliwrathSprites39
+.4byte sPoliwrathSprites40
+.4byte sPoliwrathSprites41
+.4byte sPoliwrathSprites42
+.4byte sPoliwrathSprites43
+.4byte sPoliwrathSprites44
+.4byte sPoliwrathSprites45
+.4byte sPoliwrathSprites46
+.4byte sPoliwrathSprites47
+.4byte sPoliwrathSprites48
+.4byte sPoliwrathSprites49
+.4byte sPoliwrathSprites50
+.4byte sPoliwrathSprites51
+.4byte sPoliwrathSprites52
+.4byte sPoliwrathSprites53
+.4byte sPoliwrathSprites54
+.4byte sPoliwrathSprites55
+.4byte sPoliwrathSprites56
+.4byte sPoliwrathSprites57
+.4byte sPoliwrathSprites58
+.4byte sPoliwrathSprites59
+.4byte sPoliwrathSprites60
+.4byte sPoliwrathSprites61
+.4byte sPoliwrathSprites62
+.4byte sPoliwrathSprites63
+.4byte sPoliwrathSprites64
+.4byte sPoliwrathSprites65
+.4byte sPoliwrathSprites66
+.4byte sPoliwrathSprites67
+.4byte sPoliwrathSprites68
+.4byte sPoliwrathSprites69
+.4byte sPoliwrathSprites70
+.4byte sPoliwrathSprites71
+.4byte sPoliwrathSprites72
+.4byte sPoliwrathSprites73
+.4byte sPoliwrathSprites74
+.4byte sPoliwrathSprites75
+.4byte sPoliwrathSprites76
+.4byte sPoliwrathSprites77
+.4byte sPoliwrathSprites78
+.4byte sPoliwrathSprites79
+.4byte sPoliwrathSprites80
+.4byte sPoliwrathSprites81
+.4byte sPoliwrathSprites82
+.4byte sPoliwrathSprites83
+sAxMainPoliwrath:
+ax_main sAxPosesPoliwrath, sAxAnimationsPoliwrath, 13, sAxSpritesPoliwrath, sAxPositionsPoliwrath

--- a/data/ax/ponyta.inc
+++ b/data/ax/ponyta.inc
@@ -1,0 +1,2949 @@
+.global gAxPonyta
+gAxPonyta:
+ax_siro sAxMainPonyta
+sPonytaPose1:
+ax_pose 0, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose2:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose3:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose6:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose7:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose8:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose9:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose10:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose11:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose13:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose14:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose15:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose19:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose20:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose21:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose25:
+ax_pose 0, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose26:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose27:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose28:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose29:
+ax_pose 16, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose30:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose31:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose32:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose33:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose34:
+ax_pose 18, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose35:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose36:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose37:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose38:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose39:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose40:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose41:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose42:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose43:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose44:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose45:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose46:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose47:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose48:
+ax_pose 23, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose49:
+ax_pose 24, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose50:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose51:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose52:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose53:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose54:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose55:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose56:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose57:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose58:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose59:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose60:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose61:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose62:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose63:
+ax_pose 17, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose64:
+ax_pose 18, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose65:
+ax_pose 0, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose66:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose67:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose68:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose69:
+ax_pose 16, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose70:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose71:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose72:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose73:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose74:
+ax_pose 18, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose75:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose76:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose77:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose78:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose79:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose80:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose81:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose82:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose83:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose84:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose85:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose86:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose87:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose88:
+ax_pose 23, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose89:
+ax_pose 24, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose90:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose91:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose92:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose93:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose94:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose95:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose96:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose97:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose98:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose99:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose100:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose101:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose102:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose103:
+ax_pose 17, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose104:
+ax_pose 18, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose105:
+ax_pose 0, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose106:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose107:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose108:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose109:
+ax_pose 16, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose110:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose111:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose112:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose113:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose114:
+ax_pose 18, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose115:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose116:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose117:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose118:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose119:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose120:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose121:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose122:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose123:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose124:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose125:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose126:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose127:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose128:
+ax_pose 23, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose129:
+ax_pose 24, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose130:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose131:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose132:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose133:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose134:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose135:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose136:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose137:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose138:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose139:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose140:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose141:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose142:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose143:
+ax_pose 17, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose144:
+ax_pose 18, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose145:
+ax_pose 0, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose146:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose147:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose148:
+ax_pose 16, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose149:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose150:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose151:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose152:
+ax_pose 18, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose153:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose154:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose155:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose156:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose157:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose158:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose159:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose160:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose161:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose162:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose163:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose164:
+ax_pose 24, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose165:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose166:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose167:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose168:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose169:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose170:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose171:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose172:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose173:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose174:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose175:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose176:
+ax_pose 18, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose177:
+ax_pose 25, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose178:
+ax_pose 26, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose179:
+ax_pose 27, 0x01e5, 0x80f7, 0x0c00
+ax_pose_terminator
+sPonytaPose180:
+ax_pose 28, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose181:
+ax_pose 29, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sPonytaPose182:
+ax_pose 30, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sPonytaPose183:
+ax_pose 31, 0x81e5, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose184:
+ax_pose 30, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sPonytaPose185:
+ax_pose 29, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sPonytaPose186:
+ax_pose 28, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose187:
+ax_pose 0, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose188:
+ax_pose 1, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose189:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose190:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose191:
+ax_pose 16, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose192:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose193:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose194:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose195:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose196:
+ax_pose 18, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose197:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose198:
+ax_pose 7, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose199:
+ax_pose 8, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose200:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose201:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose202:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose203:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose204:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose205:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose206:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose207:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose208:
+ax_pose 13, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose209:
+ax_pose 14, 0x81e6, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose210:
+ax_pose 23, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose211:
+ax_pose 24, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose212:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose213:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose214:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose215:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose216:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose217:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose218:
+ax_pose 7, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose219:
+ax_pose 8, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose220:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose221:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose222:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose223:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose224:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose225:
+ax_pose 17, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose226:
+ax_pose 18, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose227:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose228:
+ax_pose 17, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose229:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose230:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose231:
+ax_pose 23, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose232:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose233:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose234:
+ax_pose 17, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose235:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose236:
+ax_pose 17, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose237:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose238:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose239:
+ax_pose 23, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose240:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose241:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose242:
+ax_pose 17, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose243:
+ax_pose 0, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose244:
+ax_pose 16, 0x81e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose245:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose246:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose247:
+ax_pose 18, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose248:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose249:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose250:
+ax_pose 20, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose251:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose252:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose253:
+ax_pose 22, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose254:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose255:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose256:
+ax_pose 24, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose257:
+ax_pose 23, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose258:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose259:
+ax_pose 22, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose260:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose261:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose262:
+ax_pose 20, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose263:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose264:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose265:
+ax_pose 18, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose266:
+ax_pose 17, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose267:
+ax_pose 15, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose268:
+ax_pose 17, 0x01ed, 0x80f3, 0x0c00
+ax_pose_terminator
+sPonytaPose269:
+ax_pose 19, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose270:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose271:
+ax_pose 23, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose272:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose273:
+ax_pose 19, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose274:
+ax_pose 17, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose275:
+ax_pose 0, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose276:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose277:
+ax_pose 6, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sPonytaPose278:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sPonytaPose279:
+ax_pose 12, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sPonytaPose280:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sPonytaPose281:
+ax_pose 6, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sPonytaPose282:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+.align 2
+sPonytaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_2_1:
+ax_anim 2, 0, 28, 0, -1, 0, -1,
+ax_anim 6, 0, 28, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPonytaAnims_2_2:
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 6, 0, 33, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 32, 19, 19, 19, 19,
+ax_anim 2, 1, 32, 20, 18, 20, 18,
+ax_anim 2, 0, 32, 19, 19, 19, 19,
+ax_anim 2, 0, 32, 20, 18, 20, 18,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sPonytaAnims_2_3:
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 6, 0, 38, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 1, 37, 18, 1, 18, 1,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 37, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sPonytaAnims_2_4:
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 6, 0, 43, -2, 2, -2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, 5, -6, 5, -6,
+ax_anim 1, 0, 41, 11, -13, 11, -13,
+ax_anim 2, 0, 42, 18, -21, 18, -21,
+ax_anim 2, 1, 42, 19, -20, 19, -20,
+ax_anim 2, 0, 42, 18, -21, 18, -21,
+ax_anim 2, 0, 42, 19, -20, 19, -20,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sPonytaAnims_2_5:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 6, 0, 48, 0, 2, 0, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, -4,
+ax_anim 1, 0, 46, 0, -11, 0, -11,
+ax_anim 2, 0, 47, 0, -17, 0, -17,
+ax_anim 2, 1, 47, 1, -17, 1, -17,
+ax_anim 2, 0, 47, 0, -17, 0, -17,
+ax_anim 2, 0, 47, 1, -17, 1, -17,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sPonytaAnims_2_6:
+ax_anim 2, 0, 53, 1, 1, 1, 1,
+ax_anim 6, 0, 53, 2, 2, 2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 50, -5, -6, -5, -6,
+ax_anim 1, 0, 51, -11, -13, -11, -13,
+ax_anim 2, 0, 52, -18, -21, -18, -21,
+ax_anim 2, 1, 52, -19, -20, -19, -20,
+ax_anim 2, 0, 52, -18, -21, -18, -21,
+ax_anim 2, 0, 52, -19, -20, -19, -20,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sPonytaAnims_2_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 6, 0, 58, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 56, -10, 0, -10, 0,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 1, 57, -18, 1, -18, 1,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 0, 57, -18, 1, -18, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sPonytaAnims_2_8:
+ax_anim 2, 0, 63, 1, -1, 1, -1,
+ax_anim 6, 0, 63, 2, -2, 2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 61, -10, 10, -10, 10,
+ax_anim 2, 0, 62, -19, 19, -19, 19,
+ax_anim 2, 1, 62, -20, 18, -20, 18,
+ax_anim 2, 0, 62, -19, 19, -19, 19,
+ax_anim 2, 0, 62, -20, 18, -20, 18,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPonytaAnims_3_1:
+ax_anim 2, 0, 68, 0, -1, 0, -1,
+ax_anim 6, 0, 68, 0, -2, 0, -2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 1, 67, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 67, 1, 17, 1, 17,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sPonytaAnims_3_2:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 6, 0, 73, -2, -2, -2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, 4, 4, 4,
+ax_anim 1, 0, 71, 10, 10, 10, 10,
+ax_anim 2, 0, 72, 19, 19, 19, 19,
+ax_anim 2, 1, 72, 20, 18, 20, 18,
+ax_anim 2, 0, 72, 19, 19, 19, 19,
+ax_anim 2, 0, 72, 20, 18, 20, 18,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sPonytaAnims_3_3:
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 6, 0, 78, -2, 0, -2, 0,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 4, 0, 4, 0,
+ax_anim 1, 0, 76, 10, 0, 10, 0,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 1, 77, 18, 1, 18, 1,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 0, 77, 18, 1, 18, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sPonytaAnims_3_4:
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 6, 0, 83, -2, 2, -2, 2,
+ax_anim 1, 0, 81, 0, -1, 0, -1,
+ax_anim 1, 2, 80, 5, -6, 5, -6,
+ax_anim 1, 0, 81, 11, -13, 11, -13,
+ax_anim 2, 0, 82, 18, -21, 18, -21,
+ax_anim 2, 1, 82, 19, -20, 19, -20,
+ax_anim 2, 0, 82, 18, -21, 18, -21,
+ax_anim 2, 0, 82, 19, -20, 19, -20,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sPonytaAnims_3_5:
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 6, 0, 88, 0, 2, 0, 2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, 0, -4, 0, -4,
+ax_anim 1, 0, 86, 0, -11, 0, -11,
+ax_anim 2, 0, 87, 0, -17, 0, -17,
+ax_anim 2, 1, 87, 1, -17, 1, -17,
+ax_anim 2, 0, 87, 0, -17, 0, -17,
+ax_anim 2, 0, 87, 1, -17, 1, -17,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sPonytaAnims_3_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 6, 0, 93, 2, 2, 2, 2,
+ax_anim 1, 0, 91, 0, -1, 0, -1,
+ax_anim 1, 2, 90, -5, -6, -5, -6,
+ax_anim 1, 0, 91, -11, -13, -11, -13,
+ax_anim 2, 0, 92, -18, -21, -18, -21,
+ax_anim 2, 1, 92, -19, -20, -19, -20,
+ax_anim 2, 0, 92, -18, -21, -18, -21,
+ax_anim 2, 0, 92, -19, -20, -19, -20,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sPonytaAnims_3_7:
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 6, 0, 98, 2, 0, 2, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 95, -4, 0, -4, 0,
+ax_anim 1, 0, 96, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 1, 97, -18, 1, -18, 1,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 0, 97, -18, 1, -18, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sPonytaAnims_3_8:
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 6, 0, 103, 2, -2, 2, -2,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 100, -4, 4, -4, 4,
+ax_anim 1, 0, 101, -10, 10, -10, 10,
+ax_anim 2, 0, 102, -19, 19, -19, 19,
+ax_anim 2, 1, 102, -20, 18, -20, 18,
+ax_anim 2, 0, 102, -19, 19, -19, 19,
+ax_anim 2, 0, 102, -20, 18, -20, 18,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPonytaAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 108, 0, -3, 0, -3,
+ax_anim 6, 2, 108, 0, -4, 0, -4,
+ax_anim 1, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 1, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sPonytaAnims_4_2:
+ax_anim 2, 0, 110, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -3, -3, -3,
+ax_anim 6, 2, 113, -4, -4, -4, -4,
+ax_anim 1, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 1, 112, 5, 3, 5, 3,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 0, 112, 5, 3, 5, 3,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 0, 112, 5, 3, 5, 3,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim_terminator
+sPonytaAnims_4_3:
+ax_anim 2, 0, 115, -2, 0, -2, 0,
+ax_anim 2, 0, 118, -3, 0, -3, 0,
+ax_anim 6, 2, 118, -4, 0, -4, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 1, 117, 5, 1, 5, 1,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 117, 5, 1, 5, 1,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 117, 5, 1, 5, 1,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sPonytaAnims_4_4:
+ax_anim 2, 0, 120, -2, 2, -2, 2,
+ax_anim 2, 0, 123, -3, 3, -3, 3,
+ax_anim 6, 2, 123, -4, 4, -4, 4,
+ax_anim 1, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 1, 122, 5, -3, 5, -3,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 0, 122, 5, -3, 5, -3,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 0, 122, 5, -3, 5, -3,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim_terminator
+sPonytaAnims_4_5:
+ax_anim 2, 0, 125, 0, 2, 0, 2,
+ax_anim 2, 0, 128, 0, 3, 0, 3,
+ax_anim 6, 2, 128, 0, 4, 0, 4,
+ax_anim 1, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 1, 127, 1, -4, 1, -4,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 0, 127, 1, -4, 1, -4,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 0, 127, 1, -4, 1, -4,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sPonytaAnims_4_6:
+ax_anim 2, 0, 130, 2, 2, 2, 2,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 6, 2, 133, 4, 4, 4, 4,
+ax_anim 1, 0, 129, 1, 1, 1, 1,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 1, 132, -5, -3, -5, -3,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 0, 132, -5, -3, -5, -3,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 0, 132, -5, -3, -5, -3,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim_terminator
+sPonytaAnims_4_7:
+ax_anim 2, 0, 135, 2, 0, 2, 0,
+ax_anim 2, 0, 138, 3, 0, 3, 0,
+ax_anim 6, 2, 138, 4, 0, 4, 0,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 1, 137, -5, 1, -5, 1,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 137, -5, 1, -5, 1,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 137, -5, 1, -5, 1,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim_terminator
+sPonytaAnims_4_8:
+ax_anim 2, 0, 140, 2, -2, 2, -2,
+ax_anim 2, 0, 143, 3, -3, 3, -3,
+ax_anim 6, 2, 143, 4, -4, 4, -4,
+ax_anim 1, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 1, 142, -5, 3, -5, 3,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 0, 142, -5, 3, -5, 3,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 0, 142, -5, 3, -5, 3,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sPonytaAnims_5_1:
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_5_2:
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 1, -1, 1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, -1, 1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, -1, 1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, -1, 1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_5_3:
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 2, 155, 0, -1, 0, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_5_4:
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 2, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, 1, 1, 1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_5_5:
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 2, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, 0, 1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_5_6:
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 2, 167, -1, 1, -1, 1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 1, -1, 1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 1, -1, 1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 1, -1, 1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_5_7:
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, -1, 0, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, -1, 0, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, -1, 0, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, -1, 0, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_5_8:
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_7_1:
+ax_anim 2, 0, 178, 0, -2, 0, -2,
+ax_anim 8, 0, 178, 0, -3, 0, -3,
+ax_anim_terminator
+sPonytaAnims_7_2:
+ax_anim 2, 0, 179, -2, -2, -2, -2,
+ax_anim 8, 0, 179, -3, -3, -3, -3,
+ax_anim_terminator
+sPonytaAnims_7_3:
+ax_anim 2, 0, 180, -2, 0, -2, 0,
+ax_anim 8, 0, 180, -3, 0, -3, 0,
+ax_anim_terminator
+sPonytaAnims_7_4:
+ax_anim 2, 0, 181, -2, 2, -2, 2,
+ax_anim 8, 0, 181, -3, 3, -3, 3,
+ax_anim_terminator
+sPonytaAnims_7_5:
+ax_anim 2, 0, 182, 0, 2, 0, 2,
+ax_anim 8, 0, 182, 0, 3, 0, 3,
+ax_anim_terminator
+sPonytaAnims_7_6:
+ax_anim 2, 0, 183, 2, 2, 2, 2,
+ax_anim 8, 0, 183, 3, 3, 3, 3,
+ax_anim_terminator
+sPonytaAnims_7_7:
+ax_anim 2, 0, 184, 2, 0, 2, 0,
+ax_anim 8, 0, 184, 3, 0, 3, 0,
+ax_anim_terminator
+sPonytaAnims_7_8:
+ax_anim 2, 0, 185, 2, -2, 2, -2,
+ax_anim 8, 0, 185, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPonytaAnims_8_1:
+ax_anim 60, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -1, 0, -1, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_8_2:
+ax_anim 60, 0, 191, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_8_3:
+ax_anim 60, 0, 196, 0, 0, 0, 0,
+ax_anim 10, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, 0, -1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, 0, -1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, 0, -1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, 0, -1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, 0, -1, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, 0, -1, 0,
+ax_anim 10, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_8_4:
+ax_anim 60, 0, 201, 0, 0, 0, 0,
+ax_anim 10, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, 0, -1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, 0, -1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, 0, -1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, 0, -1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, 0, -1, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, 0, -1, 0,
+ax_anim 10, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_8_5:
+ax_anim 60, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_8_6:
+ax_anim 60, 0, 211, 0, 0, 0, 0,
+ax_anim 10, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 10, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_8_7:
+ax_anim 60, 0, 216, 0, 0, 0, 0,
+ax_anim 10, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, 0, -1, 0,
+ax_anim 10, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_8_8:
+ax_anim 60, 0, 221, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, 0, -1, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, 0, -1, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_9_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 6, 3, 6, 3,
+ax_anim 2, 0, 228, 8, 9, 8, 9,
+ax_anim 2, 0, 229, 7, 15, 7, 15,
+ax_anim 3, 0, 230, 0, 18, 0, 18,
+ax_anim 2, 3, 231, -7, 15, -7, 15,
+ax_anim 2, 0, 232, -8, 9, -8, 9,
+ax_anim 1, 0, 233, -6, 3, -6, 3,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_9_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 8, 0, 8, 0,
+ax_anim 2, 0, 227, 17, 3, 17, 3,
+ax_anim 2, 0, 228, 19, 10, 19, 10,
+ax_anim 3, 0, 229, 20, 18, 20, 18,
+ax_anim 2, 3, 230, 11, 19, 11, 19,
+ax_anim 2, 0, 231, 3, 15, 3, 15,
+ax_anim 1, 0, 232, 0, 7, 0, 7,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_9_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 3, -5, 3, -5,
+ax_anim 2, 0, 226, 11, -6, 11, -6,
+ax_anim 2, 0, 227, 17, -6, 17, -6,
+ax_anim 3, 0, 228, 20, -2, 20, -2,
+ax_anim 2, 3, 229, 18, 3, 18, 3,
+ax_anim 2, 0, 230, 12, 5, 12, 5,
+ax_anim 1, 0, 231, 4, 3, 4, 3,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_9_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, -1, -8, -1, -8,
+ax_anim 2, 0, 233, 4, -16, 4, -16,
+ax_anim 2, 0, 226, 12, -21, 12, -21,
+ax_anim 3, 0, 227, 20, -23, 20, -23,
+ax_anim 2, 3, 228, 20, -15, 20, -15,
+ax_anim 2, 0, 229, 19, -7, 19, -7,
+ax_anim 1, 0, 230, 9, -2, 9, -2,
+ax_anim 1, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_9_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, -8, -4, -8, -4,
+ax_anim 2, 0, 232, -9, -12, -9, -12,
+ax_anim 2, 0, 233, -7, -18, -7, -18,
+ax_anim 3, 0, 226, 0, -22, 0, -22,
+ax_anim 2, 3, 227, 7, -18, 7, -18,
+ax_anim 2, 0, 228, 9, -10, 9, -10,
+ax_anim 1, 0, 229, 8, -4, 8, -4,
+ax_anim 1, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_9_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 1, -8, 1, -8,
+ax_anim 2, 0, 227, -4, -16, -4, -16,
+ax_anim 2, 0, 226, -12, -21, -12, -21,
+ax_anim 3, 0, 233, -20, -23, -20, -23,
+ax_anim 2, 3, 232, -20, -15, -20, -15,
+ax_anim 2, 0, 231, -19, -7, -19, -7,
+ax_anim 1, 0, 230, -9, -2, -9, -2,
+ax_anim 1, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_9_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 227, -3, -5, -3, -5,
+ax_anim 2, 0, 226, -11, -6, -11, -6,
+ax_anim 2, 0, 233, -17, -6, -17, -6,
+ax_anim 3, 0, 232, -20, -2, -20, -2,
+ax_anim 2, 3, 231, -18, 3, -18, 3,
+ax_anim 2, 0, 230, -12, 5, -12, 5,
+ax_anim 1, 0, 229, -4, 3, -4, 3,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_9_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 226, -8, 0, -8, 0,
+ax_anim 2, 0, 233, -17, 3, -17, 3,
+ax_anim 2, 0, 232, -19, 10, -19, 10,
+ax_anim 3, 0, 231, -20, 18, -20, 18,
+ax_anim 2, 3, 230, -11, 19, -11, 19,
+ax_anim 2, 0, 229, -3, 15, -3, 15,
+ax_anim 1, 0, 228, 0, 7, 0, 7,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_10_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 3, 0, 234, 13, 0, 13, 0,
+ax_anim 3, 0, 234, -13, 0, -13, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_10_2:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 3, 0, 235, 13, -13, 13, -13,
+ax_anim 3, 0, 235, -13, 13, -13, 13,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_10_3:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 3, 0, 236, 0, -13, 0, -13,
+ax_anim 3, 0, 236, 0, 13, 0, 13,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_10_4:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 3, 0, 237, -13, -13, -13, -13,
+ax_anim 3, 0, 237, 13, 13, 13, 13,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_10_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 3, 0, 238, 13, 0, 13, 0,
+ax_anim 3, 0, 238, -13, 0, -13, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_10_6:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 3, 0, 239, 13, -13, 13, -13,
+ax_anim 3, 0, 239, -13, 13, -13, 13,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_10_7:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 3, 0, 240, 0, -13, 0, -13,
+ax_anim 3, 0, 240, 0, 13, 0, 13,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_10_8:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 3, 0, 241, -13, -13, -13, -13,
+ax_anim 3, 0, 241, 13, 13, 13, 13,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_11_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 243, 0, -20, 0, 0,
+ax_anim 4, 0, 243, 0, -21, 0, 0,
+ax_anim 4, 0, 244, 0, -25, 0, 0,
+ax_anim 3, 0, 244, 0, -22, 0, 0,
+ax_anim 2, 0, 244, 0, -18, 0, 0,
+ax_anim 1, 0, 244, 0, -12, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_11_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 246, 0, -20, 0, 0,
+ax_anim 4, 0, 246, 0, -21, 0, 0,
+ax_anim 4, 0, 247, 0, -24, 0, 0,
+ax_anim 3, 0, 247, 0, -22, 0, 0,
+ax_anim 2, 0, 247, 0, -18, 0, 0,
+ax_anim 1, 0, 247, 0, -12, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_11_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 0, -10, 0, 0,
+ax_anim 2, 0, 249, 0, -16, 0, 0,
+ax_anim 3, 0, 249, 0, -20, 0, 0,
+ax_anim 4, 0, 249, 0, -21, 0, 0,
+ax_anim 4, 0, 250, 0, -25, 0, 0,
+ax_anim 3, 0, 250, 0, -22, 0, 0,
+ax_anim 2, 0, 250, 0, -18, 0, 0,
+ax_anim 1, 0, 250, 0, -12, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_11_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -10, 0, 0,
+ax_anim 2, 0, 252, 0, -16, 0, 0,
+ax_anim 3, 0, 252, 0, -20, 0, 0,
+ax_anim 4, 0, 252, 0, -21, 0, 0,
+ax_anim 4, 0, 253, 0, -23, 0, 0,
+ax_anim 3, 0, 253, 0, -21, 0, 0,
+ax_anim 2, 0, 253, 0, -17, 0, 0,
+ax_anim 1, 0, 253, 0, -11, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_11_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, -10, 0, 0,
+ax_anim 2, 0, 255, 0, -16, 0, 0,
+ax_anim 3, 0, 255, 0, -20, 0, 0,
+ax_anim 4, 0, 255, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 256, 0, -22, 0, 0,
+ax_anim 2, 0, 256, 0, -18, 0, 0,
+ax_anim 1, 0, 256, 0, -12, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_11_6:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -16, 0, 0,
+ax_anim 3, 0, 258, 0, -20, 0, 0,
+ax_anim 4, 0, 258, 0, -21, 0, 0,
+ax_anim 4, 0, 259, 0, -23, 0, 0,
+ax_anim 3, 0, 259, 0, -21, 0, 0,
+ax_anim 2, 0, 259, 0, -17, 0, 0,
+ax_anim 1, 0, 259, 0, -11, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_11_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 261, 0, -10, 0, 0,
+ax_anim 2, 0, 261, 0, -16, 0, 0,
+ax_anim 3, 0, 261, 0, -20, 0, 0,
+ax_anim 4, 0, 261, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -25, 0, 0,
+ax_anim 3, 0, 262, 0, -22, 0, 0,
+ax_anim 2, 0, 262, 0, -18, 0, 0,
+ax_anim 1, 0, 262, 0, -12, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_11_8:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 264, 0, -10, 0, 0,
+ax_anim 2, 0, 264, 0, -16, 0, 0,
+ax_anim 3, 0, 264, 0, -20, 0, 0,
+ax_anim 4, 0, 264, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -24, 0, 0,
+ax_anim 3, 0, 265, 0, -22, 0, 0,
+ax_anim 2, 0, 265, 0, -18, 0, 0,
+ax_anim 1, 0, 265, 0, -12, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_12_1:
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 1, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_12_2:
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 1, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_12_3:
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 1, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_12_4:
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 1, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_12_5:
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 1, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_12_6:
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 1, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_12_7:
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 1, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_12_8:
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 1, 267, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPonytaAnims_13_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_13_2:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_13_3:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_13_4:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_13_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_13_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_13_7:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaAnims_13_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sPonytaGfx1:
+.incbin "baserom.gba", 0x855894, 0x100
+sPonytaSprites1:
+ax_sprite sPonytaGfx1, 0x100
+ax_sprite_terminator
+sPonytaGfx2:
+.incbin "baserom.gba", 0x8559A4, 0x100
+sPonytaSprites2:
+ax_sprite sPonytaGfx2, 0x100
+ax_sprite_terminator
+sPonytaGfx3:
+.incbin "baserom.gba", 0x855AB4, 0x100
+sPonytaSprites3:
+ax_sprite sPonytaGfx3, 0x100
+ax_sprite_terminator
+sPonytaGfx4:
+.incbin "baserom.gba", 0x855BC4, 0x200
+sPonytaSprites4:
+ax_sprite sPonytaGfx4, 0x200
+ax_sprite_terminator
+sPonytaGfx5:
+.incbin "baserom.gba", 0x855DD4, 0x200
+sPonytaSprites5:
+ax_sprite sPonytaGfx5, 0x200
+ax_sprite_terminator
+sPonytaGfx6:
+.incbin "baserom.gba", 0x855FE4, 0x200
+sPonytaSprites6:
+ax_sprite sPonytaGfx6, 0x200
+ax_sprite_terminator
+sPonytaGfx7:
+.incbin "baserom.gba", 0x8561F4, 0x200
+sPonytaSprites7:
+ax_sprite sPonytaGfx7, 0x200
+ax_sprite_terminator
+sPonytaGfx8:
+.incbin "baserom.gba", 0x856404, 0x200
+sPonytaSprites8:
+ax_sprite sPonytaGfx8, 0x200
+ax_sprite_terminator
+sPonytaGfx9:
+.incbin "baserom.gba", 0x856614, 0x200
+sPonytaSprites9:
+ax_sprite sPonytaGfx9, 0x200
+ax_sprite_terminator
+sPonytaGfx10:
+.incbin "baserom.gba", 0x856824, 0x200
+sPonytaSprites10:
+ax_sprite sPonytaGfx10, 0x200
+ax_sprite_terminator
+sPonytaGfx11:
+.incbin "baserom.gba", 0x856A34, 0x200
+sPonytaSprites11:
+ax_sprite sPonytaGfx11, 0x200
+ax_sprite_terminator
+sPonytaGfx12:
+.incbin "baserom.gba", 0x856C44, 0x200
+sPonytaSprites12:
+ax_sprite sPonytaGfx12, 0x200
+ax_sprite_terminator
+sPonytaGfx13:
+.incbin "baserom.gba", 0x856E54, 0x100
+sPonytaSprites13:
+ax_sprite sPonytaGfx13, 0x100
+ax_sprite_terminator
+sPonytaGfx14:
+.incbin "baserom.gba", 0x856F64, 0x100
+sPonytaSprites14:
+ax_sprite sPonytaGfx14, 0x100
+ax_sprite_terminator
+sPonytaGfx15:
+.incbin "baserom.gba", 0x857074, 0x100
+sPonytaSprites15:
+ax_sprite sPonytaGfx15, 0x100
+ax_sprite_terminator
+sPonytaGfx16:
+.incbin "baserom.gba", 0x857184, 0x100
+sPonytaSprites16:
+ax_sprite sPonytaGfx16, 0x100
+ax_sprite_terminator
+sPonytaGfx17:
+.incbin "baserom.gba", 0x857294, 0xC0
+sPonytaSprites17:
+ax_sprite sPonytaGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPonytaGfx18:
+.incbin "baserom.gba", 0x85736C, 0x60
+sPonytaGfx18_1:
+.incbin "baserom.gba", 0x8573CC, 0x60
+sPonytaGfx18_2:
+.incbin "baserom.gba", 0x85742C, 0x60
+sPonytaSprites18:
+ax_sprite sPonytaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPonytaGfx19:
+.incbin "baserom.gba", 0x8574C4, 0x60
+sPonytaGfx19_1:
+.incbin "baserom.gba", 0x857524, 0x60
+sPonytaGfx19_2:
+.incbin "baserom.gba", 0x857584, 0x60
+sPonytaSprites19:
+ax_sprite sPonytaGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPonytaGfx20:
+.incbin "baserom.gba", 0x85761C, 0xE0
+sPonytaGfx20_1:
+.incbin "baserom.gba", 0x8576FC, 0x60
+sPonytaSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx20, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx20_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPonytaGfx21:
+.incbin "baserom.gba", 0x85778C, 0x40
+sPonytaGfx21_1:
+.incbin "baserom.gba", 0x8577CC, 0x60
+sPonytaGfx21_2:
+.incbin "baserom.gba", 0x85782C, 0x60
+sPonytaGfx21_3:
+.incbin "baserom.gba", 0x85788C, 0x20
+sPonytaSprites21:
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPonytaGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPonytaGfx21_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPonytaGfx22:
+.incbin "baserom.gba", 0x8578FC, 0x40
+sPonytaGfx22_1:
+.incbin "baserom.gba", 0x85793C, 0x60
+sPonytaGfx22_2:
+.incbin "baserom.gba", 0x85799C, 0x60
+sPonytaSprites22:
+ax_sprite sPonytaGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPonytaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPonytaGfx23:
+.incbin "baserom.gba", 0x857A34, 0x60
+sPonytaGfx23_1:
+.incbin "baserom.gba", 0x857A94, 0x60
+sPonytaGfx23_2:
+.incbin "baserom.gba", 0x857AF4, 0x80
+sPonytaGfx23_3:
+.incbin "baserom.gba", 0x857B74, 0x20
+sPonytaSprites23:
+ax_sprite sPonytaGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx23_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPonytaGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPonytaGfx24:
+.incbin "baserom.gba", 0x857BDC, 0xC0
+sPonytaSprites24:
+ax_sprite sPonytaGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPonytaGfx25:
+.incbin "baserom.gba", 0x857CB4, 0xC0
+sPonytaSprites25:
+ax_sprite sPonytaGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPonytaGfx26:
+.incbin "baserom.gba", 0x857D8C, 0x200
+sPonytaSprites26:
+ax_sprite sPonytaGfx26, 0x200
+ax_sprite_terminator
+sPonytaGfx27:
+.incbin "baserom.gba", 0x857F9C, 0x200
+sPonytaSprites27:
+ax_sprite sPonytaGfx27, 0x200
+ax_sprite_terminator
+sPonytaGfx28:
+.incbin "baserom.gba", 0x8581AC, 0x200
+sPonytaSprites28:
+ax_sprite sPonytaGfx28, 0x200
+ax_sprite_terminator
+sPonytaGfx29:
+.incbin "baserom.gba", 0x8583BC, 0x200
+sPonytaSprites29:
+ax_sprite sPonytaGfx29, 0x200
+ax_sprite_terminator
+sPonytaGfx30:
+.incbin "baserom.gba", 0x8585CC, 0x200
+sPonytaSprites30:
+ax_sprite sPonytaGfx30, 0x200
+ax_sprite_terminator
+sPonytaGfx31:
+.incbin "baserom.gba", 0x8587DC, 0x200
+sPonytaSprites31:
+ax_sprite sPonytaGfx31, 0x200
+ax_sprite_terminator
+sPonytaGfx32:
+.incbin "baserom.gba", 0x8589EC, 0x100
+sPonytaSprites32:
+ax_sprite sPonytaGfx32, 0x100
+ax_sprite_terminator
+sAxPosesPonyta:
+.4byte sPonytaPose1
+.4byte sPonytaPose2
+.4byte sPonytaPose3
+.4byte sPonytaPose4
+.4byte sPonytaPose5
+.4byte sPonytaPose6
+.4byte sPonytaPose7
+.4byte sPonytaPose8
+.4byte sPonytaPose9
+.4byte sPonytaPose10
+.4byte sPonytaPose11
+.4byte sPonytaPose12
+.4byte sPonytaPose13
+.4byte sPonytaPose14
+.4byte sPonytaPose15
+.4byte sPonytaPose16
+.4byte sPonytaPose17
+.4byte sPonytaPose18
+.4byte sPonytaPose19
+.4byte sPonytaPose20
+.4byte sPonytaPose21
+.4byte sPonytaPose22
+.4byte sPonytaPose23
+.4byte sPonytaPose24
+.4byte sPonytaPose25
+.4byte sPonytaPose26
+.4byte sPonytaPose27
+.4byte sPonytaPose28
+.4byte sPonytaPose29
+.4byte sPonytaPose30
+.4byte sPonytaPose31
+.4byte sPonytaPose32
+.4byte sPonytaPose33
+.4byte sPonytaPose34
+.4byte sPonytaPose35
+.4byte sPonytaPose36
+.4byte sPonytaPose37
+.4byte sPonytaPose38
+.4byte sPonytaPose39
+.4byte sPonytaPose40
+.4byte sPonytaPose41
+.4byte sPonytaPose42
+.4byte sPonytaPose43
+.4byte sPonytaPose44
+.4byte sPonytaPose45
+.4byte sPonytaPose46
+.4byte sPonytaPose47
+.4byte sPonytaPose48
+.4byte sPonytaPose49
+.4byte sPonytaPose50
+.4byte sPonytaPose51
+.4byte sPonytaPose52
+.4byte sPonytaPose53
+.4byte sPonytaPose54
+.4byte sPonytaPose55
+.4byte sPonytaPose56
+.4byte sPonytaPose57
+.4byte sPonytaPose58
+.4byte sPonytaPose59
+.4byte sPonytaPose60
+.4byte sPonytaPose61
+.4byte sPonytaPose62
+.4byte sPonytaPose63
+.4byte sPonytaPose64
+.4byte sPonytaPose65
+.4byte sPonytaPose66
+.4byte sPonytaPose67
+.4byte sPonytaPose68
+.4byte sPonytaPose69
+.4byte sPonytaPose70
+.4byte sPonytaPose71
+.4byte sPonytaPose72
+.4byte sPonytaPose73
+.4byte sPonytaPose74
+.4byte sPonytaPose75
+.4byte sPonytaPose76
+.4byte sPonytaPose77
+.4byte sPonytaPose78
+.4byte sPonytaPose79
+.4byte sPonytaPose80
+.4byte sPonytaPose81
+.4byte sPonytaPose82
+.4byte sPonytaPose83
+.4byte sPonytaPose84
+.4byte sPonytaPose85
+.4byte sPonytaPose86
+.4byte sPonytaPose87
+.4byte sPonytaPose88
+.4byte sPonytaPose89
+.4byte sPonytaPose90
+.4byte sPonytaPose91
+.4byte sPonytaPose92
+.4byte sPonytaPose93
+.4byte sPonytaPose94
+.4byte sPonytaPose95
+.4byte sPonytaPose96
+.4byte sPonytaPose97
+.4byte sPonytaPose98
+.4byte sPonytaPose99
+.4byte sPonytaPose100
+.4byte sPonytaPose101
+.4byte sPonytaPose102
+.4byte sPonytaPose103
+.4byte sPonytaPose104
+.4byte sPonytaPose105
+.4byte sPonytaPose106
+.4byte sPonytaPose107
+.4byte sPonytaPose108
+.4byte sPonytaPose109
+.4byte sPonytaPose110
+.4byte sPonytaPose111
+.4byte sPonytaPose112
+.4byte sPonytaPose113
+.4byte sPonytaPose114
+.4byte sPonytaPose115
+.4byte sPonytaPose116
+.4byte sPonytaPose117
+.4byte sPonytaPose118
+.4byte sPonytaPose119
+.4byte sPonytaPose120
+.4byte sPonytaPose121
+.4byte sPonytaPose122
+.4byte sPonytaPose123
+.4byte sPonytaPose124
+.4byte sPonytaPose125
+.4byte sPonytaPose126
+.4byte sPonytaPose127
+.4byte sPonytaPose128
+.4byte sPonytaPose129
+.4byte sPonytaPose130
+.4byte sPonytaPose131
+.4byte sPonytaPose132
+.4byte sPonytaPose133
+.4byte sPonytaPose134
+.4byte sPonytaPose135
+.4byte sPonytaPose136
+.4byte sPonytaPose137
+.4byte sPonytaPose138
+.4byte sPonytaPose139
+.4byte sPonytaPose140
+.4byte sPonytaPose141
+.4byte sPonytaPose142
+.4byte sPonytaPose143
+.4byte sPonytaPose144
+.4byte sPonytaPose145
+.4byte sPonytaPose146
+.4byte sPonytaPose147
+.4byte sPonytaPose148
+.4byte sPonytaPose149
+.4byte sPonytaPose150
+.4byte sPonytaPose151
+.4byte sPonytaPose152
+.4byte sPonytaPose153
+.4byte sPonytaPose154
+.4byte sPonytaPose155
+.4byte sPonytaPose156
+.4byte sPonytaPose157
+.4byte sPonytaPose158
+.4byte sPonytaPose159
+.4byte sPonytaPose160
+.4byte sPonytaPose161
+.4byte sPonytaPose162
+.4byte sPonytaPose163
+.4byte sPonytaPose164
+.4byte sPonytaPose165
+.4byte sPonytaPose166
+.4byte sPonytaPose167
+.4byte sPonytaPose168
+.4byte sPonytaPose169
+.4byte sPonytaPose170
+.4byte sPonytaPose171
+.4byte sPonytaPose172
+.4byte sPonytaPose173
+.4byte sPonytaPose174
+.4byte sPonytaPose175
+.4byte sPonytaPose176
+.4byte sPonytaPose177
+.4byte sPonytaPose178
+.4byte sPonytaPose179
+.4byte sPonytaPose180
+.4byte sPonytaPose181
+.4byte sPonytaPose182
+.4byte sPonytaPose183
+.4byte sPonytaPose184
+.4byte sPonytaPose185
+.4byte sPonytaPose186
+.4byte sPonytaPose187
+.4byte sPonytaPose188
+.4byte sPonytaPose189
+.4byte sPonytaPose190
+.4byte sPonytaPose191
+.4byte sPonytaPose192
+.4byte sPonytaPose193
+.4byte sPonytaPose194
+.4byte sPonytaPose195
+.4byte sPonytaPose196
+.4byte sPonytaPose197
+.4byte sPonytaPose198
+.4byte sPonytaPose199
+.4byte sPonytaPose200
+.4byte sPonytaPose201
+.4byte sPonytaPose202
+.4byte sPonytaPose203
+.4byte sPonytaPose204
+.4byte sPonytaPose205
+.4byte sPonytaPose206
+.4byte sPonytaPose207
+.4byte sPonytaPose208
+.4byte sPonytaPose209
+.4byte sPonytaPose210
+.4byte sPonytaPose211
+.4byte sPonytaPose212
+.4byte sPonytaPose213
+.4byte sPonytaPose214
+.4byte sPonytaPose215
+.4byte sPonytaPose216
+.4byte sPonytaPose217
+.4byte sPonytaPose218
+.4byte sPonytaPose219
+.4byte sPonytaPose220
+.4byte sPonytaPose221
+.4byte sPonytaPose222
+.4byte sPonytaPose223
+.4byte sPonytaPose224
+.4byte sPonytaPose225
+.4byte sPonytaPose226
+.4byte sPonytaPose227
+.4byte sPonytaPose228
+.4byte sPonytaPose229
+.4byte sPonytaPose230
+.4byte sPonytaPose231
+.4byte sPonytaPose232
+.4byte sPonytaPose233
+.4byte sPonytaPose234
+.4byte sPonytaPose235
+.4byte sPonytaPose236
+.4byte sPonytaPose237
+.4byte sPonytaPose238
+.4byte sPonytaPose239
+.4byte sPonytaPose240
+.4byte sPonytaPose241
+.4byte sPonytaPose242
+.4byte sPonytaPose243
+.4byte sPonytaPose244
+.4byte sPonytaPose245
+.4byte sPonytaPose246
+.4byte sPonytaPose247
+.4byte sPonytaPose248
+.4byte sPonytaPose249
+.4byte sPonytaPose250
+.4byte sPonytaPose251
+.4byte sPonytaPose252
+.4byte sPonytaPose253
+.4byte sPonytaPose254
+.4byte sPonytaPose255
+.4byte sPonytaPose256
+.4byte sPonytaPose257
+.4byte sPonytaPose258
+.4byte sPonytaPose259
+.4byte sPonytaPose260
+.4byte sPonytaPose261
+.4byte sPonytaPose262
+.4byte sPonytaPose263
+.4byte sPonytaPose264
+.4byte sPonytaPose265
+.4byte sPonytaPose266
+.4byte sPonytaPose267
+.4byte sPonytaPose268
+.4byte sPonytaPose269
+.4byte sPonytaPose270
+.4byte sPonytaPose271
+.4byte sPonytaPose272
+.4byte sPonytaPose273
+.4byte sPonytaPose274
+.4byte sPonytaPose275
+.4byte sPonytaPose276
+.4byte sPonytaPose277
+.4byte sPonytaPose278
+.4byte sPonytaPose279
+.4byte sPonytaPose280
+.4byte sPonytaPose281
+.4byte sPonytaPose282
+sAxPositionsPonyta:
+.2byte   -1,   -3, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,   -4, 	  -2,    4, 	   1,    0, 	  -1,   -7
+.2byte   -1,   -4, 	  -3,    0, 	   0,    4, 	  -1,   -7
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,    1, 	   0,    1, 	   0,   -6
+.2byte    7,   -4, 	   2,    1, 	   4,    3, 	   0,   -5
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte   11,   -7, 	   8,   -2, 	   2,   -1, 	   0,   -7
+.2byte   11,   -7, 	   1,   -2, 	   7,   -1, 	   0,   -7
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte    9,  -10, 	   3,   -5, 	   3,   -1, 	   1,   -7
+.2byte    9,  -10, 	   0,   -4, 	   8,   -3, 	   1,   -8
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   0,   -9, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   0,   -5, 	  -2,   -9, 	  -1,  -10
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte  -10,  -10, 	  -4,   -5, 	  -4,   -1, 	  -2,   -7
+.2byte  -10,  -10, 	  -1,   -4, 	  -9,   -3, 	  -2,   -8
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte  -12,   -7, 	  -9,   -2, 	  -3,   -1, 	  -1,   -7
+.2byte  -12,   -7, 	  -2,   -2, 	  -8,   -1, 	  -1,   -7
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,    1, 	  -1,    1, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,    1, 	  -5,    3, 	  -1,   -5
+.2byte   -1,   -4, 	  -3,    1, 	   1,    1, 	  -1,   -7
+.2byte   -1,   -4, 	  -2,    4, 	   1,    0, 	  -1,   -7
+.2byte   -1,   -4, 	  -3,    0, 	   0,    4, 	  -1,   -7
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -1,  -13, 	  -3,   -7, 	   1,   -7, 	  -1,  -11
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,    1, 	   0,    1, 	   0,   -6
+.2byte    7,   -4, 	   2,    1, 	   4,    3, 	   0,   -5
+.2byte    4,   -6, 	   5,   -2, 	   0,    1, 	  -1,   -7
+.2byte    5,  -14, 	   2,   -7, 	   0,   -6, 	  -2,   -9
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte   11,   -7, 	   8,   -2, 	   2,   -1, 	   0,   -7
+.2byte   11,   -7, 	   1,   -2, 	   7,   -1, 	   0,   -7
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    5,  -17, 	   3,   -8, 	   2,   -7, 	  -3,   -9
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte    9,  -10, 	   3,   -5, 	   3,   -1, 	   1,   -7
+.2byte    9,  -10, 	   0,   -4, 	   8,   -3, 	   1,   -8
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    5,  -17, 	   1,   -9, 	   3,   -8, 	  -2,   -9
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   0,   -9, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   0,   -5, 	  -2,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -20, 	   1,  -12, 	  -3,  -12, 	  -1,  -10
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte  -10,  -10, 	  -4,   -5, 	  -4,   -1, 	  -2,   -7
+.2byte  -10,  -10, 	  -1,   -4, 	  -9,   -3, 	  -2,   -8
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -6,  -17, 	  -2,   -9, 	  -4,   -8, 	   1,   -9
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte  -12,   -7, 	  -9,   -2, 	  -3,   -1, 	  -1,   -7
+.2byte  -12,   -7, 	  -2,   -2, 	  -8,   -1, 	  -1,   -7
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -6,  -17, 	  -4,   -8, 	  -3,   -7, 	   2,   -9
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,    1, 	  -1,    1, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,    1, 	  -5,    3, 	  -1,   -5
+.2byte   -6,   -5, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -6,  -14, 	  -3,   -7, 	  -1,   -6, 	   1,   -9
+.2byte   -1,   -4, 	  -3,    1, 	   1,    1, 	  -1,   -7
+.2byte   -1,   -4, 	  -2,    4, 	   1,    0, 	  -1,   -7
+.2byte   -1,   -4, 	  -3,    0, 	   0,    4, 	  -1,   -7
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -1,  -13, 	  -3,   -7, 	   1,   -7, 	  -1,  -11
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,    1, 	   0,    1, 	   0,   -6
+.2byte    7,   -4, 	   2,    1, 	   4,    3, 	   0,   -5
+.2byte    4,   -6, 	   5,   -2, 	   0,    1, 	  -1,   -7
+.2byte    5,  -14, 	   2,   -7, 	   0,   -6, 	  -2,   -9
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte   11,   -7, 	   8,   -2, 	   2,   -1, 	   0,   -7
+.2byte   11,   -7, 	   1,   -2, 	   7,   -1, 	   0,   -7
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    5,  -17, 	   3,   -8, 	   2,   -7, 	  -3,   -9
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte    9,  -10, 	   3,   -5, 	   3,   -1, 	   1,   -7
+.2byte    9,  -10, 	   0,   -4, 	   8,   -3, 	   1,   -8
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    5,  -17, 	   1,   -9, 	   3,   -8, 	  -2,   -9
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   0,   -9, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   0,   -5, 	  -2,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -20, 	   1,  -12, 	  -3,  -12, 	  -1,  -10
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte  -10,  -10, 	  -4,   -5, 	  -4,   -1, 	  -2,   -7
+.2byte  -10,  -10, 	  -1,   -4, 	  -9,   -3, 	  -2,   -8
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -6,  -17, 	  -2,   -9, 	  -4,   -8, 	   1,   -9
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte  -12,   -7, 	  -9,   -2, 	  -3,   -1, 	  -1,   -7
+.2byte  -12,   -7, 	  -2,   -2, 	  -8,   -1, 	  -1,   -7
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -6,  -17, 	  -4,   -8, 	  -3,   -7, 	   2,   -9
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,    1, 	  -1,    1, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,    1, 	  -5,    3, 	  -1,   -5
+.2byte   -6,   -5, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -6,  -14, 	  -3,   -7, 	  -1,   -6, 	   1,   -9
+.2byte   -1,   -4, 	  -3,    1, 	   1,    1, 	  -1,   -7
+.2byte   -1,   -4, 	  -2,    4, 	   1,    0, 	  -1,   -7
+.2byte   -1,   -4, 	  -3,    0, 	   0,    4, 	  -1,   -7
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -1,  -13, 	  -3,   -7, 	   1,   -7, 	  -1,  -11
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,    1, 	   0,    1, 	   0,   -6
+.2byte    7,   -4, 	   2,    1, 	   4,    3, 	   0,   -5
+.2byte    4,   -6, 	   5,   -2, 	   0,    1, 	  -1,   -7
+.2byte    5,  -14, 	   2,   -7, 	   0,   -6, 	  -2,   -9
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte   11,   -7, 	   8,   -2, 	   2,   -1, 	   0,   -7
+.2byte   11,   -7, 	   1,   -2, 	   7,   -1, 	   0,   -7
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    5,  -17, 	   3,   -8, 	   2,   -7, 	  -3,   -9
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte    9,  -10, 	   3,   -5, 	   3,   -1, 	   1,   -7
+.2byte    9,  -10, 	   0,   -4, 	   8,   -3, 	   1,   -8
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    5,  -17, 	   1,   -9, 	   3,   -8, 	  -2,   -9
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   0,   -9, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   0,   -5, 	  -2,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -20, 	   1,  -12, 	  -3,  -12, 	  -1,  -10
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte  -10,  -10, 	  -4,   -5, 	  -4,   -1, 	  -2,   -7
+.2byte  -10,  -10, 	  -1,   -4, 	  -9,   -3, 	  -2,   -8
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -6,  -17, 	  -2,   -9, 	  -4,   -8, 	   1,   -9
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte  -12,   -7, 	  -9,   -2, 	  -3,   -1, 	  -1,   -7
+.2byte  -12,   -7, 	  -2,   -2, 	  -8,   -1, 	  -1,   -7
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -6,  -17, 	  -4,   -8, 	  -3,   -7, 	   2,   -9
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,    1, 	  -1,    1, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,    1, 	  -5,    3, 	  -1,   -5
+.2byte   -6,   -5, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -6,  -14, 	  -3,   -7, 	  -1,   -6, 	   1,   -9
+.2byte   -1,   -3, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,   -4, 	  -2,    4, 	   1,    0, 	  -1,   -7
+.2byte   -1,   -4, 	  -3,    0, 	   0,    4, 	  -1,   -7
+.2byte   -1,  -13, 	  -3,   -7, 	   1,   -7, 	  -1,  -11
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,    1, 	   0,    1, 	   0,   -6
+.2byte    7,   -4, 	   2,    1, 	   4,    3, 	   0,   -5
+.2byte    5,  -14, 	   2,   -7, 	   0,   -6, 	  -2,   -9
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte   11,   -7, 	   8,   -2, 	   2,   -1, 	   0,   -7
+.2byte   11,   -7, 	   1,   -2, 	   7,   -1, 	   0,   -7
+.2byte    5,  -17, 	   3,   -8, 	   2,   -7, 	  -3,   -9
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte    9,  -10, 	   3,   -5, 	   3,   -1, 	   1,   -7
+.2byte    9,  -10, 	   0,   -4, 	   8,   -3, 	   1,   -8
+.2byte    5,  -17, 	   1,   -9, 	   3,   -8, 	  -2,   -9
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   0,   -9, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   0,   -5, 	  -2,   -9, 	  -1,  -10
+.2byte   -1,  -20, 	   1,  -12, 	  -3,  -12, 	  -1,  -10
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte  -10,  -10, 	  -4,   -5, 	  -4,   -1, 	  -2,   -7
+.2byte  -10,  -10, 	  -1,   -4, 	  -9,   -3, 	  -2,   -8
+.2byte   -6,  -17, 	  -2,   -9, 	  -4,   -8, 	   1,   -9
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte  -12,   -7, 	  -9,   -2, 	  -3,   -1, 	  -1,   -7
+.2byte  -12,   -7, 	  -2,   -2, 	  -8,   -1, 	  -1,   -7
+.2byte   -6,  -17, 	  -4,   -8, 	  -3,   -7, 	   2,   -9
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,    1, 	  -1,    1, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,    1, 	  -5,    3, 	  -1,   -5
+.2byte   -6,  -14, 	  -3,   -7, 	  -1,   -6, 	   1,   -9
+.2byte   -8,   -2, 	  -4,   -1, 	  -3,    0, 	  -1,   -4
+.2byte   -8,   -1, 	  -4,   -1, 	  -3,    0, 	  -1,   -4
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte    7,   -1, 	   4,   -2, 	  -2,    1, 	  -1,   -7
+.2byte    9,   -3, 	   6,   -2, 	   1,    0, 	   0,   -6
+.2byte    7,   -7, 	   0,   -4, 	   5,   -1, 	   1,   -8
+.2byte    0,   -8, 	   4,   -5, 	  -4,   -5, 	   0,   -6
+.2byte   -7,   -7, 	   0,   -4, 	  -5,   -1, 	  -1,   -8
+.2byte  -10,   -3, 	  -7,   -2, 	  -2,    0, 	  -1,   -6
+.2byte   -8,   -1, 	  -5,   -2, 	   1,    1, 	   0,   -7
+.2byte   -1,   -4, 	  -3,    1, 	   1,    1, 	  -1,   -7
+.2byte   -1,   -4, 	  -2,    4, 	   1,    0, 	  -1,   -7
+.2byte   -1,   -4, 	  -3,    0, 	   0,    4, 	  -1,   -7
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -1,  -13, 	  -3,   -7, 	   1,   -7, 	  -1,  -11
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,    1, 	   0,    1, 	   0,   -6
+.2byte    7,   -4, 	   2,    1, 	   4,    3, 	   0,   -5
+.2byte    4,   -6, 	   5,   -2, 	   0,    1, 	  -1,   -7
+.2byte    5,  -14, 	   2,   -7, 	   0,   -6, 	  -2,   -9
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte   11,   -7, 	   8,   -2, 	   2,   -1, 	   0,   -7
+.2byte   11,   -7, 	   1,   -2, 	   7,   -1, 	   0,   -7
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    5,  -17, 	   3,   -8, 	   2,   -7, 	  -3,   -9
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte    9,  -10, 	   3,   -5, 	   3,   -1, 	   1,   -7
+.2byte    9,  -10, 	   0,   -4, 	   8,   -3, 	   1,   -8
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    5,  -17, 	   1,   -9, 	   3,   -8, 	  -2,   -9
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	   0,   -9, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   0,   -5, 	  -2,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -20, 	   1,  -12, 	  -3,  -12, 	  -1,  -10
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte  -10,  -10, 	  -4,   -5, 	  -4,   -1, 	  -2,   -7
+.2byte  -10,  -10, 	  -1,   -4, 	  -9,   -3, 	  -2,   -8
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -6,  -17, 	  -2,   -9, 	  -4,   -8, 	   1,   -9
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte  -12,   -7, 	  -9,   -2, 	  -3,   -1, 	  -1,   -7
+.2byte  -12,   -7, 	  -2,   -2, 	  -8,   -1, 	  -1,   -7
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -6,  -17, 	  -4,   -8, 	  -3,   -7, 	   2,   -9
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,    1, 	  -1,    1, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,    1, 	  -5,    3, 	  -1,   -5
+.2byte   -6,   -5, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -6,  -14, 	  -3,   -7, 	  -1,   -6, 	   1,   -9
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -6,   -4, 	  -7,    0, 	  -2,    3, 	  -1,   -5
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -1,  -16, 	   2,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    4,   -5, 	   5,   -1, 	   0,    2, 	  -1,   -6
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte    4,   -5, 	   5,   -1, 	   0,    2, 	  -1,   -6
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte   -1,  -16, 	   2,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -6,   -4, 	  -7,    0, 	  -2,    3, 	  -1,   -5
+.2byte   -1,   -4, 	  -3,    1, 	   1,    1, 	  -1,   -7
+.2byte   -1,  -13, 	  -3,   -7, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+.2byte    5,  -14, 	   2,   -7, 	   0,   -6, 	  -2,   -9
+.2byte    4,   -6, 	   5,   -2, 	   0,    1, 	  -1,   -7
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte    5,  -17, 	   3,   -8, 	   2,   -7, 	  -3,   -9
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte    5,  -17, 	   1,   -9, 	   3,   -8, 	  -2,   -9
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -20, 	   1,  -12, 	  -3,  -12, 	  -1,  -10
+.2byte   -1,  -17, 	   2,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte   -6,  -17, 	  -2,   -9, 	  -4,   -8, 	   1,   -9
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte   -6,  -17, 	  -4,   -8, 	  -3,   -7, 	   2,   -9
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte   -6,  -14, 	  -3,   -7, 	  -1,   -6, 	   1,   -9
+.2byte   -6,   -5, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -1,   -5, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte   -6,   -4, 	  -7,    0, 	  -2,    3, 	  -1,   -5
+.2byte   -8,   -8, 	  -7,   -4, 	  -5,    0, 	   0,   -7
+.2byte   -8,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -1,  -16, 	   2,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte    7,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -4, 	   4,    0, 	  -1,   -7
+.2byte    4,   -5, 	   5,   -1, 	   0,    2, 	  -1,   -6
+.2byte   -1,   -3, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -7,   -5, 	  -6,   -1, 	  -3,    1, 	  -1,   -7
+.2byte  -11,   -8, 	  -7,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte   -9,  -11, 	  -3,   -5, 	  -6,   -3, 	  -2,   -9
+.2byte   -1,  -13, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte    8,  -11, 	   2,   -5, 	   5,   -3, 	   1,   -9
+.2byte   10,   -8, 	   6,   -3, 	   4,   -1, 	   0,   -8
+.2byte    6,   -5, 	   5,   -1, 	   2,    1, 	   0,   -7
+sPonytaAnimTable1:
+.4byte sPonytaAnims_1_1
+.4byte sPonytaAnims_1_2
+.4byte sPonytaAnims_1_3
+.4byte sPonytaAnims_1_4
+.4byte sPonytaAnims_1_5
+.4byte sPonytaAnims_1_6
+.4byte sPonytaAnims_1_7
+.4byte sPonytaAnims_1_8
+sPonytaAnimTable2:
+.4byte sPonytaAnims_2_1
+.4byte sPonytaAnims_2_2
+.4byte sPonytaAnims_2_3
+.4byte sPonytaAnims_2_4
+.4byte sPonytaAnims_2_5
+.4byte sPonytaAnims_2_6
+.4byte sPonytaAnims_2_7
+.4byte sPonytaAnims_2_8
+sPonytaAnimTable3:
+.4byte sPonytaAnims_3_1
+.4byte sPonytaAnims_3_2
+.4byte sPonytaAnims_3_3
+.4byte sPonytaAnims_3_4
+.4byte sPonytaAnims_3_5
+.4byte sPonytaAnims_3_6
+.4byte sPonytaAnims_3_7
+.4byte sPonytaAnims_3_8
+sPonytaAnimTable4:
+.4byte sPonytaAnims_4_1
+.4byte sPonytaAnims_4_2
+.4byte sPonytaAnims_4_3
+.4byte sPonytaAnims_4_4
+.4byte sPonytaAnims_4_5
+.4byte sPonytaAnims_4_6
+.4byte sPonytaAnims_4_7
+.4byte sPonytaAnims_4_8
+sPonytaAnimTable5:
+.4byte sPonytaAnims_5_1
+.4byte sPonytaAnims_5_2
+.4byte sPonytaAnims_5_3
+.4byte sPonytaAnims_5_4
+.4byte sPonytaAnims_5_5
+.4byte sPonytaAnims_5_6
+.4byte sPonytaAnims_5_7
+.4byte sPonytaAnims_5_8
+sPonytaAnimTable6:
+.4byte sPonytaAnims_6_1
+.4byte sPonytaAnims_6_1
+.4byte sPonytaAnims_6_1
+.4byte sPonytaAnims_6_1
+.4byte sPonytaAnims_6_1
+.4byte sPonytaAnims_6_1
+.4byte sPonytaAnims_6_1
+.4byte sPonytaAnims_6_1
+sPonytaAnimTable7:
+.4byte sPonytaAnims_7_1
+.4byte sPonytaAnims_7_2
+.4byte sPonytaAnims_7_3
+.4byte sPonytaAnims_7_4
+.4byte sPonytaAnims_7_5
+.4byte sPonytaAnims_7_6
+.4byte sPonytaAnims_7_7
+.4byte sPonytaAnims_7_8
+sPonytaAnimTable8:
+.4byte sPonytaAnims_8_1
+.4byte sPonytaAnims_8_2
+.4byte sPonytaAnims_8_3
+.4byte sPonytaAnims_8_4
+.4byte sPonytaAnims_8_5
+.4byte sPonytaAnims_8_6
+.4byte sPonytaAnims_8_7
+.4byte sPonytaAnims_8_8
+sPonytaAnimTable9:
+.4byte sPonytaAnims_9_1
+.4byte sPonytaAnims_9_2
+.4byte sPonytaAnims_9_3
+.4byte sPonytaAnims_9_4
+.4byte sPonytaAnims_9_5
+.4byte sPonytaAnims_9_6
+.4byte sPonytaAnims_9_7
+.4byte sPonytaAnims_9_8
+sPonytaAnimTable10:
+.4byte sPonytaAnims_10_1
+.4byte sPonytaAnims_10_2
+.4byte sPonytaAnims_10_3
+.4byte sPonytaAnims_10_4
+.4byte sPonytaAnims_10_5
+.4byte sPonytaAnims_10_6
+.4byte sPonytaAnims_10_7
+.4byte sPonytaAnims_10_8
+sPonytaAnimTable11:
+.4byte sPonytaAnims_11_1
+.4byte sPonytaAnims_11_2
+.4byte sPonytaAnims_11_3
+.4byte sPonytaAnims_11_4
+.4byte sPonytaAnims_11_5
+.4byte sPonytaAnims_11_6
+.4byte sPonytaAnims_11_7
+.4byte sPonytaAnims_11_8
+sPonytaAnimTable12:
+.4byte sPonytaAnims_12_1
+.4byte sPonytaAnims_12_2
+.4byte sPonytaAnims_12_3
+.4byte sPonytaAnims_12_4
+.4byte sPonytaAnims_12_5
+.4byte sPonytaAnims_12_6
+.4byte sPonytaAnims_12_7
+.4byte sPonytaAnims_12_8
+sPonytaAnimTable13:
+.4byte sPonytaAnims_13_1
+.4byte sPonytaAnims_13_2
+.4byte sPonytaAnims_13_3
+.4byte sPonytaAnims_13_4
+.4byte sPonytaAnims_13_5
+.4byte sPonytaAnims_13_6
+.4byte sPonytaAnims_13_7
+.4byte sPonytaAnims_13_8
+sAxAnimationsPonyta:
+.4byte sPonytaAnimTable1
+.4byte sPonytaAnimTable2
+.4byte sPonytaAnimTable3
+.4byte sPonytaAnimTable4
+.4byte sPonytaAnimTable5
+.4byte sPonytaAnimTable6
+.4byte sPonytaAnimTable7
+.4byte sPonytaAnimTable8
+.4byte sPonytaAnimTable9
+.4byte sPonytaAnimTable10
+.4byte sPonytaAnimTable11
+.4byte sPonytaAnimTable12
+.4byte sPonytaAnimTable13
+sAxSpritesPonyta:
+.4byte sPonytaSprites1
+.4byte sPonytaSprites2
+.4byte sPonytaSprites3
+.4byte sPonytaSprites4
+.4byte sPonytaSprites5
+.4byte sPonytaSprites6
+.4byte sPonytaSprites7
+.4byte sPonytaSprites8
+.4byte sPonytaSprites9
+.4byte sPonytaSprites10
+.4byte sPonytaSprites11
+.4byte sPonytaSprites12
+.4byte sPonytaSprites13
+.4byte sPonytaSprites14
+.4byte sPonytaSprites15
+.4byte sPonytaSprites16
+.4byte sPonytaSprites17
+.4byte sPonytaSprites18
+.4byte sPonytaSprites19
+.4byte sPonytaSprites20
+.4byte sPonytaSprites21
+.4byte sPonytaSprites22
+.4byte sPonytaSprites23
+.4byte sPonytaSprites24
+.4byte sPonytaSprites25
+.4byte sPonytaSprites26
+.4byte sPonytaSprites27
+.4byte sPonytaSprites28
+.4byte sPonytaSprites29
+.4byte sPonytaSprites30
+.4byte sPonytaSprites31
+.4byte sPonytaSprites32
+sAxMainPonyta:
+ax_main sAxPosesPonyta, sAxAnimationsPonyta, 13, sAxSpritesPonyta, sAxPositionsPonyta

--- a/data/ax/poochyena.inc
+++ b/data/ax/poochyena.inc
@@ -1,0 +1,2961 @@
+.global gAxPoochyena
+gAxPoochyena:
+ax_siro sAxMainPoochyena
+sPoochyenaPose1:
+ax_pose 0, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose2:
+ax_pose 1, 0x81e7, 0x80f8, 0x5c00
+ax_pose_terminator
+sPoochyenaPose3:
+ax_pose 2, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sPoochyenaPose4:
+ax_pose 3, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose5:
+ax_pose 4, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sPoochyenaPose6:
+ax_pose 5, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sPoochyenaPose7:
+ax_pose 6, 0x01e9, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose8:
+ax_pose 7, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPoochyenaPose9:
+ax_pose 8, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sPoochyenaPose10:
+ax_pose 9, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose11:
+ax_pose 10, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sPoochyenaPose12:
+ax_pose 11, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sPoochyenaPose13:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose14:
+ax_pose 13, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sPoochyenaPose15:
+ax_pose 14, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sPoochyenaPose16:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose17:
+ax_pose 10, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sPoochyenaPose18:
+ax_pose 11, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sPoochyenaPose19:
+ax_pose 6, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose20:
+ax_pose 7, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPoochyenaPose21:
+ax_pose 8, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sPoochyenaPose22:
+ax_pose 3, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose23:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sPoochyenaPose24:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sPoochyenaPose25:
+ax_pose 0, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose26:
+ax_pose 1, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose27:
+ax_pose 2, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sPoochyenaPose28:
+ax_pose 15, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose29:
+ax_pose 16, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose30:
+ax_pose 3, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose31:
+ax_pose 4, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose32:
+ax_pose 5, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose33:
+ax_pose 17, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sPoochyenaPose34:
+ax_pose 18, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose35:
+ax_pose 6, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose36:
+ax_pose 7, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose37:
+ax_pose 8, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose38:
+ax_pose 19, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sPoochyenaPose39:
+ax_pose 20, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose40:
+ax_pose 9, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose41:
+ax_pose 10, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose42:
+ax_pose 11, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose43:
+ax_pose 21, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose44:
+ax_pose 22, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose45:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose46:
+ax_pose 13, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose47:
+ax_pose 14, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose48:
+ax_pose 23, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose49:
+ax_pose 24, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose50:
+ax_pose 9, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose51:
+ax_pose 10, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose52:
+ax_pose 11, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose53:
+ax_pose 21, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose54:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose55:
+ax_pose 6, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose56:
+ax_pose 7, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose57:
+ax_pose 8, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose58:
+ax_pose 19, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPoochyenaPose59:
+ax_pose 20, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose60:
+ax_pose 3, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose61:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose62:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose63:
+ax_pose 17, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sPoochyenaPose64:
+ax_pose 18, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose65:
+ax_pose 0, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose66:
+ax_pose 1, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose67:
+ax_pose 2, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sPoochyenaPose68:
+ax_pose 15, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose69:
+ax_pose 16, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose70:
+ax_pose 3, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose71:
+ax_pose 4, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose72:
+ax_pose 5, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose73:
+ax_pose 17, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sPoochyenaPose74:
+ax_pose 18, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose75:
+ax_pose 6, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose76:
+ax_pose 7, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose77:
+ax_pose 8, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose78:
+ax_pose 19, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sPoochyenaPose79:
+ax_pose 20, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose80:
+ax_pose 9, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose81:
+ax_pose 10, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose82:
+ax_pose 11, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose83:
+ax_pose 21, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose84:
+ax_pose 22, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose85:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose86:
+ax_pose 13, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose87:
+ax_pose 14, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose88:
+ax_pose 23, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose89:
+ax_pose 24, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose90:
+ax_pose 9, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose91:
+ax_pose 10, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose92:
+ax_pose 11, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose93:
+ax_pose 21, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose94:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose95:
+ax_pose 6, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose96:
+ax_pose 7, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose97:
+ax_pose 8, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose98:
+ax_pose 19, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPoochyenaPose99:
+ax_pose 20, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose100:
+ax_pose 3, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose101:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose102:
+ax_pose 5, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose103:
+ax_pose 17, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sPoochyenaPose104:
+ax_pose 18, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose105:
+ax_pose 0, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose106:
+ax_pose 25, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose107:
+ax_pose 26, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose108:
+ax_pose 16, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose109:
+ax_pose 27, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose110:
+ax_pose 3, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose111:
+ax_pose 28, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose112:
+ax_pose 29, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose113:
+ax_pose 18, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose114:
+ax_pose 30, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose115:
+ax_pose 6, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose116:
+ax_pose 31, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose117:
+ax_pose 32, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose118:
+ax_pose 20, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose119:
+ax_pose 33, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose120:
+ax_pose 9, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose121:
+ax_pose 34, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose122:
+ax_pose 35, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose123:
+ax_pose 22, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose124:
+ax_pose 36, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose125:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose126:
+ax_pose 37, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose127:
+ax_pose 38, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose128:
+ax_pose 24, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose129:
+ax_pose 39, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose130:
+ax_pose 9, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose131:
+ax_pose 34, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose132:
+ax_pose 35, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose133:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose134:
+ax_pose 36, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose135:
+ax_pose 6, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose136:
+ax_pose 31, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose137:
+ax_pose 32, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose138:
+ax_pose 20, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose139:
+ax_pose 33, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose140:
+ax_pose 3, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose141:
+ax_pose 28, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose142:
+ax_pose 29, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose143:
+ax_pose 18, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose144:
+ax_pose 30, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose145:
+ax_pose 25, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose146:
+ax_pose 28, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose147:
+ax_pose 31, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose148:
+ax_pose 34, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose149:
+ax_pose 37, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose150:
+ax_pose 34, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose151:
+ax_pose 31, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose152:
+ax_pose 28, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose153:
+ax_pose 40, 0x41f3, 0x80f2, 0x6c00
+ax_pose_terminator
+sPoochyenaPose154:
+ax_pose 41, 0x41f3, 0x80f2, 0x6c00
+ax_pose_terminator
+sPoochyenaPose155:
+ax_pose 42, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose156:
+ax_pose 43, 0x01e2, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose157:
+ax_pose 44, 0x01e3, 0x90e9, 0x6c00
+ax_pose_terminator
+sPoochyenaPose158:
+ax_pose 45, 0x01e5, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose159:
+ax_pose 46, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose160:
+ax_pose 45, 0x01e5, 0x80f5, 0x6c00
+ax_pose_terminator
+sPoochyenaPose161:
+ax_pose 44, 0x01e3, 0x80f7, 0x6c00
+ax_pose_terminator
+sPoochyenaPose162:
+ax_pose 43, 0x01e2, 0x80f5, 0x6c00
+ax_pose_terminator
+sPoochyenaPose163:
+ax_pose 0, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose164:
+ax_pose 25, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose165:
+ax_pose 26, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose166:
+ax_pose 16, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose167:
+ax_pose 27, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose168:
+ax_pose 3, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose169:
+ax_pose 28, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose170:
+ax_pose 29, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose171:
+ax_pose 18, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose172:
+ax_pose 30, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose173:
+ax_pose 6, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose174:
+ax_pose 31, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose175:
+ax_pose 32, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose176:
+ax_pose 20, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose177:
+ax_pose 33, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose178:
+ax_pose 9, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose179:
+ax_pose 34, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose180:
+ax_pose 35, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose181:
+ax_pose 22, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose182:
+ax_pose 36, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose183:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose184:
+ax_pose 37, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose185:
+ax_pose 38, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose186:
+ax_pose 24, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose187:
+ax_pose 39, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose188:
+ax_pose 9, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose189:
+ax_pose 34, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose190:
+ax_pose 35, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose191:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose192:
+ax_pose 36, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose193:
+ax_pose 6, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose194:
+ax_pose 31, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose195:
+ax_pose 32, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose196:
+ax_pose 20, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose197:
+ax_pose 33, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose198:
+ax_pose 3, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose199:
+ax_pose 28, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose200:
+ax_pose 29, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose201:
+ax_pose 18, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose202:
+ax_pose 30, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPoochyenaPose203:
+ax_pose 15, 0x81ea, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose204:
+ax_pose 17, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sPoochyenaPose205:
+ax_pose 19, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sPoochyenaPose206:
+ax_pose 21, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose207:
+ax_pose 23, 0x81ea, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose208:
+ax_pose 21, 0x01ea, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose209:
+ax_pose 19, 0x01ea, 0x90ef, 0x6c00
+ax_pose_terminator
+sPoochyenaPose210:
+ax_pose 17, 0x01eb, 0x90ed, 0x6c00
+ax_pose_terminator
+sPoochyenaPose211:
+ax_pose 25, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose212:
+ax_pose 28, 0x01e7, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose213:
+ax_pose 31, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose214:
+ax_pose 34, 0x01e9, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose215:
+ax_pose 37, 0x81e9, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose216:
+ax_pose 34, 0x01e9, 0x80f5, 0x6c00
+ax_pose_terminator
+sPoochyenaPose217:
+ax_pose 31, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose218:
+ax_pose 28, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose219:
+ax_pose 0, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose220:
+ax_pose 1, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose221:
+ax_pose 2, 0x01e3, 0x80f7, 0x6c00
+ax_pose_terminator
+sPoochyenaPose222:
+ax_pose 3, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose223:
+ax_pose 4, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose224:
+ax_pose 5, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose225:
+ax_pose 6, 0x01e9, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose226:
+ax_pose 7, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose227:
+ax_pose 8, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose228:
+ax_pose 9, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose229:
+ax_pose 10, 0x01e8, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose230:
+ax_pose 11, 0x01e9, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose231:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose232:
+ax_pose 13, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose233:
+ax_pose 14, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose234:
+ax_pose 9, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose235:
+ax_pose 10, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose236:
+ax_pose 11, 0x01e9, 0x80f5, 0x6c00
+ax_pose_terminator
+sPoochyenaPose237:
+ax_pose 6, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose238:
+ax_pose 7, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose239:
+ax_pose 8, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose240:
+ax_pose 3, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose241:
+ax_pose 4, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose242:
+ax_pose 5, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sPoochyenaPose243:
+ax_pose 16, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose244:
+ax_pose 18, 0x01e7, 0x80f5, 0x6c00
+ax_pose_terminator
+sPoochyenaPose245:
+ax_pose 20, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sPoochyenaPose246:
+ax_pose 22, 0x01e8, 0x80f5, 0x6c00
+ax_pose_terminator
+sPoochyenaPose247:
+ax_pose 24, 0x81e9, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose248:
+ax_pose 22, 0x01e8, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose249:
+ax_pose 20, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sPoochyenaPose250:
+ax_pose 18, 0x01e7, 0x90eb, 0x6c00
+ax_pose_terminator
+sPoochyenaPose251:
+ax_pose 0, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose252:
+ax_pose 3, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose253:
+ax_pose 6, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose254:
+ax_pose 9, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPoochyenaPose255:
+ax_pose 12, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPoochyenaPose256:
+ax_pose 9, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+sPoochyenaPose257:
+ax_pose 6, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sPoochyenaPose258:
+ax_pose 3, 0x01e7, 0x90ec, 0x6c00
+ax_pose_terminator
+.align 2
+sPoochyenaAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 1, -1, 0, 0,
+ax_anim 4, 0, 4, 2, -1, 0, 0,
+ax_anim 4, 0, 5, 1, -1, 0, 0,
+ax_anim 4, 0, 5, -1, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 1, 0, 0,
+ax_anim 4, 0, 7, 1, 0, 0, 0,
+ax_anim 4, 0, 8, 1, -1, 0, 0,
+ax_anim 4, 0, 8, 0, 1, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 1, -2, 0, 0,
+ax_anim 4, 0, 10, 2, -2, 0, 0,
+ax_anim 4, 0, 11, 1, -1, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -1, -2, 0, 0,
+ax_anim 4, 0, 16, -2, -2, 0, 0,
+ax_anim 4, 0, 17, -1, -1, 0, 0,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 1, 0, 0,
+ax_anim 4, 0, 19, -1, 0, 0, 0,
+ax_anim 4, 0, 20, -1, -1, 0, 0,
+ax_anim 4, 0, 20, 0, 1, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -1, -1, 0, 0,
+ax_anim 4, 0, 22, -2, -1, 0, 0,
+ax_anim 4, 0, 23, -1, -1, 0, 0,
+ax_anim 4, 0, 23, 1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_2_1:
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 4, 0, 24, 0, -5, 0, -5,
+ax_anim 2, 0, 27, 0, 1, 0, 1,
+ax_anim 2, 2, 27, 0, 8, 0, 8,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 1, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 0, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sPoochyenaAnims_2_2:
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -4, -4, -4, -4,
+ax_anim 4, 0, 29, -5, -5, -5, -5,
+ax_anim 2, 0, 32, 1, 0, 1, 1,
+ax_anim 2, 2, 32, 8, 3, 8, 8,
+ax_anim 2, 0, 33, 18, 19, 18, 19,
+ax_anim 2, 1, 33, 19, 18, 19, 18,
+ax_anim 2, 0, 33, 18, 19, 18, 19,
+ax_anim 2, 0, 33, 19, 18, 19, 18,
+ax_anim 2, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sPoochyenaAnims_2_3:
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -4, 0, -4, 0,
+ax_anim 4, 0, 34, -5, 0, -5, 0,
+ax_anim 2, 0, 37, 1, -2, 1, 0,
+ax_anim 2, 2, 37, 8, -4, 8, 0,
+ax_anim 2, 0, 38, 15, 0, 15, 0,
+ax_anim 2, 1, 38, 15, 1, 15, 1,
+ax_anim 2, 0, 38, 15, 0, 15, 0,
+ax_anim 2, 0, 38, 15, 1, 15, 1,
+ax_anim 2, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 4, 0, 4, 0,
+ax_anim_terminator
+sPoochyenaAnims_2_4:
+ax_anim 2, 0, 39, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -4, 4, -4, 4,
+ax_anim 4, 0, 39, -5, 5, -5, 5,
+ax_anim 2, 0, 42, 1, -7, 1, -1,
+ax_anim 2, 2, 42, 8, -15, 8, -8,
+ax_anim 2, 0, 43, 18, -19, 18, -19,
+ax_anim 2, 1, 43, 19, -18, 19, -18,
+ax_anim 2, 0, 43, 18, -19, 18, -19,
+ax_anim 2, 0, 43, 19, -18, 19, -18,
+ax_anim 2, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sPoochyenaAnims_2_5:
+ax_anim 2, 0, 44, 0, 2, 0, 2,
+ax_anim 2, 0, 44, 0, 4, 0, 4,
+ax_anim 4, 0, 44, 0, 5, 0, 5,
+ax_anim 2, 0, 47, 0, -6, 0, -4,
+ax_anim 2, 2, 47, 0, -12, 0, -10,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 1, 48, 1, -19, 1, -19,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 0, 48, 1, -19, 1, -19,
+ax_anim 2, 0, 44, 0, -10, 0, -10,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sPoochyenaAnims_2_6:
+ax_anim 2, 0, 49, 2, 2, 2, 2,
+ax_anim 2, 0, 49, 4, 4, 4, 4,
+ax_anim 4, 0, 49, 5, 5, 5, 5,
+ax_anim 2, 0, 52, -1, -7, -1, -1,
+ax_anim 2, 2, 52, -8, -15, -8, -8,
+ax_anim 2, 0, 53, -18, -19, -18, -19,
+ax_anim 2, 1, 53, -19, -18, -19, -18,
+ax_anim 2, 0, 53, -18, -19, -18, -19,
+ax_anim 2, 0, 53, -19, -18, -19, -18,
+ax_anim 2, 0, 49, -10, -10, -10, -10,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sPoochyenaAnims_2_7:
+ax_anim 2, 0, 54, 2, 0, 2, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim 4, 0, 54, 5, 0, 5, 0,
+ax_anim 2, 0, 57, -1, -2, -1, 0,
+ax_anim 2, 2, 57, -8, -4, -8, 0,
+ax_anim 2, 0, 58, -15, 0, -15, 0,
+ax_anim 2, 1, 58, -15, 1, -15, 1,
+ax_anim 2, 0, 58, -15, 0, -15, 0,
+ax_anim 2, 0, 58, -15, 1, -15, 1,
+ax_anim 2, 0, 54, -10, 0, -10, 0,
+ax_anim 2, 0, 54, -4, 0, -4, 0,
+ax_anim_terminator
+sPoochyenaAnims_2_8:
+ax_anim 2, 0, 59, 2, -2, 2, -2,
+ax_anim 2, 0, 59, 4, -4, 4, -4,
+ax_anim 4, 0, 59, 5, -5, 5, -5,
+ax_anim 2, 0, 62, -1, 0, -1, 1,
+ax_anim 2, 2, 62, -8, 3, -8, 8,
+ax_anim 2, 0, 63, -18, 19, -18, 19,
+ax_anim 2, 1, 63, -19, 18, -19, 18,
+ax_anim 2, 0, 63, -18, 19, -18, 19,
+ax_anim 2, 0, 63, -19, 18, -19, 18,
+ax_anim 2, 0, 59, -10, 10, -10, 10,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_3_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -4, 0, -4,
+ax_anim 4, 0, 64, 0, -5, 0, -5,
+ax_anim 2, 0, 67, 0, 1, 0, 1,
+ax_anim 2, 2, 67, 0, 8, 0, 8,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 1, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 0, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sPoochyenaAnims_3_2:
+ax_anim 2, 0, 69, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -4, -4, -4, -4,
+ax_anim 4, 0, 69, -5, -5, -5, -5,
+ax_anim 2, 0, 72, 1, 0, 1, 1,
+ax_anim 2, 2, 72, 8, 3, 8, 8,
+ax_anim 2, 0, 73, 18, 19, 18, 19,
+ax_anim 2, 1, 73, 19, 18, 19, 18,
+ax_anim 2, 0, 73, 18, 19, 18, 19,
+ax_anim 2, 0, 73, 19, 18, 19, 18,
+ax_anim 2, 0, 69, 10, 10, 10, 10,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sPoochyenaAnims_3_3:
+ax_anim 2, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -4, 0, -4, 0,
+ax_anim 4, 0, 74, -5, 0, -5, 0,
+ax_anim 2, 0, 77, 1, -2, 1, 0,
+ax_anim 2, 2, 77, 8, -4, 8, 0,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 1, 78, 15, 1, 15, 1,
+ax_anim 2, 0, 78, 15, 0, 15, 0,
+ax_anim 2, 0, 78, 15, 1, 15, 1,
+ax_anim 2, 0, 74, 10, 0, 10, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sPoochyenaAnims_3_4:
+ax_anim 2, 0, 79, -2, 2, -2, 2,
+ax_anim 2, 0, 79, -4, 4, -4, 4,
+ax_anim 4, 0, 79, -5, 5, -5, 5,
+ax_anim 2, 0, 82, 1, -7, 1, -1,
+ax_anim 2, 2, 82, 8, -15, 8, -8,
+ax_anim 2, 0, 83, 18, -19, 18, -19,
+ax_anim 2, 1, 83, 19, -18, 19, -18,
+ax_anim 2, 0, 83, 18, -19, 18, -19,
+ax_anim 2, 0, 83, 19, -18, 19, -18,
+ax_anim 2, 0, 79, 10, -10, 10, -10,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sPoochyenaAnims_3_5:
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 2, 0, 84, 0, 4, 0, 4,
+ax_anim 4, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 87, 0, -6, 0, -4,
+ax_anim 2, 2, 87, 0, -12, 0, -10,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 1, 88, 1, -19, 1, -19,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 0, 88, 1, -19, 1, -19,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sPoochyenaAnims_3_6:
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 4, 4, 4, 4,
+ax_anim 4, 0, 89, 5, 5, 5, 5,
+ax_anim 2, 0, 92, -1, -7, -1, -1,
+ax_anim 2, 2, 92, -8, -15, -8, -8,
+ax_anim 2, 0, 93, -18, -19, -18, -19,
+ax_anim 2, 1, 93, -19, -18, -19, -18,
+ax_anim 2, 0, 93, -18, -19, -18, -19,
+ax_anim 2, 0, 93, -19, -18, -19, -18,
+ax_anim 2, 0, 89, -10, -10, -10, -10,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sPoochyenaAnims_3_7:
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim 4, 0, 94, 5, 0, 5, 0,
+ax_anim 2, 0, 97, -1, -2, -1, 0,
+ax_anim 2, 2, 97, -8, -4, -8, 0,
+ax_anim 2, 0, 98, -15, 0, -15, 0,
+ax_anim 2, 1, 98, -15, 1, -15, 1,
+ax_anim 2, 0, 98, -15, 0, -15, 0,
+ax_anim 2, 0, 98, -15, 1, -15, 1,
+ax_anim 2, 0, 94, -10, 0, -10, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sPoochyenaAnims_3_8:
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 4, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 102, -1, 0, -1, 1,
+ax_anim 2, 2, 102, -8, 3, -8, 8,
+ax_anim 2, 0, 103, -18, 19, -18, 19,
+ax_anim 2, 1, 103, -19, 18, -19, 18,
+ax_anim 2, 0, 103, -18, 19, -18, 19,
+ax_anim 2, 0, 103, -19, 18, -19, 18,
+ax_anim 2, 0, 99, -10, 10, -10, 10,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_4_1:
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, -3, 0, -3,
+ax_anim 6, 2, 105, 0, -4, 0, -4,
+ax_anim 1, 0, 105, 0, -1, 0, -1,
+ax_anim 1, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 1, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 107, 0, 5, 0, 5,
+ax_anim 2, 0, 107, 1, 5, 1, 5,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sPoochyenaAnims_4_2:
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 6, 2, 110, -4, -4, -4, -4,
+ax_anim 1, 0, 110, -1, -1, -1, -1,
+ax_anim 1, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 1, 112, 6, 6, 6, 6,
+ax_anim 2, 0, 112, 7, 5, 7, 5,
+ax_anim 2, 0, 112, 6, 6, 6, 6,
+ax_anim 2, 0, 112, 7, 5, 7, 5,
+ax_anim 2, 0, 112, 6, 6, 6, 6,
+ax_anim 2, 0, 112, 7, 5, 7, 5,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim_terminator
+sPoochyenaAnims_4_3:
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 0, 116, -3, 0, -3, 0,
+ax_anim 6, 2, 115, -4, 0, -4, 0,
+ax_anim 1, 0, 115, -1, 0, -1, 0,
+ax_anim 1, 0, 117, 4, 0, 4, 0,
+ax_anim 2, 1, 117, 6, 0, 6, 0,
+ax_anim 2, 0, 117, 6, 1, 6, 1,
+ax_anim 2, 0, 117, 6, 0, 6, 0,
+ax_anim 2, 0, 117, 6, 1, 6, 1,
+ax_anim 2, 0, 117, 6, 0, 6, 0,
+ax_anim 2, 0, 117, 6, 1, 6, 1,
+ax_anim 2, 0, 114, 2, 0, 2, 0,
+ax_anim_terminator
+sPoochyenaAnims_4_4:
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 121, -3, 3, -3, 3,
+ax_anim 6, 2, 120, -4, 4, -4, 4,
+ax_anim 1, 0, 120, -1, 1, -1, 1,
+ax_anim 1, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 1, 122, 6, -6, 6, -6,
+ax_anim 2, 0, 122, 7, -5, 7, -5,
+ax_anim 2, 0, 122, 6, -6, 6, -6,
+ax_anim 2, 0, 122, 7, -5, 7, -5,
+ax_anim 2, 0, 122, 6, -6, 6, -6,
+ax_anim 2, 0, 122, 7, -5, 7, -5,
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim_terminator
+sPoochyenaAnims_4_5:
+ax_anim 2, 0, 126, 0, 1, 0, 1,
+ax_anim 2, 0, 126, 0, 3, 0, 3,
+ax_anim 6, 2, 125, 0, 4, 0, 4,
+ax_anim 1, 0, 125, 0, 1, 0, 1,
+ax_anim 1, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 1, 127, 0, -6, 0, -5,
+ax_anim 2, 0, 127, 1, -6, 1, -5,
+ax_anim 2, 0, 127, 0, -6, 0, -5,
+ax_anim 2, 0, 127, 1, -6, 1, -5,
+ax_anim 2, 0, 127, 0, -6, 0, -5,
+ax_anim 2, 0, 127, 1, -6, 1, -5,
+ax_anim 2, 0, 124, 0, -2, 0, -2,
+ax_anim_terminator
+sPoochyenaAnims_4_6:
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 131, 3, 3, 3, 3,
+ax_anim 6, 2, 130, 4, 4, 4, 4,
+ax_anim 1, 0, 130, 1, 1, 1, 1,
+ax_anim 1, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 1, 132, -6, -6, -6, -6,
+ax_anim 2, 0, 132, -7, -5, -7, -5,
+ax_anim 2, 0, 132, -6, -6, -6, -6,
+ax_anim 2, 0, 132, -7, -5, -7, -5,
+ax_anim 2, 0, 132, -6, -6, -6, -6,
+ax_anim 2, 0, 132, -7, -5, -7, -5,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim_terminator
+sPoochyenaAnims_4_7:
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 6, 2, 135, 4, 0, 4, 0,
+ax_anim 1, 0, 135, 1, 0, 1, 0,
+ax_anim 1, 0, 137, -4, 0, -4, 0,
+ax_anim 2, 1, 137, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -6, 1, -6, 1,
+ax_anim 2, 0, 137, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -6, 1, -6, 1,
+ax_anim 2, 0, 137, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -6, 1, -6, 1,
+ax_anim 2, 0, 134, -2, 0, -2, 0,
+ax_anim_terminator
+sPoochyenaAnims_4_8:
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 3, -3, 3, -3,
+ax_anim 6, 2, 140, 4, -4, 4, -4,
+ax_anim 1, 0, 140, 1, -1, 1, -1,
+ax_anim 1, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 1, 142, -6, 6, -6, 6,
+ax_anim 2, 0, 142, -7, 5, -7, 5,
+ax_anim 2, 0, 142, -6, 6, -6, 6,
+ax_anim 2, 0, 142, -7, 5, -7, 5,
+ax_anim 2, 0, 142, -6, 6, -6, 6,
+ax_anim 2, 0, 142, -7, 5, -7, 5,
+ax_anim 2, 0, 139, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_5_1:
+ax_anim 10, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 2, 144, 1, 0, 1, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 1, 0, 1, 0,
+ax_anim_terminator
+sPoochyenaAnims_5_2:
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 2, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim_terminator
+sPoochyenaAnims_5_3:
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 2, 146, 0, 1, 0, 1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 1, 0, 1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 1, 0, 1,
+ax_anim_terminator
+sPoochyenaAnims_5_4:
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 2, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim_terminator
+sPoochyenaAnims_5_5:
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 2, 148, 1, 0, 1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 1, 0, 1, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 1, 0, 1, 0,
+ax_anim_terminator
+sPoochyenaAnims_5_6:
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 2, 149, -1, 1, -1, 1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 1, -1, 1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 1, -1, 1,
+ax_anim_terminator
+sPoochyenaAnims_5_7:
+ax_anim 10, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 2, 150, 0, 1, 0, 1,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 1, 0, 1,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 1, 0, 1,
+ax_anim_terminator
+sPoochyenaAnims_5_8:
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 2, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sPoochyenaAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sPoochyenaAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sPoochyenaAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sPoochyenaAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sPoochyenaAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sPoochyenaAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sPoochyenaAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_8_1:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 5, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 5, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_8_2:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 5, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 5, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_8_3:
+ax_anim 40, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 5, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 5, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_8_4:
+ax_anim 40, 0, 181, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim 5, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim 5, 0, 178, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_8_5:
+ax_anim 40, 0, 186, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 5, 0, 183, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 5, 0, 183, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_8_6:
+ax_anim 40, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim 5, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim 5, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_8_7:
+ax_anim 40, 0, 196, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim 5, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim 5, 0, 193, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_8_8:
+ax_anim 40, 0, 201, 0, 0, 0, 0,
+ax_anim 8, 0, 199, 0, 0, 0, 0,
+ax_anim 5, 0, 198, 0, 0, 0, 0,
+ax_anim 8, 0, 199, 0, 0, 0, 0,
+ax_anim 5, 0, 198, 0, 0, 0, 0,
+ax_anim 8, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 9, 5, 9, 5,
+ax_anim 2, 0, 204, 9, 9, 9, 9,
+ax_anim 2, 0, 205, 7, 13, 7, 13,
+ax_anim 3, 0, 206, 0, 18, 0, 18,
+ax_anim 2, 3, 207, -7, 13, -7, 13,
+ax_anim 2, 0, 208, -9, 9, -9, 9,
+ax_anim 1, 0, 209, -9, 5, -9, 5,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 17, 3, 17, 3,
+ax_anim 2, 0, 204, 20, 8, 20, 8,
+ax_anim 3, 0, 205, 20, 18, 20, 16,
+ax_anim 2, 3, 206, 11, 19, 11, 19,
+ax_anim 2, 0, 207, 3, 15, 3, 15,
+ax_anim 1, 0, 208, -1, 7, -1, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -4, 3, -4,
+ax_anim 2, 0, 202, 10, -5, 10, -5,
+ax_anim 2, 0, 203, 18, -4, 18, -4,
+ax_anim 3, 0, 204, 20, 1, 20, 1,
+ax_anim 2, 3, 205, 18, 5, 18, 5,
+ax_anim 2, 0, 206, 10, 6, 10, 6,
+ax_anim 1, 0, 207, 4, 4, 4, 4,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -8, -1, -8,
+ax_anim 2, 0, 209, 2, -15, 2, -15,
+ax_anim 2, 0, 202, 11, -20, 11, -20,
+ax_anim 3, 0, 203, 21, -21, 21, -21,
+ax_anim 2, 3, 204, 21, -15, 21, -15,
+ax_anim 2, 0, 205, 18, -7, 18, -7,
+ax_anim 1, 0, 206, 7, -1, 7, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -9, -4, -9, -4,
+ax_anim 2, 0, 208, -12, -10, -12, -10,
+ax_anim 2, 0, 209, -10, -18, -10, -18,
+ax_anim 3, 0, 202, 0, -21, 0, -21,
+ax_anim 2, 3, 203, 10, -18, 10, -18,
+ax_anim 2, 0, 204, 12, -10, 12, -10,
+ax_anim 1, 0, 205, 9, -4, 9, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -8, 1, -8,
+ax_anim 2, 0, 203, -2, -15, -2, -15,
+ax_anim 2, 0, 202, -11, -20, -11, -20,
+ax_anim 3, 0, 209, -21, -21, -21, -21,
+ax_anim 2, 3, 208, -21, -15, -21, -15,
+ax_anim 2, 0, 207, -18, -7, -18, -7,
+ax_anim 1, 0, 206, -7, -1, -7, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -4, -3, -4,
+ax_anim 2, 0, 202, -10, -5, -10, -5,
+ax_anim 2, 0, 209, -18, -4, -18, -4,
+ax_anim 3, 0, 208, -20, 1, -20, 1,
+ax_anim 2, 3, 207, -18, 5, -18, 5,
+ax_anim 2, 0, 206, -10, 6, -10, 6,
+ax_anim 1, 0, 205, -4, 4, -4, 4,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -17, 3, -17, 3,
+ax_anim 2, 0, 208, -20, 8, -20, 8,
+ax_anim 3, 0, 207, -20, 18, -20, 18,
+ax_anim 2, 3, 206, -11, 19, -11, 19,
+ax_anim 2, 0, 205, -3, 15, -3, 15,
+ax_anim 1, 0, 204, 1, 7, 1, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -24, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -25, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -23, 0, 0,
+ax_anim 3, 0, 229, 0, -19, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -18, 0, 0,
+ax_anim 4, 0, 231, 0, -19, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 235, 0, -19, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -25, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPoochyenaAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPoochyenaGfx1:
+.incbin "baserom.gba", 0x10BB1F8, 0x100
+sPoochyenaSprites1:
+ax_sprite sPoochyenaGfx1, 0x100
+ax_sprite_terminator
+sPoochyenaGfx2:
+.incbin "baserom.gba", 0x10BB308, 0x100
+sPoochyenaSprites2:
+ax_sprite sPoochyenaGfx2, 0x100
+ax_sprite_terminator
+sPoochyenaGfx3:
+.incbin "baserom.gba", 0x10BB418, 0x200
+sPoochyenaSprites3:
+ax_sprite sPoochyenaGfx3, 0x200
+ax_sprite_terminator
+sPoochyenaGfx4:
+.incbin "baserom.gba", 0x10BB628, 0x200
+sPoochyenaSprites4:
+ax_sprite sPoochyenaGfx4, 0x200
+ax_sprite_terminator
+sPoochyenaGfx5:
+.incbin "baserom.gba", 0x10BB838, 0x200
+sPoochyenaSprites5:
+ax_sprite sPoochyenaGfx5, 0x200
+ax_sprite_terminator
+sPoochyenaGfx6:
+.incbin "baserom.gba", 0x10BBA48, 0x200
+sPoochyenaSprites6:
+ax_sprite sPoochyenaGfx6, 0x200
+ax_sprite_terminator
+sPoochyenaGfx7:
+.incbin "baserom.gba", 0x10BBC58, 0x200
+sPoochyenaSprites7:
+ax_sprite sPoochyenaGfx7, 0x200
+ax_sprite_terminator
+sPoochyenaGfx8:
+.incbin "baserom.gba", 0x10BBE68, 0x200
+sPoochyenaSprites8:
+ax_sprite sPoochyenaGfx8, 0x200
+ax_sprite_terminator
+sPoochyenaGfx9:
+.incbin "baserom.gba", 0x10BC078, 0x200
+sPoochyenaSprites9:
+ax_sprite sPoochyenaGfx9, 0x200
+ax_sprite_terminator
+sPoochyenaGfx10:
+.incbin "baserom.gba", 0x10BC288, 0x200
+sPoochyenaSprites10:
+ax_sprite sPoochyenaGfx10, 0x200
+ax_sprite_terminator
+sPoochyenaGfx11:
+.incbin "baserom.gba", 0x10BC498, 0x200
+sPoochyenaSprites11:
+ax_sprite sPoochyenaGfx11, 0x200
+ax_sprite_terminator
+sPoochyenaGfx12:
+.incbin "baserom.gba", 0x10BC6A8, 0x200
+sPoochyenaSprites12:
+ax_sprite sPoochyenaGfx12, 0x200
+ax_sprite_terminator
+sPoochyenaGfx13:
+.incbin "baserom.gba", 0x10BC8B8, 0x100
+sPoochyenaSprites13:
+ax_sprite sPoochyenaGfx13, 0x100
+ax_sprite_terminator
+sPoochyenaGfx14:
+.incbin "baserom.gba", 0x10BC9C8, 0x100
+sPoochyenaSprites14:
+ax_sprite sPoochyenaGfx14, 0x100
+ax_sprite_terminator
+sPoochyenaGfx15:
+.incbin "baserom.gba", 0x10BCAD8, 0x100
+sPoochyenaSprites15:
+ax_sprite sPoochyenaGfx15, 0x100
+ax_sprite_terminator
+sPoochyenaGfx16:
+.incbin "baserom.gba", 0x10BCBE8, 0xC0
+sPoochyenaSprites16:
+ax_sprite sPoochyenaGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoochyenaGfx17:
+.incbin "baserom.gba", 0x10BCCC0, 0xE0
+sPoochyenaSprites17:
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx17, 0xe0
+ax_sprite_terminator
+sPoochyenaGfx18:
+.incbin "baserom.gba", 0x10BCDB8, 0x20
+sPoochyenaGfx18_1:
+.incbin "baserom.gba", 0x10BCDD8, 0x20
+sPoochyenaGfx18_2:
+.incbin "baserom.gba", 0x10BCDF8, 0x60
+sPoochyenaGfx18_3:
+.incbin "baserom.gba", 0x10BCE58, 0x60
+sPoochyenaSprites18:
+ax_sprite sPoochyenaGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx18_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx18_3, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPoochyenaGfx19:
+.incbin "baserom.gba", 0x10BCF00, 0x60
+sPoochyenaGfx19_1:
+.incbin "baserom.gba", 0x10BCF60, 0x60
+sPoochyenaGfx19_2:
+.incbin "baserom.gba", 0x10BCFC0, 0x40
+sPoochyenaSprites19:
+ax_sprite 0, 0x80
+ax_sprite sPoochyenaGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx19_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoochyenaGfx20:
+.incbin "baserom.gba", 0x10BD040, 0x20
+sPoochyenaGfx20_1:
+.incbin "baserom.gba", 0x10BD060, 0x100
+sPoochyenaSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPoochyenaGfx21:
+.incbin "baserom.gba", 0x10BD190, 0x40
+sPoochyenaGfx21_1:
+.incbin "baserom.gba", 0x10BD1D0, 0x100
+sPoochyenaGfx21_2:
+.incbin "baserom.gba", 0x10BD2D0, 0x40
+sPoochyenaSprites21:
+ax_sprite sPoochyenaGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoochyenaGfx22:
+.incbin "baserom.gba", 0x10BD348, 0x40
+sPoochyenaGfx22_1:
+.incbin "baserom.gba", 0x10BD388, 0x60
+sPoochyenaGfx22_2:
+.incbin "baserom.gba", 0x10BD3E8, 0x60
+sPoochyenaGfx22_3:
+.incbin "baserom.gba", 0x10BD448, 0x40
+sPoochyenaSprites22:
+ax_sprite sPoochyenaGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoochyenaGfx23:
+.incbin "baserom.gba", 0x10BD4D0, 0x40
+sPoochyenaGfx23_1:
+.incbin "baserom.gba", 0x10BD510, 0x60
+sPoochyenaGfx23_2:
+.incbin "baserom.gba", 0x10BD570, 0x60
+sPoochyenaGfx23_3:
+.incbin "baserom.gba", 0x10BD5D0, 0x20
+sPoochyenaSprites23:
+ax_sprite sPoochyenaGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoochyenaGfx24:
+.incbin "baserom.gba", 0x10BD638, 0x100
+sPoochyenaSprites24:
+ax_sprite sPoochyenaGfx24, 0x100
+ax_sprite_terminator
+sPoochyenaGfx25:
+.incbin "baserom.gba", 0x10BD748, 0x100
+sPoochyenaSprites25:
+ax_sprite sPoochyenaGfx25, 0x100
+ax_sprite_terminator
+sPoochyenaGfx26:
+.incbin "baserom.gba", 0x10BD858, 0xC0
+sPoochyenaSprites26:
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx26, 0xc0
+ax_sprite_terminator
+sPoochyenaGfx27:
+.incbin "baserom.gba", 0x10BD930, 0xC0
+sPoochyenaSprites27:
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx27, 0xc0
+ax_sprite_terminator
+sPoochyenaGfx28:
+.incbin "baserom.gba", 0x10BDA08, 0x100
+sPoochyenaSprites28:
+ax_sprite sPoochyenaGfx28, 0x100
+ax_sprite_terminator
+sPoochyenaGfx29:
+.incbin "baserom.gba", 0x10BDB18, 0x40
+sPoochyenaGfx29_1:
+.incbin "baserom.gba", 0x10BDB58, 0x60
+sPoochyenaGfx29_2:
+.incbin "baserom.gba", 0x10BDBB8, 0x60
+sPoochyenaGfx29_3:
+.incbin "baserom.gba", 0x10BDC18, 0x40
+sPoochyenaSprites29:
+ax_sprite sPoochyenaGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx29_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoochyenaGfx30:
+.incbin "baserom.gba", 0x10BDCA0, 0x40
+sPoochyenaGfx30_1:
+.incbin "baserom.gba", 0x10BDCE0, 0x60
+sPoochyenaGfx30_2:
+.incbin "baserom.gba", 0x10BDD40, 0x60
+sPoochyenaGfx30_3:
+.incbin "baserom.gba", 0x10BDDA0, 0x40
+sPoochyenaSprites30:
+ax_sprite sPoochyenaGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx30_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoochyenaGfx31:
+.incbin "baserom.gba", 0x10BDE28, 0x40
+sPoochyenaGfx31_1:
+.incbin "baserom.gba", 0x10BDE68, 0x60
+sPoochyenaGfx31_2:
+.incbin "baserom.gba", 0x10BDEC8, 0x60
+sPoochyenaGfx31_3:
+.incbin "baserom.gba", 0x10BDF28, 0x40
+sPoochyenaSprites31:
+ax_sprite sPoochyenaGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx31_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPoochyenaGfx32:
+.incbin "baserom.gba", 0x10BDFB0, 0x40
+sPoochyenaGfx32_1:
+.incbin "baserom.gba", 0x10BDFF0, 0x60
+sPoochyenaGfx32_2:
+.incbin "baserom.gba", 0x10BE050, 0x60
+sPoochyenaGfx32_3:
+.incbin "baserom.gba", 0x10BE0B0, 0x60
+sPoochyenaSprites32:
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx32_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx32_3, 0x60
+ax_sprite_terminator
+sPoochyenaGfx33:
+.incbin "baserom.gba", 0x10BE158, 0x20
+sPoochyenaGfx33_1:
+.incbin "baserom.gba", 0x10BE178, 0x60
+sPoochyenaGfx33_2:
+.incbin "baserom.gba", 0x10BE1D8, 0x80
+sPoochyenaGfx33_3:
+.incbin "baserom.gba", 0x10BE258, 0x60
+sPoochyenaSprites33:
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx33, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx33_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx33_3, 0x60
+ax_sprite_terminator
+sPoochyenaGfx34:
+.incbin "baserom.gba", 0x10BE300, 0x40
+sPoochyenaGfx34_1:
+.incbin "baserom.gba", 0x10BE340, 0x60
+sPoochyenaGfx34_2:
+.incbin "baserom.gba", 0x10BE3A0, 0x60
+sPoochyenaGfx34_3:
+.incbin "baserom.gba", 0x10BE400, 0x60
+sPoochyenaSprites34:
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx34_3, 0x60
+ax_sprite_terminator
+sPoochyenaGfx35:
+.incbin "baserom.gba", 0x10BE4A8, 0x60
+sPoochyenaGfx35_1:
+.incbin "baserom.gba", 0x10BE508, 0x60
+sPoochyenaGfx35_2:
+.incbin "baserom.gba", 0x10BE568, 0x60
+sPoochyenaGfx35_3:
+.incbin "baserom.gba", 0x10BE5C8, 0x40
+sPoochyenaSprites35:
+ax_sprite sPoochyenaGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoochyenaGfx36:
+.incbin "baserom.gba", 0x10BE650, 0x40
+sPoochyenaGfx36_1:
+.incbin "baserom.gba", 0x10BE690, 0x60
+sPoochyenaGfx36_2:
+.incbin "baserom.gba", 0x10BE6F0, 0x60
+sPoochyenaGfx36_3:
+.incbin "baserom.gba", 0x10BE750, 0x40
+sPoochyenaSprites36:
+ax_sprite sPoochyenaGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoochyenaGfx37:
+.incbin "baserom.gba", 0x10BE7D8, 0x40
+sPoochyenaGfx37_1:
+.incbin "baserom.gba", 0x10BE818, 0x60
+sPoochyenaGfx37_2:
+.incbin "baserom.gba", 0x10BE878, 0x60
+sPoochyenaGfx37_3:
+.incbin "baserom.gba", 0x10BE8D8, 0x60
+sPoochyenaSprites37:
+ax_sprite sPoochyenaGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPoochyenaGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPoochyenaGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPoochyenaGfx38:
+.incbin "baserom.gba", 0x10BE980, 0x100
+sPoochyenaSprites38:
+ax_sprite sPoochyenaGfx38, 0x100
+ax_sprite_terminator
+sPoochyenaGfx39:
+.incbin "baserom.gba", 0x10BEA90, 0x100
+sPoochyenaSprites39:
+ax_sprite sPoochyenaGfx39, 0x100
+ax_sprite_terminator
+sPoochyenaGfx40:
+.incbin "baserom.gba", 0x10BEBA0, 0x100
+sPoochyenaSprites40:
+ax_sprite sPoochyenaGfx40, 0x100
+ax_sprite_terminator
+sPoochyenaGfx41:
+.incbin "baserom.gba", 0x10BECB0, 0x100
+sPoochyenaSprites41:
+ax_sprite sPoochyenaGfx41, 0x100
+ax_sprite_terminator
+sPoochyenaGfx42:
+.incbin "baserom.gba", 0x10BEDC0, 0x100
+sPoochyenaSprites42:
+ax_sprite sPoochyenaGfx42, 0x100
+ax_sprite_terminator
+sPoochyenaGfx43:
+.incbin "baserom.gba", 0x10BEED0, 0x200
+sPoochyenaSprites43:
+ax_sprite sPoochyenaGfx43, 0x200
+ax_sprite_terminator
+sPoochyenaGfx44:
+.incbin "baserom.gba", 0x10BF0E0, 0x200
+sPoochyenaSprites44:
+ax_sprite sPoochyenaGfx44, 0x200
+ax_sprite_terminator
+sPoochyenaGfx45:
+.incbin "baserom.gba", 0x10BF2F0, 0x200
+sPoochyenaSprites45:
+ax_sprite sPoochyenaGfx45, 0x200
+ax_sprite_terminator
+sPoochyenaGfx46:
+.incbin "baserom.gba", 0x10BF500, 0x200
+sPoochyenaSprites46:
+ax_sprite sPoochyenaGfx46, 0x200
+ax_sprite_terminator
+sPoochyenaGfx47:
+.incbin "baserom.gba", 0x10BF710, 0x200
+sPoochyenaSprites47:
+ax_sprite sPoochyenaGfx47, 0x200
+ax_sprite_terminator
+sAxPosesPoochyena:
+.4byte sPoochyenaPose1
+.4byte sPoochyenaPose2
+.4byte sPoochyenaPose3
+.4byte sPoochyenaPose4
+.4byte sPoochyenaPose5
+.4byte sPoochyenaPose6
+.4byte sPoochyenaPose7
+.4byte sPoochyenaPose8
+.4byte sPoochyenaPose9
+.4byte sPoochyenaPose10
+.4byte sPoochyenaPose11
+.4byte sPoochyenaPose12
+.4byte sPoochyenaPose13
+.4byte sPoochyenaPose14
+.4byte sPoochyenaPose15
+.4byte sPoochyenaPose16
+.4byte sPoochyenaPose17
+.4byte sPoochyenaPose18
+.4byte sPoochyenaPose19
+.4byte sPoochyenaPose20
+.4byte sPoochyenaPose21
+.4byte sPoochyenaPose22
+.4byte sPoochyenaPose23
+.4byte sPoochyenaPose24
+.4byte sPoochyenaPose25
+.4byte sPoochyenaPose26
+.4byte sPoochyenaPose27
+.4byte sPoochyenaPose28
+.4byte sPoochyenaPose29
+.4byte sPoochyenaPose30
+.4byte sPoochyenaPose31
+.4byte sPoochyenaPose32
+.4byte sPoochyenaPose33
+.4byte sPoochyenaPose34
+.4byte sPoochyenaPose35
+.4byte sPoochyenaPose36
+.4byte sPoochyenaPose37
+.4byte sPoochyenaPose38
+.4byte sPoochyenaPose39
+.4byte sPoochyenaPose40
+.4byte sPoochyenaPose41
+.4byte sPoochyenaPose42
+.4byte sPoochyenaPose43
+.4byte sPoochyenaPose44
+.4byte sPoochyenaPose45
+.4byte sPoochyenaPose46
+.4byte sPoochyenaPose47
+.4byte sPoochyenaPose48
+.4byte sPoochyenaPose49
+.4byte sPoochyenaPose50
+.4byte sPoochyenaPose51
+.4byte sPoochyenaPose52
+.4byte sPoochyenaPose53
+.4byte sPoochyenaPose54
+.4byte sPoochyenaPose55
+.4byte sPoochyenaPose56
+.4byte sPoochyenaPose57
+.4byte sPoochyenaPose58
+.4byte sPoochyenaPose59
+.4byte sPoochyenaPose60
+.4byte sPoochyenaPose61
+.4byte sPoochyenaPose62
+.4byte sPoochyenaPose63
+.4byte sPoochyenaPose64
+.4byte sPoochyenaPose65
+.4byte sPoochyenaPose66
+.4byte sPoochyenaPose67
+.4byte sPoochyenaPose68
+.4byte sPoochyenaPose69
+.4byte sPoochyenaPose70
+.4byte sPoochyenaPose71
+.4byte sPoochyenaPose72
+.4byte sPoochyenaPose73
+.4byte sPoochyenaPose74
+.4byte sPoochyenaPose75
+.4byte sPoochyenaPose76
+.4byte sPoochyenaPose77
+.4byte sPoochyenaPose78
+.4byte sPoochyenaPose79
+.4byte sPoochyenaPose80
+.4byte sPoochyenaPose81
+.4byte sPoochyenaPose82
+.4byte sPoochyenaPose83
+.4byte sPoochyenaPose84
+.4byte sPoochyenaPose85
+.4byte sPoochyenaPose86
+.4byte sPoochyenaPose87
+.4byte sPoochyenaPose88
+.4byte sPoochyenaPose89
+.4byte sPoochyenaPose90
+.4byte sPoochyenaPose91
+.4byte sPoochyenaPose92
+.4byte sPoochyenaPose93
+.4byte sPoochyenaPose94
+.4byte sPoochyenaPose95
+.4byte sPoochyenaPose96
+.4byte sPoochyenaPose97
+.4byte sPoochyenaPose98
+.4byte sPoochyenaPose99
+.4byte sPoochyenaPose100
+.4byte sPoochyenaPose101
+.4byte sPoochyenaPose102
+.4byte sPoochyenaPose103
+.4byte sPoochyenaPose104
+.4byte sPoochyenaPose105
+.4byte sPoochyenaPose106
+.4byte sPoochyenaPose107
+.4byte sPoochyenaPose108
+.4byte sPoochyenaPose109
+.4byte sPoochyenaPose110
+.4byte sPoochyenaPose111
+.4byte sPoochyenaPose112
+.4byte sPoochyenaPose113
+.4byte sPoochyenaPose114
+.4byte sPoochyenaPose115
+.4byte sPoochyenaPose116
+.4byte sPoochyenaPose117
+.4byte sPoochyenaPose118
+.4byte sPoochyenaPose119
+.4byte sPoochyenaPose120
+.4byte sPoochyenaPose121
+.4byte sPoochyenaPose122
+.4byte sPoochyenaPose123
+.4byte sPoochyenaPose124
+.4byte sPoochyenaPose125
+.4byte sPoochyenaPose126
+.4byte sPoochyenaPose127
+.4byte sPoochyenaPose128
+.4byte sPoochyenaPose129
+.4byte sPoochyenaPose130
+.4byte sPoochyenaPose131
+.4byte sPoochyenaPose132
+.4byte sPoochyenaPose133
+.4byte sPoochyenaPose134
+.4byte sPoochyenaPose135
+.4byte sPoochyenaPose136
+.4byte sPoochyenaPose137
+.4byte sPoochyenaPose138
+.4byte sPoochyenaPose139
+.4byte sPoochyenaPose140
+.4byte sPoochyenaPose141
+.4byte sPoochyenaPose142
+.4byte sPoochyenaPose143
+.4byte sPoochyenaPose144
+.4byte sPoochyenaPose145
+.4byte sPoochyenaPose146
+.4byte sPoochyenaPose147
+.4byte sPoochyenaPose148
+.4byte sPoochyenaPose149
+.4byte sPoochyenaPose150
+.4byte sPoochyenaPose151
+.4byte sPoochyenaPose152
+.4byte sPoochyenaPose153
+.4byte sPoochyenaPose154
+.4byte sPoochyenaPose155
+.4byte sPoochyenaPose156
+.4byte sPoochyenaPose157
+.4byte sPoochyenaPose158
+.4byte sPoochyenaPose159
+.4byte sPoochyenaPose160
+.4byte sPoochyenaPose161
+.4byte sPoochyenaPose162
+.4byte sPoochyenaPose163
+.4byte sPoochyenaPose164
+.4byte sPoochyenaPose165
+.4byte sPoochyenaPose166
+.4byte sPoochyenaPose167
+.4byte sPoochyenaPose168
+.4byte sPoochyenaPose169
+.4byte sPoochyenaPose170
+.4byte sPoochyenaPose171
+.4byte sPoochyenaPose172
+.4byte sPoochyenaPose173
+.4byte sPoochyenaPose174
+.4byte sPoochyenaPose175
+.4byte sPoochyenaPose176
+.4byte sPoochyenaPose177
+.4byte sPoochyenaPose178
+.4byte sPoochyenaPose179
+.4byte sPoochyenaPose180
+.4byte sPoochyenaPose181
+.4byte sPoochyenaPose182
+.4byte sPoochyenaPose183
+.4byte sPoochyenaPose184
+.4byte sPoochyenaPose185
+.4byte sPoochyenaPose186
+.4byte sPoochyenaPose187
+.4byte sPoochyenaPose188
+.4byte sPoochyenaPose189
+.4byte sPoochyenaPose190
+.4byte sPoochyenaPose191
+.4byte sPoochyenaPose192
+.4byte sPoochyenaPose193
+.4byte sPoochyenaPose194
+.4byte sPoochyenaPose195
+.4byte sPoochyenaPose196
+.4byte sPoochyenaPose197
+.4byte sPoochyenaPose198
+.4byte sPoochyenaPose199
+.4byte sPoochyenaPose200
+.4byte sPoochyenaPose201
+.4byte sPoochyenaPose202
+.4byte sPoochyenaPose203
+.4byte sPoochyenaPose204
+.4byte sPoochyenaPose205
+.4byte sPoochyenaPose206
+.4byte sPoochyenaPose207
+.4byte sPoochyenaPose208
+.4byte sPoochyenaPose209
+.4byte sPoochyenaPose210
+.4byte sPoochyenaPose211
+.4byte sPoochyenaPose212
+.4byte sPoochyenaPose213
+.4byte sPoochyenaPose214
+.4byte sPoochyenaPose215
+.4byte sPoochyenaPose216
+.4byte sPoochyenaPose217
+.4byte sPoochyenaPose218
+.4byte sPoochyenaPose219
+.4byte sPoochyenaPose220
+.4byte sPoochyenaPose221
+.4byte sPoochyenaPose222
+.4byte sPoochyenaPose223
+.4byte sPoochyenaPose224
+.4byte sPoochyenaPose225
+.4byte sPoochyenaPose226
+.4byte sPoochyenaPose227
+.4byte sPoochyenaPose228
+.4byte sPoochyenaPose229
+.4byte sPoochyenaPose230
+.4byte sPoochyenaPose231
+.4byte sPoochyenaPose232
+.4byte sPoochyenaPose233
+.4byte sPoochyenaPose234
+.4byte sPoochyenaPose235
+.4byte sPoochyenaPose236
+.4byte sPoochyenaPose237
+.4byte sPoochyenaPose238
+.4byte sPoochyenaPose239
+.4byte sPoochyenaPose240
+.4byte sPoochyenaPose241
+.4byte sPoochyenaPose242
+.4byte sPoochyenaPose243
+.4byte sPoochyenaPose244
+.4byte sPoochyenaPose245
+.4byte sPoochyenaPose246
+.4byte sPoochyenaPose247
+.4byte sPoochyenaPose248
+.4byte sPoochyenaPose249
+.4byte sPoochyenaPose250
+.4byte sPoochyenaPose251
+.4byte sPoochyenaPose252
+.4byte sPoochyenaPose253
+.4byte sPoochyenaPose254
+.4byte sPoochyenaPose255
+.4byte sPoochyenaPose256
+.4byte sPoochyenaPose257
+.4byte sPoochyenaPose258
+sAxPositionsPoochyena:
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,    1, 	  -5,    4, 	   4,    4, 	  -1,   -3
+.2byte    5,   -4, 	   6,    0, 	   0,    2, 	  -1,   -5
+.2byte    5,   -7, 	   8,   -6, 	   2,   -4, 	  -1,   -8
+.2byte    6,   -2, 	   7,    1, 	   2,    3, 	   0,   -6
+.2byte    8,   -6, 	   6,   -3, 	   3,    1, 	   0,   -4
+.2byte    8,  -11, 	   9,   -8, 	   7,   -6, 	  -1,   -8
+.2byte    9,   -6, 	   5,   -1, 	   2,    1, 	  -1,   -8
+.2byte    7,  -10, 	   0,   -4, 	   5,   -2, 	  -2,   -6
+.2byte    6,  -13, 	   0,  -11, 	   7,   -7, 	  -2,   -7
+.2byte    9,  -12, 	   2,   -5, 	   6,   -3, 	   0,  -11
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -5, 	  -1,   -7
+.2byte   -1,  -17, 	   5,  -14, 	  -6,  -14, 	  -1,   -9
+.2byte   -1,  -11, 	   4,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -8,  -10, 	  -1,   -4, 	  -6,   -2, 	   1,   -6
+.2byte   -7,  -13, 	  -1,  -11, 	  -8,   -7, 	   1,   -7
+.2byte  -10,  -12, 	  -3,   -5, 	  -7,   -3, 	  -1,  -11
+.2byte   -9,   -6, 	  -7,   -3, 	  -4,    1, 	  -1,   -4
+.2byte   -9,  -11, 	 -10,   -8, 	  -8,   -6, 	   0,   -8
+.2byte  -10,   -6, 	  -6,   -1, 	  -3,    1, 	   0,   -8
+.2byte   -6,   -4, 	  -7,    0, 	  -1,    2, 	   0,   -5
+.2byte   -6,   -7, 	  -9,   -6, 	  -3,   -4, 	   0,   -8
+.2byte   -7,   -2, 	  -8,    1, 	  -3,    3, 	  -1,   -6
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,    1, 	  -5,    4, 	   4,    4, 	  -1,   -3
+.2byte   -1,   -4, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte   -1,   -2, 	  -5,    1, 	   4,    1, 	  -1,   -7
+.2byte    5,   -5, 	   6,   -1, 	   0,    1, 	  -1,   -6
+.2byte    5,   -7, 	   8,   -6, 	   2,   -4, 	  -1,   -8
+.2byte    6,   -2, 	   7,    1, 	   2,    3, 	   0,   -6
+.2byte    6,   -7, 	   9,   -6, 	   3,   -3, 	  -2,  -10
+.2byte    7,   -3, 	   6,   -1, 	   0,    1, 	  -1,   -7
+.2byte    8,   -8, 	   6,   -5, 	   3,   -1, 	   0,   -6
+.2byte    8,  -11, 	   9,   -8, 	   7,   -6, 	  -1,   -8
+.2byte    9,   -6, 	   5,   -1, 	   2,    1, 	  -1,   -8
+.2byte    9,   -9, 	   9,  -10, 	   8,   -6, 	  -1,   -8
+.2byte   10,   -7, 	   5,   -5, 	   4,   -1, 	   1,   -8
+.2byte    7,  -11, 	   0,   -5, 	   5,   -3, 	  -2,   -7
+.2byte    6,  -13, 	   0,  -11, 	   7,   -7, 	  -2,   -7
+.2byte    9,  -12, 	   2,   -5, 	   6,   -3, 	   0,  -11
+.2byte    8,  -12, 	   1,  -14, 	   9,   -9, 	  -1,   -9
+.2byte    8,  -12, 	   0,   -7, 	   5,   -3, 	   0,   -8
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -5, 	  -1,   -7
+.2byte   -1,  -17, 	   5,  -14, 	  -6,  -14, 	  -1,   -9
+.2byte   -1,  -11, 	   4,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   5,  -14, 	  -6,  -14, 	  -1,   -9
+.2byte   -1,  -17, 	   4,   -6, 	  -5,   -6, 	  -1,  -12
+.2byte   -8,  -11, 	  -1,   -5, 	  -6,   -3, 	   1,   -7
+.2byte   -7,  -13, 	  -1,  -11, 	  -8,   -7, 	   1,   -7
+.2byte  -10,  -12, 	  -3,   -5, 	  -7,   -3, 	  -1,  -11
+.2byte   -9,  -12, 	  -2,  -14, 	 -10,   -9, 	   0,   -9
+.2byte   -9,  -12, 	  -1,   -7, 	  -6,   -3, 	  -1,   -8
+.2byte   -9,   -8, 	  -7,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte   -9,  -11, 	 -10,   -8, 	  -8,   -6, 	   0,   -8
+.2byte  -10,   -6, 	  -6,   -1, 	  -3,    1, 	   0,   -8
+.2byte  -10,   -9, 	 -10,  -10, 	  -9,   -6, 	   0,   -8
+.2byte  -11,   -7, 	  -6,   -5, 	  -5,   -1, 	  -2,   -8
+.2byte   -7,   -5, 	  -8,   -1, 	  -2,    1, 	  -1,   -6
+.2byte   -6,   -7, 	  -9,   -6, 	  -3,   -4, 	   0,   -8
+.2byte   -7,   -2, 	  -8,    1, 	  -3,    3, 	  -1,   -6
+.2byte   -8,   -7, 	 -11,   -6, 	  -5,   -3, 	   0,  -10
+.2byte   -9,   -3, 	  -8,   -1, 	  -2,    1, 	  -1,   -7
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,    1, 	  -5,    4, 	   4,    4, 	  -1,   -3
+.2byte   -1,   -4, 	  -6,   -4, 	   5,   -4, 	  -1,   -9
+.2byte   -1,   -2, 	  -5,    1, 	   4,    1, 	  -1,   -7
+.2byte    5,   -5, 	   6,   -1, 	   0,    1, 	  -1,   -6
+.2byte    5,   -7, 	   8,   -6, 	   2,   -4, 	  -1,   -8
+.2byte    6,   -2, 	   7,    1, 	   2,    3, 	   0,   -6
+.2byte    6,   -7, 	   9,   -6, 	   3,   -3, 	  -2,  -10
+.2byte    7,   -3, 	   6,   -1, 	   0,    1, 	  -1,   -7
+.2byte    8,   -8, 	   6,   -5, 	   3,   -1, 	   0,   -6
+.2byte    8,  -11, 	   9,   -8, 	   7,   -6, 	  -1,   -8
+.2byte    9,   -6, 	   5,   -1, 	   2,    1, 	  -1,   -8
+.2byte    9,   -9, 	   9,  -10, 	   8,   -6, 	  -1,   -8
+.2byte   10,   -7, 	   5,   -5, 	   4,   -1, 	   1,   -8
+.2byte    7,  -11, 	   0,   -5, 	   5,   -3, 	  -2,   -7
+.2byte    6,  -13, 	   0,  -11, 	   7,   -7, 	  -2,   -7
+.2byte    9,  -12, 	   2,   -5, 	   6,   -3, 	   0,  -11
+.2byte    8,  -12, 	   1,  -14, 	   9,   -9, 	  -1,   -9
+.2byte    8,  -12, 	   0,   -7, 	   5,   -3, 	   0,   -8
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -5, 	  -1,   -7
+.2byte   -1,  -17, 	   5,  -14, 	  -6,  -14, 	  -1,   -9
+.2byte   -1,  -11, 	   4,   -7, 	  -5,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   5,  -14, 	  -6,  -14, 	  -1,   -9
+.2byte   -1,  -17, 	   4,   -6, 	  -5,   -6, 	  -1,  -12
+.2byte   -8,  -11, 	  -1,   -5, 	  -6,   -3, 	   1,   -7
+.2byte   -7,  -13, 	  -1,  -11, 	  -8,   -7, 	   1,   -7
+.2byte  -10,  -12, 	  -3,   -5, 	  -7,   -3, 	  -1,  -11
+.2byte   -9,  -12, 	  -2,  -14, 	 -10,   -9, 	   0,   -9
+.2byte   -9,  -12, 	  -1,   -7, 	  -6,   -3, 	  -1,   -8
+.2byte   -9,   -8, 	  -7,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte   -9,  -11, 	 -10,   -8, 	  -8,   -6, 	   0,   -8
+.2byte  -10,   -6, 	  -6,   -1, 	  -3,    1, 	   0,   -8
+.2byte  -10,   -9, 	 -10,  -10, 	  -9,   -6, 	   0,   -8
+.2byte  -11,   -7, 	  -6,   -5, 	  -5,   -1, 	  -2,   -8
+.2byte   -7,   -5, 	  -8,   -1, 	  -2,    1, 	  -1,   -6
+.2byte   -6,   -7, 	  -9,   -6, 	  -3,   -4, 	   0,   -8
+.2byte   -7,   -2, 	  -8,    1, 	  -3,    3, 	  -1,   -6
+.2byte   -8,   -7, 	 -11,   -6, 	  -5,   -3, 	   0,  -10
+.2byte   -9,   -3, 	  -8,   -1, 	  -2,    1, 	  -1,   -7
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -7, 	  -4,    1, 	   3,    1, 	  -1,   -8
+.2byte   -1,   -4, 	  -4,    1, 	   3,    1, 	  -1,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   4,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,    0, 	   3,    0, 	  -1,   -9
+.2byte    5,   -5, 	   6,   -1, 	   0,    1, 	  -1,   -6
+.2byte    6,   -8, 	   6,   -1, 	   1,    1, 	  -2,   -7
+.2byte    4,   -7, 	   6,   -1, 	   1,    1, 	  -3,   -7
+.2byte    7,   -3, 	   6,   -1, 	   0,    1, 	  -1,   -7
+.2byte    3,  -10, 	   5,   -2, 	   0,    0, 	  -2,   -9
+.2byte    8,   -8, 	   6,   -5, 	   3,   -1, 	   0,   -6
+.2byte    7,  -12, 	   5,   -5, 	   4,   -1, 	  -1,   -7
+.2byte    6,   -9, 	   5,   -5, 	   4,   -1, 	  -2,   -7
+.2byte   10,   -7, 	   5,   -5, 	   4,   -1, 	   1,   -8
+.2byte    6,  -11, 	   3,   -5, 	   3,   -1, 	  -1,   -9
+.2byte    7,  -11, 	   0,   -5, 	   5,   -3, 	  -2,   -7
+.2byte    5,  -15, 	   0,   -6, 	   5,   -3, 	  -1,   -7
+.2byte    5,  -11, 	  -2,   -5, 	   5,   -3, 	  -2,   -6
+.2byte    8,  -12, 	   0,   -7, 	   5,   -3, 	   0,   -8
+.2byte    5,  -13, 	  -2,   -4, 	   4,   -2, 	  -2,   -8
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -5, 	  -1,   -7
+.2byte   -1,  -16, 	   4,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -4, 	  -5,   -4, 	  -1,   -8
+.2byte   -1,  -17, 	   4,   -6, 	  -5,   -6, 	  -1,  -12
+.2byte   -1,  -14, 	   4,   -3, 	  -5,   -3, 	  -1,  -10
+.2byte   -8,  -11, 	  -1,   -5, 	  -6,   -3, 	   1,   -7
+.2byte   -6,  -15, 	  -1,   -6, 	  -6,   -3, 	   0,   -7
+.2byte   -6,  -11, 	   1,   -5, 	  -6,   -3, 	   1,   -6
+.2byte   -9,  -12, 	  -1,   -7, 	  -6,   -3, 	  -1,   -8
+.2byte   -6,  -13, 	   1,   -4, 	  -5,   -2, 	   1,   -8
+.2byte   -9,   -8, 	  -7,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte   -8,  -12, 	  -6,   -5, 	  -5,   -1, 	   0,   -7
+.2byte   -7,   -9, 	  -6,   -5, 	  -5,   -1, 	   1,   -7
+.2byte  -11,   -7, 	  -6,   -5, 	  -5,   -1, 	  -2,   -8
+.2byte   -7,  -11, 	  -4,   -5, 	  -4,   -1, 	   0,   -9
+.2byte   -7,   -5, 	  -8,   -1, 	  -2,    1, 	  -1,   -6
+.2byte   -8,   -8, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -1, 	  -3,    1, 	   1,   -7
+.2byte   -9,   -3, 	  -8,   -1, 	  -2,    1, 	  -1,   -7
+.2byte   -5,  -10, 	  -7,   -2, 	  -2,    0, 	   0,   -9
+.2byte   -1,   -7, 	  -4,    1, 	   3,    1, 	  -1,   -8
+.2byte    6,   -8, 	   6,   -1, 	   1,    1, 	  -2,   -7
+.2byte    7,  -12, 	   5,   -5, 	   4,   -1, 	  -1,   -7
+.2byte    5,  -15, 	   0,   -6, 	   5,   -3, 	  -1,   -7
+.2byte   -1,  -16, 	   4,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -6,  -15, 	  -1,   -6, 	  -6,   -3, 	   0,   -7
+.2byte   -8,  -12, 	  -6,   -5, 	  -5,   -1, 	   0,   -7
+.2byte   -8,   -8, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte    2,   -5, 	   4,    0, 	   5,   -4, 	   1,   -4
+.2byte    2,   -5, 	   4,    0, 	   5,   -4, 	   1,   -4
+.2byte   -4,   -9, 	  -8,   -9, 	   5,  -11, 	  -1,   -9
+.2byte    5,  -11, 	   3,  -12, 	  -6,  -10, 	   0,   -9
+.2byte    3,  -12, 	  -5,  -14, 	  -1,  -11, 	  -3,   -7
+.2byte    3,  -12, 	  -6,  -12, 	   5,   -9, 	  -3,   -7
+.2byte    4,  -11, 	   6,   -8, 	  -7,  -10, 	  -1,   -7
+.2byte   -4,  -12, 	   5,  -12, 	  -6,   -9, 	   2,   -7
+.2byte   -4,  -12, 	   4,  -14, 	   0,  -11, 	   2,   -7
+.2byte   -6,  -11, 	  -4,  -12, 	   5,  -10, 	  -1,   -9
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -7, 	  -4,    1, 	   3,    1, 	  -1,   -8
+.2byte   -1,   -4, 	  -4,    1, 	   3,    1, 	  -1,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   4,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,    0, 	   3,    0, 	  -1,   -9
+.2byte    5,   -5, 	   6,   -1, 	   0,    1, 	  -1,   -6
+.2byte    6,   -8, 	   6,   -1, 	   1,    1, 	  -2,   -7
+.2byte    4,   -7, 	   6,   -1, 	   1,    1, 	  -3,   -7
+.2byte    7,   -3, 	   6,   -1, 	   0,    1, 	  -1,   -7
+.2byte    3,  -10, 	   5,   -2, 	   0,    0, 	  -2,   -9
+.2byte    8,   -8, 	   6,   -5, 	   3,   -1, 	   0,   -6
+.2byte    7,  -12, 	   5,   -5, 	   4,   -1, 	  -1,   -7
+.2byte    6,   -9, 	   5,   -5, 	   4,   -1, 	  -2,   -7
+.2byte   10,   -7, 	   5,   -5, 	   4,   -1, 	   1,   -8
+.2byte    6,  -11, 	   3,   -5, 	   3,   -1, 	  -1,   -9
+.2byte    7,  -11, 	   0,   -5, 	   5,   -3, 	  -2,   -7
+.2byte    5,  -15, 	   0,   -6, 	   5,   -3, 	  -1,   -7
+.2byte    5,  -11, 	  -2,   -5, 	   5,   -3, 	  -2,   -6
+.2byte    8,  -12, 	   0,   -7, 	   5,   -3, 	   0,   -8
+.2byte    5,  -13, 	  -2,   -4, 	   4,   -2, 	  -2,   -8
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -5, 	  -1,   -7
+.2byte   -1,  -16, 	   4,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -4, 	  -5,   -4, 	  -1,   -8
+.2byte   -1,  -17, 	   4,   -6, 	  -5,   -6, 	  -1,  -12
+.2byte   -1,  -14, 	   4,   -3, 	  -5,   -3, 	  -1,  -10
+.2byte   -8,  -11, 	  -1,   -5, 	  -6,   -3, 	   1,   -7
+.2byte   -6,  -15, 	  -1,   -6, 	  -6,   -3, 	   0,   -7
+.2byte   -6,  -11, 	   1,   -5, 	  -6,   -3, 	   1,   -6
+.2byte   -9,  -12, 	  -1,   -7, 	  -6,   -3, 	  -1,   -8
+.2byte   -6,  -13, 	   1,   -4, 	  -5,   -2, 	   1,   -8
+.2byte   -9,   -8, 	  -7,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte   -8,  -12, 	  -6,   -5, 	  -5,   -1, 	   0,   -7
+.2byte   -7,   -9, 	  -6,   -5, 	  -5,   -1, 	   1,   -7
+.2byte  -11,   -7, 	  -6,   -5, 	  -5,   -1, 	  -2,   -8
+.2byte   -7,  -11, 	  -4,   -5, 	  -4,   -1, 	   0,   -9
+.2byte   -7,   -5, 	  -8,   -1, 	  -2,    1, 	  -1,   -6
+.2byte   -8,   -8, 	  -8,   -1, 	  -3,    1, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -1, 	  -3,    1, 	   1,   -7
+.2byte   -9,   -3, 	  -8,   -1, 	  -2,    1, 	  -1,   -7
+.2byte   -5,  -10, 	  -7,   -2, 	  -2,    0, 	   0,   -9
+.2byte   -1,   -1, 	  -6,   -1, 	   5,   -1, 	  -1,   -6
+.2byte   -8,   -3, 	 -11,   -2, 	  -5,    1, 	   0,   -6
+.2byte  -10,   -6, 	 -10,   -7, 	  -9,   -3, 	   0,   -5
+.2byte   -9,   -9, 	  -2,  -11, 	 -10,   -6, 	   0,   -6
+.2byte   -1,  -12, 	   5,  -11, 	  -6,  -11, 	  -1,   -6
+.2byte    8,   -9, 	   1,  -11, 	   9,   -6, 	  -1,   -6
+.2byte    9,   -6, 	   9,   -7, 	   8,   -3, 	  -1,   -5
+.2byte    6,   -3, 	   9,   -2, 	   3,    1, 	  -2,   -6
+.2byte   -1,   -7, 	  -4,    1, 	   3,    1, 	  -1,   -8
+.2byte    5,   -8, 	   5,   -1, 	   0,    1, 	  -3,   -7
+.2byte    7,  -11, 	   5,   -4, 	   4,    0, 	  -1,   -6
+.2byte    4,  -13, 	  -1,   -4, 	   4,   -1, 	  -2,   -5
+.2byte   -1,  -14, 	   4,   -2, 	  -5,   -2, 	  -1,   -7
+.2byte   -5,  -13, 	   0,   -4, 	  -5,   -1, 	   1,   -5
+.2byte   -8,  -11, 	  -6,   -4, 	  -5,    0, 	   0,   -6
+.2byte   -7,   -8, 	  -7,   -1, 	  -2,    1, 	   1,   -7
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -3, 	  -5,    0, 	   4,    0, 	  -1,   -7
+.2byte    5,   -4, 	   6,    0, 	   0,    2, 	  -1,   -5
+.2byte    5,   -7, 	   8,   -6, 	   2,   -4, 	  -1,   -8
+.2byte    5,   -4, 	   6,   -1, 	   1,    1, 	  -1,   -8
+.2byte    8,   -6, 	   6,   -3, 	   3,    1, 	   0,   -4
+.2byte    8,  -11, 	   9,   -8, 	   7,   -6, 	  -1,   -8
+.2byte    9,   -6, 	   5,   -1, 	   2,    1, 	  -1,   -8
+.2byte    7,  -10, 	   0,   -4, 	   5,   -2, 	  -2,   -6
+.2byte    6,  -13, 	   0,  -11, 	   7,   -7, 	  -2,   -7
+.2byte    8,  -11, 	   1,   -4, 	   5,   -2, 	  -1,  -10
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -5, 	  -1,   -7
+.2byte   -1,  -17, 	   5,  -14, 	  -6,  -14, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -8, 	  -5,   -8, 	  -1,  -10
+.2byte   -8,  -10, 	  -1,   -4, 	  -6,   -2, 	   1,   -6
+.2byte   -7,  -13, 	  -1,  -11, 	  -8,   -7, 	   1,   -7
+.2byte   -9,  -11, 	  -2,   -4, 	  -6,   -2, 	   0,  -10
+.2byte   -9,   -6, 	  -7,   -3, 	  -4,    1, 	  -1,   -4
+.2byte   -9,  -11, 	 -10,   -8, 	  -8,   -6, 	   0,   -8
+.2byte  -10,   -6, 	  -6,   -1, 	  -3,    1, 	   0,   -8
+.2byte   -6,   -4, 	  -7,    0, 	  -1,    2, 	   0,   -5
+.2byte   -6,   -7, 	  -9,   -6, 	  -3,   -4, 	   0,   -8
+.2byte   -6,   -4, 	  -7,   -1, 	  -2,    1, 	   0,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   4,    1, 	  -1,   -7
+.2byte   -7,   -3, 	  -6,   -1, 	   0,    1, 	   1,   -7
+.2byte   -9,   -7, 	  -4,   -5, 	  -3,   -1, 	   0,   -8
+.2byte   -8,  -11, 	   0,   -6, 	  -5,   -2, 	   0,   -7
+.2byte   -1,  -15, 	   4,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte    7,  -11, 	  -1,   -6, 	   4,   -2, 	  -1,   -7
+.2byte    8,   -7, 	   3,   -5, 	   2,   -1, 	  -1,   -8
+.2byte    6,   -3, 	   5,   -1, 	  -1,    1, 	  -2,   -7
+.2byte   -1,   -2, 	  -4,    1, 	   3,    1, 	  -1,   -6
+.2byte   -6,   -5, 	  -7,   -1, 	  -1,    1, 	   0,   -6
+.2byte   -9,   -8, 	  -7,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte   -8,  -11, 	  -1,   -5, 	  -6,   -3, 	   1,   -7
+.2byte   -1,  -14, 	   4,   -5, 	  -5,   -5, 	  -1,   -7
+.2byte    7,  -11, 	   0,   -5, 	   5,   -3, 	  -2,   -7
+.2byte    8,   -8, 	   6,   -5, 	   3,   -1, 	   0,   -6
+.2byte    5,   -5, 	   6,   -1, 	   0,    1, 	  -1,   -6
+sPoochyenaAnimTable1:
+.4byte sPoochyenaAnims_1_1
+.4byte sPoochyenaAnims_1_2
+.4byte sPoochyenaAnims_1_3
+.4byte sPoochyenaAnims_1_4
+.4byte sPoochyenaAnims_1_5
+.4byte sPoochyenaAnims_1_6
+.4byte sPoochyenaAnims_1_7
+.4byte sPoochyenaAnims_1_8
+sPoochyenaAnimTable2:
+.4byte sPoochyenaAnims_2_1
+.4byte sPoochyenaAnims_2_2
+.4byte sPoochyenaAnims_2_3
+.4byte sPoochyenaAnims_2_4
+.4byte sPoochyenaAnims_2_5
+.4byte sPoochyenaAnims_2_6
+.4byte sPoochyenaAnims_2_7
+.4byte sPoochyenaAnims_2_8
+sPoochyenaAnimTable3:
+.4byte sPoochyenaAnims_3_1
+.4byte sPoochyenaAnims_3_2
+.4byte sPoochyenaAnims_3_3
+.4byte sPoochyenaAnims_3_4
+.4byte sPoochyenaAnims_3_5
+.4byte sPoochyenaAnims_3_6
+.4byte sPoochyenaAnims_3_7
+.4byte sPoochyenaAnims_3_8
+sPoochyenaAnimTable4:
+.4byte sPoochyenaAnims_4_1
+.4byte sPoochyenaAnims_4_2
+.4byte sPoochyenaAnims_4_3
+.4byte sPoochyenaAnims_4_4
+.4byte sPoochyenaAnims_4_5
+.4byte sPoochyenaAnims_4_6
+.4byte sPoochyenaAnims_4_7
+.4byte sPoochyenaAnims_4_8
+sPoochyenaAnimTable5:
+.4byte sPoochyenaAnims_5_1
+.4byte sPoochyenaAnims_5_2
+.4byte sPoochyenaAnims_5_3
+.4byte sPoochyenaAnims_5_4
+.4byte sPoochyenaAnims_5_5
+.4byte sPoochyenaAnims_5_6
+.4byte sPoochyenaAnims_5_7
+.4byte sPoochyenaAnims_5_8
+sPoochyenaAnimTable6:
+.4byte sPoochyenaAnims_6_1
+.4byte sPoochyenaAnims_6_1
+.4byte sPoochyenaAnims_6_1
+.4byte sPoochyenaAnims_6_1
+.4byte sPoochyenaAnims_6_1
+.4byte sPoochyenaAnims_6_1
+.4byte sPoochyenaAnims_6_1
+.4byte sPoochyenaAnims_6_1
+sPoochyenaAnimTable7:
+.4byte sPoochyenaAnims_7_1
+.4byte sPoochyenaAnims_7_2
+.4byte sPoochyenaAnims_7_3
+.4byte sPoochyenaAnims_7_4
+.4byte sPoochyenaAnims_7_5
+.4byte sPoochyenaAnims_7_6
+.4byte sPoochyenaAnims_7_7
+.4byte sPoochyenaAnims_7_8
+sPoochyenaAnimTable8:
+.4byte sPoochyenaAnims_8_1
+.4byte sPoochyenaAnims_8_2
+.4byte sPoochyenaAnims_8_3
+.4byte sPoochyenaAnims_8_4
+.4byte sPoochyenaAnims_8_5
+.4byte sPoochyenaAnims_8_6
+.4byte sPoochyenaAnims_8_7
+.4byte sPoochyenaAnims_8_8
+sPoochyenaAnimTable9:
+.4byte sPoochyenaAnims_9_1
+.4byte sPoochyenaAnims_9_2
+.4byte sPoochyenaAnims_9_3
+.4byte sPoochyenaAnims_9_4
+.4byte sPoochyenaAnims_9_5
+.4byte sPoochyenaAnims_9_6
+.4byte sPoochyenaAnims_9_7
+.4byte sPoochyenaAnims_9_8
+sPoochyenaAnimTable10:
+.4byte sPoochyenaAnims_10_1
+.4byte sPoochyenaAnims_10_2
+.4byte sPoochyenaAnims_10_3
+.4byte sPoochyenaAnims_10_4
+.4byte sPoochyenaAnims_10_5
+.4byte sPoochyenaAnims_10_6
+.4byte sPoochyenaAnims_10_7
+.4byte sPoochyenaAnims_10_8
+sPoochyenaAnimTable11:
+.4byte sPoochyenaAnims_11_1
+.4byte sPoochyenaAnims_11_2
+.4byte sPoochyenaAnims_11_3
+.4byte sPoochyenaAnims_11_4
+.4byte sPoochyenaAnims_11_5
+.4byte sPoochyenaAnims_11_6
+.4byte sPoochyenaAnims_11_7
+.4byte sPoochyenaAnims_11_8
+sPoochyenaAnimTable12:
+.4byte sPoochyenaAnims_12_1
+.4byte sPoochyenaAnims_12_2
+.4byte sPoochyenaAnims_12_3
+.4byte sPoochyenaAnims_12_4
+.4byte sPoochyenaAnims_12_5
+.4byte sPoochyenaAnims_12_6
+.4byte sPoochyenaAnims_12_7
+.4byte sPoochyenaAnims_12_8
+sPoochyenaAnimTable13:
+.4byte sPoochyenaAnims_13_1
+.4byte sPoochyenaAnims_13_2
+.4byte sPoochyenaAnims_13_3
+.4byte sPoochyenaAnims_13_4
+.4byte sPoochyenaAnims_13_5
+.4byte sPoochyenaAnims_13_6
+.4byte sPoochyenaAnims_13_7
+.4byte sPoochyenaAnims_13_8
+sAxAnimationsPoochyena:
+.4byte sPoochyenaAnimTable1
+.4byte sPoochyenaAnimTable2
+.4byte sPoochyenaAnimTable3
+.4byte sPoochyenaAnimTable4
+.4byte sPoochyenaAnimTable5
+.4byte sPoochyenaAnimTable6
+.4byte sPoochyenaAnimTable7
+.4byte sPoochyenaAnimTable8
+.4byte sPoochyenaAnimTable9
+.4byte sPoochyenaAnimTable10
+.4byte sPoochyenaAnimTable11
+.4byte sPoochyenaAnimTable12
+.4byte sPoochyenaAnimTable13
+sAxSpritesPoochyena:
+.4byte sPoochyenaSprites1
+.4byte sPoochyenaSprites2
+.4byte sPoochyenaSprites3
+.4byte sPoochyenaSprites4
+.4byte sPoochyenaSprites5
+.4byte sPoochyenaSprites6
+.4byte sPoochyenaSprites7
+.4byte sPoochyenaSprites8
+.4byte sPoochyenaSprites9
+.4byte sPoochyenaSprites10
+.4byte sPoochyenaSprites11
+.4byte sPoochyenaSprites12
+.4byte sPoochyenaSprites13
+.4byte sPoochyenaSprites14
+.4byte sPoochyenaSprites15
+.4byte sPoochyenaSprites16
+.4byte sPoochyenaSprites17
+.4byte sPoochyenaSprites18
+.4byte sPoochyenaSprites19
+.4byte sPoochyenaSprites20
+.4byte sPoochyenaSprites21
+.4byte sPoochyenaSprites22
+.4byte sPoochyenaSprites23
+.4byte sPoochyenaSprites24
+.4byte sPoochyenaSprites25
+.4byte sPoochyenaSprites26
+.4byte sPoochyenaSprites27
+.4byte sPoochyenaSprites28
+.4byte sPoochyenaSprites29
+.4byte sPoochyenaSprites30
+.4byte sPoochyenaSprites31
+.4byte sPoochyenaSprites32
+.4byte sPoochyenaSprites33
+.4byte sPoochyenaSprites34
+.4byte sPoochyenaSprites35
+.4byte sPoochyenaSprites36
+.4byte sPoochyenaSprites37
+.4byte sPoochyenaSprites38
+.4byte sPoochyenaSprites39
+.4byte sPoochyenaSprites40
+.4byte sPoochyenaSprites41
+.4byte sPoochyenaSprites42
+.4byte sPoochyenaSprites43
+.4byte sPoochyenaSprites44
+.4byte sPoochyenaSprites45
+.4byte sPoochyenaSprites46
+.4byte sPoochyenaSprites47
+sAxMainPoochyena:
+ax_main sAxPosesPoochyena, sAxAnimationsPoochyena, 13, sAxSpritesPoochyena, sAxPositionsPoochyena

--- a/data/ax/porygon.inc
+++ b/data/ax/porygon.inc
@@ -1,0 +1,2781 @@
+.global gAxPorygon
+gAxPorygon:
+ax_siro sAxMainPorygon
+sPorygonPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose6:
+ax_pose 5, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose7:
+ax_pose 6, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose8:
+ax_pose 7, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose9:
+ax_pose 8, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose10:
+ax_pose 9, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose11:
+ax_pose 10, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose12:
+ax_pose 11, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose19:
+ax_pose 6, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose20:
+ax_pose 7, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose21:
+ax_pose 8, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose22:
+ax_pose 3, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose23:
+ax_pose 4, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose24:
+ax_pose 5, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose25:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose26:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose27:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose28:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose29:
+ax_pose 16, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose30:
+ax_pose 17, 0x01ec, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygonPose31:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose32:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose33:
+ax_pose 5, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose34:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose35:
+ax_pose 19, 0x01ee, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose36:
+ax_pose 6, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose37:
+ax_pose 7, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose38:
+ax_pose 8, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose39:
+ax_pose 20, 0x01e6, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose40:
+ax_pose 21, 0x01ed, 0x90ea, 0x1c00
+ax_pose_terminator
+sPorygonPose41:
+ax_pose 9, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose42:
+ax_pose 10, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose43:
+ax_pose 11, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose44:
+ax_pose 22, 0x01e8, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose45:
+ax_pose 23, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose46:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose47:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose48:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose49:
+ax_pose 24, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose50:
+ax_pose 21, 0x01ed, 0x80f7, 0x1c00
+ax_pose_terminator
+sPorygonPose51:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose52:
+ax_pose 10, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose53:
+ax_pose 11, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose54:
+ax_pose 22, 0x01e8, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose55:
+ax_pose 19, 0x01ef, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose56:
+ax_pose 6, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose57:
+ax_pose 7, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose58:
+ax_pose 8, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose59:
+ax_pose 20, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose60:
+ax_pose 17, 0x01ec, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose61:
+ax_pose 3, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose62:
+ax_pose 4, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose63:
+ax_pose 5, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose64:
+ax_pose 18, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose65:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose66:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose67:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose68:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose69:
+ax_pose 16, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose70:
+ax_pose 17, 0x01ec, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygonPose71:
+ax_pose 3, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose72:
+ax_pose 4, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose73:
+ax_pose 5, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose74:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose75:
+ax_pose 19, 0x01ee, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose76:
+ax_pose 6, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose77:
+ax_pose 7, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose78:
+ax_pose 8, 0x01ed, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose79:
+ax_pose 20, 0x01e6, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose80:
+ax_pose 21, 0x01ed, 0x90ea, 0x1c00
+ax_pose_terminator
+sPorygonPose81:
+ax_pose 9, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose82:
+ax_pose 10, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose83:
+ax_pose 11, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose84:
+ax_pose 22, 0x01e8, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose85:
+ax_pose 23, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose86:
+ax_pose 12, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose87:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose88:
+ax_pose 14, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose89:
+ax_pose 24, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose90:
+ax_pose 21, 0x01ed, 0x80f7, 0x1c00
+ax_pose_terminator
+sPorygonPose91:
+ax_pose 9, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose92:
+ax_pose 10, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose93:
+ax_pose 11, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose94:
+ax_pose 22, 0x01e8, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose95:
+ax_pose 19, 0x01ef, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose96:
+ax_pose 6, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose97:
+ax_pose 7, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose98:
+ax_pose 8, 0x01ed, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose99:
+ax_pose 20, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose100:
+ax_pose 17, 0x01ec, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose101:
+ax_pose 3, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose102:
+ax_pose 4, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose103:
+ax_pose 5, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose104:
+ax_pose 18, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose105:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose106:
+ax_pose 25, 0x01e4, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose107:
+ax_pose 16, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose108:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygonPose109:
+ax_pose 26, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose110:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose111:
+ax_pose 19, 0x01ee, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose112:
+ax_pose 27, 0x01e8, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose113:
+ax_pose 20, 0x01e8, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose114:
+ax_pose 21, 0x01ee, 0x90ea, 0x1c00
+ax_pose_terminator
+sPorygonPose115:
+ax_pose 28, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose116:
+ax_pose 22, 0x01e8, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose117:
+ax_pose 23, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose118:
+ax_pose 29, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose119:
+ax_pose 24, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose120:
+ax_pose 21, 0x01ee, 0x80f7, 0x1c00
+ax_pose_terminator
+sPorygonPose121:
+ax_pose 28, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose122:
+ax_pose 22, 0x01e8, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose123:
+ax_pose 19, 0x01ef, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose124:
+ax_pose 27, 0x01e9, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose125:
+ax_pose 20, 0x01e9, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose126:
+ax_pose 17, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose127:
+ax_pose 26, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose128:
+ax_pose 18, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose129:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose130:
+ax_pose 16, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose131:
+ax_pose 30, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose132:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygonPose133:
+ax_pose 18, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose134:
+ax_pose 31, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose135:
+ax_pose 19, 0x01ee, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose136:
+ax_pose 20, 0x01e8, 0x90f3, 0x1c00
+ax_pose_terminator
+sPorygonPose137:
+ax_pose 32, 0x01e8, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygonPose138:
+ax_pose 21, 0x01ee, 0x90ea, 0x1c00
+ax_pose_terminator
+sPorygonPose139:
+ax_pose 22, 0x01ea, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose140:
+ax_pose 33, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose141:
+ax_pose 23, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose142:
+ax_pose 24, 0x01e9, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose143:
+ax_pose 34, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose144:
+ax_pose 21, 0x01ee, 0x80f7, 0x1c00
+ax_pose_terminator
+sPorygonPose145:
+ax_pose 22, 0x01ea, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose146:
+ax_pose 33, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose147:
+ax_pose 19, 0x01ef, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose148:
+ax_pose 20, 0x01e9, 0x80ee, 0x1c00
+ax_pose_terminator
+sPorygonPose149:
+ax_pose 32, 0x01e9, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose150:
+ax_pose 17, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose151:
+ax_pose 18, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose152:
+ax_pose 31, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose153:
+ax_pose 35, 0x01ee, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose154:
+ax_pose 36, 0x01ee, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose155:
+ax_pose 37, 0x01e2, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose156:
+ax_pose 38, 0x01e2, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose157:
+ax_pose 39, 0x01e1, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygonPose158:
+ax_pose 40, 0x01e1, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose159:
+ax_pose 41, 0x01e4, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose160:
+ax_pose 40, 0x01e1, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose161:
+ax_pose 39, 0x01e1, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose162:
+ax_pose 38, 0x01e2, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose163:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose164:
+ax_pose 17, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose165:
+ax_pose 19, 0x01ef, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose166:
+ax_pose 21, 0x01ee, 0x80f7, 0x1c00
+ax_pose_terminator
+sPorygonPose167:
+ax_pose 23, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose168:
+ax_pose 21, 0x01ee, 0x90ea, 0x1c00
+ax_pose_terminator
+sPorygonPose169:
+ax_pose 19, 0x01ee, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose170:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygonPose171:
+ax_pose 16, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose172:
+ax_pose 18, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose173:
+ax_pose 20, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose174:
+ax_pose 22, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose175:
+ax_pose 24, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose176:
+ax_pose 22, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose177:
+ax_pose 20, 0x01e8, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygonPose178:
+ax_pose 18, 0x01e5, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose179:
+ax_pose 30, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose180:
+ax_pose 31, 0x01e7, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose181:
+ax_pose 32, 0x01e7, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygonPose182:
+ax_pose 33, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose183:
+ax_pose 34, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose184:
+ax_pose 33, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose185:
+ax_pose 32, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose186:
+ax_pose 31, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose187:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose188:
+ax_pose 25, 0x01e4, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose189:
+ax_pose 16, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose190:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygonPose191:
+ax_pose 26, 0x01e7, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose192:
+ax_pose 18, 0x01e7, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose193:
+ax_pose 19, 0x01ee, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose194:
+ax_pose 27, 0x01e8, 0x90f3, 0x1c00
+ax_pose_terminator
+sPorygonPose195:
+ax_pose 20, 0x01e8, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygonPose196:
+ax_pose 21, 0x01ee, 0x90ea, 0x1c00
+ax_pose_terminator
+sPorygonPose197:
+ax_pose 28, 0x01e6, 0x90f3, 0x1c00
+ax_pose_terminator
+sPorygonPose198:
+ax_pose 22, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygonPose199:
+ax_pose 23, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose200:
+ax_pose 29, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose201:
+ax_pose 24, 0x01e7, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose202:
+ax_pose 21, 0x01ee, 0x80f6, 0x1c00
+ax_pose_terminator
+sPorygonPose203:
+ax_pose 28, 0x01e6, 0x80ed, 0x1c00
+ax_pose_terminator
+sPorygonPose204:
+ax_pose 22, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose205:
+ax_pose 19, 0x01ee, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygonPose206:
+ax_pose 27, 0x01e8, 0x80ed, 0x1c00
+ax_pose_terminator
+sPorygonPose207:
+ax_pose 20, 0x01e8, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose208:
+ax_pose 17, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose209:
+ax_pose 26, 0x01e7, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygonPose210:
+ax_pose 18, 0x01e7, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose211:
+ax_pose 16, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose212:
+ax_pose 18, 0x01e7, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygonPose213:
+ax_pose 20, 0x01e9, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygonPose214:
+ax_pose 22, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose215:
+ax_pose 24, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose216:
+ax_pose 22, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygonPose217:
+ax_pose 20, 0x01e9, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygonPose218:
+ax_pose 18, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygonPose219:
+ax_pose 15, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose220:
+ax_pose 17, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygonPose221:
+ax_pose 19, 0x01ef, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygonPose222:
+ax_pose 21, 0x01ee, 0x80f7, 0x1c00
+ax_pose_terminator
+sPorygonPose223:
+ax_pose 23, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygonPose224:
+ax_pose 21, 0x01ee, 0x90ea, 0x1c00
+ax_pose_terminator
+sPorygonPose225:
+ax_pose 19, 0x01ee, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygonPose226:
+ax_pose 17, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+.align 2
+sPorygonAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, -2, 0, 0,
+ax_anim 10, 0, 0, 0, -3, 0, 0,
+ax_anim 10, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, -2, 0, 0,
+ax_anim 10, 0, 3, 0, -3, 0, 0,
+ax_anim 10, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, -2, 0, 0,
+ax_anim 10, 0, 6, 0, -3, 0, 0,
+ax_anim 10, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, -2, 0, 0,
+ax_anim 10, 0, 9, 0, -3, 0, 0,
+ax_anim 10, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, -2, 0, 0,
+ax_anim 10, 0, 12, 0, -3, 0, 0,
+ax_anim 10, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, -2, 0, 0,
+ax_anim 10, 0, 15, 0, -3, 0, 0,
+ax_anim 10, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, -2, 0, 0,
+ax_anim 10, 0, 18, 0, -3, 0, 0,
+ax_anim 10, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, -2, 0, 0,
+ax_anim 10, 0, 21, 0, -3, 0, 0,
+ax_anim 10, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygonAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 16, 0, 16,
+ax_anim 2, 1, 28, 1, 16, 1, 16,
+ax_anim 2, 0, 28, 0, 16, 0, 16,
+ax_anim 2, 0, 28, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPorygonAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 32, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 16, 16, 16, 16,
+ax_anim 2, 1, 33, 17, 15, 17, 15,
+ax_anim 2, 0, 33, 16, 16, 16, 16,
+ax_anim 2, 0, 33, 17, 15, 17, 15,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sPorygonAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 4, 0, 4, 0,
+ax_anim 1, 0, 37, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 14, 0, 14, 0,
+ax_anim 2, 1, 38, 14, -1, 14, -1,
+ax_anim 2, 0, 38, 14, 0, 14, 0,
+ax_anim 2, 0, 38, 14, -1, 14, -1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sPorygonAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 4, -4, 4, -4,
+ax_anim 1, 0, 42, 9, -10, 9, -10,
+ax_anim 2, 0, 43, 16, -18, 16, -18,
+ax_anim 2, 1, 43, 17, -17, 17, -17,
+ax_anim 2, 0, 43, 16, -18, 16, -18,
+ax_anim 2, 0, 43, 17, -17, 17, -17,
+ax_anim 2, 0, 39, 5, -6, 5, -6,
+ax_anim_terminator
+sPorygonAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, 0, -4, 0, -4,
+ax_anim 1, 0, 47, 0, -10, 0, -10,
+ax_anim 2, 0, 48, 0, -15, 0, -15,
+ax_anim 2, 1, 48, 1, -15, 1, -15,
+ax_anim 2, 0, 48, 0, -15, 0, -15,
+ax_anim 2, 0, 48, 1, -15, 1, -15,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sPorygonAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 4, 0, 49, 2, 2, 2, 2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, -4, -4, -4,
+ax_anim 1, 0, 52, -9, -10, -9, -10,
+ax_anim 2, 0, 53, -16, -18, -16, -18,
+ax_anim 2, 1, 53, -17, -17, -17, -17,
+ax_anim 2, 0, 53, -16, -18, -16, -18,
+ax_anim 2, 0, 53, -17, -17, -17, -17,
+ax_anim 2, 0, 49, -5, -6, -5, -6,
+ax_anim_terminator
+sPorygonAnims_2_7:
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 4, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 56, -4, 0, -4, 0,
+ax_anim 1, 0, 57, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -14, 0, -14, 0,
+ax_anim 2, 1, 58, -14, -1, -14, -1,
+ax_anim 2, 0, 58, -14, 0, -14, 0,
+ax_anim 2, 0, 58, -14, -1, -14, -1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sPorygonAnims_2_8:
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 4, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, -4, 4, -4, 4,
+ax_anim 1, 0, 62, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -16, 16, -16, 16,
+ax_anim 2, 1, 63, -17, 15, -17, 15,
+ax_anim 2, 0, 63, -16, 16, -16, 16,
+ax_anim 2, 0, 63, -17, 15, -17, 15,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPorygonAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 64, 0, -2, 0, -2,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 0, 4, 0, 4,
+ax_anim 1, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 1, 68, 1, 16, 1, 16,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 0, 68, 1, 16, 1, 16,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sPorygonAnims_3_2:
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 4, 0, 69, -2, -2, -2, -2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 4, 4, 4, 4,
+ax_anim 1, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 73, 16, 16, 16, 16,
+ax_anim 2, 1, 73, 17, 15, 17, 15,
+ax_anim 2, 0, 73, 16, 16, 16, 16,
+ax_anim 2, 0, 73, 17, 15, 17, 15,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sPorygonAnims_3_3:
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 4, 0, 74, -2, 0, -2, 0,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 2, 76, 4, 0, 4, 0,
+ax_anim 1, 0, 77, 10, 0, 10, 0,
+ax_anim 2, 0, 78, 14, 0, 14, 0,
+ax_anim 2, 1, 78, 14, -1, 14, -1,
+ax_anim 2, 0, 78, 14, 0, 14, 0,
+ax_anim 2, 0, 78, 14, -1, 14, -1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sPorygonAnims_3_4:
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 4, 0, 79, -2, 2, -2, 2,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, 4, -4, 4, -4,
+ax_anim 1, 0, 82, 9, -10, 9, -10,
+ax_anim 2, 0, 83, 16, -18, 16, -18,
+ax_anim 2, 1, 83, 17, -17, 17, -17,
+ax_anim 2, 0, 83, 16, -18, 16, -18,
+ax_anim 2, 0, 83, 17, -17, 17, -17,
+ax_anim 2, 0, 79, 5, -6, 5, -6,
+ax_anim_terminator
+sPorygonAnims_3_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 4, 0, 84, 0, 2, 0, 2,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 2, 86, 0, -4, 0, -4,
+ax_anim 1, 0, 87, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 0, -15, 0, -15,
+ax_anim 2, 1, 88, 1, -15, 1, -15,
+ax_anim 2, 0, 88, 0, -15, 0, -15,
+ax_anim 2, 0, 88, 1, -15, 1, -15,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sPorygonAnims_3_6:
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 4, 0, 89, 2, 2, 2, 2,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 2, 91, -4, -4, -4, -4,
+ax_anim 1, 0, 92, -9, -10, -9, -10,
+ax_anim 2, 0, 93, -16, -18, -16, -18,
+ax_anim 2, 1, 93, -17, -17, -17, -17,
+ax_anim 2, 0, 93, -16, -18, -16, -18,
+ax_anim 2, 0, 93, -17, -17, -17, -17,
+ax_anim 2, 0, 89, -5, -6, -5, -6,
+ax_anim_terminator
+sPorygonAnims_3_7:
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 4, 0, 94, 2, 0, 2, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 2, 96, -4, 0, -4, 0,
+ax_anim 1, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 98, -14, 0, -14, 0,
+ax_anim 2, 1, 98, -14, -1, -14, -1,
+ax_anim 2, 0, 98, -14, 0, -14, 0,
+ax_anim 2, 0, 98, -14, -1, -14, -1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sPorygonAnims_3_8:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 2, 101, -4, 4, -4, 4,
+ax_anim 1, 0, 102, -10, 10, -10, 10,
+ax_anim 2, 0, 103, -16, 16, -16, 16,
+ax_anim 2, 1, 103, -17, 15, -17, 15,
+ax_anim 2, 0, 103, -16, 16, -16, 16,
+ax_anim 2, 0, 103, -17, 15, -17, 15,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sPorygonAnims_4_1:
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 6, 2, 105, 0, -4, 0, -4,
+ax_anim 1, 0, 106, 0, -2, 0, -2,
+ax_anim 1, 0, 106, 0, 2, 0, 2,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sPorygonAnims_4_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 108, -3, -3, -3, -3,
+ax_anim 6, 2, 108, -4, -4, -4, -4,
+ax_anim 1, 0, 109, -2, -2, -2, -2,
+ax_anim 1, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 1, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 4, 2, 4, 2,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 4, 2, 4, 2,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 4, 2, 4, 2,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim_terminator
+sPorygonAnims_4_3:
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 6, 2, 111, -4, 0, -4, 0,
+ax_anim 1, 0, 112, -2, 0, -2, 0,
+ax_anim 1, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 1, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, -1, 3, -1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, -1, 3, -1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, -1, 3, -1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sPorygonAnims_4_4:
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 114, -3, 3, -3, 3,
+ax_anim 6, 2, 114, -4, 4, -4, 4,
+ax_anim 1, 0, 115, -2, 2, -2, 2,
+ax_anim 1, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 1, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 4, -2, 4, -2,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 4, -2, 4, -2,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 4, -2, 4, -2,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim_terminator
+sPorygonAnims_4_5:
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim 2, 0, 117, 0, 3, 0, 3,
+ax_anim 6, 2, 117, 0, 4, 0, 4,
+ax_anim 1, 0, 118, 0, 2, 0, 2,
+ax_anim 1, 0, 118, 0, -2, 0, -2,
+ax_anim 2, 1, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sPorygonAnims_4_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 2, 0, 120, 3, 3, 3, 3,
+ax_anim 6, 2, 120, 4, 4, 4, 4,
+ax_anim 1, 0, 121, 2, 2, 2, 2,
+ax_anim 1, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 1, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -4, -2, -4, -2,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -4, -2, -4, -2,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -4, -2, -4, -2,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim_terminator
+sPorygonAnims_4_7:
+ax_anim 2, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 3, 0, 3, 0,
+ax_anim 6, 2, 123, 4, 0, 4, 0,
+ax_anim 1, 0, 124, 2, 0, 2, 0,
+ax_anim 1, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 1, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, -1, -3, -1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, -1, -3, -1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, -1, -3, -1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sPorygonAnims_4_8:
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 3, -3, 3, -3,
+ax_anim 6, 2, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 127, 2, -2, 2, -2,
+ax_anim 1, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 1, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -4, 2, -4, 2,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPorygonAnims_5_1:
+ax_anim 2, 0, 128, 0, -1, 0, -1,
+ax_anim 6, 0, 128, 0, -2, 0, -2,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 1, 0, 1,
+ax_anim 2, 0, 130, 1, 1, 1, 1,
+ax_anim 2, 2, 130, 0, 1, 0, 1,
+ax_anim 2, 0, 130, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 0, 1, 0, 1,
+ax_anim 2, 0, 130, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 0, 1, 0, 1,
+ax_anim_terminator
+sPorygonAnims_5_2:
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 6, 0, 131, -2, -2, -2, -2,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, 1, 1, 1,
+ax_anim 2, 0, 133, 2, 0, 2, 0,
+ax_anim 2, 2, 133, 1, 1, 1, 1,
+ax_anim 2, 0, 133, 2, 0, 2, 0,
+ax_anim 2, 0, 133, 1, 1, 1, 1,
+ax_anim 2, 0, 133, 2, 0, 2, 0,
+ax_anim 2, 0, 133, 1, 1, 1, 1,
+ax_anim_terminator
+sPorygonAnims_5_3:
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim 6, 0, 134, -2, 0, -2, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 1, -1, 1, -1,
+ax_anim 2, 2, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 1, -1, 1, -1,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 136, 1, -1, 1, -1,
+ax_anim 2, 0, 136, 1, 0, 1, 0,
+ax_anim_terminator
+sPorygonAnims_5_4:
+ax_anim 2, 0, 137, -1, 1, -1, 1,
+ax_anim 6, 0, 137, -2, 2, -2, 2,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 2, 0, 2, 0,
+ax_anim 2, 2, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 2, 0, 2, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 2, 0, 2, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim_terminator
+sPorygonAnims_5_5:
+ax_anim 2, 0, 140, 0, 1, 0, 1,
+ax_anim 6, 0, 140, 0, 2, 0, 2,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 2, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, 0, -1, 0, -1,
+ax_anim_terminator
+sPorygonAnims_5_6:
+ax_anim 2, 0, 143, 1, 1, 1, 1,
+ax_anim 6, 0, 143, 2, 2, 2, 2,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 0, 145, -2, 0, -2, 0,
+ax_anim 2, 2, 145, -1, -1, -1, -1,
+ax_anim 2, 0, 145, -2, 0, -2, 0,
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim 2, 0, 145, -2, 0, -2, 0,
+ax_anim 2, 0, 145, -1, -1, -1, -1,
+ax_anim_terminator
+sPorygonAnims_5_7:
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 6, 0, 146, 2, 0, 2, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, -1, -1, -1, -1,
+ax_anim 2, 2, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, -1, -1, -1, -1,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim 2, 0, 148, -1, -1, -1, -1,
+ax_anim 2, 0, 148, -1, 0, -1, 0,
+ax_anim_terminator
+sPorygonAnims_5_8:
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 6, 0, 149, 2, -2, 2, -2,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, 1, -1, 1,
+ax_anim 2, 0, 151, -2, 0, -2, 0,
+ax_anim 2, 2, 151, -1, 1, -1, 1,
+ax_anim 2, 0, 151, -2, 0, -2, 0,
+ax_anim 2, 0, 151, -1, 1, -1, 1,
+ax_anim 2, 0, 151, -2, 0, -2, 0,
+ax_anim 2, 0, 151, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sPorygonAnims_6_1:
+ax_anim 16, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 16, 0, 152, 0, -2, 0, 0,
+ax_anim 16, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygonAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sPorygonAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sPorygonAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sPorygonAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sPorygonAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sPorygonAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sPorygonAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sPorygonAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPorygonAnims_8_1:
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, -1, 0, 0,
+ax_anim 12, 0, 162, 0, -2, 0, 0,
+ax_anim 8, 0, 162, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_8_2:
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, -1, 0, 0,
+ax_anim 12, 0, 169, 0, -2, 0, 0,
+ax_anim 8, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_8_3:
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, -1, 0, 0,
+ax_anim 12, 0, 168, 0, -2, 0, 0,
+ax_anim 8, 0, 168, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_8_4:
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, -1, 0, 0,
+ax_anim 12, 0, 167, 0, -2, 0, 0,
+ax_anim 8, 0, 167, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_8_5:
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, -1, 0, 0,
+ax_anim 12, 0, 166, 0, -2, 0, 0,
+ax_anim 8, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_8_6:
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, -1, 0, 0,
+ax_anim 12, 0, 165, 0, -2, 0, 0,
+ax_anim 8, 0, 165, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_8_7:
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, -1, 0, 0,
+ax_anim 12, 0, 164, 0, -2, 0, 0,
+ax_anim 8, 0, 164, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygonAnims_8_8:
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, -1, 0, 0,
+ax_anim 12, 0, 163, 0, -2, 0, 0,
+ax_anim 8, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygonAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 10, 9, 10, 9,
+ax_anim 2, 0, 173, 8, 14, 8, 14,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -8, 14, -8, 14,
+ax_anim 2, 0, 176, -10, 9, -10, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 11, -1, 11, -1,
+ax_anim 2, 0, 171, 19, 5, 19, 5,
+ax_anim 2, 0, 172, 21, 11, 21, 11,
+ax_anim 3, 0, 173, 19, 18, 19, 18,
+ax_anim 2, 3, 174, 10, 20, 10, 20,
+ax_anim 2, 0, 175, 2, 16, 2, 16,
+ax_anim 1, 0, 176, -1, 8, -1, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 5, -5, 5, -5,
+ax_anim 2, 0, 170, 15, -9, 15, -9,
+ax_anim 2, 0, 171, 22, -6, 22, -6,
+ax_anim 3, 0, 172, 22, -2, 22, -2,
+ax_anim 2, 3, 173, 18, 5, 18, 5,
+ax_anim 2, 0, 174, 12, 9, 12, 9,
+ax_anim 1, 0, 175, 2, 5, 2, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 3, -15, 3, -15,
+ax_anim 2, 0, 170, 11, -21, 11, -21,
+ax_anim 3, 0, 171, 19, -22, 19, -22,
+ax_anim 2, 3, 172, 23, -15, 23, -15,
+ax_anim 2, 0, 173, 20, -3, 20, -3,
+ax_anim 1, 0, 174, 11, 3, 11, 3,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -5, -8, -5,
+ax_anim 2, 0, 176, -10, -12, -10, -12,
+ax_anim 2, 0, 177, -7, -19, -7, -19,
+ax_anim 3, 0, 170, 0, -23, 0, -23,
+ax_anim 2, 3, 171, 7, -19, 7, -19,
+ax_anim 2, 0, 172, 10, -12, 10, -12,
+ax_anim 1, 0, 173, 8, -5, 8, -5,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -3, -15, -3, -15,
+ax_anim 2, 0, 170, -11, -21, -11, -21,
+ax_anim 3, 0, 177, -19, -22, -19, -22,
+ax_anim 2, 3, 176, -23, -15, -23, -15,
+ax_anim 2, 0, 175, -20, -3, -20, -3,
+ax_anim 1, 0, 174, -11, 3, -11, 3,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -5, -5, -5, -5,
+ax_anim 2, 0, 170, -15, -9, -15, -9,
+ax_anim 2, 0, 177, -22, -6, -22, -6,
+ax_anim 3, 0, 176, -22, -2, -22, -2,
+ax_anim 2, 3, 175, -18, 5, -18, 5,
+ax_anim 2, 0, 174, -12, 9, -12, 9,
+ax_anim 1, 0, 173, -2, 5, -2, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -11, -1, -11, -1,
+ax_anim 2, 0, 177, -19, 5, -19, 5,
+ax_anim 2, 0, 176, -21, 11, -21, 11,
+ax_anim 3, 0, 175, -19, 18, -19, 18,
+ax_anim 2, 3, 174, -10, 20, -10, 20,
+ax_anim 2, 0, 173, -2, 16, -2, 16,
+ax_anim 1, 0, 172, -1, 8, -1, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygonAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygonAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygonAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygonAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygonGfx1:
+.incbin "baserom.gba", 0xAED190, 0x200
+sPorygonSprites1:
+ax_sprite sPorygonGfx1, 0x200
+ax_sprite_terminator
+sPorygonGfx2:
+.incbin "baserom.gba", 0xAED3A0, 0x200
+sPorygonSprites2:
+ax_sprite sPorygonGfx2, 0x200
+ax_sprite_terminator
+sPorygonGfx3:
+.incbin "baserom.gba", 0xAED5B0, 0x200
+sPorygonSprites3:
+ax_sprite sPorygonGfx3, 0x200
+ax_sprite_terminator
+sPorygonGfx4:
+.incbin "baserom.gba", 0xAED7C0, 0x200
+sPorygonSprites4:
+ax_sprite sPorygonGfx4, 0x200
+ax_sprite_terminator
+sPorygonGfx5:
+.incbin "baserom.gba", 0xAED9D0, 0x200
+sPorygonSprites5:
+ax_sprite sPorygonGfx5, 0x200
+ax_sprite_terminator
+sPorygonGfx6:
+.incbin "baserom.gba", 0xAEDBE0, 0x200
+sPorygonSprites6:
+ax_sprite sPorygonGfx6, 0x200
+ax_sprite_terminator
+sPorygonGfx7:
+.incbin "baserom.gba", 0xAEDDF0, 0x200
+sPorygonSprites7:
+ax_sprite sPorygonGfx7, 0x200
+ax_sprite_terminator
+sPorygonGfx8:
+.incbin "baserom.gba", 0xAEE000, 0x200
+sPorygonSprites8:
+ax_sprite sPorygonGfx8, 0x200
+ax_sprite_terminator
+sPorygonGfx9:
+.incbin "baserom.gba", 0xAEE210, 0x200
+sPorygonSprites9:
+ax_sprite sPorygonGfx9, 0x200
+ax_sprite_terminator
+sPorygonGfx10:
+.incbin "baserom.gba", 0xAEE420, 0x200
+sPorygonSprites10:
+ax_sprite sPorygonGfx10, 0x200
+ax_sprite_terminator
+sPorygonGfx11:
+.incbin "baserom.gba", 0xAEE630, 0x200
+sPorygonSprites11:
+ax_sprite sPorygonGfx11, 0x200
+ax_sprite_terminator
+sPorygonGfx12:
+.incbin "baserom.gba", 0xAEE840, 0x200
+sPorygonSprites12:
+ax_sprite sPorygonGfx12, 0x200
+ax_sprite_terminator
+sPorygonGfx13:
+.incbin "baserom.gba", 0xAEEA50, 0x200
+sPorygonSprites13:
+ax_sprite sPorygonGfx13, 0x200
+ax_sprite_terminator
+sPorygonGfx14:
+.incbin "baserom.gba", 0xAEEC60, 0x200
+sPorygonSprites14:
+ax_sprite sPorygonGfx14, 0x200
+ax_sprite_terminator
+sPorygonGfx15:
+.incbin "baserom.gba", 0xAEEE70, 0x200
+sPorygonSprites15:
+ax_sprite sPorygonGfx15, 0x200
+ax_sprite_terminator
+sPorygonGfx16:
+.incbin "baserom.gba", 0xAEF080, 0x20
+sPorygonGfx16_1:
+.incbin "baserom.gba", 0xAEF0A0, 0x60
+sPorygonGfx16_2:
+.incbin "baserom.gba", 0xAEF100, 0x60
+sPorygonSprites16:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygonGfx17:
+.incbin "baserom.gba", 0xAEF1A0, 0x40
+sPorygonGfx17_1:
+.incbin "baserom.gba", 0xAEF1E0, 0x100
+sPorygonSprites17:
+ax_sprite 0, 0xa0
+ax_sprite sPorygonGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx17_1, 0x100
+ax_sprite_terminator
+sPorygonGfx18:
+.incbin "baserom.gba", 0xAEF308, 0x60
+sPorygonGfx18_1:
+.incbin "baserom.gba", 0xAEF368, 0x60
+sPorygonGfx18_2:
+.incbin "baserom.gba", 0xAEF3C8, 0x60
+sPorygonSprites18:
+ax_sprite sPorygonGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygonGfx19:
+.incbin "baserom.gba", 0xAEF460, 0x40
+sPorygonGfx19_1:
+.incbin "baserom.gba", 0xAEF4A0, 0x60
+sPorygonGfx19_2:
+.incbin "baserom.gba", 0xAEF500, 0x60
+sPorygonSprites19:
+ax_sprite 0, 0xa0
+ax_sprite sPorygonGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygonGfx20:
+.incbin "baserom.gba", 0xAEF5A0, 0x100
+sPorygonGfx20_1:
+.incbin "baserom.gba", 0xAEF6A0, 0x40
+sPorygonSprites20:
+ax_sprite sPorygonGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx20_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygonGfx21:
+.incbin "baserom.gba", 0xAEF708, 0x20
+sPorygonGfx21_1:
+.incbin "baserom.gba", 0xAEF728, 0x100
+sPorygonGfx21_2:
+.incbin "baserom.gba", 0xAEF828, 0x40
+sPorygonSprites21:
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx21, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygonGfx22:
+.incbin "baserom.gba", 0xAEF8A8, 0x40
+sPorygonGfx22_1:
+.incbin "baserom.gba", 0xAEF8E8, 0x60
+sPorygonGfx22_2:
+.incbin "baserom.gba", 0xAEF948, 0x60
+sPorygonSprites22:
+ax_sprite sPorygonGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygonGfx23:
+.incbin "baserom.gba", 0xAEF9E0, 0x40
+sPorygonGfx23_1:
+.incbin "baserom.gba", 0xAEFA20, 0x60
+sPorygonGfx23_2:
+.incbin "baserom.gba", 0xAEFA80, 0x40
+sPorygonGfx23_3:
+.incbin "baserom.gba", 0xAEFAC0, 0x40
+sPorygonSprites23:
+ax_sprite sPorygonGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx23_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygonGfx24:
+.incbin "baserom.gba", 0xAEFB48, 0x60
+sPorygonGfx24_1:
+.incbin "baserom.gba", 0xAEFBA8, 0x60
+sPorygonGfx24_2:
+.incbin "baserom.gba", 0xAEFC08, 0x60
+sPorygonSprites24:
+ax_sprite sPorygonGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygonGfx25:
+.incbin "baserom.gba", 0xAEFCA0, 0x40
+sPorygonGfx25_1:
+.incbin "baserom.gba", 0xAEFCE0, 0x40
+sPorygonGfx25_2:
+.incbin "baserom.gba", 0xAEFD20, 0x100
+sPorygonSprites25:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx25_2, 0x100
+ax_sprite_terminator
+sPorygonGfx26:
+.incbin "baserom.gba", 0xAEFE58, 0x40
+sPorygonGfx26_1:
+.incbin "baserom.gba", 0xAEFE98, 0x40
+sPorygonGfx26_2:
+.incbin "baserom.gba", 0xAEFED8, 0x100
+sPorygonSprites26:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx26_2, 0x100
+ax_sprite_terminator
+sPorygonGfx27:
+.incbin "baserom.gba", 0xAF0010, 0x20
+sPorygonGfx27_1:
+.incbin "baserom.gba", 0xAF0030, 0xE0
+sPorygonGfx27_2:
+.incbin "baserom.gba", 0xAF0110, 0x40
+sPorygonSprites27:
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx27_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygonGfx28:
+.incbin "baserom.gba", 0xAF0190, 0x40
+sPorygonGfx28_1:
+.incbin "baserom.gba", 0xAF01D0, 0x60
+sPorygonGfx28_2:
+.incbin "baserom.gba", 0xAF0230, 0x60
+sPorygonGfx28_3:
+.incbin "baserom.gba", 0xAF0290, 0x60
+sPorygonSprites28:
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx28_3, 0x60
+ax_sprite_terminator
+sPorygonGfx29:
+.incbin "baserom.gba", 0xAF0338, 0x20
+sPorygonGfx29_1:
+.incbin "baserom.gba", 0xAF0358, 0xE0
+sPorygonGfx29_2:
+.incbin "baserom.gba", 0xAF0438, 0x60
+sPorygonSprites29:
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx29_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx29_2, 0x60
+ax_sprite_terminator
+sPorygonGfx30:
+.incbin "baserom.gba", 0xAF04D0, 0x40
+sPorygonGfx30_1:
+.incbin "baserom.gba", 0xAF0510, 0x100
+sPorygonSprites30:
+ax_sprite 0, 0xa0
+ax_sprite sPorygonGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx30_1, 0x100
+ax_sprite_terminator
+sPorygonGfx31:
+.incbin "baserom.gba", 0xAF0638, 0x40
+sPorygonGfx31_1:
+.incbin "baserom.gba", 0xAF0678, 0x40
+sPorygonGfx31_2:
+.incbin "baserom.gba", 0xAF06B8, 0x100
+sPorygonSprites31:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx31_2, 0x100
+ax_sprite_terminator
+sPorygonGfx32:
+.incbin "baserom.gba", 0xAF07F0, 0x40
+sPorygonGfx32_1:
+.incbin "baserom.gba", 0xAF0830, 0xE0
+sPorygonGfx32_2:
+.incbin "baserom.gba", 0xAF0910, 0x40
+sPorygonSprites32:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx32_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygonGfx33:
+.incbin "baserom.gba", 0xAF0990, 0x40
+sPorygonGfx33_1:
+.incbin "baserom.gba", 0xAF09D0, 0x60
+sPorygonGfx33_2:
+.incbin "baserom.gba", 0xAF0A30, 0x60
+sPorygonGfx33_3:
+.incbin "baserom.gba", 0xAF0A90, 0x40
+sPorygonSprites33:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygonGfx34:
+.incbin "baserom.gba", 0xAF0B20, 0x40
+sPorygonGfx34_1:
+.incbin "baserom.gba", 0xAF0B60, 0x40
+sPorygonGfx34_2:
+.incbin "baserom.gba", 0xAF0BA0, 0x80
+sPorygonGfx34_3:
+.incbin "baserom.gba", 0xAF0C20, 0x40
+sPorygonSprites34:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx34_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygonGfx35:
+.incbin "baserom.gba", 0xAF0CB0, 0x40
+sPorygonGfx35_1:
+.incbin "baserom.gba", 0xAF0CF0, 0x40
+sPorygonGfx35_2:
+.incbin "baserom.gba", 0xAF0D30, 0x100
+sPorygonSprites35:
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygonGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygonGfx35_2, 0x100
+ax_sprite_terminator
+sPorygonGfx36:
+.incbin "baserom.gba", 0xAF0E68, 0x200
+sPorygonSprites36:
+ax_sprite sPorygonGfx36, 0x200
+ax_sprite_terminator
+sPorygonGfx37:
+.incbin "baserom.gba", 0xAF1078, 0x200
+sPorygonSprites37:
+ax_sprite sPorygonGfx37, 0x200
+ax_sprite_terminator
+sPorygonGfx38:
+.incbin "baserom.gba", 0xAF1288, 0x200
+sPorygonSprites38:
+ax_sprite sPorygonGfx38, 0x200
+ax_sprite_terminator
+sPorygonGfx39:
+.incbin "baserom.gba", 0xAF1498, 0x200
+sPorygonSprites39:
+ax_sprite sPorygonGfx39, 0x200
+ax_sprite_terminator
+sPorygonGfx40:
+.incbin "baserom.gba", 0xAF16A8, 0x200
+sPorygonSprites40:
+ax_sprite sPorygonGfx40, 0x200
+ax_sprite_terminator
+sPorygonGfx41:
+.incbin "baserom.gba", 0xAF18B8, 0x200
+sPorygonSprites41:
+ax_sprite sPorygonGfx41, 0x200
+ax_sprite_terminator
+sPorygonGfx42:
+.incbin "baserom.gba", 0xAF1AC8, 0x200
+sPorygonSprites42:
+ax_sprite sPorygonGfx42, 0x200
+ax_sprite_terminator
+sAxPosesPorygon:
+.4byte sPorygonPose1
+.4byte sPorygonPose2
+.4byte sPorygonPose3
+.4byte sPorygonPose4
+.4byte sPorygonPose5
+.4byte sPorygonPose6
+.4byte sPorygonPose7
+.4byte sPorygonPose8
+.4byte sPorygonPose9
+.4byte sPorygonPose10
+.4byte sPorygonPose11
+.4byte sPorygonPose12
+.4byte sPorygonPose13
+.4byte sPorygonPose14
+.4byte sPorygonPose15
+.4byte sPorygonPose16
+.4byte sPorygonPose17
+.4byte sPorygonPose18
+.4byte sPorygonPose19
+.4byte sPorygonPose20
+.4byte sPorygonPose21
+.4byte sPorygonPose22
+.4byte sPorygonPose23
+.4byte sPorygonPose24
+.4byte sPorygonPose25
+.4byte sPorygonPose26
+.4byte sPorygonPose27
+.4byte sPorygonPose28
+.4byte sPorygonPose29
+.4byte sPorygonPose30
+.4byte sPorygonPose31
+.4byte sPorygonPose32
+.4byte sPorygonPose33
+.4byte sPorygonPose34
+.4byte sPorygonPose35
+.4byte sPorygonPose36
+.4byte sPorygonPose37
+.4byte sPorygonPose38
+.4byte sPorygonPose39
+.4byte sPorygonPose40
+.4byte sPorygonPose41
+.4byte sPorygonPose42
+.4byte sPorygonPose43
+.4byte sPorygonPose44
+.4byte sPorygonPose45
+.4byte sPorygonPose46
+.4byte sPorygonPose47
+.4byte sPorygonPose48
+.4byte sPorygonPose49
+.4byte sPorygonPose50
+.4byte sPorygonPose51
+.4byte sPorygonPose52
+.4byte sPorygonPose53
+.4byte sPorygonPose54
+.4byte sPorygonPose55
+.4byte sPorygonPose56
+.4byte sPorygonPose57
+.4byte sPorygonPose58
+.4byte sPorygonPose59
+.4byte sPorygonPose60
+.4byte sPorygonPose61
+.4byte sPorygonPose62
+.4byte sPorygonPose63
+.4byte sPorygonPose64
+.4byte sPorygonPose65
+.4byte sPorygonPose66
+.4byte sPorygonPose67
+.4byte sPorygonPose68
+.4byte sPorygonPose69
+.4byte sPorygonPose70
+.4byte sPorygonPose71
+.4byte sPorygonPose72
+.4byte sPorygonPose73
+.4byte sPorygonPose74
+.4byte sPorygonPose75
+.4byte sPorygonPose76
+.4byte sPorygonPose77
+.4byte sPorygonPose78
+.4byte sPorygonPose79
+.4byte sPorygonPose80
+.4byte sPorygonPose81
+.4byte sPorygonPose82
+.4byte sPorygonPose83
+.4byte sPorygonPose84
+.4byte sPorygonPose85
+.4byte sPorygonPose86
+.4byte sPorygonPose87
+.4byte sPorygonPose88
+.4byte sPorygonPose89
+.4byte sPorygonPose90
+.4byte sPorygonPose91
+.4byte sPorygonPose92
+.4byte sPorygonPose93
+.4byte sPorygonPose94
+.4byte sPorygonPose95
+.4byte sPorygonPose96
+.4byte sPorygonPose97
+.4byte sPorygonPose98
+.4byte sPorygonPose99
+.4byte sPorygonPose100
+.4byte sPorygonPose101
+.4byte sPorygonPose102
+.4byte sPorygonPose103
+.4byte sPorygonPose104
+.4byte sPorygonPose105
+.4byte sPorygonPose106
+.4byte sPorygonPose107
+.4byte sPorygonPose108
+.4byte sPorygonPose109
+.4byte sPorygonPose110
+.4byte sPorygonPose111
+.4byte sPorygonPose112
+.4byte sPorygonPose113
+.4byte sPorygonPose114
+.4byte sPorygonPose115
+.4byte sPorygonPose116
+.4byte sPorygonPose117
+.4byte sPorygonPose118
+.4byte sPorygonPose119
+.4byte sPorygonPose120
+.4byte sPorygonPose121
+.4byte sPorygonPose122
+.4byte sPorygonPose123
+.4byte sPorygonPose124
+.4byte sPorygonPose125
+.4byte sPorygonPose126
+.4byte sPorygonPose127
+.4byte sPorygonPose128
+.4byte sPorygonPose129
+.4byte sPorygonPose130
+.4byte sPorygonPose131
+.4byte sPorygonPose132
+.4byte sPorygonPose133
+.4byte sPorygonPose134
+.4byte sPorygonPose135
+.4byte sPorygonPose136
+.4byte sPorygonPose137
+.4byte sPorygonPose138
+.4byte sPorygonPose139
+.4byte sPorygonPose140
+.4byte sPorygonPose141
+.4byte sPorygonPose142
+.4byte sPorygonPose143
+.4byte sPorygonPose144
+.4byte sPorygonPose145
+.4byte sPorygonPose146
+.4byte sPorygonPose147
+.4byte sPorygonPose148
+.4byte sPorygonPose149
+.4byte sPorygonPose150
+.4byte sPorygonPose151
+.4byte sPorygonPose152
+.4byte sPorygonPose153
+.4byte sPorygonPose154
+.4byte sPorygonPose155
+.4byte sPorygonPose156
+.4byte sPorygonPose157
+.4byte sPorygonPose158
+.4byte sPorygonPose159
+.4byte sPorygonPose160
+.4byte sPorygonPose161
+.4byte sPorygonPose162
+.4byte sPorygonPose163
+.4byte sPorygonPose164
+.4byte sPorygonPose165
+.4byte sPorygonPose166
+.4byte sPorygonPose167
+.4byte sPorygonPose168
+.4byte sPorygonPose169
+.4byte sPorygonPose170
+.4byte sPorygonPose171
+.4byte sPorygonPose172
+.4byte sPorygonPose173
+.4byte sPorygonPose174
+.4byte sPorygonPose175
+.4byte sPorygonPose176
+.4byte sPorygonPose177
+.4byte sPorygonPose178
+.4byte sPorygonPose179
+.4byte sPorygonPose180
+.4byte sPorygonPose181
+.4byte sPorygonPose182
+.4byte sPorygonPose183
+.4byte sPorygonPose184
+.4byte sPorygonPose185
+.4byte sPorygonPose186
+.4byte sPorygonPose187
+.4byte sPorygonPose188
+.4byte sPorygonPose189
+.4byte sPorygonPose190
+.4byte sPorygonPose191
+.4byte sPorygonPose192
+.4byte sPorygonPose193
+.4byte sPorygonPose194
+.4byte sPorygonPose195
+.4byte sPorygonPose196
+.4byte sPorygonPose197
+.4byte sPorygonPose198
+.4byte sPorygonPose199
+.4byte sPorygonPose200
+.4byte sPorygonPose201
+.4byte sPorygonPose202
+.4byte sPorygonPose203
+.4byte sPorygonPose204
+.4byte sPorygonPose205
+.4byte sPorygonPose206
+.4byte sPorygonPose207
+.4byte sPorygonPose208
+.4byte sPorygonPose209
+.4byte sPorygonPose210
+.4byte sPorygonPose211
+.4byte sPorygonPose212
+.4byte sPorygonPose213
+.4byte sPorygonPose214
+.4byte sPorygonPose215
+.4byte sPorygonPose216
+.4byte sPorygonPose217
+.4byte sPorygonPose218
+.4byte sPorygonPose219
+.4byte sPorygonPose220
+.4byte sPorygonPose221
+.4byte sPorygonPose222
+.4byte sPorygonPose223
+.4byte sPorygonPose224
+.4byte sPorygonPose225
+.4byte sPorygonPose226
+sAxPositionsPorygon:
+.2byte    0,   -3, 	  -7,   -3, 	   6,   -3, 	  -1,   -6
+.2byte    0,   -2, 	  -7,    0, 	   6,   -6, 	   0,   -5
+.2byte   -1,   -4, 	  -7,   -6, 	   6,    0, 	   0,   -8
+.2byte    7,   -5, 	   5,   -4, 	  -2,   -1, 	  -1,   -8
+.2byte    7,   -4, 	   4,   -6, 	  -1,   -5, 	  -1,   -8
+.2byte    6,   -7, 	   7,   -8, 	  -4,    0, 	  -1,   -8
+.2byte   11,   -9, 	   4,   -9, 	   1,   -2, 	  -1,   -8
+.2byte   12,   -8, 	   4,   -6, 	   1,   -6, 	  -1,   -8
+.2byte   10,  -10, 	   3,  -14, 	   0,    1, 	  -2,   -7
+.2byte    8,  -14, 	  -5,   -9, 	   4,   -4, 	  -2,   -7
+.2byte    9,  -13, 	  -4,   -6, 	   4,   -6, 	  -2,   -8
+.2byte    7,  -15, 	  -4,  -10, 	   4,   -2, 	  -2,   -8
+.2byte    0,  -15, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte    0,  -14, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,  -16, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte   -9,  -14, 	   4,   -9, 	  -5,   -4, 	   1,   -7
+.2byte  -10,  -13, 	   3,   -6, 	  -5,   -6, 	   1,   -8
+.2byte   -8,  -15, 	   3,  -10, 	  -5,   -2, 	   1,   -8
+.2byte  -12,   -9, 	  -5,   -9, 	  -2,   -2, 	   0,   -8
+.2byte  -13,   -8, 	  -5,   -6, 	  -2,   -6, 	   0,   -8
+.2byte  -11,  -10, 	  -4,  -14, 	  -1,    1, 	   1,   -7
+.2byte   -9,   -5, 	  -7,   -4, 	   0,   -1, 	  -1,   -8
+.2byte   -9,   -4, 	  -6,   -6, 	  -1,   -5, 	  -1,   -8
+.2byte   -8,   -7, 	  -9,   -8, 	   2,    0, 	  -1,   -8
+.2byte   -1,   -4, 	  -7,   -1, 	   6,   -1, 	  -1,   -7
+.2byte    0,   -3, 	  -7,   -3, 	   6,   -3, 	  -1,   -6
+.2byte    0,   -2, 	  -7,    0, 	   6,   -6, 	   0,   -5
+.2byte   -1,   -4, 	  -7,   -6, 	   6,    0, 	   0,   -8
+.2byte   -1,    4, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte    6,   -5, 	   9,   -6, 	  -2,    0, 	  -1,   -7
+.2byte    7,   -5, 	   5,   -4, 	  -2,   -1, 	  -1,   -8
+.2byte    7,   -4, 	   4,   -6, 	  -1,   -5, 	  -1,   -8
+.2byte    6,   -7, 	   7,   -8, 	  -4,    0, 	  -1,   -8
+.2byte   10,    3, 	   5,   -6, 	  -2,    0, 	   1,   -6
+.2byte   10,   -9, 	   4,  -10, 	   3,   -1, 	  -1,   -7
+.2byte   11,   -9, 	   4,   -9, 	   1,   -2, 	  -1,   -8
+.2byte   12,   -8, 	   4,   -6, 	   1,   -6, 	  -1,   -8
+.2byte   10,  -10, 	   3,  -14, 	   0,    1, 	  -2,   -7
+.2byte   15,   -5, 	   1,  -11, 	   2,   -4, 	   1,   -8
+.2byte    8,  -14, 	  -3,  -10, 	   6,   -6, 	  -2,   -7
+.2byte    8,  -14, 	  -5,   -9, 	   4,   -4, 	  -2,   -7
+.2byte    9,  -13, 	  -4,   -6, 	   4,   -6, 	  -2,   -8
+.2byte    7,  -15, 	  -4,  -10, 	   4,   -2, 	  -2,   -8
+.2byte   12,  -15, 	  -3,  -10, 	   5,   -5, 	  -1,   -7
+.2byte    0,  -14, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    0,  -15, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte    0,  -14, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,  -16, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,  -20, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -8,  -14, 	   3,  -10, 	  -6,   -6, 	   2,   -7
+.2byte   -9,  -14, 	   4,   -9, 	  -5,   -4, 	   1,   -7
+.2byte  -10,  -13, 	   3,   -6, 	  -5,   -6, 	   1,   -8
+.2byte   -8,  -15, 	   3,  -10, 	  -5,   -2, 	   1,   -8
+.2byte  -12,  -15, 	   3,  -10, 	  -5,   -5, 	   1,   -7
+.2byte  -10,   -8, 	  -4,   -9, 	  -3,    0, 	   1,   -6
+.2byte  -12,   -9, 	  -5,   -9, 	  -2,   -2, 	   0,   -8
+.2byte  -13,   -8, 	  -5,   -6, 	  -2,   -6, 	   0,   -8
+.2byte  -11,  -10, 	  -4,  -14, 	  -1,    1, 	   1,   -7
+.2byte  -15,   -4, 	  -1,  -10, 	  -2,   -3, 	  -1,   -7
+.2byte   -7,   -5, 	 -10,   -6, 	   1,    0, 	   0,   -7
+.2byte   -9,   -5, 	  -7,   -4, 	   0,   -1, 	  -1,   -8
+.2byte   -9,   -4, 	  -6,   -6, 	  -1,   -5, 	  -1,   -8
+.2byte   -8,   -7, 	  -9,   -8, 	   2,    0, 	  -1,   -8
+.2byte  -11,    3, 	  -6,   -6, 	   1,    0, 	  -2,   -6
+.2byte   -1,   -4, 	  -7,   -1, 	   6,   -1, 	  -1,   -7
+.2byte    0,   -3, 	  -7,   -3, 	   6,   -3, 	  -1,   -6
+.2byte    0,   -2, 	  -7,    0, 	   6,   -6, 	   0,   -5
+.2byte   -1,   -4, 	  -7,   -6, 	   6,    0, 	   0,   -8
+.2byte   -1,    4, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte    6,   -5, 	   9,   -6, 	  -2,    0, 	  -1,   -7
+.2byte    7,   -5, 	   5,   -4, 	  -2,   -1, 	  -1,   -8
+.2byte    7,   -4, 	   4,   -6, 	  -1,   -5, 	  -1,   -8
+.2byte    6,   -7, 	   7,   -8, 	  -4,    0, 	  -1,   -8
+.2byte   10,    3, 	   5,   -6, 	  -2,    0, 	   1,   -6
+.2byte   10,   -9, 	   4,  -10, 	   3,   -1, 	  -1,   -7
+.2byte   11,   -9, 	   4,   -9, 	   1,   -2, 	  -1,   -8
+.2byte   12,   -8, 	   4,   -6, 	   1,   -6, 	  -1,   -8
+.2byte   10,  -10, 	   3,  -14, 	   0,    1, 	  -2,   -7
+.2byte   15,   -5, 	   1,  -11, 	   2,   -4, 	   1,   -8
+.2byte    8,  -14, 	  -3,  -10, 	   6,   -6, 	  -2,   -7
+.2byte    8,  -14, 	  -5,   -9, 	   4,   -4, 	  -2,   -7
+.2byte    9,  -13, 	  -4,   -6, 	   4,   -6, 	  -2,   -8
+.2byte    7,  -15, 	  -4,  -10, 	   4,   -2, 	  -2,   -8
+.2byte   12,  -15, 	  -3,  -10, 	   5,   -5, 	  -1,   -7
+.2byte    0,  -14, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    0,  -15, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte    0,  -14, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,  -16, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,  -20, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -8,  -14, 	   3,  -10, 	  -6,   -6, 	   2,   -7
+.2byte   -9,  -14, 	   4,   -9, 	  -5,   -4, 	   1,   -7
+.2byte  -10,  -13, 	   3,   -6, 	  -5,   -6, 	   1,   -8
+.2byte   -8,  -15, 	   3,  -10, 	  -5,   -2, 	   1,   -8
+.2byte  -12,  -15, 	   3,  -10, 	  -5,   -5, 	   1,   -7
+.2byte  -10,   -8, 	  -4,   -9, 	  -3,    0, 	   1,   -6
+.2byte  -12,   -9, 	  -5,   -9, 	  -2,   -2, 	   0,   -8
+.2byte  -13,   -8, 	  -5,   -6, 	  -2,   -6, 	   0,   -8
+.2byte  -11,  -10, 	  -4,  -14, 	  -1,    1, 	   1,   -7
+.2byte  -15,   -4, 	  -1,  -10, 	  -2,   -3, 	  -1,   -7
+.2byte   -7,   -5, 	 -10,   -6, 	   1,    0, 	   0,   -7
+.2byte   -9,   -5, 	  -7,   -4, 	   0,   -1, 	  -1,   -8
+.2byte   -9,   -4, 	  -6,   -6, 	  -1,   -5, 	  -1,   -8
+.2byte   -8,   -7, 	  -9,   -8, 	   2,    0, 	  -1,   -8
+.2byte  -11,    3, 	  -6,   -6, 	   1,    0, 	  -2,   -6
+.2byte   -1,   -4, 	  -7,   -1, 	   6,   -1, 	  -1,   -7
+.2byte    0,  -23, 	  -7,   -1, 	   6,   -1, 	  -1,   -9
+.2byte   -1,    4, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte    6,   -4, 	   9,   -5, 	  -2,    1, 	  -1,   -6
+.2byte   -5,  -20, 	   6,   -2, 	  -3,    2, 	  -2,   -7
+.2byte   10,    3, 	   5,   -6, 	  -2,    0, 	   1,   -6
+.2byte   10,   -9, 	   4,  -10, 	   3,   -1, 	  -1,   -7
+.2byte   -4,  -18, 	   5,   -2, 	   5,    2, 	  -1,   -6
+.2byte   15,   -3, 	   1,   -9, 	   2,   -2, 	   1,   -6
+.2byte    8,  -13, 	  -3,   -9, 	   6,   -5, 	  -2,   -6
+.2byte   -4,  -17, 	  -1,   -7, 	   7,   -5, 	   0,   -4
+.2byte   12,  -15, 	  -3,  -10, 	   5,   -5, 	  -1,   -7
+.2byte    0,  -14, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -1,  -16, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    0,  -20, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -8,  -13, 	   3,   -9, 	  -6,   -5, 	   2,   -6
+.2byte    4,  -17, 	   1,   -7, 	  -7,   -5, 	   0,   -4
+.2byte  -12,  -15, 	   3,  -10, 	  -5,   -5, 	   1,   -7
+.2byte  -10,   -8, 	  -4,   -9, 	  -3,    0, 	   1,   -6
+.2byte    4,  -17, 	  -5,   -1, 	  -5,    3, 	   1,   -5
+.2byte  -15,   -2, 	  -1,   -8, 	  -2,   -1, 	  -1,   -5
+.2byte   -7,   -4, 	 -10,   -5, 	   1,    1, 	   0,   -6
+.2byte    4,  -20, 	  -7,   -2, 	   2,    2, 	   1,   -7
+.2byte  -11,    3, 	  -6,   -6, 	   1,    0, 	  -2,   -6
+.2byte   -1,   -4, 	  -7,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -1,    4, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte    0,  -21, 	  -7,    0, 	   5,    0, 	  -1,   -6
+.2byte    6,   -4, 	   9,   -5, 	  -2,    1, 	  -1,   -6
+.2byte   10,    3, 	   5,   -6, 	  -2,    0, 	   1,   -6
+.2byte    0,  -21, 	   8,   -4, 	  -1,    1, 	   0,   -7
+.2byte   10,   -9, 	   4,  -10, 	   3,   -1, 	  -1,   -7
+.2byte   17,   -3, 	   3,   -9, 	   4,   -2, 	   3,   -6
+.2byte    2,  -21, 	   4,   -5, 	   4,    0, 	   0,   -7
+.2byte    8,  -13, 	  -3,   -9, 	   6,   -5, 	  -2,   -6
+.2byte   12,  -13, 	  -3,   -8, 	   5,   -3, 	  -1,   -5
+.2byte    2,  -22, 	  -4,   -8, 	   6,   -6, 	  -2,   -7
+.2byte    0,  -14, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    0,  -18, 	   6,   -4, 	  -7,   -4, 	   0,   -6
+.2byte   -1,  -22, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -8,  -13, 	   3,   -9, 	  -6,   -5, 	   2,   -6
+.2byte  -12,  -13, 	   3,   -8, 	  -5,   -3, 	   1,   -5
+.2byte   -2,  -22, 	   4,   -8, 	  -6,   -6, 	   2,   -7
+.2byte  -10,   -8, 	  -4,   -9, 	  -3,    0, 	   1,   -6
+.2byte  -17,   -2, 	  -3,   -8, 	  -4,   -1, 	  -3,   -5
+.2byte   -2,  -20, 	  -4,   -4, 	  -4,    1, 	   0,   -6
+.2byte   -7,   -4, 	 -10,   -5, 	   1,    1, 	   0,   -6
+.2byte  -11,    3, 	  -6,   -6, 	   1,    0, 	  -2,   -6
+.2byte   -1,  -21, 	  -9,   -4, 	   0,    1, 	  -1,   -7
+.2byte   -7,   -4, 	 -10,   -5, 	   1,    0, 	   0,   -6
+.2byte   -8,   -3, 	 -10,   -3, 	   1,    1, 	   0,   -5
+.2byte    0,  -22, 	  -7,  -10, 	   6,  -10, 	   0,  -12
+.2byte    3,  -24, 	   8,  -14, 	   1,   -6, 	  -1,  -13
+.2byte    4,  -23, 	   5,  -14, 	   6,   -7, 	  -1,  -11
+.2byte    3,  -24, 	  -2,  -14, 	   7,  -12, 	  -1,  -12
+.2byte    0,  -21, 	   6,  -12, 	  -7,  -12, 	   0,  -10
+.2byte   -4,  -24, 	   1,  -14, 	  -8,  -12, 	   0,  -12
+.2byte   -5,  -23, 	  -6,  -14, 	  -7,   -7, 	   0,  -11
+.2byte   -4,  -24, 	  -9,  -14, 	  -2,   -6, 	   0,  -13
+.2byte   -1,   -4, 	  -7,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -7,   -4, 	 -10,   -5, 	   1,    1, 	   0,   -6
+.2byte  -10,   -8, 	  -4,   -9, 	  -3,    0, 	   1,   -6
+.2byte   -8,  -13, 	   3,   -9, 	  -6,   -5, 	   2,   -6
+.2byte    0,  -14, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    8,  -13, 	  -3,   -9, 	   6,   -5, 	  -2,   -6
+.2byte   10,   -9, 	   4,  -10, 	   3,   -1, 	  -1,   -7
+.2byte    6,   -4, 	   9,   -5, 	  -2,    1, 	  -1,   -6
+.2byte   -1,    4, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte   -8,    2, 	  -3,   -7, 	   4,   -1, 	   1,   -7
+.2byte  -12,   -3, 	   2,   -9, 	   1,   -2, 	   2,   -6
+.2byte  -10,  -12, 	   5,   -7, 	  -3,   -2, 	   3,   -4
+.2byte    0,  -17, 	   6,   -3, 	  -7,   -3, 	   0,   -5
+.2byte    9,  -12, 	  -6,   -7, 	   2,   -2, 	  -4,   -4
+.2byte   11,   -3, 	  -3,   -9, 	  -2,   -2, 	  -3,   -6
+.2byte    7,    1, 	   2,   -8, 	  -5,   -2, 	  -2,   -8
+.2byte    0,  -21, 	  -7,    0, 	   5,    0, 	  -1,   -6
+.2byte    0,  -21, 	   8,   -4, 	  -1,    1, 	   0,   -7
+.2byte    2,  -22, 	   4,   -6, 	   4,   -1, 	   0,   -8
+.2byte    2,  -22, 	  -4,   -8, 	   6,   -6, 	  -2,   -7
+.2byte   -1,  -22, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -2,  -22, 	   4,   -8, 	  -6,   -6, 	   2,   -7
+.2byte   -2,  -22, 	  -4,   -6, 	  -4,   -1, 	   0,   -8
+.2byte   -1,  -21, 	  -9,   -4, 	   0,    1, 	  -1,   -7
+.2byte   -1,   -4, 	  -7,   -1, 	   6,   -1, 	  -1,   -7
+.2byte    0,  -23, 	  -7,   -1, 	   6,   -1, 	  -1,   -9
+.2byte   -1,    4, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte    6,   -4, 	   9,   -5, 	  -2,    1, 	  -1,   -6
+.2byte   -3,  -20, 	   8,   -2, 	  -1,    2, 	   0,   -7
+.2byte    9,    3, 	   4,   -6, 	  -3,    0, 	   0,   -6
+.2byte   10,   -9, 	   4,  -10, 	   3,   -1, 	  -1,   -7
+.2byte   -2,  -18, 	   7,   -2, 	   7,    2, 	   1,   -6
+.2byte   13,   -3, 	  -1,   -9, 	   0,   -2, 	  -1,   -6
+.2byte    8,  -13, 	  -3,   -9, 	   6,   -5, 	  -2,   -6
+.2byte   -2,  -18, 	   1,   -8, 	   9,   -6, 	   2,   -5
+.2byte   10,  -14, 	  -5,   -9, 	   3,   -4, 	  -3,   -6
+.2byte    0,  -14, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -1,  -16, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    0,  -20, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -9,  -13, 	   2,   -9, 	  -7,   -5, 	   1,   -6
+.2byte    1,  -18, 	  -2,   -8, 	 -10,   -6, 	  -3,   -5
+.2byte  -11,  -14, 	   4,   -9, 	  -4,   -4, 	   2,   -6
+.2byte  -11,   -9, 	  -5,  -10, 	  -4,   -1, 	   0,   -7
+.2byte    1,  -18, 	  -8,   -2, 	  -8,    2, 	  -2,   -6
+.2byte  -14,   -3, 	   0,   -9, 	  -1,   -2, 	   0,   -6
+.2byte   -7,   -4, 	 -10,   -5, 	   1,    1, 	   0,   -6
+.2byte    4,  -20, 	  -7,   -2, 	   2,    2, 	   1,   -7
+.2byte  -10,    3, 	  -5,   -6, 	   2,    0, 	  -1,   -6
+.2byte   -1,    4, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte   -9,    3, 	  -4,   -6, 	   3,    0, 	   0,   -6
+.2byte  -13,   -2, 	   1,   -8, 	   0,   -1, 	   1,   -5
+.2byte  -10,  -11, 	   5,   -6, 	  -3,   -1, 	   3,   -3
+.2byte    0,  -15, 	   6,   -1, 	  -7,   -1, 	   0,   -3
+.2byte    9,  -11, 	  -6,   -6, 	   2,   -1, 	  -4,   -3
+.2byte   12,   -2, 	  -2,   -8, 	  -1,   -1, 	  -2,   -5
+.2byte    8,    2, 	   3,   -7, 	  -4,   -1, 	  -1,   -7
+.2byte   -1,   -4, 	  -7,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -7,   -4, 	 -10,   -5, 	   1,    1, 	   0,   -6
+.2byte  -10,   -8, 	  -4,   -9, 	  -3,    0, 	   1,   -6
+.2byte   -8,  -13, 	   3,   -9, 	  -6,   -5, 	   2,   -6
+.2byte    0,  -14, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    8,  -13, 	  -3,   -9, 	   6,   -5, 	  -2,   -6
+.2byte   10,   -9, 	   4,  -10, 	   3,   -1, 	  -1,   -7
+.2byte    6,   -4, 	   9,   -5, 	  -2,    1, 	  -1,   -6
+sPorygonAnimTable1:
+.4byte sPorygonAnims_1_1
+.4byte sPorygonAnims_1_2
+.4byte sPorygonAnims_1_3
+.4byte sPorygonAnims_1_4
+.4byte sPorygonAnims_1_5
+.4byte sPorygonAnims_1_6
+.4byte sPorygonAnims_1_7
+.4byte sPorygonAnims_1_8
+sPorygonAnimTable2:
+.4byte sPorygonAnims_2_1
+.4byte sPorygonAnims_2_2
+.4byte sPorygonAnims_2_3
+.4byte sPorygonAnims_2_4
+.4byte sPorygonAnims_2_5
+.4byte sPorygonAnims_2_6
+.4byte sPorygonAnims_2_7
+.4byte sPorygonAnims_2_8
+sPorygonAnimTable3:
+.4byte sPorygonAnims_3_1
+.4byte sPorygonAnims_3_2
+.4byte sPorygonAnims_3_3
+.4byte sPorygonAnims_3_4
+.4byte sPorygonAnims_3_5
+.4byte sPorygonAnims_3_6
+.4byte sPorygonAnims_3_7
+.4byte sPorygonAnims_3_8
+sPorygonAnimTable4:
+.4byte sPorygonAnims_4_1
+.4byte sPorygonAnims_4_2
+.4byte sPorygonAnims_4_3
+.4byte sPorygonAnims_4_4
+.4byte sPorygonAnims_4_5
+.4byte sPorygonAnims_4_6
+.4byte sPorygonAnims_4_7
+.4byte sPorygonAnims_4_8
+sPorygonAnimTable5:
+.4byte sPorygonAnims_5_1
+.4byte sPorygonAnims_5_2
+.4byte sPorygonAnims_5_3
+.4byte sPorygonAnims_5_4
+.4byte sPorygonAnims_5_5
+.4byte sPorygonAnims_5_6
+.4byte sPorygonAnims_5_7
+.4byte sPorygonAnims_5_8
+sPorygonAnimTable6:
+.4byte sPorygonAnims_6_1
+.4byte sPorygonAnims_6_1
+.4byte sPorygonAnims_6_1
+.4byte sPorygonAnims_6_1
+.4byte sPorygonAnims_6_1
+.4byte sPorygonAnims_6_1
+.4byte sPorygonAnims_6_1
+.4byte sPorygonAnims_6_1
+sPorygonAnimTable7:
+.4byte sPorygonAnims_7_1
+.4byte sPorygonAnims_7_2
+.4byte sPorygonAnims_7_3
+.4byte sPorygonAnims_7_4
+.4byte sPorygonAnims_7_5
+.4byte sPorygonAnims_7_6
+.4byte sPorygonAnims_7_7
+.4byte sPorygonAnims_7_8
+sPorygonAnimTable8:
+.4byte sPorygonAnims_8_1
+.4byte sPorygonAnims_8_2
+.4byte sPorygonAnims_8_3
+.4byte sPorygonAnims_8_4
+.4byte sPorygonAnims_8_5
+.4byte sPorygonAnims_8_6
+.4byte sPorygonAnims_8_7
+.4byte sPorygonAnims_8_8
+sPorygonAnimTable9:
+.4byte sPorygonAnims_9_1
+.4byte sPorygonAnims_9_2
+.4byte sPorygonAnims_9_3
+.4byte sPorygonAnims_9_4
+.4byte sPorygonAnims_9_5
+.4byte sPorygonAnims_9_6
+.4byte sPorygonAnims_9_7
+.4byte sPorygonAnims_9_8
+sPorygonAnimTable10:
+.4byte sPorygonAnims_10_1
+.4byte sPorygonAnims_10_2
+.4byte sPorygonAnims_10_3
+.4byte sPorygonAnims_10_4
+.4byte sPorygonAnims_10_5
+.4byte sPorygonAnims_10_6
+.4byte sPorygonAnims_10_7
+.4byte sPorygonAnims_10_8
+sPorygonAnimTable11:
+.4byte sPorygonAnims_11_1
+.4byte sPorygonAnims_11_2
+.4byte sPorygonAnims_11_3
+.4byte sPorygonAnims_11_4
+.4byte sPorygonAnims_11_5
+.4byte sPorygonAnims_11_6
+.4byte sPorygonAnims_11_7
+.4byte sPorygonAnims_11_8
+sPorygonAnimTable12:
+.4byte sPorygonAnims_12_1
+.4byte sPorygonAnims_12_2
+.4byte sPorygonAnims_12_3
+.4byte sPorygonAnims_12_4
+.4byte sPorygonAnims_12_5
+.4byte sPorygonAnims_12_6
+.4byte sPorygonAnims_12_7
+.4byte sPorygonAnims_12_8
+sPorygonAnimTable13:
+.4byte sPorygonAnims_13_1
+.4byte sPorygonAnims_13_2
+.4byte sPorygonAnims_13_3
+.4byte sPorygonAnims_13_4
+.4byte sPorygonAnims_13_5
+.4byte sPorygonAnims_13_6
+.4byte sPorygonAnims_13_7
+.4byte sPorygonAnims_13_8
+sAxAnimationsPorygon:
+.4byte sPorygonAnimTable1
+.4byte sPorygonAnimTable2
+.4byte sPorygonAnimTable3
+.4byte sPorygonAnimTable4
+.4byte sPorygonAnimTable5
+.4byte sPorygonAnimTable6
+.4byte sPorygonAnimTable7
+.4byte sPorygonAnimTable8
+.4byte sPorygonAnimTable9
+.4byte sPorygonAnimTable10
+.4byte sPorygonAnimTable11
+.4byte sPorygonAnimTable12
+.4byte sPorygonAnimTable13
+sAxSpritesPorygon:
+.4byte sPorygonSprites1
+.4byte sPorygonSprites2
+.4byte sPorygonSprites3
+.4byte sPorygonSprites4
+.4byte sPorygonSprites5
+.4byte sPorygonSprites6
+.4byte sPorygonSprites7
+.4byte sPorygonSprites8
+.4byte sPorygonSprites9
+.4byte sPorygonSprites10
+.4byte sPorygonSprites11
+.4byte sPorygonSprites12
+.4byte sPorygonSprites13
+.4byte sPorygonSprites14
+.4byte sPorygonSprites15
+.4byte sPorygonSprites16
+.4byte sPorygonSprites17
+.4byte sPorygonSprites18
+.4byte sPorygonSprites19
+.4byte sPorygonSprites20
+.4byte sPorygonSprites21
+.4byte sPorygonSprites22
+.4byte sPorygonSprites23
+.4byte sPorygonSprites24
+.4byte sPorygonSprites25
+.4byte sPorygonSprites26
+.4byte sPorygonSprites27
+.4byte sPorygonSprites28
+.4byte sPorygonSprites29
+.4byte sPorygonSprites30
+.4byte sPorygonSprites31
+.4byte sPorygonSprites32
+.4byte sPorygonSprites33
+.4byte sPorygonSprites34
+.4byte sPorygonSprites35
+.4byte sPorygonSprites36
+.4byte sPorygonSprites37
+.4byte sPorygonSprites38
+.4byte sPorygonSprites39
+.4byte sPorygonSprites40
+.4byte sPorygonSprites41
+.4byte sPorygonSprites42
+sAxMainPorygon:
+ax_main sAxPosesPorygon, sAxAnimationsPorygon, 13, sAxSpritesPorygon, sAxPositionsPorygon

--- a/data/ax/porygon2.inc
+++ b/data/ax/porygon2.inc
@@ -1,0 +1,2770 @@
+.global gAxPorygon2
+gAxPorygon2:
+ax_siro sAxMainPorygon2
+sPorygon2Pose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose4:
+ax_pose 3, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose5:
+ax_pose 4, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose6:
+ax_pose 5, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose7:
+ax_pose 6, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose8:
+ax_pose 7, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose9:
+ax_pose 8, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose10:
+ax_pose 9, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose11:
+ax_pose 10, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose12:
+ax_pose 11, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose16:
+ax_pose 9, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose17:
+ax_pose 10, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose18:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose19:
+ax_pose 6, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose20:
+ax_pose 7, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose21:
+ax_pose 8, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose22:
+ax_pose 3, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose23:
+ax_pose 4, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose24:
+ax_pose 5, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose26:
+ax_pose 1, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose27:
+ax_pose 2, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose28:
+ax_pose 3, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose29:
+ax_pose 4, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose30:
+ax_pose 5, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose31:
+ax_pose 6, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose32:
+ax_pose 7, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose33:
+ax_pose 8, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose34:
+ax_pose 9, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose35:
+ax_pose 10, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose36:
+ax_pose 11, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose37:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose38:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose39:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose40:
+ax_pose 9, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose41:
+ax_pose 10, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose42:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose43:
+ax_pose 6, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose44:
+ax_pose 7, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose45:
+ax_pose 8, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose46:
+ax_pose 3, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose47:
+ax_pose 4, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose48:
+ax_pose 5, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose49:
+ax_pose 0, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose50:
+ax_pose 1, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose51:
+ax_pose 2, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose52:
+ax_pose 3, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose53:
+ax_pose 4, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose54:
+ax_pose 5, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose55:
+ax_pose 6, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose56:
+ax_pose 7, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose57:
+ax_pose 8, 0x01ea, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose58:
+ax_pose 9, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose59:
+ax_pose 10, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose60:
+ax_pose 11, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose61:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose62:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose63:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose64:
+ax_pose 9, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose65:
+ax_pose 10, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose66:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose67:
+ax_pose 6, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose68:
+ax_pose 7, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose69:
+ax_pose 8, 0x01ea, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose70:
+ax_pose 3, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose71:
+ax_pose 4, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose72:
+ax_pose 5, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose73:
+ax_pose 15, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose74:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose75:
+ax_pose 17, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose76:
+ax_pose 18, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose77:
+ax_pose 19, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose78:
+ax_pose 20, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose79:
+ax_pose 21, 0x01ec, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose80:
+ax_pose 22, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose81:
+ax_pose 23, 0x01eb, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose82:
+ax_pose 24, 0x01eb, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygon2Pose83:
+ax_pose 25, 0x01eb, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose84:
+ax_pose 26, 0x01eb, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose85:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose86:
+ax_pose 28, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose87:
+ax_pose 29, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose88:
+ax_pose 30, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygon2Pose89:
+ax_pose 31, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose90:
+ax_pose 32, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose91:
+ax_pose 33, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose92:
+ax_pose 34, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose93:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose94:
+ax_pose 28, 0x01eb, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose95:
+ax_pose 29, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose96:
+ax_pose 30, 0x01ea, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygon2Pose97:
+ax_pose 23, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose98:
+ax_pose 24, 0x01eb, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose99:
+ax_pose 25, 0x01eb, 0x80ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose100:
+ax_pose 26, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose101:
+ax_pose 19, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose102:
+ax_pose 20, 0x01eb, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose103:
+ax_pose 21, 0x01ec, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygon2Pose104:
+ax_pose 22, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose105:
+ax_pose 15, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose106:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose107:
+ax_pose 17, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose108:
+ax_pose 18, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose109:
+ax_pose 19, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose110:
+ax_pose 20, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose111:
+ax_pose 21, 0x01ec, 0x90ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose112:
+ax_pose 22, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygon2Pose113:
+ax_pose 23, 0x01eb, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose114:
+ax_pose 24, 0x01eb, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygon2Pose115:
+ax_pose 25, 0x01eb, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose116:
+ax_pose 26, 0x01eb, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose117:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose118:
+ax_pose 28, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose119:
+ax_pose 29, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose120:
+ax_pose 30, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose121:
+ax_pose 31, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose122:
+ax_pose 32, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose123:
+ax_pose 33, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose124:
+ax_pose 34, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose125:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose126:
+ax_pose 28, 0x01eb, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose127:
+ax_pose 29, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose128:
+ax_pose 30, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose129:
+ax_pose 23, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose130:
+ax_pose 24, 0x01eb, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose131:
+ax_pose 25, 0x01eb, 0x80ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose132:
+ax_pose 26, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose133:
+ax_pose 19, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose134:
+ax_pose 20, 0x01eb, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose135:
+ax_pose 21, 0x01ec, 0x80f1, 0x1c00
+ax_pose_terminator
+sPorygon2Pose136:
+ax_pose 22, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sPorygon2Pose137:
+ax_pose 35, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose138:
+ax_pose 36, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose139:
+ax_pose 37, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose140:
+ax_pose 38, 0x01e5, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose141:
+ax_pose 39, 0x81e7, 0x90f5, 0x1c00
+ax_pose 40, 0x01ed, 0x10ed, 0x1c08
+ax_pose 41, 0x01ef, 0x5105, 0x1c09
+ax_pose_terminator
+sPorygon2Pose142:
+ax_pose 42, 0x41ec, 0x90ef, 0x1c00
+ax_pose 43, 0x01ec, 0x110f, 0x1c08
+ax_pose 44, 0x41fc, 0x50ef, 0x1c09
+ax_pose_terminator
+sPorygon2Pose143:
+ax_pose 45, 0x01e9, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose144:
+ax_pose 42, 0x41ec, 0x80f1, 0x1c00
+ax_pose 43, 0x01ec, 0x00e9, 0x1c08
+ax_pose 44, 0x41fc, 0x40f1, 0x1c09
+ax_pose_terminator
+sPorygon2Pose145:
+ax_pose 39, 0x81e7, 0x80fb, 0x1c00
+ax_pose 40, 0x01ed, 0x010b, 0x1c08
+ax_pose 41, 0x01ef, 0x40eb, 0x1c09
+ax_pose_terminator
+sPorygon2Pose146:
+ax_pose 38, 0x01e5, 0x80ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose147:
+ax_pose 15, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose148:
+ax_pose 19, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose149:
+ax_pose 23, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose150:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose151:
+ax_pose 31, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose152:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose153:
+ax_pose 23, 0x01eb, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose154:
+ax_pose 19, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose155:
+ax_pose 17, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose156:
+ax_pose 21, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose157:
+ax_pose 25, 0x01ed, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose158:
+ax_pose 29, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose159:
+ax_pose 33, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose160:
+ax_pose 29, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose161:
+ax_pose 25, 0x01ed, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose162:
+ax_pose 21, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose163:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose164:
+ax_pose 28, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose165:
+ax_pose 30, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygon2Pose166:
+ax_pose 18, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose167:
+ax_pose 22, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose168:
+ax_pose 26, 0x01eb, 0x90f1, 0x1c00
+ax_pose_terminator
+sPorygon2Pose169:
+ax_pose 30, 0x01e9, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose170:
+ax_pose 34, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose171:
+ax_pose 30, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose172:
+ax_pose 26, 0x01eb, 0x80ef, 0x1c00
+ax_pose_terminator
+sPorygon2Pose173:
+ax_pose 22, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose174:
+ax_pose 15, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose175:
+ax_pose 17, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose176:
+ax_pose 18, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose177:
+ax_pose 19, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose178:
+ax_pose 21, 0x01ec, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose179:
+ax_pose 22, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose180:
+ax_pose 23, 0x01eb, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose181:
+ax_pose 25, 0x01ec, 0x90f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose182:
+ax_pose 26, 0x01ec, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose183:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose184:
+ax_pose 29, 0x01ec, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose185:
+ax_pose 30, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose186:
+ax_pose 31, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose187:
+ax_pose 33, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose188:
+ax_pose 34, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose189:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose190:
+ax_pose 29, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose191:
+ax_pose 30, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose192:
+ax_pose 23, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose193:
+ax_pose 25, 0x01ec, 0x80ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose194:
+ax_pose 26, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose195:
+ax_pose 19, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose196:
+ax_pose 21, 0x01ec, 0x80f2, 0x1c00
+ax_pose_terminator
+sPorygon2Pose197:
+ax_pose 22, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose198:
+ax_pose 17, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose199:
+ax_pose 21, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sPorygon2Pose200:
+ax_pose 25, 0x01ed, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose201:
+ax_pose 29, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose202:
+ax_pose 33, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose203:
+ax_pose 29, 0x01ed, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose204:
+ax_pose 25, 0x01ed, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose205:
+ax_pose 21, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sPorygon2Pose206:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose207:
+ax_pose 28, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sPorygon2Pose208:
+ax_pose 30, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sPorygon2Pose209:
+ax_pose 15, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose210:
+ax_pose 19, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose211:
+ax_pose 23, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose212:
+ax_pose 27, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose213:
+ax_pose 31, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sPorygon2Pose214:
+ax_pose 27, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sPorygon2Pose215:
+ax_pose 23, 0x01eb, 0x90f0, 0x1c00
+ax_pose_terminator
+sPorygon2Pose216:
+ax_pose 19, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+.align 2
+sPorygon2Anims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, -1, 0, 0,
+ax_anim 10, 0, 0, 0, -3, 0, 0,
+ax_anim 10, 0, 2, 0, -3, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, -1, 0, 0,
+ax_anim 10, 0, 3, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, -1, 0, 0,
+ax_anim 10, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, -1, 0, 0,
+ax_anim 10, 0, 9, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, -1, 0, 0,
+ax_anim 10, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, -1, 0, 0,
+ax_anim 10, 0, 15, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, -1, 0, 0,
+ax_anim 10, 0, 18, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, -1, 0, 0,
+ax_anim 10, 0, 21, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_2_1:
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 6, 0, 45, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 30, 0, 22, 0, 22,
+ax_anim 2, 1, 30, 1, 22, 1, 22,
+ax_anim 2, 0, 30, 0, 22, 0, 22,
+ax_anim 2, 0, 30, 1, 22, 1, 22,
+ax_anim 2, 0, 27, 0, 6, 0, 6,
+ax_anim_terminator
+sPorygon2Anims_2_2:
+ax_anim 2, 0, 24, -1, -1, -1, -1,
+ax_anim 6, 0, 24, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 3, 4, 3, 4,
+ax_anim 1, 0, 30, 9, 11, 9, 11,
+ax_anim 2, 0, 33, 20, 22, 20, 22,
+ax_anim 2, 1, 33, 21, 21, 21, 21,
+ax_anim 2, 0, 33, 20, 22, 20, 22,
+ax_anim 2, 0, 33, 21, 21, 21, 21,
+ax_anim 2, 0, 30, 5, 6, 5, 6,
+ax_anim_terminator
+sPorygon2Anims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 6, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 10, 0, 10, 0,
+ax_anim 2, 0, 36, 21, 0, 21, 0,
+ax_anim 2, 1, 36, 21, 1, 21, 1,
+ax_anim 2, 0, 36, 21, 0, 21, 0,
+ax_anim 2, 0, 36, 21, 1, 21, 1,
+ax_anim 2, 0, 33, 6, 0, 6, 0,
+ax_anim_terminator
+sPorygon2Anims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 6, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 5, -6, 5, -6,
+ax_anim 1, 0, 36, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 20, -19, 20, -19,
+ax_anim 2, 1, 39, 21, -18, 21, -18,
+ax_anim 2, 0, 39, 20, -19, 20, -19,
+ax_anim 2, 0, 39, 21, -18, 21, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sPorygon2Anims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 6, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 39, 0, -11, 0, -11,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 1, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 0, 42, 1, -21, 1, -21,
+ax_anim 2, 0, 39, 0, -6, 0, -6,
+ax_anim_terminator
+sPorygon2Anims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 6, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -5, -6, -5, -6,
+ax_anim 1, 0, 42, -12, -12, -12, -12,
+ax_anim 2, 0, 45, -20, -19, -20, -19,
+ax_anim 2, 1, 45, -21, -18, -21, -18,
+ax_anim 2, 0, 45, -20, -19, -20, -19,
+ax_anim 2, 0, 45, -21, -18, -21, -18,
+ax_anim 2, 0, 42, -6, -6, -6, -6,
+ax_anim_terminator
+sPorygon2Anims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 6, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 45, -10, 0, -10, 0,
+ax_anim 2, 0, 24, -21, 0, -21, 0,
+ax_anim 2, 1, 24, -21, 1, -21, 1,
+ax_anim 2, 0, 24, -21, 0, -21, 0,
+ax_anim 2, 0, 24, -21, 1, -21, 1,
+ax_anim 2, 0, 45, -6, 0, -6, 0,
+ax_anim_terminator
+sPorygon2Anims_2_8:
+ax_anim 2, 0, 42, 1, -1, 1, -1,
+ax_anim 6, 0, 42, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -3, 4, -3, 4,
+ax_anim 1, 0, 24, -9, 11, -9, 11,
+ax_anim 2, 0, 27, -20, 22, -20, 22,
+ax_anim 2, 1, 27, -21, 21, -21, 21,
+ax_anim 2, 0, 27, -20, 22, -20, 22,
+ax_anim 2, 0, 27, -21, 21, -21, 21,
+ax_anim 2, 0, 24, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_3_1:
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim 6, 0, 69, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 51, 0, 10, 0, 10,
+ax_anim 2, 0, 54, 0, 22, 0, 22,
+ax_anim 2, 1, 54, 1, 22, 1, 22,
+ax_anim 2, 0, 54, 0, 22, 0, 22,
+ax_anim 2, 0, 54, 1, 22, 1, 22,
+ax_anim 2, 0, 51, 0, 6, 0, 6,
+ax_anim_terminator
+sPorygon2Anims_3_2:
+ax_anim 2, 0, 48, -1, -1, -1, -1,
+ax_anim 6, 0, 48, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 3, 4, 3, 4,
+ax_anim 1, 0, 54, 9, 11, 9, 11,
+ax_anim 2, 0, 57, 20, 22, 20, 22,
+ax_anim 2, 1, 57, 21, 21, 21, 21,
+ax_anim 2, 0, 57, 20, 22, 20, 22,
+ax_anim 2, 0, 57, 21, 21, 21, 21,
+ax_anim 2, 0, 54, 5, 6, 5, 6,
+ax_anim_terminator
+sPorygon2Anims_3_3:
+ax_anim 2, 0, 51, -1, 0, -1, 0,
+ax_anim 6, 0, 51, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 57, 10, 0, 10, 0,
+ax_anim 2, 0, 60, 21, 0, 21, 0,
+ax_anim 2, 1, 60, 21, 1, 21, 1,
+ax_anim 2, 0, 60, 21, 0, 21, 0,
+ax_anim 2, 0, 60, 21, 1, 21, 1,
+ax_anim 2, 0, 57, 6, 0, 6, 0,
+ax_anim_terminator
+sPorygon2Anims_3_4:
+ax_anim 2, 0, 54, -1, 1, -1, 1,
+ax_anim 6, 0, 54, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 5, -6, 5, -6,
+ax_anim 1, 0, 60, 12, -12, 12, -12,
+ax_anim 2, 0, 63, 20, -19, 20, -19,
+ax_anim 2, 1, 63, 21, -18, 21, -18,
+ax_anim 2, 0, 63, 20, -19, 20, -19,
+ax_anim 2, 0, 63, 21, -18, 21, -18,
+ax_anim 2, 0, 60, 6, -6, 6, -6,
+ax_anim_terminator
+sPorygon2Anims_3_5:
+ax_anim 2, 0, 57, 0, 1, 0, 1,
+ax_anim 6, 0, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 63, 0, -11, 0, -11,
+ax_anim 2, 0, 66, 0, -21, 0, -21,
+ax_anim 2, 1, 66, 1, -21, 1, -21,
+ax_anim 2, 0, 66, 0, -21, 0, -21,
+ax_anim 2, 0, 66, 1, -21, 1, -21,
+ax_anim 2, 0, 63, 0, -6, 0, -6,
+ax_anim_terminator
+sPorygon2Anims_3_6:
+ax_anim 2, 0, 60, 1, 1, 1, 1,
+ax_anim 6, 0, 60, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -5, -6, -5, -6,
+ax_anim 1, 0, 66, -12, -12, -12, -12,
+ax_anim 2, 0, 69, -20, -19, -20, -19,
+ax_anim 2, 1, 69, -21, -18, -21, -18,
+ax_anim 2, 0, 69, -20, -19, -20, -19,
+ax_anim 2, 0, 69, -21, -18, -21, -18,
+ax_anim 2, 0, 66, -6, -6, -6, -6,
+ax_anim_terminator
+sPorygon2Anims_3_7:
+ax_anim 2, 0, 63, 1, 0, 1, 0,
+ax_anim 6, 0, 63, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -21, 0, -21, 0,
+ax_anim 2, 1, 48, -21, 1, -21, 1,
+ax_anim 2, 0, 48, -21, 0, -21, 0,
+ax_anim 2, 0, 48, -21, 1, -21, 1,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim_terminator
+sPorygon2Anims_3_8:
+ax_anim 2, 0, 66, 1, -1, 1, -1,
+ax_anim 6, 0, 66, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -3, 4, -3, 4,
+ax_anim 1, 0, 48, -9, 11, -9, 11,
+ax_anim 2, 0, 51, -20, 22, -20, 22,
+ax_anim 2, 1, 51, -21, 21, -21, 21,
+ax_anim 2, 0, 51, -20, 22, -20, 22,
+ax_anim 2, 0, 51, -21, 21, -21, 21,
+ax_anim 2, 0, 48, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, -3, 0, -3,
+ax_anim 6, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -2, 0, -2,
+ax_anim 1, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sPorygon2Anims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 2, 0, 77, -3, -3, -3, -3,
+ax_anim 6, 2, 79, -4, -4, -4, -4,
+ax_anim 1, 0, 78, -2, -2, -2, -2,
+ax_anim 1, 0, 78, 2, 2, 2, 2,
+ax_anim 2, 1, 78, 3, 3, 3, 3,
+ax_anim 2, 0, 78, 4, 2, 4, 2,
+ax_anim 2, 0, 78, 3, 3, 3, 3,
+ax_anim 2, 0, 78, 4, 2, 4, 2,
+ax_anim 2, 0, 78, 3, 3, 3, 3,
+ax_anim 2, 0, 78, 4, 2, 4, 2,
+ax_anim 2, 0, 78, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sPorygon2Anims_4_3:
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim 2, 0, 81, -3, 0, -3, 0,
+ax_anim 6, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -2, 0, -2, 0,
+ax_anim 1, 0, 82, 2, 0, 2, 0,
+ax_anim 2, 1, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 82, 3, -1, 3, -1,
+ax_anim 2, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 82, 3, -1, 3, -1,
+ax_anim 2, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 82, 3, -1, 3, -1,
+ax_anim 2, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sPorygon2Anims_4_4:
+ax_anim 2, 0, 84, -2, 2, -2, 2,
+ax_anim 2, 0, 85, -3, 3, -3, 3,
+ax_anim 6, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -2, 2, -2, 2,
+ax_anim 1, 0, 86, 2, -2, 2, -2,
+ax_anim 2, 1, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 86, 4, -2, 4, -2,
+ax_anim 2, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 86, 4, -2, 4, -2,
+ax_anim 2, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 86, 4, -2, 4, -2,
+ax_anim 2, 0, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sPorygon2Anims_4_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 6, 2, 91, 0, 4, 0, 4,
+ax_anim 1, 0, 90, 0, 2, 0, 2,
+ax_anim 1, 0, 90, 0, -2, 0, -2,
+ax_anim 2, 1, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 90, 1, -3, 1, -3,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 90, 1, -3, 1, -3,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 90, 1, -3, 1, -3,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sPorygon2Anims_4_6:
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 6, 2, 95, 4, 4, 4, 4,
+ax_anim 1, 0, 94, 2, 2, 2, 2,
+ax_anim 1, 0, 94, -2, -2, -2, -2,
+ax_anim 2, 1, 94, -3, -3, -3, -3,
+ax_anim 2, 0, 94, -4, -2, -4, -2,
+ax_anim 2, 0, 94, -3, -3, -3, -3,
+ax_anim 2, 0, 94, -4, -2, -4, -2,
+ax_anim 2, 0, 94, -3, -3, -3, -3,
+ax_anim 2, 0, 94, -4, -2, -4, -2,
+ax_anim 2, 0, 94, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sPorygon2Anims_4_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 6, 2, 99, 4, 0, 4, 0,
+ax_anim 1, 0, 98, 2, 0, 2, 0,
+ax_anim 1, 0, 98, -2, 0, -2, 0,
+ax_anim 2, 1, 98, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -3, -1, -3, -1,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -3, -1, -3, -1,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 2, 0, 98, -3, -1, -3, -1,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sPorygon2Anims_4_8:
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 101, 3, -3, 3, -3,
+ax_anim 6, 2, 103, 4, -4, 4, -4,
+ax_anim 1, 0, 102, 2, -2, 2, -2,
+ax_anim 1, 0, 102, -2, 2, -2, 2,
+ax_anim 2, 1, 102, -3, 3, -3, 3,
+ax_anim 2, 0, 102, -4, 2, -4, 2,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim 2, 0, 102, -4, 2, -4, 2,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim 2, 0, 102, -4, 2, -4, 2,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 2, 107, 0, 1, 0, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 107, 0, 1, 0, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 107, 0, 1, 0, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 107, 0, 1, 0, 1,
+ax_anim_terminator
+sPorygon2Anims_5_2:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 0, 111, 2, 0, 2, 0,
+ax_anim 2, 2, 111, 1, 1, 1, 1,
+ax_anim 2, 0, 111, 2, 0, 2, 0,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 0, 111, 2, 0, 2, 0,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 0, 111, 2, 0, 2, 0,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim_terminator
+sPorygon2Anims_5_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 2, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 1, 0, 1, 0,
+ax_anim_terminator
+sPorygon2Anims_5_4:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 2, 0, 2, 0,
+ax_anim 2, 2, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 2, 0, 2, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 2, 0, 2, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 2, 0, 2, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim_terminator
+sPorygon2Anims_5_5:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 2, 123, 0, -1, 0, -1,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, -1, 0, -1,
+ax_anim_terminator
+sPorygon2Anims_5_6:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, -2, 0, -2, 0,
+ax_anim 2, 2, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, -2, 0, -2, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, -2, 0, -2, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, -2, 0, -2, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+sPorygon2Anims_5_7:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 2, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim_terminator
+sPorygon2Anims_5_8:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, 1, -1, 1,
+ax_anim 2, 0, 135, -2, 0, -2, 0,
+ax_anim 2, 2, 135, -1, 1, -1, 1,
+ax_anim 2, 0, 135, -2, 0, -2, 0,
+ax_anim 2, 0, 135, -1, 1, -1, 1,
+ax_anim 2, 0, 135, -2, 0, -2, 0,
+ax_anim 2, 0, 135, -1, 1, -1, 1,
+ax_anim 2, 0, 135, -2, 0, -2, 0,
+ax_anim 2, 0, 135, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_6_1:
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 136, 0, -1, 0, 0,
+ax_anim 16, 0, 136, 0, -2, 0, 0,
+ax_anim 16, 0, 137, 0, -2, 0, 0,
+ax_anim 12, 0, 137, 0, -1, 0, 0,
+ax_anim 16, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sPorygon2Anims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sPorygon2Anims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sPorygon2Anims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sPorygon2Anims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sPorygon2Anims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sPorygon2Anims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sPorygon2Anims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_8_1:
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, -2, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_8_2:
+ax_anim 12, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 12, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_8_3:
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_8_4:
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim 12, 0, 151, 0, -2, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_8_5:
+ax_anim 12, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 150, 0, -1, 0, 0,
+ax_anim 12, 0, 150, 0, -2, 0, 0,
+ax_anim 8, 0, 150, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_8_6:
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, -2, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_8_7:
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, -1, 0, 0,
+ax_anim 12, 0, 148, 0, -2, 0, 0,
+ax_anim 8, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_8_8:
+ax_anim 12, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim 12, 0, 147, 0, -2, 0, 0,
+ax_anim 8, 0, 147, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 7, 4, 7, 4,
+ax_anim 2, 0, 156, 11, 10, 11, 10,
+ax_anim 2, 0, 157, 9, 17, 9, 17,
+ax_anim 3, 0, 158, 0, 19, 0, 19,
+ax_anim 2, 3, 159, -9, 17, -9, 17,
+ax_anim 2, 0, 160, -11, 10, -11, 10,
+ax_anim 1, 0, 161, -7, 4, -7, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 16, 3, 16, 3,
+ax_anim 2, 0, 156, 22, 12, 22, 12,
+ax_anim 3, 0, 157, 21, 18, 21, 18,
+ax_anim 2, 3, 158, 11, 19, 11, 19,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 4, -5, 4, -5,
+ax_anim 2, 0, 154, 13, -7, 13, -7,
+ax_anim 2, 0, 155, 19, -5, 19, -5,
+ax_anim 3, 0, 156, 22, 0, 22, 0,
+ax_anim 2, 3, 157, 18, 5, 18, 5,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 11, -23, 11, -23,
+ax_anim 3, 0, 155, 21, -24, 21, -24,
+ax_anim 2, 3, 156, 22, -16, 22, -16,
+ax_anim 2, 0, 157, 18, -8, 18, -8,
+ax_anim 1, 0, 158, 9, -1, 9, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -9, -5, -9, -5,
+ax_anim 2, 0, 160, -10, -12, -10, -12,
+ax_anim 2, 0, 161, -7, -20, -7, -20,
+ax_anim 3, 0, 154, 0, -25, 0, -25,
+ax_anim 2, 3, 155, 7, -20, 7, -20,
+ax_anim 2, 0, 156, 10, -12, 10, -12,
+ax_anim 1, 0, 157, 9, -5, 9, -5,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -11, -23, -11, -23,
+ax_anim 3, 0, 161, -21, -24, -21, -24,
+ax_anim 2, 3, 160, -22, -16, -22, -16,
+ax_anim 2, 0, 159, -18, -8, -18, -8,
+ax_anim 1, 0, 158, -9, -1, -9, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -4, -5, -4, -5,
+ax_anim 2, 0, 154, -13, -7, -13, -7,
+ax_anim 2, 0, 161, -19, -5, -19, -5,
+ax_anim 3, 0, 160, -22, 0, -22, 0,
+ax_anim 2, 3, 159, -18, 5, -18, 5,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -16, 3, -16, 3,
+ax_anim 2, 0, 160, -22, 12, -22, 12,
+ax_anim 3, 0, 159, -21, 18, -21, 18,
+ax_anim 2, 3, 158, -11, 19, -11, 19,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_10_1:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 6, 0, 6, 0,
+ax_anim 2, 0, 165, -6, 0, -6, 0,
+ax_anim 2, 0, 165, 10, 0, 10, 0,
+ax_anim 2, 0, 165, -10, 0, -10, 0,
+ax_anim 2, 0, 165, 12, 0, 12, 0,
+ax_anim 3, 0, 165, -12, 0, -12, 0,
+ax_anim 3, 0, 165, 13, 0, 13, 0,
+ax_anim 3, 0, 165, -13, 0, -13, 0,
+ax_anim 2, 0, 165, 12, 0, 12, 0,
+ax_anim 3, 0, 165, -12, 0, -12, 0,
+ax_anim 2, 0, 165, 10, 0, 10, 0,
+ax_anim 2, 0, 165, -10, 0, -10, 0,
+ax_anim 2, 0, 165, 6, 0, 6, 0,
+ax_anim 2, 0, 165, -6, 0, -6, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_10_2:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, -6, 6, -6,
+ax_anim 2, 0, 166, -6, 6, -6, 6,
+ax_anim 2, 0, 166, 10, -10, 10, -10,
+ax_anim 2, 0, 166, -10, 10, -10, 10,
+ax_anim 2, 0, 166, 12, -12, 12, -12,
+ax_anim 3, 0, 166, -12, 12, -12, 12,
+ax_anim 3, 0, 166, 13, -13, 13, -13,
+ax_anim 3, 0, 166, -13, 13, -13, 13,
+ax_anim 2, 0, 166, 12, -12, 12, -12,
+ax_anim 3, 0, 166, -12, 12, -12, 12,
+ax_anim 2, 0, 166, 10, -10, 10, -10,
+ax_anim 2, 0, 166, -10, 10, -10, 10,
+ax_anim 2, 0, 166, 6, -6, 6, -6,
+ax_anim 2, 0, 166, -6, 6, -6, 6,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_10_3:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -6, 0, -6,
+ax_anim 2, 0, 167, 0, 6, 0, 6,
+ax_anim 2, 0, 167, 0, -10, 0, -10,
+ax_anim 2, 0, 167, 0, 10, 0, 10,
+ax_anim 2, 0, 167, 0, -12, 0, -12,
+ax_anim 3, 0, 167, 0, 12, 0, 12,
+ax_anim 3, 0, 167, 0, -13, 0, -13,
+ax_anim 3, 0, 167, 0, 13, 0, 13,
+ax_anim 2, 0, 167, 0, -12, 0, -12,
+ax_anim 3, 0, 167, 0, 12, 0, 12,
+ax_anim 2, 0, 167, 0, -10, 0, -10,
+ax_anim 2, 0, 167, 0, 10, 0, 10,
+ax_anim 2, 0, 167, 0, -6, 0, -6,
+ax_anim 2, 0, 167, 0, 6, 0, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_10_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, -6, -6, -6, -6,
+ax_anim 2, 0, 168, 6, 6, 6, 6,
+ax_anim 2, 0, 168, -10, -10, -10, -10,
+ax_anim 2, 0, 168, 10, 10, 10, 10,
+ax_anim 2, 0, 168, -12, -12, -12, -12,
+ax_anim 3, 0, 168, 12, 12, 12, 12,
+ax_anim 3, 0, 168, -13, -13, -13, -13,
+ax_anim 3, 0, 168, 13, 13, 13, 13,
+ax_anim 2, 0, 168, -12, -12, -12, -12,
+ax_anim 3, 0, 168, 12, 12, 12, 12,
+ax_anim 2, 0, 168, -10, -10, -10, -10,
+ax_anim 2, 0, 168, 10, 10, 10, 10,
+ax_anim 2, 0, 168, -6, -6, -6, -6,
+ax_anim 2, 0, 168, 6, 6, 6, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_10_5:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 6, 0, 6, 0,
+ax_anim 2, 0, 169, -6, 0, -6, 0,
+ax_anim 2, 0, 169, 10, 0, 10, 0,
+ax_anim 2, 0, 169, -10, 0, -10, 0,
+ax_anim 2, 0, 169, 12, 0, 12, 0,
+ax_anim 3, 0, 169, -12, 0, -12, 0,
+ax_anim 3, 0, 169, 13, 0, 13, 0,
+ax_anim 3, 0, 169, -13, 0, -13, 0,
+ax_anim 2, 0, 169, 12, 0, 12, 0,
+ax_anim 3, 0, 169, -12, 0, -12, 0,
+ax_anim 2, 0, 169, 10, 0, 10, 0,
+ax_anim 2, 0, 169, -10, 0, -10, 0,
+ax_anim 2, 0, 169, 6, 0, 6, 0,
+ax_anim 2, 0, 169, -6, 0, -6, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_10_6:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, -6, 6, -6,
+ax_anim 2, 0, 170, -6, 6, -6, 6,
+ax_anim 2, 0, 170, 10, -10, 10, -10,
+ax_anim 2, 0, 170, -10, 10, -10, 10,
+ax_anim 2, 0, 170, 12, -12, 12, -12,
+ax_anim 3, 0, 170, -12, 12, -12, 12,
+ax_anim 3, 0, 170, 13, -13, 13, -13,
+ax_anim 3, 0, 170, -13, 13, -13, 13,
+ax_anim 2, 0, 170, 12, -12, 12, -12,
+ax_anim 3, 0, 170, -12, 12, -12, 12,
+ax_anim 2, 0, 170, 10, -10, 10, -10,
+ax_anim 2, 0, 170, -10, 10, -10, 10,
+ax_anim 2, 0, 170, 6, -6, 6, -6,
+ax_anim 2, 0, 170, -6, 6, -6, 6,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_10_7:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, -6, 0, -6,
+ax_anim 2, 0, 171, 0, 6, 0, 6,
+ax_anim 2, 0, 171, 0, -10, 0, -10,
+ax_anim 2, 0, 171, 0, 10, 0, 10,
+ax_anim 2, 0, 171, 0, -12, 0, -12,
+ax_anim 3, 0, 171, 0, 12, 0, 12,
+ax_anim 3, 0, 171, 0, -13, 0, -13,
+ax_anim 3, 0, 171, 0, 13, 0, 13,
+ax_anim 2, 0, 171, 0, -12, 0, -12,
+ax_anim 3, 0, 171, 0, 12, 0, 12,
+ax_anim 2, 0, 171, 0, -10, 0, -10,
+ax_anim 2, 0, 171, 0, 10, 0, 10,
+ax_anim 2, 0, 171, 0, -6, 0, -6,
+ax_anim 2, 0, 171, 0, 6, 0, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_10_8:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, -6, -6, -6, -6,
+ax_anim 2, 0, 172, 6, 6, 6, 6,
+ax_anim 2, 0, 172, -10, -10, -10, -10,
+ax_anim 2, 0, 172, 10, 10, 10, 10,
+ax_anim 2, 0, 172, -12, -12, -12, -12,
+ax_anim 3, 0, 172, 12, 12, 12, 12,
+ax_anim 3, 0, 172, -13, -13, -13, -13,
+ax_anim 3, 0, 172, 13, 13, 13, 13,
+ax_anim 2, 0, 172, -12, -12, -12, -12,
+ax_anim 3, 0, 172, 12, 12, 12, 12,
+ax_anim 2, 0, 172, -10, -10, -10, -10,
+ax_anim 2, 0, 172, 10, 10, 10, 10,
+ax_anim 2, 0, 172, -6, -6, -6, -6,
+ax_anim 2, 0, 172, 6, 6, 6, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_11_1:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -23, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_11_2:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -9, 0, 0,
+ax_anim 2, 0, 178, 0, -14, 0, 0,
+ax_anim 3, 0, 178, 0, -18, 0, 0,
+ax_anim 4, 0, 178, 0, -19, 0, 0,
+ax_anim 4, 0, 176, 0, -24, 0, 0,
+ax_anim 3, 0, 177, 0, -23, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_11_3:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -23, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_11_4:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -17, 0, 0,
+ax_anim 1, 0, 183, 0, -11, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_11_5:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -19, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 1, 0, 186, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_11_6:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_11_7:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -23, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_11_8:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -9, 0, 0,
+ax_anim 2, 0, 196, 0, -14, 0, 0,
+ax_anim 3, 0, 196, 0, -18, 0, 0,
+ax_anim 4, 0, 196, 0, -19, 0, 0,
+ax_anim 4, 0, 194, 0, -24, 0, 0,
+ax_anim 3, 0, 195, 0, -23, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_12_1:
+ax_anim 2, 0, 197, 1, 0, 1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, 0, 1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, 0, 1, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, 0, 1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, 0, 1, 0,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_12_2:
+ax_anim 2, 0, 204, 1, -1, 1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, -1, 1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, -1, 1, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, -1, 1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 1, -1, 1, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_12_3:
+ax_anim 2, 0, 203, 0, -1, 0, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, -1, 0, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, -1, 0, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, -1, 0, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, -1, 0, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_12_4:
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, -1, -1, -1,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_12_5:
+ax_anim 2, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, 0, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_12_6:
+ax_anim 2, 0, 200, 1, -1, 1, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, -1, 1, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, -1, 1, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, -1, 1, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, -1, 1, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_12_7:
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -1, 0, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_12_8:
+ax_anim 2, 0, 198, -1, -1, -1, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, -1, -1, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, -1, -1, -1,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, -1, -1, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, -1, -1, -1, -1,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPorygon2Anims_13_1:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_13_2:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_13_3:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_13_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_13_5:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_13_6:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_13_7:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Anims_13_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sPorygon2Gfx1:
+.incbin "baserom.gba", 0xF72B34, 0x200
+sPorygon2Sprites1:
+ax_sprite sPorygon2Gfx1, 0x200
+ax_sprite_terminator
+sPorygon2Gfx2:
+.incbin "baserom.gba", 0xF72D44, 0x200
+sPorygon2Sprites2:
+ax_sprite sPorygon2Gfx2, 0x200
+ax_sprite_terminator
+sPorygon2Gfx3:
+.incbin "baserom.gba", 0xF72F54, 0x200
+sPorygon2Sprites3:
+ax_sprite sPorygon2Gfx3, 0x200
+ax_sprite_terminator
+sPorygon2Gfx4:
+.incbin "baserom.gba", 0xF73164, 0x200
+sPorygon2Sprites4:
+ax_sprite sPorygon2Gfx4, 0x200
+ax_sprite_terminator
+sPorygon2Gfx5:
+.incbin "baserom.gba", 0xF73374, 0x200
+sPorygon2Sprites5:
+ax_sprite sPorygon2Gfx5, 0x200
+ax_sprite_terminator
+sPorygon2Gfx6:
+.incbin "baserom.gba", 0xF73584, 0x200
+sPorygon2Sprites6:
+ax_sprite sPorygon2Gfx6, 0x200
+ax_sprite_terminator
+sPorygon2Gfx7:
+.incbin "baserom.gba", 0xF73794, 0x200
+sPorygon2Sprites7:
+ax_sprite sPorygon2Gfx7, 0x200
+ax_sprite_terminator
+sPorygon2Gfx8:
+.incbin "baserom.gba", 0xF739A4, 0x200
+sPorygon2Sprites8:
+ax_sprite sPorygon2Gfx8, 0x200
+ax_sprite_terminator
+sPorygon2Gfx9:
+.incbin "baserom.gba", 0xF73BB4, 0x200
+sPorygon2Sprites9:
+ax_sprite sPorygon2Gfx9, 0x200
+ax_sprite_terminator
+sPorygon2Gfx10:
+.incbin "baserom.gba", 0xF73DC4, 0x200
+sPorygon2Sprites10:
+ax_sprite sPorygon2Gfx10, 0x200
+ax_sprite_terminator
+sPorygon2Gfx11:
+.incbin "baserom.gba", 0xF73FD4, 0x200
+sPorygon2Sprites11:
+ax_sprite sPorygon2Gfx11, 0x200
+ax_sprite_terminator
+sPorygon2Gfx12:
+.incbin "baserom.gba", 0xF741E4, 0x200
+sPorygon2Sprites12:
+ax_sprite sPorygon2Gfx12, 0x200
+ax_sprite_terminator
+sPorygon2Gfx13:
+.incbin "baserom.gba", 0xF743F4, 0x200
+sPorygon2Sprites13:
+ax_sprite sPorygon2Gfx13, 0x200
+ax_sprite_terminator
+sPorygon2Gfx14:
+.incbin "baserom.gba", 0xF74604, 0x200
+sPorygon2Sprites14:
+ax_sprite sPorygon2Gfx14, 0x200
+ax_sprite_terminator
+sPorygon2Gfx15:
+.incbin "baserom.gba", 0xF74814, 0x200
+sPorygon2Sprites15:
+ax_sprite sPorygon2Gfx15, 0x200
+ax_sprite_terminator
+sPorygon2Gfx16:
+.incbin "baserom.gba", 0xF74A24, 0x20
+sPorygon2Gfx16_1:
+.incbin "baserom.gba", 0xF74A44, 0x60
+sPorygon2Gfx16_2:
+.incbin "baserom.gba", 0xF74AA4, 0x60
+sPorygon2Sprites16:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx17:
+.incbin "baserom.gba", 0xF74B44, 0x20
+sPorygon2Gfx17_1:
+.incbin "baserom.gba", 0xF74B64, 0x60
+sPorygon2Gfx17_2:
+.incbin "baserom.gba", 0xF74BC4, 0x60
+sPorygon2Sprites17:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx18:
+.incbin "baserom.gba", 0xF74C64, 0x20
+sPorygon2Gfx18_1:
+.incbin "baserom.gba", 0xF74C84, 0x60
+sPorygon2Gfx18_2:
+.incbin "baserom.gba", 0xF74CE4, 0x60
+sPorygon2Gfx18_3:
+.incbin "baserom.gba", 0xF74D44, 0x20
+sPorygon2Gfx18_4:
+.incbin "baserom.gba", 0xF74D64, 0x20
+sPorygon2Sprites18:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx18_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx18_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygon2Gfx19:
+.incbin "baserom.gba", 0xF74DE4, 0x20
+sPorygon2Gfx19_1:
+.incbin "baserom.gba", 0xF74E04, 0x60
+sPorygon2Gfx19_2:
+.incbin "baserom.gba", 0xF74E64, 0x60
+sPorygon2Sprites19:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx20:
+.incbin "baserom.gba", 0xF74F04, 0x60
+sPorygon2Gfx20_1:
+.incbin "baserom.gba", 0xF74F64, 0x60
+sPorygon2Gfx20_2:
+.incbin "baserom.gba", 0xF74FC4, 0x60
+sPorygon2Sprites20:
+ax_sprite sPorygon2Gfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx21:
+.incbin "baserom.gba", 0xF7505C, 0xE0
+sPorygon2Gfx21_1:
+.incbin "baserom.gba", 0xF7513C, 0x40
+sPorygon2Sprites21:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx21, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx21_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx22:
+.incbin "baserom.gba", 0xF751AC, 0x20
+sPorygon2Gfx22_1:
+.incbin "baserom.gba", 0xF751CC, 0x60
+sPorygon2Gfx22_2:
+.incbin "baserom.gba", 0xF7522C, 0x60
+sPorygon2Sprites22:
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx22, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx23:
+.incbin "baserom.gba", 0xF752CC, 0x60
+sPorygon2Gfx23_1:
+.incbin "baserom.gba", 0xF7532C, 0xE0
+sPorygon2Sprites23:
+ax_sprite sPorygon2Gfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx23_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx24:
+.incbin "baserom.gba", 0xF75434, 0x40
+sPorygon2Gfx24_1:
+.incbin "baserom.gba", 0xF75474, 0xA0
+sPorygon2Gfx24_2:
+.incbin "baserom.gba", 0xF75514, 0x40
+sPorygon2Sprites24:
+ax_sprite sPorygon2Gfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx24_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx25:
+.incbin "baserom.gba", 0xF7558C, 0x40
+sPorygon2Gfx25_1:
+.incbin "baserom.gba", 0xF755CC, 0x60
+sPorygon2Gfx25_2:
+.incbin "baserom.gba", 0xF7562C, 0x60
+sPorygon2Sprites25:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx25_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPorygon2Gfx26:
+.incbin "baserom.gba", 0xF756CC, 0x100
+sPorygon2Gfx26_1:
+.incbin "baserom.gba", 0xF757CC, 0x40
+sPorygon2Sprites26:
+ax_sprite sPorygon2Gfx26, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx26_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx27:
+.incbin "baserom.gba", 0xF75834, 0x40
+sPorygon2Gfx27_1:
+.incbin "baserom.gba", 0xF75874, 0x60
+sPorygon2Gfx27_2:
+.incbin "baserom.gba", 0xF758D4, 0x60
+sPorygon2Sprites27:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx27_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPorygon2Gfx28:
+.incbin "baserom.gba", 0xF75974, 0x40
+sPorygon2Gfx28_1:
+.incbin "baserom.gba", 0xF759B4, 0x60
+sPorygon2Gfx28_2:
+.incbin "baserom.gba", 0xF75A14, 0x60
+sPorygon2Sprites28:
+ax_sprite sPorygon2Gfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx29:
+.incbin "baserom.gba", 0xF75AAC, 0x40
+sPorygon2Gfx29_1:
+.incbin "baserom.gba", 0xF75AEC, 0x60
+sPorygon2Gfx29_2:
+.incbin "baserom.gba", 0xF75B4C, 0x80
+sPorygon2Sprites29:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx29_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPorygon2Gfx30:
+.incbin "baserom.gba", 0xF75C0C, 0x60
+sPorygon2Gfx30_1:
+.incbin "baserom.gba", 0xF75C6C, 0x60
+sPorygon2Gfx30_2:
+.incbin "baserom.gba", 0xF75CCC, 0x60
+sPorygon2Sprites30:
+ax_sprite sPorygon2Gfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx31:
+.incbin "baserom.gba", 0xF75D64, 0x60
+sPorygon2Gfx31_1:
+.incbin "baserom.gba", 0xF75DC4, 0x40
+sPorygon2Gfx31_2:
+.incbin "baserom.gba", 0xF75E04, 0x60
+sPorygon2Sprites31:
+ax_sprite sPorygon2Gfx31, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx32:
+.incbin "baserom.gba", 0xF75E9C, 0x60
+sPorygon2Gfx32_1:
+.incbin "baserom.gba", 0xF75EFC, 0x60
+sPorygon2Gfx32_2:
+.incbin "baserom.gba", 0xF75F5C, 0x60
+sPorygon2Sprites32:
+ax_sprite sPorygon2Gfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPorygon2Gfx33:
+.incbin "baserom.gba", 0xF75FF4, 0x20
+sPorygon2Gfx33_1:
+.incbin "baserom.gba", 0xF76014, 0x60
+sPorygon2Gfx33_2:
+.incbin "baserom.gba", 0xF76074, 0x60
+sPorygon2Gfx33_3:
+.incbin "baserom.gba", 0xF760D4, 0x20
+sPorygon2Sprites33:
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx33, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx33_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPorygon2Gfx34:
+.incbin "baserom.gba", 0xF76144, 0x60
+sPorygon2Gfx34_1:
+.incbin "baserom.gba", 0xF761A4, 0x60
+sPorygon2Gfx34_2:
+.incbin "baserom.gba", 0xF76204, 0x60
+sPorygon2Gfx34_3:
+.incbin "baserom.gba", 0xF76264, 0x60
+sPorygon2Sprites34:
+ax_sprite sPorygon2Gfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPorygon2Gfx35:
+.incbin "baserom.gba", 0xF7630C, 0x60
+sPorygon2Gfx35_1:
+.incbin "baserom.gba", 0xF7636C, 0x60
+sPorygon2Gfx35_2:
+.incbin "baserom.gba", 0xF763CC, 0x60
+sPorygon2Gfx35_3:
+.incbin "baserom.gba", 0xF7642C, 0x20
+sPorygon2Sprites35:
+ax_sprite sPorygon2Gfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPorygon2Gfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPorygon2Gfx35_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPorygon2Gfx36:
+.incbin "baserom.gba", 0xF76494, 0x200
+sPorygon2Sprites36:
+ax_sprite sPorygon2Gfx36, 0x200
+ax_sprite_terminator
+sPorygon2Gfx37:
+.incbin "baserom.gba", 0xF766A4, 0x200
+sPorygon2Sprites37:
+ax_sprite sPorygon2Gfx37, 0x200
+ax_sprite_terminator
+sPorygon2Gfx38:
+.incbin "baserom.gba", 0xF768B4, 0x200
+sPorygon2Sprites38:
+ax_sprite sPorygon2Gfx38, 0x200
+ax_sprite_terminator
+sPorygon2Gfx39:
+.incbin "baserom.gba", 0xF76AC4, 0x200
+sPorygon2Sprites39:
+ax_sprite sPorygon2Gfx39, 0x200
+ax_sprite_terminator
+sPorygon2Gfx40:
+.incbin "baserom.gba", 0xF76CD4, 0x100
+sPorygon2Sprites40:
+ax_sprite sPorygon2Gfx40, 0x100
+ax_sprite_terminator
+sPorygon2Gfx41:
+.incbin "baserom.gba", 0xF76DE4, 0x20
+sPorygon2Sprites41:
+ax_sprite sPorygon2Gfx41, 0x20
+ax_sprite_terminator
+sPorygon2Gfx42:
+.incbin "baserom.gba", 0xF76E14, 0x80
+sPorygon2Sprites42:
+ax_sprite sPorygon2Gfx42, 0x80
+ax_sprite_terminator
+sPorygon2Gfx43:
+.incbin "baserom.gba", 0xF76EA4, 0x100
+sPorygon2Sprites43:
+ax_sprite sPorygon2Gfx43, 0x100
+ax_sprite_terminator
+sPorygon2Gfx44:
+.incbin "baserom.gba", 0xF76FB4, 0x20
+sPorygon2Sprites44:
+ax_sprite sPorygon2Gfx44, 0x20
+ax_sprite_terminator
+sPorygon2Gfx45:
+.incbin "baserom.gba", 0xF76FE4, 0x80
+sPorygon2Sprites45:
+ax_sprite sPorygon2Gfx45, 0x80
+ax_sprite_terminator
+sPorygon2Gfx46:
+.incbin "baserom.gba", 0xF77074, 0x200
+sPorygon2Sprites46:
+ax_sprite sPorygon2Gfx46, 0x200
+ax_sprite_terminator
+sAxPosesPorygon2:
+.4byte sPorygon2Pose1
+.4byte sPorygon2Pose2
+.4byte sPorygon2Pose3
+.4byte sPorygon2Pose4
+.4byte sPorygon2Pose5
+.4byte sPorygon2Pose6
+.4byte sPorygon2Pose7
+.4byte sPorygon2Pose8
+.4byte sPorygon2Pose9
+.4byte sPorygon2Pose10
+.4byte sPorygon2Pose11
+.4byte sPorygon2Pose12
+.4byte sPorygon2Pose13
+.4byte sPorygon2Pose14
+.4byte sPorygon2Pose15
+.4byte sPorygon2Pose16
+.4byte sPorygon2Pose17
+.4byte sPorygon2Pose18
+.4byte sPorygon2Pose19
+.4byte sPorygon2Pose20
+.4byte sPorygon2Pose21
+.4byte sPorygon2Pose22
+.4byte sPorygon2Pose23
+.4byte sPorygon2Pose24
+.4byte sPorygon2Pose25
+.4byte sPorygon2Pose26
+.4byte sPorygon2Pose27
+.4byte sPorygon2Pose28
+.4byte sPorygon2Pose29
+.4byte sPorygon2Pose30
+.4byte sPorygon2Pose31
+.4byte sPorygon2Pose32
+.4byte sPorygon2Pose33
+.4byte sPorygon2Pose34
+.4byte sPorygon2Pose35
+.4byte sPorygon2Pose36
+.4byte sPorygon2Pose37
+.4byte sPorygon2Pose38
+.4byte sPorygon2Pose39
+.4byte sPorygon2Pose40
+.4byte sPorygon2Pose41
+.4byte sPorygon2Pose42
+.4byte sPorygon2Pose43
+.4byte sPorygon2Pose44
+.4byte sPorygon2Pose45
+.4byte sPorygon2Pose46
+.4byte sPorygon2Pose47
+.4byte sPorygon2Pose48
+.4byte sPorygon2Pose49
+.4byte sPorygon2Pose50
+.4byte sPorygon2Pose51
+.4byte sPorygon2Pose52
+.4byte sPorygon2Pose53
+.4byte sPorygon2Pose54
+.4byte sPorygon2Pose55
+.4byte sPorygon2Pose56
+.4byte sPorygon2Pose57
+.4byte sPorygon2Pose58
+.4byte sPorygon2Pose59
+.4byte sPorygon2Pose60
+.4byte sPorygon2Pose61
+.4byte sPorygon2Pose62
+.4byte sPorygon2Pose63
+.4byte sPorygon2Pose64
+.4byte sPorygon2Pose65
+.4byte sPorygon2Pose66
+.4byte sPorygon2Pose67
+.4byte sPorygon2Pose68
+.4byte sPorygon2Pose69
+.4byte sPorygon2Pose70
+.4byte sPorygon2Pose71
+.4byte sPorygon2Pose72
+.4byte sPorygon2Pose73
+.4byte sPorygon2Pose74
+.4byte sPorygon2Pose75
+.4byte sPorygon2Pose76
+.4byte sPorygon2Pose77
+.4byte sPorygon2Pose78
+.4byte sPorygon2Pose79
+.4byte sPorygon2Pose80
+.4byte sPorygon2Pose81
+.4byte sPorygon2Pose82
+.4byte sPorygon2Pose83
+.4byte sPorygon2Pose84
+.4byte sPorygon2Pose85
+.4byte sPorygon2Pose86
+.4byte sPorygon2Pose87
+.4byte sPorygon2Pose88
+.4byte sPorygon2Pose89
+.4byte sPorygon2Pose90
+.4byte sPorygon2Pose91
+.4byte sPorygon2Pose92
+.4byte sPorygon2Pose93
+.4byte sPorygon2Pose94
+.4byte sPorygon2Pose95
+.4byte sPorygon2Pose96
+.4byte sPorygon2Pose97
+.4byte sPorygon2Pose98
+.4byte sPorygon2Pose99
+.4byte sPorygon2Pose100
+.4byte sPorygon2Pose101
+.4byte sPorygon2Pose102
+.4byte sPorygon2Pose103
+.4byte sPorygon2Pose104
+.4byte sPorygon2Pose105
+.4byte sPorygon2Pose106
+.4byte sPorygon2Pose107
+.4byte sPorygon2Pose108
+.4byte sPorygon2Pose109
+.4byte sPorygon2Pose110
+.4byte sPorygon2Pose111
+.4byte sPorygon2Pose112
+.4byte sPorygon2Pose113
+.4byte sPorygon2Pose114
+.4byte sPorygon2Pose115
+.4byte sPorygon2Pose116
+.4byte sPorygon2Pose117
+.4byte sPorygon2Pose118
+.4byte sPorygon2Pose119
+.4byte sPorygon2Pose120
+.4byte sPorygon2Pose121
+.4byte sPorygon2Pose122
+.4byte sPorygon2Pose123
+.4byte sPorygon2Pose124
+.4byte sPorygon2Pose125
+.4byte sPorygon2Pose126
+.4byte sPorygon2Pose127
+.4byte sPorygon2Pose128
+.4byte sPorygon2Pose129
+.4byte sPorygon2Pose130
+.4byte sPorygon2Pose131
+.4byte sPorygon2Pose132
+.4byte sPorygon2Pose133
+.4byte sPorygon2Pose134
+.4byte sPorygon2Pose135
+.4byte sPorygon2Pose136
+.4byte sPorygon2Pose137
+.4byte sPorygon2Pose138
+.4byte sPorygon2Pose139
+.4byte sPorygon2Pose140
+.4byte sPorygon2Pose141
+.4byte sPorygon2Pose142
+.4byte sPorygon2Pose143
+.4byte sPorygon2Pose144
+.4byte sPorygon2Pose145
+.4byte sPorygon2Pose146
+.4byte sPorygon2Pose147
+.4byte sPorygon2Pose148
+.4byte sPorygon2Pose149
+.4byte sPorygon2Pose150
+.4byte sPorygon2Pose151
+.4byte sPorygon2Pose152
+.4byte sPorygon2Pose153
+.4byte sPorygon2Pose154
+.4byte sPorygon2Pose155
+.4byte sPorygon2Pose156
+.4byte sPorygon2Pose157
+.4byte sPorygon2Pose158
+.4byte sPorygon2Pose159
+.4byte sPorygon2Pose160
+.4byte sPorygon2Pose161
+.4byte sPorygon2Pose162
+.4byte sPorygon2Pose163
+.4byte sPorygon2Pose164
+.4byte sPorygon2Pose165
+.4byte sPorygon2Pose166
+.4byte sPorygon2Pose167
+.4byte sPorygon2Pose168
+.4byte sPorygon2Pose169
+.4byte sPorygon2Pose170
+.4byte sPorygon2Pose171
+.4byte sPorygon2Pose172
+.4byte sPorygon2Pose173
+.4byte sPorygon2Pose174
+.4byte sPorygon2Pose175
+.4byte sPorygon2Pose176
+.4byte sPorygon2Pose177
+.4byte sPorygon2Pose178
+.4byte sPorygon2Pose179
+.4byte sPorygon2Pose180
+.4byte sPorygon2Pose181
+.4byte sPorygon2Pose182
+.4byte sPorygon2Pose183
+.4byte sPorygon2Pose184
+.4byte sPorygon2Pose185
+.4byte sPorygon2Pose186
+.4byte sPorygon2Pose187
+.4byte sPorygon2Pose188
+.4byte sPorygon2Pose189
+.4byte sPorygon2Pose190
+.4byte sPorygon2Pose191
+.4byte sPorygon2Pose192
+.4byte sPorygon2Pose193
+.4byte sPorygon2Pose194
+.4byte sPorygon2Pose195
+.4byte sPorygon2Pose196
+.4byte sPorygon2Pose197
+.4byte sPorygon2Pose198
+.4byte sPorygon2Pose199
+.4byte sPorygon2Pose200
+.4byte sPorygon2Pose201
+.4byte sPorygon2Pose202
+.4byte sPorygon2Pose203
+.4byte sPorygon2Pose204
+.4byte sPorygon2Pose205
+.4byte sPorygon2Pose206
+.4byte sPorygon2Pose207
+.4byte sPorygon2Pose208
+.4byte sPorygon2Pose209
+.4byte sPorygon2Pose210
+.4byte sPorygon2Pose211
+.4byte sPorygon2Pose212
+.4byte sPorygon2Pose213
+.4byte sPorygon2Pose214
+.4byte sPorygon2Pose215
+.4byte sPorygon2Pose216
+sAxPositionsPorygon2:
+.2byte   -1,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -7
+.2byte   -1,   -6, 	  -7,   -6, 	   5,   -4, 	   0,   -7
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -6, 	  -1,   -7
+.2byte   10,   -6, 	   5,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    9,   -7, 	   3,  -10, 	  -5,   -4, 	   0,   -8
+.2byte   10,   -5, 	   4,   -5, 	  -4,   -7, 	   1,   -7
+.2byte   13,   -9, 	  -1,   -6, 	  -3,   -5, 	   0,   -9
+.2byte   12,  -10, 	  -2,   -8, 	  -4,   -5, 	   0,   -9
+.2byte   14,   -8, 	   2,   -8, 	  -2,   -6, 	   0,   -8
+.2byte    9,  -11, 	  -5,   -8, 	   2,   -4, 	  -2,   -8
+.2byte    8,  -12, 	  -4,   -6, 	   0,   -5, 	  -1,   -9
+.2byte   10,  -10, 	  -5,   -8, 	   3,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -1,  -14, 	   6,   -6, 	  -6,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	   5,   -3, 	  -7,   -6, 	   0,   -7
+.2byte  -10,  -11, 	   4,   -8, 	  -3,   -4, 	   1,   -8
+.2byte   -9,  -12, 	   3,   -6, 	  -1,   -5, 	   0,   -9
+.2byte  -11,  -10, 	   4,   -8, 	  -4,   -5, 	   0,   -8
+.2byte  -13,   -9, 	   1,   -6, 	   3,   -5, 	   0,   -9
+.2byte  -12,  -10, 	   2,   -8, 	   4,   -5, 	   0,   -9
+.2byte  -14,   -8, 	  -2,   -8, 	   2,   -6, 	   0,   -8
+.2byte  -11,   -6, 	  -6,   -7, 	   3,   -5, 	  -1,   -8
+.2byte  -10,   -7, 	  -4,  -10, 	   4,   -4, 	  -1,   -8
+.2byte  -11,   -5, 	  -5,   -5, 	   3,   -7, 	  -2,   -7
+.2byte   -1,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -7
+.2byte   -1,   -6, 	  -7,   -6, 	   5,   -4, 	   0,   -7
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -6, 	  -1,   -7
+.2byte   10,   -6, 	   5,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    9,   -7, 	   3,  -10, 	  -5,   -4, 	   0,   -8
+.2byte   10,   -5, 	   4,   -5, 	  -4,   -7, 	   1,   -7
+.2byte   13,   -9, 	  -1,   -6, 	  -3,   -5, 	   0,   -9
+.2byte   12,  -10, 	  -2,   -8, 	  -4,   -5, 	   0,   -9
+.2byte   14,   -8, 	   2,   -8, 	  -2,   -6, 	   0,   -8
+.2byte    9,  -11, 	  -5,   -8, 	   2,   -4, 	  -2,   -8
+.2byte    8,  -12, 	  -4,   -6, 	   0,   -5, 	  -1,   -9
+.2byte   10,  -10, 	  -5,   -8, 	   3,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -1,  -14, 	   6,   -6, 	  -6,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	   5,   -3, 	  -7,   -6, 	   0,   -7
+.2byte  -10,  -11, 	   4,   -8, 	  -3,   -4, 	   1,   -8
+.2byte   -9,  -12, 	   3,   -6, 	  -1,   -5, 	   0,   -9
+.2byte  -11,  -10, 	   4,   -8, 	  -4,   -5, 	   0,   -8
+.2byte  -13,   -9, 	   1,   -6, 	   3,   -5, 	   0,   -9
+.2byte  -12,  -10, 	   2,   -8, 	   4,   -5, 	   0,   -9
+.2byte  -14,   -8, 	  -2,   -8, 	   2,   -6, 	   0,   -8
+.2byte  -11,   -6, 	  -6,   -7, 	   3,   -5, 	  -1,   -8
+.2byte  -10,   -7, 	  -4,  -10, 	   4,   -4, 	  -1,   -8
+.2byte  -11,   -5, 	  -5,   -5, 	   3,   -7, 	  -2,   -7
+.2byte   -1,   -5, 	  -7,   -6, 	   6,   -6, 	   0,   -7
+.2byte   -1,   -6, 	  -7,   -6, 	   5,   -4, 	   0,   -7
+.2byte   -1,   -3, 	  -7,   -4, 	   6,   -6, 	  -1,   -7
+.2byte   10,   -6, 	   5,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    9,   -7, 	   3,  -10, 	  -5,   -4, 	   0,   -8
+.2byte   10,   -5, 	   4,   -5, 	  -4,   -7, 	   1,   -7
+.2byte   13,   -9, 	  -1,   -6, 	  -3,   -5, 	   0,   -9
+.2byte   12,  -10, 	  -2,   -8, 	  -4,   -5, 	   0,   -9
+.2byte   14,   -8, 	   2,   -8, 	  -2,   -6, 	   0,   -8
+.2byte    9,  -11, 	  -5,   -8, 	   2,   -4, 	  -2,   -8
+.2byte    8,  -12, 	  -4,   -6, 	   0,   -5, 	  -1,   -9
+.2byte   10,  -10, 	  -5,   -8, 	   3,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -1,  -14, 	   6,   -6, 	  -6,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	   5,   -3, 	  -7,   -6, 	   0,   -7
+.2byte  -10,  -11, 	   4,   -8, 	  -3,   -4, 	   1,   -8
+.2byte   -9,  -12, 	   3,   -6, 	  -1,   -5, 	   0,   -9
+.2byte  -11,  -10, 	   4,   -8, 	  -4,   -5, 	   0,   -8
+.2byte  -13,   -9, 	   1,   -6, 	   3,   -5, 	   0,   -9
+.2byte  -12,  -10, 	   2,   -8, 	   4,   -5, 	   0,   -9
+.2byte  -14,   -8, 	  -2,   -8, 	   2,   -6, 	   0,   -8
+.2byte  -11,   -6, 	  -6,   -7, 	   3,   -5, 	  -1,   -8
+.2byte  -10,   -7, 	  -4,  -10, 	   4,   -4, 	  -1,   -8
+.2byte  -11,   -5, 	  -5,   -5, 	   3,   -7, 	  -2,   -7
+.2byte   -1,   -4, 	  -7,   -2, 	   6,   -2, 	   0,   -4
+.2byte   -1,   -8, 	  -7,   -5, 	   6,   -5, 	  -1,   -4
+.2byte   -1,   -2, 	  -7,   -3, 	   6,   -3, 	  -1,   -4
+.2byte   -1,  -16, 	  -7,   -5, 	   6,   -5, 	   0,   -6
+.2byte    9,   -7, 	   4,   -5, 	  -5,   -1, 	   0,   -5
+.2byte    6,  -11, 	   3,   -8, 	  -5,   -2, 	  -1,   -6
+.2byte   13,   -3, 	   4,   -4, 	  -4,   -1, 	   0,   -4
+.2byte    4,  -19, 	   3,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte   11,  -12, 	   0,   -4, 	  -1,   -1, 	   0,   -5
+.2byte    7,  -15, 	  -1,   -6, 	   0,   -2, 	  -1,   -7
+.2byte   16,  -10, 	   0,   -5, 	  -2,   -2, 	   0,   -6
+.2byte    5,  -19, 	  -1,   -5, 	   0,   -2, 	  -1,   -6
+.2byte    8,  -17, 	  -3,   -5, 	   3,   -2, 	  -1,   -6
+.2byte    4,  -17, 	  -5,   -7, 	   4,   -4, 	  -2,   -5
+.2byte   11,  -18, 	  -5,   -6, 	   2,   -2, 	  -1,   -7
+.2byte    2,  -21, 	  -7,   -5, 	   3,   -3, 	  -2,   -5
+.2byte   -1,  -19, 	   6,   -3, 	  -7,   -2, 	   0,   -6
+.2byte   -1,  -15, 	   6,   -2, 	  -7,   -2, 	   0,   -3
+.2byte   -1,  -21, 	   5,   -1, 	  -6,   -1, 	  -1,   -5
+.2byte   -1,  -16, 	   6,   -2, 	  -7,   -2, 	  -1,   -3
+.2byte   -9,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -6
+.2byte   -5,  -17, 	   4,   -7, 	  -5,   -4, 	   1,   -5
+.2byte  -12,  -18, 	   4,   -6, 	  -3,   -2, 	   0,   -7
+.2byte   -3,  -21, 	   6,   -5, 	  -4,   -3, 	   1,   -5
+.2byte  -12,  -12, 	  -1,   -4, 	   0,   -1, 	  -1,   -5
+.2byte   -8,  -15, 	   0,   -6, 	  -1,   -2, 	   0,   -7
+.2byte  -17,  -10, 	  -1,   -5, 	   1,   -2, 	  -1,   -6
+.2byte   -6,  -19, 	   0,   -5, 	  -1,   -2, 	   0,   -6
+.2byte  -10,   -7, 	  -5,   -5, 	   4,   -1, 	  -1,   -5
+.2byte   -7,  -11, 	  -4,   -8, 	   4,   -2, 	   0,   -6
+.2byte  -14,   -3, 	  -5,   -4, 	   3,   -1, 	  -1,   -4
+.2byte   -5,  -19, 	  -4,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -1,   -4, 	  -7,   -2, 	   6,   -2, 	   0,   -4
+.2byte   -1,   -8, 	  -7,   -5, 	   6,   -5, 	  -1,   -4
+.2byte   -1,   -2, 	  -7,   -3, 	   6,   -3, 	  -1,   -4
+.2byte   -1,  -15, 	  -7,   -4, 	   6,   -4, 	   0,   -5
+.2byte    9,   -7, 	   4,   -5, 	  -5,   -1, 	   0,   -5
+.2byte    6,  -11, 	   3,   -8, 	  -5,   -2, 	  -1,   -6
+.2byte   13,   -3, 	   4,   -4, 	  -4,   -1, 	   0,   -4
+.2byte    3,  -18, 	   2,   -6, 	  -5,   -1, 	  -2,   -5
+.2byte   11,  -12, 	   0,   -4, 	  -1,   -1, 	   0,   -5
+.2byte    7,  -15, 	  -1,   -6, 	   0,   -2, 	  -1,   -7
+.2byte   16,  -10, 	   0,   -5, 	  -2,   -2, 	   0,   -6
+.2byte    5,  -19, 	  -1,   -5, 	   0,   -2, 	  -1,   -6
+.2byte    8,  -17, 	  -3,   -5, 	   3,   -2, 	  -1,   -6
+.2byte    4,  -17, 	  -5,   -7, 	   4,   -4, 	  -2,   -5
+.2byte   11,  -18, 	  -5,   -6, 	   2,   -2, 	  -1,   -7
+.2byte    3,  -21, 	  -6,   -5, 	   4,   -3, 	  -1,   -5
+.2byte   -1,  -19, 	   6,   -3, 	  -7,   -2, 	   0,   -6
+.2byte   -1,  -15, 	   6,   -2, 	  -7,   -2, 	   0,   -3
+.2byte   -1,  -21, 	   5,   -1, 	  -6,   -1, 	  -1,   -5
+.2byte   -1,  -16, 	   6,   -2, 	  -7,   -2, 	  -1,   -3
+.2byte   -9,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -6
+.2byte   -5,  -17, 	   4,   -7, 	  -5,   -4, 	   1,   -5
+.2byte  -12,  -18, 	   4,   -6, 	  -3,   -2, 	   0,   -7
+.2byte   -4,  -21, 	   5,   -5, 	  -5,   -3, 	   0,   -5
+.2byte  -12,  -12, 	  -1,   -4, 	   0,   -1, 	  -1,   -5
+.2byte   -8,  -15, 	   0,   -6, 	  -1,   -2, 	   0,   -7
+.2byte  -17,  -10, 	  -1,   -5, 	   1,   -2, 	  -1,   -6
+.2byte   -6,  -19, 	   0,   -5, 	  -1,   -2, 	   0,   -6
+.2byte  -10,   -7, 	  -5,   -5, 	   4,   -1, 	  -1,   -5
+.2byte   -7,  -11, 	  -4,   -8, 	   4,   -2, 	   0,   -6
+.2byte  -14,   -3, 	  -5,   -4, 	   3,   -1, 	  -1,   -4
+.2byte   -4,  -18, 	  -3,   -6, 	   4,   -1, 	   1,   -5
+.2byte  -10,   -9, 	  -3,   -8, 	   5,   -4, 	   1,   -8
+.2byte  -11,   -8, 	  -4,   -7, 	   4,   -4, 	   0,   -7
+.2byte   -1,    4, 	  -9,  -19, 	   8,    0, 	  -1,  -11
+.2byte   16,    1, 	   0,  -21, 	  -3,    0, 	  -1,   -9
+.2byte   18,   -6, 	  -5,  -18, 	   2,    1, 	   0,   -9
+.2byte   15,  -15, 	 -12,  -13, 	  10,   -3, 	  -1,   -8
+.2byte   -1,  -20, 	   8,  -10, 	  -9,   -3, 	   0,   -7
+.2byte  -16,  -15, 	  11,  -13, 	 -11,   -3, 	   0,   -8
+.2byte  -19,   -6, 	   4,  -18, 	  -3,    1, 	  -1,   -9
+.2byte  -17,    1, 	  -1,  -21, 	   2,    0, 	   0,   -9
+.2byte   -1,   -4, 	  -7,   -2, 	   6,   -2, 	   0,   -4
+.2byte  -10,   -7, 	  -5,   -5, 	   4,   -1, 	  -1,   -5
+.2byte  -12,  -12, 	  -1,   -4, 	   0,   -1, 	  -1,   -5
+.2byte   -9,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -6
+.2byte   -1,  -19, 	   6,   -3, 	  -7,   -2, 	   0,   -6
+.2byte    8,  -17, 	  -3,   -5, 	   3,   -2, 	  -1,   -6
+.2byte   11,  -12, 	   0,   -4, 	  -1,   -1, 	   0,   -5
+.2byte    9,   -7, 	   4,   -5, 	  -5,   -1, 	   0,   -5
+.2byte   -1,   -1, 	  -7,   -2, 	   6,   -2, 	  -1,   -3
+.2byte  -12,   -3, 	  -3,   -4, 	   5,   -1, 	   1,   -4
+.2byte  -15,   -8, 	   1,   -3, 	   3,    0, 	   1,   -4
+.2byte  -11,  -16, 	   5,   -4, 	  -2,    0, 	   1,   -5
+.2byte   -1,  -20, 	   5,    0, 	  -6,    0, 	  -1,   -4
+.2byte   10,  -16, 	  -6,   -4, 	   1,    0, 	  -2,   -5
+.2byte   14,   -8, 	  -2,   -3, 	  -4,    0, 	  -2,   -4
+.2byte   11,   -3, 	   2,   -4, 	  -6,   -1, 	  -2,   -4
+.2byte    8,  -17, 	  -3,   -5, 	   3,   -2, 	  -1,   -6
+.2byte    4,  -17, 	  -5,   -7, 	   4,   -4, 	  -2,   -5
+.2byte    2,  -21, 	  -7,   -5, 	   3,   -3, 	  -2,   -5
+.2byte   -1,  -16, 	  -7,   -5, 	   6,   -5, 	   0,   -6
+.2byte    5,  -18, 	   4,   -6, 	  -3,   -1, 	   0,   -5
+.2byte    6,  -19, 	   0,   -5, 	   1,   -2, 	   0,   -6
+.2byte    4,  -22, 	  -5,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -1,  -19, 	   6,   -5, 	  -7,   -5, 	  -1,   -6
+.2byte   -5,  -22, 	   4,   -6, 	  -6,   -4, 	  -1,   -6
+.2byte   -7,  -19, 	  -1,   -5, 	  -2,   -2, 	  -1,   -6
+.2byte   -6,  -18, 	  -5,   -6, 	   2,   -1, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,   -2, 	   6,   -2, 	   0,   -4
+.2byte   -1,   -2, 	  -7,   -3, 	   6,   -3, 	  -1,   -4
+.2byte   -1,  -15, 	  -7,   -4, 	   6,   -4, 	   0,   -5
+.2byte    9,   -7, 	   4,   -5, 	  -5,   -1, 	   0,   -5
+.2byte   12,   -3, 	   3,   -4, 	  -5,   -1, 	  -1,   -4
+.2byte    4,  -19, 	   3,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte   11,  -12, 	   0,   -4, 	  -1,   -1, 	   0,   -5
+.2byte   16,   -9, 	   0,   -4, 	  -2,   -1, 	   0,   -5
+.2byte    5,  -18, 	  -1,   -4, 	   0,   -1, 	  -1,   -5
+.2byte    8,  -17, 	  -3,   -5, 	   3,   -2, 	  -1,   -6
+.2byte   10,  -17, 	  -6,   -5, 	   1,   -1, 	  -2,   -6
+.2byte    3,  -21, 	  -6,   -5, 	   4,   -3, 	  -1,   -5
+.2byte   -1,  -19, 	   6,   -3, 	  -7,   -2, 	   0,   -6
+.2byte   -1,  -21, 	   5,   -1, 	  -6,   -1, 	  -1,   -5
+.2byte   -1,  -18, 	   6,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -9,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -6
+.2byte  -11,  -17, 	   5,   -5, 	  -2,   -1, 	   1,   -6
+.2byte   -4,  -21, 	   5,   -5, 	  -5,   -3, 	   0,   -5
+.2byte  -12,  -12, 	  -1,   -4, 	   0,   -1, 	  -1,   -5
+.2byte  -17,   -9, 	  -1,   -4, 	   1,   -1, 	  -1,   -5
+.2byte   -6,  -18, 	   0,   -4, 	  -1,   -1, 	   0,   -5
+.2byte  -10,   -7, 	  -5,   -5, 	   4,   -1, 	  -1,   -5
+.2byte  -13,   -3, 	  -4,   -4, 	   4,   -1, 	   0,   -4
+.2byte   -5,  -19, 	  -4,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -1,   -1, 	  -7,   -2, 	   6,   -2, 	  -1,   -3
+.2byte  -12,   -3, 	  -3,   -4, 	   5,   -1, 	   1,   -4
+.2byte  -15,   -8, 	   1,   -3, 	   3,    0, 	   1,   -4
+.2byte  -11,  -16, 	   5,   -4, 	  -2,    0, 	   1,   -5
+.2byte   -1,  -20, 	   5,    0, 	  -6,    0, 	  -1,   -4
+.2byte   10,  -16, 	  -6,   -4, 	   1,    0, 	  -2,   -5
+.2byte   14,   -8, 	  -2,   -3, 	  -4,    0, 	  -2,   -4
+.2byte   11,   -3, 	   2,   -4, 	  -6,   -1, 	  -2,   -4
+.2byte    8,  -17, 	  -3,   -5, 	   3,   -2, 	  -1,   -6
+.2byte    4,  -17, 	  -5,   -7, 	   4,   -4, 	  -2,   -5
+.2byte    2,  -21, 	  -7,   -5, 	   3,   -3, 	  -2,   -5
+.2byte   -1,   -4, 	  -7,   -2, 	   6,   -2, 	   0,   -4
+.2byte  -10,   -7, 	  -5,   -5, 	   4,   -1, 	  -1,   -5
+.2byte  -12,  -12, 	  -1,   -4, 	   0,   -1, 	  -1,   -5
+.2byte   -9,  -17, 	   2,   -5, 	  -4,   -2, 	   0,   -6
+.2byte   -1,  -19, 	   6,   -3, 	  -7,   -2, 	   0,   -6
+.2byte    8,  -17, 	  -3,   -5, 	   3,   -2, 	  -1,   -6
+.2byte   11,  -12, 	   0,   -4, 	  -1,   -1, 	   0,   -5
+.2byte    9,   -7, 	   4,   -5, 	  -5,   -1, 	   0,   -5
+sPorygon2AnimTable1:
+.4byte sPorygon2Anims_1_1
+.4byte sPorygon2Anims_1_2
+.4byte sPorygon2Anims_1_3
+.4byte sPorygon2Anims_1_4
+.4byte sPorygon2Anims_1_5
+.4byte sPorygon2Anims_1_6
+.4byte sPorygon2Anims_1_7
+.4byte sPorygon2Anims_1_8
+sPorygon2AnimTable2:
+.4byte sPorygon2Anims_2_1
+.4byte sPorygon2Anims_2_2
+.4byte sPorygon2Anims_2_3
+.4byte sPorygon2Anims_2_4
+.4byte sPorygon2Anims_2_5
+.4byte sPorygon2Anims_2_6
+.4byte sPorygon2Anims_2_7
+.4byte sPorygon2Anims_2_8
+sPorygon2AnimTable3:
+.4byte sPorygon2Anims_3_1
+.4byte sPorygon2Anims_3_2
+.4byte sPorygon2Anims_3_3
+.4byte sPorygon2Anims_3_4
+.4byte sPorygon2Anims_3_5
+.4byte sPorygon2Anims_3_6
+.4byte sPorygon2Anims_3_7
+.4byte sPorygon2Anims_3_8
+sPorygon2AnimTable4:
+.4byte sPorygon2Anims_4_1
+.4byte sPorygon2Anims_4_2
+.4byte sPorygon2Anims_4_3
+.4byte sPorygon2Anims_4_4
+.4byte sPorygon2Anims_4_5
+.4byte sPorygon2Anims_4_6
+.4byte sPorygon2Anims_4_7
+.4byte sPorygon2Anims_4_8
+sPorygon2AnimTable5:
+.4byte sPorygon2Anims_5_1
+.4byte sPorygon2Anims_5_2
+.4byte sPorygon2Anims_5_3
+.4byte sPorygon2Anims_5_4
+.4byte sPorygon2Anims_5_5
+.4byte sPorygon2Anims_5_6
+.4byte sPorygon2Anims_5_7
+.4byte sPorygon2Anims_5_8
+sPorygon2AnimTable6:
+.4byte sPorygon2Anims_6_1
+.4byte sPorygon2Anims_6_1
+.4byte sPorygon2Anims_6_1
+.4byte sPorygon2Anims_6_1
+.4byte sPorygon2Anims_6_1
+.4byte sPorygon2Anims_6_1
+.4byte sPorygon2Anims_6_1
+.4byte sPorygon2Anims_6_1
+sPorygon2AnimTable7:
+.4byte sPorygon2Anims_7_1
+.4byte sPorygon2Anims_7_2
+.4byte sPorygon2Anims_7_3
+.4byte sPorygon2Anims_7_4
+.4byte sPorygon2Anims_7_5
+.4byte sPorygon2Anims_7_6
+.4byte sPorygon2Anims_7_7
+.4byte sPorygon2Anims_7_8
+sPorygon2AnimTable8:
+.4byte sPorygon2Anims_8_1
+.4byte sPorygon2Anims_8_2
+.4byte sPorygon2Anims_8_3
+.4byte sPorygon2Anims_8_4
+.4byte sPorygon2Anims_8_5
+.4byte sPorygon2Anims_8_6
+.4byte sPorygon2Anims_8_7
+.4byte sPorygon2Anims_8_8
+sPorygon2AnimTable9:
+.4byte sPorygon2Anims_9_1
+.4byte sPorygon2Anims_9_2
+.4byte sPorygon2Anims_9_3
+.4byte sPorygon2Anims_9_4
+.4byte sPorygon2Anims_9_5
+.4byte sPorygon2Anims_9_6
+.4byte sPorygon2Anims_9_7
+.4byte sPorygon2Anims_9_8
+sPorygon2AnimTable10:
+.4byte sPorygon2Anims_10_1
+.4byte sPorygon2Anims_10_2
+.4byte sPorygon2Anims_10_3
+.4byte sPorygon2Anims_10_4
+.4byte sPorygon2Anims_10_5
+.4byte sPorygon2Anims_10_6
+.4byte sPorygon2Anims_10_7
+.4byte sPorygon2Anims_10_8
+sPorygon2AnimTable11:
+.4byte sPorygon2Anims_11_1
+.4byte sPorygon2Anims_11_2
+.4byte sPorygon2Anims_11_3
+.4byte sPorygon2Anims_11_4
+.4byte sPorygon2Anims_11_5
+.4byte sPorygon2Anims_11_6
+.4byte sPorygon2Anims_11_7
+.4byte sPorygon2Anims_11_8
+sPorygon2AnimTable12:
+.4byte sPorygon2Anims_12_1
+.4byte sPorygon2Anims_12_2
+.4byte sPorygon2Anims_12_3
+.4byte sPorygon2Anims_12_4
+.4byte sPorygon2Anims_12_5
+.4byte sPorygon2Anims_12_6
+.4byte sPorygon2Anims_12_7
+.4byte sPorygon2Anims_12_8
+sPorygon2AnimTable13:
+.4byte sPorygon2Anims_13_1
+.4byte sPorygon2Anims_13_2
+.4byte sPorygon2Anims_13_3
+.4byte sPorygon2Anims_13_4
+.4byte sPorygon2Anims_13_5
+.4byte sPorygon2Anims_13_6
+.4byte sPorygon2Anims_13_7
+.4byte sPorygon2Anims_13_8
+sAxAnimationsPorygon2:
+.4byte sPorygon2AnimTable1
+.4byte sPorygon2AnimTable2
+.4byte sPorygon2AnimTable3
+.4byte sPorygon2AnimTable4
+.4byte sPorygon2AnimTable5
+.4byte sPorygon2AnimTable6
+.4byte sPorygon2AnimTable7
+.4byte sPorygon2AnimTable8
+.4byte sPorygon2AnimTable9
+.4byte sPorygon2AnimTable10
+.4byte sPorygon2AnimTable11
+.4byte sPorygon2AnimTable12
+.4byte sPorygon2AnimTable13
+sAxSpritesPorygon2:
+.4byte sPorygon2Sprites1
+.4byte sPorygon2Sprites2
+.4byte sPorygon2Sprites3
+.4byte sPorygon2Sprites4
+.4byte sPorygon2Sprites5
+.4byte sPorygon2Sprites6
+.4byte sPorygon2Sprites7
+.4byte sPorygon2Sprites8
+.4byte sPorygon2Sprites9
+.4byte sPorygon2Sprites10
+.4byte sPorygon2Sprites11
+.4byte sPorygon2Sprites12
+.4byte sPorygon2Sprites13
+.4byte sPorygon2Sprites14
+.4byte sPorygon2Sprites15
+.4byte sPorygon2Sprites16
+.4byte sPorygon2Sprites17
+.4byte sPorygon2Sprites18
+.4byte sPorygon2Sprites19
+.4byte sPorygon2Sprites20
+.4byte sPorygon2Sprites21
+.4byte sPorygon2Sprites22
+.4byte sPorygon2Sprites23
+.4byte sPorygon2Sprites24
+.4byte sPorygon2Sprites25
+.4byte sPorygon2Sprites26
+.4byte sPorygon2Sprites27
+.4byte sPorygon2Sprites28
+.4byte sPorygon2Sprites29
+.4byte sPorygon2Sprites30
+.4byte sPorygon2Sprites31
+.4byte sPorygon2Sprites32
+.4byte sPorygon2Sprites33
+.4byte sPorygon2Sprites34
+.4byte sPorygon2Sprites35
+.4byte sPorygon2Sprites36
+.4byte sPorygon2Sprites37
+.4byte sPorygon2Sprites38
+.4byte sPorygon2Sprites39
+.4byte sPorygon2Sprites40
+.4byte sPorygon2Sprites41
+.4byte sPorygon2Sprites42
+.4byte sPorygon2Sprites43
+.4byte sPorygon2Sprites44
+.4byte sPorygon2Sprites45
+.4byte sPorygon2Sprites46
+sAxMainPorygon2:
+ax_main sAxPosesPorygon2, sAxAnimationsPorygon2, 13, sAxSpritesPorygon2, sAxPositionsPorygon2

--- a/data/ax/primeape.inc
+++ b/data/ax/primeape.inc
@@ -1,0 +1,3195 @@
+.global gAxPrimeape
+gAxPrimeape:
+ax_siro sAxMainPrimeape
+sPrimeapePose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose3:
+ax_pose 2, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose4:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose5:
+ax_pose 4, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose6:
+ax_pose 5, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose7:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose8:
+ax_pose 7, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose9:
+ax_pose 8, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose10:
+ax_pose 9, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose11:
+ax_pose 10, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose12:
+ax_pose 11, 0x01e7, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose16:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose17:
+ax_pose 16, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose18:
+ax_pose 17, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose19:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose20:
+ax_pose 19, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose21:
+ax_pose 20, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose22:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose23:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose24:
+ax_pose 23, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose25:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose26:
+ax_pose 1, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose27:
+ax_pose 2, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose28:
+ax_pose 25, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose29:
+ax_pose 4, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose30:
+ax_pose 5, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose31:
+ax_pose 26, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose32:
+ax_pose 27, 0x81f7, 0x0108, 0x6c00
+ax_pose 7, 0x81e7, 0x80f8, 0x6c02
+ax_pose_terminator
+sPrimeapePose33:
+ax_pose 8, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose34:
+ax_pose 28, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sPrimeapePose35:
+ax_pose 10, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose36:
+ax_pose 11, 0x01e7, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose37:
+ax_pose 29, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose38:
+ax_pose 13, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose39:
+ax_pose 14, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose40:
+ax_pose 28, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPrimeapePose41:
+ax_pose 16, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose42:
+ax_pose 17, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose43:
+ax_pose 30, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sPrimeapePose44:
+ax_pose 19, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose45:
+ax_pose 20, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose46:
+ax_pose 31, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose47:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose48:
+ax_pose 23, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose49:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose50:
+ax_pose 1, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose51:
+ax_pose 2, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose52:
+ax_pose 32, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose53:
+ax_pose 33, 0x01e9, 0x80f0, 0x6c00
+ax_pose 24, 0x01e9, 0x80f0, 0x6c10
+ax_pose_terminator
+sPrimeapePose54:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose55:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose56:
+ax_pose 4, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose57:
+ax_pose 5, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose58:
+ax_pose 34, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sPrimeapePose59:
+ax_pose 35, 0x81e6, 0x90fb, 0x6c00
+ax_pose 25, 0x01e6, 0x90eb, 0x6c08
+ax_pose_terminator
+sPrimeapePose60:
+ax_pose 25, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sPrimeapePose61:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose62:
+ax_pose 7, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose63:
+ax_pose 8, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose64:
+ax_pose 36, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose65:
+ax_pose 37, 0x01e6, 0x90f0, 0x6c00
+ax_pose 26, 0x01e6, 0x90ec, 0x6c10
+ax_pose_terminator
+sPrimeapePose66:
+ax_pose 26, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose67:
+ax_pose 9, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose68:
+ax_pose 10, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose69:
+ax_pose 11, 0x01e7, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose70:
+ax_pose 38, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sPrimeapePose71:
+ax_pose 39, 0x01e6, 0x90ef, 0x6c00
+ax_pose 40, 0x01e6, 0x90ef, 0x6c10
+ax_pose_terminator
+sPrimeapePose72:
+ax_pose 40, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sPrimeapePose73:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose74:
+ax_pose 13, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose75:
+ax_pose 14, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose76:
+ax_pose 41, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose77:
+ax_pose 42, 0x81e8, 0x80fc, 0x6c00
+ax_pose 29, 0x01eb, 0x80f0, 0x6c08
+ax_pose_terminator
+sPrimeapePose78:
+ax_pose 29, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose79:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose80:
+ax_pose 16, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose81:
+ax_pose 17, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose82:
+ax_pose 38, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose83:
+ax_pose 39, 0x01e6, 0x80f1, 0x6c00
+ax_pose 40, 0x01e6, 0x80f1, 0x6c10
+ax_pose_terminator
+sPrimeapePose84:
+ax_pose 40, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose85:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose86:
+ax_pose 19, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose87:
+ax_pose 20, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose88:
+ax_pose 36, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose89:
+ax_pose 37, 0x01e6, 0x80f0, 0x6c00
+ax_pose 26, 0x01e6, 0x80f4, 0x6c10
+ax_pose_terminator
+sPrimeapePose90:
+ax_pose 26, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose91:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose92:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose93:
+ax_pose 23, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose94:
+ax_pose 34, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose95:
+ax_pose 35, 0x81e6, 0x80f4, 0x6c00
+ax_pose 25, 0x01e6, 0x80f4, 0x6c08
+ax_pose_terminator
+sPrimeapePose96:
+ax_pose 25, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose97:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose98:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose99:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose100:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose101:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose102:
+ax_pose 9, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sPrimeapePose103:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose104:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose105:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose106:
+ax_pose 1, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose107:
+ax_pose 2, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose108:
+ax_pose 43, 0x81e9, 0x80f4, 0x6c00
+ax_pose 24, 0x01e9, 0x80f0, 0x6c08
+ax_pose_terminator
+sPrimeapePose109:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose110:
+ax_pose 43, 0x81e9, 0x90fc, 0x6c00
+ax_pose 44, 0x01e9, 0x80f0, 0x6c08
+ax_pose_terminator
+sPrimeapePose111:
+ax_pose 44, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose112:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose113:
+ax_pose 4, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose114:
+ax_pose 5, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose115:
+ax_pose 45, 0x81e6, 0x90fb, 0x6c00
+ax_pose 25, 0x01e6, 0x90eb, 0x6c08
+ax_pose_terminator
+sPrimeapePose116:
+ax_pose 25, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sPrimeapePose117:
+ax_pose 46, 0x01e6, 0x90eb, 0x6c00
+ax_pose 31, 0x01e6, 0x90eb, 0x6c10
+ax_pose_terminator
+sPrimeapePose118:
+ax_pose 31, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sPrimeapePose119:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose120:
+ax_pose 7, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose121:
+ax_pose 8, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose122:
+ax_pose 47, 0x01e6, 0x90f0, 0x6c00
+ax_pose 26, 0x01e6, 0x90ec, 0x6c10
+ax_pose_terminator
+sPrimeapePose123:
+ax_pose 26, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose124:
+ax_pose 48, 0x41f0, 0x90ef, 0x6c00
+ax_pose 30, 0x01e6, 0x90ec, 0x6c08
+ax_pose_terminator
+sPrimeapePose125:
+ax_pose 30, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose126:
+ax_pose 9, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose127:
+ax_pose 10, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose128:
+ax_pose 11, 0x01e7, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose129:
+ax_pose 49, 0x01e6, 0x90ef, 0x6c00
+ax_pose 40, 0x01e6, 0x90ef, 0x6c10
+ax_pose_terminator
+sPrimeapePose130:
+ax_pose 40, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sPrimeapePose131:
+ax_pose 50, 0x81e6, 0x9100, 0x6c00
+ax_pose 28, 0x01e6, 0x90ef, 0x6c08
+ax_pose_terminator
+sPrimeapePose132:
+ax_pose 28, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sPrimeapePose133:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose134:
+ax_pose 13, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose135:
+ax_pose 14, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose136:
+ax_pose 51, 0x81e9, 0x80fc, 0x6c00
+ax_pose 29, 0x01eb, 0x80f0, 0x6c08
+ax_pose_terminator
+sPrimeapePose137:
+ax_pose 29, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose138:
+ax_pose 51, 0x81e9, 0x90f4, 0x6c00
+ax_pose 52, 0x01eb, 0x80f0, 0x6c08
+ax_pose_terminator
+sPrimeapePose139:
+ax_pose 52, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose140:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose141:
+ax_pose 16, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose142:
+ax_pose 17, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose143:
+ax_pose 49, 0x01e6, 0x80f1, 0x6c00
+ax_pose 40, 0x01e6, 0x80f1, 0x6c10
+ax_pose_terminator
+sPrimeapePose144:
+ax_pose 40, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose145:
+ax_pose 50, 0x81e6, 0x80f0, 0x6c00
+ax_pose 28, 0x01e6, 0x80f1, 0x6c08
+ax_pose_terminator
+sPrimeapePose146:
+ax_pose 28, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose147:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose148:
+ax_pose 19, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose149:
+ax_pose 20, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose150:
+ax_pose 47, 0x01e6, 0x80f0, 0x6c00
+ax_pose 26, 0x01e6, 0x80f4, 0x6c10
+ax_pose_terminator
+sPrimeapePose151:
+ax_pose 26, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose152:
+ax_pose 48, 0x41f0, 0x80f1, 0x6c00
+ax_pose 30, 0x01e6, 0x80f4, 0x6c08
+ax_pose_terminator
+sPrimeapePose153:
+ax_pose 30, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose154:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose155:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose156:
+ax_pose 23, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose157:
+ax_pose 45, 0x81e6, 0x80f4, 0x6c00
+ax_pose 25, 0x01e6, 0x80f4, 0x6c08
+ax_pose_terminator
+sPrimeapePose158:
+ax_pose 25, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose159:
+ax_pose 46, 0x01e6, 0x80f4, 0x6c00
+ax_pose 31, 0x01e6, 0x80f4, 0x6c10
+ax_pose_terminator
+sPrimeapePose160:
+ax_pose 31, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose161:
+ax_pose 53, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose162:
+ax_pose 54, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose163:
+ax_pose 55, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sPrimeapePose164:
+ax_pose 56, 0x01e8, 0x90ed, 0x6c00
+ax_pose_terminator
+sPrimeapePose165:
+ax_pose 57, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sPrimeapePose166:
+ax_pose 58, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sPrimeapePose167:
+ax_pose 59, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sPrimeapePose168:
+ax_pose 58, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sPrimeapePose169:
+ax_pose 57, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sPrimeapePose170:
+ax_pose 56, 0x01e8, 0x80f3, 0x6c00
+ax_pose_terminator
+sPrimeapePose171:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose172:
+ax_pose 1, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose173:
+ax_pose 2, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose174:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose175:
+ax_pose 4, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose176:
+ax_pose 5, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose177:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose178:
+ax_pose 7, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose179:
+ax_pose 8, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose180:
+ax_pose 9, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose181:
+ax_pose 10, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose182:
+ax_pose 11, 0x01e7, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose183:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose184:
+ax_pose 13, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose185:
+ax_pose 14, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose186:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose187:
+ax_pose 16, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose188:
+ax_pose 17, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose189:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose190:
+ax_pose 19, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose191:
+ax_pose 20, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose192:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose193:
+ax_pose 22, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose194:
+ax_pose 23, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose195:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose196:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose197:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose198:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose199:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose200:
+ax_pose 9, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sPrimeapePose201:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose202:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose203:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose204:
+ax_pose 25, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sPrimeapePose205:
+ax_pose 26, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose206:
+ax_pose 40, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sPrimeapePose207:
+ax_pose 29, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose208:
+ax_pose 40, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sPrimeapePose209:
+ax_pose 26, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose210:
+ax_pose 25, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose211:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose212:
+ax_pose 2, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose213:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose214:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose215:
+ax_pose 5, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose216:
+ax_pose 25, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sPrimeapePose217:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose218:
+ax_pose 8, 0x81e7, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose219:
+ax_pose 26, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sPrimeapePose220:
+ax_pose 9, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose221:
+ax_pose 11, 0x01e7, 0x80f6, 0x6c00
+ax_pose_terminator
+sPrimeapePose222:
+ax_pose 40, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sPrimeapePose223:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose224:
+ax_pose 14, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose225:
+ax_pose 29, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose226:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose227:
+ax_pose 17, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose228:
+ax_pose 40, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose229:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose230:
+ax_pose 20, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose231:
+ax_pose 26, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose232:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose233:
+ax_pose 23, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose234:
+ax_pose 25, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sPrimeapePose235:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose236:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose237:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose238:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose239:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose240:
+ax_pose 9, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sPrimeapePose241:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose242:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose243:
+ax_pose 0, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose244:
+ax_pose 21, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose245:
+ax_pose 18, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sPrimeapePose246:
+ax_pose 15, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sPrimeapePose247:
+ax_pose 12, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sPrimeapePose248:
+ax_pose 9, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sPrimeapePose249:
+ax_pose 6, 0x81e6, 0x80f8, 0x6c00
+ax_pose_terminator
+sPrimeapePose250:
+ax_pose 3, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+.align 2
+sPrimeapeAnims_1_1:
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_2_1:
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 4, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, -6, 0, -2,
+ax_anim 1, 2, 26, 0, -4, 0, 1,
+ax_anim 2, 0, 26, 0, 5, 0, 8,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 10, 0, 12,
+ax_anim 1, 0, 25, 0, 3, 0, 5,
+ax_anim 2, 0, 25, 0, 1, 0, 2,
+ax_anim_terminator
+sPrimeapeAnims_2_2:
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 4, 0, 28, -3, -3, -3, -3,
+ax_anim 1, 0, 29, -1, -7, -1, -1,
+ax_anim 1, 2, 29, 3, -6, 3, 3,
+ax_anim 2, 0, 29, 13, 2, 13, 12,
+ax_anim 2, 0, 27, 22, 19, 22, 19,
+ax_anim 2, 1, 27, 23, 18, 23, 18,
+ax_anim 2, 0, 27, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 23, 18, 23, 18,
+ax_anim 2, 0, 27, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 23, 18, 23, 18,
+ax_anim 2, 0, 28, 15, 10, 15, 14,
+ax_anim 1, 0, 28, 7, 3, 7, 6,
+ax_anim 2, 0, 28, 3, 1, 3, 3,
+ax_anim_terminator
+sPrimeapeAnims_2_3:
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 4, 0, 31, -3, 0, -3, 0,
+ax_anim 1, 0, 32, -1, -5, -1, 0,
+ax_anim 1, 2, 32, 3, -7, 3, 0,
+ax_anim 2, 0, 32, 16, -8, 16, 0,
+ax_anim 2, 0, 30, 22, 0, 22, 0,
+ax_anim 2, 1, 30, 22, -1, 22, -1,
+ax_anim 2, 0, 30, 22, 0, 22, 0,
+ax_anim 2, 0, 30, 22, -1, 22, -1,
+ax_anim 2, 0, 30, 22, 0, 22, 0,
+ax_anim 2, 0, 30, 22, -1, 22, -1,
+ax_anim 2, 0, 31, 15, -4, 15, 0,
+ax_anim 1, 0, 31, 7, -4, 7, 0,
+ax_anim 2, 0, 31, 3, -3, 3, 0,
+ax_anim_terminator
+sPrimeapeAnims_2_4:
+ax_anim 2, 0, 34, -2, 2, -2, 2,
+ax_anim 4, 0, 34, -3, 3, -3, 3,
+ax_anim 1, 0, 35, -1, -6, -1, 1,
+ax_anim 1, 2, 35, 3, -14, 3, -4,
+ax_anim 2, 0, 35, 11, -22, 11, -13,
+ax_anim 2, 0, 33, 19, -22, 19, -22,
+ax_anim 2, 1, 33, 18, -23, 18, -23,
+ax_anim 2, 0, 33, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 18, -23, 18, -23,
+ax_anim 2, 0, 33, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 13, -19, 13, -16,
+ax_anim 1, 0, 34, 6, -10, 6, -7,
+ax_anim 2, 0, 34, 3, -6, 3, -4,
+ax_anim_terminator
+sPrimeapeAnims_2_5:
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 4, 0, 38, 0, 3, 0, 3,
+ax_anim 1, 0, 37, 0, -6, 0, -4,
+ax_anim 1, 2, 37, 0, -14, 0, -11,
+ax_anim 2, 0, 37, 0, -20, 0, -19,
+ax_anim 2, 0, 36, 0, -22, 0, -22,
+ax_anim 2, 1, 36, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -22, 0, -22,
+ax_anim 2, 0, 36, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -22, 0, -22,
+ax_anim 2, 0, 36, 1, -22, 1, -22,
+ax_anim 2, 0, 37, 0, -19, 0, -17,
+ax_anim 1, 0, 37, 0, -10, 0, -8,
+ax_anim 2, 0, 37, 0, -6, 0, -5,
+ax_anim_terminator
+sPrimeapeAnims_2_6:
+ax_anim 2, 0, 40, 2, 2, 2, 2,
+ax_anim 4, 0, 40, 3, 3, 3, 3,
+ax_anim 1, 0, 41, 1, -6, 1, 1,
+ax_anim 1, 2, 41, -3, -14, -3, -4,
+ax_anim 2, 0, 41, -11, -22, -11, -13,
+ax_anim 2, 0, 39, -19, -22, -19, -22,
+ax_anim 2, 1, 39, -18, -23, -18, -23,
+ax_anim 2, 0, 39, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -18, -23, -18, -23,
+ax_anim 2, 0, 39, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -13, -19, -13, -16,
+ax_anim 1, 0, 40, -6, -10, -6, -7,
+ax_anim 2, 0, 40, -3, -6, -3, -4,
+ax_anim_terminator
+sPrimeapeAnims_2_7:
+ax_anim 2, 0, 43, 2, 0, 2, 0,
+ax_anim 4, 0, 43, 3, 0, 3, 0,
+ax_anim 1, 0, 44, 1, -5, 1, 0,
+ax_anim 1, 2, 44, -3, -7, -3, 0,
+ax_anim 2, 0, 44, -16, -8, -16, 0,
+ax_anim 2, 0, 42, -22, 0, -22, 0,
+ax_anim 2, 1, 42, -22, -1, -22, -1,
+ax_anim 2, 0, 42, -22, 0, -22, 0,
+ax_anim 2, 0, 42, -22, -1, -22, -1,
+ax_anim 2, 0, 42, -22, 0, -22, 0,
+ax_anim 2, 0, 42, -22, -1, -22, -1,
+ax_anim 2, 0, 43, -15, -4, -15, 0,
+ax_anim 1, 0, 43, -7, -4, -7, 0,
+ax_anim 2, 0, 43, -3, -3, -3, 0,
+ax_anim_terminator
+sPrimeapeAnims_2_8:
+ax_anim 2, 0, 46, 2, -2, 2, -2,
+ax_anim 4, 0, 46, 3, -3, 3, -3,
+ax_anim 1, 0, 47, 1, -7, 1, -1,
+ax_anim 1, 2, 47, -3, -6, -3, 3,
+ax_anim 2, 0, 47, -13, 2, -13, 12,
+ax_anim 2, 0, 45, -22, 19, -22, 19,
+ax_anim 2, 1, 45, -23, 18, -23, 18,
+ax_anim 2, 0, 45, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -23, 18, -23, 18,
+ax_anim 2, 0, 45, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -23, 18, -23, 18,
+ax_anim 2, 0, 46, -15, 10, -15, 14,
+ax_anim 1, 0, 46, -7, 3, -7, 6,
+ax_anim 2, 0, 46, -3, 1, -3, 3,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 51, 0, -3, 0, -3,
+ax_anim 1, 0, 51, 0, -4, 0, -4,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 2, 51, 0, 8, 0, 8,
+ax_anim 2, 0, 52, 0, 19, 0, 19,
+ax_anim 2, 1, 53, -1, 19, -1, 19,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 0, 53, -1, 19, -1, 19,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 0, 53, -1, 19, -1, 19,
+ax_anim 2, 0, 50, 0, 12, 0, 12,
+ax_anim 2, 0, 50, 0, 5, 0, 5,
+ax_anim_terminator
+sPrimeapeAnims_3_2:
+ax_anim 2, 0, 54, -1, -1, -1, -1,
+ax_anim 6, 0, 57, -3, -3, -3, -3,
+ax_anim 1, 0, 57, -4, -4, -4, -4,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 2, 57, 9, 8, 9, 8,
+ax_anim 2, 0, 58, 19, 18, 19, 18,
+ax_anim 2, 1, 59, 18, 19, 18, 19,
+ax_anim 2, 0, 59, 19, 18, 19, 18,
+ax_anim 2, 0, 59, 18, 19, 18, 19,
+ax_anim 2, 0, 59, 19, 18, 19, 18,
+ax_anim 2, 0, 59, 18, 19, 18, 19,
+ax_anim 2, 0, 56, 12, 12, 12, 12,
+ax_anim 2, 0, 56, 5, 5, 5, 5,
+ax_anim_terminator
+sPrimeapeAnims_3_3:
+ax_anim 2, 0, 60, -1, 0, -1, 0,
+ax_anim 6, 0, 63, -3, 0, -3, 0,
+ax_anim 1, 0, 63, -4, 0, -4, 0,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 2, 63, 9, 0, 9, 0,
+ax_anim 2, 0, 64, 17, 0, 17, 0,
+ax_anim 2, 1, 65, 17, 1, 17, 1,
+ax_anim 2, 0, 65, 17, 0, 17, 0,
+ax_anim 2, 0, 65, 17, 1, 17, 1,
+ax_anim 2, 0, 65, 17, 0, 17, 0,
+ax_anim 2, 0, 65, 17, 1, 17, 1,
+ax_anim 2, 0, 62, 12, 0, 12, 0,
+ax_anim 2, 0, 62, 5, 0, 5, 0,
+ax_anim_terminator
+sPrimeapeAnims_3_4:
+ax_anim 2, 0, 66, -1, 1, -1, 1,
+ax_anim 6, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 0, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 2, 69, 9, -9, 9, -9,
+ax_anim 2, 0, 70, 17, -17, 17, -17,
+ax_anim 2, 1, 71, 18, -16, 18, -16,
+ax_anim 2, 0, 71, 17, -17, 17, -17,
+ax_anim 2, 0, 71, 18, -16, 18, -16,
+ax_anim 2, 0, 71, 17, -17, 17, -17,
+ax_anim 2, 0, 71, 18, -16, 18, -16,
+ax_anim 2, 0, 68, 12, -12, 12, -12,
+ax_anim 2, 0, 68, 5, -5, 5, -5,
+ax_anim_terminator
+sPrimeapeAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 75, 0, 3, 0, 3,
+ax_anim 1, 0, 75, 0, 4, 0, 4,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 75, 0, -9, 0, -9,
+ax_anim 2, 0, 76, 0, -17, 0, -17,
+ax_anim 2, 1, 77, 1, -17, 1, -17,
+ax_anim 2, 0, 77, 0, -17, 0, -17,
+ax_anim 2, 0, 77, 1, -17, 1, -17,
+ax_anim 2, 0, 77, 0, -17, 0, -17,
+ax_anim 2, 0, 77, 1, -17, 1, -17,
+ax_anim 2, 0, 74, 0, -12, 0, -12,
+ax_anim 2, 0, 74, 0, -5, 0, -5,
+ax_anim_terminator
+sPrimeapeAnims_3_6:
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim 6, 0, 81, 3, 3, 3, 3,
+ax_anim 1, 0, 81, 4, 4, 4, 4,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 81, -9, -9, -9, -9,
+ax_anim 2, 0, 82, -17, -17, -17, -17,
+ax_anim 2, 1, 83, -18, -16, -18, -16,
+ax_anim 2, 0, 83, -17, -17, -17, -17,
+ax_anim 2, 0, 83, -18, -16, -18, -16,
+ax_anim 2, 0, 83, -17, -17, -17, -17,
+ax_anim 2, 0, 83, -18, -16, -18, -16,
+ax_anim 2, 0, 80, -12, -12, -12, -12,
+ax_anim 2, 0, 80, -5, -5, -5, -5,
+ax_anim_terminator
+sPrimeapeAnims_3_7:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 6, 0, 87, 3, 0, 3, 0,
+ax_anim 1, 0, 87, 4, 0, 4, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 87, -9, 0, -9, 0,
+ax_anim 2, 0, 88, -17, 0, -17, 0,
+ax_anim 2, 1, 89, -17, 1, -17, 1,
+ax_anim 2, 0, 89, -17, 0, -17, 0,
+ax_anim 2, 0, 89, -17, 1, -17, 1,
+ax_anim 2, 0, 89, -17, 0, -17, 0,
+ax_anim 2, 0, 89, -17, 1, -17, 1,
+ax_anim 2, 0, 86, -12, 0, -12, 0,
+ax_anim 2, 0, 86, -5, 0, -5, 0,
+ax_anim_terminator
+sPrimeapeAnims_3_8:
+ax_anim 2, 0, 90, 1, -1, 1, -1,
+ax_anim 6, 0, 93, 3, -3, 3, -3,
+ax_anim 1, 0, 93, 4, -4, 4, -4,
+ax_anim 1, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 93, -9, 8, -9, 8,
+ax_anim 2, 0, 94, -19, 18, -19, 18,
+ax_anim 2, 1, 95, -18, 19, -18, 19,
+ax_anim 2, 0, 95, -19, 18, -19, 18,
+ax_anim 2, 0, 95, -18, 19, -18, 19,
+ax_anim 2, 0, 95, -19, 18, -19, 18,
+ax_anim 2, 0, 95, -18, 19, -18, 19,
+ax_anim 2, 0, 92, -12, 12, -12, 12,
+ax_anim 2, 0, 92, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_4_1:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_4_2:
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_4_3:
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 1, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_4_4:
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_4_5:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 1, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_4_6:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_4_7:
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_4_8:
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 2, 1, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_5_1:
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim 6, 0, 110, 0, -6, 0, -6,
+ax_anim 1, 2, 110, 0, -3, 0, -3,
+ax_anim 1, 0, 110, 0, 3, 0, 3,
+ax_anim 2, 0, 107, 0, 18, 0, 18,
+ax_anim 2, 1, 108, 1, 19, 1, 19,
+ax_anim 2, 0, 108, 1, 15, 1, 15,
+ax_anim 2, 0, 108, 0, 13, 0, 13,
+ax_anim 2, 0, 109, 0, 18, 0, 18,
+ax_anim 2, 0, 110, -1, 19, -1, 19,
+ax_anim 2, 0, 104, -1, 16, -1, 16,
+ax_anim 2, 0, 104, 0, 11, 0, 11,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim_terminator
+sPrimeapeAnims_5_2:
+ax_anim 2, 0, 111, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -4, -4, -4, -4,
+ax_anim 6, 0, 117, -6, -6, -6, -6,
+ax_anim 1, 2, 117, -3, -3, -3, -3,
+ax_anim 1, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 114, 19, 17, 19, 19,
+ax_anim 2, 1, 115, 18, 19, 18, 21,
+ax_anim 2, 0, 115, 15, 15, 16, 17,
+ax_anim 2, 0, 115, 15, 14, 15, 14,
+ax_anim 2, 0, 116, 19, 17, 19, 19,
+ax_anim 2, 0, 117, 22, 16, 22, 16,
+ax_anim 2, 0, 111, 17, 15, 17, 15,
+ax_anim 2, 0, 111, 11, 11, 11, 11,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sPrimeapeAnims_5_3:
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim 2, 0, 118, -4, 0, -4, 0,
+ax_anim 6, 0, 124, -6, 0, -6, 0,
+ax_anim 1, 2, 124, -3, 0, -3, 0,
+ax_anim 1, 0, 124, 6, 0, 6, 0,
+ax_anim 2, 0, 121, 15, 0, 15, 0,
+ax_anim 2, 1, 122, 16, 2, 16, 2,
+ax_anim 2, 0, 122, 10, 2, 10, 2,
+ax_anim 2, 0, 122, 7, 0, 7, 0,
+ax_anim 2, 0, 123, 15, 0, 15, 0,
+ax_anim 2, 0, 124, 16, -2, 16, -2,
+ax_anim 2, 0, 118, 9, -2, 9, -2,
+ax_anim 2, 0, 118, 6, -1, 6, -1,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim_terminator
+sPrimeapeAnims_5_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 6, 0, 131, -6, 6, -6, 6,
+ax_anim 1, 2, 131, -3, 3, -3, 3,
+ax_anim 1, 0, 131, 6, -7, 6, -7,
+ax_anim 2, 0, 128, 17, -18, 17, -18,
+ax_anim 2, 1, 129, 19, -18, 19, -18,
+ax_anim 2, 0, 129, 16, -14, 16, -14,
+ax_anim 2, 0, 129, 10, -11, 10, -11,
+ax_anim 2, 0, 130, 17, -18, 17, -18,
+ax_anim 2, 0, 131, 17, -20, 17, -20,
+ax_anim 2, 0, 125, 10, -14, 10, -14,
+ax_anim 2, 0, 125, 6, -7, 6, -7,
+ax_anim 2, 0, 125, 3, -3, 3, -3,
+ax_anim_terminator
+sPrimeapeAnims_5_5:
+ax_anim 2, 0, 132, 0, 2, 0, 2,
+ax_anim 2, 0, 132, 0, 4, 0, 4,
+ax_anim 6, 0, 138, 0, 6, 0, 6,
+ax_anim 1, 2, 138, 0, 3, 0, 3,
+ax_anim 1, 0, 138, 0, -6, 0, -6,
+ax_anim 2, 0, 135, 0, -19, 0, -19,
+ax_anim 2, 1, 136, -1, -20, -1, -20,
+ax_anim 2, 0, 136, -1, -16, -1, -16,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 2, 0, 137, 0, -19, 0, -19,
+ax_anim 2, 0, 138, 1, -20, 1, -20,
+ax_anim 2, 0, 132, 1, -10, 1, -10,
+ax_anim 2, 0, 132, 0, -5, 0, -5,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim_terminator
+sPrimeapeAnims_5_6:
+ax_anim 2, 0, 139, 2, 2, 2, 2,
+ax_anim 2, 0, 139, 4, 4, 4, 4,
+ax_anim 6, 0, 145, 6, 6, 6, 6,
+ax_anim 1, 2, 145, 3, 3, 3, 3,
+ax_anim 1, 0, 145, -6, -7, -6, -7,
+ax_anim 2, 0, 142, -17, -18, -17, -18,
+ax_anim 2, 1, 143, -19, -18, -19, -18,
+ax_anim 2, 0, 143, -16, -14, -16, -14,
+ax_anim 2, 0, 143, -10, -11, -10, -11,
+ax_anim 2, 0, 144, -17, -18, -17, -18,
+ax_anim 2, 0, 145, -17, -20, -17, -20,
+ax_anim 2, 0, 139, -10, -14, -10, -14,
+ax_anim 2, 0, 139, -6, -7, -6, -7,
+ax_anim 2, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sPrimeapeAnims_5_7:
+ax_anim 2, 0, 146, 2, 0, 2, 0,
+ax_anim 2, 0, 146, 4, 0, 4, 0,
+ax_anim 6, 0, 152, 6, 0, 6, 0,
+ax_anim 1, 2, 152, 3, 0, 3, 0,
+ax_anim 1, 0, 152, -6, 0, -6, 0,
+ax_anim 2, 0, 149, -15, 0, -15, 0,
+ax_anim 2, 1, 150, -16, 2, -16, 2,
+ax_anim 2, 0, 150, -10, 2, -10, 2,
+ax_anim 2, 0, 150, -7, 0, -7, 0,
+ax_anim 2, 0, 151, -15, 0, -15, 0,
+ax_anim 2, 0, 152, -16, -2, -16, -2,
+ax_anim 2, 0, 146, -9, -2, -9, -2,
+ax_anim 2, 0, 146, -6, -1, -6, -1,
+ax_anim 2, 0, 146, -3, 0, -3, 0,
+ax_anim_terminator
+sPrimeapeAnims_5_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 6, 0, 159, 6, -6, 6, -6,
+ax_anim 1, 2, 159, 3, -3, 3, -3,
+ax_anim 1, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 156, -19, 17, -19, 19,
+ax_anim 2, 1, 157, -18, 19, -18, 21,
+ax_anim 2, 0, 157, -15, 15, -16, 17,
+ax_anim 2, 0, 157, -15, 14, -15, 14,
+ax_anim 2, 0, 158, -19, 17, -19, 19,
+ax_anim 2, 0, 159, -21, 16, -21, 18,
+ax_anim 2, 0, 153, -17, 15, -17, 15,
+ax_anim 2, 0, 153, -11, 11, -11, 11,
+ax_anim 2, 0, 153, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_6_1:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sPrimeapeAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sPrimeapeAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sPrimeapeAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sPrimeapeAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sPrimeapeAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sPrimeapeAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sPrimeapeAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_8_1:
+ax_anim 22, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, -4, 0, 0,
+ax_anim 6, 0, 171, 0, -5, 0, 0,
+ax_anim 4, 0, 171, 0, -4, 0, 0,
+ax_anim 22, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim 6, 0, 172, 0, -5, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_8_2:
+ax_anim 22, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 174, 0, -5, 0, 0,
+ax_anim 6, 0, 174, 0, -6, 0, 0,
+ax_anim 4, 0, 174, 0, -5, 0, 0,
+ax_anim 22, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, -4, 0, 0,
+ax_anim 6, 0, 175, 0, -5, 0, 0,
+ax_anim 4, 0, 175, 0, -4, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_8_3:
+ax_anim 22, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, -5, 0, 0,
+ax_anim 6, 0, 177, 0, -7, 0, 0,
+ax_anim 4, 0, 177, 0, -5, 0, 0,
+ax_anim 22, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, -4, 0, 0,
+ax_anim 6, 0, 178, 0, -6, 0, 0,
+ax_anim 4, 0, 178, 0, -4, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_8_4:
+ax_anim 22, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 180, 0, -4, 0, 0,
+ax_anim 6, 0, 180, 0, -5, 0, 0,
+ax_anim 4, 0, 180, 0, -4, 0, 0,
+ax_anim 22, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, -5, 0, 0,
+ax_anim 6, 0, 181, 0, -6, 0, 0,
+ax_anim 4, 0, 181, 0, -5, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_8_5:
+ax_anim 22, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, -5, 0, 0,
+ax_anim 6, 0, 183, 0, -6, 0, 0,
+ax_anim 4, 0, 183, 0, -5, 0, 0,
+ax_anim 22, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, -5, 0, 0,
+ax_anim 6, 0, 184, 0, -6, 0, 0,
+ax_anim 4, 0, 184, 0, -5, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_8_6:
+ax_anim 22, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 186, 0, -4, 0, 0,
+ax_anim 6, 0, 186, 0, -5, 0, 0,
+ax_anim 4, 0, 186, 0, -4, 0, 0,
+ax_anim 22, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 187, 0, -5, 0, 0,
+ax_anim 6, 0, 187, 0, -6, 0, 0,
+ax_anim 4, 0, 187, 0, -5, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_8_7:
+ax_anim 22, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 189, 0, -5, 0, 0,
+ax_anim 6, 0, 189, 0, -7, 0, 0,
+ax_anim 4, 0, 189, 0, -5, 0, 0,
+ax_anim 22, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 190, 0, -4, 0, 0,
+ax_anim 6, 0, 190, 0, -6, 0, 0,
+ax_anim 4, 0, 190, 0, -4, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_8_8:
+ax_anim 22, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 192, 0, -5, 0, 0,
+ax_anim 6, 0, 192, 0, -6, 0, 0,
+ax_anim 4, 0, 192, 0, -5, 0, 0,
+ax_anim 22, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 193, 0, -4, 0, 0,
+ax_anim 6, 0, 193, 0, -5, 0, 0,
+ax_anim 4, 0, 193, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 9, 8, 9,
+ax_anim 2, 0, 197, 7, 16, 7, 16,
+ax_anim 3, 0, 198, 0, 20, 0, 20,
+ax_anim 2, 3, 199, -7, 16, -7, 16,
+ax_anim 2, 0, 200, -8, 9, -8, 9,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 19, 3, 19, 3,
+ax_anim 2, 0, 196, 23, 10, 23, 10,
+ax_anim 3, 0, 197, 22, 20, 22, 20,
+ax_anim 2, 3, 198, 11, 19, 11, 19,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 18, -5, 18, -5,
+ax_anim 3, 0, 196, 22, -2, 22, -2,
+ax_anim 2, 3, 197, 18, 4, 18, 4,
+ax_anim 2, 0, 198, 12, 5, 12, 5,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -6, -1, -6,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 12, -22, 12, -22,
+ax_anim 3, 0, 195, 21, -19, 21, -19,
+ax_anim 2, 3, 196, 22, -11, 22, -11,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -18, -7, -18,
+ax_anim 3, 0, 194, 0, -22, 0, -22,
+ax_anim 2, 3, 195, 7, -18, 7, -18,
+ax_anim 2, 0, 196, 9, -10, 9, -10,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -6, 1, -6,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -12, -22, -12, -22,
+ax_anim 3, 0, 201, -21, -19, -21, -19,
+ax_anim 2, 3, 200, -22, -11, -22, -11,
+ax_anim 2, 0, 199, -17, -4, -17, -4,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -18, -5, -18, -5,
+ax_anim 3, 0, 200, -22, -2, -22, -2,
+ax_anim 2, 3, 199, -18, 4, -18, 4,
+ax_anim 2, 0, 198, -12, 5, -12, 5,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -19, 3, -19, 3,
+ax_anim 2, 0, 200, -23, 10, -23, 10,
+ax_anim 3, 0, 199, -22, 20, -22, 20,
+ax_anim 2, 3, 198, -11, 19, -11, 19,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -22, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPrimeapeAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sPrimeapeGfx1:
+.incbin "baserom.gba", 0x77CEA4, 0x200
+sPrimeapeSprites1:
+ax_sprite sPrimeapeGfx1, 0x200
+ax_sprite_terminator
+sPrimeapeGfx2:
+.incbin "baserom.gba", 0x77D0B4, 0x200
+sPrimeapeSprites2:
+ax_sprite sPrimeapeGfx2, 0x200
+ax_sprite_terminator
+sPrimeapeGfx3:
+.incbin "baserom.gba", 0x77D2C4, 0x200
+sPrimeapeSprites3:
+ax_sprite sPrimeapeGfx3, 0x200
+ax_sprite_terminator
+sPrimeapeGfx4:
+.incbin "baserom.gba", 0x77D4D4, 0x200
+sPrimeapeSprites4:
+ax_sprite sPrimeapeGfx4, 0x200
+ax_sprite_terminator
+sPrimeapeGfx5:
+.incbin "baserom.gba", 0x77D6E4, 0x200
+sPrimeapeSprites5:
+ax_sprite sPrimeapeGfx5, 0x200
+ax_sprite_terminator
+sPrimeapeGfx6:
+.incbin "baserom.gba", 0x77D8F4, 0x200
+sPrimeapeSprites6:
+ax_sprite sPrimeapeGfx6, 0x200
+ax_sprite_terminator
+sPrimeapeGfx7:
+.incbin "baserom.gba", 0x77DB04, 0x100
+sPrimeapeSprites7:
+ax_sprite sPrimeapeGfx7, 0x100
+ax_sprite_terminator
+sPrimeapeGfx8:
+.incbin "baserom.gba", 0x77DC14, 0x100
+sPrimeapeSprites8:
+ax_sprite sPrimeapeGfx8, 0x100
+ax_sprite_terminator
+sPrimeapeGfx9:
+.incbin "baserom.gba", 0x77DD24, 0x100
+sPrimeapeSprites9:
+ax_sprite sPrimeapeGfx9, 0x100
+ax_sprite_terminator
+sPrimeapeGfx10:
+.incbin "baserom.gba", 0x77DE34, 0x200
+sPrimeapeSprites10:
+ax_sprite sPrimeapeGfx10, 0x200
+ax_sprite_terminator
+sPrimeapeGfx11:
+.incbin "baserom.gba", 0x77E044, 0x200
+sPrimeapeSprites11:
+ax_sprite sPrimeapeGfx11, 0x200
+ax_sprite_terminator
+sPrimeapeGfx12:
+.incbin "baserom.gba", 0x77E254, 0x200
+sPrimeapeSprites12:
+ax_sprite sPrimeapeGfx12, 0x200
+ax_sprite_terminator
+sPrimeapeGfx13:
+.incbin "baserom.gba", 0x77E464, 0x200
+sPrimeapeSprites13:
+ax_sprite sPrimeapeGfx13, 0x200
+ax_sprite_terminator
+sPrimeapeGfx14:
+.incbin "baserom.gba", 0x77E674, 0x200
+sPrimeapeSprites14:
+ax_sprite sPrimeapeGfx14, 0x200
+ax_sprite_terminator
+sPrimeapeGfx15:
+.incbin "baserom.gba", 0x77E884, 0x200
+sPrimeapeSprites15:
+ax_sprite sPrimeapeGfx15, 0x200
+ax_sprite_terminator
+sPrimeapeGfx16:
+.incbin "baserom.gba", 0x77EA94, 0x200
+sPrimeapeSprites16:
+ax_sprite sPrimeapeGfx16, 0x200
+ax_sprite_terminator
+sPrimeapeGfx17:
+.incbin "baserom.gba", 0x77ECA4, 0x200
+sPrimeapeSprites17:
+ax_sprite sPrimeapeGfx17, 0x200
+ax_sprite_terminator
+sPrimeapeGfx18:
+.incbin "baserom.gba", 0x77EEB4, 0x200
+sPrimeapeSprites18:
+ax_sprite sPrimeapeGfx18, 0x200
+ax_sprite_terminator
+sPrimeapeGfx19:
+.incbin "baserom.gba", 0x77F0C4, 0x200
+sPrimeapeSprites19:
+ax_sprite sPrimeapeGfx19, 0x200
+ax_sprite_terminator
+sPrimeapeGfx20:
+.incbin "baserom.gba", 0x77F2D4, 0x200
+sPrimeapeSprites20:
+ax_sprite sPrimeapeGfx20, 0x200
+ax_sprite_terminator
+sPrimeapeGfx21:
+.incbin "baserom.gba", 0x77F4E4, 0x200
+sPrimeapeSprites21:
+ax_sprite sPrimeapeGfx21, 0x200
+ax_sprite_terminator
+sPrimeapeGfx22:
+.incbin "baserom.gba", 0x77F6F4, 0x200
+sPrimeapeSprites22:
+ax_sprite sPrimeapeGfx22, 0x200
+ax_sprite_terminator
+sPrimeapeGfx23:
+.incbin "baserom.gba", 0x77F904, 0x200
+sPrimeapeSprites23:
+ax_sprite sPrimeapeGfx23, 0x200
+ax_sprite_terminator
+sPrimeapeGfx24:
+.incbin "baserom.gba", 0x77FB14, 0x200
+sPrimeapeSprites24:
+ax_sprite sPrimeapeGfx24, 0x200
+ax_sprite_terminator
+sPrimeapeGfx25:
+.incbin "baserom.gba", 0x77FD24, 0x60
+sPrimeapeGfx25_1:
+.incbin "baserom.gba", 0x77FD84, 0x60
+sPrimeapeGfx25_2:
+.incbin "baserom.gba", 0x77FDE4, 0x40
+sPrimeapeGfx25_3:
+.incbin "baserom.gba", 0x77FE24, 0x60
+sPrimeapeSprites25:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx26:
+.incbin "baserom.gba", 0x77FED4, 0x60
+sPrimeapeGfx26_1:
+.incbin "baserom.gba", 0x77FF34, 0x60
+sPrimeapeGfx26_2:
+.incbin "baserom.gba", 0x77FF94, 0x60
+sPrimeapeSprites26:
+ax_sprite 0, 0x80
+ax_sprite sPrimeapeGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx27:
+.incbin "baserom.gba", 0x780034, 0x60
+sPrimeapeGfx27_1:
+.incbin "baserom.gba", 0x780094, 0x60
+sPrimeapeGfx27_2:
+.incbin "baserom.gba", 0x7800F4, 0x60
+sPrimeapeSprites27:
+ax_sprite 0, 0x80
+ax_sprite sPrimeapeGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx28:
+.incbin "baserom.gba", 0x780194, 0x40
+sPrimeapeSprites28:
+ax_sprite sPrimeapeGfx28, 0x40
+ax_sprite_terminator
+sPrimeapeGfx29:
+.incbin "baserom.gba", 0x7801E4, 0x40
+sPrimeapeGfx29_1:
+.incbin "baserom.gba", 0x780224, 0xE0
+sPrimeapeGfx29_2:
+.incbin "baserom.gba", 0x780304, 0x60
+sPrimeapeSprites29:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx29_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx30:
+.incbin "baserom.gba", 0x7803A4, 0x60
+sPrimeapeGfx30_1:
+.incbin "baserom.gba", 0x780404, 0x60
+sPrimeapeGfx30_2:
+.incbin "baserom.gba", 0x780464, 0x40
+sPrimeapeSprites30:
+ax_sprite sPrimeapeGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx30_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPrimeapeGfx31:
+.incbin "baserom.gba", 0x7804DC, 0x40
+sPrimeapeGfx31_1:
+.incbin "baserom.gba", 0x78051C, 0x60
+sPrimeapeGfx31_2:
+.incbin "baserom.gba", 0x78057C, 0x60
+sPrimeapeGfx31_3:
+.incbin "baserom.gba", 0x7805DC, 0x60
+sPrimeapeSprites31:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx32:
+.incbin "baserom.gba", 0x78068C, 0x40
+sPrimeapeGfx32_1:
+.incbin "baserom.gba", 0x7806CC, 0x60
+sPrimeapeGfx32_2:
+.incbin "baserom.gba", 0x78072C, 0x60
+sPrimeapeGfx32_3:
+.incbin "baserom.gba", 0x78078C, 0x60
+sPrimeapeSprites32:
+ax_sprite sPrimeapeGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx33:
+.incbin "baserom.gba", 0x780834, 0x60
+sPrimeapeGfx33_1:
+.incbin "baserom.gba", 0x780894, 0x60
+sPrimeapeGfx33_2:
+.incbin "baserom.gba", 0x7808F4, 0x40
+sPrimeapeGfx33_3:
+.incbin "baserom.gba", 0x780934, 0x20
+sPrimeapeSprites33:
+ax_sprite sPrimeapeGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx33_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sPrimeapeGfx33_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx34:
+.incbin "baserom.gba", 0x78099C, 0x40
+sPrimeapeGfx34_1:
+.incbin "baserom.gba", 0x7809DC, 0x20
+sPrimeapeGfx34_2:
+.incbin "baserom.gba", 0x7809FC, 0x60
+sPrimeapeGfx34_3:
+.incbin "baserom.gba", 0x780A5C, 0x60
+sPrimeapeSprites34:
+ax_sprite sPrimeapeGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx34_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPrimeapeGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx35:
+.incbin "baserom.gba", 0x780B04, 0x60
+sPrimeapeGfx35_1:
+.incbin "baserom.gba", 0x780B64, 0x60
+sPrimeapeGfx35_2:
+.incbin "baserom.gba", 0x780BC4, 0x60
+sPrimeapeGfx35_3:
+.incbin "baserom.gba", 0x780C24, 0x20
+sPrimeapeSprites35:
+ax_sprite sPrimeapeGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx35_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPrimeapeGfx36:
+.incbin "baserom.gba", 0x780C8C, 0xE0
+sPrimeapeSprites36:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx36, 0xe0
+ax_sprite_terminator
+sPrimeapeGfx37:
+.incbin "baserom.gba", 0x780D84, 0x40
+sPrimeapeGfx37_1:
+.incbin "baserom.gba", 0x780DC4, 0x60
+sPrimeapeGfx37_2:
+.incbin "baserom.gba", 0x780E24, 0x60
+sPrimeapeGfx37_3:
+.incbin "baserom.gba", 0x780E84, 0x40
+sPrimeapeSprites37:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx37_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPrimeapeGfx38:
+.incbin "baserom.gba", 0x780F14, 0xC0
+sPrimeapeGfx38_1:
+.incbin "baserom.gba", 0x780FD4, 0x40
+sPrimeapeGfx38_2:
+.incbin "baserom.gba", 0x781014, 0x40
+sPrimeapeSprites38:
+ax_sprite sPrimeapeGfx38, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPrimeapeGfx39:
+.incbin "baserom.gba", 0x78108C, 0x140
+sPrimeapeGfx39_1:
+.incbin "baserom.gba", 0x7811CC, 0x40
+sPrimeapeSprites39:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx39, 0x140
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx40:
+.incbin "baserom.gba", 0x78123C, 0x60
+sPrimeapeGfx40_1:
+.incbin "baserom.gba", 0x78129C, 0xC0
+sPrimeapeSprites40:
+ax_sprite sPrimeapeGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx40_1, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sPrimeapeGfx41:
+.incbin "baserom.gba", 0x781384, 0x20
+sPrimeapeGfx41_1:
+.incbin "baserom.gba", 0x7813A4, 0x60
+sPrimeapeGfx41_2:
+.incbin "baserom.gba", 0x781404, 0x60
+sPrimeapeGfx41_3:
+.incbin "baserom.gba", 0x781464, 0x40
+sPrimeapeSprites41:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx41, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx41_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx41_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx42:
+.incbin "baserom.gba", 0x7814F4, 0x160
+sPrimeapeGfx42_1:
+.incbin "baserom.gba", 0x781654, 0x20
+sPrimeapeSprites42:
+ax_sprite sPrimeapeGfx42, 0x160
+ax_sprite 0, 0x60
+ax_sprite sPrimeapeGfx42_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPrimeapeGfx43:
+.incbin "baserom.gba", 0x78169C, 0x40
+sPrimeapeGfx43_1:
+.incbin "baserom.gba", 0x7816DC, 0x20
+sPrimeapeGfx43_2:
+.incbin "baserom.gba", 0x7816FC, 0x20
+sPrimeapeGfx43_3:
+.incbin "baserom.gba", 0x78171C, 0x20
+sPrimeapeSprites43:
+ax_sprite sPrimeapeGfx43, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx43_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx43_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx43_3, 0x20
+ax_sprite_terminator
+sPrimeapeGfx44:
+.incbin "baserom.gba", 0x78177C, 0x20
+sPrimeapeGfx44_1:
+.incbin "baserom.gba", 0x78179C, 0x20
+sPrimeapeGfx44_2:
+.incbin "baserom.gba", 0x7817BC, 0x80
+sPrimeapeSprites44:
+ax_sprite sPrimeapeGfx44, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx44_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx44_2, 0x80
+ax_sprite_terminator
+sPrimeapeGfx45:
+.incbin "baserom.gba", 0x78186C, 0x60
+sPrimeapeGfx45_1:
+.incbin "baserom.gba", 0x7818CC, 0x60
+sPrimeapeGfx45_2:
+.incbin "baserom.gba", 0x78192C, 0x40
+sPrimeapeGfx45_3:
+.incbin "baserom.gba", 0x78196C, 0x60
+sPrimeapeSprites45:
+ax_sprite sPrimeapeGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx45_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx45_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx45_3, 0x60
+ax_sprite_terminator
+sPrimeapeGfx46:
+.incbin "baserom.gba", 0x781A0C, 0x80
+sPrimeapeGfx46_1:
+.incbin "baserom.gba", 0x781A8C, 0x40
+sPrimeapeSprites46:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx46, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx46_1, 0x40
+ax_sprite_terminator
+sPrimeapeGfx47:
+.incbin "baserom.gba", 0x781AF4, 0x20
+sPrimeapeGfx47_1:
+.incbin "baserom.gba", 0x781B14, 0x40
+sPrimeapeGfx47_2:
+.incbin "baserom.gba", 0x781B54, 0x40
+sPrimeapeSprites47:
+ax_sprite 0, 0xc0
+ax_sprite sPrimeapeGfx47, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx47_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx47_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPrimeapeGfx48:
+.incbin "baserom.gba", 0x781BD4, 0x40
+sPrimeapeGfx48_1:
+.incbin "baserom.gba", 0x781C14, 0x40
+sPrimeapeGfx48_2:
+.incbin "baserom.gba", 0x781C54, 0x20
+sPrimeapeGfx48_3:
+.incbin "baserom.gba", 0x781C74, 0x40
+sPrimeapeSprites48:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx48_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPrimeapeGfx48_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPrimeapeGfx48_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPrimeapeGfx49:
+.incbin "baserom.gba", 0x781D04, 0xA0
+sPrimeapeSprites49:
+ax_sprite sPrimeapeGfx49, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sPrimeapeGfx50:
+.incbin "baserom.gba", 0x781DBC, 0x60
+sPrimeapeGfx50_1:
+.incbin "baserom.gba", 0x781E1C, 0xC0
+sPrimeapeSprites50:
+ax_sprite sPrimeapeGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx50_1, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sPrimeapeGfx51:
+.incbin "baserom.gba", 0x781F04, 0xC0
+sPrimeapeSprites51:
+ax_sprite sPrimeapeGfx51, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPrimeapeGfx52:
+.incbin "baserom.gba", 0x781FDC, 0x40
+sPrimeapeGfx52_1:
+.incbin "baserom.gba", 0x78201C, 0x20
+sPrimeapeGfx52_2:
+.incbin "baserom.gba", 0x78203C, 0x20
+sPrimeapeSprites52:
+ax_sprite sPrimeapeGfx52, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx52_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx52_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPrimeapeGfx53:
+.incbin "baserom.gba", 0x782094, 0x60
+sPrimeapeGfx53_1:
+.incbin "baserom.gba", 0x7820F4, 0x60
+sPrimeapeGfx53_2:
+.incbin "baserom.gba", 0x782154, 0x40
+sPrimeapeSprites53:
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx53_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPrimeapeGfx53_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPrimeapeGfx54:
+.incbin "baserom.gba", 0x7821D4, 0x200
+sPrimeapeSprites54:
+ax_sprite sPrimeapeGfx54, 0x200
+ax_sprite_terminator
+sPrimeapeGfx55:
+.incbin "baserom.gba", 0x7823E4, 0x200
+sPrimeapeSprites55:
+ax_sprite sPrimeapeGfx55, 0x200
+ax_sprite_terminator
+sPrimeapeGfx56:
+.incbin "baserom.gba", 0x7825F4, 0x200
+sPrimeapeSprites56:
+ax_sprite sPrimeapeGfx56, 0x200
+ax_sprite_terminator
+sPrimeapeGfx57:
+.incbin "baserom.gba", 0x782804, 0x200
+sPrimeapeSprites57:
+ax_sprite sPrimeapeGfx57, 0x200
+ax_sprite_terminator
+sPrimeapeGfx58:
+.incbin "baserom.gba", 0x782A14, 0x200
+sPrimeapeSprites58:
+ax_sprite sPrimeapeGfx58, 0x200
+ax_sprite_terminator
+sPrimeapeGfx59:
+.incbin "baserom.gba", 0x782C24, 0x200
+sPrimeapeSprites59:
+ax_sprite sPrimeapeGfx59, 0x200
+ax_sprite_terminator
+sPrimeapeGfx60:
+.incbin "baserom.gba", 0x782E34, 0x200
+sPrimeapeSprites60:
+ax_sprite sPrimeapeGfx60, 0x200
+ax_sprite_terminator
+sAxPosesPrimeape:
+.4byte sPrimeapePose1
+.4byte sPrimeapePose2
+.4byte sPrimeapePose3
+.4byte sPrimeapePose4
+.4byte sPrimeapePose5
+.4byte sPrimeapePose6
+.4byte sPrimeapePose7
+.4byte sPrimeapePose8
+.4byte sPrimeapePose9
+.4byte sPrimeapePose10
+.4byte sPrimeapePose11
+.4byte sPrimeapePose12
+.4byte sPrimeapePose13
+.4byte sPrimeapePose14
+.4byte sPrimeapePose15
+.4byte sPrimeapePose16
+.4byte sPrimeapePose17
+.4byte sPrimeapePose18
+.4byte sPrimeapePose19
+.4byte sPrimeapePose20
+.4byte sPrimeapePose21
+.4byte sPrimeapePose22
+.4byte sPrimeapePose23
+.4byte sPrimeapePose24
+.4byte sPrimeapePose25
+.4byte sPrimeapePose26
+.4byte sPrimeapePose27
+.4byte sPrimeapePose28
+.4byte sPrimeapePose29
+.4byte sPrimeapePose30
+.4byte sPrimeapePose31
+.4byte sPrimeapePose32
+.4byte sPrimeapePose33
+.4byte sPrimeapePose34
+.4byte sPrimeapePose35
+.4byte sPrimeapePose36
+.4byte sPrimeapePose37
+.4byte sPrimeapePose38
+.4byte sPrimeapePose39
+.4byte sPrimeapePose40
+.4byte sPrimeapePose41
+.4byte sPrimeapePose42
+.4byte sPrimeapePose43
+.4byte sPrimeapePose44
+.4byte sPrimeapePose45
+.4byte sPrimeapePose46
+.4byte sPrimeapePose47
+.4byte sPrimeapePose48
+.4byte sPrimeapePose49
+.4byte sPrimeapePose50
+.4byte sPrimeapePose51
+.4byte sPrimeapePose52
+.4byte sPrimeapePose53
+.4byte sPrimeapePose54
+.4byte sPrimeapePose55
+.4byte sPrimeapePose56
+.4byte sPrimeapePose57
+.4byte sPrimeapePose58
+.4byte sPrimeapePose59
+.4byte sPrimeapePose60
+.4byte sPrimeapePose61
+.4byte sPrimeapePose62
+.4byte sPrimeapePose63
+.4byte sPrimeapePose64
+.4byte sPrimeapePose65
+.4byte sPrimeapePose66
+.4byte sPrimeapePose67
+.4byte sPrimeapePose68
+.4byte sPrimeapePose69
+.4byte sPrimeapePose70
+.4byte sPrimeapePose71
+.4byte sPrimeapePose72
+.4byte sPrimeapePose73
+.4byte sPrimeapePose74
+.4byte sPrimeapePose75
+.4byte sPrimeapePose76
+.4byte sPrimeapePose77
+.4byte sPrimeapePose78
+.4byte sPrimeapePose79
+.4byte sPrimeapePose80
+.4byte sPrimeapePose81
+.4byte sPrimeapePose82
+.4byte sPrimeapePose83
+.4byte sPrimeapePose84
+.4byte sPrimeapePose85
+.4byte sPrimeapePose86
+.4byte sPrimeapePose87
+.4byte sPrimeapePose88
+.4byte sPrimeapePose89
+.4byte sPrimeapePose90
+.4byte sPrimeapePose91
+.4byte sPrimeapePose92
+.4byte sPrimeapePose93
+.4byte sPrimeapePose94
+.4byte sPrimeapePose95
+.4byte sPrimeapePose96
+.4byte sPrimeapePose97
+.4byte sPrimeapePose98
+.4byte sPrimeapePose99
+.4byte sPrimeapePose100
+.4byte sPrimeapePose101
+.4byte sPrimeapePose102
+.4byte sPrimeapePose103
+.4byte sPrimeapePose104
+.4byte sPrimeapePose105
+.4byte sPrimeapePose106
+.4byte sPrimeapePose107
+.4byte sPrimeapePose108
+.4byte sPrimeapePose109
+.4byte sPrimeapePose110
+.4byte sPrimeapePose111
+.4byte sPrimeapePose112
+.4byte sPrimeapePose113
+.4byte sPrimeapePose114
+.4byte sPrimeapePose115
+.4byte sPrimeapePose116
+.4byte sPrimeapePose117
+.4byte sPrimeapePose118
+.4byte sPrimeapePose119
+.4byte sPrimeapePose120
+.4byte sPrimeapePose121
+.4byte sPrimeapePose122
+.4byte sPrimeapePose123
+.4byte sPrimeapePose124
+.4byte sPrimeapePose125
+.4byte sPrimeapePose126
+.4byte sPrimeapePose127
+.4byte sPrimeapePose128
+.4byte sPrimeapePose129
+.4byte sPrimeapePose130
+.4byte sPrimeapePose131
+.4byte sPrimeapePose132
+.4byte sPrimeapePose133
+.4byte sPrimeapePose134
+.4byte sPrimeapePose135
+.4byte sPrimeapePose136
+.4byte sPrimeapePose137
+.4byte sPrimeapePose138
+.4byte sPrimeapePose139
+.4byte sPrimeapePose140
+.4byte sPrimeapePose141
+.4byte sPrimeapePose142
+.4byte sPrimeapePose143
+.4byte sPrimeapePose144
+.4byte sPrimeapePose145
+.4byte sPrimeapePose146
+.4byte sPrimeapePose147
+.4byte sPrimeapePose148
+.4byte sPrimeapePose149
+.4byte sPrimeapePose150
+.4byte sPrimeapePose151
+.4byte sPrimeapePose152
+.4byte sPrimeapePose153
+.4byte sPrimeapePose154
+.4byte sPrimeapePose155
+.4byte sPrimeapePose156
+.4byte sPrimeapePose157
+.4byte sPrimeapePose158
+.4byte sPrimeapePose159
+.4byte sPrimeapePose160
+.4byte sPrimeapePose161
+.4byte sPrimeapePose162
+.4byte sPrimeapePose163
+.4byte sPrimeapePose164
+.4byte sPrimeapePose165
+.4byte sPrimeapePose166
+.4byte sPrimeapePose167
+.4byte sPrimeapePose168
+.4byte sPrimeapePose169
+.4byte sPrimeapePose170
+.4byte sPrimeapePose171
+.4byte sPrimeapePose172
+.4byte sPrimeapePose173
+.4byte sPrimeapePose174
+.4byte sPrimeapePose175
+.4byte sPrimeapePose176
+.4byte sPrimeapePose177
+.4byte sPrimeapePose178
+.4byte sPrimeapePose179
+.4byte sPrimeapePose180
+.4byte sPrimeapePose181
+.4byte sPrimeapePose182
+.4byte sPrimeapePose183
+.4byte sPrimeapePose184
+.4byte sPrimeapePose185
+.4byte sPrimeapePose186
+.4byte sPrimeapePose187
+.4byte sPrimeapePose188
+.4byte sPrimeapePose189
+.4byte sPrimeapePose190
+.4byte sPrimeapePose191
+.4byte sPrimeapePose192
+.4byte sPrimeapePose193
+.4byte sPrimeapePose194
+.4byte sPrimeapePose195
+.4byte sPrimeapePose196
+.4byte sPrimeapePose197
+.4byte sPrimeapePose198
+.4byte sPrimeapePose199
+.4byte sPrimeapePose200
+.4byte sPrimeapePose201
+.4byte sPrimeapePose202
+.4byte sPrimeapePose203
+.4byte sPrimeapePose204
+.4byte sPrimeapePose205
+.4byte sPrimeapePose206
+.4byte sPrimeapePose207
+.4byte sPrimeapePose208
+.4byte sPrimeapePose209
+.4byte sPrimeapePose210
+.4byte sPrimeapePose211
+.4byte sPrimeapePose212
+.4byte sPrimeapePose213
+.4byte sPrimeapePose214
+.4byte sPrimeapePose215
+.4byte sPrimeapePose216
+.4byte sPrimeapePose217
+.4byte sPrimeapePose218
+.4byte sPrimeapePose219
+.4byte sPrimeapePose220
+.4byte sPrimeapePose221
+.4byte sPrimeapePose222
+.4byte sPrimeapePose223
+.4byte sPrimeapePose224
+.4byte sPrimeapePose225
+.4byte sPrimeapePose226
+.4byte sPrimeapePose227
+.4byte sPrimeapePose228
+.4byte sPrimeapePose229
+.4byte sPrimeapePose230
+.4byte sPrimeapePose231
+.4byte sPrimeapePose232
+.4byte sPrimeapePose233
+.4byte sPrimeapePose234
+.4byte sPrimeapePose235
+.4byte sPrimeapePose236
+.4byte sPrimeapePose237
+.4byte sPrimeapePose238
+.4byte sPrimeapePose239
+.4byte sPrimeapePose240
+.4byte sPrimeapePose241
+.4byte sPrimeapePose242
+.4byte sPrimeapePose243
+.4byte sPrimeapePose244
+.4byte sPrimeapePose245
+.4byte sPrimeapePose246
+.4byte sPrimeapePose247
+.4byte sPrimeapePose248
+.4byte sPrimeapePose249
+.4byte sPrimeapePose250
+sAxPositionsPrimeape:
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte    0,   -4, 	 -12,  -18, 	   9,   -9, 	  -1,   -8
+.2byte   -2,   -5, 	 -12,  -11, 	  11,  -16, 	  -1,   -9
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte    0,   -3, 	 -12,  -14, 	  10,  -10, 	  -1,   -8
+.2byte    2,   -4, 	  -6,   -7, 	   4,  -18, 	   0,   -8
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    5,   -6, 	  -2,  -11, 	   4,  -14, 	   0,   -8
+.2byte    5,   -6, 	   3,   -7, 	   2,  -19, 	   0,   -8
+.2byte    3,   -9, 	  10,  -16, 	  -6,  -17, 	   0,  -10
+.2byte    2,   -8, 	  11,  -16, 	  -6,  -13, 	   0,   -9
+.2byte    3,   -6, 	  11,   -8, 	  -4,  -19, 	   0,   -8
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte   -1,  -10, 	  10,  -16, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -10, 	   8,  -12, 	 -12,  -15, 	  -1,   -9
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -3,   -7, 	   5,  -20, 	 -13,  -10, 	   0,   -8
+.2byte   -3,   -8, 	   1,  -13, 	 -11,  -12, 	   0,   -8
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -6,   -5, 	  -1,  -21, 	  -2,   -5, 	   0,   -8
+.2byte   -6,   -6, 	  -6,  -16, 	   2,   -8, 	   0,   -8
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -2,   -3, 	 -10,  -19, 	   8,   -8, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -13, 	  10,  -13, 	   0,   -7
+.2byte    2,   -5, 	   2,   -1, 	   8,  -19, 	   1,  -10
+.2byte    0,   -4, 	 -12,  -18, 	   9,   -9, 	  -1,   -8
+.2byte   -2,   -5, 	 -12,  -11, 	  11,  -16, 	  -1,   -9
+.2byte   -1,   -4, 	   2,    0, 	  -9,  -17, 	  -2,  -10
+.2byte    0,   -3, 	 -12,  -14, 	  10,  -10, 	  -1,   -8
+.2byte    2,   -4, 	  -6,   -7, 	   4,  -18, 	   0,   -8
+.2byte    3,   -5, 	   7,   -1, 	  -7,  -12, 	  -1,   -9
+.2byte    5,   -6, 	  -2,  -11, 	   4,  -14, 	   0,   -8
+.2byte    5,   -6, 	   3,   -7, 	   2,  -19, 	   0,   -8
+.2byte    2,   -8, 	  -9,  -16, 	   5,   -8, 	   0,   -9
+.2byte    2,   -8, 	  11,  -16, 	  -6,  -13, 	   0,   -9
+.2byte    3,   -6, 	  11,   -8, 	  -4,  -19, 	   0,   -8
+.2byte   -2,   -7, 	  -3,   -7, 	  -8,  -14, 	  -1,  -10
+.2byte   -1,  -10, 	  10,  -16, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -10, 	   8,  -12, 	 -12,  -15, 	  -1,   -9
+.2byte   -2,   -8, 	   9,  -16, 	  -5,   -8, 	   0,   -9
+.2byte   -3,   -7, 	   5,  -20, 	 -13,  -10, 	   0,   -8
+.2byte   -3,   -8, 	   1,  -13, 	 -11,  -12, 	   0,   -8
+.2byte   -8,   -6, 	   3,  -20, 	 -11,   -3, 	  -1,  -11
+.2byte   -6,   -5, 	  -1,  -21, 	  -2,   -5, 	   0,   -8
+.2byte   -6,   -6, 	  -6,  -16, 	   2,   -8, 	   0,   -8
+.2byte   -4,   -4, 	  -5,  -21, 	  -5,    0, 	   0,  -10
+.2byte   -2,   -3, 	 -10,  -19, 	   8,   -8, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -13, 	  10,  -13, 	   0,   -7
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte    0,   -4, 	 -12,  -18, 	   9,   -9, 	  -1,   -8
+.2byte   -2,   -5, 	 -12,  -11, 	  11,  -16, 	  -1,   -9
+.2byte   -3,   -9, 	  -8,  -21, 	   2,   -6, 	  -2,  -11
+.2byte    2,   -5, 	   2,   -1, 	   8,  -19, 	   1,  -10
+.2byte    2,   -5, 	   2,   -1, 	   8,  -19, 	   1,  -10
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte    0,   -3, 	 -12,  -14, 	  10,  -10, 	  -1,   -8
+.2byte    2,   -4, 	  -6,   -7, 	   4,  -18, 	   0,   -8
+.2byte    2,   -8, 	   0,  -23, 	   0,   -4, 	  -1,  -10
+.2byte   -2,   -3, 	   1,    1, 	 -10,  -16, 	  -3,   -9
+.2byte   -2,   -3, 	   1,    1, 	 -10,  -16, 	  -3,   -9
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    5,   -6, 	  -2,  -11, 	   4,  -14, 	   0,   -8
+.2byte    5,   -6, 	   3,   -7, 	   2,  -19, 	   0,   -8
+.2byte    4,  -10, 	  -5,  -22, 	   5,   -7, 	  -2,  -11
+.2byte    3,   -5, 	   7,   -1, 	  -7,  -12, 	  -1,   -9
+.2byte    3,   -5, 	   7,   -1, 	  -7,  -12, 	  -1,   -9
+.2byte    3,   -9, 	  10,  -16, 	  -6,  -17, 	   0,  -10
+.2byte    2,   -8, 	  11,  -16, 	  -6,  -13, 	   0,   -9
+.2byte    3,   -6, 	  11,   -8, 	  -4,  -19, 	   0,   -8
+.2byte    2,  -11, 	  -9,  -18, 	  11,  -14, 	  -1,  -11
+.2byte    4,   -8, 	   6,   -8, 	   3,  -16, 	   1,  -10
+.2byte    4,   -8, 	   6,   -8, 	   3,  -16, 	   1,  -10
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte   -1,  -10, 	  10,  -16, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -10, 	   8,  -12, 	 -12,  -15, 	  -1,   -9
+.2byte    0,  -10, 	   8,  -12, 	  -5,  -14, 	  -1,   -9
+.2byte   -2,   -8, 	  -3,   -8, 	  -8,  -15, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -8, 	  -8,  -15, 	  -1,  -11
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -3,   -7, 	   5,  -20, 	 -13,  -10, 	   0,   -8
+.2byte   -3,   -8, 	   1,  -13, 	 -11,  -12, 	   0,   -8
+.2byte   -3,  -11, 	   8,  -18, 	 -12,  -14, 	   0,  -11
+.2byte   -5,   -8, 	  -7,   -8, 	  -4,  -16, 	  -2,  -10
+.2byte   -5,   -8, 	  -7,   -8, 	  -4,  -16, 	  -2,  -10
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -6,   -5, 	  -1,  -21, 	  -2,   -5, 	   0,   -8
+.2byte   -6,   -6, 	  -6,  -16, 	   2,   -8, 	   0,   -8
+.2byte   -5,  -10, 	   4,  -22, 	  -6,   -7, 	   1,  -11
+.2byte   -4,   -5, 	  -8,   -1, 	   6,  -12, 	   0,   -9
+.2byte   -4,   -5, 	  -8,   -1, 	   6,  -12, 	   0,   -9
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -2,   -3, 	 -10,  -19, 	   8,   -8, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -13, 	  10,  -13, 	   0,   -7
+.2byte   -4,   -8, 	  -2,  -23, 	  -2,   -4, 	  -1,  -10
+.2byte    0,   -3, 	  -3,    1, 	   8,  -16, 	   1,   -9
+.2byte    0,   -3, 	  -3,    1, 	   8,  -16, 	   1,   -9
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte    2,   -9, 	   9,  -16, 	  -7,  -17, 	  -1,  -10
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte    0,   -4, 	 -12,  -18, 	   9,   -9, 	  -1,   -8
+.2byte   -2,   -5, 	 -12,  -11, 	  11,  -16, 	  -1,   -9
+.2byte    2,   -5, 	   2,   -1, 	   8,  -19, 	   1,  -10
+.2byte    2,   -5, 	   2,   -1, 	   8,  -19, 	   1,  -10
+.2byte   -3,   -5, 	  -9,  -19, 	  -2,   -1, 	  -1,  -11
+.2byte   -3,   -5, 	  -9,  -19, 	  -2,   -1, 	  -1,  -11
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte    0,   -3, 	 -12,  -14, 	  10,  -10, 	  -1,   -8
+.2byte    2,   -4, 	  -6,   -7, 	   4,  -18, 	   0,   -8
+.2byte   -2,   -3, 	   1,    1, 	 -10,  -16, 	  -3,   -9
+.2byte   -2,   -3, 	   1,    1, 	 -10,  -16, 	  -3,   -9
+.2byte    2,   -4, 	   3,  -21, 	   3,    0, 	  -2,  -10
+.2byte    2,   -4, 	   3,  -21, 	   3,    0, 	  -2,  -10
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    5,   -6, 	  -2,  -11, 	   4,  -14, 	   0,   -8
+.2byte    5,   -6, 	   3,   -7, 	   2,  -19, 	   0,   -8
+.2byte    3,   -5, 	   7,   -1, 	  -7,  -12, 	  -1,   -9
+.2byte    3,   -5, 	   7,   -1, 	  -7,  -12, 	  -1,   -9
+.2byte    5,   -6, 	  -6,  -20, 	   8,   -3, 	  -2,  -11
+.2byte    5,   -6, 	  -6,  -20, 	   8,   -3, 	  -2,  -11
+.2byte    3,   -9, 	  10,  -16, 	  -6,  -17, 	   0,  -10
+.2byte    2,   -8, 	  11,  -16, 	  -6,  -13, 	   0,   -9
+.2byte    3,   -6, 	  11,   -8, 	  -4,  -19, 	   0,   -8
+.2byte    4,   -8, 	   6,   -8, 	   3,  -16, 	   1,  -10
+.2byte    4,   -8, 	   6,   -8, 	   3,  -16, 	   1,  -10
+.2byte    3,   -9, 	  -8,  -17, 	   6,   -9, 	   1,  -10
+.2byte    3,   -9, 	  -8,  -17, 	   6,   -9, 	   1,  -10
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte   -1,  -10, 	  10,  -16, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -10, 	   8,  -12, 	 -12,  -15, 	  -1,   -9
+.2byte   -2,   -8, 	  -3,   -8, 	  -8,  -15, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -8, 	  -8,  -15, 	  -1,  -11
+.2byte    1,   -8, 	   7,  -15, 	   2,   -8, 	   0,  -11
+.2byte    1,   -8, 	   7,  -15, 	   2,   -8, 	   0,  -11
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -3,   -7, 	   5,  -20, 	 -13,  -10, 	   0,   -8
+.2byte   -3,   -8, 	   1,  -13, 	 -11,  -12, 	   0,   -8
+.2byte   -5,   -8, 	  -7,   -8, 	  -4,  -16, 	  -2,  -10
+.2byte   -5,   -8, 	  -7,   -8, 	  -4,  -16, 	  -2,  -10
+.2byte   -4,   -9, 	   7,  -17, 	  -7,   -9, 	  -2,  -10
+.2byte   -4,   -9, 	   7,  -17, 	  -7,   -9, 	  -2,  -10
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -6,   -5, 	  -1,  -21, 	  -2,   -5, 	   0,   -8
+.2byte   -6,   -6, 	  -6,  -16, 	   2,   -8, 	   0,   -8
+.2byte   -4,   -5, 	  -8,   -1, 	   6,  -12, 	   0,   -9
+.2byte   -4,   -5, 	  -8,   -1, 	   6,  -12, 	   0,   -9
+.2byte   -6,   -6, 	   5,  -20, 	  -9,   -3, 	   1,  -11
+.2byte   -6,   -6, 	   5,  -20, 	  -9,   -3, 	   1,  -11
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -2,   -3, 	 -10,  -19, 	   8,   -8, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -13, 	  10,  -13, 	   0,   -7
+.2byte    0,   -3, 	  -3,    1, 	   8,  -16, 	   1,   -9
+.2byte    0,   -3, 	  -3,    1, 	   8,  -16, 	   1,   -9
+.2byte   -4,   -4, 	  -5,  -21, 	  -5,    0, 	   0,  -10
+.2byte   -4,   -4, 	  -5,  -21, 	  -5,    0, 	   0,  -10
+.2byte   -2,   -4, 	  -8,   -3, 	   5,    1, 	   0,   -7
+.2byte   -2,   -3, 	  -8,   -3, 	   5,    2, 	   0,   -7
+.2byte    0,   -6, 	  -9,  -17, 	  15,   -7, 	   0,   -7
+.2byte    1,   -7, 	   3,  -21, 	 -16,   -4, 	  -2,   -6
+.2byte    3,  -10, 	   0,  -18, 	  -4,   -1, 	  -2,   -7
+.2byte   -1,  -10, 	  -8,  -15, 	   6,    1, 	  -1,   -5
+.2byte    0,   -8, 	  10,  -11, 	 -14,   -4, 	   0,   -5
+.2byte    0,  -10, 	   7,  -15, 	  -7,    1, 	   0,   -5
+.2byte   -4,  -10, 	  -1,  -18, 	   3,   -1, 	   1,   -7
+.2byte   -2,   -7, 	  -4,  -21, 	  15,   -4, 	   1,   -6
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte    0,   -4, 	 -12,  -18, 	   9,   -9, 	  -1,   -8
+.2byte   -2,   -5, 	 -12,  -11, 	  11,  -16, 	  -1,   -9
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte    0,   -3, 	 -12,  -14, 	  10,  -10, 	  -1,   -8
+.2byte    2,   -4, 	  -6,   -7, 	   4,  -18, 	   0,   -8
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    5,   -6, 	  -2,  -11, 	   4,  -14, 	   0,   -8
+.2byte    5,   -6, 	   3,   -7, 	   2,  -19, 	   0,   -8
+.2byte    3,   -9, 	  10,  -16, 	  -6,  -17, 	   0,  -10
+.2byte    2,   -8, 	  11,  -16, 	  -6,  -13, 	   0,   -9
+.2byte    3,   -6, 	  11,   -8, 	  -4,  -19, 	   0,   -8
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte   -1,  -10, 	  10,  -16, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -10, 	   8,  -12, 	 -12,  -15, 	  -1,   -9
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -3,   -7, 	   5,  -20, 	 -13,  -10, 	   0,   -8
+.2byte   -3,   -8, 	   1,  -13, 	 -11,  -12, 	   0,   -8
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -6,   -5, 	  -1,  -21, 	  -2,   -5, 	   0,   -8
+.2byte   -6,   -6, 	  -6,  -16, 	   2,   -8, 	   0,   -8
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -2,   -3, 	 -10,  -19, 	   8,   -8, 	   0,   -7
+.2byte   -4,   -4, 	 -10,  -13, 	  10,  -13, 	   0,   -7
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte    2,   -9, 	   9,  -16, 	  -7,  -17, 	  -1,  -10
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte    2,   -5, 	   2,   -1, 	   8,  -19, 	   1,  -10
+.2byte    0,   -3, 	   3,    1, 	  -8,  -16, 	  -1,   -9
+.2byte    3,   -5, 	   7,   -1, 	  -7,  -12, 	  -1,   -9
+.2byte    2,   -8, 	   4,   -8, 	   1,  -16, 	  -1,  -10
+.2byte   -2,   -8, 	  -3,   -8, 	  -8,  -15, 	  -1,  -11
+.2byte   -4,   -8, 	  -6,   -8, 	  -3,  -16, 	  -1,  -10
+.2byte   -4,   -5, 	  -8,   -1, 	   6,  -12, 	   0,   -9
+.2byte    0,   -3, 	  -3,    1, 	   8,  -16, 	   1,   -9
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte   -2,   -5, 	 -12,  -11, 	  11,  -16, 	  -1,   -9
+.2byte    2,   -5, 	   2,   -1, 	   8,  -19, 	   1,  -10
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte    2,   -4, 	  -6,   -7, 	   4,  -18, 	   0,   -8
+.2byte    0,   -3, 	   3,    1, 	  -8,  -16, 	  -1,   -9
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    5,   -6, 	   3,   -7, 	   2,  -19, 	   0,   -8
+.2byte    3,   -5, 	   7,   -1, 	  -7,  -12, 	  -1,   -9
+.2byte    3,   -9, 	  10,  -16, 	  -6,  -17, 	   0,  -10
+.2byte    3,   -6, 	  11,   -8, 	  -4,  -19, 	   0,   -8
+.2byte    4,   -8, 	   6,   -8, 	   3,  -16, 	   1,  -10
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte    0,  -10, 	   8,  -12, 	 -12,  -15, 	  -1,   -9
+.2byte   -2,   -8, 	  -3,   -8, 	  -8,  -15, 	  -1,  -11
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -3,   -8, 	   1,  -13, 	 -11,  -12, 	   0,   -8
+.2byte   -5,   -8, 	  -7,   -8, 	  -4,  -16, 	  -2,  -10
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -6,   -6, 	  -6,  -16, 	   2,   -8, 	   0,   -8
+.2byte   -4,   -5, 	  -8,   -1, 	   6,  -12, 	   0,   -9
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -4,   -4, 	 -10,  -13, 	  10,  -13, 	   0,   -7
+.2byte   -1,   -3, 	  -4,    1, 	   7,  -16, 	   0,   -9
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte    2,   -9, 	   9,  -16, 	  -7,  -17, 	  -1,  -10
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+.2byte   -1,   -6, 	 -11,  -18, 	  11,  -13, 	  -1,  -10
+.2byte   -3,   -6, 	  -8,  -20, 	   9,  -11, 	   0,   -9
+.2byte   -6,   -7, 	  -2,  -21, 	   0,   -8, 	   0,  -10
+.2byte   -4,  -10, 	   4,  -20, 	 -11,  -11, 	  -1,  -10
+.2byte   -1,  -12, 	   9,  -18, 	 -13,  -13, 	  -1,  -11
+.2byte    2,   -9, 	   9,  -16, 	  -7,  -17, 	  -1,  -10
+.2byte    5,   -8, 	  -1,  -11, 	   1,  -18, 	  -1,  -10
+.2byte    1,   -6, 	 -11,  -14, 	   7,  -16, 	  -2,  -10
+sPrimeapeAnimTable1:
+.4byte sPrimeapeAnims_1_1
+.4byte sPrimeapeAnims_1_2
+.4byte sPrimeapeAnims_1_3
+.4byte sPrimeapeAnims_1_4
+.4byte sPrimeapeAnims_1_5
+.4byte sPrimeapeAnims_1_6
+.4byte sPrimeapeAnims_1_7
+.4byte sPrimeapeAnims_1_8
+sPrimeapeAnimTable2:
+.4byte sPrimeapeAnims_2_1
+.4byte sPrimeapeAnims_2_2
+.4byte sPrimeapeAnims_2_3
+.4byte sPrimeapeAnims_2_4
+.4byte sPrimeapeAnims_2_5
+.4byte sPrimeapeAnims_2_6
+.4byte sPrimeapeAnims_2_7
+.4byte sPrimeapeAnims_2_8
+sPrimeapeAnimTable3:
+.4byte sPrimeapeAnims_3_1
+.4byte sPrimeapeAnims_3_2
+.4byte sPrimeapeAnims_3_3
+.4byte sPrimeapeAnims_3_4
+.4byte sPrimeapeAnims_3_5
+.4byte sPrimeapeAnims_3_6
+.4byte sPrimeapeAnims_3_7
+.4byte sPrimeapeAnims_3_8
+sPrimeapeAnimTable4:
+.4byte sPrimeapeAnims_4_1
+.4byte sPrimeapeAnims_4_2
+.4byte sPrimeapeAnims_4_3
+.4byte sPrimeapeAnims_4_4
+.4byte sPrimeapeAnims_4_5
+.4byte sPrimeapeAnims_4_6
+.4byte sPrimeapeAnims_4_7
+.4byte sPrimeapeAnims_4_8
+sPrimeapeAnimTable5:
+.4byte sPrimeapeAnims_5_1
+.4byte sPrimeapeAnims_5_2
+.4byte sPrimeapeAnims_5_3
+.4byte sPrimeapeAnims_5_4
+.4byte sPrimeapeAnims_5_5
+.4byte sPrimeapeAnims_5_6
+.4byte sPrimeapeAnims_5_7
+.4byte sPrimeapeAnims_5_8
+sPrimeapeAnimTable6:
+.4byte sPrimeapeAnims_6_1
+.4byte sPrimeapeAnims_6_1
+.4byte sPrimeapeAnims_6_1
+.4byte sPrimeapeAnims_6_1
+.4byte sPrimeapeAnims_6_1
+.4byte sPrimeapeAnims_6_1
+.4byte sPrimeapeAnims_6_1
+.4byte sPrimeapeAnims_6_1
+sPrimeapeAnimTable7:
+.4byte sPrimeapeAnims_7_1
+.4byte sPrimeapeAnims_7_2
+.4byte sPrimeapeAnims_7_3
+.4byte sPrimeapeAnims_7_4
+.4byte sPrimeapeAnims_7_5
+.4byte sPrimeapeAnims_7_6
+.4byte sPrimeapeAnims_7_7
+.4byte sPrimeapeAnims_7_8
+sPrimeapeAnimTable8:
+.4byte sPrimeapeAnims_8_1
+.4byte sPrimeapeAnims_8_2
+.4byte sPrimeapeAnims_8_3
+.4byte sPrimeapeAnims_8_4
+.4byte sPrimeapeAnims_8_5
+.4byte sPrimeapeAnims_8_6
+.4byte sPrimeapeAnims_8_7
+.4byte sPrimeapeAnims_8_8
+sPrimeapeAnimTable9:
+.4byte sPrimeapeAnims_9_1
+.4byte sPrimeapeAnims_9_2
+.4byte sPrimeapeAnims_9_3
+.4byte sPrimeapeAnims_9_4
+.4byte sPrimeapeAnims_9_5
+.4byte sPrimeapeAnims_9_6
+.4byte sPrimeapeAnims_9_7
+.4byte sPrimeapeAnims_9_8
+sPrimeapeAnimTable10:
+.4byte sPrimeapeAnims_10_1
+.4byte sPrimeapeAnims_10_2
+.4byte sPrimeapeAnims_10_3
+.4byte sPrimeapeAnims_10_4
+.4byte sPrimeapeAnims_10_5
+.4byte sPrimeapeAnims_10_6
+.4byte sPrimeapeAnims_10_7
+.4byte sPrimeapeAnims_10_8
+sPrimeapeAnimTable11:
+.4byte sPrimeapeAnims_11_1
+.4byte sPrimeapeAnims_11_2
+.4byte sPrimeapeAnims_11_3
+.4byte sPrimeapeAnims_11_4
+.4byte sPrimeapeAnims_11_5
+.4byte sPrimeapeAnims_11_6
+.4byte sPrimeapeAnims_11_7
+.4byte sPrimeapeAnims_11_8
+sPrimeapeAnimTable12:
+.4byte sPrimeapeAnims_12_1
+.4byte sPrimeapeAnims_12_2
+.4byte sPrimeapeAnims_12_3
+.4byte sPrimeapeAnims_12_4
+.4byte sPrimeapeAnims_12_5
+.4byte sPrimeapeAnims_12_6
+.4byte sPrimeapeAnims_12_7
+.4byte sPrimeapeAnims_12_8
+sPrimeapeAnimTable13:
+.4byte sPrimeapeAnims_13_1
+.4byte sPrimeapeAnims_13_2
+.4byte sPrimeapeAnims_13_3
+.4byte sPrimeapeAnims_13_4
+.4byte sPrimeapeAnims_13_5
+.4byte sPrimeapeAnims_13_6
+.4byte sPrimeapeAnims_13_7
+.4byte sPrimeapeAnims_13_8
+sAxAnimationsPrimeape:
+.4byte sPrimeapeAnimTable1
+.4byte sPrimeapeAnimTable2
+.4byte sPrimeapeAnimTable3
+.4byte sPrimeapeAnimTable4
+.4byte sPrimeapeAnimTable5
+.4byte sPrimeapeAnimTable6
+.4byte sPrimeapeAnimTable7
+.4byte sPrimeapeAnimTable8
+.4byte sPrimeapeAnimTable9
+.4byte sPrimeapeAnimTable10
+.4byte sPrimeapeAnimTable11
+.4byte sPrimeapeAnimTable12
+.4byte sPrimeapeAnimTable13
+sAxSpritesPrimeape:
+.4byte sPrimeapeSprites1
+.4byte sPrimeapeSprites2
+.4byte sPrimeapeSprites3
+.4byte sPrimeapeSprites4
+.4byte sPrimeapeSprites5
+.4byte sPrimeapeSprites6
+.4byte sPrimeapeSprites7
+.4byte sPrimeapeSprites8
+.4byte sPrimeapeSprites9
+.4byte sPrimeapeSprites10
+.4byte sPrimeapeSprites11
+.4byte sPrimeapeSprites12
+.4byte sPrimeapeSprites13
+.4byte sPrimeapeSprites14
+.4byte sPrimeapeSprites15
+.4byte sPrimeapeSprites16
+.4byte sPrimeapeSprites17
+.4byte sPrimeapeSprites18
+.4byte sPrimeapeSprites19
+.4byte sPrimeapeSprites20
+.4byte sPrimeapeSprites21
+.4byte sPrimeapeSprites22
+.4byte sPrimeapeSprites23
+.4byte sPrimeapeSprites24
+.4byte sPrimeapeSprites25
+.4byte sPrimeapeSprites26
+.4byte sPrimeapeSprites27
+.4byte sPrimeapeSprites28
+.4byte sPrimeapeSprites29
+.4byte sPrimeapeSprites30
+.4byte sPrimeapeSprites31
+.4byte sPrimeapeSprites32
+.4byte sPrimeapeSprites33
+.4byte sPrimeapeSprites34
+.4byte sPrimeapeSprites35
+.4byte sPrimeapeSprites36
+.4byte sPrimeapeSprites37
+.4byte sPrimeapeSprites38
+.4byte sPrimeapeSprites39
+.4byte sPrimeapeSprites40
+.4byte sPrimeapeSprites41
+.4byte sPrimeapeSprites42
+.4byte sPrimeapeSprites43
+.4byte sPrimeapeSprites44
+.4byte sPrimeapeSprites45
+.4byte sPrimeapeSprites46
+.4byte sPrimeapeSprites47
+.4byte sPrimeapeSprites48
+.4byte sPrimeapeSprites49
+.4byte sPrimeapeSprites50
+.4byte sPrimeapeSprites51
+.4byte sPrimeapeSprites52
+.4byte sPrimeapeSprites53
+.4byte sPrimeapeSprites54
+.4byte sPrimeapeSprites55
+.4byte sPrimeapeSprites56
+.4byte sPrimeapeSprites57
+.4byte sPrimeapeSprites58
+.4byte sPrimeapeSprites59
+.4byte sPrimeapeSprites60
+sAxMainPrimeape:
+ax_main sAxPosesPrimeape, sAxAnimationsPrimeape, 13, sAxSpritesPrimeape, sAxPositionsPrimeape

--- a/data/ax/psyduck.inc
+++ b/data/ax/psyduck.inc
@@ -1,0 +1,4394 @@
+.global gAxPsyduck
+gAxPsyduck:
+ax_siro sAxMainPsyduck
+sPsyduckPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose4:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose5:
+ax_pose 4, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose6:
+ax_pose 5, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose8:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose10:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose12:
+ax_pose 11, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose16:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose17:
+ax_pose 10, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose18:
+ax_pose 11, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose22:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose23:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose24:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose28:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose29:
+ax_pose 16, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose30:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose31:
+ax_pose 4, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose32:
+ax_pose 5, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose33:
+ax_pose 17, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose34:
+ax_pose 18, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose35:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose36:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose37:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose38:
+ax_pose 19, 0x01ea, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose39:
+ax_pose 20, 0x01ea, 0x90f1, 0x4c00
+ax_pose_terminator
+sPsyduckPose40:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose41:
+ax_pose 10, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose42:
+ax_pose 11, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose43:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose44:
+ax_pose 22, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose45:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose46:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose47:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose48:
+ax_pose 23, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose49:
+ax_pose 24, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose50:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose51:
+ax_pose 10, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose52:
+ax_pose 11, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose53:
+ax_pose 21, 0x01eb, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose54:
+ax_pose 22, 0x01eb, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose55:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose56:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose57:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose58:
+ax_pose 19, 0x01ea, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose59:
+ax_pose 20, 0x01ea, 0x80ee, 0x4c00
+ax_pose_terminator
+sPsyduckPose60:
+ax_pose 3, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPsyduckPose61:
+ax_pose 4, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPsyduckPose62:
+ax_pose 5, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPsyduckPose63:
+ax_pose 17, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose64:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose65:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose66:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose67:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose68:
+ax_pose 25, 0x81ea, 0x80fd, 0x4c00
+ax_pose 26, 0x01ea, 0x80f4, 0x4c08
+ax_pose_terminator
+sPsyduckPose69:
+ax_pose 26, 0x01ea, 0x80f5, 0x4c00
+ax_pose_terminator
+sPsyduckPose70:
+ax_pose 25, 0x81ea, 0x90f2, 0x4c00
+ax_pose 27, 0x01ea, 0x80f4, 0x4c08
+ax_pose_terminator
+sPsyduckPose71:
+ax_pose 27, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose72:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose73:
+ax_pose 4, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose74:
+ax_pose 5, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose75:
+ax_pose 28, 0x81e7, 0x90f4, 0x4c00
+ax_pose 29, 0x01e7, 0x90eb, 0x4c08
+ax_pose_terminator
+sPsyduckPose76:
+ax_pose 29, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose77:
+ax_pose 30, 0x81e7, 0x5103, 0x4c00
+ax_pose 31, 0x01e7, 0x90eb, 0x4c04
+ax_pose_terminator
+sPsyduckPose78:
+ax_pose 31, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose79:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose80:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose81:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose82:
+ax_pose 32, 0x01eb, 0x90eb, 0x4c00
+ax_pose 33, 0x01eb, 0x90eb, 0x4c10
+ax_pose_terminator
+sPsyduckPose83:
+ax_pose 33, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose84:
+ax_pose 34, 0x81eb, 0x5103, 0x4c00
+ax_pose 35, 0x01eb, 0x90eb, 0x4c04
+ax_pose_terminator
+sPsyduckPose85:
+ax_pose 35, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose86:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose87:
+ax_pose 10, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose88:
+ax_pose 11, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose89:
+ax_pose 36, 0x81ec, 0x90fd, 0x4c00
+ax_pose 37, 0x01ec, 0x90ed, 0x4c08
+ax_pose_terminator
+sPsyduckPose90:
+ax_pose 37, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose91:
+ax_pose 38, 0x01ec, 0x90ed, 0x4c00
+ax_pose 39, 0x01ec, 0x90ed, 0x4c10
+ax_pose_terminator
+sPsyduckPose92:
+ax_pose 39, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose93:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose94:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose95:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose96:
+ax_pose 40, 0x81eb, 0x00f4, 0x4c00
+ax_pose 41, 0x01eb, 0x80f4, 0x4c02
+ax_pose_terminator
+sPsyduckPose97:
+ax_pose 41, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose98:
+ax_pose 40, 0x81eb, 0x1103, 0x4c00
+ax_pose 42, 0x01eb, 0x80f4, 0x4c02
+ax_pose_terminator
+sPsyduckPose99:
+ax_pose 42, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose100:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose101:
+ax_pose 10, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose102:
+ax_pose 11, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose103:
+ax_pose 36, 0x81ec, 0x80f2, 0x4c00
+ax_pose 37, 0x01ec, 0x80f2, 0x4c08
+ax_pose_terminator
+sPsyduckPose104:
+ax_pose 37, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose105:
+ax_pose 38, 0x01ec, 0x80f2, 0x4c00
+ax_pose 39, 0x01ec, 0x80f2, 0x4c10
+ax_pose_terminator
+sPsyduckPose106:
+ax_pose 39, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose107:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose108:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose109:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose110:
+ax_pose 32, 0x01eb, 0x80f4, 0x4c00
+ax_pose 33, 0x01eb, 0x80f4, 0x4c10
+ax_pose_terminator
+sPsyduckPose111:
+ax_pose 33, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose112:
+ax_pose 34, 0x81eb, 0x40f4, 0x4c00
+ax_pose 35, 0x01eb, 0x80f4, 0x4c04
+ax_pose_terminator
+sPsyduckPose113:
+ax_pose 35, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose114:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose115:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose116:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose117:
+ax_pose 28, 0x81e7, 0x80f8, 0x4c00
+ax_pose 29, 0x01e7, 0x80f4, 0x4c08
+ax_pose_terminator
+sPsyduckPose118:
+ax_pose 29, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose119:
+ax_pose 30, 0x81e7, 0x40f4, 0x4c00
+ax_pose 31, 0x01e7, 0x80f4, 0x4c04
+ax_pose_terminator
+sPsyduckPose120:
+ax_pose 31, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose121:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose122:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose123:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose124:
+ax_pose 43, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose125:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose126:
+ax_pose 4, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose127:
+ax_pose 5, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose128:
+ax_pose 44, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose129:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose130:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose131:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose132:
+ax_pose 45, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose133:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose134:
+ax_pose 10, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose135:
+ax_pose 11, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose136:
+ax_pose 46, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose137:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose138:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose139:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose140:
+ax_pose 47, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose141:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose142:
+ax_pose 10, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose143:
+ax_pose 11, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose144:
+ax_pose 46, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose145:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose146:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose147:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose148:
+ax_pose 45, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose149:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose150:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose151:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose152:
+ax_pose 44, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose153:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose154:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose155:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose156:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose157:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose158:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose159:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose160:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose161:
+ax_pose 48, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sPsyduckPose162:
+ax_pose 49, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sPsyduckPose163:
+ax_pose 50, 0x01e2, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose164:
+ax_pose 51, 0x01e7, 0x90f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose165:
+ax_pose 52, 0x01e4, 0x90ea, 0x4c00
+ax_pose_terminator
+sPsyduckPose166:
+ax_pose 53, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sPsyduckPose167:
+ax_pose 54, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose168:
+ax_pose 53, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose169:
+ax_pose 52, 0x01e4, 0x80f6, 0x4c00
+ax_pose_terminator
+sPsyduckPose170:
+ax_pose 51, 0x01e7, 0x80ee, 0x4c00
+ax_pose_terminator
+sPsyduckPose171:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose172:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose173:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose174:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose175:
+ax_pose 4, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose176:
+ax_pose 5, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose177:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose178:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose179:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose180:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose181:
+ax_pose 10, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose182:
+ax_pose 11, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose183:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose184:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose185:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose186:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose187:
+ax_pose 10, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose188:
+ax_pose 11, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose189:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose190:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose191:
+ax_pose 8, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose192:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose193:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose194:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose195:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose196:
+ax_pose 17, 0x01e6, 0x80ee, 0x4c00
+ax_pose_terminator
+sPsyduckPose197:
+ax_pose 19, 0x01ec, 0x80ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose198:
+ax_pose 21, 0x01eb, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose199:
+ax_pose 23, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose200:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose201:
+ax_pose 19, 0x01ec, 0x90f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose202:
+ax_pose 17, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sPsyduckPose203:
+ax_pose 26, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose204:
+ax_pose 29, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose205:
+ax_pose 33, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose206:
+ax_pose 37, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose207:
+ax_pose 41, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose208:
+ax_pose 37, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose209:
+ax_pose 33, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose210:
+ax_pose 29, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose211:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose212:
+ax_pose 15, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose213:
+ax_pose 16, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose214:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose215:
+ax_pose 17, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose216:
+ax_pose 18, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose217:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose218:
+ax_pose 19, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose219:
+ax_pose 20, 0x01eb, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose220:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose221:
+ax_pose 21, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose222:
+ax_pose 22, 0x01ec, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose223:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose224:
+ax_pose 23, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose225:
+ax_pose 24, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose226:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose227:
+ax_pose 21, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose228:
+ax_pose 22, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose229:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose230:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose231:
+ax_pose 20, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose232:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose233:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose234:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose235:
+ax_pose 27, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose236:
+ax_pose 31, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose237:
+ax_pose 35, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose238:
+ax_pose 39, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose239:
+ax_pose 42, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose240:
+ax_pose 39, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose241:
+ax_pose 35, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose242:
+ax_pose 31, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose243:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose244:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose245:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose246:
+ax_pose 9, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose247:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose248:
+ax_pose 9, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose249:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose250:
+ax_pose 3, 0x01e7, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose251:
+ax_pose 55, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose252:
+ax_pose 56, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose253:
+ax_pose 55, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sPsyduckPose254:
+ax_pose 56, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sPsyduckPose255:
+ax_pose 55, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose256:
+ax_pose 57, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose257:
+ax_pose 58, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose258:
+ax_pose 59, 0x01eb, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose259:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose260:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose261:
+ax_pose 60, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose262:
+ax_pose 61, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose263:
+ax_pose 62, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sPsyduckPose264:
+ax_pose 63, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose265:
+ax_pose 64, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPsyduckPose266:
+ax_pose 65, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose267:
+ax_pose 66, 0x01e8, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose268:
+ax_pose 67, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose269:
+ax_pose 68, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose270:
+ax_pose 68, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose271:
+ax_pose 69, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose272:
+ax_pose 70, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose273:
+ax_pose 71, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose274:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose275:
+ax_pose 72, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose276:
+ax_pose 73, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sPsyduckPose277:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose278:
+ax_pose 74, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sPsyduckPose279:
+ax_pose 75, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sPsyduckPose280:
+ax_pose 0, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose281:
+ax_pose 63, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose282:
+ax_pose 76, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose283:
+ax_pose 6, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose284:
+ax_pose 77, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sPsyduckPose285:
+ax_pose 6, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sPsyduckPose286:
+ax_pose 77, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sPsyduckPose287:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sPsyduckPose288:
+ax_pose 78, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose289:
+ax_pose 79, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose290:
+ax_pose 80, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose291:
+ax_pose 81, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose292:
+ax_pose 82, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose293:
+ax_pose 83, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose294:
+ax_pose 79, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose295:
+ax_pose 80, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose296:
+ax_pose 81, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose297:
+ax_pose 82, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose298:
+ax_pose 83, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sPsyduckPose299:
+ax_pose 84, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sPsyduckPose300:
+ax_pose 55, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose301:
+ax_pose 56, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose302:
+ax_pose 55, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sPsyduckPose303:
+ax_pose 56, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sPsyduckPose304:
+ax_pose 55, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose305:
+ax_pose 56, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sPsyduckPose306:
+ax_pose 55, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+sPsyduckPose307:
+ax_pose 56, 0x01ec, 0x90f1, 0x4c00
+ax_pose_terminator
+.align 2
+sPsyduckAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -2, 0, -1,
+ax_anim 4, 0, 25, 0, -3, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 4, 0, 4,
+ax_anim 2, 2, 28, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 4, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sPsyduckAnims_2_2:
+ax_anim 4, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -2, -2, -1, -1,
+ax_anim 4, 0, 30, -3, -3, -2, -2,
+ax_anim 2, 0, 31, 0, -1, 0, -1,
+ax_anim 2, 0, 32, 4, 3, 4, 3,
+ax_anim 2, 2, 33, 10, 9, 10, 9,
+ax_anim 2, 0, 33, 18, 19, 18, 19,
+ax_anim 2, 1, 33, 19, 18, 19, 18,
+ax_anim 2, 0, 33, 18, 19, 18, 19,
+ax_anim 2, 0, 33, 19, 18, 19, 18,
+ax_anim 4, 0, 30, 8, 8, 8, 8,
+ax_anim_terminator
+sPsyduckAnims_2_3:
+ax_anim 4, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 4, 0, 35, -2, 0, -2, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 4, 0, 4, 0,
+ax_anim 2, 2, 38, 10, -3, 10, 0,
+ax_anim 2, 0, 38, 18, -1, 18, 0,
+ax_anim 2, 1, 38, 18, 0, 18, 1,
+ax_anim 2, 0, 38, 18, -1, 18, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 1,
+ax_anim 4, 0, 35, 6, 0, 6, 0,
+ax_anim_terminator
+sPsyduckAnims_2_4:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 41, -1, 1, -1, 1,
+ax_anim 4, 0, 40, -2, 2, -2, 2,
+ax_anim 2, 0, 41, 0, -1, 0, -1,
+ax_anim 2, 0, 42, 4, -7, 4, -4,
+ax_anim 2, 2, 42, 10, -13, 10, -10,
+ax_anim 2, 0, 43, 18, -21, 18, -18,
+ax_anim 2, 1, 43, 19, -20, 19, -17,
+ax_anim 2, 0, 43, 18, -21, 18, -18,
+ax_anim 2, 0, 43, 19, -20, 19, -17,
+ax_anim 4, 0, 40, 6, -6, 6, -6,
+ax_anim_terminator
+sPsyduckAnims_2_5:
+ax_anim 4, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 1, 0, 1,
+ax_anim 4, 0, 45, 0, 2, 0, 2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, -4,
+ax_anim 2, 2, 48, 0, -13, 0, -10,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 1, 48, 1, -21, 1, -21,
+ax_anim 2, 0, 48, 0, -21, 0, -21,
+ax_anim 2, 0, 48, 1, -21, 1, -21,
+ax_anim 4, 0, 45, 0, -6, 0, -6,
+ax_anim_terminator
+sPsyduckAnims_2_6:
+ax_anim 4, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 1, 1, 1, 1,
+ax_anim 4, 0, 50, 2, 2, 2, 2,
+ax_anim 2, 0, 51, 0, -1, 0, -1,
+ax_anim 2, 0, 52, -4, -7, -4, -4,
+ax_anim 2, 2, 52, -10, -13, -10, -10,
+ax_anim 2, 0, 53, -18, -21, -18, -18,
+ax_anim 2, 1, 53, -19, -20, -19, -17,
+ax_anim 2, 0, 53, -18, -21, -18, -18,
+ax_anim 2, 0, 53, -19, -20, -19, -17,
+ax_anim 4, 0, 50, -6, -6, -6, -6,
+ax_anim_terminator
+sPsyduckAnims_2_7:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 1, 0, 1, 0,
+ax_anim 4, 0, 55, 2, 0, 2, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -4, 0, -4, 0,
+ax_anim 2, 2, 58, -10, -3, -10, 0,
+ax_anim 2, 0, 58, -18, -1, -18, 0,
+ax_anim 2, 1, 58, -18, 0, -18, 1,
+ax_anim 2, 0, 58, -18, -1, -18, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 1,
+ax_anim 4, 0, 55, -6, 0, -6, 0,
+ax_anim_terminator
+sPsyduckAnims_2_8:
+ax_anim 4, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 2, -2, 1, -1,
+ax_anim 4, 0, 60, 3, -3, 2, -2,
+ax_anim 2, 0, 61, 0, -1, 0, -1,
+ax_anim 2, 0, 62, -4, 3, -4, 3,
+ax_anim 2, 2, 63, -10, 9, -10, 9,
+ax_anim 2, 0, 63, -18, 19, -18, 19,
+ax_anim 2, 1, 63, -19, 18, -19, 18,
+ax_anim 2, 0, 63, -18, 19, -18, 19,
+ax_anim 2, 0, 63, -19, 18, -19, 18,
+ax_anim 4, 0, 60, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_3_1:
+ax_anim 1, 0, 66, 0, 2, 0, 2,
+ax_anim 1, 0, 65, 0, 7, 0, 7,
+ax_anim 6, 2, 75, 0, 11, 0, 11,
+ax_anim 2, 0, 67, 0, 16, 0, 16,
+ax_anim 6, 1, 117, -1, 17, -1, 17,
+ax_anim 2, 0, 69, 0, 18, 0, 18,
+ax_anim 4, 0, 75, 1, 19, 1, 19,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 4, 0, 117, -1, 20, -1, 20,
+ax_anim 2, 0, 69, 2, 20, 2, 20,
+ax_anim 2, 0, 75, 2, 20, 2, 20,
+ax_anim 2, 0, 66, 0, 8, 0, 8,
+ax_anim_terminator
+sPsyduckAnims_3_2:
+ax_anim 1, 0, 73, 2, 2, 2, 2,
+ax_anim 1, 0, 72, 7, 7, 7, 7,
+ax_anim 6, 2, 68, 11, 11, 11, 11,
+ax_anim 2, 0, 74, 16, 16, 16, 16,
+ax_anim 6, 1, 82, 18, 18, 18, 18,
+ax_anim 2, 0, 76, 18, 18, 18, 18,
+ax_anim 4, 0, 68, 18, 20, 18, 20,
+ax_anim 2, 0, 74, 16, 18, 16, 18,
+ax_anim 4, 0, 82, 18, 18, 18, 18,
+ax_anim 2, 0, 76, 16, 18, 16, 18,
+ax_anim 2, 0, 68, 16, 19, 16, 19,
+ax_anim 2, 0, 73, 8, 8, 8, 8,
+ax_anim_terminator
+sPsyduckAnims_3_3:
+ax_anim 1, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 79, 7, 0, 7, 0,
+ax_anim 6, 2, 75, 9, 0, 9, 0,
+ax_anim 2, 0, 81, 14, 0, 14, 0,
+ax_anim 6, 1, 89, 18, 0, 16, 0,
+ax_anim 2, 0, 83, 18, 0, 16, 0,
+ax_anim 4, 0, 77, 18, 1, 16, 1,
+ax_anim 2, 0, 81, 19, 0, 17, 0,
+ax_anim 4, 0, 89, 19, -1, 17, -1,
+ax_anim 2, 0, 83, 20, 0, 18, 0,
+ax_anim 2, 0, 77, 20, 1, 18, 1,
+ax_anim 2, 0, 80, 8, 0, 8, 0,
+ax_anim_terminator
+sPsyduckAnims_3_4:
+ax_anim 1, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 7, -7, 7, -7,
+ax_anim 6, 2, 83, 11, -11, 11, -11,
+ax_anim 2, 0, 88, 16, -16, 16, -16,
+ax_anim 6, 1, 98, 18, -18, 18, -18,
+ax_anim 2, 0, 90, 18, -18, 18, -18,
+ax_anim 4, 0, 84, 20, -20, 20, -20,
+ax_anim 2, 0, 88, 17, -20, 17, -20,
+ax_anim 4, 0, 98, 19, -19, 19, -19,
+ax_anim 2, 0, 90, 19, -21, 19, -21,
+ax_anim 2, 0, 84, 20, -20, 20, -20,
+ax_anim 2, 0, 87, 8, -8, 8, -8,
+ax_anim_terminator
+sPsyduckAnims_3_5:
+ax_anim 1, 0, 94, 0, -2, 0, -2,
+ax_anim 1, 0, 93, 0, -7, 0, -7,
+ax_anim 6, 2, 105, 0, -9, 0, -9,
+ax_anim 2, 0, 95, 0, -12, 0, -12,
+ax_anim 6, 1, 91, 2, -16, 2, -16,
+ax_anim 2, 0, 97, 0, -18, 0, -18,
+ax_anim 4, 0, 105, 1, -19, 1, -19,
+ax_anim 2, 0, 95, 0, -19, 0, -19,
+ax_anim 4, 0, 91, 2, -21, 2, -21,
+ax_anim 2, 0, 97, 1, -20, 1, -20,
+ax_anim 2, 0, 105, 0, -20, 0, -20,
+ax_anim 2, 0, 94, 0, -8, 0, -8,
+ax_anim_terminator
+sPsyduckAnims_3_6:
+ax_anim 1, 0, 101, -2, -2, -2, -2,
+ax_anim 1, 0, 100, -7, -7, -7, -7,
+ax_anim 6, 2, 112, -11, -11, -11, -11,
+ax_anim 2, 0, 102, -16, -16, -16, -16,
+ax_anim 6, 1, 96, -18, -18, -18, -18,
+ax_anim 2, 0, 104, -18, -18, -18, -18,
+ax_anim 4, 0, 112, -21, -18, -21, -18,
+ax_anim 2, 0, 102, -20, -20, -20, -20,
+ax_anim 4, 0, 96, -19, -20, -19, -20,
+ax_anim 2, 0, 104, -21, -21, -21, -21,
+ax_anim 2, 0, 111, -21, -20, -21, -20,
+ax_anim 2, 0, 101, -8, -8, -8, -8,
+ax_anim_terminator
+sPsyduckAnims_3_7:
+ax_anim 1, 0, 108, -2, 0, -2, 0,
+ax_anim 1, 0, 107, -7, 0, -7, 0,
+ax_anim 6, 2, 119, -9, 0, -9, 0,
+ax_anim 2, 0, 109, -14, 0, -14, 0,
+ax_anim 6, 1, 103, -16, 0, -16, 0,
+ax_anim 2, 0, 111, -18, 0, -18, 0,
+ax_anim 4, 0, 119, -19, 1, -19, 1,
+ax_anim 2, 0, 109, -19, 0, -19, 0,
+ax_anim 4, 0, 103, -19, -1, -19, -1,
+ax_anim 2, 0, 111, -20, 0, -20, 0,
+ax_anim 2, 0, 119, -20, 1, -20, 1,
+ax_anim 2, 0, 108, -8, 0, -8, 0,
+ax_anim_terminator
+sPsyduckAnims_3_8:
+ax_anim 1, 0, 115, -2, 2, -2, 2,
+ax_anim 1, 0, 114, -7, 7, -7, 7,
+ax_anim 6, 2, 70, -11, 11, -11, 11,
+ax_anim 2, 0, 116, -16, 16, -16, 16,
+ax_anim 6, 1, 110, -18, 18, -18, 18,
+ax_anim 2, 0, 118, -18, 18, -18, 18,
+ax_anim 4, 0, 70, -18, 20, -18, 20,
+ax_anim 2, 0, 116, -18, 20, -18, 20,
+ax_anim 4, 0, 110, -20, 21, -20, 21,
+ax_anim 2, 0, 118, -19, 20, -19, 20,
+ax_anim 2, 0, 70, -20, 21, -20, 21,
+ax_anim 2, 0, 115, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_4_1:
+ax_anim 2, 0, 121, 0, -2, 0, -2,
+ax_anim 4, 0, 122, 0, -3, 0, -3,
+ax_anim 5, 2, 121, 0, -4, 0, -4,
+ax_anim 1, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 123, 0, 4, 0, 4,
+ax_anim 2, 1, 123, 1, 4, 1, 4,
+ax_anim 2, 0, 123, 0, 4, 0, 4,
+ax_anim 2, 0, 123, 1, 4, 1, 4,
+ax_anim 2, 0, 123, 0, 4, 0, 4,
+ax_anim 2, 0, 123, 1, 4, 1, 4,
+ax_anim_terminator
+sPsyduckAnims_4_2:
+ax_anim 2, 0, 125, -2, -2, -2, -2,
+ax_anim 4, 0, 126, -3, -3, -3, -3,
+ax_anim 5, 2, 125, -4, -4, -4, -4,
+ax_anim 1, 0, 124, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 2, 1, 127, 3, 5, 3, 5,
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 2, 0, 127, 3, 5, 3, 5,
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 2, 0, 127, 3, 5, 3, 5,
+ax_anim_terminator
+sPsyduckAnims_4_3:
+ax_anim 2, 0, 129, -2, 0, -2, 0,
+ax_anim 4, 0, 130, -3, 0, -3, 0,
+ax_anim 5, 2, 129, -4, 0, -4, 0,
+ax_anim 1, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 131, 4, 0, 4, 0,
+ax_anim 2, 1, 131, 4, -1, 4, -1,
+ax_anim 2, 0, 131, 4, 0, 4, 0,
+ax_anim 2, 0, 131, 4, -1, 4, -1,
+ax_anim 2, 0, 131, 4, 0, 4, 0,
+ax_anim 2, 0, 131, 4, -1, 4, -1,
+ax_anim_terminator
+sPsyduckAnims_4_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 4, 0, 134, -3, 3, -3, 3,
+ax_anim 5, 2, 133, -4, 4, -4, 4,
+ax_anim 1, 0, 132, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 4, -4, 4, -4,
+ax_anim 2, 1, 135, 3, -5, 3, -5,
+ax_anim 2, 0, 135, 4, -4, 4, -4,
+ax_anim 2, 0, 135, 3, -5, 3, -5,
+ax_anim 2, 0, 135, 4, -4, 4, -4,
+ax_anim 2, 0, 135, 3, -5, 3, -5,
+ax_anim_terminator
+sPsyduckAnims_4_5:
+ax_anim 2, 0, 137, 0, 2, 0, 2,
+ax_anim 4, 0, 138, 0, 3, 0, 3,
+ax_anim 5, 2, 137, 0, 4, 0, 4,
+ax_anim 1, 0, 136, 0, -1, 0, -1,
+ax_anim 2, 0, 139, 0, -4, 0, -4,
+ax_anim 2, 1, 139, 0, -5, 0, -5,
+ax_anim 2, 0, 139, 0, -4, 0, -4,
+ax_anim 2, 0, 139, 0, -5, 0, -5,
+ax_anim 2, 0, 139, 0, -4, 0, -4,
+ax_anim 2, 0, 139, 0, -5, 0, -5,
+ax_anim_terminator
+sPsyduckAnims_4_6:
+ax_anim 2, 0, 141, 2, 2, 2, 2,
+ax_anim 4, 0, 142, 3, 3, 3, 3,
+ax_anim 5, 2, 141, 4, 4, 4, 4,
+ax_anim 1, 0, 140, -1, -1, -1, -1,
+ax_anim 2, 0, 143, -4, -4, -4, -4,
+ax_anim 2, 1, 143, -3, -5, -3, -5,
+ax_anim 2, 0, 143, -4, -4, -4, -4,
+ax_anim 2, 0, 143, -3, -5, -3, -5,
+ax_anim 2, 0, 143, -4, -4, -4, -4,
+ax_anim 2, 0, 143, -3, -5, -3, -5,
+ax_anim_terminator
+sPsyduckAnims_4_7:
+ax_anim 2, 0, 145, 2, 0, 2, 0,
+ax_anim 4, 0, 146, 3, 0, 3, 0,
+ax_anim 5, 2, 145, 4, 0, 4, 0,
+ax_anim 1, 0, 144, -1, 0, -1, 0,
+ax_anim 2, 0, 147, -4, 0, -4, 0,
+ax_anim 2, 1, 147, -4, -1, -4, -1,
+ax_anim 2, 0, 147, -4, 0, -4, 0,
+ax_anim 2, 0, 147, -4, -1, -4, -1,
+ax_anim 2, 0, 147, -4, 0, -4, 0,
+ax_anim 2, 0, 147, -4, -1, -4, -1,
+ax_anim_terminator
+sPsyduckAnims_4_8:
+ax_anim 2, 0, 149, 2, -2, 2, -2,
+ax_anim 4, 0, 150, 3, -3, 3, -3,
+ax_anim 5, 2, 149, 4, -4, 4, -4,
+ax_anim 1, 0, 148, -1, 1, -1, 1,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 1, 151, -3, 5, -3, 5,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 0, 151, -3, 5, -3, 5,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 0, 151, -3, 5, -3, 5,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_5_1:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_5_2:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_5_3:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_5_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_5_5:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_5_6:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_5_7:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_5_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_6_1:
+ax_anim 35, 0, 160, 0, 0, 0, 0,
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_7_1:
+ax_anim 2, 0, 162, 0, -2, 0, -2,
+ax_anim 8, 0, 162, 0, -3, 0, -3,
+ax_anim_terminator
+sPsyduckAnims_7_2:
+ax_anim 2, 0, 163, -2, -2, -2, -2,
+ax_anim 8, 0, 163, -3, -3, -3, -3,
+ax_anim_terminator
+sPsyduckAnims_7_3:
+ax_anim 2, 0, 164, -2, 0, -2, 0,
+ax_anim 8, 0, 164, -3, 0, -3, 0,
+ax_anim_terminator
+sPsyduckAnims_7_4:
+ax_anim 2, 0, 165, -2, 2, -2, 2,
+ax_anim 8, 0, 165, -3, 3, -3, 3,
+ax_anim_terminator
+sPsyduckAnims_7_5:
+ax_anim 2, 0, 166, 0, 2, 0, 2,
+ax_anim 8, 0, 166, 0, 3, 0, 3,
+ax_anim_terminator
+sPsyduckAnims_7_6:
+ax_anim 2, 0, 167, 2, 2, 2, 2,
+ax_anim 8, 0, 167, 3, 3, 3, 3,
+ax_anim_terminator
+sPsyduckAnims_7_7:
+ax_anim 2, 0, 168, 2, 0, 2, 0,
+ax_anim 8, 0, 168, 3, 0, 3, 0,
+ax_anim_terminator
+sPsyduckAnims_7_8:
+ax_anim 2, 0, 169, 2, -2, 2, -2,
+ax_anim 8, 0, 169, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_8_1:
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim 20, 0, 171, 0, 0, 0, 0,
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_8_2:
+ax_anim 16, 0, 173, 0, 0, 0, 0,
+ax_anim 20, 0, 174, 0, 0, 0, 0,
+ax_anim 16, 0, 173, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_8_3:
+ax_anim 16, 0, 176, 0, 0, 0, 0,
+ax_anim 20, 0, 177, 0, 0, 0, 0,
+ax_anim 16, 0, 176, 0, 0, 0, 0,
+ax_anim 20, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_8_4:
+ax_anim 16, 0, 179, 0, 0, 0, 0,
+ax_anim 20, 0, 180, 0, 0, 0, 0,
+ax_anim 16, 0, 179, 0, 0, 0, 0,
+ax_anim 20, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_8_5:
+ax_anim 16, 0, 182, 0, 0, 0, 0,
+ax_anim 20, 0, 183, 0, 0, 0, 0,
+ax_anim 16, 0, 182, 0, 0, 0, 0,
+ax_anim 20, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_8_6:
+ax_anim 16, 0, 185, 0, 0, 0, 0,
+ax_anim 20, 0, 186, 0, 0, 0, 0,
+ax_anim 16, 0, 185, 0, 0, 0, 0,
+ax_anim 20, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_8_7:
+ax_anim 16, 0, 188, 0, 0, 0, 0,
+ax_anim 20, 0, 189, 0, 0, 0, 0,
+ax_anim 16, 0, 188, 0, 0, 0, 0,
+ax_anim 20, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_8_8:
+ax_anim 16, 0, 191, 0, 0, 0, 0,
+ax_anim 20, 0, 192, 0, 0, 0, 0,
+ax_anim 16, 0, 191, 0, 0, 0, 0,
+ax_anim 20, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 4, 6, 4,
+ax_anim 2, 0, 196, 10, 9, 10, 9,
+ax_anim 2, 0, 197, 7, 17, 7, 17,
+ax_anim 3, 0, 198, 0, 22, 0, 22,
+ax_anim 2, 3, 199, -7, 17, -7, 17,
+ax_anim 2, 0, 200, -10, 9, -10, 9,
+ax_anim 1, 0, 201, -6, 4, -6, 4,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 6, -1, 6, -1,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 25, 11, 25, 11,
+ax_anim 3, 0, 197, 23, 21, 23, 21,
+ax_anim 2, 3, 198, 11, 23, 11, 23,
+ax_anim 2, 0, 199, 0, 12, 0, 12,
+ax_anim 1, 0, 200, -3, 7, -3, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -4, 3, -4,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 17, -4, 17, -4,
+ax_anim 3, 0, 196, 20, 1, 20, 1,
+ax_anim 2, 3, 197, 17, 5, 17, 5,
+ax_anim 2, 0, 198, 12, 7, 12, 7,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -2, -8, -2, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 11, -22, 11, -22,
+ax_anim 3, 0, 195, 18, -22, 18, -22,
+ax_anim 2, 3, 196, 21, -12, 21, -12,
+ax_anim 2, 0, 197, 16, -6, 16, -6,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -6, -4, -6, -4,
+ax_anim 2, 0, 200, -10, -10, -10, -10,
+ax_anim 2, 0, 201, -7, -16, -7, -16,
+ax_anim 3, 0, 194, 0, -22, 0, -22,
+ax_anim 2, 3, 195, 7, -16, 7, -16,
+ax_anim 2, 0, 196, 10, -8, 10, -8,
+ax_anim 1, 0, 197, 6, -4, 6, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 2, -8, 2, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -11, -22, -11, -22,
+ax_anim 3, 0, 201, -18, -22, -18, -22,
+ax_anim 2, 3, 200, -21, -12, -21, -12,
+ax_anim 2, 0, 199, -16, -6, -16, -6,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -4, -3, -4,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -17, -4, -17, -4,
+ax_anim 3, 0, 200, -20, 1, -20, 1,
+ax_anim 2, 3, 199, -17, 5, -17, 5,
+ax_anim 2, 0, 198, -12, 7, -12, 7,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -6, -1, -6, -1,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -25, 11, -25, 11,
+ax_anim 3, 0, 199, -23, 21, -23, 21,
+ax_anim 2, 3, 198, -11, 23, -11, 23,
+ax_anim 2, 0, 197, 0, 12, 0, 12,
+ax_anim 1, 0, 196, 3, 7, 3, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 211, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 220, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -22, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 226, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 229, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_14_1:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_14_2:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_14_3:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_14_4:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_14_5:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_14_6:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_14_7:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_14_8:
+ax_anim 30, 0, 250, 0, 0, 0, 0,
+ax_anim 35, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_15_1:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_15_2:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_15_3:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_15_4:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_15_5:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_15_6:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_15_7:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_15_8:
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 6, 0, 255, 0, 0, 0, 0,
+ax_anim 14, 0, 256, 0, 0, 0, 0,
+ax_anim 4, 0, 257, 0, 0, 0, 0,
+ax_anim 10, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_16_1:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_16_2:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_16_3:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_16_4:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_16_5:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_16_6:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_16_7:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_16_8:
+ax_anim 8, 0, 259, 0, 0, 0, 0,
+ax_anim 3, 0, 260, 0, 0, 0, 0,
+ax_anim 8, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_17_1:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+sPsyduckAnims_17_2:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+sPsyduckAnims_17_3:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+sPsyduckAnims_17_4:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+sPsyduckAnims_17_5:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+sPsyduckAnims_17_6:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+sPsyduckAnims_17_7:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+sPsyduckAnims_17_8:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_18_1:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_18_2:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_18_3:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_18_4:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_18_5:
+ax_anim 12, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 8, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_18_6:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_18_7:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_18_8:
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 8, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_19_1:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_19_2:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_19_3:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_19_4:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_19_5:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_19_6:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_19_7:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_19_8:
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 271, 0, 0, 0, 0,
+ax_anim 8, 0, 270, 0, 0, 0, 0,
+ax_anim 10, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_20_1:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 1, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 0,
+ax_anim 2, 0, 275, 0, 1, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 0,
+ax_anim 2, 0, 275, 0, 1, 0, 0,
+ax_anim 2, 0, 275, 1, 1, 1, 0,
+ax_anim_terminator
+sPsyduckAnims_20_2:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim_terminator
+sPsyduckAnims_20_3:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim_terminator
+sPsyduckAnims_20_4:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim_terminator
+sPsyduckAnims_20_5:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim_terminator
+sPsyduckAnims_20_6:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim_terminator
+sPsyduckAnims_20_7:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim_terminator
+sPsyduckAnims_20_8:
+ax_anim 4, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -2, 0, 0,
+ax_anim 1, 0, 274, 0, -4, 0, 0,
+ax_anim 2, 0, 275, 0, -4, 0, 0,
+ax_anim 1, 0, 275, 0, -2, 0, 0,
+ax_anim 4, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_21_1:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_21_2:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_21_3:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_21_4:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_21_5:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_21_6:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_21_7:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_21_8:
+ax_anim 8, 0, 276, 0, 0, 0, 0,
+ax_anim 8, 0, 277, 0, 0, 0, 0,
+ax_anim 8, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_22_1:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_22_2:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_22_3:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_22_4:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_22_5:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_22_6:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_22_7:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_22_8:
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 30, 0, 280, 0, 0, 0, 0,
+ax_anim 34, 0, 281, 0, 0, 0, 0,
+ax_anim 4, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_23_1:
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 4, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_23_2:
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 4, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_23_3:
+ax_anim 10, 0, 284, 0, 0, 0, 0,
+ax_anim 8, 0, 285, 0, 0, 0, 0,
+ax_anim 12, 0, 284, 0, 0, 0, 0,
+ax_anim 8, 0, 285, 0, 0, 0, 0,
+ax_anim 4, 0, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_23_4:
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 4, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_23_5:
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 4, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_23_6:
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 4, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_23_7:
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 4, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_23_8:
+ax_anim 10, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 12, 0, 282, 0, 0, 0, 0,
+ax_anim 8, 0, 283, 0, 0, 0, 0,
+ax_anim 4, 0, 282, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_24_1:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_24_2:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_24_3:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_24_4:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_24_5:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_24_6:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_24_7:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_24_8:
+ax_anim 4, 0, 287, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_25_1:
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 294, 0, 0, 0, 0,
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 296, 0, 0, 0, 0,
+ax_anim 12, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_25_2:
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 294, 0, 0, 0, 0,
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 296, 0, 0, 0, 0,
+ax_anim 12, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_25_3:
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 294, 0, 0, 0, 0,
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 296, 0, 0, 0, 0,
+ax_anim 12, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_25_4:
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 294, 0, 0, 0, 0,
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 296, 0, 0, 0, 0,
+ax_anim 12, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_25_5:
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 294, 0, 0, 0, 0,
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 296, 0, 0, 0, 0,
+ax_anim 12, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_25_6:
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 294, 0, 0, 0, 0,
+ax_anim 12, 0, 295, 0, 0, 0, 0,
+ax_anim 10, 0, 293, 0, 0, 0, 0,
+ax_anim 8, 0, 296, 0, 0, 0, 0,
+ax_anim 12, 0, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_25_7:
+ax_anim 10, 0, 288, 0, 0, 0, 0,
+ax_anim 8, 0, 289, 0, 0, 0, 0,
+ax_anim 12, 0, 290, 0, 0, 0, 0,
+ax_anim 10, 0, 288, 0, 0, 0, 0,
+ax_anim 8, 0, 291, 0, 0, 0, 0,
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_25_8:
+ax_anim 10, 0, 288, 0, 0, 0, 0,
+ax_anim 8, 0, 289, 0, 0, 0, 0,
+ax_anim 12, 0, 290, 0, 0, 0, 0,
+ax_anim 10, 0, 288, 0, 0, 0, 0,
+ax_anim 8, 0, 291, 0, 0, 0, 0,
+ax_anim 12, 0, 292, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_26_1:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+sPsyduckAnims_26_2:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+sPsyduckAnims_26_3:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+sPsyduckAnims_26_4:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+sPsyduckAnims_26_5:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+sPsyduckAnims_26_6:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+sPsyduckAnims_26_7:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+sPsyduckAnims_26_8:
+ax_anim 2, 0, 298, 0, 0, 0, 0,
+ax_anim 2, 0, 298, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_27_1:
+ax_anim 12, 0, 299, 0, 0, 0, 0,
+ax_anim 12, 0, 299, 0, 0, 0, 0,
+ax_anim 16, 0, 299, -1, 0, 0, 0,
+ax_anim 12, 0, 299, 0, 0, 0, 0,
+ax_anim 12, 0, 299, 1, 0, 0, 0,
+ax_anim 16, 0, 299, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPsyduckAnims_28_1:
+ax_anim 12, 0, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_28_2:
+ax_anim 12, 0, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_28_3:
+ax_anim 12, 0, 306, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_28_4:
+ax_anim 12, 0, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_28_5:
+ax_anim 12, 0, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_28_6:
+ax_anim 12, 0, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_28_7:
+ax_anim 12, 0, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckAnims_28_8:
+ax_anim 12, 0, 304, 0, 0, 0, 0,
+ax_anim_terminator
+sPsyduckGfx1:
+.incbin "baserom.gba", 0x7569D4, 0x200
+sPsyduckSprites1:
+ax_sprite sPsyduckGfx1, 0x200
+ax_sprite_terminator
+sPsyduckGfx2:
+.incbin "baserom.gba", 0x756BE4, 0x200
+sPsyduckSprites2:
+ax_sprite sPsyduckGfx2, 0x200
+ax_sprite_terminator
+sPsyduckGfx3:
+.incbin "baserom.gba", 0x756DF4, 0x200
+sPsyduckSprites3:
+ax_sprite sPsyduckGfx3, 0x200
+ax_sprite_terminator
+sPsyduckGfx4:
+.incbin "baserom.gba", 0x757004, 0x200
+sPsyduckSprites4:
+ax_sprite sPsyduckGfx4, 0x200
+ax_sprite_terminator
+sPsyduckGfx5:
+.incbin "baserom.gba", 0x757214, 0x200
+sPsyduckSprites5:
+ax_sprite sPsyduckGfx5, 0x200
+ax_sprite_terminator
+sPsyduckGfx6:
+.incbin "baserom.gba", 0x757424, 0x200
+sPsyduckSprites6:
+ax_sprite sPsyduckGfx6, 0x200
+ax_sprite_terminator
+sPsyduckGfx7:
+.incbin "baserom.gba", 0x757634, 0x200
+sPsyduckSprites7:
+ax_sprite sPsyduckGfx7, 0x200
+ax_sprite_terminator
+sPsyduckGfx8:
+.incbin "baserom.gba", 0x757844, 0x200
+sPsyduckSprites8:
+ax_sprite sPsyduckGfx8, 0x200
+ax_sprite_terminator
+sPsyduckGfx9:
+.incbin "baserom.gba", 0x757A54, 0x200
+sPsyduckSprites9:
+ax_sprite sPsyduckGfx9, 0x200
+ax_sprite_terminator
+sPsyduckGfx10:
+.incbin "baserom.gba", 0x757C64, 0x200
+sPsyduckSprites10:
+ax_sprite sPsyduckGfx10, 0x200
+ax_sprite_terminator
+sPsyduckGfx11:
+.incbin "baserom.gba", 0x757E74, 0x200
+sPsyduckSprites11:
+ax_sprite sPsyduckGfx11, 0x200
+ax_sprite_terminator
+sPsyduckGfx12:
+.incbin "baserom.gba", 0x758084, 0x200
+sPsyduckSprites12:
+ax_sprite sPsyduckGfx12, 0x200
+ax_sprite_terminator
+sPsyduckGfx13:
+.incbin "baserom.gba", 0x758294, 0x200
+sPsyduckSprites13:
+ax_sprite sPsyduckGfx13, 0x200
+ax_sprite_terminator
+sPsyduckGfx14:
+.incbin "baserom.gba", 0x7584A4, 0x200
+sPsyduckSprites14:
+ax_sprite sPsyduckGfx14, 0x200
+ax_sprite_terminator
+sPsyduckGfx15:
+.incbin "baserom.gba", 0x7586B4, 0x200
+sPsyduckSprites15:
+ax_sprite sPsyduckGfx15, 0x200
+ax_sprite_terminator
+sPsyduckGfx16:
+.incbin "baserom.gba", 0x7588C4, 0x40
+sPsyduckGfx16_1:
+.incbin "baserom.gba", 0x758904, 0x100
+sPsyduckSprites16:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx16_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPsyduckGfx17:
+.incbin "baserom.gba", 0x758A34, 0x40
+sPsyduckGfx17_1:
+.incbin "baserom.gba", 0x758A74, 0x100
+sPsyduckGfx17_2:
+.incbin "baserom.gba", 0x758B74, 0x40
+sPsyduckSprites17:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPsyduckGfx18:
+.incbin "baserom.gba", 0x758BF4, 0x20
+sPsyduckGfx18_1:
+.incbin "baserom.gba", 0x758C14, 0x100
+sPsyduckGfx18_2:
+.incbin "baserom.gba", 0x758D14, 0x60
+sPsyduckSprites18:
+ax_sprite 0, 0x40
+ax_sprite sPsyduckGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx18_2, 0x60
+ax_sprite_terminator
+sPsyduckGfx19:
+.incbin "baserom.gba", 0x758DAC, 0x180
+sPsyduckSprites19:
+ax_sprite 0, 0x80
+ax_sprite sPsyduckGfx19, 0x180
+ax_sprite_terminator
+sPsyduckGfx20:
+.incbin "baserom.gba", 0x758F44, 0x40
+sPsyduckGfx20_1:
+.incbin "baserom.gba", 0x758F84, 0x100
+sPsyduckSprites20:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPsyduckGfx21:
+.incbin "baserom.gba", 0x7590B4, 0x60
+sPsyduckGfx21_1:
+.incbin "baserom.gba", 0x759114, 0x100
+sPsyduckSprites21:
+ax_sprite sPsyduckGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPsyduckGfx22:
+.incbin "baserom.gba", 0x75923C, 0x40
+sPsyduckGfx22_1:
+.incbin "baserom.gba", 0x75927C, 0x80
+sPsyduckGfx22_2:
+.incbin "baserom.gba", 0x7592FC, 0x60
+sPsyduckSprites22:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx22_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx22_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPsyduckGfx23:
+.incbin "baserom.gba", 0x75939C, 0x60
+sPsyduckGfx23_1:
+.incbin "baserom.gba", 0x7593FC, 0x100
+sPsyduckSprites23:
+ax_sprite sPsyduckGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx23_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sPsyduckGfx24:
+.incbin "baserom.gba", 0x759524, 0x40
+sPsyduckGfx24_1:
+.incbin "baserom.gba", 0x759564, 0x80
+sPsyduckGfx24_2:
+.incbin "baserom.gba", 0x7595E4, 0x40
+sPsyduckSprites24:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx25:
+.incbin "baserom.gba", 0x759664, 0x40
+sPsyduckGfx25_1:
+.incbin "baserom.gba", 0x7596A4, 0x60
+sPsyduckGfx25_2:
+.incbin "baserom.gba", 0x759704, 0x60
+sPsyduckSprites25:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx26:
+.incbin "baserom.gba", 0x7597A4, 0x20
+sPsyduckGfx26_1:
+.incbin "baserom.gba", 0x7597C4, 0x60
+sPsyduckSprites26:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx26, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPsyduckGfx27:
+.incbin "baserom.gba", 0x759854, 0x60
+sPsyduckGfx27_1:
+.incbin "baserom.gba", 0x7598B4, 0x60
+sPsyduckGfx27_2:
+.incbin "baserom.gba", 0x759914, 0x60
+sPsyduckSprites27:
+ax_sprite sPsyduckGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx28:
+.incbin "baserom.gba", 0x7599AC, 0x60
+sPsyduckGfx28_1:
+.incbin "baserom.gba", 0x759A0C, 0x60
+sPsyduckGfx28_2:
+.incbin "baserom.gba", 0x759A6C, 0x60
+sPsyduckSprites28:
+ax_sprite sPsyduckGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx29:
+.incbin "baserom.gba", 0x759B04, 0xA0
+sPsyduckSprites29:
+ax_sprite 0, 0x60
+ax_sprite sPsyduckGfx29, 0xa0
+ax_sprite_terminator
+sPsyduckGfx30:
+.incbin "baserom.gba", 0x759BBC, 0x40
+sPsyduckGfx30_1:
+.incbin "baserom.gba", 0x759BFC, 0x60
+sPsyduckGfx30_2:
+.incbin "baserom.gba", 0x759C5C, 0x60
+sPsyduckGfx30_3:
+.incbin "baserom.gba", 0x759CBC, 0x60
+sPsyduckSprites30:
+ax_sprite sPsyduckGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sPsyduckGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPsyduckGfx31:
+.incbin "baserom.gba", 0x759D64, 0x60
+sPsyduckSprites31:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx31, 0x60
+ax_sprite_terminator
+sPsyduckGfx32:
+.incbin "baserom.gba", 0x759DDC, 0x20
+sPsyduckGfx32_1:
+.incbin "baserom.gba", 0x759DFC, 0x60
+sPsyduckGfx32_2:
+.incbin "baserom.gba", 0x759E5C, 0x60
+sPsyduckGfx32_3:
+.incbin "baserom.gba", 0x759EBC, 0x60
+sPsyduckSprites32:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx32, 0x20
+ax_sprite 0, 0x40
+ax_sprite sPsyduckGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPsyduckGfx33:
+.incbin "baserom.gba", 0x759F6C, 0x40
+sPsyduckGfx33_1:
+.incbin "baserom.gba", 0x759FAC, 0x60
+sPsyduckSprites33:
+ax_sprite 0, 0xa0
+ax_sprite sPsyduckGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx33_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx34:
+.incbin "baserom.gba", 0x75A03C, 0x60
+sPsyduckGfx34_1:
+.incbin "baserom.gba", 0x75A09C, 0x60
+sPsyduckGfx34_2:
+.incbin "baserom.gba", 0x75A0FC, 0x60
+sPsyduckSprites34:
+ax_sprite sPsyduckGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx35:
+.incbin "baserom.gba", 0x75A194, 0x60
+sPsyduckSprites35:
+ax_sprite sPsyduckGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPsyduckGfx36:
+.incbin "baserom.gba", 0x75A20C, 0x60
+sPsyduckGfx36_1:
+.incbin "baserom.gba", 0x75A26C, 0x60
+sPsyduckGfx36_2:
+.incbin "baserom.gba", 0x75A2CC, 0x60
+sPsyduckSprites36:
+ax_sprite sPsyduckGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx37:
+.incbin "baserom.gba", 0x75A364, 0x80
+sPsyduckSprites37:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx37, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sPsyduckGfx38:
+.incbin "baserom.gba", 0x75A404, 0x60
+sPsyduckGfx38_1:
+.incbin "baserom.gba", 0x75A464, 0x60
+sPsyduckGfx38_2:
+.incbin "baserom.gba", 0x75A4C4, 0x60
+sPsyduckSprites38:
+ax_sprite sPsyduckGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx39:
+.incbin "baserom.gba", 0x75A55C, 0x20
+sPsyduckGfx39_1:
+.incbin "baserom.gba", 0x75A57C, 0x20
+sPsyduckGfx39_2:
+.incbin "baserom.gba", 0x75A59C, 0x20
+sPsyduckSprites39:
+ax_sprite 0, 0x40
+ax_sprite sPsyduckGfx39, 0x20
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx39_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sPsyduckGfx39_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sPsyduckGfx40:
+.incbin "baserom.gba", 0x75A5FC, 0x60
+sPsyduckGfx40_1:
+.incbin "baserom.gba", 0x75A65C, 0x60
+sPsyduckGfx40_2:
+.incbin "baserom.gba", 0x75A6BC, 0x40
+sPsyduckSprites40:
+ax_sprite sPsyduckGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx40_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPsyduckGfx40_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx41:
+.incbin "baserom.gba", 0x75A734, 0x40
+sPsyduckSprites41:
+ax_sprite sPsyduckGfx41, 0x40
+ax_sprite_terminator
+sPsyduckGfx42:
+.incbin "baserom.gba", 0x75A784, 0x60
+sPsyduckGfx42_1:
+.incbin "baserom.gba", 0x75A7E4, 0x60
+sPsyduckGfx42_2:
+.incbin "baserom.gba", 0x75A844, 0x60
+sPsyduckSprites42:
+ax_sprite sPsyduckGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx42_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx43:
+.incbin "baserom.gba", 0x75A8DC, 0x60
+sPsyduckGfx43_1:
+.incbin "baserom.gba", 0x75A93C, 0x60
+sPsyduckGfx43_2:
+.incbin "baserom.gba", 0x75A99C, 0x60
+sPsyduckSprites43:
+ax_sprite sPsyduckGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx43_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx44:
+.incbin "baserom.gba", 0x75AA34, 0x60
+sPsyduckGfx44_1:
+.incbin "baserom.gba", 0x75AA94, 0x60
+sPsyduckGfx44_2:
+.incbin "baserom.gba", 0x75AAF4, 0x60
+sPsyduckGfx44_3:
+.incbin "baserom.gba", 0x75AB54, 0x60
+sPsyduckSprites44:
+ax_sprite sPsyduckGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx44_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPsyduckGfx45:
+.incbin "baserom.gba", 0x75ABFC, 0x40
+sPsyduckGfx45_1:
+.incbin "baserom.gba", 0x75AC3C, 0x60
+sPsyduckGfx45_2:
+.incbin "baserom.gba", 0x75AC9C, 0x60
+sPsyduckGfx45_3:
+.incbin "baserom.gba", 0x75ACFC, 0x60
+sPsyduckSprites45:
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx45_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPsyduckGfx46:
+.incbin "baserom.gba", 0x75ADAC, 0x60
+sPsyduckGfx46_1:
+.incbin "baserom.gba", 0x75AE0C, 0x60
+sPsyduckGfx46_2:
+.incbin "baserom.gba", 0x75AE6C, 0x60
+sPsyduckSprites46:
+ax_sprite sPsyduckGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx46_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx47:
+.incbin "baserom.gba", 0x75AF04, 0x60
+sPsyduckGfx47_1:
+.incbin "baserom.gba", 0x75AF64, 0x60
+sPsyduckGfx47_2:
+.incbin "baserom.gba", 0x75AFC4, 0x40
+sPsyduckSprites47:
+ax_sprite sPsyduckGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx47_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sPsyduckGfx47_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx48:
+.incbin "baserom.gba", 0x75B03C, 0x60
+sPsyduckGfx48_1:
+.incbin "baserom.gba", 0x75B09C, 0x60
+sPsyduckGfx48_2:
+.incbin "baserom.gba", 0x75B0FC, 0x60
+sPsyduckSprites48:
+ax_sprite sPsyduckGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sPsyduckGfx48_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sPsyduckGfx49:
+.incbin "baserom.gba", 0x75B194, 0x200
+sPsyduckSprites49:
+ax_sprite sPsyduckGfx49, 0x200
+ax_sprite_terminator
+sPsyduckGfx50:
+.incbin "baserom.gba", 0x75B3A4, 0x200
+sPsyduckSprites50:
+ax_sprite sPsyduckGfx50, 0x200
+ax_sprite_terminator
+sPsyduckGfx51:
+.incbin "baserom.gba", 0x75B5B4, 0x200
+sPsyduckSprites51:
+ax_sprite sPsyduckGfx51, 0x200
+ax_sprite_terminator
+sPsyduckGfx52:
+.incbin "baserom.gba", 0x75B7C4, 0x200
+sPsyduckSprites52:
+ax_sprite sPsyduckGfx52, 0x200
+ax_sprite_terminator
+sPsyduckGfx53:
+.incbin "baserom.gba", 0x75B9D4, 0x200
+sPsyduckSprites53:
+ax_sprite sPsyduckGfx53, 0x200
+ax_sprite_terminator
+sPsyduckGfx54:
+.incbin "baserom.gba", 0x75BBE4, 0x200
+sPsyduckSprites54:
+ax_sprite sPsyduckGfx54, 0x200
+ax_sprite_terminator
+sPsyduckGfx55:
+.incbin "baserom.gba", 0x75BDF4, 0x200
+sPsyduckSprites55:
+ax_sprite sPsyduckGfx55, 0x200
+ax_sprite_terminator
+sPsyduckGfx56:
+.incbin "baserom.gba", 0x75C004, 0x200
+sPsyduckSprites56:
+ax_sprite sPsyduckGfx56, 0x200
+ax_sprite_terminator
+sPsyduckGfx57:
+.incbin "baserom.gba", 0x75C214, 0x200
+sPsyduckSprites57:
+ax_sprite sPsyduckGfx57, 0x200
+ax_sprite_terminator
+sPsyduckGfx58:
+.incbin "baserom.gba", 0x75C424, 0x200
+sPsyduckSprites58:
+ax_sprite sPsyduckGfx58, 0x200
+ax_sprite_terminator
+sPsyduckGfx59:
+.incbin "baserom.gba", 0x75C634, 0x200
+sPsyduckSprites59:
+ax_sprite sPsyduckGfx59, 0x200
+ax_sprite_terminator
+sPsyduckGfx60:
+.incbin "baserom.gba", 0x75C844, 0x200
+sPsyduckSprites60:
+ax_sprite sPsyduckGfx60, 0x200
+ax_sprite_terminator
+sPsyduckGfx61:
+.incbin "baserom.gba", 0x75CA54, 0x200
+sPsyduckSprites61:
+ax_sprite sPsyduckGfx61, 0x200
+ax_sprite_terminator
+sPsyduckGfx62:
+.incbin "baserom.gba", 0x75CC64, 0x200
+sPsyduckSprites62:
+ax_sprite sPsyduckGfx62, 0x200
+ax_sprite_terminator
+sPsyduckGfx63:
+.incbin "baserom.gba", 0x75CE74, 0x200
+sPsyduckSprites63:
+ax_sprite sPsyduckGfx63, 0x200
+ax_sprite_terminator
+sPsyduckGfx64:
+.incbin "baserom.gba", 0x75D084, 0x200
+sPsyduckSprites64:
+ax_sprite sPsyduckGfx64, 0x200
+ax_sprite_terminator
+sPsyduckGfx65:
+.incbin "baserom.gba", 0x75D294, 0x200
+sPsyduckSprites65:
+ax_sprite sPsyduckGfx65, 0x200
+ax_sprite_terminator
+sPsyduckGfx66:
+.incbin "baserom.gba", 0x75D4A4, 0x200
+sPsyduckSprites66:
+ax_sprite sPsyduckGfx66, 0x200
+ax_sprite_terminator
+sPsyduckGfx67:
+.incbin "baserom.gba", 0x75D6B4, 0x200
+sPsyduckSprites67:
+ax_sprite sPsyduckGfx67, 0x200
+ax_sprite_terminator
+sPsyduckGfx68:
+.incbin "baserom.gba", 0x75D8C4, 0x200
+sPsyduckSprites68:
+ax_sprite sPsyduckGfx68, 0x200
+ax_sprite_terminator
+sPsyduckGfx69:
+.incbin "baserom.gba", 0x75DAD4, 0x200
+sPsyduckSprites69:
+ax_sprite sPsyduckGfx69, 0x200
+ax_sprite_terminator
+sPsyduckGfx70:
+.incbin "baserom.gba", 0x75DCE4, 0x200
+sPsyduckSprites70:
+ax_sprite sPsyduckGfx70, 0x200
+ax_sprite_terminator
+sPsyduckGfx71:
+.incbin "baserom.gba", 0x75DEF4, 0x200
+sPsyduckSprites71:
+ax_sprite sPsyduckGfx71, 0x200
+ax_sprite_terminator
+sPsyduckGfx72:
+.incbin "baserom.gba", 0x75E104, 0x200
+sPsyduckSprites72:
+ax_sprite sPsyduckGfx72, 0x200
+ax_sprite_terminator
+sPsyduckGfx73:
+.incbin "baserom.gba", 0x75E314, 0x200
+sPsyduckSprites73:
+ax_sprite sPsyduckGfx73, 0x200
+ax_sprite_terminator
+sPsyduckGfx74:
+.incbin "baserom.gba", 0x75E524, 0x200
+sPsyduckSprites74:
+ax_sprite sPsyduckGfx74, 0x200
+ax_sprite_terminator
+sPsyduckGfx75:
+.incbin "baserom.gba", 0x75E734, 0x200
+sPsyduckSprites75:
+ax_sprite sPsyduckGfx75, 0x200
+ax_sprite_terminator
+sPsyduckGfx76:
+.incbin "baserom.gba", 0x75E944, 0x200
+sPsyduckSprites76:
+ax_sprite sPsyduckGfx76, 0x200
+ax_sprite_terminator
+sPsyduckGfx77:
+.incbin "baserom.gba", 0x75EB54, 0x200
+sPsyduckSprites77:
+ax_sprite sPsyduckGfx77, 0x200
+ax_sprite_terminator
+sPsyduckGfx78:
+.incbin "baserom.gba", 0x75ED64, 0x200
+sPsyduckSprites78:
+ax_sprite sPsyduckGfx78, 0x200
+ax_sprite_terminator
+sPsyduckGfx79:
+.incbin "baserom.gba", 0x75EF74, 0x200
+sPsyduckSprites79:
+ax_sprite sPsyduckGfx79, 0x200
+ax_sprite_terminator
+sPsyduckGfx80:
+.incbin "baserom.gba", 0x75F184, 0x200
+sPsyduckSprites80:
+ax_sprite sPsyduckGfx80, 0x200
+ax_sprite_terminator
+sPsyduckGfx81:
+.incbin "baserom.gba", 0x75F394, 0x200
+sPsyduckSprites81:
+ax_sprite sPsyduckGfx81, 0x200
+ax_sprite_terminator
+sPsyduckGfx82:
+.incbin "baserom.gba", 0x75F5A4, 0x200
+sPsyduckSprites82:
+ax_sprite sPsyduckGfx82, 0x200
+ax_sprite_terminator
+sPsyduckGfx83:
+.incbin "baserom.gba", 0x75F7B4, 0x200
+sPsyduckSprites83:
+ax_sprite sPsyduckGfx83, 0x200
+ax_sprite_terminator
+sPsyduckGfx84:
+.incbin "baserom.gba", 0x75F9C4, 0x200
+sPsyduckSprites84:
+ax_sprite sPsyduckGfx84, 0x200
+ax_sprite_terminator
+sPsyduckGfx85:
+.incbin "baserom.gba", 0x75FBD4, 0x200
+sPsyduckSprites85:
+ax_sprite sPsyduckGfx85, 0x200
+ax_sprite_terminator
+sAxPosesPsyduck:
+.4byte sPsyduckPose1
+.4byte sPsyduckPose2
+.4byte sPsyduckPose3
+.4byte sPsyduckPose4
+.4byte sPsyduckPose5
+.4byte sPsyduckPose6
+.4byte sPsyduckPose7
+.4byte sPsyduckPose8
+.4byte sPsyduckPose9
+.4byte sPsyduckPose10
+.4byte sPsyduckPose11
+.4byte sPsyduckPose12
+.4byte sPsyduckPose13
+.4byte sPsyduckPose14
+.4byte sPsyduckPose15
+.4byte sPsyduckPose16
+.4byte sPsyduckPose17
+.4byte sPsyduckPose18
+.4byte sPsyduckPose19
+.4byte sPsyduckPose20
+.4byte sPsyduckPose21
+.4byte sPsyduckPose22
+.4byte sPsyduckPose23
+.4byte sPsyduckPose24
+.4byte sPsyduckPose25
+.4byte sPsyduckPose26
+.4byte sPsyduckPose27
+.4byte sPsyduckPose28
+.4byte sPsyduckPose29
+.4byte sPsyduckPose30
+.4byte sPsyduckPose31
+.4byte sPsyduckPose32
+.4byte sPsyduckPose33
+.4byte sPsyduckPose34
+.4byte sPsyduckPose35
+.4byte sPsyduckPose36
+.4byte sPsyduckPose37
+.4byte sPsyduckPose38
+.4byte sPsyduckPose39
+.4byte sPsyduckPose40
+.4byte sPsyduckPose41
+.4byte sPsyduckPose42
+.4byte sPsyduckPose43
+.4byte sPsyduckPose44
+.4byte sPsyduckPose45
+.4byte sPsyduckPose46
+.4byte sPsyduckPose47
+.4byte sPsyduckPose48
+.4byte sPsyduckPose49
+.4byte sPsyduckPose50
+.4byte sPsyduckPose51
+.4byte sPsyduckPose52
+.4byte sPsyduckPose53
+.4byte sPsyduckPose54
+.4byte sPsyduckPose55
+.4byte sPsyduckPose56
+.4byte sPsyduckPose57
+.4byte sPsyduckPose58
+.4byte sPsyduckPose59
+.4byte sPsyduckPose60
+.4byte sPsyduckPose61
+.4byte sPsyduckPose62
+.4byte sPsyduckPose63
+.4byte sPsyduckPose64
+.4byte sPsyduckPose65
+.4byte sPsyduckPose66
+.4byte sPsyduckPose67
+.4byte sPsyduckPose68
+.4byte sPsyduckPose69
+.4byte sPsyduckPose70
+.4byte sPsyduckPose71
+.4byte sPsyduckPose72
+.4byte sPsyduckPose73
+.4byte sPsyduckPose74
+.4byte sPsyduckPose75
+.4byte sPsyduckPose76
+.4byte sPsyduckPose77
+.4byte sPsyduckPose78
+.4byte sPsyduckPose79
+.4byte sPsyduckPose80
+.4byte sPsyduckPose81
+.4byte sPsyduckPose82
+.4byte sPsyduckPose83
+.4byte sPsyduckPose84
+.4byte sPsyduckPose85
+.4byte sPsyduckPose86
+.4byte sPsyduckPose87
+.4byte sPsyduckPose88
+.4byte sPsyduckPose89
+.4byte sPsyduckPose90
+.4byte sPsyduckPose91
+.4byte sPsyduckPose92
+.4byte sPsyduckPose93
+.4byte sPsyduckPose94
+.4byte sPsyduckPose95
+.4byte sPsyduckPose96
+.4byte sPsyduckPose97
+.4byte sPsyduckPose98
+.4byte sPsyduckPose99
+.4byte sPsyduckPose100
+.4byte sPsyduckPose101
+.4byte sPsyduckPose102
+.4byte sPsyduckPose103
+.4byte sPsyduckPose104
+.4byte sPsyduckPose105
+.4byte sPsyduckPose106
+.4byte sPsyduckPose107
+.4byte sPsyduckPose108
+.4byte sPsyduckPose109
+.4byte sPsyduckPose110
+.4byte sPsyduckPose111
+.4byte sPsyduckPose112
+.4byte sPsyduckPose113
+.4byte sPsyduckPose114
+.4byte sPsyduckPose115
+.4byte sPsyduckPose116
+.4byte sPsyduckPose117
+.4byte sPsyduckPose118
+.4byte sPsyduckPose119
+.4byte sPsyduckPose120
+.4byte sPsyduckPose121
+.4byte sPsyduckPose122
+.4byte sPsyduckPose123
+.4byte sPsyduckPose124
+.4byte sPsyduckPose125
+.4byte sPsyduckPose126
+.4byte sPsyduckPose127
+.4byte sPsyduckPose128
+.4byte sPsyduckPose129
+.4byte sPsyduckPose130
+.4byte sPsyduckPose131
+.4byte sPsyduckPose132
+.4byte sPsyduckPose133
+.4byte sPsyduckPose134
+.4byte sPsyduckPose135
+.4byte sPsyduckPose136
+.4byte sPsyduckPose137
+.4byte sPsyduckPose138
+.4byte sPsyduckPose139
+.4byte sPsyduckPose140
+.4byte sPsyduckPose141
+.4byte sPsyduckPose142
+.4byte sPsyduckPose143
+.4byte sPsyduckPose144
+.4byte sPsyduckPose145
+.4byte sPsyduckPose146
+.4byte sPsyduckPose147
+.4byte sPsyduckPose148
+.4byte sPsyduckPose149
+.4byte sPsyduckPose150
+.4byte sPsyduckPose151
+.4byte sPsyduckPose152
+.4byte sPsyduckPose153
+.4byte sPsyduckPose154
+.4byte sPsyduckPose155
+.4byte sPsyduckPose156
+.4byte sPsyduckPose157
+.4byte sPsyduckPose158
+.4byte sPsyduckPose159
+.4byte sPsyduckPose160
+.4byte sPsyduckPose161
+.4byte sPsyduckPose162
+.4byte sPsyduckPose163
+.4byte sPsyduckPose164
+.4byte sPsyduckPose165
+.4byte sPsyduckPose166
+.4byte sPsyduckPose167
+.4byte sPsyduckPose168
+.4byte sPsyduckPose169
+.4byte sPsyduckPose170
+.4byte sPsyduckPose171
+.4byte sPsyduckPose172
+.4byte sPsyduckPose173
+.4byte sPsyduckPose174
+.4byte sPsyduckPose175
+.4byte sPsyduckPose176
+.4byte sPsyduckPose177
+.4byte sPsyduckPose178
+.4byte sPsyduckPose179
+.4byte sPsyduckPose180
+.4byte sPsyduckPose181
+.4byte sPsyduckPose182
+.4byte sPsyduckPose183
+.4byte sPsyduckPose184
+.4byte sPsyduckPose185
+.4byte sPsyduckPose186
+.4byte sPsyduckPose187
+.4byte sPsyduckPose188
+.4byte sPsyduckPose189
+.4byte sPsyduckPose190
+.4byte sPsyduckPose191
+.4byte sPsyduckPose192
+.4byte sPsyduckPose193
+.4byte sPsyduckPose194
+.4byte sPsyduckPose195
+.4byte sPsyduckPose196
+.4byte sPsyduckPose197
+.4byte sPsyduckPose198
+.4byte sPsyduckPose199
+.4byte sPsyduckPose200
+.4byte sPsyduckPose201
+.4byte sPsyduckPose202
+.4byte sPsyduckPose203
+.4byte sPsyduckPose204
+.4byte sPsyduckPose205
+.4byte sPsyduckPose206
+.4byte sPsyduckPose207
+.4byte sPsyduckPose208
+.4byte sPsyduckPose209
+.4byte sPsyduckPose210
+.4byte sPsyduckPose211
+.4byte sPsyduckPose212
+.4byte sPsyduckPose213
+.4byte sPsyduckPose214
+.4byte sPsyduckPose215
+.4byte sPsyduckPose216
+.4byte sPsyduckPose217
+.4byte sPsyduckPose218
+.4byte sPsyduckPose219
+.4byte sPsyduckPose220
+.4byte sPsyduckPose221
+.4byte sPsyduckPose222
+.4byte sPsyduckPose223
+.4byte sPsyduckPose224
+.4byte sPsyduckPose225
+.4byte sPsyduckPose226
+.4byte sPsyduckPose227
+.4byte sPsyduckPose228
+.4byte sPsyduckPose229
+.4byte sPsyduckPose230
+.4byte sPsyduckPose231
+.4byte sPsyduckPose232
+.4byte sPsyduckPose233
+.4byte sPsyduckPose234
+.4byte sPsyduckPose235
+.4byte sPsyduckPose236
+.4byte sPsyduckPose237
+.4byte sPsyduckPose238
+.4byte sPsyduckPose239
+.4byte sPsyduckPose240
+.4byte sPsyduckPose241
+.4byte sPsyduckPose242
+.4byte sPsyduckPose243
+.4byte sPsyduckPose244
+.4byte sPsyduckPose245
+.4byte sPsyduckPose246
+.4byte sPsyduckPose247
+.4byte sPsyduckPose248
+.4byte sPsyduckPose249
+.4byte sPsyduckPose250
+.4byte sPsyduckPose251
+.4byte sPsyduckPose252
+.4byte sPsyduckPose253
+.4byte sPsyduckPose254
+.4byte sPsyduckPose255
+.4byte sPsyduckPose256
+.4byte sPsyduckPose257
+.4byte sPsyduckPose258
+.4byte sPsyduckPose259
+.4byte sPsyduckPose260
+.4byte sPsyduckPose261
+.4byte sPsyduckPose262
+.4byte sPsyduckPose263
+.4byte sPsyduckPose264
+.4byte sPsyduckPose265
+.4byte sPsyduckPose266
+.4byte sPsyduckPose267
+.4byte sPsyduckPose268
+.4byte sPsyduckPose269
+.4byte sPsyduckPose270
+.4byte sPsyduckPose271
+.4byte sPsyduckPose272
+.4byte sPsyduckPose273
+.4byte sPsyduckPose274
+.4byte sPsyduckPose275
+.4byte sPsyduckPose276
+.4byte sPsyduckPose277
+.4byte sPsyduckPose278
+.4byte sPsyduckPose279
+.4byte sPsyduckPose280
+.4byte sPsyduckPose281
+.4byte sPsyduckPose282
+.4byte sPsyduckPose283
+.4byte sPsyduckPose284
+.4byte sPsyduckPose285
+.4byte sPsyduckPose286
+.4byte sPsyduckPose287
+.4byte sPsyduckPose288
+.4byte sPsyduckPose289
+.4byte sPsyduckPose290
+.4byte sPsyduckPose291
+.4byte sPsyduckPose292
+.4byte sPsyduckPose293
+.4byte sPsyduckPose294
+.4byte sPsyduckPose295
+.4byte sPsyduckPose296
+.4byte sPsyduckPose297
+.4byte sPsyduckPose298
+.4byte sPsyduckPose299
+.4byte sPsyduckPose300
+.4byte sPsyduckPose301
+.4byte sPsyduckPose302
+.4byte sPsyduckPose303
+.4byte sPsyduckPose304
+.4byte sPsyduckPose305
+.4byte sPsyduckPose306
+.4byte sPsyduckPose307
+sAxPositionsPsyduck:
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	 -10,   -5, 	   7,   -6, 	  -1,   -6
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte    3,   -6, 	   4,   -6, 	  -5,   -2, 	  -2,   -5
+.2byte    3,   -6, 	   5,   -4, 	  -8,   -4, 	  -2,   -5
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    5,   -9, 	  -5,   -5, 	   0,   -2, 	  -2,   -5
+.2byte    5,   -8, 	   1,   -4, 	  -5,   -2, 	  -3,   -5
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    6,   -9, 	  -8,   -4, 	   5,   -3, 	  -2,   -6
+.2byte    6,   -9, 	  -5,   -5, 	   1,   -1, 	  -2,   -6
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -8,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -6, 	  -8,   -4, 	   0,   -6
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -8,   -9, 	   6,   -4, 	  -7,   -3, 	   0,   -6
+.2byte   -8,   -9, 	   3,   -5, 	  -3,   -1, 	   0,   -6
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -7,   -9, 	   3,   -5, 	  -2,   -2, 	   0,   -5
+.2byte   -7,   -8, 	  -3,   -4, 	   3,   -2, 	   1,   -5
+.2byte   -5,   -7, 	  -7,   -6, 	   5,   -4, 	   0,   -5
+.2byte   -5,   -6, 	  -6,   -6, 	   3,   -2, 	   0,   -5
+.2byte   -5,   -6, 	  -7,   -4, 	   6,   -4, 	   0,   -5
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	 -10,   -5, 	   7,   -6, 	  -1,   -6
+.2byte   -1,   -5, 	 -11,   -6, 	   9,   -6, 	  -1,   -8
+.2byte   -1,    0, 	 -10,   -7, 	   7,   -7, 	  -1,   -6
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte    3,   -6, 	   4,   -6, 	  -5,   -2, 	  -2,   -5
+.2byte    3,   -6, 	   5,   -4, 	  -8,   -4, 	  -2,   -5
+.2byte    5,   -6, 	   9,   -9, 	  -3,   -5, 	  -1,   -7
+.2byte    7,   -1, 	   6,   -6, 	  -8,   -5, 	  -1,   -6
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    5,   -9, 	  -5,   -5, 	   0,   -2, 	  -2,   -5
+.2byte    5,   -8, 	   1,   -4, 	  -5,   -2, 	  -3,   -5
+.2byte    8,  -10, 	   2,  -13, 	   2,   -8, 	  -3,  -10
+.2byte    5,   -3, 	  -3,  -12, 	  -5,   -7, 	  -1,   -9
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    6,   -9, 	  -8,   -4, 	   5,   -3, 	  -2,   -6
+.2byte    6,   -9, 	  -5,   -5, 	   1,   -1, 	  -2,   -6
+.2byte    8,  -10, 	  -2,  -12, 	   7,   -9, 	  -2,   -7
+.2byte    6,   -3, 	  -6,  -10, 	  -2,   -5, 	   0,   -9
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -8,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -6, 	  -8,   -4, 	   0,   -6
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte   -1,  -13, 	   6,   -7, 	  -8,   -6, 	  -1,  -10
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -8,   -9, 	   6,   -4, 	  -7,   -3, 	   0,   -6
+.2byte   -8,   -9, 	   3,   -5, 	  -3,   -1, 	   0,   -6
+.2byte  -10,  -10, 	   0,  -12, 	  -9,   -9, 	   0,   -7
+.2byte   -8,   -3, 	   4,  -10, 	   0,   -5, 	  -2,   -9
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -7,   -9, 	   3,   -5, 	  -2,   -2, 	   0,   -5
+.2byte   -7,   -8, 	  -3,   -4, 	   3,   -2, 	   1,   -5
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	   1,  -10
+.2byte   -7,   -3, 	   1,  -12, 	   3,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	  -6,   -6, 	   6,   -4, 	   1,   -5
+.2byte   -4,   -6, 	  -5,   -6, 	   4,   -2, 	   1,   -5
+.2byte   -4,   -6, 	  -6,   -4, 	   7,   -4, 	   1,   -5
+.2byte   -6,   -6, 	 -10,   -9, 	   2,   -5, 	   0,   -7
+.2byte   -8,   -1, 	  -7,   -6, 	   7,   -5, 	   0,   -6
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	 -10,   -5, 	   7,   -6, 	  -1,   -6
+.2byte   -2,   -5, 	 -10,  -13, 	   2,   -1, 	  -2,   -8
+.2byte   -1,   -5, 	  -9,  -13, 	   3,   -1, 	  -1,   -8
+.2byte    0,   -5, 	  -4,   -1, 	   8,  -13, 	   0,   -8
+.2byte    0,   -5, 	  -4,   -1, 	   8,  -13, 	   0,   -8
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte    3,   -6, 	   4,   -6, 	  -5,   -2, 	  -2,   -5
+.2byte    3,   -6, 	   5,   -4, 	  -8,   -4, 	  -2,   -5
+.2byte    4,   -6, 	   7,  -16, 	  -2,    0, 	   0,   -6
+.2byte    4,   -6, 	   7,  -16, 	  -2,    0, 	   0,   -6
+.2byte    3,   -6, 	   5,    0, 	  -8,  -12, 	  -1,   -5
+.2byte    3,   -6, 	   5,    0, 	  -8,  -12, 	  -1,   -5
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    5,   -9, 	  -5,   -5, 	   0,   -2, 	  -2,   -5
+.2byte    5,   -8, 	   1,   -4, 	  -5,   -2, 	  -3,   -5
+.2byte    6,   -8, 	   4,  -16, 	   3,   -1, 	  -1,   -6
+.2byte    6,   -8, 	   4,  -16, 	   3,   -1, 	  -1,   -6
+.2byte    5,   -8, 	   4,   -4, 	  -6,  -12, 	  -2,   -6
+.2byte    5,   -8, 	   4,   -4, 	  -6,  -12, 	  -2,   -6
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    6,   -9, 	  -8,   -4, 	   5,   -3, 	  -2,   -6
+.2byte    6,   -9, 	  -5,   -5, 	   1,   -1, 	  -2,   -6
+.2byte    6,   -7, 	  -6,  -14, 	   6,   -3, 	  -1,   -6
+.2byte    6,   -7, 	  -6,  -14, 	   6,   -3, 	  -1,   -6
+.2byte    5,   -9, 	  -2,   -6, 	   3,  -12, 	  -3,   -6
+.2byte    5,   -9, 	  -2,   -6, 	   3,  -12, 	  -3,   -6
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -8,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -6, 	  -8,   -4, 	   0,   -6
+.2byte    3,  -13, 	   7,  -14, 	  -2,   -6, 	   0,   -7
+.2byte    3,  -13, 	   7,  -14, 	  -2,   -6, 	   0,   -7
+.2byte   -4,  -12, 	   2,   -5, 	  -9,  -13, 	  -2,   -6
+.2byte   -4,  -12, 	   2,   -5, 	  -9,  -13, 	  -2,   -6
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -8,   -9, 	   6,   -4, 	  -7,   -3, 	   0,   -6
+.2byte   -8,   -9, 	   3,   -5, 	  -3,   -1, 	   0,   -6
+.2byte   -8,   -7, 	   4,  -14, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,   -7, 	   4,  -14, 	  -8,   -3, 	  -1,   -6
+.2byte   -7,   -9, 	   0,   -6, 	  -5,  -12, 	   1,   -6
+.2byte   -7,   -9, 	   0,   -6, 	  -5,  -12, 	   1,   -6
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -7,   -9, 	   3,   -5, 	  -2,   -2, 	   0,   -5
+.2byte   -7,   -8, 	  -3,   -4, 	   3,   -2, 	   1,   -5
+.2byte   -8,   -8, 	  -6,  -16, 	  -5,   -1, 	  -1,   -6
+.2byte   -8,   -8, 	  -6,  -16, 	  -5,   -1, 	  -1,   -6
+.2byte   -7,   -8, 	  -6,   -4, 	   4,  -12, 	   0,   -6
+.2byte   -7,   -8, 	  -6,   -4, 	   4,  -12, 	   0,   -6
+.2byte   -5,   -7, 	  -7,   -6, 	   5,   -4, 	   0,   -5
+.2byte   -5,   -6, 	  -6,   -6, 	   3,   -2, 	   0,   -5
+.2byte   -5,   -6, 	  -7,   -4, 	   6,   -4, 	   0,   -5
+.2byte   -6,   -6, 	  -9,  -16, 	   0,    0, 	  -2,   -6
+.2byte   -6,   -6, 	  -9,  -16, 	   0,    0, 	  -2,   -6
+.2byte   -5,   -6, 	  -7,    0, 	   6,  -12, 	  -1,   -5
+.2byte   -5,   -6, 	  -7,    0, 	   6,  -12, 	  -1,   -5
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	 -10,   -5, 	   7,   -6, 	  -1,   -6
+.2byte   -1,   -5, 	 -10,   -7, 	   8,   -7, 	  -1,   -7
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte    3,   -6, 	   4,   -6, 	  -5,   -2, 	  -2,   -5
+.2byte    3,   -6, 	   5,   -4, 	  -8,   -4, 	  -2,   -5
+.2byte    2,   -5, 	   8,   -6, 	  -9,   -4, 	   0,   -6
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    5,   -9, 	  -5,   -5, 	   0,   -2, 	  -2,   -5
+.2byte    5,   -8, 	   1,   -4, 	  -5,   -2, 	  -3,   -5
+.2byte    4,   -7, 	  -4,   -8, 	  -6,   -4, 	  -3,   -6
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    6,   -9, 	  -8,   -4, 	   5,   -3, 	  -2,   -6
+.2byte    6,   -9, 	  -5,   -5, 	   1,   -1, 	  -2,   -6
+.2byte    5,   -9, 	  -9,   -9, 	   1,   -5, 	  -3,   -6
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -8,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -6, 	  -8,   -4, 	   0,   -6
+.2byte   -1,  -13, 	   9,   -9, 	 -11,   -9, 	  -1,   -7
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -8,   -9, 	   6,   -4, 	  -7,   -3, 	   0,   -6
+.2byte   -8,   -9, 	   3,   -5, 	  -3,   -1, 	   0,   -6
+.2byte   -7,   -9, 	   7,   -9, 	  -3,   -5, 	   1,   -6
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -7,   -9, 	   3,   -5, 	  -2,   -2, 	   0,   -5
+.2byte   -7,   -8, 	  -3,   -4, 	   3,   -2, 	   1,   -5
+.2byte   -6,   -7, 	   2,   -8, 	   4,   -4, 	   1,   -6
+.2byte   -5,   -7, 	  -7,   -6, 	   5,   -4, 	   0,   -5
+.2byte   -5,   -6, 	  -6,   -6, 	   3,   -2, 	   0,   -5
+.2byte   -5,   -6, 	  -7,   -4, 	   6,   -4, 	   0,   -5
+.2byte   -4,   -5, 	 -10,   -6, 	   7,   -4, 	  -2,   -6
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -5,   -7, 	  -7,   -6, 	   5,   -4, 	   0,   -5
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte   -4,   -7, 	  -5,   -4, 	   7,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -5,   -4, 	   6,   -1, 	   0,   -6
+.2byte   -1,  -10, 	  -5,  -15, 	   2,  -15, 	  -1,   -8
+.2byte    1,  -10, 	   2,  -16, 	  -2,  -13, 	  -1,   -6
+.2byte    4,  -11, 	   1,  -16, 	  -1,  -13, 	   0,   -7
+.2byte    5,  -13, 	   0,  -16, 	   3,  -13, 	  -2,   -7
+.2byte   -1,  -14, 	   4,  -14, 	  -5,  -14, 	   0,   -8
+.2byte   -6,  -13, 	  -1,  -16, 	  -4,  -13, 	   1,   -7
+.2byte   -5,  -11, 	  -2,  -16, 	   0,  -13, 	  -1,   -7
+.2byte   -2,  -10, 	  -3,  -16, 	   1,  -13, 	   0,   -6
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,   -6, 	   8,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	 -10,   -5, 	   7,   -6, 	  -1,   -6
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte    3,   -6, 	   4,   -6, 	  -5,   -2, 	  -2,   -5
+.2byte    3,   -6, 	   5,   -4, 	  -8,   -4, 	  -2,   -5
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    5,   -9, 	  -5,   -5, 	   0,   -2, 	  -2,   -5
+.2byte    5,   -8, 	   1,   -4, 	  -5,   -2, 	  -3,   -5
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    6,   -9, 	  -8,   -4, 	   5,   -3, 	  -2,   -6
+.2byte    6,   -9, 	  -5,   -5, 	   1,   -1, 	  -2,   -6
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -8,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -6, 	  -8,   -4, 	   0,   -6
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -8,   -9, 	   6,   -4, 	  -7,   -3, 	   0,   -6
+.2byte   -8,   -9, 	   3,   -5, 	  -3,   -1, 	   0,   -6
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -7,   -9, 	   3,   -5, 	  -2,   -2, 	   0,   -5
+.2byte   -7,   -8, 	  -3,   -4, 	   3,   -2, 	   1,   -5
+.2byte   -5,   -7, 	  -7,   -6, 	   5,   -4, 	   0,   -5
+.2byte   -5,   -6, 	  -6,   -6, 	   3,   -2, 	   0,   -5
+.2byte   -5,   -6, 	  -7,   -4, 	   6,   -4, 	   0,   -5
+.2byte   -1,   -5, 	 -11,   -6, 	   9,   -6, 	  -1,   -8
+.2byte   -8,   -6, 	 -12,   -9, 	   0,   -5, 	  -2,   -7
+.2byte  -12,   -8, 	  -6,  -11, 	  -6,   -6, 	  -1,   -8
+.2byte  -10,  -10, 	   0,  -12, 	  -9,   -9, 	   0,   -7
+.2byte   -1,  -14, 	   7,  -12, 	  -9,  -12, 	  -1,   -8
+.2byte    8,  -10, 	  -2,  -12, 	   7,   -9, 	  -2,   -7
+.2byte   10,   -8, 	   4,  -11, 	   4,   -6, 	  -1,   -8
+.2byte    6,   -6, 	  10,   -9, 	  -2,   -5, 	   0,   -7
+.2byte   -2,   -5, 	 -10,  -13, 	   2,   -1, 	  -2,   -8
+.2byte    4,   -6, 	   7,  -16, 	  -2,    0, 	   0,   -6
+.2byte    6,   -8, 	   4,  -16, 	   3,   -1, 	  -1,   -6
+.2byte    6,   -7, 	  -6,  -14, 	   6,   -3, 	  -1,   -6
+.2byte    3,  -13, 	   7,  -14, 	  -2,   -6, 	   0,   -7
+.2byte   -8,   -7, 	   4,  -14, 	  -8,   -3, 	  -1,   -6
+.2byte   -8,   -8, 	  -6,  -16, 	  -5,   -1, 	  -1,   -6
+.2byte   -6,   -6, 	  -9,  -16, 	   0,    0, 	  -2,   -6
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -1,   -4, 	 -11,   -5, 	   9,   -5, 	  -1,   -7
+.2byte   -1,    1, 	 -10,   -6, 	   7,   -6, 	  -1,   -5
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte    5,   -5, 	   9,   -8, 	  -3,   -4, 	  -1,   -6
+.2byte    7,    0, 	   6,   -5, 	  -8,   -4, 	  -1,   -5
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    8,   -9, 	   2,  -12, 	   2,   -7, 	  -3,   -9
+.2byte    4,   -2, 	  -4,  -11, 	  -6,   -6, 	  -2,   -8
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    8,   -9, 	  -2,  -11, 	   7,   -8, 	  -2,   -6
+.2byte    6,   -2, 	  -6,   -9, 	  -2,   -4, 	   0,   -8
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,  -13, 	   7,  -11, 	  -9,  -11, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -6, 	  -8,   -5, 	  -1,   -9
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -9,   -9, 	   1,  -11, 	  -8,   -8, 	   1,   -6
+.2byte   -7,   -2, 	   5,   -9, 	   1,   -4, 	  -1,   -8
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -9,   -9, 	  -3,  -12, 	  -3,   -7, 	   2,   -9
+.2byte   -5,   -2, 	   3,  -11, 	   5,   -6, 	   1,   -8
+.2byte   -5,   -7, 	  -7,   -6, 	   5,   -4, 	   0,   -5
+.2byte   -6,   -5, 	 -10,   -8, 	   2,   -4, 	   0,   -6
+.2byte   -8,    0, 	  -7,   -5, 	   7,   -4, 	   0,   -5
+.2byte    0,   -5, 	  -4,   -1, 	   8,  -13, 	   0,   -8
+.2byte   -5,   -6, 	  -7,    0, 	   6,  -12, 	  -1,   -5
+.2byte   -7,   -8, 	  -6,   -4, 	   4,  -12, 	   0,   -6
+.2byte   -7,   -9, 	   0,   -6, 	  -5,  -12, 	   1,   -6
+.2byte   -4,  -12, 	   2,   -5, 	  -9,  -13, 	  -2,   -6
+.2byte    5,   -9, 	  -2,   -6, 	   3,  -12, 	  -3,   -6
+.2byte    5,   -8, 	   4,   -4, 	  -6,  -12, 	  -2,   -6
+.2byte    3,   -6, 	   5,    0, 	  -8,  -12, 	  -1,   -5
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -5,   -7, 	  -7,   -6, 	   5,   -4, 	   0,   -5
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -8,  -10, 	   5,   -6, 	  -7,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte    6,  -10, 	  -7,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    3,   -7, 	   5,   -6, 	  -7,   -4, 	  -2,   -5
+.2byte   -3,  -10, 	  -8,    1, 	  -7,   -7, 	  -3,   -6
+.2byte   -4,   -9, 	  -8,    1, 	  -7,   -7, 	  -3,   -6
+.2byte    2,  -10, 	   7,    1, 	   6,   -7, 	   2,   -6
+.2byte    3,   -9, 	   7,    1, 	   6,   -7, 	   2,   -6
+.2byte   -3,  -10, 	  -8,    1, 	  -7,   -7, 	  -3,   -6
+.2byte    1,  -10, 	   0,   -6, 	   6,   -9, 	  -2,   -6
+.2byte    3,   -6, 	  -1,   -1, 	   3,   -3, 	  -1,   -6
+.2byte    4,   -7, 	   0,   -2, 	   3,   -4, 	   0,   -7
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,   -8, 	   8,   -6, 	 -10,   -6, 	  -1,   -9
+.2byte   -1,   -7, 	  10,   -6, 	 -12,   -6, 	  -1,  -10
+.2byte   -1,   -5, 	 -10,   -8, 	   8,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	 -10,  -13, 	   8,  -13, 	  -1,   -9
+.2byte   -2,   -7, 	  -8,   -7, 	   6,   -6, 	   0,   -9
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -8, 	  -8,  -15, 	   9,   -6, 	   0,   -9
+.2byte    5,   -9, 	   8,   -4, 	  -8,   -8, 	   0,   -8
+.2byte   -1,  -11, 	   7,  -13, 	 -10,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	   7,  -13, 	 -10,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	  -7,   -7, 	   5,   -7, 	  -1,   -9
+.2byte   -1,   -6, 	  -7,   -6, 	   5,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -6, 	   5,   -6, 	  -1,   -8
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -3,  -12, 	  -9,   -8, 	  -1,   -6, 	  -1,   -7
+.2byte    0,  -13, 	  -8,  -12, 	   9,   -4, 	   1,   -8
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -4, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,   -6, 	   8,   -2, 	 -10,   -2, 	  -1,   -5
+.2byte   -1,   -6, 	  -9,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -1,  -10, 	 -10,  -13, 	   8,  -13, 	  -1,   -9
+.2byte   -1,   -7, 	  -4,   -5, 	   2,   -5, 	  -1,   -9
+.2byte   -7,  -10, 	  -2,   -6, 	   1,   -3, 	   0,   -5
+.2byte   -8,   -6, 	  -2,   -5, 	   1,   -3, 	  -2,   -8
+.2byte    5,  -10, 	   0,   -6, 	  -3,   -3, 	  -2,   -5
+.2byte    6,   -6, 	   0,   -5, 	  -3,   -3, 	   0,   -8
+.2byte   -1,  -13, 	   7,   -5, 	  -9,   -6, 	  -1,   -7
+.2byte    0,  -10, 	   8,  -11, 	 -10,  -11, 	   0,   -7
+.2byte   -5,   -7, 	  -2,   -6, 	   5,   -4, 	  -1,   -6
+.2byte   -3,   -8, 	  -2,   -7, 	   7,   -4, 	   1,   -7
+.2byte   -7,   -7, 	  -6,   -6, 	   4,   -4, 	  -3,   -7
+.2byte   -3,   -8, 	  -2,   -6, 	   7,   -4, 	   0,   -7
+.2byte   -7,   -7, 	  -1,   -6, 	   4,   -4, 	  -3,   -7
+.2byte    4,   -7, 	   1,   -6, 	  -6,   -4, 	   0,   -6
+.2byte    2,   -8, 	   1,   -7, 	  -8,   -4, 	  -2,   -7
+.2byte    6,   -7, 	   5,   -6, 	  -5,   -4, 	   2,   -7
+.2byte    2,   -8, 	   1,   -6, 	  -8,   -4, 	  -1,   -7
+.2byte    6,   -7, 	   0,   -6, 	  -5,   -4, 	   2,   -7
+.2byte    2,   -8, 	  -3,  -11, 	   7,   -9, 	  -2,   -7
+.2byte   -3,  -10, 	  -8,    1, 	  -7,   -7, 	  -3,   -6
+.2byte   -4,   -9, 	  -8,    1, 	  -7,   -7, 	  -3,   -6
+.2byte    2,  -10, 	   7,    1, 	   6,   -7, 	   2,   -6
+.2byte    3,   -9, 	   7,    1, 	   6,   -7, 	   2,   -6
+.2byte   -3,  -10, 	  -8,    1, 	  -7,   -7, 	  -3,   -6
+.2byte   -4,   -9, 	  -8,    1, 	  -7,   -7, 	  -3,   -6
+.2byte    2,  -10, 	   7,    1, 	   6,   -7, 	   2,   -6
+.2byte    3,   -9, 	   7,    1, 	   6,   -7, 	   2,   -6
+sPsyduckAnimTable1:
+.4byte sPsyduckAnims_1_1
+.4byte sPsyduckAnims_1_2
+.4byte sPsyduckAnims_1_3
+.4byte sPsyduckAnims_1_4
+.4byte sPsyduckAnims_1_5
+.4byte sPsyduckAnims_1_6
+.4byte sPsyduckAnims_1_7
+.4byte sPsyduckAnims_1_8
+sPsyduckAnimTable2:
+.4byte sPsyduckAnims_2_1
+.4byte sPsyduckAnims_2_2
+.4byte sPsyduckAnims_2_3
+.4byte sPsyduckAnims_2_4
+.4byte sPsyduckAnims_2_5
+.4byte sPsyduckAnims_2_6
+.4byte sPsyduckAnims_2_7
+.4byte sPsyduckAnims_2_8
+sPsyduckAnimTable3:
+.4byte sPsyduckAnims_3_1
+.4byte sPsyduckAnims_3_2
+.4byte sPsyduckAnims_3_3
+.4byte sPsyduckAnims_3_4
+.4byte sPsyduckAnims_3_5
+.4byte sPsyduckAnims_3_6
+.4byte sPsyduckAnims_3_7
+.4byte sPsyduckAnims_3_8
+sPsyduckAnimTable4:
+.4byte sPsyduckAnims_4_1
+.4byte sPsyduckAnims_4_2
+.4byte sPsyduckAnims_4_3
+.4byte sPsyduckAnims_4_4
+.4byte sPsyduckAnims_4_5
+.4byte sPsyduckAnims_4_6
+.4byte sPsyduckAnims_4_7
+.4byte sPsyduckAnims_4_8
+sPsyduckAnimTable5:
+.4byte sPsyduckAnims_5_1
+.4byte sPsyduckAnims_5_2
+.4byte sPsyduckAnims_5_3
+.4byte sPsyduckAnims_5_4
+.4byte sPsyduckAnims_5_5
+.4byte sPsyduckAnims_5_6
+.4byte sPsyduckAnims_5_7
+.4byte sPsyduckAnims_5_8
+sPsyduckAnimTable6:
+.4byte sPsyduckAnims_6_1
+.4byte sPsyduckAnims_6_1
+.4byte sPsyduckAnims_6_1
+.4byte sPsyduckAnims_6_1
+.4byte sPsyduckAnims_6_1
+.4byte sPsyduckAnims_6_1
+.4byte sPsyduckAnims_6_1
+.4byte sPsyduckAnims_6_1
+sPsyduckAnimTable7:
+.4byte sPsyduckAnims_7_1
+.4byte sPsyduckAnims_7_2
+.4byte sPsyduckAnims_7_3
+.4byte sPsyduckAnims_7_4
+.4byte sPsyduckAnims_7_5
+.4byte sPsyduckAnims_7_6
+.4byte sPsyduckAnims_7_7
+.4byte sPsyduckAnims_7_8
+sPsyduckAnimTable8:
+.4byte sPsyduckAnims_8_1
+.4byte sPsyduckAnims_8_2
+.4byte sPsyduckAnims_8_3
+.4byte sPsyduckAnims_8_4
+.4byte sPsyduckAnims_8_5
+.4byte sPsyduckAnims_8_6
+.4byte sPsyduckAnims_8_7
+.4byte sPsyduckAnims_8_8
+sPsyduckAnimTable9:
+.4byte sPsyduckAnims_9_1
+.4byte sPsyduckAnims_9_2
+.4byte sPsyduckAnims_9_3
+.4byte sPsyduckAnims_9_4
+.4byte sPsyduckAnims_9_5
+.4byte sPsyduckAnims_9_6
+.4byte sPsyduckAnims_9_7
+.4byte sPsyduckAnims_9_8
+sPsyduckAnimTable10:
+.4byte sPsyduckAnims_10_1
+.4byte sPsyduckAnims_10_2
+.4byte sPsyduckAnims_10_3
+.4byte sPsyduckAnims_10_4
+.4byte sPsyduckAnims_10_5
+.4byte sPsyduckAnims_10_6
+.4byte sPsyduckAnims_10_7
+.4byte sPsyduckAnims_10_8
+sPsyduckAnimTable11:
+.4byte sPsyduckAnims_11_1
+.4byte sPsyduckAnims_11_2
+.4byte sPsyduckAnims_11_3
+.4byte sPsyduckAnims_11_4
+.4byte sPsyduckAnims_11_5
+.4byte sPsyduckAnims_11_6
+.4byte sPsyduckAnims_11_7
+.4byte sPsyduckAnims_11_8
+sPsyduckAnimTable12:
+.4byte sPsyduckAnims_12_1
+.4byte sPsyduckAnims_12_2
+.4byte sPsyduckAnims_12_3
+.4byte sPsyduckAnims_12_4
+.4byte sPsyduckAnims_12_5
+.4byte sPsyduckAnims_12_6
+.4byte sPsyduckAnims_12_7
+.4byte sPsyduckAnims_12_8
+sPsyduckAnimTable13:
+.4byte sPsyduckAnims_13_1
+.4byte sPsyduckAnims_13_2
+.4byte sPsyduckAnims_13_3
+.4byte sPsyduckAnims_13_4
+.4byte sPsyduckAnims_13_5
+.4byte sPsyduckAnims_13_6
+.4byte sPsyduckAnims_13_7
+.4byte sPsyduckAnims_13_8
+sPsyduckAnimTable14:
+.4byte sPsyduckAnims_14_1
+.4byte sPsyduckAnims_14_2
+.4byte sPsyduckAnims_14_3
+.4byte sPsyduckAnims_14_4
+.4byte sPsyduckAnims_14_5
+.4byte sPsyduckAnims_14_6
+.4byte sPsyduckAnims_14_7
+.4byte sPsyduckAnims_14_8
+sPsyduckAnimTable15:
+.4byte sPsyduckAnims_15_1
+.4byte sPsyduckAnims_15_2
+.4byte sPsyduckAnims_15_3
+.4byte sPsyduckAnims_15_4
+.4byte sPsyduckAnims_15_5
+.4byte sPsyduckAnims_15_6
+.4byte sPsyduckAnims_15_7
+.4byte sPsyduckAnims_15_8
+sPsyduckAnimTable16:
+.4byte sPsyduckAnims_16_1
+.4byte sPsyduckAnims_16_2
+.4byte sPsyduckAnims_16_3
+.4byte sPsyduckAnims_16_4
+.4byte sPsyduckAnims_16_5
+.4byte sPsyduckAnims_16_6
+.4byte sPsyduckAnims_16_7
+.4byte sPsyduckAnims_16_8
+sPsyduckAnimTable17:
+.4byte sPsyduckAnims_17_1
+.4byte sPsyduckAnims_17_2
+.4byte sPsyduckAnims_17_3
+.4byte sPsyduckAnims_17_4
+.4byte sPsyduckAnims_17_5
+.4byte sPsyduckAnims_17_6
+.4byte sPsyduckAnims_17_7
+.4byte sPsyduckAnims_17_8
+sPsyduckAnimTable18:
+.4byte sPsyduckAnims_18_1
+.4byte sPsyduckAnims_18_2
+.4byte sPsyduckAnims_18_3
+.4byte sPsyduckAnims_18_4
+.4byte sPsyduckAnims_18_5
+.4byte sPsyduckAnims_18_6
+.4byte sPsyduckAnims_18_7
+.4byte sPsyduckAnims_18_8
+sPsyduckAnimTable19:
+.4byte sPsyduckAnims_19_1
+.4byte sPsyduckAnims_19_2
+.4byte sPsyduckAnims_19_3
+.4byte sPsyduckAnims_19_4
+.4byte sPsyduckAnims_19_5
+.4byte sPsyduckAnims_19_6
+.4byte sPsyduckAnims_19_7
+.4byte sPsyduckAnims_19_8
+sPsyduckAnimTable20:
+.4byte sPsyduckAnims_20_1
+.4byte sPsyduckAnims_20_2
+.4byte sPsyduckAnims_20_3
+.4byte sPsyduckAnims_20_4
+.4byte sPsyduckAnims_20_5
+.4byte sPsyduckAnims_20_6
+.4byte sPsyduckAnims_20_7
+.4byte sPsyduckAnims_20_8
+sPsyduckAnimTable21:
+.4byte sPsyduckAnims_21_1
+.4byte sPsyduckAnims_21_2
+.4byte sPsyduckAnims_21_3
+.4byte sPsyduckAnims_21_4
+.4byte sPsyduckAnims_21_5
+.4byte sPsyduckAnims_21_6
+.4byte sPsyduckAnims_21_7
+.4byte sPsyduckAnims_21_8
+sPsyduckAnimTable22:
+.4byte sPsyduckAnims_22_1
+.4byte sPsyduckAnims_22_2
+.4byte sPsyduckAnims_22_3
+.4byte sPsyduckAnims_22_4
+.4byte sPsyduckAnims_22_5
+.4byte sPsyduckAnims_22_6
+.4byte sPsyduckAnims_22_7
+.4byte sPsyduckAnims_22_8
+sPsyduckAnimTable23:
+.4byte sPsyduckAnims_23_1
+.4byte sPsyduckAnims_23_2
+.4byte sPsyduckAnims_23_3
+.4byte sPsyduckAnims_23_4
+.4byte sPsyduckAnims_23_5
+.4byte sPsyduckAnims_23_6
+.4byte sPsyduckAnims_23_7
+.4byte sPsyduckAnims_23_8
+sPsyduckAnimTable24:
+.4byte sPsyduckAnims_24_1
+.4byte sPsyduckAnims_24_2
+.4byte sPsyduckAnims_24_3
+.4byte sPsyduckAnims_24_4
+.4byte sPsyduckAnims_24_5
+.4byte sPsyduckAnims_24_6
+.4byte sPsyduckAnims_24_7
+.4byte sPsyduckAnims_24_8
+sPsyduckAnimTable25:
+.4byte sPsyduckAnims_25_1
+.4byte sPsyduckAnims_25_2
+.4byte sPsyduckAnims_25_3
+.4byte sPsyduckAnims_25_4
+.4byte sPsyduckAnims_25_5
+.4byte sPsyduckAnims_25_6
+.4byte sPsyduckAnims_25_7
+.4byte sPsyduckAnims_25_8
+sPsyduckAnimTable26:
+.4byte sPsyduckAnims_26_1
+.4byte sPsyduckAnims_26_2
+.4byte sPsyduckAnims_26_3
+.4byte sPsyduckAnims_26_4
+.4byte sPsyduckAnims_26_5
+.4byte sPsyduckAnims_26_6
+.4byte sPsyduckAnims_26_7
+.4byte sPsyduckAnims_26_8
+sPsyduckAnimTable27:
+.4byte sPsyduckAnims_27_1
+.4byte sPsyduckAnims_27_1
+.4byte sPsyduckAnims_27_1
+.4byte sPsyduckAnims_27_1
+.4byte sPsyduckAnims_27_1
+.4byte sPsyduckAnims_27_1
+.4byte sPsyduckAnims_27_1
+.4byte sPsyduckAnims_27_1
+sPsyduckAnimTable28:
+.4byte sPsyduckAnims_28_1
+.4byte sPsyduckAnims_28_2
+.4byte sPsyduckAnims_28_3
+.4byte sPsyduckAnims_28_4
+.4byte sPsyduckAnims_28_5
+.4byte sPsyduckAnims_28_6
+.4byte sPsyduckAnims_28_7
+.4byte sPsyduckAnims_28_8
+sAxAnimationsPsyduck:
+.4byte sPsyduckAnimTable1
+.4byte sPsyduckAnimTable2
+.4byte sPsyduckAnimTable3
+.4byte sPsyduckAnimTable4
+.4byte sPsyduckAnimTable5
+.4byte sPsyduckAnimTable6
+.4byte sPsyduckAnimTable7
+.4byte sPsyduckAnimTable8
+.4byte sPsyduckAnimTable9
+.4byte sPsyduckAnimTable10
+.4byte sPsyduckAnimTable11
+.4byte sPsyduckAnimTable12
+.4byte sPsyduckAnimTable13
+.4byte sPsyduckAnimTable14
+.4byte sPsyduckAnimTable15
+.4byte sPsyduckAnimTable16
+.4byte sPsyduckAnimTable17
+.4byte sPsyduckAnimTable18
+.4byte sPsyduckAnimTable19
+.4byte sPsyduckAnimTable20
+.4byte sPsyduckAnimTable21
+.4byte sPsyduckAnimTable22
+.4byte sPsyduckAnimTable23
+.4byte sPsyduckAnimTable24
+.4byte sPsyduckAnimTable25
+.4byte sPsyduckAnimTable26
+.4byte sPsyduckAnimTable27
+.4byte sPsyduckAnimTable28
+sAxSpritesPsyduck:
+.4byte sPsyduckSprites1
+.4byte sPsyduckSprites2
+.4byte sPsyduckSprites3
+.4byte sPsyduckSprites4
+.4byte sPsyduckSprites5
+.4byte sPsyduckSprites6
+.4byte sPsyduckSprites7
+.4byte sPsyduckSprites8
+.4byte sPsyduckSprites9
+.4byte sPsyduckSprites10
+.4byte sPsyduckSprites11
+.4byte sPsyduckSprites12
+.4byte sPsyduckSprites13
+.4byte sPsyduckSprites14
+.4byte sPsyduckSprites15
+.4byte sPsyduckSprites16
+.4byte sPsyduckSprites17
+.4byte sPsyduckSprites18
+.4byte sPsyduckSprites19
+.4byte sPsyduckSprites20
+.4byte sPsyduckSprites21
+.4byte sPsyduckSprites22
+.4byte sPsyduckSprites23
+.4byte sPsyduckSprites24
+.4byte sPsyduckSprites25
+.4byte sPsyduckSprites26
+.4byte sPsyduckSprites27
+.4byte sPsyduckSprites28
+.4byte sPsyduckSprites29
+.4byte sPsyduckSprites30
+.4byte sPsyduckSprites31
+.4byte sPsyduckSprites32
+.4byte sPsyduckSprites33
+.4byte sPsyduckSprites34
+.4byte sPsyduckSprites35
+.4byte sPsyduckSprites36
+.4byte sPsyduckSprites37
+.4byte sPsyduckSprites38
+.4byte sPsyduckSprites39
+.4byte sPsyduckSprites40
+.4byte sPsyduckSprites41
+.4byte sPsyduckSprites42
+.4byte sPsyduckSprites43
+.4byte sPsyduckSprites44
+.4byte sPsyduckSprites45
+.4byte sPsyduckSprites46
+.4byte sPsyduckSprites47
+.4byte sPsyduckSprites48
+.4byte sPsyduckSprites49
+.4byte sPsyduckSprites50
+.4byte sPsyduckSprites51
+.4byte sPsyduckSprites52
+.4byte sPsyduckSprites53
+.4byte sPsyduckSprites54
+.4byte sPsyduckSprites55
+.4byte sPsyduckSprites56
+.4byte sPsyduckSprites57
+.4byte sPsyduckSprites58
+.4byte sPsyduckSprites59
+.4byte sPsyduckSprites60
+.4byte sPsyduckSprites61
+.4byte sPsyduckSprites62
+.4byte sPsyduckSprites63
+.4byte sPsyduckSprites64
+.4byte sPsyduckSprites65
+.4byte sPsyduckSprites66
+.4byte sPsyduckSprites67
+.4byte sPsyduckSprites68
+.4byte sPsyduckSprites69
+.4byte sPsyduckSprites70
+.4byte sPsyduckSprites71
+.4byte sPsyduckSprites72
+.4byte sPsyduckSprites73
+.4byte sPsyduckSprites74
+.4byte sPsyduckSprites75
+.4byte sPsyduckSprites76
+.4byte sPsyduckSprites77
+.4byte sPsyduckSprites78
+.4byte sPsyduckSprites79
+.4byte sPsyduckSprites80
+.4byte sPsyduckSprites81
+.4byte sPsyduckSprites82
+.4byte sPsyduckSprites83
+.4byte sPsyduckSprites84
+.4byte sPsyduckSprites85
+sAxMainPsyduck:
+ax_main sAxPosesPsyduck, sAxAnimationsPsyduck, 28, sAxSpritesPsyduck, sAxPositionsPsyduck

--- a/data/ax/pupitar.inc
+++ b/data/ax/pupitar.inc
@@ -1,0 +1,2346 @@
+.global gAxPupitar
+gAxPupitar:
+ax_siro sAxMainPupitar
+sPupitarPose1:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose4:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose5:
+ax_pose 4, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose6:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose7:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose8:
+ax_pose 7, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose9:
+ax_pose 8, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose10:
+ax_pose 9, 0x01e8, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose11:
+ax_pose 10, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose12:
+ax_pose 11, 0x01e8, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose13:
+ax_pose 12, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose14:
+ax_pose 13, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose16:
+ax_pose 9, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose17:
+ax_pose 10, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose18:
+ax_pose 11, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose19:
+ax_pose 6, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose20:
+ax_pose 7, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose21:
+ax_pose 8, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose22:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose24:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose25:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose26:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose27:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose28:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose29:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose30:
+ax_pose 5, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose31:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose32:
+ax_pose 7, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose33:
+ax_pose 8, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose34:
+ax_pose 9, 0x01e8, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose35:
+ax_pose 10, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose36:
+ax_pose 11, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPupitarPose37:
+ax_pose 12, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose38:
+ax_pose 13, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose39:
+ax_pose 14, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose40:
+ax_pose 9, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose41:
+ax_pose 10, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose42:
+ax_pose 11, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose43:
+ax_pose 6, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose44:
+ax_pose 7, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose45:
+ax_pose 8, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose46:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose47:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose48:
+ax_pose 5, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose49:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose50:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose51:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose52:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose53:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose54:
+ax_pose 5, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose55:
+ax_pose 6, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose56:
+ax_pose 7, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose57:
+ax_pose 8, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose58:
+ax_pose 9, 0x01e8, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose59:
+ax_pose 10, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose60:
+ax_pose 11, 0x01e8, 0x90ea, 0x0c00
+ax_pose_terminator
+sPupitarPose61:
+ax_pose 12, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose62:
+ax_pose 13, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose63:
+ax_pose 14, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose64:
+ax_pose 9, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose65:
+ax_pose 10, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose66:
+ax_pose 11, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose67:
+ax_pose 6, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose68:
+ax_pose 7, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose69:
+ax_pose 8, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose70:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose71:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose72:
+ax_pose 5, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose73:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose74:
+ax_pose 15, 0x81e5, 0x80f6, 0x0c00
+ax_pose 16, 0x81e5, 0x0106, 0x0c08
+ax_pose_terminator
+sPupitarPose75:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose76:
+ax_pose 17, 0x81e5, 0x90f9, 0x0c00
+ax_pose 18, 0x81e5, 0x50f1, 0x0c08
+ax_pose_terminator
+sPupitarPose77:
+ax_pose 6, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose78:
+ax_pose 19, 0x81e6, 0x90f6, 0x0c00
+ax_pose_terminator
+sPupitarPose79:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose80:
+ax_pose 20, 0x81e5, 0x90f8, 0x0c00
+ax_pose 21, 0x81e5, 0x50f0, 0x0c08
+ax_pose_terminator
+sPupitarPose81:
+ax_pose 12, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose82:
+ax_pose 22, 0x81e1, 0x80f5, 0x0c00
+ax_pose 23, 0x81e9, 0x0105, 0x0c08
+ax_pose_terminator
+sPupitarPose83:
+ax_pose 9, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose84:
+ax_pose 20, 0x81e5, 0x80f8, 0x0c00
+ax_pose 21, 0x81e5, 0x4108, 0x0c08
+ax_pose_terminator
+sPupitarPose85:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose86:
+ax_pose 19, 0x81e6, 0x80fa, 0x0c00
+ax_pose_terminator
+sPupitarPose87:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose88:
+ax_pose 17, 0x81e5, 0x80f7, 0x0c00
+ax_pose 18, 0x81e5, 0x4107, 0x0c08
+ax_pose_terminator
+sPupitarPose89:
+ax_pose 0, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose90:
+ax_pose 3, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sPupitarPose91:
+ax_pose 6, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sPupitarPose92:
+ax_pose 9, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sPupitarPose93:
+ax_pose 12, 0x01df, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose94:
+ax_pose 9, 0x01e4, 0x90ee, 0x0c00
+ax_pose_terminator
+sPupitarPose95:
+ax_pose 6, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sPupitarPose96:
+ax_pose 3, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sPupitarPose97:
+ax_pose 24, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose98:
+ax_pose 25, 0x01e8, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose99:
+ax_pose 26, 0x01e1, 0x80f0, 0x0c00
+ax_pose_terminator
+sPupitarPose100:
+ax_pose 27, 0x01e0, 0x90e8, 0x0c00
+ax_pose_terminator
+sPupitarPose101:
+ax_pose 28, 0x01e0, 0x90e8, 0x0c00
+ax_pose_terminator
+sPupitarPose102:
+ax_pose 29, 0x01e2, 0x90e7, 0x0c00
+ax_pose_terminator
+sPupitarPose103:
+ax_pose 30, 0x01e1, 0x80f2, 0x0c00
+ax_pose_terminator
+sPupitarPose104:
+ax_pose 29, 0x01e2, 0x80f9, 0x0c00
+ax_pose_terminator
+sPupitarPose105:
+ax_pose 28, 0x01e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sPupitarPose106:
+ax_pose 27, 0x01e0, 0x80f8, 0x0c00
+ax_pose_terminator
+sPupitarPose107:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose108:
+ax_pose 15, 0x81e7, 0x80f6, 0x0c00
+ax_pose 16, 0x81e7, 0x0106, 0x0c08
+ax_pose_terminator
+sPupitarPose109:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sPupitarPose110:
+ax_pose 17, 0x81e6, 0x90f9, 0x0c00
+ax_pose 18, 0x81e6, 0x50f1, 0x0c08
+ax_pose_terminator
+sPupitarPose111:
+ax_pose 6, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose112:
+ax_pose 19, 0x81e7, 0x90f5, 0x0c00
+ax_pose_terminator
+sPupitarPose113:
+ax_pose 9, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose114:
+ax_pose 20, 0x81e5, 0x90f7, 0x0c00
+ax_pose 21, 0x81e5, 0x50ef, 0x0c08
+ax_pose_terminator
+sPupitarPose115:
+ax_pose 12, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose116:
+ax_pose 22, 0x81e1, 0x80f5, 0x0c00
+ax_pose 23, 0x81e9, 0x0105, 0x0c08
+ax_pose_terminator
+sPupitarPose117:
+ax_pose 9, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose118:
+ax_pose 20, 0x81e5, 0x80f9, 0x0c00
+ax_pose 21, 0x81e5, 0x4109, 0x0c08
+ax_pose_terminator
+sPupitarPose119:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose120:
+ax_pose 19, 0x81e7, 0x80fb, 0x0c00
+ax_pose_terminator
+sPupitarPose121:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose122:
+ax_pose 17, 0x81e6, 0x80f7, 0x0c00
+ax_pose 18, 0x81e6, 0x4107, 0x0c08
+ax_pose_terminator
+sPupitarPose123:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose124:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose125:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose126:
+ax_pose 9, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose127:
+ax_pose 12, 0x01e3, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose128:
+ax_pose 9, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose129:
+ax_pose 6, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose130:
+ax_pose 3, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose131:
+ax_pose 15, 0x81e6, 0x80f6, 0x0c00
+ax_pose 16, 0x81e6, 0x0106, 0x0c08
+ax_pose_terminator
+sPupitarPose132:
+ax_pose 17, 0x81e5, 0x90f9, 0x0c00
+ax_pose 18, 0x81e5, 0x50f1, 0x0c08
+ax_pose_terminator
+sPupitarPose133:
+ax_pose 19, 0x81e6, 0x90f6, 0x0c00
+ax_pose_terminator
+sPupitarPose134:
+ax_pose 20, 0x81e5, 0x90f8, 0x0c00
+ax_pose 21, 0x81e5, 0x50f0, 0x0c08
+ax_pose_terminator
+sPupitarPose135:
+ax_pose 22, 0x81e2, 0x80f5, 0x0c00
+ax_pose 23, 0x81ea, 0x0105, 0x0c08
+ax_pose_terminator
+sPupitarPose136:
+ax_pose 20, 0x81e5, 0x80f8, 0x0c00
+ax_pose 21, 0x81e5, 0x4108, 0x0c08
+ax_pose_terminator
+sPupitarPose137:
+ax_pose 19, 0x81e6, 0x80fa, 0x0c00
+ax_pose_terminator
+sPupitarPose138:
+ax_pose 17, 0x81e5, 0x80f7, 0x0c00
+ax_pose 18, 0x81e5, 0x4107, 0x0c08
+ax_pose_terminator
+sPupitarPose139:
+ax_pose 0, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose140:
+ax_pose 1, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose141:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose142:
+ax_pose 3, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose143:
+ax_pose 4, 0x01e8, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose144:
+ax_pose 5, 0x01e8, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose145:
+ax_pose 6, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose146:
+ax_pose 7, 0x01e7, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose147:
+ax_pose 8, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose148:
+ax_pose 9, 0x01e8, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose149:
+ax_pose 10, 0x01e7, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose150:
+ax_pose 11, 0x01e9, 0x90ea, 0x0c00
+ax_pose_terminator
+sPupitarPose151:
+ax_pose 12, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose152:
+ax_pose 13, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose153:
+ax_pose 14, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose154:
+ax_pose 9, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose155:
+ax_pose 10, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose156:
+ax_pose 11, 0x01e9, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose157:
+ax_pose 6, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose158:
+ax_pose 7, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose159:
+ax_pose 8, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose160:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose161:
+ax_pose 4, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose162:
+ax_pose 5, 0x01e7, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose163:
+ax_pose 2, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose164:
+ax_pose 5, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose165:
+ax_pose 8, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose166:
+ax_pose 11, 0x01e9, 0x80f5, 0x0c00
+ax_pose_terminator
+sPupitarPose167:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose168:
+ax_pose 11, 0x01e9, 0x90eb, 0x0c00
+ax_pose_terminator
+sPupitarPose169:
+ax_pose 8, 0x01e8, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose170:
+ax_pose 5, 0x01e8, 0x90ec, 0x0c00
+ax_pose_terminator
+sPupitarPose171:
+ax_pose 0, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose172:
+ax_pose 3, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sPupitarPose173:
+ax_pose 6, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sPupitarPose174:
+ax_pose 9, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sPupitarPose175:
+ax_pose 12, 0x01df, 0x80f4, 0x0c00
+ax_pose_terminator
+sPupitarPose176:
+ax_pose 9, 0x01e4, 0x90ee, 0x0c00
+ax_pose_terminator
+sPupitarPose177:
+ax_pose 6, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sPupitarPose178:
+ax_pose 3, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+.align 2
+sPupitarAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 5, 0, 1,
+ax_anim 6, 0, 2, 0, 5, 0, 2,
+ax_anim 6, 0, 2, 0, 3, 0, 1,
+ax_anim_terminator
+sPupitarAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 2, 0, 1, 0,
+ax_anim 6, 0, 4, 4, 1, 2, 1,
+ax_anim 6, 0, 5, 4, 2, 3, 2,
+ax_anim 6, 0, 5, 2, 1, 2, 1,
+ax_anim_terminator
+sPupitarAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 0,
+ax_anim 6, 0, 7, 4, 0, 2, 0,
+ax_anim 6, 0, 8, 4, 0, 3, 0,
+ax_anim 6, 0, 8, 2, 0, 2, 0,
+ax_anim_terminator
+sPupitarAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 2, -1, 1, -1,
+ax_anim 6, 0, 10, 4, -2, 2, -2,
+ax_anim 6, 0, 11, 4, -1, 3, -3,
+ax_anim 6, 0, 11, 2, 0, 2, -2,
+ax_anim_terminator
+sPupitarAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, -1,
+ax_anim 6, 0, 13, 0, -4, 0, -2,
+ax_anim 6, 0, 14, 0, -6, 0, -3,
+ax_anim 6, 0, 14, 0, -5, 0, -2,
+ax_anim_terminator
+sPupitarAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -2, -1, -1, -1,
+ax_anim 6, 0, 16, -4, -2, -2, -2,
+ax_anim 6, 0, 17, -4, -1, -3, -3,
+ax_anim 6, 0, 17, -2, 0, -2, -2,
+ax_anim_terminator
+sPupitarAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -2, 0, -1, 0,
+ax_anim 6, 0, 19, -4, 0, -2, 0,
+ax_anim 6, 0, 20, -4, 0, -3, 0,
+ax_anim 6, 0, 20, -2, 0, -2, 0,
+ax_anim_terminator
+sPupitarAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -2, 0, -1, 0,
+ax_anim 6, 0, 22, -4, 1, -2, 1,
+ax_anim 6, 0, 23, -4, 2, -3, 2,
+ax_anim 6, 0, 23, -2, 1, -2, 1,
+ax_anim_terminator
+.align 2
+sPupitarAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, -4, 0, -1,
+ax_anim 2, 2, 25, 0, 1, 0, 3,
+ax_anim 2, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 23, 0, 23,
+ax_anim 2, 1, 26, 1, 23, 1, 23,
+ax_anim 2, 0, 26, 0, 23, 0, 23,
+ax_anim 2, 0, 26, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sPupitarAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 3, -1, 3, 3,
+ax_anim 2, 2, 28, 9, 6, 9, 9,
+ax_anim 2, 0, 28, 16, 14, 16, 16,
+ax_anim 2, 0, 29, 20, 24, 20, 20,
+ax_anim 2, 1, 29, 21, 23, 21, 19,
+ax_anim 2, 0, 29, 20, 24, 20, 20,
+ax_anim 2, 0, 29, 21, 23, 21, 19,
+ax_anim 2, 0, 27, 8, 5, 8, 8,
+ax_anim_terminator
+sPupitarAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 4, -3, 4, 0,
+ax_anim 2, 2, 31, 9, -3, 9, 0,
+ax_anim 2, 0, 31, 15, 0, 15, 0,
+ax_anim 2, 0, 32, 19, 2, 19, 0,
+ax_anim 2, 1, 32, 19, 3, 19, 1,
+ax_anim 2, 0, 32, 19, 2, 19, 0,
+ax_anim 2, 0, 32, 19, 3, 19, 1,
+ax_anim 2, 0, 30, 6, 1, 6, 0,
+ax_anim_terminator
+sPupitarAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 3, -6, 3, -3,
+ax_anim 2, 2, 34, 8, -12, 8, -8,
+ax_anim 2, 0, 34, 16, -16, 16, -16,
+ax_anim 2, 0, 35, 21, -16, 21, -21,
+ax_anim 2, 1, 35, 22, -15, 22, -20,
+ax_anim 2, 0, 35, 21, -16, 21, -21,
+ax_anim 2, 0, 35, 22, -15, 22, -20,
+ax_anim 2, 0, 33, 6, -8, 6, -6,
+ax_anim_terminator
+sPupitarAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, -3, 0, -1,
+ax_anim 2, 2, 37, 0, -9, 0, -6,
+ax_anim 2, 0, 37, 0, -13, 0, -13,
+ax_anim 2, 0, 38, 0, -17, 0, -20,
+ax_anim 2, 1, 38, 1, -17, 1, -20,
+ax_anim 2, 0, 38, 0, -17, 0, -20,
+ax_anim 2, 0, 38, 1, -17, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sPupitarAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, -3, -6, -3, -3,
+ax_anim 2, 2, 40, -8, -12, -8, -8,
+ax_anim 2, 0, 40, -16, -16, -16, -16,
+ax_anim 2, 0, 41, -21, -16, -21, -21,
+ax_anim 2, 1, 41, -22, -15, -22, -20,
+ax_anim 2, 0, 41, -21, -16, -21, -21,
+ax_anim 2, 0, 41, -22, -15, -22, -20,
+ax_anim 2, 0, 39, -6, -8, -6, -6,
+ax_anim_terminator
+sPupitarAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, -4, -3, -4, 0,
+ax_anim 2, 2, 43, -9, -3, -9, 0,
+ax_anim 2, 0, 43, -15, 0, -15, 0,
+ax_anim 2, 0, 44, -19, 2, -19, 0,
+ax_anim 2, 1, 44, -19, 3, -19, 1,
+ax_anim 2, 0, 44, -19, 2, -19, 0,
+ax_anim 2, 0, 44, -19, 3, -19, 1,
+ax_anim 2, 0, 42, -6, 1, -6, 0,
+ax_anim_terminator
+sPupitarAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, -3, -1, -3, 3,
+ax_anim 2, 2, 46, -9, 6, -9, 9,
+ax_anim 2, 0, 46, -16, 14, -16, 16,
+ax_anim 2, 0, 47, -20, 24, -20, 20,
+ax_anim 2, 1, 47, -21, 23, -21, 19,
+ax_anim 2, 0, 47, -20, 24, -20, 20,
+ax_anim 2, 0, 47, -21, 23, -21, 19,
+ax_anim 2, 0, 45, -8, 5, -8, 8,
+ax_anim_terminator
+.align 2
+sPupitarAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, -4, 0, -1,
+ax_anim 2, 2, 49, 0, 1, 0, 3,
+ax_anim 2, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 23, 0, 23,
+ax_anim 2, 1, 50, 1, 23, 1, 23,
+ax_anim 2, 0, 50, 0, 23, 0, 23,
+ax_anim 2, 0, 50, 1, 23, 1, 23,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sPupitarAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 3, -1, 3, 3,
+ax_anim 2, 2, 52, 9, 6, 9, 9,
+ax_anim 2, 0, 52, 16, 14, 16, 16,
+ax_anim 2, 0, 53, 20, 24, 20, 20,
+ax_anim 2, 1, 53, 21, 23, 21, 19,
+ax_anim 2, 0, 53, 20, 24, 20, 20,
+ax_anim 2, 0, 53, 21, 23, 21, 19,
+ax_anim 2, 0, 51, 8, 5, 8, 8,
+ax_anim_terminator
+sPupitarAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 4, -3, 4, 0,
+ax_anim 2, 2, 55, 9, -3, 9, 0,
+ax_anim 2, 0, 55, 15, 0, 15, 0,
+ax_anim 2, 0, 56, 19, 2, 19, 0,
+ax_anim 2, 1, 56, 19, 3, 19, 1,
+ax_anim 2, 0, 56, 19, 2, 19, 0,
+ax_anim 2, 0, 56, 19, 3, 19, 1,
+ax_anim 2, 0, 54, 6, 1, 6, 0,
+ax_anim_terminator
+sPupitarAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 3, -6, 3, -3,
+ax_anim 2, 2, 58, 8, -12, 8, -8,
+ax_anim 2, 0, 58, 16, -16, 16, -16,
+ax_anim 2, 0, 59, 21, -16, 21, -21,
+ax_anim 2, 1, 59, 22, -15, 22, -20,
+ax_anim 2, 0, 59, 21, -16, 21, -21,
+ax_anim 2, 0, 59, 22, -15, 22, -20,
+ax_anim 2, 0, 57, 6, -8, 6, -6,
+ax_anim_terminator
+sPupitarAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, -3, 0, -1,
+ax_anim 2, 2, 61, 0, -9, 0, -6,
+ax_anim 2, 0, 61, 0, -13, 0, -13,
+ax_anim 2, 0, 62, 0, -17, 0, -20,
+ax_anim 2, 1, 62, 1, -17, 1, -20,
+ax_anim 2, 0, 62, 0, -17, 0, -20,
+ax_anim 2, 0, 62, 1, -17, 1, -20,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sPupitarAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, -3, -6, -3, -3,
+ax_anim 2, 2, 64, -8, -12, -8, -8,
+ax_anim 2, 0, 64, -16, -16, -16, -16,
+ax_anim 2, 0, 65, -21, -16, -21, -21,
+ax_anim 2, 1, 65, -22, -15, -22, -20,
+ax_anim 2, 0, 65, -21, -16, -21, -21,
+ax_anim 2, 0, 65, -22, -15, -22, -20,
+ax_anim 2, 0, 63, -6, -8, -6, -6,
+ax_anim_terminator
+sPupitarAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, -4, -3, -4, 0,
+ax_anim 2, 2, 67, -9, -3, -9, 0,
+ax_anim 2, 0, 67, -15, 0, -15, 0,
+ax_anim 2, 0, 68, -19, 2, -19, 0,
+ax_anim 2, 1, 68, -19, 3, -19, 1,
+ax_anim 2, 0, 68, -19, 2, -19, 0,
+ax_anim 2, 0, 68, -19, 3, -19, 1,
+ax_anim 2, 0, 66, -6, 1, -6, 0,
+ax_anim_terminator
+sPupitarAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, -3, -1, -3, 3,
+ax_anim 2, 2, 70, -9, 6, -9, 9,
+ax_anim 2, 0, 70, -16, 14, -16, 16,
+ax_anim 2, 0, 71, -20, 24, -20, 20,
+ax_anim 2, 1, 71, -21, 23, -21, 19,
+ax_anim 2, 0, 71, -20, 24, -20, 20,
+ax_anim 2, 0, 71, -21, 23, -21, 19,
+ax_anim 2, 0, 69, -8, 5, -8, 8,
+ax_anim_terminator
+.align 2
+sPupitarAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 72, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 1, 3, 1, 3,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 1, 3, 1, 3,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 1, 3, 1, 3,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sPupitarAnims_4_2:
+ax_anim 2, 0, 75, -2, -2, -2, -2,
+ax_anim 6, 2, 75, -3, -3, -3, -3,
+ax_anim 2, 0, 74, -1, -1, -1, -1,
+ax_anim 2, 1, 74, 2, 2, 2, 2,
+ax_anim 2, 0, 74, 3, 1, 3, 1,
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim 2, 0, 74, 3, 1, 3, 1,
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim 2, 0, 74, 3, 1, 3, 1,
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim 2, 0, 74, 1, 1, 1, 1,
+ax_anim_terminator
+sPupitarAnims_4_3:
+ax_anim 2, 0, 77, -2, 0, -2, 0,
+ax_anim 6, 2, 77, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 2, 1, 76, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 2, 1, 2, 1,
+ax_anim 2, 0, 76, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 2, 1, 2, 1,
+ax_anim 2, 0, 76, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 2, 1, 2, 1,
+ax_anim 2, 0, 76, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim_terminator
+sPupitarAnims_4_4:
+ax_anim 2, 0, 79, -2, 2, -2, 2,
+ax_anim 6, 2, 79, -3, 3, -3, 3,
+ax_anim 2, 0, 78, -1, 1, -1, 1,
+ax_anim 2, 1, 78, 2, -2, 2, -2,
+ax_anim 2, 0, 78, 3, -1, 3, -1,
+ax_anim 2, 0, 78, 2, -2, 2, -2,
+ax_anim 2, 0, 78, 3, -1, 3, -1,
+ax_anim 2, 0, 78, 2, -2, 2, -2,
+ax_anim 2, 0, 78, 3, -1, 3, -1,
+ax_anim 2, 0, 78, 2, -2, 2, -2,
+ax_anim 2, 0, 78, 1, -1, 1, -1,
+ax_anim_terminator
+sPupitarAnims_4_5:
+ax_anim 2, 0, 81, 0, 2, 0, 2,
+ax_anim 6, 2, 81, 0, 3, 0, 3,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 1, 80, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 1, -3, 1, -3,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 1, -3, 1, -3,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 1, -3, 1, -3,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim_terminator
+sPupitarAnims_4_6:
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 6, 2, 83, 3, 3, 3, 3,
+ax_anim 2, 0, 82, 1, 1, 1, 1,
+ax_anim 2, 1, 82, -2, -2, -2, -2,
+ax_anim 2, 0, 82, -3, -1, -3, -1,
+ax_anim 2, 0, 82, -2, -2, -2, -2,
+ax_anim 2, 0, 82, -3, -1, -3, -1,
+ax_anim 2, 0, 82, -2, -2, -2, -2,
+ax_anim 2, 0, 82, -3, -1, -3, -1,
+ax_anim 2, 0, 82, -2, -2, -2, -2,
+ax_anim 2, 0, 82, -1, -1, -1, -1,
+ax_anim_terminator
+sPupitarAnims_4_7:
+ax_anim 2, 0, 85, 2, 0, 2, 0,
+ax_anim 6, 2, 85, 3, 0, 3, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, -2, 0, -2, 0,
+ax_anim 2, 0, 84, -2, 1, -2, 1,
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 2, 0, 84, -2, 1, -2, 1,
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 2, 0, 84, -2, 1, -2, 1,
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim_terminator
+sPupitarAnims_4_8:
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 6, 2, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -3, 1, -3, 1,
+ax_anim 2, 0, 86, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -3, 1, -3, 1,
+ax_anim 2, 0, 86, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -3, 1, -3, 1,
+ax_anim 2, 0, 86, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sPupitarAnims_5_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_5_2:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_5_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_5_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_5_6:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_5_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_5_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPupitarAnims_6_1:
+ax_anim 8, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 0, 96, 0, -1, 0, 0,
+ax_anim 26, 0, 96, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -1, 0, 0,
+ax_anim 26, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPupitarAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sPupitarAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sPupitarAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sPupitarAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sPupitarAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sPupitarAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sPupitarAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sPupitarAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sPupitarAnims_8_1:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, -1, 0, 0,
+ax_anim 4, 0, 107, 0, -2, 0, 0,
+ax_anim 12, 0, 107, 0, -3, 0, 0,
+ax_anim 6, 0, 106, 0, -3, 0, 0,
+ax_anim 4, 0, 106, 0, -2, 0, 0,
+ax_anim 4, 0, 106, 0, -1, 0, 0,
+ax_anim 36, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_8_2:
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, -1, 0, 0,
+ax_anim 4, 0, 109, 0, -2, 0, 0,
+ax_anim 12, 0, 109, 0, -3, 0, 0,
+ax_anim 6, 0, 108, 0, -3, 0, 0,
+ax_anim 4, 0, 108, 0, -2, 0, 0,
+ax_anim 4, 0, 108, 0, -1, 0, 0,
+ax_anim 36, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_8_3:
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, -1, 0, 0,
+ax_anim 4, 0, 111, 0, -2, 0, 0,
+ax_anim 12, 0, 111, 0, -3, 0, 0,
+ax_anim 6, 0, 110, 0, -3, 0, 0,
+ax_anim 4, 0, 110, 0, -2, 0, 0,
+ax_anim 4, 0, 110, 0, -1, 0, 0,
+ax_anim 36, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_8_4:
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, -1, 0, 0,
+ax_anim 4, 0, 113, 0, -2, 0, 0,
+ax_anim 12, 0, 113, 0, -3, 0, 0,
+ax_anim 6, 0, 112, 0, -3, 0, 0,
+ax_anim 4, 0, 112, 0, -2, 0, 0,
+ax_anim 4, 0, 112, 0, -1, 0, 0,
+ax_anim 36, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_8_5:
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, -1, 0, 0,
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 12, 0, 115, 0, -3, 0, 0,
+ax_anim 6, 0, 114, 0, -3, 0, 0,
+ax_anim 4, 0, 114, 0, -2, 0, 0,
+ax_anim 4, 0, 114, 0, -1, 0, 0,
+ax_anim 36, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_8_6:
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, -1, 0, 0,
+ax_anim 4, 0, 117, 0, -2, 0, 0,
+ax_anim 12, 0, 117, 0, -3, 0, 0,
+ax_anim 6, 0, 116, 0, -3, 0, 0,
+ax_anim 4, 0, 116, 0, -2, 0, 0,
+ax_anim 4, 0, 116, 0, -1, 0, 0,
+ax_anim 36, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_8_7:
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, -1, 0, 0,
+ax_anim 4, 0, 119, 0, -2, 0, 0,
+ax_anim 12, 0, 119, 0, -3, 0, 0,
+ax_anim 6, 0, 118, 0, -3, 0, 0,
+ax_anim 4, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 118, 0, -1, 0, 0,
+ax_anim 36, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_8_8:
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, -1, 0, 0,
+ax_anim 4, 0, 121, 0, -2, 0, 0,
+ax_anim 12, 0, 121, 0, -3, 0, 0,
+ax_anim 6, 0, 120, 0, -3, 0, 0,
+ax_anim 4, 0, 120, 0, -2, 0, 0,
+ax_anim 4, 0, 120, 0, -1, 0, 0,
+ax_anim 36, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPupitarAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 6, 3, 6, 3,
+ax_anim 2, 0, 124, 8, 11, 8, 11,
+ax_anim 2, 0, 125, 5, 21, 5, 21,
+ax_anim 3, 0, 126, 1, 22, 1, 22,
+ax_anim 2, 3, 127, -4, 21, -4, 21,
+ax_anim 2, 0, 128, -8, 11, -8, 11,
+ax_anim 1, 0, 129, -6, 3, -6, 3,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 8, 0, 8, 0,
+ax_anim 2, 0, 123, 17, 3, 17, 3,
+ax_anim 2, 0, 124, 20, 15, 20, 14,
+ax_anim 3, 0, 125, 19, 23, 19, 21,
+ax_anim 2, 3, 126, 10, 22, 10, 20,
+ax_anim 2, 0, 127, 4, 17, 4, 17,
+ax_anim 1, 0, 128, 0, 7, 0, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 4, -4, 4, -4,
+ax_anim 2, 0, 122, 11, -6, 11, -6,
+ax_anim 2, 0, 123, 17, -5, 17, -5,
+ax_anim 3, 0, 124, 21, 2, 22, 0,
+ax_anim 2, 3, 125, 19, 8, 19, 6,
+ax_anim 2, 0, 126, 9, 8, 9, 8,
+ax_anim 1, 0, 127, 4, 5, 4, 4,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -8, 0, -8,
+ax_anim 2, 0, 129, 1, -14, 1, -14,
+ax_anim 2, 0, 122, 10, -21, 10, -21,
+ax_anim 3, 0, 123, 20, -16, 20, -17,
+ax_anim 2, 3, 124, 20, -11, 20, -12,
+ax_anim 2, 0, 125, 14, -4, 14, -4,
+ax_anim 1, 0, 126, 7, -1, 7, -1,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 128, -9, -12, -9, -12,
+ax_anim 2, 0, 129, -7, -14, -7, -14,
+ax_anim 3, 0, 122, 0, -17, 0, -17,
+ax_anim 2, 3, 123, 7, -14, 7, -14,
+ax_anim 2, 0, 124, 9, -10, 9, -10,
+ax_anim 1, 0, 125, 8, -4, 8, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, -8, 0, -8,
+ax_anim 2, 0, 123, -1, -14, -1, -14,
+ax_anim 2, 0, 122, -10, -21, -10, -21,
+ax_anim 3, 0, 129, -20, -16, -20, -17,
+ax_anim 2, 3, 128, -20, -11, -20, -12,
+ax_anim 2, 0, 127, -14, -4, -14, -4,
+ax_anim 1, 0, 126, -7, -1, -7, -1,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -4, -4, -4, -4,
+ax_anim 2, 0, 122, -11, -6, -11, -6,
+ax_anim 2, 0, 129, -17, -5, -17, -5,
+ax_anim 3, 0, 128, -21, 2, -22, 0,
+ax_anim 2, 3, 127, -19, 8, -19, 6,
+ax_anim 2, 0, 126, -9, 8, -9, 8,
+ax_anim 1, 0, 125, -4, 5, -4, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -8, 0, -8, 0,
+ax_anim 2, 0, 129, -17, 3, -17, 3,
+ax_anim 2, 0, 128, -20, 15, -20, 13,
+ax_anim 3, 0, 127, -19, 23, -19, 21,
+ax_anim 2, 3, 126, -10, 22, -10, 20,
+ax_anim 2, 0, 125, -4, 17, -4, 17,
+ax_anim 1, 0, 124, 0, 7, 0, 7,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPupitarAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPupitarAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -23, 0, 0,
+ax_anim 3, 0, 140, 0, -22, 0, 0,
+ax_anim 2, 0, 140, 0, -18, 0, 0,
+ax_anim 1, 0, 140, 0, -10, 0, 0,
+ax_anim 2, 2, 140, 0, 4, 0, 0,
+ax_anim_terminator
+sPupitarAnims_11_2:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -10, 0, 0,
+ax_anim 2, 0, 142, 0, -16, 0, 0,
+ax_anim 3, 0, 142, 0, -20, 0, 0,
+ax_anim 4, 0, 142, 0, -21, 0, 0,
+ax_anim 4, 0, 141, 0, -23, 0, 0,
+ax_anim 3, 0, 143, 0, -22, 0, 0,
+ax_anim 2, 0, 143, 0, -18, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 2, 143, 0, 5, 0, 0,
+ax_anim_terminator
+sPupitarAnims_11_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -23, 0, 0,
+ax_anim 3, 0, 146, 0, -22, 0, 0,
+ax_anim 2, 0, 146, 0, -18, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 2, 146, 0, 4, 0, 0,
+ax_anim_terminator
+sPupitarAnims_11_4:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -23, 0, 0,
+ax_anim 3, 0, 149, 0, -21, 0, 0,
+ax_anim 2, 0, 149, 0, -17, 0, 0,
+ax_anim 1, 0, 149, 0, -8, 0, 0,
+ax_anim 2, 2, 149, 0, 3, 0, 0,
+ax_anim_terminator
+sPupitarAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -22, 0, 0,
+ax_anim 3, 0, 152, 0, -22, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -9, 0, 0,
+ax_anim 2, 2, 152, 0, 3, 0, 0,
+ax_anim_terminator
+sPupitarAnims_11_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -23, 0, 0,
+ax_anim 3, 0, 155, 0, -21, 0, 0,
+ax_anim 2, 0, 155, 0, -17, 0, 0,
+ax_anim 1, 0, 155, 0, -8, 0, 0,
+ax_anim 2, 2, 155, 0, 3, 0, 0,
+ax_anim_terminator
+sPupitarAnims_11_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 158, 0, -22, 0, 0,
+ax_anim 2, 0, 158, 0, -18, 0, 0,
+ax_anim 1, 0, 158, 0, -9, 0, 0,
+ax_anim 2, 2, 158, 0, 4, 0, 0,
+ax_anim_terminator
+sPupitarAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 161, 0, -22, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -9, 0, 0,
+ax_anim 2, 2, 161, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sPupitarAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sPupitarAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sPupitarGfx1:
+.incbin "baserom.gba", 0x100B258, 0x200
+sPupitarSprites1:
+ax_sprite sPupitarGfx1, 0x200
+ax_sprite_terminator
+sPupitarGfx2:
+.incbin "baserom.gba", 0x100B468, 0x200
+sPupitarSprites2:
+ax_sprite sPupitarGfx2, 0x200
+ax_sprite_terminator
+sPupitarGfx3:
+.incbin "baserom.gba", 0x100B678, 0x200
+sPupitarSprites3:
+ax_sprite sPupitarGfx3, 0x200
+ax_sprite_terminator
+sPupitarGfx4:
+.incbin "baserom.gba", 0x100B888, 0x200
+sPupitarSprites4:
+ax_sprite sPupitarGfx4, 0x200
+ax_sprite_terminator
+sPupitarGfx5:
+.incbin "baserom.gba", 0x100BA98, 0x200
+sPupitarSprites5:
+ax_sprite sPupitarGfx5, 0x200
+ax_sprite_terminator
+sPupitarGfx6:
+.incbin "baserom.gba", 0x100BCA8, 0x200
+sPupitarSprites6:
+ax_sprite sPupitarGfx6, 0x200
+ax_sprite_terminator
+sPupitarGfx7:
+.incbin "baserom.gba", 0x100BEB8, 0x200
+sPupitarSprites7:
+ax_sprite sPupitarGfx7, 0x200
+ax_sprite_terminator
+sPupitarGfx8:
+.incbin "baserom.gba", 0x100C0C8, 0x200
+sPupitarSprites8:
+ax_sprite sPupitarGfx8, 0x200
+ax_sprite_terminator
+sPupitarGfx9:
+.incbin "baserom.gba", 0x100C2D8, 0x200
+sPupitarSprites9:
+ax_sprite sPupitarGfx9, 0x200
+ax_sprite_terminator
+sPupitarGfx10:
+.incbin "baserom.gba", 0x100C4E8, 0x200
+sPupitarSprites10:
+ax_sprite sPupitarGfx10, 0x200
+ax_sprite_terminator
+sPupitarGfx11:
+.incbin "baserom.gba", 0x100C6F8, 0x200
+sPupitarSprites11:
+ax_sprite sPupitarGfx11, 0x200
+ax_sprite_terminator
+sPupitarGfx12:
+.incbin "baserom.gba", 0x100C908, 0x200
+sPupitarSprites12:
+ax_sprite sPupitarGfx12, 0x200
+ax_sprite_terminator
+sPupitarGfx13:
+.incbin "baserom.gba", 0x100CB18, 0x200
+sPupitarSprites13:
+ax_sprite sPupitarGfx13, 0x200
+ax_sprite_terminator
+sPupitarGfx14:
+.incbin "baserom.gba", 0x100CD28, 0x200
+sPupitarSprites14:
+ax_sprite sPupitarGfx14, 0x200
+ax_sprite_terminator
+sPupitarGfx15:
+.incbin "baserom.gba", 0x100CF38, 0x200
+sPupitarSprites15:
+ax_sprite sPupitarGfx15, 0x200
+ax_sprite_terminator
+sPupitarGfx16:
+.incbin "baserom.gba", 0x100D148, 0xC0
+sPupitarGfx16_1:
+.incbin "baserom.gba", 0x100D208, 0x20
+sPupitarSprites16:
+ax_sprite sPupitarGfx16, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sPupitarGfx16_1, 0x20
+ax_sprite_terminator
+sPupitarGfx17:
+.incbin "baserom.gba", 0x100D248, 0x40
+sPupitarSprites17:
+ax_sprite sPupitarGfx17, 0x40
+ax_sprite_terminator
+sPupitarGfx18:
+.incbin "baserom.gba", 0x100D298, 0x100
+sPupitarSprites18:
+ax_sprite sPupitarGfx18, 0x100
+ax_sprite_terminator
+sPupitarGfx19:
+.incbin "baserom.gba", 0x100D3A8, 0x60
+sPupitarSprites19:
+ax_sprite sPupitarGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPupitarGfx20:
+.incbin "baserom.gba", 0x100D420, 0xC0
+sPupitarSprites20:
+ax_sprite sPupitarGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sPupitarGfx21:
+.incbin "baserom.gba", 0x100D4F8, 0xC0
+sPupitarGfx21_1:
+.incbin "baserom.gba", 0x100D5B8, 0x20
+sPupitarSprites21:
+ax_sprite sPupitarGfx21, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sPupitarGfx21_1, 0x20
+ax_sprite_terminator
+sPupitarGfx22:
+.incbin "baserom.gba", 0x100D5F8, 0x60
+sPupitarSprites22:
+ax_sprite sPupitarGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sPupitarGfx23:
+.incbin "baserom.gba", 0x100D670, 0xE0
+sPupitarSprites23:
+ax_sprite 0, 0x20
+ax_sprite sPupitarGfx23, 0xe0
+ax_sprite_terminator
+sPupitarGfx24:
+.incbin "baserom.gba", 0x100D768, 0x40
+sPupitarSprites24:
+ax_sprite sPupitarGfx24, 0x40
+ax_sprite_terminator
+sPupitarGfx25:
+.incbin "baserom.gba", 0x100D7B8, 0x200
+sPupitarSprites25:
+ax_sprite sPupitarGfx25, 0x200
+ax_sprite_terminator
+sPupitarGfx26:
+.incbin "baserom.gba", 0x100D9C8, 0x200
+sPupitarSprites26:
+ax_sprite sPupitarGfx26, 0x200
+ax_sprite_terminator
+sPupitarGfx27:
+.incbin "baserom.gba", 0x100DBD8, 0x200
+sPupitarSprites27:
+ax_sprite sPupitarGfx27, 0x200
+ax_sprite_terminator
+sPupitarGfx28:
+.incbin "baserom.gba", 0x100DDE8, 0x200
+sPupitarSprites28:
+ax_sprite sPupitarGfx28, 0x200
+ax_sprite_terminator
+sPupitarGfx29:
+.incbin "baserom.gba", 0x100DFF8, 0x200
+sPupitarSprites29:
+ax_sprite sPupitarGfx29, 0x200
+ax_sprite_terminator
+sPupitarGfx30:
+.incbin "baserom.gba", 0x100E208, 0x200
+sPupitarSprites30:
+ax_sprite sPupitarGfx30, 0x200
+ax_sprite_terminator
+sPupitarGfx31:
+.incbin "baserom.gba", 0x100E418, 0x200
+sPupitarSprites31:
+ax_sprite sPupitarGfx31, 0x200
+ax_sprite_terminator
+sAxPosesPupitar:
+.4byte sPupitarPose1
+.4byte sPupitarPose2
+.4byte sPupitarPose3
+.4byte sPupitarPose4
+.4byte sPupitarPose5
+.4byte sPupitarPose6
+.4byte sPupitarPose7
+.4byte sPupitarPose8
+.4byte sPupitarPose9
+.4byte sPupitarPose10
+.4byte sPupitarPose11
+.4byte sPupitarPose12
+.4byte sPupitarPose13
+.4byte sPupitarPose14
+.4byte sPupitarPose15
+.4byte sPupitarPose16
+.4byte sPupitarPose17
+.4byte sPupitarPose18
+.4byte sPupitarPose19
+.4byte sPupitarPose20
+.4byte sPupitarPose21
+.4byte sPupitarPose22
+.4byte sPupitarPose23
+.4byte sPupitarPose24
+.4byte sPupitarPose25
+.4byte sPupitarPose26
+.4byte sPupitarPose27
+.4byte sPupitarPose28
+.4byte sPupitarPose29
+.4byte sPupitarPose30
+.4byte sPupitarPose31
+.4byte sPupitarPose32
+.4byte sPupitarPose33
+.4byte sPupitarPose34
+.4byte sPupitarPose35
+.4byte sPupitarPose36
+.4byte sPupitarPose37
+.4byte sPupitarPose38
+.4byte sPupitarPose39
+.4byte sPupitarPose40
+.4byte sPupitarPose41
+.4byte sPupitarPose42
+.4byte sPupitarPose43
+.4byte sPupitarPose44
+.4byte sPupitarPose45
+.4byte sPupitarPose46
+.4byte sPupitarPose47
+.4byte sPupitarPose48
+.4byte sPupitarPose49
+.4byte sPupitarPose50
+.4byte sPupitarPose51
+.4byte sPupitarPose52
+.4byte sPupitarPose53
+.4byte sPupitarPose54
+.4byte sPupitarPose55
+.4byte sPupitarPose56
+.4byte sPupitarPose57
+.4byte sPupitarPose58
+.4byte sPupitarPose59
+.4byte sPupitarPose60
+.4byte sPupitarPose61
+.4byte sPupitarPose62
+.4byte sPupitarPose63
+.4byte sPupitarPose64
+.4byte sPupitarPose65
+.4byte sPupitarPose66
+.4byte sPupitarPose67
+.4byte sPupitarPose68
+.4byte sPupitarPose69
+.4byte sPupitarPose70
+.4byte sPupitarPose71
+.4byte sPupitarPose72
+.4byte sPupitarPose73
+.4byte sPupitarPose74
+.4byte sPupitarPose75
+.4byte sPupitarPose76
+.4byte sPupitarPose77
+.4byte sPupitarPose78
+.4byte sPupitarPose79
+.4byte sPupitarPose80
+.4byte sPupitarPose81
+.4byte sPupitarPose82
+.4byte sPupitarPose83
+.4byte sPupitarPose84
+.4byte sPupitarPose85
+.4byte sPupitarPose86
+.4byte sPupitarPose87
+.4byte sPupitarPose88
+.4byte sPupitarPose89
+.4byte sPupitarPose90
+.4byte sPupitarPose91
+.4byte sPupitarPose92
+.4byte sPupitarPose93
+.4byte sPupitarPose94
+.4byte sPupitarPose95
+.4byte sPupitarPose96
+.4byte sPupitarPose97
+.4byte sPupitarPose98
+.4byte sPupitarPose99
+.4byte sPupitarPose100
+.4byte sPupitarPose101
+.4byte sPupitarPose102
+.4byte sPupitarPose103
+.4byte sPupitarPose104
+.4byte sPupitarPose105
+.4byte sPupitarPose106
+.4byte sPupitarPose107
+.4byte sPupitarPose108
+.4byte sPupitarPose109
+.4byte sPupitarPose110
+.4byte sPupitarPose111
+.4byte sPupitarPose112
+.4byte sPupitarPose113
+.4byte sPupitarPose114
+.4byte sPupitarPose115
+.4byte sPupitarPose116
+.4byte sPupitarPose117
+.4byte sPupitarPose118
+.4byte sPupitarPose119
+.4byte sPupitarPose120
+.4byte sPupitarPose121
+.4byte sPupitarPose122
+.4byte sPupitarPose123
+.4byte sPupitarPose124
+.4byte sPupitarPose125
+.4byte sPupitarPose126
+.4byte sPupitarPose127
+.4byte sPupitarPose128
+.4byte sPupitarPose129
+.4byte sPupitarPose130
+.4byte sPupitarPose131
+.4byte sPupitarPose132
+.4byte sPupitarPose133
+.4byte sPupitarPose134
+.4byte sPupitarPose135
+.4byte sPupitarPose136
+.4byte sPupitarPose137
+.4byte sPupitarPose138
+.4byte sPupitarPose139
+.4byte sPupitarPose140
+.4byte sPupitarPose141
+.4byte sPupitarPose142
+.4byte sPupitarPose143
+.4byte sPupitarPose144
+.4byte sPupitarPose145
+.4byte sPupitarPose146
+.4byte sPupitarPose147
+.4byte sPupitarPose148
+.4byte sPupitarPose149
+.4byte sPupitarPose150
+.4byte sPupitarPose151
+.4byte sPupitarPose152
+.4byte sPupitarPose153
+.4byte sPupitarPose154
+.4byte sPupitarPose155
+.4byte sPupitarPose156
+.4byte sPupitarPose157
+.4byte sPupitarPose158
+.4byte sPupitarPose159
+.4byte sPupitarPose160
+.4byte sPupitarPose161
+.4byte sPupitarPose162
+.4byte sPupitarPose163
+.4byte sPupitarPose164
+.4byte sPupitarPose165
+.4byte sPupitarPose166
+.4byte sPupitarPose167
+.4byte sPupitarPose168
+.4byte sPupitarPose169
+.4byte sPupitarPose170
+.4byte sPupitarPose171
+.4byte sPupitarPose172
+.4byte sPupitarPose173
+.4byte sPupitarPose174
+.4byte sPupitarPose175
+.4byte sPupitarPose176
+.4byte sPupitarPose177
+.4byte sPupitarPose178
+sAxPositionsPupitar:
+.2byte   -1,   -7, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte   -1,  -10, 	  -8,  -15, 	   6,  -15, 	  -1,  -15
+.2byte   -1,   -6, 	  -8,  -10, 	   6,  -10, 	  -1,  -10
+.2byte    2,   -7, 	   6,  -13, 	  -6,  -11, 	   0,  -12
+.2byte    2,  -10, 	   6,  -16, 	  -6,  -14, 	   0,  -15
+.2byte    4,   -7, 	   7,  -12, 	  -5,  -10, 	   2,  -11
+.2byte    3,   -8, 	  -1,  -15, 	  -3,  -10, 	   0,  -12
+.2byte    2,  -10, 	  -1,  -18, 	  -3,  -13, 	   0,  -15
+.2byte    3,   -6, 	   0,  -14, 	  -2,   -9, 	   1,  -11
+.2byte   -1,  -11, 	  -8,  -15, 	   4,  -11, 	  -2,  -13
+.2byte   -1,  -14, 	  -8,  -18, 	   4,  -14, 	  -2,  -16
+.2byte    0,  -11, 	  -7,  -14, 	   5,  -10, 	  -1,  -12
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -16, 	   6,  -15, 	  -8,  -15, 	  -1,  -15
+.2byte   -1,  -12, 	   6,  -10, 	  -8,  -10, 	  -1,  -11
+.2byte   -1,  -11, 	   6,  -15, 	  -6,  -11, 	   0,  -13
+.2byte   -1,  -14, 	   6,  -18, 	  -6,  -14, 	   0,  -16
+.2byte   -2,  -11, 	   5,  -14, 	  -7,  -10, 	  -1,  -12
+.2byte   -5,   -8, 	  -1,  -15, 	   1,  -10, 	  -2,  -12
+.2byte   -4,  -10, 	  -1,  -18, 	   1,  -13, 	  -2,  -15
+.2byte   -5,   -6, 	  -2,  -14, 	   0,   -9, 	  -3,  -11
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -2,  -10, 	  -6,  -16, 	   6,  -14, 	   0,  -15
+.2byte   -4,   -7, 	  -7,  -12, 	   5,  -10, 	  -2,  -11
+.2byte   -1,   -7, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte   -1,   -8, 	  -8,  -13, 	   6,  -13, 	  -1,  -13
+.2byte   -1,   -6, 	  -8,  -10, 	   6,  -10, 	  -1,  -10
+.2byte    2,   -7, 	   6,  -13, 	  -6,  -11, 	   0,  -12
+.2byte    2,   -8, 	   6,  -14, 	  -6,  -12, 	   0,  -13
+.2byte    3,   -7, 	   6,  -12, 	  -6,  -10, 	   1,  -11
+.2byte    3,   -8, 	  -1,  -15, 	  -3,  -10, 	   0,  -12
+.2byte    2,   -8, 	  -1,  -16, 	  -3,  -11, 	   0,  -13
+.2byte    3,   -6, 	   0,  -14, 	  -2,   -9, 	   1,  -11
+.2byte   -1,  -11, 	  -8,  -15, 	   4,  -11, 	  -2,  -13
+.2byte   -1,  -12, 	  -8,  -16, 	   4,  -12, 	  -2,  -14
+.2byte   -1,  -11, 	  -8,  -14, 	   4,  -10, 	  -2,  -12
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -14, 	   6,  -13, 	  -8,  -13, 	  -1,  -13
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -11, 	   6,  -15, 	  -6,  -11, 	   0,  -13
+.2byte   -1,  -12, 	   6,  -16, 	  -6,  -12, 	   0,  -14
+.2byte   -1,  -11, 	   6,  -14, 	  -6,  -10, 	   0,  -12
+.2byte   -5,   -8, 	  -1,  -15, 	   1,  -10, 	  -2,  -12
+.2byte   -4,   -8, 	  -1,  -16, 	   1,  -11, 	  -2,  -13
+.2byte   -5,   -6, 	  -2,  -14, 	   0,   -9, 	  -3,  -11
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -2,   -8, 	  -6,  -14, 	   6,  -12, 	   0,  -13
+.2byte   -3,   -7, 	  -6,  -12, 	   6,  -10, 	  -1,  -11
+.2byte   -1,   -7, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte   -1,   -8, 	  -8,  -13, 	   6,  -13, 	  -1,  -13
+.2byte   -1,   -6, 	  -8,  -10, 	   6,  -10, 	  -1,  -10
+.2byte    2,   -7, 	   6,  -13, 	  -6,  -11, 	   0,  -12
+.2byte    2,   -8, 	   6,  -14, 	  -6,  -12, 	   0,  -13
+.2byte    3,   -7, 	   6,  -12, 	  -6,  -10, 	   1,  -11
+.2byte    3,   -8, 	  -1,  -15, 	  -3,  -10, 	   0,  -12
+.2byte    2,   -8, 	  -1,  -16, 	  -3,  -11, 	   0,  -13
+.2byte    3,   -6, 	   0,  -14, 	  -2,   -9, 	   1,  -11
+.2byte   -1,  -11, 	  -8,  -15, 	   4,  -11, 	  -2,  -13
+.2byte   -1,  -12, 	  -8,  -16, 	   4,  -12, 	  -2,  -14
+.2byte   -1,  -11, 	  -8,  -14, 	   4,  -10, 	  -2,  -12
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -14, 	   6,  -13, 	  -8,  -13, 	  -1,  -13
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -11, 	   6,  -15, 	  -6,  -11, 	   0,  -13
+.2byte   -1,  -12, 	   6,  -16, 	  -6,  -12, 	   0,  -14
+.2byte   -1,  -11, 	   6,  -14, 	  -6,  -10, 	   0,  -12
+.2byte   -5,   -8, 	  -1,  -15, 	   1,  -10, 	  -2,  -12
+.2byte   -4,   -8, 	  -1,  -16, 	   1,  -11, 	  -2,  -13
+.2byte   -5,   -6, 	  -2,  -14, 	   0,   -9, 	  -3,  -11
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -2,   -8, 	  -6,  -14, 	   6,  -12, 	   0,  -13
+.2byte   -3,   -7, 	  -6,  -12, 	   6,  -10, 	  -1,  -11
+.2byte   -1,   -7, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte   -1,  -11, 	  -8,  -15, 	   6,  -15, 	  -1,  -14
+.2byte    2,   -7, 	   6,  -13, 	  -6,  -11, 	   0,  -12
+.2byte    2,   -9, 	   5,  -15, 	  -7,  -13, 	   0,  -14
+.2byte    1,   -8, 	  -3,  -15, 	  -5,  -10, 	  -2,  -12
+.2byte    3,  -10, 	  -3,  -17, 	  -4,  -12, 	  -1,  -14
+.2byte   -1,  -12, 	  -8,  -16, 	   4,  -12, 	  -2,  -14
+.2byte    2,  -15, 	  -8,  -15, 	   5,  -12, 	  -1,  -12
+.2byte   -1,  -14, 	   6,  -13, 	  -8,  -13, 	  -1,  -13
+.2byte   -1,  -14, 	   5,  -15, 	  -7,  -15, 	  -1,  -13
+.2byte   -1,  -12, 	   6,  -16, 	  -6,  -12, 	   0,  -14
+.2byte   -3,  -15, 	   7,  -15, 	  -6,  -12, 	   0,  -12
+.2byte   -3,   -8, 	   1,  -15, 	   3,  -10, 	   0,  -12
+.2byte   -4,  -10, 	   2,  -17, 	   3,  -12, 	   0,  -14
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -3,   -9, 	  -6,  -15, 	   6,  -13, 	  -1,  -14
+.2byte   -1,  -10, 	  -8,  -15, 	   6,  -15, 	  -1,  -15
+.2byte   -6,  -10, 	 -10,  -16, 	   2,  -14, 	  -4,  -15
+.2byte   -7,  -11, 	  -3,  -18, 	  -1,  -13, 	  -4,  -15
+.2byte   -4,  -15, 	   3,  -19, 	  -9,  -15, 	  -3,  -17
+.2byte   -1,  -18, 	   6,  -17, 	  -8,  -17, 	  -1,  -17
+.2byte    2,  -15, 	  -5,  -19, 	   7,  -15, 	   1,  -17
+.2byte    5,  -11, 	   1,  -18, 	  -1,  -13, 	   2,  -15
+.2byte    4,  -10, 	   8,  -16, 	  -4,  -14, 	   2,  -15
+.2byte   -4,  -12, 	  -4,  -16, 	   5,   -9, 	   0,  -13
+.2byte   -3,  -11, 	  -5,  -16, 	   6,   -9, 	   0,  -13
+.2byte   -1,   -8, 	  -8,  -13, 	   6,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	   3,  -14, 	  -9,  -12, 	  -3,  -13
+.2byte    1,  -10, 	  -8,  -15, 	  -8,  -11, 	  -5,  -12
+.2byte   -4,   -9, 	 -11,  -12, 	   1,   -8, 	  -5,   -9
+.2byte    0,  -12, 	   6,  -11, 	  -6,  -11, 	   0,  -11
+.2byte    3,   -9, 	  10,  -12, 	  -2,   -8, 	   4,   -9
+.2byte   -2,  -10, 	   7,  -15, 	   7,  -11, 	   4,  -12
+.2byte    0,   -8, 	  -4,  -14, 	   8,  -12, 	   2,  -13
+.2byte   -1,   -7, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte   -1,   -9, 	  -8,  -13, 	   6,  -13, 	  -1,  -12
+.2byte    2,   -7, 	   6,  -13, 	  -6,  -11, 	   0,  -12
+.2byte    2,   -8, 	   5,  -14, 	  -7,  -12, 	   0,  -13
+.2byte    1,   -8, 	  -3,  -15, 	  -5,  -10, 	  -2,  -12
+.2byte    2,   -9, 	  -4,  -16, 	  -5,  -11, 	  -2,  -13
+.2byte   -1,  -12, 	  -8,  -16, 	   4,  -12, 	  -2,  -14
+.2byte    1,  -15, 	  -9,  -15, 	   4,  -12, 	  -2,  -12
+.2byte   -1,  -14, 	   6,  -13, 	  -8,  -13, 	  -1,  -13
+.2byte   -1,  -14, 	   5,  -15, 	  -7,  -15, 	  -1,  -13
+.2byte   -1,  -12, 	   6,  -16, 	  -6,  -12, 	   0,  -14
+.2byte   -2,  -15, 	   8,  -15, 	  -5,  -12, 	   1,  -12
+.2byte   -3,   -8, 	   1,  -15, 	   3,  -10, 	   0,  -12
+.2byte   -3,   -9, 	   3,  -16, 	   4,  -11, 	   1,  -13
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -3,   -8, 	  -6,  -14, 	   6,  -12, 	  -1,  -13
+.2byte   -1,   -7, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -3,   -8, 	   1,  -15, 	   3,  -10, 	   0,  -12
+.2byte   -1,  -12, 	   6,  -16, 	  -6,  -12, 	   0,  -14
+.2byte   -1,  -14, 	  -8,  -13, 	   6,  -13, 	  -1,  -13
+.2byte    0,  -12, 	  -7,  -16, 	   5,  -12, 	  -1,  -14
+.2byte    2,   -8, 	  -2,  -15, 	  -4,  -10, 	  -1,  -12
+.2byte    1,   -7, 	   5,  -13, 	  -7,  -11, 	  -1,  -12
+.2byte   -1,  -10, 	  -8,  -14, 	   6,  -14, 	  -1,  -13
+.2byte    2,   -9, 	   5,  -15, 	  -7,  -13, 	   0,  -14
+.2byte    3,  -10, 	  -3,  -17, 	  -4,  -12, 	  -1,  -14
+.2byte    2,  -15, 	  -8,  -15, 	   5,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -3,  -15, 	   7,  -15, 	  -6,  -12, 	   0,  -12
+.2byte   -4,  -10, 	   2,  -17, 	   3,  -12, 	   0,  -14
+.2byte   -3,   -9, 	  -6,  -15, 	   6,  -13, 	  -1,  -14
+.2byte   -1,   -7, 	  -8,  -12, 	   6,  -12, 	  -1,  -12
+.2byte   -1,   -8, 	  -8,  -13, 	   6,  -13, 	  -1,  -13
+.2byte   -1,   -6, 	  -8,  -10, 	   6,  -10, 	  -1,  -10
+.2byte    1,   -7, 	   5,  -13, 	  -7,  -11, 	  -1,  -12
+.2byte    1,   -7, 	   5,  -13, 	  -7,  -11, 	  -1,  -12
+.2byte    2,   -6, 	   5,  -11, 	  -7,   -9, 	   0,  -10
+.2byte    2,   -8, 	  -2,  -15, 	  -4,  -10, 	  -1,  -12
+.2byte    1,   -8, 	  -2,  -16, 	  -4,  -11, 	  -1,  -13
+.2byte    1,   -6, 	  -2,  -14, 	  -4,   -9, 	  -1,  -11
+.2byte   -1,  -11, 	  -8,  -15, 	   4,  -11, 	  -2,  -13
+.2byte   -1,  -12, 	  -8,  -16, 	   4,  -12, 	  -2,  -14
+.2byte   -1,  -10, 	  -8,  -13, 	   4,   -9, 	  -2,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -11, 	   6,  -15, 	  -6,  -11, 	   0,  -13
+.2byte   -1,  -12, 	   6,  -16, 	  -6,  -12, 	   0,  -14
+.2byte   -1,  -10, 	   6,  -13, 	  -6,   -9, 	   0,  -11
+.2byte   -3,   -8, 	   1,  -15, 	   3,  -10, 	   0,  -12
+.2byte   -2,   -8, 	   1,  -16, 	   3,  -11, 	   0,  -13
+.2byte   -2,   -6, 	   1,  -14, 	   3,   -9, 	   0,  -11
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -2,   -7, 	  -6,  -13, 	   6,  -11, 	   0,  -12
+.2byte   -3,   -7, 	  -6,  -12, 	   6,  -10, 	  -1,  -11
+.2byte   -1,   -6, 	  -8,  -10, 	   6,  -10, 	  -1,  -10
+.2byte   -4,   -6, 	  -7,  -11, 	   5,   -9, 	  -2,  -10
+.2byte   -3,   -5, 	   0,  -13, 	   2,   -8, 	  -1,  -10
+.2byte   -1,  -10, 	   6,  -13, 	  -6,   -9, 	   0,  -11
+.2byte   -1,  -12, 	   6,  -10, 	  -8,  -10, 	  -1,  -11
+.2byte    0,  -10, 	  -7,  -13, 	   5,   -9, 	  -1,  -11
+.2byte    2,   -5, 	  -1,  -13, 	  -3,   -8, 	   0,  -10
+.2byte    3,   -6, 	   6,  -11, 	  -6,   -9, 	   1,  -10
+.2byte   -1,  -10, 	  -8,  -15, 	   6,  -15, 	  -1,  -15
+.2byte   -6,  -10, 	 -10,  -16, 	   2,  -14, 	  -4,  -15
+.2byte   -7,  -11, 	  -3,  -18, 	  -1,  -13, 	  -4,  -15
+.2byte   -4,  -15, 	   3,  -19, 	  -9,  -15, 	  -3,  -17
+.2byte   -1,  -18, 	   6,  -17, 	  -8,  -17, 	  -1,  -17
+.2byte    2,  -15, 	  -5,  -19, 	   7,  -15, 	   1,  -17
+.2byte    5,  -11, 	   1,  -18, 	  -1,  -13, 	   2,  -15
+.2byte    4,  -10, 	   8,  -16, 	  -4,  -14, 	   2,  -15
+sPupitarAnimTable1:
+.4byte sPupitarAnims_1_1
+.4byte sPupitarAnims_1_2
+.4byte sPupitarAnims_1_3
+.4byte sPupitarAnims_1_4
+.4byte sPupitarAnims_1_5
+.4byte sPupitarAnims_1_6
+.4byte sPupitarAnims_1_7
+.4byte sPupitarAnims_1_8
+sPupitarAnimTable2:
+.4byte sPupitarAnims_2_1
+.4byte sPupitarAnims_2_2
+.4byte sPupitarAnims_2_3
+.4byte sPupitarAnims_2_4
+.4byte sPupitarAnims_2_5
+.4byte sPupitarAnims_2_6
+.4byte sPupitarAnims_2_7
+.4byte sPupitarAnims_2_8
+sPupitarAnimTable3:
+.4byte sPupitarAnims_3_1
+.4byte sPupitarAnims_3_2
+.4byte sPupitarAnims_3_3
+.4byte sPupitarAnims_3_4
+.4byte sPupitarAnims_3_5
+.4byte sPupitarAnims_3_6
+.4byte sPupitarAnims_3_7
+.4byte sPupitarAnims_3_8
+sPupitarAnimTable4:
+.4byte sPupitarAnims_4_1
+.4byte sPupitarAnims_4_2
+.4byte sPupitarAnims_4_3
+.4byte sPupitarAnims_4_4
+.4byte sPupitarAnims_4_5
+.4byte sPupitarAnims_4_6
+.4byte sPupitarAnims_4_7
+.4byte sPupitarAnims_4_8
+sPupitarAnimTable5:
+.4byte sPupitarAnims_5_1
+.4byte sPupitarAnims_5_2
+.4byte sPupitarAnims_5_3
+.4byte sPupitarAnims_5_4
+.4byte sPupitarAnims_5_5
+.4byte sPupitarAnims_5_6
+.4byte sPupitarAnims_5_7
+.4byte sPupitarAnims_5_8
+sPupitarAnimTable6:
+.4byte sPupitarAnims_6_1
+.4byte sPupitarAnims_6_1
+.4byte sPupitarAnims_6_1
+.4byte sPupitarAnims_6_1
+.4byte sPupitarAnims_6_1
+.4byte sPupitarAnims_6_1
+.4byte sPupitarAnims_6_1
+.4byte sPupitarAnims_6_1
+sPupitarAnimTable7:
+.4byte sPupitarAnims_7_1
+.4byte sPupitarAnims_7_2
+.4byte sPupitarAnims_7_3
+.4byte sPupitarAnims_7_4
+.4byte sPupitarAnims_7_5
+.4byte sPupitarAnims_7_6
+.4byte sPupitarAnims_7_7
+.4byte sPupitarAnims_7_8
+sPupitarAnimTable8:
+.4byte sPupitarAnims_8_1
+.4byte sPupitarAnims_8_2
+.4byte sPupitarAnims_8_3
+.4byte sPupitarAnims_8_4
+.4byte sPupitarAnims_8_5
+.4byte sPupitarAnims_8_6
+.4byte sPupitarAnims_8_7
+.4byte sPupitarAnims_8_8
+sPupitarAnimTable9:
+.4byte sPupitarAnims_9_1
+.4byte sPupitarAnims_9_2
+.4byte sPupitarAnims_9_3
+.4byte sPupitarAnims_9_4
+.4byte sPupitarAnims_9_5
+.4byte sPupitarAnims_9_6
+.4byte sPupitarAnims_9_7
+.4byte sPupitarAnims_9_8
+sPupitarAnimTable10:
+.4byte sPupitarAnims_10_1
+.4byte sPupitarAnims_10_2
+.4byte sPupitarAnims_10_3
+.4byte sPupitarAnims_10_4
+.4byte sPupitarAnims_10_5
+.4byte sPupitarAnims_10_6
+.4byte sPupitarAnims_10_7
+.4byte sPupitarAnims_10_8
+sPupitarAnimTable11:
+.4byte sPupitarAnims_11_1
+.4byte sPupitarAnims_11_2
+.4byte sPupitarAnims_11_3
+.4byte sPupitarAnims_11_4
+.4byte sPupitarAnims_11_5
+.4byte sPupitarAnims_11_6
+.4byte sPupitarAnims_11_7
+.4byte sPupitarAnims_11_8
+sPupitarAnimTable12:
+.4byte sPupitarAnims_12_1
+.4byte sPupitarAnims_12_2
+.4byte sPupitarAnims_12_3
+.4byte sPupitarAnims_12_4
+.4byte sPupitarAnims_12_5
+.4byte sPupitarAnims_12_6
+.4byte sPupitarAnims_12_7
+.4byte sPupitarAnims_12_8
+sPupitarAnimTable13:
+.4byte sPupitarAnims_13_1
+.4byte sPupitarAnims_13_2
+.4byte sPupitarAnims_13_3
+.4byte sPupitarAnims_13_4
+.4byte sPupitarAnims_13_5
+.4byte sPupitarAnims_13_6
+.4byte sPupitarAnims_13_7
+.4byte sPupitarAnims_13_8
+sAxAnimationsPupitar:
+.4byte sPupitarAnimTable1
+.4byte sPupitarAnimTable2
+.4byte sPupitarAnimTable3
+.4byte sPupitarAnimTable4
+.4byte sPupitarAnimTable5
+.4byte sPupitarAnimTable6
+.4byte sPupitarAnimTable7
+.4byte sPupitarAnimTable8
+.4byte sPupitarAnimTable9
+.4byte sPupitarAnimTable10
+.4byte sPupitarAnimTable11
+.4byte sPupitarAnimTable12
+.4byte sPupitarAnimTable13
+sAxSpritesPupitar:
+.4byte sPupitarSprites1
+.4byte sPupitarSprites2
+.4byte sPupitarSprites3
+.4byte sPupitarSprites4
+.4byte sPupitarSprites5
+.4byte sPupitarSprites6
+.4byte sPupitarSprites7
+.4byte sPupitarSprites8
+.4byte sPupitarSprites9
+.4byte sPupitarSprites10
+.4byte sPupitarSprites11
+.4byte sPupitarSprites12
+.4byte sPupitarSprites13
+.4byte sPupitarSprites14
+.4byte sPupitarSprites15
+.4byte sPupitarSprites16
+.4byte sPupitarSprites17
+.4byte sPupitarSprites18
+.4byte sPupitarSprites19
+.4byte sPupitarSprites20
+.4byte sPupitarSprites21
+.4byte sPupitarSprites22
+.4byte sPupitarSprites23
+.4byte sPupitarSprites24
+.4byte sPupitarSprites25
+.4byte sPupitarSprites26
+.4byte sPupitarSprites27
+.4byte sPupitarSprites28
+.4byte sPupitarSprites29
+.4byte sPupitarSprites30
+.4byte sPupitarSprites31
+sAxMainPupitar:
+ax_main sAxPosesPupitar, sAxAnimationsPupitar, 13, sAxSpritesPupitar, sAxPositionsPupitar

--- a/data/ax/quagsire.inc
+++ b/data/ax/quagsire.inc
@@ -1,0 +1,2530 @@
+.global gAxQuagsire
+gAxQuagsire:
+ax_siro sAxMainQuagsire
+sQuagsirePose1:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose2:
+ax_pose 1, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose3:
+ax_pose 2, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose4:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose5:
+ax_pose 4, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose6:
+ax_pose 5, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose7:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose8:
+ax_pose 7, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose9:
+ax_pose 8, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose10:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose11:
+ax_pose 10, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose12:
+ax_pose 11, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose13:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose16:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose17:
+ax_pose 10, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose18:
+ax_pose 11, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose19:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose20:
+ax_pose 7, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose21:
+ax_pose 8, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose22:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose23:
+ax_pose 4, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose24:
+ax_pose 5, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose25:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose26:
+ax_pose 1, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose27:
+ax_pose 2, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose28:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose29:
+ax_pose 4, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose30:
+ax_pose 5, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose31:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose32:
+ax_pose 7, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose33:
+ax_pose 8, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose34:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose35:
+ax_pose 10, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose36:
+ax_pose 11, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose37:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose38:
+ax_pose 13, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose39:
+ax_pose 14, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose40:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose41:
+ax_pose 10, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose42:
+ax_pose 11, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose43:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose44:
+ax_pose 7, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose45:
+ax_pose 8, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose46:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose47:
+ax_pose 4, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose48:
+ax_pose 5, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose49:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose50:
+ax_pose 1, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose51:
+ax_pose 2, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose52:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose53:
+ax_pose 4, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose54:
+ax_pose 5, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose55:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose56:
+ax_pose 7, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose57:
+ax_pose 8, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose58:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose59:
+ax_pose 10, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose60:
+ax_pose 11, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose61:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose62:
+ax_pose 13, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose63:
+ax_pose 14, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose64:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose65:
+ax_pose 10, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose66:
+ax_pose 11, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose67:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose68:
+ax_pose 7, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose69:
+ax_pose 8, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose70:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose71:
+ax_pose 4, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose72:
+ax_pose 5, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose73:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose74:
+ax_pose 1, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose75:
+ax_pose 2, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose76:
+ax_pose 15, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose77:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose78:
+ax_pose 4, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose79:
+ax_pose 5, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose80:
+ax_pose 16, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose81:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose82:
+ax_pose 7, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose83:
+ax_pose 8, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose84:
+ax_pose 17, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose85:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose86:
+ax_pose 10, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose87:
+ax_pose 11, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose88:
+ax_pose 18, 0x01e5, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose89:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose90:
+ax_pose 13, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose91:
+ax_pose 14, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose92:
+ax_pose 19, 0x01e5, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose93:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose94:
+ax_pose 10, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose95:
+ax_pose 11, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose96:
+ax_pose 18, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose97:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose98:
+ax_pose 7, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose99:
+ax_pose 8, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose100:
+ax_pose 17, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose101:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose102:
+ax_pose 4, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose103:
+ax_pose 5, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose104:
+ax_pose 16, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose105:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose106:
+ax_pose 1, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose107:
+ax_pose 2, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose108:
+ax_pose 15, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose109:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose110:
+ax_pose 4, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose111:
+ax_pose 5, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose112:
+ax_pose 16, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose113:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose114:
+ax_pose 7, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose115:
+ax_pose 8, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose116:
+ax_pose 17, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose117:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose118:
+ax_pose 10, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose119:
+ax_pose 11, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose120:
+ax_pose 18, 0x01e5, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose121:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose122:
+ax_pose 13, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose123:
+ax_pose 14, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose124:
+ax_pose 19, 0x01e5, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose125:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose126:
+ax_pose 10, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose127:
+ax_pose 11, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose128:
+ax_pose 18, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose129:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose130:
+ax_pose 7, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose131:
+ax_pose 8, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose132:
+ax_pose 17, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose133:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose134:
+ax_pose 4, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose135:
+ax_pose 5, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose136:
+ax_pose 16, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose137:
+ax_pose 20, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sQuagsirePose138:
+ax_pose 21, 0x01ee, 0x80f0, 0x7c00
+ax_pose_terminator
+sQuagsirePose139:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sQuagsirePose140:
+ax_pose 23, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose141:
+ax_pose 24, 0x01e7, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose142:
+ax_pose 25, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose143:
+ax_pose 26, 0x81e6, 0x4100, 0x7c00
+ax_pose 27, 0x0206, 0x00fb, 0x7c04
+ax_pose 28, 0x81e6, 0x0108, 0x7c05
+ax_pose 29, 0x81e6, 0x80f0, 0x7c07
+ax_pose_terminator
+sQuagsirePose144:
+ax_pose 25, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose145:
+ax_pose 24, 0x01e7, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose146:
+ax_pose 23, 0x01e6, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose147:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose148:
+ax_pose 15, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose149:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose150:
+ax_pose 16, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose151:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose152:
+ax_pose 17, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose153:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose154:
+ax_pose 18, 0x01e5, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose155:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose156:
+ax_pose 19, 0x01e5, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose157:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose158:
+ax_pose 18, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose159:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose160:
+ax_pose 17, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose161:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose162:
+ax_pose 16, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose163:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose164:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose165:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose166:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose167:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose168:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose169:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose170:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose171:
+ax_pose 15, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose172:
+ax_pose 16, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose173:
+ax_pose 17, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose174:
+ax_pose 18, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose175:
+ax_pose 19, 0x01e5, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose176:
+ax_pose 18, 0x01e5, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose177:
+ax_pose 17, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose178:
+ax_pose 16, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose179:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose180:
+ax_pose 1, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose181:
+ax_pose 2, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose182:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose183:
+ax_pose 4, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose184:
+ax_pose 5, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sQuagsirePose185:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose186:
+ax_pose 7, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose187:
+ax_pose 8, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose188:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose189:
+ax_pose 10, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose190:
+ax_pose 11, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose191:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose192:
+ax_pose 13, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose193:
+ax_pose 14, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose194:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose195:
+ax_pose 10, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose196:
+ax_pose 11, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose197:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose198:
+ax_pose 7, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose199:
+ax_pose 8, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose200:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose201:
+ax_pose 4, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose202:
+ax_pose 5, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose203:
+ax_pose 15, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose204:
+ax_pose 16, 0x01e5, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose205:
+ax_pose 17, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose206:
+ax_pose 18, 0x01e5, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose207:
+ax_pose 19, 0x01e5, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose208:
+ax_pose 18, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose209:
+ax_pose 17, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose210:
+ax_pose 16, 0x01e5, 0x90ec, 0x7c00
+ax_pose_terminator
+sQuagsirePose211:
+ax_pose 0, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose212:
+ax_pose 3, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sQuagsirePose213:
+ax_pose 6, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sQuagsirePose214:
+ax_pose 9, 0x01e8, 0x80f2, 0x7c00
+ax_pose_terminator
+sQuagsirePose215:
+ax_pose 12, 0x01e7, 0x80f4, 0x7c00
+ax_pose_terminator
+sQuagsirePose216:
+ax_pose 9, 0x01e8, 0x90ee, 0x7c00
+ax_pose_terminator
+sQuagsirePose217:
+ax_pose 6, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sQuagsirePose218:
+ax_pose 3, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+.align 2
+sQuagsireAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_2_1:
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 6, 0, 47, 0, -3, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 0, 4, 0, 4,
+ax_anim 1, 0, 31, 0, 10, 0, 10,
+ax_anim 2, 0, 35, 0, 19, 0, 19,
+ax_anim 2, 1, 37, 1, 19, 1, 19,
+ax_anim 2, 0, 40, 0, 19, 0, 19,
+ax_anim 2, 0, 43, 1, 19, 1, 19,
+ax_anim 2, 0, 46, 0, 9, 0, 9,
+ax_anim_terminator
+sQuagsireAnims_2_2:
+ax_anim 2, 0, 24, -1, -1, -1, -1,
+ax_anim 6, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 35, 10, 10, 10, 10,
+ax_anim 2, 0, 37, 20, 19, 20, 19,
+ax_anim 2, 1, 40, 21, 18, 21, 18,
+ax_anim 2, 0, 43, 20, 19, 20, 19,
+ax_anim 2, 0, 46, 21, 18, 21, 18,
+ax_anim 2, 0, 25, 9, 9, 9, 9,
+ax_anim_terminator
+sQuagsireAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 6, 0, 28, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 37, 10, 0, 10, 0,
+ax_anim 2, 0, 40, 21, 0, 21, 0,
+ax_anim 2, 1, 43, 21, 1, 21, 1,
+ax_anim 2, 0, 46, 21, 0, 21, 0,
+ax_anim 2, 0, 25, 21, 1, 21, 1,
+ax_anim 2, 0, 29, 8, 0, 8, 0,
+ax_anim_terminator
+sQuagsireAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 6, 0, 31, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -6, 6, -6,
+ax_anim 1, 0, 40, 13, -13, 13, -13,
+ax_anim 2, 0, 43, 19, -18, 19, -18,
+ax_anim 2, 1, 46, 22, -20, 22, -20,
+ax_anim 2, 0, 25, 21, -21, 21, -21,
+ax_anim 2, 0, 29, 21, -19, 21, -19,
+ax_anim 2, 0, 32, 9, -9, 9, -9,
+ax_anim_terminator
+sQuagsireAnims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 6, 0, 34, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 46, 0, -19, 0, -19,
+ax_anim 2, 1, 25, 1, -19, 1, -19,
+ax_anim 2, 0, 29, 0, -19, 0, -19,
+ax_anim 2, 0, 32, 1, -19, 1, -19,
+ax_anim 2, 0, 35, 0, -9, 0, -9,
+ax_anim_terminator
+sQuagsireAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 6, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 43, -6, -6, -6, -6,
+ax_anim 1, 0, 46, -13, -13, -13, -13,
+ax_anim 2, 0, 25, -19, -18, -19, -18,
+ax_anim 2, 1, 29, -22, -20, -22, -20,
+ax_anim 2, 0, 32, -21, -21, -21, -21,
+ax_anim 2, 0, 35, -21, -19, -21, -19,
+ax_anim 2, 0, 37, -9, -9, -9, -9,
+ax_anim_terminator
+sQuagsireAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 6, 0, 41, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 0, -4, 0,
+ax_anim 1, 0, 26, -10, 0, -10, 0,
+ax_anim 2, 0, 29, -21, 0, -21, 0,
+ax_anim 2, 1, 32, -21, 1, -21, 1,
+ax_anim 2, 0, 35, -21, 0, -21, 0,
+ax_anim 2, 0, 37, -21, 1, -21, 1,
+ax_anim 2, 0, 40, -8, 0, -8, 0,
+ax_anim_terminator
+sQuagsireAnims_2_8:
+ax_anim 2, 0, 42, 1, -1, 1, -1,
+ax_anim 6, 0, 44, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 25, -4, 4, -4, 4,
+ax_anim 1, 0, 29, -10, 10, -10, 10,
+ax_anim 2, 0, 32, -20, 19, -20, 19,
+ax_anim 2, 1, 35, -21, 18, -21, 18,
+ax_anim 2, 0, 37, -20, 19, -20, 19,
+ax_anim 2, 0, 40, -21, 18, -21, 18,
+ax_anim 2, 0, 43, -9, 9, -9, 9,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_3_1:
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim 6, 0, 71, 0, -3, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 0, 4, 0, 4,
+ax_anim 1, 0, 55, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 61, 1, 19, 1, 19,
+ax_anim 2, 0, 64, 0, 19, 0, 19,
+ax_anim 2, 0, 67, 1, 19, 1, 19,
+ax_anim 2, 0, 70, 0, 9, 0, 9,
+ax_anim_terminator
+sQuagsireAnims_3_2:
+ax_anim 2, 0, 48, -1, -1, -1, -1,
+ax_anim 6, 0, 50, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 4, 4, 4,
+ax_anim 1, 0, 59, 10, 10, 10, 10,
+ax_anim 2, 0, 61, 20, 19, 20, 19,
+ax_anim 2, 1, 64, 21, 18, 21, 18,
+ax_anim 2, 0, 67, 20, 19, 20, 19,
+ax_anim 2, 0, 70, 21, 18, 21, 18,
+ax_anim 2, 0, 49, 9, 9, 9, 9,
+ax_anim_terminator
+sQuagsireAnims_3_3:
+ax_anim 2, 0, 51, -1, 0, -1, 0,
+ax_anim 6, 0, 52, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 4, 0, 4, 0,
+ax_anim 1, 0, 61, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 21, 0, 21, 0,
+ax_anim 2, 1, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 70, 21, 0, 21, 0,
+ax_anim 2, 0, 49, 21, 1, 21, 1,
+ax_anim 2, 0, 53, 8, 0, 8, 0,
+ax_anim_terminator
+sQuagsireAnims_3_4:
+ax_anim 2, 0, 54, -1, 1, -1, 1,
+ax_anim 6, 0, 55, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 61, 6, -6, 6, -6,
+ax_anim 1, 0, 64, 13, -13, 13, -13,
+ax_anim 2, 0, 67, 19, -18, 19, -18,
+ax_anim 2, 1, 70, 22, -20, 22, -20,
+ax_anim 2, 0, 49, 21, -21, 21, -21,
+ax_anim 2, 0, 53, 21, -19, 21, -19,
+ax_anim 2, 0, 56, 9, -9, 9, -9,
+ax_anim_terminator
+sQuagsireAnims_3_5:
+ax_anim 2, 0, 57, 0, 1, 0, 1,
+ax_anim 6, 0, 58, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 0, -4, 0, -4,
+ax_anim 1, 0, 67, 0, -11, 0, -11,
+ax_anim 2, 0, 70, 0, -19, 0, -19,
+ax_anim 2, 1, 49, 1, -19, 1, -19,
+ax_anim 2, 0, 53, 0, -19, 0, -19,
+ax_anim 2, 0, 56, 1, -19, 1, -19,
+ax_anim 2, 0, 59, 0, -9, 0, -9,
+ax_anim_terminator
+sQuagsireAnims_3_6:
+ax_anim 2, 0, 60, 1, 1, 1, 1,
+ax_anim 6, 0, 61, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 67, -6, -6, -6, -6,
+ax_anim 1, 0, 70, -13, -13, -13, -13,
+ax_anim 2, 0, 49, -19, -18, -19, -18,
+ax_anim 2, 1, 53, -22, -20, -22, -20,
+ax_anim 2, 0, 56, -21, -21, -21, -21,
+ax_anim 2, 0, 59, -21, -19, -21, -19,
+ax_anim 2, 0, 61, -9, -9, -9, -9,
+ax_anim_terminator
+sQuagsireAnims_3_7:
+ax_anim 2, 0, 63, 1, 0, 1, 0,
+ax_anim 6, 0, 65, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 53, -21, 0, -21, 0,
+ax_anim 2, 1, 56, -21, 1, -21, 1,
+ax_anim 2, 0, 59, -21, 0, -21, 0,
+ax_anim 2, 0, 61, -21, 1, -21, 1,
+ax_anim 2, 0, 64, -8, 0, -8, 0,
+ax_anim_terminator
+sQuagsireAnims_3_8:
+ax_anim 2, 0, 66, 1, -1, 1, -1,
+ax_anim 6, 0, 68, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 4, -4, 4,
+ax_anim 1, 0, 53, -10, 10, -10, 10,
+ax_anim 2, 0, 56, -20, 19, -20, 19,
+ax_anim 2, 1, 59, -21, 18, -21, 18,
+ax_anim 2, 0, 61, -20, 19, -20, 19,
+ax_anim 2, 0, 64, -21, 18, -21, 18,
+ax_anim 2, 0, 67, -9, 9, -9, 9,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 6, 2, 72, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 1, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 72, 0, 3, 0, 2,
+ax_anim_terminator
+sQuagsireAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 1, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 76, 2, 2, 1, 1,
+ax_anim_terminator
+sQuagsireAnims_4_3:
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim 6, 2, 80, -3, 0, -3, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 1, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sQuagsireAnims_4_4:
+ax_anim 2, 0, 84, -2, 2, -2, 2,
+ax_anim 6, 2, 84, -3, 3, -3, 3,
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 1, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 84, 2, -2, 1, -1,
+ax_anim_terminator
+sQuagsireAnims_4_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 6, 2, 88, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 1, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim_terminator
+sQuagsireAnims_4_6:
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 6, 2, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 1, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 92, -2, -2, -1, -1,
+ax_anim_terminator
+sQuagsireAnims_4_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 6, 2, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 1, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sQuagsireAnims_4_8:
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 6, 2, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 1, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 100, -2, 2, -1, 1,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_5_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 1, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_5_2:
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 6, 2, 109, -3, -3, -3, -3,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 1, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_5_3:
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim 6, 2, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 1, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_5_4:
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim 6, 2, 117, -3, 3, -3, 3,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 1, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_5_5:
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 6, 2, 121, 0, 3, 0, 3,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 1, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_5_6:
+ax_anim 2, 0, 124, 1, 1, 1, 1,
+ax_anim 6, 2, 125, 3, 3, 3, 3,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 1, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_5_7:
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 6, 2, 129, 3, 0, 3, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 1, 107, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_5_8:
+ax_anim 2, 0, 132, 1, -1, 1, -1,
+ax_anim 6, 2, 133, 3, -3, 3, -3,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 1, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sQuagsireAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sQuagsireAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sQuagsireAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sQuagsireAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sQuagsireAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sQuagsireAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sQuagsireAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_8_1:
+ax_anim 36, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, -1, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, -1, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 36, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_8_2:
+ax_anim 36, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -1, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -1, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 36, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_8_3:
+ax_anim 36, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, -1, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, -1, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 36, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_8_4:
+ax_anim 36, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, -1, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, -1, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 36, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_8_5:
+ax_anim 36, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, -1, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 36, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_8_6:
+ax_anim 36, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, -1, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, -1, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 36, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_8_7:
+ax_anim 36, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, -1, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 36, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_8_8:
+ax_anim 36, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, -1, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 36, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 5, 16, 5, 16,
+ax_anim 3, 0, 166, 0, 17, 0, 17,
+ax_anim 2, 3, 167, -5, 16, -5, 16,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, 1, 9, 1,
+ax_anim 2, 0, 163, 18, 5, 18, 5,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 17, 17, 17, 17,
+ax_anim 2, 3, 166, 11, 18, 11, 18,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 15, -5, 15, -5,
+ax_anim 3, 0, 164, 15, -2, 15, -2,
+ax_anim 2, 3, 165, 14, 4, 14, 4,
+ax_anim 2, 0, 166, 11, 5, 11, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 1, -15, 1, -15,
+ax_anim 2, 0, 162, 7, -19, 7, -19,
+ax_anim 3, 0, 163, 14, -20, 14, -20,
+ax_anim 2, 3, 164, 18, -14, 18, -14,
+ax_anim 2, 0, 165, 16, -7, 16, -7,
+ax_anim 1, 0, 166, 10, -2, 10, -2,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -8, -11, -8, -11,
+ax_anim 2, 0, 169, -7, -17, -7, -17,
+ax_anim 3, 0, 162, 0, -20, 0, -20,
+ax_anim 2, 3, 163, 6, -17, 6, -17,
+ax_anim 2, 0, 164, 9, -9, 9, -9,
+ax_anim 1, 0, 165, 8, -3, 8, -3,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -6,
+ax_anim 2, 0, 163, -1, -15, -4, -16,
+ax_anim 2, 0, 162, -7, -19, -12, -22,
+ax_anim 3, 0, 169, -14, -20, -18, -22,
+ax_anim 2, 3, 168, -18, -14, -20, -15,
+ax_anim 2, 0, 167, -16, -7, -17, -4,
+ax_anim 1, 0, 166, -10, -2, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -15, -5, -16, -5,
+ax_anim 3, 0, 168, -15, -2, -18, -2,
+ax_anim 2, 3, 167, -14, 4, -16, 4,
+ax_anim 2, 0, 166, -11, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, 1, -8, 0,
+ax_anim 2, 0, 169, -18, 5, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -17, 17, -17, 19,
+ax_anim 2, 3, 166, -11, 18, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuagsireAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sQuagsireGfx1:
+.incbin "baserom.gba", 0xD5E580, 0x200
+sQuagsireSprites1:
+ax_sprite sQuagsireGfx1, 0x200
+ax_sprite_terminator
+sQuagsireGfx2:
+.incbin "baserom.gba", 0xD5E790, 0x200
+sQuagsireSprites2:
+ax_sprite sQuagsireGfx2, 0x200
+ax_sprite_terminator
+sQuagsireGfx3:
+.incbin "baserom.gba", 0xD5E9A0, 0x200
+sQuagsireSprites3:
+ax_sprite sQuagsireGfx3, 0x200
+ax_sprite_terminator
+sQuagsireGfx4:
+.incbin "baserom.gba", 0xD5EBB0, 0x200
+sQuagsireSprites4:
+ax_sprite sQuagsireGfx4, 0x200
+ax_sprite_terminator
+sQuagsireGfx5:
+.incbin "baserom.gba", 0xD5EDC0, 0x200
+sQuagsireSprites5:
+ax_sprite sQuagsireGfx5, 0x200
+ax_sprite_terminator
+sQuagsireGfx6:
+.incbin "baserom.gba", 0xD5EFD0, 0x200
+sQuagsireSprites6:
+ax_sprite sQuagsireGfx6, 0x200
+ax_sprite_terminator
+sQuagsireGfx7:
+.incbin "baserom.gba", 0xD5F1E0, 0x200
+sQuagsireSprites7:
+ax_sprite sQuagsireGfx7, 0x200
+ax_sprite_terminator
+sQuagsireGfx8:
+.incbin "baserom.gba", 0xD5F3F0, 0x200
+sQuagsireSprites8:
+ax_sprite sQuagsireGfx8, 0x200
+ax_sprite_terminator
+sQuagsireGfx9:
+.incbin "baserom.gba", 0xD5F600, 0x200
+sQuagsireSprites9:
+ax_sprite sQuagsireGfx9, 0x200
+ax_sprite_terminator
+sQuagsireGfx10:
+.incbin "baserom.gba", 0xD5F810, 0x200
+sQuagsireSprites10:
+ax_sprite sQuagsireGfx10, 0x200
+ax_sprite_terminator
+sQuagsireGfx11:
+.incbin "baserom.gba", 0xD5FA20, 0x200
+sQuagsireSprites11:
+ax_sprite sQuagsireGfx11, 0x200
+ax_sprite_terminator
+sQuagsireGfx12:
+.incbin "baserom.gba", 0xD5FC30, 0x200
+sQuagsireSprites12:
+ax_sprite sQuagsireGfx12, 0x200
+ax_sprite_terminator
+sQuagsireGfx13:
+.incbin "baserom.gba", 0xD5FE40, 0x200
+sQuagsireSprites13:
+ax_sprite sQuagsireGfx13, 0x200
+ax_sprite_terminator
+sQuagsireGfx14:
+.incbin "baserom.gba", 0xD60050, 0x200
+sQuagsireSprites14:
+ax_sprite sQuagsireGfx14, 0x200
+ax_sprite_terminator
+sQuagsireGfx15:
+.incbin "baserom.gba", 0xD60260, 0x200
+sQuagsireSprites15:
+ax_sprite sQuagsireGfx15, 0x200
+ax_sprite_terminator
+sQuagsireGfx16:
+.incbin "baserom.gba", 0xD60470, 0x60
+sQuagsireGfx16_1:
+.incbin "baserom.gba", 0xD604D0, 0x60
+sQuagsireGfx16_2:
+.incbin "baserom.gba", 0xD60530, 0x60
+sQuagsireGfx16_3:
+.incbin "baserom.gba", 0xD60590, 0x60
+sQuagsireSprites16:
+ax_sprite sQuagsireGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuagsireGfx17:
+.incbin "baserom.gba", 0xD60638, 0x60
+sQuagsireGfx17_1:
+.incbin "baserom.gba", 0xD60698, 0x160
+sQuagsireSprites17:
+ax_sprite sQuagsireGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx17_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuagsireGfx18:
+.incbin "baserom.gba", 0xD60820, 0x60
+sQuagsireGfx18_1:
+.incbin "baserom.gba", 0xD60880, 0x100
+sQuagsireGfx18_2:
+.incbin "baserom.gba", 0xD60980, 0x20
+sQuagsireSprites18:
+ax_sprite sQuagsireGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx18_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuagsireGfx19:
+.incbin "baserom.gba", 0xD609D8, 0x60
+sQuagsireGfx19_1:
+.incbin "baserom.gba", 0xD60A38, 0x160
+sQuagsireSprites19:
+ax_sprite sQuagsireGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuagsireGfx20:
+.incbin "baserom.gba", 0xD60BC0, 0x60
+sQuagsireGfx20_1:
+.incbin "baserom.gba", 0xD60C20, 0x60
+sQuagsireGfx20_2:
+.incbin "baserom.gba", 0xD60C80, 0x60
+sQuagsireGfx20_3:
+.incbin "baserom.gba", 0xD60CE0, 0x60
+sQuagsireSprites20:
+ax_sprite sQuagsireGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuagsireGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuagsireGfx21:
+.incbin "baserom.gba", 0xD60D88, 0x200
+sQuagsireSprites21:
+ax_sprite sQuagsireGfx21, 0x200
+ax_sprite_terminator
+sQuagsireGfx22:
+.incbin "baserom.gba", 0xD60F98, 0x200
+sQuagsireSprites22:
+ax_sprite sQuagsireGfx22, 0x200
+ax_sprite_terminator
+sQuagsireGfx23:
+.incbin "baserom.gba", 0xD611A8, 0x200
+sQuagsireSprites23:
+ax_sprite sQuagsireGfx23, 0x200
+ax_sprite_terminator
+sQuagsireGfx24:
+.incbin "baserom.gba", 0xD613B8, 0x200
+sQuagsireSprites24:
+ax_sprite sQuagsireGfx24, 0x200
+ax_sprite_terminator
+sQuagsireGfx25:
+.incbin "baserom.gba", 0xD615C8, 0x200
+sQuagsireSprites25:
+ax_sprite sQuagsireGfx25, 0x200
+ax_sprite_terminator
+sQuagsireGfx26:
+.incbin "baserom.gba", 0xD617D8, 0x200
+sQuagsireSprites26:
+ax_sprite sQuagsireGfx26, 0x200
+ax_sprite_terminator
+sQuagsireGfx27:
+.incbin "baserom.gba", 0xD619E8, 0x80
+sQuagsireSprites27:
+ax_sprite sQuagsireGfx27, 0x80
+ax_sprite_terminator
+sQuagsireGfx28:
+.incbin "baserom.gba", 0xD61A78, 0x20
+sQuagsireSprites28:
+ax_sprite sQuagsireGfx28, 0x20
+ax_sprite_terminator
+sQuagsireGfx29:
+.incbin "baserom.gba", 0xD61AA8, 0x40
+sQuagsireSprites29:
+ax_sprite sQuagsireGfx29, 0x40
+ax_sprite_terminator
+sQuagsireGfx30:
+.incbin "baserom.gba", 0xD61AF8, 0x100
+sQuagsireSprites30:
+ax_sprite sQuagsireGfx30, 0x100
+ax_sprite_terminator
+sAxPosesQuagsire:
+.4byte sQuagsirePose1
+.4byte sQuagsirePose2
+.4byte sQuagsirePose3
+.4byte sQuagsirePose4
+.4byte sQuagsirePose5
+.4byte sQuagsirePose6
+.4byte sQuagsirePose7
+.4byte sQuagsirePose8
+.4byte sQuagsirePose9
+.4byte sQuagsirePose10
+.4byte sQuagsirePose11
+.4byte sQuagsirePose12
+.4byte sQuagsirePose13
+.4byte sQuagsirePose14
+.4byte sQuagsirePose15
+.4byte sQuagsirePose16
+.4byte sQuagsirePose17
+.4byte sQuagsirePose18
+.4byte sQuagsirePose19
+.4byte sQuagsirePose20
+.4byte sQuagsirePose21
+.4byte sQuagsirePose22
+.4byte sQuagsirePose23
+.4byte sQuagsirePose24
+.4byte sQuagsirePose25
+.4byte sQuagsirePose26
+.4byte sQuagsirePose27
+.4byte sQuagsirePose28
+.4byte sQuagsirePose29
+.4byte sQuagsirePose30
+.4byte sQuagsirePose31
+.4byte sQuagsirePose32
+.4byte sQuagsirePose33
+.4byte sQuagsirePose34
+.4byte sQuagsirePose35
+.4byte sQuagsirePose36
+.4byte sQuagsirePose37
+.4byte sQuagsirePose38
+.4byte sQuagsirePose39
+.4byte sQuagsirePose40
+.4byte sQuagsirePose41
+.4byte sQuagsirePose42
+.4byte sQuagsirePose43
+.4byte sQuagsirePose44
+.4byte sQuagsirePose45
+.4byte sQuagsirePose46
+.4byte sQuagsirePose47
+.4byte sQuagsirePose48
+.4byte sQuagsirePose49
+.4byte sQuagsirePose50
+.4byte sQuagsirePose51
+.4byte sQuagsirePose52
+.4byte sQuagsirePose53
+.4byte sQuagsirePose54
+.4byte sQuagsirePose55
+.4byte sQuagsirePose56
+.4byte sQuagsirePose57
+.4byte sQuagsirePose58
+.4byte sQuagsirePose59
+.4byte sQuagsirePose60
+.4byte sQuagsirePose61
+.4byte sQuagsirePose62
+.4byte sQuagsirePose63
+.4byte sQuagsirePose64
+.4byte sQuagsirePose65
+.4byte sQuagsirePose66
+.4byte sQuagsirePose67
+.4byte sQuagsirePose68
+.4byte sQuagsirePose69
+.4byte sQuagsirePose70
+.4byte sQuagsirePose71
+.4byte sQuagsirePose72
+.4byte sQuagsirePose73
+.4byte sQuagsirePose74
+.4byte sQuagsirePose75
+.4byte sQuagsirePose76
+.4byte sQuagsirePose77
+.4byte sQuagsirePose78
+.4byte sQuagsirePose79
+.4byte sQuagsirePose80
+.4byte sQuagsirePose81
+.4byte sQuagsirePose82
+.4byte sQuagsirePose83
+.4byte sQuagsirePose84
+.4byte sQuagsirePose85
+.4byte sQuagsirePose86
+.4byte sQuagsirePose87
+.4byte sQuagsirePose88
+.4byte sQuagsirePose89
+.4byte sQuagsirePose90
+.4byte sQuagsirePose91
+.4byte sQuagsirePose92
+.4byte sQuagsirePose93
+.4byte sQuagsirePose94
+.4byte sQuagsirePose95
+.4byte sQuagsirePose96
+.4byte sQuagsirePose97
+.4byte sQuagsirePose98
+.4byte sQuagsirePose99
+.4byte sQuagsirePose100
+.4byte sQuagsirePose101
+.4byte sQuagsirePose102
+.4byte sQuagsirePose103
+.4byte sQuagsirePose104
+.4byte sQuagsirePose105
+.4byte sQuagsirePose106
+.4byte sQuagsirePose107
+.4byte sQuagsirePose108
+.4byte sQuagsirePose109
+.4byte sQuagsirePose110
+.4byte sQuagsirePose111
+.4byte sQuagsirePose112
+.4byte sQuagsirePose113
+.4byte sQuagsirePose114
+.4byte sQuagsirePose115
+.4byte sQuagsirePose116
+.4byte sQuagsirePose117
+.4byte sQuagsirePose118
+.4byte sQuagsirePose119
+.4byte sQuagsirePose120
+.4byte sQuagsirePose121
+.4byte sQuagsirePose122
+.4byte sQuagsirePose123
+.4byte sQuagsirePose124
+.4byte sQuagsirePose125
+.4byte sQuagsirePose126
+.4byte sQuagsirePose127
+.4byte sQuagsirePose128
+.4byte sQuagsirePose129
+.4byte sQuagsirePose130
+.4byte sQuagsirePose131
+.4byte sQuagsirePose132
+.4byte sQuagsirePose133
+.4byte sQuagsirePose134
+.4byte sQuagsirePose135
+.4byte sQuagsirePose136
+.4byte sQuagsirePose137
+.4byte sQuagsirePose138
+.4byte sQuagsirePose139
+.4byte sQuagsirePose140
+.4byte sQuagsirePose141
+.4byte sQuagsirePose142
+.4byte sQuagsirePose143
+.4byte sQuagsirePose144
+.4byte sQuagsirePose145
+.4byte sQuagsirePose146
+.4byte sQuagsirePose147
+.4byte sQuagsirePose148
+.4byte sQuagsirePose149
+.4byte sQuagsirePose150
+.4byte sQuagsirePose151
+.4byte sQuagsirePose152
+.4byte sQuagsirePose153
+.4byte sQuagsirePose154
+.4byte sQuagsirePose155
+.4byte sQuagsirePose156
+.4byte sQuagsirePose157
+.4byte sQuagsirePose158
+.4byte sQuagsirePose159
+.4byte sQuagsirePose160
+.4byte sQuagsirePose161
+.4byte sQuagsirePose162
+.4byte sQuagsirePose163
+.4byte sQuagsirePose164
+.4byte sQuagsirePose165
+.4byte sQuagsirePose166
+.4byte sQuagsirePose167
+.4byte sQuagsirePose168
+.4byte sQuagsirePose169
+.4byte sQuagsirePose170
+.4byte sQuagsirePose171
+.4byte sQuagsirePose172
+.4byte sQuagsirePose173
+.4byte sQuagsirePose174
+.4byte sQuagsirePose175
+.4byte sQuagsirePose176
+.4byte sQuagsirePose177
+.4byte sQuagsirePose178
+.4byte sQuagsirePose179
+.4byte sQuagsirePose180
+.4byte sQuagsirePose181
+.4byte sQuagsirePose182
+.4byte sQuagsirePose183
+.4byte sQuagsirePose184
+.4byte sQuagsirePose185
+.4byte sQuagsirePose186
+.4byte sQuagsirePose187
+.4byte sQuagsirePose188
+.4byte sQuagsirePose189
+.4byte sQuagsirePose190
+.4byte sQuagsirePose191
+.4byte sQuagsirePose192
+.4byte sQuagsirePose193
+.4byte sQuagsirePose194
+.4byte sQuagsirePose195
+.4byte sQuagsirePose196
+.4byte sQuagsirePose197
+.4byte sQuagsirePose198
+.4byte sQuagsirePose199
+.4byte sQuagsirePose200
+.4byte sQuagsirePose201
+.4byte sQuagsirePose202
+.4byte sQuagsirePose203
+.4byte sQuagsirePose204
+.4byte sQuagsirePose205
+.4byte sQuagsirePose206
+.4byte sQuagsirePose207
+.4byte sQuagsirePose208
+.4byte sQuagsirePose209
+.4byte sQuagsirePose210
+.4byte sQuagsirePose211
+.4byte sQuagsirePose212
+.4byte sQuagsirePose213
+.4byte sQuagsirePose214
+.4byte sQuagsirePose215
+.4byte sQuagsirePose216
+.4byte sQuagsirePose217
+.4byte sQuagsirePose218
+sAxPositionsQuagsire:
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -2,   -7, 	   6,   -6, 	   0,   -8
+.2byte    1,  -12, 	  -8,   -6, 	   2,   -7, 	   1,   -8
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte    5,  -12, 	   5,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    3,  -12, 	   6,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    5,  -13, 	   6,   -8, 	  -1,   -5, 	  -2,  -10
+.2byte    5,  -14, 	  -1,   -8, 	   5,   -7, 	  -2,   -9
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    4,  -15, 	   1,  -10, 	   5,   -7, 	  -2,  -11
+.2byte    2,  -15, 	  -6,   -8, 	   7,   -7, 	  -2,  -10
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -14, 	   2,   -8, 	  -6,   -7, 	   0,  -10
+.2byte    1,  -14, 	   5,   -7, 	  -3,   -8, 	  -1,  -11
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -5,  -15, 	  -2,  -10, 	  -6,   -7, 	   1,  -11
+.2byte   -3,  -15, 	   5,   -8, 	  -8,   -7, 	   1,  -10
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -6,  -13, 	  -7,   -8, 	   0,   -5, 	   1,  -10
+.2byte   -6,  -14, 	   0,   -8, 	  -6,   -7, 	   1,   -9
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -12, 	  -6,   -7, 	   1,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -2,   -7, 	   6,   -6, 	   0,   -8
+.2byte    1,  -12, 	  -8,   -6, 	   2,   -7, 	   1,   -8
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte    5,  -12, 	   5,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    3,  -12, 	   6,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    5,  -13, 	   6,   -8, 	  -1,   -5, 	  -2,  -10
+.2byte    5,  -14, 	  -1,   -8, 	   5,   -7, 	  -2,   -9
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    4,  -15, 	   1,  -10, 	   5,   -7, 	  -2,  -11
+.2byte    2,  -15, 	  -6,   -8, 	   7,   -7, 	  -2,  -10
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -14, 	   2,   -8, 	  -6,   -7, 	   0,  -10
+.2byte    1,  -14, 	   5,   -7, 	  -3,   -8, 	  -1,  -11
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -5,  -15, 	  -2,  -10, 	  -6,   -7, 	   1,  -11
+.2byte   -3,  -15, 	   5,   -8, 	  -8,   -7, 	   1,  -10
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -6,  -13, 	  -7,   -8, 	   0,   -5, 	   1,  -10
+.2byte   -6,  -14, 	   0,   -8, 	  -6,   -7, 	   1,   -9
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -12, 	  -6,   -7, 	   1,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -2,   -7, 	   6,   -6, 	   0,   -8
+.2byte    1,  -12, 	  -8,   -6, 	   2,   -7, 	   1,   -8
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte    5,  -12, 	   5,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    3,  -12, 	   6,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    5,  -13, 	   6,   -8, 	  -1,   -5, 	  -2,  -10
+.2byte    5,  -14, 	  -1,   -8, 	   5,   -7, 	  -2,   -9
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    4,  -15, 	   1,  -10, 	   5,   -7, 	  -2,  -11
+.2byte    2,  -15, 	  -6,   -8, 	   7,   -7, 	  -2,  -10
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -14, 	   2,   -8, 	  -6,   -7, 	   0,  -10
+.2byte    1,  -14, 	   5,   -7, 	  -3,   -8, 	  -1,  -11
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -5,  -15, 	  -2,  -10, 	  -6,   -7, 	   1,  -11
+.2byte   -3,  -15, 	   5,   -8, 	  -8,   -7, 	   1,  -10
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -6,  -13, 	  -7,   -8, 	   0,   -5, 	   1,  -10
+.2byte   -6,  -14, 	   0,   -8, 	  -6,   -7, 	   1,   -9
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -12, 	  -6,   -7, 	   1,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -2,   -7, 	   6,   -6, 	   0,   -8
+.2byte    1,  -12, 	  -8,   -6, 	   2,   -7, 	   1,   -8
+.2byte   -1,  -19, 	  -7,  -10, 	   6,  -10, 	   0,  -12
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte    5,  -12, 	   5,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    3,  -12, 	   6,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    2,  -18, 	   8,  -10, 	  -2,   -8, 	   1,  -13
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    5,  -13, 	   6,   -8, 	  -1,   -5, 	  -2,  -10
+.2byte    5,  -14, 	  -1,   -8, 	   5,   -7, 	  -2,   -9
+.2byte    2,  -19, 	   7,  -11, 	   1,   -8, 	  -1,  -13
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    4,  -15, 	   1,  -10, 	   5,   -7, 	  -2,  -11
+.2byte    2,  -15, 	  -6,   -8, 	   7,   -7, 	  -2,  -10
+.2byte    0,  -18, 	  -2,  -12, 	   7,   -9, 	  -2,  -13
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -14, 	   2,   -8, 	  -6,   -7, 	   0,  -10
+.2byte    1,  -14, 	   5,   -7, 	  -3,   -8, 	  -1,  -11
+.2byte    0,  -19, 	   4,  -11, 	  -5,  -11, 	   0,  -12
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -5,  -15, 	  -2,  -10, 	  -6,   -7, 	   1,  -11
+.2byte   -3,  -15, 	   5,   -8, 	  -8,   -7, 	   1,  -10
+.2byte   -1,  -18, 	   1,  -12, 	  -8,   -9, 	   1,  -13
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -6,  -13, 	  -7,   -8, 	   0,   -5, 	   1,  -10
+.2byte   -6,  -14, 	   0,   -8, 	  -6,   -7, 	   1,   -9
+.2byte   -3,  -19, 	  -8,  -11, 	  -2,   -8, 	   0,  -13
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -12, 	  -6,   -7, 	   1,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -3,  -18, 	  -9,  -10, 	   1,   -8, 	  -2,  -13
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -2,   -7, 	   6,   -6, 	   0,   -8
+.2byte    1,  -12, 	  -8,   -6, 	   2,   -7, 	   1,   -8
+.2byte   -1,  -19, 	  -7,  -10, 	   6,  -10, 	   0,  -12
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte    5,  -12, 	   5,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    3,  -12, 	   6,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    2,  -18, 	   8,  -10, 	  -2,   -8, 	   1,  -13
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    5,  -13, 	   6,   -8, 	  -1,   -5, 	  -2,  -10
+.2byte    5,  -14, 	  -1,   -8, 	   5,   -7, 	  -2,   -9
+.2byte    2,  -19, 	   7,  -11, 	   1,   -8, 	  -1,  -13
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    4,  -15, 	   1,  -10, 	   5,   -7, 	  -2,  -11
+.2byte    2,  -15, 	  -6,   -8, 	   7,   -7, 	  -2,  -10
+.2byte    0,  -18, 	  -2,  -12, 	   7,   -9, 	  -2,  -13
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -14, 	   2,   -8, 	  -6,   -7, 	   0,  -10
+.2byte    1,  -14, 	   5,   -7, 	  -3,   -8, 	  -1,  -11
+.2byte    0,  -19, 	   4,  -11, 	  -5,  -11, 	   0,  -12
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -5,  -15, 	  -2,  -10, 	  -6,   -7, 	   1,  -11
+.2byte   -3,  -15, 	   5,   -8, 	  -8,   -7, 	   1,  -10
+.2byte   -1,  -18, 	   1,  -12, 	  -8,   -9, 	   1,  -13
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -6,  -13, 	  -7,   -8, 	   0,   -5, 	   1,  -10
+.2byte   -6,  -14, 	   0,   -8, 	  -6,   -7, 	   1,   -9
+.2byte   -3,  -19, 	  -8,  -11, 	  -2,   -8, 	   0,  -13
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -12, 	  -6,   -7, 	   1,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -3,  -18, 	  -9,  -10, 	   1,   -8, 	  -2,  -13
+.2byte    7,   -7, 	   0,  -11, 	   1,   -2, 	   3,   -6
+.2byte    7,   -7, 	   0,  -12, 	   3,   -2, 	   3,   -6
+.2byte   -1,  -12, 	  -5,  -11, 	   4,  -11, 	   0,   -6
+.2byte   -1,  -14, 	   5,  -14, 	  -2,  -12, 	  -1,   -8
+.2byte   -1,  -14, 	   4,  -13, 	   0,  -11, 	  -1,   -6
+.2byte    2,  -15, 	   1,  -14, 	   6,  -13, 	   0,   -9
+.2byte   -1,  -13, 	   6,  -15, 	  -9,  -15, 	  -1,   -9
+.2byte   -3,  -15, 	  -2,  -14, 	  -7,  -13, 	  -1,   -9
+.2byte    0,  -14, 	  -5,  -13, 	  -1,  -11, 	   0,   -6
+.2byte    0,  -14, 	  -6,  -14, 	   1,  -12, 	   0,   -8
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -1,  -19, 	  -7,  -10, 	   6,  -10, 	   0,  -12
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte    2,  -18, 	   8,  -10, 	  -2,   -8, 	   1,  -13
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    2,  -19, 	   7,  -11, 	   1,   -8, 	  -1,  -13
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    0,  -18, 	  -2,  -12, 	   7,   -9, 	  -2,  -13
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte    0,  -19, 	   4,  -11, 	  -5,  -11, 	   0,  -12
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -1,  -18, 	   1,  -12, 	  -8,   -9, 	   1,  -13
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -3,  -19, 	  -8,  -11, 	  -2,   -8, 	   0,  -13
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -3,  -18, 	  -9,  -10, 	   1,   -8, 	  -2,  -13
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte   -1,  -19, 	  -7,  -10, 	   6,  -10, 	   0,  -12
+.2byte    2,  -18, 	   8,  -10, 	  -2,   -8, 	   1,  -13
+.2byte    2,  -19, 	   7,  -11, 	   1,   -8, 	  -1,  -13
+.2byte    1,  -18, 	  -1,  -12, 	   8,   -9, 	  -1,  -13
+.2byte    0,  -19, 	   4,  -11, 	  -5,  -11, 	   0,  -12
+.2byte   -2,  -18, 	   0,  -12, 	  -9,   -9, 	   0,  -13
+.2byte   -3,  -19, 	  -8,  -11, 	  -2,   -8, 	   0,  -13
+.2byte   -3,  -18, 	  -9,  -10, 	   1,   -8, 	  -2,  -13
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -2,   -7, 	   6,   -6, 	   0,   -8
+.2byte    1,  -12, 	  -8,   -6, 	   2,   -7, 	   1,   -8
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+.2byte    5,  -12, 	   5,   -7, 	  -2,   -5, 	   0,   -9
+.2byte    3,  -12, 	   6,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    5,  -13, 	   6,   -8, 	  -1,   -5, 	  -2,  -10
+.2byte    5,  -14, 	  -1,   -8, 	   5,   -7, 	  -2,   -9
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    4,  -15, 	   1,  -10, 	   5,   -7, 	  -2,  -11
+.2byte    2,  -15, 	  -6,   -8, 	   7,   -7, 	  -2,  -10
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -14, 	   2,   -8, 	  -6,   -7, 	   0,  -10
+.2byte    1,  -14, 	   5,   -7, 	  -3,   -8, 	  -1,  -11
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -5,  -15, 	  -2,  -10, 	  -6,   -7, 	   1,  -11
+.2byte   -3,  -15, 	   5,   -8, 	  -8,   -7, 	   1,  -10
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -6,  -13, 	  -7,   -8, 	   0,   -5, 	   1,  -10
+.2byte   -6,  -14, 	   0,   -8, 	  -6,   -7, 	   1,   -9
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -12, 	  -6,   -7, 	   1,   -5, 	  -1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -19, 	  -7,  -10, 	   6,  -10, 	   0,  -12
+.2byte   -2,  -17, 	  -8,   -9, 	   2,   -7, 	  -1,  -12
+.2byte   -3,  -19, 	  -8,  -11, 	  -2,   -8, 	   0,  -13
+.2byte   -2,  -18, 	   0,  -12, 	  -9,   -9, 	   0,  -13
+.2byte    0,  -19, 	   4,  -11, 	  -5,  -11, 	   0,  -12
+.2byte    1,  -18, 	  -1,  -12, 	   8,   -9, 	  -1,  -13
+.2byte    2,  -19, 	   7,  -11, 	   1,   -8, 	  -1,  -13
+.2byte    1,  -17, 	   7,   -9, 	  -3,   -7, 	   0,  -12
+.2byte   -1,  -13, 	  -4,   -7, 	   4,   -7, 	   0,   -9
+.2byte   -5,  -13, 	  -7,   -8, 	  -1,   -6, 	   0,  -11
+.2byte   -6,  -14, 	  -6,  -10, 	  -4,   -7, 	   1,  -10
+.2byte   -4,  -16, 	   3,   -9, 	  -7,   -8, 	   2,  -11
+.2byte   -1,  -15, 	   4,   -8, 	  -4,   -8, 	   0,  -10
+.2byte    3,  -16, 	  -4,   -9, 	   6,   -8, 	  -3,  -11
+.2byte    5,  -14, 	   5,  -10, 	   3,   -7, 	  -2,  -10
+.2byte    4,  -13, 	   6,   -8, 	   0,   -6, 	  -1,  -11
+sQuagsireAnimTable1:
+.4byte sQuagsireAnims_1_1
+.4byte sQuagsireAnims_1_2
+.4byte sQuagsireAnims_1_3
+.4byte sQuagsireAnims_1_4
+.4byte sQuagsireAnims_1_5
+.4byte sQuagsireAnims_1_6
+.4byte sQuagsireAnims_1_7
+.4byte sQuagsireAnims_1_8
+sQuagsireAnimTable2:
+.4byte sQuagsireAnims_2_1
+.4byte sQuagsireAnims_2_2
+.4byte sQuagsireAnims_2_3
+.4byte sQuagsireAnims_2_4
+.4byte sQuagsireAnims_2_5
+.4byte sQuagsireAnims_2_6
+.4byte sQuagsireAnims_2_7
+.4byte sQuagsireAnims_2_8
+sQuagsireAnimTable3:
+.4byte sQuagsireAnims_3_1
+.4byte sQuagsireAnims_3_2
+.4byte sQuagsireAnims_3_3
+.4byte sQuagsireAnims_3_4
+.4byte sQuagsireAnims_3_5
+.4byte sQuagsireAnims_3_6
+.4byte sQuagsireAnims_3_7
+.4byte sQuagsireAnims_3_8
+sQuagsireAnimTable4:
+.4byte sQuagsireAnims_4_1
+.4byte sQuagsireAnims_4_2
+.4byte sQuagsireAnims_4_3
+.4byte sQuagsireAnims_4_4
+.4byte sQuagsireAnims_4_5
+.4byte sQuagsireAnims_4_6
+.4byte sQuagsireAnims_4_7
+.4byte sQuagsireAnims_4_8
+sQuagsireAnimTable5:
+.4byte sQuagsireAnims_5_1
+.4byte sQuagsireAnims_5_2
+.4byte sQuagsireAnims_5_3
+.4byte sQuagsireAnims_5_4
+.4byte sQuagsireAnims_5_5
+.4byte sQuagsireAnims_5_6
+.4byte sQuagsireAnims_5_7
+.4byte sQuagsireAnims_5_8
+sQuagsireAnimTable6:
+.4byte sQuagsireAnims_6_1
+.4byte sQuagsireAnims_6_1
+.4byte sQuagsireAnims_6_1
+.4byte sQuagsireAnims_6_1
+.4byte sQuagsireAnims_6_1
+.4byte sQuagsireAnims_6_1
+.4byte sQuagsireAnims_6_1
+.4byte sQuagsireAnims_6_1
+sQuagsireAnimTable7:
+.4byte sQuagsireAnims_7_1
+.4byte sQuagsireAnims_7_2
+.4byte sQuagsireAnims_7_3
+.4byte sQuagsireAnims_7_4
+.4byte sQuagsireAnims_7_5
+.4byte sQuagsireAnims_7_6
+.4byte sQuagsireAnims_7_7
+.4byte sQuagsireAnims_7_8
+sQuagsireAnimTable8:
+.4byte sQuagsireAnims_8_1
+.4byte sQuagsireAnims_8_2
+.4byte sQuagsireAnims_8_3
+.4byte sQuagsireAnims_8_4
+.4byte sQuagsireAnims_8_5
+.4byte sQuagsireAnims_8_6
+.4byte sQuagsireAnims_8_7
+.4byte sQuagsireAnims_8_8
+sQuagsireAnimTable9:
+.4byte sQuagsireAnims_9_1
+.4byte sQuagsireAnims_9_2
+.4byte sQuagsireAnims_9_3
+.4byte sQuagsireAnims_9_4
+.4byte sQuagsireAnims_9_5
+.4byte sQuagsireAnims_9_6
+.4byte sQuagsireAnims_9_7
+.4byte sQuagsireAnims_9_8
+sQuagsireAnimTable10:
+.4byte sQuagsireAnims_10_1
+.4byte sQuagsireAnims_10_2
+.4byte sQuagsireAnims_10_3
+.4byte sQuagsireAnims_10_4
+.4byte sQuagsireAnims_10_5
+.4byte sQuagsireAnims_10_6
+.4byte sQuagsireAnims_10_7
+.4byte sQuagsireAnims_10_8
+sQuagsireAnimTable11:
+.4byte sQuagsireAnims_11_1
+.4byte sQuagsireAnims_11_2
+.4byte sQuagsireAnims_11_3
+.4byte sQuagsireAnims_11_4
+.4byte sQuagsireAnims_11_5
+.4byte sQuagsireAnims_11_6
+.4byte sQuagsireAnims_11_7
+.4byte sQuagsireAnims_11_8
+sQuagsireAnimTable12:
+.4byte sQuagsireAnims_12_1
+.4byte sQuagsireAnims_12_2
+.4byte sQuagsireAnims_12_3
+.4byte sQuagsireAnims_12_4
+.4byte sQuagsireAnims_12_5
+.4byte sQuagsireAnims_12_6
+.4byte sQuagsireAnims_12_7
+.4byte sQuagsireAnims_12_8
+sQuagsireAnimTable13:
+.4byte sQuagsireAnims_13_1
+.4byte sQuagsireAnims_13_2
+.4byte sQuagsireAnims_13_3
+.4byte sQuagsireAnims_13_4
+.4byte sQuagsireAnims_13_5
+.4byte sQuagsireAnims_13_6
+.4byte sQuagsireAnims_13_7
+.4byte sQuagsireAnims_13_8
+sAxAnimationsQuagsire:
+.4byte sQuagsireAnimTable1
+.4byte sQuagsireAnimTable2
+.4byte sQuagsireAnimTable3
+.4byte sQuagsireAnimTable4
+.4byte sQuagsireAnimTable5
+.4byte sQuagsireAnimTable6
+.4byte sQuagsireAnimTable7
+.4byte sQuagsireAnimTable8
+.4byte sQuagsireAnimTable9
+.4byte sQuagsireAnimTable10
+.4byte sQuagsireAnimTable11
+.4byte sQuagsireAnimTable12
+.4byte sQuagsireAnimTable13
+sAxSpritesQuagsire:
+.4byte sQuagsireSprites1
+.4byte sQuagsireSprites2
+.4byte sQuagsireSprites3
+.4byte sQuagsireSprites4
+.4byte sQuagsireSprites5
+.4byte sQuagsireSprites6
+.4byte sQuagsireSprites7
+.4byte sQuagsireSprites8
+.4byte sQuagsireSprites9
+.4byte sQuagsireSprites10
+.4byte sQuagsireSprites11
+.4byte sQuagsireSprites12
+.4byte sQuagsireSprites13
+.4byte sQuagsireSprites14
+.4byte sQuagsireSprites15
+.4byte sQuagsireSprites16
+.4byte sQuagsireSprites17
+.4byte sQuagsireSprites18
+.4byte sQuagsireSprites19
+.4byte sQuagsireSprites20
+.4byte sQuagsireSprites21
+.4byte sQuagsireSprites22
+.4byte sQuagsireSprites23
+.4byte sQuagsireSprites24
+.4byte sQuagsireSprites25
+.4byte sQuagsireSprites26
+.4byte sQuagsireSprites27
+.4byte sQuagsireSprites28
+.4byte sQuagsireSprites29
+.4byte sQuagsireSprites30
+sAxMainQuagsire:
+ax_main sAxPosesQuagsire, sAxAnimationsQuagsire, 13, sAxSpritesQuagsire, sAxPositionsQuagsire

--- a/data/ax/quilava.inc
+++ b/data/ax/quilava.inc
@@ -1,0 +1,3009 @@
+.global gAxQuilava
+gAxQuilava:
+ax_siro sAxMainQuilava
+sQuilavaPose1:
+ax_pose 0, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose2:
+ax_pose 1, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose3:
+ax_pose 2, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose4:
+ax_pose 3, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose5:
+ax_pose 4, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose6:
+ax_pose 5, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose7:
+ax_pose 6, 0x41f3, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose8:
+ax_pose 7, 0x41f3, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose9:
+ax_pose 8, 0x41f3, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose10:
+ax_pose 9, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose11:
+ax_pose 10, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose12:
+ax_pose 11, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose13:
+ax_pose 12, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose14:
+ax_pose 13, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose15:
+ax_pose 14, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose16:
+ax_pose 9, 0x01f1, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose17:
+ax_pose 10, 0x01f1, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose18:
+ax_pose 11, 0x01f1, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose19:
+ax_pose 6, 0x41f3, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose20:
+ax_pose 7, 0x41f3, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose21:
+ax_pose 8, 0x41f3, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose22:
+ax_pose 3, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose23:
+ax_pose 4, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose24:
+ax_pose 5, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose25:
+ax_pose 15, 0x01e6, 0x80f4, 0x2c00
+ax_pose 0, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose26:
+ax_pose 16, 0x01e5, 0x80f4, 0x2c00
+ax_pose 1, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose27:
+ax_pose 17, 0x01e6, 0x80f4, 0x2c00
+ax_pose 2, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose28:
+ax_pose 0, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose29:
+ax_pose 18, 0x01e5, 0x90ed, 0x2c00
+ax_pose 3, 0x01f0, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose30:
+ax_pose 19, 0x01e5, 0x90ed, 0x2c00
+ax_pose 4, 0x01f0, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose31:
+ax_pose 20, 0x01e5, 0x90ed, 0x2c00
+ax_pose 5, 0x01f0, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose32:
+ax_pose 3, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose33:
+ax_pose 21, 0x01e9, 0x90ef, 0x2c00
+ax_pose 6, 0x41f3, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose34:
+ax_pose 22, 0x01e9, 0x90ef, 0x2c00
+ax_pose 7, 0x41f3, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose35:
+ax_pose 23, 0x01e9, 0x90ef, 0x2c00
+ax_pose 8, 0x41f3, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose36:
+ax_pose 6, 0x41f3, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose37:
+ax_pose 24, 0x01ec, 0x90ef, 0x2c00
+ax_pose 9, 0x01f1, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose38:
+ax_pose 25, 0x01ec, 0x90ed, 0x2c00
+ax_pose 10, 0x01f1, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose39:
+ax_pose 26, 0x01ec, 0x90ed, 0x2c00
+ax_pose 11, 0x01f1, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose40:
+ax_pose 9, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose41:
+ax_pose 27, 0x01ec, 0x80f3, 0x2c00
+ax_pose 12, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose42:
+ax_pose 28, 0x81ec, 0x80f3, 0x2c00
+ax_pose 13, 0x81f0, 0x80f8, 0x2c08
+ax_pose_terminator
+sQuilavaPose43:
+ax_pose 29, 0x01ec, 0x80f3, 0x2c00
+ax_pose 14, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose44:
+ax_pose 12, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose45:
+ax_pose 24, 0x01ec, 0x80f0, 0x2c00
+ax_pose 9, 0x01f1, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose46:
+ax_pose 25, 0x01ec, 0x80f2, 0x2c00
+ax_pose 10, 0x01f1, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose47:
+ax_pose 26, 0x01ec, 0x80f2, 0x2c00
+ax_pose 11, 0x01f1, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose48:
+ax_pose 9, 0x01f1, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose49:
+ax_pose 21, 0x01e9, 0x80f0, 0x2c00
+ax_pose 6, 0x41f3, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose50:
+ax_pose 22, 0x01e9, 0x80f0, 0x2c00
+ax_pose 7, 0x41f3, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose51:
+ax_pose 23, 0x01e9, 0x80f0, 0x2c00
+ax_pose 8, 0x41f3, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose52:
+ax_pose 6, 0x41f3, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose53:
+ax_pose 18, 0x01e5, 0x80f2, 0x2c00
+ax_pose 3, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose54:
+ax_pose 19, 0x01e5, 0x80f2, 0x2c00
+ax_pose 4, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose55:
+ax_pose 20, 0x01e5, 0x80f2, 0x2c00
+ax_pose 5, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose56:
+ax_pose 3, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose57:
+ax_pose 15, 0x01e6, 0x80f4, 0x2c00
+ax_pose 0, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose58:
+ax_pose 16, 0x01e5, 0x80f4, 0x2c00
+ax_pose 1, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose59:
+ax_pose 17, 0x01e6, 0x80f4, 0x2c00
+ax_pose 2, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose60:
+ax_pose 18, 0x01e5, 0x90ed, 0x2c00
+ax_pose 3, 0x01f0, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose61:
+ax_pose 19, 0x01e5, 0x90ed, 0x2c00
+ax_pose 4, 0x01f0, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose62:
+ax_pose 20, 0x01e5, 0x90ed, 0x2c00
+ax_pose 5, 0x01f0, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose63:
+ax_pose 21, 0x01e9, 0x90ef, 0x2c00
+ax_pose 6, 0x41f3, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose64:
+ax_pose 22, 0x01e9, 0x90ef, 0x2c00
+ax_pose 7, 0x41f3, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose65:
+ax_pose 23, 0x01e9, 0x90ef, 0x2c00
+ax_pose 8, 0x41f3, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose66:
+ax_pose 24, 0x01ec, 0x90ef, 0x2c00
+ax_pose 9, 0x01f1, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose67:
+ax_pose 25, 0x01ec, 0x90ed, 0x2c00
+ax_pose 10, 0x01f1, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose68:
+ax_pose 26, 0x01ec, 0x90ed, 0x2c00
+ax_pose 11, 0x01f1, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose69:
+ax_pose 27, 0x01ec, 0x80f3, 0x2c00
+ax_pose 12, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose70:
+ax_pose 28, 0x81ec, 0x80f3, 0x2c00
+ax_pose 13, 0x81f0, 0x80f8, 0x2c08
+ax_pose_terminator
+sQuilavaPose71:
+ax_pose 29, 0x01ec, 0x80f3, 0x2c00
+ax_pose 14, 0x81f0, 0x80f8, 0x2c10
+ax_pose_terminator
+sQuilavaPose72:
+ax_pose 24, 0x01ec, 0x80f0, 0x2c00
+ax_pose 9, 0x01f1, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose73:
+ax_pose 25, 0x01ec, 0x80f2, 0x2c00
+ax_pose 10, 0x01f1, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose74:
+ax_pose 26, 0x01ec, 0x80f2, 0x2c00
+ax_pose 11, 0x01f1, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose75:
+ax_pose 21, 0x01e9, 0x80f0, 0x2c00
+ax_pose 6, 0x41f3, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose76:
+ax_pose 22, 0x01e9, 0x80f0, 0x2c00
+ax_pose 7, 0x41f3, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose77:
+ax_pose 23, 0x01e9, 0x80f0, 0x2c00
+ax_pose 8, 0x41f3, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose78:
+ax_pose 18, 0x01e5, 0x80f2, 0x2c00
+ax_pose 3, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose79:
+ax_pose 19, 0x01e5, 0x80f2, 0x2c00
+ax_pose 4, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose80:
+ax_pose 20, 0x01e5, 0x80f2, 0x2c00
+ax_pose 5, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose81:
+ax_pose 0, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose82:
+ax_pose 30, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose83:
+ax_pose 31, 0x01e7, 0x80f5, 0x2c00
+ax_pose 32, 0x01e7, 0x80f5, 0x2c10
+ax_pose_terminator
+sQuilavaPose84:
+ax_pose 31, 0x01e7, 0x80f5, 0x2c00
+ax_pose 33, 0x01e7, 0x80f5, 0x2c10
+ax_pose_terminator
+sQuilavaPose85:
+ax_pose 31, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose86:
+ax_pose 3, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose87:
+ax_pose 34, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose88:
+ax_pose 35, 0x01e8, 0x90ed, 0x2c00
+ax_pose 36, 0x01e8, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose89:
+ax_pose 37, 0x01e8, 0x90ed, 0x2c00
+ax_pose 36, 0x01e8, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose90:
+ax_pose 36, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose91:
+ax_pose 6, 0x41f3, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose92:
+ax_pose 38, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose93:
+ax_pose 39, 0x01e9, 0x90ef, 0x2c00
+ax_pose 40, 0x01e9, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose94:
+ax_pose 41, 0x01e9, 0x90ef, 0x2c00
+ax_pose 40, 0x01e9, 0x90ef, 0x2c10
+ax_pose_terminator
+sQuilavaPose95:
+ax_pose 40, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose96:
+ax_pose 9, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose97:
+ax_pose 42, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose98:
+ax_pose 43, 0x01e9, 0x90ed, 0x2c00
+ax_pose 44, 0x01e9, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose99:
+ax_pose 45, 0x01e9, 0x90ed, 0x2c00
+ax_pose 44, 0x01e9, 0x90ed, 0x2c10
+ax_pose_terminator
+sQuilavaPose100:
+ax_pose 44, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose101:
+ax_pose 12, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose102:
+ax_pose 46, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose103:
+ax_pose 47, 0x01e9, 0x80f6, 0x2c00
+ax_pose 48, 0x01e9, 0x80f6, 0x2c10
+ax_pose_terminator
+sQuilavaPose104:
+ax_pose 49, 0x01e9, 0x80f6, 0x2c00
+ax_pose 48, 0x01e9, 0x80f6, 0x2c10
+ax_pose_terminator
+sQuilavaPose105:
+ax_pose 48, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose106:
+ax_pose 9, 0x01f1, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose107:
+ax_pose 42, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose108:
+ax_pose 43, 0x01e9, 0x80f2, 0x2c00
+ax_pose 44, 0x01e9, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose109:
+ax_pose 45, 0x01e9, 0x80f2, 0x2c00
+ax_pose 44, 0x01e9, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose110:
+ax_pose 44, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose111:
+ax_pose 6, 0x41f3, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose112:
+ax_pose 38, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose113:
+ax_pose 39, 0x01e9, 0x80f0, 0x2c00
+ax_pose 40, 0x01e9, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose114:
+ax_pose 41, 0x01e9, 0x80f0, 0x2c00
+ax_pose 40, 0x01e9, 0x80f0, 0x2c10
+ax_pose_terminator
+sQuilavaPose115:
+ax_pose 40, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose116:
+ax_pose 3, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose117:
+ax_pose 34, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose118:
+ax_pose 35, 0x01e8, 0x80f2, 0x2c00
+ax_pose 36, 0x01e8, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose119:
+ax_pose 37, 0x01e8, 0x80f2, 0x2c00
+ax_pose 36, 0x01e8, 0x80f2, 0x2c10
+ax_pose_terminator
+sQuilavaPose120:
+ax_pose 36, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose121:
+ax_pose 0, 0x81ef, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose122:
+ax_pose 3, 0x01ef, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose123:
+ax_pose 6, 0x41f2, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose124:
+ax_pose 9, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose125:
+ax_pose 12, 0x81ef, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose126:
+ax_pose 9, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose127:
+ax_pose 6, 0x41f2, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose128:
+ax_pose 3, 0x01ef, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose129:
+ax_pose 50, 0x01f1, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose130:
+ax_pose 51, 0x01f1, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose131:
+ax_pose 52, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose132:
+ax_pose 53, 0x01e2, 0x90ea, 0x2c00
+ax_pose_terminator
+sQuilavaPose133:
+ax_pose 54, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose134:
+ax_pose 55, 0x01e3, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose135:
+ax_pose 56, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sQuilavaPose136:
+ax_pose 55, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sQuilavaPose137:
+ax_pose 54, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sQuilavaPose138:
+ax_pose 53, 0x01e2, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose139:
+ax_pose 0, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose140:
+ax_pose 30, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose141:
+ax_pose 3, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose142:
+ax_pose 34, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose143:
+ax_pose 6, 0x41f3, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose144:
+ax_pose 38, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose145:
+ax_pose 9, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose146:
+ax_pose 42, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sQuilavaPose147:
+ax_pose 12, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose148:
+ax_pose 46, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose149:
+ax_pose 9, 0x01f1, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose150:
+ax_pose 42, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sQuilavaPose151:
+ax_pose 6, 0x41f3, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose152:
+ax_pose 38, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose153:
+ax_pose 3, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose154:
+ax_pose 34, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose155:
+ax_pose 31, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose156:
+ax_pose 36, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose157:
+ax_pose 40, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose158:
+ax_pose 44, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose159:
+ax_pose 48, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose160:
+ax_pose 44, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose161:
+ax_pose 40, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose162:
+ax_pose 36, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose163:
+ax_pose 31, 0x01e6, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose164:
+ax_pose 36, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose165:
+ax_pose 40, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose166:
+ax_pose 44, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sQuilavaPose167:
+ax_pose 48, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose168:
+ax_pose 44, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sQuilavaPose169:
+ax_pose 40, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose170:
+ax_pose 36, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose171:
+ax_pose 0, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose172:
+ax_pose 30, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose173:
+ax_pose 31, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose174:
+ax_pose 3, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose175:
+ax_pose 34, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sQuilavaPose176:
+ax_pose 36, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose177:
+ax_pose 6, 0x41f3, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose178:
+ax_pose 38, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose179:
+ax_pose 40, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sQuilavaPose180:
+ax_pose 9, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose181:
+ax_pose 42, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose182:
+ax_pose 44, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sQuilavaPose183:
+ax_pose 12, 0x81f0, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose184:
+ax_pose 46, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose185:
+ax_pose 48, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose186:
+ax_pose 9, 0x01f1, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose187:
+ax_pose 42, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose188:
+ax_pose 44, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sQuilavaPose189:
+ax_pose 6, 0x41f3, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose190:
+ax_pose 38, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose191:
+ax_pose 40, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sQuilavaPose192:
+ax_pose 3, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose193:
+ax_pose 34, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sQuilavaPose194:
+ax_pose 36, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose195:
+ax_pose 30, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQuilavaPose196:
+ax_pose 34, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose197:
+ax_pose 38, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose198:
+ax_pose 42, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose199:
+ax_pose 46, 0x01e9, 0x80f6, 0x2c00
+ax_pose_terminator
+sQuilavaPose200:
+ax_pose 42, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose201:
+ax_pose 38, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose202:
+ax_pose 34, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose203:
+ax_pose 0, 0x81ef, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose204:
+ax_pose 3, 0x01ef, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose205:
+ax_pose 6, 0x41f2, 0x80f0, 0x2c00
+ax_pose_terminator
+sQuilavaPose206:
+ax_pose 9, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sQuilavaPose207:
+ax_pose 12, 0x81ef, 0x80f8, 0x2c00
+ax_pose_terminator
+sQuilavaPose208:
+ax_pose 9, 0x01f0, 0x90ed, 0x2c00
+ax_pose_terminator
+sQuilavaPose209:
+ax_pose 6, 0x41f2, 0x90ef, 0x2c00
+ax_pose_terminator
+sQuilavaPose210:
+ax_pose 3, 0x01ef, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sQuilavaAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 2, 0, 2,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 7, 0, 7,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 1, 0, 27, 0, 13, 0, 13,
+ax_anim 2, 0, 25, 0, 16, 0, 16,
+ax_anim 1, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 1, 26, 0, 16, 0, 16,
+ax_anim 1, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 25, 0, 16, 0, 16,
+ax_anim 1, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sQuilavaAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, -1, -1, -1, -1,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 29, 2, 2, 2, 2,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 7, 7, 7, 7,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 1, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 30, 18, 16, 18, 16,
+ax_anim 1, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 1, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 30, 18, 16, 18, 16,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sQuilavaAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 2, 0, 2, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 7, 0, 7, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 1, 0, 35, 13, 0, 13, 0,
+ax_anim 2, 0, 33, 16, 0, 16, 0,
+ax_anim 1, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 34, 16, 0, 16, 0,
+ax_anim 1, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 33, 16, 0, 16, 0,
+ax_anim 1, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 34, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sQuilavaAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 0, 39, 2, -3, 2, -3,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 7, -8, 7, -8,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 1, 0, 39, 14, -18, 14, -18,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 1, 0, 39, 18, -23, 18, -23,
+ax_anim 2, 1, 38, 18, -23, 18, -23,
+ax_anim 1, 0, 39, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 1, 0, 39, 18, -23, 18, -23,
+ax_anim 2, 0, 38, 18, -23, 18, -23,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sQuilavaAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, -2, 0, -2,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -8, 0, -8,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 1, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 41, 0, -21, 0, -21,
+ax_anim 1, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 42, 0, -21, 0, -21,
+ax_anim 1, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 41, 0, -21, 0, -21,
+ax_anim 1, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 42, 0, -21, 0, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sQuilavaAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 0, 47, -2, -3, -2, -3,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -7, -8, -7, -8,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 1, 0, 47, -14, -18, -14, -18,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 1, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 1, 46, -18, -23, -18, -23,
+ax_anim 1, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 1, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 0, 46, -18, -23, -18, -23,
+ax_anim 2, 0, 47, -6, -6, -6, -6,
+ax_anim_terminator
+sQuilavaAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 51, -2, 0, -2, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -7, 0, -7, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 1, 0, 51, -13, 0, -13, 0,
+ax_anim 2, 0, 49, -16, 0, -16, 0,
+ax_anim 1, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 50, -16, 0, -16, 0,
+ax_anim 1, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 49, -16, 0, -16, 0,
+ax_anim 1, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 50, -16, 0, -16, 0,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sQuilavaAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 1, -1, 1, -1,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 0, 53, -2, 2, -2, 2,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -7, 7, -7, 7,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 53, -18, 18, -18, 18,
+ax_anim 1, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 1, 54, -18, 16, -18, 16,
+ax_anim 1, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 53, -18, 18, -18, 18,
+ax_anim 1, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 54, -18, 16, -18, 16,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 56, 0, -4, 0, -4,
+ax_anim 3, 0, 78, 0, -5, 0, -5,
+ax_anim 3, 0, 79, 0, -5, 0, -5,
+ax_anim 1, 2, 56, -1, 2, -1, 2,
+ax_anim 1, 0, 59, -2, 12, -2, 12,
+ax_anim 2, 0, 63, 0, 20, 0, 20,
+ax_anim 2, 1, 64, 1, 20, 1, 20,
+ax_anim 2, 0, 63, 0, 20, 0, 20,
+ax_anim 2, 0, 64, 1, 20, 1, 20,
+ax_anim 2, 0, 63, 0, 20, 0, 20,
+ax_anim 2, 0, 64, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sQuilavaAnims_3_2:
+ax_anim 2, 0, 59, -2, -2, -2, -2,
+ax_anim 2, 0, 59, -4, -4, -4, -4,
+ax_anim 3, 0, 57, -5, -5, -5, -5,
+ax_anim 3, 0, 58, -5, -5, -5, -5,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 62, 12, 13, 12, 13,
+ax_anim 2, 0, 66, 20, 16, 20, 16,
+ax_anim 2, 1, 67, 20, 16, 20, 16,
+ax_anim 2, 0, 66, 20, 16, 20, 16,
+ax_anim 2, 0, 67, 20, 16, 20, 16,
+ax_anim 2, 0, 66, 20, 16, 20, 16,
+ax_anim 2, 0, 67, 20, 16, 20, 16,
+ax_anim 2, 0, 62, 15, 12, 15, 12,
+ax_anim 2, 0, 59, 4, 3, 4, 3,
+ax_anim_terminator
+sQuilavaAnims_3_3:
+ax_anim 2, 0, 62, -2, 0, -2, 0,
+ax_anim 2, 0, 62, -4, 0, -4, 0,
+ax_anim 3, 0, 60, -5, 0, -5, 0,
+ax_anim 3, 0, 61, -5, 0, -5, 0,
+ax_anim 1, 2, 62, 0, 1, 0, 0,
+ax_anim 1, 0, 65, 12, 1, 12, 0,
+ax_anim 2, 0, 69, 23, 0, 23, 0,
+ax_anim 2, 1, 70, 23, 0, 23, 0,
+ax_anim 2, 0, 69, 23, 0, 23, 0,
+ax_anim 2, 0, 70, 23, 0, 23, 0,
+ax_anim 2, 0, 69, 23, 0, 23, 0,
+ax_anim 2, 0, 70, 23, 0, 23, 0,
+ax_anim 2, 0, 65, 15, 0, 15, 0,
+ax_anim 2, 0, 62, 4, 0, 4, 0,
+ax_anim_terminator
+sQuilavaAnims_3_4:
+ax_anim 2, 0, 65, -2, 2, -2, 2,
+ax_anim 2, 0, 65, -4, 4, -4, 4,
+ax_anim 3, 0, 63, -5, 5, -5, 5,
+ax_anim 3, 0, 64, -5, 5, -5, 5,
+ax_anim 1, 2, 65, 6, -4, 6, -4,
+ax_anim 1, 0, 68, 14, -13, 14, -13,
+ax_anim 2, 0, 72, 21, -24, 21, -24,
+ax_anim 2, 1, 73, 21, -24, 21, -24,
+ax_anim 2, 0, 72, 21, -24, 21, -24,
+ax_anim 2, 0, 73, 21, -24, 21, -24,
+ax_anim 2, 0, 72, 21, -24, 21, -24,
+ax_anim 2, 0, 73, 21, -24, 21, -24,
+ax_anim 2, 0, 68, 12, -13, 12, -13,
+ax_anim 2, 0, 65, 4, -3, 4, -3,
+ax_anim_terminator
+sQuilavaAnims_3_5:
+ax_anim 2, 0, 68, 0, 2, 0, 2,
+ax_anim 2, 0, 68, 0, 4, 0, 4,
+ax_anim 3, 0, 66, 0, 5, 0, 5,
+ax_anim 3, 0, 67, 0, 5, 0, 5,
+ax_anim 1, 2, 68, 1, -2, 1, -2,
+ax_anim 1, 0, 71, 2, -15, 2, -15,
+ax_anim 2, 0, 75, 0, -25, 0, -25,
+ax_anim 2, 1, 76, -1, -25, -1, -25,
+ax_anim 2, 0, 75, 0, -25, 0, -25,
+ax_anim 2, 0, 76, -1, -25, -1, -25,
+ax_anim 2, 0, 75, 0, -25, 0, -25,
+ax_anim 2, 0, 76, -1, -25, -1, -25,
+ax_anim 2, 0, 71, 0, -16, 0, -16,
+ax_anim 2, 0, 68, 0, -4, 0, -4,
+ax_anim_terminator
+sQuilavaAnims_3_6:
+ax_anim 2, 0, 71, 2, 2, 2, 2,
+ax_anim 2, 0, 71, 4, 4, 4, 4,
+ax_anim 3, 0, 69, 5, 5, 5, 5,
+ax_anim 3, 0, 70, 5, 5, 5, 5,
+ax_anim 1, 2, 71, -3, -6, -3, -6,
+ax_anim 1, 0, 74, -11, -15, -11, -15,
+ax_anim 2, 0, 78, -21, -24, -21, -24,
+ax_anim 2, 1, 79, -21, -24, -21, -24,
+ax_anim 2, 0, 78, -21, -24, -21, -24,
+ax_anim 2, 0, 79, -21, -24, -21, -24,
+ax_anim 2, 0, 78, -21, -24, -21, -24,
+ax_anim 2, 0, 79, -21, -24, -21, -24,
+ax_anim 2, 0, 74, -12, -13, -12, -13,
+ax_anim 2, 0, 71, -4, -3, -4, -3,
+ax_anim_terminator
+sQuilavaAnims_3_7:
+ax_anim 2, 0, 74, 2, 0, 2, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim 3, 0, 72, 5, 0, 5, 0,
+ax_anim 3, 0, 73, 5, 0, 5, 0,
+ax_anim 1, 2, 74, 0, -1, 0, 0,
+ax_anim 1, 0, 77, -12, -1, -12, 0,
+ax_anim 2, 0, 57, -23, 0, -23, 0,
+ax_anim 2, 1, 58, -23, 0, -23, 0,
+ax_anim 2, 0, 57, -23, 0, -23, 0,
+ax_anim 2, 0, 58, -23, 0, -23, 0,
+ax_anim 2, 0, 57, -23, 0, -23, 0,
+ax_anim 2, 0, 58, -23, 0, -23, 0,
+ax_anim 2, 0, 77, -15, 0, -15, 0,
+ax_anim 2, 0, 74, -4, 0, -4, 0,
+ax_anim_terminator
+sQuilavaAnims_3_8:
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 2, 0, 77, 4, -4, 4, -4,
+ax_anim 3, 0, 75, 5, -5, 5, -5,
+ax_anim 3, 0, 76, 5, -5, 5, -5,
+ax_anim 1, 2, 77, -7, 3, -7, 3,
+ax_anim 1, 0, 56, -17, 11, -17, 11,
+ax_anim 2, 0, 60, -20, 16, -20, 16,
+ax_anim 2, 1, 61, -20, 16, -20, 16,
+ax_anim 2, 0, 60, -20, 16, -20, 16,
+ax_anim 2, 0, 61, -20, 16, -20, 16,
+ax_anim 2, 0, 60, -20, 16, -20, 16,
+ax_anim 2, 0, 61, -20, 16, -20, 16,
+ax_anim 2, 0, 56, -15, 12, -15, 12,
+ax_anim 2, 0, 77, -4, 3, -4, 3,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_4_1:
+ax_anim 3, 0, 81, 0, -1, 0, -1,
+ax_anim 6, 2, 81, 0, -2, 0, -2,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 1, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim_terminator
+sQuilavaAnims_4_2:
+ax_anim 3, 0, 86, -1, -1, -1, -1,
+ax_anim 6, 2, 86, -2, -2, -2, -2,
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 1, 88, 1, 3, 1, 3,
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 88, 1, 3, 1, 3,
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 88, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 1, 1, 1, 1,
+ax_anim_terminator
+sQuilavaAnims_4_3:
+ax_anim 3, 0, 91, -1, 0, -1, 0,
+ax_anim 6, 2, 91, -2, 0, -2, 0,
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 1, 93, 2, -1, 2, -1,
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, -1, 2, -1,
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, -1, 2, -1,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim_terminator
+sQuilavaAnims_4_4:
+ax_anim 3, 0, 96, -1, 1, -1, 1,
+ax_anim 6, 2, 96, -2, 2, -2, 2,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim 2, 1, 98, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim 2, 0, 98, 1, -3, 1, -3,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim 2, 0, 98, 1, -3, 1, -3,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim_terminator
+sQuilavaAnims_4_5:
+ax_anim 3, 0, 101, 0, 1, 0, 1,
+ax_anim 6, 2, 101, 0, 2, 0, 2,
+ax_anim 2, 0, 103, 0, -2, 0, -2,
+ax_anim 2, 1, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 103, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 103, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 1, -2, 1, -2,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sQuilavaAnims_4_6:
+ax_anim 3, 0, 106, 1, 1, 1, 1,
+ax_anim 6, 2, 106, 2, 2, 2, 2,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 1, 108, -1, -3, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 108, -1, -3, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 108, -1, -3, -1, -3,
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim_terminator
+sQuilavaAnims_4_7:
+ax_anim 3, 0, 111, 1, 0, 1, 0,
+ax_anim 6, 2, 111, 2, 0, 2, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim 2, 1, 113, -2, -1, -2, -1,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim 2, 0, 113, -2, -1, -2, -1,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim 2, 0, 113, -2, -1, -2, -1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim_terminator
+sQuilavaAnims_4_8:
+ax_anim 3, 0, 116, 1, -1, 2, -2,
+ax_anim 6, 0, 116, 2, -2, 3, -3,
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 2, 118, -1, 3, -1, 3,
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -1, 3, -1, 3,
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -1, 3, -1, 3,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 115, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sQuilavaAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sQuilavaAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sQuilavaAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sQuilavaAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sQuilavaAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sQuilavaAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sQuilavaAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_8_2:
+ax_anim 30, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_8_3:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_8_4:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_8_5:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_8_6:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_8_7:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_8_8:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 5, 3, 5, 3,
+ax_anim 2, 0, 156, 10, 8, 10, 8,
+ax_anim 2, 0, 157, 8, 15, 8, 15,
+ax_anim 3, 0, 158, 0, 16, 0, 16,
+ax_anim 2, 3, 159, -8, 15, -8, 15,
+ax_anim 2, 0, 160, -10, 8, -10, 8,
+ax_anim 1, 0, 161, -5, 3, -5, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 155, 18, 6, 18, 6,
+ax_anim 2, 0, 156, 23, 12, 23, 12,
+ax_anim 3, 0, 157, 20, 16, 20, 16,
+ax_anim 2, 3, 158, 11, 17, 11, 17,
+ax_anim 2, 0, 159, 3, 14, 3, 14,
+ax_anim 1, 0, 160, -1, 7, -1, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 9, -7, 9, -7,
+ax_anim 2, 0, 155, 16, -4, 16, -4,
+ax_anim 3, 0, 156, 20, 0, 20, 0,
+ax_anim 2, 3, 157, 17, 6, 17, 6,
+ax_anim 2, 0, 158, 10, 7, 10, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -18, 4, -18,
+ax_anim 2, 0, 154, 13, -25, 13, -25,
+ax_anim 3, 0, 155, 21, -23, 21, -23,
+ax_anim 2, 3, 156, 23, -14, 23, -14,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 9, -1, 9, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -2, -8, -2,
+ax_anim 2, 0, 160, -11, -11, -11, -11,
+ax_anim 2, 0, 161, -7, -19, -7, -19,
+ax_anim 3, 0, 154, 0, -24, 0, -24,
+ax_anim 2, 3, 155, 7, -19, 7, -19,
+ax_anim 2, 0, 156, 11, -9, 11, -9,
+ax_anim 1, 0, 157, 8, -2, 8, -2,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -18, -4, -18,
+ax_anim 2, 0, 154, -13, -25, -13, -25,
+ax_anim 3, 0, 161, -21, -23, -21, -23,
+ax_anim 2, 3, 160, -23, -14, -23, -14,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -9, -1, -9, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -9, -7, -9, -7,
+ax_anim 2, 0, 161, -16, -4, -16, -4,
+ax_anim 3, 0, 160, -20, 0, -20, 0,
+ax_anim 2, 3, 159, -17, 6, -17, 6,
+ax_anim 2, 0, 158, -10, 7, -10, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 161, -18, 6, -18, 6,
+ax_anim 2, 0, 160, -23, 12, -23, 12,
+ax_anim 3, 0, 159, -20, 16, -20, 16,
+ax_anim 2, 3, 158, -11, 17, -11, 17,
+ax_anim 2, 0, 157, -3, 14, -3, 14,
+ax_anim 1, 0, 156, 1, 7, 1, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -11, 0, 0,
+ax_anim 2, 0, 172, 0, -17, 0, 0,
+ax_anim 3, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -9, 0, 0,
+ax_anim 2, 0, 175, 0, -15, 0, 0,
+ax_anim 3, 0, 175, 0, -19, 0, 0,
+ax_anim 4, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 3, 0, 174, 0, -18, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -24, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -18, 0, 0,
+ax_anim 4, 0, 184, 0, -19, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -15, 0, 0,
+ax_anim 1, 0, 183, 0, -9, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -24, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -18, 0, 0,
+ax_anim 1, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -9, 0, 0,
+ax_anim 2, 0, 193, 0, -15, 0, 0,
+ax_anim 3, 0, 193, 0, -19, 0, 0,
+ax_anim 4, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 3, 0, 192, 0, -18, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQuilavaAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sQuilavaGfx1:
+.incbin "baserom.gba", 0xBD5564, 0x100
+sQuilavaSprites1:
+ax_sprite sQuilavaGfx1, 0x100
+ax_sprite_terminator
+sQuilavaGfx2:
+.incbin "baserom.gba", 0xBD5674, 0x100
+sQuilavaSprites2:
+ax_sprite sQuilavaGfx2, 0x100
+ax_sprite_terminator
+sQuilavaGfx3:
+.incbin "baserom.gba", 0xBD5784, 0x100
+sQuilavaSprites3:
+ax_sprite sQuilavaGfx3, 0x100
+ax_sprite_terminator
+sQuilavaGfx4:
+.incbin "baserom.gba", 0xBD5894, 0x200
+sQuilavaSprites4:
+ax_sprite sQuilavaGfx4, 0x200
+ax_sprite_terminator
+sQuilavaGfx5:
+.incbin "baserom.gba", 0xBD5AA4, 0x200
+sQuilavaSprites5:
+ax_sprite sQuilavaGfx5, 0x200
+ax_sprite_terminator
+sQuilavaGfx6:
+.incbin "baserom.gba", 0xBD5CB4, 0x200
+sQuilavaSprites6:
+ax_sprite sQuilavaGfx6, 0x200
+ax_sprite_terminator
+sQuilavaGfx7:
+.incbin "baserom.gba", 0xBD5EC4, 0x100
+sQuilavaSprites7:
+ax_sprite sQuilavaGfx7, 0x100
+ax_sprite_terminator
+sQuilavaGfx8:
+.incbin "baserom.gba", 0xBD5FD4, 0x100
+sQuilavaSprites8:
+ax_sprite sQuilavaGfx8, 0x100
+ax_sprite_terminator
+sQuilavaGfx9:
+.incbin "baserom.gba", 0xBD60E4, 0x100
+sQuilavaSprites9:
+ax_sprite sQuilavaGfx9, 0x100
+ax_sprite_terminator
+sQuilavaGfx10:
+.incbin "baserom.gba", 0xBD61F4, 0x200
+sQuilavaSprites10:
+ax_sprite sQuilavaGfx10, 0x200
+ax_sprite_terminator
+sQuilavaGfx11:
+.incbin "baserom.gba", 0xBD6404, 0x200
+sQuilavaSprites11:
+ax_sprite sQuilavaGfx11, 0x200
+ax_sprite_terminator
+sQuilavaGfx12:
+.incbin "baserom.gba", 0xBD6614, 0x200
+sQuilavaSprites12:
+ax_sprite sQuilavaGfx12, 0x200
+ax_sprite_terminator
+sQuilavaGfx13:
+.incbin "baserom.gba", 0xBD6824, 0x100
+sQuilavaSprites13:
+ax_sprite sQuilavaGfx13, 0x100
+ax_sprite_terminator
+sQuilavaGfx14:
+.incbin "baserom.gba", 0xBD6934, 0x100
+sQuilavaSprites14:
+ax_sprite sQuilavaGfx14, 0x100
+ax_sprite_terminator
+sQuilavaGfx15:
+.incbin "baserom.gba", 0xBD6A44, 0x100
+sQuilavaSprites15:
+ax_sprite sQuilavaGfx15, 0x100
+ax_sprite_terminator
+sQuilavaGfx16:
+.incbin "baserom.gba", 0xBD6B54, 0x60
+sQuilavaGfx16_1:
+.incbin "baserom.gba", 0xBD6BB4, 0x60
+sQuilavaGfx16_2:
+.incbin "baserom.gba", 0xBD6C14, 0x60
+sQuilavaSprites16:
+ax_sprite sQuilavaGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx17:
+.incbin "baserom.gba", 0xBD6CAC, 0x60
+sQuilavaGfx17_1:
+.incbin "baserom.gba", 0xBD6D0C, 0x60
+sQuilavaGfx17_2:
+.incbin "baserom.gba", 0xBD6D6C, 0x60
+sQuilavaGfx17_3:
+.incbin "baserom.gba", 0xBD6DCC, 0x20
+sQuilavaSprites17:
+ax_sprite sQuilavaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx17_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx18:
+.incbin "baserom.gba", 0xBD6E34, 0x40
+sQuilavaGfx18_1:
+.incbin "baserom.gba", 0xBD6E74, 0x60
+sQuilavaGfx18_2:
+.incbin "baserom.gba", 0xBD6ED4, 0x60
+sQuilavaGfx18_3:
+.incbin "baserom.gba", 0xBD6F34, 0x20
+sQuilavaSprites18:
+ax_sprite sQuilavaGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx19:
+.incbin "baserom.gba", 0xBD6F9C, 0x180
+sQuilavaSprites19:
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx19, 0x180
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sQuilavaGfx20:
+.incbin "baserom.gba", 0xBD713C, 0x160
+sQuilavaSprites20:
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx20, 0x160
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sQuilavaGfx21:
+.incbin "baserom.gba", 0xBD72BC, 0x60
+sQuilavaGfx21_1:
+.incbin "baserom.gba", 0xBD731C, 0x120
+sQuilavaSprites21:
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx21_1, 0x120
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx22:
+.incbin "baserom.gba", 0xBD746C, 0x100
+sQuilavaGfx22_1:
+.incbin "baserom.gba", 0xBD756C, 0x40
+sQuilavaSprites22:
+ax_sprite sQuilavaGfx22, 0x100
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx22_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx23:
+.incbin "baserom.gba", 0xBD75D4, 0x120
+sQuilavaGfx23_1:
+.incbin "baserom.gba", 0xBD76F4, 0x40
+sQuilavaSprites23:
+ax_sprite sQuilavaGfx23, 0x120
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx23_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx24:
+.incbin "baserom.gba", 0xBD775C, 0x160
+sQuilavaSprites24:
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx24, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx25:
+.incbin "baserom.gba", 0xBD78DC, 0x60
+sQuilavaGfx25_1:
+.incbin "baserom.gba", 0xBD793C, 0x80
+sQuilavaGfx25_2:
+.incbin "baserom.gba", 0xBD79BC, 0x40
+sQuilavaSprites25:
+ax_sprite sQuilavaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx25_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx26:
+.incbin "baserom.gba", 0xBD7A34, 0x60
+sQuilavaGfx26_1:
+.incbin "baserom.gba", 0xBD7A94, 0x60
+sQuilavaGfx26_2:
+.incbin "baserom.gba", 0xBD7AF4, 0x60
+sQuilavaSprites26:
+ax_sprite sQuilavaGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx27:
+.incbin "baserom.gba", 0xBD7B8C, 0x60
+sQuilavaGfx27_1:
+.incbin "baserom.gba", 0xBD7BEC, 0x80
+sQuilavaGfx27_2:
+.incbin "baserom.gba", 0xBD7C6C, 0x60
+sQuilavaSprites27:
+ax_sprite sQuilavaGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx27_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx28:
+.incbin "baserom.gba", 0xBD7D04, 0x20
+sQuilavaGfx28_1:
+.incbin "baserom.gba", 0xBD7D24, 0x60
+sQuilavaGfx28_2:
+.incbin "baserom.gba", 0xBD7D84, 0x60
+sQuilavaSprites28:
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx29:
+.incbin "baserom.gba", 0xBD7E24, 0xA0
+sQuilavaSprites29:
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx29, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx30:
+.incbin "baserom.gba", 0xBD7EE4, 0x20
+sQuilavaGfx30_1:
+.incbin "baserom.gba", 0xBD7F04, 0x60
+sQuilavaGfx30_2:
+.incbin "baserom.gba", 0xBD7F64, 0x60
+sQuilavaSprites30:
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx30, 0x20
+ax_sprite 0, 0x60
+ax_sprite sQuilavaGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx30_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx31:
+.incbin "baserom.gba", 0xBD8004, 0x60
+sQuilavaGfx31_1:
+.incbin "baserom.gba", 0xBD8064, 0x60
+sQuilavaGfx31_2:
+.incbin "baserom.gba", 0xBD80C4, 0x60
+sQuilavaSprites31:
+ax_sprite 0, 0x80
+ax_sprite sQuilavaGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuilavaGfx32:
+.incbin "baserom.gba", 0xBD8164, 0x40
+sQuilavaGfx32_1:
+.incbin "baserom.gba", 0xBD81A4, 0x60
+sQuilavaGfx32_2:
+.incbin "baserom.gba", 0xBD8204, 0x60
+sQuilavaSprites32:
+ax_sprite 0, 0x80
+ax_sprite sQuilavaGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuilavaGfx33:
+.incbin "baserom.gba", 0xBD82A4, 0x60
+sQuilavaGfx33_1:
+.incbin "baserom.gba", 0xBD8304, 0x60
+sQuilavaGfx33_2:
+.incbin "baserom.gba", 0xBD8364, 0x20
+sQuilavaGfx33_3:
+.incbin "baserom.gba", 0xBD8384, 0x20
+sQuilavaSprites33:
+ax_sprite sQuilavaGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx33_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx33_3, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx34:
+.incbin "baserom.gba", 0xBD83EC, 0x60
+sQuilavaGfx34_1:
+.incbin "baserom.gba", 0xBD844C, 0x60
+sQuilavaGfx34_2:
+.incbin "baserom.gba", 0xBD84AC, 0x20
+sQuilavaGfx34_3:
+.incbin "baserom.gba", 0xBD84CC, 0x20
+sQuilavaSprites34:
+ax_sprite sQuilavaGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx34_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx34_3, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx35:
+.incbin "baserom.gba", 0xBD8534, 0x40
+sQuilavaGfx35_1:
+.incbin "baserom.gba", 0xBD8574, 0x60
+sQuilavaGfx35_2:
+.incbin "baserom.gba", 0xBD85D4, 0x40
+sQuilavaSprites35:
+ax_sprite 0, 0xa0
+ax_sprite sQuilavaGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx35_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx36:
+.incbin "baserom.gba", 0xBD8654, 0x100
+sQuilavaGfx36_1:
+.incbin "baserom.gba", 0xBD8754, 0x40
+sQuilavaSprites36:
+ax_sprite sQuilavaGfx36, 0x100
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx36_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx37:
+.incbin "baserom.gba", 0xBD87BC, 0x60
+sQuilavaGfx37_1:
+.incbin "baserom.gba", 0xBD881C, 0x60
+sQuilavaGfx37_2:
+.incbin "baserom.gba", 0xBD887C, 0x40
+sQuilavaSprites37:
+ax_sprite 0, 0x80
+ax_sprite sQuilavaGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx37_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx38:
+.incbin "baserom.gba", 0xBD88FC, 0x100
+sQuilavaGfx38_1:
+.incbin "baserom.gba", 0xBD89FC, 0x40
+sQuilavaSprites38:
+ax_sprite sQuilavaGfx38, 0x100
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx38_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx39:
+.incbin "baserom.gba", 0xBD8A64, 0x60
+sQuilavaGfx39_1:
+.incbin "baserom.gba", 0xBD8AC4, 0x60
+sQuilavaGfx39_2:
+.incbin "baserom.gba", 0xBD8B24, 0x60
+sQuilavaSprites39:
+ax_sprite 0, 0x80
+ax_sprite sQuilavaGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuilavaGfx40:
+.incbin "baserom.gba", 0xBD8BC4, 0x100
+sQuilavaGfx40_1:
+.incbin "baserom.gba", 0xBD8CC4, 0x40
+sQuilavaSprites40:
+ax_sprite sQuilavaGfx40, 0x100
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx40_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx41:
+.incbin "baserom.gba", 0xBD8D2C, 0x60
+sQuilavaGfx41_1:
+.incbin "baserom.gba", 0xBD8D8C, 0x80
+sQuilavaGfx41_2:
+.incbin "baserom.gba", 0xBD8E0C, 0x60
+sQuilavaSprites41:
+ax_sprite 0, 0x80
+ax_sprite sQuilavaGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx41_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx41_2, 0x60
+ax_sprite_terminator
+sQuilavaGfx42:
+.incbin "baserom.gba", 0xBD8EA4, 0x100
+sQuilavaGfx42_1:
+.incbin "baserom.gba", 0xBD8FA4, 0x40
+sQuilavaSprites42:
+ax_sprite sQuilavaGfx42, 0x100
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx42_1, 0x40
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sQuilavaGfx43:
+.incbin "baserom.gba", 0xBD900C, 0x60
+sQuilavaGfx43_1:
+.incbin "baserom.gba", 0xBD906C, 0x60
+sQuilavaGfx43_2:
+.incbin "baserom.gba", 0xBD90CC, 0x40
+sQuilavaSprites43:
+ax_sprite 0, 0x80
+ax_sprite sQuilavaGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx43_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx43_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuilavaGfx44:
+.incbin "baserom.gba", 0xBD914C, 0x60
+sQuilavaGfx44_1:
+.incbin "baserom.gba", 0xBD91AC, 0x40
+sQuilavaGfx44_2:
+.incbin "baserom.gba", 0xBD91EC, 0x40
+sQuilavaSprites44:
+ax_sprite sQuilavaGfx44, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx44_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx44_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx45:
+.incbin "baserom.gba", 0xBD9264, 0x40
+sQuilavaGfx45_1:
+.incbin "baserom.gba", 0xBD92A4, 0x60
+sQuilavaGfx45_2:
+.incbin "baserom.gba", 0xBD9304, 0x60
+sQuilavaGfx45_3:
+.incbin "baserom.gba", 0xBD9364, 0x40
+sQuilavaSprites45:
+ax_sprite sQuilavaGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx45_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx45_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQuilavaGfx46:
+.incbin "baserom.gba", 0xBD93EC, 0x60
+sQuilavaGfx46_1:
+.incbin "baserom.gba", 0xBD944C, 0x60
+sQuilavaGfx46_2:
+.incbin "baserom.gba", 0xBD94AC, 0x40
+sQuilavaSprites46:
+ax_sprite sQuilavaGfx46, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx46_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx47:
+.incbin "baserom.gba", 0xBD9524, 0x40
+sQuilavaGfx47_1:
+.incbin "baserom.gba", 0xBD9564, 0x60
+sQuilavaGfx47_2:
+.incbin "baserom.gba", 0xBD95C4, 0x40
+sQuilavaSprites47:
+ax_sprite 0, 0x80
+ax_sprite sQuilavaGfx47, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx47_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx48:
+.incbin "baserom.gba", 0xBD9644, 0x40
+sQuilavaGfx48_1:
+.incbin "baserom.gba", 0xBD9684, 0x60
+sQuilavaGfx48_2:
+.incbin "baserom.gba", 0xBD96E4, 0x60
+sQuilavaSprites48:
+ax_sprite sQuilavaGfx48, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx48_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx49:
+.incbin "baserom.gba", 0xBD977C, 0x40
+sQuilavaGfx49_1:
+.incbin "baserom.gba", 0xBD97BC, 0x40
+sQuilavaGfx49_2:
+.incbin "baserom.gba", 0xBD97FC, 0x60
+sQuilavaGfx49_3:
+.incbin "baserom.gba", 0xBD985C, 0x40
+sQuilavaSprites49:
+ax_sprite sQuilavaGfx49, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx49_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx49_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQuilavaGfx50:
+.incbin "baserom.gba", 0xBD98E4, 0x40
+sQuilavaGfx50_1:
+.incbin "baserom.gba", 0xBD9924, 0x60
+sQuilavaGfx50_2:
+.incbin "baserom.gba", 0xBD9984, 0x60
+sQuilavaSprites50:
+ax_sprite sQuilavaGfx50, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQuilavaGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQuilavaGfx50_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sQuilavaGfx51:
+.incbin "baserom.gba", 0xBD9A1C, 0x200
+sQuilavaSprites51:
+ax_sprite sQuilavaGfx51, 0x200
+ax_sprite_terminator
+sQuilavaGfx52:
+.incbin "baserom.gba", 0xBD9C2C, 0x200
+sQuilavaSprites52:
+ax_sprite sQuilavaGfx52, 0x200
+ax_sprite_terminator
+sQuilavaGfx53:
+.incbin "baserom.gba", 0xBD9E3C, 0x200
+sQuilavaSprites53:
+ax_sprite sQuilavaGfx53, 0x200
+ax_sprite_terminator
+sQuilavaGfx54:
+.incbin "baserom.gba", 0xBDA04C, 0x200
+sQuilavaSprites54:
+ax_sprite sQuilavaGfx54, 0x200
+ax_sprite_terminator
+sQuilavaGfx55:
+.incbin "baserom.gba", 0xBDA25C, 0x200
+sQuilavaSprites55:
+ax_sprite sQuilavaGfx55, 0x200
+ax_sprite_terminator
+sQuilavaGfx56:
+.incbin "baserom.gba", 0xBDA46C, 0x200
+sQuilavaSprites56:
+ax_sprite sQuilavaGfx56, 0x200
+ax_sprite_terminator
+sQuilavaGfx57:
+.incbin "baserom.gba", 0xBDA67C, 0x200
+sQuilavaSprites57:
+ax_sprite sQuilavaGfx57, 0x200
+ax_sprite_terminator
+sAxPosesQuilava:
+.4byte sQuilavaPose1
+.4byte sQuilavaPose2
+.4byte sQuilavaPose3
+.4byte sQuilavaPose4
+.4byte sQuilavaPose5
+.4byte sQuilavaPose6
+.4byte sQuilavaPose7
+.4byte sQuilavaPose8
+.4byte sQuilavaPose9
+.4byte sQuilavaPose10
+.4byte sQuilavaPose11
+.4byte sQuilavaPose12
+.4byte sQuilavaPose13
+.4byte sQuilavaPose14
+.4byte sQuilavaPose15
+.4byte sQuilavaPose16
+.4byte sQuilavaPose17
+.4byte sQuilavaPose18
+.4byte sQuilavaPose19
+.4byte sQuilavaPose20
+.4byte sQuilavaPose21
+.4byte sQuilavaPose22
+.4byte sQuilavaPose23
+.4byte sQuilavaPose24
+.4byte sQuilavaPose25
+.4byte sQuilavaPose26
+.4byte sQuilavaPose27
+.4byte sQuilavaPose28
+.4byte sQuilavaPose29
+.4byte sQuilavaPose30
+.4byte sQuilavaPose31
+.4byte sQuilavaPose32
+.4byte sQuilavaPose33
+.4byte sQuilavaPose34
+.4byte sQuilavaPose35
+.4byte sQuilavaPose36
+.4byte sQuilavaPose37
+.4byte sQuilavaPose38
+.4byte sQuilavaPose39
+.4byte sQuilavaPose40
+.4byte sQuilavaPose41
+.4byte sQuilavaPose42
+.4byte sQuilavaPose43
+.4byte sQuilavaPose44
+.4byte sQuilavaPose45
+.4byte sQuilavaPose46
+.4byte sQuilavaPose47
+.4byte sQuilavaPose48
+.4byte sQuilavaPose49
+.4byte sQuilavaPose50
+.4byte sQuilavaPose51
+.4byte sQuilavaPose52
+.4byte sQuilavaPose53
+.4byte sQuilavaPose54
+.4byte sQuilavaPose55
+.4byte sQuilavaPose56
+.4byte sQuilavaPose57
+.4byte sQuilavaPose58
+.4byte sQuilavaPose59
+.4byte sQuilavaPose60
+.4byte sQuilavaPose61
+.4byte sQuilavaPose62
+.4byte sQuilavaPose63
+.4byte sQuilavaPose64
+.4byte sQuilavaPose65
+.4byte sQuilavaPose66
+.4byte sQuilavaPose67
+.4byte sQuilavaPose68
+.4byte sQuilavaPose69
+.4byte sQuilavaPose70
+.4byte sQuilavaPose71
+.4byte sQuilavaPose72
+.4byte sQuilavaPose73
+.4byte sQuilavaPose74
+.4byte sQuilavaPose75
+.4byte sQuilavaPose76
+.4byte sQuilavaPose77
+.4byte sQuilavaPose78
+.4byte sQuilavaPose79
+.4byte sQuilavaPose80
+.4byte sQuilavaPose81
+.4byte sQuilavaPose82
+.4byte sQuilavaPose83
+.4byte sQuilavaPose84
+.4byte sQuilavaPose85
+.4byte sQuilavaPose86
+.4byte sQuilavaPose87
+.4byte sQuilavaPose88
+.4byte sQuilavaPose89
+.4byte sQuilavaPose90
+.4byte sQuilavaPose91
+.4byte sQuilavaPose92
+.4byte sQuilavaPose93
+.4byte sQuilavaPose94
+.4byte sQuilavaPose95
+.4byte sQuilavaPose96
+.4byte sQuilavaPose97
+.4byte sQuilavaPose98
+.4byte sQuilavaPose99
+.4byte sQuilavaPose100
+.4byte sQuilavaPose101
+.4byte sQuilavaPose102
+.4byte sQuilavaPose103
+.4byte sQuilavaPose104
+.4byte sQuilavaPose105
+.4byte sQuilavaPose106
+.4byte sQuilavaPose107
+.4byte sQuilavaPose108
+.4byte sQuilavaPose109
+.4byte sQuilavaPose110
+.4byte sQuilavaPose111
+.4byte sQuilavaPose112
+.4byte sQuilavaPose113
+.4byte sQuilavaPose114
+.4byte sQuilavaPose115
+.4byte sQuilavaPose116
+.4byte sQuilavaPose117
+.4byte sQuilavaPose118
+.4byte sQuilavaPose119
+.4byte sQuilavaPose120
+.4byte sQuilavaPose121
+.4byte sQuilavaPose122
+.4byte sQuilavaPose123
+.4byte sQuilavaPose124
+.4byte sQuilavaPose125
+.4byte sQuilavaPose126
+.4byte sQuilavaPose127
+.4byte sQuilavaPose128
+.4byte sQuilavaPose129
+.4byte sQuilavaPose130
+.4byte sQuilavaPose131
+.4byte sQuilavaPose132
+.4byte sQuilavaPose133
+.4byte sQuilavaPose134
+.4byte sQuilavaPose135
+.4byte sQuilavaPose136
+.4byte sQuilavaPose137
+.4byte sQuilavaPose138
+.4byte sQuilavaPose139
+.4byte sQuilavaPose140
+.4byte sQuilavaPose141
+.4byte sQuilavaPose142
+.4byte sQuilavaPose143
+.4byte sQuilavaPose144
+.4byte sQuilavaPose145
+.4byte sQuilavaPose146
+.4byte sQuilavaPose147
+.4byte sQuilavaPose148
+.4byte sQuilavaPose149
+.4byte sQuilavaPose150
+.4byte sQuilavaPose151
+.4byte sQuilavaPose152
+.4byte sQuilavaPose153
+.4byte sQuilavaPose154
+.4byte sQuilavaPose155
+.4byte sQuilavaPose156
+.4byte sQuilavaPose157
+.4byte sQuilavaPose158
+.4byte sQuilavaPose159
+.4byte sQuilavaPose160
+.4byte sQuilavaPose161
+.4byte sQuilavaPose162
+.4byte sQuilavaPose163
+.4byte sQuilavaPose164
+.4byte sQuilavaPose165
+.4byte sQuilavaPose166
+.4byte sQuilavaPose167
+.4byte sQuilavaPose168
+.4byte sQuilavaPose169
+.4byte sQuilavaPose170
+.4byte sQuilavaPose171
+.4byte sQuilavaPose172
+.4byte sQuilavaPose173
+.4byte sQuilavaPose174
+.4byte sQuilavaPose175
+.4byte sQuilavaPose176
+.4byte sQuilavaPose177
+.4byte sQuilavaPose178
+.4byte sQuilavaPose179
+.4byte sQuilavaPose180
+.4byte sQuilavaPose181
+.4byte sQuilavaPose182
+.4byte sQuilavaPose183
+.4byte sQuilavaPose184
+.4byte sQuilavaPose185
+.4byte sQuilavaPose186
+.4byte sQuilavaPose187
+.4byte sQuilavaPose188
+.4byte sQuilavaPose189
+.4byte sQuilavaPose190
+.4byte sQuilavaPose191
+.4byte sQuilavaPose192
+.4byte sQuilavaPose193
+.4byte sQuilavaPose194
+.4byte sQuilavaPose195
+.4byte sQuilavaPose196
+.4byte sQuilavaPose197
+.4byte sQuilavaPose198
+.4byte sQuilavaPose199
+.4byte sQuilavaPose200
+.4byte sQuilavaPose201
+.4byte sQuilavaPose202
+.4byte sQuilavaPose203
+.4byte sQuilavaPose204
+.4byte sQuilavaPose205
+.4byte sQuilavaPose206
+.4byte sQuilavaPose207
+.4byte sQuilavaPose208
+.4byte sQuilavaPose209
+.4byte sQuilavaPose210
+sAxPositionsQuilava:
+.2byte   -1,    2, 	  -6,    4, 	   4,    4, 	  -1,   -5
+.2byte   -2,    3, 	  -5,    5, 	   3,    3, 	  -2,   -6
+.2byte    0,    3, 	  -5,    3, 	   3,    5, 	   0,   -6
+.2byte    7,    1, 	   6,    0, 	   1,    3, 	  -2,   -6
+.2byte    8,    2, 	   8,    1, 	  -1,    2, 	  -1,   -5
+.2byte    6,    3, 	   4,    0, 	   2,    4, 	  -3,   -5
+.2byte   11,   -3, 	   6,   -2, 	   5,    1, 	  -2,   -5
+.2byte   12,   -2, 	   9,   -2, 	   0,    1, 	  -2,   -4
+.2byte   11,   -1, 	   1,   -1, 	   6,    1, 	  -2,   -4
+.2byte    7,   -7, 	   1,   -5, 	   7,   -2, 	  -1,   -4
+.2byte    6,   -6, 	   1,   -7, 	   4,   -1, 	  -2,   -3
+.2byte    8,   -6, 	   0,   -5, 	   7,   -3, 	  -1,   -4
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -2,   -8, 	   3,   -5, 	  -6,   -2, 	  -1,   -4
+.2byte    0,   -8, 	   4,   -2, 	  -5,   -5, 	  -1,   -4
+.2byte   -9,   -7, 	  -3,   -5, 	  -9,   -2, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,   -7, 	  -6,   -1, 	   0,   -3
+.2byte  -10,   -6, 	  -2,   -5, 	  -9,   -3, 	  -1,   -4
+.2byte  -13,   -3, 	  -8,   -2, 	  -7,    1, 	   0,   -5
+.2byte  -14,   -2, 	 -11,   -2, 	  -2,    1, 	   0,   -4
+.2byte  -13,   -1, 	  -3,   -1, 	  -8,    1, 	   0,   -4
+.2byte   -9,    1, 	  -8,    0, 	  -3,    3, 	   0,   -6
+.2byte  -10,    2, 	 -10,    1, 	  -1,    2, 	  -1,   -5
+.2byte   -8,    3, 	  -6,    0, 	  -4,    4, 	   1,   -5
+.2byte   -1,    2, 	  -6,    4, 	   4,    4, 	  -1,   -5
+.2byte   -2,    3, 	  -5,    5, 	   3,    3, 	  -2,   -6
+.2byte    0,    3, 	  -5,    3, 	   3,    5, 	   0,   -6
+.2byte   -1,    2, 	  -6,    4, 	   4,    4, 	  -1,   -5
+.2byte    7,    1, 	   6,    0, 	   1,    3, 	  -2,   -6
+.2byte    8,    2, 	   8,    1, 	  -1,    2, 	  -1,   -5
+.2byte    6,    3, 	   4,    0, 	   2,    4, 	  -3,   -5
+.2byte    7,    1, 	   6,    0, 	   1,    3, 	  -2,   -6
+.2byte   11,   -3, 	   6,   -2, 	   5,    1, 	  -2,   -5
+.2byte   12,   -2, 	   9,   -2, 	   0,    1, 	  -2,   -4
+.2byte   11,   -1, 	   1,   -1, 	   6,    1, 	  -2,   -4
+.2byte   11,   -3, 	   6,   -2, 	   5,    1, 	  -2,   -5
+.2byte    7,   -7, 	   1,   -5, 	   7,   -2, 	  -1,   -4
+.2byte    6,   -6, 	   1,   -7, 	   4,   -1, 	  -2,   -3
+.2byte    8,   -6, 	   0,   -5, 	   7,   -3, 	  -1,   -4
+.2byte    7,   -7, 	   1,   -5, 	   7,   -2, 	  -1,   -4
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -2,   -8, 	   3,   -5, 	  -6,   -2, 	  -1,   -4
+.2byte    0,   -8, 	   4,   -2, 	  -5,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -9,   -7, 	  -3,   -5, 	  -9,   -2, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,   -7, 	  -6,   -1, 	   0,   -3
+.2byte  -10,   -6, 	  -2,   -5, 	  -9,   -3, 	  -1,   -4
+.2byte   -9,   -7, 	  -3,   -5, 	  -9,   -2, 	  -1,   -4
+.2byte  -13,   -3, 	  -8,   -2, 	  -7,    1, 	   0,   -5
+.2byte  -14,   -2, 	 -11,   -2, 	  -2,    1, 	   0,   -4
+.2byte  -13,   -1, 	  -3,   -1, 	  -8,    1, 	   0,   -4
+.2byte  -13,   -3, 	  -8,   -2, 	  -7,    1, 	   0,   -5
+.2byte   -9,    1, 	  -8,    0, 	  -3,    3, 	   0,   -6
+.2byte  -10,    2, 	 -10,    1, 	  -1,    2, 	  -1,   -5
+.2byte   -8,    3, 	  -6,    0, 	  -4,    4, 	   1,   -5
+.2byte   -9,    1, 	  -8,    0, 	  -3,    3, 	   0,   -6
+.2byte   -1,    2, 	  -6,    4, 	   4,    4, 	  -1,   -5
+.2byte   -2,    3, 	  -5,    5, 	   3,    3, 	  -2,   -6
+.2byte    0,    3, 	  -5,    3, 	   3,    5, 	   0,   -6
+.2byte    7,    1, 	   6,    0, 	   1,    3, 	  -2,   -6
+.2byte    8,    2, 	   8,    1, 	  -1,    2, 	  -1,   -5
+.2byte    6,    3, 	   4,    0, 	   2,    4, 	  -3,   -5
+.2byte   11,   -3, 	   6,   -2, 	   5,    1, 	  -2,   -5
+.2byte   12,   -2, 	   9,   -2, 	   0,    1, 	  -2,   -4
+.2byte   11,   -1, 	   1,   -1, 	   6,    1, 	  -2,   -4
+.2byte    7,   -7, 	   1,   -5, 	   7,   -2, 	  -1,   -4
+.2byte    6,   -6, 	   1,   -7, 	   4,   -1, 	  -2,   -3
+.2byte    8,   -6, 	   0,   -5, 	   7,   -3, 	  -1,   -4
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -2,   -8, 	   3,   -5, 	  -6,   -2, 	  -1,   -4
+.2byte    0,   -8, 	   4,   -2, 	  -5,   -5, 	  -1,   -4
+.2byte   -9,   -7, 	  -3,   -5, 	  -9,   -2, 	  -1,   -4
+.2byte   -8,   -6, 	  -3,   -7, 	  -6,   -1, 	   0,   -3
+.2byte  -10,   -6, 	  -2,   -5, 	  -9,   -3, 	  -1,   -4
+.2byte  -13,   -3, 	  -8,   -2, 	  -7,    1, 	   0,   -5
+.2byte  -14,   -2, 	 -11,   -2, 	  -2,    1, 	   0,   -4
+.2byte  -13,   -1, 	  -3,   -1, 	  -8,    1, 	   0,   -4
+.2byte   -9,    1, 	  -8,    0, 	  -3,    3, 	   0,   -6
+.2byte  -10,    2, 	 -10,    1, 	  -1,    2, 	  -1,   -5
+.2byte   -8,    3, 	  -6,    0, 	  -4,    4, 	   1,   -5
+.2byte   -1,    2, 	  -6,    4, 	   4,    4, 	  -1,   -5
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -1,   -4, 	  -7,    4, 	   5,    4, 	  -1,   -2
+.2byte   -1,   -4, 	  -7,    4, 	   5,    4, 	  -1,   -2
+.2byte   -1,   -4, 	  -7,    4, 	   5,    4, 	  -1,   -2
+.2byte    7,    1, 	   6,    0, 	   1,    3, 	  -2,   -6
+.2byte    6,    3, 	   6,    1, 	   0,    2, 	   1,   -7
+.2byte    6,   -4, 	   5,   -1, 	  -2,    2, 	  -2,   -7
+.2byte    6,   -4, 	   5,   -1, 	  -2,    2, 	  -2,   -7
+.2byte    6,   -4, 	   5,   -1, 	  -2,    2, 	  -2,   -7
+.2byte   11,   -3, 	   6,   -2, 	   5,    1, 	  -2,   -5
+.2byte    9,    0, 	   3,   -2, 	   2,    1, 	  -1,   -7
+.2byte   10,   -5, 	   6,   -2, 	   5,    2, 	  -1,   -4
+.2byte   10,   -5, 	   6,   -2, 	   5,    2, 	  -1,   -4
+.2byte   10,   -5, 	   6,   -2, 	   5,    2, 	  -1,   -4
+.2byte    7,   -7, 	   1,   -5, 	   7,   -2, 	  -1,   -4
+.2byte    6,   -4, 	   0,   -4, 	   5,   -1, 	   0,   -7
+.2byte    7,  -11, 	   0,   -7, 	   7,   -3, 	   0,   -6
+.2byte    7,  -11, 	   0,   -7, 	   7,   -3, 	   0,   -6
+.2byte    7,  -11, 	   0,   -7, 	   7,   -3, 	   0,   -6
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -13, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,  -13, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,  -13, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -9,   -7, 	  -3,   -5, 	  -9,   -2, 	  -1,   -4
+.2byte   -8,   -4, 	  -2,   -4, 	  -7,   -1, 	  -2,   -7
+.2byte   -9,  -11, 	  -2,   -7, 	  -9,   -3, 	  -2,   -6
+.2byte   -9,  -11, 	  -2,   -7, 	  -9,   -3, 	  -2,   -6
+.2byte   -9,  -11, 	  -2,   -7, 	  -9,   -3, 	  -2,   -6
+.2byte  -13,   -3, 	  -8,   -2, 	  -7,    1, 	   0,   -5
+.2byte  -11,    0, 	  -5,   -2, 	  -4,    1, 	  -1,   -7
+.2byte  -12,   -5, 	  -8,   -2, 	  -7,    2, 	  -1,   -4
+.2byte  -12,   -5, 	  -8,   -2, 	  -7,    2, 	  -1,   -4
+.2byte  -12,   -5, 	  -8,   -2, 	  -7,    2, 	  -1,   -4
+.2byte   -9,    1, 	  -8,    0, 	  -3,    3, 	   0,   -6
+.2byte   -8,    3, 	  -8,    1, 	  -2,    2, 	  -3,   -7
+.2byte   -8,   -4, 	  -7,   -1, 	   0,    2, 	   0,   -7
+.2byte   -8,   -4, 	  -7,   -1, 	   0,    2, 	   0,   -7
+.2byte   -8,   -4, 	  -7,   -1, 	   0,    2, 	   0,   -7
+.2byte   -1,    1, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte   -9,    0, 	  -8,   -1, 	  -3,    2, 	   0,   -7
+.2byte  -13,   -4, 	  -8,   -3, 	  -7,    0, 	   0,   -6
+.2byte   -9,   -8, 	  -3,   -6, 	  -9,   -3, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -5
+.2byte    7,   -8, 	   1,   -6, 	   7,   -3, 	  -1,   -5
+.2byte   11,   -4, 	   6,   -3, 	   5,    0, 	  -2,   -6
+.2byte    7,    0, 	   6,   -1, 	   1,    2, 	  -2,   -7
+.2byte   -2,    2, 	  -4,    4, 	   1,    3, 	   0,   -7
+.2byte   -2,    3, 	  -5,    4, 	   1,    3, 	   0,   -7
+.2byte    0,  -13, 	  -3,  -11, 	   3,  -11, 	   0,   -9
+.2byte    4,  -12, 	   4,  -10, 	  -1,  -11, 	  -2,   -9
+.2byte    5,  -15, 	   0,  -13, 	   1,  -11, 	  -4,   -9
+.2byte    6,  -17, 	   1,  -15, 	   5,  -12, 	  -3,   -9
+.2byte    0,  -17, 	   5,  -11, 	  -5,  -11, 	   0,  -10
+.2byte   -7,  -17, 	  -2,  -15, 	  -6,  -12, 	   2,   -9
+.2byte   -6,  -15, 	  -1,  -13, 	  -2,  -11, 	   3,   -9
+.2byte   -5,  -12, 	  -5,  -10, 	   0,  -11, 	   1,   -9
+.2byte   -1,    2, 	  -6,    4, 	   4,    4, 	  -1,   -5
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte    7,    1, 	   6,    0, 	   1,    3, 	  -2,   -6
+.2byte    6,    3, 	   6,    1, 	   0,    2, 	   1,   -7
+.2byte   11,   -3, 	   6,   -2, 	   5,    1, 	  -2,   -5
+.2byte   10,    0, 	   4,   -2, 	   3,    1, 	   0,   -7
+.2byte    7,   -7, 	   1,   -5, 	   7,   -2, 	  -1,   -4
+.2byte    7,   -4, 	   1,   -4, 	   6,   -1, 	   1,   -7
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -9,   -7, 	  -3,   -5, 	  -9,   -2, 	  -1,   -4
+.2byte   -9,   -4, 	  -3,   -4, 	  -8,   -1, 	  -3,   -7
+.2byte  -13,   -3, 	  -8,   -2, 	  -7,    1, 	   0,   -5
+.2byte  -12,    0, 	  -6,   -2, 	  -5,    1, 	  -2,   -7
+.2byte   -9,    1, 	  -8,    0, 	  -3,    3, 	   0,   -6
+.2byte   -8,    3, 	  -8,    1, 	  -2,    2, 	  -3,   -7
+.2byte   -1,   -4, 	  -7,    4, 	   5,    4, 	  -1,   -2
+.2byte   -8,   -3, 	  -7,    0, 	   0,    3, 	   0,   -6
+.2byte  -12,   -5, 	  -8,   -2, 	  -7,    2, 	  -1,   -4
+.2byte   -9,  -11, 	  -2,   -7, 	  -9,   -3, 	  -2,   -6
+.2byte   -1,  -13, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte    7,  -11, 	   0,   -7, 	   7,   -3, 	   0,   -6
+.2byte   10,   -5, 	   6,   -2, 	   5,    2, 	  -1,   -4
+.2byte    6,   -3, 	   5,    0, 	  -2,    3, 	  -2,   -6
+.2byte   -1,   -5, 	  -7,    3, 	   5,    3, 	  -1,   -3
+.2byte    6,   -3, 	   5,    0, 	  -2,    3, 	  -2,   -6
+.2byte   10,   -5, 	   6,   -2, 	   5,    2, 	  -1,   -4
+.2byte    6,  -11, 	  -1,   -7, 	   6,   -3, 	  -1,   -6
+.2byte   -1,  -13, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -8,  -11, 	  -1,   -7, 	  -8,   -3, 	  -1,   -6
+.2byte  -12,   -5, 	  -8,   -2, 	  -7,    2, 	  -1,   -4
+.2byte   -8,   -3, 	  -7,    0, 	   0,    3, 	   0,   -6
+.2byte   -1,    2, 	  -6,    4, 	   4,    4, 	  -1,   -5
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -1,   -4, 	  -7,    4, 	   5,    4, 	  -1,   -2
+.2byte    7,    1, 	   6,    0, 	   1,    3, 	  -2,   -6
+.2byte    5,    3, 	   5,    1, 	  -1,    2, 	   0,   -7
+.2byte    6,   -4, 	   5,   -1, 	  -2,    2, 	  -2,   -7
+.2byte   11,   -3, 	   6,   -2, 	   5,    1, 	  -2,   -5
+.2byte    9,    0, 	   3,   -2, 	   2,    1, 	  -1,   -7
+.2byte    9,   -5, 	   5,   -2, 	   4,    2, 	  -2,   -4
+.2byte    7,   -7, 	   1,   -5, 	   7,   -2, 	  -1,   -4
+.2byte    6,   -4, 	   0,   -4, 	   5,   -1, 	   0,   -7
+.2byte    6,  -11, 	  -1,   -7, 	   6,   -3, 	  -1,   -6
+.2byte   -1,   -8, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -13, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -9,   -7, 	  -3,   -5, 	  -9,   -2, 	  -1,   -4
+.2byte   -8,   -4, 	  -2,   -4, 	  -7,   -1, 	  -2,   -7
+.2byte   -8,  -11, 	  -1,   -7, 	  -8,   -3, 	  -1,   -6
+.2byte  -13,   -3, 	  -8,   -2, 	  -7,    1, 	   0,   -5
+.2byte  -11,    0, 	  -5,   -2, 	  -4,    1, 	  -1,   -7
+.2byte  -11,   -5, 	  -7,   -2, 	  -6,    2, 	   0,   -4
+.2byte   -9,    1, 	  -8,    0, 	  -3,    3, 	   0,   -6
+.2byte   -7,    3, 	  -7,    1, 	  -1,    2, 	  -2,   -7
+.2byte   -8,   -4, 	  -7,   -1, 	   0,    2, 	   0,   -7
+.2byte   -1,    3, 	  -6,    3, 	   4,    3, 	  -1,   -7
+.2byte   -8,    3, 	  -8,    1, 	  -2,    2, 	  -3,   -7
+.2byte  -11,    0, 	  -5,   -2, 	  -4,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -2,   -4, 	  -7,   -1, 	  -2,   -7
+.2byte   -1,   -9, 	   5,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte    6,   -4, 	   0,   -4, 	   5,   -1, 	   0,   -7
+.2byte    9,    0, 	   3,   -2, 	   2,    1, 	  -1,   -7
+.2byte    6,    3, 	   6,    1, 	   0,    2, 	   1,   -7
+.2byte   -1,    1, 	  -6,    3, 	   4,    3, 	  -1,   -6
+.2byte   -9,    0, 	  -8,   -1, 	  -3,    2, 	   0,   -7
+.2byte  -13,   -4, 	  -8,   -3, 	  -7,    0, 	   0,   -6
+.2byte   -9,   -8, 	  -3,   -6, 	  -9,   -3, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -4, 	  -6,   -4, 	  -1,   -5
+.2byte    7,   -8, 	   1,   -6, 	   7,   -3, 	  -1,   -5
+.2byte   11,   -4, 	   6,   -3, 	   5,    0, 	  -2,   -6
+.2byte    7,    0, 	   6,   -1, 	   1,    2, 	  -2,   -7
+sQuilavaAnimTable1:
+.4byte sQuilavaAnims_1_1
+.4byte sQuilavaAnims_1_2
+.4byte sQuilavaAnims_1_3
+.4byte sQuilavaAnims_1_4
+.4byte sQuilavaAnims_1_5
+.4byte sQuilavaAnims_1_6
+.4byte sQuilavaAnims_1_7
+.4byte sQuilavaAnims_1_8
+sQuilavaAnimTable2:
+.4byte sQuilavaAnims_2_1
+.4byte sQuilavaAnims_2_2
+.4byte sQuilavaAnims_2_3
+.4byte sQuilavaAnims_2_4
+.4byte sQuilavaAnims_2_5
+.4byte sQuilavaAnims_2_6
+.4byte sQuilavaAnims_2_7
+.4byte sQuilavaAnims_2_8
+sQuilavaAnimTable3:
+.4byte sQuilavaAnims_3_1
+.4byte sQuilavaAnims_3_2
+.4byte sQuilavaAnims_3_3
+.4byte sQuilavaAnims_3_4
+.4byte sQuilavaAnims_3_5
+.4byte sQuilavaAnims_3_6
+.4byte sQuilavaAnims_3_7
+.4byte sQuilavaAnims_3_8
+sQuilavaAnimTable4:
+.4byte sQuilavaAnims_4_1
+.4byte sQuilavaAnims_4_2
+.4byte sQuilavaAnims_4_3
+.4byte sQuilavaAnims_4_4
+.4byte sQuilavaAnims_4_5
+.4byte sQuilavaAnims_4_6
+.4byte sQuilavaAnims_4_7
+.4byte sQuilavaAnims_4_8
+sQuilavaAnimTable5:
+.4byte sQuilavaAnims_5_1
+.4byte sQuilavaAnims_5_2
+.4byte sQuilavaAnims_5_3
+.4byte sQuilavaAnims_5_4
+.4byte sQuilavaAnims_5_5
+.4byte sQuilavaAnims_5_6
+.4byte sQuilavaAnims_5_7
+.4byte sQuilavaAnims_5_8
+sQuilavaAnimTable6:
+.4byte sQuilavaAnims_6_1
+.4byte sQuilavaAnims_6_1
+.4byte sQuilavaAnims_6_1
+.4byte sQuilavaAnims_6_1
+.4byte sQuilavaAnims_6_1
+.4byte sQuilavaAnims_6_1
+.4byte sQuilavaAnims_6_1
+.4byte sQuilavaAnims_6_1
+sQuilavaAnimTable7:
+.4byte sQuilavaAnims_7_1
+.4byte sQuilavaAnims_7_2
+.4byte sQuilavaAnims_7_3
+.4byte sQuilavaAnims_7_4
+.4byte sQuilavaAnims_7_5
+.4byte sQuilavaAnims_7_6
+.4byte sQuilavaAnims_7_7
+.4byte sQuilavaAnims_7_8
+sQuilavaAnimTable8:
+.4byte sQuilavaAnims_8_1
+.4byte sQuilavaAnims_8_2
+.4byte sQuilavaAnims_8_3
+.4byte sQuilavaAnims_8_4
+.4byte sQuilavaAnims_8_5
+.4byte sQuilavaAnims_8_6
+.4byte sQuilavaAnims_8_7
+.4byte sQuilavaAnims_8_8
+sQuilavaAnimTable9:
+.4byte sQuilavaAnims_9_1
+.4byte sQuilavaAnims_9_2
+.4byte sQuilavaAnims_9_3
+.4byte sQuilavaAnims_9_4
+.4byte sQuilavaAnims_9_5
+.4byte sQuilavaAnims_9_6
+.4byte sQuilavaAnims_9_7
+.4byte sQuilavaAnims_9_8
+sQuilavaAnimTable10:
+.4byte sQuilavaAnims_10_1
+.4byte sQuilavaAnims_10_2
+.4byte sQuilavaAnims_10_3
+.4byte sQuilavaAnims_10_4
+.4byte sQuilavaAnims_10_5
+.4byte sQuilavaAnims_10_6
+.4byte sQuilavaAnims_10_7
+.4byte sQuilavaAnims_10_8
+sQuilavaAnimTable11:
+.4byte sQuilavaAnims_11_1
+.4byte sQuilavaAnims_11_2
+.4byte sQuilavaAnims_11_3
+.4byte sQuilavaAnims_11_4
+.4byte sQuilavaAnims_11_5
+.4byte sQuilavaAnims_11_6
+.4byte sQuilavaAnims_11_7
+.4byte sQuilavaAnims_11_8
+sQuilavaAnimTable12:
+.4byte sQuilavaAnims_12_1
+.4byte sQuilavaAnims_12_2
+.4byte sQuilavaAnims_12_3
+.4byte sQuilavaAnims_12_4
+.4byte sQuilavaAnims_12_5
+.4byte sQuilavaAnims_12_6
+.4byte sQuilavaAnims_12_7
+.4byte sQuilavaAnims_12_8
+sQuilavaAnimTable13:
+.4byte sQuilavaAnims_13_1
+.4byte sQuilavaAnims_13_2
+.4byte sQuilavaAnims_13_3
+.4byte sQuilavaAnims_13_4
+.4byte sQuilavaAnims_13_5
+.4byte sQuilavaAnims_13_6
+.4byte sQuilavaAnims_13_7
+.4byte sQuilavaAnims_13_8
+sAxAnimationsQuilava:
+.4byte sQuilavaAnimTable1
+.4byte sQuilavaAnimTable2
+.4byte sQuilavaAnimTable3
+.4byte sQuilavaAnimTable4
+.4byte sQuilavaAnimTable5
+.4byte sQuilavaAnimTable6
+.4byte sQuilavaAnimTable7
+.4byte sQuilavaAnimTable8
+.4byte sQuilavaAnimTable9
+.4byte sQuilavaAnimTable10
+.4byte sQuilavaAnimTable11
+.4byte sQuilavaAnimTable12
+.4byte sQuilavaAnimTable13
+sAxSpritesQuilava:
+.4byte sQuilavaSprites1
+.4byte sQuilavaSprites2
+.4byte sQuilavaSprites3
+.4byte sQuilavaSprites4
+.4byte sQuilavaSprites5
+.4byte sQuilavaSprites6
+.4byte sQuilavaSprites7
+.4byte sQuilavaSprites8
+.4byte sQuilavaSprites9
+.4byte sQuilavaSprites10
+.4byte sQuilavaSprites11
+.4byte sQuilavaSprites12
+.4byte sQuilavaSprites13
+.4byte sQuilavaSprites14
+.4byte sQuilavaSprites15
+.4byte sQuilavaSprites16
+.4byte sQuilavaSprites17
+.4byte sQuilavaSprites18
+.4byte sQuilavaSprites19
+.4byte sQuilavaSprites20
+.4byte sQuilavaSprites21
+.4byte sQuilavaSprites22
+.4byte sQuilavaSprites23
+.4byte sQuilavaSprites24
+.4byte sQuilavaSprites25
+.4byte sQuilavaSprites26
+.4byte sQuilavaSprites27
+.4byte sQuilavaSprites28
+.4byte sQuilavaSprites29
+.4byte sQuilavaSprites30
+.4byte sQuilavaSprites31
+.4byte sQuilavaSprites32
+.4byte sQuilavaSprites33
+.4byte sQuilavaSprites34
+.4byte sQuilavaSprites35
+.4byte sQuilavaSprites36
+.4byte sQuilavaSprites37
+.4byte sQuilavaSprites38
+.4byte sQuilavaSprites39
+.4byte sQuilavaSprites40
+.4byte sQuilavaSprites41
+.4byte sQuilavaSprites42
+.4byte sQuilavaSprites43
+.4byte sQuilavaSprites44
+.4byte sQuilavaSprites45
+.4byte sQuilavaSprites46
+.4byte sQuilavaSprites47
+.4byte sQuilavaSprites48
+.4byte sQuilavaSprites49
+.4byte sQuilavaSprites50
+.4byte sQuilavaSprites51
+.4byte sQuilavaSprites52
+.4byte sQuilavaSprites53
+.4byte sQuilavaSprites54
+.4byte sQuilavaSprites55
+.4byte sQuilavaSprites56
+.4byte sQuilavaSprites57
+sAxMainQuilava:
+ax_main sAxPosesQuilava, sAxAnimationsQuilava, 13, sAxSpritesQuilava, sAxPositionsQuilava

--- a/data/ax/qwilfish.inc
+++ b/data/ax/qwilfish.inc
@@ -1,0 +1,2967 @@
+.global gAxQwilfish
+gAxQwilfish:
+ax_siro sAxMainQwilfish
+sQwilfishPose1:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose2:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose3:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose4:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose5:
+ax_pose 4, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose6:
+ax_pose 5, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose7:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose8:
+ax_pose 7, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose9:
+ax_pose 8, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose10:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose11:
+ax_pose 10, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose12:
+ax_pose 11, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose13:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose14:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose15:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose16:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose17:
+ax_pose 10, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose18:
+ax_pose 11, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose19:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose20:
+ax_pose 7, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose21:
+ax_pose 8, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose22:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose23:
+ax_pose 4, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose24:
+ax_pose 5, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose25:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose26:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose27:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose28:
+ax_pose 15, 0x81ec, 0x80f7, 0x2c00
+ax_pose 16, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose29:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose30:
+ax_pose 4, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose31:
+ax_pose 5, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose32:
+ax_pose 17, 0x81e5, 0x90f9, 0x2c00
+ax_pose 18, 0x01ed, 0x10f1, 0x2c08
+ax_pose_terminator
+sQwilfishPose33:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose34:
+ax_pose 7, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose35:
+ax_pose 8, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose36:
+ax_pose 19, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sQwilfishPose37:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose38:
+ax_pose 10, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose39:
+ax_pose 11, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose40:
+ax_pose 20, 0x81ea, 0x90fc, 0x2c00
+ax_pose 21, 0x81ea, 0x10f4, 0x2c08
+ax_pose_terminator
+sQwilfishPose41:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose42:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose43:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose44:
+ax_pose 22, 0x01f0, 0x40f5, 0x2c00
+ax_pose 23, 0x81f0, 0x0105, 0x2c04
+ax_pose_terminator
+sQwilfishPose45:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose46:
+ax_pose 10, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose47:
+ax_pose 11, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose48:
+ax_pose 20, 0x81ea, 0x80f3, 0x2c00
+ax_pose 21, 0x81ea, 0x0103, 0x2c08
+ax_pose_terminator
+sQwilfishPose49:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose50:
+ax_pose 7, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose51:
+ax_pose 8, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose52:
+ax_pose 19, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sQwilfishPose53:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose54:
+ax_pose 4, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose55:
+ax_pose 5, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose56:
+ax_pose 17, 0x81e5, 0x80f6, 0x2c00
+ax_pose 18, 0x01ed, 0x0106, 0x2c08
+ax_pose_terminator
+sQwilfishPose57:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose58:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose59:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose60:
+ax_pose 15, 0x81ec, 0x80f7, 0x2c00
+ax_pose 16, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose61:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose62:
+ax_pose 4, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose63:
+ax_pose 5, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose64:
+ax_pose 17, 0x81e5, 0x90f9, 0x2c00
+ax_pose 18, 0x01ed, 0x10f1, 0x2c08
+ax_pose_terminator
+sQwilfishPose65:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose66:
+ax_pose 7, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose67:
+ax_pose 8, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose68:
+ax_pose 19, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sQwilfishPose69:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose70:
+ax_pose 10, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose71:
+ax_pose 11, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose72:
+ax_pose 20, 0x81ea, 0x90fc, 0x2c00
+ax_pose 21, 0x81ea, 0x10f4, 0x2c08
+ax_pose_terminator
+sQwilfishPose73:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose74:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose75:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose76:
+ax_pose 22, 0x01f0, 0x40f5, 0x2c00
+ax_pose 23, 0x81f0, 0x0105, 0x2c04
+ax_pose_terminator
+sQwilfishPose77:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose78:
+ax_pose 10, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose79:
+ax_pose 11, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose80:
+ax_pose 20, 0x81ea, 0x80f3, 0x2c00
+ax_pose 21, 0x81ea, 0x0103, 0x2c08
+ax_pose_terminator
+sQwilfishPose81:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose82:
+ax_pose 7, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose83:
+ax_pose 8, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose84:
+ax_pose 19, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sQwilfishPose85:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose86:
+ax_pose 4, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose87:
+ax_pose 5, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose88:
+ax_pose 17, 0x81e5, 0x80f6, 0x2c00
+ax_pose 18, 0x01ed, 0x0106, 0x2c08
+ax_pose_terminator
+sQwilfishPose89:
+ax_pose 24, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sQwilfishPose90:
+ax_pose 25, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sQwilfishPose91:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose92:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose93:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose94:
+ax_pose 15, 0x81ec, 0x80f7, 0x2c00
+ax_pose 16, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose95:
+ax_pose 26, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sQwilfishPose96:
+ax_pose 27, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sQwilfishPose97:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose98:
+ax_pose 4, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose99:
+ax_pose 5, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose100:
+ax_pose 17, 0x81e5, 0x90f9, 0x2c00
+ax_pose 18, 0x01ed, 0x10f1, 0x2c08
+ax_pose_terminator
+sQwilfishPose101:
+ax_pose 28, 0x01e7, 0x90ea, 0x2c00
+ax_pose_terminator
+sQwilfishPose102:
+ax_pose 29, 0x01e7, 0x90ea, 0x2c00
+ax_pose_terminator
+sQwilfishPose103:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose104:
+ax_pose 7, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose105:
+ax_pose 8, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose106:
+ax_pose 19, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sQwilfishPose107:
+ax_pose 30, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sQwilfishPose108:
+ax_pose 31, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sQwilfishPose109:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose110:
+ax_pose 10, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose111:
+ax_pose 11, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose112:
+ax_pose 20, 0x81ea, 0x90fc, 0x2c00
+ax_pose 21, 0x81ea, 0x10f4, 0x2c08
+ax_pose_terminator
+sQwilfishPose113:
+ax_pose 32, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sQwilfishPose114:
+ax_pose 33, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sQwilfishPose115:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose116:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose117:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose118:
+ax_pose 22, 0x01f0, 0x40f5, 0x2c00
+ax_pose 23, 0x81f0, 0x0105, 0x2c04
+ax_pose_terminator
+sQwilfishPose119:
+ax_pose 30, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sQwilfishPose120:
+ax_pose 31, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sQwilfishPose121:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose122:
+ax_pose 10, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose123:
+ax_pose 11, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose124:
+ax_pose 20, 0x81ea, 0x80f3, 0x2c00
+ax_pose 21, 0x81ea, 0x0103, 0x2c08
+ax_pose_terminator
+sQwilfishPose125:
+ax_pose 28, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQwilfishPose126:
+ax_pose 29, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sQwilfishPose127:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose128:
+ax_pose 7, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose129:
+ax_pose 8, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose130:
+ax_pose 19, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sQwilfishPose131:
+ax_pose 26, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sQwilfishPose132:
+ax_pose 27, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sQwilfishPose133:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose134:
+ax_pose 4, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose135:
+ax_pose 5, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose136:
+ax_pose 17, 0x81e5, 0x80f6, 0x2c00
+ax_pose 18, 0x01ed, 0x0106, 0x2c08
+ax_pose_terminator
+sQwilfishPose137:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose138:
+ax_pose 34, 0x01ef, 0x40f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose139:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose140:
+ax_pose 35, 0x01ed, 0x50f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose141:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose142:
+ax_pose 36, 0x01ee, 0x50f6, 0x2c00
+ax_pose 37, 0x81ee, 0x10ee, 0x2c04
+ax_pose_terminator
+sQwilfishPose143:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose144:
+ax_pose 38, 0x01f1, 0x50f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose145:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose146:
+ax_pose 39, 0x01f0, 0x40f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose147:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose148:
+ax_pose 38, 0x01f1, 0x40f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose149:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose150:
+ax_pose 36, 0x01ee, 0x40f9, 0x2c00
+ax_pose 37, 0x81ee, 0x0109, 0x2c04
+ax_pose_terminator
+sQwilfishPose151:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose152:
+ax_pose 35, 0x01ed, 0x40f9, 0x2c00
+ax_pose_terminator
+sQwilfishPose153:
+ax_pose 40, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose154:
+ax_pose 41, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose155:
+ax_pose 42, 0x01e1, 0x80f3, 0x2c00
+ax_pose_terminator
+sQwilfishPose156:
+ax_pose 43, 0x01e7, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose157:
+ax_pose 44, 0x01e4, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose158:
+ax_pose 45, 0x01e6, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose159:
+ax_pose 46, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sQwilfishPose160:
+ax_pose 45, 0x01e6, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose161:
+ax_pose 44, 0x01e4, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose162:
+ax_pose 43, 0x01e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose163:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose164:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose165:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose166:
+ax_pose 15, 0x81ec, 0x80f7, 0x2c00
+ax_pose 16, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose167:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose168:
+ax_pose 4, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose169:
+ax_pose 5, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose170:
+ax_pose 17, 0x81e5, 0x90f9, 0x2c00
+ax_pose 18, 0x01ed, 0x10f1, 0x2c08
+ax_pose_terminator
+sQwilfishPose171:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose172:
+ax_pose 7, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose173:
+ax_pose 8, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose174:
+ax_pose 19, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sQwilfishPose175:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose176:
+ax_pose 10, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose177:
+ax_pose 11, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose178:
+ax_pose 20, 0x81ea, 0x90fc, 0x2c00
+ax_pose 21, 0x81ea, 0x10f4, 0x2c08
+ax_pose_terminator
+sQwilfishPose179:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose180:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose181:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose182:
+ax_pose 22, 0x01f0, 0x40f5, 0x2c00
+ax_pose 23, 0x81f0, 0x0105, 0x2c04
+ax_pose_terminator
+sQwilfishPose183:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose184:
+ax_pose 10, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose185:
+ax_pose 11, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose186:
+ax_pose 20, 0x81ea, 0x80f3, 0x2c00
+ax_pose 21, 0x81ea, 0x0103, 0x2c08
+ax_pose_terminator
+sQwilfishPose187:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose188:
+ax_pose 7, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose189:
+ax_pose 8, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose190:
+ax_pose 19, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sQwilfishPose191:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose192:
+ax_pose 4, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose193:
+ax_pose 5, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose194:
+ax_pose 17, 0x81e5, 0x80f6, 0x2c00
+ax_pose 18, 0x01ed, 0x0106, 0x2c08
+ax_pose_terminator
+sQwilfishPose195:
+ax_pose 15, 0x81ea, 0x80f7, 0x2c00
+ax_pose 16, 0x01f2, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose196:
+ax_pose 17, 0x81e6, 0x80f7, 0x2c00
+ax_pose 18, 0x01ee, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose197:
+ax_pose 19, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose198:
+ax_pose 20, 0x81ec, 0x80f6, 0x2c00
+ax_pose 21, 0x81ec, 0x0106, 0x2c08
+ax_pose_terminator
+sQwilfishPose199:
+ax_pose 22, 0x01f0, 0x40f5, 0x2c00
+ax_pose 23, 0x81f0, 0x0105, 0x2c04
+ax_pose_terminator
+sQwilfishPose200:
+ax_pose 20, 0x81ec, 0x90fa, 0x2c00
+ax_pose 21, 0x81ec, 0x10f2, 0x2c08
+ax_pose_terminator
+sQwilfishPose201:
+ax_pose 19, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sQwilfishPose202:
+ax_pose 17, 0x81e6, 0x90f9, 0x2c00
+ax_pose 18, 0x01ee, 0x10f1, 0x2c08
+ax_pose_terminator
+sQwilfishPose203:
+ax_pose 15, 0x81ea, 0x80f7, 0x2c00
+ax_pose 16, 0x01f2, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose204:
+ax_pose 17, 0x81e6, 0x90f9, 0x2c00
+ax_pose 18, 0x01ee, 0x10f1, 0x2c08
+ax_pose_terminator
+sQwilfishPose205:
+ax_pose 19, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sQwilfishPose206:
+ax_pose 20, 0x81ec, 0x90fa, 0x2c00
+ax_pose 21, 0x81ec, 0x10f2, 0x2c08
+ax_pose_terminator
+sQwilfishPose207:
+ax_pose 22, 0x01f0, 0x40f5, 0x2c00
+ax_pose 23, 0x81f0, 0x0105, 0x2c04
+ax_pose_terminator
+sQwilfishPose208:
+ax_pose 20, 0x81ec, 0x80f6, 0x2c00
+ax_pose 21, 0x81ec, 0x0106, 0x2c08
+ax_pose_terminator
+sQwilfishPose209:
+ax_pose 19, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose210:
+ax_pose 17, 0x81e6, 0x80f7, 0x2c00
+ax_pose 18, 0x01ee, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose211:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose212:
+ax_pose 1, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose213:
+ax_pose 2, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose214:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose215:
+ax_pose 4, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose216:
+ax_pose 5, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose217:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose218:
+ax_pose 7, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose219:
+ax_pose 8, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose220:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose221:
+ax_pose 10, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose222:
+ax_pose 11, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose223:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose224:
+ax_pose 13, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose225:
+ax_pose 14, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose226:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose227:
+ax_pose 10, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose228:
+ax_pose 11, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose229:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose230:
+ax_pose 7, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose231:
+ax_pose 8, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose232:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose233:
+ax_pose 4, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose234:
+ax_pose 5, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose235:
+ax_pose 15, 0x81ea, 0x80f7, 0x2c00
+ax_pose 16, 0x01f2, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose236:
+ax_pose 17, 0x81e6, 0x90f9, 0x2c00
+ax_pose 18, 0x01ee, 0x10f1, 0x2c08
+ax_pose_terminator
+sQwilfishPose237:
+ax_pose 19, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sQwilfishPose238:
+ax_pose 20, 0x81ec, 0x90fa, 0x2c00
+ax_pose 21, 0x81ec, 0x10f2, 0x2c08
+ax_pose_terminator
+sQwilfishPose239:
+ax_pose 22, 0x01f0, 0x40f5, 0x2c00
+ax_pose 23, 0x81f0, 0x0105, 0x2c04
+ax_pose_terminator
+sQwilfishPose240:
+ax_pose 20, 0x81ec, 0x80f6, 0x2c00
+ax_pose 21, 0x81ec, 0x0106, 0x2c08
+ax_pose_terminator
+sQwilfishPose241:
+ax_pose 19, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose242:
+ax_pose 17, 0x81e6, 0x80f7, 0x2c00
+ax_pose 18, 0x01ee, 0x0107, 0x2c08
+ax_pose_terminator
+sQwilfishPose243:
+ax_pose 0, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose244:
+ax_pose 3, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose245:
+ax_pose 6, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sQwilfishPose246:
+ax_pose 9, 0x01e8, 0x80f6, 0x2c00
+ax_pose_terminator
+sQwilfishPose247:
+ax_pose 12, 0x81e8, 0x80f8, 0x2c00
+ax_pose_terminator
+sQwilfishPose248:
+ax_pose 9, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sQwilfishPose249:
+ax_pose 6, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sQwilfishPose250:
+ax_pose 3, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+.align 2
+sQwilfishAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 6, 0, 26, 0, -3, 0, -3,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sQwilfishAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 6, 0, 30, -3, -3, -3, -3,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 22, 22, 22, 22,
+ax_anim 2, 1, 31, 23, 21, 23, 21,
+ax_anim 2, 0, 31, 22, 22, 22, 22,
+ax_anim 2, 0, 31, 23, 21, 23, 21,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sQwilfishAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 33, -3, 0, -3, 0,
+ax_anim 6, 0, 34, -3, 0, -3, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 1, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sQwilfishAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 2, 0, 38, -2, 2, -2, 2,
+ax_anim 2, 0, 37, -3, 3, -3, 3,
+ax_anim 6, 0, 38, -3, 3, -3, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 4, -4, 4, -4,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 2, 1, 39, 20, -18, 20, -18,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 2, 0, 39, 20, -18, 20, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sQwilfishAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 2, 0, 42, 0, 2, 0, 2,
+ax_anim 2, 0, 41, 0, 3, 0, 3,
+ax_anim 6, 0, 42, 0, 3, 0, 3,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -10, 0, -10,
+ax_anim 2, 0, 43, 0, -22, 0, -22,
+ax_anim 2, 1, 43, 1, -22, 1, -22,
+ax_anim 2, 0, 43, 0, -22, 0, -22,
+ax_anim 2, 0, 43, 1, -22, 1, -22,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sQwilfishAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 2, 0, 45, 3, 3, 3, 3,
+ax_anim 6, 0, 46, 3, 3, 3, 3,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, -4, -4, -4,
+ax_anim 1, 0, 47, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 1, 47, -20, -18, -20, -18,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 0, 47, -20, -18, -20, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sQwilfishAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 2, 0, 50, 2, 0, 2, 0,
+ax_anim 2, 0, 49, 3, 0, 3, 0,
+ax_anim 6, 0, 50, 3, 0, 3, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 1, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sQwilfishAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 0, 54, 2, -2, 2, -2,
+ax_anim 2, 0, 53, 3, -3, 3, -3,
+ax_anim 6, 0, 54, 3, -3, 3, -3,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -22, 22, -22, 22,
+ax_anim 2, 1, 55, -23, 21, -23, 21,
+ax_anim 2, 0, 55, -22, 22, -22, 22,
+ax_anim 2, 0, 55, -23, 21, -23, 21,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 2, 0, 57, 0, -3, 0, -3,
+ax_anim 6, 0, 58, 0, -3, 0, -3,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sQwilfishAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 61, -3, -3, -3, -3,
+ax_anim 6, 0, 62, -3, -3, -3, -3,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 22, 22, 22, 22,
+ax_anim 2, 1, 63, 23, 21, 23, 21,
+ax_anim 2, 0, 63, 22, 22, 22, 22,
+ax_anim 2, 0, 63, 23, 21, 23, 21,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sQwilfishAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 2, 0, 66, -2, 0, -2, 0,
+ax_anim 2, 0, 65, -3, 0, -3, 0,
+ax_anim 6, 0, 66, -3, 0, -3, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 1, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 0, 67, 21, 1, 21, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sQwilfishAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 2, 0, 70, -2, 2, -2, 2,
+ax_anim 2, 0, 69, -3, 3, -3, 3,
+ax_anim 6, 0, 70, -3, 3, -3, 3,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 4, -4, 4, -4,
+ax_anim 1, 0, 71, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 1, 71, 20, -18, 20, -18,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 71, 20, -18, 20, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sQwilfishAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 6, 0, 74, 0, 3, 0, 3,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -10, 0, -10,
+ax_anim 2, 0, 75, 0, -22, 0, -22,
+ax_anim 2, 1, 75, 1, -22, 1, -22,
+ax_anim 2, 0, 75, 0, -22, 0, -22,
+ax_anim 2, 0, 75, 1, -22, 1, -22,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sQwilfishAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 2, 0, 78, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 6, 0, 78, 3, 3, 3, 3,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 2, 79, -4, -4, -4, -4,
+ax_anim 1, 0, 79, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 2, 1, 79, -20, -18, -20, -18,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 2, 0, 79, -20, -18, -20, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sQwilfishAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim 2, 0, 81, 3, 0, 3, 0,
+ax_anim 6, 0, 82, 3, 0, 3, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 1, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 0, 83, -21, 1, -21, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sQwilfishAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 2, 0, 85, 3, -3, 3, -3,
+ax_anim 6, 0, 86, 3, -3, 3, -3,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -22, 22, -22, 22,
+ax_anim 2, 1, 87, -23, 21, -23, 21,
+ax_anim 2, 0, 87, -22, 22, -22, 22,
+ax_anim 2, 0, 87, -23, 21, -23, 21,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_4_1:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 2, 93, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, 7, 0, 7,
+ax_anim 2, 0, 89, -1, 7, -1, 7,
+ax_anim 2, 1, 88, 0, 7, 0, 7,
+ax_anim 2, 0, 89, -1, 7, -1, 7,
+ax_anim 2, 0, 88, 0, 7, 0, 7,
+ax_anim 2, 0, 89, -1, 7, -1, 7,
+ax_anim 2, 0, 88, 0, 7, 0, 7,
+ax_anim 2, 0, 89, -1, 7, -1, 7,
+ax_anim 2, 0, 88, 0, 7, 0, 7,
+ax_anim 2, 0, 93, 0, 5, 0, 5,
+ax_anim_terminator
+sQwilfishAnims_4_2:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 2, 2, 99, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 6, 6, 6, 6,
+ax_anim 2, 0, 94, 7, 7, 7, 7,
+ax_anim 2, 0, 95, 8, 6, 8, 6,
+ax_anim 2, 1, 94, 7, 7, 7, 7,
+ax_anim 2, 0, 95, 8, 6, 8, 6,
+ax_anim 2, 0, 94, 7, 7, 7, 7,
+ax_anim 2, 0, 95, 8, 6, 8, 6,
+ax_anim 2, 0, 94, 7, 7, 7, 7,
+ax_anim 2, 0, 95, 8, 6, 8, 6,
+ax_anim 2, 0, 94, 7, 7, 7, 7,
+ax_anim 2, 0, 99, 5, 5, 5, 5,
+ax_anim_terminator
+sQwilfishAnims_4_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 2, 0, 2, 0,
+ax_anim 2, 2, 105, 3, -1, 3, 0,
+ax_anim 2, 0, 101, 6, 0, 6, 0,
+ax_anim 2, 0, 100, 7, 0, 7, 0,
+ax_anim 2, 0, 101, 8, 0, 8, 0,
+ax_anim 2, 1, 100, 8, -1, 8, -1,
+ax_anim 2, 0, 101, 8, 0, 8, 0,
+ax_anim 2, 0, 100, 8, -1, 8, -1,
+ax_anim 2, 0, 101, 8, 0, 8, 0,
+ax_anim 2, 0, 100, 8, -1, 8, -1,
+ax_anim 2, 0, 101, 8, 0, 8, 0,
+ax_anim 2, 0, 100, 8, -1, 8, -1,
+ax_anim 2, 0, 105, 5, -1, 5, 0,
+ax_anim_terminator
+sQwilfishAnims_4_4:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim 2, 2, 111, 3, -3, 3, -3,
+ax_anim 2, 0, 107, 6, -6, 6, -6,
+ax_anim 2, 0, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 107, 8, -6, 8, -6,
+ax_anim 2, 1, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 107, 8, -6, 8, -6,
+ax_anim 2, 0, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 107, 8, -6, 8, -6,
+ax_anim 2, 0, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 107, 8, -6, 8, -6,
+ax_anim 2, 0, 106, 7, -7, 7, -7,
+ax_anim 2, 0, 111, 5, -5, 5, -5,
+ax_anim_terminator
+sQwilfishAnims_4_5:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 2, 2, 117, 0, -3, 0, -3,
+ax_anim 2, 0, 113, 0, -6, 0, -6,
+ax_anim 2, 0, 112, 0, -7, 0, -7,
+ax_anim 2, 0, 113, -1, -7, -1, -7,
+ax_anim 2, 1, 112, 0, -7, 0, -7,
+ax_anim 2, 0, 113, -1, -7, -1, -7,
+ax_anim 2, 0, 112, 0, -7, 0, -7,
+ax_anim 2, 0, 113, -1, -7, -1, -7,
+ax_anim 2, 0, 112, 0, -7, 0, -7,
+ax_anim 2, 0, 113, -1, -7, -1, -7,
+ax_anim 2, 0, 112, 0, -7, 0, -7,
+ax_anim 2, 0, 117, 0, -5, 0, -5,
+ax_anim_terminator
+sQwilfishAnims_4_6:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, -2, -2, -2, -2,
+ax_anim 2, 2, 123, -3, -3, -3, -3,
+ax_anim 2, 0, 119, -6, -6, -6, -6,
+ax_anim 2, 0, 118, -7, -7, -7, -7,
+ax_anim 2, 0, 119, -8, -6, -8, -6,
+ax_anim 2, 1, 118, -7, -7, -7, -7,
+ax_anim 2, 0, 119, -8, -6, -8, -6,
+ax_anim 2, 0, 118, -7, -7, -7, -7,
+ax_anim 2, 0, 119, -8, -6, -8, -6,
+ax_anim 2, 0, 118, -7, -7, -7, -7,
+ax_anim 2, 0, 119, -8, -6, -8, -6,
+ax_anim 2, 0, 118, -7, -7, -7, -7,
+ax_anim 2, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sQwilfishAnims_4_7:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -2, 0, -2, 0,
+ax_anim 2, 2, 129, -3, -1, -3, 0,
+ax_anim 2, 0, 125, -6, 0, -6, 0,
+ax_anim 2, 0, 124, -7, 0, -7, 0,
+ax_anim 2, 0, 125, -8, 0, -8, 0,
+ax_anim 2, 1, 124, -8, -1, -8, -1,
+ax_anim 2, 0, 125, -8, 0, -8, 0,
+ax_anim 2, 0, 124, -8, -1, -8, -1,
+ax_anim 2, 0, 125, -8, 0, -8, 0,
+ax_anim 2, 0, 124, -8, -1, -8, -1,
+ax_anim 2, 0, 125, -8, 0, -8, 0,
+ax_anim 2, 0, 124, -8, -1, -8, -1,
+ax_anim 2, 0, 129, -5, -1, -5, 0,
+ax_anim_terminator
+sQwilfishAnims_4_8:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim 2, 2, 135, -3, 3, -3, 3,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 130, -7, 7, -7, 7,
+ax_anim 2, 0, 131, -8, 6, -8, 6,
+ax_anim 2, 1, 130, -7, 7, -7, 7,
+ax_anim 2, 0, 131, -8, 6, -8, 6,
+ax_anim 2, 0, 130, -7, 7, -7, 7,
+ax_anim 2, 0, 131, -8, 6, -8, 6,
+ax_anim 2, 0, 130, -7, 7, -7, 7,
+ax_anim 2, 0, 131, -8, 6, -8, 6,
+ax_anim 2, 0, 130, -7, 7, -7, 7,
+ax_anim 2, 0, 135, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_5_1:
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 6, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, -1, -6, -1, 0,
+ax_anim 2, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, -1, -6, -1, 0,
+ax_anim 2, 2, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, -1, -6, -1, 0,
+ax_anim 2, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_5_2:
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 6, 0, 138, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 139, -1, -4, -1, 1,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 139, -1, -4, -1, 1,
+ax_anim 2, 2, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 139, -1, -4, -1, 1,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_5_3:
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -4, 0, 0,
+ax_anim 6, 0, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, -1,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, -1,
+ax_anim 2, 2, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, -1,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_5_4:
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 6, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 143, -1, -5, 0, 0,
+ax_anim 2, 0, 143, 1, -4, 1, 1,
+ax_anim 2, 0, 143, -1, -5, 0, 0,
+ax_anim 2, 0, 143, 1, -4, 1, 1,
+ax_anim 2, 2, 143, -1, -5, 0, 0,
+ax_anim 2, 0, 143, 1, -4, 1, 1,
+ax_anim 2, 0, 143, -1, -5, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_5_5:
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 6, 0, 144, 0, -5, 0, 0,
+ax_anim 2, 0, 145, 0, -5, 0, 0,
+ax_anim 2, 0, 145, 1, -5, 1, 0,
+ax_anim 2, 0, 145, 0, -5, 0, 0,
+ax_anim 2, 0, 145, 1, -5, 1, 0,
+ax_anim 2, 2, 145, 0, -5, 0, 0,
+ax_anim 2, 0, 145, 1, -5, 1, 0,
+ax_anim 2, 0, 145, 0, -5, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_5_6:
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 2, 0, 146, 0, -4, 0, 0,
+ax_anim 6, 0, 146, 0, -5, 0, 0,
+ax_anim 2, 0, 147, 1, -5, 0, 0,
+ax_anim 2, 0, 147, -1, -4, -1, 1,
+ax_anim 2, 0, 147, 1, -5, 0, 0,
+ax_anim 2, 0, 147, -1, -4, -1, 1,
+ax_anim 2, 2, 147, 1, -5, 0, 0,
+ax_anim 2, 0, 147, -1, -4, -1, 1,
+ax_anim 2, 0, 147, 1, -5, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_5_7:
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 148, 0, -4, 0, 0,
+ax_anim 6, 0, 148, 0, -5, 0, 0,
+ax_anim 2, 0, 149, 0, -5, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, -1,
+ax_anim 2, 0, 149, 0, -5, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, -1,
+ax_anim 2, 2, 149, 0, -5, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, -1,
+ax_anim 2, 0, 149, 0, -5, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_5_8:
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, -4, 0, 0,
+ax_anim 6, 0, 150, 0, -5, 0, 0,
+ax_anim 2, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, 1, -4, 1, 1,
+ax_anim 2, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, 1, -4, 1, 1,
+ax_anim 2, 2, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, 1, -4, 1, 1,
+ax_anim 2, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_6_1:
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 26, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 26, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sQwilfishAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sQwilfishAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sQwilfishAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sQwilfishAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sQwilfishAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sQwilfishAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sQwilfishAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_8_1:
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 164, 0, -1, 0, 0,
+ax_anim 10, 0, 164, 0, -2, 0, 0,
+ax_anim 10, 0, 164, 0, -3, 0, 0,
+ax_anim 12, 0, 162, 0, -3, 0, 0,
+ax_anim 10, 0, 163, 0, -2, 0, 0,
+ax_anim 10, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_8_2:
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 167, 0, -1, 0, 0,
+ax_anim 10, 0, 167, 0, -2, 0, 0,
+ax_anim 10, 0, 167, 0, -3, 0, 0,
+ax_anim 12, 0, 166, 0, -3, 0, 0,
+ax_anim 10, 0, 168, 0, -2, 0, 0,
+ax_anim 10, 0, 168, 0, -1, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_8_3:
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, -1, 0, 0,
+ax_anim 10, 0, 172, 0, -2, 0, 0,
+ax_anim 10, 0, 172, 0, -3, 0, 0,
+ax_anim 12, 0, 170, 0, -3, 0, 0,
+ax_anim 10, 0, 171, 0, -2, 0, 0,
+ax_anim 10, 0, 171, 0, -1, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_8_4:
+ax_anim 12, 0, 174, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, -1, 0, 0,
+ax_anim 10, 0, 175, 0, -2, 0, 0,
+ax_anim 10, 0, 175, 0, -3, 0, 0,
+ax_anim 12, 0, 174, 0, -3, 0, 0,
+ax_anim 10, 0, 176, 0, -2, 0, 0,
+ax_anim 10, 0, 176, 0, -1, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_8_5:
+ax_anim 12, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, -1, 0, 0,
+ax_anim 10, 0, 179, 0, -2, 0, 0,
+ax_anim 10, 0, 179, 0, -3, 0, 0,
+ax_anim 12, 0, 178, 0, -3, 0, 0,
+ax_anim 10, 0, 180, 0, -2, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_8_6:
+ax_anim 12, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim 10, 0, 183, 0, -2, 0, 0,
+ax_anim 10, 0, 183, 0, -3, 0, 0,
+ax_anim 12, 0, 182, 0, -3, 0, 0,
+ax_anim 10, 0, 184, 0, -2, 0, 0,
+ax_anim 10, 0, 184, 0, -1, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_8_7:
+ax_anim 12, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, -1, 0, 0,
+ax_anim 10, 0, 188, 0, -2, 0, 0,
+ax_anim 10, 0, 188, 0, -3, 0, 0,
+ax_anim 12, 0, 186, 0, -3, 0, 0,
+ax_anim 10, 0, 187, 0, -2, 0, 0,
+ax_anim 10, 0, 187, 0, -1, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_8_8:
+ax_anim 12, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, -1, 0, 0,
+ax_anim 10, 0, 191, 0, -2, 0, 0,
+ax_anim 10, 0, 191, 0, -3, 0, 0,
+ax_anim 12, 0, 190, 0, -3, 0, 0,
+ax_anim 10, 0, 192, 0, -2, 0, 0,
+ax_anim 10, 0, 192, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 11, 8, 11,
+ax_anim 2, 0, 197, 7, 19, 7, 19,
+ax_anim 3, 0, 198, 0, 22, 0, 22,
+ax_anim 2, 3, 199, -7, 19, -7, 19,
+ax_anim 2, 0, 200, -8, 11, -8, 11,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 20, 15, 20, 15,
+ax_anim 3, 0, 197, 21, 22, 21, 22,
+ax_anim 2, 3, 198, 13, 23, 13, 23,
+ax_anim 2, 0, 199, 4, 16, 4, 16,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -5, 16, -5,
+ax_anim 3, 0, 196, 20, 0, 20, 0,
+ax_anim 2, 3, 197, 17, 5, 17, 5,
+ax_anim 2, 0, 198, 12, 6, 12, 6,
+ax_anim 1, 0, 199, 4, 4, 4, 4,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -8, 0, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 14, -22, 14, -22,
+ax_anim 3, 0, 195, 22, -21, 22, -21,
+ax_anim 2, 3, 196, 22, -13, 22, -13,
+ax_anim 2, 0, 197, 17, -4, 17, -4,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, -4, -8, -4,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -18, -7, -18,
+ax_anim 3, 0, 194, 0, -22, 0, -22,
+ax_anim 2, 3, 195, 7, -18, 7, -18,
+ax_anim 2, 0, 196, 9, -12, 9, -12,
+ax_anim 1, 0, 197, 8, -4, 8, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -8, 0, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -14, -22, -14, -22,
+ax_anim 3, 0, 201, -22, -21, -22, -21,
+ax_anim 2, 3, 200, -22, -13, -22, -13,
+ax_anim 2, 0, 199, -17, -4, -17, -4,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -5, -16, -5,
+ax_anim 3, 0, 200, -20, 0, -20, 0,
+ax_anim 2, 3, 199, -17, 5, -17, 5,
+ax_anim 2, 0, 198, -12, 6, -12, 6,
+ax_anim 1, 0, 197, -4, 6, -4, 6,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -20, 15, -20, 15,
+ax_anim 3, 0, 199, -21, 22, -21, 22,
+ax_anim 2, 3, 198, -13, 23, -13, 23,
+ax_anim 2, 0, 197, -4, 16, -4, 16,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 215, 0, -21, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 3, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -21, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -22, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 3, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 2, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -22, 0, 0,
+ax_anim 3, 0, 233, 0, -21, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_12_2:
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, -1, 1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_12_3:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_12_4:
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -1, -1, -1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_12_6:
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, -1, 1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_12_7:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_12_8:
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -1, -1, -1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sQwilfishAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sQwilfishGfx1:
+.incbin "baserom.gba", 0xE87490, 0x100
+sQwilfishSprites1:
+ax_sprite sQwilfishGfx1, 0x100
+ax_sprite_terminator
+sQwilfishGfx2:
+.incbin "baserom.gba", 0xE875A0, 0x100
+sQwilfishSprites2:
+ax_sprite sQwilfishGfx2, 0x100
+ax_sprite_terminator
+sQwilfishGfx3:
+.incbin "baserom.gba", 0xE876B0, 0x100
+sQwilfishSprites3:
+ax_sprite sQwilfishGfx3, 0x100
+ax_sprite_terminator
+sQwilfishGfx4:
+.incbin "baserom.gba", 0xE877C0, 0x200
+sQwilfishSprites4:
+ax_sprite sQwilfishGfx4, 0x200
+ax_sprite_terminator
+sQwilfishGfx5:
+.incbin "baserom.gba", 0xE879D0, 0x200
+sQwilfishSprites5:
+ax_sprite sQwilfishGfx5, 0x200
+ax_sprite_terminator
+sQwilfishGfx6:
+.incbin "baserom.gba", 0xE87BE0, 0x200
+sQwilfishSprites6:
+ax_sprite sQwilfishGfx6, 0x200
+ax_sprite_terminator
+sQwilfishGfx7:
+.incbin "baserom.gba", 0xE87DF0, 0x200
+sQwilfishSprites7:
+ax_sprite sQwilfishGfx7, 0x200
+ax_sprite_terminator
+sQwilfishGfx8:
+.incbin "baserom.gba", 0xE88000, 0x200
+sQwilfishSprites8:
+ax_sprite sQwilfishGfx8, 0x200
+ax_sprite_terminator
+sQwilfishGfx9:
+.incbin "baserom.gba", 0xE88210, 0x200
+sQwilfishSprites9:
+ax_sprite sQwilfishGfx9, 0x200
+ax_sprite_terminator
+sQwilfishGfx10:
+.incbin "baserom.gba", 0xE88420, 0x200
+sQwilfishSprites10:
+ax_sprite sQwilfishGfx10, 0x200
+ax_sprite_terminator
+sQwilfishGfx11:
+.incbin "baserom.gba", 0xE88630, 0x200
+sQwilfishSprites11:
+ax_sprite sQwilfishGfx11, 0x200
+ax_sprite_terminator
+sQwilfishGfx12:
+.incbin "baserom.gba", 0xE88840, 0x200
+sQwilfishSprites12:
+ax_sprite sQwilfishGfx12, 0x200
+ax_sprite_terminator
+sQwilfishGfx13:
+.incbin "baserom.gba", 0xE88A50, 0x100
+sQwilfishSprites13:
+ax_sprite sQwilfishGfx13, 0x100
+ax_sprite_terminator
+sQwilfishGfx14:
+.incbin "baserom.gba", 0xE88B60, 0x100
+sQwilfishSprites14:
+ax_sprite sQwilfishGfx14, 0x100
+ax_sprite_terminator
+sQwilfishGfx15:
+.incbin "baserom.gba", 0xE88C70, 0x100
+sQwilfishSprites15:
+ax_sprite sQwilfishGfx15, 0x100
+ax_sprite_terminator
+sQwilfishGfx16:
+.incbin "baserom.gba", 0xE88D80, 0xC0
+sQwilfishSprites16:
+ax_sprite sQwilfishGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQwilfishGfx17:
+.incbin "baserom.gba", 0xE88E58, 0x20
+sQwilfishSprites17:
+ax_sprite sQwilfishGfx17, 0x20
+ax_sprite_terminator
+sQwilfishGfx18:
+.incbin "baserom.gba", 0xE88E88, 0xC0
+sQwilfishSprites18:
+ax_sprite 0, 0x40
+ax_sprite sQwilfishGfx18, 0xc0
+ax_sprite_terminator
+sQwilfishGfx19:
+.incbin "baserom.gba", 0xE88F60, 0x20
+sQwilfishSprites19:
+ax_sprite sQwilfishGfx19, 0x20
+ax_sprite_terminator
+sQwilfishGfx20:
+.incbin "baserom.gba", 0xE88F90, 0x60
+sQwilfishGfx20_1:
+.incbin "baserom.gba", 0xE88FF0, 0xE0
+sQwilfishGfx20_2:
+.incbin "baserom.gba", 0xE890D0, 0x20
+sQwilfishSprites20:
+ax_sprite sQwilfishGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx20_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx20_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sQwilfishGfx21:
+.incbin "baserom.gba", 0xE89128, 0xC0
+sQwilfishSprites21:
+ax_sprite sQwilfishGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQwilfishGfx22:
+.incbin "baserom.gba", 0xE89200, 0x40
+sQwilfishSprites22:
+ax_sprite sQwilfishGfx22, 0x40
+ax_sprite_terminator
+sQwilfishGfx23:
+.incbin "baserom.gba", 0xE89250, 0x80
+sQwilfishSprites23:
+ax_sprite sQwilfishGfx23, 0x80
+ax_sprite_terminator
+sQwilfishGfx24:
+.incbin "baserom.gba", 0xE892E0, 0x40
+sQwilfishSprites24:
+ax_sprite sQwilfishGfx24, 0x40
+ax_sprite_terminator
+sQwilfishGfx25:
+.incbin "baserom.gba", 0xE89330, 0x40
+sQwilfishGfx25_1:
+.incbin "baserom.gba", 0xE89370, 0x60
+sQwilfishGfx25_2:
+.incbin "baserom.gba", 0xE893D0, 0x60
+sQwilfishGfx25_3:
+.incbin "baserom.gba", 0xE89430, 0x60
+sQwilfishSprites25:
+ax_sprite sQwilfishGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQwilfishGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQwilfishGfx26:
+.incbin "baserom.gba", 0xE894D8, 0x40
+sQwilfishGfx26_1:
+.incbin "baserom.gba", 0xE89518, 0x60
+sQwilfishGfx26_2:
+.incbin "baserom.gba", 0xE89578, 0xE0
+sQwilfishSprites26:
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx26_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQwilfishGfx27:
+.incbin "baserom.gba", 0xE89698, 0x60
+sQwilfishGfx27_1:
+.incbin "baserom.gba", 0xE896F8, 0x60
+sQwilfishGfx27_2:
+.incbin "baserom.gba", 0xE89758, 0x60
+sQwilfishGfx27_3:
+.incbin "baserom.gba", 0xE897B8, 0x20
+sQwilfishSprites27:
+ax_sprite sQwilfishGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQwilfishGfx27_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQwilfishGfx28:
+.incbin "baserom.gba", 0xE89820, 0x160
+sQwilfishGfx28_1:
+.incbin "baserom.gba", 0xE89980, 0x20
+sQwilfishSprites28:
+ax_sprite sQwilfishGfx28, 0x160
+ax_sprite 0, 0x40
+ax_sprite sQwilfishGfx28_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQwilfishGfx29:
+.incbin "baserom.gba", 0xE899C8, 0x60
+sQwilfishGfx29_1:
+.incbin "baserom.gba", 0xE89A28, 0xE0
+sQwilfishGfx29_2:
+.incbin "baserom.gba", 0xE89B08, 0x40
+sQwilfishSprites29:
+ax_sprite sQwilfishGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx29_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQwilfishGfx30:
+.incbin "baserom.gba", 0xE89B80, 0x40
+sQwilfishGfx30_1:
+.incbin "baserom.gba", 0xE89BC0, 0x60
+sQwilfishGfx30_2:
+.incbin "baserom.gba", 0xE89C20, 0xC0
+sQwilfishSprites30:
+ax_sprite sQwilfishGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sQwilfishGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx30_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQwilfishGfx31:
+.incbin "baserom.gba", 0xE89D18, 0x60
+sQwilfishGfx31_1:
+.incbin "baserom.gba", 0xE89D78, 0x140
+sQwilfishSprites31:
+ax_sprite sQwilfishGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx31_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sQwilfishGfx32:
+.incbin "baserom.gba", 0xE89EE0, 0x60
+sQwilfishGfx32_1:
+.incbin "baserom.gba", 0xE89F40, 0x60
+sQwilfishGfx32_2:
+.incbin "baserom.gba", 0xE89FA0, 0x60
+sQwilfishGfx32_3:
+.incbin "baserom.gba", 0xE8A000, 0x40
+sQwilfishSprites32:
+ax_sprite sQwilfishGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQwilfishGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQwilfishGfx33:
+.incbin "baserom.gba", 0xE8A088, 0x60
+sQwilfishGfx33_1:
+.incbin "baserom.gba", 0xE8A0E8, 0x60
+sQwilfishGfx33_2:
+.incbin "baserom.gba", 0xE8A148, 0xE0
+sQwilfishSprites33:
+ax_sprite sQwilfishGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx33_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQwilfishGfx34:
+.incbin "baserom.gba", 0xE8A260, 0x60
+sQwilfishGfx34_1:
+.incbin "baserom.gba", 0xE8A2C0, 0x60
+sQwilfishGfx34_2:
+.incbin "baserom.gba", 0xE8A320, 0x60
+sQwilfishGfx34_3:
+.incbin "baserom.gba", 0xE8A380, 0x40
+sQwilfishSprites34:
+ax_sprite sQwilfishGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sQwilfishGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sQwilfishGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sQwilfishGfx35:
+.incbin "baserom.gba", 0xE8A408, 0x80
+sQwilfishSprites35:
+ax_sprite sQwilfishGfx35, 0x80
+ax_sprite_terminator
+sQwilfishGfx36:
+.incbin "baserom.gba", 0xE8A498, 0x80
+sQwilfishSprites36:
+ax_sprite sQwilfishGfx36, 0x80
+ax_sprite_terminator
+sQwilfishGfx37:
+.incbin "baserom.gba", 0xE8A528, 0x80
+sQwilfishSprites37:
+ax_sprite sQwilfishGfx37, 0x80
+ax_sprite_terminator
+sQwilfishGfx38:
+.incbin "baserom.gba", 0xE8A5B8, 0x40
+sQwilfishSprites38:
+ax_sprite sQwilfishGfx38, 0x40
+ax_sprite_terminator
+sQwilfishGfx39:
+.incbin "baserom.gba", 0xE8A608, 0x80
+sQwilfishSprites39:
+ax_sprite sQwilfishGfx39, 0x80
+ax_sprite_terminator
+sQwilfishGfx40:
+.incbin "baserom.gba", 0xE8A698, 0x80
+sQwilfishSprites40:
+ax_sprite sQwilfishGfx40, 0x80
+ax_sprite_terminator
+sQwilfishGfx41:
+.incbin "baserom.gba", 0xE8A728, 0x100
+sQwilfishSprites41:
+ax_sprite sQwilfishGfx41, 0x100
+ax_sprite_terminator
+sQwilfishGfx42:
+.incbin "baserom.gba", 0xE8A838, 0x100
+sQwilfishSprites42:
+ax_sprite sQwilfishGfx42, 0x100
+ax_sprite_terminator
+sQwilfishGfx43:
+.incbin "baserom.gba", 0xE8A948, 0x200
+sQwilfishSprites43:
+ax_sprite sQwilfishGfx43, 0x200
+ax_sprite_terminator
+sQwilfishGfx44:
+.incbin "baserom.gba", 0xE8AB58, 0x200
+sQwilfishSprites44:
+ax_sprite sQwilfishGfx44, 0x200
+ax_sprite_terminator
+sQwilfishGfx45:
+.incbin "baserom.gba", 0xE8AD68, 0x200
+sQwilfishSprites45:
+ax_sprite sQwilfishGfx45, 0x200
+ax_sprite_terminator
+sQwilfishGfx46:
+.incbin "baserom.gba", 0xE8AF78, 0x200
+sQwilfishSprites46:
+ax_sprite sQwilfishGfx46, 0x200
+ax_sprite_terminator
+sQwilfishGfx47:
+.incbin "baserom.gba", 0xE8B188, 0x200
+sQwilfishSprites47:
+ax_sprite sQwilfishGfx47, 0x200
+ax_sprite_terminator
+sAxPosesQwilfish:
+.4byte sQwilfishPose1
+.4byte sQwilfishPose2
+.4byte sQwilfishPose3
+.4byte sQwilfishPose4
+.4byte sQwilfishPose5
+.4byte sQwilfishPose6
+.4byte sQwilfishPose7
+.4byte sQwilfishPose8
+.4byte sQwilfishPose9
+.4byte sQwilfishPose10
+.4byte sQwilfishPose11
+.4byte sQwilfishPose12
+.4byte sQwilfishPose13
+.4byte sQwilfishPose14
+.4byte sQwilfishPose15
+.4byte sQwilfishPose16
+.4byte sQwilfishPose17
+.4byte sQwilfishPose18
+.4byte sQwilfishPose19
+.4byte sQwilfishPose20
+.4byte sQwilfishPose21
+.4byte sQwilfishPose22
+.4byte sQwilfishPose23
+.4byte sQwilfishPose24
+.4byte sQwilfishPose25
+.4byte sQwilfishPose26
+.4byte sQwilfishPose27
+.4byte sQwilfishPose28
+.4byte sQwilfishPose29
+.4byte sQwilfishPose30
+.4byte sQwilfishPose31
+.4byte sQwilfishPose32
+.4byte sQwilfishPose33
+.4byte sQwilfishPose34
+.4byte sQwilfishPose35
+.4byte sQwilfishPose36
+.4byte sQwilfishPose37
+.4byte sQwilfishPose38
+.4byte sQwilfishPose39
+.4byte sQwilfishPose40
+.4byte sQwilfishPose41
+.4byte sQwilfishPose42
+.4byte sQwilfishPose43
+.4byte sQwilfishPose44
+.4byte sQwilfishPose45
+.4byte sQwilfishPose46
+.4byte sQwilfishPose47
+.4byte sQwilfishPose48
+.4byte sQwilfishPose49
+.4byte sQwilfishPose50
+.4byte sQwilfishPose51
+.4byte sQwilfishPose52
+.4byte sQwilfishPose53
+.4byte sQwilfishPose54
+.4byte sQwilfishPose55
+.4byte sQwilfishPose56
+.4byte sQwilfishPose57
+.4byte sQwilfishPose58
+.4byte sQwilfishPose59
+.4byte sQwilfishPose60
+.4byte sQwilfishPose61
+.4byte sQwilfishPose62
+.4byte sQwilfishPose63
+.4byte sQwilfishPose64
+.4byte sQwilfishPose65
+.4byte sQwilfishPose66
+.4byte sQwilfishPose67
+.4byte sQwilfishPose68
+.4byte sQwilfishPose69
+.4byte sQwilfishPose70
+.4byte sQwilfishPose71
+.4byte sQwilfishPose72
+.4byte sQwilfishPose73
+.4byte sQwilfishPose74
+.4byte sQwilfishPose75
+.4byte sQwilfishPose76
+.4byte sQwilfishPose77
+.4byte sQwilfishPose78
+.4byte sQwilfishPose79
+.4byte sQwilfishPose80
+.4byte sQwilfishPose81
+.4byte sQwilfishPose82
+.4byte sQwilfishPose83
+.4byte sQwilfishPose84
+.4byte sQwilfishPose85
+.4byte sQwilfishPose86
+.4byte sQwilfishPose87
+.4byte sQwilfishPose88
+.4byte sQwilfishPose89
+.4byte sQwilfishPose90
+.4byte sQwilfishPose91
+.4byte sQwilfishPose92
+.4byte sQwilfishPose93
+.4byte sQwilfishPose94
+.4byte sQwilfishPose95
+.4byte sQwilfishPose96
+.4byte sQwilfishPose97
+.4byte sQwilfishPose98
+.4byte sQwilfishPose99
+.4byte sQwilfishPose100
+.4byte sQwilfishPose101
+.4byte sQwilfishPose102
+.4byte sQwilfishPose103
+.4byte sQwilfishPose104
+.4byte sQwilfishPose105
+.4byte sQwilfishPose106
+.4byte sQwilfishPose107
+.4byte sQwilfishPose108
+.4byte sQwilfishPose109
+.4byte sQwilfishPose110
+.4byte sQwilfishPose111
+.4byte sQwilfishPose112
+.4byte sQwilfishPose113
+.4byte sQwilfishPose114
+.4byte sQwilfishPose115
+.4byte sQwilfishPose116
+.4byte sQwilfishPose117
+.4byte sQwilfishPose118
+.4byte sQwilfishPose119
+.4byte sQwilfishPose120
+.4byte sQwilfishPose121
+.4byte sQwilfishPose122
+.4byte sQwilfishPose123
+.4byte sQwilfishPose124
+.4byte sQwilfishPose125
+.4byte sQwilfishPose126
+.4byte sQwilfishPose127
+.4byte sQwilfishPose128
+.4byte sQwilfishPose129
+.4byte sQwilfishPose130
+.4byte sQwilfishPose131
+.4byte sQwilfishPose132
+.4byte sQwilfishPose133
+.4byte sQwilfishPose134
+.4byte sQwilfishPose135
+.4byte sQwilfishPose136
+.4byte sQwilfishPose137
+.4byte sQwilfishPose138
+.4byte sQwilfishPose139
+.4byte sQwilfishPose140
+.4byte sQwilfishPose141
+.4byte sQwilfishPose142
+.4byte sQwilfishPose143
+.4byte sQwilfishPose144
+.4byte sQwilfishPose145
+.4byte sQwilfishPose146
+.4byte sQwilfishPose147
+.4byte sQwilfishPose148
+.4byte sQwilfishPose149
+.4byte sQwilfishPose150
+.4byte sQwilfishPose151
+.4byte sQwilfishPose152
+.4byte sQwilfishPose153
+.4byte sQwilfishPose154
+.4byte sQwilfishPose155
+.4byte sQwilfishPose156
+.4byte sQwilfishPose157
+.4byte sQwilfishPose158
+.4byte sQwilfishPose159
+.4byte sQwilfishPose160
+.4byte sQwilfishPose161
+.4byte sQwilfishPose162
+.4byte sQwilfishPose163
+.4byte sQwilfishPose164
+.4byte sQwilfishPose165
+.4byte sQwilfishPose166
+.4byte sQwilfishPose167
+.4byte sQwilfishPose168
+.4byte sQwilfishPose169
+.4byte sQwilfishPose170
+.4byte sQwilfishPose171
+.4byte sQwilfishPose172
+.4byte sQwilfishPose173
+.4byte sQwilfishPose174
+.4byte sQwilfishPose175
+.4byte sQwilfishPose176
+.4byte sQwilfishPose177
+.4byte sQwilfishPose178
+.4byte sQwilfishPose179
+.4byte sQwilfishPose180
+.4byte sQwilfishPose181
+.4byte sQwilfishPose182
+.4byte sQwilfishPose183
+.4byte sQwilfishPose184
+.4byte sQwilfishPose185
+.4byte sQwilfishPose186
+.4byte sQwilfishPose187
+.4byte sQwilfishPose188
+.4byte sQwilfishPose189
+.4byte sQwilfishPose190
+.4byte sQwilfishPose191
+.4byte sQwilfishPose192
+.4byte sQwilfishPose193
+.4byte sQwilfishPose194
+.4byte sQwilfishPose195
+.4byte sQwilfishPose196
+.4byte sQwilfishPose197
+.4byte sQwilfishPose198
+.4byte sQwilfishPose199
+.4byte sQwilfishPose200
+.4byte sQwilfishPose201
+.4byte sQwilfishPose202
+.4byte sQwilfishPose203
+.4byte sQwilfishPose204
+.4byte sQwilfishPose205
+.4byte sQwilfishPose206
+.4byte sQwilfishPose207
+.4byte sQwilfishPose208
+.4byte sQwilfishPose209
+.4byte sQwilfishPose210
+.4byte sQwilfishPose211
+.4byte sQwilfishPose212
+.4byte sQwilfishPose213
+.4byte sQwilfishPose214
+.4byte sQwilfishPose215
+.4byte sQwilfishPose216
+.4byte sQwilfishPose217
+.4byte sQwilfishPose218
+.4byte sQwilfishPose219
+.4byte sQwilfishPose220
+.4byte sQwilfishPose221
+.4byte sQwilfishPose222
+.4byte sQwilfishPose223
+.4byte sQwilfishPose224
+.4byte sQwilfishPose225
+.4byte sQwilfishPose226
+.4byte sQwilfishPose227
+.4byte sQwilfishPose228
+.4byte sQwilfishPose229
+.4byte sQwilfishPose230
+.4byte sQwilfishPose231
+.4byte sQwilfishPose232
+.4byte sQwilfishPose233
+.4byte sQwilfishPose234
+.4byte sQwilfishPose235
+.4byte sQwilfishPose236
+.4byte sQwilfishPose237
+.4byte sQwilfishPose238
+.4byte sQwilfishPose239
+.4byte sQwilfishPose240
+.4byte sQwilfishPose241
+.4byte sQwilfishPose242
+.4byte sQwilfishPose243
+.4byte sQwilfishPose244
+.4byte sQwilfishPose245
+.4byte sQwilfishPose246
+.4byte sQwilfishPose247
+.4byte sQwilfishPose248
+.4byte sQwilfishPose249
+.4byte sQwilfishPose250
+sAxPositionsQwilfish:
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte   -1,   -5, 	  -5,   -9, 	   5,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -5,   -6, 	   5,   -9, 	   0,   -8
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   3,  -12, 	  -3,   -5, 	  -1,   -9
+.2byte    2,   -5, 	   5,   -9, 	  -5,   -6, 	  -1,   -9
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   0,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    2,  -10, 	  -5,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -11, 	   3,   -6, 	  -1,   -9
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   3,  -10, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -10, 	   5,   -9, 	  -4,  -10, 	   0,  -10
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -4,  -10, 	   3,   -9, 	  -6,   -8, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -11, 	  -5,   -6, 	  -1,   -9
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -5,  -12, 	   1,   -5, 	  -1,   -9
+.2byte   -4,   -5, 	  -7,   -9, 	   3,   -6, 	  -1,   -9
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte   -1,   -5, 	  -5,   -9, 	   5,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -5,   -6, 	   5,   -9, 	   0,   -8
+.2byte    0,   -2, 	  -8,   -6, 	   8,   -6, 	   0,   -5
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   3,  -12, 	  -3,   -5, 	  -1,   -9
+.2byte    2,   -5, 	   5,   -9, 	  -5,   -6, 	  -1,   -9
+.2byte    4,   -5, 	   4,  -10, 	  -5,   -7, 	   0,   -8
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   0,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte    6,   -6, 	   0,  -10, 	  -2,   -7, 	   1,   -7
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    2,  -10, 	  -5,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -11, 	   3,   -6, 	  -1,   -9
+.2byte    4,  -10, 	  -2,  -13, 	   9,   -8, 	   2,  -10
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   3,  -10, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -10, 	   5,   -9, 	  -4,  -10, 	   0,  -10
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -4,  -10, 	   3,   -9, 	  -6,   -8, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -11, 	  -5,   -6, 	  -1,   -9
+.2byte   -6,  -10, 	   0,  -13, 	 -11,   -8, 	  -4,  -10
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	  -1,  -10, 	   1,   -7, 	  -2,   -7
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -5,  -12, 	   1,   -5, 	  -1,   -9
+.2byte   -4,   -5, 	  -7,   -9, 	   3,   -6, 	  -1,   -9
+.2byte   -6,   -5, 	  -6,  -10, 	   3,   -7, 	  -2,   -8
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte   -1,   -5, 	  -5,   -9, 	   5,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -5,   -6, 	   5,   -9, 	   0,   -8
+.2byte    0,   -2, 	  -8,   -6, 	   8,   -6, 	   0,   -5
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   3,  -12, 	  -3,   -5, 	  -1,   -9
+.2byte    2,   -5, 	   5,   -9, 	  -5,   -6, 	  -1,   -9
+.2byte    4,   -5, 	   4,  -10, 	  -5,   -7, 	   0,   -8
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   0,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte    6,   -6, 	   0,  -10, 	  -2,   -7, 	   1,   -7
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    2,  -10, 	  -5,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -11, 	   3,   -6, 	  -1,   -9
+.2byte    4,  -10, 	  -2,  -13, 	   9,   -8, 	   2,  -10
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   3,  -10, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -10, 	   5,   -9, 	  -4,  -10, 	   0,  -10
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -4,  -10, 	   3,   -9, 	  -6,   -8, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -11, 	  -5,   -6, 	  -1,   -9
+.2byte   -6,  -10, 	   0,  -13, 	 -11,   -8, 	  -4,  -10
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	  -1,  -10, 	   1,   -7, 	  -2,   -7
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -5,  -12, 	   1,   -5, 	  -1,   -9
+.2byte   -4,   -5, 	  -7,   -9, 	   3,   -6, 	  -1,   -9
+.2byte   -6,   -5, 	  -6,  -10, 	   3,   -7, 	  -2,   -8
+.2byte    0,   -4, 	 -11,   -8, 	   9,   -8, 	   0,   -8
+.2byte    0,   -4, 	  -9,   -8, 	  11,   -8, 	   0,   -7
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte   -1,   -5, 	  -5,   -9, 	   5,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -5,   -6, 	   5,   -9, 	   0,   -8
+.2byte    0,   -2, 	  -8,   -6, 	   8,   -6, 	   0,   -5
+.2byte    5,   -6, 	  10,   -9, 	  -4,   -7, 	  -1,   -9
+.2byte    5,   -6, 	   8,   -9, 	  -6,   -7, 	  -1,   -9
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   3,  -12, 	  -3,   -5, 	  -1,   -9
+.2byte    2,   -5, 	   5,   -9, 	  -5,   -6, 	  -1,   -9
+.2byte    4,   -5, 	   4,  -10, 	  -5,   -7, 	   0,   -8
+.2byte    7,   -9, 	  -1,  -13, 	  -1,   -5, 	  -2,  -10
+.2byte    7,   -9, 	  -3,  -13, 	  -4,   -7, 	  -1,   -9
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   0,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte    6,   -6, 	   0,  -10, 	  -2,   -7, 	   1,   -7
+.2byte    3,   -9, 	  -4,  -13, 	   6,   -6, 	  -1,  -10
+.2byte    5,  -10, 	  -7,  -13, 	   9,   -7, 	   0,  -10
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    2,  -10, 	  -5,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -11, 	   3,   -6, 	  -1,   -9
+.2byte    4,  -10, 	  -2,  -13, 	   9,   -8, 	   2,  -10
+.2byte   -2,  -10, 	   6,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte    0,  -10, 	   7,   -7, 	  -8,  -11, 	  -1,  -10
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   3,  -10, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -10, 	   5,   -9, 	  -4,  -10, 	   0,  -10
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -4,   -9, 	   3,  -13, 	  -7,   -6, 	   0,  -10
+.2byte   -6,  -10, 	   6,  -13, 	 -10,   -7, 	  -1,  -10
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -4,  -10, 	   3,   -9, 	  -6,   -8, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -11, 	  -5,   -6, 	  -1,   -9
+.2byte   -6,  -10, 	   0,  -13, 	 -11,   -8, 	  -4,  -10
+.2byte   -9,   -9, 	  -1,  -13, 	  -1,   -5, 	   0,  -10
+.2byte   -9,   -9, 	   1,  -13, 	   2,   -7, 	  -1,   -9
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	  -1,  -10, 	   1,   -7, 	  -2,   -7
+.2byte   -6,   -6, 	 -11,   -9, 	   3,   -7, 	   0,   -9
+.2byte   -6,   -6, 	  -9,   -9, 	   5,   -7, 	   0,   -9
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -5,  -12, 	   1,   -5, 	  -1,   -9
+.2byte   -4,   -5, 	  -7,   -9, 	   3,   -6, 	  -1,   -9
+.2byte   -6,   -5, 	  -6,  -10, 	   3,   -7, 	  -2,   -8
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte    0,   -5, 	  -5,   -7, 	   5,   -7, 	   0,   -7
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte    4,   -8, 	   3,  -10, 	  -1,   -7, 	   0,   -9
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    4,   -8, 	  -1,  -10, 	  -1,   -5, 	  -1,   -8
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    2,   -9, 	  -2,  -11, 	   2,   -7, 	   0,   -9
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,   -9, 	   4,   -8, 	  -6,   -8, 	  -1,   -8
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -3,   -9, 	   1,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	  -1,  -10, 	  -1,   -5, 	  -1,   -8
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -5,   -8, 	  -4,  -10, 	   0,   -7, 	  -1,   -9
+.2byte    0,   -6, 	  -6,   -9, 	   6,   -9, 	   0,   -8
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -7
+.2byte    0,  -12, 	  -6,   -9, 	   6,   -9, 	   0,  -11
+.2byte    3,  -12, 	   5,  -11, 	  -3,   -7, 	   0,  -10
+.2byte    5,  -11, 	  -1,  -12, 	   0,   -8, 	   0,  -11
+.2byte    2,  -13, 	  -3,  -11, 	   5,   -8, 	  -1,  -10
+.2byte    0,  -13, 	   6,   -8, 	  -6,   -8, 	   0,  -11
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -8, 	   0,  -10
+.2byte   -6,  -11, 	   0,  -12, 	  -1,   -8, 	  -1,  -11
+.2byte   -4,  -12, 	  -6,  -11, 	   2,   -7, 	  -1,  -10
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte   -1,   -5, 	  -5,   -9, 	   5,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -5,   -6, 	   5,   -9, 	   0,   -8
+.2byte    0,   -2, 	  -8,   -6, 	   8,   -6, 	   0,   -5
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   3,  -12, 	  -3,   -5, 	  -1,   -9
+.2byte    2,   -5, 	   5,   -9, 	  -5,   -6, 	  -1,   -9
+.2byte    4,   -5, 	   4,  -10, 	  -5,   -7, 	   0,   -8
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   0,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte    6,   -6, 	   0,  -10, 	  -2,   -7, 	   1,   -7
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    2,  -10, 	  -5,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -11, 	   3,   -6, 	  -1,   -9
+.2byte    4,  -10, 	  -2,  -13, 	   9,   -8, 	   2,  -10
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   3,  -10, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -10, 	   5,   -9, 	  -4,  -10, 	   0,  -10
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -4,  -10, 	   3,   -9, 	  -6,   -8, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -11, 	  -5,   -6, 	  -1,   -9
+.2byte   -6,  -10, 	   0,  -13, 	 -11,   -8, 	  -4,  -10
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	  -1,  -10, 	   1,   -7, 	  -2,   -7
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -5,  -12, 	   1,   -5, 	  -1,   -9
+.2byte   -4,   -5, 	  -7,   -9, 	   3,   -6, 	  -1,   -9
+.2byte   -6,   -5, 	  -6,  -10, 	   3,   -7, 	  -2,   -8
+.2byte    0,   -4, 	  -8,   -8, 	   8,   -8, 	   0,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -6, 	  -1,   -7
+.2byte   -6,   -6, 	   0,  -10, 	   2,   -7, 	  -1,   -7
+.2byte   -3,   -8, 	   3,  -11, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte    2,   -8, 	  -4,  -11, 	   7,   -6, 	   0,   -8
+.2byte    6,   -6, 	   0,  -10, 	  -2,   -7, 	   1,   -7
+.2byte    4,   -4, 	   4,   -9, 	  -5,   -6, 	   0,   -7
+.2byte    0,   -4, 	  -8,   -8, 	   8,   -8, 	   0,   -7
+.2byte    4,   -4, 	   4,   -9, 	  -5,   -6, 	   0,   -7
+.2byte    6,   -6, 	   0,  -10, 	  -2,   -7, 	   1,   -7
+.2byte    2,   -8, 	  -4,  -11, 	   7,   -6, 	   0,   -8
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -3,   -8, 	   3,  -11, 	  -8,   -6, 	  -1,   -8
+.2byte   -6,   -6, 	   0,  -10, 	   2,   -7, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -6, 	  -1,   -7
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte   -1,   -5, 	  -5,   -9, 	   5,   -6, 	   0,   -8
+.2byte    1,   -5, 	  -5,   -6, 	   5,   -9, 	   0,   -8
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   3,  -12, 	  -3,   -5, 	  -1,   -9
+.2byte    2,   -5, 	   5,   -9, 	  -5,   -6, 	  -1,   -9
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   0,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    2,  -10, 	  -5,   -9, 	   4,   -8, 	  -1,   -9
+.2byte    5,   -9, 	  -3,  -11, 	   3,   -6, 	  -1,   -9
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   3,  -10, 	  -7,   -9, 	  -1,  -10
+.2byte    1,  -10, 	   5,   -9, 	  -4,  -10, 	   0,  -10
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -4,  -10, 	   3,   -9, 	  -6,   -8, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -11, 	  -5,   -6, 	  -1,   -9
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	  -2,  -11, 	  -1,   -5, 	  -1,   -8
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -5,  -12, 	   1,   -5, 	  -1,   -9
+.2byte   -4,   -5, 	  -7,   -9, 	   3,   -6, 	  -1,   -9
+.2byte    0,   -4, 	  -8,   -8, 	   8,   -8, 	   0,   -7
+.2byte    4,   -4, 	   4,   -9, 	  -5,   -6, 	   0,   -7
+.2byte    6,   -6, 	   0,  -10, 	  -2,   -7, 	   1,   -7
+.2byte    2,   -8, 	  -4,  -11, 	   7,   -6, 	   0,   -8
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -3,   -8, 	   3,  -11, 	  -8,   -6, 	  -1,   -8
+.2byte   -6,   -6, 	   0,  -10, 	   2,   -7, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -6, 	  -1,   -7
+.2byte    0,   -5, 	  -6,   -8, 	   6,   -8, 	   0,   -8
+.2byte   -6,   -7, 	  -5,  -11, 	   2,   -6, 	  -1,   -9
+.2byte   -7,   -8, 	  -2,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte   -3,  -11, 	   1,  -10, 	  -5,   -6, 	  -2,   -9
+.2byte   -1,  -10, 	   5,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte    1,  -11, 	  -3,  -10, 	   3,   -6, 	   0,   -9
+.2byte    5,   -8, 	   0,  -10, 	  -1,   -5, 	  -1,   -9
+.2byte    4,   -7, 	   3,  -11, 	  -4,   -6, 	  -1,   -9
+sQwilfishAnimTable1:
+.4byte sQwilfishAnims_1_1
+.4byte sQwilfishAnims_1_2
+.4byte sQwilfishAnims_1_3
+.4byte sQwilfishAnims_1_4
+.4byte sQwilfishAnims_1_5
+.4byte sQwilfishAnims_1_6
+.4byte sQwilfishAnims_1_7
+.4byte sQwilfishAnims_1_8
+sQwilfishAnimTable2:
+.4byte sQwilfishAnims_2_1
+.4byte sQwilfishAnims_2_2
+.4byte sQwilfishAnims_2_3
+.4byte sQwilfishAnims_2_4
+.4byte sQwilfishAnims_2_5
+.4byte sQwilfishAnims_2_6
+.4byte sQwilfishAnims_2_7
+.4byte sQwilfishAnims_2_8
+sQwilfishAnimTable3:
+.4byte sQwilfishAnims_3_1
+.4byte sQwilfishAnims_3_2
+.4byte sQwilfishAnims_3_3
+.4byte sQwilfishAnims_3_4
+.4byte sQwilfishAnims_3_5
+.4byte sQwilfishAnims_3_6
+.4byte sQwilfishAnims_3_7
+.4byte sQwilfishAnims_3_8
+sQwilfishAnimTable4:
+.4byte sQwilfishAnims_4_1
+.4byte sQwilfishAnims_4_2
+.4byte sQwilfishAnims_4_3
+.4byte sQwilfishAnims_4_4
+.4byte sQwilfishAnims_4_5
+.4byte sQwilfishAnims_4_6
+.4byte sQwilfishAnims_4_7
+.4byte sQwilfishAnims_4_8
+sQwilfishAnimTable5:
+.4byte sQwilfishAnims_5_1
+.4byte sQwilfishAnims_5_2
+.4byte sQwilfishAnims_5_3
+.4byte sQwilfishAnims_5_4
+.4byte sQwilfishAnims_5_5
+.4byte sQwilfishAnims_5_6
+.4byte sQwilfishAnims_5_7
+.4byte sQwilfishAnims_5_8
+sQwilfishAnimTable6:
+.4byte sQwilfishAnims_6_1
+.4byte sQwilfishAnims_6_1
+.4byte sQwilfishAnims_6_1
+.4byte sQwilfishAnims_6_1
+.4byte sQwilfishAnims_6_1
+.4byte sQwilfishAnims_6_1
+.4byte sQwilfishAnims_6_1
+.4byte sQwilfishAnims_6_1
+sQwilfishAnimTable7:
+.4byte sQwilfishAnims_7_1
+.4byte sQwilfishAnims_7_2
+.4byte sQwilfishAnims_7_3
+.4byte sQwilfishAnims_7_4
+.4byte sQwilfishAnims_7_5
+.4byte sQwilfishAnims_7_6
+.4byte sQwilfishAnims_7_7
+.4byte sQwilfishAnims_7_8
+sQwilfishAnimTable8:
+.4byte sQwilfishAnims_8_1
+.4byte sQwilfishAnims_8_2
+.4byte sQwilfishAnims_8_3
+.4byte sQwilfishAnims_8_4
+.4byte sQwilfishAnims_8_5
+.4byte sQwilfishAnims_8_6
+.4byte sQwilfishAnims_8_7
+.4byte sQwilfishAnims_8_8
+sQwilfishAnimTable9:
+.4byte sQwilfishAnims_9_1
+.4byte sQwilfishAnims_9_2
+.4byte sQwilfishAnims_9_3
+.4byte sQwilfishAnims_9_4
+.4byte sQwilfishAnims_9_5
+.4byte sQwilfishAnims_9_6
+.4byte sQwilfishAnims_9_7
+.4byte sQwilfishAnims_9_8
+sQwilfishAnimTable10:
+.4byte sQwilfishAnims_10_1
+.4byte sQwilfishAnims_10_2
+.4byte sQwilfishAnims_10_3
+.4byte sQwilfishAnims_10_4
+.4byte sQwilfishAnims_10_5
+.4byte sQwilfishAnims_10_6
+.4byte sQwilfishAnims_10_7
+.4byte sQwilfishAnims_10_8
+sQwilfishAnimTable11:
+.4byte sQwilfishAnims_11_1
+.4byte sQwilfishAnims_11_2
+.4byte sQwilfishAnims_11_3
+.4byte sQwilfishAnims_11_4
+.4byte sQwilfishAnims_11_5
+.4byte sQwilfishAnims_11_6
+.4byte sQwilfishAnims_11_7
+.4byte sQwilfishAnims_11_8
+sQwilfishAnimTable12:
+.4byte sQwilfishAnims_12_1
+.4byte sQwilfishAnims_12_2
+.4byte sQwilfishAnims_12_3
+.4byte sQwilfishAnims_12_4
+.4byte sQwilfishAnims_12_5
+.4byte sQwilfishAnims_12_6
+.4byte sQwilfishAnims_12_7
+.4byte sQwilfishAnims_12_8
+sQwilfishAnimTable13:
+.4byte sQwilfishAnims_13_1
+.4byte sQwilfishAnims_13_2
+.4byte sQwilfishAnims_13_3
+.4byte sQwilfishAnims_13_4
+.4byte sQwilfishAnims_13_5
+.4byte sQwilfishAnims_13_6
+.4byte sQwilfishAnims_13_7
+.4byte sQwilfishAnims_13_8
+sAxAnimationsQwilfish:
+.4byte sQwilfishAnimTable1
+.4byte sQwilfishAnimTable2
+.4byte sQwilfishAnimTable3
+.4byte sQwilfishAnimTable4
+.4byte sQwilfishAnimTable5
+.4byte sQwilfishAnimTable6
+.4byte sQwilfishAnimTable7
+.4byte sQwilfishAnimTable8
+.4byte sQwilfishAnimTable9
+.4byte sQwilfishAnimTable10
+.4byte sQwilfishAnimTable11
+.4byte sQwilfishAnimTable12
+.4byte sQwilfishAnimTable13
+sAxSpritesQwilfish:
+.4byte sQwilfishSprites1
+.4byte sQwilfishSprites2
+.4byte sQwilfishSprites3
+.4byte sQwilfishSprites4
+.4byte sQwilfishSprites5
+.4byte sQwilfishSprites6
+.4byte sQwilfishSprites7
+.4byte sQwilfishSprites8
+.4byte sQwilfishSprites9
+.4byte sQwilfishSprites10
+.4byte sQwilfishSprites11
+.4byte sQwilfishSprites12
+.4byte sQwilfishSprites13
+.4byte sQwilfishSprites14
+.4byte sQwilfishSprites15
+.4byte sQwilfishSprites16
+.4byte sQwilfishSprites17
+.4byte sQwilfishSprites18
+.4byte sQwilfishSprites19
+.4byte sQwilfishSprites20
+.4byte sQwilfishSprites21
+.4byte sQwilfishSprites22
+.4byte sQwilfishSprites23
+.4byte sQwilfishSprites24
+.4byte sQwilfishSprites25
+.4byte sQwilfishSprites26
+.4byte sQwilfishSprites27
+.4byte sQwilfishSprites28
+.4byte sQwilfishSprites29
+.4byte sQwilfishSprites30
+.4byte sQwilfishSprites31
+.4byte sQwilfishSprites32
+.4byte sQwilfishSprites33
+.4byte sQwilfishSprites34
+.4byte sQwilfishSprites35
+.4byte sQwilfishSprites36
+.4byte sQwilfishSprites37
+.4byte sQwilfishSprites38
+.4byte sQwilfishSprites39
+.4byte sQwilfishSprites40
+.4byte sQwilfishSprites41
+.4byte sQwilfishSprites42
+.4byte sQwilfishSprites43
+.4byte sQwilfishSprites44
+.4byte sQwilfishSprites45
+.4byte sQwilfishSprites46
+.4byte sQwilfishSprites47
+sAxMainQwilfish:
+ax_main sAxPosesQwilfish, sAxAnimationsQwilfish, 13, sAxSpritesQwilfish, sAxPositionsQwilfish

--- a/data/ax/raichu.inc
+++ b/data/ax/raichu.inc
@@ -1,0 +1,3195 @@
+.global gAxRaichu
+gAxRaichu:
+ax_siro sAxMainRaichu
+sRaichuPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose4:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose5:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose6:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose7:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose8:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose9:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose10:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose11:
+ax_pose 10, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose12:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose14:
+ax_pose 13, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose15:
+ax_pose 14, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose16:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose17:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose18:
+ax_pose 17, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose19:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose20:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose21:
+ax_pose 20, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose22:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose23:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose24:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose28:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose29:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose30:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose31:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose32:
+ax_pose 25, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaichuPose33:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose34:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose35:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose36:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose37:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose38:
+ax_pose 10, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose39:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose40:
+ax_pose 27, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaichuPose41:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose42:
+ax_pose 13, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose43:
+ax_pose 14, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose44:
+ax_pose 28, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose45:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose46:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose47:
+ax_pose 17, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose48:
+ax_pose 27, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose49:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose50:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose51:
+ax_pose 20, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose52:
+ax_pose 26, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose53:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose54:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose55:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose56:
+ax_pose 25, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose58:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose59:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose60:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose61:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose62:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose63:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose64:
+ax_pose 25, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaichuPose65:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose66:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose67:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose68:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose69:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose70:
+ax_pose 10, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose71:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose72:
+ax_pose 27, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaichuPose73:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose74:
+ax_pose 13, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose75:
+ax_pose 14, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose76:
+ax_pose 28, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose77:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose78:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose79:
+ax_pose 17, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose80:
+ax_pose 27, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose81:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose82:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose83:
+ax_pose 20, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose84:
+ax_pose 26, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose85:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose86:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose87:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose88:
+ax_pose 25, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose90:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose91:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose92:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose93:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose94:
+ax_pose 31, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose95:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose96:
+ax_pose 32, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose97:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose98:
+ax_pose 33, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose99:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose100:
+ax_pose 32, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose101:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose102:
+ax_pose 31, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose103:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose104:
+ax_pose 30, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose105:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose106:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose107:
+ax_pose 34, 0x01df, 0x80e8, 0x4c00
+ax_pose 35, 0x81df, 0x8108, 0x4c10
+ax_pose 36, 0x41ff, 0x00e8, 0x4c18
+ax_pose 37, 0x41ff, 0x0108, 0x4c1a
+ax_pose 38, 0x01e6, 0x80f0, 0x4c1c
+ax_pose_terminator
+sRaichuPose108:
+ax_pose 39, 0x41e0, 0x00e8, 0x4c00
+ax_pose 40, 0x81e8, 0x80e8, 0x4c02
+ax_pose 41, 0x41e0, 0x40f8, 0x4c0a
+ax_pose 42, 0x41e8, 0x0100, 0x4c0e
+ax_pose 43, 0x81e8, 0x4110, 0x4c10
+ax_pose 44, 0x81f0, 0x0108, 0x4c14
+ax_pose 45, 0x0200, 0x0108, 0x4c16
+ax_pose 46, 0x41e6, 0x80f0, 0x4c17
+ax_pose 47, 0x41f6, 0x40f0, 0x4c1f
+ax_pose 48, 0x41fe, 0x40f0, 0x4c23
+ax_pose_terminator
+sRaichuPose109:
+ax_pose 38, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose110:
+ax_pose 46, 0x41e6, 0x80f0, 0x4c00
+ax_pose 47, 0x41f6, 0x40f0, 0x4c08
+ax_pose 48, 0x41fe, 0x40f0, 0x4c0c
+ax_pose_terminator
+sRaichuPose111:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose112:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose113:
+ax_pose 49, 0x01dd, 0x90f2, 0x4c00
+ax_pose 50, 0x81dd, 0x50ea, 0x4c10
+ax_pose 51, 0x41fd, 0x10ea, 0x4c14
+ax_pose 52, 0x01e6, 0x90f0, 0x4c16
+ax_pose_terminator
+sRaichuPose114:
+ax_pose 53, 0x81de, 0x9108, 0x4c00
+ax_pose 54, 0x41de, 0x90e8, 0x4c08
+ax_pose 55, 0x81ee, 0x90e8, 0x4c10
+ax_pose 56, 0x01fe, 0x1108, 0x4c18
+ax_pose 57, 0x41e6, 0x50f0, 0x4c19
+ax_pose 58, 0x41ee, 0x50f0, 0x4c1d
+ax_pose 59, 0x41f6, 0x50f0, 0x4c21
+ax_pose 60, 0x41fe, 0x50f0, 0x4c25
+ax_pose_terminator
+sRaichuPose115:
+ax_pose 52, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose116:
+ax_pose 57, 0x41e6, 0x50f0, 0x4c00
+ax_pose 58, 0x41ee, 0x50f0, 0x4c04
+ax_pose 59, 0x41f6, 0x50f0, 0x4c08
+ax_pose 60, 0x41fe, 0x50f0, 0x4c0c
+ax_pose_terminator
+sRaichuPose117:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose118:
+ax_pose 31, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose119:
+ax_pose 61, 0x01e0, 0x90f2, 0x4c00
+ax_pose 62, 0x81e0, 0x50ea, 0x4c10
+ax_pose 63, 0x01e6, 0x90f0, 0x4c14
+ax_pose_terminator
+sRaichuPose120:
+ax_pose 39, 0x41df, 0x1106, 0x4c00
+ax_pose 40, 0x81e7, 0x9106, 0x4c02
+ax_pose 41, 0x41df, 0x50e6, 0x4c0a
+ax_pose 42, 0x41e7, 0x10ee, 0x4c0e
+ax_pose 43, 0x81e7, 0x50e6, 0x4c10
+ax_pose 44, 0x81ef, 0x10ee, 0x4c14
+ax_pose 45, 0x01ff, 0x10ee, 0x4c16
+ax_pose 64, 0x81e6, 0x9100, 0x4c17
+ax_pose 65, 0x81e6, 0x90f0, 0x4c1f
+ax_pose_terminator
+sRaichuPose121:
+ax_pose 63, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose122:
+ax_pose 64, 0x81e6, 0x9100, 0x4c00
+ax_pose 65, 0x81e6, 0x90f0, 0x4c08
+ax_pose_terminator
+sRaichuPose123:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose124:
+ax_pose 32, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose125:
+ax_pose 66, 0x41df, 0x90f1, 0x4c00
+ax_pose 67, 0x01ef, 0x5101, 0x4c08
+ax_pose 68, 0x41ff, 0x50f1, 0x4c0c
+ax_pose 69, 0x81df, 0x50e9, 0x4c10
+ax_pose 70, 0x01e6, 0x90ef, 0x4c14
+ax_pose_terminator
+sRaichuPose126:
+ax_pose 53, 0x81df, 0x80e3, 0x4c00
+ax_pose 54, 0x41df, 0x80f3, 0x4c08
+ax_pose 55, 0x81ef, 0x8103, 0x4c10
+ax_pose 56, 0x01ff, 0x00eb, 0x4c18
+ax_pose 71, 0x81e6, 0x90ff, 0x4c19
+ax_pose 72, 0x81e6, 0x90ef, 0x4c21
+ax_pose_terminator
+sRaichuPose127:
+ax_pose 70, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose128:
+ax_pose 71, 0x81e6, 0x90ff, 0x4c00
+ax_pose 72, 0x81e6, 0x90ef, 0x4c08
+ax_pose_terminator
+sRaichuPose129:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose130:
+ax_pose 33, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose131:
+ax_pose 73, 0x41e1, 0x80e9, 0x4c00
+ax_pose 74, 0x81e1, 0x8109, 0x4c08
+ax_pose 75, 0x4201, 0x0109, 0x4c10
+ax_pose 76, 0x01f1, 0x40e9, 0x4c12
+ax_pose 77, 0x4201, 0x00e9, 0x4c16
+ax_pose 78, 0x01e8, 0x80f1, 0x4c18
+ax_pose_terminator
+sRaichuPose132:
+ax_pose 39, 0x41e1, 0x00e8, 0x4c00
+ax_pose 40, 0x81e9, 0x80e8, 0x4c02
+ax_pose 41, 0x41e1, 0x40f8, 0x4c0a
+ax_pose 42, 0x41e9, 0x0100, 0x4c0e
+ax_pose 43, 0x81e9, 0x4110, 0x4c10
+ax_pose 44, 0x81f1, 0x0108, 0x4c14
+ax_pose 45, 0x0201, 0x0108, 0x4c16
+ax_pose 79, 0x01e8, 0x40f1, 0x4c17
+ax_pose 80, 0x01e8, 0x4101, 0x4c1b
+ax_pose 81, 0x01f8, 0x40f1, 0x4c1f
+ax_pose 82, 0x01f8, 0x4101, 0x4c23
+ax_pose_terminator
+sRaichuPose133:
+ax_pose 78, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose134:
+ax_pose 79, 0x01e8, 0x40f1, 0x4c00
+ax_pose 80, 0x01e8, 0x4101, 0x4c04
+ax_pose 81, 0x01f8, 0x40f1, 0x4c08
+ax_pose 82, 0x01f8, 0x4101, 0x4c0c
+ax_pose_terminator
+sRaichuPose135:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose136:
+ax_pose 32, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose137:
+ax_pose 66, 0x41df, 0x80ee, 0x4c00
+ax_pose 67, 0x01ef, 0x40ee, 0x4c08
+ax_pose 68, 0x41ff, 0x40ee, 0x4c0c
+ax_pose 69, 0x81df, 0x410e, 0x4c10
+ax_pose 70, 0x01e6, 0x80f0, 0x4c14
+ax_pose_terminator
+sRaichuPose138:
+ax_pose 53, 0x81df, 0x910c, 0x4c00
+ax_pose 54, 0x41df, 0x90ec, 0x4c08
+ax_pose 55, 0x81ef, 0x90ec, 0x4c10
+ax_pose 56, 0x01ff, 0x110c, 0x4c18
+ax_pose 71, 0x81e6, 0x80f0, 0x4c19
+ax_pose 72, 0x81e6, 0x8100, 0x4c21
+ax_pose_terminator
+sRaichuPose139:
+ax_pose 70, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose140:
+ax_pose 71, 0x81e6, 0x80f0, 0x4c00
+ax_pose 72, 0x81e6, 0x8100, 0x4c08
+ax_pose_terminator
+sRaichuPose141:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose142:
+ax_pose 31, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose143:
+ax_pose 61, 0x01e0, 0x80ee, 0x4c00
+ax_pose 62, 0x81e0, 0x410e, 0x4c10
+ax_pose 63, 0x01e6, 0x80f0, 0x4c14
+ax_pose_terminator
+sRaichuPose144:
+ax_pose 39, 0x41df, 0x00ea, 0x4c00
+ax_pose 40, 0x81e7, 0x80ea, 0x4c02
+ax_pose 41, 0x41df, 0x40fa, 0x4c0a
+ax_pose 42, 0x41e7, 0x0102, 0x4c0e
+ax_pose 43, 0x81e7, 0x4112, 0x4c10
+ax_pose 44, 0x81ef, 0x010a, 0x4c14
+ax_pose 45, 0x01ff, 0x010a, 0x4c16
+ax_pose 64, 0x81e6, 0x80f0, 0x4c17
+ax_pose 65, 0x81e6, 0x8100, 0x4c1f
+ax_pose_terminator
+sRaichuPose145:
+ax_pose 63, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose146:
+ax_pose 64, 0x81e6, 0x80f0, 0x4c00
+ax_pose 65, 0x81e6, 0x8100, 0x4c08
+ax_pose_terminator
+sRaichuPose147:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose148:
+ax_pose 30, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose149:
+ax_pose 49, 0x01dd, 0x80ee, 0x4c00
+ax_pose 50, 0x81dd, 0x410e, 0x4c10
+ax_pose 51, 0x41fd, 0x0106, 0x4c14
+ax_pose 52, 0x01e6, 0x80f0, 0x4c16
+ax_pose_terminator
+sRaichuPose150:
+ax_pose 53, 0x81de, 0x80e8, 0x4c00
+ax_pose 54, 0x41de, 0x80f8, 0x4c08
+ax_pose 55, 0x81ee, 0x8108, 0x4c10
+ax_pose 56, 0x01fe, 0x00f0, 0x4c18
+ax_pose 57, 0x41e6, 0x40f0, 0x4c19
+ax_pose 58, 0x41ee, 0x40f0, 0x4c1d
+ax_pose 59, 0x41f6, 0x40f0, 0x4c21
+ax_pose 60, 0x41fe, 0x40f0, 0x4c25
+ax_pose_terminator
+sRaichuPose151:
+ax_pose 52, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose152:
+ax_pose 57, 0x41e6, 0x40f0, 0x4c00
+ax_pose 58, 0x41ee, 0x40f0, 0x4c04
+ax_pose 59, 0x41f6, 0x40f0, 0x4c08
+ax_pose 60, 0x41fe, 0x40f0, 0x4c0c
+ax_pose_terminator
+sRaichuPose153:
+ax_pose 83, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose154:
+ax_pose 84, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose155:
+ax_pose 85, 0x01e1, 0x80ee, 0x4c00
+ax_pose_terminator
+sRaichuPose156:
+ax_pose 86, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose157:
+ax_pose 87, 0x01e3, 0x90e7, 0x4c00
+ax_pose_terminator
+sRaichuPose158:
+ax_pose 88, 0x01e4, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaichuPose159:
+ax_pose 89, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose160:
+ax_pose 88, 0x01e4, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaichuPose161:
+ax_pose 87, 0x01e3, 0x80f9, 0x4c00
+ax_pose_terminator
+sRaichuPose162:
+ax_pose 86, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose163:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose164:
+ax_pose 1, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose165:
+ax_pose 2, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose166:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose167:
+ax_pose 4, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose168:
+ax_pose 5, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose169:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose170:
+ax_pose 7, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose171:
+ax_pose 8, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose172:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose173:
+ax_pose 10, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose174:
+ax_pose 11, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose175:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose176:
+ax_pose 13, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose177:
+ax_pose 14, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose178:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose179:
+ax_pose 16, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose180:
+ax_pose 17, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose181:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose182:
+ax_pose 19, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose183:
+ax_pose 20, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose184:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose185:
+ax_pose 22, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose186:
+ax_pose 23, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose187:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose188:
+ax_pose 25, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose189:
+ax_pose 26, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose190:
+ax_pose 27, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose191:
+ax_pose 28, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose192:
+ax_pose 27, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaichuPose193:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose194:
+ax_pose 25, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaichuPose195:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose196:
+ax_pose 30, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose197:
+ax_pose 31, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaichuPose198:
+ax_pose 32, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose199:
+ax_pose 33, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose200:
+ax_pose 32, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose201:
+ax_pose 31, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose202:
+ax_pose 30, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose203:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose204:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose205:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose206:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose207:
+ax_pose 30, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose208:
+ax_pose 25, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaichuPose209:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose210:
+ax_pose 31, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose211:
+ax_pose 26, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose212:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose213:
+ax_pose 32, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose214:
+ax_pose 27, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaichuPose215:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose216:
+ax_pose 33, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose217:
+ax_pose 28, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose218:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose219:
+ax_pose 32, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose220:
+ax_pose 27, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaichuPose221:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose222:
+ax_pose 31, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose223:
+ax_pose 26, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose224:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose225:
+ax_pose 30, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose226:
+ax_pose 25, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaichuPose227:
+ax_pose 38, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose228:
+ax_pose 52, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose229:
+ax_pose 63, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose230:
+ax_pose 70, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sRaichuPose231:
+ax_pose 78, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaichuPose232:
+ax_pose 70, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaichuPose233:
+ax_pose 63, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose234:
+ax_pose 52, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaichuPose235:
+ax_pose 0, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose236:
+ax_pose 21, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose237:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose238:
+ax_pose 15, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose239:
+ax_pose 12, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose240:
+ax_pose 9, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose241:
+ax_pose 6, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaichuPose242:
+ax_pose 3, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+.align 2
+sRaichuAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 1, 0, 1,
+ax_anim 1, 2, 27, 0, 3, 0, 3,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 1, 27, 1, 23, 1, 23,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 2, 0, 27, 1, 23, 1, 23,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRaichuAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, -1,
+ax_anim 1, 2, 31, 6, 2, 6, 6,
+ax_anim 1, 0, 31, 13, 9, 13, 14,
+ax_anim 2, 0, 31, 20, 23, 20, 23,
+ax_anim 2, 1, 31, 21, 22, 21, 22,
+ax_anim 2, 0, 31, 20, 23, 20, 23,
+ax_anim 2, 0, 31, 21, 22, 21, 22,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sRaichuAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, -1, 0, 0,
+ax_anim 1, 2, 35, 4, -3, 4, 0,
+ax_anim 1, 0, 35, 10, -5, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sRaichuAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -3, 0, 0,
+ax_anim 1, 2, 39, 6, -13, 6, -6,
+ax_anim 1, 0, 39, 15, -18, 15, -15,
+ax_anim 2, 0, 39, 19, -16, 19, -16,
+ax_anim 2, 1, 39, 20, -15, 20, -15,
+ax_anim 2, 0, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 39, 20, -15, 20, -15,
+ax_anim 2, 0, 36, 7, -7, 7, -7,
+ax_anim_terminator
+sRaichuAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -6, 0, -4,
+ax_anim 1, 0, 43, 0, -15, 0, -11,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sRaichuAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -3, 0, -1,
+ax_anim 1, 2, 47, -6, -13, -6, -6,
+ax_anim 1, 0, 47, -15, -18, -15, -15,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 1, 47, -20, -15, -20, -15,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 47, -20, -15, -20, -15,
+ax_anim 2, 0, 44, -7, -7, -7, -7,
+ax_anim_terminator
+sRaichuAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, -1, 0, 0,
+ax_anim 1, 2, 51, -4, -3, -4, 0,
+ax_anim 1, 0, 51, -10, -5, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sRaichuAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, -1,
+ax_anim 1, 2, 55, -6, 2, -6, 6,
+ax_anim 1, 0, 55, -13, 9, -13, 14,
+ax_anim 2, 0, 55, -20, 23, -20, 23,
+ax_anim 2, 1, 55, -21, 22, -21, 22,
+ax_anim 2, 0, 55, -20, 23, -20, 23,
+ax_anim 2, 0, 55, -21, 22, -21, 22,
+ax_anim 2, 0, 52, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRaichuAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 1, 0, 1,
+ax_anim 1, 2, 59, 0, 3, 0, 3,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 23, 0, 23,
+ax_anim 2, 1, 59, 1, 23, 1, 23,
+ax_anim 2, 0, 59, 0, 23, 0, 23,
+ax_anim 2, 0, 59, 1, 23, 1, 23,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sRaichuAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, -1, 0, -1,
+ax_anim 1, 2, 63, 6, 2, 6, 6,
+ax_anim 1, 0, 63, 13, 9, 13, 14,
+ax_anim 2, 0, 63, 20, 23, 20, 23,
+ax_anim 2, 1, 63, 21, 22, 21, 22,
+ax_anim 2, 0, 63, 20, 23, 20, 23,
+ax_anim 2, 0, 63, 21, 22, 21, 22,
+ax_anim 2, 0, 60, 8, 8, 8, 8,
+ax_anim_terminator
+sRaichuAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, -1, 0, 0,
+ax_anim 1, 2, 67, 4, -3, 4, 0,
+ax_anim 1, 0, 67, 10, -5, 10, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sRaichuAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -3, 0, 0,
+ax_anim 1, 2, 71, 6, -13, 6, -6,
+ax_anim 1, 0, 71, 15, -18, 15, -15,
+ax_anim 2, 0, 71, 19, -16, 19, -16,
+ax_anim 2, 1, 71, 20, -15, 20, -15,
+ax_anim 2, 0, 71, 19, -16, 19, -16,
+ax_anim 2, 0, 71, 20, -15, 20, -15,
+ax_anim 2, 0, 68, 7, -7, 7, -7,
+ax_anim_terminator
+sRaichuAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -6, 0, -4,
+ax_anim 1, 0, 75, 0, -15, 0, -11,
+ax_anim 2, 0, 75, 0, -15, 0, -15,
+ax_anim 2, 1, 75, 1, -15, 1, -15,
+ax_anim 2, 0, 75, 0, -15, 0, -15,
+ax_anim 2, 0, 75, 1, -15, 1, -15,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sRaichuAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -3, 0, -1,
+ax_anim 1, 2, 79, -6, -13, -6, -6,
+ax_anim 1, 0, 79, -15, -18, -15, -15,
+ax_anim 2, 0, 79, -19, -16, -19, -16,
+ax_anim 2, 1, 79, -20, -15, -20, -15,
+ax_anim 2, 0, 79, -19, -16, -19, -16,
+ax_anim 2, 0, 79, -20, -15, -20, -15,
+ax_anim 2, 0, 76, -7, -7, -7, -7,
+ax_anim_terminator
+sRaichuAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, -1, 0, 0,
+ax_anim 1, 2, 83, -4, -3, -4, 0,
+ax_anim 1, 0, 83, -10, -5, -10, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sRaichuAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, -1, 0, -1,
+ax_anim 1, 2, 87, -6, 2, -6, 6,
+ax_anim 1, 0, 87, -13, 9, -13, 14,
+ax_anim 2, 0, 87, -20, 23, -20, 23,
+ax_anim 2, 1, 87, -21, 22, -21, 22,
+ax_anim 2, 0, 87, -20, 23, -20, 23,
+ax_anim 2, 0, 87, -21, 22, -21, 22,
+ax_anim 2, 0, 84, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRaichuAnims_4_1:
+ax_anim 1, 0, 88, 0, -2, 0, -1,
+ax_anim 2, 0, 88, 0, -3, 0, -2,
+ax_anim 6, 2, 88, 0, -4, 0, -4,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_4_2:
+ax_anim 1, 0, 90, -2, -4, -2, -2,
+ax_anim 2, 0, 90, -3, -5, -3, -3,
+ax_anim 6, 2, 90, -4, -4, -4, -4,
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_4_3:
+ax_anim 1, 0, 92, -2, -1, -2, 0,
+ax_anim 2, 0, 92, -3, -2, -3, 0,
+ax_anim 6, 2, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 1, 0, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 1, 0, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 1, 0, 1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_4_4:
+ax_anim 1, 0, 94, -2, 1, -2, 2,
+ax_anim 2, 0, 94, -3, 2, -3, 3,
+ax_anim 6, 2, 94, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_4_5:
+ax_anim 1, 0, 96, 0, 2, 0, 2,
+ax_anim 2, 0, 96, 0, 3, 0, 3,
+ax_anim 6, 2, 96, 0, 4, 0, 4,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 2, 1, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_4_6:
+ax_anim 1, 0, 98, 2, 1, 2, 2,
+ax_anim 2, 0, 98, 3, 2, 3, 3,
+ax_anim 6, 2, 98, 4, 4, 4, 4,
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_4_7:
+ax_anim 1, 0, 100, 2, -1, 2, 0,
+ax_anim 2, 0, 100, 3, -2, 3, 0,
+ax_anim 6, 2, 100, 4, 0, 4, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 1, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_4_8:
+ax_anim 1, 0, 102, 2, -4, 2, -2,
+ax_anim 2, 0, 102, 3, -5, 3, -3,
+ax_anim 6, 2, 102, 4, -4, 4, -4,
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_5_1:
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 2, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 1, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_5_2:
+ax_anim 8, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 2, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 1, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_5_3:
+ax_anim 8, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 2, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 1, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_5_4:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 2, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 1, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_5_5:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 1, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_5_6:
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 2, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 1, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_5_7:
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 2, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 1, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_5_8:
+ax_anim 8, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 2, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 1, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sRaichuAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sRaichuAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sRaichuAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sRaichuAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sRaichuAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sRaichuAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sRaichuAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRaichuAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, -3, 0, 0,
+ax_anim 4, 0, 163, 0, -4, 0, 0,
+ax_anim 4, 0, 162, 0, -4, 0, 0,
+ax_anim 4, 0, 164, 0, -4, 0, 0,
+ax_anim 2, 0, 164, 0, -3, 0, 0,
+ax_anim_terminator
+sRaichuAnims_8_2:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -3, 0, 0,
+ax_anim 4, 0, 166, 0, -4, 0, 0,
+ax_anim 4, 0, 165, 0, -4, 0, 0,
+ax_anim 4, 0, 167, 0, -4, 0, 0,
+ax_anim 2, 0, 167, 0, -3, 0, 0,
+ax_anim_terminator
+sRaichuAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, -3, 0, 0,
+ax_anim 4, 0, 169, 0, -4, 0, 0,
+ax_anim 4, 0, 168, 0, -4, 0, 0,
+ax_anim 4, 0, 170, 0, -4, 0, 0,
+ax_anim 2, 0, 170, 0, -3, 0, 0,
+ax_anim_terminator
+sRaichuAnims_8_4:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -3, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim 4, 0, 171, 0, -4, 0, 0,
+ax_anim 4, 0, 173, 0, -4, 0, 0,
+ax_anim 2, 0, 173, 0, -3, 0, 0,
+ax_anim_terminator
+sRaichuAnims_8_5:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, -3, 0, 0,
+ax_anim 4, 0, 175, 0, -4, 0, 0,
+ax_anim 4, 0, 174, 0, -4, 0, 0,
+ax_anim 4, 0, 176, 0, -4, 0, 0,
+ax_anim 2, 0, 176, 0, -3, 0, 0,
+ax_anim_terminator
+sRaichuAnims_8_6:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, -3, 0, 0,
+ax_anim 4, 0, 178, 0, -4, 0, 0,
+ax_anim 4, 0, 177, 0, -4, 0, 0,
+ax_anim 4, 0, 179, 0, -4, 0, 0,
+ax_anim 2, 0, 179, 0, -3, 0, 0,
+ax_anim_terminator
+sRaichuAnims_8_7:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, -3, 0, 0,
+ax_anim 4, 0, 181, 0, -4, 0, 0,
+ax_anim 4, 0, 180, 0, -4, 0, 0,
+ax_anim 4, 0, 182, 0, -4, 0, 0,
+ax_anim 2, 0, 182, 0, -3, 0, 0,
+ax_anim_terminator
+sRaichuAnims_8_8:
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -3, 0, 0,
+ax_anim 4, 0, 184, 0, -4, 0, 0,
+ax_anim 4, 0, 183, 0, -4, 0, 0,
+ax_anim 4, 0, 185, 0, -4, 0, 0,
+ax_anim 2, 0, 185, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 4, 6, 4,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 19, 7, 19,
+ax_anim 3, 0, 190, 0, 24, 0, 24,
+ax_anim 2, 3, 191, -7, 19, -7, 19,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 4, -6, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 21, 11, 21, 11,
+ax_anim 3, 0, 189, 20, 20, 20, 20,
+ax_anim 2, 3, 190, 11, 22, 11, 22,
+ax_anim 2, 0, 191, 2, 14, 2, 14,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -4, 3, -4,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 17, -4, 17, -4,
+ax_anim 3, 0, 188, 20, 1, 20, 1,
+ax_anim 2, 3, 189, 17, 5, 17, 5,
+ax_anim 2, 0, 190, 12, 7, 12, 7,
+ax_anim 1, 0, 191, 4, 3, 4, 3,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -6, -1, -6,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -18, 12, -18,
+ax_anim 3, 0, 187, 19, -17, 19, -17,
+ax_anim 2, 3, 188, 18, -10, 18, -10,
+ax_anim 2, 0, 189, 14, -4, 14, -4,
+ax_anim 1, 0, 190, 7, 1, 7, 1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -6, -4, -6, -4,
+ax_anim 2, 0, 192, -8, -10, -8, -10,
+ax_anim 2, 0, 193, -7, -15, -7, -15,
+ax_anim 3, 0, 186, 0, -16, 0, -16,
+ax_anim 2, 3, 187, 7, -15, 7, -15,
+ax_anim 2, 0, 188, 8, -8, 8, -8,
+ax_anim 1, 0, 189, 6, -4, 6, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -6, 1, -6,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -18, -12, -18,
+ax_anim 3, 0, 193, -19, -17, -19, -17,
+ax_anim 2, 3, 192, -19, -10, -19, -10,
+ax_anim 2, 0, 191, -14, -4, -14, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -4, -3, -4,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -17, -4, -17, -4,
+ax_anim 3, 0, 192, -20, 1, -20, 1,
+ax_anim 2, 3, 191, -17, 5, -17, 5,
+ax_anim 2, 0, 190, -12, 7, -12, 7,
+ax_anim 1, 0, 189, -4, 3, -4, 3,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -21, 11, -21, 11,
+ax_anim 3, 0, 191, -20, 20, -20, 20,
+ax_anim 2, 3, 190, -11, 22, -11, 22,
+ax_anim 2, 0, 189, -2, 14, -2, 14,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaichuAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sRaichuGfx1:
+.incbin "baserom.gba", 0x62B978, 0x200
+sRaichuSprites1:
+ax_sprite sRaichuGfx1, 0x200
+ax_sprite_terminator
+sRaichuGfx2:
+.incbin "baserom.gba", 0x62BB88, 0x200
+sRaichuSprites2:
+ax_sprite sRaichuGfx2, 0x200
+ax_sprite_terminator
+sRaichuGfx3:
+.incbin "baserom.gba", 0x62BD98, 0x200
+sRaichuSprites3:
+ax_sprite sRaichuGfx3, 0x200
+ax_sprite_terminator
+sRaichuGfx4:
+.incbin "baserom.gba", 0x62BFA8, 0x200
+sRaichuSprites4:
+ax_sprite sRaichuGfx4, 0x200
+ax_sprite_terminator
+sRaichuGfx5:
+.incbin "baserom.gba", 0x62C1B8, 0x200
+sRaichuSprites5:
+ax_sprite sRaichuGfx5, 0x200
+ax_sprite_terminator
+sRaichuGfx6:
+.incbin "baserom.gba", 0x62C3C8, 0x200
+sRaichuSprites6:
+ax_sprite sRaichuGfx6, 0x200
+ax_sprite_terminator
+sRaichuGfx7:
+.incbin "baserom.gba", 0x62C5D8, 0x200
+sRaichuSprites7:
+ax_sprite sRaichuGfx7, 0x200
+ax_sprite_terminator
+sRaichuGfx8:
+.incbin "baserom.gba", 0x62C7E8, 0x200
+sRaichuSprites8:
+ax_sprite sRaichuGfx8, 0x200
+ax_sprite_terminator
+sRaichuGfx9:
+.incbin "baserom.gba", 0x62C9F8, 0x200
+sRaichuSprites9:
+ax_sprite sRaichuGfx9, 0x200
+ax_sprite_terminator
+sRaichuGfx10:
+.incbin "baserom.gba", 0x62CC08, 0x200
+sRaichuSprites10:
+ax_sprite sRaichuGfx10, 0x200
+ax_sprite_terminator
+sRaichuGfx11:
+.incbin "baserom.gba", 0x62CE18, 0x200
+sRaichuSprites11:
+ax_sprite sRaichuGfx11, 0x200
+ax_sprite_terminator
+sRaichuGfx12:
+.incbin "baserom.gba", 0x62D028, 0x200
+sRaichuSprites12:
+ax_sprite sRaichuGfx12, 0x200
+ax_sprite_terminator
+sRaichuGfx13:
+.incbin "baserom.gba", 0x62D238, 0x200
+sRaichuSprites13:
+ax_sprite sRaichuGfx13, 0x200
+ax_sprite_terminator
+sRaichuGfx14:
+.incbin "baserom.gba", 0x62D448, 0x200
+sRaichuSprites14:
+ax_sprite sRaichuGfx14, 0x200
+ax_sprite_terminator
+sRaichuGfx15:
+.incbin "baserom.gba", 0x62D658, 0x200
+sRaichuSprites15:
+ax_sprite sRaichuGfx15, 0x200
+ax_sprite_terminator
+sRaichuGfx16:
+.incbin "baserom.gba", 0x62D868, 0x200
+sRaichuSprites16:
+ax_sprite sRaichuGfx16, 0x200
+ax_sprite_terminator
+sRaichuGfx17:
+.incbin "baserom.gba", 0x62DA78, 0x200
+sRaichuSprites17:
+ax_sprite sRaichuGfx17, 0x200
+ax_sprite_terminator
+sRaichuGfx18:
+.incbin "baserom.gba", 0x62DC88, 0x200
+sRaichuSprites18:
+ax_sprite sRaichuGfx18, 0x200
+ax_sprite_terminator
+sRaichuGfx19:
+.incbin "baserom.gba", 0x62DE98, 0x200
+sRaichuSprites19:
+ax_sprite sRaichuGfx19, 0x200
+ax_sprite_terminator
+sRaichuGfx20:
+.incbin "baserom.gba", 0x62E0A8, 0x200
+sRaichuSprites20:
+ax_sprite sRaichuGfx20, 0x200
+ax_sprite_terminator
+sRaichuGfx21:
+.incbin "baserom.gba", 0x62E2B8, 0x200
+sRaichuSprites21:
+ax_sprite sRaichuGfx21, 0x200
+ax_sprite_terminator
+sRaichuGfx22:
+.incbin "baserom.gba", 0x62E4C8, 0x200
+sRaichuSprites22:
+ax_sprite sRaichuGfx22, 0x200
+ax_sprite_terminator
+sRaichuGfx23:
+.incbin "baserom.gba", 0x62E6D8, 0x200
+sRaichuSprites23:
+ax_sprite sRaichuGfx23, 0x200
+ax_sprite_terminator
+sRaichuGfx24:
+.incbin "baserom.gba", 0x62E8E8, 0x200
+sRaichuSprites24:
+ax_sprite sRaichuGfx24, 0x200
+ax_sprite_terminator
+sRaichuGfx25:
+.incbin "baserom.gba", 0x62EAF8, 0x180
+sRaichuGfx25_1:
+.incbin "baserom.gba", 0x62EC78, 0x40
+sRaichuSprites25:
+ax_sprite sRaichuGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx26:
+.incbin "baserom.gba", 0x62ECE0, 0x60
+sRaichuGfx26_1:
+.incbin "baserom.gba", 0x62ED40, 0x100
+sRaichuGfx26_2:
+.incbin "baserom.gba", 0x62EE40, 0x20
+sRaichuSprites26:
+ax_sprite sRaichuGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx26_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sRaichuGfx26_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx27:
+.incbin "baserom.gba", 0x62EE98, 0x180
+sRaichuGfx27_1:
+.incbin "baserom.gba", 0x62F018, 0x20
+sRaichuSprites27:
+ax_sprite sRaichuGfx27, 0x180
+ax_sprite 0, 0x40
+ax_sprite sRaichuGfx27_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx28:
+.incbin "baserom.gba", 0x62F060, 0x60
+sRaichuGfx28_1:
+.incbin "baserom.gba", 0x62F0C0, 0x100
+sRaichuGfx28_2:
+.incbin "baserom.gba", 0x62F1C0, 0x40
+sRaichuSprites28:
+ax_sprite sRaichuGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx28_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx29:
+.incbin "baserom.gba", 0x62F238, 0x180
+sRaichuSprites29:
+ax_sprite sRaichuGfx29, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRaichuGfx30:
+.incbin "baserom.gba", 0x62F3D0, 0x200
+sRaichuSprites30:
+ax_sprite sRaichuGfx30, 0x200
+ax_sprite_terminator
+sRaichuGfx31:
+.incbin "baserom.gba", 0x62F5E0, 0x1C0
+sRaichuSprites31:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx31, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx32:
+.incbin "baserom.gba", 0x62F7C0, 0x60
+sRaichuGfx32_1:
+.incbin "baserom.gba", 0x62F820, 0x100
+sRaichuGfx32_2:
+.incbin "baserom.gba", 0x62F920, 0x60
+sRaichuSprites32:
+ax_sprite sRaichuGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx32_2, 0x60
+ax_sprite_terminator
+sRaichuGfx33:
+.incbin "baserom.gba", 0x62F9B0, 0xE0
+sRaichuGfx33_1:
+.incbin "baserom.gba", 0x62FA90, 0xE0
+sRaichuSprites33:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx33, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx33_1, 0xe0
+ax_sprite_terminator
+sRaichuGfx34:
+.incbin "baserom.gba", 0x62FB98, 0x200
+sRaichuSprites34:
+ax_sprite sRaichuGfx34, 0x200
+ax_sprite_terminator
+sRaichuGfx35:
+.incbin "baserom.gba", 0x62FDA8, 0xE0
+sRaichuGfx35_1:
+.incbin "baserom.gba", 0x62FE88, 0xA0
+sRaichuSprites35:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx35, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx35_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRaichuGfx36:
+.incbin "baserom.gba", 0x62FF58, 0x20
+sRaichuGfx36_1:
+.incbin "baserom.gba", 0x62FF78, 0x20
+sRaichuGfx36_2:
+.incbin "baserom.gba", 0x62FF98, 0x80
+sRaichuSprites36:
+ax_sprite sRaichuGfx36, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx36_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx36_2, 0x80
+ax_sprite_terminator
+sRaichuGfx37:
+.incbin "baserom.gba", 0x630048, 0x40
+sRaichuSprites37:
+ax_sprite sRaichuGfx37, 0x40
+ax_sprite_terminator
+sRaichuGfx38:
+.incbin "baserom.gba", 0x630098, 0x40
+sRaichuSprites38:
+ax_sprite sRaichuGfx38, 0x40
+ax_sprite_terminator
+sRaichuGfx39:
+.incbin "baserom.gba", 0x6300E8, 0x200
+sRaichuSprites39:
+ax_sprite sRaichuGfx39, 0x200
+ax_sprite_terminator
+sRaichuGfx40:
+.incbin "baserom.gba", 0x6302F8, 0x40
+sRaichuSprites40:
+ax_sprite sRaichuGfx40, 0x40
+ax_sprite_terminator
+sRaichuGfx41:
+.incbin "baserom.gba", 0x630348, 0x100
+sRaichuSprites41:
+ax_sprite sRaichuGfx41, 0x100
+ax_sprite_terminator
+sRaichuGfx42:
+.incbin "baserom.gba", 0x630458, 0x60
+sRaichuSprites42:
+ax_sprite sRaichuGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx43:
+.incbin "baserom.gba", 0x6304D0, 0x40
+sRaichuSprites43:
+ax_sprite sRaichuGfx43, 0x40
+ax_sprite_terminator
+sRaichuGfx44:
+.incbin "baserom.gba", 0x630520, 0x80
+sRaichuSprites44:
+ax_sprite sRaichuGfx44, 0x80
+ax_sprite_terminator
+sRaichuGfx45:
+.incbin "baserom.gba", 0x6305B0, 0x40
+sRaichuSprites45:
+ax_sprite sRaichuGfx45, 0x40
+ax_sprite_terminator
+sRaichuGfx46:
+.incbin "baserom.gba", 0x630600, 0x20
+sRaichuSprites46:
+ax_sprite sRaichuGfx46, 0x20
+ax_sprite_terminator
+sRaichuGfx47:
+.incbin "baserom.gba", 0x630630, 0x100
+sRaichuSprites47:
+ax_sprite sRaichuGfx47, 0x100
+ax_sprite_terminator
+sRaichuGfx48:
+.incbin "baserom.gba", 0x630740, 0x80
+sRaichuSprites48:
+ax_sprite sRaichuGfx48, 0x80
+ax_sprite_terminator
+sRaichuGfx49:
+.incbin "baserom.gba", 0x6307D0, 0x80
+sRaichuSprites49:
+ax_sprite sRaichuGfx49, 0x80
+ax_sprite_terminator
+sRaichuGfx50:
+.incbin "baserom.gba", 0x630860, 0xC0
+sRaichuGfx50_1:
+.incbin "baserom.gba", 0x630920, 0x40
+sRaichuGfx50_2:
+.incbin "baserom.gba", 0x630960, 0x60
+sRaichuGfx50_3:
+.incbin "baserom.gba", 0x6309C0, 0x40
+sRaichuSprites50:
+ax_sprite sRaichuGfx50, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx50_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx50_3, 0x40
+ax_sprite_terminator
+sRaichuGfx51:
+.incbin "baserom.gba", 0x630A40, 0x80
+sRaichuSprites51:
+ax_sprite sRaichuGfx51, 0x80
+ax_sprite_terminator
+sRaichuGfx52:
+.incbin "baserom.gba", 0x630AD0, 0x40
+sRaichuSprites52:
+ax_sprite sRaichuGfx52, 0x40
+ax_sprite_terminator
+sRaichuGfx53:
+.incbin "baserom.gba", 0x630B20, 0x1C0
+sRaichuSprites53:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx53, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx54:
+.incbin "baserom.gba", 0x630D00, 0xE0
+sRaichuSprites54:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx54, 0xe0
+ax_sprite_terminator
+sRaichuGfx55:
+.incbin "baserom.gba", 0x630DF8, 0x100
+sRaichuSprites55:
+ax_sprite sRaichuGfx55, 0x100
+ax_sprite_terminator
+sRaichuGfx56:
+.incbin "baserom.gba", 0x630F08, 0xA0
+sRaichuSprites56:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx56, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRaichuGfx57:
+.incbin "baserom.gba", 0x630FC8, 0x20
+sRaichuSprites57:
+ax_sprite sRaichuGfx57, 0x20
+ax_sprite_terminator
+sRaichuGfx58:
+.incbin "baserom.gba", 0x630FF8, 0x60
+sRaichuSprites58:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx58, 0x60
+ax_sprite_terminator
+sRaichuGfx59:
+.incbin "baserom.gba", 0x631070, 0x80
+sRaichuSprites59:
+ax_sprite sRaichuGfx59, 0x80
+ax_sprite_terminator
+sRaichuGfx60:
+.incbin "baserom.gba", 0x631100, 0x80
+sRaichuSprites60:
+ax_sprite sRaichuGfx60, 0x80
+ax_sprite_terminator
+sRaichuGfx61:
+.incbin "baserom.gba", 0x631190, 0x60
+sRaichuSprites61:
+ax_sprite sRaichuGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx62:
+.incbin "baserom.gba", 0x631208, 0xC0
+sRaichuGfx62_1:
+.incbin "baserom.gba", 0x6312C8, 0xE0
+sRaichuGfx62_2:
+.incbin "baserom.gba", 0x6313A8, 0x20
+sRaichuSprites62:
+ax_sprite sRaichuGfx62, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx62_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx62_2, 0x20
+ax_sprite_terminator
+sRaichuGfx63:
+.incbin "baserom.gba", 0x6313F8, 0x80
+sRaichuSprites63:
+ax_sprite sRaichuGfx63, 0x80
+ax_sprite_terminator
+sRaichuGfx64:
+.incbin "baserom.gba", 0x631488, 0x60
+sRaichuGfx64_1:
+.incbin "baserom.gba", 0x6314E8, 0x100
+sRaichuGfx64_2:
+.incbin "baserom.gba", 0x6315E8, 0x60
+sRaichuSprites64:
+ax_sprite sRaichuGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx64_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx64_2, 0x60
+ax_sprite_terminator
+sRaichuGfx65:
+.incbin "baserom.gba", 0x631678, 0xC0
+sRaichuGfx65_1:
+.incbin "baserom.gba", 0x631738, 0x20
+sRaichuSprites65:
+ax_sprite sRaichuGfx65, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx65_1, 0x20
+ax_sprite_terminator
+sRaichuGfx66:
+.incbin "baserom.gba", 0x631778, 0x20
+sRaichuGfx66_1:
+.incbin "baserom.gba", 0x631798, 0xC0
+sRaichuSprites66:
+ax_sprite sRaichuGfx66, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx66_1, 0xc0
+ax_sprite_terminator
+sRaichuGfx67:
+.incbin "baserom.gba", 0x631878, 0x100
+sRaichuSprites67:
+ax_sprite sRaichuGfx67, 0x100
+ax_sprite_terminator
+sRaichuGfx68:
+.incbin "baserom.gba", 0x631988, 0x80
+sRaichuSprites68:
+ax_sprite sRaichuGfx68, 0x80
+ax_sprite_terminator
+sRaichuGfx69:
+.incbin "baserom.gba", 0x631A18, 0x60
+sRaichuSprites69:
+ax_sprite sRaichuGfx69, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaichuGfx70:
+.incbin "baserom.gba", 0x631A90, 0x60
+sRaichuSprites70:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx70, 0x60
+ax_sprite_terminator
+sRaichuGfx71:
+.incbin "baserom.gba", 0x631B08, 0x1E0
+sRaichuSprites71:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx71, 0x1e0
+ax_sprite_terminator
+sRaichuGfx72:
+.incbin "baserom.gba", 0x631D00, 0xE0
+sRaichuSprites72:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx72, 0xe0
+ax_sprite_terminator
+sRaichuGfx73:
+.incbin "baserom.gba", 0x631DF8, 0x100
+sRaichuSprites73:
+ax_sprite sRaichuGfx73, 0x100
+ax_sprite_terminator
+sRaichuGfx74:
+.incbin "baserom.gba", 0x631F08, 0xE0
+sRaichuSprites74:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx74, 0xe0
+ax_sprite_terminator
+sRaichuGfx75:
+.incbin "baserom.gba", 0x632000, 0x20
+sRaichuGfx75_1:
+.incbin "baserom.gba", 0x632020, 0x20
+sRaichuGfx75_2:
+.incbin "baserom.gba", 0x632040, 0x80
+sRaichuSprites75:
+ax_sprite sRaichuGfx75, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx75_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx75_2, 0x80
+ax_sprite_terminator
+sRaichuGfx76:
+.incbin "baserom.gba", 0x6320F0, 0x40
+sRaichuSprites76:
+ax_sprite sRaichuGfx76, 0x40
+ax_sprite_terminator
+sRaichuGfx77:
+.incbin "baserom.gba", 0x632140, 0x60
+sRaichuSprites77:
+ax_sprite 0, 0x20
+ax_sprite sRaichuGfx77, 0x60
+ax_sprite_terminator
+sRaichuGfx78:
+.incbin "baserom.gba", 0x6321B8, 0x40
+sRaichuSprites78:
+ax_sprite sRaichuGfx78, 0x40
+ax_sprite_terminator
+sRaichuGfx79:
+.incbin "baserom.gba", 0x632208, 0x200
+sRaichuSprites79:
+ax_sprite sRaichuGfx79, 0x200
+ax_sprite_terminator
+sRaichuGfx80:
+.incbin "baserom.gba", 0x632418, 0x80
+sRaichuSprites80:
+ax_sprite sRaichuGfx80, 0x80
+ax_sprite_terminator
+sRaichuGfx81:
+.incbin "baserom.gba", 0x6324A8, 0x80
+sRaichuSprites81:
+ax_sprite sRaichuGfx81, 0x80
+ax_sprite_terminator
+sRaichuGfx82:
+.incbin "baserom.gba", 0x632538, 0x80
+sRaichuSprites82:
+ax_sprite sRaichuGfx82, 0x80
+ax_sprite_terminator
+sRaichuGfx83:
+.incbin "baserom.gba", 0x6325C8, 0x80
+sRaichuSprites83:
+ax_sprite sRaichuGfx83, 0x80
+ax_sprite_terminator
+sRaichuGfx84:
+.incbin "baserom.gba", 0x632658, 0x200
+sRaichuSprites84:
+ax_sprite sRaichuGfx84, 0x200
+ax_sprite_terminator
+sRaichuGfx85:
+.incbin "baserom.gba", 0x632868, 0x200
+sRaichuSprites85:
+ax_sprite sRaichuGfx85, 0x200
+ax_sprite_terminator
+sRaichuGfx86:
+.incbin "baserom.gba", 0x632A78, 0x200
+sRaichuSprites86:
+ax_sprite sRaichuGfx86, 0x200
+ax_sprite_terminator
+sRaichuGfx87:
+.incbin "baserom.gba", 0x632C88, 0x200
+sRaichuSprites87:
+ax_sprite sRaichuGfx87, 0x200
+ax_sprite_terminator
+sRaichuGfx88:
+.incbin "baserom.gba", 0x632E98, 0x200
+sRaichuSprites88:
+ax_sprite sRaichuGfx88, 0x200
+ax_sprite_terminator
+sRaichuGfx89:
+.incbin "baserom.gba", 0x6330A8, 0x200
+sRaichuSprites89:
+ax_sprite sRaichuGfx89, 0x200
+ax_sprite_terminator
+sRaichuGfx90:
+.incbin "baserom.gba", 0x6332B8, 0x200
+sRaichuSprites90:
+ax_sprite sRaichuGfx90, 0x200
+ax_sprite_terminator
+sAxPosesRaichu:
+.4byte sRaichuPose1
+.4byte sRaichuPose2
+.4byte sRaichuPose3
+.4byte sRaichuPose4
+.4byte sRaichuPose5
+.4byte sRaichuPose6
+.4byte sRaichuPose7
+.4byte sRaichuPose8
+.4byte sRaichuPose9
+.4byte sRaichuPose10
+.4byte sRaichuPose11
+.4byte sRaichuPose12
+.4byte sRaichuPose13
+.4byte sRaichuPose14
+.4byte sRaichuPose15
+.4byte sRaichuPose16
+.4byte sRaichuPose17
+.4byte sRaichuPose18
+.4byte sRaichuPose19
+.4byte sRaichuPose20
+.4byte sRaichuPose21
+.4byte sRaichuPose22
+.4byte sRaichuPose23
+.4byte sRaichuPose24
+.4byte sRaichuPose25
+.4byte sRaichuPose26
+.4byte sRaichuPose27
+.4byte sRaichuPose28
+.4byte sRaichuPose29
+.4byte sRaichuPose30
+.4byte sRaichuPose31
+.4byte sRaichuPose32
+.4byte sRaichuPose33
+.4byte sRaichuPose34
+.4byte sRaichuPose35
+.4byte sRaichuPose36
+.4byte sRaichuPose37
+.4byte sRaichuPose38
+.4byte sRaichuPose39
+.4byte sRaichuPose40
+.4byte sRaichuPose41
+.4byte sRaichuPose42
+.4byte sRaichuPose43
+.4byte sRaichuPose44
+.4byte sRaichuPose45
+.4byte sRaichuPose46
+.4byte sRaichuPose47
+.4byte sRaichuPose48
+.4byte sRaichuPose49
+.4byte sRaichuPose50
+.4byte sRaichuPose51
+.4byte sRaichuPose52
+.4byte sRaichuPose53
+.4byte sRaichuPose54
+.4byte sRaichuPose55
+.4byte sRaichuPose56
+.4byte sRaichuPose57
+.4byte sRaichuPose58
+.4byte sRaichuPose59
+.4byte sRaichuPose60
+.4byte sRaichuPose61
+.4byte sRaichuPose62
+.4byte sRaichuPose63
+.4byte sRaichuPose64
+.4byte sRaichuPose65
+.4byte sRaichuPose66
+.4byte sRaichuPose67
+.4byte sRaichuPose68
+.4byte sRaichuPose69
+.4byte sRaichuPose70
+.4byte sRaichuPose71
+.4byte sRaichuPose72
+.4byte sRaichuPose73
+.4byte sRaichuPose74
+.4byte sRaichuPose75
+.4byte sRaichuPose76
+.4byte sRaichuPose77
+.4byte sRaichuPose78
+.4byte sRaichuPose79
+.4byte sRaichuPose80
+.4byte sRaichuPose81
+.4byte sRaichuPose82
+.4byte sRaichuPose83
+.4byte sRaichuPose84
+.4byte sRaichuPose85
+.4byte sRaichuPose86
+.4byte sRaichuPose87
+.4byte sRaichuPose88
+.4byte sRaichuPose89
+.4byte sRaichuPose90
+.4byte sRaichuPose91
+.4byte sRaichuPose92
+.4byte sRaichuPose93
+.4byte sRaichuPose94
+.4byte sRaichuPose95
+.4byte sRaichuPose96
+.4byte sRaichuPose97
+.4byte sRaichuPose98
+.4byte sRaichuPose99
+.4byte sRaichuPose100
+.4byte sRaichuPose101
+.4byte sRaichuPose102
+.4byte sRaichuPose103
+.4byte sRaichuPose104
+.4byte sRaichuPose105
+.4byte sRaichuPose106
+.4byte sRaichuPose107
+.4byte sRaichuPose108
+.4byte sRaichuPose109
+.4byte sRaichuPose110
+.4byte sRaichuPose111
+.4byte sRaichuPose112
+.4byte sRaichuPose113
+.4byte sRaichuPose114
+.4byte sRaichuPose115
+.4byte sRaichuPose116
+.4byte sRaichuPose117
+.4byte sRaichuPose118
+.4byte sRaichuPose119
+.4byte sRaichuPose120
+.4byte sRaichuPose121
+.4byte sRaichuPose122
+.4byte sRaichuPose123
+.4byte sRaichuPose124
+.4byte sRaichuPose125
+.4byte sRaichuPose126
+.4byte sRaichuPose127
+.4byte sRaichuPose128
+.4byte sRaichuPose129
+.4byte sRaichuPose130
+.4byte sRaichuPose131
+.4byte sRaichuPose132
+.4byte sRaichuPose133
+.4byte sRaichuPose134
+.4byte sRaichuPose135
+.4byte sRaichuPose136
+.4byte sRaichuPose137
+.4byte sRaichuPose138
+.4byte sRaichuPose139
+.4byte sRaichuPose140
+.4byte sRaichuPose141
+.4byte sRaichuPose142
+.4byte sRaichuPose143
+.4byte sRaichuPose144
+.4byte sRaichuPose145
+.4byte sRaichuPose146
+.4byte sRaichuPose147
+.4byte sRaichuPose148
+.4byte sRaichuPose149
+.4byte sRaichuPose150
+.4byte sRaichuPose151
+.4byte sRaichuPose152
+.4byte sRaichuPose153
+.4byte sRaichuPose154
+.4byte sRaichuPose155
+.4byte sRaichuPose156
+.4byte sRaichuPose157
+.4byte sRaichuPose158
+.4byte sRaichuPose159
+.4byte sRaichuPose160
+.4byte sRaichuPose161
+.4byte sRaichuPose162
+.4byte sRaichuPose163
+.4byte sRaichuPose164
+.4byte sRaichuPose165
+.4byte sRaichuPose166
+.4byte sRaichuPose167
+.4byte sRaichuPose168
+.4byte sRaichuPose169
+.4byte sRaichuPose170
+.4byte sRaichuPose171
+.4byte sRaichuPose172
+.4byte sRaichuPose173
+.4byte sRaichuPose174
+.4byte sRaichuPose175
+.4byte sRaichuPose176
+.4byte sRaichuPose177
+.4byte sRaichuPose178
+.4byte sRaichuPose179
+.4byte sRaichuPose180
+.4byte sRaichuPose181
+.4byte sRaichuPose182
+.4byte sRaichuPose183
+.4byte sRaichuPose184
+.4byte sRaichuPose185
+.4byte sRaichuPose186
+.4byte sRaichuPose187
+.4byte sRaichuPose188
+.4byte sRaichuPose189
+.4byte sRaichuPose190
+.4byte sRaichuPose191
+.4byte sRaichuPose192
+.4byte sRaichuPose193
+.4byte sRaichuPose194
+.4byte sRaichuPose195
+.4byte sRaichuPose196
+.4byte sRaichuPose197
+.4byte sRaichuPose198
+.4byte sRaichuPose199
+.4byte sRaichuPose200
+.4byte sRaichuPose201
+.4byte sRaichuPose202
+.4byte sRaichuPose203
+.4byte sRaichuPose204
+.4byte sRaichuPose205
+.4byte sRaichuPose206
+.4byte sRaichuPose207
+.4byte sRaichuPose208
+.4byte sRaichuPose209
+.4byte sRaichuPose210
+.4byte sRaichuPose211
+.4byte sRaichuPose212
+.4byte sRaichuPose213
+.4byte sRaichuPose214
+.4byte sRaichuPose215
+.4byte sRaichuPose216
+.4byte sRaichuPose217
+.4byte sRaichuPose218
+.4byte sRaichuPose219
+.4byte sRaichuPose220
+.4byte sRaichuPose221
+.4byte sRaichuPose222
+.4byte sRaichuPose223
+.4byte sRaichuPose224
+.4byte sRaichuPose225
+.4byte sRaichuPose226
+.4byte sRaichuPose227
+.4byte sRaichuPose228
+.4byte sRaichuPose229
+.4byte sRaichuPose230
+.4byte sRaichuPose231
+.4byte sRaichuPose232
+.4byte sRaichuPose233
+.4byte sRaichuPose234
+.4byte sRaichuPose235
+.4byte sRaichuPose236
+.4byte sRaichuPose237
+.4byte sRaichuPose238
+.4byte sRaichuPose239
+.4byte sRaichuPose240
+.4byte sRaichuPose241
+.4byte sRaichuPose242
+sAxPositionsRaichu:
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -2,   -9, 	  -8,   -5, 	   3,   -6, 	  -1,   -8
+.2byte    0,   -9, 	  -5,   -6, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+.2byte    3,  -10, 	  -3,   -4, 	   8,   -8, 	   0,   -8
+.2byte    5,  -10, 	   0,   -6, 	   6,   -6, 	   0,   -8
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    6,  -10, 	   1,   -5, 	   5,   -7, 	   0,   -8
+.2byte    6,  -10, 	   5,   -6, 	   0,   -7, 	   0,   -8
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    5,  -11, 	   4,   -5, 	   0,   -8, 	  -2,   -8
+.2byte    3,  -12, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    0,  -13, 	   5,   -6, 	  -6,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   4,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -4,  -11, 	   4,   -9, 	  -8,   -7, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -7, 	  -6,   -5, 	   1,   -8
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -8,  -10, 	   3,   -6, 	  -6,   -5, 	   1,   -9
+.2byte   -7,  -10, 	  -6,   -6, 	  -1,   -5, 	   0,   -9
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -6,  -10, 	  -7,   -5, 	  -1,   -7, 	   0,   -9
+.2byte   -4,  -10, 	  -9,   -8, 	   2,   -4, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -2,   -9, 	  -8,   -5, 	   3,   -6, 	  -1,   -8
+.2byte    0,   -9, 	  -5,   -6, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+.2byte    3,  -10, 	  -3,   -4, 	   8,   -8, 	   0,   -8
+.2byte    5,  -10, 	   0,   -6, 	   6,   -6, 	   0,   -8
+.2byte    7,  -11, 	  12,  -12, 	   1,   -9, 	  -1,  -11
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    6,  -10, 	   1,   -5, 	   5,   -7, 	   0,   -8
+.2byte    6,  -10, 	   5,   -6, 	   0,   -7, 	   0,   -8
+.2byte    9,  -12, 	   8,  -11, 	   7,  -10, 	  -1,  -12
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    5,  -11, 	   4,   -5, 	   0,   -8, 	  -2,   -8
+.2byte    3,  -12, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    6,  -17, 	  -1,  -15, 	   9,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    0,  -13, 	   5,   -6, 	  -6,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   4,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -1,  -20, 	   7,  -17, 	  -9,  -17, 	  -1,  -12
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -4,  -11, 	   4,   -9, 	  -8,   -7, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -7, 	  -6,   -5, 	   1,   -8
+.2byte   -8,  -17, 	  -1,  -15, 	 -11,  -11, 	  -1,  -12
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -8,  -10, 	   3,   -6, 	  -6,   -5, 	   1,   -9
+.2byte   -7,  -10, 	  -6,   -6, 	  -1,   -5, 	   0,   -9
+.2byte  -10,  -12, 	  -9,  -11, 	  -8,  -10, 	   0,  -12
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -6,  -10, 	  -7,   -5, 	  -1,   -7, 	   0,   -9
+.2byte   -4,  -10, 	  -9,   -8, 	   2,   -4, 	   0,   -9
+.2byte   -8,  -11, 	 -13,  -12, 	  -2,   -9, 	   0,  -11
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -2,   -9, 	  -8,   -5, 	   3,   -6, 	  -1,   -8
+.2byte    0,   -9, 	  -5,   -6, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+.2byte    3,  -10, 	  -3,   -4, 	   8,   -8, 	   0,   -8
+.2byte    5,  -10, 	   0,   -6, 	   6,   -6, 	   0,   -8
+.2byte    7,  -11, 	  12,  -12, 	   1,   -9, 	  -1,  -11
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    6,  -10, 	   1,   -5, 	   5,   -7, 	   0,   -8
+.2byte    6,  -10, 	   5,   -6, 	   0,   -7, 	   0,   -8
+.2byte    9,  -12, 	   8,  -11, 	   7,  -10, 	  -1,  -12
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    5,  -11, 	   4,   -5, 	   0,   -8, 	  -2,   -8
+.2byte    3,  -12, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte    6,  -17, 	  -1,  -15, 	   9,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    0,  -13, 	   5,   -6, 	  -6,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   4,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -1,  -20, 	   7,  -17, 	  -9,  -17, 	  -1,  -12
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -4,  -11, 	   4,   -9, 	  -8,   -7, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -7, 	  -6,   -5, 	   1,   -8
+.2byte   -8,  -17, 	  -1,  -15, 	 -11,  -11, 	  -1,  -12
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -8,  -10, 	   3,   -6, 	  -6,   -5, 	   1,   -9
+.2byte   -7,  -10, 	  -6,   -6, 	  -1,   -5, 	   0,   -9
+.2byte  -10,  -12, 	  -9,  -11, 	  -8,  -10, 	   0,  -12
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -6,  -10, 	  -7,   -5, 	  -1,   -7, 	   0,   -9
+.2byte   -4,  -10, 	  -9,   -8, 	   2,   -4, 	   0,   -9
+.2byte   -8,  -11, 	 -13,  -12, 	  -2,   -9, 	   0,  -11
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+.2byte    3,  -16, 	   9,  -15, 	  -4,  -13, 	   0,  -11
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    7,  -19, 	   3,  -17, 	   2,  -15, 	   0,  -11
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -13, 	  -3,  -10
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -22, 	   7,  -14, 	  -9,  -14, 	  -1,   -9
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -13, 	   1,  -10
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -8,  -19, 	  -4,  -17, 	  -3,  -15, 	  -1,  -11
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -4,  -16, 	 -10,  -15, 	   3,  -13, 	  -1,  -11
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte   -1,  -15, 	  -4,  -11, 	   2,  -11, 	  -1,  -10
+.2byte   -1,  -15, 	  -4,  -11, 	   2,  -11, 	  -1,  -10
+.2byte   -1,  -15, 	  -4,  -11, 	   2,  -11, 	  -1,  -10
+.2byte   -1,  -15, 	  -4,  -11, 	   2,  -11, 	  -1,  -10
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+.2byte    3,  -16, 	   9,  -15, 	  -4,  -13, 	   0,  -11
+.2byte    3,  -17, 	   8,  -12, 	  -1,  -10, 	   0,  -11
+.2byte    3,  -17, 	   8,  -12, 	  -1,  -10, 	   0,  -11
+.2byte    3,  -17, 	   8,  -12, 	  -1,  -10, 	   0,  -11
+.2byte    3,  -17, 	   8,  -12, 	  -1,  -10, 	   0,  -11
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    7,  -19, 	   3,  -17, 	   2,  -15, 	   0,  -11
+.2byte    6,  -20, 	   7,  -13, 	   7,  -11, 	   0,  -11
+.2byte    6,  -20, 	   7,  -13, 	   7,  -11, 	   0,  -11
+.2byte    6,  -20, 	   7,  -13, 	   7,  -11, 	   0,  -11
+.2byte    6,  -20, 	   7,  -13, 	   7,  -11, 	   0,  -11
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -13, 	  -3,  -10
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -12, 	  -3,  -10
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -12, 	  -3,  -10
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -12, 	  -3,  -10
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -12, 	  -3,  -10
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -22, 	   7,  -14, 	  -9,  -14, 	  -1,   -9
+.2byte   -1,  -22, 	   7,  -13, 	  -9,  -13, 	  -1,   -8
+.2byte   -1,  -22, 	   7,  -13, 	  -9,  -13, 	  -1,   -8
+.2byte   -1,  -22, 	   7,  -13, 	  -9,  -13, 	  -1,   -8
+.2byte   -1,  -22, 	   7,  -13, 	  -9,  -13, 	  -1,   -8
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -13, 	   1,  -10
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -12, 	   1,  -10
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -12, 	   1,  -10
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -12, 	   1,  -10
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -12, 	   1,  -10
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -8,  -19, 	  -4,  -17, 	  -3,  -15, 	  -1,  -11
+.2byte   -7,  -20, 	  -8,  -13, 	  -8,  -11, 	  -1,  -11
+.2byte   -7,  -20, 	  -8,  -13, 	  -8,  -11, 	  -1,  -11
+.2byte   -7,  -20, 	  -8,  -13, 	  -8,  -11, 	  -1,  -11
+.2byte   -7,  -20, 	  -8,  -13, 	  -8,  -11, 	  -1,  -11
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -4,  -16, 	 -10,  -15, 	   3,  -13, 	  -1,  -11
+.2byte   -4,  -17, 	  -9,  -12, 	   0,  -10, 	  -1,  -11
+.2byte   -4,  -17, 	  -9,  -12, 	   0,  -10, 	  -1,  -11
+.2byte   -4,  -17, 	  -9,  -12, 	   0,  -10, 	  -1,  -11
+.2byte   -4,  -17, 	  -9,  -12, 	   0,  -10, 	  -1,  -11
+.2byte   -3,   -8, 	  -6,   -4, 	   0,   -3, 	   0,   -7
+.2byte   -5,   -7, 	  -6,   -3, 	  -1,   -2, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,  -12, 	   6,  -12, 	  -1,   -9
+.2byte    2,   -7, 	   5,  -14, 	  -4,  -12, 	  -2,   -8
+.2byte    2,   -8, 	  -2,  -16, 	  -3,  -12, 	  -5,   -7
+.2byte    1,   -9, 	  -7,  -13, 	   4,  -11, 	  -3,   -7
+.2byte    0,  -10, 	   8,  -12, 	  -8,  -12, 	   0,   -9
+.2byte   -2,   -9, 	   6,  -13, 	  -5,  -11, 	   2,   -7
+.2byte   -3,   -8, 	   1,  -16, 	   2,  -12, 	   4,   -7
+.2byte   -3,   -7, 	  -6,  -14, 	   3,  -12, 	   1,   -8
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -2,   -9, 	  -8,   -5, 	   3,   -6, 	  -1,   -8
+.2byte    0,   -9, 	  -5,   -6, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+.2byte    3,  -10, 	  -3,   -4, 	   8,   -8, 	   0,   -8
+.2byte    5,  -10, 	   0,   -6, 	   6,   -6, 	   0,   -8
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    6,  -10, 	   1,   -5, 	   5,   -7, 	   0,   -8
+.2byte    6,  -10, 	   5,   -6, 	   0,   -7, 	   0,   -8
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    5,  -11, 	   4,   -5, 	   0,   -8, 	  -2,   -8
+.2byte    3,  -12, 	   6,   -7, 	  -7,   -6, 	  -1,   -8
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    0,  -13, 	   5,   -6, 	  -6,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   4,   -8, 	  -7,   -6, 	  -1,   -9
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -4,  -11, 	   4,   -9, 	  -8,   -7, 	   1,   -8
+.2byte   -4,  -11, 	   6,   -7, 	  -6,   -5, 	   1,   -8
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -8,  -10, 	   3,   -6, 	  -6,   -5, 	   1,   -9
+.2byte   -7,  -10, 	  -6,   -6, 	  -1,   -5, 	   0,   -9
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -6,  -10, 	  -7,   -5, 	  -1,   -7, 	   0,   -9
+.2byte   -4,  -10, 	  -9,   -8, 	   2,   -4, 	   0,   -9
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte   -8,  -11, 	 -13,  -12, 	  -2,   -9, 	   0,  -11
+.2byte  -10,  -12, 	  -9,  -11, 	  -8,  -10, 	   0,  -12
+.2byte   -8,  -17, 	  -1,  -15, 	 -11,  -11, 	  -1,  -12
+.2byte   -1,  -20, 	   7,  -17, 	  -9,  -17, 	  -1,  -12
+.2byte    6,  -17, 	  -1,  -15, 	   9,  -11, 	  -1,  -12
+.2byte    9,  -12, 	   8,  -11, 	   7,  -10, 	  -1,  -12
+.2byte    7,  -11, 	  12,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -1,  -16, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    2,  -16, 	   8,  -15, 	  -5,  -13, 	  -1,  -11
+.2byte    5,  -19, 	   1,  -17, 	   0,  -15, 	  -2,  -11
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -13, 	  -3,  -10
+.2byte   -1,  -22, 	   7,  -14, 	  -9,  -14, 	  -1,   -9
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -13, 	   1,  -10
+.2byte   -6,  -19, 	  -2,  -17, 	  -1,  -15, 	   1,  -11
+.2byte   -3,  -16, 	  -9,  -15, 	   4,  -13, 	   0,  -11
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -11, 	   6,  -11, 	  -1,  -11
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+.2byte    3,  -16, 	   9,  -15, 	  -4,  -13, 	   0,  -11
+.2byte    6,  -11, 	  11,  -12, 	   0,   -9, 	  -2,  -11
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    7,  -19, 	   3,  -17, 	   2,  -15, 	   0,  -11
+.2byte    9,  -12, 	   8,  -11, 	   7,  -10, 	  -1,  -12
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    2,  -16, 	  -3,  -15, 	   6,  -13, 	  -3,  -10
+.2byte    6,  -17, 	  -1,  -15, 	   9,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -22, 	   7,  -14, 	  -9,  -14, 	  -1,   -9
+.2byte   -1,  -20, 	   7,  -17, 	  -9,  -17, 	  -1,  -12
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -4,  -16, 	   1,  -15, 	  -8,  -13, 	   1,  -10
+.2byte   -8,  -17, 	  -1,  -15, 	 -11,  -11, 	  -1,  -12
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -8,  -19, 	  -4,  -17, 	  -3,  -15, 	  -1,  -11
+.2byte  -10,  -12, 	  -9,  -11, 	  -8,  -10, 	   0,  -12
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -4,  -16, 	 -10,  -15, 	   3,  -13, 	  -1,  -11
+.2byte   -7,  -11, 	 -12,  -12, 	  -1,   -9, 	   1,  -11
+.2byte   -1,  -15, 	  -4,  -11, 	   2,  -11, 	  -1,  -10
+.2byte   -3,  -17, 	  -8,  -12, 	   1,  -10, 	   0,  -11
+.2byte   -6,  -20, 	  -7,  -13, 	  -7,  -11, 	   0,  -11
+.2byte   -5,  -16, 	   0,  -15, 	  -9,  -12, 	   0,  -10
+.2byte   -1,  -22, 	   7,  -13, 	  -9,  -13, 	  -1,   -8
+.2byte    3,  -16, 	  -2,  -15, 	   7,  -12, 	  -2,  -10
+.2byte    5,  -20, 	   6,  -13, 	   6,  -11, 	  -1,  -11
+.2byte    2,  -17, 	   7,  -12, 	  -2,  -10, 	  -1,  -11
+.2byte   -1,  -10, 	  -6,   -5, 	   4,   -5, 	  -1,   -9
+.2byte   -5,  -11, 	  -8,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -7,  -11, 	  -5,   -7, 	  -4,   -6, 	   0,  -10
+.2byte   -4,  -13, 	   3,   -9, 	  -7,   -6, 	   0,   -9
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    4,  -12, 	   5,   -7, 	  -3,   -9, 	  -2,   -9
+.2byte    6,  -11, 	   3,   -6, 	   4,   -7, 	  -1,   -9
+.2byte    4,  -11, 	  -2,   -5, 	   7,   -7, 	   0,   -9
+sRaichuAnimTable1:
+.4byte sRaichuAnims_1_1
+.4byte sRaichuAnims_1_2
+.4byte sRaichuAnims_1_3
+.4byte sRaichuAnims_1_4
+.4byte sRaichuAnims_1_5
+.4byte sRaichuAnims_1_6
+.4byte sRaichuAnims_1_7
+.4byte sRaichuAnims_1_8
+sRaichuAnimTable2:
+.4byte sRaichuAnims_2_1
+.4byte sRaichuAnims_2_2
+.4byte sRaichuAnims_2_3
+.4byte sRaichuAnims_2_4
+.4byte sRaichuAnims_2_5
+.4byte sRaichuAnims_2_6
+.4byte sRaichuAnims_2_7
+.4byte sRaichuAnims_2_8
+sRaichuAnimTable3:
+.4byte sRaichuAnims_3_1
+.4byte sRaichuAnims_3_2
+.4byte sRaichuAnims_3_3
+.4byte sRaichuAnims_3_4
+.4byte sRaichuAnims_3_5
+.4byte sRaichuAnims_3_6
+.4byte sRaichuAnims_3_7
+.4byte sRaichuAnims_3_8
+sRaichuAnimTable4:
+.4byte sRaichuAnims_4_1
+.4byte sRaichuAnims_4_2
+.4byte sRaichuAnims_4_3
+.4byte sRaichuAnims_4_4
+.4byte sRaichuAnims_4_5
+.4byte sRaichuAnims_4_6
+.4byte sRaichuAnims_4_7
+.4byte sRaichuAnims_4_8
+sRaichuAnimTable5:
+.4byte sRaichuAnims_5_1
+.4byte sRaichuAnims_5_2
+.4byte sRaichuAnims_5_3
+.4byte sRaichuAnims_5_4
+.4byte sRaichuAnims_5_5
+.4byte sRaichuAnims_5_6
+.4byte sRaichuAnims_5_7
+.4byte sRaichuAnims_5_8
+sRaichuAnimTable6:
+.4byte sRaichuAnims_6_1
+.4byte sRaichuAnims_6_1
+.4byte sRaichuAnims_6_1
+.4byte sRaichuAnims_6_1
+.4byte sRaichuAnims_6_1
+.4byte sRaichuAnims_6_1
+.4byte sRaichuAnims_6_1
+.4byte sRaichuAnims_6_1
+sRaichuAnimTable7:
+.4byte sRaichuAnims_7_1
+.4byte sRaichuAnims_7_2
+.4byte sRaichuAnims_7_3
+.4byte sRaichuAnims_7_4
+.4byte sRaichuAnims_7_5
+.4byte sRaichuAnims_7_6
+.4byte sRaichuAnims_7_7
+.4byte sRaichuAnims_7_8
+sRaichuAnimTable8:
+.4byte sRaichuAnims_8_1
+.4byte sRaichuAnims_8_2
+.4byte sRaichuAnims_8_3
+.4byte sRaichuAnims_8_4
+.4byte sRaichuAnims_8_5
+.4byte sRaichuAnims_8_6
+.4byte sRaichuAnims_8_7
+.4byte sRaichuAnims_8_8
+sRaichuAnimTable9:
+.4byte sRaichuAnims_9_1
+.4byte sRaichuAnims_9_2
+.4byte sRaichuAnims_9_3
+.4byte sRaichuAnims_9_4
+.4byte sRaichuAnims_9_5
+.4byte sRaichuAnims_9_6
+.4byte sRaichuAnims_9_7
+.4byte sRaichuAnims_9_8
+sRaichuAnimTable10:
+.4byte sRaichuAnims_10_1
+.4byte sRaichuAnims_10_2
+.4byte sRaichuAnims_10_3
+.4byte sRaichuAnims_10_4
+.4byte sRaichuAnims_10_5
+.4byte sRaichuAnims_10_6
+.4byte sRaichuAnims_10_7
+.4byte sRaichuAnims_10_8
+sRaichuAnimTable11:
+.4byte sRaichuAnims_11_1
+.4byte sRaichuAnims_11_2
+.4byte sRaichuAnims_11_3
+.4byte sRaichuAnims_11_4
+.4byte sRaichuAnims_11_5
+.4byte sRaichuAnims_11_6
+.4byte sRaichuAnims_11_7
+.4byte sRaichuAnims_11_8
+sRaichuAnimTable12:
+.4byte sRaichuAnims_12_1
+.4byte sRaichuAnims_12_2
+.4byte sRaichuAnims_12_3
+.4byte sRaichuAnims_12_4
+.4byte sRaichuAnims_12_5
+.4byte sRaichuAnims_12_6
+.4byte sRaichuAnims_12_7
+.4byte sRaichuAnims_12_8
+sRaichuAnimTable13:
+.4byte sRaichuAnims_13_1
+.4byte sRaichuAnims_13_2
+.4byte sRaichuAnims_13_3
+.4byte sRaichuAnims_13_4
+.4byte sRaichuAnims_13_5
+.4byte sRaichuAnims_13_6
+.4byte sRaichuAnims_13_7
+.4byte sRaichuAnims_13_8
+sAxAnimationsRaichu:
+.4byte sRaichuAnimTable1
+.4byte sRaichuAnimTable2
+.4byte sRaichuAnimTable3
+.4byte sRaichuAnimTable4
+.4byte sRaichuAnimTable5
+.4byte sRaichuAnimTable6
+.4byte sRaichuAnimTable7
+.4byte sRaichuAnimTable8
+.4byte sRaichuAnimTable9
+.4byte sRaichuAnimTable10
+.4byte sRaichuAnimTable11
+.4byte sRaichuAnimTable12
+.4byte sRaichuAnimTable13
+sAxSpritesRaichu:
+.4byte sRaichuSprites1
+.4byte sRaichuSprites2
+.4byte sRaichuSprites3
+.4byte sRaichuSprites4
+.4byte sRaichuSprites5
+.4byte sRaichuSprites6
+.4byte sRaichuSprites7
+.4byte sRaichuSprites8
+.4byte sRaichuSprites9
+.4byte sRaichuSprites10
+.4byte sRaichuSprites11
+.4byte sRaichuSprites12
+.4byte sRaichuSprites13
+.4byte sRaichuSprites14
+.4byte sRaichuSprites15
+.4byte sRaichuSprites16
+.4byte sRaichuSprites17
+.4byte sRaichuSprites18
+.4byte sRaichuSprites19
+.4byte sRaichuSprites20
+.4byte sRaichuSprites21
+.4byte sRaichuSprites22
+.4byte sRaichuSprites23
+.4byte sRaichuSprites24
+.4byte sRaichuSprites25
+.4byte sRaichuSprites26
+.4byte sRaichuSprites27
+.4byte sRaichuSprites28
+.4byte sRaichuSprites29
+.4byte sRaichuSprites30
+.4byte sRaichuSprites31
+.4byte sRaichuSprites32
+.4byte sRaichuSprites33
+.4byte sRaichuSprites34
+.4byte sRaichuSprites35
+.4byte sRaichuSprites36
+.4byte sRaichuSprites37
+.4byte sRaichuSprites38
+.4byte sRaichuSprites39
+.4byte sRaichuSprites40
+.4byte sRaichuSprites41
+.4byte sRaichuSprites42
+.4byte sRaichuSprites43
+.4byte sRaichuSprites44
+.4byte sRaichuSprites45
+.4byte sRaichuSprites46
+.4byte sRaichuSprites47
+.4byte sRaichuSprites48
+.4byte sRaichuSprites49
+.4byte sRaichuSprites50
+.4byte sRaichuSprites51
+.4byte sRaichuSprites52
+.4byte sRaichuSprites53
+.4byte sRaichuSprites54
+.4byte sRaichuSprites55
+.4byte sRaichuSprites56
+.4byte sRaichuSprites57
+.4byte sRaichuSprites58
+.4byte sRaichuSprites59
+.4byte sRaichuSprites60
+.4byte sRaichuSprites61
+.4byte sRaichuSprites62
+.4byte sRaichuSprites63
+.4byte sRaichuSprites64
+.4byte sRaichuSprites65
+.4byte sRaichuSprites66
+.4byte sRaichuSprites67
+.4byte sRaichuSprites68
+.4byte sRaichuSprites69
+.4byte sRaichuSprites70
+.4byte sRaichuSprites71
+.4byte sRaichuSprites72
+.4byte sRaichuSprites73
+.4byte sRaichuSprites74
+.4byte sRaichuSprites75
+.4byte sRaichuSprites76
+.4byte sRaichuSprites77
+.4byte sRaichuSprites78
+.4byte sRaichuSprites79
+.4byte sRaichuSprites80
+.4byte sRaichuSprites81
+.4byte sRaichuSprites82
+.4byte sRaichuSprites83
+.4byte sRaichuSprites84
+.4byte sRaichuSprites85
+.4byte sRaichuSprites86
+.4byte sRaichuSprites87
+.4byte sRaichuSprites88
+.4byte sRaichuSprites89
+.4byte sRaichuSprites90
+sAxMainRaichu:
+ax_main sAxPosesRaichu, sAxAnimationsRaichu, 13, sAxSpritesRaichu, sAxPositionsRaichu

--- a/data/ax/raikou.inc
+++ b/data/ax/raikou.inc
@@ -1,0 +1,4463 @@
+.global gAxRaikou
+gAxRaikou:
+ax_siro sAxMainRaikou
+sRaikouPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose2:
+ax_pose 1, 0x81e5, 0x80f5, 0x2c00
+ax_pose 2, 0x81e5, 0x4105, 0x2c08
+ax_pose 3, 0x0205, 0x00f7, 0x2c0c
+ax_pose_terminator
+sRaikouPose3:
+ax_pose 4, 0x81e5, 0x80f5, 0x2c00
+ax_pose 5, 0x0205, 0x0103, 0x2c08
+ax_pose 6, 0x81e5, 0x4105, 0x2c09
+ax_pose_terminator
+sRaikouPose4:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose5:
+ax_pose 8, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose6:
+ax_pose 9, 0x41ed, 0x90f1, 0x2c00
+ax_pose 10, 0x0205, 0x1101, 0x2c08
+ax_pose 11, 0x41fd, 0x10ff, 0x2c09
+ax_pose 12, 0x41e5, 0x10f7, 0x2c0b
+ax_pose 13, 0x01e5, 0x10ef, 0x2c0d
+ax_pose_terminator
+sRaikouPose7:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose8:
+ax_pose 15, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose9:
+ax_pose 16, 0x41e4, 0x10f1, 0x2c00
+ax_pose 17, 0x41ec, 0x50f1, 0x2c02
+ax_pose 18, 0x41f4, 0x90f1, 0x2c06
+ax_pose 19, 0x01fb, 0x10e9, 0x2c0e
+ax_pose_terminator
+sRaikouPose10:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose11:
+ax_pose 21, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose12:
+ax_pose 22, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose13:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose14:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose15:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose16:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose17:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose18:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose19:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose20:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose21:
+ax_pose 16, 0x41e4, 0x0100, 0x2c00
+ax_pose 17, 0x41ec, 0x40f0, 0x2c02
+ax_pose 18, 0x41f4, 0x80f0, 0x2c06
+ax_pose 19, 0x01fb, 0x0110, 0x2c0e
+ax_pose_terminator
+sRaikouPose22:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose23:
+ax_pose 8, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose24:
+ax_pose 9, 0x41ed, 0x80f0, 0x2c00
+ax_pose 11, 0x41fd, 0x00f2, 0x2c08
+ax_pose 12, 0x41e5, 0x00fa, 0x2c0a
+ax_pose 10, 0x0205, 0x00f8, 0x2c0c
+ax_pose 13, 0x01e5, 0x010a, 0x2c0d
+ax_pose_terminator
+sRaikouPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose26:
+ax_pose 1, 0x81e5, 0x80f5, 0x2c00
+ax_pose 2, 0x81e5, 0x4105, 0x2c08
+ax_pose 3, 0x0205, 0x00f7, 0x2c0c
+ax_pose_terminator
+sRaikouPose27:
+ax_pose 4, 0x81e5, 0x80f5, 0x2c00
+ax_pose 5, 0x0205, 0x0103, 0x2c08
+ax_pose 6, 0x81e5, 0x4105, 0x2c09
+ax_pose_terminator
+sRaikouPose28:
+ax_pose 26, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose29:
+ax_pose 27, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose30:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose31:
+ax_pose 8, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose32:
+ax_pose 9, 0x41ed, 0x90f1, 0x2c00
+ax_pose 10, 0x0205, 0x1101, 0x2c08
+ax_pose 11, 0x41fd, 0x10ff, 0x2c09
+ax_pose 12, 0x41e5, 0x10f7, 0x2c0b
+ax_pose 13, 0x01e5, 0x10ef, 0x2c0d
+ax_pose_terminator
+sRaikouPose33:
+ax_pose 28, 0x01e4, 0x90ec, 0x2c00
+ax_pose 29, 0x01dc, 0x10fc, 0x2c10
+ax_pose 30, 0x01ec, 0x110c, 0x2c11
+ax_pose 31, 0x81f4, 0x110c, 0x2c12
+ax_pose_terminator
+sRaikouPose34:
+ax_pose 32, 0x01e7, 0x90f3, 0x2c00
+ax_pose_terminator
+sRaikouPose35:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose36:
+ax_pose 15, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose37:
+ax_pose 16, 0x41e4, 0x10f1, 0x2c00
+ax_pose 17, 0x41ec, 0x50f1, 0x2c02
+ax_pose 18, 0x41f4, 0x90f1, 0x2c06
+ax_pose 19, 0x01fb, 0x10e9, 0x2c0e
+ax_pose_terminator
+sRaikouPose38:
+ax_pose 33, 0x01e4, 0x90f5, 0x2c00
+ax_pose 34, 0x81e4, 0x50ed, 0x2c10
+ax_pose 35, 0x01ec, 0x10e5, 0x2c14
+ax_pose_terminator
+sRaikouPose39:
+ax_pose 36, 0x01e6, 0x90f5, 0x2c00
+ax_pose 37, 0x81e6, 0x50ed, 0x2c10
+ax_pose_terminator
+sRaikouPose40:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose41:
+ax_pose 21, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose42:
+ax_pose 22, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose43:
+ax_pose 38, 0x41e5, 0x90f1, 0x2c00
+ax_pose 39, 0x41f5, 0x50f1, 0x2c08
+ax_pose 40, 0x41fd, 0x10f1, 0x2c0c
+ax_pose 41, 0x01fd, 0x10e9, 0x2c0e
+ax_pose 42, 0x01f5, 0x10e9, 0x2c0f
+ax_pose_terminator
+sRaikouPose44:
+ax_pose 43, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sRaikouPose45:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose46:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose47:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose48:
+ax_pose 44, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose49:
+ax_pose 45, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose50:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose51:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose52:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose53:
+ax_pose 38, 0x41e5, 0x80f0, 0x2c00
+ax_pose 39, 0x41f5, 0x40f0, 0x2c08
+ax_pose 40, 0x41fd, 0x0100, 0x2c0c
+ax_pose 41, 0x01fd, 0x0110, 0x2c0e
+ax_pose 42, 0x01f5, 0x0110, 0x2c0f
+ax_pose_terminator
+sRaikouPose54:
+ax_pose 43, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose55:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose56:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose57:
+ax_pose 16, 0x41e4, 0x0100, 0x2c00
+ax_pose 17, 0x41ec, 0x40f0, 0x2c02
+ax_pose 18, 0x41f4, 0x80f0, 0x2c06
+ax_pose 19, 0x01fb, 0x0110, 0x2c0e
+ax_pose_terminator
+sRaikouPose58:
+ax_pose 33, 0x01e4, 0x80ec, 0x2c00
+ax_pose 34, 0x81e4, 0x410c, 0x2c10
+ax_pose 35, 0x01ec, 0x0114, 0x2c14
+ax_pose_terminator
+sRaikouPose59:
+ax_pose 36, 0x01e6, 0x80ec, 0x2c00
+ax_pose 37, 0x81e6, 0x410c, 0x2c10
+ax_pose_terminator
+sRaikouPose60:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose61:
+ax_pose 8, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose62:
+ax_pose 9, 0x41ed, 0x80f0, 0x2c00
+ax_pose 11, 0x41fd, 0x00f2, 0x2c08
+ax_pose 12, 0x41e5, 0x00fa, 0x2c0a
+ax_pose 10, 0x0205, 0x00f8, 0x2c0c
+ax_pose 13, 0x01e5, 0x010a, 0x2c0d
+ax_pose_terminator
+sRaikouPose63:
+ax_pose 28, 0x01e4, 0x80f5, 0x2c00
+ax_pose 29, 0x01dc, 0x00fd, 0x2c10
+ax_pose 30, 0x01ec, 0x00ed, 0x2c11
+ax_pose 31, 0x81f4, 0x00ed, 0x2c12
+ax_pose_terminator
+sRaikouPose64:
+ax_pose 32, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sRaikouPose65:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose66:
+ax_pose 1, 0x81e5, 0x80f5, 0x2c00
+ax_pose 2, 0x81e5, 0x4105, 0x2c08
+ax_pose 3, 0x0205, 0x00f7, 0x2c0c
+ax_pose_terminator
+sRaikouPose67:
+ax_pose 4, 0x81e5, 0x80f5, 0x2c00
+ax_pose 5, 0x0205, 0x0103, 0x2c08
+ax_pose 6, 0x81e5, 0x4105, 0x2c09
+ax_pose_terminator
+sRaikouPose68:
+ax_pose 26, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose69:
+ax_pose 27, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose70:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose71:
+ax_pose 8, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose72:
+ax_pose 9, 0x41ed, 0x90f1, 0x2c00
+ax_pose 10, 0x0205, 0x1101, 0x2c08
+ax_pose 11, 0x41fd, 0x10ff, 0x2c09
+ax_pose 12, 0x41e5, 0x10f7, 0x2c0b
+ax_pose 13, 0x01e5, 0x10ef, 0x2c0d
+ax_pose_terminator
+sRaikouPose73:
+ax_pose 28, 0x01e4, 0x90ec, 0x2c00
+ax_pose 29, 0x01dc, 0x10fc, 0x2c10
+ax_pose 30, 0x01ec, 0x110c, 0x2c11
+ax_pose 31, 0x81f4, 0x110c, 0x2c12
+ax_pose_terminator
+sRaikouPose74:
+ax_pose 32, 0x01e7, 0x90f3, 0x2c00
+ax_pose_terminator
+sRaikouPose75:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose76:
+ax_pose 15, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose77:
+ax_pose 16, 0x41e4, 0x10f1, 0x2c00
+ax_pose 17, 0x41ec, 0x50f1, 0x2c02
+ax_pose 18, 0x41f4, 0x90f1, 0x2c06
+ax_pose 19, 0x01fb, 0x10e9, 0x2c0e
+ax_pose_terminator
+sRaikouPose78:
+ax_pose 33, 0x01e4, 0x90f5, 0x2c00
+ax_pose 34, 0x81e4, 0x50ed, 0x2c10
+ax_pose 35, 0x01ec, 0x10e5, 0x2c14
+ax_pose_terminator
+sRaikouPose79:
+ax_pose 36, 0x01e6, 0x90f5, 0x2c00
+ax_pose 37, 0x81e6, 0x50ed, 0x2c10
+ax_pose_terminator
+sRaikouPose80:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose81:
+ax_pose 21, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose82:
+ax_pose 22, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose83:
+ax_pose 38, 0x41e5, 0x90f1, 0x2c00
+ax_pose 39, 0x41f5, 0x50f1, 0x2c08
+ax_pose 40, 0x41fd, 0x10f1, 0x2c0c
+ax_pose 41, 0x01fd, 0x10e9, 0x2c0e
+ax_pose 42, 0x01f5, 0x10e9, 0x2c0f
+ax_pose_terminator
+sRaikouPose84:
+ax_pose 43, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sRaikouPose85:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose86:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose87:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose88:
+ax_pose 44, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose89:
+ax_pose 45, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose90:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose91:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose92:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose93:
+ax_pose 38, 0x41e5, 0x80f0, 0x2c00
+ax_pose 39, 0x41f5, 0x40f0, 0x2c08
+ax_pose 40, 0x41fd, 0x0100, 0x2c0c
+ax_pose 41, 0x01fd, 0x0110, 0x2c0e
+ax_pose 42, 0x01f5, 0x0110, 0x2c0f
+ax_pose_terminator
+sRaikouPose94:
+ax_pose 43, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose95:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose96:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose97:
+ax_pose 16, 0x41e4, 0x0100, 0x2c00
+ax_pose 17, 0x41ec, 0x40f0, 0x2c02
+ax_pose 18, 0x41f4, 0x80f0, 0x2c06
+ax_pose 19, 0x01fb, 0x0110, 0x2c0e
+ax_pose_terminator
+sRaikouPose98:
+ax_pose 33, 0x01e4, 0x80ec, 0x2c00
+ax_pose 34, 0x81e4, 0x410c, 0x2c10
+ax_pose 35, 0x01ec, 0x0114, 0x2c14
+ax_pose_terminator
+sRaikouPose99:
+ax_pose 36, 0x01e6, 0x80ec, 0x2c00
+ax_pose 37, 0x81e6, 0x410c, 0x2c10
+ax_pose_terminator
+sRaikouPose100:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose101:
+ax_pose 8, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose102:
+ax_pose 9, 0x41ed, 0x80f0, 0x2c00
+ax_pose 11, 0x41fd, 0x00f2, 0x2c08
+ax_pose 12, 0x41e5, 0x00fa, 0x2c0a
+ax_pose 10, 0x0205, 0x00f8, 0x2c0c
+ax_pose 13, 0x01e5, 0x010a, 0x2c0d
+ax_pose_terminator
+sRaikouPose103:
+ax_pose 28, 0x01e4, 0x80f5, 0x2c00
+ax_pose 29, 0x01dc, 0x00fd, 0x2c10
+ax_pose 30, 0x01ec, 0x00ed, 0x2c11
+ax_pose 31, 0x81f4, 0x00ed, 0x2c12
+ax_pose_terminator
+sRaikouPose104:
+ax_pose 32, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sRaikouPose105:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose106:
+ax_pose 46, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose107:
+ax_pose 47, 0x81e4, 0x80f5, 0x2c00
+ax_pose 48, 0x81e4, 0x4105, 0x2c08
+ax_pose 49, 0x0204, 0x00fd, 0x2c0c
+ax_pose 50, 0x0204, 0x0105, 0x2c0d
+ax_pose_terminator
+sRaikouPose108:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose109:
+ax_pose 51, 0x81e4, 0x90f1, 0x2c00
+ax_pose 52, 0x81e4, 0x5101, 0x2c08
+ax_pose 53, 0x0204, 0x10fc, 0x2c0c
+ax_pose 54, 0x01ec, 0x1109, 0x2c0d
+ax_pose 55, 0x81f4, 0x1109, 0x2c0e
+ax_pose_terminator
+sRaikouPose110:
+ax_pose 56, 0x81e6, 0x90f2, 0x2c00
+ax_pose 57, 0x81e6, 0x5102, 0x2c08
+ax_pose 58, 0x01e9, 0x10ea, 0x2c0c
+ax_pose 59, 0x01ee, 0x110a, 0x2c0d
+ax_pose 60, 0x81f6, 0x110a, 0x2c0e
+ax_pose_terminator
+sRaikouPose111:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose112:
+ax_pose 61, 0x41e4, 0x90ef, 0x2c00
+ax_pose 62, 0x41f4, 0x50ef, 0x2c08
+ax_pose 63, 0x01fc, 0x1103, 0x2c0c
+ax_pose 64, 0x01ec, 0x10e7, 0x2c0d
+ax_pose 65, 0x41fc, 0x10f3, 0x2c0e
+ax_pose_terminator
+sRaikouPose113:
+ax_pose 66, 0x41ec, 0x50f3, 0x2c00
+ax_pose 67, 0x41f4, 0x90f3, 0x2c04
+ax_pose 68, 0x41f4, 0x10e3, 0x2c0c
+ax_pose 69, 0x01fc, 0x10eb, 0x2c0e
+ax_pose 70, 0x01e4, 0x10f7, 0x2c0f
+ax_pose_terminator
+sRaikouPose114:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose115:
+ax_pose 71, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sRaikouPose116:
+ax_pose 72, 0x41e9, 0x90ef, 0x2c00
+ax_pose 73, 0x41f9, 0x50ef, 0x2c08
+ax_pose 74, 0x4201, 0x10f7, 0x2c0c
+ax_pose 75, 0x01fc, 0x10e7, 0x2c0e
+ax_pose_terminator
+sRaikouPose117:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose118:
+ax_pose 76, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose119:
+ax_pose 77, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose120:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose121:
+ax_pose 71, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sRaikouPose122:
+ax_pose 72, 0x41e9, 0x80f2, 0x2c00
+ax_pose 73, 0x41f9, 0x40f2, 0x2c08
+ax_pose 74, 0x4201, 0x00fa, 0x2c0c
+ax_pose 75, 0x01fc, 0x0112, 0x2c0e
+ax_pose_terminator
+sRaikouPose123:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose124:
+ax_pose 61, 0x41e4, 0x80f2, 0x2c00
+ax_pose 62, 0x41f4, 0x40f2, 0x2c08
+ax_pose 63, 0x01fc, 0x00f6, 0x2c0c
+ax_pose 64, 0x01ec, 0x0112, 0x2c0d
+ax_pose 65, 0x41fc, 0x00fe, 0x2c0e
+ax_pose_terminator
+sRaikouPose125:
+ax_pose 66, 0x41ec, 0x40ee, 0x2c00
+ax_pose 67, 0x41f4, 0x80ee, 0x2c04
+ax_pose 68, 0x41f4, 0x010e, 0x2c0c
+ax_pose 69, 0x01fc, 0x010e, 0x2c0e
+ax_pose 70, 0x01e4, 0x0102, 0x2c0f
+ax_pose_terminator
+sRaikouPose126:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose127:
+ax_pose 51, 0x81e4, 0x8100, 0x2c00
+ax_pose 52, 0x81e4, 0x40f8, 0x2c08
+ax_pose 53, 0x0204, 0x00fd, 0x2c0c
+ax_pose 54, 0x01ec, 0x00f0, 0x2c0d
+ax_pose 55, 0x81f4, 0x00f0, 0x2c0e
+ax_pose_terminator
+sRaikouPose128:
+ax_pose 56, 0x81e6, 0x80ff, 0x2c00
+ax_pose 57, 0x81e6, 0x40f7, 0x2c08
+ax_pose 58, 0x01e9, 0x010f, 0x2c0c
+ax_pose 59, 0x01ee, 0x00ef, 0x2c0d
+ax_pose 60, 0x81f6, 0x00ef, 0x2c0e
+ax_pose_terminator
+sRaikouPose129:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose130:
+ax_pose 46, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose131:
+ax_pose 78, 0x41d3, 0x80ea, 0x2c00
+ax_pose 79, 0x01d3, 0x410a, 0x2c08
+ax_pose 80, 0x01db, 0x011a, 0x2c0c
+ax_pose 81, 0x41e3, 0x40e2, 0x2c0d
+ax_pose 82, 0x41e3, 0x4102, 0x2c11
+ax_pose 83, 0x81eb, 0x80e2, 0x2c15
+ax_pose 84, 0x81fb, 0x00f2, 0x2c1d
+ax_pose 85, 0x0203, 0x0102, 0x2c1f
+ax_pose 86, 0x81eb, 0x810a, 0x2c20
+ax_pose 87, 0x81eb, 0x011a, 0x2c28
+ax_pose 88, 0x01e6, 0x80f1, 0x2c2a
+ax_pose_terminator
+sRaikouPose132:
+ax_pose 89, 0x41db, 0x80f2, 0x2c00
+ax_pose 90, 0x81e3, 0x40ea, 0x2c08
+ax_pose 91, 0x4203, 0x00ea, 0x2c0c
+ax_pose 92, 0x01eb, 0x00f2, 0x2c0e
+ax_pose 93, 0x81eb, 0x810a, 0x2c0f
+ax_pose 94, 0x01e6, 0x80f1, 0x2c17
+ax_pose_terminator
+sRaikouPose133:
+ax_pose 88, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose134:
+ax_pose 94, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose135:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose136:
+ax_pose 51, 0x81e4, 0x90f1, 0x2c00
+ax_pose 52, 0x81e4, 0x5101, 0x2c08
+ax_pose 53, 0x0204, 0x10fc, 0x2c0c
+ax_pose 54, 0x01ec, 0x1109, 0x2c0d
+ax_pose 55, 0x81f4, 0x1109, 0x2c0e
+ax_pose_terminator
+sRaikouPose137:
+ax_pose 95, 0x01d6, 0x5104, 0x2c00
+ax_pose 96, 0x81d6, 0x10fc, 0x2c04
+ax_pose 97, 0x01de, 0x1114, 0x2c06
+ax_pose 98, 0x81e6, 0x910c, 0x2c07
+ax_pose 99, 0x0206, 0x110c, 0x2c0f
+ax_pose 100, 0x41fe, 0x90e4, 0x2c10
+ax_pose 101, 0x81de, 0x90e4, 0x2c18
+ax_pose 102, 0x81de, 0x10f4, 0x2c20
+ax_pose 103, 0x81e6, 0x90f1, 0x2c22
+ax_pose 104, 0x81e6, 0x5101, 0x2c2a
+ax_pose 105, 0x01ee, 0x10e9, 0x2c2e
+ax_pose 106, 0x01ee, 0x1109, 0x2c2f
+ax_pose 107, 0x81f6, 0x1109, 0x2c30
+ax_pose_terminator
+sRaikouPose138:
+ax_pose 108, 0x81e8, 0x510e, 0x2c00
+ax_pose 109, 0x01e8, 0x1106, 0x2c04
+ax_pose 110, 0x41e0, 0x50ee, 0x2c05
+ax_pose 111, 0x01e8, 0x10f6, 0x2c09
+ax_pose 112, 0x81e8, 0x50ee, 0x2c0a
+ax_pose 113, 0x0200, 0x50f6, 0x2c0e
+ax_pose 114, 0x81e6, 0x90f1, 0x2c12
+ax_pose 115, 0x81e6, 0x5101, 0x2c1a
+ax_pose 116, 0x01ee, 0x10e9, 0x2c1e
+ax_pose 117, 0x01ee, 0x1109, 0x2c1f
+ax_pose 118, 0x81f6, 0x1109, 0x2c20
+ax_pose_terminator
+sRaikouPose139:
+ax_pose 103, 0x81e6, 0x90f1, 0x2c00
+ax_pose 104, 0x81e6, 0x5101, 0x2c08
+ax_pose 105, 0x01ee, 0x10e9, 0x2c0c
+ax_pose 106, 0x01ee, 0x1109, 0x2c0d
+ax_pose 107, 0x81f6, 0x1109, 0x2c0e
+ax_pose_terminator
+sRaikouPose140:
+ax_pose 114, 0x81e6, 0x90f1, 0x2c00
+ax_pose 115, 0x81e6, 0x5101, 0x2c08
+ax_pose 116, 0x01ee, 0x10e9, 0x2c0c
+ax_pose 117, 0x01ee, 0x1109, 0x2c0d
+ax_pose 118, 0x81f6, 0x1109, 0x2c0e
+ax_pose_terminator
+sRaikouPose141:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose142:
+ax_pose 61, 0x41e4, 0x90ef, 0x2c00
+ax_pose 62, 0x41f4, 0x50ef, 0x2c08
+ax_pose 63, 0x01fc, 0x1103, 0x2c0c
+ax_pose 64, 0x01ec, 0x10e7, 0x2c0d
+ax_pose 65, 0x41fc, 0x10f3, 0x2c0e
+ax_pose_terminator
+sRaikouPose143:
+ax_pose 78, 0x41d5, 0x80ea, 0x2c00
+ax_pose 79, 0x01d5, 0x410a, 0x2c08
+ax_pose 80, 0x01dd, 0x011a, 0x2c0c
+ax_pose 81, 0x41e5, 0x40e2, 0x2c0d
+ax_pose 82, 0x41e5, 0x4102, 0x2c11
+ax_pose 83, 0x81ed, 0x80e2, 0x2c15
+ax_pose 84, 0x81fd, 0x00f2, 0x2c1d
+ax_pose 85, 0x0205, 0x0102, 0x2c1f
+ax_pose 86, 0x81ed, 0x810a, 0x2c20
+ax_pose 87, 0x81ed, 0x011a, 0x2c28
+ax_pose 119, 0x81e6, 0x9101, 0x2c2a
+ax_pose 120, 0x81e6, 0x50f9, 0x2c32
+ax_pose 121, 0x01ee, 0x10f1, 0x2c36
+ax_pose 122, 0x81f6, 0x10f1, 0x2c37
+ax_pose 123, 0x01f7, 0x10e9, 0x2c39
+ax_pose_terminator
+sRaikouPose144:
+ax_pose 89, 0x41dd, 0x80f2, 0x2c00
+ax_pose 90, 0x81e5, 0x40ea, 0x2c08
+ax_pose 91, 0x4205, 0x00ea, 0x2c0c
+ax_pose 92, 0x01ed, 0x00f2, 0x2c0e
+ax_pose 93, 0x81ed, 0x810a, 0x2c0f
+ax_pose 124, 0x81e6, 0x9101, 0x2c17
+ax_pose 125, 0x81e6, 0x50f9, 0x2c1f
+ax_pose 126, 0x01ee, 0x10f1, 0x2c23
+ax_pose 127, 0x81f6, 0x10f1, 0x2c24
+ax_pose 128, 0x01f7, 0x10e9, 0x2c26
+ax_pose_terminator
+sRaikouPose145:
+ax_pose 119, 0x81e6, 0x9101, 0x2c00
+ax_pose 120, 0x81e6, 0x50f9, 0x2c08
+ax_pose 121, 0x01ee, 0x10f1, 0x2c0c
+ax_pose 122, 0x81f6, 0x10f1, 0x2c0d
+ax_pose 123, 0x01f7, 0x10e9, 0x2c0f
+ax_pose_terminator
+sRaikouPose146:
+ax_pose 124, 0x81e6, 0x9101, 0x2c00
+ax_pose 125, 0x81e6, 0x50f9, 0x2c08
+ax_pose 126, 0x01ee, 0x10f1, 0x2c0c
+ax_pose 127, 0x81f6, 0x10f1, 0x2c0d
+ax_pose 128, 0x01f7, 0x10e9, 0x2c0f
+ax_pose_terminator
+sRaikouPose147:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose148:
+ax_pose 71, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sRaikouPose149:
+ax_pose 95, 0x01d6, 0x40ef, 0x2c00
+ax_pose 96, 0x81d6, 0x00ff, 0x2c04
+ax_pose 97, 0x01de, 0x00e7, 0x2c06
+ax_pose 98, 0x81e6, 0x80e7, 0x2c07
+ax_pose 99, 0x0206, 0x00ef, 0x2c0f
+ax_pose 100, 0x41fe, 0x80ff, 0x2c10
+ax_pose 101, 0x81de, 0x810f, 0x2c18
+ax_pose 102, 0x81de, 0x0107, 0x2c20
+ax_pose 129, 0x01e7, 0x90f1, 0x2c22
+ax_pose_terminator
+sRaikouPose150:
+ax_pose 108, 0x81e8, 0x40ed, 0x2c00
+ax_pose 109, 0x01e8, 0x00f5, 0x2c04
+ax_pose 110, 0x41e0, 0x40f5, 0x2c05
+ax_pose 111, 0x01e8, 0x0105, 0x2c09
+ax_pose 112, 0x81e8, 0x410d, 0x2c0a
+ax_pose 113, 0x0200, 0x40fd, 0x2c0e
+ax_pose 130, 0x01e7, 0x90f1, 0x2c12
+ax_pose_terminator
+sRaikouPose151:
+ax_pose 129, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose152:
+ax_pose 130, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose153:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose154:
+ax_pose 76, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose155:
+ax_pose 78, 0x41d3, 0x80ea, 0x2c00
+ax_pose 79, 0x01d3, 0x410a, 0x2c08
+ax_pose 80, 0x01db, 0x011a, 0x2c0c
+ax_pose 81, 0x41e3, 0x40e2, 0x2c0d
+ax_pose 82, 0x41e3, 0x4102, 0x2c11
+ax_pose 83, 0x81eb, 0x80e2, 0x2c15
+ax_pose 84, 0x81fb, 0x00f2, 0x2c1d
+ax_pose 85, 0x0203, 0x0102, 0x2c1f
+ax_pose 86, 0x81eb, 0x810a, 0x2c20
+ax_pose 87, 0x81eb, 0x011a, 0x2c28
+ax_pose 131, 0x01e8, 0x80f1, 0x2c2a
+ax_pose_terminator
+sRaikouPose156:
+ax_pose 89, 0x41db, 0x80f2, 0x2c00
+ax_pose 90, 0x81e3, 0x40ea, 0x2c08
+ax_pose 91, 0x4203, 0x00ea, 0x2c0c
+ax_pose 92, 0x01eb, 0x00f2, 0x2c0e
+ax_pose 93, 0x81eb, 0x810a, 0x2c0f
+ax_pose 132, 0x01e8, 0x80f1, 0x2c17
+ax_pose_terminator
+sRaikouPose157:
+ax_pose 131, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose158:
+ax_pose 132, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose159:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose160:
+ax_pose 71, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sRaikouPose161:
+ax_pose 95, 0x01d7, 0x5102, 0x2c00
+ax_pose 96, 0x81d7, 0x10fa, 0x2c04
+ax_pose 97, 0x01df, 0x1112, 0x2c06
+ax_pose 98, 0x81e7, 0x910a, 0x2c07
+ax_pose 99, 0x0207, 0x110a, 0x2c0f
+ax_pose 100, 0x41ff, 0x90e2, 0x2c10
+ax_pose 101, 0x81df, 0x90e2, 0x2c18
+ax_pose 102, 0x81df, 0x10f2, 0x2c20
+ax_pose 129, 0x01e7, 0x80f0, 0x2c22
+ax_pose_terminator
+sRaikouPose162:
+ax_pose 108, 0x81e9, 0x510c, 0x2c00
+ax_pose 109, 0x01e9, 0x1104, 0x2c04
+ax_pose 110, 0x41e1, 0x50ec, 0x2c05
+ax_pose 111, 0x01e9, 0x10f4, 0x2c09
+ax_pose 112, 0x81e9, 0x50ec, 0x2c0a
+ax_pose 113, 0x0201, 0x50f4, 0x2c0e
+ax_pose 130, 0x01e7, 0x80f0, 0x2c12
+ax_pose_terminator
+sRaikouPose163:
+ax_pose 129, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose164:
+ax_pose 130, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose165:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose166:
+ax_pose 61, 0x41e4, 0x80f2, 0x2c00
+ax_pose 62, 0x41f4, 0x40f2, 0x2c08
+ax_pose 63, 0x01fc, 0x00f6, 0x2c0c
+ax_pose 64, 0x01ec, 0x0112, 0x2c0d
+ax_pose 65, 0x41fc, 0x00fe, 0x2c0e
+ax_pose_terminator
+sRaikouPose167:
+ax_pose 78, 0x41d5, 0x80ea, 0x2c00
+ax_pose 79, 0x01d5, 0x410a, 0x2c08
+ax_pose 80, 0x01dd, 0x011a, 0x2c0c
+ax_pose 81, 0x41e5, 0x40e2, 0x2c0d
+ax_pose 82, 0x41e5, 0x4102, 0x2c11
+ax_pose 83, 0x81ed, 0x80e2, 0x2c15
+ax_pose 84, 0x81fd, 0x00f2, 0x2c1d
+ax_pose 85, 0x0205, 0x0102, 0x2c1f
+ax_pose 86, 0x81ed, 0x810a, 0x2c20
+ax_pose 87, 0x81ed, 0x011a, 0x2c28
+ax_pose 119, 0x81e6, 0x80f0, 0x2c2a
+ax_pose 120, 0x81e6, 0x4100, 0x2c32
+ax_pose 121, 0x01ee, 0x0108, 0x2c36
+ax_pose 122, 0x81f6, 0x0108, 0x2c37
+ax_pose 123, 0x01f7, 0x0110, 0x2c39
+ax_pose_terminator
+sRaikouPose168:
+ax_pose 89, 0x41dd, 0x80f2, 0x2c00
+ax_pose 90, 0x81e5, 0x40ea, 0x2c08
+ax_pose 91, 0x4205, 0x00ea, 0x2c0c
+ax_pose 92, 0x01ed, 0x00f2, 0x2c0e
+ax_pose 93, 0x81ed, 0x810a, 0x2c0f
+ax_pose 124, 0x81e6, 0x80f0, 0x2c17
+ax_pose 125, 0x81e6, 0x4100, 0x2c1f
+ax_pose 126, 0x01ee, 0x0108, 0x2c23
+ax_pose 127, 0x81f6, 0x0108, 0x2c24
+ax_pose 128, 0x01f7, 0x0110, 0x2c26
+ax_pose_terminator
+sRaikouPose169:
+ax_pose 119, 0x81e6, 0x80f0, 0x2c00
+ax_pose 120, 0x81e6, 0x4100, 0x2c08
+ax_pose 121, 0x01ee, 0x0108, 0x2c0c
+ax_pose 122, 0x81f6, 0x0108, 0x2c0d
+ax_pose 123, 0x01f7, 0x0110, 0x2c0f
+ax_pose_terminator
+sRaikouPose170:
+ax_pose 124, 0x81e6, 0x80f0, 0x2c00
+ax_pose 125, 0x81e6, 0x4100, 0x2c08
+ax_pose 126, 0x01ee, 0x0108, 0x2c0c
+ax_pose 127, 0x81f6, 0x0108, 0x2c0d
+ax_pose 128, 0x01f7, 0x0110, 0x2c0f
+ax_pose_terminator
+sRaikouPose171:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose172:
+ax_pose 51, 0x81e4, 0x8100, 0x2c00
+ax_pose 52, 0x81e4, 0x40f8, 0x2c08
+ax_pose 53, 0x0204, 0x00fd, 0x2c0c
+ax_pose 54, 0x01ec, 0x00f0, 0x2c0d
+ax_pose 55, 0x81f4, 0x00f0, 0x2c0e
+ax_pose_terminator
+sRaikouPose173:
+ax_pose 95, 0x01d6, 0x40ed, 0x2c00
+ax_pose 96, 0x81d6, 0x00fd, 0x2c04
+ax_pose 97, 0x01de, 0x00e5, 0x2c06
+ax_pose 98, 0x81e6, 0x80e5, 0x2c07
+ax_pose 99, 0x0206, 0x00ed, 0x2c0f
+ax_pose 100, 0x41fe, 0x80fd, 0x2c10
+ax_pose 101, 0x81de, 0x810d, 0x2c18
+ax_pose 102, 0x81de, 0x0105, 0x2c20
+ax_pose 103, 0x81e6, 0x8100, 0x2c22
+ax_pose 104, 0x81e6, 0x40f8, 0x2c2a
+ax_pose 105, 0x01ee, 0x0110, 0x2c2e
+ax_pose 106, 0x01ee, 0x00f0, 0x2c2f
+ax_pose 107, 0x81f6, 0x00f0, 0x2c30
+ax_pose_terminator
+sRaikouPose174:
+ax_pose 108, 0x81e8, 0x40eb, 0x2c00
+ax_pose 109, 0x01e8, 0x00f3, 0x2c04
+ax_pose 110, 0x41e0, 0x40f3, 0x2c05
+ax_pose 111, 0x01e8, 0x0103, 0x2c09
+ax_pose 112, 0x81e8, 0x410b, 0x2c0a
+ax_pose 113, 0x0200, 0x40fb, 0x2c0e
+ax_pose 114, 0x81e6, 0x8100, 0x2c12
+ax_pose 115, 0x81e6, 0x40f8, 0x2c1a
+ax_pose 116, 0x01ee, 0x0110, 0x2c1e
+ax_pose 117, 0x01ee, 0x00f0, 0x2c1f
+ax_pose 118, 0x81f6, 0x00f0, 0x2c20
+ax_pose_terminator
+sRaikouPose175:
+ax_pose 103, 0x81e6, 0x8100, 0x2c00
+ax_pose 104, 0x81e6, 0x40f8, 0x2c08
+ax_pose 105, 0x01ee, 0x0110, 0x2c0c
+ax_pose 106, 0x01ee, 0x00f0, 0x2c0d
+ax_pose 107, 0x81f6, 0x00f0, 0x2c0e
+ax_pose_terminator
+sRaikouPose176:
+ax_pose 114, 0x81e6, 0x8100, 0x2c00
+ax_pose 115, 0x81e6, 0x40f8, 0x2c08
+ax_pose 116, 0x01ee, 0x0110, 0x2c0c
+ax_pose 117, 0x01ee, 0x00f0, 0x2c0d
+ax_pose 118, 0x81f6, 0x00f0, 0x2c0e
+ax_pose_terminator
+sRaikouPose177:
+ax_pose 133, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose178:
+ax_pose 134, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose179:
+ax_pose 135, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose180:
+ax_pose 136, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose181:
+ax_pose 137, 0x01e4, 0x90f2, 0x2c00
+ax_pose_terminator
+sRaikouPose182:
+ax_pose 138, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sRaikouPose183:
+ax_pose 139, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose184:
+ax_pose 138, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose185:
+ax_pose 137, 0x01e4, 0x80ee, 0x2c00
+ax_pose_terminator
+sRaikouPose186:
+ax_pose 136, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sRaikouPose187:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose188:
+ax_pose 46, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose189:
+ax_pose 47, 0x81e4, 0x80f5, 0x2c00
+ax_pose 48, 0x81e4, 0x4105, 0x2c08
+ax_pose 49, 0x0204, 0x00fd, 0x2c0c
+ax_pose 50, 0x0204, 0x0105, 0x2c0d
+ax_pose_terminator
+sRaikouPose190:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose191:
+ax_pose 51, 0x81e4, 0x90f1, 0x2c00
+ax_pose 52, 0x81e4, 0x5101, 0x2c08
+ax_pose 53, 0x0204, 0x10fc, 0x2c0c
+ax_pose 54, 0x01ec, 0x1109, 0x2c0d
+ax_pose 55, 0x81f4, 0x1109, 0x2c0e
+ax_pose_terminator
+sRaikouPose192:
+ax_pose 56, 0x81e6, 0x90f2, 0x2c00
+ax_pose 57, 0x81e6, 0x5102, 0x2c08
+ax_pose 58, 0x01e9, 0x10ea, 0x2c0c
+ax_pose 59, 0x01ee, 0x110a, 0x2c0d
+ax_pose 60, 0x81f6, 0x110a, 0x2c0e
+ax_pose_terminator
+sRaikouPose193:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose194:
+ax_pose 61, 0x41e4, 0x90ef, 0x2c00
+ax_pose 62, 0x41f4, 0x50ef, 0x2c08
+ax_pose 63, 0x01fc, 0x1103, 0x2c0c
+ax_pose 64, 0x01ec, 0x10e7, 0x2c0d
+ax_pose 65, 0x41fc, 0x10f3, 0x2c0e
+ax_pose_terminator
+sRaikouPose195:
+ax_pose 66, 0x41ec, 0x50f3, 0x2c00
+ax_pose 67, 0x41f4, 0x90f3, 0x2c04
+ax_pose 68, 0x41f4, 0x10e3, 0x2c0c
+ax_pose 69, 0x01fc, 0x10eb, 0x2c0e
+ax_pose 70, 0x01e4, 0x10f7, 0x2c0f
+ax_pose_terminator
+sRaikouPose196:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose197:
+ax_pose 71, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sRaikouPose198:
+ax_pose 72, 0x41e9, 0x90ef, 0x2c00
+ax_pose 73, 0x41f9, 0x50ef, 0x2c08
+ax_pose 74, 0x4201, 0x10f7, 0x2c0c
+ax_pose 75, 0x01fc, 0x10e7, 0x2c0e
+ax_pose_terminator
+sRaikouPose199:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose200:
+ax_pose 76, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose201:
+ax_pose 77, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose202:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose203:
+ax_pose 71, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sRaikouPose204:
+ax_pose 72, 0x41e9, 0x80f2, 0x2c00
+ax_pose 73, 0x41f9, 0x40f2, 0x2c08
+ax_pose 74, 0x4201, 0x00fa, 0x2c0c
+ax_pose 75, 0x01fc, 0x0112, 0x2c0e
+ax_pose_terminator
+sRaikouPose205:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose206:
+ax_pose 61, 0x41e4, 0x80f2, 0x2c00
+ax_pose 62, 0x41f4, 0x40f2, 0x2c08
+ax_pose 63, 0x01fc, 0x00f6, 0x2c0c
+ax_pose 64, 0x01ec, 0x0112, 0x2c0d
+ax_pose 65, 0x41fc, 0x00fe, 0x2c0e
+ax_pose_terminator
+sRaikouPose207:
+ax_pose 66, 0x41ec, 0x40ee, 0x2c00
+ax_pose 67, 0x41f4, 0x80ee, 0x2c04
+ax_pose 68, 0x41f4, 0x010e, 0x2c0c
+ax_pose 69, 0x01fc, 0x010e, 0x2c0e
+ax_pose 70, 0x01e4, 0x0102, 0x2c0f
+ax_pose_terminator
+sRaikouPose208:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose209:
+ax_pose 51, 0x81e4, 0x8100, 0x2c00
+ax_pose 52, 0x81e4, 0x40f8, 0x2c08
+ax_pose 53, 0x0204, 0x00fd, 0x2c0c
+ax_pose 54, 0x01ec, 0x00f0, 0x2c0d
+ax_pose 55, 0x81f4, 0x00f0, 0x2c0e
+ax_pose_terminator
+sRaikouPose210:
+ax_pose 56, 0x81e6, 0x80ff, 0x2c00
+ax_pose 57, 0x81e6, 0x40f7, 0x2c08
+ax_pose 58, 0x01e9, 0x010f, 0x2c0c
+ax_pose 59, 0x01ee, 0x00ef, 0x2c0d
+ax_pose 60, 0x81f6, 0x00ef, 0x2c0e
+ax_pose_terminator
+sRaikouPose211:
+ax_pose 47, 0x81e4, 0x80f5, 0x2c00
+ax_pose 48, 0x81e4, 0x4105, 0x2c08
+ax_pose 49, 0x0204, 0x00fd, 0x2c0c
+ax_pose 50, 0x0204, 0x0105, 0x2c0d
+ax_pose_terminator
+sRaikouPose212:
+ax_pose 56, 0x81e6, 0x80ff, 0x2c00
+ax_pose 57, 0x81e6, 0x40f7, 0x2c08
+ax_pose 58, 0x01e9, 0x010f, 0x2c0c
+ax_pose 59, 0x01ee, 0x00ef, 0x2c0d
+ax_pose 60, 0x81f6, 0x00ef, 0x2c0e
+ax_pose_terminator
+sRaikouPose213:
+ax_pose 66, 0x41ec, 0x40ee, 0x2c00
+ax_pose 67, 0x41f4, 0x80ee, 0x2c04
+ax_pose 68, 0x41f4, 0x010e, 0x2c0c
+ax_pose 69, 0x01fc, 0x010e, 0x2c0e
+ax_pose 70, 0x01e4, 0x0102, 0x2c0f
+ax_pose_terminator
+sRaikouPose214:
+ax_pose 72, 0x41e9, 0x80f2, 0x2c00
+ax_pose 73, 0x41f9, 0x40f2, 0x2c08
+ax_pose 74, 0x4201, 0x00fa, 0x2c0c
+ax_pose 75, 0x01fc, 0x0112, 0x2c0e
+ax_pose_terminator
+sRaikouPose215:
+ax_pose 77, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose216:
+ax_pose 72, 0x41e9, 0x90ef, 0x2c00
+ax_pose 73, 0x41f9, 0x50ef, 0x2c08
+ax_pose 74, 0x4201, 0x10f7, 0x2c0c
+ax_pose 75, 0x01fc, 0x10e7, 0x2c0e
+ax_pose_terminator
+sRaikouPose217:
+ax_pose 66, 0x41ec, 0x50f3, 0x2c00
+ax_pose 67, 0x41f4, 0x90f3, 0x2c04
+ax_pose 68, 0x41f4, 0x10e3, 0x2c0c
+ax_pose 69, 0x01fc, 0x10eb, 0x2c0e
+ax_pose 70, 0x01e4, 0x10f7, 0x2c0f
+ax_pose_terminator
+sRaikouPose218:
+ax_pose 56, 0x81e6, 0x90f2, 0x2c00
+ax_pose 57, 0x81e6, 0x5102, 0x2c08
+ax_pose 58, 0x01e9, 0x10ea, 0x2c0c
+ax_pose 59, 0x01ee, 0x110a, 0x2c0d
+ax_pose 60, 0x81f6, 0x110a, 0x2c0e
+ax_pose_terminator
+sRaikouPose219:
+ax_pose 46, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose220:
+ax_pose 51, 0x81e4, 0x90f2, 0x2c00
+ax_pose 52, 0x81e4, 0x5102, 0x2c08
+ax_pose 53, 0x0204, 0x10fd, 0x2c0c
+ax_pose 54, 0x01ec, 0x110a, 0x2c0d
+ax_pose 55, 0x81f4, 0x110a, 0x2c0e
+ax_pose_terminator
+sRaikouPose221:
+ax_pose 61, 0x41e4, 0x90f1, 0x2c00
+ax_pose 62, 0x41f4, 0x50f1, 0x2c08
+ax_pose 63, 0x01fc, 0x1105, 0x2c0c
+ax_pose 64, 0x01ec, 0x10e9, 0x2c0d
+ax_pose 65, 0x41fc, 0x10f5, 0x2c0e
+ax_pose_terminator
+sRaikouPose222:
+ax_pose 71, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sRaikouPose223:
+ax_pose 76, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose224:
+ax_pose 71, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose225:
+ax_pose 61, 0x41e4, 0x80f0, 0x2c00
+ax_pose 62, 0x41f4, 0x40f0, 0x2c08
+ax_pose 63, 0x01fc, 0x00f4, 0x2c0c
+ax_pose 64, 0x01ec, 0x0110, 0x2c0d
+ax_pose 65, 0x41fc, 0x00fc, 0x2c0e
+ax_pose_terminator
+sRaikouPose226:
+ax_pose 51, 0x81e4, 0x80ff, 0x2c00
+ax_pose 52, 0x81e4, 0x40f7, 0x2c08
+ax_pose 53, 0x0204, 0x00fc, 0x2c0c
+ax_pose 54, 0x01ec, 0x00ef, 0x2c0d
+ax_pose 55, 0x81f4, 0x00ef, 0x2c0e
+ax_pose_terminator
+sRaikouPose227:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose228:
+ax_pose 46, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose229:
+ax_pose 47, 0x81e4, 0x80f5, 0x2c00
+ax_pose 48, 0x81e4, 0x4105, 0x2c08
+ax_pose 49, 0x0204, 0x00fd, 0x2c0c
+ax_pose 50, 0x0204, 0x0105, 0x2c0d
+ax_pose_terminator
+sRaikouPose230:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose231:
+ax_pose 51, 0x81e4, 0x90f1, 0x2c00
+ax_pose 52, 0x81e4, 0x5101, 0x2c08
+ax_pose 53, 0x0204, 0x10fc, 0x2c0c
+ax_pose 54, 0x01ec, 0x1109, 0x2c0d
+ax_pose 55, 0x81f4, 0x1109, 0x2c0e
+ax_pose_terminator
+sRaikouPose232:
+ax_pose 56, 0x81e6, 0x90f2, 0x2c00
+ax_pose 57, 0x81e6, 0x5102, 0x2c08
+ax_pose 58, 0x01e9, 0x10ea, 0x2c0c
+ax_pose 59, 0x01ee, 0x110a, 0x2c0d
+ax_pose 60, 0x81f6, 0x110a, 0x2c0e
+ax_pose_terminator
+sRaikouPose233:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose234:
+ax_pose 61, 0x41e4, 0x90ef, 0x2c00
+ax_pose 62, 0x41f4, 0x50ef, 0x2c08
+ax_pose 63, 0x01fc, 0x1103, 0x2c0c
+ax_pose 64, 0x01ec, 0x10e7, 0x2c0d
+ax_pose 65, 0x41fc, 0x10f3, 0x2c0e
+ax_pose_terminator
+sRaikouPose235:
+ax_pose 66, 0x41ec, 0x50f3, 0x2c00
+ax_pose 67, 0x41f4, 0x90f3, 0x2c04
+ax_pose 68, 0x41f4, 0x10e3, 0x2c0c
+ax_pose 69, 0x01fc, 0x10eb, 0x2c0e
+ax_pose 70, 0x01e4, 0x10f7, 0x2c0f
+ax_pose_terminator
+sRaikouPose236:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose237:
+ax_pose 71, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sRaikouPose238:
+ax_pose 72, 0x41e9, 0x90ef, 0x2c00
+ax_pose 73, 0x41f9, 0x50ef, 0x2c08
+ax_pose 74, 0x4201, 0x10f7, 0x2c0c
+ax_pose 75, 0x01fc, 0x10e7, 0x2c0e
+ax_pose_terminator
+sRaikouPose239:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose240:
+ax_pose 76, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose241:
+ax_pose 77, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose242:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose243:
+ax_pose 71, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sRaikouPose244:
+ax_pose 72, 0x41e9, 0x80f2, 0x2c00
+ax_pose 73, 0x41f9, 0x40f2, 0x2c08
+ax_pose 74, 0x4201, 0x00fa, 0x2c0c
+ax_pose 75, 0x01fc, 0x0112, 0x2c0e
+ax_pose_terminator
+sRaikouPose245:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose246:
+ax_pose 61, 0x41e4, 0x80f2, 0x2c00
+ax_pose 62, 0x41f4, 0x40f2, 0x2c08
+ax_pose 63, 0x01fc, 0x00f6, 0x2c0c
+ax_pose 64, 0x01ec, 0x0112, 0x2c0d
+ax_pose 65, 0x41fc, 0x00fe, 0x2c0e
+ax_pose_terminator
+sRaikouPose247:
+ax_pose 66, 0x41ec, 0x40ee, 0x2c00
+ax_pose 67, 0x41f4, 0x80ee, 0x2c04
+ax_pose 68, 0x41f4, 0x010e, 0x2c0c
+ax_pose 69, 0x01fc, 0x010e, 0x2c0e
+ax_pose 70, 0x01e4, 0x0102, 0x2c0f
+ax_pose_terminator
+sRaikouPose248:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose249:
+ax_pose 51, 0x81e4, 0x8100, 0x2c00
+ax_pose 52, 0x81e4, 0x40f8, 0x2c08
+ax_pose 53, 0x0204, 0x00fd, 0x2c0c
+ax_pose 54, 0x01ec, 0x00f0, 0x2c0d
+ax_pose 55, 0x81f4, 0x00f0, 0x2c0e
+ax_pose_terminator
+sRaikouPose250:
+ax_pose 56, 0x81e6, 0x80ff, 0x2c00
+ax_pose 57, 0x81e6, 0x40f7, 0x2c08
+ax_pose 58, 0x01e9, 0x010f, 0x2c0c
+ax_pose 59, 0x01ee, 0x00ef, 0x2c0d
+ax_pose 60, 0x81f6, 0x00ef, 0x2c0e
+ax_pose_terminator
+sRaikouPose251:
+ax_pose 47, 0x81e4, 0x80f5, 0x2c00
+ax_pose 48, 0x81e4, 0x4105, 0x2c08
+ax_pose 49, 0x0204, 0x00fd, 0x2c0c
+ax_pose 50, 0x0204, 0x0105, 0x2c0d
+ax_pose_terminator
+sRaikouPose252:
+ax_pose 56, 0x81e6, 0x80ff, 0x2c00
+ax_pose 57, 0x81e6, 0x40f7, 0x2c08
+ax_pose 58, 0x01e9, 0x010f, 0x2c0c
+ax_pose 59, 0x01ee, 0x00ef, 0x2c0d
+ax_pose 60, 0x81f6, 0x00ef, 0x2c0e
+ax_pose_terminator
+sRaikouPose253:
+ax_pose 66, 0x41ec, 0x40ee, 0x2c00
+ax_pose 67, 0x41f4, 0x80ee, 0x2c04
+ax_pose 68, 0x41f4, 0x010e, 0x2c0c
+ax_pose 69, 0x01fc, 0x010e, 0x2c0e
+ax_pose 70, 0x01e4, 0x0102, 0x2c0f
+ax_pose_terminator
+sRaikouPose254:
+ax_pose 72, 0x41e9, 0x80f2, 0x2c00
+ax_pose 73, 0x41f9, 0x40f2, 0x2c08
+ax_pose 74, 0x4201, 0x00fa, 0x2c0c
+ax_pose 75, 0x01fc, 0x0112, 0x2c0e
+ax_pose_terminator
+sRaikouPose255:
+ax_pose 77, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose256:
+ax_pose 72, 0x41e9, 0x90ef, 0x2c00
+ax_pose 73, 0x41f9, 0x50ef, 0x2c08
+ax_pose 74, 0x4201, 0x10f7, 0x2c0c
+ax_pose 75, 0x01fc, 0x10e7, 0x2c0e
+ax_pose_terminator
+sRaikouPose257:
+ax_pose 66, 0x41ec, 0x50f3, 0x2c00
+ax_pose 67, 0x41f4, 0x90f3, 0x2c04
+ax_pose 68, 0x41f4, 0x10e3, 0x2c0c
+ax_pose 69, 0x01fc, 0x10eb, 0x2c0e
+ax_pose 70, 0x01e4, 0x10f7, 0x2c0f
+ax_pose_terminator
+sRaikouPose258:
+ax_pose 56, 0x81e6, 0x90f2, 0x2c00
+ax_pose 57, 0x81e6, 0x5102, 0x2c08
+ax_pose 58, 0x01e9, 0x10ea, 0x2c0c
+ax_pose 59, 0x01ee, 0x110a, 0x2c0d
+ax_pose 60, 0x81f6, 0x110a, 0x2c0e
+ax_pose_terminator
+sRaikouPose259:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose260:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose261:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose262:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose263:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose264:
+ax_pose 20, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose265:
+ax_pose 14, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose266:
+ax_pose 7, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sRaikouPose267:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sRaikouPose268:
+ax_pose 140, 0x01ec, 0x0111, 0x2c00
+ax_pose 141, 0x01f4, 0x4111, 0x2c01
+ax_pose 142, 0x01e4, 0x0101, 0x2c05
+ax_pose 143, 0x81d4, 0x4109, 0x2c06
+ax_pose 144, 0x41e4, 0x00f1, 0x2c0a
+ax_pose 145, 0x81dc, 0x00e9, 0x2c0c
+ax_pose 146, 0x41d4, 0x00e1, 0x2c0e
+ax_pose 147, 0x41f4, 0x00e9, 0x2c10
+ax_pose 148, 0x81ec, 0x00e1, 0x2c12
+ax_pose 149, 0x0204, 0x0101, 0x2c14
+ax_pose 150, 0x81f4, 0x40f9, 0x2c15
+ax_pose 46, 0x01e4, 0x80f1, 0x2c19
+ax_pose_terminator
+sRaikouPose269:
+ax_pose 46, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose270:
+ax_pose 151, 0x01ec, 0x0101, 0x2c00
+ax_pose 152, 0x4204, 0x0111, 0x2c01
+ax_pose 153, 0x81ec, 0x4109, 0x2c03
+ax_pose 154, 0x01dc, 0x0119, 0x2c07
+ax_pose 155, 0x01d4, 0x0111, 0x2c08
+ax_pose 156, 0x01dc, 0x4109, 0x2c09
+ax_pose 157, 0x01e4, 0x00f9, 0x2c0d
+ax_pose 158, 0x01d4, 0x40f1, 0x2c0e
+ax_pose 159, 0x01e4, 0x00e1, 0x2c12
+ax_pose 160, 0x41ec, 0x00e9, 0x2c13
+ax_pose 161, 0x01fc, 0x00e1, 0x2c15
+ax_pose 162, 0x41f4, 0x00e1, 0x2c16
+ax_pose 163, 0x81f4, 0x40f1, 0x2c18
+ax_pose 164, 0x0204, 0x00e9, 0x2c1c
+ax_pose 165, 0x01e4, 0x80f1, 0x2c1d
+ax_pose_terminator
+sRaikouPose271:
+ax_pose 165, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sRaikouPose272:
+ax_pose 47, 0x81e4, 0x80f5, 0x2c00
+ax_pose 48, 0x81e4, 0x4105, 0x2c08
+ax_pose 49, 0x0204, 0x00fd, 0x2c0c
+ax_pose 50, 0x0204, 0x0105, 0x2c0d
+ax_pose_terminator
+.align 2
+sRaikouAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, -2, 0, -1,
+ax_anim 2, 0, 27, 0, 2, 0, 2,
+ax_anim 2, 2, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRaikouAnims_2_2:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 32, 3, -1, 3, 3,
+ax_anim 2, 0, 32, 7, 5, 7, 9,
+ax_anim 2, 2, 32, 11, 12, 11, 15,
+ax_anim 2, 0, 33, 13, 19, 13, 19,
+ax_anim 2, 1, 33, 14, 18, 14, 18,
+ax_anim 2, 0, 33, 13, 19, 13, 19,
+ax_anim 2, 0, 33, 14, 18, 14, 18,
+ax_anim 2, 0, 33, 13, 19, 13, 19,
+ax_anim 2, 0, 33, 14, 18, 14, 18,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim_terminator
+sRaikouAnims_2_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 6, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 37, 0, -3, 0, 0,
+ax_anim 2, 0, 37, 4, -5, 4, 0,
+ax_anim 2, 2, 37, 7, -4, 7, 0,
+ax_anim 2, 0, 38, 12, 0, 12, 0,
+ax_anim 2, 1, 38, 12, -1, 12, -1,
+ax_anim 2, 0, 38, 12, 0, 12, 0,
+ax_anim 2, 0, 38, 12, -1, 12, -1,
+ax_anim 2, 0, 38, 12, 0, 12, 0,
+ax_anim 2, 0, 38, 12, -1, 12, -1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sRaikouAnims_2_4:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 42, 2, -5, 2, -4,
+ax_anim 2, 0, 42, 6, -15, 6, -9,
+ax_anim 2, 2, 42, 11, -17, 11, -14,
+ax_anim 2, 0, 43, 16, -19, 16, -19,
+ax_anim 2, 1, 43, 17, -18, 17, -18,
+ax_anim 2, 0, 43, 16, -19, 16, -19,
+ax_anim 2, 0, 43, 17, -18, 17, -18,
+ax_anim 2, 0, 43, 16, -19, 16, -19,
+ax_anim 2, 0, 43, 17, -18, 17, -18,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sRaikouAnims_2_5:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 6, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 47, 0, -3, 0, -1,
+ax_anim 2, 0, 47, 0, -9, 0, -6,
+ax_anim 2, 2, 47, 0, -14, 0, -12,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 1, 48, 1, -20, 1, -20,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 48, 1, -20, 1, -20,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 48, 1, -20, 1, -20,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sRaikouAnims_2_6:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 6, 0, 49, 2, 2, 2, 2,
+ax_anim 1, 0, 52, -2, -5, -2, -4,
+ax_anim 2, 0, 52, -6, -15, -6, -9,
+ax_anim 2, 2, 52, -11, -17, -11, -14,
+ax_anim 2, 0, 53, -16, -19, -16, -19,
+ax_anim 2, 1, 53, -17, -18, -17, -18,
+ax_anim 2, 0, 53, -16, -19, -16, -19,
+ax_anim 2, 0, 53, -17, -18, -17, -18,
+ax_anim 2, 0, 53, -16, -19, -16, -19,
+ax_anim 2, 0, 53, -17, -18, -17, -18,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sRaikouAnims_2_7:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 6, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 0, 57, 0, -3, 0, 0,
+ax_anim 2, 0, 57, -4, -5, -4, 0,
+ax_anim 2, 2, 57, -7, -4, -7, 0,
+ax_anim 2, 0, 58, -12, 0, -12, 0,
+ax_anim 2, 1, 58, -12, -1, -12, -1,
+ax_anim 2, 0, 58, -12, 0, -12, 0,
+ax_anim 2, 0, 58, -12, -1, -12, -1,
+ax_anim 2, 0, 58, -12, 0, -12, 0,
+ax_anim 2, 0, 58, -12, -1, -12, -1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sRaikouAnims_2_8:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 6, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 62, -3, -1, -3, 3,
+ax_anim 2, 0, 62, -7, 5, -7, 9,
+ax_anim 2, 2, 62, -11, 12, -11, 15,
+ax_anim 2, 0, 63, -13, 19, -13, 19,
+ax_anim 2, 1, 63, -14, 18, -14, 18,
+ax_anim 2, 0, 63, -13, 19, -13, 19,
+ax_anim 2, 0, 63, -14, 18, -14, 18,
+ax_anim 2, 0, 63, -13, 19, -13, 19,
+ax_anim 2, 0, 63, -14, 18, -14, 18,
+ax_anim 2, 0, 59, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRaikouAnims_3_1:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 6, 0, 64, 0, -2, 0, -2,
+ax_anim 1, 0, 67, 0, -2, 0, -1,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 2, 67, 0, 26, 0, 26,
+ax_anim 2, 0, 68, 0, 42, 0, 42,
+ax_anim 2, 1, 68, 1, 42, 1, 42,
+ax_anim 2, 0, 68, 0, 42, 0, 42,
+ax_anim 2, 0, 68, 1, 42, 1, 42,
+ax_anim 2, 0, 68, 0, 42, 0, 42,
+ax_anim 2, 0, 68, 1, 18, 1, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sRaikouAnims_3_2:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 6, 0, 69, -2, -2, -2, -2,
+ax_anim 1, 0, 72, 3, -1, 3, 3,
+ax_anim 2, 0, 72, 15, 13, 15, 17,
+ax_anim 2, 2, 72, 27, 28, 27, 31,
+ax_anim 2, 0, 73, 37, 43, 37, 43,
+ax_anim 2, 1, 73, 38, 42, 38, 42,
+ax_anim 2, 0, 73, 37, 43, 37, 43,
+ax_anim 2, 0, 73, 38, 42, 38, 42,
+ax_anim 2, 0, 73, 37, 43, 37, 43,
+ax_anim 2, 0, 73, 14, 18, 14, 18,
+ax_anim 2, 0, 69, 8, 8, 8, 8,
+ax_anim_terminator
+sRaikouAnims_3_3:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 6, 0, 74, -2, 0, -2, 0,
+ax_anim 1, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 12, -5, 12, 0,
+ax_anim 2, 2, 77, 23, -4, 23, 0,
+ax_anim 2, 0, 78, 36, 0, 36, 0,
+ax_anim 2, 1, 78, 36, -1, 36, -1,
+ax_anim 2, 0, 78, 36, 0, 36, 0,
+ax_anim 2, 0, 78, 36, -1, 36, -1,
+ax_anim 2, 0, 78, 36, 0, 36, 0,
+ax_anim 2, 0, 78, 12, -1, 12, -1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sRaikouAnims_3_4:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 6, 0, 79, -2, 2, -2, 2,
+ax_anim 1, 0, 82, 2, -5, 2, -4,
+ax_anim 2, 0, 82, 14, -23, 14, -17,
+ax_anim 2, 2, 82, 27, -33, 27, -30,
+ax_anim 2, 0, 83, 40, -43, 40, -43,
+ax_anim 2, 1, 83, 41, -42, 41, -42,
+ax_anim 2, 0, 83, 40, -43, 40, -43,
+ax_anim 2, 0, 83, 41, -42, 41, -42,
+ax_anim 2, 0, 83, 40, -43, 40, -43,
+ax_anim 2, 0, 83, 17, -18, 17, -18,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sRaikouAnims_3_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 6, 0, 84, 0, 2, 0, 2,
+ax_anim 1, 0, 87, 0, -3, 0, -1,
+ax_anim 2, 0, 87, 0, -17, 0, -14,
+ax_anim 2, 2, 87, 0, -30, 0, -28,
+ax_anim 2, 0, 88, 0, -44, 0, -44,
+ax_anim 2, 1, 88, 1, -44, 1, -44,
+ax_anim 2, 0, 88, 0, -44, 0, -44,
+ax_anim 2, 0, 88, 1, -44, 1, -44,
+ax_anim 2, 0, 88, 0, -44, 0, -44,
+ax_anim 2, 0, 88, 1, -20, 1, -20,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sRaikouAnims_3_6:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 6, 0, 89, 2, 2, 2, 2,
+ax_anim 1, 0, 92, -2, -5, -2, -4,
+ax_anim 2, 0, 92, -14, -23, -14, -17,
+ax_anim 2, 2, 92, -27, -33, -27, -30,
+ax_anim 2, 0, 93, -40, -43, -40, -43,
+ax_anim 2, 1, 93, -41, -42, -41, -42,
+ax_anim 2, 0, 93, -40, -43, -40, -43,
+ax_anim 2, 0, 93, -41, -42, -41, -42,
+ax_anim 2, 0, 93, -40, -43, -40, -43,
+ax_anim 2, 0, 93, -17, -18, -17, -18,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sRaikouAnims_3_7:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 6, 0, 94, 2, 0, 2, 0,
+ax_anim 1, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 97, -12, -5, -12, 0,
+ax_anim 2, 2, 97, -23, -4, -23, 0,
+ax_anim 2, 0, 98, -36, 0, -36, 0,
+ax_anim 2, 1, 98, -36, -1, -36, -1,
+ax_anim 2, 0, 98, -36, 0, -36, 0,
+ax_anim 2, 0, 98, -36, -1, -36, -1,
+ax_anim 2, 0, 98, -36, 0, -36, 0,
+ax_anim 2, 0, 98, -12, -1, -12, -1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sRaikouAnims_3_8:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 6, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 0, 102, -3, -1, -3, 3,
+ax_anim 2, 0, 102, -15, 13, -15, 17,
+ax_anim 2, 2, 102, -27, 28, -27, 31,
+ax_anim 2, 0, 103, -37, 43, -37, 43,
+ax_anim 2, 1, 103, -38, 42, -38, 42,
+ax_anim 2, 0, 103, -37, 43, -37, 43,
+ax_anim 2, 0, 103, -38, 42, -38, 42,
+ax_anim 2, 0, 103, -37, 43, -37, 43,
+ax_anim 2, 0, 103, -14, 18, -14, 18,
+ax_anim 2, 0, 99, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRaikouAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sRaikouAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sRaikouAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sRaikouAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sRaikouAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sRaikouAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sRaikouAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 127, -3, 1, -3, 1,
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRaikouAnims_5_1:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 2, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 1, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_5_2:
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 2, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 1, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_5_3:
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 2, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 1, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_5_4:
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 2, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 1, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_5_5:
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 2, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 1, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_5_6:
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 2, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 1, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_5_7:
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 2, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 1, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_5_8:
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 2, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 1, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_7_1:
+ax_anim 2, 0, 178, 0, -6, 0, -6,
+ax_anim 8, 0, 178, 0, -7, 0, -7,
+ax_anim_terminator
+sRaikouAnims_7_2:
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 8, 0, 179, -7, -7, -7, -7,
+ax_anim_terminator
+sRaikouAnims_7_3:
+ax_anim 2, 0, 180, -6, 0, -6, 0,
+ax_anim 8, 0, 180, -7, 0, -7, 0,
+ax_anim_terminator
+sRaikouAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sRaikouAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sRaikouAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sRaikouAnims_7_7:
+ax_anim 2, 0, 184, 6, 0, 6, 0,
+ax_anim 8, 0, 184, 7, 0, 7, 0,
+ax_anim_terminator
+sRaikouAnims_7_8:
+ax_anim 2, 0, 185, 6, -6, 6, -6,
+ax_anim 8, 0, 185, 7, -7, 7, -7,
+ax_anim_terminator
+.align 2
+sRaikouAnims_8_1:
+ax_anim 60, 0, 186, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_8_2:
+ax_anim 60, 0, 189, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_8_3:
+ax_anim 60, 0, 192, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_8_4:
+ax_anim 60, 0, 195, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_8_5:
+ax_anim 60, 0, 198, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_8_6:
+ax_anim 60, 0, 201, 0, 0, 0, 0,
+ax_anim 10, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, 0, -1, 0,
+ax_anim 10, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_8_7:
+ax_anim 60, 0, 204, 0, 0, 0, 0,
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -1, 0, -1, 0,
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_8_8:
+ax_anim 60, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -1, 0, -1, 0,
+ax_anim 10, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 6, 3, 6, 3,
+ax_anim 2, 0, 212, 8, 9, 8, 9,
+ax_anim 2, 0, 213, 7, 15, 7, 15,
+ax_anim 3, 0, 214, 0, 18, 0, 18,
+ax_anim 2, 3, 215, -7, 15, -7, 15,
+ax_anim 2, 0, 216, -8, 9, -8, 9,
+ax_anim 1, 0, 217, -6, 3, -6, 3,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 8, 0, 8, 0,
+ax_anim 2, 0, 211, 17, 3, 17, 3,
+ax_anim 2, 0, 212, 19, 10, 19, 10,
+ax_anim 3, 0, 213, 17, 19, 17, 19,
+ax_anim 2, 3, 214, 11, 19, 11, 19,
+ax_anim 2, 0, 215, 3, 15, 3, 15,
+ax_anim 1, 0, 216, 0, 7, 0, 7,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 3, -5, 3, -5,
+ax_anim 2, 0, 210, 11, -6, 11, -6,
+ax_anim 2, 0, 211, 16, -5, 16, -5,
+ax_anim 3, 0, 212, 18, -2, 18, -2,
+ax_anim 2, 3, 213, 16, 4, 16, 4,
+ax_anim 2, 0, 214, 12, 5, 12, 5,
+ax_anim 1, 0, 215, 4, 5, 4, 5,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, -1, -8, -1, -8,
+ax_anim 2, 0, 217, 4, -16, 4, -16,
+ax_anim 2, 0, 210, 12, -22, 12, -22,
+ax_anim 3, 0, 211, 18, -22, 18, -22,
+ax_anim 2, 3, 212, 20, -15, 20, -15,
+ax_anim 2, 0, 213, 17, -4, 17, -4,
+ax_anim 1, 0, 214, 7, -1, 7, -1,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -8, -4, -8, -4,
+ax_anim 2, 0, 216, -9, -12, -9, -12,
+ax_anim 2, 0, 217, -7, -18, -7, -18,
+ax_anim 3, 0, 210, 0, -22, 0, -22,
+ax_anim 2, 3, 211, 7, -18, 7, -18,
+ax_anim 2, 0, 212, 9, -12, 9, -12,
+ax_anim 1, 0, 213, 8, -4, 8, -4,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 1, -6, 1, -6,
+ax_anim 2, 0, 211, -4, -16, -4, -16,
+ax_anim 2, 0, 210, -12, -22, -12, -22,
+ax_anim 3, 0, 217, -18, -22, -18, -22,
+ax_anim 2, 3, 216, -20, -15, -20, -15,
+ax_anim 2, 0, 215, -17, -4, -17, -4,
+ax_anim 1, 0, 214, -7, -1, -7, -1,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, -3, -5, -3, -5,
+ax_anim 2, 0, 210, -11, -6, -11, -6,
+ax_anim 2, 0, 217, -16, -5, -16, -5,
+ax_anim 3, 0, 216, -18, -2, -18, -2,
+ax_anim 2, 3, 215, -16, 4, -16, 4,
+ax_anim 2, 0, 214, -12, 5, -12, 5,
+ax_anim 1, 0, 213, -4, 5, -4, 5,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -8, 0, -8, 0,
+ax_anim 2, 0, 217, -17, 3, -17, 3,
+ax_anim 2, 0, 216, -19, 10, -19, 10,
+ax_anim 3, 0, 215, -17, 19, -17, 19,
+ax_anim 2, 3, 214, -11, 19, -11, 19,
+ax_anim 2, 0, 213, -3, 15, -3, 15,
+ax_anim 1, 0, 212, 0, 7, 0, 7,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 228, 0, -22, 0, 0,
+ax_anim 2, 0, 228, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_11_2:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 230, 0, -16, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -23, 0, 0,
+ax_anim 3, 0, 231, 0, -22, 0, 0,
+ax_anim 2, 0, 231, 0, -18, 0, 0,
+ax_anim 1, 0, 231, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_11_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -22, 0, 0,
+ax_anim 3, 0, 234, 0, -21, 0, 0,
+ax_anim 2, 0, 234, 0, -18, 0, 0,
+ax_anim 1, 0, 234, 0, -12, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_11_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 236, 0, -16, 0, 0,
+ax_anim 3, 0, 236, 0, -20, 0, 0,
+ax_anim 4, 0, 236, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -22, 0, 0,
+ax_anim 3, 0, 237, 0, -21, 0, 0,
+ax_anim 2, 0, 237, 0, -17, 0, 0,
+ax_anim 1, 0, 237, 0, -11, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_11_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 239, 0, -16, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 240, 0, -21, 0, 0,
+ax_anim 2, 0, 240, 0, -18, 0, 0,
+ax_anim 1, 0, 240, 0, -12, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_11_6:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -10, 0, 0,
+ax_anim 2, 0, 242, 0, -16, 0, 0,
+ax_anim 3, 0, 242, 0, -20, 0, 0,
+ax_anim 4, 0, 242, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -22, 0, 0,
+ax_anim 3, 0, 243, 0, -21, 0, 0,
+ax_anim 2, 0, 243, 0, -17, 0, 0,
+ax_anim 1, 0, 243, 0, -11, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_11_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 245, 0, -10, 0, 0,
+ax_anim 2, 0, 245, 0, -16, 0, 0,
+ax_anim 3, 0, 245, 0, -20, 0, 0,
+ax_anim 4, 0, 245, 0, -21, 0, 0,
+ax_anim 4, 0, 244, 0, -22, 0, 0,
+ax_anim 3, 0, 246, 0, -21, 0, 0,
+ax_anim 2, 0, 246, 0, -18, 0, 0,
+ax_anim 1, 0, 246, 0, -12, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_11_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -10, 0, 0,
+ax_anim 2, 0, 248, 0, -16, 0, 0,
+ax_anim 3, 0, 248, 0, -20, 0, 0,
+ax_anim 4, 0, 248, 0, -21, 0, 0,
+ax_anim 4, 0, 247, 0, -23, 0, 0,
+ax_anim 3, 0, 249, 0, -22, 0, 0,
+ax_anim 2, 0, 249, 0, -18, 0, 0,
+ax_anim 1, 0, 249, 0, -12, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_12_1:
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_12_2:
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, -1,
+ax_anim 2, 1, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_12_3:
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 1, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_12_4:
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 1, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_12_5:
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 1, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_12_6:
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 1, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_12_7:
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 1, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_12_8:
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 1, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_13_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_13_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_13_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_13_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_13_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_13_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_13_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sRaikouAnims_13_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaikouAnims_14_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_14_2:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_14_3:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_14_4:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_14_5:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_14_6:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_14_7:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouAnims_14_8:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -2, 0, -2,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 1, 0, 267, 0, -3, 0, -3,
+ax_anim 1, 0, 269, 0, -3, 0, -3,
+ax_anim 10, 0, 268, 0, -3, 0, -3,
+ax_anim 1, 0, 271, 0, -2, 0, -2,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim 2, 0, 271, -1, 1, -1, 1,
+ax_anim 2, 0, 271, 0, 1, 0, 1,
+ax_anim_terminator
+sRaikouGfx1:
+.incbin "baserom.gba", 0xFDC3D4, 0x200
+sRaikouSprites1:
+ax_sprite sRaikouGfx1, 0x200
+ax_sprite_terminator
+sRaikouGfx2:
+.incbin "baserom.gba", 0xFDC5E4, 0x100
+sRaikouSprites2:
+ax_sprite sRaikouGfx2, 0x100
+ax_sprite_terminator
+sRaikouGfx3:
+.incbin "baserom.gba", 0xFDC6F4, 0x80
+sRaikouSprites3:
+ax_sprite sRaikouGfx3, 0x80
+ax_sprite_terminator
+sRaikouGfx4:
+.incbin "baserom.gba", 0xFDC784, 0x20
+sRaikouSprites4:
+ax_sprite sRaikouGfx4, 0x20
+ax_sprite_terminator
+sRaikouGfx5:
+.incbin "baserom.gba", 0xFDC7B4, 0x100
+sRaikouSprites5:
+ax_sprite sRaikouGfx5, 0x100
+ax_sprite_terminator
+sRaikouGfx6:
+.incbin "baserom.gba", 0xFDC8C4, 0x20
+sRaikouSprites6:
+ax_sprite sRaikouGfx6, 0x20
+ax_sprite_terminator
+sRaikouGfx7:
+.incbin "baserom.gba", 0xFDC8F4, 0x80
+sRaikouSprites7:
+ax_sprite sRaikouGfx7, 0x80
+ax_sprite_terminator
+sRaikouGfx8:
+.incbin "baserom.gba", 0xFDC984, 0x200
+sRaikouSprites8:
+ax_sprite sRaikouGfx8, 0x200
+ax_sprite_terminator
+sRaikouGfx9:
+.incbin "baserom.gba", 0xFDCB94, 0x200
+sRaikouSprites9:
+ax_sprite sRaikouGfx9, 0x200
+ax_sprite_terminator
+sRaikouGfx10:
+.incbin "baserom.gba", 0xFDCDA4, 0x100
+sRaikouSprites10:
+ax_sprite sRaikouGfx10, 0x100
+ax_sprite_terminator
+sRaikouGfx11:
+.incbin "baserom.gba", 0xFDCEB4, 0x20
+sRaikouSprites11:
+ax_sprite sRaikouGfx11, 0x20
+ax_sprite_terminator
+sRaikouGfx12:
+.incbin "baserom.gba", 0xFDCEE4, 0x40
+sRaikouSprites12:
+ax_sprite sRaikouGfx12, 0x40
+ax_sprite_terminator
+sRaikouGfx13:
+.incbin "baserom.gba", 0xFDCF34, 0x40
+sRaikouSprites13:
+ax_sprite sRaikouGfx13, 0x40
+ax_sprite_terminator
+sRaikouGfx14:
+.incbin "baserom.gba", 0xFDCF84, 0x20
+sRaikouSprites14:
+ax_sprite sRaikouGfx14, 0x20
+ax_sprite_terminator
+sRaikouGfx15:
+.incbin "baserom.gba", 0xFDCFB4, 0x200
+sRaikouSprites15:
+ax_sprite sRaikouGfx15, 0x200
+ax_sprite_terminator
+sRaikouGfx16:
+.incbin "baserom.gba", 0xFDD1C4, 0x200
+sRaikouSprites16:
+ax_sprite sRaikouGfx16, 0x200
+ax_sprite_terminator
+sRaikouGfx17:
+.incbin "baserom.gba", 0xFDD3D4, 0x40
+sRaikouSprites17:
+ax_sprite sRaikouGfx17, 0x40
+ax_sprite_terminator
+sRaikouGfx18:
+.incbin "baserom.gba", 0xFDD424, 0x80
+sRaikouSprites18:
+ax_sprite sRaikouGfx18, 0x80
+ax_sprite_terminator
+sRaikouGfx19:
+.incbin "baserom.gba", 0xFDD4B4, 0x100
+sRaikouSprites19:
+ax_sprite sRaikouGfx19, 0x100
+ax_sprite_terminator
+sRaikouGfx20:
+.incbin "baserom.gba", 0xFDD5C4, 0x20
+sRaikouSprites20:
+ax_sprite sRaikouGfx20, 0x20
+ax_sprite_terminator
+sRaikouGfx21:
+.incbin "baserom.gba", 0xFDD5F4, 0x200
+sRaikouSprites21:
+ax_sprite sRaikouGfx21, 0x200
+ax_sprite_terminator
+sRaikouGfx22:
+.incbin "baserom.gba", 0xFDD804, 0x200
+sRaikouSprites22:
+ax_sprite sRaikouGfx22, 0x200
+ax_sprite_terminator
+sRaikouGfx23:
+.incbin "baserom.gba", 0xFDDA14, 0x200
+sRaikouSprites23:
+ax_sprite sRaikouGfx23, 0x200
+ax_sprite_terminator
+sRaikouGfx24:
+.incbin "baserom.gba", 0xFDDC24, 0x200
+sRaikouSprites24:
+ax_sprite sRaikouGfx24, 0x200
+ax_sprite_terminator
+sRaikouGfx25:
+.incbin "baserom.gba", 0xFDDE34, 0x200
+sRaikouSprites25:
+ax_sprite sRaikouGfx25, 0x200
+ax_sprite_terminator
+sRaikouGfx26:
+.incbin "baserom.gba", 0xFDE044, 0x200
+sRaikouSprites26:
+ax_sprite sRaikouGfx26, 0x200
+ax_sprite_terminator
+sRaikouGfx27:
+.incbin "baserom.gba", 0xFDE254, 0x60
+sRaikouGfx27_1:
+.incbin "baserom.gba", 0xFDE2B4, 0x180
+sRaikouSprites27:
+ax_sprite sRaikouGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx27_1, 0x180
+ax_sprite_terminator
+sRaikouGfx28:
+.incbin "baserom.gba", 0xFDE454, 0x40
+sRaikouGfx28_1:
+.incbin "baserom.gba", 0xFDE494, 0x180
+sRaikouSprites28:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx28_1, 0x180
+ax_sprite_terminator
+sRaikouGfx29:
+.incbin "baserom.gba", 0xFDE63C, 0x200
+sRaikouSprites29:
+ax_sprite sRaikouGfx29, 0x200
+ax_sprite_terminator
+sRaikouGfx30:
+.incbin "baserom.gba", 0xFDE84C, 0x20
+sRaikouSprites30:
+ax_sprite sRaikouGfx30, 0x20
+ax_sprite_terminator
+sRaikouGfx31:
+.incbin "baserom.gba", 0xFDE87C, 0x20
+sRaikouSprites31:
+ax_sprite sRaikouGfx31, 0x20
+ax_sprite_terminator
+sRaikouGfx32:
+.incbin "baserom.gba", 0xFDE8AC, 0x40
+sRaikouSprites32:
+ax_sprite sRaikouGfx32, 0x40
+ax_sprite_terminator
+sRaikouGfx33:
+.incbin "baserom.gba", 0xFDE8FC, 0x1C0
+sRaikouSprites33:
+ax_sprite 0, 0x40
+ax_sprite sRaikouGfx33, 0x1c0
+ax_sprite_terminator
+sRaikouGfx34:
+.incbin "baserom.gba", 0xFDEAD4, 0x1E0
+sRaikouSprites34:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx34, 0x1e0
+ax_sprite_terminator
+sRaikouGfx35:
+.incbin "baserom.gba", 0xFDECCC, 0x60
+sRaikouSprites35:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx35, 0x60
+ax_sprite_terminator
+sRaikouGfx36:
+.incbin "baserom.gba", 0xFDED44, 0x20
+sRaikouSprites36:
+ax_sprite sRaikouGfx36, 0x20
+ax_sprite_terminator
+sRaikouGfx37:
+.incbin "baserom.gba", 0xFDED74, 0x180
+sRaikouSprites37:
+ax_sprite 0, 0x80
+ax_sprite sRaikouGfx37, 0x180
+ax_sprite_terminator
+sRaikouGfx38:
+.incbin "baserom.gba", 0xFDEF0C, 0x80
+sRaikouSprites38:
+ax_sprite sRaikouGfx38, 0x80
+ax_sprite_terminator
+sRaikouGfx39:
+.incbin "baserom.gba", 0xFDEF9C, 0x100
+sRaikouSprites39:
+ax_sprite sRaikouGfx39, 0x100
+ax_sprite_terminator
+sRaikouGfx40:
+.incbin "baserom.gba", 0xFDF0AC, 0x80
+sRaikouSprites40:
+ax_sprite sRaikouGfx40, 0x80
+ax_sprite_terminator
+sRaikouGfx41:
+.incbin "baserom.gba", 0xFDF13C, 0x40
+sRaikouSprites41:
+ax_sprite sRaikouGfx41, 0x40
+ax_sprite_terminator
+sRaikouGfx42:
+.incbin "baserom.gba", 0xFDF18C, 0x20
+sRaikouSprites42:
+ax_sprite sRaikouGfx42, 0x20
+ax_sprite_terminator
+sRaikouGfx43:
+.incbin "baserom.gba", 0xFDF1BC, 0x20
+sRaikouSprites43:
+ax_sprite sRaikouGfx43, 0x20
+ax_sprite_terminator
+sRaikouGfx44:
+.incbin "baserom.gba", 0xFDF1EC, 0x180
+sRaikouGfx44_1:
+.incbin "baserom.gba", 0xFDF36C, 0x60
+sRaikouSprites44:
+ax_sprite sRaikouGfx44, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx44_1, 0x60
+ax_sprite_terminator
+sRaikouGfx45:
+.incbin "baserom.gba", 0xFDF3EC, 0x40
+sRaikouGfx45_1:
+.incbin "baserom.gba", 0xFDF42C, 0x180
+sRaikouSprites45:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx45_1, 0x180
+ax_sprite_terminator
+sRaikouGfx46:
+.incbin "baserom.gba", 0xFDF5D4, 0x40
+sRaikouGfx46_1:
+.incbin "baserom.gba", 0xFDF614, 0x180
+sRaikouSprites46:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx46_1, 0x180
+ax_sprite_terminator
+sRaikouGfx47:
+.incbin "baserom.gba", 0xFDF7BC, 0x200
+sRaikouSprites47:
+ax_sprite sRaikouGfx47, 0x200
+ax_sprite_terminator
+sRaikouGfx48:
+.incbin "baserom.gba", 0xFDF9CC, 0x100
+sRaikouSprites48:
+ax_sprite sRaikouGfx48, 0x100
+ax_sprite_terminator
+sRaikouGfx49:
+.incbin "baserom.gba", 0xFDFADC, 0x80
+sRaikouSprites49:
+ax_sprite sRaikouGfx49, 0x80
+ax_sprite_terminator
+sRaikouGfx50:
+.incbin "baserom.gba", 0xFDFB6C, 0x20
+sRaikouSprites50:
+ax_sprite sRaikouGfx50, 0x20
+ax_sprite_terminator
+sRaikouGfx51:
+.incbin "baserom.gba", 0xFDFB9C, 0x20
+sRaikouSprites51:
+ax_sprite sRaikouGfx51, 0x20
+ax_sprite_terminator
+sRaikouGfx52:
+.incbin "baserom.gba", 0xFDFBCC, 0x100
+sRaikouSprites52:
+ax_sprite sRaikouGfx52, 0x100
+ax_sprite_terminator
+sRaikouGfx53:
+.incbin "baserom.gba", 0xFDFCDC, 0x80
+sRaikouSprites53:
+ax_sprite sRaikouGfx53, 0x80
+ax_sprite_terminator
+sRaikouGfx54:
+.incbin "baserom.gba", 0xFDFD6C, 0x20
+sRaikouSprites54:
+ax_sprite sRaikouGfx54, 0x20
+ax_sprite_terminator
+sRaikouGfx55:
+.incbin "baserom.gba", 0xFDFD9C, 0x20
+sRaikouSprites55:
+ax_sprite sRaikouGfx55, 0x20
+ax_sprite_terminator
+sRaikouGfx56:
+.incbin "baserom.gba", 0xFDFDCC, 0x40
+sRaikouSprites56:
+ax_sprite sRaikouGfx56, 0x40
+ax_sprite_terminator
+sRaikouGfx57:
+.incbin "baserom.gba", 0xFDFE1C, 0x100
+sRaikouSprites57:
+ax_sprite sRaikouGfx57, 0x100
+ax_sprite_terminator
+sRaikouGfx58:
+.incbin "baserom.gba", 0xFDFF2C, 0x80
+sRaikouSprites58:
+ax_sprite sRaikouGfx58, 0x80
+ax_sprite_terminator
+sRaikouGfx59:
+.incbin "baserom.gba", 0xFDFFBC, 0x20
+sRaikouSprites59:
+ax_sprite sRaikouGfx59, 0x20
+ax_sprite_terminator
+sRaikouGfx60:
+.incbin "baserom.gba", 0xFDFFEC, 0x20
+sRaikouSprites60:
+ax_sprite sRaikouGfx60, 0x20
+ax_sprite_terminator
+sRaikouGfx61:
+.incbin "baserom.gba", 0xFE001C, 0x40
+sRaikouSprites61:
+ax_sprite sRaikouGfx61, 0x40
+ax_sprite_terminator
+sRaikouGfx62:
+.incbin "baserom.gba", 0xFE006C, 0x100
+sRaikouSprites62:
+ax_sprite sRaikouGfx62, 0x100
+ax_sprite_terminator
+sRaikouGfx63:
+.incbin "baserom.gba", 0xFE017C, 0x80
+sRaikouSprites63:
+ax_sprite sRaikouGfx63, 0x80
+ax_sprite_terminator
+sRaikouGfx64:
+.incbin "baserom.gba", 0xFE020C, 0x20
+sRaikouSprites64:
+ax_sprite sRaikouGfx64, 0x20
+ax_sprite_terminator
+sRaikouGfx65:
+.incbin "baserom.gba", 0xFE023C, 0x20
+sRaikouSprites65:
+ax_sprite sRaikouGfx65, 0x20
+ax_sprite_terminator
+sRaikouGfx66:
+.incbin "baserom.gba", 0xFE026C, 0x40
+sRaikouSprites66:
+ax_sprite sRaikouGfx66, 0x40
+ax_sprite_terminator
+sRaikouGfx67:
+.incbin "baserom.gba", 0xFE02BC, 0x80
+sRaikouSprites67:
+ax_sprite sRaikouGfx67, 0x80
+ax_sprite_terminator
+sRaikouGfx68:
+.incbin "baserom.gba", 0xFE034C, 0x100
+sRaikouSprites68:
+ax_sprite sRaikouGfx68, 0x100
+ax_sprite_terminator
+sRaikouGfx69:
+.incbin "baserom.gba", 0xFE045C, 0x40
+sRaikouSprites69:
+ax_sprite sRaikouGfx69, 0x40
+ax_sprite_terminator
+sRaikouGfx70:
+.incbin "baserom.gba", 0xFE04AC, 0x20
+sRaikouSprites70:
+ax_sprite sRaikouGfx70, 0x20
+ax_sprite_terminator
+sRaikouGfx71:
+.incbin "baserom.gba", 0xFE04DC, 0x20
+sRaikouSprites71:
+ax_sprite sRaikouGfx71, 0x20
+ax_sprite_terminator
+sRaikouGfx72:
+.incbin "baserom.gba", 0xFE050C, 0x200
+sRaikouSprites72:
+ax_sprite sRaikouGfx72, 0x200
+ax_sprite_terminator
+sRaikouGfx73:
+.incbin "baserom.gba", 0xFE071C, 0x100
+sRaikouSprites73:
+ax_sprite sRaikouGfx73, 0x100
+ax_sprite_terminator
+sRaikouGfx74:
+.incbin "baserom.gba", 0xFE082C, 0x80
+sRaikouSprites74:
+ax_sprite sRaikouGfx74, 0x80
+ax_sprite_terminator
+sRaikouGfx75:
+.incbin "baserom.gba", 0xFE08BC, 0x40
+sRaikouSprites75:
+ax_sprite sRaikouGfx75, 0x40
+ax_sprite_terminator
+sRaikouGfx76:
+.incbin "baserom.gba", 0xFE090C, 0x20
+sRaikouSprites76:
+ax_sprite sRaikouGfx76, 0x20
+ax_sprite_terminator
+sRaikouGfx77:
+.incbin "baserom.gba", 0xFE093C, 0x60
+sRaikouGfx77_1:
+.incbin "baserom.gba", 0xFE099C, 0x180
+sRaikouSprites77:
+ax_sprite sRaikouGfx77, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx77_1, 0x180
+ax_sprite_terminator
+sRaikouGfx78:
+.incbin "baserom.gba", 0xFE0B3C, 0x40
+sRaikouGfx78_1:
+.incbin "baserom.gba", 0xFE0B7C, 0x180
+sRaikouSprites78:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx78, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx78_1, 0x180
+ax_sprite_terminator
+sRaikouGfx79:
+.incbin "baserom.gba", 0xFE0D24, 0x100
+sRaikouSprites79:
+ax_sprite sRaikouGfx79, 0x100
+ax_sprite_terminator
+sRaikouGfx80:
+.incbin "baserom.gba", 0xFE0E34, 0x60
+sRaikouSprites80:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx80, 0x60
+ax_sprite_terminator
+sRaikouGfx81:
+.incbin "baserom.gba", 0xFE0EAC, 0x20
+sRaikouSprites81:
+ax_sprite sRaikouGfx81, 0x20
+ax_sprite_terminator
+sRaikouGfx82:
+.incbin "baserom.gba", 0xFE0EDC, 0x80
+sRaikouSprites82:
+ax_sprite sRaikouGfx82, 0x80
+ax_sprite_terminator
+sRaikouGfx83:
+.incbin "baserom.gba", 0xFE0F6C, 0x60
+sRaikouSprites83:
+ax_sprite sRaikouGfx83, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaikouGfx84:
+.incbin "baserom.gba", 0xFE0FE4, 0x100
+sRaikouSprites84:
+ax_sprite sRaikouGfx84, 0x100
+ax_sprite_terminator
+sRaikouGfx85:
+.incbin "baserom.gba", 0xFE10F4, 0x20
+sRaikouSprites85:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx85, 0x20
+ax_sprite_terminator
+sRaikouGfx86:
+.incbin "baserom.gba", 0xFE112C, 0x20
+sRaikouSprites86:
+ax_sprite sRaikouGfx86, 0x20
+ax_sprite_terminator
+sRaikouGfx87:
+.incbin "baserom.gba", 0xFE115C, 0x100
+sRaikouSprites87:
+ax_sprite sRaikouGfx87, 0x100
+ax_sprite_terminator
+sRaikouGfx88:
+.incbin "baserom.gba", 0xFE126C, 0x40
+sRaikouSprites88:
+ax_sprite sRaikouGfx88, 0x40
+ax_sprite_terminator
+sRaikouGfx89:
+.incbin "baserom.gba", 0xFE12BC, 0x40
+sRaikouGfx89_1:
+.incbin "baserom.gba", 0xFE12FC, 0x180
+sRaikouSprites89:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx89, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx89_1, 0x180
+ax_sprite_terminator
+sRaikouGfx90:
+.incbin "baserom.gba", 0xFE14A4, 0x100
+sRaikouSprites90:
+ax_sprite sRaikouGfx90, 0x100
+ax_sprite_terminator
+sRaikouGfx91:
+.incbin "baserom.gba", 0xFE15B4, 0x80
+sRaikouSprites91:
+ax_sprite sRaikouGfx91, 0x80
+ax_sprite_terminator
+sRaikouGfx92:
+.incbin "baserom.gba", 0xFE1644, 0x40
+sRaikouSprites92:
+ax_sprite sRaikouGfx92, 0x40
+ax_sprite_terminator
+sRaikouGfx93:
+.incbin "baserom.gba", 0xFE1694, 0x20
+sRaikouSprites93:
+ax_sprite sRaikouGfx93, 0x20
+ax_sprite_terminator
+sRaikouGfx94:
+.incbin "baserom.gba", 0xFE16C4, 0x100
+sRaikouSprites94:
+ax_sprite sRaikouGfx94, 0x100
+ax_sprite_terminator
+sRaikouGfx95:
+.incbin "baserom.gba", 0xFE17D4, 0x40
+sRaikouGfx95_1:
+.incbin "baserom.gba", 0xFE1814, 0x180
+sRaikouSprites95:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx95, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx95_1, 0x180
+ax_sprite_terminator
+sRaikouGfx96:
+.incbin "baserom.gba", 0xFE19BC, 0x80
+sRaikouSprites96:
+ax_sprite sRaikouGfx96, 0x80
+ax_sprite_terminator
+sRaikouGfx97:
+.incbin "baserom.gba", 0xFE1A4C, 0x40
+sRaikouSprites97:
+ax_sprite sRaikouGfx97, 0x40
+ax_sprite_terminator
+sRaikouGfx98:
+.incbin "baserom.gba", 0xFE1A9C, 0x20
+sRaikouSprites98:
+ax_sprite sRaikouGfx98, 0x20
+ax_sprite_terminator
+sRaikouGfx99:
+.incbin "baserom.gba", 0xFE1ACC, 0x100
+sRaikouSprites99:
+ax_sprite sRaikouGfx99, 0x100
+ax_sprite_terminator
+sRaikouGfx100:
+.incbin "baserom.gba", 0xFE1BDC, 0x20
+sRaikouSprites100:
+ax_sprite sRaikouGfx100, 0x20
+ax_sprite_terminator
+sRaikouGfx101:
+.incbin "baserom.gba", 0xFE1C0C, 0xE0
+sRaikouSprites101:
+ax_sprite sRaikouGfx101, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaikouGfx102:
+.incbin "baserom.gba", 0xFE1D04, 0x20
+sRaikouGfx102_1:
+.incbin "baserom.gba", 0xFE1D24, 0xC0
+sRaikouSprites102:
+ax_sprite sRaikouGfx102, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx102_1, 0xc0
+ax_sprite_terminator
+sRaikouGfx103:
+.incbin "baserom.gba", 0xFE1E04, 0x40
+sRaikouSprites103:
+ax_sprite sRaikouGfx103, 0x40
+ax_sprite_terminator
+sRaikouGfx104:
+.incbin "baserom.gba", 0xFE1E54, 0x20
+sRaikouGfx104_1:
+.incbin "baserom.gba", 0xFE1E74, 0xC0
+sRaikouSprites104:
+ax_sprite sRaikouGfx104, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx104_1, 0xc0
+ax_sprite_terminator
+sRaikouGfx105:
+.incbin "baserom.gba", 0xFE1F54, 0x80
+sRaikouSprites105:
+ax_sprite sRaikouGfx105, 0x80
+ax_sprite_terminator
+sRaikouGfx106:
+.incbin "baserom.gba", 0xFE1FE4, 0x20
+sRaikouSprites106:
+ax_sprite sRaikouGfx106, 0x20
+ax_sprite_terminator
+sRaikouGfx107:
+.incbin "baserom.gba", 0xFE2014, 0x20
+sRaikouSprites107:
+ax_sprite sRaikouGfx107, 0x20
+ax_sprite_terminator
+sRaikouGfx108:
+.incbin "baserom.gba", 0xFE2044, 0x40
+sRaikouSprites108:
+ax_sprite sRaikouGfx108, 0x40
+ax_sprite_terminator
+sRaikouGfx109:
+.incbin "baserom.gba", 0xFE2094, 0x80
+sRaikouSprites109:
+ax_sprite sRaikouGfx109, 0x80
+ax_sprite_terminator
+sRaikouGfx110:
+.incbin "baserom.gba", 0xFE2124, 0x20
+sRaikouSprites110:
+ax_sprite sRaikouGfx110, 0x20
+ax_sprite_terminator
+sRaikouGfx111:
+.incbin "baserom.gba", 0xFE2154, 0x60
+sRaikouSprites111:
+ax_sprite sRaikouGfx111, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaikouGfx112:
+.incbin "baserom.gba", 0xFE21CC, 0x20
+sRaikouSprites112:
+ax_sprite sRaikouGfx112, 0x20
+ax_sprite_terminator
+sRaikouGfx113:
+.incbin "baserom.gba", 0xFE21FC, 0x80
+sRaikouSprites113:
+ax_sprite sRaikouGfx113, 0x80
+ax_sprite_terminator
+sRaikouGfx114:
+.incbin "baserom.gba", 0xFE228C, 0x80
+sRaikouSprites114:
+ax_sprite sRaikouGfx114, 0x80
+ax_sprite_terminator
+sRaikouGfx115:
+.incbin "baserom.gba", 0xFE231C, 0x20
+sRaikouGfx115_1:
+.incbin "baserom.gba", 0xFE233C, 0xC0
+sRaikouSprites115:
+ax_sprite sRaikouGfx115, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx115_1, 0xc0
+ax_sprite_terminator
+sRaikouGfx116:
+.incbin "baserom.gba", 0xFE241C, 0x80
+sRaikouSprites116:
+ax_sprite sRaikouGfx116, 0x80
+ax_sprite_terminator
+sRaikouGfx117:
+.incbin "baserom.gba", 0xFE24AC, 0x20
+sRaikouSprites117:
+ax_sprite sRaikouGfx117, 0x20
+ax_sprite_terminator
+sRaikouGfx118:
+.incbin "baserom.gba", 0xFE24DC, 0x20
+sRaikouSprites118:
+ax_sprite sRaikouGfx118, 0x20
+ax_sprite_terminator
+sRaikouGfx119:
+.incbin "baserom.gba", 0xFE250C, 0x40
+sRaikouSprites119:
+ax_sprite sRaikouGfx119, 0x40
+ax_sprite_terminator
+sRaikouGfx120:
+.incbin "baserom.gba", 0xFE255C, 0xE0
+sRaikouSprites120:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx120, 0xe0
+ax_sprite_terminator
+sRaikouGfx121:
+.incbin "baserom.gba", 0xFE2654, 0x80
+sRaikouSprites121:
+ax_sprite sRaikouGfx121, 0x80
+ax_sprite_terminator
+sRaikouGfx122:
+.incbin "baserom.gba", 0xFE26E4, 0x20
+sRaikouSprites122:
+ax_sprite sRaikouGfx122, 0x20
+ax_sprite_terminator
+sRaikouGfx123:
+.incbin "baserom.gba", 0xFE2714, 0x40
+sRaikouSprites123:
+ax_sprite sRaikouGfx123, 0x40
+ax_sprite_terminator
+sRaikouGfx124:
+.incbin "baserom.gba", 0xFE2764, 0x20
+sRaikouSprites124:
+ax_sprite sRaikouGfx124, 0x20
+ax_sprite_terminator
+sRaikouGfx125:
+.incbin "baserom.gba", 0xFE2794, 0xE0
+sRaikouSprites125:
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx125, 0xe0
+ax_sprite_terminator
+sRaikouGfx126:
+.incbin "baserom.gba", 0xFE288C, 0x80
+sRaikouSprites126:
+ax_sprite sRaikouGfx126, 0x80
+ax_sprite_terminator
+sRaikouGfx127:
+.incbin "baserom.gba", 0xFE291C, 0x20
+sRaikouSprites127:
+ax_sprite sRaikouGfx127, 0x20
+ax_sprite_terminator
+sRaikouGfx128:
+.incbin "baserom.gba", 0xFE294C, 0x40
+sRaikouSprites128:
+ax_sprite sRaikouGfx128, 0x40
+ax_sprite_terminator
+sRaikouGfx129:
+.incbin "baserom.gba", 0xFE299C, 0x20
+sRaikouSprites129:
+ax_sprite sRaikouGfx129, 0x20
+ax_sprite_terminator
+sRaikouGfx130:
+.incbin "baserom.gba", 0xFE29CC, 0x200
+sRaikouSprites130:
+ax_sprite sRaikouGfx130, 0x200
+ax_sprite_terminator
+sRaikouGfx131:
+.incbin "baserom.gba", 0xFE2BDC, 0x200
+sRaikouSprites131:
+ax_sprite sRaikouGfx131, 0x200
+ax_sprite_terminator
+sRaikouGfx132:
+.incbin "baserom.gba", 0xFE2DEC, 0x60
+sRaikouGfx132_1:
+.incbin "baserom.gba", 0xFE2E4C, 0x180
+sRaikouSprites132:
+ax_sprite sRaikouGfx132, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx132_1, 0x180
+ax_sprite_terminator
+sRaikouGfx133:
+.incbin "baserom.gba", 0xFE2FEC, 0x60
+sRaikouGfx133_1:
+.incbin "baserom.gba", 0xFE304C, 0x180
+sRaikouSprites133:
+ax_sprite sRaikouGfx133, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaikouGfx133_1, 0x180
+ax_sprite_terminator
+sRaikouGfx134:
+.incbin "baserom.gba", 0xFE31EC, 0x200
+sRaikouSprites134:
+ax_sprite sRaikouGfx134, 0x200
+ax_sprite_terminator
+sRaikouGfx135:
+.incbin "baserom.gba", 0xFE33FC, 0x200
+sRaikouSprites135:
+ax_sprite sRaikouGfx135, 0x200
+ax_sprite_terminator
+sRaikouGfx136:
+.incbin "baserom.gba", 0xFE360C, 0x200
+sRaikouSprites136:
+ax_sprite sRaikouGfx136, 0x200
+ax_sprite_terminator
+sRaikouGfx137:
+.incbin "baserom.gba", 0xFE381C, 0x200
+sRaikouSprites137:
+ax_sprite sRaikouGfx137, 0x200
+ax_sprite_terminator
+sRaikouGfx138:
+.incbin "baserom.gba", 0xFE3A2C, 0x200
+sRaikouSprites138:
+ax_sprite sRaikouGfx138, 0x200
+ax_sprite_terminator
+sRaikouGfx139:
+.incbin "baserom.gba", 0xFE3C3C, 0x200
+sRaikouSprites139:
+ax_sprite sRaikouGfx139, 0x200
+ax_sprite_terminator
+sRaikouGfx140:
+.incbin "baserom.gba", 0xFE3E4C, 0x200
+sRaikouSprites140:
+ax_sprite sRaikouGfx140, 0x200
+ax_sprite_terminator
+sRaikouGfx141:
+.incbin "baserom.gba", 0xFE405C, 0x20
+sRaikouSprites141:
+ax_sprite sRaikouGfx141, 0x20
+ax_sprite_terminator
+sRaikouGfx142:
+.incbin "baserom.gba", 0xFE408C, 0x80
+sRaikouSprites142:
+ax_sprite sRaikouGfx142, 0x80
+ax_sprite_terminator
+sRaikouGfx143:
+.incbin "baserom.gba", 0xFE411C, 0x20
+sRaikouSprites143:
+ax_sprite sRaikouGfx143, 0x20
+ax_sprite_terminator
+sRaikouGfx144:
+.incbin "baserom.gba", 0xFE414C, 0x80
+sRaikouSprites144:
+ax_sprite sRaikouGfx144, 0x80
+ax_sprite_terminator
+sRaikouGfx145:
+.incbin "baserom.gba", 0xFE41DC, 0x40
+sRaikouSprites145:
+ax_sprite sRaikouGfx145, 0x40
+ax_sprite_terminator
+sRaikouGfx146:
+.incbin "baserom.gba", 0xFE422C, 0x40
+sRaikouSprites146:
+ax_sprite sRaikouGfx146, 0x40
+ax_sprite_terminator
+sRaikouGfx147:
+.incbin "baserom.gba", 0xFE427C, 0x40
+sRaikouSprites147:
+ax_sprite sRaikouGfx147, 0x40
+ax_sprite_terminator
+sRaikouGfx148:
+.incbin "baserom.gba", 0xFE42CC, 0x40
+sRaikouSprites148:
+ax_sprite sRaikouGfx148, 0x40
+ax_sprite_terminator
+sRaikouGfx149:
+.incbin "baserom.gba", 0xFE431C, 0x40
+sRaikouSprites149:
+ax_sprite sRaikouGfx149, 0x40
+ax_sprite_terminator
+sRaikouGfx150:
+.incbin "baserom.gba", 0xFE436C, 0x20
+sRaikouSprites150:
+ax_sprite sRaikouGfx150, 0x20
+ax_sprite_terminator
+sRaikouGfx151:
+.incbin "baserom.gba", 0xFE439C, 0x80
+sRaikouSprites151:
+ax_sprite sRaikouGfx151, 0x80
+ax_sprite_terminator
+sRaikouGfx152:
+.incbin "baserom.gba", 0xFE442C, 0x20
+sRaikouSprites152:
+ax_sprite sRaikouGfx152, 0x20
+ax_sprite_terminator
+sRaikouGfx153:
+.incbin "baserom.gba", 0xFE445C, 0x40
+sRaikouSprites153:
+ax_sprite sRaikouGfx153, 0x40
+ax_sprite_terminator
+sRaikouGfx154:
+.incbin "baserom.gba", 0xFE44AC, 0x80
+sRaikouSprites154:
+ax_sprite sRaikouGfx154, 0x80
+ax_sprite_terminator
+sRaikouGfx155:
+.incbin "baserom.gba", 0xFE453C, 0x20
+sRaikouSprites155:
+ax_sprite sRaikouGfx155, 0x20
+ax_sprite_terminator
+sRaikouGfx156:
+.incbin "baserom.gba", 0xFE456C, 0x20
+sRaikouSprites156:
+ax_sprite sRaikouGfx156, 0x20
+ax_sprite_terminator
+sRaikouGfx157:
+.incbin "baserom.gba", 0xFE459C, 0x80
+sRaikouSprites157:
+ax_sprite sRaikouGfx157, 0x80
+ax_sprite_terminator
+sRaikouGfx158:
+.incbin "baserom.gba", 0xFE462C, 0x20
+sRaikouSprites158:
+ax_sprite sRaikouGfx158, 0x20
+ax_sprite_terminator
+sRaikouGfx159:
+.incbin "baserom.gba", 0xFE465C, 0x80
+sRaikouSprites159:
+ax_sprite sRaikouGfx159, 0x80
+ax_sprite_terminator
+sRaikouGfx160:
+.incbin "baserom.gba", 0xFE46EC, 0x20
+sRaikouSprites160:
+ax_sprite sRaikouGfx160, 0x20
+ax_sprite_terminator
+sRaikouGfx161:
+.incbin "baserom.gba", 0xFE471C, 0x40
+sRaikouSprites161:
+ax_sprite sRaikouGfx161, 0x40
+ax_sprite_terminator
+sRaikouGfx162:
+.incbin "baserom.gba", 0xFE476C, 0x20
+sRaikouSprites162:
+ax_sprite sRaikouGfx162, 0x20
+ax_sprite_terminator
+sRaikouGfx163:
+.incbin "baserom.gba", 0xFE479C, 0x40
+sRaikouSprites163:
+ax_sprite sRaikouGfx163, 0x40
+ax_sprite_terminator
+sRaikouGfx164:
+.incbin "baserom.gba", 0xFE47EC, 0x80
+sRaikouSprites164:
+ax_sprite sRaikouGfx164, 0x80
+ax_sprite_terminator
+sRaikouGfx165:
+.incbin "baserom.gba", 0xFE487C, 0x20
+sRaikouSprites165:
+ax_sprite sRaikouGfx165, 0x20
+ax_sprite_terminator
+sRaikouGfx166:
+.incbin "baserom.gba", 0xFE48AC, 0x200
+sRaikouSprites166:
+ax_sprite sRaikouGfx166, 0x200
+ax_sprite_terminator
+sAxPosesRaikou:
+.4byte sRaikouPose1
+.4byte sRaikouPose2
+.4byte sRaikouPose3
+.4byte sRaikouPose4
+.4byte sRaikouPose5
+.4byte sRaikouPose6
+.4byte sRaikouPose7
+.4byte sRaikouPose8
+.4byte sRaikouPose9
+.4byte sRaikouPose10
+.4byte sRaikouPose11
+.4byte sRaikouPose12
+.4byte sRaikouPose13
+.4byte sRaikouPose14
+.4byte sRaikouPose15
+.4byte sRaikouPose16
+.4byte sRaikouPose17
+.4byte sRaikouPose18
+.4byte sRaikouPose19
+.4byte sRaikouPose20
+.4byte sRaikouPose21
+.4byte sRaikouPose22
+.4byte sRaikouPose23
+.4byte sRaikouPose24
+.4byte sRaikouPose25
+.4byte sRaikouPose26
+.4byte sRaikouPose27
+.4byte sRaikouPose28
+.4byte sRaikouPose29
+.4byte sRaikouPose30
+.4byte sRaikouPose31
+.4byte sRaikouPose32
+.4byte sRaikouPose33
+.4byte sRaikouPose34
+.4byte sRaikouPose35
+.4byte sRaikouPose36
+.4byte sRaikouPose37
+.4byte sRaikouPose38
+.4byte sRaikouPose39
+.4byte sRaikouPose40
+.4byte sRaikouPose41
+.4byte sRaikouPose42
+.4byte sRaikouPose43
+.4byte sRaikouPose44
+.4byte sRaikouPose45
+.4byte sRaikouPose46
+.4byte sRaikouPose47
+.4byte sRaikouPose48
+.4byte sRaikouPose49
+.4byte sRaikouPose50
+.4byte sRaikouPose51
+.4byte sRaikouPose52
+.4byte sRaikouPose53
+.4byte sRaikouPose54
+.4byte sRaikouPose55
+.4byte sRaikouPose56
+.4byte sRaikouPose57
+.4byte sRaikouPose58
+.4byte sRaikouPose59
+.4byte sRaikouPose60
+.4byte sRaikouPose61
+.4byte sRaikouPose62
+.4byte sRaikouPose63
+.4byte sRaikouPose64
+.4byte sRaikouPose65
+.4byte sRaikouPose66
+.4byte sRaikouPose67
+.4byte sRaikouPose68
+.4byte sRaikouPose69
+.4byte sRaikouPose70
+.4byte sRaikouPose71
+.4byte sRaikouPose72
+.4byte sRaikouPose73
+.4byte sRaikouPose74
+.4byte sRaikouPose75
+.4byte sRaikouPose76
+.4byte sRaikouPose77
+.4byte sRaikouPose78
+.4byte sRaikouPose79
+.4byte sRaikouPose80
+.4byte sRaikouPose81
+.4byte sRaikouPose82
+.4byte sRaikouPose83
+.4byte sRaikouPose84
+.4byte sRaikouPose85
+.4byte sRaikouPose86
+.4byte sRaikouPose87
+.4byte sRaikouPose88
+.4byte sRaikouPose89
+.4byte sRaikouPose90
+.4byte sRaikouPose91
+.4byte sRaikouPose92
+.4byte sRaikouPose93
+.4byte sRaikouPose94
+.4byte sRaikouPose95
+.4byte sRaikouPose96
+.4byte sRaikouPose97
+.4byte sRaikouPose98
+.4byte sRaikouPose99
+.4byte sRaikouPose100
+.4byte sRaikouPose101
+.4byte sRaikouPose102
+.4byte sRaikouPose103
+.4byte sRaikouPose104
+.4byte sRaikouPose105
+.4byte sRaikouPose106
+.4byte sRaikouPose107
+.4byte sRaikouPose108
+.4byte sRaikouPose109
+.4byte sRaikouPose110
+.4byte sRaikouPose111
+.4byte sRaikouPose112
+.4byte sRaikouPose113
+.4byte sRaikouPose114
+.4byte sRaikouPose115
+.4byte sRaikouPose116
+.4byte sRaikouPose117
+.4byte sRaikouPose118
+.4byte sRaikouPose119
+.4byte sRaikouPose120
+.4byte sRaikouPose121
+.4byte sRaikouPose122
+.4byte sRaikouPose123
+.4byte sRaikouPose124
+.4byte sRaikouPose125
+.4byte sRaikouPose126
+.4byte sRaikouPose127
+.4byte sRaikouPose128
+.4byte sRaikouPose129
+.4byte sRaikouPose130
+.4byte sRaikouPose131
+.4byte sRaikouPose132
+.4byte sRaikouPose133
+.4byte sRaikouPose134
+.4byte sRaikouPose135
+.4byte sRaikouPose136
+.4byte sRaikouPose137
+.4byte sRaikouPose138
+.4byte sRaikouPose139
+.4byte sRaikouPose140
+.4byte sRaikouPose141
+.4byte sRaikouPose142
+.4byte sRaikouPose143
+.4byte sRaikouPose144
+.4byte sRaikouPose145
+.4byte sRaikouPose146
+.4byte sRaikouPose147
+.4byte sRaikouPose148
+.4byte sRaikouPose149
+.4byte sRaikouPose150
+.4byte sRaikouPose151
+.4byte sRaikouPose152
+.4byte sRaikouPose153
+.4byte sRaikouPose154
+.4byte sRaikouPose155
+.4byte sRaikouPose156
+.4byte sRaikouPose157
+.4byte sRaikouPose158
+.4byte sRaikouPose159
+.4byte sRaikouPose160
+.4byte sRaikouPose161
+.4byte sRaikouPose162
+.4byte sRaikouPose163
+.4byte sRaikouPose164
+.4byte sRaikouPose165
+.4byte sRaikouPose166
+.4byte sRaikouPose167
+.4byte sRaikouPose168
+.4byte sRaikouPose169
+.4byte sRaikouPose170
+.4byte sRaikouPose171
+.4byte sRaikouPose172
+.4byte sRaikouPose173
+.4byte sRaikouPose174
+.4byte sRaikouPose175
+.4byte sRaikouPose176
+.4byte sRaikouPose177
+.4byte sRaikouPose178
+.4byte sRaikouPose179
+.4byte sRaikouPose180
+.4byte sRaikouPose181
+.4byte sRaikouPose182
+.4byte sRaikouPose183
+.4byte sRaikouPose184
+.4byte sRaikouPose185
+.4byte sRaikouPose186
+.4byte sRaikouPose187
+.4byte sRaikouPose188
+.4byte sRaikouPose189
+.4byte sRaikouPose190
+.4byte sRaikouPose191
+.4byte sRaikouPose192
+.4byte sRaikouPose193
+.4byte sRaikouPose194
+.4byte sRaikouPose195
+.4byte sRaikouPose196
+.4byte sRaikouPose197
+.4byte sRaikouPose198
+.4byte sRaikouPose199
+.4byte sRaikouPose200
+.4byte sRaikouPose201
+.4byte sRaikouPose202
+.4byte sRaikouPose203
+.4byte sRaikouPose204
+.4byte sRaikouPose205
+.4byte sRaikouPose206
+.4byte sRaikouPose207
+.4byte sRaikouPose208
+.4byte sRaikouPose209
+.4byte sRaikouPose210
+.4byte sRaikouPose211
+.4byte sRaikouPose212
+.4byte sRaikouPose213
+.4byte sRaikouPose214
+.4byte sRaikouPose215
+.4byte sRaikouPose216
+.4byte sRaikouPose217
+.4byte sRaikouPose218
+.4byte sRaikouPose219
+.4byte sRaikouPose220
+.4byte sRaikouPose221
+.4byte sRaikouPose222
+.4byte sRaikouPose223
+.4byte sRaikouPose224
+.4byte sRaikouPose225
+.4byte sRaikouPose226
+.4byte sRaikouPose227
+.4byte sRaikouPose228
+.4byte sRaikouPose229
+.4byte sRaikouPose230
+.4byte sRaikouPose231
+.4byte sRaikouPose232
+.4byte sRaikouPose233
+.4byte sRaikouPose234
+.4byte sRaikouPose235
+.4byte sRaikouPose236
+.4byte sRaikouPose237
+.4byte sRaikouPose238
+.4byte sRaikouPose239
+.4byte sRaikouPose240
+.4byte sRaikouPose241
+.4byte sRaikouPose242
+.4byte sRaikouPose243
+.4byte sRaikouPose244
+.4byte sRaikouPose245
+.4byte sRaikouPose246
+.4byte sRaikouPose247
+.4byte sRaikouPose248
+.4byte sRaikouPose249
+.4byte sRaikouPose250
+.4byte sRaikouPose251
+.4byte sRaikouPose252
+.4byte sRaikouPose253
+.4byte sRaikouPose254
+.4byte sRaikouPose255
+.4byte sRaikouPose256
+.4byte sRaikouPose257
+.4byte sRaikouPose258
+.4byte sRaikouPose259
+.4byte sRaikouPose260
+.4byte sRaikouPose261
+.4byte sRaikouPose262
+.4byte sRaikouPose263
+.4byte sRaikouPose264
+.4byte sRaikouPose265
+.4byte sRaikouPose266
+.4byte sRaikouPose267
+.4byte sRaikouPose268
+.4byte sRaikouPose269
+.4byte sRaikouPose270
+.4byte sRaikouPose271
+.4byte sRaikouPose272
+sAxPositionsRaikou:
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,   -3, 	  -6,    4, 	   6,    0, 	   0,  -12
+.2byte    0,   -3, 	  -7,    0, 	   6,    4, 	   0,  -12
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    9,   -4, 	  12,    2, 	  -3,    2, 	  -3,   -9
+.2byte    9,   -4, 	   7,   -1, 	   5,    5, 	  -3,  -12
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte   13,   -5, 	  13,   -3, 	   0,    2, 	  -1,   -9
+.2byte   13,   -5, 	   0,   -2, 	  11,    2, 	  -1,   -9
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -14, 	   6,   -8, 	   5,   -1, 	  -1,  -10
+.2byte    8,  -14, 	   0,   -4, 	  14,   -4, 	  -1,  -10
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    0,  -14, 	   6,   -1, 	  -6,   -5, 	  -1,   -9
+.2byte    0,  -15, 	   6,   -4, 	  -6,   -1, 	   1,  -10
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte   -8,  -14, 	  -6,   -8, 	  -5,   -1, 	   1,  -10
+.2byte   -8,  -14, 	   0,   -4, 	 -14,   -4, 	   1,  -10
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte  -13,   -5, 	 -13,   -3, 	   0,    2, 	   1,   -9
+.2byte  -13,   -5, 	   0,   -2, 	 -11,    2, 	   1,   -9
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte   -9,   -4, 	 -12,    2, 	   3,    2, 	   3,   -9
+.2byte   -9,   -4, 	  -7,   -1, 	  -5,    5, 	   3,  -12
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,   -3, 	  -6,    4, 	   6,    0, 	   0,  -12
+.2byte    0,   -3, 	  -7,    0, 	   6,    4, 	   0,  -12
+.2byte    0,   -4, 	 -10,    0, 	  10,    0, 	   0,  -15
+.2byte    0,   -1, 	  -8,    2, 	   8,    2, 	   0,  -12
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    9,   -4, 	  12,    2, 	  -3,    2, 	  -3,   -9
+.2byte    9,   -4, 	   7,   -1, 	   5,    5, 	  -3,  -12
+.2byte   11,   -6, 	  17,   -3, 	   7,    2, 	  -2,  -13
+.2byte   12,   -1, 	  16,   -2, 	   3,    3, 	  -2,   -8
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte   13,   -5, 	  13,   -3, 	   0,    2, 	  -1,   -9
+.2byte   13,   -5, 	   0,   -2, 	  11,    2, 	  -1,   -9
+.2byte   15,   -7, 	  19,   -6, 	  15,   -1, 	   1,  -10
+.2byte   14,    0, 	  12,    0, 	   9,    2, 	   0,   -5
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -14, 	   6,   -8, 	   5,   -1, 	  -1,  -10
+.2byte    8,  -14, 	   0,   -4, 	  14,   -4, 	  -1,  -10
+.2byte    8,  -17, 	   4,  -17, 	  13,  -11, 	  -2,  -11
+.2byte   11,   -7, 	   1,  -10, 	  10,   -5, 	  -2,   -8
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    0,  -14, 	   6,   -1, 	  -6,   -5, 	  -1,   -9
+.2byte    0,  -15, 	   6,   -4, 	  -6,   -1, 	   1,  -10
+.2byte    0,  -15, 	   7,  -15, 	  -7,  -15, 	   0,  -12
+.2byte    0,  -10, 	   8,   -5, 	  -8,   -5, 	   0,   -9
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte   -8,  -14, 	  -6,   -8, 	  -5,   -1, 	   1,  -10
+.2byte   -8,  -14, 	   0,   -4, 	 -14,   -4, 	   1,  -10
+.2byte   -8,  -17, 	  -4,  -17, 	 -13,  -11, 	   2,  -11
+.2byte  -11,   -7, 	  -1,  -10, 	 -10,   -5, 	   2,   -8
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte  -13,   -5, 	 -13,   -3, 	   0,    2, 	   1,   -9
+.2byte  -13,   -5, 	   0,   -2, 	 -11,    2, 	   1,   -9
+.2byte  -15,   -7, 	 -19,   -6, 	 -15,   -1, 	  -1,  -10
+.2byte  -14,    0, 	 -12,    0, 	  -9,    2, 	   0,   -5
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte   -9,   -4, 	 -12,    2, 	   3,    2, 	   3,   -9
+.2byte   -9,   -4, 	  -7,   -1, 	  -5,    5, 	   3,  -12
+.2byte  -11,   -6, 	 -17,   -3, 	  -7,    2, 	   2,  -13
+.2byte  -12,   -1, 	 -16,   -2, 	  -3,    3, 	   2,   -8
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,   -3, 	  -6,    4, 	   6,    0, 	   0,  -12
+.2byte    0,   -3, 	  -7,    0, 	   6,    4, 	   0,  -12
+.2byte    0,   -4, 	 -10,    0, 	  10,    0, 	   0,  -15
+.2byte    0,   -1, 	  -8,    2, 	   8,    2, 	   0,  -12
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    9,   -4, 	  12,    2, 	  -3,    2, 	  -3,   -9
+.2byte    9,   -4, 	   7,   -1, 	   5,    5, 	  -3,  -12
+.2byte   11,   -6, 	  17,   -3, 	   7,    2, 	  -2,  -13
+.2byte   12,   -1, 	  16,   -2, 	   3,    3, 	  -2,   -8
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte   13,   -5, 	  13,   -3, 	   0,    2, 	  -1,   -9
+.2byte   13,   -5, 	   0,   -2, 	  11,    2, 	  -1,   -9
+.2byte   15,   -7, 	  19,   -6, 	  15,   -1, 	   1,  -10
+.2byte   14,    0, 	  12,    0, 	   9,    2, 	   0,   -5
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -14, 	   6,   -8, 	   5,   -1, 	  -1,  -10
+.2byte    8,  -14, 	   0,   -4, 	  14,   -4, 	  -1,  -10
+.2byte    8,  -17, 	   4,  -17, 	  13,  -11, 	  -2,  -11
+.2byte   11,   -7, 	   1,  -10, 	  10,   -5, 	  -2,   -8
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    0,  -14, 	   6,   -1, 	  -6,   -5, 	  -1,   -9
+.2byte    0,  -15, 	   6,   -4, 	  -6,   -1, 	   1,  -10
+.2byte    0,  -15, 	   7,  -15, 	  -7,  -15, 	   0,  -12
+.2byte    0,  -10, 	   8,   -5, 	  -8,   -5, 	   0,   -9
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte   -8,  -14, 	  -6,   -8, 	  -5,   -1, 	   1,  -10
+.2byte   -8,  -14, 	   0,   -4, 	 -14,   -4, 	   1,  -10
+.2byte   -8,  -17, 	  -4,  -17, 	 -13,  -11, 	   2,  -11
+.2byte  -11,   -7, 	  -1,  -10, 	 -10,   -5, 	   2,   -8
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte  -13,   -5, 	 -13,   -3, 	   0,    2, 	   1,   -9
+.2byte  -13,   -5, 	   0,   -2, 	 -11,    2, 	   1,   -9
+.2byte  -15,   -7, 	 -19,   -6, 	 -15,   -1, 	  -1,  -10
+.2byte  -14,    0, 	 -12,    0, 	  -9,    2, 	   0,   -5
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte   -9,   -4, 	 -12,    2, 	   3,    2, 	   3,   -9
+.2byte   -9,   -4, 	  -7,   -1, 	  -5,    5, 	   3,  -12
+.2byte  -11,   -6, 	 -17,   -3, 	  -7,    2, 	   2,  -13
+.2byte  -12,   -1, 	 -16,   -2, 	  -3,    3, 	   2,   -8
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,  -10, 	  -9,    2, 	   9,    2, 	   0,  -16
+.2byte    0,    2, 	  -9,    2, 	   9,    4, 	   0,  -10
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    7,  -12, 	  11,   -1, 	   0,    3, 	  -4,  -15
+.2byte   11,    1, 	  13,   -4, 	   2,    4, 	  -2,  -11
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte   10,  -16, 	   8,   -3, 	   7,    2, 	  -4,  -10
+.2byte   13,   -2, 	  11,   -3, 	   9,    2, 	   0,  -11
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -22, 	   1,   -9, 	  11,   -4, 	  -2,  -11
+.2byte   10,  -11, 	   0,  -11, 	  12,   -5, 	   0,   -9
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    0,  -25, 	   8,   -5, 	  -8,   -5, 	   0,  -13
+.2byte    0,  -11, 	   8,   -7, 	  -7,   -8, 	   0,  -12
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte   -8,  -22, 	  -1,   -9, 	 -11,   -4, 	   2,  -11
+.2byte  -10,  -11, 	   0,  -11, 	 -12,   -5, 	   0,   -9
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte  -10,  -16, 	  -8,   -3, 	  -7,    2, 	   4,  -10
+.2byte  -13,   -2, 	 -11,   -3, 	  -9,    2, 	   0,  -11
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte   -7,  -12, 	 -11,   -1, 	   0,    3, 	   4,  -15
+.2byte  -11,    1, 	 -13,   -4, 	  -2,    4, 	   2,  -11
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,  -10, 	  -9,    2, 	   9,    2, 	   0,  -16
+.2byte    0,    1, 	  -9,    2, 	   9,    2, 	   0,  -11
+.2byte    0,    1, 	  -9,    2, 	   9,    2, 	   0,   -9
+.2byte    0,    1, 	  -9,    2, 	   9,    2, 	   0,  -11
+.2byte    0,    1, 	  -9,    2, 	   9,    2, 	   0,   -9
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    7,  -12, 	  11,   -1, 	   0,    3, 	  -4,  -15
+.2byte   10,   -1, 	  12,   -1, 	   2,    3, 	  -1,  -11
+.2byte   12,   -1, 	  15,   -5, 	   2,    3, 	   0,  -10
+.2byte   10,   -1, 	  12,   -1, 	   2,    3, 	  -1,  -11
+.2byte   12,   -1, 	  15,   -5, 	   2,    3, 	   0,  -10
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte   10,  -16, 	   8,   -3, 	   7,    2, 	  -4,  -10
+.2byte   10,   -2, 	  12,   -2, 	   8,    2, 	   0,   -9
+.2byte   12,   -1, 	  10,   -1, 	   8,    2, 	   2,   -8
+.2byte   10,   -2, 	  12,   -2, 	   8,    2, 	   0,   -9
+.2byte   12,   -1, 	  10,   -1, 	   8,    2, 	   2,   -8
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -22, 	   1,   -9, 	  11,   -4, 	  -2,  -11
+.2byte   10,   -9, 	   2,  -10, 	  12,   -4, 	   1,  -10
+.2byte   12,  -10, 	   3,  -11, 	  12,   -4, 	   0,  -10
+.2byte   10,   -9, 	   2,  -10, 	  12,   -4, 	   1,  -10
+.2byte   12,  -10, 	   3,  -11, 	  12,   -4, 	   0,  -10
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    0,  -25, 	   8,   -5, 	  -8,   -5, 	   0,  -13
+.2byte    0,   -8, 	   8,   -7, 	  -8,   -5, 	   0,   -9
+.2byte    0,  -13, 	   7,   -6, 	  -7,   -4, 	   0,  -12
+.2byte    0,   -8, 	   8,   -7, 	  -8,   -5, 	   0,   -9
+.2byte    0,  -13, 	   7,   -6, 	  -7,   -4, 	   0,  -12
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte   -8,  -22, 	  -1,   -9, 	 -11,   -4, 	   2,  -11
+.2byte  -10,   -9, 	  -2,  -10, 	 -12,   -4, 	  -1,  -10
+.2byte  -12,  -10, 	  -3,  -11, 	 -12,   -4, 	   0,  -10
+.2byte  -10,   -9, 	  -2,  -10, 	 -12,   -4, 	  -1,  -10
+.2byte  -12,  -10, 	  -3,  -11, 	 -12,   -4, 	   0,  -10
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte  -10,  -16, 	  -8,   -3, 	  -7,    2, 	   4,  -10
+.2byte  -10,   -2, 	 -12,   -2, 	  -8,    2, 	   0,   -9
+.2byte  -12,   -1, 	 -10,   -1, 	  -8,    2, 	  -2,   -8
+.2byte  -10,   -2, 	 -12,   -2, 	  -8,    2, 	   0,   -9
+.2byte  -12,   -1, 	 -10,   -1, 	  -8,    2, 	  -2,   -8
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte   -7,  -12, 	 -11,   -1, 	   0,    3, 	   4,  -15
+.2byte  -10,   -1, 	 -12,   -1, 	  -2,    3, 	   1,  -11
+.2byte  -12,   -1, 	 -15,   -5, 	  -2,    3, 	   0,  -10
+.2byte  -10,   -1, 	 -12,   -1, 	  -2,    3, 	   1,  -11
+.2byte  -12,   -1, 	 -15,   -5, 	  -2,    3, 	   0,  -10
+.2byte   -8,   -1, 	  -9,    2, 	  -8,    2, 	   2,   -9
+.2byte   -8,   -1, 	  -9,    2, 	  -8,    2, 	   1,   -9
+.2byte    0,    1, 	  -9,    3, 	   9,    3, 	   0,   -8
+.2byte    9,    0, 	  12,    0, 	   1,    4, 	  -1,   -8
+.2byte   12,   -3, 	  10,   -3, 	  10,    1, 	   0,   -8
+.2byte   10,  -11, 	   3,   -7, 	   9,   -3, 	   1,   -9
+.2byte    0,  -15, 	   8,   -6, 	  -8,   -6, 	   0,  -10
+.2byte  -11,  -11, 	  -4,   -7, 	 -10,   -3, 	  -2,   -9
+.2byte  -13,   -3, 	 -11,   -3, 	 -11,    1, 	  -1,   -8
+.2byte  -10,    0, 	 -13,    0, 	  -2,    4, 	   0,   -8
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,  -10, 	  -9,    2, 	   9,    2, 	   0,  -16
+.2byte    0,    2, 	  -9,    2, 	   9,    4, 	   0,  -10
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    7,  -12, 	  11,   -1, 	   0,    3, 	  -4,  -15
+.2byte   11,    1, 	  13,   -4, 	   2,    4, 	  -2,  -11
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte   10,  -16, 	   8,   -3, 	   7,    2, 	  -4,  -10
+.2byte   13,   -2, 	  11,   -3, 	   9,    2, 	   0,  -11
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -22, 	   1,   -9, 	  11,   -4, 	  -2,  -11
+.2byte   10,  -11, 	   0,  -11, 	  12,   -5, 	   0,   -9
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    0,  -25, 	   8,   -5, 	  -8,   -5, 	   0,  -13
+.2byte    0,  -11, 	   8,   -7, 	  -7,   -8, 	   0,  -12
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte   -8,  -22, 	  -1,   -9, 	 -11,   -4, 	   2,  -11
+.2byte  -10,  -11, 	   0,  -11, 	 -12,   -5, 	   0,   -9
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte  -10,  -16, 	  -8,   -3, 	  -7,    2, 	   4,  -10
+.2byte  -13,   -2, 	 -11,   -3, 	  -9,    2, 	   0,  -11
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte   -7,  -12, 	 -11,   -1, 	   0,    3, 	   4,  -15
+.2byte  -11,    1, 	 -13,   -4, 	  -2,    4, 	   2,  -11
+.2byte    0,    2, 	  -9,    2, 	   9,    4, 	   0,  -10
+.2byte  -11,    1, 	 -13,   -4, 	  -2,    4, 	   2,  -11
+.2byte  -13,   -2, 	 -11,   -3, 	  -9,    2, 	   0,  -11
+.2byte  -10,  -11, 	   0,  -11, 	 -12,   -5, 	   0,   -9
+.2byte    0,  -10, 	   8,   -6, 	  -7,   -7, 	   0,  -11
+.2byte   10,  -11, 	   0,  -11, 	  12,   -5, 	   0,   -9
+.2byte   13,   -2, 	  11,   -3, 	   9,    2, 	   0,  -11
+.2byte   11,    1, 	  13,   -4, 	   2,    4, 	  -2,  -11
+.2byte    0,  -10, 	  -9,    2, 	   9,    2, 	   0,  -16
+.2byte    8,  -12, 	  12,   -1, 	   1,    3, 	  -3,  -15
+.2byte   12,  -16, 	  10,   -3, 	   9,    2, 	  -2,  -10
+.2byte    8,  -22, 	   1,   -9, 	  11,   -4, 	  -2,  -11
+.2byte    0,  -25, 	   8,   -5, 	  -8,   -5, 	   0,  -13
+.2byte   -9,  -22, 	  -2,   -9, 	 -12,   -4, 	   1,  -11
+.2byte  -12,  -16, 	 -10,   -3, 	  -9,    2, 	   2,  -10
+.2byte   -8,  -12, 	 -12,   -1, 	  -1,    3, 	   3,  -15
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,  -10, 	  -9,    2, 	   9,    2, 	   0,  -16
+.2byte    0,    2, 	  -9,    2, 	   9,    4, 	   0,  -10
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    7,  -12, 	  11,   -1, 	   0,    3, 	  -4,  -15
+.2byte   11,    1, 	  13,   -4, 	   2,    4, 	  -2,  -11
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte   10,  -16, 	   8,   -3, 	   7,    2, 	  -4,  -10
+.2byte   13,   -2, 	  11,   -3, 	   9,    2, 	   0,  -11
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -22, 	   1,   -9, 	  11,   -4, 	  -2,  -11
+.2byte   10,  -11, 	   0,  -11, 	  12,   -5, 	   0,   -9
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    0,  -25, 	   8,   -5, 	  -8,   -5, 	   0,  -13
+.2byte    0,  -11, 	   8,   -7, 	  -7,   -8, 	   0,  -12
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte   -8,  -22, 	  -1,   -9, 	 -11,   -4, 	   2,  -11
+.2byte  -10,  -11, 	   0,  -11, 	 -12,   -5, 	   0,   -9
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte  -10,  -16, 	  -8,   -3, 	  -7,    2, 	   4,  -10
+.2byte  -13,   -2, 	 -11,   -3, 	  -9,    2, 	   0,  -11
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte   -7,  -12, 	 -11,   -1, 	   0,    3, 	   4,  -15
+.2byte  -11,    1, 	 -13,   -4, 	  -2,    4, 	   2,  -11
+.2byte    0,    2, 	  -9,    2, 	   9,    4, 	   0,  -10
+.2byte  -11,    1, 	 -13,   -4, 	  -2,    4, 	   2,  -11
+.2byte  -13,   -2, 	 -11,   -3, 	  -9,    2, 	   0,  -11
+.2byte  -10,  -11, 	   0,  -11, 	 -12,   -5, 	   0,   -9
+.2byte    0,  -10, 	   8,   -6, 	  -7,   -7, 	   0,  -11
+.2byte   10,  -11, 	   0,  -11, 	  12,   -5, 	   0,   -9
+.2byte   13,   -2, 	  11,   -3, 	   9,    2, 	   0,  -11
+.2byte   11,    1, 	  13,   -4, 	   2,    4, 	  -2,  -11
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte   -9,   -6, 	 -11,   -1, 	   0,    3, 	   2,  -12
+.2byte  -13,   -7, 	  -8,   -3, 	  -8,    2, 	   1,  -11
+.2byte   -8,  -15, 	  -1,   -9, 	 -11,   -4, 	   1,  -11
+.2byte    0,  -16, 	   8,   -6, 	  -8,   -6, 	   0,  -11
+.2byte    8,  -15, 	   1,   -9, 	  11,   -4, 	  -1,  -11
+.2byte   13,   -7, 	   8,   -3, 	   8,    2, 	  -1,  -11
+.2byte    9,   -6, 	  11,   -1, 	   0,    3, 	  -2,  -12
+.2byte    0,   -5, 	  -9,    2, 	   9,    2, 	   0,  -14
+.2byte    0,  -10, 	  -9,    2, 	   9,    2, 	   0,  -16
+.2byte    0,  -10, 	  -9,    2, 	   9,    2, 	   0,  -16
+.2byte    0,   -8, 	  10,   -7, 	 -10,   -7, 	   0,  -16
+.2byte    0,   -8, 	  10,   -7, 	 -10,   -7, 	   0,  -16
+.2byte    0,    2, 	  -9,    2, 	   9,    4, 	   0,  -10
+sRaikouAnimTable1:
+.4byte sRaikouAnims_1_1
+.4byte sRaikouAnims_1_2
+.4byte sRaikouAnims_1_3
+.4byte sRaikouAnims_1_4
+.4byte sRaikouAnims_1_5
+.4byte sRaikouAnims_1_6
+.4byte sRaikouAnims_1_7
+.4byte sRaikouAnims_1_8
+sRaikouAnimTable2:
+.4byte sRaikouAnims_2_1
+.4byte sRaikouAnims_2_2
+.4byte sRaikouAnims_2_3
+.4byte sRaikouAnims_2_4
+.4byte sRaikouAnims_2_5
+.4byte sRaikouAnims_2_6
+.4byte sRaikouAnims_2_7
+.4byte sRaikouAnims_2_8
+sRaikouAnimTable3:
+.4byte sRaikouAnims_3_1
+.4byte sRaikouAnims_3_2
+.4byte sRaikouAnims_3_3
+.4byte sRaikouAnims_3_4
+.4byte sRaikouAnims_3_5
+.4byte sRaikouAnims_3_6
+.4byte sRaikouAnims_3_7
+.4byte sRaikouAnims_3_8
+sRaikouAnimTable4:
+.4byte sRaikouAnims_4_1
+.4byte sRaikouAnims_4_2
+.4byte sRaikouAnims_4_3
+.4byte sRaikouAnims_4_4
+.4byte sRaikouAnims_4_5
+.4byte sRaikouAnims_4_6
+.4byte sRaikouAnims_4_7
+.4byte sRaikouAnims_4_8
+sRaikouAnimTable5:
+.4byte sRaikouAnims_5_1
+.4byte sRaikouAnims_5_2
+.4byte sRaikouAnims_5_3
+.4byte sRaikouAnims_5_4
+.4byte sRaikouAnims_5_5
+.4byte sRaikouAnims_5_6
+.4byte sRaikouAnims_5_7
+.4byte sRaikouAnims_5_8
+sRaikouAnimTable6:
+.4byte sRaikouAnims_6_1
+.4byte sRaikouAnims_6_1
+.4byte sRaikouAnims_6_1
+.4byte sRaikouAnims_6_1
+.4byte sRaikouAnims_6_1
+.4byte sRaikouAnims_6_1
+.4byte sRaikouAnims_6_1
+.4byte sRaikouAnims_6_1
+sRaikouAnimTable7:
+.4byte sRaikouAnims_7_1
+.4byte sRaikouAnims_7_2
+.4byte sRaikouAnims_7_3
+.4byte sRaikouAnims_7_4
+.4byte sRaikouAnims_7_5
+.4byte sRaikouAnims_7_6
+.4byte sRaikouAnims_7_7
+.4byte sRaikouAnims_7_8
+sRaikouAnimTable8:
+.4byte sRaikouAnims_8_1
+.4byte sRaikouAnims_8_2
+.4byte sRaikouAnims_8_3
+.4byte sRaikouAnims_8_4
+.4byte sRaikouAnims_8_5
+.4byte sRaikouAnims_8_6
+.4byte sRaikouAnims_8_7
+.4byte sRaikouAnims_8_8
+sRaikouAnimTable9:
+.4byte sRaikouAnims_9_1
+.4byte sRaikouAnims_9_2
+.4byte sRaikouAnims_9_3
+.4byte sRaikouAnims_9_4
+.4byte sRaikouAnims_9_5
+.4byte sRaikouAnims_9_6
+.4byte sRaikouAnims_9_7
+.4byte sRaikouAnims_9_8
+sRaikouAnimTable10:
+.4byte sRaikouAnims_10_1
+.4byte sRaikouAnims_10_2
+.4byte sRaikouAnims_10_3
+.4byte sRaikouAnims_10_4
+.4byte sRaikouAnims_10_5
+.4byte sRaikouAnims_10_6
+.4byte sRaikouAnims_10_7
+.4byte sRaikouAnims_10_8
+sRaikouAnimTable11:
+.4byte sRaikouAnims_11_1
+.4byte sRaikouAnims_11_2
+.4byte sRaikouAnims_11_3
+.4byte sRaikouAnims_11_4
+.4byte sRaikouAnims_11_5
+.4byte sRaikouAnims_11_6
+.4byte sRaikouAnims_11_7
+.4byte sRaikouAnims_11_8
+sRaikouAnimTable12:
+.4byte sRaikouAnims_12_1
+.4byte sRaikouAnims_12_2
+.4byte sRaikouAnims_12_3
+.4byte sRaikouAnims_12_4
+.4byte sRaikouAnims_12_5
+.4byte sRaikouAnims_12_6
+.4byte sRaikouAnims_12_7
+.4byte sRaikouAnims_12_8
+sRaikouAnimTable13:
+.4byte sRaikouAnims_13_1
+.4byte sRaikouAnims_13_2
+.4byte sRaikouAnims_13_3
+.4byte sRaikouAnims_13_4
+.4byte sRaikouAnims_13_5
+.4byte sRaikouAnims_13_6
+.4byte sRaikouAnims_13_7
+.4byte sRaikouAnims_13_8
+sRaikouAnimTable14:
+.4byte sRaikouAnims_14_1
+.4byte sRaikouAnims_14_2
+.4byte sRaikouAnims_14_3
+.4byte sRaikouAnims_14_4
+.4byte sRaikouAnims_14_5
+.4byte sRaikouAnims_14_6
+.4byte sRaikouAnims_14_7
+.4byte sRaikouAnims_14_8
+sAxAnimationsRaikou:
+.4byte sRaikouAnimTable1
+.4byte sRaikouAnimTable2
+.4byte sRaikouAnimTable3
+.4byte sRaikouAnimTable4
+.4byte sRaikouAnimTable5
+.4byte sRaikouAnimTable6
+.4byte sRaikouAnimTable7
+.4byte sRaikouAnimTable8
+.4byte sRaikouAnimTable9
+.4byte sRaikouAnimTable10
+.4byte sRaikouAnimTable11
+.4byte sRaikouAnimTable12
+.4byte sRaikouAnimTable13
+.4byte sRaikouAnimTable14
+sAxSpritesRaikou:
+.4byte sRaikouSprites1
+.4byte sRaikouSprites2
+.4byte sRaikouSprites3
+.4byte sRaikouSprites4
+.4byte sRaikouSprites5
+.4byte sRaikouSprites6
+.4byte sRaikouSprites7
+.4byte sRaikouSprites8
+.4byte sRaikouSprites9
+.4byte sRaikouSprites10
+.4byte sRaikouSprites11
+.4byte sRaikouSprites12
+.4byte sRaikouSprites13
+.4byte sRaikouSprites14
+.4byte sRaikouSprites15
+.4byte sRaikouSprites16
+.4byte sRaikouSprites17
+.4byte sRaikouSprites18
+.4byte sRaikouSprites19
+.4byte sRaikouSprites20
+.4byte sRaikouSprites21
+.4byte sRaikouSprites22
+.4byte sRaikouSprites23
+.4byte sRaikouSprites24
+.4byte sRaikouSprites25
+.4byte sRaikouSprites26
+.4byte sRaikouSprites27
+.4byte sRaikouSprites28
+.4byte sRaikouSprites29
+.4byte sRaikouSprites30
+.4byte sRaikouSprites31
+.4byte sRaikouSprites32
+.4byte sRaikouSprites33
+.4byte sRaikouSprites34
+.4byte sRaikouSprites35
+.4byte sRaikouSprites36
+.4byte sRaikouSprites37
+.4byte sRaikouSprites38
+.4byte sRaikouSprites39
+.4byte sRaikouSprites40
+.4byte sRaikouSprites41
+.4byte sRaikouSprites42
+.4byte sRaikouSprites43
+.4byte sRaikouSprites44
+.4byte sRaikouSprites45
+.4byte sRaikouSprites46
+.4byte sRaikouSprites47
+.4byte sRaikouSprites48
+.4byte sRaikouSprites49
+.4byte sRaikouSprites50
+.4byte sRaikouSprites51
+.4byte sRaikouSprites52
+.4byte sRaikouSprites53
+.4byte sRaikouSprites54
+.4byte sRaikouSprites55
+.4byte sRaikouSprites56
+.4byte sRaikouSprites57
+.4byte sRaikouSprites58
+.4byte sRaikouSprites59
+.4byte sRaikouSprites60
+.4byte sRaikouSprites61
+.4byte sRaikouSprites62
+.4byte sRaikouSprites63
+.4byte sRaikouSprites64
+.4byte sRaikouSprites65
+.4byte sRaikouSprites66
+.4byte sRaikouSprites67
+.4byte sRaikouSprites68
+.4byte sRaikouSprites69
+.4byte sRaikouSprites70
+.4byte sRaikouSprites71
+.4byte sRaikouSprites72
+.4byte sRaikouSprites73
+.4byte sRaikouSprites74
+.4byte sRaikouSprites75
+.4byte sRaikouSprites76
+.4byte sRaikouSprites77
+.4byte sRaikouSprites78
+.4byte sRaikouSprites79
+.4byte sRaikouSprites80
+.4byte sRaikouSprites81
+.4byte sRaikouSprites82
+.4byte sRaikouSprites83
+.4byte sRaikouSprites84
+.4byte sRaikouSprites85
+.4byte sRaikouSprites86
+.4byte sRaikouSprites87
+.4byte sRaikouSprites88
+.4byte sRaikouSprites89
+.4byte sRaikouSprites90
+.4byte sRaikouSprites91
+.4byte sRaikouSprites92
+.4byte sRaikouSprites93
+.4byte sRaikouSprites94
+.4byte sRaikouSprites95
+.4byte sRaikouSprites96
+.4byte sRaikouSprites97
+.4byte sRaikouSprites98
+.4byte sRaikouSprites99
+.4byte sRaikouSprites100
+.4byte sRaikouSprites101
+.4byte sRaikouSprites102
+.4byte sRaikouSprites103
+.4byte sRaikouSprites104
+.4byte sRaikouSprites105
+.4byte sRaikouSprites106
+.4byte sRaikouSprites107
+.4byte sRaikouSprites108
+.4byte sRaikouSprites109
+.4byte sRaikouSprites110
+.4byte sRaikouSprites111
+.4byte sRaikouSprites112
+.4byte sRaikouSprites113
+.4byte sRaikouSprites114
+.4byte sRaikouSprites115
+.4byte sRaikouSprites116
+.4byte sRaikouSprites117
+.4byte sRaikouSprites118
+.4byte sRaikouSprites119
+.4byte sRaikouSprites120
+.4byte sRaikouSprites121
+.4byte sRaikouSprites122
+.4byte sRaikouSprites123
+.4byte sRaikouSprites124
+.4byte sRaikouSprites125
+.4byte sRaikouSprites126
+.4byte sRaikouSprites127
+.4byte sRaikouSprites128
+.4byte sRaikouSprites129
+.4byte sRaikouSprites130
+.4byte sRaikouSprites131
+.4byte sRaikouSprites132
+.4byte sRaikouSprites133
+.4byte sRaikouSprites134
+.4byte sRaikouSprites135
+.4byte sRaikouSprites136
+.4byte sRaikouSprites137
+.4byte sRaikouSprites138
+.4byte sRaikouSprites139
+.4byte sRaikouSprites140
+.4byte sRaikouSprites141
+.4byte sRaikouSprites142
+.4byte sRaikouSprites143
+.4byte sRaikouSprites144
+.4byte sRaikouSprites145
+.4byte sRaikouSprites146
+.4byte sRaikouSprites147
+.4byte sRaikouSprites148
+.4byte sRaikouSprites149
+.4byte sRaikouSprites150
+.4byte sRaikouSprites151
+.4byte sRaikouSprites152
+.4byte sRaikouSprites153
+.4byte sRaikouSprites154
+.4byte sRaikouSprites155
+.4byte sRaikouSprites156
+.4byte sRaikouSprites157
+.4byte sRaikouSprites158
+.4byte sRaikouSprites159
+.4byte sRaikouSprites160
+.4byte sRaikouSprites161
+.4byte sRaikouSprites162
+.4byte sRaikouSprites163
+.4byte sRaikouSprites164
+.4byte sRaikouSprites165
+.4byte sRaikouSprites166
+sAxMainRaikou:
+ax_main sAxPosesRaikou, sAxAnimationsRaikou, 14, sAxSpritesRaikou, sAxPositionsRaikou

--- a/data/ax/ralts.inc
+++ b/data/ax/ralts.inc
@@ -1,0 +1,2166 @@
+.global gAxRalts
+gAxRalts:
+ax_siro sAxMainRalts
+sRaltsPose1:
+ax_pose 0, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose2:
+ax_pose 1, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose3:
+ax_pose 2, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose4:
+ax_pose 3, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose5:
+ax_pose 4, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose6:
+ax_pose 5, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose7:
+ax_pose 6, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose8:
+ax_pose 7, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose9:
+ax_pose 8, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose10:
+ax_pose 9, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose11:
+ax_pose 10, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose12:
+ax_pose 11, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose13:
+ax_pose 12, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose14:
+ax_pose 13, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose15:
+ax_pose 14, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose16:
+ax_pose 9, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose17:
+ax_pose 10, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose18:
+ax_pose 11, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose19:
+ax_pose 6, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose21:
+ax_pose 8, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose22:
+ax_pose 3, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose23:
+ax_pose 4, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose24:
+ax_pose 5, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose25:
+ax_pose 0, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose26:
+ax_pose 1, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose27:
+ax_pose 2, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose28:
+ax_pose 3, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose29:
+ax_pose 4, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose30:
+ax_pose 5, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose31:
+ax_pose 6, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose32:
+ax_pose 7, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose33:
+ax_pose 8, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose34:
+ax_pose 9, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose35:
+ax_pose 10, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose36:
+ax_pose 11, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose37:
+ax_pose 12, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose38:
+ax_pose 13, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose39:
+ax_pose 14, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose40:
+ax_pose 9, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose41:
+ax_pose 10, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose42:
+ax_pose 11, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose43:
+ax_pose 6, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose44:
+ax_pose 7, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose45:
+ax_pose 8, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose46:
+ax_pose 3, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose47:
+ax_pose 4, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose48:
+ax_pose 5, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose49:
+ax_pose 0, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose50:
+ax_pose 1, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose51:
+ax_pose 2, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose52:
+ax_pose 3, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose53:
+ax_pose 4, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose54:
+ax_pose 5, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose55:
+ax_pose 6, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose56:
+ax_pose 7, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose57:
+ax_pose 8, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose58:
+ax_pose 9, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose59:
+ax_pose 10, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose60:
+ax_pose 11, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose61:
+ax_pose 12, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose62:
+ax_pose 13, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose63:
+ax_pose 14, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose64:
+ax_pose 9, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose65:
+ax_pose 10, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose66:
+ax_pose 11, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose67:
+ax_pose 6, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose68:
+ax_pose 7, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose69:
+ax_pose 8, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose70:
+ax_pose 3, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose71:
+ax_pose 4, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose72:
+ax_pose 5, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose73:
+ax_pose 15, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose74:
+ax_pose 16, 0x01eb, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose75:
+ax_pose 17, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sRaltsPose76:
+ax_pose 18, 0x01eb, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose77:
+ax_pose 19, 0x01eb, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose78:
+ax_pose 18, 0x01eb, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose79:
+ax_pose 17, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sRaltsPose80:
+ax_pose 16, 0x01eb, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose81:
+ax_pose 15, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose82:
+ax_pose 16, 0x01ec, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose83:
+ax_pose 17, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sRaltsPose84:
+ax_pose 18, 0x01ec, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose85:
+ax_pose 19, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose86:
+ax_pose 18, 0x01ec, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose87:
+ax_pose 17, 0x01ec, 0x90ed, 0xac00
+ax_pose_terminator
+sRaltsPose88:
+ax_pose 16, 0x01ec, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose89:
+ax_pose 20, 0x81eb, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose90:
+ax_pose 21, 0x81eb, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose91:
+ax_pose 22, 0x01e3, 0x80f1, 0xac00
+ax_pose_terminator
+sRaltsPose92:
+ax_pose 23, 0x01e6, 0x90e9, 0xac00
+ax_pose_terminator
+sRaltsPose93:
+ax_pose 24, 0x01e4, 0x90ea, 0xac00
+ax_pose_terminator
+sRaltsPose94:
+ax_pose 25, 0x01e6, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose95:
+ax_pose 26, 0x01e2, 0x80f1, 0xac00
+ax_pose_terminator
+sRaltsPose96:
+ax_pose 25, 0x01e6, 0x80f5, 0xac00
+ax_pose_terminator
+sRaltsPose97:
+ax_pose 24, 0x01e6, 0x80f5, 0xac00
+ax_pose_terminator
+sRaltsPose98:
+ax_pose 23, 0x01e6, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose99:
+ax_pose 0, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose100:
+ax_pose 15, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose101:
+ax_pose 3, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose102:
+ax_pose 16, 0x01ec, 0x90e7, 0xac00
+ax_pose_terminator
+sRaltsPose103:
+ax_pose 6, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose104:
+ax_pose 17, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose105:
+ax_pose 9, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose106:
+ax_pose 18, 0x01ec, 0x90e7, 0xac00
+ax_pose_terminator
+sRaltsPose107:
+ax_pose 12, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose108:
+ax_pose 19, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose109:
+ax_pose 9, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose110:
+ax_pose 18, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose111:
+ax_pose 6, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose112:
+ax_pose 17, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose113:
+ax_pose 3, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose114:
+ax_pose 16, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose115:
+ax_pose 0, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose116:
+ax_pose 3, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose117:
+ax_pose 6, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose118:
+ax_pose 9, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose119:
+ax_pose 12, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose120:
+ax_pose 9, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose121:
+ax_pose 6, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose122:
+ax_pose 3, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose123:
+ax_pose 15, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose124:
+ax_pose 16, 0x01eb, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose125:
+ax_pose 17, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sRaltsPose126:
+ax_pose 18, 0x01eb, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose127:
+ax_pose 19, 0x01eb, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose128:
+ax_pose 18, 0x01eb, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose129:
+ax_pose 17, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sRaltsPose130:
+ax_pose 16, 0x01eb, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose131:
+ax_pose 0, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose132:
+ax_pose 15, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose133:
+ax_pose 3, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose134:
+ax_pose 16, 0x01ec, 0x90e7, 0xac00
+ax_pose_terminator
+sRaltsPose135:
+ax_pose 6, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose136:
+ax_pose 17, 0x01ec, 0x90ec, 0xac00
+ax_pose_terminator
+sRaltsPose137:
+ax_pose 9, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose138:
+ax_pose 18, 0x01ec, 0x90e7, 0xac00
+ax_pose_terminator
+sRaltsPose139:
+ax_pose 12, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose140:
+ax_pose 19, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose141:
+ax_pose 9, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose142:
+ax_pose 18, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose143:
+ax_pose 6, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose144:
+ax_pose 17, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sRaltsPose145:
+ax_pose 3, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose146:
+ax_pose 16, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose147:
+ax_pose 15, 0x01ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose148:
+ax_pose 16, 0x01eb, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose149:
+ax_pose 17, 0x01eb, 0x80f2, 0xac00
+ax_pose_terminator
+sRaltsPose150:
+ax_pose 18, 0x01eb, 0x80f7, 0xac00
+ax_pose_terminator
+sRaltsPose151:
+ax_pose 19, 0x01eb, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose152:
+ax_pose 18, 0x01eb, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose153:
+ax_pose 17, 0x01eb, 0x90ed, 0xac00
+ax_pose_terminator
+sRaltsPose154:
+ax_pose 16, 0x01eb, 0x90e8, 0xac00
+ax_pose_terminator
+sRaltsPose155:
+ax_pose 0, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose156:
+ax_pose 3, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose157:
+ax_pose 6, 0x01ec, 0x80f4, 0xac00
+ax_pose_terminator
+sRaltsPose158:
+ax_pose 9, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose159:
+ax_pose 12, 0x81ec, 0x80f8, 0xac00
+ax_pose_terminator
+sRaltsPose160:
+ax_pose 9, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+sRaltsPose161:
+ax_pose 6, 0x01ec, 0x90eb, 0xac00
+ax_pose_terminator
+sRaltsPose162:
+ax_pose 3, 0x81ec, 0x90f7, 0xac00
+ax_pose_terminator
+.align 2
+sRaltsAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRaltsAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 11, 11, 11, 11,
+ax_anim 2, 0, 27, 23, 23, 23, 23,
+ax_anim 2, 1, 27, 24, 22, 24, 22,
+ax_anim 2, 0, 27, 23, 23, 23, 23,
+ax_anim 2, 0, 27, 24, 22, 24, 22,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sRaltsAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 1, 30, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 23, 0, 23, 0,
+ax_anim 2, 0, 30, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sRaltsAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 13, -13, 13, -13,
+ax_anim 2, 0, 33, 22, -23, 22, -23,
+ax_anim 2, 1, 33, 23, -22, 23, -22,
+ax_anim 2, 0, 33, 22, -23, 22, -23,
+ax_anim 2, 0, 33, 23, -22, 23, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sRaltsAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -5, 0, -5,
+ax_anim 1, 0, 38, 0, -12, 0, -12,
+ax_anim 2, 0, 36, 0, -23, 0, -23,
+ax_anim 2, 1, 36, 1, -23, 1, -23,
+ax_anim 2, 0, 36, 0, -23, 0, -23,
+ax_anim 2, 0, 36, 1, -23, 1, -23,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sRaltsAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 41, -13, -13, -13, -13,
+ax_anim 2, 0, 39, -22, -23, -22, -23,
+ax_anim 2, 1, 39, -23, -22, -23, -22,
+ax_anim 2, 0, 39, -22, -23, -22, -23,
+ax_anim 2, 0, 39, -23, -22, -23, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sRaltsAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 2, 0, 42, -23, 0, -23, 0,
+ax_anim 2, 1, 42, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -23, 0, -23, 0,
+ax_anim 2, 0, 42, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sRaltsAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -11, 11, -11, 11,
+ax_anim 2, 0, 45, -23, 23, -23, 23,
+ax_anim 2, 1, 45, -24, 22, -24, 22,
+ax_anim 2, 0, 45, -23, 23, -23, 23,
+ax_anim 2, 0, 45, -24, 22, -24, 22,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRaltsAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sRaltsAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 11, 11, 11, 11,
+ax_anim 2, 0, 51, 23, 23, 23, 23,
+ax_anim 2, 1, 51, 24, 22, 24, 22,
+ax_anim 2, 0, 51, 23, 23, 23, 23,
+ax_anim 2, 0, 51, 24, 22, 24, 22,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sRaltsAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 12, 0, 12, 0,
+ax_anim 2, 0, 54, 23, 0, 23, 0,
+ax_anim 2, 1, 54, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 23, 0, 23, 0,
+ax_anim 2, 0, 54, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sRaltsAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 5, -6, 5, -6,
+ax_anim 1, 0, 59, 13, -13, 13, -13,
+ax_anim 2, 0, 57, 22, -23, 22, -23,
+ax_anim 2, 1, 57, 23, -22, 23, -22,
+ax_anim 2, 0, 57, 22, -23, 22, -23,
+ax_anim 2, 0, 57, 23, -22, 23, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sRaltsAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -5, 0, -5,
+ax_anim 1, 0, 62, 0, -12, 0, -12,
+ax_anim 2, 0, 60, 0, -23, 0, -23,
+ax_anim 2, 1, 60, 1, -23, 1, -23,
+ax_anim 2, 0, 60, 0, -23, 0, -23,
+ax_anim 2, 0, 60, 1, -23, 1, -23,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sRaltsAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -5, -6, -5, -6,
+ax_anim 1, 0, 65, -13, -13, -13, -13,
+ax_anim 2, 0, 63, -22, -23, -22, -23,
+ax_anim 2, 1, 63, -23, -22, -23, -22,
+ax_anim 2, 0, 63, -22, -23, -22, -23,
+ax_anim 2, 0, 63, -23, -22, -23, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sRaltsAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -12, 0, -12, 0,
+ax_anim 2, 0, 66, -23, 0, -23, 0,
+ax_anim 2, 1, 66, -23, 1, -23, 1,
+ax_anim 2, 0, 66, -23, 0, -23, 0,
+ax_anim 2, 0, 66, -23, 1, -23, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sRaltsAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -11, 11, -11, 11,
+ax_anim 2, 0, 69, -23, 23, -23, 23,
+ax_anim 2, 1, 69, -24, 22, -24, 22,
+ax_anim 2, 0, 69, -23, 23, -23, 23,
+ax_anim 2, 0, 69, -24, 22, -24, 22,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRaltsAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_5_1:
+ax_anim 3, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 3, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 2, 80, 0, 0, 0, 0,
+ax_anim 3, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 3, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_5_2:
+ax_anim 3, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 3, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 2, 87, 0, 0, 0, 0,
+ax_anim 3, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 3, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_5_3:
+ax_anim 3, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 3, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 2, 86, 0, 0, 0, 0,
+ax_anim 3, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 3, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_5_4:
+ax_anim 3, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 3, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 2, 85, 0, 0, 0, 0,
+ax_anim 3, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 3, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_5_5:
+ax_anim 3, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 3, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 2, 84, 0, 0, 0, 0,
+ax_anim 3, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 3, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_5_6:
+ax_anim 3, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 3, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 2, 83, 0, 0, 0, 0,
+ax_anim 3, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 3, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_5_7:
+ax_anim 3, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 3, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 2, 82, 0, 0, 0, 0,
+ax_anim 3, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 3, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_5_8:
+ax_anim 3, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 3, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 2, 81, 0, 0, 0, 0,
+ax_anim 3, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 3, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_6_1:
+ax_anim 30, 0, 88, 0, 0, 0, 0,
+ax_anim 35, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_7_1:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 8, 0, 90, 0, -3, 0, -3,
+ax_anim_terminator
+sRaltsAnims_7_2:
+ax_anim 2, 0, 91, -2, -2, -2, -2,
+ax_anim 8, 0, 91, -3, -3, -3, -3,
+ax_anim_terminator
+sRaltsAnims_7_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 8, 0, 92, -3, 0, -3, 0,
+ax_anim_terminator
+sRaltsAnims_7_4:
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim 8, 0, 93, -3, 3, -3, 3,
+ax_anim_terminator
+sRaltsAnims_7_5:
+ax_anim 2, 0, 94, 0, 2, 0, 2,
+ax_anim 8, 0, 94, 0, 3, 0, 3,
+ax_anim_terminator
+sRaltsAnims_7_6:
+ax_anim 2, 0, 95, 2, 2, 2, 2,
+ax_anim 8, 0, 95, 3, 3, 3, 3,
+ax_anim_terminator
+sRaltsAnims_7_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 8, 0, 96, 3, 0, 3, 0,
+ax_anim_terminator
+sRaltsAnims_7_8:
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim 8, 0, 97, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRaltsAnims_8_1:
+ax_anim 40, 0, 98, 0, 0, 0, 0,
+ax_anim 25, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_8_2:
+ax_anim 40, 0, 100, 0, 0, 0, 0,
+ax_anim 25, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_8_3:
+ax_anim 40, 0, 102, 0, 0, 0, 0,
+ax_anim 25, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_8_4:
+ax_anim 40, 0, 104, 0, 0, 0, 0,
+ax_anim 25, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_8_5:
+ax_anim 40, 0, 106, 0, 0, 0, 0,
+ax_anim 25, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_8_6:
+ax_anim 40, 0, 108, 0, 0, 0, 0,
+ax_anim 25, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_8_7:
+ax_anim 40, 0, 110, 0, 0, 0, 0,
+ax_anim 25, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_8_8:
+ax_anim 40, 0, 112, 0, 0, 0, 0,
+ax_anim 25, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_9_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 6, 3, 6, 3,
+ax_anim 2, 0, 116, 8, 9, 8, 9,
+ax_anim 2, 0, 117, 7, 17, 7, 17,
+ax_anim 3, 0, 118, 0, 19, 0, 19,
+ax_anim 2, 3, 119, -7, 17, -7, 17,
+ax_anim 2, 0, 120, -8, 9, -8, 9,
+ax_anim 1, 0, 121, -6, 3, -6, 3,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_9_2:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 10, 1, 10, 1,
+ax_anim 2, 0, 115, 18, 4, 18, 4,
+ax_anim 2, 0, 116, 23, 12, 23, 12,
+ax_anim 3, 0, 117, 22, 19, 22, 19,
+ax_anim 2, 3, 118, 11, 20, 11, 20,
+ax_anim 2, 0, 119, 2, 16, 2, 16,
+ax_anim 1, 0, 120, 0, 7, 0, 7,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_9_3:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 3, -4, 3, -4,
+ax_anim 2, 0, 114, 11, -6, 11, -6,
+ax_anim 2, 0, 115, 17, -5, 17, -5,
+ax_anim 3, 0, 116, 21, 0, 21, 0,
+ax_anim 2, 3, 117, 19, 4, 19, 4,
+ax_anim 2, 0, 118, 12, 5, 12, 5,
+ax_anim 1, 0, 119, 3, 3, 3, 3,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_9_4:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, -8, 0, -8,
+ax_anim 2, 0, 121, 3, -18, 3, -18,
+ax_anim 2, 0, 114, 11, -23, 11, -23,
+ax_anim 3, 0, 115, 21, -23, 21, -23,
+ax_anim 2, 3, 116, 25, -15, 25, -15,
+ax_anim 2, 0, 117, 22, -6, 22, -6,
+ax_anim 1, 0, 118, 13, -2, 13, -2,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_9_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, -8, -4, -8, -4,
+ax_anim 2, 0, 120, -9, -13, -9, -13,
+ax_anim 2, 0, 121, -7, -20, -7, -20,
+ax_anim 3, 0, 114, 0, -22, 0, -22,
+ax_anim 2, 3, 115, 7, -20, 7, -20,
+ax_anim 2, 0, 116, 9, -13, 9, -13,
+ax_anim 1, 0, 117, 8, -4, 8, -4,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_9_6:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, -8, 0, -8,
+ax_anim 2, 0, 115, -3, -18, -3, -18,
+ax_anim 2, 0, 114, -11, -23, -11, -23,
+ax_anim 3, 0, 121, -21, -23, -21, -23,
+ax_anim 2, 3, 120, -25, -15, -25, -15,
+ax_anim 2, 0, 119, -22, -6, -22, -6,
+ax_anim 1, 0, 118, -13, -2, -13, -2,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_9_7:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, -3, -4, -3, -4,
+ax_anim 2, 0, 114, -11, -6, -11, -6,
+ax_anim 2, 0, 121, -17, -5, -17, -5,
+ax_anim 3, 0, 120, -21, 0, -21, 0,
+ax_anim 2, 3, 119, -19, 4, -19, 4,
+ax_anim 2, 0, 118, -12, 5, -12, 5,
+ax_anim 1, 0, 117, -3, 3, -3, 3,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_9_8:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 114, -10, 1, -10, 1,
+ax_anim 2, 0, 121, -18, 4, -18, 4,
+ax_anim 2, 0, 120, -23, 12, -23, 12,
+ax_anim 3, 0, 119, -22, 19, -22, 19,
+ax_anim 2, 3, 118, -11, 20, -11, 20,
+ax_anim 2, 0, 117, -2, 16, -2, 16,
+ax_anim 1, 0, 116, 0, 7, 0, 7,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_10_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 3, 0, 122, 13, 0, 13, 0,
+ax_anim 3, 0, 122, -13, 0, -13, 0,
+ax_anim 2, 0, 122, 12, 0, 12, 0,
+ax_anim 3, 0, 122, -12, 0, -12, 0,
+ax_anim 2, 0, 122, 10, 0, 10, 0,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_10_2:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 3, 0, 123, 13, -13, 13, -13,
+ax_anim 3, 0, 123, -13, 13, -13, 13,
+ax_anim 2, 0, 123, 12, -12, 12, -12,
+ax_anim 3, 0, 123, -12, 12, -12, 12,
+ax_anim 2, 0, 123, 10, -10, 10, -10,
+ax_anim 2, 0, 123, -10, 10, -10, 10,
+ax_anim 2, 0, 123, 6, -6, 6, -6,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_10_3:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 3, 0, 124, 0, -13, 0, -13,
+ax_anim 3, 0, 124, 0, 13, 0, 13,
+ax_anim 2, 0, 124, 0, -12, 0, -12,
+ax_anim 3, 0, 124, 0, 12, 0, 12,
+ax_anim 2, 0, 124, 0, -10, 0, -10,
+ax_anim 2, 0, 124, 0, 10, 0, 10,
+ax_anim 2, 0, 124, 0, -6, 0, -6,
+ax_anim 2, 0, 124, 0, 6, 0, 6,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_10_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 3, 0, 125, -13, -13, -13, -13,
+ax_anim 3, 0, 125, 13, 13, 13, 13,
+ax_anim 2, 0, 125, -12, -12, -12, -12,
+ax_anim 3, 0, 125, 12, 12, 12, 12,
+ax_anim 2, 0, 125, -10, -10, -10, -10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, -6, -6, -6, -6,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_10_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 3, 0, 126, 13, 0, 13, 0,
+ax_anim 3, 0, 126, -13, 0, -13, 0,
+ax_anim 2, 0, 126, 12, 0, 12, 0,
+ax_anim 3, 0, 126, -12, 0, -12, 0,
+ax_anim 2, 0, 126, 10, 0, 10, 0,
+ax_anim 2, 0, 126, -10, 0, -10, 0,
+ax_anim 2, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 0, 126, -6, 0, -6, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_10_6:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 3, 0, 127, 13, -13, 13, -13,
+ax_anim 3, 0, 127, -13, 13, -13, 13,
+ax_anim 2, 0, 127, 12, -12, 12, -12,
+ax_anim 3, 0, 127, -12, 12, -12, 12,
+ax_anim 2, 0, 127, 10, -10, 10, -10,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, 6, -6, 6, -6,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_10_7:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 3, 0, 128, 0, -13, 0, -13,
+ax_anim 3, 0, 128, 0, 13, 0, 13,
+ax_anim 2, 0, 128, 0, -12, 0, -12,
+ax_anim 3, 0, 128, 0, 12, 0, 12,
+ax_anim 2, 0, 128, 0, -10, 0, -10,
+ax_anim 2, 0, 128, 0, 10, 0, 10,
+ax_anim 2, 0, 128, 0, -6, 0, -6,
+ax_anim 2, 0, 128, 0, 6, 0, 6,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_10_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 3, 0, 129, -13, -13, -13, -13,
+ax_anim 3, 0, 129, 13, 13, 13, 13,
+ax_anim 2, 0, 129, -12, -12, -12, -12,
+ax_anim 3, 0, 129, 12, 12, 12, 12,
+ax_anim 2, 0, 129, -10, -10, -10, -10,
+ax_anim 2, 0, 129, 10, 10, 10, 10,
+ax_anim 2, 0, 129, -6, -6, -6, -6,
+ax_anim 2, 0, 129, 6, 6, 6, 6,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_11_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 2, 0, 131, 0, -16, 0, 0,
+ax_anim 3, 0, 131, 0, -20, 0, 0,
+ax_anim 4, 0, 131, 0, -21, 0, 0,
+ax_anim 4, 0, 130, 0, -22, 0, 0,
+ax_anim 3, 0, 130, 0, -21, 0, 0,
+ax_anim 2, 0, 130, 0, -18, 0, 0,
+ax_anim 1, 0, 130, 0, -12, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_11_2:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 2, 0, 133, 0, -16, 0, 0,
+ax_anim 3, 0, 133, 0, -20, 0, 0,
+ax_anim 4, 0, 133, 0, -21, 0, 0,
+ax_anim 4, 0, 132, 0, -22, 0, 0,
+ax_anim 3, 0, 132, 0, -21, 0, 0,
+ax_anim 2, 0, 132, 0, -18, 0, 0,
+ax_anim 1, 0, 132, 0, -12, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_11_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 2, 0, 135, 0, -16, 0, 0,
+ax_anim 3, 0, 135, 0, -20, 0, 0,
+ax_anim 4, 0, 135, 0, -21, 0, 0,
+ax_anim 4, 0, 134, 0, -22, 0, 0,
+ax_anim 3, 0, 134, 0, -21, 0, 0,
+ax_anim 2, 0, 134, 0, -18, 0, 0,
+ax_anim 1, 0, 134, 0, -12, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_11_4:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -10, 0, 0,
+ax_anim 2, 0, 137, 0, -16, 0, 0,
+ax_anim 3, 0, 137, 0, -20, 0, 0,
+ax_anim 4, 0, 137, 0, -21, 0, 0,
+ax_anim 4, 0, 136, 0, -22, 0, 0,
+ax_anim 3, 0, 136, 0, -21, 0, 0,
+ax_anim 2, 0, 136, 0, -17, 0, 0,
+ax_anim 1, 0, 136, 0, -11, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_11_5:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -22, 0, 0,
+ax_anim 3, 0, 138, 0, -21, 0, 0,
+ax_anim 2, 0, 138, 0, -18, 0, 0,
+ax_anim 1, 0, 138, 0, -12, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_11_6:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -10, 0, 0,
+ax_anim 2, 0, 141, 0, -16, 0, 0,
+ax_anim 3, 0, 141, 0, -20, 0, 0,
+ax_anim 4, 0, 141, 0, -21, 0, 0,
+ax_anim 4, 0, 140, 0, -22, 0, 0,
+ax_anim 3, 0, 140, 0, -21, 0, 0,
+ax_anim 2, 0, 140, 0, -17, 0, 0,
+ax_anim 1, 0, 140, 0, -11, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_11_7:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 0, 143, 0, -16, 0, 0,
+ax_anim 3, 0, 143, 0, -20, 0, 0,
+ax_anim 4, 0, 143, 0, -21, 0, 0,
+ax_anim 4, 0, 142, 0, -22, 0, 0,
+ax_anim 3, 0, 142, 0, -21, 0, 0,
+ax_anim 2, 0, 142, 0, -18, 0, 0,
+ax_anim 1, 0, 142, 0, -12, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_11_8:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -22, 0, 0,
+ax_anim 3, 0, 144, 0, -21, 0, 0,
+ax_anim 2, 0, 144, 0, -18, 0, 0,
+ax_anim 1, 0, 144, 0, -12, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_12_1:
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 1, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_12_2:
+ax_anim 2, 0, 153, 1, -1, 1, -1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 1, -1, 1, -1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 1, -1, 1, -1,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 1, -1, 1, -1,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 1, -1, 1, -1,
+ax_anim 2, 1, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_12_3:
+ax_anim 2, 0, 152, 0, -1, 0, -1,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, -1,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, -1,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, -1,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -1, 0, -1,
+ax_anim 2, 1, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_12_4:
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 1, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_12_5:
+ax_anim 2, 0, 150, 1, 0, 1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 1, 0, 1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 1, 0, 1, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 1, 0, 1, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 1, 0, 1, 0,
+ax_anim 2, 1, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_12_6:
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 1, -1, 1, -1,
+ax_anim 2, 1, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_12_7:
+ax_anim 2, 0, 148, 0, -1, 0, -1,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, -1,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, -1,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, -1,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, -1,
+ax_anim 2, 1, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_12_8:
+ax_anim 2, 0, 147, -1, -1, -1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, -1, -1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, -1, -1, -1,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, -1, -1, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, -1, -1, -1, -1,
+ax_anim 2, 1, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaltsAnims_13_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_13_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_13_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_13_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_13_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_13_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_13_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsAnims_13_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sRaltsGfx1:
+.incbin "baserom.gba", 0x1172134, 0x100
+sRaltsSprites1:
+ax_sprite sRaltsGfx1, 0x100
+ax_sprite_terminator
+sRaltsGfx2:
+.incbin "baserom.gba", 0x1172244, 0x100
+sRaltsSprites2:
+ax_sprite sRaltsGfx2, 0x100
+ax_sprite_terminator
+sRaltsGfx3:
+.incbin "baserom.gba", 0x1172354, 0x100
+sRaltsSprites3:
+ax_sprite sRaltsGfx3, 0x100
+ax_sprite_terminator
+sRaltsGfx4:
+.incbin "baserom.gba", 0x1172464, 0x100
+sRaltsSprites4:
+ax_sprite sRaltsGfx4, 0x100
+ax_sprite_terminator
+sRaltsGfx5:
+.incbin "baserom.gba", 0x1172574, 0x100
+sRaltsSprites5:
+ax_sprite sRaltsGfx5, 0x100
+ax_sprite_terminator
+sRaltsGfx6:
+.incbin "baserom.gba", 0x1172684, 0x100
+sRaltsSprites6:
+ax_sprite sRaltsGfx6, 0x100
+ax_sprite_terminator
+sRaltsGfx7:
+.incbin "baserom.gba", 0x1172794, 0x200
+sRaltsSprites7:
+ax_sprite sRaltsGfx7, 0x200
+ax_sprite_terminator
+sRaltsGfx8:
+.incbin "baserom.gba", 0x11729A4, 0x200
+sRaltsSprites8:
+ax_sprite sRaltsGfx8, 0x200
+ax_sprite_terminator
+sRaltsGfx9:
+.incbin "baserom.gba", 0x1172BB4, 0x200
+sRaltsSprites9:
+ax_sprite sRaltsGfx9, 0x200
+ax_sprite_terminator
+sRaltsGfx10:
+.incbin "baserom.gba", 0x1172DC4, 0x100
+sRaltsSprites10:
+ax_sprite sRaltsGfx10, 0x100
+ax_sprite_terminator
+sRaltsGfx11:
+.incbin "baserom.gba", 0x1172ED4, 0x100
+sRaltsSprites11:
+ax_sprite sRaltsGfx11, 0x100
+ax_sprite_terminator
+sRaltsGfx12:
+.incbin "baserom.gba", 0x1172FE4, 0x100
+sRaltsSprites12:
+ax_sprite sRaltsGfx12, 0x100
+ax_sprite_terminator
+sRaltsGfx13:
+.incbin "baserom.gba", 0x11730F4, 0x100
+sRaltsSprites13:
+ax_sprite sRaltsGfx13, 0x100
+ax_sprite_terminator
+sRaltsGfx14:
+.incbin "baserom.gba", 0x1173204, 0x100
+sRaltsSprites14:
+ax_sprite sRaltsGfx14, 0x100
+ax_sprite_terminator
+sRaltsGfx15:
+.incbin "baserom.gba", 0x1173314, 0x100
+sRaltsSprites15:
+ax_sprite sRaltsGfx15, 0x100
+ax_sprite_terminator
+sRaltsGfx16:
+.incbin "baserom.gba", 0x1173424, 0x40
+sRaltsGfx16_1:
+.incbin "baserom.gba", 0x1173464, 0x40
+sRaltsGfx16_2:
+.incbin "baserom.gba", 0x11734A4, 0x40
+sRaltsSprites16:
+ax_sprite sRaltsGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx16_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx16_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sRaltsGfx17:
+.incbin "baserom.gba", 0x117351C, 0x40
+sRaltsGfx17_1:
+.incbin "baserom.gba", 0x117355C, 0x40
+sRaltsGfx17_2:
+.incbin "baserom.gba", 0x117359C, 0x40
+sRaltsSprites17:
+ax_sprite sRaltsGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx17_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sRaltsGfx18:
+.incbin "baserom.gba", 0x1173614, 0x40
+sRaltsGfx18_1:
+.incbin "baserom.gba", 0x1173654, 0x60
+sRaltsGfx18_2:
+.incbin "baserom.gba", 0x11736B4, 0x40
+sRaltsSprites18:
+ax_sprite 0, 0x20
+ax_sprite sRaltsGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaltsGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRaltsGfx19:
+.incbin "baserom.gba", 0x1173734, 0x40
+sRaltsGfx19_1:
+.incbin "baserom.gba", 0x1173774, 0x60
+sRaltsGfx19_2:
+.incbin "baserom.gba", 0x11737D4, 0x40
+sRaltsSprites19:
+ax_sprite sRaltsGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaltsGfx19_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sRaltsGfx20:
+.incbin "baserom.gba", 0x117384C, 0x40
+sRaltsGfx20_1:
+.incbin "baserom.gba", 0x117388C, 0x40
+sRaltsGfx20_2:
+.incbin "baserom.gba", 0x11738CC, 0x40
+sRaltsSprites20:
+ax_sprite sRaltsGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaltsGfx20_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sRaltsGfx21:
+.incbin "baserom.gba", 0x1173944, 0x100
+sRaltsSprites21:
+ax_sprite sRaltsGfx21, 0x100
+ax_sprite_terminator
+sRaltsGfx22:
+.incbin "baserom.gba", 0x1173A54, 0x100
+sRaltsSprites22:
+ax_sprite sRaltsGfx22, 0x100
+ax_sprite_terminator
+sRaltsGfx23:
+.incbin "baserom.gba", 0x1173B64, 0x200
+sRaltsSprites23:
+ax_sprite sRaltsGfx23, 0x200
+ax_sprite_terminator
+sRaltsGfx24:
+.incbin "baserom.gba", 0x1173D74, 0x200
+sRaltsSprites24:
+ax_sprite sRaltsGfx24, 0x200
+ax_sprite_terminator
+sRaltsGfx25:
+.incbin "baserom.gba", 0x1173F84, 0x200
+sRaltsSprites25:
+ax_sprite sRaltsGfx25, 0x200
+ax_sprite_terminator
+sRaltsGfx26:
+.incbin "baserom.gba", 0x1174194, 0x200
+sRaltsSprites26:
+ax_sprite sRaltsGfx26, 0x200
+ax_sprite_terminator
+sRaltsGfx27:
+.incbin "baserom.gba", 0x11743A4, 0x200
+sRaltsSprites27:
+ax_sprite sRaltsGfx27, 0x200
+ax_sprite_terminator
+sAxPosesRalts:
+.4byte sRaltsPose1
+.4byte sRaltsPose2
+.4byte sRaltsPose3
+.4byte sRaltsPose4
+.4byte sRaltsPose5
+.4byte sRaltsPose6
+.4byte sRaltsPose7
+.4byte sRaltsPose8
+.4byte sRaltsPose9
+.4byte sRaltsPose10
+.4byte sRaltsPose11
+.4byte sRaltsPose12
+.4byte sRaltsPose13
+.4byte sRaltsPose14
+.4byte sRaltsPose15
+.4byte sRaltsPose16
+.4byte sRaltsPose17
+.4byte sRaltsPose18
+.4byte sRaltsPose19
+.4byte sRaltsPose20
+.4byte sRaltsPose21
+.4byte sRaltsPose22
+.4byte sRaltsPose23
+.4byte sRaltsPose24
+.4byte sRaltsPose25
+.4byte sRaltsPose26
+.4byte sRaltsPose27
+.4byte sRaltsPose28
+.4byte sRaltsPose29
+.4byte sRaltsPose30
+.4byte sRaltsPose31
+.4byte sRaltsPose32
+.4byte sRaltsPose33
+.4byte sRaltsPose34
+.4byte sRaltsPose35
+.4byte sRaltsPose36
+.4byte sRaltsPose37
+.4byte sRaltsPose38
+.4byte sRaltsPose39
+.4byte sRaltsPose40
+.4byte sRaltsPose41
+.4byte sRaltsPose42
+.4byte sRaltsPose43
+.4byte sRaltsPose44
+.4byte sRaltsPose45
+.4byte sRaltsPose46
+.4byte sRaltsPose47
+.4byte sRaltsPose48
+.4byte sRaltsPose49
+.4byte sRaltsPose50
+.4byte sRaltsPose51
+.4byte sRaltsPose52
+.4byte sRaltsPose53
+.4byte sRaltsPose54
+.4byte sRaltsPose55
+.4byte sRaltsPose56
+.4byte sRaltsPose57
+.4byte sRaltsPose58
+.4byte sRaltsPose59
+.4byte sRaltsPose60
+.4byte sRaltsPose61
+.4byte sRaltsPose62
+.4byte sRaltsPose63
+.4byte sRaltsPose64
+.4byte sRaltsPose65
+.4byte sRaltsPose66
+.4byte sRaltsPose67
+.4byte sRaltsPose68
+.4byte sRaltsPose69
+.4byte sRaltsPose70
+.4byte sRaltsPose71
+.4byte sRaltsPose72
+.4byte sRaltsPose73
+.4byte sRaltsPose74
+.4byte sRaltsPose75
+.4byte sRaltsPose76
+.4byte sRaltsPose77
+.4byte sRaltsPose78
+.4byte sRaltsPose79
+.4byte sRaltsPose80
+.4byte sRaltsPose81
+.4byte sRaltsPose82
+.4byte sRaltsPose83
+.4byte sRaltsPose84
+.4byte sRaltsPose85
+.4byte sRaltsPose86
+.4byte sRaltsPose87
+.4byte sRaltsPose88
+.4byte sRaltsPose89
+.4byte sRaltsPose90
+.4byte sRaltsPose91
+.4byte sRaltsPose92
+.4byte sRaltsPose93
+.4byte sRaltsPose94
+.4byte sRaltsPose95
+.4byte sRaltsPose96
+.4byte sRaltsPose97
+.4byte sRaltsPose98
+.4byte sRaltsPose99
+.4byte sRaltsPose100
+.4byte sRaltsPose101
+.4byte sRaltsPose102
+.4byte sRaltsPose103
+.4byte sRaltsPose104
+.4byte sRaltsPose105
+.4byte sRaltsPose106
+.4byte sRaltsPose107
+.4byte sRaltsPose108
+.4byte sRaltsPose109
+.4byte sRaltsPose110
+.4byte sRaltsPose111
+.4byte sRaltsPose112
+.4byte sRaltsPose113
+.4byte sRaltsPose114
+.4byte sRaltsPose115
+.4byte sRaltsPose116
+.4byte sRaltsPose117
+.4byte sRaltsPose118
+.4byte sRaltsPose119
+.4byte sRaltsPose120
+.4byte sRaltsPose121
+.4byte sRaltsPose122
+.4byte sRaltsPose123
+.4byte sRaltsPose124
+.4byte sRaltsPose125
+.4byte sRaltsPose126
+.4byte sRaltsPose127
+.4byte sRaltsPose128
+.4byte sRaltsPose129
+.4byte sRaltsPose130
+.4byte sRaltsPose131
+.4byte sRaltsPose132
+.4byte sRaltsPose133
+.4byte sRaltsPose134
+.4byte sRaltsPose135
+.4byte sRaltsPose136
+.4byte sRaltsPose137
+.4byte sRaltsPose138
+.4byte sRaltsPose139
+.4byte sRaltsPose140
+.4byte sRaltsPose141
+.4byte sRaltsPose142
+.4byte sRaltsPose143
+.4byte sRaltsPose144
+.4byte sRaltsPose145
+.4byte sRaltsPose146
+.4byte sRaltsPose147
+.4byte sRaltsPose148
+.4byte sRaltsPose149
+.4byte sRaltsPose150
+.4byte sRaltsPose151
+.4byte sRaltsPose152
+.4byte sRaltsPose153
+.4byte sRaltsPose154
+.4byte sRaltsPose155
+.4byte sRaltsPose156
+.4byte sRaltsPose157
+.4byte sRaltsPose158
+.4byte sRaltsPose159
+.4byte sRaltsPose160
+.4byte sRaltsPose161
+.4byte sRaltsPose162
+sAxPositionsRalts:
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -4
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -4
+.2byte    2,   -6, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -5, 	  -1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte    1,   -5, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte    2,   -6, 	   0,   -4, 	   0,   -3, 	  -1,   -5
+.2byte    1,   -5, 	  -3,   -2, 	   0,   -2, 	  -1,   -4
+.2byte    2,   -5, 	   1,   -2, 	   0,   -2, 	  -1,   -4
+.2byte    1,   -7, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte    1,   -6, 	  -3,   -2, 	   1,   -2, 	  -1,   -4
+.2byte    1,   -6, 	   0,   -3, 	   1,   -2, 	  -1,   -4
+.2byte   -1,   -7, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte   -2,   -7, 	   2,   -2, 	  -3,   -3, 	  -1,   -5
+.2byte    0,   -7, 	   1,   -3, 	  -4,   -2, 	  -1,   -5
+.2byte   -3,   -7, 	   0,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte   -3,   -6, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte   -3,   -6, 	  -2,   -3, 	  -3,   -2, 	  -1,   -4
+.2byte   -4,   -6, 	  -2,   -4, 	  -2,   -3, 	  -1,   -5
+.2byte   -3,   -5, 	   1,   -2, 	  -2,   -2, 	  -1,   -4
+.2byte   -4,   -5, 	  -3,   -2, 	  -2,   -2, 	  -1,   -4
+.2byte   -4,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -5, 	  -1,   -2, 	   1,   -2, 	  -1,   -4
+.2byte   -3,   -5, 	  -3,   -2, 	   1,   -2, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -4
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -4
+.2byte    2,   -6, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -5, 	  -1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte    1,   -5, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte    2,   -6, 	   0,   -4, 	   0,   -3, 	  -1,   -5
+.2byte    1,   -5, 	  -3,   -2, 	   0,   -2, 	  -1,   -4
+.2byte    2,   -5, 	   1,   -2, 	   0,   -2, 	  -1,   -4
+.2byte    1,   -7, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte    1,   -6, 	  -3,   -2, 	   1,   -2, 	  -1,   -4
+.2byte    1,   -6, 	   0,   -3, 	   1,   -2, 	  -1,   -4
+.2byte   -1,   -7, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte   -2,   -7, 	   2,   -2, 	  -3,   -3, 	  -1,   -5
+.2byte    0,   -7, 	   1,   -3, 	  -4,   -2, 	  -1,   -5
+.2byte   -3,   -7, 	   0,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte   -3,   -6, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte   -3,   -6, 	  -2,   -3, 	  -3,   -2, 	  -1,   -4
+.2byte   -4,   -6, 	  -2,   -4, 	  -2,   -3, 	  -1,   -5
+.2byte   -3,   -5, 	   1,   -2, 	  -2,   -2, 	  -1,   -4
+.2byte   -4,   -5, 	  -3,   -2, 	  -2,   -2, 	  -1,   -4
+.2byte   -4,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -5, 	  -1,   -2, 	   1,   -2, 	  -1,   -4
+.2byte   -3,   -5, 	  -3,   -2, 	   1,   -2, 	  -1,   -4
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -5
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -4
+.2byte   -1,   -5, 	  -4,   -2, 	   2,   -2, 	  -1,   -4
+.2byte    2,   -6, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -5, 	  -1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte    1,   -5, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte    2,   -6, 	   0,   -4, 	   0,   -3, 	  -1,   -5
+.2byte    1,   -5, 	  -3,   -2, 	   0,   -2, 	  -1,   -4
+.2byte    2,   -5, 	   1,   -2, 	   0,   -2, 	  -1,   -4
+.2byte    1,   -7, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte    1,   -6, 	  -3,   -2, 	   1,   -2, 	  -1,   -4
+.2byte    1,   -6, 	   0,   -3, 	   1,   -2, 	  -1,   -4
+.2byte   -1,   -7, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte   -2,   -7, 	   2,   -2, 	  -3,   -3, 	  -1,   -5
+.2byte    0,   -7, 	   1,   -3, 	  -4,   -2, 	  -1,   -5
+.2byte   -3,   -7, 	   0,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte   -3,   -6, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte   -3,   -6, 	  -2,   -3, 	  -3,   -2, 	  -1,   -4
+.2byte   -4,   -6, 	  -2,   -4, 	  -2,   -3, 	  -1,   -5
+.2byte   -3,   -5, 	   1,   -2, 	  -2,   -2, 	  -1,   -4
+.2byte   -4,   -5, 	  -3,   -2, 	  -2,   -2, 	  -1,   -4
+.2byte   -4,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -5, 	  -1,   -2, 	   1,   -2, 	  -1,   -4
+.2byte   -3,   -5, 	  -3,   -2, 	   1,   -2, 	  -1,   -4
+.2byte   -1,   -7, 	  -3,   -6, 	   1,   -6, 	  -1,   -5
+.2byte   -4,   -8, 	  -5,   -7, 	  -2,   -7, 	  -1,   -7
+.2byte   -4,   -8, 	  -5,   -9, 	  -5,   -7, 	  -2,   -6
+.2byte   -3,   -9, 	   0,   -9, 	  -5,   -7, 	  -2,   -6
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -8, 	  -1,   -5
+.2byte    1,   -9, 	  -2,   -9, 	   3,   -7, 	   0,   -6
+.2byte    2,   -8, 	   3,   -9, 	   3,   -7, 	   0,   -6
+.2byte    2,   -8, 	   3,   -7, 	   0,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	  -3,   -6, 	   1,   -6, 	  -1,   -5
+.2byte   -4,   -7, 	  -5,   -6, 	  -2,   -6, 	  -1,   -6
+.2byte   -4,   -7, 	  -5,   -8, 	  -5,   -6, 	  -2,   -5
+.2byte   -3,   -8, 	   0,   -8, 	  -5,   -6, 	  -2,   -5
+.2byte   -1,   -8, 	   1,   -7, 	  -3,   -7, 	  -1,   -4
+.2byte    1,   -8, 	  -2,   -8, 	   3,   -6, 	   0,   -5
+.2byte    2,   -7, 	   3,   -8, 	   3,   -6, 	   0,   -5
+.2byte    2,   -7, 	   3,   -6, 	   0,   -6, 	  -1,   -6
+.2byte   -4,   -5, 	  -3,   -2, 	   1,   -2, 	  -1,   -4
+.2byte   -5,   -4, 	  -3,   -2, 	   1,   -1, 	  -2,   -3
+.2byte    0,   -9, 	  -3,   -9, 	   3,   -9, 	   0,   -7
+.2byte    1,   -9, 	   2,   -9, 	  -2,   -8, 	   0,   -6
+.2byte    2,   -8, 	   1,  -10, 	   1,   -7, 	   0,   -5
+.2byte    1,  -10, 	  -2,  -10, 	   3,   -8, 	   0,   -6
+.2byte    0,   -8, 	   3,   -8, 	  -3,   -8, 	   0,   -5
+.2byte   -2,  -10, 	   1,  -10, 	  -4,   -8, 	  -1,   -6
+.2byte   -4,   -6, 	  -3,   -8, 	  -3,   -5, 	  -2,   -3
+.2byte   -2,   -9, 	  -3,   -9, 	   1,   -8, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -6, 	   1,   -6, 	  -1,   -5
+.2byte    2,   -6, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -7, 	   2,   -6, 	  -1,   -6, 	  -2,   -6
+.2byte    2,   -6, 	   0,   -4, 	   0,   -3, 	  -1,   -5
+.2byte    0,   -7, 	   1,   -8, 	   1,   -6, 	  -2,   -5
+.2byte    1,   -7, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -6, 	  -1,   -5
+.2byte   -1,   -7, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte   -1,   -8, 	   1,   -7, 	  -3,   -7, 	  -1,   -4
+.2byte   -3,   -7, 	   0,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte   -2,   -8, 	   1,   -8, 	  -4,   -6, 	  -1,   -5
+.2byte   -4,   -6, 	  -2,   -4, 	  -2,   -3, 	  -1,   -5
+.2byte   -2,   -7, 	  -3,   -8, 	  -3,   -6, 	   0,   -5
+.2byte   -4,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	  -4,   -6, 	  -1,   -6, 	   0,   -6
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -5
+.2byte   -4,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -4,   -6, 	  -2,   -4, 	  -2,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	   0,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -7, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte    2,   -6, 	   0,   -4, 	   0,   -3, 	  -1,   -5
+.2byte    2,   -6, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -6, 	   1,   -6, 	  -1,   -5
+.2byte    2,   -8, 	   3,   -7, 	   0,   -7, 	  -1,   -7
+.2byte    2,   -8, 	   3,   -9, 	   3,   -7, 	   0,   -6
+.2byte    1,   -9, 	  -2,   -9, 	   3,   -7, 	   0,   -6
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -8, 	  -1,   -5
+.2byte   -3,   -9, 	   0,   -9, 	  -5,   -7, 	  -2,   -6
+.2byte   -4,   -8, 	  -5,   -9, 	  -5,   -7, 	  -2,   -6
+.2byte   -4,   -8, 	  -5,   -7, 	  -2,   -7, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -6, 	   1,   -6, 	  -1,   -5
+.2byte    2,   -6, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -7, 	   2,   -6, 	  -1,   -6, 	  -2,   -6
+.2byte    2,   -6, 	   0,   -4, 	   0,   -3, 	  -1,   -5
+.2byte    1,   -7, 	   2,   -8, 	   2,   -6, 	  -1,   -5
+.2byte    1,   -7, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -6, 	  -1,   -5
+.2byte   -1,   -7, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte   -1,   -8, 	   1,   -7, 	  -3,   -7, 	  -1,   -4
+.2byte   -3,   -7, 	   0,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte   -2,   -8, 	   1,   -8, 	  -4,   -6, 	  -1,   -5
+.2byte   -4,   -6, 	  -2,   -4, 	  -2,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	  -4,   -8, 	  -4,   -6, 	  -1,   -5
+.2byte   -4,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	  -4,   -6, 	  -1,   -6, 	   0,   -6
+.2byte   -1,   -7, 	  -3,   -6, 	   1,   -6, 	  -1,   -5
+.2byte   -4,   -8, 	  -5,   -7, 	  -2,   -7, 	  -1,   -7
+.2byte   -4,   -8, 	  -5,   -9, 	  -5,   -7, 	  -2,   -6
+.2byte   -3,   -9, 	   0,   -9, 	  -5,   -7, 	  -2,   -6
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -8, 	  -1,   -5
+.2byte    1,   -9, 	  -2,   -9, 	   3,   -7, 	   0,   -6
+.2byte    2,   -8, 	   3,   -9, 	   3,   -7, 	   0,   -6
+.2byte    2,   -8, 	   3,   -7, 	   0,   -7, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -3, 	   2,   -3, 	  -1,   -5
+.2byte   -4,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -4,   -6, 	  -2,   -4, 	  -2,   -3, 	  -1,   -5
+.2byte   -3,   -7, 	   0,   -4, 	  -3,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+.2byte    1,   -7, 	  -2,   -4, 	   1,   -3, 	  -1,   -5
+.2byte    2,   -6, 	   0,   -4, 	   0,   -3, 	  -1,   -5
+.2byte    2,   -6, 	   1,   -3, 	  -3,   -3, 	  -1,   -5
+sRaltsAnimTable1:
+.4byte sRaltsAnims_1_1
+.4byte sRaltsAnims_1_2
+.4byte sRaltsAnims_1_3
+.4byte sRaltsAnims_1_4
+.4byte sRaltsAnims_1_5
+.4byte sRaltsAnims_1_6
+.4byte sRaltsAnims_1_7
+.4byte sRaltsAnims_1_8
+sRaltsAnimTable2:
+.4byte sRaltsAnims_2_1
+.4byte sRaltsAnims_2_2
+.4byte sRaltsAnims_2_3
+.4byte sRaltsAnims_2_4
+.4byte sRaltsAnims_2_5
+.4byte sRaltsAnims_2_6
+.4byte sRaltsAnims_2_7
+.4byte sRaltsAnims_2_8
+sRaltsAnimTable3:
+.4byte sRaltsAnims_3_1
+.4byte sRaltsAnims_3_2
+.4byte sRaltsAnims_3_3
+.4byte sRaltsAnims_3_4
+.4byte sRaltsAnims_3_5
+.4byte sRaltsAnims_3_6
+.4byte sRaltsAnims_3_7
+.4byte sRaltsAnims_3_8
+sRaltsAnimTable4:
+.4byte sRaltsAnims_4_1
+.4byte sRaltsAnims_4_2
+.4byte sRaltsAnims_4_3
+.4byte sRaltsAnims_4_4
+.4byte sRaltsAnims_4_5
+.4byte sRaltsAnims_4_6
+.4byte sRaltsAnims_4_7
+.4byte sRaltsAnims_4_8
+sRaltsAnimTable5:
+.4byte sRaltsAnims_5_1
+.4byte sRaltsAnims_5_2
+.4byte sRaltsAnims_5_3
+.4byte sRaltsAnims_5_4
+.4byte sRaltsAnims_5_5
+.4byte sRaltsAnims_5_6
+.4byte sRaltsAnims_5_7
+.4byte sRaltsAnims_5_8
+sRaltsAnimTable6:
+.4byte sRaltsAnims_6_1
+.4byte sRaltsAnims_6_1
+.4byte sRaltsAnims_6_1
+.4byte sRaltsAnims_6_1
+.4byte sRaltsAnims_6_1
+.4byte sRaltsAnims_6_1
+.4byte sRaltsAnims_6_1
+.4byte sRaltsAnims_6_1
+sRaltsAnimTable7:
+.4byte sRaltsAnims_7_1
+.4byte sRaltsAnims_7_2
+.4byte sRaltsAnims_7_3
+.4byte sRaltsAnims_7_4
+.4byte sRaltsAnims_7_5
+.4byte sRaltsAnims_7_6
+.4byte sRaltsAnims_7_7
+.4byte sRaltsAnims_7_8
+sRaltsAnimTable8:
+.4byte sRaltsAnims_8_1
+.4byte sRaltsAnims_8_2
+.4byte sRaltsAnims_8_3
+.4byte sRaltsAnims_8_4
+.4byte sRaltsAnims_8_5
+.4byte sRaltsAnims_8_6
+.4byte sRaltsAnims_8_7
+.4byte sRaltsAnims_8_8
+sRaltsAnimTable9:
+.4byte sRaltsAnims_9_1
+.4byte sRaltsAnims_9_2
+.4byte sRaltsAnims_9_3
+.4byte sRaltsAnims_9_4
+.4byte sRaltsAnims_9_5
+.4byte sRaltsAnims_9_6
+.4byte sRaltsAnims_9_7
+.4byte sRaltsAnims_9_8
+sRaltsAnimTable10:
+.4byte sRaltsAnims_10_1
+.4byte sRaltsAnims_10_2
+.4byte sRaltsAnims_10_3
+.4byte sRaltsAnims_10_4
+.4byte sRaltsAnims_10_5
+.4byte sRaltsAnims_10_6
+.4byte sRaltsAnims_10_7
+.4byte sRaltsAnims_10_8
+sRaltsAnimTable11:
+.4byte sRaltsAnims_11_1
+.4byte sRaltsAnims_11_2
+.4byte sRaltsAnims_11_3
+.4byte sRaltsAnims_11_4
+.4byte sRaltsAnims_11_5
+.4byte sRaltsAnims_11_6
+.4byte sRaltsAnims_11_7
+.4byte sRaltsAnims_11_8
+sRaltsAnimTable12:
+.4byte sRaltsAnims_12_1
+.4byte sRaltsAnims_12_2
+.4byte sRaltsAnims_12_3
+.4byte sRaltsAnims_12_4
+.4byte sRaltsAnims_12_5
+.4byte sRaltsAnims_12_6
+.4byte sRaltsAnims_12_7
+.4byte sRaltsAnims_12_8
+sRaltsAnimTable13:
+.4byte sRaltsAnims_13_1
+.4byte sRaltsAnims_13_2
+.4byte sRaltsAnims_13_3
+.4byte sRaltsAnims_13_4
+.4byte sRaltsAnims_13_5
+.4byte sRaltsAnims_13_6
+.4byte sRaltsAnims_13_7
+.4byte sRaltsAnims_13_8
+sAxAnimationsRalts:
+.4byte sRaltsAnimTable1
+.4byte sRaltsAnimTable2
+.4byte sRaltsAnimTable3
+.4byte sRaltsAnimTable4
+.4byte sRaltsAnimTable5
+.4byte sRaltsAnimTable6
+.4byte sRaltsAnimTable7
+.4byte sRaltsAnimTable8
+.4byte sRaltsAnimTable9
+.4byte sRaltsAnimTable10
+.4byte sRaltsAnimTable11
+.4byte sRaltsAnimTable12
+.4byte sRaltsAnimTable13
+sAxSpritesRalts:
+.4byte sRaltsSprites1
+.4byte sRaltsSprites2
+.4byte sRaltsSprites3
+.4byte sRaltsSprites4
+.4byte sRaltsSprites5
+.4byte sRaltsSprites6
+.4byte sRaltsSprites7
+.4byte sRaltsSprites8
+.4byte sRaltsSprites9
+.4byte sRaltsSprites10
+.4byte sRaltsSprites11
+.4byte sRaltsSprites12
+.4byte sRaltsSprites13
+.4byte sRaltsSprites14
+.4byte sRaltsSprites15
+.4byte sRaltsSprites16
+.4byte sRaltsSprites17
+.4byte sRaltsSprites18
+.4byte sRaltsSprites19
+.4byte sRaltsSprites20
+.4byte sRaltsSprites21
+.4byte sRaltsSprites22
+.4byte sRaltsSprites23
+.4byte sRaltsSprites24
+.4byte sRaltsSprites25
+.4byte sRaltsSprites26
+.4byte sRaltsSprites27
+sAxMainRalts:
+ax_main sAxPosesRalts, sAxAnimationsRalts, 13, sAxSpritesRalts, sAxPositionsRalts

--- a/data/ax/rapidash.inc
+++ b/data/ax/rapidash.inc
@@ -1,0 +1,3571 @@
+.global gAxRapidash
+gAxRapidash:
+ax_siro sAxMainRapidash
+sRapidashPose1:
+ax_pose 0, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose2:
+ax_pose 1, 0x81e6, 0x4108, 0x0c00
+ax_pose 2, 0x81e6, 0x80f8, 0x0c04
+ax_pose 3, 0x01de, 0x0100, 0x0c0c
+ax_pose 4, 0x01de, 0x00f8, 0x0c0d
+ax_pose_terminator
+sRapidashPose3:
+ax_pose 5, 0x81e6, 0x80f8, 0x0c00
+ax_pose 6, 0x81e6, 0x4108, 0x0c08
+ax_pose 7, 0x01de, 0x0100, 0x0c0c
+ax_pose 8, 0x01de, 0x00f8, 0x0c0d
+ax_pose_terminator
+sRapidashPose4:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose5:
+ax_pose 10, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose6:
+ax_pose 11, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose7:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose8:
+ax_pose 13, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose9:
+ax_pose 14, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose10:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose11:
+ax_pose 16, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose12:
+ax_pose 17, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose13:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose14:
+ax_pose 19, 0x81e3, 0x80f8, 0x0c00
+ax_pose 20, 0x0203, 0x00f9, 0x0c08
+ax_pose_terminator
+sRapidashPose15:
+ax_pose 21, 0x81e3, 0x80f9, 0x0c00
+ax_pose 22, 0x0203, 0x0100, 0x0c08
+ax_pose_terminator
+sRapidashPose16:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose17:
+ax_pose 16, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose18:
+ax_pose 17, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose19:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose20:
+ax_pose 13, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose21:
+ax_pose 14, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose22:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose23:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose24:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose25:
+ax_pose 0, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose26:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose 3, 0x01de, 0x0100, 0x0c08
+ax_pose 4, 0x01de, 0x00f8, 0x0c09
+ax_pose_terminator
+sRapidashPose27:
+ax_pose 5, 0x81e6, 0x80f8, 0x0c00
+ax_pose 6, 0x81e6, 0x4108, 0x0c08
+ax_pose 7, 0x01de, 0x0100, 0x0c0c
+ax_pose 8, 0x01de, 0x00f8, 0x0c0d
+ax_pose_terminator
+sRapidashPose28:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose29:
+ax_pose 24, 0x81e2, 0x80f9, 0x0c00
+ax_pose 25, 0x01da, 0x00f9, 0x0c08
+ax_pose 26, 0x01da, 0x0101, 0x0c09
+ax_pose_terminator
+sRapidashPose30:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose31:
+ax_pose 10, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose32:
+ax_pose 11, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose33:
+ax_pose 27, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose34:
+ax_pose 28, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose35:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose36:
+ax_pose 13, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose37:
+ax_pose 14, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose38:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose39:
+ax_pose 34, 0x81e3, 0x90f2, 0x0c00
+ax_pose 35, 0x81e3, 0x1102, 0x0c08
+ax_pose 36, 0x01f3, 0x1102, 0x0c0a
+ax_pose 37, 0x01f3, 0x10ea, 0x0c0b
+ax_pose 38, 0x01eb, 0x10ea, 0x0c0c
+ax_pose 39, 0x01e3, 0x10ea, 0x0c0d
+ax_pose 40, 0x01db, 0x10fa, 0x0c0e
+ax_pose 41, 0x01db, 0x1102, 0x0c0f
+ax_pose_terminator
+sRapidashPose40:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose41:
+ax_pose 16, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose42:
+ax_pose 17, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose43:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose44:
+ax_pose 43, 0x41e4, 0x90eb, 0x0c00
+ax_pose 44, 0x01f4, 0x50eb, 0x0c08
+ax_pose 45, 0x81f4, 0x10fb, 0x0c0c
+ax_pose 46, 0x01f4, 0x1103, 0x0c0e
+ax_pose 47, 0x01dc, 0x10fb, 0x0c0f
+ax_pose_terminator
+sRapidashPose45:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose46:
+ax_pose 19, 0x81e3, 0x80f8, 0x0c00
+ax_pose 20, 0x0203, 0x00f9, 0x0c08
+ax_pose_terminator
+sRapidashPose47:
+ax_pose 21, 0x81e3, 0x80f9, 0x0c00
+ax_pose 22, 0x0203, 0x0100, 0x0c08
+ax_pose_terminator
+sRapidashPose48:
+ax_pose 48, 0x81e4, 0x80f7, 0x0c00
+ax_pose 49, 0x01f4, 0x00ef, 0x0c08
+ax_pose 50, 0x01f4, 0x0107, 0x0c09
+ax_pose 51, 0x01dc, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose49:
+ax_pose 52, 0x81e6, 0x80f8, 0x0c00
+ax_pose 53, 0x01de, 0x00f8, 0x0c08
+ax_pose 54, 0x01de, 0x0100, 0x0c09
+ax_pose_terminator
+sRapidashPose50:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose51:
+ax_pose 16, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose52:
+ax_pose 17, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose53:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose54:
+ax_pose 43, 0x41e4, 0x80f6, 0x0c00
+ax_pose 44, 0x01f4, 0x4106, 0x0c08
+ax_pose 45, 0x81f4, 0x00fe, 0x0c0c
+ax_pose 46, 0x01f4, 0x00f6, 0x0c0e
+ax_pose 47, 0x01dc, 0x00fe, 0x0c0f
+ax_pose_terminator
+sRapidashPose55:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose56:
+ax_pose 13, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose57:
+ax_pose 14, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose58:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose59:
+ax_pose 34, 0x81e3, 0x80ff, 0x0c00
+ax_pose 35, 0x81e3, 0x00f7, 0x0c08
+ax_pose 36, 0x01f3, 0x00f7, 0x0c0a
+ax_pose 37, 0x01f3, 0x010f, 0x0c0b
+ax_pose 38, 0x01eb, 0x010f, 0x0c0c
+ax_pose 39, 0x01e3, 0x010f, 0x0c0d
+ax_pose 40, 0x01db, 0x00ff, 0x0c0e
+ax_pose 41, 0x01db, 0x00f7, 0x0c0f
+ax_pose_terminator
+sRapidashPose60:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose61:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose62:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose63:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose64:
+ax_pose 28, 0x01e0, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose65:
+ax_pose 0, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose66:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose 3, 0x01de, 0x0100, 0x0c08
+ax_pose 4, 0x01de, 0x00f8, 0x0c09
+ax_pose_terminator
+sRapidashPose67:
+ax_pose 5, 0x81e6, 0x80f8, 0x0c00
+ax_pose 6, 0x81e6, 0x4108, 0x0c08
+ax_pose 7, 0x01de, 0x0100, 0x0c0c
+ax_pose 8, 0x01de, 0x00f8, 0x0c0d
+ax_pose_terminator
+sRapidashPose68:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose69:
+ax_pose 24, 0x81e2, 0x80f9, 0x0c00
+ax_pose 25, 0x01da, 0x00f9, 0x0c08
+ax_pose 26, 0x01da, 0x0101, 0x0c09
+ax_pose_terminator
+sRapidashPose70:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose71:
+ax_pose 10, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose72:
+ax_pose 11, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose73:
+ax_pose 27, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose74:
+ax_pose 28, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose75:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose76:
+ax_pose 13, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose77:
+ax_pose 14, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose78:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose79:
+ax_pose 34, 0x81e3, 0x90f2, 0x0c00
+ax_pose 35, 0x81e3, 0x1102, 0x0c08
+ax_pose 36, 0x01f3, 0x1102, 0x0c0a
+ax_pose 37, 0x01f3, 0x10ea, 0x0c0b
+ax_pose 38, 0x01eb, 0x10ea, 0x0c0c
+ax_pose 39, 0x01e3, 0x10ea, 0x0c0d
+ax_pose 40, 0x01db, 0x10fa, 0x0c0e
+ax_pose 41, 0x01db, 0x1102, 0x0c0f
+ax_pose_terminator
+sRapidashPose80:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose81:
+ax_pose 16, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose82:
+ax_pose 17, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose83:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose84:
+ax_pose 43, 0x41e4, 0x90eb, 0x0c00
+ax_pose 44, 0x01f4, 0x50eb, 0x0c08
+ax_pose 45, 0x81f4, 0x10fb, 0x0c0c
+ax_pose 46, 0x01f4, 0x1103, 0x0c0e
+ax_pose 47, 0x01dc, 0x10fb, 0x0c0f
+ax_pose_terminator
+sRapidashPose85:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose86:
+ax_pose 19, 0x81e3, 0x80f8, 0x0c00
+ax_pose 20, 0x0203, 0x00f9, 0x0c08
+ax_pose_terminator
+sRapidashPose87:
+ax_pose 21, 0x81e3, 0x80f9, 0x0c00
+ax_pose 22, 0x0203, 0x0100, 0x0c08
+ax_pose_terminator
+sRapidashPose88:
+ax_pose 48, 0x81e4, 0x80f7, 0x0c00
+ax_pose 49, 0x01f4, 0x00ef, 0x0c08
+ax_pose 50, 0x01f4, 0x0107, 0x0c09
+ax_pose 51, 0x01dc, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose89:
+ax_pose 52, 0x81e6, 0x80f8, 0x0c00
+ax_pose 53, 0x01de, 0x00f8, 0x0c08
+ax_pose 54, 0x01de, 0x0100, 0x0c09
+ax_pose_terminator
+sRapidashPose90:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose91:
+ax_pose 16, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose92:
+ax_pose 17, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose93:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose94:
+ax_pose 43, 0x41e4, 0x80f6, 0x0c00
+ax_pose 44, 0x01f4, 0x4106, 0x0c08
+ax_pose 45, 0x81f4, 0x00fe, 0x0c0c
+ax_pose 46, 0x01f4, 0x00f6, 0x0c0e
+ax_pose 47, 0x01dc, 0x00fe, 0x0c0f
+ax_pose_terminator
+sRapidashPose95:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose96:
+ax_pose 13, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose97:
+ax_pose 14, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose98:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose99:
+ax_pose 34, 0x81e3, 0x80ff, 0x0c00
+ax_pose 35, 0x81e3, 0x00f7, 0x0c08
+ax_pose 36, 0x01f3, 0x00f7, 0x0c0a
+ax_pose 37, 0x01f3, 0x010f, 0x0c0b
+ax_pose 38, 0x01eb, 0x010f, 0x0c0c
+ax_pose 39, 0x01e3, 0x010f, 0x0c0d
+ax_pose 40, 0x01db, 0x00ff, 0x0c0e
+ax_pose 41, 0x01db, 0x00f7, 0x0c0f
+ax_pose_terminator
+sRapidashPose100:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose101:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose102:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose103:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose104:
+ax_pose 28, 0x01e0, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose105:
+ax_pose 0, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose106:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose 3, 0x01de, 0x0100, 0x0c08
+ax_pose 4, 0x01de, 0x00f8, 0x0c09
+ax_pose_terminator
+sRapidashPose107:
+ax_pose 5, 0x81e6, 0x80f8, 0x0c00
+ax_pose 6, 0x81e6, 0x4108, 0x0c08
+ax_pose 7, 0x01de, 0x0100, 0x0c0c
+ax_pose 8, 0x01de, 0x00f8, 0x0c0d
+ax_pose_terminator
+sRapidashPose108:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose109:
+ax_pose 24, 0x81e2, 0x80f9, 0x0c00
+ax_pose 25, 0x01da, 0x00f9, 0x0c08
+ax_pose 26, 0x01da, 0x0101, 0x0c09
+ax_pose_terminator
+sRapidashPose110:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose111:
+ax_pose 10, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose112:
+ax_pose 11, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose113:
+ax_pose 27, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose114:
+ax_pose 28, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose115:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose116:
+ax_pose 13, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose117:
+ax_pose 14, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose118:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose119:
+ax_pose 34, 0x81e3, 0x90f2, 0x0c00
+ax_pose 35, 0x81e3, 0x1102, 0x0c08
+ax_pose 36, 0x01f3, 0x1102, 0x0c0a
+ax_pose 37, 0x01f3, 0x10ea, 0x0c0b
+ax_pose 38, 0x01eb, 0x10ea, 0x0c0c
+ax_pose 39, 0x01e3, 0x10ea, 0x0c0d
+ax_pose 40, 0x01db, 0x10fa, 0x0c0e
+ax_pose 41, 0x01db, 0x1102, 0x0c0f
+ax_pose_terminator
+sRapidashPose120:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose121:
+ax_pose 16, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose122:
+ax_pose 17, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose123:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose124:
+ax_pose 43, 0x41e4, 0x90eb, 0x0c00
+ax_pose 44, 0x01f4, 0x50eb, 0x0c08
+ax_pose 45, 0x81f4, 0x10fb, 0x0c0c
+ax_pose 46, 0x01f4, 0x1103, 0x0c0e
+ax_pose 47, 0x01dc, 0x10fb, 0x0c0f
+ax_pose_terminator
+sRapidashPose125:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose126:
+ax_pose 19, 0x81e3, 0x80f8, 0x0c00
+ax_pose 20, 0x0203, 0x00f9, 0x0c08
+ax_pose_terminator
+sRapidashPose127:
+ax_pose 21, 0x81e3, 0x80f9, 0x0c00
+ax_pose 22, 0x0203, 0x0100, 0x0c08
+ax_pose_terminator
+sRapidashPose128:
+ax_pose 48, 0x81e4, 0x80f7, 0x0c00
+ax_pose 49, 0x01f4, 0x00ef, 0x0c08
+ax_pose 50, 0x01f4, 0x0107, 0x0c09
+ax_pose 51, 0x01dc, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose129:
+ax_pose 52, 0x81e6, 0x80f8, 0x0c00
+ax_pose 53, 0x01de, 0x00f8, 0x0c08
+ax_pose 54, 0x01de, 0x0100, 0x0c09
+ax_pose_terminator
+sRapidashPose130:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose131:
+ax_pose 16, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose132:
+ax_pose 17, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose133:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose134:
+ax_pose 43, 0x41e4, 0x80f6, 0x0c00
+ax_pose 44, 0x01f4, 0x4106, 0x0c08
+ax_pose 45, 0x81f4, 0x00fe, 0x0c0c
+ax_pose 46, 0x01f4, 0x00f6, 0x0c0e
+ax_pose 47, 0x01dc, 0x00fe, 0x0c0f
+ax_pose_terminator
+sRapidashPose135:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose136:
+ax_pose 13, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose137:
+ax_pose 14, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose138:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose139:
+ax_pose 34, 0x81e3, 0x80ff, 0x0c00
+ax_pose 35, 0x81e3, 0x00f7, 0x0c08
+ax_pose 36, 0x01f3, 0x00f7, 0x0c0a
+ax_pose 37, 0x01f3, 0x010f, 0x0c0b
+ax_pose 38, 0x01eb, 0x010f, 0x0c0c
+ax_pose 39, 0x01e3, 0x010f, 0x0c0d
+ax_pose 40, 0x01db, 0x00ff, 0x0c0e
+ax_pose 41, 0x01db, 0x00f7, 0x0c0f
+ax_pose_terminator
+sRapidashPose140:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose141:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose142:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose143:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose144:
+ax_pose 28, 0x01e0, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose145:
+ax_pose 0, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose146:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose 3, 0x01de, 0x0100, 0x0c08
+ax_pose 4, 0x01de, 0x00f8, 0x0c09
+ax_pose_terminator
+sRapidashPose147:
+ax_pose 5, 0x81e6, 0x80f8, 0x0c00
+ax_pose 6, 0x81e6, 0x4108, 0x0c08
+ax_pose 7, 0x01de, 0x0100, 0x0c0c
+ax_pose 8, 0x01de, 0x00f8, 0x0c0d
+ax_pose_terminator
+sRapidashPose148:
+ax_pose 55, 0x81de, 0x80f9, 0x0c00
+ax_pose 56, 0x01d6, 0x00f9, 0x0c08
+ax_pose 57, 0x01d6, 0x0101, 0x0c09
+ax_pose_terminator
+sRapidashPose149:
+ax_pose 24, 0x81de, 0x80f9, 0x0c00
+ax_pose 25, 0x01d6, 0x00f9, 0x0c08
+ax_pose 26, 0x01d6, 0x0101, 0x0c09
+ax_pose_terminator
+sRapidashPose150:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose151:
+ax_pose 10, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose152:
+ax_pose 11, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose153:
+ax_pose 58, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose154:
+ax_pose 28, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose155:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose156:
+ax_pose 13, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose157:
+ax_pose 14, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose158:
+ax_pose 59, 0x41e3, 0x90ee, 0x0c00
+ax_pose 60, 0x01f3, 0x50f6, 0x0c08
+ax_pose 61, 0x01f3, 0x1106, 0x0c0c
+ax_pose 62, 0x01db, 0x10fe, 0x0c0d
+ax_pose 63, 0x01db, 0x10f6, 0x0c0e
+ax_pose 64, 0x01f3, 0x10ee, 0x0c0f
+ax_pose_terminator
+sRapidashPose159:
+ax_pose 34, 0x81e3, 0x90f2, 0x0c00
+ax_pose 35, 0x81e3, 0x1102, 0x0c08
+ax_pose 36, 0x01f3, 0x1102, 0x0c0a
+ax_pose 37, 0x01f3, 0x10ea, 0x0c0b
+ax_pose 38, 0x01eb, 0x10ea, 0x0c0c
+ax_pose 39, 0x01e3, 0x10ea, 0x0c0d
+ax_pose 40, 0x01db, 0x10fa, 0x0c0e
+ax_pose 41, 0x01db, 0x1102, 0x0c0f
+ax_pose_terminator
+sRapidashPose160:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose161:
+ax_pose 16, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose162:
+ax_pose 17, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose163:
+ax_pose 65, 0x41e4, 0x90ea, 0x0c00
+ax_pose 66, 0x01f4, 0x50ea, 0x0c08
+ax_pose 67, 0x81f4, 0x10fa, 0x0c0c
+ax_pose 68, 0x01f4, 0x1102, 0x0c0e
+ax_pose 69, 0x01dc, 0x10fa, 0x0c0f
+ax_pose_terminator
+sRapidashPose164:
+ax_pose 43, 0x41e4, 0x90eb, 0x0c00
+ax_pose 44, 0x01f4, 0x50eb, 0x0c08
+ax_pose 45, 0x81f4, 0x10fb, 0x0c0c
+ax_pose 46, 0x01f4, 0x1103, 0x0c0e
+ax_pose 47, 0x01dc, 0x10fb, 0x0c0f
+ax_pose_terminator
+sRapidashPose165:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose166:
+ax_pose 19, 0x81e3, 0x80f8, 0x0c00
+ax_pose 20, 0x0203, 0x00f9, 0x0c08
+ax_pose_terminator
+sRapidashPose167:
+ax_pose 21, 0x81e3, 0x80f9, 0x0c00
+ax_pose 22, 0x0203, 0x0100, 0x0c08
+ax_pose_terminator
+sRapidashPose168:
+ax_pose 70, 0x81e6, 0x80f9, 0x0c00
+ax_pose 71, 0x01de, 0x00f9, 0x0c08
+ax_pose 72, 0x01de, 0x0101, 0x0c09
+ax_pose 73, 0x01ee, 0x00f1, 0x0c0a
+ax_pose_terminator
+sRapidashPose169:
+ax_pose 52, 0x81e6, 0x80f8, 0x0c00
+ax_pose 53, 0x01de, 0x00f8, 0x0c08
+ax_pose 54, 0x01de, 0x0100, 0x0c09
+ax_pose_terminator
+sRapidashPose170:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose171:
+ax_pose 16, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose172:
+ax_pose 17, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose173:
+ax_pose 65, 0x41e4, 0x80f7, 0x0c00
+ax_pose 66, 0x01f4, 0x4107, 0x0c08
+ax_pose 67, 0x81f4, 0x00ff, 0x0c0c
+ax_pose 68, 0x01f4, 0x00f7, 0x0c0e
+ax_pose 69, 0x01dc, 0x00ff, 0x0c0f
+ax_pose_terminator
+sRapidashPose174:
+ax_pose 43, 0x41e4, 0x80f6, 0x0c00
+ax_pose 44, 0x01f4, 0x4106, 0x0c08
+ax_pose 45, 0x81f4, 0x00fe, 0x0c0c
+ax_pose 46, 0x01f4, 0x00f6, 0x0c0e
+ax_pose 47, 0x01dc, 0x00fe, 0x0c0f
+ax_pose_terminator
+sRapidashPose175:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose176:
+ax_pose 13, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose177:
+ax_pose 14, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose178:
+ax_pose 59, 0x41e3, 0x80f3, 0x0c00
+ax_pose 60, 0x01f3, 0x40fb, 0x0c08
+ax_pose 61, 0x01f3, 0x00f3, 0x0c0c
+ax_pose 62, 0x01db, 0x00fb, 0x0c0d
+ax_pose 63, 0x01db, 0x0103, 0x0c0e
+ax_pose 64, 0x01f3, 0x010b, 0x0c0f
+ax_pose_terminator
+sRapidashPose179:
+ax_pose 34, 0x81e3, 0x80ff, 0x0c00
+ax_pose 35, 0x81e3, 0x00f7, 0x0c08
+ax_pose 36, 0x01f3, 0x00f7, 0x0c0a
+ax_pose 37, 0x01f3, 0x010f, 0x0c0b
+ax_pose 38, 0x01eb, 0x010f, 0x0c0c
+ax_pose 39, 0x01e3, 0x010f, 0x0c0d
+ax_pose 40, 0x01db, 0x00ff, 0x0c0e
+ax_pose 41, 0x01db, 0x00f7, 0x0c0f
+ax_pose_terminator
+sRapidashPose180:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose181:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose182:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose183:
+ax_pose 58, 0x01e0, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose184:
+ax_pose 28, 0x01e0, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose185:
+ax_pose 74, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose186:
+ax_pose 75, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose187:
+ax_pose 76, 0x01e0, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose188:
+ax_pose 77, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose189:
+ax_pose 78, 0x01e3, 0x90ea, 0x0c00
+ax_pose_terminator
+sRapidashPose190:
+ax_pose 79, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sRapidashPose191:
+ax_pose 80, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose192:
+ax_pose 79, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose193:
+ax_pose 78, 0x01e3, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose194:
+ax_pose 77, 0x01e3, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose195:
+ax_pose 0, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose196:
+ax_pose 2, 0x81e6, 0x80f8, 0x0c00
+ax_pose 3, 0x01de, 0x0100, 0x0c08
+ax_pose 4, 0x01de, 0x00f8, 0x0c09
+ax_pose_terminator
+sRapidashPose197:
+ax_pose 5, 0x81e6, 0x80f8, 0x0c00
+ax_pose 6, 0x81e6, 0x4108, 0x0c08
+ax_pose 7, 0x01de, 0x0100, 0x0c0c
+ax_pose 8, 0x01de, 0x00f8, 0x0c0d
+ax_pose_terminator
+sRapidashPose198:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose199:
+ax_pose 24, 0x81e2, 0x80f9, 0x0c00
+ax_pose 25, 0x01da, 0x00f9, 0x0c08
+ax_pose 26, 0x01da, 0x0101, 0x0c09
+ax_pose_terminator
+sRapidashPose200:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose201:
+ax_pose 10, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose202:
+ax_pose 11, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose203:
+ax_pose 27, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose204:
+ax_pose 28, 0x01e0, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose205:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose206:
+ax_pose 13, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose207:
+ax_pose 14, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose208:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose209:
+ax_pose 34, 0x81e3, 0x90f2, 0x0c00
+ax_pose 35, 0x81e3, 0x1102, 0x0c08
+ax_pose 36, 0x01f3, 0x1102, 0x0c0a
+ax_pose 37, 0x01f3, 0x10ea, 0x0c0b
+ax_pose 38, 0x01eb, 0x10ea, 0x0c0c
+ax_pose 39, 0x01e3, 0x10ea, 0x0c0d
+ax_pose 40, 0x01db, 0x10fa, 0x0c0e
+ax_pose 41, 0x01db, 0x1102, 0x0c0f
+ax_pose_terminator
+sRapidashPose210:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose211:
+ax_pose 16, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose212:
+ax_pose 17, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose213:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose214:
+ax_pose 43, 0x41e4, 0x90eb, 0x0c00
+ax_pose 44, 0x01f4, 0x50eb, 0x0c08
+ax_pose 45, 0x81f4, 0x10fb, 0x0c0c
+ax_pose 46, 0x01f4, 0x1103, 0x0c0e
+ax_pose 47, 0x01dc, 0x10fb, 0x0c0f
+ax_pose_terminator
+sRapidashPose215:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose216:
+ax_pose 19, 0x81e3, 0x80f8, 0x0c00
+ax_pose 20, 0x0203, 0x00f9, 0x0c08
+ax_pose_terminator
+sRapidashPose217:
+ax_pose 21, 0x81e3, 0x80f9, 0x0c00
+ax_pose 22, 0x0203, 0x0100, 0x0c08
+ax_pose_terminator
+sRapidashPose218:
+ax_pose 48, 0x81e4, 0x80f7, 0x0c00
+ax_pose 49, 0x01f4, 0x00ef, 0x0c08
+ax_pose 50, 0x01f4, 0x0107, 0x0c09
+ax_pose 51, 0x01dc, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose219:
+ax_pose 52, 0x81e6, 0x80f8, 0x0c00
+ax_pose 53, 0x01de, 0x00f8, 0x0c08
+ax_pose 54, 0x01de, 0x0100, 0x0c09
+ax_pose_terminator
+sRapidashPose220:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose221:
+ax_pose 16, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose222:
+ax_pose 17, 0x01e4, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose223:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose224:
+ax_pose 43, 0x41e4, 0x80f6, 0x0c00
+ax_pose 44, 0x01f4, 0x4106, 0x0c08
+ax_pose 45, 0x81f4, 0x00fe, 0x0c0c
+ax_pose 46, 0x01f4, 0x00f6, 0x0c0e
+ax_pose 47, 0x01dc, 0x00fe, 0x0c0f
+ax_pose_terminator
+sRapidashPose225:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose226:
+ax_pose 13, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose227:
+ax_pose 14, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose228:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose229:
+ax_pose 34, 0x81e3, 0x80ff, 0x0c00
+ax_pose 35, 0x81e3, 0x00f7, 0x0c08
+ax_pose 36, 0x01f3, 0x00f7, 0x0c0a
+ax_pose 37, 0x01f3, 0x010f, 0x0c0b
+ax_pose 38, 0x01eb, 0x010f, 0x0c0c
+ax_pose 39, 0x01e3, 0x010f, 0x0c0d
+ax_pose 40, 0x01db, 0x00ff, 0x0c0e
+ax_pose 41, 0x01db, 0x00f7, 0x0c0f
+ax_pose_terminator
+sRapidashPose230:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose231:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose232:
+ax_pose 11, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose233:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose234:
+ax_pose 28, 0x01e0, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose235:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose236:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose237:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose238:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose239:
+ax_pose 48, 0x81e5, 0x80f7, 0x0c00
+ax_pose 49, 0x01f5, 0x00ef, 0x0c08
+ax_pose 50, 0x01f5, 0x0107, 0x0c09
+ax_pose 51, 0x01dd, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose240:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose241:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose242:
+ax_pose 27, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose243:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose244:
+ax_pose 27, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose245:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose246:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose247:
+ax_pose 48, 0x81e5, 0x80f7, 0x0c00
+ax_pose 49, 0x01f5, 0x00ef, 0x0c08
+ax_pose 50, 0x01f5, 0x0107, 0x0c09
+ax_pose 51, 0x01dd, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose248:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose249:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose250:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose251:
+ax_pose 0, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose252:
+ax_pose 24, 0x81e2, 0x80f9, 0x0c00
+ax_pose 25, 0x01da, 0x00f9, 0x0c08
+ax_pose 26, 0x01da, 0x0101, 0x0c09
+ax_pose_terminator
+sRapidashPose253:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose254:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose255:
+ax_pose 28, 0x01e0, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose256:
+ax_pose 27, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sRapidashPose257:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose258:
+ax_pose 34, 0x81e3, 0x90f2, 0x0c00
+ax_pose 35, 0x81e3, 0x1102, 0x0c08
+ax_pose 36, 0x01f3, 0x1102, 0x0c0a
+ax_pose 37, 0x01f3, 0x10ea, 0x0c0b
+ax_pose 38, 0x01eb, 0x10ea, 0x0c0c
+ax_pose 39, 0x01e3, 0x10ea, 0x0c0d
+ax_pose 40, 0x01db, 0x10fa, 0x0c0e
+ax_pose 41, 0x01db, 0x1102, 0x0c0f
+ax_pose_terminator
+sRapidashPose259:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose260:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose261:
+ax_pose 43, 0x41e4, 0x90ed, 0x0c00
+ax_pose 44, 0x01f4, 0x50ed, 0x0c08
+ax_pose 45, 0x81f4, 0x10fd, 0x0c0c
+ax_pose 46, 0x01f4, 0x1105, 0x0c0e
+ax_pose 47, 0x01dc, 0x10fd, 0x0c0f
+ax_pose_terminator
+sRapidashPose262:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose263:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose264:
+ax_pose 52, 0x81e6, 0x80f8, 0x0c00
+ax_pose 53, 0x01de, 0x00f8, 0x0c08
+ax_pose 54, 0x01de, 0x0100, 0x0c09
+ax_pose_terminator
+sRapidashPose265:
+ax_pose 48, 0x81e4, 0x80f7, 0x0c00
+ax_pose 49, 0x01f4, 0x00ef, 0x0c08
+ax_pose 50, 0x01f4, 0x0107, 0x0c09
+ax_pose 51, 0x01dc, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose266:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose267:
+ax_pose 43, 0x41e4, 0x80f4, 0x0c00
+ax_pose 44, 0x01f4, 0x4104, 0x0c08
+ax_pose 45, 0x81f4, 0x00fc, 0x0c0c
+ax_pose 46, 0x01f4, 0x00f4, 0x0c0e
+ax_pose 47, 0x01dc, 0x00fc, 0x0c0f
+ax_pose_terminator
+sRapidashPose268:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose269:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose270:
+ax_pose 34, 0x81e3, 0x80ff, 0x0c00
+ax_pose 35, 0x81e3, 0x00f7, 0x0c08
+ax_pose 36, 0x01f3, 0x00f7, 0x0c0a
+ax_pose 37, 0x01f3, 0x010f, 0x0c0b
+ax_pose 38, 0x01eb, 0x010f, 0x0c0c
+ax_pose 39, 0x01e3, 0x010f, 0x0c0d
+ax_pose 40, 0x01db, 0x00ff, 0x0c0e
+ax_pose 41, 0x01db, 0x00f7, 0x0c0f
+ax_pose_terminator
+sRapidashPose271:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose272:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose273:
+ax_pose 28, 0x01e0, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose274:
+ax_pose 27, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose275:
+ax_pose 23, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose276:
+ax_pose 27, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose277:
+ax_pose 29, 0x81e7, 0x80f3, 0x0c00
+ax_pose 30, 0x81e7, 0x4103, 0x0c08
+ax_pose 31, 0x81ef, 0x010b, 0x0c0c
+ax_pose 32, 0x01e7, 0x00eb, 0x0c0e
+ax_pose 33, 0x01ef, 0x00eb, 0x0c0f
+ax_pose_terminator
+sRapidashPose278:
+ax_pose 42, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sRapidashPose279:
+ax_pose 48, 0x81e5, 0x80f7, 0x0c00
+ax_pose 49, 0x01f5, 0x00ef, 0x0c08
+ax_pose 50, 0x01f5, 0x0107, 0x0c09
+ax_pose 51, 0x01dd, 0x00ff, 0x0c0a
+ax_pose_terminator
+sRapidashPose280:
+ax_pose 42, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sRapidashPose281:
+ax_pose 29, 0x81e7, 0x90fd, 0x0c00
+ax_pose 30, 0x81e7, 0x50f5, 0x0c08
+ax_pose 31, 0x81ef, 0x10ed, 0x0c0c
+ax_pose 32, 0x01e8, 0x110d, 0x0c0e
+ax_pose 33, 0x01f0, 0x110d, 0x0c0f
+ax_pose_terminator
+sRapidashPose282:
+ax_pose 27, 0x01e6, 0x90f1, 0x0c00
+ax_pose_terminator
+sRapidashPose283:
+ax_pose 0, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sRapidashPose284:
+ax_pose 9, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose285:
+ax_pose 12, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sRapidashPose286:
+ax_pose 15, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sRapidashPose287:
+ax_pose 18, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sRapidashPose288:
+ax_pose 15, 0x01e5, 0x90eb, 0x0c00
+ax_pose_terminator
+sRapidashPose289:
+ax_pose 12, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sRapidashPose290:
+ax_pose 9, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+.align 2
+sRapidashAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_2_1:
+ax_anim 2, 0, 28, 0, -1, 0, -1,
+ax_anim 6, 0, 28, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRapidashAnims_2_2:
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 6, 0, 33, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 4, 4, 4,
+ax_anim 1, 0, 32, 10, 10, 10, 10,
+ax_anim 2, 0, 32, 18, 18, 18, 18,
+ax_anim 2, 1, 32, 19, 17, 19, 17,
+ax_anim 2, 0, 32, 18, 18, 18, 18,
+ax_anim 2, 0, 32, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sRapidashAnims_2_3:
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 6, 0, 38, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 4, 0, 4, 0,
+ax_anim 1, 0, 37, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 1, 37, 18, 1, 18, 1,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 37, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sRapidashAnims_2_4:
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 6, 0, 43, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 42, 5, -6, 5, -6,
+ax_anim 1, 0, 42, 13, -13, 13, -13,
+ax_anim 2, 0, 42, 18, -17, 18, -17,
+ax_anim 2, 1, 42, 19, -16, 19, -16,
+ax_anim 2, 0, 42, 18, -17, 18, -17,
+ax_anim 2, 0, 42, 19, -16, 19, -16,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sRapidashAnims_2_5:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 6, 0, 48, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 47, 0, -4, 0, -4,
+ax_anim 1, 0, 47, 0, -11, 0, -11,
+ax_anim 2, 0, 47, 0, -15, 0, -15,
+ax_anim 2, 1, 47, 1, -15, 1, -15,
+ax_anim 2, 0, 47, 0, -15, 0, -15,
+ax_anim 2, 0, 47, 1, -15, 1, -15,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sRapidashAnims_2_6:
+ax_anim 2, 0, 53, 1, 1, 1, 1,
+ax_anim 6, 0, 53, 2, 2, 2, 2,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 2, 52, -5, -6, -5, -6,
+ax_anim 1, 0, 52, -13, -13, -13, -13,
+ax_anim 2, 0, 52, -18, -17, -18, -17,
+ax_anim 2, 1, 52, -19, -16, -19, -16,
+ax_anim 2, 0, 52, -18, -17, -18, -17,
+ax_anim 2, 0, 52, -19, -16, -19, -16,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sRapidashAnims_2_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 6, 0, 58, 2, 0, 2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 57, -4, 0, -4, 0,
+ax_anim 1, 0, 57, -10, 0, -10, 0,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 1, 57, -18, 1, -18, 1,
+ax_anim 2, 0, 57, -18, 0, -18, 0,
+ax_anim 2, 0, 57, -18, 1, -18, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sRapidashAnims_2_8:
+ax_anim 2, 0, 63, 1, -1, 1, -1,
+ax_anim 6, 0, 63, 2, -2, 2, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 62, -4, 4, -4, 4,
+ax_anim 1, 0, 62, -10, 10, -10, 10,
+ax_anim 2, 0, 62, -18, 18, -18, 18,
+ax_anim 2, 1, 62, -19, 17, -19, 17,
+ax_anim 2, 0, 62, -18, 18, -18, 18,
+ax_anim 2, 0, 62, -19, 17, -19, 17,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRapidashAnims_3_1:
+ax_anim 2, 0, 68, 0, -1, 0, -1,
+ax_anim 6, 0, 68, 0, -2, 0, -2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 0, 4, 0, 4,
+ax_anim 1, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 1, 67, 1, 17, 1, 17,
+ax_anim 2, 0, 67, 0, 17, 0, 17,
+ax_anim 2, 0, 67, 1, 17, 1, 17,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sRapidashAnims_3_2:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 6, 0, 73, -2, -2, -2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 72, 4, 4, 4, 4,
+ax_anim 1, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, 18, 18, 18, 18,
+ax_anim 2, 1, 72, 19, 17, 19, 17,
+ax_anim 2, 0, 72, 18, 18, 18, 18,
+ax_anim 2, 0, 72, 19, 17, 19, 17,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sRapidashAnims_3_3:
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 6, 0, 78, -2, 0, -2, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 77, 4, 0, 4, 0,
+ax_anim 1, 0, 77, 10, 0, 10, 0,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 1, 77, 18, 1, 18, 1,
+ax_anim 2, 0, 77, 18, 0, 18, 0,
+ax_anim 2, 0, 77, 18, 1, 18, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sRapidashAnims_3_4:
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 6, 0, 83, -2, 2, -2, 2,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 1, 2, 82, 5, -6, 5, -6,
+ax_anim 1, 0, 82, 13, -13, 13, -13,
+ax_anim 2, 0, 82, 18, -17, 18, -17,
+ax_anim 2, 1, 82, 19, -16, 19, -16,
+ax_anim 2, 0, 82, 18, -17, 18, -17,
+ax_anim 2, 0, 82, 19, -16, 19, -16,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sRapidashAnims_3_5:
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 6, 0, 88, 0, 2, 0, 2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 87, 0, -4, 0, -4,
+ax_anim 1, 0, 87, 0, -11, 0, -11,
+ax_anim 2, 0, 87, 0, -15, 0, -15,
+ax_anim 2, 1, 87, 1, -15, 1, -15,
+ax_anim 2, 0, 87, 0, -15, 0, -15,
+ax_anim 2, 0, 87, 1, -15, 1, -15,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sRapidashAnims_3_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 6, 0, 93, 2, 2, 2, 2,
+ax_anim 1, 0, 89, 0, -1, 0, -1,
+ax_anim 1, 2, 92, -5, -6, -5, -6,
+ax_anim 1, 0, 92, -13, -13, -13, -13,
+ax_anim 2, 0, 92, -18, -17, -18, -17,
+ax_anim 2, 1, 92, -19, -16, -19, -16,
+ax_anim 2, 0, 92, -18, -17, -18, -17,
+ax_anim 2, 0, 92, -19, -16, -19, -16,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sRapidashAnims_3_7:
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 6, 0, 98, 2, 0, 2, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 2, 97, -4, 0, -4, 0,
+ax_anim 1, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 1, 97, -18, 1, -18, 1,
+ax_anim 2, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 0, 97, -18, 1, -18, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sRapidashAnims_3_8:
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 6, 0, 103, 2, -2, 2, -2,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 102, -4, 4, -4, 4,
+ax_anim 1, 0, 102, -10, 10, -10, 10,
+ax_anim 2, 0, 102, -18, 18, -18, 18,
+ax_anim 2, 1, 102, -19, 17, -19, 17,
+ax_anim 2, 0, 102, -18, 18, -18, 18,
+ax_anim 2, 0, 102, -19, 17, -19, 17,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRapidashAnims_4_1:
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim 2, 0, 108, 0, -3, 0, -3,
+ax_anim 6, 2, 108, 0, -4, 0, -4,
+ax_anim 1, 0, 107, 0, -1, 0, -1,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 1, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sRapidashAnims_4_2:
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -3, -3, -3,
+ax_anim 6, 2, 113, -4, -4, -4, -4,
+ax_anim 1, 0, 112, -1, -1, -1, -1,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 1, 112, 5, 3, 5, 3,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 0, 112, 5, 3, 5, 3,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 0, 112, 5, 3, 5, 3,
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim_terminator
+sRapidashAnims_4_3:
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim 2, 0, 118, -3, 0, -3, 0,
+ax_anim 6, 2, 118, -4, 0, -4, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 1, 117, 5, 1, 5, 1,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 117, 5, 1, 5, 1,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 117, 5, 1, 5, 1,
+ax_anim 2, 0, 117, 5, 0, 5, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sRapidashAnims_4_4:
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim 2, 0, 123, -3, 3, -3, 3,
+ax_anim 6, 2, 123, -4, 4, -4, 4,
+ax_anim 1, 0, 122, -1, 1, -1, 1,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 1, 122, 5, -3, 5, -3,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 0, 122, 5, -3, 5, -3,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 0, 122, 5, -3, 5, -3,
+ax_anim 2, 0, 122, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim_terminator
+sRapidashAnims_4_5:
+ax_anim 2, 0, 128, 0, 2, 0, 2,
+ax_anim 2, 0, 128, 0, 3, 0, 3,
+ax_anim 6, 2, 128, 0, 4, 0, 4,
+ax_anim 1, 0, 127, 0, 1, 0, 1,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 1, 127, 1, -4, 1, -4,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 0, 127, 1, -4, 1, -4,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 0, 127, 1, -4, 1, -4,
+ax_anim 2, 0, 127, 0, -4, 0, -4,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sRapidashAnims_4_6:
+ax_anim 2, 0, 133, 2, 2, 2, 2,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 6, 2, 133, 4, 4, 4, 4,
+ax_anim 1, 0, 132, 1, 1, 1, 1,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 1, 132, -5, -3, -5, -3,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 0, 132, -5, -3, -5, -3,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 0, 132, -5, -3, -5, -3,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim_terminator
+sRapidashAnims_4_7:
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 0, 138, 3, 0, 3, 0,
+ax_anim 6, 2, 138, 4, 0, 4, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 1, 137, -5, 1, -5, 1,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 137, -5, 1, -5, 1,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 137, -5, 1, -5, 1,
+ax_anim 2, 0, 137, -5, 0, -5, 0,
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim_terminator
+sRapidashAnims_4_8:
+ax_anim 2, 0, 143, 2, -2, 2, -2,
+ax_anim 2, 0, 143, 3, -3, 3, -3,
+ax_anim 6, 2, 143, 4, -4, 4, -4,
+ax_anim 1, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 1, 142, -5, 3, -5, 3,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 0, 142, -5, 3, -5, 3,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 0, 142, -5, 3, -5, 3,
+ax_anim 2, 0, 142, -4, 4, -4, 4,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRapidashAnims_5_1:
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 2, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 1, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_5_2:
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 2, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 1, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_5_3:
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 2, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 1, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_5_4:
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 2, 163, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim 3, 1, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_5_5:
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 2, 168, 0, 0, 0, 0,
+ax_anim 3, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 168, 0, 0, 0, 0,
+ax_anim 3, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 168, 0, 0, 0, 0,
+ax_anim 3, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 168, 0, 0, 0, 0,
+ax_anim 3, 1, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_5_6:
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 3, 2, 173, 0, 0, 0, 0,
+ax_anim 3, 0, 172, 0, 0, 0, 0,
+ax_anim 3, 0, 173, 0, 0, 0, 0,
+ax_anim 3, 0, 172, 0, 0, 0, 0,
+ax_anim 3, 0, 173, 0, 0, 0, 0,
+ax_anim 3, 0, 172, 0, 0, 0, 0,
+ax_anim 3, 0, 173, 0, 0, 0, 0,
+ax_anim 3, 1, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_5_7:
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 3, 2, 178, 0, 0, 0, 0,
+ax_anim 3, 0, 177, 0, 0, 0, 0,
+ax_anim 3, 0, 178, 0, 0, 0, 0,
+ax_anim 3, 0, 177, 0, 0, 0, 0,
+ax_anim 3, 0, 178, 0, 0, 0, 0,
+ax_anim 3, 0, 177, 0, 0, 0, 0,
+ax_anim 3, 0, 178, 0, 0, 0, 0,
+ax_anim 3, 1, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_5_8:
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 3, 2, 183, 0, 0, 0, 0,
+ax_anim 3, 0, 182, 0, 0, 0, 0,
+ax_anim 3, 0, 183, 0, 0, 0, 0,
+ax_anim 3, 0, 182, 0, 0, 0, 0,
+ax_anim 3, 0, 183, 0, 0, 0, 0,
+ax_anim 3, 0, 182, 0, 0, 0, 0,
+ax_anim 3, 0, 183, 0, 0, 0, 0,
+ax_anim 3, 1, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_6_1:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 35, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_7_1:
+ax_anim 2, 0, 186, 0, -2, 0, -2,
+ax_anim 8, 0, 186, 0, -3, 0, -3,
+ax_anim_terminator
+sRapidashAnims_7_2:
+ax_anim 2, 0, 187, -2, -2, -2, -2,
+ax_anim 8, 0, 187, -3, -3, -3, -3,
+ax_anim_terminator
+sRapidashAnims_7_3:
+ax_anim 2, 0, 188, -2, 0, -2, 0,
+ax_anim 8, 0, 188, -3, 0, -3, 0,
+ax_anim_terminator
+sRapidashAnims_7_4:
+ax_anim 2, 0, 189, -2, 2, -2, 2,
+ax_anim 8, 0, 189, -3, 3, -3, 3,
+ax_anim_terminator
+sRapidashAnims_7_5:
+ax_anim 2, 0, 190, 0, 2, 0, 2,
+ax_anim 8, 0, 190, 0, 3, 0, 3,
+ax_anim_terminator
+sRapidashAnims_7_6:
+ax_anim 2, 0, 191, 2, 2, 2, 2,
+ax_anim 8, 0, 191, 3, 3, 3, 3,
+ax_anim_terminator
+sRapidashAnims_7_7:
+ax_anim 2, 0, 192, 2, 0, 2, 0,
+ax_anim 8, 0, 192, 3, 0, 3, 0,
+ax_anim_terminator
+sRapidashAnims_7_8:
+ax_anim 2, 0, 193, 2, -2, 2, -2,
+ax_anim 8, 0, 193, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRapidashAnims_8_1:
+ax_anim 60, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_8_2:
+ax_anim 60, 0, 199, 0, 0, 0, 0,
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, 0, -1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, 0, -1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, 0, -1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, 0, -1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, 0, -1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, -1, 0, -1, 0,
+ax_anim 10, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_8_3:
+ax_anim 60, 0, 204, 0, 0, 0, 0,
+ax_anim 10, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, 0, -1, 0,
+ax_anim 10, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_8_4:
+ax_anim 60, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, 0, -1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, 0, -1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, 0, -1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, 0, -1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, 0, -1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, 0, -1, 0,
+ax_anim 10, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_8_5:
+ax_anim 60, 0, 214, 0, 0, 0, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, 0, -1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, 0, -1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, 0, -1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, 0, -1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, 0, -1, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, 0, -1, 0,
+ax_anim 10, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_8_6:
+ax_anim 60, 0, 219, 0, 0, 0, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 10, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_8_7:
+ax_anim 60, 0, 224, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, 0, -1, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_8_8:
+ax_anim 60, 0, 229, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, 0, -1, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, 0, -1, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, 0, -1, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, 0, -1, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, 0, -1, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, -1, 0, -1, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_9_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 6, 3, 6, 3,
+ax_anim 2, 0, 236, 8, 9, 8, 9,
+ax_anim 2, 0, 237, 7, 14, 7, 14,
+ax_anim 3, 0, 238, 0, 18, 0, 18,
+ax_anim 2, 3, 239, -7, 14, -7, 14,
+ax_anim 2, 0, 240, -8, 9, -8, 9,
+ax_anim 1, 0, 241, -6, 3, -6, 3,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_9_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 8, 0, 8, 0,
+ax_anim 2, 0, 235, 17, 3, 17, 3,
+ax_anim 2, 0, 236, 20, 10, 20, 10,
+ax_anim 3, 0, 237, 17, 19, 17, 19,
+ax_anim 2, 3, 238, 11, 19, 11, 19,
+ax_anim 2, 0, 239, 3, 15, 3, 15,
+ax_anim 1, 0, 240, 0, 7, 0, 7,
+ax_anim 1, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_9_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 3, -5, 3, -5,
+ax_anim 2, 0, 234, 11, -6, 11, -6,
+ax_anim 2, 0, 235, 16, -5, 16, -5,
+ax_anim 3, 0, 236, 18, -2, 18, -2,
+ax_anim 2, 3, 237, 16, 2, 16, 2,
+ax_anim 2, 0, 238, 12, 5, 12, 5,
+ax_anim 1, 0, 239, 5, 3, 5, 3,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_9_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, -1, -8, -1, -8,
+ax_anim 2, 0, 241, 4, -16, 4, -16,
+ax_anim 2, 0, 234, 11, -20, 11, -20,
+ax_anim 3, 0, 235, 18, -20, 18, -20,
+ax_anim 2, 3, 236, 20, -15, 20, -15,
+ax_anim 2, 0, 237, 17, -6, 17, -6,
+ax_anim 1, 0, 238, 8, 1, 8, 1,
+ax_anim 1, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_9_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, -8, -4, -8, -4,
+ax_anim 2, 0, 240, -9, -12, -9, -12,
+ax_anim 2, 0, 241, -7, -18, -7, -18,
+ax_anim 3, 0, 234, 0, -22, 0, -22,
+ax_anim 2, 3, 235, 7, -18, 7, -18,
+ax_anim 2, 0, 236, 9, -10, 9, -10,
+ax_anim 1, 0, 237, 8, -4, 8, -4,
+ax_anim 1, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_9_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 1, -8, 1, -8,
+ax_anim 2, 0, 235, -4, -16, -4, -16,
+ax_anim 2, 0, 234, -11, -20, -11, -20,
+ax_anim 3, 0, 241, -18, -20, -18, -20,
+ax_anim 2, 3, 240, -20, -15, -20, -15,
+ax_anim 2, 0, 239, -17, -6, -17, -6,
+ax_anim 1, 0, 238, -8, -1, -8, -1,
+ax_anim 1, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_9_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 235, -3, -5, -3, -5,
+ax_anim 2, 0, 234, -11, -6, -11, -6,
+ax_anim 2, 0, 241, -16, -5, -16, -5,
+ax_anim 3, 0, 240, -18, -2, -18, -2,
+ax_anim 2, 3, 239, -16, 2, -16, 2,
+ax_anim 2, 0, 238, -12, 5, -12, 5,
+ax_anim 1, 0, 237, -5, 3, -5, 3,
+ax_anim 1, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_9_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 234, -8, 0, -8, 0,
+ax_anim 2, 0, 241, -17, 3, -17, 3,
+ax_anim 2, 0, 240, -20, 10, -20, 10,
+ax_anim 3, 0, 239, -17, 19, -17, 19,
+ax_anim 2, 3, 238, -11, 19, -11, 19,
+ax_anim 2, 0, 237, -3, 15, -3, 15,
+ax_anim 1, 0, 236, 0, 7, 0, 7,
+ax_anim 1, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_10_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 3, 0, 242, 13, 0, 13, 0,
+ax_anim 3, 0, 242, -13, 0, -13, 0,
+ax_anim 2, 0, 242, 12, 0, 12, 0,
+ax_anim 3, 0, 242, -12, 0, -12, 0,
+ax_anim 2, 0, 242, 10, 0, 10, 0,
+ax_anim 2, 0, 242, -10, 0, -10, 0,
+ax_anim 2, 0, 242, 6, 0, 6, 0,
+ax_anim 2, 0, 242, -6, 0, -6, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_10_2:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 3, 0, 243, 13, -13, 13, -13,
+ax_anim 3, 0, 243, -13, 13, -13, 13,
+ax_anim 2, 0, 243, 12, -12, 12, -12,
+ax_anim 3, 0, 243, -12, 12, -12, 12,
+ax_anim 2, 0, 243, 10, -10, 10, -10,
+ax_anim 2, 0, 243, -10, 10, -10, 10,
+ax_anim 2, 0, 243, 6, -6, 6, -6,
+ax_anim 2, 0, 243, -6, 6, -6, 6,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_10_3:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 3, 0, 244, 0, -13, 0, -13,
+ax_anim 3, 0, 244, 0, 13, 0, 13,
+ax_anim 2, 0, 244, 0, -12, 0, -12,
+ax_anim 3, 0, 244, 0, 12, 0, 12,
+ax_anim 2, 0, 244, 0, -10, 0, -10,
+ax_anim 2, 0, 244, 0, 10, 0, 10,
+ax_anim 2, 0, 244, 0, -6, 0, -6,
+ax_anim 2, 0, 244, 0, 6, 0, 6,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_10_4:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 3, 0, 245, -13, -13, -13, -13,
+ax_anim 3, 0, 245, 13, 13, 13, 13,
+ax_anim 2, 0, 245, -12, -12, -12, -12,
+ax_anim 3, 0, 245, 12, 12, 12, 12,
+ax_anim 2, 0, 245, -10, -10, -10, -10,
+ax_anim 2, 0, 245, 10, 10, 10, 10,
+ax_anim 2, 0, 245, -6, -6, -6, -6,
+ax_anim 2, 0, 245, 6, 6, 6, 6,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_10_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 3, 0, 246, 13, 0, 13, 0,
+ax_anim 3, 0, 246, -13, 0, -13, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_10_6:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 3, 0, 247, 13, -13, 13, -13,
+ax_anim 3, 0, 247, -13, 13, -13, 13,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_10_7:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 3, 0, 248, 0, -13, 0, -13,
+ax_anim 3, 0, 248, 0, 13, 0, 13,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_10_8:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 3, 0, 249, -13, -13, -13, -13,
+ax_anim 3, 0, 249, 13, 13, 13, 13,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_11_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 0, -10, 0, 0,
+ax_anim 2, 0, 251, 0, -16, 0, 0,
+ax_anim 3, 0, 251, 0, -19, 0, 0,
+ax_anim 4, 0, 251, 0, -20, 0, 0,
+ax_anim 4, 0, 252, 0, -26, 0, 0,
+ax_anim 3, 0, 252, 0, -22, 0, 0,
+ax_anim 2, 0, 252, 0, -18, 0, 0,
+ax_anim 1, 0, 252, 0, -12, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_11_2:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 254, 0, -10, 0, 0,
+ax_anim 2, 0, 254, 0, -16, 0, 0,
+ax_anim 3, 0, 254, 0, -20, 0, 0,
+ax_anim 4, 0, 254, 0, -21, 0, 0,
+ax_anim 4, 0, 255, 0, -25, 0, 0,
+ax_anim 3, 0, 255, 0, -22, 0, 0,
+ax_anim 2, 0, 255, 0, -18, 0, 0,
+ax_anim 1, 0, 255, 0, -12, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_11_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 0, -10, 0, 0,
+ax_anim 2, 0, 257, 0, -16, 0, 0,
+ax_anim 3, 0, 257, 0, -20, 0, 0,
+ax_anim 4, 0, 257, 0, -21, 0, 0,
+ax_anim 4, 0, 258, 0, -23, 0, 0,
+ax_anim 3, 0, 258, 0, -22, 0, 0,
+ax_anim 2, 0, 258, 0, -18, 0, 0,
+ax_anim 1, 0, 258, 0, -12, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_11_4:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -10, 0, 0,
+ax_anim 2, 0, 260, 0, -16, 0, 0,
+ax_anim 3, 0, 260, 0, -20, 0, 0,
+ax_anim 4, 0, 260, 0, -21, 0, 0,
+ax_anim 4, 0, 261, 0, -22, 0, 0,
+ax_anim 3, 0, 261, 0, -21, 0, 0,
+ax_anim 2, 0, 261, 0, -17, 0, 0,
+ax_anim 1, 0, 261, 0, -11, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_11_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 264, 0, -23, 0, 0,
+ax_anim 3, 0, 264, 0, -22, 0, 0,
+ax_anim 2, 0, 264, 0, -18, 0, 0,
+ax_anim 1, 0, 264, 0, -12, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_11_6:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 267, 0, -22, 0, 0,
+ax_anim 3, 0, 267, 0, -21, 0, 0,
+ax_anim 2, 0, 267, 0, -17, 0, 0,
+ax_anim 1, 0, 267, 0, -11, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_11_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 270, 0, -23, 0, 0,
+ax_anim 3, 0, 270, 0, -22, 0, 0,
+ax_anim 2, 0, 270, 0, -18, 0, 0,
+ax_anim 1, 0, 270, 0, -12, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_11_8:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 273, 0, -25, 0, 0,
+ax_anim 3, 0, 273, 0, -22, 0, 0,
+ax_anim 2, 0, 273, 0, -18, 0, 0,
+ax_anim 1, 0, 273, 0, -12, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_12_1:
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 1, 0, 1, 0,
+ax_anim 2, 1, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_12_2:
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 1, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_12_3:
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 1, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_12_4:
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 1, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_12_5:
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 1, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_12_6:
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 1, -1, 1, -1,
+ax_anim 2, 1, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_12_7:
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -1, 0, -1,
+ax_anim 2, 1, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_12_8:
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, -1, -1, -1, -1,
+ax_anim 2, 1, 275, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRapidashAnims_13_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_13_2:
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_13_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_13_4:
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_13_5:
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_13_6:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_13_7:
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashAnims_13_8:
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sRapidashGfx1:
+.incbin "baserom.gba", 0x85F6C4, 0x200
+sRapidashSprites1:
+ax_sprite sRapidashGfx1, 0x200
+ax_sprite_terminator
+sRapidashGfx2:
+.incbin "baserom.gba", 0x85F8D4, 0x80
+sRapidashSprites2:
+ax_sprite sRapidashGfx2, 0x80
+ax_sprite_terminator
+sRapidashGfx3:
+.incbin "baserom.gba", 0x85F964, 0x100
+sRapidashSprites3:
+ax_sprite sRapidashGfx3, 0x100
+ax_sprite_terminator
+sRapidashGfx4:
+.incbin "baserom.gba", 0x85FA74, 0x20
+sRapidashSprites4:
+ax_sprite sRapidashGfx4, 0x20
+ax_sprite_terminator
+sRapidashGfx5:
+.incbin "baserom.gba", 0x85FAA4, 0x20
+sRapidashSprites5:
+ax_sprite sRapidashGfx5, 0x20
+ax_sprite_terminator
+sRapidashGfx6:
+.incbin "baserom.gba", 0x85FAD4, 0x100
+sRapidashSprites6:
+ax_sprite sRapidashGfx6, 0x100
+ax_sprite_terminator
+sRapidashGfx7:
+.incbin "baserom.gba", 0x85FBE4, 0x80
+sRapidashSprites7:
+ax_sprite sRapidashGfx7, 0x80
+ax_sprite_terminator
+sRapidashGfx8:
+.incbin "baserom.gba", 0x85FC74, 0x20
+sRapidashSprites8:
+ax_sprite sRapidashGfx8, 0x20
+ax_sprite_terminator
+sRapidashGfx9:
+.incbin "baserom.gba", 0x85FCA4, 0x20
+sRapidashSprites9:
+ax_sprite sRapidashGfx9, 0x20
+ax_sprite_terminator
+sRapidashGfx10:
+.incbin "baserom.gba", 0x85FCD4, 0x200
+sRapidashSprites10:
+ax_sprite sRapidashGfx10, 0x200
+ax_sprite_terminator
+sRapidashGfx11:
+.incbin "baserom.gba", 0x85FEE4, 0x200
+sRapidashSprites11:
+ax_sprite sRapidashGfx11, 0x200
+ax_sprite_terminator
+sRapidashGfx12:
+.incbin "baserom.gba", 0x8600F4, 0x200
+sRapidashSprites12:
+ax_sprite sRapidashGfx12, 0x200
+ax_sprite_terminator
+sRapidashGfx13:
+.incbin "baserom.gba", 0x860304, 0x200
+sRapidashSprites13:
+ax_sprite sRapidashGfx13, 0x200
+ax_sprite_terminator
+sRapidashGfx14:
+.incbin "baserom.gba", 0x860514, 0x200
+sRapidashSprites14:
+ax_sprite sRapidashGfx14, 0x200
+ax_sprite_terminator
+sRapidashGfx15:
+.incbin "baserom.gba", 0x860724, 0x200
+sRapidashSprites15:
+ax_sprite sRapidashGfx15, 0x200
+ax_sprite_terminator
+sRapidashGfx16:
+.incbin "baserom.gba", 0x860934, 0x200
+sRapidashSprites16:
+ax_sprite sRapidashGfx16, 0x200
+ax_sprite_terminator
+sRapidashGfx17:
+.incbin "baserom.gba", 0x860B44, 0x200
+sRapidashSprites17:
+ax_sprite sRapidashGfx17, 0x200
+ax_sprite_terminator
+sRapidashGfx18:
+.incbin "baserom.gba", 0x860D54, 0x200
+sRapidashSprites18:
+ax_sprite sRapidashGfx18, 0x200
+ax_sprite_terminator
+sRapidashGfx19:
+.incbin "baserom.gba", 0x860F64, 0x200
+sRapidashSprites19:
+ax_sprite sRapidashGfx19, 0x200
+ax_sprite_terminator
+sRapidashGfx20:
+.incbin "baserom.gba", 0x861174, 0x100
+sRapidashSprites20:
+ax_sprite sRapidashGfx20, 0x100
+ax_sprite_terminator
+sRapidashGfx21:
+.incbin "baserom.gba", 0x861284, 0x20
+sRapidashSprites21:
+ax_sprite sRapidashGfx21, 0x20
+ax_sprite_terminator
+sRapidashGfx22:
+.incbin "baserom.gba", 0x8612B4, 0x100
+sRapidashSprites22:
+ax_sprite sRapidashGfx22, 0x100
+ax_sprite_terminator
+sRapidashGfx23:
+.incbin "baserom.gba", 0x8613C4, 0x20
+sRapidashSprites23:
+ax_sprite sRapidashGfx23, 0x20
+ax_sprite_terminator
+sRapidashGfx24:
+.incbin "baserom.gba", 0x8613F4, 0x40
+sRapidashGfx24_1:
+.incbin "baserom.gba", 0x861434, 0x180
+sRapidashSprites24:
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx24_1, 0x180
+ax_sprite_terminator
+sRapidashGfx25:
+.incbin "baserom.gba", 0x8615DC, 0x100
+sRapidashSprites25:
+ax_sprite sRapidashGfx25, 0x100
+ax_sprite_terminator
+sRapidashGfx26:
+.incbin "baserom.gba", 0x8616EC, 0x20
+sRapidashSprites26:
+ax_sprite sRapidashGfx26, 0x20
+ax_sprite_terminator
+sRapidashGfx27:
+.incbin "baserom.gba", 0x86171C, 0x20
+sRapidashSprites27:
+ax_sprite sRapidashGfx27, 0x20
+ax_sprite_terminator
+sRapidashGfx28:
+.incbin "baserom.gba", 0x86174C, 0x200
+sRapidashSprites28:
+ax_sprite sRapidashGfx28, 0x200
+ax_sprite_terminator
+sRapidashGfx29:
+.incbin "baserom.gba", 0x86195C, 0x60
+sRapidashGfx29_1:
+.incbin "baserom.gba", 0x8619BC, 0x60
+sRapidashGfx29_2:
+.incbin "baserom.gba", 0x861A1C, 0x60
+sRapidashGfx29_3:
+.incbin "baserom.gba", 0x861A7C, 0x60
+sRapidashSprites29:
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx29_3, 0x60
+ax_sprite_terminator
+sRapidashGfx30:
+.incbin "baserom.gba", 0x861B24, 0x100
+sRapidashSprites30:
+ax_sprite sRapidashGfx30, 0x100
+ax_sprite_terminator
+sRapidashGfx31:
+.incbin "baserom.gba", 0x861C34, 0x80
+sRapidashSprites31:
+ax_sprite sRapidashGfx31, 0x80
+ax_sprite_terminator
+sRapidashGfx32:
+.incbin "baserom.gba", 0x861CC4, 0x40
+sRapidashSprites32:
+ax_sprite sRapidashGfx32, 0x40
+ax_sprite_terminator
+sRapidashGfx33:
+.incbin "baserom.gba", 0x861D14, 0x20
+sRapidashSprites33:
+ax_sprite sRapidashGfx33, 0x20
+ax_sprite_terminator
+sRapidashGfx34:
+.incbin "baserom.gba", 0x861D44, 0x20
+sRapidashSprites34:
+ax_sprite sRapidashGfx34, 0x20
+ax_sprite_terminator
+sRapidashGfx35:
+.incbin "baserom.gba", 0x861D74, 0x100
+sRapidashSprites35:
+ax_sprite sRapidashGfx35, 0x100
+ax_sprite_terminator
+sRapidashGfx36:
+.incbin "baserom.gba", 0x861E84, 0x40
+sRapidashSprites36:
+ax_sprite sRapidashGfx36, 0x40
+ax_sprite_terminator
+sRapidashGfx37:
+.incbin "baserom.gba", 0x861ED4, 0x20
+sRapidashSprites37:
+ax_sprite sRapidashGfx37, 0x20
+ax_sprite_terminator
+sRapidashGfx38:
+.incbin "baserom.gba", 0x861F04, 0x20
+sRapidashSprites38:
+ax_sprite sRapidashGfx38, 0x20
+ax_sprite_terminator
+sRapidashGfx39:
+.incbin "baserom.gba", 0x861F34, 0x20
+sRapidashSprites39:
+ax_sprite sRapidashGfx39, 0x20
+ax_sprite_terminator
+sRapidashGfx40:
+.incbin "baserom.gba", 0x861F64, 0x20
+sRapidashSprites40:
+ax_sprite sRapidashGfx40, 0x20
+ax_sprite_terminator
+sRapidashGfx41:
+.incbin "baserom.gba", 0x861F94, 0x20
+sRapidashSprites41:
+ax_sprite sRapidashGfx41, 0x20
+ax_sprite_terminator
+sRapidashGfx42:
+.incbin "baserom.gba", 0x861FC4, 0x20
+sRapidashSprites42:
+ax_sprite sRapidashGfx42, 0x20
+ax_sprite_terminator
+sRapidashGfx43:
+.incbin "baserom.gba", 0x861FF4, 0x60
+sRapidashGfx43_1:
+.incbin "baserom.gba", 0x862054, 0x60
+sRapidashGfx43_2:
+.incbin "baserom.gba", 0x8620B4, 0xE0
+sRapidashSprites43:
+ax_sprite sRapidashGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx43_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRapidashGfx44:
+.incbin "baserom.gba", 0x8621CC, 0x100
+sRapidashSprites44:
+ax_sprite sRapidashGfx44, 0x100
+ax_sprite_terminator
+sRapidashGfx45:
+.incbin "baserom.gba", 0x8622DC, 0x60
+sRapidashSprites45:
+ax_sprite sRapidashGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRapidashGfx46:
+.incbin "baserom.gba", 0x862354, 0x40
+sRapidashSprites46:
+ax_sprite sRapidashGfx46, 0x40
+ax_sprite_terminator
+sRapidashGfx47:
+.incbin "baserom.gba", 0x8623A4, 0x20
+sRapidashSprites47:
+ax_sprite sRapidashGfx47, 0x20
+ax_sprite_terminator
+sRapidashGfx48:
+.incbin "baserom.gba", 0x8623D4, 0x20
+sRapidashSprites48:
+ax_sprite sRapidashGfx48, 0x20
+ax_sprite_terminator
+sRapidashGfx49:
+.incbin "baserom.gba", 0x862404, 0x100
+sRapidashSprites49:
+ax_sprite sRapidashGfx49, 0x100
+ax_sprite_terminator
+sRapidashGfx50:
+.incbin "baserom.gba", 0x862514, 0x20
+sRapidashSprites50:
+ax_sprite sRapidashGfx50, 0x20
+ax_sprite_terminator
+sRapidashGfx51:
+.incbin "baserom.gba", 0x862544, 0x20
+sRapidashSprites51:
+ax_sprite sRapidashGfx51, 0x20
+ax_sprite_terminator
+sRapidashGfx52:
+.incbin "baserom.gba", 0x862574, 0x20
+sRapidashSprites52:
+ax_sprite sRapidashGfx52, 0x20
+ax_sprite_terminator
+sRapidashGfx53:
+.incbin "baserom.gba", 0x8625A4, 0x100
+sRapidashSprites53:
+ax_sprite sRapidashGfx53, 0x100
+ax_sprite_terminator
+sRapidashGfx54:
+.incbin "baserom.gba", 0x8626B4, 0x20
+sRapidashSprites54:
+ax_sprite sRapidashGfx54, 0x20
+ax_sprite_terminator
+sRapidashGfx55:
+.incbin "baserom.gba", 0x8626E4, 0x20
+sRapidashSprites55:
+ax_sprite sRapidashGfx55, 0x20
+ax_sprite_terminator
+sRapidashGfx56:
+.incbin "baserom.gba", 0x862714, 0x100
+sRapidashSprites56:
+ax_sprite sRapidashGfx56, 0x100
+ax_sprite_terminator
+sRapidashGfx57:
+.incbin "baserom.gba", 0x862824, 0x20
+sRapidashSprites57:
+ax_sprite sRapidashGfx57, 0x20
+ax_sprite_terminator
+sRapidashGfx58:
+.incbin "baserom.gba", 0x862854, 0x20
+sRapidashSprites58:
+ax_sprite sRapidashGfx58, 0x20
+ax_sprite_terminator
+sRapidashGfx59:
+.incbin "baserom.gba", 0x862884, 0x60
+sRapidashGfx59_1:
+.incbin "baserom.gba", 0x8628E4, 0x60
+sRapidashGfx59_2:
+.incbin "baserom.gba", 0x862944, 0x60
+sRapidashGfx59_3:
+.incbin "baserom.gba", 0x8629A4, 0x60
+sRapidashSprites59:
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx59, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx59_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx59_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRapidashGfx59_3, 0x60
+ax_sprite_terminator
+sRapidashGfx60:
+.incbin "baserom.gba", 0x862A4C, 0x100
+sRapidashSprites60:
+ax_sprite sRapidashGfx60, 0x100
+ax_sprite_terminator
+sRapidashGfx61:
+.incbin "baserom.gba", 0x862B5C, 0x80
+sRapidashSprites61:
+ax_sprite sRapidashGfx61, 0x80
+ax_sprite_terminator
+sRapidashGfx62:
+.incbin "baserom.gba", 0x862BEC, 0x20
+sRapidashSprites62:
+ax_sprite sRapidashGfx62, 0x20
+ax_sprite_terminator
+sRapidashGfx63:
+.incbin "baserom.gba", 0x862C1C, 0x20
+sRapidashSprites63:
+ax_sprite sRapidashGfx63, 0x20
+ax_sprite_terminator
+sRapidashGfx64:
+.incbin "baserom.gba", 0x862C4C, 0x20
+sRapidashSprites64:
+ax_sprite sRapidashGfx64, 0x20
+ax_sprite_terminator
+sRapidashGfx65:
+.incbin "baserom.gba", 0x862C7C, 0x20
+sRapidashSprites65:
+ax_sprite sRapidashGfx65, 0x20
+ax_sprite_terminator
+sRapidashGfx66:
+.incbin "baserom.gba", 0x862CAC, 0x100
+sRapidashSprites66:
+ax_sprite sRapidashGfx66, 0x100
+ax_sprite_terminator
+sRapidashGfx67:
+.incbin "baserom.gba", 0x862DBC, 0x80
+sRapidashSprites67:
+ax_sprite sRapidashGfx67, 0x80
+ax_sprite_terminator
+sRapidashGfx68:
+.incbin "baserom.gba", 0x862E4C, 0x40
+sRapidashSprites68:
+ax_sprite sRapidashGfx68, 0x40
+ax_sprite_terminator
+sRapidashGfx69:
+.incbin "baserom.gba", 0x862E9C, 0x20
+sRapidashSprites69:
+ax_sprite sRapidashGfx69, 0x20
+ax_sprite_terminator
+sRapidashGfx70:
+.incbin "baserom.gba", 0x862ECC, 0x20
+sRapidashSprites70:
+ax_sprite sRapidashGfx70, 0x20
+ax_sprite_terminator
+sRapidashGfx71:
+.incbin "baserom.gba", 0x862EFC, 0x100
+sRapidashSprites71:
+ax_sprite sRapidashGfx71, 0x100
+ax_sprite_terminator
+sRapidashGfx72:
+.incbin "baserom.gba", 0x86300C, 0x20
+sRapidashSprites72:
+ax_sprite sRapidashGfx72, 0x20
+ax_sprite_terminator
+sRapidashGfx73:
+.incbin "baserom.gba", 0x86303C, 0x20
+sRapidashSprites73:
+ax_sprite sRapidashGfx73, 0x20
+ax_sprite_terminator
+sRapidashGfx74:
+.incbin "baserom.gba", 0x86306C, 0x20
+sRapidashSprites74:
+ax_sprite sRapidashGfx74, 0x20
+ax_sprite_terminator
+sRapidashGfx75:
+.incbin "baserom.gba", 0x86309C, 0x200
+sRapidashSprites75:
+ax_sprite sRapidashGfx75, 0x200
+ax_sprite_terminator
+sRapidashGfx76:
+.incbin "baserom.gba", 0x8632AC, 0x200
+sRapidashSprites76:
+ax_sprite sRapidashGfx76, 0x200
+ax_sprite_terminator
+sRapidashGfx77:
+.incbin "baserom.gba", 0x8634BC, 0x200
+sRapidashSprites77:
+ax_sprite sRapidashGfx77, 0x200
+ax_sprite_terminator
+sRapidashGfx78:
+.incbin "baserom.gba", 0x8636CC, 0x200
+sRapidashSprites78:
+ax_sprite sRapidashGfx78, 0x200
+ax_sprite_terminator
+sRapidashGfx79:
+.incbin "baserom.gba", 0x8638DC, 0x200
+sRapidashSprites79:
+ax_sprite sRapidashGfx79, 0x200
+ax_sprite_terminator
+sRapidashGfx80:
+.incbin "baserom.gba", 0x863AEC, 0x200
+sRapidashSprites80:
+ax_sprite sRapidashGfx80, 0x200
+ax_sprite_terminator
+sRapidashGfx81:
+.incbin "baserom.gba", 0x863CFC, 0x200
+sRapidashSprites81:
+ax_sprite sRapidashGfx81, 0x200
+ax_sprite_terminator
+sAxPosesRapidash:
+.4byte sRapidashPose1
+.4byte sRapidashPose2
+.4byte sRapidashPose3
+.4byte sRapidashPose4
+.4byte sRapidashPose5
+.4byte sRapidashPose6
+.4byte sRapidashPose7
+.4byte sRapidashPose8
+.4byte sRapidashPose9
+.4byte sRapidashPose10
+.4byte sRapidashPose11
+.4byte sRapidashPose12
+.4byte sRapidashPose13
+.4byte sRapidashPose14
+.4byte sRapidashPose15
+.4byte sRapidashPose16
+.4byte sRapidashPose17
+.4byte sRapidashPose18
+.4byte sRapidashPose19
+.4byte sRapidashPose20
+.4byte sRapidashPose21
+.4byte sRapidashPose22
+.4byte sRapidashPose23
+.4byte sRapidashPose24
+.4byte sRapidashPose25
+.4byte sRapidashPose26
+.4byte sRapidashPose27
+.4byte sRapidashPose28
+.4byte sRapidashPose29
+.4byte sRapidashPose30
+.4byte sRapidashPose31
+.4byte sRapidashPose32
+.4byte sRapidashPose33
+.4byte sRapidashPose34
+.4byte sRapidashPose35
+.4byte sRapidashPose36
+.4byte sRapidashPose37
+.4byte sRapidashPose38
+.4byte sRapidashPose39
+.4byte sRapidashPose40
+.4byte sRapidashPose41
+.4byte sRapidashPose42
+.4byte sRapidashPose43
+.4byte sRapidashPose44
+.4byte sRapidashPose45
+.4byte sRapidashPose46
+.4byte sRapidashPose47
+.4byte sRapidashPose48
+.4byte sRapidashPose49
+.4byte sRapidashPose50
+.4byte sRapidashPose51
+.4byte sRapidashPose52
+.4byte sRapidashPose53
+.4byte sRapidashPose54
+.4byte sRapidashPose55
+.4byte sRapidashPose56
+.4byte sRapidashPose57
+.4byte sRapidashPose58
+.4byte sRapidashPose59
+.4byte sRapidashPose60
+.4byte sRapidashPose61
+.4byte sRapidashPose62
+.4byte sRapidashPose63
+.4byte sRapidashPose64
+.4byte sRapidashPose65
+.4byte sRapidashPose66
+.4byte sRapidashPose67
+.4byte sRapidashPose68
+.4byte sRapidashPose69
+.4byte sRapidashPose70
+.4byte sRapidashPose71
+.4byte sRapidashPose72
+.4byte sRapidashPose73
+.4byte sRapidashPose74
+.4byte sRapidashPose75
+.4byte sRapidashPose76
+.4byte sRapidashPose77
+.4byte sRapidashPose78
+.4byte sRapidashPose79
+.4byte sRapidashPose80
+.4byte sRapidashPose81
+.4byte sRapidashPose82
+.4byte sRapidashPose83
+.4byte sRapidashPose84
+.4byte sRapidashPose85
+.4byte sRapidashPose86
+.4byte sRapidashPose87
+.4byte sRapidashPose88
+.4byte sRapidashPose89
+.4byte sRapidashPose90
+.4byte sRapidashPose91
+.4byte sRapidashPose92
+.4byte sRapidashPose93
+.4byte sRapidashPose94
+.4byte sRapidashPose95
+.4byte sRapidashPose96
+.4byte sRapidashPose97
+.4byte sRapidashPose98
+.4byte sRapidashPose99
+.4byte sRapidashPose100
+.4byte sRapidashPose101
+.4byte sRapidashPose102
+.4byte sRapidashPose103
+.4byte sRapidashPose104
+.4byte sRapidashPose105
+.4byte sRapidashPose106
+.4byte sRapidashPose107
+.4byte sRapidashPose108
+.4byte sRapidashPose109
+.4byte sRapidashPose110
+.4byte sRapidashPose111
+.4byte sRapidashPose112
+.4byte sRapidashPose113
+.4byte sRapidashPose114
+.4byte sRapidashPose115
+.4byte sRapidashPose116
+.4byte sRapidashPose117
+.4byte sRapidashPose118
+.4byte sRapidashPose119
+.4byte sRapidashPose120
+.4byte sRapidashPose121
+.4byte sRapidashPose122
+.4byte sRapidashPose123
+.4byte sRapidashPose124
+.4byte sRapidashPose125
+.4byte sRapidashPose126
+.4byte sRapidashPose127
+.4byte sRapidashPose128
+.4byte sRapidashPose129
+.4byte sRapidashPose130
+.4byte sRapidashPose131
+.4byte sRapidashPose132
+.4byte sRapidashPose133
+.4byte sRapidashPose134
+.4byte sRapidashPose135
+.4byte sRapidashPose136
+.4byte sRapidashPose137
+.4byte sRapidashPose138
+.4byte sRapidashPose139
+.4byte sRapidashPose140
+.4byte sRapidashPose141
+.4byte sRapidashPose142
+.4byte sRapidashPose143
+.4byte sRapidashPose144
+.4byte sRapidashPose145
+.4byte sRapidashPose146
+.4byte sRapidashPose147
+.4byte sRapidashPose148
+.4byte sRapidashPose149
+.4byte sRapidashPose150
+.4byte sRapidashPose151
+.4byte sRapidashPose152
+.4byte sRapidashPose153
+.4byte sRapidashPose154
+.4byte sRapidashPose155
+.4byte sRapidashPose156
+.4byte sRapidashPose157
+.4byte sRapidashPose158
+.4byte sRapidashPose159
+.4byte sRapidashPose160
+.4byte sRapidashPose161
+.4byte sRapidashPose162
+.4byte sRapidashPose163
+.4byte sRapidashPose164
+.4byte sRapidashPose165
+.4byte sRapidashPose166
+.4byte sRapidashPose167
+.4byte sRapidashPose168
+.4byte sRapidashPose169
+.4byte sRapidashPose170
+.4byte sRapidashPose171
+.4byte sRapidashPose172
+.4byte sRapidashPose173
+.4byte sRapidashPose174
+.4byte sRapidashPose175
+.4byte sRapidashPose176
+.4byte sRapidashPose177
+.4byte sRapidashPose178
+.4byte sRapidashPose179
+.4byte sRapidashPose180
+.4byte sRapidashPose181
+.4byte sRapidashPose182
+.4byte sRapidashPose183
+.4byte sRapidashPose184
+.4byte sRapidashPose185
+.4byte sRapidashPose186
+.4byte sRapidashPose187
+.4byte sRapidashPose188
+.4byte sRapidashPose189
+.4byte sRapidashPose190
+.4byte sRapidashPose191
+.4byte sRapidashPose192
+.4byte sRapidashPose193
+.4byte sRapidashPose194
+.4byte sRapidashPose195
+.4byte sRapidashPose196
+.4byte sRapidashPose197
+.4byte sRapidashPose198
+.4byte sRapidashPose199
+.4byte sRapidashPose200
+.4byte sRapidashPose201
+.4byte sRapidashPose202
+.4byte sRapidashPose203
+.4byte sRapidashPose204
+.4byte sRapidashPose205
+.4byte sRapidashPose206
+.4byte sRapidashPose207
+.4byte sRapidashPose208
+.4byte sRapidashPose209
+.4byte sRapidashPose210
+.4byte sRapidashPose211
+.4byte sRapidashPose212
+.4byte sRapidashPose213
+.4byte sRapidashPose214
+.4byte sRapidashPose215
+.4byte sRapidashPose216
+.4byte sRapidashPose217
+.4byte sRapidashPose218
+.4byte sRapidashPose219
+.4byte sRapidashPose220
+.4byte sRapidashPose221
+.4byte sRapidashPose222
+.4byte sRapidashPose223
+.4byte sRapidashPose224
+.4byte sRapidashPose225
+.4byte sRapidashPose226
+.4byte sRapidashPose227
+.4byte sRapidashPose228
+.4byte sRapidashPose229
+.4byte sRapidashPose230
+.4byte sRapidashPose231
+.4byte sRapidashPose232
+.4byte sRapidashPose233
+.4byte sRapidashPose234
+.4byte sRapidashPose235
+.4byte sRapidashPose236
+.4byte sRapidashPose237
+.4byte sRapidashPose238
+.4byte sRapidashPose239
+.4byte sRapidashPose240
+.4byte sRapidashPose241
+.4byte sRapidashPose242
+.4byte sRapidashPose243
+.4byte sRapidashPose244
+.4byte sRapidashPose245
+.4byte sRapidashPose246
+.4byte sRapidashPose247
+.4byte sRapidashPose248
+.4byte sRapidashPose249
+.4byte sRapidashPose250
+.4byte sRapidashPose251
+.4byte sRapidashPose252
+.4byte sRapidashPose253
+.4byte sRapidashPose254
+.4byte sRapidashPose255
+.4byte sRapidashPose256
+.4byte sRapidashPose257
+.4byte sRapidashPose258
+.4byte sRapidashPose259
+.4byte sRapidashPose260
+.4byte sRapidashPose261
+.4byte sRapidashPose262
+.4byte sRapidashPose263
+.4byte sRapidashPose264
+.4byte sRapidashPose265
+.4byte sRapidashPose266
+.4byte sRapidashPose267
+.4byte sRapidashPose268
+.4byte sRapidashPose269
+.4byte sRapidashPose270
+.4byte sRapidashPose271
+.4byte sRapidashPose272
+.4byte sRapidashPose273
+.4byte sRapidashPose274
+.4byte sRapidashPose275
+.4byte sRapidashPose276
+.4byte sRapidashPose277
+.4byte sRapidashPose278
+.4byte sRapidashPose279
+.4byte sRapidashPose280
+.4byte sRapidashPose281
+.4byte sRapidashPose282
+.4byte sRapidashPose283
+.4byte sRapidashPose284
+.4byte sRapidashPose285
+.4byte sRapidashPose286
+.4byte sRapidashPose287
+.4byte sRapidashPose288
+.4byte sRapidashPose289
+.4byte sRapidashPose290
+sAxPositionsRapidash:
+.2byte    0,   -9, 	  -3,    3, 	   3,    3, 	   0,   -8
+.2byte    0,  -10, 	  -3,   -1, 	   3,    4, 	   0,   -9
+.2byte    0,  -10, 	  -3,    4, 	   3,   -1, 	   0,   -9
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+.2byte    9,  -11, 	   3,   -2, 	   5,    4, 	   0,  -10
+.2byte    8,  -12, 	  10,    0, 	  -1,    0, 	   0,  -10
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte   14,  -15, 	   2,   -2, 	   8,    1, 	   1,   -9
+.2byte   13,  -16, 	   9,   -2, 	   3,    1, 	   1,   -9
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte   10,  -19, 	   0,   -6, 	   9,   -3, 	   1,  -11
+.2byte    9,  -20, 	   5,   -8, 	   3,   -2, 	   0,  -11
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    0,  -22, 	   3,   -3, 	  -3,   -5, 	   0,  -15
+.2byte    0,  -21, 	   3,   -5, 	  -3,   -3, 	   0,  -14
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte  -10,  -19, 	   0,   -6, 	  -9,   -3, 	  -1,  -11
+.2byte   -9,  -20, 	  -5,   -8, 	  -3,   -2, 	   0,  -11
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte  -14,  -15, 	  -2,   -2, 	  -8,    1, 	  -1,   -9
+.2byte  -13,  -16, 	  -9,   -2, 	  -3,    1, 	  -1,   -9
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte   -9,  -11, 	  -3,   -2, 	  -5,    4, 	   0,  -10
+.2byte   -8,  -12, 	 -10,    0, 	   1,    0, 	   0,  -10
+.2byte    0,  -10, 	  -3,    2, 	   3,    2, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -1, 	   3,    4, 	   0,   -9
+.2byte    0,  -10, 	  -3,    4, 	   3,   -1, 	   0,   -9
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte    0,  -19, 	  -4,  -13, 	   4,   -9, 	   0,  -13
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+.2byte    9,  -11, 	   3,   -2, 	   5,    4, 	   0,  -10
+.2byte    8,  -12, 	  10,    0, 	  -1,    0, 	   0,  -10
+.2byte   10,   -7, 	   9,    1, 	   2,    4, 	   1,   -8
+.2byte    2,  -19, 	   5,  -14, 	   2,   -8, 	  -3,  -14
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte   14,  -15, 	   2,   -2, 	   8,    1, 	   1,   -9
+.2byte   13,  -16, 	   9,   -2, 	   3,    1, 	   1,   -9
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte    5,  -20, 	   6,  -14, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte   10,  -19, 	   0,   -6, 	   9,   -3, 	   1,  -11
+.2byte    9,  -20, 	   5,   -8, 	   3,   -2, 	   0,  -11
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte    2,  -21, 	   1,  -16, 	   6,   -9, 	  -3,  -11
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    0,  -22, 	   3,   -3, 	  -3,   -5, 	   0,  -15
+.2byte    0,  -21, 	   3,   -5, 	  -3,   -3, 	   0,  -14
+.2byte    0,  -21, 	   6,   -5, 	  -6,   -5, 	   0,  -13
+.2byte    0,  -24, 	   5,  -18, 	  -5,  -12, 	   0,  -15
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte  -10,  -19, 	   0,   -6, 	  -9,   -3, 	  -1,  -11
+.2byte   -9,  -20, 	  -5,   -8, 	  -3,   -2, 	   0,  -11
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte   -2,  -21, 	  -1,  -16, 	  -6,   -9, 	   3,  -11
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte  -14,  -15, 	  -2,   -2, 	  -8,    1, 	  -1,   -9
+.2byte  -13,  -16, 	  -9,   -2, 	  -3,    1, 	  -1,   -9
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte   -5,  -20, 	  -6,  -14, 	  -8,   -8, 	   1,  -13
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte   -9,  -11, 	  -3,   -2, 	  -5,    4, 	   0,  -10
+.2byte   -8,  -12, 	 -10,    0, 	   1,    0, 	   0,  -10
+.2byte  -10,   -7, 	  -9,    1, 	  -2,    4, 	  -1,   -8
+.2byte   -2,  -19, 	  -5,  -14, 	  -2,   -8, 	   3,  -14
+.2byte    0,  -10, 	  -3,    2, 	   3,    2, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -1, 	   3,    4, 	   0,   -9
+.2byte    0,  -10, 	  -3,    4, 	   3,   -1, 	   0,   -9
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte    0,  -19, 	  -4,  -13, 	   4,   -9, 	   0,  -13
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+.2byte    9,  -11, 	   3,   -2, 	   5,    4, 	   0,  -10
+.2byte    8,  -12, 	  10,    0, 	  -1,    0, 	   0,  -10
+.2byte   10,   -7, 	   9,    1, 	   2,    4, 	   1,   -8
+.2byte    2,  -19, 	   5,  -14, 	   2,   -8, 	  -3,  -14
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte   14,  -15, 	   2,   -2, 	   8,    1, 	   1,   -9
+.2byte   13,  -16, 	   9,   -2, 	   3,    1, 	   1,   -9
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte    5,  -20, 	   6,  -14, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte   10,  -19, 	   0,   -6, 	   9,   -3, 	   1,  -11
+.2byte    9,  -20, 	   5,   -8, 	   3,   -2, 	   0,  -11
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte    2,  -21, 	   1,  -16, 	   6,   -9, 	  -3,  -11
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    0,  -22, 	   3,   -3, 	  -3,   -5, 	   0,  -15
+.2byte    0,  -21, 	   3,   -5, 	  -3,   -3, 	   0,  -14
+.2byte    0,  -21, 	   6,   -5, 	  -6,   -5, 	   0,  -13
+.2byte    0,  -24, 	   5,  -18, 	  -5,  -12, 	   0,  -15
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte  -10,  -19, 	   0,   -6, 	  -9,   -3, 	  -1,  -11
+.2byte   -9,  -20, 	  -5,   -8, 	  -3,   -2, 	   0,  -11
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte   -2,  -21, 	  -1,  -16, 	  -6,   -9, 	   3,  -11
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte  -14,  -15, 	  -2,   -2, 	  -8,    1, 	  -1,   -9
+.2byte  -13,  -16, 	  -9,   -2, 	  -3,    1, 	  -1,   -9
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte   -5,  -20, 	  -6,  -14, 	  -8,   -8, 	   1,  -13
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte   -9,  -11, 	  -3,   -2, 	  -5,    4, 	   0,  -10
+.2byte   -8,  -12, 	 -10,    0, 	   1,    0, 	   0,  -10
+.2byte  -10,   -7, 	  -9,    1, 	  -2,    4, 	  -1,   -8
+.2byte   -2,  -19, 	  -5,  -14, 	  -2,   -8, 	   3,  -14
+.2byte    0,  -10, 	  -3,    2, 	   3,    2, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -1, 	   3,    4, 	   0,   -9
+.2byte    0,  -10, 	  -3,    4, 	   3,   -1, 	   0,   -9
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte    0,  -19, 	  -4,  -13, 	   4,   -9, 	   0,  -13
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+.2byte    9,  -11, 	   3,   -2, 	   5,    4, 	   0,  -10
+.2byte    8,  -12, 	  10,    0, 	  -1,    0, 	   0,  -10
+.2byte   10,   -7, 	   9,    1, 	   2,    4, 	   1,   -8
+.2byte    2,  -19, 	   5,  -14, 	   2,   -8, 	  -3,  -14
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte   14,  -15, 	   2,   -2, 	   8,    1, 	   1,   -9
+.2byte   13,  -16, 	   9,   -2, 	   3,    1, 	   1,   -9
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte    5,  -20, 	   6,  -14, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte   10,  -19, 	   0,   -6, 	   9,   -3, 	   1,  -11
+.2byte    9,  -20, 	   5,   -8, 	   3,   -2, 	   0,  -11
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte    2,  -21, 	   1,  -16, 	   6,   -9, 	  -3,  -11
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    0,  -22, 	   3,   -3, 	  -3,   -5, 	   0,  -15
+.2byte    0,  -21, 	   3,   -5, 	  -3,   -3, 	   0,  -14
+.2byte    0,  -21, 	   6,   -5, 	  -6,   -5, 	   0,  -13
+.2byte    0,  -24, 	   5,  -18, 	  -5,  -12, 	   0,  -15
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte  -10,  -19, 	   0,   -6, 	  -9,   -3, 	  -1,  -11
+.2byte   -9,  -20, 	  -5,   -8, 	  -3,   -2, 	   0,  -11
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte   -2,  -21, 	  -1,  -16, 	  -6,   -9, 	   3,  -11
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte  -14,  -15, 	  -2,   -2, 	  -8,    1, 	  -1,   -9
+.2byte  -13,  -16, 	  -9,   -2, 	  -3,    1, 	  -1,   -9
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte   -5,  -20, 	  -6,  -14, 	  -8,   -8, 	   1,  -13
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte   -9,  -11, 	  -3,   -2, 	  -5,    4, 	   0,  -10
+.2byte   -8,  -12, 	 -10,    0, 	   1,    0, 	   0,  -10
+.2byte  -10,   -7, 	  -9,    1, 	  -2,    4, 	  -1,   -8
+.2byte   -2,  -19, 	  -5,  -14, 	  -2,   -8, 	   3,  -14
+.2byte    0,   -9, 	  -3,    3, 	   3,    3, 	   0,   -8
+.2byte    0,  -10, 	  -3,   -1, 	   3,    4, 	   0,   -9
+.2byte    0,  -10, 	  -3,    4, 	   3,   -1, 	   0,   -9
+.2byte    0,  -23, 	  -4,  -13, 	   4,  -17, 	   0,  -17
+.2byte    0,  -23, 	  -4,  -17, 	   4,  -13, 	   0,  -17
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+.2byte    9,  -11, 	   3,   -2, 	   5,    4, 	   0,  -10
+.2byte    8,  -12, 	  10,    0, 	  -1,    0, 	   0,  -10
+.2byte    2,  -19, 	   5,  -10, 	   3,  -13, 	  -2,  -14
+.2byte    2,  -19, 	   5,  -14, 	   2,   -8, 	  -3,  -14
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte   14,  -15, 	   2,   -2, 	   8,    1, 	   1,   -9
+.2byte   13,  -16, 	   9,   -2, 	   3,    1, 	   1,   -9
+.2byte    5,  -20, 	   8,  -13, 	   6,   -9, 	  -2,  -13
+.2byte    5,  -20, 	   6,  -14, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte   10,  -19, 	   0,   -6, 	   9,   -3, 	   1,  -11
+.2byte    9,  -20, 	   5,   -8, 	   3,   -2, 	   0,  -11
+.2byte    2,  -21, 	   0,  -16, 	   5,  -14, 	  -3,  -11
+.2byte    2,  -21, 	   1,  -16, 	   6,   -9, 	  -3,  -11
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    0,  -22, 	   3,   -3, 	  -3,   -5, 	   0,  -15
+.2byte    0,  -21, 	   3,   -5, 	  -3,   -3, 	   0,  -14
+.2byte    0,  -24, 	   5,  -12, 	  -5,  -17, 	   0,  -15
+.2byte    0,  -24, 	   5,  -18, 	  -5,  -12, 	   0,  -15
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte  -10,  -19, 	   0,   -6, 	  -9,   -3, 	  -1,  -11
+.2byte   -9,  -20, 	  -5,   -8, 	  -3,   -2, 	   0,  -11
+.2byte   -2,  -21, 	   0,  -16, 	  -5,  -14, 	   3,  -11
+.2byte   -2,  -21, 	  -1,  -16, 	  -6,   -9, 	   3,  -11
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte  -14,  -15, 	  -2,   -2, 	  -8,    1, 	  -1,   -9
+.2byte  -13,  -16, 	  -9,   -2, 	  -3,    1, 	  -1,   -9
+.2byte   -5,  -20, 	  -8,  -13, 	  -6,   -9, 	   2,  -13
+.2byte   -5,  -20, 	  -6,  -14, 	  -8,   -8, 	   1,  -13
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte   -9,  -11, 	  -3,   -2, 	  -5,    4, 	   0,  -10
+.2byte   -8,  -12, 	 -10,    0, 	   1,    0, 	   0,  -10
+.2byte   -2,  -19, 	  -5,  -10, 	  -3,  -13, 	   2,  -14
+.2byte   -2,  -19, 	  -5,  -14, 	  -2,   -8, 	   3,  -14
+.2byte   -2,   -6, 	 -14,    0, 	 -11,    1, 	   0,   -6
+.2byte   -2,   -5, 	 -14,    0, 	 -11,    1, 	   0,   -6
+.2byte    0,  -17, 	  -5,   -3, 	   6,   -4, 	   0,  -12
+.2byte    7,  -19, 	   8,   -8, 	   1,   -6, 	  -2,  -12
+.2byte    5,  -22, 	   8,  -12, 	   6,   -6, 	  -3,  -11
+.2byte    5,  -21, 	   5,  -10, 	   8,   -6, 	  -2,  -10
+.2byte    0,  -23, 	   4,  -12, 	  -4,  -12, 	   0,  -12
+.2byte   -6,  -21, 	  -6,  -10, 	  -9,   -6, 	   1,  -10
+.2byte   -6,  -22, 	  -9,  -12, 	  -7,   -6, 	   2,  -11
+.2byte   -8,  -19, 	  -9,   -8, 	  -2,   -6, 	   1,  -12
+.2byte    0,  -10, 	  -3,    2, 	   3,    2, 	   0,   -9
+.2byte    0,  -10, 	  -3,   -1, 	   3,    4, 	   0,   -9
+.2byte    0,  -10, 	  -3,    4, 	   3,   -1, 	   0,   -9
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte    0,  -19, 	  -4,  -13, 	   4,   -9, 	   0,  -13
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+.2byte    9,  -11, 	   3,   -2, 	   5,    4, 	   0,  -10
+.2byte    8,  -12, 	  10,    0, 	  -1,    0, 	   0,  -10
+.2byte   10,   -7, 	   9,    1, 	   2,    4, 	   1,   -8
+.2byte    2,  -19, 	   5,  -14, 	   2,   -8, 	  -3,  -14
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte   14,  -15, 	   2,   -2, 	   8,    1, 	   1,   -9
+.2byte   13,  -16, 	   9,   -2, 	   3,    1, 	   1,   -9
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte    5,  -20, 	   6,  -14, 	   8,   -8, 	  -1,  -13
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte   10,  -19, 	   0,   -6, 	   9,   -3, 	   1,  -11
+.2byte    9,  -20, 	   5,   -8, 	   3,   -2, 	   0,  -11
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte    2,  -21, 	   1,  -16, 	   6,   -9, 	  -3,  -11
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    0,  -22, 	   3,   -3, 	  -3,   -5, 	   0,  -15
+.2byte    0,  -21, 	   3,   -5, 	  -3,   -3, 	   0,  -14
+.2byte    0,  -21, 	   6,   -5, 	  -6,   -5, 	   0,  -13
+.2byte    0,  -24, 	   5,  -18, 	  -5,  -12, 	   0,  -15
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte  -10,  -19, 	   0,   -6, 	  -9,   -3, 	  -1,  -11
+.2byte   -9,  -20, 	  -5,   -8, 	  -3,   -2, 	   0,  -11
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte   -2,  -21, 	  -1,  -16, 	  -6,   -9, 	   3,  -11
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte  -14,  -15, 	  -2,   -2, 	  -8,    1, 	  -1,   -9
+.2byte  -13,  -16, 	  -9,   -2, 	  -3,    1, 	  -1,   -9
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte   -5,  -20, 	  -6,  -14, 	  -8,   -8, 	   1,  -13
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte   -9,  -11, 	  -3,   -2, 	  -5,    4, 	   0,  -10
+.2byte   -8,  -12, 	 -10,    0, 	   1,    0, 	   0,  -10
+.2byte  -10,   -7, 	  -9,    1, 	  -2,    4, 	  -1,   -8
+.2byte   -2,  -19, 	  -5,  -14, 	  -2,   -8, 	   3,  -14
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte  -10,   -7, 	  -9,    1, 	  -2,    4, 	  -1,   -8
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte    0,  -20, 	   6,   -4, 	  -6,   -4, 	   0,  -12
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte   10,   -7, 	   9,    1, 	   2,    4, 	   1,   -8
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte   10,   -7, 	   9,    1, 	   2,    4, 	   1,   -8
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte    0,  -20, 	   6,   -4, 	  -6,   -4, 	   0,  -12
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte  -10,   -7, 	  -9,    1, 	  -2,    4, 	  -1,   -8
+.2byte    0,  -10, 	  -3,    2, 	   3,    2, 	   0,   -9
+.2byte    0,  -19, 	  -4,  -13, 	   4,   -9, 	   0,  -13
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+.2byte    3,  -19, 	   6,  -14, 	   3,   -8, 	  -2,  -14
+.2byte    9,   -7, 	   8,    1, 	   1,    4, 	   0,   -8
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte    5,  -20, 	   6,  -14, 	   8,   -8, 	  -1,  -13
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte    4,  -21, 	   3,  -16, 	   8,   -9, 	  -1,  -11
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    0,  -24, 	   5,  -18, 	  -5,  -12, 	   0,  -15
+.2byte    0,  -21, 	   6,   -5, 	  -6,   -5, 	   0,  -13
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte   -4,  -21, 	  -3,  -16, 	  -8,   -9, 	   1,  -11
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte   -5,  -20, 	  -6,  -14, 	  -8,   -8, 	   1,  -13
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte   -3,  -19, 	  -6,  -14, 	  -3,   -8, 	   2,  -14
+.2byte   -9,   -7, 	  -8,    1, 	  -1,    4, 	   0,   -8
+.2byte    0,   -4, 	  -5,    4, 	   5,    4, 	   0,   -7
+.2byte  -10,   -7, 	  -9,    1, 	  -2,    4, 	  -1,   -8
+.2byte  -15,  -11, 	  -9,   -3, 	  -8,    2, 	  -2,  -10
+.2byte  -10,  -17, 	  -2,   -5, 	  -8,   -2, 	  -2,  -10
+.2byte    0,  -20, 	   6,   -4, 	  -6,   -4, 	   0,  -12
+.2byte   10,  -17, 	   2,   -5, 	   8,   -2, 	   2,  -10
+.2byte   14,  -10, 	   8,   -3, 	   7,    2, 	   1,  -10
+.2byte   10,   -7, 	   9,    1, 	   2,    4, 	   1,   -8
+.2byte    0,   -9, 	  -3,    3, 	   3,    3, 	   0,   -8
+.2byte   -8,  -11, 	  -7,    1, 	  -2,    3, 	   0,  -10
+.2byte  -13,  -15, 	  -7,   -2, 	  -5,    1, 	  -1,  -10
+.2byte   -9,  -19, 	  -2,   -5, 	  -6,   -2, 	   0,  -11
+.2byte    0,  -21, 	   3,   -4, 	  -3,   -4, 	   0,  -13
+.2byte    9,  -19, 	   2,   -5, 	   6,   -2, 	   0,  -11
+.2byte   13,  -15, 	   7,   -2, 	   5,    1, 	   1,  -10
+.2byte    8,  -11, 	   7,    1, 	   2,    3, 	   0,  -10
+sRapidashAnimTable1:
+.4byte sRapidashAnims_1_1
+.4byte sRapidashAnims_1_2
+.4byte sRapidashAnims_1_3
+.4byte sRapidashAnims_1_4
+.4byte sRapidashAnims_1_5
+.4byte sRapidashAnims_1_6
+.4byte sRapidashAnims_1_7
+.4byte sRapidashAnims_1_8
+sRapidashAnimTable2:
+.4byte sRapidashAnims_2_1
+.4byte sRapidashAnims_2_2
+.4byte sRapidashAnims_2_3
+.4byte sRapidashAnims_2_4
+.4byte sRapidashAnims_2_5
+.4byte sRapidashAnims_2_6
+.4byte sRapidashAnims_2_7
+.4byte sRapidashAnims_2_8
+sRapidashAnimTable3:
+.4byte sRapidashAnims_3_1
+.4byte sRapidashAnims_3_2
+.4byte sRapidashAnims_3_3
+.4byte sRapidashAnims_3_4
+.4byte sRapidashAnims_3_5
+.4byte sRapidashAnims_3_6
+.4byte sRapidashAnims_3_7
+.4byte sRapidashAnims_3_8
+sRapidashAnimTable4:
+.4byte sRapidashAnims_4_1
+.4byte sRapidashAnims_4_2
+.4byte sRapidashAnims_4_3
+.4byte sRapidashAnims_4_4
+.4byte sRapidashAnims_4_5
+.4byte sRapidashAnims_4_6
+.4byte sRapidashAnims_4_7
+.4byte sRapidashAnims_4_8
+sRapidashAnimTable5:
+.4byte sRapidashAnims_5_1
+.4byte sRapidashAnims_5_2
+.4byte sRapidashAnims_5_3
+.4byte sRapidashAnims_5_4
+.4byte sRapidashAnims_5_5
+.4byte sRapidashAnims_5_6
+.4byte sRapidashAnims_5_7
+.4byte sRapidashAnims_5_8
+sRapidashAnimTable6:
+.4byte sRapidashAnims_6_1
+.4byte sRapidashAnims_6_1
+.4byte sRapidashAnims_6_1
+.4byte sRapidashAnims_6_1
+.4byte sRapidashAnims_6_1
+.4byte sRapidashAnims_6_1
+.4byte sRapidashAnims_6_1
+.4byte sRapidashAnims_6_1
+sRapidashAnimTable7:
+.4byte sRapidashAnims_7_1
+.4byte sRapidashAnims_7_2
+.4byte sRapidashAnims_7_3
+.4byte sRapidashAnims_7_4
+.4byte sRapidashAnims_7_5
+.4byte sRapidashAnims_7_6
+.4byte sRapidashAnims_7_7
+.4byte sRapidashAnims_7_8
+sRapidashAnimTable8:
+.4byte sRapidashAnims_8_1
+.4byte sRapidashAnims_8_2
+.4byte sRapidashAnims_8_3
+.4byte sRapidashAnims_8_4
+.4byte sRapidashAnims_8_5
+.4byte sRapidashAnims_8_6
+.4byte sRapidashAnims_8_7
+.4byte sRapidashAnims_8_8
+sRapidashAnimTable9:
+.4byte sRapidashAnims_9_1
+.4byte sRapidashAnims_9_2
+.4byte sRapidashAnims_9_3
+.4byte sRapidashAnims_9_4
+.4byte sRapidashAnims_9_5
+.4byte sRapidashAnims_9_6
+.4byte sRapidashAnims_9_7
+.4byte sRapidashAnims_9_8
+sRapidashAnimTable10:
+.4byte sRapidashAnims_10_1
+.4byte sRapidashAnims_10_2
+.4byte sRapidashAnims_10_3
+.4byte sRapidashAnims_10_4
+.4byte sRapidashAnims_10_5
+.4byte sRapidashAnims_10_6
+.4byte sRapidashAnims_10_7
+.4byte sRapidashAnims_10_8
+sRapidashAnimTable11:
+.4byte sRapidashAnims_11_1
+.4byte sRapidashAnims_11_2
+.4byte sRapidashAnims_11_3
+.4byte sRapidashAnims_11_4
+.4byte sRapidashAnims_11_5
+.4byte sRapidashAnims_11_6
+.4byte sRapidashAnims_11_7
+.4byte sRapidashAnims_11_8
+sRapidashAnimTable12:
+.4byte sRapidashAnims_12_1
+.4byte sRapidashAnims_12_2
+.4byte sRapidashAnims_12_3
+.4byte sRapidashAnims_12_4
+.4byte sRapidashAnims_12_5
+.4byte sRapidashAnims_12_6
+.4byte sRapidashAnims_12_7
+.4byte sRapidashAnims_12_8
+sRapidashAnimTable13:
+.4byte sRapidashAnims_13_1
+.4byte sRapidashAnims_13_2
+.4byte sRapidashAnims_13_3
+.4byte sRapidashAnims_13_4
+.4byte sRapidashAnims_13_5
+.4byte sRapidashAnims_13_6
+.4byte sRapidashAnims_13_7
+.4byte sRapidashAnims_13_8
+sAxAnimationsRapidash:
+.4byte sRapidashAnimTable1
+.4byte sRapidashAnimTable2
+.4byte sRapidashAnimTable3
+.4byte sRapidashAnimTable4
+.4byte sRapidashAnimTable5
+.4byte sRapidashAnimTable6
+.4byte sRapidashAnimTable7
+.4byte sRapidashAnimTable8
+.4byte sRapidashAnimTable9
+.4byte sRapidashAnimTable10
+.4byte sRapidashAnimTable11
+.4byte sRapidashAnimTable12
+.4byte sRapidashAnimTable13
+sAxSpritesRapidash:
+.4byte sRapidashSprites1
+.4byte sRapidashSprites2
+.4byte sRapidashSprites3
+.4byte sRapidashSprites4
+.4byte sRapidashSprites5
+.4byte sRapidashSprites6
+.4byte sRapidashSprites7
+.4byte sRapidashSprites8
+.4byte sRapidashSprites9
+.4byte sRapidashSprites10
+.4byte sRapidashSprites11
+.4byte sRapidashSprites12
+.4byte sRapidashSprites13
+.4byte sRapidashSprites14
+.4byte sRapidashSprites15
+.4byte sRapidashSprites16
+.4byte sRapidashSprites17
+.4byte sRapidashSprites18
+.4byte sRapidashSprites19
+.4byte sRapidashSprites20
+.4byte sRapidashSprites21
+.4byte sRapidashSprites22
+.4byte sRapidashSprites23
+.4byte sRapidashSprites24
+.4byte sRapidashSprites25
+.4byte sRapidashSprites26
+.4byte sRapidashSprites27
+.4byte sRapidashSprites28
+.4byte sRapidashSprites29
+.4byte sRapidashSprites30
+.4byte sRapidashSprites31
+.4byte sRapidashSprites32
+.4byte sRapidashSprites33
+.4byte sRapidashSprites34
+.4byte sRapidashSprites35
+.4byte sRapidashSprites36
+.4byte sRapidashSprites37
+.4byte sRapidashSprites38
+.4byte sRapidashSprites39
+.4byte sRapidashSprites40
+.4byte sRapidashSprites41
+.4byte sRapidashSprites42
+.4byte sRapidashSprites43
+.4byte sRapidashSprites44
+.4byte sRapidashSprites45
+.4byte sRapidashSprites46
+.4byte sRapidashSprites47
+.4byte sRapidashSprites48
+.4byte sRapidashSprites49
+.4byte sRapidashSprites50
+.4byte sRapidashSprites51
+.4byte sRapidashSprites52
+.4byte sRapidashSprites53
+.4byte sRapidashSprites54
+.4byte sRapidashSprites55
+.4byte sRapidashSprites56
+.4byte sRapidashSprites57
+.4byte sRapidashSprites58
+.4byte sRapidashSprites59
+.4byte sRapidashSprites60
+.4byte sRapidashSprites61
+.4byte sRapidashSprites62
+.4byte sRapidashSprites63
+.4byte sRapidashSprites64
+.4byte sRapidashSprites65
+.4byte sRapidashSprites66
+.4byte sRapidashSprites67
+.4byte sRapidashSprites68
+.4byte sRapidashSprites69
+.4byte sRapidashSprites70
+.4byte sRapidashSprites71
+.4byte sRapidashSprites72
+.4byte sRapidashSprites73
+.4byte sRapidashSprites74
+.4byte sRapidashSprites75
+.4byte sRapidashSprites76
+.4byte sRapidashSprites77
+.4byte sRapidashSprites78
+.4byte sRapidashSprites79
+.4byte sRapidashSprites80
+.4byte sRapidashSprites81
+sAxMainRapidash:
+ax_main sAxPosesRapidash, sAxAnimationsRapidash, 13, sAxSpritesRapidash, sAxPositionsRapidash

--- a/data/ax/raticate.inc
+++ b/data/ax/raticate.inc
@@ -1,0 +1,2797 @@
+.global gAxRaticate
+gAxRaticate:
+ax_siro sAxMainRaticate
+sRaticatePose1:
+ax_pose 0, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose2:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose3:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose4:
+ax_pose 3, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose5:
+ax_pose 4, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sRaticatePose6:
+ax_pose 5, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose7:
+ax_pose 6, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose8:
+ax_pose 7, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaticatePose9:
+ax_pose 8, 0x01e9, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose10:
+ax_pose 9, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose11:
+ax_pose 10, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose12:
+ax_pose 11, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose16:
+ax_pose 9, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose17:
+ax_pose 10, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose18:
+ax_pose 11, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose19:
+ax_pose 6, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose20:
+ax_pose 7, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaticatePose21:
+ax_pose 8, 0x01e9, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose22:
+ax_pose 3, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose23:
+ax_pose 4, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sRaticatePose24:
+ax_pose 5, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose25:
+ax_pose 0, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose26:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose27:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose28:
+ax_pose 3, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose29:
+ax_pose 4, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sRaticatePose30:
+ax_pose 5, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose31:
+ax_pose 6, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose32:
+ax_pose 7, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaticatePose33:
+ax_pose 8, 0x01e9, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose34:
+ax_pose 9, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose35:
+ax_pose 10, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose36:
+ax_pose 11, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose37:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose39:
+ax_pose 14, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose40:
+ax_pose 9, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose41:
+ax_pose 10, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose42:
+ax_pose 11, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose43:
+ax_pose 6, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose44:
+ax_pose 7, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaticatePose45:
+ax_pose 8, 0x01e9, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose46:
+ax_pose 3, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose47:
+ax_pose 4, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sRaticatePose48:
+ax_pose 5, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose49:
+ax_pose 0, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose50:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose51:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose52:
+ax_pose 3, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose53:
+ax_pose 4, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sRaticatePose54:
+ax_pose 5, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose55:
+ax_pose 6, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose56:
+ax_pose 7, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaticatePose57:
+ax_pose 8, 0x01e9, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose58:
+ax_pose 9, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose59:
+ax_pose 10, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose60:
+ax_pose 11, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose61:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose62:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose63:
+ax_pose 14, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose64:
+ax_pose 9, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose65:
+ax_pose 10, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose66:
+ax_pose 11, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose67:
+ax_pose 6, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose68:
+ax_pose 7, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaticatePose69:
+ax_pose 8, 0x01e9, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose70:
+ax_pose 3, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose71:
+ax_pose 4, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sRaticatePose72:
+ax_pose 5, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose73:
+ax_pose 0, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose74:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose75:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose76:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose77:
+ax_pose 3, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose78:
+ax_pose 17, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose79:
+ax_pose 18, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose80:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sRaticatePose81:
+ax_pose 6, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose82:
+ax_pose 19, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose83:
+ax_pose 20, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose84:
+ax_pose 7, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaticatePose85:
+ax_pose 9, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose86:
+ax_pose 21, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose87:
+ax_pose 22, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose88:
+ax_pose 10, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose89:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose90:
+ax_pose 23, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose91:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose92:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose93:
+ax_pose 9, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose94:
+ax_pose 21, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose95:
+ax_pose 22, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose96:
+ax_pose 10, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose97:
+ax_pose 6, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose98:
+ax_pose 19, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose99:
+ax_pose 20, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose100:
+ax_pose 7, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaticatePose101:
+ax_pose 3, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose102:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose103:
+ax_pose 18, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose104:
+ax_pose 4, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose105:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose106:
+ax_pose 26, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose107:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose108:
+ax_pose 27, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose109:
+ax_pose 28, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose110:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sRaticatePose111:
+ax_pose 29, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose112:
+ax_pose 30, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose113:
+ax_pose 7, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaticatePose114:
+ax_pose 31, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose115:
+ax_pose 32, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose116:
+ax_pose 10, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose117:
+ax_pose 33, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose118:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose119:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose120:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose121:
+ax_pose 32, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose122:
+ax_pose 10, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose123:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose124:
+ax_pose 30, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose125:
+ax_pose 7, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaticatePose126:
+ax_pose 27, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose127:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose128:
+ax_pose 4, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose129:
+ax_pose 35, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sRaticatePose130:
+ax_pose 36, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sRaticatePose131:
+ax_pose 37, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose132:
+ax_pose 38, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sRaticatePose133:
+ax_pose 39, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose134:
+ax_pose 40, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose135:
+ax_pose 41, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose136:
+ax_pose 40, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose137:
+ax_pose 39, 0x01e6, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose138:
+ax_pose 38, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sRaticatePose139:
+ax_pose 0, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose140:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose141:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose142:
+ax_pose 3, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose143:
+ax_pose 4, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sRaticatePose144:
+ax_pose 5, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose145:
+ax_pose 6, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose146:
+ax_pose 7, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaticatePose147:
+ax_pose 8, 0x01e9, 0x90eb, 0x4c00
+ax_pose_terminator
+sRaticatePose148:
+ax_pose 9, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose149:
+ax_pose 10, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose150:
+ax_pose 11, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose151:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose152:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose153:
+ax_pose 14, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose154:
+ax_pose 9, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose155:
+ax_pose 10, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose156:
+ax_pose 11, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose157:
+ax_pose 6, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose158:
+ax_pose 7, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaticatePose159:
+ax_pose 8, 0x01e9, 0x80f5, 0x4c00
+ax_pose_terminator
+sRaticatePose160:
+ax_pose 3, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose161:
+ax_pose 4, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose162:
+ax_pose 5, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose163:
+ax_pose 16, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose164:
+ax_pose 18, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaticatePose165:
+ax_pose 20, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaticatePose166:
+ax_pose 22, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaticatePose167:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose168:
+ax_pose 22, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaticatePose169:
+ax_pose 20, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaticatePose170:
+ax_pose 18, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaticatePose171:
+ax_pose 15, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose172:
+ax_pose 17, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose173:
+ax_pose 19, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose174:
+ax_pose 21, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sRaticatePose175:
+ax_pose 23, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose176:
+ax_pose 21, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sRaticatePose177:
+ax_pose 19, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose178:
+ax_pose 17, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose179:
+ax_pose 0, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose180:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose181:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose182:
+ax_pose 3, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose183:
+ax_pose 5, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose184:
+ax_pose 4, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sRaticatePose185:
+ax_pose 6, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose186:
+ax_pose 8, 0x01e9, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose187:
+ax_pose 7, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sRaticatePose188:
+ax_pose 9, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose189:
+ax_pose 11, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose190:
+ax_pose 10, 0x01ea, 0x90e9, 0x4c00
+ax_pose_terminator
+sRaticatePose191:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose192:
+ax_pose 14, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose193:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose194:
+ax_pose 9, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose195:
+ax_pose 11, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose196:
+ax_pose 10, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose197:
+ax_pose 6, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose198:
+ax_pose 8, 0x01e9, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose199:
+ax_pose 7, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sRaticatePose200:
+ax_pose 3, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose201:
+ax_pose 5, 0x01ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sRaticatePose202:
+ax_pose 4, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sRaticatePose203:
+ax_pose 16, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose204:
+ax_pose 18, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaticatePose205:
+ax_pose 20, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaticatePose206:
+ax_pose 22, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sRaticatePose207:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sRaticatePose208:
+ax_pose 22, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaticatePose209:
+ax_pose 20, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaticatePose210:
+ax_pose 18, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sRaticatePose211:
+ax_pose 0, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose212:
+ax_pose 3, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose213:
+ax_pose 6, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sRaticatePose214:
+ax_pose 9, 0x01ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sRaticatePose215:
+ax_pose 12, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sRaticatePose216:
+ax_pose 9, 0x01ea, 0x90e8, 0x4c00
+ax_pose_terminator
+sRaticatePose217:
+ax_pose 6, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sRaticatePose218:
+ax_pose 3, 0x01ea, 0x90ea, 0x4c00
+ax_pose_terminator
+.align 2
+sRaticateAnims_1_1:
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 1,
+ax_anim 4, 0, 2, 0, -3, 0, 1,
+ax_anim 4, 0, 0, 0, 0, 0, 1,
+ax_anim_terminator
+sRaticateAnims_1_2:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -1, -1, -1, -1,
+ax_anim 4, 0, 5, -1, -3, -1, -1,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 4, 0, 5, 1, -3, 1, 1,
+ax_anim 4, 0, 3, 1, 1, 1, 1,
+ax_anim_terminator
+sRaticateAnims_1_3:
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -1, 0, -1, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 1, -4, 1, 0,
+ax_anim 4, 0, 8, 2, -3, 2, 0,
+ax_anim 4, 0, 6, 1, 0, 1, 0,
+ax_anim_terminator
+sRaticateAnims_1_4:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -1, -3, -1, 1,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim 4, 0, 11, 1, -3, 1, -1,
+ax_anim 4, 0, 9, 1, -1, 1, -1,
+ax_anim_terminator
+sRaticateAnims_1_5:
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, 1,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -4, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, -1,
+ax_anim 4, 0, 12, 0, -1, 0, -1,
+ax_anim_terminator
+sRaticateAnims_1_6:
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 1, 1, 1, 1,
+ax_anim 4, 0, 17, 1, -3, 1, 1,
+ax_anim 4, 0, 17, 0, -4, 0, 0,
+ax_anim 4, 0, 17, -1, -3, -1, -1,
+ax_anim 4, 0, 15, -1, -1, -1, -1,
+ax_anim_terminator
+sRaticateAnims_1_7:
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 1, 0, 1, 0,
+ax_anim 4, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 20, -1, -4, -1, 0,
+ax_anim 4, 0, 20, -2, -3, -2, 0,
+ax_anim 4, 0, 18, -1, 0, -1, 0,
+ax_anim_terminator
+sRaticateAnims_1_8:
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 1, -3, 1, -1,
+ax_anim 4, 0, 23, 0, -4, 0, 0,
+ax_anim 4, 0, 23, -1, -3, -1, 1,
+ax_anim 4, 0, 21, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRaticateAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 4, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 26, 0, -3, 0, -2,
+ax_anim 2, 0, 26, 0, -1, 0, 1,
+ax_anim 2, 2, 26, 0, 11, 0, 13,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, -1, 20, -1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, -1, 20, -1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sRaticateAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, -3, -3, -3, -3,
+ax_anim 4, 0, 28, -4, -4, -4, -4,
+ax_anim 1, 0, 29, 0, -2, 0, 0,
+ax_anim 2, 0, 29, 4, 1, 4, 4,
+ax_anim 2, 2, 29, 15, 13, 15, 15,
+ax_anim 2, 0, 28, 21, 20, 21, 20,
+ax_anim 2, 1, 28, 22, 19, 22, 19,
+ax_anim 2, 0, 28, 21, 20, 21, 20,
+ax_anim 2, 0, 28, 22, 19, 22, 19,
+ax_anim 2, 0, 28, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 4, 4, 4, 4,
+ax_anim_terminator
+sRaticateAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 4, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 0, 32, 0, -1, 0, 0,
+ax_anim 2, 0, 32, 4, -4, 4, 0,
+ax_anim 2, 2, 32, 13, -4, 13, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 4, 0, 4, 0,
+ax_anim_terminator
+sRaticateAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 33, -3, 3, -3, 3,
+ax_anim 4, 0, 34, -4, 4, -4, 4,
+ax_anim 1, 0, 35, 0, -1, 0, 0,
+ax_anim 2, 0, 35, 4, -9, 4, -4,
+ax_anim 2, 2, 35, 13, -17, 13, -13,
+ax_anim 2, 0, 34, 22, -23, 22, -23,
+ax_anim 2, 1, 34, 22, -22, 22, -22,
+ax_anim 2, 0, 34, 22, -23, 22, -23,
+ax_anim 2, 0, 34, 22, -22, 22, -22,
+ax_anim 2, 0, 34, 22, -23, 22, -23,
+ax_anim 2, 0, 33, 10, -10, 10, -10,
+ax_anim 2, 0, 33, 4, -4, 4, -4,
+ax_anim_terminator
+sRaticateAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 3, 0, 3,
+ax_anim 4, 0, 37, 0, 4, 0, 4,
+ax_anim 1, 0, 38, 0, -3, 0, -1,
+ax_anim 2, 0, 38, 0, -12, 0, -9,
+ax_anim 2, 2, 38, 0, -17, 0, -16,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 1, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 0, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 0, 36, 0, -10, 0, -10,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sRaticateAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 3, 3, 3, 3,
+ax_anim 4, 0, 40, 4, 4, 4, 4,
+ax_anim 1, 0, 41, 0, -1, 0, 0,
+ax_anim 2, 0, 41, -4, -9, -4, -4,
+ax_anim 2, 2, 41, -13, -17, -13, -13,
+ax_anim 2, 0, 40, -22, -23, -22, -23,
+ax_anim 2, 1, 40, -22, -22, -22, -22,
+ax_anim 2, 0, 40, -22, -23, -22, -23,
+ax_anim 2, 0, 40, -22, -22, -22, -22,
+ax_anim 2, 0, 40, -22, -23, -22, -23,
+ax_anim 2, 0, 39, -10, -10, -10, -10,
+ax_anim 2, 0, 39, -4, -4, -4, -4,
+ax_anim_terminator
+sRaticateAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 4, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 0, 44, 0, -1, 0, 0,
+ax_anim 2, 0, 44, -4, -4, -4, 0,
+ax_anim 2, 2, 44, -13, -4, -13, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -4, 0, -4, 0,
+ax_anim_terminator
+sRaticateAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 45, 3, -3, 3, -3,
+ax_anim 4, 0, 46, 4, -4, 4, -4,
+ax_anim 1, 0, 47, 0, -2, 0, 0,
+ax_anim 2, 0, 47, -4, 1, -4, 4,
+ax_anim 2, 2, 47, -15, 13, -15, 15,
+ax_anim 2, 0, 46, -21, 20, -21, 20,
+ax_anim 2, 1, 46, -22, 19, -22, 19,
+ax_anim 2, 0, 46, -21, 20, -21, 20,
+ax_anim 2, 0, 46, -22, 19, -22, 19,
+ax_anim 2, 0, 46, -21, 20, -21, 20,
+ax_anim 2, 0, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sRaticateAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 48, 0, -3, 0, -3,
+ax_anim 4, 0, 49, 0, -4, 0, -4,
+ax_anim 1, 0, 50, 0, -3, 0, -2,
+ax_anim 2, 0, 50, 0, -1, 0, 1,
+ax_anim 2, 2, 50, 0, 11, 0, 13,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 1, 49, -1, 20, -1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 49, -1, 20, -1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sRaticateAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 51, -3, -3, -3, -3,
+ax_anim 4, 0, 52, -4, -4, -4, -4,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 2, 0, 53, 4, 1, 4, 4,
+ax_anim 2, 2, 53, 15, 13, 15, 15,
+ax_anim 2, 0, 52, 21, 20, 21, 20,
+ax_anim 2, 1, 52, 22, 19, 22, 19,
+ax_anim 2, 0, 52, 21, 20, 21, 20,
+ax_anim 2, 0, 52, 22, 19, 22, 19,
+ax_anim 2, 0, 52, 21, 20, 21, 20,
+ax_anim 2, 0, 51, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 4, 4, 4, 4,
+ax_anim_terminator
+sRaticateAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 2, 0, 54, -3, 0, -3, 0,
+ax_anim 4, 0, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 56, 0, -1, 0, 0,
+ax_anim 2, 0, 56, 4, -4, 4, 0,
+ax_anim 2, 2, 56, 13, -4, 13, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 54, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim_terminator
+sRaticateAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 2, 0, 57, -3, 3, -3, 3,
+ax_anim 4, 0, 58, -4, 4, -4, 4,
+ax_anim 1, 0, 59, 0, -1, 0, 0,
+ax_anim 2, 0, 59, 4, -9, 4, -4,
+ax_anim 2, 2, 59, 13, -17, 13, -13,
+ax_anim 2, 0, 58, 22, -23, 22, -23,
+ax_anim 2, 1, 58, 22, -22, 22, -22,
+ax_anim 2, 0, 58, 22, -23, 22, -23,
+ax_anim 2, 0, 58, 22, -22, 22, -22,
+ax_anim 2, 0, 58, 22, -23, 22, -23,
+ax_anim 2, 0, 57, 10, -10, 10, -10,
+ax_anim 2, 0, 57, 4, -4, 4, -4,
+ax_anim_terminator
+sRaticateAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 60, 0, 3, 0, 3,
+ax_anim 4, 0, 61, 0, 4, 0, 4,
+ax_anim 1, 0, 62, 0, -3, 0, -1,
+ax_anim 2, 0, 62, 0, -12, 0, -9,
+ax_anim 2, 2, 62, 0, -17, 0, -16,
+ax_anim 2, 0, 61, 0, -23, 0, -23,
+ax_anim 2, 1, 61, 1, -23, 1, -23,
+ax_anim 2, 0, 61, 0, -23, 0, -23,
+ax_anim 2, 0, 61, 1, -23, 1, -23,
+ax_anim 2, 0, 61, 0, -23, 0, -23,
+ax_anim 2, 0, 60, 0, -10, 0, -10,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sRaticateAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 2, 0, 63, 3, 3, 3, 3,
+ax_anim 4, 0, 64, 4, 4, 4, 4,
+ax_anim 1, 0, 65, 0, -1, 0, 0,
+ax_anim 2, 0, 65, -4, -9, -4, -4,
+ax_anim 2, 2, 65, -13, -17, -13, -13,
+ax_anim 2, 0, 64, -22, -23, -22, -23,
+ax_anim 2, 1, 64, -22, -22, -22, -22,
+ax_anim 2, 0, 64, -22, -23, -22, -23,
+ax_anim 2, 0, 64, -22, -22, -22, -22,
+ax_anim 2, 0, 64, -22, -23, -22, -23,
+ax_anim 2, 0, 63, -10, -10, -10, -10,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim_terminator
+sRaticateAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 2, 0, 66, 3, 0, 3, 0,
+ax_anim 4, 0, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 68, 0, -1, 0, 0,
+ax_anim 2, 0, 68, -4, -4, -4, 0,
+ax_anim 2, 2, 68, -13, -4, -13, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -10, 0, -10, 0,
+ax_anim 2, 0, 66, -4, 0, -4, 0,
+ax_anim_terminator
+sRaticateAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 2, 0, 69, 3, -3, 3, -3,
+ax_anim 4, 0, 70, 4, -4, 4, -4,
+ax_anim 1, 0, 71, 0, -2, 0, 0,
+ax_anim 2, 0, 71, -4, 1, -4, 4,
+ax_anim 2, 2, 71, -15, 13, -15, 15,
+ax_anim 2, 0, 70, -21, 20, -21, 20,
+ax_anim 2, 1, 70, -22, 19, -22, 19,
+ax_anim 2, 0, 70, -21, 20, -21, 20,
+ax_anim 2, 0, 70, -22, 19, -22, 19,
+ax_anim 2, 0, 70, -21, 20, -21, 20,
+ax_anim 2, 0, 69, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sRaticateAnims_4_1:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 4, 2, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 1, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, 1, 4, 1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, 1, 4, 1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 75, 1, 4, 1, 4,
+ax_anim 2, 0, 75, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sRaticateAnims_4_2:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 4, 2, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 2, 2, 2, 2,
+ax_anim 2, 1, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 5, 3, 5, 3,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 5, 3, 5, 3,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 79, 5, 3, 5, 3,
+ax_anim 2, 0, 79, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sRaticateAnims_4_3:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, -3, 0, 0,
+ax_anim 4, 2, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, 2, 0, 2, 0,
+ax_anim 2, 1, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, -1, 4, -1,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sRaticateAnims_4_4:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 4, 2, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 2, -2, 2, -2,
+ax_anim 2, 1, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 5, -3, 5, -3,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 5, -3, 5, -3,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 5, -3, 5, -3,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sRaticateAnims_4_5:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 4, 2, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, -2,
+ax_anim 2, 1, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 1, -4, 1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 1, -4, 1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 1, -4, 1, -4,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sRaticateAnims_4_6:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 2, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -1, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, -2, -2, -2, -2,
+ax_anim 2, 1, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -5, -3, -5, -3,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -5, -3, -5, -3,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -5, -3, -5, -3,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sRaticateAnims_4_7:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 4, 2, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, -2, 0, -2, 0,
+ax_anim 2, 1, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, -1, -4, -1,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sRaticateAnims_4_8:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 4, 2, 101, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, -2, 2, -2, 2,
+ax_anim 2, 1, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 103, -5, 3, -5, 3,
+ax_anim 2, 0, 103, -4, 4, -4, 4,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sRaticateAnims_5_1:
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 2, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_5_2:
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 3, 2, 109, 0, 0, 0, 0,
+ax_anim 3, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_5_3:
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 2, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 3, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_5_4:
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 3, 2, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_5_5:
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 2, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_5_6:
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 3, 2, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_5_7:
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 2, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_5_8:
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 2, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaticateAnims_6_1:
+ax_anim 35, 0, 128, 0, 0, 0, 0,
+ax_anim 30, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaticateAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sRaticateAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sRaticateAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sRaticateAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sRaticateAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sRaticateAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sRaticateAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sRaticateAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRaticateAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 3, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 3, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 3, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim 3, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 3, 0, 152, 0, -2, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim 3, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 3, 0, 155, 0, -2, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 3, 0, 158, 0, -2, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim 3, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 3, 0, 161, 0, -2, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaticateAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 11, 8, 11,
+ax_anim 2, 0, 165, 7, 19, 7, 19,
+ax_anim 3, 0, 166, 0, 22, 0, 22,
+ax_anim 2, 3, 167, -7, 19, -7, 19,
+ax_anim 2, 0, 168, -8, 11, -8, 11,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 11, 22, 11,
+ax_anim 3, 0, 165, 21, 20, 21, 20,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 14, 2, 14,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 21, 1, 21, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 11, -22, 11, -22,
+ax_anim 3, 0, 163, 20, -22, 20, -22,
+ax_anim 2, 3, 164, 20, -11, 20, -11,
+ax_anim 2, 0, 165, 16, -6, 16, -6,
+ax_anim 1, 0, 166, 8, 0, 8, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -9, -10, -9, -10,
+ax_anim 2, 0, 169, -6, -18, -6, -18,
+ax_anim 3, 0, 162, 0, -20, 0, -20,
+ax_anim 2, 3, 163, 6, -18, 6, -18,
+ax_anim 2, 0, 164, 9, -8, 9, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -11, -22, -11, -22,
+ax_anim 3, 0, 169, -20, -22, -20, -22,
+ax_anim 2, 3, 168, -20, -11, -20, -11,
+ax_anim 2, 0, 167, -16, -6, -16, -6,
+ax_anim 1, 0, 166, -8, 0, -8, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -21, 1, -21, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 11, -22, 11,
+ax_anim 3, 0, 167, -21, 20, -21, 20,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -2, 14, -2, 14,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaticateAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaticateAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -25, 0, 0,
+ax_anim 3, 0, 180, 0, -23, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -26, 0, 0,
+ax_anim 3, 0, 183, 0, -24, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -25, 0, 0,
+ax_anim 3, 0, 186, 0, -23, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -25, 0, 0,
+ax_anim 3, 0, 189, 0, -23, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -25, 0, 0,
+ax_anim 3, 0, 192, 0, -23, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -25, 0, 0,
+ax_anim 3, 0, 195, 0, -23, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -25, 0, 0,
+ax_anim 3, 0, 198, 0, -23, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -26, 0, 0,
+ax_anim 3, 0, 201, 0, -24, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaticateAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRaticateAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRaticateGfx1:
+.incbin "baserom.gba", 0x5E379C, 0x100
+sRaticateSprites1:
+ax_sprite sRaticateGfx1, 0x100
+ax_sprite_terminator
+sRaticateGfx2:
+.incbin "baserom.gba", 0x5E38AC, 0x100
+sRaticateSprites2:
+ax_sprite sRaticateGfx2, 0x100
+ax_sprite_terminator
+sRaticateGfx3:
+.incbin "baserom.gba", 0x5E39BC, 0x100
+sRaticateSprites3:
+ax_sprite sRaticateGfx3, 0x100
+ax_sprite_terminator
+sRaticateGfx4:
+.incbin "baserom.gba", 0x5E3ACC, 0x200
+sRaticateSprites4:
+ax_sprite sRaticateGfx4, 0x200
+ax_sprite_terminator
+sRaticateGfx5:
+.incbin "baserom.gba", 0x5E3CDC, 0x200
+sRaticateSprites5:
+ax_sprite sRaticateGfx5, 0x200
+ax_sprite_terminator
+sRaticateGfx6:
+.incbin "baserom.gba", 0x5E3EEC, 0x200
+sRaticateSprites6:
+ax_sprite sRaticateGfx6, 0x200
+ax_sprite_terminator
+sRaticateGfx7:
+.incbin "baserom.gba", 0x5E40FC, 0x200
+sRaticateSprites7:
+ax_sprite sRaticateGfx7, 0x200
+ax_sprite_terminator
+sRaticateGfx8:
+.incbin "baserom.gba", 0x5E430C, 0x200
+sRaticateSprites8:
+ax_sprite sRaticateGfx8, 0x200
+ax_sprite_terminator
+sRaticateGfx9:
+.incbin "baserom.gba", 0x5E451C, 0x200
+sRaticateSprites9:
+ax_sprite sRaticateGfx9, 0x200
+ax_sprite_terminator
+sRaticateGfx10:
+.incbin "baserom.gba", 0x5E472C, 0x200
+sRaticateSprites10:
+ax_sprite sRaticateGfx10, 0x200
+ax_sprite_terminator
+sRaticateGfx11:
+.incbin "baserom.gba", 0x5E493C, 0x200
+sRaticateSprites11:
+ax_sprite sRaticateGfx11, 0x200
+ax_sprite_terminator
+sRaticateGfx12:
+.incbin "baserom.gba", 0x5E4B4C, 0x200
+sRaticateSprites12:
+ax_sprite sRaticateGfx12, 0x200
+ax_sprite_terminator
+sRaticateGfx13:
+.incbin "baserom.gba", 0x5E4D5C, 0x200
+sRaticateSprites13:
+ax_sprite sRaticateGfx13, 0x200
+ax_sprite_terminator
+sRaticateGfx14:
+.incbin "baserom.gba", 0x5E4F6C, 0x200
+sRaticateSprites14:
+ax_sprite sRaticateGfx14, 0x200
+ax_sprite_terminator
+sRaticateGfx15:
+.incbin "baserom.gba", 0x5E517C, 0x200
+sRaticateSprites15:
+ax_sprite sRaticateGfx15, 0x200
+ax_sprite_terminator
+sRaticateGfx16:
+.incbin "baserom.gba", 0x5E538C, 0x40
+sRaticateGfx16_1:
+.incbin "baserom.gba", 0x5E53CC, 0x80
+sRaticateGfx16_2:
+.incbin "baserom.gba", 0x5E544C, 0x40
+sRaticateGfx16_3:
+.incbin "baserom.gba", 0x5E548C, 0x40
+sRaticateSprites16:
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx16_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx17:
+.incbin "baserom.gba", 0x5E551C, 0x40
+sRaticateGfx17_1:
+.incbin "baserom.gba", 0x5E555C, 0x40
+sRaticateGfx17_2:
+.incbin "baserom.gba", 0x5E559C, 0x80
+sRaticateGfx17_3:
+.incbin "baserom.gba", 0x5E561C, 0x40
+sRaticateSprites17:
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx17_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx18:
+.incbin "baserom.gba", 0x5E56AC, 0x40
+sRaticateGfx18_1:
+.incbin "baserom.gba", 0x5E56EC, 0x100
+sRaticateGfx18_2:
+.incbin "baserom.gba", 0x5E57EC, 0x40
+sRaticateSprites18:
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx19:
+.incbin "baserom.gba", 0x5E586C, 0xE0
+sRaticateGfx19_1:
+.incbin "baserom.gba", 0x5E594C, 0x40
+sRaticateSprites19:
+ax_sprite 0, 0x80
+ax_sprite sRaticateGfx19, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx20:
+.incbin "baserom.gba", 0x5E59BC, 0x40
+sRaticateGfx20_1:
+.incbin "baserom.gba", 0x5E59FC, 0xE0
+sRaticateGfx20_2:
+.incbin "baserom.gba", 0x5E5ADC, 0x40
+sRaticateSprites20:
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx20_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx21:
+.incbin "baserom.gba", 0x5E5B5C, 0x160
+sRaticateSprites21:
+ax_sprite 0, 0x80
+ax_sprite sRaticateGfx21, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx22:
+.incbin "baserom.gba", 0x5E5CDC, 0x40
+sRaticateGfx22_1:
+.incbin "baserom.gba", 0x5E5D1C, 0x60
+sRaticateGfx22_2:
+.incbin "baserom.gba", 0x5E5D7C, 0x60
+sRaticateGfx22_3:
+.incbin "baserom.gba", 0x5E5DDC, 0x60
+sRaticateSprites22:
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx22_3, 0x60
+ax_sprite_terminator
+sRaticateGfx23:
+.incbin "baserom.gba", 0x5E5E84, 0x100
+sRaticateGfx23_1:
+.incbin "baserom.gba", 0x5E5F84, 0x40
+sRaticateSprites23:
+ax_sprite 0, 0x80
+ax_sprite sRaticateGfx23, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx24:
+.incbin "baserom.gba", 0x5E5FF4, 0x40
+sRaticateGfx24_1:
+.incbin "baserom.gba", 0x5E6034, 0x80
+sRaticateGfx24_2:
+.incbin "baserom.gba", 0x5E60B4, 0x40
+sRaticateGfx24_3:
+.incbin "baserom.gba", 0x5E60F4, 0x40
+sRaticateSprites24:
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx25:
+.incbin "baserom.gba", 0x5E6184, 0x100
+sRaticateGfx25_1:
+.incbin "baserom.gba", 0x5E6284, 0x40
+sRaticateSprites25:
+ax_sprite 0, 0x80
+ax_sprite sRaticateGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx26:
+.incbin "baserom.gba", 0x5E62F4, 0x60
+sRaticateGfx26_1:
+.incbin "baserom.gba", 0x5E6354, 0x80
+sRaticateGfx26_2:
+.incbin "baserom.gba", 0x5E63D4, 0x40
+sRaticateSprites26:
+ax_sprite 0, 0x80
+ax_sprite sRaticateGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx26_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx27:
+.incbin "baserom.gba", 0x5E6454, 0xE0
+sRaticateGfx27_1:
+.incbin "baserom.gba", 0x5E6534, 0x40
+sRaticateSprites27:
+ax_sprite 0, 0xa0
+ax_sprite sRaticateGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx28:
+.incbin "baserom.gba", 0x5E65A4, 0x100
+sRaticateGfx28_1:
+.incbin "baserom.gba", 0x5E66A4, 0x40
+sRaticateSprites28:
+ax_sprite 0, 0x80
+ax_sprite sRaticateGfx28, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx29:
+.incbin "baserom.gba", 0x5E6714, 0x40
+sRaticateGfx29_1:
+.incbin "baserom.gba", 0x5E6754, 0x80
+sRaticateGfx29_2:
+.incbin "baserom.gba", 0x5E67D4, 0x40
+sRaticateSprites29:
+ax_sprite 0, 0xa0
+ax_sprite sRaticateGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx29_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx30:
+.incbin "baserom.gba", 0x5E6854, 0xE0
+sRaticateGfx30_1:
+.incbin "baserom.gba", 0x5E6934, 0x40
+sRaticateSprites30:
+ax_sprite 0, 0xa0
+ax_sprite sRaticateGfx30, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx31:
+.incbin "baserom.gba", 0x5E69A4, 0x100
+sRaticateGfx31_1:
+.incbin "baserom.gba", 0x5E6AA4, 0x40
+sRaticateSprites31:
+ax_sprite 0, 0x80
+ax_sprite sRaticateGfx31, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx32:
+.incbin "baserom.gba", 0x5E6B14, 0x60
+sRaticateGfx32_1:
+.incbin "baserom.gba", 0x5E6B74, 0x60
+sRaticateGfx32_2:
+.incbin "baserom.gba", 0x5E6BD4, 0x40
+sRaticateSprites32:
+ax_sprite 0, 0xa0
+ax_sprite sRaticateGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx33:
+.incbin "baserom.gba", 0x5E6C54, 0x40
+sRaticateGfx33_1:
+.incbin "baserom.gba", 0x5E6C94, 0x40
+sRaticateGfx33_2:
+.incbin "baserom.gba", 0x5E6CD4, 0x40
+sRaticateSprites33:
+ax_sprite 0, 0xa0
+ax_sprite sRaticateGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx33_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx34:
+.incbin "baserom.gba", 0x5E6D54, 0x40
+sRaticateGfx34_1:
+.incbin "baserom.gba", 0x5E6D94, 0x60
+sRaticateGfx34_2:
+.incbin "baserom.gba", 0x5E6DF4, 0x40
+sRaticateSprites34:
+ax_sprite 0, 0xa0
+ax_sprite sRaticateGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx35:
+.incbin "baserom.gba", 0x5E6E74, 0x40
+sRaticateGfx35_1:
+.incbin "baserom.gba", 0x5E6EB4, 0x60
+sRaticateGfx35_2:
+.incbin "baserom.gba", 0x5E6F14, 0x40
+sRaticateSprites35:
+ax_sprite 0, 0xa0
+ax_sprite sRaticateGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRaticateGfx35_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRaticateGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRaticateGfx36:
+.incbin "baserom.gba", 0x5E6F94, 0x200
+sRaticateSprites36:
+ax_sprite sRaticateGfx36, 0x200
+ax_sprite_terminator
+sRaticateGfx37:
+.incbin "baserom.gba", 0x5E71A4, 0x200
+sRaticateSprites37:
+ax_sprite sRaticateGfx37, 0x200
+ax_sprite_terminator
+sRaticateGfx38:
+.incbin "baserom.gba", 0x5E73B4, 0x200
+sRaticateSprites38:
+ax_sprite sRaticateGfx38, 0x200
+ax_sprite_terminator
+sRaticateGfx39:
+.incbin "baserom.gba", 0x5E75C4, 0x200
+sRaticateSprites39:
+ax_sprite sRaticateGfx39, 0x200
+ax_sprite_terminator
+sRaticateGfx40:
+.incbin "baserom.gba", 0x5E77D4, 0x200
+sRaticateSprites40:
+ax_sprite sRaticateGfx40, 0x200
+ax_sprite_terminator
+sRaticateGfx41:
+.incbin "baserom.gba", 0x5E79E4, 0x200
+sRaticateSprites41:
+ax_sprite sRaticateGfx41, 0x200
+ax_sprite_terminator
+sRaticateGfx42:
+.incbin "baserom.gba", 0x5E7BF4, 0x200
+sRaticateSprites42:
+ax_sprite sRaticateGfx42, 0x200
+ax_sprite_terminator
+sAxPosesRaticate:
+.4byte sRaticatePose1
+.4byte sRaticatePose2
+.4byte sRaticatePose3
+.4byte sRaticatePose4
+.4byte sRaticatePose5
+.4byte sRaticatePose6
+.4byte sRaticatePose7
+.4byte sRaticatePose8
+.4byte sRaticatePose9
+.4byte sRaticatePose10
+.4byte sRaticatePose11
+.4byte sRaticatePose12
+.4byte sRaticatePose13
+.4byte sRaticatePose14
+.4byte sRaticatePose15
+.4byte sRaticatePose16
+.4byte sRaticatePose17
+.4byte sRaticatePose18
+.4byte sRaticatePose19
+.4byte sRaticatePose20
+.4byte sRaticatePose21
+.4byte sRaticatePose22
+.4byte sRaticatePose23
+.4byte sRaticatePose24
+.4byte sRaticatePose25
+.4byte sRaticatePose26
+.4byte sRaticatePose27
+.4byte sRaticatePose28
+.4byte sRaticatePose29
+.4byte sRaticatePose30
+.4byte sRaticatePose31
+.4byte sRaticatePose32
+.4byte sRaticatePose33
+.4byte sRaticatePose34
+.4byte sRaticatePose35
+.4byte sRaticatePose36
+.4byte sRaticatePose37
+.4byte sRaticatePose38
+.4byte sRaticatePose39
+.4byte sRaticatePose40
+.4byte sRaticatePose41
+.4byte sRaticatePose42
+.4byte sRaticatePose43
+.4byte sRaticatePose44
+.4byte sRaticatePose45
+.4byte sRaticatePose46
+.4byte sRaticatePose47
+.4byte sRaticatePose48
+.4byte sRaticatePose49
+.4byte sRaticatePose50
+.4byte sRaticatePose51
+.4byte sRaticatePose52
+.4byte sRaticatePose53
+.4byte sRaticatePose54
+.4byte sRaticatePose55
+.4byte sRaticatePose56
+.4byte sRaticatePose57
+.4byte sRaticatePose58
+.4byte sRaticatePose59
+.4byte sRaticatePose60
+.4byte sRaticatePose61
+.4byte sRaticatePose62
+.4byte sRaticatePose63
+.4byte sRaticatePose64
+.4byte sRaticatePose65
+.4byte sRaticatePose66
+.4byte sRaticatePose67
+.4byte sRaticatePose68
+.4byte sRaticatePose69
+.4byte sRaticatePose70
+.4byte sRaticatePose71
+.4byte sRaticatePose72
+.4byte sRaticatePose73
+.4byte sRaticatePose74
+.4byte sRaticatePose75
+.4byte sRaticatePose76
+.4byte sRaticatePose77
+.4byte sRaticatePose78
+.4byte sRaticatePose79
+.4byte sRaticatePose80
+.4byte sRaticatePose81
+.4byte sRaticatePose82
+.4byte sRaticatePose83
+.4byte sRaticatePose84
+.4byte sRaticatePose85
+.4byte sRaticatePose86
+.4byte sRaticatePose87
+.4byte sRaticatePose88
+.4byte sRaticatePose89
+.4byte sRaticatePose90
+.4byte sRaticatePose91
+.4byte sRaticatePose92
+.4byte sRaticatePose93
+.4byte sRaticatePose94
+.4byte sRaticatePose95
+.4byte sRaticatePose96
+.4byte sRaticatePose97
+.4byte sRaticatePose98
+.4byte sRaticatePose99
+.4byte sRaticatePose100
+.4byte sRaticatePose101
+.4byte sRaticatePose102
+.4byte sRaticatePose103
+.4byte sRaticatePose104
+.4byte sRaticatePose105
+.4byte sRaticatePose106
+.4byte sRaticatePose107
+.4byte sRaticatePose108
+.4byte sRaticatePose109
+.4byte sRaticatePose110
+.4byte sRaticatePose111
+.4byte sRaticatePose112
+.4byte sRaticatePose113
+.4byte sRaticatePose114
+.4byte sRaticatePose115
+.4byte sRaticatePose116
+.4byte sRaticatePose117
+.4byte sRaticatePose118
+.4byte sRaticatePose119
+.4byte sRaticatePose120
+.4byte sRaticatePose121
+.4byte sRaticatePose122
+.4byte sRaticatePose123
+.4byte sRaticatePose124
+.4byte sRaticatePose125
+.4byte sRaticatePose126
+.4byte sRaticatePose127
+.4byte sRaticatePose128
+.4byte sRaticatePose129
+.4byte sRaticatePose130
+.4byte sRaticatePose131
+.4byte sRaticatePose132
+.4byte sRaticatePose133
+.4byte sRaticatePose134
+.4byte sRaticatePose135
+.4byte sRaticatePose136
+.4byte sRaticatePose137
+.4byte sRaticatePose138
+.4byte sRaticatePose139
+.4byte sRaticatePose140
+.4byte sRaticatePose141
+.4byte sRaticatePose142
+.4byte sRaticatePose143
+.4byte sRaticatePose144
+.4byte sRaticatePose145
+.4byte sRaticatePose146
+.4byte sRaticatePose147
+.4byte sRaticatePose148
+.4byte sRaticatePose149
+.4byte sRaticatePose150
+.4byte sRaticatePose151
+.4byte sRaticatePose152
+.4byte sRaticatePose153
+.4byte sRaticatePose154
+.4byte sRaticatePose155
+.4byte sRaticatePose156
+.4byte sRaticatePose157
+.4byte sRaticatePose158
+.4byte sRaticatePose159
+.4byte sRaticatePose160
+.4byte sRaticatePose161
+.4byte sRaticatePose162
+.4byte sRaticatePose163
+.4byte sRaticatePose164
+.4byte sRaticatePose165
+.4byte sRaticatePose166
+.4byte sRaticatePose167
+.4byte sRaticatePose168
+.4byte sRaticatePose169
+.4byte sRaticatePose170
+.4byte sRaticatePose171
+.4byte sRaticatePose172
+.4byte sRaticatePose173
+.4byte sRaticatePose174
+.4byte sRaticatePose175
+.4byte sRaticatePose176
+.4byte sRaticatePose177
+.4byte sRaticatePose178
+.4byte sRaticatePose179
+.4byte sRaticatePose180
+.4byte sRaticatePose181
+.4byte sRaticatePose182
+.4byte sRaticatePose183
+.4byte sRaticatePose184
+.4byte sRaticatePose185
+.4byte sRaticatePose186
+.4byte sRaticatePose187
+.4byte sRaticatePose188
+.4byte sRaticatePose189
+.4byte sRaticatePose190
+.4byte sRaticatePose191
+.4byte sRaticatePose192
+.4byte sRaticatePose193
+.4byte sRaticatePose194
+.4byte sRaticatePose195
+.4byte sRaticatePose196
+.4byte sRaticatePose197
+.4byte sRaticatePose198
+.4byte sRaticatePose199
+.4byte sRaticatePose200
+.4byte sRaticatePose201
+.4byte sRaticatePose202
+.4byte sRaticatePose203
+.4byte sRaticatePose204
+.4byte sRaticatePose205
+.4byte sRaticatePose206
+.4byte sRaticatePose207
+.4byte sRaticatePose208
+.4byte sRaticatePose209
+.4byte sRaticatePose210
+.4byte sRaticatePose211
+.4byte sRaticatePose212
+.4byte sRaticatePose213
+.4byte sRaticatePose214
+.4byte sRaticatePose215
+.4byte sRaticatePose216
+.4byte sRaticatePose217
+.4byte sRaticatePose218
+sAxPositionsRaticate:
+.2byte    0,   -6, 	  -6,   -4, 	   5,   -4, 	   0,   -7
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -4, 	   0,   -6
+.2byte   -1,  -10, 	  -6,   -6, 	   5,   -6, 	   0,  -10
+.2byte    5,   -7, 	   7,   -6, 	  -1,   -3, 	   0,   -7
+.2byte    4,   -4, 	   7,   -5, 	  -1,   -3, 	  -2,   -7
+.2byte    5,  -13, 	   5,   -9, 	  -2,   -8, 	  -1,  -12
+.2byte    7,   -8, 	   6,   -5, 	   5,   -3, 	   0,   -8
+.2byte    6,   -5, 	   5,   -4, 	   4,   -3, 	  -1,   -7
+.2byte    5,  -13, 	   3,   -8, 	   2,   -6, 	  -1,  -11
+.2byte    6,   -9, 	   0,   -8, 	   6,   -6, 	  -1,   -8
+.2byte    5,   -7, 	  -1,   -7, 	   4,   -6, 	  -2,   -7
+.2byte    5,  -15, 	  -2,  -11, 	   4,   -8, 	  -2,  -13
+.2byte    0,  -11, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,   -8, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte    0,  -15, 	   4,  -12, 	  -5,  -12, 	   0,  -11
+.2byte   -7,   -9, 	  -1,   -8, 	  -7,   -6, 	   0,   -8
+.2byte   -6,   -7, 	   0,   -7, 	  -5,   -6, 	   1,   -7
+.2byte   -6,  -15, 	   1,  -11, 	  -5,   -8, 	   1,  -13
+.2byte   -8,   -8, 	  -7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,   -5, 	  -6,   -4, 	  -5,   -3, 	   0,   -7
+.2byte   -6,  -13, 	  -4,   -8, 	  -3,   -6, 	   0,  -11
+.2byte   -6,   -7, 	  -8,   -6, 	   0,   -3, 	  -1,   -7
+.2byte   -5,   -4, 	  -8,   -5, 	   0,   -3, 	   1,   -7
+.2byte   -6,  -13, 	  -6,   -9, 	   1,   -8, 	   0,  -12
+.2byte    0,   -6, 	  -6,   -4, 	   5,   -4, 	   0,   -7
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -4, 	   0,   -6
+.2byte   -1,  -10, 	  -6,   -6, 	   5,   -6, 	   0,  -10
+.2byte    5,   -7, 	   7,   -6, 	  -1,   -3, 	   0,   -7
+.2byte    4,   -4, 	   7,   -5, 	  -1,   -3, 	  -2,   -7
+.2byte    5,  -13, 	   5,   -9, 	  -2,   -8, 	  -1,  -12
+.2byte    7,   -8, 	   6,   -5, 	   5,   -3, 	   0,   -8
+.2byte    6,   -5, 	   5,   -4, 	   4,   -3, 	  -1,   -7
+.2byte    5,  -13, 	   3,   -8, 	   2,   -6, 	  -1,  -11
+.2byte    6,   -9, 	   0,   -8, 	   6,   -6, 	  -1,   -8
+.2byte    5,   -7, 	  -1,   -7, 	   4,   -6, 	  -2,   -7
+.2byte    5,  -15, 	  -2,  -11, 	   4,   -8, 	  -2,  -13
+.2byte    0,  -11, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,   -8, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte    0,  -15, 	   4,  -12, 	  -5,  -12, 	   0,  -11
+.2byte   -7,   -9, 	  -1,   -8, 	  -7,   -6, 	   0,   -8
+.2byte   -6,   -7, 	   0,   -7, 	  -5,   -6, 	   1,   -7
+.2byte   -6,  -15, 	   1,  -11, 	  -5,   -8, 	   1,  -13
+.2byte   -8,   -8, 	  -7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,   -5, 	  -6,   -4, 	  -5,   -3, 	   0,   -7
+.2byte   -6,  -13, 	  -4,   -8, 	  -3,   -6, 	   0,  -11
+.2byte   -6,   -7, 	  -8,   -6, 	   0,   -3, 	  -1,   -7
+.2byte   -5,   -4, 	  -8,   -5, 	   0,   -3, 	   1,   -7
+.2byte   -6,  -13, 	  -6,   -9, 	   1,   -8, 	   0,  -12
+.2byte    0,   -6, 	  -6,   -4, 	   5,   -4, 	   0,   -7
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -4, 	   0,   -6
+.2byte   -1,  -10, 	  -6,   -6, 	   5,   -6, 	   0,  -10
+.2byte    5,   -7, 	   7,   -6, 	  -1,   -3, 	   0,   -7
+.2byte    4,   -4, 	   7,   -5, 	  -1,   -3, 	  -2,   -7
+.2byte    5,  -13, 	   5,   -9, 	  -2,   -8, 	  -1,  -12
+.2byte    7,   -8, 	   6,   -5, 	   5,   -3, 	   0,   -8
+.2byte    6,   -5, 	   5,   -4, 	   4,   -3, 	  -1,   -7
+.2byte    5,  -13, 	   3,   -8, 	   2,   -6, 	  -1,  -11
+.2byte    6,   -9, 	   0,   -8, 	   6,   -6, 	  -1,   -8
+.2byte    5,   -7, 	  -1,   -7, 	   4,   -6, 	  -2,   -7
+.2byte    5,  -15, 	  -2,  -11, 	   4,   -8, 	  -2,  -13
+.2byte    0,  -11, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,   -8, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte    0,  -15, 	   4,  -12, 	  -5,  -12, 	   0,  -11
+.2byte   -7,   -9, 	  -1,   -8, 	  -7,   -6, 	   0,   -8
+.2byte   -6,   -7, 	   0,   -7, 	  -5,   -6, 	   1,   -7
+.2byte   -6,  -15, 	   1,  -11, 	  -5,   -8, 	   1,  -13
+.2byte   -8,   -8, 	  -7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,   -5, 	  -6,   -4, 	  -5,   -3, 	   0,   -7
+.2byte   -6,  -13, 	  -4,   -8, 	  -3,   -6, 	   0,  -11
+.2byte   -6,   -7, 	  -8,   -6, 	   0,   -3, 	  -1,   -7
+.2byte   -5,   -4, 	  -8,   -5, 	   0,   -3, 	   1,   -7
+.2byte   -6,  -13, 	  -6,   -9, 	   1,   -8, 	   0,  -12
+.2byte    0,   -6, 	  -6,   -4, 	   5,   -4, 	   0,   -7
+.2byte    0,  -12, 	  -6,   -7, 	   5,   -7, 	   0,   -8
+.2byte    0,   -3, 	  -7,   -5, 	   6,   -5, 	   0,   -9
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -4, 	   0,   -6
+.2byte    5,   -7, 	   7,   -6, 	  -1,   -3, 	   0,   -7
+.2byte    5,  -13, 	   7,  -10, 	  -1,   -6, 	  -1,   -9
+.2byte    7,   -4, 	   9,   -4, 	   1,   -1, 	   0,   -8
+.2byte    5,   -4, 	   8,   -5, 	   0,   -3, 	  -1,   -7
+.2byte    7,   -8, 	   6,   -5, 	   5,   -3, 	   0,   -8
+.2byte    4,  -18, 	   6,  -10, 	   7,   -9, 	  -1,   -9
+.2byte    9,   -6, 	   8,   -4, 	   7,   -3, 	   1,   -8
+.2byte    6,   -5, 	   5,   -4, 	   4,   -3, 	  -1,   -7
+.2byte    6,   -9, 	   0,   -8, 	   6,   -6, 	  -1,   -8
+.2byte    5,  -16, 	  -1,  -11, 	   5,   -9, 	  -2,   -9
+.2byte    9,   -9, 	   1,   -7, 	   8,   -5, 	   0,   -9
+.2byte    5,   -7, 	  -1,   -7, 	   4,   -6, 	  -2,   -7
+.2byte    0,  -11, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,  -15, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte    0,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -8
+.2byte    0,   -8, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte   -7,   -9, 	  -1,   -8, 	  -7,   -6, 	   0,   -8
+.2byte   -6,  -16, 	   0,  -11, 	  -6,   -9, 	   1,   -9
+.2byte  -10,   -9, 	  -2,   -7, 	  -9,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	   0,   -7, 	  -5,   -6, 	   1,   -7
+.2byte   -8,   -8, 	  -7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte   -5,  -18, 	  -7,  -10, 	  -8,   -9, 	   0,   -9
+.2byte  -10,   -6, 	  -9,   -4, 	  -8,   -3, 	  -2,   -8
+.2byte   -7,   -5, 	  -6,   -4, 	  -5,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -6, 	   0,   -3, 	  -1,   -7
+.2byte   -6,  -13, 	  -8,  -10, 	   0,   -6, 	   0,   -9
+.2byte   -8,   -4, 	 -10,   -4, 	  -2,   -1, 	  -1,   -8
+.2byte   -6,   -4, 	  -9,   -5, 	  -1,   -3, 	   0,   -7
+.2byte    1,   -3, 	  -6,   -3, 	   6,   -5, 	   0,   -8
+.2byte   -1,   -3, 	  -7,   -5, 	   5,   -3, 	  -1,   -8
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -4, 	   0,   -6
+.2byte    4,   -4, 	   8,   -4, 	  -2,   -3, 	  -1,   -7
+.2byte    5,   -4, 	   8,   -5, 	   1,   -3, 	  -1,   -7
+.2byte    5,   -4, 	   8,   -5, 	   0,   -3, 	  -1,   -7
+.2byte    7,   -3, 	   4,   -4, 	   3,   -3, 	  -2,   -6
+.2byte    7,   -5, 	   4,   -5, 	   5,   -3, 	  -1,   -6
+.2byte    6,   -4, 	   5,   -3, 	   4,   -2, 	  -1,   -6
+.2byte    6,   -7, 	   4,   -6, 	   4,   -5, 	  -2,   -6
+.2byte    5,   -8, 	  -1,   -8, 	   5,   -6, 	  -2,   -6
+.2byte    6,   -7, 	   0,   -7, 	   5,   -6, 	  -1,   -7
+.2byte   -2,   -9, 	   7,   -7, 	  -6,   -5, 	   1,   -7
+.2byte    2,   -9, 	   5,   -5, 	  -6,   -6, 	  -1,   -7
+.2byte    0,   -8, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte   -7,   -7, 	  -5,   -6, 	  -5,   -5, 	   1,   -6
+.2byte   -6,   -8, 	   0,   -8, 	  -6,   -6, 	   1,   -6
+.2byte   -7,   -7, 	  -1,   -7, 	  -6,   -6, 	   0,   -7
+.2byte   -8,   -3, 	  -5,   -4, 	  -4,   -3, 	   1,   -6
+.2byte   -8,   -5, 	  -5,   -5, 	  -6,   -3, 	   0,   -6
+.2byte   -7,   -4, 	  -6,   -3, 	  -5,   -2, 	   0,   -6
+.2byte   -5,   -4, 	  -9,   -4, 	   1,   -3, 	   0,   -7
+.2byte   -6,   -4, 	  -9,   -5, 	  -2,   -3, 	   0,   -7
+.2byte   -6,   -4, 	  -9,   -5, 	  -1,   -3, 	   0,   -7
+.2byte   -5,    0, 	  -4,    0, 	   0,    1, 	   1,   -4
+.2byte   -5,    0, 	  -4,    0, 	   0,    1, 	   1,   -4
+.2byte    0,   -5, 	  -6,   -8, 	   5,   -8, 	   0,   -6
+.2byte    4,   -4, 	   7,   -8, 	  -1,   -7, 	  -2,   -6
+.2byte    4,   -6, 	   4,   -5, 	   3,   -4, 	  -3,   -6
+.2byte    6,   -7, 	  -1,   -8, 	   4,   -5, 	  -2,   -7
+.2byte    0,   -8, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -7,   -7, 	   0,   -8, 	  -5,   -5, 	   1,   -7
+.2byte   -6,   -6, 	  -6,   -5, 	  -5,   -4, 	   1,   -6
+.2byte   -5,   -4, 	  -8,   -8, 	   0,   -7, 	   1,   -6
+.2byte    0,   -6, 	  -6,   -4, 	   5,   -4, 	   0,   -7
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -4, 	   0,   -6
+.2byte   -1,  -10, 	  -6,   -6, 	   5,   -6, 	   0,  -10
+.2byte    5,   -7, 	   7,   -6, 	  -1,   -3, 	   0,   -7
+.2byte    5,   -4, 	   8,   -5, 	   0,   -3, 	  -1,   -7
+.2byte    5,  -13, 	   5,   -9, 	  -2,   -8, 	  -1,  -12
+.2byte    7,   -8, 	   6,   -5, 	   5,   -3, 	   0,   -8
+.2byte    6,   -4, 	   5,   -3, 	   4,   -2, 	  -1,   -6
+.2byte    6,  -13, 	   4,   -8, 	   3,   -6, 	   0,  -11
+.2byte    6,   -9, 	   0,   -8, 	   6,   -6, 	  -1,   -8
+.2byte    6,   -7, 	   0,   -7, 	   5,   -6, 	  -1,   -7
+.2byte    6,  -15, 	  -1,  -11, 	   5,   -8, 	  -1,  -13
+.2byte    0,  -11, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,   -8, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte    0,  -15, 	   4,  -12, 	  -5,  -12, 	   0,  -11
+.2byte   -7,   -9, 	  -1,   -8, 	  -7,   -6, 	   0,   -8
+.2byte   -7,   -7, 	  -1,   -7, 	  -6,   -6, 	   0,   -7
+.2byte   -7,  -15, 	   0,  -11, 	  -6,   -8, 	   0,  -13
+.2byte   -8,   -8, 	  -7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,   -4, 	  -6,   -3, 	  -5,   -2, 	   0,   -6
+.2byte   -7,  -13, 	  -5,   -8, 	  -4,   -6, 	  -1,  -11
+.2byte   -6,   -7, 	  -8,   -6, 	   0,   -3, 	  -1,   -7
+.2byte   -6,   -4, 	  -9,   -5, 	  -1,   -3, 	   0,   -7
+.2byte   -6,  -13, 	  -6,   -9, 	   1,   -8, 	   0,  -12
+.2byte    0,   -2, 	  -7,   -4, 	   6,   -4, 	   0,   -8
+.2byte   -6,   -4, 	  -8,   -4, 	   0,   -1, 	   1,   -8
+.2byte   -8,   -6, 	  -7,   -4, 	  -6,   -3, 	   0,   -8
+.2byte   -8,   -8, 	   0,   -6, 	  -7,   -4, 	   1,   -8
+.2byte    0,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -8
+.2byte    7,   -8, 	  -1,   -6, 	   6,   -4, 	  -2,   -8
+.2byte    7,   -6, 	   6,   -4, 	   5,   -3, 	  -1,   -8
+.2byte    5,   -4, 	   7,   -4, 	  -1,   -1, 	  -2,   -8
+.2byte    0,  -12, 	  -6,   -7, 	   5,   -7, 	   0,   -8
+.2byte    5,  -13, 	   7,  -10, 	  -1,   -6, 	  -1,   -9
+.2byte    4,  -18, 	   6,  -10, 	   7,   -9, 	  -1,   -9
+.2byte    5,  -16, 	  -1,  -11, 	   5,   -9, 	  -2,   -9
+.2byte    0,  -15, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte   -7,  -16, 	  -1,  -11, 	  -7,   -9, 	   0,   -9
+.2byte   -5,  -18, 	  -7,  -10, 	  -8,   -9, 	   0,   -9
+.2byte   -6,  -13, 	  -8,  -10, 	   0,   -6, 	   0,   -9
+.2byte    0,   -6, 	  -6,   -4, 	   5,   -4, 	   0,   -7
+.2byte   -1,  -10, 	  -6,   -6, 	   5,   -6, 	   0,  -10
+.2byte    0,   -4, 	  -6,   -4, 	   5,   -4, 	   0,   -6
+.2byte    5,   -7, 	   7,   -6, 	  -1,   -3, 	   0,   -7
+.2byte    5,  -13, 	   5,   -9, 	  -2,   -8, 	  -1,  -12
+.2byte    4,   -4, 	   7,   -5, 	  -1,   -3, 	  -2,   -7
+.2byte    7,   -8, 	   6,   -5, 	   5,   -3, 	   0,   -8
+.2byte    5,  -13, 	   3,   -8, 	   2,   -6, 	  -1,  -11
+.2byte    6,   -5, 	   5,   -4, 	   4,   -3, 	  -1,   -7
+.2byte    6,   -9, 	   0,   -8, 	   6,   -6, 	  -1,   -8
+.2byte    5,  -15, 	  -2,  -11, 	   4,   -8, 	  -2,  -13
+.2byte    5,   -7, 	  -1,   -7, 	   4,   -6, 	  -2,   -7
+.2byte    0,  -11, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    0,  -15, 	   4,  -12, 	  -5,  -12, 	   0,  -11
+.2byte    0,   -8, 	   6,   -6, 	  -7,   -6, 	   0,   -7
+.2byte   -7,   -9, 	  -1,   -8, 	  -7,   -6, 	   0,   -8
+.2byte   -6,  -15, 	   1,  -11, 	  -5,   -8, 	   1,  -13
+.2byte   -6,   -7, 	   0,   -7, 	  -5,   -6, 	   1,   -7
+.2byte   -8,   -8, 	  -7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte   -6,  -13, 	  -4,   -8, 	  -3,   -6, 	   0,  -11
+.2byte   -7,   -5, 	  -6,   -4, 	  -5,   -3, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -6, 	   0,   -3, 	  -1,   -7
+.2byte   -6,  -13, 	  -6,   -9, 	   1,   -8, 	   0,  -12
+.2byte   -5,   -4, 	  -8,   -5, 	   0,   -3, 	   1,   -7
+.2byte    0,   -2, 	  -7,   -4, 	   6,   -4, 	   0,   -8
+.2byte   -6,   -4, 	  -8,   -4, 	   0,   -1, 	   1,   -8
+.2byte   -8,   -6, 	  -7,   -4, 	  -6,   -3, 	   0,   -8
+.2byte   -8,   -8, 	   0,   -6, 	  -7,   -4, 	   1,   -8
+.2byte    0,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -8
+.2byte    7,   -8, 	  -1,   -6, 	   6,   -4, 	  -2,   -8
+.2byte    7,   -6, 	   6,   -4, 	   5,   -3, 	  -1,   -8
+.2byte    5,   -4, 	   7,   -4, 	  -1,   -1, 	  -2,   -8
+.2byte    0,   -6, 	  -6,   -4, 	   5,   -4, 	   0,   -7
+.2byte   -6,   -7, 	  -8,   -6, 	   0,   -3, 	  -1,   -7
+.2byte   -8,   -8, 	  -7,   -5, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,   -9, 	  -1,   -8, 	  -7,   -6, 	   0,   -8
+.2byte    0,  -11, 	   6,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    6,   -9, 	   0,   -8, 	   6,   -6, 	  -1,   -8
+.2byte    7,   -8, 	   6,   -5, 	   5,   -3, 	   0,   -8
+.2byte    5,   -7, 	   7,   -6, 	  -1,   -3, 	   0,   -7
+sRaticateAnimTable1:
+.4byte sRaticateAnims_1_1
+.4byte sRaticateAnims_1_2
+.4byte sRaticateAnims_1_3
+.4byte sRaticateAnims_1_4
+.4byte sRaticateAnims_1_5
+.4byte sRaticateAnims_1_6
+.4byte sRaticateAnims_1_7
+.4byte sRaticateAnims_1_8
+sRaticateAnimTable2:
+.4byte sRaticateAnims_2_1
+.4byte sRaticateAnims_2_2
+.4byte sRaticateAnims_2_3
+.4byte sRaticateAnims_2_4
+.4byte sRaticateAnims_2_5
+.4byte sRaticateAnims_2_6
+.4byte sRaticateAnims_2_7
+.4byte sRaticateAnims_2_8
+sRaticateAnimTable3:
+.4byte sRaticateAnims_3_1
+.4byte sRaticateAnims_3_2
+.4byte sRaticateAnims_3_3
+.4byte sRaticateAnims_3_4
+.4byte sRaticateAnims_3_5
+.4byte sRaticateAnims_3_6
+.4byte sRaticateAnims_3_7
+.4byte sRaticateAnims_3_8
+sRaticateAnimTable4:
+.4byte sRaticateAnims_4_1
+.4byte sRaticateAnims_4_2
+.4byte sRaticateAnims_4_3
+.4byte sRaticateAnims_4_4
+.4byte sRaticateAnims_4_5
+.4byte sRaticateAnims_4_6
+.4byte sRaticateAnims_4_7
+.4byte sRaticateAnims_4_8
+sRaticateAnimTable5:
+.4byte sRaticateAnims_5_1
+.4byte sRaticateAnims_5_2
+.4byte sRaticateAnims_5_3
+.4byte sRaticateAnims_5_4
+.4byte sRaticateAnims_5_5
+.4byte sRaticateAnims_5_6
+.4byte sRaticateAnims_5_7
+.4byte sRaticateAnims_5_8
+sRaticateAnimTable6:
+.4byte sRaticateAnims_6_1
+.4byte sRaticateAnims_6_1
+.4byte sRaticateAnims_6_1
+.4byte sRaticateAnims_6_1
+.4byte sRaticateAnims_6_1
+.4byte sRaticateAnims_6_1
+.4byte sRaticateAnims_6_1
+.4byte sRaticateAnims_6_1
+sRaticateAnimTable7:
+.4byte sRaticateAnims_7_1
+.4byte sRaticateAnims_7_2
+.4byte sRaticateAnims_7_3
+.4byte sRaticateAnims_7_4
+.4byte sRaticateAnims_7_5
+.4byte sRaticateAnims_7_6
+.4byte sRaticateAnims_7_7
+.4byte sRaticateAnims_7_8
+sRaticateAnimTable8:
+.4byte sRaticateAnims_8_1
+.4byte sRaticateAnims_8_2
+.4byte sRaticateAnims_8_3
+.4byte sRaticateAnims_8_4
+.4byte sRaticateAnims_8_5
+.4byte sRaticateAnims_8_6
+.4byte sRaticateAnims_8_7
+.4byte sRaticateAnims_8_8
+sRaticateAnimTable9:
+.4byte sRaticateAnims_9_1
+.4byte sRaticateAnims_9_2
+.4byte sRaticateAnims_9_3
+.4byte sRaticateAnims_9_4
+.4byte sRaticateAnims_9_5
+.4byte sRaticateAnims_9_6
+.4byte sRaticateAnims_9_7
+.4byte sRaticateAnims_9_8
+sRaticateAnimTable10:
+.4byte sRaticateAnims_10_1
+.4byte sRaticateAnims_10_2
+.4byte sRaticateAnims_10_3
+.4byte sRaticateAnims_10_4
+.4byte sRaticateAnims_10_5
+.4byte sRaticateAnims_10_6
+.4byte sRaticateAnims_10_7
+.4byte sRaticateAnims_10_8
+sRaticateAnimTable11:
+.4byte sRaticateAnims_11_1
+.4byte sRaticateAnims_11_2
+.4byte sRaticateAnims_11_3
+.4byte sRaticateAnims_11_4
+.4byte sRaticateAnims_11_5
+.4byte sRaticateAnims_11_6
+.4byte sRaticateAnims_11_7
+.4byte sRaticateAnims_11_8
+sRaticateAnimTable12:
+.4byte sRaticateAnims_12_1
+.4byte sRaticateAnims_12_2
+.4byte sRaticateAnims_12_3
+.4byte sRaticateAnims_12_4
+.4byte sRaticateAnims_12_5
+.4byte sRaticateAnims_12_6
+.4byte sRaticateAnims_12_7
+.4byte sRaticateAnims_12_8
+sRaticateAnimTable13:
+.4byte sRaticateAnims_13_1
+.4byte sRaticateAnims_13_2
+.4byte sRaticateAnims_13_3
+.4byte sRaticateAnims_13_4
+.4byte sRaticateAnims_13_5
+.4byte sRaticateAnims_13_6
+.4byte sRaticateAnims_13_7
+.4byte sRaticateAnims_13_8
+sAxAnimationsRaticate:
+.4byte sRaticateAnimTable1
+.4byte sRaticateAnimTable2
+.4byte sRaticateAnimTable3
+.4byte sRaticateAnimTable4
+.4byte sRaticateAnimTable5
+.4byte sRaticateAnimTable6
+.4byte sRaticateAnimTable7
+.4byte sRaticateAnimTable8
+.4byte sRaticateAnimTable9
+.4byte sRaticateAnimTable10
+.4byte sRaticateAnimTable11
+.4byte sRaticateAnimTable12
+.4byte sRaticateAnimTable13
+sAxSpritesRaticate:
+.4byte sRaticateSprites1
+.4byte sRaticateSprites2
+.4byte sRaticateSprites3
+.4byte sRaticateSprites4
+.4byte sRaticateSprites5
+.4byte sRaticateSprites6
+.4byte sRaticateSprites7
+.4byte sRaticateSprites8
+.4byte sRaticateSprites9
+.4byte sRaticateSprites10
+.4byte sRaticateSprites11
+.4byte sRaticateSprites12
+.4byte sRaticateSprites13
+.4byte sRaticateSprites14
+.4byte sRaticateSprites15
+.4byte sRaticateSprites16
+.4byte sRaticateSprites17
+.4byte sRaticateSprites18
+.4byte sRaticateSprites19
+.4byte sRaticateSprites20
+.4byte sRaticateSprites21
+.4byte sRaticateSprites22
+.4byte sRaticateSprites23
+.4byte sRaticateSprites24
+.4byte sRaticateSprites25
+.4byte sRaticateSprites26
+.4byte sRaticateSprites27
+.4byte sRaticateSprites28
+.4byte sRaticateSprites29
+.4byte sRaticateSprites30
+.4byte sRaticateSprites31
+.4byte sRaticateSprites32
+.4byte sRaticateSprites33
+.4byte sRaticateSprites34
+.4byte sRaticateSprites35
+.4byte sRaticateSprites36
+.4byte sRaticateSprites37
+.4byte sRaticateSprites38
+.4byte sRaticateSprites39
+.4byte sRaticateSprites40
+.4byte sRaticateSprites41
+.4byte sRaticateSprites42
+sAxMainRaticate:
+ax_main sAxPosesRaticate, sAxAnimationsRaticate, 13, sAxSpritesRaticate, sAxPositionsRaticate

--- a/data/ax/rattata.inc
+++ b/data/ax/rattata.inc
@@ -1,0 +1,2781 @@
+.global gAxRattata
+gAxRattata:
+ax_siro sAxMainRattata
+sRattataPose1:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose2:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose3:
+ax_pose 2, 0x81ec, 0x80f7, 0x2c00
+ax_pose 3, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sRattataPose4:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose5:
+ax_pose 5, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose6:
+ax_pose 6, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose7:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose8:
+ax_pose 8, 0x01ed, 0x90f2, 0x2c00
+ax_pose_terminator
+sRattataPose9:
+ax_pose 9, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose10:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose11:
+ax_pose 11, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose12:
+ax_pose 12, 0x01ee, 0x90e9, 0x2c00
+ax_pose_terminator
+sRattataPose13:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose14:
+ax_pose 14, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose15:
+ax_pose 15, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose16:
+ax_pose 10, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose17:
+ax_pose 11, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose18:
+ax_pose 12, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose19:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose20:
+ax_pose 8, 0x01ed, 0x80ee, 0x2c00
+ax_pose_terminator
+sRattataPose21:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose22:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose23:
+ax_pose 5, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose24:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose25:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose26:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose27:
+ax_pose 2, 0x81ec, 0x80f7, 0x2c00
+ax_pose 3, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sRattataPose28:
+ax_pose 16, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose29:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose30:
+ax_pose 5, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose31:
+ax_pose 6, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose32:
+ax_pose 17, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose33:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose34:
+ax_pose 8, 0x01ed, 0x90f2, 0x2c00
+ax_pose_terminator
+sRattataPose35:
+ax_pose 9, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose36:
+ax_pose 18, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose37:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose38:
+ax_pose 11, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose39:
+ax_pose 12, 0x01ee, 0x90e9, 0x2c00
+ax_pose_terminator
+sRattataPose40:
+ax_pose 19, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose41:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose42:
+ax_pose 14, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose43:
+ax_pose 15, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose44:
+ax_pose 20, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose45:
+ax_pose 10, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose46:
+ax_pose 11, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose47:
+ax_pose 12, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose48:
+ax_pose 19, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose49:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose50:
+ax_pose 8, 0x01ed, 0x80ee, 0x2c00
+ax_pose_terminator
+sRattataPose51:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose52:
+ax_pose 18, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose53:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose54:
+ax_pose 5, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose55:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose56:
+ax_pose 17, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose57:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose58:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose59:
+ax_pose 2, 0x81ec, 0x80f7, 0x2c00
+ax_pose 3, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sRattataPose60:
+ax_pose 16, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose61:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose62:
+ax_pose 5, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose63:
+ax_pose 6, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose64:
+ax_pose 17, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose65:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose66:
+ax_pose 8, 0x01ed, 0x90f2, 0x2c00
+ax_pose_terminator
+sRattataPose67:
+ax_pose 9, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose68:
+ax_pose 18, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose69:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose70:
+ax_pose 11, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose71:
+ax_pose 12, 0x01ee, 0x90e9, 0x2c00
+ax_pose_terminator
+sRattataPose72:
+ax_pose 19, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose73:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose74:
+ax_pose 14, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose75:
+ax_pose 15, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose76:
+ax_pose 20, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose77:
+ax_pose 10, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose78:
+ax_pose 11, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose79:
+ax_pose 12, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose80:
+ax_pose 19, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose81:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose82:
+ax_pose 8, 0x01ed, 0x80ee, 0x2c00
+ax_pose_terminator
+sRattataPose83:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose84:
+ax_pose 18, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose85:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose86:
+ax_pose 5, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose87:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose88:
+ax_pose 17, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose89:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose90:
+ax_pose 16, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose91:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose92:
+ax_pose 17, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose93:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose94:
+ax_pose 18, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose95:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose96:
+ax_pose 19, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose97:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose98:
+ax_pose 20, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose99:
+ax_pose 10, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose100:
+ax_pose 19, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose101:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose102:
+ax_pose 18, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose103:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose104:
+ax_pose 17, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose105:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose106:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose107:
+ax_pose 2, 0x81ec, 0x80f7, 0x2c00
+ax_pose 3, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sRattataPose108:
+ax_pose 21, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose109:
+ax_pose 22, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose110:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose111:
+ax_pose 5, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose112:
+ax_pose 6, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose113:
+ax_pose 23, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose114:
+ax_pose 24, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose115:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose116:
+ax_pose 8, 0x01ed, 0x90f2, 0x2c00
+ax_pose_terminator
+sRattataPose117:
+ax_pose 9, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose118:
+ax_pose 25, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose119:
+ax_pose 26, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose120:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose121:
+ax_pose 11, 0x01ee, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose122:
+ax_pose 12, 0x01ee, 0x90e9, 0x2c00
+ax_pose_terminator
+sRattataPose123:
+ax_pose 27, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose124:
+ax_pose 28, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose125:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose126:
+ax_pose 14, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose127:
+ax_pose 15, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose128:
+ax_pose 29, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose129:
+ax_pose 30, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose130:
+ax_pose 10, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose131:
+ax_pose 11, 0x01ee, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose132:
+ax_pose 12, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose133:
+ax_pose 27, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose134:
+ax_pose 28, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose135:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose136:
+ax_pose 8, 0x01ed, 0x80ee, 0x2c00
+ax_pose_terminator
+sRattataPose137:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose138:
+ax_pose 25, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose139:
+ax_pose 26, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose140:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose141:
+ax_pose 5, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose142:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose143:
+ax_pose 23, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose144:
+ax_pose 24, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose145:
+ax_pose 31, 0x01f1, 0x80f5, 0x2c00
+ax_pose_terminator
+sRattataPose146:
+ax_pose 32, 0x01f1, 0x80f5, 0x2c00
+ax_pose_terminator
+sRattataPose147:
+ax_pose 33, 0x01e1, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose148:
+ax_pose 34, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sRattataPose149:
+ax_pose 35, 0x01e3, 0x90e8, 0x2c00
+ax_pose_terminator
+sRattataPose150:
+ax_pose 36, 0x01e6, 0x90e6, 0x2c00
+ax_pose_terminator
+sRattataPose151:
+ax_pose 37, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose152:
+ax_pose 36, 0x01e6, 0x80fa, 0x2c00
+ax_pose_terminator
+sRattataPose153:
+ax_pose 35, 0x01e3, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose154:
+ax_pose 34, 0x01e3, 0x80f5, 0x2c00
+ax_pose_terminator
+sRattataPose155:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose156:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose157:
+ax_pose 2, 0x81ec, 0x80f7, 0x2c00
+ax_pose 3, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sRattataPose158:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose159:
+ax_pose 5, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose160:
+ax_pose 6, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose161:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose162:
+ax_pose 8, 0x01ed, 0x90f2, 0x2c00
+ax_pose_terminator
+sRattataPose163:
+ax_pose 9, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose164:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose165:
+ax_pose 11, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose166:
+ax_pose 12, 0x01ee, 0x90e9, 0x2c00
+ax_pose_terminator
+sRattataPose167:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose168:
+ax_pose 14, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose169:
+ax_pose 15, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose170:
+ax_pose 10, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose171:
+ax_pose 11, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose172:
+ax_pose 12, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose173:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose174:
+ax_pose 8, 0x01ed, 0x80ee, 0x2c00
+ax_pose_terminator
+sRattataPose175:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose176:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose177:
+ax_pose 5, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose178:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose179:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose180:
+ax_pose 4, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose181:
+ax_pose 7, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose182:
+ax_pose 10, 0x01ee, 0x80f5, 0x2c00
+ax_pose_terminator
+sRattataPose183:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose184:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose185:
+ax_pose 7, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose186:
+ax_pose 4, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose187:
+ax_pose 16, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose188:
+ax_pose 17, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose189:
+ax_pose 18, 0x01ed, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose190:
+ax_pose 19, 0x01ee, 0x90eb, 0x2c00
+ax_pose_terminator
+sRattataPose191:
+ax_pose 20, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose192:
+ax_pose 19, 0x01ee, 0x80f5, 0x2c00
+ax_pose_terminator
+sRattataPose193:
+ax_pose 18, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose194:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose195:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose196:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose197:
+ax_pose 2, 0x81ec, 0x80f7, 0x2c00
+ax_pose 3, 0x01f4, 0x0107, 0x2c08
+ax_pose_terminator
+sRattataPose198:
+ax_pose 4, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sRattataPose199:
+ax_pose 5, 0x01ee, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose200:
+ax_pose 6, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose201:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose202:
+ax_pose 8, 0x01ed, 0x90f2, 0x2c00
+ax_pose_terminator
+sRattataPose203:
+ax_pose 9, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose204:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose205:
+ax_pose 11, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose206:
+ax_pose 12, 0x01ee, 0x90e9, 0x2c00
+ax_pose_terminator
+sRattataPose207:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose208:
+ax_pose 14, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose209:
+ax_pose 15, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose210:
+ax_pose 10, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose211:
+ax_pose 11, 0x01ee, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose212:
+ax_pose 12, 0x01ee, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose213:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose214:
+ax_pose 8, 0x01ed, 0x80ee, 0x2c00
+ax_pose_terminator
+sRattataPose215:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose216:
+ax_pose 4, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose217:
+ax_pose 5, 0x01ee, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose218:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose219:
+ax_pose 16, 0x01ec, 0x80f7, 0x2c00
+ax_pose_terminator
+sRattataPose220:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sRattataPose221:
+ax_pose 18, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sRattataPose222:
+ax_pose 19, 0x01ee, 0x80f5, 0x2c00
+ax_pose_terminator
+sRattataPose223:
+ax_pose 20, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose224:
+ax_pose 19, 0x01ee, 0x90eb, 0x2c00
+ax_pose_terminator
+sRattataPose225:
+ax_pose 18, 0x01ed, 0x90ef, 0x2c00
+ax_pose_terminator
+sRattataPose226:
+ax_pose 17, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose227:
+ax_pose 0, 0x81ec, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose228:
+ax_pose 4, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sRattataPose229:
+ax_pose 7, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sRattataPose230:
+ax_pose 10, 0x01ee, 0x80f5, 0x2c00
+ax_pose_terminator
+sRattataPose231:
+ax_pose 13, 0x81ee, 0x80f8, 0x2c00
+ax_pose_terminator
+sRattataPose232:
+ax_pose 10, 0x01ee, 0x90ec, 0x2c00
+ax_pose_terminator
+sRattataPose233:
+ax_pose 7, 0x01ec, 0x90f0, 0x2c00
+ax_pose_terminator
+sRattataPose234:
+ax_pose 4, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sRattataAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 3, 0, 0,
+ax_anim 4, 0, 1, 0, 5, 0, 3,
+ax_anim 4, 0, 2, 0, 5, 0, 5,
+ax_anim 4, 0, 2, 0, 8, 0, 5,
+ax_anim 4, 0, 0, 0, 8, 0, 2,
+ax_anim 4, 0, 0, 0, 4, 0, -1,
+ax_anim_terminator
+sRattataAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 4, -1, 3, 3,
+ax_anim 4, 0, 4, 5, -1, 5, 5,
+ax_anim 4, 0, 5, 8, 0, 6, 6,
+ax_anim 4, 0, 5, 10, 5, 7, 7,
+ax_anim 4, 0, 3, 7, 7, 7, 7,
+ax_anim 4, 0, 3, 3, 3, 3, 3,
+ax_anim_terminator
+sRattataAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 3, -1, 3, 0,
+ax_anim 4, 0, 7, 5, -3, 5, 0,
+ax_anim 4, 0, 8, 7, -3, 7, 0,
+ax_anim 4, 0, 8, 8, -1, 8, 0,
+ax_anim 4, 0, 6, 8, 0, 8, 0,
+ax_anim 4, 0, 6, 4, 0, 4, 0,
+ax_anim_terminator
+sRattataAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 2, -5, 2, -2,
+ax_anim 4, 0, 10, 4, -7, 4, -4,
+ax_anim 4, 0, 11, 5, -8, 5, -5,
+ax_anim 4, 0, 11, 7, -6, 7, -7,
+ax_anim 4, 0, 9, 5, -5, 5, -5,
+ax_anim 4, 0, 9, 3, -3, 3, -3,
+ax_anim_terminator
+sRattataAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -4, 0, -3,
+ax_anim 4, 0, 13, 0, -6, 0, -4,
+ax_anim 4, 0, 14, 0, -7, 0, -5,
+ax_anim 4, 0, 14, 0, -6, 0, -6,
+ax_anim 4, 0, 12, 0, -4, 0, -5,
+ax_anim 4, 0, 12, 0, -2, 0, -3,
+ax_anim_terminator
+sRattataAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -2, -5, -2, -2,
+ax_anim 4, 0, 16, -4, -7, -4, -4,
+ax_anim 4, 0, 17, -5, -8, -5, -5,
+ax_anim 4, 0, 17, -7, -6, -7, -7,
+ax_anim 4, 0, 15, -5, -5, -5, -5,
+ax_anim 4, 0, 15, -3, -3, -3, -3,
+ax_anim_terminator
+sRattataAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -3, -1, -3, 0,
+ax_anim 4, 0, 19, -5, -3, -5, 0,
+ax_anim 4, 0, 20, -7, -3, -7, 0,
+ax_anim 4, 0, 20, -8, -1, -8, 0,
+ax_anim 4, 0, 18, -8, 0, -8, 0,
+ax_anim 4, 0, 18, -4, 0, -4, 0,
+ax_anim_terminator
+sRattataAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -4, -1, -3, 3,
+ax_anim 4, 0, 22, -5, -1, -5, 5,
+ax_anim 4, 0, 23, -8, 0, -6, 6,
+ax_anim 4, 0, 23, -10, 5, -7, 7,
+ax_anim 4, 0, 21, -7, 7, -7, 7,
+ax_anim 4, 0, 21, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sRattataAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 12,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRattataAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 5, 2, 5, 5,
+ax_anim 1, 0, 30, 12, 8, 12, 12,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sRattataAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, -1, 0, 0,
+ax_anim 1, 2, 33, 4, -4, 4, 0,
+ax_anim 1, 0, 34, 13, -4, 13, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sRattataAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -3, 0, -1,
+ax_anim 1, 2, 37, 3, -14, 4, -7,
+ax_anim 1, 0, 38, 11, -20, 11, -16,
+ax_anim 2, 0, 39, 16, -23, 16, -23,
+ax_anim 2, 1, 39, 17, -22, 17, -22,
+ax_anim 2, 0, 39, 16, -23, 16, -23,
+ax_anim 2, 0, 39, 17, -22, 17, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sRattataAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -3,
+ax_anim 1, 0, 42, 0, -13, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sRattataAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -3, -14, -4, -7,
+ax_anim 1, 0, 46, -11, -20, -11, -16,
+ax_anim 2, 0, 47, -16, -23, -16, -23,
+ax_anim 2, 1, 47, -17, -22, -17, -22,
+ax_anim 2, 0, 47, -16, -23, -16, -23,
+ax_anim 2, 0, 47, -17, -22, -17, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sRattataAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, -1, 0, 0,
+ax_anim 1, 2, 49, -4, -4, -4, 0,
+ax_anim 1, 0, 50, -13, -4, -13, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sRattataAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -5, 2, -5, 5,
+ax_anim 1, 0, 54, -12, 8, -12, 12,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 1, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 55, -17, 19, -17, 19,
+ax_anim 2, 0, 52, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRattataAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 12,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 1, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, 1, 17, 1, 17,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sRattataAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 5, 2, 5, 5,
+ax_anim 1, 0, 62, 12, 8, 12, 12,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 1, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 60, 8, 8, 8, 8,
+ax_anim_terminator
+sRattataAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, -1, 0, 0,
+ax_anim 1, 2, 65, 4, -4, 4, 0,
+ax_anim 1, 0, 66, 13, -4, 13, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sRattataAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -3, 0, -1,
+ax_anim 1, 2, 69, 3, -14, 4, -7,
+ax_anim 1, 0, 70, 11, -20, 11, -16,
+ax_anim 2, 0, 71, 16, -23, 16, -23,
+ax_anim 2, 1, 71, 17, -22, 17, -22,
+ax_anim 2, 0, 71, 16, -23, 16, -23,
+ax_anim 2, 0, 71, 17, -22, 17, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sRattataAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -3,
+ax_anim 1, 0, 74, 0, -13, 0, -11,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 1, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sRattataAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -3, -14, -4, -7,
+ax_anim 1, 0, 78, -11, -20, -11, -16,
+ax_anim 2, 0, 79, -16, -23, -16, -23,
+ax_anim 2, 1, 79, -17, -22, -17, -22,
+ax_anim 2, 0, 79, -16, -23, -16, -23,
+ax_anim 2, 0, 79, -17, -22, -17, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sRattataAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, -1, 0, 0,
+ax_anim 1, 2, 81, -4, -4, -4, 0,
+ax_anim 1, 0, 82, -13, -4, -13, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sRattataAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -5, 2, -5, 5,
+ax_anim 1, 0, 86, -12, 8, -12, 12,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 1, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 0, 87, -17, 19, -17, 19,
+ax_anim 2, 0, 84, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRattataAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim 4, 0, 88, 0, -4, 0, -4,
+ax_anim 1, 0, 88, 0, -4, 0, -4,
+ax_anim 2, 2, 89, 0, -2, 0, -2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 1, 2, 1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 1, 89, 1, 2, 1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 1, 2, 1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 1, 2, 1, 2,
+ax_anim_terminator
+sRattataAnims_4_2:
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 0, 90, -3, -3, -3, -3,
+ax_anim 4, 0, 90, -4, -4, -4, -4,
+ax_anim 1, 0, 90, -4, -4, -4, -4,
+ax_anim 2, 2, 91, -2, -2, -2, -2,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 3, 1, 3, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 1, 91, 3, 1, 3, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 3, 1, 3, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 3, 1, 3, 1,
+ax_anim_terminator
+sRattataAnims_4_3:
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 4, 0, 92, -4, 0, -4, 0,
+ax_anim 1, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 2, 93, -2, 0, -2, 0,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 1, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim_terminator
+sRattataAnims_4_4:
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 0, 94, -3, 3, -3, 3,
+ax_anim 4, 0, 94, -4, 4, -4, 4,
+ax_anim 1, 0, 94, -4, 4, -4, 4,
+ax_anim 2, 2, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 1, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim_terminator
+sRattataAnims_4_5:
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 2, 0, 96, 0, 3, 0, 3,
+ax_anim 4, 0, 96, 0, 4, 0, 4,
+ax_anim 1, 0, 96, 0, 4, 0, 4,
+ax_anim 2, 2, 97, 0, 2, 0, 2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, -1, -2, -1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 1, 97, -1, -2, -1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, -1, -2, -1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, -1, -2, -1, -2,
+ax_anim_terminator
+sRattataAnims_4_6:
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 2, 0, 98, 3, 3, 3, 3,
+ax_anim 4, 0, 98, 4, 4, 4, 4,
+ax_anim 1, 0, 98, 4, 4, 4, 4,
+ax_anim 2, 2, 99, 2, 2, 2, 2,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 1, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim_terminator
+sRattataAnims_4_7:
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 3, 0, 3, 0,
+ax_anim 4, 0, 100, 4, 0, 4, 0,
+ax_anim 1, 0, 100, 4, 0, 4, 0,
+ax_anim 2, 2, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 1, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, 1, -2, 1,
+ax_anim_terminator
+sRattataAnims_4_8:
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 2, 0, 102, 3, -3, 3, -3,
+ax_anim 4, 0, 102, 4, -4, 4, -4,
+ax_anim 1, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 2, 103, 2, -2, 2, -2,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 1, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 1, -3, 1,
+ax_anim_terminator
+.align 2
+sRattataAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, -1, 0, 0,
+ax_anim 2, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -1, 0, 0,
+ax_anim 4, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_5_2:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_5_3:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 4, 0, 114, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_5_4:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 4, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 4, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_5_6:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 4, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_5_7:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_5_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRattataAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRattataAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sRattataAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sRattataAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sRattataAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sRattataAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sRattataAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sRattataAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sRattataAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRattataAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 1, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 1, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 1, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 1, 0, 0,
+ax_anim_terminator
+sRattataAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim_terminator
+sRattataAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim_terminator
+sRattataAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, -2, 0, 0,
+ax_anim 2, 0, 164, 1, -3, 0, 0,
+ax_anim 2, 0, 164, 1, -2, 0, 0,
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, -2, 0, 0,
+ax_anim 2, 0, 164, 1, -3, 0, 0,
+ax_anim 2, 0, 164, 1, -2, 0, 0,
+ax_anim_terminator
+sRattataAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 2, 0, 167, 0, -3, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 4, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 2, 0, 167, 0, -3, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim_terminator
+sRattataAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, -1, -2, 0, 0,
+ax_anim 2, 0, 170, -1, -3, 0, 0,
+ax_anim 2, 0, 170, -1, -2, 0, 0,
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, -1, -2, 0, 0,
+ax_anim 2, 0, 170, -1, -3, 0, 0,
+ax_anim 2, 0, 170, -1, -2, 0, 0,
+ax_anim_terminator
+sRattataAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -1, 0, 0,
+ax_anim 2, 0, 173, 0, -2, 0, 0,
+ax_anim 2, 0, 173, 0, -1, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -1, 0, 0,
+ax_anim 2, 0, 173, 0, -2, 0, 0,
+ax_anim 2, 0, 173, 0, -1, 0, 0,
+ax_anim_terminator
+sRattataAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, 0,
+ax_anim 2, 0, 176, 0, -2, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, 0,
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, 0,
+ax_anim 2, 0, 176, 0, -2, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sRattataAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 17, 7, 17,
+ax_anim 3, 0, 182, 0, 21, 0, 21,
+ax_anim 2, 3, 183, -7, 17, -7, 17,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 22, 9, 22, 9,
+ax_anim 3, 0, 181, 20, 21, 20, 21,
+ax_anim 2, 3, 182, 11, 21, 11, 21,
+ax_anim 2, 0, 183, 2, 12, 2, 12,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -4, 17, -4,
+ax_anim 3, 0, 180, 20, 1, 20, 1,
+ax_anim 2, 3, 181, 17, 5, 17, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 11, -22, 11, -22,
+ax_anim 3, 0, 179, 19, -23, 19, -23,
+ax_anim 2, 3, 180, 20, -12, 20, -12,
+ax_anim 2, 0, 181, 16, -6, 16, -6,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -8, -10, -8, -10,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 8, -8, 8, -8,
+ax_anim 1, 0, 181, 6, -4, 6, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -11, -22, -11, -22,
+ax_anim 3, 0, 185, -19, -23, -19, -23,
+ax_anim 2, 3, 184, -20, -12, -20, -12,
+ax_anim 2, 0, 183, -16, -6, -16, -6,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -4, -17, -4,
+ax_anim 3, 0, 184, -20, 1, -20, 1,
+ax_anim 2, 3, 183, -17, 5, -17, 5,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -22, 9, -22, 9,
+ax_anim 3, 0, 183, -20, 21, -20, 21,
+ax_anim 2, 3, 182, -11, 21, -11, 21,
+ax_anim 2, 0, 181, -2, 12, -2, 12,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRattataAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRattataAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRattataAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRattataAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sRattataGfx1:
+.incbin "baserom.gba", 0x5DA7B0, 0x100
+sRattataSprites1:
+ax_sprite sRattataGfx1, 0x100
+ax_sprite_terminator
+sRattataGfx2:
+.incbin "baserom.gba", 0x5DA8C0, 0x100
+sRattataSprites2:
+ax_sprite sRattataGfx2, 0x100
+ax_sprite_terminator
+sRattataGfx3:
+.incbin "baserom.gba", 0x5DA9D0, 0x100
+sRattataSprites3:
+ax_sprite sRattataGfx3, 0x100
+ax_sprite_terminator
+sRattataGfx4:
+.incbin "baserom.gba", 0x5DAAE0, 0x20
+sRattataSprites4:
+ax_sprite sRattataGfx4, 0x20
+ax_sprite_terminator
+sRattataGfx5:
+.incbin "baserom.gba", 0x5DAB10, 0x200
+sRattataSprites5:
+ax_sprite sRattataGfx5, 0x200
+ax_sprite_terminator
+sRattataGfx6:
+.incbin "baserom.gba", 0x5DAD20, 0x200
+sRattataSprites6:
+ax_sprite sRattataGfx6, 0x200
+ax_sprite_terminator
+sRattataGfx7:
+.incbin "baserom.gba", 0x5DAF30, 0x200
+sRattataSprites7:
+ax_sprite sRattataGfx7, 0x200
+ax_sprite_terminator
+sRattataGfx8:
+.incbin "baserom.gba", 0x5DB140, 0x200
+sRattataSprites8:
+ax_sprite sRattataGfx8, 0x200
+ax_sprite_terminator
+sRattataGfx9:
+.incbin "baserom.gba", 0x5DB350, 0x200
+sRattataSprites9:
+ax_sprite sRattataGfx9, 0x200
+ax_sprite_terminator
+sRattataGfx10:
+.incbin "baserom.gba", 0x5DB560, 0x200
+sRattataSprites10:
+ax_sprite sRattataGfx10, 0x200
+ax_sprite_terminator
+sRattataGfx11:
+.incbin "baserom.gba", 0x5DB770, 0x200
+sRattataSprites11:
+ax_sprite sRattataGfx11, 0x200
+ax_sprite_terminator
+sRattataGfx12:
+.incbin "baserom.gba", 0x5DB980, 0x200
+sRattataSprites12:
+ax_sprite sRattataGfx12, 0x200
+ax_sprite_terminator
+sRattataGfx13:
+.incbin "baserom.gba", 0x5DBB90, 0x200
+sRattataSprites13:
+ax_sprite sRattataGfx13, 0x200
+ax_sprite_terminator
+sRattataGfx14:
+.incbin "baserom.gba", 0x5DBDA0, 0x100
+sRattataSprites14:
+ax_sprite sRattataGfx14, 0x100
+ax_sprite_terminator
+sRattataGfx15:
+.incbin "baserom.gba", 0x5DBEB0, 0x100
+sRattataSprites15:
+ax_sprite sRattataGfx15, 0x100
+ax_sprite_terminator
+sRattataGfx16:
+.incbin "baserom.gba", 0x5DBFC0, 0x100
+sRattataSprites16:
+ax_sprite sRattataGfx16, 0x100
+ax_sprite_terminator
+sRattataGfx17:
+.incbin "baserom.gba", 0x5DC0D0, 0x40
+sRattataGfx17_1:
+.incbin "baserom.gba", 0x5DC110, 0x40
+sRattataGfx17_2:
+.incbin "baserom.gba", 0x5DC150, 0x60
+sRattataGfx17_3:
+.incbin "baserom.gba", 0x5DC1B0, 0x60
+sRattataSprites17:
+ax_sprite sRattataGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRattataGfx18:
+.incbin "baserom.gba", 0x5DC258, 0x20
+sRattataGfx18_1:
+.incbin "baserom.gba", 0x5DC278, 0x60
+sRattataGfx18_2:
+.incbin "baserom.gba", 0x5DC2D8, 0x60
+sRattataGfx18_3:
+.incbin "baserom.gba", 0x5DC338, 0x20
+sRattataSprites18:
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRattataGfx19:
+.incbin "baserom.gba", 0x5DC3A8, 0x20
+sRattataGfx19_1:
+.incbin "baserom.gba", 0x5DC3C8, 0x120
+sRattataSprites19:
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx19_1, 0x120
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRattataGfx20:
+.incbin "baserom.gba", 0x5DC518, 0x160
+sRattataSprites20:
+ax_sprite sRattataGfx20, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRattataGfx21:
+.incbin "baserom.gba", 0x5DC690, 0xC0
+sRattataSprites21:
+ax_sprite sRattataGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRattataGfx22:
+.incbin "baserom.gba", 0x5DC768, 0x40
+sRattataGfx22_1:
+.incbin "baserom.gba", 0x5DC7A8, 0x40
+sRattataGfx22_2:
+.incbin "baserom.gba", 0x5DC7E8, 0x60
+sRattataSprites22:
+ax_sprite sRattataGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx22_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRattataGfx23:
+.incbin "baserom.gba", 0x5DC880, 0x40
+sRattataGfx23_1:
+.incbin "baserom.gba", 0x5DC8C0, 0x40
+sRattataGfx23_2:
+.incbin "baserom.gba", 0x5DC900, 0x60
+sRattataSprites23:
+ax_sprite sRattataGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRattataGfx24:
+.incbin "baserom.gba", 0x5DC998, 0x40
+sRattataGfx24_1:
+.incbin "baserom.gba", 0x5DC9D8, 0x60
+sRattataGfx24_2:
+.incbin "baserom.gba", 0x5DCA38, 0x60
+sRattataSprites24:
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRattataGfx25:
+.incbin "baserom.gba", 0x5DCAD8, 0x40
+sRattataGfx25_1:
+.incbin "baserom.gba", 0x5DCB18, 0x60
+sRattataGfx25_2:
+.incbin "baserom.gba", 0x5DCB78, 0x60
+sRattataSprites25:
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRattataGfx26:
+.incbin "baserom.gba", 0x5DCC18, 0x140
+sRattataSprites26:
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx26, 0x140
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRattataGfx27:
+.incbin "baserom.gba", 0x5DCD78, 0x20
+sRattataGfx27_1:
+.incbin "baserom.gba", 0x5DCD98, 0x100
+sRattataSprites27:
+ax_sprite 0, 0x40
+ax_sprite sRattataGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx27_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRattataGfx28:
+.incbin "baserom.gba", 0x5DCEC8, 0x60
+sRattataGfx28_1:
+.incbin "baserom.gba", 0x5DCF28, 0x60
+sRattataGfx28_2:
+.incbin "baserom.gba", 0x5DCF88, 0x60
+sRattataSprites28:
+ax_sprite sRattataGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRattataGfx29:
+.incbin "baserom.gba", 0x5DD020, 0x60
+sRattataGfx29_1:
+.incbin "baserom.gba", 0x5DD080, 0x60
+sRattataGfx29_2:
+.incbin "baserom.gba", 0x5DD0E0, 0x60
+sRattataSprites29:
+ax_sprite sRattataGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRattataGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRattataGfx30:
+.incbin "baserom.gba", 0x5DD178, 0xC0
+sRattataSprites30:
+ax_sprite sRattataGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRattataGfx31:
+.incbin "baserom.gba", 0x5DD250, 0xC0
+sRattataSprites31:
+ax_sprite sRattataGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRattataGfx32:
+.incbin "baserom.gba", 0x5DD328, 0x200
+sRattataSprites32:
+ax_sprite sRattataGfx32, 0x200
+ax_sprite_terminator
+sRattataGfx33:
+.incbin "baserom.gba", 0x5DD538, 0x200
+sRattataSprites33:
+ax_sprite sRattataGfx33, 0x200
+ax_sprite_terminator
+sRattataGfx34:
+.incbin "baserom.gba", 0x5DD748, 0x200
+sRattataSprites34:
+ax_sprite sRattataGfx34, 0x200
+ax_sprite_terminator
+sRattataGfx35:
+.incbin "baserom.gba", 0x5DD958, 0x200
+sRattataSprites35:
+ax_sprite sRattataGfx35, 0x200
+ax_sprite_terminator
+sRattataGfx36:
+.incbin "baserom.gba", 0x5DDB68, 0x200
+sRattataSprites36:
+ax_sprite sRattataGfx36, 0x200
+ax_sprite_terminator
+sRattataGfx37:
+.incbin "baserom.gba", 0x5DDD78, 0x200
+sRattataSprites37:
+ax_sprite sRattataGfx37, 0x200
+ax_sprite_terminator
+sRattataGfx38:
+.incbin "baserom.gba", 0x5DDF88, 0x200
+sRattataSprites38:
+ax_sprite sRattataGfx38, 0x200
+ax_sprite_terminator
+sAxPosesRattata:
+.4byte sRattataPose1
+.4byte sRattataPose2
+.4byte sRattataPose3
+.4byte sRattataPose4
+.4byte sRattataPose5
+.4byte sRattataPose6
+.4byte sRattataPose7
+.4byte sRattataPose8
+.4byte sRattataPose9
+.4byte sRattataPose10
+.4byte sRattataPose11
+.4byte sRattataPose12
+.4byte sRattataPose13
+.4byte sRattataPose14
+.4byte sRattataPose15
+.4byte sRattataPose16
+.4byte sRattataPose17
+.4byte sRattataPose18
+.4byte sRattataPose19
+.4byte sRattataPose20
+.4byte sRattataPose21
+.4byte sRattataPose22
+.4byte sRattataPose23
+.4byte sRattataPose24
+.4byte sRattataPose25
+.4byte sRattataPose26
+.4byte sRattataPose27
+.4byte sRattataPose28
+.4byte sRattataPose29
+.4byte sRattataPose30
+.4byte sRattataPose31
+.4byte sRattataPose32
+.4byte sRattataPose33
+.4byte sRattataPose34
+.4byte sRattataPose35
+.4byte sRattataPose36
+.4byte sRattataPose37
+.4byte sRattataPose38
+.4byte sRattataPose39
+.4byte sRattataPose40
+.4byte sRattataPose41
+.4byte sRattataPose42
+.4byte sRattataPose43
+.4byte sRattataPose44
+.4byte sRattataPose45
+.4byte sRattataPose46
+.4byte sRattataPose47
+.4byte sRattataPose48
+.4byte sRattataPose49
+.4byte sRattataPose50
+.4byte sRattataPose51
+.4byte sRattataPose52
+.4byte sRattataPose53
+.4byte sRattataPose54
+.4byte sRattataPose55
+.4byte sRattataPose56
+.4byte sRattataPose57
+.4byte sRattataPose58
+.4byte sRattataPose59
+.4byte sRattataPose60
+.4byte sRattataPose61
+.4byte sRattataPose62
+.4byte sRattataPose63
+.4byte sRattataPose64
+.4byte sRattataPose65
+.4byte sRattataPose66
+.4byte sRattataPose67
+.4byte sRattataPose68
+.4byte sRattataPose69
+.4byte sRattataPose70
+.4byte sRattataPose71
+.4byte sRattataPose72
+.4byte sRattataPose73
+.4byte sRattataPose74
+.4byte sRattataPose75
+.4byte sRattataPose76
+.4byte sRattataPose77
+.4byte sRattataPose78
+.4byte sRattataPose79
+.4byte sRattataPose80
+.4byte sRattataPose81
+.4byte sRattataPose82
+.4byte sRattataPose83
+.4byte sRattataPose84
+.4byte sRattataPose85
+.4byte sRattataPose86
+.4byte sRattataPose87
+.4byte sRattataPose88
+.4byte sRattataPose89
+.4byte sRattataPose90
+.4byte sRattataPose91
+.4byte sRattataPose92
+.4byte sRattataPose93
+.4byte sRattataPose94
+.4byte sRattataPose95
+.4byte sRattataPose96
+.4byte sRattataPose97
+.4byte sRattataPose98
+.4byte sRattataPose99
+.4byte sRattataPose100
+.4byte sRattataPose101
+.4byte sRattataPose102
+.4byte sRattataPose103
+.4byte sRattataPose104
+.4byte sRattataPose105
+.4byte sRattataPose106
+.4byte sRattataPose107
+.4byte sRattataPose108
+.4byte sRattataPose109
+.4byte sRattataPose110
+.4byte sRattataPose111
+.4byte sRattataPose112
+.4byte sRattataPose113
+.4byte sRattataPose114
+.4byte sRattataPose115
+.4byte sRattataPose116
+.4byte sRattataPose117
+.4byte sRattataPose118
+.4byte sRattataPose119
+.4byte sRattataPose120
+.4byte sRattataPose121
+.4byte sRattataPose122
+.4byte sRattataPose123
+.4byte sRattataPose124
+.4byte sRattataPose125
+.4byte sRattataPose126
+.4byte sRattataPose127
+.4byte sRattataPose128
+.4byte sRattataPose129
+.4byte sRattataPose130
+.4byte sRattataPose131
+.4byte sRattataPose132
+.4byte sRattataPose133
+.4byte sRattataPose134
+.4byte sRattataPose135
+.4byte sRattataPose136
+.4byte sRattataPose137
+.4byte sRattataPose138
+.4byte sRattataPose139
+.4byte sRattataPose140
+.4byte sRattataPose141
+.4byte sRattataPose142
+.4byte sRattataPose143
+.4byte sRattataPose144
+.4byte sRattataPose145
+.4byte sRattataPose146
+.4byte sRattataPose147
+.4byte sRattataPose148
+.4byte sRattataPose149
+.4byte sRattataPose150
+.4byte sRattataPose151
+.4byte sRattataPose152
+.4byte sRattataPose153
+.4byte sRattataPose154
+.4byte sRattataPose155
+.4byte sRattataPose156
+.4byte sRattataPose157
+.4byte sRattataPose158
+.4byte sRattataPose159
+.4byte sRattataPose160
+.4byte sRattataPose161
+.4byte sRattataPose162
+.4byte sRattataPose163
+.4byte sRattataPose164
+.4byte sRattataPose165
+.4byte sRattataPose166
+.4byte sRattataPose167
+.4byte sRattataPose168
+.4byte sRattataPose169
+.4byte sRattataPose170
+.4byte sRattataPose171
+.4byte sRattataPose172
+.4byte sRattataPose173
+.4byte sRattataPose174
+.4byte sRattataPose175
+.4byte sRattataPose176
+.4byte sRattataPose177
+.4byte sRattataPose178
+.4byte sRattataPose179
+.4byte sRattataPose180
+.4byte sRattataPose181
+.4byte sRattataPose182
+.4byte sRattataPose183
+.4byte sRattataPose184
+.4byte sRattataPose185
+.4byte sRattataPose186
+.4byte sRattataPose187
+.4byte sRattataPose188
+.4byte sRattataPose189
+.4byte sRattataPose190
+.4byte sRattataPose191
+.4byte sRattataPose192
+.4byte sRattataPose193
+.4byte sRattataPose194
+.4byte sRattataPose195
+.4byte sRattataPose196
+.4byte sRattataPose197
+.4byte sRattataPose198
+.4byte sRattataPose199
+.4byte sRattataPose200
+.4byte sRattataPose201
+.4byte sRattataPose202
+.4byte sRattataPose203
+.4byte sRattataPose204
+.4byte sRattataPose205
+.4byte sRattataPose206
+.4byte sRattataPose207
+.4byte sRattataPose208
+.4byte sRattataPose209
+.4byte sRattataPose210
+.4byte sRattataPose211
+.4byte sRattataPose212
+.4byte sRattataPose213
+.4byte sRattataPose214
+.4byte sRattataPose215
+.4byte sRattataPose216
+.4byte sRattataPose217
+.4byte sRattataPose218
+.4byte sRattataPose219
+.4byte sRattataPose220
+.4byte sRattataPose221
+.4byte sRattataPose222
+.4byte sRattataPose223
+.4byte sRattataPose224
+.4byte sRattataPose225
+.4byte sRattataPose226
+.4byte sRattataPose227
+.4byte sRattataPose228
+.4byte sRattataPose229
+.4byte sRattataPose230
+.4byte sRattataPose231
+.4byte sRattataPose232
+.4byte sRattataPose233
+.4byte sRattataPose234
+sAxPositionsRattata:
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -6, 	   5,   -6, 	   0,  -11
+.2byte    0,    0, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    4,    0, 	   8,    1, 	  -1,    2, 	   0,   -6
+.2byte    4,   -4, 	   6,   -5, 	  -2,   -3, 	  -1,   -7
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	  -1,   -8
+.2byte    7,   -3, 	   7,   -4, 	   3,    0, 	  -1,   -6
+.2byte    8,   -6, 	   8,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    6,   -3, 	   6,    0, 	   6,    1, 	  -1,   -8
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    6,   -9, 	  -1,   -7, 	   5,   -5, 	  -2,   -7
+.2byte    6,   -7, 	   0,   -5, 	   6,   -2, 	  -1,   -9
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -8, 	  -5,   -8, 	   0,   -9
+.2byte   -8,   -7, 	   0,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -7,   -9, 	   0,   -7, 	  -6,   -5, 	   1,   -7
+.2byte   -7,   -7, 	  -1,   -5, 	  -7,   -2, 	   0,   -9
+.2byte   -8,   -3, 	  -8,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -9,   -6, 	  -9,   -7, 	  -4,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -7,    0, 	  -7,    1, 	   0,   -8
+.2byte   -5,    0, 	  -9,    1, 	   0,    2, 	  -1,   -6
+.2byte   -5,   -4, 	  -7,   -5, 	   1,   -3, 	   0,   -7
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	   0,   -8
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -6, 	   5,   -6, 	   0,  -11
+.2byte    0,    0, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,    0, 	  -7,    3, 	   6,    3, 	   0,   -6
+.2byte    4,    0, 	   8,    1, 	  -1,    2, 	   0,   -6
+.2byte    4,   -4, 	   6,   -5, 	  -2,   -3, 	  -1,   -7
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	  -1,   -8
+.2byte    5,    1, 	  10,    2, 	   0,    4, 	   1,   -5
+.2byte    7,   -3, 	   7,   -4, 	   3,    0, 	  -1,   -6
+.2byte    8,   -6, 	   8,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    6,   -3, 	   6,    0, 	   6,    1, 	  -1,   -8
+.2byte    9,   -3, 	   7,   -1, 	   6,    0, 	   0,   -6
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    6,   -9, 	  -1,   -7, 	   5,   -5, 	  -2,   -7
+.2byte    6,   -7, 	   0,   -5, 	   6,   -2, 	  -1,   -9
+.2byte    8,   -9, 	   0,   -7, 	   8,   -4, 	  -1,   -7
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -8, 	  -5,   -8, 	   0,   -9
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -8,   -7, 	   0,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -7,   -9, 	   0,   -7, 	  -6,   -5, 	   1,   -7
+.2byte   -7,   -7, 	  -1,   -5, 	  -7,   -2, 	   0,   -9
+.2byte   -9,   -9, 	  -1,   -7, 	  -9,   -4, 	   0,   -7
+.2byte   -8,   -3, 	  -8,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -9,   -6, 	  -9,   -7, 	  -4,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -7,    0, 	  -7,    1, 	   0,   -8
+.2byte  -10,   -3, 	  -8,   -1, 	  -7,    0, 	  -1,   -6
+.2byte   -5,    0, 	  -9,    1, 	   0,    2, 	  -1,   -6
+.2byte   -5,   -4, 	  -7,   -5, 	   1,   -3, 	   0,   -7
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	   0,   -8
+.2byte   -6,    1, 	 -11,    2, 	  -1,    4, 	  -2,   -5
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -6, 	   5,   -6, 	   0,  -11
+.2byte    0,    0, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,    0, 	  -7,    3, 	   6,    3, 	   0,   -6
+.2byte    4,    0, 	   8,    1, 	  -1,    2, 	   0,   -6
+.2byte    4,   -4, 	   6,   -5, 	  -2,   -3, 	  -1,   -7
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	  -1,   -8
+.2byte    5,    1, 	  10,    2, 	   0,    4, 	   1,   -5
+.2byte    7,   -3, 	   7,   -4, 	   3,    0, 	  -1,   -6
+.2byte    8,   -6, 	   8,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    6,   -3, 	   6,    0, 	   6,    1, 	  -1,   -8
+.2byte    9,   -3, 	   7,   -1, 	   6,    0, 	   0,   -6
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    6,   -9, 	  -1,   -7, 	   5,   -5, 	  -2,   -7
+.2byte    6,   -7, 	   0,   -5, 	   6,   -2, 	  -1,   -9
+.2byte    8,   -9, 	   0,   -7, 	   8,   -4, 	  -1,   -7
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -8, 	  -5,   -8, 	   0,   -9
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -8,   -7, 	   0,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -7,   -9, 	   0,   -7, 	  -6,   -5, 	   1,   -7
+.2byte   -7,   -7, 	  -1,   -5, 	  -7,   -2, 	   0,   -9
+.2byte   -9,   -9, 	  -1,   -7, 	  -9,   -4, 	   0,   -7
+.2byte   -8,   -3, 	  -8,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -9,   -6, 	  -9,   -7, 	  -4,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -7,    0, 	  -7,    1, 	   0,   -8
+.2byte  -10,   -3, 	  -8,   -1, 	  -7,    0, 	  -1,   -6
+.2byte   -5,    0, 	  -9,    1, 	   0,    2, 	  -1,   -6
+.2byte   -5,   -4, 	  -7,   -5, 	   1,   -3, 	   0,   -7
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	   0,   -8
+.2byte   -6,    1, 	 -11,    2, 	  -1,    4, 	  -2,   -5
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte    0,    0, 	  -7,    3, 	   6,    3, 	   0,   -6
+.2byte    4,    0, 	   8,    1, 	  -1,    2, 	   0,   -6
+.2byte    5,    1, 	  10,    2, 	   0,    4, 	   1,   -5
+.2byte    7,   -3, 	   7,   -4, 	   3,    0, 	  -1,   -6
+.2byte    9,   -3, 	   7,   -1, 	   6,    0, 	   0,   -6
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    8,   -9, 	   0,   -7, 	   8,   -4, 	  -1,   -7
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -8,   -7, 	   0,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -9,   -9, 	  -1,   -7, 	  -9,   -4, 	   0,   -7
+.2byte   -8,   -3, 	  -8,   -4, 	  -4,    0, 	   0,   -6
+.2byte  -10,   -3, 	  -8,   -1, 	  -7,    0, 	  -1,   -6
+.2byte   -5,    0, 	  -9,    1, 	   0,    2, 	  -1,   -6
+.2byte   -6,    1, 	 -11,    2, 	  -1,    4, 	  -2,   -5
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -6, 	   5,   -6, 	   0,  -11
+.2byte    0,    0, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    0,    1, 	  -6,    2, 	   5,    2, 	   0,   -6
+.2byte    0,    1, 	  -6,    2, 	   5,    2, 	   0,   -6
+.2byte    4,    0, 	   8,    1, 	  -1,    2, 	   0,   -6
+.2byte    4,   -4, 	   6,   -5, 	  -2,   -3, 	  -1,   -7
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	  -1,   -8
+.2byte    3,    2, 	   9,    1, 	  -1,    2, 	   0,   -5
+.2byte    3,    2, 	   9,    1, 	  -1,    2, 	   0,   -5
+.2byte    7,   -3, 	   7,   -4, 	   3,    0, 	  -1,   -6
+.2byte    8,   -6, 	   8,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    6,   -3, 	   6,    0, 	   6,    1, 	  -1,   -8
+.2byte    6,   -1, 	   3,   -1, 	   2,    0, 	  -2,   -6
+.2byte    6,   -1, 	   3,   -1, 	   2,    0, 	  -2,   -6
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    7,   -9, 	   0,   -7, 	   6,   -5, 	  -1,   -7
+.2byte    6,   -7, 	   0,   -5, 	   6,   -2, 	  -1,   -9
+.2byte    8,   -6, 	  -1,   -6, 	   6,   -3, 	  -2,   -6
+.2byte    8,   -6, 	  -1,   -6, 	   6,   -3, 	  -2,   -6
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -8, 	  -5,   -8, 	   0,   -9
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,   -9, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte   -8,   -7, 	   0,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -8,   -9, 	  -1,   -7, 	  -7,   -5, 	   0,   -7
+.2byte   -7,   -7, 	  -1,   -5, 	  -7,   -2, 	   0,   -9
+.2byte   -9,   -6, 	   0,   -6, 	  -7,   -3, 	   1,   -6
+.2byte   -9,   -6, 	   0,   -6, 	  -7,   -3, 	   1,   -6
+.2byte   -8,   -3, 	  -8,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -9,   -6, 	  -9,   -7, 	  -4,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -7,    0, 	  -7,    1, 	   0,   -8
+.2byte   -7,   -1, 	  -4,   -1, 	  -3,    0, 	   1,   -6
+.2byte   -7,   -1, 	  -4,   -1, 	  -3,    0, 	   1,   -6
+.2byte   -5,    0, 	  -9,    1, 	   0,    2, 	  -1,   -6
+.2byte   -5,   -4, 	  -7,   -5, 	   1,   -3, 	   0,   -7
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	   0,   -8
+.2byte   -4,    2, 	 -10,    1, 	   0,    2, 	  -1,   -5
+.2byte   -4,    2, 	 -10,    1, 	   0,    2, 	  -1,   -5
+.2byte   -5,    0, 	  -7,    0, 	  -1,    1, 	   0,   -5
+.2byte   -5,    1, 	  -8,    0, 	  -1,    1, 	  -1,   -4
+.2byte   -1,   -8, 	  -7,   -9, 	   6,   -9, 	   0,   -8
+.2byte    0,  -10, 	   2,  -12, 	  -6,   -9, 	  -5,   -7
+.2byte   -1,   -7, 	  -1,  -11, 	  -4,   -9, 	  -5,   -6
+.2byte    1,  -11, 	  -4,  -10, 	   2,   -8, 	  -5,   -5
+.2byte    0,  -10, 	   5,   -8, 	  -6,   -8, 	   0,   -6
+.2byte   -2,  -11, 	   3,  -10, 	  -3,   -8, 	   4,   -5
+.2byte    0,   -7, 	   0,  -11, 	   3,   -9, 	   4,   -6
+.2byte   -1,  -10, 	  -3,  -12, 	   5,   -9, 	   4,   -7
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -6, 	   5,   -6, 	   0,  -11
+.2byte    0,    0, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    4,    0, 	   8,    1, 	  -1,    2, 	   0,   -6
+.2byte    4,   -4, 	   6,   -5, 	  -2,   -3, 	  -1,   -7
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	  -1,   -8
+.2byte    7,   -3, 	   7,   -4, 	   3,    0, 	  -1,   -6
+.2byte    8,   -6, 	   8,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    6,   -3, 	   6,    0, 	   6,    1, 	  -1,   -8
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    6,   -9, 	  -1,   -7, 	   5,   -5, 	  -2,   -7
+.2byte    6,   -7, 	   0,   -5, 	   6,   -2, 	  -1,   -9
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -8, 	  -5,   -8, 	   0,   -9
+.2byte   -8,   -7, 	   0,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -7,   -9, 	   0,   -7, 	  -6,   -5, 	   1,   -7
+.2byte   -7,   -7, 	  -1,   -5, 	  -7,   -2, 	   0,   -9
+.2byte   -8,   -3, 	  -8,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -9,   -6, 	  -9,   -7, 	  -4,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -7,    0, 	  -7,    1, 	   0,   -8
+.2byte   -5,    0, 	  -9,    1, 	   0,    2, 	  -1,   -6
+.2byte   -5,   -4, 	  -7,   -5, 	   1,   -3, 	   0,   -7
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	   0,   -8
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte   -5,   -1, 	  -9,    0, 	   0,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,   -5, 	  -4,   -1, 	   0,   -7
+.2byte   -7,   -7, 	   1,   -4, 	  -6,   -2, 	   1,   -7
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    7,   -4, 	   7,   -5, 	   3,   -1, 	  -1,   -7
+.2byte    4,   -1, 	   8,    0, 	  -1,    1, 	   0,   -7
+.2byte    0,    0, 	  -7,    3, 	   6,    3, 	   0,   -6
+.2byte    4,    1, 	   9,    2, 	  -1,    4, 	   0,   -5
+.2byte    8,   -3, 	   6,   -1, 	   5,    0, 	  -1,   -6
+.2byte    7,   -9, 	  -1,   -7, 	   7,   -4, 	  -2,   -7
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -8,   -9, 	   0,   -7, 	  -8,   -4, 	   1,   -7
+.2byte   -9,   -3, 	  -7,   -1, 	  -6,    0, 	   0,   -6
+.2byte   -5,    1, 	 -10,    2, 	   0,    4, 	  -1,   -5
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte    0,   -6, 	  -6,   -6, 	   5,   -6, 	   0,  -11
+.2byte    0,    0, 	  -5,    2, 	   4,    2, 	   0,   -7
+.2byte    4,    0, 	   8,    1, 	  -1,    2, 	   0,   -6
+.2byte    4,   -4, 	   6,   -5, 	  -2,   -3, 	  -1,   -7
+.2byte    4,   -1, 	   9,   -2, 	   2,    2, 	  -1,   -8
+.2byte    7,   -3, 	   7,   -4, 	   3,    0, 	  -1,   -6
+.2byte    8,   -6, 	   8,   -7, 	   3,   -4, 	  -1,   -7
+.2byte    6,   -3, 	   6,    0, 	   6,    1, 	  -1,   -8
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    6,   -9, 	  -1,   -7, 	   5,   -5, 	  -2,   -7
+.2byte    6,   -7, 	   0,   -5, 	   6,   -2, 	  -1,   -9
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,   -7
+.2byte    0,  -10, 	   4,   -8, 	  -5,   -8, 	   0,   -9
+.2byte   -8,   -7, 	   0,   -4, 	  -7,   -2, 	   0,   -7
+.2byte   -7,   -9, 	   0,   -7, 	  -6,   -5, 	   1,   -7
+.2byte   -7,   -7, 	  -1,   -5, 	  -7,   -2, 	   0,   -9
+.2byte   -8,   -3, 	  -8,   -4, 	  -4,    0, 	   0,   -6
+.2byte   -9,   -6, 	  -9,   -7, 	  -4,   -4, 	   0,   -7
+.2byte   -7,   -3, 	  -7,    0, 	  -7,    1, 	   0,   -8
+.2byte   -5,    0, 	  -9,    1, 	   0,    2, 	  -1,   -6
+.2byte   -5,   -4, 	  -7,   -5, 	   1,   -3, 	   0,   -7
+.2byte   -5,   -1, 	 -10,   -2, 	  -3,    2, 	   0,   -8
+.2byte    0,    0, 	  -7,    3, 	   6,    3, 	   0,   -6
+.2byte   -5,    1, 	 -10,    2, 	   0,    4, 	  -1,   -5
+.2byte   -9,   -3, 	  -7,   -1, 	  -6,    0, 	   0,   -6
+.2byte   -8,   -9, 	   0,   -7, 	  -8,   -4, 	   1,   -7
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte    7,   -9, 	  -1,   -7, 	   7,   -4, 	  -2,   -7
+.2byte    8,   -3, 	   6,   -1, 	   5,    0, 	  -1,   -6
+.2byte    4,    1, 	   9,    2, 	  -1,    4, 	   0,   -5
+.2byte    0,   -1, 	  -6,    1, 	   5,    1, 	   0,   -7
+.2byte   -5,   -1, 	  -9,    0, 	   0,    1, 	  -1,   -7
+.2byte   -8,   -4, 	  -8,   -5, 	  -4,   -1, 	   0,   -7
+.2byte   -7,   -7, 	   1,   -4, 	  -6,   -2, 	   1,   -7
+.2byte    0,  -10, 	   5,   -5, 	  -6,   -5, 	   0,   -7
+.2byte    7,   -7, 	  -1,   -4, 	   6,   -2, 	  -1,   -7
+.2byte    7,   -4, 	   7,   -5, 	   3,   -1, 	  -1,   -7
+.2byte    4,   -1, 	   8,    0, 	  -1,    1, 	   0,   -7
+sRattataAnimTable1:
+.4byte sRattataAnims_1_1
+.4byte sRattataAnims_1_2
+.4byte sRattataAnims_1_3
+.4byte sRattataAnims_1_4
+.4byte sRattataAnims_1_5
+.4byte sRattataAnims_1_6
+.4byte sRattataAnims_1_7
+.4byte sRattataAnims_1_8
+sRattataAnimTable2:
+.4byte sRattataAnims_2_1
+.4byte sRattataAnims_2_2
+.4byte sRattataAnims_2_3
+.4byte sRattataAnims_2_4
+.4byte sRattataAnims_2_5
+.4byte sRattataAnims_2_6
+.4byte sRattataAnims_2_7
+.4byte sRattataAnims_2_8
+sRattataAnimTable3:
+.4byte sRattataAnims_3_1
+.4byte sRattataAnims_3_2
+.4byte sRattataAnims_3_3
+.4byte sRattataAnims_3_4
+.4byte sRattataAnims_3_5
+.4byte sRattataAnims_3_6
+.4byte sRattataAnims_3_7
+.4byte sRattataAnims_3_8
+sRattataAnimTable4:
+.4byte sRattataAnims_4_1
+.4byte sRattataAnims_4_2
+.4byte sRattataAnims_4_3
+.4byte sRattataAnims_4_4
+.4byte sRattataAnims_4_5
+.4byte sRattataAnims_4_6
+.4byte sRattataAnims_4_7
+.4byte sRattataAnims_4_8
+sRattataAnimTable5:
+.4byte sRattataAnims_5_1
+.4byte sRattataAnims_5_2
+.4byte sRattataAnims_5_3
+.4byte sRattataAnims_5_4
+.4byte sRattataAnims_5_5
+.4byte sRattataAnims_5_6
+.4byte sRattataAnims_5_7
+.4byte sRattataAnims_5_8
+sRattataAnimTable6:
+.4byte sRattataAnims_6_1
+.4byte sRattataAnims_6_1
+.4byte sRattataAnims_6_1
+.4byte sRattataAnims_6_1
+.4byte sRattataAnims_6_1
+.4byte sRattataAnims_6_1
+.4byte sRattataAnims_6_1
+.4byte sRattataAnims_6_1
+sRattataAnimTable7:
+.4byte sRattataAnims_7_1
+.4byte sRattataAnims_7_2
+.4byte sRattataAnims_7_3
+.4byte sRattataAnims_7_4
+.4byte sRattataAnims_7_5
+.4byte sRattataAnims_7_6
+.4byte sRattataAnims_7_7
+.4byte sRattataAnims_7_8
+sRattataAnimTable8:
+.4byte sRattataAnims_8_1
+.4byte sRattataAnims_8_2
+.4byte sRattataAnims_8_3
+.4byte sRattataAnims_8_4
+.4byte sRattataAnims_8_5
+.4byte sRattataAnims_8_6
+.4byte sRattataAnims_8_7
+.4byte sRattataAnims_8_8
+sRattataAnimTable9:
+.4byte sRattataAnims_9_1
+.4byte sRattataAnims_9_2
+.4byte sRattataAnims_9_3
+.4byte sRattataAnims_9_4
+.4byte sRattataAnims_9_5
+.4byte sRattataAnims_9_6
+.4byte sRattataAnims_9_7
+.4byte sRattataAnims_9_8
+sRattataAnimTable10:
+.4byte sRattataAnims_10_1
+.4byte sRattataAnims_10_2
+.4byte sRattataAnims_10_3
+.4byte sRattataAnims_10_4
+.4byte sRattataAnims_10_5
+.4byte sRattataAnims_10_6
+.4byte sRattataAnims_10_7
+.4byte sRattataAnims_10_8
+sRattataAnimTable11:
+.4byte sRattataAnims_11_1
+.4byte sRattataAnims_11_2
+.4byte sRattataAnims_11_3
+.4byte sRattataAnims_11_4
+.4byte sRattataAnims_11_5
+.4byte sRattataAnims_11_6
+.4byte sRattataAnims_11_7
+.4byte sRattataAnims_11_8
+sRattataAnimTable12:
+.4byte sRattataAnims_12_1
+.4byte sRattataAnims_12_2
+.4byte sRattataAnims_12_3
+.4byte sRattataAnims_12_4
+.4byte sRattataAnims_12_5
+.4byte sRattataAnims_12_6
+.4byte sRattataAnims_12_7
+.4byte sRattataAnims_12_8
+sRattataAnimTable13:
+.4byte sRattataAnims_13_1
+.4byte sRattataAnims_13_2
+.4byte sRattataAnims_13_3
+.4byte sRattataAnims_13_4
+.4byte sRattataAnims_13_5
+.4byte sRattataAnims_13_6
+.4byte sRattataAnims_13_7
+.4byte sRattataAnims_13_8
+sAxAnimationsRattata:
+.4byte sRattataAnimTable1
+.4byte sRattataAnimTable2
+.4byte sRattataAnimTable3
+.4byte sRattataAnimTable4
+.4byte sRattataAnimTable5
+.4byte sRattataAnimTable6
+.4byte sRattataAnimTable7
+.4byte sRattataAnimTable8
+.4byte sRattataAnimTable9
+.4byte sRattataAnimTable10
+.4byte sRattataAnimTable11
+.4byte sRattataAnimTable12
+.4byte sRattataAnimTable13
+sAxSpritesRattata:
+.4byte sRattataSprites1
+.4byte sRattataSprites2
+.4byte sRattataSprites3
+.4byte sRattataSprites4
+.4byte sRattataSprites5
+.4byte sRattataSprites6
+.4byte sRattataSprites7
+.4byte sRattataSprites8
+.4byte sRattataSprites9
+.4byte sRattataSprites10
+.4byte sRattataSprites11
+.4byte sRattataSprites12
+.4byte sRattataSprites13
+.4byte sRattataSprites14
+.4byte sRattataSprites15
+.4byte sRattataSprites16
+.4byte sRattataSprites17
+.4byte sRattataSprites18
+.4byte sRattataSprites19
+.4byte sRattataSprites20
+.4byte sRattataSprites21
+.4byte sRattataSprites22
+.4byte sRattataSprites23
+.4byte sRattataSprites24
+.4byte sRattataSprites25
+.4byte sRattataSprites26
+.4byte sRattataSprites27
+.4byte sRattataSprites28
+.4byte sRattataSprites29
+.4byte sRattataSprites30
+.4byte sRattataSprites31
+.4byte sRattataSprites32
+.4byte sRattataSprites33
+.4byte sRattataSprites34
+.4byte sRattataSprites35
+.4byte sRattataSprites36
+.4byte sRattataSprites37
+.4byte sRattataSprites38
+sAxMainRattata:
+ax_main sAxPosesRattata, sAxAnimationsRattata, 13, sAxSpritesRattata, sAxPositionsRattata

--- a/data/ax/rayquaza.inc
+++ b/data/ax/rayquaza.inc
@@ -1,0 +1,5342 @@
+.global gAxRayquaza
+gAxRayquaza:
+ax_siro sAxMainRayquaza
+sRayquazaPose1:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose2:
+ax_pose 4, 0x81c3, 0xc0f1, 0x3c00
+ax_pose 5, 0x81e3, 0x80e1, 0x3c20
+ax_pose 6, 0x4203, 0x00f1, 0x3c28
+ax_pose 7, 0x01e3, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaPose3:
+ax_pose 8, 0x81c2, 0xc0f1, 0x3c00
+ax_pose 9, 0x81e2, 0x80e1, 0x3c20
+ax_pose 10, 0x4202, 0x00f1, 0x3c28
+ax_pose 11, 0x01e2, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaPose4:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose5:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaPose6:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaPose7:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose8:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaPose9:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose10:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose11:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaPose12:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaPose13:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose14:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaPose15:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaPose16:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose17:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaPose18:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaPose19:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose20:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaPose21:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaPose22:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose23:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaPose24:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaPose25:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose26:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaPose27:
+ax_pose 100, 0x81c4, 0xc0f8, 0x3c00
+ax_pose 101, 0x01f4, 0x40e8, 0x3c20
+ax_pose 102, 0x4204, 0x80f8, 0x3c24
+ax_pose 103, 0x0204, 0x00f0, 0x3c2c
+ax_pose_terminator
+sRayquazaPose28:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose29:
+ax_pose 104, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaPose30:
+ax_pose 105, 0x01f5, 0x910b, 0x3c00
+ax_pose 106, 0x41ed, 0x510b, 0x3c10
+ax_pose 107, 0x01e5, 0x90eb, 0x3c14
+ax_pose 108, 0x8205, 0x1103, 0x3c24
+ax_pose 109, 0x81fd, 0x112b, 0x3c26
+ax_pose 110, 0x01e5, 0x50db, 0x3c28
+ax_pose 111, 0x01d5, 0x50db, 0x3c2c
+ax_pose 112, 0x01c5, 0x50da, 0x3c30
+ax_pose 113, 0x81c5, 0x10d2, 0x3c34
+ax_pose_terminator
+sRayquazaPose31:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose32:
+ax_pose 114, 0x01c5, 0xd0d1, 0x3c00
+ax_pose_terminator
+sRayquazaPose33:
+ax_pose 115, 0x01e6, 0x90f7, 0x3c00
+ax_pose 116, 0x41e6, 0x90d7, 0x3c10
+ax_pose 117, 0x41f6, 0x50d7, 0x3c18
+ax_pose 118, 0x01d6, 0x9117, 0x3c1c
+ax_pose 119, 0x01f6, 0x5117, 0x3c2c
+ax_pose 120, 0x41f6, 0x1127, 0x3c30
+ax_pose 121, 0x01f6, 0x1137, 0x3c32
+ax_pose 122, 0x01ee, 0x1137, 0x3c33
+ax_pose 123, 0x81d6, 0x10d7, 0x3c34
+ax_pose 124, 0x01d6, 0x50c7, 0x3c36
+ax_pose 125, 0x81e6, 0x10cf, 0x3c3a
+ax_pose 126, 0x01c6, 0x50c7, 0x3c3c
+ax_pose_terminator
+sRayquazaPose34:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose35:
+ax_pose 127, 0x41d9, 0xd0d4, 0x3c00
+ax_pose 128, 0x41f9, 0x90d4, 0x3c20
+ax_pose 129, 0x01f9, 0x50f4, 0x3c28
+ax_pose 130, 0x4209, 0x50d4, 0x3c2c
+ax_pose 131, 0x4211, 0x10dc, 0x3c30
+ax_pose 132, 0x41c9, 0x90e3, 0x3c32
+ax_pose 133, 0x01d0, 0x10db, 0x3c3a
+ax_pose 134, 0x41c1, 0x10f3, 0x3c3b
+ax_pose 135, 0x01f9, 0x1104, 0x3c3d
+ax_pose_terminator
+sRayquazaPose36:
+ax_pose 136, 0x01eb, 0x90d8, 0x3c00
+ax_pose 137, 0x41eb, 0x90f8, 0x3c10
+ax_pose 138, 0x41fb, 0x10f8, 0x3c18
+ax_pose 139, 0x01fb, 0x1108, 0x3c1a
+ax_pose 140, 0x420b, 0x50d8, 0x3c1b
+ax_pose 141, 0x4213, 0x10e0, 0x3c1f
+ax_pose 142, 0x81cb, 0x5110, 0x3c21
+ax_pose 143, 0x81db, 0x1108, 0x3c25
+ax_pose 144, 0x81cb, 0x9118, 0x3c27
+ax_pose 145, 0x81d3, 0x1128, 0x3c2f
+ax_pose 146, 0x41eb, 0x1118, 0x3c31
+ax_pose 147, 0x01eb, 0x50c8, 0x3c33
+ax_pose 148, 0x81fb, 0x10d0, 0x3c37
+ax_pose 149, 0x41e3, 0x10c8, 0x3c39
+ax_pose_terminator
+sRayquazaPose37:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose38:
+ax_pose 150, 0x81da, 0xc0f8, 0x3c00
+ax_pose 151, 0x81da, 0x80e8, 0x3c20
+ax_pose 152, 0x81fa, 0x80e8, 0x3c28
+ax_pose 153, 0x81f2, 0x00e0, 0x3c30
+ax_pose 154, 0x01ca, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaPose39:
+ax_pose 155, 0x81c6, 0xc0f8, 0x3c00
+ax_pose 156, 0x81c6, 0x40f0, 0x3c20
+ax_pose 157, 0x81d6, 0x00e8, 0x3c24
+ax_pose 158, 0x01e6, 0x00f0, 0x3c26
+ax_pose 159, 0x0206, 0x40f9, 0x3c27
+ax_pose 160, 0x0206, 0x40e9, 0x3c2b
+ax_pose 161, 0x020c, 0x40d9, 0x3c2f
+ax_pose 162, 0x4216, 0x40e9, 0x3c33
+ax_pose_terminator
+sRayquazaPose40:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose41:
+ax_pose 127, 0x41d9, 0xc0f0, 0x3c00
+ax_pose 128, 0x41f9, 0x8110, 0x3c20
+ax_pose 129, 0x01f9, 0x4100, 0x3c28
+ax_pose 130, 0x4209, 0x4110, 0x3c2c
+ax_pose 131, 0x4211, 0x0118, 0x3c30
+ax_pose 132, 0x41c9, 0x8101, 0x3c32
+ax_pose 133, 0x01d0, 0x0121, 0x3c3a
+ax_pose 134, 0x41c1, 0x0101, 0x3c3b
+ax_pose 135, 0x01f9, 0x00f8, 0x3c3d
+ax_pose_terminator
+sRayquazaPose42:
+ax_pose 136, 0x01eb, 0x810c, 0x3c00
+ax_pose 137, 0x41eb, 0x80ec, 0x3c10
+ax_pose 138, 0x41fb, 0x00fc, 0x3c18
+ax_pose 139, 0x01fb, 0x00f4, 0x3c1a
+ax_pose 140, 0x420b, 0x410c, 0x3c1b
+ax_pose 141, 0x4213, 0x0114, 0x3c1f
+ax_pose 142, 0x81cb, 0x40ec, 0x3c21
+ax_pose 143, 0x81db, 0x00f4, 0x3c25
+ax_pose 144, 0x81cb, 0x80dc, 0x3c27
+ax_pose 145, 0x81d3, 0x00d4, 0x3c2f
+ax_pose 146, 0x41eb, 0x00dc, 0x3c31
+ax_pose 147, 0x01eb, 0x412c, 0x3c33
+ax_pose 148, 0x81fb, 0x012c, 0x3c37
+ax_pose 149, 0x41e3, 0x012c, 0x3c39
+ax_pose_terminator
+sRayquazaPose43:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose44:
+ax_pose 114, 0x01c5, 0xc0ef, 0x3c00
+ax_pose_terminator
+sRayquazaPose45:
+ax_pose 115, 0x01e6, 0x80e9, 0x3c00
+ax_pose 116, 0x41e6, 0x8109, 0x3c10
+ax_pose 117, 0x41f6, 0x4109, 0x3c18
+ax_pose 118, 0x01d6, 0x80c9, 0x3c1c
+ax_pose 119, 0x01f6, 0x40d9, 0x3c2c
+ax_pose 120, 0x41f6, 0x00c9, 0x3c30
+ax_pose 121, 0x01f6, 0x00c1, 0x3c32
+ax_pose 122, 0x01ee, 0x00c1, 0x3c33
+ax_pose 123, 0x81d6, 0x0121, 0x3c34
+ax_pose 124, 0x01d6, 0x4129, 0x3c36
+ax_pose 125, 0x81e6, 0x0129, 0x3c3a
+ax_pose 126, 0x01c6, 0x4129, 0x3c3c
+ax_pose_terminator
+sRayquazaPose46:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose47:
+ax_pose 104, 0x01c5, 0xc0e8, 0x3c00
+ax_pose_terminator
+sRayquazaPose48:
+ax_pose 105, 0x01f5, 0x80d5, 0x3c00
+ax_pose 106, 0x41ed, 0x40d5, 0x3c10
+ax_pose 107, 0x01e5, 0x80f5, 0x3c14
+ax_pose 108, 0x8205, 0x00f5, 0x3c24
+ax_pose 109, 0x81fd, 0x00cd, 0x3c26
+ax_pose 110, 0x01e5, 0x4115, 0x3c28
+ax_pose 111, 0x01d5, 0x4115, 0x3c2c
+ax_pose 112, 0x01c5, 0x4116, 0x3c30
+ax_pose 113, 0x81c5, 0x0126, 0x3c34
+ax_pose_terminator
+sRayquazaPose49:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose50:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaPose51:
+ax_pose 100, 0x81c4, 0xc0f8, 0x3c00
+ax_pose 101, 0x01f4, 0x40e8, 0x3c20
+ax_pose 102, 0x4204, 0x80f8, 0x3c24
+ax_pose 103, 0x0204, 0x00f0, 0x3c2c
+ax_pose_terminator
+sRayquazaPose52:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose53:
+ax_pose 104, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaPose54:
+ax_pose 105, 0x01f5, 0x910b, 0x3c00
+ax_pose 106, 0x41ed, 0x510b, 0x3c10
+ax_pose 107, 0x01e5, 0x90eb, 0x3c14
+ax_pose 108, 0x8205, 0x1103, 0x3c24
+ax_pose 109, 0x81fd, 0x112b, 0x3c26
+ax_pose 110, 0x01e5, 0x50db, 0x3c28
+ax_pose 111, 0x01d5, 0x50db, 0x3c2c
+ax_pose 112, 0x01c5, 0x50da, 0x3c30
+ax_pose 113, 0x81c5, 0x10d2, 0x3c34
+ax_pose_terminator
+sRayquazaPose55:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose56:
+ax_pose 114, 0x01c5, 0xd0d1, 0x3c00
+ax_pose_terminator
+sRayquazaPose57:
+ax_pose 115, 0x01e6, 0x90f7, 0x3c00
+ax_pose 116, 0x41e6, 0x90d7, 0x3c10
+ax_pose 117, 0x41f6, 0x50d7, 0x3c18
+ax_pose 118, 0x01d6, 0x9117, 0x3c1c
+ax_pose 119, 0x01f6, 0x5117, 0x3c2c
+ax_pose 120, 0x41f6, 0x1127, 0x3c30
+ax_pose 121, 0x01f6, 0x1137, 0x3c32
+ax_pose 122, 0x01ee, 0x1137, 0x3c33
+ax_pose 123, 0x81d6, 0x10d7, 0x3c34
+ax_pose 124, 0x01d6, 0x50c7, 0x3c36
+ax_pose 125, 0x81e6, 0x10cf, 0x3c3a
+ax_pose 126, 0x01c6, 0x50c7, 0x3c3c
+ax_pose_terminator
+sRayquazaPose58:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose59:
+ax_pose 127, 0x41d9, 0xd0d4, 0x3c00
+ax_pose 128, 0x41f9, 0x90d4, 0x3c20
+ax_pose 129, 0x01f9, 0x50f4, 0x3c28
+ax_pose 130, 0x4209, 0x50d4, 0x3c2c
+ax_pose 131, 0x4211, 0x10dc, 0x3c30
+ax_pose 132, 0x41c9, 0x90e3, 0x3c32
+ax_pose 133, 0x01d0, 0x10db, 0x3c3a
+ax_pose 134, 0x41c1, 0x10f3, 0x3c3b
+ax_pose 135, 0x01f9, 0x1104, 0x3c3d
+ax_pose_terminator
+sRayquazaPose60:
+ax_pose 136, 0x01eb, 0x90d8, 0x3c00
+ax_pose 137, 0x41eb, 0x90f8, 0x3c10
+ax_pose 138, 0x41fb, 0x10f8, 0x3c18
+ax_pose 139, 0x01fb, 0x1108, 0x3c1a
+ax_pose 140, 0x420b, 0x50d8, 0x3c1b
+ax_pose 141, 0x4213, 0x10e0, 0x3c1f
+ax_pose 142, 0x81cb, 0x5110, 0x3c21
+ax_pose 143, 0x81db, 0x1108, 0x3c25
+ax_pose 144, 0x81cb, 0x9118, 0x3c27
+ax_pose 145, 0x81d3, 0x1128, 0x3c2f
+ax_pose 146, 0x41eb, 0x1118, 0x3c31
+ax_pose 147, 0x01eb, 0x50c8, 0x3c33
+ax_pose 148, 0x81fb, 0x10d0, 0x3c37
+ax_pose 149, 0x41e3, 0x10c8, 0x3c39
+ax_pose_terminator
+sRayquazaPose61:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose62:
+ax_pose 150, 0x81da, 0xc0f8, 0x3c00
+ax_pose 151, 0x81da, 0x80e8, 0x3c20
+ax_pose 152, 0x81fa, 0x80e8, 0x3c28
+ax_pose 153, 0x81f2, 0x00e0, 0x3c30
+ax_pose 154, 0x01ca, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaPose63:
+ax_pose 155, 0x81c6, 0xc0f8, 0x3c00
+ax_pose 156, 0x81c6, 0x40f0, 0x3c20
+ax_pose 157, 0x81d6, 0x00e8, 0x3c24
+ax_pose 158, 0x01e6, 0x00f0, 0x3c26
+ax_pose 159, 0x0206, 0x40f9, 0x3c27
+ax_pose 160, 0x0206, 0x40e9, 0x3c2b
+ax_pose 161, 0x020c, 0x40d9, 0x3c2f
+ax_pose 162, 0x4216, 0x40e9, 0x3c33
+ax_pose_terminator
+sRayquazaPose64:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose65:
+ax_pose 127, 0x41d9, 0xc0f0, 0x3c00
+ax_pose 128, 0x41f9, 0x8110, 0x3c20
+ax_pose 129, 0x01f9, 0x4100, 0x3c28
+ax_pose 130, 0x4209, 0x4110, 0x3c2c
+ax_pose 131, 0x4211, 0x0118, 0x3c30
+ax_pose 132, 0x41c9, 0x8101, 0x3c32
+ax_pose 133, 0x01d0, 0x0121, 0x3c3a
+ax_pose 134, 0x41c1, 0x0101, 0x3c3b
+ax_pose 135, 0x01f9, 0x00f8, 0x3c3d
+ax_pose_terminator
+sRayquazaPose66:
+ax_pose 136, 0x01eb, 0x810c, 0x3c00
+ax_pose 137, 0x41eb, 0x80ec, 0x3c10
+ax_pose 138, 0x41fb, 0x00fc, 0x3c18
+ax_pose 139, 0x01fb, 0x00f4, 0x3c1a
+ax_pose 140, 0x420b, 0x410c, 0x3c1b
+ax_pose 141, 0x4213, 0x0114, 0x3c1f
+ax_pose 142, 0x81cb, 0x40ec, 0x3c21
+ax_pose 143, 0x81db, 0x00f4, 0x3c25
+ax_pose 144, 0x81cb, 0x80dc, 0x3c27
+ax_pose 145, 0x81d3, 0x00d4, 0x3c2f
+ax_pose 146, 0x41eb, 0x00dc, 0x3c31
+ax_pose 147, 0x01eb, 0x412c, 0x3c33
+ax_pose 148, 0x81fb, 0x012c, 0x3c37
+ax_pose 149, 0x41e3, 0x012c, 0x3c39
+ax_pose_terminator
+sRayquazaPose67:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose68:
+ax_pose 114, 0x01c5, 0xc0ef, 0x3c00
+ax_pose_terminator
+sRayquazaPose69:
+ax_pose 115, 0x01e6, 0x80e9, 0x3c00
+ax_pose 116, 0x41e6, 0x8109, 0x3c10
+ax_pose 117, 0x41f6, 0x4109, 0x3c18
+ax_pose 118, 0x01d6, 0x80c9, 0x3c1c
+ax_pose 119, 0x01f6, 0x40d9, 0x3c2c
+ax_pose 120, 0x41f6, 0x00c9, 0x3c30
+ax_pose 121, 0x01f6, 0x00c1, 0x3c32
+ax_pose 122, 0x01ee, 0x00c1, 0x3c33
+ax_pose 123, 0x81d6, 0x0121, 0x3c34
+ax_pose 124, 0x01d6, 0x4129, 0x3c36
+ax_pose 125, 0x81e6, 0x0129, 0x3c3a
+ax_pose 126, 0x01c6, 0x4129, 0x3c3c
+ax_pose_terminator
+sRayquazaPose70:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose71:
+ax_pose 104, 0x01c5, 0xc0e8, 0x3c00
+ax_pose_terminator
+sRayquazaPose72:
+ax_pose 105, 0x01f5, 0x80d5, 0x3c00
+ax_pose 106, 0x41ed, 0x40d5, 0x3c10
+ax_pose 107, 0x01e5, 0x80f5, 0x3c14
+ax_pose 108, 0x8205, 0x00f5, 0x3c24
+ax_pose 109, 0x81fd, 0x00cd, 0x3c26
+ax_pose 110, 0x01e5, 0x4115, 0x3c28
+ax_pose 111, 0x01d5, 0x4115, 0x3c2c
+ax_pose 112, 0x01c5, 0x4116, 0x3c30
+ax_pose 113, 0x81c5, 0x0126, 0x3c34
+ax_pose_terminator
+sRayquazaPose73:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose74:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaPose75:
+ax_pose 163, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 164, 0x81e8, 0x80e8, 0x3c20
+ax_pose 165, 0x01e0, 0x00f0, 0x3c28
+ax_pose 166, 0x41c0, 0x00f8, 0x3c29
+ax_pose_terminator
+sRayquazaPose76:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose77:
+ax_pose 104, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaPose78:
+ax_pose 167, 0x41e8, 0xd0de, 0x3c00
+ax_pose 168, 0x81d8, 0x911e, 0x3c20
+ax_pose 169, 0x41f8, 0x111e, 0x3c28
+ax_pose 170, 0x41e0, 0x110e, 0x3c2a
+ax_pose 171, 0x01c8, 0x90de, 0x3c2c
+ax_pose_terminator
+sRayquazaPose79:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose80:
+ax_pose 114, 0x01c5, 0xd0d1, 0x3c00
+ax_pose_terminator
+sRayquazaPose81:
+ax_pose 172, 0x41e5, 0xd0d9, 0x3c00
+ax_pose 173, 0x81d5, 0x9119, 0x3c20
+ax_pose 174, 0x81d5, 0x5129, 0x3c28
+ax_pose 175, 0x81dd, 0x1131, 0x3c2c
+ax_pose 176, 0x01cd, 0x1119, 0x3c2e
+ax_pose 177, 0x81d5, 0x1111, 0x3c2f
+ax_pose 178, 0x01cd, 0x1111, 0x3c31
+ax_pose 179, 0x01dd, 0x1109, 0x3c32
+ax_pose 180, 0x81c5, 0x90d9, 0x3c33
+ax_pose_terminator
+sRayquazaPose82:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose83:
+ax_pose 127, 0x41d9, 0xd0d4, 0x3c00
+ax_pose 128, 0x41f9, 0x90d4, 0x3c20
+ax_pose 129, 0x01f9, 0x50f4, 0x3c28
+ax_pose 130, 0x4209, 0x50d4, 0x3c2c
+ax_pose 131, 0x4211, 0x10dc, 0x3c30
+ax_pose 132, 0x41c9, 0x90e3, 0x3c32
+ax_pose 133, 0x01d0, 0x10db, 0x3c3a
+ax_pose 134, 0x41c1, 0x10f3, 0x3c3b
+ax_pose 135, 0x01f9, 0x1104, 0x3c3d
+ax_pose_terminator
+sRayquazaPose84:
+ax_pose 181, 0x01d6, 0x90f6, 0x3c00
+ax_pose 182, 0x01f6, 0x90d6, 0x3c10
+ax_pose 183, 0x01f6, 0x50f6, 0x3c20
+ax_pose 184, 0x41c6, 0x9106, 0x3c24
+ax_pose 185, 0x01d6, 0x5116, 0x3c2c
+ax_pose 186, 0x41e6, 0x1116, 0x3c30
+ax_pose 187, 0x81d6, 0x90d6, 0x3c32
+ax_pose 188, 0x81d6, 0x10ce, 0x3c3a
+ax_pose 189, 0x01f6, 0x1106, 0x3c3c
+ax_pose_terminator
+sRayquazaPose85:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose86:
+ax_pose 150, 0x81da, 0xc0f8, 0x3c00
+ax_pose 151, 0x81da, 0x80e8, 0x3c20
+ax_pose 152, 0x81fa, 0x80e8, 0x3c28
+ax_pose 153, 0x81f2, 0x00e0, 0x3c30
+ax_pose 154, 0x01ca, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaPose87:
+ax_pose 190, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 191, 0x81c8, 0x80e9, 0x3c20
+ax_pose 192, 0x81e8, 0x80e9, 0x3c28
+ax_pose 193, 0x0208, 0x40f9, 0x3c30
+ax_pose 194, 0x0208, 0x40e9, 0x3c34
+ax_pose_terminator
+sRayquazaPose88:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose89:
+ax_pose 127, 0x41d9, 0xc0f0, 0x3c00
+ax_pose 128, 0x41f9, 0x8110, 0x3c20
+ax_pose 129, 0x01f9, 0x4100, 0x3c28
+ax_pose 130, 0x4209, 0x4110, 0x3c2c
+ax_pose 131, 0x4211, 0x0118, 0x3c30
+ax_pose 132, 0x41c9, 0x8101, 0x3c32
+ax_pose 133, 0x01d0, 0x0121, 0x3c3a
+ax_pose 134, 0x41c1, 0x0101, 0x3c3b
+ax_pose 135, 0x01f9, 0x00f8, 0x3c3d
+ax_pose_terminator
+sRayquazaPose90:
+ax_pose 181, 0x01d6, 0x80ee, 0x3c00
+ax_pose 182, 0x01f6, 0x810e, 0x3c10
+ax_pose 183, 0x01f6, 0x40fe, 0x3c20
+ax_pose 184, 0x41c6, 0x80de, 0x3c24
+ax_pose 185, 0x01d6, 0x40de, 0x3c2c
+ax_pose 186, 0x41e6, 0x00de, 0x3c30
+ax_pose 187, 0x81d6, 0x811e, 0x3c32
+ax_pose 188, 0x81d6, 0x012e, 0x3c3a
+ax_pose 189, 0x01f6, 0x00f6, 0x3c3c
+ax_pose_terminator
+sRayquazaPose91:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose92:
+ax_pose 114, 0x01c5, 0xc0ef, 0x3c00
+ax_pose_terminator
+sRayquazaPose93:
+ax_pose 172, 0x41e5, 0xc0e7, 0x3c00
+ax_pose 173, 0x81d5, 0x80d7, 0x3c20
+ax_pose 174, 0x81d5, 0x40cf, 0x3c28
+ax_pose 175, 0x81dd, 0x00c7, 0x3c2c
+ax_pose 176, 0x01cd, 0x00df, 0x3c2e
+ax_pose 177, 0x81d5, 0x00e7, 0x3c2f
+ax_pose 178, 0x01cd, 0x00e7, 0x3c31
+ax_pose 179, 0x01dd, 0x00ef, 0x3c32
+ax_pose 180, 0x81c5, 0x8117, 0x3c33
+ax_pose_terminator
+sRayquazaPose94:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose95:
+ax_pose 104, 0x01c5, 0xc0e8, 0x3c00
+ax_pose_terminator
+sRayquazaPose96:
+ax_pose 167, 0x41e8, 0xc0e2, 0x3c00
+ax_pose 168, 0x81d8, 0x80d2, 0x3c20
+ax_pose 169, 0x41f8, 0x00d2, 0x3c28
+ax_pose 170, 0x41e0, 0x00e2, 0x3c2a
+ax_pose 171, 0x01c8, 0x8102, 0x3c2c
+ax_pose_terminator
+sRayquazaPose97:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose98:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaPose99:
+ax_pose 195, 0x81c4, 0xc0eb, 0x3c00
+ax_pose 196, 0x81c4, 0x810b, 0x3c20
+ax_pose 197, 0x01e4, 0x410b, 0x3c28
+ax_pose 198, 0x4204, 0x00f4, 0x3c2c
+ax_pose_terminator
+sRayquazaPose100:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose101:
+ax_pose 104, 0x01c9, 0xd0dc, 0x3c00
+ax_pose_terminator
+sRayquazaPose102:
+ax_pose 199, 0x01b6, 0x50fc, 0x3c00
+ax_pose 200, 0x41c6, 0xd0de, 0x3c04
+ax_pose 201, 0x01e6, 0x90de, 0x3c24
+ax_pose 202, 0x81e6, 0x90fe, 0x3c34
+ax_pose_terminator
+sRayquazaPose103:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose104:
+ax_pose 114, 0x01c5, 0xd0d5, 0x3c00
+ax_pose_terminator
+sRayquazaPose105:
+ax_pose 203, 0x81bf, 0x90db, 0x3c00
+ax_pose 204, 0x81df, 0x90db, 0x3c08
+ax_pose 205, 0x01ef, 0x50eb, 0x3c10
+ax_pose 206, 0x01e7, 0x10f3, 0x3c14
+ax_pose 207, 0x81bf, 0xd0fb, 0x3c15
+ax_pose 208, 0x01af, 0x50fb, 0x3c35
+ax_pose 209, 0x81c7, 0x10f3, 0x3c39
+ax_pose_terminator
+sRayquazaPose106:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose107:
+ax_pose 127, 0x41d7, 0xd0dc, 0x3c00
+ax_pose 128, 0x41f7, 0x90dc, 0x3c20
+ax_pose 129, 0x01f7, 0x50fc, 0x3c28
+ax_pose 130, 0x4207, 0x50dc, 0x3c2c
+ax_pose 131, 0x420f, 0x10e4, 0x3c30
+ax_pose 132, 0x41c7, 0x90eb, 0x3c32
+ax_pose 133, 0x01ce, 0x10e3, 0x3c3a
+ax_pose 134, 0x41bf, 0x10fb, 0x3c3b
+ax_pose 135, 0x01f7, 0x110c, 0x3c3d
+ax_pose_terminator
+sRayquazaPose108:
+ax_pose 210, 0x81b5, 0xd0f4, 0x3c00
+ax_pose 211, 0x01f5, 0x90e0, 0x3c20
+ax_pose 212, 0x81d5, 0x90e4, 0x3c30
+ax_pose 213, 0x01dd, 0x10dc, 0x3c38
+ax_pose 214, 0x01f5, 0x1100, 0x3c39
+ax_pose 215, 0x01c6, 0x10ec, 0x3c3a
+ax_pose_terminator
+sRayquazaPose109:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose110:
+ax_pose 150, 0x81cf, 0xc0f8, 0x3c00
+ax_pose 151, 0x81cf, 0x80e8, 0x3c20
+ax_pose 152, 0x81ef, 0x80e8, 0x3c28
+ax_pose 153, 0x81e7, 0x00e0, 0x3c30
+ax_pose 154, 0x01bf, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaPose111:
+ax_pose 216, 0x81bf, 0xc0f3, 0x3c00
+ax_pose 217, 0x81df, 0x40eb, 0x3c20
+ax_pose 218, 0x81cf, 0x00eb, 0x3c24
+ax_pose 219, 0x41ff, 0x80f3, 0x3c26
+ax_pose_terminator
+sRayquazaPose112:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose113:
+ax_pose 127, 0x41d7, 0xc0e6, 0x3c00
+ax_pose 128, 0x41f7, 0x8106, 0x3c20
+ax_pose 129, 0x01f7, 0x40f6, 0x3c28
+ax_pose 130, 0x4207, 0x4106, 0x3c2c
+ax_pose 131, 0x420f, 0x010e, 0x3c30
+ax_pose 132, 0x41c7, 0x80f7, 0x3c32
+ax_pose 133, 0x01ce, 0x0117, 0x3c3a
+ax_pose 134, 0x41bf, 0x00f7, 0x3c3b
+ax_pose 135, 0x01f7, 0x00ee, 0x3c3d
+ax_pose_terminator
+sRayquazaPose114:
+ax_pose 210, 0x81b5, 0xc0ee, 0x3c00
+ax_pose 211, 0x01f5, 0x8102, 0x3c20
+ax_pose 212, 0x81d5, 0x810e, 0x3c30
+ax_pose 213, 0x01dd, 0x011e, 0x3c38
+ax_pose 214, 0x01f5, 0x00fa, 0x3c39
+ax_pose 215, 0x01c6, 0x010e, 0x3c3a
+ax_pose_terminator
+sRayquazaPose115:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose116:
+ax_pose 114, 0x01c5, 0xc0eb, 0x3c00
+ax_pose_terminator
+sRayquazaPose117:
+ax_pose 203, 0x81bf, 0x8115, 0x3c00
+ax_pose 204, 0x81df, 0x8115, 0x3c08
+ax_pose 205, 0x01ef, 0x4105, 0x3c10
+ax_pose 206, 0x01e7, 0x0105, 0x3c14
+ax_pose 207, 0x81bf, 0xc0e5, 0x3c15
+ax_pose 208, 0x01af, 0x40f5, 0x3c35
+ax_pose 209, 0x81c7, 0x0105, 0x3c39
+ax_pose_terminator
+sRayquazaPose118:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose119:
+ax_pose 104, 0x01c9, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaPose120:
+ax_pose 199, 0x01b6, 0x40f4, 0x3c00
+ax_pose 200, 0x41c6, 0xc0e2, 0x3c04
+ax_pose 201, 0x01e6, 0x8102, 0x3c24
+ax_pose 202, 0x81e6, 0x80f2, 0x3c34
+ax_pose_terminator
+sRayquazaPose121:
+ax_pose 220, 0x01ca, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaPose122:
+ax_pose 221, 0x01ca, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaPose123:
+ax_pose 222, 0x01be, 0xc0e2, 0x3c00
+ax_pose_terminator
+sRayquazaPose124:
+ax_pose 223, 0x01c0, 0xd0e0, 0x3c00
+ax_pose_terminator
+sRayquazaPose125:
+ax_pose 224, 0x01bd, 0xd0dc, 0x3c00
+ax_pose_terminator
+sRayquazaPose126:
+ax_pose 225, 0x01c1, 0xd0da, 0x3c00
+ax_pose_terminator
+sRayquazaPose127:
+ax_pose 226, 0x81c7, 0x410c, 0x3c00
+ax_pose 227, 0x41bf, 0x00f8, 0x3c04
+ax_pose 228, 0x01df, 0x0114, 0x3c06
+ax_pose 229, 0x81e7, 0x810c, 0x3c07
+ax_pose 230, 0x81c7, 0xc0ec, 0x3c0f
+ax_pose_terminator
+sRayquazaPose128:
+ax_pose 225, 0x01c1, 0xc0e6, 0x3c00
+ax_pose_terminator
+sRayquazaPose129:
+ax_pose 224, 0x01bd, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaPose130:
+ax_pose 223, 0x01c0, 0xc0e0, 0x3c00
+ax_pose_terminator
+sRayquazaPose131:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose132:
+ax_pose 4, 0x81c3, 0xc0f1, 0x3c00
+ax_pose 5, 0x81e3, 0x80e1, 0x3c20
+ax_pose 6, 0x4203, 0x00f1, 0x3c28
+ax_pose 7, 0x01e3, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaPose133:
+ax_pose 8, 0x81c2, 0xc0f1, 0x3c00
+ax_pose 9, 0x81e2, 0x80e1, 0x3c20
+ax_pose 10, 0x4202, 0x00f1, 0x3c28
+ax_pose 11, 0x01e2, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaPose134:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose135:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaPose136:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaPose137:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose138:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaPose139:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose140:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose141:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaPose142:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaPose143:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose144:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaPose145:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaPose146:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose147:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaPose148:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaPose149:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose150:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaPose151:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaPose152:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose153:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaPose154:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaPose155:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose156:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose157:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose158:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose159:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose160:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose161:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose162:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose163:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaPose164:
+ax_pose 104, 0x01c5, 0xd0e0, 0x3c00
+ax_pose_terminator
+sRayquazaPose165:
+ax_pose 114, 0x01c3, 0xd0df, 0x3c00
+ax_pose_terminator
+sRayquazaPose166:
+ax_pose 127, 0x41d5, 0xd0e2, 0x3c00
+ax_pose 128, 0x41f5, 0x90e2, 0x3c20
+ax_pose 129, 0x01f5, 0x5102, 0x3c28
+ax_pose 130, 0x4205, 0x50e2, 0x3c2c
+ax_pose 131, 0x420d, 0x10ea, 0x3c30
+ax_pose 132, 0x41c5, 0x90f1, 0x3c32
+ax_pose 133, 0x01cc, 0x10e9, 0x3c3a
+ax_pose 134, 0x41bd, 0x1101, 0x3c3b
+ax_pose 135, 0x01f5, 0x1112, 0x3c3d
+ax_pose_terminator
+sRayquazaPose167:
+ax_pose 150, 0x81cc, 0xc0f8, 0x3c00
+ax_pose 151, 0x81cc, 0x80e8, 0x3c20
+ax_pose 152, 0x81ec, 0x80e8, 0x3c28
+ax_pose 153, 0x81e4, 0x00e0, 0x3c30
+ax_pose 154, 0x01bc, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaPose168:
+ax_pose 127, 0x41d5, 0xc0de, 0x3c00
+ax_pose 128, 0x41f5, 0x80fe, 0x3c20
+ax_pose 129, 0x01f5, 0x40ee, 0x3c28
+ax_pose 130, 0x4205, 0x40fe, 0x3c2c
+ax_pose 131, 0x420d, 0x0106, 0x3c30
+ax_pose 132, 0x41c5, 0x80ef, 0x3c32
+ax_pose 133, 0x01cc, 0x010f, 0x3c3a
+ax_pose 134, 0x41bd, 0x00ef, 0x3c3b
+ax_pose 135, 0x01f5, 0x00e6, 0x3c3d
+ax_pose_terminator
+sRayquazaPose169:
+ax_pose 114, 0x01c3, 0xc0e1, 0x3c00
+ax_pose_terminator
+sRayquazaPose170:
+ax_pose 104, 0x01c5, 0xc0e0, 0x3c00
+ax_pose_terminator
+sRayquazaPose171:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose172:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaPose173:
+ax_pose 195, 0x81be, 0xc0eb, 0x3c00
+ax_pose 196, 0x81be, 0x810b, 0x3c20
+ax_pose 197, 0x01de, 0x410b, 0x3c28
+ax_pose 198, 0x41fe, 0x00f4, 0x3c2c
+ax_pose_terminator
+sRayquazaPose174:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose175:
+ax_pose 104, 0x01c6, 0xd0dc, 0x3c00
+ax_pose_terminator
+sRayquazaPose176:
+ax_pose 199, 0x01b3, 0x50fc, 0x3c00
+ax_pose 200, 0x41c3, 0xd0de, 0x3c04
+ax_pose 201, 0x01e3, 0x90de, 0x3c24
+ax_pose 202, 0x81e3, 0x90fe, 0x3c34
+ax_pose_terminator
+sRayquazaPose177:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose178:
+ax_pose 114, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaPose179:
+ax_pose 203, 0x81bf, 0x90db, 0x3c00
+ax_pose 204, 0x81df, 0x90db, 0x3c08
+ax_pose 205, 0x01ef, 0x50eb, 0x3c10
+ax_pose 206, 0x01e7, 0x10f3, 0x3c14
+ax_pose 207, 0x81bf, 0xd0fb, 0x3c15
+ax_pose 208, 0x01af, 0x50fb, 0x3c35
+ax_pose 209, 0x81c7, 0x10f3, 0x3c39
+ax_pose_terminator
+sRayquazaPose180:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose181:
+ax_pose 127, 0x41d7, 0xd0dc, 0x3c00
+ax_pose 128, 0x41f7, 0x90dc, 0x3c20
+ax_pose 129, 0x01f7, 0x50fc, 0x3c28
+ax_pose 130, 0x4207, 0x50dc, 0x3c2c
+ax_pose 131, 0x420f, 0x10e4, 0x3c30
+ax_pose 132, 0x41c7, 0x90eb, 0x3c32
+ax_pose 133, 0x01ce, 0x10e3, 0x3c3a
+ax_pose 134, 0x41bf, 0x10fb, 0x3c3b
+ax_pose 135, 0x01f7, 0x110c, 0x3c3d
+ax_pose_terminator
+sRayquazaPose182:
+ax_pose 210, 0x81b5, 0xd0f4, 0x3c00
+ax_pose 211, 0x01f5, 0x90e0, 0x3c20
+ax_pose 212, 0x81d5, 0x90e4, 0x3c30
+ax_pose 213, 0x01dd, 0x10dc, 0x3c38
+ax_pose 214, 0x01f5, 0x1100, 0x3c39
+ax_pose 215, 0x01c6, 0x10ec, 0x3c3a
+ax_pose_terminator
+sRayquazaPose183:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose184:
+ax_pose 150, 0x81cf, 0xc0f8, 0x3c00
+ax_pose 151, 0x81cf, 0x80e8, 0x3c20
+ax_pose 152, 0x81ef, 0x80e8, 0x3c28
+ax_pose 153, 0x81e7, 0x00e0, 0x3c30
+ax_pose 154, 0x01bf, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaPose185:
+ax_pose 216, 0x81bf, 0xc0f3, 0x3c00
+ax_pose 217, 0x81df, 0x40eb, 0x3c20
+ax_pose 218, 0x81cf, 0x00eb, 0x3c24
+ax_pose 219, 0x41ff, 0x80f3, 0x3c26
+ax_pose_terminator
+sRayquazaPose186:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose187:
+ax_pose 127, 0x41d7, 0xc0e6, 0x3c00
+ax_pose 128, 0x41f7, 0x8106, 0x3c20
+ax_pose 129, 0x01f7, 0x40f6, 0x3c28
+ax_pose 130, 0x4207, 0x4106, 0x3c2c
+ax_pose 131, 0x420f, 0x010e, 0x3c30
+ax_pose 132, 0x41c7, 0x80f7, 0x3c32
+ax_pose 133, 0x01ce, 0x0117, 0x3c3a
+ax_pose 134, 0x41bf, 0x00f7, 0x3c3b
+ax_pose 135, 0x01f7, 0x00ee, 0x3c3d
+ax_pose_terminator
+sRayquazaPose188:
+ax_pose 210, 0x81b5, 0xc0ee, 0x3c00
+ax_pose 211, 0x01f5, 0x8102, 0x3c20
+ax_pose 212, 0x81d5, 0x810e, 0x3c30
+ax_pose 213, 0x01dd, 0x011e, 0x3c38
+ax_pose 214, 0x01f5, 0x00fa, 0x3c39
+ax_pose 215, 0x01c6, 0x010e, 0x3c3a
+ax_pose_terminator
+sRayquazaPose189:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose190:
+ax_pose 114, 0x01c5, 0xc0e9, 0x3c00
+ax_pose_terminator
+sRayquazaPose191:
+ax_pose 203, 0x81bf, 0x8115, 0x3c00
+ax_pose 204, 0x81df, 0x8115, 0x3c08
+ax_pose 205, 0x01ef, 0x4105, 0x3c10
+ax_pose 206, 0x01e7, 0x0105, 0x3c14
+ax_pose 207, 0x81bf, 0xc0e5, 0x3c15
+ax_pose 208, 0x01af, 0x40f5, 0x3c35
+ax_pose 209, 0x81c7, 0x0105, 0x3c39
+ax_pose_terminator
+sRayquazaPose192:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose193:
+ax_pose 104, 0x01c9, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaPose194:
+ax_pose 199, 0x01b6, 0x40f4, 0x3c00
+ax_pose 200, 0x41c6, 0xc0e2, 0x3c04
+ax_pose 201, 0x01e6, 0x8102, 0x3c24
+ax_pose 202, 0x81e6, 0x80f2, 0x3c34
+ax_pose_terminator
+sRayquazaPose195:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose196:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose197:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose198:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose199:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose200:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose201:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose202:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaPose203:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaPose204:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaPose205:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaPose206:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaPose207:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaPose208:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaPose209:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaPose210:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+.align 2
+sRayquazaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 8, 0, 2, 0, -5, 0, 0,
+ax_anim 8, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 0, 0, -4, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 8, 0, 5, 0, -5, 0, 0,
+ax_anim 8, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 0, -4, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -4, 0, 0,
+ax_anim 8, 0, 8, 0, -5, 0, 0,
+ax_anim 8, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 6, 0, -4, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim 8, 0, 11, 0, -5, 0, 0,
+ax_anim 8, 0, 10, 0, -5, 0, 0,
+ax_anim 6, 0, 9, 0, -4, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -4, 0, 0,
+ax_anim 8, 0, 14, 0, -5, 0, 0,
+ax_anim 8, 0, 13, 0, -5, 0, 0,
+ax_anim 6, 0, 12, 0, -4, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 4, 0, 17, 0, -3, 0, 0,
+ax_anim 4, 0, 17, 0, -4, 0, 0,
+ax_anim 8, 0, 17, 0, -5, 0, 0,
+ax_anim 8, 0, 16, 0, -5, 0, 0,
+ax_anim 6, 0, 15, 0, -4, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 4, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -4, 0, 0,
+ax_anim 8, 0, 20, 0, -5, 0, 0,
+ax_anim 8, 0, 19, 0, -5, 0, 0,
+ax_anim 6, 0, 18, 0, -4, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 4, 0, 23, 0, -3, 0, 0,
+ax_anim 4, 0, 23, 0, -4, 0, 0,
+ax_anim 8, 0, 23, 0, -5, 0, 0,
+ax_anim 8, 0, 22, 0, -5, 0, 0,
+ax_anim 6, 0, 21, 0, -4, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 1, 0, 1,
+ax_anim 1, 0, 26, 0, 6, 0, 6,
+ax_anim 2, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 1, 26, 1, 12, 1, 12,
+ax_anim 2, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 26, 1, 12, 1, 12,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRayquazaAnims_2_2:
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 4, 0, 28, -3, -3, -3, -3,
+ax_anim 1, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 2, 29, -4, 1, 0, 1,
+ax_anim 1, 0, 29, -3, 6, 4, 6,
+ax_anim 2, 0, 29, -2, 12, 9, 12,
+ax_anim 2, 1, 29, -1, 11, 10, 11,
+ax_anim 2, 0, 29, -2, 12, 9, 12,
+ax_anim 2, 0, 29, -1, 11, 10, 11,
+ax_anim 2, 0, 27, 3, 6, 4, 6,
+ax_anim_terminator
+sRayquazaAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -7, 0, -7, 0,
+ax_anim 1, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 2, 32, -29, -17, -2, 0,
+ax_anim 1, 0, 32, -19, -6, 2, 0,
+ax_anim 2, 0, 32, -15, 0, 8, 0,
+ax_anim 2, 1, 32, -15, 1, 8, 1,
+ax_anim 2, 0, 32, -15, 0, 8, 0,
+ax_anim 2, 0, 32, -15, 1, 8, 1,
+ax_anim 2, 0, 30, 2, 0, 4, 0,
+ax_anim_terminator
+sRayquazaAnims_2_4:
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 4, 0, 34, -7, 7, -7, 7,
+ax_anim 1, 0, 34, -4, 4, -4, 4,
+ax_anim 1, 2, 35, -18, -15, 4, -8,
+ax_anim 1, 0, 35, -12, -14, 7, -11,
+ax_anim 2, 0, 35, -5, -13, 11, -16,
+ax_anim 2, 1, 35, -4, -12, 12, -15,
+ax_anim 2, 0, 35, -5, -13, 11, -16,
+ax_anim 2, 0, 35, -4, -12, 12, -15,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sRayquazaAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, 6, 0, -1,
+ax_anim 1, 0, 38, 0, 2, 0, -6,
+ax_anim 2, 0, 38, 0, -1, 0, -12,
+ax_anim 2, 1, 38, 1, -1, 1, -12,
+ax_anim 2, 0, 38, 0, -1, 0, -12,
+ax_anim 2, 0, 38, 1, -1, 1, -12,
+ax_anim 2, 0, 36, 0, -1, 0, -6,
+ax_anim_terminator
+sRayquazaAnims_2_6:
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 4, 0, 40, 7, 7, 7, 7,
+ax_anim 1, 0, 40, 4, 4, 4, 4,
+ax_anim 1, 2, 41, 18, -15, -4, -8,
+ax_anim 1, 0, 41, 12, -14, -7, -11,
+ax_anim 2, 0, 41, 5, -13, -11, -16,
+ax_anim 2, 1, 41, 4, -12, -12, -15,
+ax_anim 2, 0, 41, 5, -13, -11, -16,
+ax_anim 2, 0, 41, 4, -12, -12, -15,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sRayquazaAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 7, 0, 7, 0,
+ax_anim 1, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 2, 44, 29, -17, 2, 0,
+ax_anim 1, 0, 44, 19, -6, -2, 0,
+ax_anim 2, 0, 44, 15, 0, -8, 0,
+ax_anim 2, 1, 44, 15, 1, -8, 1,
+ax_anim 2, 0, 44, 15, 0, -8, 0,
+ax_anim 2, 0, 44, 15, 1, -8, 1,
+ax_anim 2, 0, 42, -2, 0, -4, 0,
+ax_anim_terminator
+sRayquazaAnims_2_8:
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 4, 0, 46, 3, -3, 3, -3,
+ax_anim 1, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 2, 47, 4, 1, 0, 1,
+ax_anim 1, 0, 47, 3, 6, -4, 6,
+ax_anim 2, 0, 47, 2, 12, -9, 12,
+ax_anim 2, 1, 47, 1, 11, -10, 11,
+ax_anim 2, 0, 47, 2, 12, -9, 12,
+ax_anim 2, 0, 47, 1, 11, -10, 11,
+ax_anim 2, 0, 45, -3, 6, -4, 6,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 3, 0, 3,
+ax_anim 1, 0, 50, 0, 12, 0, 12,
+ax_anim 2, 0, 50, 0, 37, 0, 37,
+ax_anim 2, 1, 50, 1, 37, 1, 37,
+ax_anim 2, 0, 50, 0, 37, 0, 37,
+ax_anim 2, 0, 50, 1, 37, 1, 37,
+ax_anim 2, 0, 48, 0, 16, 0, 16,
+ax_anim 1, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sRayquazaAnims_3_2:
+ax_anim 2, 0, 51, -2, -2, -2, -2,
+ax_anim 4, 0, 52, -3, -3, -3, -3,
+ax_anim 1, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 2, 53, 2, 4, 2, 4,
+ax_anim 1, 0, 53, 11, 19, 11, 19,
+ax_anim 2, 0, 53, 22, 36, 22, 36,
+ax_anim 2, 1, 53, 23, 35, 23, 35,
+ax_anim 2, 0, 53, 22, 36, 22, 36,
+ax_anim 2, 0, 53, 23, 35, 23, 35,
+ax_anim 2, 0, 51, 14, 23, 14, 23,
+ax_anim 1, 0, 51, 6, 10, 6, 10,
+ax_anim_terminator
+sRayquazaAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 55, -7, 0, -7, 0,
+ax_anim 1, 0, 55, -4, 0, -4, 0,
+ax_anim 1, 2, 56, -19, -20, 1, 0,
+ax_anim 1, 0, 56, -1, -10, 11, 0,
+ax_anim 2, 0, 56, 9, 0, 22, 0,
+ax_anim 2, 1, 56, 9, 1, 22, 1,
+ax_anim 2, 0, 56, 9, 0, 22, 0,
+ax_anim 2, 0, 56, 9, 1, 22, 1,
+ax_anim 2, 0, 54, 18, 3, 18, 0,
+ax_anim 1, 0, 54, 6, 1, 6, 0,
+ax_anim_terminator
+sRayquazaAnims_3_4:
+ax_anim 2, 0, 57, -2, 2, -2, 2,
+ax_anim 4, 0, 58, -7, 7, -7, 7,
+ax_anim 1, 0, 58, -4, 4, -4, 4,
+ax_anim 1, 2, 59, -16, -19, 2, -4,
+ax_anim 1, 0, 59, 3, -29, 12, -19,
+ax_anim 2, 0, 59, 19, -37, 27, -39,
+ax_anim 2, 1, 59, 20, -36, 28, -38,
+ax_anim 2, 0, 59, 19, -37, 27, -39,
+ax_anim 2, 0, 59, 20, -36, 28, -38,
+ax_anim 2, 0, 57, 12, -16, 12, -16,
+ax_anim 1, 0, 57, 4, -6, 4, -6,
+ax_anim_terminator
+sRayquazaAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -1, 0, -1,
+ax_anim 1, 0, 62, 0, -14, 0, -14,
+ax_anim 2, 0, 62, 0, -28, 0, -28,
+ax_anim 2, 1, 62, 1, -28, 1, -28,
+ax_anim 2, 0, 62, 0, -28, 0, -28,
+ax_anim 2, 0, 62, 1, -28, 1, -28,
+ax_anim 2, 0, 60, 0, -13, 0, -13,
+ax_anim 1, 0, 60, 0, -5, 0, -5,
+ax_anim_terminator
+sRayquazaAnims_3_6:
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 4, 0, 64, 7, 7, 7, 7,
+ax_anim 1, 0, 64, 4, 4, 4, 4,
+ax_anim 1, 2, 65, 16, -19, -2, -4,
+ax_anim 1, 0, 65, -3, -29, -12, -19,
+ax_anim 2, 0, 65, -19, -37, -27, -39,
+ax_anim 2, 1, 65, -20, -36, -28, -38,
+ax_anim 2, 0, 65, -19, -37, -27, -39,
+ax_anim 2, 0, 65, -20, -36, -28, -38,
+ax_anim 2, 0, 63, -12, -16, -12, -16,
+ax_anim 1, 0, 63, -4, -6, -4, -6,
+ax_anim_terminator
+sRayquazaAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 67, 7, 0, 7, 0,
+ax_anim 1, 0, 67, 4, 0, 4, 0,
+ax_anim 1, 2, 68, 19, -20, -1, 0,
+ax_anim 1, 0, 68, 1, -10, -11, 0,
+ax_anim 2, 0, 68, -9, 0, -22, 0,
+ax_anim 2, 1, 68, -9, 1, -22, 1,
+ax_anim 2, 0, 68, -9, 0, -22, 0,
+ax_anim 2, 0, 68, -9, 1, -22, 1,
+ax_anim 2, 0, 66, -18, 3, -18, 0,
+ax_anim 1, 0, 66, -6, 1, -6, 0,
+ax_anim_terminator
+sRayquazaAnims_3_8:
+ax_anim 2, 0, 69, 2, -2, 2, -2,
+ax_anim 4, 0, 70, 3, -3, 3, -3,
+ax_anim 1, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 2, 71, -2, 4, -2, 4,
+ax_anim 1, 0, 71, -11, 19, -11, 19,
+ax_anim 2, 0, 71, -22, 36, -22, 36,
+ax_anim 2, 1, 71, -23, 35, -23, 35,
+ax_anim 2, 0, 71, -22, 36, -22, 36,
+ax_anim 2, 0, 71, -23, 35, -23, 35,
+ax_anim 2, 0, 69, -14, 23, -14, 23,
+ax_anim 1, 0, 69, -6, 10, -6, 10,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sRayquazaAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sRayquazaAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sRayquazaAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sRayquazaAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sRayquazaAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sRayquazaAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sRayquazaAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_5_1:
+ax_anim 2, 0, 96, 0, 2, 0, 1,
+ax_anim 2, 0, 96, 0, 3, 0, 2,
+ax_anim 6, 0, 96, 0, 4, 0, 3,
+ax_anim 2, 0, 97, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 0, -3, 0, 3,
+ax_anim 2, 2, 98, 0, -5, 0, 2,
+ax_anim 2, 0, 98, -1, -5, -1, 1,
+ax_anim 2, 0, 98, 0, -5, 0, 1,
+ax_anim 2, 0, 98, -1, -5, -1, 1,
+ax_anim 2, 0, 98, 0, -5, 0, 1,
+ax_anim 2, 0, 98, -1, -5, -1, 1,
+ax_anim 2, 0, 98, 0, -4, 0, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 1,
+ax_anim_terminator
+sRayquazaAnims_5_2:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 6, 0, 99, 2, 2, 2, 2,
+ax_anim 2, 0, 100, 6, -1, 3, 3,
+ax_anim 2, 0, 101, 6, -3, 3, 3,
+ax_anim 2, 2, 101, 5, -5, 2, 2,
+ax_anim 2, 0, 101, 4, -4, 1, 3,
+ax_anim 2, 0, 101, 5, -5, 2, 2,
+ax_anim 2, 0, 101, 4, -4, 1, 3,
+ax_anim 2, 0, 101, 5, -5, 2, 2,
+ax_anim 2, 0, 101, 4, -4, 1, 3,
+ax_anim 2, 0, 101, 4, -3, 2, 2,
+ax_anim 2, 0, 100, 3, -5, 2, 2,
+ax_anim_terminator
+sRayquazaAnims_5_3:
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 2, 1, 2, 0,
+ax_anim 6, 0, 102, 3, 2, 3, 0,
+ax_anim 2, 0, 103, 5, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 3, 0,
+ax_anim 2, 2, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 1, -1, 2, -1,
+ax_anim 2, 0, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 1, -1, 2, -1,
+ax_anim 2, 0, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 1, -1, 2, -1,
+ax_anim 2, 0, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 103, 3, 0, 1, 0,
+ax_anim_terminator
+sRayquazaAnims_5_4:
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 6, 0, 105, 3, -3, 3, -3,
+ax_anim 2, 0, 106, 6, -3, 3, -3,
+ax_anim 2, 0, 107, 6, 2, 3, -3,
+ax_anim 2, 2, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 107, 4, -1, 1, -3,
+ax_anim 2, 0, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 107, 4, -1, 1, -3,
+ax_anim 2, 0, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 107, 4, -1, 1, -3,
+ax_anim 2, 0, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 106, 8, -3, 3, -3,
+ax_anim_terminator
+sRayquazaAnims_5_5:
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim 6, 0, 108, 0, -3, 0, -3,
+ax_anim 2, 0, 109, 0, -8, 0, -4,
+ax_anim 2, 0, 110, 0, -11, 0, -4,
+ax_anim 2, 2, 110, 0, -12, 0, -3,
+ax_anim 2, 0, 110, -1, -12, -1, -3,
+ax_anim 2, 0, 110, 0, -12, 0, -3,
+ax_anim 2, 0, 110, -1, -12, -1, -3,
+ax_anim 2, 0, 110, 0, -12, 0, -3,
+ax_anim 2, 0, 110, -1, -12, -1, -3,
+ax_anim 2, 0, 110, 0, -10, 0, -3,
+ax_anim 2, 0, 109, 0, -8, 0, -2,
+ax_anim_terminator
+sRayquazaAnims_5_6:
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, -2, -2, -2, -2,
+ax_anim 6, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 112, -6, -3, -3, -3,
+ax_anim 2, 0, 113, -6, 2, -3, -3,
+ax_anim 2, 2, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 113, -4, -1, -1, -3,
+ax_anim 2, 0, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 113, -4, -1, -1, -3,
+ax_anim 2, 0, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 113, -4, -1, -1, -3,
+ax_anim 2, 0, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 112, -8, -3, -3, -3,
+ax_anim_terminator
+sRayquazaAnims_5_7:
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 0,
+ax_anim 6, 0, 114, -3, 2, -3, 0,
+ax_anim 2, 0, 115, -5, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -3, 0,
+ax_anim 2, 2, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 116, -1, -1, -2, -1,
+ax_anim 2, 0, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 116, -1, -1, -2, -1,
+ax_anim 2, 0, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 116, -1, -1, -2, -1,
+ax_anim 2, 0, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 115, -3, 0, -1, 0,
+ax_anim_terminator
+sRayquazaAnims_5_8:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 6, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -6, -1, -3, 3,
+ax_anim 2, 0, 119, -6, -3, -3, 3,
+ax_anim 2, 2, 119, -5, -5, -2, 2,
+ax_anim 2, 0, 119, -4, -4, -1, 3,
+ax_anim 2, 0, 119, -5, -5, -2, 2,
+ax_anim 2, 0, 119, -4, -4, -1, 3,
+ax_anim 2, 0, 119, -5, -5, -2, 2,
+ax_anim 2, 0, 119, -4, -4, -1, 3,
+ax_anim 2, 0, 119, -4, -3, -2, 2,
+ax_anim 2, 0, 118, -3, -5, -2, 2,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_6_1:
+ax_anim 10, 0, 120, 0, 0, 0, 0,
+ax_anim 10, 0, 120, 0, -1, 0, 0,
+ax_anim 10, 0, 120, 0, -2, 0, 0,
+ax_anim 30, 0, 120, 0, -3, 0, 0,
+ax_anim 10, 0, 121, 0, -3, 0, 0,
+ax_anim 10, 0, 121, 0, -2, 0, 0,
+ax_anim 10, 0, 121, 0, -1, 0, 0,
+ax_anim 30, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sRayquazaAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sRayquazaAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sRayquazaAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sRayquazaAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sRayquazaAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sRayquazaAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sRayquazaAnims_7_8:
+ax_anim 2, 0, 129, 8, -2, 8, -2,
+ax_anim 8, 0, 129, 9, -3, 9, -3,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_8_1:
+ax_anim 14, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 14, 0, 132, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_8_2:
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_8_3:
+ax_anim 14, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_8_4:
+ax_anim 14, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 14, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_8_5:
+ax_anim 14, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 14, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_8_6:
+ax_anim 14, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_8_7:
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_8_8:
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 14, 7, 14,
+ax_anim 3, 0, 158, 0, 16, 0, 16,
+ax_anim 2, 3, 159, -7, 14, -7, 14,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 7, 4, 7, 4,
+ax_anim 2, 0, 155, 12, 10, 12, 10,
+ax_anim 2, 0, 156, 11, 15, 11, 15,
+ax_anim 3, 0, 157, 7, 18, 7, 18,
+ax_anim 2, 3, 158, 4, 16, 4, 16,
+ax_anim 2, 0, 159, 1, 12, 1, 12,
+ax_anim 1, 0, 160, 1, 7, 1, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 1, -2, 1, -2,
+ax_anim 2, 0, 154, 3, -3, 3, -3,
+ax_anim 2, 0, 155, 4, -1, 4, -1,
+ax_anim 3, 0, 156, 5, 2, 5, 2,
+ax_anim 2, 3, 157, 4, 4, 4, 4,
+ax_anim 2, 0, 158, 3, 4, 3, 4,
+ax_anim 1, 0, 159, 1, 2, 1, 2,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 1, -8, 1, -8,
+ax_anim 2, 0, 161, 5, -14, 5, -14,
+ax_anim 2, 0, 154, 12, -16, 12, -16,
+ax_anim 3, 0, 155, 16, -15, 16, -15,
+ax_anim 2, 3, 156, 18, -10, 18, -10,
+ax_anim 2, 0, 157, 13, -5, 13, -5,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -4, -2, -4, -2,
+ax_anim 2, 0, 160, -7, -6, -7, -6,
+ax_anim 2, 0, 161, -5, -11, -5, -11,
+ax_anim 3, 0, 154, 0, -12, 0, -12,
+ax_anim 2, 3, 155, 5, -11, 5, -11,
+ax_anim 2, 0, 156, 7, -6, 7, -6,
+ax_anim 1, 0, 157, 4, -2, 4, -2,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -5, -14, -5, -14,
+ax_anim 2, 0, 154, -12, -16, -12, -16,
+ax_anim 3, 0, 161, -16, -15, -16, -15,
+ax_anim 2, 3, 160, -18, -10, -18, -10,
+ax_anim 2, 0, 159, -13, -5, -13, -5,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -1, -2, -1, -2,
+ax_anim 2, 0, 154, -3, -3, -3, -3,
+ax_anim 2, 0, 161, -4, -1, -4, -1,
+ax_anim 3, 0, 160, -5, 2, -5, 2,
+ax_anim 2, 3, 159, -4, 4, -4, 4,
+ax_anim 2, 0, 158, -3, 4, -3, 4,
+ax_anim 1, 0, 157, -1, 2, -1, 2,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -7, 4, -7, 4,
+ax_anim 2, 0, 161, -12, 10, -12, 10,
+ax_anim 2, 0, 160, -11, 15, -11, 15,
+ax_anim 3, 0, 159, -7, 18, -7, 18,
+ax_anim 2, 3, 158, -4, 16, -4, 16,
+ax_anim 2, 0, 157, -1, 12, -1, 12,
+ax_anim 1, 0, 156, -1, 7, -1, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -29, 0, 0,
+ax_anim 3, 0, 170, 0, -28, 0, 0,
+ax_anim 2, 0, 170, 0, -17, 0, 0,
+ax_anim 1, 0, 170, 0, -11, 0, 0,
+ax_anim 2, 2, 170, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -23, 0, 0,
+ax_anim 2, 0, 173, 0, -20, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -19, 0, 0,
+ax_anim 2, 0, 191, 0, -15, 0, 0,
+ax_anim 1, 0, 191, 0, -9, 0, 0,
+ax_anim 2, 2, 191, 0, 6, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaGfx1:
+.incbin "baserom.gba", 0x15EB834, 0x20
+sRayquazaGfx1_1:
+.incbin "baserom.gba", 0x15EB854, 0x100
+sRayquazaGfx1_2:
+.incbin "baserom.gba", 0x15EB954, 0x260
+sRayquazaSprites1:
+ax_sprite sRayquazaGfx1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx1_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx1_2, 0x260
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx2:
+.incbin "baserom.gba", 0x15EBBEC, 0xC0
+sRayquazaGfx2_1:
+.incbin "baserom.gba", 0x15EBCAC, 0x20
+sRayquazaSprites2:
+ax_sprite sRayquazaGfx2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx2_1, 0x20
+ax_sprite_terminator
+sRayquazaGfx3:
+.incbin "baserom.gba", 0x15EBCEC, 0x20
+sRayquazaSprites3:
+ax_sprite sRayquazaGfx3, 0x20
+ax_sprite_terminator
+sRayquazaGfx4:
+.incbin "baserom.gba", 0x15EBD1C, 0x80
+sRayquazaSprites4:
+ax_sprite sRayquazaGfx4, 0x80
+ax_sprite_terminator
+sRayquazaGfx5:
+.incbin "baserom.gba", 0x15EBDAC, 0x20
+sRayquazaGfx5_1:
+.incbin "baserom.gba", 0x15EBDCC, 0x3A0
+sRayquazaSprites5:
+ax_sprite sRayquazaGfx5, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx5_1, 0x3a0
+ax_sprite_terminator
+sRayquazaGfx6:
+.incbin "baserom.gba", 0x15EC18C, 0x100
+sRayquazaSprites6:
+ax_sprite sRayquazaGfx6, 0x100
+ax_sprite_terminator
+sRayquazaGfx7:
+.incbin "baserom.gba", 0x15EC29C, 0x40
+sRayquazaSprites7:
+ax_sprite sRayquazaGfx7, 0x40
+ax_sprite_terminator
+sRayquazaGfx8:
+.incbin "baserom.gba", 0x15EC2EC, 0x40
+sRayquazaGfx8_1:
+.incbin "baserom.gba", 0x15EC32C, 0x20
+sRayquazaSprites8:
+ax_sprite sRayquazaGfx8, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx8_1, 0x20
+ax_sprite_terminator
+sRayquazaGfx9:
+.incbin "baserom.gba", 0x15EC36C, 0x20
+sRayquazaGfx9_1:
+.incbin "baserom.gba", 0x15EC38C, 0x3A0
+sRayquazaSprites9:
+ax_sprite sRayquazaGfx9, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx9_1, 0x3a0
+ax_sprite_terminator
+sRayquazaGfx10:
+.incbin "baserom.gba", 0x15EC74C, 0x100
+sRayquazaSprites10:
+ax_sprite sRayquazaGfx10, 0x100
+ax_sprite_terminator
+sRayquazaGfx11:
+.incbin "baserom.gba", 0x15EC85C, 0x40
+sRayquazaSprites11:
+ax_sprite sRayquazaGfx11, 0x40
+ax_sprite_terminator
+sRayquazaGfx12:
+.incbin "baserom.gba", 0x15EC8AC, 0x80
+sRayquazaSprites12:
+ax_sprite sRayquazaGfx12, 0x80
+ax_sprite_terminator
+sRayquazaGfx13:
+.incbin "baserom.gba", 0x15EC93C, 0x20
+sRayquazaGfx13_1:
+.incbin "baserom.gba", 0x15EC95C, 0x40
+sRayquazaGfx13_2:
+.incbin "baserom.gba", 0x15EC99C, 0x40
+sRayquazaGfx13_3:
+.incbin "baserom.gba", 0x15EC9DC, 0x260
+sRayquazaSprites13:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx13, 0x20
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx13_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx13_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx13_3, 0x260
+ax_sprite_terminator
+sRayquazaGfx14:
+.incbin "baserom.gba", 0x15ECC84, 0x20
+sRayquazaGfx14_1:
+.incbin "baserom.gba", 0x15ECCA4, 0xC0
+sRayquazaSprites14:
+ax_sprite sRayquazaGfx14, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx14_1, 0xc0
+ax_sprite_terminator
+sRayquazaGfx15:
+.incbin "baserom.gba", 0x15ECD84, 0x100
+sRayquazaSprites15:
+ax_sprite sRayquazaGfx15, 0x100
+ax_sprite_terminator
+sRayquazaGfx16:
+.incbin "baserom.gba", 0x15ECE94, 0x20
+sRayquazaGfx16_1:
+.incbin "baserom.gba", 0x15ECEB4, 0x20
+sRayquazaGfx16_2:
+.incbin "baserom.gba", 0x15ECED4, 0x380
+sRayquazaSprites16:
+ax_sprite sRayquazaGfx16, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx16_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx16_2, 0x380
+ax_sprite_terminator
+sRayquazaGfx17:
+.incbin "baserom.gba", 0x15ED284, 0x100
+sRayquazaSprites17:
+ax_sprite sRayquazaGfx17, 0x100
+ax_sprite_terminator
+sRayquazaGfx18:
+.incbin "baserom.gba", 0x15ED394, 0x20
+sRayquazaSprites18:
+ax_sprite sRayquazaGfx18, 0x20
+ax_sprite_terminator
+sRayquazaGfx19:
+.incbin "baserom.gba", 0x15ED3C4, 0x20
+sRayquazaSprites19:
+ax_sprite sRayquazaGfx19, 0x20
+ax_sprite_terminator
+sRayquazaGfx20:
+.incbin "baserom.gba", 0x15ED3F4, 0x20
+sRayquazaGfx20_1:
+.incbin "baserom.gba", 0x15ED414, 0x20
+sRayquazaGfx20_2:
+.incbin "baserom.gba", 0x15ED434, 0x380
+sRayquazaSprites20:
+ax_sprite sRayquazaGfx20, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx20_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx20_2, 0x380
+ax_sprite_terminator
+sRayquazaGfx21:
+.incbin "baserom.gba", 0x15ED7E4, 0x100
+sRayquazaSprites21:
+ax_sprite sRayquazaGfx21, 0x100
+ax_sprite_terminator
+sRayquazaGfx22:
+.incbin "baserom.gba", 0x15ED8F4, 0x20
+sRayquazaSprites22:
+ax_sprite sRayquazaGfx22, 0x20
+ax_sprite_terminator
+sRayquazaGfx23:
+.incbin "baserom.gba", 0x15ED924, 0x20
+sRayquazaSprites23:
+ax_sprite sRayquazaGfx23, 0x20
+ax_sprite_terminator
+sRayquazaGfx24:
+.incbin "baserom.gba", 0x15ED954, 0xE0
+sRayquazaGfx24_1:
+.incbin "baserom.gba", 0x15EDA34, 0xE0
+sRayquazaGfx24_2:
+.incbin "baserom.gba", 0x15EDB14, 0xE0
+sRayquazaGfx24_3:
+.incbin "baserom.gba", 0x15EDBF4, 0xA0
+sRayquazaSprites24:
+ax_sprite sRayquazaGfx24, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx24_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx24_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx24_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx25:
+.incbin "baserom.gba", 0x15EDCDC, 0x60
+sRayquazaGfx25_1:
+.incbin "baserom.gba", 0x15EDD3C, 0x180
+sRayquazaSprites25:
+ax_sprite sRayquazaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx25_1, 0x180
+ax_sprite_terminator
+sRayquazaGfx26:
+.incbin "baserom.gba", 0x15EDEDC, 0x60
+sRayquazaSprites26:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx26, 0x60
+ax_sprite_terminator
+sRayquazaGfx27:
+.incbin "baserom.gba", 0x15EDF54, 0x20
+sRayquazaSprites27:
+ax_sprite sRayquazaGfx27, 0x20
+ax_sprite_terminator
+sRayquazaGfx28:
+.incbin "baserom.gba", 0x15EDF84, 0x20
+sRayquazaSprites28:
+ax_sprite sRayquazaGfx28, 0x20
+ax_sprite_terminator
+sRayquazaGfx29:
+.incbin "baserom.gba", 0x15EDFB4, 0xE0
+sRayquazaGfx29_1:
+.incbin "baserom.gba", 0x15EE094, 0xE0
+sRayquazaGfx29_2:
+.incbin "baserom.gba", 0x15EE174, 0xE0
+sRayquazaGfx29_3:
+.incbin "baserom.gba", 0x15EE254, 0xA0
+sRayquazaSprites29:
+ax_sprite sRayquazaGfx29, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx29_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx29_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx29_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx30:
+.incbin "baserom.gba", 0x15EE33C, 0x60
+sRayquazaGfx30_1:
+.incbin "baserom.gba", 0x15EE39C, 0x180
+sRayquazaSprites30:
+ax_sprite sRayquazaGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx30_1, 0x180
+ax_sprite_terminator
+sRayquazaGfx31:
+.incbin "baserom.gba", 0x15EE53C, 0x40
+sRayquazaSprites31:
+ax_sprite sRayquazaGfx31, 0x40
+ax_sprite_terminator
+sRayquazaGfx32:
+.incbin "baserom.gba", 0x15EE58C, 0x20
+sRayquazaSprites32:
+ax_sprite sRayquazaGfx32, 0x20
+ax_sprite_terminator
+sRayquazaGfx33:
+.incbin "baserom.gba", 0x15EE5BC, 0x20
+sRayquazaSprites33:
+ax_sprite sRayquazaGfx33, 0x20
+ax_sprite_terminator
+sRayquazaGfx34:
+.incbin "baserom.gba", 0x15EE5EC, 0xE0
+sRayquazaGfx34_1:
+.incbin "baserom.gba", 0x15EE6CC, 0xE0
+sRayquazaGfx34_2:
+.incbin "baserom.gba", 0x15EE7AC, 0xE0
+sRayquazaGfx34_3:
+.incbin "baserom.gba", 0x15EE88C, 0xA0
+sRayquazaSprites34:
+ax_sprite sRayquazaGfx34, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx34_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx34_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx34_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx35:
+.incbin "baserom.gba", 0x15EE974, 0x60
+sRayquazaGfx35_1:
+.incbin "baserom.gba", 0x15EE9D4, 0x180
+sRayquazaSprites35:
+ax_sprite sRayquazaGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx35_1, 0x180
+ax_sprite_terminator
+sRayquazaGfx36:
+.incbin "baserom.gba", 0x15EEB74, 0x60
+sRayquazaSprites36:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx36, 0x60
+ax_sprite_terminator
+sRayquazaGfx37:
+.incbin "baserom.gba", 0x15EEBEC, 0x20
+sRayquazaSprites37:
+ax_sprite sRayquazaGfx37, 0x20
+ax_sprite_terminator
+sRayquazaGfx38:
+.incbin "baserom.gba", 0x15EEC1C, 0x20
+sRayquazaSprites38:
+ax_sprite sRayquazaGfx38, 0x20
+ax_sprite_terminator
+sRayquazaGfx39:
+.incbin "baserom.gba", 0x15EEC4C, 0x40
+sRayquazaGfx39_1:
+.incbin "baserom.gba", 0x15EEC8C, 0x60
+sRayquazaGfx39_2:
+.incbin "baserom.gba", 0x15EECEC, 0x300
+sRayquazaSprites39:
+ax_sprite sRayquazaGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx39_2, 0x300
+ax_sprite_terminator
+sRayquazaGfx40:
+.incbin "baserom.gba", 0x15EF01C, 0x100
+sRayquazaGfx40_1:
+.incbin "baserom.gba", 0x15EF11C, 0x60
+sRayquazaGfx40_2:
+.incbin "baserom.gba", 0x15EF17C, 0x40
+sRayquazaSprites40:
+ax_sprite sRayquazaGfx40, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx40_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx40_2, 0x40
+ax_sprite_terminator
+sRayquazaGfx41:
+.incbin "baserom.gba", 0x15EF1EC, 0x20
+sRayquazaGfx41_1:
+.incbin "baserom.gba", 0x15EF20C, 0x40
+sRayquazaSprites41:
+ax_sprite sRayquazaGfx41, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx41_1, 0x40
+ax_sprite_terminator
+sRayquazaGfx42:
+.incbin "baserom.gba", 0x15EF26C, 0x20
+sRayquazaSprites42:
+ax_sprite sRayquazaGfx42, 0x20
+ax_sprite_terminator
+sRayquazaGfx43:
+.incbin "baserom.gba", 0x15EF29C, 0x20
+sRayquazaSprites43:
+ax_sprite sRayquazaGfx43, 0x20
+ax_sprite_terminator
+sRayquazaGfx44:
+.incbin "baserom.gba", 0x15EF2CC, 0x40
+sRayquazaGfx44_1:
+.incbin "baserom.gba", 0x15EF30C, 0x60
+sRayquazaGfx44_2:
+.incbin "baserom.gba", 0x15EF36C, 0x60
+sRayquazaGfx44_3:
+.incbin "baserom.gba", 0x15EF3CC, 0x60
+sRayquazaGfx44_4:
+.incbin "baserom.gba", 0x15EF42C, 0x200
+sRayquazaSprites44:
+ax_sprite sRayquazaGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx44_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx44_4, 0x200
+ax_sprite_terminator
+sRayquazaGfx45:
+.incbin "baserom.gba", 0x15EF67C, 0x100
+sRayquazaGfx45_1:
+.incbin "baserom.gba", 0x15EF77C, 0x60
+sRayquazaGfx45_2:
+.incbin "baserom.gba", 0x15EF7DC, 0x40
+sRayquazaSprites45:
+ax_sprite sRayquazaGfx45, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx45_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx45_2, 0x40
+ax_sprite_terminator
+sRayquazaGfx46:
+.incbin "baserom.gba", 0x15EF84C, 0x80
+sRayquazaSprites46:
+ax_sprite sRayquazaGfx46, 0x80
+ax_sprite_terminator
+sRayquazaGfx47:
+.incbin "baserom.gba", 0x15EF8DC, 0x20
+sRayquazaSprites47:
+ax_sprite sRayquazaGfx47, 0x20
+ax_sprite_terminator
+sRayquazaGfx48:
+.incbin "baserom.gba", 0x15EF90C, 0x20
+sRayquazaSprites48:
+ax_sprite sRayquazaGfx48, 0x20
+ax_sprite_terminator
+sRayquazaGfx49:
+.incbin "baserom.gba", 0x15EF93C, 0x60
+sRayquazaGfx49_1:
+.incbin "baserom.gba", 0x15EF99C, 0x60
+sRayquazaGfx49_2:
+.incbin "baserom.gba", 0x15EF9FC, 0x60
+sRayquazaGfx49_3:
+.incbin "baserom.gba", 0x15EFA5C, 0x60
+sRayquazaGfx49_4:
+.incbin "baserom.gba", 0x15EFABC, 0x200
+sRayquazaSprites49:
+ax_sprite sRayquazaGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx49_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx49_4, 0x200
+ax_sprite_terminator
+sRayquazaGfx50:
+.incbin "baserom.gba", 0x15EFD0C, 0x100
+sRayquazaGfx50_1:
+.incbin "baserom.gba", 0x15EFE0C, 0x60
+sRayquazaGfx50_2:
+.incbin "baserom.gba", 0x15EFE6C, 0x40
+sRayquazaSprites50:
+ax_sprite sRayquazaGfx50, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx50_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx50_2, 0x40
+ax_sprite_terminator
+sRayquazaGfx51:
+.incbin "baserom.gba", 0x15EFEDC, 0x80
+sRayquazaSprites51:
+ax_sprite sRayquazaGfx51, 0x80
+ax_sprite_terminator
+sRayquazaGfx52:
+.incbin "baserom.gba", 0x15EFF6C, 0x40
+sRayquazaSprites52:
+ax_sprite sRayquazaGfx52, 0x40
+ax_sprite_terminator
+sRayquazaGfx53:
+.incbin "baserom.gba", 0x15EFFBC, 0x20
+sRayquazaSprites53:
+ax_sprite sRayquazaGfx53, 0x20
+ax_sprite_terminator
+sRayquazaGfx54:
+.incbin "baserom.gba", 0x15EFFEC, 0x80
+sRayquazaGfx54_1:
+.incbin "baserom.gba", 0x15F006C, 0x60
+sRayquazaGfx54_2:
+.incbin "baserom.gba", 0x15F00CC, 0x60
+sRayquazaGfx54_3:
+.incbin "baserom.gba", 0x15F012C, 0x260
+sRayquazaSprites54:
+ax_sprite sRayquazaGfx54, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx54_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx54_3, 0x260
+ax_sprite_terminator
+sRayquazaGfx55:
+.incbin "baserom.gba", 0x15F03CC, 0x20
+sRayquazaGfx55_1:
+.incbin "baserom.gba", 0x15F03EC, 0x20
+sRayquazaGfx55_2:
+.incbin "baserom.gba", 0x15F040C, 0x20
+sRayquazaGfx55_3:
+.incbin "baserom.gba", 0x15F042C, 0x40
+sRayquazaSprites55:
+ax_sprite sRayquazaGfx55, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx55_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx55_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx55_3, 0x40
+ax_sprite_terminator
+sRayquazaGfx56:
+.incbin "baserom.gba", 0x15F04AC, 0x100
+sRayquazaSprites56:
+ax_sprite sRayquazaGfx56, 0x100
+ax_sprite_terminator
+sRayquazaGfx57:
+.incbin "baserom.gba", 0x15F05BC, 0x40
+sRayquazaSprites57:
+ax_sprite sRayquazaGfx57, 0x40
+ax_sprite_terminator
+sRayquazaGfx58:
+.incbin "baserom.gba", 0x15F060C, 0x80
+sRayquazaGfx58_1:
+.incbin "baserom.gba", 0x15F068C, 0x60
+sRayquazaGfx58_2:
+.incbin "baserom.gba", 0x15F06EC, 0x60
+sRayquazaGfx58_3:
+.incbin "baserom.gba", 0x15F074C, 0x260
+sRayquazaSprites58:
+ax_sprite sRayquazaGfx58, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx58_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx58_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx58_3, 0x260
+ax_sprite_terminator
+sRayquazaGfx59:
+.incbin "baserom.gba", 0x15F09EC, 0x80
+sRayquazaSprites59:
+ax_sprite sRayquazaGfx59, 0x80
+ax_sprite_terminator
+sRayquazaGfx60:
+.incbin "baserom.gba", 0x15F0A7C, 0x80
+sRayquazaSprites60:
+ax_sprite sRayquazaGfx60, 0x80
+ax_sprite_terminator
+sRayquazaGfx61:
+.incbin "baserom.gba", 0x15F0B0C, 0x80
+sRayquazaSprites61:
+ax_sprite sRayquazaGfx61, 0x80
+ax_sprite_terminator
+sRayquazaGfx62:
+.incbin "baserom.gba", 0x15F0B9C, 0x40
+sRayquazaSprites62:
+ax_sprite sRayquazaGfx62, 0x40
+ax_sprite_terminator
+sRayquazaGfx63:
+.incbin "baserom.gba", 0x15F0BEC, 0x80
+sRayquazaGfx63_1:
+.incbin "baserom.gba", 0x15F0C6C, 0x60
+sRayquazaGfx63_2:
+.incbin "baserom.gba", 0x15F0CCC, 0x60
+sRayquazaGfx63_3:
+.incbin "baserom.gba", 0x15F0D2C, 0x260
+sRayquazaSprites63:
+ax_sprite sRayquazaGfx63, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx63_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx63_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx63_3, 0x260
+ax_sprite_terminator
+sRayquazaGfx64:
+.incbin "baserom.gba", 0x15F0FCC, 0x80
+sRayquazaSprites64:
+ax_sprite sRayquazaGfx64, 0x80
+ax_sprite_terminator
+sRayquazaGfx65:
+.incbin "baserom.gba", 0x15F105C, 0x100
+sRayquazaSprites65:
+ax_sprite sRayquazaGfx65, 0x100
+ax_sprite_terminator
+sRayquazaGfx66:
+.incbin "baserom.gba", 0x15F116C, 0x40
+sRayquazaSprites66:
+ax_sprite sRayquazaGfx66, 0x40
+ax_sprite_terminator
+sRayquazaGfx67:
+.incbin "baserom.gba", 0x15F11BC, 0x360
+sRayquazaGfx67_1:
+.incbin "baserom.gba", 0x15F151C, 0x60
+sRayquazaSprites67:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx67, 0x360
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx67_1, 0x60
+ax_sprite_terminator
+sRayquazaGfx68:
+.incbin "baserom.gba", 0x15F15A4, 0x100
+sRayquazaSprites68:
+ax_sprite sRayquazaGfx68, 0x100
+ax_sprite_terminator
+sRayquazaGfx69:
+.incbin "baserom.gba", 0x15F16B4, 0x40
+sRayquazaSprites69:
+ax_sprite sRayquazaGfx69, 0x40
+ax_sprite_terminator
+sRayquazaGfx70:
+.incbin "baserom.gba", 0x15F1704, 0x40
+sRayquazaSprites70:
+ax_sprite sRayquazaGfx70, 0x40
+ax_sprite_terminator
+sRayquazaGfx71:
+.incbin "baserom.gba", 0x15F1754, 0x360
+sRayquazaGfx71_1:
+.incbin "baserom.gba", 0x15F1AB4, 0x60
+sRayquazaSprites71:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx71, 0x360
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx71_1, 0x60
+ax_sprite_terminator
+sRayquazaGfx72:
+.incbin "baserom.gba", 0x15F1B3C, 0x100
+sRayquazaSprites72:
+ax_sprite sRayquazaGfx72, 0x100
+ax_sprite_terminator
+sRayquazaGfx73:
+.incbin "baserom.gba", 0x15F1C4C, 0x40
+sRayquazaSprites73:
+ax_sprite sRayquazaGfx73, 0x40
+ax_sprite_terminator
+sRayquazaGfx74:
+.incbin "baserom.gba", 0x15F1C9C, 0x360
+sRayquazaGfx74_1:
+.incbin "baserom.gba", 0x15F1FFC, 0x60
+sRayquazaSprites74:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx74, 0x360
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx74_1, 0x60
+ax_sprite_terminator
+sRayquazaGfx75:
+.incbin "baserom.gba", 0x15F2084, 0x100
+sRayquazaSprites75:
+ax_sprite sRayquazaGfx75, 0x100
+ax_sprite_terminator
+sRayquazaGfx76:
+.incbin "baserom.gba", 0x15F2194, 0x20
+sRayquazaSprites76:
+ax_sprite sRayquazaGfx76, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx77:
+.incbin "baserom.gba", 0x15F21CC, 0x40
+sRayquazaSprites77:
+ax_sprite sRayquazaGfx77, 0x40
+ax_sprite_terminator
+sRayquazaGfx78:
+.incbin "baserom.gba", 0x15F221C, 0x40
+sRayquazaGfx78_1:
+.incbin "baserom.gba", 0x15F225C, 0x340
+sRayquazaSprites78:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx78, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx78_1, 0x340
+ax_sprite_terminator
+sRayquazaGfx79:
+.incbin "baserom.gba", 0x15F25C4, 0x40
+sRayquazaGfx79_1:
+.incbin "baserom.gba", 0x15F2604, 0x60
+sRayquazaGfx79_2:
+.incbin "baserom.gba", 0x15F2664, 0x60
+sRayquazaGfx79_3:
+.incbin "baserom.gba", 0x15F26C4, 0x60
+sRayquazaSprites79:
+ax_sprite sRayquazaGfx79, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx79_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx79_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx79_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx80:
+.incbin "baserom.gba", 0x15F276C, 0x20
+sRayquazaSprites80:
+ax_sprite sRayquazaGfx80, 0x20
+ax_sprite_terminator
+sRayquazaGfx81:
+.incbin "baserom.gba", 0x15F279C, 0x40
+sRayquazaSprites81:
+ax_sprite sRayquazaGfx81, 0x40
+ax_sprite_terminator
+sRayquazaGfx82:
+.incbin "baserom.gba", 0x15F27EC, 0x40
+sRayquazaGfx82_1:
+.incbin "baserom.gba", 0x15F282C, 0x340
+sRayquazaSprites82:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx82, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx82_1, 0x340
+ax_sprite_terminator
+sRayquazaGfx83:
+.incbin "baserom.gba", 0x15F2B94, 0x40
+sRayquazaGfx83_1:
+.incbin "baserom.gba", 0x15F2BD4, 0x60
+sRayquazaGfx83_2:
+.incbin "baserom.gba", 0x15F2C34, 0x60
+sRayquazaGfx83_3:
+.incbin "baserom.gba", 0x15F2C94, 0x60
+sRayquazaSprites83:
+ax_sprite sRayquazaGfx83, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx83_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx83_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx83_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx84:
+.incbin "baserom.gba", 0x15F2D3C, 0x20
+sRayquazaSprites84:
+ax_sprite sRayquazaGfx84, 0x20
+ax_sprite_terminator
+sRayquazaGfx85:
+.incbin "baserom.gba", 0x15F2D6C, 0x40
+sRayquazaSprites85:
+ax_sprite sRayquazaGfx85, 0x40
+ax_sprite_terminator
+sRayquazaGfx86:
+.incbin "baserom.gba", 0x15F2DBC, 0x40
+sRayquazaGfx86_1:
+.incbin "baserom.gba", 0x15F2DFC, 0x340
+sRayquazaSprites86:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx86, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx86_1, 0x340
+ax_sprite_terminator
+sRayquazaGfx87:
+.incbin "baserom.gba", 0x15F3164, 0x40
+sRayquazaGfx87_1:
+.incbin "baserom.gba", 0x15F31A4, 0x60
+sRayquazaGfx87_2:
+.incbin "baserom.gba", 0x15F3204, 0x60
+sRayquazaGfx87_3:
+.incbin "baserom.gba", 0x15F3264, 0x60
+sRayquazaSprites87:
+ax_sprite sRayquazaGfx87, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx87_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx87_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx87_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx88:
+.incbin "baserom.gba", 0x15F330C, 0x20
+sRayquazaSprites88:
+ax_sprite sRayquazaGfx88, 0x20
+ax_sprite_terminator
+sRayquazaGfx89:
+.incbin "baserom.gba", 0x15F333C, 0x40
+sRayquazaSprites89:
+ax_sprite sRayquazaGfx89, 0x40
+ax_sprite_terminator
+sRayquazaGfx90:
+.incbin "baserom.gba", 0x15F338C, 0x40
+sRayquazaGfx90_1:
+.incbin "baserom.gba", 0x15F33CC, 0x100
+sRayquazaGfx90_2:
+.incbin "baserom.gba", 0x15F34CC, 0x80
+sRayquazaSprites90:
+ax_sprite sRayquazaGfx90, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx90_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx90_2, 0x80
+ax_sprite_terminator
+sRayquazaGfx91:
+.incbin "baserom.gba", 0x15F357C, 0xE0
+sRayquazaGfx91_1:
+.incbin "baserom.gba", 0x15F365C, 0x2A0
+sRayquazaGfx91_2:
+.incbin "baserom.gba", 0x15F38FC, 0x20
+sRayquazaSprites91:
+ax_sprite sRayquazaGfx91, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx91_1, 0x2a0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx91_2, 0x20
+ax_sprite_terminator
+sRayquazaGfx92:
+.incbin "baserom.gba", 0x15F394C, 0xC0
+sRayquazaGfx92_1:
+.incbin "baserom.gba", 0x15F3A0C, 0x2A0
+sRayquazaGfx92_2:
+.incbin "baserom.gba", 0x15F3CAC, 0x20
+sRayquazaSprites92:
+ax_sprite sRayquazaGfx92, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx92_1, 0x2a0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx92_2, 0x20
+ax_sprite_terminator
+sRayquazaGfx93:
+.incbin "baserom.gba", 0x15F3CFC, 0x40
+sRayquazaGfx93_1:
+.incbin "baserom.gba", 0x15F3D3C, 0x1A0
+sRayquazaSprites93:
+ax_sprite sRayquazaGfx93, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx93_1, 0x1a0
+ax_sprite_terminator
+sRayquazaGfx94:
+.incbin "baserom.gba", 0x15F3EFC, 0x20
+sRayquazaSprites94:
+ax_sprite sRayquazaGfx94, 0x20
+ax_sprite_terminator
+sRayquazaGfx95:
+.incbin "baserom.gba", 0x15F3F2C, 0xC0
+sRayquazaGfx95_1:
+.incbin "baserom.gba", 0x15F3FEC, 0x2A0
+sRayquazaSprites95:
+ax_sprite sRayquazaGfx95, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx95_1, 0x2a0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sRayquazaGfx96:
+.incbin "baserom.gba", 0x15F42B4, 0x20
+sRayquazaGfx96_1:
+.incbin "baserom.gba", 0x15F42D4, 0x1A0
+sRayquazaSprites96:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx96, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx96_1, 0x1a0
+ax_sprite_terminator
+sRayquazaGfx97:
+.incbin "baserom.gba", 0x15F449C, 0x20
+sRayquazaSprites97:
+ax_sprite sRayquazaGfx97, 0x20
+ax_sprite_terminator
+sRayquazaGfx98:
+.incbin "baserom.gba", 0x15F44CC, 0x40
+sRayquazaGfx98_1:
+.incbin "baserom.gba", 0x15F450C, 0x20
+sRayquazaGfx98_2:
+.incbin "baserom.gba", 0x15F452C, 0x60
+sRayquazaGfx98_3:
+.incbin "baserom.gba", 0x15F458C, 0x60
+sRayquazaGfx98_4:
+.incbin "baserom.gba", 0x15F45EC, 0x1E0
+sRayquazaGfx98_5:
+.incbin "baserom.gba", 0x15F47CC, 0x60
+sRayquazaSprites98:
+ax_sprite sRayquazaGfx98, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx98_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx98_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx98_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx98_4, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx98_5, 0x60
+ax_sprite_terminator
+sRayquazaGfx99:
+.incbin "baserom.gba", 0x15F488C, 0x100
+sRayquazaSprites99:
+ax_sprite sRayquazaGfx99, 0x100
+ax_sprite_terminator
+sRayquazaGfx100:
+.incbin "baserom.gba", 0x15F499C, 0x80
+sRayquazaSprites100:
+ax_sprite sRayquazaGfx100, 0x80
+ax_sprite_terminator
+sRayquazaGfx101:
+.incbin "baserom.gba", 0x15F4A2C, 0x40
+sRayquazaGfx101_1:
+.incbin "baserom.gba", 0x15F4A6C, 0x60
+sRayquazaGfx101_2:
+.incbin "baserom.gba", 0x15F4ACC, 0x60
+sRayquazaGfx101_3:
+.incbin "baserom.gba", 0x15F4B2C, 0x140
+sRayquazaGfx101_4:
+.incbin "baserom.gba", 0x15F4C6C, 0x100
+sRayquazaSprites101:
+ax_sprite sRayquazaGfx101, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx101_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx101_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx101_3, 0x140
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx101_4, 0x100
+ax_sprite_terminator
+sRayquazaGfx102:
+.incbin "baserom.gba", 0x15F4DBC, 0x60
+sRayquazaSprites102:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx102, 0x60
+ax_sprite_terminator
+sRayquazaGfx103:
+.incbin "baserom.gba", 0x15F4E34, 0xE0
+sRayquazaSprites103:
+ax_sprite sRayquazaGfx103, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx104:
+.incbin "baserom.gba", 0x15F4F2C, 0x20
+sRayquazaSprites104:
+ax_sprite sRayquazaGfx104, 0x20
+ax_sprite_terminator
+sRayquazaGfx105:
+.incbin "baserom.gba", 0x15F4F5C, 0xE0
+sRayquazaGfx105_1:
+.incbin "baserom.gba", 0x15F503C, 0x180
+sRayquazaGfx105_2:
+.incbin "baserom.gba", 0x15F51BC, 0xE0
+sRayquazaGfx105_3:
+.incbin "baserom.gba", 0x15F529C, 0x40
+sRayquazaGfx105_4:
+.incbin "baserom.gba", 0x15F52DC, 0xE0
+sRayquazaGfx105_5:
+.incbin "baserom.gba", 0x15F53BC, 0xE0
+sRayquazaGfx105_6:
+.incbin "baserom.gba", 0x15F549C, 0xC0
+sRayquazaGfx105_7:
+.incbin "baserom.gba", 0x15F555C, 0x60
+sRayquazaSprites105:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx105, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx105_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx105_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx105_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx105_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx105_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx105_6, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx105_7, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRayquazaGfx106:
+.incbin "baserom.gba", 0x15F564C, 0x1A0
+sRayquazaSprites106:
+ax_sprite sRayquazaGfx106, 0x1a0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sRayquazaGfx107:
+.incbin "baserom.gba", 0x15F5804, 0x80
+sRayquazaSprites107:
+ax_sprite sRayquazaGfx107, 0x80
+ax_sprite_terminator
+sRayquazaGfx108:
+.incbin "baserom.gba", 0x15F5894, 0x1C0
+sRayquazaSprites108:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx108, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx109:
+.incbin "baserom.gba", 0x15F5A74, 0x40
+sRayquazaSprites109:
+ax_sprite sRayquazaGfx109, 0x40
+ax_sprite_terminator
+sRayquazaGfx110:
+.incbin "baserom.gba", 0x15F5AC4, 0x40
+sRayquazaSprites110:
+ax_sprite sRayquazaGfx110, 0x40
+ax_sprite_terminator
+sRayquazaGfx111:
+.incbin "baserom.gba", 0x15F5B14, 0x80
+sRayquazaSprites111:
+ax_sprite sRayquazaGfx111, 0x80
+ax_sprite_terminator
+sRayquazaGfx112:
+.incbin "baserom.gba", 0x15F5BA4, 0x80
+sRayquazaSprites112:
+ax_sprite sRayquazaGfx112, 0x80
+ax_sprite_terminator
+sRayquazaGfx113:
+.incbin "baserom.gba", 0x15F5C34, 0x60
+sRayquazaSprites113:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx113, 0x60
+ax_sprite_terminator
+sRayquazaGfx114:
+.incbin "baserom.gba", 0x15F5CAC, 0x40
+sRayquazaSprites114:
+ax_sprite sRayquazaGfx114, 0x40
+ax_sprite_terminator
+sRayquazaGfx115:
+.incbin "baserom.gba", 0x15F5CFC, 0xA0
+sRayquazaGfx115_1:
+.incbin "baserom.gba", 0x15F5D9C, 0xE0
+sRayquazaGfx115_2:
+.incbin "baserom.gba", 0x15F5E7C, 0xC0
+sRayquazaGfx115_3:
+.incbin "baserom.gba", 0x15F5F3C, 0xE0
+sRayquazaGfx115_4:
+.incbin "baserom.gba", 0x15F601C, 0x340
+sRayquazaGfx115_5:
+.incbin "baserom.gba", 0x15F635C, 0x60
+sRayquazaSprites115:
+ax_sprite sRayquazaGfx115, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx115_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx115_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx115_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx115_4, 0x340
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx115_5, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRayquazaGfx116:
+.incbin "baserom.gba", 0x15F6424, 0x20
+sRayquazaGfx116_1:
+.incbin "baserom.gba", 0x15F6444, 0x1A0
+sRayquazaSprites116:
+ax_sprite sRayquazaGfx116, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx116_1, 0x1a0
+ax_sprite_terminator
+sRayquazaGfx117:
+.incbin "baserom.gba", 0x15F6604, 0x100
+sRayquazaSprites117:
+ax_sprite sRayquazaGfx117, 0x100
+ax_sprite_terminator
+sRayquazaGfx118:
+.incbin "baserom.gba", 0x15F6714, 0x80
+sRayquazaSprites118:
+ax_sprite sRayquazaGfx118, 0x80
+ax_sprite_terminator
+sRayquazaGfx119:
+.incbin "baserom.gba", 0x15F67A4, 0x20
+sRayquazaGfx119_1:
+.incbin "baserom.gba", 0x15F67C4, 0x40
+sRayquazaGfx119_2:
+.incbin "baserom.gba", 0x15F6804, 0x100
+sRayquazaSprites119:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx119, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx119_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx119_2, 0x100
+ax_sprite_terminator
+sRayquazaGfx120:
+.incbin "baserom.gba", 0x15F693C, 0x80
+sRayquazaSprites120:
+ax_sprite sRayquazaGfx120, 0x80
+ax_sprite_terminator
+sRayquazaGfx121:
+.incbin "baserom.gba", 0x15F69CC, 0x40
+sRayquazaSprites121:
+ax_sprite sRayquazaGfx121, 0x40
+ax_sprite_terminator
+sRayquazaGfx122:
+.incbin "baserom.gba", 0x15F6A1C, 0x20
+sRayquazaSprites122:
+ax_sprite sRayquazaGfx122, 0x20
+ax_sprite_terminator
+sRayquazaGfx123:
+.incbin "baserom.gba", 0x15F6A4C, 0x20
+sRayquazaSprites123:
+ax_sprite sRayquazaGfx123, 0x20
+ax_sprite_terminator
+sRayquazaGfx124:
+.incbin "baserom.gba", 0x15F6A7C, 0x40
+sRayquazaSprites124:
+ax_sprite sRayquazaGfx124, 0x40
+ax_sprite_terminator
+sRayquazaGfx125:
+.incbin "baserom.gba", 0x15F6ACC, 0x80
+sRayquazaSprites125:
+ax_sprite sRayquazaGfx125, 0x80
+ax_sprite_terminator
+sRayquazaGfx126:
+.incbin "baserom.gba", 0x15F6B5C, 0x40
+sRayquazaSprites126:
+ax_sprite sRayquazaGfx126, 0x40
+ax_sprite_terminator
+sRayquazaGfx127:
+.incbin "baserom.gba", 0x15F6BAC, 0x80
+sRayquazaSprites127:
+ax_sprite sRayquazaGfx127, 0x80
+ax_sprite_terminator
+sRayquazaGfx128:
+.incbin "baserom.gba", 0x15F6C3C, 0x20
+sRayquazaGfx128_1:
+.incbin "baserom.gba", 0x15F6C5C, 0x60
+sRayquazaGfx128_2:
+.incbin "baserom.gba", 0x15F6CBC, 0xE0
+sRayquazaGfx128_3:
+.incbin "baserom.gba", 0x15F6D9C, 0xE0
+sRayquazaGfx128_4:
+.incbin "baserom.gba", 0x15F6E7C, 0x140
+sRayquazaSprites128:
+ax_sprite sRayquazaGfx128, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx128_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx128_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx128_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx128_4, 0x140
+ax_sprite_terminator
+sRayquazaGfx129:
+.incbin "baserom.gba", 0x15F700C, 0x100
+sRayquazaSprites129:
+ax_sprite sRayquazaGfx129, 0x100
+ax_sprite_terminator
+sRayquazaGfx130:
+.incbin "baserom.gba", 0x15F711C, 0x40
+sRayquazaGfx130_1:
+.incbin "baserom.gba", 0x15F715C, 0x20
+sRayquazaSprites130:
+ax_sprite sRayquazaGfx130, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx130_1, 0x20
+ax_sprite_terminator
+sRayquazaGfx131:
+.incbin "baserom.gba", 0x15F719C, 0x80
+sRayquazaSprites131:
+ax_sprite sRayquazaGfx131, 0x80
+ax_sprite_terminator
+sRayquazaGfx132:
+.incbin "baserom.gba", 0x15F722C, 0x40
+sRayquazaSprites132:
+ax_sprite sRayquazaGfx132, 0x40
+ax_sprite_terminator
+sRayquazaGfx133:
+.incbin "baserom.gba", 0x15F727C, 0x100
+sRayquazaSprites133:
+ax_sprite sRayquazaGfx133, 0x100
+ax_sprite_terminator
+sRayquazaGfx134:
+.incbin "baserom.gba", 0x15F738C, 0x20
+sRayquazaSprites134:
+ax_sprite sRayquazaGfx134, 0x20
+ax_sprite_terminator
+sRayquazaGfx135:
+.incbin "baserom.gba", 0x15F73BC, 0x40
+sRayquazaSprites135:
+ax_sprite sRayquazaGfx135, 0x40
+ax_sprite_terminator
+sRayquazaGfx136:
+.incbin "baserom.gba", 0x15F740C, 0x20
+sRayquazaSprites136:
+ax_sprite sRayquazaGfx136, 0x20
+ax_sprite_terminator
+sRayquazaGfx137:
+.incbin "baserom.gba", 0x15F743C, 0x20
+sRayquazaGfx137_1:
+.incbin "baserom.gba", 0x15F745C, 0x40
+sRayquazaGfx137_2:
+.incbin "baserom.gba", 0x15F749C, 0x140
+sRayquazaSprites137:
+ax_sprite sRayquazaGfx137, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx137_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx137_2, 0x140
+ax_sprite_terminator
+sRayquazaGfx138:
+.incbin "baserom.gba", 0x15F760C, 0x100
+sRayquazaSprites138:
+ax_sprite sRayquazaGfx138, 0x100
+ax_sprite_terminator
+sRayquazaGfx139:
+.incbin "baserom.gba", 0x15F771C, 0x40
+sRayquazaSprites139:
+ax_sprite sRayquazaGfx139, 0x40
+ax_sprite_terminator
+sRayquazaGfx140:
+.incbin "baserom.gba", 0x15F776C, 0x20
+sRayquazaSprites140:
+ax_sprite sRayquazaGfx140, 0x20
+ax_sprite_terminator
+sRayquazaGfx141:
+.incbin "baserom.gba", 0x15F779C, 0x80
+sRayquazaSprites141:
+ax_sprite sRayquazaGfx141, 0x80
+ax_sprite_terminator
+sRayquazaGfx142:
+.incbin "baserom.gba", 0x15F782C, 0x40
+sRayquazaSprites142:
+ax_sprite sRayquazaGfx142, 0x40
+ax_sprite_terminator
+sRayquazaGfx143:
+.incbin "baserom.gba", 0x15F787C, 0x80
+sRayquazaSprites143:
+ax_sprite sRayquazaGfx143, 0x80
+ax_sprite_terminator
+sRayquazaGfx144:
+.incbin "baserom.gba", 0x15F790C, 0x40
+sRayquazaSprites144:
+ax_sprite sRayquazaGfx144, 0x40
+ax_sprite_terminator
+sRayquazaGfx145:
+.incbin "baserom.gba", 0x15F795C, 0xE0
+sRayquazaSprites145:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx145, 0xe0
+ax_sprite_terminator
+sRayquazaGfx146:
+.incbin "baserom.gba", 0x15F7A54, 0x40
+sRayquazaSprites146:
+ax_sprite sRayquazaGfx146, 0x40
+ax_sprite_terminator
+sRayquazaGfx147:
+.incbin "baserom.gba", 0x15F7AA4, 0x40
+sRayquazaSprites147:
+ax_sprite sRayquazaGfx147, 0x40
+ax_sprite_terminator
+sRayquazaGfx148:
+.incbin "baserom.gba", 0x15F7AF4, 0x60
+sRayquazaSprites148:
+ax_sprite sRayquazaGfx148, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx149:
+.incbin "baserom.gba", 0x15F7B6C, 0x40
+sRayquazaSprites149:
+ax_sprite sRayquazaGfx149, 0x40
+ax_sprite_terminator
+sRayquazaGfx150:
+.incbin "baserom.gba", 0x15F7BBC, 0x40
+sRayquazaSprites150:
+ax_sprite sRayquazaGfx150, 0x40
+ax_sprite_terminator
+sRayquazaGfx151:
+.incbin "baserom.gba", 0x15F7C0C, 0x60
+sRayquazaGfx151_1:
+.incbin "baserom.gba", 0x15F7C6C, 0x160
+sRayquazaGfx151_2:
+.incbin "baserom.gba", 0x15F7DCC, 0x60
+sRayquazaGfx151_3:
+.incbin "baserom.gba", 0x15F7E2C, 0x60
+sRayquazaGfx151_4:
+.incbin "baserom.gba", 0x15F7E8C, 0x60
+sRayquazaGfx151_5:
+.incbin "baserom.gba", 0x15F7EEC, 0x40
+sRayquazaSprites151:
+ax_sprite sRayquazaGfx151, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx151_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx151_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx151_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx151_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx151_5, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx152:
+.incbin "baserom.gba", 0x15F7F94, 0xC0
+sRayquazaSprites152:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx152, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx153:
+.incbin "baserom.gba", 0x15F8074, 0xC0
+sRayquazaGfx153_1:
+.incbin "baserom.gba", 0x15F8134, 0x20
+sRayquazaSprites153:
+ax_sprite sRayquazaGfx153, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx153_1, 0x20
+ax_sprite_terminator
+sRayquazaGfx154:
+.incbin "baserom.gba", 0x15F8174, 0x40
+sRayquazaSprites154:
+ax_sprite sRayquazaGfx154, 0x40
+ax_sprite_terminator
+sRayquazaGfx155:
+.incbin "baserom.gba", 0x15F81C4, 0x80
+sRayquazaSprites155:
+ax_sprite sRayquazaGfx155, 0x80
+ax_sprite_terminator
+sRayquazaGfx156:
+.incbin "baserom.gba", 0x15F8254, 0x60
+sRayquazaGfx156_1:
+.incbin "baserom.gba", 0x15F82B4, 0x60
+sRayquazaGfx156_2:
+.incbin "baserom.gba", 0x15F8314, 0x160
+sRayquazaGfx156_3:
+.incbin "baserom.gba", 0x15F8474, 0x60
+sRayquazaGfx156_4:
+.incbin "baserom.gba", 0x15F84D4, 0x60
+sRayquazaGfx156_5:
+.incbin "baserom.gba", 0x15F8534, 0x60
+sRayquazaSprites156:
+ax_sprite sRayquazaGfx156, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx156_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx156_2, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx156_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx156_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx156_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx157:
+.incbin "baserom.gba", 0x15F85FC, 0x80
+sRayquazaSprites157:
+ax_sprite sRayquazaGfx157, 0x80
+ax_sprite_terminator
+sRayquazaGfx158:
+.incbin "baserom.gba", 0x15F868C, 0x40
+sRayquazaSprites158:
+ax_sprite sRayquazaGfx158, 0x40
+ax_sprite_terminator
+sRayquazaGfx159:
+.incbin "baserom.gba", 0x15F86DC, 0x20
+sRayquazaSprites159:
+ax_sprite sRayquazaGfx159, 0x20
+ax_sprite_terminator
+sRayquazaGfx160:
+.incbin "baserom.gba", 0x15F870C, 0x80
+sRayquazaSprites160:
+ax_sprite sRayquazaGfx160, 0x80
+ax_sprite_terminator
+sRayquazaGfx161:
+.incbin "baserom.gba", 0x15F879C, 0x80
+sRayquazaSprites161:
+ax_sprite sRayquazaGfx161, 0x80
+ax_sprite_terminator
+sRayquazaGfx162:
+.incbin "baserom.gba", 0x15F882C, 0x60
+sRayquazaSprites162:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx162, 0x60
+ax_sprite_terminator
+sRayquazaGfx163:
+.incbin "baserom.gba", 0x15F88A4, 0x80
+sRayquazaSprites163:
+ax_sprite sRayquazaGfx163, 0x80
+ax_sprite_terminator
+sRayquazaGfx164:
+.incbin "baserom.gba", 0x15F8934, 0x60
+sRayquazaGfx164_1:
+.incbin "baserom.gba", 0x15F8994, 0x60
+sRayquazaGfx164_2:
+.incbin "baserom.gba", 0x15F89F4, 0x60
+sRayquazaGfx164_3:
+.incbin "baserom.gba", 0x15F8A54, 0x220
+sRayquazaSprites164:
+ax_sprite sRayquazaGfx164, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx164_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx164_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx164_3, 0x220
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx165:
+.incbin "baserom.gba", 0x15F8CBC, 0xA0
+sRayquazaGfx165_1:
+.incbin "baserom.gba", 0x15F8D5C, 0x20
+sRayquazaSprites165:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx165, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx165_1, 0x20
+ax_sprite_terminator
+sRayquazaGfx166:
+.incbin "baserom.gba", 0x15F8DA4, 0x20
+sRayquazaSprites166:
+ax_sprite sRayquazaGfx166, 0x20
+ax_sprite_terminator
+sRayquazaGfx167:
+.incbin "baserom.gba", 0x15F8DD4, 0x40
+sRayquazaSprites167:
+ax_sprite sRayquazaGfx167, 0x40
+ax_sprite_terminator
+sRayquazaGfx168:
+.incbin "baserom.gba", 0x15F8E24, 0x80
+sRayquazaGfx168_1:
+.incbin "baserom.gba", 0x15F8EA4, 0x240
+sRayquazaGfx168_2:
+.incbin "baserom.gba", 0x15F90E4, 0xA0
+sRayquazaSprites168:
+ax_sprite sRayquazaGfx168, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx168_1, 0x240
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx168_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx169:
+.incbin "baserom.gba", 0x15F91BC, 0x20
+sRayquazaGfx169_1:
+.incbin "baserom.gba", 0x15F91DC, 0xA0
+sRayquazaSprites169:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx169, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx169_1, 0xa0
+ax_sprite_terminator
+sRayquazaGfx170:
+.incbin "baserom.gba", 0x15F92A4, 0x40
+sRayquazaSprites170:
+ax_sprite sRayquazaGfx170, 0x40
+ax_sprite_terminator
+sRayquazaGfx171:
+.incbin "baserom.gba", 0x15F92F4, 0x40
+sRayquazaSprites171:
+ax_sprite sRayquazaGfx171, 0x40
+ax_sprite_terminator
+sRayquazaGfx172:
+.incbin "baserom.gba", 0x15F9344, 0x60
+sRayquazaGfx172_1:
+.incbin "baserom.gba", 0x15F93A4, 0x60
+sRayquazaGfx172_2:
+.incbin "baserom.gba", 0x15F9404, 0x60
+sRayquazaGfx172_3:
+.incbin "baserom.gba", 0x15F9464, 0x60
+sRayquazaSprites172:
+ax_sprite sRayquazaGfx172, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx172_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx172_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx172_3, 0x60
+ax_sprite_terminator
+sRayquazaGfx173:
+.incbin "baserom.gba", 0x15F9504, 0x60
+sRayquazaGfx173_1:
+.incbin "baserom.gba", 0x15F9564, 0x240
+sRayquazaGfx173_2:
+.incbin "baserom.gba", 0x15F97A4, 0xA0
+sRayquazaSprites173:
+ax_sprite sRayquazaGfx173, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx173_1, 0x240
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx173_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx174:
+.incbin "baserom.gba", 0x15F987C, 0x100
+sRayquazaSprites174:
+ax_sprite sRayquazaGfx174, 0x100
+ax_sprite_terminator
+sRayquazaGfx175:
+.incbin "baserom.gba", 0x15F998C, 0x80
+sRayquazaSprites175:
+ax_sprite sRayquazaGfx175, 0x80
+ax_sprite_terminator
+sRayquazaGfx176:
+.incbin "baserom.gba", 0x15F9A1C, 0x40
+sRayquazaSprites176:
+ax_sprite sRayquazaGfx176, 0x40
+ax_sprite_terminator
+sRayquazaGfx177:
+.incbin "baserom.gba", 0x15F9A6C, 0x20
+sRayquazaSprites177:
+ax_sprite sRayquazaGfx177, 0x20
+ax_sprite_terminator
+sRayquazaGfx178:
+.incbin "baserom.gba", 0x15F9A9C, 0x40
+sRayquazaSprites178:
+ax_sprite sRayquazaGfx178, 0x40
+ax_sprite_terminator
+sRayquazaGfx179:
+.incbin "baserom.gba", 0x15F9AEC, 0x20
+sRayquazaSprites179:
+ax_sprite sRayquazaGfx179, 0x20
+ax_sprite_terminator
+sRayquazaGfx180:
+.incbin "baserom.gba", 0x15F9B1C, 0x20
+sRayquazaSprites180:
+ax_sprite sRayquazaGfx180, 0x20
+ax_sprite_terminator
+sRayquazaGfx181:
+.incbin "baserom.gba", 0x15F9B4C, 0x100
+sRayquazaSprites181:
+ax_sprite sRayquazaGfx181, 0x100
+ax_sprite_terminator
+sRayquazaGfx182:
+.incbin "baserom.gba", 0x15F9C5C, 0x60
+sRayquazaGfx182_1:
+.incbin "baserom.gba", 0x15F9CBC, 0x60
+sRayquazaGfx182_2:
+.incbin "baserom.gba", 0x15F9D1C, 0x60
+sRayquazaGfx182_3:
+.incbin "baserom.gba", 0x15F9D7C, 0x80
+sRayquazaSprites182:
+ax_sprite sRayquazaGfx182, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx182_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx182_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx182_3, 0x80
+ax_sprite_terminator
+sRayquazaGfx183:
+.incbin "baserom.gba", 0x15F9E3C, 0x20
+sRayquazaGfx183_1:
+.incbin "baserom.gba", 0x15F9E5C, 0x140
+sRayquazaGfx183_2:
+.incbin "baserom.gba", 0x15F9F9C, 0x40
+sRayquazaSprites183:
+ax_sprite sRayquazaGfx183, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx183_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx183_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx184:
+.incbin "baserom.gba", 0x15FA014, 0x80
+sRayquazaSprites184:
+ax_sprite sRayquazaGfx184, 0x80
+ax_sprite_terminator
+sRayquazaGfx185:
+.incbin "baserom.gba", 0x15FA0A4, 0x100
+sRayquazaSprites185:
+ax_sprite sRayquazaGfx185, 0x100
+ax_sprite_terminator
+sRayquazaGfx186:
+.incbin "baserom.gba", 0x15FA1B4, 0x80
+sRayquazaSprites186:
+ax_sprite sRayquazaGfx186, 0x80
+ax_sprite_terminator
+sRayquazaGfx187:
+.incbin "baserom.gba", 0x15FA244, 0x40
+sRayquazaSprites187:
+ax_sprite sRayquazaGfx187, 0x40
+ax_sprite_terminator
+sRayquazaGfx188:
+.incbin "baserom.gba", 0x15FA294, 0x20
+sRayquazaGfx188_1:
+.incbin "baserom.gba", 0x15FA2B4, 0xA0
+sRayquazaSprites188:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx188, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx188_1, 0xa0
+ax_sprite_terminator
+sRayquazaGfx189:
+.incbin "baserom.gba", 0x15FA37C, 0x40
+sRayquazaSprites189:
+ax_sprite sRayquazaGfx189, 0x40
+ax_sprite_terminator
+sRayquazaGfx190:
+.incbin "baserom.gba", 0x15FA3CC, 0x20
+sRayquazaSprites190:
+ax_sprite sRayquazaGfx190, 0x20
+ax_sprite_terminator
+sRayquazaGfx191:
+.incbin "baserom.gba", 0x15FA3FC, 0x60
+sRayquazaGfx191_1:
+.incbin "baserom.gba", 0x15FA45C, 0x60
+sRayquazaGfx191_2:
+.incbin "baserom.gba", 0x15FA4BC, 0x160
+sRayquazaGfx191_3:
+.incbin "baserom.gba", 0x15FA61C, 0x40
+sRayquazaGfx191_4:
+.incbin "baserom.gba", 0x15FA65C, 0x60
+sRayquazaGfx191_5:
+.incbin "baserom.gba", 0x15FA6BC, 0x60
+sRayquazaSprites191:
+ax_sprite sRayquazaGfx191, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx191_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx191_2, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx191_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx191_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx191_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx192:
+.incbin "baserom.gba", 0x15FA784, 0x40
+sRayquazaGfx192_1:
+.incbin "baserom.gba", 0x15FA7C4, 0xA0
+sRayquazaSprites192:
+ax_sprite sRayquazaGfx192, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx192_1, 0xa0
+ax_sprite_terminator
+sRayquazaGfx193:
+.incbin "baserom.gba", 0x15FA884, 0xE0
+sRayquazaSprites193:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx193, 0xe0
+ax_sprite_terminator
+sRayquazaGfx194:
+.incbin "baserom.gba", 0x15FA97C, 0x80
+sRayquazaSprites194:
+ax_sprite sRayquazaGfx194, 0x80
+ax_sprite_terminator
+sRayquazaGfx195:
+.incbin "baserom.gba", 0x15FAA0C, 0x40
+sRayquazaGfx195_1:
+.incbin "baserom.gba", 0x15FAA4C, 0x20
+sRayquazaSprites195:
+ax_sprite sRayquazaGfx195, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx195_1, 0x20
+ax_sprite_terminator
+sRayquazaGfx196:
+.incbin "baserom.gba", 0x15FAA8C, 0x60
+sRayquazaGfx196_1:
+.incbin "baserom.gba", 0x15FAAEC, 0x1E0
+sRayquazaGfx196_2:
+.incbin "baserom.gba", 0x15FACCC, 0x160
+sRayquazaSprites196:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx196, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx196_1, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx196_2, 0x160
+ax_sprite_terminator
+sRayquazaGfx197:
+.incbin "baserom.gba", 0x15FAE64, 0x20
+sRayquazaGfx197_1:
+.incbin "baserom.gba", 0x15FAE84, 0xC0
+sRayquazaSprites197:
+ax_sprite sRayquazaGfx197, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx197_1, 0xc0
+ax_sprite_terminator
+sRayquazaGfx198:
+.incbin "baserom.gba", 0x15FAF64, 0x60
+sRayquazaSprites198:
+ax_sprite sRayquazaGfx198, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx199:
+.incbin "baserom.gba", 0x15FAFDC, 0x40
+sRayquazaSprites199:
+ax_sprite sRayquazaGfx199, 0x40
+ax_sprite_terminator
+sRayquazaGfx200:
+.incbin "baserom.gba", 0x15FB02C, 0x40
+sRayquazaSprites200:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx200, 0x40
+ax_sprite_terminator
+sRayquazaGfx201:
+.incbin "baserom.gba", 0x15FB084, 0xA0
+sRayquazaGfx201_1:
+.incbin "baserom.gba", 0x15FB124, 0xA0
+sRayquazaGfx201_2:
+.incbin "baserom.gba", 0x15FB1C4, 0xE0
+sRayquazaGfx201_3:
+.incbin "baserom.gba", 0x15FB2A4, 0x80
+sRayquazaGfx201_4:
+.incbin "baserom.gba", 0x15FB324, 0x40
+sRayquazaSprites201:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx201, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx201_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx201_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx201_3, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx201_4, 0x40
+ax_sprite_terminator
+sRayquazaGfx202:
+.incbin "baserom.gba", 0x15FB3BC, 0x20
+sRayquazaGfx202_1:
+.incbin "baserom.gba", 0x15FB3DC, 0x1A0
+sRayquazaSprites202:
+ax_sprite sRayquazaGfx202, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx202_1, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx203:
+.incbin "baserom.gba", 0x15FB5A4, 0x100
+sRayquazaSprites203:
+ax_sprite sRayquazaGfx203, 0x100
+ax_sprite_terminator
+sRayquazaGfx204:
+.incbin "baserom.gba", 0x15FB6B4, 0x20
+sRayquazaGfx204_1:
+.incbin "baserom.gba", 0x15FB6D4, 0xC0
+sRayquazaSprites204:
+ax_sprite sRayquazaGfx204, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx204_1, 0xc0
+ax_sprite_terminator
+sRayquazaGfx205:
+.incbin "baserom.gba", 0x15FB7B4, 0x100
+sRayquazaSprites205:
+ax_sprite sRayquazaGfx205, 0x100
+ax_sprite_terminator
+sRayquazaGfx206:
+.incbin "baserom.gba", 0x15FB8C4, 0x80
+sRayquazaSprites206:
+ax_sprite sRayquazaGfx206, 0x80
+ax_sprite_terminator
+sRayquazaGfx207:
+.incbin "baserom.gba", 0x15FB954, 0x20
+sRayquazaSprites207:
+ax_sprite sRayquazaGfx207, 0x20
+ax_sprite_terminator
+sRayquazaGfx208:
+.incbin "baserom.gba", 0x15FB984, 0x60
+sRayquazaGfx208_1:
+.incbin "baserom.gba", 0x15FB9E4, 0x160
+sRayquazaGfx208_2:
+.incbin "baserom.gba", 0x15FBB44, 0x160
+sRayquazaGfx208_3:
+.incbin "baserom.gba", 0x15FBCA4, 0x60
+sRayquazaSprites208:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx208, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx208_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx208_2, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx208_3, 0x60
+ax_sprite_terminator
+sRayquazaGfx209:
+.incbin "baserom.gba", 0x15FBD4C, 0x20
+sRayquazaGfx209_1:
+.incbin "baserom.gba", 0x15FBD6C, 0x40
+sRayquazaSprites209:
+ax_sprite sRayquazaGfx209, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx209_1, 0x40
+ax_sprite_terminator
+sRayquazaGfx210:
+.incbin "baserom.gba", 0x15FBDCC, 0x40
+sRayquazaSprites210:
+ax_sprite sRayquazaGfx210, 0x40
+ax_sprite_terminator
+sRayquazaGfx211:
+.incbin "baserom.gba", 0x15FBE1C, 0x40
+sRayquazaGfx211_1:
+.incbin "baserom.gba", 0x15FBE5C, 0x60
+sRayquazaGfx211_2:
+.incbin "baserom.gba", 0x15FBEBC, 0x240
+sRayquazaGfx211_3:
+.incbin "baserom.gba", 0x15FC0FC, 0x80
+sRayquazaSprites211:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx211, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx211_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx211_2, 0x240
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx211_3, 0x80
+ax_sprite_terminator
+sRayquazaGfx212:
+.incbin "baserom.gba", 0x15FC1C4, 0x180
+sRayquazaSprites212:
+ax_sprite sRayquazaGfx212, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRayquazaGfx213:
+.incbin "baserom.gba", 0x15FC35C, 0x100
+sRayquazaSprites213:
+ax_sprite sRayquazaGfx213, 0x100
+ax_sprite_terminator
+sRayquazaGfx214:
+.incbin "baserom.gba", 0x15FC46C, 0x20
+sRayquazaSprites214:
+ax_sprite sRayquazaGfx214, 0x20
+ax_sprite_terminator
+sRayquazaGfx215:
+.incbin "baserom.gba", 0x15FC49C, 0x20
+sRayquazaSprites215:
+ax_sprite sRayquazaGfx215, 0x20
+ax_sprite_terminator
+sRayquazaGfx216:
+.incbin "baserom.gba", 0x15FC4CC, 0x20
+sRayquazaSprites216:
+ax_sprite sRayquazaGfx216, 0x20
+ax_sprite_terminator
+sRayquazaGfx217:
+.incbin "baserom.gba", 0x15FC4FC, 0x60
+sRayquazaGfx217_1:
+.incbin "baserom.gba", 0x15FC55C, 0x60
+sRayquazaGfx217_2:
+.incbin "baserom.gba", 0x15FC5BC, 0x1E0
+sRayquazaGfx217_3:
+.incbin "baserom.gba", 0x15FC79C, 0x100
+sRayquazaSprites217:
+ax_sprite sRayquazaGfx217, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx217_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx217_2, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx217_3, 0x100
+ax_sprite_terminator
+sRayquazaGfx218:
+.incbin "baserom.gba", 0x15FC8DC, 0x80
+sRayquazaSprites218:
+ax_sprite sRayquazaGfx218, 0x80
+ax_sprite_terminator
+sRayquazaGfx219:
+.incbin "baserom.gba", 0x15FC96C, 0x40
+sRayquazaSprites219:
+ax_sprite sRayquazaGfx219, 0x40
+ax_sprite_terminator
+sRayquazaGfx220:
+.incbin "baserom.gba", 0x15FC9BC, 0xE0
+sRayquazaSprites220:
+ax_sprite sRayquazaGfx220, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx221:
+.incbin "baserom.gba", 0x15FCAB4, 0x20
+sRayquazaGfx221_1:
+.incbin "baserom.gba", 0x15FCAD4, 0x80
+sRayquazaGfx221_2:
+.incbin "baserom.gba", 0x15FCB54, 0xA0
+sRayquazaGfx221_3:
+.incbin "baserom.gba", 0x15FCBF4, 0xC0
+sRayquazaGfx221_4:
+.incbin "baserom.gba", 0x15FCCB4, 0xE0
+sRayquazaGfx221_5:
+.incbin "baserom.gba", 0x15FCD94, 0x100
+sRayquazaGfx221_6:
+.incbin "baserom.gba", 0x15FCE94, 0x80
+sRayquazaGfx221_7:
+.incbin "baserom.gba", 0x15FCF14, 0x40
+sRayquazaGfx221_8:
+.incbin "baserom.gba", 0x15FCF54, 0x20
+sRayquazaSprites221:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx221, 0x20
+ax_sprite 0, 0xc0
+ax_sprite sRayquazaGfx221_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sRayquazaGfx221_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx221_3, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx221_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx221_5, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx221_6, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx221_7, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sRayquazaGfx221_8, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx222:
+.incbin "baserom.gba", 0x15FD014, 0x80
+sRayquazaGfx222_1:
+.incbin "baserom.gba", 0x15FD094, 0xA0
+sRayquazaGfx222_2:
+.incbin "baserom.gba", 0x15FD134, 0xC0
+sRayquazaGfx222_3:
+.incbin "baserom.gba", 0x15FD1F4, 0xE0
+sRayquazaGfx222_4:
+.incbin "baserom.gba", 0x15FD2D4, 0x100
+sRayquazaGfx222_5:
+.incbin "baserom.gba", 0x15FD3D4, 0xE0
+sRayquazaSprites222:
+ax_sprite 0, 0x120
+ax_sprite sRayquazaGfx222, 0x80
+ax_sprite 0, 0x80
+ax_sprite sRayquazaGfx222_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx222_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx222_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx222_4, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx222_5, 0xe0
+ax_sprite 0, 0x100
+ax_sprite_terminator
+sRayquazaGfx223:
+.incbin "baserom.gba", 0x15FD524, 0x80
+sRayquazaGfx223_1:
+.incbin "baserom.gba", 0x15FD5A4, 0xA0
+sRayquazaGfx223_2:
+.incbin "baserom.gba", 0x15FD644, 0xC0
+sRayquazaGfx223_3:
+.incbin "baserom.gba", 0x15FD704, 0xC0
+sRayquazaGfx223_4:
+.incbin "baserom.gba", 0x15FD7C4, 0xA0
+sRayquazaGfx223_5:
+.incbin "baserom.gba", 0x15FD864, 0xC0
+sRayquazaGfx223_6:
+.incbin "baserom.gba", 0x15FD924, 0xC0
+sRayquazaGfx223_7:
+.incbin "baserom.gba", 0x15FD9E4, 0x80
+sRayquazaSprites223:
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx223, 0x80
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx223_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx223_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx223_3, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx223_4, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx223_5, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx223_6, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx223_7, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sRayquazaGfx224:
+.incbin "baserom.gba", 0x15FDAF4, 0x60
+sRayquazaGfx224_1:
+.incbin "baserom.gba", 0x15FDB54, 0x20
+sRayquazaGfx224_2:
+.incbin "baserom.gba", 0x15FDB74, 0xC0
+sRayquazaGfx224_3:
+.incbin "baserom.gba", 0x15FDC34, 0xC0
+sRayquazaGfx224_4:
+.incbin "baserom.gba", 0x15FDCF4, 0xC0
+sRayquazaGfx224_5:
+.incbin "baserom.gba", 0x15FDDB4, 0x280
+sRayquazaGfx224_6:
+.incbin "baserom.gba", 0x15FE034, 0xA0
+sRayquazaSprites224:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx224, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx224_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx224_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx224_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx224_4, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx224_5, 0x280
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx224_6, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaGfx225:
+.incbin "baserom.gba", 0x15FE154, 0x40
+sRayquazaGfx225_1:
+.incbin "baserom.gba", 0x15FE194, 0x60
+sRayquazaGfx225_2:
+.incbin "baserom.gba", 0x15FE1F4, 0x20
+sRayquazaGfx225_3:
+.incbin "baserom.gba", 0x15FE214, 0xC0
+sRayquazaGfx225_4:
+.incbin "baserom.gba", 0x15FE2D4, 0x160
+sRayquazaGfx225_5:
+.incbin "baserom.gba", 0x15FE434, 0x320
+sRayquazaSprites225:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx225, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sRayquazaGfx225_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx225_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sRayquazaGfx225_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx225_4, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx225_5, 0x320
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx226:
+.incbin "baserom.gba", 0x15FE7C4, 0x60
+sRayquazaGfx226_1:
+.incbin "baserom.gba", 0x15FE824, 0x60
+sRayquazaGfx226_2:
+.incbin "baserom.gba", 0x15FE884, 0xA0
+sRayquazaGfx226_3:
+.incbin "baserom.gba", 0x15FE924, 0xE0
+sRayquazaGfx226_4:
+.incbin "baserom.gba", 0x15FEA04, 0xE0
+sRayquazaGfx226_5:
+.incbin "baserom.gba", 0x15FEAE4, 0xE0
+sRayquazaGfx226_6:
+.incbin "baserom.gba", 0x15FEBC4, 0xE0
+sRayquazaGfx226_7:
+.incbin "baserom.gba", 0x15FECA4, 0x80
+sRayquazaSprites226:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaGfx226, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sRayquazaGfx226_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sRayquazaGfx226_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx226_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx226_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx226_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx226_6, 0xe0
+ax_sprite 0, 0x80
+ax_sprite sRayquazaGfx226_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx227:
+.incbin "baserom.gba", 0x15FEDB4, 0x20
+sRayquazaGfx227_1:
+.incbin "baserom.gba", 0x15FEDD4, 0x20
+sRayquazaSprites227:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx227, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx227_1, 0x20
+ax_sprite_terminator
+sRayquazaGfx228:
+.incbin "baserom.gba", 0x15FEE1C, 0x40
+sRayquazaSprites228:
+ax_sprite sRayquazaGfx228, 0x40
+ax_sprite_terminator
+sRayquazaGfx229:
+.incbin "baserom.gba", 0x15FEE6C, 0x20
+sRayquazaSprites229:
+ax_sprite sRayquazaGfx229, 0x20
+ax_sprite_terminator
+sRayquazaGfx230:
+.incbin "baserom.gba", 0x15FEE9C, 0xE0
+sRayquazaSprites230:
+ax_sprite sRayquazaGfx230, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaGfx231:
+.incbin "baserom.gba", 0x15FEF94, 0x3E0
+sRayquazaSprites231:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaGfx231, 0x3e0
+ax_sprite_terminator
+sAxPosesRayquaza:
+.4byte sRayquazaPose1
+.4byte sRayquazaPose2
+.4byte sRayquazaPose3
+.4byte sRayquazaPose4
+.4byte sRayquazaPose5
+.4byte sRayquazaPose6
+.4byte sRayquazaPose7
+.4byte sRayquazaPose8
+.4byte sRayquazaPose9
+.4byte sRayquazaPose10
+.4byte sRayquazaPose11
+.4byte sRayquazaPose12
+.4byte sRayquazaPose13
+.4byte sRayquazaPose14
+.4byte sRayquazaPose15
+.4byte sRayquazaPose16
+.4byte sRayquazaPose17
+.4byte sRayquazaPose18
+.4byte sRayquazaPose19
+.4byte sRayquazaPose20
+.4byte sRayquazaPose21
+.4byte sRayquazaPose22
+.4byte sRayquazaPose23
+.4byte sRayquazaPose24
+.4byte sRayquazaPose25
+.4byte sRayquazaPose26
+.4byte sRayquazaPose27
+.4byte sRayquazaPose28
+.4byte sRayquazaPose29
+.4byte sRayquazaPose30
+.4byte sRayquazaPose31
+.4byte sRayquazaPose32
+.4byte sRayquazaPose33
+.4byte sRayquazaPose34
+.4byte sRayquazaPose35
+.4byte sRayquazaPose36
+.4byte sRayquazaPose37
+.4byte sRayquazaPose38
+.4byte sRayquazaPose39
+.4byte sRayquazaPose40
+.4byte sRayquazaPose41
+.4byte sRayquazaPose42
+.4byte sRayquazaPose43
+.4byte sRayquazaPose44
+.4byte sRayquazaPose45
+.4byte sRayquazaPose46
+.4byte sRayquazaPose47
+.4byte sRayquazaPose48
+.4byte sRayquazaPose49
+.4byte sRayquazaPose50
+.4byte sRayquazaPose51
+.4byte sRayquazaPose52
+.4byte sRayquazaPose53
+.4byte sRayquazaPose54
+.4byte sRayquazaPose55
+.4byte sRayquazaPose56
+.4byte sRayquazaPose57
+.4byte sRayquazaPose58
+.4byte sRayquazaPose59
+.4byte sRayquazaPose60
+.4byte sRayquazaPose61
+.4byte sRayquazaPose62
+.4byte sRayquazaPose63
+.4byte sRayquazaPose64
+.4byte sRayquazaPose65
+.4byte sRayquazaPose66
+.4byte sRayquazaPose67
+.4byte sRayquazaPose68
+.4byte sRayquazaPose69
+.4byte sRayquazaPose70
+.4byte sRayquazaPose71
+.4byte sRayquazaPose72
+.4byte sRayquazaPose73
+.4byte sRayquazaPose74
+.4byte sRayquazaPose75
+.4byte sRayquazaPose76
+.4byte sRayquazaPose77
+.4byte sRayquazaPose78
+.4byte sRayquazaPose79
+.4byte sRayquazaPose80
+.4byte sRayquazaPose81
+.4byte sRayquazaPose82
+.4byte sRayquazaPose83
+.4byte sRayquazaPose84
+.4byte sRayquazaPose85
+.4byte sRayquazaPose86
+.4byte sRayquazaPose87
+.4byte sRayquazaPose88
+.4byte sRayquazaPose89
+.4byte sRayquazaPose90
+.4byte sRayquazaPose91
+.4byte sRayquazaPose92
+.4byte sRayquazaPose93
+.4byte sRayquazaPose94
+.4byte sRayquazaPose95
+.4byte sRayquazaPose96
+.4byte sRayquazaPose97
+.4byte sRayquazaPose98
+.4byte sRayquazaPose99
+.4byte sRayquazaPose100
+.4byte sRayquazaPose101
+.4byte sRayquazaPose102
+.4byte sRayquazaPose103
+.4byte sRayquazaPose104
+.4byte sRayquazaPose105
+.4byte sRayquazaPose106
+.4byte sRayquazaPose107
+.4byte sRayquazaPose108
+.4byte sRayquazaPose109
+.4byte sRayquazaPose110
+.4byte sRayquazaPose111
+.4byte sRayquazaPose112
+.4byte sRayquazaPose113
+.4byte sRayquazaPose114
+.4byte sRayquazaPose115
+.4byte sRayquazaPose116
+.4byte sRayquazaPose117
+.4byte sRayquazaPose118
+.4byte sRayquazaPose119
+.4byte sRayquazaPose120
+.4byte sRayquazaPose121
+.4byte sRayquazaPose122
+.4byte sRayquazaPose123
+.4byte sRayquazaPose124
+.4byte sRayquazaPose125
+.4byte sRayquazaPose126
+.4byte sRayquazaPose127
+.4byte sRayquazaPose128
+.4byte sRayquazaPose129
+.4byte sRayquazaPose130
+.4byte sRayquazaPose131
+.4byte sRayquazaPose132
+.4byte sRayquazaPose133
+.4byte sRayquazaPose134
+.4byte sRayquazaPose135
+.4byte sRayquazaPose136
+.4byte sRayquazaPose137
+.4byte sRayquazaPose138
+.4byte sRayquazaPose139
+.4byte sRayquazaPose140
+.4byte sRayquazaPose141
+.4byte sRayquazaPose142
+.4byte sRayquazaPose143
+.4byte sRayquazaPose144
+.4byte sRayquazaPose145
+.4byte sRayquazaPose146
+.4byte sRayquazaPose147
+.4byte sRayquazaPose148
+.4byte sRayquazaPose149
+.4byte sRayquazaPose150
+.4byte sRayquazaPose151
+.4byte sRayquazaPose152
+.4byte sRayquazaPose153
+.4byte sRayquazaPose154
+.4byte sRayquazaPose155
+.4byte sRayquazaPose156
+.4byte sRayquazaPose157
+.4byte sRayquazaPose158
+.4byte sRayquazaPose159
+.4byte sRayquazaPose160
+.4byte sRayquazaPose161
+.4byte sRayquazaPose162
+.4byte sRayquazaPose163
+.4byte sRayquazaPose164
+.4byte sRayquazaPose165
+.4byte sRayquazaPose166
+.4byte sRayquazaPose167
+.4byte sRayquazaPose168
+.4byte sRayquazaPose169
+.4byte sRayquazaPose170
+.4byte sRayquazaPose171
+.4byte sRayquazaPose172
+.4byte sRayquazaPose173
+.4byte sRayquazaPose174
+.4byte sRayquazaPose175
+.4byte sRayquazaPose176
+.4byte sRayquazaPose177
+.4byte sRayquazaPose178
+.4byte sRayquazaPose179
+.4byte sRayquazaPose180
+.4byte sRayquazaPose181
+.4byte sRayquazaPose182
+.4byte sRayquazaPose183
+.4byte sRayquazaPose184
+.4byte sRayquazaPose185
+.4byte sRayquazaPose186
+.4byte sRayquazaPose187
+.4byte sRayquazaPose188
+.4byte sRayquazaPose189
+.4byte sRayquazaPose190
+.4byte sRayquazaPose191
+.4byte sRayquazaPose192
+.4byte sRayquazaPose193
+.4byte sRayquazaPose194
+.4byte sRayquazaPose195
+.4byte sRayquazaPose196
+.4byte sRayquazaPose197
+.4byte sRayquazaPose198
+.4byte sRayquazaPose199
+.4byte sRayquazaPose200
+.4byte sRayquazaPose201
+.4byte sRayquazaPose202
+.4byte sRayquazaPose203
+.4byte sRayquazaPose204
+.4byte sRayquazaPose205
+.4byte sRayquazaPose206
+.4byte sRayquazaPose207
+.4byte sRayquazaPose208
+.4byte sRayquazaPose209
+.4byte sRayquazaPose210
+sAxPositionsRayquaza:
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -30, 	  -8,  -28, 	  13,  -24, 	   3,  -18
+.2byte    0,  -31, 	 -10,  -29, 	  15,  -25, 	   3,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,   16, 	 -15,   -1, 	  17,   -1, 	   3,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    2,  -48, 	  15,  -33, 	  -6,  -25, 	   4,  -20
+.2byte   38,   11, 	  27,    5, 	   9,   10, 	   5,   -6
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    3,  -47, 	  10,  -32, 	   7,  -25, 	   4,  -17
+.2byte   52,   -8, 	  30,   -3, 	  21,    1, 	  11,   -8
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   -4,  -45, 	  -6,  -34, 	  15,  -27, 	   0,  -23
+.2byte   42,  -32, 	  24,  -30, 	  35,  -18, 	  15,  -15
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -41, 	  17,  -21, 	 -18,  -21, 	   3,  -11
+.2byte   -1,  -53, 	  13,  -33, 	 -15,  -33, 	   0,  -23
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte    7,  -45, 	   9,  -34, 	 -12,  -27, 	   3,  -23
+.2byte  -39,  -32, 	 -21,  -30, 	 -32,  -18, 	 -12,  -15
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -4,  -47, 	 -11,  -32, 	  -8,  -25, 	  -5,  -17
+.2byte  -53,   -8, 	 -31,   -3, 	 -22,    1, 	 -12,   -8
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -3,  -48, 	 -16,  -33, 	   5,  -25, 	  -5,  -20
+.2byte  -39,   11, 	 -28,    5, 	 -10,   10, 	  -6,   -6
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,   16, 	 -15,   -1, 	  17,   -1, 	   3,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    2,  -48, 	  15,  -33, 	  -6,  -25, 	   4,  -20
+.2byte   38,   11, 	  27,    5, 	   9,   10, 	   5,   -6
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    3,  -47, 	  10,  -32, 	   7,  -25, 	   4,  -17
+.2byte   52,   -8, 	  30,   -3, 	  21,    1, 	  11,   -8
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   -4,  -45, 	  -6,  -34, 	  15,  -27, 	   0,  -23
+.2byte   42,  -32, 	  24,  -30, 	  35,  -18, 	  15,  -15
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -41, 	  17,  -21, 	 -18,  -21, 	   3,  -11
+.2byte   -1,  -53, 	  13,  -33, 	 -15,  -33, 	   0,  -23
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte    7,  -45, 	   9,  -34, 	 -12,  -27, 	   3,  -23
+.2byte  -39,  -32, 	 -21,  -30, 	 -32,  -18, 	 -12,  -15
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -4,  -47, 	 -11,  -32, 	  -8,  -25, 	  -5,  -17
+.2byte  -53,   -8, 	 -31,   -3, 	 -22,    1, 	 -12,   -8
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -3,  -48, 	 -16,  -33, 	   5,  -25, 	  -5,  -20
+.2byte  -39,   11, 	 -28,    5, 	 -10,   10, 	  -6,   -6
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,    1, 	 -16,   -8, 	  17,   -8, 	   5,  -20
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    2,  -48, 	  15,  -33, 	  -6,  -25, 	   4,  -20
+.2byte   31,   -6, 	  25,   -6, 	   1,   -3, 	  10,   -5
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    3,  -47, 	  10,  -32, 	   7,  -25, 	   4,  -17
+.2byte   40,  -26, 	  26,  -16, 	  20,   -8, 	  12,  -12
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   -4,  -45, 	  -6,  -34, 	  15,  -27, 	   0,  -23
+.2byte   29,  -42, 	  10,  -35, 	  28,  -25, 	  10,  -22
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -41, 	  17,  -21, 	 -18,  -21, 	   3,  -11
+.2byte   -1,  -52, 	  17,  -29, 	 -19,  -30, 	  -1,  -22
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte    7,  -45, 	   9,  -34, 	 -12,  -27, 	   3,  -23
+.2byte  -26,  -42, 	  -7,  -35, 	 -25,  -25, 	  -7,  -22
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -4,  -47, 	 -11,  -32, 	  -8,  -25, 	  -5,  -17
+.2byte  -41,  -26, 	 -27,  -16, 	 -21,   -8, 	 -13,  -12
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -3,  -48, 	 -16,  -33, 	   5,  -25, 	  -5,  -20
+.2byte  -32,   -6, 	 -26,   -6, 	  -2,   -3, 	 -11,   -5
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,  -54, 	 -14,  -31, 	  15,  -31, 	   0,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    6,  -44, 	  19,  -29, 	  -2,  -21, 	   8,  -16
+.2byte    1,  -56, 	  15,  -37, 	  -6,  -28, 	   6,  -19
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    7,  -47, 	  14,  -32, 	  11,  -25, 	   8,  -17
+.2byte    4,  -60, 	  17,  -43, 	   7,  -37, 	  12,  -24
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte    4,  -47, 	   2,  -36, 	  23,  -29, 	   8,  -25
+.2byte    2,  -62, 	  -7,  -47, 	  13,  -45, 	   8,  -29
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -52, 	  17,  -32, 	 -18,  -32, 	   3,  -22
+.2byte   -1,  -57, 	  15,  -34, 	 -16,  -34, 	   2,  -20
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -3,  -47, 	  -1,  -36, 	 -22,  -29, 	  -7,  -25
+.2byte   -1,  -62, 	   8,  -47, 	 -12,  -45, 	  -7,  -29
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -8,  -47, 	 -15,  -32, 	 -12,  -25, 	  -9,  -17
+.2byte   -5,  -60, 	 -18,  -43, 	  -8,  -37, 	 -13,  -24
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -44, 	 -20,  -29, 	   1,  -21, 	  -9,  -16
+.2byte   -2,  -56, 	 -16,  -37, 	   5,  -28, 	  -7,  -19
+.2byte  -14,  -19, 	   0,  -22, 	   9,  -14, 	   6,  -13
+.2byte  -13,  -18, 	   0,  -20, 	  11,  -13, 	   6,  -14
+.2byte    1,  -55, 	 -13,  -37, 	  16,  -28, 	   1,  -25
+.2byte    4,  -54, 	   6,  -35, 	 -12,  -23, 	   1,  -21
+.2byte    3,  -53, 	   5,  -36, 	   1,  -18, 	   1,  -25
+.2byte    4,  -51, 	  -5,  -25, 	  14,  -19, 	   0,  -22
+.2byte    0,  -56, 	  16,  -28, 	 -15,  -24, 	   0,  -22
+.2byte   -5,  -51, 	   4,  -25, 	 -15,  -19, 	  -1,  -22
+.2byte   -4,  -53, 	  -6,  -36, 	  -2,  -18, 	  -2,  -25
+.2byte   -5,  -54, 	  -7,  -35, 	  11,  -23, 	  -2,  -21
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -30, 	  -8,  -28, 	  13,  -24, 	   3,  -18
+.2byte    0,  -31, 	 -10,  -29, 	  15,  -25, 	   3,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte   10,  -48, 	  23,  -33, 	   2,  -25, 	  12,  -20
+.2byte   17,  -49, 	  24,  -34, 	  21,  -27, 	  18,  -19
+.2byte   10,  -49, 	   8,  -38, 	  29,  -31, 	  14,  -27
+.2byte   -1,  -55, 	  17,  -35, 	 -18,  -35, 	   3,  -25
+.2byte  -11,  -49, 	  -9,  -38, 	 -30,  -31, 	 -15,  -27
+.2byte  -18,  -49, 	 -25,  -34, 	 -22,  -27, 	 -19,  -19
+.2byte  -11,  -48, 	 -24,  -33, 	  -3,  -25, 	 -13,  -20
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,  -60, 	 -14,  -37, 	  15,  -37, 	   0,  -25
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    6,  -47, 	  19,  -32, 	  -2,  -24, 	   8,  -19
+.2byte    1,  -59, 	  15,  -40, 	  -6,  -31, 	   6,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   10,  -47, 	  17,  -32, 	  14,  -25, 	  11,  -17
+.2byte    4,  -60, 	  17,  -43, 	   7,  -37, 	  12,  -24
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte    4,  -47, 	   2,  -36, 	  23,  -29, 	   8,  -25
+.2byte    2,  -62, 	  -7,  -47, 	  13,  -45, 	   8,  -29
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -52, 	  17,  -32, 	 -18,  -32, 	   3,  -22
+.2byte   -1,  -57, 	  15,  -34, 	 -16,  -34, 	   2,  -20
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -3,  -47, 	  -1,  -36, 	 -22,  -29, 	  -7,  -25
+.2byte   -1,  -62, 	   8,  -47, 	 -12,  -45, 	  -7,  -29
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -10,  -47, 	 -17,  -32, 	 -14,  -25, 	 -11,  -17
+.2byte   -5,  -60, 	 -18,  -43, 	  -8,  -37, 	 -13,  -24
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -44, 	 -20,  -29, 	   1,  -21, 	  -9,  -16
+.2byte   -2,  -56, 	 -16,  -37, 	   5,  -28, 	  -7,  -19
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+sRayquazaAnimTable1:
+.4byte sRayquazaAnims_1_1
+.4byte sRayquazaAnims_1_2
+.4byte sRayquazaAnims_1_3
+.4byte sRayquazaAnims_1_4
+.4byte sRayquazaAnims_1_5
+.4byte sRayquazaAnims_1_6
+.4byte sRayquazaAnims_1_7
+.4byte sRayquazaAnims_1_8
+sRayquazaAnimTable2:
+.4byte sRayquazaAnims_2_1
+.4byte sRayquazaAnims_2_2
+.4byte sRayquazaAnims_2_3
+.4byte sRayquazaAnims_2_4
+.4byte sRayquazaAnims_2_5
+.4byte sRayquazaAnims_2_6
+.4byte sRayquazaAnims_2_7
+.4byte sRayquazaAnims_2_8
+sRayquazaAnimTable3:
+.4byte sRayquazaAnims_3_1
+.4byte sRayquazaAnims_3_2
+.4byte sRayquazaAnims_3_3
+.4byte sRayquazaAnims_3_4
+.4byte sRayquazaAnims_3_5
+.4byte sRayquazaAnims_3_6
+.4byte sRayquazaAnims_3_7
+.4byte sRayquazaAnims_3_8
+sRayquazaAnimTable4:
+.4byte sRayquazaAnims_4_1
+.4byte sRayquazaAnims_4_2
+.4byte sRayquazaAnims_4_3
+.4byte sRayquazaAnims_4_4
+.4byte sRayquazaAnims_4_5
+.4byte sRayquazaAnims_4_6
+.4byte sRayquazaAnims_4_7
+.4byte sRayquazaAnims_4_8
+sRayquazaAnimTable5:
+.4byte sRayquazaAnims_5_1
+.4byte sRayquazaAnims_5_2
+.4byte sRayquazaAnims_5_3
+.4byte sRayquazaAnims_5_4
+.4byte sRayquazaAnims_5_5
+.4byte sRayquazaAnims_5_6
+.4byte sRayquazaAnims_5_7
+.4byte sRayquazaAnims_5_8
+sRayquazaAnimTable6:
+.4byte sRayquazaAnims_6_1
+.4byte sRayquazaAnims_6_1
+.4byte sRayquazaAnims_6_1
+.4byte sRayquazaAnims_6_1
+.4byte sRayquazaAnims_6_1
+.4byte sRayquazaAnims_6_1
+.4byte sRayquazaAnims_6_1
+.4byte sRayquazaAnims_6_1
+sRayquazaAnimTable7:
+.4byte sRayquazaAnims_7_1
+.4byte sRayquazaAnims_7_2
+.4byte sRayquazaAnims_7_3
+.4byte sRayquazaAnims_7_4
+.4byte sRayquazaAnims_7_5
+.4byte sRayquazaAnims_7_6
+.4byte sRayquazaAnims_7_7
+.4byte sRayquazaAnims_7_8
+sRayquazaAnimTable8:
+.4byte sRayquazaAnims_8_1
+.4byte sRayquazaAnims_8_2
+.4byte sRayquazaAnims_8_3
+.4byte sRayquazaAnims_8_4
+.4byte sRayquazaAnims_8_5
+.4byte sRayquazaAnims_8_6
+.4byte sRayquazaAnims_8_7
+.4byte sRayquazaAnims_8_8
+sRayquazaAnimTable9:
+.4byte sRayquazaAnims_9_1
+.4byte sRayquazaAnims_9_2
+.4byte sRayquazaAnims_9_3
+.4byte sRayquazaAnims_9_4
+.4byte sRayquazaAnims_9_5
+.4byte sRayquazaAnims_9_6
+.4byte sRayquazaAnims_9_7
+.4byte sRayquazaAnims_9_8
+sRayquazaAnimTable10:
+.4byte sRayquazaAnims_10_1
+.4byte sRayquazaAnims_10_2
+.4byte sRayquazaAnims_10_3
+.4byte sRayquazaAnims_10_4
+.4byte sRayquazaAnims_10_5
+.4byte sRayquazaAnims_10_6
+.4byte sRayquazaAnims_10_7
+.4byte sRayquazaAnims_10_8
+sRayquazaAnimTable11:
+.4byte sRayquazaAnims_11_1
+.4byte sRayquazaAnims_11_2
+.4byte sRayquazaAnims_11_3
+.4byte sRayquazaAnims_11_4
+.4byte sRayquazaAnims_11_5
+.4byte sRayquazaAnims_11_6
+.4byte sRayquazaAnims_11_7
+.4byte sRayquazaAnims_11_8
+sRayquazaAnimTable12:
+.4byte sRayquazaAnims_12_1
+.4byte sRayquazaAnims_12_2
+.4byte sRayquazaAnims_12_3
+.4byte sRayquazaAnims_12_4
+.4byte sRayquazaAnims_12_5
+.4byte sRayquazaAnims_12_6
+.4byte sRayquazaAnims_12_7
+.4byte sRayquazaAnims_12_8
+sRayquazaAnimTable13:
+.4byte sRayquazaAnims_13_1
+.4byte sRayquazaAnims_13_2
+.4byte sRayquazaAnims_13_3
+.4byte sRayquazaAnims_13_4
+.4byte sRayquazaAnims_13_5
+.4byte sRayquazaAnims_13_6
+.4byte sRayquazaAnims_13_7
+.4byte sRayquazaAnims_13_8
+sAxAnimationsRayquaza:
+.4byte sRayquazaAnimTable1
+.4byte sRayquazaAnimTable2
+.4byte sRayquazaAnimTable3
+.4byte sRayquazaAnimTable4
+.4byte sRayquazaAnimTable5
+.4byte sRayquazaAnimTable6
+.4byte sRayquazaAnimTable7
+.4byte sRayquazaAnimTable8
+.4byte sRayquazaAnimTable9
+.4byte sRayquazaAnimTable10
+.4byte sRayquazaAnimTable11
+.4byte sRayquazaAnimTable12
+.4byte sRayquazaAnimTable13
+sAxSpritesRayquaza:
+.4byte sRayquazaSprites1
+.4byte sRayquazaSprites2
+.4byte sRayquazaSprites3
+.4byte sRayquazaSprites4
+.4byte sRayquazaSprites5
+.4byte sRayquazaSprites6
+.4byte sRayquazaSprites7
+.4byte sRayquazaSprites8
+.4byte sRayquazaSprites9
+.4byte sRayquazaSprites10
+.4byte sRayquazaSprites11
+.4byte sRayquazaSprites12
+.4byte sRayquazaSprites13
+.4byte sRayquazaSprites14
+.4byte sRayquazaSprites15
+.4byte sRayquazaSprites16
+.4byte sRayquazaSprites17
+.4byte sRayquazaSprites18
+.4byte sRayquazaSprites19
+.4byte sRayquazaSprites20
+.4byte sRayquazaSprites21
+.4byte sRayquazaSprites22
+.4byte sRayquazaSprites23
+.4byte sRayquazaSprites24
+.4byte sRayquazaSprites25
+.4byte sRayquazaSprites26
+.4byte sRayquazaSprites27
+.4byte sRayquazaSprites28
+.4byte sRayquazaSprites29
+.4byte sRayquazaSprites30
+.4byte sRayquazaSprites31
+.4byte sRayquazaSprites32
+.4byte sRayquazaSprites33
+.4byte sRayquazaSprites34
+.4byte sRayquazaSprites35
+.4byte sRayquazaSprites36
+.4byte sRayquazaSprites37
+.4byte sRayquazaSprites38
+.4byte sRayquazaSprites39
+.4byte sRayquazaSprites40
+.4byte sRayquazaSprites41
+.4byte sRayquazaSprites42
+.4byte sRayquazaSprites43
+.4byte sRayquazaSprites44
+.4byte sRayquazaSprites45
+.4byte sRayquazaSprites46
+.4byte sRayquazaSprites47
+.4byte sRayquazaSprites48
+.4byte sRayquazaSprites49
+.4byte sRayquazaSprites50
+.4byte sRayquazaSprites51
+.4byte sRayquazaSprites52
+.4byte sRayquazaSprites53
+.4byte sRayquazaSprites54
+.4byte sRayquazaSprites55
+.4byte sRayquazaSprites56
+.4byte sRayquazaSprites57
+.4byte sRayquazaSprites58
+.4byte sRayquazaSprites59
+.4byte sRayquazaSprites60
+.4byte sRayquazaSprites61
+.4byte sRayquazaSprites62
+.4byte sRayquazaSprites63
+.4byte sRayquazaSprites64
+.4byte sRayquazaSprites65
+.4byte sRayquazaSprites66
+.4byte sRayquazaSprites67
+.4byte sRayquazaSprites68
+.4byte sRayquazaSprites69
+.4byte sRayquazaSprites70
+.4byte sRayquazaSprites71
+.4byte sRayquazaSprites72
+.4byte sRayquazaSprites73
+.4byte sRayquazaSprites74
+.4byte sRayquazaSprites75
+.4byte sRayquazaSprites76
+.4byte sRayquazaSprites77
+.4byte sRayquazaSprites78
+.4byte sRayquazaSprites79
+.4byte sRayquazaSprites80
+.4byte sRayquazaSprites81
+.4byte sRayquazaSprites82
+.4byte sRayquazaSprites83
+.4byte sRayquazaSprites84
+.4byte sRayquazaSprites85
+.4byte sRayquazaSprites86
+.4byte sRayquazaSprites87
+.4byte sRayquazaSprites88
+.4byte sRayquazaSprites89
+.4byte sRayquazaSprites90
+.4byte sRayquazaSprites91
+.4byte sRayquazaSprites92
+.4byte sRayquazaSprites93
+.4byte sRayquazaSprites94
+.4byte sRayquazaSprites95
+.4byte sRayquazaSprites96
+.4byte sRayquazaSprites97
+.4byte sRayquazaSprites98
+.4byte sRayquazaSprites99
+.4byte sRayquazaSprites100
+.4byte sRayquazaSprites101
+.4byte sRayquazaSprites102
+.4byte sRayquazaSprites103
+.4byte sRayquazaSprites104
+.4byte sRayquazaSprites105
+.4byte sRayquazaSprites106
+.4byte sRayquazaSprites107
+.4byte sRayquazaSprites108
+.4byte sRayquazaSprites109
+.4byte sRayquazaSprites110
+.4byte sRayquazaSprites111
+.4byte sRayquazaSprites112
+.4byte sRayquazaSprites113
+.4byte sRayquazaSprites114
+.4byte sRayquazaSprites115
+.4byte sRayquazaSprites116
+.4byte sRayquazaSprites117
+.4byte sRayquazaSprites118
+.4byte sRayquazaSprites119
+.4byte sRayquazaSprites120
+.4byte sRayquazaSprites121
+.4byte sRayquazaSprites122
+.4byte sRayquazaSprites123
+.4byte sRayquazaSprites124
+.4byte sRayquazaSprites125
+.4byte sRayquazaSprites126
+.4byte sRayquazaSprites127
+.4byte sRayquazaSprites128
+.4byte sRayquazaSprites129
+.4byte sRayquazaSprites130
+.4byte sRayquazaSprites131
+.4byte sRayquazaSprites132
+.4byte sRayquazaSprites133
+.4byte sRayquazaSprites134
+.4byte sRayquazaSprites135
+.4byte sRayquazaSprites136
+.4byte sRayquazaSprites137
+.4byte sRayquazaSprites138
+.4byte sRayquazaSprites139
+.4byte sRayquazaSprites140
+.4byte sRayquazaSprites141
+.4byte sRayquazaSprites142
+.4byte sRayquazaSprites143
+.4byte sRayquazaSprites144
+.4byte sRayquazaSprites145
+.4byte sRayquazaSprites146
+.4byte sRayquazaSprites147
+.4byte sRayquazaSprites148
+.4byte sRayquazaSprites149
+.4byte sRayquazaSprites150
+.4byte sRayquazaSprites151
+.4byte sRayquazaSprites152
+.4byte sRayquazaSprites153
+.4byte sRayquazaSprites154
+.4byte sRayquazaSprites155
+.4byte sRayquazaSprites156
+.4byte sRayquazaSprites157
+.4byte sRayquazaSprites158
+.4byte sRayquazaSprites159
+.4byte sRayquazaSprites160
+.4byte sRayquazaSprites161
+.4byte sRayquazaSprites162
+.4byte sRayquazaSprites163
+.4byte sRayquazaSprites164
+.4byte sRayquazaSprites165
+.4byte sRayquazaSprites166
+.4byte sRayquazaSprites167
+.4byte sRayquazaSprites168
+.4byte sRayquazaSprites169
+.4byte sRayquazaSprites170
+.4byte sRayquazaSprites171
+.4byte sRayquazaSprites172
+.4byte sRayquazaSprites173
+.4byte sRayquazaSprites174
+.4byte sRayquazaSprites175
+.4byte sRayquazaSprites176
+.4byte sRayquazaSprites177
+.4byte sRayquazaSprites178
+.4byte sRayquazaSprites179
+.4byte sRayquazaSprites180
+.4byte sRayquazaSprites181
+.4byte sRayquazaSprites182
+.4byte sRayquazaSprites183
+.4byte sRayquazaSprites184
+.4byte sRayquazaSprites185
+.4byte sRayquazaSprites186
+.4byte sRayquazaSprites187
+.4byte sRayquazaSprites188
+.4byte sRayquazaSprites189
+.4byte sRayquazaSprites190
+.4byte sRayquazaSprites191
+.4byte sRayquazaSprites192
+.4byte sRayquazaSprites193
+.4byte sRayquazaSprites194
+.4byte sRayquazaSprites195
+.4byte sRayquazaSprites196
+.4byte sRayquazaSprites197
+.4byte sRayquazaSprites198
+.4byte sRayquazaSprites199
+.4byte sRayquazaSprites200
+.4byte sRayquazaSprites201
+.4byte sRayquazaSprites202
+.4byte sRayquazaSprites203
+.4byte sRayquazaSprites204
+.4byte sRayquazaSprites205
+.4byte sRayquazaSprites206
+.4byte sRayquazaSprites207
+.4byte sRayquazaSprites208
+.4byte sRayquazaSprites209
+.4byte sRayquazaSprites210
+.4byte sRayquazaSprites211
+.4byte sRayquazaSprites212
+.4byte sRayquazaSprites213
+.4byte sRayquazaSprites214
+.4byte sRayquazaSprites215
+.4byte sRayquazaSprites216
+.4byte sRayquazaSprites217
+.4byte sRayquazaSprites218
+.4byte sRayquazaSprites219
+.4byte sRayquazaSprites220
+.4byte sRayquazaSprites221
+.4byte sRayquazaSprites222
+.4byte sRayquazaSprites223
+.4byte sRayquazaSprites224
+.4byte sRayquazaSprites225
+.4byte sRayquazaSprites226
+.4byte sRayquazaSprites227
+.4byte sRayquazaSprites228
+.4byte sRayquazaSprites229
+.4byte sRayquazaSprites230
+.4byte sRayquazaSprites231
+sAxMainRayquaza:
+ax_main sAxPosesRayquaza, sAxAnimationsRayquaza, 13, sAxSpritesRayquaza, sAxPositionsRayquaza

--- a/data/ax/rayquazacutscene.inc
+++ b/data/ax/rayquazacutscene.inc
@@ -1,0 +1,6540 @@
+.global gAxRayquazaCutscene
+gAxRayquazaCutscene:
+ax_siro sAxMainRayquazaCutscene
+sRayquazaCutscenePose1:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose2:
+ax_pose 4, 0x81c3, 0xc0f1, 0x3c00
+ax_pose 5, 0x81e3, 0x80e1, 0x3c20
+ax_pose 6, 0x4203, 0x00f1, 0x3c28
+ax_pose 7, 0x01e3, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose3:
+ax_pose 8, 0x81c2, 0xc0f1, 0x3c00
+ax_pose 9, 0x81e2, 0x80e1, 0x3c20
+ax_pose 10, 0x4202, 0x00f1, 0x3c28
+ax_pose 11, 0x01e2, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose4:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose5:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose6:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose7:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose8:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose9:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose10:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose11:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose12:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose13:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose14:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose15:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose16:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose17:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose18:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose19:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose20:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose21:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose22:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose23:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose24:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose25:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose26:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose27:
+ax_pose 100, 0x81c4, 0xc0f8, 0x3c00
+ax_pose 101, 0x01f4, 0x40e8, 0x3c20
+ax_pose 102, 0x4204, 0x80f8, 0x3c24
+ax_pose 103, 0x0204, 0x00f0, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose28:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose29:
+ax_pose 104, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose30:
+ax_pose 105, 0x01f5, 0x910b, 0x3c00
+ax_pose 106, 0x41ed, 0x510b, 0x3c10
+ax_pose 107, 0x01e5, 0x90eb, 0x3c14
+ax_pose 108, 0x8205, 0x1103, 0x3c24
+ax_pose 109, 0x81fd, 0x112b, 0x3c26
+ax_pose 110, 0x01e5, 0x50db, 0x3c28
+ax_pose 111, 0x01d5, 0x50db, 0x3c2c
+ax_pose 112, 0x01c5, 0x50da, 0x3c30
+ax_pose 113, 0x81c5, 0x10d2, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose31:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose32:
+ax_pose 114, 0x01c5, 0xd0d1, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose33:
+ax_pose 115, 0x01e6, 0x90f7, 0x3c00
+ax_pose 116, 0x41e6, 0x90d7, 0x3c10
+ax_pose 117, 0x41f6, 0x50d7, 0x3c18
+ax_pose 118, 0x01d6, 0x9117, 0x3c1c
+ax_pose 119, 0x01f6, 0x5117, 0x3c2c
+ax_pose 120, 0x41f6, 0x1127, 0x3c30
+ax_pose 121, 0x01f6, 0x1137, 0x3c32
+ax_pose 122, 0x01ee, 0x1137, 0x3c33
+ax_pose 123, 0x81d6, 0x10d7, 0x3c34
+ax_pose 124, 0x01d6, 0x50c7, 0x3c36
+ax_pose 125, 0x81e6, 0x10cf, 0x3c3a
+ax_pose 126, 0x01c6, 0x50c7, 0x3c3c
+ax_pose_terminator
+sRayquazaCutscenePose34:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose35:
+ax_pose 127, 0x41d9, 0xd0d4, 0x3c00
+ax_pose 128, 0x41f9, 0x90d4, 0x3c20
+ax_pose 129, 0x01f9, 0x50f4, 0x3c28
+ax_pose 130, 0x4209, 0x50d4, 0x3c2c
+ax_pose 131, 0x4211, 0x10dc, 0x3c30
+ax_pose 132, 0x41c9, 0x90e3, 0x3c32
+ax_pose 133, 0x01d0, 0x10db, 0x3c3a
+ax_pose 134, 0x41c1, 0x10f3, 0x3c3b
+ax_pose 135, 0x01f9, 0x1104, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose36:
+ax_pose 136, 0x01eb, 0x90d8, 0x3c00
+ax_pose 137, 0x41eb, 0x90f8, 0x3c10
+ax_pose 138, 0x41fb, 0x10f8, 0x3c18
+ax_pose 139, 0x01fb, 0x1108, 0x3c1a
+ax_pose 140, 0x420b, 0x50d8, 0x3c1b
+ax_pose 141, 0x4213, 0x10e0, 0x3c1f
+ax_pose 142, 0x81cb, 0x5110, 0x3c21
+ax_pose 143, 0x81db, 0x1108, 0x3c25
+ax_pose 144, 0x81cb, 0x9118, 0x3c27
+ax_pose 145, 0x81d3, 0x1128, 0x3c2f
+ax_pose 146, 0x41eb, 0x1118, 0x3c31
+ax_pose 147, 0x01eb, 0x50c8, 0x3c33
+ax_pose 148, 0x81fb, 0x10d0, 0x3c37
+ax_pose 149, 0x41e3, 0x10c8, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose37:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose38:
+ax_pose 150, 0x81da, 0xc0f8, 0x3c00
+ax_pose 151, 0x81da, 0x80e8, 0x3c20
+ax_pose 152, 0x81fa, 0x80e8, 0x3c28
+ax_pose 153, 0x81f2, 0x00e0, 0x3c30
+ax_pose 154, 0x01ca, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaCutscenePose39:
+ax_pose 155, 0x81c6, 0xc0f8, 0x3c00
+ax_pose 156, 0x81c6, 0x40f0, 0x3c20
+ax_pose 157, 0x81d6, 0x00e8, 0x3c24
+ax_pose 158, 0x01e6, 0x00f0, 0x3c26
+ax_pose 159, 0x0206, 0x40f9, 0x3c27
+ax_pose 160, 0x0206, 0x40e9, 0x3c2b
+ax_pose 161, 0x020c, 0x40d9, 0x3c2f
+ax_pose 162, 0x4216, 0x40e9, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose40:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose41:
+ax_pose 127, 0x41d9, 0xc0f0, 0x3c00
+ax_pose 128, 0x41f9, 0x8110, 0x3c20
+ax_pose 129, 0x01f9, 0x4100, 0x3c28
+ax_pose 130, 0x4209, 0x4110, 0x3c2c
+ax_pose 131, 0x4211, 0x0118, 0x3c30
+ax_pose 132, 0x41c9, 0x8101, 0x3c32
+ax_pose 133, 0x01d0, 0x0121, 0x3c3a
+ax_pose 134, 0x41c1, 0x0101, 0x3c3b
+ax_pose 135, 0x01f9, 0x00f8, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose42:
+ax_pose 136, 0x01eb, 0x810c, 0x3c00
+ax_pose 137, 0x41eb, 0x80ec, 0x3c10
+ax_pose 138, 0x41fb, 0x00fc, 0x3c18
+ax_pose 139, 0x01fb, 0x00f4, 0x3c1a
+ax_pose 140, 0x420b, 0x410c, 0x3c1b
+ax_pose 141, 0x4213, 0x0114, 0x3c1f
+ax_pose 142, 0x81cb, 0x40ec, 0x3c21
+ax_pose 143, 0x81db, 0x00f4, 0x3c25
+ax_pose 144, 0x81cb, 0x80dc, 0x3c27
+ax_pose 145, 0x81d3, 0x00d4, 0x3c2f
+ax_pose 146, 0x41eb, 0x00dc, 0x3c31
+ax_pose 147, 0x01eb, 0x412c, 0x3c33
+ax_pose 148, 0x81fb, 0x012c, 0x3c37
+ax_pose 149, 0x41e3, 0x012c, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose43:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose44:
+ax_pose 114, 0x01c5, 0xc0ef, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose45:
+ax_pose 115, 0x01e6, 0x80e9, 0x3c00
+ax_pose 116, 0x41e6, 0x8109, 0x3c10
+ax_pose 117, 0x41f6, 0x4109, 0x3c18
+ax_pose 118, 0x01d6, 0x80c9, 0x3c1c
+ax_pose 119, 0x01f6, 0x40d9, 0x3c2c
+ax_pose 120, 0x41f6, 0x00c9, 0x3c30
+ax_pose 121, 0x01f6, 0x00c1, 0x3c32
+ax_pose 122, 0x01ee, 0x00c1, 0x3c33
+ax_pose 123, 0x81d6, 0x0121, 0x3c34
+ax_pose 124, 0x01d6, 0x4129, 0x3c36
+ax_pose 125, 0x81e6, 0x0129, 0x3c3a
+ax_pose 126, 0x01c6, 0x4129, 0x3c3c
+ax_pose_terminator
+sRayquazaCutscenePose46:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose47:
+ax_pose 104, 0x01c5, 0xc0e8, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose48:
+ax_pose 105, 0x01f5, 0x80d5, 0x3c00
+ax_pose 106, 0x41ed, 0x40d5, 0x3c10
+ax_pose 107, 0x01e5, 0x80f5, 0x3c14
+ax_pose 108, 0x8205, 0x00f5, 0x3c24
+ax_pose 109, 0x81fd, 0x00cd, 0x3c26
+ax_pose 110, 0x01e5, 0x4115, 0x3c28
+ax_pose 111, 0x01d5, 0x4115, 0x3c2c
+ax_pose 112, 0x01c5, 0x4116, 0x3c30
+ax_pose 113, 0x81c5, 0x0126, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose49:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose50:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose51:
+ax_pose 100, 0x81c4, 0xc0f8, 0x3c00
+ax_pose 101, 0x01f4, 0x40e8, 0x3c20
+ax_pose 102, 0x4204, 0x80f8, 0x3c24
+ax_pose 103, 0x0204, 0x00f0, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose52:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose53:
+ax_pose 104, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose54:
+ax_pose 105, 0x01f5, 0x910b, 0x3c00
+ax_pose 106, 0x41ed, 0x510b, 0x3c10
+ax_pose 107, 0x01e5, 0x90eb, 0x3c14
+ax_pose 108, 0x8205, 0x1103, 0x3c24
+ax_pose 109, 0x81fd, 0x112b, 0x3c26
+ax_pose 110, 0x01e5, 0x50db, 0x3c28
+ax_pose 111, 0x01d5, 0x50db, 0x3c2c
+ax_pose 112, 0x01c5, 0x50da, 0x3c30
+ax_pose 113, 0x81c5, 0x10d2, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose55:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose56:
+ax_pose 114, 0x01c5, 0xd0d1, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose57:
+ax_pose 115, 0x01e6, 0x90f7, 0x3c00
+ax_pose 116, 0x41e6, 0x90d7, 0x3c10
+ax_pose 117, 0x41f6, 0x50d7, 0x3c18
+ax_pose 118, 0x01d6, 0x9117, 0x3c1c
+ax_pose 119, 0x01f6, 0x5117, 0x3c2c
+ax_pose 120, 0x41f6, 0x1127, 0x3c30
+ax_pose 121, 0x01f6, 0x1137, 0x3c32
+ax_pose 122, 0x01ee, 0x1137, 0x3c33
+ax_pose 123, 0x81d6, 0x10d7, 0x3c34
+ax_pose 124, 0x01d6, 0x50c7, 0x3c36
+ax_pose 125, 0x81e6, 0x10cf, 0x3c3a
+ax_pose 126, 0x01c6, 0x50c7, 0x3c3c
+ax_pose_terminator
+sRayquazaCutscenePose58:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose59:
+ax_pose 127, 0x41d9, 0xd0d4, 0x3c00
+ax_pose 128, 0x41f9, 0x90d4, 0x3c20
+ax_pose 129, 0x01f9, 0x50f4, 0x3c28
+ax_pose 130, 0x4209, 0x50d4, 0x3c2c
+ax_pose 131, 0x4211, 0x10dc, 0x3c30
+ax_pose 132, 0x41c9, 0x90e3, 0x3c32
+ax_pose 133, 0x01d0, 0x10db, 0x3c3a
+ax_pose 134, 0x41c1, 0x10f3, 0x3c3b
+ax_pose 135, 0x01f9, 0x1104, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose60:
+ax_pose 136, 0x01eb, 0x90d8, 0x3c00
+ax_pose 137, 0x41eb, 0x90f8, 0x3c10
+ax_pose 138, 0x41fb, 0x10f8, 0x3c18
+ax_pose 139, 0x01fb, 0x1108, 0x3c1a
+ax_pose 140, 0x420b, 0x50d8, 0x3c1b
+ax_pose 141, 0x4213, 0x10e0, 0x3c1f
+ax_pose 142, 0x81cb, 0x5110, 0x3c21
+ax_pose 143, 0x81db, 0x1108, 0x3c25
+ax_pose 144, 0x81cb, 0x9118, 0x3c27
+ax_pose 145, 0x81d3, 0x1128, 0x3c2f
+ax_pose 146, 0x41eb, 0x1118, 0x3c31
+ax_pose 147, 0x01eb, 0x50c8, 0x3c33
+ax_pose 148, 0x81fb, 0x10d0, 0x3c37
+ax_pose 149, 0x41e3, 0x10c8, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose61:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose62:
+ax_pose 150, 0x81da, 0xc0f8, 0x3c00
+ax_pose 151, 0x81da, 0x80e8, 0x3c20
+ax_pose 152, 0x81fa, 0x80e8, 0x3c28
+ax_pose 153, 0x81f2, 0x00e0, 0x3c30
+ax_pose 154, 0x01ca, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaCutscenePose63:
+ax_pose 155, 0x81c6, 0xc0f8, 0x3c00
+ax_pose 156, 0x81c6, 0x40f0, 0x3c20
+ax_pose 157, 0x81d6, 0x00e8, 0x3c24
+ax_pose 158, 0x01e6, 0x00f0, 0x3c26
+ax_pose 159, 0x0206, 0x40f9, 0x3c27
+ax_pose 160, 0x0206, 0x40e9, 0x3c2b
+ax_pose 161, 0x020c, 0x40d9, 0x3c2f
+ax_pose 162, 0x4216, 0x40e9, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose64:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose65:
+ax_pose 127, 0x41d9, 0xc0f0, 0x3c00
+ax_pose 128, 0x41f9, 0x8110, 0x3c20
+ax_pose 129, 0x01f9, 0x4100, 0x3c28
+ax_pose 130, 0x4209, 0x4110, 0x3c2c
+ax_pose 131, 0x4211, 0x0118, 0x3c30
+ax_pose 132, 0x41c9, 0x8101, 0x3c32
+ax_pose 133, 0x01d0, 0x0121, 0x3c3a
+ax_pose 134, 0x41c1, 0x0101, 0x3c3b
+ax_pose 135, 0x01f9, 0x00f8, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose66:
+ax_pose 136, 0x01eb, 0x810c, 0x3c00
+ax_pose 137, 0x41eb, 0x80ec, 0x3c10
+ax_pose 138, 0x41fb, 0x00fc, 0x3c18
+ax_pose 139, 0x01fb, 0x00f4, 0x3c1a
+ax_pose 140, 0x420b, 0x410c, 0x3c1b
+ax_pose 141, 0x4213, 0x0114, 0x3c1f
+ax_pose 142, 0x81cb, 0x40ec, 0x3c21
+ax_pose 143, 0x81db, 0x00f4, 0x3c25
+ax_pose 144, 0x81cb, 0x80dc, 0x3c27
+ax_pose 145, 0x81d3, 0x00d4, 0x3c2f
+ax_pose 146, 0x41eb, 0x00dc, 0x3c31
+ax_pose 147, 0x01eb, 0x412c, 0x3c33
+ax_pose 148, 0x81fb, 0x012c, 0x3c37
+ax_pose 149, 0x41e3, 0x012c, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose67:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose68:
+ax_pose 114, 0x01c5, 0xc0ef, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose69:
+ax_pose 115, 0x01e6, 0x80e9, 0x3c00
+ax_pose 116, 0x41e6, 0x8109, 0x3c10
+ax_pose 117, 0x41f6, 0x4109, 0x3c18
+ax_pose 118, 0x01d6, 0x80c9, 0x3c1c
+ax_pose 119, 0x01f6, 0x40d9, 0x3c2c
+ax_pose 120, 0x41f6, 0x00c9, 0x3c30
+ax_pose 121, 0x01f6, 0x00c1, 0x3c32
+ax_pose 122, 0x01ee, 0x00c1, 0x3c33
+ax_pose 123, 0x81d6, 0x0121, 0x3c34
+ax_pose 124, 0x01d6, 0x4129, 0x3c36
+ax_pose 125, 0x81e6, 0x0129, 0x3c3a
+ax_pose 126, 0x01c6, 0x4129, 0x3c3c
+ax_pose_terminator
+sRayquazaCutscenePose70:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose71:
+ax_pose 104, 0x01c5, 0xc0e8, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose72:
+ax_pose 105, 0x01f5, 0x80d5, 0x3c00
+ax_pose 106, 0x41ed, 0x40d5, 0x3c10
+ax_pose 107, 0x01e5, 0x80f5, 0x3c14
+ax_pose 108, 0x8205, 0x00f5, 0x3c24
+ax_pose 109, 0x81fd, 0x00cd, 0x3c26
+ax_pose 110, 0x01e5, 0x4115, 0x3c28
+ax_pose 111, 0x01d5, 0x4115, 0x3c2c
+ax_pose 112, 0x01c5, 0x4116, 0x3c30
+ax_pose 113, 0x81c5, 0x0126, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose73:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose74:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose75:
+ax_pose 163, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 164, 0x81e8, 0x80e8, 0x3c20
+ax_pose 165, 0x01e0, 0x00f0, 0x3c28
+ax_pose 166, 0x41c0, 0x00f8, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose76:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose77:
+ax_pose 104, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose78:
+ax_pose 167, 0x41e8, 0xd0de, 0x3c00
+ax_pose 168, 0x81d8, 0x911e, 0x3c20
+ax_pose 169, 0x41f8, 0x111e, 0x3c28
+ax_pose 170, 0x41e0, 0x110e, 0x3c2a
+ax_pose 171, 0x01c8, 0x90de, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose79:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose80:
+ax_pose 114, 0x01c5, 0xd0d1, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose81:
+ax_pose 172, 0x41e5, 0xd0d9, 0x3c00
+ax_pose 173, 0x81d5, 0x9119, 0x3c20
+ax_pose 174, 0x81d5, 0x5129, 0x3c28
+ax_pose 175, 0x81dd, 0x1131, 0x3c2c
+ax_pose 176, 0x01cd, 0x1119, 0x3c2e
+ax_pose 177, 0x81d5, 0x1111, 0x3c2f
+ax_pose 178, 0x01cd, 0x1111, 0x3c31
+ax_pose 179, 0x01dd, 0x1109, 0x3c32
+ax_pose 180, 0x81c5, 0x90d9, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose82:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose83:
+ax_pose 127, 0x41d9, 0xd0d4, 0x3c00
+ax_pose 128, 0x41f9, 0x90d4, 0x3c20
+ax_pose 129, 0x01f9, 0x50f4, 0x3c28
+ax_pose 130, 0x4209, 0x50d4, 0x3c2c
+ax_pose 131, 0x4211, 0x10dc, 0x3c30
+ax_pose 132, 0x41c9, 0x90e3, 0x3c32
+ax_pose 133, 0x01d0, 0x10db, 0x3c3a
+ax_pose 134, 0x41c1, 0x10f3, 0x3c3b
+ax_pose 135, 0x01f9, 0x1104, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose84:
+ax_pose 181, 0x01d6, 0x90f6, 0x3c00
+ax_pose 182, 0x01f6, 0x90d6, 0x3c10
+ax_pose 183, 0x01f6, 0x50f6, 0x3c20
+ax_pose 184, 0x41c6, 0x9106, 0x3c24
+ax_pose 185, 0x01d6, 0x5116, 0x3c2c
+ax_pose 186, 0x41e6, 0x1116, 0x3c30
+ax_pose 187, 0x81d6, 0x90d6, 0x3c32
+ax_pose 188, 0x81d6, 0x10ce, 0x3c3a
+ax_pose 189, 0x01f6, 0x1106, 0x3c3c
+ax_pose_terminator
+sRayquazaCutscenePose85:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose86:
+ax_pose 150, 0x81da, 0xc0f8, 0x3c00
+ax_pose 151, 0x81da, 0x80e8, 0x3c20
+ax_pose 152, 0x81fa, 0x80e8, 0x3c28
+ax_pose 153, 0x81f2, 0x00e0, 0x3c30
+ax_pose 154, 0x01ca, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaCutscenePose87:
+ax_pose 190, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 191, 0x81c8, 0x80e9, 0x3c20
+ax_pose 192, 0x81e8, 0x80e9, 0x3c28
+ax_pose 193, 0x0208, 0x40f9, 0x3c30
+ax_pose 194, 0x0208, 0x40e9, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose88:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose89:
+ax_pose 127, 0x41d9, 0xc0f0, 0x3c00
+ax_pose 128, 0x41f9, 0x8110, 0x3c20
+ax_pose 129, 0x01f9, 0x4100, 0x3c28
+ax_pose 130, 0x4209, 0x4110, 0x3c2c
+ax_pose 131, 0x4211, 0x0118, 0x3c30
+ax_pose 132, 0x41c9, 0x8101, 0x3c32
+ax_pose 133, 0x01d0, 0x0121, 0x3c3a
+ax_pose 134, 0x41c1, 0x0101, 0x3c3b
+ax_pose 135, 0x01f9, 0x00f8, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose90:
+ax_pose 181, 0x01d6, 0x80ee, 0x3c00
+ax_pose 182, 0x01f6, 0x810e, 0x3c10
+ax_pose 183, 0x01f6, 0x40fe, 0x3c20
+ax_pose 184, 0x41c6, 0x80de, 0x3c24
+ax_pose 185, 0x01d6, 0x40de, 0x3c2c
+ax_pose 186, 0x41e6, 0x00de, 0x3c30
+ax_pose 187, 0x81d6, 0x811e, 0x3c32
+ax_pose 188, 0x81d6, 0x012e, 0x3c3a
+ax_pose 189, 0x01f6, 0x00f6, 0x3c3c
+ax_pose_terminator
+sRayquazaCutscenePose91:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose92:
+ax_pose 114, 0x01c5, 0xc0ef, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose93:
+ax_pose 172, 0x41e5, 0xc0e7, 0x3c00
+ax_pose 173, 0x81d5, 0x80d7, 0x3c20
+ax_pose 174, 0x81d5, 0x40cf, 0x3c28
+ax_pose 175, 0x81dd, 0x00c7, 0x3c2c
+ax_pose 176, 0x01cd, 0x00df, 0x3c2e
+ax_pose 177, 0x81d5, 0x00e7, 0x3c2f
+ax_pose 178, 0x01cd, 0x00e7, 0x3c31
+ax_pose 179, 0x01dd, 0x00ef, 0x3c32
+ax_pose 180, 0x81c5, 0x8117, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose94:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose95:
+ax_pose 104, 0x01c5, 0xc0e8, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose96:
+ax_pose 167, 0x41e8, 0xc0e2, 0x3c00
+ax_pose 168, 0x81d8, 0x80d2, 0x3c20
+ax_pose 169, 0x41f8, 0x00d2, 0x3c28
+ax_pose 170, 0x41e0, 0x00e2, 0x3c2a
+ax_pose 171, 0x01c8, 0x8102, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose97:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose98:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose99:
+ax_pose 195, 0x81c4, 0xc0eb, 0x3c00
+ax_pose 196, 0x81c4, 0x810b, 0x3c20
+ax_pose 197, 0x01e4, 0x410b, 0x3c28
+ax_pose 198, 0x4204, 0x00f4, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose100:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose101:
+ax_pose 104, 0x01c9, 0xd0dc, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose102:
+ax_pose 199, 0x01b6, 0x50fc, 0x3c00
+ax_pose 200, 0x41c6, 0xd0de, 0x3c04
+ax_pose 201, 0x01e6, 0x90de, 0x3c24
+ax_pose 202, 0x81e6, 0x90fe, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose103:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose104:
+ax_pose 114, 0x01c5, 0xd0d5, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose105:
+ax_pose 203, 0x81bf, 0x90db, 0x3c00
+ax_pose 204, 0x81df, 0x90db, 0x3c08
+ax_pose 205, 0x01ef, 0x50eb, 0x3c10
+ax_pose 206, 0x01e7, 0x10f3, 0x3c14
+ax_pose 207, 0x81bf, 0xd0fb, 0x3c15
+ax_pose 208, 0x01af, 0x50fb, 0x3c35
+ax_pose 209, 0x81c7, 0x10f3, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose106:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose107:
+ax_pose 127, 0x41d7, 0xd0dc, 0x3c00
+ax_pose 128, 0x41f7, 0x90dc, 0x3c20
+ax_pose 129, 0x01f7, 0x50fc, 0x3c28
+ax_pose 130, 0x4207, 0x50dc, 0x3c2c
+ax_pose 131, 0x420f, 0x10e4, 0x3c30
+ax_pose 132, 0x41c7, 0x90eb, 0x3c32
+ax_pose 133, 0x01ce, 0x10e3, 0x3c3a
+ax_pose 134, 0x41bf, 0x10fb, 0x3c3b
+ax_pose 135, 0x01f7, 0x110c, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose108:
+ax_pose 210, 0x81b5, 0xd0f4, 0x3c00
+ax_pose 211, 0x01f5, 0x90e0, 0x3c20
+ax_pose 212, 0x81d5, 0x90e4, 0x3c30
+ax_pose 213, 0x01dd, 0x10dc, 0x3c38
+ax_pose 214, 0x01f5, 0x1100, 0x3c39
+ax_pose 215, 0x01c6, 0x10ec, 0x3c3a
+ax_pose_terminator
+sRayquazaCutscenePose109:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose110:
+ax_pose 150, 0x81cf, 0xc0f8, 0x3c00
+ax_pose 151, 0x81cf, 0x80e8, 0x3c20
+ax_pose 152, 0x81ef, 0x80e8, 0x3c28
+ax_pose 153, 0x81e7, 0x00e0, 0x3c30
+ax_pose 154, 0x01bf, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaCutscenePose111:
+ax_pose 216, 0x81bf, 0xc0f3, 0x3c00
+ax_pose 217, 0x81df, 0x40eb, 0x3c20
+ax_pose 218, 0x81cf, 0x00eb, 0x3c24
+ax_pose 219, 0x41ff, 0x80f3, 0x3c26
+ax_pose_terminator
+sRayquazaCutscenePose112:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose113:
+ax_pose 127, 0x41d7, 0xc0e6, 0x3c00
+ax_pose 128, 0x41f7, 0x8106, 0x3c20
+ax_pose 129, 0x01f7, 0x40f6, 0x3c28
+ax_pose 130, 0x4207, 0x4106, 0x3c2c
+ax_pose 131, 0x420f, 0x010e, 0x3c30
+ax_pose 132, 0x41c7, 0x80f7, 0x3c32
+ax_pose 133, 0x01ce, 0x0117, 0x3c3a
+ax_pose 134, 0x41bf, 0x00f7, 0x3c3b
+ax_pose 135, 0x01f7, 0x00ee, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose114:
+ax_pose 210, 0x81b5, 0xc0ee, 0x3c00
+ax_pose 211, 0x01f5, 0x8102, 0x3c20
+ax_pose 212, 0x81d5, 0x810e, 0x3c30
+ax_pose 213, 0x01dd, 0x011e, 0x3c38
+ax_pose 214, 0x01f5, 0x00fa, 0x3c39
+ax_pose 215, 0x01c6, 0x010e, 0x3c3a
+ax_pose_terminator
+sRayquazaCutscenePose115:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose116:
+ax_pose 114, 0x01c5, 0xc0eb, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose117:
+ax_pose 203, 0x81bf, 0x8115, 0x3c00
+ax_pose 204, 0x81df, 0x8115, 0x3c08
+ax_pose 205, 0x01ef, 0x4105, 0x3c10
+ax_pose 206, 0x01e7, 0x0105, 0x3c14
+ax_pose 207, 0x81bf, 0xc0e5, 0x3c15
+ax_pose 208, 0x01af, 0x40f5, 0x3c35
+ax_pose 209, 0x81c7, 0x0105, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose118:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose119:
+ax_pose 104, 0x01c9, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose120:
+ax_pose 199, 0x01b6, 0x40f4, 0x3c00
+ax_pose 200, 0x41c6, 0xc0e2, 0x3c04
+ax_pose 201, 0x01e6, 0x8102, 0x3c24
+ax_pose 202, 0x81e6, 0x80f2, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose121:
+ax_pose 220, 0x01ca, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose122:
+ax_pose 221, 0x01ca, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose123:
+ax_pose 222, 0x01be, 0xc0e2, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose124:
+ax_pose 223, 0x01c0, 0xd0e0, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose125:
+ax_pose 224, 0x01bd, 0xd0dc, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose126:
+ax_pose 225, 0x01c1, 0xd0da, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose127:
+ax_pose 226, 0x81c7, 0x410c, 0x3c00
+ax_pose 227, 0x41bf, 0x00f8, 0x3c04
+ax_pose 228, 0x01df, 0x0114, 0x3c06
+ax_pose 229, 0x81e7, 0x810c, 0x3c07
+ax_pose 230, 0x81c7, 0xc0ec, 0x3c0f
+ax_pose_terminator
+sRayquazaCutscenePose128:
+ax_pose 225, 0x01c1, 0xc0e6, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose129:
+ax_pose 224, 0x01bd, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose130:
+ax_pose 223, 0x01c0, 0xc0e0, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose131:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose132:
+ax_pose 4, 0x81c3, 0xc0f1, 0x3c00
+ax_pose 5, 0x81e3, 0x80e1, 0x3c20
+ax_pose 6, 0x4203, 0x00f1, 0x3c28
+ax_pose 7, 0x01e3, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose133:
+ax_pose 8, 0x81c2, 0xc0f1, 0x3c00
+ax_pose 9, 0x81e2, 0x80e1, 0x3c20
+ax_pose 10, 0x4202, 0x00f1, 0x3c28
+ax_pose 11, 0x01e2, 0x4111, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose134:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose135:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose136:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose137:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose138:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose139:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose140:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose141:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose142:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose143:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose144:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose145:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose146:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose147:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose148:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose149:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose150:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose151:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose152:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose153:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose154:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose155:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose156:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose157:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose158:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose159:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose160:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose161:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose162:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose163:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose164:
+ax_pose 104, 0x01c5, 0xd0e0, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose165:
+ax_pose 114, 0x01c3, 0xd0df, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose166:
+ax_pose 127, 0x41d5, 0xd0e2, 0x3c00
+ax_pose 128, 0x41f5, 0x90e2, 0x3c20
+ax_pose 129, 0x01f5, 0x5102, 0x3c28
+ax_pose 130, 0x4205, 0x50e2, 0x3c2c
+ax_pose 131, 0x420d, 0x10ea, 0x3c30
+ax_pose 132, 0x41c5, 0x90f1, 0x3c32
+ax_pose 133, 0x01cc, 0x10e9, 0x3c3a
+ax_pose 134, 0x41bd, 0x1101, 0x3c3b
+ax_pose 135, 0x01f5, 0x1112, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose167:
+ax_pose 150, 0x81cc, 0xc0f8, 0x3c00
+ax_pose 151, 0x81cc, 0x80e8, 0x3c20
+ax_pose 152, 0x81ec, 0x80e8, 0x3c28
+ax_pose 153, 0x81e4, 0x00e0, 0x3c30
+ax_pose 154, 0x01bc, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaCutscenePose168:
+ax_pose 127, 0x41d5, 0xc0de, 0x3c00
+ax_pose 128, 0x41f5, 0x80fe, 0x3c20
+ax_pose 129, 0x01f5, 0x40ee, 0x3c28
+ax_pose 130, 0x4205, 0x40fe, 0x3c2c
+ax_pose 131, 0x420d, 0x0106, 0x3c30
+ax_pose 132, 0x41c5, 0x80ef, 0x3c32
+ax_pose 133, 0x01cc, 0x010f, 0x3c3a
+ax_pose 134, 0x41bd, 0x00ef, 0x3c3b
+ax_pose 135, 0x01f5, 0x00e6, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose169:
+ax_pose 114, 0x01c3, 0xc0e1, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose170:
+ax_pose 104, 0x01c5, 0xc0e0, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose171:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose172:
+ax_pose 97, 0x81c4, 0xc0ea, 0x3c00
+ax_pose 98, 0x81c4, 0x810a, 0x3c20
+ax_pose 99, 0x01e4, 0x410a, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose173:
+ax_pose 195, 0x81be, 0xc0eb, 0x3c00
+ax_pose 196, 0x81be, 0x810b, 0x3c20
+ax_pose 197, 0x01de, 0x410b, 0x3c28
+ax_pose 198, 0x41fe, 0x00f4, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose174:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose175:
+ax_pose 104, 0x01c6, 0xd0dc, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose176:
+ax_pose 199, 0x01b3, 0x50fc, 0x3c00
+ax_pose 200, 0x41c3, 0xd0de, 0x3c04
+ax_pose 201, 0x01e3, 0x90de, 0x3c24
+ax_pose 202, 0x81e3, 0x90fe, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose177:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose178:
+ax_pose 114, 0x01c5, 0xd0d8, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose179:
+ax_pose 203, 0x81bf, 0x90db, 0x3c00
+ax_pose 204, 0x81df, 0x90db, 0x3c08
+ax_pose 205, 0x01ef, 0x50eb, 0x3c10
+ax_pose 206, 0x01e7, 0x10f3, 0x3c14
+ax_pose 207, 0x81bf, 0xd0fb, 0x3c15
+ax_pose 208, 0x01af, 0x50fb, 0x3c35
+ax_pose 209, 0x81c7, 0x10f3, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose180:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose181:
+ax_pose 127, 0x41d7, 0xd0dc, 0x3c00
+ax_pose 128, 0x41f7, 0x90dc, 0x3c20
+ax_pose 129, 0x01f7, 0x50fc, 0x3c28
+ax_pose 130, 0x4207, 0x50dc, 0x3c2c
+ax_pose 131, 0x420f, 0x10e4, 0x3c30
+ax_pose 132, 0x41c7, 0x90eb, 0x3c32
+ax_pose 133, 0x01ce, 0x10e3, 0x3c3a
+ax_pose 134, 0x41bf, 0x10fb, 0x3c3b
+ax_pose 135, 0x01f7, 0x110c, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose182:
+ax_pose 210, 0x81b5, 0xd0f4, 0x3c00
+ax_pose 211, 0x01f5, 0x90e0, 0x3c20
+ax_pose 212, 0x81d5, 0x90e4, 0x3c30
+ax_pose 213, 0x01dd, 0x10dc, 0x3c38
+ax_pose 214, 0x01f5, 0x1100, 0x3c39
+ax_pose 215, 0x01c6, 0x10ec, 0x3c3a
+ax_pose_terminator
+sRayquazaCutscenePose183:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose184:
+ax_pose 150, 0x81cf, 0xc0f8, 0x3c00
+ax_pose 151, 0x81cf, 0x80e8, 0x3c20
+ax_pose 152, 0x81ef, 0x80e8, 0x3c28
+ax_pose 153, 0x81e7, 0x00e0, 0x3c30
+ax_pose 154, 0x01bf, 0x40f8, 0x3c32
+ax_pose_terminator
+sRayquazaCutscenePose185:
+ax_pose 216, 0x81bf, 0xc0f3, 0x3c00
+ax_pose 217, 0x81df, 0x40eb, 0x3c20
+ax_pose 218, 0x81cf, 0x00eb, 0x3c24
+ax_pose 219, 0x41ff, 0x80f3, 0x3c26
+ax_pose_terminator
+sRayquazaCutscenePose186:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose187:
+ax_pose 127, 0x41d7, 0xc0e6, 0x3c00
+ax_pose 128, 0x41f7, 0x8106, 0x3c20
+ax_pose 129, 0x01f7, 0x40f6, 0x3c28
+ax_pose 130, 0x4207, 0x4106, 0x3c2c
+ax_pose 131, 0x420f, 0x010e, 0x3c30
+ax_pose 132, 0x41c7, 0x80f7, 0x3c32
+ax_pose 133, 0x01ce, 0x0117, 0x3c3a
+ax_pose 134, 0x41bf, 0x00f7, 0x3c3b
+ax_pose 135, 0x01f7, 0x00ee, 0x3c3d
+ax_pose_terminator
+sRayquazaCutscenePose188:
+ax_pose 210, 0x81b5, 0xc0ee, 0x3c00
+ax_pose 211, 0x01f5, 0x8102, 0x3c20
+ax_pose 212, 0x81d5, 0x810e, 0x3c30
+ax_pose 213, 0x01dd, 0x011e, 0x3c38
+ax_pose 214, 0x01f5, 0x00fa, 0x3c39
+ax_pose 215, 0x01c6, 0x010e, 0x3c3a
+ax_pose_terminator
+sRayquazaCutscenePose189:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose190:
+ax_pose 114, 0x01c5, 0xc0e9, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose191:
+ax_pose 203, 0x81bf, 0x8115, 0x3c00
+ax_pose 204, 0x81df, 0x8115, 0x3c08
+ax_pose 205, 0x01ef, 0x4105, 0x3c10
+ax_pose 206, 0x01e7, 0x0105, 0x3c14
+ax_pose 207, 0x81bf, 0xc0e5, 0x3c15
+ax_pose 208, 0x01af, 0x40f5, 0x3c35
+ax_pose 209, 0x81c7, 0x0105, 0x3c39
+ax_pose_terminator
+sRayquazaCutscenePose192:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose193:
+ax_pose 104, 0x01c9, 0xc0e4, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose194:
+ax_pose 199, 0x01b6, 0x40f4, 0x3c00
+ax_pose 200, 0x41c6, 0xc0e2, 0x3c04
+ax_pose 201, 0x01e6, 0x8102, 0x3c24
+ax_pose 202, 0x81e6, 0x80f2, 0x3c34
+ax_pose_terminator
+sRayquazaCutscenePose195:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose196:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose197:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose198:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose199:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose200:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose201:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose202:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose203:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose204:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose205:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose206:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose207:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose208:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose209:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose210:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose211:
+ax_pose 231, 0x41d4, 0xc0dc, 0x3c00
+ax_pose 232, 0x41f4, 0x40e4, 0x3c20
+ax_pose 233, 0x41f4, 0x0104, 0x3c24
+ax_pose 234, 0x41fc, 0x40ec, 0x3c26
+ax_pose_terminator
+sRayquazaCutscenePose212:
+ax_pose 235, 0x41d7, 0xc0dc, 0x3c00
+ax_pose 236, 0x41f7, 0x40e4, 0x3c20
+ax_pose 237, 0x41f7, 0x0104, 0x3c24
+ax_pose 238, 0x41ff, 0x40ec, 0x3c26
+ax_pose_terminator
+sRayquazaCutscenePose213:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose214:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose215:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose216:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose217:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose218:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose219:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose220:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose221:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose222:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose223:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose224:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose225:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose226:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose227:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose228:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose229:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose230:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose231:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose232:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose233:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose234:
+ax_pose 239, 0x81c5, 0xc0fe, 0x3c00
+ax_pose 240, 0x01e5, 0x80de, 0x3c20
+ax_pose 241, 0x01d5, 0x40ee, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose235:
+ax_pose 242, 0x81c5, 0xc0ff, 0x3c00
+ax_pose 243, 0x01e5, 0x80df, 0x3c20
+ax_pose 244, 0x81c5, 0x80ef, 0x3c30
+ax_pose 245, 0x01bd, 0x0113, 0x3c38
+ax_pose_terminator
+sRayquazaCutscenePose236:
+ax_pose 246, 0x81c5, 0xc0ff, 0x3c00
+ax_pose 247, 0x01e5, 0x80df, 0x3c20
+ax_pose 248, 0x81c5, 0x80ef, 0x3c30
+ax_pose 249, 0x41bd, 0x00ff, 0x3c38
+ax_pose_terminator
+sRayquazaCutscenePose237:
+ax_pose 250, 0x01c4, 0x80ee, 0x3c00
+ax_pose 251, 0x41e4, 0xc0de, 0x3c10
+ax_pose 252, 0x01c8, 0x010e, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose238:
+ax_pose 253, 0x01c5, 0x80ef, 0x3c00
+ax_pose 254, 0x41e5, 0xc0df, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose239:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose240:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose241:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose242:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose243:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose244:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose245:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose246:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose247:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose248:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose249:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose250:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose251:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose252:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose253:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose254:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose255:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose256:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose257:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose258:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose259:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose260:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose261:
+ax_pose 239, 0x81c5, 0xc0fe, 0x3c00
+ax_pose 240, 0x01e5, 0x80de, 0x3c20
+ax_pose 241, 0x01d5, 0x40ee, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose262:
+ax_pose 242, 0x81c5, 0xc0ff, 0x3c00
+ax_pose 243, 0x01e5, 0x80df, 0x3c20
+ax_pose 244, 0x81c5, 0x80ef, 0x3c30
+ax_pose 245, 0x01bd, 0x0113, 0x3c38
+ax_pose_terminator
+sRayquazaCutscenePose263:
+ax_pose 246, 0x81c5, 0xc0ff, 0x3c00
+ax_pose 247, 0x01e5, 0x80df, 0x3c20
+ax_pose 248, 0x81c5, 0x80ef, 0x3c30
+ax_pose 249, 0x41bd, 0x00ff, 0x3c38
+ax_pose_terminator
+sRayquazaCutscenePose264:
+ax_pose 250, 0x01c4, 0x80ee, 0x3c00
+ax_pose 251, 0x41e4, 0xc0de, 0x3c10
+ax_pose 252, 0x01c8, 0x010e, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose265:
+ax_pose 253, 0x01c5, 0x80ef, 0x3c00
+ax_pose 254, 0x41e5, 0xc0df, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose266:
+ax_pose 255, 0x01c2, 0x80f1, 0x3c00
+ax_pose 256, 0x81c2, 0x8111, 0x3c10
+ax_pose 257, 0x01e2, 0x80e9, 0x3c18
+ax_pose 258, 0x81e2, 0x8109, 0x3c28
+ax_pose 259, 0x0202, 0x00f4, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose267:
+ax_pose 260, 0x01c5, 0x80f1, 0x3c00
+ax_pose 261, 0x81c5, 0x4111, 0x3c10
+ax_pose 262, 0x01d9, 0x0119, 0x3c14
+ax_pose 263, 0x01e5, 0x80e9, 0x3c15
+ax_pose 264, 0x81e5, 0x8109, 0x3c25
+ax_pose_terminator
+sRayquazaCutscenePose268:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose269:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose270:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose271:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose272:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose273:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose274:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose275:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose276:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose277:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose278:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose279:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose280:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose281:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose282:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose283:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose284:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose285:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose286:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose287:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose288:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose289:
+ax_pose 260, 0x01c5, 0x80f1, 0x3c00
+ax_pose 261, 0x81c5, 0x4111, 0x3c10
+ax_pose 262, 0x01d9, 0x0119, 0x3c14
+ax_pose 263, 0x01e5, 0x80e9, 0x3c15
+ax_pose 264, 0x81e5, 0x8109, 0x3c25
+ax_pose_terminator
+sRayquazaCutscenePose290:
+ax_pose 265, 0x01cf, 0x80ea, 0x3c00
+ax_pose 266, 0x81cf, 0x810a, 0x3c10
+ax_pose 267, 0x41ef, 0x80ea, 0x3c18
+ax_pose 268, 0x01ef, 0x410a, 0x3c20
+ax_pose 269, 0x41ff, 0x40ea, 0x3c24
+ax_pose_terminator
+sRayquazaCutscenePose291:
+ax_pose 270, 0x01cf, 0x80ea, 0x3c00
+ax_pose 271, 0x81cf, 0x810a, 0x3c10
+ax_pose 272, 0x41ef, 0x80ea, 0x3c18
+ax_pose 273, 0x01ef, 0x410a, 0x3c20
+ax_pose 274, 0x41ff, 0x40ea, 0x3c24
+ax_pose_terminator
+sRayquazaCutscenePose292:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose293:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose294:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose295:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose296:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose297:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose298:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose299:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose300:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose301:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose302:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose303:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose304:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose305:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose306:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose307:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose308:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose309:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose310:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose311:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose312:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose313:
+ax_pose 255, 0x01c2, 0x80f1, 0x3c00
+ax_pose 256, 0x81c2, 0x8111, 0x3c10
+ax_pose 257, 0x01e2, 0x80e9, 0x3c18
+ax_pose 258, 0x81e2, 0x8109, 0x3c28
+ax_pose 259, 0x0202, 0x00f4, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose314:
+ax_pose 275, 0x41d2, 0xc0e2, 0x3c00
+ax_pose 276, 0x41f2, 0x80e2, 0x3c20
+ax_pose 277, 0x41f2, 0x8102, 0x3c28
+ax_pose 278, 0x4202, 0x40f2, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose315:
+ax_pose 279, 0x41ce, 0xc0e9, 0x3c00
+ax_pose 280, 0x41ee, 0x80e9, 0x3c20
+ax_pose 281, 0x81ee, 0x0109, 0x3c28
+ax_pose 282, 0x41fe, 0x40e9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose316:
+ax_pose 283, 0x81c3, 0xc0ee, 0x3c00
+ax_pose 284, 0x81cb, 0x810e, 0x3c20
+ax_pose 285, 0x0203, 0x00f6, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose317:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose318:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose319:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose320:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose321:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose322:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose323:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose324:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose325:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose326:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose327:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose328:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose329:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose330:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose331:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose332:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose333:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose334:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose335:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose336:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose337:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose338:
+ax_pose 0, 0x81c4, 0xc0f2, 0x3c00
+ax_pose 1, 0x81e4, 0x80e2, 0x3c20
+ax_pose 2, 0x01c4, 0x00ea, 0x3c28
+ax_pose 3, 0x01e0, 0x4112, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose339:
+ax_pose 286, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose340:
+ax_pose 287, 0x01c6, 0xc0e2, 0x3c00
+ax_pose_terminator
+sRayquazaCutscenePose341:
+ax_pose 12, 0x81c4, 0xc0e6, 0x3c00
+ax_pose 13, 0x81c4, 0x8106, 0x3c20
+ax_pose 14, 0x81e4, 0x8106, 0x3c28
+ax_pose_terminator
+sRayquazaCutscenePose342:
+ax_pose 15, 0x81c4, 0xc0f6, 0x3c00
+ax_pose 16, 0x81e4, 0x80e6, 0x3c20
+ax_pose 17, 0x01dc, 0x00ee, 0x3c28
+ax_pose 18, 0x01bc, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose343:
+ax_pose 19, 0x81c2, 0xc0f6, 0x3c00
+ax_pose 20, 0x81e2, 0x80e6, 0x3c20
+ax_pose 21, 0x01da, 0x00ee, 0x3c28
+ax_pose 22, 0x0202, 0x0106, 0x3c29
+ax_pose_terminator
+sRayquazaCutscenePose344:
+ax_pose 23, 0x41e7, 0xc0e4, 0x3c00
+ax_pose 24, 0x01c7, 0x80f4, 0x3c20
+ax_pose 25, 0x01d7, 0x40e4, 0x3c30
+ax_pose 26, 0x01d7, 0x0114, 0x3c34
+ax_pose 27, 0x01bf, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose345:
+ax_pose 28, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 29, 0x01c6, 0x80f4, 0x3c20
+ax_pose 30, 0x41de, 0x00e4, 0x3c30
+ax_pose 31, 0x01d6, 0x0114, 0x3c32
+ax_pose 32, 0x01be, 0x00fc, 0x3c33
+ax_pose_terminator
+sRayquazaCutscenePose346:
+ax_pose 33, 0x41e6, 0xc0e4, 0x3c00
+ax_pose 34, 0x01c6, 0x80f4, 0x3c20
+ax_pose 35, 0x01d6, 0x40e4, 0x3c30
+ax_pose 36, 0x01d6, 0x0114, 0x3c34
+ax_pose 37, 0x01be, 0x00fc, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose347:
+ax_pose 38, 0x81c8, 0xc0f8, 0x3c00
+ax_pose 39, 0x01e8, 0x80d8, 0x3c20
+ax_pose 40, 0x81c8, 0x40f0, 0x3c30
+ax_pose 41, 0x01e0, 0x00e8, 0x3c34
+ax_pose 42, 0x01c0, 0x00f0, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose348:
+ax_pose 43, 0x81c8, 0xc0f9, 0x3c00
+ax_pose 44, 0x01e8, 0x80d9, 0x3c20
+ax_pose 45, 0x81c8, 0x40f1, 0x3c30
+ax_pose 46, 0x01e0, 0x00e9, 0x3c34
+ax_pose 47, 0x01c0, 0x00f1, 0x3c35
+ax_pose_terminator
+sRayquazaCutscenePose349:
+ax_pose 48, 0x81ca, 0xc0fb, 0x3c00
+ax_pose 49, 0x01ea, 0x80db, 0x3c20
+ax_pose 50, 0x81ca, 0x40f3, 0x3c30
+ax_pose 51, 0x81da, 0x00eb, 0x3c34
+ax_pose 52, 0x01c2, 0x00f3, 0x3c36
+ax_pose_terminator
+sRayquazaCutscenePose350:
+ax_pose 53, 0x81cb, 0xc0e9, 0x3c00
+ax_pose 54, 0x81cb, 0x8109, 0x3c20
+ax_pose 55, 0x81eb, 0x8109, 0x3c28
+ax_pose 56, 0x81eb, 0x0119, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose351:
+ax_pose 57, 0x81ca, 0xc0ea, 0x3c00
+ax_pose 58, 0x81ca, 0x410a, 0x3c20
+ax_pose 59, 0x81ea, 0x410a, 0x3c24
+ax_pose 60, 0x81e2, 0x4112, 0x3c28
+ax_pose 61, 0x81ea, 0x011a, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose352:
+ax_pose 62, 0x81c9, 0xc0eb, 0x3c00
+ax_pose 63, 0x81c9, 0x410b, 0x3c20
+ax_pose 64, 0x81e9, 0x810b, 0x3c24
+ax_pose 65, 0x81e9, 0x011b, 0x3c2c
+ax_pose_terminator
+sRayquazaCutscenePose353:
+ax_pose 66, 0x81c7, 0xc0ed, 0x3c00
+ax_pose 67, 0x81e7, 0x810d, 0x3c20
+ax_pose 68, 0x41df, 0x010d, 0x3c28
+ax_pose 69, 0x4207, 0x00f8, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose354:
+ax_pose 70, 0x81c6, 0xc0ed, 0x3c00
+ax_pose 71, 0x81e6, 0x810d, 0x3c20
+ax_pose 72, 0x41de, 0x010d, 0x3c28
+ax_pose 69, 0x4206, 0x00f9, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose355:
+ax_pose 73, 0x81c4, 0xc0ed, 0x3c00
+ax_pose 74, 0x81e4, 0x810d, 0x3c20
+ax_pose 75, 0x41dc, 0x010d, 0x3c28
+ax_pose 76, 0x4204, 0x00fe, 0x3c2a
+ax_pose_terminator
+sRayquazaCutscenePose356:
+ax_pose 77, 0x81c1, 0xc0eb, 0x3c00
+ax_pose 78, 0x01e1, 0x810b, 0x3c20
+ax_pose 79, 0x01d9, 0x010b, 0x3c30
+ax_pose 80, 0x4201, 0x010b, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose357:
+ax_pose 81, 0x81c0, 0xc0ea, 0x3c00
+ax_pose 82, 0x01e0, 0x810a, 0x3c20
+ax_pose 83, 0x01d8, 0x010a, 0x3c30
+ax_pose 84, 0x4200, 0x010d, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose358:
+ax_pose 85, 0x81bf, 0xc0ea, 0x3c00
+ax_pose 86, 0x01df, 0x810a, 0x3c20
+ax_pose 87, 0x01d7, 0x010a, 0x3c30
+ax_pose 88, 0x41ff, 0x010a, 0x3c31
+ax_pose_terminator
+sRayquazaCutscenePose359:
+ax_pose 89, 0x01c2, 0x80f2, 0x3c00
+ax_pose 90, 0x41e2, 0xc0e8, 0x3c10
+ax_pose_terminator
+sRayquazaCutscenePose360:
+ax_pose 91, 0x41e2, 0xc0e8, 0x3c00
+ax_pose 92, 0x01c2, 0x80f0, 0x3c20
+ax_pose 93, 0x01da, 0x0110, 0x3c30
+ax_pose_terminator
+sRayquazaCutscenePose361:
+ax_pose 94, 0x41e3, 0xc0e7, 0x3c00
+ax_pose 95, 0x01c3, 0x80ef, 0x3c20
+ax_pose 96, 0x01db, 0x010f, 0x3c30
+ax_pose_terminator
+.align 2
+sRayquazaCutsceneAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, 0,
+ax_anim 8, 0, 2, 0, -5, 0, 0,
+ax_anim 8, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 0, 0, -4, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim 8, 0, 5, 0, -5, 0, 0,
+ax_anim 8, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 0, -4, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -4, 0, 0,
+ax_anim 8, 0, 8, 0, -5, 0, 0,
+ax_anim 8, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 6, 0, -4, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim 8, 0, 11, 0, -5, 0, 0,
+ax_anim 8, 0, 10, 0, -5, 0, 0,
+ax_anim 6, 0, 9, 0, -4, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -4, 0, 0,
+ax_anim 8, 0, 14, 0, -5, 0, 0,
+ax_anim 8, 0, 13, 0, -5, 0, 0,
+ax_anim 6, 0, 12, 0, -4, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 4, 0, 17, 0, -3, 0, 0,
+ax_anim 4, 0, 17, 0, -4, 0, 0,
+ax_anim 8, 0, 17, 0, -5, 0, 0,
+ax_anim 8, 0, 16, 0, -5, 0, 0,
+ax_anim 6, 0, 15, 0, -4, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 4, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -4, 0, 0,
+ax_anim 8, 0, 20, 0, -5, 0, 0,
+ax_anim 8, 0, 19, 0, -5, 0, 0,
+ax_anim 6, 0, 18, 0, -4, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -1, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 4, 0, 23, 0, -3, 0, 0,
+ax_anim 4, 0, 23, 0, -4, 0, 0,
+ax_anim 8, 0, 23, 0, -5, 0, 0,
+ax_anim 8, 0, 22, 0, -5, 0, 0,
+ax_anim 6, 0, 21, 0, -4, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 1, 0, 1,
+ax_anim 1, 0, 26, 0, 6, 0, 6,
+ax_anim 2, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 1, 26, 1, 12, 1, 12,
+ax_anim 2, 0, 26, 0, 12, 0, 12,
+ax_anim 2, 0, 26, 1, 12, 1, 12,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_2_2:
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 4, 0, 28, -3, -3, -3, -3,
+ax_anim 1, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 2, 29, -4, 1, 0, 1,
+ax_anim 1, 0, 29, -3, 6, 4, 6,
+ax_anim 2, 0, 29, -2, 12, 9, 12,
+ax_anim 2, 1, 29, -1, 11, 10, 11,
+ax_anim 2, 0, 29, -2, 12, 9, 12,
+ax_anim 2, 0, 29, -1, 11, 10, 11,
+ax_anim 2, 0, 27, 3, 6, 4, 6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -7, 0, -7, 0,
+ax_anim 1, 0, 31, -4, 0, -4, 0,
+ax_anim 1, 2, 32, -29, -17, -2, 0,
+ax_anim 1, 0, 32, -19, -6, 2, 0,
+ax_anim 2, 0, 32, -15, 0, 8, 0,
+ax_anim 2, 1, 32, -15, 1, 8, 1,
+ax_anim 2, 0, 32, -15, 0, 8, 0,
+ax_anim 2, 0, 32, -15, 1, 8, 1,
+ax_anim 2, 0, 30, 2, 0, 4, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_2_4:
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 4, 0, 34, -7, 7, -7, 7,
+ax_anim 1, 0, 34, -4, 4, -4, 4,
+ax_anim 1, 2, 35, -18, -15, 4, -8,
+ax_anim 1, 0, 35, -12, -14, 7, -11,
+ax_anim 2, 0, 35, -5, -13, 11, -16,
+ax_anim 2, 1, 35, -4, -12, 12, -15,
+ax_anim 2, 0, 35, -5, -13, 11, -16,
+ax_anim 2, 0, 35, -4, -12, 12, -15,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, 6, 0, -1,
+ax_anim 1, 0, 38, 0, 2, 0, -6,
+ax_anim 2, 0, 38, 0, -1, 0, -12,
+ax_anim 2, 1, 38, 1, -1, 1, -12,
+ax_anim 2, 0, 38, 0, -1, 0, -12,
+ax_anim 2, 0, 38, 1, -1, 1, -12,
+ax_anim 2, 0, 36, 0, -1, 0, -6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_2_6:
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 4, 0, 40, 7, 7, 7, 7,
+ax_anim 1, 0, 40, 4, 4, 4, 4,
+ax_anim 1, 2, 41, 18, -15, -4, -8,
+ax_anim 1, 0, 41, 12, -14, -7, -11,
+ax_anim 2, 0, 41, 5, -13, -11, -16,
+ax_anim 2, 1, 41, 4, -12, -12, -15,
+ax_anim 2, 0, 41, 5, -13, -11, -16,
+ax_anim 2, 0, 41, 4, -12, -12, -15,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 7, 0, 7, 0,
+ax_anim 1, 0, 43, 4, 0, 4, 0,
+ax_anim 1, 2, 44, 29, -17, 2, 0,
+ax_anim 1, 0, 44, 19, -6, -2, 0,
+ax_anim 2, 0, 44, 15, 0, -8, 0,
+ax_anim 2, 1, 44, 15, 1, -8, 1,
+ax_anim 2, 0, 44, 15, 0, -8, 0,
+ax_anim 2, 0, 44, 15, 1, -8, 1,
+ax_anim 2, 0, 42, -2, 0, -4, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_2_8:
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 4, 0, 46, 3, -3, 3, -3,
+ax_anim 1, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 2, 47, 4, 1, 0, 1,
+ax_anim 1, 0, 47, 3, 6, -4, 6,
+ax_anim 2, 0, 47, 2, 12, -9, 12,
+ax_anim 2, 1, 47, 1, 11, -10, 11,
+ax_anim 2, 0, 47, 2, 12, -9, 12,
+ax_anim 2, 0, 47, 1, 11, -10, 11,
+ax_anim 2, 0, 45, -3, 6, -4, 6,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 3, 0, 3,
+ax_anim 1, 0, 50, 0, 12, 0, 12,
+ax_anim 2, 0, 50, 0, 37, 0, 37,
+ax_anim 2, 1, 50, 1, 37, 1, 37,
+ax_anim 2, 0, 50, 0, 37, 0, 37,
+ax_anim 2, 0, 50, 1, 37, 1, 37,
+ax_anim 2, 0, 48, 0, 16, 0, 16,
+ax_anim 1, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_3_2:
+ax_anim 2, 0, 51, -2, -2, -2, -2,
+ax_anim 4, 0, 52, -3, -3, -3, -3,
+ax_anim 1, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 2, 53, 2, 4, 2, 4,
+ax_anim 1, 0, 53, 11, 19, 11, 19,
+ax_anim 2, 0, 53, 22, 36, 22, 36,
+ax_anim 2, 1, 53, 23, 35, 23, 35,
+ax_anim 2, 0, 53, 22, 36, 22, 36,
+ax_anim 2, 0, 53, 23, 35, 23, 35,
+ax_anim 2, 0, 51, 14, 23, 14, 23,
+ax_anim 1, 0, 51, 6, 10, 6, 10,
+ax_anim_terminator
+sRayquazaCutsceneAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 55, -7, 0, -7, 0,
+ax_anim 1, 0, 55, -4, 0, -4, 0,
+ax_anim 1, 2, 56, -19, -20, 1, 0,
+ax_anim 1, 0, 56, -1, -10, 11, 0,
+ax_anim 2, 0, 56, 9, 0, 22, 0,
+ax_anim 2, 1, 56, 9, 1, 22, 1,
+ax_anim 2, 0, 56, 9, 0, 22, 0,
+ax_anim 2, 0, 56, 9, 1, 22, 1,
+ax_anim 2, 0, 54, 18, 3, 18, 0,
+ax_anim 1, 0, 54, 6, 1, 6, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_3_4:
+ax_anim 2, 0, 57, -2, 2, -2, 2,
+ax_anim 4, 0, 58, -7, 7, -7, 7,
+ax_anim 1, 0, 58, -4, 4, -4, 4,
+ax_anim 1, 2, 59, -16, -19, 2, -4,
+ax_anim 1, 0, 59, 3, -29, 12, -19,
+ax_anim 2, 0, 59, 19, -37, 27, -39,
+ax_anim 2, 1, 59, 20, -36, 28, -38,
+ax_anim 2, 0, 59, 19, -37, 27, -39,
+ax_anim 2, 0, 59, 20, -36, 28, -38,
+ax_anim 2, 0, 57, 12, -16, 12, -16,
+ax_anim 1, 0, 57, 4, -6, 4, -6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -1, 0, -1,
+ax_anim 1, 0, 62, 0, -14, 0, -14,
+ax_anim 2, 0, 62, 0, -28, 0, -28,
+ax_anim 2, 1, 62, 1, -28, 1, -28,
+ax_anim 2, 0, 62, 0, -28, 0, -28,
+ax_anim 2, 0, 62, 1, -28, 1, -28,
+ax_anim 2, 0, 60, 0, -13, 0, -13,
+ax_anim 1, 0, 60, 0, -5, 0, -5,
+ax_anim_terminator
+sRayquazaCutsceneAnims_3_6:
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 4, 0, 64, 7, 7, 7, 7,
+ax_anim 1, 0, 64, 4, 4, 4, 4,
+ax_anim 1, 2, 65, 16, -19, -2, -4,
+ax_anim 1, 0, 65, -3, -29, -12, -19,
+ax_anim 2, 0, 65, -19, -37, -27, -39,
+ax_anim 2, 1, 65, -20, -36, -28, -38,
+ax_anim 2, 0, 65, -19, -37, -27, -39,
+ax_anim 2, 0, 65, -20, -36, -28, -38,
+ax_anim 2, 0, 63, -12, -16, -12, -16,
+ax_anim 1, 0, 63, -4, -6, -4, -6,
+ax_anim_terminator
+sRayquazaCutsceneAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 67, 7, 0, 7, 0,
+ax_anim 1, 0, 67, 4, 0, 4, 0,
+ax_anim 1, 2, 68, 19, -20, -1, 0,
+ax_anim 1, 0, 68, 1, -10, -11, 0,
+ax_anim 2, 0, 68, -9, 0, -22, 0,
+ax_anim 2, 1, 68, -9, 1, -22, 1,
+ax_anim 2, 0, 68, -9, 0, -22, 0,
+ax_anim 2, 0, 68, -9, 1, -22, 1,
+ax_anim 2, 0, 66, -18, 3, -18, 0,
+ax_anim 1, 0, 66, -6, 1, -6, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_3_8:
+ax_anim 2, 0, 69, 2, -2, 2, -2,
+ax_anim 4, 0, 70, 3, -3, 3, -3,
+ax_anim 1, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 2, 71, -2, 4, -2, 4,
+ax_anim 1, 0, 71, -11, 19, -11, 19,
+ax_anim 2, 0, 71, -22, 36, -22, 36,
+ax_anim 2, 1, 71, -23, 35, -23, 35,
+ax_anim 2, 0, 71, -22, 36, -22, 36,
+ax_anim 2, 0, 71, -23, 35, -23, 35,
+ax_anim 2, 0, 69, -14, 23, -14, 23,
+ax_anim 1, 0, 69, -6, 10, -6, 10,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sRayquazaCutsceneAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sRayquazaCutsceneAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sRayquazaCutsceneAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sRayquazaCutsceneAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sRayquazaCutsceneAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_5_1:
+ax_anim 2, 0, 96, 0, 2, 0, 1,
+ax_anim 2, 0, 96, 0, 3, 0, 2,
+ax_anim 6, 0, 96, 0, 4, 0, 3,
+ax_anim 2, 0, 97, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 0, -3, 0, 3,
+ax_anim 2, 2, 98, 0, -5, 0, 2,
+ax_anim 2, 0, 98, -1, -5, -1, 1,
+ax_anim 2, 0, 98, 0, -5, 0, 1,
+ax_anim 2, 0, 98, -1, -5, -1, 1,
+ax_anim 2, 0, 98, 0, -5, 0, 1,
+ax_anim 2, 0, 98, -1, -5, -1, 1,
+ax_anim 2, 0, 98, 0, -4, 0, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 1,
+ax_anim_terminator
+sRayquazaCutsceneAnims_5_2:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 6, 0, 99, 2, 2, 2, 2,
+ax_anim 2, 0, 100, 6, -1, 3, 3,
+ax_anim 2, 0, 101, 6, -3, 3, 3,
+ax_anim 2, 2, 101, 5, -5, 2, 2,
+ax_anim 2, 0, 101, 4, -4, 1, 3,
+ax_anim 2, 0, 101, 5, -5, 2, 2,
+ax_anim 2, 0, 101, 4, -4, 1, 3,
+ax_anim 2, 0, 101, 5, -5, 2, 2,
+ax_anim 2, 0, 101, 4, -4, 1, 3,
+ax_anim 2, 0, 101, 4, -3, 2, 2,
+ax_anim 2, 0, 100, 3, -5, 2, 2,
+ax_anim_terminator
+sRayquazaCutsceneAnims_5_3:
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 2, 1, 2, 0,
+ax_anim 6, 0, 102, 3, 2, 3, 0,
+ax_anim 2, 0, 103, 5, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 3, 0,
+ax_anim 2, 2, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 1, -1, 2, -1,
+ax_anim 2, 0, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 1, -1, 2, -1,
+ax_anim 2, 0, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 1, -1, 2, -1,
+ax_anim 2, 0, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 103, 3, 0, 1, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_5_4:
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 6, 0, 105, 3, -3, 3, -3,
+ax_anim 2, 0, 106, 6, -3, 3, -3,
+ax_anim 2, 0, 107, 6, 2, 3, -3,
+ax_anim 2, 2, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 107, 4, -1, 1, -3,
+ax_anim 2, 0, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 107, 4, -1, 1, -3,
+ax_anim 2, 0, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 107, 4, -1, 1, -3,
+ax_anim 2, 0, 107, 5, 0, 2, -2,
+ax_anim 2, 0, 106, 8, -3, 3, -3,
+ax_anim_terminator
+sRayquazaCutsceneAnims_5_5:
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim 6, 0, 108, 0, -3, 0, -3,
+ax_anim 2, 0, 109, 0, -8, 0, -4,
+ax_anim 2, 0, 110, 0, -11, 0, -4,
+ax_anim 2, 2, 110, 0, -12, 0, -3,
+ax_anim 2, 0, 110, -1, -12, -1, -3,
+ax_anim 2, 0, 110, 0, -12, 0, -3,
+ax_anim 2, 0, 110, -1, -12, -1, -3,
+ax_anim 2, 0, 110, 0, -12, 0, -3,
+ax_anim 2, 0, 110, -1, -12, -1, -3,
+ax_anim 2, 0, 110, 0, -10, 0, -3,
+ax_anim 2, 0, 109, 0, -8, 0, -2,
+ax_anim_terminator
+sRayquazaCutsceneAnims_5_6:
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, -2, -2, -2, -2,
+ax_anim 6, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 112, -6, -3, -3, -3,
+ax_anim 2, 0, 113, -6, 2, -3, -3,
+ax_anim 2, 2, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 113, -4, -1, -1, -3,
+ax_anim 2, 0, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 113, -4, -1, -1, -3,
+ax_anim 2, 0, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 113, -4, -1, -1, -3,
+ax_anim 2, 0, 113, -5, 0, -2, -2,
+ax_anim 2, 0, 112, -8, -3, -3, -3,
+ax_anim_terminator
+sRayquazaCutsceneAnims_5_7:
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, -2, 1, -2, 0,
+ax_anim 6, 0, 114, -3, 2, -3, 0,
+ax_anim 2, 0, 115, -5, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -3, 0,
+ax_anim 2, 2, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 116, -1, -1, -2, -1,
+ax_anim 2, 0, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 116, -1, -1, -2, -1,
+ax_anim 2, 0, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 116, -1, -1, -2, -1,
+ax_anim 2, 0, 116, -1, 0, -2, 0,
+ax_anim 2, 0, 115, -3, 0, -1, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_5_8:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim 6, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -6, -1, -3, 3,
+ax_anim 2, 0, 119, -6, -3, -3, 3,
+ax_anim 2, 2, 119, -5, -5, -2, 2,
+ax_anim 2, 0, 119, -4, -4, -1, 3,
+ax_anim 2, 0, 119, -5, -5, -2, 2,
+ax_anim 2, 0, 119, -4, -4, -1, 3,
+ax_anim 2, 0, 119, -5, -5, -2, 2,
+ax_anim 2, 0, 119, -4, -4, -1, 3,
+ax_anim 2, 0, 119, -4, -3, -2, 2,
+ax_anim 2, 0, 118, -3, -5, -2, 2,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_6_1:
+ax_anim 10, 0, 120, 0, 0, 0, 0,
+ax_anim 10, 0, 120, 0, -1, 0, 0,
+ax_anim 10, 0, 120, 0, -2, 0, 0,
+ax_anim 30, 0, 120, 0, -3, 0, 0,
+ax_anim 10, 0, 121, 0, -3, 0, 0,
+ax_anim 10, 0, 121, 0, -2, 0, 0,
+ax_anim 10, 0, 121, 0, -1, 0, 0,
+ax_anim 30, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sRayquazaCutsceneAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sRayquazaCutsceneAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sRayquazaCutsceneAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sRayquazaCutsceneAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sRayquazaCutsceneAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_7_8:
+ax_anim 2, 0, 129, 8, -2, 8, -2,
+ax_anim 8, 0, 129, 9, -3, 9, -3,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_8_1:
+ax_anim 14, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 14, 0, 132, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_8_2:
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_8_3:
+ax_anim 14, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_8_4:
+ax_anim 14, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 14, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_8_5:
+ax_anim 14, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 14, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_8_6:
+ax_anim 14, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_8_7:
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_8_8:
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 14, 7, 14,
+ax_anim 3, 0, 158, 0, 16, 0, 16,
+ax_anim 2, 3, 159, -7, 14, -7, 14,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 7, 4, 7, 4,
+ax_anim 2, 0, 155, 12, 10, 12, 10,
+ax_anim 2, 0, 156, 11, 15, 11, 15,
+ax_anim 3, 0, 157, 7, 18, 7, 18,
+ax_anim 2, 3, 158, 4, 16, 4, 16,
+ax_anim 2, 0, 159, 1, 12, 1, 12,
+ax_anim 1, 0, 160, 1, 7, 1, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 1, -2, 1, -2,
+ax_anim 2, 0, 154, 3, -3, 3, -3,
+ax_anim 2, 0, 155, 4, -1, 4, -1,
+ax_anim 3, 0, 156, 5, 2, 5, 2,
+ax_anim 2, 3, 157, 4, 4, 4, 4,
+ax_anim 2, 0, 158, 3, 4, 3, 4,
+ax_anim 1, 0, 159, 1, 2, 1, 2,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 1, -8, 1, -8,
+ax_anim 2, 0, 161, 5, -14, 5, -14,
+ax_anim 2, 0, 154, 12, -16, 12, -16,
+ax_anim 3, 0, 155, 16, -15, 16, -15,
+ax_anim 2, 3, 156, 18, -10, 18, -10,
+ax_anim 2, 0, 157, 13, -5, 13, -5,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -4, -2, -4, -2,
+ax_anim 2, 0, 160, -7, -6, -7, -6,
+ax_anim 2, 0, 161, -5, -11, -5, -11,
+ax_anim 3, 0, 154, 0, -12, 0, -12,
+ax_anim 2, 3, 155, 5, -11, 5, -11,
+ax_anim 2, 0, 156, 7, -6, 7, -6,
+ax_anim 1, 0, 157, 4, -2, 4, -2,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -5, -14, -5, -14,
+ax_anim 2, 0, 154, -12, -16, -12, -16,
+ax_anim 3, 0, 161, -16, -15, -16, -15,
+ax_anim 2, 3, 160, -18, -10, -18, -10,
+ax_anim 2, 0, 159, -13, -5, -13, -5,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -1, -2, -1, -2,
+ax_anim 2, 0, 154, -3, -3, -3, -3,
+ax_anim 2, 0, 161, -4, -1, -4, -1,
+ax_anim 3, 0, 160, -5, 2, -5, 2,
+ax_anim 2, 3, 159, -4, 4, -4, 4,
+ax_anim 2, 0, 158, -3, 4, -3, 4,
+ax_anim 1, 0, 157, -1, 2, -1, 2,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -7, 4, -7, 4,
+ax_anim 2, 0, 161, -12, 10, -12, 10,
+ax_anim 2, 0, 160, -11, 15, -11, 15,
+ax_anim 3, 0, 159, -7, 18, -7, 18,
+ax_anim 2, 3, 158, -4, 16, -4, 16,
+ax_anim 2, 0, 157, -1, 12, -1, 12,
+ax_anim 1, 0, 156, -1, 7, -1, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -29, 0, 0,
+ax_anim 3, 0, 170, 0, -28, 0, 0,
+ax_anim 2, 0, 170, 0, -17, 0, 0,
+ax_anim 1, 0, 170, 0, -11, 0, 0,
+ax_anim 2, 2, 170, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -23, 0, 0,
+ax_anim 2, 0, 173, 0, -20, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 6, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -19, 0, 0,
+ax_anim 2, 0, 191, 0, -15, 0, 0,
+ax_anim 1, 0, 191, 0, -9, 0, 0,
+ax_anim 2, 2, 191, 0, 6, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_14_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_14_2:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_14_3:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_14_4:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_14_5:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_14_6:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_14_7:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneAnims_14_8:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 36, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_15_1:
+ax_anim 6, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 0, 0,
+ax_anim 4, 0, 234, 3, -2, 0, 0,
+ax_anim 2, 0, 235, 2, -2, 0, 0,
+ax_anim 5, 0, 235, 0, -2, 0, 0,
+ax_anim 5, 0, 236, 0, -1, 0, 0,
+ax_anim 5, 0, 236, -2, 0, 0, 0,
+ax_anim 6, 0, 237, -3, -1, 0, 0,
+ax_anim 6, 0, 237, -1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_16_1:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 4, 0, 264, 0, 0, 0, 0,
+ax_anim 4, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 1, 0, 262, -1, 0, -1, 0,
+ax_anim 1, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, -1, 0, -1, 0,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 4, 0, 265, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 3, 0, 3,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 2, 0, 2,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 1, 0, 1,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, 1, 0, 1,
+ax_anim 10, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_17_1:
+ax_anim 10, 0, 288, 0, 0, 0, 0,
+ax_anim 5, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, -1, 0, -1, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 290, -1, 0, -1, 0,
+ax_anim 8, 0, 290, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_18_1:
+ax_anim 5, 0, 312, 0, 0, 0, 0,
+ax_anim 12, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 10, 0, 315, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRayquazaCutsceneAnims_19_1:
+ax_anim 10, 0, 337, 0, 0, 0, 0,
+ax_anim 6, 0, 338, 0, 0, 0, 0,
+ax_anim 20, 0, 339, 0, 0, 0, 0,
+ax_anim_terminator
+sRayquazaCutsceneGfx1:
+.incbin "baserom.gba", 0x16620EC, 0x400
+sRayquazaCutsceneSprites1:
+ax_sprite sRayquazaCutsceneGfx1, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx2:
+.incbin "baserom.gba", 0x16624FC, 0x100
+sRayquazaCutsceneSprites2:
+ax_sprite sRayquazaCutsceneGfx2, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx3:
+.incbin "baserom.gba", 0x166260C, 0x20
+sRayquazaCutsceneSprites3:
+ax_sprite sRayquazaCutsceneGfx3, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx4:
+.incbin "baserom.gba", 0x166263C, 0x80
+sRayquazaCutsceneSprites4:
+ax_sprite sRayquazaCutsceneGfx4, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx5:
+.incbin "baserom.gba", 0x16626CC, 0x400
+sRayquazaCutsceneSprites5:
+ax_sprite sRayquazaCutsceneGfx5, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx6:
+.incbin "baserom.gba", 0x1662ADC, 0x100
+sRayquazaCutsceneSprites6:
+ax_sprite sRayquazaCutsceneGfx6, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx7:
+.incbin "baserom.gba", 0x1662BEC, 0x40
+sRayquazaCutsceneSprites7:
+ax_sprite sRayquazaCutsceneGfx7, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx8:
+.incbin "baserom.gba", 0x1662C3C, 0x80
+sRayquazaCutsceneSprites8:
+ax_sprite sRayquazaCutsceneGfx8, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx9:
+.incbin "baserom.gba", 0x1662CCC, 0x400
+sRayquazaCutsceneSprites9:
+ax_sprite sRayquazaCutsceneGfx9, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx10:
+.incbin "baserom.gba", 0x16630DC, 0x100
+sRayquazaCutsceneSprites10:
+ax_sprite sRayquazaCutsceneGfx10, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx11:
+.incbin "baserom.gba", 0x16631EC, 0x40
+sRayquazaCutsceneSprites11:
+ax_sprite sRayquazaCutsceneGfx11, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx12:
+.incbin "baserom.gba", 0x166323C, 0x80
+sRayquazaCutsceneSprites12:
+ax_sprite sRayquazaCutsceneGfx12, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx13:
+.incbin "baserom.gba", 0x16632CC, 0x400
+sRayquazaCutsceneSprites13:
+ax_sprite sRayquazaCutsceneGfx13, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx14:
+.incbin "baserom.gba", 0x16636DC, 0x100
+sRayquazaCutsceneSprites14:
+ax_sprite sRayquazaCutsceneGfx14, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx15:
+.incbin "baserom.gba", 0x16637EC, 0x100
+sRayquazaCutsceneSprites15:
+ax_sprite sRayquazaCutsceneGfx15, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx16:
+.incbin "baserom.gba", 0x16638FC, 0x400
+sRayquazaCutsceneSprites16:
+ax_sprite sRayquazaCutsceneGfx16, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx17:
+.incbin "baserom.gba", 0x1663D0C, 0x100
+sRayquazaCutsceneSprites17:
+ax_sprite sRayquazaCutsceneGfx17, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx18:
+.incbin "baserom.gba", 0x1663E1C, 0x20
+sRayquazaCutsceneSprites18:
+ax_sprite sRayquazaCutsceneGfx18, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx19:
+.incbin "baserom.gba", 0x1663E4C, 0x20
+sRayquazaCutsceneSprites19:
+ax_sprite sRayquazaCutsceneGfx19, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx20:
+.incbin "baserom.gba", 0x1663E7C, 0x400
+sRayquazaCutsceneSprites20:
+ax_sprite sRayquazaCutsceneGfx20, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx21:
+.incbin "baserom.gba", 0x166428C, 0x100
+sRayquazaCutsceneSprites21:
+ax_sprite sRayquazaCutsceneGfx21, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx22:
+.incbin "baserom.gba", 0x166439C, 0x20
+sRayquazaCutsceneSprites22:
+ax_sprite sRayquazaCutsceneGfx22, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx23:
+.incbin "baserom.gba", 0x16643CC, 0x20
+sRayquazaCutsceneSprites23:
+ax_sprite sRayquazaCutsceneGfx23, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx24:
+.incbin "baserom.gba", 0x16643FC, 0x400
+sRayquazaCutsceneSprites24:
+ax_sprite sRayquazaCutsceneGfx24, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx25:
+.incbin "baserom.gba", 0x166480C, 0x200
+sRayquazaCutsceneSprites25:
+ax_sprite sRayquazaCutsceneGfx25, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx26:
+.incbin "baserom.gba", 0x1664A1C, 0x80
+sRayquazaCutsceneSprites26:
+ax_sprite sRayquazaCutsceneGfx26, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx27:
+.incbin "baserom.gba", 0x1664AAC, 0x20
+sRayquazaCutsceneSprites27:
+ax_sprite sRayquazaCutsceneGfx27, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx28:
+.incbin "baserom.gba", 0x1664ADC, 0x20
+sRayquazaCutsceneSprites28:
+ax_sprite sRayquazaCutsceneGfx28, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx29:
+.incbin "baserom.gba", 0x1664B0C, 0x400
+sRayquazaCutsceneSprites29:
+ax_sprite sRayquazaCutsceneGfx29, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx30:
+.incbin "baserom.gba", 0x1664F1C, 0x200
+sRayquazaCutsceneSprites30:
+ax_sprite sRayquazaCutsceneGfx30, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx31:
+.incbin "baserom.gba", 0x166512C, 0x40
+sRayquazaCutsceneSprites31:
+ax_sprite sRayquazaCutsceneGfx31, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx32:
+.incbin "baserom.gba", 0x166517C, 0x20
+sRayquazaCutsceneSprites32:
+ax_sprite sRayquazaCutsceneGfx32, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx33:
+.incbin "baserom.gba", 0x16651AC, 0x20
+sRayquazaCutsceneSprites33:
+ax_sprite sRayquazaCutsceneGfx33, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx34:
+.incbin "baserom.gba", 0x16651DC, 0x400
+sRayquazaCutsceneSprites34:
+ax_sprite sRayquazaCutsceneGfx34, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx35:
+.incbin "baserom.gba", 0x16655EC, 0x200
+sRayquazaCutsceneSprites35:
+ax_sprite sRayquazaCutsceneGfx35, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx36:
+.incbin "baserom.gba", 0x16657FC, 0x80
+sRayquazaCutsceneSprites36:
+ax_sprite sRayquazaCutsceneGfx36, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx37:
+.incbin "baserom.gba", 0x166588C, 0x20
+sRayquazaCutsceneSprites37:
+ax_sprite sRayquazaCutsceneGfx37, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx38:
+.incbin "baserom.gba", 0x16658BC, 0x20
+sRayquazaCutsceneSprites38:
+ax_sprite sRayquazaCutsceneGfx38, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx39:
+.incbin "baserom.gba", 0x16658EC, 0x400
+sRayquazaCutsceneSprites39:
+ax_sprite sRayquazaCutsceneGfx39, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx40:
+.incbin "baserom.gba", 0x1665CFC, 0x200
+sRayquazaCutsceneSprites40:
+ax_sprite sRayquazaCutsceneGfx40, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx41:
+.incbin "baserom.gba", 0x1665F0C, 0x80
+sRayquazaCutsceneSprites41:
+ax_sprite sRayquazaCutsceneGfx41, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx42:
+.incbin "baserom.gba", 0x1665F9C, 0x20
+sRayquazaCutsceneSprites42:
+ax_sprite sRayquazaCutsceneGfx42, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx43:
+.incbin "baserom.gba", 0x1665FCC, 0x20
+sRayquazaCutsceneSprites43:
+ax_sprite sRayquazaCutsceneGfx43, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx44:
+.incbin "baserom.gba", 0x1665FFC, 0x400
+sRayquazaCutsceneSprites44:
+ax_sprite sRayquazaCutsceneGfx44, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx45:
+.incbin "baserom.gba", 0x166640C, 0x200
+sRayquazaCutsceneSprites45:
+ax_sprite sRayquazaCutsceneGfx45, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx46:
+.incbin "baserom.gba", 0x166661C, 0x80
+sRayquazaCutsceneSprites46:
+ax_sprite sRayquazaCutsceneGfx46, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx47:
+.incbin "baserom.gba", 0x16666AC, 0x20
+sRayquazaCutsceneSprites47:
+ax_sprite sRayquazaCutsceneGfx47, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx48:
+.incbin "baserom.gba", 0x16666DC, 0x20
+sRayquazaCutsceneSprites48:
+ax_sprite sRayquazaCutsceneGfx48, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx49:
+.incbin "baserom.gba", 0x166670C, 0x400
+sRayquazaCutsceneSprites49:
+ax_sprite sRayquazaCutsceneGfx49, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx50:
+.incbin "baserom.gba", 0x1666B1C, 0x200
+sRayquazaCutsceneSprites50:
+ax_sprite sRayquazaCutsceneGfx50, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx51:
+.incbin "baserom.gba", 0x1666D2C, 0x80
+sRayquazaCutsceneSprites51:
+ax_sprite sRayquazaCutsceneGfx51, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx52:
+.incbin "baserom.gba", 0x1666DBC, 0x40
+sRayquazaCutsceneSprites52:
+ax_sprite sRayquazaCutsceneGfx52, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx53:
+.incbin "baserom.gba", 0x1666E0C, 0x20
+sRayquazaCutsceneSprites53:
+ax_sprite sRayquazaCutsceneGfx53, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx54:
+.incbin "baserom.gba", 0x1666E3C, 0x400
+sRayquazaCutsceneSprites54:
+ax_sprite sRayquazaCutsceneGfx54, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx55:
+.incbin "baserom.gba", 0x166724C, 0x100
+sRayquazaCutsceneSprites55:
+ax_sprite sRayquazaCutsceneGfx55, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx56:
+.incbin "baserom.gba", 0x166735C, 0x100
+sRayquazaCutsceneSprites56:
+ax_sprite sRayquazaCutsceneGfx56, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx57:
+.incbin "baserom.gba", 0x166746C, 0x40
+sRayquazaCutsceneSprites57:
+ax_sprite sRayquazaCutsceneGfx57, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx58:
+.incbin "baserom.gba", 0x16674BC, 0x400
+sRayquazaCutsceneSprites58:
+ax_sprite sRayquazaCutsceneGfx58, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx59:
+.incbin "baserom.gba", 0x16678CC, 0x80
+sRayquazaCutsceneSprites59:
+ax_sprite sRayquazaCutsceneGfx59, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx60:
+.incbin "baserom.gba", 0x166795C, 0x80
+sRayquazaCutsceneSprites60:
+ax_sprite sRayquazaCutsceneGfx60, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx61:
+.incbin "baserom.gba", 0x16679EC, 0x80
+sRayquazaCutsceneSprites61:
+ax_sprite sRayquazaCutsceneGfx61, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx62:
+.incbin "baserom.gba", 0x1667A7C, 0x40
+sRayquazaCutsceneSprites62:
+ax_sprite sRayquazaCutsceneGfx62, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx63:
+.incbin "baserom.gba", 0x1667ACC, 0x400
+sRayquazaCutsceneSprites63:
+ax_sprite sRayquazaCutsceneGfx63, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx64:
+.incbin "baserom.gba", 0x1667EDC, 0x80
+sRayquazaCutsceneSprites64:
+ax_sprite sRayquazaCutsceneGfx64, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx65:
+.incbin "baserom.gba", 0x1667F6C, 0x100
+sRayquazaCutsceneSprites65:
+ax_sprite sRayquazaCutsceneGfx65, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx66:
+.incbin "baserom.gba", 0x166807C, 0x40
+sRayquazaCutsceneSprites66:
+ax_sprite sRayquazaCutsceneGfx66, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx67:
+.incbin "baserom.gba", 0x16680CC, 0x400
+sRayquazaCutsceneSprites67:
+ax_sprite sRayquazaCutsceneGfx67, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx68:
+.incbin "baserom.gba", 0x16684DC, 0x100
+sRayquazaCutsceneSprites68:
+ax_sprite sRayquazaCutsceneGfx68, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx69:
+.incbin "baserom.gba", 0x16685EC, 0x40
+sRayquazaCutsceneSprites69:
+ax_sprite sRayquazaCutsceneGfx69, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx70:
+.incbin "baserom.gba", 0x166863C, 0x40
+sRayquazaCutsceneSprites70:
+ax_sprite sRayquazaCutsceneGfx70, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx71:
+.incbin "baserom.gba", 0x166868C, 0x400
+sRayquazaCutsceneSprites71:
+ax_sprite sRayquazaCutsceneGfx71, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx72:
+.incbin "baserom.gba", 0x1668A9C, 0x100
+sRayquazaCutsceneSprites72:
+ax_sprite sRayquazaCutsceneGfx72, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx73:
+.incbin "baserom.gba", 0x1668BAC, 0x40
+sRayquazaCutsceneSprites73:
+ax_sprite sRayquazaCutsceneGfx73, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx74:
+.incbin "baserom.gba", 0x1668BFC, 0x400
+sRayquazaCutsceneSprites74:
+ax_sprite sRayquazaCutsceneGfx74, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx75:
+.incbin "baserom.gba", 0x166900C, 0x100
+sRayquazaCutsceneSprites75:
+ax_sprite sRayquazaCutsceneGfx75, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx76:
+.incbin "baserom.gba", 0x166911C, 0x40
+sRayquazaCutsceneSprites76:
+ax_sprite sRayquazaCutsceneGfx76, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx77:
+.incbin "baserom.gba", 0x166916C, 0x40
+sRayquazaCutsceneSprites77:
+ax_sprite sRayquazaCutsceneGfx77, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx78:
+.incbin "baserom.gba", 0x16691BC, 0x400
+sRayquazaCutsceneSprites78:
+ax_sprite sRayquazaCutsceneGfx78, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx79:
+.incbin "baserom.gba", 0x16695CC, 0x200
+sRayquazaCutsceneSprites79:
+ax_sprite sRayquazaCutsceneGfx79, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx80:
+.incbin "baserom.gba", 0x16697DC, 0x20
+sRayquazaCutsceneSprites80:
+ax_sprite sRayquazaCutsceneGfx80, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx81:
+.incbin "baserom.gba", 0x166980C, 0x40
+sRayquazaCutsceneSprites81:
+ax_sprite sRayquazaCutsceneGfx81, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx82:
+.incbin "baserom.gba", 0x166985C, 0x400
+sRayquazaCutsceneSprites82:
+ax_sprite sRayquazaCutsceneGfx82, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx83:
+.incbin "baserom.gba", 0x1669C6C, 0x200
+sRayquazaCutsceneSprites83:
+ax_sprite sRayquazaCutsceneGfx83, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx84:
+.incbin "baserom.gba", 0x1669E7C, 0x20
+sRayquazaCutsceneSprites84:
+ax_sprite sRayquazaCutsceneGfx84, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx85:
+.incbin "baserom.gba", 0x1669EAC, 0x40
+sRayquazaCutsceneSprites85:
+ax_sprite sRayquazaCutsceneGfx85, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx86:
+.incbin "baserom.gba", 0x1669EFC, 0x400
+sRayquazaCutsceneSprites86:
+ax_sprite sRayquazaCutsceneGfx86, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx87:
+.incbin "baserom.gba", 0x166A30C, 0x200
+sRayquazaCutsceneSprites87:
+ax_sprite sRayquazaCutsceneGfx87, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx88:
+.incbin "baserom.gba", 0x166A51C, 0x20
+sRayquazaCutsceneSprites88:
+ax_sprite sRayquazaCutsceneGfx88, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx89:
+.incbin "baserom.gba", 0x166A54C, 0x40
+sRayquazaCutsceneSprites89:
+ax_sprite sRayquazaCutsceneGfx89, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx90:
+.incbin "baserom.gba", 0x166A59C, 0x200
+sRayquazaCutsceneSprites90:
+ax_sprite sRayquazaCutsceneGfx90, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx91:
+.incbin "baserom.gba", 0x166A7AC, 0x400
+sRayquazaCutsceneSprites91:
+ax_sprite sRayquazaCutsceneGfx91, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx92:
+.incbin "baserom.gba", 0x166ABBC, 0x400
+sRayquazaCutsceneSprites92:
+ax_sprite sRayquazaCutsceneGfx92, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx93:
+.incbin "baserom.gba", 0x166AFCC, 0x200
+sRayquazaCutsceneSprites93:
+ax_sprite sRayquazaCutsceneGfx93, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx94:
+.incbin "baserom.gba", 0x166B1DC, 0x20
+sRayquazaCutsceneSprites94:
+ax_sprite sRayquazaCutsceneGfx94, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx95:
+.incbin "baserom.gba", 0x166B20C, 0x400
+sRayquazaCutsceneSprites95:
+ax_sprite sRayquazaCutsceneGfx95, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx96:
+.incbin "baserom.gba", 0x166B61C, 0x200
+sRayquazaCutsceneSprites96:
+ax_sprite sRayquazaCutsceneGfx96, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx97:
+.incbin "baserom.gba", 0x166B82C, 0x20
+sRayquazaCutsceneSprites97:
+ax_sprite sRayquazaCutsceneGfx97, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx98:
+.incbin "baserom.gba", 0x166B85C, 0x40
+sRayquazaCutsceneGfx98_1:
+.incbin "baserom.gba", 0x166B89C, 0x20
+sRayquazaCutsceneGfx98_2:
+.incbin "baserom.gba", 0x166B8BC, 0x60
+sRayquazaCutsceneGfx98_3:
+.incbin "baserom.gba", 0x166B91C, 0x60
+sRayquazaCutsceneGfx98_4:
+.incbin "baserom.gba", 0x166B97C, 0x1E0
+sRayquazaCutsceneGfx98_5:
+.incbin "baserom.gba", 0x166BB5C, 0x60
+sRayquazaCutsceneSprites98:
+ax_sprite sRayquazaCutsceneGfx98, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx98_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx98_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx98_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx98_4, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx98_5, 0x60
+ax_sprite_terminator
+sRayquazaCutsceneGfx99:
+.incbin "baserom.gba", 0x166BC1C, 0x100
+sRayquazaCutsceneSprites99:
+ax_sprite sRayquazaCutsceneGfx99, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx100:
+.incbin "baserom.gba", 0x166BD2C, 0x80
+sRayquazaCutsceneSprites100:
+ax_sprite sRayquazaCutsceneGfx100, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx101:
+.incbin "baserom.gba", 0x166BDBC, 0x40
+sRayquazaCutsceneGfx101_1:
+.incbin "baserom.gba", 0x166BDFC, 0x60
+sRayquazaCutsceneGfx101_2:
+.incbin "baserom.gba", 0x166BE5C, 0x60
+sRayquazaCutsceneGfx101_3:
+.incbin "baserom.gba", 0x166BEBC, 0x140
+sRayquazaCutsceneGfx101_4:
+.incbin "baserom.gba", 0x166BFFC, 0x100
+sRayquazaCutsceneSprites101:
+ax_sprite sRayquazaCutsceneGfx101, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx101_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx101_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx101_3, 0x140
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx101_4, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx102:
+.incbin "baserom.gba", 0x166C14C, 0x60
+sRayquazaCutsceneSprites102:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx102, 0x60
+ax_sprite_terminator
+sRayquazaCutsceneGfx103:
+.incbin "baserom.gba", 0x166C1C4, 0xE0
+sRayquazaCutsceneSprites103:
+ax_sprite sRayquazaCutsceneGfx103, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx104:
+.incbin "baserom.gba", 0x166C2BC, 0x20
+sRayquazaCutsceneSprites104:
+ax_sprite sRayquazaCutsceneGfx104, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx105:
+.incbin "baserom.gba", 0x166C2EC, 0xE0
+sRayquazaCutsceneGfx105_1:
+.incbin "baserom.gba", 0x166C3CC, 0x180
+sRayquazaCutsceneGfx105_2:
+.incbin "baserom.gba", 0x166C54C, 0xE0
+sRayquazaCutsceneGfx105_3:
+.incbin "baserom.gba", 0x166C62C, 0x40
+sRayquazaCutsceneGfx105_4:
+.incbin "baserom.gba", 0x166C66C, 0xE0
+sRayquazaCutsceneGfx105_5:
+.incbin "baserom.gba", 0x166C74C, 0xE0
+sRayquazaCutsceneGfx105_6:
+.incbin "baserom.gba", 0x166C82C, 0xC0
+sRayquazaCutsceneGfx105_7:
+.incbin "baserom.gba", 0x166C8EC, 0x60
+sRayquazaCutsceneSprites105:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx105, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx105_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx105_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx105_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx105_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx105_5, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx105_6, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx105_7, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx106:
+.incbin "baserom.gba", 0x166C9DC, 0x1A0
+sRayquazaCutsceneSprites106:
+ax_sprite sRayquazaCutsceneGfx106, 0x1a0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sRayquazaCutsceneGfx107:
+.incbin "baserom.gba", 0x166CB94, 0x80
+sRayquazaCutsceneSprites107:
+ax_sprite sRayquazaCutsceneGfx107, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx108:
+.incbin "baserom.gba", 0x166CC24, 0x1C0
+sRayquazaCutsceneSprites108:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx108, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx109:
+.incbin "baserom.gba", 0x166CE04, 0x40
+sRayquazaCutsceneSprites109:
+ax_sprite sRayquazaCutsceneGfx109, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx110:
+.incbin "baserom.gba", 0x166CE54, 0x40
+sRayquazaCutsceneSprites110:
+ax_sprite sRayquazaCutsceneGfx110, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx111:
+.incbin "baserom.gba", 0x166CEA4, 0x80
+sRayquazaCutsceneSprites111:
+ax_sprite sRayquazaCutsceneGfx111, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx112:
+.incbin "baserom.gba", 0x166CF34, 0x80
+sRayquazaCutsceneSprites112:
+ax_sprite sRayquazaCutsceneGfx112, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx113:
+.incbin "baserom.gba", 0x166CFC4, 0x60
+sRayquazaCutsceneSprites113:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx113, 0x60
+ax_sprite_terminator
+sRayquazaCutsceneGfx114:
+.incbin "baserom.gba", 0x166D03C, 0x40
+sRayquazaCutsceneSprites114:
+ax_sprite sRayquazaCutsceneGfx114, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx115:
+.incbin "baserom.gba", 0x166D08C, 0xA0
+sRayquazaCutsceneGfx115_1:
+.incbin "baserom.gba", 0x166D12C, 0xE0
+sRayquazaCutsceneGfx115_2:
+.incbin "baserom.gba", 0x166D20C, 0xC0
+sRayquazaCutsceneGfx115_3:
+.incbin "baserom.gba", 0x166D2CC, 0xE0
+sRayquazaCutsceneGfx115_4:
+.incbin "baserom.gba", 0x166D3AC, 0x340
+sRayquazaCutsceneGfx115_5:
+.incbin "baserom.gba", 0x166D6EC, 0x60
+sRayquazaCutsceneSprites115:
+ax_sprite sRayquazaCutsceneGfx115, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx115_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx115_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx115_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx115_4, 0x340
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx115_5, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx116:
+.incbin "baserom.gba", 0x166D7B4, 0x20
+sRayquazaCutsceneGfx116_1:
+.incbin "baserom.gba", 0x166D7D4, 0x1A0
+sRayquazaCutsceneSprites116:
+ax_sprite sRayquazaCutsceneGfx116, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx116_1, 0x1a0
+ax_sprite_terminator
+sRayquazaCutsceneGfx117:
+.incbin "baserom.gba", 0x166D994, 0x100
+sRayquazaCutsceneSprites117:
+ax_sprite sRayquazaCutsceneGfx117, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx118:
+.incbin "baserom.gba", 0x166DAA4, 0x80
+sRayquazaCutsceneSprites118:
+ax_sprite sRayquazaCutsceneGfx118, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx119:
+.incbin "baserom.gba", 0x166DB34, 0x20
+sRayquazaCutsceneGfx119_1:
+.incbin "baserom.gba", 0x166DB54, 0x40
+sRayquazaCutsceneGfx119_2:
+.incbin "baserom.gba", 0x166DB94, 0x100
+sRayquazaCutsceneSprites119:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx119, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx119_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx119_2, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx120:
+.incbin "baserom.gba", 0x166DCCC, 0x80
+sRayquazaCutsceneSprites120:
+ax_sprite sRayquazaCutsceneGfx120, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx121:
+.incbin "baserom.gba", 0x166DD5C, 0x40
+sRayquazaCutsceneSprites121:
+ax_sprite sRayquazaCutsceneGfx121, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx122:
+.incbin "baserom.gba", 0x166DDAC, 0x20
+sRayquazaCutsceneSprites122:
+ax_sprite sRayquazaCutsceneGfx122, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx123:
+.incbin "baserom.gba", 0x166DDDC, 0x20
+sRayquazaCutsceneSprites123:
+ax_sprite sRayquazaCutsceneGfx123, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx124:
+.incbin "baserom.gba", 0x166DE0C, 0x40
+sRayquazaCutsceneSprites124:
+ax_sprite sRayquazaCutsceneGfx124, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx125:
+.incbin "baserom.gba", 0x166DE5C, 0x80
+sRayquazaCutsceneSprites125:
+ax_sprite sRayquazaCutsceneGfx125, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx126:
+.incbin "baserom.gba", 0x166DEEC, 0x40
+sRayquazaCutsceneSprites126:
+ax_sprite sRayquazaCutsceneGfx126, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx127:
+.incbin "baserom.gba", 0x166DF3C, 0x80
+sRayquazaCutsceneSprites127:
+ax_sprite sRayquazaCutsceneGfx127, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx128:
+.incbin "baserom.gba", 0x166DFCC, 0x20
+sRayquazaCutsceneGfx128_1:
+.incbin "baserom.gba", 0x166DFEC, 0x60
+sRayquazaCutsceneGfx128_2:
+.incbin "baserom.gba", 0x166E04C, 0xE0
+sRayquazaCutsceneGfx128_3:
+.incbin "baserom.gba", 0x166E12C, 0xE0
+sRayquazaCutsceneGfx128_4:
+.incbin "baserom.gba", 0x166E20C, 0x140
+sRayquazaCutsceneSprites128:
+ax_sprite sRayquazaCutsceneGfx128, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx128_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx128_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx128_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx128_4, 0x140
+ax_sprite_terminator
+sRayquazaCutsceneGfx129:
+.incbin "baserom.gba", 0x166E39C, 0x100
+sRayquazaCutsceneSprites129:
+ax_sprite sRayquazaCutsceneGfx129, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx130:
+.incbin "baserom.gba", 0x166E4AC, 0x40
+sRayquazaCutsceneGfx130_1:
+.incbin "baserom.gba", 0x166E4EC, 0x20
+sRayquazaCutsceneSprites130:
+ax_sprite sRayquazaCutsceneGfx130, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx130_1, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx131:
+.incbin "baserom.gba", 0x166E52C, 0x80
+sRayquazaCutsceneSprites131:
+ax_sprite sRayquazaCutsceneGfx131, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx132:
+.incbin "baserom.gba", 0x166E5BC, 0x40
+sRayquazaCutsceneSprites132:
+ax_sprite sRayquazaCutsceneGfx132, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx133:
+.incbin "baserom.gba", 0x166E60C, 0x100
+sRayquazaCutsceneSprites133:
+ax_sprite sRayquazaCutsceneGfx133, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx134:
+.incbin "baserom.gba", 0x166E71C, 0x20
+sRayquazaCutsceneSprites134:
+ax_sprite sRayquazaCutsceneGfx134, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx135:
+.incbin "baserom.gba", 0x166E74C, 0x40
+sRayquazaCutsceneSprites135:
+ax_sprite sRayquazaCutsceneGfx135, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx136:
+.incbin "baserom.gba", 0x166E79C, 0x20
+sRayquazaCutsceneSprites136:
+ax_sprite sRayquazaCutsceneGfx136, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx137:
+.incbin "baserom.gba", 0x166E7CC, 0x20
+sRayquazaCutsceneGfx137_1:
+.incbin "baserom.gba", 0x166E7EC, 0x40
+sRayquazaCutsceneGfx137_2:
+.incbin "baserom.gba", 0x166E82C, 0x140
+sRayquazaCutsceneSprites137:
+ax_sprite sRayquazaCutsceneGfx137, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx137_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx137_2, 0x140
+ax_sprite_terminator
+sRayquazaCutsceneGfx138:
+.incbin "baserom.gba", 0x166E99C, 0x100
+sRayquazaCutsceneSprites138:
+ax_sprite sRayquazaCutsceneGfx138, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx139:
+.incbin "baserom.gba", 0x166EAAC, 0x40
+sRayquazaCutsceneSprites139:
+ax_sprite sRayquazaCutsceneGfx139, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx140:
+.incbin "baserom.gba", 0x166EAFC, 0x20
+sRayquazaCutsceneSprites140:
+ax_sprite sRayquazaCutsceneGfx140, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx141:
+.incbin "baserom.gba", 0x166EB2C, 0x80
+sRayquazaCutsceneSprites141:
+ax_sprite sRayquazaCutsceneGfx141, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx142:
+.incbin "baserom.gba", 0x166EBBC, 0x40
+sRayquazaCutsceneSprites142:
+ax_sprite sRayquazaCutsceneGfx142, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx143:
+.incbin "baserom.gba", 0x166EC0C, 0x80
+sRayquazaCutsceneSprites143:
+ax_sprite sRayquazaCutsceneGfx143, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx144:
+.incbin "baserom.gba", 0x166EC9C, 0x40
+sRayquazaCutsceneSprites144:
+ax_sprite sRayquazaCutsceneGfx144, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx145:
+.incbin "baserom.gba", 0x166ECEC, 0xE0
+sRayquazaCutsceneSprites145:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx145, 0xe0
+ax_sprite_terminator
+sRayquazaCutsceneGfx146:
+.incbin "baserom.gba", 0x166EDE4, 0x40
+sRayquazaCutsceneSprites146:
+ax_sprite sRayquazaCutsceneGfx146, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx147:
+.incbin "baserom.gba", 0x166EE34, 0x40
+sRayquazaCutsceneSprites147:
+ax_sprite sRayquazaCutsceneGfx147, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx148:
+.incbin "baserom.gba", 0x166EE84, 0x60
+sRayquazaCutsceneSprites148:
+ax_sprite sRayquazaCutsceneGfx148, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx149:
+.incbin "baserom.gba", 0x166EEFC, 0x40
+sRayquazaCutsceneSprites149:
+ax_sprite sRayquazaCutsceneGfx149, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx150:
+.incbin "baserom.gba", 0x166EF4C, 0x40
+sRayquazaCutsceneSprites150:
+ax_sprite sRayquazaCutsceneGfx150, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx151:
+.incbin "baserom.gba", 0x166EF9C, 0x60
+sRayquazaCutsceneGfx151_1:
+.incbin "baserom.gba", 0x166EFFC, 0x160
+sRayquazaCutsceneGfx151_2:
+.incbin "baserom.gba", 0x166F15C, 0x60
+sRayquazaCutsceneGfx151_3:
+.incbin "baserom.gba", 0x166F1BC, 0x60
+sRayquazaCutsceneGfx151_4:
+.incbin "baserom.gba", 0x166F21C, 0x60
+sRayquazaCutsceneGfx151_5:
+.incbin "baserom.gba", 0x166F27C, 0x40
+sRayquazaCutsceneSprites151:
+ax_sprite sRayquazaCutsceneGfx151, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx151_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx151_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx151_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx151_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx151_5, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx152:
+.incbin "baserom.gba", 0x166F324, 0xC0
+sRayquazaCutsceneSprites152:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx152, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx153:
+.incbin "baserom.gba", 0x166F404, 0xC0
+sRayquazaCutsceneGfx153_1:
+.incbin "baserom.gba", 0x166F4C4, 0x20
+sRayquazaCutsceneSprites153:
+ax_sprite sRayquazaCutsceneGfx153, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx153_1, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx154:
+.incbin "baserom.gba", 0x166F504, 0x40
+sRayquazaCutsceneSprites154:
+ax_sprite sRayquazaCutsceneGfx154, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx155:
+.incbin "baserom.gba", 0x166F554, 0x80
+sRayquazaCutsceneSprites155:
+ax_sprite sRayquazaCutsceneGfx155, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx156:
+.incbin "baserom.gba", 0x166F5E4, 0x60
+sRayquazaCutsceneGfx156_1:
+.incbin "baserom.gba", 0x166F644, 0x60
+sRayquazaCutsceneGfx156_2:
+.incbin "baserom.gba", 0x166F6A4, 0x160
+sRayquazaCutsceneGfx156_3:
+.incbin "baserom.gba", 0x166F804, 0x60
+sRayquazaCutsceneGfx156_4:
+.incbin "baserom.gba", 0x166F864, 0x60
+sRayquazaCutsceneGfx156_5:
+.incbin "baserom.gba", 0x166F8C4, 0x60
+sRayquazaCutsceneSprites156:
+ax_sprite sRayquazaCutsceneGfx156, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx156_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx156_2, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx156_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx156_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx156_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx157:
+.incbin "baserom.gba", 0x166F98C, 0x80
+sRayquazaCutsceneSprites157:
+ax_sprite sRayquazaCutsceneGfx157, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx158:
+.incbin "baserom.gba", 0x166FA1C, 0x40
+sRayquazaCutsceneSprites158:
+ax_sprite sRayquazaCutsceneGfx158, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx159:
+.incbin "baserom.gba", 0x166FA6C, 0x20
+sRayquazaCutsceneSprites159:
+ax_sprite sRayquazaCutsceneGfx159, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx160:
+.incbin "baserom.gba", 0x166FA9C, 0x80
+sRayquazaCutsceneSprites160:
+ax_sprite sRayquazaCutsceneGfx160, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx161:
+.incbin "baserom.gba", 0x166FB2C, 0x80
+sRayquazaCutsceneSprites161:
+ax_sprite sRayquazaCutsceneGfx161, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx162:
+.incbin "baserom.gba", 0x166FBBC, 0x60
+sRayquazaCutsceneSprites162:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx162, 0x60
+ax_sprite_terminator
+sRayquazaCutsceneGfx163:
+.incbin "baserom.gba", 0x166FC34, 0x80
+sRayquazaCutsceneSprites163:
+ax_sprite sRayquazaCutsceneGfx163, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx164:
+.incbin "baserom.gba", 0x166FCC4, 0x60
+sRayquazaCutsceneGfx164_1:
+.incbin "baserom.gba", 0x166FD24, 0x60
+sRayquazaCutsceneGfx164_2:
+.incbin "baserom.gba", 0x166FD84, 0x60
+sRayquazaCutsceneGfx164_3:
+.incbin "baserom.gba", 0x166FDE4, 0x220
+sRayquazaCutsceneSprites164:
+ax_sprite sRayquazaCutsceneGfx164, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx164_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx164_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx164_3, 0x220
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx165:
+.incbin "baserom.gba", 0x167004C, 0xA0
+sRayquazaCutsceneGfx165_1:
+.incbin "baserom.gba", 0x16700EC, 0x20
+sRayquazaCutsceneSprites165:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx165, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx165_1, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx166:
+.incbin "baserom.gba", 0x1670134, 0x20
+sRayquazaCutsceneSprites166:
+ax_sprite sRayquazaCutsceneGfx166, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx167:
+.incbin "baserom.gba", 0x1670164, 0x40
+sRayquazaCutsceneSprites167:
+ax_sprite sRayquazaCutsceneGfx167, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx168:
+.incbin "baserom.gba", 0x16701B4, 0x80
+sRayquazaCutsceneGfx168_1:
+.incbin "baserom.gba", 0x1670234, 0x240
+sRayquazaCutsceneGfx168_2:
+.incbin "baserom.gba", 0x1670474, 0xA0
+sRayquazaCutsceneSprites168:
+ax_sprite sRayquazaCutsceneGfx168, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx168_1, 0x240
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx168_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx169:
+.incbin "baserom.gba", 0x167054C, 0x20
+sRayquazaCutsceneGfx169_1:
+.incbin "baserom.gba", 0x167056C, 0xA0
+sRayquazaCutsceneSprites169:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx169, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx169_1, 0xa0
+ax_sprite_terminator
+sRayquazaCutsceneGfx170:
+.incbin "baserom.gba", 0x1670634, 0x40
+sRayquazaCutsceneSprites170:
+ax_sprite sRayquazaCutsceneGfx170, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx171:
+.incbin "baserom.gba", 0x1670684, 0x40
+sRayquazaCutsceneSprites171:
+ax_sprite sRayquazaCutsceneGfx171, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx172:
+.incbin "baserom.gba", 0x16706D4, 0x60
+sRayquazaCutsceneGfx172_1:
+.incbin "baserom.gba", 0x1670734, 0x60
+sRayquazaCutsceneGfx172_2:
+.incbin "baserom.gba", 0x1670794, 0x60
+sRayquazaCutsceneGfx172_3:
+.incbin "baserom.gba", 0x16707F4, 0x60
+sRayquazaCutsceneSprites172:
+ax_sprite sRayquazaCutsceneGfx172, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx172_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx172_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx172_3, 0x60
+ax_sprite_terminator
+sRayquazaCutsceneGfx173:
+.incbin "baserom.gba", 0x1670894, 0x60
+sRayquazaCutsceneGfx173_1:
+.incbin "baserom.gba", 0x16708F4, 0x240
+sRayquazaCutsceneGfx173_2:
+.incbin "baserom.gba", 0x1670B34, 0xA0
+sRayquazaCutsceneSprites173:
+ax_sprite sRayquazaCutsceneGfx173, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx173_1, 0x240
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx173_2, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx174:
+.incbin "baserom.gba", 0x1670C0C, 0x100
+sRayquazaCutsceneSprites174:
+ax_sprite sRayquazaCutsceneGfx174, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx175:
+.incbin "baserom.gba", 0x1670D1C, 0x80
+sRayquazaCutsceneSprites175:
+ax_sprite sRayquazaCutsceneGfx175, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx176:
+.incbin "baserom.gba", 0x1670DAC, 0x40
+sRayquazaCutsceneSprites176:
+ax_sprite sRayquazaCutsceneGfx176, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx177:
+.incbin "baserom.gba", 0x1670DFC, 0x20
+sRayquazaCutsceneSprites177:
+ax_sprite sRayquazaCutsceneGfx177, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx178:
+.incbin "baserom.gba", 0x1670E2C, 0x40
+sRayquazaCutsceneSprites178:
+ax_sprite sRayquazaCutsceneGfx178, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx179:
+.incbin "baserom.gba", 0x1670E7C, 0x20
+sRayquazaCutsceneSprites179:
+ax_sprite sRayquazaCutsceneGfx179, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx180:
+.incbin "baserom.gba", 0x1670EAC, 0x20
+sRayquazaCutsceneSprites180:
+ax_sprite sRayquazaCutsceneGfx180, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx181:
+.incbin "baserom.gba", 0x1670EDC, 0x100
+sRayquazaCutsceneSprites181:
+ax_sprite sRayquazaCutsceneGfx181, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx182:
+.incbin "baserom.gba", 0x1670FEC, 0x60
+sRayquazaCutsceneGfx182_1:
+.incbin "baserom.gba", 0x167104C, 0x60
+sRayquazaCutsceneGfx182_2:
+.incbin "baserom.gba", 0x16710AC, 0x60
+sRayquazaCutsceneGfx182_3:
+.incbin "baserom.gba", 0x167110C, 0x80
+sRayquazaCutsceneSprites182:
+ax_sprite sRayquazaCutsceneGfx182, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx182_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx182_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx182_3, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx183:
+.incbin "baserom.gba", 0x16711CC, 0x20
+sRayquazaCutsceneGfx183_1:
+.incbin "baserom.gba", 0x16711EC, 0x140
+sRayquazaCutsceneGfx183_2:
+.incbin "baserom.gba", 0x167132C, 0x40
+sRayquazaCutsceneSprites183:
+ax_sprite sRayquazaCutsceneGfx183, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx183_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx183_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx184:
+.incbin "baserom.gba", 0x16713A4, 0x80
+sRayquazaCutsceneSprites184:
+ax_sprite sRayquazaCutsceneGfx184, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx185:
+.incbin "baserom.gba", 0x1671434, 0x100
+sRayquazaCutsceneSprites185:
+ax_sprite sRayquazaCutsceneGfx185, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx186:
+.incbin "baserom.gba", 0x1671544, 0x80
+sRayquazaCutsceneSprites186:
+ax_sprite sRayquazaCutsceneGfx186, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx187:
+.incbin "baserom.gba", 0x16715D4, 0x40
+sRayquazaCutsceneSprites187:
+ax_sprite sRayquazaCutsceneGfx187, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx188:
+.incbin "baserom.gba", 0x1671624, 0x20
+sRayquazaCutsceneGfx188_1:
+.incbin "baserom.gba", 0x1671644, 0xA0
+sRayquazaCutsceneSprites188:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx188, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx188_1, 0xa0
+ax_sprite_terminator
+sRayquazaCutsceneGfx189:
+.incbin "baserom.gba", 0x167170C, 0x40
+sRayquazaCutsceneSprites189:
+ax_sprite sRayquazaCutsceneGfx189, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx190:
+.incbin "baserom.gba", 0x167175C, 0x20
+sRayquazaCutsceneSprites190:
+ax_sprite sRayquazaCutsceneGfx190, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx191:
+.incbin "baserom.gba", 0x167178C, 0x60
+sRayquazaCutsceneGfx191_1:
+.incbin "baserom.gba", 0x16717EC, 0x60
+sRayquazaCutsceneGfx191_2:
+.incbin "baserom.gba", 0x167184C, 0x160
+sRayquazaCutsceneGfx191_3:
+.incbin "baserom.gba", 0x16719AC, 0x40
+sRayquazaCutsceneGfx191_4:
+.incbin "baserom.gba", 0x16719EC, 0x60
+sRayquazaCutsceneGfx191_5:
+.incbin "baserom.gba", 0x1671A4C, 0x60
+sRayquazaCutsceneSprites191:
+ax_sprite sRayquazaCutsceneGfx191, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx191_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx191_2, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx191_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx191_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx191_5, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx192:
+.incbin "baserom.gba", 0x1671B14, 0x40
+sRayquazaCutsceneGfx192_1:
+.incbin "baserom.gba", 0x1671B54, 0xA0
+sRayquazaCutsceneSprites192:
+ax_sprite sRayquazaCutsceneGfx192, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx192_1, 0xa0
+ax_sprite_terminator
+sRayquazaCutsceneGfx193:
+.incbin "baserom.gba", 0x1671C14, 0xE0
+sRayquazaCutsceneSprites193:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx193, 0xe0
+ax_sprite_terminator
+sRayquazaCutsceneGfx194:
+.incbin "baserom.gba", 0x1671D0C, 0x80
+sRayquazaCutsceneSprites194:
+ax_sprite sRayquazaCutsceneGfx194, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx195:
+.incbin "baserom.gba", 0x1671D9C, 0x40
+sRayquazaCutsceneGfx195_1:
+.incbin "baserom.gba", 0x1671DDC, 0x20
+sRayquazaCutsceneSprites195:
+ax_sprite sRayquazaCutsceneGfx195, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx195_1, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx196:
+.incbin "baserom.gba", 0x1671E1C, 0x60
+sRayquazaCutsceneGfx196_1:
+.incbin "baserom.gba", 0x1671E7C, 0x1E0
+sRayquazaCutsceneGfx196_2:
+.incbin "baserom.gba", 0x167205C, 0x160
+sRayquazaCutsceneSprites196:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx196, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx196_1, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx196_2, 0x160
+ax_sprite_terminator
+sRayquazaCutsceneGfx197:
+.incbin "baserom.gba", 0x16721F4, 0x20
+sRayquazaCutsceneGfx197_1:
+.incbin "baserom.gba", 0x1672214, 0xC0
+sRayquazaCutsceneSprites197:
+ax_sprite sRayquazaCutsceneGfx197, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx197_1, 0xc0
+ax_sprite_terminator
+sRayquazaCutsceneGfx198:
+.incbin "baserom.gba", 0x16722F4, 0x60
+sRayquazaCutsceneSprites198:
+ax_sprite sRayquazaCutsceneGfx198, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx199:
+.incbin "baserom.gba", 0x167236C, 0x40
+sRayquazaCutsceneSprites199:
+ax_sprite sRayquazaCutsceneGfx199, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx200:
+.incbin "baserom.gba", 0x16723BC, 0x40
+sRayquazaCutsceneSprites200:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx200, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx201:
+.incbin "baserom.gba", 0x1672414, 0xA0
+sRayquazaCutsceneGfx201_1:
+.incbin "baserom.gba", 0x16724B4, 0xA0
+sRayquazaCutsceneGfx201_2:
+.incbin "baserom.gba", 0x1672554, 0xE0
+sRayquazaCutsceneGfx201_3:
+.incbin "baserom.gba", 0x1672634, 0x80
+sRayquazaCutsceneGfx201_4:
+.incbin "baserom.gba", 0x16726B4, 0x40
+sRayquazaCutsceneSprites201:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx201, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sRayquazaCutsceneGfx201_1, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx201_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx201_3, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx201_4, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx202:
+.incbin "baserom.gba", 0x167274C, 0x20
+sRayquazaCutsceneGfx202_1:
+.incbin "baserom.gba", 0x167276C, 0x1A0
+sRayquazaCutsceneSprites202:
+ax_sprite sRayquazaCutsceneGfx202, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx202_1, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx203:
+.incbin "baserom.gba", 0x1672934, 0x100
+sRayquazaCutsceneSprites203:
+ax_sprite sRayquazaCutsceneGfx203, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx204:
+.incbin "baserom.gba", 0x1672A44, 0x20
+sRayquazaCutsceneGfx204_1:
+.incbin "baserom.gba", 0x1672A64, 0xC0
+sRayquazaCutsceneSprites204:
+ax_sprite sRayquazaCutsceneGfx204, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx204_1, 0xc0
+ax_sprite_terminator
+sRayquazaCutsceneGfx205:
+.incbin "baserom.gba", 0x1672B44, 0x100
+sRayquazaCutsceneSprites205:
+ax_sprite sRayquazaCutsceneGfx205, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx206:
+.incbin "baserom.gba", 0x1672C54, 0x80
+sRayquazaCutsceneSprites206:
+ax_sprite sRayquazaCutsceneGfx206, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx207:
+.incbin "baserom.gba", 0x1672CE4, 0x20
+sRayquazaCutsceneSprites207:
+ax_sprite sRayquazaCutsceneGfx207, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx208:
+.incbin "baserom.gba", 0x1672D14, 0x60
+sRayquazaCutsceneGfx208_1:
+.incbin "baserom.gba", 0x1672D74, 0x160
+sRayquazaCutsceneGfx208_2:
+.incbin "baserom.gba", 0x1672ED4, 0x160
+sRayquazaCutsceneGfx208_3:
+.incbin "baserom.gba", 0x1673034, 0x60
+sRayquazaCutsceneSprites208:
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx208, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx208_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx208_2, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx208_3, 0x60
+ax_sprite_terminator
+sRayquazaCutsceneGfx209:
+.incbin "baserom.gba", 0x16730DC, 0x20
+sRayquazaCutsceneGfx209_1:
+.incbin "baserom.gba", 0x16730FC, 0x40
+sRayquazaCutsceneSprites209:
+ax_sprite sRayquazaCutsceneGfx209, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx209_1, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx210:
+.incbin "baserom.gba", 0x167315C, 0x40
+sRayquazaCutsceneSprites210:
+ax_sprite sRayquazaCutsceneGfx210, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx211:
+.incbin "baserom.gba", 0x16731AC, 0x40
+sRayquazaCutsceneGfx211_1:
+.incbin "baserom.gba", 0x16731EC, 0x60
+sRayquazaCutsceneGfx211_2:
+.incbin "baserom.gba", 0x167324C, 0x240
+sRayquazaCutsceneGfx211_3:
+.incbin "baserom.gba", 0x167348C, 0x80
+sRayquazaCutsceneSprites211:
+ax_sprite 0, 0x40
+ax_sprite sRayquazaCutsceneGfx211, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx211_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx211_2, 0x240
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx211_3, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx212:
+.incbin "baserom.gba", 0x1673554, 0x180
+sRayquazaCutsceneSprites212:
+ax_sprite sRayquazaCutsceneGfx212, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx213:
+.incbin "baserom.gba", 0x16736EC, 0x100
+sRayquazaCutsceneSprites213:
+ax_sprite sRayquazaCutsceneGfx213, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx214:
+.incbin "baserom.gba", 0x16737FC, 0x20
+sRayquazaCutsceneSprites214:
+ax_sprite sRayquazaCutsceneGfx214, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx215:
+.incbin "baserom.gba", 0x167382C, 0x20
+sRayquazaCutsceneSprites215:
+ax_sprite sRayquazaCutsceneGfx215, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx216:
+.incbin "baserom.gba", 0x167385C, 0x20
+sRayquazaCutsceneSprites216:
+ax_sprite sRayquazaCutsceneGfx216, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx217:
+.incbin "baserom.gba", 0x167388C, 0x60
+sRayquazaCutsceneGfx217_1:
+.incbin "baserom.gba", 0x16738EC, 0x60
+sRayquazaCutsceneGfx217_2:
+.incbin "baserom.gba", 0x167394C, 0x1E0
+sRayquazaCutsceneGfx217_3:
+.incbin "baserom.gba", 0x1673B2C, 0x100
+sRayquazaCutsceneSprites217:
+ax_sprite sRayquazaCutsceneGfx217, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx217_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx217_2, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite sRayquazaCutsceneGfx217_3, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx218:
+.incbin "baserom.gba", 0x1673C6C, 0x80
+sRayquazaCutsceneSprites218:
+ax_sprite sRayquazaCutsceneGfx218, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx219:
+.incbin "baserom.gba", 0x1673CFC, 0x40
+sRayquazaCutsceneSprites219:
+ax_sprite sRayquazaCutsceneGfx219, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx220:
+.incbin "baserom.gba", 0x1673D4C, 0xE0
+sRayquazaCutsceneSprites220:
+ax_sprite sRayquazaCutsceneGfx220, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx221:
+.incbin "baserom.gba", 0x1673E44, 0x800
+sRayquazaCutsceneSprites221:
+ax_sprite sRayquazaCutsceneGfx221, 0x800
+ax_sprite_terminator
+sRayquazaCutsceneGfx222:
+.incbin "baserom.gba", 0x1674654, 0x800
+sRayquazaCutsceneSprites222:
+ax_sprite sRayquazaCutsceneGfx222, 0x800
+ax_sprite_terminator
+sRayquazaCutsceneGfx223:
+.incbin "baserom.gba", 0x1674E64, 0x800
+sRayquazaCutsceneSprites223:
+ax_sprite sRayquazaCutsceneGfx223, 0x800
+ax_sprite_terminator
+sRayquazaCutsceneGfx224:
+.incbin "baserom.gba", 0x1675674, 0x800
+sRayquazaCutsceneSprites224:
+ax_sprite sRayquazaCutsceneGfx224, 0x800
+ax_sprite_terminator
+sRayquazaCutsceneGfx225:
+.incbin "baserom.gba", 0x1675E84, 0x800
+sRayquazaCutsceneSprites225:
+ax_sprite sRayquazaCutsceneGfx225, 0x800
+ax_sprite_terminator
+sRayquazaCutsceneGfx226:
+.incbin "baserom.gba", 0x1676694, 0x800
+sRayquazaCutsceneSprites226:
+ax_sprite sRayquazaCutsceneGfx226, 0x800
+ax_sprite_terminator
+sRayquazaCutsceneGfx227:
+.incbin "baserom.gba", 0x1676EA4, 0x80
+sRayquazaCutsceneSprites227:
+ax_sprite sRayquazaCutsceneGfx227, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx228:
+.incbin "baserom.gba", 0x1676F34, 0x40
+sRayquazaCutsceneSprites228:
+ax_sprite sRayquazaCutsceneGfx228, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx229:
+.incbin "baserom.gba", 0x1676F84, 0x20
+sRayquazaCutsceneSprites229:
+ax_sprite sRayquazaCutsceneGfx229, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx230:
+.incbin "baserom.gba", 0x1676FB4, 0x100
+sRayquazaCutsceneSprites230:
+ax_sprite sRayquazaCutsceneGfx230, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx231:
+.incbin "baserom.gba", 0x16770C4, 0x400
+sRayquazaCutsceneSprites231:
+ax_sprite sRayquazaCutsceneGfx231, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx232:
+.incbin "baserom.gba", 0x16774D4, 0x400
+sRayquazaCutsceneSprites232:
+ax_sprite sRayquazaCutsceneGfx232, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx233:
+.incbin "baserom.gba", 0x16778E4, 0x80
+sRayquazaCutsceneSprites233:
+ax_sprite sRayquazaCutsceneGfx233, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx234:
+.incbin "baserom.gba", 0x1677974, 0x40
+sRayquazaCutsceneSprites234:
+ax_sprite sRayquazaCutsceneGfx234, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx235:
+.incbin "baserom.gba", 0x16779C4, 0x80
+sRayquazaCutsceneSprites235:
+ax_sprite sRayquazaCutsceneGfx235, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx236:
+.incbin "baserom.gba", 0x1677A54, 0x400
+sRayquazaCutsceneSprites236:
+ax_sprite sRayquazaCutsceneGfx236, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx237:
+.incbin "baserom.gba", 0x1677E64, 0x80
+sRayquazaCutsceneSprites237:
+ax_sprite sRayquazaCutsceneGfx237, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx238:
+.incbin "baserom.gba", 0x1677EF4, 0x40
+sRayquazaCutsceneSprites238:
+ax_sprite sRayquazaCutsceneGfx238, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx239:
+.incbin "baserom.gba", 0x1677F44, 0x80
+sRayquazaCutsceneSprites239:
+ax_sprite sRayquazaCutsceneGfx239, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx240:
+.incbin "baserom.gba", 0x1677FD4, 0x400
+sRayquazaCutsceneSprites240:
+ax_sprite sRayquazaCutsceneGfx240, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx241:
+.incbin "baserom.gba", 0x16783E4, 0x200
+sRayquazaCutsceneSprites241:
+ax_sprite sRayquazaCutsceneGfx241, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx242:
+.incbin "baserom.gba", 0x16785F4, 0x80
+sRayquazaCutsceneSprites242:
+ax_sprite sRayquazaCutsceneGfx242, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx243:
+.incbin "baserom.gba", 0x1678684, 0x400
+sRayquazaCutsceneSprites243:
+ax_sprite sRayquazaCutsceneGfx243, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx244:
+.incbin "baserom.gba", 0x1678A94, 0x200
+sRayquazaCutsceneSprites244:
+ax_sprite sRayquazaCutsceneGfx244, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx245:
+.incbin "baserom.gba", 0x1678CA4, 0x100
+sRayquazaCutsceneSprites245:
+ax_sprite sRayquazaCutsceneGfx245, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx246:
+.incbin "baserom.gba", 0x1678DB4, 0x20
+sRayquazaCutsceneSprites246:
+ax_sprite sRayquazaCutsceneGfx246, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx247:
+.incbin "baserom.gba", 0x1678DE4, 0x400
+sRayquazaCutsceneSprites247:
+ax_sprite sRayquazaCutsceneGfx247, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx248:
+.incbin "baserom.gba", 0x16791F4, 0x200
+sRayquazaCutsceneSprites248:
+ax_sprite sRayquazaCutsceneGfx248, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx249:
+.incbin "baserom.gba", 0x1679404, 0x100
+sRayquazaCutsceneSprites249:
+ax_sprite sRayquazaCutsceneGfx249, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx250:
+.incbin "baserom.gba", 0x1679514, 0x40
+sRayquazaCutsceneSprites250:
+ax_sprite sRayquazaCutsceneGfx250, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx251:
+.incbin "baserom.gba", 0x1679564, 0x200
+sRayquazaCutsceneSprites251:
+ax_sprite sRayquazaCutsceneGfx251, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx252:
+.incbin "baserom.gba", 0x1679774, 0x400
+sRayquazaCutsceneSprites252:
+ax_sprite sRayquazaCutsceneGfx252, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx253:
+.incbin "baserom.gba", 0x1679B84, 0x20
+sRayquazaCutsceneSprites253:
+ax_sprite sRayquazaCutsceneGfx253, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx254:
+.incbin "baserom.gba", 0x1679BB4, 0x200
+sRayquazaCutsceneSprites254:
+ax_sprite sRayquazaCutsceneGfx254, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx255:
+.incbin "baserom.gba", 0x1679DC4, 0x400
+sRayquazaCutsceneSprites255:
+ax_sprite sRayquazaCutsceneGfx255, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx256:
+.incbin "baserom.gba", 0x167A1D4, 0x200
+sRayquazaCutsceneSprites256:
+ax_sprite sRayquazaCutsceneGfx256, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx257:
+.incbin "baserom.gba", 0x167A3E4, 0x100
+sRayquazaCutsceneSprites257:
+ax_sprite sRayquazaCutsceneGfx257, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx258:
+.incbin "baserom.gba", 0x167A4F4, 0x200
+sRayquazaCutsceneSprites258:
+ax_sprite sRayquazaCutsceneGfx258, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx259:
+.incbin "baserom.gba", 0x167A704, 0x100
+sRayquazaCutsceneSprites259:
+ax_sprite sRayquazaCutsceneGfx259, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx260:
+.incbin "baserom.gba", 0x167A814, 0x20
+sRayquazaCutsceneSprites260:
+ax_sprite sRayquazaCutsceneGfx260, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx261:
+.incbin "baserom.gba", 0x167A844, 0x200
+sRayquazaCutsceneSprites261:
+ax_sprite sRayquazaCutsceneGfx261, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx262:
+.incbin "baserom.gba", 0x167AA54, 0x80
+sRayquazaCutsceneSprites262:
+ax_sprite sRayquazaCutsceneGfx262, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx263:
+.incbin "baserom.gba", 0x167AAE4, 0x20
+sRayquazaCutsceneSprites263:
+ax_sprite sRayquazaCutsceneGfx263, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx264:
+.incbin "baserom.gba", 0x167AB14, 0x200
+sRayquazaCutsceneSprites264:
+ax_sprite sRayquazaCutsceneGfx264, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx265:
+.incbin "baserom.gba", 0x167AD24, 0x100
+sRayquazaCutsceneSprites265:
+ax_sprite sRayquazaCutsceneGfx265, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx266:
+.incbin "baserom.gba", 0x167AE34, 0x200
+sRayquazaCutsceneSprites266:
+ax_sprite sRayquazaCutsceneGfx266, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx267:
+.incbin "baserom.gba", 0x167B044, 0x100
+sRayquazaCutsceneSprites267:
+ax_sprite sRayquazaCutsceneGfx267, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx268:
+.incbin "baserom.gba", 0x167B154, 0x100
+sRayquazaCutsceneSprites268:
+ax_sprite sRayquazaCutsceneGfx268, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx269:
+.incbin "baserom.gba", 0x167B264, 0x80
+sRayquazaCutsceneSprites269:
+ax_sprite sRayquazaCutsceneGfx269, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx270:
+.incbin "baserom.gba", 0x167B2F4, 0x80
+sRayquazaCutsceneSprites270:
+ax_sprite sRayquazaCutsceneGfx270, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx271:
+.incbin "baserom.gba", 0x167B384, 0x200
+sRayquazaCutsceneSprites271:
+ax_sprite sRayquazaCutsceneGfx271, 0x200
+ax_sprite_terminator
+sRayquazaCutsceneGfx272:
+.incbin "baserom.gba", 0x167B594, 0x100
+sRayquazaCutsceneSprites272:
+ax_sprite sRayquazaCutsceneGfx272, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx273:
+.incbin "baserom.gba", 0x167B6A4, 0x100
+sRayquazaCutsceneSprites273:
+ax_sprite sRayquazaCutsceneGfx273, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx274:
+.incbin "baserom.gba", 0x167B7B4, 0x80
+sRayquazaCutsceneSprites274:
+ax_sprite sRayquazaCutsceneGfx274, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx275:
+.incbin "baserom.gba", 0x167B844, 0x80
+sRayquazaCutsceneSprites275:
+ax_sprite sRayquazaCutsceneGfx275, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx276:
+.incbin "baserom.gba", 0x167B8D4, 0x400
+sRayquazaCutsceneSprites276:
+ax_sprite sRayquazaCutsceneGfx276, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx277:
+.incbin "baserom.gba", 0x167BCE4, 0x100
+sRayquazaCutsceneSprites277:
+ax_sprite sRayquazaCutsceneGfx277, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx278:
+.incbin "baserom.gba", 0x167BDF4, 0x100
+sRayquazaCutsceneSprites278:
+ax_sprite sRayquazaCutsceneGfx278, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx279:
+.incbin "baserom.gba", 0x167BF04, 0x80
+sRayquazaCutsceneSprites279:
+ax_sprite sRayquazaCutsceneGfx279, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx280:
+.incbin "baserom.gba", 0x167BF94, 0x400
+sRayquazaCutsceneSprites280:
+ax_sprite sRayquazaCutsceneGfx280, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx281:
+.incbin "baserom.gba", 0x167C3A4, 0x100
+sRayquazaCutsceneSprites281:
+ax_sprite sRayquazaCutsceneGfx281, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx282:
+.incbin "baserom.gba", 0x167C4B4, 0x40
+sRayquazaCutsceneSprites282:
+ax_sprite sRayquazaCutsceneGfx282, 0x40
+ax_sprite_terminator
+sRayquazaCutsceneGfx283:
+.incbin "baserom.gba", 0x167C504, 0x80
+sRayquazaCutsceneSprites283:
+ax_sprite sRayquazaCutsceneGfx283, 0x80
+ax_sprite_terminator
+sRayquazaCutsceneGfx284:
+.incbin "baserom.gba", 0x167C594, 0x400
+sRayquazaCutsceneSprites284:
+ax_sprite sRayquazaCutsceneGfx284, 0x400
+ax_sprite_terminator
+sRayquazaCutsceneGfx285:
+.incbin "baserom.gba", 0x167C9A4, 0x100
+sRayquazaCutsceneSprites285:
+ax_sprite sRayquazaCutsceneGfx285, 0x100
+ax_sprite_terminator
+sRayquazaCutsceneGfx286:
+.incbin "baserom.gba", 0x167CAB4, 0x20
+sRayquazaCutsceneSprites286:
+ax_sprite sRayquazaCutsceneGfx286, 0x20
+ax_sprite_terminator
+sRayquazaCutsceneGfx287:
+.incbin "baserom.gba", 0x167CAE4, 0x800
+sRayquazaCutsceneSprites287:
+ax_sprite sRayquazaCutsceneGfx287, 0x800
+ax_sprite_terminator
+sRayquazaCutsceneGfx288:
+.incbin "baserom.gba", 0x167D2F4, 0x800
+sRayquazaCutsceneSprites288:
+ax_sprite sRayquazaCutsceneGfx288, 0x800
+ax_sprite_terminator
+sAxPosesRayquazaCutscene:
+.4byte sRayquazaCutscenePose1
+.4byte sRayquazaCutscenePose2
+.4byte sRayquazaCutscenePose3
+.4byte sRayquazaCutscenePose4
+.4byte sRayquazaCutscenePose5
+.4byte sRayquazaCutscenePose6
+.4byte sRayquazaCutscenePose7
+.4byte sRayquazaCutscenePose8
+.4byte sRayquazaCutscenePose9
+.4byte sRayquazaCutscenePose10
+.4byte sRayquazaCutscenePose11
+.4byte sRayquazaCutscenePose12
+.4byte sRayquazaCutscenePose13
+.4byte sRayquazaCutscenePose14
+.4byte sRayquazaCutscenePose15
+.4byte sRayquazaCutscenePose16
+.4byte sRayquazaCutscenePose17
+.4byte sRayquazaCutscenePose18
+.4byte sRayquazaCutscenePose19
+.4byte sRayquazaCutscenePose20
+.4byte sRayquazaCutscenePose21
+.4byte sRayquazaCutscenePose22
+.4byte sRayquazaCutscenePose23
+.4byte sRayquazaCutscenePose24
+.4byte sRayquazaCutscenePose25
+.4byte sRayquazaCutscenePose26
+.4byte sRayquazaCutscenePose27
+.4byte sRayquazaCutscenePose28
+.4byte sRayquazaCutscenePose29
+.4byte sRayquazaCutscenePose30
+.4byte sRayquazaCutscenePose31
+.4byte sRayquazaCutscenePose32
+.4byte sRayquazaCutscenePose33
+.4byte sRayquazaCutscenePose34
+.4byte sRayquazaCutscenePose35
+.4byte sRayquazaCutscenePose36
+.4byte sRayquazaCutscenePose37
+.4byte sRayquazaCutscenePose38
+.4byte sRayquazaCutscenePose39
+.4byte sRayquazaCutscenePose40
+.4byte sRayquazaCutscenePose41
+.4byte sRayquazaCutscenePose42
+.4byte sRayquazaCutscenePose43
+.4byte sRayquazaCutscenePose44
+.4byte sRayquazaCutscenePose45
+.4byte sRayquazaCutscenePose46
+.4byte sRayquazaCutscenePose47
+.4byte sRayquazaCutscenePose48
+.4byte sRayquazaCutscenePose49
+.4byte sRayquazaCutscenePose50
+.4byte sRayquazaCutscenePose51
+.4byte sRayquazaCutscenePose52
+.4byte sRayquazaCutscenePose53
+.4byte sRayquazaCutscenePose54
+.4byte sRayquazaCutscenePose55
+.4byte sRayquazaCutscenePose56
+.4byte sRayquazaCutscenePose57
+.4byte sRayquazaCutscenePose58
+.4byte sRayquazaCutscenePose59
+.4byte sRayquazaCutscenePose60
+.4byte sRayquazaCutscenePose61
+.4byte sRayquazaCutscenePose62
+.4byte sRayquazaCutscenePose63
+.4byte sRayquazaCutscenePose64
+.4byte sRayquazaCutscenePose65
+.4byte sRayquazaCutscenePose66
+.4byte sRayquazaCutscenePose67
+.4byte sRayquazaCutscenePose68
+.4byte sRayquazaCutscenePose69
+.4byte sRayquazaCutscenePose70
+.4byte sRayquazaCutscenePose71
+.4byte sRayquazaCutscenePose72
+.4byte sRayquazaCutscenePose73
+.4byte sRayquazaCutscenePose74
+.4byte sRayquazaCutscenePose75
+.4byte sRayquazaCutscenePose76
+.4byte sRayquazaCutscenePose77
+.4byte sRayquazaCutscenePose78
+.4byte sRayquazaCutscenePose79
+.4byte sRayquazaCutscenePose80
+.4byte sRayquazaCutscenePose81
+.4byte sRayquazaCutscenePose82
+.4byte sRayquazaCutscenePose83
+.4byte sRayquazaCutscenePose84
+.4byte sRayquazaCutscenePose85
+.4byte sRayquazaCutscenePose86
+.4byte sRayquazaCutscenePose87
+.4byte sRayquazaCutscenePose88
+.4byte sRayquazaCutscenePose89
+.4byte sRayquazaCutscenePose90
+.4byte sRayquazaCutscenePose91
+.4byte sRayquazaCutscenePose92
+.4byte sRayquazaCutscenePose93
+.4byte sRayquazaCutscenePose94
+.4byte sRayquazaCutscenePose95
+.4byte sRayquazaCutscenePose96
+.4byte sRayquazaCutscenePose97
+.4byte sRayquazaCutscenePose98
+.4byte sRayquazaCutscenePose99
+.4byte sRayquazaCutscenePose100
+.4byte sRayquazaCutscenePose101
+.4byte sRayquazaCutscenePose102
+.4byte sRayquazaCutscenePose103
+.4byte sRayquazaCutscenePose104
+.4byte sRayquazaCutscenePose105
+.4byte sRayquazaCutscenePose106
+.4byte sRayquazaCutscenePose107
+.4byte sRayquazaCutscenePose108
+.4byte sRayquazaCutscenePose109
+.4byte sRayquazaCutscenePose110
+.4byte sRayquazaCutscenePose111
+.4byte sRayquazaCutscenePose112
+.4byte sRayquazaCutscenePose113
+.4byte sRayquazaCutscenePose114
+.4byte sRayquazaCutscenePose115
+.4byte sRayquazaCutscenePose116
+.4byte sRayquazaCutscenePose117
+.4byte sRayquazaCutscenePose118
+.4byte sRayquazaCutscenePose119
+.4byte sRayquazaCutscenePose120
+.4byte sRayquazaCutscenePose121
+.4byte sRayquazaCutscenePose122
+.4byte sRayquazaCutscenePose123
+.4byte sRayquazaCutscenePose124
+.4byte sRayquazaCutscenePose125
+.4byte sRayquazaCutscenePose126
+.4byte sRayquazaCutscenePose127
+.4byte sRayquazaCutscenePose128
+.4byte sRayquazaCutscenePose129
+.4byte sRayquazaCutscenePose130
+.4byte sRayquazaCutscenePose131
+.4byte sRayquazaCutscenePose132
+.4byte sRayquazaCutscenePose133
+.4byte sRayquazaCutscenePose134
+.4byte sRayquazaCutscenePose135
+.4byte sRayquazaCutscenePose136
+.4byte sRayquazaCutscenePose137
+.4byte sRayquazaCutscenePose138
+.4byte sRayquazaCutscenePose139
+.4byte sRayquazaCutscenePose140
+.4byte sRayquazaCutscenePose141
+.4byte sRayquazaCutscenePose142
+.4byte sRayquazaCutscenePose143
+.4byte sRayquazaCutscenePose144
+.4byte sRayquazaCutscenePose145
+.4byte sRayquazaCutscenePose146
+.4byte sRayquazaCutscenePose147
+.4byte sRayquazaCutscenePose148
+.4byte sRayquazaCutscenePose149
+.4byte sRayquazaCutscenePose150
+.4byte sRayquazaCutscenePose151
+.4byte sRayquazaCutscenePose152
+.4byte sRayquazaCutscenePose153
+.4byte sRayquazaCutscenePose154
+.4byte sRayquazaCutscenePose155
+.4byte sRayquazaCutscenePose156
+.4byte sRayquazaCutscenePose157
+.4byte sRayquazaCutscenePose158
+.4byte sRayquazaCutscenePose159
+.4byte sRayquazaCutscenePose160
+.4byte sRayquazaCutscenePose161
+.4byte sRayquazaCutscenePose162
+.4byte sRayquazaCutscenePose163
+.4byte sRayquazaCutscenePose164
+.4byte sRayquazaCutscenePose165
+.4byte sRayquazaCutscenePose166
+.4byte sRayquazaCutscenePose167
+.4byte sRayquazaCutscenePose168
+.4byte sRayquazaCutscenePose169
+.4byte sRayquazaCutscenePose170
+.4byte sRayquazaCutscenePose171
+.4byte sRayquazaCutscenePose172
+.4byte sRayquazaCutscenePose173
+.4byte sRayquazaCutscenePose174
+.4byte sRayquazaCutscenePose175
+.4byte sRayquazaCutscenePose176
+.4byte sRayquazaCutscenePose177
+.4byte sRayquazaCutscenePose178
+.4byte sRayquazaCutscenePose179
+.4byte sRayquazaCutscenePose180
+.4byte sRayquazaCutscenePose181
+.4byte sRayquazaCutscenePose182
+.4byte sRayquazaCutscenePose183
+.4byte sRayquazaCutscenePose184
+.4byte sRayquazaCutscenePose185
+.4byte sRayquazaCutscenePose186
+.4byte sRayquazaCutscenePose187
+.4byte sRayquazaCutscenePose188
+.4byte sRayquazaCutscenePose189
+.4byte sRayquazaCutscenePose190
+.4byte sRayquazaCutscenePose191
+.4byte sRayquazaCutscenePose192
+.4byte sRayquazaCutscenePose193
+.4byte sRayquazaCutscenePose194
+.4byte sRayquazaCutscenePose195
+.4byte sRayquazaCutscenePose196
+.4byte sRayquazaCutscenePose197
+.4byte sRayquazaCutscenePose198
+.4byte sRayquazaCutscenePose199
+.4byte sRayquazaCutscenePose200
+.4byte sRayquazaCutscenePose201
+.4byte sRayquazaCutscenePose202
+.4byte sRayquazaCutscenePose203
+.4byte sRayquazaCutscenePose204
+.4byte sRayquazaCutscenePose205
+.4byte sRayquazaCutscenePose206
+.4byte sRayquazaCutscenePose207
+.4byte sRayquazaCutscenePose208
+.4byte sRayquazaCutscenePose209
+.4byte sRayquazaCutscenePose210
+.4byte sRayquazaCutscenePose211
+.4byte sRayquazaCutscenePose212
+.4byte sRayquazaCutscenePose213
+.4byte sRayquazaCutscenePose214
+.4byte sRayquazaCutscenePose215
+.4byte sRayquazaCutscenePose216
+.4byte sRayquazaCutscenePose217
+.4byte sRayquazaCutscenePose218
+.4byte sRayquazaCutscenePose219
+.4byte sRayquazaCutscenePose220
+.4byte sRayquazaCutscenePose221
+.4byte sRayquazaCutscenePose222
+.4byte sRayquazaCutscenePose223
+.4byte sRayquazaCutscenePose224
+.4byte sRayquazaCutscenePose225
+.4byte sRayquazaCutscenePose226
+.4byte sRayquazaCutscenePose227
+.4byte sRayquazaCutscenePose228
+.4byte sRayquazaCutscenePose229
+.4byte sRayquazaCutscenePose230
+.4byte sRayquazaCutscenePose231
+.4byte sRayquazaCutscenePose232
+.4byte sRayquazaCutscenePose233
+.4byte sRayquazaCutscenePose234
+.4byte sRayquazaCutscenePose235
+.4byte sRayquazaCutscenePose236
+.4byte sRayquazaCutscenePose237
+.4byte sRayquazaCutscenePose238
+.4byte sRayquazaCutscenePose239
+.4byte sRayquazaCutscenePose240
+.4byte sRayquazaCutscenePose241
+.4byte sRayquazaCutscenePose242
+.4byte sRayquazaCutscenePose243
+.4byte sRayquazaCutscenePose244
+.4byte sRayquazaCutscenePose245
+.4byte sRayquazaCutscenePose246
+.4byte sRayquazaCutscenePose247
+.4byte sRayquazaCutscenePose248
+.4byte sRayquazaCutscenePose249
+.4byte sRayquazaCutscenePose250
+.4byte sRayquazaCutscenePose251
+.4byte sRayquazaCutscenePose252
+.4byte sRayquazaCutscenePose253
+.4byte sRayquazaCutscenePose254
+.4byte sRayquazaCutscenePose255
+.4byte sRayquazaCutscenePose256
+.4byte sRayquazaCutscenePose257
+.4byte sRayquazaCutscenePose258
+.4byte sRayquazaCutscenePose259
+.4byte sRayquazaCutscenePose260
+.4byte sRayquazaCutscenePose261
+.4byte sRayquazaCutscenePose262
+.4byte sRayquazaCutscenePose263
+.4byte sRayquazaCutscenePose264
+.4byte sRayquazaCutscenePose265
+.4byte sRayquazaCutscenePose266
+.4byte sRayquazaCutscenePose267
+.4byte sRayquazaCutscenePose268
+.4byte sRayquazaCutscenePose269
+.4byte sRayquazaCutscenePose270
+.4byte sRayquazaCutscenePose271
+.4byte sRayquazaCutscenePose272
+.4byte sRayquazaCutscenePose273
+.4byte sRayquazaCutscenePose274
+.4byte sRayquazaCutscenePose275
+.4byte sRayquazaCutscenePose276
+.4byte sRayquazaCutscenePose277
+.4byte sRayquazaCutscenePose278
+.4byte sRayquazaCutscenePose279
+.4byte sRayquazaCutscenePose280
+.4byte sRayquazaCutscenePose281
+.4byte sRayquazaCutscenePose282
+.4byte sRayquazaCutscenePose283
+.4byte sRayquazaCutscenePose284
+.4byte sRayquazaCutscenePose285
+.4byte sRayquazaCutscenePose286
+.4byte sRayquazaCutscenePose287
+.4byte sRayquazaCutscenePose288
+.4byte sRayquazaCutscenePose289
+.4byte sRayquazaCutscenePose290
+.4byte sRayquazaCutscenePose291
+.4byte sRayquazaCutscenePose292
+.4byte sRayquazaCutscenePose293
+.4byte sRayquazaCutscenePose294
+.4byte sRayquazaCutscenePose295
+.4byte sRayquazaCutscenePose296
+.4byte sRayquazaCutscenePose297
+.4byte sRayquazaCutscenePose298
+.4byte sRayquazaCutscenePose299
+.4byte sRayquazaCutscenePose300
+.4byte sRayquazaCutscenePose301
+.4byte sRayquazaCutscenePose302
+.4byte sRayquazaCutscenePose303
+.4byte sRayquazaCutscenePose304
+.4byte sRayquazaCutscenePose305
+.4byte sRayquazaCutscenePose306
+.4byte sRayquazaCutscenePose307
+.4byte sRayquazaCutscenePose308
+.4byte sRayquazaCutscenePose309
+.4byte sRayquazaCutscenePose310
+.4byte sRayquazaCutscenePose311
+.4byte sRayquazaCutscenePose312
+.4byte sRayquazaCutscenePose313
+.4byte sRayquazaCutscenePose314
+.4byte sRayquazaCutscenePose315
+.4byte sRayquazaCutscenePose316
+.4byte sRayquazaCutscenePose317
+.4byte sRayquazaCutscenePose318
+.4byte sRayquazaCutscenePose319
+.4byte sRayquazaCutscenePose320
+.4byte sRayquazaCutscenePose321
+.4byte sRayquazaCutscenePose322
+.4byte sRayquazaCutscenePose323
+.4byte sRayquazaCutscenePose324
+.4byte sRayquazaCutscenePose325
+.4byte sRayquazaCutscenePose326
+.4byte sRayquazaCutscenePose327
+.4byte sRayquazaCutscenePose328
+.4byte sRayquazaCutscenePose329
+.4byte sRayquazaCutscenePose330
+.4byte sRayquazaCutscenePose331
+.4byte sRayquazaCutscenePose332
+.4byte sRayquazaCutscenePose333
+.4byte sRayquazaCutscenePose334
+.4byte sRayquazaCutscenePose335
+.4byte sRayquazaCutscenePose336
+.4byte sRayquazaCutscenePose337
+.4byte sRayquazaCutscenePose338
+.4byte sRayquazaCutscenePose339
+.4byte sRayquazaCutscenePose340
+.4byte sRayquazaCutscenePose341
+.4byte sRayquazaCutscenePose342
+.4byte sRayquazaCutscenePose343
+.4byte sRayquazaCutscenePose344
+.4byte sRayquazaCutscenePose345
+.4byte sRayquazaCutscenePose346
+.4byte sRayquazaCutscenePose347
+.4byte sRayquazaCutscenePose348
+.4byte sRayquazaCutscenePose349
+.4byte sRayquazaCutscenePose350
+.4byte sRayquazaCutscenePose351
+.4byte sRayquazaCutscenePose352
+.4byte sRayquazaCutscenePose353
+.4byte sRayquazaCutscenePose354
+.4byte sRayquazaCutscenePose355
+.4byte sRayquazaCutscenePose356
+.4byte sRayquazaCutscenePose357
+.4byte sRayquazaCutscenePose358
+.4byte sRayquazaCutscenePose359
+.4byte sRayquazaCutscenePose360
+.4byte sRayquazaCutscenePose361
+sAxPositionsRayquazaCutscene:
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -30, 	  -8,  -28, 	  13,  -24, 	   3,  -18
+.2byte    0,  -31, 	 -10,  -29, 	  15,  -25, 	   3,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,   16, 	 -15,   -1, 	  17,   -1, 	   3,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    2,  -48, 	  15,  -33, 	  -6,  -25, 	   4,  -20
+.2byte   38,   11, 	  27,    5, 	   9,   10, 	   5,   -6
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    3,  -47, 	  10,  -32, 	   7,  -25, 	   4,  -17
+.2byte   52,   -8, 	  30,   -3, 	  21,    1, 	  11,   -8
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   -4,  -45, 	  -6,  -34, 	  15,  -27, 	   0,  -23
+.2byte   42,  -32, 	  24,  -30, 	  35,  -18, 	  15,  -15
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -41, 	  17,  -21, 	 -18,  -21, 	   3,  -11
+.2byte   -1,  -53, 	  13,  -33, 	 -15,  -33, 	   0,  -23
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte    7,  -45, 	   9,  -34, 	 -12,  -27, 	   3,  -23
+.2byte  -39,  -32, 	 -21,  -30, 	 -32,  -18, 	 -12,  -15
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -4,  -47, 	 -11,  -32, 	  -8,  -25, 	  -5,  -17
+.2byte  -53,   -8, 	 -31,   -3, 	 -22,    1, 	 -12,   -8
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -3,  -48, 	 -16,  -33, 	   5,  -25, 	  -5,  -20
+.2byte  -39,   11, 	 -28,    5, 	 -10,   10, 	  -6,   -6
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,   16, 	 -15,   -1, 	  17,   -1, 	   3,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    2,  -48, 	  15,  -33, 	  -6,  -25, 	   4,  -20
+.2byte   38,   11, 	  27,    5, 	   9,   10, 	   5,   -6
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    3,  -47, 	  10,  -32, 	   7,  -25, 	   4,  -17
+.2byte   52,   -8, 	  30,   -3, 	  21,    1, 	  11,   -8
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   -4,  -45, 	  -6,  -34, 	  15,  -27, 	   0,  -23
+.2byte   42,  -32, 	  24,  -30, 	  35,  -18, 	  15,  -15
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -41, 	  17,  -21, 	 -18,  -21, 	   3,  -11
+.2byte   -1,  -53, 	  13,  -33, 	 -15,  -33, 	   0,  -23
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte    7,  -45, 	   9,  -34, 	 -12,  -27, 	   3,  -23
+.2byte  -39,  -32, 	 -21,  -30, 	 -32,  -18, 	 -12,  -15
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -4,  -47, 	 -11,  -32, 	  -8,  -25, 	  -5,  -17
+.2byte  -53,   -8, 	 -31,   -3, 	 -22,    1, 	 -12,   -8
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -3,  -48, 	 -16,  -33, 	   5,  -25, 	  -5,  -20
+.2byte  -39,   11, 	 -28,    5, 	 -10,   10, 	  -6,   -6
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,    1, 	 -16,   -8, 	  17,   -8, 	   5,  -20
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    2,  -48, 	  15,  -33, 	  -6,  -25, 	   4,  -20
+.2byte   31,   -6, 	  25,   -6, 	   1,   -3, 	  10,   -5
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    3,  -47, 	  10,  -32, 	   7,  -25, 	   4,  -17
+.2byte   40,  -26, 	  26,  -16, 	  20,   -8, 	  12,  -12
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   -4,  -45, 	  -6,  -34, 	  15,  -27, 	   0,  -23
+.2byte   29,  -42, 	  10,  -35, 	  28,  -25, 	  10,  -22
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -41, 	  17,  -21, 	 -18,  -21, 	   3,  -11
+.2byte   -1,  -52, 	  17,  -29, 	 -19,  -30, 	  -1,  -22
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte    7,  -45, 	   9,  -34, 	 -12,  -27, 	   3,  -23
+.2byte  -26,  -42, 	  -7,  -35, 	 -25,  -25, 	  -7,  -22
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -4,  -47, 	 -11,  -32, 	  -8,  -25, 	  -5,  -17
+.2byte  -41,  -26, 	 -27,  -16, 	 -21,   -8, 	 -13,  -12
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -3,  -48, 	 -16,  -33, 	   5,  -25, 	  -5,  -20
+.2byte  -32,   -6, 	 -26,   -6, 	  -2,   -3, 	 -11,   -5
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,  -54, 	 -14,  -31, 	  15,  -31, 	   0,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    6,  -44, 	  19,  -29, 	  -2,  -21, 	   8,  -16
+.2byte    1,  -56, 	  15,  -37, 	  -6,  -28, 	   6,  -19
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte    7,  -47, 	  14,  -32, 	  11,  -25, 	   8,  -17
+.2byte    4,  -60, 	  17,  -43, 	   7,  -37, 	  12,  -24
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte    4,  -47, 	   2,  -36, 	  23,  -29, 	   8,  -25
+.2byte    2,  -62, 	  -7,  -47, 	  13,  -45, 	   8,  -29
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -52, 	  17,  -32, 	 -18,  -32, 	   3,  -22
+.2byte   -1,  -57, 	  15,  -34, 	 -16,  -34, 	   2,  -20
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -3,  -47, 	  -1,  -36, 	 -22,  -29, 	  -7,  -25
+.2byte   -1,  -62, 	   8,  -47, 	 -12,  -45, 	  -7,  -29
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte   -8,  -47, 	 -15,  -32, 	 -12,  -25, 	  -9,  -17
+.2byte   -5,  -60, 	 -18,  -43, 	  -8,  -37, 	 -13,  -24
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -44, 	 -20,  -29, 	   1,  -21, 	  -9,  -16
+.2byte   -2,  -56, 	 -16,  -37, 	   5,  -28, 	  -7,  -19
+.2byte  -14,  -19, 	   0,  -22, 	   9,  -14, 	   6,  -13
+.2byte  -13,  -18, 	   0,  -20, 	  11,  -13, 	   6,  -14
+.2byte    1,  -55, 	 -13,  -37, 	  16,  -28, 	   1,  -25
+.2byte    4,  -54, 	   6,  -35, 	 -12,  -23, 	   1,  -21
+.2byte    3,  -53, 	   5,  -36, 	   1,  -18, 	   1,  -25
+.2byte    4,  -51, 	  -5,  -25, 	  14,  -19, 	   0,  -22
+.2byte    0,  -56, 	  16,  -28, 	 -15,  -24, 	   0,  -22
+.2byte   -5,  -51, 	   4,  -25, 	 -15,  -19, 	  -1,  -22
+.2byte   -4,  -53, 	  -6,  -36, 	  -2,  -18, 	  -2,  -25
+.2byte   -5,  -54, 	  -7,  -35, 	  11,  -23, 	  -2,  -21
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -30, 	  -8,  -28, 	  13,  -24, 	   3,  -18
+.2byte    0,  -31, 	 -10,  -29, 	  15,  -25, 	   3,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte   10,  -48, 	  23,  -33, 	   2,  -25, 	  12,  -20
+.2byte   17,  -49, 	  24,  -34, 	  21,  -27, 	  18,  -19
+.2byte   10,  -49, 	   8,  -38, 	  29,  -31, 	  14,  -27
+.2byte   -1,  -55, 	  17,  -35, 	 -18,  -35, 	   3,  -25
+.2byte  -11,  -49, 	  -9,  -38, 	 -30,  -31, 	 -15,  -27
+.2byte  -18,  -49, 	 -25,  -34, 	 -22,  -27, 	 -19,  -19
+.2byte  -11,  -48, 	 -24,  -33, 	  -3,  -25, 	 -13,  -20
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -35, 	 -15,  -23, 	  16,  -23, 	   1,  -18
+.2byte    0,  -60, 	 -14,  -37, 	  15,  -37, 	   0,  -25
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    6,  -47, 	  19,  -32, 	  -2,  -24, 	   8,  -19
+.2byte    1,  -59, 	  15,  -40, 	  -6,  -31, 	   6,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   10,  -47, 	  17,  -32, 	  14,  -25, 	  11,  -17
+.2byte    4,  -60, 	  17,  -43, 	   7,  -37, 	  12,  -24
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte    4,  -47, 	   2,  -36, 	  23,  -29, 	   8,  -25
+.2byte    2,  -62, 	  -7,  -47, 	  13,  -45, 	   8,  -29
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -52, 	  17,  -32, 	 -18,  -32, 	   3,  -22
+.2byte   -1,  -57, 	  15,  -34, 	 -16,  -34, 	   2,  -20
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -3,  -47, 	  -1,  -36, 	 -22,  -29, 	  -7,  -25
+.2byte   -1,  -62, 	   8,  -47, 	 -12,  -45, 	  -7,  -29
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -10,  -47, 	 -17,  -32, 	 -14,  -25, 	 -11,  -17
+.2byte   -5,  -60, 	 -18,  -43, 	  -8,  -37, 	 -13,  -24
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -44, 	 -20,  -29, 	   1,  -21, 	  -9,  -16
+.2byte   -2,  -56, 	 -16,  -37, 	   5,  -28, 	  -7,  -19
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte    8,  -13, 	  21,  -24, 	  -7,  -21, 	  -1,  -19
+.2byte    8,  -10, 	  20,  -18, 	  -4,  -16, 	  -1,  -16
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte   14,  -31, 	  -2,  -18, 	  18,  -22, 	   5,  -19
+.2byte   22,  -53, 	   0,  -25, 	  23,  -29, 	   8,  -22
+.2byte    5,  -53, 	  -9,  -29, 	  20,  -29, 	   5,  -23
+.2byte   -9,  -53, 	 -13,  -29, 	  11,  -24, 	   2,  -23
+.2byte   -6,  -30, 	  -8,  -22, 	  14,  -20, 	   4,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte   14,  -31, 	  -2,  -18, 	  18,  -22, 	   5,  -19
+.2byte   22,  -53, 	   0,  -25, 	  23,  -29, 	   8,  -22
+.2byte    5,  -53, 	  -9,  -29, 	  20,  -29, 	   5,  -23
+.2byte   -9,  -53, 	 -13,  -29, 	  11,  -24, 	   2,  -23
+.2byte   -6,  -30, 	  -8,  -22, 	  14,  -20, 	   4,  -19
+.2byte    4,  -33, 	 -11,  -24, 	  19,  -24, 	   4,  -20
+.2byte    4,  -29, 	 -12,  -20, 	  19,  -20, 	   4,  -19
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    4,  -29, 	 -12,  -20, 	  19,  -20, 	   4,  -19
+.2byte    4,  -10, 	 -10,  -16, 	  20,  -17, 	   4,  -16
+.2byte    4,   -7, 	 -12,  -16, 	  21,  -16, 	   4,  -14
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    4,  -33, 	 -11,  -24, 	  19,  -24, 	   4,  -20
+.2byte    3,  -18, 	 -11,  -14, 	  17,  -14, 	   0,  -20
+.2byte    3,  -34, 	 -11,  -22, 	  18,  -22, 	   3,  -20
+.2byte    3,  -49, 	 -11,  -29, 	  18,  -29, 	   3,  -20
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+.2byte    0,  -29, 	  -7,  -27, 	  12,  -24, 	   3,  -18
+.2byte    0,  -42, 	 -12,  -23, 	  14,  -22, 	   1,  -23
+.2byte    0,  -50, 	 -15,  -19, 	  14,  -19, 	   1,  -22
+.2byte   11,  -32, 	 -10,  -20, 	   8,  -26, 	   2,  -20
+.2byte   11,  -33, 	 -11,  -22, 	   9,  -27, 	   2,  -22
+.2byte   11,  -34, 	 -13,  -23, 	  10,  -28, 	   1,  -22
+.2byte   14,  -35, 	  -2,  -15, 	  -1,  -28, 	  -1,  -21
+.2byte   14,  -36, 	  -3,  -15, 	   0,  -30, 	  -1,  -21
+.2byte   14,  -36, 	  -4,  -16, 	  -1,  -31, 	  -1,  -21
+.2byte   10,  -37, 	   5,  -17, 	  -8,  -26, 	  -7,  -18
+.2byte   10,  -38, 	   6,  -19, 	  -8,  -28, 	  -7,  -19
+.2byte   10,  -39, 	   7,  -21, 	 -15,  -30, 	  -5,  -17
+.2byte   -1,  -41, 	  10,  -20, 	 -14,  -18, 	  -1,  -18
+.2byte   -1,  -42, 	  11,  -20, 	 -14,  -19, 	  -1,  -19
+.2byte   -1,  -43, 	  12,  -21, 	 -15,  -19, 	  -1,  -19
+.2byte  -12,  -36, 	  12,  -25, 	  -6,  -15, 	   4,  -19
+.2byte  -12,  -37, 	  12,  -27, 	  -7,  -16, 	   4,  -19
+.2byte  -12,  -38, 	  13,  -29, 	  -8,  -16, 	   5,  -21
+.2byte  -11,  -32, 	   5,  -26, 	   5,  -13, 	   9,  -21
+.2byte  -11,  -33, 	   5,  -26, 	   7,  -12, 	   8,  -22
+.2byte  -11,  -34, 	   4,  -28, 	   8,  -14, 	  11,  -22
+.2byte   -8,  -30, 	  -1,  -25, 	  13,  -16, 	   6,  -17
+.2byte   -7,  -31, 	  -1,  -26, 	  13,  -17, 	   7,  -19
+.2byte   -7,  -32, 	  -2,  -28, 	  15,  -18, 	   7,  -18
+sRayquazaCutsceneAnimTable1:
+.4byte sRayquazaCutsceneAnims_1_1
+.4byte sRayquazaCutsceneAnims_1_2
+.4byte sRayquazaCutsceneAnims_1_3
+.4byte sRayquazaCutsceneAnims_1_4
+.4byte sRayquazaCutsceneAnims_1_5
+.4byte sRayquazaCutsceneAnims_1_6
+.4byte sRayquazaCutsceneAnims_1_7
+.4byte sRayquazaCutsceneAnims_1_8
+sRayquazaCutsceneAnimTable2:
+.4byte sRayquazaCutsceneAnims_2_1
+.4byte sRayquazaCutsceneAnims_2_2
+.4byte sRayquazaCutsceneAnims_2_3
+.4byte sRayquazaCutsceneAnims_2_4
+.4byte sRayquazaCutsceneAnims_2_5
+.4byte sRayquazaCutsceneAnims_2_6
+.4byte sRayquazaCutsceneAnims_2_7
+.4byte sRayquazaCutsceneAnims_2_8
+sRayquazaCutsceneAnimTable3:
+.4byte sRayquazaCutsceneAnims_3_1
+.4byte sRayquazaCutsceneAnims_3_2
+.4byte sRayquazaCutsceneAnims_3_3
+.4byte sRayquazaCutsceneAnims_3_4
+.4byte sRayquazaCutsceneAnims_3_5
+.4byte sRayquazaCutsceneAnims_3_6
+.4byte sRayquazaCutsceneAnims_3_7
+.4byte sRayquazaCutsceneAnims_3_8
+sRayquazaCutsceneAnimTable4:
+.4byte sRayquazaCutsceneAnims_4_1
+.4byte sRayquazaCutsceneAnims_4_2
+.4byte sRayquazaCutsceneAnims_4_3
+.4byte sRayquazaCutsceneAnims_4_4
+.4byte sRayquazaCutsceneAnims_4_5
+.4byte sRayquazaCutsceneAnims_4_6
+.4byte sRayquazaCutsceneAnims_4_7
+.4byte sRayquazaCutsceneAnims_4_8
+sRayquazaCutsceneAnimTable5:
+.4byte sRayquazaCutsceneAnims_5_1
+.4byte sRayquazaCutsceneAnims_5_2
+.4byte sRayquazaCutsceneAnims_5_3
+.4byte sRayquazaCutsceneAnims_5_4
+.4byte sRayquazaCutsceneAnims_5_5
+.4byte sRayquazaCutsceneAnims_5_6
+.4byte sRayquazaCutsceneAnims_5_7
+.4byte sRayquazaCutsceneAnims_5_8
+sRayquazaCutsceneAnimTable6:
+.4byte sRayquazaCutsceneAnims_6_1
+.4byte sRayquazaCutsceneAnims_6_1
+.4byte sRayquazaCutsceneAnims_6_1
+.4byte sRayquazaCutsceneAnims_6_1
+.4byte sRayquazaCutsceneAnims_6_1
+.4byte sRayquazaCutsceneAnims_6_1
+.4byte sRayquazaCutsceneAnims_6_1
+.4byte sRayquazaCutsceneAnims_6_1
+sRayquazaCutsceneAnimTable7:
+.4byte sRayquazaCutsceneAnims_7_1
+.4byte sRayquazaCutsceneAnims_7_2
+.4byte sRayquazaCutsceneAnims_7_3
+.4byte sRayquazaCutsceneAnims_7_4
+.4byte sRayquazaCutsceneAnims_7_5
+.4byte sRayquazaCutsceneAnims_7_6
+.4byte sRayquazaCutsceneAnims_7_7
+.4byte sRayquazaCutsceneAnims_7_8
+sRayquazaCutsceneAnimTable8:
+.4byte sRayquazaCutsceneAnims_8_1
+.4byte sRayquazaCutsceneAnims_8_2
+.4byte sRayquazaCutsceneAnims_8_3
+.4byte sRayquazaCutsceneAnims_8_4
+.4byte sRayquazaCutsceneAnims_8_5
+.4byte sRayquazaCutsceneAnims_8_6
+.4byte sRayquazaCutsceneAnims_8_7
+.4byte sRayquazaCutsceneAnims_8_8
+sRayquazaCutsceneAnimTable9:
+.4byte sRayquazaCutsceneAnims_9_1
+.4byte sRayquazaCutsceneAnims_9_2
+.4byte sRayquazaCutsceneAnims_9_3
+.4byte sRayquazaCutsceneAnims_9_4
+.4byte sRayquazaCutsceneAnims_9_5
+.4byte sRayquazaCutsceneAnims_9_6
+.4byte sRayquazaCutsceneAnims_9_7
+.4byte sRayquazaCutsceneAnims_9_8
+sRayquazaCutsceneAnimTable10:
+.4byte sRayquazaCutsceneAnims_10_1
+.4byte sRayquazaCutsceneAnims_10_2
+.4byte sRayquazaCutsceneAnims_10_3
+.4byte sRayquazaCutsceneAnims_10_4
+.4byte sRayquazaCutsceneAnims_10_5
+.4byte sRayquazaCutsceneAnims_10_6
+.4byte sRayquazaCutsceneAnims_10_7
+.4byte sRayquazaCutsceneAnims_10_8
+sRayquazaCutsceneAnimTable11:
+.4byte sRayquazaCutsceneAnims_11_1
+.4byte sRayquazaCutsceneAnims_11_2
+.4byte sRayquazaCutsceneAnims_11_3
+.4byte sRayquazaCutsceneAnims_11_4
+.4byte sRayquazaCutsceneAnims_11_5
+.4byte sRayquazaCutsceneAnims_11_6
+.4byte sRayquazaCutsceneAnims_11_7
+.4byte sRayquazaCutsceneAnims_11_8
+sRayquazaCutsceneAnimTable12:
+.4byte sRayquazaCutsceneAnims_12_1
+.4byte sRayquazaCutsceneAnims_12_2
+.4byte sRayquazaCutsceneAnims_12_3
+.4byte sRayquazaCutsceneAnims_12_4
+.4byte sRayquazaCutsceneAnims_12_5
+.4byte sRayquazaCutsceneAnims_12_6
+.4byte sRayquazaCutsceneAnims_12_7
+.4byte sRayquazaCutsceneAnims_12_8
+sRayquazaCutsceneAnimTable13:
+.4byte sRayquazaCutsceneAnims_13_1
+.4byte sRayquazaCutsceneAnims_13_2
+.4byte sRayquazaCutsceneAnims_13_3
+.4byte sRayquazaCutsceneAnims_13_4
+.4byte sRayquazaCutsceneAnims_13_5
+.4byte sRayquazaCutsceneAnims_13_6
+.4byte sRayquazaCutsceneAnims_13_7
+.4byte sRayquazaCutsceneAnims_13_8
+sRayquazaCutsceneAnimTable14:
+.4byte sRayquazaCutsceneAnims_14_1
+.4byte sRayquazaCutsceneAnims_14_2
+.4byte sRayquazaCutsceneAnims_14_3
+.4byte sRayquazaCutsceneAnims_14_4
+.4byte sRayquazaCutsceneAnims_14_5
+.4byte sRayquazaCutsceneAnims_14_6
+.4byte sRayquazaCutsceneAnims_14_7
+.4byte sRayquazaCutsceneAnims_14_8
+sRayquazaCutsceneAnimTable15:
+.4byte sRayquazaCutsceneAnims_15_1
+.4byte sRayquazaCutsceneAnims_15_1
+.4byte sRayquazaCutsceneAnims_15_1
+.4byte sRayquazaCutsceneAnims_15_1
+.4byte sRayquazaCutsceneAnims_15_1
+.4byte sRayquazaCutsceneAnims_15_1
+.4byte sRayquazaCutsceneAnims_15_1
+.4byte sRayquazaCutsceneAnims_15_1
+sRayquazaCutsceneAnimTable16:
+.4byte sRayquazaCutsceneAnims_16_1
+.4byte sRayquazaCutsceneAnims_16_1
+.4byte sRayquazaCutsceneAnims_16_1
+.4byte sRayquazaCutsceneAnims_16_1
+.4byte sRayquazaCutsceneAnims_16_1
+.4byte sRayquazaCutsceneAnims_16_1
+.4byte sRayquazaCutsceneAnims_16_1
+.4byte sRayquazaCutsceneAnims_16_1
+sRayquazaCutsceneAnimTable17:
+.4byte sRayquazaCutsceneAnims_17_1
+.4byte sRayquazaCutsceneAnims_17_1
+.4byte sRayquazaCutsceneAnims_17_1
+.4byte sRayquazaCutsceneAnims_17_1
+.4byte sRayquazaCutsceneAnims_17_1
+.4byte sRayquazaCutsceneAnims_17_1
+.4byte sRayquazaCutsceneAnims_17_1
+.4byte sRayquazaCutsceneAnims_17_1
+sRayquazaCutsceneAnimTable18:
+.4byte sRayquazaCutsceneAnims_18_1
+.4byte sRayquazaCutsceneAnims_18_1
+.4byte sRayquazaCutsceneAnims_18_1
+.4byte sRayquazaCutsceneAnims_18_1
+.4byte sRayquazaCutsceneAnims_18_1
+.4byte sRayquazaCutsceneAnims_18_1
+.4byte sRayquazaCutsceneAnims_18_1
+.4byte sRayquazaCutsceneAnims_18_1
+sRayquazaCutsceneAnimTable19:
+.4byte sRayquazaCutsceneAnims_19_1
+.4byte sRayquazaCutsceneAnims_19_1
+.4byte sRayquazaCutsceneAnims_19_1
+.4byte sRayquazaCutsceneAnims_19_1
+.4byte sRayquazaCutsceneAnims_19_1
+.4byte sRayquazaCutsceneAnims_19_1
+.4byte sRayquazaCutsceneAnims_19_1
+.4byte sRayquazaCutsceneAnims_19_1
+sAxAnimationsRayquazaCutscene:
+.4byte sRayquazaCutsceneAnimTable1
+.4byte sRayquazaCutsceneAnimTable2
+.4byte sRayquazaCutsceneAnimTable3
+.4byte sRayquazaCutsceneAnimTable4
+.4byte sRayquazaCutsceneAnimTable5
+.4byte sRayquazaCutsceneAnimTable6
+.4byte sRayquazaCutsceneAnimTable7
+.4byte sRayquazaCutsceneAnimTable8
+.4byte sRayquazaCutsceneAnimTable9
+.4byte sRayquazaCutsceneAnimTable10
+.4byte sRayquazaCutsceneAnimTable11
+.4byte sRayquazaCutsceneAnimTable12
+.4byte sRayquazaCutsceneAnimTable13
+.4byte sRayquazaCutsceneAnimTable14
+.4byte sRayquazaCutsceneAnimTable15
+.4byte sRayquazaCutsceneAnimTable16
+.4byte sRayquazaCutsceneAnimTable17
+.4byte sRayquazaCutsceneAnimTable18
+.4byte sRayquazaCutsceneAnimTable19
+sAxSpritesRayquazaCutscene:
+.4byte sRayquazaCutsceneSprites1
+.4byte sRayquazaCutsceneSprites2
+.4byte sRayquazaCutsceneSprites3
+.4byte sRayquazaCutsceneSprites4
+.4byte sRayquazaCutsceneSprites5
+.4byte sRayquazaCutsceneSprites6
+.4byte sRayquazaCutsceneSprites7
+.4byte sRayquazaCutsceneSprites8
+.4byte sRayquazaCutsceneSprites9
+.4byte sRayquazaCutsceneSprites10
+.4byte sRayquazaCutsceneSprites11
+.4byte sRayquazaCutsceneSprites12
+.4byte sRayquazaCutsceneSprites13
+.4byte sRayquazaCutsceneSprites14
+.4byte sRayquazaCutsceneSprites15
+.4byte sRayquazaCutsceneSprites16
+.4byte sRayquazaCutsceneSprites17
+.4byte sRayquazaCutsceneSprites18
+.4byte sRayquazaCutsceneSprites19
+.4byte sRayquazaCutsceneSprites20
+.4byte sRayquazaCutsceneSprites21
+.4byte sRayquazaCutsceneSprites22
+.4byte sRayquazaCutsceneSprites23
+.4byte sRayquazaCutsceneSprites24
+.4byte sRayquazaCutsceneSprites25
+.4byte sRayquazaCutsceneSprites26
+.4byte sRayquazaCutsceneSprites27
+.4byte sRayquazaCutsceneSprites28
+.4byte sRayquazaCutsceneSprites29
+.4byte sRayquazaCutsceneSprites30
+.4byte sRayquazaCutsceneSprites31
+.4byte sRayquazaCutsceneSprites32
+.4byte sRayquazaCutsceneSprites33
+.4byte sRayquazaCutsceneSprites34
+.4byte sRayquazaCutsceneSprites35
+.4byte sRayquazaCutsceneSprites36
+.4byte sRayquazaCutsceneSprites37
+.4byte sRayquazaCutsceneSprites38
+.4byte sRayquazaCutsceneSprites39
+.4byte sRayquazaCutsceneSprites40
+.4byte sRayquazaCutsceneSprites41
+.4byte sRayquazaCutsceneSprites42
+.4byte sRayquazaCutsceneSprites43
+.4byte sRayquazaCutsceneSprites44
+.4byte sRayquazaCutsceneSprites45
+.4byte sRayquazaCutsceneSprites46
+.4byte sRayquazaCutsceneSprites47
+.4byte sRayquazaCutsceneSprites48
+.4byte sRayquazaCutsceneSprites49
+.4byte sRayquazaCutsceneSprites50
+.4byte sRayquazaCutsceneSprites51
+.4byte sRayquazaCutsceneSprites52
+.4byte sRayquazaCutsceneSprites53
+.4byte sRayquazaCutsceneSprites54
+.4byte sRayquazaCutsceneSprites55
+.4byte sRayquazaCutsceneSprites56
+.4byte sRayquazaCutsceneSprites57
+.4byte sRayquazaCutsceneSprites58
+.4byte sRayquazaCutsceneSprites59
+.4byte sRayquazaCutsceneSprites60
+.4byte sRayquazaCutsceneSprites61
+.4byte sRayquazaCutsceneSprites62
+.4byte sRayquazaCutsceneSprites63
+.4byte sRayquazaCutsceneSprites64
+.4byte sRayquazaCutsceneSprites65
+.4byte sRayquazaCutsceneSprites66
+.4byte sRayquazaCutsceneSprites67
+.4byte sRayquazaCutsceneSprites68
+.4byte sRayquazaCutsceneSprites69
+.4byte sRayquazaCutsceneSprites70
+.4byte sRayquazaCutsceneSprites71
+.4byte sRayquazaCutsceneSprites72
+.4byte sRayquazaCutsceneSprites73
+.4byte sRayquazaCutsceneSprites74
+.4byte sRayquazaCutsceneSprites75
+.4byte sRayquazaCutsceneSprites76
+.4byte sRayquazaCutsceneSprites77
+.4byte sRayquazaCutsceneSprites78
+.4byte sRayquazaCutsceneSprites79
+.4byte sRayquazaCutsceneSprites80
+.4byte sRayquazaCutsceneSprites81
+.4byte sRayquazaCutsceneSprites82
+.4byte sRayquazaCutsceneSprites83
+.4byte sRayquazaCutsceneSprites84
+.4byte sRayquazaCutsceneSprites85
+.4byte sRayquazaCutsceneSprites86
+.4byte sRayquazaCutsceneSprites87
+.4byte sRayquazaCutsceneSprites88
+.4byte sRayquazaCutsceneSprites89
+.4byte sRayquazaCutsceneSprites90
+.4byte sRayquazaCutsceneSprites91
+.4byte sRayquazaCutsceneSprites92
+.4byte sRayquazaCutsceneSprites93
+.4byte sRayquazaCutsceneSprites94
+.4byte sRayquazaCutsceneSprites95
+.4byte sRayquazaCutsceneSprites96
+.4byte sRayquazaCutsceneSprites97
+.4byte sRayquazaCutsceneSprites98
+.4byte sRayquazaCutsceneSprites99
+.4byte sRayquazaCutsceneSprites100
+.4byte sRayquazaCutsceneSprites101
+.4byte sRayquazaCutsceneSprites102
+.4byte sRayquazaCutsceneSprites103
+.4byte sRayquazaCutsceneSprites104
+.4byte sRayquazaCutsceneSprites105
+.4byte sRayquazaCutsceneSprites106
+.4byte sRayquazaCutsceneSprites107
+.4byte sRayquazaCutsceneSprites108
+.4byte sRayquazaCutsceneSprites109
+.4byte sRayquazaCutsceneSprites110
+.4byte sRayquazaCutsceneSprites111
+.4byte sRayquazaCutsceneSprites112
+.4byte sRayquazaCutsceneSprites113
+.4byte sRayquazaCutsceneSprites114
+.4byte sRayquazaCutsceneSprites115
+.4byte sRayquazaCutsceneSprites116
+.4byte sRayquazaCutsceneSprites117
+.4byte sRayquazaCutsceneSprites118
+.4byte sRayquazaCutsceneSprites119
+.4byte sRayquazaCutsceneSprites120
+.4byte sRayquazaCutsceneSprites121
+.4byte sRayquazaCutsceneSprites122
+.4byte sRayquazaCutsceneSprites123
+.4byte sRayquazaCutsceneSprites124
+.4byte sRayquazaCutsceneSprites125
+.4byte sRayquazaCutsceneSprites126
+.4byte sRayquazaCutsceneSprites127
+.4byte sRayquazaCutsceneSprites128
+.4byte sRayquazaCutsceneSprites129
+.4byte sRayquazaCutsceneSprites130
+.4byte sRayquazaCutsceneSprites131
+.4byte sRayquazaCutsceneSprites132
+.4byte sRayquazaCutsceneSprites133
+.4byte sRayquazaCutsceneSprites134
+.4byte sRayquazaCutsceneSprites135
+.4byte sRayquazaCutsceneSprites136
+.4byte sRayquazaCutsceneSprites137
+.4byte sRayquazaCutsceneSprites138
+.4byte sRayquazaCutsceneSprites139
+.4byte sRayquazaCutsceneSprites140
+.4byte sRayquazaCutsceneSprites141
+.4byte sRayquazaCutsceneSprites142
+.4byte sRayquazaCutsceneSprites143
+.4byte sRayquazaCutsceneSprites144
+.4byte sRayquazaCutsceneSprites145
+.4byte sRayquazaCutsceneSprites146
+.4byte sRayquazaCutsceneSprites147
+.4byte sRayquazaCutsceneSprites148
+.4byte sRayquazaCutsceneSprites149
+.4byte sRayquazaCutsceneSprites150
+.4byte sRayquazaCutsceneSprites151
+.4byte sRayquazaCutsceneSprites152
+.4byte sRayquazaCutsceneSprites153
+.4byte sRayquazaCutsceneSprites154
+.4byte sRayquazaCutsceneSprites155
+.4byte sRayquazaCutsceneSprites156
+.4byte sRayquazaCutsceneSprites157
+.4byte sRayquazaCutsceneSprites158
+.4byte sRayquazaCutsceneSprites159
+.4byte sRayquazaCutsceneSprites160
+.4byte sRayquazaCutsceneSprites161
+.4byte sRayquazaCutsceneSprites162
+.4byte sRayquazaCutsceneSprites163
+.4byte sRayquazaCutsceneSprites164
+.4byte sRayquazaCutsceneSprites165
+.4byte sRayquazaCutsceneSprites166
+.4byte sRayquazaCutsceneSprites167
+.4byte sRayquazaCutsceneSprites168
+.4byte sRayquazaCutsceneSprites169
+.4byte sRayquazaCutsceneSprites170
+.4byte sRayquazaCutsceneSprites171
+.4byte sRayquazaCutsceneSprites172
+.4byte sRayquazaCutsceneSprites173
+.4byte sRayquazaCutsceneSprites174
+.4byte sRayquazaCutsceneSprites175
+.4byte sRayquazaCutsceneSprites176
+.4byte sRayquazaCutsceneSprites177
+.4byte sRayquazaCutsceneSprites178
+.4byte sRayquazaCutsceneSprites179
+.4byte sRayquazaCutsceneSprites180
+.4byte sRayquazaCutsceneSprites181
+.4byte sRayquazaCutsceneSprites182
+.4byte sRayquazaCutsceneSprites183
+.4byte sRayquazaCutsceneSprites184
+.4byte sRayquazaCutsceneSprites185
+.4byte sRayquazaCutsceneSprites186
+.4byte sRayquazaCutsceneSprites187
+.4byte sRayquazaCutsceneSprites188
+.4byte sRayquazaCutsceneSprites189
+.4byte sRayquazaCutsceneSprites190
+.4byte sRayquazaCutsceneSprites191
+.4byte sRayquazaCutsceneSprites192
+.4byte sRayquazaCutsceneSprites193
+.4byte sRayquazaCutsceneSprites194
+.4byte sRayquazaCutsceneSprites195
+.4byte sRayquazaCutsceneSprites196
+.4byte sRayquazaCutsceneSprites197
+.4byte sRayquazaCutsceneSprites198
+.4byte sRayquazaCutsceneSprites199
+.4byte sRayquazaCutsceneSprites200
+.4byte sRayquazaCutsceneSprites201
+.4byte sRayquazaCutsceneSprites202
+.4byte sRayquazaCutsceneSprites203
+.4byte sRayquazaCutsceneSprites204
+.4byte sRayquazaCutsceneSprites205
+.4byte sRayquazaCutsceneSprites206
+.4byte sRayquazaCutsceneSprites207
+.4byte sRayquazaCutsceneSprites208
+.4byte sRayquazaCutsceneSprites209
+.4byte sRayquazaCutsceneSprites210
+.4byte sRayquazaCutsceneSprites211
+.4byte sRayquazaCutsceneSprites212
+.4byte sRayquazaCutsceneSprites213
+.4byte sRayquazaCutsceneSprites214
+.4byte sRayquazaCutsceneSprites215
+.4byte sRayquazaCutsceneSprites216
+.4byte sRayquazaCutsceneSprites217
+.4byte sRayquazaCutsceneSprites218
+.4byte sRayquazaCutsceneSprites219
+.4byte sRayquazaCutsceneSprites220
+.4byte sRayquazaCutsceneSprites221
+.4byte sRayquazaCutsceneSprites222
+.4byte sRayquazaCutsceneSprites223
+.4byte sRayquazaCutsceneSprites224
+.4byte sRayquazaCutsceneSprites225
+.4byte sRayquazaCutsceneSprites226
+.4byte sRayquazaCutsceneSprites227
+.4byte sRayquazaCutsceneSprites228
+.4byte sRayquazaCutsceneSprites229
+.4byte sRayquazaCutsceneSprites230
+.4byte sRayquazaCutsceneSprites231
+.4byte sRayquazaCutsceneSprites232
+.4byte sRayquazaCutsceneSprites233
+.4byte sRayquazaCutsceneSprites234
+.4byte sRayquazaCutsceneSprites235
+.4byte sRayquazaCutsceneSprites236
+.4byte sRayquazaCutsceneSprites237
+.4byte sRayquazaCutsceneSprites238
+.4byte sRayquazaCutsceneSprites239
+.4byte sRayquazaCutsceneSprites240
+.4byte sRayquazaCutsceneSprites241
+.4byte sRayquazaCutsceneSprites242
+.4byte sRayquazaCutsceneSprites243
+.4byte sRayquazaCutsceneSprites244
+.4byte sRayquazaCutsceneSprites245
+.4byte sRayquazaCutsceneSprites246
+.4byte sRayquazaCutsceneSprites247
+.4byte sRayquazaCutsceneSprites248
+.4byte sRayquazaCutsceneSprites249
+.4byte sRayquazaCutsceneSprites250
+.4byte sRayquazaCutsceneSprites251
+.4byte sRayquazaCutsceneSprites252
+.4byte sRayquazaCutsceneSprites253
+.4byte sRayquazaCutsceneSprites254
+.4byte sRayquazaCutsceneSprites255
+.4byte sRayquazaCutsceneSprites256
+.4byte sRayquazaCutsceneSprites257
+.4byte sRayquazaCutsceneSprites258
+.4byte sRayquazaCutsceneSprites259
+.4byte sRayquazaCutsceneSprites260
+.4byte sRayquazaCutsceneSprites261
+.4byte sRayquazaCutsceneSprites262
+.4byte sRayquazaCutsceneSprites263
+.4byte sRayquazaCutsceneSprites264
+.4byte sRayquazaCutsceneSprites265
+.4byte sRayquazaCutsceneSprites266
+.4byte sRayquazaCutsceneSprites267
+.4byte sRayquazaCutsceneSprites268
+.4byte sRayquazaCutsceneSprites269
+.4byte sRayquazaCutsceneSprites270
+.4byte sRayquazaCutsceneSprites271
+.4byte sRayquazaCutsceneSprites272
+.4byte sRayquazaCutsceneSprites273
+.4byte sRayquazaCutsceneSprites274
+.4byte sRayquazaCutsceneSprites275
+.4byte sRayquazaCutsceneSprites276
+.4byte sRayquazaCutsceneSprites277
+.4byte sRayquazaCutsceneSprites278
+.4byte sRayquazaCutsceneSprites279
+.4byte sRayquazaCutsceneSprites280
+.4byte sRayquazaCutsceneSprites281
+.4byte sRayquazaCutsceneSprites282
+.4byte sRayquazaCutsceneSprites283
+.4byte sRayquazaCutsceneSprites284
+.4byte sRayquazaCutsceneSprites285
+.4byte sRayquazaCutsceneSprites286
+.4byte sRayquazaCutsceneSprites287
+.4byte sRayquazaCutsceneSprites288
+sAxMainRayquazaCutscene:
+ax_main sAxPosesRayquazaCutscene, sAxAnimationsRayquazaCutscene, 19, sAxSpritesRayquazaCutscene, sAxPositionsRayquazaCutscene

--- a/data/ax/regice.inc
+++ b/data/ax/regice.inc
@@ -1,0 +1,2662 @@
+.global gAxRegice
+gAxRegice:
+ax_siro sAxMainRegice
+sRegicePose1:
+ax_pose 0, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose2:
+ax_pose 1, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose3:
+ax_pose 2, 0x01e2, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose4:
+ax_pose 3, 0x01e2, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose5:
+ax_pose 4, 0x01e1, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose6:
+ax_pose 5, 0x01e1, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose7:
+ax_pose 6, 0x01e1, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose8:
+ax_pose 7, 0x01e1, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose9:
+ax_pose 8, 0x01e1, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose10:
+ax_pose 9, 0x01e1, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose11:
+ax_pose 6, 0x01e1, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose12:
+ax_pose 7, 0x01e1, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose13:
+ax_pose 4, 0x01e1, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose14:
+ax_pose 5, 0x01e1, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose15:
+ax_pose 2, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose16:
+ax_pose 3, 0x01e2, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose18:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose19:
+ax_pose 1, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose20:
+ax_pose 11, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose21:
+ax_pose 2, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose22:
+ax_pose 3, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose23:
+ax_pose 12, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose24:
+ax_pose 4, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose25:
+ax_pose 5, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose26:
+ax_pose 13, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose27:
+ax_pose 6, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose28:
+ax_pose 7, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose29:
+ax_pose 14, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose30:
+ax_pose 8, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose31:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose32:
+ax_pose 13, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose33:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose34:
+ax_pose 7, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose35:
+ax_pose 12, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose36:
+ax_pose 4, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose37:
+ax_pose 5, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose38:
+ax_pose 11, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose39:
+ax_pose 2, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose40:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose41:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose42:
+ax_pose 0, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose43:
+ax_pose 1, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose44:
+ax_pose 11, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose45:
+ax_pose 2, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose46:
+ax_pose 3, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose47:
+ax_pose 12, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose48:
+ax_pose 4, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose49:
+ax_pose 5, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose50:
+ax_pose 13, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose51:
+ax_pose 6, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose52:
+ax_pose 7, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose53:
+ax_pose 14, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose54:
+ax_pose 8, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose55:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose56:
+ax_pose 13, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose57:
+ax_pose 6, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose58:
+ax_pose 7, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose59:
+ax_pose 12, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose60:
+ax_pose 4, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose61:
+ax_pose 5, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose62:
+ax_pose 11, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose63:
+ax_pose 2, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose64:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose65:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose66:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose67:
+ax_pose 11, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose68:
+ax_pose 16, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose69:
+ax_pose 12, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose70:
+ax_pose 17, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose71:
+ax_pose 13, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose72:
+ax_pose 18, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose73:
+ax_pose 14, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose74:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose75:
+ax_pose 13, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose76:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose77:
+ax_pose 12, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose78:
+ax_pose 17, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose79:
+ax_pose 11, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose80:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose81:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose82:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose83:
+ax_pose 20, 0x41e7, 0x80f0, 0x9c00
+ax_pose 21, 0x01f7, 0x4100, 0x9c08
+ax_pose 22, 0x41f7, 0x00f0, 0x9c0c
+ax_pose 23, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 24, 0x01e7, 0x00e8, 0x9c0f
+ax_pose_terminator
+sRegicePose84:
+ax_pose 11, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose85:
+ax_pose 16, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose86:
+ax_pose 25, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose87:
+ax_pose 12, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose88:
+ax_pose 17, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose89:
+ax_pose 26, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose90:
+ax_pose 13, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose91:
+ax_pose 18, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose92:
+ax_pose 27, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose93:
+ax_pose 14, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose94:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose95:
+ax_pose 28, 0x41e7, 0x80f0, 0x9c00
+ax_pose 29, 0x01f7, 0x4100, 0x9c08
+ax_pose 30, 0x41f7, 0x00f0, 0x9c0c
+ax_pose 31, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 32, 0x01e7, 0x00e8, 0x9c0f
+ax_pose_terminator
+sRegicePose96:
+ax_pose 13, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose97:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose98:
+ax_pose 27, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose99:
+ax_pose 12, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose100:
+ax_pose 17, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose101:
+ax_pose 26, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose102:
+ax_pose 11, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose103:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose104:
+ax_pose 25, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose105:
+ax_pose 33, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose106:
+ax_pose 34, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose107:
+ax_pose 35, 0x81e4, 0x80f0, 0x9c00
+ax_pose 36, 0x01f4, 0x0110, 0x9c08
+ax_pose 37, 0x01f4, 0x0108, 0x9c09
+ax_pose 38, 0x81e4, 0x0108, 0x9c0a
+ax_pose 39, 0x81e4, 0x4100, 0x9c0c
+ax_pose_terminator
+sRegicePose108:
+ax_pose 40, 0x01e2, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose109:
+ax_pose 41, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose110:
+ax_pose 42, 0x81e3, 0x90f9, 0x9c00
+ax_pose 43, 0x01eb, 0x10e9, 0x9c08
+ax_pose 44, 0x81eb, 0x1109, 0x9c09
+ax_pose 45, 0x81e3, 0x50f1, 0x9c0b
+ax_pose_terminator
+sRegicePose111:
+ax_pose 46, 0x81e3, 0x80ff, 0x9c00
+ax_pose 47, 0x01eb, 0x010f, 0x9c08
+ax_pose 48, 0x81eb, 0x00ef, 0x9c09
+ax_pose 49, 0x81e3, 0x40f7, 0x9c0b
+ax_pose_terminator
+sRegicePose112:
+ax_pose 42, 0x81e3, 0x80f7, 0x9c00
+ax_pose 43, 0x01eb, 0x010f, 0x9c08
+ax_pose 44, 0x81eb, 0x00ef, 0x9c09
+ax_pose 45, 0x81e3, 0x4107, 0x9c0b
+ax_pose_terminator
+sRegicePose113:
+ax_pose 41, 0x01e3, 0x80f1, 0x9c00
+ax_pose_terminator
+sRegicePose114:
+ax_pose 40, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sRegicePose115:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose116:
+ax_pose 50, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose117:
+ax_pose 51, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose118:
+ax_pose 11, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose119:
+ax_pose 52, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose120:
+ax_pose 53, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose121:
+ax_pose 12, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose122:
+ax_pose 54, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose123:
+ax_pose 55, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose124:
+ax_pose 13, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose125:
+ax_pose 56, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose126:
+ax_pose 57, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose127:
+ax_pose 14, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose128:
+ax_pose 58, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose129:
+ax_pose 59, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose130:
+ax_pose 13, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose131:
+ax_pose 56, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose132:
+ax_pose 57, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose133:
+ax_pose 12, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose134:
+ax_pose 54, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose135:
+ax_pose 55, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose136:
+ax_pose 11, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose137:
+ax_pose 52, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose138:
+ax_pose 53, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose139:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose140:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose141:
+ax_pose 17, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose142:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose143:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose144:
+ax_pose 18, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose145:
+ax_pose 17, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose146:
+ax_pose 16, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose147:
+ax_pose 20, 0x41e7, 0x80f0, 0x9c00
+ax_pose 21, 0x01f7, 0x4100, 0x9c08
+ax_pose 22, 0x41f7, 0x00f0, 0x9c0c
+ax_pose 23, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 24, 0x01e7, 0x00e8, 0x9c0f
+ax_pose_terminator
+sRegicePose148:
+ax_pose 25, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose149:
+ax_pose 26, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose150:
+ax_pose 27, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose151:
+ax_pose 28, 0x41e7, 0x80f0, 0x9c00
+ax_pose 29, 0x01f7, 0x4100, 0x9c08
+ax_pose 30, 0x41f7, 0x00f0, 0x9c0c
+ax_pose 31, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 32, 0x01e7, 0x00e8, 0x9c0f
+ax_pose_terminator
+sRegicePose152:
+ax_pose 27, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose153:
+ax_pose 26, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose154:
+ax_pose 25, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose155:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose156:
+ax_pose 20, 0x41e7, 0x80f0, 0x9c00
+ax_pose 21, 0x01f7, 0x4100, 0x9c08
+ax_pose 22, 0x41f7, 0x00f0, 0x9c0c
+ax_pose 23, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 24, 0x01e7, 0x00e8, 0x9c0f
+ax_pose_terminator
+sRegicePose157:
+ax_pose 1, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose158:
+ax_pose 11, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose159:
+ax_pose 25, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose160:
+ax_pose 3, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose161:
+ax_pose 12, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose162:
+ax_pose 26, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose163:
+ax_pose 5, 0x01e3, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose164:
+ax_pose 13, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose165:
+ax_pose 27, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose166:
+ax_pose 7, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose167:
+ax_pose 14, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose168:
+ax_pose 28, 0x41e7, 0x80f0, 0x9c00
+ax_pose 29, 0x01f7, 0x4100, 0x9c08
+ax_pose 30, 0x41f7, 0x00f0, 0x9c0c
+ax_pose 31, 0x01ff, 0x00f8, 0x9c0e
+ax_pose 32, 0x01e7, 0x00e8, 0x9c0f
+ax_pose_terminator
+sRegicePose169:
+ax_pose 9, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose170:
+ax_pose 13, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose171:
+ax_pose 27, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose172:
+ax_pose 7, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose173:
+ax_pose 12, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose174:
+ax_pose 26, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose175:
+ax_pose 5, 0x01e3, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose176:
+ax_pose 11, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose177:
+ax_pose 25, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose178:
+ax_pose 3, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose179:
+ax_pose 15, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose180:
+ax_pose 16, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose181:
+ax_pose 17, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose182:
+ax_pose 18, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose183:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose184:
+ax_pose 18, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose185:
+ax_pose 17, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose186:
+ax_pose 16, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose187:
+ax_pose 10, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose188:
+ax_pose 11, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose189:
+ax_pose 12, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose190:
+ax_pose 13, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose191:
+ax_pose 14, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sRegicePose192:
+ax_pose 13, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose193:
+ax_pose 12, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sRegicePose194:
+ax_pose 11, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+.align 2
+sRegiceAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_1_2:
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_1_3:
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_1_4:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_1_5:
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_1_6:
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_1_7:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_1_8:
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 0, 4, 0, 4,
+ax_anim 1, 0, 18, 0, 10, 0, 10,
+ax_anim 2, 0, 17, 0, 22, 0, 20,
+ax_anim 2, 1, 17, 1, 22, 1, 20,
+ax_anim 2, 0, 17, 0, 22, 0, 20,
+ax_anim 2, 0, 17, 1, 22, 1, 20,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sRegiceAnims_2_2:
+ax_anim 2, 0, 19, -1, -1, -1, -1,
+ax_anim 6, 0, 19, -2, -2, -2, -2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 4, 4, 4, 4,
+ax_anim 1, 0, 21, 11, 10, 11, 10,
+ax_anim 2, 0, 20, 22, 22, 21, 20,
+ax_anim 2, 1, 20, 23, 21, 22, 19,
+ax_anim 2, 0, 20, 22, 22, 21, 20,
+ax_anim 2, 0, 20, 23, 21, 22, 19,
+ax_anim 2, 0, 19, 7, 6, 7, 6,
+ax_anim_terminator
+sRegiceAnims_2_3:
+ax_anim 2, 0, 22, -1, 0, -1, 0,
+ax_anim 6, 0, 22, -3, 0, -3, 0,
+ax_anim 1, 0, 24, 3, 0, 3, 0,
+ax_anim 1, 2, 23, 8, 0, 8, 0,
+ax_anim 1, 0, 24, 14, 0, 14, 0,
+ax_anim 2, 0, 23, 22, 1, 22, 0,
+ax_anim 2, 1, 23, 22, 2, 22, 1,
+ax_anim 2, 0, 23, 22, 1, 22, 0,
+ax_anim 2, 0, 23, 22, 2, 22, 1,
+ax_anim 2, 0, 22, 8, 0, 8, 0,
+ax_anim_terminator
+sRegiceAnims_2_4:
+ax_anim 2, 0, 25, -1, 1, -1, 1,
+ax_anim 6, 0, 25, -2, 2, -2, 2,
+ax_anim 1, 0, 27, 0, -1, 0, -1,
+ax_anim 1, 2, 26, 7, -5, 7, -6,
+ax_anim 1, 0, 27, 13, -10, 13, -11,
+ax_anim 2, 0, 26, 20, -15, 20, -17,
+ax_anim 2, 1, 26, 21, -14, 21, -16,
+ax_anim 2, 0, 26, 20, -15, 20, -17,
+ax_anim 2, 0, 26, 21, -14, 21, -16,
+ax_anim 2, 0, 25, 8, -6, 8, -7,
+ax_anim_terminator
+sRegiceAnims_2_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 6, 0, 28, 0, 3, 0, 3,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 0, -4, 0, -4,
+ax_anim 1, 0, 30, 0, -9, 0, -10,
+ax_anim 2, 0, 29, 0, -15, 0, -17,
+ax_anim 2, 1, 29, 1, -15, 1, -17,
+ax_anim 2, 0, 29, 0, -15, 0, -17,
+ax_anim 2, 0, 29, 1, -15, 1, -17,
+ax_anim 2, 0, 28, 0, -5, 0, -5,
+ax_anim_terminator
+sRegiceAnims_2_6:
+ax_anim 2, 0, 31, 1, 1, 1, 1,
+ax_anim 6, 0, 31, 2, 2, 2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 32, -7, -5, -7, -6,
+ax_anim 1, 0, 33, -13, -10, -13, -11,
+ax_anim 2, 0, 32, -20, -15, -20, -17,
+ax_anim 2, 1, 32, -21, -14, -21, -16,
+ax_anim 2, 0, 32, -20, -15, -20, -17,
+ax_anim 2, 0, 32, -21, -14, -21, -16,
+ax_anim 2, 0, 31, -8, -6, -8, -7,
+ax_anim_terminator
+sRegiceAnims_2_7:
+ax_anim 2, 0, 34, 1, 0, 1, 0,
+ax_anim 6, 0, 34, 3, 0, 3, 0,
+ax_anim 1, 0, 36, -3, 0, -3, 0,
+ax_anim 1, 2, 35, -8, 0, -8, 0,
+ax_anim 1, 0, 36, -14, 0, -14, 0,
+ax_anim 2, 0, 35, -22, 1, -22, 0,
+ax_anim 2, 1, 35, -22, 2, -22, 1,
+ax_anim 2, 0, 35, -22, 1, -22, 0,
+ax_anim 2, 0, 35, -22, 2, -22, 1,
+ax_anim 2, 0, 34, -8, 0, -8, 0,
+ax_anim_terminator
+sRegiceAnims_2_8:
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 6, 0, 37, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 38, -4, 4, -4, 4,
+ax_anim 1, 0, 39, -11, 10, -11, 10,
+ax_anim 2, 0, 38, -22, 22, -21, 20,
+ax_anim 2, 1, 38, -23, 21, -22, 19,
+ax_anim 2, 0, 38, -22, 22, -21, 20,
+ax_anim 2, 0, 38, -23, 21, -22, 19,
+ax_anim 2, 0, 37, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sRegiceAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 6, 0, 40, 0, -2, 0, -2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 42, 0, 10, 0, 10,
+ax_anim 2, 0, 41, 0, 22, 0, 20,
+ax_anim 2, 1, 41, 1, 22, 1, 20,
+ax_anim 2, 0, 41, 0, 22, 0, 20,
+ax_anim 2, 0, 41, 1, 22, 1, 20,
+ax_anim 2, 0, 40, 0, 6, 0, 6,
+ax_anim_terminator
+sRegiceAnims_3_2:
+ax_anim 2, 0, 43, -1, -1, -1, -1,
+ax_anim 6, 0, 43, -2, -2, -2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 4, 4, 4, 4,
+ax_anim 1, 0, 45, 11, 10, 11, 10,
+ax_anim 2, 0, 44, 22, 22, 21, 20,
+ax_anim 2, 1, 44, 23, 21, 22, 19,
+ax_anim 2, 0, 44, 22, 22, 21, 20,
+ax_anim 2, 0, 44, 23, 21, 22, 19,
+ax_anim 2, 0, 43, 7, 6, 7, 6,
+ax_anim_terminator
+sRegiceAnims_3_3:
+ax_anim 2, 0, 46, -1, 0, -1, 0,
+ax_anim 6, 0, 46, -3, 0, -3, 0,
+ax_anim 1, 0, 48, 3, 0, 3, 0,
+ax_anim 1, 2, 47, 8, 0, 8, 0,
+ax_anim 1, 0, 48, 14, 0, 14, 0,
+ax_anim 2, 0, 47, 22, 1, 22, 0,
+ax_anim 2, 1, 47, 22, 2, 22, 1,
+ax_anim 2, 0, 47, 22, 1, 22, 0,
+ax_anim 2, 0, 47, 22, 2, 22, 1,
+ax_anim 2, 0, 46, 8, 0, 8, 0,
+ax_anim_terminator
+sRegiceAnims_3_4:
+ax_anim 2, 0, 49, -1, 1, -1, 1,
+ax_anim 6, 0, 49, -2, 2, -2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 50, 7, -5, 7, -6,
+ax_anim 1, 0, 51, 13, -10, 13, -11,
+ax_anim 2, 0, 50, 20, -15, 20, -17,
+ax_anim 2, 1, 50, 21, -14, 21, -16,
+ax_anim 2, 0, 50, 20, -15, 20, -17,
+ax_anim 2, 0, 50, 21, -14, 21, -16,
+ax_anim 2, 0, 49, 8, -6, 8, -7,
+ax_anim_terminator
+sRegiceAnims_3_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 6, 0, 52, 0, 3, 0, 3,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 0, -4, 0, -4,
+ax_anim 1, 0, 54, 0, -9, 0, -10,
+ax_anim 2, 0, 53, 0, -15, 0, -17,
+ax_anim 2, 1, 53, 1, -15, 1, -17,
+ax_anim 2, 0, 53, 0, -15, 0, -17,
+ax_anim 2, 0, 53, 1, -15, 1, -17,
+ax_anim 2, 0, 52, 0, -5, 0, -5,
+ax_anim_terminator
+sRegiceAnims_3_6:
+ax_anim 2, 0, 55, 1, 1, 1, 1,
+ax_anim 6, 0, 55, 2, 2, 2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 56, -7, -5, -7, -6,
+ax_anim 1, 0, 57, -13, -10, -13, -11,
+ax_anim 2, 0, 56, -20, -15, -20, -17,
+ax_anim 2, 1, 56, -21, -14, -21, -16,
+ax_anim 2, 0, 56, -20, -15, -20, -17,
+ax_anim 2, 0, 56, -21, -14, -21, -16,
+ax_anim 2, 0, 55, -8, -6, -8, -7,
+ax_anim_terminator
+sRegiceAnims_3_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 6, 0, 58, 3, 0, 3, 0,
+ax_anim 1, 0, 60, -3, 0, -3, 0,
+ax_anim 1, 2, 59, -8, 0, -8, 0,
+ax_anim 1, 0, 60, -14, 0, -14, 0,
+ax_anim 2, 0, 59, -22, 1, -22, 0,
+ax_anim 2, 1, 59, -22, 2, -22, 1,
+ax_anim 2, 0, 59, -22, 1, -22, 0,
+ax_anim 2, 0, 59, -22, 2, -22, 1,
+ax_anim 2, 0, 58, -8, 0, -8, 0,
+ax_anim_terminator
+sRegiceAnims_3_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 6, 0, 61, 2, -2, 2, -2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 62, -4, 4, -4, 4,
+ax_anim 1, 0, 63, -11, 10, -11, 10,
+ax_anim 2, 0, 62, -22, 22, -21, 20,
+ax_anim 2, 1, 62, -23, 21, -22, 19,
+ax_anim 2, 0, 62, -22, 22, -21, 20,
+ax_anim 2, 0, 62, -23, 21, -22, 19,
+ax_anim 2, 0, 61, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sRegiceAnims_4_1:
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 0, 64, 0, 3, 0, 3,
+ax_anim 8, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 1, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 65, 0, -5, 0, -5,
+ax_anim 1, 0, 65, 0, -8, 0, -8,
+ax_anim 4, 0, 65, 0, -9, 0, -9,
+ax_anim 2, 0, 64, 0, -7, 0, -7,
+ax_anim 2, 0, 64, 0, -4, 0, -4,
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim_terminator
+sRegiceAnims_4_2:
+ax_anim 2, 0, 66, 1, 1, 1, 1,
+ax_anim 2, 0, 66, 3, 3, 3, 3,
+ax_anim 8, 2, 67, 4, 4, 4, 4,
+ax_anim 1, 1, 67, 4, 4, 4, 4,
+ax_anim 1, 0, 67, -5, -5, -5, -5,
+ax_anim 1, 0, 67, -8, -8, -8, -8,
+ax_anim 4, 0, 67, -9, -9, -9, -9,
+ax_anim 2, 0, 66, -7, -7, -7, -7,
+ax_anim 2, 0, 66, -4, -4, -4, -4,
+ax_anim 2, 0, 66, -2, -2, -2, -2,
+ax_anim_terminator
+sRegiceAnims_4_3:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 68, 3, 0, 3, 0,
+ax_anim 8, 2, 69, 4, 0, 4, 0,
+ax_anim 1, 1, 69, 4, 0, 4, 0,
+ax_anim 1, 0, 69, -5, 0, -5, 0,
+ax_anim 1, 0, 69, -8, 0, -8, 0,
+ax_anim 4, 0, 69, -9, 0, -9, 0,
+ax_anim 2, 0, 68, -7, 0, -7, 0,
+ax_anim 2, 0, 68, -4, 0, -4, 0,
+ax_anim 2, 0, 68, -2, 0, -2, 0,
+ax_anim_terminator
+sRegiceAnims_4_4:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 2, 0, 70, 3, -3, 3, -3,
+ax_anim 8, 2, 71, 4, -4, 4, -4,
+ax_anim 1, 1, 71, 4, -4, 4, -4,
+ax_anim 1, 0, 71, -5, 5, -5, 5,
+ax_anim 1, 0, 71, -8, 8, -8, 8,
+ax_anim 4, 0, 71, -9, 9, -9, 9,
+ax_anim 2, 0, 70, -7, 7, -7, 7,
+ax_anim 2, 0, 70, -4, 4, -4, 4,
+ax_anim 2, 0, 70, -2, 2, -2, 2,
+ax_anim_terminator
+sRegiceAnims_4_5:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim 8, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 1, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 73, 0, 5, 0, 5,
+ax_anim 1, 0, 73, 0, 8, 0, 8,
+ax_anim 4, 0, 73, 0, 9, 0, 9,
+ax_anim 2, 0, 72, 0, 7, 0, 7,
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sRegiceAnims_4_6:
+ax_anim 2, 0, 74, -1, -1, -1, -1,
+ax_anim 2, 0, 74, -3, -3, -3, -3,
+ax_anim 8, 2, 75, -4, -4, -4, -4,
+ax_anim 1, 1, 75, -4, -4, -4, -4,
+ax_anim 1, 0, 75, 5, 5, 5, 5,
+ax_anim 1, 0, 75, 8, 8, 8, 8,
+ax_anim 4, 0, 75, 9, 9, 9, 9,
+ax_anim 2, 0, 74, 7, 7, 7, 7,
+ax_anim 2, 0, 74, 4, 4, 4, 4,
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim_terminator
+sRegiceAnims_4_7:
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 2, 0, 76, -3, 0, -3, 0,
+ax_anim 8, 2, 77, -4, 0, -4, 0,
+ax_anim 1, 1, 77, -4, 0, -4, 0,
+ax_anim 1, 0, 77, 5, 0, 5, 0,
+ax_anim 1, 0, 77, 8, 0, 8, 0,
+ax_anim 4, 0, 77, 9, 0, 9, 0,
+ax_anim 2, 0, 76, 7, 0, 7, 0,
+ax_anim 2, 0, 76, 4, 0, 4, 0,
+ax_anim 2, 0, 76, 2, 0, 2, 0,
+ax_anim_terminator
+sRegiceAnims_4_8:
+ax_anim 2, 0, 78, -1, 1, -1, 1,
+ax_anim 2, 0, 78, -3, 3, -3, 3,
+ax_anim 8, 2, 79, -4, 4, -4, 4,
+ax_anim 1, 1, 79, -4, 4, -4, 4,
+ax_anim 1, 0, 79, 5, -5, 5, -5,
+ax_anim 1, 0, 79, 8, -8, 8, -8,
+ax_anim 4, 0, 79, 9, -9, 9, -9,
+ax_anim 2, 0, 78, 7, -7, 7, -7,
+ax_anim 2, 0, 78, 4, -4, 4, -4,
+ax_anim 2, 0, 78, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sRegiceAnims_5_1:
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 2, 82, 0, -6, 0, 0,
+ax_anim 2, 0, 82, 1, -6, 0, 0,
+ax_anim 2, 0, 82, 0, -6, 0, 0,
+ax_anim 2, 0, 82, 1, -6, 0, 0,
+ax_anim 2, 0, 82, 0, -6, 0, 0,
+ax_anim 2, 0, 82, 1, -6, 0, 0,
+ax_anim 4, 0, 82, 0, -6, 0, 0,
+ax_anim 2, 0, 81, 0, -5, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 1, 80, 0, -2, 0, 0,
+ax_anim_terminator
+sRegiceAnims_5_2:
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 4, 2, 85, 0, -6, 0, 0,
+ax_anim 2, 0, 85, 1, -6, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, 0,
+ax_anim 2, 0, 85, 1, -6, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, 0,
+ax_anim 2, 0, 85, 1, -6, 0, 0,
+ax_anim 4, 0, 85, 0, -6, 0, 0,
+ax_anim 2, 0, 84, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 1, 83, 0, -2, 0, 0,
+ax_anim_terminator
+sRegiceAnims_5_3:
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 4, 2, 88, 0, -6, 0, 0,
+ax_anim 2, 0, 88, 1, -6, 0, 0,
+ax_anim 2, 0, 88, 0, -6, 0, 0,
+ax_anim 2, 0, 88, 1, -6, 0, 0,
+ax_anim 2, 0, 88, 0, -6, 0, 0,
+ax_anim 2, 0, 88, 1, -6, 0, 0,
+ax_anim 4, 0, 88, 0, -6, 0, 0,
+ax_anim 2, 0, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 1, 86, 0, -2, 0, 0,
+ax_anim_terminator
+sRegiceAnims_5_4:
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 4, 2, 91, 0, -6, 0, 0,
+ax_anim 2, 0, 91, 1, -6, 0, 0,
+ax_anim 2, 0, 91, 0, -6, 0, 0,
+ax_anim 2, 0, 91, 1, -6, 0, 0,
+ax_anim 2, 0, 91, 0, -6, 0, 0,
+ax_anim 2, 0, 91, 1, -6, 0, 0,
+ax_anim 4, 0, 91, 0, -6, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 1, 89, 0, -2, 0, 0,
+ax_anim_terminator
+sRegiceAnims_5_5:
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 4, 2, 94, 0, -6, 0, 0,
+ax_anim 2, 0, 94, 1, -6, 0, 0,
+ax_anim 2, 0, 94, 0, -6, 0, 0,
+ax_anim 2, 0, 94, 1, -6, 0, 0,
+ax_anim 2, 0, 94, 0, -6, 0, 0,
+ax_anim 2, 0, 94, 1, -6, 0, 0,
+ax_anim 4, 0, 94, 0, -6, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 1, 92, 0, -2, 0, 0,
+ax_anim_terminator
+sRegiceAnims_5_6:
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 4, 2, 97, 0, -6, 0, 0,
+ax_anim 2, 0, 97, 1, -6, 0, 0,
+ax_anim 2, 0, 97, 0, -6, 0, 0,
+ax_anim 2, 0, 97, 1, -6, 0, 0,
+ax_anim 2, 0, 97, 0, -6, 0, 0,
+ax_anim 2, 0, 97, 1, -6, 0, 0,
+ax_anim 4, 0, 97, 0, -6, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim 2, 1, 95, 0, -2, 0, 0,
+ax_anim_terminator
+sRegiceAnims_5_7:
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 4, 2, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 1, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 1, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 1, -6, 0, 0,
+ax_anim 4, 0, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 1, 98, 0, -2, 0, 0,
+ax_anim_terminator
+sRegiceAnims_5_8:
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 4, 2, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 103, 1, -6, 0, 0,
+ax_anim 2, 0, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 103, 1, -6, 0, 0,
+ax_anim 2, 0, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 103, 1, -6, 0, 0,
+ax_anim 4, 0, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 1, 101, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sRegiceAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sRegiceAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sRegiceAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sRegiceAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sRegiceAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sRegiceAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sRegiceAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sRegiceAnims_8_1:
+ax_anim 8, 0, 114, 0, 0, 0, 0,
+ax_anim 8, 0, 115, 0, 0, 0, 0,
+ax_anim 8, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_8_2:
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 8, 0, 118, 0, 0, 0, 0,
+ax_anim 8, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_8_3:
+ax_anim 8, 0, 120, 0, 0, 0, 0,
+ax_anim 8, 0, 121, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_8_4:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_8_5:
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_8_6:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_8_7:
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_8_8:
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 8, 6, 8, 6,
+ax_anim 2, 0, 140, 12, 12, 12, 12,
+ax_anim 2, 0, 141, 11, 19, 11, 19,
+ax_anim 3, 0, 142, 0, 22, 0, 22,
+ax_anim 2, 3, 143, -11, 19, -11, 19,
+ax_anim 2, 0, 144, -12, 12, -12, 12,
+ax_anim 1, 0, 145, -8, 6, -8, 6,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 10, 2, 10, 2,
+ax_anim 2, 0, 139, 17, 7, 17, 7,
+ax_anim 2, 0, 140, 22, 13, 22, 13,
+ax_anim 3, 0, 141, 21, 21, 21, 21,
+ax_anim 2, 3, 142, 12, 22, 12, 22,
+ax_anim 2, 0, 143, 3, 19, 3, 19,
+ax_anim 1, 0, 144, -1, 8, -1, 8,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 4, -4, 4, -4,
+ax_anim 2, 0, 138, 10, -7, 10, -7,
+ax_anim 2, 0, 139, 16, -4, 16, -4,
+ax_anim 3, 0, 140, 21, 1, 21, 1,
+ax_anim 2, 3, 141, 18, 6, 18, 6,
+ax_anim 2, 0, 142, 12, 7, 12, 7,
+ax_anim 1, 0, 143, 5, 5, 5, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 5, -16, 5, -16,
+ax_anim 2, 0, 138, 13, -19, 13, -19,
+ax_anim 3, 0, 139, 21, -17, 21, -17,
+ax_anim 2, 3, 140, 25, -12, 25, -12,
+ax_anim 2, 0, 141, 20, -5, 20, -5,
+ax_anim 1, 0, 142, 9, -1, 9, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -9, -3, -9, -3,
+ax_anim 2, 0, 144, -12, -11, -12, -11,
+ax_anim 2, 0, 145, -7, -17, -7, -17,
+ax_anim 3, 0, 138, 0, -19, 0, -19,
+ax_anim 2, 3, 139, 7, -17, 7, -17,
+ax_anim 2, 0, 140, 13, -11, 13, -11,
+ax_anim 1, 0, 141, 9, -3, 9, -3,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -5, -16, -5, -16,
+ax_anim 2, 0, 138, -13, -19, -13, -19,
+ax_anim 3, 0, 145, -21, -17, -21, -17,
+ax_anim 2, 3, 144, -25, -12, -25, -12,
+ax_anim 2, 0, 143, -20, -5, -20, -5,
+ax_anim 1, 0, 142, -9, -1, -9, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -4, -4, -4, -4,
+ax_anim 2, 0, 138, -10, -7, -10, -7,
+ax_anim 2, 0, 145, -16, -4, -16, -4,
+ax_anim 3, 0, 144, -21, 1, -21, 1,
+ax_anim 2, 3, 143, -18, 6, -18, 6,
+ax_anim 2, 0, 142, -12, 7, -12, 7,
+ax_anim 1, 0, 141, -5, 5, -5, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -10, 2, -10, 2,
+ax_anim 2, 0, 145, -17, 7, -17, 7,
+ax_anim 2, 0, 144, -22, 13, -22, 13,
+ax_anim 3, 0, 143, -21, 21, -21, 21,
+ax_anim 2, 3, 142, -12, 22, -12, 22,
+ax_anim 2, 0, 141, -3, 19, -3, 19,
+ax_anim 1, 0, 140, 1, 8, 1, 8,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 156, 0, -19, 0, 0,
+ax_anim 2, 0, 156, 0, -15, 0, 0,
+ax_anim 1, 0, 156, 0, -9, 0, 0,
+ax_anim 2, 2, 156, 0, 3, 0, 0,
+ax_anim_terminator
+sRegiceAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -22, 0, 0,
+ax_anim 3, 0, 162, 0, -21, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 2, 162, 0, 1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 1, 0, 165, 0, -9, 0, 0,
+ax_anim 2, 2, 165, 0, 1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -22, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 2, 168, 0, 1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 1, 0, 171, 0, -9, 0, 0,
+ax_anim 2, 2, 171, 0, 1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 174, 0, -21, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 2, 174, 0, 1, 0, 0,
+ax_anim_terminator
+sRegiceAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegiceAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sRegiceGfx1:
+.incbin "baserom.gba", 0x1594620, 0x200
+sRegiceSprites1:
+ax_sprite sRegiceGfx1, 0x200
+ax_sprite_terminator
+sRegiceGfx2:
+.incbin "baserom.gba", 0x1594830, 0x200
+sRegiceSprites2:
+ax_sprite sRegiceGfx2, 0x200
+ax_sprite_terminator
+sRegiceGfx3:
+.incbin "baserom.gba", 0x1594A40, 0x200
+sRegiceSprites3:
+ax_sprite sRegiceGfx3, 0x200
+ax_sprite_terminator
+sRegiceGfx4:
+.incbin "baserom.gba", 0x1594C50, 0x200
+sRegiceSprites4:
+ax_sprite sRegiceGfx4, 0x200
+ax_sprite_terminator
+sRegiceGfx5:
+.incbin "baserom.gba", 0x1594E60, 0x200
+sRegiceSprites5:
+ax_sprite sRegiceGfx5, 0x200
+ax_sprite_terminator
+sRegiceGfx6:
+.incbin "baserom.gba", 0x1595070, 0x200
+sRegiceSprites6:
+ax_sprite sRegiceGfx6, 0x200
+ax_sprite_terminator
+sRegiceGfx7:
+.incbin "baserom.gba", 0x1595280, 0x200
+sRegiceSprites7:
+ax_sprite sRegiceGfx7, 0x200
+ax_sprite_terminator
+sRegiceGfx8:
+.incbin "baserom.gba", 0x1595490, 0x200
+sRegiceSprites8:
+ax_sprite sRegiceGfx8, 0x200
+ax_sprite_terminator
+sRegiceGfx9:
+.incbin "baserom.gba", 0x15956A0, 0x200
+sRegiceSprites9:
+ax_sprite sRegiceGfx9, 0x200
+ax_sprite_terminator
+sRegiceGfx10:
+.incbin "baserom.gba", 0x15958B0, 0x200
+sRegiceSprites10:
+ax_sprite sRegiceGfx10, 0x200
+ax_sprite_terminator
+sRegiceGfx11:
+.incbin "baserom.gba", 0x1595AC0, 0x60
+sRegiceGfx11_1:
+.incbin "baserom.gba", 0x1595B20, 0x160
+sRegiceSprites11:
+ax_sprite sRegiceGfx11, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx11_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx12:
+.incbin "baserom.gba", 0x1595CA8, 0x160
+sRegiceGfx12_1:
+.incbin "baserom.gba", 0x1595E08, 0x60
+sRegiceSprites12:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx12, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx12_1, 0x60
+ax_sprite_terminator
+sRegiceGfx13:
+.incbin "baserom.gba", 0x1595E90, 0x60
+sRegiceGfx13_1:
+.incbin "baserom.gba", 0x1595EF0, 0x60
+sRegiceGfx13_2:
+.incbin "baserom.gba", 0x1595F50, 0x60
+sRegiceGfx13_3:
+.incbin "baserom.gba", 0x1595FB0, 0x40
+sRegiceSprites13:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx13, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx13_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx13_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx13_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx14:
+.incbin "baserom.gba", 0x1596040, 0x40
+sRegiceGfx14_1:
+.incbin "baserom.gba", 0x1596080, 0x160
+sRegiceSprites14:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx14, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx14_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx15:
+.incbin "baserom.gba", 0x1596210, 0x40
+sRegiceGfx15_1:
+.incbin "baserom.gba", 0x1596250, 0x160
+sRegiceSprites15:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx15, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx15_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx16:
+.incbin "baserom.gba", 0x15963E0, 0x60
+sRegiceGfx16_1:
+.incbin "baserom.gba", 0x1596440, 0x180
+sRegiceSprites16:
+ax_sprite sRegiceGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx16_1, 0x180
+ax_sprite_terminator
+sRegiceGfx17:
+.incbin "baserom.gba", 0x15965E0, 0x160
+sRegiceGfx17_1:
+.incbin "baserom.gba", 0x1596740, 0x60
+sRegiceSprites17:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx17, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx17_1, 0x60
+ax_sprite_terminator
+sRegiceGfx18:
+.incbin "baserom.gba", 0x15967C8, 0x160
+sRegiceGfx18_1:
+.incbin "baserom.gba", 0x1596928, 0x40
+sRegiceSprites18:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx18, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx19:
+.incbin "baserom.gba", 0x1596998, 0x40
+sRegiceGfx19_1:
+.incbin "baserom.gba", 0x15969D8, 0x160
+sRegiceSprites19:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx20:
+.incbin "baserom.gba", 0x1596B68, 0x40
+sRegiceGfx20_1:
+.incbin "baserom.gba", 0x1596BA8, 0x180
+sRegiceSprites20:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx20_1, 0x180
+ax_sprite_terminator
+sRegiceGfx21:
+.incbin "baserom.gba", 0x1596D50, 0x100
+sRegiceSprites21:
+ax_sprite sRegiceGfx21, 0x100
+ax_sprite_terminator
+sRegiceGfx22:
+.incbin "baserom.gba", 0x1596E60, 0x60
+sRegiceSprites22:
+ax_sprite sRegiceGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx23:
+.incbin "baserom.gba", 0x1596ED8, 0x40
+sRegiceSprites23:
+ax_sprite sRegiceGfx23, 0x40
+ax_sprite_terminator
+sRegiceGfx24:
+.incbin "baserom.gba", 0x1596F28, 0x20
+sRegiceSprites24:
+ax_sprite sRegiceGfx24, 0x20
+ax_sprite_terminator
+sRegiceGfx25:
+.incbin "baserom.gba", 0x1596F58, 0x20
+sRegiceSprites25:
+ax_sprite sRegiceGfx25, 0x20
+ax_sprite_terminator
+sRegiceGfx26:
+.incbin "baserom.gba", 0x1596F88, 0x180
+sRegiceGfx26_1:
+.incbin "baserom.gba", 0x1597108, 0x60
+sRegiceSprites26:
+ax_sprite sRegiceGfx26, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx26_1, 0x60
+ax_sprite_terminator
+sRegiceGfx27:
+.incbin "baserom.gba", 0x1597188, 0x60
+sRegiceGfx27_1:
+.incbin "baserom.gba", 0x15971E8, 0x60
+sRegiceGfx27_2:
+.incbin "baserom.gba", 0x1597248, 0x60
+sRegiceGfx27_3:
+.incbin "baserom.gba", 0x15972A8, 0x40
+sRegiceSprites27:
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegiceGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx28:
+.incbin "baserom.gba", 0x1597338, 0x1E0
+sRegiceSprites28:
+ax_sprite sRegiceGfx28, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx29:
+.incbin "baserom.gba", 0x1597530, 0x100
+sRegiceSprites29:
+ax_sprite sRegiceGfx29, 0x100
+ax_sprite_terminator
+sRegiceGfx30:
+.incbin "baserom.gba", 0x1597640, 0x60
+sRegiceSprites30:
+ax_sprite sRegiceGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegiceGfx31:
+.incbin "baserom.gba", 0x15976B8, 0x40
+sRegiceSprites31:
+ax_sprite sRegiceGfx31, 0x40
+ax_sprite_terminator
+sRegiceGfx32:
+.incbin "baserom.gba", 0x1597708, 0x20
+sRegiceSprites32:
+ax_sprite sRegiceGfx32, 0x20
+ax_sprite_terminator
+sRegiceGfx33:
+.incbin "baserom.gba", 0x1597738, 0x20
+sRegiceSprites33:
+ax_sprite sRegiceGfx33, 0x20
+ax_sprite_terminator
+sRegiceGfx34:
+.incbin "baserom.gba", 0x1597768, 0x200
+sRegiceSprites34:
+ax_sprite sRegiceGfx34, 0x200
+ax_sprite_terminator
+sRegiceGfx35:
+.incbin "baserom.gba", 0x1597978, 0x200
+sRegiceSprites35:
+ax_sprite sRegiceGfx35, 0x200
+ax_sprite_terminator
+sRegiceGfx36:
+.incbin "baserom.gba", 0x1597B88, 0x100
+sRegiceSprites36:
+ax_sprite sRegiceGfx36, 0x100
+ax_sprite_terminator
+sRegiceGfx37:
+.incbin "baserom.gba", 0x1597C98, 0x20
+sRegiceSprites37:
+ax_sprite sRegiceGfx37, 0x20
+ax_sprite_terminator
+sRegiceGfx38:
+.incbin "baserom.gba", 0x1597CC8, 0x20
+sRegiceSprites38:
+ax_sprite sRegiceGfx38, 0x20
+ax_sprite_terminator
+sRegiceGfx39:
+.incbin "baserom.gba", 0x1597CF8, 0x40
+sRegiceSprites39:
+ax_sprite sRegiceGfx39, 0x40
+ax_sprite_terminator
+sRegiceGfx40:
+.incbin "baserom.gba", 0x1597D48, 0x80
+sRegiceSprites40:
+ax_sprite sRegiceGfx40, 0x80
+ax_sprite_terminator
+sRegiceGfx41:
+.incbin "baserom.gba", 0x1597DD8, 0x200
+sRegiceSprites41:
+ax_sprite sRegiceGfx41, 0x200
+ax_sprite_terminator
+sRegiceGfx42:
+.incbin "baserom.gba", 0x1597FE8, 0x200
+sRegiceSprites42:
+ax_sprite sRegiceGfx42, 0x200
+ax_sprite_terminator
+sRegiceGfx43:
+.incbin "baserom.gba", 0x15981F8, 0x100
+sRegiceSprites43:
+ax_sprite sRegiceGfx43, 0x100
+ax_sprite_terminator
+sRegiceGfx44:
+.incbin "baserom.gba", 0x1598308, 0x20
+sRegiceSprites44:
+ax_sprite sRegiceGfx44, 0x20
+ax_sprite_terminator
+sRegiceGfx45:
+.incbin "baserom.gba", 0x1598338, 0x40
+sRegiceSprites45:
+ax_sprite sRegiceGfx45, 0x40
+ax_sprite_terminator
+sRegiceGfx46:
+.incbin "baserom.gba", 0x1598388, 0x80
+sRegiceSprites46:
+ax_sprite sRegiceGfx46, 0x80
+ax_sprite_terminator
+sRegiceGfx47:
+.incbin "baserom.gba", 0x1598418, 0x100
+sRegiceSprites47:
+ax_sprite sRegiceGfx47, 0x100
+ax_sprite_terminator
+sRegiceGfx48:
+.incbin "baserom.gba", 0x1598528, 0x20
+sRegiceSprites48:
+ax_sprite sRegiceGfx48, 0x20
+ax_sprite_terminator
+sRegiceGfx49:
+.incbin "baserom.gba", 0x1598558, 0x40
+sRegiceSprites49:
+ax_sprite sRegiceGfx49, 0x40
+ax_sprite_terminator
+sRegiceGfx50:
+.incbin "baserom.gba", 0x15985A8, 0x80
+sRegiceSprites50:
+ax_sprite sRegiceGfx50, 0x80
+ax_sprite_terminator
+sRegiceGfx51:
+.incbin "baserom.gba", 0x1598638, 0x200
+sRegiceSprites51:
+ax_sprite sRegiceGfx51, 0x200
+ax_sprite_terminator
+sRegiceGfx52:
+.incbin "baserom.gba", 0x1598848, 0x200
+sRegiceSprites52:
+ax_sprite sRegiceGfx52, 0x200
+ax_sprite_terminator
+sRegiceGfx53:
+.incbin "baserom.gba", 0x1598A58, 0x200
+sRegiceSprites53:
+ax_sprite sRegiceGfx53, 0x200
+ax_sprite_terminator
+sRegiceGfx54:
+.incbin "baserom.gba", 0x1598C68, 0x200
+sRegiceSprites54:
+ax_sprite sRegiceGfx54, 0x200
+ax_sprite_terminator
+sRegiceGfx55:
+.incbin "baserom.gba", 0x1598E78, 0x200
+sRegiceSprites55:
+ax_sprite sRegiceGfx55, 0x200
+ax_sprite_terminator
+sRegiceGfx56:
+.incbin "baserom.gba", 0x1599088, 0x200
+sRegiceSprites56:
+ax_sprite sRegiceGfx56, 0x200
+ax_sprite_terminator
+sRegiceGfx57:
+.incbin "baserom.gba", 0x1599298, 0x200
+sRegiceSprites57:
+ax_sprite sRegiceGfx57, 0x200
+ax_sprite_terminator
+sRegiceGfx58:
+.incbin "baserom.gba", 0x15994A8, 0x200
+sRegiceSprites58:
+ax_sprite sRegiceGfx58, 0x200
+ax_sprite_terminator
+sRegiceGfx59:
+.incbin "baserom.gba", 0x15996B8, 0x200
+sRegiceSprites59:
+ax_sprite sRegiceGfx59, 0x200
+ax_sprite_terminator
+sRegiceGfx60:
+.incbin "baserom.gba", 0x15998C8, 0x200
+sRegiceSprites60:
+ax_sprite sRegiceGfx60, 0x200
+ax_sprite_terminator
+sAxPosesRegice:
+.4byte sRegicePose1
+.4byte sRegicePose2
+.4byte sRegicePose3
+.4byte sRegicePose4
+.4byte sRegicePose5
+.4byte sRegicePose6
+.4byte sRegicePose7
+.4byte sRegicePose8
+.4byte sRegicePose9
+.4byte sRegicePose10
+.4byte sRegicePose11
+.4byte sRegicePose12
+.4byte sRegicePose13
+.4byte sRegicePose14
+.4byte sRegicePose15
+.4byte sRegicePose16
+.4byte sRegicePose17
+.4byte sRegicePose18
+.4byte sRegicePose19
+.4byte sRegicePose20
+.4byte sRegicePose21
+.4byte sRegicePose22
+.4byte sRegicePose23
+.4byte sRegicePose24
+.4byte sRegicePose25
+.4byte sRegicePose26
+.4byte sRegicePose27
+.4byte sRegicePose28
+.4byte sRegicePose29
+.4byte sRegicePose30
+.4byte sRegicePose31
+.4byte sRegicePose32
+.4byte sRegicePose33
+.4byte sRegicePose34
+.4byte sRegicePose35
+.4byte sRegicePose36
+.4byte sRegicePose37
+.4byte sRegicePose38
+.4byte sRegicePose39
+.4byte sRegicePose40
+.4byte sRegicePose41
+.4byte sRegicePose42
+.4byte sRegicePose43
+.4byte sRegicePose44
+.4byte sRegicePose45
+.4byte sRegicePose46
+.4byte sRegicePose47
+.4byte sRegicePose48
+.4byte sRegicePose49
+.4byte sRegicePose50
+.4byte sRegicePose51
+.4byte sRegicePose52
+.4byte sRegicePose53
+.4byte sRegicePose54
+.4byte sRegicePose55
+.4byte sRegicePose56
+.4byte sRegicePose57
+.4byte sRegicePose58
+.4byte sRegicePose59
+.4byte sRegicePose60
+.4byte sRegicePose61
+.4byte sRegicePose62
+.4byte sRegicePose63
+.4byte sRegicePose64
+.4byte sRegicePose65
+.4byte sRegicePose66
+.4byte sRegicePose67
+.4byte sRegicePose68
+.4byte sRegicePose69
+.4byte sRegicePose70
+.4byte sRegicePose71
+.4byte sRegicePose72
+.4byte sRegicePose73
+.4byte sRegicePose74
+.4byte sRegicePose75
+.4byte sRegicePose76
+.4byte sRegicePose77
+.4byte sRegicePose78
+.4byte sRegicePose79
+.4byte sRegicePose80
+.4byte sRegicePose81
+.4byte sRegicePose82
+.4byte sRegicePose83
+.4byte sRegicePose84
+.4byte sRegicePose85
+.4byte sRegicePose86
+.4byte sRegicePose87
+.4byte sRegicePose88
+.4byte sRegicePose89
+.4byte sRegicePose90
+.4byte sRegicePose91
+.4byte sRegicePose92
+.4byte sRegicePose93
+.4byte sRegicePose94
+.4byte sRegicePose95
+.4byte sRegicePose96
+.4byte sRegicePose97
+.4byte sRegicePose98
+.4byte sRegicePose99
+.4byte sRegicePose100
+.4byte sRegicePose101
+.4byte sRegicePose102
+.4byte sRegicePose103
+.4byte sRegicePose104
+.4byte sRegicePose105
+.4byte sRegicePose106
+.4byte sRegicePose107
+.4byte sRegicePose108
+.4byte sRegicePose109
+.4byte sRegicePose110
+.4byte sRegicePose111
+.4byte sRegicePose112
+.4byte sRegicePose113
+.4byte sRegicePose114
+.4byte sRegicePose115
+.4byte sRegicePose116
+.4byte sRegicePose117
+.4byte sRegicePose118
+.4byte sRegicePose119
+.4byte sRegicePose120
+.4byte sRegicePose121
+.4byte sRegicePose122
+.4byte sRegicePose123
+.4byte sRegicePose124
+.4byte sRegicePose125
+.4byte sRegicePose126
+.4byte sRegicePose127
+.4byte sRegicePose128
+.4byte sRegicePose129
+.4byte sRegicePose130
+.4byte sRegicePose131
+.4byte sRegicePose132
+.4byte sRegicePose133
+.4byte sRegicePose134
+.4byte sRegicePose135
+.4byte sRegicePose136
+.4byte sRegicePose137
+.4byte sRegicePose138
+.4byte sRegicePose139
+.4byte sRegicePose140
+.4byte sRegicePose141
+.4byte sRegicePose142
+.4byte sRegicePose143
+.4byte sRegicePose144
+.4byte sRegicePose145
+.4byte sRegicePose146
+.4byte sRegicePose147
+.4byte sRegicePose148
+.4byte sRegicePose149
+.4byte sRegicePose150
+.4byte sRegicePose151
+.4byte sRegicePose152
+.4byte sRegicePose153
+.4byte sRegicePose154
+.4byte sRegicePose155
+.4byte sRegicePose156
+.4byte sRegicePose157
+.4byte sRegicePose158
+.4byte sRegicePose159
+.4byte sRegicePose160
+.4byte sRegicePose161
+.4byte sRegicePose162
+.4byte sRegicePose163
+.4byte sRegicePose164
+.4byte sRegicePose165
+.4byte sRegicePose166
+.4byte sRegicePose167
+.4byte sRegicePose168
+.4byte sRegicePose169
+.4byte sRegicePose170
+.4byte sRegicePose171
+.4byte sRegicePose172
+.4byte sRegicePose173
+.4byte sRegicePose174
+.4byte sRegicePose175
+.4byte sRegicePose176
+.4byte sRegicePose177
+.4byte sRegicePose178
+.4byte sRegicePose179
+.4byte sRegicePose180
+.4byte sRegicePose181
+.4byte sRegicePose182
+.4byte sRegicePose183
+.4byte sRegicePose184
+.4byte sRegicePose185
+.4byte sRegicePose186
+.4byte sRegicePose187
+.4byte sRegicePose188
+.4byte sRegicePose189
+.4byte sRegicePose190
+.4byte sRegicePose191
+.4byte sRegicePose192
+.4byte sRegicePose193
+.4byte sRegicePose194
+sAxPositionsRegice:
+.2byte   -1,  -12, 	 -11,  -12, 	   9,  -12, 	  -1,  -11
+.2byte   -1,  -12, 	 -11,  -12, 	   9,  -12, 	  -1,  -11
+.2byte    3,  -13, 	   8,  -12, 	  -9,  -12, 	  -1,  -13
+.2byte    3,  -13, 	   8,  -12, 	  -9,  -12, 	  -1,  -13
+.2byte    5,  -14, 	  -4,  -10, 	  -5,   -7, 	  -1,  -13
+.2byte    5,  -14, 	  -4,  -10, 	  -5,   -7, 	  -1,  -13
+.2byte    4,  -19, 	  -3,  -14, 	   6,  -10, 	   0,  -16
+.2byte    3,  -19, 	  -3,  -14, 	   6,  -10, 	   1,  -16
+.2byte   -1,  -19, 	  10,  -14, 	 -11,  -14, 	  -1,  -15
+.2byte   -1,  -19, 	  10,  -14, 	 -11,  -14, 	  -1,  -15
+.2byte   -6,  -19, 	   1,  -14, 	  -8,  -10, 	  -2,  -16
+.2byte   -5,  -19, 	   1,  -14, 	  -8,  -10, 	  -3,  -16
+.2byte   -7,  -14, 	   2,  -10, 	   3,   -7, 	  -1,  -13
+.2byte   -7,  -14, 	   2,  -10, 	   3,   -7, 	  -1,  -13
+.2byte   -5,  -13, 	 -10,  -12, 	   7,  -12, 	  -1,  -13
+.2byte   -5,  -13, 	 -10,  -12, 	   7,  -12, 	  -1,  -13
+.2byte   -1,  -13, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -10, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte    2,  -13, 	   7,  -14, 	  -9,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   8,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte    3,  -11, 	   8,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte    4,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte    5,  -12, 	  -4,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    5,  -12, 	  -4,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -16, 	  -6,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    4,  -16, 	  -3,  -11, 	   6,   -7, 	   0,  -13
+.2byte    3,  -16, 	  -3,  -11, 	   6,   -7, 	   1,  -13
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -16, 	  10,  -11, 	 -11,  -11, 	  -1,  -12
+.2byte   -1,  -16, 	  10,  -11, 	 -11,  -11, 	  -1,  -12
+.2byte   -3,  -16, 	   4,  -10, 	 -10,   -8, 	   0,  -11
+.2byte   -6,  -16, 	   1,  -11, 	  -8,   -7, 	  -2,  -13
+.2byte   -5,  -16, 	   1,  -11, 	  -8,   -7, 	  -3,  -13
+.2byte   -6,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte   -7,  -12, 	   2,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -7,  -12, 	   2,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -4,  -13, 	  -9,  -14, 	   7,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	 -10,  -10, 	   7,  -10, 	  -1,  -11
+.2byte   -5,  -11, 	 -10,  -10, 	   7,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -10, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	 -11,  -10, 	   9,  -10, 	  -1,   -9
+.2byte    2,  -13, 	   7,  -14, 	  -9,   -7, 	  -1,  -11
+.2byte    3,  -11, 	   8,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte    3,  -11, 	   8,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte    4,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte    5,  -12, 	  -4,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    5,  -12, 	  -4,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -16, 	  -6,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    4,  -16, 	  -3,  -11, 	   6,   -7, 	   0,  -13
+.2byte    3,  -16, 	  -3,  -11, 	   6,   -7, 	   1,  -13
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -16, 	  10,  -11, 	 -11,  -11, 	  -1,  -12
+.2byte   -1,  -16, 	  10,  -11, 	 -11,  -11, 	  -1,  -12
+.2byte   -3,  -16, 	   4,  -10, 	 -10,   -8, 	   0,  -11
+.2byte   -6,  -16, 	   1,  -11, 	  -8,   -7, 	  -2,  -13
+.2byte   -5,  -16, 	   1,  -11, 	  -8,   -7, 	  -3,  -13
+.2byte   -6,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte   -7,  -12, 	   2,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -7,  -12, 	   2,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -4,  -13, 	  -9,  -14, 	   7,   -7, 	  -1,  -11
+.2byte   -5,  -11, 	 -10,  -10, 	   7,  -10, 	  -1,  -11
+.2byte   -5,  -11, 	 -10,  -10, 	   7,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	 -11,  -12, 	  10,  -12, 	  -1,  -10
+.2byte    2,  -13, 	   7,  -14, 	  -9,   -7, 	  -1,  -11
+.2byte    2,  -13, 	   8,  -13, 	  -4,   -8, 	  -2,  -10
+.2byte    4,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte    4,  -14, 	   7,  -16, 	   6,  -11, 	  -1,   -9
+.2byte    1,  -16, 	  -6,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    1,  -16, 	  -1,  -19, 	   9,  -15, 	  -3,  -11
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -16, 	  -9,  -16, 	  -1,  -10
+.2byte   -3,  -16, 	   4,  -10, 	 -10,   -8, 	   0,  -11
+.2byte   -3,  -16, 	  -1,  -19, 	 -11,  -15, 	   1,  -11
+.2byte   -6,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte   -6,  -14, 	  -9,  -16, 	  -8,  -11, 	  -1,   -9
+.2byte   -4,  -13, 	  -9,  -14, 	   7,   -7, 	  -1,  -11
+.2byte   -4,  -13, 	 -10,  -13, 	   2,   -8, 	   0,  -10
+.2byte   -1,  -13, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	 -11,  -12, 	  10,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	 -13,  -19, 	  10,  -18, 	  -1,  -11
+.2byte    2,  -13, 	   7,  -14, 	  -9,   -7, 	  -1,  -11
+.2byte    2,  -13, 	   8,  -13, 	  -4,   -8, 	  -2,  -10
+.2byte    2,  -13, 	   6,  -23, 	 -10,  -17, 	  -2,  -10
+.2byte    4,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte    4,  -14, 	   7,  -16, 	   6,  -11, 	  -1,   -9
+.2byte    4,  -14, 	  -1,  -20, 	  -1,  -18, 	  -1,  -10
+.2byte    1,  -16, 	  -6,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    1,  -16, 	  -1,  -19, 	   9,  -15, 	  -3,  -11
+.2byte    1,  -16, 	  -7,  -20, 	   7,  -17, 	  -3,  -11
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -16, 	  -9,  -16, 	  -1,  -10
+.2byte   -1,  -13, 	  11,  -18, 	 -12,  -18, 	  -1,   -9
+.2byte   -3,  -16, 	   4,  -10, 	 -10,   -8, 	   0,  -11
+.2byte   -3,  -16, 	  -1,  -19, 	 -11,  -15, 	   1,  -11
+.2byte   -3,  -16, 	   5,  -20, 	  -9,  -17, 	   1,  -11
+.2byte   -6,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte   -6,  -14, 	  -9,  -16, 	  -8,  -11, 	  -1,   -9
+.2byte   -6,  -14, 	  -1,  -20, 	  -1,  -18, 	  -1,  -10
+.2byte   -4,  -13, 	  -9,  -14, 	   7,   -7, 	  -1,  -11
+.2byte   -4,  -13, 	 -10,  -13, 	   2,   -8, 	   0,  -10
+.2byte   -4,  -13, 	  -8,  -23, 	   8,  -17, 	   0,  -10
+.2byte   -5,   -7, 	 -10,   -7, 	  10,   -3, 	   0,   -7
+.2byte   -5,   -6, 	 -10,   -7, 	  10,   -2, 	   0,   -6
+.2byte    0,  -18, 	 -11,  -15, 	  12,  -10, 	   0,  -15
+.2byte    2,  -17, 	   9,  -17, 	 -12,   -5, 	  -1,  -14
+.2byte    2,  -20, 	   6,  -21, 	   2,   -9, 	  -1,  -15
+.2byte    0,  -20, 	 -14,  -19, 	  11,  -13, 	  -1,  -13
+.2byte    0,  -19, 	  13,  -17, 	 -12,  -14, 	   0,  -13
+.2byte   -1,  -20, 	  13,  -19, 	 -12,  -13, 	   0,  -13
+.2byte   -3,  -20, 	  -7,  -21, 	  -3,   -9, 	   0,  -15
+.2byte   -3,  -17, 	 -10,  -17, 	  11,   -5, 	   0,  -14
+.2byte   -1,  -13, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	 -11,  -10, 	  10,  -10, 	  -1,  -10
+.2byte   -1,  -13, 	 -11,  -10, 	  10,  -10, 	  -1,  -10
+.2byte    2,  -13, 	   7,  -14, 	  -9,   -7, 	  -1,  -11
+.2byte    2,  -13, 	   6,  -14, 	  -9,   -6, 	  -1,  -11
+.2byte    2,  -13, 	   6,  -14, 	  -9,   -6, 	  -1,  -11
+.2byte    4,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte    4,  -14, 	  -1,  -10, 	  -1,   -3, 	  -1,  -11
+.2byte    4,  -14, 	  -1,  -10, 	  -1,   -3, 	  -1,  -11
+.2byte    1,  -16, 	  -6,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    1,  -15, 	  -7,  -10, 	   8,   -7, 	  -2,  -11
+.2byte    2,  -16, 	  -7,  -10, 	   8,   -7, 	  -2,  -11
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	  10,  -11, 	 -11,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	  10,  -11, 	 -11,  -11, 	  -1,  -10
+.2byte   -3,  -16, 	   4,  -10, 	 -10,   -8, 	   0,  -11
+.2byte   -3,  -15, 	   5,  -10, 	 -10,   -7, 	   0,  -11
+.2byte   -4,  -16, 	   5,  -10, 	 -10,   -7, 	   0,  -11
+.2byte   -6,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte   -6,  -14, 	  -1,  -10, 	  -1,   -3, 	  -1,  -11
+.2byte   -6,  -14, 	  -1,  -10, 	  -1,   -3, 	  -1,  -11
+.2byte   -4,  -13, 	  -9,  -14, 	   7,   -7, 	  -1,  -11
+.2byte   -4,  -13, 	  -8,  -14, 	   7,   -6, 	  -1,  -11
+.2byte   -4,  -13, 	  -8,  -14, 	   7,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	 -11,  -12, 	  10,  -12, 	  -1,  -10
+.2byte   -4,  -13, 	 -10,  -13, 	   2,   -8, 	   0,  -10
+.2byte   -6,  -14, 	  -9,  -16, 	  -8,  -11, 	  -1,   -9
+.2byte   -3,  -16, 	  -1,  -19, 	 -11,  -15, 	   1,  -11
+.2byte   -1,  -15, 	   8,  -16, 	  -9,  -16, 	  -1,  -10
+.2byte    1,  -16, 	  -1,  -19, 	   9,  -15, 	  -3,  -11
+.2byte    4,  -14, 	   7,  -16, 	   6,  -11, 	  -1,   -9
+.2byte    2,  -13, 	   8,  -13, 	  -4,   -8, 	  -2,  -10
+.2byte   -1,  -13, 	 -13,  -19, 	  10,  -18, 	  -1,  -11
+.2byte    2,  -13, 	   6,  -23, 	 -10,  -17, 	  -2,  -10
+.2byte    4,  -14, 	  -1,  -20, 	  -1,  -18, 	  -1,  -10
+.2byte    1,  -16, 	  -7,  -20, 	   7,  -17, 	  -3,  -11
+.2byte   -1,  -13, 	  11,  -18, 	 -12,  -18, 	  -1,   -9
+.2byte   -3,  -16, 	   5,  -20, 	  -9,  -17, 	   1,  -11
+.2byte   -6,  -14, 	  -1,  -20, 	  -1,  -18, 	  -1,  -10
+.2byte   -4,  -13, 	  -8,  -23, 	   8,  -17, 	   0,  -10
+.2byte   -1,  -13, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	 -13,  -19, 	  10,  -18, 	  -1,  -11
+.2byte   -1,  -11, 	 -11,  -11, 	   9,  -11, 	  -1,  -10
+.2byte    2,  -13, 	   7,  -14, 	  -9,   -7, 	  -1,  -11
+.2byte    2,  -13, 	   6,  -23, 	 -10,  -17, 	  -2,  -10
+.2byte    3,  -11, 	   8,  -10, 	  -9,  -10, 	  -1,  -11
+.2byte    4,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte    4,  -14, 	  -1,  -20, 	  -1,  -18, 	  -1,  -10
+.2byte    5,  -12, 	  -4,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -16, 	  -6,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    1,  -16, 	  -7,  -20, 	   7,  -17, 	  -3,  -11
+.2byte    3,  -16, 	  -3,  -11, 	   6,   -7, 	   1,  -13
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -1,  -13, 	  11,  -18, 	 -12,  -18, 	  -1,   -9
+.2byte   -1,  -16, 	  10,  -11, 	 -11,  -11, 	  -1,  -12
+.2byte   -3,  -16, 	   4,  -10, 	 -10,   -8, 	   0,  -11
+.2byte   -3,  -16, 	   5,  -20, 	  -9,  -17, 	   1,  -11
+.2byte   -5,  -16, 	   1,  -11, 	  -8,   -7, 	  -3,  -13
+.2byte   -6,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte   -6,  -14, 	  -1,  -20, 	  -1,  -18, 	  -1,  -10
+.2byte   -7,  -12, 	   2,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -4,  -13, 	  -9,  -14, 	   7,   -7, 	  -1,  -11
+.2byte   -4,  -13, 	  -8,  -23, 	   8,  -17, 	   0,  -10
+.2byte   -5,  -11, 	 -10,  -10, 	   7,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	 -11,  -12, 	  10,  -12, 	  -1,  -10
+.2byte   -4,  -13, 	 -10,  -13, 	   2,   -8, 	   0,  -10
+.2byte   -6,  -14, 	  -9,  -16, 	  -8,  -11, 	  -1,   -9
+.2byte   -3,  -16, 	  -1,  -19, 	 -11,  -15, 	   1,  -11
+.2byte   -1,  -15, 	   8,  -16, 	  -9,  -16, 	  -1,  -10
+.2byte    1,  -16, 	  -1,  -19, 	   9,  -15, 	  -3,  -11
+.2byte    4,  -14, 	   7,  -16, 	   6,  -11, 	  -1,   -9
+.2byte    2,  -13, 	   8,  -13, 	  -4,   -8, 	  -2,  -10
+.2byte   -1,  -13, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -4,  -13, 	  -9,  -14, 	   7,   -7, 	  -1,  -11
+.2byte   -6,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte   -3,  -16, 	   4,  -10, 	 -10,   -8, 	   0,  -11
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte    1,  -16, 	  -6,  -10, 	   8,   -8, 	  -2,  -11
+.2byte    4,  -14, 	  -1,   -8, 	  -1,   -3, 	  -1,  -12
+.2byte    2,  -13, 	   7,  -14, 	  -9,   -7, 	  -1,  -11
+sRegiceAnimTable1:
+.4byte sRegiceAnims_1_1
+.4byte sRegiceAnims_1_2
+.4byte sRegiceAnims_1_3
+.4byte sRegiceAnims_1_4
+.4byte sRegiceAnims_1_5
+.4byte sRegiceAnims_1_6
+.4byte sRegiceAnims_1_7
+.4byte sRegiceAnims_1_8
+sRegiceAnimTable2:
+.4byte sRegiceAnims_2_1
+.4byte sRegiceAnims_2_2
+.4byte sRegiceAnims_2_3
+.4byte sRegiceAnims_2_4
+.4byte sRegiceAnims_2_5
+.4byte sRegiceAnims_2_6
+.4byte sRegiceAnims_2_7
+.4byte sRegiceAnims_2_8
+sRegiceAnimTable3:
+.4byte sRegiceAnims_3_1
+.4byte sRegiceAnims_3_2
+.4byte sRegiceAnims_3_3
+.4byte sRegiceAnims_3_4
+.4byte sRegiceAnims_3_5
+.4byte sRegiceAnims_3_6
+.4byte sRegiceAnims_3_7
+.4byte sRegiceAnims_3_8
+sRegiceAnimTable4:
+.4byte sRegiceAnims_4_1
+.4byte sRegiceAnims_4_2
+.4byte sRegiceAnims_4_3
+.4byte sRegiceAnims_4_4
+.4byte sRegiceAnims_4_5
+.4byte sRegiceAnims_4_6
+.4byte sRegiceAnims_4_7
+.4byte sRegiceAnims_4_8
+sRegiceAnimTable5:
+.4byte sRegiceAnims_5_1
+.4byte sRegiceAnims_5_2
+.4byte sRegiceAnims_5_3
+.4byte sRegiceAnims_5_4
+.4byte sRegiceAnims_5_5
+.4byte sRegiceAnims_5_6
+.4byte sRegiceAnims_5_7
+.4byte sRegiceAnims_5_8
+sRegiceAnimTable6:
+.4byte sRegiceAnims_6_1
+.4byte sRegiceAnims_6_1
+.4byte sRegiceAnims_6_1
+.4byte sRegiceAnims_6_1
+.4byte sRegiceAnims_6_1
+.4byte sRegiceAnims_6_1
+.4byte sRegiceAnims_6_1
+.4byte sRegiceAnims_6_1
+sRegiceAnimTable7:
+.4byte sRegiceAnims_7_1
+.4byte sRegiceAnims_7_2
+.4byte sRegiceAnims_7_3
+.4byte sRegiceAnims_7_4
+.4byte sRegiceAnims_7_5
+.4byte sRegiceAnims_7_6
+.4byte sRegiceAnims_7_7
+.4byte sRegiceAnims_7_8
+sRegiceAnimTable8:
+.4byte sRegiceAnims_8_1
+.4byte sRegiceAnims_8_2
+.4byte sRegiceAnims_8_3
+.4byte sRegiceAnims_8_4
+.4byte sRegiceAnims_8_5
+.4byte sRegiceAnims_8_6
+.4byte sRegiceAnims_8_7
+.4byte sRegiceAnims_8_8
+sRegiceAnimTable9:
+.4byte sRegiceAnims_9_1
+.4byte sRegiceAnims_9_2
+.4byte sRegiceAnims_9_3
+.4byte sRegiceAnims_9_4
+.4byte sRegiceAnims_9_5
+.4byte sRegiceAnims_9_6
+.4byte sRegiceAnims_9_7
+.4byte sRegiceAnims_9_8
+sRegiceAnimTable10:
+.4byte sRegiceAnims_10_1
+.4byte sRegiceAnims_10_2
+.4byte sRegiceAnims_10_3
+.4byte sRegiceAnims_10_4
+.4byte sRegiceAnims_10_5
+.4byte sRegiceAnims_10_6
+.4byte sRegiceAnims_10_7
+.4byte sRegiceAnims_10_8
+sRegiceAnimTable11:
+.4byte sRegiceAnims_11_1
+.4byte sRegiceAnims_11_2
+.4byte sRegiceAnims_11_3
+.4byte sRegiceAnims_11_4
+.4byte sRegiceAnims_11_5
+.4byte sRegiceAnims_11_6
+.4byte sRegiceAnims_11_7
+.4byte sRegiceAnims_11_8
+sRegiceAnimTable12:
+.4byte sRegiceAnims_12_1
+.4byte sRegiceAnims_12_2
+.4byte sRegiceAnims_12_3
+.4byte sRegiceAnims_12_4
+.4byte sRegiceAnims_12_5
+.4byte sRegiceAnims_12_6
+.4byte sRegiceAnims_12_7
+.4byte sRegiceAnims_12_8
+sRegiceAnimTable13:
+.4byte sRegiceAnims_13_1
+.4byte sRegiceAnims_13_2
+.4byte sRegiceAnims_13_3
+.4byte sRegiceAnims_13_4
+.4byte sRegiceAnims_13_5
+.4byte sRegiceAnims_13_6
+.4byte sRegiceAnims_13_7
+.4byte sRegiceAnims_13_8
+sAxAnimationsRegice:
+.4byte sRegiceAnimTable1
+.4byte sRegiceAnimTable2
+.4byte sRegiceAnimTable3
+.4byte sRegiceAnimTable4
+.4byte sRegiceAnimTable5
+.4byte sRegiceAnimTable6
+.4byte sRegiceAnimTable7
+.4byte sRegiceAnimTable8
+.4byte sRegiceAnimTable9
+.4byte sRegiceAnimTable10
+.4byte sRegiceAnimTable11
+.4byte sRegiceAnimTable12
+.4byte sRegiceAnimTable13
+sAxSpritesRegice:
+.4byte sRegiceSprites1
+.4byte sRegiceSprites2
+.4byte sRegiceSprites3
+.4byte sRegiceSprites4
+.4byte sRegiceSprites5
+.4byte sRegiceSprites6
+.4byte sRegiceSprites7
+.4byte sRegiceSprites8
+.4byte sRegiceSprites9
+.4byte sRegiceSprites10
+.4byte sRegiceSprites11
+.4byte sRegiceSprites12
+.4byte sRegiceSprites13
+.4byte sRegiceSprites14
+.4byte sRegiceSprites15
+.4byte sRegiceSprites16
+.4byte sRegiceSprites17
+.4byte sRegiceSprites18
+.4byte sRegiceSprites19
+.4byte sRegiceSprites20
+.4byte sRegiceSprites21
+.4byte sRegiceSprites22
+.4byte sRegiceSprites23
+.4byte sRegiceSprites24
+.4byte sRegiceSprites25
+.4byte sRegiceSprites26
+.4byte sRegiceSprites27
+.4byte sRegiceSprites28
+.4byte sRegiceSprites29
+.4byte sRegiceSprites30
+.4byte sRegiceSprites31
+.4byte sRegiceSprites32
+.4byte sRegiceSprites33
+.4byte sRegiceSprites34
+.4byte sRegiceSprites35
+.4byte sRegiceSprites36
+.4byte sRegiceSprites37
+.4byte sRegiceSprites38
+.4byte sRegiceSprites39
+.4byte sRegiceSprites40
+.4byte sRegiceSprites41
+.4byte sRegiceSprites42
+.4byte sRegiceSprites43
+.4byte sRegiceSprites44
+.4byte sRegiceSprites45
+.4byte sRegiceSprites46
+.4byte sRegiceSprites47
+.4byte sRegiceSprites48
+.4byte sRegiceSprites49
+.4byte sRegiceSprites50
+.4byte sRegiceSprites51
+.4byte sRegiceSprites52
+.4byte sRegiceSprites53
+.4byte sRegiceSprites54
+.4byte sRegiceSprites55
+.4byte sRegiceSprites56
+.4byte sRegiceSprites57
+.4byte sRegiceSprites58
+.4byte sRegiceSprites59
+.4byte sRegiceSprites60
+sAxMainRegice:
+ax_main sAxPosesRegice, sAxAnimationsRegice, 13, sAxSpritesRegice, sAxPositionsRegice

--- a/data/ax/regirock.inc
+++ b/data/ax/regirock.inc
@@ -1,0 +1,3002 @@
+.global gAxRegirock
+gAxRegirock:
+ax_siro sAxMainRegirock
+sRegirockPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose4:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose5:
+ax_pose 4, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose6:
+ax_pose 5, 0x81e4, 0x40f8, 0x6c00
+ax_pose 6, 0x81e4, 0x8100, 0x6c04
+ax_pose 7, 0x81ec, 0x00f0, 0x6c0c
+ax_pose 8, 0x0204, 0x00fb, 0x6c0e
+ax_pose_terminator
+sRegirockPose7:
+ax_pose 9, 0x81e4, 0x40f4, 0x6c00
+ax_pose 10, 0x81e4, 0x80fc, 0x6c04
+ax_pose_terminator
+sRegirockPose8:
+ax_pose 11, 0x81e4, 0x80fc, 0x6c00
+ax_pose 12, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose9:
+ax_pose 13, 0x81e4, 0x80fc, 0x6c00
+ax_pose 14, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose10:
+ax_pose 15, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose11:
+ax_pose 16, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose12:
+ax_pose 17, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose13:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose14:
+ax_pose 19, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose15:
+ax_pose 20, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose16:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose17:
+ax_pose 22, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose18:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose19:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose20:
+ax_pose 25, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose21:
+ax_pose 26, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose22:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose23:
+ax_pose 28, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose24:
+ax_pose 29, 0x81e4, 0x80f0, 0x6c00
+ax_pose 30, 0x81e4, 0x4100, 0x6c08
+ax_pose 31, 0x81f4, 0x0108, 0x6c0c
+ax_pose 32, 0x01ec, 0x0108, 0x6c0e
+ax_pose 33, 0x0204, 0x00fc, 0x6c0f
+ax_pose_terminator
+sRegirockPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose28:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose29:
+ax_pose 4, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose30:
+ax_pose 5, 0x81e4, 0x40f8, 0x6c00
+ax_pose 6, 0x81e4, 0x8100, 0x6c04
+ax_pose 7, 0x81ec, 0x00f0, 0x6c0c
+ax_pose 8, 0x0204, 0x00fb, 0x6c0e
+ax_pose_terminator
+sRegirockPose31:
+ax_pose 9, 0x81e4, 0x40f4, 0x6c00
+ax_pose 10, 0x81e4, 0x80fc, 0x6c04
+ax_pose_terminator
+sRegirockPose32:
+ax_pose 11, 0x81e4, 0x80fc, 0x6c00
+ax_pose 12, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose33:
+ax_pose 13, 0x81e4, 0x80fc, 0x6c00
+ax_pose 14, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose34:
+ax_pose 15, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose35:
+ax_pose 16, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose36:
+ax_pose 17, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose37:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose38:
+ax_pose 19, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose39:
+ax_pose 20, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose40:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose41:
+ax_pose 22, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose42:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose43:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose44:
+ax_pose 25, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose45:
+ax_pose 26, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose46:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose47:
+ax_pose 28, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose48:
+ax_pose 29, 0x81e4, 0x80f0, 0x6c00
+ax_pose 30, 0x81e4, 0x4100, 0x6c08
+ax_pose 31, 0x81f4, 0x0108, 0x6c0c
+ax_pose 32, 0x01ec, 0x0108, 0x6c0e
+ax_pose 33, 0x0204, 0x00fc, 0x6c0f
+ax_pose_terminator
+sRegirockPose49:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose50:
+ax_pose 1, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose51:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose52:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose53:
+ax_pose 4, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose54:
+ax_pose 5, 0x81e4, 0x40f8, 0x6c00
+ax_pose 6, 0x81e4, 0x8100, 0x6c04
+ax_pose 7, 0x81ec, 0x00f0, 0x6c0c
+ax_pose 8, 0x0204, 0x00fb, 0x6c0e
+ax_pose_terminator
+sRegirockPose55:
+ax_pose 9, 0x81e4, 0x40f4, 0x6c00
+ax_pose 10, 0x81e4, 0x80fc, 0x6c04
+ax_pose_terminator
+sRegirockPose56:
+ax_pose 11, 0x81e4, 0x80fc, 0x6c00
+ax_pose 12, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose57:
+ax_pose 13, 0x81e4, 0x80fc, 0x6c00
+ax_pose 14, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose58:
+ax_pose 15, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose59:
+ax_pose 16, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose60:
+ax_pose 17, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose61:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose62:
+ax_pose 19, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose63:
+ax_pose 20, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose64:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose65:
+ax_pose 22, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose66:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose67:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose68:
+ax_pose 25, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose69:
+ax_pose 26, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose70:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose71:
+ax_pose 28, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose72:
+ax_pose 29, 0x81e4, 0x80f0, 0x6c00
+ax_pose 30, 0x81e4, 0x4100, 0x6c08
+ax_pose 31, 0x81f4, 0x0108, 0x6c0c
+ax_pose 32, 0x01ec, 0x0108, 0x6c0e
+ax_pose 33, 0x0204, 0x00fc, 0x6c0f
+ax_pose_terminator
+sRegirockPose73:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose74:
+ax_pose 1, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose75:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose76:
+ax_pose 34, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose77:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose78:
+ax_pose 4, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose79:
+ax_pose 5, 0x81e4, 0x40f8, 0x6c00
+ax_pose 6, 0x81e4, 0x8100, 0x6c04
+ax_pose 7, 0x81ec, 0x00f0, 0x6c0c
+ax_pose 8, 0x0204, 0x00fb, 0x6c0e
+ax_pose_terminator
+sRegirockPose80:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose81:
+ax_pose 9, 0x81e4, 0x40f4, 0x6c00
+ax_pose 10, 0x81e4, 0x80fc, 0x6c04
+ax_pose_terminator
+sRegirockPose82:
+ax_pose 11, 0x81e4, 0x80fc, 0x6c00
+ax_pose 12, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose83:
+ax_pose 13, 0x81e4, 0x80fc, 0x6c00
+ax_pose 14, 0x81e4, 0x40f4, 0x6c08
+ax_pose_terminator
+sRegirockPose84:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose85:
+ax_pose 15, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose86:
+ax_pose 16, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose87:
+ax_pose 17, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose88:
+ax_pose 37, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose89:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose90:
+ax_pose 19, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose91:
+ax_pose 20, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose92:
+ax_pose 38, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose93:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose94:
+ax_pose 22, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose95:
+ax_pose 23, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose96:
+ax_pose 39, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sRegirockPose97:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose98:
+ax_pose 25, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose99:
+ax_pose 26, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose100:
+ax_pose 36, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose101:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose102:
+ax_pose 28, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose103:
+ax_pose 29, 0x81e4, 0x80f0, 0x6c00
+ax_pose 30, 0x81e4, 0x4100, 0x6c08
+ax_pose 31, 0x81f4, 0x0108, 0x6c0c
+ax_pose 32, 0x01ec, 0x0108, 0x6c0e
+ax_pose 33, 0x0204, 0x00fc, 0x6c0f
+ax_pose_terminator
+sRegirockPose104:
+ax_pose 40, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sRegirockPose105:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose106:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose107:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose108:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose109:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose110:
+ax_pose 21, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sRegirockPose111:
+ax_pose 24, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sRegirockPose112:
+ax_pose 27, 0x01e4, 0x90f1, 0x6c00
+ax_pose_terminator
+sRegirockPose113:
+ax_pose 41, 0x41e3, 0x80f0, 0x6c00
+ax_pose 42, 0x01f3, 0x4100, 0x6c08
+ax_pose 43, 0x41f3, 0x00f0, 0x6c0c
+ax_pose 44, 0x01fb, 0x00f8, 0x6c0e
+ax_pose 45, 0x01e3, 0x0110, 0x6c0f
+ax_pose_terminator
+sRegirockPose114:
+ax_pose 46, 0x81e1, 0x80f1, 0x6c00
+ax_pose 47, 0x81e1, 0x4101, 0x6c08
+ax_pose 48, 0x81e1, 0x0109, 0x6c0c
+ax_pose 49, 0x01f1, 0x0109, 0x6c0e
+ax_pose 50, 0x0201, 0x00f9, 0x6c0f
+ax_pose_terminator
+sRegirockPose115:
+ax_pose 51, 0x81e1, 0x80fc, 0x6c00
+ax_pose 52, 0x81e1, 0x40f4, 0x6c08
+ax_pose 53, 0x0201, 0x00fc, 0x6c0c
+ax_pose_terminator
+sRegirockPose116:
+ax_pose 54, 0x41e5, 0x80ef, 0x6c00
+ax_pose 55, 0x01dd, 0x00f6, 0x6c08
+ax_pose 56, 0x81f5, 0x00f7, 0x6c09
+ax_pose 57, 0x01f5, 0x40ff, 0x6c0b
+ax_pose_terminator
+sRegirockPose117:
+ax_pose 58, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose118:
+ax_pose 59, 0x81e5, 0x80f2, 0x6c00
+ax_pose 60, 0x01e5, 0x4102, 0x6c08
+ax_pose 61, 0x81f5, 0x0102, 0x6c0c
+ax_pose 62, 0x01dd, 0x0103, 0x6c0e
+ax_pose_terminator
+sRegirockPose119:
+ax_pose 63, 0x81e1, 0x80f9, 0x6c00
+ax_pose 64, 0x81e9, 0x0109, 0x6c08
+ax_pose 65, 0x0201, 0x00fc, 0x6c0a
+ax_pose_terminator
+sRegirockPose120:
+ax_pose 66, 0x41e1, 0x80f0, 0x6c00
+ax_pose 67, 0x01f1, 0x4100, 0x6c08
+ax_pose 68, 0x41f1, 0x00f0, 0x6c0c
+ax_pose 69, 0x01f9, 0x00f8, 0x6c0e
+ax_pose 70, 0x0201, 0x0100, 0x6c0f
+ax_pose_terminator
+sRegirockPose121:
+ax_pose 71, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose122:
+ax_pose 72, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose123:
+ax_pose 73, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sRegirockPose124:
+ax_pose 74, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose125:
+ax_pose 75, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sRegirockPose126:
+ax_pose 76, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose127:
+ax_pose 77, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose128:
+ax_pose 78, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose129:
+ax_pose 79, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose130:
+ax_pose 80, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose131:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose132:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose133:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose134:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose135:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose136:
+ax_pose 15, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose137:
+ax_pose 81, 0x01e4, 0x80ec, 0x6c00
+ax_pose_terminator
+sRegirockPose138:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose139:
+ax_pose 34, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose140:
+ax_pose 40, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sRegirockPose141:
+ax_pose 36, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose142:
+ax_pose 39, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sRegirockPose143:
+ax_pose 38, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose144:
+ax_pose 37, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose145:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose146:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose147:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose148:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose149:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose150:
+ax_pose 37, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose151:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose152:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose153:
+ax_pose 82, 0x41f5, 0x80f0, 0x6c00
+ax_pose 83, 0x41ed, 0x40f0, 0x6c08
+ax_pose 84, 0x01f5, 0x0110, 0x6c0c
+ax_pose_terminator
+sRegirockPose154:
+ax_pose 37, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose155:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose156:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose157:
+ax_pose 39, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sRegirockPose158:
+ax_pose 82, 0x41f5, 0x80f0, 0x6c00
+ax_pose 83, 0x41ed, 0x40f0, 0x6c08
+ax_pose 84, 0x01f5, 0x0110, 0x6c0c
+ax_pose_terminator
+sRegirockPose159:
+ax_pose 37, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose160:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose161:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose162:
+ax_pose 36, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose163:
+ax_pose 39, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sRegirockPose164:
+ax_pose 82, 0x41f5, 0x80f0, 0x6c00
+ax_pose 83, 0x41ed, 0x40f0, 0x6c08
+ax_pose 84, 0x01f5, 0x0110, 0x6c0c
+ax_pose_terminator
+sRegirockPose165:
+ax_pose 37, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose166:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose167:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose168:
+ax_pose 40, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sRegirockPose169:
+ax_pose 36, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose170:
+ax_pose 39, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sRegirockPose171:
+ax_pose 82, 0x41f5, 0x80f0, 0x6c00
+ax_pose 83, 0x41ed, 0x40f0, 0x6c08
+ax_pose 84, 0x01f5, 0x0110, 0x6c0c
+ax_pose_terminator
+sRegirockPose172:
+ax_pose 37, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose173:
+ax_pose 36, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRegirockPose174:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose175:
+ax_pose 41, 0x41e3, 0x80f0, 0x6c00
+ax_pose 42, 0x01f3, 0x4100, 0x6c08
+ax_pose 43, 0x41f3, 0x00f0, 0x6c0c
+ax_pose 44, 0x01fb, 0x00f8, 0x6c0e
+ax_pose 45, 0x01e3, 0x0110, 0x6c0f
+ax_pose_terminator
+sRegirockPose176:
+ax_pose 46, 0x81e1, 0x80f1, 0x6c00
+ax_pose 47, 0x81e1, 0x4101, 0x6c08
+ax_pose 48, 0x81e1, 0x0109, 0x6c0c
+ax_pose 49, 0x01f1, 0x0109, 0x6c0e
+ax_pose 50, 0x0201, 0x00f9, 0x6c0f
+ax_pose_terminator
+sRegirockPose177:
+ax_pose 51, 0x81e1, 0x80fc, 0x6c00
+ax_pose 52, 0x81e1, 0x40f4, 0x6c08
+ax_pose 53, 0x0201, 0x00fc, 0x6c0c
+ax_pose_terminator
+sRegirockPose178:
+ax_pose 54, 0x41e5, 0x80ef, 0x6c00
+ax_pose 55, 0x01dd, 0x00f6, 0x6c08
+ax_pose 56, 0x81f5, 0x00f7, 0x6c09
+ax_pose 57, 0x01f5, 0x40ff, 0x6c0b
+ax_pose_terminator
+sRegirockPose179:
+ax_pose 58, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose180:
+ax_pose 59, 0x81e5, 0x80f2, 0x6c00
+ax_pose 60, 0x01e5, 0x4102, 0x6c08
+ax_pose 61, 0x81f5, 0x0102, 0x6c0c
+ax_pose 62, 0x01dd, 0x0103, 0x6c0e
+ax_pose_terminator
+sRegirockPose181:
+ax_pose 63, 0x81e1, 0x80f9, 0x6c00
+ax_pose 64, 0x81e9, 0x0109, 0x6c08
+ax_pose 65, 0x0201, 0x00fc, 0x6c0a
+ax_pose_terminator
+sRegirockPose182:
+ax_pose 66, 0x41e1, 0x80f0, 0x6c00
+ax_pose 67, 0x01f1, 0x4100, 0x6c08
+ax_pose 68, 0x41f1, 0x00f0, 0x6c0c
+ax_pose 69, 0x01f9, 0x00f8, 0x6c0e
+ax_pose 70, 0x0201, 0x0100, 0x6c0f
+ax_pose_terminator
+sRegirockPose183:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose184:
+ax_pose 41, 0x41e2, 0x80f0, 0x6c00
+ax_pose 42, 0x01f2, 0x4100, 0x6c08
+ax_pose 43, 0x41f2, 0x00f0, 0x6c0c
+ax_pose 44, 0x01fa, 0x00f8, 0x6c0e
+ax_pose 45, 0x01e2, 0x0110, 0x6c0f
+ax_pose_terminator
+sRegirockPose185:
+ax_pose 34, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose186:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose187:
+ax_pose 46, 0x81e0, 0x80f1, 0x6c00
+ax_pose 47, 0x81e0, 0x4101, 0x6c08
+ax_pose 48, 0x81e0, 0x0109, 0x6c0c
+ax_pose 49, 0x01f0, 0x0109, 0x6c0e
+ax_pose 50, 0x0200, 0x00f9, 0x6c0f
+ax_pose_terminator
+sRegirockPose188:
+ax_pose 35, 0x01ea, 0x80f2, 0x6c00
+ax_pose_terminator
+sRegirockPose189:
+ax_pose 9, 0x81e4, 0x40f4, 0x6c00
+ax_pose 10, 0x81e4, 0x80fc, 0x6c04
+ax_pose_terminator
+sRegirockPose190:
+ax_pose 51, 0x81e1, 0x80fc, 0x6c00
+ax_pose 53, 0x0201, 0x00fc, 0x6c08
+ax_pose 52, 0x81e1, 0x40f4, 0x6c09
+ax_pose_terminator
+sRegirockPose191:
+ax_pose 36, 0x01e7, 0x90f2, 0x6c00
+ax_pose_terminator
+sRegirockPose192:
+ax_pose 15, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose193:
+ax_pose 54, 0x41e3, 0x80ef, 0x6c00
+ax_pose 55, 0x01db, 0x00f6, 0x6c08
+ax_pose 56, 0x81f3, 0x00f7, 0x6c09
+ax_pose 57, 0x01f3, 0x40ff, 0x6c0b
+ax_pose_terminator
+sRegirockPose194:
+ax_pose 37, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose195:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose196:
+ax_pose 58, 0x01e1, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose197:
+ax_pose 38, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose198:
+ax_pose 21, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose199:
+ax_pose 59, 0x81e4, 0x80f2, 0x6c00
+ax_pose 60, 0x01e4, 0x4102, 0x6c08
+ax_pose 61, 0x81f4, 0x0102, 0x6c0c
+ax_pose 62, 0x01dc, 0x0103, 0x6c0e
+ax_pose_terminator
+sRegirockPose200:
+ax_pose 39, 0x01e4, 0x80ed, 0x6c00
+ax_pose_terminator
+sRegirockPose201:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose202:
+ax_pose 63, 0x81e0, 0x80f9, 0x6c00
+ax_pose 64, 0x81e8, 0x0109, 0x6c08
+ax_pose 65, 0x0200, 0x00fc, 0x6c0a
+ax_pose_terminator
+sRegirockPose203:
+ax_pose 36, 0x01e7, 0x80ef, 0x6c00
+ax_pose_terminator
+sRegirockPose204:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose205:
+ax_pose 66, 0x41e0, 0x80f0, 0x6c00
+ax_pose 67, 0x01f0, 0x4100, 0x6c08
+ax_pose 68, 0x41f0, 0x00f0, 0x6c0c
+ax_pose 69, 0x01f8, 0x00f8, 0x6c0e
+ax_pose 70, 0x0200, 0x0100, 0x6c0f
+ax_pose_terminator
+sRegirockPose206:
+ax_pose 40, 0x01ea, 0x80ee, 0x6c00
+ax_pose_terminator
+sRegirockPose207:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose208:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose209:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose210:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose211:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose212:
+ax_pose 15, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose213:
+ax_pose 9, 0x81e4, 0x40f4, 0x6c00
+ax_pose 10, 0x81e4, 0x80fc, 0x6c04
+ax_pose_terminator
+sRegirockPose214:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose215:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose216:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose217:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sRegirockPose218:
+ax_pose 21, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose219:
+ax_pose 18, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRegirockPose220:
+ax_pose 15, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRegirockPose221:
+ax_pose 81, 0x01e4, 0x80ec, 0x6c00
+ax_pose_terminator
+sRegirockPose222:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+.align 2
+sRegirockAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 18, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 18, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 18, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 18, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 18, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 18, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 18, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 18, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 18, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 18, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 18, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 18, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 18, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 18, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 18, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 18, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_2_1:
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 4, 0, 45, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 29, 0, 10, 0, 10,
+ax_anim 2, 0, 31, 0, 18, 0, 18,
+ax_anim 2, 1, 31, 1, 18, 1, 18,
+ax_anim 2, 0, 31, 0, 18, 0, 18,
+ax_anim 2, 0, 31, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRegirockAnims_2_2:
+ax_anim 2, 0, 24, -1, -1, -1, -1,
+ax_anim 4, 0, 24, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 32, 10, 10, 10, 10,
+ax_anim 2, 0, 34, 18, 18, 18, 18,
+ax_anim 2, 1, 34, 19, 17, 19, 17,
+ax_anim 2, 0, 34, 18, 18, 18, 18,
+ax_anim 2, 0, 34, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sRegirockAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 4, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 1, 37, 18, 1, 18, 1,
+ax_anim 2, 0, 37, 18, 0, 18, 0,
+ax_anim 2, 0, 37, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sRegirockAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 4, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 6, -5, 6, -5,
+ax_anim 1, 0, 38, 12, -11, 12, -11,
+ax_anim 2, 0, 40, 20, -17, 20, -17,
+ax_anim 2, 1, 40, 21, -16, 21, -16,
+ax_anim 2, 0, 40, 20, -17, 20, -17,
+ax_anim 2, 0, 40, 21, -16, 21, -16,
+ax_anim 2, 0, 33, 8, -6, 8, -6,
+ax_anim_terminator
+sRegirockAnims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 4, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 41, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 1, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sRegirockAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 4, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -6, -5, -6, -5,
+ax_anim 1, 0, 44, -12, -11, -12, -11,
+ax_anim 2, 0, 46, -17, -16, -17, -16,
+ax_anim 2, 1, 46, -18, -15, -18, -15,
+ax_anim 2, 0, 46, -17, -16, -17, -16,
+ax_anim 2, 0, 46, -18, -15, -18, -15,
+ax_anim 2, 0, 39, -8, -6, -8, -6,
+ax_anim_terminator
+sRegirockAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 4, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 47, -10, 0, -10, 0,
+ax_anim 2, 0, 25, -18, 0, -18, 0,
+ax_anim 2, 1, 25, -18, 1, -18, 1,
+ax_anim 2, 0, 25, -18, 0, -18, 0,
+ax_anim 2, 0, 25, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sRegirockAnims_2_8:
+ax_anim 2, 0, 42, 1, -1, 1, -1,
+ax_anim 4, 0, 42, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 26, -10, 10, -10, 10,
+ax_anim 2, 0, 28, -18, 19, -18, 19,
+ax_anim 2, 1, 28, -19, 18, -19, 18,
+ax_anim 2, 0, 28, -18, 19, -18, 19,
+ax_anim 2, 0, 28, -19, 18, -19, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRegirockAnims_3_1:
+ax_anim 2, 0, 69, 0, -1, 0, -1,
+ax_anim 4, 0, 69, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 53, 0, 10, 0, 10,
+ax_anim 2, 0, 55, 0, 18, 0, 18,
+ax_anim 2, 1, 55, 1, 18, 1, 18,
+ax_anim 2, 0, 55, 0, 18, 0, 18,
+ax_anim 2, 0, 55, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sRegirockAnims_3_2:
+ax_anim 2, 0, 48, -1, -1, -1, -1,
+ax_anim 4, 0, 48, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 56, 10, 10, 10, 10,
+ax_anim 2, 0, 58, 18, 18, 18, 18,
+ax_anim 2, 1, 58, 19, 17, 19, 17,
+ax_anim 2, 0, 58, 18, 18, 18, 18,
+ax_anim 2, 0, 58, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sRegirockAnims_3_3:
+ax_anim 2, 0, 51, -1, 0, -1, 0,
+ax_anim 4, 0, 51, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 59, 10, 0, 10, 0,
+ax_anim 2, 0, 61, 18, 0, 18, 0,
+ax_anim 2, 1, 61, 18, 1, 18, 1,
+ax_anim 2, 0, 61, 18, 0, 18, 0,
+ax_anim 2, 0, 61, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sRegirockAnims_3_4:
+ax_anim 2, 0, 54, -1, 1, -1, 1,
+ax_anim 4, 0, 54, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 6, -5, 6, -5,
+ax_anim 1, 0, 62, 12, -11, 12, -11,
+ax_anim 2, 0, 64, 20, -17, 20, -17,
+ax_anim 2, 1, 64, 21, -16, 21, -16,
+ax_anim 2, 0, 64, 20, -17, 20, -17,
+ax_anim 2, 0, 64, 21, -16, 21, -16,
+ax_anim 2, 0, 57, 8, -6, 8, -6,
+ax_anim_terminator
+sRegirockAnims_3_5:
+ax_anim 2, 0, 57, 0, 1, 0, 1,
+ax_anim 4, 0, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 65, 0, -11, 0, -11,
+ax_anim 2, 0, 67, 0, -16, 0, -16,
+ax_anim 2, 1, 67, 1, -16, 1, -16,
+ax_anim 2, 0, 67, 0, -16, 0, -16,
+ax_anim 2, 0, 67, 1, -16, 1, -16,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sRegirockAnims_3_6:
+ax_anim 2, 0, 60, 1, 1, 1, 1,
+ax_anim 4, 0, 60, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -6, -5, -6, -5,
+ax_anim 1, 0, 68, -12, -11, -12, -11,
+ax_anim 2, 0, 70, -17, -16, -17, -16,
+ax_anim 2, 1, 70, -18, -15, -18, -15,
+ax_anim 2, 0, 70, -17, -16, -17, -16,
+ax_anim 2, 0, 70, -18, -15, -18, -15,
+ax_anim 2, 0, 63, -8, -6, -8, -6,
+ax_anim_terminator
+sRegirockAnims_3_7:
+ax_anim 2, 0, 63, 1, 0, 1, 0,
+ax_anim 4, 0, 63, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 71, -10, 0, -10, 0,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 1, 49, -18, 1, -18, 1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sRegirockAnims_3_8:
+ax_anim 2, 0, 66, 1, -1, 1, -1,
+ax_anim 4, 0, 66, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 50, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -18, 19, -18, 19,
+ax_anim 2, 1, 52, -19, 18, -19, 18,
+ax_anim 2, 0, 52, -18, 19, -18, 19,
+ax_anim 2, 0, 52, -19, 18, -19, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRegirockAnims_4_1:
+ax_anim 8, 2, 75, 0, 0, 0, 0,
+ax_anim 1, 1, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -8, 0, -8,
+ax_anim 1, 0, 75, 0, -10, 0, -10,
+ax_anim 8, 0, 75, 0, -11, 0, -11,
+ax_anim 6, 0, 72, 0, -11, 0, -11,
+ax_anim 2, 0, 73, 0, -8, 0, -8,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim 2, 0, 74, 0, -2, 0, -2,
+ax_anim_terminator
+sRegirockAnims_4_2:
+ax_anim 8, 2, 79, 0, 0, 0, 0,
+ax_anim 1, 1, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, -8, -8, -8, -8,
+ax_anim 1, 0, 79, -10, -10, -10, -10,
+ax_anim 8, 0, 79, -11, -11, -11, -11,
+ax_anim 6, 0, 76, -11, -11, -11, -11,
+ax_anim 2, 0, 77, -8, -8, -8, -8,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim 2, 0, 78, -2, -2, -2, -2,
+ax_anim_terminator
+sRegirockAnims_4_3:
+ax_anim 8, 2, 83, 0, 0, 0, 0,
+ax_anim 1, 1, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, -8, 0, -8, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 8, 0, 83, -11, 0, -11, 0,
+ax_anim 6, 0, 80, -11, 0, -11, 0,
+ax_anim 2, 0, 81, -8, 0, -8, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim 2, 0, 82, -2, 0, -2, 0,
+ax_anim_terminator
+sRegirockAnims_4_4:
+ax_anim 8, 2, 87, 0, 0, 0, 0,
+ax_anim 1, 1, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 87, -8, 8, -8, 8,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 8, 0, 87, -11, 11, -11, 11,
+ax_anim 6, 0, 84, -11, 11, -11, 11,
+ax_anim 2, 0, 85, -8, 8, -8, 8,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim 2, 0, 86, -2, 2, -2, 2,
+ax_anim_terminator
+sRegirockAnims_4_5:
+ax_anim 8, 2, 91, 0, 0, 0, 0,
+ax_anim 1, 1, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, 8, 0, 8,
+ax_anim 1, 0, 91, 0, 10, 0, 10,
+ax_anim 8, 0, 91, 0, 11, 0, 11,
+ax_anim 6, 0, 88, 0, 11, 0, 11,
+ax_anim 2, 0, 89, 0, 8, 0, 8,
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim_terminator
+sRegirockAnims_4_6:
+ax_anim 8, 2, 95, 0, 0, 0, 0,
+ax_anim 1, 1, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 8, 8, 8, 8,
+ax_anim 1, 0, 95, 10, 10, 10, 10,
+ax_anim 8, 0, 95, 11, 11, 11, 11,
+ax_anim 6, 0, 92, 11, 11, 11, 11,
+ax_anim 2, 0, 93, 8, 8, 8, 8,
+ax_anim 2, 0, 92, 4, 4, 4, 4,
+ax_anim 2, 0, 94, 2, 2, 2, 2,
+ax_anim_terminator
+sRegirockAnims_4_7:
+ax_anim 8, 2, 99, 0, 0, 0, 0,
+ax_anim 1, 1, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 8, 0, 8, 0,
+ax_anim 1, 0, 99, 10, 0, 10, 0,
+ax_anim 8, 0, 99, 11, 0, 11, 0,
+ax_anim 6, 0, 96, 11, 0, 11, 0,
+ax_anim 2, 0, 97, 8, 0, 8, 0,
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sRegirockAnims_4_8:
+ax_anim 8, 2, 103, 0, 0, 0, 0,
+ax_anim 1, 1, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 8, -8, 8, -8,
+ax_anim 1, 0, 103, 10, -10, 10, -10,
+ax_anim 8, 0, 103, 11, -11, 11, -11,
+ax_anim 6, 0, 100, 11, -11, 11, -11,
+ax_anim 2, 0, 101, 8, -8, 8, -8,
+ax_anim 2, 0, 100, 4, -4, 4, -4,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sRegirockAnims_5_1:
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 3, 0, 112, 0, -4, 0, 0,
+ax_anim 4, 0, 112, 0, -5, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 4, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_5_2:
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 3, 0, 113, 0, -4, 0, 0,
+ax_anim 4, 0, 113, 0, -5, 0, 0,
+ax_anim 1, 0, 113, 0, -4, 0, 0,
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 4, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_5_3:
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 3, 0, 114, 0, -4, 0, 0,
+ax_anim 4, 0, 114, 0, -5, 0, 0,
+ax_anim 1, 0, 114, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 4, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 1, 0, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 1, 0, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 1, 0, 1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_5_4:
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 3, 0, 115, 0, -4, 0, 0,
+ax_anim 4, 0, 115, 0, -5, 0, 0,
+ax_anim 1, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_5_5:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 3, 0, 116, 0, -4, 0, 0,
+ax_anim 4, 0, 116, 0, -5, 0, 0,
+ax_anim 1, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 4, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_5_6:
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 3, 0, 117, 0, -4, 0, 0,
+ax_anim 4, 0, 117, 0, -5, 0, 0,
+ax_anim 1, 0, 117, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 4, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_5_7:
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 3, 0, 118, 0, -4, 0, 0,
+ax_anim 4, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 1, 0, 1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 1, 0, 1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 1, 0, 1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_5_8:
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 3, 0, 119, 0, -4, 0, 0,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 1, 0, 119, 0, -4, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 4, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sRegirockAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sRegirockAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sRegirockAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sRegirockAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sRegirockAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sRegirockAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sRegirockAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRegirockAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 4, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, -1, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_8_2:
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 3, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, -1, 0, 0,
+ax_anim 3, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, -1, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_8_4:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -2, 0, 0,
+ax_anim 4, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, -1, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_8_5:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, -1, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_8_6:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, -1, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_8_7:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 4, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, -1, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_8_8:
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, -1, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 15, 7, 15,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -7, 15, -7, 15,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 1, 8, 1,
+ax_anim 2, 0, 139, 16, 7, 16, 7,
+ax_anim 2, 0, 140, 21, 12, 21, 12,
+ax_anim 3, 0, 141, 20, 17, 20, 17,
+ax_anim 2, 3, 142, 12, 20, 12, 20,
+ax_anim 2, 0, 143, 6, 13, 6, 13,
+ax_anim 1, 0, 144, 2, 7, 2, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -3, 3, -3,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 19, -3, 19, -3,
+ax_anim 3, 0, 140, 22, 0, 22, 0,
+ax_anim 2, 3, 141, 20, 6, 20, 6,
+ax_anim 2, 0, 142, 12, 8, 12, 8,
+ax_anim 1, 0, 143, 5, 5, 5, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -17, 4, -17,
+ax_anim 2, 0, 138, 12, -23, 12, -23,
+ax_anim 3, 0, 139, 20, -22, 20, -22,
+ax_anim 2, 3, 140, 23, -16, 23, -16,
+ax_anim 2, 0, 141, 19, -7, 19, -7,
+ax_anim 1, 0, 142, 9, 1, 9, 1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -5, -4, -5, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -6, -20, -6, -20,
+ax_anim 3, 0, 138, 0, -24, 0, -24,
+ax_anim 2, 3, 139, 6, -20, 6, -20,
+ax_anim 2, 0, 140, 9, -12, 9, -12,
+ax_anim 1, 0, 141, 5, -4, 5, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -6,
+ax_anim 2, 0, 139, -4, -17, -4, -16,
+ax_anim 2, 0, 138, -12, -23, -12, -22,
+ax_anim 3, 0, 145, -20, -22, -18, -22,
+ax_anim 2, 3, 144, -23, -16, -20, -15,
+ax_anim 2, 0, 143, -19, -7, -17, -4,
+ax_anim 1, 0, 142, -9, 1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -3, -3, -3,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -19, -3, -19, -3,
+ax_anim 3, 0, 144, -22, 0, -22, 0,
+ax_anim 2, 3, 143, -20, 6, -20, 6,
+ax_anim 2, 0, 142, -12, 8, -12, 8,
+ax_anim 1, 0, 141, -5, 5, -5, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 1, -8, 1,
+ax_anim 2, 0, 145, -16, 7, -16, 7,
+ax_anim 2, 0, 144, -21, 12, -21, 12,
+ax_anim 3, 0, 143, -20, 17, -20, 17,
+ax_anim 2, 3, 142, -12, 20, -12, 20,
+ax_anim 2, 0, 141, -6, 13, -6, 13,
+ax_anim 1, 0, 140, -2, 7, -2, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_10_1:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_10_2:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_10_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_10_4:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_10_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_10_6:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_10_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_10_8:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_11_1:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -25, 0, 0,
+ax_anim 3, 0, 184, 0, -24, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_11_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -25, 0, 0,
+ax_anim 3, 0, 187, 0, -24, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_11_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -25, 0, 0,
+ax_anim 3, 0, 190, 0, -24, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_11_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_11_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -17, 0, 0,
+ax_anim 1, 0, 199, 0, -11, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_11_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -25, 0, 0,
+ax_anim 3, 0, 202, 0, -24, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_11_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -25, 0, 0,
+ax_anim 3, 0, 205, 0, -24, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_12_1:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_12_2:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_12_3:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_12_4:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_12_5:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_12_6:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_12_7:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_12_8:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegirockAnims_13_1:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_13_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_13_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_13_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_13_5:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_13_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_13_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockAnims_13_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sRegirockGfx1:
+.incbin "baserom.gba", 0x1588CBC, 0x200
+sRegirockSprites1:
+ax_sprite sRegirockGfx1, 0x200
+ax_sprite_terminator
+sRegirockGfx2:
+.incbin "baserom.gba", 0x1588ECC, 0x200
+sRegirockSprites2:
+ax_sprite sRegirockGfx2, 0x200
+ax_sprite_terminator
+sRegirockGfx3:
+.incbin "baserom.gba", 0x15890DC, 0x200
+sRegirockSprites3:
+ax_sprite sRegirockGfx3, 0x200
+ax_sprite_terminator
+sRegirockGfx4:
+.incbin "baserom.gba", 0x15892EC, 0x200
+sRegirockSprites4:
+ax_sprite sRegirockGfx4, 0x200
+ax_sprite_terminator
+sRegirockGfx5:
+.incbin "baserom.gba", 0x15894FC, 0x200
+sRegirockSprites5:
+ax_sprite sRegirockGfx5, 0x200
+ax_sprite_terminator
+sRegirockGfx6:
+.incbin "baserom.gba", 0x158970C, 0x80
+sRegirockSprites6:
+ax_sprite sRegirockGfx6, 0x80
+ax_sprite_terminator
+sRegirockGfx7:
+.incbin "baserom.gba", 0x158979C, 0x100
+sRegirockSprites7:
+ax_sprite sRegirockGfx7, 0x100
+ax_sprite_terminator
+sRegirockGfx8:
+.incbin "baserom.gba", 0x15898AC, 0x40
+sRegirockSprites8:
+ax_sprite sRegirockGfx8, 0x40
+ax_sprite_terminator
+sRegirockGfx9:
+.incbin "baserom.gba", 0x15898FC, 0x20
+sRegirockSprites9:
+ax_sprite sRegirockGfx9, 0x20
+ax_sprite_terminator
+sRegirockGfx10:
+.incbin "baserom.gba", 0x158992C, 0x80
+sRegirockSprites10:
+ax_sprite sRegirockGfx10, 0x80
+ax_sprite_terminator
+sRegirockGfx11:
+.incbin "baserom.gba", 0x15899BC, 0x100
+sRegirockSprites11:
+ax_sprite sRegirockGfx11, 0x100
+ax_sprite_terminator
+sRegirockGfx12:
+.incbin "baserom.gba", 0x1589ACC, 0x100
+sRegirockSprites12:
+ax_sprite sRegirockGfx12, 0x100
+ax_sprite_terminator
+sRegirockGfx13:
+.incbin "baserom.gba", 0x1589BDC, 0x80
+sRegirockSprites13:
+ax_sprite sRegirockGfx13, 0x80
+ax_sprite_terminator
+sRegirockGfx14:
+.incbin "baserom.gba", 0x1589C6C, 0x100
+sRegirockSprites14:
+ax_sprite sRegirockGfx14, 0x100
+ax_sprite_terminator
+sRegirockGfx15:
+.incbin "baserom.gba", 0x1589D7C, 0x80
+sRegirockSprites15:
+ax_sprite sRegirockGfx15, 0x80
+ax_sprite_terminator
+sRegirockGfx16:
+.incbin "baserom.gba", 0x1589E0C, 0x200
+sRegirockSprites16:
+ax_sprite sRegirockGfx16, 0x200
+ax_sprite_terminator
+sRegirockGfx17:
+.incbin "baserom.gba", 0x158A01C, 0x200
+sRegirockSprites17:
+ax_sprite sRegirockGfx17, 0x200
+ax_sprite_terminator
+sRegirockGfx18:
+.incbin "baserom.gba", 0x158A22C, 0x200
+sRegirockSprites18:
+ax_sprite sRegirockGfx18, 0x200
+ax_sprite_terminator
+sRegirockGfx19:
+.incbin "baserom.gba", 0x158A43C, 0x200
+sRegirockSprites19:
+ax_sprite sRegirockGfx19, 0x200
+ax_sprite_terminator
+sRegirockGfx20:
+.incbin "baserom.gba", 0x158A64C, 0x200
+sRegirockSprites20:
+ax_sprite sRegirockGfx20, 0x200
+ax_sprite_terminator
+sRegirockGfx21:
+.incbin "baserom.gba", 0x158A85C, 0x200
+sRegirockSprites21:
+ax_sprite sRegirockGfx21, 0x200
+ax_sprite_terminator
+sRegirockGfx22:
+.incbin "baserom.gba", 0x158AA6C, 0x200
+sRegirockSprites22:
+ax_sprite sRegirockGfx22, 0x200
+ax_sprite_terminator
+sRegirockGfx23:
+.incbin "baserom.gba", 0x158AC7C, 0x200
+sRegirockSprites23:
+ax_sprite sRegirockGfx23, 0x200
+ax_sprite_terminator
+sRegirockGfx24:
+.incbin "baserom.gba", 0x158AE8C, 0x200
+sRegirockSprites24:
+ax_sprite sRegirockGfx24, 0x200
+ax_sprite_terminator
+sRegirockGfx25:
+.incbin "baserom.gba", 0x158B09C, 0x200
+sRegirockSprites25:
+ax_sprite sRegirockGfx25, 0x200
+ax_sprite_terminator
+sRegirockGfx26:
+.incbin "baserom.gba", 0x158B2AC, 0x200
+sRegirockSprites26:
+ax_sprite sRegirockGfx26, 0x200
+ax_sprite_terminator
+sRegirockGfx27:
+.incbin "baserom.gba", 0x158B4BC, 0x200
+sRegirockSprites27:
+ax_sprite sRegirockGfx27, 0x200
+ax_sprite_terminator
+sRegirockGfx28:
+.incbin "baserom.gba", 0x158B6CC, 0x200
+sRegirockSprites28:
+ax_sprite sRegirockGfx28, 0x200
+ax_sprite_terminator
+sRegirockGfx29:
+.incbin "baserom.gba", 0x158B8DC, 0x200
+sRegirockSprites29:
+ax_sprite sRegirockGfx29, 0x200
+ax_sprite_terminator
+sRegirockGfx30:
+.incbin "baserom.gba", 0x158BAEC, 0x100
+sRegirockSprites30:
+ax_sprite sRegirockGfx30, 0x100
+ax_sprite_terminator
+sRegirockGfx31:
+.incbin "baserom.gba", 0x158BBFC, 0x80
+sRegirockSprites31:
+ax_sprite sRegirockGfx31, 0x80
+ax_sprite_terminator
+sRegirockGfx32:
+.incbin "baserom.gba", 0x158BC8C, 0x40
+sRegirockSprites32:
+ax_sprite sRegirockGfx32, 0x40
+ax_sprite_terminator
+sRegirockGfx33:
+.incbin "baserom.gba", 0x158BCDC, 0x20
+sRegirockSprites33:
+ax_sprite sRegirockGfx33, 0x20
+ax_sprite_terminator
+sRegirockGfx34:
+.incbin "baserom.gba", 0x158BD0C, 0x20
+sRegirockSprites34:
+ax_sprite sRegirockGfx34, 0x20
+ax_sprite_terminator
+sRegirockGfx35:
+.incbin "baserom.gba", 0x158BD3C, 0x200
+sRegirockSprites35:
+ax_sprite sRegirockGfx35, 0x200
+ax_sprite_terminator
+sRegirockGfx36:
+.incbin "baserom.gba", 0x158BF4C, 0x180
+sRegirockGfx36_1:
+.incbin "baserom.gba", 0x158C0CC, 0x40
+sRegirockSprites36:
+ax_sprite sRegirockGfx36, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx36_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegirockGfx37:
+.incbin "baserom.gba", 0x158C134, 0x40
+sRegirockGfx37_1:
+.incbin "baserom.gba", 0x158C174, 0x160
+sRegirockSprites37:
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx37_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegirockGfx38:
+.incbin "baserom.gba", 0x158C304, 0x60
+sRegirockGfx38_1:
+.incbin "baserom.gba", 0x158C364, 0x180
+sRegirockSprites38:
+ax_sprite sRegirockGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx38_1, 0x180
+ax_sprite_terminator
+sRegirockGfx39:
+.incbin "baserom.gba", 0x158C504, 0x200
+sRegirockSprites39:
+ax_sprite sRegirockGfx39, 0x200
+ax_sprite_terminator
+sRegirockGfx40:
+.incbin "baserom.gba", 0x158C714, 0x1E0
+sRegirockSprites40:
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx40, 0x1e0
+ax_sprite_terminator
+sRegirockGfx41:
+.incbin "baserom.gba", 0x158C90C, 0x160
+sRegirockGfx41_1:
+.incbin "baserom.gba", 0x158CA6C, 0x60
+sRegirockSprites41:
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx41, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx41_1, 0x60
+ax_sprite_terminator
+sRegirockGfx42:
+.incbin "baserom.gba", 0x158CAF4, 0x100
+sRegirockSprites42:
+ax_sprite sRegirockGfx42, 0x100
+ax_sprite_terminator
+sRegirockGfx43:
+.incbin "baserom.gba", 0x158CC04, 0x80
+sRegirockSprites43:
+ax_sprite sRegirockGfx43, 0x80
+ax_sprite_terminator
+sRegirockGfx44:
+.incbin "baserom.gba", 0x158CC94, 0x40
+sRegirockSprites44:
+ax_sprite sRegirockGfx44, 0x40
+ax_sprite_terminator
+sRegirockGfx45:
+.incbin "baserom.gba", 0x158CCE4, 0x20
+sRegirockSprites45:
+ax_sprite sRegirockGfx45, 0x20
+ax_sprite_terminator
+sRegirockGfx46:
+.incbin "baserom.gba", 0x158CD14, 0x20
+sRegirockSprites46:
+ax_sprite sRegirockGfx46, 0x20
+ax_sprite_terminator
+sRegirockGfx47:
+.incbin "baserom.gba", 0x158CD44, 0x20
+sRegirockGfx47_1:
+.incbin "baserom.gba", 0x158CD64, 0xC0
+sRegirockSprites47:
+ax_sprite sRegirockGfx47, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx47_1, 0xc0
+ax_sprite_terminator
+sRegirockGfx48:
+.incbin "baserom.gba", 0x158CE44, 0x80
+sRegirockSprites48:
+ax_sprite sRegirockGfx48, 0x80
+ax_sprite_terminator
+sRegirockGfx49:
+.incbin "baserom.gba", 0x158CED4, 0x40
+sRegirockSprites49:
+ax_sprite sRegirockGfx49, 0x40
+ax_sprite_terminator
+sRegirockGfx50:
+.incbin "baserom.gba", 0x158CF24, 0x20
+sRegirockSprites50:
+ax_sprite sRegirockGfx50, 0x20
+ax_sprite_terminator
+sRegirockGfx51:
+.incbin "baserom.gba", 0x158CF54, 0x20
+sRegirockSprites51:
+ax_sprite sRegirockGfx51, 0x20
+ax_sprite_terminator
+sRegirockGfx52:
+.incbin "baserom.gba", 0x158CF84, 0x100
+sRegirockSprites52:
+ax_sprite sRegirockGfx52, 0x100
+ax_sprite_terminator
+sRegirockGfx53:
+.incbin "baserom.gba", 0x158D094, 0x80
+sRegirockSprites53:
+ax_sprite sRegirockGfx53, 0x80
+ax_sprite_terminator
+sRegirockGfx54:
+.incbin "baserom.gba", 0x158D124, 0x20
+sRegirockSprites54:
+ax_sprite sRegirockGfx54, 0x20
+ax_sprite_terminator
+sRegirockGfx55:
+.incbin "baserom.gba", 0x158D154, 0x100
+sRegirockSprites55:
+ax_sprite sRegirockGfx55, 0x100
+ax_sprite_terminator
+sRegirockGfx56:
+.incbin "baserom.gba", 0x158D264, 0x20
+sRegirockSprites56:
+ax_sprite sRegirockGfx56, 0x20
+ax_sprite_terminator
+sRegirockGfx57:
+.incbin "baserom.gba", 0x158D294, 0x40
+sRegirockSprites57:
+ax_sprite sRegirockGfx57, 0x40
+ax_sprite_terminator
+sRegirockGfx58:
+.incbin "baserom.gba", 0x158D2E4, 0x60
+sRegirockSprites58:
+ax_sprite sRegirockGfx58, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegirockGfx59:
+.incbin "baserom.gba", 0x158D35C, 0x180
+sRegirockGfx59_1:
+.incbin "baserom.gba", 0x158D4DC, 0x60
+sRegirockSprites59:
+ax_sprite sRegirockGfx59, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx59_1, 0x60
+ax_sprite_terminator
+sRegirockGfx60:
+.incbin "baserom.gba", 0x158D55C, 0xC0
+sRegirockGfx60_1:
+.incbin "baserom.gba", 0x158D61C, 0x20
+sRegirockSprites60:
+ax_sprite sRegirockGfx60, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx60_1, 0x20
+ax_sprite_terminator
+sRegirockGfx61:
+.incbin "baserom.gba", 0x158D65C, 0x80
+sRegirockSprites61:
+ax_sprite sRegirockGfx61, 0x80
+ax_sprite_terminator
+sRegirockGfx62:
+.incbin "baserom.gba", 0x158D6EC, 0x40
+sRegirockSprites62:
+ax_sprite sRegirockGfx62, 0x40
+ax_sprite_terminator
+sRegirockGfx63:
+.incbin "baserom.gba", 0x158D73C, 0x20
+sRegirockSprites63:
+ax_sprite sRegirockGfx63, 0x20
+ax_sprite_terminator
+sRegirockGfx64:
+.incbin "baserom.gba", 0x158D76C, 0x100
+sRegirockSprites64:
+ax_sprite sRegirockGfx64, 0x100
+ax_sprite_terminator
+sRegirockGfx65:
+.incbin "baserom.gba", 0x158D87C, 0x40
+sRegirockSprites65:
+ax_sprite sRegirockGfx65, 0x40
+ax_sprite_terminator
+sRegirockGfx66:
+.incbin "baserom.gba", 0x158D8CC, 0x20
+sRegirockSprites66:
+ax_sprite sRegirockGfx66, 0x20
+ax_sprite_terminator
+sRegirockGfx67:
+.incbin "baserom.gba", 0x158D8FC, 0x40
+sRegirockGfx67_1:
+.incbin "baserom.gba", 0x158D93C, 0xA0
+sRegirockSprites67:
+ax_sprite sRegirockGfx67, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegirockGfx67_1, 0xa0
+ax_sprite_terminator
+sRegirockGfx68:
+.incbin "baserom.gba", 0x158D9FC, 0x80
+sRegirockSprites68:
+ax_sprite sRegirockGfx68, 0x80
+ax_sprite_terminator
+sRegirockGfx69:
+.incbin "baserom.gba", 0x158DA8C, 0x40
+sRegirockSprites69:
+ax_sprite sRegirockGfx69, 0x40
+ax_sprite_terminator
+sRegirockGfx70:
+.incbin "baserom.gba", 0x158DADC, 0x20
+sRegirockSprites70:
+ax_sprite sRegirockGfx70, 0x20
+ax_sprite_terminator
+sRegirockGfx71:
+.incbin "baserom.gba", 0x158DB0C, 0x20
+sRegirockSprites71:
+ax_sprite sRegirockGfx71, 0x20
+ax_sprite_terminator
+sRegirockGfx72:
+.incbin "baserom.gba", 0x158DB3C, 0x200
+sRegirockSprites72:
+ax_sprite sRegirockGfx72, 0x200
+ax_sprite_terminator
+sRegirockGfx73:
+.incbin "baserom.gba", 0x158DD4C, 0x200
+sRegirockSprites73:
+ax_sprite sRegirockGfx73, 0x200
+ax_sprite_terminator
+sRegirockGfx74:
+.incbin "baserom.gba", 0x158DF5C, 0x200
+sRegirockSprites74:
+ax_sprite sRegirockGfx74, 0x200
+ax_sprite_terminator
+sRegirockGfx75:
+.incbin "baserom.gba", 0x158E16C, 0x200
+sRegirockSprites75:
+ax_sprite sRegirockGfx75, 0x200
+ax_sprite_terminator
+sRegirockGfx76:
+.incbin "baserom.gba", 0x158E37C, 0x200
+sRegirockSprites76:
+ax_sprite sRegirockGfx76, 0x200
+ax_sprite_terminator
+sRegirockGfx77:
+.incbin "baserom.gba", 0x158E58C, 0x200
+sRegirockSprites77:
+ax_sprite sRegirockGfx77, 0x200
+ax_sprite_terminator
+sRegirockGfx78:
+.incbin "baserom.gba", 0x158E79C, 0x200
+sRegirockSprites78:
+ax_sprite sRegirockGfx78, 0x200
+ax_sprite_terminator
+sRegirockGfx79:
+.incbin "baserom.gba", 0x158E9AC, 0x200
+sRegirockSprites79:
+ax_sprite sRegirockGfx79, 0x200
+ax_sprite_terminator
+sRegirockGfx80:
+.incbin "baserom.gba", 0x158EBBC, 0x200
+sRegirockSprites80:
+ax_sprite sRegirockGfx80, 0x200
+ax_sprite_terminator
+sRegirockGfx81:
+.incbin "baserom.gba", 0x158EDCC, 0x200
+sRegirockSprites81:
+ax_sprite sRegirockGfx81, 0x200
+ax_sprite_terminator
+sRegirockGfx82:
+.incbin "baserom.gba", 0x158EFDC, 0x200
+sRegirockSprites82:
+ax_sprite sRegirockGfx82, 0x200
+ax_sprite_terminator
+sRegirockGfx83:
+.incbin "baserom.gba", 0x158F1EC, 0x100
+sRegirockSprites83:
+ax_sprite sRegirockGfx83, 0x100
+ax_sprite_terminator
+sRegirockGfx84:
+.incbin "baserom.gba", 0x158F2FC, 0x80
+sRegirockSprites84:
+ax_sprite sRegirockGfx84, 0x80
+ax_sprite_terminator
+sRegirockGfx85:
+.incbin "baserom.gba", 0x158F38C, 0x20
+sRegirockSprites85:
+ax_sprite sRegirockGfx85, 0x20
+ax_sprite_terminator
+sAxPosesRegirock:
+.4byte sRegirockPose1
+.4byte sRegirockPose2
+.4byte sRegirockPose3
+.4byte sRegirockPose4
+.4byte sRegirockPose5
+.4byte sRegirockPose6
+.4byte sRegirockPose7
+.4byte sRegirockPose8
+.4byte sRegirockPose9
+.4byte sRegirockPose10
+.4byte sRegirockPose11
+.4byte sRegirockPose12
+.4byte sRegirockPose13
+.4byte sRegirockPose14
+.4byte sRegirockPose15
+.4byte sRegirockPose16
+.4byte sRegirockPose17
+.4byte sRegirockPose18
+.4byte sRegirockPose19
+.4byte sRegirockPose20
+.4byte sRegirockPose21
+.4byte sRegirockPose22
+.4byte sRegirockPose23
+.4byte sRegirockPose24
+.4byte sRegirockPose25
+.4byte sRegirockPose26
+.4byte sRegirockPose27
+.4byte sRegirockPose28
+.4byte sRegirockPose29
+.4byte sRegirockPose30
+.4byte sRegirockPose31
+.4byte sRegirockPose32
+.4byte sRegirockPose33
+.4byte sRegirockPose34
+.4byte sRegirockPose35
+.4byte sRegirockPose36
+.4byte sRegirockPose37
+.4byte sRegirockPose38
+.4byte sRegirockPose39
+.4byte sRegirockPose40
+.4byte sRegirockPose41
+.4byte sRegirockPose42
+.4byte sRegirockPose43
+.4byte sRegirockPose44
+.4byte sRegirockPose45
+.4byte sRegirockPose46
+.4byte sRegirockPose47
+.4byte sRegirockPose48
+.4byte sRegirockPose49
+.4byte sRegirockPose50
+.4byte sRegirockPose51
+.4byte sRegirockPose52
+.4byte sRegirockPose53
+.4byte sRegirockPose54
+.4byte sRegirockPose55
+.4byte sRegirockPose56
+.4byte sRegirockPose57
+.4byte sRegirockPose58
+.4byte sRegirockPose59
+.4byte sRegirockPose60
+.4byte sRegirockPose61
+.4byte sRegirockPose62
+.4byte sRegirockPose63
+.4byte sRegirockPose64
+.4byte sRegirockPose65
+.4byte sRegirockPose66
+.4byte sRegirockPose67
+.4byte sRegirockPose68
+.4byte sRegirockPose69
+.4byte sRegirockPose70
+.4byte sRegirockPose71
+.4byte sRegirockPose72
+.4byte sRegirockPose73
+.4byte sRegirockPose74
+.4byte sRegirockPose75
+.4byte sRegirockPose76
+.4byte sRegirockPose77
+.4byte sRegirockPose78
+.4byte sRegirockPose79
+.4byte sRegirockPose80
+.4byte sRegirockPose81
+.4byte sRegirockPose82
+.4byte sRegirockPose83
+.4byte sRegirockPose84
+.4byte sRegirockPose85
+.4byte sRegirockPose86
+.4byte sRegirockPose87
+.4byte sRegirockPose88
+.4byte sRegirockPose89
+.4byte sRegirockPose90
+.4byte sRegirockPose91
+.4byte sRegirockPose92
+.4byte sRegirockPose93
+.4byte sRegirockPose94
+.4byte sRegirockPose95
+.4byte sRegirockPose96
+.4byte sRegirockPose97
+.4byte sRegirockPose98
+.4byte sRegirockPose99
+.4byte sRegirockPose100
+.4byte sRegirockPose101
+.4byte sRegirockPose102
+.4byte sRegirockPose103
+.4byte sRegirockPose104
+.4byte sRegirockPose105
+.4byte sRegirockPose106
+.4byte sRegirockPose107
+.4byte sRegirockPose108
+.4byte sRegirockPose109
+.4byte sRegirockPose110
+.4byte sRegirockPose111
+.4byte sRegirockPose112
+.4byte sRegirockPose113
+.4byte sRegirockPose114
+.4byte sRegirockPose115
+.4byte sRegirockPose116
+.4byte sRegirockPose117
+.4byte sRegirockPose118
+.4byte sRegirockPose119
+.4byte sRegirockPose120
+.4byte sRegirockPose121
+.4byte sRegirockPose122
+.4byte sRegirockPose123
+.4byte sRegirockPose124
+.4byte sRegirockPose125
+.4byte sRegirockPose126
+.4byte sRegirockPose127
+.4byte sRegirockPose128
+.4byte sRegirockPose129
+.4byte sRegirockPose130
+.4byte sRegirockPose131
+.4byte sRegirockPose132
+.4byte sRegirockPose133
+.4byte sRegirockPose134
+.4byte sRegirockPose135
+.4byte sRegirockPose136
+.4byte sRegirockPose137
+.4byte sRegirockPose138
+.4byte sRegirockPose139
+.4byte sRegirockPose140
+.4byte sRegirockPose141
+.4byte sRegirockPose142
+.4byte sRegirockPose143
+.4byte sRegirockPose144
+.4byte sRegirockPose145
+.4byte sRegirockPose146
+.4byte sRegirockPose147
+.4byte sRegirockPose148
+.4byte sRegirockPose149
+.4byte sRegirockPose150
+.4byte sRegirockPose151
+.4byte sRegirockPose152
+.4byte sRegirockPose153
+.4byte sRegirockPose154
+.4byte sRegirockPose155
+.4byte sRegirockPose156
+.4byte sRegirockPose157
+.4byte sRegirockPose158
+.4byte sRegirockPose159
+.4byte sRegirockPose160
+.4byte sRegirockPose161
+.4byte sRegirockPose162
+.4byte sRegirockPose163
+.4byte sRegirockPose164
+.4byte sRegirockPose165
+.4byte sRegirockPose166
+.4byte sRegirockPose167
+.4byte sRegirockPose168
+.4byte sRegirockPose169
+.4byte sRegirockPose170
+.4byte sRegirockPose171
+.4byte sRegirockPose172
+.4byte sRegirockPose173
+.4byte sRegirockPose174
+.4byte sRegirockPose175
+.4byte sRegirockPose176
+.4byte sRegirockPose177
+.4byte sRegirockPose178
+.4byte sRegirockPose179
+.4byte sRegirockPose180
+.4byte sRegirockPose181
+.4byte sRegirockPose182
+.4byte sRegirockPose183
+.4byte sRegirockPose184
+.4byte sRegirockPose185
+.4byte sRegirockPose186
+.4byte sRegirockPose187
+.4byte sRegirockPose188
+.4byte sRegirockPose189
+.4byte sRegirockPose190
+.4byte sRegirockPose191
+.4byte sRegirockPose192
+.4byte sRegirockPose193
+.4byte sRegirockPose194
+.4byte sRegirockPose195
+.4byte sRegirockPose196
+.4byte sRegirockPose197
+.4byte sRegirockPose198
+.4byte sRegirockPose199
+.4byte sRegirockPose200
+.4byte sRegirockPose201
+.4byte sRegirockPose202
+.4byte sRegirockPose203
+.4byte sRegirockPose204
+.4byte sRegirockPose205
+.4byte sRegirockPose206
+.4byte sRegirockPose207
+.4byte sRegirockPose208
+.4byte sRegirockPose209
+.4byte sRegirockPose210
+.4byte sRegirockPose211
+.4byte sRegirockPose212
+.4byte sRegirockPose213
+.4byte sRegirockPose214
+.4byte sRegirockPose215
+.4byte sRegirockPose216
+.4byte sRegirockPose217
+.4byte sRegirockPose218
+.4byte sRegirockPose219
+.4byte sRegirockPose220
+.4byte sRegirockPose221
+.4byte sRegirockPose222
+sAxPositionsRegirock:
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte    1,  -13, 	 -10,   -2, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -13, 	 -11,   -6, 	  10,   -2, 	   0,   -8
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+.2byte    2,  -15, 	  -9,   -5, 	  12,   -6, 	   1,  -10
+.2byte    4,  -14, 	  -2,   -2, 	  11,  -11, 	   1,   -9
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    4,  -15, 	   1,   -2, 	   8,   -9, 	   1,   -9
+.2byte    5,  -15, 	   5,   -3, 	  -4,   -9, 	   0,   -9
+.2byte    2,  -15, 	  10,   -4, 	  -6,  -11, 	  -1,  -10
+.2byte    1,  -14, 	   8,    0, 	  -1,  -10, 	  -1,   -8
+.2byte    2,  -15, 	  11,   -6, 	  -9,   -7, 	  -1,   -9
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -8, 	 -12,   -5, 	   2,   -9
+.2byte    0,  -15, 	  11,   -4, 	 -10,   -8, 	  -1,   -8
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte   -2,  -15, 	   3,  -11, 	  -8,    0, 	   2,   -9
+.2byte   -1,  -16, 	   9,   -8, 	 -11,   -6, 	   1,  -10
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -4,  -14, 	  -8,   -9, 	  -1,   -1, 	   0,   -8
+.2byte   -5,  -14, 	   4,   -9, 	  -5,   -2, 	   1,   -9
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -2,  -15, 	 -11,   -7, 	   9,   -4, 	  -1,   -9
+.2byte   -4,  -14, 	 -10,  -11, 	   2,   -2, 	   0,   -9
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte    1,  -13, 	 -10,   -2, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -13, 	 -11,   -6, 	  10,   -2, 	   0,   -8
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+.2byte    2,  -15, 	  -9,   -5, 	  12,   -6, 	   1,  -10
+.2byte    4,  -14, 	  -2,   -2, 	  11,  -11, 	   1,   -9
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    4,  -15, 	   1,   -2, 	   8,   -9, 	   1,   -9
+.2byte    5,  -15, 	   5,   -3, 	  -4,   -9, 	   0,   -9
+.2byte    2,  -15, 	  10,   -4, 	  -6,  -11, 	  -1,  -10
+.2byte    1,  -14, 	   8,    0, 	  -1,  -10, 	  -1,   -8
+.2byte    2,  -15, 	  11,   -6, 	  -9,   -7, 	  -1,   -9
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -8, 	 -12,   -5, 	   2,   -9
+.2byte    0,  -15, 	  11,   -4, 	 -10,   -8, 	  -1,   -8
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte   -2,  -15, 	   3,  -11, 	  -8,    0, 	   2,   -9
+.2byte   -1,  -16, 	   9,   -8, 	 -11,   -6, 	   1,  -10
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -4,  -14, 	  -8,   -9, 	  -1,   -1, 	   0,   -8
+.2byte   -5,  -14, 	   4,   -9, 	  -5,   -2, 	   1,   -9
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -2,  -15, 	 -11,   -7, 	   9,   -4, 	  -1,   -9
+.2byte   -4,  -14, 	 -10,  -11, 	   2,   -2, 	   0,   -9
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte    1,  -13, 	 -10,   -2, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -13, 	 -11,   -6, 	  10,   -2, 	   0,   -8
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+.2byte    2,  -15, 	  -9,   -5, 	  12,   -6, 	   1,  -10
+.2byte    4,  -14, 	  -2,   -2, 	  11,  -11, 	   1,   -9
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    4,  -15, 	   1,   -2, 	   8,   -9, 	   1,   -9
+.2byte    5,  -15, 	   5,   -3, 	  -4,   -9, 	   0,   -9
+.2byte    2,  -15, 	  10,   -4, 	  -6,  -11, 	  -1,  -10
+.2byte    1,  -14, 	   8,    0, 	  -1,  -10, 	  -1,   -8
+.2byte    2,  -15, 	  11,   -6, 	  -9,   -7, 	  -1,   -9
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -8, 	 -12,   -5, 	   2,   -9
+.2byte    0,  -15, 	  11,   -4, 	 -10,   -8, 	  -1,   -8
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte   -2,  -15, 	   3,  -11, 	  -8,    0, 	   2,   -9
+.2byte   -1,  -16, 	   9,   -8, 	 -11,   -6, 	   1,  -10
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -4,  -14, 	  -8,   -9, 	  -1,   -1, 	   0,   -8
+.2byte   -5,  -14, 	   4,   -9, 	  -5,   -2, 	   1,   -9
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -2,  -15, 	 -11,   -7, 	   9,   -4, 	  -1,   -9
+.2byte   -4,  -14, 	 -10,  -11, 	   2,   -2, 	   0,   -9
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte    1,  -13, 	 -10,   -2, 	  11,   -5, 	   1,   -8
+.2byte   -1,  -13, 	 -11,   -6, 	  10,   -2, 	   0,   -8
+.2byte    0,   -9, 	 -11,    2, 	  11,    3, 	   0,   -6
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+.2byte    2,  -15, 	  -9,   -5, 	  12,   -6, 	   1,  -10
+.2byte    4,  -14, 	  -2,   -2, 	  11,  -11, 	   1,   -9
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    4,  -15, 	   1,   -2, 	   8,   -9, 	   1,   -9
+.2byte    5,  -15, 	   5,   -3, 	  -4,   -9, 	   0,   -9
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    2,  -15, 	  10,   -4, 	  -6,  -11, 	  -1,  -10
+.2byte    1,  -14, 	   8,    0, 	  -1,  -10, 	  -1,   -8
+.2byte    2,  -15, 	  11,   -6, 	  -9,   -7, 	  -1,   -9
+.2byte    3,  -12, 	  14,   -4, 	   1,  -10, 	  -1,   -8
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    0,  -15, 	  10,   -8, 	 -12,   -5, 	   2,   -9
+.2byte    0,  -15, 	  11,   -4, 	 -10,   -8, 	  -1,   -8
+.2byte    0,  -13, 	  11,   -6, 	 -12,   -7, 	   0,   -8
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte   -2,  -15, 	   3,  -11, 	  -8,    0, 	   2,   -9
+.2byte   -1,  -16, 	   9,   -8, 	 -11,   -6, 	   1,  -10
+.2byte   -3,  -14, 	   0,  -10, 	 -13,   -4, 	   1,   -8
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -4,  -14, 	  -8,   -9, 	  -1,   -1, 	   0,   -8
+.2byte   -5,  -14, 	   4,   -9, 	  -5,   -2, 	   1,   -9
+.2byte   -5,  -10, 	 -11,   -8, 	  -9,    2, 	   1,   -7
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -2,  -15, 	 -11,   -7, 	   9,   -4, 	  -1,   -9
+.2byte   -4,  -14, 	 -10,  -11, 	   2,   -2, 	   0,   -9
+.2byte   -4,   -9, 	 -13,   -3, 	  -1,    6, 	   2,   -8
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    2,  -15, 	  -7,  -11, 	  10,   -4, 	  -2,  -10
+.2byte    5,  -15, 	   3,  -10, 	   3,   -3, 	   0,  -10
+.2byte    3,  -15, 	  11,  -10, 	  -5,   -3, 	   0,  -10
+.2byte    0,  -13, 	 -12,  -24, 	  13,  -25, 	   0,   -9
+.2byte    3,  -13, 	 -12,  -23, 	   9,  -28, 	   1,  -10
+.2byte    5,  -15, 	  -4,  -23, 	   2,  -28, 	   0,   -8
+.2byte    2,  -15, 	  10,  -21, 	  -7,  -27, 	  -1,   -9
+.2byte    0,  -15, 	  10,  -25, 	 -10,  -25, 	   0,   -8
+.2byte   -1,  -16, 	   7,  -28, 	 -10,  -21, 	   1,   -9
+.2byte   -4,  -14, 	  -2,  -28, 	   4,  -22, 	   0,  -11
+.2byte   -3,  -14, 	  -9,  -27, 	  12,  -23, 	  -1,  -10
+.2byte   -3,  -11, 	  -9,   -6, 	  11,    0, 	  -1,   -7
+.2byte   -3,  -10, 	 -10,   -6, 	  10,    0, 	  -1,   -7
+.2byte   -1,  -14, 	 -12,   -4, 	  11,   -3, 	  -1,   -9
+.2byte    0,  -13, 	  -7,   -1, 	  11,  -10, 	   0,   -8
+.2byte   -1,  -12, 	  -1,    1, 	   6,  -11, 	  -1,   -6
+.2byte   -2,  -10, 	  11,    0, 	  -5,   -6, 	   0,   -4
+.2byte    0,  -10, 	  11,   -5, 	 -11,   -5, 	   0,   -6
+.2byte    3,  -12, 	   6,   -9, 	  -9,   -1, 	   4,   -6
+.2byte    0,  -13, 	  -6,  -12, 	   1,    1, 	   2,   -7
+.2byte    0,  -12, 	 -10,  -10, 	   7,    1, 	   1,   -7
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    2,  -15, 	  10,   -4, 	  -6,  -11, 	  -1,  -10
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+.2byte    0,   -9, 	 -11,    2, 	  11,    3, 	   0,   -6
+.2byte   -4,   -9, 	 -13,   -3, 	  -1,    6, 	   2,   -8
+.2byte   -5,  -10, 	 -11,   -8, 	  -9,    2, 	   1,   -7
+.2byte   -3,  -14, 	   0,  -10, 	 -13,   -4, 	   1,   -8
+.2byte    0,  -14, 	  11,   -7, 	 -12,   -8, 	   0,   -9
+.2byte    3,  -12, 	  14,   -4, 	   1,  -10, 	  -1,   -8
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte    3,  -12, 	  14,   -4, 	   1,  -10, 	  -1,   -8
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte    0,  -15, 	  11,   -8, 	 -12,   -9, 	   0,  -10
+.2byte    3,  -12, 	  14,   -4, 	   1,  -10, 	  -1,   -8
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte   -3,  -14, 	   0,  -10, 	 -13,   -4, 	   1,   -8
+.2byte    0,  -15, 	  11,   -8, 	 -12,   -9, 	   0,  -10
+.2byte    3,  -12, 	  14,   -4, 	   1,  -10, 	  -1,   -8
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte   -5,  -10, 	 -11,   -8, 	  -9,    2, 	   1,   -7
+.2byte   -3,  -14, 	   0,  -10, 	 -13,   -4, 	   1,   -8
+.2byte    0,  -15, 	  11,   -8, 	 -12,   -9, 	   0,  -10
+.2byte    3,  -12, 	  14,   -4, 	   1,  -10, 	  -1,   -8
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte   -4,   -9, 	 -13,   -3, 	  -1,    6, 	   2,   -8
+.2byte   -5,  -10, 	 -11,   -8, 	  -9,    2, 	   1,   -7
+.2byte   -3,  -14, 	   0,  -10, 	 -13,   -4, 	   1,   -8
+.2byte    0,  -15, 	  11,   -8, 	 -12,   -9, 	   0,  -10
+.2byte    3,  -12, 	  14,   -4, 	   1,  -10, 	  -1,   -8
+.2byte    5,  -10, 	  11,   -8, 	   9,    2, 	  -1,   -7
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte    0,  -13, 	 -12,  -24, 	  13,  -25, 	   0,   -9
+.2byte    3,  -13, 	 -12,  -23, 	   9,  -28, 	   1,  -10
+.2byte    5,  -15, 	  -4,  -23, 	   2,  -28, 	   0,   -8
+.2byte    2,  -15, 	  10,  -21, 	  -7,  -27, 	  -1,   -9
+.2byte    0,  -15, 	  10,  -25, 	 -10,  -25, 	   0,   -8
+.2byte   -1,  -16, 	   7,  -28, 	 -10,  -21, 	   1,   -9
+.2byte   -4,  -14, 	  -2,  -28, 	   4,  -22, 	   0,  -11
+.2byte   -3,  -14, 	  -9,  -27, 	  12,  -23, 	  -1,  -10
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte    0,  -14, 	 -12,  -25, 	  13,  -26, 	   0,  -10
+.2byte    0,   -8, 	 -11,    3, 	  11,    4, 	   0,   -5
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+.2byte    3,  -14, 	 -12,  -24, 	   9,  -29, 	   1,  -11
+.2byte    4,   -9, 	   1,    6, 	  13,   -3, 	   0,   -8
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    5,  -15, 	  -4,  -23, 	   2,  -28, 	   0,   -8
+.2byte    7,  -10, 	  13,   -8, 	  11,    2, 	   1,   -7
+.2byte    2,  -16, 	  10,   -5, 	  -6,  -12, 	  -1,  -11
+.2byte    2,  -17, 	  10,  -23, 	  -7,  -29, 	  -1,  -11
+.2byte    5,  -15, 	  16,   -7, 	   3,  -13, 	   1,  -11
+.2byte    0,  -16, 	  11,   -8, 	 -12,   -8, 	   0,  -10
+.2byte    0,  -17, 	  10,  -27, 	 -10,  -27, 	   0,  -10
+.2byte    0,  -15, 	  11,   -8, 	 -12,   -9, 	   0,  -10
+.2byte   -2,  -16, 	   7,  -12, 	 -10,   -5, 	   2,  -11
+.2byte   -1,  -17, 	   7,  -29, 	 -10,  -22, 	   1,  -10
+.2byte   -5,  -17, 	  -2,  -13, 	 -15,   -7, 	  -1,  -11
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -4,  -15, 	  -2,  -29, 	   4,  -23, 	   0,  -12
+.2byte   -7,  -10, 	 -13,   -8, 	 -11,    2, 	  -1,   -7
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -3,  -15, 	  -9,  -28, 	  12,  -24, 	  -1,  -11
+.2byte   -4,   -9, 	 -13,   -3, 	  -1,    6, 	   2,   -8
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    2,  -15, 	  10,   -4, 	  -6,  -11, 	  -1,  -10
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+.2byte    0,  -14, 	 -12,   -6, 	  11,   -5, 	   0,   -9
+.2byte   -3,  -15, 	 -11,  -10, 	   5,   -3, 	   0,  -10
+.2byte   -5,  -15, 	  -3,  -10, 	  -3,   -3, 	   0,  -10
+.2byte   -2,  -15, 	   7,  -11, 	 -10,   -4, 	   2,  -10
+.2byte    0,  -15, 	  11,   -7, 	 -12,   -7, 	   0,   -9
+.2byte    2,  -15, 	  10,   -4, 	  -6,  -11, 	  -1,  -10
+.2byte    5,  -15, 	   3,   -3, 	   2,  -10, 	   1,   -9
+.2byte    3,  -15, 	  -5,   -4, 	  11,  -10, 	   1,  -10
+sRegirockAnimTable1:
+.4byte sRegirockAnims_1_1
+.4byte sRegirockAnims_1_2
+.4byte sRegirockAnims_1_3
+.4byte sRegirockAnims_1_4
+.4byte sRegirockAnims_1_5
+.4byte sRegirockAnims_1_6
+.4byte sRegirockAnims_1_7
+.4byte sRegirockAnims_1_8
+sRegirockAnimTable2:
+.4byte sRegirockAnims_2_1
+.4byte sRegirockAnims_2_2
+.4byte sRegirockAnims_2_3
+.4byte sRegirockAnims_2_4
+.4byte sRegirockAnims_2_5
+.4byte sRegirockAnims_2_6
+.4byte sRegirockAnims_2_7
+.4byte sRegirockAnims_2_8
+sRegirockAnimTable3:
+.4byte sRegirockAnims_3_1
+.4byte sRegirockAnims_3_2
+.4byte sRegirockAnims_3_3
+.4byte sRegirockAnims_3_4
+.4byte sRegirockAnims_3_5
+.4byte sRegirockAnims_3_6
+.4byte sRegirockAnims_3_7
+.4byte sRegirockAnims_3_8
+sRegirockAnimTable4:
+.4byte sRegirockAnims_4_1
+.4byte sRegirockAnims_4_2
+.4byte sRegirockAnims_4_3
+.4byte sRegirockAnims_4_4
+.4byte sRegirockAnims_4_5
+.4byte sRegirockAnims_4_6
+.4byte sRegirockAnims_4_7
+.4byte sRegirockAnims_4_8
+sRegirockAnimTable5:
+.4byte sRegirockAnims_5_1
+.4byte sRegirockAnims_5_2
+.4byte sRegirockAnims_5_3
+.4byte sRegirockAnims_5_4
+.4byte sRegirockAnims_5_5
+.4byte sRegirockAnims_5_6
+.4byte sRegirockAnims_5_7
+.4byte sRegirockAnims_5_8
+sRegirockAnimTable6:
+.4byte sRegirockAnims_6_1
+.4byte sRegirockAnims_6_1
+.4byte sRegirockAnims_6_1
+.4byte sRegirockAnims_6_1
+.4byte sRegirockAnims_6_1
+.4byte sRegirockAnims_6_1
+.4byte sRegirockAnims_6_1
+.4byte sRegirockAnims_6_1
+sRegirockAnimTable7:
+.4byte sRegirockAnims_7_1
+.4byte sRegirockAnims_7_2
+.4byte sRegirockAnims_7_3
+.4byte sRegirockAnims_7_4
+.4byte sRegirockAnims_7_5
+.4byte sRegirockAnims_7_6
+.4byte sRegirockAnims_7_7
+.4byte sRegirockAnims_7_8
+sRegirockAnimTable8:
+.4byte sRegirockAnims_8_1
+.4byte sRegirockAnims_8_2
+.4byte sRegirockAnims_8_3
+.4byte sRegirockAnims_8_4
+.4byte sRegirockAnims_8_5
+.4byte sRegirockAnims_8_6
+.4byte sRegirockAnims_8_7
+.4byte sRegirockAnims_8_8
+sRegirockAnimTable9:
+.4byte sRegirockAnims_9_1
+.4byte sRegirockAnims_9_2
+.4byte sRegirockAnims_9_3
+.4byte sRegirockAnims_9_4
+.4byte sRegirockAnims_9_5
+.4byte sRegirockAnims_9_6
+.4byte sRegirockAnims_9_7
+.4byte sRegirockAnims_9_8
+sRegirockAnimTable10:
+.4byte sRegirockAnims_10_1
+.4byte sRegirockAnims_10_2
+.4byte sRegirockAnims_10_3
+.4byte sRegirockAnims_10_4
+.4byte sRegirockAnims_10_5
+.4byte sRegirockAnims_10_6
+.4byte sRegirockAnims_10_7
+.4byte sRegirockAnims_10_8
+sRegirockAnimTable11:
+.4byte sRegirockAnims_11_1
+.4byte sRegirockAnims_11_2
+.4byte sRegirockAnims_11_3
+.4byte sRegirockAnims_11_4
+.4byte sRegirockAnims_11_5
+.4byte sRegirockAnims_11_6
+.4byte sRegirockAnims_11_7
+.4byte sRegirockAnims_11_8
+sRegirockAnimTable12:
+.4byte sRegirockAnims_12_1
+.4byte sRegirockAnims_12_2
+.4byte sRegirockAnims_12_3
+.4byte sRegirockAnims_12_4
+.4byte sRegirockAnims_12_5
+.4byte sRegirockAnims_12_6
+.4byte sRegirockAnims_12_7
+.4byte sRegirockAnims_12_8
+sRegirockAnimTable13:
+.4byte sRegirockAnims_13_1
+.4byte sRegirockAnims_13_2
+.4byte sRegirockAnims_13_3
+.4byte sRegirockAnims_13_4
+.4byte sRegirockAnims_13_5
+.4byte sRegirockAnims_13_6
+.4byte sRegirockAnims_13_7
+.4byte sRegirockAnims_13_8
+sAxAnimationsRegirock:
+.4byte sRegirockAnimTable1
+.4byte sRegirockAnimTable2
+.4byte sRegirockAnimTable3
+.4byte sRegirockAnimTable4
+.4byte sRegirockAnimTable5
+.4byte sRegirockAnimTable6
+.4byte sRegirockAnimTable7
+.4byte sRegirockAnimTable8
+.4byte sRegirockAnimTable9
+.4byte sRegirockAnimTable10
+.4byte sRegirockAnimTable11
+.4byte sRegirockAnimTable12
+.4byte sRegirockAnimTable13
+sAxSpritesRegirock:
+.4byte sRegirockSprites1
+.4byte sRegirockSprites2
+.4byte sRegirockSprites3
+.4byte sRegirockSprites4
+.4byte sRegirockSprites5
+.4byte sRegirockSprites6
+.4byte sRegirockSprites7
+.4byte sRegirockSprites8
+.4byte sRegirockSprites9
+.4byte sRegirockSprites10
+.4byte sRegirockSprites11
+.4byte sRegirockSprites12
+.4byte sRegirockSprites13
+.4byte sRegirockSprites14
+.4byte sRegirockSprites15
+.4byte sRegirockSprites16
+.4byte sRegirockSprites17
+.4byte sRegirockSprites18
+.4byte sRegirockSprites19
+.4byte sRegirockSprites20
+.4byte sRegirockSprites21
+.4byte sRegirockSprites22
+.4byte sRegirockSprites23
+.4byte sRegirockSprites24
+.4byte sRegirockSprites25
+.4byte sRegirockSprites26
+.4byte sRegirockSprites27
+.4byte sRegirockSprites28
+.4byte sRegirockSprites29
+.4byte sRegirockSprites30
+.4byte sRegirockSprites31
+.4byte sRegirockSprites32
+.4byte sRegirockSprites33
+.4byte sRegirockSprites34
+.4byte sRegirockSprites35
+.4byte sRegirockSprites36
+.4byte sRegirockSprites37
+.4byte sRegirockSprites38
+.4byte sRegirockSprites39
+.4byte sRegirockSprites40
+.4byte sRegirockSprites41
+.4byte sRegirockSprites42
+.4byte sRegirockSprites43
+.4byte sRegirockSprites44
+.4byte sRegirockSprites45
+.4byte sRegirockSprites46
+.4byte sRegirockSprites47
+.4byte sRegirockSprites48
+.4byte sRegirockSprites49
+.4byte sRegirockSprites50
+.4byte sRegirockSprites51
+.4byte sRegirockSprites52
+.4byte sRegirockSprites53
+.4byte sRegirockSprites54
+.4byte sRegirockSprites55
+.4byte sRegirockSprites56
+.4byte sRegirockSprites57
+.4byte sRegirockSprites58
+.4byte sRegirockSprites59
+.4byte sRegirockSprites60
+.4byte sRegirockSprites61
+.4byte sRegirockSprites62
+.4byte sRegirockSprites63
+.4byte sRegirockSprites64
+.4byte sRegirockSprites65
+.4byte sRegirockSprites66
+.4byte sRegirockSprites67
+.4byte sRegirockSprites68
+.4byte sRegirockSprites69
+.4byte sRegirockSprites70
+.4byte sRegirockSprites71
+.4byte sRegirockSprites72
+.4byte sRegirockSprites73
+.4byte sRegirockSprites74
+.4byte sRegirockSprites75
+.4byte sRegirockSprites76
+.4byte sRegirockSprites77
+.4byte sRegirockSprites78
+.4byte sRegirockSprites79
+.4byte sRegirockSprites80
+.4byte sRegirockSprites81
+.4byte sRegirockSprites82
+.4byte sRegirockSprites83
+.4byte sRegirockSprites84
+.4byte sRegirockSprites85
+sAxMainRegirock:
+ax_main sAxPosesRegirock, sAxAnimationsRegirock, 13, sAxSpritesRegirock, sAxPositionsRegirock

--- a/data/ax/registeel.inc
+++ b/data/ax/registeel.inc
@@ -1,0 +1,2713 @@
+.global gAxRegisteel
+gAxRegisteel:
+ax_siro sAxMainRegisteel
+sRegisteelPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose4:
+ax_pose 3, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose5:
+ax_pose 4, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose6:
+ax_pose 5, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose9:
+ax_pose 8, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose10:
+ax_pose 9, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose11:
+ax_pose 10, 0x01e5, 0x90f3, 0x5c00
+ax_pose_terminator
+sRegisteelPose12:
+ax_pose 11, 0x01e5, 0x90f2, 0x5c00
+ax_pose_terminator
+sRegisteelPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose16:
+ax_pose 9, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose17:
+ax_pose 10, 0x01e5, 0x80ec, 0x5c00
+ax_pose_terminator
+sRegisteelPose18:
+ax_pose 11, 0x01e5, 0x80ed, 0x5c00
+ax_pose_terminator
+sRegisteelPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose22:
+ax_pose 3, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose23:
+ax_pose 4, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose24:
+ax_pose 5, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose26:
+ax_pose 15, 0x41e7, 0x80ee, 0x5c00
+ax_pose 16, 0x01f7, 0x40f6, 0x5c08
+ax_pose 17, 0x81f7, 0x0106, 0x5c0c
+ax_pose 18, 0x01e8, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose27:
+ax_pose 3, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose28:
+ax_pose 19, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sRegisteelPose29:
+ax_pose 6, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose30:
+ax_pose 20, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sRegisteelPose31:
+ax_pose 9, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose32:
+ax_pose 21, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose33:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose34:
+ax_pose 22, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose35:
+ax_pose 9, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose36:
+ax_pose 21, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose37:
+ax_pose 6, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose38:
+ax_pose 20, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sRegisteelPose39:
+ax_pose 3, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose40:
+ax_pose 19, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sRegisteelPose41:
+ax_pose 0, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose42:
+ax_pose 15, 0x41e7, 0x80ee, 0x5c00
+ax_pose 16, 0x01f7, 0x40f6, 0x5c08
+ax_pose 17, 0x81f7, 0x0106, 0x5c0c
+ax_pose 18, 0x01e8, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose43:
+ax_pose 3, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose44:
+ax_pose 19, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sRegisteelPose45:
+ax_pose 6, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose46:
+ax_pose 20, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sRegisteelPose47:
+ax_pose 9, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose48:
+ax_pose 21, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose49:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose50:
+ax_pose 22, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose51:
+ax_pose 9, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose52:
+ax_pose 21, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose53:
+ax_pose 6, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose54:
+ax_pose 20, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sRegisteelPose55:
+ax_pose 3, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose56:
+ax_pose 19, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sRegisteelPose57:
+ax_pose 0, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose58:
+ax_pose 15, 0x41e7, 0x80ee, 0x5c00
+ax_pose 16, 0x01f7, 0x40f6, 0x5c08
+ax_pose 17, 0x81f7, 0x0106, 0x5c0c
+ax_pose 18, 0x01e8, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose59:
+ax_pose 23, 0x41f6, 0x80ee, 0x5c00
+ax_pose 24, 0x41ee, 0x40ee, 0x5c08
+ax_pose 25, 0x41e6, 0x00f6, 0x5c0c
+ax_pose 26, 0x01fe, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose60:
+ax_pose 3, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose61:
+ax_pose 19, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sRegisteelPose62:
+ax_pose 27, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose63:
+ax_pose 6, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose64:
+ax_pose 20, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sRegisteelPose65:
+ax_pose 28, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose66:
+ax_pose 9, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose67:
+ax_pose 21, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose68:
+ax_pose 29, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose69:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose70:
+ax_pose 22, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose71:
+ax_pose 30, 0x41f2, 0x80ee, 0x5c00
+ax_pose 31, 0x41ea, 0x40ee, 0x5c08
+ax_pose 32, 0x41e2, 0x00f6, 0x5c0c
+ax_pose 33, 0x01f8, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose72:
+ax_pose 9, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose73:
+ax_pose 21, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose74:
+ax_pose 29, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose75:
+ax_pose 6, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose76:
+ax_pose 20, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sRegisteelPose77:
+ax_pose 28, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose78:
+ax_pose 3, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose79:
+ax_pose 19, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sRegisteelPose80:
+ax_pose 27, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose81:
+ax_pose 34, 0x41e9, 0x80ef, 0x5c00
+ax_pose 35, 0x01f9, 0x40f7, 0x5c08
+ax_pose 36, 0x01e1, 0x00ed, 0x5c0c
+ax_pose 37, 0x01e1, 0x010a, 0x5c0d
+ax_pose 38, 0x01f9, 0x0107, 0x5c0e
+ax_pose 39, 0x01e9, 0x010f, 0x5c0f
+ax_pose_terminator
+sRegisteelPose82:
+ax_pose 40, 0x81e5, 0x90ff, 0x5c00
+ax_pose 41, 0x81e5, 0x50f7, 0x5c08
+ax_pose 42, 0x81e5, 0x10ef, 0x5c0c
+ax_pose 43, 0x01dd, 0x1105, 0x5c0e
+ax_pose 44, 0x01f5, 0x10ef, 0x5c0f
+ax_pose_terminator
+sRegisteelPose83:
+ax_pose 45, 0x81e5, 0x90f8, 0x5c00
+ax_pose 46, 0x81ed, 0x10f0, 0x5c08
+ax_pose 47, 0x01dd, 0x10ff, 0x5c0a
+ax_pose_terminator
+sRegisteelPose84:
+ax_pose 48, 0x41e5, 0x90f4, 0x5c00
+ax_pose 49, 0x01f5, 0x50f4, 0x5c08
+ax_pose 50, 0x81f5, 0x1104, 0x5c0c
+ax_pose 51, 0x01dd, 0x10f4, 0x5c0e
+ax_pose_terminator
+sRegisteelPose85:
+ax_pose 52, 0x41e9, 0x80f0, 0x5c00
+ax_pose 53, 0x01e1, 0x0109, 0x5c08
+ax_pose 54, 0x01e1, 0x00f0, 0x5c09
+ax_pose 55, 0x01e3, 0x00e8, 0x5c0a
+ax_pose 56, 0x01f9, 0x00f0, 0x5c0b
+ax_pose 57, 0x01f9, 0x40f8, 0x5c0c
+ax_pose_terminator
+sRegisteelPose86:
+ax_pose 48, 0x41e5, 0x80eb, 0x5c00
+ax_pose 49, 0x01f5, 0x40fb, 0x5c08
+ax_pose 50, 0x81f5, 0x00f3, 0x5c0c
+ax_pose 51, 0x01dd, 0x0103, 0x5c0e
+ax_pose_terminator
+sRegisteelPose87:
+ax_pose 45, 0x81e5, 0x80f7, 0x5c00
+ax_pose 46, 0x81ed, 0x0107, 0x5c08
+ax_pose 47, 0x01dd, 0x00f8, 0x5c0a
+ax_pose_terminator
+sRegisteelPose88:
+ax_pose 40, 0x81e5, 0x80f0, 0x5c00
+ax_pose 41, 0x81e5, 0x4100, 0x5c08
+ax_pose 42, 0x81e5, 0x0108, 0x5c0c
+ax_pose 43, 0x01dd, 0x00f2, 0x5c0e
+ax_pose 44, 0x01f5, 0x0108, 0x5c0f
+ax_pose_terminator
+sRegisteelPose89:
+ax_pose 58, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose90:
+ax_pose 59, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose91:
+ax_pose 60, 0x81de, 0x80f0, 0x5c00
+ax_pose 61, 0x01f6, 0x0110, 0x5c08
+ax_pose 62, 0x81ee, 0x0108, 0x5c09
+ax_pose 63, 0x01e6, 0x0108, 0x5c0b
+ax_pose 64, 0x81de, 0x4100, 0x5c0c
+ax_pose_terminator
+sRegisteelPose92:
+ax_pose 65, 0x01e2, 0x90f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose93:
+ax_pose 66, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose94:
+ax_pose 67, 0x81e4, 0x90fa, 0x5c00
+ax_pose 68, 0x01dc, 0x10fa, 0x5c08
+ax_pose 69, 0x81ec, 0x110a, 0x5c09
+ax_pose 70, 0x81e4, 0x50f2, 0x5c0b
+ax_pose_terminator
+sRegisteelPose95:
+ax_pose 71, 0x81de, 0x4107, 0x5c00
+ax_pose 72, 0x01e6, 0x010f, 0x5c04
+ax_pose 73, 0x81ee, 0x00ef, 0x5c05
+ax_pose 74, 0x81de, 0x80f7, 0x5c07
+ax_pose_terminator
+sRegisteelPose96:
+ax_pose 67, 0x81e4, 0x80f6, 0x5c00
+ax_pose 68, 0x01dc, 0x00fe, 0x5c08
+ax_pose 69, 0x81ec, 0x00ee, 0x5c09
+ax_pose 70, 0x81e4, 0x4106, 0x5c0b
+ax_pose_terminator
+sRegisteelPose97:
+ax_pose 66, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose98:
+ax_pose 65, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose99:
+ax_pose 0, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose100:
+ax_pose 15, 0x41e7, 0x80ee, 0x5c00
+ax_pose 16, 0x01f7, 0x40f6, 0x5c08
+ax_pose 17, 0x81f7, 0x0106, 0x5c0c
+ax_pose 18, 0x01e8, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose101:
+ax_pose 23, 0x41f6, 0x80ee, 0x5c00
+ax_pose 24, 0x41ee, 0x40ee, 0x5c08
+ax_pose 25, 0x41e6, 0x00f6, 0x5c0c
+ax_pose 26, 0x01fe, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose102:
+ax_pose 3, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose103:
+ax_pose 19, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sRegisteelPose104:
+ax_pose 27, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose105:
+ax_pose 6, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose106:
+ax_pose 20, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sRegisteelPose107:
+ax_pose 28, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose108:
+ax_pose 9, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose109:
+ax_pose 21, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose110:
+ax_pose 29, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose111:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose112:
+ax_pose 22, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose113:
+ax_pose 30, 0x41f2, 0x80ee, 0x5c00
+ax_pose 31, 0x41ea, 0x40ee, 0x5c08
+ax_pose 32, 0x41e2, 0x00f6, 0x5c0c
+ax_pose 33, 0x01f8, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose114:
+ax_pose 9, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose115:
+ax_pose 21, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose116:
+ax_pose 29, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose117:
+ax_pose 6, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose118:
+ax_pose 20, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sRegisteelPose119:
+ax_pose 28, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose120:
+ax_pose 3, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose121:
+ax_pose 19, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sRegisteelPose122:
+ax_pose 27, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose123:
+ax_pose 34, 0x41e9, 0x80ef, 0x5c00
+ax_pose 35, 0x01f9, 0x40f7, 0x5c08
+ax_pose 36, 0x01e1, 0x00ed, 0x5c0c
+ax_pose 37, 0x01e1, 0x010a, 0x5c0d
+ax_pose 38, 0x01f9, 0x0107, 0x5c0e
+ax_pose 39, 0x01e9, 0x010f, 0x5c0f
+ax_pose_terminator
+sRegisteelPose124:
+ax_pose 40, 0x81e5, 0x80f0, 0x5c00
+ax_pose 41, 0x81e5, 0x4100, 0x5c08
+ax_pose 42, 0x81e5, 0x0108, 0x5c0c
+ax_pose 43, 0x01dd, 0x00f2, 0x5c0e
+ax_pose 44, 0x01f5, 0x0108, 0x5c0f
+ax_pose_terminator
+sRegisteelPose125:
+ax_pose 45, 0x81e5, 0x80f7, 0x5c00
+ax_pose 46, 0x81ed, 0x0107, 0x5c08
+ax_pose 47, 0x01dd, 0x00f8, 0x5c0a
+ax_pose_terminator
+sRegisteelPose126:
+ax_pose 48, 0x41e5, 0x80eb, 0x5c00
+ax_pose 49, 0x01f5, 0x40fb, 0x5c08
+ax_pose 50, 0x81f5, 0x00f3, 0x5c0c
+ax_pose 51, 0x01dd, 0x0103, 0x5c0e
+ax_pose_terminator
+sRegisteelPose127:
+ax_pose 52, 0x41e9, 0x80f0, 0x5c00
+ax_pose 53, 0x01e1, 0x0109, 0x5c08
+ax_pose 54, 0x01e1, 0x00f0, 0x5c09
+ax_pose 55, 0x01e3, 0x00e8, 0x5c0a
+ax_pose 56, 0x01f9, 0x00f0, 0x5c0b
+ax_pose 57, 0x01f9, 0x40f8, 0x5c0c
+ax_pose_terminator
+sRegisteelPose128:
+ax_pose 48, 0x41e5, 0x90f4, 0x5c00
+ax_pose 49, 0x01f5, 0x50f4, 0x5c08
+ax_pose 50, 0x81f5, 0x1104, 0x5c0c
+ax_pose 51, 0x01dd, 0x10f4, 0x5c0e
+ax_pose_terminator
+sRegisteelPose129:
+ax_pose 45, 0x81e5, 0x90f8, 0x5c00
+ax_pose 46, 0x81ed, 0x10f0, 0x5c08
+ax_pose 47, 0x01dd, 0x10ff, 0x5c0a
+ax_pose_terminator
+sRegisteelPose130:
+ax_pose 40, 0x81e5, 0x90ff, 0x5c00
+ax_pose 41, 0x81e5, 0x50f7, 0x5c08
+ax_pose 42, 0x81e5, 0x10ef, 0x5c0c
+ax_pose 43, 0x01dd, 0x1105, 0x5c0e
+ax_pose 44, 0x01f5, 0x10ef, 0x5c0f
+ax_pose_terminator
+sRegisteelPose131:
+ax_pose 23, 0x41f6, 0x80ef, 0x5c00
+ax_pose 24, 0x41ee, 0x40ef, 0x5c08
+ax_pose 25, 0x41e6, 0x00f7, 0x5c0c
+ax_pose 26, 0x01fe, 0x010f, 0x5c0e
+ax_pose_terminator
+sRegisteelPose132:
+ax_pose 27, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose133:
+ax_pose 28, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose134:
+ax_pose 29, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sRegisteelPose135:
+ax_pose 30, 0x41f4, 0x80ef, 0x5c00
+ax_pose 31, 0x41ec, 0x40ef, 0x5c08
+ax_pose 32, 0x41e4, 0x00f7, 0x5c0c
+ax_pose 33, 0x01fa, 0x010f, 0x5c0e
+ax_pose_terminator
+sRegisteelPose136:
+ax_pose 29, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose137:
+ax_pose 28, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose138:
+ax_pose 27, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose139:
+ax_pose 0, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose140:
+ax_pose 23, 0x41f5, 0x80ee, 0x5c00
+ax_pose 24, 0x41ed, 0x40ee, 0x5c08
+ax_pose 25, 0x41e5, 0x00f6, 0x5c0c
+ax_pose 26, 0x01fd, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose141:
+ax_pose 34, 0x41e8, 0x80ef, 0x5c00
+ax_pose 35, 0x01f8, 0x40f7, 0x5c08
+ax_pose 36, 0x01e0, 0x00ed, 0x5c0c
+ax_pose 37, 0x01e0, 0x010a, 0x5c0d
+ax_pose 38, 0x01f8, 0x0107, 0x5c0e
+ax_pose 39, 0x01e8, 0x010f, 0x5c0f
+ax_pose_terminator
+sRegisteelPose142:
+ax_pose 3, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose143:
+ax_pose 27, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose144:
+ax_pose 40, 0x81e5, 0x90ff, 0x5c00
+ax_pose 41, 0x81e5, 0x50f7, 0x5c08
+ax_pose 42, 0x81e5, 0x10ef, 0x5c0c
+ax_pose 43, 0x01dd, 0x1105, 0x5c0e
+ax_pose 44, 0x01f5, 0x10ef, 0x5c0f
+ax_pose_terminator
+sRegisteelPose145:
+ax_pose 6, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose146:
+ax_pose 28, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose147:
+ax_pose 45, 0x81e5, 0x90f8, 0x5c00
+ax_pose 46, 0x81ed, 0x10f0, 0x5c08
+ax_pose 47, 0x01dd, 0x10ff, 0x5c0a
+ax_pose_terminator
+sRegisteelPose148:
+ax_pose 9, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose149:
+ax_pose 29, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose150:
+ax_pose 48, 0x41e5, 0x90f4, 0x5c00
+ax_pose 49, 0x01f5, 0x50f4, 0x5c08
+ax_pose 50, 0x81f5, 0x1104, 0x5c0c
+ax_pose 51, 0x01dd, 0x10f4, 0x5c0e
+ax_pose_terminator
+sRegisteelPose151:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose152:
+ax_pose 30, 0x41f2, 0x80ee, 0x5c00
+ax_pose 31, 0x41ea, 0x40ee, 0x5c08
+ax_pose 32, 0x41e2, 0x00f6, 0x5c0c
+ax_pose 33, 0x01f8, 0x010e, 0x5c0e
+ax_pose_terminator
+sRegisteelPose153:
+ax_pose 52, 0x41e9, 0x80f0, 0x5c00
+ax_pose 53, 0x01e1, 0x0109, 0x5c08
+ax_pose 54, 0x01e1, 0x00f0, 0x5c09
+ax_pose 55, 0x01e3, 0x00e8, 0x5c0a
+ax_pose 56, 0x01f9, 0x00f0, 0x5c0b
+ax_pose 57, 0x01f9, 0x40f8, 0x5c0c
+ax_pose_terminator
+sRegisteelPose154:
+ax_pose 9, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose155:
+ax_pose 29, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose156:
+ax_pose 48, 0x41e5, 0x80ec, 0x5c00
+ax_pose 49, 0x01f5, 0x40fc, 0x5c08
+ax_pose 50, 0x81f5, 0x00f4, 0x5c0c
+ax_pose 51, 0x01dd, 0x0104, 0x5c0e
+ax_pose_terminator
+sRegisteelPose157:
+ax_pose 6, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose158:
+ax_pose 28, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose159:
+ax_pose 45, 0x81e5, 0x80f8, 0x5c00
+ax_pose 46, 0x81ed, 0x0108, 0x5c08
+ax_pose 47, 0x01dd, 0x00f9, 0x5c0a
+ax_pose_terminator
+sRegisteelPose160:
+ax_pose 3, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose161:
+ax_pose 27, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose162:
+ax_pose 40, 0x81e5, 0x80f1, 0x5c00
+ax_pose 41, 0x81e5, 0x4101, 0x5c08
+ax_pose 42, 0x81e5, 0x0109, 0x5c0c
+ax_pose 43, 0x01dd, 0x00f3, 0x5c0e
+ax_pose 44, 0x01f5, 0x0109, 0x5c0f
+ax_pose_terminator
+sRegisteelPose163:
+ax_pose 15, 0x41e8, 0x80ef, 0x5c00
+ax_pose 16, 0x01f8, 0x40f7, 0x5c08
+ax_pose 17, 0x81f8, 0x0107, 0x5c0c
+ax_pose 18, 0x01e9, 0x010f, 0x5c0e
+ax_pose_terminator
+sRegisteelPose164:
+ax_pose 19, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sRegisteelPose165:
+ax_pose 20, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose166:
+ax_pose 21, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sRegisteelPose167:
+ax_pose 22, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose168:
+ax_pose 21, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sRegisteelPose169:
+ax_pose 20, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose170:
+ax_pose 19, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sRegisteelPose171:
+ax_pose 0, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose172:
+ax_pose 3, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose173:
+ax_pose 6, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose174:
+ax_pose 9, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sRegisteelPose175:
+ax_pose 12, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sRegisteelPose176:
+ax_pose 9, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sRegisteelPose177:
+ax_pose 6, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sRegisteelPose178:
+ax_pose 3, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+.align 2
+sRegisteelAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 21, 0, 18,
+ax_anim 2, 1, 25, 1, 21, 1, 18,
+ax_anim 2, 0, 25, 0, 21, 0, 18,
+ax_anim 2, 0, 25, 1, 21, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRegisteelAnims_2_2:
+ax_anim 2, 0, 26, -1, -1, -1, -1,
+ax_anim 6, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 21, 20, 21, 20,
+ax_anim 2, 1, 27, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 22, 19, 22, 19,
+ax_anim 2, 0, 26, 6, 6, 6, 6,
+ax_anim_terminator
+sRegisteelAnims_2_3:
+ax_anim 2, 0, 28, -1, 0, -1, 0,
+ax_anim 6, 0, 28, -2, 0, -2, 0,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 6, 0, 6, 0,
+ax_anim 1, 0, 29, 12, 0, 12, 0,
+ax_anim 2, 0, 29, 23, 0, 23, 0,
+ax_anim 2, 1, 29, 23, 1, 23, 1,
+ax_anim 2, 0, 29, 23, 0, 23, 0,
+ax_anim 2, 0, 29, 23, 1, 23, 1,
+ax_anim 2, 0, 28, 6, 0, 6, 0,
+ax_anim_terminator
+sRegisteelAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 6, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 31, 0, -1, 0, -1,
+ax_anim 1, 2, 31, 5, -5, 5, -5,
+ax_anim 1, 0, 31, 12, -11, 12, -11,
+ax_anim 2, 0, 31, 20, -16, 20, -16,
+ax_anim 2, 1, 31, 21, -15, 21, -15,
+ax_anim 2, 0, 31, 20, -16, 20, -16,
+ax_anim 2, 0, 31, 21, -15, 21, -15,
+ax_anim 2, 0, 30, 6, -6, 6, -6,
+ax_anim_terminator
+sRegisteelAnims_2_5:
+ax_anim 2, 0, 32, 0, 1, 0, 1,
+ax_anim 6, 0, 32, 0, 2, 0, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, -4, 0, -4,
+ax_anim 1, 0, 33, 0, -9, 0, -9,
+ax_anim 2, 0, 33, 0, -16, 0, -16,
+ax_anim 2, 1, 33, 1, -16, 1, -16,
+ax_anim 2, 0, 33, 0, -16, 0, -16,
+ax_anim 2, 0, 33, 1, -16, 1, -16,
+ax_anim 2, 0, 32, 0, -6, 0, -6,
+ax_anim_terminator
+sRegisteelAnims_2_6:
+ax_anim 2, 0, 34, 1, 1, 1, 1,
+ax_anim 6, 0, 34, 2, 2, 2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 35, -5, -5, -5, -5,
+ax_anim 1, 0, 35, -12, -11, -12, -11,
+ax_anim 2, 0, 35, -20, -16, -20, -16,
+ax_anim 2, 1, 35, -21, -15, -21, -15,
+ax_anim 2, 0, 35, -20, -16, -20, -16,
+ax_anim 2, 0, 35, -21, -15, -21, -15,
+ax_anim 2, 0, 34, -6, -6, -6, -6,
+ax_anim_terminator
+sRegisteelAnims_2_7:
+ax_anim 2, 0, 36, 1, 0, 1, 0,
+ax_anim 6, 0, 36, 2, 0, 2, 0,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, -6, 0, -6, 0,
+ax_anim 1, 0, 37, -12, 0, -12, 0,
+ax_anim 2, 0, 37, -23, 0, -23, 0,
+ax_anim 2, 1, 37, -23, 1, -23, 1,
+ax_anim 2, 0, 37, -23, 0, -23, 0,
+ax_anim 2, 0, 37, -23, 1, -23, 1,
+ax_anim 2, 0, 36, -6, 0, -6, 0,
+ax_anim_terminator
+sRegisteelAnims_2_8:
+ax_anim 2, 0, 38, 1, -1, 1, -1,
+ax_anim 6, 0, 38, 2, -2, 2, -2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, -4, 4, -4, 4,
+ax_anim 1, 0, 39, -10, 10, -10, 10,
+ax_anim 2, 0, 39, -21, 20, -21, 20,
+ax_anim 2, 1, 39, -22, 19, -22, 19,
+ax_anim 2, 0, 39, -21, 20, -21, 20,
+ax_anim 2, 0, 39, -22, 19, -22, 19,
+ax_anim 2, 0, 38, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 6, 0, 40, 0, -2, 0, -2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 41, 0, 10, 0, 10,
+ax_anim 2, 0, 41, 0, 21, 0, 18,
+ax_anim 2, 1, 41, 1, 21, 1, 18,
+ax_anim 2, 0, 41, 0, 21, 0, 18,
+ax_anim 2, 0, 41, 1, 21, 1, 18,
+ax_anim 2, 0, 40, 0, 6, 0, 6,
+ax_anim_terminator
+sRegisteelAnims_3_2:
+ax_anim 2, 0, 42, -1, -1, -1, -1,
+ax_anim 6, 0, 42, -2, -2, -2, -2,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 4, 4, 4, 4,
+ax_anim 1, 0, 43, 10, 10, 10, 10,
+ax_anim 2, 0, 43, 21, 20, 21, 20,
+ax_anim 2, 1, 43, 22, 19, 22, 19,
+ax_anim 2, 0, 43, 21, 20, 21, 20,
+ax_anim 2, 0, 43, 22, 19, 22, 19,
+ax_anim 2, 0, 42, 6, 6, 6, 6,
+ax_anim_terminator
+sRegisteelAnims_3_3:
+ax_anim 2, 0, 44, -1, 0, -1, 0,
+ax_anim 6, 0, 44, -2, 0, -2, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 6, 0, 6, 0,
+ax_anim 1, 0, 45, 12, 0, 12, 0,
+ax_anim 2, 0, 45, 23, 0, 23, 0,
+ax_anim 2, 1, 45, 23, 1, 23, 1,
+ax_anim 2, 0, 45, 23, 0, 23, 0,
+ax_anim 2, 0, 45, 23, 1, 23, 1,
+ax_anim 2, 0, 44, 6, 0, 6, 0,
+ax_anim_terminator
+sRegisteelAnims_3_4:
+ax_anim 2, 0, 46, -1, 1, -1, 1,
+ax_anim 6, 0, 46, -2, 2, -2, 2,
+ax_anim 1, 0, 47, 0, -1, 0, -1,
+ax_anim 1, 2, 47, 5, -5, 5, -5,
+ax_anim 1, 0, 47, 12, -11, 12, -11,
+ax_anim 2, 0, 47, 20, -16, 20, -16,
+ax_anim 2, 1, 47, 21, -15, 21, -15,
+ax_anim 2, 0, 47, 20, -16, 20, -16,
+ax_anim 2, 0, 47, 21, -15, 21, -15,
+ax_anim 2, 0, 46, 6, -6, 6, -6,
+ax_anim_terminator
+sRegisteelAnims_3_5:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 6, 0, 48, 0, 2, 0, 2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, -4, 0, -4,
+ax_anim 1, 0, 49, 0, -9, 0, -9,
+ax_anim 2, 0, 49, 0, -16, 0, -16,
+ax_anim 2, 1, 49, 1, -16, 1, -16,
+ax_anim 2, 0, 49, 0, -16, 0, -16,
+ax_anim 2, 0, 49, 1, -16, 1, -16,
+ax_anim 2, 0, 48, 0, -6, 0, -6,
+ax_anim_terminator
+sRegisteelAnims_3_6:
+ax_anim 2, 0, 50, 1, 1, 1, 1,
+ax_anim 6, 0, 50, 2, 2, 2, 2,
+ax_anim 1, 0, 51, 0, -1, 0, -1,
+ax_anim 1, 2, 51, -5, -5, -5, -5,
+ax_anim 1, 0, 51, -12, -11, -12, -11,
+ax_anim 2, 0, 51, -20, -16, -20, -16,
+ax_anim 2, 1, 51, -21, -15, -21, -15,
+ax_anim 2, 0, 51, -20, -16, -20, -16,
+ax_anim 2, 0, 51, -21, -15, -21, -15,
+ax_anim 2, 0, 50, -6, -6, -6, -6,
+ax_anim_terminator
+sRegisteelAnims_3_7:
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 6, 0, 52, 2, 0, 2, 0,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -6, 0, -6, 0,
+ax_anim 1, 0, 53, -12, 0, -12, 0,
+ax_anim 2, 0, 53, -23, 0, -23, 0,
+ax_anim 2, 1, 53, -23, 1, -23, 1,
+ax_anim 2, 0, 53, -23, 0, -23, 0,
+ax_anim 2, 0, 53, -23, 1, -23, 1,
+ax_anim 2, 0, 52, -6, 0, -6, 0,
+ax_anim_terminator
+sRegisteelAnims_3_8:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 6, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 1, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 0, 55, -22, 19, -22, 19,
+ax_anim 2, 0, 54, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_4_1:
+ax_anim 8, 2, 58, 0, 0, 0, 0,
+ax_anim 1, 1, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 0, -8, 0, -8,
+ax_anim 1, 0, 58, 0, -10, 0, -10,
+ax_anim 4, 0, 58, 0, -11, 0, -11,
+ax_anim 4, 0, 56, 0, -11, 0, -11,
+ax_anim 2, 0, 56, 0, -8, 0, -8,
+ax_anim 2, 0, 56, 0, -4, 0, -4,
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim_terminator
+sRegisteelAnims_4_2:
+ax_anim 8, 2, 61, 0, 0, 0, 0,
+ax_anim 1, 1, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 61, -8, -8, -8, -8,
+ax_anim 1, 0, 61, -10, -10, -10, -10,
+ax_anim 4, 0, 61, -11, -11, -11, -11,
+ax_anim 4, 0, 59, -11, -11, -11, -11,
+ax_anim 2, 0, 59, -8, -8, -8, -8,
+ax_anim 2, 0, 59, -4, -4, -4, -4,
+ax_anim 2, 0, 59, -2, -2, -2, -2,
+ax_anim_terminator
+sRegisteelAnims_4_3:
+ax_anim 8, 2, 64, 0, 0, 0, 0,
+ax_anim 1, 1, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -8, 0, -8, 0,
+ax_anim 1, 0, 64, -10, 0, -10, 0,
+ax_anim 4, 0, 64, -11, 0, -11, 0,
+ax_anim 4, 0, 62, -11, 0, -11, 0,
+ax_anim 2, 0, 62, -8, 0, -8, 0,
+ax_anim 2, 0, 62, -4, 0, -4, 0,
+ax_anim 2, 0, 62, -2, 0, -2, 0,
+ax_anim_terminator
+sRegisteelAnims_4_4:
+ax_anim 8, 2, 67, 0, 0, 0, 0,
+ax_anim 1, 1, 67, 0, 0, 0, 0,
+ax_anim 1, 0, 67, -8, 8, -8, 8,
+ax_anim 1, 0, 67, -10, 10, -10, 10,
+ax_anim 4, 0, 67, -11, 11, -11, 11,
+ax_anim 4, 0, 65, -11, 11, -11, 11,
+ax_anim 2, 0, 65, -8, 8, -8, 8,
+ax_anim 2, 0, 65, -4, 4, -4, 4,
+ax_anim 2, 0, 65, -2, 2, -2, 2,
+ax_anim_terminator
+sRegisteelAnims_4_5:
+ax_anim 8, 2, 70, 0, 0, 0, 0,
+ax_anim 1, 1, 70, 0, 0, 0, 0,
+ax_anim 1, 0, 70, 0, 8, 0, 8,
+ax_anim 1, 0, 70, 0, 10, 0, 10,
+ax_anim 4, 0, 70, 0, 11, 0, 11,
+ax_anim 4, 0, 68, 0, 11, 0, 11,
+ax_anim 2, 0, 68, 0, 8, 0, 8,
+ax_anim 2, 0, 68, 0, 4, 0, 4,
+ax_anim 2, 0, 68, 0, 2, 0, 2,
+ax_anim_terminator
+sRegisteelAnims_4_6:
+ax_anim 8, 2, 73, 0, 0, 0, 0,
+ax_anim 1, 1, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 8, 8, 8, 8,
+ax_anim 1, 0, 73, 10, 10, 10, 10,
+ax_anim 4, 0, 73, 11, 11, 11, 11,
+ax_anim 4, 0, 71, 11, 11, 11, 11,
+ax_anim 2, 0, 71, 8, 8, 8, 8,
+ax_anim 2, 0, 71, 4, 4, 4, 4,
+ax_anim 2, 0, 71, 2, 2, 2, 2,
+ax_anim_terminator
+sRegisteelAnims_4_7:
+ax_anim 8, 2, 76, 0, 0, 0, 0,
+ax_anim 1, 1, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 8, 0, 8, 0,
+ax_anim 1, 0, 76, 10, 0, 10, 0,
+ax_anim 4, 0, 76, 11, 0, 11, 0,
+ax_anim 4, 0, 74, 11, 0, 11, 0,
+ax_anim 2, 0, 74, 8, 0, 8, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim 2, 0, 74, 2, 0, 2, 0,
+ax_anim_terminator
+sRegisteelAnims_4_8:
+ax_anim 8, 2, 79, 0, 0, 0, 0,
+ax_anim 1, 1, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 8, -8, 8, -8,
+ax_anim 1, 0, 79, 10, -10, 10, -10,
+ax_anim 4, 0, 79, 11, -11, 11, -11,
+ax_anim 4, 0, 77, 11, -11, 11, -11,
+ax_anim 2, 0, 77, 8, -8, 8, -8,
+ax_anim 2, 0, 77, 4, -4, 4, -4,
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_5_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 2, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_5_2:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 2, 81, 1, -1, 1, -1,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim 2, 1, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_5_3:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 1, 0, 1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 1, 0, 1,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 2, 82, 0, 1, 0, 1,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 1, 0, 1,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 1, 0, 1,
+ax_anim 2, 1, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 1, 0, 1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 1, 0, 1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_5_4:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 2, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 1, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_5_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 2, 2, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, -1, 0, -1, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_5_6:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 2, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 1, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_5_7:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_5_8:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 2, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 1, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_6_1:
+ax_anim 30, 0, 88, 0, 0, 0, 0,
+ax_anim 35, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_7_1:
+ax_anim 2, 0, 90, 0, -4, 0, -4,
+ax_anim 8, 0, 90, 0, -5, 0, -5,
+ax_anim_terminator
+sRegisteelAnims_7_2:
+ax_anim 2, 0, 91, -4, -4, -4, -4,
+ax_anim 8, 0, 91, -5, -5, -5, -5,
+ax_anim_terminator
+sRegisteelAnims_7_3:
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 8, 0, 92, -5, 0, -5, 0,
+ax_anim_terminator
+sRegisteelAnims_7_4:
+ax_anim 2, 0, 93, -4, 4, -4, 4,
+ax_anim 8, 0, 93, -5, 5, -5, 5,
+ax_anim_terminator
+sRegisteelAnims_7_5:
+ax_anim 2, 0, 94, 0, 4, 0, 4,
+ax_anim 8, 0, 94, 0, 5, 0, 5,
+ax_anim_terminator
+sRegisteelAnims_7_6:
+ax_anim 2, 0, 95, 4, 4, 4, 4,
+ax_anim 8, 0, 95, 5, 5, 5, 5,
+ax_anim_terminator
+sRegisteelAnims_7_7:
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 8, 0, 96, 5, 0, 5, 0,
+ax_anim_terminator
+sRegisteelAnims_7_8:
+ax_anim 2, 0, 97, 4, -4, 4, -4,
+ax_anim 8, 0, 97, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_8_1:
+ax_anim 40, 0, 98, 0, 0, 0, 0,
+ax_anim 40, 0, 100, 0, 1, 0, 1,
+ax_anim_terminator
+sRegisteelAnims_8_2:
+ax_anim 40, 0, 101, 0, 0, 0, 0,
+ax_anim 40, 0, 103, 1, 1, 1, 1,
+ax_anim_terminator
+sRegisteelAnims_8_3:
+ax_anim 40, 0, 104, 0, 0, 0, 0,
+ax_anim 40, 0, 106, 1, 0, 1, 0,
+ax_anim_terminator
+sRegisteelAnims_8_4:
+ax_anim 40, 0, 107, 0, 0, 0, 0,
+ax_anim 40, 0, 109, 1, -1, 1, -1,
+ax_anim_terminator
+sRegisteelAnims_8_5:
+ax_anim 40, 0, 110, 0, 0, 0, 0,
+ax_anim 40, 0, 112, 0, -1, 0, -1,
+ax_anim_terminator
+sRegisteelAnims_8_6:
+ax_anim 40, 0, 113, 0, 0, 0, 0,
+ax_anim 40, 0, 115, -1, -1, -1, -1,
+ax_anim_terminator
+sRegisteelAnims_8_7:
+ax_anim 40, 0, 116, 0, 0, 0, 0,
+ax_anim 40, 0, 118, -1, 0, -1, 0,
+ax_anim_terminator
+sRegisteelAnims_8_8:
+ax_anim 40, 0, 119, 0, 0, 0, 0,
+ax_anim 40, 0, 121, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 6, 3, 6, 3,
+ax_anim 2, 0, 124, 10, 11, 10, 11,
+ax_anim 2, 0, 125, 9, 18, 9, 18,
+ax_anim 3, 0, 126, 0, 21, 0, 21,
+ax_anim 2, 3, 127, -9, 18, -9, 18,
+ax_anim 2, 0, 128, -10, 11, -10, 11,
+ax_anim 1, 0, 129, -6, 3, -6, 3,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 11, 1, 11, 1,
+ax_anim 2, 0, 123, 17, 3, 17, 3,
+ax_anim 2, 0, 124, 23, 10, 23, 10,
+ax_anim 3, 0, 125, 23, 18, 23, 18,
+ax_anim 2, 3, 126, 11, 20, 11, 20,
+ax_anim 2, 0, 127, 2, 15, 2, 15,
+ax_anim 1, 0, 128, 0, 7, 0, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 6, -5, 6, -5,
+ax_anim 2, 0, 122, 13, -6, 13, -6,
+ax_anim 2, 0, 123, 19, -5, 19, -5,
+ax_anim 3, 0, 124, 23, 1, 23, 1,
+ax_anim 2, 3, 125, 20, 5, 20, 5,
+ax_anim 2, 0, 126, 12, 7, 12, 7,
+ax_anim 1, 0, 127, 4, 5, 4, 5,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, -1, -8, -1, -8,
+ax_anim 2, 0, 129, 4, -16, 4, -16,
+ax_anim 2, 0, 122, 12, -20, 12, -20,
+ax_anim 3, 0, 123, 22, -19, 22, -19,
+ax_anim 2, 3, 124, 23, -13, 23, -13,
+ax_anim 2, 0, 125, 19, -4, 19, -4,
+ax_anim 1, 0, 126, 10, 0, 10, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -10, -4, -10, -4,
+ax_anim 2, 0, 128, -11, -11, -11, -11,
+ax_anim 2, 0, 129, -8, -18, -8, -18,
+ax_anim 3, 0, 122, 0, -21, 0, -21,
+ax_anim 2, 3, 123, 8, -18, 8, -18,
+ax_anim 2, 0, 124, 11, -11, 11, -11,
+ax_anim 1, 0, 125, 10, -4, 10, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 1, -8, 1, -8,
+ax_anim 2, 0, 123, -4, -16, -4, -16,
+ax_anim 2, 0, 122, -12, -20, -12, -20,
+ax_anim 3, 0, 129, -22, -19, -22, -19,
+ax_anim 2, 3, 128, -23, -13, -23, -13,
+ax_anim 2, 0, 127, -19, -4, -19, -4,
+ax_anim 1, 0, 126, -10, 0, -10, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -6, -5, -6, -5,
+ax_anim 2, 0, 122, -13, -6, -13, -6,
+ax_anim 2, 0, 129, -19, -5, -19, -5,
+ax_anim 3, 0, 128, -23, 1, -23, 1,
+ax_anim 2, 3, 127, -20, 5, -20, 5,
+ax_anim 2, 0, 126, -12, 7, -12, 7,
+ax_anim 1, 0, 125, -4, 5, -4, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -11, 1, -11, 1,
+ax_anim 2, 0, 129, -17, 3, -17, 3,
+ax_anim 2, 0, 128, -23, 10, -23, 10,
+ax_anim 3, 0, 127, -23, 18, -23, 18,
+ax_anim 2, 3, 126, -11, 20, -11, 20,
+ax_anim 2, 0, 125, -2, 15, -2, 15,
+ax_anim 1, 0, 124, 0, 7, 0, 7,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -10, 0, 0,
+ax_anim 2, 0, 140, 0, -16, 0, 0,
+ax_anim 3, 0, 140, 0, -20, 0, 0,
+ax_anim 4, 0, 140, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -22, 0, 0,
+ax_anim 3, 0, 139, 0, -23, 0, 0,
+ax_anim 2, 0, 139, 0, -18, 0, 0,
+ax_anim 1, 0, 139, 0, -12, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_11_2:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 0, 143, 0, -16, 0, 0,
+ax_anim 3, 0, 143, 0, -20, 0, 0,
+ax_anim 4, 0, 143, 0, -21, 0, 0,
+ax_anim 4, 0, 141, 0, -21, 0, 0,
+ax_anim 3, 0, 142, 0, -22, 0, 0,
+ax_anim 2, 0, 142, 0, -18, 0, 0,
+ax_anim 1, 0, 142, 0, -12, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_11_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 0, 146, 0, -16, 0, 0,
+ax_anim 3, 0, 146, 0, -20, 0, 0,
+ax_anim 4, 0, 146, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -21, 0, 0,
+ax_anim 3, 0, 145, 0, -23, 0, 0,
+ax_anim 2, 0, 145, 0, -18, 0, 0,
+ax_anim 1, 0, 145, 0, -12, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_11_4:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -17, 0, 0,
+ax_anim 1, 0, 148, 0, -11, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 1, 0, 151, 0, -11, 0, 0,
+ax_anim 2, 2, 151, 0, 1, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_11_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 3, 0, 154, 0, -22, 0, 0,
+ax_anim 2, 0, 154, 0, -17, 0, 0,
+ax_anim 1, 0, 154, 0, -11, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_11_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 3, 0, 157, 0, -22, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRegisteelAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sRegisteelGfx1:
+.incbin "baserom.gba", 0x159EC84, 0x200
+sRegisteelSprites1:
+ax_sprite sRegisteelGfx1, 0x200
+ax_sprite_terminator
+sRegisteelGfx2:
+.incbin "baserom.gba", 0x159EE94, 0x200
+sRegisteelSprites2:
+ax_sprite sRegisteelGfx2, 0x200
+ax_sprite_terminator
+sRegisteelGfx3:
+.incbin "baserom.gba", 0x159F0A4, 0x200
+sRegisteelSprites3:
+ax_sprite sRegisteelGfx3, 0x200
+ax_sprite_terminator
+sRegisteelGfx4:
+.incbin "baserom.gba", 0x159F2B4, 0x200
+sRegisteelSprites4:
+ax_sprite sRegisteelGfx4, 0x200
+ax_sprite_terminator
+sRegisteelGfx5:
+.incbin "baserom.gba", 0x159F4C4, 0x200
+sRegisteelSprites5:
+ax_sprite sRegisteelGfx5, 0x200
+ax_sprite_terminator
+sRegisteelGfx6:
+.incbin "baserom.gba", 0x159F6D4, 0x200
+sRegisteelSprites6:
+ax_sprite sRegisteelGfx6, 0x200
+ax_sprite_terminator
+sRegisteelGfx7:
+.incbin "baserom.gba", 0x159F8E4, 0x200
+sRegisteelSprites7:
+ax_sprite sRegisteelGfx7, 0x200
+ax_sprite_terminator
+sRegisteelGfx8:
+.incbin "baserom.gba", 0x159FAF4, 0x200
+sRegisteelSprites8:
+ax_sprite sRegisteelGfx8, 0x200
+ax_sprite_terminator
+sRegisteelGfx9:
+.incbin "baserom.gba", 0x159FD04, 0x200
+sRegisteelSprites9:
+ax_sprite sRegisteelGfx9, 0x200
+ax_sprite_terminator
+sRegisteelGfx10:
+.incbin "baserom.gba", 0x159FF14, 0x200
+sRegisteelSprites10:
+ax_sprite sRegisteelGfx10, 0x200
+ax_sprite_terminator
+sRegisteelGfx11:
+.incbin "baserom.gba", 0x15A0124, 0x200
+sRegisteelSprites11:
+ax_sprite sRegisteelGfx11, 0x200
+ax_sprite_terminator
+sRegisteelGfx12:
+.incbin "baserom.gba", 0x15A0334, 0x200
+sRegisteelSprites12:
+ax_sprite sRegisteelGfx12, 0x200
+ax_sprite_terminator
+sRegisteelGfx13:
+.incbin "baserom.gba", 0x15A0544, 0x200
+sRegisteelSprites13:
+ax_sprite sRegisteelGfx13, 0x200
+ax_sprite_terminator
+sRegisteelGfx14:
+.incbin "baserom.gba", 0x15A0754, 0x200
+sRegisteelSprites14:
+ax_sprite sRegisteelGfx14, 0x200
+ax_sprite_terminator
+sRegisteelGfx15:
+.incbin "baserom.gba", 0x15A0964, 0x200
+sRegisteelSprites15:
+ax_sprite sRegisteelGfx15, 0x200
+ax_sprite_terminator
+sRegisteelGfx16:
+.incbin "baserom.gba", 0x15A0B74, 0x100
+sRegisteelSprites16:
+ax_sprite sRegisteelGfx16, 0x100
+ax_sprite_terminator
+sRegisteelGfx17:
+.incbin "baserom.gba", 0x15A0C84, 0x80
+sRegisteelSprites17:
+ax_sprite sRegisteelGfx17, 0x80
+ax_sprite_terminator
+sRegisteelGfx18:
+.incbin "baserom.gba", 0x15A0D14, 0x40
+sRegisteelSprites18:
+ax_sprite sRegisteelGfx18, 0x40
+ax_sprite_terminator
+sRegisteelGfx19:
+.incbin "baserom.gba", 0x15A0D64, 0x20
+sRegisteelSprites19:
+ax_sprite sRegisteelGfx19, 0x20
+ax_sprite_terminator
+sRegisteelGfx20:
+.incbin "baserom.gba", 0x15A0D94, 0x40
+sRegisteelGfx20_1:
+.incbin "baserom.gba", 0x15A0DD4, 0x160
+sRegisteelSprites20:
+ax_sprite sRegisteelGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRegisteelGfx20_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegisteelGfx21:
+.incbin "baserom.gba", 0x15A0F5C, 0x60
+sRegisteelGfx21_1:
+.incbin "baserom.gba", 0x15A0FBC, 0x100
+sRegisteelGfx21_2:
+.incbin "baserom.gba", 0x15A10BC, 0x60
+sRegisteelSprites21:
+ax_sprite sRegisteelGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx21_2, 0x60
+ax_sprite_terminator
+sRegisteelGfx22:
+.incbin "baserom.gba", 0x15A114C, 0x60
+sRegisteelGfx22_1:
+.incbin "baserom.gba", 0x15A11AC, 0x160
+sRegisteelSprites22:
+ax_sprite sRegisteelGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRegisteelGfx23:
+.incbin "baserom.gba", 0x15A1334, 0x60
+sRegisteelGfx23_1:
+.incbin "baserom.gba", 0x15A1394, 0x180
+sRegisteelSprites23:
+ax_sprite sRegisteelGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx23_1, 0x180
+ax_sprite_terminator
+sRegisteelGfx24:
+.incbin "baserom.gba", 0x15A1534, 0x100
+sRegisteelSprites24:
+ax_sprite sRegisteelGfx24, 0x100
+ax_sprite_terminator
+sRegisteelGfx25:
+.incbin "baserom.gba", 0x15A1644, 0x80
+sRegisteelSprites25:
+ax_sprite sRegisteelGfx25, 0x80
+ax_sprite_terminator
+sRegisteelGfx26:
+.incbin "baserom.gba", 0x15A16D4, 0x40
+sRegisteelSprites26:
+ax_sprite sRegisteelGfx26, 0x40
+ax_sprite_terminator
+sRegisteelGfx27:
+.incbin "baserom.gba", 0x15A1724, 0x20
+sRegisteelSprites27:
+ax_sprite sRegisteelGfx27, 0x20
+ax_sprite_terminator
+sRegisteelGfx28:
+.incbin "baserom.gba", 0x15A1754, 0x40
+sRegisteelGfx28_1:
+.incbin "baserom.gba", 0x15A1794, 0x120
+sRegisteelGfx28_2:
+.incbin "baserom.gba", 0x15A18B4, 0x40
+sRegisteelSprites28:
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx28_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx28_2, 0x40
+ax_sprite_terminator
+sRegisteelGfx29:
+.incbin "baserom.gba", 0x15A192C, 0x40
+sRegisteelGfx29_1:
+.incbin "baserom.gba", 0x15A196C, 0x180
+sRegisteelSprites29:
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx29_1, 0x180
+ax_sprite_terminator
+sRegisteelGfx30:
+.incbin "baserom.gba", 0x15A1B14, 0x40
+sRegisteelGfx30_1:
+.incbin "baserom.gba", 0x15A1B54, 0x180
+sRegisteelSprites30:
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRegisteelGfx30_1, 0x180
+ax_sprite_terminator
+sRegisteelGfx31:
+.incbin "baserom.gba", 0x15A1CFC, 0x100
+sRegisteelSprites31:
+ax_sprite sRegisteelGfx31, 0x100
+ax_sprite_terminator
+sRegisteelGfx32:
+.incbin "baserom.gba", 0x15A1E0C, 0x80
+sRegisteelSprites32:
+ax_sprite sRegisteelGfx32, 0x80
+ax_sprite_terminator
+sRegisteelGfx33:
+.incbin "baserom.gba", 0x15A1E9C, 0x40
+sRegisteelSprites33:
+ax_sprite sRegisteelGfx33, 0x40
+ax_sprite_terminator
+sRegisteelGfx34:
+.incbin "baserom.gba", 0x15A1EEC, 0x20
+sRegisteelSprites34:
+ax_sprite sRegisteelGfx34, 0x20
+ax_sprite_terminator
+sRegisteelGfx35:
+.incbin "baserom.gba", 0x15A1F1C, 0x100
+sRegisteelSprites35:
+ax_sprite sRegisteelGfx35, 0x100
+ax_sprite_terminator
+sRegisteelGfx36:
+.incbin "baserom.gba", 0x15A202C, 0x80
+sRegisteelSprites36:
+ax_sprite sRegisteelGfx36, 0x80
+ax_sprite_terminator
+sRegisteelGfx37:
+.incbin "baserom.gba", 0x15A20BC, 0x20
+sRegisteelSprites37:
+ax_sprite sRegisteelGfx37, 0x20
+ax_sprite_terminator
+sRegisteelGfx38:
+.incbin "baserom.gba", 0x15A20EC, 0x20
+sRegisteelSprites38:
+ax_sprite sRegisteelGfx38, 0x20
+ax_sprite_terminator
+sRegisteelGfx39:
+.incbin "baserom.gba", 0x15A211C, 0x20
+sRegisteelSprites39:
+ax_sprite sRegisteelGfx39, 0x20
+ax_sprite_terminator
+sRegisteelGfx40:
+.incbin "baserom.gba", 0x15A214C, 0x20
+sRegisteelSprites40:
+ax_sprite sRegisteelGfx40, 0x20
+ax_sprite_terminator
+sRegisteelGfx41:
+.incbin "baserom.gba", 0x15A217C, 0x100
+sRegisteelSprites41:
+ax_sprite sRegisteelGfx41, 0x100
+ax_sprite_terminator
+sRegisteelGfx42:
+.incbin "baserom.gba", 0x15A228C, 0x80
+sRegisteelSprites42:
+ax_sprite sRegisteelGfx42, 0x80
+ax_sprite_terminator
+sRegisteelGfx43:
+.incbin "baserom.gba", 0x15A231C, 0x40
+sRegisteelSprites43:
+ax_sprite sRegisteelGfx43, 0x40
+ax_sprite_terminator
+sRegisteelGfx44:
+.incbin "baserom.gba", 0x15A236C, 0x20
+sRegisteelSprites44:
+ax_sprite sRegisteelGfx44, 0x20
+ax_sprite_terminator
+sRegisteelGfx45:
+.incbin "baserom.gba", 0x15A239C, 0x20
+sRegisteelSprites45:
+ax_sprite sRegisteelGfx45, 0x20
+ax_sprite_terminator
+sRegisteelGfx46:
+.incbin "baserom.gba", 0x15A23CC, 0x100
+sRegisteelSprites46:
+ax_sprite sRegisteelGfx46, 0x100
+ax_sprite_terminator
+sRegisteelGfx47:
+.incbin "baserom.gba", 0x15A24DC, 0x40
+sRegisteelSprites47:
+ax_sprite sRegisteelGfx47, 0x40
+ax_sprite_terminator
+sRegisteelGfx48:
+.incbin "baserom.gba", 0x15A252C, 0x20
+sRegisteelSprites48:
+ax_sprite sRegisteelGfx48, 0x20
+ax_sprite_terminator
+sRegisteelGfx49:
+.incbin "baserom.gba", 0x15A255C, 0x100
+sRegisteelSprites49:
+ax_sprite sRegisteelGfx49, 0x100
+ax_sprite_terminator
+sRegisteelGfx50:
+.incbin "baserom.gba", 0x15A266C, 0x80
+sRegisteelSprites50:
+ax_sprite sRegisteelGfx50, 0x80
+ax_sprite_terminator
+sRegisteelGfx51:
+.incbin "baserom.gba", 0x15A26FC, 0x40
+sRegisteelSprites51:
+ax_sprite sRegisteelGfx51, 0x40
+ax_sprite_terminator
+sRegisteelGfx52:
+.incbin "baserom.gba", 0x15A274C, 0x20
+sRegisteelSprites52:
+ax_sprite sRegisteelGfx52, 0x20
+ax_sprite_terminator
+sRegisteelGfx53:
+.incbin "baserom.gba", 0x15A277C, 0x100
+sRegisteelSprites53:
+ax_sprite sRegisteelGfx53, 0x100
+ax_sprite_terminator
+sRegisteelGfx54:
+.incbin "baserom.gba", 0x15A288C, 0x20
+sRegisteelSprites54:
+ax_sprite sRegisteelGfx54, 0x20
+ax_sprite_terminator
+sRegisteelGfx55:
+.incbin "baserom.gba", 0x15A28BC, 0x20
+sRegisteelSprites55:
+ax_sprite sRegisteelGfx55, 0x20
+ax_sprite_terminator
+sRegisteelGfx56:
+.incbin "baserom.gba", 0x15A28EC, 0x20
+sRegisteelSprites56:
+ax_sprite sRegisteelGfx56, 0x20
+ax_sprite_terminator
+sRegisteelGfx57:
+.incbin "baserom.gba", 0x15A291C, 0x20
+sRegisteelSprites57:
+ax_sprite sRegisteelGfx57, 0x20
+ax_sprite_terminator
+sRegisteelGfx58:
+.incbin "baserom.gba", 0x15A294C, 0x80
+sRegisteelSprites58:
+ax_sprite sRegisteelGfx58, 0x80
+ax_sprite_terminator
+sRegisteelGfx59:
+.incbin "baserom.gba", 0x15A29DC, 0x200
+sRegisteelSprites59:
+ax_sprite sRegisteelGfx59, 0x200
+ax_sprite_terminator
+sRegisteelGfx60:
+.incbin "baserom.gba", 0x15A2BEC, 0x200
+sRegisteelSprites60:
+ax_sprite sRegisteelGfx60, 0x200
+ax_sprite_terminator
+sRegisteelGfx61:
+.incbin "baserom.gba", 0x15A2DFC, 0x100
+sRegisteelSprites61:
+ax_sprite sRegisteelGfx61, 0x100
+ax_sprite_terminator
+sRegisteelGfx62:
+.incbin "baserom.gba", 0x15A2F0C, 0x20
+sRegisteelSprites62:
+ax_sprite sRegisteelGfx62, 0x20
+ax_sprite_terminator
+sRegisteelGfx63:
+.incbin "baserom.gba", 0x15A2F3C, 0x40
+sRegisteelSprites63:
+ax_sprite sRegisteelGfx63, 0x40
+ax_sprite_terminator
+sRegisteelGfx64:
+.incbin "baserom.gba", 0x15A2F8C, 0x20
+sRegisteelSprites64:
+ax_sprite sRegisteelGfx64, 0x20
+ax_sprite_terminator
+sRegisteelGfx65:
+.incbin "baserom.gba", 0x15A2FBC, 0x80
+sRegisteelSprites65:
+ax_sprite sRegisteelGfx65, 0x80
+ax_sprite_terminator
+sRegisteelGfx66:
+.incbin "baserom.gba", 0x15A304C, 0x200
+sRegisteelSprites66:
+ax_sprite sRegisteelGfx66, 0x200
+ax_sprite_terminator
+sRegisteelGfx67:
+.incbin "baserom.gba", 0x15A325C, 0x200
+sRegisteelSprites67:
+ax_sprite sRegisteelGfx67, 0x200
+ax_sprite_terminator
+sRegisteelGfx68:
+.incbin "baserom.gba", 0x15A346C, 0x100
+sRegisteelSprites68:
+ax_sprite sRegisteelGfx68, 0x100
+ax_sprite_terminator
+sRegisteelGfx69:
+.incbin "baserom.gba", 0x15A357C, 0x20
+sRegisteelSprites69:
+ax_sprite sRegisteelGfx69, 0x20
+ax_sprite_terminator
+sRegisteelGfx70:
+.incbin "baserom.gba", 0x15A35AC, 0x40
+sRegisteelSprites70:
+ax_sprite sRegisteelGfx70, 0x40
+ax_sprite_terminator
+sRegisteelGfx71:
+.incbin "baserom.gba", 0x15A35FC, 0x80
+sRegisteelSprites71:
+ax_sprite sRegisteelGfx71, 0x80
+ax_sprite_terminator
+sRegisteelGfx72:
+.incbin "baserom.gba", 0x15A368C, 0x80
+sRegisteelSprites72:
+ax_sprite sRegisteelGfx72, 0x80
+ax_sprite_terminator
+sRegisteelGfx73:
+.incbin "baserom.gba", 0x15A371C, 0x20
+sRegisteelSprites73:
+ax_sprite sRegisteelGfx73, 0x20
+ax_sprite_terminator
+sRegisteelGfx74:
+.incbin "baserom.gba", 0x15A374C, 0x40
+sRegisteelSprites74:
+ax_sprite sRegisteelGfx74, 0x40
+ax_sprite_terminator
+sRegisteelGfx75:
+.incbin "baserom.gba", 0x15A379C, 0x100
+sRegisteelSprites75:
+ax_sprite sRegisteelGfx75, 0x100
+ax_sprite_terminator
+sAxPosesRegisteel:
+.4byte sRegisteelPose1
+.4byte sRegisteelPose2
+.4byte sRegisteelPose3
+.4byte sRegisteelPose4
+.4byte sRegisteelPose5
+.4byte sRegisteelPose6
+.4byte sRegisteelPose7
+.4byte sRegisteelPose8
+.4byte sRegisteelPose9
+.4byte sRegisteelPose10
+.4byte sRegisteelPose11
+.4byte sRegisteelPose12
+.4byte sRegisteelPose13
+.4byte sRegisteelPose14
+.4byte sRegisteelPose15
+.4byte sRegisteelPose16
+.4byte sRegisteelPose17
+.4byte sRegisteelPose18
+.4byte sRegisteelPose19
+.4byte sRegisteelPose20
+.4byte sRegisteelPose21
+.4byte sRegisteelPose22
+.4byte sRegisteelPose23
+.4byte sRegisteelPose24
+.4byte sRegisteelPose25
+.4byte sRegisteelPose26
+.4byte sRegisteelPose27
+.4byte sRegisteelPose28
+.4byte sRegisteelPose29
+.4byte sRegisteelPose30
+.4byte sRegisteelPose31
+.4byte sRegisteelPose32
+.4byte sRegisteelPose33
+.4byte sRegisteelPose34
+.4byte sRegisteelPose35
+.4byte sRegisteelPose36
+.4byte sRegisteelPose37
+.4byte sRegisteelPose38
+.4byte sRegisteelPose39
+.4byte sRegisteelPose40
+.4byte sRegisteelPose41
+.4byte sRegisteelPose42
+.4byte sRegisteelPose43
+.4byte sRegisteelPose44
+.4byte sRegisteelPose45
+.4byte sRegisteelPose46
+.4byte sRegisteelPose47
+.4byte sRegisteelPose48
+.4byte sRegisteelPose49
+.4byte sRegisteelPose50
+.4byte sRegisteelPose51
+.4byte sRegisteelPose52
+.4byte sRegisteelPose53
+.4byte sRegisteelPose54
+.4byte sRegisteelPose55
+.4byte sRegisteelPose56
+.4byte sRegisteelPose57
+.4byte sRegisteelPose58
+.4byte sRegisteelPose59
+.4byte sRegisteelPose60
+.4byte sRegisteelPose61
+.4byte sRegisteelPose62
+.4byte sRegisteelPose63
+.4byte sRegisteelPose64
+.4byte sRegisteelPose65
+.4byte sRegisteelPose66
+.4byte sRegisteelPose67
+.4byte sRegisteelPose68
+.4byte sRegisteelPose69
+.4byte sRegisteelPose70
+.4byte sRegisteelPose71
+.4byte sRegisteelPose72
+.4byte sRegisteelPose73
+.4byte sRegisteelPose74
+.4byte sRegisteelPose75
+.4byte sRegisteelPose76
+.4byte sRegisteelPose77
+.4byte sRegisteelPose78
+.4byte sRegisteelPose79
+.4byte sRegisteelPose80
+.4byte sRegisteelPose81
+.4byte sRegisteelPose82
+.4byte sRegisteelPose83
+.4byte sRegisteelPose84
+.4byte sRegisteelPose85
+.4byte sRegisteelPose86
+.4byte sRegisteelPose87
+.4byte sRegisteelPose88
+.4byte sRegisteelPose89
+.4byte sRegisteelPose90
+.4byte sRegisteelPose91
+.4byte sRegisteelPose92
+.4byte sRegisteelPose93
+.4byte sRegisteelPose94
+.4byte sRegisteelPose95
+.4byte sRegisteelPose96
+.4byte sRegisteelPose97
+.4byte sRegisteelPose98
+.4byte sRegisteelPose99
+.4byte sRegisteelPose100
+.4byte sRegisteelPose101
+.4byte sRegisteelPose102
+.4byte sRegisteelPose103
+.4byte sRegisteelPose104
+.4byte sRegisteelPose105
+.4byte sRegisteelPose106
+.4byte sRegisteelPose107
+.4byte sRegisteelPose108
+.4byte sRegisteelPose109
+.4byte sRegisteelPose110
+.4byte sRegisteelPose111
+.4byte sRegisteelPose112
+.4byte sRegisteelPose113
+.4byte sRegisteelPose114
+.4byte sRegisteelPose115
+.4byte sRegisteelPose116
+.4byte sRegisteelPose117
+.4byte sRegisteelPose118
+.4byte sRegisteelPose119
+.4byte sRegisteelPose120
+.4byte sRegisteelPose121
+.4byte sRegisteelPose122
+.4byte sRegisteelPose123
+.4byte sRegisteelPose124
+.4byte sRegisteelPose125
+.4byte sRegisteelPose126
+.4byte sRegisteelPose127
+.4byte sRegisteelPose128
+.4byte sRegisteelPose129
+.4byte sRegisteelPose130
+.4byte sRegisteelPose131
+.4byte sRegisteelPose132
+.4byte sRegisteelPose133
+.4byte sRegisteelPose134
+.4byte sRegisteelPose135
+.4byte sRegisteelPose136
+.4byte sRegisteelPose137
+.4byte sRegisteelPose138
+.4byte sRegisteelPose139
+.4byte sRegisteelPose140
+.4byte sRegisteelPose141
+.4byte sRegisteelPose142
+.4byte sRegisteelPose143
+.4byte sRegisteelPose144
+.4byte sRegisteelPose145
+.4byte sRegisteelPose146
+.4byte sRegisteelPose147
+.4byte sRegisteelPose148
+.4byte sRegisteelPose149
+.4byte sRegisteelPose150
+.4byte sRegisteelPose151
+.4byte sRegisteelPose152
+.4byte sRegisteelPose153
+.4byte sRegisteelPose154
+.4byte sRegisteelPose155
+.4byte sRegisteelPose156
+.4byte sRegisteelPose157
+.4byte sRegisteelPose158
+.4byte sRegisteelPose159
+.4byte sRegisteelPose160
+.4byte sRegisteelPose161
+.4byte sRegisteelPose162
+.4byte sRegisteelPose163
+.4byte sRegisteelPose164
+.4byte sRegisteelPose165
+.4byte sRegisteelPose166
+.4byte sRegisteelPose167
+.4byte sRegisteelPose168
+.4byte sRegisteelPose169
+.4byte sRegisteelPose170
+.4byte sRegisteelPose171
+.4byte sRegisteelPose172
+.4byte sRegisteelPose173
+.4byte sRegisteelPose174
+.4byte sRegisteelPose175
+.4byte sRegisteelPose176
+.4byte sRegisteelPose177
+.4byte sRegisteelPose178
+sAxPositionsRegisteel:
+.2byte   -1,  -14, 	 -13,   -4, 	  11,   -4, 	  -1,  -12
+.2byte    0,  -13, 	 -13,   -2, 	  11,   -5, 	   0,  -11
+.2byte   -2,  -13, 	 -13,   -5, 	  11,   -1, 	  -2,  -11
+.2byte    1,  -14, 	  11,   -9, 	  -6,   -2, 	  -1,  -12
+.2byte    0,  -13, 	  11,   -6, 	  -8,   -3, 	  -1,  -11
+.2byte    2,  -13, 	  10,  -10, 	  -5,    0, 	  -1,  -11
+.2byte    6,  -15, 	  10,  -15, 	   8,   -4, 	  -3,  -10
+.2byte    5,  -14, 	  10,  -13, 	   7,   -5, 	  -3,  -10
+.2byte    4,  -15, 	   9,  -16, 	   9,   -2, 	  -1,  -10
+.2byte    0,  -16, 	  -4,  -13, 	  13,   -8, 	  -2,  -12
+.2byte    1,  -16, 	  -3,  -13, 	  11,   -5, 	  -2,  -11
+.2byte   -1,  -16, 	  -7,  -14, 	  14,  -10, 	  -2,  -11
+.2byte   -1,  -18, 	  11,  -11, 	 -13,  -11, 	  -1,  -12
+.2byte   -1,  -17, 	  12,  -10, 	 -14,  -12, 	   0,  -11
+.2byte   -1,  -17, 	  11,  -12, 	 -14,  -10, 	  -2,  -11
+.2byte   -2,  -16, 	   2,  -13, 	 -15,   -8, 	   0,  -12
+.2byte   -3,  -16, 	   1,  -13, 	 -13,   -5, 	   0,  -11
+.2byte   -1,  -16, 	   5,  -14, 	 -16,  -10, 	   0,  -11
+.2byte   -8,  -15, 	 -12,  -15, 	 -10,   -4, 	   1,  -10
+.2byte   -7,  -14, 	 -12,  -13, 	  -9,   -5, 	   1,  -10
+.2byte   -6,  -15, 	 -11,  -16, 	 -11,   -2, 	  -1,  -10
+.2byte   -3,  -14, 	 -13,   -9, 	   4,   -2, 	  -1,  -12
+.2byte   -2,  -13, 	 -13,   -6, 	   6,   -3, 	  -1,  -11
+.2byte   -4,  -13, 	 -12,  -10, 	   3,    0, 	  -1,  -11
+.2byte   -1,  -14, 	 -13,   -4, 	  11,   -4, 	  -1,  -12
+.2byte   -1,  -11, 	 -14,  -21, 	  12,  -22, 	  -1,  -12
+.2byte    1,  -14, 	  11,   -9, 	  -6,   -2, 	  -1,  -12
+.2byte    3,  -10, 	   1,  -24, 	 -16,  -15, 	   0,  -10
+.2byte    6,  -15, 	  10,  -15, 	   8,   -4, 	  -3,  -10
+.2byte    6,  -12, 	 -16,  -14, 	 -15,   -5, 	  -2,  -11
+.2byte    0,  -16, 	  -4,  -13, 	  13,   -8, 	  -2,  -12
+.2byte    3,  -17, 	 -14,   -8, 	   4,   -1, 	  -1,  -12
+.2byte   -1,  -18, 	  11,  -11, 	 -13,  -11, 	  -1,  -12
+.2byte   -1,  -18, 	  11,   -5, 	 -12,   -6, 	  -1,  -13
+.2byte   -2,  -16, 	   2,  -13, 	 -15,   -8, 	   0,  -12
+.2byte   -5,  -17, 	  12,   -8, 	  -6,   -1, 	  -1,  -12
+.2byte   -8,  -15, 	 -12,  -15, 	 -10,   -4, 	   1,  -10
+.2byte   -8,  -12, 	  14,  -14, 	  13,   -5, 	   0,  -11
+.2byte   -3,  -14, 	 -13,   -9, 	   4,   -2, 	  -1,  -12
+.2byte   -5,  -10, 	  -3,  -24, 	  14,  -15, 	  -2,  -10
+.2byte   -1,  -14, 	 -13,   -4, 	  11,   -4, 	  -1,  -12
+.2byte   -1,  -11, 	 -14,  -21, 	  12,  -22, 	  -1,  -12
+.2byte    1,  -14, 	  11,   -9, 	  -6,   -2, 	  -1,  -12
+.2byte    3,  -10, 	   1,  -24, 	 -16,  -15, 	   0,  -10
+.2byte    6,  -15, 	  10,  -15, 	   8,   -4, 	  -3,  -10
+.2byte    6,  -12, 	 -16,  -14, 	 -15,   -5, 	  -2,  -11
+.2byte    0,  -16, 	  -4,  -13, 	  13,   -8, 	  -2,  -12
+.2byte    3,  -17, 	 -14,   -8, 	   4,   -1, 	  -1,  -12
+.2byte   -1,  -18, 	  11,  -11, 	 -13,  -11, 	  -1,  -12
+.2byte   -1,  -18, 	  11,   -5, 	 -12,   -6, 	  -1,  -13
+.2byte   -2,  -16, 	   2,  -13, 	 -15,   -8, 	   0,  -12
+.2byte   -5,  -17, 	  12,   -8, 	  -6,   -1, 	  -1,  -12
+.2byte   -8,  -15, 	 -12,  -15, 	 -10,   -4, 	   1,  -10
+.2byte   -8,  -12, 	  14,  -14, 	  13,   -5, 	   0,  -11
+.2byte   -3,  -14, 	 -13,   -9, 	   4,   -2, 	  -1,  -12
+.2byte   -5,  -10, 	  -3,  -24, 	  14,  -15, 	  -2,  -10
+.2byte   -1,  -14, 	 -13,   -4, 	  11,   -4, 	  -1,  -12
+.2byte   -1,  -11, 	 -14,  -21, 	  12,  -22, 	  -1,  -12
+.2byte   -1,   -9, 	 -13,    1, 	  11,    1, 	  -1,  -10
+.2byte    1,  -14, 	  11,   -9, 	  -6,   -2, 	  -1,  -12
+.2byte    3,  -10, 	   1,  -24, 	 -16,  -15, 	   0,  -10
+.2byte    3,   -9, 	  11,   -3, 	  -6,    3, 	   0,   -9
+.2byte    6,  -15, 	  10,  -15, 	   8,   -4, 	  -3,  -10
+.2byte    6,  -12, 	 -16,  -14, 	 -15,   -5, 	  -2,  -11
+.2byte    7,  -12, 	  10,   -6, 	   7,    2, 	  -1,   -8
+.2byte    0,  -16, 	  -4,  -13, 	  13,   -8, 	  -2,  -12
+.2byte    3,  -17, 	 -14,   -8, 	   4,   -1, 	  -1,  -12
+.2byte    2,  -13, 	  -5,  -12, 	  12,   -3, 	  -1,  -10
+.2byte   -1,  -18, 	  11,  -11, 	 -13,  -11, 	  -1,  -12
+.2byte   -1,  -18, 	  11,   -5, 	 -12,   -6, 	  -1,  -13
+.2byte   -1,  -16, 	  12,   -5, 	 -14,   -6, 	  -1,  -11
+.2byte   -2,  -16, 	   2,  -13, 	 -15,   -8, 	   0,  -12
+.2byte   -5,  -17, 	  12,   -8, 	  -6,   -1, 	  -1,  -12
+.2byte   -4,  -13, 	   3,  -12, 	 -14,   -3, 	  -1,  -10
+.2byte   -8,  -15, 	 -12,  -15, 	 -10,   -4, 	   1,  -10
+.2byte   -8,  -12, 	  14,  -14, 	  13,   -5, 	   0,  -11
+.2byte   -9,  -12, 	 -12,   -6, 	  -9,    2, 	  -1,   -8
+.2byte   -3,  -14, 	 -13,   -9, 	   4,   -2, 	  -1,  -12
+.2byte   -5,  -10, 	  -3,  -24, 	  14,  -15, 	  -2,  -10
+.2byte   -5,   -9, 	 -13,   -3, 	   4,    3, 	  -2,   -9
+.2byte   -1,  -13, 	 -15,  -25, 	  13,  -26, 	  -1,  -11
+.2byte    1,  -13, 	   8,  -29, 	 -14,  -20, 	  -1,  -12
+.2byte    5,  -14, 	   2,  -29, 	  -5,  -21, 	  -3,   -9
+.2byte    1,  -17, 	  -9,  -26, 	  12,  -20, 	  -2,  -10
+.2byte   -1,  -18, 	  13,  -25, 	 -15,  -26, 	  -1,  -13
+.2byte   -3,  -17, 	   7,  -26, 	 -14,  -20, 	   0,  -10
+.2byte   -7,  -14, 	  -4,  -29, 	   3,  -21, 	   1,   -9
+.2byte   -3,  -13, 	 -10,  -29, 	  12,  -20, 	  -1,  -12
+.2byte   -2,   -9, 	 -10,   -3, 	   9,    1, 	   0,   -9
+.2byte   -2,   -8, 	 -10,   -3, 	   9,    1, 	   0,   -8
+.2byte    0,  -21, 	 -13,  -27, 	  14,   -8, 	   0,  -17
+.2byte    0,  -19, 	  11,  -25, 	 -12,   -3, 	  -1,  -15
+.2byte    2,  -19, 	   5,  -26, 	  -9,   -2, 	  -3,  -14
+.2byte    0,  -19, 	  -3,  -26, 	   4,   -1, 	  -2,  -13
+.2byte    0,  -19, 	  13,  -22, 	 -13,   -7, 	   0,  -13
+.2byte   -1,  -19, 	   2,  -26, 	  -5,   -1, 	   1,  -13
+.2byte   -3,  -19, 	  -6,  -26, 	   8,   -2, 	   2,  -14
+.2byte   -1,  -19, 	 -12,  -25, 	  11,   -3, 	   0,  -15
+.2byte   -1,  -14, 	 -13,   -4, 	  11,   -4, 	  -1,  -12
+.2byte   -1,  -11, 	 -14,  -21, 	  12,  -22, 	  -1,  -12
+.2byte   -1,   -9, 	 -13,    1, 	  11,    1, 	  -1,  -10
+.2byte    1,  -14, 	  11,   -9, 	  -6,   -2, 	  -1,  -12
+.2byte    3,  -10, 	   1,  -24, 	 -16,  -15, 	   0,  -10
+.2byte    3,   -9, 	  11,   -3, 	  -6,    3, 	   0,   -9
+.2byte    6,  -15, 	  10,  -15, 	   8,   -4, 	  -3,  -10
+.2byte    6,  -12, 	 -16,  -14, 	 -15,   -5, 	  -2,  -11
+.2byte    7,  -12, 	  10,   -6, 	   7,    2, 	  -1,   -8
+.2byte    0,  -16, 	  -4,  -13, 	  13,   -8, 	  -2,  -12
+.2byte    3,  -17, 	 -14,   -8, 	   4,   -1, 	  -1,  -12
+.2byte    2,  -13, 	  -5,  -12, 	  12,   -3, 	  -1,  -10
+.2byte   -1,  -18, 	  11,  -11, 	 -13,  -11, 	  -1,  -12
+.2byte   -1,  -18, 	  11,   -5, 	 -12,   -6, 	  -1,  -13
+.2byte   -1,  -16, 	  12,   -5, 	 -14,   -6, 	  -1,  -11
+.2byte   -2,  -16, 	   2,  -13, 	 -15,   -8, 	   0,  -12
+.2byte   -5,  -17, 	  12,   -8, 	  -6,   -1, 	  -1,  -12
+.2byte   -4,  -13, 	   3,  -12, 	 -14,   -3, 	  -1,  -10
+.2byte   -8,  -15, 	 -12,  -15, 	 -10,   -4, 	   1,  -10
+.2byte   -8,  -12, 	  14,  -14, 	  13,   -5, 	   0,  -11
+.2byte   -9,  -12, 	 -12,   -6, 	  -9,    2, 	  -1,   -8
+.2byte   -3,  -14, 	 -13,   -9, 	   4,   -2, 	  -1,  -12
+.2byte   -5,  -10, 	  -3,  -24, 	  14,  -15, 	  -2,  -10
+.2byte   -5,   -9, 	 -13,   -3, 	   4,    3, 	  -2,   -9
+.2byte   -1,  -13, 	 -15,  -25, 	  13,  -26, 	  -1,  -11
+.2byte   -3,  -13, 	 -10,  -29, 	  12,  -20, 	  -1,  -12
+.2byte   -7,  -14, 	  -4,  -29, 	   3,  -21, 	   1,   -9
+.2byte   -3,  -17, 	   7,  -26, 	 -14,  -20, 	   0,  -10
+.2byte   -1,  -18, 	  13,  -25, 	 -15,  -26, 	  -1,  -13
+.2byte    1,  -17, 	  -9,  -26, 	  12,  -20, 	  -2,  -10
+.2byte    5,  -14, 	   2,  -29, 	  -5,  -21, 	  -3,   -9
+.2byte    1,  -13, 	   8,  -29, 	 -14,  -20, 	  -1,  -12
+.2byte    0,   -9, 	 -12,    1, 	  12,    1, 	   0,  -10
+.2byte    3,   -9, 	  11,   -3, 	  -6,    3, 	   0,   -9
+.2byte    8,  -12, 	  11,   -6, 	   8,    2, 	   0,   -8
+.2byte    3,  -13, 	  -4,  -12, 	  13,   -3, 	   0,  -10
+.2byte    0,  -14, 	  13,   -3, 	 -13,   -4, 	   0,   -9
+.2byte   -4,  -13, 	   3,  -12, 	 -14,   -3, 	  -1,  -10
+.2byte   -9,  -12, 	 -12,   -6, 	  -9,    2, 	  -1,   -8
+.2byte   -4,   -9, 	 -12,   -3, 	   5,    3, 	  -1,   -9
+.2byte   -1,  -14, 	 -13,   -4, 	  11,   -4, 	  -1,  -12
+.2byte   -1,  -10, 	 -13,    0, 	  11,    0, 	  -1,  -11
+.2byte   -1,  -14, 	 -15,  -26, 	  13,  -27, 	  -1,  -12
+.2byte    1,  -14, 	  11,   -9, 	  -6,   -2, 	  -1,  -12
+.2byte    3,   -9, 	  11,   -3, 	  -6,    3, 	   0,   -9
+.2byte    1,  -13, 	   8,  -29, 	 -14,  -20, 	  -1,  -12
+.2byte    6,  -15, 	  10,  -15, 	   8,   -4, 	  -3,  -10
+.2byte    7,  -12, 	  10,   -6, 	   7,    2, 	  -1,   -8
+.2byte    5,  -14, 	   2,  -29, 	  -5,  -21, 	  -3,   -9
+.2byte    0,  -16, 	  -4,  -13, 	  13,   -8, 	  -2,  -12
+.2byte    2,  -13, 	  -5,  -12, 	  12,   -3, 	  -1,  -10
+.2byte    1,  -17, 	  -9,  -26, 	  12,  -20, 	  -2,  -10
+.2byte   -1,  -18, 	  11,  -11, 	 -13,  -11, 	  -1,  -12
+.2byte   -1,  -16, 	  12,   -5, 	 -14,   -6, 	  -1,  -11
+.2byte   -1,  -18, 	  13,  -25, 	 -15,  -26, 	  -1,  -13
+.2byte   -1,  -16, 	   3,  -13, 	 -14,   -8, 	   1,  -12
+.2byte   -3,  -13, 	   4,  -12, 	 -13,   -3, 	   0,  -10
+.2byte   -2,  -17, 	   8,  -26, 	 -13,  -20, 	   1,  -10
+.2byte   -7,  -15, 	 -11,  -15, 	  -9,   -4, 	   2,  -10
+.2byte   -8,  -12, 	 -11,   -6, 	  -8,    2, 	   0,   -8
+.2byte   -6,  -14, 	  -3,  -29, 	   4,  -21, 	   2,   -9
+.2byte   -2,  -14, 	 -12,   -9, 	   5,   -2, 	   0,  -12
+.2byte   -4,   -9, 	 -12,   -3, 	   5,    3, 	  -1,   -9
+.2byte   -2,  -13, 	  -9,  -29, 	  13,  -20, 	   0,  -12
+.2byte    0,  -10, 	 -13,  -20, 	  13,  -21, 	   0,  -11
+.2byte   -4,  -10, 	  -2,  -24, 	  15,  -15, 	  -1,  -10
+.2byte   -9,  -12, 	  13,  -14, 	  12,   -5, 	  -1,  -11
+.2byte   -3,  -16, 	  14,   -7, 	  -4,    0, 	   1,  -11
+.2byte    0,  -17, 	  12,   -4, 	 -11,   -5, 	   0,  -12
+.2byte    2,  -16, 	 -15,   -7, 	   3,    0, 	  -2,  -11
+.2byte    8,  -12, 	 -14,  -14, 	 -13,   -5, 	   0,  -11
+.2byte    3,  -10, 	   1,  -24, 	 -16,  -15, 	   0,  -10
+.2byte   -1,  -14, 	 -13,   -4, 	  11,   -4, 	  -1,  -12
+.2byte   -3,  -14, 	 -13,   -9, 	   4,   -2, 	  -1,  -12
+.2byte   -8,  -15, 	 -12,  -15, 	 -10,   -4, 	   1,  -10
+.2byte   -2,  -16, 	   2,  -13, 	 -15,   -8, 	   0,  -12
+.2byte   -1,  -18, 	  11,  -11, 	 -13,  -11, 	  -1,  -12
+.2byte    0,  -16, 	  -4,  -13, 	  13,   -8, 	  -2,  -12
+.2byte    6,  -15, 	  10,  -15, 	   8,   -4, 	  -3,  -10
+.2byte    1,  -14, 	  11,   -9, 	  -6,   -2, 	  -1,  -12
+sRegisteelAnimTable1:
+.4byte sRegisteelAnims_1_1
+.4byte sRegisteelAnims_1_2
+.4byte sRegisteelAnims_1_3
+.4byte sRegisteelAnims_1_4
+.4byte sRegisteelAnims_1_5
+.4byte sRegisteelAnims_1_6
+.4byte sRegisteelAnims_1_7
+.4byte sRegisteelAnims_1_8
+sRegisteelAnimTable2:
+.4byte sRegisteelAnims_2_1
+.4byte sRegisteelAnims_2_2
+.4byte sRegisteelAnims_2_3
+.4byte sRegisteelAnims_2_4
+.4byte sRegisteelAnims_2_5
+.4byte sRegisteelAnims_2_6
+.4byte sRegisteelAnims_2_7
+.4byte sRegisteelAnims_2_8
+sRegisteelAnimTable3:
+.4byte sRegisteelAnims_3_1
+.4byte sRegisteelAnims_3_2
+.4byte sRegisteelAnims_3_3
+.4byte sRegisteelAnims_3_4
+.4byte sRegisteelAnims_3_5
+.4byte sRegisteelAnims_3_6
+.4byte sRegisteelAnims_3_7
+.4byte sRegisteelAnims_3_8
+sRegisteelAnimTable4:
+.4byte sRegisteelAnims_4_1
+.4byte sRegisteelAnims_4_2
+.4byte sRegisteelAnims_4_3
+.4byte sRegisteelAnims_4_4
+.4byte sRegisteelAnims_4_5
+.4byte sRegisteelAnims_4_6
+.4byte sRegisteelAnims_4_7
+.4byte sRegisteelAnims_4_8
+sRegisteelAnimTable5:
+.4byte sRegisteelAnims_5_1
+.4byte sRegisteelAnims_5_2
+.4byte sRegisteelAnims_5_3
+.4byte sRegisteelAnims_5_4
+.4byte sRegisteelAnims_5_5
+.4byte sRegisteelAnims_5_6
+.4byte sRegisteelAnims_5_7
+.4byte sRegisteelAnims_5_8
+sRegisteelAnimTable6:
+.4byte sRegisteelAnims_6_1
+.4byte sRegisteelAnims_6_1
+.4byte sRegisteelAnims_6_1
+.4byte sRegisteelAnims_6_1
+.4byte sRegisteelAnims_6_1
+.4byte sRegisteelAnims_6_1
+.4byte sRegisteelAnims_6_1
+.4byte sRegisteelAnims_6_1
+sRegisteelAnimTable7:
+.4byte sRegisteelAnims_7_1
+.4byte sRegisteelAnims_7_2
+.4byte sRegisteelAnims_7_3
+.4byte sRegisteelAnims_7_4
+.4byte sRegisteelAnims_7_5
+.4byte sRegisteelAnims_7_6
+.4byte sRegisteelAnims_7_7
+.4byte sRegisteelAnims_7_8
+sRegisteelAnimTable8:
+.4byte sRegisteelAnims_8_1
+.4byte sRegisteelAnims_8_2
+.4byte sRegisteelAnims_8_3
+.4byte sRegisteelAnims_8_4
+.4byte sRegisteelAnims_8_5
+.4byte sRegisteelAnims_8_6
+.4byte sRegisteelAnims_8_7
+.4byte sRegisteelAnims_8_8
+sRegisteelAnimTable9:
+.4byte sRegisteelAnims_9_1
+.4byte sRegisteelAnims_9_2
+.4byte sRegisteelAnims_9_3
+.4byte sRegisteelAnims_9_4
+.4byte sRegisteelAnims_9_5
+.4byte sRegisteelAnims_9_6
+.4byte sRegisteelAnims_9_7
+.4byte sRegisteelAnims_9_8
+sRegisteelAnimTable10:
+.4byte sRegisteelAnims_10_1
+.4byte sRegisteelAnims_10_2
+.4byte sRegisteelAnims_10_3
+.4byte sRegisteelAnims_10_4
+.4byte sRegisteelAnims_10_5
+.4byte sRegisteelAnims_10_6
+.4byte sRegisteelAnims_10_7
+.4byte sRegisteelAnims_10_8
+sRegisteelAnimTable11:
+.4byte sRegisteelAnims_11_1
+.4byte sRegisteelAnims_11_2
+.4byte sRegisteelAnims_11_3
+.4byte sRegisteelAnims_11_4
+.4byte sRegisteelAnims_11_5
+.4byte sRegisteelAnims_11_6
+.4byte sRegisteelAnims_11_7
+.4byte sRegisteelAnims_11_8
+sRegisteelAnimTable12:
+.4byte sRegisteelAnims_12_1
+.4byte sRegisteelAnims_12_2
+.4byte sRegisteelAnims_12_3
+.4byte sRegisteelAnims_12_4
+.4byte sRegisteelAnims_12_5
+.4byte sRegisteelAnims_12_6
+.4byte sRegisteelAnims_12_7
+.4byte sRegisteelAnims_12_8
+sRegisteelAnimTable13:
+.4byte sRegisteelAnims_13_1
+.4byte sRegisteelAnims_13_2
+.4byte sRegisteelAnims_13_3
+.4byte sRegisteelAnims_13_4
+.4byte sRegisteelAnims_13_5
+.4byte sRegisteelAnims_13_6
+.4byte sRegisteelAnims_13_7
+.4byte sRegisteelAnims_13_8
+sAxAnimationsRegisteel:
+.4byte sRegisteelAnimTable1
+.4byte sRegisteelAnimTable2
+.4byte sRegisteelAnimTable3
+.4byte sRegisteelAnimTable4
+.4byte sRegisteelAnimTable5
+.4byte sRegisteelAnimTable6
+.4byte sRegisteelAnimTable7
+.4byte sRegisteelAnimTable8
+.4byte sRegisteelAnimTable9
+.4byte sRegisteelAnimTable10
+.4byte sRegisteelAnimTable11
+.4byte sRegisteelAnimTable12
+.4byte sRegisteelAnimTable13
+sAxSpritesRegisteel:
+.4byte sRegisteelSprites1
+.4byte sRegisteelSprites2
+.4byte sRegisteelSprites3
+.4byte sRegisteelSprites4
+.4byte sRegisteelSprites5
+.4byte sRegisteelSprites6
+.4byte sRegisteelSprites7
+.4byte sRegisteelSprites8
+.4byte sRegisteelSprites9
+.4byte sRegisteelSprites10
+.4byte sRegisteelSprites11
+.4byte sRegisteelSprites12
+.4byte sRegisteelSprites13
+.4byte sRegisteelSprites14
+.4byte sRegisteelSprites15
+.4byte sRegisteelSprites16
+.4byte sRegisteelSprites17
+.4byte sRegisteelSprites18
+.4byte sRegisteelSprites19
+.4byte sRegisteelSprites20
+.4byte sRegisteelSprites21
+.4byte sRegisteelSprites22
+.4byte sRegisteelSprites23
+.4byte sRegisteelSprites24
+.4byte sRegisteelSprites25
+.4byte sRegisteelSprites26
+.4byte sRegisteelSprites27
+.4byte sRegisteelSprites28
+.4byte sRegisteelSprites29
+.4byte sRegisteelSprites30
+.4byte sRegisteelSprites31
+.4byte sRegisteelSprites32
+.4byte sRegisteelSprites33
+.4byte sRegisteelSprites34
+.4byte sRegisteelSprites35
+.4byte sRegisteelSprites36
+.4byte sRegisteelSprites37
+.4byte sRegisteelSprites38
+.4byte sRegisteelSprites39
+.4byte sRegisteelSprites40
+.4byte sRegisteelSprites41
+.4byte sRegisteelSprites42
+.4byte sRegisteelSprites43
+.4byte sRegisteelSprites44
+.4byte sRegisteelSprites45
+.4byte sRegisteelSprites46
+.4byte sRegisteelSprites47
+.4byte sRegisteelSprites48
+.4byte sRegisteelSprites49
+.4byte sRegisteelSprites50
+.4byte sRegisteelSprites51
+.4byte sRegisteelSprites52
+.4byte sRegisteelSprites53
+.4byte sRegisteelSprites54
+.4byte sRegisteelSprites55
+.4byte sRegisteelSprites56
+.4byte sRegisteelSprites57
+.4byte sRegisteelSprites58
+.4byte sRegisteelSprites59
+.4byte sRegisteelSprites60
+.4byte sRegisteelSprites61
+.4byte sRegisteelSprites62
+.4byte sRegisteelSprites63
+.4byte sRegisteelSprites64
+.4byte sRegisteelSprites65
+.4byte sRegisteelSprites66
+.4byte sRegisteelSprites67
+.4byte sRegisteelSprites68
+.4byte sRegisteelSprites69
+.4byte sRegisteelSprites70
+.4byte sRegisteelSprites71
+.4byte sRegisteelSprites72
+.4byte sRegisteelSprites73
+.4byte sRegisteelSprites74
+.4byte sRegisteelSprites75
+sAxMainRegisteel:
+ax_main sAxPosesRegisteel, sAxAnimationsRegisteel, 13, sAxSpritesRegisteel, sAxPositionsRegisteel

--- a/data/ax/relicanth.inc
+++ b/data/ax/relicanth.inc
@@ -1,0 +1,2371 @@
+.global gAxRelicanth
+gAxRelicanth:
+ax_siro sAxMainRelicanth
+sRelicanthPose1:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose2:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose3:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose9:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose10:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose11:
+ax_pose 10, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose12:
+ax_pose 11, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose13:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose14:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose15:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose25:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose26:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose27:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose28:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose29:
+ax_pose 4, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose30:
+ax_pose 5, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose31:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose32:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose33:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose34:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose35:
+ax_pose 10, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose36:
+ax_pose 11, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose37:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose38:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose39:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose40:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose41:
+ax_pose 10, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose42:
+ax_pose 11, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose43:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose44:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose45:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose46:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose47:
+ax_pose 4, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose48:
+ax_pose 5, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose49:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose50:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose51:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose52:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose53:
+ax_pose 4, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose54:
+ax_pose 5, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose55:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose56:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose57:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose58:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose59:
+ax_pose 10, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose60:
+ax_pose 11, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose61:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose62:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose63:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose64:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose65:
+ax_pose 10, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose66:
+ax_pose 11, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose67:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose68:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose69:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose70:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose71:
+ax_pose 4, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose72:
+ax_pose 5, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose73:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose74:
+ax_pose 15, 0x81e5, 0x80f7, 0x6c00
+ax_pose 16, 0x01f5, 0x0107, 0x6c08
+ax_pose_terminator
+sRelicanthPose75:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose76:
+ax_pose 17, 0x81e4, 0x90fd, 0x6c00
+ax_pose 18, 0x81e4, 0x50f5, 0x6c08
+ax_pose_terminator
+sRelicanthPose77:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose78:
+ax_pose 19, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose79:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose80:
+ax_pose 20, 0x81e6, 0x90fc, 0x6c00
+ax_pose 21, 0x81e6, 0x50f4, 0x6c08
+ax_pose_terminator
+sRelicanthPose81:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose82:
+ax_pose 22, 0x81e6, 0x80f9, 0x6c00
+ax_pose 23, 0x81ee, 0x00f1, 0x6c08
+ax_pose 24, 0x01de, 0x00f9, 0x6c0a
+ax_pose_terminator
+sRelicanthPose83:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose84:
+ax_pose 20, 0x81e6, 0x80f4, 0x6c00
+ax_pose 21, 0x81e6, 0x4104, 0x6c08
+ax_pose_terminator
+sRelicanthPose85:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose86:
+ax_pose 19, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose87:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose88:
+ax_pose 17, 0x81e4, 0x80f3, 0x6c00
+ax_pose 18, 0x81e4, 0x4103, 0x6c08
+ax_pose_terminator
+sRelicanthPose89:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose90:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose91:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose92:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose93:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose94:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose95:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose96:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose97:
+ax_pose 25, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose98:
+ax_pose 26, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose99:
+ax_pose 27, 0x01e0, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose100:
+ax_pose 28, 0x01e0, 0x90eb, 0x6c00
+ax_pose_terminator
+sRelicanthPose101:
+ax_pose 29, 0x01e1, 0x90ed, 0x6c00
+ax_pose_terminator
+sRelicanthPose102:
+ax_pose 30, 0x01e7, 0x90e9, 0x6c00
+ax_pose_terminator
+sRelicanthPose103:
+ax_pose 31, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose104:
+ax_pose 30, 0x01e7, 0x80f7, 0x6c00
+ax_pose_terminator
+sRelicanthPose105:
+ax_pose 29, 0x01e1, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose106:
+ax_pose 28, 0x01e0, 0x80f5, 0x6c00
+ax_pose_terminator
+sRelicanthPose107:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose108:
+ax_pose 1, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose109:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose110:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose111:
+ax_pose 4, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose112:
+ax_pose 5, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose113:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose114:
+ax_pose 7, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose115:
+ax_pose 8, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose116:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose117:
+ax_pose 10, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose118:
+ax_pose 11, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose119:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose120:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose121:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose122:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose123:
+ax_pose 10, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose124:
+ax_pose 11, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose125:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose126:
+ax_pose 7, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose127:
+ax_pose 8, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose128:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose129:
+ax_pose 4, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose130:
+ax_pose 5, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose131:
+ax_pose 15, 0x81e5, 0x80f7, 0x6c00
+ax_pose 16, 0x01f5, 0x0107, 0x6c08
+ax_pose_terminator
+sRelicanthPose132:
+ax_pose 17, 0x81e4, 0x80f3, 0x6c00
+ax_pose 18, 0x81e4, 0x4103, 0x6c08
+ax_pose_terminator
+sRelicanthPose133:
+ax_pose 19, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sRelicanthPose134:
+ax_pose 20, 0x81e6, 0x80f3, 0x6c00
+ax_pose 21, 0x81e6, 0x4103, 0x6c08
+ax_pose_terminator
+sRelicanthPose135:
+ax_pose 22, 0x81e6, 0x80f9, 0x6c00
+ax_pose 23, 0x81ee, 0x00f1, 0x6c08
+ax_pose 24, 0x01de, 0x00f9, 0x6c0a
+ax_pose_terminator
+sRelicanthPose136:
+ax_pose 20, 0x81e6, 0x90fd, 0x6c00
+ax_pose 21, 0x81e6, 0x50f5, 0x6c08
+ax_pose_terminator
+sRelicanthPose137:
+ax_pose 19, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose138:
+ax_pose 17, 0x81e4, 0x90fd, 0x6c00
+ax_pose 18, 0x81e4, 0x50f5, 0x6c08
+ax_pose_terminator
+sRelicanthPose139:
+ax_pose 2, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose140:
+ax_pose 5, 0x01e5, 0x90ee, 0x6c00
+ax_pose_terminator
+sRelicanthPose141:
+ax_pose 8, 0x01e4, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose142:
+ax_pose 11, 0x01e5, 0x90f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose143:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose144:
+ax_pose 11, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose145:
+ax_pose 8, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sRelicanthPose146:
+ax_pose 5, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sRelicanthPose147:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose148:
+ax_pose 15, 0x81e6, 0x80f7, 0x6c00
+ax_pose 16, 0x01f6, 0x0107, 0x6c08
+ax_pose_terminator
+sRelicanthPose149:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose150:
+ax_pose 17, 0x81e5, 0x90fc, 0x6c00
+ax_pose 18, 0x81e5, 0x50f4, 0x6c08
+ax_pose_terminator
+sRelicanthPose151:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose152:
+ax_pose 19, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose153:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose154:
+ax_pose 20, 0x81e7, 0x90fc, 0x6c00
+ax_pose 21, 0x81e7, 0x50f4, 0x6c08
+ax_pose_terminator
+sRelicanthPose155:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose156:
+ax_pose 22, 0x81e7, 0x80f9, 0x6c00
+ax_pose 23, 0x81ef, 0x00f1, 0x6c08
+ax_pose 24, 0x01df, 0x00f9, 0x6c0a
+ax_pose_terminator
+sRelicanthPose157:
+ax_pose 9, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRelicanthPose158:
+ax_pose 20, 0x81e7, 0x80f4, 0x6c00
+ax_pose 21, 0x81e7, 0x4104, 0x6c08
+ax_pose_terminator
+sRelicanthPose159:
+ax_pose 6, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRelicanthPose160:
+ax_pose 19, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRelicanthPose161:
+ax_pose 3, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sRelicanthPose162:
+ax_pose 17, 0x81e5, 0x80f4, 0x6c00
+ax_pose 18, 0x81e5, 0x4104, 0x6c08
+ax_pose_terminator
+sRelicanthPose163:
+ax_pose 15, 0x81e5, 0x80f7, 0x6c00
+ax_pose 16, 0x01f5, 0x0107, 0x6c08
+ax_pose_terminator
+sRelicanthPose164:
+ax_pose 17, 0x81e4, 0x80f3, 0x6c00
+ax_pose 18, 0x81e4, 0x4103, 0x6c08
+ax_pose_terminator
+sRelicanthPose165:
+ax_pose 19, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sRelicanthPose166:
+ax_pose 20, 0x81e6, 0x80f3, 0x6c00
+ax_pose 21, 0x81e6, 0x4103, 0x6c08
+ax_pose_terminator
+sRelicanthPose167:
+ax_pose 22, 0x81e5, 0x80f9, 0x6c00
+ax_pose 23, 0x81ed, 0x00f1, 0x6c08
+ax_pose 24, 0x01dd, 0x00f9, 0x6c0a
+ax_pose_terminator
+sRelicanthPose168:
+ax_pose 20, 0x81e6, 0x90fd, 0x6c00
+ax_pose 21, 0x81e6, 0x50f5, 0x6c08
+ax_pose_terminator
+sRelicanthPose169:
+ax_pose 19, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose170:
+ax_pose 17, 0x81e4, 0x90fd, 0x6c00
+ax_pose 18, 0x81e4, 0x50f5, 0x6c08
+ax_pose_terminator
+sRelicanthPose171:
+ax_pose 0, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose172:
+ax_pose 3, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose173:
+ax_pose 6, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose174:
+ax_pose 9, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRelicanthPose175:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sRelicanthPose176:
+ax_pose 9, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose177:
+ax_pose 6, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+sRelicanthPose178:
+ax_pose 3, 0x01e5, 0x90ef, 0x6c00
+ax_pose_terminator
+.align 2
+sRelicanthAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 4, 0, 26, 0, -3, 0, -2,
+ax_anim 4, 0, 25, 0, -3, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 9,
+ax_anim 2, 0, 24, 0, 22, 0, 19,
+ax_anim 2, 1, 24, 1, 22, 1, 19,
+ax_anim 2, 0, 24, 0, 22, 0, 19,
+ax_anim 2, 0, 24, 1, 22, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRelicanthAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 4, 0, 29, -3, -3, -3, -3,
+ax_anim 4, 0, 28, -3, -3, -3, -3,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 5, 4, 5,
+ax_anim 1, 0, 27, 10, 12, 10, 11,
+ax_anim 2, 0, 27, 18, 22, 18, 20,
+ax_anim 2, 1, 27, 19, 21, 19, 19,
+ax_anim 2, 0, 27, 18, 22, 18, 20,
+ax_anim 2, 0, 27, 19, 21, 19, 19,
+ax_anim 2, 0, 27, 5, 7, 5, 7,
+ax_anim_terminator
+sRelicanthAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -2, 0, -2, 0,
+ax_anim 4, 0, 32, -3, 0, -3, 0,
+ax_anim 4, 0, 31, -3, 0, -3, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 10, 1, 10, 0,
+ax_anim 2, 0, 30, 16, 2, 16, 0,
+ax_anim 2, 1, 30, 16, 3, 16, 1,
+ax_anim 2, 0, 30, 16, 2, 16, 0,
+ax_anim 2, 0, 30, 16, 3, 16, 1,
+ax_anim 2, 0, 30, 6, 1, 6, 0,
+ax_anim_terminator
+sRelicanthAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 34, -2, 2, -2, 2,
+ax_anim 4, 0, 35, -3, 3, -3, 3,
+ax_anim 4, 0, 34, -3, 3, -3, 3,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 5, -5, 5, -6,
+ax_anim 1, 0, 33, 11, -11, 11, -13,
+ax_anim 2, 0, 33, 18, -17, 19, -22,
+ax_anim 2, 1, 33, 19, -16, 20, -21,
+ax_anim 2, 0, 33, 18, -17, 19, -22,
+ax_anim 2, 0, 33, 19, -16, 20, -21,
+ax_anim 2, 0, 33, 6, -6, 6, -7,
+ax_anim_terminator
+sRelicanthAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 4, 0, 38, 0, 3, 0, 3,
+ax_anim 4, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -11, 0, -13,
+ax_anim 2, 0, 36, 0, -17, 0, -22,
+ax_anim 2, 1, 36, 1, -17, 1, -22,
+ax_anim 2, 0, 36, 0, -17, 0, -22,
+ax_anim 2, 0, 36, 1, -17, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sRelicanthAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 40, 2, 2, 2, 2,
+ax_anim 4, 0, 41, 3, 3, 3, 3,
+ax_anim 4, 0, 40, 3, 3, 3, 3,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -5, -5, -5, -6,
+ax_anim 1, 0, 39, -11, -11, -11, -13,
+ax_anim 2, 0, 39, -18, -17, -19, -22,
+ax_anim 2, 1, 39, -19, -16, -20, -21,
+ax_anim 2, 0, 39, -18, -17, -19, -22,
+ax_anim 2, 0, 39, -19, -16, -20, -21,
+ax_anim 2, 0, 39, -6, -6, -6, -7,
+ax_anim_terminator
+sRelicanthAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 2, 0, 2, 0,
+ax_anim 4, 0, 44, 3, 0, 3, 0,
+ax_anim 4, 0, 43, 3, 0, 3, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -10, 1, -10, 0,
+ax_anim 2, 0, 42, -16, 2, -16, 0,
+ax_anim 2, 1, 42, -16, 3, -16, 1,
+ax_anim 2, 0, 42, -16, 2, -16, 0,
+ax_anim 2, 0, 42, -16, 3, -16, 1,
+ax_anim 2, 0, 42, -6, 1, -6, 0,
+ax_anim_terminator
+sRelicanthAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 46, 2, -2, 2, -2,
+ax_anim 4, 0, 47, 3, -3, 3, -3,
+ax_anim 4, 0, 46, 3, -3, 3, -3,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 5, -4, 5,
+ax_anim 1, 0, 45, -10, 12, -10, 11,
+ax_anim 2, 0, 45, -18, 22, -18, 20,
+ax_anim 2, 1, 45, -19, 21, -19, 19,
+ax_anim 2, 0, 45, -18, 22, -18, 20,
+ax_anim 2, 0, 45, -19, 21, -19, 19,
+ax_anim 2, 0, 45, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 4, 0, 50, 0, -3, 0, -2,
+ax_anim 4, 0, 49, 0, -3, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 48, 0, 10, 0, 9,
+ax_anim 2, 0, 48, 0, 22, 0, 19,
+ax_anim 2, 1, 48, 1, 22, 1, 19,
+ax_anim 2, 0, 48, 0, 22, 0, 19,
+ax_anim 2, 0, 48, 1, 22, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sRelicanthAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 4, 0, 53, -3, -3, -3, -3,
+ax_anim 4, 0, 52, -3, -3, -3, -3,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 5, 4, 5,
+ax_anim 1, 0, 51, 10, 12, 10, 11,
+ax_anim 2, 0, 51, 18, 22, 18, 20,
+ax_anim 2, 1, 51, 19, 21, 19, 19,
+ax_anim 2, 0, 51, 18, 22, 18, 20,
+ax_anim 2, 0, 51, 19, 21, 19, 19,
+ax_anim 2, 0, 51, 5, 7, 5, 7,
+ax_anim_terminator
+sRelicanthAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 55, -2, 0, -2, 0,
+ax_anim 4, 0, 56, -3, 0, -3, 0,
+ax_anim 4, 0, 55, -3, 0, -3, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 10, 1, 10, 0,
+ax_anim 2, 0, 54, 16, 2, 16, 0,
+ax_anim 2, 1, 54, 16, 3, 16, 1,
+ax_anim 2, 0, 54, 16, 2, 16, 0,
+ax_anim 2, 0, 54, 16, 3, 16, 1,
+ax_anim 2, 0, 54, 6, 1, 6, 0,
+ax_anim_terminator
+sRelicanthAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 58, -2, 2, -2, 2,
+ax_anim 4, 0, 59, -3, 3, -3, 3,
+ax_anim 4, 0, 58, -3, 3, -3, 3,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 5, -5, 5, -6,
+ax_anim 1, 0, 57, 11, -11, 11, -13,
+ax_anim 2, 0, 57, 18, -17, 19, -22,
+ax_anim 2, 1, 57, 19, -16, 20, -21,
+ax_anim 2, 0, 57, 18, -17, 19, -22,
+ax_anim 2, 0, 57, 19, -16, 20, -21,
+ax_anim 2, 0, 57, 6, -6, 6, -7,
+ax_anim_terminator
+sRelicanthAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 4, 0, 62, 0, 3, 0, 3,
+ax_anim 4, 0, 61, 0, 3, 0, 3,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -11, 0, -13,
+ax_anim 2, 0, 60, 0, -17, 0, -22,
+ax_anim 2, 1, 60, 1, -17, 1, -22,
+ax_anim 2, 0, 60, 0, -17, 0, -22,
+ax_anim 2, 0, 60, 1, -17, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sRelicanthAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 64, 2, 2, 2, 2,
+ax_anim 4, 0, 65, 3, 3, 3, 3,
+ax_anim 4, 0, 64, 3, 3, 3, 3,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -5, -5, -5, -6,
+ax_anim 1, 0, 63, -11, -11, -11, -13,
+ax_anim 2, 0, 63, -18, -17, -19, -22,
+ax_anim 2, 1, 63, -19, -16, -20, -21,
+ax_anim 2, 0, 63, -18, -17, -19, -22,
+ax_anim 2, 0, 63, -19, -16, -20, -21,
+ax_anim 2, 0, 63, -6, -6, -6, -7,
+ax_anim_terminator
+sRelicanthAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 67, 2, 0, 2, 0,
+ax_anim 4, 0, 68, 3, 0, 3, 0,
+ax_anim 4, 0, 67, 3, 0, 3, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -10, 1, -10, 0,
+ax_anim 2, 0, 66, -16, 2, -16, 0,
+ax_anim 2, 1, 66, -16, 3, -16, 1,
+ax_anim 2, 0, 66, -16, 2, -16, 0,
+ax_anim 2, 0, 66, -16, 3, -16, 1,
+ax_anim 2, 0, 66, -6, 1, -6, 0,
+ax_anim_terminator
+sRelicanthAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 70, 2, -2, 2, -2,
+ax_anim 4, 0, 71, 3, -3, 3, -3,
+ax_anim 4, 0, 70, 3, -3, 3, -3,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 5, -4, 5,
+ax_anim 1, 0, 69, -10, 12, -10, 11,
+ax_anim 2, 0, 69, -18, 22, -18, 20,
+ax_anim 2, 1, 69, -19, 21, -19, 19,
+ax_anim 2, 0, 69, -18, 22, -18, 20,
+ax_anim 2, 0, 69, -19, 21, -19, 19,
+ax_anim 2, 0, 69, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 6, 2, 72, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 1, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 1, 3, 1, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 1, 3, 1, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 1, 3, 1, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sRelicanthAnims_4_2:
+ax_anim 2, 0, 74, -2, -2, -2, -2,
+ax_anim 6, 2, 74, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 75, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 3, 1, 3, 1,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 3, 1, 3, 1,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 3, 1, 3, 1,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim 2, 0, 74, 1, 1, 1, 1,
+ax_anim_terminator
+sRelicanthAnims_4_3:
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 6, 2, 76, -3, 0, -3, 0,
+ax_anim 2, 0, 77, -1, 0, -1, 0,
+ax_anim 2, 1, 77, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 3, 0, 3, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim_terminator
+sRelicanthAnims_4_4:
+ax_anim 2, 0, 78, -2, 2, -2, 2,
+ax_anim 6, 2, 78, -3, 3, -3, 3,
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 2, 1, 79, 2, -2, 2, -2,
+ax_anim 2, 0, 79, 3, -1, 3, -1,
+ax_anim 2, 0, 79, 2, -2, 2, -2,
+ax_anim 2, 0, 79, 3, -1, 3, -1,
+ax_anim 2, 0, 79, 2, -2, 2, -2,
+ax_anim 2, 0, 79, 3, -1, 3, -1,
+ax_anim 2, 0, 79, 2, -2, 2, -2,
+ax_anim 2, 0, 78, 1, -1, 1, -1,
+ax_anim_terminator
+sRelicanthAnims_4_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 6, 2, 80, 0, 3, 0, 3,
+ax_anim 2, 0, 81, 0, 1, 0, 1,
+ax_anim 2, 1, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 81, 1, -3, 1, -3,
+ax_anim 2, 0, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 81, 1, -3, 1, -3,
+ax_anim 2, 0, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 81, 1, -3, 1, -3,
+ax_anim 2, 0, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim_terminator
+sRelicanthAnims_4_6:
+ax_anim 2, 0, 82, 2, 2, 2, 2,
+ax_anim 6, 2, 82, 3, 3, 3, 3,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 1, 83, -2, -2, -2, -2,
+ax_anim 2, 0, 83, -3, -1, -3, -1,
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 2, 0, 83, -3, -1, -3, -1,
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 2, 0, 83, -3, -1, -3, -1,
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 2, 0, 82, -1, -1, -1, -1,
+ax_anim_terminator
+sRelicanthAnims_4_7:
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 6, 2, 84, 3, 0, 3, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, -3, 0, -3, 0,
+ax_anim 2, 0, 85, -3, 1, -3, 1,
+ax_anim 2, 0, 85, -3, 0, -3, 0,
+ax_anim 2, 0, 85, -3, 1, -3, 1,
+ax_anim 2, 0, 85, -3, 0, -3, 0,
+ax_anim 2, 0, 85, -3, 1, -3, 1,
+ax_anim 2, 0, 85, -3, 0, -3, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim_terminator
+sRelicanthAnims_4_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 6, 2, 86, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 1, 87, -2, 2, -2, 2,
+ax_anim 2, 0, 87, -3, 1, -3, 1,
+ax_anim 2, 0, 87, -2, 2, -2, 2,
+ax_anim 2, 0, 87, -3, 1, -3, 1,
+ax_anim 2, 0, 87, -2, 2, -2, 2,
+ax_anim 2, 0, 87, -3, 1, -3, 1,
+ax_anim 2, 0, 87, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_5_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_5_2:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_5_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_5_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_5_6:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_5_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_5_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_6_1:
+ax_anim 16, 0, 96, 0, 0, 0, 0,
+ax_anim 12, 0, 96, 0, -1, 0, 0,
+ax_anim 16, 0, 96, 0, -2, 0, 0,
+ax_anim 16, 0, 97, 0, -2, 0, 0,
+ax_anim 12, 0, 97, 0, -1, 0, 0,
+ax_anim 16, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sRelicanthAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sRelicanthAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sRelicanthAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sRelicanthAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sRelicanthAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sRelicanthAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sRelicanthAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_8_1:
+ax_anim 30, 0, 106, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, -1, 0, 0,
+ax_anim 4, 0, 106, 0, -2, 0, 0,
+ax_anim 6, 0, 108, 0, -3, 0, 0,
+ax_anim 4, 0, 106, 0, -4, 0, 0,
+ax_anim 14, 0, 106, 0, -4, 0, 0,
+ax_anim 8, 0, 106, 0, -3, 0, 0,
+ax_anim 8, 0, 106, 0, -2, 0, 0,
+ax_anim 8, 0, 106, 0, -1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_8_2:
+ax_anim 30, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, -1, 0, 0,
+ax_anim 4, 0, 109, 0, -2, 0, 0,
+ax_anim 6, 0, 111, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, -4, 0, 0,
+ax_anim 14, 0, 109, 0, -4, 0, 0,
+ax_anim 8, 0, 109, 0, -3, 0, 0,
+ax_anim 8, 0, 109, 0, -2, 0, 0,
+ax_anim 8, 0, 109, 0, -1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_8_3:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, -1, 0, 0,
+ax_anim 4, 0, 112, 0, -2, 0, 0,
+ax_anim 6, 0, 114, 0, -3, 0, 0,
+ax_anim 4, 0, 112, 0, -4, 0, 0,
+ax_anim 14, 0, 112, 0, -4, 0, 0,
+ax_anim 8, 0, 112, 0, -3, 0, 0,
+ax_anim 8, 0, 112, 0, -2, 0, 0,
+ax_anim 8, 0, 112, 0, -1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_8_4:
+ax_anim 30, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, -1, 0, 0,
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 6, 0, 117, 0, -3, 0, 0,
+ax_anim 4, 0, 115, 0, -4, 0, 0,
+ax_anim 14, 0, 115, 0, -4, 0, 0,
+ax_anim 8, 0, 115, 0, -3, 0, 0,
+ax_anim 8, 0, 115, 0, -2, 0, 0,
+ax_anim 8, 0, 115, 0, -1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_8_5:
+ax_anim 30, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, -1, 0, 0,
+ax_anim 4, 0, 118, 0, -2, 0, 0,
+ax_anim 6, 0, 120, 0, -3, 0, 0,
+ax_anim 4, 0, 118, 0, -4, 0, 0,
+ax_anim 14, 0, 118, 0, -4, 0, 0,
+ax_anim 8, 0, 118, 0, -3, 0, 0,
+ax_anim 8, 0, 118, 0, -2, 0, 0,
+ax_anim 8, 0, 118, 0, -1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_8_6:
+ax_anim 30, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 121, 0, -2, 0, 0,
+ax_anim 6, 0, 123, 0, -3, 0, 0,
+ax_anim 4, 0, 121, 0, -4, 0, 0,
+ax_anim 14, 0, 121, 0, -4, 0, 0,
+ax_anim 8, 0, 121, 0, -3, 0, 0,
+ax_anim 8, 0, 121, 0, -2, 0, 0,
+ax_anim 8, 0, 121, 0, -1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_8_7:
+ax_anim 30, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 124, 0, -2, 0, 0,
+ax_anim 6, 0, 126, 0, -3, 0, 0,
+ax_anim 4, 0, 124, 0, -4, 0, 0,
+ax_anim 14, 0, 124, 0, -4, 0, 0,
+ax_anim 8, 0, 124, 0, -3, 0, 0,
+ax_anim 8, 0, 124, 0, -2, 0, 0,
+ax_anim 8, 0, 124, 0, -1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_8_8:
+ax_anim 30, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, -2, 0, 0,
+ax_anim 6, 0, 129, 0, -3, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 14, 0, 127, 0, -4, 0, 0,
+ax_anim 8, 0, 127, 0, -3, 0, 0,
+ax_anim 8, 0, 127, 0, -2, 0, 0,
+ax_anim 8, 0, 127, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 7, 4, 7, 4,
+ax_anim 2, 0, 132, 10, 9, 10, 9,
+ax_anim 2, 0, 133, 8, 14, 8, 14,
+ax_anim 3, 0, 134, 0, 17, 0, 17,
+ax_anim 2, 3, 135, -8, 14, -8, 14,
+ax_anim 2, 0, 136, -10, 9, -10, 9,
+ax_anim 1, 0, 137, -7, 4, -7, 4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 9, -1, 9, -1,
+ax_anim 2, 0, 131, 18, 3, 18, 3,
+ax_anim 2, 0, 132, 21, 12, 21, 12,
+ax_anim 3, 0, 133, 20, 19, 20, 19,
+ax_anim 2, 3, 134, 11, 19, 11, 19,
+ax_anim 2, 0, 135, 1, 15, 1, 15,
+ax_anim 1, 0, 136, -1, 7, -1, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 4, -4, 4, -4,
+ax_anim 2, 0, 130, 11, -7, 11, -7,
+ax_anim 2, 0, 131, 18, -4, 18, -4,
+ax_anim 3, 0, 132, 18, 2, 18, 2,
+ax_anim 2, 3, 133, 15, 6, 15, 6,
+ax_anim 2, 0, 134, 8, 7, 8, 7,
+ax_anim 1, 0, 135, 3, 5, 3, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 1, -7, 1, -7,
+ax_anim 2, 0, 137, 6, -13, 6, -13,
+ax_anim 2, 0, 130, 13, -16, 13, -16,
+ax_anim 3, 0, 131, 20, -15, 20, -15,
+ax_anim 2, 3, 132, 21, -10, 21, -10,
+ax_anim 2, 0, 133, 18, -5, 18, -5,
+ax_anim 1, 0, 134, 8, 0, 8, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -9, -4, -9, -4,
+ax_anim 2, 0, 136, -11, -10, -11, -10,
+ax_anim 2, 0, 137, -7, -15, -7, -15,
+ax_anim 3, 0, 130, 0, -17, 0, -17,
+ax_anim 2, 3, 131, 7, -15, 7, -15,
+ax_anim 2, 0, 132, 11, -10, 11, -10,
+ax_anim 1, 0, 133, 9, -4, 9, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, -1, -7, -1, -7,
+ax_anim 2, 0, 131, -6, -13, -6, -13,
+ax_anim 2, 0, 130, -13, -16, -13, -16,
+ax_anim 3, 0, 137, -20, -15, -20, -15,
+ax_anim 2, 3, 136, -21, -10, -21, -10,
+ax_anim 2, 0, 135, -18, -5, -18, -5,
+ax_anim 1, 0, 134, -8, 0, -8, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -4, -4, -4, -4,
+ax_anim 2, 0, 130, -11, -7, -11, -7,
+ax_anim 2, 0, 137, -18, -4, -18, -4,
+ax_anim 3, 0, 136, -18, 2, -18, 2,
+ax_anim 2, 3, 135, -15, 6, -15, 6,
+ax_anim 2, 0, 134, -8, 7, -8, 7,
+ax_anim 1, 0, 133, -3, 5, -3, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -9, -1, -9, -1,
+ax_anim 2, 0, 137, -18, 3, -18, 3,
+ax_anim 2, 0, 136, -21, 12, -21, 12,
+ax_anim 3, 0, 135, -21, 19, -21, 19,
+ax_anim 2, 3, 134, -11, 19, -11, 19,
+ax_anim 2, 0, 133, -1, 15, -1, 15,
+ax_anim 1, 0, 132, 1, 7, 1, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -23, 0, 0,
+ax_anim 3, 0, 146, 0, -22, 0, 0,
+ax_anim 2, 0, 146, 0, -16, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 2, 146, 0, 2, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_11_2:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -23, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 2, 148, 0, 2, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_11_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -23, 0, 0,
+ax_anim 3, 0, 150, 0, -22, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 2, 150, 0, 3, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_11_4:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -22, 0, 0,
+ax_anim 3, 0, 152, 0, -21, 0, 0,
+ax_anim 2, 0, 152, 0, -15, 0, 0,
+ax_anim 1, 0, 152, 0, -9, 0, 0,
+ax_anim 2, 2, 152, 0, 3, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_11_5:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -23, 0, 0,
+ax_anim 3, 0, 154, 0, -22, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 2, 154, 0, 1, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_11_6:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -22, 0, 0,
+ax_anim 3, 0, 156, 0, -21, 0, 0,
+ax_anim 2, 0, 156, 0, -15, 0, 0,
+ax_anim 1, 0, 156, 0, -9, 0, 0,
+ax_anim 2, 2, 156, 0, 3, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_11_7:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 158, 0, -23, 0, 0,
+ax_anim 3, 0, 158, 0, -22, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 2, 158, 0, 3, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_11_8:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 2, 160, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRelicanthAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sRelicanthGfx1:
+.incbin "baserom.gba", 0x1537C98, 0x200
+sRelicanthSprites1:
+ax_sprite sRelicanthGfx1, 0x200
+ax_sprite_terminator
+sRelicanthGfx2:
+.incbin "baserom.gba", 0x1537EA8, 0x200
+sRelicanthSprites2:
+ax_sprite sRelicanthGfx2, 0x200
+ax_sprite_terminator
+sRelicanthGfx3:
+.incbin "baserom.gba", 0x15380B8, 0x200
+sRelicanthSprites3:
+ax_sprite sRelicanthGfx3, 0x200
+ax_sprite_terminator
+sRelicanthGfx4:
+.incbin "baserom.gba", 0x15382C8, 0x200
+sRelicanthSprites4:
+ax_sprite sRelicanthGfx4, 0x200
+ax_sprite_terminator
+sRelicanthGfx5:
+.incbin "baserom.gba", 0x15384D8, 0x200
+sRelicanthSprites5:
+ax_sprite sRelicanthGfx5, 0x200
+ax_sprite_terminator
+sRelicanthGfx6:
+.incbin "baserom.gba", 0x15386E8, 0x200
+sRelicanthSprites6:
+ax_sprite sRelicanthGfx6, 0x200
+ax_sprite_terminator
+sRelicanthGfx7:
+.incbin "baserom.gba", 0x15388F8, 0x200
+sRelicanthSprites7:
+ax_sprite sRelicanthGfx7, 0x200
+ax_sprite_terminator
+sRelicanthGfx8:
+.incbin "baserom.gba", 0x1538B08, 0x200
+sRelicanthSprites8:
+ax_sprite sRelicanthGfx8, 0x200
+ax_sprite_terminator
+sRelicanthGfx9:
+.incbin "baserom.gba", 0x1538D18, 0x200
+sRelicanthSprites9:
+ax_sprite sRelicanthGfx9, 0x200
+ax_sprite_terminator
+sRelicanthGfx10:
+.incbin "baserom.gba", 0x1538F28, 0x200
+sRelicanthSprites10:
+ax_sprite sRelicanthGfx10, 0x200
+ax_sprite_terminator
+sRelicanthGfx11:
+.incbin "baserom.gba", 0x1539138, 0x200
+sRelicanthSprites11:
+ax_sprite sRelicanthGfx11, 0x200
+ax_sprite_terminator
+sRelicanthGfx12:
+.incbin "baserom.gba", 0x1539348, 0x200
+sRelicanthSprites12:
+ax_sprite sRelicanthGfx12, 0x200
+ax_sprite_terminator
+sRelicanthGfx13:
+.incbin "baserom.gba", 0x1539558, 0x200
+sRelicanthSprites13:
+ax_sprite sRelicanthGfx13, 0x200
+ax_sprite_terminator
+sRelicanthGfx14:
+.incbin "baserom.gba", 0x1539768, 0x200
+sRelicanthSprites14:
+ax_sprite sRelicanthGfx14, 0x200
+ax_sprite_terminator
+sRelicanthGfx15:
+.incbin "baserom.gba", 0x1539978, 0x200
+sRelicanthSprites15:
+ax_sprite sRelicanthGfx15, 0x200
+ax_sprite_terminator
+sRelicanthGfx16:
+.incbin "baserom.gba", 0x1539B88, 0x100
+sRelicanthSprites16:
+ax_sprite sRelicanthGfx16, 0x100
+ax_sprite_terminator
+sRelicanthGfx17:
+.incbin "baserom.gba", 0x1539C98, 0x20
+sRelicanthSprites17:
+ax_sprite sRelicanthGfx17, 0x20
+ax_sprite_terminator
+sRelicanthGfx18:
+.incbin "baserom.gba", 0x1539CC8, 0x100
+sRelicanthSprites18:
+ax_sprite sRelicanthGfx18, 0x100
+ax_sprite_terminator
+sRelicanthGfx19:
+.incbin "baserom.gba", 0x1539DD8, 0x80
+sRelicanthSprites19:
+ax_sprite sRelicanthGfx19, 0x80
+ax_sprite_terminator
+sRelicanthGfx20:
+.incbin "baserom.gba", 0x1539E68, 0x180
+sRelicanthGfx20_1:
+.incbin "baserom.gba", 0x1539FE8, 0x40
+sRelicanthSprites20:
+ax_sprite sRelicanthGfx20, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRelicanthGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRelicanthGfx21:
+.incbin "baserom.gba", 0x153A050, 0x100
+sRelicanthSprites21:
+ax_sprite sRelicanthGfx21, 0x100
+ax_sprite_terminator
+sRelicanthGfx22:
+.incbin "baserom.gba", 0x153A160, 0x80
+sRelicanthSprites22:
+ax_sprite sRelicanthGfx22, 0x80
+ax_sprite_terminator
+sRelicanthGfx23:
+.incbin "baserom.gba", 0x153A1F0, 0x100
+sRelicanthSprites23:
+ax_sprite sRelicanthGfx23, 0x100
+ax_sprite_terminator
+sRelicanthGfx24:
+.incbin "baserom.gba", 0x153A300, 0x40
+sRelicanthSprites24:
+ax_sprite sRelicanthGfx24, 0x40
+ax_sprite_terminator
+sRelicanthGfx25:
+.incbin "baserom.gba", 0x153A350, 0x20
+sRelicanthSprites25:
+ax_sprite sRelicanthGfx25, 0x20
+ax_sprite_terminator
+sRelicanthGfx26:
+.incbin "baserom.gba", 0x153A380, 0x200
+sRelicanthSprites26:
+ax_sprite sRelicanthGfx26, 0x200
+ax_sprite_terminator
+sRelicanthGfx27:
+.incbin "baserom.gba", 0x153A590, 0x200
+sRelicanthSprites27:
+ax_sprite sRelicanthGfx27, 0x200
+ax_sprite_terminator
+sRelicanthGfx28:
+.incbin "baserom.gba", 0x153A7A0, 0x200
+sRelicanthSprites28:
+ax_sprite sRelicanthGfx28, 0x200
+ax_sprite_terminator
+sRelicanthGfx29:
+.incbin "baserom.gba", 0x153A9B0, 0x200
+sRelicanthSprites29:
+ax_sprite sRelicanthGfx29, 0x200
+ax_sprite_terminator
+sRelicanthGfx30:
+.incbin "baserom.gba", 0x153ABC0, 0x200
+sRelicanthSprites30:
+ax_sprite sRelicanthGfx30, 0x200
+ax_sprite_terminator
+sRelicanthGfx31:
+.incbin "baserom.gba", 0x153ADD0, 0x200
+sRelicanthSprites31:
+ax_sprite sRelicanthGfx31, 0x200
+ax_sprite_terminator
+sRelicanthGfx32:
+.incbin "baserom.gba", 0x153AFE0, 0x200
+sRelicanthSprites32:
+ax_sprite sRelicanthGfx32, 0x200
+ax_sprite_terminator
+sAxPosesRelicanth:
+.4byte sRelicanthPose1
+.4byte sRelicanthPose2
+.4byte sRelicanthPose3
+.4byte sRelicanthPose4
+.4byte sRelicanthPose5
+.4byte sRelicanthPose6
+.4byte sRelicanthPose7
+.4byte sRelicanthPose8
+.4byte sRelicanthPose9
+.4byte sRelicanthPose10
+.4byte sRelicanthPose11
+.4byte sRelicanthPose12
+.4byte sRelicanthPose13
+.4byte sRelicanthPose14
+.4byte sRelicanthPose15
+.4byte sRelicanthPose16
+.4byte sRelicanthPose17
+.4byte sRelicanthPose18
+.4byte sRelicanthPose19
+.4byte sRelicanthPose20
+.4byte sRelicanthPose21
+.4byte sRelicanthPose22
+.4byte sRelicanthPose23
+.4byte sRelicanthPose24
+.4byte sRelicanthPose25
+.4byte sRelicanthPose26
+.4byte sRelicanthPose27
+.4byte sRelicanthPose28
+.4byte sRelicanthPose29
+.4byte sRelicanthPose30
+.4byte sRelicanthPose31
+.4byte sRelicanthPose32
+.4byte sRelicanthPose33
+.4byte sRelicanthPose34
+.4byte sRelicanthPose35
+.4byte sRelicanthPose36
+.4byte sRelicanthPose37
+.4byte sRelicanthPose38
+.4byte sRelicanthPose39
+.4byte sRelicanthPose40
+.4byte sRelicanthPose41
+.4byte sRelicanthPose42
+.4byte sRelicanthPose43
+.4byte sRelicanthPose44
+.4byte sRelicanthPose45
+.4byte sRelicanthPose46
+.4byte sRelicanthPose47
+.4byte sRelicanthPose48
+.4byte sRelicanthPose49
+.4byte sRelicanthPose50
+.4byte sRelicanthPose51
+.4byte sRelicanthPose52
+.4byte sRelicanthPose53
+.4byte sRelicanthPose54
+.4byte sRelicanthPose55
+.4byte sRelicanthPose56
+.4byte sRelicanthPose57
+.4byte sRelicanthPose58
+.4byte sRelicanthPose59
+.4byte sRelicanthPose60
+.4byte sRelicanthPose61
+.4byte sRelicanthPose62
+.4byte sRelicanthPose63
+.4byte sRelicanthPose64
+.4byte sRelicanthPose65
+.4byte sRelicanthPose66
+.4byte sRelicanthPose67
+.4byte sRelicanthPose68
+.4byte sRelicanthPose69
+.4byte sRelicanthPose70
+.4byte sRelicanthPose71
+.4byte sRelicanthPose72
+.4byte sRelicanthPose73
+.4byte sRelicanthPose74
+.4byte sRelicanthPose75
+.4byte sRelicanthPose76
+.4byte sRelicanthPose77
+.4byte sRelicanthPose78
+.4byte sRelicanthPose79
+.4byte sRelicanthPose80
+.4byte sRelicanthPose81
+.4byte sRelicanthPose82
+.4byte sRelicanthPose83
+.4byte sRelicanthPose84
+.4byte sRelicanthPose85
+.4byte sRelicanthPose86
+.4byte sRelicanthPose87
+.4byte sRelicanthPose88
+.4byte sRelicanthPose89
+.4byte sRelicanthPose90
+.4byte sRelicanthPose91
+.4byte sRelicanthPose92
+.4byte sRelicanthPose93
+.4byte sRelicanthPose94
+.4byte sRelicanthPose95
+.4byte sRelicanthPose96
+.4byte sRelicanthPose97
+.4byte sRelicanthPose98
+.4byte sRelicanthPose99
+.4byte sRelicanthPose100
+.4byte sRelicanthPose101
+.4byte sRelicanthPose102
+.4byte sRelicanthPose103
+.4byte sRelicanthPose104
+.4byte sRelicanthPose105
+.4byte sRelicanthPose106
+.4byte sRelicanthPose107
+.4byte sRelicanthPose108
+.4byte sRelicanthPose109
+.4byte sRelicanthPose110
+.4byte sRelicanthPose111
+.4byte sRelicanthPose112
+.4byte sRelicanthPose113
+.4byte sRelicanthPose114
+.4byte sRelicanthPose115
+.4byte sRelicanthPose116
+.4byte sRelicanthPose117
+.4byte sRelicanthPose118
+.4byte sRelicanthPose119
+.4byte sRelicanthPose120
+.4byte sRelicanthPose121
+.4byte sRelicanthPose122
+.4byte sRelicanthPose123
+.4byte sRelicanthPose124
+.4byte sRelicanthPose125
+.4byte sRelicanthPose126
+.4byte sRelicanthPose127
+.4byte sRelicanthPose128
+.4byte sRelicanthPose129
+.4byte sRelicanthPose130
+.4byte sRelicanthPose131
+.4byte sRelicanthPose132
+.4byte sRelicanthPose133
+.4byte sRelicanthPose134
+.4byte sRelicanthPose135
+.4byte sRelicanthPose136
+.4byte sRelicanthPose137
+.4byte sRelicanthPose138
+.4byte sRelicanthPose139
+.4byte sRelicanthPose140
+.4byte sRelicanthPose141
+.4byte sRelicanthPose142
+.4byte sRelicanthPose143
+.4byte sRelicanthPose144
+.4byte sRelicanthPose145
+.4byte sRelicanthPose146
+.4byte sRelicanthPose147
+.4byte sRelicanthPose148
+.4byte sRelicanthPose149
+.4byte sRelicanthPose150
+.4byte sRelicanthPose151
+.4byte sRelicanthPose152
+.4byte sRelicanthPose153
+.4byte sRelicanthPose154
+.4byte sRelicanthPose155
+.4byte sRelicanthPose156
+.4byte sRelicanthPose157
+.4byte sRelicanthPose158
+.4byte sRelicanthPose159
+.4byte sRelicanthPose160
+.4byte sRelicanthPose161
+.4byte sRelicanthPose162
+.4byte sRelicanthPose163
+.4byte sRelicanthPose164
+.4byte sRelicanthPose165
+.4byte sRelicanthPose166
+.4byte sRelicanthPose167
+.4byte sRelicanthPose168
+.4byte sRelicanthPose169
+.4byte sRelicanthPose170
+.4byte sRelicanthPose171
+.4byte sRelicanthPose172
+.4byte sRelicanthPose173
+.4byte sRelicanthPose174
+.4byte sRelicanthPose175
+.4byte sRelicanthPose176
+.4byte sRelicanthPose177
+.4byte sRelicanthPose178
+sAxPositionsRelicanth:
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte    3,   -7, 	  -9,   -2, 	   7,   -6, 	  -1,  -12
+.2byte   -5,   -7, 	  -8,   -6, 	   7,   -3, 	   1,  -12
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+.2byte    4,   -5, 	   9,   -7, 	  -4,   -2, 	  -4,  -12
+.2byte   10,   -7, 	   3,  -13, 	   0,   -3, 	  -3,  -12
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte   10,   -7, 	   5,  -11, 	   1,   -2, 	  -3,  -11
+.2byte   11,   -9, 	   2,  -12, 	   5,   -3, 	  -2,  -11
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte   11,  -10, 	   1,  -12, 	   6,   -5, 	  -2,  -11
+.2byte    6,  -13, 	  -4,   -9, 	   6,   -6, 	  -1,  -11
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte   -3,  -15, 	   5,  -11, 	 -11,   -7, 	  -2,  -11
+.2byte    2,  -16, 	   9,   -7, 	  -7,  -11, 	   0,  -11
+.2byte  -11,  -12, 	  -2,  -12, 	  -9,   -5, 	   0,  -11
+.2byte  -13,  -10, 	  -3,  -12, 	  -8,   -5, 	   0,  -11
+.2byte   -8,  -13, 	   2,   -9, 	  -8,   -6, 	  -1,  -11
+.2byte  -14,   -8, 	  -4,  -13, 	  -4,   -3, 	   0,  -12
+.2byte  -12,   -7, 	  -7,  -11, 	  -3,   -2, 	   1,  -11
+.2byte  -13,   -9, 	  -4,  -12, 	  -7,   -3, 	   0,  -11
+.2byte  -10,   -7, 	  -7,  -11, 	   0,   -2, 	   0,  -12
+.2byte   -6,   -5, 	 -11,   -7, 	   2,   -2, 	   2,  -12
+.2byte  -12,   -7, 	  -5,  -13, 	  -2,   -3, 	   1,  -12
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte    3,   -7, 	  -9,   -2, 	   7,   -6, 	  -1,  -12
+.2byte   -5,   -7, 	  -8,   -6, 	   7,   -3, 	   1,  -12
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+.2byte    4,   -5, 	   9,   -7, 	  -4,   -2, 	  -4,  -12
+.2byte   10,   -7, 	   3,  -13, 	   0,   -3, 	  -3,  -12
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte   10,   -7, 	   5,  -11, 	   1,   -2, 	  -3,  -11
+.2byte   11,   -9, 	   2,  -12, 	   5,   -3, 	  -2,  -11
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte   11,  -10, 	   1,  -12, 	   6,   -5, 	  -2,  -11
+.2byte    6,  -13, 	  -4,   -9, 	   6,   -6, 	  -1,  -11
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte   -3,  -15, 	   5,  -11, 	 -11,   -7, 	  -2,  -11
+.2byte    2,  -16, 	   9,   -7, 	  -7,  -11, 	   0,  -11
+.2byte  -11,  -12, 	  -2,  -12, 	  -9,   -5, 	   0,  -11
+.2byte  -13,  -10, 	  -3,  -12, 	  -8,   -5, 	   0,  -11
+.2byte   -8,  -13, 	   2,   -9, 	  -8,   -6, 	  -1,  -11
+.2byte  -14,   -8, 	  -4,  -13, 	  -4,   -3, 	   0,  -12
+.2byte  -12,   -7, 	  -7,  -11, 	  -3,   -2, 	   1,  -11
+.2byte  -13,   -9, 	  -4,  -12, 	  -7,   -3, 	   0,  -11
+.2byte  -10,   -7, 	  -7,  -11, 	   0,   -2, 	   0,  -12
+.2byte   -6,   -5, 	 -11,   -7, 	   2,   -2, 	   2,  -12
+.2byte  -12,   -7, 	  -5,  -13, 	  -2,   -3, 	   1,  -12
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte    3,   -7, 	  -9,   -2, 	   7,   -6, 	  -1,  -12
+.2byte   -5,   -7, 	  -8,   -6, 	   7,   -3, 	   1,  -12
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+.2byte    4,   -5, 	   9,   -7, 	  -4,   -2, 	  -4,  -12
+.2byte   10,   -7, 	   3,  -13, 	   0,   -3, 	  -3,  -12
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte   10,   -7, 	   5,  -11, 	   1,   -2, 	  -3,  -11
+.2byte   11,   -9, 	   2,  -12, 	   5,   -3, 	  -2,  -11
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte   11,  -10, 	   1,  -12, 	   6,   -5, 	  -2,  -11
+.2byte    6,  -13, 	  -4,   -9, 	   6,   -6, 	  -1,  -11
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte   -3,  -15, 	   5,  -11, 	 -11,   -7, 	  -2,  -11
+.2byte    2,  -16, 	   9,   -7, 	  -7,  -11, 	   0,  -11
+.2byte  -11,  -12, 	  -2,  -12, 	  -9,   -5, 	   0,  -11
+.2byte  -13,  -10, 	  -3,  -12, 	  -8,   -5, 	   0,  -11
+.2byte   -8,  -13, 	   2,   -9, 	  -8,   -6, 	  -1,  -11
+.2byte  -14,   -8, 	  -4,  -13, 	  -4,   -3, 	   0,  -12
+.2byte  -12,   -7, 	  -7,  -11, 	  -3,   -2, 	   1,  -11
+.2byte  -13,   -9, 	  -4,  -12, 	  -7,   -3, 	   0,  -11
+.2byte  -10,   -7, 	  -7,  -11, 	   0,   -2, 	   0,  -12
+.2byte   -6,   -5, 	 -11,   -7, 	   2,   -2, 	   2,  -12
+.2byte  -12,   -7, 	  -5,  -13, 	  -2,   -3, 	   1,  -12
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte   -1,   -8, 	  -7,   -6, 	   5,   -5, 	  -1,  -13
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+.2byte    8,  -10, 	   7,   -7, 	   2,   -4, 	  -2,  -13
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte   10,  -10, 	   6,   -9, 	   6,   -4, 	  -1,  -11
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte    7,  -14, 	   0,  -13, 	   7,   -7, 	  -1,  -11
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte   -1,  -19, 	   7,  -10, 	  -8,  -10, 	   0,  -11
+.2byte  -11,  -12, 	  -2,  -12, 	  -9,   -5, 	   0,  -11
+.2byte   -8,  -14, 	  -1,  -13, 	  -8,   -7, 	   0,  -11
+.2byte  -14,   -8, 	  -4,  -13, 	  -4,   -3, 	   0,  -12
+.2byte  -11,  -10, 	  -7,   -9, 	  -7,   -4, 	   0,  -11
+.2byte  -10,   -7, 	  -7,  -11, 	   0,   -2, 	   0,  -12
+.2byte   -9,  -10, 	  -8,   -7, 	  -3,   -4, 	   1,  -13
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte  -10,   -7, 	  -7,  -11, 	   0,   -2, 	   0,  -12
+.2byte  -14,   -8, 	  -4,  -13, 	  -4,   -3, 	   0,  -12
+.2byte  -11,  -12, 	  -2,  -12, 	  -9,   -5, 	   0,  -11
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+.2byte   -9,   -4, 	  -8,   -9, 	   0,   -1, 	   1,  -11
+.2byte  -10,   -6, 	  -9,  -10, 	   2,   -3, 	   1,  -12
+.2byte    6,   -5, 	  -6,   -8, 	  10,  -11, 	   1,  -13
+.2byte    1,   -4, 	   8,   -9, 	  -9,   -6, 	  -3,  -14
+.2byte    8,   -3, 	   8,  -10, 	  -5,   -3, 	  -4,  -11
+.2byte    4,   -3, 	  -2,   -9, 	   5,   -4, 	  -5,   -7
+.2byte   -4,   -9, 	   7,   -8, 	  -8,   -2, 	   0,   -5
+.2byte   -5,   -3, 	   1,   -9, 	  -6,   -4, 	   4,   -7
+.2byte   -9,   -3, 	  -9,  -10, 	   4,   -3, 	   3,  -11
+.2byte   -2,   -4, 	  -9,   -9, 	   8,   -6, 	   2,  -14
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte    3,   -7, 	  -9,   -2, 	   7,   -6, 	  -1,  -12
+.2byte   -5,   -7, 	  -8,   -6, 	   7,   -3, 	   1,  -12
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+.2byte    4,   -5, 	   9,   -7, 	  -4,   -2, 	  -4,  -12
+.2byte   10,   -7, 	   3,  -13, 	   0,   -3, 	  -3,  -12
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte   10,   -7, 	   5,  -11, 	   1,   -2, 	  -3,  -11
+.2byte   11,   -9, 	   2,  -12, 	   5,   -3, 	  -2,  -11
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte   11,  -10, 	   1,  -12, 	   6,   -5, 	  -2,  -11
+.2byte    6,  -13, 	  -4,   -9, 	   6,   -6, 	  -1,  -11
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte   -3,  -15, 	   5,  -11, 	 -11,   -7, 	  -2,  -11
+.2byte    2,  -16, 	   9,   -7, 	  -7,  -11, 	   0,  -11
+.2byte  -11,  -12, 	  -2,  -12, 	  -9,   -5, 	   0,  -11
+.2byte  -13,  -10, 	  -3,  -12, 	  -8,   -5, 	   0,  -11
+.2byte   -8,  -13, 	   2,   -9, 	  -8,   -6, 	  -1,  -11
+.2byte  -14,   -8, 	  -4,  -13, 	  -4,   -3, 	   0,  -12
+.2byte  -12,   -7, 	  -7,  -11, 	  -3,   -2, 	   1,  -11
+.2byte  -13,   -9, 	  -4,  -12, 	  -7,   -3, 	   0,  -11
+.2byte  -10,   -7, 	  -7,  -11, 	   0,   -2, 	   0,  -12
+.2byte   -6,   -5, 	 -11,   -7, 	   2,   -2, 	   2,  -12
+.2byte  -12,   -7, 	  -5,  -13, 	  -2,   -3, 	   1,  -12
+.2byte   -1,   -8, 	  -7,   -6, 	   5,   -5, 	  -1,  -13
+.2byte   -9,  -10, 	  -8,   -7, 	  -3,   -4, 	   1,  -13
+.2byte  -10,  -11, 	  -6,  -10, 	  -6,   -5, 	   1,  -12
+.2byte   -9,  -14, 	  -2,  -13, 	  -9,   -7, 	  -1,  -11
+.2byte   -1,  -19, 	   7,  -10, 	  -8,  -10, 	   0,  -11
+.2byte    8,  -14, 	   1,  -13, 	   8,   -7, 	   0,  -11
+.2byte    9,  -10, 	   5,   -9, 	   5,   -4, 	  -2,  -11
+.2byte    8,  -10, 	   7,   -7, 	   2,   -4, 	  -2,  -13
+.2byte   -5,   -7, 	  -8,   -6, 	   7,   -3, 	   1,  -12
+.2byte    9,   -7, 	   2,  -13, 	  -1,   -3, 	  -4,  -12
+.2byte   11,  -10, 	   2,  -13, 	   5,   -4, 	  -2,  -12
+.2byte    7,  -13, 	  -3,   -9, 	   7,   -6, 	   0,  -11
+.2byte    2,  -16, 	   9,   -7, 	  -7,  -11, 	   0,  -11
+.2byte   -8,  -13, 	   2,   -9, 	  -8,   -6, 	  -1,  -11
+.2byte  -12,  -10, 	  -3,  -13, 	  -6,   -4, 	   1,  -12
+.2byte  -10,   -7, 	  -3,  -13, 	   0,   -3, 	   3,  -12
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -4, 	  -1,  -12
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+.2byte    7,   -9, 	   6,   -6, 	   1,   -3, 	  -3,  -12
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte    9,  -10, 	   5,   -9, 	   5,   -4, 	  -2,  -11
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte    7,  -13, 	   0,  -12, 	   7,   -6, 	  -1,  -10
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte   -1,  -18, 	   7,   -9, 	  -8,   -9, 	   0,  -10
+.2byte  -10,  -12, 	  -1,  -12, 	  -8,   -5, 	   1,  -11
+.2byte   -8,  -13, 	  -1,  -12, 	  -8,   -6, 	   0,  -10
+.2byte  -13,   -8, 	  -3,  -13, 	  -3,   -3, 	   1,  -12
+.2byte  -10,  -10, 	  -6,   -9, 	  -6,   -4, 	   1,  -11
+.2byte   -9,   -7, 	  -6,  -11, 	   1,   -2, 	   1,  -12
+.2byte   -8,   -9, 	  -7,   -6, 	  -2,   -3, 	   2,  -12
+.2byte   -1,   -8, 	  -7,   -6, 	   5,   -5, 	  -1,  -13
+.2byte   -9,  -10, 	  -8,   -7, 	  -3,   -4, 	   1,  -13
+.2byte  -10,  -11, 	  -6,  -10, 	  -6,   -5, 	   1,  -12
+.2byte   -9,  -14, 	  -2,  -13, 	  -9,   -7, 	  -1,  -11
+.2byte   -1,  -20, 	   7,  -11, 	  -8,  -11, 	   0,  -12
+.2byte    8,  -14, 	   1,  -13, 	   8,   -7, 	   0,  -11
+.2byte    9,  -10, 	   5,   -9, 	   5,   -4, 	  -2,  -11
+.2byte    8,  -10, 	   7,   -7, 	   2,   -4, 	  -2,  -13
+.2byte   -1,   -5, 	  -9,   -4, 	   7,   -4, 	  -1,  -11
+.2byte  -10,   -7, 	  -7,  -11, 	   0,   -2, 	   0,  -12
+.2byte  -14,   -8, 	  -4,  -13, 	  -4,   -3, 	   0,  -12
+.2byte  -11,  -12, 	  -2,  -12, 	  -9,   -5, 	   0,  -11
+.2byte   -1,  -16, 	   8,   -9, 	 -10,   -9, 	  -1,  -12
+.2byte    9,  -12, 	   0,  -12, 	   7,   -5, 	  -2,  -11
+.2byte   12,   -8, 	   2,  -13, 	   2,   -3, 	  -2,  -12
+.2byte    8,   -7, 	   5,  -11, 	  -2,   -2, 	  -2,  -12
+sRelicanthAnimTable1:
+.4byte sRelicanthAnims_1_1
+.4byte sRelicanthAnims_1_2
+.4byte sRelicanthAnims_1_3
+.4byte sRelicanthAnims_1_4
+.4byte sRelicanthAnims_1_5
+.4byte sRelicanthAnims_1_6
+.4byte sRelicanthAnims_1_7
+.4byte sRelicanthAnims_1_8
+sRelicanthAnimTable2:
+.4byte sRelicanthAnims_2_1
+.4byte sRelicanthAnims_2_2
+.4byte sRelicanthAnims_2_3
+.4byte sRelicanthAnims_2_4
+.4byte sRelicanthAnims_2_5
+.4byte sRelicanthAnims_2_6
+.4byte sRelicanthAnims_2_7
+.4byte sRelicanthAnims_2_8
+sRelicanthAnimTable3:
+.4byte sRelicanthAnims_3_1
+.4byte sRelicanthAnims_3_2
+.4byte sRelicanthAnims_3_3
+.4byte sRelicanthAnims_3_4
+.4byte sRelicanthAnims_3_5
+.4byte sRelicanthAnims_3_6
+.4byte sRelicanthAnims_3_7
+.4byte sRelicanthAnims_3_8
+sRelicanthAnimTable4:
+.4byte sRelicanthAnims_4_1
+.4byte sRelicanthAnims_4_2
+.4byte sRelicanthAnims_4_3
+.4byte sRelicanthAnims_4_4
+.4byte sRelicanthAnims_4_5
+.4byte sRelicanthAnims_4_6
+.4byte sRelicanthAnims_4_7
+.4byte sRelicanthAnims_4_8
+sRelicanthAnimTable5:
+.4byte sRelicanthAnims_5_1
+.4byte sRelicanthAnims_5_2
+.4byte sRelicanthAnims_5_3
+.4byte sRelicanthAnims_5_4
+.4byte sRelicanthAnims_5_5
+.4byte sRelicanthAnims_5_6
+.4byte sRelicanthAnims_5_7
+.4byte sRelicanthAnims_5_8
+sRelicanthAnimTable6:
+.4byte sRelicanthAnims_6_1
+.4byte sRelicanthAnims_6_1
+.4byte sRelicanthAnims_6_1
+.4byte sRelicanthAnims_6_1
+.4byte sRelicanthAnims_6_1
+.4byte sRelicanthAnims_6_1
+.4byte sRelicanthAnims_6_1
+.4byte sRelicanthAnims_6_1
+sRelicanthAnimTable7:
+.4byte sRelicanthAnims_7_1
+.4byte sRelicanthAnims_7_2
+.4byte sRelicanthAnims_7_3
+.4byte sRelicanthAnims_7_4
+.4byte sRelicanthAnims_7_5
+.4byte sRelicanthAnims_7_6
+.4byte sRelicanthAnims_7_7
+.4byte sRelicanthAnims_7_8
+sRelicanthAnimTable8:
+.4byte sRelicanthAnims_8_1
+.4byte sRelicanthAnims_8_2
+.4byte sRelicanthAnims_8_3
+.4byte sRelicanthAnims_8_4
+.4byte sRelicanthAnims_8_5
+.4byte sRelicanthAnims_8_6
+.4byte sRelicanthAnims_8_7
+.4byte sRelicanthAnims_8_8
+sRelicanthAnimTable9:
+.4byte sRelicanthAnims_9_1
+.4byte sRelicanthAnims_9_2
+.4byte sRelicanthAnims_9_3
+.4byte sRelicanthAnims_9_4
+.4byte sRelicanthAnims_9_5
+.4byte sRelicanthAnims_9_6
+.4byte sRelicanthAnims_9_7
+.4byte sRelicanthAnims_9_8
+sRelicanthAnimTable10:
+.4byte sRelicanthAnims_10_1
+.4byte sRelicanthAnims_10_2
+.4byte sRelicanthAnims_10_3
+.4byte sRelicanthAnims_10_4
+.4byte sRelicanthAnims_10_5
+.4byte sRelicanthAnims_10_6
+.4byte sRelicanthAnims_10_7
+.4byte sRelicanthAnims_10_8
+sRelicanthAnimTable11:
+.4byte sRelicanthAnims_11_1
+.4byte sRelicanthAnims_11_2
+.4byte sRelicanthAnims_11_3
+.4byte sRelicanthAnims_11_4
+.4byte sRelicanthAnims_11_5
+.4byte sRelicanthAnims_11_6
+.4byte sRelicanthAnims_11_7
+.4byte sRelicanthAnims_11_8
+sRelicanthAnimTable12:
+.4byte sRelicanthAnims_12_1
+.4byte sRelicanthAnims_12_2
+.4byte sRelicanthAnims_12_3
+.4byte sRelicanthAnims_12_4
+.4byte sRelicanthAnims_12_5
+.4byte sRelicanthAnims_12_6
+.4byte sRelicanthAnims_12_7
+.4byte sRelicanthAnims_12_8
+sRelicanthAnimTable13:
+.4byte sRelicanthAnims_13_1
+.4byte sRelicanthAnims_13_2
+.4byte sRelicanthAnims_13_3
+.4byte sRelicanthAnims_13_4
+.4byte sRelicanthAnims_13_5
+.4byte sRelicanthAnims_13_6
+.4byte sRelicanthAnims_13_7
+.4byte sRelicanthAnims_13_8
+sAxAnimationsRelicanth:
+.4byte sRelicanthAnimTable1
+.4byte sRelicanthAnimTable2
+.4byte sRelicanthAnimTable3
+.4byte sRelicanthAnimTable4
+.4byte sRelicanthAnimTable5
+.4byte sRelicanthAnimTable6
+.4byte sRelicanthAnimTable7
+.4byte sRelicanthAnimTable8
+.4byte sRelicanthAnimTable9
+.4byte sRelicanthAnimTable10
+.4byte sRelicanthAnimTable11
+.4byte sRelicanthAnimTable12
+.4byte sRelicanthAnimTable13
+sAxSpritesRelicanth:
+.4byte sRelicanthSprites1
+.4byte sRelicanthSprites2
+.4byte sRelicanthSprites3
+.4byte sRelicanthSprites4
+.4byte sRelicanthSprites5
+.4byte sRelicanthSprites6
+.4byte sRelicanthSprites7
+.4byte sRelicanthSprites8
+.4byte sRelicanthSprites9
+.4byte sRelicanthSprites10
+.4byte sRelicanthSprites11
+.4byte sRelicanthSprites12
+.4byte sRelicanthSprites13
+.4byte sRelicanthSprites14
+.4byte sRelicanthSprites15
+.4byte sRelicanthSprites16
+.4byte sRelicanthSprites17
+.4byte sRelicanthSprites18
+.4byte sRelicanthSprites19
+.4byte sRelicanthSprites20
+.4byte sRelicanthSprites21
+.4byte sRelicanthSprites22
+.4byte sRelicanthSprites23
+.4byte sRelicanthSprites24
+.4byte sRelicanthSprites25
+.4byte sRelicanthSprites26
+.4byte sRelicanthSprites27
+.4byte sRelicanthSprites28
+.4byte sRelicanthSprites29
+.4byte sRelicanthSprites30
+.4byte sRelicanthSprites31
+.4byte sRelicanthSprites32
+sAxMainRelicanth:
+ax_main sAxPosesRelicanth, sAxAnimationsRelicanth, 13, sAxSpritesRelicanth, sAxPositionsRelicanth

--- a/data/ax/remoraid.inc
+++ b/data/ax/remoraid.inc
@@ -1,0 +1,2882 @@
+.global gAxRemoraid
+gAxRemoraid:
+ax_siro sAxMainRemoraid
+sRemoraidPose1:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose2:
+ax_pose 1, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose3:
+ax_pose 2, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose4:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose5:
+ax_pose 4, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose6:
+ax_pose 5, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose7:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose8:
+ax_pose 7, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose9:
+ax_pose 8, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose10:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose11:
+ax_pose 10, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose12:
+ax_pose 11, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose13:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose14:
+ax_pose 13, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose15:
+ax_pose 14, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose16:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose17:
+ax_pose 10, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose18:
+ax_pose 11, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose19:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose20:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose21:
+ax_pose 8, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose22:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose23:
+ax_pose 4, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose24:
+ax_pose 5, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose25:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose26:
+ax_pose 1, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose27:
+ax_pose 2, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose28:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose29:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose30:
+ax_pose 4, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose31:
+ax_pose 5, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose32:
+ax_pose 16, 0x81e8, 0x90f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose33:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose34:
+ax_pose 7, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose35:
+ax_pose 8, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose36:
+ax_pose 17, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose37:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose38:
+ax_pose 10, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose39:
+ax_pose 11, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose40:
+ax_pose 18, 0x81ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sRemoraidPose41:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose42:
+ax_pose 13, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose43:
+ax_pose 14, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose44:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose45:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose46:
+ax_pose 10, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose47:
+ax_pose 11, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose48:
+ax_pose 18, 0x81ea, 0x80fb, 0x5c00
+ax_pose_terminator
+sRemoraidPose49:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose50:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose51:
+ax_pose 8, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose52:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose53:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose54:
+ax_pose 4, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose55:
+ax_pose 5, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose56:
+ax_pose 16, 0x81e8, 0x80fb, 0x5c00
+ax_pose_terminator
+sRemoraidPose57:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose58:
+ax_pose 1, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose59:
+ax_pose 2, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose60:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose61:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose62:
+ax_pose 4, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose63:
+ax_pose 5, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose64:
+ax_pose 16, 0x81e8, 0x90f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose65:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose66:
+ax_pose 7, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose67:
+ax_pose 8, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose68:
+ax_pose 17, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose69:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose70:
+ax_pose 10, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose71:
+ax_pose 11, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose72:
+ax_pose 18, 0x81ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sRemoraidPose73:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose74:
+ax_pose 13, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose75:
+ax_pose 14, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose76:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose77:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose78:
+ax_pose 10, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose79:
+ax_pose 11, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose80:
+ax_pose 18, 0x81ea, 0x80fb, 0x5c00
+ax_pose_terminator
+sRemoraidPose81:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose82:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose83:
+ax_pose 8, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose84:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose85:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose86:
+ax_pose 4, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose87:
+ax_pose 5, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose88:
+ax_pose 16, 0x81e8, 0x80fb, 0x5c00
+ax_pose_terminator
+sRemoraidPose89:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose90:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose91:
+ax_pose 20, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose92:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose93:
+ax_pose 16, 0x81e8, 0x90f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose94:
+ax_pose 21, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose95:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose96:
+ax_pose 17, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose97:
+ax_pose 22, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose98:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose99:
+ax_pose 18, 0x81ea, 0x90f3, 0x5c00
+ax_pose_terminator
+sRemoraidPose100:
+ax_pose 23, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose101:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose102:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose103:
+ax_pose 24, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose104:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose105:
+ax_pose 18, 0x81ea, 0x80fb, 0x5c00
+ax_pose_terminator
+sRemoraidPose106:
+ax_pose 23, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose107:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose108:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose109:
+ax_pose 22, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose110:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose111:
+ax_pose 16, 0x81e8, 0x80fb, 0x5c00
+ax_pose_terminator
+sRemoraidPose112:
+ax_pose 21, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose113:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose114:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose115:
+ax_pose 25, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose116:
+ax_pose 26, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose117:
+ax_pose 27, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose118:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose119:
+ax_pose 16, 0x81e8, 0x90f6, 0x5c00
+ax_pose_terminator
+sRemoraidPose120:
+ax_pose 28, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose121:
+ax_pose 29, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose122:
+ax_pose 30, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose123:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose124:
+ax_pose 17, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose125:
+ax_pose 31, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sRemoraidPose126:
+ax_pose 32, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose127:
+ax_pose 33, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose128:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose129:
+ax_pose 18, 0x81ea, 0x90f6, 0x5c00
+ax_pose_terminator
+sRemoraidPose130:
+ax_pose 34, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose131:
+ax_pose 35, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose132:
+ax_pose 36, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose133:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose134:
+ax_pose 19, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose135:
+ax_pose 37, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose136:
+ax_pose 38, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose137:
+ax_pose 39, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose138:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose139:
+ax_pose 18, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose140:
+ax_pose 34, 0x81ea, 0x80fa, 0x5c00
+ax_pose_terminator
+sRemoraidPose141:
+ax_pose 35, 0x81ea, 0x80fa, 0x5c00
+ax_pose_terminator
+sRemoraidPose142:
+ax_pose 36, 0x81ea, 0x80fa, 0x5c00
+ax_pose_terminator
+sRemoraidPose143:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose144:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose145:
+ax_pose 31, 0x01ea, 0x80f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose146:
+ax_pose 32, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose147:
+ax_pose 33, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose148:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose149:
+ax_pose 16, 0x81e8, 0x80fa, 0x5c00
+ax_pose_terminator
+sRemoraidPose150:
+ax_pose 28, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose151:
+ax_pose 29, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose152:
+ax_pose 30, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose153:
+ax_pose 40, 0x41f1, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose154:
+ax_pose 41, 0x41f1, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose155:
+ax_pose 42, 0x01df, 0x80f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose156:
+ax_pose 43, 0x01de, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose157:
+ax_pose 44, 0x01e2, 0x90ea, 0x5c00
+ax_pose_terminator
+sRemoraidPose158:
+ax_pose 45, 0x01e1, 0x90e6, 0x5c00
+ax_pose_terminator
+sRemoraidPose159:
+ax_pose 46, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose160:
+ax_pose 45, 0x01e1, 0x80fa, 0x5c00
+ax_pose_terminator
+sRemoraidPose161:
+ax_pose 44, 0x01e2, 0x80f6, 0x5c00
+ax_pose_terminator
+sRemoraidPose162:
+ax_pose 43, 0x01de, 0x80f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose163:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose164:
+ax_pose 1, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose165:
+ax_pose 2, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose166:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose167:
+ax_pose 4, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose168:
+ax_pose 5, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose169:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose170:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose171:
+ax_pose 8, 0x01e9, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose172:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose173:
+ax_pose 10, 0x01eb, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose174:
+ax_pose 11, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose175:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose176:
+ax_pose 13, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose177:
+ax_pose 14, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose178:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose179:
+ax_pose 10, 0x01eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose180:
+ax_pose 11, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose181:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose182:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose183:
+ax_pose 8, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose184:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose185:
+ax_pose 4, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose186:
+ax_pose 5, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose187:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose188:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose189:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose190:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose191:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose192:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose193:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose194:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose195:
+ax_pose 20, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose196:
+ax_pose 21, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose197:
+ax_pose 22, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose198:
+ax_pose 23, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose199:
+ax_pose 24, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose200:
+ax_pose 23, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose201:
+ax_pose 22, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose202:
+ax_pose 21, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose203:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose204:
+ax_pose 15, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose205:
+ax_pose 20, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose206:
+ax_pose 3, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sRemoraidPose207:
+ax_pose 16, 0x81e5, 0x90f6, 0x5c00
+ax_pose_terminator
+sRemoraidPose208:
+ax_pose 21, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sRemoraidPose209:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose210:
+ax_pose 17, 0x01e5, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose211:
+ax_pose 22, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose212:
+ax_pose 9, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose213:
+ax_pose 18, 0x81e9, 0x90f6, 0x5c00
+ax_pose_terminator
+sRemoraidPose214:
+ax_pose 23, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sRemoraidPose215:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose216:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose217:
+ax_pose 24, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose218:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose219:
+ax_pose 18, 0x81e9, 0x80fa, 0x5c00
+ax_pose_terminator
+sRemoraidPose220:
+ax_pose 23, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose221:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose222:
+ax_pose 17, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose223:
+ax_pose 22, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose224:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose225:
+ax_pose 16, 0x81e5, 0x80fa, 0x5c00
+ax_pose_terminator
+sRemoraidPose226:
+ax_pose 21, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose227:
+ax_pose 25, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose228:
+ax_pose 28, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose229:
+ax_pose 31, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sRemoraidPose230:
+ax_pose 34, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose231:
+ax_pose 37, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose232:
+ax_pose 34, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose233:
+ax_pose 31, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose234:
+ax_pose 28, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose235:
+ax_pose 27, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose236:
+ax_pose 30, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose237:
+ax_pose 33, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose238:
+ax_pose 36, 0x81e9, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose239:
+ax_pose 39, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose240:
+ax_pose 36, 0x81e9, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose241:
+ax_pose 33, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose242:
+ax_pose 30, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose243:
+ax_pose 26, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sRemoraidPose244:
+ax_pose 29, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose245:
+ax_pose 32, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose246:
+ax_pose 35, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose247:
+ax_pose 38, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose248:
+ax_pose 35, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose249:
+ax_pose 32, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose250:
+ax_pose 29, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose251:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose252:
+ax_pose 3, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sRemoraidPose253:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sRemoraidPose254:
+ax_pose 9, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose255:
+ax_pose 12, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sRemoraidPose256:
+ax_pose 9, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sRemoraidPose257:
+ax_pose 6, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sRemoraidPose258:
+ax_pose 3, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+.align 2
+sRemoraidAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 22, 0, 20,
+ax_anim 2, 1, 24, 1, 22, 1, 20,
+ax_anim 2, 0, 24, 0, 22, 0, 20,
+ax_anim 2, 0, 24, 1, 22, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRemoraidAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 6, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 9,
+ax_anim 2, 0, 28, 22, 23, 22, 21,
+ax_anim 2, 1, 28, 23, 22, 23, 20,
+ax_anim 2, 0, 28, 22, 23, 22, 21,
+ax_anim 2, 0, 28, 23, 22, 23, 20,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sRemoraidAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 6, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 1, 10, 0,
+ax_anim 2, 0, 32, 22, 3, 22, 0,
+ax_anim 2, 1, 32, 22, 4, 22, 1,
+ax_anim 2, 0, 32, 22, 3, 22, 0,
+ax_anim 2, 0, 32, 22, 4, 22, 1,
+ax_anim 2, 0, 32, 6, 1, 6, 0,
+ax_anim_terminator
+sRemoraidAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -5, 5, -5,
+ax_anim 1, 0, 38, 12, -12, 12, -13,
+ax_anim 2, 0, 36, 22, -20, 22, -24,
+ax_anim 2, 1, 36, 23, -19, 23, -23,
+ax_anim 2, 0, 36, 22, -20, 22, -24,
+ax_anim 2, 0, 36, 23, -19, 23, -23,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sRemoraidAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 6, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -12,
+ax_anim 2, 0, 40, 0, -21, 0, -25,
+ax_anim 2, 1, 40, 1, -21, 1, -25,
+ax_anim 2, 0, 40, 0, -21, 0, -25,
+ax_anim 2, 0, 40, 1, -21, 1, -25,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sRemoraidAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 6, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -5, -5, -5,
+ax_anim 1, 0, 46, -12, -12, -12, -13,
+ax_anim 2, 0, 44, -22, -20, -22, -24,
+ax_anim 2, 1, 44, -23, -19, -23, -23,
+ax_anim 2, 0, 44, -22, -20, -22, -24,
+ax_anim 2, 0, 44, -23, -19, -23, -23,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sRemoraidAnims_2_7:
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 6, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 1, -10, 0,
+ax_anim 2, 0, 48, -22, 3, -22, 0,
+ax_anim 2, 1, 48, -22, 4, -22, 1,
+ax_anim 2, 0, 48, -22, 3, -22, 0,
+ax_anim 2, 0, 48, -22, 4, -22, 1,
+ax_anim 2, 0, 48, -6, 1, -6, 0,
+ax_anim_terminator
+sRemoraidAnims_2_8:
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 6, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 9,
+ax_anim 2, 0, 52, -22, 23, -22, 21,
+ax_anim 2, 1, 52, -23, 22, -23, 20,
+ax_anim 2, 0, 52, -22, 23, -22, 21,
+ax_anim 2, 0, 52, -23, 22, -23, 20,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_3_1:
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 6, 0, 59, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 22, 0, 20,
+ax_anim 2, 1, 56, 1, 22, 1, 20,
+ax_anim 2, 0, 56, 0, 22, 0, 20,
+ax_anim 2, 0, 56, 1, 22, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sRemoraidAnims_3_2:
+ax_anim 2, 0, 63, -1, -1, -1, -1,
+ax_anim 6, 0, 63, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 9,
+ax_anim 2, 0, 60, 22, 23, 22, 21,
+ax_anim 2, 1, 60, 23, 22, 23, 20,
+ax_anim 2, 0, 60, 22, 23, 22, 21,
+ax_anim 2, 0, 60, 23, 22, 23, 20,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sRemoraidAnims_3_3:
+ax_anim 2, 0, 67, -1, 0, -1, 0,
+ax_anim 6, 0, 67, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 1, 10, 0,
+ax_anim 2, 0, 64, 22, 3, 22, 0,
+ax_anim 2, 1, 64, 22, 4, 22, 1,
+ax_anim 2, 0, 64, 22, 3, 22, 0,
+ax_anim 2, 0, 64, 22, 4, 22, 1,
+ax_anim 2, 0, 64, 6, 1, 6, 0,
+ax_anim_terminator
+sRemoraidAnims_3_4:
+ax_anim 2, 0, 71, -1, 1, -1, 1,
+ax_anim 6, 0, 71, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 5, -5, 5, -5,
+ax_anim 1, 0, 70, 12, -12, 12, -13,
+ax_anim 2, 0, 68, 22, -20, 22, -24,
+ax_anim 2, 1, 68, 23, -19, 23, -23,
+ax_anim 2, 0, 68, 22, -20, 22, -24,
+ax_anim 2, 0, 68, 23, -19, 23, -23,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sRemoraidAnims_3_5:
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 6, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -12,
+ax_anim 2, 0, 72, 0, -21, 0, -25,
+ax_anim 2, 1, 72, 1, -21, 1, -25,
+ax_anim 2, 0, 72, 0, -21, 0, -25,
+ax_anim 2, 0, 72, 1, -21, 1, -25,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sRemoraidAnims_3_6:
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 6, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -5, -5, -5, -5,
+ax_anim 1, 0, 78, -12, -12, -12, -13,
+ax_anim 2, 0, 76, -22, -20, -22, -24,
+ax_anim 2, 1, 76, -23, -19, -23, -23,
+ax_anim 2, 0, 76, -22, -20, -22, -24,
+ax_anim 2, 0, 76, -23, -19, -23, -23,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sRemoraidAnims_3_7:
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 6, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 1, -10, 0,
+ax_anim 2, 0, 80, -22, 3, -22, 0,
+ax_anim 2, 1, 80, -22, 4, -22, 1,
+ax_anim 2, 0, 80, -22, 3, -22, 0,
+ax_anim 2, 0, 80, -22, 4, -22, 1,
+ax_anim 2, 0, 80, -6, 1, -6, 0,
+ax_anim_terminator
+sRemoraidAnims_3_8:
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 6, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 9,
+ax_anim 2, 0, 84, -22, 23, -22, 21,
+ax_anim 2, 1, 84, -23, 22, -23, 20,
+ax_anim 2, 0, 84, -22, 23, -22, 21,
+ax_anim 2, 0, 84, -23, 22, -23, 20,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sRemoraidAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sRemoraidAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sRemoraidAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sRemoraidAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sRemoraidAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sRemoraidAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sRemoraidAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_5_1:
+ax_anim 1, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim 2, 0, 113, 0, 2, 0, 2,
+ax_anim 2, 0, 114, 0, 2, 0, 2,
+ax_anim 3, 0, 115, 0, 1, 0, 2,
+ax_anim 3, 2, 114, 0, 0, 0, 2,
+ax_anim 3, 0, 116, 0, -1, 0, 2,
+ax_anim 3, 0, 114, 0, -2, 0, 2,
+ax_anim 3, 0, 115, 0, -3, 0, 2,
+ax_anim 3, 0, 114, 0, -3, 0, 2,
+ax_anim 3, 0, 116, 0, -2, 0, 2,
+ax_anim 2, 0, 113, 0, -1, 0, 1,
+ax_anim_terminator
+sRemoraidAnims_5_2:
+ax_anim 1, 0, 117, 1, 1, 1, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 118, 2, 2, 2, 2,
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 3, 0, 120, 2, 1, 2, 2,
+ax_anim 3, 2, 119, 2, 0, 2, 2,
+ax_anim 3, 0, 121, 2, -1, 2, 2,
+ax_anim 3, 0, 119, 2, -2, 2, 2,
+ax_anim 3, 0, 120, 2, -3, 2, 2,
+ax_anim 3, 0, 119, 2, -3, 2, 2,
+ax_anim 3, 0, 121, 2, -2, 2, 2,
+ax_anim 2, 0, 118, 1, -1, 1, 1,
+ax_anim_terminator
+sRemoraidAnims_5_3:
+ax_anim 1, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 4, 0, 4, 0,
+ax_anim 3, 0, 125, 4, -1, 4, 0,
+ax_anim 3, 2, 124, 4, -2, 4, 0,
+ax_anim 3, 0, 126, 4, -3, 4, 0,
+ax_anim 3, 0, 124, 4, -4, 4, 0,
+ax_anim 3, 0, 125, 4, -5, 4, 0,
+ax_anim 3, 0, 124, 4, -5, 4, 0,
+ax_anim 3, 0, 126, 4, -4, 4, 0,
+ax_anim 2, 0, 123, 3, -3, 2, 0,
+ax_anim_terminator
+sRemoraidAnims_5_4:
+ax_anim 1, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 128, 3, -3, 2, -2,
+ax_anim 2, 0, 129, 3, -4, 2, -2,
+ax_anim 3, 0, 130, 3, -4, 2, -2,
+ax_anim 3, 2, 129, 3, -5, 2, -2,
+ax_anim 3, 0, 131, 3, -6, 2, -2,
+ax_anim 3, 0, 129, 3, -7, 2, -2,
+ax_anim 3, 0, 130, 3, -8, 2, -2,
+ax_anim 3, 0, 129, 3, -8, 2, -2,
+ax_anim 3, 0, 131, 3, -7, 2, -2,
+ax_anim 2, 0, 128, 1, -3, 1, -1,
+ax_anim_terminator
+sRemoraidAnims_5_5:
+ax_anim 1, 0, 132, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, -2, 0, -2,
+ax_anim 2, 0, 132, 0, -3, 0, -2,
+ax_anim 2, 0, 134, 0, -2, 0, -2,
+ax_anim 3, 0, 135, 0, -3, 0, -2,
+ax_anim 3, 2, 134, 0, -4, 0, -2,
+ax_anim 3, 0, 136, 0, -5, 0, -2,
+ax_anim 3, 0, 134, 0, -6, 0, -2,
+ax_anim 3, 0, 135, 0, -7, 0, -2,
+ax_anim 3, 0, 134, 0, -7, 0, -2,
+ax_anim 3, 0, 136, 0, -6, 0, -2,
+ax_anim 2, 0, 132, 0, -4, 0, -1,
+ax_anim_terminator
+sRemoraidAnims_5_6:
+ax_anim 1, 0, 137, -1, -1, -1, -1,
+ax_anim 2, 0, 137, -2, -2, -2, -2,
+ax_anim 2, 0, 138, -3, -3, -2, -2,
+ax_anim 2, 0, 139, -3, -4, -2, -2,
+ax_anim 3, 0, 140, -3, -4, -2, -2,
+ax_anim 3, 2, 139, -3, -5, -2, -2,
+ax_anim 3, 0, 141, -3, -6, -2, -2,
+ax_anim 3, 0, 139, -3, -7, -2, -2,
+ax_anim 3, 0, 140, -3, -8, -2, -2,
+ax_anim 3, 0, 139, -3, -8, -2, -2,
+ax_anim 3, 0, 141, -3, -7, -2, -2,
+ax_anim 2, 0, 138, -1, -3, -1, -1,
+ax_anim_terminator
+sRemoraidAnims_5_7:
+ax_anim 1, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 0, 142, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -3, 0, -3, 0,
+ax_anim 2, 0, 144, -4, 0, -4, 0,
+ax_anim 3, 0, 145, -4, -1, -4, 0,
+ax_anim 3, 2, 144, -4, -2, -4, 0,
+ax_anim 3, 0, 146, -4, -3, -4, 0,
+ax_anim 3, 0, 144, -4, -4, -4, 0,
+ax_anim 3, 0, 145, -4, -5, -4, 0,
+ax_anim 3, 0, 144, -4, -5, -4, 0,
+ax_anim 3, 0, 146, -4, -4, -4, 0,
+ax_anim 2, 0, 143, -3, -3, -2, 0,
+ax_anim_terminator
+sRemoraidAnims_5_8:
+ax_anim 1, 0, 147, -1, 1, -1, 1,
+ax_anim 2, 0, 147, -2, 2, -2, 2,
+ax_anim 2, 0, 148, -2, 2, -2, 2,
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 3, 0, 150, -2, 1, -2, 2,
+ax_anim 3, 2, 149, -2, 0, -2, 2,
+ax_anim 3, 0, 151, -2, -1, -2, 2,
+ax_anim 3, 0, 149, -2, -2, -2, 2,
+ax_anim 3, 0, 150, -2, -3, -2, 2,
+ax_anim 3, 0, 149, -2, -3, -2, 2,
+ax_anim 3, 0, 151, -2, -2, -2, 2,
+ax_anim 2, 0, 148, -1, -1, -1, 1,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_6_1:
+ax_anim 8, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 26, 0, 152, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -2, 0, 0,
+ax_anim 8, 0, 153, 0, -1, 0, 0,
+ax_anim 26, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sRemoraidAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sRemoraidAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sRemoraidAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sRemoraidAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sRemoraidAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sRemoraidAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sRemoraidAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_8_1:
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, -1, 0, 0,
+ax_anim 10, 0, 163, 0, -2, 0, 0,
+ax_anim 10, 0, 163, 0, -3, 0, 0,
+ax_anim 8, 0, 162, 0, -3, 0, 0,
+ax_anim 8, 0, 162, 0, -2, 0, 0,
+ax_anim 10, 0, 164, 0, -1, 0, 0,
+ax_anim 10, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_8_2:
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, -1, 0, 0,
+ax_anim 10, 0, 166, 0, -2, 0, 0,
+ax_anim 10, 0, 166, 0, -3, 0, 0,
+ax_anim 8, 0, 165, 0, -3, 0, 0,
+ax_anim 8, 0, 165, 0, -2, 0, 0,
+ax_anim 10, 0, 167, 0, -1, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_8_3:
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, -1, 0, 0,
+ax_anim 10, 0, 169, 0, -2, 0, 0,
+ax_anim 10, 0, 169, 0, -3, 0, 0,
+ax_anim 8, 0, 168, 0, -3, 0, 0,
+ax_anim 8, 0, 168, 0, -2, 0, 0,
+ax_anim 10, 0, 170, 0, -1, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_8_4:
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, -1, 0, 0,
+ax_anim 10, 0, 172, 0, -2, 0, 0,
+ax_anim 10, 0, 172, 0, -3, 0, 0,
+ax_anim 8, 0, 171, 0, -3, 0, 0,
+ax_anim 8, 0, 171, 0, -2, 0, 0,
+ax_anim 10, 0, 173, 0, -1, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_8_5:
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, -1, 0, 0,
+ax_anim 10, 0, 175, 0, -2, 0, 0,
+ax_anim 10, 0, 175, 0, -3, 0, 0,
+ax_anim 8, 0, 174, 0, -3, 0, 0,
+ax_anim 8, 0, 174, 0, -2, 0, 0,
+ax_anim 10, 0, 176, 0, -1, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_8_6:
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, -1, 0, 0,
+ax_anim 10, 0, 178, 0, -2, 0, 0,
+ax_anim 10, 0, 178, 0, -3, 0, 0,
+ax_anim 8, 0, 177, 0, -3, 0, 0,
+ax_anim 8, 0, 177, 0, -2, 0, 0,
+ax_anim 10, 0, 179, 0, -1, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_8_7:
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim 8, 0, 180, 0, -1, 0, 0,
+ax_anim 10, 0, 181, 0, -2, 0, 0,
+ax_anim 10, 0, 181, 0, -3, 0, 0,
+ax_anim 8, 0, 180, 0, -3, 0, 0,
+ax_anim 8, 0, 180, 0, -2, 0, 0,
+ax_anim 10, 0, 182, 0, -1, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_8_8:
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, -1, 0, 0,
+ax_anim 10, 0, 184, 0, -2, 0, 0,
+ax_anim 10, 0, 184, 0, -3, 0, 0,
+ax_anim 8, 0, 183, 0, -3, 0, 0,
+ax_anim 8, 0, 183, 0, -2, 0, 0,
+ax_anim 10, 0, 185, 0, -1, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 4, 3, 4, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 5, 18, 5, 18,
+ax_anim 3, 0, 190, 0, 21, 0, 21,
+ax_anim 2, 3, 191, -5, 18, -5, 18,
+ax_anim 2, 0, 192, -8, 7, -8, 7,
+ax_anim 1, 0, 193, -4, 3, -4, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 11, 1, 11, 1,
+ax_anim 2, 0, 187, 19, 5, 19, 5,
+ax_anim 2, 0, 188, 22, 15, 22, 14,
+ax_anim 3, 0, 189, 20, 21, 20, 17,
+ax_anim 2, 3, 190, 11, 21, 11, 19,
+ax_anim 2, 0, 191, 6, 18, 6, 18,
+ax_anim 1, 0, 192, 1, 8, 1, 8,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 5, -5, 5, -5,
+ax_anim 2, 0, 186, 11, -7, 11, -7,
+ax_anim 2, 0, 187, 17, -4, 17, -4,
+ax_anim 3, 0, 188, 20, 2, 20, -1,
+ax_anim 2, 3, 189, 16, 6, 16, 6,
+ax_anim 2, 0, 190, 11, 7, 11, 7,
+ax_anim 1, 0, 191, 6, 6, 6, 6,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -7, 0, -7,
+ax_anim 2, 0, 193, 3, -16, 3, -16,
+ax_anim 2, 0, 186, 9, -20, 9, -20,
+ax_anim 3, 0, 187, 20, -19, 20, -23,
+ax_anim 2, 3, 188, 20, -12, 20, -12,
+ax_anim 2, 0, 189, 16, -3, 16, -3,
+ax_anim 1, 0, 190, 9, 0, 9, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -5, -4, -5, -4,
+ax_anim 2, 0, 192, -7, -10, -7, -10,
+ax_anim 2, 0, 193, -6, -16, -6, -19,
+ax_anim 3, 0, 186, 0, -19, 0, -21,
+ax_anim 2, 3, 187, 6, -16, 6, -19,
+ax_anim 2, 0, 188, 7, -10, 7, -10,
+ax_anim 1, 0, 189, 5, -4, 5, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -7, 0, -7,
+ax_anim 2, 0, 187, -3, -16, -3, -16,
+ax_anim 2, 0, 186, -9, -20, -9, -20,
+ax_anim 3, 0, 193, -20, -19, -21, -23,
+ax_anim 2, 3, 192, -20, -12, -20, -12,
+ax_anim 2, 0, 191, -16, -3, -16, -3,
+ax_anim 1, 0, 190, -9, 0, -9, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -5, -5, -5, -5,
+ax_anim 2, 0, 186, -11, -7, -11, -7,
+ax_anim 2, 0, 193, -17, -4, -17, -4,
+ax_anim 3, 0, 192, -20, 2, -20, 0,
+ax_anim 2, 3, 191, -16, 6, -16, 6,
+ax_anim 2, 0, 190, -11, 7, -11, 7,
+ax_anim 1, 0, 189, -6, 6, -6, 6,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -11, 1, -8, 0,
+ax_anim 2, 0, 193, -19, 5, -19, 3,
+ax_anim 2, 0, 192, -22, 15, -19, 10,
+ax_anim 3, 0, 191, -20, 21, -19, 16,
+ax_anim 2, 3, 190, -11, 21, -11, 19,
+ax_anim 2, 0, 189, -6, 18, -3, 15,
+ax_anim 1, 0, 188, -1, 8, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -19, 0, 0,
+ax_anim 4, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 3, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -17, 0, 0,
+ax_anim 4, 0, 206, 0, -18, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 3, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -18, 0, 0,
+ax_anim 4, 0, 209, 0, -19, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 4, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 4, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 4, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 4, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -18, 0, 0,
+ax_anim 4, 0, 221, 0, -19, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 4, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -17, 0, 0,
+ax_anim 4, 0, 224, 0, -18, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRemoraidAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sRemoraidGfx1:
+.incbin "baserom.gba", 0xF08C88, 0x100
+sRemoraidSprites1:
+ax_sprite sRemoraidGfx1, 0x100
+ax_sprite_terminator
+sRemoraidGfx2:
+.incbin "baserom.gba", 0xF08D98, 0x100
+sRemoraidSprites2:
+ax_sprite sRemoraidGfx2, 0x100
+ax_sprite_terminator
+sRemoraidGfx3:
+.incbin "baserom.gba", 0xF08EA8, 0x100
+sRemoraidSprites3:
+ax_sprite sRemoraidGfx3, 0x100
+ax_sprite_terminator
+sRemoraidGfx4:
+.incbin "baserom.gba", 0xF08FB8, 0x200
+sRemoraidSprites4:
+ax_sprite sRemoraidGfx4, 0x200
+ax_sprite_terminator
+sRemoraidGfx5:
+.incbin "baserom.gba", 0xF091C8, 0x100
+sRemoraidSprites5:
+ax_sprite sRemoraidGfx5, 0x100
+ax_sprite_terminator
+sRemoraidGfx6:
+.incbin "baserom.gba", 0xF092D8, 0x200
+sRemoraidSprites6:
+ax_sprite sRemoraidGfx6, 0x200
+ax_sprite_terminator
+sRemoraidGfx7:
+.incbin "baserom.gba", 0xF094E8, 0x200
+sRemoraidSprites7:
+ax_sprite sRemoraidGfx7, 0x200
+ax_sprite_terminator
+sRemoraidGfx8:
+.incbin "baserom.gba", 0xF096F8, 0x200
+sRemoraidSprites8:
+ax_sprite sRemoraidGfx8, 0x200
+ax_sprite_terminator
+sRemoraidGfx9:
+.incbin "baserom.gba", 0xF09908, 0x200
+sRemoraidSprites9:
+ax_sprite sRemoraidGfx9, 0x200
+ax_sprite_terminator
+sRemoraidGfx10:
+.incbin "baserom.gba", 0xF09B18, 0x200
+sRemoraidSprites10:
+ax_sprite sRemoraidGfx10, 0x200
+ax_sprite_terminator
+sRemoraidGfx11:
+.incbin "baserom.gba", 0xF09D28, 0x200
+sRemoraidSprites11:
+ax_sprite sRemoraidGfx11, 0x200
+ax_sprite_terminator
+sRemoraidGfx12:
+.incbin "baserom.gba", 0xF09F38, 0x100
+sRemoraidSprites12:
+ax_sprite sRemoraidGfx12, 0x100
+ax_sprite_terminator
+sRemoraidGfx13:
+.incbin "baserom.gba", 0xF0A048, 0x100
+sRemoraidSprites13:
+ax_sprite sRemoraidGfx13, 0x100
+ax_sprite_terminator
+sRemoraidGfx14:
+.incbin "baserom.gba", 0xF0A158, 0x100
+sRemoraidSprites14:
+ax_sprite sRemoraidGfx14, 0x100
+ax_sprite_terminator
+sRemoraidGfx15:
+.incbin "baserom.gba", 0xF0A268, 0x100
+sRemoraidSprites15:
+ax_sprite sRemoraidGfx15, 0x100
+ax_sprite_terminator
+sRemoraidGfx16:
+.incbin "baserom.gba", 0xF0A378, 0x100
+sRemoraidSprites16:
+ax_sprite sRemoraidGfx16, 0x100
+ax_sprite_terminator
+sRemoraidGfx17:
+.incbin "baserom.gba", 0xF0A488, 0x20
+sRemoraidGfx17_1:
+.incbin "baserom.gba", 0xF0A4A8, 0xC0
+sRemoraidSprites17:
+ax_sprite sRemoraidGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx17_1, 0xc0
+ax_sprite_terminator
+sRemoraidGfx18:
+.incbin "baserom.gba", 0xF0A588, 0x40
+sRemoraidGfx18_1:
+.incbin "baserom.gba", 0xF0A5C8, 0xE0
+sRemoraidGfx18_2:
+.incbin "baserom.gba", 0xF0A6A8, 0x40
+sRemoraidSprites18:
+ax_sprite sRemoraidGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRemoraidGfx18_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sRemoraidGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRemoraidGfx19:
+.incbin "baserom.gba", 0xF0A720, 0xE0
+sRemoraidSprites19:
+ax_sprite sRemoraidGfx19, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRemoraidGfx20:
+.incbin "baserom.gba", 0xF0A818, 0x100
+sRemoraidSprites20:
+ax_sprite sRemoraidGfx20, 0x100
+ax_sprite_terminator
+sRemoraidGfx21:
+.incbin "baserom.gba", 0xF0A928, 0xC0
+sRemoraidSprites21:
+ax_sprite sRemoraidGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx22:
+.incbin "baserom.gba", 0xF0AA00, 0x40
+sRemoraidGfx22_1:
+.incbin "baserom.gba", 0xF0AA40, 0x60
+sRemoraidGfx22_2:
+.incbin "baserom.gba", 0xF0AAA0, 0x60
+sRemoraidSprites22:
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRemoraidGfx23:
+.incbin "baserom.gba", 0xF0AB40, 0x20
+sRemoraidGfx23_1:
+.incbin "baserom.gba", 0xF0AB60, 0x20
+sRemoraidGfx23_2:
+.incbin "baserom.gba", 0xF0AB80, 0x60
+sRemoraidGfx23_3:
+.incbin "baserom.gba", 0xF0ABE0, 0x60
+sRemoraidSprites23:
+ax_sprite sRemoraidGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx23_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx23_3, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRemoraidGfx24:
+.incbin "baserom.gba", 0xF0AC88, 0x60
+sRemoraidGfx24_1:
+.incbin "baserom.gba", 0xF0ACE8, 0x40
+sRemoraidGfx24_2:
+.incbin "baserom.gba", 0xF0AD28, 0x40
+sRemoraidSprites24:
+ax_sprite sRemoraidGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRemoraidGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRemoraidGfx24_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sRemoraidGfx25:
+.incbin "baserom.gba", 0xF0ADA0, 0xC0
+sRemoraidSprites25:
+ax_sprite sRemoraidGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx26:
+.incbin "baserom.gba", 0xF0AE78, 0xE0
+sRemoraidSprites26:
+ax_sprite sRemoraidGfx26, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRemoraidGfx27:
+.incbin "baserom.gba", 0xF0AF70, 0xC0
+sRemoraidSprites27:
+ax_sprite sRemoraidGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx28:
+.incbin "baserom.gba", 0xF0B048, 0xC0
+sRemoraidSprites28:
+ax_sprite sRemoraidGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx29:
+.incbin "baserom.gba", 0xF0B120, 0xC0
+sRemoraidSprites29:
+ax_sprite sRemoraidGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx30:
+.incbin "baserom.gba", 0xF0B1F8, 0xC0
+sRemoraidSprites30:
+ax_sprite sRemoraidGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx31:
+.incbin "baserom.gba", 0xF0B2D0, 0xC0
+sRemoraidSprites31:
+ax_sprite sRemoraidGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx32:
+.incbin "baserom.gba", 0xF0B3A8, 0x40
+sRemoraidGfx32_1:
+.incbin "baserom.gba", 0xF0B3E8, 0x40
+sRemoraidGfx32_2:
+.incbin "baserom.gba", 0xF0B428, 0x60
+sRemoraidSprites32:
+ax_sprite sRemoraidGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRemoraidGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRemoraidGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRemoraidGfx33:
+.incbin "baserom.gba", 0xF0B4C0, 0xC0
+sRemoraidSprites33:
+ax_sprite sRemoraidGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx34:
+.incbin "baserom.gba", 0xF0B598, 0xC0
+sRemoraidSprites34:
+ax_sprite sRemoraidGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx35:
+.incbin "baserom.gba", 0xF0B670, 0xC0
+sRemoraidSprites35:
+ax_sprite sRemoraidGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx36:
+.incbin "baserom.gba", 0xF0B748, 0xC0
+sRemoraidSprites36:
+ax_sprite sRemoraidGfx36, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx37:
+.incbin "baserom.gba", 0xF0B820, 0xC0
+sRemoraidSprites37:
+ax_sprite sRemoraidGfx37, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx38:
+.incbin "baserom.gba", 0xF0B8F8, 0x100
+sRemoraidSprites38:
+ax_sprite sRemoraidGfx38, 0x100
+ax_sprite_terminator
+sRemoraidGfx39:
+.incbin "baserom.gba", 0xF0BA08, 0xC0
+sRemoraidSprites39:
+ax_sprite sRemoraidGfx39, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx40:
+.incbin "baserom.gba", 0xF0BAE0, 0xC0
+sRemoraidSprites40:
+ax_sprite sRemoraidGfx40, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sRemoraidGfx41:
+.incbin "baserom.gba", 0xF0BBB8, 0x100
+sRemoraidSprites41:
+ax_sprite sRemoraidGfx41, 0x100
+ax_sprite_terminator
+sRemoraidGfx42:
+.incbin "baserom.gba", 0xF0BCC8, 0x100
+sRemoraidSprites42:
+ax_sprite sRemoraidGfx42, 0x100
+ax_sprite_terminator
+sRemoraidGfx43:
+.incbin "baserom.gba", 0xF0BDD8, 0x200
+sRemoraidSprites43:
+ax_sprite sRemoraidGfx43, 0x200
+ax_sprite_terminator
+sRemoraidGfx44:
+.incbin "baserom.gba", 0xF0BFE8, 0x200
+sRemoraidSprites44:
+ax_sprite sRemoraidGfx44, 0x200
+ax_sprite_terminator
+sRemoraidGfx45:
+.incbin "baserom.gba", 0xF0C1F8, 0x200
+sRemoraidSprites45:
+ax_sprite sRemoraidGfx45, 0x200
+ax_sprite_terminator
+sRemoraidGfx46:
+.incbin "baserom.gba", 0xF0C408, 0x200
+sRemoraidSprites46:
+ax_sprite sRemoraidGfx46, 0x200
+ax_sprite_terminator
+sRemoraidGfx47:
+.incbin "baserom.gba", 0xF0C618, 0x200
+sRemoraidSprites47:
+ax_sprite sRemoraidGfx47, 0x200
+ax_sprite_terminator
+sAxPosesRemoraid:
+.4byte sRemoraidPose1
+.4byte sRemoraidPose2
+.4byte sRemoraidPose3
+.4byte sRemoraidPose4
+.4byte sRemoraidPose5
+.4byte sRemoraidPose6
+.4byte sRemoraidPose7
+.4byte sRemoraidPose8
+.4byte sRemoraidPose9
+.4byte sRemoraidPose10
+.4byte sRemoraidPose11
+.4byte sRemoraidPose12
+.4byte sRemoraidPose13
+.4byte sRemoraidPose14
+.4byte sRemoraidPose15
+.4byte sRemoraidPose16
+.4byte sRemoraidPose17
+.4byte sRemoraidPose18
+.4byte sRemoraidPose19
+.4byte sRemoraidPose20
+.4byte sRemoraidPose21
+.4byte sRemoraidPose22
+.4byte sRemoraidPose23
+.4byte sRemoraidPose24
+.4byte sRemoraidPose25
+.4byte sRemoraidPose26
+.4byte sRemoraidPose27
+.4byte sRemoraidPose28
+.4byte sRemoraidPose29
+.4byte sRemoraidPose30
+.4byte sRemoraidPose31
+.4byte sRemoraidPose32
+.4byte sRemoraidPose33
+.4byte sRemoraidPose34
+.4byte sRemoraidPose35
+.4byte sRemoraidPose36
+.4byte sRemoraidPose37
+.4byte sRemoraidPose38
+.4byte sRemoraidPose39
+.4byte sRemoraidPose40
+.4byte sRemoraidPose41
+.4byte sRemoraidPose42
+.4byte sRemoraidPose43
+.4byte sRemoraidPose44
+.4byte sRemoraidPose45
+.4byte sRemoraidPose46
+.4byte sRemoraidPose47
+.4byte sRemoraidPose48
+.4byte sRemoraidPose49
+.4byte sRemoraidPose50
+.4byte sRemoraidPose51
+.4byte sRemoraidPose52
+.4byte sRemoraidPose53
+.4byte sRemoraidPose54
+.4byte sRemoraidPose55
+.4byte sRemoraidPose56
+.4byte sRemoraidPose57
+.4byte sRemoraidPose58
+.4byte sRemoraidPose59
+.4byte sRemoraidPose60
+.4byte sRemoraidPose61
+.4byte sRemoraidPose62
+.4byte sRemoraidPose63
+.4byte sRemoraidPose64
+.4byte sRemoraidPose65
+.4byte sRemoraidPose66
+.4byte sRemoraidPose67
+.4byte sRemoraidPose68
+.4byte sRemoraidPose69
+.4byte sRemoraidPose70
+.4byte sRemoraidPose71
+.4byte sRemoraidPose72
+.4byte sRemoraidPose73
+.4byte sRemoraidPose74
+.4byte sRemoraidPose75
+.4byte sRemoraidPose76
+.4byte sRemoraidPose77
+.4byte sRemoraidPose78
+.4byte sRemoraidPose79
+.4byte sRemoraidPose80
+.4byte sRemoraidPose81
+.4byte sRemoraidPose82
+.4byte sRemoraidPose83
+.4byte sRemoraidPose84
+.4byte sRemoraidPose85
+.4byte sRemoraidPose86
+.4byte sRemoraidPose87
+.4byte sRemoraidPose88
+.4byte sRemoraidPose89
+.4byte sRemoraidPose90
+.4byte sRemoraidPose91
+.4byte sRemoraidPose92
+.4byte sRemoraidPose93
+.4byte sRemoraidPose94
+.4byte sRemoraidPose95
+.4byte sRemoraidPose96
+.4byte sRemoraidPose97
+.4byte sRemoraidPose98
+.4byte sRemoraidPose99
+.4byte sRemoraidPose100
+.4byte sRemoraidPose101
+.4byte sRemoraidPose102
+.4byte sRemoraidPose103
+.4byte sRemoraidPose104
+.4byte sRemoraidPose105
+.4byte sRemoraidPose106
+.4byte sRemoraidPose107
+.4byte sRemoraidPose108
+.4byte sRemoraidPose109
+.4byte sRemoraidPose110
+.4byte sRemoraidPose111
+.4byte sRemoraidPose112
+.4byte sRemoraidPose113
+.4byte sRemoraidPose114
+.4byte sRemoraidPose115
+.4byte sRemoraidPose116
+.4byte sRemoraidPose117
+.4byte sRemoraidPose118
+.4byte sRemoraidPose119
+.4byte sRemoraidPose120
+.4byte sRemoraidPose121
+.4byte sRemoraidPose122
+.4byte sRemoraidPose123
+.4byte sRemoraidPose124
+.4byte sRemoraidPose125
+.4byte sRemoraidPose126
+.4byte sRemoraidPose127
+.4byte sRemoraidPose128
+.4byte sRemoraidPose129
+.4byte sRemoraidPose130
+.4byte sRemoraidPose131
+.4byte sRemoraidPose132
+.4byte sRemoraidPose133
+.4byte sRemoraidPose134
+.4byte sRemoraidPose135
+.4byte sRemoraidPose136
+.4byte sRemoraidPose137
+.4byte sRemoraidPose138
+.4byte sRemoraidPose139
+.4byte sRemoraidPose140
+.4byte sRemoraidPose141
+.4byte sRemoraidPose142
+.4byte sRemoraidPose143
+.4byte sRemoraidPose144
+.4byte sRemoraidPose145
+.4byte sRemoraidPose146
+.4byte sRemoraidPose147
+.4byte sRemoraidPose148
+.4byte sRemoraidPose149
+.4byte sRemoraidPose150
+.4byte sRemoraidPose151
+.4byte sRemoraidPose152
+.4byte sRemoraidPose153
+.4byte sRemoraidPose154
+.4byte sRemoraidPose155
+.4byte sRemoraidPose156
+.4byte sRemoraidPose157
+.4byte sRemoraidPose158
+.4byte sRemoraidPose159
+.4byte sRemoraidPose160
+.4byte sRemoraidPose161
+.4byte sRemoraidPose162
+.4byte sRemoraidPose163
+.4byte sRemoraidPose164
+.4byte sRemoraidPose165
+.4byte sRemoraidPose166
+.4byte sRemoraidPose167
+.4byte sRemoraidPose168
+.4byte sRemoraidPose169
+.4byte sRemoraidPose170
+.4byte sRemoraidPose171
+.4byte sRemoraidPose172
+.4byte sRemoraidPose173
+.4byte sRemoraidPose174
+.4byte sRemoraidPose175
+.4byte sRemoraidPose176
+.4byte sRemoraidPose177
+.4byte sRemoraidPose178
+.4byte sRemoraidPose179
+.4byte sRemoraidPose180
+.4byte sRemoraidPose181
+.4byte sRemoraidPose182
+.4byte sRemoraidPose183
+.4byte sRemoraidPose184
+.4byte sRemoraidPose185
+.4byte sRemoraidPose186
+.4byte sRemoraidPose187
+.4byte sRemoraidPose188
+.4byte sRemoraidPose189
+.4byte sRemoraidPose190
+.4byte sRemoraidPose191
+.4byte sRemoraidPose192
+.4byte sRemoraidPose193
+.4byte sRemoraidPose194
+.4byte sRemoraidPose195
+.4byte sRemoraidPose196
+.4byte sRemoraidPose197
+.4byte sRemoraidPose198
+.4byte sRemoraidPose199
+.4byte sRemoraidPose200
+.4byte sRemoraidPose201
+.4byte sRemoraidPose202
+.4byte sRemoraidPose203
+.4byte sRemoraidPose204
+.4byte sRemoraidPose205
+.4byte sRemoraidPose206
+.4byte sRemoraidPose207
+.4byte sRemoraidPose208
+.4byte sRemoraidPose209
+.4byte sRemoraidPose210
+.4byte sRemoraidPose211
+.4byte sRemoraidPose212
+.4byte sRemoraidPose213
+.4byte sRemoraidPose214
+.4byte sRemoraidPose215
+.4byte sRemoraidPose216
+.4byte sRemoraidPose217
+.4byte sRemoraidPose218
+.4byte sRemoraidPose219
+.4byte sRemoraidPose220
+.4byte sRemoraidPose221
+.4byte sRemoraidPose222
+.4byte sRemoraidPose223
+.4byte sRemoraidPose224
+.4byte sRemoraidPose225
+.4byte sRemoraidPose226
+.4byte sRemoraidPose227
+.4byte sRemoraidPose228
+.4byte sRemoraidPose229
+.4byte sRemoraidPose230
+.4byte sRemoraidPose231
+.4byte sRemoraidPose232
+.4byte sRemoraidPose233
+.4byte sRemoraidPose234
+.4byte sRemoraidPose235
+.4byte sRemoraidPose236
+.4byte sRemoraidPose237
+.4byte sRemoraidPose238
+.4byte sRemoraidPose239
+.4byte sRemoraidPose240
+.4byte sRemoraidPose241
+.4byte sRemoraidPose242
+.4byte sRemoraidPose243
+.4byte sRemoraidPose244
+.4byte sRemoraidPose245
+.4byte sRemoraidPose246
+.4byte sRemoraidPose247
+.4byte sRemoraidPose248
+.4byte sRemoraidPose249
+.4byte sRemoraidPose250
+.4byte sRemoraidPose251
+.4byte sRemoraidPose252
+.4byte sRemoraidPose253
+.4byte sRemoraidPose254
+.4byte sRemoraidPose255
+.4byte sRemoraidPose256
+.4byte sRemoraidPose257
+.4byte sRemoraidPose258
+sAxPositionsRemoraid:
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -2,   -4, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte    0,   -4, 	  -6,   -8, 	   4,  -10, 	   0,   -9
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    5,   -6, 	   3,   -9, 	   0,   -6, 	   0,   -8
+.2byte    3,   -6, 	   1,   -9, 	  -3,   -5, 	  -1,   -8
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    6,   -9, 	   1,  -11, 	   0,   -7, 	  -1,  -10
+.2byte    5,   -6, 	  -1,  -10, 	  -2,   -5, 	  -2,   -9
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    5,  -11, 	  -1,  -12, 	   4,   -8, 	  -2,  -10
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -6, 	  -1,  -10
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte    1,  -14, 	   4,   -8, 	  -6,  -10, 	  -1,  -10
+.2byte   -3,  -14, 	   4,  -10, 	  -6,   -8, 	  -1,  -10
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -7,  -11, 	  -1,  -12, 	  -6,   -8, 	   0,  -10
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -6, 	  -1,  -10
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -8,   -9, 	  -3,  -11, 	  -2,   -7, 	  -1,  -10
+.2byte   -7,   -6, 	  -1,  -10, 	   0,   -5, 	   0,   -9
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	  -5,   -9, 	  -2,   -6, 	  -2,   -8
+.2byte   -5,   -6, 	  -3,   -9, 	   1,   -5, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -2,   -4, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte    0,   -4, 	  -6,   -8, 	   4,  -10, 	   0,   -9
+.2byte   -1,  -10, 	  -6,  -11, 	   4,  -11, 	  -1,   -9
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    5,   -6, 	   3,   -9, 	   0,   -6, 	   0,   -8
+.2byte    3,   -6, 	   1,   -9, 	  -3,   -5, 	  -1,   -8
+.2byte    2,  -11, 	  -2,  -11, 	  -2,   -8, 	  -3,  -10
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    6,   -9, 	   1,  -11, 	   0,   -7, 	  -1,  -10
+.2byte    5,   -6, 	  -1,  -10, 	  -2,   -5, 	  -2,   -9
+.2byte    5,  -12, 	   0,  -11, 	   1,   -8, 	  -1,  -10
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    5,  -11, 	  -1,  -12, 	   4,   -8, 	  -2,  -10
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -6, 	  -1,  -10
+.2byte    1,  -10, 	  -3,  -10, 	  -2,   -6, 	  -4,   -9
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte    1,  -14, 	   4,   -8, 	  -6,  -10, 	  -1,  -10
+.2byte   -3,  -14, 	   4,  -10, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -7,  -11, 	  -1,  -12, 	  -6,   -8, 	   0,  -10
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -6, 	  -1,  -10
+.2byte   -4,  -10, 	   0,  -10, 	  -1,   -6, 	   1,   -9
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -8,   -9, 	  -3,  -11, 	  -2,   -7, 	  -1,  -10
+.2byte   -7,   -6, 	  -1,  -10, 	   0,   -5, 	   0,   -9
+.2byte   -7,  -10, 	  -2,   -9, 	  -3,   -6, 	  -1,   -8
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	  -5,   -9, 	  -2,   -6, 	  -2,   -8
+.2byte   -5,   -6, 	  -3,   -9, 	   1,   -5, 	  -1,   -8
+.2byte   -3,  -11, 	   1,  -11, 	   1,   -8, 	   2,  -10
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -2,   -4, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte    0,   -4, 	  -6,   -8, 	   4,  -10, 	   0,   -9
+.2byte   -1,  -10, 	  -6,  -11, 	   4,  -11, 	  -1,   -9
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    5,   -6, 	   3,   -9, 	   0,   -6, 	   0,   -8
+.2byte    3,   -6, 	   1,   -9, 	  -3,   -5, 	  -1,   -8
+.2byte    2,  -11, 	  -2,  -11, 	  -2,   -8, 	  -3,  -10
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    6,   -9, 	   1,  -11, 	   0,   -7, 	  -1,  -10
+.2byte    5,   -6, 	  -1,  -10, 	  -2,   -5, 	  -2,   -9
+.2byte    5,  -12, 	   0,  -11, 	   1,   -8, 	  -1,  -10
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    5,  -11, 	  -1,  -12, 	   4,   -8, 	  -2,  -10
+.2byte    5,   -9, 	  -3,  -10, 	   1,   -6, 	  -1,  -10
+.2byte    1,  -10, 	  -3,  -10, 	  -2,   -6, 	  -4,   -9
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte    1,  -14, 	   4,   -8, 	  -6,  -10, 	  -1,  -10
+.2byte   -3,  -14, 	   4,  -10, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -7,  -11, 	  -1,  -12, 	  -6,   -8, 	   0,  -10
+.2byte   -7,   -9, 	   1,  -10, 	  -3,   -6, 	  -1,  -10
+.2byte   -4,  -10, 	   0,  -10, 	  -1,   -6, 	   1,   -9
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -8,   -9, 	  -3,  -11, 	  -2,   -7, 	  -1,  -10
+.2byte   -7,   -6, 	  -1,  -10, 	   0,   -5, 	   0,   -9
+.2byte   -7,  -10, 	  -2,   -9, 	  -3,   -6, 	  -1,   -8
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	  -5,   -9, 	  -2,   -6, 	  -2,   -8
+.2byte   -5,   -6, 	  -3,   -9, 	   1,   -5, 	  -1,   -8
+.2byte   -3,  -11, 	   1,  -11, 	   1,   -8, 	   2,  -10
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -11, 	   4,  -11, 	  -1,   -9
+.2byte   -1,   -4, 	  -6,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    2,  -11, 	  -2,  -11, 	  -2,   -8, 	  -3,  -10
+.2byte    4,   -6, 	   2,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    5,  -12, 	   0,  -11, 	   1,   -8, 	  -1,  -10
+.2byte    6,   -9, 	   0,  -10, 	   0,   -6, 	  -1,   -9
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    1,  -10, 	  -3,  -10, 	  -2,   -6, 	  -4,   -9
+.2byte    5,  -11, 	  -1,  -10, 	   3,   -8, 	  -2,  -10
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -4,  -10, 	   0,  -10, 	  -1,   -6, 	   1,   -9
+.2byte   -7,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -7,  -10, 	  -2,   -9, 	  -3,   -6, 	  -1,   -8
+.2byte   -8,   -9, 	  -2,  -10, 	  -2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -3,  -11, 	   1,  -11, 	   1,   -8, 	   2,  -10
+.2byte   -6,   -6, 	  -4,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -11, 	   4,  -11, 	  -1,   -9
+.2byte   -1,  -18, 	  -6,  -10, 	   4,  -10, 	  -1,  -12
+.2byte    3,  -16, 	  -6,  -11, 	   6,   -9, 	   0,  -11
+.2byte   -1,  -15, 	  -5,   -9, 	   7,  -11, 	   1,  -11
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    3,  -11, 	  -1,  -11, 	  -1,   -8, 	  -2,  -10
+.2byte   -1,  -18, 	   5,  -13, 	  -6,  -11, 	  -1,  -12
+.2byte   -4,  -18, 	   3,  -13, 	  -7,  -11, 	  -2,  -12
+.2byte    0,  -18, 	   5,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    5,  -12, 	   0,  -11, 	   1,   -8, 	  -1,  -10
+.2byte    1,  -18, 	   2,  -13, 	   3,  -11, 	  -1,  -12
+.2byte    1,  -17, 	  -1,  -12, 	   2,  -10, 	  -2,  -12
+.2byte   -1,  -18, 	  -1,  -12, 	   1,  -11, 	  -2,  -12
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    4,  -10, 	   0,  -10, 	   1,   -6, 	  -1,   -9
+.2byte    0,  -18, 	  -2,  -12, 	   4,  -11, 	  -1,  -12
+.2byte    0,  -17, 	  -3,  -13, 	   2,  -11, 	  -2,  -11
+.2byte    0,  -17, 	  -1,  -12, 	   3,  -11, 	   0,  -12
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -9, 	  -6,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   4,  -11, 	  -6,  -11, 	  -1,  -11
+.2byte   -2,  -15, 	   5,  -12, 	  -6,  -10, 	   0,  -11
+.2byte    1,  -15, 	   5,  -10, 	  -6,  -12, 	   0,  -11
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -6,  -10, 	  -2,  -10, 	  -3,   -6, 	  -1,   -9
+.2byte    0,  -18, 	   2,  -12, 	  -4,  -11, 	   1,  -12
+.2byte    0,  -17, 	   3,  -13, 	  -2,  -11, 	   2,  -11
+.2byte    0,  -17, 	   1,  -12, 	  -3,  -11, 	   0,  -12
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -7,  -10, 	  -2,   -9, 	  -3,   -6, 	  -1,   -8
+.2byte   -3,  -18, 	  -4,  -13, 	  -5,  -11, 	  -1,  -12
+.2byte   -4,  -17, 	  -2,  -12, 	  -5,  -10, 	  -1,  -12
+.2byte   -2,  -18, 	  -2,  -12, 	  -4,  -11, 	  -1,  -12
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -4,  -11, 	   0,  -11, 	   0,   -8, 	   1,  -10
+.2byte   -1,  -18, 	  -7,  -13, 	   4,  -11, 	  -1,  -12
+.2byte    2,  -18, 	  -5,  -13, 	   5,  -11, 	   0,  -12
+.2byte   -2,  -18, 	  -7,  -12, 	   4,  -12, 	  -1,  -12
+.2byte   -9,   -7, 	  -4,   -7, 	  -2,   -6, 	  -2,   -8
+.2byte   -9,   -8, 	  -5,   -6, 	  -2,   -8, 	  -2,   -7
+.2byte    0,  -10, 	  -5,  -15, 	   5,  -15, 	   0,  -14
+.2byte    6,  -14, 	   0,  -14, 	  -1,  -11, 	  -1,  -14
+.2byte    5,  -16, 	   0,  -13, 	   0,  -11, 	  -1,  -13
+.2byte    4,  -15, 	  -3,  -13, 	   2,  -11, 	  -2,  -12
+.2byte    0,  -15, 	   5,  -12, 	  -5,  -12, 	   0,  -12
+.2byte   -5,  -15, 	   2,  -13, 	  -3,  -11, 	   1,  -12
+.2byte   -6,  -16, 	  -1,  -13, 	  -1,  -11, 	   0,  -13
+.2byte   -7,  -14, 	  -1,  -14, 	   0,  -11, 	   0,  -14
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -2,   -4, 	  -6,  -10, 	   4,   -8, 	  -1,   -8
+.2byte    0,   -4, 	  -6,   -8, 	   4,  -10, 	   0,   -9
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    5,   -6, 	   3,   -9, 	   0,   -6, 	   0,   -8
+.2byte    3,   -6, 	   1,   -9, 	  -3,   -5, 	  -1,   -8
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    6,   -8, 	   1,  -10, 	   0,   -6, 	  -1,   -9
+.2byte    5,   -7, 	  -1,  -11, 	  -2,   -6, 	  -2,  -10
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    5,  -10, 	  -1,  -11, 	   4,   -7, 	  -2,   -9
+.2byte    5,  -10, 	  -3,  -11, 	   1,   -7, 	  -1,  -11
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte    1,  -14, 	   4,   -8, 	  -6,  -10, 	  -1,  -10
+.2byte   -3,  -14, 	   4,  -10, 	  -6,   -8, 	  -1,  -10
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -7,  -10, 	  -1,  -11, 	  -6,   -7, 	   0,   -9
+.2byte   -7,  -10, 	   1,  -11, 	  -3,   -7, 	  -1,  -11
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -8,   -8, 	  -3,  -10, 	  -2,   -6, 	  -1,   -9
+.2byte   -7,   -7, 	  -1,  -11, 	   0,   -6, 	   0,  -10
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -7,   -6, 	  -5,   -9, 	  -2,   -6, 	  -2,   -8
+.2byte   -5,   -6, 	  -3,   -9, 	   1,   -5, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,   -6, 	   2,   -8, 	  -2,   -6, 	  -1,   -8
+.2byte    6,   -9, 	   0,  -10, 	   0,   -6, 	  -1,   -9
+.2byte    5,  -11, 	  -1,  -10, 	   3,   -8, 	  -2,  -10
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,   -9, 	  -2,  -10, 	  -2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -4,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,  -11, 	   4,  -11, 	  -1,   -9
+.2byte   -1,   -4, 	  -6,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    5,   -6, 	   2,   -8, 	  -1,   -6, 	   0,   -8
+.2byte    3,  -14, 	  -1,  -14, 	  -1,  -11, 	  -2,  -13
+.2byte    5,   -6, 	   3,   -8, 	  -1,   -6, 	   0,   -8
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    5,  -15, 	   0,  -14, 	   1,  -11, 	  -1,  -13
+.2byte    6,   -9, 	   0,  -10, 	   0,   -6, 	  -1,   -9
+.2byte    6,  -10, 	  -2,  -11, 	   3,   -8, 	  -1,  -10
+.2byte    4,  -11, 	   0,  -11, 	   1,   -7, 	  -1,  -10
+.2byte    6,  -11, 	   0,  -10, 	   4,   -8, 	  -1,  -10
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -1,  -12, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -5,  -11, 	  -1,  -11, 	  -2,   -7, 	   0,  -10
+.2byte   -7,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -6,  -15, 	  -1,  -14, 	  -2,  -11, 	   0,  -13
+.2byte   -8,   -9, 	  -2,  -10, 	  -2,   -6, 	  -1,   -9
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -4,  -14, 	   0,  -14, 	   0,  -11, 	   1,  -13
+.2byte   -6,   -6, 	  -4,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -1,  -18, 	  -6,  -10, 	   4,  -10, 	  -1,  -12
+.2byte    0,  -18, 	  -6,  -13, 	   5,  -11, 	   0,  -12
+.2byte   -3,  -17, 	  -4,  -12, 	  -5,  -10, 	  -1,  -11
+.2byte   -1,  -18, 	   1,  -12, 	  -5,  -11, 	   0,  -12
+.2byte   -1,  -15, 	   4,  -11, 	  -6,  -11, 	  -1,  -11
+.2byte    0,  -18, 	  -2,  -12, 	   4,  -11, 	  -1,  -12
+.2byte    2,  -17, 	   3,  -12, 	   4,  -10, 	   0,  -11
+.2byte   -1,  -18, 	   5,  -13, 	  -6,  -11, 	  -1,  -12
+.2byte   -2,  -15, 	  -6,   -9, 	   6,  -11, 	   0,  -11
+.2byte   -1,  -17, 	  -6,  -11, 	   5,  -11, 	   0,  -11
+.2byte    0,  -17, 	   0,  -11, 	  -2,  -10, 	   1,  -11
+.2byte   -1,  -18, 	   0,  -13, 	  -4,  -12, 	  -1,  -13
+.2byte    1,  -15, 	   5,  -10, 	  -6,  -12, 	   0,  -11
+.2byte    0,  -18, 	  -1,  -13, 	   3,  -12, 	   0,  -13
+.2byte    0,  -18, 	   0,  -12, 	   2,  -11, 	  -1,  -12
+.2byte    0,  -18, 	   5,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte    3,  -16, 	  -6,  -11, 	   6,   -9, 	   0,  -11
+.2byte    2,  -16, 	  -5,  -11, 	   5,   -9, 	   0,  -10
+.2byte   -3,  -16, 	  -1,  -11, 	  -4,   -9, 	   0,  -11
+.2byte   -2,  -17, 	   1,  -13, 	  -4,  -11, 	   0,  -11
+.2byte   -2,  -15, 	   5,  -12, 	  -6,  -10, 	   0,  -11
+.2byte    1,  -17, 	  -2,  -13, 	   3,  -11, 	  -1,  -11
+.2byte    2,  -16, 	   0,  -11, 	   3,   -9, 	  -1,  -11
+.2byte   -3,  -18, 	   4,  -13, 	  -6,  -11, 	  -1,  -12
+.2byte   -1,   -4, 	  -6,   -9, 	   4,   -9, 	  -1,   -9
+.2byte   -6,   -6, 	  -3,   -8, 	   0,   -6, 	  -1,   -8
+.2byte   -8,   -8, 	  -2,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte   -7,  -10, 	   1,  -11, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -15, 	   4,   -9, 	  -6,   -9, 	  -1,  -10
+.2byte    5,  -10, 	  -3,  -11, 	   2,   -8, 	  -2,  -10
+.2byte    6,   -8, 	   0,  -11, 	  -1,   -6, 	  -1,   -9
+.2byte    4,   -6, 	   1,   -8, 	  -2,   -6, 	  -1,   -8
+sRemoraidAnimTable1:
+.4byte sRemoraidAnims_1_1
+.4byte sRemoraidAnims_1_2
+.4byte sRemoraidAnims_1_3
+.4byte sRemoraidAnims_1_4
+.4byte sRemoraidAnims_1_5
+.4byte sRemoraidAnims_1_6
+.4byte sRemoraidAnims_1_7
+.4byte sRemoraidAnims_1_8
+sRemoraidAnimTable2:
+.4byte sRemoraidAnims_2_1
+.4byte sRemoraidAnims_2_2
+.4byte sRemoraidAnims_2_3
+.4byte sRemoraidAnims_2_4
+.4byte sRemoraidAnims_2_5
+.4byte sRemoraidAnims_2_6
+.4byte sRemoraidAnims_2_7
+.4byte sRemoraidAnims_2_8
+sRemoraidAnimTable3:
+.4byte sRemoraidAnims_3_1
+.4byte sRemoraidAnims_3_2
+.4byte sRemoraidAnims_3_3
+.4byte sRemoraidAnims_3_4
+.4byte sRemoraidAnims_3_5
+.4byte sRemoraidAnims_3_6
+.4byte sRemoraidAnims_3_7
+.4byte sRemoraidAnims_3_8
+sRemoraidAnimTable4:
+.4byte sRemoraidAnims_4_1
+.4byte sRemoraidAnims_4_2
+.4byte sRemoraidAnims_4_3
+.4byte sRemoraidAnims_4_4
+.4byte sRemoraidAnims_4_5
+.4byte sRemoraidAnims_4_6
+.4byte sRemoraidAnims_4_7
+.4byte sRemoraidAnims_4_8
+sRemoraidAnimTable5:
+.4byte sRemoraidAnims_5_1
+.4byte sRemoraidAnims_5_2
+.4byte sRemoraidAnims_5_3
+.4byte sRemoraidAnims_5_4
+.4byte sRemoraidAnims_5_5
+.4byte sRemoraidAnims_5_6
+.4byte sRemoraidAnims_5_7
+.4byte sRemoraidAnims_5_8
+sRemoraidAnimTable6:
+.4byte sRemoraidAnims_6_1
+.4byte sRemoraidAnims_6_1
+.4byte sRemoraidAnims_6_1
+.4byte sRemoraidAnims_6_1
+.4byte sRemoraidAnims_6_1
+.4byte sRemoraidAnims_6_1
+.4byte sRemoraidAnims_6_1
+.4byte sRemoraidAnims_6_1
+sRemoraidAnimTable7:
+.4byte sRemoraidAnims_7_1
+.4byte sRemoraidAnims_7_2
+.4byte sRemoraidAnims_7_3
+.4byte sRemoraidAnims_7_4
+.4byte sRemoraidAnims_7_5
+.4byte sRemoraidAnims_7_6
+.4byte sRemoraidAnims_7_7
+.4byte sRemoraidAnims_7_8
+sRemoraidAnimTable8:
+.4byte sRemoraidAnims_8_1
+.4byte sRemoraidAnims_8_2
+.4byte sRemoraidAnims_8_3
+.4byte sRemoraidAnims_8_4
+.4byte sRemoraidAnims_8_5
+.4byte sRemoraidAnims_8_6
+.4byte sRemoraidAnims_8_7
+.4byte sRemoraidAnims_8_8
+sRemoraidAnimTable9:
+.4byte sRemoraidAnims_9_1
+.4byte sRemoraidAnims_9_2
+.4byte sRemoraidAnims_9_3
+.4byte sRemoraidAnims_9_4
+.4byte sRemoraidAnims_9_5
+.4byte sRemoraidAnims_9_6
+.4byte sRemoraidAnims_9_7
+.4byte sRemoraidAnims_9_8
+sRemoraidAnimTable10:
+.4byte sRemoraidAnims_10_1
+.4byte sRemoraidAnims_10_2
+.4byte sRemoraidAnims_10_3
+.4byte sRemoraidAnims_10_4
+.4byte sRemoraidAnims_10_5
+.4byte sRemoraidAnims_10_6
+.4byte sRemoraidAnims_10_7
+.4byte sRemoraidAnims_10_8
+sRemoraidAnimTable11:
+.4byte sRemoraidAnims_11_1
+.4byte sRemoraidAnims_11_2
+.4byte sRemoraidAnims_11_3
+.4byte sRemoraidAnims_11_4
+.4byte sRemoraidAnims_11_5
+.4byte sRemoraidAnims_11_6
+.4byte sRemoraidAnims_11_7
+.4byte sRemoraidAnims_11_8
+sRemoraidAnimTable12:
+.4byte sRemoraidAnims_12_1
+.4byte sRemoraidAnims_12_2
+.4byte sRemoraidAnims_12_3
+.4byte sRemoraidAnims_12_4
+.4byte sRemoraidAnims_12_5
+.4byte sRemoraidAnims_12_6
+.4byte sRemoraidAnims_12_7
+.4byte sRemoraidAnims_12_8
+sRemoraidAnimTable13:
+.4byte sRemoraidAnims_13_1
+.4byte sRemoraidAnims_13_2
+.4byte sRemoraidAnims_13_3
+.4byte sRemoraidAnims_13_4
+.4byte sRemoraidAnims_13_5
+.4byte sRemoraidAnims_13_6
+.4byte sRemoraidAnims_13_7
+.4byte sRemoraidAnims_13_8
+sAxAnimationsRemoraid:
+.4byte sRemoraidAnimTable1
+.4byte sRemoraidAnimTable2
+.4byte sRemoraidAnimTable3
+.4byte sRemoraidAnimTable4
+.4byte sRemoraidAnimTable5
+.4byte sRemoraidAnimTable6
+.4byte sRemoraidAnimTable7
+.4byte sRemoraidAnimTable8
+.4byte sRemoraidAnimTable9
+.4byte sRemoraidAnimTable10
+.4byte sRemoraidAnimTable11
+.4byte sRemoraidAnimTable12
+.4byte sRemoraidAnimTable13
+sAxSpritesRemoraid:
+.4byte sRemoraidSprites1
+.4byte sRemoraidSprites2
+.4byte sRemoraidSprites3
+.4byte sRemoraidSprites4
+.4byte sRemoraidSprites5
+.4byte sRemoraidSprites6
+.4byte sRemoraidSprites7
+.4byte sRemoraidSprites8
+.4byte sRemoraidSprites9
+.4byte sRemoraidSprites10
+.4byte sRemoraidSprites11
+.4byte sRemoraidSprites12
+.4byte sRemoraidSprites13
+.4byte sRemoraidSprites14
+.4byte sRemoraidSprites15
+.4byte sRemoraidSprites16
+.4byte sRemoraidSprites17
+.4byte sRemoraidSprites18
+.4byte sRemoraidSprites19
+.4byte sRemoraidSprites20
+.4byte sRemoraidSprites21
+.4byte sRemoraidSprites22
+.4byte sRemoraidSprites23
+.4byte sRemoraidSprites24
+.4byte sRemoraidSprites25
+.4byte sRemoraidSprites26
+.4byte sRemoraidSprites27
+.4byte sRemoraidSprites28
+.4byte sRemoraidSprites29
+.4byte sRemoraidSprites30
+.4byte sRemoraidSprites31
+.4byte sRemoraidSprites32
+.4byte sRemoraidSprites33
+.4byte sRemoraidSprites34
+.4byte sRemoraidSprites35
+.4byte sRemoraidSprites36
+.4byte sRemoraidSprites37
+.4byte sRemoraidSprites38
+.4byte sRemoraidSprites39
+.4byte sRemoraidSprites40
+.4byte sRemoraidSprites41
+.4byte sRemoraidSprites42
+.4byte sRemoraidSprites43
+.4byte sRemoraidSprites44
+.4byte sRemoraidSprites45
+.4byte sRemoraidSprites46
+.4byte sRemoraidSprites47
+sAxMainRemoraid:
+ax_main sAxPosesRemoraid, sAxAnimationsRemoraid, 13, sAxSpritesRemoraid, sAxPositionsRemoraid

--- a/data/ax/rhydon.inc
+++ b/data/ax/rhydon.inc
@@ -1,0 +1,2652 @@
+.global gAxRhydon
+gAxRhydon:
+ax_siro sAxMainRhydon
+sRhydonPose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose3:
+ax_pose 2, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose4:
+ax_pose 3, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose5:
+ax_pose 4, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose6:
+ax_pose 5, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose7:
+ax_pose 6, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose8:
+ax_pose 7, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose9:
+ax_pose 8, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose10:
+ax_pose 9, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose11:
+ax_pose 10, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose12:
+ax_pose 11, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose13:
+ax_pose 12, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose14:
+ax_pose 13, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose15:
+ax_pose 14, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose22:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose23:
+ax_pose 4, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose24:
+ax_pose 5, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose25:
+ax_pose 0, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose26:
+ax_pose 1, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose27:
+ax_pose 2, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose28:
+ax_pose 3, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose29:
+ax_pose 4, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose30:
+ax_pose 5, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose31:
+ax_pose 6, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose32:
+ax_pose 7, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose33:
+ax_pose 8, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose34:
+ax_pose 9, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose35:
+ax_pose 10, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose36:
+ax_pose 11, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose37:
+ax_pose 12, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose38:
+ax_pose 13, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose39:
+ax_pose 14, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose40:
+ax_pose 9, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose41:
+ax_pose 10, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose42:
+ax_pose 11, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose43:
+ax_pose 6, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose44:
+ax_pose 7, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose45:
+ax_pose 8, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose46:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose47:
+ax_pose 4, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose48:
+ax_pose 5, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose49:
+ax_pose 0, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose50:
+ax_pose 1, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose51:
+ax_pose 2, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose52:
+ax_pose 15, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose53:
+ax_pose 16, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose54:
+ax_pose 17, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose55:
+ax_pose 3, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose56:
+ax_pose 4, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose57:
+ax_pose 5, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose58:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose59:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose60:
+ax_pose 20, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose61:
+ax_pose 6, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose62:
+ax_pose 7, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose63:
+ax_pose 8, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose64:
+ax_pose 21, 0x81e4, 0x9102, 0x6c00
+ax_pose 22, 0x01ec, 0x50f2, 0x6c08
+ax_pose 23, 0x41fc, 0x10f2, 0x6c0c
+ax_pose 24, 0x01f5, 0x10ea, 0x6c0e
+ax_pose_terminator
+sRhydonPose65:
+ax_pose 25, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sRhydonPose66:
+ax_pose 26, 0x81e4, 0x9101, 0x6c00
+ax_pose 27, 0x01ec, 0x50f1, 0x6c08
+ax_pose 28, 0x41fc, 0x10f1, 0x6c0c
+ax_pose 29, 0x01f5, 0x10e9, 0x6c0e
+ax_pose_terminator
+sRhydonPose67:
+ax_pose 9, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose68:
+ax_pose 10, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose69:
+ax_pose 11, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose70:
+ax_pose 30, 0x01e4, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhydonPose71:
+ax_pose 31, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sRhydonPose72:
+ax_pose 32, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sRhydonPose73:
+ax_pose 12, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose74:
+ax_pose 13, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose75:
+ax_pose 14, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose76:
+ax_pose 33, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose77:
+ax_pose 34, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose78:
+ax_pose 35, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose79:
+ax_pose 9, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose80:
+ax_pose 10, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose81:
+ax_pose 11, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose82:
+ax_pose 30, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhydonPose83:
+ax_pose 31, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sRhydonPose84:
+ax_pose 32, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sRhydonPose85:
+ax_pose 6, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose86:
+ax_pose 7, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose87:
+ax_pose 8, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose88:
+ax_pose 21, 0x81e4, 0x80ee, 0x6c00
+ax_pose 22, 0x01ec, 0x40fe, 0x6c08
+ax_pose 23, 0x41fc, 0x00fe, 0x6c0c
+ax_pose 24, 0x01f5, 0x010e, 0x6c0e
+ax_pose_terminator
+sRhydonPose89:
+ax_pose 25, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sRhydonPose90:
+ax_pose 26, 0x81e4, 0x80ef, 0x6c00
+ax_pose 27, 0x01ec, 0x40ff, 0x6c08
+ax_pose 28, 0x41fc, 0x00ff, 0x6c0c
+ax_pose 29, 0x01f5, 0x010f, 0x6c0e
+ax_pose_terminator
+sRhydonPose91:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose92:
+ax_pose 4, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose93:
+ax_pose 5, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose94:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose95:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose96:
+ax_pose 20, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose97:
+ax_pose 15, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose98:
+ax_pose 16, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose99:
+ax_pose 17, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose100:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose101:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose102:
+ax_pose 20, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose103:
+ax_pose 21, 0x81e4, 0x9102, 0x6c00
+ax_pose 22, 0x01ec, 0x50f2, 0x6c08
+ax_pose 23, 0x41fc, 0x10f2, 0x6c0c
+ax_pose 24, 0x01f5, 0x10ea, 0x6c0e
+ax_pose_terminator
+sRhydonPose104:
+ax_pose 25, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sRhydonPose105:
+ax_pose 26, 0x81e4, 0x9101, 0x6c00
+ax_pose 27, 0x01ec, 0x50f1, 0x6c08
+ax_pose 28, 0x41fc, 0x10f1, 0x6c0c
+ax_pose 29, 0x01f5, 0x10e9, 0x6c0e
+ax_pose_terminator
+sRhydonPose106:
+ax_pose 30, 0x01e4, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhydonPose107:
+ax_pose 31, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sRhydonPose108:
+ax_pose 32, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sRhydonPose109:
+ax_pose 33, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose110:
+ax_pose 34, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose111:
+ax_pose 35, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose112:
+ax_pose 30, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhydonPose113:
+ax_pose 31, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sRhydonPose114:
+ax_pose 32, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sRhydonPose115:
+ax_pose 21, 0x81e4, 0x80ee, 0x6c00
+ax_pose 22, 0x01ec, 0x40fe, 0x6c08
+ax_pose 23, 0x41fc, 0x00fe, 0x6c0c
+ax_pose 24, 0x01f5, 0x010e, 0x6c0e
+ax_pose_terminator
+sRhydonPose116:
+ax_pose 25, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sRhydonPose117:
+ax_pose 26, 0x81e4, 0x80ef, 0x6c00
+ax_pose 27, 0x01ec, 0x40ff, 0x6c08
+ax_pose 28, 0x41fc, 0x00ff, 0x6c0c
+ax_pose 29, 0x01f5, 0x010f, 0x6c0e
+ax_pose_terminator
+sRhydonPose118:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose119:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose120:
+ax_pose 20, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose121:
+ax_pose 0, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose122:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose123:
+ax_pose 6, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose124:
+ax_pose 9, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose125:
+ax_pose 12, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose126:
+ax_pose 9, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose127:
+ax_pose 6, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose128:
+ax_pose 3, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose129:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose130:
+ax_pose 37, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose131:
+ax_pose 38, 0x01e2, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhydonPose132:
+ax_pose 39, 0x01e2, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhydonPose133:
+ax_pose 40, 0x01e0, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhydonPose134:
+ax_pose 41, 0x01e2, 0x90ec, 0x6c00
+ax_pose_terminator
+sRhydonPose135:
+ax_pose 42, 0x01e2, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhydonPose136:
+ax_pose 41, 0x01e2, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhydonPose137:
+ax_pose 40, 0x01e0, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhydonPose138:
+ax_pose 39, 0x01e2, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhydonPose139:
+ax_pose 0, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose140:
+ax_pose 17, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose141:
+ax_pose 3, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose142:
+ax_pose 20, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose143:
+ax_pose 6, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose144:
+ax_pose 26, 0x81e4, 0x9102, 0x6c00
+ax_pose 27, 0x01ec, 0x50f2, 0x6c08
+ax_pose 28, 0x41fc, 0x10f2, 0x6c0c
+ax_pose 29, 0x01f5, 0x10ea, 0x6c0e
+ax_pose_terminator
+sRhydonPose145:
+ax_pose 9, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose146:
+ax_pose 32, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sRhydonPose147:
+ax_pose 12, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose148:
+ax_pose 35, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose149:
+ax_pose 9, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose150:
+ax_pose 32, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sRhydonPose151:
+ax_pose 6, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose152:
+ax_pose 26, 0x81e4, 0x80ee, 0x6c00
+ax_pose 27, 0x01ec, 0x40fe, 0x6c08
+ax_pose 28, 0x41fc, 0x00fe, 0x6c0c
+ax_pose 29, 0x01f5, 0x010e, 0x6c0e
+ax_pose_terminator
+sRhydonPose153:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose154:
+ax_pose 20, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose155:
+ax_pose 17, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose156:
+ax_pose 20, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose157:
+ax_pose 26, 0x81e4, 0x80ef, 0x6c00
+ax_pose 27, 0x01ec, 0x40ff, 0x6c08
+ax_pose 28, 0x41fc, 0x00ff, 0x6c0c
+ax_pose 29, 0x01f5, 0x010f, 0x6c0e
+ax_pose_terminator
+sRhydonPose158:
+ax_pose 32, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sRhydonPose159:
+ax_pose 35, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose160:
+ax_pose 32, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sRhydonPose161:
+ax_pose 26, 0x81e4, 0x9101, 0x6c00
+ax_pose 27, 0x01ec, 0x50f1, 0x6c08
+ax_pose 28, 0x41fc, 0x10f1, 0x6c0c
+ax_pose 29, 0x01f5, 0x10e9, 0x6c0e
+ax_pose_terminator
+sRhydonPose162:
+ax_pose 20, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose163:
+ax_pose 17, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose164:
+ax_pose 20, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose165:
+ax_pose 26, 0x81e4, 0x9101, 0x6c00
+ax_pose 27, 0x01ec, 0x50f1, 0x6c08
+ax_pose 28, 0x41fc, 0x10f1, 0x6c0c
+ax_pose 29, 0x01f5, 0x10e9, 0x6c0e
+ax_pose_terminator
+sRhydonPose166:
+ax_pose 32, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sRhydonPose167:
+ax_pose 35, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose168:
+ax_pose 32, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sRhydonPose169:
+ax_pose 26, 0x81e4, 0x80ef, 0x6c00
+ax_pose 27, 0x01ec, 0x40ff, 0x6c08
+ax_pose 28, 0x41fc, 0x00ff, 0x6c0c
+ax_pose 29, 0x01f5, 0x010f, 0x6c0e
+ax_pose_terminator
+sRhydonPose170:
+ax_pose 20, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose171:
+ax_pose 0, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose172:
+ax_pose 16, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose173:
+ax_pose 15, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose174:
+ax_pose 3, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose175:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose176:
+ax_pose 18, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sRhydonPose177:
+ax_pose 6, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose178:
+ax_pose 25, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sRhydonPose179:
+ax_pose 21, 0x81e4, 0x9102, 0x6c00
+ax_pose 22, 0x01ec, 0x50f2, 0x6c08
+ax_pose 23, 0x41fc, 0x10f2, 0x6c0c
+ax_pose 24, 0x01f5, 0x10ea, 0x6c0e
+ax_pose_terminator
+sRhydonPose180:
+ax_pose 9, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose181:
+ax_pose 31, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sRhydonPose182:
+ax_pose 30, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sRhydonPose183:
+ax_pose 12, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose184:
+ax_pose 34, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose185:
+ax_pose 33, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose186:
+ax_pose 9, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose187:
+ax_pose 31, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sRhydonPose188:
+ax_pose 30, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sRhydonPose189:
+ax_pose 6, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose190:
+ax_pose 25, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sRhydonPose191:
+ax_pose 21, 0x81e4, 0x80ee, 0x6c00
+ax_pose 22, 0x01ec, 0x40fe, 0x6c08
+ax_pose 23, 0x41fc, 0x00fe, 0x6c0c
+ax_pose 24, 0x01f5, 0x010e, 0x6c0e
+ax_pose_terminator
+sRhydonPose192:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose193:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose194:
+ax_pose 18, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sRhydonPose195:
+ax_pose 15, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose196:
+ax_pose 18, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sRhydonPose197:
+ax_pose 21, 0x81e4, 0x80ef, 0x6c00
+ax_pose 22, 0x01ec, 0x40ff, 0x6c08
+ax_pose 23, 0x41fc, 0x00ff, 0x6c0c
+ax_pose 24, 0x01f5, 0x010f, 0x6c0e
+ax_pose_terminator
+sRhydonPose198:
+ax_pose 30, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sRhydonPose199:
+ax_pose 33, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose200:
+ax_pose 30, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sRhydonPose201:
+ax_pose 21, 0x81e4, 0x9101, 0x6c00
+ax_pose 22, 0x01ec, 0x50f1, 0x6c08
+ax_pose 23, 0x41fc, 0x10f1, 0x6c0c
+ax_pose 24, 0x01f5, 0x10e9, 0x6c0e
+ax_pose_terminator
+sRhydonPose202:
+ax_pose 18, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sRhydonPose203:
+ax_pose 0, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose204:
+ax_pose 3, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose205:
+ax_pose 6, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose206:
+ax_pose 9, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose207:
+ax_pose 12, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhydonPose208:
+ax_pose 9, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose209:
+ax_pose 6, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhydonPose210:
+ax_pose 3, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+.align 2
+sRhydonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_2_1:
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 6, 0, 45, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 1, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 28, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRhydonAnims_2_2:
+ax_anim 2, 0, 24, -1, -1, -1, -1,
+ax_anim 6, 0, 24, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 1, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 20, 17, 20, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sRhydonAnims_2_3:
+ax_anim 2, 0, 27, -1, 0, -1, 0,
+ax_anim 6, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 1, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 19, 0, 19, 0,
+ax_anim 2, 0, 34, 19, 1, 19, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sRhydonAnims_2_4:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 6, 0, 30, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 37, 19, -17, 19, -17,
+ax_anim 2, 1, 37, 20, -16, 20, -16,
+ax_anim 2, 0, 37, 19, -17, 19, -17,
+ax_anim 2, 0, 37, 20, -16, 20, -16,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sRhydonAnims_2_5:
+ax_anim 2, 0, 33, 0, 1, 0, 1,
+ax_anim 6, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -9, 0, -9,
+ax_anim 2, 0, 40, 0, -17, 0, -17,
+ax_anim 2, 1, 40, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -17, 0, -17,
+ax_anim 2, 0, 40, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sRhydonAnims_2_6:
+ax_anim 2, 0, 36, 1, 1, 1, 1,
+ax_anim 6, 0, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -6, -6, -6, -6,
+ax_anim 1, 0, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 43, -17, -17, -17, -17,
+ax_anim 2, 1, 43, -18, -16, -18, -16,
+ax_anim 2, 0, 43, -17, -17, -17, -17,
+ax_anim 2, 0, 43, -18, -16, -18, -16,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sRhydonAnims_2_7:
+ax_anim 2, 0, 39, 1, 0, 1, 0,
+ax_anim 6, 0, 39, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 46, -17, 0, -17, 0,
+ax_anim 2, 1, 46, -17, 1, -17, 1,
+ax_anim 2, 0, 46, -17, 0, -17, 0,
+ax_anim 2, 0, 46, -17, 1, -17, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sRhydonAnims_2_8:
+ax_anim 2, 0, 42, 1, -1, 1, -1,
+ax_anim 6, 0, 42, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 25, -18, 18, -18, 18,
+ax_anim 2, 1, 25, -19, 17, -19, 17,
+ax_anim 2, 0, 25, -18, 18, -18, 18,
+ax_anim 2, 0, 25, -19, 17, -19, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRhydonAnims_3_1:
+ax_anim 8, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, -3, 0, 3,
+ax_anim 2, 0, 52, 0, -6, 0, 6,
+ax_anim 2, 0, 52, 0, -7, 0, 9,
+ax_anim 2, 0, 52, 0, -1, 0, 12,
+ax_anim 2, 2, 52, 0, 8, 0, 15,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 1, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 0, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 0, 48, 0, 9, 0, 9,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sRhydonAnims_3_2:
+ax_anim 8, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 3, -3, 3, 3,
+ax_anim 2, 0, 58, 6, -6, 6, 6,
+ax_anim 2, 0, 58, 9, -7, 9, 9,
+ax_anim 2, 0, 58, 12, -1, 12, 12,
+ax_anim 2, 2, 58, 15, 8, 15, 15,
+ax_anim 2, 0, 59, 19, 19, 19, 19,
+ax_anim 2, 1, 59, 20, 19, 20, 19,
+ax_anim 2, 0, 59, 19, 19, 19, 19,
+ax_anim 2, 0, 59, 20, 19, 20, 19,
+ax_anim 2, 0, 59, 19, 19, 19, 19,
+ax_anim 2, 0, 55, 9, 9, 9, 9,
+ax_anim 2, 0, 56, 4, 4, 4, 4,
+ax_anim_terminator
+sRhydonAnims_3_3:
+ax_anim 8, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 3, -4, 3, 0,
+ax_anim 2, 0, 64, 6, -9, 6, 0,
+ax_anim 2, 0, 64, 9, -12, 9, 0,
+ax_anim 2, 0, 64, 12, -11, 12, 0,
+ax_anim 2, 2, 64, 15, -7, 15, 0,
+ax_anim 2, 0, 65, 19, 0, 19, 0,
+ax_anim 2, 1, 65, 19, -1, 19, -1,
+ax_anim 2, 0, 65, 19, 0, 19, 0,
+ax_anim 2, 0, 65, 19, -1, 19, -1,
+ax_anim 2, 0, 65, 19, 0, 19, 0,
+ax_anim 2, 0, 61, 12, 0, 12, 0,
+ax_anim 2, 0, 62, 4, 0, 4, 0,
+ax_anim_terminator
+sRhydonAnims_3_4:
+ax_anim 8, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 3, -7, 3, -3,
+ax_anim 2, 0, 70, 6, -15, 6, -6,
+ax_anim 2, 0, 70, 9, -21, 9, -9,
+ax_anim 2, 0, 70, 12, -23, 12, -12,
+ax_anim 2, 2, 70, 15, -22, 15, -15,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 1, 71, 18, -20, 18, -20,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 71, 18, -20, 18, -20,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 67, 12, -12, 12, -12,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sRhydonAnims_3_5:
+ax_anim 8, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -7, 0, -3,
+ax_anim 2, 0, 76, 0, -15, 0, -6,
+ax_anim 2, 0, 76, 0, -21, 0, -9,
+ax_anim 2, 0, 76, 0, -23, 0, -12,
+ax_anim 2, 2, 76, 0, -22, 0, -15,
+ax_anim 2, 0, 77, 0, -19, 0, -19,
+ax_anim 2, 1, 77, 0, -20, 0, -20,
+ax_anim 2, 0, 77, 0, -19, 0, -19,
+ax_anim 2, 0, 77, 0, -20, 0, -20,
+ax_anim 2, 0, 77, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 0, -12, 0, -12,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim_terminator
+sRhydonAnims_3_6:
+ax_anim 8, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, -3, -7, -3, -3,
+ax_anim 2, 0, 82, -6, -15, -6, -6,
+ax_anim 2, 0, 82, -9, -21, -9, -9,
+ax_anim 2, 0, 82, -12, -23, -12, -12,
+ax_anim 2, 2, 82, -15, -22, -15, -15,
+ax_anim 2, 0, 83, -19, -19, -19, -19,
+ax_anim 2, 1, 83, -18, -20, -18, -20,
+ax_anim 2, 0, 83, -19, -19, -19, -19,
+ax_anim 2, 0, 83, -18, -20, -18, -20,
+ax_anim 2, 0, 83, -19, -19, -19, -19,
+ax_anim 2, 0, 79, -12, -12, -12, -12,
+ax_anim 2, 0, 80, -4, -4, -4, -4,
+ax_anim_terminator
+sRhydonAnims_3_7:
+ax_anim 8, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -3, -4, -3, 0,
+ax_anim 2, 0, 88, -6, -9, -6, 0,
+ax_anim 2, 0, 88, -9, -12, -9, 0,
+ax_anim 2, 0, 88, -12, -11, -12, 0,
+ax_anim 2, 2, 88, -15, -7, -15, 0,
+ax_anim 2, 0, 89, -19, 0, -19, 0,
+ax_anim 2, 1, 89, -19, -1, -19, -1,
+ax_anim 2, 0, 89, -19, 0, -19, 0,
+ax_anim 2, 0, 89, -19, -1, -19, -1,
+ax_anim 2, 0, 89, -19, 0, -19, 0,
+ax_anim 2, 0, 85, -12, 0, -12, 0,
+ax_anim 2, 0, 86, -4, 0, -4, 0,
+ax_anim_terminator
+sRhydonAnims_3_8:
+ax_anim 8, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -3, -3, -3, 3,
+ax_anim 2, 0, 94, -6, -6, -6, 6,
+ax_anim 2, 0, 94, -9, -7, -9, 9,
+ax_anim 2, 0, 94, -12, -1, -12, 12,
+ax_anim 2, 2, 94, -15, 8, -15, 15,
+ax_anim 2, 0, 95, -19, 19, -19, 19,
+ax_anim 2, 1, 95, -20, 19, -20, 19,
+ax_anim 2, 0, 95, -19, 19, -19, 19,
+ax_anim 2, 0, 95, -20, 19, -20, 19,
+ax_anim 2, 0, 95, -19, 19, -19, 19,
+ax_anim 2, 0, 91, -9, 9, -9, 9,
+ax_anim 2, 0, 92, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sRhydonAnims_4_1:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 3, 0, 97, 0, -5, 0, 0,
+ax_anim 3, 2, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_4_2:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 3, 0, 100, 0, -6, 0, 0,
+ax_anim 3, 2, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 1, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_4_3:
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 103, 0, -6, 0, 0,
+ax_anim 3, 0, 103, 0, -7, 0, 0,
+ax_anim 3, 2, 103, 0, -6, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 1, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_4_4:
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 3, 0, 106, 0, -7, 0, 0,
+ax_anim 3, 2, 106, 0, -6, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 107, 1, 1, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 1, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 1, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_4_5:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 3, 0, 109, 0, -5, 0, 0,
+ax_anim 3, 2, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_4_6:
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 6, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -6, 0, 0,
+ax_anim 3, 0, 112, 0, -7, 0, 0,
+ax_anim 3, 2, 112, 0, -6, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_4_7:
+ax_anim 2, 0, 114, 0, 1, 0, 1,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -6, 0, 0,
+ax_anim 3, 0, 115, 0, -7, 0, 0,
+ax_anim 3, 2, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 1, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_4_8:
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 3, 0, 118, 0, -6, 0, 0,
+ax_anim 3, 2, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -3,
+ax_anim 8, 0, 130, 0, -5, 0, -4,
+ax_anim_terminator
+sRhydonAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sRhydonAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sRhydonAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sRhydonAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sRhydonAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sRhydonAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sRhydonAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sRhydonAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 26, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_8_2:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 26, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_8_3:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 26, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_8_4:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 26, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_8_5:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 26, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_8_6:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 26, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_8_7:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 26, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_8_8:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 26, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 15, 7, 15,
+ax_anim 3, 0, 158, 0, 18, 0, 18,
+ax_anim 2, 3, 159, -7, 15, -7, 15,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 19, 10, 19, 10,
+ax_anim 3, 0, 157, 17, 19, 17, 19,
+ax_anim 2, 3, 158, 11, 19, 11, 19,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -5, 16, -5,
+ax_anim 3, 0, 156, 18, -2, 18, -2,
+ax_anim 2, 3, 157, 16, 4, 16, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -22, 12, -22,
+ax_anim 3, 0, 155, 18, -20, 18, -20,
+ax_anim 2, 3, 156, 20, -15, 20, -15,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -20, 0, -20,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -22, -12, -22,
+ax_anim 3, 0, 161, -18, -20, -18, -20,
+ax_anim 2, 3, 160, -20, -15, -20, -15,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -5, -16, -5,
+ax_anim 3, 0, 160, -18, -2, -18, -2,
+ax_anim 2, 3, 159, -16, 4, -16, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -19, 10, -19, 10,
+ax_anim 3, 0, 159, -17, 19, -17, 19,
+ax_anim 2, 3, 158, -11, 19, -11, 19,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -27, 0, 0,
+ax_anim 3, 0, 178, 0, -26, 0, 0,
+ax_anim 2, 0, 178, 0, -20, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -24, 0, 0,
+ax_anim 3, 0, 181, 0, -23, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -24, 0, 0,
+ax_anim 3, 0, 187, 0, -23, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -27, 0, 0,
+ax_anim 3, 0, 190, 0, -26, 0, 0,
+ax_anim 2, 0, 190, 0, -20, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhydonAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sRhydonGfx1:
+.incbin "baserom.gba", 0x9D81D4, 0x200
+sRhydonSprites1:
+ax_sprite sRhydonGfx1, 0x200
+ax_sprite_terminator
+sRhydonGfx2:
+.incbin "baserom.gba", 0x9D83E4, 0x200
+sRhydonSprites2:
+ax_sprite sRhydonGfx2, 0x200
+ax_sprite_terminator
+sRhydonGfx3:
+.incbin "baserom.gba", 0x9D85F4, 0x200
+sRhydonSprites3:
+ax_sprite sRhydonGfx3, 0x200
+ax_sprite_terminator
+sRhydonGfx4:
+.incbin "baserom.gba", 0x9D8804, 0x200
+sRhydonSprites4:
+ax_sprite sRhydonGfx4, 0x200
+ax_sprite_terminator
+sRhydonGfx5:
+.incbin "baserom.gba", 0x9D8A14, 0x200
+sRhydonSprites5:
+ax_sprite sRhydonGfx5, 0x200
+ax_sprite_terminator
+sRhydonGfx6:
+.incbin "baserom.gba", 0x9D8C24, 0x200
+sRhydonSprites6:
+ax_sprite sRhydonGfx6, 0x200
+ax_sprite_terminator
+sRhydonGfx7:
+.incbin "baserom.gba", 0x9D8E34, 0x200
+sRhydonSprites7:
+ax_sprite sRhydonGfx7, 0x200
+ax_sprite_terminator
+sRhydonGfx8:
+.incbin "baserom.gba", 0x9D9044, 0x200
+sRhydonSprites8:
+ax_sprite sRhydonGfx8, 0x200
+ax_sprite_terminator
+sRhydonGfx9:
+.incbin "baserom.gba", 0x9D9254, 0x200
+sRhydonSprites9:
+ax_sprite sRhydonGfx9, 0x200
+ax_sprite_terminator
+sRhydonGfx10:
+.incbin "baserom.gba", 0x9D9464, 0x200
+sRhydonSprites10:
+ax_sprite sRhydonGfx10, 0x200
+ax_sprite_terminator
+sRhydonGfx11:
+.incbin "baserom.gba", 0x9D9674, 0x200
+sRhydonSprites11:
+ax_sprite sRhydonGfx11, 0x200
+ax_sprite_terminator
+sRhydonGfx12:
+.incbin "baserom.gba", 0x9D9884, 0x200
+sRhydonSprites12:
+ax_sprite sRhydonGfx12, 0x200
+ax_sprite_terminator
+sRhydonGfx13:
+.incbin "baserom.gba", 0x9D9A94, 0x200
+sRhydonSprites13:
+ax_sprite sRhydonGfx13, 0x200
+ax_sprite_terminator
+sRhydonGfx14:
+.incbin "baserom.gba", 0x9D9CA4, 0x200
+sRhydonSprites14:
+ax_sprite sRhydonGfx14, 0x200
+ax_sprite_terminator
+sRhydonGfx15:
+.incbin "baserom.gba", 0x9D9EB4, 0x200
+sRhydonSprites15:
+ax_sprite sRhydonGfx15, 0x200
+ax_sprite_terminator
+sRhydonGfx16:
+.incbin "baserom.gba", 0x9DA0C4, 0x40
+sRhydonGfx16_1:
+.incbin "baserom.gba", 0x9DA104, 0x180
+sRhydonSprites16:
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx16_1, 0x180
+ax_sprite_terminator
+sRhydonGfx17:
+.incbin "baserom.gba", 0x9DA2AC, 0x200
+sRhydonSprites17:
+ax_sprite sRhydonGfx17, 0x200
+ax_sprite_terminator
+sRhydonGfx18:
+.incbin "baserom.gba", 0x9DA4BC, 0x40
+sRhydonGfx18_1:
+.incbin "baserom.gba", 0x9DA4FC, 0x180
+sRhydonSprites18:
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx18_1, 0x180
+ax_sprite_terminator
+sRhydonGfx19:
+.incbin "baserom.gba", 0x9DA6A4, 0x20
+sRhydonGfx19_1:
+.incbin "baserom.gba", 0x9DA6C4, 0x180
+sRhydonSprites19:
+ax_sprite sRhydonGfx19, 0x20
+ax_sprite 0, 0x60
+ax_sprite sRhydonGfx19_1, 0x180
+ax_sprite_terminator
+sRhydonGfx20:
+.incbin "baserom.gba", 0x9DA864, 0x200
+sRhydonSprites20:
+ax_sprite sRhydonGfx20, 0x200
+ax_sprite_terminator
+sRhydonGfx21:
+.incbin "baserom.gba", 0x9DAA74, 0x60
+sRhydonGfx21_1:
+.incbin "baserom.gba", 0x9DAAD4, 0x180
+sRhydonSprites21:
+ax_sprite sRhydonGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx21_1, 0x180
+ax_sprite_terminator
+sRhydonGfx22:
+.incbin "baserom.gba", 0x9DAC74, 0xE0
+sRhydonSprites22:
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx22, 0xe0
+ax_sprite_terminator
+sRhydonGfx23:
+.incbin "baserom.gba", 0x9DAD6C, 0x20
+sRhydonGfx23_1:
+.incbin "baserom.gba", 0x9DAD8C, 0x40
+sRhydonSprites23:
+ax_sprite sRhydonGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx23_1, 0x40
+ax_sprite_terminator
+sRhydonGfx24:
+.incbin "baserom.gba", 0x9DADEC, 0x40
+sRhydonSprites24:
+ax_sprite sRhydonGfx24, 0x40
+ax_sprite_terminator
+sRhydonGfx25:
+.incbin "baserom.gba", 0x9DAE3C, 0x20
+sRhydonSprites25:
+ax_sprite sRhydonGfx25, 0x20
+ax_sprite_terminator
+sRhydonGfx26:
+.incbin "baserom.gba", 0x9DAE6C, 0x60
+sRhydonGfx26_1:
+.incbin "baserom.gba", 0x9DAECC, 0x60
+sRhydonGfx26_2:
+.incbin "baserom.gba", 0x9DAF2C, 0x100
+sRhydonSprites26:
+ax_sprite sRhydonGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx26_2, 0x100
+ax_sprite_terminator
+sRhydonGfx27:
+.incbin "baserom.gba", 0x9DB05C, 0xC0
+sRhydonGfx27_1:
+.incbin "baserom.gba", 0x9DB11C, 0x20
+sRhydonSprites27:
+ax_sprite sRhydonGfx27, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx27_1, 0x20
+ax_sprite_terminator
+sRhydonGfx28:
+.incbin "baserom.gba", 0x9DB15C, 0x20
+sRhydonGfx28_1:
+.incbin "baserom.gba", 0x9DB17C, 0x40
+sRhydonSprites28:
+ax_sprite sRhydonGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx28_1, 0x40
+ax_sprite_terminator
+sRhydonGfx29:
+.incbin "baserom.gba", 0x9DB1DC, 0x40
+sRhydonSprites29:
+ax_sprite sRhydonGfx29, 0x40
+ax_sprite_terminator
+sRhydonGfx30:
+.incbin "baserom.gba", 0x9DB22C, 0x20
+sRhydonSprites30:
+ax_sprite sRhydonGfx30, 0x20
+ax_sprite_terminator
+sRhydonGfx31:
+.incbin "baserom.gba", 0x9DB25C, 0x40
+sRhydonGfx31_1:
+.incbin "baserom.gba", 0x9DB29C, 0x60
+sRhydonGfx31_2:
+.incbin "baserom.gba", 0x9DB2FC, 0x100
+sRhydonSprites31:
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx31_2, 0x100
+ax_sprite_terminator
+sRhydonGfx32:
+.incbin "baserom.gba", 0x9DB434, 0x40
+sRhydonGfx32_1:
+.incbin "baserom.gba", 0x9DB474, 0xE0
+sRhydonGfx32_2:
+.incbin "baserom.gba", 0x9DB554, 0x80
+sRhydonSprites32:
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx32_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx32_2, 0x80
+ax_sprite_terminator
+sRhydonGfx33:
+.incbin "baserom.gba", 0x9DB60C, 0x60
+sRhydonGfx33_1:
+.incbin "baserom.gba", 0x9DB66C, 0x60
+sRhydonGfx33_2:
+.incbin "baserom.gba", 0x9DB6CC, 0x100
+sRhydonSprites33:
+ax_sprite sRhydonGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx33_2, 0x100
+ax_sprite_terminator
+sRhydonGfx34:
+.incbin "baserom.gba", 0x9DB7FC, 0x60
+sRhydonGfx34_1:
+.incbin "baserom.gba", 0x9DB85C, 0x180
+sRhydonSprites34:
+ax_sprite sRhydonGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx34_1, 0x180
+ax_sprite_terminator
+sRhydonGfx35:
+.incbin "baserom.gba", 0x9DB9FC, 0x40
+sRhydonGfx35_1:
+.incbin "baserom.gba", 0x9DBA3C, 0x180
+sRhydonSprites35:
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx35_1, 0x180
+ax_sprite_terminator
+sRhydonGfx36:
+.incbin "baserom.gba", 0x9DBBE4, 0x60
+sRhydonGfx36_1:
+.incbin "baserom.gba", 0x9DBC44, 0x180
+sRhydonSprites36:
+ax_sprite sRhydonGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhydonGfx36_1, 0x180
+ax_sprite_terminator
+sRhydonGfx37:
+.incbin "baserom.gba", 0x9DBDE4, 0x200
+sRhydonSprites37:
+ax_sprite sRhydonGfx37, 0x200
+ax_sprite_terminator
+sRhydonGfx38:
+.incbin "baserom.gba", 0x9DBFF4, 0x200
+sRhydonSprites38:
+ax_sprite sRhydonGfx38, 0x200
+ax_sprite_terminator
+sRhydonGfx39:
+.incbin "baserom.gba", 0x9DC204, 0x200
+sRhydonSprites39:
+ax_sprite sRhydonGfx39, 0x200
+ax_sprite_terminator
+sRhydonGfx40:
+.incbin "baserom.gba", 0x9DC414, 0x200
+sRhydonSprites40:
+ax_sprite sRhydonGfx40, 0x200
+ax_sprite_terminator
+sRhydonGfx41:
+.incbin "baserom.gba", 0x9DC624, 0x200
+sRhydonSprites41:
+ax_sprite sRhydonGfx41, 0x200
+ax_sprite_terminator
+sRhydonGfx42:
+.incbin "baserom.gba", 0x9DC834, 0x200
+sRhydonSprites42:
+ax_sprite sRhydonGfx42, 0x200
+ax_sprite_terminator
+sRhydonGfx43:
+.incbin "baserom.gba", 0x9DCA44, 0x200
+sRhydonSprites43:
+ax_sprite sRhydonGfx43, 0x200
+ax_sprite_terminator
+sAxPosesRhydon:
+.4byte sRhydonPose1
+.4byte sRhydonPose2
+.4byte sRhydonPose3
+.4byte sRhydonPose4
+.4byte sRhydonPose5
+.4byte sRhydonPose6
+.4byte sRhydonPose7
+.4byte sRhydonPose8
+.4byte sRhydonPose9
+.4byte sRhydonPose10
+.4byte sRhydonPose11
+.4byte sRhydonPose12
+.4byte sRhydonPose13
+.4byte sRhydonPose14
+.4byte sRhydonPose15
+.4byte sRhydonPose16
+.4byte sRhydonPose17
+.4byte sRhydonPose18
+.4byte sRhydonPose19
+.4byte sRhydonPose20
+.4byte sRhydonPose21
+.4byte sRhydonPose22
+.4byte sRhydonPose23
+.4byte sRhydonPose24
+.4byte sRhydonPose25
+.4byte sRhydonPose26
+.4byte sRhydonPose27
+.4byte sRhydonPose28
+.4byte sRhydonPose29
+.4byte sRhydonPose30
+.4byte sRhydonPose31
+.4byte sRhydonPose32
+.4byte sRhydonPose33
+.4byte sRhydonPose34
+.4byte sRhydonPose35
+.4byte sRhydonPose36
+.4byte sRhydonPose37
+.4byte sRhydonPose38
+.4byte sRhydonPose39
+.4byte sRhydonPose40
+.4byte sRhydonPose41
+.4byte sRhydonPose42
+.4byte sRhydonPose43
+.4byte sRhydonPose44
+.4byte sRhydonPose45
+.4byte sRhydonPose46
+.4byte sRhydonPose47
+.4byte sRhydonPose48
+.4byte sRhydonPose49
+.4byte sRhydonPose50
+.4byte sRhydonPose51
+.4byte sRhydonPose52
+.4byte sRhydonPose53
+.4byte sRhydonPose54
+.4byte sRhydonPose55
+.4byte sRhydonPose56
+.4byte sRhydonPose57
+.4byte sRhydonPose58
+.4byte sRhydonPose59
+.4byte sRhydonPose60
+.4byte sRhydonPose61
+.4byte sRhydonPose62
+.4byte sRhydonPose63
+.4byte sRhydonPose64
+.4byte sRhydonPose65
+.4byte sRhydonPose66
+.4byte sRhydonPose67
+.4byte sRhydonPose68
+.4byte sRhydonPose69
+.4byte sRhydonPose70
+.4byte sRhydonPose71
+.4byte sRhydonPose72
+.4byte sRhydonPose73
+.4byte sRhydonPose74
+.4byte sRhydonPose75
+.4byte sRhydonPose76
+.4byte sRhydonPose77
+.4byte sRhydonPose78
+.4byte sRhydonPose79
+.4byte sRhydonPose80
+.4byte sRhydonPose81
+.4byte sRhydonPose82
+.4byte sRhydonPose83
+.4byte sRhydonPose84
+.4byte sRhydonPose85
+.4byte sRhydonPose86
+.4byte sRhydonPose87
+.4byte sRhydonPose88
+.4byte sRhydonPose89
+.4byte sRhydonPose90
+.4byte sRhydonPose91
+.4byte sRhydonPose92
+.4byte sRhydonPose93
+.4byte sRhydonPose94
+.4byte sRhydonPose95
+.4byte sRhydonPose96
+.4byte sRhydonPose97
+.4byte sRhydonPose98
+.4byte sRhydonPose99
+.4byte sRhydonPose100
+.4byte sRhydonPose101
+.4byte sRhydonPose102
+.4byte sRhydonPose103
+.4byte sRhydonPose104
+.4byte sRhydonPose105
+.4byte sRhydonPose106
+.4byte sRhydonPose107
+.4byte sRhydonPose108
+.4byte sRhydonPose109
+.4byte sRhydonPose110
+.4byte sRhydonPose111
+.4byte sRhydonPose112
+.4byte sRhydonPose113
+.4byte sRhydonPose114
+.4byte sRhydonPose115
+.4byte sRhydonPose116
+.4byte sRhydonPose117
+.4byte sRhydonPose118
+.4byte sRhydonPose119
+.4byte sRhydonPose120
+.4byte sRhydonPose121
+.4byte sRhydonPose122
+.4byte sRhydonPose123
+.4byte sRhydonPose124
+.4byte sRhydonPose125
+.4byte sRhydonPose126
+.4byte sRhydonPose127
+.4byte sRhydonPose128
+.4byte sRhydonPose129
+.4byte sRhydonPose130
+.4byte sRhydonPose131
+.4byte sRhydonPose132
+.4byte sRhydonPose133
+.4byte sRhydonPose134
+.4byte sRhydonPose135
+.4byte sRhydonPose136
+.4byte sRhydonPose137
+.4byte sRhydonPose138
+.4byte sRhydonPose139
+.4byte sRhydonPose140
+.4byte sRhydonPose141
+.4byte sRhydonPose142
+.4byte sRhydonPose143
+.4byte sRhydonPose144
+.4byte sRhydonPose145
+.4byte sRhydonPose146
+.4byte sRhydonPose147
+.4byte sRhydonPose148
+.4byte sRhydonPose149
+.4byte sRhydonPose150
+.4byte sRhydonPose151
+.4byte sRhydonPose152
+.4byte sRhydonPose153
+.4byte sRhydonPose154
+.4byte sRhydonPose155
+.4byte sRhydonPose156
+.4byte sRhydonPose157
+.4byte sRhydonPose158
+.4byte sRhydonPose159
+.4byte sRhydonPose160
+.4byte sRhydonPose161
+.4byte sRhydonPose162
+.4byte sRhydonPose163
+.4byte sRhydonPose164
+.4byte sRhydonPose165
+.4byte sRhydonPose166
+.4byte sRhydonPose167
+.4byte sRhydonPose168
+.4byte sRhydonPose169
+.4byte sRhydonPose170
+.4byte sRhydonPose171
+.4byte sRhydonPose172
+.4byte sRhydonPose173
+.4byte sRhydonPose174
+.4byte sRhydonPose175
+.4byte sRhydonPose176
+.4byte sRhydonPose177
+.4byte sRhydonPose178
+.4byte sRhydonPose179
+.4byte sRhydonPose180
+.4byte sRhydonPose181
+.4byte sRhydonPose182
+.4byte sRhydonPose183
+.4byte sRhydonPose184
+.4byte sRhydonPose185
+.4byte sRhydonPose186
+.4byte sRhydonPose187
+.4byte sRhydonPose188
+.4byte sRhydonPose189
+.4byte sRhydonPose190
+.4byte sRhydonPose191
+.4byte sRhydonPose192
+.4byte sRhydonPose193
+.4byte sRhydonPose194
+.4byte sRhydonPose195
+.4byte sRhydonPose196
+.4byte sRhydonPose197
+.4byte sRhydonPose198
+.4byte sRhydonPose199
+.4byte sRhydonPose200
+.4byte sRhydonPose201
+.4byte sRhydonPose202
+.4byte sRhydonPose203
+.4byte sRhydonPose204
+.4byte sRhydonPose205
+.4byte sRhydonPose206
+.4byte sRhydonPose207
+.4byte sRhydonPose208
+.4byte sRhydonPose209
+.4byte sRhydonPose210
+sAxPositionsRhydon:
+.2byte   -1,  -11, 	 -13,   -8, 	  11,   -8, 	  -1,  -13
+.2byte   -1,  -12, 	 -14,   -9, 	   8,   -9, 	  -1,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	  12,   -9, 	  -1,  -13
+.2byte    3,  -12, 	  10,  -10, 	  -6,   -6, 	  -1,  -11
+.2byte    3,  -13, 	   9,  -10, 	  -4,   -6, 	   0,  -12
+.2byte    3,  -13, 	  12,   -9, 	  -8,   -7, 	   1,  -12
+.2byte    7,  -12, 	   4,  -10, 	   6,   -5, 	  -2,  -10
+.2byte    7,  -11, 	  -1,  -11, 	   8,   -4, 	  -2,   -9
+.2byte    7,  -11, 	   6,   -8, 	   1,   -5, 	  -1,   -9
+.2byte    3,  -16, 	  -6,  -13, 	   9,   -9, 	  -1,  -11
+.2byte    3,  -14, 	  -6,  -13, 	   9,   -9, 	  -1,  -10
+.2byte    3,  -15, 	  -1,  -15, 	   6,   -7, 	  -3,  -10
+.2byte   -1,  -16, 	   9,  -13, 	 -11,  -13, 	  -1,  -12
+.2byte    0,  -15, 	   9,  -11, 	 -11,  -14, 	  -2,  -11
+.2byte   -2,  -15, 	   8,  -14, 	 -11,  -11, 	   0,  -11
+.2byte   -4,  -16, 	   5,  -13, 	 -10,   -9, 	   0,  -11
+.2byte   -4,  -14, 	   5,  -13, 	 -10,   -9, 	   0,  -10
+.2byte   -4,  -15, 	   0,  -15, 	  -7,   -7, 	   2,  -10
+.2byte   -8,  -12, 	  -5,  -10, 	  -7,   -5, 	   1,  -10
+.2byte   -8,  -11, 	   0,  -11, 	  -9,   -4, 	   1,   -9
+.2byte   -8,  -11, 	  -7,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -4,  -12, 	 -11,  -10, 	   5,   -6, 	   0,  -11
+.2byte   -4,  -13, 	 -10,  -10, 	   3,   -6, 	  -1,  -12
+.2byte   -4,  -13, 	 -13,   -9, 	   7,   -7, 	  -2,  -12
+.2byte   -1,  -11, 	 -13,   -8, 	  11,   -8, 	  -1,  -13
+.2byte   -1,  -12, 	 -14,   -9, 	   8,   -9, 	  -1,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	  12,   -9, 	  -1,  -13
+.2byte    3,  -12, 	  10,  -10, 	  -6,   -6, 	  -1,  -11
+.2byte    3,  -13, 	   9,  -10, 	  -4,   -6, 	   0,  -12
+.2byte    3,  -13, 	  12,   -9, 	  -8,   -7, 	   1,  -12
+.2byte    7,  -12, 	   4,  -10, 	   6,   -5, 	  -2,  -10
+.2byte    7,  -11, 	  -1,  -11, 	   8,   -4, 	  -2,   -9
+.2byte    7,  -11, 	   6,   -8, 	   1,   -5, 	  -1,   -9
+.2byte    3,  -16, 	  -6,  -13, 	   9,   -9, 	  -1,  -11
+.2byte    3,  -14, 	  -6,  -13, 	   9,   -9, 	  -1,  -10
+.2byte    3,  -15, 	  -1,  -15, 	   6,   -7, 	  -3,  -10
+.2byte   -1,  -16, 	   9,  -13, 	 -11,  -13, 	  -1,  -12
+.2byte    0,  -15, 	   9,  -11, 	 -11,  -14, 	  -2,  -11
+.2byte   -2,  -15, 	   8,  -14, 	 -11,  -11, 	   0,  -11
+.2byte   -4,  -16, 	   5,  -13, 	 -10,   -9, 	   0,  -11
+.2byte   -4,  -14, 	   5,  -13, 	 -10,   -9, 	   0,  -10
+.2byte   -4,  -15, 	   0,  -15, 	  -7,   -7, 	   2,  -10
+.2byte   -8,  -12, 	  -5,  -10, 	  -7,   -5, 	   1,  -10
+.2byte   -8,  -11, 	   0,  -11, 	  -9,   -4, 	   1,   -9
+.2byte   -8,  -11, 	  -7,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -4,  -12, 	 -11,  -10, 	   5,   -6, 	   0,  -11
+.2byte   -4,  -13, 	 -10,  -10, 	   3,   -6, 	  -1,  -12
+.2byte   -4,  -13, 	 -13,   -9, 	   7,   -7, 	  -2,  -12
+.2byte   -1,  -11, 	 -13,   -8, 	  11,   -8, 	  -1,  -13
+.2byte   -1,  -12, 	 -14,   -9, 	   8,   -9, 	  -1,  -13
+.2byte   -1,  -12, 	 -10,   -9, 	  12,   -9, 	  -1,  -13
+.2byte   -1,   -5, 	 -11,   -6, 	   9,   -6, 	  -1,  -11
+.2byte   -1,  -19, 	 -13,  -20, 	  11,  -20, 	  -1,  -13
+.2byte   -1,   -8, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte    3,  -12, 	  10,  -10, 	  -6,   -6, 	  -1,  -11
+.2byte    3,  -13, 	   9,  -10, 	  -4,   -6, 	   0,  -12
+.2byte    3,  -13, 	  12,   -9, 	  -8,   -7, 	   1,  -12
+.2byte    5,   -4, 	  13,   -9, 	  -3,   -4, 	   2,   -8
+.2byte    1,  -19, 	  10,  -19, 	 -10,  -18, 	  -1,  -12
+.2byte    5,   -8, 	  12,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    7,  -12, 	   4,  -10, 	   6,   -5, 	  -2,  -10
+.2byte    7,  -11, 	  -1,  -11, 	   8,   -4, 	  -2,   -9
+.2byte    7,  -11, 	   6,   -8, 	   1,   -5, 	  -1,   -9
+.2byte    8,   -4, 	  11,   -8, 	   6,   -3, 	   2,   -8
+.2byte    3,  -18, 	  -1,  -21, 	  -1,  -15, 	  -2,   -9
+.2byte    9,   -9, 	   7,  -11, 	   5,   -3, 	  -1,   -9
+.2byte    3,  -16, 	  -6,  -13, 	   9,   -9, 	  -1,  -11
+.2byte    3,  -14, 	  -6,  -13, 	   9,   -9, 	  -1,  -10
+.2byte    3,  -15, 	  -1,  -15, 	   6,   -7, 	  -3,  -10
+.2byte    8,  -10, 	   4,  -13, 	  12,   -8, 	   1,  -10
+.2byte    3,  -21, 	  -8,  -23, 	   8,  -14, 	  -4,   -9
+.2byte    6,  -15, 	  -2,  -14, 	  12,   -7, 	  -1,  -11
+.2byte   -1,  -16, 	   9,  -13, 	 -11,  -13, 	  -1,  -12
+.2byte    0,  -15, 	   9,  -11, 	 -11,  -14, 	  -2,  -11
+.2byte   -2,  -15, 	   8,  -14, 	 -11,  -11, 	   0,  -11
+.2byte   -1,  -14, 	   8,  -10, 	 -11,  -10, 	  -1,  -12
+.2byte   -1,  -22, 	  10,  -19, 	 -12,  -19, 	  -1,  -14
+.2byte   -1,  -16, 	  10,  -11, 	 -12,  -11, 	  -1,  -12
+.2byte   -4,  -16, 	   5,  -13, 	 -10,   -9, 	   0,  -11
+.2byte   -4,  -14, 	   5,  -13, 	 -10,   -9, 	   0,  -10
+.2byte   -4,  -15, 	   0,  -15, 	  -7,   -7, 	   2,  -10
+.2byte   -9,  -10, 	  -5,  -13, 	 -13,   -8, 	  -2,  -10
+.2byte   -4,  -21, 	   7,  -23, 	  -9,  -14, 	   3,   -9
+.2byte   -7,  -15, 	   1,  -14, 	 -13,   -7, 	   0,  -11
+.2byte   -8,  -12, 	  -5,  -10, 	  -7,   -5, 	   1,  -10
+.2byte   -8,  -11, 	   0,  -11, 	  -9,   -4, 	   1,   -9
+.2byte   -8,  -11, 	  -7,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -9,   -4, 	 -12,   -8, 	  -7,   -3, 	  -3,   -8
+.2byte   -4,  -18, 	   0,  -21, 	   0,  -15, 	   1,   -9
+.2byte  -10,   -9, 	  -8,  -11, 	  -6,   -3, 	   0,   -9
+.2byte   -4,  -12, 	 -11,  -10, 	   5,   -6, 	   0,  -11
+.2byte   -4,  -13, 	 -10,  -10, 	   3,   -6, 	  -1,  -12
+.2byte   -4,  -13, 	 -13,   -9, 	   7,   -7, 	  -2,  -12
+.2byte   -6,   -4, 	 -14,   -9, 	   2,   -4, 	  -3,   -8
+.2byte   -2,  -19, 	 -11,  -19, 	   9,  -18, 	   0,  -12
+.2byte   -6,   -8, 	 -13,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -5, 	 -11,   -6, 	   9,   -6, 	  -1,  -11
+.2byte   -1,  -19, 	 -13,  -20, 	  11,  -20, 	  -1,  -13
+.2byte   -1,   -8, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte    5,   -4, 	  13,   -9, 	  -3,   -4, 	   2,   -8
+.2byte    1,  -19, 	  10,  -19, 	 -10,  -18, 	  -1,  -12
+.2byte    5,   -8, 	  12,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    8,   -4, 	  11,   -8, 	   6,   -3, 	   2,   -8
+.2byte    3,  -18, 	  -1,  -21, 	  -1,  -15, 	  -2,   -9
+.2byte    9,   -9, 	   7,  -11, 	   5,   -3, 	  -1,   -9
+.2byte    8,  -10, 	   4,  -13, 	  12,   -8, 	   1,  -10
+.2byte    3,  -21, 	  -8,  -23, 	   8,  -14, 	  -4,   -9
+.2byte    6,  -15, 	  -2,  -14, 	  12,   -7, 	  -1,  -11
+.2byte   -1,  -14, 	   8,  -10, 	 -11,  -10, 	  -1,  -12
+.2byte   -1,  -22, 	  10,  -19, 	 -12,  -19, 	  -1,  -14
+.2byte   -1,  -16, 	  10,  -11, 	 -12,  -11, 	  -1,  -12
+.2byte   -9,  -10, 	  -5,  -13, 	 -13,   -8, 	  -2,  -10
+.2byte   -4,  -21, 	   7,  -23, 	  -9,  -14, 	   3,   -9
+.2byte   -7,  -15, 	   1,  -14, 	 -13,   -7, 	   0,  -11
+.2byte   -9,   -4, 	 -12,   -8, 	  -7,   -3, 	  -3,   -8
+.2byte   -4,  -18, 	   0,  -21, 	   0,  -15, 	   1,   -9
+.2byte  -10,   -9, 	  -8,  -11, 	  -6,   -3, 	   0,   -9
+.2byte   -6,   -4, 	 -14,   -9, 	   2,   -4, 	  -3,   -8
+.2byte   -2,  -19, 	 -11,  -19, 	   9,  -18, 	   0,  -12
+.2byte   -6,   -8, 	 -13,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,  -11, 	 -13,   -8, 	  11,   -8, 	  -1,  -13
+.2byte   -4,  -12, 	 -11,  -10, 	   5,   -6, 	   0,  -11
+.2byte   -8,  -12, 	  -5,  -10, 	  -7,   -5, 	   1,  -10
+.2byte   -4,  -16, 	   5,  -13, 	 -10,   -9, 	   0,  -11
+.2byte   -1,  -16, 	   9,  -13, 	 -11,  -13, 	  -1,  -12
+.2byte    3,  -16, 	  -6,  -13, 	   9,   -9, 	  -1,  -11
+.2byte    7,  -12, 	   4,  -10, 	   6,   -5, 	  -2,  -10
+.2byte    3,  -12, 	  10,  -10, 	  -6,   -6, 	  -1,  -11
+.2byte   -4,  -10, 	 -11,   -4, 	   6,   -2, 	  -1,   -9
+.2byte   -4,   -9, 	 -11,   -5, 	   6,   -1, 	  -1,   -7
+.2byte    0,  -11, 	  -7,  -14, 	   7,  -14, 	   0,  -13
+.2byte    3,  -13, 	  10,  -19, 	  -4,  -15, 	  -1,  -11
+.2byte    5,  -12, 	   7,  -17, 	   4,  -14, 	  -2,  -13
+.2byte    2,  -15, 	  -4,  -17, 	   5,  -18, 	  -2,  -12
+.2byte    0,  -15, 	   6,  -17, 	  -6,  -17, 	   0,  -11
+.2byte   -3,  -15, 	   3,  -17, 	  -6,  -18, 	   1,  -12
+.2byte   -6,  -12, 	  -8,  -17, 	  -5,  -14, 	   1,  -13
+.2byte   -4,  -13, 	 -11,  -19, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -11, 	 -13,   -8, 	  11,   -8, 	  -1,  -13
+.2byte   -1,   -8, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte    3,  -12, 	  10,  -10, 	  -6,   -6, 	  -1,  -11
+.2byte    5,   -8, 	  12,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    7,  -12, 	   4,  -10, 	   6,   -5, 	  -2,  -10
+.2byte   10,   -9, 	   8,  -11, 	   6,   -3, 	   0,   -9
+.2byte    3,  -16, 	  -6,  -13, 	   9,   -9, 	  -1,  -11
+.2byte    5,  -15, 	  -3,  -14, 	  11,   -7, 	  -2,  -11
+.2byte   -1,  -16, 	   9,  -13, 	 -11,  -13, 	  -1,  -12
+.2byte   -1,  -16, 	  10,  -11, 	 -12,  -11, 	  -1,  -12
+.2byte   -4,  -16, 	   5,  -13, 	 -10,   -9, 	   0,  -11
+.2byte   -6,  -15, 	   2,  -14, 	 -12,   -7, 	   1,  -11
+.2byte   -8,  -12, 	  -5,  -10, 	  -7,   -5, 	   1,  -10
+.2byte  -11,   -9, 	  -9,  -11, 	  -7,   -3, 	  -1,   -9
+.2byte   -4,  -12, 	 -11,  -10, 	   5,   -6, 	   0,  -11
+.2byte   -6,   -8, 	 -13,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,   -8, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte   -6,   -8, 	 -13,   -9, 	   8,   -5, 	  -1,   -8
+.2byte  -10,   -9, 	  -8,  -11, 	  -6,   -3, 	   0,   -9
+.2byte   -6,  -15, 	   2,  -14, 	 -12,   -7, 	   1,  -11
+.2byte   -1,  -16, 	  10,  -11, 	 -12,  -11, 	  -1,  -12
+.2byte    5,  -15, 	  -3,  -14, 	  11,   -7, 	  -2,  -11
+.2byte    9,   -9, 	   7,  -11, 	   5,   -3, 	  -1,   -9
+.2byte    5,   -8, 	  12,   -9, 	  -9,   -5, 	   0,   -8
+.2byte   -1,   -8, 	 -13,   -7, 	  11,   -7, 	  -1,  -10
+.2byte    5,   -8, 	  12,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    9,   -9, 	   7,  -11, 	   5,   -3, 	  -1,   -9
+.2byte    5,  -15, 	  -3,  -14, 	  11,   -7, 	  -2,  -11
+.2byte   -1,  -16, 	  10,  -11, 	 -12,  -11, 	  -1,  -12
+.2byte   -6,  -15, 	   2,  -14, 	 -12,   -7, 	   1,  -11
+.2byte  -10,   -9, 	  -8,  -11, 	  -6,   -3, 	   0,   -9
+.2byte   -6,   -8, 	 -13,   -9, 	   8,   -5, 	  -1,   -8
+.2byte   -1,  -11, 	 -13,   -8, 	  11,   -8, 	  -1,  -13
+.2byte   -1,  -19, 	 -13,  -20, 	  11,  -20, 	  -1,  -13
+.2byte   -1,   -5, 	 -11,   -6, 	   9,   -6, 	  -1,  -11
+.2byte    3,  -12, 	  10,  -10, 	  -6,   -6, 	  -1,  -11
+.2byte    1,  -19, 	  10,  -19, 	 -10,  -18, 	  -1,  -12
+.2byte    3,   -4, 	  11,   -9, 	  -5,   -4, 	   0,   -8
+.2byte    7,  -12, 	   4,  -10, 	   6,   -5, 	  -2,  -10
+.2byte    3,  -18, 	  -1,  -21, 	  -1,  -15, 	  -2,   -9
+.2byte    8,   -4, 	  11,   -8, 	   6,   -3, 	   2,   -8
+.2byte    3,  -16, 	  -6,  -13, 	   9,   -9, 	  -1,  -11
+.2byte    3,  -21, 	  -8,  -23, 	   8,  -14, 	  -4,   -9
+.2byte    6,  -10, 	   2,  -13, 	  10,   -8, 	  -1,  -10
+.2byte   -1,  -16, 	   9,  -13, 	 -11,  -13, 	  -1,  -12
+.2byte   -1,  -22, 	  10,  -19, 	 -12,  -19, 	  -1,  -14
+.2byte   -1,  -14, 	   8,  -10, 	 -11,  -10, 	  -1,  -12
+.2byte   -4,  -16, 	   5,  -13, 	 -10,   -9, 	   0,  -11
+.2byte   -4,  -21, 	   7,  -23, 	  -9,  -14, 	   3,   -9
+.2byte   -7,  -10, 	  -3,  -13, 	 -11,   -8, 	   0,  -10
+.2byte   -8,  -12, 	  -5,  -10, 	  -7,   -5, 	   1,  -10
+.2byte   -4,  -18, 	   0,  -21, 	   0,  -15, 	   1,   -9
+.2byte   -9,   -4, 	 -12,   -8, 	  -7,   -3, 	  -3,   -8
+.2byte   -4,  -12, 	 -11,  -10, 	   5,   -6, 	   0,  -11
+.2byte   -2,  -19, 	 -11,  -19, 	   9,  -18, 	   0,  -12
+.2byte   -4,   -4, 	 -12,   -9, 	   4,   -4, 	  -1,   -8
+.2byte   -1,   -5, 	 -11,   -6, 	   9,   -6, 	  -1,  -11
+.2byte   -4,   -4, 	 -12,   -9, 	   4,   -4, 	  -1,   -8
+.2byte   -8,   -4, 	 -11,   -8, 	  -6,   -3, 	  -2,   -8
+.2byte   -7,  -10, 	  -3,  -13, 	 -11,   -8, 	   0,  -10
+.2byte   -1,  -14, 	   8,  -10, 	 -11,  -10, 	  -1,  -12
+.2byte    6,  -10, 	   2,  -13, 	  10,   -8, 	  -1,  -10
+.2byte    7,   -4, 	  10,   -8, 	   5,   -3, 	   1,   -8
+.2byte    3,   -4, 	  11,   -9, 	  -5,   -4, 	   0,   -8
+.2byte   -1,  -11, 	 -13,   -8, 	  11,   -8, 	  -1,  -13
+.2byte   -4,  -12, 	 -11,  -10, 	   5,   -6, 	   0,  -11
+.2byte   -8,  -12, 	  -5,  -10, 	  -7,   -5, 	   1,  -10
+.2byte   -4,  -16, 	   5,  -13, 	 -10,   -9, 	   0,  -11
+.2byte   -1,  -16, 	   9,  -13, 	 -11,  -13, 	  -1,  -12
+.2byte    3,  -16, 	  -6,  -13, 	   9,   -9, 	  -1,  -11
+.2byte    7,  -12, 	   4,  -10, 	   6,   -5, 	  -2,  -10
+.2byte    3,  -12, 	  10,  -10, 	  -6,   -6, 	  -1,  -11
+sRhydonAnimTable1:
+.4byte sRhydonAnims_1_1
+.4byte sRhydonAnims_1_2
+.4byte sRhydonAnims_1_3
+.4byte sRhydonAnims_1_4
+.4byte sRhydonAnims_1_5
+.4byte sRhydonAnims_1_6
+.4byte sRhydonAnims_1_7
+.4byte sRhydonAnims_1_8
+sRhydonAnimTable2:
+.4byte sRhydonAnims_2_1
+.4byte sRhydonAnims_2_2
+.4byte sRhydonAnims_2_3
+.4byte sRhydonAnims_2_4
+.4byte sRhydonAnims_2_5
+.4byte sRhydonAnims_2_6
+.4byte sRhydonAnims_2_7
+.4byte sRhydonAnims_2_8
+sRhydonAnimTable3:
+.4byte sRhydonAnims_3_1
+.4byte sRhydonAnims_3_2
+.4byte sRhydonAnims_3_3
+.4byte sRhydonAnims_3_4
+.4byte sRhydonAnims_3_5
+.4byte sRhydonAnims_3_6
+.4byte sRhydonAnims_3_7
+.4byte sRhydonAnims_3_8
+sRhydonAnimTable4:
+.4byte sRhydonAnims_4_1
+.4byte sRhydonAnims_4_2
+.4byte sRhydonAnims_4_3
+.4byte sRhydonAnims_4_4
+.4byte sRhydonAnims_4_5
+.4byte sRhydonAnims_4_6
+.4byte sRhydonAnims_4_7
+.4byte sRhydonAnims_4_8
+sRhydonAnimTable5:
+.4byte sRhydonAnims_5_1
+.4byte sRhydonAnims_5_2
+.4byte sRhydonAnims_5_3
+.4byte sRhydonAnims_5_4
+.4byte sRhydonAnims_5_5
+.4byte sRhydonAnims_5_6
+.4byte sRhydonAnims_5_7
+.4byte sRhydonAnims_5_8
+sRhydonAnimTable6:
+.4byte sRhydonAnims_6_1
+.4byte sRhydonAnims_6_1
+.4byte sRhydonAnims_6_1
+.4byte sRhydonAnims_6_1
+.4byte sRhydonAnims_6_1
+.4byte sRhydonAnims_6_1
+.4byte sRhydonAnims_6_1
+.4byte sRhydonAnims_6_1
+sRhydonAnimTable7:
+.4byte sRhydonAnims_7_1
+.4byte sRhydonAnims_7_2
+.4byte sRhydonAnims_7_3
+.4byte sRhydonAnims_7_4
+.4byte sRhydonAnims_7_5
+.4byte sRhydonAnims_7_6
+.4byte sRhydonAnims_7_7
+.4byte sRhydonAnims_7_8
+sRhydonAnimTable8:
+.4byte sRhydonAnims_8_1
+.4byte sRhydonAnims_8_2
+.4byte sRhydonAnims_8_3
+.4byte sRhydonAnims_8_4
+.4byte sRhydonAnims_8_5
+.4byte sRhydonAnims_8_6
+.4byte sRhydonAnims_8_7
+.4byte sRhydonAnims_8_8
+sRhydonAnimTable9:
+.4byte sRhydonAnims_9_1
+.4byte sRhydonAnims_9_2
+.4byte sRhydonAnims_9_3
+.4byte sRhydonAnims_9_4
+.4byte sRhydonAnims_9_5
+.4byte sRhydonAnims_9_6
+.4byte sRhydonAnims_9_7
+.4byte sRhydonAnims_9_8
+sRhydonAnimTable10:
+.4byte sRhydonAnims_10_1
+.4byte sRhydonAnims_10_2
+.4byte sRhydonAnims_10_3
+.4byte sRhydonAnims_10_4
+.4byte sRhydonAnims_10_5
+.4byte sRhydonAnims_10_6
+.4byte sRhydonAnims_10_7
+.4byte sRhydonAnims_10_8
+sRhydonAnimTable11:
+.4byte sRhydonAnims_11_1
+.4byte sRhydonAnims_11_2
+.4byte sRhydonAnims_11_3
+.4byte sRhydonAnims_11_4
+.4byte sRhydonAnims_11_5
+.4byte sRhydonAnims_11_6
+.4byte sRhydonAnims_11_7
+.4byte sRhydonAnims_11_8
+sRhydonAnimTable12:
+.4byte sRhydonAnims_12_1
+.4byte sRhydonAnims_12_2
+.4byte sRhydonAnims_12_3
+.4byte sRhydonAnims_12_4
+.4byte sRhydonAnims_12_5
+.4byte sRhydonAnims_12_6
+.4byte sRhydonAnims_12_7
+.4byte sRhydonAnims_12_8
+sRhydonAnimTable13:
+.4byte sRhydonAnims_13_1
+.4byte sRhydonAnims_13_2
+.4byte sRhydonAnims_13_3
+.4byte sRhydonAnims_13_4
+.4byte sRhydonAnims_13_5
+.4byte sRhydonAnims_13_6
+.4byte sRhydonAnims_13_7
+.4byte sRhydonAnims_13_8
+sAxAnimationsRhydon:
+.4byte sRhydonAnimTable1
+.4byte sRhydonAnimTable2
+.4byte sRhydonAnimTable3
+.4byte sRhydonAnimTable4
+.4byte sRhydonAnimTable5
+.4byte sRhydonAnimTable6
+.4byte sRhydonAnimTable7
+.4byte sRhydonAnimTable8
+.4byte sRhydonAnimTable9
+.4byte sRhydonAnimTable10
+.4byte sRhydonAnimTable11
+.4byte sRhydonAnimTable12
+.4byte sRhydonAnimTable13
+sAxSpritesRhydon:
+.4byte sRhydonSprites1
+.4byte sRhydonSprites2
+.4byte sRhydonSprites3
+.4byte sRhydonSprites4
+.4byte sRhydonSprites5
+.4byte sRhydonSprites6
+.4byte sRhydonSprites7
+.4byte sRhydonSprites8
+.4byte sRhydonSprites9
+.4byte sRhydonSprites10
+.4byte sRhydonSprites11
+.4byte sRhydonSprites12
+.4byte sRhydonSprites13
+.4byte sRhydonSprites14
+.4byte sRhydonSprites15
+.4byte sRhydonSprites16
+.4byte sRhydonSprites17
+.4byte sRhydonSprites18
+.4byte sRhydonSprites19
+.4byte sRhydonSprites20
+.4byte sRhydonSprites21
+.4byte sRhydonSprites22
+.4byte sRhydonSprites23
+.4byte sRhydonSprites24
+.4byte sRhydonSprites25
+.4byte sRhydonSprites26
+.4byte sRhydonSprites27
+.4byte sRhydonSprites28
+.4byte sRhydonSprites29
+.4byte sRhydonSprites30
+.4byte sRhydonSprites31
+.4byte sRhydonSprites32
+.4byte sRhydonSprites33
+.4byte sRhydonSprites34
+.4byte sRhydonSprites35
+.4byte sRhydonSprites36
+.4byte sRhydonSprites37
+.4byte sRhydonSprites38
+.4byte sRhydonSprites39
+.4byte sRhydonSprites40
+.4byte sRhydonSprites41
+.4byte sRhydonSprites42
+.4byte sRhydonSprites43
+sAxMainRhydon:
+ax_main sAxPosesRhydon, sAxAnimationsRhydon, 13, sAxSpritesRhydon, sAxPositionsRhydon

--- a/data/ax/rhyhorn.inc
+++ b/data/ax/rhyhorn.inc
@@ -1,0 +1,2558 @@
+.global gAxRhyhorn
+gAxRhyhorn:
+ax_siro sAxMainRhyhorn
+sRhyhornPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose2:
+ax_pose 1, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose3:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose4:
+ax_pose 3, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose5:
+ax_pose 4, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sRhyhornPose6:
+ax_pose 5, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose7:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose8:
+ax_pose 7, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose9:
+ax_pose 8, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose10:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose11:
+ax_pose 10, 0x01ed, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose12:
+ax_pose 11, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose13:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose14:
+ax_pose 13, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose15:
+ax_pose 14, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose16:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose17:
+ax_pose 10, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose18:
+ax_pose 11, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose19:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose20:
+ax_pose 7, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose21:
+ax_pose 8, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose22:
+ax_pose 3, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose23:
+ax_pose 4, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sRhyhornPose24:
+ax_pose 5, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose25:
+ax_pose 15, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose26:
+ax_pose 16, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose27:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose28:
+ax_pose 17, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose29:
+ax_pose 18, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sRhyhornPose30:
+ax_pose 5, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose31:
+ax_pose 19, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose32:
+ax_pose 20, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose33:
+ax_pose 8, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose34:
+ax_pose 21, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose35:
+ax_pose 22, 0x01ed, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose36:
+ax_pose 11, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose37:
+ax_pose 23, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose38:
+ax_pose 24, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose39:
+ax_pose 14, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose40:
+ax_pose 21, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose41:
+ax_pose 22, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose42:
+ax_pose 11, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose43:
+ax_pose 19, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose44:
+ax_pose 20, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose45:
+ax_pose 8, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose46:
+ax_pose 17, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose47:
+ax_pose 18, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sRhyhornPose48:
+ax_pose 5, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose49:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose50:
+ax_pose 1, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose51:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose52:
+ax_pose 15, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose53:
+ax_pose 16, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose54:
+ax_pose 3, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose55:
+ax_pose 4, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sRhyhornPose56:
+ax_pose 5, 0x01e8, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose57:
+ax_pose 17, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose58:
+ax_pose 18, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose59:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose60:
+ax_pose 7, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose61:
+ax_pose 8, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose62:
+ax_pose 19, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose63:
+ax_pose 20, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose64:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose65:
+ax_pose 10, 0x01ed, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose66:
+ax_pose 11, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose67:
+ax_pose 21, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose68:
+ax_pose 22, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose69:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose70:
+ax_pose 13, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose71:
+ax_pose 14, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose72:
+ax_pose 23, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose73:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose74:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose75:
+ax_pose 10, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose76:
+ax_pose 11, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose77:
+ax_pose 21, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose78:
+ax_pose 22, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose79:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose80:
+ax_pose 7, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose81:
+ax_pose 8, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose82:
+ax_pose 19, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose83:
+ax_pose 20, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose84:
+ax_pose 3, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose85:
+ax_pose 4, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sRhyhornPose86:
+ax_pose 5, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose87:
+ax_pose 17, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose88:
+ax_pose 18, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose89:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose90:
+ax_pose 16, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose91:
+ax_pose 25, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose92:
+ax_pose 3, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose93:
+ax_pose 18, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose94:
+ax_pose 26, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose95:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose96:
+ax_pose 20, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose97:
+ax_pose 27, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose98:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose99:
+ax_pose 22, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose100:
+ax_pose 28, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose101:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose102:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose103:
+ax_pose 29, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose104:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose105:
+ax_pose 22, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose106:
+ax_pose 28, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose107:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose108:
+ax_pose 20, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose109:
+ax_pose 27, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose110:
+ax_pose 3, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose111:
+ax_pose 18, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose112:
+ax_pose 26, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose113:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose114:
+ax_pose 3, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose115:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose116:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose117:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose118:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose119:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose120:
+ax_pose 3, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose121:
+ax_pose 30, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sRhyhornPose122:
+ax_pose 31, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sRhyhornPose123:
+ax_pose 32, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose124:
+ax_pose 33, 0x01e8, 0x90ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose125:
+ax_pose 34, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose126:
+ax_pose 35, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sRhyhornPose127:
+ax_pose 36, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose128:
+ax_pose 35, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose129:
+ax_pose 34, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose130:
+ax_pose 33, 0x01e8, 0x80f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose131:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose132:
+ax_pose 3, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose133:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose134:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose135:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose136:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose137:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose138:
+ax_pose 3, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose139:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose140:
+ax_pose 16, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose141:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose142:
+ax_pose 3, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose143:
+ax_pose 18, 0x01ed, 0x90f2, 0x6c00
+ax_pose_terminator
+sRhyhornPose144:
+ax_pose 4, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose145:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose146:
+ax_pose 20, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose147:
+ax_pose 8, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose148:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose149:
+ax_pose 22, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose150:
+ax_pose 11, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose151:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose152:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose153:
+ax_pose 14, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose154:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose155:
+ax_pose 22, 0x01eb, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose156:
+ax_pose 11, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose157:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose158:
+ax_pose 20, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose159:
+ax_pose 8, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose160:
+ax_pose 3, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose161:
+ax_pose 18, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sRhyhornPose162:
+ax_pose 4, 0x01ec, 0x80ee, 0x6c00
+ax_pose_terminator
+sRhyhornPose163:
+ax_pose 25, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose164:
+ax_pose 26, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose165:
+ax_pose 27, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose166:
+ax_pose 28, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose167:
+ax_pose 29, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose168:
+ax_pose 28, 0x01ee, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose169:
+ax_pose 27, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose170:
+ax_pose 26, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose171:
+ax_pose 25, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose172:
+ax_pose 26, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose173:
+ax_pose 27, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose174:
+ax_pose 28, 0x01ee, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose175:
+ax_pose 29, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose176:
+ax_pose 28, 0x01ee, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose177:
+ax_pose 27, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose178:
+ax_pose 26, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose179:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose180:
+ax_pose 15, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose181:
+ax_pose 16, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose182:
+ax_pose 3, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose183:
+ax_pose 17, 0x01ee, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose184:
+ax_pose 18, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose185:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose186:
+ax_pose 19, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose187:
+ax_pose 20, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose188:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose189:
+ax_pose 21, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose190:
+ax_pose 22, 0x01eb, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose191:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose192:
+ax_pose 23, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose193:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose194:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose195:
+ax_pose 21, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose196:
+ax_pose 22, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose197:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose198:
+ax_pose 19, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose199:
+ax_pose 20, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose200:
+ax_pose 3, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose201:
+ax_pose 17, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose202:
+ax_pose 18, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose203:
+ax_pose 16, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose204:
+ax_pose 18, 0x01ed, 0x80ef, 0x6c00
+ax_pose_terminator
+sRhyhornPose205:
+ax_pose 20, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose206:
+ax_pose 22, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose207:
+ax_pose 24, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose208:
+ax_pose 22, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose209:
+ax_pose 20, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose210:
+ax_pose 18, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sRhyhornPose211:
+ax_pose 0, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sRhyhornPose212:
+ax_pose 3, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose213:
+ax_pose 6, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose214:
+ax_pose 9, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose215:
+ax_pose 12, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose216:
+ax_pose 9, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose217:
+ax_pose 6, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sRhyhornPose218:
+ax_pose 3, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+.align 2
+sRhyhornAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_2_1:
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 6, 0, 24, 0, -3, 0, -3,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 17, 0, 17,
+ax_anim 2, 1, 25, 1, 17, 1, 17,
+ax_anim 2, 0, 25, 0, 17, 0, 17,
+ax_anim 2, 0, 25, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRhyhornAnims_2_2:
+ax_anim 2, 0, 27, -2, -2, -2, -2,
+ax_anim 6, 0, 27, -3, -3, -3, -3,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 17, 17, 17, 17,
+ax_anim 2, 1, 28, 18, 16, 18, 16,
+ax_anim 2, 0, 28, 17, 17, 17, 17,
+ax_anim 2, 0, 28, 18, 16, 18, 16,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sRhyhornAnims_2_3:
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 6, 0, 30, -3, 0, -3, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 16, 0, 16, 0,
+ax_anim 2, 1, 31, 16, 1, 16, 1,
+ax_anim 2, 0, 31, 16, 0, 16, 0,
+ax_anim 2, 0, 31, 16, 1, 16, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sRhyhornAnims_2_4:
+ax_anim 2, 0, 33, -2, 2, -2, 2,
+ax_anim 6, 0, 33, -3, 3, -3, 3,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 34, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 16, -21, 16, -21,
+ax_anim 2, 1, 34, 17, -20, 17, -20,
+ax_anim 2, 0, 34, 16, -21, 16, -21,
+ax_anim 2, 0, 34, 17, -20, 17, -20,
+ax_anim 2, 0, 33, 5, -6, 5, -6,
+ax_anim_terminator
+sRhyhornAnims_2_5:
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 6, 0, 36, 0, 3, 0, 3,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 1, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 0, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sRhyhornAnims_2_6:
+ax_anim 2, 0, 39, 2, 2, 2, 2,
+ax_anim 6, 0, 39, 3, 3, 3, 3,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 40, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -16, -21, -16, -21,
+ax_anim 2, 1, 40, -17, -20, -17, -20,
+ax_anim 2, 0, 40, -16, -21, -16, -21,
+ax_anim 2, 0, 40, -17, -20, -17, -20,
+ax_anim 2, 0, 39, -5, -6, -5, -6,
+ax_anim_terminator
+sRhyhornAnims_2_7:
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 6, 0, 42, 3, 0, 3, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -16, 0, -16, 0,
+ax_anim 2, 1, 43, -16, 1, -16, 1,
+ax_anim 2, 0, 43, -16, 0, -16, 0,
+ax_anim 2, 0, 43, -16, 1, -16, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sRhyhornAnims_2_8:
+ax_anim 2, 0, 45, 2, -2, 2, -2,
+ax_anim 6, 0, 45, 3, -3, 3, -3,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 17, -17, 17,
+ax_anim 2, 1, 46, -18, 16, -18, 16,
+ax_anim 2, 0, 46, -17, 17, -17, 17,
+ax_anim 2, 0, 46, -18, 16, -18, 16,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_3_1:
+ax_anim 6, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 3,
+ax_anim 2, 0, 51, 0, -3, 0, 6,
+ax_anim 2, 0, 51, 0, 0, 0, 9,
+ax_anim 2, 2, 51, 0, 8, 0, 13,
+ax_anim 2, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 1, 48, -1, 18, -1, 18,
+ax_anim 2, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 48, -1, 18, -1, 18,
+ax_anim 2, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 48, -1, 18, -1, 18,
+ax_anim 2, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 4, 0, 4,
+ax_anim_terminator
+sRhyhornAnims_3_2:
+ax_anim 6, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 3, -2, 3, 3,
+ax_anim 2, 0, 56, 6, -3, 6, 6,
+ax_anim 2, 0, 56, 9, -1, 9, 9,
+ax_anim 2, 2, 56, 13, 5, 13, 13,
+ax_anim 2, 0, 53, 17, 17, 17, 17,
+ax_anim 2, 1, 53, 16, 18, 16, 18,
+ax_anim 2, 0, 53, 17, 17, 17, 17,
+ax_anim 2, 0, 53, 16, 18, 16, 18,
+ax_anim 2, 0, 53, 17, 17, 17, 17,
+ax_anim 2, 0, 53, 16, 18, 16, 18,
+ax_anim 2, 0, 54, 10, 10, 10, 10,
+ax_anim 2, 0, 55, 4, 4, 4, 4,
+ax_anim_terminator
+sRhyhornAnims_3_3:
+ax_anim 6, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 3, -5, 3, 0,
+ax_anim 2, 0, 61, 6, -9, 6, 0,
+ax_anim 2, 0, 61, 9, -10, 9, 0,
+ax_anim 2, 2, 61, 13, -8, 13, 0,
+ax_anim 2, 0, 58, 16, 0, 16, 0,
+ax_anim 2, 1, 58, 16, 1, 16, 1,
+ax_anim 2, 0, 58, 16, 0, 16, 0,
+ax_anim 2, 0, 58, 16, 1, 16, 1,
+ax_anim 2, 0, 58, 16, 0, 16, 0,
+ax_anim 2, 0, 58, 16, 1, 16, 1,
+ax_anim 2, 0, 59, 10, 0, 10, 0,
+ax_anim 2, 0, 60, 4, 0, 4, 0,
+ax_anim_terminator
+sRhyhornAnims_3_4:
+ax_anim 6, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 3, -8, 3, -3,
+ax_anim 2, 0, 66, 6, -15, 6, -6,
+ax_anim 2, 0, 66, 9, -19, 9, -9,
+ax_anim 2, 2, 66, 13, -20, 13, -13,
+ax_anim 2, 0, 63, 19, -19, 19, -19,
+ax_anim 2, 1, 63, 20, -18, 19, -18,
+ax_anim 2, 0, 63, 19, -19, 19, -19,
+ax_anim 2, 0, 63, 20, -18, 20, -18,
+ax_anim 2, 0, 63, 19, -19, 19, -19,
+ax_anim 2, 0, 63, 20, -18, 20, -18,
+ax_anim 2, 0, 64, 10, -10, 10, -10,
+ax_anim 2, 0, 65, 4, -4, 4, 0,
+ax_anim_terminator
+sRhyhornAnims_3_5:
+ax_anim 6, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -8, 0, -3,
+ax_anim 2, 0, 71, 0, -15, 0, -6,
+ax_anim 2, 0, 71, 0, -19, 0, -9,
+ax_anim 2, 2, 71, 0, -20, 0, -13,
+ax_anim 2, 0, 68, 0, -19, 0, -19,
+ax_anim 2, 1, 68, 0, -18, 0, -18,
+ax_anim 2, 0, 68, 0, -19, 0, -19,
+ax_anim 2, 0, 68, 0, -18, 0, -18,
+ax_anim 2, 0, 68, 0, -19, 0, -19,
+ax_anim 2, 0, 68, 0, -18, 0, -18,
+ax_anim 2, 0, 69, 0, -10, 0, -10,
+ax_anim 2, 0, 70, 0, -4, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_3_6:
+ax_anim 6, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 76, -3, -8, -3, -3,
+ax_anim 2, 0, 76, -6, -15, -6, -6,
+ax_anim 2, 0, 76, -9, -19, -9, -9,
+ax_anim 2, 2, 76, -13, -20, -13, -13,
+ax_anim 2, 0, 73, -19, -19, -19, -19,
+ax_anim 2, 1, 73, -20, -18, -19, -18,
+ax_anim 2, 0, 73, -19, -19, -19, -19,
+ax_anim 2, 0, 73, -20, -18, -20, -18,
+ax_anim 2, 0, 73, -19, -19, -19, -19,
+ax_anim 2, 0, 73, -20, -18, -20, -18,
+ax_anim 2, 0, 74, -10, -10, -10, -10,
+ax_anim 2, 0, 75, -4, -4, -4, 0,
+ax_anim_terminator
+sRhyhornAnims_3_7:
+ax_anim 6, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -3, -5, -3, 0,
+ax_anim 2, 0, 81, -6, -9, -6, 0,
+ax_anim 2, 0, 81, -9, -10, -9, 0,
+ax_anim 2, 2, 81, -13, -8, -13, 0,
+ax_anim 2, 0, 78, -16, 0, -16, 0,
+ax_anim 2, 1, 78, -16, 1, -16, 1,
+ax_anim 2, 0, 78, -16, 0, -16, 0,
+ax_anim 2, 0, 78, -16, 1, -16, 1,
+ax_anim 2, 0, 78, -16, 0, -16, 0,
+ax_anim 2, 0, 78, -16, 1, -16, 1,
+ax_anim 2, 0, 79, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sRhyhornAnims_3_8:
+ax_anim 6, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -3, -2, -3, 3,
+ax_anim 2, 0, 86, -6, -3, -6, 6,
+ax_anim 2, 0, 86, -9, -1, -9, 9,
+ax_anim 2, 2, 86, -13, 5, -13, 13,
+ax_anim 2, 0, 83, -17, 17, -17, 17,
+ax_anim 2, 1, 83, -16, 18, -16, 18,
+ax_anim 2, 0, 83, -17, 17, -17, 17,
+ax_anim 2, 0, 83, -16, 18, -16, 18,
+ax_anim 2, 0, 83, -17, 17, -17, 17,
+ax_anim 2, 0, 83, -16, 18, -16, 18,
+ax_anim 2, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 85, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_4_1:
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim 6, 2, 89, 0, -2, 0, -2,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim 2, 1, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sRhyhornAnims_4_2:
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 6, 2, 92, -2, -2, -2, -2,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 3, 3, 3, 3,
+ax_anim 2, 1, 93, 2, 4, 2, 4,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 2, 4, 2, 4,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 2, 4, 2, 4,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sRhyhornAnims_4_3:
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 6, 2, 95, -2, 0, -2, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 3, 0, 3, 0,
+ax_anim 2, 1, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sRhyhornAnims_4_4:
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 6, 2, 98, -2, 2, -2, 2,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 3, -3, 3, -3,
+ax_anim 2, 1, 99, 2, -4, 2, -4,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 2, -4, 2, -4,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 2, -4, 2, -4,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sRhyhornAnims_4_5:
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 6, 2, 101, 0, 2, 0, 2,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, -3,
+ax_anim 2, 1, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sRhyhornAnims_4_6:
+ax_anim 2, 0, 104, 1, 1, 1, 1,
+ax_anim 6, 2, 104, 2, 2, 2, 2,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -3, -3, -3, -3,
+ax_anim 2, 1, 105, -2, -4, -2, -4,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -2, -4, -2, -4,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -2, -4, -2, -4,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sRhyhornAnims_4_7:
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 6, 2, 107, 2, 0, 2, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim 2, 1, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sRhyhornAnims_4_8:
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 6, 2, 110, 2, -2, 2, -2,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -3, 3, -3, 3,
+ax_anim 2, 1, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -2, 4, -2, 4,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sRhyhornAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sRhyhornAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sRhyhornAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sRhyhornAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sRhyhornAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sRhyhornAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sRhyhornAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 20, 0, 139, -1, 0, -1, 0,
+ax_anim 15, 0, 140, 0, -2, 0, -2,
+ax_anim_terminator
+sRhyhornAnims_8_2:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 20, 0, 142, 0, 0, 0, 0,
+ax_anim 15, 0, 143, -1, -2, -1, -2,
+ax_anim_terminator
+sRhyhornAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 20, 0, 145, 0, 0, 0, 0,
+ax_anim 15, 0, 146, -4, 0, -4, 0,
+ax_anim_terminator
+sRhyhornAnims_8_4:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 20, 0, 148, 0, 0, 0, 0,
+ax_anim 15, 0, 149, -3, 1, -3, 1,
+ax_anim_terminator
+sRhyhornAnims_8_5:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 20, 0, 151, 0, 0, 0, 0,
+ax_anim 15, 0, 152, 0, 2, 0, 2,
+ax_anim_terminator
+sRhyhornAnims_8_6:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 20, 0, 154, 0, 0, 0, 0,
+ax_anim 15, 0, 155, 1, 1, 1, 1,
+ax_anim_terminator
+sRhyhornAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 20, 0, 157, 0, 0, 0, 0,
+ax_anim 15, 0, 158, 4, 0, 4, 0,
+ax_anim_terminator
+sRhyhornAnims_8_8:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 20, 0, 160, 0, 0, 0, 0,
+ax_anim 15, 0, 161, 2, -1, 2, -1,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 15, 7, 15,
+ax_anim 3, 0, 166, 0, 17, 0, 18,
+ax_anim 2, 3, 167, -7, 15, -7, 15,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 19, 17, 19, 17,
+ax_anim 2, 3, 166, 11, 18, 11, 18,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -5, 17, -5,
+ax_anim 3, 0, 164, 20, -2, 20, -2,
+ax_anim 2, 3, 165, 17, 4, 17, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 20, -22, 20, -22,
+ax_anim 2, 3, 164, 20, -15, 20, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -23, 0, -23,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -20, -22, -20, -22,
+ax_anim 2, 3, 168, -20, -15, -20, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -5, -17, -5,
+ax_anim 3, 0, 168, -20, -2, -20, -2,
+ax_anim 2, 3, 167, -17, 4, -17, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -19, 17, -19, 17,
+ax_anim 2, 3, 166, -11, 18, -11, 18,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRhyhornAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sRhyhornGfx1:
+.incbin "baserom.gba", 0x9CE8C8, 0x200
+sRhyhornSprites1:
+ax_sprite sRhyhornGfx1, 0x200
+ax_sprite_terminator
+sRhyhornGfx2:
+.incbin "baserom.gba", 0x9CEAD8, 0x200
+sRhyhornSprites2:
+ax_sprite sRhyhornGfx2, 0x200
+ax_sprite_terminator
+sRhyhornGfx3:
+.incbin "baserom.gba", 0x9CECE8, 0x200
+sRhyhornSprites3:
+ax_sprite sRhyhornGfx3, 0x200
+ax_sprite_terminator
+sRhyhornGfx4:
+.incbin "baserom.gba", 0x9CEEF8, 0x200
+sRhyhornSprites4:
+ax_sprite sRhyhornGfx4, 0x200
+ax_sprite_terminator
+sRhyhornGfx5:
+.incbin "baserom.gba", 0x9CF108, 0x200
+sRhyhornSprites5:
+ax_sprite sRhyhornGfx5, 0x200
+ax_sprite_terminator
+sRhyhornGfx6:
+.incbin "baserom.gba", 0x9CF318, 0x200
+sRhyhornSprites6:
+ax_sprite sRhyhornGfx6, 0x200
+ax_sprite_terminator
+sRhyhornGfx7:
+.incbin "baserom.gba", 0x9CF528, 0x200
+sRhyhornSprites7:
+ax_sprite sRhyhornGfx7, 0x200
+ax_sprite_terminator
+sRhyhornGfx8:
+.incbin "baserom.gba", 0x9CF738, 0x200
+sRhyhornSprites8:
+ax_sprite sRhyhornGfx8, 0x200
+ax_sprite_terminator
+sRhyhornGfx9:
+.incbin "baserom.gba", 0x9CF948, 0x200
+sRhyhornSprites9:
+ax_sprite sRhyhornGfx9, 0x200
+ax_sprite_terminator
+sRhyhornGfx10:
+.incbin "baserom.gba", 0x9CFB58, 0x200
+sRhyhornSprites10:
+ax_sprite sRhyhornGfx10, 0x200
+ax_sprite_terminator
+sRhyhornGfx11:
+.incbin "baserom.gba", 0x9CFD68, 0x200
+sRhyhornSprites11:
+ax_sprite sRhyhornGfx11, 0x200
+ax_sprite_terminator
+sRhyhornGfx12:
+.incbin "baserom.gba", 0x9CFF78, 0x200
+sRhyhornSprites12:
+ax_sprite sRhyhornGfx12, 0x200
+ax_sprite_terminator
+sRhyhornGfx13:
+.incbin "baserom.gba", 0x9D0188, 0x200
+sRhyhornSprites13:
+ax_sprite sRhyhornGfx13, 0x200
+ax_sprite_terminator
+sRhyhornGfx14:
+.incbin "baserom.gba", 0x9D0398, 0x200
+sRhyhornSprites14:
+ax_sprite sRhyhornGfx14, 0x200
+ax_sprite_terminator
+sRhyhornGfx15:
+.incbin "baserom.gba", 0x9D05A8, 0x200
+sRhyhornSprites15:
+ax_sprite sRhyhornGfx15, 0x200
+ax_sprite_terminator
+sRhyhornGfx16:
+.incbin "baserom.gba", 0x9D07B8, 0x60
+sRhyhornGfx16_1:
+.incbin "baserom.gba", 0x9D0818, 0x60
+sRhyhornGfx16_2:
+.incbin "baserom.gba", 0x9D0878, 0x60
+sRhyhornSprites16:
+ax_sprite sRhyhornGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRhyhornGfx17:
+.incbin "baserom.gba", 0x9D0910, 0x60
+sRhyhornGfx17_1:
+.incbin "baserom.gba", 0x9D0970, 0x60
+sRhyhornGfx17_2:
+.incbin "baserom.gba", 0x9D09D0, 0x60
+sRhyhornSprites17:
+ax_sprite sRhyhornGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRhyhornGfx18:
+.incbin "baserom.gba", 0x9D0A68, 0x180
+sRhyhornSprites18:
+ax_sprite sRhyhornGfx18, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx19:
+.incbin "baserom.gba", 0x9D0C00, 0x180
+sRhyhornSprites19:
+ax_sprite sRhyhornGfx19, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx20:
+.incbin "baserom.gba", 0x9D0D98, 0x100
+sRhyhornGfx20_1:
+.incbin "baserom.gba", 0x9D0E98, 0x60
+sRhyhornSprites20:
+ax_sprite sRhyhornGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx20_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx21:
+.incbin "baserom.gba", 0x9D0F20, 0x180
+sRhyhornSprites21:
+ax_sprite sRhyhornGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx22:
+.incbin "baserom.gba", 0x9D10B8, 0x180
+sRhyhornGfx22_1:
+.incbin "baserom.gba", 0x9D1238, 0x40
+sRhyhornSprites22:
+ax_sprite sRhyhornGfx22, 0x180
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRhyhornGfx23:
+.incbin "baserom.gba", 0x9D12A0, 0x180
+sRhyhornSprites23:
+ax_sprite sRhyhornGfx23, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx24:
+.incbin "baserom.gba", 0x9D1438, 0x200
+sRhyhornSprites24:
+ax_sprite sRhyhornGfx24, 0x200
+ax_sprite_terminator
+sRhyhornGfx25:
+.incbin "baserom.gba", 0x9D1648, 0x40
+sRhyhornGfx25_1:
+.incbin "baserom.gba", 0x9D1688, 0x100
+sRhyhornGfx25_2:
+.incbin "baserom.gba", 0x9D1788, 0x60
+sRhyhornSprites25:
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx25_2, 0x60
+ax_sprite_terminator
+sRhyhornGfx26:
+.incbin "baserom.gba", 0x9D1820, 0x60
+sRhyhornGfx26_1:
+.incbin "baserom.gba", 0x9D1880, 0x60
+sRhyhornGfx26_2:
+.incbin "baserom.gba", 0x9D18E0, 0x60
+sRhyhornSprites26:
+ax_sprite sRhyhornGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sRhyhornGfx27:
+.incbin "baserom.gba", 0x9D1978, 0x180
+sRhyhornSprites27:
+ax_sprite sRhyhornGfx27, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx28:
+.incbin "baserom.gba", 0x9D1B10, 0x180
+sRhyhornSprites28:
+ax_sprite sRhyhornGfx28, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx29:
+.incbin "baserom.gba", 0x9D1CA8, 0x180
+sRhyhornSprites29:
+ax_sprite sRhyhornGfx29, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sRhyhornGfx30:
+.incbin "baserom.gba", 0x9D1E40, 0x160
+sRhyhornGfx30_1:
+.incbin "baserom.gba", 0x9D1FA0, 0x60
+sRhyhornSprites30:
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx30, 0x160
+ax_sprite 0, 0x20
+ax_sprite sRhyhornGfx30_1, 0x60
+ax_sprite_terminator
+sRhyhornGfx31:
+.incbin "baserom.gba", 0x9D2028, 0x200
+sRhyhornSprites31:
+ax_sprite sRhyhornGfx31, 0x200
+ax_sprite_terminator
+sRhyhornGfx32:
+.incbin "baserom.gba", 0x9D2238, 0x200
+sRhyhornSprites32:
+ax_sprite sRhyhornGfx32, 0x200
+ax_sprite_terminator
+sRhyhornGfx33:
+.incbin "baserom.gba", 0x9D2448, 0x200
+sRhyhornSprites33:
+ax_sprite sRhyhornGfx33, 0x200
+ax_sprite_terminator
+sRhyhornGfx34:
+.incbin "baserom.gba", 0x9D2658, 0x200
+sRhyhornSprites34:
+ax_sprite sRhyhornGfx34, 0x200
+ax_sprite_terminator
+sRhyhornGfx35:
+.incbin "baserom.gba", 0x9D2868, 0x200
+sRhyhornSprites35:
+ax_sprite sRhyhornGfx35, 0x200
+ax_sprite_terminator
+sRhyhornGfx36:
+.incbin "baserom.gba", 0x9D2A78, 0x200
+sRhyhornSprites36:
+ax_sprite sRhyhornGfx36, 0x200
+ax_sprite_terminator
+sRhyhornGfx37:
+.incbin "baserom.gba", 0x9D2C88, 0x200
+sRhyhornSprites37:
+ax_sprite sRhyhornGfx37, 0x200
+ax_sprite_terminator
+sAxPosesRhyhorn:
+.4byte sRhyhornPose1
+.4byte sRhyhornPose2
+.4byte sRhyhornPose3
+.4byte sRhyhornPose4
+.4byte sRhyhornPose5
+.4byte sRhyhornPose6
+.4byte sRhyhornPose7
+.4byte sRhyhornPose8
+.4byte sRhyhornPose9
+.4byte sRhyhornPose10
+.4byte sRhyhornPose11
+.4byte sRhyhornPose12
+.4byte sRhyhornPose13
+.4byte sRhyhornPose14
+.4byte sRhyhornPose15
+.4byte sRhyhornPose16
+.4byte sRhyhornPose17
+.4byte sRhyhornPose18
+.4byte sRhyhornPose19
+.4byte sRhyhornPose20
+.4byte sRhyhornPose21
+.4byte sRhyhornPose22
+.4byte sRhyhornPose23
+.4byte sRhyhornPose24
+.4byte sRhyhornPose25
+.4byte sRhyhornPose26
+.4byte sRhyhornPose27
+.4byte sRhyhornPose28
+.4byte sRhyhornPose29
+.4byte sRhyhornPose30
+.4byte sRhyhornPose31
+.4byte sRhyhornPose32
+.4byte sRhyhornPose33
+.4byte sRhyhornPose34
+.4byte sRhyhornPose35
+.4byte sRhyhornPose36
+.4byte sRhyhornPose37
+.4byte sRhyhornPose38
+.4byte sRhyhornPose39
+.4byte sRhyhornPose40
+.4byte sRhyhornPose41
+.4byte sRhyhornPose42
+.4byte sRhyhornPose43
+.4byte sRhyhornPose44
+.4byte sRhyhornPose45
+.4byte sRhyhornPose46
+.4byte sRhyhornPose47
+.4byte sRhyhornPose48
+.4byte sRhyhornPose49
+.4byte sRhyhornPose50
+.4byte sRhyhornPose51
+.4byte sRhyhornPose52
+.4byte sRhyhornPose53
+.4byte sRhyhornPose54
+.4byte sRhyhornPose55
+.4byte sRhyhornPose56
+.4byte sRhyhornPose57
+.4byte sRhyhornPose58
+.4byte sRhyhornPose59
+.4byte sRhyhornPose60
+.4byte sRhyhornPose61
+.4byte sRhyhornPose62
+.4byte sRhyhornPose63
+.4byte sRhyhornPose64
+.4byte sRhyhornPose65
+.4byte sRhyhornPose66
+.4byte sRhyhornPose67
+.4byte sRhyhornPose68
+.4byte sRhyhornPose69
+.4byte sRhyhornPose70
+.4byte sRhyhornPose71
+.4byte sRhyhornPose72
+.4byte sRhyhornPose73
+.4byte sRhyhornPose74
+.4byte sRhyhornPose75
+.4byte sRhyhornPose76
+.4byte sRhyhornPose77
+.4byte sRhyhornPose78
+.4byte sRhyhornPose79
+.4byte sRhyhornPose80
+.4byte sRhyhornPose81
+.4byte sRhyhornPose82
+.4byte sRhyhornPose83
+.4byte sRhyhornPose84
+.4byte sRhyhornPose85
+.4byte sRhyhornPose86
+.4byte sRhyhornPose87
+.4byte sRhyhornPose88
+.4byte sRhyhornPose89
+.4byte sRhyhornPose90
+.4byte sRhyhornPose91
+.4byte sRhyhornPose92
+.4byte sRhyhornPose93
+.4byte sRhyhornPose94
+.4byte sRhyhornPose95
+.4byte sRhyhornPose96
+.4byte sRhyhornPose97
+.4byte sRhyhornPose98
+.4byte sRhyhornPose99
+.4byte sRhyhornPose100
+.4byte sRhyhornPose101
+.4byte sRhyhornPose102
+.4byte sRhyhornPose103
+.4byte sRhyhornPose104
+.4byte sRhyhornPose105
+.4byte sRhyhornPose106
+.4byte sRhyhornPose107
+.4byte sRhyhornPose108
+.4byte sRhyhornPose109
+.4byte sRhyhornPose110
+.4byte sRhyhornPose111
+.4byte sRhyhornPose112
+.4byte sRhyhornPose113
+.4byte sRhyhornPose114
+.4byte sRhyhornPose115
+.4byte sRhyhornPose116
+.4byte sRhyhornPose117
+.4byte sRhyhornPose118
+.4byte sRhyhornPose119
+.4byte sRhyhornPose120
+.4byte sRhyhornPose121
+.4byte sRhyhornPose122
+.4byte sRhyhornPose123
+.4byte sRhyhornPose124
+.4byte sRhyhornPose125
+.4byte sRhyhornPose126
+.4byte sRhyhornPose127
+.4byte sRhyhornPose128
+.4byte sRhyhornPose129
+.4byte sRhyhornPose130
+.4byte sRhyhornPose131
+.4byte sRhyhornPose132
+.4byte sRhyhornPose133
+.4byte sRhyhornPose134
+.4byte sRhyhornPose135
+.4byte sRhyhornPose136
+.4byte sRhyhornPose137
+.4byte sRhyhornPose138
+.4byte sRhyhornPose139
+.4byte sRhyhornPose140
+.4byte sRhyhornPose141
+.4byte sRhyhornPose142
+.4byte sRhyhornPose143
+.4byte sRhyhornPose144
+.4byte sRhyhornPose145
+.4byte sRhyhornPose146
+.4byte sRhyhornPose147
+.4byte sRhyhornPose148
+.4byte sRhyhornPose149
+.4byte sRhyhornPose150
+.4byte sRhyhornPose151
+.4byte sRhyhornPose152
+.4byte sRhyhornPose153
+.4byte sRhyhornPose154
+.4byte sRhyhornPose155
+.4byte sRhyhornPose156
+.4byte sRhyhornPose157
+.4byte sRhyhornPose158
+.4byte sRhyhornPose159
+.4byte sRhyhornPose160
+.4byte sRhyhornPose161
+.4byte sRhyhornPose162
+.4byte sRhyhornPose163
+.4byte sRhyhornPose164
+.4byte sRhyhornPose165
+.4byte sRhyhornPose166
+.4byte sRhyhornPose167
+.4byte sRhyhornPose168
+.4byte sRhyhornPose169
+.4byte sRhyhornPose170
+.4byte sRhyhornPose171
+.4byte sRhyhornPose172
+.4byte sRhyhornPose173
+.4byte sRhyhornPose174
+.4byte sRhyhornPose175
+.4byte sRhyhornPose176
+.4byte sRhyhornPose177
+.4byte sRhyhornPose178
+.4byte sRhyhornPose179
+.4byte sRhyhornPose180
+.4byte sRhyhornPose181
+.4byte sRhyhornPose182
+.4byte sRhyhornPose183
+.4byte sRhyhornPose184
+.4byte sRhyhornPose185
+.4byte sRhyhornPose186
+.4byte sRhyhornPose187
+.4byte sRhyhornPose188
+.4byte sRhyhornPose189
+.4byte sRhyhornPose190
+.4byte sRhyhornPose191
+.4byte sRhyhornPose192
+.4byte sRhyhornPose193
+.4byte sRhyhornPose194
+.4byte sRhyhornPose195
+.4byte sRhyhornPose196
+.4byte sRhyhornPose197
+.4byte sRhyhornPose198
+.4byte sRhyhornPose199
+.4byte sRhyhornPose200
+.4byte sRhyhornPose201
+.4byte sRhyhornPose202
+.4byte sRhyhornPose203
+.4byte sRhyhornPose204
+.4byte sRhyhornPose205
+.4byte sRhyhornPose206
+.4byte sRhyhornPose207
+.4byte sRhyhornPose208
+.4byte sRhyhornPose209
+.4byte sRhyhornPose210
+.4byte sRhyhornPose211
+.4byte sRhyhornPose212
+.4byte sRhyhornPose213
+.4byte sRhyhornPose214
+.4byte sRhyhornPose215
+.4byte sRhyhornPose216
+.4byte sRhyhornPose217
+.4byte sRhyhornPose218
+sAxPositionsRhyhorn:
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte    1,    2, 	  -6,    3, 	   7,    0, 	   1,   -8
+.2byte   -1,    2, 	  -7,    0, 	   6,    3, 	  -1,   -8
+.2byte    7,    1, 	  10,    0, 	   0,    2, 	   0,   -8
+.2byte    6,    2, 	  11,    1, 	  -2,    1, 	   0,   -7
+.2byte    7,    2, 	   9,   -3, 	   2,    5, 	  -1,   -7
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte    9,   -1, 	  11,   -6, 	   2,    0, 	   0,   -8
+.2byte   10,   -2, 	   3,   -6, 	   7,    0, 	   1,   -7
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    9,   -5, 	   6,  -12, 	   6,   -2, 	   0,   -8
+.2byte    7,   -6, 	  -2,  -11, 	  10,   -5, 	  -1,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -6, 	  -8,   -3, 	   0,   -7
+.2byte    0,  -11, 	   8,   -4, 	  -8,   -6, 	   0,   -7
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte  -11,   -5, 	  -8,  -12, 	  -8,   -2, 	  -2,   -8
+.2byte   -7,   -6, 	   2,  -11, 	 -10,   -5, 	   1,   -8
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte  -10,   -1, 	 -12,   -6, 	  -3,    0, 	  -1,   -8
+.2byte  -11,   -2, 	  -4,   -6, 	  -8,    0, 	  -2,   -7
+.2byte   -8,    1, 	 -11,    0, 	  -1,    2, 	  -1,   -8
+.2byte   -7,    2, 	 -12,    1, 	   1,    1, 	  -1,   -7
+.2byte   -8,    2, 	 -10,   -3, 	  -3,    5, 	   0,   -7
+.2byte    0,   -2, 	  -8,   -2, 	   8,   -2, 	   0,  -10
+.2byte    0,    3, 	  -7,    2, 	   7,    2, 	   0,   -8
+.2byte   -1,    2, 	  -7,    0, 	   6,    3, 	  -1,   -8
+.2byte    7,   -3, 	  11,   -4, 	   2,   -1, 	   0,   -9
+.2byte    6,    2, 	  10,    0, 	  -1,    2, 	   0,   -7
+.2byte    7,    2, 	   9,   -3, 	   2,    5, 	  -1,   -7
+.2byte    9,   -5, 	   7,  -10, 	   5,   -2, 	  -2,   -9
+.2byte    9,    0, 	   4,   -5, 	   2,    0, 	  -1,   -7
+.2byte   10,   -2, 	   3,   -6, 	   7,    0, 	   1,   -7
+.2byte    8,  -10, 	   1,  -14, 	  10,   -9, 	  -1,  -10
+.2byte    7,   -3, 	  -3,   -7, 	   6,   -1, 	  -1,   -7
+.2byte    7,   -6, 	  -2,  -11, 	  10,   -5, 	  -1,   -8
+.2byte    0,  -14, 	   6,  -16, 	  -6,  -16, 	   0,   -9
+.2byte    0,  -10, 	   7,   -5, 	  -7,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -4, 	  -8,   -6, 	   0,   -7
+.2byte   -9,   -9, 	  -2,  -13, 	 -11,   -8, 	   0,   -9
+.2byte   -9,   -3, 	   1,   -7, 	  -8,   -1, 	  -1,   -7
+.2byte   -7,   -6, 	   2,  -11, 	 -10,   -5, 	   1,   -8
+.2byte  -10,   -5, 	  -8,  -10, 	  -6,   -2, 	   1,   -9
+.2byte  -10,    0, 	  -5,   -5, 	  -3,    0, 	   0,   -7
+.2byte  -11,   -2, 	  -4,   -6, 	  -8,    0, 	  -2,   -7
+.2byte   -8,   -3, 	 -12,   -4, 	  -3,   -1, 	  -1,   -9
+.2byte   -7,    2, 	 -11,    0, 	   0,    2, 	  -1,   -7
+.2byte   -8,    2, 	 -10,   -3, 	  -3,    5, 	   0,   -7
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte    1,    2, 	  -6,    3, 	   7,    0, 	   1,   -8
+.2byte   -1,    2, 	  -7,    0, 	   6,    3, 	  -1,   -8
+.2byte    0,   -2, 	  -8,   -2, 	   8,   -2, 	   0,  -10
+.2byte    0,    2, 	  -7,    1, 	   7,    1, 	   0,   -9
+.2byte    7,    1, 	  10,    0, 	   0,    2, 	   0,   -8
+.2byte    6,    2, 	  11,    1, 	  -2,    1, 	   0,   -7
+.2byte    7,    2, 	   9,   -3, 	   2,    5, 	  -1,   -7
+.2byte    7,   -3, 	  11,   -4, 	   2,   -1, 	   0,   -9
+.2byte    5,    2, 	   9,    0, 	  -2,    2, 	  -1,   -7
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte    9,   -1, 	  11,   -6, 	   2,    0, 	   0,   -8
+.2byte   10,   -2, 	   3,   -6, 	   7,    0, 	   1,   -7
+.2byte    9,   -5, 	   7,  -10, 	   5,   -2, 	  -2,   -9
+.2byte    9,    0, 	   4,   -5, 	   2,    0, 	  -1,   -7
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    9,   -5, 	   6,  -12, 	   6,   -2, 	   0,   -8
+.2byte    7,   -6, 	  -2,  -11, 	  10,   -5, 	  -1,   -8
+.2byte    8,  -11, 	   1,  -15, 	  10,  -10, 	  -1,  -11
+.2byte    8,   -5, 	  -2,   -9, 	   7,   -3, 	   0,   -9
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -11, 	   8,   -6, 	  -8,   -3, 	   0,   -7
+.2byte    0,  -11, 	   8,   -4, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -14, 	   6,  -16, 	  -6,  -16, 	   0,   -9
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -7, 	   0,  -10
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte  -11,   -5, 	  -8,  -12, 	  -8,   -2, 	  -2,   -8
+.2byte   -7,   -6, 	   2,  -11, 	 -10,   -5, 	   1,   -8
+.2byte   -9,  -11, 	  -2,  -15, 	 -11,  -10, 	   0,  -11
+.2byte   -9,   -5, 	   1,   -9, 	  -8,   -3, 	  -1,   -9
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte  -10,   -1, 	 -12,   -6, 	  -3,    0, 	  -1,   -8
+.2byte  -11,   -2, 	  -4,   -6, 	  -8,    0, 	  -2,   -7
+.2byte  -10,   -5, 	  -8,  -10, 	  -6,   -2, 	   1,   -9
+.2byte  -10,    0, 	  -5,   -5, 	  -3,    0, 	   0,   -7
+.2byte   -8,    1, 	 -11,    0, 	  -1,    2, 	  -1,   -8
+.2byte   -7,    2, 	 -12,    1, 	   1,    1, 	  -1,   -7
+.2byte   -8,    2, 	 -10,   -3, 	  -3,    5, 	   0,   -7
+.2byte   -8,   -3, 	 -12,   -4, 	  -3,   -1, 	  -1,   -9
+.2byte   -6,    2, 	 -10,    0, 	   1,    2, 	   0,   -7
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte    0,    2, 	  -7,    1, 	   7,    1, 	   0,   -9
+.2byte    0,    1, 	  -7,    1, 	   7,    1, 	   0,   -8
+.2byte    7,    1, 	  10,    0, 	   0,    2, 	   0,   -8
+.2byte    5,    2, 	   9,    0, 	  -2,    2, 	  -1,   -7
+.2byte    5,   -1, 	   9,    0, 	  -2,    2, 	   0,   -8
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte    9,    0, 	   4,   -5, 	   2,    0, 	  -1,   -7
+.2byte   10,   -3, 	   5,   -5, 	   2,    0, 	  -1,   -8
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    8,   -5, 	  -2,   -9, 	   7,   -3, 	   0,   -9
+.2byte    9,  -10, 	  -4,  -10, 	   7,   -3, 	   1,  -10
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -7, 	   0,  -10
+.2byte    0,  -17, 	   7,  -10, 	  -7,  -10, 	   0,  -11
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte   -9,   -5, 	   1,   -9, 	  -8,   -3, 	  -1,   -9
+.2byte  -10,  -10, 	   3,  -10, 	  -8,   -3, 	  -2,  -10
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte  -10,    0, 	  -5,   -5, 	  -3,    0, 	   0,   -7
+.2byte  -11,   -3, 	  -6,   -5, 	  -3,    0, 	   0,   -8
+.2byte   -8,    1, 	 -11,    0, 	  -1,    2, 	  -1,   -8
+.2byte   -6,    2, 	 -10,    0, 	   1,    2, 	   0,   -7
+.2byte   -6,   -1, 	 -10,    0, 	   1,    2, 	  -1,   -8
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte   -7,    0, 	 -10,   -1, 	   0,    1, 	   0,   -9
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte    6,    0, 	   9,   -1, 	  -1,    1, 	  -1,   -9
+.2byte   -6,    3, 	 -10,    0, 	  -1,    2, 	  -1,   -8
+.2byte   -6,    3, 	 -10,    0, 	  -1,    2, 	   0,   -7
+.2byte    0,    4, 	  -5,   -5, 	   5,   -5, 	   0,   -7
+.2byte    6,    3, 	  11,   -6, 	   2,   -5, 	  -1,   -6
+.2byte   10,    1, 	   9,   -9, 	   7,   -7, 	  -1,   -7
+.2byte    7,   -4, 	   2,  -13, 	   6,  -10, 	  -1,   -6
+.2byte    0,   -6, 	   4,  -11, 	  -4,  -11, 	   0,   -5
+.2byte   -8,   -4, 	  -3,  -13, 	  -7,  -10, 	   0,   -6
+.2byte  -11,    1, 	 -10,   -9, 	  -8,   -7, 	   0,   -7
+.2byte   -7,    3, 	 -12,   -6, 	  -3,   -5, 	   0,   -6
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte   -7,    0, 	 -10,   -1, 	   0,    1, 	   0,   -9
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte    6,    0, 	   9,   -1, 	  -1,    1, 	  -1,   -9
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte    0,    2, 	  -7,    1, 	   7,    1, 	   0,   -9
+.2byte   -1,    2, 	  -7,    0, 	   6,    3, 	  -1,   -8
+.2byte    7,    1, 	  10,    0, 	   0,    2, 	   0,   -8
+.2byte    6,    2, 	  10,    0, 	  -1,    2, 	   0,   -7
+.2byte    5,    2, 	  10,    1, 	  -3,    1, 	  -1,   -7
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte   10,    0, 	   5,   -5, 	   3,    0, 	   0,   -7
+.2byte   10,   -2, 	   3,   -6, 	   7,    0, 	   1,   -7
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    8,   -5, 	  -2,   -9, 	   7,   -3, 	   0,   -9
+.2byte    7,   -6, 	  -2,  -11, 	  10,   -5, 	  -1,   -8
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -7, 	   0,  -10
+.2byte    0,  -11, 	   8,   -4, 	  -8,   -6, 	   0,   -7
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte  -10,   -5, 	   0,   -9, 	  -9,   -3, 	  -2,   -9
+.2byte   -7,   -6, 	   2,  -11, 	 -10,   -5, 	   1,   -8
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte  -11,    0, 	  -6,   -5, 	  -4,    0, 	  -1,   -7
+.2byte  -11,   -2, 	  -4,   -6, 	  -8,    0, 	  -2,   -7
+.2byte   -8,    1, 	 -11,    0, 	  -1,    2, 	  -1,   -8
+.2byte   -7,    2, 	 -11,    0, 	   0,    2, 	  -1,   -7
+.2byte   -7,    1, 	 -12,    0, 	   1,    0, 	  -1,   -8
+.2byte    0,    1, 	  -7,    1, 	   7,    1, 	   0,   -8
+.2byte   -6,   -1, 	 -10,    0, 	   1,    2, 	  -1,   -8
+.2byte  -11,   -3, 	  -6,   -5, 	  -3,    0, 	   0,   -8
+.2byte  -10,   -7, 	   3,   -7, 	  -8,    0, 	  -2,   -7
+.2byte    0,  -14, 	   7,   -7, 	  -7,   -7, 	   0,   -8
+.2byte    9,   -7, 	  -4,   -7, 	   7,    0, 	   1,   -7
+.2byte   10,   -3, 	   5,   -5, 	   2,    0, 	  -1,   -8
+.2byte    5,   -1, 	   9,    0, 	  -2,    2, 	   0,   -8
+.2byte    0,    1, 	  -7,    1, 	   7,    1, 	   0,   -8
+.2byte    5,   -1, 	   9,    0, 	  -2,    2, 	   0,   -8
+.2byte   10,   -3, 	   5,   -5, 	   2,    0, 	  -1,   -8
+.2byte    9,   -7, 	  -4,   -7, 	   7,    0, 	   1,   -7
+.2byte    0,  -14, 	   7,   -7, 	  -7,   -7, 	   0,   -8
+.2byte  -10,   -7, 	   3,   -7, 	  -8,    0, 	  -2,   -7
+.2byte  -11,   -3, 	  -6,   -5, 	  -3,    0, 	   0,   -8
+.2byte   -6,   -1, 	 -10,    0, 	   1,    2, 	  -1,   -8
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte    0,   -2, 	  -8,   -2, 	   8,   -2, 	   0,  -10
+.2byte    0,    2, 	  -7,    1, 	   7,    1, 	   0,   -9
+.2byte    7,    1, 	  10,    0, 	   0,    2, 	   0,   -8
+.2byte    7,   -3, 	  11,   -4, 	   2,   -1, 	   0,   -9
+.2byte    5,    2, 	   9,    0, 	  -2,    2, 	  -1,   -7
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte    9,   -5, 	   7,  -10, 	   5,   -2, 	  -2,   -9
+.2byte    9,    0, 	   4,   -5, 	   2,    0, 	  -1,   -7
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    8,  -11, 	   1,  -15, 	  10,  -10, 	  -1,  -11
+.2byte    8,   -5, 	  -2,   -9, 	   7,   -3, 	   0,   -9
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    0,  -14, 	   6,  -16, 	  -6,  -16, 	   0,   -9
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -7, 	   0,  -10
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte   -9,  -11, 	  -2,  -15, 	 -11,  -10, 	   0,  -11
+.2byte   -9,   -5, 	   1,   -9, 	  -8,   -3, 	  -1,   -9
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte  -10,   -5, 	  -8,  -10, 	  -6,   -2, 	   1,   -9
+.2byte  -10,    0, 	  -5,   -5, 	  -3,    0, 	   0,   -7
+.2byte   -8,    1, 	 -11,    0, 	  -1,    2, 	  -1,   -8
+.2byte   -8,   -3, 	 -12,   -4, 	  -3,   -1, 	  -1,   -9
+.2byte   -6,    2, 	 -10,    0, 	   1,    2, 	   0,   -7
+.2byte    0,    2, 	  -7,    1, 	   7,    1, 	   0,   -9
+.2byte   -6,    2, 	 -10,    0, 	   1,    2, 	   0,   -7
+.2byte  -10,    0, 	  -5,   -5, 	  -3,    0, 	   0,   -7
+.2byte   -9,   -4, 	   1,   -8, 	  -8,   -2, 	  -1,   -8
+.2byte    0,  -12, 	   7,   -7, 	  -7,   -7, 	   0,  -10
+.2byte    8,   -4, 	  -2,   -8, 	   7,   -2, 	   0,   -8
+.2byte    9,    0, 	   4,   -5, 	   2,    0, 	  -1,   -7
+.2byte    5,    2, 	   9,    0, 	  -2,    2, 	  -1,   -7
+.2byte    0,    1, 	  -6,    1, 	   6,    1, 	   0,   -8
+.2byte   -7,    0, 	 -10,   -1, 	   0,    1, 	   0,   -9
+.2byte  -10,   -2, 	  -7,   -8, 	  -5,    0, 	   0,   -8
+.2byte   -9,   -7, 	   1,  -11, 	  -9,   -4, 	   0,   -9
+.2byte    0,  -11, 	   8,   -5, 	  -8,   -5, 	   0,   -8
+.2byte    8,   -7, 	  -2,  -11, 	   8,   -4, 	  -1,   -9
+.2byte    9,   -2, 	   6,   -8, 	   4,    0, 	  -1,   -8
+.2byte    6,    0, 	   9,   -1, 	  -1,    1, 	  -1,   -9
+sRhyhornAnimTable1:
+.4byte sRhyhornAnims_1_1
+.4byte sRhyhornAnims_1_2
+.4byte sRhyhornAnims_1_3
+.4byte sRhyhornAnims_1_4
+.4byte sRhyhornAnims_1_5
+.4byte sRhyhornAnims_1_6
+.4byte sRhyhornAnims_1_7
+.4byte sRhyhornAnims_1_8
+sRhyhornAnimTable2:
+.4byte sRhyhornAnims_2_1
+.4byte sRhyhornAnims_2_2
+.4byte sRhyhornAnims_2_3
+.4byte sRhyhornAnims_2_4
+.4byte sRhyhornAnims_2_5
+.4byte sRhyhornAnims_2_6
+.4byte sRhyhornAnims_2_7
+.4byte sRhyhornAnims_2_8
+sRhyhornAnimTable3:
+.4byte sRhyhornAnims_3_1
+.4byte sRhyhornAnims_3_2
+.4byte sRhyhornAnims_3_3
+.4byte sRhyhornAnims_3_4
+.4byte sRhyhornAnims_3_5
+.4byte sRhyhornAnims_3_6
+.4byte sRhyhornAnims_3_7
+.4byte sRhyhornAnims_3_8
+sRhyhornAnimTable4:
+.4byte sRhyhornAnims_4_1
+.4byte sRhyhornAnims_4_2
+.4byte sRhyhornAnims_4_3
+.4byte sRhyhornAnims_4_4
+.4byte sRhyhornAnims_4_5
+.4byte sRhyhornAnims_4_6
+.4byte sRhyhornAnims_4_7
+.4byte sRhyhornAnims_4_8
+sRhyhornAnimTable5:
+.4byte sRhyhornAnims_5_1
+.4byte sRhyhornAnims_5_2
+.4byte sRhyhornAnims_5_3
+.4byte sRhyhornAnims_5_4
+.4byte sRhyhornAnims_5_5
+.4byte sRhyhornAnims_5_6
+.4byte sRhyhornAnims_5_7
+.4byte sRhyhornAnims_5_8
+sRhyhornAnimTable6:
+.4byte sRhyhornAnims_6_1
+.4byte sRhyhornAnims_6_1
+.4byte sRhyhornAnims_6_1
+.4byte sRhyhornAnims_6_1
+.4byte sRhyhornAnims_6_1
+.4byte sRhyhornAnims_6_1
+.4byte sRhyhornAnims_6_1
+.4byte sRhyhornAnims_6_1
+sRhyhornAnimTable7:
+.4byte sRhyhornAnims_7_1
+.4byte sRhyhornAnims_7_2
+.4byte sRhyhornAnims_7_3
+.4byte sRhyhornAnims_7_4
+.4byte sRhyhornAnims_7_5
+.4byte sRhyhornAnims_7_6
+.4byte sRhyhornAnims_7_7
+.4byte sRhyhornAnims_7_8
+sRhyhornAnimTable8:
+.4byte sRhyhornAnims_8_1
+.4byte sRhyhornAnims_8_2
+.4byte sRhyhornAnims_8_3
+.4byte sRhyhornAnims_8_4
+.4byte sRhyhornAnims_8_5
+.4byte sRhyhornAnims_8_6
+.4byte sRhyhornAnims_8_7
+.4byte sRhyhornAnims_8_8
+sRhyhornAnimTable9:
+.4byte sRhyhornAnims_9_1
+.4byte sRhyhornAnims_9_2
+.4byte sRhyhornAnims_9_3
+.4byte sRhyhornAnims_9_4
+.4byte sRhyhornAnims_9_5
+.4byte sRhyhornAnims_9_6
+.4byte sRhyhornAnims_9_7
+.4byte sRhyhornAnims_9_8
+sRhyhornAnimTable10:
+.4byte sRhyhornAnims_10_1
+.4byte sRhyhornAnims_10_2
+.4byte sRhyhornAnims_10_3
+.4byte sRhyhornAnims_10_4
+.4byte sRhyhornAnims_10_5
+.4byte sRhyhornAnims_10_6
+.4byte sRhyhornAnims_10_7
+.4byte sRhyhornAnims_10_8
+sRhyhornAnimTable11:
+.4byte sRhyhornAnims_11_1
+.4byte sRhyhornAnims_11_2
+.4byte sRhyhornAnims_11_3
+.4byte sRhyhornAnims_11_4
+.4byte sRhyhornAnims_11_5
+.4byte sRhyhornAnims_11_6
+.4byte sRhyhornAnims_11_7
+.4byte sRhyhornAnims_11_8
+sRhyhornAnimTable12:
+.4byte sRhyhornAnims_12_1
+.4byte sRhyhornAnims_12_2
+.4byte sRhyhornAnims_12_3
+.4byte sRhyhornAnims_12_4
+.4byte sRhyhornAnims_12_5
+.4byte sRhyhornAnims_12_6
+.4byte sRhyhornAnims_12_7
+.4byte sRhyhornAnims_12_8
+sRhyhornAnimTable13:
+.4byte sRhyhornAnims_13_1
+.4byte sRhyhornAnims_13_2
+.4byte sRhyhornAnims_13_3
+.4byte sRhyhornAnims_13_4
+.4byte sRhyhornAnims_13_5
+.4byte sRhyhornAnims_13_6
+.4byte sRhyhornAnims_13_7
+.4byte sRhyhornAnims_13_8
+sAxAnimationsRhyhorn:
+.4byte sRhyhornAnimTable1
+.4byte sRhyhornAnimTable2
+.4byte sRhyhornAnimTable3
+.4byte sRhyhornAnimTable4
+.4byte sRhyhornAnimTable5
+.4byte sRhyhornAnimTable6
+.4byte sRhyhornAnimTable7
+.4byte sRhyhornAnimTable8
+.4byte sRhyhornAnimTable9
+.4byte sRhyhornAnimTable10
+.4byte sRhyhornAnimTable11
+.4byte sRhyhornAnimTable12
+.4byte sRhyhornAnimTable13
+sAxSpritesRhyhorn:
+.4byte sRhyhornSprites1
+.4byte sRhyhornSprites2
+.4byte sRhyhornSprites3
+.4byte sRhyhornSprites4
+.4byte sRhyhornSprites5
+.4byte sRhyhornSprites6
+.4byte sRhyhornSprites7
+.4byte sRhyhornSprites8
+.4byte sRhyhornSprites9
+.4byte sRhyhornSprites10
+.4byte sRhyhornSprites11
+.4byte sRhyhornSprites12
+.4byte sRhyhornSprites13
+.4byte sRhyhornSprites14
+.4byte sRhyhornSprites15
+.4byte sRhyhornSprites16
+.4byte sRhyhornSprites17
+.4byte sRhyhornSprites18
+.4byte sRhyhornSprites19
+.4byte sRhyhornSprites20
+.4byte sRhyhornSprites21
+.4byte sRhyhornSprites22
+.4byte sRhyhornSprites23
+.4byte sRhyhornSprites24
+.4byte sRhyhornSprites25
+.4byte sRhyhornSprites26
+.4byte sRhyhornSprites27
+.4byte sRhyhornSprites28
+.4byte sRhyhornSprites29
+.4byte sRhyhornSprites30
+.4byte sRhyhornSprites31
+.4byte sRhyhornSprites32
+.4byte sRhyhornSprites33
+.4byte sRhyhornSprites34
+.4byte sRhyhornSprites35
+.4byte sRhyhornSprites36
+.4byte sRhyhornSprites37
+sAxMainRhyhorn:
+ax_main sAxPosesRhyhorn, sAxAnimationsRhyhorn, 13, sAxSpritesRhyhorn, sAxPositionsRhyhorn

--- a/data/ax/roselia.inc
+++ b/data/ax/roselia.inc
@@ -1,0 +1,2750 @@
+.global gAxRoselia
+gAxRoselia:
+ax_siro sAxMainRoselia
+sRoseliaPose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose3:
+ax_pose 2, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose4:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose5:
+ax_pose 4, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose6:
+ax_pose 5, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose7:
+ax_pose 6, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose8:
+ax_pose 7, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose9:
+ax_pose 8, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose10:
+ax_pose 9, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose11:
+ax_pose 10, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose12:
+ax_pose 11, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose16:
+ax_pose 15, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose17:
+ax_pose 16, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose18:
+ax_pose 17, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose19:
+ax_pose 18, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose20:
+ax_pose 19, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose21:
+ax_pose 20, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose22:
+ax_pose 21, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose23:
+ax_pose 22, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose24:
+ax_pose 23, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose25:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose26:
+ax_pose 24, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose27:
+ax_pose 25, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose28:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose29:
+ax_pose 26, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose30:
+ax_pose 27, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose31:
+ax_pose 6, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose32:
+ax_pose 28, 0x81e6, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose33:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose34:
+ax_pose 9, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose35:
+ax_pose 30, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose36:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose37:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose38:
+ax_pose 32, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose39:
+ax_pose 33, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose40:
+ax_pose 15, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose41:
+ax_pose 34, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose42:
+ax_pose 35, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose43:
+ax_pose 18, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose44:
+ax_pose 36, 0x81e6, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose45:
+ax_pose 37, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose46:
+ax_pose 21, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose47:
+ax_pose 38, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose48:
+ax_pose 39, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose49:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose50:
+ax_pose 24, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose51:
+ax_pose 25, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose52:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose53:
+ax_pose 26, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose54:
+ax_pose 27, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose55:
+ax_pose 6, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose56:
+ax_pose 28, 0x81e6, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose57:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose58:
+ax_pose 9, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose59:
+ax_pose 30, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose60:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose61:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose62:
+ax_pose 32, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose63:
+ax_pose 33, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose64:
+ax_pose 15, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose65:
+ax_pose 34, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose66:
+ax_pose 35, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose67:
+ax_pose 18, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose68:
+ax_pose 36, 0x81e6, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose69:
+ax_pose 37, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose70:
+ax_pose 21, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose71:
+ax_pose 38, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose72:
+ax_pose 39, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose73:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose74:
+ax_pose 25, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose75:
+ax_pose 40, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose76:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose77:
+ax_pose 27, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose78:
+ax_pose 41, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose79:
+ax_pose 6, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose80:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose81:
+ax_pose 42, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose82:
+ax_pose 9, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose83:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose84:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose85:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose86:
+ax_pose 33, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose87:
+ax_pose 44, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose88:
+ax_pose 15, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose89:
+ax_pose 35, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose90:
+ax_pose 45, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose91:
+ax_pose 18, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose92:
+ax_pose 37, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose93:
+ax_pose 46, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose94:
+ax_pose 21, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose95:
+ax_pose 39, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose96:
+ax_pose 47, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose97:
+ax_pose 40, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose98:
+ax_pose 41, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose99:
+ax_pose 42, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose100:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose101:
+ax_pose 44, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose102:
+ax_pose 45, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose103:
+ax_pose 46, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose104:
+ax_pose 47, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose105:
+ax_pose 48, 0x01f0, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose106:
+ax_pose 49, 0x01f0, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose107:
+ax_pose 50, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose108:
+ax_pose 51, 0x01e3, 0x80ee, 0x3c00
+ax_pose_terminator
+sRoseliaPose109:
+ax_pose 52, 0x01e4, 0x80ec, 0x3c00
+ax_pose_terminator
+sRoseliaPose110:
+ax_pose 53, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sRoseliaPose111:
+ax_pose 54, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose112:
+ax_pose 55, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose113:
+ax_pose 56, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sRoseliaPose114:
+ax_pose 57, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sRoseliaPose115:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose116:
+ax_pose 21, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose117:
+ax_pose 18, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose118:
+ax_pose 15, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose119:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose120:
+ax_pose 9, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose121:
+ax_pose 6, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose122:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose123:
+ax_pose 2, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose124:
+ax_pose 23, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose125:
+ax_pose 20, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose126:
+ax_pose 17, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose127:
+ax_pose 14, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose128:
+ax_pose 11, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose129:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose130:
+ax_pose 5, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose131:
+ax_pose 40, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose132:
+ax_pose 47, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose133:
+ax_pose 46, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose134:
+ax_pose 45, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose135:
+ax_pose 44, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose136:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose137:
+ax_pose 42, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose138:
+ax_pose 41, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose139:
+ax_pose 40, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose140:
+ax_pose 41, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose141:
+ax_pose 42, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose142:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose143:
+ax_pose 44, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose144:
+ax_pose 45, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose145:
+ax_pose 46, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose146:
+ax_pose 47, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose147:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose148:
+ax_pose 40, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose149:
+ax_pose 24, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose150:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose151:
+ax_pose 41, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose152:
+ax_pose 26, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose153:
+ax_pose 6, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose154:
+ax_pose 42, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose155:
+ax_pose 28, 0x81e8, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose156:
+ax_pose 9, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose157:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose158:
+ax_pose 30, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose159:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose160:
+ax_pose 44, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose161:
+ax_pose 32, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose162:
+ax_pose 15, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose163:
+ax_pose 45, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose164:
+ax_pose 34, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose165:
+ax_pose 18, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose166:
+ax_pose 46, 0x81e5, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose167:
+ax_pose 36, 0x81e8, 0x80f8, 0x3c00
+ax_pose_terminator
+sRoseliaPose168:
+ax_pose 21, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose169:
+ax_pose 47, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose170:
+ax_pose 38, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose171:
+ax_pose 25, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose172:
+ax_pose 39, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose173:
+ax_pose 37, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose174:
+ax_pose 35, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose175:
+ax_pose 33, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose176:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose177:
+ax_pose 29, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose178:
+ax_pose 27, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose179:
+ax_pose 0, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose180:
+ax_pose 21, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose181:
+ax_pose 18, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose182:
+ax_pose 15, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sRoseliaPose183:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sRoseliaPose184:
+ax_pose 9, 0x01ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sRoseliaPose185:
+ax_pose 6, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sRoseliaPose186:
+ax_pose 3, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+.align 2
+sRoseliaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -4, 0, 0,
+ax_anim 2, 0, 25, 0, 2, 0, 6,
+ax_anim 2, 2, 25, 0, 10, 0, 12,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sRoseliaAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 4, -1, 4, 4,
+ax_anim 2, 0, 28, 12, 6, 12, 12,
+ax_anim 2, 2, 28, 15, 12, 15, 15,
+ax_anim 2, 0, 29, 18, 19, 18, 18,
+ax_anim 2, 1, 29, 19, 18, 19, 17,
+ax_anim 2, 0, 29, 18, 19, 18, 18,
+ax_anim 2, 0, 29, 19, 18, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sRoseliaAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 1, -2, 1, 0,
+ax_anim 2, 0, 31, 8, -5, 8, 0,
+ax_anim 2, 2, 31, 15, -5, 15, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sRoseliaAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 2, -5, 2, -2,
+ax_anim 2, 0, 34, 6, -13, 6, -6,
+ax_anim 2, 2, 34, 11, -18, 11, -11,
+ax_anim 2, 0, 35, 18, -22, 18, -18,
+ax_anim 2, 1, 35, 19, -21, 19, -17,
+ax_anim 2, 0, 35, 18, -22, 18, -18,
+ax_anim 2, 0, 35, 19, -21, 19, -17,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sRoseliaAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, -4, 0, -1,
+ax_anim 2, 0, 37, 0, -11, 0, -6,
+ax_anim 2, 2, 37, 0, -17, 0, -13,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 1, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 0, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sRoseliaAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, -2, -5, -2, -2,
+ax_anim 2, 0, 40, -6, -13, -6, -6,
+ax_anim 2, 2, 40, -11, -18, -11, -11,
+ax_anim 2, 0, 41, -18, -22, -18, -18,
+ax_anim 2, 1, 41, -19, -21, -19, -17,
+ax_anim 2, 0, 41, -18, -22, -18, -18,
+ax_anim 2, 0, 41, -19, -21, -19, -17,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sRoseliaAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, -1, -2, -1, 0,
+ax_anim 2, 0, 43, -8, -5, -8, 0,
+ax_anim 2, 2, 43, -15, -5, -15, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sRoseliaAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, -4, -1, -4, 4,
+ax_anim 2, 0, 46, -12, 6, -12, 14,
+ax_anim 2, 2, 46, -15, 12, -15, 17,
+ax_anim 2, 0, 47, -18, 19, -18, 18,
+ax_anim 2, 1, 47, -19, 18, -19, 17,
+ax_anim 2, 0, 47, -18, 19, -18, 18,
+ax_anim 2, 0, 47, -19, 18, -19, 17,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 49, 0, 2, 0, 6,
+ax_anim 2, 2, 49, 0, 10, 0, 12,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sRoseliaAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 4, -1, 4, 4,
+ax_anim 2, 0, 52, 12, 6, 12, 12,
+ax_anim 2, 2, 52, 15, 12, 15, 15,
+ax_anim 2, 0, 53, 18, 19, 18, 18,
+ax_anim 2, 1, 53, 19, 18, 19, 17,
+ax_anim 2, 0, 53, 18, 19, 18, 18,
+ax_anim 2, 0, 53, 19, 18, 19, 17,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sRoseliaAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 1, -2, 1, 0,
+ax_anim 2, 0, 55, 8, -5, 8, 0,
+ax_anim 2, 2, 55, 15, -5, 15, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sRoseliaAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 2, -5, 2, -2,
+ax_anim 2, 0, 58, 6, -13, 6, -6,
+ax_anim 2, 2, 58, 11, -18, 11, -11,
+ax_anim 2, 0, 59, 18, -22, 18, -18,
+ax_anim 2, 1, 59, 19, -21, 19, -17,
+ax_anim 2, 0, 59, 18, -22, 18, -18,
+ax_anim 2, 0, 59, 19, -21, 19, -17,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sRoseliaAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, -4, 0, -1,
+ax_anim 2, 0, 61, 0, -11, 0, -6,
+ax_anim 2, 2, 61, 0, -17, 0, -13,
+ax_anim 2, 0, 62, 0, -22, 0, -22,
+ax_anim 2, 1, 62, 1, -22, 1, -22,
+ax_anim 2, 0, 62, 0, -22, 0, -22,
+ax_anim 2, 0, 62, 1, -22, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sRoseliaAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, -2, -5, -2, -2,
+ax_anim 2, 0, 64, -6, -13, -6, -6,
+ax_anim 2, 2, 64, -11, -18, -11, -11,
+ax_anim 2, 0, 65, -18, -22, -18, -18,
+ax_anim 2, 1, 65, -19, -21, -19, -17,
+ax_anim 2, 0, 65, -18, -22, -18, -18,
+ax_anim 2, 0, 65, -19, -21, -19, -17,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sRoseliaAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, -1, -2, -1, 0,
+ax_anim 2, 0, 67, -8, -5, -8, 0,
+ax_anim 2, 2, 67, -15, -5, -15, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sRoseliaAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, -4, -1, -4, 4,
+ax_anim 2, 0, 70, -12, 6, -12, 14,
+ax_anim 2, 2, 70, -15, 12, -15, 17,
+ax_anim 2, 0, 71, -18, 19, -18, 18,
+ax_anim 2, 1, 71, -19, 18, -19, 17,
+ax_anim 2, 0, 71, -18, 19, -18, 18,
+ax_anim 2, 0, 71, -19, 18, -19, 17,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_4_1:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 8, 2, 73, 0, 3, 0, 3,
+ax_anim 1, 1, 73, 0, -9, 0, -9,
+ax_anim 1, 0, 73, 0, -12, 0, -12,
+ax_anim 4, 0, 73, 0, -13, 0, -13,
+ax_anim 3, 0, 73, 0, -12, 0, -12,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim_terminator
+sRoseliaAnims_4_2:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 8, 2, 76, 3, 3, 3, 3,
+ax_anim 1, 1, 76, -9, -9, -9, -9,
+ax_anim 1, 0, 76, -12, -12, -12, -12,
+ax_anim 4, 0, 76, -13, -13, -13, -13,
+ax_anim 3, 0, 76, -12, -12, -12, -12,
+ax_anim 2, 0, 75, -6, -6, -6, -6,
+ax_anim 2, 0, 75, -2, -2, -2, -2,
+ax_anim_terminator
+sRoseliaAnims_4_3:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 79, 3, 0, 3, 0,
+ax_anim 8, 2, 79, 3, 0, 3, 0,
+ax_anim 1, 1, 79, -9, 0, -9, 0,
+ax_anim 1, 0, 79, -12, 0, -12, 0,
+ax_anim 4, 0, 79, -13, 0, -13, 0,
+ax_anim 3, 0, 79, -12, 0, -12, 0,
+ax_anim 2, 0, 78, -6, 0, -6, 0,
+ax_anim 2, 0, 78, -2, 0, -2, 0,
+ax_anim_terminator
+sRoseliaAnims_4_4:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 82, 3, -3, 3, -3,
+ax_anim 8, 2, 82, 3, -3, 3, -3,
+ax_anim 1, 1, 82, -9, 9, -9, 9,
+ax_anim 1, 0, 82, -12, 12, -12, 12,
+ax_anim 4, 0, 82, -13, 13, -13, 13,
+ax_anim 3, 0, 82, -12, 12, -12, 12,
+ax_anim 2, 0, 81, -6, 6, -6, 6,
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim_terminator
+sRoseliaAnims_4_5:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, -2,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 8, 2, 85, 0, -3, 0, -3,
+ax_anim 1, 1, 85, 0, 9, 0, 9,
+ax_anim 1, 0, 85, 0, 12, 0, 12,
+ax_anim 4, 0, 85, 0, 13, 0, 13,
+ax_anim 3, 0, 85, 0, 12, 0, 12,
+ax_anim 2, 0, 84, 0, 6, 0, 6,
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim_terminator
+sRoseliaAnims_4_6:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 88, -3, -3, -3, -3,
+ax_anim 8, 2, 88, -3, -3, -3, -3,
+ax_anim 1, 1, 88, 9, 9, 9, 9,
+ax_anim 1, 0, 88, 12, 12, 12, 12,
+ax_anim 4, 0, 88, 13, 13, 13, 13,
+ax_anim 3, 0, 88, 12, 12, 12, 12,
+ax_anim 2, 0, 87, 6, 6, 6, 6,
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim_terminator
+sRoseliaAnims_4_7:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -3, 0, -3, 0,
+ax_anim 8, 2, 91, -3, 0, -3, 0,
+ax_anim 1, 1, 91, 9, 0, 9, 0,
+ax_anim 1, 0, 91, 12, 0, 12, 0,
+ax_anim 4, 0, 91, 13, 0, 13, 0,
+ax_anim 3, 0, 91, 12, 0, 12, 0,
+ax_anim 2, 0, 90, 6, 0, 6, 0,
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim_terminator
+sRoseliaAnims_4_8:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 94, -3, 3, -3, 3,
+ax_anim 8, 2, 94, -3, 3, -3, 3,
+ax_anim 1, 1, 94, 9, -9, 9, -9,
+ax_anim 1, 0, 94, 12, -12, 12, -12,
+ax_anim 4, 0, 94, 13, -13, 13, -13,
+ax_anim 3, 0, 94, 12, -12, 12, -12,
+ax_anim 2, 0, 93, 6, -6, 6, -6,
+ax_anim 2, 0, 93, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_5_1:
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 3, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 2, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_5_2:
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 2, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_5_3:
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 3, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 2, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_5_4:
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 3, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_5_5:
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 2, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 2, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_5_6:
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 2, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 2, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_5_7:
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 3, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 2, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_5_8:
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 3, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 2, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 2, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sRoseliaAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sRoseliaAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sRoseliaAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sRoseliaAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sRoseliaAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sRoseliaAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sRoseliaAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_8_1:
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_8_2:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 40, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_8_3:
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_8_4:
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 40, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_8_5:
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_8_6:
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 40, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_8_7:
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 40, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_8_8:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 40, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 3, 6, 3,
+ax_anim 2, 0, 132, 8, 9, 8, 9,
+ax_anim 2, 0, 133, 7, 17, 7, 17,
+ax_anim 3, 0, 134, 0, 21, 0, 21,
+ax_anim 2, 3, 135, -7, 17, -7, 17,
+ax_anim 2, 0, 136, -8, 9, -8, 9,
+ax_anim 1, 0, 137, -6, 3, -6, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 8, 0, 8, 0,
+ax_anim 2, 0, 131, 17, 3, 17, 3,
+ax_anim 2, 0, 132, 23, 11, 23, 11,
+ax_anim 3, 0, 133, 24, 20, 24, 20,
+ax_anim 2, 3, 134, 14, 21, 14, 21,
+ax_anim 2, 0, 135, 3, 15, 3, 15,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 4, -5, 4, -5,
+ax_anim 2, 0, 130, 11, -7, 11, -7,
+ax_anim 2, 0, 131, 20, -4, 20, -4,
+ax_anim 3, 0, 132, 25, 0, 25, 0,
+ax_anim 2, 3, 133, 21, 4, 21, 4,
+ax_anim 2, 0, 134, 12, 6, 12, 6,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 3, -18, 3, -18,
+ax_anim 2, 0, 130, 13, -23, 13, -23,
+ax_anim 3, 0, 131, 24, -22, 24, -22,
+ax_anim 2, 3, 132, 25, -13, 25, -13,
+ax_anim 2, 0, 133, 19, -4, 19, -4,
+ax_anim 1, 0, 134, 9, 0, 9, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -8, -4, -8, -4,
+ax_anim 2, 0, 136, -10, -12, -10, -12,
+ax_anim 2, 0, 137, -7, -20, -7, -20,
+ax_anim 3, 0, 130, 0, -22, 0, -22,
+ax_anim 2, 3, 131, 7, -20, 7, -20,
+ax_anim 2, 0, 132, 10, -12, 10, -12,
+ax_anim 1, 0, 133, 8, -4, 8, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -8, 1, -8,
+ax_anim 2, 0, 131, -3, -18, -3, -18,
+ax_anim 2, 0, 130, -13, -23, -13, -23,
+ax_anim 3, 0, 137, -24, -22, -24, -22,
+ax_anim 2, 3, 136, -25, -13, -25, -13,
+ax_anim 2, 0, 135, -19, -4, -19, -4,
+ax_anim 1, 0, 134, -9, 0, -9, 0,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -4, -5, -4, -5,
+ax_anim 2, 0, 130, -11, -7, -11, -7,
+ax_anim 2, 0, 137, -20, -4, -20, -4,
+ax_anim 3, 0, 136, -25, 0, -25, 0,
+ax_anim 2, 3, 135, -21, 4, -21, 4,
+ax_anim 2, 0, 134, -12, 6, -12, 6,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -8, 0, -8, 0,
+ax_anim 2, 0, 137, -17, 3, -17, 3,
+ax_anim 2, 0, 136, -23, 11, -23, 11,
+ax_anim 3, 0, 135, -24, 20, -24, 20,
+ax_anim 2, 3, 134, -14, 21, -14, 21,
+ax_anim 2, 0, 133, -3, 15, -3, 15,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -22, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 149, 0, -22, 0, 0,
+ax_anim 3, 0, 151, 0, -22, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -22, 0, 0,
+ax_anim 3, 0, 154, 0, -22, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 155, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -22, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 158, 0, -22, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -22, 0, 0,
+ax_anim 2, 0, 163, 0, -17, 0, 0,
+ax_anim 1, 0, 163, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -22, 0, 0,
+ax_anim 3, 0, 166, 0, -22, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -22, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sRoseliaAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sRoseliaGfx1:
+.incbin "baserom.gba", 0x12D4738, 0x200
+sRoseliaSprites1:
+ax_sprite sRoseliaGfx1, 0x200
+ax_sprite_terminator
+sRoseliaGfx2:
+.incbin "baserom.gba", 0x12D4948, 0x200
+sRoseliaSprites2:
+ax_sprite sRoseliaGfx2, 0x200
+ax_sprite_terminator
+sRoseliaGfx3:
+.incbin "baserom.gba", 0x12D4B58, 0x200
+sRoseliaSprites3:
+ax_sprite sRoseliaGfx3, 0x200
+ax_sprite_terminator
+sRoseliaGfx4:
+.incbin "baserom.gba", 0x12D4D68, 0x200
+sRoseliaSprites4:
+ax_sprite sRoseliaGfx4, 0x200
+ax_sprite_terminator
+sRoseliaGfx5:
+.incbin "baserom.gba", 0x12D4F78, 0x200
+sRoseliaSprites5:
+ax_sprite sRoseliaGfx5, 0x200
+ax_sprite_terminator
+sRoseliaGfx6:
+.incbin "baserom.gba", 0x12D5188, 0x200
+sRoseliaSprites6:
+ax_sprite sRoseliaGfx6, 0x200
+ax_sprite_terminator
+sRoseliaGfx7:
+.incbin "baserom.gba", 0x12D5398, 0x200
+sRoseliaSprites7:
+ax_sprite sRoseliaGfx7, 0x200
+ax_sprite_terminator
+sRoseliaGfx8:
+.incbin "baserom.gba", 0x12D55A8, 0x200
+sRoseliaSprites8:
+ax_sprite sRoseliaGfx8, 0x200
+ax_sprite_terminator
+sRoseliaGfx9:
+.incbin "baserom.gba", 0x12D57B8, 0x200
+sRoseliaSprites9:
+ax_sprite sRoseliaGfx9, 0x200
+ax_sprite_terminator
+sRoseliaGfx10:
+.incbin "baserom.gba", 0x12D59C8, 0x200
+sRoseliaSprites10:
+ax_sprite sRoseliaGfx10, 0x200
+ax_sprite_terminator
+sRoseliaGfx11:
+.incbin "baserom.gba", 0x12D5BD8, 0x200
+sRoseliaSprites11:
+ax_sprite sRoseliaGfx11, 0x200
+ax_sprite_terminator
+sRoseliaGfx12:
+.incbin "baserom.gba", 0x12D5DE8, 0x200
+sRoseliaSprites12:
+ax_sprite sRoseliaGfx12, 0x200
+ax_sprite_terminator
+sRoseliaGfx13:
+.incbin "baserom.gba", 0x12D5FF8, 0x200
+sRoseliaSprites13:
+ax_sprite sRoseliaGfx13, 0x200
+ax_sprite_terminator
+sRoseliaGfx14:
+.incbin "baserom.gba", 0x12D6208, 0x200
+sRoseliaSprites14:
+ax_sprite sRoseliaGfx14, 0x200
+ax_sprite_terminator
+sRoseliaGfx15:
+.incbin "baserom.gba", 0x12D6418, 0x200
+sRoseliaSprites15:
+ax_sprite sRoseliaGfx15, 0x200
+ax_sprite_terminator
+sRoseliaGfx16:
+.incbin "baserom.gba", 0x12D6628, 0x200
+sRoseliaSprites16:
+ax_sprite sRoseliaGfx16, 0x200
+ax_sprite_terminator
+sRoseliaGfx17:
+.incbin "baserom.gba", 0x12D6838, 0x200
+sRoseliaSprites17:
+ax_sprite sRoseliaGfx17, 0x200
+ax_sprite_terminator
+sRoseliaGfx18:
+.incbin "baserom.gba", 0x12D6A48, 0x200
+sRoseliaSprites18:
+ax_sprite sRoseliaGfx18, 0x200
+ax_sprite_terminator
+sRoseliaGfx19:
+.incbin "baserom.gba", 0x12D6C58, 0x200
+sRoseliaSprites19:
+ax_sprite sRoseliaGfx19, 0x200
+ax_sprite_terminator
+sRoseliaGfx20:
+.incbin "baserom.gba", 0x12D6E68, 0x200
+sRoseliaSprites20:
+ax_sprite sRoseliaGfx20, 0x200
+ax_sprite_terminator
+sRoseliaGfx21:
+.incbin "baserom.gba", 0x12D7078, 0x200
+sRoseliaSprites21:
+ax_sprite sRoseliaGfx21, 0x200
+ax_sprite_terminator
+sRoseliaGfx22:
+.incbin "baserom.gba", 0x12D7288, 0x200
+sRoseliaSprites22:
+ax_sprite sRoseliaGfx22, 0x200
+ax_sprite_terminator
+sRoseliaGfx23:
+.incbin "baserom.gba", 0x12D7498, 0x200
+sRoseliaSprites23:
+ax_sprite sRoseliaGfx23, 0x200
+ax_sprite_terminator
+sRoseliaGfx24:
+.incbin "baserom.gba", 0x12D76A8, 0x200
+sRoseliaSprites24:
+ax_sprite sRoseliaGfx24, 0x200
+ax_sprite_terminator
+sRoseliaGfx25:
+.incbin "baserom.gba", 0x12D78B8, 0x40
+sRoseliaGfx25_1:
+.incbin "baserom.gba", 0x12D78F8, 0x40
+sRoseliaGfx25_2:
+.incbin "baserom.gba", 0x12D7938, 0x100
+sRoseliaSprites25:
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx25_2, 0x100
+ax_sprite_terminator
+sRoseliaGfx26:
+.incbin "baserom.gba", 0x12D7A70, 0x40
+sRoseliaGfx26_1:
+.incbin "baserom.gba", 0x12D7AB0, 0x40
+sRoseliaGfx26_2:
+.incbin "baserom.gba", 0x12D7AF0, 0x80
+sRoseliaSprites26:
+ax_sprite 0, 0xa0
+ax_sprite sRoseliaGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx26_2, 0x80
+ax_sprite_terminator
+sRoseliaGfx27:
+.incbin "baserom.gba", 0x12D7BA8, 0x20
+sRoseliaGfx27_1:
+.incbin "baserom.gba", 0x12D7BC8, 0x40
+sRoseliaGfx27_2:
+.incbin "baserom.gba", 0x12D7C08, 0xE0
+sRoseliaSprites27:
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx27, 0x20
+ax_sprite 0, 0x60
+ax_sprite sRoseliaGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx27_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx28:
+.incbin "baserom.gba", 0x12D7D28, 0x40
+sRoseliaGfx28_1:
+.incbin "baserom.gba", 0x12D7D68, 0x60
+sRoseliaGfx28_2:
+.incbin "baserom.gba", 0x12D7DC8, 0x60
+sRoseliaSprites28:
+ax_sprite 0, 0xa0
+ax_sprite sRoseliaGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx28_2, 0x60
+ax_sprite_terminator
+sRoseliaGfx29:
+.incbin "baserom.gba", 0x12D7E60, 0x20
+sRoseliaGfx29_1:
+.incbin "baserom.gba", 0x12D7E80, 0xC0
+sRoseliaSprites29:
+ax_sprite sRoseliaGfx29, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx29_1, 0xc0
+ax_sprite_terminator
+sRoseliaGfx30:
+.incbin "baserom.gba", 0x12D7F60, 0x40
+sRoseliaGfx30_1:
+.incbin "baserom.gba", 0x12D7FA0, 0x60
+sRoseliaGfx30_2:
+.incbin "baserom.gba", 0x12D8000, 0x60
+sRoseliaSprites30:
+ax_sprite 0, 0xa0
+ax_sprite sRoseliaGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx30_2, 0x60
+ax_sprite_terminator
+sRoseliaGfx31:
+.incbin "baserom.gba", 0x12D8098, 0x20
+sRoseliaGfx31_1:
+.incbin "baserom.gba", 0x12D80B8, 0x40
+sRoseliaGfx31_2:
+.incbin "baserom.gba", 0x12D80F8, 0x80
+sRoseliaGfx31_3:
+.incbin "baserom.gba", 0x12D8178, 0x60
+sRoseliaSprites31:
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx31, 0x20
+ax_sprite 0, 0x60
+ax_sprite sRoseliaGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx31_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx31_3, 0x60
+ax_sprite_terminator
+sRoseliaGfx32:
+.incbin "baserom.gba", 0x12D8220, 0x60
+sRoseliaGfx32_1:
+.incbin "baserom.gba", 0x12D8280, 0x60
+sRoseliaGfx32_2:
+.incbin "baserom.gba", 0x12D82E0, 0x40
+sRoseliaSprites32:
+ax_sprite 0, 0xa0
+ax_sprite sRoseliaGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx33:
+.incbin "baserom.gba", 0x12D8360, 0x20
+sRoseliaGfx33_1:
+.incbin "baserom.gba", 0x12D8380, 0x180
+sRoseliaSprites33:
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx33_1, 0x180
+ax_sprite_terminator
+sRoseliaGfx34:
+.incbin "baserom.gba", 0x12D8528, 0x100
+sRoseliaGfx34_1:
+.incbin "baserom.gba", 0x12D8628, 0x40
+sRoseliaSprites34:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx34, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx35:
+.incbin "baserom.gba", 0x12D8698, 0x20
+sRoseliaGfx35_1:
+.incbin "baserom.gba", 0x12D86B8, 0x40
+sRoseliaGfx35_2:
+.incbin "baserom.gba", 0x12D86F8, 0xE0
+sRoseliaSprites35:
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx35, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx35_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx36:
+.incbin "baserom.gba", 0x12D8818, 0x60
+sRoseliaGfx36_1:
+.incbin "baserom.gba", 0x12D8878, 0x60
+sRoseliaGfx36_2:
+.incbin "baserom.gba", 0x12D88D8, 0x40
+sRoseliaSprites36:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx36_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx37:
+.incbin "baserom.gba", 0x12D8958, 0xE0
+sRoseliaSprites37:
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx37, 0xe0
+ax_sprite_terminator
+sRoseliaGfx38:
+.incbin "baserom.gba", 0x12D8A50, 0x40
+sRoseliaGfx38_1:
+.incbin "baserom.gba", 0x12D8A90, 0x60
+sRoseliaGfx38_2:
+.incbin "baserom.gba", 0x12D8AF0, 0x60
+sRoseliaSprites38:
+ax_sprite 0, 0xa0
+ax_sprite sRoseliaGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx39:
+.incbin "baserom.gba", 0x12D8B90, 0x20
+sRoseliaGfx39_1:
+.incbin "baserom.gba", 0x12D8BB0, 0x40
+sRoseliaGfx39_2:
+.incbin "baserom.gba", 0x12D8BF0, 0x80
+sRoseliaGfx39_3:
+.incbin "baserom.gba", 0x12D8C70, 0x60
+sRoseliaSprites39:
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx39, 0x20
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx39_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx39_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx39_3, 0x60
+ax_sprite_terminator
+sRoseliaGfx40:
+.incbin "baserom.gba", 0x12D8D18, 0x40
+sRoseliaGfx40_1:
+.incbin "baserom.gba", 0x12D8D58, 0x60
+sRoseliaGfx40_2:
+.incbin "baserom.gba", 0x12D8DB8, 0x60
+sRoseliaSprites40:
+ax_sprite 0, 0xa0
+ax_sprite sRoseliaGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx41:
+.incbin "baserom.gba", 0x12D8E58, 0x100
+sRoseliaGfx41_1:
+.incbin "baserom.gba", 0x12D8F58, 0x40
+sRoseliaSprites41:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx41, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx41_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx42:
+.incbin "baserom.gba", 0x12D8FC8, 0x100
+sRoseliaGfx42_1:
+.incbin "baserom.gba", 0x12D90C8, 0x40
+sRoseliaSprites42:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx42, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx42_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx43:
+.incbin "baserom.gba", 0x12D9138, 0xC0
+sRoseliaSprites43:
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx43, 0xc0
+ax_sprite_terminator
+sRoseliaGfx44:
+.incbin "baserom.gba", 0x12D9210, 0x80
+sRoseliaGfx44_1:
+.incbin "baserom.gba", 0x12D9290, 0x60
+sRoseliaGfx44_2:
+.incbin "baserom.gba", 0x12D92F0, 0x40
+sRoseliaSprites44:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx44, 0x80
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx44_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx45:
+.incbin "baserom.gba", 0x12D9370, 0x100
+sRoseliaGfx45_1:
+.incbin "baserom.gba", 0x12D9470, 0x40
+sRoseliaSprites45:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx45, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx45_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx46:
+.incbin "baserom.gba", 0x12D94E0, 0xE0
+sRoseliaGfx46_1:
+.incbin "baserom.gba", 0x12D95C0, 0x40
+sRoseliaSprites46:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx46, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx46_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx47:
+.incbin "baserom.gba", 0x12D9630, 0xC0
+sRoseliaSprites47:
+ax_sprite 0, 0x40
+ax_sprite sRoseliaGfx47, 0xc0
+ax_sprite_terminator
+sRoseliaGfx48:
+.incbin "baserom.gba", 0x12D9708, 0x100
+sRoseliaGfx48_1:
+.incbin "baserom.gba", 0x12D9808, 0x40
+sRoseliaSprites48:
+ax_sprite 0, 0x80
+ax_sprite sRoseliaGfx48, 0x100
+ax_sprite 0, 0x20
+ax_sprite sRoseliaGfx48_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sRoseliaGfx49:
+.incbin "baserom.gba", 0x12D9878, 0x200
+sRoseliaSprites49:
+ax_sprite sRoseliaGfx49, 0x200
+ax_sprite_terminator
+sRoseliaGfx50:
+.incbin "baserom.gba", 0x12D9A88, 0x200
+sRoseliaSprites50:
+ax_sprite sRoseliaGfx50, 0x200
+ax_sprite_terminator
+sRoseliaGfx51:
+.incbin "baserom.gba", 0x12D9C98, 0x200
+sRoseliaSprites51:
+ax_sprite sRoseliaGfx51, 0x200
+ax_sprite_terminator
+sRoseliaGfx52:
+.incbin "baserom.gba", 0x12D9EA8, 0x200
+sRoseliaSprites52:
+ax_sprite sRoseliaGfx52, 0x200
+ax_sprite_terminator
+sRoseliaGfx53:
+.incbin "baserom.gba", 0x12DA0B8, 0x200
+sRoseliaSprites53:
+ax_sprite sRoseliaGfx53, 0x200
+ax_sprite_terminator
+sRoseliaGfx54:
+.incbin "baserom.gba", 0x12DA2C8, 0x200
+sRoseliaSprites54:
+ax_sprite sRoseliaGfx54, 0x200
+ax_sprite_terminator
+sRoseliaGfx55:
+.incbin "baserom.gba", 0x12DA4D8, 0x200
+sRoseliaSprites55:
+ax_sprite sRoseliaGfx55, 0x200
+ax_sprite_terminator
+sRoseliaGfx56:
+.incbin "baserom.gba", 0x12DA6E8, 0x200
+sRoseliaSprites56:
+ax_sprite sRoseliaGfx56, 0x200
+ax_sprite_terminator
+sRoseliaGfx57:
+.incbin "baserom.gba", 0x12DA8F8, 0x200
+sRoseliaSprites57:
+ax_sprite sRoseliaGfx57, 0x200
+ax_sprite_terminator
+sRoseliaGfx58:
+.incbin "baserom.gba", 0x12DAB08, 0x200
+sRoseliaSprites58:
+ax_sprite sRoseliaGfx58, 0x200
+ax_sprite_terminator
+sAxPosesRoselia:
+.4byte sRoseliaPose1
+.4byte sRoseliaPose2
+.4byte sRoseliaPose3
+.4byte sRoseliaPose4
+.4byte sRoseliaPose5
+.4byte sRoseliaPose6
+.4byte sRoseliaPose7
+.4byte sRoseliaPose8
+.4byte sRoseliaPose9
+.4byte sRoseliaPose10
+.4byte sRoseliaPose11
+.4byte sRoseliaPose12
+.4byte sRoseliaPose13
+.4byte sRoseliaPose14
+.4byte sRoseliaPose15
+.4byte sRoseliaPose16
+.4byte sRoseliaPose17
+.4byte sRoseliaPose18
+.4byte sRoseliaPose19
+.4byte sRoseliaPose20
+.4byte sRoseliaPose21
+.4byte sRoseliaPose22
+.4byte sRoseliaPose23
+.4byte sRoseliaPose24
+.4byte sRoseliaPose25
+.4byte sRoseliaPose26
+.4byte sRoseliaPose27
+.4byte sRoseliaPose28
+.4byte sRoseliaPose29
+.4byte sRoseliaPose30
+.4byte sRoseliaPose31
+.4byte sRoseliaPose32
+.4byte sRoseliaPose33
+.4byte sRoseliaPose34
+.4byte sRoseliaPose35
+.4byte sRoseliaPose36
+.4byte sRoseliaPose37
+.4byte sRoseliaPose38
+.4byte sRoseliaPose39
+.4byte sRoseliaPose40
+.4byte sRoseliaPose41
+.4byte sRoseliaPose42
+.4byte sRoseliaPose43
+.4byte sRoseliaPose44
+.4byte sRoseliaPose45
+.4byte sRoseliaPose46
+.4byte sRoseliaPose47
+.4byte sRoseliaPose48
+.4byte sRoseliaPose49
+.4byte sRoseliaPose50
+.4byte sRoseliaPose51
+.4byte sRoseliaPose52
+.4byte sRoseliaPose53
+.4byte sRoseliaPose54
+.4byte sRoseliaPose55
+.4byte sRoseliaPose56
+.4byte sRoseliaPose57
+.4byte sRoseliaPose58
+.4byte sRoseliaPose59
+.4byte sRoseliaPose60
+.4byte sRoseliaPose61
+.4byte sRoseliaPose62
+.4byte sRoseliaPose63
+.4byte sRoseliaPose64
+.4byte sRoseliaPose65
+.4byte sRoseliaPose66
+.4byte sRoseliaPose67
+.4byte sRoseliaPose68
+.4byte sRoseliaPose69
+.4byte sRoseliaPose70
+.4byte sRoseliaPose71
+.4byte sRoseliaPose72
+.4byte sRoseliaPose73
+.4byte sRoseliaPose74
+.4byte sRoseliaPose75
+.4byte sRoseliaPose76
+.4byte sRoseliaPose77
+.4byte sRoseliaPose78
+.4byte sRoseliaPose79
+.4byte sRoseliaPose80
+.4byte sRoseliaPose81
+.4byte sRoseliaPose82
+.4byte sRoseliaPose83
+.4byte sRoseliaPose84
+.4byte sRoseliaPose85
+.4byte sRoseliaPose86
+.4byte sRoseliaPose87
+.4byte sRoseliaPose88
+.4byte sRoseliaPose89
+.4byte sRoseliaPose90
+.4byte sRoseliaPose91
+.4byte sRoseliaPose92
+.4byte sRoseliaPose93
+.4byte sRoseliaPose94
+.4byte sRoseliaPose95
+.4byte sRoseliaPose96
+.4byte sRoseliaPose97
+.4byte sRoseliaPose98
+.4byte sRoseliaPose99
+.4byte sRoseliaPose100
+.4byte sRoseliaPose101
+.4byte sRoseliaPose102
+.4byte sRoseliaPose103
+.4byte sRoseliaPose104
+.4byte sRoseliaPose105
+.4byte sRoseliaPose106
+.4byte sRoseliaPose107
+.4byte sRoseliaPose108
+.4byte sRoseliaPose109
+.4byte sRoseliaPose110
+.4byte sRoseliaPose111
+.4byte sRoseliaPose112
+.4byte sRoseliaPose113
+.4byte sRoseliaPose114
+.4byte sRoseliaPose115
+.4byte sRoseliaPose116
+.4byte sRoseliaPose117
+.4byte sRoseliaPose118
+.4byte sRoseliaPose119
+.4byte sRoseliaPose120
+.4byte sRoseliaPose121
+.4byte sRoseliaPose122
+.4byte sRoseliaPose123
+.4byte sRoseliaPose124
+.4byte sRoseliaPose125
+.4byte sRoseliaPose126
+.4byte sRoseliaPose127
+.4byte sRoseliaPose128
+.4byte sRoseliaPose129
+.4byte sRoseliaPose130
+.4byte sRoseliaPose131
+.4byte sRoseliaPose132
+.4byte sRoseliaPose133
+.4byte sRoseliaPose134
+.4byte sRoseliaPose135
+.4byte sRoseliaPose136
+.4byte sRoseliaPose137
+.4byte sRoseliaPose138
+.4byte sRoseliaPose139
+.4byte sRoseliaPose140
+.4byte sRoseliaPose141
+.4byte sRoseliaPose142
+.4byte sRoseliaPose143
+.4byte sRoseliaPose144
+.4byte sRoseliaPose145
+.4byte sRoseliaPose146
+.4byte sRoseliaPose147
+.4byte sRoseliaPose148
+.4byte sRoseliaPose149
+.4byte sRoseliaPose150
+.4byte sRoseliaPose151
+.4byte sRoseliaPose152
+.4byte sRoseliaPose153
+.4byte sRoseliaPose154
+.4byte sRoseliaPose155
+.4byte sRoseliaPose156
+.4byte sRoseliaPose157
+.4byte sRoseliaPose158
+.4byte sRoseliaPose159
+.4byte sRoseliaPose160
+.4byte sRoseliaPose161
+.4byte sRoseliaPose162
+.4byte sRoseliaPose163
+.4byte sRoseliaPose164
+.4byte sRoseliaPose165
+.4byte sRoseliaPose166
+.4byte sRoseliaPose167
+.4byte sRoseliaPose168
+.4byte sRoseliaPose169
+.4byte sRoseliaPose170
+.4byte sRoseliaPose171
+.4byte sRoseliaPose172
+.4byte sRoseliaPose173
+.4byte sRoseliaPose174
+.4byte sRoseliaPose175
+.4byte sRoseliaPose176
+.4byte sRoseliaPose177
+.4byte sRoseliaPose178
+.4byte sRoseliaPose179
+.4byte sRoseliaPose180
+.4byte sRoseliaPose181
+.4byte sRoseliaPose182
+.4byte sRoseliaPose183
+.4byte sRoseliaPose184
+.4byte sRoseliaPose185
+.4byte sRoseliaPose186
+sAxPositionsRoselia:
+.2byte   -1,   -7, 	 -10,   -8, 	  10,   -8, 	   0,   -4
+.2byte   -2,   -6, 	  -9,   -8, 	   9,   -5, 	  -1,   -4
+.2byte    1,   -6, 	  -9,   -5, 	   9,   -8, 	   0,   -4
+.2byte    2,   -7, 	  -7,   -4, 	   8,   -9, 	   0,   -4
+.2byte    3,   -7, 	  -5,   -2, 	   5,  -10, 	   0,   -3
+.2byte    1,   -6, 	  -8,   -5, 	   8,   -8, 	   0,   -3
+.2byte    2,   -7, 	   2,   -2, 	   4,  -12, 	   1,   -3
+.2byte    3,   -6, 	   4,   -3, 	  -3,   -9, 	   0,   -2
+.2byte    2,   -6, 	  -2,   -1, 	   6,   -9, 	  -1,   -2
+.2byte    3,   -8, 	   9,   -6, 	  -4,  -10, 	   0,   -4
+.2byte    3,   -7, 	   9,   -6, 	  -6,   -7, 	   0,   -3
+.2byte    3,   -7, 	   7,   -4, 	  -4,  -10, 	   0,   -2
+.2byte    0,   -9, 	   9,   -8, 	 -10,   -8, 	   0,   -4
+.2byte    0,   -9, 	   8,   -5, 	  -9,   -9, 	  -1,   -3
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -4, 	   0,   -3
+.2byte   -4,  -10, 	   4,  -10, 	 -11,   -5, 	  -1,   -5
+.2byte   -5,   -8, 	   4,   -8, 	 -11,   -6, 	  -1,   -4
+.2byte   -3,  -10, 	   2,  -10, 	  -9,   -3, 	  -1,   -4
+.2byte   -4,   -8, 	  -5,  -12, 	  -3,   -1, 	  -2,   -4
+.2byte   -4,   -7, 	   2,   -8, 	  -5,   -1, 	  -1,   -3
+.2byte   -4,   -7, 	  -6,   -9, 	   0,    0, 	   0,   -2
+.2byte   -3,   -7, 	  -8,  -10, 	   6,   -4, 	  -1,   -5
+.2byte   -3,   -6, 	  -7,   -9, 	   4,   -2, 	  -1,   -4
+.2byte   -1,   -6, 	  -9,   -8, 	   7,   -5, 	  -1,   -4
+.2byte   -1,   -7, 	 -10,   -8, 	  10,   -8, 	   0,   -4
+.2byte   -1,   -8, 	 -11,   -4, 	  10,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -2, 	   4,   -2, 	   0,   -5
+.2byte    2,   -7, 	  -7,   -4, 	   8,   -9, 	   0,   -4
+.2byte    2,   -8, 	  -6,   -2, 	   7,   -6, 	   1,   -5
+.2byte    2,   -7, 	   4,   -1, 	   9,   -4, 	   1,   -4
+.2byte    2,   -7, 	   2,   -2, 	   4,  -12, 	   1,   -3
+.2byte    2,   -8, 	   2,    0, 	   4,   -7, 	  -1,   -4
+.2byte    2,   -7, 	   7,   -4, 	   6,   -8, 	   0,   -4
+.2byte    3,   -8, 	   9,   -6, 	  -4,  -10, 	   0,   -4
+.2byte    2,   -9, 	   8,   -3, 	  -5,   -7, 	   0,   -4
+.2byte    3,   -8, 	   8,   -9, 	   5,  -10, 	   0,   -3
+.2byte    0,   -9, 	   9,   -8, 	 -10,   -8, 	   0,   -4
+.2byte    0,  -11, 	   9,   -6, 	 -10,   -6, 	   0,   -4
+.2byte    0,   -9, 	   6,  -11, 	  -7,  -11, 	  -1,   -3
+.2byte   -4,  -10, 	   4,  -10, 	 -11,   -5, 	  -1,   -5
+.2byte   -3,  -11, 	   5,   -7, 	  -9,   -2, 	  -1,   -4
+.2byte   -4,  -10, 	  -6,  -10, 	 -10,   -9, 	  -1,   -3
+.2byte   -4,   -8, 	  -5,  -12, 	  -3,   -1, 	  -2,   -4
+.2byte   -3,   -8, 	  -5,   -7, 	  -2,    0, 	  -1,   -6
+.2byte   -3,   -7, 	  -8,   -9, 	  -9,   -4, 	  -1,   -5
+.2byte   -3,   -7, 	  -8,  -10, 	   6,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -8,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -3,   -7, 	 -10,   -5, 	  -6,   -1, 	  -2,   -5
+.2byte   -1,   -7, 	 -10,   -8, 	  10,   -8, 	   0,   -4
+.2byte   -1,   -8, 	 -11,   -4, 	  10,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -2, 	   4,   -2, 	   0,   -5
+.2byte    2,   -7, 	  -7,   -4, 	   8,   -9, 	   0,   -4
+.2byte    2,   -8, 	  -6,   -2, 	   7,   -6, 	   1,   -5
+.2byte    2,   -7, 	   4,   -1, 	   9,   -4, 	   1,   -4
+.2byte    2,   -7, 	   2,   -2, 	   4,  -12, 	   1,   -3
+.2byte    2,   -8, 	   2,    0, 	   4,   -7, 	  -1,   -4
+.2byte    2,   -7, 	   7,   -4, 	   6,   -8, 	   0,   -4
+.2byte    3,   -8, 	   9,   -6, 	  -4,  -10, 	   0,   -4
+.2byte    2,   -9, 	   8,   -3, 	  -5,   -7, 	   0,   -4
+.2byte    3,   -8, 	   8,   -9, 	   5,  -10, 	   0,   -3
+.2byte    0,   -9, 	   9,   -8, 	 -10,   -8, 	   0,   -4
+.2byte    0,  -11, 	   9,   -6, 	 -10,   -6, 	   0,   -4
+.2byte    0,   -9, 	   6,  -11, 	  -7,  -11, 	  -1,   -3
+.2byte   -4,  -10, 	   4,  -10, 	 -11,   -5, 	  -1,   -5
+.2byte   -3,  -11, 	   5,   -7, 	  -9,   -2, 	  -1,   -4
+.2byte   -4,  -10, 	  -6,  -10, 	 -10,   -9, 	  -1,   -3
+.2byte   -4,   -8, 	  -5,  -12, 	  -3,   -1, 	  -2,   -4
+.2byte   -3,   -8, 	  -5,   -7, 	  -2,    0, 	  -1,   -6
+.2byte   -3,   -7, 	  -8,   -9, 	  -9,   -4, 	  -1,   -5
+.2byte   -3,   -7, 	  -8,  -10, 	   6,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -8,   -6, 	   6,   -2, 	  -1,   -6
+.2byte   -3,   -7, 	 -10,   -5, 	  -6,   -1, 	  -2,   -5
+.2byte   -1,   -7, 	 -10,   -8, 	  10,   -8, 	   0,   -4
+.2byte   -1,   -7, 	  -6,   -2, 	   4,   -2, 	   0,   -5
+.2byte   -1,   -9, 	 -10,  -14, 	   9,  -14, 	  -1,   -5
+.2byte    2,   -7, 	  -7,   -4, 	   8,   -9, 	   0,   -4
+.2byte    2,   -7, 	   4,   -1, 	   9,   -4, 	   1,   -4
+.2byte    2,   -9, 	  -7,  -12, 	   7,  -14, 	   0,   -4
+.2byte    2,   -7, 	   2,   -2, 	   4,  -12, 	   1,   -3
+.2byte    2,   -7, 	   7,   -4, 	   6,   -8, 	   0,   -4
+.2byte    1,   -8, 	   1,  -11, 	   2,  -16, 	   0,   -3
+.2byte    3,   -8, 	   9,   -6, 	  -4,  -10, 	   0,   -4
+.2byte    3,   -8, 	   8,   -9, 	   5,  -10, 	   0,   -3
+.2byte    2,   -9, 	   7,  -12, 	  -5,  -15, 	   0,   -4
+.2byte    0,   -9, 	   9,   -8, 	 -10,   -8, 	   0,   -4
+.2byte    0,   -9, 	   6,  -11, 	  -7,  -11, 	  -1,   -3
+.2byte    0,   -9, 	   9,  -13, 	 -10,  -13, 	   0,   -3
+.2byte   -4,  -10, 	   4,  -10, 	 -11,   -5, 	  -1,   -5
+.2byte   -4,  -10, 	  -6,  -10, 	 -10,   -9, 	  -1,   -3
+.2byte   -2,  -10, 	   5,  -14, 	  -8,  -12, 	  -1,   -3
+.2byte   -4,   -8, 	  -5,  -12, 	  -3,   -1, 	  -2,   -4
+.2byte   -3,   -7, 	  -8,   -9, 	  -9,   -4, 	  -1,   -5
+.2byte   -3,  -10, 	  -3,  -16, 	  -1,  -11, 	  -1,   -4
+.2byte   -3,   -7, 	  -8,  -10, 	   6,   -4, 	  -1,   -5
+.2byte   -3,   -7, 	 -10,   -5, 	  -6,   -1, 	  -2,   -5
+.2byte   -3,   -9, 	  -8,  -16, 	   6,  -12, 	  -1,   -5
+.2byte   -1,   -9, 	 -10,  -14, 	   9,  -14, 	  -1,   -5
+.2byte    2,   -9, 	  -7,  -12, 	   7,  -14, 	   0,   -4
+.2byte    1,   -8, 	   1,  -11, 	   2,  -16, 	   0,   -3
+.2byte    2,   -9, 	   7,  -12, 	  -5,  -15, 	   0,   -4
+.2byte    0,   -9, 	   9,  -13, 	 -10,  -13, 	   0,   -3
+.2byte   -2,  -10, 	   5,  -14, 	  -8,  -12, 	  -1,   -3
+.2byte   -3,  -10, 	  -3,  -16, 	  -1,  -11, 	  -1,   -4
+.2byte   -3,   -9, 	  -8,  -16, 	   6,  -12, 	  -1,   -5
+.2byte   -2,   -4, 	   4,    1, 	  10,   -3, 	  -3,   -2
+.2byte   -2,   -3, 	   5,    1, 	   9,   -3, 	  -3,   -2
+.2byte    0,  -11, 	  -7,   -2, 	   6,   -2, 	   0,   -8
+.2byte    1,  -11, 	  -3,   -2, 	   7,   -7, 	   0,   -8
+.2byte    0,  -11, 	   3,   -3, 	   6,  -12, 	   0,   -8
+.2byte    0,   -8, 	   8,   -9, 	   2,  -15, 	   1,   -6
+.2byte   -1,  -16, 	   9,  -15, 	 -10,  -15, 	   0,   -8
+.2byte   -2,  -12, 	  -3,  -15, 	 -10,  -10, 	  -2,   -7
+.2byte   -1,  -10, 	  -7,  -10, 	  -5,   -2, 	  -2,   -7
+.2byte   -2,  -11, 	  -8,   -7, 	   2,   -2, 	  -1,   -6
+.2byte   -1,   -7, 	 -10,   -8, 	  10,   -8, 	   0,   -4
+.2byte   -3,   -7, 	  -8,  -10, 	   6,   -4, 	  -1,   -5
+.2byte   -4,   -8, 	  -5,  -12, 	  -3,   -1, 	  -2,   -4
+.2byte   -4,  -10, 	   4,  -10, 	 -11,   -5, 	  -1,   -5
+.2byte    0,   -9, 	   9,   -8, 	 -10,   -8, 	   0,   -4
+.2byte    3,   -8, 	   9,   -6, 	  -4,  -10, 	   0,   -4
+.2byte    2,   -7, 	   2,   -2, 	   4,  -12, 	   1,   -3
+.2byte    2,   -7, 	  -7,   -4, 	   8,   -9, 	   0,   -4
+.2byte    1,   -6, 	  -9,   -5, 	   9,   -8, 	   0,   -4
+.2byte   -1,   -6, 	  -9,   -8, 	   7,   -5, 	  -1,   -4
+.2byte   -4,   -8, 	  -6,  -10, 	   0,   -1, 	   0,   -3
+.2byte   -3,  -11, 	   2,  -11, 	  -9,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   8,   -9, 	  -9,   -4, 	   0,   -3
+.2byte    3,   -8, 	   7,   -5, 	  -4,  -11, 	   0,   -3
+.2byte    2,   -7, 	  -2,   -2, 	   6,  -10, 	  -1,   -3
+.2byte    1,   -6, 	  -8,   -5, 	   8,   -8, 	   0,   -3
+.2byte   -1,   -9, 	 -10,  -14, 	   9,  -14, 	  -1,   -5
+.2byte   -3,   -9, 	  -8,  -16, 	   6,  -12, 	  -1,   -5
+.2byte   -3,  -10, 	  -3,  -16, 	  -1,  -11, 	  -1,   -4
+.2byte   -2,  -10, 	   5,  -14, 	  -8,  -12, 	  -1,   -3
+.2byte    0,   -9, 	   9,  -13, 	 -10,  -13, 	   0,   -3
+.2byte    2,   -9, 	   7,  -12, 	  -5,  -15, 	   0,   -4
+.2byte    1,   -8, 	   1,  -11, 	   2,  -16, 	   0,   -3
+.2byte    2,   -9, 	  -7,  -12, 	   7,  -14, 	   0,   -4
+.2byte   -1,   -9, 	 -10,  -14, 	   9,  -14, 	  -1,   -5
+.2byte    2,   -9, 	  -7,  -12, 	   7,  -14, 	   0,   -4
+.2byte    1,   -8, 	   1,  -11, 	   2,  -16, 	   0,   -3
+.2byte    2,   -9, 	   7,  -12, 	  -5,  -15, 	   0,   -4
+.2byte    0,   -9, 	   9,  -13, 	 -10,  -13, 	   0,   -3
+.2byte   -2,  -10, 	   5,  -14, 	  -8,  -12, 	  -1,   -3
+.2byte   -3,  -10, 	  -3,  -16, 	  -1,  -11, 	  -1,   -4
+.2byte   -3,   -9, 	  -8,  -16, 	   6,  -12, 	  -1,   -5
+.2byte   -1,   -7, 	 -10,   -8, 	  10,   -8, 	   0,   -4
+.2byte   -1,   -9, 	 -10,  -14, 	   9,  -14, 	  -1,   -5
+.2byte   -1,   -6, 	 -11,   -2, 	  10,   -2, 	  -1,   -4
+.2byte    2,   -7, 	  -7,   -4, 	   8,   -9, 	   0,   -4
+.2byte    2,   -9, 	  -7,  -12, 	   7,  -14, 	   0,   -4
+.2byte    2,   -6, 	  -6,    0, 	   7,   -4, 	   1,   -3
+.2byte    2,   -7, 	   2,   -2, 	   4,  -12, 	   1,   -3
+.2byte    1,   -8, 	   1,  -11, 	   2,  -16, 	   0,   -3
+.2byte    2,   -6, 	   2,    2, 	   4,   -5, 	  -1,   -2
+.2byte    3,   -8, 	   9,   -6, 	  -4,  -10, 	   0,   -4
+.2byte    2,   -9, 	   7,  -12, 	  -5,  -15, 	   0,   -4
+.2byte    2,   -7, 	   8,   -1, 	  -5,   -5, 	   0,   -2
+.2byte    0,   -9, 	   9,   -8, 	 -10,   -8, 	   0,   -4
+.2byte    0,   -9, 	   9,  -13, 	 -10,  -13, 	   0,   -3
+.2byte    0,   -9, 	   9,   -4, 	 -10,   -4, 	   0,   -2
+.2byte   -4,  -10, 	   4,  -10, 	 -11,   -5, 	  -1,   -5
+.2byte   -2,  -10, 	   5,  -14, 	  -8,  -12, 	  -1,   -3
+.2byte   -3,   -9, 	   5,   -5, 	  -9,    0, 	  -1,   -2
+.2byte   -4,   -8, 	  -5,  -12, 	  -3,   -1, 	  -2,   -4
+.2byte   -3,  -10, 	  -3,  -16, 	  -1,  -11, 	  -1,   -4
+.2byte   -3,   -6, 	  -5,   -5, 	  -2,    2, 	  -1,   -4
+.2byte   -3,   -7, 	  -8,  -10, 	   6,   -4, 	  -1,   -5
+.2byte   -3,   -9, 	  -8,  -16, 	   6,  -12, 	  -1,   -5
+.2byte   -3,   -6, 	  -8,   -4, 	   6,    0, 	  -1,   -4
+.2byte   -1,   -7, 	  -6,   -2, 	   4,   -2, 	   0,   -5
+.2byte   -3,   -7, 	 -10,   -5, 	  -6,   -1, 	  -2,   -5
+.2byte   -3,   -7, 	  -8,   -9, 	  -9,   -4, 	  -1,   -5
+.2byte   -4,  -10, 	  -6,  -10, 	 -10,   -9, 	  -1,   -3
+.2byte    0,   -9, 	   6,  -11, 	  -7,  -11, 	  -1,   -3
+.2byte    3,   -8, 	   8,   -9, 	   5,  -10, 	   0,   -3
+.2byte    2,   -7, 	   7,   -4, 	   6,   -8, 	   0,   -4
+.2byte    2,   -7, 	   4,   -1, 	   9,   -4, 	   1,   -4
+.2byte   -1,   -7, 	 -10,   -8, 	  10,   -8, 	   0,   -4
+.2byte   -3,   -7, 	  -8,  -10, 	   6,   -4, 	  -1,   -5
+.2byte   -4,   -8, 	  -5,  -12, 	  -3,   -1, 	  -2,   -4
+.2byte   -4,  -10, 	   4,  -10, 	 -11,   -5, 	  -1,   -5
+.2byte    0,   -9, 	   9,   -8, 	 -10,   -8, 	   0,   -4
+.2byte    3,   -8, 	   9,   -6, 	  -4,  -10, 	   0,   -4
+.2byte    2,   -7, 	   2,   -2, 	   4,  -12, 	   1,   -3
+.2byte    2,   -7, 	  -7,   -4, 	   8,   -9, 	   0,   -4
+sRoseliaAnimTable1:
+.4byte sRoseliaAnims_1_1
+.4byte sRoseliaAnims_1_2
+.4byte sRoseliaAnims_1_3
+.4byte sRoseliaAnims_1_4
+.4byte sRoseliaAnims_1_5
+.4byte sRoseliaAnims_1_6
+.4byte sRoseliaAnims_1_7
+.4byte sRoseliaAnims_1_8
+sRoseliaAnimTable2:
+.4byte sRoseliaAnims_2_1
+.4byte sRoseliaAnims_2_2
+.4byte sRoseliaAnims_2_3
+.4byte sRoseliaAnims_2_4
+.4byte sRoseliaAnims_2_5
+.4byte sRoseliaAnims_2_6
+.4byte sRoseliaAnims_2_7
+.4byte sRoseliaAnims_2_8
+sRoseliaAnimTable3:
+.4byte sRoseliaAnims_3_1
+.4byte sRoseliaAnims_3_2
+.4byte sRoseliaAnims_3_3
+.4byte sRoseliaAnims_3_4
+.4byte sRoseliaAnims_3_5
+.4byte sRoseliaAnims_3_6
+.4byte sRoseliaAnims_3_7
+.4byte sRoseliaAnims_3_8
+sRoseliaAnimTable4:
+.4byte sRoseliaAnims_4_1
+.4byte sRoseliaAnims_4_2
+.4byte sRoseliaAnims_4_3
+.4byte sRoseliaAnims_4_4
+.4byte sRoseliaAnims_4_5
+.4byte sRoseliaAnims_4_6
+.4byte sRoseliaAnims_4_7
+.4byte sRoseliaAnims_4_8
+sRoseliaAnimTable5:
+.4byte sRoseliaAnims_5_1
+.4byte sRoseliaAnims_5_2
+.4byte sRoseliaAnims_5_3
+.4byte sRoseliaAnims_5_4
+.4byte sRoseliaAnims_5_5
+.4byte sRoseliaAnims_5_6
+.4byte sRoseliaAnims_5_7
+.4byte sRoseliaAnims_5_8
+sRoseliaAnimTable6:
+.4byte sRoseliaAnims_6_1
+.4byte sRoseliaAnims_6_1
+.4byte sRoseliaAnims_6_1
+.4byte sRoseliaAnims_6_1
+.4byte sRoseliaAnims_6_1
+.4byte sRoseliaAnims_6_1
+.4byte sRoseliaAnims_6_1
+.4byte sRoseliaAnims_6_1
+sRoseliaAnimTable7:
+.4byte sRoseliaAnims_7_1
+.4byte sRoseliaAnims_7_2
+.4byte sRoseliaAnims_7_3
+.4byte sRoseliaAnims_7_4
+.4byte sRoseliaAnims_7_5
+.4byte sRoseliaAnims_7_6
+.4byte sRoseliaAnims_7_7
+.4byte sRoseliaAnims_7_8
+sRoseliaAnimTable8:
+.4byte sRoseliaAnims_8_1
+.4byte sRoseliaAnims_8_2
+.4byte sRoseliaAnims_8_3
+.4byte sRoseliaAnims_8_4
+.4byte sRoseliaAnims_8_5
+.4byte sRoseliaAnims_8_6
+.4byte sRoseliaAnims_8_7
+.4byte sRoseliaAnims_8_8
+sRoseliaAnimTable9:
+.4byte sRoseliaAnims_9_1
+.4byte sRoseliaAnims_9_2
+.4byte sRoseliaAnims_9_3
+.4byte sRoseliaAnims_9_4
+.4byte sRoseliaAnims_9_5
+.4byte sRoseliaAnims_9_6
+.4byte sRoseliaAnims_9_7
+.4byte sRoseliaAnims_9_8
+sRoseliaAnimTable10:
+.4byte sRoseliaAnims_10_1
+.4byte sRoseliaAnims_10_2
+.4byte sRoseliaAnims_10_3
+.4byte sRoseliaAnims_10_4
+.4byte sRoseliaAnims_10_5
+.4byte sRoseliaAnims_10_6
+.4byte sRoseliaAnims_10_7
+.4byte sRoseliaAnims_10_8
+sRoseliaAnimTable11:
+.4byte sRoseliaAnims_11_1
+.4byte sRoseliaAnims_11_2
+.4byte sRoseliaAnims_11_3
+.4byte sRoseliaAnims_11_4
+.4byte sRoseliaAnims_11_5
+.4byte sRoseliaAnims_11_6
+.4byte sRoseliaAnims_11_7
+.4byte sRoseliaAnims_11_8
+sRoseliaAnimTable12:
+.4byte sRoseliaAnims_12_1
+.4byte sRoseliaAnims_12_2
+.4byte sRoseliaAnims_12_3
+.4byte sRoseliaAnims_12_4
+.4byte sRoseliaAnims_12_5
+.4byte sRoseliaAnims_12_6
+.4byte sRoseliaAnims_12_7
+.4byte sRoseliaAnims_12_8
+sRoseliaAnimTable13:
+.4byte sRoseliaAnims_13_1
+.4byte sRoseliaAnims_13_2
+.4byte sRoseliaAnims_13_3
+.4byte sRoseliaAnims_13_4
+.4byte sRoseliaAnims_13_5
+.4byte sRoseliaAnims_13_6
+.4byte sRoseliaAnims_13_7
+.4byte sRoseliaAnims_13_8
+sAxAnimationsRoselia:
+.4byte sRoseliaAnimTable1
+.4byte sRoseliaAnimTable2
+.4byte sRoseliaAnimTable3
+.4byte sRoseliaAnimTable4
+.4byte sRoseliaAnimTable5
+.4byte sRoseliaAnimTable6
+.4byte sRoseliaAnimTable7
+.4byte sRoseliaAnimTable8
+.4byte sRoseliaAnimTable9
+.4byte sRoseliaAnimTable10
+.4byte sRoseliaAnimTable11
+.4byte sRoseliaAnimTable12
+.4byte sRoseliaAnimTable13
+sAxSpritesRoselia:
+.4byte sRoseliaSprites1
+.4byte sRoseliaSprites2
+.4byte sRoseliaSprites3
+.4byte sRoseliaSprites4
+.4byte sRoseliaSprites5
+.4byte sRoseliaSprites6
+.4byte sRoseliaSprites7
+.4byte sRoseliaSprites8
+.4byte sRoseliaSprites9
+.4byte sRoseliaSprites10
+.4byte sRoseliaSprites11
+.4byte sRoseliaSprites12
+.4byte sRoseliaSprites13
+.4byte sRoseliaSprites14
+.4byte sRoseliaSprites15
+.4byte sRoseliaSprites16
+.4byte sRoseliaSprites17
+.4byte sRoseliaSprites18
+.4byte sRoseliaSprites19
+.4byte sRoseliaSprites20
+.4byte sRoseliaSprites21
+.4byte sRoseliaSprites22
+.4byte sRoseliaSprites23
+.4byte sRoseliaSprites24
+.4byte sRoseliaSprites25
+.4byte sRoseliaSprites26
+.4byte sRoseliaSprites27
+.4byte sRoseliaSprites28
+.4byte sRoseliaSprites29
+.4byte sRoseliaSprites30
+.4byte sRoseliaSprites31
+.4byte sRoseliaSprites32
+.4byte sRoseliaSprites33
+.4byte sRoseliaSprites34
+.4byte sRoseliaSprites35
+.4byte sRoseliaSprites36
+.4byte sRoseliaSprites37
+.4byte sRoseliaSprites38
+.4byte sRoseliaSprites39
+.4byte sRoseliaSprites40
+.4byte sRoseliaSprites41
+.4byte sRoseliaSprites42
+.4byte sRoseliaSprites43
+.4byte sRoseliaSprites44
+.4byte sRoseliaSprites45
+.4byte sRoseliaSprites46
+.4byte sRoseliaSprites47
+.4byte sRoseliaSprites48
+.4byte sRoseliaSprites49
+.4byte sRoseliaSprites50
+.4byte sRoseliaSprites51
+.4byte sRoseliaSprites52
+.4byte sRoseliaSprites53
+.4byte sRoseliaSprites54
+.4byte sRoseliaSprites55
+.4byte sRoseliaSprites56
+.4byte sRoseliaSprites57
+.4byte sRoseliaSprites58
+sAxMainRoselia:
+ax_main sAxPosesRoselia, sAxAnimationsRoselia, 13, sAxSpritesRoselia, sAxPositionsRoselia

--- a/data/ax/sableye.inc
+++ b/data/ax/sableye.inc
@@ -1,0 +1,3428 @@
+.global gAxSableye
+gAxSableye:
+ax_siro sAxMainSableye
+sSableyePose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose4:
+ax_pose 3, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose5:
+ax_pose 4, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose6:
+ax_pose 5, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose7:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose8:
+ax_pose 7, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose9:
+ax_pose 8, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose10:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose11:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose12:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose16:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose17:
+ax_pose 16, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose18:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose19:
+ax_pose 18, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose20:
+ax_pose 19, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose21:
+ax_pose 8, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose22:
+ax_pose 3, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose23:
+ax_pose 4, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose24:
+ax_pose 5, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose28:
+ax_pose 20, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose29:
+ax_pose 3, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose30:
+ax_pose 4, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose31:
+ax_pose 5, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose32:
+ax_pose 21, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSableyePose33:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose34:
+ax_pose 7, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose35:
+ax_pose 8, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose36:
+ax_pose 22, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSableyePose37:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose38:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose39:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose40:
+ax_pose 23, 0x01ea, 0x80f6, 0x2c00
+ax_pose_terminator
+sSableyePose41:
+ax_pose 12, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose42:
+ax_pose 13, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose43:
+ax_pose 14, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose44:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose45:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose46:
+ax_pose 16, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose47:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose48:
+ax_pose 25, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose49:
+ax_pose 18, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose50:
+ax_pose 19, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose51:
+ax_pose 8, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose52:
+ax_pose 22, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSableyePose53:
+ax_pose 3, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose54:
+ax_pose 4, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose55:
+ax_pose 5, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose56:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose57:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose58:
+ax_pose 1, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose59:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose60:
+ax_pose 26, 0x01e6, 0x80ee, 0x2c00
+ax_pose 27, 0x01e9, 0x80f0, 0x2c10
+ax_pose_terminator
+sSableyePose61:
+ax_pose 27, 0x01e9, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose62:
+ax_pose 28, 0x01e4, 0x80f4, 0x2c00
+ax_pose 29, 0x01e9, 0x80f5, 0x2c10
+ax_pose_terminator
+sSableyePose63:
+ax_pose 29, 0x01e9, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose64:
+ax_pose 3, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose65:
+ax_pose 4, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose66:
+ax_pose 5, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose67:
+ax_pose 30, 0x01e8, 0x90f4, 0x2c00
+ax_pose 31, 0x01e9, 0x90f2, 0x2c10
+ax_pose_terminator
+sSableyePose68:
+ax_pose 31, 0x01e9, 0x90f2, 0x2c00
+ax_pose_terminator
+sSableyePose69:
+ax_pose 32, 0x01e7, 0x90f2, 0x2c00
+ax_pose 33, 0x01e9, 0x90f3, 0x2c10
+ax_pose_terminator
+sSableyePose70:
+ax_pose 33, 0x01e9, 0x90f3, 0x2c00
+ax_pose_terminator
+sSableyePose71:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose72:
+ax_pose 7, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose73:
+ax_pose 8, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose74:
+ax_pose 34, 0x01ea, 0x90f2, 0x2c00
+ax_pose 35, 0x01ea, 0x90f0, 0x2c10
+ax_pose_terminator
+sSableyePose75:
+ax_pose 35, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose76:
+ax_pose 36, 0x01e9, 0x90f4, 0x2c00
+ax_pose 37, 0x01e9, 0x90f1, 0x2c10
+ax_pose_terminator
+sSableyePose77:
+ax_pose 37, 0x01e9, 0x90f1, 0x2c00
+ax_pose_terminator
+sSableyePose78:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose79:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose80:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose81:
+ax_pose 38, 0x41f2, 0x90f2, 0x2c00
+ax_pose 39, 0x01ea, 0x80f3, 0x2c08
+ax_pose_terminator
+sSableyePose82:
+ax_pose 39, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose83:
+ax_pose 40, 0x01ec, 0x90f4, 0x2c00
+ax_pose 41, 0x01ec, 0x80f4, 0x2c10
+ax_pose_terminator
+sSableyePose84:
+ax_pose 41, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose85:
+ax_pose 12, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose86:
+ax_pose 13, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose87:
+ax_pose 14, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose88:
+ax_pose 42, 0x41f9, 0x00ff, 0x2c00
+ax_pose 43, 0x01e7, 0x80f0, 0x2c02
+ax_pose 44, 0x01e9, 0x40ff, 0x2c12
+ax_pose 45, 0x81e9, 0x80ef, 0x2c16
+ax_pose_terminator
+sSableyePose89:
+ax_pose 43, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose90:
+ax_pose 46, 0x01e7, 0x80ee, 0x2c00
+ax_pose 47, 0x01e8, 0x80ee, 0x2c10
+ax_pose_terminator
+sSableyePose91:
+ax_pose 46, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSableyePose92:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose93:
+ax_pose 16, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose94:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose95:
+ax_pose 40, 0x01ec, 0x80ec, 0x2c00
+ax_pose 48, 0x01ec, 0x80f4, 0x2c10
+ax_pose_terminator
+sSableyePose96:
+ax_pose 48, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose97:
+ax_pose 38, 0x41f2, 0x80ee, 0x2c00
+ax_pose 49, 0x01ea, 0x80f1, 0x2c08
+ax_pose_terminator
+sSableyePose98:
+ax_pose 49, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sSableyePose99:
+ax_pose 18, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose100:
+ax_pose 19, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose101:
+ax_pose 8, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose102:
+ax_pose 36, 0x01e9, 0x80ec, 0x2c00
+ax_pose 37, 0x01e9, 0x80ef, 0x2c10
+ax_pose_terminator
+sSableyePose103:
+ax_pose 37, 0x01e9, 0x80ef, 0x2c00
+ax_pose_terminator
+sSableyePose104:
+ax_pose 34, 0x01ea, 0x80ee, 0x2c00
+ax_pose 35, 0x01ea, 0x80f0, 0x2c10
+ax_pose_terminator
+sSableyePose105:
+ax_pose 35, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose106:
+ax_pose 3, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose107:
+ax_pose 4, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose108:
+ax_pose 5, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose109:
+ax_pose 32, 0x01e7, 0x80ee, 0x2c00
+ax_pose 33, 0x01e9, 0x80ed, 0x2c10
+ax_pose_terminator
+sSableyePose110:
+ax_pose 33, 0x01e9, 0x80ed, 0x2c00
+ax_pose_terminator
+sSableyePose111:
+ax_pose 30, 0x01e8, 0x80ec, 0x2c00
+ax_pose 31, 0x01e9, 0x80ee, 0x2c10
+ax_pose_terminator
+sSableyePose112:
+ax_pose 31, 0x01e9, 0x80ee, 0x2c00
+ax_pose_terminator
+sSableyePose113:
+ax_pose 20, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose114:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose115:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose116:
+ax_pose 25, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose117:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose118:
+ax_pose 23, 0x01ea, 0x80f6, 0x2c00
+ax_pose_terminator
+sSableyePose119:
+ax_pose 22, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose120:
+ax_pose 21, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSableyePose121:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose122:
+ax_pose 1, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose123:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose124:
+ax_pose 50, 0x01f5, 0x00f7, 0x2c00
+ax_pose -1, 0x01f5, 0x0100, 0x2c00
+ax_pose 20, 0x01e6, 0x80f2, 0x2c01
+ax_pose_terminator
+sSableyePose125:
+ax_pose 51, 0x01f5, 0x00f7, 0x2c00
+ax_pose -1, 0x01f5, 0x0100, 0x2c00
+ax_pose 20, 0x01e6, 0x80f2, 0x2c01
+ax_pose_terminator
+sSableyePose126:
+ax_pose 52, 0x01f1, 0x40f3, 0x2c00
+ax_pose -1, 0x01f1, 0x40fc, 0x2c00
+ax_pose 20, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sSableyePose127:
+ax_pose 53, 0x01f1, 0x40f3, 0x2c00
+ax_pose -1, 0x01f1, 0x40fc, 0x2c00
+ax_pose 20, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sSableyePose128:
+ax_pose 54, 0x01f1, 0x40f3, 0x2c00
+ax_pose -1, 0x01f1, 0x40fc, 0x2c00
+ax_pose 20, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sSableyePose129:
+ax_pose 55, 0x01f1, 0x40f3, 0x2c00
+ax_pose -1, 0x01f1, 0x40fc, 0x2c00
+ax_pose 20, 0x01e6, 0x80f2, 0x2c04
+ax_pose_terminator
+sSableyePose130:
+ax_pose 20, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose131:
+ax_pose 3, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose132:
+ax_pose 4, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose133:
+ax_pose 5, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose134:
+ax_pose 50, 0x01f4, 0x00fe, 0x2c00
+ax_pose -1, 0x01f1, 0x0105, 0x2c00
+ax_pose 21, 0x01e6, 0x90ec, 0x2c01
+ax_pose_terminator
+sSableyePose135:
+ax_pose 51, 0x01f4, 0x00fe, 0x2c00
+ax_pose -1, 0x01f1, 0x0105, 0x2c00
+ax_pose 21, 0x01e6, 0x90ec, 0x2c01
+ax_pose_terminator
+sSableyePose136:
+ax_pose 52, 0x01f0, 0x40fa, 0x2c00
+ax_pose -1, 0x01ed, 0x4101, 0x2c00
+ax_pose 21, 0x01e6, 0x90ec, 0x2c04
+ax_pose_terminator
+sSableyePose137:
+ax_pose 53, 0x01f0, 0x40fa, 0x2c00
+ax_pose -1, 0x01ed, 0x4101, 0x2c00
+ax_pose 21, 0x01e6, 0x90ec, 0x2c04
+ax_pose_terminator
+sSableyePose138:
+ax_pose 54, 0x01f0, 0x40fa, 0x2c00
+ax_pose -1, 0x01ed, 0x4101, 0x2c00
+ax_pose 21, 0x01e6, 0x90ec, 0x2c04
+ax_pose_terminator
+sSableyePose139:
+ax_pose 55, 0x01f0, 0x40fa, 0x2c00
+ax_pose -1, 0x01ed, 0x4101, 0x2c00
+ax_pose 21, 0x01e6, 0x90ec, 0x2c04
+ax_pose_terminator
+sSableyePose140:
+ax_pose 21, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSableyePose141:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose142:
+ax_pose 7, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose143:
+ax_pose 8, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose144:
+ax_pose 50, 0x01f3, 0x0106, 0x2c00
+ax_pose 22, 0x01e7, 0x90f2, 0x2c01
+ax_pose -1, 0x01f0, 0x0108, 0x2c00
+ax_pose_terminator
+sSableyePose145:
+ax_pose 51, 0x01f3, 0x0106, 0x2c00
+ax_pose 22, 0x01e7, 0x90f2, 0x2c01
+ax_pose -1, 0x01f0, 0x0108, 0x2c00
+ax_pose_terminator
+sSableyePose146:
+ax_pose 52, 0x01ef, 0x4102, 0x2c00
+ax_pose 22, 0x01e7, 0x90f2, 0x2c04
+ax_pose -1, 0x01ec, 0x4104, 0x2c00
+ax_pose_terminator
+sSableyePose147:
+ax_pose 53, 0x01ef, 0x4102, 0x2c00
+ax_pose 22, 0x01e7, 0x90f2, 0x2c04
+ax_pose -1, 0x01ec, 0x4104, 0x2c00
+ax_pose_terminator
+sSableyePose148:
+ax_pose 54, 0x01ef, 0x4102, 0x2c00
+ax_pose 22, 0x01e7, 0x90f2, 0x2c04
+ax_pose -1, 0x01ec, 0x4104, 0x2c00
+ax_pose_terminator
+sSableyePose149:
+ax_pose 55, 0x01ef, 0x4102, 0x2c00
+ax_pose 22, 0x01e7, 0x90f2, 0x2c04
+ax_pose -1, 0x01ec, 0x4104, 0x2c00
+ax_pose_terminator
+sSableyePose150:
+ax_pose 22, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSableyePose151:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose152:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose153:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose154:
+ax_pose 50, 0x01ef, 0x0105, 0x2c00
+ax_pose 23, 0x01ea, 0x80f6, 0x2c01
+ax_pose -1, 0x01ed, 0x00ff, 0x2c00
+ax_pose_terminator
+sSableyePose155:
+ax_pose 51, 0x01ef, 0x0105, 0x2c00
+ax_pose 23, 0x01ea, 0x80f6, 0x2c01
+ax_pose -1, 0x01ed, 0x00ff, 0x2c00
+ax_pose_terminator
+sSableyePose156:
+ax_pose 52, 0x01eb, 0x4101, 0x2c00
+ax_pose 23, 0x01ea, 0x80f6, 0x2c04
+ax_pose -1, 0x01e9, 0x40fb, 0x2c00
+ax_pose_terminator
+sSableyePose157:
+ax_pose 53, 0x01eb, 0x4101, 0x2c00
+ax_pose 23, 0x01ea, 0x80f6, 0x2c04
+ax_pose -1, 0x01e9, 0x40fb, 0x2c00
+ax_pose_terminator
+sSableyePose158:
+ax_pose 54, 0x01eb, 0x4101, 0x2c00
+ax_pose 23, 0x01ea, 0x80f6, 0x2c04
+ax_pose -1, 0x01e9, 0x40fb, 0x2c00
+ax_pose_terminator
+sSableyePose159:
+ax_pose 55, 0x01eb, 0x4101, 0x2c00
+ax_pose 23, 0x01ea, 0x80f6, 0x2c04
+ax_pose -1, 0x01e9, 0x40fb, 0x2c00
+ax_pose_terminator
+sSableyePose160:
+ax_pose 23, 0x01ea, 0x80f6, 0x2c00
+ax_pose_terminator
+sSableyePose161:
+ax_pose 12, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose162:
+ax_pose 13, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose163:
+ax_pose 14, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose164:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose 50, 0x01ed, 0x0100, 0x2c10
+ax_pose -1, 0x01ed, 0x00f9, 0x2c10
+ax_pose_terminator
+sSableyePose165:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose 51, 0x01ed, 0x0100, 0x2c10
+ax_pose -1, 0x01ed, 0x00f9, 0x2c10
+ax_pose_terminator
+sSableyePose166:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose 52, 0x01e9, 0x40fc, 0x2c10
+ax_pose -1, 0x01e9, 0x40f5, 0x2c10
+ax_pose_terminator
+sSableyePose167:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose 53, 0x01e9, 0x40fc, 0x2c10
+ax_pose -1, 0x01e9, 0x40f5, 0x2c10
+ax_pose_terminator
+sSableyePose168:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose 54, 0x01e9, 0x40fc, 0x2c10
+ax_pose -1, 0x01e9, 0x40f5, 0x2c10
+ax_pose_terminator
+sSableyePose169:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose 55, 0x01e9, 0x40fc, 0x2c10
+ax_pose -1, 0x01e9, 0x40f5, 0x2c10
+ax_pose_terminator
+sSableyePose170:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose171:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose172:
+ax_pose 16, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose173:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose174:
+ax_pose 50, 0x01ef, 0x00f3, 0x2c00
+ax_pose 25, 0x01ea, 0x80f2, 0x2c01
+ax_pose -1, 0x01ed, 0x00f9, 0x2c00
+ax_pose_terminator
+sSableyePose175:
+ax_pose 51, 0x01ef, 0x00f3, 0x2c00
+ax_pose 25, 0x01ea, 0x80f2, 0x2c01
+ax_pose -1, 0x01ed, 0x00f9, 0x2c00
+ax_pose_terminator
+sSableyePose176:
+ax_pose 52, 0x01eb, 0x40ef, 0x2c00
+ax_pose 25, 0x01ea, 0x80f2, 0x2c04
+ax_pose -1, 0x01e9, 0x40f5, 0x2c00
+ax_pose_terminator
+sSableyePose177:
+ax_pose 53, 0x01eb, 0x40ef, 0x2c00
+ax_pose 25, 0x01ea, 0x80f2, 0x2c04
+ax_pose -1, 0x01e9, 0x40f5, 0x2c00
+ax_pose_terminator
+sSableyePose178:
+ax_pose 54, 0x01eb, 0x40ef, 0x2c00
+ax_pose 25, 0x01ea, 0x80f2, 0x2c04
+ax_pose -1, 0x01e9, 0x40f5, 0x2c00
+ax_pose_terminator
+sSableyePose179:
+ax_pose 55, 0x01eb, 0x40ef, 0x2c00
+ax_pose 25, 0x01ea, 0x80f2, 0x2c04
+ax_pose -1, 0x01e9, 0x40f5, 0x2c00
+ax_pose_terminator
+sSableyePose180:
+ax_pose 25, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose181:
+ax_pose 18, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose182:
+ax_pose 19, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose183:
+ax_pose 8, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose184:
+ax_pose 50, 0x01f3, 0x00f2, 0x2c00
+ax_pose 22, 0x01e7, 0x80ee, 0x2c01
+ax_pose -1, 0x01f0, 0x00f0, 0x2c00
+ax_pose_terminator
+sSableyePose185:
+ax_pose 51, 0x01f3, 0x00f2, 0x2c00
+ax_pose 22, 0x01e7, 0x80ee, 0x2c01
+ax_pose -1, 0x01f0, 0x00f0, 0x2c00
+ax_pose_terminator
+sSableyePose186:
+ax_pose 52, 0x01ef, 0x40ee, 0x2c00
+ax_pose 22, 0x01e7, 0x80ee, 0x2c04
+ax_pose -1, 0x01ec, 0x40ec, 0x2c00
+ax_pose_terminator
+sSableyePose187:
+ax_pose 53, 0x01ef, 0x40ee, 0x2c00
+ax_pose 22, 0x01e7, 0x80ee, 0x2c04
+ax_pose -1, 0x01ec, 0x40ec, 0x2c00
+ax_pose_terminator
+sSableyePose188:
+ax_pose 54, 0x01ef, 0x40ee, 0x2c00
+ax_pose 22, 0x01e7, 0x80ee, 0x2c04
+ax_pose -1, 0x01ec, 0x40ec, 0x2c00
+ax_pose_terminator
+sSableyePose189:
+ax_pose 55, 0x01ef, 0x40ee, 0x2c00
+ax_pose 22, 0x01e7, 0x80ee, 0x2c04
+ax_pose -1, 0x01ec, 0x40ec, 0x2c00
+ax_pose_terminator
+sSableyePose190:
+ax_pose 22, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSableyePose191:
+ax_pose 3, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose192:
+ax_pose 4, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose193:
+ax_pose 5, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose194:
+ax_pose 50, 0x01f4, 0x00fa, 0x2c00
+ax_pose -1, 0x01f1, 0x00f3, 0x2c00
+ax_pose 21, 0x01e6, 0x80f4, 0x2c01
+ax_pose_terminator
+sSableyePose195:
+ax_pose 51, 0x01f4, 0x00fa, 0x2c00
+ax_pose -1, 0x01f1, 0x00f3, 0x2c00
+ax_pose 21, 0x01e6, 0x80f4, 0x2c01
+ax_pose_terminator
+sSableyePose196:
+ax_pose 52, 0x01f0, 0x40f6, 0x2c00
+ax_pose -1, 0x01ed, 0x40ef, 0x2c00
+ax_pose 21, 0x01e6, 0x80f4, 0x2c04
+ax_pose_terminator
+sSableyePose197:
+ax_pose 53, 0x01f0, 0x40f6, 0x2c00
+ax_pose -1, 0x01ed, 0x40ef, 0x2c00
+ax_pose 21, 0x01e6, 0x80f4, 0x2c04
+ax_pose_terminator
+sSableyePose198:
+ax_pose 54, 0x01f0, 0x40f6, 0x2c00
+ax_pose -1, 0x01ed, 0x40ef, 0x2c00
+ax_pose 21, 0x01e6, 0x80f4, 0x2c04
+ax_pose_terminator
+sSableyePose199:
+ax_pose 55, 0x01f0, 0x40f6, 0x2c00
+ax_pose -1, 0x01ed, 0x40ef, 0x2c00
+ax_pose 21, 0x01e6, 0x80f4, 0x2c04
+ax_pose_terminator
+sSableyePose200:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose201:
+ax_pose 56, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose202:
+ax_pose 57, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose203:
+ax_pose 58, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose204:
+ax_pose 59, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sSableyePose205:
+ax_pose 60, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sSableyePose206:
+ax_pose 61, 0x01e4, 0x80ec, 0x2c00
+ax_pose_terminator
+sSableyePose207:
+ax_pose 62, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose208:
+ax_pose 63, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose209:
+ax_pose 60, 0x01e1, 0x80f6, 0x2c00
+ax_pose_terminator
+sSableyePose210:
+ax_pose 59, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose211:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose212:
+ax_pose 20, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose213:
+ax_pose 3, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose214:
+ax_pose 21, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSableyePose215:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose216:
+ax_pose 22, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSableyePose217:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose218:
+ax_pose 23, 0x01ea, 0x80f6, 0x2c00
+ax_pose_terminator
+sSableyePose219:
+ax_pose 12, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose220:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose221:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose222:
+ax_pose 25, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose223:
+ax_pose 18, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose224:
+ax_pose 22, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSableyePose225:
+ax_pose 3, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose226:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose227:
+ax_pose 29, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose228:
+ax_pose 31, 0x01e9, 0x80ee, 0x2c00
+ax_pose_terminator
+sSableyePose229:
+ax_pose 35, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose230:
+ax_pose 49, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose231:
+ax_pose 46, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSableyePose232:
+ax_pose 41, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose233:
+ax_pose 37, 0x01e9, 0x90f1, 0x2c00
+ax_pose_terminator
+sSableyePose234:
+ax_pose 33, 0x01e8, 0x90f4, 0x2c00
+ax_pose_terminator
+sSableyePose235:
+ax_pose 29, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose236:
+ax_pose 33, 0x01e8, 0x90f4, 0x2c00
+ax_pose_terminator
+sSableyePose237:
+ax_pose 37, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose238:
+ax_pose 41, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose239:
+ax_pose 46, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSableyePose240:
+ax_pose 49, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose241:
+ax_pose 35, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose242:
+ax_pose 31, 0x01ea, 0x80ef, 0x2c00
+ax_pose_terminator
+sSableyePose243:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose244:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose245:
+ax_pose 20, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose246:
+ax_pose 3, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSableyePose247:
+ax_pose 5, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sSableyePose248:
+ax_pose 21, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSableyePose249:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose250:
+ax_pose 8, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sSableyePose251:
+ax_pose 22, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose252:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose253:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose254:
+ax_pose 23, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose255:
+ax_pose 12, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose256:
+ax_pose 14, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose257:
+ax_pose 24, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose258:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose259:
+ax_pose 17, 0x01ed, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose260:
+ax_pose 25, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose261:
+ax_pose 18, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose262:
+ax_pose 8, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSableyePose263:
+ax_pose 22, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sSableyePose264:
+ax_pose 3, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose265:
+ax_pose 5, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose266:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose267:
+ax_pose 20, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSableyePose268:
+ax_pose 21, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose269:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose270:
+ax_pose 25, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose271:
+ax_pose 24, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sSableyePose272:
+ax_pose 23, 0x01ea, 0x80f6, 0x2c00
+ax_pose_terminator
+sSableyePose273:
+ax_pose 22, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSableyePose274:
+ax_pose 21, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSableyePose275:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose276:
+ax_pose 3, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSableyePose277:
+ax_pose 18, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose278:
+ax_pose 15, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose279:
+ax_pose 12, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose280:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSableyePose281:
+ax_pose 6, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSableyePose282:
+ax_pose 3, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sSableyeAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSableyeAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 1, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 0, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sSableyeAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSableyeAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 11, -12, 11, -12,
+ax_anim 2, 0, 39, 19, -20, 19, -20,
+ax_anim 2, 1, 39, 20, -19, 20, -19,
+ax_anim 2, 0, 39, 19, -20, 19, -20,
+ax_anim 2, 0, 39, 20, -19, 20, -19,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sSableyeAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 1, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sSableyeAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -11, -12, -11, -12,
+ax_anim 2, 0, 47, -19, -20, -19, -20,
+ax_anim 2, 1, 47, -20, -19, -20, -19,
+ax_anim 2, 0, 47, -19, -20, -19, -20,
+ax_anim 2, 0, 47, -20, -19, -20, -19,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sSableyeAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sSableyeAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 1, 55, -21, 19, -21, 19,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 0, 55, -21, 19, -21, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSableyeAnims_3_1:
+ax_anim 2, 0, 109, 0, -2, 0, -2,
+ax_anim 2, 0, 109, 0, -4, 0, -4,
+ax_anim 4, 0, 109, 0, -6, 0, -6,
+ax_anim 1, 2, 109, 0, -3, 0, -3,
+ax_anim 1, 0, 60, 0, 3, 0, 3,
+ax_anim 2, 0, 61, 0, 18, 0, 18,
+ax_anim 2, 1, 69, 2, 19, 2, 19,
+ax_anim 4, 0, 69, 3, 18, 3, 18,
+ax_anim 2, 0, 62, 0, 19, 0, 19,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 109, -2, 18, -2, 18,
+ax_anim 2, 0, 60, -1, 15, -1, 15,
+ax_anim 2, 0, 56, 0, 11, 0, 11,
+ax_anim_terminator
+sSableyeAnims_3_2:
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 60, -4, -4, -4, -4,
+ax_anim 4, 0, 60, -6, -6, -6, -6,
+ax_anim 1, 2, 60, -3, -3, -3, -3,
+ax_anim 1, 0, 67, 7, 7, 7, 7,
+ax_anim 2, 0, 68, 16, 15, 16, 15,
+ax_anim 2, 1, 76, 16, 17, 16, 17,
+ax_anim 4, 0, 76, 13, 14, 13, 14,
+ax_anim 2, 0, 69, 12, 12, 12, 12,
+ax_anim 2, 0, 66, 16, 15, 16, 15,
+ax_anim 2, 0, 60, 17, 15, 17, 15,
+ax_anim 2, 0, 67, 15, 13, 15, 13,
+ax_anim 2, 0, 63, 11, 10, 11, 10,
+ax_anim_terminator
+sSableyeAnims_3_3:
+ax_anim 2, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 67, -4, 0, -4, 0,
+ax_anim 4, 0, 67, -6, 0, -6, 0,
+ax_anim 1, 2, 67, -3, 0, -3, 0,
+ax_anim 1, 0, 74, 6, 0, 6, 0,
+ax_anim 2, 0, 75, 14, 0, 14, 0,
+ax_anim 2, 1, 83, 15, -1, 15, -1,
+ax_anim 4, 0, 83, 13, -1, 13, -1,
+ax_anim 2, 0, 76, 15, 0, 15, 0,
+ax_anim 2, 0, 73, 16, 0, 16, 0,
+ax_anim 2, 0, 67, 16, 0, 16, 0,
+ax_anim 2, 0, 74, 8, -1, 8, -1,
+ax_anim 2, 0, 70, 4, -1, 4, -1,
+ax_anim_terminator
+sSableyeAnims_3_4:
+ax_anim 2, 0, 74, -2, 2, -2, 2,
+ax_anim 2, 0, 74, -4, 4, -4, 4,
+ax_anim 4, 0, 74, -6, 6, -6, 6,
+ax_anim 1, 2, 74, -3, 3, -3, 3,
+ax_anim 1, 0, 81, 5, -5, 5, -5,
+ax_anim 2, 0, 82, 12, -12, 12, -12,
+ax_anim 2, 1, 90, 15, -15, 15, -15,
+ax_anim 4, 0, 90, 13, -13, 13, -13,
+ax_anim 2, 0, 83, 15, -18, 15, -18,
+ax_anim 2, 0, 80, 19, -19, 19, -19,
+ax_anim 2, 0, 74, 21, -19, 21, -19,
+ax_anim 2, 0, 81, 12, -14, 12, -14,
+ax_anim 2, 0, 77, 6, -8, 6, -8,
+ax_anim_terminator
+sSableyeAnims_3_5:
+ax_anim 2, 0, 81, 0, 2, 0, 2,
+ax_anim 2, 0, 81, 0, 4, 0, 4,
+ax_anim 4, 0, 81, 0, 6, 0, 6,
+ax_anim 1, 2, 81, 0, 3, 0, 3,
+ax_anim 1, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 89, 0, -12, 0, -12,
+ax_anim 2, 1, 97, -2, -13, -2, -13,
+ax_anim 4, 0, 97, -3, -12, -3, -12,
+ax_anim 2, 0, 90, -2, -14, -2, -14,
+ax_anim 2, 0, 87, 0, -19, 0, -19,
+ax_anim 2, 0, 81, 1, -19, 1, -19,
+ax_anim 2, 0, 88, 1, -15, 1, -15,
+ax_anim 2, 0, 84, 0, -8, 0, -8,
+ax_anim_terminator
+sSableyeAnims_3_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 2, 0, 88, 4, 4, 4, 4,
+ax_anim 4, 0, 88, 6, 6, 6, 6,
+ax_anim 1, 2, 88, 3, 3, 3, 3,
+ax_anim 1, 0, 95, -6, -8, -6, -8,
+ax_anim 2, 0, 96, -10, -14, -10, -14,
+ax_anim 2, 1, 104, -17, -15, -17, -15,
+ax_anim 4, 0, 104, -16, -14, -16, -14,
+ax_anim 2, 0, 97, -14, -17, -14, -17,
+ax_anim 2, 0, 94, -16, -22, -16, -22,
+ax_anim 2, 0, 88, -15, -23, -15, -23,
+ax_anim 2, 0, 95, -12, -18, -12, -18,
+ax_anim 2, 0, 91, -6, -8, -6, -8,
+ax_anim_terminator
+sSableyeAnims_3_7:
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 4, 0, 4, 0,
+ax_anim 4, 0, 95, 6, 0, 6, 0,
+ax_anim 1, 2, 95, 3, 0, 3, 0,
+ax_anim 1, 0, 102, -4, 0, -4, 0,
+ax_anim 2, 0, 103, -11, 0, -11, 0,
+ax_anim 2, 1, 111, -14, 0, -14, 0,
+ax_anim 4, 0, 111, -13, 0, -13, 0,
+ax_anim 2, 0, 104, -14, 0, -14, 0,
+ax_anim 2, 0, 101, -14, 0, -14, 0,
+ax_anim 2, 0, 95, -15, -2, -15, -2,
+ax_anim 2, 0, 102, -11, 0, -11, 0,
+ax_anim 2, 0, 98, -6, -1, -6, -1,
+ax_anim_terminator
+sSableyeAnims_3_8:
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 4, 0, 102, 6, -6, 6, -6,
+ax_anim 1, 2, 102, 3, -3, 3, -3,
+ax_anim 1, 0, 109, -5, 3, -5, 3,
+ax_anim 2, 0, 110, -11, 10, -11, 10,
+ax_anim 2, 1, 62, -16, 13, -16, 13,
+ax_anim 4, 0, 62, -15, 12, -15, 12,
+ax_anim 2, 0, 111, -14, 14, -14, 14,
+ax_anim 2, 0, 108, -16, 15, -16, 15,
+ax_anim 2, 0, 102, -17, 15, -17, 15,
+ax_anim 2, 0, 109, -13, 11, -13, 11,
+ax_anim 2, 0, 105, -7, 7, -7, 7,
+ax_anim_terminator
+.align 2
+sSableyeAnims_4_1:
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_4_2:
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_4_3:
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_4_4:
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_4_5:
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_4_6:
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_4_7:
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_4_8:
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_5_1:
+ax_anim 2, 0, 121, 0, -2, 0, -2,
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 6, 0, 120, 0, -5, 0, -5,
+ax_anim 1, 0, 129, 0, -2, 0, -2,
+ax_anim 1, 0, 129, 0, 3, 0, 3,
+ax_anim 4, 0, 129, 0, 5, 0, 5,
+ax_anim 1, 0, 123, 0, 5, 0, 5,
+ax_anim 1, 0, 125, 0, 5, 0, 5,
+ax_anim 1, 2, 127, 0, 5, 0, 5,
+ax_anim 1, 0, 128, 0, 5, 0, 5,
+ax_anim 1, 0, 124, 0, 5, 0, 5,
+ax_anim 1, 0, 127, 0, 5, 0, 5,
+ax_anim 1, 0, 128, 0, 5, 0, 5,
+ax_anim 1, 0, 125, 0, 5, 0, 5,
+ax_anim 1, 1, 124, 0, 5, 0, 5,
+ax_anim 2, 0, 129, 0, 5, 0, 5,
+ax_anim 2, 0, 120, 0, 2, 0, 2,
+ax_anim_terminator
+sSableyeAnims_5_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 2, 0, 132, -4, -4, -4, -4,
+ax_anim 6, 0, 130, -5, -5, -5, -5,
+ax_anim 1, 0, 139, -2, -2, -2, -2,
+ax_anim 1, 0, 139, 3, 3, 3, 3,
+ax_anim 4, 0, 139, 5, 5, 5, 5,
+ax_anim 1, 0, 133, 5, 5, 5, 5,
+ax_anim 1, 0, 135, 5, 5, 5, 5,
+ax_anim 1, 2, 137, 5, 5, 5, 5,
+ax_anim 1, 0, 138, 5, 5, 5, 5,
+ax_anim 1, 0, 134, 5, 5, 5, 5,
+ax_anim 1, 0, 137, 5, 5, 5, 5,
+ax_anim 1, 0, 138, 5, 5, 5, 5,
+ax_anim 1, 0, 135, 5, 5, 5, 5,
+ax_anim 1, 1, 134, 5, 5, 5, 5,
+ax_anim 2, 0, 139, 5, 5, 5, 5,
+ax_anim 2, 0, 130, 2, 2, 2, 2,
+ax_anim_terminator
+sSableyeAnims_5_3:
+ax_anim 2, 0, 141, -2, 0, -2, 0,
+ax_anim 2, 0, 142, -4, 0, -4, 0,
+ax_anim 6, 0, 140, -5, 0, -5, 0,
+ax_anim 1, 0, 149, -2, 0, -2, 0,
+ax_anim 1, 0, 149, 3, 0, 3, 0,
+ax_anim 4, 0, 149, 5, 0, 5, 0,
+ax_anim 1, 0, 143, 5, 0, 5, 0,
+ax_anim 1, 0, 145, 5, 0, 5, 0,
+ax_anim 1, 2, 147, 5, 0, 5, 0,
+ax_anim 1, 0, 148, 5, 0, 5, 0,
+ax_anim 1, 0, 144, 5, 0, 5, 0,
+ax_anim 1, 0, 147, 5, 0, 5, 0,
+ax_anim 1, 0, 148, 5, 0, 5, 0,
+ax_anim 1, 0, 145, 5, 0, 5, 0,
+ax_anim 1, 1, 144, 5, 0, 5, 0,
+ax_anim 2, 0, 149, 5, 0, 5, 0,
+ax_anim 2, 0, 140, 2, 0, 2, 0,
+ax_anim_terminator
+sSableyeAnims_5_4:
+ax_anim 2, 0, 151, -2, 2, -2, 2,
+ax_anim 2, 0, 152, -4, 4, -4, 4,
+ax_anim 6, 0, 150, -5, 5, -5, 5,
+ax_anim 1, 0, 159, -2, 2, -2, 2,
+ax_anim 1, 0, 159, 3, -3, 3, -3,
+ax_anim 4, 0, 159, 5, -5, 5, -5,
+ax_anim 1, 0, 153, 5, -5, 5, -5,
+ax_anim 1, 0, 155, 5, -5, 5, -5,
+ax_anim 1, 2, 157, 5, -5, 5, -5,
+ax_anim 1, 0, 158, 5, -5, 5, -5,
+ax_anim 1, 0, 154, 5, -5, 5, -5,
+ax_anim 1, 0, 157, 5, -5, 5, -5,
+ax_anim 1, 0, 158, 5, -5, 5, -5,
+ax_anim 1, 0, 155, 5, -5, 5, -5,
+ax_anim 1, 1, 154, 5, -5, 5, -5,
+ax_anim 2, 0, 159, 5, -5, 5, -5,
+ax_anim 2, 0, 150, 2, -2, 2, -2,
+ax_anim_terminator
+sSableyeAnims_5_5:
+ax_anim 2, 0, 161, 0, 2, 0, 2,
+ax_anim 2, 0, 162, 0, 4, 0, 4,
+ax_anim 6, 0, 160, 0, 5, 0, 5,
+ax_anim 1, 0, 169, 0, 2, 0, 2,
+ax_anim 1, 0, 169, 0, -3, 0, -3,
+ax_anim 4, 0, 169, 0, -5, 0, -5,
+ax_anim 1, 0, 163, 0, -5, 0, -5,
+ax_anim 1, 0, 165, 0, -5, 0, -5,
+ax_anim 1, 2, 167, 0, -5, 0, -5,
+ax_anim 1, 0, 168, 0, -5, 0, -5,
+ax_anim 1, 0, 164, 0, -5, 0, -5,
+ax_anim 1, 0, 167, 0, -5, 0, -5,
+ax_anim 1, 0, 168, 0, -5, 0, -5,
+ax_anim 1, 0, 165, 0, -5, 0, -5,
+ax_anim 1, 1, 164, 0, -5, 0, -5,
+ax_anim 2, 0, 169, 0, -5, 0, -5,
+ax_anim 2, 0, 160, 0, -2, 0, -2,
+ax_anim_terminator
+sSableyeAnims_5_6:
+ax_anim 2, 0, 171, 2, 2, 2, 2,
+ax_anim 2, 0, 172, 4, 4, 4, 4,
+ax_anim 6, 0, 170, 5, 5, 5, 5,
+ax_anim 1, 0, 179, 2, 2, 2, 2,
+ax_anim 1, 0, 179, -3, -3, -3, -3,
+ax_anim 4, 0, 179, -5, -5, -5, -5,
+ax_anim 1, 0, 173, -5, -5, -5, -5,
+ax_anim 1, 0, 175, -5, -5, -5, -5,
+ax_anim 1, 2, 177, -5, -5, -5, -5,
+ax_anim 1, 0, 178, -5, -5, -5, -5,
+ax_anim 1, 0, 174, -5, -5, -5, -5,
+ax_anim 1, 0, 177, -5, -5, -5, -5,
+ax_anim 1, 0, 178, -5, -5, -5, -5,
+ax_anim 1, 0, 175, -5, -5, -5, -5,
+ax_anim 1, 1, 174, -5, -5, -5, -5,
+ax_anim 2, 0, 179, -5, -5, -5, -5,
+ax_anim 2, 0, 170, -2, -2, -2, -2,
+ax_anim_terminator
+sSableyeAnims_5_7:
+ax_anim 2, 0, 181, 2, 0, 2, 0,
+ax_anim 2, 0, 182, 4, 0, 4, 0,
+ax_anim 6, 0, 180, 5, 0, 5, 0,
+ax_anim 1, 0, 189, 2, 0, 2, 0,
+ax_anim 1, 0, 189, -3, 0, -3, 0,
+ax_anim 4, 0, 189, -5, 0, -5, 0,
+ax_anim 1, 0, 183, -5, 0, -5, 0,
+ax_anim 1, 0, 185, -5, 0, -5, 0,
+ax_anim 1, 2, 187, -5, 0, -5, 0,
+ax_anim 1, 0, 188, -5, 0, -5, 0,
+ax_anim 1, 0, 184, -5, 0, -5, 0,
+ax_anim 1, 0, 187, -5, 0, -5, 0,
+ax_anim 1, 0, 188, -5, 0, -5, 0,
+ax_anim 1, 0, 185, -5, 0, -5, 0,
+ax_anim 1, 1, 184, -5, 0, -5, 0,
+ax_anim 2, 0, 189, -5, 0, -5, 0,
+ax_anim 2, 0, 180, -2, 0, -2, 0,
+ax_anim_terminator
+sSableyeAnims_5_8:
+ax_anim 2, 0, 191, 2, -2, 2, -2,
+ax_anim 2, 0, 192, 4, -4, 4, -4,
+ax_anim 6, 0, 190, 5, -5, 5, -5,
+ax_anim 1, 0, 199, 2, -2, 2, -2,
+ax_anim 1, 0, 199, -3, 3, -3, 3,
+ax_anim 4, 0, 199, -5, 5, -5, 5,
+ax_anim 1, 0, 193, -5, 5, -5, 5,
+ax_anim 1, 0, 195, -5, 5, -5, 5,
+ax_anim 1, 2, 197, -5, 5, -5, 5,
+ax_anim 1, 0, 198, -5, 5, -5, 5,
+ax_anim 1, 0, 194, -5, 5, -5, 5,
+ax_anim 1, 0, 197, -5, 5, -5, 5,
+ax_anim 1, 0, 198, -5, 5, -5, 5,
+ax_anim 1, 0, 195, -5, 5, -5, 5,
+ax_anim 1, 1, 194, -5, 5, -5, 5,
+ax_anim 2, 0, 199, -5, 5, -5, 5,
+ax_anim 2, 0, 190, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSableyeAnims_6_1:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 35, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_7_1:
+ax_anim 2, 0, 202, 0, -4, 0, -4,
+ax_anim 8, 0, 202, 0, -5, 0, -5,
+ax_anim_terminator
+sSableyeAnims_7_2:
+ax_anim 2, 0, 203, -4, -4, -4, -4,
+ax_anim 8, 0, 203, -5, -5, -5, -5,
+ax_anim_terminator
+sSableyeAnims_7_3:
+ax_anim 2, 0, 204, -4, 0, -4, 0,
+ax_anim 8, 0, 204, -5, 0, -5, 0,
+ax_anim_terminator
+sSableyeAnims_7_4:
+ax_anim 2, 0, 205, -4, 4, -4, 4,
+ax_anim 8, 0, 205, -5, 5, -5, 5,
+ax_anim_terminator
+sSableyeAnims_7_5:
+ax_anim 2, 0, 206, 0, 4, 0, 4,
+ax_anim 8, 0, 206, 0, 5, 0, 5,
+ax_anim_terminator
+sSableyeAnims_7_6:
+ax_anim 2, 0, 207, 4, 4, 4, 4,
+ax_anim 8, 0, 207, 5, 5, 5, 5,
+ax_anim_terminator
+sSableyeAnims_7_7:
+ax_anim 2, 0, 208, 4, 0, 4, 0,
+ax_anim 8, 0, 208, 5, 0, 5, 0,
+ax_anim_terminator
+sSableyeAnims_7_8:
+ax_anim 2, 0, 209, 4, -4, 4, -4,
+ax_anim 8, 0, 209, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSableyeAnims_8_1:
+ax_anim 40, 0, 210, 0, 0, 0, 0,
+ax_anim 12, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_8_2:
+ax_anim 40, 0, 212, 0, 0, 0, 0,
+ax_anim 12, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_8_3:
+ax_anim 40, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_8_4:
+ax_anim 40, 0, 216, 0, 0, 0, 0,
+ax_anim 12, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_8_5:
+ax_anim 40, 0, 218, 0, 0, 0, 0,
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_8_6:
+ax_anim 40, 0, 220, 0, 0, 0, 0,
+ax_anim 12, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_8_7:
+ax_anim 40, 0, 222, 0, 0, 0, 0,
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_8_8:
+ax_anim 40, 0, 224, 0, 0, 0, 0,
+ax_anim 12, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_9_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 9, 2, 9, 2,
+ax_anim 2, 0, 228, 15, 7, 15, 7,
+ax_anim 2, 0, 229, 12, 18, 15, 18,
+ax_anim 3, 0, 230, 0, 21, 0, 21,
+ax_anim 2, 3, 231, -11, 17, -11, 17,
+ax_anim 2, 0, 232, -13, 9, -13, 9,
+ax_anim 1, 0, 233, -9, 3, -9, 3,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_9_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 8, 0, 8, 0,
+ax_anim 2, 0, 227, 17, 3, 17, 3,
+ax_anim 2, 0, 228, 25, 10, 25, 10,
+ax_anim 3, 0, 229, 20, 19, 24, 21,
+ax_anim 2, 3, 230, 11, 21, 11, 21,
+ax_anim 2, 0, 231, 3, 15, 3, 15,
+ax_anim 1, 0, 232, 0, 7, 0, 7,
+ax_anim 1, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_9_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 3, -5, 3, -5,
+ax_anim 2, 0, 226, 11, -6, 11, -6,
+ax_anim 2, 0, 227, 18, -5, 18, -5,
+ax_anim 3, 0, 228, 21, 0, 27, 0,
+ax_anim 2, 3, 229, 20, 8, 20, 8,
+ax_anim 2, 0, 230, 12, 9, 12, 9,
+ax_anim 1, 0, 231, 4, 5, 4, 5,
+ax_anim 1, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_9_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, -1, -8, -1, -8,
+ax_anim 2, 0, 233, 2, -16, 2, -16,
+ax_anim 2, 0, 226, 11, -20, 11, -20,
+ax_anim 3, 0, 227, 20, -21, 20, -21,
+ax_anim 2, 3, 228, 25, -15, 29, -15,
+ax_anim 2, 0, 229, 23, -6, 23, -6,
+ax_anim 1, 0, 230, 14, -1, 14, -1,
+ax_anim 1, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_9_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, -8, -4, -8, -4,
+ax_anim 2, 0, 232, -12, -12, -12, -12,
+ax_anim 2, 0, 233, -11, -18, -11, -18,
+ax_anim 3, 0, 226, 0, -21, -3, -20,
+ax_anim 2, 3, 227, 10, -18, 10, -18,
+ax_anim 2, 0, 228, 17, -12, 17, -12,
+ax_anim 1, 0, 229, 12, -4, 12, -4,
+ax_anim 1, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_9_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 1, -8, 1, -8,
+ax_anim 2, 0, 227, -4, -16, -4, -16,
+ax_anim 2, 0, 226, -12, -20, -12, -20,
+ax_anim 3, 0, 233, -23, -20, -23, -20,
+ax_anim 2, 3, 232, -27, -13, -27, -13,
+ax_anim 2, 0, 231, -21, -6, -21, -6,
+ax_anim 1, 0, 230, -14, -1, -14, -1,
+ax_anim 1, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_9_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 227, -3, -5, -3, -5,
+ax_anim 2, 0, 226, -11, -6, -11, -6,
+ax_anim 2, 0, 233, -20, -5, -20, -5,
+ax_anim 3, 0, 232, -26, -1, -26, -1,
+ax_anim 2, 3, 231, -20, 6, -20, 6,
+ax_anim 2, 0, 230, -12, 9, -12, 9,
+ax_anim 1, 0, 229, -4, 7, -4, 7,
+ax_anim 1, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_9_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 226, -8, 0, -8, 0,
+ax_anim 2, 0, 233, -20, 4, -19, 3,
+ax_anim 2, 0, 232, -26, 12, -26, 10,
+ax_anim 3, 0, 231, -24, 19, -24, 19,
+ax_anim 2, 3, 230, -11, 21, -11, 19,
+ax_anim 2, 0, 229, -1, 15, -1, 15,
+ax_anim 1, 0, 228, 2, 7, 2, 7,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_10_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 3, 0, 234, 13, 0, 13, 0,
+ax_anim 3, 0, 234, -13, 0, -13, 0,
+ax_anim 2, 0, 234, 12, 0, 12, 0,
+ax_anim 3, 0, 234, -12, 0, -12, 0,
+ax_anim 2, 0, 234, 10, 0, 10, 0,
+ax_anim 2, 0, 234, -10, 0, -10, 0,
+ax_anim 2, 0, 234, 6, 0, 6, 0,
+ax_anim 2, 0, 234, -6, 0, -6, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_10_2:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 3, 0, 235, 13, -13, 13, -13,
+ax_anim 3, 0, 235, -13, 13, -13, 13,
+ax_anim 2, 0, 235, 12, -12, 12, -12,
+ax_anim 3, 0, 235, -12, 12, -12, 12,
+ax_anim 2, 0, 235, 10, -10, 10, -10,
+ax_anim 2, 0, 235, -10, 10, -10, 10,
+ax_anim 2, 0, 235, 6, -6, 6, -6,
+ax_anim 2, 0, 235, -6, 6, -6, 6,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_10_3:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 3, 0, 236, 0, -13, 0, -13,
+ax_anim 3, 0, 236, 0, 13, 0, 13,
+ax_anim 2, 0, 236, 0, -12, 0, -12,
+ax_anim 3, 0, 236, 0, 12, 0, 12,
+ax_anim 2, 0, 236, 0, -10, 0, -10,
+ax_anim 2, 0, 236, 0, 10, 0, 10,
+ax_anim 2, 0, 236, 0, -6, 0, -6,
+ax_anim 2, 0, 236, 0, 6, 0, 6,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_10_4:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 3, 0, 237, -13, -13, -13, -13,
+ax_anim 3, 0, 237, 13, 13, 13, 13,
+ax_anim 2, 0, 237, -12, -12, -12, -12,
+ax_anim 3, 0, 237, 12, 12, 12, 12,
+ax_anim 2, 0, 237, -10, -10, -10, -10,
+ax_anim 2, 0, 237, 10, 10, 10, 10,
+ax_anim 2, 0, 237, -6, -6, -6, -6,
+ax_anim 2, 0, 237, 6, 6, 6, 6,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_10_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 3, 0, 238, 13, 0, 13, 0,
+ax_anim 3, 0, 238, -13, 0, -13, 0,
+ax_anim 2, 0, 238, 12, 0, 12, 0,
+ax_anim 3, 0, 238, -12, 0, -12, 0,
+ax_anim 2, 0, 238, 10, 0, 10, 0,
+ax_anim 2, 0, 238, -10, 0, -10, 0,
+ax_anim 2, 0, 238, 6, 0, 6, 0,
+ax_anim 2, 0, 238, -6, 0, -6, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_10_6:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 3, 0, 239, 13, -13, 13, -13,
+ax_anim 3, 0, 239, -13, 13, -13, 13,
+ax_anim 2, 0, 239, 12, -12, 12, -12,
+ax_anim 3, 0, 239, -12, 12, -12, 12,
+ax_anim 2, 0, 239, 10, -10, 10, -10,
+ax_anim 2, 0, 239, -10, 10, -10, 10,
+ax_anim 2, 0, 239, 6, -6, 6, -6,
+ax_anim 2, 0, 239, -6, 6, -6, 6,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_10_7:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 3, 0, 240, 0, -13, 0, -13,
+ax_anim 3, 0, 240, 0, 13, 0, 13,
+ax_anim 2, 0, 240, 0, -12, 0, -12,
+ax_anim 3, 0, 240, 0, 12, 0, 12,
+ax_anim 2, 0, 240, 0, -10, 0, -10,
+ax_anim 2, 0, 240, 0, 10, 0, 10,
+ax_anim 2, 0, 240, 0, -6, 0, -6,
+ax_anim 2, 0, 240, 0, 6, 0, 6,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_10_8:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 3, 0, 241, -13, -13, -13, -13,
+ax_anim 3, 0, 241, 13, 13, 13, 13,
+ax_anim 2, 0, 241, -12, -12, -12, -12,
+ax_anim 3, 0, 241, 12, 12, 12, 12,
+ax_anim 2, 0, 241, -10, -10, -10, -10,
+ax_anim 2, 0, 241, 10, 10, 10, 10,
+ax_anim 2, 0, 241, -6, -6, -6, -6,
+ax_anim 2, 0, 241, 6, 6, 6, 6,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_11_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 243, 0, -20, 0, 0,
+ax_anim 4, 0, 243, 0, -21, 0, 0,
+ax_anim 4, 0, 243, 0, -22, 0, 0,
+ax_anim 3, 0, 244, 0, -22, 0, 0,
+ax_anim 2, 0, 244, 0, -18, 0, 0,
+ax_anim 1, 0, 244, 0, -12, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_11_2:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 246, 0, -20, 0, 0,
+ax_anim 4, 0, 246, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -22, 0, 0,
+ax_anim 3, 0, 247, 0, -20, 0, 0,
+ax_anim 2, 0, 247, 0, -18, 0, 0,
+ax_anim 1, 0, 247, 0, -12, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_11_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 0, -10, 0, 0,
+ax_anim 2, 0, 249, 0, -16, 0, 0,
+ax_anim 3, 0, 249, 0, -20, 0, 0,
+ax_anim 4, 0, 249, 0, -21, 0, 0,
+ax_anim 4, 0, 249, 0, -22, 0, 0,
+ax_anim 3, 0, 250, 0, -20, 0, 0,
+ax_anim 2, 0, 250, 0, -18, 0, 0,
+ax_anim 1, 0, 250, 0, -12, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_11_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 0, -9, 0, 0,
+ax_anim 2, 0, 252, 0, -15, 0, 0,
+ax_anim 3, 0, 252, 0, -19, 0, 0,
+ax_anim 4, 0, 252, 0, -20, 0, 0,
+ax_anim 4, 0, 252, 0, -21, 0, 0,
+ax_anim 3, 0, 253, 0, -21, 0, 0,
+ax_anim 2, 0, 253, 0, -17, 0, 0,
+ax_anim 1, 0, 253, 0, -11, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_11_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, 0, -10, 0, 0,
+ax_anim 2, 0, 255, 0, -16, 0, 0,
+ax_anim 3, 0, 255, 0, -20, 0, 0,
+ax_anim 4, 0, 255, 0, -21, 0, 0,
+ax_anim 4, 0, 255, 0, -23, 0, 0,
+ax_anim 3, 0, 256, 0, -20, 0, 0,
+ax_anim 2, 0, 256, 0, -18, 0, 0,
+ax_anim 1, 0, 256, 0, -12, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_11_6:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 258, 0, -10, 0, 0,
+ax_anim 2, 0, 258, 0, -16, 0, 0,
+ax_anim 3, 0, 258, 0, -20, 0, 0,
+ax_anim 4, 0, 258, 0, -21, 0, 0,
+ax_anim 4, 0, 258, 0, -22, 0, 0,
+ax_anim 3, 0, 259, 0, -20, 0, 0,
+ax_anim 2, 0, 259, 0, -17, 0, 0,
+ax_anim 1, 0, 259, 0, -11, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_11_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 261, 0, -10, 0, 0,
+ax_anim 2, 0, 261, 0, -16, 0, 0,
+ax_anim 3, 0, 261, 0, -20, 0, 0,
+ax_anim 4, 0, 261, 0, -21, 0, 0,
+ax_anim 4, 0, 261, 0, -22, 0, 0,
+ax_anim 3, 0, 262, 0, -20, 0, 0,
+ax_anim 2, 0, 262, 0, -18, 0, 0,
+ax_anim 1, 0, 262, 0, -12, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_11_8:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 264, 0, -10, 0, 0,
+ax_anim 2, 0, 264, 0, -16, 0, 0,
+ax_anim 3, 0, 264, 0, -20, 0, 0,
+ax_anim 4, 0, 264, 0, -21, 0, 0,
+ax_anim 4, 0, 264, 0, -23, 0, 0,
+ax_anim 3, 0, 265, 0, -21, 0, 0,
+ax_anim 2, 0, 265, 0, -18, 0, 0,
+ax_anim 1, 0, 265, 0, -12, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_12_1:
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 1, 0, 1, 0,
+ax_anim 2, 1, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_12_2:
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 1, -1, 1, -1,
+ax_anim 2, 1, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_12_3:
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, -1, 0, -1,
+ax_anim 2, 1, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_12_4:
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 271, -1, -1, -1, -1,
+ax_anim 2, 1, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_12_5:
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 1, 0, 1, 0,
+ax_anim 2, 1, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_12_6:
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 1, -1, 1, -1,
+ax_anim 2, 1, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_12_7:
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, -1, 0, -1,
+ax_anim 2, 1, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_12_8:
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, -1, -1, -1, -1,
+ax_anim 2, 1, 267, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSableyeAnims_13_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 2, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_13_2:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_13_3:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_13_4:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_13_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_13_6:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_13_7:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeAnims_13_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sSableyeGfx1:
+.incbin "baserom.gba", 0x1249870, 0x200
+sSableyeSprites1:
+ax_sprite sSableyeGfx1, 0x200
+ax_sprite_terminator
+sSableyeGfx2:
+.incbin "baserom.gba", 0x1249A80, 0x200
+sSableyeSprites2:
+ax_sprite sSableyeGfx2, 0x200
+ax_sprite_terminator
+sSableyeGfx3:
+.incbin "baserom.gba", 0x1249C90, 0x200
+sSableyeSprites3:
+ax_sprite sSableyeGfx3, 0x200
+ax_sprite_terminator
+sSableyeGfx4:
+.incbin "baserom.gba", 0x1249EA0, 0x200
+sSableyeSprites4:
+ax_sprite sSableyeGfx4, 0x200
+ax_sprite_terminator
+sSableyeGfx5:
+.incbin "baserom.gba", 0x124A0B0, 0x200
+sSableyeSprites5:
+ax_sprite sSableyeGfx5, 0x200
+ax_sprite_terminator
+sSableyeGfx6:
+.incbin "baserom.gba", 0x124A2C0, 0x200
+sSableyeSprites6:
+ax_sprite sSableyeGfx6, 0x200
+ax_sprite_terminator
+sSableyeGfx7:
+.incbin "baserom.gba", 0x124A4D0, 0x200
+sSableyeSprites7:
+ax_sprite sSableyeGfx7, 0x200
+ax_sprite_terminator
+sSableyeGfx8:
+.incbin "baserom.gba", 0x124A6E0, 0x200
+sSableyeSprites8:
+ax_sprite sSableyeGfx8, 0x200
+ax_sprite_terminator
+sSableyeGfx9:
+.incbin "baserom.gba", 0x124A8F0, 0x200
+sSableyeSprites9:
+ax_sprite sSableyeGfx9, 0x200
+ax_sprite_terminator
+sSableyeGfx10:
+.incbin "baserom.gba", 0x124AB00, 0x200
+sSableyeSprites10:
+ax_sprite sSableyeGfx10, 0x200
+ax_sprite_terminator
+sSableyeGfx11:
+.incbin "baserom.gba", 0x124AD10, 0x200
+sSableyeSprites11:
+ax_sprite sSableyeGfx11, 0x200
+ax_sprite_terminator
+sSableyeGfx12:
+.incbin "baserom.gba", 0x124AF20, 0x200
+sSableyeSprites12:
+ax_sprite sSableyeGfx12, 0x200
+ax_sprite_terminator
+sSableyeGfx13:
+.incbin "baserom.gba", 0x124B130, 0x200
+sSableyeSprites13:
+ax_sprite sSableyeGfx13, 0x200
+ax_sprite_terminator
+sSableyeGfx14:
+.incbin "baserom.gba", 0x124B340, 0x200
+sSableyeSprites14:
+ax_sprite sSableyeGfx14, 0x200
+ax_sprite_terminator
+sSableyeGfx15:
+.incbin "baserom.gba", 0x124B550, 0x200
+sSableyeSprites15:
+ax_sprite sSableyeGfx15, 0x200
+ax_sprite_terminator
+sSableyeGfx16:
+.incbin "baserom.gba", 0x124B760, 0x200
+sSableyeSprites16:
+ax_sprite sSableyeGfx16, 0x200
+ax_sprite_terminator
+sSableyeGfx17:
+.incbin "baserom.gba", 0x124B970, 0x200
+sSableyeSprites17:
+ax_sprite sSableyeGfx17, 0x200
+ax_sprite_terminator
+sSableyeGfx18:
+.incbin "baserom.gba", 0x124BB80, 0x200
+sSableyeSprites18:
+ax_sprite sSableyeGfx18, 0x200
+ax_sprite_terminator
+sSableyeGfx19:
+.incbin "baserom.gba", 0x124BD90, 0x200
+sSableyeSprites19:
+ax_sprite sSableyeGfx19, 0x200
+ax_sprite_terminator
+sSableyeGfx20:
+.incbin "baserom.gba", 0x124BFA0, 0x200
+sSableyeSprites20:
+ax_sprite sSableyeGfx20, 0x200
+ax_sprite_terminator
+sSableyeGfx21:
+.incbin "baserom.gba", 0x124C1B0, 0x40
+sSableyeGfx21_1:
+.incbin "baserom.gba", 0x124C1F0, 0x60
+sSableyeGfx21_2:
+.incbin "baserom.gba", 0x124C250, 0xE0
+sSableyeSprites21:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx21_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx22:
+.incbin "baserom.gba", 0x124C370, 0x60
+sSableyeGfx22_1:
+.incbin "baserom.gba", 0x124C3D0, 0x60
+sSableyeGfx22_2:
+.incbin "baserom.gba", 0x124C430, 0x60
+sSableyeGfx22_3:
+.incbin "baserom.gba", 0x124C490, 0x60
+sSableyeSprites22:
+ax_sprite sSableyeGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx23:
+.incbin "baserom.gba", 0x124C538, 0x40
+sSableyeGfx23_1:
+.incbin "baserom.gba", 0x124C578, 0xE0
+sSableyeGfx23_2:
+.incbin "baserom.gba", 0x124C658, 0x40
+sSableyeSprites23:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx23_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx24:
+.incbin "baserom.gba", 0x124C6D8, 0x60
+sSableyeGfx24_1:
+.incbin "baserom.gba", 0x124C738, 0x60
+sSableyeGfx24_2:
+.incbin "baserom.gba", 0x124C798, 0x60
+sSableyeSprites24:
+ax_sprite sSableyeGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSableyeGfx25:
+.incbin "baserom.gba", 0x124C830, 0x60
+sSableyeGfx25_1:
+.incbin "baserom.gba", 0x124C890, 0x60
+sSableyeGfx25_2:
+.incbin "baserom.gba", 0x124C8F0, 0x60
+sSableyeGfx25_3:
+.incbin "baserom.gba", 0x124C950, 0x60
+sSableyeSprites25:
+ax_sprite sSableyeGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx26:
+.incbin "baserom.gba", 0x124C9F8, 0x60
+sSableyeGfx26_1:
+.incbin "baserom.gba", 0x124CA58, 0x60
+sSableyeGfx26_2:
+.incbin "baserom.gba", 0x124CAB8, 0x60
+sSableyeSprites26:
+ax_sprite sSableyeGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSableyeGfx27:
+.incbin "baserom.gba", 0x124CB50, 0x20
+sSableyeGfx27_1:
+.incbin "baserom.gba", 0x124CB70, 0x20
+sSableyeGfx27_2:
+.incbin "baserom.gba", 0x124CB90, 0x60
+sSableyeGfx27_3:
+.incbin "baserom.gba", 0x124CBF0, 0x60
+sSableyeSprites27:
+ax_sprite 0, 0x60
+ax_sprite sSableyeGfx27, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSableyeGfx27_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx27_3, 0x60
+ax_sprite_terminator
+sSableyeGfx28:
+.incbin "baserom.gba", 0x124CC98, 0x60
+sSableyeGfx28_1:
+.incbin "baserom.gba", 0x124CCF8, 0x60
+sSableyeGfx28_2:
+.incbin "baserom.gba", 0x124CD58, 0x100
+sSableyeSprites28:
+ax_sprite sSableyeGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx28_2, 0x100
+ax_sprite_terminator
+sSableyeGfx29:
+.incbin "baserom.gba", 0x124CE88, 0x20
+sSableyeGfx29_1:
+.incbin "baserom.gba", 0x124CEA8, 0x20
+sSableyeGfx29_2:
+.incbin "baserom.gba", 0x124CEC8, 0x100
+sSableyeSprites29:
+ax_sprite sSableyeGfx29, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSableyeGfx29_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSableyeGfx29_2, 0x100
+ax_sprite_terminator
+sSableyeGfx30:
+.incbin "baserom.gba", 0x124CFF8, 0x60
+sSableyeGfx30_1:
+.incbin "baserom.gba", 0x124D058, 0x100
+sSableyeGfx30_2:
+.incbin "baserom.gba", 0x124D158, 0x40
+sSableyeSprites30:
+ax_sprite sSableyeGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx31:
+.incbin "baserom.gba", 0x124D1D0, 0x40
+sSableyeGfx31_1:
+.incbin "baserom.gba", 0x124D210, 0x40
+sSableyeGfx31_2:
+.incbin "baserom.gba", 0x124D250, 0x40
+sSableyeGfx31_3:
+.incbin "baserom.gba", 0x124D290, 0x80
+sSableyeSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx31_3, 0x80
+ax_sprite_terminator
+sSableyeGfx32:
+.incbin "baserom.gba", 0x124D358, 0x60
+sSableyeGfx32_1:
+.incbin "baserom.gba", 0x124D3B8, 0x60
+sSableyeGfx32_2:
+.incbin "baserom.gba", 0x124D418, 0x60
+sSableyeGfx32_3:
+.incbin "baserom.gba", 0x124D478, 0x60
+sSableyeSprites32:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx32_3, 0x60
+ax_sprite_terminator
+sSableyeGfx33:
+.incbin "baserom.gba", 0x124D520, 0x20
+sSableyeGfx33_1:
+.incbin "baserom.gba", 0x124D540, 0x120
+sSableyeSprites33:
+ax_sprite 0, 0x60
+ax_sprite sSableyeGfx33, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSableyeGfx33_1, 0x120
+ax_sprite_terminator
+sSableyeGfx34:
+.incbin "baserom.gba", 0x124D688, 0x60
+sSableyeGfx34_1:
+.incbin "baserom.gba", 0x124D6E8, 0x60
+sSableyeGfx34_2:
+.incbin "baserom.gba", 0x124D748, 0x60
+sSableyeGfx34_3:
+.incbin "baserom.gba", 0x124D7A8, 0x60
+sSableyeSprites34:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx34_3, 0x60
+ax_sprite_terminator
+sSableyeGfx35:
+.incbin "baserom.gba", 0x124D850, 0x60
+sSableyeGfx35_1:
+.incbin "baserom.gba", 0x124D8B0, 0x80
+sSableyeGfx35_2:
+.incbin "baserom.gba", 0x124D930, 0x60
+sSableyeSprites35:
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx35, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx35_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx36:
+.incbin "baserom.gba", 0x124D9D0, 0x40
+sSableyeGfx36_1:
+.incbin "baserom.gba", 0x124DA10, 0x60
+sSableyeGfx36_2:
+.incbin "baserom.gba", 0x124DA70, 0x80
+sSableyeGfx36_3:
+.incbin "baserom.gba", 0x124DAF0, 0x40
+sSableyeSprites36:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx36_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx37:
+.incbin "baserom.gba", 0x124DB80, 0x40
+sSableyeGfx37_1:
+.incbin "baserom.gba", 0x124DBC0, 0x80
+sSableyeGfx37_2:
+.incbin "baserom.gba", 0x124DC40, 0x40
+sSableyeSprites37:
+ax_sprite 0, 0x80
+ax_sprite sSableyeGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx37_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx37_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx38:
+.incbin "baserom.gba", 0x124DCC0, 0x40
+sSableyeGfx38_1:
+.incbin "baserom.gba", 0x124DD00, 0x60
+sSableyeGfx38_2:
+.incbin "baserom.gba", 0x124DD60, 0x40
+sSableyeGfx38_3:
+.incbin "baserom.gba", 0x124DDA0, 0x40
+sSableyeSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx38_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx39:
+.incbin "baserom.gba", 0x124DE30, 0xC0
+sSableyeGfx39_1:
+.incbin "baserom.gba", 0x124DEF0, 0x20
+sSableyeSprites39:
+ax_sprite sSableyeGfx39, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx39_1, 0x20
+ax_sprite_terminator
+sSableyeGfx40:
+.incbin "baserom.gba", 0x124DF30, 0x40
+sSableyeGfx40_1:
+.incbin "baserom.gba", 0x124DF70, 0xC0
+sSableyeGfx40_2:
+.incbin "baserom.gba", 0x124E030, 0x40
+sSableyeSprites40:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx40_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx40_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx41:
+.incbin "baserom.gba", 0x124E0B0, 0x40
+sSableyeGfx41_1:
+.incbin "baserom.gba", 0x124E0F0, 0x40
+sSableyeGfx41_2:
+.incbin "baserom.gba", 0x124E130, 0x60
+sSableyeGfx41_3:
+.incbin "baserom.gba", 0x124E190, 0x40
+sSableyeSprites41:
+ax_sprite sSableyeGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx41_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx41_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSableyeGfx41_3, 0x40
+ax_sprite_terminator
+sSableyeGfx42:
+.incbin "baserom.gba", 0x124E210, 0x60
+sSableyeGfx42_1:
+.incbin "baserom.gba", 0x124E270, 0x60
+sSableyeGfx42_2:
+.incbin "baserom.gba", 0x124E2D0, 0x60
+sSableyeSprites42:
+ax_sprite sSableyeGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx42_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSableyeGfx43:
+.incbin "baserom.gba", 0x124E368, 0x40
+sSableyeSprites43:
+ax_sprite sSableyeGfx43, 0x40
+ax_sprite_terminator
+sSableyeGfx44:
+.incbin "baserom.gba", 0x124E3B8, 0x40
+sSableyeGfx44_1:
+.incbin "baserom.gba", 0x124E3F8, 0x140
+sSableyeSprites44:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx44_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSableyeGfx45:
+.incbin "baserom.gba", 0x124E568, 0x40
+sSableyeGfx45_1:
+.incbin "baserom.gba", 0x124E5A8, 0x20
+sSableyeSprites45:
+ax_sprite sSableyeGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx45_1, 0x20
+ax_sprite_terminator
+sSableyeGfx46:
+.incbin "baserom.gba", 0x124E5E8, 0xA0
+sSableyeSprites46:
+ax_sprite sSableyeGfx46, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSableyeGfx47:
+.incbin "baserom.gba", 0x124E6A0, 0x160
+sSableyeGfx47_1:
+.incbin "baserom.gba", 0x124E800, 0x60
+sSableyeSprites47:
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx47, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx47_1, 0x60
+ax_sprite_terminator
+sSableyeGfx48:
+.incbin "baserom.gba", 0x124E888, 0xC0
+sSableyeGfx48_1:
+.incbin "baserom.gba", 0x124E948, 0x40
+sSableyeGfx48_2:
+.incbin "baserom.gba", 0x124E988, 0x20
+sSableyeSprites48:
+ax_sprite sSableyeGfx48, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx48_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx48_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSableyeGfx49:
+.incbin "baserom.gba", 0x124E9E0, 0x60
+sSableyeGfx49_1:
+.incbin "baserom.gba", 0x124EA40, 0x60
+sSableyeGfx49_2:
+.incbin "baserom.gba", 0x124EAA0, 0x60
+sSableyeSprites49:
+ax_sprite sSableyeGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx49_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSableyeGfx50:
+.incbin "baserom.gba", 0x124EB38, 0x60
+sSableyeGfx50_1:
+.incbin "baserom.gba", 0x124EB98, 0x60
+sSableyeGfx50_2:
+.incbin "baserom.gba", 0x124EBF8, 0x60
+sSableyeGfx50_3:
+.incbin "baserom.gba", 0x124EC58, 0x20
+sSableyeSprites50:
+ax_sprite sSableyeGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSableyeGfx50_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSableyeGfx50_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSableyeGfx51:
+.incbin "baserom.gba", 0x124ECC0, 0x20
+sSableyeSprites51:
+ax_sprite sSableyeGfx51, 0x20
+ax_sprite_terminator
+sSableyeGfx52:
+.incbin "baserom.gba", 0x124ECF0, 0x20
+sSableyeSprites52:
+ax_sprite sSableyeGfx52, 0x20
+ax_sprite_terminator
+sSableyeGfx53:
+.incbin "baserom.gba", 0x124ED20, 0x80
+sSableyeSprites53:
+ax_sprite sSableyeGfx53, 0x80
+ax_sprite_terminator
+sSableyeGfx54:
+.incbin "baserom.gba", 0x124EDB0, 0x80
+sSableyeSprites54:
+ax_sprite sSableyeGfx54, 0x80
+ax_sprite_terminator
+sSableyeGfx55:
+.incbin "baserom.gba", 0x124EE40, 0x80
+sSableyeSprites55:
+ax_sprite sSableyeGfx55, 0x80
+ax_sprite_terminator
+sSableyeGfx56:
+.incbin "baserom.gba", 0x124EED0, 0x80
+sSableyeSprites56:
+ax_sprite sSableyeGfx56, 0x80
+ax_sprite_terminator
+sSableyeGfx57:
+.incbin "baserom.gba", 0x124EF60, 0x200
+sSableyeSprites57:
+ax_sprite sSableyeGfx57, 0x200
+ax_sprite_terminator
+sSableyeGfx58:
+.incbin "baserom.gba", 0x124F170, 0x200
+sSableyeSprites58:
+ax_sprite sSableyeGfx58, 0x200
+ax_sprite_terminator
+sSableyeGfx59:
+.incbin "baserom.gba", 0x124F380, 0x200
+sSableyeSprites59:
+ax_sprite sSableyeGfx59, 0x200
+ax_sprite_terminator
+sSableyeGfx60:
+.incbin "baserom.gba", 0x124F590, 0x200
+sSableyeSprites60:
+ax_sprite sSableyeGfx60, 0x200
+ax_sprite_terminator
+sSableyeGfx61:
+.incbin "baserom.gba", 0x124F7A0, 0x200
+sSableyeSprites61:
+ax_sprite sSableyeGfx61, 0x200
+ax_sprite_terminator
+sSableyeGfx62:
+.incbin "baserom.gba", 0x124F9B0, 0x200
+sSableyeSprites62:
+ax_sprite sSableyeGfx62, 0x200
+ax_sprite_terminator
+sSableyeGfx63:
+.incbin "baserom.gba", 0x124FBC0, 0x200
+sSableyeSprites63:
+ax_sprite sSableyeGfx63, 0x200
+ax_sprite_terminator
+sSableyeGfx64:
+.incbin "baserom.gba", 0x124FDD0, 0x200
+sSableyeSprites64:
+ax_sprite sSableyeGfx64, 0x200
+ax_sprite_terminator
+sAxPosesSableye:
+.4byte sSableyePose1
+.4byte sSableyePose2
+.4byte sSableyePose3
+.4byte sSableyePose4
+.4byte sSableyePose5
+.4byte sSableyePose6
+.4byte sSableyePose7
+.4byte sSableyePose8
+.4byte sSableyePose9
+.4byte sSableyePose10
+.4byte sSableyePose11
+.4byte sSableyePose12
+.4byte sSableyePose13
+.4byte sSableyePose14
+.4byte sSableyePose15
+.4byte sSableyePose16
+.4byte sSableyePose17
+.4byte sSableyePose18
+.4byte sSableyePose19
+.4byte sSableyePose20
+.4byte sSableyePose21
+.4byte sSableyePose22
+.4byte sSableyePose23
+.4byte sSableyePose24
+.4byte sSableyePose25
+.4byte sSableyePose26
+.4byte sSableyePose27
+.4byte sSableyePose28
+.4byte sSableyePose29
+.4byte sSableyePose30
+.4byte sSableyePose31
+.4byte sSableyePose32
+.4byte sSableyePose33
+.4byte sSableyePose34
+.4byte sSableyePose35
+.4byte sSableyePose36
+.4byte sSableyePose37
+.4byte sSableyePose38
+.4byte sSableyePose39
+.4byte sSableyePose40
+.4byte sSableyePose41
+.4byte sSableyePose42
+.4byte sSableyePose43
+.4byte sSableyePose44
+.4byte sSableyePose45
+.4byte sSableyePose46
+.4byte sSableyePose47
+.4byte sSableyePose48
+.4byte sSableyePose49
+.4byte sSableyePose50
+.4byte sSableyePose51
+.4byte sSableyePose52
+.4byte sSableyePose53
+.4byte sSableyePose54
+.4byte sSableyePose55
+.4byte sSableyePose56
+.4byte sSableyePose57
+.4byte sSableyePose58
+.4byte sSableyePose59
+.4byte sSableyePose60
+.4byte sSableyePose61
+.4byte sSableyePose62
+.4byte sSableyePose63
+.4byte sSableyePose64
+.4byte sSableyePose65
+.4byte sSableyePose66
+.4byte sSableyePose67
+.4byte sSableyePose68
+.4byte sSableyePose69
+.4byte sSableyePose70
+.4byte sSableyePose71
+.4byte sSableyePose72
+.4byte sSableyePose73
+.4byte sSableyePose74
+.4byte sSableyePose75
+.4byte sSableyePose76
+.4byte sSableyePose77
+.4byte sSableyePose78
+.4byte sSableyePose79
+.4byte sSableyePose80
+.4byte sSableyePose81
+.4byte sSableyePose82
+.4byte sSableyePose83
+.4byte sSableyePose84
+.4byte sSableyePose85
+.4byte sSableyePose86
+.4byte sSableyePose87
+.4byte sSableyePose88
+.4byte sSableyePose89
+.4byte sSableyePose90
+.4byte sSableyePose91
+.4byte sSableyePose92
+.4byte sSableyePose93
+.4byte sSableyePose94
+.4byte sSableyePose95
+.4byte sSableyePose96
+.4byte sSableyePose97
+.4byte sSableyePose98
+.4byte sSableyePose99
+.4byte sSableyePose100
+.4byte sSableyePose101
+.4byte sSableyePose102
+.4byte sSableyePose103
+.4byte sSableyePose104
+.4byte sSableyePose105
+.4byte sSableyePose106
+.4byte sSableyePose107
+.4byte sSableyePose108
+.4byte sSableyePose109
+.4byte sSableyePose110
+.4byte sSableyePose111
+.4byte sSableyePose112
+.4byte sSableyePose113
+.4byte sSableyePose114
+.4byte sSableyePose115
+.4byte sSableyePose116
+.4byte sSableyePose117
+.4byte sSableyePose118
+.4byte sSableyePose119
+.4byte sSableyePose120
+.4byte sSableyePose121
+.4byte sSableyePose122
+.4byte sSableyePose123
+.4byte sSableyePose124
+.4byte sSableyePose125
+.4byte sSableyePose126
+.4byte sSableyePose127
+.4byte sSableyePose128
+.4byte sSableyePose129
+.4byte sSableyePose130
+.4byte sSableyePose131
+.4byte sSableyePose132
+.4byte sSableyePose133
+.4byte sSableyePose134
+.4byte sSableyePose135
+.4byte sSableyePose136
+.4byte sSableyePose137
+.4byte sSableyePose138
+.4byte sSableyePose139
+.4byte sSableyePose140
+.4byte sSableyePose141
+.4byte sSableyePose142
+.4byte sSableyePose143
+.4byte sSableyePose144
+.4byte sSableyePose145
+.4byte sSableyePose146
+.4byte sSableyePose147
+.4byte sSableyePose148
+.4byte sSableyePose149
+.4byte sSableyePose150
+.4byte sSableyePose151
+.4byte sSableyePose152
+.4byte sSableyePose153
+.4byte sSableyePose154
+.4byte sSableyePose155
+.4byte sSableyePose156
+.4byte sSableyePose157
+.4byte sSableyePose158
+.4byte sSableyePose159
+.4byte sSableyePose160
+.4byte sSableyePose161
+.4byte sSableyePose162
+.4byte sSableyePose163
+.4byte sSableyePose164
+.4byte sSableyePose165
+.4byte sSableyePose166
+.4byte sSableyePose167
+.4byte sSableyePose168
+.4byte sSableyePose169
+.4byte sSableyePose170
+.4byte sSableyePose171
+.4byte sSableyePose172
+.4byte sSableyePose173
+.4byte sSableyePose174
+.4byte sSableyePose175
+.4byte sSableyePose176
+.4byte sSableyePose177
+.4byte sSableyePose178
+.4byte sSableyePose179
+.4byte sSableyePose180
+.4byte sSableyePose181
+.4byte sSableyePose182
+.4byte sSableyePose183
+.4byte sSableyePose184
+.4byte sSableyePose185
+.4byte sSableyePose186
+.4byte sSableyePose187
+.4byte sSableyePose188
+.4byte sSableyePose189
+.4byte sSableyePose190
+.4byte sSableyePose191
+.4byte sSableyePose192
+.4byte sSableyePose193
+.4byte sSableyePose194
+.4byte sSableyePose195
+.4byte sSableyePose196
+.4byte sSableyePose197
+.4byte sSableyePose198
+.4byte sSableyePose199
+.4byte sSableyePose200
+.4byte sSableyePose201
+.4byte sSableyePose202
+.4byte sSableyePose203
+.4byte sSableyePose204
+.4byte sSableyePose205
+.4byte sSableyePose206
+.4byte sSableyePose207
+.4byte sSableyePose208
+.4byte sSableyePose209
+.4byte sSableyePose210
+.4byte sSableyePose211
+.4byte sSableyePose212
+.4byte sSableyePose213
+.4byte sSableyePose214
+.4byte sSableyePose215
+.4byte sSableyePose216
+.4byte sSableyePose217
+.4byte sSableyePose218
+.4byte sSableyePose219
+.4byte sSableyePose220
+.4byte sSableyePose221
+.4byte sSableyePose222
+.4byte sSableyePose223
+.4byte sSableyePose224
+.4byte sSableyePose225
+.4byte sSableyePose226
+.4byte sSableyePose227
+.4byte sSableyePose228
+.4byte sSableyePose229
+.4byte sSableyePose230
+.4byte sSableyePose231
+.4byte sSableyePose232
+.4byte sSableyePose233
+.4byte sSableyePose234
+.4byte sSableyePose235
+.4byte sSableyePose236
+.4byte sSableyePose237
+.4byte sSableyePose238
+.4byte sSableyePose239
+.4byte sSableyePose240
+.4byte sSableyePose241
+.4byte sSableyePose242
+.4byte sSableyePose243
+.4byte sSableyePose244
+.4byte sSableyePose245
+.4byte sSableyePose246
+.4byte sSableyePose247
+.4byte sSableyePose248
+.4byte sSableyePose249
+.4byte sSableyePose250
+.4byte sSableyePose251
+.4byte sSableyePose252
+.4byte sSableyePose253
+.4byte sSableyePose254
+.4byte sSableyePose255
+.4byte sSableyePose256
+.4byte sSableyePose257
+.4byte sSableyePose258
+.4byte sSableyePose259
+.4byte sSableyePose260
+.4byte sSableyePose261
+.4byte sSableyePose262
+.4byte sSableyePose263
+.4byte sSableyePose264
+.4byte sSableyePose265
+.4byte sSableyePose266
+.4byte sSableyePose267
+.4byte sSableyePose268
+.4byte sSableyePose269
+.4byte sSableyePose270
+.4byte sSableyePose271
+.4byte sSableyePose272
+.4byte sSableyePose273
+.4byte sSableyePose274
+.4byte sSableyePose275
+.4byte sSableyePose276
+.4byte sSableyePose277
+.4byte sSableyePose278
+.4byte sSableyePose279
+.4byte sSableyePose280
+.4byte sSableyePose281
+.4byte sSableyePose282
+sAxPositionsSableye:
+.2byte   -1,   -7, 	  -9,   -5, 	   8,   -5, 	  -1,   -9
+.2byte   -2,   -6, 	  -9,   -6, 	   8,   -3, 	  -2,   -8
+.2byte    1,   -6, 	  -9,   -3, 	   8,   -6, 	   1,   -8
+.2byte    5,   -8, 	   7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte    6,   -7, 	   6,   -6, 	  -1,   -2, 	   0,   -6
+.2byte    4,   -7, 	   8,   -5, 	  -5,   -3, 	  -2,   -6
+.2byte    4,   -8, 	   4,   -7, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -7, 	   2,   -7, 	   2,   -3, 	  -2,   -6
+.2byte    3,   -7, 	   6,   -6, 	  -2,   -1, 	  -2,   -6
+.2byte    2,  -11, 	   6,   -4, 	  -1,   -6, 	  -2,   -7
+.2byte    3,   -9, 	   7,   -4, 	  -5,   -4, 	  -2,   -6
+.2byte    1,   -9, 	   5,   -2, 	   2,   -7, 	  -3,   -6
+.2byte   -1,  -11, 	   6,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -2,  -10, 	   6,   -4, 	  -6,   -8, 	  -1,   -8
+.2byte    1,  -10, 	   5,   -8, 	  -7,   -4, 	   0,   -8
+.2byte   -2,  -10, 	   1,   -9, 	  -7,   -4, 	   1,   -6
+.2byte   -2,   -8, 	   4,   -5, 	  -8,   -4, 	   1,   -5
+.2byte    0,   -9, 	  -1,   -8, 	  -6,   -2, 	   2,   -6
+.2byte   -5,   -8, 	  -5,   -7, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -7, 	  -3,   -7, 	  -3,   -3, 	   1,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   1,   -1, 	   1,   -6
+.2byte   -6,   -8, 	  -8,   -6, 	   2,   -3, 	   0,   -7
+.2byte   -7,   -7, 	  -7,   -6, 	   0,   -2, 	  -1,   -6
+.2byte   -5,   -7, 	  -9,   -5, 	   4,   -3, 	   1,   -6
+.2byte   -1,   -7, 	  -9,   -5, 	   8,   -5, 	  -1,   -9
+.2byte   -2,   -6, 	  -9,   -6, 	   8,   -3, 	  -2,   -8
+.2byte    1,   -6, 	  -9,   -3, 	   8,   -6, 	   1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte    5,   -8, 	   7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte    6,   -7, 	   6,   -6, 	  -1,   -2, 	   0,   -6
+.2byte    4,   -7, 	   8,   -5, 	  -5,   -3, 	  -2,   -6
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    4,   -8, 	   4,   -7, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -7, 	   2,   -7, 	   2,   -3, 	  -2,   -6
+.2byte    3,   -7, 	   6,   -6, 	  -2,   -1, 	  -2,   -6
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    2,  -11, 	   6,   -4, 	  -1,   -6, 	  -2,   -7
+.2byte    3,   -9, 	   7,   -4, 	  -5,   -4, 	  -2,   -6
+.2byte    1,   -9, 	   5,   -2, 	   2,   -7, 	  -3,   -6
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,  -11, 	   6,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -2,  -10, 	   6,   -4, 	  -6,   -8, 	  -1,   -8
+.2byte    1,  -10, 	   5,   -8, 	  -7,   -4, 	   0,   -8
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte   -2,  -10, 	   1,   -9, 	  -7,   -4, 	   1,   -6
+.2byte   -2,   -8, 	   4,   -5, 	  -8,   -4, 	   1,   -5
+.2byte    0,   -9, 	  -1,   -8, 	  -6,   -2, 	   2,   -6
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -5,   -8, 	  -5,   -7, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -7, 	  -3,   -7, 	  -3,   -3, 	   1,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   1,   -1, 	   1,   -6
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte   -6,   -8, 	  -8,   -6, 	   2,   -3, 	   0,   -7
+.2byte   -7,   -7, 	  -7,   -6, 	   0,   -2, 	  -1,   -6
+.2byte   -5,   -7, 	  -9,   -5, 	   4,   -3, 	   1,   -6
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -1,   -7, 	  -9,   -5, 	   8,   -5, 	  -1,   -9
+.2byte   -2,   -6, 	  -9,   -6, 	   8,   -3, 	  -2,   -8
+.2byte    1,   -6, 	  -9,   -3, 	   8,   -6, 	   1,   -8
+.2byte   -4,   -6, 	  -4,  -18, 	  -7,   -2, 	  -4,   -7
+.2byte   -4,   -6, 	  -4,  -18, 	  -7,   -2, 	  -4,   -7
+.2byte    3,   -5, 	  10,   -4, 	  11,  -11, 	   3,   -6
+.2byte    3,   -5, 	  10,   -4, 	  11,  -11, 	   3,   -6
+.2byte    5,   -8, 	   7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte    6,   -7, 	   6,   -6, 	  -1,   -2, 	   0,   -6
+.2byte    4,   -7, 	   8,   -5, 	  -5,   -3, 	  -2,   -6
+.2byte    6,   -6, 	  -6,    1, 	  -7,   -6, 	  -1,   -5
+.2byte    6,   -6, 	  -6,    1, 	  -7,   -6, 	  -1,   -5
+.2byte    7,   -7, 	  -1,  -19, 	   6,   -1, 	  -1,   -6
+.2byte    7,   -7, 	  -1,  -19, 	   6,   -1, 	  -1,   -6
+.2byte    4,   -8, 	   4,   -7, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -7, 	   2,   -7, 	   2,   -3, 	  -2,   -6
+.2byte    3,   -7, 	   6,   -6, 	  -2,   -1, 	  -2,   -6
+.2byte    7,   -6, 	   1,    3, 	  -3,   -5, 	  -1,   -8
+.2byte    7,   -6, 	   1,    3, 	  -3,   -5, 	  -1,   -8
+.2byte    4,   -8, 	  -2,  -16, 	  -4,  -18, 	   1,   -8
+.2byte    4,   -8, 	  -2,  -16, 	  -4,  -18, 	   1,   -8
+.2byte    2,  -11, 	   6,   -4, 	  -1,   -6, 	  -2,   -7
+.2byte    3,   -9, 	   7,   -4, 	  -5,   -4, 	  -2,   -6
+.2byte    1,   -9, 	   5,   -2, 	   2,   -7, 	  -3,   -6
+.2byte    5,  -10, 	   5,   -7, 	   8,   -2, 	   1,   -7
+.2byte    5,  -10, 	   5,   -7, 	   8,   -2, 	   1,   -7
+.2byte    3,  -10, 	  -8,  -17, 	  -6,  -16, 	  -1,   -5
+.2byte    3,  -10, 	  -8,  -17, 	  -6,  -16, 	  -1,   -5
+.2byte   -1,  -11, 	   6,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -2,  -10, 	   6,   -4, 	  -6,   -8, 	  -1,   -8
+.2byte    1,  -10, 	   5,   -8, 	  -7,   -4, 	   0,   -8
+.2byte    3,  -10, 	   3,  -15, 	   5,   -4, 	   0,   -7
+.2byte    3,  -10, 	   3,  -15, 	   5,   -4, 	   0,   -7
+.2byte   -3,  -10, 	 -11,   -5, 	  -8,   -8, 	  -1,   -8
+.2byte   -3,  -10, 	 -11,   -5, 	  -8,   -8, 	  -1,   -8
+.2byte   -2,  -10, 	   1,   -9, 	  -7,   -4, 	   1,   -6
+.2byte   -2,   -8, 	   4,   -5, 	  -8,   -4, 	   1,   -5
+.2byte    0,   -9, 	  -1,   -8, 	  -6,   -2, 	   2,   -6
+.2byte   -4,  -10, 	   5,  -16, 	   7,  -17, 	   0,   -8
+.2byte   -4,  -10, 	   5,  -16, 	   7,  -17, 	   0,   -8
+.2byte   -8,   -9, 	  -9,   -2, 	  -6,   -7, 	  -1,   -7
+.2byte   -8,   -9, 	  -9,   -2, 	  -6,   -7, 	  -1,   -7
+.2byte   -5,   -8, 	  -5,   -7, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -7, 	  -3,   -7, 	  -3,   -3, 	   1,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   1,   -1, 	   1,   -6
+.2byte   -5,   -8, 	   1,  -16, 	   3,  -18, 	  -2,   -8
+.2byte   -5,   -8, 	   1,  -16, 	   3,  -18, 	  -2,   -8
+.2byte   -8,   -6, 	  -2,    3, 	   2,   -5, 	   0,   -8
+.2byte   -8,   -6, 	  -2,    3, 	   2,   -5, 	   0,   -8
+.2byte   -6,   -8, 	  -8,   -6, 	   2,   -3, 	   0,   -7
+.2byte   -7,   -7, 	  -7,   -6, 	   0,   -2, 	  -1,   -6
+.2byte   -5,   -7, 	  -9,   -5, 	   4,   -3, 	   1,   -6
+.2byte   -8,   -7, 	   0,  -19, 	  -7,   -1, 	   0,   -6
+.2byte   -8,   -7, 	   0,  -19, 	  -7,   -1, 	   0,   -6
+.2byte   -7,   -6, 	   5,    1, 	   6,   -6, 	   0,   -5
+.2byte   -7,   -6, 	   5,    1, 	   6,   -6, 	   0,   -5
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -9, 	  -4,  -13, 	  -3,   -5, 	   0,   -7
+.2byte   -5,  -10, 	   6,  -11, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    7,   -9, 	   3,  -13, 	   2,   -5, 	  -1,   -7
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte   -1,   -7, 	  -9,   -5, 	   8,   -5, 	  -1,   -9
+.2byte   -2,   -6, 	  -9,   -6, 	   8,   -3, 	  -2,   -8
+.2byte    1,   -6, 	  -9,   -3, 	   8,   -6, 	   1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte    5,   -8, 	   7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte    6,   -7, 	   6,   -6, 	  -1,   -2, 	   0,   -6
+.2byte    4,   -7, 	   8,   -5, 	  -5,   -3, 	  -2,   -6
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    4,   -8, 	   4,   -7, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -7, 	   2,   -7, 	   2,   -3, 	  -2,   -6
+.2byte    3,   -7, 	   6,   -6, 	  -2,   -1, 	  -2,   -6
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    2,  -11, 	   6,   -4, 	  -1,   -6, 	  -2,   -7
+.2byte    3,   -9, 	   7,   -4, 	  -5,   -4, 	  -2,   -6
+.2byte    1,   -9, 	   5,   -2, 	   2,   -7, 	  -3,   -6
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,  -11, 	   6,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte   -2,  -10, 	   6,   -4, 	  -6,   -8, 	  -1,   -8
+.2byte    1,  -10, 	   5,   -8, 	  -7,   -4, 	   0,   -8
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte   -2,  -10, 	   1,   -9, 	  -7,   -4, 	   1,   -6
+.2byte   -2,   -8, 	   4,   -5, 	  -8,   -4, 	   1,   -5
+.2byte    0,   -9, 	  -1,   -8, 	  -6,   -2, 	   2,   -6
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -5,   -8, 	  -5,   -7, 	  -3,   -2, 	   1,   -7
+.2byte   -6,   -7, 	  -3,   -7, 	  -3,   -3, 	   1,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   1,   -1, 	   1,   -6
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte   -6,   -8, 	  -8,   -6, 	   2,   -3, 	   0,   -7
+.2byte   -7,   -7, 	  -7,   -6, 	   0,   -2, 	  -1,   -6
+.2byte   -5,   -7, 	  -9,   -5, 	   4,   -3, 	   1,   -6
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -4,   -6, 	  -4,   -2, 	   4,    0, 	   1,   -6
+.2byte   -5,   -7, 	  -4,   -2, 	   4,    0, 	   2,   -6
+.2byte   -1,  -11, 	 -10,   -9, 	   9,   -9, 	   0,  -10
+.2byte    2,  -13, 	   7,  -10, 	  -7,   -5, 	   1,   -9
+.2byte    3,  -14, 	  -3,   -8, 	  -4,   -5, 	  -2,  -10
+.2byte    2,  -12, 	   4,   -5, 	  -1,  -13, 	  -2,   -9
+.2byte   -1,  -14, 	   8,   -6, 	  -9,   -6, 	  -1,  -10
+.2byte   -3,  -14, 	   2,   -7, 	 -10,   -8, 	  -4,   -8
+.2byte   -4,  -14, 	   2,   -8, 	   3,   -5, 	   1,  -10
+.2byte   -3,  -13, 	  -8,  -10, 	   6,   -5, 	  -2,   -9
+.2byte   -1,   -7, 	  -9,   -5, 	   8,   -5, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte    5,   -8, 	   7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    4,   -8, 	   4,   -7, 	   2,   -2, 	  -2,   -7
+.2byte    9,   -9, 	   5,  -13, 	   4,   -5, 	   1,   -7
+.2byte    2,  -11, 	   6,   -4, 	  -1,   -6, 	  -2,   -7
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte   -1,  -11, 	   6,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte   -2,  -10, 	   1,   -9, 	  -7,   -4, 	   1,   -6
+.2byte   -6,  -10, 	   5,  -11, 	  -9,   -7, 	  -1,   -9
+.2byte   -5,   -8, 	  -5,   -7, 	  -3,   -2, 	   1,   -7
+.2byte  -10,   -9, 	  -6,  -13, 	  -5,   -5, 	  -2,   -7
+.2byte   -6,   -8, 	  -8,   -6, 	   2,   -3, 	   0,   -7
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte    0,   -5, 	   7,   -4, 	   8,  -11, 	   0,   -6
+.2byte   -7,   -6, 	   5,    1, 	   6,   -6, 	   0,   -5
+.2byte   -8,   -5, 	  -2,    4, 	   2,   -4, 	   0,   -7
+.2byte   -6,   -9, 	  -7,   -2, 	  -4,   -7, 	   1,   -7
+.2byte   -2,  -10, 	 -10,   -5, 	  -7,   -8, 	   0,   -8
+.2byte    3,  -11, 	  -8,  -18, 	  -6,  -17, 	  -1,   -6
+.2byte    4,   -8, 	  -2,  -16, 	  -4,  -18, 	   1,   -8
+.2byte    8,   -8, 	   0,  -20, 	   7,   -2, 	   0,   -7
+.2byte    0,   -5, 	   7,   -4, 	   8,  -11, 	   0,   -6
+.2byte    8,   -8, 	   0,  -20, 	   7,   -2, 	   0,   -7
+.2byte    3,   -8, 	  -3,  -16, 	  -5,  -18, 	   0,   -8
+.2byte    3,  -11, 	  -8,  -18, 	  -6,  -17, 	  -1,   -6
+.2byte   -2,  -10, 	 -10,   -5, 	  -7,   -8, 	   0,   -8
+.2byte   -7,  -10, 	  -8,   -3, 	  -5,   -8, 	   0,   -8
+.2byte   -8,   -5, 	  -2,    4, 	   2,   -4, 	   0,   -7
+.2byte   -6,   -5, 	   6,    2, 	   7,   -5, 	   1,   -4
+.2byte   -1,   -7, 	  -9,   -5, 	   8,   -5, 	  -1,   -9
+.2byte    1,   -6, 	  -9,   -3, 	   8,   -6, 	   1,   -8
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte    5,   -8, 	   7,   -6, 	  -3,   -3, 	  -1,   -7
+.2byte    5,   -7, 	   9,   -5, 	  -4,   -3, 	  -1,   -6
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte    4,   -8, 	   4,   -7, 	   2,   -2, 	  -2,   -7
+.2byte    4,   -7, 	   7,   -6, 	  -1,   -1, 	  -1,   -6
+.2byte    7,   -9, 	   3,  -13, 	   2,   -5, 	  -1,   -7
+.2byte    2,  -11, 	   6,   -4, 	  -1,   -6, 	  -2,   -7
+.2byte    1,  -10, 	   5,   -3, 	   2,   -8, 	  -3,   -7
+.2byte    3,  -10, 	   6,   -7, 	  -9,  -11, 	  -3,   -9
+.2byte   -1,  -11, 	   6,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte    1,  -10, 	   5,   -8, 	  -7,   -4, 	   0,   -8
+.2byte    0,  -12, 	   8,  -10, 	  -9,  -10, 	   0,  -10
+.2byte   -2,  -10, 	   1,   -9, 	  -7,   -4, 	   1,   -6
+.2byte   -1,   -9, 	  -2,   -8, 	  -7,   -2, 	   1,   -6
+.2byte   -4,  -10, 	   7,  -11, 	  -7,   -7, 	   1,   -9
+.2byte   -5,   -8, 	  -5,   -7, 	  -3,   -2, 	   1,   -7
+.2byte   -5,   -7, 	  -8,   -6, 	   0,   -1, 	   0,   -6
+.2byte   -7,   -9, 	  -3,  -13, 	  -2,   -5, 	   1,   -7
+.2byte   -7,   -8, 	  -9,   -6, 	   1,   -3, 	  -1,   -7
+.2byte   -6,   -7, 	 -10,   -5, 	   3,   -3, 	   0,   -6
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -1,   -6, 	 -12,   -7, 	  10,   -7, 	  -1,   -8
+.2byte   -8,   -8, 	  -8,  -12, 	   7,   -7, 	   0,   -9
+.2byte   -8,   -9, 	  -4,  -13, 	  -3,   -5, 	   0,   -7
+.2byte   -5,  -10, 	   6,  -11, 	  -8,   -7, 	   0,   -9
+.2byte    0,  -11, 	   8,   -9, 	  -9,   -9, 	   0,   -9
+.2byte    5,  -10, 	   8,   -7, 	  -7,  -11, 	  -1,   -9
+.2byte    7,   -9, 	   3,  -13, 	   2,   -5, 	  -1,   -7
+.2byte    7,   -8, 	   7,  -12, 	  -8,   -7, 	  -1,   -9
+.2byte   -1,   -7, 	  -9,   -5, 	   8,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	  -8,   -6, 	   2,   -3, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -7, 	  -3,   -2, 	   1,   -7
+.2byte   -2,  -10, 	   1,   -9, 	  -7,   -4, 	   1,   -6
+.2byte   -1,  -11, 	   6,   -6, 	  -7,   -6, 	  -1,   -9
+.2byte    2,  -11, 	   6,   -4, 	  -1,   -6, 	  -2,   -7
+.2byte    4,   -8, 	   4,   -7, 	   2,   -2, 	  -2,   -7
+.2byte    5,   -8, 	   7,   -6, 	  -3,   -3, 	  -1,   -7
+sSableyeAnimTable1:
+.4byte sSableyeAnims_1_1
+.4byte sSableyeAnims_1_2
+.4byte sSableyeAnims_1_3
+.4byte sSableyeAnims_1_4
+.4byte sSableyeAnims_1_5
+.4byte sSableyeAnims_1_6
+.4byte sSableyeAnims_1_7
+.4byte sSableyeAnims_1_8
+sSableyeAnimTable2:
+.4byte sSableyeAnims_2_1
+.4byte sSableyeAnims_2_2
+.4byte sSableyeAnims_2_3
+.4byte sSableyeAnims_2_4
+.4byte sSableyeAnims_2_5
+.4byte sSableyeAnims_2_6
+.4byte sSableyeAnims_2_7
+.4byte sSableyeAnims_2_8
+sSableyeAnimTable3:
+.4byte sSableyeAnims_3_1
+.4byte sSableyeAnims_3_2
+.4byte sSableyeAnims_3_3
+.4byte sSableyeAnims_3_4
+.4byte sSableyeAnims_3_5
+.4byte sSableyeAnims_3_6
+.4byte sSableyeAnims_3_7
+.4byte sSableyeAnims_3_8
+sSableyeAnimTable4:
+.4byte sSableyeAnims_4_1
+.4byte sSableyeAnims_4_2
+.4byte sSableyeAnims_4_3
+.4byte sSableyeAnims_4_4
+.4byte sSableyeAnims_4_5
+.4byte sSableyeAnims_4_6
+.4byte sSableyeAnims_4_7
+.4byte sSableyeAnims_4_8
+sSableyeAnimTable5:
+.4byte sSableyeAnims_5_1
+.4byte sSableyeAnims_5_2
+.4byte sSableyeAnims_5_3
+.4byte sSableyeAnims_5_4
+.4byte sSableyeAnims_5_5
+.4byte sSableyeAnims_5_6
+.4byte sSableyeAnims_5_7
+.4byte sSableyeAnims_5_8
+sSableyeAnimTable6:
+.4byte sSableyeAnims_6_1
+.4byte sSableyeAnims_6_1
+.4byte sSableyeAnims_6_1
+.4byte sSableyeAnims_6_1
+.4byte sSableyeAnims_6_1
+.4byte sSableyeAnims_6_1
+.4byte sSableyeAnims_6_1
+.4byte sSableyeAnims_6_1
+sSableyeAnimTable7:
+.4byte sSableyeAnims_7_1
+.4byte sSableyeAnims_7_2
+.4byte sSableyeAnims_7_3
+.4byte sSableyeAnims_7_4
+.4byte sSableyeAnims_7_5
+.4byte sSableyeAnims_7_6
+.4byte sSableyeAnims_7_7
+.4byte sSableyeAnims_7_8
+sSableyeAnimTable8:
+.4byte sSableyeAnims_8_1
+.4byte sSableyeAnims_8_2
+.4byte sSableyeAnims_8_3
+.4byte sSableyeAnims_8_4
+.4byte sSableyeAnims_8_5
+.4byte sSableyeAnims_8_6
+.4byte sSableyeAnims_8_7
+.4byte sSableyeAnims_8_8
+sSableyeAnimTable9:
+.4byte sSableyeAnims_9_1
+.4byte sSableyeAnims_9_2
+.4byte sSableyeAnims_9_3
+.4byte sSableyeAnims_9_4
+.4byte sSableyeAnims_9_5
+.4byte sSableyeAnims_9_6
+.4byte sSableyeAnims_9_7
+.4byte sSableyeAnims_9_8
+sSableyeAnimTable10:
+.4byte sSableyeAnims_10_1
+.4byte sSableyeAnims_10_2
+.4byte sSableyeAnims_10_3
+.4byte sSableyeAnims_10_4
+.4byte sSableyeAnims_10_5
+.4byte sSableyeAnims_10_6
+.4byte sSableyeAnims_10_7
+.4byte sSableyeAnims_10_8
+sSableyeAnimTable11:
+.4byte sSableyeAnims_11_1
+.4byte sSableyeAnims_11_2
+.4byte sSableyeAnims_11_3
+.4byte sSableyeAnims_11_4
+.4byte sSableyeAnims_11_5
+.4byte sSableyeAnims_11_6
+.4byte sSableyeAnims_11_7
+.4byte sSableyeAnims_11_8
+sSableyeAnimTable12:
+.4byte sSableyeAnims_12_1
+.4byte sSableyeAnims_12_2
+.4byte sSableyeAnims_12_3
+.4byte sSableyeAnims_12_4
+.4byte sSableyeAnims_12_5
+.4byte sSableyeAnims_12_6
+.4byte sSableyeAnims_12_7
+.4byte sSableyeAnims_12_8
+sSableyeAnimTable13:
+.4byte sSableyeAnims_13_1
+.4byte sSableyeAnims_13_2
+.4byte sSableyeAnims_13_3
+.4byte sSableyeAnims_13_4
+.4byte sSableyeAnims_13_5
+.4byte sSableyeAnims_13_6
+.4byte sSableyeAnims_13_7
+.4byte sSableyeAnims_13_8
+sAxAnimationsSableye:
+.4byte sSableyeAnimTable1
+.4byte sSableyeAnimTable2
+.4byte sSableyeAnimTable3
+.4byte sSableyeAnimTable4
+.4byte sSableyeAnimTable5
+.4byte sSableyeAnimTable6
+.4byte sSableyeAnimTable7
+.4byte sSableyeAnimTable8
+.4byte sSableyeAnimTable9
+.4byte sSableyeAnimTable10
+.4byte sSableyeAnimTable11
+.4byte sSableyeAnimTable12
+.4byte sSableyeAnimTable13
+sAxSpritesSableye:
+.4byte sSableyeSprites1
+.4byte sSableyeSprites2
+.4byte sSableyeSprites3
+.4byte sSableyeSprites4
+.4byte sSableyeSprites5
+.4byte sSableyeSprites6
+.4byte sSableyeSprites7
+.4byte sSableyeSprites8
+.4byte sSableyeSprites9
+.4byte sSableyeSprites10
+.4byte sSableyeSprites11
+.4byte sSableyeSprites12
+.4byte sSableyeSprites13
+.4byte sSableyeSprites14
+.4byte sSableyeSprites15
+.4byte sSableyeSprites16
+.4byte sSableyeSprites17
+.4byte sSableyeSprites18
+.4byte sSableyeSprites19
+.4byte sSableyeSprites20
+.4byte sSableyeSprites21
+.4byte sSableyeSprites22
+.4byte sSableyeSprites23
+.4byte sSableyeSprites24
+.4byte sSableyeSprites25
+.4byte sSableyeSprites26
+.4byte sSableyeSprites27
+.4byte sSableyeSprites28
+.4byte sSableyeSprites29
+.4byte sSableyeSprites30
+.4byte sSableyeSprites31
+.4byte sSableyeSprites32
+.4byte sSableyeSprites33
+.4byte sSableyeSprites34
+.4byte sSableyeSprites35
+.4byte sSableyeSprites36
+.4byte sSableyeSprites37
+.4byte sSableyeSprites38
+.4byte sSableyeSprites39
+.4byte sSableyeSprites40
+.4byte sSableyeSprites41
+.4byte sSableyeSprites42
+.4byte sSableyeSprites43
+.4byte sSableyeSprites44
+.4byte sSableyeSprites45
+.4byte sSableyeSprites46
+.4byte sSableyeSprites47
+.4byte sSableyeSprites48
+.4byte sSableyeSprites49
+.4byte sSableyeSprites50
+.4byte sSableyeSprites51
+.4byte sSableyeSprites52
+.4byte sSableyeSprites53
+.4byte sSableyeSprites54
+.4byte sSableyeSprites55
+.4byte sSableyeSprites56
+.4byte sSableyeSprites57
+.4byte sSableyeSprites58
+.4byte sSableyeSprites59
+.4byte sSableyeSprites60
+.4byte sSableyeSprites61
+.4byte sSableyeSprites62
+.4byte sSableyeSprites63
+.4byte sSableyeSprites64
+sAxMainSableye:
+ax_main sAxPosesSableye, sAxAnimationsSableye, 13, sAxSpritesSableye, sAxPositionsSableye

--- a/data/ax/salamence.inc
+++ b/data/ax/salamence.inc
@@ -1,0 +1,4270 @@
+.global gAxSalamence
+gAxSalamence:
+ax_siro sAxMainSalamence
+sSalamencePose1:
+ax_pose 0, 0x01df, 0x80e8, 0x5c00
+ax_pose 1, 0x81df, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose2:
+ax_pose 2, 0x01e1, 0x80e8, 0x5c00
+ax_pose 3, 0x81e1, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose3:
+ax_pose 4, 0x01dd, 0x90f1, 0x5c00
+ax_pose 5, 0x81dd, 0x50e9, 0x5c10
+ax_pose 6, 0x41fd, 0x10f4, 0x5c14
+ax_pose 7, 0x01fd, 0x10ec, 0x5c16
+ax_pose_terminator
+sSalamencePose4:
+ax_pose 8, 0x01e0, 0x90f0, 0x5c00
+ax_pose 9, 0x81e8, 0x10e8, 0x5c10
+ax_pose 10, 0x0200, 0x10f0, 0x5c12
+ax_pose_terminator
+sSalamencePose5:
+ax_pose 11, 0x01dd, 0x90f6, 0x5c00
+ax_pose 12, 0x81e5, 0x50ee, 0x5c10
+ax_pose 13, 0x81f5, 0x10e6, 0x5c14
+ax_pose 14, 0x01fd, 0x10f6, 0x5c16
+ax_pose_terminator
+sSalamencePose6:
+ax_pose 15, 0x41df, 0x90f8, 0x5c00
+ax_pose 16, 0x01ef, 0x50f8, 0x5c08
+ax_pose 17, 0x81e7, 0x50f0, 0x5c0c
+ax_pose 18, 0x81f7, 0x10e8, 0x5c10
+ax_pose 19, 0x01ff, 0x10f8, 0x5c12
+ax_pose_terminator
+sSalamencePose7:
+ax_pose 20, 0x01d9, 0x90f0, 0x5c00
+ax_pose 21, 0x01e1, 0x10e8, 0x5c10
+ax_pose 22, 0x81e9, 0x10e8, 0x5c11
+ax_pose 23, 0x41f9, 0x50f0, 0x5c13
+ax_pose 24, 0x4201, 0x10ec, 0x5c17
+ax_pose_terminator
+sSalamencePose8:
+ax_pose 25, 0x01db, 0x90f2, 0x5c00
+ax_pose 26, 0x01e3, 0x10ea, 0x5c10
+ax_pose 27, 0x81eb, 0x10ea, 0x5c11
+ax_pose 28, 0x41fb, 0x10fa, 0x5c13
+ax_pose 29, 0x01fb, 0x10f2, 0x5c15
+ax_pose 30, 0x0203, 0x10f2, 0x5c16
+ax_pose_terminator
+sSalamencePose9:
+ax_pose 31, 0x01d9, 0x80e8, 0x5c00
+ax_pose 32, 0x81d9, 0x8108, 0x5c10
+ax_pose 33, 0x41f9, 0x00f0, 0x5c18
+ax_pose 34, 0x0201, 0x00fc, 0x5c1a
+ax_pose 35, 0x41f9, 0x0100, 0x5c1b
+ax_pose_terminator
+sSalamencePose10:
+ax_pose 36, 0x01e0, 0x80e8, 0x5c00
+ax_pose 37, 0x81e0, 0x8108, 0x5c10
+ax_pose 38, 0x41d8, 0x00f8, 0x5c18
+ax_pose 39, 0x8200, 0x00fb, 0x5c1a
+ax_pose_terminator
+sSalamencePose11:
+ax_pose 20, 0x01d9, 0x80f0, 0x5c00
+ax_pose 21, 0x01e1, 0x0110, 0x5c10
+ax_pose 22, 0x81e9, 0x0110, 0x5c11
+ax_pose 23, 0x41f9, 0x40f0, 0x5c13
+ax_pose 24, 0x4201, 0x0104, 0x5c17
+ax_pose_terminator
+sSalamencePose12:
+ax_pose 25, 0x01db, 0x80ee, 0x5c00
+ax_pose 26, 0x01e3, 0x010e, 0x5c10
+ax_pose 27, 0x81eb, 0x010e, 0x5c11
+ax_pose 28, 0x41fb, 0x00f6, 0x5c13
+ax_pose 29, 0x01fb, 0x0106, 0x5c15
+ax_pose 30, 0x0203, 0x0106, 0x5c16
+ax_pose_terminator
+sSalamencePose13:
+ax_pose 11, 0x01dd, 0x80ea, 0x5c00
+ax_pose 12, 0x81e5, 0x410a, 0x5c10
+ax_pose 13, 0x81f5, 0x0112, 0x5c14
+ax_pose 14, 0x01fd, 0x0102, 0x5c16
+ax_pose_terminator
+sSalamencePose14:
+ax_pose 15, 0x41df, 0x80e8, 0x5c00
+ax_pose 16, 0x01ef, 0x40f8, 0x5c08
+ax_pose 17, 0x81e7, 0x4108, 0x5c0c
+ax_pose 18, 0x81f7, 0x0110, 0x5c10
+ax_pose 19, 0x01ff, 0x0100, 0x5c12
+ax_pose_terminator
+sSalamencePose15:
+ax_pose 4, 0x01dd, 0x80ef, 0x5c00
+ax_pose 5, 0x81dd, 0x410f, 0x5c10
+ax_pose 6, 0x41fd, 0x00fc, 0x5c14
+ax_pose 7, 0x01fd, 0x010c, 0x5c16
+ax_pose_terminator
+sSalamencePose16:
+ax_pose 8, 0x01e0, 0x80f0, 0x5c00
+ax_pose 9, 0x81e8, 0x0110, 0x5c10
+ax_pose 10, 0x0200, 0x0108, 0x5c12
+ax_pose_terminator
+sSalamencePose17:
+ax_pose 40, 0x41e5, 0x80df, 0x5c00
+ax_pose 41, 0x41e5, 0x80ff, 0x5c08
+ax_pose 42, 0x41f5, 0x80ef, 0x5c10
+ax_pose_terminator
+sSalamencePose18:
+ax_pose 43, 0x01e2, 0x80e7, 0x5c00
+ax_pose 44, 0x81e2, 0x8107, 0x5c10
+ax_pose 45, 0x0202, 0x0107, 0x5c18
+ax_pose 46, 0x0202, 0x00ef, 0x5c19
+ax_pose_terminator
+sSalamencePose19:
+ax_pose 47, 0x01dc, 0x80e7, 0x5c00
+ax_pose 48, 0x81dc, 0x8107, 0x5c10
+ax_pose 49, 0x01fc, 0x00fa, 0x5c18
+ax_pose_terminator
+sSalamencePose20:
+ax_pose 50, 0x41e1, 0xc0e0, 0x5c00
+ax_pose 51, 0x01f9, 0x40f7, 0x5c20
+ax_pose_terminator
+sSalamencePose21:
+ax_pose 50, 0x41e1, 0xc0e0, 0x5c00
+ax_pose 52, 0x01f9, 0x40f7, 0x5c20
+ax_pose_terminator
+sSalamencePose22:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+sSalamencePose23:
+ax_pose 57, 0x01e2, 0x90f0, 0x5c00
+ax_pose 58, 0x01ee, 0x50e0, 0x5c10
+ax_pose 59, 0x0202, 0x10fa, 0x5c14
+ax_pose_terminator
+sSalamencePose24:
+ax_pose 60, 0x01db, 0x90ef, 0x5c00
+ax_pose 61, 0x81db, 0x90df, 0x5c10
+ax_pose 62, 0x01fb, 0x10f9, 0x5c18
+ax_pose 63, 0x01fb, 0x10f1, 0x5c19
+ax_pose 64, 0x01fb, 0x10e9, 0x5c1a
+ax_pose_terminator
+sSalamencePose25:
+ax_pose 65, 0x01e9, 0x1110, 0x5c00
+ax_pose 66, 0x01e1, 0x90f0, 0x5c01
+ax_pose 67, 0x81e1, 0x50e8, 0x5c11
+ax_pose 68, 0x01f5, 0x5104, 0x5c15
+ax_pose_terminator
+sSalamencePose26:
+ax_pose 65, 0x01e9, 0x1110, 0x5c00
+ax_pose 66, 0x01e1, 0x90f0, 0x5c01
+ax_pose 67, 0x81e1, 0x50e8, 0x5c11
+ax_pose 69, 0x01f5, 0x5104, 0x5c15
+ax_pose_terminator
+sSalamencePose27:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose28:
+ax_pose 72, 0x01e2, 0x90f1, 0x5c00
+ax_pose 73, 0x01f2, 0x50e2, 0x5c10
+ax_pose 74, 0x0202, 0x1104, 0x5c14
+ax_pose 75, 0x0202, 0x10f6, 0x5c15
+ax_pose_terminator
+sSalamencePose29:
+ax_pose 76, 0x01dd, 0x90ec, 0x5c00
+ax_pose 77, 0x81ed, 0x10e4, 0x5c10
+ax_pose 78, 0x01fd, 0x10e5, 0x5c12
+ax_pose 79, 0x41fd, 0x10ed, 0x5c13
+ax_pose_terminator
+sSalamencePose30:
+ax_pose 80, 0x01e2, 0x90eb, 0x5c00
+ax_pose 81, 0x01f4, 0x10e3, 0x5c10
+ax_pose 82, 0x01ed, 0x510b, 0x5c11
+ax_pose_terminator
+sSalamencePose31:
+ax_pose 80, 0x01e2, 0x90eb, 0x5c00
+ax_pose 81, 0x01f4, 0x10e3, 0x5c10
+ax_pose 83, 0x01ed, 0x510b, 0x5c11
+ax_pose_terminator
+sSalamencePose32:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose33:
+ax_pose 87, 0x01e6, 0x90f0, 0x5c00
+ax_pose 88, 0x81e6, 0x90e0, 0x5c10
+ax_pose 89, 0x41de, 0x10f0, 0x5c18
+ax_pose 90, 0x41de, 0x1100, 0x5c1a
+ax_pose_terminator
+sSalamencePose34:
+ax_pose 91, 0x01da, 0x90ea, 0x5c00
+ax_pose 92, 0x01fa, 0x50ea, 0x5c10
+ax_pose 93, 0x81ea, 0x110a, 0x5c14
+ax_pose 94, 0x01fa, 0x50fa, 0x5c16
+ax_pose_terminator
+sSalamencePose35:
+ax_pose 95, 0x01e4, 0x90f7, 0x5c00
+ax_pose 96, 0x81e4, 0x90e7, 0x5c10
+ax_pose 97, 0x0204, 0x10ff, 0x5c18
+ax_pose_terminator
+sSalamencePose36:
+ax_pose 98, 0x01e4, 0x80e8, 0x5c00
+ax_pose 99, 0x81e4, 0x8108, 0x5c10
+ax_pose 100, 0x4204, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose37:
+ax_pose 101, 0x01e7, 0x80eb, 0x5c00
+ax_pose 102, 0x81e7, 0x810b, 0x5c10
+ax_pose 103, 0x41df, 0x40ef, 0x5c18
+ax_pose_terminator
+sSalamencePose38:
+ax_pose 104, 0x01e3, 0x80eb, 0x5c00
+ax_pose 105, 0x81e3, 0x810b, 0x5c10
+ax_pose 106, 0x41dc, 0x00f7, 0x5c18
+ax_pose 107, 0x0203, 0x010b, 0x5c1a
+ax_pose 108, 0x4203, 0x00fb, 0x5c1b
+ax_pose_terminator
+sSalamencePose39:
+ax_pose 109, 0x01e1, 0x80eb, 0x5c00
+ax_pose 110, 0x81e1, 0x810b, 0x5c10
+ax_pose 111, 0x0201, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose40:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose41:
+ax_pose 87, 0x01e6, 0x80f0, 0x5c00
+ax_pose 88, 0x81e6, 0x8110, 0x5c10
+ax_pose 89, 0x41de, 0x0100, 0x5c18
+ax_pose 90, 0x41de, 0x00f0, 0x5c1a
+ax_pose_terminator
+sSalamencePose42:
+ax_pose 91, 0x01da, 0x80f6, 0x5c00
+ax_pose 92, 0x01fa, 0x4106, 0x5c10
+ax_pose 93, 0x81ea, 0x00ee, 0x5c14
+ax_pose 94, 0x01fa, 0x40f6, 0x5c16
+ax_pose_terminator
+sSalamencePose43:
+ax_pose 95, 0x01e4, 0x80e9, 0x5c00
+ax_pose 96, 0x81e4, 0x8109, 0x5c10
+ax_pose 97, 0x0204, 0x00f9, 0x5c18
+ax_pose_terminator
+sSalamencePose44:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose45:
+ax_pose 72, 0x01e2, 0x80ef, 0x5c00
+ax_pose 73, 0x01f2, 0x410e, 0x5c10
+ax_pose 74, 0x0202, 0x00f4, 0x5c14
+ax_pose 75, 0x0202, 0x0102, 0x5c15
+ax_pose_terminator
+sSalamencePose46:
+ax_pose 76, 0x01dd, 0x80f4, 0x5c00
+ax_pose 77, 0x81ed, 0x0114, 0x5c10
+ax_pose 78, 0x01fd, 0x0113, 0x5c12
+ax_pose 79, 0x41fd, 0x0103, 0x5c13
+ax_pose_terminator
+sSalamencePose47:
+ax_pose 80, 0x01e2, 0x80f5, 0x5c00
+ax_pose 81, 0x01f4, 0x0115, 0x5c10
+ax_pose 82, 0x01ed, 0x40e5, 0x5c11
+ax_pose_terminator
+sSalamencePose48:
+ax_pose 80, 0x01e2, 0x80f5, 0x5c00
+ax_pose 81, 0x01f4, 0x0115, 0x5c10
+ax_pose 83, 0x01ed, 0x40e5, 0x5c11
+ax_pose_terminator
+sSalamencePose49:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose50:
+ax_pose 57, 0x01e2, 0x80f0, 0x5c00
+ax_pose 58, 0x01ee, 0x4110, 0x5c10
+ax_pose 59, 0x0202, 0x00fe, 0x5c14
+ax_pose_terminator
+sSalamencePose51:
+ax_pose 60, 0x01db, 0x80f1, 0x5c00
+ax_pose 61, 0x81db, 0x8111, 0x5c10
+ax_pose 62, 0x01fb, 0x00ff, 0x5c18
+ax_pose 63, 0x01fb, 0x0107, 0x5c19
+ax_pose 64, 0x01fb, 0x010f, 0x5c1a
+ax_pose_terminator
+sSalamencePose52:
+ax_pose 65, 0x01e9, 0x00e8, 0x5c00
+ax_pose 66, 0x01e1, 0x80f0, 0x5c01
+ax_pose 67, 0x81e1, 0x4110, 0x5c11
+ax_pose 68, 0x01f5, 0x40ec, 0x5c15
+ax_pose_terminator
+sSalamencePose53:
+ax_pose 65, 0x01e9, 0x00e8, 0x5c00
+ax_pose 66, 0x01e1, 0x80f0, 0x5c01
+ax_pose 67, 0x81e1, 0x4110, 0x5c11
+ax_pose 69, 0x01f5, 0x40ec, 0x5c15
+ax_pose_terminator
+sSalamencePose54:
+ax_pose 40, 0x41e5, 0x80df, 0x5c00
+ax_pose 41, 0x41e5, 0x80ff, 0x5c08
+ax_pose 42, 0x41f5, 0x80ef, 0x5c10
+ax_pose_terminator
+sSalamencePose55:
+ax_pose 43, 0x01e2, 0x80e7, 0x5c00
+ax_pose 44, 0x81e2, 0x8107, 0x5c10
+ax_pose 45, 0x0202, 0x0107, 0x5c18
+ax_pose 46, 0x0202, 0x00ef, 0x5c19
+ax_pose_terminator
+sSalamencePose56:
+ax_pose 47, 0x01dc, 0x80e7, 0x5c00
+ax_pose 48, 0x81dc, 0x8107, 0x5c10
+ax_pose 49, 0x01fc, 0x00fa, 0x5c18
+ax_pose_terminator
+sSalamencePose57:
+ax_pose 50, 0x41e1, 0xc0e0, 0x5c00
+ax_pose 51, 0x01f9, 0x40f7, 0x5c20
+ax_pose_terminator
+sSalamencePose58:
+ax_pose 50, 0x41e1, 0xc0e0, 0x5c00
+ax_pose 52, 0x01f9, 0x40f7, 0x5c20
+ax_pose_terminator
+sSalamencePose59:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+sSalamencePose60:
+ax_pose 57, 0x01e2, 0x90f0, 0x5c00
+ax_pose 58, 0x01ee, 0x50e0, 0x5c10
+ax_pose 59, 0x0202, 0x10fa, 0x5c14
+ax_pose_terminator
+sSalamencePose61:
+ax_pose 60, 0x01db, 0x90ef, 0x5c00
+ax_pose 61, 0x81db, 0x90df, 0x5c10
+ax_pose 62, 0x01fb, 0x10f9, 0x5c18
+ax_pose 63, 0x01fb, 0x10f1, 0x5c19
+ax_pose 64, 0x01fb, 0x10e9, 0x5c1a
+ax_pose_terminator
+sSalamencePose62:
+ax_pose 65, 0x01e9, 0x1110, 0x5c00
+ax_pose 66, 0x01e1, 0x90f0, 0x5c01
+ax_pose 67, 0x81e1, 0x50e8, 0x5c11
+ax_pose 68, 0x01f5, 0x5104, 0x5c15
+ax_pose_terminator
+sSalamencePose63:
+ax_pose 65, 0x01e9, 0x1110, 0x5c00
+ax_pose 66, 0x01e1, 0x90f0, 0x5c01
+ax_pose 67, 0x81e1, 0x50e8, 0x5c11
+ax_pose 69, 0x01f5, 0x5104, 0x5c15
+ax_pose_terminator
+sSalamencePose64:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose65:
+ax_pose 72, 0x01e2, 0x90f1, 0x5c00
+ax_pose 73, 0x01f2, 0x50e2, 0x5c10
+ax_pose 74, 0x0202, 0x1104, 0x5c14
+ax_pose 75, 0x0202, 0x10f6, 0x5c15
+ax_pose_terminator
+sSalamencePose66:
+ax_pose 76, 0x01dd, 0x90ec, 0x5c00
+ax_pose 77, 0x81ed, 0x10e4, 0x5c10
+ax_pose 78, 0x01fd, 0x10e5, 0x5c12
+ax_pose 79, 0x41fd, 0x10ed, 0x5c13
+ax_pose_terminator
+sSalamencePose67:
+ax_pose 80, 0x01e2, 0x90eb, 0x5c00
+ax_pose 81, 0x01f4, 0x10e3, 0x5c10
+ax_pose 82, 0x01ed, 0x510b, 0x5c11
+ax_pose_terminator
+sSalamencePose68:
+ax_pose 80, 0x01e2, 0x90eb, 0x5c00
+ax_pose 81, 0x01f4, 0x10e3, 0x5c10
+ax_pose 83, 0x01ed, 0x510b, 0x5c11
+ax_pose_terminator
+sSalamencePose69:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose70:
+ax_pose 87, 0x01e6, 0x90f0, 0x5c00
+ax_pose 88, 0x81e6, 0x90e0, 0x5c10
+ax_pose 89, 0x41de, 0x10f0, 0x5c18
+ax_pose 90, 0x41de, 0x1100, 0x5c1a
+ax_pose_terminator
+sSalamencePose71:
+ax_pose 91, 0x01da, 0x90ea, 0x5c00
+ax_pose 92, 0x01fa, 0x50ea, 0x5c10
+ax_pose 93, 0x81ea, 0x110a, 0x5c14
+ax_pose 94, 0x01fa, 0x50fa, 0x5c16
+ax_pose_terminator
+sSalamencePose72:
+ax_pose 95, 0x01e4, 0x90f7, 0x5c00
+ax_pose 96, 0x81e4, 0x90e7, 0x5c10
+ax_pose 97, 0x0204, 0x10ff, 0x5c18
+ax_pose_terminator
+sSalamencePose73:
+ax_pose 98, 0x01e4, 0x80e8, 0x5c00
+ax_pose 99, 0x81e4, 0x8108, 0x5c10
+ax_pose 100, 0x4204, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose74:
+ax_pose 101, 0x01e7, 0x80eb, 0x5c00
+ax_pose 102, 0x81e7, 0x810b, 0x5c10
+ax_pose 103, 0x41df, 0x40ef, 0x5c18
+ax_pose_terminator
+sSalamencePose75:
+ax_pose 104, 0x01e3, 0x80eb, 0x5c00
+ax_pose 105, 0x81e3, 0x810b, 0x5c10
+ax_pose 106, 0x41dc, 0x00f7, 0x5c18
+ax_pose 107, 0x0203, 0x010b, 0x5c1a
+ax_pose 108, 0x4203, 0x00fb, 0x5c1b
+ax_pose_terminator
+sSalamencePose76:
+ax_pose 109, 0x01e1, 0x80eb, 0x5c00
+ax_pose 110, 0x81e1, 0x810b, 0x5c10
+ax_pose 111, 0x0201, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose77:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose78:
+ax_pose 87, 0x01e6, 0x80f0, 0x5c00
+ax_pose 88, 0x81e6, 0x8110, 0x5c10
+ax_pose 89, 0x41de, 0x0100, 0x5c18
+ax_pose 90, 0x41de, 0x00f0, 0x5c1a
+ax_pose_terminator
+sSalamencePose79:
+ax_pose 91, 0x01da, 0x80f6, 0x5c00
+ax_pose 92, 0x01fa, 0x4106, 0x5c10
+ax_pose 93, 0x81ea, 0x00ee, 0x5c14
+ax_pose 94, 0x01fa, 0x40f6, 0x5c16
+ax_pose_terminator
+sSalamencePose80:
+ax_pose 95, 0x01e4, 0x80e9, 0x5c00
+ax_pose 96, 0x81e4, 0x8109, 0x5c10
+ax_pose 97, 0x0204, 0x00f9, 0x5c18
+ax_pose_terminator
+sSalamencePose81:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose82:
+ax_pose 72, 0x01e2, 0x80ef, 0x5c00
+ax_pose 73, 0x01f2, 0x410e, 0x5c10
+ax_pose 74, 0x0202, 0x00f4, 0x5c14
+ax_pose 75, 0x0202, 0x0102, 0x5c15
+ax_pose_terminator
+sSalamencePose83:
+ax_pose 76, 0x01dd, 0x80f4, 0x5c00
+ax_pose 77, 0x81ed, 0x0114, 0x5c10
+ax_pose 78, 0x01fd, 0x0113, 0x5c12
+ax_pose 79, 0x41fd, 0x0103, 0x5c13
+ax_pose_terminator
+sSalamencePose84:
+ax_pose 80, 0x01e2, 0x80f5, 0x5c00
+ax_pose 81, 0x01f4, 0x0115, 0x5c10
+ax_pose 82, 0x01ed, 0x40e5, 0x5c11
+ax_pose_terminator
+sSalamencePose85:
+ax_pose 80, 0x01e2, 0x80f5, 0x5c00
+ax_pose 81, 0x01f4, 0x0115, 0x5c10
+ax_pose 83, 0x01ed, 0x40e5, 0x5c11
+ax_pose_terminator
+sSalamencePose86:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose87:
+ax_pose 57, 0x01e2, 0x80f0, 0x5c00
+ax_pose 58, 0x01ee, 0x4110, 0x5c10
+ax_pose 59, 0x0202, 0x00fe, 0x5c14
+ax_pose_terminator
+sSalamencePose88:
+ax_pose 60, 0x01db, 0x80f1, 0x5c00
+ax_pose 61, 0x81db, 0x8111, 0x5c10
+ax_pose 62, 0x01fb, 0x00ff, 0x5c18
+ax_pose 63, 0x01fb, 0x0107, 0x5c19
+ax_pose 64, 0x01fb, 0x010f, 0x5c1a
+ax_pose_terminator
+sSalamencePose89:
+ax_pose 65, 0x01e9, 0x00e8, 0x5c00
+ax_pose 66, 0x01e1, 0x80f0, 0x5c01
+ax_pose 67, 0x81e1, 0x4110, 0x5c11
+ax_pose 68, 0x01f5, 0x40ec, 0x5c15
+ax_pose_terminator
+sSalamencePose90:
+ax_pose 65, 0x01e9, 0x00e8, 0x5c00
+ax_pose 66, 0x01e1, 0x80f0, 0x5c01
+ax_pose 67, 0x81e1, 0x4110, 0x5c11
+ax_pose 69, 0x01f5, 0x40ec, 0x5c15
+ax_pose_terminator
+sSalamencePose91:
+ax_pose 40, 0x41e5, 0x80e0, 0x5c00
+ax_pose 41, 0x41e5, 0x8100, 0x5c08
+ax_pose 42, 0x41f5, 0x80f0, 0x5c10
+ax_pose_terminator
+sSalamencePose92:
+ax_pose 43, 0x01e2, 0x80e8, 0x5c00
+ax_pose 44, 0x81e2, 0x8108, 0x5c10
+ax_pose 45, 0x0202, 0x0108, 0x5c18
+ax_pose 46, 0x0202, 0x00f0, 0x5c19
+ax_pose_terminator
+sSalamencePose93:
+ax_pose 47, 0x01dc, 0x80e8, 0x5c00
+ax_pose 48, 0x81dc, 0x8108, 0x5c10
+ax_pose 49, 0x01fc, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose94:
+ax_pose 112, 0x41e6, 0xc0e1, 0x5c00
+ax_pose_terminator
+sSalamencePose95:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+sSalamencePose96:
+ax_pose 57, 0x01e2, 0x90f0, 0x5c00
+ax_pose 58, 0x01ee, 0x50e0, 0x5c10
+ax_pose 59, 0x0202, 0x10fa, 0x5c14
+ax_pose_terminator
+sSalamencePose97:
+ax_pose 60, 0x01db, 0x90ef, 0x5c00
+ax_pose 61, 0x81db, 0x90df, 0x5c10
+ax_pose 62, 0x01fb, 0x10f9, 0x5c18
+ax_pose 63, 0x01fb, 0x10f1, 0x5c19
+ax_pose 64, 0x01fb, 0x10e9, 0x5c1a
+ax_pose_terminator
+sSalamencePose98:
+ax_pose 113, 0x01e5, 0x90f5, 0x5c00
+ax_pose 114, 0x81e5, 0x90e5, 0x5c10
+ax_pose 115, 0x0205, 0x10f9, 0x5c18
+ax_pose_terminator
+sSalamencePose99:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose100:
+ax_pose 72, 0x01e2, 0x90f1, 0x5c00
+ax_pose 73, 0x01f2, 0x50e2, 0x5c10
+ax_pose 74, 0x0202, 0x1104, 0x5c14
+ax_pose 75, 0x0202, 0x10f6, 0x5c15
+ax_pose_terminator
+sSalamencePose101:
+ax_pose 76, 0x01dd, 0x90ec, 0x5c00
+ax_pose 77, 0x81ed, 0x10e4, 0x5c10
+ax_pose 78, 0x01fd, 0x10e5, 0x5c12
+ax_pose 79, 0x41fd, 0x10ed, 0x5c13
+ax_pose_terminator
+sSalamencePose102:
+ax_pose 116, 0x01e4, 0x90fa, 0x5c00
+ax_pose 117, 0x81e4, 0x90ea, 0x5c10
+ax_pose 118, 0x0204, 0x1102, 0x5c18
+ax_pose 119, 0x01f4, 0x10e2, 0x5c19
+ax_pose_terminator
+sSalamencePose103:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose104:
+ax_pose 87, 0x01e6, 0x90f0, 0x5c00
+ax_pose 88, 0x81e6, 0x90e0, 0x5c10
+ax_pose 89, 0x41de, 0x10f0, 0x5c18
+ax_pose 90, 0x41de, 0x1100, 0x5c1a
+ax_pose_terminator
+sSalamencePose105:
+ax_pose 91, 0x01da, 0x90ea, 0x5c00
+ax_pose 92, 0x01fa, 0x50ea, 0x5c10
+ax_pose 93, 0x81ea, 0x110a, 0x5c14
+ax_pose 94, 0x01fa, 0x50fa, 0x5c16
+ax_pose_terminator
+sSalamencePose106:
+ax_pose 120, 0x01e3, 0x90f5, 0x5c00
+ax_pose 121, 0x81e3, 0x90e5, 0x5c10
+ax_pose 122, 0x0203, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose107:
+ax_pose 95, 0x01e4, 0x90f7, 0x5c00
+ax_pose 96, 0x81e4, 0x90e7, 0x5c10
+ax_pose 97, 0x0204, 0x10ff, 0x5c18
+ax_pose_terminator
+sSalamencePose108:
+ax_pose 98, 0x01e5, 0x80e8, 0x5c00
+ax_pose 99, 0x81e5, 0x8108, 0x5c10
+ax_pose 100, 0x4205, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose109:
+ax_pose 101, 0x01e7, 0x80eb, 0x5c00
+ax_pose 102, 0x81e7, 0x810b, 0x5c10
+ax_pose 103, 0x41df, 0x40ef, 0x5c18
+ax_pose_terminator
+sSalamencePose110:
+ax_pose 104, 0x01e4, 0x80eb, 0x5c00
+ax_pose 105, 0x81e4, 0x810b, 0x5c10
+ax_pose 106, 0x41dd, 0x00f7, 0x5c18
+ax_pose 107, 0x0204, 0x010b, 0x5c1a
+ax_pose 108, 0x4204, 0x00fb, 0x5c1b
+ax_pose_terminator
+sSalamencePose111:
+ax_pose 123, 0x41e2, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSalamencePose112:
+ax_pose 109, 0x01e2, 0x80eb, 0x5c00
+ax_pose 110, 0x81e2, 0x810b, 0x5c10
+ax_pose 111, 0x0202, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose113:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose114:
+ax_pose 87, 0x01e6, 0x80f0, 0x5c00
+ax_pose 88, 0x81e6, 0x8110, 0x5c10
+ax_pose 89, 0x41de, 0x0100, 0x5c18
+ax_pose 90, 0x41de, 0x00f0, 0x5c1a
+ax_pose_terminator
+sSalamencePose115:
+ax_pose 91, 0x01da, 0x80f6, 0x5c00
+ax_pose 92, 0x01fa, 0x4106, 0x5c10
+ax_pose 93, 0x81ea, 0x00ee, 0x5c14
+ax_pose 94, 0x01fa, 0x40f6, 0x5c16
+ax_pose_terminator
+sSalamencePose116:
+ax_pose 120, 0x01e3, 0x80eb, 0x5c00
+ax_pose 121, 0x81e3, 0x810b, 0x5c10
+ax_pose 122, 0x0203, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose117:
+ax_pose 95, 0x01e4, 0x80e9, 0x5c00
+ax_pose 96, 0x81e4, 0x8109, 0x5c10
+ax_pose 97, 0x0204, 0x00f9, 0x5c18
+ax_pose_terminator
+sSalamencePose118:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose119:
+ax_pose 72, 0x01e2, 0x80ef, 0x5c00
+ax_pose 73, 0x01f2, 0x410e, 0x5c10
+ax_pose 74, 0x0202, 0x00f4, 0x5c14
+ax_pose 75, 0x0202, 0x0102, 0x5c15
+ax_pose_terminator
+sSalamencePose120:
+ax_pose 76, 0x01dd, 0x80f4, 0x5c00
+ax_pose 77, 0x81ed, 0x0114, 0x5c10
+ax_pose 78, 0x01fd, 0x0113, 0x5c12
+ax_pose 79, 0x41fd, 0x0103, 0x5c13
+ax_pose_terminator
+sSalamencePose121:
+ax_pose 116, 0x01e4, 0x80e6, 0x5c00
+ax_pose 117, 0x81e4, 0x8106, 0x5c10
+ax_pose 118, 0x0204, 0x00f6, 0x5c18
+ax_pose 119, 0x01f4, 0x0116, 0x5c19
+ax_pose_terminator
+sSalamencePose122:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose123:
+ax_pose 57, 0x01e2, 0x80f0, 0x5c00
+ax_pose 58, 0x01ee, 0x4110, 0x5c10
+ax_pose 59, 0x0202, 0x00fe, 0x5c14
+ax_pose_terminator
+sSalamencePose124:
+ax_pose 60, 0x01db, 0x80f1, 0x5c00
+ax_pose 61, 0x81db, 0x8111, 0x5c10
+ax_pose 62, 0x01fb, 0x00ff, 0x5c18
+ax_pose 63, 0x01fb, 0x0107, 0x5c19
+ax_pose 64, 0x01fb, 0x010f, 0x5c1a
+ax_pose_terminator
+sSalamencePose125:
+ax_pose 113, 0x01e5, 0x80eb, 0x5c00
+ax_pose 114, 0x81e5, 0x810b, 0x5c10
+ax_pose 115, 0x0205, 0x00ff, 0x5c18
+ax_pose_terminator
+sSalamencePose126:
+ax_pose 40, 0x41e5, 0x80df, 0x5c00
+ax_pose 41, 0x41e5, 0x80ff, 0x5c08
+ax_pose 42, 0x41f5, 0x80ef, 0x5c10
+ax_pose_terminator
+sSalamencePose127:
+ax_pose 43, 0x01e2, 0x80e7, 0x5c00
+ax_pose 44, 0x81e2, 0x8107, 0x5c10
+ax_pose 45, 0x0202, 0x0107, 0x5c18
+ax_pose 46, 0x0202, 0x00ef, 0x5c19
+ax_pose_terminator
+sSalamencePose128:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+sSalamencePose129:
+ax_pose 57, 0x01e2, 0x90f0, 0x5c00
+ax_pose 58, 0x01ee, 0x50e0, 0x5c10
+ax_pose 59, 0x0202, 0x10fa, 0x5c14
+ax_pose_terminator
+sSalamencePose130:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose131:
+ax_pose 72, 0x01e2, 0x90f1, 0x5c00
+ax_pose 73, 0x01f2, 0x50e2, 0x5c10
+ax_pose 74, 0x0202, 0x1104, 0x5c14
+ax_pose 75, 0x0202, 0x10f6, 0x5c15
+ax_pose_terminator
+sSalamencePose132:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose133:
+ax_pose 87, 0x01e6, 0x90f0, 0x5c00
+ax_pose 88, 0x81e6, 0x90e0, 0x5c10
+ax_pose 89, 0x41de, 0x10f0, 0x5c18
+ax_pose 90, 0x41de, 0x1100, 0x5c1a
+ax_pose_terminator
+sSalamencePose134:
+ax_pose 98, 0x01e4, 0x80e8, 0x5c00
+ax_pose 99, 0x81e4, 0x8108, 0x5c10
+ax_pose 100, 0x4204, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose135:
+ax_pose 101, 0x01e7, 0x80eb, 0x5c00
+ax_pose 102, 0x81e7, 0x810b, 0x5c10
+ax_pose 103, 0x41df, 0x40ef, 0x5c18
+ax_pose_terminator
+sSalamencePose136:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose137:
+ax_pose 87, 0x01e6, 0x80f0, 0x5c00
+ax_pose 88, 0x81e6, 0x8110, 0x5c10
+ax_pose 89, 0x41de, 0x0100, 0x5c18
+ax_pose 90, 0x41de, 0x00f0, 0x5c1a
+ax_pose_terminator
+sSalamencePose138:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose139:
+ax_pose 72, 0x01e2, 0x80ef, 0x5c00
+ax_pose 73, 0x01f2, 0x410e, 0x5c10
+ax_pose 74, 0x0202, 0x00f4, 0x5c14
+ax_pose 75, 0x0202, 0x0102, 0x5c15
+ax_pose_terminator
+sSalamencePose140:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose141:
+ax_pose 57, 0x01e2, 0x80f0, 0x5c00
+ax_pose 58, 0x01ee, 0x4110, 0x5c10
+ax_pose 59, 0x0202, 0x00fe, 0x5c14
+ax_pose_terminator
+sSalamencePose142:
+ax_pose 124, 0x01e5, 0x80e8, 0x5c00
+ax_pose 125, 0x81e5, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose143:
+ax_pose 126, 0x01e5, 0x80e8, 0x5c00
+ax_pose 127, 0x81e5, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose144:
+ax_pose 128, 0x01d9, 0x80f5, 0x5c00
+ax_pose 129, 0x01f1, 0x40e5, 0x5c10
+ax_pose 130, 0x01e1, 0x40e5, 0x5c14
+ax_pose 131, 0x41f9, 0x80f5, 0x5c18
+ax_pose_terminator
+sSalamencePose145:
+ax_pose 132, 0x01d9, 0x90ec, 0x5c00
+ax_pose 133, 0x01e1, 0x110c, 0x5c10
+ax_pose 134, 0x01f1, 0x110c, 0x5c11
+ax_pose 135, 0x01fa, 0x10e4, 0x5c12
+ax_pose 136, 0x01f9, 0x50ec, 0x5c13
+ax_pose 137, 0x01f9, 0x50fc, 0x5c17
+ax_pose 138, 0x81d9, 0x50e4, 0x5c1b
+ax_pose_terminator
+sSalamencePose146:
+ax_pose 139, 0x01d4, 0x90f0, 0x5c00
+ax_pose 140, 0x0204, 0x10f0, 0x5c10
+ax_pose 141, 0x81fa, 0x10e8, 0x5c11
+ax_pose 142, 0x41f4, 0x90f0, 0x5c13
+ax_pose_terminator
+sSalamencePose147:
+ax_pose 143, 0x41de, 0x90ef, 0x5c00
+ax_pose 144, 0x01f6, 0x10e7, 0x5c08
+ax_pose 145, 0x01ee, 0x10e7, 0x5c09
+ax_pose 146, 0x01e6, 0x10e7, 0x5c0a
+ax_pose 147, 0x41d6, 0x50ef, 0x5c0b
+ax_pose 148, 0x01ee, 0x90ef, 0x5c0f
+ax_pose_terminator
+sSalamencePose148:
+ax_pose 149, 0x41e5, 0x80ea, 0x5c00
+ax_pose 150, 0x81dd, 0x010a, 0x5c08
+ax_pose 151, 0x01f1, 0x0112, 0x5c0a
+ax_pose 152, 0x81ed, 0x010a, 0x5c0b
+ax_pose 153, 0x01e9, 0x0112, 0x5c0d
+ax_pose 154, 0x01fd, 0x010a, 0x5c0e
+ax_pose 155, 0x4205, 0x00f3, 0x5c0f
+ax_pose 156, 0x81d5, 0x00f2, 0x5c11
+ax_pose 157, 0x01d5, 0x40fa, 0x5c13
+ax_pose 158, 0x41f5, 0x80ea, 0x5c17
+ax_pose_terminator
+sSalamencePose149:
+ax_pose 143, 0x41de, 0x80f1, 0x5c00
+ax_pose 144, 0x01f6, 0x0111, 0x5c08
+ax_pose 145, 0x01ee, 0x0111, 0x5c09
+ax_pose 146, 0x01e6, 0x0111, 0x5c0a
+ax_pose 147, 0x41d6, 0x40f1, 0x5c0b
+ax_pose 148, 0x01ee, 0x80f1, 0x5c0f
+ax_pose_terminator
+sSalamencePose150:
+ax_pose 139, 0x01d4, 0x80f0, 0x5c00
+ax_pose 140, 0x0204, 0x0108, 0x5c10
+ax_pose 141, 0x81fa, 0x0110, 0x5c11
+ax_pose 142, 0x41f4, 0x80f0, 0x5c13
+ax_pose_terminator
+sSalamencePose151:
+ax_pose 132, 0x01d9, 0x80f7, 0x5c00
+ax_pose 133, 0x01e1, 0x00ef, 0x5c10
+ax_pose 134, 0x01f1, 0x00ef, 0x5c11
+ax_pose 135, 0x01fa, 0x0117, 0x5c12
+ax_pose 136, 0x01f9, 0x4107, 0x5c13
+ax_pose 137, 0x01f9, 0x40f7, 0x5c17
+ax_pose 138, 0x81d9, 0x4117, 0x5c1b
+ax_pose_terminator
+sSalamencePose152:
+ax_pose 40, 0x41e5, 0x80e0, 0x5c00
+ax_pose 41, 0x41e5, 0x8100, 0x5c08
+ax_pose 42, 0x41f5, 0x80f0, 0x5c10
+ax_pose_terminator
+sSalamencePose153:
+ax_pose 43, 0x01e2, 0x80e8, 0x5c00
+ax_pose 44, 0x81e2, 0x8108, 0x5c10
+ax_pose 45, 0x0202, 0x0108, 0x5c18
+ax_pose 46, 0x0202, 0x00f0, 0x5c19
+ax_pose_terminator
+sSalamencePose154:
+ax_pose 47, 0x01dc, 0x80e8, 0x5c00
+ax_pose 48, 0x81dc, 0x8108, 0x5c10
+ax_pose 49, 0x01fc, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose155:
+ax_pose 112, 0x41e6, 0xc0e1, 0x5c00
+ax_pose_terminator
+sSalamencePose156:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+sSalamencePose157:
+ax_pose 57, 0x01e2, 0x90f0, 0x5c00
+ax_pose 58, 0x01ee, 0x50e0, 0x5c10
+ax_pose 59, 0x0202, 0x10fa, 0x5c14
+ax_pose_terminator
+sSalamencePose158:
+ax_pose 60, 0x01db, 0x90ef, 0x5c00
+ax_pose 61, 0x81db, 0x90df, 0x5c10
+ax_pose 62, 0x01fb, 0x10f9, 0x5c18
+ax_pose 63, 0x01fb, 0x10f1, 0x5c19
+ax_pose 64, 0x01fb, 0x10e9, 0x5c1a
+ax_pose_terminator
+sSalamencePose159:
+ax_pose 113, 0x01e5, 0x90f5, 0x5c00
+ax_pose 114, 0x81e5, 0x90e5, 0x5c10
+ax_pose 115, 0x0205, 0x10f9, 0x5c18
+ax_pose_terminator
+sSalamencePose160:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose161:
+ax_pose 72, 0x01e2, 0x90f1, 0x5c00
+ax_pose 73, 0x01f2, 0x50e2, 0x5c10
+ax_pose 74, 0x0202, 0x1104, 0x5c14
+ax_pose 75, 0x0202, 0x10f6, 0x5c15
+ax_pose_terminator
+sSalamencePose162:
+ax_pose 76, 0x01dd, 0x90ec, 0x5c00
+ax_pose 77, 0x81ed, 0x10e4, 0x5c10
+ax_pose 78, 0x01fd, 0x10e5, 0x5c12
+ax_pose 79, 0x41fd, 0x10ed, 0x5c13
+ax_pose_terminator
+sSalamencePose163:
+ax_pose 116, 0x01e4, 0x90fa, 0x5c00
+ax_pose 117, 0x81e4, 0x90ea, 0x5c10
+ax_pose 118, 0x0204, 0x1102, 0x5c18
+ax_pose 119, 0x01f4, 0x10e2, 0x5c19
+ax_pose_terminator
+sSalamencePose164:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose165:
+ax_pose 87, 0x01e6, 0x90f0, 0x5c00
+ax_pose 88, 0x81e6, 0x90e0, 0x5c10
+ax_pose 89, 0x41de, 0x10f0, 0x5c18
+ax_pose 90, 0x41de, 0x1100, 0x5c1a
+ax_pose_terminator
+sSalamencePose166:
+ax_pose 91, 0x01da, 0x90ea, 0x5c00
+ax_pose 92, 0x01fa, 0x50ea, 0x5c10
+ax_pose 93, 0x81ea, 0x110a, 0x5c14
+ax_pose 94, 0x01fa, 0x50fa, 0x5c16
+ax_pose_terminator
+sSalamencePose167:
+ax_pose 120, 0x01e3, 0x90f5, 0x5c00
+ax_pose 121, 0x81e3, 0x90e5, 0x5c10
+ax_pose 122, 0x0203, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose168:
+ax_pose 95, 0x01e4, 0x90f7, 0x5c00
+ax_pose 96, 0x81e4, 0x90e7, 0x5c10
+ax_pose 97, 0x0204, 0x10ff, 0x5c18
+ax_pose_terminator
+sSalamencePose169:
+ax_pose 98, 0x01e5, 0x80e8, 0x5c00
+ax_pose 99, 0x81e5, 0x8108, 0x5c10
+ax_pose 100, 0x4205, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose170:
+ax_pose 101, 0x01e7, 0x80eb, 0x5c00
+ax_pose 102, 0x81e7, 0x810b, 0x5c10
+ax_pose 103, 0x41df, 0x40ef, 0x5c18
+ax_pose_terminator
+sSalamencePose171:
+ax_pose 104, 0x01e4, 0x80eb, 0x5c00
+ax_pose 105, 0x81e4, 0x810b, 0x5c10
+ax_pose 106, 0x41dd, 0x00f7, 0x5c18
+ax_pose 107, 0x0204, 0x010b, 0x5c1a
+ax_pose 108, 0x4204, 0x00fb, 0x5c1b
+ax_pose_terminator
+sSalamencePose172:
+ax_pose 123, 0x41e2, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSalamencePose173:
+ax_pose 109, 0x01e2, 0x80eb, 0x5c00
+ax_pose 110, 0x81e2, 0x810b, 0x5c10
+ax_pose 111, 0x0202, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose174:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose175:
+ax_pose 87, 0x01e6, 0x80f0, 0x5c00
+ax_pose 88, 0x81e6, 0x8110, 0x5c10
+ax_pose 89, 0x41de, 0x0100, 0x5c18
+ax_pose 90, 0x41de, 0x00f0, 0x5c1a
+ax_pose_terminator
+sSalamencePose176:
+ax_pose 91, 0x01da, 0x80f6, 0x5c00
+ax_pose 92, 0x01fa, 0x4106, 0x5c10
+ax_pose 93, 0x81ea, 0x00ee, 0x5c14
+ax_pose 94, 0x01fa, 0x40f6, 0x5c16
+ax_pose_terminator
+sSalamencePose177:
+ax_pose 120, 0x01e3, 0x80eb, 0x5c00
+ax_pose 121, 0x81e3, 0x810b, 0x5c10
+ax_pose 122, 0x0203, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose178:
+ax_pose 95, 0x01e4, 0x80e9, 0x5c00
+ax_pose 96, 0x81e4, 0x8109, 0x5c10
+ax_pose 97, 0x0204, 0x00f9, 0x5c18
+ax_pose_terminator
+sSalamencePose179:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose180:
+ax_pose 72, 0x01e2, 0x80ef, 0x5c00
+ax_pose 73, 0x01f2, 0x410e, 0x5c10
+ax_pose 74, 0x0202, 0x00f4, 0x5c14
+ax_pose 75, 0x0202, 0x0102, 0x5c15
+ax_pose_terminator
+sSalamencePose181:
+ax_pose 76, 0x01dd, 0x80f4, 0x5c00
+ax_pose 77, 0x81ed, 0x0114, 0x5c10
+ax_pose 78, 0x01fd, 0x0113, 0x5c12
+ax_pose 79, 0x41fd, 0x0103, 0x5c13
+ax_pose_terminator
+sSalamencePose182:
+ax_pose 116, 0x01e4, 0x80e6, 0x5c00
+ax_pose 117, 0x81e4, 0x8106, 0x5c10
+ax_pose 118, 0x0204, 0x00f6, 0x5c18
+ax_pose 119, 0x01f4, 0x0116, 0x5c19
+ax_pose_terminator
+sSalamencePose183:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose184:
+ax_pose 57, 0x01e2, 0x80f0, 0x5c00
+ax_pose 58, 0x01ee, 0x4110, 0x5c10
+ax_pose 59, 0x0202, 0x00fe, 0x5c14
+ax_pose_terminator
+sSalamencePose185:
+ax_pose 60, 0x01db, 0x80f1, 0x5c00
+ax_pose 61, 0x81db, 0x8111, 0x5c10
+ax_pose 62, 0x01fb, 0x00ff, 0x5c18
+ax_pose 63, 0x01fb, 0x0107, 0x5c19
+ax_pose 64, 0x01fb, 0x010f, 0x5c1a
+ax_pose_terminator
+sSalamencePose186:
+ax_pose 113, 0x01e5, 0x80eb, 0x5c00
+ax_pose 114, 0x81e5, 0x810b, 0x5c10
+ax_pose 115, 0x0205, 0x00ff, 0x5c18
+ax_pose_terminator
+sSalamencePose187:
+ax_pose 159, 0x01e1, 0x80f0, 0x5c00
+ax_pose 160, 0x81e1, 0x80e0, 0x5c10
+ax_pose -1, 0x81e1, 0x910e, 0x5c10
+ax_pose 52, 0x01f9, 0x40f7, 0x5c18
+ax_pose_terminator
+sSalamencePose188:
+ax_pose 65, 0x01e9, 0x00e8, 0x5c00
+ax_pose 66, 0x01e1, 0x80f0, 0x5c01
+ax_pose 67, 0x81e1, 0x4110, 0x5c11
+ax_pose 69, 0x01f5, 0x40ec, 0x5c15
+ax_pose_terminator
+sSalamencePose189:
+ax_pose 80, 0x01e2, 0x80f5, 0x5c00
+ax_pose 81, 0x01f4, 0x0115, 0x5c10
+ax_pose 83, 0x01ed, 0x40e5, 0x5c11
+ax_pose_terminator
+sSalamencePose190:
+ax_pose 95, 0x01e3, 0x80ec, 0x5c00
+ax_pose 96, 0x81e3, 0x810c, 0x5c10
+ax_pose 97, 0x0203, 0x00fc, 0x5c18
+ax_pose_terminator
+sSalamencePose191:
+ax_pose 109, 0x01e2, 0x80eb, 0x5c00
+ax_pose 110, 0x81e2, 0x810b, 0x5c10
+ax_pose 111, 0x0202, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose192:
+ax_pose 95, 0x01e3, 0x90f4, 0x5c00
+ax_pose 96, 0x81e3, 0x90e4, 0x5c10
+ax_pose 97, 0x0203, 0x10fc, 0x5c18
+ax_pose_terminator
+sSalamencePose193:
+ax_pose 80, 0x01e2, 0x90eb, 0x5c00
+ax_pose 81, 0x01f4, 0x10e3, 0x5c10
+ax_pose 83, 0x01ed, 0x510b, 0x5c11
+ax_pose_terminator
+sSalamencePose194:
+ax_pose 65, 0x01e9, 0x1110, 0x5c00
+ax_pose 66, 0x01e1, 0x90f0, 0x5c01
+ax_pose 67, 0x81e1, 0x50e8, 0x5c11
+ax_pose 69, 0x01f5, 0x5104, 0x5c15
+ax_pose_terminator
+sSalamencePose195:
+ax_pose 43, 0x01e2, 0x80e7, 0x5c00
+ax_pose 44, 0x81e2, 0x8107, 0x5c10
+ax_pose 45, 0x0202, 0x0107, 0x5c18
+ax_pose 46, 0x0202, 0x00ef, 0x5c19
+ax_pose_terminator
+sSalamencePose196:
+ax_pose 57, 0x01e2, 0x90f0, 0x5c00
+ax_pose 58, 0x01ee, 0x50e0, 0x5c10
+ax_pose 59, 0x0202, 0x10fa, 0x5c14
+ax_pose_terminator
+sSalamencePose197:
+ax_pose 72, 0x01e2, 0x90f1, 0x5c00
+ax_pose 73, 0x01f2, 0x50e2, 0x5c10
+ax_pose 74, 0x0202, 0x1104, 0x5c14
+ax_pose 75, 0x0202, 0x10f6, 0x5c15
+ax_pose_terminator
+sSalamencePose198:
+ax_pose 87, 0x01e7, 0x90ef, 0x5c00
+ax_pose 88, 0x81e7, 0x90df, 0x5c10
+ax_pose 89, 0x41df, 0x10ef, 0x5c18
+ax_pose 90, 0x41df, 0x10ff, 0x5c1a
+ax_pose_terminator
+sSalamencePose199:
+ax_pose 101, 0x01e7, 0x80eb, 0x5c00
+ax_pose 102, 0x81e7, 0x810b, 0x5c10
+ax_pose 103, 0x41df, 0x40ef, 0x5c18
+ax_pose_terminator
+sSalamencePose200:
+ax_pose 87, 0x01e7, 0x80f1, 0x5c00
+ax_pose 88, 0x81e7, 0x8111, 0x5c10
+ax_pose 89, 0x41df, 0x0101, 0x5c18
+ax_pose 90, 0x41df, 0x00f1, 0x5c1a
+ax_pose_terminator
+sSalamencePose201:
+ax_pose 72, 0x01e2, 0x80ef, 0x5c00
+ax_pose 73, 0x01f2, 0x410e, 0x5c10
+ax_pose 74, 0x0202, 0x00f4, 0x5c14
+ax_pose 75, 0x0202, 0x0102, 0x5c15
+ax_pose_terminator
+sSalamencePose202:
+ax_pose 57, 0x01e2, 0x80f0, 0x5c00
+ax_pose 58, 0x01ee, 0x4110, 0x5c10
+ax_pose 59, 0x0202, 0x00fe, 0x5c14
+ax_pose_terminator
+sSalamencePose203:
+ax_pose 40, 0x41e5, 0x80e0, 0x5c00
+ax_pose 41, 0x41e5, 0x8100, 0x5c08
+ax_pose 42, 0x41f5, 0x80f0, 0x5c10
+ax_pose_terminator
+sSalamencePose204:
+ax_pose 47, 0x01dc, 0x80e8, 0x5c00
+ax_pose 48, 0x81dc, 0x8108, 0x5c10
+ax_pose 49, 0x01fc, 0x00fb, 0x5c18
+ax_pose_terminator
+sSalamencePose205:
+ax_pose 112, 0x41e6, 0xc0e1, 0x5c00
+ax_pose_terminator
+sSalamencePose206:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+sSalamencePose207:
+ax_pose 60, 0x01db, 0x90f1, 0x5c00
+ax_pose 61, 0x81db, 0x90e1, 0x5c10
+ax_pose 62, 0x01fb, 0x10fb, 0x5c18
+ax_pose 63, 0x01fb, 0x10f3, 0x5c19
+ax_pose 64, 0x01fb, 0x10eb, 0x5c1a
+ax_pose_terminator
+sSalamencePose208:
+ax_pose 113, 0x01e6, 0x90f5, 0x5c00
+ax_pose 114, 0x81e6, 0x90e5, 0x5c10
+ax_pose 115, 0x0206, 0x10f9, 0x5c18
+ax_pose_terminator
+sSalamencePose209:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose210:
+ax_pose 76, 0x01dd, 0x90f0, 0x5c00
+ax_pose 77, 0x81ed, 0x10e8, 0x5c10
+ax_pose 78, 0x01fd, 0x10e9, 0x5c12
+ax_pose 79, 0x41fd, 0x10f1, 0x5c13
+ax_pose_terminator
+sSalamencePose211:
+ax_pose 116, 0x01e4, 0x90fa, 0x5c00
+ax_pose 117, 0x81e4, 0x90ea, 0x5c10
+ax_pose 118, 0x0204, 0x1102, 0x5c18
+ax_pose 119, 0x01f4, 0x10e2, 0x5c19
+ax_pose_terminator
+sSalamencePose212:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose213:
+ax_pose 91, 0x01da, 0x90ed, 0x5c00
+ax_pose 92, 0x01fa, 0x50ed, 0x5c10
+ax_pose 93, 0x81ea, 0x110d, 0x5c14
+ax_pose 94, 0x01fa, 0x50fd, 0x5c16
+ax_pose_terminator
+sSalamencePose214:
+ax_pose 120, 0x01e3, 0x90f4, 0x5c00
+ax_pose 121, 0x81e3, 0x90e4, 0x5c10
+ax_pose 122, 0x0203, 0x10ff, 0x5c18
+ax_pose_terminator
+sSalamencePose215:
+ax_pose 98, 0x01e5, 0x80e8, 0x5c00
+ax_pose 99, 0x81e5, 0x8108, 0x5c10
+ax_pose 100, 0x4205, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose216:
+ax_pose 104, 0x01e4, 0x80eb, 0x5c00
+ax_pose 105, 0x81e4, 0x810b, 0x5c10
+ax_pose 106, 0x41dd, 0x00f7, 0x5c18
+ax_pose 107, 0x0204, 0x010b, 0x5c1a
+ax_pose 108, 0x4204, 0x00fb, 0x5c1b
+ax_pose_terminator
+sSalamencePose217:
+ax_pose 123, 0x41e2, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSalamencePose218:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose219:
+ax_pose 91, 0x01da, 0x80f3, 0x5c00
+ax_pose 92, 0x01fa, 0x4103, 0x5c10
+ax_pose 93, 0x81ea, 0x00eb, 0x5c14
+ax_pose 94, 0x01fa, 0x40f3, 0x5c16
+ax_pose_terminator
+sSalamencePose220:
+ax_pose 120, 0x01e3, 0x80ec, 0x5c00
+ax_pose 121, 0x81e3, 0x810c, 0x5c10
+ax_pose 122, 0x0203, 0x00f9, 0x5c18
+ax_pose_terminator
+sSalamencePose221:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose222:
+ax_pose 76, 0x01dd, 0x80f0, 0x5c00
+ax_pose 77, 0x81ed, 0x0110, 0x5c10
+ax_pose 78, 0x01fd, 0x010f, 0x5c12
+ax_pose 79, 0x41fd, 0x00ff, 0x5c13
+ax_pose_terminator
+sSalamencePose223:
+ax_pose 116, 0x01e4, 0x80e6, 0x5c00
+ax_pose 117, 0x81e4, 0x8106, 0x5c10
+ax_pose 118, 0x0204, 0x00f6, 0x5c18
+ax_pose 119, 0x01f4, 0x0116, 0x5c19
+ax_pose_terminator
+sSalamencePose224:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose225:
+ax_pose 60, 0x01db, 0x80ef, 0x5c00
+ax_pose 61, 0x81db, 0x810f, 0x5c10
+ax_pose 62, 0x01fb, 0x00fd, 0x5c18
+ax_pose 63, 0x01fb, 0x0105, 0x5c19
+ax_pose 64, 0x01fb, 0x010d, 0x5c1a
+ax_pose_terminator
+sSalamencePose226:
+ax_pose 113, 0x01e6, 0x80eb, 0x5c00
+ax_pose 114, 0x81e6, 0x810b, 0x5c10
+ax_pose 115, 0x0206, 0x00ff, 0x5c18
+ax_pose_terminator
+sSalamencePose227:
+ax_pose 40, 0x41e5, 0x80df, 0x5c00
+ax_pose 41, 0x41e5, 0x80ff, 0x5c08
+ax_pose 42, 0x41f5, 0x80ef, 0x5c10
+ax_pose_terminator
+sSalamencePose228:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose229:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose230:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose231:
+ax_pose 98, 0x01e4, 0x80e8, 0x5c00
+ax_pose 99, 0x81e4, 0x8108, 0x5c10
+ax_pose 100, 0x4204, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose232:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose233:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose234:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+sSalamencePose235:
+ax_pose 40, 0x41e5, 0x80df, 0x5c00
+ax_pose 41, 0x41e5, 0x80ff, 0x5c08
+ax_pose 42, 0x41f5, 0x80ef, 0x5c10
+ax_pose_terminator
+sSalamencePose236:
+ax_pose 53, 0x01e4, 0x80f7, 0x5c00
+ax_pose 54, 0x81e4, 0x40ef, 0x5c10
+ax_pose 55, 0x81ec, 0x00e7, 0x5c14
+ax_pose 56, 0x0204, 0x00fe, 0x5c16
+ax_pose_terminator
+sSalamencePose237:
+ax_pose 70, 0x01e4, 0x80e8, 0x5c00
+ax_pose 71, 0x81e4, 0x8108, 0x5c10
+ax_pose_terminator
+sSalamencePose238:
+ax_pose 84, 0x81e4, 0x80e8, 0x5c00
+ax_pose 85, 0x01e4, 0x80f8, 0x5c08
+ax_pose 86, 0x0204, 0x00f8, 0x5c18
+ax_pose_terminator
+sSalamencePose239:
+ax_pose 98, 0x01e4, 0x80e8, 0x5c00
+ax_pose 99, 0x81e4, 0x8108, 0x5c10
+ax_pose 100, 0x4204, 0x0100, 0x5c18
+ax_pose_terminator
+sSalamencePose240:
+ax_pose 84, 0x81e4, 0x9108, 0x5c00
+ax_pose 85, 0x01e4, 0x90e8, 0x5c08
+ax_pose 86, 0x0204, 0x1100, 0x5c18
+ax_pose_terminator
+sSalamencePose241:
+ax_pose 70, 0x01e4, 0x90f8, 0x5c00
+ax_pose 71, 0x81e4, 0x90e8, 0x5c10
+ax_pose_terminator
+sSalamencePose242:
+ax_pose 53, 0x01e4, 0x90e9, 0x5c00
+ax_pose 54, 0x81e4, 0x5109, 0x5c10
+ax_pose 55, 0x81ec, 0x1111, 0x5c14
+ax_pose 56, 0x0204, 0x10fa, 0x5c16
+ax_pose_terminator
+.align 2
+sSalamenceAnims_1_1:
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_1_3:
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_1_4:
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_1_5:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_1_6:
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_1_7:
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_1_8:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_2_1:
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, -10, 0, -3,
+ax_anim 1, 2, 20, 0, 0, 0, 2,
+ax_anim 1, 0, 20, 0, 9, 0, 10,
+ax_anim 2, 0, 19, 0, 14, 0, 14,
+ax_anim 2, 1, 19, 1, 14, 1, 14,
+ax_anim 2, 0, 19, 0, 14, 0, 14,
+ax_anim 2, 0, 19, 1, 14, 1, 14,
+ax_anim 2, 0, 16, 0, 4, 0, 4,
+ax_anim_terminator
+sSalamenceAnims_2_2:
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 23, -1, -2, -2, -2,
+ax_anim 1, 0, 21, -2, -7, -3, -3,
+ax_anim 1, 2, 25, 3, 3, 3, 3,
+ax_anim 1, 0, 25, 9, 9, 6, 8,
+ax_anim 2, 0, 24, 11, 17, 12, 14,
+ax_anim 2, 1, 24, 12, 16, 13, 13,
+ax_anim 2, 0, 24, 11, 17, 12, 14,
+ax_anim 2, 0, 24, 12, 16, 13, 13,
+ax_anim 2, 0, 21, 3, 4, 3, 4,
+ax_anim_terminator
+sSalamenceAnims_2_3:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 6, 0, 28, -1, -2, -3, 0,
+ax_anim 1, 0, 26, -6, -9, -5, 0,
+ax_anim 1, 2, 30, 0, -7, 0, 0,
+ax_anim 1, 0, 30, 6, -2, 6, 0,
+ax_anim 2, 0, 29, 10, 0, 10, 0,
+ax_anim 2, 1, 29, 10, 1, 10, 1,
+ax_anim 2, 0, 29, 10, 0, 10, 0,
+ax_anim 2, 0, 29, 10, 1, 10, 1,
+ax_anim 2, 0, 26, 4, 0, 4, 0,
+ax_anim_terminator
+sSalamenceAnims_2_4:
+ax_anim 4, 0, 32, 0, 0, 0, 0,
+ax_anim 6, 0, 33, -1, -1, -2, 2,
+ax_anim 1, 0, 31, -3, -7, -3, 3,
+ax_anim 1, 2, 34, -1, -6, 5, -5,
+ax_anim 1, 0, 34, 5, -11, 11, -11,
+ax_anim 2, 0, 34, 10, -14, 16, -17,
+ax_anim 2, 1, 34, 11, -13, 17, -16,
+ax_anim 2, 0, 34, 10, -14, 16, -17,
+ax_anim 2, 0, 34, 11, -13, 17, -16,
+ax_anim 2, 0, 31, 4, -5, 4, -5,
+ax_anim_terminator
+sSalamenceAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 6, 0, 37, 0, -2, 0, 2,
+ax_anim 1, 0, 35, 0, -8, 0, 3,
+ax_anim 1, 2, 38, 0, -5, 0, 1,
+ax_anim 1, 0, 38, 0, -6, 0, -10,
+ax_anim 2, 0, 38, 0, -9, 0, -18,
+ax_anim 2, 1, 38, 1, -9, 1, -18,
+ax_anim 2, 0, 38, 0, -9, 0, -18,
+ax_anim 2, 0, 38, 1, -9, 1, -18,
+ax_anim 2, 0, 35, 0, -4, 0, -4,
+ax_anim_terminator
+sSalamenceAnims_2_6:
+ax_anim 4, 0, 40, 0, 0, 0, 0,
+ax_anim 6, 0, 41, 1, -1, 2, 2,
+ax_anim 1, 0, 39, 3, -7, 3, 3,
+ax_anim 1, 2, 42, 1, -7, -5, -5,
+ax_anim 1, 0, 42, -5, -11, -11, -11,
+ax_anim 2, 0, 42, -10, -14, -16, -17,
+ax_anim 2, 1, 42, -11, -13, -17, -16,
+ax_anim 2, 0, 42, -10, -14, -16, -17,
+ax_anim 2, 0, 42, -11, -13, -17, -16,
+ax_anim 2, 0, 39, -4, -5, -4, -5,
+ax_anim_terminator
+sSalamenceAnims_2_7:
+ax_anim 4, 0, 44, 0, 0, 0, 0,
+ax_anim 6, 0, 45, 1, -2, 3, 0,
+ax_anim 1, 0, 43, 6, -9, 5, 0,
+ax_anim 1, 2, 47, 1, -5, 3, 0,
+ax_anim 1, 0, 47, -6, -2, -6, 0,
+ax_anim 2, 0, 46, -10, 0, -10, 0,
+ax_anim 2, 1, 46, -10, 1, -10, 1,
+ax_anim 2, 0, 46, -10, 0, -10, 0,
+ax_anim 2, 0, 46, -10, 1, -10, 1,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim_terminator
+sSalamenceAnims_2_8:
+ax_anim 4, 0, 49, 0, 0, 0, 0,
+ax_anim 6, 0, 50, 1, -2, 2, -2,
+ax_anim 1, 0, 48, 2, -7, 3, -3,
+ax_anim 1, 2, 52, -3, 3, -3, 3,
+ax_anim 1, 0, 52, -8, 8, -8, 8,
+ax_anim 2, 0, 51, -11, 17, -12, 14,
+ax_anim 2, 1, 51, -12, 16, -13, 13,
+ax_anim 2, 0, 51, -11, 17, -12, 14,
+ax_anim 2, 0, 51, -12, 16, -13, 13,
+ax_anim 2, 0, 48, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_3_1:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 6, 0, 55, 0, -2, 0, -2,
+ax_anim 1, 0, 53, 0, -10, 0, -3,
+ax_anim 1, 2, 57, 0, 0, 0, 2,
+ax_anim 1, 0, 57, 0, 9, 0, 10,
+ax_anim 2, 0, 56, 0, 14, 0, 14,
+ax_anim 2, 1, 56, 1, 14, 1, 14,
+ax_anim 2, 0, 56, 0, 14, 0, 14,
+ax_anim 2, 0, 56, 1, 14, 1, 14,
+ax_anim 2, 0, 53, 0, 4, 0, 4,
+ax_anim_terminator
+sSalamenceAnims_3_2:
+ax_anim 4, 0, 59, 0, 0, 0, 0,
+ax_anim 6, 0, 60, -1, -2, -2, -2,
+ax_anim 1, 0, 58, -2, -7, -3, -3,
+ax_anim 1, 2, 62, 3, 3, 3, 3,
+ax_anim 1, 0, 62, 9, 9, 6, 8,
+ax_anim 2, 0, 61, 11, 17, 12, 14,
+ax_anim 2, 1, 61, 12, 16, 13, 13,
+ax_anim 2, 0, 61, 11, 17, 12, 14,
+ax_anim 2, 0, 61, 12, 16, 13, 13,
+ax_anim 2, 0, 58, 3, 4, 3, 4,
+ax_anim_terminator
+sSalamenceAnims_3_3:
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim 6, 0, 65, -1, -2, -3, 0,
+ax_anim 1, 0, 63, -6, -9, -5, 0,
+ax_anim 1, 2, 67, 0, -7, 0, 0,
+ax_anim 1, 0, 67, 6, -2, 6, 0,
+ax_anim 2, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 1, 66, 10, 1, 10, 1,
+ax_anim 2, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 66, 10, 1, 10, 1,
+ax_anim 2, 0, 63, 4, 0, 4, 0,
+ax_anim_terminator
+sSalamenceAnims_3_4:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 6, 0, 70, -1, -1, -2, 2,
+ax_anim 1, 0, 68, -3, -7, -3, 3,
+ax_anim 1, 2, 71, -1, -6, 5, -5,
+ax_anim 1, 0, 71, 5, -11, 11, -11,
+ax_anim 2, 0, 71, 10, -14, 16, -17,
+ax_anim 2, 1, 71, 11, -13, 17, -16,
+ax_anim 2, 0, 71, 10, -14, 16, -17,
+ax_anim 2, 0, 71, 11, -13, 17, -16,
+ax_anim 2, 0, 68, 4, -5, 4, -5,
+ax_anim_terminator
+sSalamenceAnims_3_5:
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 6, 0, 74, 0, -2, 0, 2,
+ax_anim 1, 0, 72, 0, -8, 0, 3,
+ax_anim 1, 2, 75, 0, -5, 0, 1,
+ax_anim 1, 0, 75, 0, -6, 0, -10,
+ax_anim 2, 0, 75, 0, -9, 0, -18,
+ax_anim 2, 1, 75, 1, -9, 1, -18,
+ax_anim 2, 0, 75, 0, -9, 0, -18,
+ax_anim 2, 0, 75, 1, -9, 1, -18,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sSalamenceAnims_3_6:
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 6, 0, 78, 1, -1, 2, 2,
+ax_anim 1, 0, 76, 3, -7, 3, 3,
+ax_anim 1, 2, 79, 1, -7, -5, -5,
+ax_anim 1, 0, 79, -5, -11, -11, -11,
+ax_anim 2, 0, 79, -10, -14, -16, -17,
+ax_anim 2, 1, 79, -11, -13, -17, -16,
+ax_anim 2, 0, 79, -10, -14, -16, -17,
+ax_anim 2, 0, 79, -11, -13, -17, -16,
+ax_anim 2, 0, 76, -4, -5, -4, -5,
+ax_anim_terminator
+sSalamenceAnims_3_7:
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 6, 0, 82, 1, -2, 3, 0,
+ax_anim 1, 0, 80, 6, -9, 5, 0,
+ax_anim 1, 2, 84, 1, -5, 3, 0,
+ax_anim 1, 0, 84, -6, -2, -6, 0,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 1, 83, -10, 1, -10, 1,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -10, 1, -10, 1,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sSalamenceAnims_3_8:
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 6, 0, 87, 1, -2, 2, -2,
+ax_anim 1, 0, 85, 2, -7, 3, -3,
+ax_anim 1, 2, 89, -3, 3, -3, 3,
+ax_anim 1, 0, 89, -8, 8, -8, 8,
+ax_anim 2, 0, 88, -11, 17, -12, 14,
+ax_anim 2, 1, 88, -12, 16, -13, 13,
+ax_anim 2, 0, 88, -11, 17, -12, 14,
+ax_anim 2, 0, 88, -12, 16, -13, 13,
+ax_anim 2, 0, 85, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_4_1:
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 4, 0, 92, 0, -5, 0, 0,
+ax_anim 4, 2, 92, 0, -3, 0, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim_terminator
+sSalamenceAnims_4_2:
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 4, 0, 96, 0, -5, 0, 0,
+ax_anim 4, 2, 96, 0, -3, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 1, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sSalamenceAnims_4_3:
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 4, 0, 100, 0, -5, 0, 0,
+ax_anim 4, 2, 100, 0, -3, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 1, 101, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim_terminator
+sSalamenceAnims_4_4:
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 4, 0, 104, 0, -5, 0, 0,
+ax_anim 4, 2, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim_terminator
+sSalamenceAnims_4_5:
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, -5, 0, 0,
+ax_anim 4, 2, 109, 0, -3, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sSalamenceAnims_4_6:
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -3, 0, 0,
+ax_anim 4, 0, 114, 0, -5, 0, 0,
+ax_anim 4, 2, 114, 0, -3, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim_terminator
+sSalamenceAnims_4_7:
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 4, 0, 119, 0, -5, 0, 0,
+ax_anim 4, 2, 119, 0, -3, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sSalamenceAnims_4_8:
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 4, 0, 123, 0, -5, 0, 0,
+ax_anim 4, 2, 123, 0, -3, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 1, 124, -1, -1, -1, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, -1, -1, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_5_1:
+ax_anim 2, 0, 126, 0, -1, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 4, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 6, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, 0, 1, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, 0, 1, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 1, 0, 1, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_5_2:
+ax_anim 2, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 6, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_5_3:
+ax_anim 2, 0, 130, 0, -1, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 4, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 6, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_5_4:
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 6, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, -1, -1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_5_5:
+ax_anim 2, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 6, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_5_6:
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 4, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 6, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_5_7:
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 138, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 6, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, -1,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_5_8:
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 6, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_6_1:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 35, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_7_1:
+ax_anim 2, 0, 143, 0, -4, 0, -4,
+ax_anim 8, 0, 143, 0, -5, 0, -5,
+ax_anim_terminator
+sSalamenceAnims_7_2:
+ax_anim 2, 0, 144, -4, -4, -4, -4,
+ax_anim 8, 0, 144, -5, -5, -5, -5,
+ax_anim_terminator
+sSalamenceAnims_7_3:
+ax_anim 2, 0, 145, -4, 0, -4, 0,
+ax_anim 8, 0, 145, -5, 0, -5, 0,
+ax_anim_terminator
+sSalamenceAnims_7_4:
+ax_anim 2, 0, 146, -4, 4, -4, 4,
+ax_anim 8, 0, 146, -5, 5, -5, 5,
+ax_anim_terminator
+sSalamenceAnims_7_5:
+ax_anim 2, 0, 147, 0, 4, 0, 4,
+ax_anim 8, 0, 147, 0, 5, 0, 5,
+ax_anim_terminator
+sSalamenceAnims_7_6:
+ax_anim 2, 0, 148, 4, 4, 4, 4,
+ax_anim 8, 0, 148, 5, 5, 5, 5,
+ax_anim_terminator
+sSalamenceAnims_7_7:
+ax_anim 2, 0, 149, 4, 0, 4, 0,
+ax_anim 8, 0, 149, 5, 0, 5, 0,
+ax_anim_terminator
+sSalamenceAnims_7_8:
+ax_anim 2, 0, 150, 4, -4, 4, -4,
+ax_anim 8, 0, 150, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_8_1:
+ax_anim 60, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -1, 0, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -1, 0, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -1, 0, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -1, 0, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -1, 0, -1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -1, 0, -1, 0,
+ax_anim 10, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_8_2:
+ax_anim 60, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, 0, -1, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_8_3:
+ax_anim 60, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -1, 0, -1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -1, 0, -1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -1, 0, -1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -1, 0, -1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -1, 0, -1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -1, 0, -1, 0,
+ax_anim 10, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_8_4:
+ax_anim 60, 0, 163, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 0, -1, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_8_5:
+ax_anim 60, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, 0, -1, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_8_6:
+ax_anim 60, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, -1, 0, -1, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_8_7:
+ax_anim 60, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -1, 0, -1, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_8_8:
+ax_anim 60, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 5, 6, 5,
+ax_anim 2, 0, 188, 8, 10, 8, 10,
+ax_anim 2, 0, 189, 5, 19, 5, 19,
+ax_anim 3, 0, 190, 0, 23, 0, 21,
+ax_anim 2, 3, 191, -5, 19, -5, 19,
+ax_anim 2, 0, 192, -8, 10, -8, 10,
+ax_anim 1, 0, 193, -6, 5, -6, 5,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 16, -2, 16, -2,
+ax_anim 2, 0, 187, 22, 6, 22, 6,
+ax_anim 2, 0, 188, 23, 13, 23, 13,
+ax_anim 3, 0, 189, 17, 19, 19, 17,
+ax_anim 2, 3, 190, 11, 23, 11, 19,
+ax_anim 2, 0, 191, 4, 17, 4, 17,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 6, -1, 6, -3,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 14, -1, 14, -3,
+ax_anim 3, 0, 188, 13, 0, 16, 0,
+ax_anim 2, 3, 189, 13, 6, 13, 6,
+ax_anim 2, 0, 190, 9, 10, 9, 8,
+ax_anim 1, 0, 191, 4, 7, 4, 7,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -2, -6, -2, -6,
+ax_anim 2, 0, 193, 3, -11, 3, -11,
+ax_anim 2, 0, 186, 11, -19, 11, -19,
+ax_anim 3, 0, 187, 13, -16, 15, -18,
+ax_anim 2, 3, 188, 17, -12, 17, -12,
+ax_anim 2, 0, 189, 17, -4, 17, -4,
+ax_anim 1, 0, 190, 10, 2, 10, 2,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -4, -3, -4, -3,
+ax_anim 2, 0, 192, -5, -9, -5, -9,
+ax_anim 2, 0, 193, -3, -13, -3, -13,
+ax_anim 3, 0, 186, 0, -19, 0, -19,
+ax_anim 2, 3, 187, 3, -13, 3, -13,
+ax_anim 2, 0, 188, 5, -9, 5, -9,
+ax_anim 1, 0, 189, 4, -3, 4, -3,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 2, -6, 2, -6,
+ax_anim 2, 0, 187, -3, -11, -3, -11,
+ax_anim 2, 0, 186, -11, -19, -11, -19,
+ax_anim 3, 0, 193, -13, -16, -15, -18,
+ax_anim 2, 3, 192, -17, -12, -17, -12,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -10, 2, -10, 2,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -6, -1, -6, -3,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -14, -1, -14, -3,
+ax_anim 3, 0, 192, -13, 0, -16, 0,
+ax_anim 2, 3, 191, -13, 6, -13, 6,
+ax_anim 2, 0, 190, -9, 10, -9, 8,
+ax_anim 1, 0, 189, -4, 7, -4, 7,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -16, -2, -16, -2,
+ax_anim 2, 0, 193, -22, 6, -22, 6,
+ax_anim 2, 0, 192, -23, 13, -23, 13,
+ax_anim 3, 0, 191, -17, 19, -19, 17,
+ax_anim 2, 3, 190, -11, 23, -11, 19,
+ax_anim 2, 0, 189, -4, 17, -4, 17,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -9, 0, 0,
+ax_anim 2, 0, 203, 0, -15, 0, 0,
+ax_anim 3, 0, 203, 0, -18, 0, 0,
+ax_anim 4, 0, 203, 0, -19, 0, 0,
+ax_anim 4, 0, 202, 0, -26, 0, 0,
+ax_anim 3, 0, 204, 0, -25, 0, 0,
+ax_anim 2, 0, 204, 0, -19, 0, 0,
+ax_anim 1, 0, 204, 0, -9, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -9, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -18, 0, 0,
+ax_anim 4, 0, 206, 0, -19, 0, 0,
+ax_anim 4, 0, 205, 0, -26, 0, 0,
+ax_anim 3, 0, 207, 0, -25, 0, 0,
+ax_anim 2, 0, 207, 0, -19, 0, 0,
+ax_anim 1, 0, 207, 0, -9, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -9, 0, 0,
+ax_anim 2, 0, 209, 0, -14, 0, 0,
+ax_anim 3, 0, 209, 0, -16, 0, 0,
+ax_anim 4, 0, 209, 0, -17, 0, 0,
+ax_anim 4, 0, 208, 0, -26, 0, 0,
+ax_anim 3, 0, 210, 0, -25, 0, 0,
+ax_anim 2, 0, 210, 0, -19, 0, 0,
+ax_anim 1, 0, 210, 0, -9, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -6, 0, 0,
+ax_anim 2, 0, 212, 0, -11, 0, 0,
+ax_anim 3, 0, 212, 0, -15, 0, 0,
+ax_anim 4, 0, 212, 0, -16, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -19, 0, 0,
+ax_anim 1, 0, 213, 0, -9, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -6, 0, 0,
+ax_anim 2, 0, 215, 0, -13, 0, 0,
+ax_anim 3, 0, 215, 0, -15, 0, 0,
+ax_anim 4, 0, 215, 0, -16, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 216, 0, -19, 0, 0,
+ax_anim 2, 0, 216, 0, -17, 0, 0,
+ax_anim 1, 0, 216, 0, -9, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -6, 0, 0,
+ax_anim 2, 0, 218, 0, -11, 0, 0,
+ax_anim 3, 0, 218, 0, -15, 0, 0,
+ax_anim 4, 0, 218, 0, -16, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -19, 0, 0,
+ax_anim 1, 0, 219, 0, -9, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -9, 0, 0,
+ax_anim 2, 0, 221, 0, -14, 0, 0,
+ax_anim 3, 0, 221, 0, -16, 0, 0,
+ax_anim 4, 0, 221, 0, -17, 0, 0,
+ax_anim 4, 0, 220, 0, -26, 0, 0,
+ax_anim 3, 0, 222, 0, -25, 0, 0,
+ax_anim 2, 0, 222, 0, -19, 0, 0,
+ax_anim 1, 0, 222, 0, -9, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -9, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -18, 0, 0,
+ax_anim 4, 0, 224, 0, -19, 0, 0,
+ax_anim 4, 0, 223, 0, -26, 0, 0,
+ax_anim 3, 0, 225, 0, -25, 0, 0,
+ax_anim 2, 0, 225, 0, -19, 0, 0,
+ax_anim 1, 0, 225, 0, -9, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSalamenceAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sSalamenceGfx1:
+.incbin "baserom.gba", 0x155CBB8, 0x200
+sSalamenceSprites1:
+ax_sprite sSalamenceGfx1, 0x200
+ax_sprite_terminator
+sSalamenceGfx2:
+.incbin "baserom.gba", 0x155CDC8, 0x100
+sSalamenceSprites2:
+ax_sprite sSalamenceGfx2, 0x100
+ax_sprite_terminator
+sSalamenceGfx3:
+.incbin "baserom.gba", 0x155CED8, 0x200
+sSalamenceSprites3:
+ax_sprite sSalamenceGfx3, 0x200
+ax_sprite_terminator
+sSalamenceGfx4:
+.incbin "baserom.gba", 0x155D0E8, 0x100
+sSalamenceSprites4:
+ax_sprite sSalamenceGfx4, 0x100
+ax_sprite_terminator
+sSalamenceGfx5:
+.incbin "baserom.gba", 0x155D1F8, 0x200
+sSalamenceSprites5:
+ax_sprite sSalamenceGfx5, 0x200
+ax_sprite_terminator
+sSalamenceGfx6:
+.incbin "baserom.gba", 0x155D408, 0x80
+sSalamenceSprites6:
+ax_sprite sSalamenceGfx6, 0x80
+ax_sprite_terminator
+sSalamenceGfx7:
+.incbin "baserom.gba", 0x155D498, 0x40
+sSalamenceSprites7:
+ax_sprite sSalamenceGfx7, 0x40
+ax_sprite_terminator
+sSalamenceGfx8:
+.incbin "baserom.gba", 0x155D4E8, 0x20
+sSalamenceSprites8:
+ax_sprite sSalamenceGfx8, 0x20
+ax_sprite_terminator
+sSalamenceGfx9:
+.incbin "baserom.gba", 0x155D518, 0x200
+sSalamenceSprites9:
+ax_sprite sSalamenceGfx9, 0x200
+ax_sprite_terminator
+sSalamenceGfx10:
+.incbin "baserom.gba", 0x155D728, 0x40
+sSalamenceSprites10:
+ax_sprite sSalamenceGfx10, 0x40
+ax_sprite_terminator
+sSalamenceGfx11:
+.incbin "baserom.gba", 0x155D778, 0x20
+sSalamenceSprites11:
+ax_sprite sSalamenceGfx11, 0x20
+ax_sprite_terminator
+sSalamenceGfx12:
+.incbin "baserom.gba", 0x155D7A8, 0x200
+sSalamenceSprites12:
+ax_sprite sSalamenceGfx12, 0x200
+ax_sprite_terminator
+sSalamenceGfx13:
+.incbin "baserom.gba", 0x155D9B8, 0x80
+sSalamenceSprites13:
+ax_sprite sSalamenceGfx13, 0x80
+ax_sprite_terminator
+sSalamenceGfx14:
+.incbin "baserom.gba", 0x155DA48, 0x40
+sSalamenceSprites14:
+ax_sprite sSalamenceGfx14, 0x40
+ax_sprite_terminator
+sSalamenceGfx15:
+.incbin "baserom.gba", 0x155DA98, 0x20
+sSalamenceSprites15:
+ax_sprite sSalamenceGfx15, 0x20
+ax_sprite_terminator
+sSalamenceGfx16:
+.incbin "baserom.gba", 0x155DAC8, 0x100
+sSalamenceSprites16:
+ax_sprite sSalamenceGfx16, 0x100
+ax_sprite_terminator
+sSalamenceGfx17:
+.incbin "baserom.gba", 0x155DBD8, 0x80
+sSalamenceSprites17:
+ax_sprite sSalamenceGfx17, 0x80
+ax_sprite_terminator
+sSalamenceGfx18:
+.incbin "baserom.gba", 0x155DC68, 0x80
+sSalamenceSprites18:
+ax_sprite sSalamenceGfx18, 0x80
+ax_sprite_terminator
+sSalamenceGfx19:
+.incbin "baserom.gba", 0x155DCF8, 0x40
+sSalamenceSprites19:
+ax_sprite sSalamenceGfx19, 0x40
+ax_sprite_terminator
+sSalamenceGfx20:
+.incbin "baserom.gba", 0x155DD48, 0x20
+sSalamenceSprites20:
+ax_sprite sSalamenceGfx20, 0x20
+ax_sprite_terminator
+sSalamenceGfx21:
+.incbin "baserom.gba", 0x155DD78, 0x200
+sSalamenceSprites21:
+ax_sprite sSalamenceGfx21, 0x200
+ax_sprite_terminator
+sSalamenceGfx22:
+.incbin "baserom.gba", 0x155DF88, 0x20
+sSalamenceSprites22:
+ax_sprite sSalamenceGfx22, 0x20
+ax_sprite_terminator
+sSalamenceGfx23:
+.incbin "baserom.gba", 0x155DFB8, 0x40
+sSalamenceSprites23:
+ax_sprite sSalamenceGfx23, 0x40
+ax_sprite_terminator
+sSalamenceGfx24:
+.incbin "baserom.gba", 0x155E008, 0x80
+sSalamenceSprites24:
+ax_sprite sSalamenceGfx24, 0x80
+ax_sprite_terminator
+sSalamenceGfx25:
+.incbin "baserom.gba", 0x155E098, 0x40
+sSalamenceSprites25:
+ax_sprite sSalamenceGfx25, 0x40
+ax_sprite_terminator
+sSalamenceGfx26:
+.incbin "baserom.gba", 0x155E0E8, 0x200
+sSalamenceSprites26:
+ax_sprite sSalamenceGfx26, 0x200
+ax_sprite_terminator
+sSalamenceGfx27:
+.incbin "baserom.gba", 0x155E2F8, 0x20
+sSalamenceSprites27:
+ax_sprite sSalamenceGfx27, 0x20
+ax_sprite_terminator
+sSalamenceGfx28:
+.incbin "baserom.gba", 0x155E328, 0x40
+sSalamenceSprites28:
+ax_sprite sSalamenceGfx28, 0x40
+ax_sprite_terminator
+sSalamenceGfx29:
+.incbin "baserom.gba", 0x155E378, 0x40
+sSalamenceSprites29:
+ax_sprite sSalamenceGfx29, 0x40
+ax_sprite_terminator
+sSalamenceGfx30:
+.incbin "baserom.gba", 0x155E3C8, 0x20
+sSalamenceSprites30:
+ax_sprite sSalamenceGfx30, 0x20
+ax_sprite_terminator
+sSalamenceGfx31:
+.incbin "baserom.gba", 0x155E3F8, 0x20
+sSalamenceSprites31:
+ax_sprite sSalamenceGfx31, 0x20
+ax_sprite_terminator
+sSalamenceGfx32:
+.incbin "baserom.gba", 0x155E428, 0x200
+sSalamenceSprites32:
+ax_sprite sSalamenceGfx32, 0x200
+ax_sprite_terminator
+sSalamenceGfx33:
+.incbin "baserom.gba", 0x155E638, 0x100
+sSalamenceSprites33:
+ax_sprite sSalamenceGfx33, 0x100
+ax_sprite_terminator
+sSalamenceGfx34:
+.incbin "baserom.gba", 0x155E748, 0x40
+sSalamenceSprites34:
+ax_sprite sSalamenceGfx34, 0x40
+ax_sprite_terminator
+sSalamenceGfx35:
+.incbin "baserom.gba", 0x155E798, 0x20
+sSalamenceSprites35:
+ax_sprite sSalamenceGfx35, 0x20
+ax_sprite_terminator
+sSalamenceGfx36:
+.incbin "baserom.gba", 0x155E7C8, 0x40
+sSalamenceSprites36:
+ax_sprite sSalamenceGfx36, 0x40
+ax_sprite_terminator
+sSalamenceGfx37:
+.incbin "baserom.gba", 0x155E818, 0x200
+sSalamenceSprites37:
+ax_sprite sSalamenceGfx37, 0x200
+ax_sprite_terminator
+sSalamenceGfx38:
+.incbin "baserom.gba", 0x155EA28, 0x100
+sSalamenceSprites38:
+ax_sprite sSalamenceGfx38, 0x100
+ax_sprite_terminator
+sSalamenceGfx39:
+.incbin "baserom.gba", 0x155EB38, 0x40
+sSalamenceSprites39:
+ax_sprite sSalamenceGfx39, 0x40
+ax_sprite_terminator
+sSalamenceGfx40:
+.incbin "baserom.gba", 0x155EB88, 0x40
+sSalamenceSprites40:
+ax_sprite sSalamenceGfx40, 0x40
+ax_sprite_terminator
+sSalamenceGfx41:
+.incbin "baserom.gba", 0x155EBD8, 0xE0
+sSalamenceSprites41:
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx41, 0xe0
+ax_sprite_terminator
+sSalamenceGfx42:
+.incbin "baserom.gba", 0x155ECD0, 0x60
+sSalamenceGfx42_1:
+.incbin "baserom.gba", 0x155ED30, 0x80
+sSalamenceSprites42:
+ax_sprite sSalamenceGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx42_1, 0x80
+ax_sprite_terminator
+sSalamenceGfx43:
+.incbin "baserom.gba", 0x155EDD0, 0x100
+sSalamenceSprites43:
+ax_sprite sSalamenceGfx43, 0x100
+ax_sprite_terminator
+sSalamenceGfx44:
+.incbin "baserom.gba", 0x155EEE0, 0x180
+sSalamenceGfx44_1:
+.incbin "baserom.gba", 0x155F060, 0x60
+sSalamenceSprites44:
+ax_sprite sSalamenceGfx44, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx44_1, 0x60
+ax_sprite_terminator
+sSalamenceGfx45:
+.incbin "baserom.gba", 0x155F0E0, 0xE0
+sSalamenceSprites45:
+ax_sprite sSalamenceGfx45, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx46:
+.incbin "baserom.gba", 0x155F1D8, 0x20
+sSalamenceSprites46:
+ax_sprite sSalamenceGfx46, 0x20
+ax_sprite_terminator
+sSalamenceGfx47:
+.incbin "baserom.gba", 0x155F208, 0x20
+sSalamenceSprites47:
+ax_sprite sSalamenceGfx47, 0x20
+ax_sprite_terminator
+sSalamenceGfx48:
+.incbin "baserom.gba", 0x155F238, 0x180
+sSalamenceGfx48_1:
+.incbin "baserom.gba", 0x155F3B8, 0x60
+sSalamenceSprites48:
+ax_sprite sSalamenceGfx48, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx48_1, 0x60
+ax_sprite_terminator
+sSalamenceGfx49:
+.incbin "baserom.gba", 0x155F438, 0xE0
+sSalamenceSprites49:
+ax_sprite sSalamenceGfx49, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx50:
+.incbin "baserom.gba", 0x155F530, 0x20
+sSalamenceSprites50:
+ax_sprite sSalamenceGfx50, 0x20
+ax_sprite_terminator
+sSalamenceGfx51:
+.incbin "baserom.gba", 0x155F560, 0x20
+sSalamenceGfx51_1:
+.incbin "baserom.gba", 0x155F580, 0x80
+sSalamenceGfx51_2:
+.incbin "baserom.gba", 0x155F600, 0xE0
+sSalamenceGfx51_3:
+.incbin "baserom.gba", 0x155F6E0, 0xA0
+sSalamenceGfx51_4:
+.incbin "baserom.gba", 0x155F780, 0x40
+sSalamenceGfx51_5:
+.incbin "baserom.gba", 0x155F7C0, 0x40
+sSalamenceSprites51:
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx51, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx51_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx51_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSalamenceGfx51_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSalamenceGfx51_4, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx51_5, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSalamenceGfx52:
+.incbin "baserom.gba", 0x155F870, 0x80
+sSalamenceSprites52:
+ax_sprite sSalamenceGfx52, 0x80
+ax_sprite_terminator
+sSalamenceGfx53:
+.incbin "baserom.gba", 0x155F900, 0x80
+sSalamenceSprites53:
+ax_sprite sSalamenceGfx53, 0x80
+ax_sprite_terminator
+sSalamenceGfx54:
+.incbin "baserom.gba", 0x155F990, 0x60
+sSalamenceGfx54_1:
+.incbin "baserom.gba", 0x155F9F0, 0x160
+sSalamenceSprites54:
+ax_sprite sSalamenceGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx54_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx55:
+.incbin "baserom.gba", 0x155FB78, 0x80
+sSalamenceSprites55:
+ax_sprite sSalamenceGfx55, 0x80
+ax_sprite_terminator
+sSalamenceGfx56:
+.incbin "baserom.gba", 0x155FC08, 0x40
+sSalamenceSprites56:
+ax_sprite sSalamenceGfx56, 0x40
+ax_sprite_terminator
+sSalamenceGfx57:
+.incbin "baserom.gba", 0x155FC58, 0x20
+sSalamenceSprites57:
+ax_sprite sSalamenceGfx57, 0x20
+ax_sprite_terminator
+sSalamenceGfx58:
+.incbin "baserom.gba", 0x155FC88, 0x200
+sSalamenceSprites58:
+ax_sprite sSalamenceGfx58, 0x200
+ax_sprite_terminator
+sSalamenceGfx59:
+.incbin "baserom.gba", 0x155FE98, 0x20
+sSalamenceGfx59_1:
+.incbin "baserom.gba", 0x155FEB8, 0x20
+sSalamenceSprites59:
+ax_sprite sSalamenceGfx59, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx59_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx60:
+.incbin "baserom.gba", 0x155FF00, 0x20
+sSalamenceSprites60:
+ax_sprite sSalamenceGfx60, 0x20
+ax_sprite_terminator
+sSalamenceGfx61:
+.incbin "baserom.gba", 0x155FF30, 0x200
+sSalamenceSprites61:
+ax_sprite sSalamenceGfx61, 0x200
+ax_sprite_terminator
+sSalamenceGfx62:
+.incbin "baserom.gba", 0x1560140, 0x20
+sSalamenceGfx62_1:
+.incbin "baserom.gba", 0x1560160, 0x20
+sSalamenceGfx62_2:
+.incbin "baserom.gba", 0x1560180, 0x20
+sSalamenceSprites62:
+ax_sprite 0, 0x40
+ax_sprite sSalamenceGfx62, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx62_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx62_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx63:
+.incbin "baserom.gba", 0x15601E0, 0x20
+sSalamenceSprites63:
+ax_sprite sSalamenceGfx63, 0x20
+ax_sprite_terminator
+sSalamenceGfx64:
+.incbin "baserom.gba", 0x1560210, 0x20
+sSalamenceSprites64:
+ax_sprite sSalamenceGfx64, 0x20
+ax_sprite_terminator
+sSalamenceGfx65:
+.incbin "baserom.gba", 0x1560240, 0x20
+sSalamenceSprites65:
+ax_sprite sSalamenceGfx65, 0x20
+ax_sprite_terminator
+sSalamenceGfx66:
+.incbin "baserom.gba", 0x1560270, 0x20
+sSalamenceSprites66:
+ax_sprite sSalamenceGfx66, 0x20
+ax_sprite_terminator
+sSalamenceGfx67:
+.incbin "baserom.gba", 0x15602A0, 0x180
+sSalamenceGfx67_1:
+.incbin "baserom.gba", 0x1560420, 0x60
+sSalamenceSprites67:
+ax_sprite sSalamenceGfx67, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx67_1, 0x60
+ax_sprite_terminator
+sSalamenceGfx68:
+.incbin "baserom.gba", 0x15604A0, 0x60
+sSalamenceSprites68:
+ax_sprite sSalamenceGfx68, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx69:
+.incbin "baserom.gba", 0x1560518, 0x80
+sSalamenceSprites69:
+ax_sprite sSalamenceGfx69, 0x80
+ax_sprite_terminator
+sSalamenceGfx70:
+.incbin "baserom.gba", 0x15605A8, 0x80
+sSalamenceSprites70:
+ax_sprite sSalamenceGfx70, 0x80
+ax_sprite_terminator
+sSalamenceGfx71:
+.incbin "baserom.gba", 0x1560638, 0x160
+sSalamenceGfx71_1:
+.incbin "baserom.gba", 0x1560798, 0x60
+sSalamenceSprites71:
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx71, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx71_1, 0x60
+ax_sprite_terminator
+sSalamenceGfx72:
+.incbin "baserom.gba", 0x1560820, 0x20
+sSalamenceGfx72_1:
+.incbin "baserom.gba", 0x1560840, 0xC0
+sSalamenceSprites72:
+ax_sprite sSalamenceGfx72, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx72_1, 0xc0
+ax_sprite_terminator
+sSalamenceGfx73:
+.incbin "baserom.gba", 0x1560920, 0x200
+sSalamenceSprites73:
+ax_sprite sSalamenceGfx73, 0x200
+ax_sprite_terminator
+sSalamenceGfx74:
+.incbin "baserom.gba", 0x1560B30, 0x20
+sSalamenceGfx74_1:
+.incbin "baserom.gba", 0x1560B50, 0x40
+sSalamenceSprites74:
+ax_sprite sSalamenceGfx74, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx74_1, 0x40
+ax_sprite_terminator
+sSalamenceGfx75:
+.incbin "baserom.gba", 0x1560BB0, 0x20
+sSalamenceSprites75:
+ax_sprite sSalamenceGfx75, 0x20
+ax_sprite_terminator
+sSalamenceGfx76:
+.incbin "baserom.gba", 0x1560BE0, 0x20
+sSalamenceSprites76:
+ax_sprite sSalamenceGfx76, 0x20
+ax_sprite_terminator
+sSalamenceGfx77:
+.incbin "baserom.gba", 0x1560C10, 0x60
+sSalamenceGfx77_1:
+.incbin "baserom.gba", 0x1560C70, 0x180
+sSalamenceSprites77:
+ax_sprite sSalamenceGfx77, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx77_1, 0x180
+ax_sprite_terminator
+sSalamenceGfx78:
+.incbin "baserom.gba", 0x1560E10, 0x40
+sSalamenceSprites78:
+ax_sprite sSalamenceGfx78, 0x40
+ax_sprite_terminator
+sSalamenceGfx79:
+.incbin "baserom.gba", 0x1560E60, 0x20
+sSalamenceSprites79:
+ax_sprite sSalamenceGfx79, 0x20
+ax_sprite_terminator
+sSalamenceGfx80:
+.incbin "baserom.gba", 0x1560E90, 0x40
+sSalamenceSprites80:
+ax_sprite sSalamenceGfx80, 0x40
+ax_sprite_terminator
+sSalamenceGfx81:
+.incbin "baserom.gba", 0x1560EE0, 0x60
+sSalamenceGfx81_1:
+.incbin "baserom.gba", 0x1560F40, 0x180
+sSalamenceSprites81:
+ax_sprite sSalamenceGfx81, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx81_1, 0x180
+ax_sprite_terminator
+sSalamenceGfx82:
+.incbin "baserom.gba", 0x15610E0, 0x20
+sSalamenceSprites82:
+ax_sprite sSalamenceGfx82, 0x20
+ax_sprite_terminator
+sSalamenceGfx83:
+.incbin "baserom.gba", 0x1561110, 0x80
+sSalamenceSprites83:
+ax_sprite sSalamenceGfx83, 0x80
+ax_sprite_terminator
+sSalamenceGfx84:
+.incbin "baserom.gba", 0x15611A0, 0x80
+sSalamenceSprites84:
+ax_sprite sSalamenceGfx84, 0x80
+ax_sprite_terminator
+sSalamenceGfx85:
+.incbin "baserom.gba", 0x1561230, 0xC0
+sSalamenceGfx85_1:
+.incbin "baserom.gba", 0x15612F0, 0x20
+sSalamenceSprites85:
+ax_sprite sSalamenceGfx85, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx85_1, 0x20
+ax_sprite_terminator
+sSalamenceGfx86:
+.incbin "baserom.gba", 0x1561330, 0x200
+sSalamenceSprites86:
+ax_sprite sSalamenceGfx86, 0x200
+ax_sprite_terminator
+sSalamenceGfx87:
+.incbin "baserom.gba", 0x1561540, 0x20
+sSalamenceSprites87:
+ax_sprite sSalamenceGfx87, 0x20
+ax_sprite_terminator
+sSalamenceGfx88:
+.incbin "baserom.gba", 0x1561570, 0x200
+sSalamenceSprites88:
+ax_sprite sSalamenceGfx88, 0x200
+ax_sprite_terminator
+sSalamenceGfx89:
+.incbin "baserom.gba", 0x1561780, 0x20
+sSalamenceGfx89_1:
+.incbin "baserom.gba", 0x15617A0, 0x20
+sSalamenceGfx89_2:
+.incbin "baserom.gba", 0x15617C0, 0x20
+sSalamenceGfx89_3:
+.incbin "baserom.gba", 0x15617E0, 0x20
+sSalamenceSprites89:
+ax_sprite sSalamenceGfx89, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx89_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx89_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx89_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx90:
+.incbin "baserom.gba", 0x1561848, 0x40
+sSalamenceSprites90:
+ax_sprite sSalamenceGfx90, 0x40
+ax_sprite_terminator
+sSalamenceGfx91:
+.incbin "baserom.gba", 0x1561898, 0x40
+sSalamenceSprites91:
+ax_sprite sSalamenceGfx91, 0x40
+ax_sprite_terminator
+sSalamenceGfx92:
+.incbin "baserom.gba", 0x15618E8, 0x60
+sSalamenceGfx92_1:
+.incbin "baserom.gba", 0x1561948, 0x180
+sSalamenceSprites92:
+ax_sprite sSalamenceGfx92, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx92_1, 0x180
+ax_sprite_terminator
+sSalamenceGfx93:
+.incbin "baserom.gba", 0x1561AE8, 0x80
+sSalamenceSprites93:
+ax_sprite sSalamenceGfx93, 0x80
+ax_sprite_terminator
+sSalamenceGfx94:
+.incbin "baserom.gba", 0x1561B78, 0x40
+sSalamenceSprites94:
+ax_sprite sSalamenceGfx94, 0x40
+ax_sprite_terminator
+sSalamenceGfx95:
+.incbin "baserom.gba", 0x1561BC8, 0x80
+sSalamenceSprites95:
+ax_sprite sSalamenceGfx95, 0x80
+ax_sprite_terminator
+sSalamenceGfx96:
+.incbin "baserom.gba", 0x1561C58, 0x200
+sSalamenceSprites96:
+ax_sprite sSalamenceGfx96, 0x200
+ax_sprite_terminator
+sSalamenceGfx97:
+.incbin "baserom.gba", 0x1561E68, 0x20
+sSalamenceGfx97_1:
+.incbin "baserom.gba", 0x1561E88, 0xC0
+sSalamenceSprites97:
+ax_sprite sSalamenceGfx97, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx97_1, 0xc0
+ax_sprite_terminator
+sSalamenceGfx98:
+.incbin "baserom.gba", 0x1561F68, 0x20
+sSalamenceSprites98:
+ax_sprite sSalamenceGfx98, 0x20
+ax_sprite_terminator
+sSalamenceGfx99:
+.incbin "baserom.gba", 0x1561F98, 0x200
+sSalamenceSprites99:
+ax_sprite sSalamenceGfx99, 0x200
+ax_sprite_terminator
+sSalamenceGfx100:
+.incbin "baserom.gba", 0x15621A8, 0x100
+sSalamenceSprites100:
+ax_sprite sSalamenceGfx100, 0x100
+ax_sprite_terminator
+sSalamenceGfx101:
+.incbin "baserom.gba", 0x15622B8, 0x40
+sSalamenceSprites101:
+ax_sprite sSalamenceGfx101, 0x40
+ax_sprite_terminator
+sSalamenceGfx102:
+.incbin "baserom.gba", 0x1562308, 0x200
+sSalamenceSprites102:
+ax_sprite sSalamenceGfx102, 0x200
+ax_sprite_terminator
+sSalamenceGfx103:
+.incbin "baserom.gba", 0x1562518, 0x20
+sSalamenceGfx103_1:
+.incbin "baserom.gba", 0x1562538, 0xA0
+sSalamenceSprites103:
+ax_sprite sSalamenceGfx103, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx103_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx104:
+.incbin "baserom.gba", 0x1562600, 0x80
+sSalamenceSprites104:
+ax_sprite sSalamenceGfx104, 0x80
+ax_sprite_terminator
+sSalamenceGfx105:
+.incbin "baserom.gba", 0x1562690, 0x200
+sSalamenceSprites105:
+ax_sprite sSalamenceGfx105, 0x200
+ax_sprite_terminator
+sSalamenceGfx106:
+.incbin "baserom.gba", 0x15628A0, 0x20
+sSalamenceGfx106_1:
+.incbin "baserom.gba", 0x15628C0, 0x20
+sSalamenceGfx106_2:
+.incbin "baserom.gba", 0x15628E0, 0x80
+sSalamenceSprites106:
+ax_sprite sSalamenceGfx106, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx106_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx106_2, 0x80
+ax_sprite_terminator
+sSalamenceGfx107:
+.incbin "baserom.gba", 0x1562990, 0x40
+sSalamenceSprites107:
+ax_sprite sSalamenceGfx107, 0x40
+ax_sprite_terminator
+sSalamenceGfx108:
+.incbin "baserom.gba", 0x15629E0, 0x20
+sSalamenceSprites108:
+ax_sprite sSalamenceGfx108, 0x20
+ax_sprite_terminator
+sSalamenceGfx109:
+.incbin "baserom.gba", 0x1562A10, 0x40
+sSalamenceSprites109:
+ax_sprite sSalamenceGfx109, 0x40
+ax_sprite_terminator
+sSalamenceGfx110:
+.incbin "baserom.gba", 0x1562A60, 0x180
+sSalamenceGfx110_1:
+.incbin "baserom.gba", 0x1562BE0, 0x60
+sSalamenceSprites110:
+ax_sprite sSalamenceGfx110, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx110_1, 0x60
+ax_sprite_terminator
+sSalamenceGfx111:
+.incbin "baserom.gba", 0x1562C60, 0x20
+sSalamenceGfx111_1:
+.incbin "baserom.gba", 0x1562C80, 0x60
+sSalamenceGfx111_2:
+.incbin "baserom.gba", 0x1562CE0, 0x20
+sSalamenceSprites111:
+ax_sprite sSalamenceGfx111, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx111_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx111_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx112:
+.incbin "baserom.gba", 0x1562D38, 0x20
+sSalamenceSprites112:
+ax_sprite sSalamenceGfx112, 0x20
+ax_sprite_terminator
+sSalamenceGfx113:
+.incbin "baserom.gba", 0x1562D68, 0xE0
+sSalamenceGfx113_1:
+.incbin "baserom.gba", 0x1562E48, 0x100
+sSalamenceGfx113_2:
+.incbin "baserom.gba", 0x1562F48, 0x80
+sSalamenceGfx113_3:
+.incbin "baserom.gba", 0x1562FC8, 0xA0
+sSalamenceSprites113:
+ax_sprite sSalamenceGfx113, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx113_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sSalamenceGfx113_2, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSalamenceGfx113_3, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSalamenceGfx114:
+.incbin "baserom.gba", 0x15630B0, 0x200
+sSalamenceSprites114:
+ax_sprite sSalamenceGfx114, 0x200
+ax_sprite_terminator
+sSalamenceGfx115:
+.incbin "baserom.gba", 0x15632C0, 0x20
+sSalamenceGfx115_1:
+.incbin "baserom.gba", 0x15632E0, 0x60
+sSalamenceGfx115_2:
+.incbin "baserom.gba", 0x1563340, 0x20
+sSalamenceSprites115:
+ax_sprite sSalamenceGfx115, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx115_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx115_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx116:
+.incbin "baserom.gba", 0x1563398, 0x20
+sSalamenceSprites116:
+ax_sprite sSalamenceGfx116, 0x20
+ax_sprite_terminator
+sSalamenceGfx117:
+.incbin "baserom.gba", 0x15633C8, 0x1E0
+sSalamenceSprites117:
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx117, 0x1e0
+ax_sprite_terminator
+sSalamenceGfx118:
+.incbin "baserom.gba", 0x15635C0, 0x20
+sSalamenceGfx118_1:
+.incbin "baserom.gba", 0x15635E0, 0xC0
+sSalamenceSprites118:
+ax_sprite sSalamenceGfx118, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx118_1, 0xc0
+ax_sprite_terminator
+sSalamenceGfx119:
+.incbin "baserom.gba", 0x15636C0, 0x20
+sSalamenceSprites119:
+ax_sprite sSalamenceGfx119, 0x20
+ax_sprite_terminator
+sSalamenceGfx120:
+.incbin "baserom.gba", 0x15636F0, 0x20
+sSalamenceSprites120:
+ax_sprite sSalamenceGfx120, 0x20
+ax_sprite_terminator
+sSalamenceGfx121:
+.incbin "baserom.gba", 0x1563720, 0x200
+sSalamenceSprites121:
+ax_sprite sSalamenceGfx121, 0x200
+ax_sprite_terminator
+sSalamenceGfx122:
+.incbin "baserom.gba", 0x1563930, 0x20
+sSalamenceGfx122_1:
+.incbin "baserom.gba", 0x1563950, 0xA0
+sSalamenceSprites122:
+ax_sprite sSalamenceGfx122, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx122_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSalamenceGfx123:
+.incbin "baserom.gba", 0x1563A18, 0x20
+sSalamenceSprites123:
+ax_sprite sSalamenceGfx123, 0x20
+ax_sprite_terminator
+sSalamenceGfx124:
+.incbin "baserom.gba", 0x1563A48, 0xC0
+sSalamenceGfx124_1:
+.incbin "baserom.gba", 0x1563B08, 0xC0
+sSalamenceGfx124_2:
+.incbin "baserom.gba", 0x1563BC8, 0xC0
+sSalamenceGfx124_3:
+.incbin "baserom.gba", 0x1563C88, 0x80
+sSalamenceSprites124:
+ax_sprite 0, 0x20
+ax_sprite sSalamenceGfx124, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSalamenceGfx124_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSalamenceGfx124_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSalamenceGfx124_3, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSalamenceGfx125:
+.incbin "baserom.gba", 0x1563D58, 0x200
+sSalamenceSprites125:
+ax_sprite sSalamenceGfx125, 0x200
+ax_sprite_terminator
+sSalamenceGfx126:
+.incbin "baserom.gba", 0x1563F68, 0x100
+sSalamenceSprites126:
+ax_sprite sSalamenceGfx126, 0x100
+ax_sprite_terminator
+sSalamenceGfx127:
+.incbin "baserom.gba", 0x1564078, 0x200
+sSalamenceSprites127:
+ax_sprite sSalamenceGfx127, 0x200
+ax_sprite_terminator
+sSalamenceGfx128:
+.incbin "baserom.gba", 0x1564288, 0x100
+sSalamenceSprites128:
+ax_sprite sSalamenceGfx128, 0x100
+ax_sprite_terminator
+sSalamenceGfx129:
+.incbin "baserom.gba", 0x1564398, 0x200
+sSalamenceSprites129:
+ax_sprite sSalamenceGfx129, 0x200
+ax_sprite_terminator
+sSalamenceGfx130:
+.incbin "baserom.gba", 0x15645A8, 0x80
+sSalamenceSprites130:
+ax_sprite sSalamenceGfx130, 0x80
+ax_sprite_terminator
+sSalamenceGfx131:
+.incbin "baserom.gba", 0x1564638, 0x80
+sSalamenceSprites131:
+ax_sprite sSalamenceGfx131, 0x80
+ax_sprite_terminator
+sSalamenceGfx132:
+.incbin "baserom.gba", 0x15646C8, 0x100
+sSalamenceSprites132:
+ax_sprite sSalamenceGfx132, 0x100
+ax_sprite_terminator
+sSalamenceGfx133:
+.incbin "baserom.gba", 0x15647D8, 0x200
+sSalamenceSprites133:
+ax_sprite sSalamenceGfx133, 0x200
+ax_sprite_terminator
+sSalamenceGfx134:
+.incbin "baserom.gba", 0x15649E8, 0x20
+sSalamenceSprites134:
+ax_sprite sSalamenceGfx134, 0x20
+ax_sprite_terminator
+sSalamenceGfx135:
+.incbin "baserom.gba", 0x1564A18, 0x20
+sSalamenceSprites135:
+ax_sprite sSalamenceGfx135, 0x20
+ax_sprite_terminator
+sSalamenceGfx136:
+.incbin "baserom.gba", 0x1564A48, 0x20
+sSalamenceSprites136:
+ax_sprite sSalamenceGfx136, 0x20
+ax_sprite_terminator
+sSalamenceGfx137:
+.incbin "baserom.gba", 0x1564A78, 0x80
+sSalamenceSprites137:
+ax_sprite sSalamenceGfx137, 0x80
+ax_sprite_terminator
+sSalamenceGfx138:
+.incbin "baserom.gba", 0x1564B08, 0x80
+sSalamenceSprites138:
+ax_sprite sSalamenceGfx138, 0x80
+ax_sprite_terminator
+sSalamenceGfx139:
+.incbin "baserom.gba", 0x1564B98, 0x80
+sSalamenceSprites139:
+ax_sprite sSalamenceGfx139, 0x80
+ax_sprite_terminator
+sSalamenceGfx140:
+.incbin "baserom.gba", 0x1564C28, 0x200
+sSalamenceSprites140:
+ax_sprite sSalamenceGfx140, 0x200
+ax_sprite_terminator
+sSalamenceGfx141:
+.incbin "baserom.gba", 0x1564E38, 0x20
+sSalamenceSprites141:
+ax_sprite sSalamenceGfx141, 0x20
+ax_sprite_terminator
+sSalamenceGfx142:
+.incbin "baserom.gba", 0x1564E68, 0x40
+sSalamenceSprites142:
+ax_sprite sSalamenceGfx142, 0x40
+ax_sprite_terminator
+sSalamenceGfx143:
+.incbin "baserom.gba", 0x1564EB8, 0x100
+sSalamenceSprites143:
+ax_sprite sSalamenceGfx143, 0x100
+ax_sprite_terminator
+sSalamenceGfx144:
+.incbin "baserom.gba", 0x1564FC8, 0x100
+sSalamenceSprites144:
+ax_sprite sSalamenceGfx144, 0x100
+ax_sprite_terminator
+sSalamenceGfx145:
+.incbin "baserom.gba", 0x15650D8, 0x20
+sSalamenceSprites145:
+ax_sprite sSalamenceGfx145, 0x20
+ax_sprite_terminator
+sSalamenceGfx146:
+.incbin "baserom.gba", 0x1565108, 0x20
+sSalamenceSprites146:
+ax_sprite sSalamenceGfx146, 0x20
+ax_sprite_terminator
+sSalamenceGfx147:
+.incbin "baserom.gba", 0x1565138, 0x20
+sSalamenceSprites147:
+ax_sprite sSalamenceGfx147, 0x20
+ax_sprite_terminator
+sSalamenceGfx148:
+.incbin "baserom.gba", 0x1565168, 0x80
+sSalamenceSprites148:
+ax_sprite sSalamenceGfx148, 0x80
+ax_sprite_terminator
+sSalamenceGfx149:
+.incbin "baserom.gba", 0x15651F8, 0x200
+sSalamenceSprites149:
+ax_sprite sSalamenceGfx149, 0x200
+ax_sprite_terminator
+sSalamenceGfx150:
+.incbin "baserom.gba", 0x1565408, 0x100
+sSalamenceSprites150:
+ax_sprite sSalamenceGfx150, 0x100
+ax_sprite_terminator
+sSalamenceGfx151:
+.incbin "baserom.gba", 0x1565518, 0x40
+sSalamenceSprites151:
+ax_sprite sSalamenceGfx151, 0x40
+ax_sprite_terminator
+sSalamenceGfx152:
+.incbin "baserom.gba", 0x1565568, 0x20
+sSalamenceSprites152:
+ax_sprite sSalamenceGfx152, 0x20
+ax_sprite_terminator
+sSalamenceGfx153:
+.incbin "baserom.gba", 0x1565598, 0x40
+sSalamenceSprites153:
+ax_sprite sSalamenceGfx153, 0x40
+ax_sprite_terminator
+sSalamenceGfx154:
+.incbin "baserom.gba", 0x15655E8, 0x20
+sSalamenceSprites154:
+ax_sprite sSalamenceGfx154, 0x20
+ax_sprite_terminator
+sSalamenceGfx155:
+.incbin "baserom.gba", 0x1565618, 0x20
+sSalamenceSprites155:
+ax_sprite sSalamenceGfx155, 0x20
+ax_sprite_terminator
+sSalamenceGfx156:
+.incbin "baserom.gba", 0x1565648, 0x40
+sSalamenceSprites156:
+ax_sprite sSalamenceGfx156, 0x40
+ax_sprite_terminator
+sSalamenceGfx157:
+.incbin "baserom.gba", 0x1565698, 0x40
+sSalamenceSprites157:
+ax_sprite sSalamenceGfx157, 0x40
+ax_sprite_terminator
+sSalamenceGfx158:
+.incbin "baserom.gba", 0x15656E8, 0x80
+sSalamenceSprites158:
+ax_sprite sSalamenceGfx158, 0x80
+ax_sprite_terminator
+sSalamenceGfx159:
+.incbin "baserom.gba", 0x1565778, 0x100
+sSalamenceSprites159:
+ax_sprite sSalamenceGfx159, 0x100
+ax_sprite_terminator
+sSalamenceGfx160:
+.incbin "baserom.gba", 0x1565888, 0x200
+sSalamenceSprites160:
+ax_sprite sSalamenceGfx160, 0x200
+ax_sprite_terminator
+sSalamenceGfx161:
+.incbin "baserom.gba", 0x1565A98, 0x100
+sSalamenceSprites161:
+ax_sprite sSalamenceGfx161, 0x100
+ax_sprite_terminator
+sAxPosesSalamence:
+.4byte sSalamencePose1
+.4byte sSalamencePose2
+.4byte sSalamencePose3
+.4byte sSalamencePose4
+.4byte sSalamencePose5
+.4byte sSalamencePose6
+.4byte sSalamencePose7
+.4byte sSalamencePose8
+.4byte sSalamencePose9
+.4byte sSalamencePose10
+.4byte sSalamencePose11
+.4byte sSalamencePose12
+.4byte sSalamencePose13
+.4byte sSalamencePose14
+.4byte sSalamencePose15
+.4byte sSalamencePose16
+.4byte sSalamencePose17
+.4byte sSalamencePose18
+.4byte sSalamencePose19
+.4byte sSalamencePose20
+.4byte sSalamencePose21
+.4byte sSalamencePose22
+.4byte sSalamencePose23
+.4byte sSalamencePose24
+.4byte sSalamencePose25
+.4byte sSalamencePose26
+.4byte sSalamencePose27
+.4byte sSalamencePose28
+.4byte sSalamencePose29
+.4byte sSalamencePose30
+.4byte sSalamencePose31
+.4byte sSalamencePose32
+.4byte sSalamencePose33
+.4byte sSalamencePose34
+.4byte sSalamencePose35
+.4byte sSalamencePose36
+.4byte sSalamencePose37
+.4byte sSalamencePose38
+.4byte sSalamencePose39
+.4byte sSalamencePose40
+.4byte sSalamencePose41
+.4byte sSalamencePose42
+.4byte sSalamencePose43
+.4byte sSalamencePose44
+.4byte sSalamencePose45
+.4byte sSalamencePose46
+.4byte sSalamencePose47
+.4byte sSalamencePose48
+.4byte sSalamencePose49
+.4byte sSalamencePose50
+.4byte sSalamencePose51
+.4byte sSalamencePose52
+.4byte sSalamencePose53
+.4byte sSalamencePose54
+.4byte sSalamencePose55
+.4byte sSalamencePose56
+.4byte sSalamencePose57
+.4byte sSalamencePose58
+.4byte sSalamencePose59
+.4byte sSalamencePose60
+.4byte sSalamencePose61
+.4byte sSalamencePose62
+.4byte sSalamencePose63
+.4byte sSalamencePose64
+.4byte sSalamencePose65
+.4byte sSalamencePose66
+.4byte sSalamencePose67
+.4byte sSalamencePose68
+.4byte sSalamencePose69
+.4byte sSalamencePose70
+.4byte sSalamencePose71
+.4byte sSalamencePose72
+.4byte sSalamencePose73
+.4byte sSalamencePose74
+.4byte sSalamencePose75
+.4byte sSalamencePose76
+.4byte sSalamencePose77
+.4byte sSalamencePose78
+.4byte sSalamencePose79
+.4byte sSalamencePose80
+.4byte sSalamencePose81
+.4byte sSalamencePose82
+.4byte sSalamencePose83
+.4byte sSalamencePose84
+.4byte sSalamencePose85
+.4byte sSalamencePose86
+.4byte sSalamencePose87
+.4byte sSalamencePose88
+.4byte sSalamencePose89
+.4byte sSalamencePose90
+.4byte sSalamencePose91
+.4byte sSalamencePose92
+.4byte sSalamencePose93
+.4byte sSalamencePose94
+.4byte sSalamencePose95
+.4byte sSalamencePose96
+.4byte sSalamencePose97
+.4byte sSalamencePose98
+.4byte sSalamencePose99
+.4byte sSalamencePose100
+.4byte sSalamencePose101
+.4byte sSalamencePose102
+.4byte sSalamencePose103
+.4byte sSalamencePose104
+.4byte sSalamencePose105
+.4byte sSalamencePose106
+.4byte sSalamencePose107
+.4byte sSalamencePose108
+.4byte sSalamencePose109
+.4byte sSalamencePose110
+.4byte sSalamencePose111
+.4byte sSalamencePose112
+.4byte sSalamencePose113
+.4byte sSalamencePose114
+.4byte sSalamencePose115
+.4byte sSalamencePose116
+.4byte sSalamencePose117
+.4byte sSalamencePose118
+.4byte sSalamencePose119
+.4byte sSalamencePose120
+.4byte sSalamencePose121
+.4byte sSalamencePose122
+.4byte sSalamencePose123
+.4byte sSalamencePose124
+.4byte sSalamencePose125
+.4byte sSalamencePose126
+.4byte sSalamencePose127
+.4byte sSalamencePose128
+.4byte sSalamencePose129
+.4byte sSalamencePose130
+.4byte sSalamencePose131
+.4byte sSalamencePose132
+.4byte sSalamencePose133
+.4byte sSalamencePose134
+.4byte sSalamencePose135
+.4byte sSalamencePose136
+.4byte sSalamencePose137
+.4byte sSalamencePose138
+.4byte sSalamencePose139
+.4byte sSalamencePose140
+.4byte sSalamencePose141
+.4byte sSalamencePose142
+.4byte sSalamencePose143
+.4byte sSalamencePose144
+.4byte sSalamencePose145
+.4byte sSalamencePose146
+.4byte sSalamencePose147
+.4byte sSalamencePose148
+.4byte sSalamencePose149
+.4byte sSalamencePose150
+.4byte sSalamencePose151
+.4byte sSalamencePose152
+.4byte sSalamencePose153
+.4byte sSalamencePose154
+.4byte sSalamencePose155
+.4byte sSalamencePose156
+.4byte sSalamencePose157
+.4byte sSalamencePose158
+.4byte sSalamencePose159
+.4byte sSalamencePose160
+.4byte sSalamencePose161
+.4byte sSalamencePose162
+.4byte sSalamencePose163
+.4byte sSalamencePose164
+.4byte sSalamencePose165
+.4byte sSalamencePose166
+.4byte sSalamencePose167
+.4byte sSalamencePose168
+.4byte sSalamencePose169
+.4byte sSalamencePose170
+.4byte sSalamencePose171
+.4byte sSalamencePose172
+.4byte sSalamencePose173
+.4byte sSalamencePose174
+.4byte sSalamencePose175
+.4byte sSalamencePose176
+.4byte sSalamencePose177
+.4byte sSalamencePose178
+.4byte sSalamencePose179
+.4byte sSalamencePose180
+.4byte sSalamencePose181
+.4byte sSalamencePose182
+.4byte sSalamencePose183
+.4byte sSalamencePose184
+.4byte sSalamencePose185
+.4byte sSalamencePose186
+.4byte sSalamencePose187
+.4byte sSalamencePose188
+.4byte sSalamencePose189
+.4byte sSalamencePose190
+.4byte sSalamencePose191
+.4byte sSalamencePose192
+.4byte sSalamencePose193
+.4byte sSalamencePose194
+.4byte sSalamencePose195
+.4byte sSalamencePose196
+.4byte sSalamencePose197
+.4byte sSalamencePose198
+.4byte sSalamencePose199
+.4byte sSalamencePose200
+.4byte sSalamencePose201
+.4byte sSalamencePose202
+.4byte sSalamencePose203
+.4byte sSalamencePose204
+.4byte sSalamencePose205
+.4byte sSalamencePose206
+.4byte sSalamencePose207
+.4byte sSalamencePose208
+.4byte sSalamencePose209
+.4byte sSalamencePose210
+.4byte sSalamencePose211
+.4byte sSalamencePose212
+.4byte sSalamencePose213
+.4byte sSalamencePose214
+.4byte sSalamencePose215
+.4byte sSalamencePose216
+.4byte sSalamencePose217
+.4byte sSalamencePose218
+.4byte sSalamencePose219
+.4byte sSalamencePose220
+.4byte sSalamencePose221
+.4byte sSalamencePose222
+.4byte sSalamencePose223
+.4byte sSalamencePose224
+.4byte sSalamencePose225
+.4byte sSalamencePose226
+.4byte sSalamencePose227
+.4byte sSalamencePose228
+.4byte sSalamencePose229
+.4byte sSalamencePose230
+.4byte sSalamencePose231
+.4byte sSalamencePose232
+.4byte sSalamencePose233
+.4byte sSalamencePose234
+.4byte sSalamencePose235
+.4byte sSalamencePose236
+.4byte sSalamencePose237
+.4byte sSalamencePose238
+.4byte sSalamencePose239
+.4byte sSalamencePose240
+.4byte sSalamencePose241
+.4byte sSalamencePose242
+sAxPositionsSalamence:
+.2byte   -2,  -12, 	 -13,   -4, 	  10,   -4, 	  -1,  -11
+.2byte   -2,  -14, 	 -12,   -6, 	   9,   -6, 	  -1,  -11
+.2byte   13,  -16, 	  10,   -9, 	  -2,   -4, 	  -2,  -13
+.2byte   12,  -18, 	   9,  -10, 	   0,   -5, 	  -1,  -14
+.2byte   19,  -20, 	   5,  -11, 	   7,   -6, 	  -3,  -13
+.2byte   18,  -22, 	   5,  -13, 	   6,   -7, 	  -2,  -13
+.2byte    9,  -28, 	  -3,  -14, 	  12,  -10, 	  -1,  -15
+.2byte    7,  -31, 	  -7,  -14, 	   6,  -11, 	  -2,  -13
+.2byte   -1,  -32, 	   7,  -13, 	  -9,  -13, 	  -1,  -16
+.2byte   -1,  -33, 	   7,  -13, 	  -9,  -13, 	  -1,  -17
+.2byte  -10,  -28, 	   2,  -14, 	 -13,  -10, 	   0,  -15
+.2byte   -8,  -31, 	   6,  -14, 	  -7,  -11, 	   1,  -13
+.2byte  -20,  -20, 	  -6,  -11, 	  -8,   -6, 	   2,  -13
+.2byte  -19,  -22, 	  -6,  -13, 	  -7,   -7, 	   1,  -13
+.2byte  -14,  -16, 	 -11,   -9, 	   1,   -4, 	   1,  -13
+.2byte  -13,  -18, 	 -10,  -10, 	  -1,   -5, 	   0,  -14
+.2byte   -2,   -3, 	 -15,    2, 	  12,    2, 	  -1,   -6
+.2byte   -1,  -22, 	 -14,    2, 	  11,    2, 	  -1,   -9
+.2byte   -2,  -28, 	 -12,  -14, 	   9,  -14, 	  -1,  -15
+.2byte   -2,    7, 	 -16,   -5, 	  13,   -5, 	  -1,   -8
+.2byte   -1,    5, 	 -16,   -5, 	  13,   -5, 	  -1,   -8
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    8,  -18, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    9,  -26, 	  13,  -14, 	  -2,  -10, 	  -3,  -13
+.2byte   16,    3, 	   7,  -13, 	  -7,   -3, 	  -2,  -13
+.2byte   15,    0, 	   7,  -13, 	  -7,   -3, 	  -2,  -13
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   12,  -19, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte    8,  -28, 	   5,  -22, 	   9,  -15, 	  -5,  -11
+.2byte   23,   -8, 	  -2,  -11, 	  -2,   -1, 	  -4,   -9
+.2byte   20,   -7, 	  -2,  -11, 	  -2,   -1, 	  -4,   -9
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte    9,  -27, 	  -4,   -5, 	  13,   -2, 	  -1,   -9
+.2byte    7,  -31, 	  -1,  -22, 	  14,  -17, 	  -4,  -11
+.2byte   17,  -21, 	  -4,  -10, 	  11,   -2, 	   2,  -11
+.2byte   -1,  -21, 	   9,   -4, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -29, 	   7,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -1,  -31, 	   6,  -20, 	  -8,  -20, 	  -1,  -10
+.2byte   -1,  -23, 	   8,  -14, 	 -10,  -14, 	  -1,  -16
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte  -10,  -27, 	   3,   -5, 	 -14,   -2, 	   0,   -9
+.2byte   -8,  -31, 	   0,  -22, 	 -15,  -17, 	   3,  -11
+.2byte  -18,  -21, 	   3,  -10, 	 -12,   -2, 	  -3,  -11
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -19, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte   -9,  -28, 	  -6,  -22, 	 -10,  -15, 	   4,  -11
+.2byte  -24,   -8, 	   1,  -11, 	   1,   -1, 	   3,   -9
+.2byte  -21,   -7, 	   1,  -11, 	   1,   -1, 	   3,   -9
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte   -9,  -18, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -10,  -26, 	 -14,  -14, 	   1,  -10, 	   2,  -13
+.2byte  -17,    3, 	  -8,  -13, 	   6,   -3, 	   1,  -13
+.2byte  -16,    0, 	  -8,  -13, 	   6,   -3, 	   1,  -13
+.2byte   -2,   -3, 	 -15,    2, 	  12,    2, 	  -1,   -6
+.2byte   -1,  -22, 	 -14,    2, 	  11,    2, 	  -1,   -9
+.2byte   -2,  -28, 	 -12,  -14, 	   9,  -14, 	  -1,  -15
+.2byte   -2,    7, 	 -16,   -5, 	  13,   -5, 	  -1,   -8
+.2byte   -1,    5, 	 -16,   -5, 	  13,   -5, 	  -1,   -8
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    8,  -18, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    9,  -26, 	  13,  -14, 	  -2,  -10, 	  -3,  -13
+.2byte   16,    3, 	   7,  -13, 	  -7,   -3, 	  -2,  -13
+.2byte   15,    0, 	   7,  -13, 	  -7,   -3, 	  -2,  -13
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   12,  -19, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte    8,  -28, 	   5,  -22, 	   9,  -15, 	  -5,  -11
+.2byte   23,   -8, 	  -2,  -11, 	  -2,   -1, 	  -4,   -9
+.2byte   20,   -7, 	  -2,  -11, 	  -2,   -1, 	  -4,   -9
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte    9,  -27, 	  -4,   -5, 	  13,   -2, 	  -1,   -9
+.2byte    7,  -31, 	  -1,  -22, 	  14,  -17, 	  -4,  -11
+.2byte   17,  -21, 	  -4,  -10, 	  11,   -2, 	   2,  -11
+.2byte   -1,  -21, 	   9,   -4, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -29, 	   7,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -1,  -31, 	   6,  -20, 	  -8,  -20, 	  -1,  -10
+.2byte   -1,  -23, 	   8,  -14, 	 -10,  -14, 	  -1,  -16
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte  -10,  -27, 	   3,   -5, 	 -14,   -2, 	   0,   -9
+.2byte   -8,  -31, 	   0,  -22, 	 -15,  -17, 	   3,  -11
+.2byte  -18,  -21, 	   3,  -10, 	 -12,   -2, 	  -3,  -11
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -19, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte   -9,  -28, 	  -6,  -22, 	 -10,  -15, 	   4,  -11
+.2byte  -24,   -8, 	   1,  -11, 	   1,   -1, 	   3,   -9
+.2byte  -21,   -7, 	   1,  -11, 	   1,   -1, 	   3,   -9
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte   -9,  -18, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -10,  -26, 	 -14,  -14, 	   1,  -10, 	   2,  -13
+.2byte  -17,    3, 	  -8,  -13, 	   6,   -3, 	   1,  -13
+.2byte  -16,    0, 	  -8,  -13, 	   6,   -3, 	   1,  -13
+.2byte   -1,   -3, 	 -14,    2, 	  13,    2, 	   0,   -6
+.2byte    0,  -22, 	 -13,    2, 	  12,    2, 	   0,   -9
+.2byte   -1,  -28, 	 -11,  -14, 	  10,  -14, 	   0,  -15
+.2byte    0,    0, 	 -15,    3, 	  14,    3, 	  -1,  -12
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    8,  -18, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    9,  -26, 	  13,  -14, 	  -2,  -10, 	  -3,  -13
+.2byte   16,    0, 	  13,   -3, 	  -2,    4, 	  -3,   -7
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   12,  -19, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte    8,  -28, 	   5,  -22, 	   9,  -15, 	  -5,  -11
+.2byte   20,   -7, 	  10,   -6, 	   7,    3, 	   0,   -6
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte    9,  -27, 	  -4,   -5, 	  13,   -2, 	  -1,   -9
+.2byte    7,  -31, 	  -1,  -22, 	  14,  -17, 	  -4,  -11
+.2byte   14,  -17, 	  -1,   -8, 	  17,   -1, 	   1,   -9
+.2byte   17,  -21, 	  -4,  -10, 	  11,   -2, 	   2,  -11
+.2byte   -1,  -20, 	   9,   -3, 	 -11,   -3, 	  -1,   -8
+.2byte   -1,  -29, 	   7,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -1,  -30, 	   6,  -19, 	  -8,  -19, 	  -1,   -9
+.2byte   -1,  -18, 	   7,   -7, 	  -9,   -7, 	  -1,  -11
+.2byte   -1,  -22, 	   8,  -13, 	 -10,  -13, 	  -1,  -15
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte  -10,  -27, 	   3,   -5, 	 -14,   -2, 	   0,   -9
+.2byte   -8,  -31, 	   0,  -22, 	 -15,  -17, 	   3,  -11
+.2byte  -15,  -17, 	   0,   -8, 	 -18,   -1, 	  -2,   -9
+.2byte  -18,  -21, 	   3,  -10, 	 -12,   -2, 	  -3,  -11
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -19, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte   -9,  -28, 	  -6,  -22, 	 -10,  -15, 	   4,  -11
+.2byte  -21,   -7, 	 -11,   -6, 	  -8,    3, 	  -1,   -6
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte   -9,  -18, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -10,  -26, 	 -14,  -14, 	   1,  -10, 	   2,  -13
+.2byte  -17,    0, 	 -14,   -3, 	   1,    4, 	   2,   -7
+.2byte   -2,   -3, 	 -15,    2, 	  12,    2, 	  -1,   -6
+.2byte   -1,  -22, 	 -14,    2, 	  11,    2, 	  -1,   -9
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    8,  -18, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   12,  -19, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte    9,  -27, 	  -4,   -5, 	  13,   -2, 	  -1,   -9
+.2byte   -1,  -21, 	   9,   -4, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -29, 	   7,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte  -10,  -27, 	   3,   -5, 	 -14,   -2, 	   0,   -9
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -19, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte   -9,  -18, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -16,    1, 	 -12,    1, 	  -1,    3, 	   0,   -7
+.2byte  -16,    2, 	 -11,    1, 	  -2,    3, 	   1,   -7
+.2byte   -2,  -25, 	 -13,   -6, 	  11,    2, 	  -1,   -8
+.2byte    7,  -26, 	  17,  -10, 	  -1,    4, 	  -3,   -8
+.2byte   11,  -25, 	  13,  -11, 	   8,    1, 	  -2,   -7
+.2byte    7,  -29, 	  -2,  -14, 	  12,   -4, 	  -1,   -9
+.2byte    0,  -30, 	   8,  -11, 	  -8,   -5, 	   1,   -7
+.2byte   -8,  -29, 	   1,  -14, 	 -13,   -4, 	   0,   -9
+.2byte  -12,  -25, 	 -14,  -11, 	  -9,    1, 	   1,   -7
+.2byte   -5,  -26, 	 -15,  -10, 	   3,    4, 	   5,   -8
+.2byte   -1,   -3, 	 -14,    2, 	  13,    2, 	   0,   -6
+.2byte    0,  -22, 	 -13,    2, 	  12,    2, 	   0,   -9
+.2byte   -1,  -28, 	 -11,  -14, 	  10,  -14, 	   0,  -15
+.2byte    0,    0, 	 -15,    3, 	  14,    3, 	  -1,  -12
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    8,  -18, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte    9,  -26, 	  13,  -14, 	  -2,  -10, 	  -3,  -13
+.2byte   16,    0, 	  13,   -3, 	  -2,    4, 	  -3,   -7
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   12,  -19, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte    8,  -28, 	   5,  -22, 	   9,  -15, 	  -5,  -11
+.2byte   20,   -7, 	  10,   -6, 	   7,    3, 	   0,   -6
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte    9,  -27, 	  -4,   -5, 	  13,   -2, 	  -1,   -9
+.2byte    7,  -31, 	  -1,  -22, 	  14,  -17, 	  -4,  -11
+.2byte   14,  -17, 	  -1,   -8, 	  17,   -1, 	   1,   -9
+.2byte   17,  -21, 	  -4,  -10, 	  11,   -2, 	   2,  -11
+.2byte   -1,  -20, 	   9,   -3, 	 -11,   -3, 	  -1,   -8
+.2byte   -1,  -29, 	   7,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -1,  -30, 	   6,  -19, 	  -8,  -19, 	  -1,   -9
+.2byte   -1,  -18, 	   7,   -7, 	  -9,   -7, 	  -1,  -11
+.2byte   -1,  -22, 	   8,  -13, 	 -10,  -13, 	  -1,  -15
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte  -10,  -27, 	   3,   -5, 	 -14,   -2, 	   0,   -9
+.2byte   -8,  -31, 	   0,  -22, 	 -15,  -17, 	   3,  -11
+.2byte  -15,  -17, 	   0,   -8, 	 -18,   -1, 	  -2,   -9
+.2byte  -18,  -21, 	   3,  -10, 	 -12,   -2, 	  -3,  -11
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -19, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte   -9,  -28, 	  -6,  -22, 	 -10,  -15, 	   4,  -11
+.2byte  -21,   -7, 	 -11,   -6, 	  -8,    3, 	  -1,   -6
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte   -9,  -18, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -10,  -26, 	 -14,  -14, 	   1,  -10, 	   2,  -13
+.2byte  -17,    0, 	 -14,   -3, 	   1,    4, 	   2,   -7
+.2byte   -1,    5, 	 -16,   -5, 	  13,   -5, 	  -1,   -8
+.2byte  -16,    0, 	  -8,  -13, 	   6,   -3, 	   1,  -13
+.2byte  -21,   -7, 	   1,  -11, 	   1,   -1, 	   3,   -9
+.2byte  -15,  -22, 	   6,  -11, 	  -9,   -3, 	   0,  -12
+.2byte   -1,  -22, 	   8,  -13, 	 -10,  -13, 	  -1,  -15
+.2byte   14,  -22, 	  -7,  -11, 	   8,   -3, 	  -1,  -12
+.2byte   20,   -7, 	  -2,  -11, 	  -2,   -1, 	  -4,   -9
+.2byte   15,    0, 	   7,  -13, 	  -7,   -3, 	  -2,  -13
+.2byte   -1,  -22, 	 -14,    2, 	  11,    2, 	  -1,   -9
+.2byte    8,  -18, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte   12,  -19, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte    8,  -26, 	  -5,   -4, 	  12,   -1, 	  -2,   -8
+.2byte   -1,  -29, 	   7,   -5, 	 -10,   -5, 	  -1,   -9
+.2byte   -9,  -26, 	   4,   -4, 	 -13,   -1, 	   1,   -8
+.2byte  -13,  -19, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte   -9,  -18, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte   -1,   -3, 	 -14,    2, 	  13,    2, 	   0,   -6
+.2byte   -1,  -28, 	 -11,  -14, 	  10,  -14, 	   0,  -15
+.2byte    0,    0, 	 -15,    3, 	  14,    3, 	  -1,  -12
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte   11,  -26, 	  15,  -14, 	   0,  -10, 	  -1,  -13
+.2byte   16,    1, 	  13,   -2, 	  -2,    5, 	  -3,   -6
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   12,  -28, 	   9,  -22, 	  13,  -15, 	  -1,  -11
+.2byte   20,   -7, 	  10,   -6, 	   7,    3, 	   0,   -6
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte   10,  -31, 	   2,  -22, 	  17,  -17, 	  -1,  -11
+.2byte   13,  -17, 	  -2,   -8, 	  16,   -1, 	   0,   -9
+.2byte   -1,  -20, 	   9,   -3, 	 -11,   -3, 	  -1,   -8
+.2byte   -1,  -30, 	   6,  -19, 	  -8,  -19, 	  -1,   -9
+.2byte   -1,  -18, 	   7,   -7, 	  -9,   -7, 	  -1,  -11
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte  -11,  -31, 	  -3,  -22, 	 -18,  -17, 	   0,  -11
+.2byte  -14,  -17, 	   1,   -8, 	 -17,   -1, 	  -1,   -9
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -28, 	 -10,  -22, 	 -14,  -15, 	   0,  -11
+.2byte  -21,   -7, 	 -11,   -6, 	  -8,    3, 	  -1,   -6
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -12,  -26, 	 -16,  -14, 	  -1,  -10, 	   0,  -13
+.2byte  -17,    1, 	 -14,   -2, 	   1,    5, 	   2,   -6
+.2byte   -2,   -3, 	 -15,    2, 	  12,    2, 	  -1,   -6
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte   -1,  -21, 	   9,   -4, 	 -11,   -4, 	  -1,   -9
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+.2byte   -2,   -3, 	 -15,    2, 	  12,    2, 	  -1,   -6
+.2byte  -16,   -6, 	 -14,   -1, 	   2,    4, 	   0,   -7
+.2byte  -22,  -11, 	 -10,   -5, 	 -10,    2, 	   1,   -6
+.2byte  -13,  -19, 	  -2,   -8, 	 -15,   -2, 	  -1,   -7
+.2byte   -1,  -21, 	   9,   -4, 	 -11,   -4, 	  -1,   -9
+.2byte   12,  -19, 	   1,   -8, 	  14,   -2, 	   0,   -7
+.2byte   21,  -11, 	   9,   -5, 	   9,    2, 	  -2,   -6
+.2byte   15,   -6, 	  13,   -1, 	  -3,    4, 	  -1,   -7
+sSalamenceAnimTable1:
+.4byte sSalamenceAnims_1_1
+.4byte sSalamenceAnims_1_2
+.4byte sSalamenceAnims_1_3
+.4byte sSalamenceAnims_1_4
+.4byte sSalamenceAnims_1_5
+.4byte sSalamenceAnims_1_6
+.4byte sSalamenceAnims_1_7
+.4byte sSalamenceAnims_1_8
+sSalamenceAnimTable2:
+.4byte sSalamenceAnims_2_1
+.4byte sSalamenceAnims_2_2
+.4byte sSalamenceAnims_2_3
+.4byte sSalamenceAnims_2_4
+.4byte sSalamenceAnims_2_5
+.4byte sSalamenceAnims_2_6
+.4byte sSalamenceAnims_2_7
+.4byte sSalamenceAnims_2_8
+sSalamenceAnimTable3:
+.4byte sSalamenceAnims_3_1
+.4byte sSalamenceAnims_3_2
+.4byte sSalamenceAnims_3_3
+.4byte sSalamenceAnims_3_4
+.4byte sSalamenceAnims_3_5
+.4byte sSalamenceAnims_3_6
+.4byte sSalamenceAnims_3_7
+.4byte sSalamenceAnims_3_8
+sSalamenceAnimTable4:
+.4byte sSalamenceAnims_4_1
+.4byte sSalamenceAnims_4_2
+.4byte sSalamenceAnims_4_3
+.4byte sSalamenceAnims_4_4
+.4byte sSalamenceAnims_4_5
+.4byte sSalamenceAnims_4_6
+.4byte sSalamenceAnims_4_7
+.4byte sSalamenceAnims_4_8
+sSalamenceAnimTable5:
+.4byte sSalamenceAnims_5_1
+.4byte sSalamenceAnims_5_2
+.4byte sSalamenceAnims_5_3
+.4byte sSalamenceAnims_5_4
+.4byte sSalamenceAnims_5_5
+.4byte sSalamenceAnims_5_6
+.4byte sSalamenceAnims_5_7
+.4byte sSalamenceAnims_5_8
+sSalamenceAnimTable6:
+.4byte sSalamenceAnims_6_1
+.4byte sSalamenceAnims_6_1
+.4byte sSalamenceAnims_6_1
+.4byte sSalamenceAnims_6_1
+.4byte sSalamenceAnims_6_1
+.4byte sSalamenceAnims_6_1
+.4byte sSalamenceAnims_6_1
+.4byte sSalamenceAnims_6_1
+sSalamenceAnimTable7:
+.4byte sSalamenceAnims_7_1
+.4byte sSalamenceAnims_7_2
+.4byte sSalamenceAnims_7_3
+.4byte sSalamenceAnims_7_4
+.4byte sSalamenceAnims_7_5
+.4byte sSalamenceAnims_7_6
+.4byte sSalamenceAnims_7_7
+.4byte sSalamenceAnims_7_8
+sSalamenceAnimTable8:
+.4byte sSalamenceAnims_8_1
+.4byte sSalamenceAnims_8_2
+.4byte sSalamenceAnims_8_3
+.4byte sSalamenceAnims_8_4
+.4byte sSalamenceAnims_8_5
+.4byte sSalamenceAnims_8_6
+.4byte sSalamenceAnims_8_7
+.4byte sSalamenceAnims_8_8
+sSalamenceAnimTable9:
+.4byte sSalamenceAnims_9_1
+.4byte sSalamenceAnims_9_2
+.4byte sSalamenceAnims_9_3
+.4byte sSalamenceAnims_9_4
+.4byte sSalamenceAnims_9_5
+.4byte sSalamenceAnims_9_6
+.4byte sSalamenceAnims_9_7
+.4byte sSalamenceAnims_9_8
+sSalamenceAnimTable10:
+.4byte sSalamenceAnims_10_1
+.4byte sSalamenceAnims_10_2
+.4byte sSalamenceAnims_10_3
+.4byte sSalamenceAnims_10_4
+.4byte sSalamenceAnims_10_5
+.4byte sSalamenceAnims_10_6
+.4byte sSalamenceAnims_10_7
+.4byte sSalamenceAnims_10_8
+sSalamenceAnimTable11:
+.4byte sSalamenceAnims_11_1
+.4byte sSalamenceAnims_11_2
+.4byte sSalamenceAnims_11_3
+.4byte sSalamenceAnims_11_4
+.4byte sSalamenceAnims_11_5
+.4byte sSalamenceAnims_11_6
+.4byte sSalamenceAnims_11_7
+.4byte sSalamenceAnims_11_8
+sSalamenceAnimTable12:
+.4byte sSalamenceAnims_12_1
+.4byte sSalamenceAnims_12_2
+.4byte sSalamenceAnims_12_3
+.4byte sSalamenceAnims_12_4
+.4byte sSalamenceAnims_12_5
+.4byte sSalamenceAnims_12_6
+.4byte sSalamenceAnims_12_7
+.4byte sSalamenceAnims_12_8
+sSalamenceAnimTable13:
+.4byte sSalamenceAnims_13_1
+.4byte sSalamenceAnims_13_2
+.4byte sSalamenceAnims_13_3
+.4byte sSalamenceAnims_13_4
+.4byte sSalamenceAnims_13_5
+.4byte sSalamenceAnims_13_6
+.4byte sSalamenceAnims_13_7
+.4byte sSalamenceAnims_13_8
+sAxAnimationsSalamence:
+.4byte sSalamenceAnimTable1
+.4byte sSalamenceAnimTable2
+.4byte sSalamenceAnimTable3
+.4byte sSalamenceAnimTable4
+.4byte sSalamenceAnimTable5
+.4byte sSalamenceAnimTable6
+.4byte sSalamenceAnimTable7
+.4byte sSalamenceAnimTable8
+.4byte sSalamenceAnimTable9
+.4byte sSalamenceAnimTable10
+.4byte sSalamenceAnimTable11
+.4byte sSalamenceAnimTable12
+.4byte sSalamenceAnimTable13
+sAxSpritesSalamence:
+.4byte sSalamenceSprites1
+.4byte sSalamenceSprites2
+.4byte sSalamenceSprites3
+.4byte sSalamenceSprites4
+.4byte sSalamenceSprites5
+.4byte sSalamenceSprites6
+.4byte sSalamenceSprites7
+.4byte sSalamenceSprites8
+.4byte sSalamenceSprites9
+.4byte sSalamenceSprites10
+.4byte sSalamenceSprites11
+.4byte sSalamenceSprites12
+.4byte sSalamenceSprites13
+.4byte sSalamenceSprites14
+.4byte sSalamenceSprites15
+.4byte sSalamenceSprites16
+.4byte sSalamenceSprites17
+.4byte sSalamenceSprites18
+.4byte sSalamenceSprites19
+.4byte sSalamenceSprites20
+.4byte sSalamenceSprites21
+.4byte sSalamenceSprites22
+.4byte sSalamenceSprites23
+.4byte sSalamenceSprites24
+.4byte sSalamenceSprites25
+.4byte sSalamenceSprites26
+.4byte sSalamenceSprites27
+.4byte sSalamenceSprites28
+.4byte sSalamenceSprites29
+.4byte sSalamenceSprites30
+.4byte sSalamenceSprites31
+.4byte sSalamenceSprites32
+.4byte sSalamenceSprites33
+.4byte sSalamenceSprites34
+.4byte sSalamenceSprites35
+.4byte sSalamenceSprites36
+.4byte sSalamenceSprites37
+.4byte sSalamenceSprites38
+.4byte sSalamenceSprites39
+.4byte sSalamenceSprites40
+.4byte sSalamenceSprites41
+.4byte sSalamenceSprites42
+.4byte sSalamenceSprites43
+.4byte sSalamenceSprites44
+.4byte sSalamenceSprites45
+.4byte sSalamenceSprites46
+.4byte sSalamenceSprites47
+.4byte sSalamenceSprites48
+.4byte sSalamenceSprites49
+.4byte sSalamenceSprites50
+.4byte sSalamenceSprites51
+.4byte sSalamenceSprites52
+.4byte sSalamenceSprites53
+.4byte sSalamenceSprites54
+.4byte sSalamenceSprites55
+.4byte sSalamenceSprites56
+.4byte sSalamenceSprites57
+.4byte sSalamenceSprites58
+.4byte sSalamenceSprites59
+.4byte sSalamenceSprites60
+.4byte sSalamenceSprites61
+.4byte sSalamenceSprites62
+.4byte sSalamenceSprites63
+.4byte sSalamenceSprites64
+.4byte sSalamenceSprites65
+.4byte sSalamenceSprites66
+.4byte sSalamenceSprites67
+.4byte sSalamenceSprites68
+.4byte sSalamenceSprites69
+.4byte sSalamenceSprites70
+.4byte sSalamenceSprites71
+.4byte sSalamenceSprites72
+.4byte sSalamenceSprites73
+.4byte sSalamenceSprites74
+.4byte sSalamenceSprites75
+.4byte sSalamenceSprites76
+.4byte sSalamenceSprites77
+.4byte sSalamenceSprites78
+.4byte sSalamenceSprites79
+.4byte sSalamenceSprites80
+.4byte sSalamenceSprites81
+.4byte sSalamenceSprites82
+.4byte sSalamenceSprites83
+.4byte sSalamenceSprites84
+.4byte sSalamenceSprites85
+.4byte sSalamenceSprites86
+.4byte sSalamenceSprites87
+.4byte sSalamenceSprites88
+.4byte sSalamenceSprites89
+.4byte sSalamenceSprites90
+.4byte sSalamenceSprites91
+.4byte sSalamenceSprites92
+.4byte sSalamenceSprites93
+.4byte sSalamenceSprites94
+.4byte sSalamenceSprites95
+.4byte sSalamenceSprites96
+.4byte sSalamenceSprites97
+.4byte sSalamenceSprites98
+.4byte sSalamenceSprites99
+.4byte sSalamenceSprites100
+.4byte sSalamenceSprites101
+.4byte sSalamenceSprites102
+.4byte sSalamenceSprites103
+.4byte sSalamenceSprites104
+.4byte sSalamenceSprites105
+.4byte sSalamenceSprites106
+.4byte sSalamenceSprites107
+.4byte sSalamenceSprites108
+.4byte sSalamenceSprites109
+.4byte sSalamenceSprites110
+.4byte sSalamenceSprites111
+.4byte sSalamenceSprites112
+.4byte sSalamenceSprites113
+.4byte sSalamenceSprites114
+.4byte sSalamenceSprites115
+.4byte sSalamenceSprites116
+.4byte sSalamenceSprites117
+.4byte sSalamenceSprites118
+.4byte sSalamenceSprites119
+.4byte sSalamenceSprites120
+.4byte sSalamenceSprites121
+.4byte sSalamenceSprites122
+.4byte sSalamenceSprites123
+.4byte sSalamenceSprites124
+.4byte sSalamenceSprites125
+.4byte sSalamenceSprites126
+.4byte sSalamenceSprites127
+.4byte sSalamenceSprites128
+.4byte sSalamenceSprites129
+.4byte sSalamenceSprites130
+.4byte sSalamenceSprites131
+.4byte sSalamenceSprites132
+.4byte sSalamenceSprites133
+.4byte sSalamenceSprites134
+.4byte sSalamenceSprites135
+.4byte sSalamenceSprites136
+.4byte sSalamenceSprites137
+.4byte sSalamenceSprites138
+.4byte sSalamenceSprites139
+.4byte sSalamenceSprites140
+.4byte sSalamenceSprites141
+.4byte sSalamenceSprites142
+.4byte sSalamenceSprites143
+.4byte sSalamenceSprites144
+.4byte sSalamenceSprites145
+.4byte sSalamenceSprites146
+.4byte sSalamenceSprites147
+.4byte sSalamenceSprites148
+.4byte sSalamenceSprites149
+.4byte sSalamenceSprites150
+.4byte sSalamenceSprites151
+.4byte sSalamenceSprites152
+.4byte sSalamenceSprites153
+.4byte sSalamenceSprites154
+.4byte sSalamenceSprites155
+.4byte sSalamenceSprites156
+.4byte sSalamenceSprites157
+.4byte sSalamenceSprites158
+.4byte sSalamenceSprites159
+.4byte sSalamenceSprites160
+.4byte sSalamenceSprites161
+sAxMainSalamence:
+ax_main sAxPosesSalamence, sAxAnimationsSalamence, 13, sAxSpritesSalamence, sAxPositionsSalamence

--- a/data/ax/sandshrew.inc
+++ b/data/ax/sandshrew.inc
@@ -1,0 +1,2466 @@
+.global gAxSandshrew
+gAxSandshrew:
+ax_siro sAxMainSandshrew
+sSandshrewPose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose3:
+ax_pose 2, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose4:
+ax_pose 3, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose5:
+ax_pose 4, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose7:
+ax_pose 6, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose8:
+ax_pose 7, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose9:
+ax_pose 8, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose10:
+ax_pose 9, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose11:
+ax_pose 10, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose12:
+ax_pose 11, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose14:
+ax_pose 13, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose15:
+ax_pose 14, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose19:
+ax_pose 6, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose20:
+ax_pose 7, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose21:
+ax_pose 8, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose23:
+ax_pose 4, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose25:
+ax_pose 15, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose26:
+ax_pose 1, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose27:
+ax_pose 2, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose28:
+ax_pose 16, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose29:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sSandshrewPose30:
+ax_pose 4, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose31:
+ax_pose 5, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose32:
+ax_pose 18, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose33:
+ax_pose 19, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose34:
+ax_pose 7, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose35:
+ax_pose 8, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose36:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose37:
+ax_pose 21, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose38:
+ax_pose 10, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose39:
+ax_pose 11, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose40:
+ax_pose 22, 0x81ef, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose41:
+ax_pose 23, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose42:
+ax_pose 13, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose43:
+ax_pose 14, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose44:
+ax_pose 24, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose45:
+ax_pose 21, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose46:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose47:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose48:
+ax_pose 22, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose49:
+ax_pose 19, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sSandshrewPose50:
+ax_pose 7, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose51:
+ax_pose 8, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose52:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose53:
+ax_pose 17, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose54:
+ax_pose 4, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose55:
+ax_pose 5, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose56:
+ax_pose 18, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose57:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose58:
+ax_pose 25, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose59:
+ax_pose 26, 0x01ec, 0x80f0, 0x0c00
+ax_pose 15, 0x01ec, 0x80f0, 0x0c10
+ax_pose_terminator
+sSandshrewPose60:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose61:
+ax_pose 3, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose62:
+ax_pose 27, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose63:
+ax_pose 28, 0x01ed, 0x90ed, 0x0c00
+ax_pose 17, 0x01ed, 0x90eb, 0x0c10
+ax_pose_terminator
+sSandshrewPose64:
+ax_pose 17, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose65:
+ax_pose 6, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose66:
+ax_pose 29, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sSandshrewPose67:
+ax_pose 30, 0x01e7, 0x90ef, 0x0c00
+ax_pose 19, 0x01eb, 0x90ea, 0x0c10
+ax_pose_terminator
+sSandshrewPose68:
+ax_pose 19, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose69:
+ax_pose 9, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose70:
+ax_pose 31, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose71:
+ax_pose 32, 0x01ec, 0x90f3, 0x0c00
+ax_pose 21, 0x01ec, 0x90eb, 0x0c10
+ax_pose_terminator
+sSandshrewPose72:
+ax_pose 21, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose73:
+ax_pose 12, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose74:
+ax_pose 33, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose75:
+ax_pose 34, 0x01e6, 0x80f3, 0x0c00
+ax_pose 23, 0x01eb, 0x80f0, 0x0c10
+ax_pose_terminator
+sSandshrewPose76:
+ax_pose 23, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose77:
+ax_pose 9, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose78:
+ax_pose 31, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose79:
+ax_pose 32, 0x01ec, 0x80ed, 0x0c00
+ax_pose 21, 0x01ec, 0x80f5, 0x0c10
+ax_pose_terminator
+sSandshrewPose80:
+ax_pose 21, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose81:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sSandshrewPose82:
+ax_pose 29, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sSandshrewPose83:
+ax_pose 30, 0x01e7, 0x80f1, 0x0c00
+ax_pose 19, 0x01eb, 0x80f6, 0x0c10
+ax_pose_terminator
+sSandshrewPose84:
+ax_pose 19, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sSandshrewPose85:
+ax_pose 3, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose86:
+ax_pose 27, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose87:
+ax_pose 28, 0x01ed, 0x80f3, 0x0c00
+ax_pose 17, 0x01ed, 0x80f5, 0x0c10
+ax_pose_terminator
+sSandshrewPose88:
+ax_pose 17, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose89:
+ax_pose 15, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose90:
+ax_pose 17, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose91:
+ax_pose 19, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sSandshrewPose92:
+ax_pose 21, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose93:
+ax_pose 23, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose94:
+ax_pose 21, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose95:
+ax_pose 19, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose96:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sSandshrewPose97:
+ax_pose 16, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose98:
+ax_pose 18, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose99:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose100:
+ax_pose 22, 0x81ef, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose101:
+ax_pose 24, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose102:
+ax_pose 22, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose103:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose104:
+ax_pose 18, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose105:
+ax_pose 35, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose106:
+ax_pose 36, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose107:
+ax_pose 37, 0x41e9, 0x00f7, 0x0c00
+ax_pose 16, 0x81e9, 0x80f8, 0x0c02
+ax_pose_terminator
+sSandshrewPose108:
+ax_pose 38, 0x01e8, 0x50f0, 0x0c00
+ax_pose 18, 0x81eb, 0x90f8, 0x0c04
+ax_pose_terminator
+sSandshrewPose109:
+ax_pose 39, 0x01ea, 0x50eb, 0x0c00
+ax_pose 20, 0x81eb, 0x90f7, 0x0c04
+ax_pose_terminator
+sSandshrewPose110:
+ax_pose 40, 0x01e8, 0x50ee, 0x0c00
+ax_pose 22, 0x81ef, 0x90f7, 0x0c04
+ax_pose_terminator
+sSandshrewPose111:
+ax_pose 41, 0x41e9, 0x40f3, 0x0c00
+ax_pose 24, 0x81ec, 0x80f8, 0x0c04
+ax_pose_terminator
+sSandshrewPose112:
+ax_pose 40, 0x01e8, 0x4102, 0x0c00
+ax_pose 22, 0x81ef, 0x80f9, 0x0c04
+ax_pose_terminator
+sSandshrewPose113:
+ax_pose 39, 0x01ea, 0x4105, 0x0c00
+ax_pose 20, 0x81eb, 0x80f9, 0x0c04
+ax_pose_terminator
+sSandshrewPose114:
+ax_pose 38, 0x01e8, 0x4100, 0x0c00
+ax_pose 18, 0x81eb, 0x80f8, 0x0c04
+ax_pose_terminator
+sSandshrewPose115:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose116:
+ax_pose 3, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose117:
+ax_pose 6, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose118:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose119:
+ax_pose 12, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose120:
+ax_pose 9, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose121:
+ax_pose 6, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose122:
+ax_pose 3, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose123:
+ax_pose 16, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose124:
+ax_pose 18, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose125:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose126:
+ax_pose 22, 0x81ef, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose127:
+ax_pose 24, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose128:
+ax_pose 22, 0x81ef, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose129:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose130:
+ax_pose 18, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose131:
+ax_pose 15, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose132:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sSandshrewPose133:
+ax_pose 19, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose134:
+ax_pose 21, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose135:
+ax_pose 23, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose136:
+ax_pose 21, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose137:
+ax_pose 19, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sSandshrewPose138:
+ax_pose 17, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose139:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose140:
+ax_pose 25, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose141:
+ax_pose 16, 0x81e9, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose142:
+ax_pose 3, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose143:
+ax_pose 27, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose144:
+ax_pose 18, 0x81eb, 0x90f7, 0x0c00
+ax_pose_terminator
+sSandshrewPose145:
+ax_pose 6, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose146:
+ax_pose 29, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sSandshrewPose147:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose148:
+ax_pose 9, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose149:
+ax_pose 31, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose150:
+ax_pose 22, 0x81ef, 0x90f7, 0x0c00
+ax_pose_terminator
+sSandshrewPose151:
+ax_pose 12, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose152:
+ax_pose 33, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose153:
+ax_pose 24, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose154:
+ax_pose 9, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose155:
+ax_pose 31, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose156:
+ax_pose 22, 0x81ef, 0x80f9, 0x0c00
+ax_pose_terminator
+sSandshrewPose157:
+ax_pose 6, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sSandshrewPose158:
+ax_pose 29, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sSandshrewPose159:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSandshrewPose160:
+ax_pose 3, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose161:
+ax_pose 27, 0x01ed, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose162:
+ax_pose 18, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sSandshrewPose163:
+ax_pose 15, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose164:
+ax_pose 17, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose165:
+ax_pose 19, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sSandshrewPose166:
+ax_pose 21, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose167:
+ax_pose 23, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose168:
+ax_pose 21, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose169:
+ax_pose 19, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose170:
+ax_pose 17, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sSandshrewPose171:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose172:
+ax_pose 3, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose173:
+ax_pose 6, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSandshrewPose174:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSandshrewPose175:
+ax_pose 12, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSandshrewPose176:
+ax_pose 9, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sSandshrewPose177:
+ax_pose 6, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSandshrewPose178:
+ax_pose 3, 0x01ed, 0x90eb, 0x0c00
+ax_pose_terminator
+.align 2
+sSandshrewAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 11, 0, 11,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim_terminator
+sSandshrewAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 22, 21, 22, 21,
+ax_anim 2, 1, 31, 23, 20, 23, 20,
+ax_anim 2, 0, 31, 22, 21, 22, 21,
+ax_anim 2, 0, 31, 23, 20, 23, 20,
+ax_anim 2, 0, 31, 11, 11, 11, 11,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sSandshrewAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 33, 4, 0, 4, 0,
+ax_anim_terminator
+sSandshrewAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -5, 4, -5,
+ax_anim 1, 0, 39, 10, -12, 10, -12,
+ax_anim 2, 0, 39, 21, -23, 21, -23,
+ax_anim 2, 1, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 39, 21, -23, 21, -23,
+ax_anim 2, 0, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 39, 11, -11, 11, -11,
+ax_anim 2, 0, 37, 4, -4, 4, -4,
+ax_anim_terminator
+sSandshrewAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 41, 0, -4, 0, -4,
+ax_anim_terminator
+sSandshrewAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -5, -4, -5,
+ax_anim 1, 0, 47, -10, -12, -10, -12,
+ax_anim 2, 0, 47, -21, -23, -21, -23,
+ax_anim 2, 1, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 47, -21, -23, -21, -23,
+ax_anim 2, 0, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 47, -11, -11, -11, -11,
+ax_anim 2, 0, 45, -4, -4, -4, -4,
+ax_anim_terminator
+sSandshrewAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -11, 0, -11, 0,
+ax_anim 2, 0, 49, -4, 0, -4, 0,
+ax_anim_terminator
+sSandshrewAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -22, 21, -22, 21,
+ax_anim 2, 1, 55, -23, 20, -23, 20,
+ax_anim 2, 0, 55, -22, 21, -22, 21,
+ax_anim 2, 0, 55, -23, 20, -23, 20,
+ax_anim 2, 0, 55, -11, 11, -11, 11,
+ax_anim 2, 0, 53, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 57, 0, -5, 0, -5,
+ax_anim 6, 0, 57, 0, -6, 0, -6,
+ax_anim 1, 2, 57, 0, 1, 0, 1,
+ax_anim 1, 0, 57, 0, 7, 0, 7,
+ax_anim 2, 0, 58, 0, 17, 0, 17,
+ax_anim 2, 1, 59, -1, 17, -1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, -1, 17, -1, 17,
+ax_anim 2, 0, 59, 0, 17, 0, 17,
+ax_anim 2, 0, 59, -1, 17, -1, 17,
+ax_anim 2, 0, 57, 0, 8, 0, 8,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sSandshrewAnims_3_2:
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 61, -5, -5, -5, -5,
+ax_anim 6, 0, 61, -6, -6, -6, -6,
+ax_anim 1, 2, 61, 1, 1, 1, 1,
+ax_anim 1, 0, 61, 7, 7, 7, 7,
+ax_anim 2, 0, 62, 17, 17, 17, 17,
+ax_anim 2, 1, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 17, 18, 17, 18,
+ax_anim 2, 0, 61, 8, 8, 8, 8,
+ax_anim 2, 0, 60, 3, 3, 3, 3,
+ax_anim_terminator
+sSandshrewAnims_3_3:
+ax_anim 2, 0, 64, -2, 0, -2, 0,
+ax_anim 2, 0, 65, -5, 0, -5, 0,
+ax_anim 6, 0, 65, -6, 0, -6, 0,
+ax_anim 1, 2, 65, 1, 0, 1, 0,
+ax_anim 1, 0, 65, 7, 0, 7, 0,
+ax_anim 2, 0, 66, 17, 0, 17, 0,
+ax_anim 2, 1, 67, 17, -1, 17, -1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, -1, 17, -1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, -1, 17, -1,
+ax_anim 2, 0, 65, 8, 0, 8, 0,
+ax_anim 2, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sSandshrewAnims_3_4:
+ax_anim 2, 0, 68, -2, 2, -2, 2,
+ax_anim 2, 0, 69, -5, 5, -5, 5,
+ax_anim 6, 0, 69, -6, 6, -6, 6,
+ax_anim 1, 2, 69, 1, -2, 1, -2,
+ax_anim 1, 0, 69, 8, -8, 8, -8,
+ax_anim 2, 0, 70, 14, -16, 14, -16,
+ax_anim 2, 1, 71, 15, -15, 15, -15,
+ax_anim 2, 0, 71, 14, -16, 14, -16,
+ax_anim 2, 0, 71, 15, -15, 15, -15,
+ax_anim 2, 0, 71, 14, -16, 14, -16,
+ax_anim 2, 0, 71, 15, -15, 15, -15,
+ax_anim 2, 0, 68, 12, -11, 12, -11,
+ax_anim 2, 0, 68, 3, -3, 3, -3,
+ax_anim_terminator
+sSandshrewAnims_3_5:
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 6, 0, 73, -1, 6, -1, 6,
+ax_anim 1, 2, 73, 1, -1, 1, -1,
+ax_anim 1, 0, 73, 2, -4, 2, -4,
+ax_anim 2, 0, 74, 3, -15, 3, -15,
+ax_anim 2, 1, 75, 4, -15, 4, -15,
+ax_anim 2, 0, 75, 3, -15, 3, -15,
+ax_anim 2, 0, 75, 4, -15, 4, -15,
+ax_anim 2, 0, 75, 3, -15, 3, -15,
+ax_anim 2, 0, 75, 4, -15, 4, -15,
+ax_anim 2, 0, 73, 1, -8, 1, -8,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sSandshrewAnims_3_6:
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 5, 5, 5, 5,
+ax_anim 6, 0, 77, 6, 6, 6, 6,
+ax_anim 1, 2, 77, -1, -2, -1, -2,
+ax_anim 1, 0, 77, -8, -8, -8, -8,
+ax_anim 2, 0, 78, -14, -16, -14, -16,
+ax_anim 2, 1, 79, -15, -15, -15, -15,
+ax_anim 2, 0, 79, -14, -16, -14, -16,
+ax_anim 2, 0, 79, -15, -15, -15, -15,
+ax_anim 2, 0, 79, -14, -16, -14, -16,
+ax_anim 2, 0, 79, -15, -15, -15, -15,
+ax_anim 2, 0, 76, -12, -11, -12, -11,
+ax_anim 2, 0, 76, -3, -3, -3, -3,
+ax_anim_terminator
+sSandshrewAnims_3_7:
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 81, 5, 0, 5, 0,
+ax_anim 6, 0, 81, 6, 0, 6, 0,
+ax_anim 1, 2, 81, -1, 0, -1, 0,
+ax_anim 1, 0, 81, -7, 0, -7, 0,
+ax_anim 2, 0, 82, -17, 0, -17, 0,
+ax_anim 2, 1, 83, -17, -1, -17, -1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, -1, -17, -1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, -1, -17, -1,
+ax_anim 2, 0, 81, -8, 0, -8, 0,
+ax_anim 2, 0, 80, -3, 0, -3, 0,
+ax_anim_terminator
+sSandshrewAnims_3_8:
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim 2, 0, 85, 5, -5, 5, -5,
+ax_anim 6, 0, 85, 6, -6, 6, -6,
+ax_anim 1, 2, 85, -1, 1, -1, 1,
+ax_anim 1, 0, 85, -7, 7, -7, 7,
+ax_anim 2, 0, 86, -17, 17, -17, 17,
+ax_anim 2, 1, 87, -17, 18, -17, 18,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -17, 18, -17, 18,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -17, 18, -17, 18,
+ax_anim 2, 0, 85, -8, 8, -8, 8,
+ax_anim 2, 0, 84, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_4_1:
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_4_2:
+ax_anim 2, 0, 95, 1, -1, 1, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, 0,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_4_3:
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_4_4:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_4_5:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_4_6:
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_4_7:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_4_8:
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_5_1:
+ax_anim 16, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_5_2:
+ax_anim 16, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_5_3:
+ax_anim 16, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_5_4:
+ax_anim 16, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_5_5:
+ax_anim 16, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_5_6:
+ax_anim 16, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_5_7:
+ax_anim 16, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 102, -1, 0, -1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_5_8:
+ax_anim 16, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sSandshrewAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sSandshrewAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sSandshrewAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sSandshrewAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sSandshrewAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sSandshrewAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sSandshrewAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_8_1:
+ax_anim 40, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_8_2:
+ax_anim 40, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_8_3:
+ax_anim 40, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, 0,
+ax_anim 2, 0, 120, 0, -2, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_8_4:
+ax_anim 40, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_8_5:
+ax_anim 40, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_8_6:
+ax_anim 40, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, 0,
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_8_7:
+ax_anim 40, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_8_8:
+ax_anim 40, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 6, 4, 6, 4,
+ax_anim 2, 0, 124, 8, 9, 8, 9,
+ax_anim 2, 0, 125, 7, 17, 7, 17,
+ax_anim 3, 0, 126, 0, 21, 0, 21,
+ax_anim 2, 3, 127, -7, 17, -7, 17,
+ax_anim 2, 0, 128, -8, 9, -8, 9,
+ax_anim 1, 0, 129, -6, 4, -6, 4,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 123, 17, 3, 17, 3,
+ax_anim 2, 0, 124, 23, 11, 23, 11,
+ax_anim 3, 0, 125, 21, 20, 21, 20,
+ax_anim 2, 3, 126, 11, 21, 11, 21,
+ax_anim 2, 0, 127, 4, 15, 4, 15,
+ax_anim 1, 0, 128, 0, 7, 0, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 3, -4, 3, -4,
+ax_anim 2, 0, 122, 11, -6, 11, -6,
+ax_anim 2, 0, 123, 17, -4, 17, -4,
+ax_anim 3, 0, 124, 22, 1, 22, 1,
+ax_anim 2, 3, 125, 17, 5, 17, 5,
+ax_anim 2, 0, 126, 12, 7, 12, 7,
+ax_anim 1, 0, 127, 4, 5, 4, 5,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, -1, -6, -1, -6,
+ax_anim 2, 0, 129, 4, -16, 4, -16,
+ax_anim 2, 0, 122, 11, -21, 11, -21,
+ax_anim 3, 0, 123, 21, -23, 21, -23,
+ax_anim 2, 3, 124, 22, -12, 22, -12,
+ax_anim 2, 0, 125, 16, -6, 16, -6,
+ax_anim 1, 0, 126, 7, -1, 7, -1,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 128, -8, -10, -8, -10,
+ax_anim 2, 0, 129, -7, -18, -7, -18,
+ax_anim 3, 0, 122, 0, -23, 0, -23,
+ax_anim 2, 3, 123, 7, -18, 7, -18,
+ax_anim 2, 0, 124, 8, -8, 8, -8,
+ax_anim 1, 0, 125, 6, -4, 6, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 1, -6, 1, -6,
+ax_anim 2, 0, 123, -4, -16, -4, -16,
+ax_anim 2, 0, 122, -11, -21, -11, -21,
+ax_anim 3, 0, 129, -21, -23, -21, -23,
+ax_anim 2, 3, 128, -22, -12, -22, -12,
+ax_anim 2, 0, 127, -16, -6, -16, -6,
+ax_anim 1, 0, 126, -7, -1, -7, -1,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -3, -4, -3, -4,
+ax_anim 2, 0, 122, -11, -6, -11, -6,
+ax_anim 2, 0, 129, -17, -4, -17, -4,
+ax_anim 3, 0, 128, -22, 1, -22, 1,
+ax_anim 2, 3, 127, -17, 5, -17, 5,
+ax_anim 2, 0, 126, -12, 7, -12, 7,
+ax_anim 1, 0, 125, -4, 5, -4, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 129, -17, 3, -17, 3,
+ax_anim 2, 0, 128, -23, 11, -23, 11,
+ax_anim 3, 0, 127, -20, 20, -20, 20,
+ax_anim 2, 3, 126, -11, 21, -11, 21,
+ax_anim 2, 0, 125, -4, 15, -4, 15,
+ax_anim 1, 0, 124, 0, 7, 0, 7,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 139, 0, -23, 0, 0,
+ax_anim 3, 0, 140, 0, -22, 0, 0,
+ax_anim 2, 0, 140, 0, -18, 0, 0,
+ax_anim 1, 0, 140, 0, -12, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_11_2:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -10, 0, 0,
+ax_anim 2, 0, 142, 0, -16, 0, 0,
+ax_anim 3, 0, 142, 0, -20, 0, 0,
+ax_anim 4, 0, 142, 0, -21, 0, 0,
+ax_anim 4, 0, 142, 0, -23, 0, 0,
+ax_anim 3, 0, 143, 0, -23, 0, 0,
+ax_anim 2, 0, 143, 0, -18, 0, 0,
+ax_anim 1, 0, 143, 0, -12, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_11_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 145, 0, -23, 0, 0,
+ax_anim 3, 0, 146, 0, -23, 0, 0,
+ax_anim 2, 0, 146, 0, -18, 0, 0,
+ax_anim 1, 0, 146, 0, -12, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_11_4:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -22, 0, 0,
+ax_anim 3, 0, 149, 0, -23, 0, 0,
+ax_anim 2, 0, 149, 0, -17, 0, 0,
+ax_anim 1, 0, 149, 0, -11, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 151, 0, -23, 0, 0,
+ax_anim 3, 0, 152, 0, -22, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_11_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 155, 0, -23, 0, 0,
+ax_anim 2, 0, 155, 0, -17, 0, 0,
+ax_anim 1, 0, 155, 0, -11, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_11_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 158, 0, -23, 0, 0,
+ax_anim 2, 0, 158, 0, -18, 0, 0,
+ax_anim 1, 0, 158, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 161, 0, -23, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandshrewAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSandshrewGfx1:
+.incbin "baserom.gba", 0x6384DC, 0x200
+sSandshrewSprites1:
+ax_sprite sSandshrewGfx1, 0x200
+ax_sprite_terminator
+sSandshrewGfx2:
+.incbin "baserom.gba", 0x6386EC, 0x200
+sSandshrewSprites2:
+ax_sprite sSandshrewGfx2, 0x200
+ax_sprite_terminator
+sSandshrewGfx3:
+.incbin "baserom.gba", 0x6388FC, 0x200
+sSandshrewSprites3:
+ax_sprite sSandshrewGfx3, 0x200
+ax_sprite_terminator
+sSandshrewGfx4:
+.incbin "baserom.gba", 0x638B0C, 0x200
+sSandshrewSprites4:
+ax_sprite sSandshrewGfx4, 0x200
+ax_sprite_terminator
+sSandshrewGfx5:
+.incbin "baserom.gba", 0x638D1C, 0x200
+sSandshrewSprites5:
+ax_sprite sSandshrewGfx5, 0x200
+ax_sprite_terminator
+sSandshrewGfx6:
+.incbin "baserom.gba", 0x638F2C, 0x200
+sSandshrewSprites6:
+ax_sprite sSandshrewGfx6, 0x200
+ax_sprite_terminator
+sSandshrewGfx7:
+.incbin "baserom.gba", 0x63913C, 0x200
+sSandshrewSprites7:
+ax_sprite sSandshrewGfx7, 0x200
+ax_sprite_terminator
+sSandshrewGfx8:
+.incbin "baserom.gba", 0x63934C, 0x200
+sSandshrewSprites8:
+ax_sprite sSandshrewGfx8, 0x200
+ax_sprite_terminator
+sSandshrewGfx9:
+.incbin "baserom.gba", 0x63955C, 0x200
+sSandshrewSprites9:
+ax_sprite sSandshrewGfx9, 0x200
+ax_sprite_terminator
+sSandshrewGfx10:
+.incbin "baserom.gba", 0x63976C, 0x200
+sSandshrewSprites10:
+ax_sprite sSandshrewGfx10, 0x200
+ax_sprite_terminator
+sSandshrewGfx11:
+.incbin "baserom.gba", 0x63997C, 0x200
+sSandshrewSprites11:
+ax_sprite sSandshrewGfx11, 0x200
+ax_sprite_terminator
+sSandshrewGfx12:
+.incbin "baserom.gba", 0x639B8C, 0x200
+sSandshrewSprites12:
+ax_sprite sSandshrewGfx12, 0x200
+ax_sprite_terminator
+sSandshrewGfx13:
+.incbin "baserom.gba", 0x639D9C, 0x200
+sSandshrewSprites13:
+ax_sprite sSandshrewGfx13, 0x200
+ax_sprite_terminator
+sSandshrewGfx14:
+.incbin "baserom.gba", 0x639FAC, 0x200
+sSandshrewSprites14:
+ax_sprite sSandshrewGfx14, 0x200
+ax_sprite_terminator
+sSandshrewGfx15:
+.incbin "baserom.gba", 0x63A1BC, 0x200
+sSandshrewSprites15:
+ax_sprite sSandshrewGfx15, 0x200
+ax_sprite_terminator
+sSandshrewGfx16:
+.incbin "baserom.gba", 0x63A3CC, 0x40
+sSandshrewGfx16_1:
+.incbin "baserom.gba", 0x63A40C, 0xE0
+sSandshrewSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx16_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSandshrewGfx17:
+.incbin "baserom.gba", 0x63A51C, 0xC0
+sSandshrewSprites17:
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx17, 0xc0
+ax_sprite_terminator
+sSandshrewGfx18:
+.incbin "baserom.gba", 0x63A5F4, 0x40
+sSandshrewGfx18_1:
+.incbin "baserom.gba", 0x63A634, 0x60
+sSandshrewGfx18_2:
+.incbin "baserom.gba", 0x63A694, 0x60
+sSandshrewSprites18:
+ax_sprite sSandshrewGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSandshrewGfx19:
+.incbin "baserom.gba", 0x63A72C, 0xC0
+sSandshrewSprites19:
+ax_sprite sSandshrewGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSandshrewGfx20:
+.incbin "baserom.gba", 0x63A804, 0x40
+sSandshrewGfx20_1:
+.incbin "baserom.gba", 0x63A844, 0x60
+sSandshrewGfx20_2:
+.incbin "baserom.gba", 0x63A8A4, 0x60
+sSandshrewSprites20:
+ax_sprite sSandshrewGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSandshrewGfx21:
+.incbin "baserom.gba", 0x63A93C, 0xC0
+sSandshrewSprites21:
+ax_sprite sSandshrewGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSandshrewGfx22:
+.incbin "baserom.gba", 0x63AA14, 0x40
+sSandshrewGfx22_1:
+.incbin "baserom.gba", 0x63AA54, 0x60
+sSandshrewGfx22_2:
+.incbin "baserom.gba", 0x63AAB4, 0x60
+sSandshrewSprites22:
+ax_sprite sSandshrewGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSandshrewGfx23:
+.incbin "baserom.gba", 0x63AB4C, 0xC0
+sSandshrewSprites23:
+ax_sprite sSandshrewGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSandshrewGfx24:
+.incbin "baserom.gba", 0x63AC24, 0x40
+sSandshrewGfx24_1:
+.incbin "baserom.gba", 0x63AC64, 0x60
+sSandshrewGfx24_2:
+.incbin "baserom.gba", 0x63ACC4, 0x60
+sSandshrewSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSandshrewGfx25:
+.incbin "baserom.gba", 0x63AD64, 0xC0
+sSandshrewSprites25:
+ax_sprite sSandshrewGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSandshrewGfx26:
+.incbin "baserom.gba", 0x63AE3C, 0x60
+sSandshrewGfx26_1:
+.incbin "baserom.gba", 0x63AE9C, 0x60
+sSandshrewGfx26_2:
+.incbin "baserom.gba", 0x63AEFC, 0x80
+sSandshrewSprites26:
+ax_sprite sSandshrewGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx26_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSandshrewGfx27:
+.incbin "baserom.gba", 0x63AFB4, 0x20
+sSandshrewGfx27_1:
+.incbin "baserom.gba", 0x63AFD4, 0x40
+sSandshrewGfx27_2:
+.incbin "baserom.gba", 0x63B014, 0x60
+sSandshrewGfx27_3:
+.incbin "baserom.gba", 0x63B074, 0x40
+sSandshrewSprites27:
+ax_sprite sSandshrewGfx27, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSandshrewGfx27_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandshrewGfx28:
+.incbin "baserom.gba", 0x63B0FC, 0x60
+sSandshrewGfx28_1:
+.incbin "baserom.gba", 0x63B15C, 0x60
+sSandshrewGfx28_2:
+.incbin "baserom.gba", 0x63B1BC, 0x80
+sSandshrewSprites28:
+ax_sprite sSandshrewGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx28_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSandshrewGfx29:
+.incbin "baserom.gba", 0x63B274, 0x40
+sSandshrewGfx29_1:
+.incbin "baserom.gba", 0x63B2B4, 0x20
+sSandshrewGfx29_2:
+.incbin "baserom.gba", 0x63B2D4, 0x40
+sSandshrewGfx29_3:
+.incbin "baserom.gba", 0x63B314, 0x40
+sSandshrewSprites29:
+ax_sprite sSandshrewGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx29_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSandshrewGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx29_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSandshrewGfx30:
+.incbin "baserom.gba", 0x63B39C, 0x180
+sSandshrewSprites30:
+ax_sprite sSandshrewGfx30, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSandshrewGfx31:
+.incbin "baserom.gba", 0x63B534, 0x120
+sSandshrewGfx31_1:
+.incbin "baserom.gba", 0x63B654, 0x40
+sSandshrewSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx31, 0x120
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSandshrewGfx32:
+.incbin "baserom.gba", 0x63B6C4, 0x60
+sSandshrewGfx32_1:
+.incbin "baserom.gba", 0x63B724, 0x60
+sSandshrewGfx32_2:
+.incbin "baserom.gba", 0x63B784, 0x60
+sSandshrewSprites32:
+ax_sprite sSandshrewGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSandshrewGfx33:
+.incbin "baserom.gba", 0x63B81C, 0x60
+sSandshrewGfx33_1:
+.incbin "baserom.gba", 0x63B87C, 0x60
+sSandshrewGfx33_2:
+.incbin "baserom.gba", 0x63B8DC, 0x20
+sSandshrewSprites33:
+ax_sprite sSandshrewGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx33_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSandshrewGfx34:
+.incbin "baserom.gba", 0x63B934, 0x40
+sSandshrewGfx34_1:
+.incbin "baserom.gba", 0x63B974, 0x60
+sSandshrewGfx34_2:
+.incbin "baserom.gba", 0x63B9D4, 0x60
+sSandshrewSprites34:
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandshrewGfx34_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSandshrewGfx35:
+.incbin "baserom.gba", 0x63BA74, 0x40
+sSandshrewGfx35_1:
+.incbin "baserom.gba", 0x63BAB4, 0x40
+sSandshrewGfx35_2:
+.incbin "baserom.gba", 0x63BAF4, 0x20
+sSandshrewSprites35:
+ax_sprite sSandshrewGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandshrewGfx35_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sSandshrewGfx36:
+.incbin "baserom.gba", 0x63BB4C, 0x200
+sSandshrewSprites36:
+ax_sprite sSandshrewGfx36, 0x200
+ax_sprite_terminator
+sSandshrewGfx37:
+.incbin "baserom.gba", 0x63BD5C, 0x200
+sSandshrewSprites37:
+ax_sprite sSandshrewGfx37, 0x200
+ax_sprite_terminator
+sSandshrewGfx38:
+.incbin "baserom.gba", 0x63BF6C, 0x40
+sSandshrewSprites38:
+ax_sprite sSandshrewGfx38, 0x40
+ax_sprite_terminator
+sSandshrewGfx39:
+.incbin "baserom.gba", 0x63BFBC, 0x80
+sSandshrewSprites39:
+ax_sprite sSandshrewGfx39, 0x80
+ax_sprite_terminator
+sSandshrewGfx40:
+.incbin "baserom.gba", 0x63C04C, 0x80
+sSandshrewSprites40:
+ax_sprite sSandshrewGfx40, 0x80
+ax_sprite_terminator
+sSandshrewGfx41:
+.incbin "baserom.gba", 0x63C0DC, 0x80
+sSandshrewSprites41:
+ax_sprite sSandshrewGfx41, 0x80
+ax_sprite_terminator
+sSandshrewGfx42:
+.incbin "baserom.gba", 0x63C16C, 0x80
+sSandshrewSprites42:
+ax_sprite sSandshrewGfx42, 0x80
+ax_sprite_terminator
+sAxPosesSandshrew:
+.4byte sSandshrewPose1
+.4byte sSandshrewPose2
+.4byte sSandshrewPose3
+.4byte sSandshrewPose4
+.4byte sSandshrewPose5
+.4byte sSandshrewPose6
+.4byte sSandshrewPose7
+.4byte sSandshrewPose8
+.4byte sSandshrewPose9
+.4byte sSandshrewPose10
+.4byte sSandshrewPose11
+.4byte sSandshrewPose12
+.4byte sSandshrewPose13
+.4byte sSandshrewPose14
+.4byte sSandshrewPose15
+.4byte sSandshrewPose16
+.4byte sSandshrewPose17
+.4byte sSandshrewPose18
+.4byte sSandshrewPose19
+.4byte sSandshrewPose20
+.4byte sSandshrewPose21
+.4byte sSandshrewPose22
+.4byte sSandshrewPose23
+.4byte sSandshrewPose24
+.4byte sSandshrewPose25
+.4byte sSandshrewPose26
+.4byte sSandshrewPose27
+.4byte sSandshrewPose28
+.4byte sSandshrewPose29
+.4byte sSandshrewPose30
+.4byte sSandshrewPose31
+.4byte sSandshrewPose32
+.4byte sSandshrewPose33
+.4byte sSandshrewPose34
+.4byte sSandshrewPose35
+.4byte sSandshrewPose36
+.4byte sSandshrewPose37
+.4byte sSandshrewPose38
+.4byte sSandshrewPose39
+.4byte sSandshrewPose40
+.4byte sSandshrewPose41
+.4byte sSandshrewPose42
+.4byte sSandshrewPose43
+.4byte sSandshrewPose44
+.4byte sSandshrewPose45
+.4byte sSandshrewPose46
+.4byte sSandshrewPose47
+.4byte sSandshrewPose48
+.4byte sSandshrewPose49
+.4byte sSandshrewPose50
+.4byte sSandshrewPose51
+.4byte sSandshrewPose52
+.4byte sSandshrewPose53
+.4byte sSandshrewPose54
+.4byte sSandshrewPose55
+.4byte sSandshrewPose56
+.4byte sSandshrewPose57
+.4byte sSandshrewPose58
+.4byte sSandshrewPose59
+.4byte sSandshrewPose60
+.4byte sSandshrewPose61
+.4byte sSandshrewPose62
+.4byte sSandshrewPose63
+.4byte sSandshrewPose64
+.4byte sSandshrewPose65
+.4byte sSandshrewPose66
+.4byte sSandshrewPose67
+.4byte sSandshrewPose68
+.4byte sSandshrewPose69
+.4byte sSandshrewPose70
+.4byte sSandshrewPose71
+.4byte sSandshrewPose72
+.4byte sSandshrewPose73
+.4byte sSandshrewPose74
+.4byte sSandshrewPose75
+.4byte sSandshrewPose76
+.4byte sSandshrewPose77
+.4byte sSandshrewPose78
+.4byte sSandshrewPose79
+.4byte sSandshrewPose80
+.4byte sSandshrewPose81
+.4byte sSandshrewPose82
+.4byte sSandshrewPose83
+.4byte sSandshrewPose84
+.4byte sSandshrewPose85
+.4byte sSandshrewPose86
+.4byte sSandshrewPose87
+.4byte sSandshrewPose88
+.4byte sSandshrewPose89
+.4byte sSandshrewPose90
+.4byte sSandshrewPose91
+.4byte sSandshrewPose92
+.4byte sSandshrewPose93
+.4byte sSandshrewPose94
+.4byte sSandshrewPose95
+.4byte sSandshrewPose96
+.4byte sSandshrewPose97
+.4byte sSandshrewPose98
+.4byte sSandshrewPose99
+.4byte sSandshrewPose100
+.4byte sSandshrewPose101
+.4byte sSandshrewPose102
+.4byte sSandshrewPose103
+.4byte sSandshrewPose104
+.4byte sSandshrewPose105
+.4byte sSandshrewPose106
+.4byte sSandshrewPose107
+.4byte sSandshrewPose108
+.4byte sSandshrewPose109
+.4byte sSandshrewPose110
+.4byte sSandshrewPose111
+.4byte sSandshrewPose112
+.4byte sSandshrewPose113
+.4byte sSandshrewPose114
+.4byte sSandshrewPose115
+.4byte sSandshrewPose116
+.4byte sSandshrewPose117
+.4byte sSandshrewPose118
+.4byte sSandshrewPose119
+.4byte sSandshrewPose120
+.4byte sSandshrewPose121
+.4byte sSandshrewPose122
+.4byte sSandshrewPose123
+.4byte sSandshrewPose124
+.4byte sSandshrewPose125
+.4byte sSandshrewPose126
+.4byte sSandshrewPose127
+.4byte sSandshrewPose128
+.4byte sSandshrewPose129
+.4byte sSandshrewPose130
+.4byte sSandshrewPose131
+.4byte sSandshrewPose132
+.4byte sSandshrewPose133
+.4byte sSandshrewPose134
+.4byte sSandshrewPose135
+.4byte sSandshrewPose136
+.4byte sSandshrewPose137
+.4byte sSandshrewPose138
+.4byte sSandshrewPose139
+.4byte sSandshrewPose140
+.4byte sSandshrewPose141
+.4byte sSandshrewPose142
+.4byte sSandshrewPose143
+.4byte sSandshrewPose144
+.4byte sSandshrewPose145
+.4byte sSandshrewPose146
+.4byte sSandshrewPose147
+.4byte sSandshrewPose148
+.4byte sSandshrewPose149
+.4byte sSandshrewPose150
+.4byte sSandshrewPose151
+.4byte sSandshrewPose152
+.4byte sSandshrewPose153
+.4byte sSandshrewPose154
+.4byte sSandshrewPose155
+.4byte sSandshrewPose156
+.4byte sSandshrewPose157
+.4byte sSandshrewPose158
+.4byte sSandshrewPose159
+.4byte sSandshrewPose160
+.4byte sSandshrewPose161
+.4byte sSandshrewPose162
+.4byte sSandshrewPose163
+.4byte sSandshrewPose164
+.4byte sSandshrewPose165
+.4byte sSandshrewPose166
+.4byte sSandshrewPose167
+.4byte sSandshrewPose168
+.4byte sSandshrewPose169
+.4byte sSandshrewPose170
+.4byte sSandshrewPose171
+.4byte sSandshrewPose172
+.4byte sSandshrewPose173
+.4byte sSandshrewPose174
+.4byte sSandshrewPose175
+.4byte sSandshrewPose176
+.4byte sSandshrewPose177
+.4byte sSandshrewPose178
+sAxPositionsSandshrew:
+.2byte   -1,   -6, 	  -4,   -6, 	   2,   -6, 	  -1,   -8
+.2byte   -1,   -5, 	  -3,   -4, 	   3,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -5, 	   1,   -4, 	  -1,   -7
+.2byte    3,   -6, 	   5,   -7, 	  -1,   -5, 	  -2,   -8
+.2byte    3,   -5, 	   4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte    3,   -5, 	   5,   -6, 	   0,   -4, 	  -2,   -7
+.2byte    5,   -7, 	   2,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    5,   -6, 	   0,   -6, 	   1,   -5, 	  -2,   -8
+.2byte    5,   -6, 	   4,   -6, 	   3,   -5, 	  -2,   -9
+.2byte    3,  -11, 	  -2,  -10, 	   5,   -7, 	  -1,  -10
+.2byte    3,  -10, 	  -3,   -8, 	   4,   -6, 	  -1,   -9
+.2byte    3,  -10, 	   0,   -9, 	   6,   -7, 	  -1,   -9
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -12, 	   4,   -9, 	  -7,   -8, 	  -1,   -9
+.2byte   -1,  -12, 	   5,   -7, 	  -6,   -9, 	  -1,   -9
+.2byte   -5,  -11, 	   0,  -10, 	  -7,   -7, 	  -1,  -10
+.2byte   -5,  -10, 	   1,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte   -5,  -10, 	  -2,   -9, 	  -8,   -7, 	  -1,   -9
+.2byte   -7,   -7, 	  -4,   -7, 	  -4,   -6, 	  -1,   -9
+.2byte   -7,   -6, 	  -2,   -6, 	  -3,   -5, 	   0,   -8
+.2byte   -7,   -6, 	  -6,   -6, 	  -5,   -5, 	   0,   -9
+.2byte   -5,   -6, 	  -7,   -7, 	  -1,   -5, 	   0,   -8
+.2byte   -5,   -5, 	  -6,   -5, 	   0,   -4, 	   0,   -7
+.2byte   -5,   -5, 	  -7,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    0,   -3, 	  -1,   -1, 	   8,   -8, 	   0,   -6
+.2byte   -1,   -5, 	  -3,   -4, 	   3,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -5, 	   1,   -4, 	  -1,   -7
+.2byte   -1,   -4, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte    3,   -4, 	   3,   -1, 	  -8,   -9, 	   0,   -7
+.2byte    3,   -5, 	   4,   -5, 	  -2,   -4, 	  -2,   -7
+.2byte    3,   -5, 	   5,   -6, 	   0,   -4, 	  -2,   -7
+.2byte    0,   -4, 	   1,   -9, 	  -4,   -5, 	  -1,   -6
+.2byte    5,   -4, 	  -8,  -11, 	   4,   -3, 	  -2,   -7
+.2byte    5,   -6, 	   0,   -6, 	   1,   -5, 	  -2,   -8
+.2byte    5,   -6, 	   4,   -6, 	   3,   -5, 	  -2,   -9
+.2byte    0,   -4, 	  -2,   -7, 	  -2,   -4, 	  -1,   -7
+.2byte    2,   -8, 	  -7,  -10, 	   5,   -5, 	  -2,   -7
+.2byte    3,  -10, 	  -3,   -8, 	   4,   -6, 	  -1,   -9
+.2byte    3,  -10, 	   0,   -9, 	   6,   -7, 	  -1,   -9
+.2byte    0,   -4, 	  -5,   -8, 	   3,   -5, 	  -1,   -6
+.2byte    1,   -7, 	   5,   -5, 	  -2,   -5, 	   0,   -7
+.2byte   -1,  -12, 	   4,   -9, 	  -7,   -8, 	  -1,   -9
+.2byte   -1,  -12, 	   5,   -7, 	  -6,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte   -3,   -8, 	   6,  -10, 	  -6,   -5, 	   1,   -7
+.2byte   -5,  -10, 	   1,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte   -5,  -10, 	  -2,   -9, 	  -8,   -7, 	  -1,   -9
+.2byte   -1,   -4, 	   4,   -8, 	  -4,   -5, 	   0,   -6
+.2byte   -6,   -4, 	   7,  -11, 	  -5,   -3, 	   1,   -7
+.2byte   -7,   -6, 	  -2,   -6, 	  -3,   -5, 	   0,   -8
+.2byte   -7,   -6, 	  -6,   -6, 	  -5,   -5, 	   0,   -9
+.2byte   -1,   -4, 	   1,   -7, 	   1,   -4, 	   0,   -7
+.2byte   -4,   -2, 	  -4,    1, 	   7,   -7, 	  -1,   -5
+.2byte   -5,   -5, 	  -6,   -5, 	   0,   -4, 	   0,   -7
+.2byte   -5,   -5, 	  -7,   -6, 	  -2,   -4, 	   0,   -7
+.2byte   -1,   -4, 	  -2,   -9, 	   3,   -5, 	   0,   -6
+.2byte   -1,   -6, 	  -4,   -6, 	   2,   -6, 	  -1,   -8
+.2byte   -3,   -6, 	  -9,  -14, 	   1,   -8, 	  -1,   -6
+.2byte    0,   -2, 	  -1,    0, 	   8,   -7, 	   0,   -5
+.2byte    0,   -2, 	  -1,    0, 	   8,   -7, 	   0,   -5
+.2byte    3,   -6, 	   5,   -7, 	  -1,   -5, 	  -2,   -8
+.2byte    2,   -7, 	   3,  -16, 	  -2,   -8, 	  -2,   -6
+.2byte    2,   -2, 	   2,    1, 	  -9,   -7, 	  -1,   -5
+.2byte    2,   -2, 	   2,    1, 	  -9,   -7, 	  -1,   -5
+.2byte    5,   -7, 	   2,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    2,   -9, 	   8,  -12, 	  -8,  -14, 	  -1,   -8
+.2byte    5,   -4, 	  -8,  -11, 	   4,   -3, 	  -2,   -7
+.2byte    5,   -4, 	  -8,  -11, 	   4,   -3, 	  -2,   -7
+.2byte    3,  -11, 	  -2,  -10, 	   5,   -7, 	  -1,  -10
+.2byte    2,   -8, 	   4,  -16, 	  -6,  -14, 	  -2,   -9
+.2byte    2,   -8, 	  -7,  -10, 	   5,   -5, 	  -2,   -7
+.2byte    2,   -8, 	  -7,  -10, 	   5,   -5, 	  -2,   -7
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	   1,   -7, 	  -5,  -16, 	   0,   -8
+.2byte    1,   -9, 	   5,   -7, 	  -2,   -7, 	   0,   -9
+.2byte    1,   -9, 	   5,   -7, 	  -2,   -7, 	   0,   -9
+.2byte   -4,  -11, 	   1,  -10, 	  -6,   -7, 	   0,  -10
+.2byte   -3,   -8, 	  -5,  -16, 	   5,  -14, 	   1,   -9
+.2byte   -3,   -8, 	   6,  -10, 	  -6,   -5, 	   1,   -7
+.2byte   -3,   -8, 	   6,  -10, 	  -6,   -5, 	   1,   -7
+.2byte   -6,   -7, 	  -3,   -7, 	  -3,   -6, 	   0,   -9
+.2byte   -3,   -9, 	  -9,  -12, 	   7,  -14, 	   0,   -8
+.2byte   -6,   -4, 	   7,  -11, 	  -5,   -3, 	   1,   -7
+.2byte   -6,   -4, 	   7,  -11, 	  -5,   -3, 	   1,   -7
+.2byte   -4,   -6, 	  -6,   -7, 	   0,   -5, 	   1,   -8
+.2byte   -3,   -7, 	  -4,  -16, 	   1,   -8, 	   1,   -6
+.2byte   -3,   -2, 	  -3,    1, 	   8,   -7, 	   0,   -5
+.2byte   -3,   -2, 	  -3,    1, 	   8,   -7, 	   0,   -5
+.2byte    0,   -3, 	  -1,   -1, 	   8,   -8, 	   0,   -6
+.2byte   -4,   -2, 	  -4,    1, 	   7,   -7, 	  -1,   -5
+.2byte   -6,   -4, 	   7,  -11, 	  -5,   -3, 	   1,   -7
+.2byte   -3,   -8, 	   6,  -10, 	  -6,   -5, 	   1,   -7
+.2byte    1,   -7, 	   5,   -5, 	  -2,   -5, 	   0,   -7
+.2byte    2,   -8, 	  -7,  -10, 	   5,   -5, 	  -2,   -7
+.2byte    5,   -4, 	  -8,  -11, 	   4,   -3, 	  -2,   -7
+.2byte    3,   -4, 	   3,   -1, 	  -8,   -9, 	   0,   -7
+.2byte   -1,   -4, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte    0,   -4, 	   1,   -9, 	  -4,   -5, 	  -1,   -6
+.2byte    0,   -4, 	  -2,   -7, 	  -2,   -4, 	  -1,   -7
+.2byte    0,   -4, 	  -5,   -8, 	   3,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte   -1,   -4, 	   4,   -8, 	  -4,   -5, 	   0,   -6
+.2byte   -1,   -4, 	   1,   -7, 	   1,   -4, 	   0,   -7
+.2byte   -1,   -4, 	  -2,   -9, 	   3,   -5, 	   0,   -6
+.2byte   -4,   -5, 	  -7,   -5, 	  -1,   -3, 	   1,   -7
+.2byte   -4,   -4, 	  -7,   -5, 	  -1,   -3, 	   1,   -7
+.2byte   -1,   -4, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte    0,   -4, 	   1,   -9, 	  -4,   -5, 	  -1,   -6
+.2byte   -1,   -4, 	  -3,   -7, 	  -3,   -4, 	  -2,   -7
+.2byte   -1,   -4, 	  -6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte   -1,   -5, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte    0,   -4, 	   5,   -8, 	  -3,   -5, 	   1,   -6
+.2byte    0,   -4, 	   2,   -7, 	   2,   -4, 	   1,   -7
+.2byte   -1,   -4, 	  -2,   -9, 	   3,   -5, 	   0,   -6
+.2byte   -1,   -6, 	  -4,   -6, 	   2,   -6, 	  -1,   -8
+.2byte   -5,   -6, 	  -7,   -7, 	  -1,   -5, 	   0,   -8
+.2byte   -7,   -7, 	  -4,   -7, 	  -4,   -6, 	  -1,   -9
+.2byte   -5,  -11, 	   0,  -10, 	  -7,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    3,  -11, 	  -2,  -10, 	   5,   -7, 	  -1,  -10
+.2byte    5,   -7, 	   2,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    3,   -6, 	   5,   -7, 	  -1,   -5, 	  -2,   -8
+.2byte   -1,   -4, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,   -4, 	  -2,   -9, 	   3,   -5, 	   0,   -6
+.2byte   -1,   -4, 	   1,   -7, 	   1,   -4, 	   0,   -7
+.2byte   -1,   -4, 	   4,   -8, 	  -4,   -5, 	   0,   -6
+.2byte   -1,   -5, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte    0,   -4, 	  -5,   -8, 	   3,   -5, 	  -1,   -6
+.2byte    0,   -4, 	  -2,   -7, 	  -2,   -4, 	  -1,   -7
+.2byte    0,   -4, 	   1,   -9, 	  -4,   -5, 	  -1,   -6
+.2byte    0,   -3, 	  -1,   -1, 	   8,   -8, 	   0,   -6
+.2byte    3,   -4, 	   3,   -1, 	  -8,   -9, 	   0,   -7
+.2byte    5,   -4, 	  -8,  -11, 	   4,   -3, 	  -2,   -7
+.2byte    2,   -8, 	  -7,  -10, 	   5,   -5, 	  -2,   -7
+.2byte    1,   -7, 	   5,   -5, 	  -2,   -5, 	   0,   -7
+.2byte   -3,   -8, 	   6,  -10, 	  -6,   -5, 	   1,   -7
+.2byte   -6,   -4, 	   7,  -11, 	  -5,   -3, 	   1,   -7
+.2byte   -4,   -2, 	  -4,    1, 	   7,   -7, 	  -1,   -5
+.2byte   -1,   -6, 	  -4,   -6, 	   2,   -6, 	  -1,   -8
+.2byte   -3,   -6, 	  -9,  -14, 	   1,   -8, 	  -1,   -6
+.2byte   -1,   -4, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte    3,   -6, 	   5,   -7, 	  -1,   -5, 	  -2,   -8
+.2byte    2,   -7, 	   3,  -16, 	  -2,   -8, 	  -2,   -6
+.2byte   -1,   -4, 	   0,   -9, 	  -5,   -5, 	  -2,   -6
+.2byte    5,   -7, 	   2,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    2,   -9, 	   8,  -12, 	  -8,  -14, 	  -1,   -8
+.2byte    0,   -4, 	  -2,   -7, 	  -2,   -4, 	  -1,   -7
+.2byte    3,  -11, 	  -2,  -10, 	   5,   -7, 	  -1,  -10
+.2byte    2,   -8, 	   4,  -16, 	  -6,  -14, 	  -2,   -9
+.2byte   -1,   -4, 	  -6,   -8, 	   2,   -5, 	  -2,   -6
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte   -1,  -11, 	   1,   -7, 	  -5,  -16, 	   0,   -8
+.2byte   -1,   -5, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte   -4,  -11, 	   1,  -10, 	  -6,   -7, 	   0,  -10
+.2byte   -3,   -8, 	  -5,  -16, 	   5,  -14, 	   1,   -9
+.2byte    0,   -4, 	   5,   -8, 	  -3,   -5, 	   1,   -6
+.2byte   -6,   -7, 	  -3,   -7, 	  -3,   -6, 	   0,   -9
+.2byte   -3,   -9, 	  -9,  -12, 	   7,  -14, 	   0,   -8
+.2byte   -1,   -4, 	   1,   -7, 	   1,   -4, 	   0,   -7
+.2byte   -4,   -6, 	  -6,   -7, 	   0,   -5, 	   1,   -8
+.2byte   -3,   -7, 	  -4,  -16, 	   1,   -8, 	   1,   -6
+.2byte    0,   -4, 	  -1,   -9, 	   4,   -5, 	   1,   -6
+.2byte    0,   -3, 	  -1,   -1, 	   8,   -8, 	   0,   -6
+.2byte   -4,   -2, 	  -4,    1, 	   7,   -7, 	  -1,   -5
+.2byte   -6,   -4, 	   7,  -11, 	  -5,   -3, 	   1,   -7
+.2byte   -3,   -8, 	   6,  -10, 	  -6,   -5, 	   1,   -7
+.2byte    1,   -7, 	   5,   -5, 	  -2,   -5, 	   0,   -7
+.2byte    2,   -8, 	  -7,  -10, 	   5,   -5, 	  -2,   -7
+.2byte    5,   -4, 	  -8,  -11, 	   4,   -3, 	  -2,   -7
+.2byte    3,   -4, 	   3,   -1, 	  -8,   -9, 	   0,   -7
+.2byte   -1,   -6, 	  -4,   -6, 	   2,   -6, 	  -1,   -8
+.2byte   -5,   -6, 	  -7,   -7, 	  -1,   -5, 	   0,   -8
+.2byte   -7,   -7, 	  -4,   -7, 	  -4,   -6, 	  -1,   -9
+.2byte   -5,  -11, 	   0,  -10, 	  -7,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -8, 	  -6,   -8, 	  -1,  -10
+.2byte    3,  -11, 	  -2,  -10, 	   5,   -7, 	  -1,  -10
+.2byte    5,   -7, 	   2,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    3,   -6, 	   5,   -7, 	  -1,   -5, 	  -2,   -8
+sSandshrewAnimTable1:
+.4byte sSandshrewAnims_1_1
+.4byte sSandshrewAnims_1_2
+.4byte sSandshrewAnims_1_3
+.4byte sSandshrewAnims_1_4
+.4byte sSandshrewAnims_1_5
+.4byte sSandshrewAnims_1_6
+.4byte sSandshrewAnims_1_7
+.4byte sSandshrewAnims_1_8
+sSandshrewAnimTable2:
+.4byte sSandshrewAnims_2_1
+.4byte sSandshrewAnims_2_2
+.4byte sSandshrewAnims_2_3
+.4byte sSandshrewAnims_2_4
+.4byte sSandshrewAnims_2_5
+.4byte sSandshrewAnims_2_6
+.4byte sSandshrewAnims_2_7
+.4byte sSandshrewAnims_2_8
+sSandshrewAnimTable3:
+.4byte sSandshrewAnims_3_1
+.4byte sSandshrewAnims_3_2
+.4byte sSandshrewAnims_3_3
+.4byte sSandshrewAnims_3_4
+.4byte sSandshrewAnims_3_5
+.4byte sSandshrewAnims_3_6
+.4byte sSandshrewAnims_3_7
+.4byte sSandshrewAnims_3_8
+sSandshrewAnimTable4:
+.4byte sSandshrewAnims_4_1
+.4byte sSandshrewAnims_4_2
+.4byte sSandshrewAnims_4_3
+.4byte sSandshrewAnims_4_4
+.4byte sSandshrewAnims_4_5
+.4byte sSandshrewAnims_4_6
+.4byte sSandshrewAnims_4_7
+.4byte sSandshrewAnims_4_8
+sSandshrewAnimTable5:
+.4byte sSandshrewAnims_5_1
+.4byte sSandshrewAnims_5_2
+.4byte sSandshrewAnims_5_3
+.4byte sSandshrewAnims_5_4
+.4byte sSandshrewAnims_5_5
+.4byte sSandshrewAnims_5_6
+.4byte sSandshrewAnims_5_7
+.4byte sSandshrewAnims_5_8
+sSandshrewAnimTable6:
+.4byte sSandshrewAnims_6_1
+.4byte sSandshrewAnims_6_1
+.4byte sSandshrewAnims_6_1
+.4byte sSandshrewAnims_6_1
+.4byte sSandshrewAnims_6_1
+.4byte sSandshrewAnims_6_1
+.4byte sSandshrewAnims_6_1
+.4byte sSandshrewAnims_6_1
+sSandshrewAnimTable7:
+.4byte sSandshrewAnims_7_1
+.4byte sSandshrewAnims_7_2
+.4byte sSandshrewAnims_7_3
+.4byte sSandshrewAnims_7_4
+.4byte sSandshrewAnims_7_5
+.4byte sSandshrewAnims_7_6
+.4byte sSandshrewAnims_7_7
+.4byte sSandshrewAnims_7_8
+sSandshrewAnimTable8:
+.4byte sSandshrewAnims_8_1
+.4byte sSandshrewAnims_8_2
+.4byte sSandshrewAnims_8_3
+.4byte sSandshrewAnims_8_4
+.4byte sSandshrewAnims_8_5
+.4byte sSandshrewAnims_8_6
+.4byte sSandshrewAnims_8_7
+.4byte sSandshrewAnims_8_8
+sSandshrewAnimTable9:
+.4byte sSandshrewAnims_9_1
+.4byte sSandshrewAnims_9_2
+.4byte sSandshrewAnims_9_3
+.4byte sSandshrewAnims_9_4
+.4byte sSandshrewAnims_9_5
+.4byte sSandshrewAnims_9_6
+.4byte sSandshrewAnims_9_7
+.4byte sSandshrewAnims_9_8
+sSandshrewAnimTable10:
+.4byte sSandshrewAnims_10_1
+.4byte sSandshrewAnims_10_2
+.4byte sSandshrewAnims_10_3
+.4byte sSandshrewAnims_10_4
+.4byte sSandshrewAnims_10_5
+.4byte sSandshrewAnims_10_6
+.4byte sSandshrewAnims_10_7
+.4byte sSandshrewAnims_10_8
+sSandshrewAnimTable11:
+.4byte sSandshrewAnims_11_1
+.4byte sSandshrewAnims_11_2
+.4byte sSandshrewAnims_11_3
+.4byte sSandshrewAnims_11_4
+.4byte sSandshrewAnims_11_5
+.4byte sSandshrewAnims_11_6
+.4byte sSandshrewAnims_11_7
+.4byte sSandshrewAnims_11_8
+sSandshrewAnimTable12:
+.4byte sSandshrewAnims_12_1
+.4byte sSandshrewAnims_12_2
+.4byte sSandshrewAnims_12_3
+.4byte sSandshrewAnims_12_4
+.4byte sSandshrewAnims_12_5
+.4byte sSandshrewAnims_12_6
+.4byte sSandshrewAnims_12_7
+.4byte sSandshrewAnims_12_8
+sSandshrewAnimTable13:
+.4byte sSandshrewAnims_13_1
+.4byte sSandshrewAnims_13_2
+.4byte sSandshrewAnims_13_3
+.4byte sSandshrewAnims_13_4
+.4byte sSandshrewAnims_13_5
+.4byte sSandshrewAnims_13_6
+.4byte sSandshrewAnims_13_7
+.4byte sSandshrewAnims_13_8
+sAxAnimationsSandshrew:
+.4byte sSandshrewAnimTable1
+.4byte sSandshrewAnimTable2
+.4byte sSandshrewAnimTable3
+.4byte sSandshrewAnimTable4
+.4byte sSandshrewAnimTable5
+.4byte sSandshrewAnimTable6
+.4byte sSandshrewAnimTable7
+.4byte sSandshrewAnimTable8
+.4byte sSandshrewAnimTable9
+.4byte sSandshrewAnimTable10
+.4byte sSandshrewAnimTable11
+.4byte sSandshrewAnimTable12
+.4byte sSandshrewAnimTable13
+sAxSpritesSandshrew:
+.4byte sSandshrewSprites1
+.4byte sSandshrewSprites2
+.4byte sSandshrewSprites3
+.4byte sSandshrewSprites4
+.4byte sSandshrewSprites5
+.4byte sSandshrewSprites6
+.4byte sSandshrewSprites7
+.4byte sSandshrewSprites8
+.4byte sSandshrewSprites9
+.4byte sSandshrewSprites10
+.4byte sSandshrewSprites11
+.4byte sSandshrewSprites12
+.4byte sSandshrewSprites13
+.4byte sSandshrewSprites14
+.4byte sSandshrewSprites15
+.4byte sSandshrewSprites16
+.4byte sSandshrewSprites17
+.4byte sSandshrewSprites18
+.4byte sSandshrewSprites19
+.4byte sSandshrewSprites20
+.4byte sSandshrewSprites21
+.4byte sSandshrewSprites22
+.4byte sSandshrewSprites23
+.4byte sSandshrewSprites24
+.4byte sSandshrewSprites25
+.4byte sSandshrewSprites26
+.4byte sSandshrewSprites27
+.4byte sSandshrewSprites28
+.4byte sSandshrewSprites29
+.4byte sSandshrewSprites30
+.4byte sSandshrewSprites31
+.4byte sSandshrewSprites32
+.4byte sSandshrewSprites33
+.4byte sSandshrewSprites34
+.4byte sSandshrewSprites35
+.4byte sSandshrewSprites36
+.4byte sSandshrewSprites37
+.4byte sSandshrewSprites38
+.4byte sSandshrewSprites39
+.4byte sSandshrewSprites40
+.4byte sSandshrewSprites41
+.4byte sSandshrewSprites42
+sAxMainSandshrew:
+ax_main sAxPosesSandshrew, sAxAnimationsSandshrew, 13, sAxSpritesSandshrew, sAxPositionsSandshrew

--- a/data/ax/sandslash.inc
+++ b/data/ax/sandslash.inc
@@ -1,0 +1,2617 @@
+.global gAxSandslash
+gAxSandslash:
+ax_siro sAxMainSandslash
+sSandslashPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose4:
+ax_pose 3, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose5:
+ax_pose 4, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose6:
+ax_pose 5, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose8:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose9:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose10:
+ax_pose 9, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose11:
+ax_pose 10, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose12:
+ax_pose 11, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose13:
+ax_pose 12, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose14:
+ax_pose 13, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose15:
+ax_pose 14, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose16:
+ax_pose 9, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose17:
+ax_pose 10, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose18:
+ax_pose 11, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose22:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose23:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose24:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose26:
+ax_pose 1, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose27:
+ax_pose 2, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose28:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose29:
+ax_pose 3, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose30:
+ax_pose 4, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose31:
+ax_pose 5, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose32:
+ax_pose 16, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose33:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose34:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose35:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose36:
+ax_pose 17, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sSandslashPose37:
+ax_pose 9, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose38:
+ax_pose 10, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose39:
+ax_pose 11, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose40:
+ax_pose 18, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose41:
+ax_pose 12, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose42:
+ax_pose 13, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose43:
+ax_pose 14, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose44:
+ax_pose 19, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose45:
+ax_pose 9, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose46:
+ax_pose 10, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose47:
+ax_pose 11, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose48:
+ax_pose 18, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose49:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose50:
+ax_pose 7, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose51:
+ax_pose 8, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose52:
+ax_pose 17, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sSandslashPose53:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose54:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose55:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose56:
+ax_pose 16, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose57:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose58:
+ax_pose 20, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose59:
+ax_pose 21, 0x01e6, 0x80f2, 0x4c00
+ax_pose 22, 0x01e6, 0x80f2, 0x4c10
+ax_pose_terminator
+sSandslashPose60:
+ax_pose 22, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose61:
+ax_pose 3, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose62:
+ax_pose 23, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose63:
+ax_pose 24, 0x01e6, 0x90ec, 0x4c00
+ax_pose 25, 0x01e6, 0x90ec, 0x4c10
+ax_pose_terminator
+sSandslashPose64:
+ax_pose 25, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose65:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose66:
+ax_pose 26, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose67:
+ax_pose 27, 0x01e4, 0x90f5, 0x4c00
+ax_pose 28, 0x01e7, 0x90ef, 0x4c10
+ax_pose_terminator
+sSandslashPose68:
+ax_pose 28, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose69:
+ax_pose 9, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose70:
+ax_pose 29, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sSandslashPose71:
+ax_pose 30, 0x01e6, 0x90f2, 0x4c00
+ax_pose 31, 0x01e6, 0x90ec, 0x4c10
+ax_pose_terminator
+sSandslashPose72:
+ax_pose 31, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose73:
+ax_pose 12, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose74:
+ax_pose 32, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose75:
+ax_pose 33, 0x01e1, 0x80ef, 0x4c00
+ax_pose 34, 0x01e6, 0x80f3, 0x4c10
+ax_pose_terminator
+sSandslashPose76:
+ax_pose 34, 0x01e6, 0x90ed, 0x4c00
+ax_pose_terminator
+sSandslashPose77:
+ax_pose 34, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose78:
+ax_pose 9, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose79:
+ax_pose 29, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose80:
+ax_pose 30, 0x01e6, 0x80ed, 0x4c00
+ax_pose 31, 0x01e6, 0x80f3, 0x4c10
+ax_pose_terminator
+sSandslashPose81:
+ax_pose 31, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose82:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose83:
+ax_pose 26, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose84:
+ax_pose 27, 0x01e3, 0x80e9, 0x4c00
+ax_pose 28, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sSandslashPose85:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose86:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose87:
+ax_pose 23, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose88:
+ax_pose 24, 0x01e6, 0x80f3, 0x4c00
+ax_pose 25, 0x01e6, 0x80f3, 0x4c10
+ax_pose_terminator
+sSandslashPose89:
+ax_pose 25, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose90:
+ax_pose 22, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose91:
+ax_pose 25, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose92:
+ax_pose 28, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose93:
+ax_pose 31, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose94:
+ax_pose 34, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose95:
+ax_pose 31, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose96:
+ax_pose 28, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sSandslashPose97:
+ax_pose 25, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose98:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose99:
+ax_pose 16, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose100:
+ax_pose 17, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose101:
+ax_pose 18, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose102:
+ax_pose 19, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose103:
+ax_pose 18, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose104:
+ax_pose 17, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose105:
+ax_pose 16, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose106:
+ax_pose 35, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sSandslashPose107:
+ax_pose 36, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sSandslashPose108:
+ax_pose 37, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sSandslashPose109:
+ax_pose 38, 0x01e3, 0x90ee, 0x4c00
+ax_pose_terminator
+sSandslashPose110:
+ax_pose 39, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sSandslashPose111:
+ax_pose 40, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSandslashPose112:
+ax_pose 41, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSandslashPose113:
+ax_pose 40, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose114:
+ax_pose 39, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose115:
+ax_pose 38, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose116:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose117:
+ax_pose 1, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose118:
+ax_pose 2, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose119:
+ax_pose 3, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose120:
+ax_pose 4, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose121:
+ax_pose 5, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose122:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose123:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose124:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose125:
+ax_pose 9, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose126:
+ax_pose 10, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose127:
+ax_pose 11, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose128:
+ax_pose 12, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose129:
+ax_pose 13, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose130:
+ax_pose 14, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose131:
+ax_pose 9, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose132:
+ax_pose 10, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose133:
+ax_pose 11, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose134:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose135:
+ax_pose 7, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose136:
+ax_pose 8, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose137:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose138:
+ax_pose 4, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose139:
+ax_pose 5, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose140:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose141:
+ax_pose 16, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose142:
+ax_pose 17, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sSandslashPose143:
+ax_pose 18, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose144:
+ax_pose 19, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose145:
+ax_pose 18, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose146:
+ax_pose 17, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sSandslashPose147:
+ax_pose 16, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose148:
+ax_pose 22, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose149:
+ax_pose 25, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose150:
+ax_pose 28, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sSandslashPose151:
+ax_pose 31, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose152:
+ax_pose 34, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose153:
+ax_pose 31, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose154:
+ax_pose 28, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose155:
+ax_pose 25, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose156:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose157:
+ax_pose 20, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose158:
+ax_pose 15, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose159:
+ax_pose 3, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose160:
+ax_pose 23, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose161:
+ax_pose 16, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose162:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose163:
+ax_pose 26, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose164:
+ax_pose 17, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSandslashPose165:
+ax_pose 9, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose166:
+ax_pose 29, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sSandslashPose167:
+ax_pose 18, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose168:
+ax_pose 12, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose169:
+ax_pose 32, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose170:
+ax_pose 19, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose171:
+ax_pose 9, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose172:
+ax_pose 29, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sSandslashPose173:
+ax_pose 18, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose174:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose175:
+ax_pose 26, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose176:
+ax_pose 17, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose177:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose178:
+ax_pose 23, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose179:
+ax_pose 16, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose180:
+ax_pose 22, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose181:
+ax_pose 25, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose182:
+ax_pose 28, 0x01e8, 0x80f2, 0x4c00
+ax_pose_terminator
+sSandslashPose183:
+ax_pose 31, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose184:
+ax_pose 34, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose185:
+ax_pose 31, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose186:
+ax_pose 28, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sSandslashPose187:
+ax_pose 25, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSandslashPose188:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose189:
+ax_pose 3, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sSandslashPose190:
+ax_pose 6, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSandslashPose191:
+ax_pose 9, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose192:
+ax_pose 12, 0x01e6, 0x80f3, 0x4c00
+ax_pose_terminator
+sSandslashPose193:
+ax_pose 9, 0x01e6, 0x90ec, 0x4c00
+ax_pose_terminator
+sSandslashPose194:
+ax_pose 6, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSandslashPose195:
+ax_pose 3, 0x01e6, 0x90eb, 0x4c00
+ax_pose_terminator
+.align 2
+sSandslashAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 27, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 11, 0, 11,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim_terminator
+sSandslashAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 11, 10, 11, 10,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 1, 31, 21, 17, 21, 17,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 21, 17, 21, 17,
+ax_anim 2, 0, 31, 11, 11, 11, 11,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sSandslashAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 33, 4, 0, 4, 0,
+ax_anim_terminator
+sSandslashAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -4, 4, -4,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 20, -19, 20, -19,
+ax_anim 2, 1, 39, 21, -18, 21, -18,
+ax_anim 2, 0, 39, 20, -19, 20, -19,
+ax_anim 2, 0, 39, 21, -18, 21, -18,
+ax_anim 2, 0, 39, 11, -11, 11, -11,
+ax_anim 2, 0, 37, 4, -4, 4, -4,
+ax_anim_terminator
+sSandslashAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 1, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, 1, -20, 1, -20,
+ax_anim 2, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 41, 0, -4, 0, -4,
+ax_anim_terminator
+sSandslashAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -4, -4, -4,
+ax_anim 1, 0, 47, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -20, -19, -20, -19,
+ax_anim 2, 1, 47, -21, -18, -21, -18,
+ax_anim 2, 0, 47, -20, -19, -20, -19,
+ax_anim 2, 0, 47, -21, -18, -21, -18,
+ax_anim 2, 0, 47, -11, -11, -11, -11,
+ax_anim 2, 0, 45, -4, -4, -4, -4,
+ax_anim_terminator
+sSandslashAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -11, 0, -11, 0,
+ax_anim 2, 0, 49, -4, 0, -4, 0,
+ax_anim_terminator
+sSandslashAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -11, 10, -11, 10,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 1, 55, -21, 17, -21, 17,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -21, 17, -21, 17,
+ax_anim 2, 0, 55, -11, 11, -11, 11,
+ax_anim 2, 0, 53, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSandslashAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 57, 0, -5, 0, -5,
+ax_anim 6, 0, 57, 0, -6, 0, -6,
+ax_anim 1, 2, 57, 0, 1, 0, 1,
+ax_anim 1, 0, 57, 0, 7, 0, 7,
+ax_anim 2, 0, 58, 0, 17, 0, 17,
+ax_anim 2, 1, 88, -1, 19, -1, 17,
+ax_anim 2, 0, 88, 0, 19, 0, 17,
+ax_anim 2, 0, 88, -1, 19, -1, 17,
+ax_anim 2, 0, 88, 0, 19, 0, 17,
+ax_anim 2, 0, 88, -1, 19, -1, 17,
+ax_anim 2, 0, 57, 0, 8, 0, 8,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sSandslashAnims_3_2:
+ax_anim 2, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 61, -5, -5, -5, -5,
+ax_anim 6, 0, 61, -6, -6, -6, -6,
+ax_anim 1, 2, 61, 1, 1, 1, 1,
+ax_anim 1, 0, 61, 7, 7, 7, 7,
+ax_anim 2, 0, 62, 19, 17, 19, 17,
+ax_anim 2, 1, 67, 21, 22, 19, 18,
+ax_anim 2, 0, 67, 22, 21, 20, 17,
+ax_anim 2, 0, 67, 21, 22, 19, 18,
+ax_anim 2, 0, 67, 22, 21, 20, 17,
+ax_anim 2, 0, 67, 21, 22, 19, 18,
+ax_anim 2, 0, 61, 8, 8, 8, 8,
+ax_anim 2, 0, 60, 3, 3, 3, 3,
+ax_anim_terminator
+sSandslashAnims_3_3:
+ax_anim 2, 0, 64, -2, 0, -2, 0,
+ax_anim 2, 0, 65, -5, 0, -5, 0,
+ax_anim 6, 0, 65, -6, 0, -6, 0,
+ax_anim 1, 2, 65, 1, 0, 1, 0,
+ax_anim 1, 0, 65, 5, 0, 5, 0,
+ax_anim 2, 0, 66, 12, 0, 12, 0,
+ax_anim 2, 1, 71, 18, 0, 12, -1,
+ax_anim 2, 0, 71, 18, 1, 12, 0,
+ax_anim 2, 0, 71, 18, 0, 12, -1,
+ax_anim 2, 0, 71, 18, 1, 12, 0,
+ax_anim 2, 0, 71, 18, 0, 12, -1,
+ax_anim 2, 0, 65, 8, 0, 8, 0,
+ax_anim 2, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sSandslashAnims_3_4:
+ax_anim 2, 0, 68, -2, 2, -2, 2,
+ax_anim 2, 0, 69, -5, 5, -5, 5,
+ax_anim 6, 0, 69, -6, 6, -6, 6,
+ax_anim 1, 2, 69, 1, -2, 1, -2,
+ax_anim 1, 0, 69, 9, -9, 7, -9,
+ax_anim 2, 0, 70, 12, -16, 12, -16,
+ax_anim 2, 1, 75, 12, -17, 13, -15,
+ax_anim 2, 0, 75, 11, -18, 12, -16,
+ax_anim 2, 0, 75, 12, -17, 13, -15,
+ax_anim 2, 0, 75, 11, -18, 12, -16,
+ax_anim 2, 0, 75, 12, -17, 13, -15,
+ax_anim 2, 0, 68, 9, -11, 9, -11,
+ax_anim 2, 0, 68, 3, -3, 3, -3,
+ax_anim_terminator
+sSandslashAnims_3_5:
+ax_anim 2, 0, 78, 0, 2, 0, 2,
+ax_anim 2, 0, 78, -1, 5, -1, 5,
+ax_anim 6, 0, 78, -1, 6, -1, 6,
+ax_anim 1, 2, 73, 1, 1, 1, -1,
+ax_anim 1, 0, 73, 2, -4, 2, -4,
+ax_anim 2, 0, 74, 3, -15, 3, -15,
+ax_anim 2, 1, 71, 5, -16, 4, -15,
+ax_anim 2, 0, 71, 4, -16, 3, -15,
+ax_anim 2, 0, 71, 5, -16, 4, -15,
+ax_anim 2, 0, 71, 4, -16, 3, -15,
+ax_anim 2, 0, 71, 5, -16, 4, -15,
+ax_anim 2, 0, 73, 1, -8, 1, -8,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim_terminator
+sSandslashAnims_3_6:
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 5, 5, 5, 5,
+ax_anim 6, 0, 78, 6, 6, 6, 6,
+ax_anim 1, 2, 78, -1, -2, -1, -2,
+ax_anim 1, 0, 78, -7, -9, -7, -9,
+ax_anim 2, 0, 79, -12, -16, -12, -16,
+ax_anim 2, 1, 75, -13, -15, -13, -15,
+ax_anim 2, 0, 75, -12, -16, -12, -16,
+ax_anim 2, 0, 75, -13, -15, -13, -15,
+ax_anim 2, 0, 75, -12, -16, -12, -16,
+ax_anim 2, 0, 75, -13, -15, -13, -15,
+ax_anim 2, 0, 77, -9, -11, -9, -11,
+ax_anim 2, 0, 77, -3, -3, -3, -3,
+ax_anim_terminator
+sSandslashAnims_3_7:
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 2, 0, 82, 5, 0, 5, 0,
+ax_anim 6, 0, 82, 6, 0, 6, 0,
+ax_anim 1, 2, 82, -1, 0, -1, 0,
+ax_anim 1, 0, 82, -5, 0, -5, 0,
+ax_anim 2, 0, 83, -12, 0, -12, 0,
+ax_anim 2, 1, 80, -14, 0, -12, -1,
+ax_anim 2, 0, 80, -14, 1, -12, 0,
+ax_anim 2, 0, 80, -14, 0, -12, -1,
+ax_anim 2, 0, 80, -14, 1, -12, 0,
+ax_anim 2, 0, 80, -14, 0, -12, -1,
+ax_anim 2, 0, 82, -8, 0, -8, 0,
+ax_anim 2, 0, 81, -3, 0, -3, 0,
+ax_anim_terminator
+sSandslashAnims_3_8:
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 2, 0, 86, 5, -5, 5, -5,
+ax_anim 6, 0, 86, 6, -6, 6, -6,
+ax_anim 1, 2, 86, -1, 1, -1, 1,
+ax_anim 1, 0, 86, -7, 7, -7, 7,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 1, 84, -21, 20, -19, 18,
+ax_anim 2, 0, 84, -22, 19, -20, 17,
+ax_anim 2, 0, 84, -21, 20, -19, 18,
+ax_anim 2, 0, 84, -22, 19, -20, 17,
+ax_anim 2, 0, 84, -21, 20, -19, 18,
+ax_anim 2, 0, 86, -8, 8, -8, 8,
+ax_anim 2, 0, 85, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sSandslashAnims_4_1:
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 0, 1, 0,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_4_2:
+ax_anim 2, 0, 96, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, -1, 1, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, -1, 1, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_4_3:
+ax_anim 2, 0, 95, 0, -1, 0, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, -1,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, -1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_4_4:
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_4_5:
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_4_6:
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_4_7:
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_4_8:
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_5_1:
+ax_anim 16, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_5_2:
+ax_anim 16, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 1, -1, 1, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_5_3:
+ax_anim 16, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 1, 0, 1, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_5_4:
+ax_anim 16, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 1, 1, 1, 1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 1, 1, 1,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_5_5:
+ax_anim 16, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 1, 0, 1, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, 0, 1, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_5_6:
+ax_anim 16, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 102, -1, 1, -1, 1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_5_7:
+ax_anim 16, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 103, -1, 0, -1, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, 0, -1, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_5_8:
+ax_anim 16, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 104, -1, -1, -1, -1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, -1, -1, -1, -1,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_6_1:
+ax_anim 30, 0, 105, 0, 0, 0, 0,
+ax_anim 35, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_7_1:
+ax_anim 2, 0, 107, 0, -4, 0, -4,
+ax_anim 8, 0, 107, 0, -5, 0, -5,
+ax_anim_terminator
+sSandslashAnims_7_2:
+ax_anim 2, 0, 108, -4, -4, -4, -4,
+ax_anim 8, 0, 108, -5, -5, -5, -5,
+ax_anim_terminator
+sSandslashAnims_7_3:
+ax_anim 2, 0, 109, -4, 0, -4, 0,
+ax_anim 8, 0, 109, -5, 0, -5, 0,
+ax_anim_terminator
+sSandslashAnims_7_4:
+ax_anim 2, 0, 110, -4, 4, -4, 4,
+ax_anim 8, 0, 110, -5, 5, -5, 5,
+ax_anim_terminator
+sSandslashAnims_7_5:
+ax_anim 2, 0, 111, 0, 4, 0, 4,
+ax_anim 8, 0, 111, 0, 5, 0, 5,
+ax_anim_terminator
+sSandslashAnims_7_6:
+ax_anim 2, 0, 112, 4, 4, 4, 4,
+ax_anim 8, 0, 112, 5, 5, 5, 5,
+ax_anim_terminator
+sSandslashAnims_7_7:
+ax_anim 2, 0, 113, 4, 0, 4, 0,
+ax_anim 8, 0, 113, 5, 0, 5, 0,
+ax_anim_terminator
+sSandslashAnims_7_8:
+ax_anim 2, 0, 114, 4, -4, 4, -4,
+ax_anim 8, 0, 114, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSandslashAnims_8_1:
+ax_anim 25, 0, 115, 0, 0, 0, 0,
+ax_anim 10, 0, 116, 0, 0, 0, 0,
+ax_anim 25, 0, 115, 0, 0, 0, 0,
+ax_anim 10, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_8_2:
+ax_anim 25, 0, 118, 0, 0, 0, 0,
+ax_anim 10, 0, 119, 0, 0, 0, 0,
+ax_anim 25, 0, 118, 0, 0, 0, 0,
+ax_anim 10, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_8_3:
+ax_anim 25, 0, 121, 0, 0, 0, 0,
+ax_anim 10, 0, 122, 0, 0, 0, 0,
+ax_anim 25, 0, 121, 0, 0, 0, 0,
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_8_4:
+ax_anim 25, 0, 124, 0, 0, 0, 0,
+ax_anim 10, 0, 125, 0, 0, 0, 0,
+ax_anim 25, 0, 124, 0, 0, 0, 0,
+ax_anim 10, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_8_5:
+ax_anim 25, 0, 127, 0, 0, 0, 0,
+ax_anim 10, 0, 128, 0, 0, 0, 0,
+ax_anim 25, 0, 127, 0, 0, 0, 0,
+ax_anim 10, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_8_6:
+ax_anim 25, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 25, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_8_7:
+ax_anim 25, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 25, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_8_8:
+ax_anim 25, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 25, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_9_1:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 6, 4, 6, 4,
+ax_anim 2, 0, 141, 8, 9, 8, 9,
+ax_anim 2, 0, 142, 7, 17, 7, 17,
+ax_anim 3, 0, 143, 0, 21, 0, 21,
+ax_anim 2, 3, 144, -7, 17, -7, 17,
+ax_anim 2, 0, 145, -8, 9, -8, 9,
+ax_anim 1, 0, 146, -6, 4, -6, 4,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_9_2:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 0, 6, 0,
+ax_anim 2, 0, 140, 17, 3, 17, 3,
+ax_anim 2, 0, 141, 23, 11, 23, 11,
+ax_anim 3, 0, 142, 21, 20, 21, 20,
+ax_anim 2, 3, 143, 11, 21, 11, 21,
+ax_anim 2, 0, 144, 4, 15, 4, 15,
+ax_anim 1, 0, 145, 0, 7, 0, 7,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_9_3:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 3, -4, 3, -4,
+ax_anim 2, 0, 139, 11, -6, 11, -6,
+ax_anim 2, 0, 140, 17, -4, 17, -4,
+ax_anim 3, 0, 141, 22, 1, 22, 1,
+ax_anim 2, 3, 142, 17, 5, 17, 5,
+ax_anim 2, 0, 143, 12, 7, 12, 7,
+ax_anim 1, 0, 144, 4, 5, 4, 5,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_9_4:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, -1, -6, -1, -6,
+ax_anim 2, 0, 146, 4, -16, 4, -16,
+ax_anim 2, 0, 139, 11, -21, 11, -21,
+ax_anim 3, 0, 140, 21, -23, 21, -23,
+ax_anim 2, 3, 141, 22, -12, 22, -12,
+ax_anim 2, 0, 142, 16, -6, 16, -6,
+ax_anim 1, 0, 143, 7, -1, 7, -1,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_9_5:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -6, -4, -6, -4,
+ax_anim 2, 0, 145, -8, -10, -8, -10,
+ax_anim 2, 0, 146, -7, -18, -7, -18,
+ax_anim 3, 0, 139, 0, -23, 0, -23,
+ax_anim 2, 3, 140, 7, -18, 7, -18,
+ax_anim 2, 0, 141, 8, -8, 8, -8,
+ax_anim 1, 0, 142, 6, -4, 6, -4,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_9_6:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 1, -6, 1, -6,
+ax_anim 2, 0, 140, -4, -16, -4, -16,
+ax_anim 2, 0, 139, -11, -21, -11, -21,
+ax_anim 3, 0, 146, -21, -23, -21, -23,
+ax_anim 2, 3, 145, -22, -12, -22, -12,
+ax_anim 2, 0, 144, -16, -6, -16, -6,
+ax_anim 1, 0, 143, -7, -1, -7, -1,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_9_7:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -3, -4, -3, -4,
+ax_anim 2, 0, 139, -11, -6, -11, -6,
+ax_anim 2, 0, 146, -17, -4, -17, -4,
+ax_anim 3, 0, 145, -22, 1, -22, 1,
+ax_anim 2, 3, 144, -17, 5, -17, 5,
+ax_anim 2, 0, 143, -12, 7, -12, 7,
+ax_anim 1, 0, 142, -4, 5, -4, 5,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_9_8:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -6, 0, -6, 0,
+ax_anim 2, 0, 146, -17, 3, -17, 3,
+ax_anim 2, 0, 145, -23, 11, -23, 11,
+ax_anim 3, 0, 144, -20, 20, -20, 20,
+ax_anim 2, 3, 143, -11, 21, -11, 21,
+ax_anim 2, 0, 142, -4, 15, -4, 15,
+ax_anim 1, 0, 141, 0, 7, 0, 7,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_10_1:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, 0, 6, 0,
+ax_anim 2, 0, 147, -6, 0, -6, 0,
+ax_anim 2, 0, 147, 10, 0, 10, 0,
+ax_anim 2, 0, 147, -10, 0, -10, 0,
+ax_anim 2, 0, 147, 12, 0, 12, 0,
+ax_anim 3, 0, 147, -12, 0, -12, 0,
+ax_anim 3, 0, 147, 13, 0, 13, 0,
+ax_anim 3, 0, 147, -13, 0, -13, 0,
+ax_anim 2, 0, 147, 12, 0, 12, 0,
+ax_anim 3, 0, 147, -12, 0, -12, 0,
+ax_anim 2, 0, 147, 10, 0, 10, 0,
+ax_anim 2, 0, 147, -10, 0, -10, 0,
+ax_anim 2, 0, 147, 6, 0, 6, 0,
+ax_anim 2, 0, 147, -6, 0, -6, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_10_2:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 6, -6, 6, -6,
+ax_anim 2, 0, 148, -6, 6, -6, 6,
+ax_anim 2, 0, 148, 10, -10, 10, -10,
+ax_anim 2, 0, 148, -10, 10, -10, 10,
+ax_anim 2, 0, 148, 12, -12, 12, -12,
+ax_anim 3, 0, 148, -12, 12, -12, 12,
+ax_anim 3, 0, 148, 13, -13, 13, -13,
+ax_anim 3, 0, 148, -13, 13, -13, 13,
+ax_anim 2, 0, 148, 12, -12, 12, -12,
+ax_anim 3, 0, 148, -12, 12, -12, 12,
+ax_anim 2, 0, 148, 10, -10, 10, -10,
+ax_anim 2, 0, 148, -10, 10, -10, 10,
+ax_anim 2, 0, 148, 6, -6, 6, -6,
+ax_anim 2, 0, 148, -6, 6, -6, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_10_3:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, -6,
+ax_anim 2, 0, 149, 0, 6, 0, 6,
+ax_anim 2, 0, 149, 0, -10, 0, -10,
+ax_anim 2, 0, 149, 0, 10, 0, 10,
+ax_anim 2, 0, 149, 0, -12, 0, -12,
+ax_anim 3, 0, 149, 0, 12, 0, 12,
+ax_anim 3, 0, 149, 0, -13, 0, -13,
+ax_anim 3, 0, 149, 0, 13, 0, 13,
+ax_anim 2, 0, 149, 0, -12, 0, -12,
+ax_anim 3, 0, 149, 0, 12, 0, 12,
+ax_anim 2, 0, 149, 0, -10, 0, -10,
+ax_anim 2, 0, 149, 0, 10, 0, 10,
+ax_anim 2, 0, 149, 0, -6, 0, -6,
+ax_anim 2, 0, 149, 0, 6, 0, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_10_4:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -6, -6, -6, -6,
+ax_anim 2, 0, 150, 6, 6, 6, 6,
+ax_anim 2, 0, 150, -10, -10, -10, -10,
+ax_anim 2, 0, 150, 10, 10, 10, 10,
+ax_anim 2, 0, 150, -12, -12, -12, -12,
+ax_anim 3, 0, 150, 12, 12, 12, 12,
+ax_anim 3, 0, 150, -13, -13, -13, -13,
+ax_anim 3, 0, 150, 13, 13, 13, 13,
+ax_anim 2, 0, 150, -12, -12, -12, -12,
+ax_anim 3, 0, 150, 12, 12, 12, 12,
+ax_anim 2, 0, 150, -10, -10, -10, -10,
+ax_anim 2, 0, 150, 10, 10, 10, 10,
+ax_anim 2, 0, 150, -6, -6, -6, -6,
+ax_anim 2, 0, 150, 6, 6, 6, 6,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_10_5:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, 0, 6, 0,
+ax_anim 2, 0, 151, -6, 0, -6, 0,
+ax_anim 2, 0, 151, 10, 0, 10, 0,
+ax_anim 2, 0, 151, -10, 0, -10, 0,
+ax_anim 2, 0, 151, 12, 0, 12, 0,
+ax_anim 3, 0, 151, -12, 0, -12, 0,
+ax_anim 3, 0, 151, 13, 0, 13, 0,
+ax_anim 3, 0, 151, -13, 0, -13, 0,
+ax_anim 2, 0, 151, 12, 0, 12, 0,
+ax_anim 3, 0, 151, -12, 0, -12, 0,
+ax_anim 2, 0, 151, 10, 0, 10, 0,
+ax_anim 2, 0, 151, -10, 0, -10, 0,
+ax_anim 2, 0, 151, 6, 0, 6, 0,
+ax_anim 2, 0, 151, -6, 0, -6, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_10_6:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 6, -6, 6, -6,
+ax_anim 2, 0, 152, -6, 6, -6, 6,
+ax_anim 2, 0, 152, 10, -10, 10, -10,
+ax_anim 2, 0, 152, -10, 10, -10, 10,
+ax_anim 2, 0, 152, 12, -12, 12, -12,
+ax_anim 3, 0, 152, -12, 12, -12, 12,
+ax_anim 3, 0, 152, 13, -13, 13, -13,
+ax_anim 3, 0, 152, -13, 13, -13, 13,
+ax_anim 2, 0, 152, 12, -12, 12, -12,
+ax_anim 3, 0, 152, -12, 12, -12, 12,
+ax_anim 2, 0, 152, 10, -10, 10, -10,
+ax_anim 2, 0, 152, -10, 10, -10, 10,
+ax_anim 2, 0, 152, 6, -6, 6, -6,
+ax_anim 2, 0, 152, -6, 6, -6, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_10_7:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, -6, 0, -6,
+ax_anim 2, 0, 153, 0, 6, 0, 6,
+ax_anim 2, 0, 153, 0, -10, 0, -10,
+ax_anim 2, 0, 153, 0, 10, 0, 10,
+ax_anim 2, 0, 153, 0, -12, 0, -12,
+ax_anim 3, 0, 153, 0, 12, 0, 12,
+ax_anim 3, 0, 153, 0, -13, 0, -13,
+ax_anim 3, 0, 153, 0, 13, 0, 13,
+ax_anim 2, 0, 153, 0, -12, 0, -12,
+ax_anim 3, 0, 153, 0, 12, 0, 12,
+ax_anim 2, 0, 153, 0, -10, 0, -10,
+ax_anim 2, 0, 153, 0, 10, 0, 10,
+ax_anim 2, 0, 153, 0, -6, 0, -6,
+ax_anim 2, 0, 153, 0, 6, 0, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_10_8:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -6, -6, -6, -6,
+ax_anim 2, 0, 154, 6, 6, 6, 6,
+ax_anim 2, 0, 154, -10, -10, -10, -10,
+ax_anim 2, 0, 154, 10, 10, 10, 10,
+ax_anim 2, 0, 154, -12, -12, -12, -12,
+ax_anim 3, 0, 154, 12, 12, 12, 12,
+ax_anim 3, 0, 154, -13, -13, -13, -13,
+ax_anim 3, 0, 154, 13, 13, 13, 13,
+ax_anim 2, 0, 154, -12, -12, -12, -12,
+ax_anim 3, 0, 154, 12, 12, 12, 12,
+ax_anim 2, 0, 154, -10, -10, -10, -10,
+ax_anim 2, 0, 154, 10, 10, 10, 10,
+ax_anim 2, 0, 154, -6, -6, -6, -6,
+ax_anim 2, 0, 154, 6, 6, 6, 6,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_11_1:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -25, 0, 0,
+ax_anim 3, 0, 157, 0, -24, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_11_2:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -25, 0, 0,
+ax_anim 3, 0, 160, 0, -23, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_11_3:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -25, 0, 0,
+ax_anim 3, 0, 163, 0, -23, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_11_4:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -24, 0, 0,
+ax_anim 3, 0, 166, 0, -23, 0, 0,
+ax_anim 2, 0, 166, 0, -17, 0, 0,
+ax_anim 1, 0, 166, 0, -11, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_11_5:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -25, 0, 0,
+ax_anim 3, 0, 169, 0, -23, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_11_6:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -24, 0, 0,
+ax_anim 3, 0, 172, 0, -23, 0, 0,
+ax_anim 2, 0, 172, 0, -17, 0, 0,
+ax_anim 1, 0, 172, 0, -11, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_11_7:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -25, 0, 0,
+ax_anim 3, 0, 175, 0, -24, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_11_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -25, 0, 0,
+ax_anim 3, 0, 178, 0, -24, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_12_1:
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 1, 0, 1, 0,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_12_2:
+ax_anim 2, 0, 186, 1, -1, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, -1, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, -1, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, -1, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, -1, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_12_3:
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -1, 0, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_12_4:
+ax_anim 2, 0, 184, -1, -1, -1, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, -1, -1, -1, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, -1, -1, -1, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, -1, -1, -1, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, -1, -1, -1, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_12_5:
+ax_anim 2, 0, 183, 1, 0, 1, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, 0, 1, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, 0, 1, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, 0, 1, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 1, 0, 1, 0,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_12_6:
+ax_anim 2, 0, 182, 1, -1, 1, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, -1,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, -1,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, -1, 1, -1,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_12_7:
+ax_anim 2, 0, 181, 0, -1, 0, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, -1, 0, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, -1, 0, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, -1, 0, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, -1, 0, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_12_8:
+ax_anim 2, 0, 180, -1, -1, -1, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, -1, -1, -1, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, -1, -1, -1, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, -1, -1, -1, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, -1, -1, -1, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSandslashAnims_13_1:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_13_2:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_13_3:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_13_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_13_5:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_13_6:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_13_7:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashAnims_13_8:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSandslashGfx1:
+.incbin "baserom.gba", 0x640D54, 0x200
+sSandslashSprites1:
+ax_sprite sSandslashGfx1, 0x200
+ax_sprite_terminator
+sSandslashGfx2:
+.incbin "baserom.gba", 0x640F64, 0x200
+sSandslashSprites2:
+ax_sprite sSandslashGfx2, 0x200
+ax_sprite_terminator
+sSandslashGfx3:
+.incbin "baserom.gba", 0x641174, 0x200
+sSandslashSprites3:
+ax_sprite sSandslashGfx3, 0x200
+ax_sprite_terminator
+sSandslashGfx4:
+.incbin "baserom.gba", 0x641384, 0x200
+sSandslashSprites4:
+ax_sprite sSandslashGfx4, 0x200
+ax_sprite_terminator
+sSandslashGfx5:
+.incbin "baserom.gba", 0x641594, 0x200
+sSandslashSprites5:
+ax_sprite sSandslashGfx5, 0x200
+ax_sprite_terminator
+sSandslashGfx6:
+.incbin "baserom.gba", 0x6417A4, 0x200
+sSandslashSprites6:
+ax_sprite sSandslashGfx6, 0x200
+ax_sprite_terminator
+sSandslashGfx7:
+.incbin "baserom.gba", 0x6419B4, 0x200
+sSandslashSprites7:
+ax_sprite sSandslashGfx7, 0x200
+ax_sprite_terminator
+sSandslashGfx8:
+.incbin "baserom.gba", 0x641BC4, 0x200
+sSandslashSprites8:
+ax_sprite sSandslashGfx8, 0x200
+ax_sprite_terminator
+sSandslashGfx9:
+.incbin "baserom.gba", 0x641DD4, 0x200
+sSandslashSprites9:
+ax_sprite sSandslashGfx9, 0x200
+ax_sprite_terminator
+sSandslashGfx10:
+.incbin "baserom.gba", 0x641FE4, 0x200
+sSandslashSprites10:
+ax_sprite sSandslashGfx10, 0x200
+ax_sprite_terminator
+sSandslashGfx11:
+.incbin "baserom.gba", 0x6421F4, 0x200
+sSandslashSprites11:
+ax_sprite sSandslashGfx11, 0x200
+ax_sprite_terminator
+sSandslashGfx12:
+.incbin "baserom.gba", 0x642404, 0x200
+sSandslashSprites12:
+ax_sprite sSandslashGfx12, 0x200
+ax_sprite_terminator
+sSandslashGfx13:
+.incbin "baserom.gba", 0x642614, 0x200
+sSandslashSprites13:
+ax_sprite sSandslashGfx13, 0x200
+ax_sprite_terminator
+sSandslashGfx14:
+.incbin "baserom.gba", 0x642824, 0x200
+sSandslashSprites14:
+ax_sprite sSandslashGfx14, 0x200
+ax_sprite_terminator
+sSandslashGfx15:
+.incbin "baserom.gba", 0x642A34, 0x200
+sSandslashSprites15:
+ax_sprite sSandslashGfx15, 0x200
+ax_sprite_terminator
+sSandslashGfx16:
+.incbin "baserom.gba", 0x642C44, 0x20
+sSandslashGfx16_1:
+.incbin "baserom.gba", 0x642C64, 0x60
+sSandslashGfx16_2:
+.incbin "baserom.gba", 0x642CC4, 0x60
+sSandslashGfx16_3:
+.incbin "baserom.gba", 0x642D24, 0x60
+sSandslashSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSandslashGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx17:
+.incbin "baserom.gba", 0x642DD4, 0x40
+sSandslashGfx17_1:
+.incbin "baserom.gba", 0x642E14, 0x60
+sSandslashGfx17_2:
+.incbin "baserom.gba", 0x642E74, 0x60
+sSandslashGfx17_3:
+.incbin "baserom.gba", 0x642ED4, 0x60
+sSandslashSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx18:
+.incbin "baserom.gba", 0x642F84, 0x180
+sSandslashGfx18_1:
+.incbin "baserom.gba", 0x643104, 0x40
+sSandslashSprites18:
+ax_sprite sSandslashGfx18, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx19:
+.incbin "baserom.gba", 0x64316C, 0x60
+sSandslashGfx19_1:
+.incbin "baserom.gba", 0x6431CC, 0x60
+sSandslashGfx19_2:
+.incbin "baserom.gba", 0x64322C, 0x60
+sSandslashGfx19_3:
+.incbin "baserom.gba", 0x64328C, 0x60
+sSandslashSprites19:
+ax_sprite sSandslashGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx20:
+.incbin "baserom.gba", 0x643334, 0x60
+sSandslashGfx20_1:
+.incbin "baserom.gba", 0x643394, 0x60
+sSandslashGfx20_2:
+.incbin "baserom.gba", 0x6433F4, 0x60
+sSandslashGfx20_3:
+.incbin "baserom.gba", 0x643454, 0x60
+sSandslashSprites20:
+ax_sprite sSandslashGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx21:
+.incbin "baserom.gba", 0x6434FC, 0x160
+sSandslashGfx21_1:
+.incbin "baserom.gba", 0x64365C, 0x60
+sSandslashSprites21:
+ax_sprite sSandslashGfx21, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx22:
+.incbin "baserom.gba", 0x6436E4, 0x20
+sSandslashGfx22_1:
+.incbin "baserom.gba", 0x643704, 0x20
+sSandslashGfx22_2:
+.incbin "baserom.gba", 0x643724, 0x40
+sSandslashGfx22_3:
+.incbin "baserom.gba", 0x643764, 0x60
+sSandslashSprites22:
+ax_sprite 0, 0x60
+ax_sprite sSandslashGfx22, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSandslashGfx22_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSandslashGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx22_3, 0x60
+ax_sprite_terminator
+sSandslashGfx23:
+.incbin "baserom.gba", 0x64380C, 0x60
+sSandslashGfx23_1:
+.incbin "baserom.gba", 0x64386C, 0x60
+sSandslashGfx23_2:
+.incbin "baserom.gba", 0x6438CC, 0xE0
+sSandslashSprites23:
+ax_sprite sSandslashGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx23_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx24:
+.incbin "baserom.gba", 0x6439E4, 0x60
+sSandslashGfx24_1:
+.incbin "baserom.gba", 0x643A44, 0x60
+sSandslashGfx24_2:
+.incbin "baserom.gba", 0x643AA4, 0x60
+sSandslashGfx24_3:
+.incbin "baserom.gba", 0x643B04, 0x60
+sSandslashSprites24:
+ax_sprite sSandslashGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx25:
+.incbin "baserom.gba", 0x643BAC, 0x20
+sSandslashGfx25_1:
+.incbin "baserom.gba", 0x643BCC, 0x20
+sSandslashGfx25_2:
+.incbin "baserom.gba", 0x643BEC, 0xC0
+sSandslashSprites25:
+ax_sprite 0, 0x60
+ax_sprite sSandslashGfx25, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSandslashGfx25_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx25_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx26:
+.incbin "baserom.gba", 0x643CEC, 0x20
+sSandslashGfx26_1:
+.incbin "baserom.gba", 0x643D0C, 0x60
+sSandslashGfx26_2:
+.incbin "baserom.gba", 0x643D6C, 0x60
+sSandslashGfx26_3:
+.incbin "baserom.gba", 0x643DCC, 0x60
+sSandslashSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx26, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSandslashGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx27:
+.incbin "baserom.gba", 0x643E7C, 0x160
+sSandslashGfx27_1:
+.incbin "baserom.gba", 0x643FDC, 0x40
+sSandslashSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx27, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx28:
+.incbin "baserom.gba", 0x64404C, 0xC0
+sSandslashGfx28_1:
+.incbin "baserom.gba", 0x64410C, 0x40
+sSandslashSprites28:
+ax_sprite 0, 0x80
+ax_sprite sSandslashGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSandslashGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSandslashGfx29:
+.incbin "baserom.gba", 0x64417C, 0x60
+sSandslashGfx29_1:
+.incbin "baserom.gba", 0x6441DC, 0xE0
+sSandslashGfx29_2:
+.incbin "baserom.gba", 0x6442BC, 0x40
+sSandslashSprites29:
+ax_sprite sSandslashGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx29_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSandslashGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx30:
+.incbin "baserom.gba", 0x644334, 0x60
+sSandslashGfx30_1:
+.incbin "baserom.gba", 0x644394, 0x80
+sSandslashGfx30_2:
+.incbin "baserom.gba", 0x644414, 0xC0
+sSandslashSprites30:
+ax_sprite sSandslashGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx30_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx30_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx31:
+.incbin "baserom.gba", 0x64450C, 0x40
+sSandslashGfx31_1:
+.incbin "baserom.gba", 0x64454C, 0x60
+sSandslashGfx31_2:
+.incbin "baserom.gba", 0x6445AC, 0x20
+sSandslashSprites31:
+ax_sprite sSandslashGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSandslashGfx31_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSandslashGfx31_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSandslashGfx32:
+.incbin "baserom.gba", 0x644604, 0x60
+sSandslashGfx32_1:
+.incbin "baserom.gba", 0x644664, 0x60
+sSandslashGfx32_2:
+.incbin "baserom.gba", 0x6446C4, 0x60
+sSandslashGfx32_3:
+.incbin "baserom.gba", 0x644724, 0x60
+sSandslashSprites32:
+ax_sprite sSandslashGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx33:
+.incbin "baserom.gba", 0x6447CC, 0x60
+sSandslashGfx33_1:
+.incbin "baserom.gba", 0x64482C, 0x60
+sSandslashGfx33_2:
+.incbin "baserom.gba", 0x64488C, 0x60
+sSandslashGfx33_3:
+.incbin "baserom.gba", 0x6448EC, 0x60
+sSandslashSprites33:
+ax_sprite sSandslashGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx33_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx34:
+.incbin "baserom.gba", 0x644994, 0x60
+sSandslashGfx34_1:
+.incbin "baserom.gba", 0x6449F4, 0x60
+sSandslashGfx34_2:
+.incbin "baserom.gba", 0x644A54, 0x20
+sSandslashSprites34:
+ax_sprite sSandslashGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx34_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sSandslashGfx35:
+.incbin "baserom.gba", 0x644AAC, 0x60
+sSandslashGfx35_1:
+.incbin "baserom.gba", 0x644B0C, 0x60
+sSandslashGfx35_2:
+.incbin "baserom.gba", 0x644B6C, 0x60
+sSandslashGfx35_3:
+.incbin "baserom.gba", 0x644BCC, 0x60
+sSandslashSprites35:
+ax_sprite sSandslashGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSandslashGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSandslashGfx36:
+.incbin "baserom.gba", 0x644C74, 0x200
+sSandslashSprites36:
+ax_sprite sSandslashGfx36, 0x200
+ax_sprite_terminator
+sSandslashGfx37:
+.incbin "baserom.gba", 0x644E84, 0x200
+sSandslashSprites37:
+ax_sprite sSandslashGfx37, 0x200
+ax_sprite_terminator
+sSandslashGfx38:
+.incbin "baserom.gba", 0x645094, 0x200
+sSandslashSprites38:
+ax_sprite sSandslashGfx38, 0x200
+ax_sprite_terminator
+sSandslashGfx39:
+.incbin "baserom.gba", 0x6452A4, 0x200
+sSandslashSprites39:
+ax_sprite sSandslashGfx39, 0x200
+ax_sprite_terminator
+sSandslashGfx40:
+.incbin "baserom.gba", 0x6454B4, 0x200
+sSandslashSprites40:
+ax_sprite sSandslashGfx40, 0x200
+ax_sprite_terminator
+sSandslashGfx41:
+.incbin "baserom.gba", 0x6456C4, 0x200
+sSandslashSprites41:
+ax_sprite sSandslashGfx41, 0x200
+ax_sprite_terminator
+sSandslashGfx42:
+.incbin "baserom.gba", 0x6458D4, 0x200
+sSandslashSprites42:
+ax_sprite sSandslashGfx42, 0x200
+ax_sprite_terminator
+sAxPosesSandslash:
+.4byte sSandslashPose1
+.4byte sSandslashPose2
+.4byte sSandslashPose3
+.4byte sSandslashPose4
+.4byte sSandslashPose5
+.4byte sSandslashPose6
+.4byte sSandslashPose7
+.4byte sSandslashPose8
+.4byte sSandslashPose9
+.4byte sSandslashPose10
+.4byte sSandslashPose11
+.4byte sSandslashPose12
+.4byte sSandslashPose13
+.4byte sSandslashPose14
+.4byte sSandslashPose15
+.4byte sSandslashPose16
+.4byte sSandslashPose17
+.4byte sSandslashPose18
+.4byte sSandslashPose19
+.4byte sSandslashPose20
+.4byte sSandslashPose21
+.4byte sSandslashPose22
+.4byte sSandslashPose23
+.4byte sSandslashPose24
+.4byte sSandslashPose25
+.4byte sSandslashPose26
+.4byte sSandslashPose27
+.4byte sSandslashPose28
+.4byte sSandslashPose29
+.4byte sSandslashPose30
+.4byte sSandslashPose31
+.4byte sSandslashPose32
+.4byte sSandslashPose33
+.4byte sSandslashPose34
+.4byte sSandslashPose35
+.4byte sSandslashPose36
+.4byte sSandslashPose37
+.4byte sSandslashPose38
+.4byte sSandslashPose39
+.4byte sSandslashPose40
+.4byte sSandslashPose41
+.4byte sSandslashPose42
+.4byte sSandslashPose43
+.4byte sSandslashPose44
+.4byte sSandslashPose45
+.4byte sSandslashPose46
+.4byte sSandslashPose47
+.4byte sSandslashPose48
+.4byte sSandslashPose49
+.4byte sSandslashPose50
+.4byte sSandslashPose51
+.4byte sSandslashPose52
+.4byte sSandslashPose53
+.4byte sSandslashPose54
+.4byte sSandslashPose55
+.4byte sSandslashPose56
+.4byte sSandslashPose57
+.4byte sSandslashPose58
+.4byte sSandslashPose59
+.4byte sSandslashPose60
+.4byte sSandslashPose61
+.4byte sSandslashPose62
+.4byte sSandslashPose63
+.4byte sSandslashPose64
+.4byte sSandslashPose65
+.4byte sSandslashPose66
+.4byte sSandslashPose67
+.4byte sSandslashPose68
+.4byte sSandslashPose69
+.4byte sSandslashPose70
+.4byte sSandslashPose71
+.4byte sSandslashPose72
+.4byte sSandslashPose73
+.4byte sSandslashPose74
+.4byte sSandslashPose75
+.4byte sSandslashPose76
+.4byte sSandslashPose77
+.4byte sSandslashPose78
+.4byte sSandslashPose79
+.4byte sSandslashPose80
+.4byte sSandslashPose81
+.4byte sSandslashPose82
+.4byte sSandslashPose83
+.4byte sSandslashPose84
+.4byte sSandslashPose85
+.4byte sSandslashPose86
+.4byte sSandslashPose87
+.4byte sSandslashPose88
+.4byte sSandslashPose89
+.4byte sSandslashPose90
+.4byte sSandslashPose91
+.4byte sSandslashPose92
+.4byte sSandslashPose93
+.4byte sSandslashPose94
+.4byte sSandslashPose95
+.4byte sSandslashPose96
+.4byte sSandslashPose97
+.4byte sSandslashPose98
+.4byte sSandslashPose99
+.4byte sSandslashPose100
+.4byte sSandslashPose101
+.4byte sSandslashPose102
+.4byte sSandslashPose103
+.4byte sSandslashPose104
+.4byte sSandslashPose105
+.4byte sSandslashPose106
+.4byte sSandslashPose107
+.4byte sSandslashPose108
+.4byte sSandslashPose109
+.4byte sSandslashPose110
+.4byte sSandslashPose111
+.4byte sSandslashPose112
+.4byte sSandslashPose113
+.4byte sSandslashPose114
+.4byte sSandslashPose115
+.4byte sSandslashPose116
+.4byte sSandslashPose117
+.4byte sSandslashPose118
+.4byte sSandslashPose119
+.4byte sSandslashPose120
+.4byte sSandslashPose121
+.4byte sSandslashPose122
+.4byte sSandslashPose123
+.4byte sSandslashPose124
+.4byte sSandslashPose125
+.4byte sSandslashPose126
+.4byte sSandslashPose127
+.4byte sSandslashPose128
+.4byte sSandslashPose129
+.4byte sSandslashPose130
+.4byte sSandslashPose131
+.4byte sSandslashPose132
+.4byte sSandslashPose133
+.4byte sSandslashPose134
+.4byte sSandslashPose135
+.4byte sSandslashPose136
+.4byte sSandslashPose137
+.4byte sSandslashPose138
+.4byte sSandslashPose139
+.4byte sSandslashPose140
+.4byte sSandslashPose141
+.4byte sSandslashPose142
+.4byte sSandslashPose143
+.4byte sSandslashPose144
+.4byte sSandslashPose145
+.4byte sSandslashPose146
+.4byte sSandslashPose147
+.4byte sSandslashPose148
+.4byte sSandslashPose149
+.4byte sSandslashPose150
+.4byte sSandslashPose151
+.4byte sSandslashPose152
+.4byte sSandslashPose153
+.4byte sSandslashPose154
+.4byte sSandslashPose155
+.4byte sSandslashPose156
+.4byte sSandslashPose157
+.4byte sSandslashPose158
+.4byte sSandslashPose159
+.4byte sSandslashPose160
+.4byte sSandslashPose161
+.4byte sSandslashPose162
+.4byte sSandslashPose163
+.4byte sSandslashPose164
+.4byte sSandslashPose165
+.4byte sSandslashPose166
+.4byte sSandslashPose167
+.4byte sSandslashPose168
+.4byte sSandslashPose169
+.4byte sSandslashPose170
+.4byte sSandslashPose171
+.4byte sSandslashPose172
+.4byte sSandslashPose173
+.4byte sSandslashPose174
+.4byte sSandslashPose175
+.4byte sSandslashPose176
+.4byte sSandslashPose177
+.4byte sSandslashPose178
+.4byte sSandslashPose179
+.4byte sSandslashPose180
+.4byte sSandslashPose181
+.4byte sSandslashPose182
+.4byte sSandslashPose183
+.4byte sSandslashPose184
+.4byte sSandslashPose185
+.4byte sSandslashPose186
+.4byte sSandslashPose187
+.4byte sSandslashPose188
+.4byte sSandslashPose189
+.4byte sSandslashPose190
+.4byte sSandslashPose191
+.4byte sSandslashPose192
+.4byte sSandslashPose193
+.4byte sSandslashPose194
+.4byte sSandslashPose195
+sAxPositionsSandslash:
+.2byte   -1,   -6, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -5, 	  -5,   -1, 	   7,   -3, 	  -1,   -8
+.2byte   -2,   -5, 	  -9,   -3, 	   3,   -1, 	  -1,   -8
+.2byte    3,   -6, 	   8,   -3, 	   0,   -1, 	  -2,  -10
+.2byte    2,   -4, 	   7,   -1, 	  -3,   -1, 	  -2,   -8
+.2byte    4,   -5, 	   8,   -4, 	   2,    0, 	  -1,   -9
+.2byte    8,   -9, 	   7,   -4, 	   5,   -2, 	  -2,   -9
+.2byte    8,   -7, 	   8,   -4, 	   3,   -1, 	  -2,   -8
+.2byte    9,   -8, 	   5,   -5, 	   7,   -3, 	   0,   -8
+.2byte    2,  -13, 	  -5,  -11, 	   9,   -7, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -11, 	   8,   -5, 	  -2,  -10
+.2byte    0,  -13, 	  -6,  -10, 	  10,  -10, 	  -2,  -11
+.2byte   -1,  -14, 	   8,  -11, 	 -10,  -11, 	  -1,  -10
+.2byte   -2,  -13, 	   5,  -12, 	  -9,   -8, 	  -1,  -10
+.2byte    1,  -13, 	   7,   -8, 	  -7,  -12, 	  -1,  -10
+.2byte   -4,  -12, 	   3,  -10, 	 -11,   -6, 	  -1,  -10
+.2byte   -3,  -11, 	   0,  -10, 	 -10,   -4, 	   0,   -9
+.2byte   -2,  -12, 	   4,   -9, 	 -12,   -9, 	   0,  -10
+.2byte  -10,   -8, 	  -9,   -3, 	  -7,   -1, 	   0,   -8
+.2byte  -10,   -6, 	 -10,   -3, 	  -5,    0, 	   0,   -7
+.2byte  -11,   -7, 	  -7,   -4, 	  -9,   -2, 	  -2,   -7
+.2byte   -5,   -5, 	 -10,   -2, 	  -2,    0, 	   0,   -9
+.2byte   -4,   -3, 	  -9,    0, 	   1,    0, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -3, 	  -4,    1, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -5, 	  -5,   -1, 	   7,   -3, 	  -1,   -8
+.2byte   -2,   -5, 	  -9,   -3, 	   3,   -1, 	  -1,   -8
+.2byte   -1,   -2, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte    3,   -6, 	   8,   -3, 	   0,   -1, 	  -2,  -10
+.2byte    2,   -4, 	   7,   -1, 	  -3,   -1, 	  -2,   -8
+.2byte    4,   -5, 	   8,   -4, 	   2,    0, 	  -1,   -9
+.2byte    1,   -3, 	   5,   -9, 	  -5,   -3, 	  -1,   -8
+.2byte    8,  -10, 	   7,   -5, 	   5,   -3, 	  -2,  -10
+.2byte    8,   -7, 	   8,   -4, 	   3,   -1, 	  -2,   -8
+.2byte    9,   -8, 	   5,   -5, 	   7,   -3, 	   0,   -8
+.2byte    2,   -4, 	   4,  -11, 	   3,   -3, 	  -1,   -8
+.2byte    2,  -13, 	  -5,  -11, 	   9,   -7, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -11, 	   8,   -5, 	  -2,  -10
+.2byte    0,  -13, 	  -6,  -10, 	  10,  -10, 	  -2,  -11
+.2byte    1,   -9, 	  -4,  -13, 	   5,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   8,  -12, 	 -10,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,   -8, 	  -1,  -10
+.2byte    1,  -13, 	   7,   -8, 	  -7,  -12, 	  -1,  -10
+.2byte   -1,  -10, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -4,  -13, 	   3,  -11, 	 -11,   -7, 	  -1,  -11
+.2byte   -3,  -11, 	   0,  -10, 	 -10,   -4, 	   0,   -9
+.2byte   -2,  -12, 	   4,   -9, 	 -12,   -9, 	   0,  -10
+.2byte   -3,   -9, 	   2,  -13, 	  -7,   -9, 	  -1,   -9
+.2byte  -10,  -10, 	  -9,   -5, 	  -7,   -3, 	   0,  -10
+.2byte  -10,   -6, 	 -10,   -3, 	  -5,    0, 	   0,   -7
+.2byte  -11,   -7, 	  -7,   -4, 	  -9,   -2, 	  -2,   -7
+.2byte   -4,   -4, 	  -6,  -11, 	  -5,   -3, 	  -1,   -8
+.2byte   -5,   -6, 	 -10,   -3, 	  -2,   -1, 	   0,  -10
+.2byte   -4,   -3, 	  -9,    0, 	   1,    0, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -3, 	  -4,    1, 	  -1,   -8
+.2byte   -3,   -3, 	  -7,   -9, 	   3,   -3, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -8, 	  -2,   -5, 	   8,  -20, 	  -1,   -9
+.2byte   -1,   -3, 	 -12,   -8, 	   0,    1, 	  -1,   -8
+.2byte   -1,   -3, 	 -12,   -8, 	   0,    1, 	  -1,   -8
+.2byte    3,   -6, 	   8,   -3, 	   0,   -1, 	  -2,  -10
+.2byte    1,  -10, 	   5,   -6, 	  -8,  -18, 	  -1,   -9
+.2byte    4,   -4, 	   9,   -9, 	   3,    2, 	   0,   -7
+.2byte    4,   -4, 	   9,   -9, 	   3,    2, 	   0,   -7
+.2byte    8,  -10, 	   7,   -5, 	   5,   -3, 	  -2,  -10
+.2byte    5,  -13, 	   4,   -7, 	  -9,  -17, 	  -1,  -10
+.2byte    8,   -8, 	   4,  -11, 	   9,   -4, 	   1,   -9
+.2byte    8,   -8, 	   4,  -11, 	   9,   -4, 	   1,   -9
+.2byte    2,  -13, 	  -5,  -11, 	   9,   -7, 	  -1,  -11
+.2byte    4,  -15, 	  -1,  -10, 	   4,  -18, 	  -3,  -12
+.2byte    5,  -10, 	  -6,  -15, 	   4,   -7, 	  -2,  -10
+.2byte    5,  -10, 	  -6,  -15, 	   4,   -7, 	  -2,  -10
+.2byte   -1,  -15, 	   8,  -12, 	 -10,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   3,  -16, 	 -10,  -20, 	   0,  -13
+.2byte    0,  -12, 	   8,   -7, 	   0,  -10, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	  -1,  -10, 	   0,  -11
+.2byte    0,  -12, 	   8,   -7, 	   0,  -10, 	  -1,  -11
+.2byte   -4,  -13, 	   3,  -11, 	 -11,   -7, 	  -1,  -11
+.2byte   -6,  -15, 	  -1,  -10, 	  -6,  -18, 	   1,  -12
+.2byte   -7,  -10, 	   4,  -15, 	  -6,   -7, 	   0,  -10
+.2byte   -7,  -10, 	   4,  -15, 	  -6,   -7, 	   0,  -10
+.2byte  -10,  -10, 	  -9,   -5, 	  -7,   -3, 	   0,  -10
+.2byte   -7,  -13, 	  -6,   -7, 	   7,  -17, 	  -1,  -10
+.2byte  -10,   -8, 	  -6,  -11, 	 -11,   -4, 	  -3,   -9
+.2byte  -10,   -8, 	  -6,  -11, 	 -11,   -4, 	  -3,   -9
+.2byte   -5,   -6, 	 -10,   -3, 	  -2,   -1, 	   0,  -10
+.2byte   -3,  -10, 	  -7,   -6, 	   6,  -18, 	  -1,   -9
+.2byte   -6,   -4, 	 -11,   -9, 	  -5,    2, 	  -2,   -7
+.2byte   -6,   -4, 	 -11,   -9, 	  -5,    2, 	  -2,   -7
+.2byte   -1,   -3, 	 -12,   -8, 	   0,    1, 	  -1,   -8
+.2byte   -5,   -5, 	 -10,  -10, 	  -4,    1, 	  -1,   -8
+.2byte   -8,   -7, 	  -4,  -10, 	  -9,   -3, 	  -1,   -8
+.2byte   -7,  -10, 	   4,  -15, 	  -6,   -7, 	   0,  -10
+.2byte    0,  -12, 	   8,   -7, 	   0,  -10, 	  -1,  -11
+.2byte    5,  -10, 	  -6,  -15, 	   4,   -7, 	  -2,  -10
+.2byte    6,   -7, 	   2,  -10, 	   7,   -3, 	  -1,   -8
+.2byte    3,   -5, 	   8,  -10, 	   2,    1, 	  -1,   -8
+.2byte   -1,   -2, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte    1,   -3, 	   5,   -9, 	  -5,   -3, 	  -1,   -8
+.2byte    3,   -4, 	   5,  -11, 	   4,   -3, 	   0,   -8
+.2byte    1,   -9, 	  -4,  -13, 	   5,   -9, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -3,   -9, 	   2,  -13, 	  -7,   -9, 	  -1,   -9
+.2byte   -5,   -4, 	  -7,  -11, 	  -6,   -3, 	  -2,   -8
+.2byte   -3,   -3, 	  -7,   -9, 	   3,   -3, 	  -1,   -8
+.2byte   -4,   -4, 	  -8,   -2, 	   1,    2, 	   0,   -9
+.2byte   -5,   -3, 	  -8,   -2, 	   1,    2, 	   0,   -8
+.2byte    0,   -6, 	  -2,  -13, 	   2,  -13, 	   0,  -11
+.2byte    3,   -5, 	   7,  -12, 	   0,  -10, 	  -1,  -13
+.2byte    3,   -7, 	   8,  -11, 	   4,  -11, 	  -1,  -11
+.2byte    2,  -11, 	  -1,  -14, 	   6,  -12, 	  -2,  -11
+.2byte    0,  -12, 	   8,  -11, 	  -8,  -11, 	   0,  -11
+.2byte   -3,  -11, 	   0,  -14, 	  -7,  -12, 	   1,  -11
+.2byte   -4,   -7, 	  -9,  -11, 	  -5,  -11, 	   0,  -11
+.2byte   -4,   -5, 	  -8,  -12, 	  -1,  -10, 	   0,  -13
+.2byte   -1,   -6, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -5, 	  -5,   -1, 	   7,   -3, 	  -1,   -8
+.2byte   -2,   -5, 	  -9,   -3, 	   3,   -1, 	  -1,   -8
+.2byte    3,   -6, 	   8,   -3, 	   0,   -1, 	  -2,  -10
+.2byte    2,   -4, 	   7,   -1, 	  -3,   -1, 	  -2,   -8
+.2byte    4,   -5, 	   8,   -4, 	   2,    0, 	  -1,   -9
+.2byte    8,   -9, 	   7,   -4, 	   5,   -2, 	  -2,   -9
+.2byte    8,   -7, 	   8,   -4, 	   3,   -1, 	  -2,   -8
+.2byte    9,   -8, 	   5,   -5, 	   7,   -3, 	   0,   -8
+.2byte    2,  -13, 	  -5,  -11, 	   9,   -7, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -11, 	   8,   -5, 	  -2,  -10
+.2byte    0,  -13, 	  -6,  -10, 	  10,  -10, 	  -2,  -11
+.2byte   -1,  -14, 	   8,  -11, 	 -10,  -11, 	  -1,  -10
+.2byte   -2,  -13, 	   5,  -12, 	  -9,   -8, 	  -1,  -10
+.2byte    1,  -13, 	   7,   -8, 	  -7,  -12, 	  -1,  -10
+.2byte   -4,  -12, 	   3,  -10, 	 -11,   -6, 	  -1,  -10
+.2byte   -3,  -11, 	   0,  -10, 	 -10,   -4, 	   0,   -9
+.2byte   -2,  -12, 	   4,   -9, 	 -12,   -9, 	   0,  -10
+.2byte  -10,   -8, 	  -9,   -3, 	  -7,   -1, 	   0,   -8
+.2byte  -10,   -6, 	 -10,   -3, 	  -5,    0, 	   0,   -7
+.2byte  -11,   -7, 	  -7,   -4, 	  -9,   -2, 	  -2,   -7
+.2byte   -5,   -5, 	 -10,   -2, 	  -2,    0, 	   0,   -9
+.2byte   -4,   -3, 	  -9,    0, 	   1,    0, 	   0,   -7
+.2byte   -6,   -4, 	 -10,   -3, 	  -4,    1, 	  -1,   -8
+.2byte   -1,   -2, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -3,   -3, 	  -7,   -9, 	   3,   -3, 	  -1,   -8
+.2byte   -4,   -4, 	  -6,  -11, 	  -5,   -3, 	  -1,   -8
+.2byte   -3,   -9, 	   2,  -13, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte    1,   -9, 	  -4,  -13, 	   5,   -9, 	  -1,   -9
+.2byte    2,   -4, 	   4,  -11, 	   3,   -3, 	  -1,   -8
+.2byte    1,   -3, 	   5,   -9, 	  -5,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	 -12,   -8, 	   0,    1, 	  -1,   -8
+.2byte    3,   -5, 	   8,  -10, 	   2,    1, 	  -1,   -8
+.2byte    6,   -7, 	   2,  -10, 	   7,   -3, 	  -1,   -8
+.2byte    5,  -10, 	  -6,  -15, 	   4,   -7, 	  -2,  -10
+.2byte    0,  -12, 	   8,   -7, 	   0,  -10, 	  -1,  -11
+.2byte   -7,  -10, 	   4,  -15, 	  -6,   -7, 	   0,  -10
+.2byte   -8,   -7, 	  -4,  -10, 	  -9,   -3, 	  -1,   -8
+.2byte   -5,   -5, 	 -10,  -10, 	  -4,    1, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -8, 	  -2,   -5, 	   8,  -20, 	  -1,   -9
+.2byte   -1,   -2, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte    3,   -6, 	   8,   -3, 	   0,   -1, 	  -2,  -10
+.2byte    1,  -10, 	   5,   -6, 	  -8,  -18, 	  -1,   -9
+.2byte    1,   -3, 	   5,   -9, 	  -5,   -3, 	  -1,   -8
+.2byte    8,  -10, 	   7,   -5, 	   5,   -3, 	  -2,  -10
+.2byte    5,  -13, 	   4,   -7, 	  -9,  -17, 	  -1,  -10
+.2byte    1,   -4, 	   3,  -11, 	   2,   -3, 	  -2,   -8
+.2byte    2,  -13, 	  -5,  -11, 	   9,   -7, 	  -1,  -11
+.2byte    5,  -15, 	   0,  -10, 	   5,  -18, 	  -2,  -12
+.2byte    1,   -9, 	  -4,  -13, 	   5,   -9, 	  -1,   -9
+.2byte   -1,  -15, 	   8,  -12, 	 -10,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	   3,  -16, 	 -10,  -20, 	   0,  -13
+.2byte   -1,  -10, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -4,  -13, 	   3,  -11, 	 -11,   -7, 	  -1,  -11
+.2byte   -7,  -15, 	  -2,  -10, 	  -7,  -18, 	   0,  -12
+.2byte   -3,   -9, 	   2,  -13, 	  -7,   -9, 	  -1,   -9
+.2byte  -10,  -10, 	  -9,   -5, 	  -7,   -3, 	   0,  -10
+.2byte   -7,  -13, 	  -6,   -7, 	   7,  -17, 	  -1,  -10
+.2byte   -3,   -4, 	  -5,  -11, 	  -4,   -3, 	   0,   -8
+.2byte   -5,   -6, 	 -10,   -3, 	  -2,   -1, 	   0,  -10
+.2byte   -3,  -10, 	  -7,   -6, 	   6,  -18, 	  -1,   -9
+.2byte   -3,   -3, 	  -7,   -9, 	   3,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	 -12,   -8, 	   0,    1, 	  -1,   -8
+.2byte   -5,   -5, 	 -10,  -10, 	  -4,    1, 	  -1,   -8
+.2byte   -8,   -7, 	  -4,  -10, 	  -9,   -3, 	  -1,   -8
+.2byte   -7,  -10, 	   4,  -15, 	  -6,   -7, 	   0,  -10
+.2byte    0,  -12, 	   8,   -7, 	   0,  -10, 	  -1,  -11
+.2byte    5,  -10, 	  -6,  -15, 	   4,   -7, 	  -2,  -10
+.2byte    6,   -7, 	   2,  -10, 	   7,   -3, 	  -1,   -8
+.2byte    3,   -5, 	   8,  -10, 	   2,    1, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte   -5,   -6, 	 -10,   -3, 	  -2,   -1, 	   0,  -10
+.2byte  -10,  -10, 	  -9,   -5, 	  -7,   -3, 	   0,  -10
+.2byte   -4,  -13, 	   3,  -11, 	 -11,   -7, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -12, 	 -10,  -12, 	  -1,  -11
+.2byte    2,  -13, 	  -5,  -11, 	   9,   -7, 	  -1,  -11
+.2byte    8,  -10, 	   7,   -5, 	   5,   -3, 	  -2,  -10
+.2byte    3,   -6, 	   8,   -3, 	   0,   -1, 	  -2,  -10
+sSandslashAnimTable1:
+.4byte sSandslashAnims_1_1
+.4byte sSandslashAnims_1_2
+.4byte sSandslashAnims_1_3
+.4byte sSandslashAnims_1_4
+.4byte sSandslashAnims_1_5
+.4byte sSandslashAnims_1_6
+.4byte sSandslashAnims_1_7
+.4byte sSandslashAnims_1_8
+sSandslashAnimTable2:
+.4byte sSandslashAnims_2_1
+.4byte sSandslashAnims_2_2
+.4byte sSandslashAnims_2_3
+.4byte sSandslashAnims_2_4
+.4byte sSandslashAnims_2_5
+.4byte sSandslashAnims_2_6
+.4byte sSandslashAnims_2_7
+.4byte sSandslashAnims_2_8
+sSandslashAnimTable3:
+.4byte sSandslashAnims_3_1
+.4byte sSandslashAnims_3_2
+.4byte sSandslashAnims_3_3
+.4byte sSandslashAnims_3_4
+.4byte sSandslashAnims_3_5
+.4byte sSandslashAnims_3_6
+.4byte sSandslashAnims_3_7
+.4byte sSandslashAnims_3_8
+sSandslashAnimTable4:
+.4byte sSandslashAnims_4_1
+.4byte sSandslashAnims_4_2
+.4byte sSandslashAnims_4_3
+.4byte sSandslashAnims_4_4
+.4byte sSandslashAnims_4_5
+.4byte sSandslashAnims_4_6
+.4byte sSandslashAnims_4_7
+.4byte sSandslashAnims_4_8
+sSandslashAnimTable5:
+.4byte sSandslashAnims_5_1
+.4byte sSandslashAnims_5_2
+.4byte sSandslashAnims_5_3
+.4byte sSandslashAnims_5_4
+.4byte sSandslashAnims_5_5
+.4byte sSandslashAnims_5_6
+.4byte sSandslashAnims_5_7
+.4byte sSandslashAnims_5_8
+sSandslashAnimTable6:
+.4byte sSandslashAnims_6_1
+.4byte sSandslashAnims_6_1
+.4byte sSandslashAnims_6_1
+.4byte sSandslashAnims_6_1
+.4byte sSandslashAnims_6_1
+.4byte sSandslashAnims_6_1
+.4byte sSandslashAnims_6_1
+.4byte sSandslashAnims_6_1
+sSandslashAnimTable7:
+.4byte sSandslashAnims_7_1
+.4byte sSandslashAnims_7_2
+.4byte sSandslashAnims_7_3
+.4byte sSandslashAnims_7_4
+.4byte sSandslashAnims_7_5
+.4byte sSandslashAnims_7_6
+.4byte sSandslashAnims_7_7
+.4byte sSandslashAnims_7_8
+sSandslashAnimTable8:
+.4byte sSandslashAnims_8_1
+.4byte sSandslashAnims_8_2
+.4byte sSandslashAnims_8_3
+.4byte sSandslashAnims_8_4
+.4byte sSandslashAnims_8_5
+.4byte sSandslashAnims_8_6
+.4byte sSandslashAnims_8_7
+.4byte sSandslashAnims_8_8
+sSandslashAnimTable9:
+.4byte sSandslashAnims_9_1
+.4byte sSandslashAnims_9_2
+.4byte sSandslashAnims_9_3
+.4byte sSandslashAnims_9_4
+.4byte sSandslashAnims_9_5
+.4byte sSandslashAnims_9_6
+.4byte sSandslashAnims_9_7
+.4byte sSandslashAnims_9_8
+sSandslashAnimTable10:
+.4byte sSandslashAnims_10_1
+.4byte sSandslashAnims_10_2
+.4byte sSandslashAnims_10_3
+.4byte sSandslashAnims_10_4
+.4byte sSandslashAnims_10_5
+.4byte sSandslashAnims_10_6
+.4byte sSandslashAnims_10_7
+.4byte sSandslashAnims_10_8
+sSandslashAnimTable11:
+.4byte sSandslashAnims_11_1
+.4byte sSandslashAnims_11_2
+.4byte sSandslashAnims_11_3
+.4byte sSandslashAnims_11_4
+.4byte sSandslashAnims_11_5
+.4byte sSandslashAnims_11_6
+.4byte sSandslashAnims_11_7
+.4byte sSandslashAnims_11_8
+sSandslashAnimTable12:
+.4byte sSandslashAnims_12_1
+.4byte sSandslashAnims_12_2
+.4byte sSandslashAnims_12_3
+.4byte sSandslashAnims_12_4
+.4byte sSandslashAnims_12_5
+.4byte sSandslashAnims_12_6
+.4byte sSandslashAnims_12_7
+.4byte sSandslashAnims_12_8
+sSandslashAnimTable13:
+.4byte sSandslashAnims_13_1
+.4byte sSandslashAnims_13_2
+.4byte sSandslashAnims_13_3
+.4byte sSandslashAnims_13_4
+.4byte sSandslashAnims_13_5
+.4byte sSandslashAnims_13_6
+.4byte sSandslashAnims_13_7
+.4byte sSandslashAnims_13_8
+sAxAnimationsSandslash:
+.4byte sSandslashAnimTable1
+.4byte sSandslashAnimTable2
+.4byte sSandslashAnimTable3
+.4byte sSandslashAnimTable4
+.4byte sSandslashAnimTable5
+.4byte sSandslashAnimTable6
+.4byte sSandslashAnimTable7
+.4byte sSandslashAnimTable8
+.4byte sSandslashAnimTable9
+.4byte sSandslashAnimTable10
+.4byte sSandslashAnimTable11
+.4byte sSandslashAnimTable12
+.4byte sSandslashAnimTable13
+sAxSpritesSandslash:
+.4byte sSandslashSprites1
+.4byte sSandslashSprites2
+.4byte sSandslashSprites3
+.4byte sSandslashSprites4
+.4byte sSandslashSprites5
+.4byte sSandslashSprites6
+.4byte sSandslashSprites7
+.4byte sSandslashSprites8
+.4byte sSandslashSprites9
+.4byte sSandslashSprites10
+.4byte sSandslashSprites11
+.4byte sSandslashSprites12
+.4byte sSandslashSprites13
+.4byte sSandslashSprites14
+.4byte sSandslashSprites15
+.4byte sSandslashSprites16
+.4byte sSandslashSprites17
+.4byte sSandslashSprites18
+.4byte sSandslashSprites19
+.4byte sSandslashSprites20
+.4byte sSandslashSprites21
+.4byte sSandslashSprites22
+.4byte sSandslashSprites23
+.4byte sSandslashSprites24
+.4byte sSandslashSprites25
+.4byte sSandslashSprites26
+.4byte sSandslashSprites27
+.4byte sSandslashSprites28
+.4byte sSandslashSprites29
+.4byte sSandslashSprites30
+.4byte sSandslashSprites31
+.4byte sSandslashSprites32
+.4byte sSandslashSprites33
+.4byte sSandslashSprites34
+.4byte sSandslashSprites35
+.4byte sSandslashSprites36
+.4byte sSandslashSprites37
+.4byte sSandslashSprites38
+.4byte sSandslashSprites39
+.4byte sSandslashSprites40
+.4byte sSandslashSprites41
+.4byte sSandslashSprites42
+sAxMainSandslash:
+ax_main sAxPosesSandslash, sAxAnimationsSandslash, 13, sAxSpritesSandslash, sAxPositionsSandslash

--- a/data/ax/sceptile.inc
+++ b/data/ax/sceptile.inc
@@ -1,0 +1,2949 @@
+.global gAxSceptile
+gAxSceptile:
+ax_siro sAxMainSceptile
+sSceptilePose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose4:
+ax_pose 3, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose5:
+ax_pose 4, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose6:
+ax_pose 5, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose7:
+ax_pose 6, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose8:
+ax_pose 7, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose9:
+ax_pose 8, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose10:
+ax_pose 9, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose11:
+ax_pose 10, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose12:
+ax_pose 11, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose13:
+ax_pose 12, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose14:
+ax_pose 13, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose15:
+ax_pose 14, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose19:
+ax_pose 6, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose26:
+ax_pose 1, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose27:
+ax_pose 2, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose28:
+ax_pose 15, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose29:
+ax_pose 3, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose30:
+ax_pose 4, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose31:
+ax_pose 5, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose32:
+ax_pose 16, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose33:
+ax_pose 6, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose34:
+ax_pose 7, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose35:
+ax_pose 8, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose36:
+ax_pose 17, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSceptilePose37:
+ax_pose 9, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose38:
+ax_pose 10, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose39:
+ax_pose 11, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose40:
+ax_pose 18, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose41:
+ax_pose 12, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose42:
+ax_pose 13, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose43:
+ax_pose 14, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose44:
+ax_pose 19, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sSceptilePose45:
+ax_pose 9, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose46:
+ax_pose 10, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose47:
+ax_pose 11, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose48:
+ax_pose 18, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose49:
+ax_pose 6, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose50:
+ax_pose 7, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose51:
+ax_pose 8, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose52:
+ax_pose 17, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose53:
+ax_pose 3, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose54:
+ax_pose 4, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose55:
+ax_pose 5, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose56:
+ax_pose 16, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose57:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose58:
+ax_pose 15, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose59:
+ax_pose 20, 0x81df, 0x8102, 0x3c00
+ax_pose 21, 0x01df, 0x80f3, 0x3c08
+ax_pose_terminator
+sSceptilePose60:
+ax_pose 21, 0x01df, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose61:
+ax_pose 1, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose62:
+ax_pose 3, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sSceptilePose63:
+ax_pose 16, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose64:
+ax_pose 22, 0x81de, 0x90fc, 0x3c00
+ax_pose 23, 0x01e0, 0x90ef, 0x3c08
+ax_pose_terminator
+sSceptilePose65:
+ax_pose 23, 0x01e0, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose66:
+ax_pose 4, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose67:
+ax_pose 6, 0x01e6, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose68:
+ax_pose 17, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose69:
+ax_pose 24, 0x81dc, 0x9100, 0x3c00
+ax_pose 25, 0x01df, 0x90f0, 0x3c08
+ax_pose_terminator
+sSceptilePose70:
+ax_pose 25, 0x01e0, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose71:
+ax_pose 7, 0x01e6, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose72:
+ax_pose 9, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose73:
+ax_pose 18, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose74:
+ax_pose 26, 0x81dd, 0x9101, 0x3c00
+ax_pose 27, 0x01e3, 0x90ee, 0x3c08
+ax_pose_terminator
+sSceptilePose75:
+ax_pose 27, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sSceptilePose76:
+ax_pose 10, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose77:
+ax_pose 12, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose78:
+ax_pose 19, 0x01e7, 0x80ef, 0x3c00
+ax_pose_terminator
+sSceptilePose79:
+ax_pose 28, 0x81dc, 0x80f1, 0x3c00
+ax_pose 29, 0x81e5, 0x80f4, 0x3c08
+ax_pose 30, 0x01dd, 0x00f7, 0x3c10
+ax_pose 31, 0x01dd, 0x00ff, 0x3c11
+ax_pose 32, 0x81e5, 0x4104, 0x3c12
+ax_pose_terminator
+sSceptilePose80:
+ax_pose 29, 0x81e5, 0x80f4, 0x3c00
+ax_pose 30, 0x01dd, 0x00f7, 0x3c08
+ax_pose 31, 0x01dd, 0x00ff, 0x3c09
+ax_pose 32, 0x81e5, 0x4104, 0x3c0a
+ax_pose_terminator
+sSceptilePose81:
+ax_pose 28, 0x81dc, 0x90ff, 0x3c00
+ax_pose 29, 0x81e5, 0x90fc, 0x3c08
+ax_pose 30, 0x01dd, 0x1101, 0x3c10
+ax_pose 31, 0x01dd, 0x10f9, 0x3c11
+ax_pose 32, 0x81e5, 0x50f4, 0x3c12
+ax_pose_terminator
+sSceptilePose82:
+ax_pose 29, 0x81e5, 0x90fc, 0x3c00
+ax_pose 30, 0x01dd, 0x1101, 0x3c08
+ax_pose 31, 0x01dd, 0x10f9, 0x3c09
+ax_pose 32, 0x81e5, 0x50f4, 0x3c0a
+ax_pose_terminator
+sSceptilePose83:
+ax_pose 9, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose84:
+ax_pose 18, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose85:
+ax_pose 26, 0x81de, 0x80ee, 0x3c00
+ax_pose 27, 0x01e4, 0x80f1, 0x3c08
+ax_pose_terminator
+sSceptilePose86:
+ax_pose 27, 0x01e4, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose87:
+ax_pose 6, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose88:
+ax_pose 17, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose89:
+ax_pose 24, 0x81dc, 0x80f0, 0x3c00
+ax_pose 25, 0x01df, 0x80f0, 0x3c08
+ax_pose_terminator
+sSceptilePose90:
+ax_pose 25, 0x01e0, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose91:
+ax_pose 3, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose92:
+ax_pose 16, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose93:
+ax_pose 22, 0x81de, 0x80f4, 0x3c00
+ax_pose 23, 0x01e0, 0x80f1, 0x3c08
+ax_pose_terminator
+sSceptilePose94:
+ax_pose 23, 0x01e0, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose95:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose96:
+ax_pose 33, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose97:
+ax_pose 34, 0x41ea, 0x40f3, 0x3c00
+ax_pose 35, 0x41f2, 0x80f3, 0x3c04
+ax_pose 36, 0x01ea, 0x00eb, 0x3c0c
+ax_pose 37, 0x01f2, 0x00eb, 0x3c0d
+ax_pose_terminator
+sSceptilePose98:
+ax_pose 3, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sSceptilePose99:
+ax_pose 38, 0x81e5, 0x90f1, 0x3c00
+ax_pose 39, 0x81e5, 0x5101, 0x3c08
+ax_pose 40, 0x01dd, 0x10fb, 0x3c0c
+ax_pose_terminator
+sSceptilePose100:
+ax_pose 41, 0x41ea, 0x50ee, 0x3c00
+ax_pose 42, 0x41f2, 0x90ee, 0x3c04
+ax_pose 43, 0x01ec, 0x110e, 0x3c0c
+ax_pose_terminator
+sSceptilePose101:
+ax_pose 6, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose102:
+ax_pose 44, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose103:
+ax_pose 45, 0x41eb, 0x50ec, 0x3c00
+ax_pose 46, 0x41f3, 0x90ec, 0x3c04
+ax_pose 47, 0x01f3, 0x110c, 0x3c0c
+ax_pose 48, 0x01fb, 0x110c, 0x3c0d
+ax_pose_terminator
+sSceptilePose104:
+ax_pose 9, 0x01e7, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose105:
+ax_pose 49, 0x81e6, 0x9100, 0x3c00
+ax_pose 50, 0x81e6, 0x50f8, 0x3c08
+ax_pose 51, 0x81f6, 0x10f0, 0x3c0c
+ax_pose 52, 0x01de, 0x1100, 0x3c0e
+ax_pose 53, 0x01de, 0x10f8, 0x3c0f
+ax_pose_terminator
+sSceptilePose106:
+ax_pose 54, 0x81e5, 0x90ff, 0x3c00
+ax_pose 55, 0x81e5, 0x50f7, 0x3c08
+ax_pose 56, 0x81ed, 0x110f, 0x3c0c
+ax_pose 57, 0x81f5, 0x10ef, 0x3c0e
+ax_pose_terminator
+sSceptilePose107:
+ax_pose 12, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose108:
+ax_pose 58, 0x81e5, 0x80fe, 0x3c00
+ax_pose 59, 0x81e5, 0x40f6, 0x3c08
+ax_pose 60, 0x81e5, 0x00ee, 0x3c0c
+ax_pose 61, 0x01dd, 0x00f6, 0x3c0e
+ax_pose 62, 0x01dd, 0x00fe, 0x3c0f
+ax_pose_terminator
+sSceptilePose109:
+ax_pose 63, 0x81e5, 0x80fe, 0x3c00
+ax_pose 64, 0x81e5, 0x40f6, 0x3c08
+ax_pose 65, 0x01ed, 0x00ee, 0x3c0c
+ax_pose 66, 0x01ed, 0x010e, 0x3c0d
+ax_pose_terminator
+sSceptilePose110:
+ax_pose 9, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose111:
+ax_pose 49, 0x81e6, 0x80f0, 0x3c00
+ax_pose 50, 0x81e6, 0x4100, 0x3c08
+ax_pose 51, 0x81f6, 0x0108, 0x3c0c
+ax_pose 52, 0x01de, 0x00f8, 0x3c0e
+ax_pose 53, 0x01de, 0x0100, 0x3c0f
+ax_pose_terminator
+sSceptilePose112:
+ax_pose 54, 0x81e5, 0x80f1, 0x3c00
+ax_pose 55, 0x81e5, 0x4101, 0x3c08
+ax_pose 56, 0x81ed, 0x00e9, 0x3c0c
+ax_pose 57, 0x81f5, 0x0109, 0x3c0e
+ax_pose_terminator
+sSceptilePose113:
+ax_pose 6, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose114:
+ax_pose 44, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose115:
+ax_pose 45, 0x41eb, 0x40f4, 0x3c00
+ax_pose 46, 0x41f3, 0x80f4, 0x3c04
+ax_pose 47, 0x01f3, 0x00ec, 0x3c0c
+ax_pose 48, 0x01fb, 0x00ec, 0x3c0d
+ax_pose_terminator
+sSceptilePose116:
+ax_pose 3, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose117:
+ax_pose 38, 0x81e5, 0x80ff, 0x3c00
+ax_pose 39, 0x81e5, 0x40f7, 0x3c08
+ax_pose 40, 0x01dd, 0x00fd, 0x3c0c
+ax_pose_terminator
+sSceptilePose118:
+ax_pose 41, 0x41ea, 0x40f2, 0x3c00
+ax_pose 42, 0x41f2, 0x80f2, 0x3c04
+ax_pose 43, 0x01ec, 0x00ea, 0x3c0c
+ax_pose_terminator
+sSceptilePose119:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose120:
+ax_pose 3, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose121:
+ax_pose 6, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose122:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose123:
+ax_pose 12, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose124:
+ax_pose 9, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose125:
+ax_pose 6, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose126:
+ax_pose 3, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose127:
+ax_pose 67, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose128:
+ax_pose 68, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose129:
+ax_pose 69, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose130:
+ax_pose 70, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sSceptilePose131:
+ax_pose 71, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sSceptilePose132:
+ax_pose 72, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sSceptilePose133:
+ax_pose 73, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose134:
+ax_pose 72, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose135:
+ax_pose 71, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sSceptilePose136:
+ax_pose 70, 0x01e2, 0x80f5, 0x3c00
+ax_pose_terminator
+sSceptilePose137:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose138:
+ax_pose 74, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose139:
+ax_pose 3, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose140:
+ax_pose 75, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose141:
+ax_pose 6, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose142:
+ax_pose 76, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose143:
+ax_pose 9, 0x01e7, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose144:
+ax_pose 77, 0x01e7, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose145:
+ax_pose 12, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose146:
+ax_pose 78, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose147:
+ax_pose 9, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose148:
+ax_pose 77, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose149:
+ax_pose 6, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose150:
+ax_pose 76, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose151:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose152:
+ax_pose 75, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose153:
+ax_pose 34, 0x41ea, 0x40f3, 0x3c00
+ax_pose 35, 0x41f2, 0x80f3, 0x3c04
+ax_pose 36, 0x01ea, 0x00eb, 0x3c0c
+ax_pose 37, 0x01f2, 0x00eb, 0x3c0d
+ax_pose_terminator
+sSceptilePose154:
+ax_pose 41, 0x41ea, 0x40f2, 0x3c00
+ax_pose 42, 0x41f2, 0x80f2, 0x3c04
+ax_pose 43, 0x01ec, 0x00ea, 0x3c0c
+ax_pose_terminator
+sSceptilePose155:
+ax_pose 45, 0x41ea, 0x40f6, 0x3c00
+ax_pose 46, 0x41f2, 0x80f6, 0x3c04
+ax_pose 47, 0x01f2, 0x00ee, 0x3c0c
+ax_pose 48, 0x01fa, 0x00ee, 0x3c0d
+ax_pose_terminator
+sSceptilePose156:
+ax_pose 54, 0x81e5, 0x80f5, 0x3c00
+ax_pose 55, 0x81e5, 0x4105, 0x3c08
+ax_pose 56, 0x81ed, 0x00ed, 0x3c0c
+ax_pose 57, 0x81f5, 0x010d, 0x3c0e
+ax_pose_terminator
+sSceptilePose157:
+ax_pose 63, 0x81ea, 0x80fe, 0x3c00
+ax_pose 64, 0x81ea, 0x40f6, 0x3c08
+ax_pose 65, 0x01f2, 0x00ee, 0x3c0c
+ax_pose 66, 0x01f2, 0x010e, 0x3c0d
+ax_pose_terminator
+sSceptilePose158:
+ax_pose 54, 0x81e5, 0x90fb, 0x3c00
+ax_pose 55, 0x81e5, 0x50f3, 0x3c08
+ax_pose 56, 0x81ed, 0x110b, 0x3c0c
+ax_pose 57, 0x81f5, 0x10eb, 0x3c0e
+ax_pose_terminator
+sSceptilePose159:
+ax_pose 45, 0x41ea, 0x50ea, 0x3c00
+ax_pose 46, 0x41f2, 0x90ea, 0x3c04
+ax_pose 47, 0x01f2, 0x110a, 0x3c0c
+ax_pose 48, 0x01fa, 0x110a, 0x3c0d
+ax_pose_terminator
+sSceptilePose160:
+ax_pose 41, 0x41ea, 0x50ee, 0x3c00
+ax_pose 42, 0x41f2, 0x90ee, 0x3c04
+ax_pose 43, 0x01ec, 0x110e, 0x3c0c
+ax_pose_terminator
+sSceptilePose161:
+ax_pose 15, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose162:
+ax_pose 16, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose163:
+ax_pose 17, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose164:
+ax_pose 18, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose165:
+ax_pose 19, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sSceptilePose166:
+ax_pose 18, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose167:
+ax_pose 17, 0x01e4, 0x80ef, 0x3c00
+ax_pose_terminator
+sSceptilePose168:
+ax_pose 16, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose169:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose170:
+ax_pose 33, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose171:
+ax_pose 34, 0x41ea, 0x40f3, 0x3c00
+ax_pose 35, 0x41f2, 0x80f3, 0x3c04
+ax_pose 36, 0x01ea, 0x00eb, 0x3c0c
+ax_pose 37, 0x01f2, 0x00eb, 0x3c0d
+ax_pose_terminator
+sSceptilePose172:
+ax_pose 3, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sSceptilePose173:
+ax_pose 38, 0x81e6, 0x90f1, 0x3c00
+ax_pose 39, 0x81e6, 0x5101, 0x3c08
+ax_pose 40, 0x01de, 0x10fb, 0x3c0c
+ax_pose_terminator
+sSceptilePose174:
+ax_pose 41, 0x41ea, 0x50ed, 0x3c00
+ax_pose 42, 0x41f2, 0x90ed, 0x3c04
+ax_pose 43, 0x01ec, 0x110d, 0x3c0c
+ax_pose_terminator
+sSceptilePose175:
+ax_pose 6, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose176:
+ax_pose 44, 0x01e3, 0x90ef, 0x3c00
+ax_pose_terminator
+sSceptilePose177:
+ax_pose 45, 0x41eb, 0x50ec, 0x3c00
+ax_pose 46, 0x41f3, 0x90ec, 0x3c04
+ax_pose 47, 0x01f3, 0x110c, 0x3c0c
+ax_pose 48, 0x01fb, 0x110c, 0x3c0d
+ax_pose_terminator
+sSceptilePose178:
+ax_pose 9, 0x01e7, 0x90f0, 0x3c00
+ax_pose_terminator
+sSceptilePose179:
+ax_pose 49, 0x81e6, 0x90ff, 0x3c00
+ax_pose 50, 0x81e6, 0x50f7, 0x3c08
+ax_pose 51, 0x81f6, 0x10ef, 0x3c0c
+ax_pose 52, 0x01de, 0x10ff, 0x3c0e
+ax_pose 53, 0x01de, 0x10f7, 0x3c0f
+ax_pose_terminator
+sSceptilePose180:
+ax_pose 54, 0x81e5, 0x90fd, 0x3c00
+ax_pose 55, 0x81e5, 0x50f5, 0x3c08
+ax_pose 56, 0x81ed, 0x110d, 0x3c0c
+ax_pose 57, 0x81f5, 0x10ed, 0x3c0e
+ax_pose_terminator
+sSceptilePose181:
+ax_pose 12, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sSceptilePose182:
+ax_pose 58, 0x81e7, 0x80fd, 0x3c00
+ax_pose 59, 0x81e7, 0x40f5, 0x3c08
+ax_pose 60, 0x81e7, 0x00ed, 0x3c0c
+ax_pose 61, 0x01df, 0x00f5, 0x3c0e
+ax_pose 62, 0x01df, 0x00fd, 0x3c0f
+ax_pose_terminator
+sSceptilePose183:
+ax_pose 63, 0x81e5, 0x80fe, 0x3c00
+ax_pose 64, 0x81e5, 0x40f6, 0x3c08
+ax_pose 65, 0x01ed, 0x00ee, 0x3c0c
+ax_pose 66, 0x01ed, 0x010e, 0x3c0d
+ax_pose_terminator
+sSceptilePose184:
+ax_pose 9, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose185:
+ax_pose 49, 0x81e6, 0x80f1, 0x3c00
+ax_pose 50, 0x81e6, 0x4101, 0x3c08
+ax_pose 51, 0x81f6, 0x0109, 0x3c0c
+ax_pose 52, 0x01de, 0x00f9, 0x3c0e
+ax_pose 53, 0x01de, 0x0101, 0x3c0f
+ax_pose_terminator
+sSceptilePose186:
+ax_pose 54, 0x81e5, 0x80f3, 0x3c00
+ax_pose 55, 0x81e5, 0x4103, 0x3c08
+ax_pose 56, 0x81ed, 0x00eb, 0x3c0c
+ax_pose 57, 0x81f5, 0x010b, 0x3c0e
+ax_pose_terminator
+sSceptilePose187:
+ax_pose 6, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose188:
+ax_pose 44, 0x01e3, 0x80f1, 0x3c00
+ax_pose_terminator
+sSceptilePose189:
+ax_pose 45, 0x41eb, 0x40f4, 0x3c00
+ax_pose 46, 0x41f3, 0x80f4, 0x3c04
+ax_pose 47, 0x01f3, 0x00ec, 0x3c0c
+ax_pose 48, 0x01fb, 0x00ec, 0x3c0d
+ax_pose_terminator
+sSceptilePose190:
+ax_pose 3, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSceptilePose191:
+ax_pose 38, 0x81e6, 0x80ff, 0x3c00
+ax_pose 39, 0x81e6, 0x40f7, 0x3c08
+ax_pose 40, 0x01de, 0x00fd, 0x3c0c
+ax_pose_terminator
+sSceptilePose192:
+ax_pose 41, 0x41ea, 0x40f3, 0x3c00
+ax_pose 42, 0x41f2, 0x80f3, 0x3c04
+ax_pose 43, 0x01ec, 0x00eb, 0x3c0c
+ax_pose_terminator
+sSceptilePose193:
+ax_pose 34, 0x41ea, 0x40f3, 0x3c00
+ax_pose 35, 0x41f2, 0x80f3, 0x3c04
+ax_pose 36, 0x01ea, 0x00eb, 0x3c0c
+ax_pose 37, 0x01f2, 0x00eb, 0x3c0d
+ax_pose_terminator
+sSceptilePose194:
+ax_pose 41, 0x41ea, 0x40f2, 0x3c00
+ax_pose 42, 0x41f2, 0x80f2, 0x3c04
+ax_pose 43, 0x01ec, 0x00ea, 0x3c0c
+ax_pose_terminator
+sSceptilePose195:
+ax_pose 45, 0x41ea, 0x40f6, 0x3c00
+ax_pose 46, 0x41f2, 0x80f6, 0x3c04
+ax_pose 47, 0x01f2, 0x00ee, 0x3c0c
+ax_pose 48, 0x01fa, 0x00ee, 0x3c0d
+ax_pose_terminator
+sSceptilePose196:
+ax_pose 54, 0x81e5, 0x80f5, 0x3c00
+ax_pose 55, 0x81e5, 0x4105, 0x3c08
+ax_pose 56, 0x81ed, 0x00ed, 0x3c0c
+ax_pose 57, 0x81f5, 0x010d, 0x3c0e
+ax_pose_terminator
+sSceptilePose197:
+ax_pose 63, 0x81e6, 0x80fe, 0x3c00
+ax_pose 64, 0x81e6, 0x40f6, 0x3c08
+ax_pose 65, 0x01ee, 0x00ee, 0x3c0c
+ax_pose 66, 0x01ee, 0x010e, 0x3c0d
+ax_pose_terminator
+sSceptilePose198:
+ax_pose 54, 0x81e5, 0x90fb, 0x3c00
+ax_pose 55, 0x81e5, 0x50f3, 0x3c08
+ax_pose 56, 0x81ed, 0x110b, 0x3c0c
+ax_pose 57, 0x81f5, 0x10eb, 0x3c0e
+ax_pose_terminator
+sSceptilePose199:
+ax_pose 45, 0x41ea, 0x50ea, 0x3c00
+ax_pose 46, 0x41f2, 0x90ea, 0x3c04
+ax_pose 47, 0x01f2, 0x110a, 0x3c0c
+ax_pose 48, 0x01fa, 0x110a, 0x3c0d
+ax_pose_terminator
+sSceptilePose200:
+ax_pose 41, 0x41ea, 0x50ee, 0x3c00
+ax_pose 42, 0x41f2, 0x90ee, 0x3c04
+ax_pose 43, 0x01ec, 0x110e, 0x3c0c
+ax_pose_terminator
+sSceptilePose201:
+ax_pose 0, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose202:
+ax_pose 3, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose203:
+ax_pose 6, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose204:
+ax_pose 9, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sSceptilePose205:
+ax_pose 12, 0x01e6, 0x80f4, 0x3c00
+ax_pose_terminator
+sSceptilePose206:
+ax_pose 9, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose207:
+ax_pose 6, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sSceptilePose208:
+ax_pose 3, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+.align 2
+sSceptileAnims_1_1:
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_1_2:
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_1_3:
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_1_4:
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_1_5:
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_1_6:
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_1_7:
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_1_8:
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_2_1:
+ax_anim 2, 0, 54, 0, -1, 0, -1,
+ax_anim 6, 0, 54, 0, -2, 0, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSceptileAnims_2_2:
+ax_anim 2, 0, 26, -1, -1, -1, -1,
+ax_anim 6, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 5, 5, 5, 5,
+ax_anim 1, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 20, 22, 20, 22,
+ax_anim 2, 1, 31, 21, 21, 21, 21,
+ax_anim 2, 0, 31, 20, 22, 20, 22,
+ax_anim 2, 0, 31, 21, 21, 21, 21,
+ax_anim 2, 0, 28, 6, 8, 6, 8,
+ax_anim_terminator
+sSceptileAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 6, 0, 6, 0,
+ax_anim 1, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 22, 0, 22, 0,
+ax_anim 2, 1, 35, 22, 1, 22, 1,
+ax_anim 2, 0, 35, 22, 0, 22, 0,
+ax_anim 2, 0, 35, 22, 1, 22, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSceptileAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 38, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 12, -17, 12, -17,
+ax_anim 2, 0, 39, 18, -24, 18, -24,
+ax_anim 2, 1, 39, 19, -23, 19, -23,
+ax_anim 2, 0, 39, 18, -24, 18, -24,
+ax_anim 2, 0, 39, 19, -23, 19, -23,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sSceptileAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -2, 0, -2,
+ax_anim 1, 0, 43, 0, -13, 0, -13,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sSceptileAnims_2_6:
+ax_anim 2, 0, 42, 1, 1, 1, 1,
+ax_anim 6, 0, 42, 2, 2, 2, 2,
+ax_anim 1, 0, 42, 0, -1, 0, -1,
+ax_anim 1, 2, 46, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -10, -16, -10, -13,
+ax_anim 2, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 1, 47, -19, -22, -19, -22,
+ax_anim 2, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 0, 47, -19, -22, -19, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sSceptileAnims_2_7:
+ax_anim 2, 0, 46, 1, 0, 1, 0,
+ax_anim 6, 0, 46, 2, 0, 2, 0,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -22, 0, -22, 0,
+ax_anim 2, 1, 51, -22, 1, -22, 1,
+ax_anim 2, 0, 51, -22, 0, -22, 0,
+ax_anim 2, 0, 51, -22, 1, -22, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sSceptileAnims_2_8:
+ax_anim 2, 0, 26, 1, -1, 1, -1,
+ax_anim 6, 0, 26, 2, -2, 2, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 5, -4, 5,
+ax_anim 1, 0, 55, -12, 14, -12, 14,
+ax_anim 2, 0, 55, -16, 22, -16, 22,
+ax_anim 2, 1, 55, -17, 21, -17, 21,
+ax_anim 2, 0, 55, -16, 22, -16, 22,
+ax_anim 2, 0, 55, -17, 21, -17, 21,
+ax_anim 2, 0, 52, -6, 8, -6, 8,
+ax_anim_terminator
+.align 2
+sSceptileAnims_3_1:
+ax_anim 4, 0, 90, 0, -2, 0, 0,
+ax_anim 1, 2, 57, 0, 9, 0, 9,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 6, 0, 57, 0, 22, 0, 23,
+ax_anim 2, 1, 92, 0, 16, 0, 23,
+ax_anim 3, 0, 93, 0, 12, 0, 22,
+ax_anim 3, 0, 93, 0, 10, 0, 20,
+ax_anim 2, 0, 93, 0, 9, 0, 19,
+ax_anim 2, 0, 93, 0, 10, 0, 17,
+ax_anim 2, 0, 93, 0, 11, 0, 15,
+ax_anim 2, 0, 93, 0, 12, 0, 14,
+ax_anim 2, 0, 91, 0, 13, 0, 13,
+ax_anim_terminator
+sSceptileAnims_3_2:
+ax_anim 4, 0, 56, -2, -2, -2, -2,
+ax_anim 1, 2, 62, 9, 9, 9, 9,
+ax_anim 2, 0, 62, 20, 20, 20, 20,
+ax_anim 6, 0, 62, 22, 22, 22, 22,
+ax_anim 2, 1, 68, 22, 16, 22, 22,
+ax_anim 3, 0, 69, 21, 12, 21, 21,
+ax_anim 3, 0, 69, 20, 10, 20, 20,
+ax_anim 2, 0, 69, 19, 9, 19, 19,
+ax_anim 2, 0, 69, 17, 10, 17, 17,
+ax_anim 2, 0, 69, 15, 11, 15, 15,
+ax_anim 2, 0, 69, 14, 12, 14, 14,
+ax_anim 2, 0, 67, 13, 13, 13, 13,
+ax_anim_terminator
+sSceptileAnims_3_3:
+ax_anim 4, 0, 61, -2, 0, -2, 0,
+ax_anim 1, 2, 67, 9, 0, 9, 0,
+ax_anim 2, 0, 67, 20, 0, 20, 0,
+ax_anim 6, 0, 67, 22, 0, 22, 0,
+ax_anim 2, 1, 68, 22, -6, 22, 0,
+ax_anim 3, 0, 74, 21, -12, 21, 0,
+ax_anim 3, 0, 74, 20, -12, 20, 0,
+ax_anim 2, 0, 74, 19, -10, 19, 0,
+ax_anim 2, 0, 74, 17, -7, 17, 0,
+ax_anim 2, 0, 74, 15, -5, 15, 0,
+ax_anim 2, 0, 74, 14, -1, 14, 0,
+ax_anim 2, 0, 72, 13, 0, 13, 0,
+ax_anim_terminator
+sSceptileAnims_3_4:
+ax_anim 4, 0, 66, -2, 2, -2, 2,
+ax_anim 1, 2, 72, 9, -9, 9, -9,
+ax_anim 2, 0, 72, 20, -20, 20, -20,
+ax_anim 6, 0, 72, 22, -22, 22, -22,
+ax_anim 2, 1, 80, 22, -26, 22, -22,
+ax_anim 3, 0, 81, 21, -27, 21, -21,
+ax_anim 3, 0, 81, 20, -27, 20, -20,
+ax_anim 2, 0, 81, 19, -25, 19, -19,
+ax_anim 2, 0, 81, 17, -22, 17, -17,
+ax_anim 2, 0, 81, 15, -17, 15, -15,
+ax_anim 2, 0, 81, 14, -13, 14, -14,
+ax_anim 2, 0, 77, 13, -13, 13, -13,
+ax_anim_terminator
+sSceptileAnims_3_5:
+ax_anim 4, 0, 71, 0, 2, 0, 2,
+ax_anim 1, 2, 77, 0, -9, 0, -9,
+ax_anim 2, 0, 77, 0, -20, 0, -20,
+ax_anim 6, 0, 77, 0, -22, 0, -22,
+ax_anim 2, 1, 78, 0, -26, 0, -22,
+ax_anim 3, 0, 79, 0, -27, 0, -21,
+ax_anim 3, 0, 79, 0, -28, 0, -21,
+ax_anim 2, 0, 79, 0, -26, 0, -19,
+ax_anim 2, 0, 79, 0, -22, 0, -17,
+ax_anim 2, 0, 79, 0, -17, 0, -15,
+ax_anim 2, 0, 79, 0, -13, 0, -14,
+ax_anim 2, 0, 77, 0, -13, 0, -13,
+ax_anim_terminator
+sSceptileAnims_3_6:
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 2, 83, -9, -9, -9, -9,
+ax_anim 2, 0, 83, -20, -20, -20, -20,
+ax_anim 6, 0, 83, -22, -22, -22, -22,
+ax_anim 2, 1, 78, -22, -26, -22, -22,
+ax_anim 3, 0, 79, -21, -27, -21, -21,
+ax_anim 3, 0, 79, -20, -27, -20, -20,
+ax_anim 2, 0, 79, -19, -25, -19, -19,
+ax_anim 2, 0, 79, -17, -22, -17, -17,
+ax_anim 2, 0, 79, -15, -17, -15, -15,
+ax_anim 2, 0, 79, -14, -13, -14, -14,
+ax_anim 2, 0, 77, -13, -13, -13, -13,
+ax_anim_terminator
+sSceptileAnims_3_7:
+ax_anim 4, 0, 90, 2, 0, 2, 0,
+ax_anim 1, 2, 87, -9, 0, -9, 0,
+ax_anim 2, 0, 87, -20, 0, -20, 0,
+ax_anim 6, 0, 87, -22, 0, -22, 0,
+ax_anim 2, 1, 88, -22, -6, -22, 0,
+ax_anim 3, 0, 85, -21, -15, -21, 0,
+ax_anim 3, 0, 85, -20, -16, -20, 0,
+ax_anim 2, 0, 85, -19, -14, -19, 0,
+ax_anim 2, 0, 85, -17, -10, -17, 0,
+ax_anim 2, 0, 85, -15, -5, -15, 0,
+ax_anim 2, 0, 85, -14, -1, -14, 0,
+ax_anim 2, 0, 83, -13, 0, -13, 0,
+ax_anim_terminator
+sSceptileAnims_3_8:
+ax_anim 4, 0, 56, 2, -2, 2, -2,
+ax_anim 1, 2, 91, -9, 9, -9, 9,
+ax_anim 2, 0, 91, -20, 20, -20, 20,
+ax_anim 6, 0, 91, -22, 22, -22, 22,
+ax_anim 2, 1, 88, -22, 16, -22, 22,
+ax_anim 3, 0, 89, -21, 12, -21, 21,
+ax_anim 3, 0, 89, -20, 10, -20, 20,
+ax_anim 2, 0, 89, -19, 9, -19, 19,
+ax_anim 2, 0, 89, -17, 10, -17, 17,
+ax_anim 2, 0, 89, -15, 11, -15, 15,
+ax_anim 2, 0, 89, -14, 12, -14, 14,
+ax_anim 2, 0, 87, -13, 13, -13, 13,
+ax_anim_terminator
+.align 2
+sSceptileAnims_4_1:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 4, 2, 95, 0, -3, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 1,
+ax_anim 1, 0, 96, 0, -1, 0, 2,
+ax_anim 1, 0, 96, 0, 2, 0, 2,
+ax_anim 2, 0, 96, -1, 2, -1, 2,
+ax_anim 2, 1, 96, 0, 2, 0, 2,
+ax_anim 2, 0, 96, -1, 2, -1, 2,
+ax_anim 2, 0, 96, 0, 2, 0, 2,
+ax_anim 2, 0, 96, -1, 2, -1, 2,
+ax_anim_terminator
+sSceptileAnims_4_2:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 4, 2, 98, 0, -3, 0, 0,
+ax_anim 1, 0, 97, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 1, -1, 1, 1,
+ax_anim 1, 0, 99, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 3, 1, 2,
+ax_anim 2, 1, 99, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 3, 1, 2,
+ax_anim 2, 0, 99, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 3, 1, 2,
+ax_anim_terminator
+sSceptileAnims_4_3:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 4, 2, 101, 0, -3, 0, 0,
+ax_anim 1, 0, 100, 0, -4, 0, 0,
+ax_anim 1, 0, 102, 1, -3, 1, 0,
+ax_anim 1, 0, 102, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 2, -1, 1, 0,
+ax_anim 2, 1, 102, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 2, -1, 1, 0,
+ax_anim 2, 0, 102, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 2, -1, 1, 0,
+ax_anim_terminator
+sSceptileAnims_4_4:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 4, 2, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 103, 0, -7, 0, 0,
+ax_anim 1, 0, 105, 1, -5, 1, -1,
+ax_anim 1, 0, 105, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -3, 1, -3,
+ax_anim 2, 1, 105, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -3, 1, -3,
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -3, 1, -3,
+ax_anim_terminator
+sSceptileAnims_4_5:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -2, 0, 0,
+ax_anim 4, 2, 107, 0, -3, 0, 0,
+ax_anim 1, 0, 106, 0, -6, 0, -1,
+ax_anim 1, 0, 108, 0, -4, 0, -2,
+ax_anim 1, 0, 108, 0, -2, 0, -2,
+ax_anim 2, 0, 108, -1, -2, -1, -2,
+ax_anim 2, 1, 108, 0, -2, 0, -2,
+ax_anim 2, 0, 108, -1, -2, -1, -2,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim 2, 0, 108, -1, -2, -1, -2,
+ax_anim_terminator
+sSceptileAnims_4_6:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 2, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 109, 0, -7, 0, 0,
+ax_anim 1, 0, 111, -1, -5, -1, -1,
+ax_anim 1, 0, 111, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -3, -1, -3,
+ax_anim 2, 1, 111, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -3, -1, -3,
+ax_anim 2, 0, 111, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -3, -1, -3,
+ax_anim_terminator
+sSceptileAnims_4_7:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, -2, 0, 0,
+ax_anim 4, 2, 113, 0, -3, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 114, -1, -3, -1, 0,
+ax_anim 1, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, -1, -1, 0,
+ax_anim 2, 1, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, -1, -1, 0,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, -1, -1, 0,
+ax_anim_terminator
+sSceptileAnims_4_8:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -2, 0, 0,
+ax_anim 4, 2, 116, 0, -3, 0, 0,
+ax_anim 1, 0, 115, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 1, -1, 1, 1,
+ax_anim 1, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 1, 3, 1, 2,
+ax_anim 2, 1, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 1, 3, 1, 2,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 1, 3, 1, 2,
+ax_anim_terminator
+.align 2
+sSceptileAnims_5_1:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_5_2:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_5_3:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_5_4:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_5_5:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_5_6:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_5_7:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_5_8:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_6_1:
+ax_anim 30, 0, 126, 0, 0, 0, 0,
+ax_anim 35, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_7_1:
+ax_anim 2, 0, 128, 0, -2, 0, -2,
+ax_anim 8, 0, 128, 0, -3, 0, -3,
+ax_anim_terminator
+sSceptileAnims_7_2:
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 8, 0, 129, -3, -3, -3, -3,
+ax_anim_terminator
+sSceptileAnims_7_3:
+ax_anim 2, 0, 130, -2, 0, -2, 0,
+ax_anim 8, 0, 130, -3, 0, -3, 0,
+ax_anim_terminator
+sSceptileAnims_7_4:
+ax_anim 2, 0, 131, -2, 2, -2, 2,
+ax_anim 8, 0, 131, -3, 3, -3, 3,
+ax_anim_terminator
+sSceptileAnims_7_5:
+ax_anim 2, 0, 132, 0, 2, 0, 2,
+ax_anim 8, 0, 132, 0, 3, 0, 3,
+ax_anim_terminator
+sSceptileAnims_7_6:
+ax_anim 2, 0, 133, 2, 2, 2, 2,
+ax_anim 8, 0, 133, 3, 3, 3, 3,
+ax_anim_terminator
+sSceptileAnims_7_7:
+ax_anim 2, 0, 134, 2, 0, 2, 0,
+ax_anim 8, 0, 134, 3, 0, 3, 0,
+ax_anim_terminator
+sSceptileAnims_7_8:
+ax_anim 2, 0, 135, 2, -2, 2, -2,
+ax_anim 8, 0, 135, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSceptileAnims_8_1:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_8_2:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 30, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_8_3:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_8_4:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 30, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_8_5:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 30, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_8_6:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_8_8:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 30, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_9_1:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 8, 3, 8, 3,
+ax_anim 2, 0, 154, 11, 9, 11, 9,
+ax_anim 2, 0, 155, 8, 18, 8, 18,
+ax_anim 3, 0, 156, 0, 20, 0, 20,
+ax_anim 2, 3, 157, -8, 18, -8, 18,
+ax_anim 2, 0, 158, -11, 9, -11, 9,
+ax_anim 1, 0, 159, -8, 3, -8, 3,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_9_2:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 8, 0, 8, 0,
+ax_anim 2, 0, 153, 17, 3, 17, 3,
+ax_anim 2, 0, 154, 22, 13, 22, 13,
+ax_anim 3, 0, 155, 19, 21, 19, 21,
+ax_anim 2, 3, 156, 10, 21, 10, 21,
+ax_anim 2, 0, 157, 1, 17, 1, 17,
+ax_anim 1, 0, 158, -1, 7, -1, 7,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_9_3:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 4, -5, 4, -5,
+ax_anim 2, 0, 152, 11, -6, 11, -6,
+ax_anim 2, 0, 153, 19, -5, 19, -5,
+ax_anim 3, 0, 154, 21, 0, 21, 0,
+ax_anim 2, 3, 155, 16, 8, 16, 8,
+ax_anim 2, 0, 156, 12, 8, 12, 8,
+ax_anim 1, 0, 157, 4, 8, 4, 8,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_9_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, -1, -8, -1, -8,
+ax_anim 2, 0, 159, 4, -16, 4, -16,
+ax_anim 2, 0, 152, 12, -22, 12, -22,
+ax_anim 3, 0, 153, 21, -21, 21, -21,
+ax_anim 2, 3, 154, 22, -13, 22, -13,
+ax_anim 2, 0, 155, 17, -4, 17, -4,
+ax_anim 1, 0, 156, 8, 0, 8, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_9_5:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, -8, -3, -8, -3,
+ax_anim 2, 0, 158, -9, -11, -9, -11,
+ax_anim 2, 0, 159, -7, -18, -7, -18,
+ax_anim 3, 0, 152, 0, -21, 0, -21,
+ax_anim 2, 3, 153, 7, -18, 7, -18,
+ax_anim 2, 0, 154, 9, -11, 9, -11,
+ax_anim 1, 0, 155, 8, -3, 8, -3,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_9_6:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 1, -8, 1, -8,
+ax_anim 2, 0, 153, -4, -16, -4, -16,
+ax_anim 2, 0, 152, -12, -22, -12, -22,
+ax_anim 3, 0, 159, -21, -21, -21, -21,
+ax_anim 2, 3, 158, -22, -13, -22, -13,
+ax_anim 2, 0, 157, -17, -4, -17, -4,
+ax_anim 1, 0, 156, -8, 0, -8, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_9_7:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 153, -4, -5, -4, -5,
+ax_anim 2, 0, 152, -11, -6, -11, -6,
+ax_anim 2, 0, 159, -19, -5, -19, -5,
+ax_anim 3, 0, 158, -21, 0, -21, 0,
+ax_anim 2, 3, 157, -16, 8, -16, 8,
+ax_anim 2, 0, 156, -12, 8, -12, 8,
+ax_anim 1, 0, 155, -4, 8, -4, 8,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_9_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -8, 0, -8, 0,
+ax_anim 2, 0, 159, -17, 3, -17, 3,
+ax_anim 2, 0, 158, -22, 13, -22, 13,
+ax_anim 3, 0, 157, -19, 21, -19, 21,
+ax_anim 2, 3, 156, -10, 21, -10, 21,
+ax_anim 2, 0, 155, -1, 17, -1, 17,
+ax_anim 1, 0, 154, 1, 7, 1, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_10_1:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 6, 0, 6, 0,
+ax_anim 2, 0, 160, -6, 0, -6, 0,
+ax_anim 2, 0, 160, 10, 0, 10, 0,
+ax_anim 2, 0, 160, -10, 0, -10, 0,
+ax_anim 2, 0, 160, 12, 0, 12, 0,
+ax_anim 3, 0, 160, -12, 0, -12, 0,
+ax_anim 3, 0, 160, 13, 0, 13, 0,
+ax_anim 3, 0, 160, -13, 0, -13, 0,
+ax_anim 2, 0, 160, 12, 0, 12, 0,
+ax_anim 3, 0, 160, -12, 0, -12, 0,
+ax_anim 2, 0, 160, 10, 0, 10, 0,
+ax_anim 2, 0, 160, -10, 0, -10, 0,
+ax_anim 2, 0, 160, 6, 0, 6, 0,
+ax_anim 2, 0, 160, -6, 0, -6, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_10_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 6, -6, 6, -6,
+ax_anim 2, 0, 161, -6, 6, -6, 6,
+ax_anim 2, 0, 161, 10, -10, 10, -10,
+ax_anim 2, 0, 161, -10, 10, -10, 10,
+ax_anim 2, 0, 161, 12, -12, 12, -12,
+ax_anim 3, 0, 161, -12, 12, -12, 12,
+ax_anim 3, 0, 161, 13, -13, 13, -13,
+ax_anim 3, 0, 161, -13, 13, -13, 13,
+ax_anim 2, 0, 161, 12, -12, 12, -12,
+ax_anim 3, 0, 161, -12, 12, -12, 12,
+ax_anim 2, 0, 161, 10, -10, 10, -10,
+ax_anim 2, 0, 161, -10, 10, -10, 10,
+ax_anim 2, 0, 161, 6, -6, 6, -6,
+ax_anim 2, 0, 161, -6, 6, -6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_10_3:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -6, 0, -6,
+ax_anim 2, 0, 162, 0, 6, 0, 6,
+ax_anim 2, 0, 162, 0, -10, 0, -10,
+ax_anim 2, 0, 162, 0, 10, 0, 10,
+ax_anim 2, 0, 162, 0, -12, 0, -12,
+ax_anim 3, 0, 162, 0, 12, 0, 12,
+ax_anim 3, 0, 162, 0, -13, 0, -13,
+ax_anim 3, 0, 162, 0, 13, 0, 13,
+ax_anim 2, 0, 162, 0, -12, 0, -12,
+ax_anim 3, 0, 162, 0, 12, 0, 12,
+ax_anim 2, 0, 162, 0, -10, 0, -10,
+ax_anim 2, 0, 162, 0, 10, 0, 10,
+ax_anim 2, 0, 162, 0, -6, 0, -6,
+ax_anim 2, 0, 162, 0, 6, 0, 6,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_10_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -6, -6, -6, -6,
+ax_anim 2, 0, 163, 6, 6, 6, 6,
+ax_anim 2, 0, 163, -10, -10, -10, -10,
+ax_anim 2, 0, 163, 10, 10, 10, 10,
+ax_anim 2, 0, 163, -12, -12, -12, -12,
+ax_anim 3, 0, 163, 12, 12, 12, 12,
+ax_anim 3, 0, 163, -13, -13, -13, -13,
+ax_anim 3, 0, 163, 13, 13, 13, 13,
+ax_anim 2, 0, 163, -12, -12, -12, -12,
+ax_anim 3, 0, 163, 12, 12, 12, 12,
+ax_anim 2, 0, 163, -10, -10, -10, -10,
+ax_anim 2, 0, 163, 10, 10, 10, 10,
+ax_anim 2, 0, 163, -6, -6, -6, -6,
+ax_anim 2, 0, 163, 6, 6, 6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_10_5:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 6, 0, 6, 0,
+ax_anim 2, 0, 164, -6, 0, -6, 0,
+ax_anim 2, 0, 164, 10, 0, 10, 0,
+ax_anim 2, 0, 164, -10, 0, -10, 0,
+ax_anim 2, 0, 164, 12, 0, 12, 0,
+ax_anim 3, 0, 164, -12, 0, -12, 0,
+ax_anim 3, 0, 164, 13, 0, 13, 0,
+ax_anim 3, 0, 164, -13, 0, -13, 0,
+ax_anim 2, 0, 164, 12, 0, 12, 0,
+ax_anim 3, 0, 164, -12, 0, -12, 0,
+ax_anim 2, 0, 164, 10, 0, 10, 0,
+ax_anim 2, 0, 164, -10, 0, -10, 0,
+ax_anim 2, 0, 164, 6, 0, 6, 0,
+ax_anim 2, 0, 164, -6, 0, -6, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_10_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 6, -6, 6, -6,
+ax_anim 2, 0, 165, -6, 6, -6, 6,
+ax_anim 2, 0, 165, 10, -10, 10, -10,
+ax_anim 2, 0, 165, -10, 10, -10, 10,
+ax_anim 2, 0, 165, 12, -12, 12, -12,
+ax_anim 3, 0, 165, -12, 12, -12, 12,
+ax_anim 3, 0, 165, 13, -13, 13, -13,
+ax_anim 3, 0, 165, -13, 13, -13, 13,
+ax_anim 2, 0, 165, 12, -12, 12, -12,
+ax_anim 3, 0, 165, -12, 12, -12, 12,
+ax_anim 2, 0, 165, 10, -10, 10, -10,
+ax_anim 2, 0, 165, -10, 10, -10, 10,
+ax_anim 2, 0, 165, 6, -6, 6, -6,
+ax_anim 2, 0, 165, -6, 6, -6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_10_7:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -6, 0, -6,
+ax_anim 2, 0, 166, 0, 6, 0, 6,
+ax_anim 2, 0, 166, 0, -10, 0, -10,
+ax_anim 2, 0, 166, 0, 10, 0, 10,
+ax_anim 2, 0, 166, 0, -12, 0, -12,
+ax_anim 3, 0, 166, 0, 12, 0, 12,
+ax_anim 3, 0, 166, 0, -13, 0, -13,
+ax_anim 3, 0, 166, 0, 13, 0, 13,
+ax_anim 2, 0, 166, 0, -12, 0, -12,
+ax_anim 3, 0, 166, 0, 12, 0, 12,
+ax_anim 2, 0, 166, 0, -10, 0, -10,
+ax_anim 2, 0, 166, 0, 10, 0, 10,
+ax_anim 2, 0, 166, 0, -6, 0, -6,
+ax_anim 2, 0, 166, 0, 6, 0, 6,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_10_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -6, -6, -6, -6,
+ax_anim 2, 0, 167, 6, 6, 6, 6,
+ax_anim 2, 0, 167, -10, -10, -10, -10,
+ax_anim 2, 0, 167, 10, 10, 10, 10,
+ax_anim 2, 0, 167, -12, -12, -12, -12,
+ax_anim 3, 0, 167, 12, 12, 12, 12,
+ax_anim 3, 0, 167, -13, -13, -13, -13,
+ax_anim 3, 0, 167, 13, 13, 13, 13,
+ax_anim 2, 0, 167, -12, -12, -12, -12,
+ax_anim 3, 0, 167, 12, 12, 12, 12,
+ax_anim 2, 0, 167, -10, -10, -10, -10,
+ax_anim 2, 0, 167, 10, 10, 10, 10,
+ax_anim 2, 0, 167, -6, -6, -6, -6,
+ax_anim 2, 0, 167, 6, 6, 6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_11_1:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -24, 0, 0,
+ax_anim 3, 0, 170, 0, -24, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_11_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -18, 0, 0,
+ax_anim 4, 0, 172, 0, -19, 0, 0,
+ax_anim 4, 0, 171, 0, -24, 0, 0,
+ax_anim 3, 0, 173, 0, -25, 0, 0,
+ax_anim 2, 0, 173, 0, -20, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_11_3:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -18, 0, 0,
+ax_anim 4, 0, 175, 0, -19, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -26, 0, 0,
+ax_anim 2, 0, 176, 0, -20, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_11_4:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -18, 0, 0,
+ax_anim 4, 0, 178, 0, -19, 0, 0,
+ax_anim 4, 0, 177, 0, -25, 0, 0,
+ax_anim 3, 0, 179, 0, -24, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_11_5:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -18, 0, 0,
+ax_anim 4, 0, 181, 0, -19, 0, 0,
+ax_anim 4, 0, 182, 0, -25, 0, 0,
+ax_anim 3, 0, 182, 0, -24, 0, 0,
+ax_anim 2, 0, 182, 0, -20, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_11_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -18, 0, 0,
+ax_anim 4, 0, 184, 0, -19, 0, 0,
+ax_anim 4, 0, 183, 0, -25, 0, 0,
+ax_anim 3, 0, 185, 0, -24, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_11_7:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -18, 0, 0,
+ax_anim 4, 0, 187, 0, -19, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -26, 0, 0,
+ax_anim 2, 0, 188, 0, -20, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_11_8:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -18, 0, 0,
+ax_anim 4, 0, 190, 0, -19, 0, 0,
+ax_anim 4, 0, 189, 0, -24, 0, 0,
+ax_anim 3, 0, 191, 0, -25, 0, 0,
+ax_anim 2, 0, 191, 0, -20, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_12_1:
+ax_anim 2, 0, 192, 1, 0, 1, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 1, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 1, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 1, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 1, 0, 1, 0,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_12_2:
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_12_3:
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_12_4:
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_12_5:
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_12_6:
+ax_anim 2, 0, 195, 1, -1, 1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, -1, 1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, -1, 1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, -1, 1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 1, -1, 1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_12_7:
+ax_anim 2, 0, 194, 0, -1, 0, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, -1, 0, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, -1, 0, -1,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, -1, 0, -1,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, -1, 0, -1,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_12_8:
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -1, -1, -1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSceptileAnims_13_1:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_13_2:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_13_3:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_13_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_13_5:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_13_6:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_13_7:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileAnims_13_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSceptileGfx1:
+.incbin "baserom.gba", 0x10695BC, 0x200
+sSceptileSprites1:
+ax_sprite sSceptileGfx1, 0x200
+ax_sprite_terminator
+sSceptileGfx2:
+.incbin "baserom.gba", 0x10697CC, 0x200
+sSceptileSprites2:
+ax_sprite sSceptileGfx2, 0x200
+ax_sprite_terminator
+sSceptileGfx3:
+.incbin "baserom.gba", 0x10699DC, 0x200
+sSceptileSprites3:
+ax_sprite sSceptileGfx3, 0x200
+ax_sprite_terminator
+sSceptileGfx4:
+.incbin "baserom.gba", 0x1069BEC, 0x200
+sSceptileSprites4:
+ax_sprite sSceptileGfx4, 0x200
+ax_sprite_terminator
+sSceptileGfx5:
+.incbin "baserom.gba", 0x1069DFC, 0x200
+sSceptileSprites5:
+ax_sprite sSceptileGfx5, 0x200
+ax_sprite_terminator
+sSceptileGfx6:
+.incbin "baserom.gba", 0x106A00C, 0x200
+sSceptileSprites6:
+ax_sprite sSceptileGfx6, 0x200
+ax_sprite_terminator
+sSceptileGfx7:
+.incbin "baserom.gba", 0x106A21C, 0x200
+sSceptileSprites7:
+ax_sprite sSceptileGfx7, 0x200
+ax_sprite_terminator
+sSceptileGfx8:
+.incbin "baserom.gba", 0x106A42C, 0x200
+sSceptileSprites8:
+ax_sprite sSceptileGfx8, 0x200
+ax_sprite_terminator
+sSceptileGfx9:
+.incbin "baserom.gba", 0x106A63C, 0x200
+sSceptileSprites9:
+ax_sprite sSceptileGfx9, 0x200
+ax_sprite_terminator
+sSceptileGfx10:
+.incbin "baserom.gba", 0x106A84C, 0x200
+sSceptileSprites10:
+ax_sprite sSceptileGfx10, 0x200
+ax_sprite_terminator
+sSceptileGfx11:
+.incbin "baserom.gba", 0x106AA5C, 0x200
+sSceptileSprites11:
+ax_sprite sSceptileGfx11, 0x200
+ax_sprite_terminator
+sSceptileGfx12:
+.incbin "baserom.gba", 0x106AC6C, 0x200
+sSceptileSprites12:
+ax_sprite sSceptileGfx12, 0x200
+ax_sprite_terminator
+sSceptileGfx13:
+.incbin "baserom.gba", 0x106AE7C, 0x200
+sSceptileSprites13:
+ax_sprite sSceptileGfx13, 0x200
+ax_sprite_terminator
+sSceptileGfx14:
+.incbin "baserom.gba", 0x106B08C, 0x200
+sSceptileSprites14:
+ax_sprite sSceptileGfx14, 0x200
+ax_sprite_terminator
+sSceptileGfx15:
+.incbin "baserom.gba", 0x106B29C, 0x200
+sSceptileSprites15:
+ax_sprite sSceptileGfx15, 0x200
+ax_sprite_terminator
+sSceptileGfx16:
+.incbin "baserom.gba", 0x106B4AC, 0x60
+sSceptileGfx16_1:
+.incbin "baserom.gba", 0x106B50C, 0x60
+sSceptileGfx16_2:
+.incbin "baserom.gba", 0x106B56C, 0x60
+sSceptileSprites16:
+ax_sprite 0, 0x80
+ax_sprite sSceptileGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx17:
+.incbin "baserom.gba", 0x106B60C, 0x160
+sSceptileSprites17:
+ax_sprite 0, 0xa0
+ax_sprite sSceptileGfx17, 0x160
+ax_sprite_terminator
+sSceptileGfx18:
+.incbin "baserom.gba", 0x106B784, 0x160
+sSceptileSprites18:
+ax_sprite 0, 0x80
+ax_sprite sSceptileGfx18, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx19:
+.incbin "baserom.gba", 0x106B904, 0x60
+sSceptileGfx19_1:
+.incbin "baserom.gba", 0x106B964, 0x80
+sSceptileGfx19_2:
+.incbin "baserom.gba", 0x106B9E4, 0x60
+sSceptileSprites19:
+ax_sprite 0, 0x80
+ax_sprite sSceptileGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx19_2, 0x60
+ax_sprite_terminator
+sSceptileGfx20:
+.incbin "baserom.gba", 0x106BA7C, 0x40
+sSceptileGfx20_1:
+.incbin "baserom.gba", 0x106BABC, 0x40
+sSceptileGfx20_2:
+.incbin "baserom.gba", 0x106BAFC, 0x80
+sSceptileGfx20_3:
+.incbin "baserom.gba", 0x106BB7C, 0x60
+sSceptileSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx20_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx20_3, 0x60
+ax_sprite_terminator
+sSceptileGfx21:
+.incbin "baserom.gba", 0x106BC24, 0xE0
+sSceptileSprites21:
+ax_sprite sSceptileGfx21, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx22:
+.incbin "baserom.gba", 0x106BD1C, 0x60
+sSceptileGfx22_1:
+.incbin "baserom.gba", 0x106BD7C, 0x160
+sSceptileSprites22:
+ax_sprite sSceptileGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx23:
+.incbin "baserom.gba", 0x106BF04, 0xA0
+sSceptileGfx23_1:
+.incbin "baserom.gba", 0x106BFA4, 0x40
+sSceptileSprites23:
+ax_sprite sSceptileGfx23, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx23_1, 0x40
+ax_sprite_terminator
+sSceptileGfx24:
+.incbin "baserom.gba", 0x106C004, 0x60
+sSceptileGfx24_1:
+.incbin "baserom.gba", 0x106C064, 0x100
+sSceptileGfx24_2:
+.incbin "baserom.gba", 0x106C164, 0x60
+sSceptileSprites24:
+ax_sprite sSceptileGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx24_2, 0x60
+ax_sprite_terminator
+sSceptileGfx25:
+.incbin "baserom.gba", 0x106C1F4, 0xA0
+sSceptileGfx25_1:
+.incbin "baserom.gba", 0x106C294, 0x20
+sSceptileSprites25:
+ax_sprite sSceptileGfx25, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx25_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx26:
+.incbin "baserom.gba", 0x106C2DC, 0x40
+sSceptileGfx26_1:
+.incbin "baserom.gba", 0x106C31C, 0x60
+sSceptileGfx26_2:
+.incbin "baserom.gba", 0x106C37C, 0x60
+sSceptileGfx26_3:
+.incbin "baserom.gba", 0x106C3DC, 0x60
+sSceptileSprites26:
+ax_sprite sSceptileGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx26_3, 0x60
+ax_sprite_terminator
+sSceptileGfx27:
+.incbin "baserom.gba", 0x106C47C, 0x100
+sSceptileSprites27:
+ax_sprite sSceptileGfx27, 0x100
+ax_sprite_terminator
+sSceptileGfx28:
+.incbin "baserom.gba", 0x106C58C, 0x40
+sSceptileGfx28_1:
+.incbin "baserom.gba", 0x106C5CC, 0x60
+sSceptileGfx28_2:
+.incbin "baserom.gba", 0x106C62C, 0x40
+sSceptileGfx28_3:
+.incbin "baserom.gba", 0x106C66C, 0x60
+sSceptileSprites28:
+ax_sprite sSceptileGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx28_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx28_3, 0x60
+ax_sprite_terminator
+sSceptileGfx29:
+.incbin "baserom.gba", 0x106C70C, 0xE0
+sSceptileSprites29:
+ax_sprite sSceptileGfx29, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx30:
+.incbin "baserom.gba", 0x106C804, 0x100
+sSceptileSprites30:
+ax_sprite sSceptileGfx30, 0x100
+ax_sprite_terminator
+sSceptileGfx31:
+.incbin "baserom.gba", 0x106C914, 0x20
+sSceptileSprites31:
+ax_sprite sSceptileGfx31, 0x20
+ax_sprite_terminator
+sSceptileGfx32:
+.incbin "baserom.gba", 0x106C944, 0x20
+sSceptileSprites32:
+ax_sprite sSceptileGfx32, 0x20
+ax_sprite_terminator
+sSceptileGfx33:
+.incbin "baserom.gba", 0x106C974, 0x80
+sSceptileSprites33:
+ax_sprite sSceptileGfx33, 0x80
+ax_sprite_terminator
+sSceptileGfx34:
+.incbin "baserom.gba", 0x106CA04, 0x1E0
+sSceptileSprites34:
+ax_sprite sSceptileGfx34, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx35:
+.incbin "baserom.gba", 0x106CBFC, 0x80
+sSceptileSprites35:
+ax_sprite sSceptileGfx35, 0x80
+ax_sprite_terminator
+sSceptileGfx36:
+.incbin "baserom.gba", 0x106CC8C, 0xE0
+sSceptileSprites36:
+ax_sprite sSceptileGfx36, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSceptileGfx37:
+.incbin "baserom.gba", 0x106CD84, 0x20
+sSceptileSprites37:
+ax_sprite sSceptileGfx37, 0x20
+ax_sprite_terminator
+sSceptileGfx38:
+.incbin "baserom.gba", 0x106CDB4, 0x20
+sSceptileSprites38:
+ax_sprite sSceptileGfx38, 0x20
+ax_sprite_terminator
+sSceptileGfx39:
+.incbin "baserom.gba", 0x106CDE4, 0x20
+sSceptileGfx39_1:
+.incbin "baserom.gba", 0x106CE04, 0xC0
+sSceptileSprites39:
+ax_sprite sSceptileGfx39, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx39_1, 0xc0
+ax_sprite_terminator
+sSceptileGfx40:
+.incbin "baserom.gba", 0x106CEE4, 0x80
+sSceptileSprites40:
+ax_sprite sSceptileGfx40, 0x80
+ax_sprite_terminator
+sSceptileGfx41:
+.incbin "baserom.gba", 0x106CF74, 0x20
+sSceptileSprites41:
+ax_sprite sSceptileGfx41, 0x20
+ax_sprite_terminator
+sSceptileGfx42:
+.incbin "baserom.gba", 0x106CFA4, 0x20
+sSceptileGfx42_1:
+.incbin "baserom.gba", 0x106CFC4, 0x40
+sSceptileSprites42:
+ax_sprite sSceptileGfx42, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx42_1, 0x40
+ax_sprite_terminator
+sSceptileGfx43:
+.incbin "baserom.gba", 0x106D024, 0x100
+sSceptileSprites43:
+ax_sprite sSceptileGfx43, 0x100
+ax_sprite_terminator
+sSceptileGfx44:
+.incbin "baserom.gba", 0x106D134, 0x20
+sSceptileSprites44:
+ax_sprite sSceptileGfx44, 0x20
+ax_sprite_terminator
+sSceptileGfx45:
+.incbin "baserom.gba", 0x106D164, 0x40
+sSceptileGfx45_1:
+.incbin "baserom.gba", 0x106D1A4, 0x40
+sSceptileGfx45_2:
+.incbin "baserom.gba", 0x106D1E4, 0x60
+sSceptileGfx45_3:
+.incbin "baserom.gba", 0x106D244, 0x60
+sSceptileSprites45:
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx45_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSceptileGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx45_3, 0x60
+ax_sprite_terminator
+sSceptileGfx46:
+.incbin "baserom.gba", 0x106D2EC, 0x80
+sSceptileSprites46:
+ax_sprite sSceptileGfx46, 0x80
+ax_sprite_terminator
+sSceptileGfx47:
+.incbin "baserom.gba", 0x106D37C, 0x100
+sSceptileSprites47:
+ax_sprite sSceptileGfx47, 0x100
+ax_sprite_terminator
+sSceptileGfx48:
+.incbin "baserom.gba", 0x106D48C, 0x20
+sSceptileSprites48:
+ax_sprite sSceptileGfx48, 0x20
+ax_sprite_terminator
+sSceptileGfx49:
+.incbin "baserom.gba", 0x106D4BC, 0x20
+sSceptileSprites49:
+ax_sprite sSceptileGfx49, 0x20
+ax_sprite_terminator
+sSceptileGfx50:
+.incbin "baserom.gba", 0x106D4EC, 0x100
+sSceptileSprites50:
+ax_sprite sSceptileGfx50, 0x100
+ax_sprite_terminator
+sSceptileGfx51:
+.incbin "baserom.gba", 0x106D5FC, 0x80
+sSceptileSprites51:
+ax_sprite sSceptileGfx51, 0x80
+ax_sprite_terminator
+sSceptileGfx52:
+.incbin "baserom.gba", 0x106D68C, 0x40
+sSceptileSprites52:
+ax_sprite sSceptileGfx52, 0x40
+ax_sprite_terminator
+sSceptileGfx53:
+.incbin "baserom.gba", 0x106D6DC, 0x20
+sSceptileSprites53:
+ax_sprite sSceptileGfx53, 0x20
+ax_sprite_terminator
+sSceptileGfx54:
+.incbin "baserom.gba", 0x106D70C, 0x20
+sSceptileSprites54:
+ax_sprite sSceptileGfx54, 0x20
+ax_sprite_terminator
+sSceptileGfx55:
+.incbin "baserom.gba", 0x106D73C, 0xC0
+sSceptileGfx55_1:
+.incbin "baserom.gba", 0x106D7FC, 0x20
+sSceptileSprites55:
+ax_sprite sSceptileGfx55, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx55_1, 0x20
+ax_sprite_terminator
+sSceptileGfx56:
+.incbin "baserom.gba", 0x106D83C, 0x80
+sSceptileSprites56:
+ax_sprite sSceptileGfx56, 0x80
+ax_sprite_terminator
+sSceptileGfx57:
+.incbin "baserom.gba", 0x106D8CC, 0x40
+sSceptileSprites57:
+ax_sprite sSceptileGfx57, 0x40
+ax_sprite_terminator
+sSceptileGfx58:
+.incbin "baserom.gba", 0x106D91C, 0x40
+sSceptileSprites58:
+ax_sprite sSceptileGfx58, 0x40
+ax_sprite_terminator
+sSceptileGfx59:
+.incbin "baserom.gba", 0x106D96C, 0x100
+sSceptileSprites59:
+ax_sprite sSceptileGfx59, 0x100
+ax_sprite_terminator
+sSceptileGfx60:
+.incbin "baserom.gba", 0x106DA7C, 0x80
+sSceptileSprites60:
+ax_sprite sSceptileGfx60, 0x80
+ax_sprite_terminator
+sSceptileGfx61:
+.incbin "baserom.gba", 0x106DB0C, 0x40
+sSceptileSprites61:
+ax_sprite sSceptileGfx61, 0x40
+ax_sprite_terminator
+sSceptileGfx62:
+.incbin "baserom.gba", 0x106DB5C, 0x20
+sSceptileSprites62:
+ax_sprite sSceptileGfx62, 0x20
+ax_sprite_terminator
+sSceptileGfx63:
+.incbin "baserom.gba", 0x106DB8C, 0x20
+sSceptileSprites63:
+ax_sprite sSceptileGfx63, 0x20
+ax_sprite_terminator
+sSceptileGfx64:
+.incbin "baserom.gba", 0x106DBBC, 0x20
+sSceptileGfx64_1:
+.incbin "baserom.gba", 0x106DBDC, 0xC0
+sSceptileSprites64:
+ax_sprite sSceptileGfx64, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSceptileGfx64_1, 0xc0
+ax_sprite_terminator
+sSceptileGfx65:
+.incbin "baserom.gba", 0x106DCBC, 0x80
+sSceptileSprites65:
+ax_sprite sSceptileGfx65, 0x80
+ax_sprite_terminator
+sSceptileGfx66:
+.incbin "baserom.gba", 0x106DD4C, 0x20
+sSceptileSprites66:
+ax_sprite sSceptileGfx66, 0x20
+ax_sprite_terminator
+sSceptileGfx67:
+.incbin "baserom.gba", 0x106DD7C, 0x20
+sSceptileSprites67:
+ax_sprite sSceptileGfx67, 0x20
+ax_sprite_terminator
+sSceptileGfx68:
+.incbin "baserom.gba", 0x106DDAC, 0x200
+sSceptileSprites68:
+ax_sprite sSceptileGfx68, 0x200
+ax_sprite_terminator
+sSceptileGfx69:
+.incbin "baserom.gba", 0x106DFBC, 0x200
+sSceptileSprites69:
+ax_sprite sSceptileGfx69, 0x200
+ax_sprite_terminator
+sSceptileGfx70:
+.incbin "baserom.gba", 0x106E1CC, 0x200
+sSceptileSprites70:
+ax_sprite sSceptileGfx70, 0x200
+ax_sprite_terminator
+sSceptileGfx71:
+.incbin "baserom.gba", 0x106E3DC, 0x200
+sSceptileSprites71:
+ax_sprite sSceptileGfx71, 0x200
+ax_sprite_terminator
+sSceptileGfx72:
+.incbin "baserom.gba", 0x106E5EC, 0x200
+sSceptileSprites72:
+ax_sprite sSceptileGfx72, 0x200
+ax_sprite_terminator
+sSceptileGfx73:
+.incbin "baserom.gba", 0x106E7FC, 0x200
+sSceptileSprites73:
+ax_sprite sSceptileGfx73, 0x200
+ax_sprite_terminator
+sSceptileGfx74:
+.incbin "baserom.gba", 0x106EA0C, 0x200
+sSceptileSprites74:
+ax_sprite sSceptileGfx74, 0x200
+ax_sprite_terminator
+sSceptileGfx75:
+.incbin "baserom.gba", 0x106EC1C, 0x200
+sSceptileSprites75:
+ax_sprite sSceptileGfx75, 0x200
+ax_sprite_terminator
+sSceptileGfx76:
+.incbin "baserom.gba", 0x106EE2C, 0x200
+sSceptileSprites76:
+ax_sprite sSceptileGfx76, 0x200
+ax_sprite_terminator
+sSceptileGfx77:
+.incbin "baserom.gba", 0x106F03C, 0x200
+sSceptileSprites77:
+ax_sprite sSceptileGfx77, 0x200
+ax_sprite_terminator
+sSceptileGfx78:
+.incbin "baserom.gba", 0x106F24C, 0x200
+sSceptileSprites78:
+ax_sprite sSceptileGfx78, 0x200
+ax_sprite_terminator
+sSceptileGfx79:
+.incbin "baserom.gba", 0x106F45C, 0x200
+sSceptileSprites79:
+ax_sprite sSceptileGfx79, 0x200
+ax_sprite_terminator
+sAxPosesSceptile:
+.4byte sSceptilePose1
+.4byte sSceptilePose2
+.4byte sSceptilePose3
+.4byte sSceptilePose4
+.4byte sSceptilePose5
+.4byte sSceptilePose6
+.4byte sSceptilePose7
+.4byte sSceptilePose8
+.4byte sSceptilePose9
+.4byte sSceptilePose10
+.4byte sSceptilePose11
+.4byte sSceptilePose12
+.4byte sSceptilePose13
+.4byte sSceptilePose14
+.4byte sSceptilePose15
+.4byte sSceptilePose16
+.4byte sSceptilePose17
+.4byte sSceptilePose18
+.4byte sSceptilePose19
+.4byte sSceptilePose20
+.4byte sSceptilePose21
+.4byte sSceptilePose22
+.4byte sSceptilePose23
+.4byte sSceptilePose24
+.4byte sSceptilePose25
+.4byte sSceptilePose26
+.4byte sSceptilePose27
+.4byte sSceptilePose28
+.4byte sSceptilePose29
+.4byte sSceptilePose30
+.4byte sSceptilePose31
+.4byte sSceptilePose32
+.4byte sSceptilePose33
+.4byte sSceptilePose34
+.4byte sSceptilePose35
+.4byte sSceptilePose36
+.4byte sSceptilePose37
+.4byte sSceptilePose38
+.4byte sSceptilePose39
+.4byte sSceptilePose40
+.4byte sSceptilePose41
+.4byte sSceptilePose42
+.4byte sSceptilePose43
+.4byte sSceptilePose44
+.4byte sSceptilePose45
+.4byte sSceptilePose46
+.4byte sSceptilePose47
+.4byte sSceptilePose48
+.4byte sSceptilePose49
+.4byte sSceptilePose50
+.4byte sSceptilePose51
+.4byte sSceptilePose52
+.4byte sSceptilePose53
+.4byte sSceptilePose54
+.4byte sSceptilePose55
+.4byte sSceptilePose56
+.4byte sSceptilePose57
+.4byte sSceptilePose58
+.4byte sSceptilePose59
+.4byte sSceptilePose60
+.4byte sSceptilePose61
+.4byte sSceptilePose62
+.4byte sSceptilePose63
+.4byte sSceptilePose64
+.4byte sSceptilePose65
+.4byte sSceptilePose66
+.4byte sSceptilePose67
+.4byte sSceptilePose68
+.4byte sSceptilePose69
+.4byte sSceptilePose70
+.4byte sSceptilePose71
+.4byte sSceptilePose72
+.4byte sSceptilePose73
+.4byte sSceptilePose74
+.4byte sSceptilePose75
+.4byte sSceptilePose76
+.4byte sSceptilePose77
+.4byte sSceptilePose78
+.4byte sSceptilePose79
+.4byte sSceptilePose80
+.4byte sSceptilePose81
+.4byte sSceptilePose82
+.4byte sSceptilePose83
+.4byte sSceptilePose84
+.4byte sSceptilePose85
+.4byte sSceptilePose86
+.4byte sSceptilePose87
+.4byte sSceptilePose88
+.4byte sSceptilePose89
+.4byte sSceptilePose90
+.4byte sSceptilePose91
+.4byte sSceptilePose92
+.4byte sSceptilePose93
+.4byte sSceptilePose94
+.4byte sSceptilePose95
+.4byte sSceptilePose96
+.4byte sSceptilePose97
+.4byte sSceptilePose98
+.4byte sSceptilePose99
+.4byte sSceptilePose100
+.4byte sSceptilePose101
+.4byte sSceptilePose102
+.4byte sSceptilePose103
+.4byte sSceptilePose104
+.4byte sSceptilePose105
+.4byte sSceptilePose106
+.4byte sSceptilePose107
+.4byte sSceptilePose108
+.4byte sSceptilePose109
+.4byte sSceptilePose110
+.4byte sSceptilePose111
+.4byte sSceptilePose112
+.4byte sSceptilePose113
+.4byte sSceptilePose114
+.4byte sSceptilePose115
+.4byte sSceptilePose116
+.4byte sSceptilePose117
+.4byte sSceptilePose118
+.4byte sSceptilePose119
+.4byte sSceptilePose120
+.4byte sSceptilePose121
+.4byte sSceptilePose122
+.4byte sSceptilePose123
+.4byte sSceptilePose124
+.4byte sSceptilePose125
+.4byte sSceptilePose126
+.4byte sSceptilePose127
+.4byte sSceptilePose128
+.4byte sSceptilePose129
+.4byte sSceptilePose130
+.4byte sSceptilePose131
+.4byte sSceptilePose132
+.4byte sSceptilePose133
+.4byte sSceptilePose134
+.4byte sSceptilePose135
+.4byte sSceptilePose136
+.4byte sSceptilePose137
+.4byte sSceptilePose138
+.4byte sSceptilePose139
+.4byte sSceptilePose140
+.4byte sSceptilePose141
+.4byte sSceptilePose142
+.4byte sSceptilePose143
+.4byte sSceptilePose144
+.4byte sSceptilePose145
+.4byte sSceptilePose146
+.4byte sSceptilePose147
+.4byte sSceptilePose148
+.4byte sSceptilePose149
+.4byte sSceptilePose150
+.4byte sSceptilePose151
+.4byte sSceptilePose152
+.4byte sSceptilePose153
+.4byte sSceptilePose154
+.4byte sSceptilePose155
+.4byte sSceptilePose156
+.4byte sSceptilePose157
+.4byte sSceptilePose158
+.4byte sSceptilePose159
+.4byte sSceptilePose160
+.4byte sSceptilePose161
+.4byte sSceptilePose162
+.4byte sSceptilePose163
+.4byte sSceptilePose164
+.4byte sSceptilePose165
+.4byte sSceptilePose166
+.4byte sSceptilePose167
+.4byte sSceptilePose168
+.4byte sSceptilePose169
+.4byte sSceptilePose170
+.4byte sSceptilePose171
+.4byte sSceptilePose172
+.4byte sSceptilePose173
+.4byte sSceptilePose174
+.4byte sSceptilePose175
+.4byte sSceptilePose176
+.4byte sSceptilePose177
+.4byte sSceptilePose178
+.4byte sSceptilePose179
+.4byte sSceptilePose180
+.4byte sSceptilePose181
+.4byte sSceptilePose182
+.4byte sSceptilePose183
+.4byte sSceptilePose184
+.4byte sSceptilePose185
+.4byte sSceptilePose186
+.4byte sSceptilePose187
+.4byte sSceptilePose188
+.4byte sSceptilePose189
+.4byte sSceptilePose190
+.4byte sSceptilePose191
+.4byte sSceptilePose192
+.4byte sSceptilePose193
+.4byte sSceptilePose194
+.4byte sSceptilePose195
+.4byte sSceptilePose196
+.4byte sSceptilePose197
+.4byte sSceptilePose198
+.4byte sSceptilePose199
+.4byte sSceptilePose200
+.4byte sSceptilePose201
+.4byte sSceptilePose202
+.4byte sSceptilePose203
+.4byte sSceptilePose204
+.4byte sSceptilePose205
+.4byte sSceptilePose206
+.4byte sSceptilePose207
+.4byte sSceptilePose208
+sAxPositionsSceptile:
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte    0,  -11, 	  -7,   -7, 	   7,   -4, 	   0,   -7
+.2byte    0,  -11, 	  -7,   -4, 	   7,   -7, 	   0,   -7
+.2byte    7,  -13, 	   9,   -9, 	   0,   -6, 	   3,   -9
+.2byte    7,  -12, 	   8,  -11, 	   2,   -6, 	   3,   -8
+.2byte    7,  -12, 	  10,   -7, 	  -2,   -7, 	   3,   -8
+.2byte   10,  -16, 	   6,  -13, 	   8,   -7, 	   1,  -10
+.2byte   10,  -15, 	   1,  -11, 	  10,   -7, 	   1,  -10
+.2byte   10,  -15, 	   9,  -11, 	   4,   -7, 	   0,  -10
+.2byte    7,  -17, 	   0,  -14, 	  10,   -8, 	   2,  -13
+.2byte    7,  -16, 	  -1,  -11, 	  11,   -9, 	   2,  -12
+.2byte    7,  -16, 	   4,  -14, 	   7,   -7, 	   2,  -12
+.2byte    0,  -20, 	   6,  -12, 	  -7,  -11, 	   0,  -12
+.2byte    0,  -19, 	   6,   -9, 	  -5,  -13, 	  -1,  -12
+.2byte    0,  -19, 	   5,  -15, 	  -5,   -8, 	   0,  -12
+.2byte   -7,  -17, 	   0,  -14, 	 -10,   -8, 	  -2,  -13
+.2byte   -7,  -16, 	   1,  -11, 	 -11,   -9, 	  -2,  -12
+.2byte   -7,  -16, 	  -4,  -14, 	  -7,   -7, 	  -2,  -12
+.2byte  -10,  -16, 	  -6,  -13, 	  -8,   -7, 	  -1,  -10
+.2byte  -10,  -15, 	  -1,  -11, 	 -10,   -7, 	  -1,  -10
+.2byte  -10,  -15, 	  -9,  -11, 	  -4,   -7, 	   0,  -10
+.2byte   -7,  -13, 	  -9,   -9, 	   0,   -6, 	  -3,   -9
+.2byte   -7,  -12, 	  -8,  -11, 	  -2,   -6, 	  -3,   -8
+.2byte   -7,  -12, 	 -10,   -7, 	   2,   -7, 	  -3,   -8
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte    0,  -11, 	  -7,   -7, 	   7,   -4, 	   0,   -7
+.2byte    0,  -11, 	  -7,   -4, 	   7,   -7, 	   0,   -7
+.2byte    0,   -9, 	  -1,   -6, 	   5,   -5, 	   0,   -7
+.2byte    5,  -13, 	   7,   -9, 	  -2,   -6, 	   1,   -9
+.2byte    5,  -12, 	   6,  -11, 	   0,   -6, 	   1,   -8
+.2byte    5,  -12, 	   8,   -7, 	  -4,   -7, 	   1,   -8
+.2byte    3,   -9, 	   5,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    8,  -16, 	   4,  -13, 	   6,   -7, 	  -1,  -10
+.2byte    8,  -15, 	  -1,  -11, 	   8,   -7, 	  -1,  -10
+.2byte    8,  -15, 	   7,  -11, 	   2,   -7, 	  -2,  -10
+.2byte    4,  -11, 	   1,   -6, 	  -2,   -3, 	  -4,   -6
+.2byte    5,  -16, 	  -2,  -13, 	   8,   -7, 	   0,  -12
+.2byte    5,  -15, 	  -3,  -10, 	   9,   -8, 	   0,  -11
+.2byte    5,  -15, 	   2,  -13, 	   5,   -6, 	   0,  -11
+.2byte    8,  -11, 	   3,   -7, 	   3,   -4, 	  -1,   -8
+.2byte    0,  -19, 	   6,  -11, 	  -7,  -10, 	   0,  -11
+.2byte    0,  -18, 	   6,   -8, 	  -5,  -12, 	  -1,  -11
+.2byte    0,  -18, 	   5,  -14, 	  -5,   -7, 	   0,  -11
+.2byte   -1,  -15, 	   2,  -11, 	  -6,   -7, 	   1,   -8
+.2byte   -5,  -16, 	   2,  -13, 	  -8,   -7, 	   0,  -12
+.2byte   -5,  -15, 	   3,  -10, 	  -9,   -8, 	   0,  -11
+.2byte   -5,  -15, 	  -2,  -13, 	  -5,   -6, 	   0,  -11
+.2byte   -8,  -11, 	  -3,   -7, 	  -3,   -4, 	   1,   -8
+.2byte   -8,  -16, 	  -4,  -13, 	  -6,   -7, 	   1,  -10
+.2byte   -8,  -15, 	   1,  -11, 	  -8,   -7, 	   1,  -10
+.2byte   -8,  -15, 	  -7,  -11, 	  -2,   -7, 	   2,  -10
+.2byte   -5,  -12, 	  -2,   -7, 	   1,   -4, 	   3,   -7
+.2byte   -4,  -13, 	  -6,   -9, 	   3,   -6, 	   0,   -9
+.2byte   -4,  -12, 	  -5,  -11, 	   1,   -6, 	   0,   -8
+.2byte   -4,  -12, 	  -7,   -7, 	   5,   -7, 	   0,   -8
+.2byte   -2,   -9, 	  -4,   -5, 	   5,   -5, 	   1,   -6
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte    0,   -9, 	  -1,   -6, 	   5,   -5, 	   0,   -7
+.2byte   -1,  -19, 	  -8,  -14, 	   5,  -29, 	  -1,  -15
+.2byte   -1,  -19, 	  -8,  -14, 	   5,  -29, 	  -1,  -15
+.2byte   -1,  -12, 	  -8,   -8, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -13, 	   6,   -9, 	  -3,   -6, 	   0,   -9
+.2byte    2,   -9, 	   4,   -5, 	  -5,   -5, 	  -1,   -6
+.2byte    4,  -20, 	   5,  -14, 	   1,  -29, 	   0,  -15
+.2byte    4,  -20, 	   5,  -14, 	   1,  -29, 	   0,  -15
+.2byte    5,  -13, 	   6,  -12, 	   0,   -7, 	   1,   -9
+.2byte    9,  -16, 	   5,  -13, 	   7,   -7, 	   0,  -10
+.2byte    6,  -12, 	   3,   -7, 	   0,   -4, 	  -2,   -7
+.2byte    9,  -25, 	   1,  -18, 	   9,  -31, 	   1,  -16
+.2byte    9,  -24, 	   1,  -17, 	   9,  -30, 	   1,  -15
+.2byte    9,  -15, 	   0,  -11, 	   9,   -7, 	   0,  -10
+.2byte    5,  -16, 	  -2,  -13, 	   8,   -7, 	   0,  -12
+.2byte    8,  -11, 	   3,   -7, 	   3,   -4, 	  -1,   -8
+.2byte    6,  -22, 	  -3,  -12, 	   9,  -27, 	   0,  -13
+.2byte    6,  -22, 	  -3,  -12, 	   9,  -27, 	   0,  -13
+.2byte    5,  -15, 	  -3,  -10, 	   9,   -8, 	   0,  -11
+.2byte    0,  -18, 	   6,  -10, 	  -7,   -9, 	   0,  -10
+.2byte   -1,  -14, 	   2,  -10, 	  -6,   -6, 	   1,   -7
+.2byte    0,  -24, 	   7,  -13, 	  -7,  -28, 	  -1,  -13
+.2byte    0,  -24, 	   7,  -13, 	  -7,  -28, 	  -1,  -13
+.2byte   -1,  -24, 	  -8,  -13, 	   6,  -28, 	   0,  -13
+.2byte   -1,  -24, 	  -8,  -13, 	   6,  -28, 	   0,  -13
+.2byte   -7,  -15, 	   0,  -12, 	 -10,   -6, 	  -2,  -11
+.2byte  -10,  -10, 	  -5,   -6, 	  -5,   -3, 	  -1,   -7
+.2byte   -8,  -21, 	   1,  -11, 	 -11,  -26, 	  -2,  -12
+.2byte   -8,  -21, 	   1,  -11, 	 -11,  -26, 	  -2,  -12
+.2byte  -10,  -16, 	  -6,  -13, 	  -8,   -7, 	  -1,  -10
+.2byte   -7,  -12, 	  -4,   -7, 	  -1,   -4, 	   1,   -7
+.2byte  -10,  -25, 	  -2,  -18, 	 -10,  -31, 	  -2,  -16
+.2byte  -10,  -24, 	  -2,  -17, 	 -10,  -30, 	  -2,  -15
+.2byte   -5,  -13, 	  -7,   -9, 	   2,   -6, 	  -1,   -9
+.2byte   -3,   -9, 	  -5,   -5, 	   4,   -5, 	   0,   -6
+.2byte   -5,  -20, 	  -6,  -14, 	  -2,  -29, 	  -1,  -15
+.2byte   -5,  -20, 	  -6,  -14, 	  -2,  -29, 	  -1,  -15
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte    0,  -18, 	  -9,  -14, 	  11,  -14, 	   0,  -13
+.2byte    0,   -3, 	 -15,  -12, 	  14,  -12, 	   0,   -9
+.2byte    4,  -13, 	   6,   -9, 	  -3,   -6, 	   0,   -9
+.2byte    0,  -19, 	   5,  -16, 	  -7,  -11, 	  -1,  -11
+.2byte    8,   -4, 	  13,  -16, 	 -11,   -7, 	  -1,   -7
+.2byte    8,  -16, 	   4,  -13, 	   6,   -7, 	  -1,  -10
+.2byte    4,  -21, 	   2,  -14, 	   1,   -8, 	  -1,  -11
+.2byte   15,   -6, 	   4,  -14, 	   0,   -2, 	   1,   -7
+.2byte    6,  -16, 	  -1,  -13, 	   9,   -7, 	   1,  -12
+.2byte    5,  -22, 	  -4,  -19, 	  10,  -12, 	   0,  -12
+.2byte   11,  -15, 	  -3,  -17, 	  17,   -7, 	   3,  -10
+.2byte   -1,  -20, 	   5,  -12, 	  -8,  -11, 	  -1,  -12
+.2byte    0,  -27, 	   9,  -19, 	 -11,  -20, 	  -1,  -14
+.2byte   -1,  -20, 	  12,  -16, 	 -14,  -16, 	  -1,  -13
+.2byte   -7,  -16, 	   0,  -13, 	 -10,   -7, 	  -2,  -12
+.2byte   -6,  -22, 	   3,  -19, 	 -11,  -12, 	  -1,  -12
+.2byte  -12,  -15, 	   2,  -17, 	 -18,   -7, 	  -4,  -10
+.2byte   -9,  -16, 	  -5,  -13, 	  -7,   -7, 	   0,  -10
+.2byte   -5,  -21, 	  -3,  -14, 	  -2,   -8, 	   0,  -11
+.2byte  -16,   -6, 	  -5,  -14, 	  -1,   -2, 	  -2,   -7
+.2byte   -5,  -13, 	  -7,   -9, 	   2,   -6, 	  -1,   -9
+.2byte   -1,  -19, 	  -6,  -16, 	   6,  -11, 	   0,  -11
+.2byte   -9,   -4, 	 -14,  -16, 	  10,   -7, 	   0,   -7
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte   -7,  -13, 	  -9,   -9, 	   0,   -6, 	  -3,   -9
+.2byte  -10,  -16, 	  -6,  -13, 	  -8,   -7, 	  -1,  -10
+.2byte   -7,  -17, 	   0,  -14, 	 -10,   -8, 	  -2,  -13
+.2byte    0,  -20, 	   6,  -12, 	  -7,  -11, 	   0,  -12
+.2byte    7,  -17, 	   0,  -14, 	  10,   -8, 	   2,  -13
+.2byte   10,  -16, 	   6,  -13, 	   8,   -7, 	   1,  -10
+.2byte    7,  -13, 	   9,   -9, 	   0,   -6, 	   3,   -9
+.2byte   -1,  -11, 	  -7,   -8, 	   4,   -1, 	  -1,   -7
+.2byte   -2,  -10, 	  -7,   -7, 	   2,   -2, 	  -1,   -7
+.2byte   -2,  -19, 	  -4,  -24, 	   5,  -16, 	   0,  -11
+.2byte    0,  -16, 	   1,  -24, 	  -6,  -16, 	  -3,  -12
+.2byte   -1,  -18, 	  -1,  -24, 	  -6,  -14, 	  -4,  -11
+.2byte    2,  -17, 	  -4,  -22, 	   3,  -16, 	  -2,   -8
+.2byte    2,  -17, 	   6,  -17, 	  -5,  -14, 	   0,   -9
+.2byte   -3,  -17, 	   3,  -22, 	  -4,  -16, 	   1,   -8
+.2byte    0,  -18, 	   0,  -24, 	   5,  -14, 	   3,  -11
+.2byte   -1,  -16, 	  -2,  -24, 	   5,  -16, 	   2,  -12
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte    0,  -11, 	  -9,   -5, 	   9,   -5, 	   0,   -7
+.2byte    5,  -13, 	   7,   -9, 	  -2,   -6, 	   1,   -9
+.2byte    7,  -12, 	   9,   -8, 	  -2,   -5, 	   1,   -9
+.2byte    8,  -16, 	   4,  -13, 	   6,   -7, 	  -1,  -10
+.2byte   10,  -14, 	   4,  -10, 	   7,   -7, 	  -1,   -8
+.2byte    6,  -16, 	  -1,  -13, 	   9,   -7, 	   1,  -12
+.2byte    9,  -14, 	   1,  -13, 	  11,   -6, 	   2,  -10
+.2byte    0,  -18, 	   6,  -10, 	  -7,   -9, 	   0,  -10
+.2byte    0,  -17, 	   7,  -12, 	  -7,  -12, 	   0,  -12
+.2byte   -6,  -16, 	   1,  -13, 	  -9,   -7, 	  -1,  -12
+.2byte   -9,  -14, 	  -1,  -13, 	 -11,   -6, 	  -2,  -10
+.2byte   -9,  -16, 	  -5,  -13, 	  -7,   -7, 	   0,  -10
+.2byte  -11,  -14, 	  -5,  -10, 	  -8,   -7, 	   0,   -8
+.2byte   -5,  -12, 	  -7,   -8, 	   2,   -5, 	  -1,   -8
+.2byte   -7,  -11, 	  -9,   -7, 	   2,   -4, 	  -1,   -8
+.2byte    0,   -3, 	 -15,  -12, 	  14,  -12, 	   0,   -9
+.2byte   -9,   -4, 	 -14,  -16, 	  10,   -7, 	   0,   -7
+.2byte  -14,   -7, 	  -3,  -15, 	   1,   -3, 	   0,   -8
+.2byte   -8,  -15, 	   6,  -17, 	 -14,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  12,  -11, 	 -14,  -11, 	  -1,   -8
+.2byte    7,  -15, 	  -7,  -17, 	  13,   -7, 	  -1,  -10
+.2byte   13,   -7, 	   2,  -15, 	  -2,   -3, 	  -1,   -8
+.2byte    8,   -4, 	  13,  -16, 	 -11,   -7, 	  -1,   -7
+.2byte    0,   -9, 	  -1,   -6, 	   5,   -5, 	   0,   -7
+.2byte    3,   -9, 	   5,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    7,  -11, 	   4,   -6, 	   1,   -3, 	  -1,   -6
+.2byte    8,  -11, 	   3,   -7, 	   3,   -4, 	  -1,   -8
+.2byte   -1,  -15, 	   2,  -11, 	  -6,   -7, 	   1,   -8
+.2byte   -8,  -11, 	  -3,   -7, 	  -3,   -4, 	   1,   -8
+.2byte   -8,  -12, 	  -5,   -7, 	  -2,   -4, 	   0,   -7
+.2byte   -2,   -9, 	  -4,   -5, 	   5,   -5, 	   1,   -6
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte    0,  -16, 	  -9,  -12, 	  11,  -12, 	   0,  -11
+.2byte    0,   -3, 	 -15,  -12, 	  14,  -12, 	   0,   -9
+.2byte    4,  -13, 	   6,   -9, 	  -3,   -6, 	   0,   -9
+.2byte    0,  -18, 	   5,  -15, 	  -7,  -10, 	  -1,  -10
+.2byte    7,   -4, 	  12,  -16, 	 -12,   -7, 	  -2,   -7
+.2byte    8,  -16, 	   4,  -13, 	   6,   -7, 	  -1,  -10
+.2byte    4,  -21, 	   2,  -14, 	   1,   -8, 	  -1,  -11
+.2byte   15,   -6, 	   4,  -14, 	   0,   -2, 	   1,   -7
+.2byte    6,  -16, 	  -1,  -13, 	   9,   -7, 	   1,  -12
+.2byte    4,  -22, 	  -5,  -19, 	   9,  -12, 	  -1,  -12
+.2byte    9,  -15, 	  -5,  -17, 	  15,   -7, 	   1,  -10
+.2byte   -1,  -20, 	   5,  -12, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -25, 	   8,  -17, 	 -12,  -18, 	  -2,  -12
+.2byte   -1,  -20, 	  12,  -16, 	 -14,  -16, 	  -1,  -13
+.2byte   -7,  -16, 	   0,  -13, 	 -10,   -7, 	  -2,  -12
+.2byte   -5,  -22, 	   4,  -19, 	 -10,  -12, 	   0,  -12
+.2byte  -10,  -15, 	   4,  -17, 	 -16,   -7, 	  -2,  -10
+.2byte   -9,  -16, 	  -5,  -13, 	  -7,   -7, 	   0,  -10
+.2byte   -5,  -21, 	  -3,  -14, 	  -2,   -8, 	   0,  -11
+.2byte  -16,   -6, 	  -5,  -14, 	  -1,   -2, 	  -2,   -7
+.2byte   -5,  -13, 	  -7,   -9, 	   2,   -6, 	  -1,   -9
+.2byte   -1,  -18, 	  -6,  -15, 	   6,  -10, 	   0,  -10
+.2byte   -8,   -4, 	 -13,  -16, 	  11,   -7, 	   1,   -7
+.2byte    0,   -3, 	 -15,  -12, 	  14,  -12, 	   0,   -9
+.2byte   -9,   -4, 	 -14,  -16, 	  10,   -7, 	   0,   -7
+.2byte  -14,   -7, 	  -3,  -15, 	   1,   -3, 	   0,   -8
+.2byte   -8,  -15, 	   6,  -17, 	 -14,   -7, 	   0,  -10
+.2byte   -1,  -19, 	  12,  -15, 	 -14,  -15, 	  -1,  -12
+.2byte    7,  -15, 	  -7,  -17, 	  13,   -7, 	  -1,  -10
+.2byte   13,   -7, 	   2,  -15, 	  -2,   -3, 	  -1,   -8
+.2byte    8,   -4, 	  13,  -16, 	 -11,   -7, 	  -1,   -7
+.2byte    0,  -12, 	  -8,   -6, 	   8,   -6, 	   0,   -8
+.2byte   -7,  -13, 	  -9,   -9, 	   0,   -6, 	  -3,   -9
+.2byte  -10,  -16, 	  -6,  -13, 	  -8,   -7, 	  -1,  -10
+.2byte   -7,  -17, 	   0,  -14, 	 -10,   -8, 	  -2,  -13
+.2byte    0,  -20, 	   6,  -12, 	  -7,  -11, 	   0,  -12
+.2byte    7,  -17, 	   0,  -14, 	  10,   -8, 	   2,  -13
+.2byte   10,  -16, 	   6,  -13, 	   8,   -7, 	   1,  -10
+.2byte    7,  -13, 	   9,   -9, 	   0,   -6, 	   3,   -9
+sSceptileAnimTable1:
+.4byte sSceptileAnims_1_1
+.4byte sSceptileAnims_1_2
+.4byte sSceptileAnims_1_3
+.4byte sSceptileAnims_1_4
+.4byte sSceptileAnims_1_5
+.4byte sSceptileAnims_1_6
+.4byte sSceptileAnims_1_7
+.4byte sSceptileAnims_1_8
+sSceptileAnimTable2:
+.4byte sSceptileAnims_2_1
+.4byte sSceptileAnims_2_2
+.4byte sSceptileAnims_2_3
+.4byte sSceptileAnims_2_4
+.4byte sSceptileAnims_2_5
+.4byte sSceptileAnims_2_6
+.4byte sSceptileAnims_2_7
+.4byte sSceptileAnims_2_8
+sSceptileAnimTable3:
+.4byte sSceptileAnims_3_1
+.4byte sSceptileAnims_3_2
+.4byte sSceptileAnims_3_3
+.4byte sSceptileAnims_3_4
+.4byte sSceptileAnims_3_5
+.4byte sSceptileAnims_3_6
+.4byte sSceptileAnims_3_7
+.4byte sSceptileAnims_3_8
+sSceptileAnimTable4:
+.4byte sSceptileAnims_4_1
+.4byte sSceptileAnims_4_2
+.4byte sSceptileAnims_4_3
+.4byte sSceptileAnims_4_4
+.4byte sSceptileAnims_4_5
+.4byte sSceptileAnims_4_6
+.4byte sSceptileAnims_4_7
+.4byte sSceptileAnims_4_8
+sSceptileAnimTable5:
+.4byte sSceptileAnims_5_1
+.4byte sSceptileAnims_5_2
+.4byte sSceptileAnims_5_3
+.4byte sSceptileAnims_5_4
+.4byte sSceptileAnims_5_5
+.4byte sSceptileAnims_5_6
+.4byte sSceptileAnims_5_7
+.4byte sSceptileAnims_5_8
+sSceptileAnimTable6:
+.4byte sSceptileAnims_6_1
+.4byte sSceptileAnims_6_1
+.4byte sSceptileAnims_6_1
+.4byte sSceptileAnims_6_1
+.4byte sSceptileAnims_6_1
+.4byte sSceptileAnims_6_1
+.4byte sSceptileAnims_6_1
+.4byte sSceptileAnims_6_1
+sSceptileAnimTable7:
+.4byte sSceptileAnims_7_1
+.4byte sSceptileAnims_7_2
+.4byte sSceptileAnims_7_3
+.4byte sSceptileAnims_7_4
+.4byte sSceptileAnims_7_5
+.4byte sSceptileAnims_7_6
+.4byte sSceptileAnims_7_7
+.4byte sSceptileAnims_7_8
+sSceptileAnimTable8:
+.4byte sSceptileAnims_8_1
+.4byte sSceptileAnims_8_2
+.4byte sSceptileAnims_8_3
+.4byte sSceptileAnims_8_4
+.4byte sSceptileAnims_8_5
+.4byte sSceptileAnims_8_6
+.4byte sSceptileAnims_8_7
+.4byte sSceptileAnims_8_8
+sSceptileAnimTable9:
+.4byte sSceptileAnims_9_1
+.4byte sSceptileAnims_9_2
+.4byte sSceptileAnims_9_3
+.4byte sSceptileAnims_9_4
+.4byte sSceptileAnims_9_5
+.4byte sSceptileAnims_9_6
+.4byte sSceptileAnims_9_7
+.4byte sSceptileAnims_9_8
+sSceptileAnimTable10:
+.4byte sSceptileAnims_10_1
+.4byte sSceptileAnims_10_2
+.4byte sSceptileAnims_10_3
+.4byte sSceptileAnims_10_4
+.4byte sSceptileAnims_10_5
+.4byte sSceptileAnims_10_6
+.4byte sSceptileAnims_10_7
+.4byte sSceptileAnims_10_8
+sSceptileAnimTable11:
+.4byte sSceptileAnims_11_1
+.4byte sSceptileAnims_11_2
+.4byte sSceptileAnims_11_3
+.4byte sSceptileAnims_11_4
+.4byte sSceptileAnims_11_5
+.4byte sSceptileAnims_11_6
+.4byte sSceptileAnims_11_7
+.4byte sSceptileAnims_11_8
+sSceptileAnimTable12:
+.4byte sSceptileAnims_12_1
+.4byte sSceptileAnims_12_2
+.4byte sSceptileAnims_12_3
+.4byte sSceptileAnims_12_4
+.4byte sSceptileAnims_12_5
+.4byte sSceptileAnims_12_6
+.4byte sSceptileAnims_12_7
+.4byte sSceptileAnims_12_8
+sSceptileAnimTable13:
+.4byte sSceptileAnims_13_1
+.4byte sSceptileAnims_13_2
+.4byte sSceptileAnims_13_3
+.4byte sSceptileAnims_13_4
+.4byte sSceptileAnims_13_5
+.4byte sSceptileAnims_13_6
+.4byte sSceptileAnims_13_7
+.4byte sSceptileAnims_13_8
+sAxAnimationsSceptile:
+.4byte sSceptileAnimTable1
+.4byte sSceptileAnimTable2
+.4byte sSceptileAnimTable3
+.4byte sSceptileAnimTable4
+.4byte sSceptileAnimTable5
+.4byte sSceptileAnimTable6
+.4byte sSceptileAnimTable7
+.4byte sSceptileAnimTable8
+.4byte sSceptileAnimTable9
+.4byte sSceptileAnimTable10
+.4byte sSceptileAnimTable11
+.4byte sSceptileAnimTable12
+.4byte sSceptileAnimTable13
+sAxSpritesSceptile:
+.4byte sSceptileSprites1
+.4byte sSceptileSprites2
+.4byte sSceptileSprites3
+.4byte sSceptileSprites4
+.4byte sSceptileSprites5
+.4byte sSceptileSprites6
+.4byte sSceptileSprites7
+.4byte sSceptileSprites8
+.4byte sSceptileSprites9
+.4byte sSceptileSprites10
+.4byte sSceptileSprites11
+.4byte sSceptileSprites12
+.4byte sSceptileSprites13
+.4byte sSceptileSprites14
+.4byte sSceptileSprites15
+.4byte sSceptileSprites16
+.4byte sSceptileSprites17
+.4byte sSceptileSprites18
+.4byte sSceptileSprites19
+.4byte sSceptileSprites20
+.4byte sSceptileSprites21
+.4byte sSceptileSprites22
+.4byte sSceptileSprites23
+.4byte sSceptileSprites24
+.4byte sSceptileSprites25
+.4byte sSceptileSprites26
+.4byte sSceptileSprites27
+.4byte sSceptileSprites28
+.4byte sSceptileSprites29
+.4byte sSceptileSprites30
+.4byte sSceptileSprites31
+.4byte sSceptileSprites32
+.4byte sSceptileSprites33
+.4byte sSceptileSprites34
+.4byte sSceptileSprites35
+.4byte sSceptileSprites36
+.4byte sSceptileSprites37
+.4byte sSceptileSprites38
+.4byte sSceptileSprites39
+.4byte sSceptileSprites40
+.4byte sSceptileSprites41
+.4byte sSceptileSprites42
+.4byte sSceptileSprites43
+.4byte sSceptileSprites44
+.4byte sSceptileSprites45
+.4byte sSceptileSprites46
+.4byte sSceptileSprites47
+.4byte sSceptileSprites48
+.4byte sSceptileSprites49
+.4byte sSceptileSprites50
+.4byte sSceptileSprites51
+.4byte sSceptileSprites52
+.4byte sSceptileSprites53
+.4byte sSceptileSprites54
+.4byte sSceptileSprites55
+.4byte sSceptileSprites56
+.4byte sSceptileSprites57
+.4byte sSceptileSprites58
+.4byte sSceptileSprites59
+.4byte sSceptileSprites60
+.4byte sSceptileSprites61
+.4byte sSceptileSprites62
+.4byte sSceptileSprites63
+.4byte sSceptileSprites64
+.4byte sSceptileSprites65
+.4byte sSceptileSprites66
+.4byte sSceptileSprites67
+.4byte sSceptileSprites68
+.4byte sSceptileSprites69
+.4byte sSceptileSprites70
+.4byte sSceptileSprites71
+.4byte sSceptileSprites72
+.4byte sSceptileSprites73
+.4byte sSceptileSprites74
+.4byte sSceptileSprites75
+.4byte sSceptileSprites76
+.4byte sSceptileSprites77
+.4byte sSceptileSprites78
+.4byte sSceptileSprites79
+sAxMainSceptile:
+ax_main sAxPosesSceptile, sAxAnimationsSceptile, 13, sAxSpritesSceptile, sAxPositionsSceptile

--- a/data/ax/scizor.inc
+++ b/data/ax/scizor.inc
@@ -1,0 +1,2955 @@
+.global gAxScizor
+gAxScizor:
+ax_siro sAxMainScizor
+sScizorPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose2:
+ax_pose 1, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sScizorPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose7:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose9:
+ax_pose 8, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose10:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose11:
+ax_pose 10, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose12:
+ax_pose 11, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose26:
+ax_pose 1, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sScizorPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose28:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose29:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose30:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose31:
+ax_pose 4, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose32:
+ax_pose 5, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose33:
+ax_pose 17, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose34:
+ax_pose 18, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose35:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose36:
+ax_pose 7, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose37:
+ax_pose 8, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose38:
+ax_pose 19, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose39:
+ax_pose 20, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose40:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose41:
+ax_pose 10, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose42:
+ax_pose 11, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose43:
+ax_pose 21, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose44:
+ax_pose 22, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose45:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose46:
+ax_pose 13, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose47:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose48:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose49:
+ax_pose 24, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose50:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose51:
+ax_pose 10, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose52:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose53:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose54:
+ax_pose 22, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose55:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose56:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose57:
+ax_pose 8, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose58:
+ax_pose 19, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose59:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose60:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose61:
+ax_pose 4, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose62:
+ax_pose 5, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose63:
+ax_pose 17, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose64:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose65:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose66:
+ax_pose 1, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sScizorPose67:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose68:
+ax_pose 25, 0x01e8, 0x80f0, 0x2c00
+ax_pose 26, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose69:
+ax_pose 26, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose70:
+ax_pose 25, 0x01e8, 0x90f0, 0x2c00
+ax_pose 26, 0x01e5, 0x90f0, 0x2c10
+ax_pose_terminator
+sScizorPose71:
+ax_pose 26, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sScizorPose72:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose73:
+ax_pose 4, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose74:
+ax_pose 5, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose75:
+ax_pose 27, 0x01e5, 0x90f3, 0x2c00
+ax_pose 28, 0x01e5, 0x90ef, 0x2c10
+ax_pose_terminator
+sScizorPose76:
+ax_pose 28, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose77:
+ax_pose 29, 0x01e5, 0x90f1, 0x2c00
+ax_pose 30, 0x01e5, 0x90ef, 0x2c10
+ax_pose_terminator
+sScizorPose78:
+ax_pose 30, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose79:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose80:
+ax_pose 7, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose81:
+ax_pose 8, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose82:
+ax_pose 31, 0x01e5, 0x90f3, 0x2c00
+ax_pose 32, 0x01e5, 0x90ef, 0x2c10
+ax_pose_terminator
+sScizorPose83:
+ax_pose 32, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose84:
+ax_pose 33, 0x01e5, 0x90f4, 0x2c00
+ax_pose 34, 0x01e5, 0x90ef, 0x2c10
+ax_pose_terminator
+sScizorPose85:
+ax_pose 34, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose86:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose87:
+ax_pose 10, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose88:
+ax_pose 11, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose89:
+ax_pose 35, 0x01e5, 0x90f0, 0x2c00
+ax_pose 36, 0x01e5, 0x90ef, 0x2c10
+ax_pose_terminator
+sScizorPose90:
+ax_pose 36, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose91:
+ax_pose 37, 0x01e4, 0x90ef, 0x2c00
+ax_pose 38, 0x01e5, 0x90ef, 0x2c10
+ax_pose_terminator
+sScizorPose92:
+ax_pose 38, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose93:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose94:
+ax_pose 13, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose95:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose96:
+ax_pose 39, 0x01e1, 0x80f0, 0x2c00
+ax_pose 40, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose97:
+ax_pose 40, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose98:
+ax_pose 39, 0x01e1, 0x90f0, 0x2c00
+ax_pose 40, 0x01e5, 0x90f0, 0x2c10
+ax_pose_terminator
+sScizorPose99:
+ax_pose 40, 0x01e5, 0x90f0, 0x2c00
+ax_pose_terminator
+sScizorPose100:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose101:
+ax_pose 10, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose102:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose103:
+ax_pose 35, 0x01e5, 0x80ef, 0x2c00
+ax_pose 36, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose104:
+ax_pose 36, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose105:
+ax_pose 37, 0x01e4, 0x80f0, 0x2c00
+ax_pose 38, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose106:
+ax_pose 38, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose107:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose108:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose109:
+ax_pose 8, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose110:
+ax_pose 31, 0x01e5, 0x80ec, 0x2c00
+ax_pose 32, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose111:
+ax_pose 32, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose112:
+ax_pose 33, 0x01e5, 0x80eb, 0x2c00
+ax_pose 34, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose113:
+ax_pose 34, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose114:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose115:
+ax_pose 4, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose116:
+ax_pose 5, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose117:
+ax_pose 27, 0x01e5, 0x80ec, 0x2c00
+ax_pose 28, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose118:
+ax_pose 28, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose119:
+ax_pose 29, 0x01e5, 0x80ee, 0x2c00
+ax_pose 30, 0x01e5, 0x80f0, 0x2c10
+ax_pose_terminator
+sScizorPose120:
+ax_pose 30, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose121:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose122:
+ax_pose 17, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sScizorPose123:
+ax_pose 19, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sScizorPose124:
+ax_pose 21, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose125:
+ax_pose 23, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose126:
+ax_pose 21, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sScizorPose127:
+ax_pose 19, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sScizorPose128:
+ax_pose 17, 0x01e5, 0x90f2, 0x2c00
+ax_pose_terminator
+sScizorPose129:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose130:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose131:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose132:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose133:
+ax_pose 17, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose134:
+ax_pose 18, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose135:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose136:
+ax_pose 19, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose137:
+ax_pose 20, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose138:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose139:
+ax_pose 21, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose140:
+ax_pose 22, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose141:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose142:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose143:
+ax_pose 24, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose144:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose145:
+ax_pose 21, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose146:
+ax_pose 22, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose147:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose148:
+ax_pose 19, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose149:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose150:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose151:
+ax_pose 17, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose152:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose153:
+ax_pose 41, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sScizorPose154:
+ax_pose 42, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sScizorPose155:
+ax_pose 43, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose156:
+ax_pose 44, 0x01e3, 0x90ea, 0x2c00
+ax_pose_terminator
+sScizorPose157:
+ax_pose 45, 0x01e3, 0x90ea, 0x2c00
+ax_pose_terminator
+sScizorPose158:
+ax_pose 46, 0x01e3, 0x90e9, 0x2c00
+ax_pose_terminator
+sScizorPose159:
+ax_pose 47, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sScizorPose160:
+ax_pose 46, 0x01e3, 0x80f7, 0x2c00
+ax_pose_terminator
+sScizorPose161:
+ax_pose 45, 0x01e3, 0x80f6, 0x2c00
+ax_pose_terminator
+sScizorPose162:
+ax_pose 44, 0x01e3, 0x80f6, 0x2c00
+ax_pose_terminator
+sScizorPose163:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose164:
+ax_pose 16, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sScizorPose165:
+ax_pose 2, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose166:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose167:
+ax_pose 18, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose168:
+ax_pose 5, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose169:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose170:
+ax_pose 20, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose171:
+ax_pose 8, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose172:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose173:
+ax_pose 22, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose174:
+ax_pose 11, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose175:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose176:
+ax_pose 24, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose177:
+ax_pose 14, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose178:
+ax_pose 22, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose179:
+ax_pose 10, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose180:
+ax_pose 11, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose181:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose182:
+ax_pose 7, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose183:
+ax_pose 8, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose184:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose185:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose186:
+ax_pose 5, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose187:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose188:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose189:
+ax_pose 20, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sScizorPose190:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose191:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose192:
+ax_pose 22, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sScizorPose193:
+ax_pose 20, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sScizorPose194:
+ax_pose 18, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sScizorPose195:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose196:
+ax_pose 18, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sScizorPose197:
+ax_pose 20, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sScizorPose198:
+ax_pose 22, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sScizorPose199:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose200:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose201:
+ax_pose 20, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sScizorPose202:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose203:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose204:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose205:
+ax_pose 16, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose206:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose207:
+ax_pose 17, 0x01e5, 0x90f2, 0x2c00
+ax_pose_terminator
+sScizorPose208:
+ax_pose 18, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sScizorPose209:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose210:
+ax_pose 19, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sScizorPose211:
+ax_pose 20, 0x01e5, 0x90ee, 0x2c00
+ax_pose_terminator
+sScizorPose212:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose213:
+ax_pose 21, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sScizorPose214:
+ax_pose 22, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose215:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose216:
+ax_pose 23, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose217:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose218:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose219:
+ax_pose 21, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sScizorPose220:
+ax_pose 22, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose221:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose222:
+ax_pose 19, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sScizorPose223:
+ax_pose 20, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sScizorPose224:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose225:
+ax_pose 17, 0x01e5, 0x80ed, 0x2c00
+ax_pose_terminator
+sScizorPose226:
+ax_pose 18, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sScizorPose227:
+ax_pose 15, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose228:
+ax_pose 17, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sScizorPose229:
+ax_pose 19, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sScizorPose230:
+ax_pose 21, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose231:
+ax_pose 23, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose232:
+ax_pose 21, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sScizorPose233:
+ax_pose 19, 0x01e4, 0x90f1, 0x2c00
+ax_pose_terminator
+sScizorPose234:
+ax_pose 17, 0x01e5, 0x90f2, 0x2c00
+ax_pose_terminator
+sScizorPose235:
+ax_pose 0, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose236:
+ax_pose 3, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose237:
+ax_pose 6, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose238:
+ax_pose 9, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose239:
+ax_pose 12, 0x01e5, 0x80f0, 0x2c00
+ax_pose_terminator
+sScizorPose240:
+ax_pose 9, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose241:
+ax_pose 6, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+sScizorPose242:
+ax_pose 3, 0x01e5, 0x90ef, 0x2c00
+ax_pose_terminator
+.align 2
+sScizorAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 0, 4, 0, 4,
+ax_anim 1, 0, 28, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sScizorAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 6, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 4, 4, 4,
+ax_anim 1, 0, 33, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 18, 18, 18, 18,
+ax_anim 2, 1, 33, 19, 17, 19, 17,
+ax_anim 2, 0, 33, 18, 18, 18, 18,
+ax_anim 2, 0, 33, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sScizorAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 6, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, 0, 4, 0,
+ax_anim 1, 0, 38, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 1, 38, 16, 1, 16, 1,
+ax_anim 2, 0, 38, 16, 0, 16, 0,
+ax_anim 2, 0, 38, 16, 1, 16, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sScizorAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 6, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 43, 0, -1, 0, -1,
+ax_anim 1, 2, 43, 6, -6, 6, -6,
+ax_anim 1, 0, 43, 13, -13, 13, -13,
+ax_anim 2, 0, 43, 19, -18, 19, -18,
+ax_anim 2, 1, 43, 20, -17, 20, -17,
+ax_anim 2, 0, 43, 19, -18, 19, -18,
+ax_anim 2, 0, 43, 20, -17, 20, -17,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sScizorAnims_2_5:
+ax_anim 2, 0, 47, 0, 1, 0, 1,
+ax_anim 6, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, -4, 0, -4,
+ax_anim 1, 0, 48, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -18, 0, -18,
+ax_anim 2, 1, 48, 1, -18, 1, -18,
+ax_anim 2, 0, 48, 0, -18, 0, -18,
+ax_anim 2, 0, 48, 1, -18, 1, -18,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sScizorAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 6, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 53, 0, -1, 0, -1,
+ax_anim 1, 2, 53, -6, -6, -6, -6,
+ax_anim 1, 0, 53, -13, -13, -13, -13,
+ax_anim 2, 0, 53, -19, -18, -19, -18,
+ax_anim 2, 1, 53, -20, -17, -20, -17,
+ax_anim 2, 0, 53, -19, -18, -19, -18,
+ax_anim 2, 0, 53, -20, -17, -20, -17,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sScizorAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 6, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 58, -4, 0, -4, 0,
+ax_anim 1, 0, 58, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 1, 58, -16, 1, -16, 1,
+ax_anim 2, 0, 58, -16, 0, -16, 0,
+ax_anim 2, 0, 58, -16, 1, -16, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sScizorAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 6, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 63, -4, 4, -4, 4,
+ax_anim 1, 0, 63, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -18, 18, -18, 18,
+ax_anim 2, 1, 63, -19, 17, -19, 17,
+ax_anim 2, 0, 63, -18, 18, -18, 18,
+ax_anim 2, 0, 63, -19, 17, -19, 17,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sScizorAnims_3_1:
+ax_anim 1, 0, 119, 0, -2, 0, -2,
+ax_anim 2, 0, 119, 0, -4, 0, -4,
+ax_anim 6, 0, 119, 0, -6, 0, -6,
+ax_anim 1, 0, 119, 0, -3, 0, -3,
+ax_anim 2, 2, 70, 0, 3, 0, 3,
+ax_anim 2, 0, 67, 0, 14, 0, 14,
+ax_anim 2, 1, 77, 1, 15, 1, 15,
+ax_anim 2, 0, 77, 1, 11, 1, 11,
+ax_anim 2, 0, 68, 0, 9, 0, 9,
+ax_anim 2, 0, 69, 0, 14, 0, 14,
+ax_anim 4, 0, 119, -1, 15, -1, 15,
+ax_anim 2, 0, 70, -1, 16, -1, 16,
+ax_anim 2, 0, 65, 0, 11, 0, 11,
+ax_anim 2, 0, 64, 0, 3, 0, 3,
+ax_anim_terminator
+sScizorAnims_3_2:
+ax_anim 1, 0, 84, -2, -2, -2, -2,
+ax_anim 2, 0, 84, -4, -4, -4, -4,
+ax_anim 6, 0, 84, -6, -6, -6, -6,
+ax_anim 1, 0, 84, -3, -3, -3, -3,
+ax_anim 2, 2, 77, 6, 6, 6, 6,
+ax_anim 2, 0, 74, 13, 17, 13, 17,
+ax_anim 2, 1, 70, 12, 19, 12, 19,
+ax_anim 2, 0, 70, 10, 15, 10, 15,
+ax_anim 2, 0, 75, 10, 12, 10, 12,
+ax_anim 2, 0, 76, 13, 17, 13, 17,
+ax_anim 4, 0, 84, 15, 16, 15, 16,
+ax_anim 2, 0, 77, 14, 13, 14, 13,
+ax_anim 2, 0, 72, 11, 11, 11, 11,
+ax_anim 2, 0, 71, 3, 3, 3, 3,
+ax_anim_terminator
+sScizorAnims_3_3:
+ax_anim 1, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -4, 0, -4, 0,
+ax_anim 6, 0, 91, -6, 0, -6, 0,
+ax_anim 1, 0, 91, -3, 0, -3, 0,
+ax_anim 2, 2, 84, 6, 0, 6, 0,
+ax_anim 2, 0, 81, 12, 0, 12, 0,
+ax_anim 2, 1, 75, 13, 2, 13, 2,
+ax_anim 2, 0, 75, 7, 2, 7, 2,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 12, 0, 12, 0,
+ax_anim 4, 0, 91, 13, -1, 13, -1,
+ax_anim 2, 0, 84, 10, -1, 10, -1,
+ax_anim 2, 0, 79, 6, -1, 6, -1,
+ax_anim 2, 0, 78, 3, 0, 3, 0,
+ax_anim_terminator
+sScizorAnims_3_4:
+ax_anim 1, 0, 96, -2, 2, -2, 2,
+ax_anim 2, 0, 96, -4, 4, -4, 4,
+ax_anim 6, 0, 96, -6, 6, -6, 6,
+ax_anim 1, 0, 96, -3, 3, -3, 3,
+ax_anim 2, 2, 91, 6, -7, 6, -7,
+ax_anim 2, 0, 88, 16, -13, 16, -13,
+ax_anim 2, 1, 82, 18, -13, 18, -13,
+ax_anim 2, 0, 82, 14, -9, 14, -9,
+ax_anim 2, 0, 89, 8, -6, 8, -6,
+ax_anim 2, 0, 90, 16, -13, 16, -13,
+ax_anim 4, 0, 96, 16, -15, 16, -15,
+ax_anim 2, 0, 91, 10, -13, 10, -13,
+ax_anim 2, 0, 86, 6, -7, 6, -7,
+ax_anim 2, 0, 85, 3, -3, 3, -3,
+ax_anim_terminator
+sScizorAnims_3_5:
+ax_anim 1, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 0, 4, 0, 4,
+ax_anim 6, 0, 89, 0, 6, 0, 6,
+ax_anim 1, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 2, 98, 0, -6, 0, -6,
+ax_anim 2, 0, 95, 0, -11, 0, -11,
+ax_anim 2, 1, 103, -1, -12, -1, -12,
+ax_anim 2, 0, 103, -1, -8, -1, -8,
+ax_anim 2, 0, 96, 0, -4, 0, -4,
+ax_anim 2, 0, 97, 0, -11, 0, -11,
+ax_anim 4, 0, 89, 1, -12, 1, -12,
+ax_anim 2, 0, 98, 1, -10, 1, -10,
+ax_anim 2, 0, 93, 0, -5, 0, -5,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim_terminator
+sScizorAnims_3_6:
+ax_anim 1, 0, 98, 2, 2, 2, 2,
+ax_anim 2, 0, 98, 4, 4, 4, 4,
+ax_anim 6, 0, 98, 6, 6, 6, 6,
+ax_anim 1, 0, 98, 3, 3, 3, 3,
+ax_anim 2, 2, 105, -6, -7, -6, -7,
+ax_anim 2, 0, 102, -16, -13, -16, -13,
+ax_anim 2, 1, 110, -18, -13, -18, -13,
+ax_anim 2, 0, 110, -14, -9, -14, -9,
+ax_anim 2, 0, 103, -8, -6, -8, -6,
+ax_anim 2, 0, 104, -16, -13, -16, -13,
+ax_anim 4, 0, 98, -16, -15, -16, -15,
+ax_anim 2, 0, 105, -10, -13, -10, -13,
+ax_anim 2, 0, 100, -6, -7, -6, -7,
+ax_anim 2, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sScizorAnims_3_7:
+ax_anim 1, 0, 105, 2, 0, 2, 0,
+ax_anim 2, 0, 105, 4, 0, 4, 0,
+ax_anim 6, 0, 105, 6, 0, 6, 0,
+ax_anim 1, 0, 105, 3, 0, 3, 0,
+ax_anim 2, 2, 112, -6, 0, -6, 0,
+ax_anim 2, 0, 109, -12, 0, -12, 0,
+ax_anim 2, 1, 117, -13, 2, -13, 2,
+ax_anim 2, 0, 117, -7, 2, -7, 2,
+ax_anim 2, 0, 110, -4, 0, -4, 0,
+ax_anim 2, 0, 111, -12, 0, -12, 0,
+ax_anim 4, 0, 105, -13, -1, -13, -1,
+ax_anim 2, 0, 112, -10, -1, -10, -1,
+ax_anim 2, 0, 107, -6, -1, -6, -1,
+ax_anim 2, 0, 106, -3, 0, -3, 0,
+ax_anim_terminator
+sScizorAnims_3_8:
+ax_anim 1, 0, 112, 2, -2, 2, -2,
+ax_anim 2, 0, 112, 4, -4, 4, -4,
+ax_anim 6, 0, 112, 6, -6, 6, -6,
+ax_anim 1, 0, 112, 3, -3, 3, -3,
+ax_anim 2, 2, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 116, -13, 17, -13, 17,
+ax_anim 2, 1, 68, -12, 19, -12, 19,
+ax_anim 2, 0, 68, -10, 15, -10, 15,
+ax_anim 2, 0, 117, -9, 12, -9, 12,
+ax_anim 2, 0, 118, -13, 17, -13, 17,
+ax_anim 4, 0, 112, -15, 16, -15, 16,
+ax_anim 2, 0, 119, -14, 13, -14, 13,
+ax_anim 2, 0, 114, -11, 11, -11, 11,
+ax_anim 2, 0, 113, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sScizorAnims_4_1:
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_4_2:
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, 1, -1,
+ax_anim 2, 1, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_4_3:
+ax_anim 2, 0, 126, 0, -1, 0, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -1, 0, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -1, 0, -1,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -1, 0, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, -1, 0, -1,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_4_4:
+ax_anim 2, 0, 125, -1, -1, -1, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -1, -1, -1, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -1, -1, -1, -1,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -1, -1, -1, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, -1, -1, -1, -1,
+ax_anim 2, 1, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_4_5:
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 1, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_4_6:
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_4_7:
+ax_anim 2, 0, 122, 0, -1, 0, -1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, -1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, -1,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, -1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, -1,
+ax_anim 2, 1, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_4_8:
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim 2, 1, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_5_1:
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim 2, 0, 129, 0, -3, 0, -3,
+ax_anim 6, 2, 129, 0, -4, 0, -4,
+ax_anim 1, 0, 130, 0, -2, 0, -2,
+ax_anim 2, 0, 130, 0, 4, 0, 4,
+ax_anim 2, 1, 130, 1, 4, 1, 4,
+ax_anim 2, 0, 130, 0, 4, 0, 4,
+ax_anim 2, 0, 130, 1, 4, 1, 4,
+ax_anim 2, 0, 130, 0, 4, 0, 4,
+ax_anim 2, 0, 130, 1, 4, 1, 4,
+ax_anim 2, 0, 130, 0, 4, 0, 4,
+ax_anim 2, 0, 128, 0, 2, 0, 2,
+ax_anim_terminator
+sScizorAnims_5_2:
+ax_anim 2, 0, 132, -1, -1, -1, -1,
+ax_anim 2, 0, 132, -3, -3, -3, -3,
+ax_anim 6, 2, 132, -4, -4, -4, -4,
+ax_anim 1, 0, 131, -2, -2, -2, -2,
+ax_anim 2, 0, 133, 4, 4, 4, 4,
+ax_anim 2, 1, 133, 5, 3, 5, 3,
+ax_anim 2, 0, 133, 4, 4, 4, 4,
+ax_anim 2, 0, 133, 5, 3, 5, 3,
+ax_anim 2, 0, 133, 4, 4, 4, 4,
+ax_anim 2, 0, 133, 5, 3, 5, 3,
+ax_anim 2, 0, 133, 4, 4, 4, 4,
+ax_anim 2, 0, 131, 2, 2, 2, 2,
+ax_anim_terminator
+sScizorAnims_5_3:
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 2, 0, 135, -3, 0, -3, 0,
+ax_anim 6, 2, 135, -4, 0, -4, 0,
+ax_anim 1, 0, 134, -2, 0, -2, 0,
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 2, 1, 136, 4, 1, 4, 1,
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 2, 0, 136, 4, 1, 4, 1,
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 2, 0, 136, 4, 1, 4, 1,
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 2, 0, 134, 2, 0, 2, 0,
+ax_anim_terminator
+sScizorAnims_5_4:
+ax_anim 2, 0, 138, -1, 1, -1, 1,
+ax_anim 2, 0, 138, -3, 3, -3, 3,
+ax_anim 6, 2, 138, -4, 4, -4, 4,
+ax_anim 1, 0, 137, -2, 2, -2, 2,
+ax_anim 2, 0, 139, 4, -4, 4, -4,
+ax_anim 2, 1, 139, 5, -3, 5, -3,
+ax_anim 2, 0, 139, 4, -4, 4, -4,
+ax_anim 2, 0, 139, 5, -3, 5, -3,
+ax_anim 2, 0, 139, 4, -4, 4, -4,
+ax_anim 2, 0, 139, 5, -3, 5, -3,
+ax_anim 2, 0, 139, 4, -4, 4, -4,
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim_terminator
+sScizorAnims_5_5:
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 3, 0, 3,
+ax_anim 6, 2, 141, 0, 4, 0, 4,
+ax_anim 1, 0, 140, 0, 2, 0, 2,
+ax_anim 2, 0, 142, 0, -4, 0, -4,
+ax_anim 2, 1, 142, 1, -4, 1, -4,
+ax_anim 2, 0, 142, 0, -4, 0, -4,
+ax_anim 2, 0, 142, 1, -4, 1, -4,
+ax_anim 2, 0, 142, 0, -4, 0, -4,
+ax_anim 2, 0, 142, 1, -4, 1, -4,
+ax_anim 2, 0, 142, 0, -4, 0, -4,
+ax_anim 2, 0, 140, 0, -2, 0, -2,
+ax_anim_terminator
+sScizorAnims_5_6:
+ax_anim 2, 0, 144, 1, 1, 1, 1,
+ax_anim 2, 0, 144, 3, 3, 3, 3,
+ax_anim 6, 2, 144, 4, 4, 4, 4,
+ax_anim 1, 0, 143, 2, 2, 2, 2,
+ax_anim 2, 0, 145, -4, -4, -4, -4,
+ax_anim 2, 1, 145, -5, -3, -5, -3,
+ax_anim 2, 0, 145, -4, -4, -4, -4,
+ax_anim 2, 0, 145, -5, -3, -5, -3,
+ax_anim 2, 0, 145, -4, -4, -4, -4,
+ax_anim 2, 0, 145, -5, -3, -5, -3,
+ax_anim 2, 0, 145, -4, -4, -4, -4,
+ax_anim 2, 0, 143, -2, -2, -2, -2,
+ax_anim_terminator
+sScizorAnims_5_7:
+ax_anim 2, 0, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, 3, 0, 3, 0,
+ax_anim 6, 2, 147, 4, 0, 4, 0,
+ax_anim 1, 0, 146, 2, 0, 2, 0,
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 2, 1, 148, -4, 1, -4, 1,
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 2, 0, 148, -4, 1, -4, 1,
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 2, 0, 148, -4, 1, -4, 1,
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 2, 0, 146, -2, 0, -2, 0,
+ax_anim_terminator
+sScizorAnims_5_8:
+ax_anim 2, 0, 150, 1, -1, 1, -1,
+ax_anim 2, 0, 150, 3, -3, 3, -3,
+ax_anim 6, 2, 150, 4, -4, 4, -4,
+ax_anim 1, 0, 149, 2, -2, 2, -2,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 1, 151, -5, 3, -5, 3,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 0, 151, -5, 3, -5, 3,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 0, 151, -5, 3, -5, 3,
+ax_anim 2, 0, 151, -4, 4, -4, 4,
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sScizorAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sScizorAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sScizorAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sScizorAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sScizorAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sScizorAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sScizorAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sScizorAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sScizorAnims_8_1:
+ax_anim 30, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim 3, 0, 162, 0, -6, 0, 0,
+ax_anim 3, 0, 162, 0, -7, 0, 0,
+ax_anim 3, 0, 162, 0, -6, 0, 0,
+ax_anim 2, 0, 162, 0, -4, 0, 0,
+ax_anim_terminator
+sScizorAnims_8_2:
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim 3, 0, 165, 0, -6, 0, 0,
+ax_anim 3, 0, 165, 0, -7, 0, 0,
+ax_anim 3, 0, 165, 0, -6, 0, 0,
+ax_anim 2, 0, 165, 0, -4, 0, 0,
+ax_anim_terminator
+sScizorAnims_8_3:
+ax_anim 30, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -4, 0, 0,
+ax_anim 3, 0, 168, 0, -6, 0, 0,
+ax_anim 3, 0, 168, 0, -7, 0, 0,
+ax_anim 3, 0, 168, 0, -6, 0, 0,
+ax_anim 2, 0, 168, 0, -4, 0, 0,
+ax_anim_terminator
+sScizorAnims_8_4:
+ax_anim 30, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, -4, 0, 0,
+ax_anim 3, 0, 171, 0, -6, 0, 0,
+ax_anim 3, 0, 171, 0, -7, 0, 0,
+ax_anim 3, 0, 171, 0, -6, 0, 0,
+ax_anim 2, 0, 171, 0, -4, 0, 0,
+ax_anim_terminator
+sScizorAnims_8_5:
+ax_anim 30, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, -4, 0, 0,
+ax_anim 3, 0, 174, 0, -6, 0, 0,
+ax_anim 3, 0, 174, 0, -7, 0, 0,
+ax_anim 3, 0, 174, 0, -6, 0, 0,
+ax_anim 2, 0, 174, 0, -4, 0, 0,
+ax_anim_terminator
+sScizorAnims_8_6:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, -4, 0, 0,
+ax_anim 3, 0, 177, 0, -6, 0, 0,
+ax_anim 3, 0, 177, 0, -7, 0, 0,
+ax_anim 3, 0, 177, 0, -6, 0, 0,
+ax_anim 2, 0, 177, 0, -4, 0, 0,
+ax_anim_terminator
+sScizorAnims_8_7:
+ax_anim 30, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -4, 0, 0,
+ax_anim 3, 0, 180, 0, -6, 0, 0,
+ax_anim 3, 0, 180, 0, -7, 0, 0,
+ax_anim 3, 0, 180, 0, -6, 0, 0,
+ax_anim 2, 0, 180, 0, -4, 0, 0,
+ax_anim_terminator
+sScizorAnims_8_8:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, -4, 0, 0,
+ax_anim 3, 0, 183, 0, -6, 0, 0,
+ax_anim 3, 0, 183, 0, -7, 0, 0,
+ax_anim 3, 0, 183, 0, -6, 0, 0,
+ax_anim 2, 0, 183, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 15, 7, 15,
+ax_anim 3, 0, 190, 0, 18, 0, 18,
+ax_anim 2, 3, 191, -7, 15, -7, 15,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 20, 12, 20, 12,
+ax_anim 3, 0, 189, 19, 19, 19, 19,
+ax_anim 2, 3, 190, 11, 18, 11, 18,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -7, 11, -7,
+ax_anim 2, 0, 187, 17, -6, 17, -6,
+ax_anim 3, 0, 188, 21, -2, 21, -2,
+ax_anim 2, 3, 189, 19, 3, 19, 3,
+ax_anim 2, 0, 190, 12, 4, 12, 4,
+ax_anim 1, 0, 191, 4, 3, 4, 3,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 18, -22, 18, -22,
+ax_anim 2, 3, 188, 20, -15, 20, -15,
+ax_anim 2, 0, 189, 17, -4, 17, -4,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -22, 0, -22,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 9, -12, 9, -12,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -6, 1, -6,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -18, -22, -18, -22,
+ax_anim 2, 3, 192, -20, -15, -20, -15,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -7, -11, -7,
+ax_anim 2, 0, 193, -17, -6, -17, -6,
+ax_anim 3, 0, 192, -21, -2, -21, -2,
+ax_anim 2, 3, 191, -19, 3, -19, 3,
+ax_anim 2, 0, 190, -12, 4, -12, 4,
+ax_anim 1, 0, 189, -4, 3, -4, 3,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -20, 12, -20, 12,
+ax_anim 3, 0, 191, -19, 19, -19, 19,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -19, 0, 0,
+ax_anim 4, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -19, 0, 0,
+ax_anim 4, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScizorAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sScizorGfx1:
+.incbin "baserom.gba", 0xE90C00, 0x200
+sScizorSprites1:
+ax_sprite sScizorGfx1, 0x200
+ax_sprite_terminator
+sScizorGfx2:
+.incbin "baserom.gba", 0xE90E10, 0x200
+sScizorSprites2:
+ax_sprite sScizorGfx2, 0x200
+ax_sprite_terminator
+sScizorGfx3:
+.incbin "baserom.gba", 0xE91020, 0x200
+sScizorSprites3:
+ax_sprite sScizorGfx3, 0x200
+ax_sprite_terminator
+sScizorGfx4:
+.incbin "baserom.gba", 0xE91230, 0x200
+sScizorSprites4:
+ax_sprite sScizorGfx4, 0x200
+ax_sprite_terminator
+sScizorGfx5:
+.incbin "baserom.gba", 0xE91440, 0x200
+sScizorSprites5:
+ax_sprite sScizorGfx5, 0x200
+ax_sprite_terminator
+sScizorGfx6:
+.incbin "baserom.gba", 0xE91650, 0x200
+sScizorSprites6:
+ax_sprite sScizorGfx6, 0x200
+ax_sprite_terminator
+sScizorGfx7:
+.incbin "baserom.gba", 0xE91860, 0x200
+sScizorSprites7:
+ax_sprite sScizorGfx7, 0x200
+ax_sprite_terminator
+sScizorGfx8:
+.incbin "baserom.gba", 0xE91A70, 0x200
+sScizorSprites8:
+ax_sprite sScizorGfx8, 0x200
+ax_sprite_terminator
+sScizorGfx9:
+.incbin "baserom.gba", 0xE91C80, 0x200
+sScizorSprites9:
+ax_sprite sScizorGfx9, 0x200
+ax_sprite_terminator
+sScizorGfx10:
+.incbin "baserom.gba", 0xE91E90, 0x200
+sScizorSprites10:
+ax_sprite sScizorGfx10, 0x200
+ax_sprite_terminator
+sScizorGfx11:
+.incbin "baserom.gba", 0xE920A0, 0x200
+sScizorSprites11:
+ax_sprite sScizorGfx11, 0x200
+ax_sprite_terminator
+sScizorGfx12:
+.incbin "baserom.gba", 0xE922B0, 0x200
+sScizorSprites12:
+ax_sprite sScizorGfx12, 0x200
+ax_sprite_terminator
+sScizorGfx13:
+.incbin "baserom.gba", 0xE924C0, 0x200
+sScizorSprites13:
+ax_sprite sScizorGfx13, 0x200
+ax_sprite_terminator
+sScizorGfx14:
+.incbin "baserom.gba", 0xE926D0, 0x200
+sScizorSprites14:
+ax_sprite sScizorGfx14, 0x200
+ax_sprite_terminator
+sScizorGfx15:
+.incbin "baserom.gba", 0xE928E0, 0x200
+sScizorSprites15:
+ax_sprite sScizorGfx15, 0x200
+ax_sprite_terminator
+sScizorGfx16:
+.incbin "baserom.gba", 0xE92AF0, 0x60
+sScizorGfx16_1:
+.incbin "baserom.gba", 0xE92B50, 0x160
+sScizorSprites16:
+ax_sprite sScizorGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx16_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx17:
+.incbin "baserom.gba", 0xE92CD8, 0x200
+sScizorSprites17:
+ax_sprite sScizorGfx17, 0x200
+ax_sprite_terminator
+sScizorGfx18:
+.incbin "baserom.gba", 0xE92EE8, 0xE0
+sScizorGfx18_1:
+.incbin "baserom.gba", 0xE92FC8, 0x60
+sScizorGfx18_2:
+.incbin "baserom.gba", 0xE93028, 0x60
+sScizorSprites18:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx18, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx18_2, 0x60
+ax_sprite_terminator
+sScizorGfx19:
+.incbin "baserom.gba", 0xE930C0, 0x20
+sScizorGfx19_1:
+.incbin "baserom.gba", 0xE930E0, 0x160
+sScizorSprites19:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx19, 0x20
+ax_sprite 0, 0x60
+ax_sprite sScizorGfx19_1, 0x160
+ax_sprite_terminator
+sScizorGfx20:
+.incbin "baserom.gba", 0xE93268, 0xE0
+sScizorGfx20_1:
+.incbin "baserom.gba", 0xE93348, 0x60
+sScizorGfx20_2:
+.incbin "baserom.gba", 0xE933A8, 0x60
+sScizorSprites20:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx20, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx20_2, 0x60
+ax_sprite_terminator
+sScizorGfx21:
+.incbin "baserom.gba", 0xE93440, 0x40
+sScizorGfx21_1:
+.incbin "baserom.gba", 0xE93480, 0x60
+sScizorGfx21_2:
+.incbin "baserom.gba", 0xE934E0, 0xE0
+sScizorSprites21:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx21_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx22:
+.incbin "baserom.gba", 0xE93600, 0x40
+sScizorGfx22_1:
+.incbin "baserom.gba", 0xE93640, 0x100
+sScizorGfx22_2:
+.incbin "baserom.gba", 0xE93740, 0x40
+sScizorSprites22:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx23:
+.incbin "baserom.gba", 0xE937C0, 0x200
+sScizorSprites23:
+ax_sprite sScizorGfx23, 0x200
+ax_sprite_terminator
+sScizorGfx24:
+.incbin "baserom.gba", 0xE939D0, 0x40
+sScizorGfx24_1:
+.incbin "baserom.gba", 0xE93A10, 0x100
+sScizorGfx24_2:
+.incbin "baserom.gba", 0xE93B10, 0x40
+sScizorSprites24:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx25:
+.incbin "baserom.gba", 0xE93B90, 0x180
+sScizorGfx25_1:
+.incbin "baserom.gba", 0xE93D10, 0x20
+sScizorSprites25:
+ax_sprite sScizorGfx25, 0x180
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx25_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx26:
+.incbin "baserom.gba", 0xE93D58, 0x20
+sScizorGfx26_1:
+.incbin "baserom.gba", 0xE93D78, 0x60
+sScizorGfx26_2:
+.incbin "baserom.gba", 0xE93DD8, 0x120
+sScizorSprites26:
+ax_sprite sScizorGfx26, 0x20
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx26_2, 0x120
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx27:
+.incbin "baserom.gba", 0xE93F30, 0xE0
+sScizorGfx27_1:
+.incbin "baserom.gba", 0xE94010, 0xC0
+sScizorSprites27:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx27_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx28:
+.incbin "baserom.gba", 0xE94100, 0x160
+sScizorSprites28:
+ax_sprite 0, 0x80
+ax_sprite sScizorGfx28, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx29:
+.incbin "baserom.gba", 0xE94280, 0x40
+sScizorGfx29_1:
+.incbin "baserom.gba", 0xE942C0, 0xE0
+sScizorGfx29_2:
+.incbin "baserom.gba", 0xE943A0, 0x60
+sScizorSprites29:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx29_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx30:
+.incbin "baserom.gba", 0xE94440, 0x40
+sScizorGfx30_1:
+.incbin "baserom.gba", 0xE94480, 0x100
+sScizorSprites30:
+ax_sprite 0, 0x80
+ax_sprite sScizorGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx31:
+.incbin "baserom.gba", 0xE945B0, 0x40
+sScizorGfx31_1:
+.incbin "baserom.gba", 0xE945F0, 0xE0
+sScizorGfx31_2:
+.incbin "baserom.gba", 0xE946D0, 0x40
+sScizorSprites31:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx31_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx32:
+.incbin "baserom.gba", 0xE94750, 0x40
+sScizorGfx32_1:
+.incbin "baserom.gba", 0xE94790, 0xC0
+sScizorSprites32:
+ax_sprite 0, 0x80
+ax_sprite sScizorGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx32_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sScizorGfx33:
+.incbin "baserom.gba", 0xE94880, 0x40
+sScizorGfx33_1:
+.incbin "baserom.gba", 0xE948C0, 0x180
+sScizorSprites33:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx33_1, 0x180
+ax_sprite_terminator
+sScizorGfx34:
+.incbin "baserom.gba", 0xE94A68, 0x40
+sScizorGfx34_1:
+.incbin "baserom.gba", 0xE94AA8, 0x40
+sScizorGfx34_2:
+.incbin "baserom.gba", 0xE94AE8, 0xE0
+sScizorSprites34:
+ax_sprite sScizorGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx34_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx34_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx35:
+.incbin "baserom.gba", 0xE94C00, 0x60
+sScizorGfx35_1:
+.incbin "baserom.gba", 0xE94C60, 0xE0
+sScizorGfx35_2:
+.incbin "baserom.gba", 0xE94D40, 0x60
+sScizorSprites35:
+ax_sprite sScizorGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx35_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx36:
+.incbin "baserom.gba", 0xE94DD8, 0x60
+sScizorGfx36_1:
+.incbin "baserom.gba", 0xE94E38, 0x80
+sScizorGfx36_2:
+.incbin "baserom.gba", 0xE94EB8, 0x20
+sScizorSprites36:
+ax_sprite sScizorGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx36_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sScizorGfx36_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sScizorGfx37:
+.incbin "baserom.gba", 0xE94F10, 0x60
+sScizorGfx37_1:
+.incbin "baserom.gba", 0xE94F70, 0xE0
+sScizorGfx37_2:
+.incbin "baserom.gba", 0xE95050, 0x40
+sScizorSprites37:
+ax_sprite sScizorGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx37_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx37_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx38:
+.incbin "baserom.gba", 0xE950C8, 0x60
+sScizorGfx38_1:
+.incbin "baserom.gba", 0xE95128, 0x40
+sScizorGfx38_2:
+.incbin "baserom.gba", 0xE95168, 0x20
+sScizorGfx38_3:
+.incbin "baserom.gba", 0xE95188, 0x40
+sScizorSprites38:
+ax_sprite sScizorGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx38_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sScizorGfx38_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sScizorGfx39:
+.incbin "baserom.gba", 0xE95210, 0x40
+sScizorGfx39_1:
+.incbin "baserom.gba", 0xE95250, 0x60
+sScizorGfx39_2:
+.incbin "baserom.gba", 0xE952B0, 0xE0
+sScizorSprites39:
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx39_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx40:
+.incbin "baserom.gba", 0xE953D0, 0x60
+sScizorGfx40_1:
+.incbin "baserom.gba", 0xE95430, 0x80
+sScizorGfx40_2:
+.incbin "baserom.gba", 0xE954B0, 0x20
+sScizorGfx40_3:
+.incbin "baserom.gba", 0xE954D0, 0x40
+sScizorSprites40:
+ax_sprite sScizorGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx40_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sScizorGfx40_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx40_3, 0x40
+ax_sprite_terminator
+sScizorGfx41:
+.incbin "baserom.gba", 0xE95550, 0x60
+sScizorGfx41_1:
+.incbin "baserom.gba", 0xE955B0, 0xE0
+sScizorGfx41_2:
+.incbin "baserom.gba", 0xE95690, 0x40
+sScizorSprites41:
+ax_sprite sScizorGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScizorGfx41_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sScizorGfx41_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScizorGfx42:
+.incbin "baserom.gba", 0xE95708, 0x200
+sScizorSprites42:
+ax_sprite sScizorGfx42, 0x200
+ax_sprite_terminator
+sScizorGfx43:
+.incbin "baserom.gba", 0xE95918, 0x200
+sScizorSprites43:
+ax_sprite sScizorGfx43, 0x200
+ax_sprite_terminator
+sScizorGfx44:
+.incbin "baserom.gba", 0xE95B28, 0x200
+sScizorSprites44:
+ax_sprite sScizorGfx44, 0x200
+ax_sprite_terminator
+sScizorGfx45:
+.incbin "baserom.gba", 0xE95D38, 0x200
+sScizorSprites45:
+ax_sprite sScizorGfx45, 0x200
+ax_sprite_terminator
+sScizorGfx46:
+.incbin "baserom.gba", 0xE95F48, 0x200
+sScizorSprites46:
+ax_sprite sScizorGfx46, 0x200
+ax_sprite_terminator
+sScizorGfx47:
+.incbin "baserom.gba", 0xE96158, 0x200
+sScizorSprites47:
+ax_sprite sScizorGfx47, 0x200
+ax_sprite_terminator
+sScizorGfx48:
+.incbin "baserom.gba", 0xE96368, 0x200
+sScizorSprites48:
+ax_sprite sScizorGfx48, 0x200
+ax_sprite_terminator
+sAxPosesScizor:
+.4byte sScizorPose1
+.4byte sScizorPose2
+.4byte sScizorPose3
+.4byte sScizorPose4
+.4byte sScizorPose5
+.4byte sScizorPose6
+.4byte sScizorPose7
+.4byte sScizorPose8
+.4byte sScizorPose9
+.4byte sScizorPose10
+.4byte sScizorPose11
+.4byte sScizorPose12
+.4byte sScizorPose13
+.4byte sScizorPose14
+.4byte sScizorPose15
+.4byte sScizorPose16
+.4byte sScizorPose17
+.4byte sScizorPose18
+.4byte sScizorPose19
+.4byte sScizorPose20
+.4byte sScizorPose21
+.4byte sScizorPose22
+.4byte sScizorPose23
+.4byte sScizorPose24
+.4byte sScizorPose25
+.4byte sScizorPose26
+.4byte sScizorPose27
+.4byte sScizorPose28
+.4byte sScizorPose29
+.4byte sScizorPose30
+.4byte sScizorPose31
+.4byte sScizorPose32
+.4byte sScizorPose33
+.4byte sScizorPose34
+.4byte sScizorPose35
+.4byte sScizorPose36
+.4byte sScizorPose37
+.4byte sScizorPose38
+.4byte sScizorPose39
+.4byte sScizorPose40
+.4byte sScizorPose41
+.4byte sScizorPose42
+.4byte sScizorPose43
+.4byte sScizorPose44
+.4byte sScizorPose45
+.4byte sScizorPose46
+.4byte sScizorPose47
+.4byte sScizorPose48
+.4byte sScizorPose49
+.4byte sScizorPose50
+.4byte sScizorPose51
+.4byte sScizorPose52
+.4byte sScizorPose53
+.4byte sScizorPose54
+.4byte sScizorPose55
+.4byte sScizorPose56
+.4byte sScizorPose57
+.4byte sScizorPose58
+.4byte sScizorPose59
+.4byte sScizorPose60
+.4byte sScizorPose61
+.4byte sScizorPose62
+.4byte sScizorPose63
+.4byte sScizorPose64
+.4byte sScizorPose65
+.4byte sScizorPose66
+.4byte sScizorPose67
+.4byte sScizorPose68
+.4byte sScizorPose69
+.4byte sScizorPose70
+.4byte sScizorPose71
+.4byte sScizorPose72
+.4byte sScizorPose73
+.4byte sScizorPose74
+.4byte sScizorPose75
+.4byte sScizorPose76
+.4byte sScizorPose77
+.4byte sScizorPose78
+.4byte sScizorPose79
+.4byte sScizorPose80
+.4byte sScizorPose81
+.4byte sScizorPose82
+.4byte sScizorPose83
+.4byte sScizorPose84
+.4byte sScizorPose85
+.4byte sScizorPose86
+.4byte sScizorPose87
+.4byte sScizorPose88
+.4byte sScizorPose89
+.4byte sScizorPose90
+.4byte sScizorPose91
+.4byte sScizorPose92
+.4byte sScizorPose93
+.4byte sScizorPose94
+.4byte sScizorPose95
+.4byte sScizorPose96
+.4byte sScizorPose97
+.4byte sScizorPose98
+.4byte sScizorPose99
+.4byte sScizorPose100
+.4byte sScizorPose101
+.4byte sScizorPose102
+.4byte sScizorPose103
+.4byte sScizorPose104
+.4byte sScizorPose105
+.4byte sScizorPose106
+.4byte sScizorPose107
+.4byte sScizorPose108
+.4byte sScizorPose109
+.4byte sScizorPose110
+.4byte sScizorPose111
+.4byte sScizorPose112
+.4byte sScizorPose113
+.4byte sScizorPose114
+.4byte sScizorPose115
+.4byte sScizorPose116
+.4byte sScizorPose117
+.4byte sScizorPose118
+.4byte sScizorPose119
+.4byte sScizorPose120
+.4byte sScizorPose121
+.4byte sScizorPose122
+.4byte sScizorPose123
+.4byte sScizorPose124
+.4byte sScizorPose125
+.4byte sScizorPose126
+.4byte sScizorPose127
+.4byte sScizorPose128
+.4byte sScizorPose129
+.4byte sScizorPose130
+.4byte sScizorPose131
+.4byte sScizorPose132
+.4byte sScizorPose133
+.4byte sScizorPose134
+.4byte sScizorPose135
+.4byte sScizorPose136
+.4byte sScizorPose137
+.4byte sScizorPose138
+.4byte sScizorPose139
+.4byte sScizorPose140
+.4byte sScizorPose141
+.4byte sScizorPose142
+.4byte sScizorPose143
+.4byte sScizorPose144
+.4byte sScizorPose145
+.4byte sScizorPose146
+.4byte sScizorPose147
+.4byte sScizorPose148
+.4byte sScizorPose149
+.4byte sScizorPose150
+.4byte sScizorPose151
+.4byte sScizorPose152
+.4byte sScizorPose153
+.4byte sScizorPose154
+.4byte sScizorPose155
+.4byte sScizorPose156
+.4byte sScizorPose157
+.4byte sScizorPose158
+.4byte sScizorPose159
+.4byte sScizorPose160
+.4byte sScizorPose161
+.4byte sScizorPose162
+.4byte sScizorPose163
+.4byte sScizorPose164
+.4byte sScizorPose165
+.4byte sScizorPose166
+.4byte sScizorPose167
+.4byte sScizorPose168
+.4byte sScizorPose169
+.4byte sScizorPose170
+.4byte sScizorPose171
+.4byte sScizorPose172
+.4byte sScizorPose173
+.4byte sScizorPose174
+.4byte sScizorPose175
+.4byte sScizorPose176
+.4byte sScizorPose177
+.4byte sScizorPose178
+.4byte sScizorPose179
+.4byte sScizorPose180
+.4byte sScizorPose181
+.4byte sScizorPose182
+.4byte sScizorPose183
+.4byte sScizorPose184
+.4byte sScizorPose185
+.4byte sScizorPose186
+.4byte sScizorPose187
+.4byte sScizorPose188
+.4byte sScizorPose189
+.4byte sScizorPose190
+.4byte sScizorPose191
+.4byte sScizorPose192
+.4byte sScizorPose193
+.4byte sScizorPose194
+.4byte sScizorPose195
+.4byte sScizorPose196
+.4byte sScizorPose197
+.4byte sScizorPose198
+.4byte sScizorPose199
+.4byte sScizorPose200
+.4byte sScizorPose201
+.4byte sScizorPose202
+.4byte sScizorPose203
+.4byte sScizorPose204
+.4byte sScizorPose205
+.4byte sScizorPose206
+.4byte sScizorPose207
+.4byte sScizorPose208
+.4byte sScizorPose209
+.4byte sScizorPose210
+.4byte sScizorPose211
+.4byte sScizorPose212
+.4byte sScizorPose213
+.4byte sScizorPose214
+.4byte sScizorPose215
+.4byte sScizorPose216
+.4byte sScizorPose217
+.4byte sScizorPose218
+.4byte sScizorPose219
+.4byte sScizorPose220
+.4byte sScizorPose221
+.4byte sScizorPose222
+.4byte sScizorPose223
+.4byte sScizorPose224
+.4byte sScizorPose225
+.4byte sScizorPose226
+.4byte sScizorPose227
+.4byte sScizorPose228
+.4byte sScizorPose229
+.4byte sScizorPose230
+.4byte sScizorPose231
+.4byte sScizorPose232
+.4byte sScizorPose233
+.4byte sScizorPose234
+.4byte sScizorPose235
+.4byte sScizorPose236
+.4byte sScizorPose237
+.4byte sScizorPose238
+.4byte sScizorPose239
+.4byte sScizorPose240
+.4byte sScizorPose241
+.4byte sScizorPose242
+sAxPositionsScizor:
+.2byte   -1,  -10, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -1,   -8, 	 -13,   -7, 	   6,   -2, 	  -1,   -9
+.2byte   -1,   -8, 	  -8,   -2, 	  11,   -7, 	  -1,   -9
+.2byte    4,  -12, 	   9,  -10, 	  -5,   -3, 	  -1,  -10
+.2byte    4,  -10, 	   6,  -11, 	  -2,   -1, 	  -2,   -9
+.2byte    4,  -10, 	  10,   -7, 	  -9,   -3, 	   1,   -7
+.2byte    5,  -13, 	   6,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    5,  -11, 	  -1,  -13, 	   6,   -5, 	  -2,   -8
+.2byte    5,  -11, 	   8,  -12, 	  -4,   -1, 	  -1,   -8
+.2byte    3,  -17, 	  -2,  -11, 	  10,   -8, 	  -2,  -10
+.2byte    2,  -13, 	 -10,   -6, 	  11,  -10, 	  -2,  -11
+.2byte    3,  -13, 	   1,  -12, 	   6,   -3, 	  -2,  -10
+.2byte   -1,  -17, 	  10,  -12, 	 -12,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	  11,   -8, 	 -10,  -14, 	  -1,  -10
+.2byte   -1,  -16, 	   8,  -14, 	 -13,   -8, 	  -1,  -10
+.2byte   -5,  -17, 	   0,  -11, 	 -12,   -8, 	   0,  -10
+.2byte   -4,  -13, 	   8,   -6, 	 -13,  -10, 	   0,  -11
+.2byte   -5,  -13, 	  -3,  -12, 	  -8,   -3, 	   0,  -10
+.2byte   -7,  -13, 	  -8,  -14, 	  -5,   -3, 	  -1,   -9
+.2byte   -7,  -11, 	  -1,  -13, 	  -8,   -5, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -12, 	   2,   -1, 	  -1,   -8
+.2byte   -6,  -12, 	 -11,  -10, 	   3,   -3, 	  -1,  -10
+.2byte   -6,  -10, 	  -8,  -11, 	   0,   -1, 	   0,   -9
+.2byte   -6,  -10, 	 -12,   -7, 	   7,   -3, 	  -3,   -7
+.2byte   -1,  -10, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -1,   -8, 	 -13,   -7, 	   6,   -2, 	  -1,   -9
+.2byte   -1,   -8, 	  -8,   -2, 	  11,   -7, 	  -1,   -9
+.2byte   -1,  -12, 	   5,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -3, 	   7,   -2, 	  -1,   -7
+.2byte    4,  -12, 	   9,  -10, 	  -5,   -3, 	  -1,  -10
+.2byte    4,  -10, 	   6,  -11, 	  -2,   -1, 	  -2,   -9
+.2byte    4,  -10, 	  10,   -7, 	  -9,   -3, 	   1,   -7
+.2byte   -1,  -13, 	  -6,   -9, 	   3,  -13, 	  -4,  -12
+.2byte    2,   -8, 	   9,   -7, 	  -1,   -4, 	  -4,   -9
+.2byte    5,  -13, 	   6,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    5,  -11, 	  -1,  -13, 	   6,   -5, 	  -2,   -8
+.2byte    5,  -11, 	   8,  -12, 	  -4,   -1, 	  -1,   -8
+.2byte    1,  -11, 	   2,   -6, 	   4,  -15, 	  -5,  -10
+.2byte    7,  -10, 	  10,  -13, 	   9,   -4, 	   0,   -8
+.2byte    3,  -17, 	  -2,  -11, 	  10,   -8, 	  -2,  -10
+.2byte    2,  -13, 	 -10,   -6, 	  11,  -10, 	  -2,  -11
+.2byte    3,  -13, 	   1,  -12, 	   6,   -3, 	  -2,  -10
+.2byte    0,  -12, 	   9,  -13, 	  -7,  -17, 	  -3,  -11
+.2byte    4,  -17, 	  -3,  -20, 	  11,  -17, 	  -3,  -12
+.2byte   -1,  -17, 	  10,  -12, 	 -12,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	  11,   -8, 	 -10,  -14, 	  -1,  -10
+.2byte   -1,  -16, 	   8,  -14, 	 -13,   -8, 	  -1,  -10
+.2byte   -1,  -14, 	   6,  -15, 	  -8,  -15, 	  -1,   -9
+.2byte   -1,  -18, 	   8,  -22, 	 -10,  -22, 	  -1,  -13
+.2byte   -5,  -17, 	   0,  -11, 	 -12,   -8, 	   0,  -10
+.2byte   -4,  -13, 	   8,   -6, 	 -13,  -10, 	   0,  -11
+.2byte   -5,  -13, 	  -3,  -12, 	  -8,   -3, 	   0,  -10
+.2byte   -2,  -12, 	 -11,  -13, 	   5,  -17, 	   1,  -11
+.2byte   -6,  -17, 	   1,  -20, 	 -13,  -17, 	   1,  -12
+.2byte   -7,  -13, 	  -8,  -14, 	  -5,   -3, 	  -1,   -9
+.2byte   -7,  -11, 	  -1,  -13, 	  -8,   -5, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -12, 	   2,   -1, 	  -1,   -8
+.2byte   -3,  -11, 	  -4,   -6, 	  -6,  -15, 	   3,  -10
+.2byte   -9,  -10, 	 -12,  -13, 	 -11,   -4, 	  -2,   -8
+.2byte   -6,  -12, 	 -11,  -10, 	   3,   -3, 	  -1,  -10
+.2byte   -6,  -10, 	  -8,  -11, 	   0,   -1, 	   0,   -9
+.2byte   -6,  -10, 	 -12,   -7, 	   7,   -3, 	  -3,   -7
+.2byte   -1,  -13, 	   4,   -9, 	  -5,  -13, 	   2,  -12
+.2byte   -4,   -8, 	 -11,   -7, 	  -1,   -4, 	   2,   -9
+.2byte   -1,  -10, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -1,   -8, 	 -13,   -7, 	   6,   -2, 	  -1,   -9
+.2byte   -1,   -8, 	  -8,   -2, 	  11,   -7, 	  -1,   -9
+.2byte    6,   -9, 	   6,  -10, 	   6,  -18, 	   1,   -9
+.2byte    6,   -9, 	   6,  -10, 	   6,  -18, 	   1,   -9
+.2byte   -7,   -9, 	  -7,  -10, 	  -7,  -18, 	  -2,   -9
+.2byte   -7,   -9, 	  -7,  -10, 	  -7,  -18, 	  -2,   -9
+.2byte    4,  -12, 	   9,  -10, 	  -5,   -3, 	  -1,  -10
+.2byte    4,  -10, 	   6,  -11, 	  -2,   -1, 	  -2,   -9
+.2byte    4,  -10, 	  10,   -7, 	  -9,   -3, 	   1,   -7
+.2byte   -3,   -9, 	  -3,  -10, 	  -8,  -14, 	   0,   -8
+.2byte   -3,   -9, 	  -3,  -10, 	  -8,  -14, 	   0,   -8
+.2byte   10,  -13, 	   9,  -13, 	  -3,  -17, 	  -2,  -10
+.2byte   10,  -13, 	   9,  -13, 	  -3,  -17, 	  -2,  -10
+.2byte    5,  -13, 	   6,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    5,  -11, 	  -1,  -13, 	   6,   -5, 	  -2,   -8
+.2byte    5,  -11, 	   8,  -12, 	  -4,   -1, 	  -1,   -8
+.2byte    9,  -14, 	  10,  -14, 	 -11,  -13, 	   0,  -10
+.2byte    9,  -14, 	  10,  -14, 	 -11,  -13, 	   0,  -10
+.2byte   12,  -17, 	  11,  -17, 	  -8,  -14, 	   2,  -10
+.2byte   12,  -17, 	  11,  -17, 	  -8,  -14, 	   2,  -10
+.2byte    3,  -17, 	  -2,  -11, 	  10,   -8, 	  -2,  -10
+.2byte    2,  -13, 	 -10,   -6, 	  11,  -10, 	  -2,  -11
+.2byte    3,  -13, 	   1,  -12, 	   6,   -3, 	  -2,  -10
+.2byte   11,  -16, 	  10,  -16, 	   1,   -5, 	   0,  -10
+.2byte   11,  -16, 	  10,  -16, 	   1,   -5, 	   0,  -10
+.2byte   -4,  -22, 	  -2,  -22, 	  -6,   -7, 	   0,  -10
+.2byte   -4,  -22, 	  -2,  -22, 	  -6,   -7, 	   0,  -10
+.2byte   -1,  -17, 	  10,  -12, 	 -12,  -12, 	  -1,  -11
+.2byte   -1,  -16, 	  11,   -8, 	 -10,  -14, 	  -1,  -10
+.2byte   -1,  -16, 	   8,  -14, 	 -13,   -8, 	  -1,  -10
+.2byte   -9,  -20, 	  -8,  -20, 	  -7,   -9, 	  -2,  -12
+.2byte   -9,  -20, 	  -8,  -20, 	  -7,   -9, 	  -2,  -12
+.2byte    8,  -20, 	   7,  -20, 	   6,   -9, 	   1,  -12
+.2byte    8,  -20, 	   7,  -20, 	   6,   -9, 	   1,  -12
+.2byte   -5,  -17, 	   0,  -11, 	 -12,   -8, 	   0,  -10
+.2byte   -4,  -13, 	   8,   -6, 	 -13,  -10, 	   0,  -11
+.2byte   -5,  -13, 	  -3,  -12, 	  -8,   -3, 	   0,  -10
+.2byte  -13,  -16, 	 -12,  -16, 	  -3,   -5, 	  -2,  -10
+.2byte  -13,  -16, 	 -12,  -16, 	  -3,   -5, 	  -2,  -10
+.2byte    2,  -22, 	   0,  -22, 	   4,   -7, 	  -2,  -10
+.2byte    2,  -22, 	   0,  -22, 	   4,   -7, 	  -2,  -10
+.2byte   -7,  -13, 	  -8,  -14, 	  -5,   -3, 	  -1,   -9
+.2byte   -7,  -11, 	  -1,  -13, 	  -8,   -5, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -12, 	   2,   -1, 	  -1,   -8
+.2byte  -11,  -14, 	 -12,  -14, 	   9,  -13, 	  -2,  -10
+.2byte  -11,  -14, 	 -12,  -14, 	   9,  -13, 	  -2,  -10
+.2byte  -14,  -17, 	 -13,  -17, 	   6,  -14, 	  -4,  -10
+.2byte  -14,  -17, 	 -13,  -17, 	   6,  -14, 	  -4,  -10
+.2byte   -6,  -12, 	 -11,  -10, 	   3,   -3, 	  -1,  -10
+.2byte   -6,  -10, 	  -8,  -11, 	   0,   -1, 	   0,   -9
+.2byte   -6,  -10, 	 -12,   -7, 	   7,   -3, 	  -3,   -7
+.2byte    1,   -9, 	   1,  -10, 	   6,  -14, 	  -2,   -8
+.2byte    1,   -9, 	   1,  -10, 	   6,  -14, 	  -2,   -8
+.2byte  -12,  -13, 	 -11,  -13, 	   1,  -17, 	   0,  -10
+.2byte  -12,  -13, 	 -11,  -13, 	   1,  -17, 	   0,  -10
+.2byte   -1,  -12, 	   5,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -3,  -13, 	   2,   -9, 	  -7,  -13, 	   0,  -12
+.2byte   -4,  -12, 	  -5,   -7, 	  -7,  -16, 	   2,  -11
+.2byte   -2,  -13, 	 -11,  -14, 	   5,  -18, 	   1,  -12
+.2byte   -1,  -16, 	   6,  -17, 	  -8,  -17, 	  -1,  -11
+.2byte    1,  -13, 	  10,  -14, 	  -6,  -18, 	  -2,  -12
+.2byte    3,  -12, 	   4,   -7, 	   6,  -16, 	  -3,  -11
+.2byte    2,  -13, 	  -3,   -9, 	   6,  -13, 	  -1,  -12
+.2byte   -1,  -10, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -1,  -12, 	   5,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -3, 	   7,   -2, 	  -1,   -7
+.2byte    4,  -12, 	   9,  -10, 	  -5,   -3, 	  -1,  -10
+.2byte   -1,  -13, 	  -6,   -9, 	   3,  -13, 	  -4,  -12
+.2byte    2,   -8, 	   9,   -7, 	  -1,   -4, 	  -4,   -9
+.2byte    5,  -13, 	   6,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    1,  -11, 	   2,   -6, 	   4,  -15, 	  -5,  -10
+.2byte    7,  -10, 	  10,  -13, 	   9,   -4, 	   0,   -8
+.2byte    3,  -17, 	  -2,  -11, 	  10,   -8, 	  -2,  -10
+.2byte    0,  -12, 	   9,  -13, 	  -7,  -17, 	  -3,  -11
+.2byte    4,  -17, 	  -3,  -20, 	  11,  -17, 	  -3,  -12
+.2byte   -1,  -17, 	  10,  -12, 	 -12,  -12, 	  -1,  -11
+.2byte   -1,  -14, 	   6,  -15, 	  -8,  -15, 	  -1,   -9
+.2byte   -1,  -18, 	   8,  -22, 	 -10,  -22, 	  -1,  -13
+.2byte   -5,  -17, 	   0,  -11, 	 -12,   -8, 	   0,  -10
+.2byte   -2,  -12, 	 -11,  -13, 	   5,  -17, 	   1,  -11
+.2byte   -6,  -17, 	   1,  -20, 	 -13,  -17, 	   1,  -12
+.2byte   -7,  -13, 	  -8,  -14, 	  -5,   -3, 	  -1,   -9
+.2byte   -3,  -11, 	  -4,   -6, 	  -6,  -15, 	   3,  -10
+.2byte   -9,  -10, 	 -12,  -13, 	 -11,   -4, 	  -2,   -8
+.2byte   -6,  -12, 	 -11,  -10, 	   3,   -3, 	  -1,  -10
+.2byte   -1,  -13, 	   4,   -9, 	  -5,  -13, 	   2,  -12
+.2byte   -4,   -8, 	 -11,   -7, 	  -1,   -4, 	   2,   -9
+.2byte   -3,   -8, 	  -7,   -8, 	   6,   -2, 	   1,   -8
+.2byte   -4,   -7, 	  -7,   -7, 	   6,   -1, 	   2,   -9
+.2byte    1,   -8, 	  -5,   -6, 	   8,   -2, 	   1,   -9
+.2byte    2,  -10, 	   6,   -8, 	  -3,   -1, 	  -1,   -9
+.2byte    4,  -11, 	   6,   -7, 	   3,   -2, 	  -1,   -9
+.2byte    3,  -11, 	  -3,   -7, 	   5,   -4, 	  -3,   -9
+.2byte    0,   -9, 	   4,   -6, 	  -8,   -2, 	   0,   -6
+.2byte   -4,  -11, 	   2,   -7, 	  -6,   -4, 	   2,   -9
+.2byte   -5,  -11, 	  -7,   -7, 	  -4,   -2, 	   0,   -9
+.2byte   -3,  -10, 	  -7,   -8, 	   2,   -1, 	   0,   -9
+.2byte   -1,  -10, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -2,   -8, 	  -9,   -3, 	   6,   -2, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -2, 	  11,   -7, 	  -1,   -9
+.2byte    4,  -12, 	   9,  -10, 	  -5,   -3, 	  -1,  -10
+.2byte    2,   -8, 	   9,   -7, 	  -1,   -4, 	  -4,   -9
+.2byte    4,  -10, 	  10,   -7, 	  -9,   -3, 	   1,   -7
+.2byte    5,  -13, 	   6,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    7,  -10, 	  10,  -13, 	   9,   -4, 	   0,   -8
+.2byte    5,  -11, 	   8,  -12, 	  -4,   -1, 	  -1,   -8
+.2byte    3,  -17, 	  -2,  -11, 	  10,   -8, 	  -2,  -10
+.2byte    4,  -17, 	  -3,  -20, 	  11,  -17, 	  -3,  -12
+.2byte    3,  -13, 	   1,  -12, 	   6,   -3, 	  -2,  -10
+.2byte   -1,  -17, 	  10,  -12, 	 -12,  -12, 	  -1,  -11
+.2byte   -1,  -18, 	   8,  -22, 	 -10,  -22, 	  -1,  -13
+.2byte   -1,  -16, 	   8,  -14, 	 -13,   -8, 	  -1,  -10
+.2byte   -6,  -17, 	   1,  -20, 	 -13,  -17, 	   1,  -12
+.2byte   -4,  -13, 	   8,   -6, 	 -13,  -10, 	   0,  -11
+.2byte   -5,  -13, 	  -3,  -12, 	  -8,   -3, 	   0,  -10
+.2byte   -9,  -10, 	 -12,  -13, 	 -11,   -4, 	  -2,   -8
+.2byte   -7,  -11, 	  -1,  -13, 	  -8,   -5, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -12, 	   2,   -1, 	  -1,   -8
+.2byte   -6,  -12, 	 -11,  -10, 	   3,   -3, 	  -1,  -10
+.2byte   -4,   -8, 	 -11,   -7, 	  -1,   -4, 	   2,   -9
+.2byte   -6,  -10, 	 -12,   -7, 	   7,   -3, 	  -3,   -7
+.2byte   -1,   -8, 	  -8,   -3, 	   7,   -2, 	  -1,   -7
+.2byte   -4,   -8, 	 -11,   -7, 	  -1,   -4, 	   2,   -9
+.2byte   -7,  -10, 	 -10,  -13, 	  -9,   -4, 	   0,   -8
+.2byte   -6,  -16, 	   1,  -19, 	 -13,  -16, 	   1,  -11
+.2byte   -1,  -16, 	   8,  -20, 	 -10,  -20, 	  -1,  -11
+.2byte    5,  -16, 	  -2,  -19, 	  12,  -16, 	  -2,  -11
+.2byte    6,  -10, 	   9,  -13, 	   8,   -4, 	  -1,   -8
+.2byte    4,   -9, 	  11,   -8, 	   1,   -5, 	  -2,  -10
+.2byte   -1,   -8, 	  -8,   -3, 	   7,   -2, 	  -1,   -7
+.2byte    4,   -9, 	  11,   -8, 	   1,   -5, 	  -2,  -10
+.2byte    6,  -10, 	   9,  -13, 	   8,   -4, 	  -1,   -8
+.2byte    5,  -16, 	  -2,  -19, 	  12,  -16, 	  -2,  -11
+.2byte   -1,  -16, 	   8,  -20, 	 -10,  -20, 	  -1,  -11
+.2byte   -6,  -16, 	   1,  -19, 	 -13,  -16, 	   1,  -11
+.2byte   -7,  -10, 	 -10,  -13, 	  -9,   -4, 	   0,   -8
+.2byte   -4,   -8, 	 -11,   -7, 	  -1,   -4, 	   2,   -9
+.2byte   -1,  -10, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -1,  -12, 	   5,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	  -8,   -3, 	   7,   -2, 	  -1,   -7
+.2byte    4,  -12, 	   9,  -10, 	  -5,   -3, 	  -1,  -10
+.2byte    2,  -13, 	  -3,   -9, 	   6,  -13, 	  -1,  -12
+.2byte    4,   -8, 	  11,   -7, 	   1,   -4, 	  -2,   -9
+.2byte    5,  -13, 	   6,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    3,  -11, 	   4,   -6, 	   6,  -15, 	  -3,  -10
+.2byte    6,  -10, 	   9,  -13, 	   8,   -4, 	  -1,   -8
+.2byte    3,  -17, 	  -2,  -11, 	  10,   -8, 	  -2,  -10
+.2byte    2,  -12, 	  11,  -13, 	  -5,  -17, 	  -1,  -11
+.2byte    4,  -17, 	  -3,  -20, 	  11,  -17, 	  -3,  -12
+.2byte   -1,  -17, 	  10,  -12, 	 -12,  -12, 	  -1,  -11
+.2byte   -1,  -14, 	   6,  -15, 	  -8,  -15, 	  -1,   -9
+.2byte   -1,  -16, 	   8,  -20, 	 -10,  -20, 	  -1,  -11
+.2byte   -5,  -17, 	   0,  -11, 	 -12,   -8, 	   0,  -10
+.2byte   -4,  -12, 	 -13,  -13, 	   3,  -17, 	  -1,  -11
+.2byte   -6,  -17, 	   1,  -20, 	 -13,  -17, 	   1,  -12
+.2byte   -7,  -13, 	  -8,  -14, 	  -5,   -3, 	  -1,   -9
+.2byte   -5,  -11, 	  -6,   -6, 	  -8,  -15, 	   1,  -10
+.2byte   -8,  -10, 	 -11,  -13, 	 -10,   -4, 	  -1,   -8
+.2byte   -6,  -12, 	 -11,  -10, 	   3,   -3, 	  -1,  -10
+.2byte   -4,  -13, 	   1,   -9, 	  -8,  -13, 	  -1,  -12
+.2byte   -6,   -8, 	 -13,   -7, 	  -3,   -4, 	   0,   -9
+.2byte   -1,  -12, 	   5,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -3,  -13, 	   2,   -9, 	  -7,  -13, 	   0,  -12
+.2byte   -4,  -12, 	  -5,   -7, 	  -7,  -16, 	   2,  -11
+.2byte   -2,  -13, 	 -11,  -14, 	   5,  -18, 	   1,  -12
+.2byte   -1,  -16, 	   6,  -17, 	  -8,  -17, 	  -1,  -11
+.2byte    1,  -13, 	  10,  -14, 	  -6,  -18, 	  -2,  -12
+.2byte    3,  -12, 	   4,   -7, 	   6,  -16, 	  -3,  -11
+.2byte    2,  -13, 	  -3,   -9, 	   6,  -13, 	  -1,  -12
+.2byte   -1,  -10, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -6,  -12, 	 -11,  -10, 	   3,   -3, 	  -1,  -10
+.2byte   -7,  -13, 	  -8,  -14, 	  -5,   -3, 	  -1,   -9
+.2byte   -5,  -17, 	   0,  -11, 	 -12,   -8, 	   0,  -10
+.2byte   -1,  -17, 	  10,  -12, 	 -12,  -12, 	  -1,  -11
+.2byte    3,  -17, 	  -2,  -11, 	  10,   -8, 	  -2,  -10
+.2byte    5,  -13, 	   6,  -14, 	   3,   -3, 	  -1,   -9
+.2byte    4,  -12, 	   9,  -10, 	  -5,   -3, 	  -1,  -10
+sScizorAnimTable1:
+.4byte sScizorAnims_1_1
+.4byte sScizorAnims_1_2
+.4byte sScizorAnims_1_3
+.4byte sScizorAnims_1_4
+.4byte sScizorAnims_1_5
+.4byte sScizorAnims_1_6
+.4byte sScizorAnims_1_7
+.4byte sScizorAnims_1_8
+sScizorAnimTable2:
+.4byte sScizorAnims_2_1
+.4byte sScizorAnims_2_2
+.4byte sScizorAnims_2_3
+.4byte sScizorAnims_2_4
+.4byte sScizorAnims_2_5
+.4byte sScizorAnims_2_6
+.4byte sScizorAnims_2_7
+.4byte sScizorAnims_2_8
+sScizorAnimTable3:
+.4byte sScizorAnims_3_1
+.4byte sScizorAnims_3_2
+.4byte sScizorAnims_3_3
+.4byte sScizorAnims_3_4
+.4byte sScizorAnims_3_5
+.4byte sScizorAnims_3_6
+.4byte sScizorAnims_3_7
+.4byte sScizorAnims_3_8
+sScizorAnimTable4:
+.4byte sScizorAnims_4_1
+.4byte sScizorAnims_4_2
+.4byte sScizorAnims_4_3
+.4byte sScizorAnims_4_4
+.4byte sScizorAnims_4_5
+.4byte sScizorAnims_4_6
+.4byte sScizorAnims_4_7
+.4byte sScizorAnims_4_8
+sScizorAnimTable5:
+.4byte sScizorAnims_5_1
+.4byte sScizorAnims_5_2
+.4byte sScizorAnims_5_3
+.4byte sScizorAnims_5_4
+.4byte sScizorAnims_5_5
+.4byte sScizorAnims_5_6
+.4byte sScizorAnims_5_7
+.4byte sScizorAnims_5_8
+sScizorAnimTable6:
+.4byte sScizorAnims_6_1
+.4byte sScizorAnims_6_1
+.4byte sScizorAnims_6_1
+.4byte sScizorAnims_6_1
+.4byte sScizorAnims_6_1
+.4byte sScizorAnims_6_1
+.4byte sScizorAnims_6_1
+.4byte sScizorAnims_6_1
+sScizorAnimTable7:
+.4byte sScizorAnims_7_1
+.4byte sScizorAnims_7_2
+.4byte sScizorAnims_7_3
+.4byte sScizorAnims_7_4
+.4byte sScizorAnims_7_5
+.4byte sScizorAnims_7_6
+.4byte sScizorAnims_7_7
+.4byte sScizorAnims_7_8
+sScizorAnimTable8:
+.4byte sScizorAnims_8_1
+.4byte sScizorAnims_8_2
+.4byte sScizorAnims_8_3
+.4byte sScizorAnims_8_4
+.4byte sScizorAnims_8_5
+.4byte sScizorAnims_8_6
+.4byte sScizorAnims_8_7
+.4byte sScizorAnims_8_8
+sScizorAnimTable9:
+.4byte sScizorAnims_9_1
+.4byte sScizorAnims_9_2
+.4byte sScizorAnims_9_3
+.4byte sScizorAnims_9_4
+.4byte sScizorAnims_9_5
+.4byte sScizorAnims_9_6
+.4byte sScizorAnims_9_7
+.4byte sScizorAnims_9_8
+sScizorAnimTable10:
+.4byte sScizorAnims_10_1
+.4byte sScizorAnims_10_2
+.4byte sScizorAnims_10_3
+.4byte sScizorAnims_10_4
+.4byte sScizorAnims_10_5
+.4byte sScizorAnims_10_6
+.4byte sScizorAnims_10_7
+.4byte sScizorAnims_10_8
+sScizorAnimTable11:
+.4byte sScizorAnims_11_1
+.4byte sScizorAnims_11_2
+.4byte sScizorAnims_11_3
+.4byte sScizorAnims_11_4
+.4byte sScizorAnims_11_5
+.4byte sScizorAnims_11_6
+.4byte sScizorAnims_11_7
+.4byte sScizorAnims_11_8
+sScizorAnimTable12:
+.4byte sScizorAnims_12_1
+.4byte sScizorAnims_12_2
+.4byte sScizorAnims_12_3
+.4byte sScizorAnims_12_4
+.4byte sScizorAnims_12_5
+.4byte sScizorAnims_12_6
+.4byte sScizorAnims_12_7
+.4byte sScizorAnims_12_8
+sScizorAnimTable13:
+.4byte sScizorAnims_13_1
+.4byte sScizorAnims_13_2
+.4byte sScizorAnims_13_3
+.4byte sScizorAnims_13_4
+.4byte sScizorAnims_13_5
+.4byte sScizorAnims_13_6
+.4byte sScizorAnims_13_7
+.4byte sScizorAnims_13_8
+sAxAnimationsScizor:
+.4byte sScizorAnimTable1
+.4byte sScizorAnimTable2
+.4byte sScizorAnimTable3
+.4byte sScizorAnimTable4
+.4byte sScizorAnimTable5
+.4byte sScizorAnimTable6
+.4byte sScizorAnimTable7
+.4byte sScizorAnimTable8
+.4byte sScizorAnimTable9
+.4byte sScizorAnimTable10
+.4byte sScizorAnimTable11
+.4byte sScizorAnimTable12
+.4byte sScizorAnimTable13
+sAxSpritesScizor:
+.4byte sScizorSprites1
+.4byte sScizorSprites2
+.4byte sScizorSprites3
+.4byte sScizorSprites4
+.4byte sScizorSprites5
+.4byte sScizorSprites6
+.4byte sScizorSprites7
+.4byte sScizorSprites8
+.4byte sScizorSprites9
+.4byte sScizorSprites10
+.4byte sScizorSprites11
+.4byte sScizorSprites12
+.4byte sScizorSprites13
+.4byte sScizorSprites14
+.4byte sScizorSprites15
+.4byte sScizorSprites16
+.4byte sScizorSprites17
+.4byte sScizorSprites18
+.4byte sScizorSprites19
+.4byte sScizorSprites20
+.4byte sScizorSprites21
+.4byte sScizorSprites22
+.4byte sScizorSprites23
+.4byte sScizorSprites24
+.4byte sScizorSprites25
+.4byte sScizorSprites26
+.4byte sScizorSprites27
+.4byte sScizorSprites28
+.4byte sScizorSprites29
+.4byte sScizorSprites30
+.4byte sScizorSprites31
+.4byte sScizorSprites32
+.4byte sScizorSprites33
+.4byte sScizorSprites34
+.4byte sScizorSprites35
+.4byte sScizorSprites36
+.4byte sScizorSprites37
+.4byte sScizorSprites38
+.4byte sScizorSprites39
+.4byte sScizorSprites40
+.4byte sScizorSprites41
+.4byte sScizorSprites42
+.4byte sScizorSprites43
+.4byte sScizorSprites44
+.4byte sScizorSprites45
+.4byte sScizorSprites46
+.4byte sScizorSprites47
+.4byte sScizorSprites48
+sAxMainScizor:
+ax_main sAxPosesScizor, sAxAnimationsScizor, 13, sAxSpritesScizor, sAxPositionsScizor

--- a/data/ax/scyther.inc
+++ b/data/ax/scyther.inc
@@ -1,0 +1,2700 @@
+.global gAxScyther
+gAxScyther:
+ax_siro sAxMainScyther
+sScytherPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose4:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose5:
+ax_pose 4, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose6:
+ax_pose 5, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose7:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose8:
+ax_pose 7, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose9:
+ax_pose 8, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose10:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose11:
+ax_pose 10, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose12:
+ax_pose 11, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose28:
+ax_pose 15, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose29:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose30:
+ax_pose 4, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose31:
+ax_pose 5, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose32:
+ax_pose 16, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose33:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose34:
+ax_pose 7, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose35:
+ax_pose 8, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose36:
+ax_pose 17, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose37:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose38:
+ax_pose 10, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose39:
+ax_pose 11, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose40:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose41:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose42:
+ax_pose 13, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose43:
+ax_pose 14, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose44:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose45:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose46:
+ax_pose 10, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose47:
+ax_pose 11, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose48:
+ax_pose 18, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose49:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose50:
+ax_pose 7, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose51:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose52:
+ax_pose 17, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose53:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose54:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose55:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose56:
+ax_pose 16, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose57:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose58:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose59:
+ax_pose 21, 0x01e7, 0x80f8, 0x8c00
+ax_pose -1, 0x01e7, 0x90e8, 0x8c00
+ax_pose 15, 0x01e5, 0x80f0, 0x8c10
+ax_pose_terminator
+sScytherPose60:
+ax_pose 15, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose61:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose62:
+ax_pose 22, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose63:
+ax_pose 23, 0x01f1, 0x90ec, 0x8c00
+ax_pose 24, 0x01eb, 0x90ff, 0x8c10
+ax_pose 16, 0x01e5, 0x90f1, 0x8c20
+ax_pose_terminator
+sScytherPose64:
+ax_pose 16, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose65:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose66:
+ax_pose 25, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose67:
+ax_pose 26, 0x81f9, 0x1112, 0x8c00
+ax_pose 27, 0x41f9, 0x90f2, 0x8c02
+ax_pose 17, 0x01e5, 0x90f0, 0x8c0a
+ax_pose 28, 0x41eb, 0x90fb, 0x8c1a
+ax_pose_terminator
+sScytherPose68:
+ax_pose 17, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose69:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose70:
+ax_pose 29, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose71:
+ax_pose 30, 0x41f3, 0x90fe, 0x8c00
+ax_pose 31, 0x01e3, 0x510e, 0x8c08
+ax_pose 18, 0x01e5, 0x90f0, 0x8c0c
+ax_pose 32, 0x41e3, 0x90ee, 0x8c1c
+ax_pose_terminator
+sScytherPose72:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose73:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose74:
+ax_pose 33, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose75:
+ax_pose 34, 0x41f3, 0x1107, 0x8c00
+ax_pose -1, 0x41f3, 0x00e9, 0x8c00
+ax_pose 19, 0x01e5, 0x80f0, 0x8c02
+ax_pose 35, 0x41e3, 0x90f9, 0x8c12
+ax_pose -1, 0x41e3, 0x80e7, 0x8c12
+ax_pose_terminator
+sScytherPose76:
+ax_pose 19, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose77:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose78:
+ax_pose 29, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose79:
+ax_pose 30, 0x41f3, 0x80e2, 0x8c00
+ax_pose 31, 0x01e3, 0x40e2, 0x8c08
+ax_pose 18, 0x01e5, 0x80f0, 0x8c0c
+ax_pose 32, 0x41e3, 0x80f2, 0x8c1c
+ax_pose_terminator
+sScytherPose80:
+ax_pose 18, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose81:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose82:
+ax_pose 25, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose83:
+ax_pose 26, 0x81f9, 0x00e6, 0x8c00
+ax_pose 27, 0x41f9, 0x80ee, 0x8c02
+ax_pose 17, 0x01e5, 0x80f0, 0x8c0a
+ax_pose 28, 0x41eb, 0x80e5, 0x8c1a
+ax_pose_terminator
+sScytherPose84:
+ax_pose 17, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose85:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose86:
+ax_pose 22, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose87:
+ax_pose 23, 0x01f0, 0x80f4, 0x8c00
+ax_pose 24, 0x01ea, 0x80e2, 0x8c10
+ax_pose 16, 0x01e5, 0x80ef, 0x8c20
+ax_pose_terminator
+sScytherPose88:
+ax_pose 16, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose89:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose90:
+ax_pose 36, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose91:
+ax_pose 15, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose92:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose93:
+ax_pose 37, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose94:
+ax_pose 16, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose95:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose96:
+ax_pose 38, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose97:
+ax_pose 17, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose98:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose99:
+ax_pose 39, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose100:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose101:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose102:
+ax_pose 40, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose103:
+ax_pose 41, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose104:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose105:
+ax_pose 39, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose106:
+ax_pose 18, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose107:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose108:
+ax_pose 38, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose109:
+ax_pose 17, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose110:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose111:
+ax_pose 37, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose112:
+ax_pose 16, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose113:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose114:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose115:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose116:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose117:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose118:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose119:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose120:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose121:
+ax_pose 42, 0x01e8, 0x80f2, 0x8c00
+ax_pose_terminator
+sScytherPose122:
+ax_pose 43, 0x01e8, 0x80f2, 0x8c00
+ax_pose_terminator
+sScytherPose123:
+ax_pose 44, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sScytherPose124:
+ax_pose 45, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sScytherPose125:
+ax_pose 46, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sScytherPose126:
+ax_pose 47, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose127:
+ax_pose 48, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sScytherPose128:
+ax_pose 47, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sScytherPose129:
+ax_pose 46, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sScytherPose130:
+ax_pose 45, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sScytherPose131:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose132:
+ax_pose 1, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose133:
+ax_pose 2, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose134:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose135:
+ax_pose 4, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose136:
+ax_pose 5, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose137:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose138:
+ax_pose 7, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose139:
+ax_pose 8, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose140:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose141:
+ax_pose 10, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose142:
+ax_pose 11, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose143:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose144:
+ax_pose 13, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose145:
+ax_pose 14, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose146:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose147:
+ax_pose 10, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose148:
+ax_pose 11, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose149:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose150:
+ax_pose 7, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose151:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose152:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose153:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose154:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose155:
+ax_pose 15, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose156:
+ax_pose 16, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose157:
+ax_pose 17, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose158:
+ax_pose 18, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose159:
+ax_pose 41, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose160:
+ax_pose 18, 0x01e7, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose161:
+ax_pose 17, 0x01e4, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose162:
+ax_pose 16, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose163:
+ax_pose 36, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose164:
+ax_pose 37, 0x01e5, 0x90f2, 0x8c00
+ax_pose_terminator
+sScytherPose165:
+ax_pose 38, 0x01e4, 0x90f2, 0x8c00
+ax_pose_terminator
+sScytherPose166:
+ax_pose 39, 0x01e3, 0x90f2, 0x8c00
+ax_pose_terminator
+sScytherPose167:
+ax_pose 40, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose168:
+ax_pose 39, 0x01e3, 0x80ee, 0x8c00
+ax_pose_terminator
+sScytherPose169:
+ax_pose 38, 0x01e4, 0x80ee, 0x8c00
+ax_pose_terminator
+sScytherPose170:
+ax_pose 37, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sScytherPose171:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose172:
+ax_pose 36, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose173:
+ax_pose 15, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose174:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose175:
+ax_pose 37, 0x01e5, 0x90f2, 0x8c00
+ax_pose_terminator
+sScytherPose176:
+ax_pose 16, 0x01e5, 0x90ef, 0x8c00
+ax_pose_terminator
+sScytherPose177:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose178:
+ax_pose 38, 0x01e5, 0x90f2, 0x8c00
+ax_pose_terminator
+sScytherPose179:
+ax_pose 17, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose180:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose181:
+ax_pose 39, 0x01e5, 0x90f2, 0x8c00
+ax_pose_terminator
+sScytherPose182:
+ax_pose 18, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sScytherPose183:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose184:
+ax_pose 40, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose185:
+ax_pose 41, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose186:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose187:
+ax_pose 39, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sScytherPose188:
+ax_pose 18, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose189:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose190:
+ax_pose 38, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sScytherPose191:
+ax_pose 17, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose192:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose193:
+ax_pose 37, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sScytherPose194:
+ax_pose 16, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sScytherPose195:
+ax_pose 20, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose196:
+ax_pose 22, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose197:
+ax_pose 25, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sScytherPose198:
+ax_pose 29, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sScytherPose199:
+ax_pose 33, 0x01e3, 0x80f1, 0x8c00
+ax_pose_terminator
+sScytherPose200:
+ax_pose 29, 0x01e5, 0x90f3, 0x8c00
+ax_pose_terminator
+sScytherPose201:
+ax_pose 25, 0x01e6, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose202:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sScytherPose203:
+ax_pose 0, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose204:
+ax_pose 3, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose205:
+ax_pose 6, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose206:
+ax_pose 9, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose207:
+ax_pose 12, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sScytherPose208:
+ax_pose 9, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose209:
+ax_pose 6, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+sScytherPose210:
+ax_pose 3, 0x01e5, 0x90f1, 0x8c00
+ax_pose_terminator
+.align 2
+sScytherAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sScytherAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 3, 4, 3, 4,
+ax_anim 1, 0, 31, 9, 11, 9, 11,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 1, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 0, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 28, 5, 7, 5, 7,
+ax_anim_terminator
+sScytherAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 3, 0, 3, 0,
+ax_anim 1, 0, 35, 8, 0, 8, 0,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sScytherAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 6, -6, 6, -6,
+ax_anim 1, 0, 39, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 1, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sScytherAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 1, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sScytherAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 47, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -6, -6, -6, -6,
+ax_anim 1, 0, 47, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 1, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sScytherAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -3, 0, -3, 0,
+ax_anim 1, 0, 51, -8, 0, -8, 0,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sScytherAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -3, 4, -3, 4,
+ax_anim 1, 0, 55, -9, 11, -9, 11,
+ax_anim 2, 0, 55, -16, 19, -16, 19,
+ax_anim 2, 1, 55, -17, 18, -17, 18,
+ax_anim 2, 0, 55, -16, 19, -16, 19,
+ax_anim 2, 0, 55, -17, 18, -17, 18,
+ax_anim 2, 0, 52, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sScytherAnims_3_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 4, 0, 57, 0, -3, 0, -3,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 57, 0, 6, 0, 6,
+ax_anim 2, 0, 58, 0, 12, 0, 12,
+ax_anim 2, 1, 59, 1, 12, 1, 12,
+ax_anim 2, 0, 59, 0, 12, 0, 12,
+ax_anim 2, 0, 59, 1, 11, 1, 11,
+ax_anim 2, 0, 59, 0, 11, 0, 11,
+ax_anim 2, 0, 59, 1, 11, 1, 11,
+ax_anim 2, 0, 59, 0, 11, 0, 11,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sScytherAnims_3_2:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 4, 0, 61, -3, -3, -3, -3,
+ax_anim 1, 2, 61, 2, 2, 2, 2,
+ax_anim 1, 0, 61, 6, 6, 6, 6,
+ax_anim 2, 0, 62, 10, 12, 10, 12,
+ax_anim 2, 1, 63, 11, 11, 11, 11,
+ax_anim 2, 0, 63, 10, 12, 10, 12,
+ax_anim 2, 0, 63, 11, 11, 11, 11,
+ax_anim 2, 0, 63, 10, 12, 10, 12,
+ax_anim 2, 0, 63, 11, 11, 11, 11,
+ax_anim 2, 0, 63, 10, 12, 10, 12,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sScytherAnims_3_3:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 4, 0, 65, -3, 0, -3, 0,
+ax_anim 1, 2, 65, 2, 0, 2, 0,
+ax_anim 1, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 1, 67, 10, 1, 10, 1,
+ax_anim 2, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 10, 1, 10, 1,
+ax_anim 2, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 10, 1, 10, 1,
+ax_anim 2, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sScytherAnims_3_4:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 4, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 2, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 5, -7, 5, -7,
+ax_anim 2, 0, 70, 10, -14, 10, -14,
+ax_anim 2, 1, 71, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 10, -14, 10, -14,
+ax_anim 2, 0, 71, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 10, -14, 10, -14,
+ax_anim 2, 0, 71, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 10, -14, 10, -14,
+ax_anim 2, 0, 68, 3, -5, 3, -5,
+ax_anim_terminator
+sScytherAnims_3_5:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 4, 0, 73, 0, 3, 0, 3,
+ax_anim 1, 2, 73, 0, -2, 0, -2,
+ax_anim 1, 0, 73, 0, -6, 0, -6,
+ax_anim 2, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 1, 75, 1, -11, 1, -11,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 1, -11, 1, -11,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 1, -11, 1, -11,
+ax_anim 2, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sScytherAnims_3_6:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 4, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 2, 77, -2, -2, -2, -2,
+ax_anim 1, 0, 77, -5, -7, -5, -7,
+ax_anim 2, 0, 78, -10, -14, -10, -14,
+ax_anim 2, 1, 79, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -10, -14, -10, -14,
+ax_anim 2, 0, 79, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -10, -14, -10, -14,
+ax_anim 2, 0, 79, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -10, -14, -10, -14,
+ax_anim 2, 0, 76, -3, -5, -3, -5,
+ax_anim_terminator
+sScytherAnims_3_7:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 4, 0, 81, 3, 0, 3, 0,
+ax_anim 1, 2, 81, -2, 0, -2, 0,
+ax_anim 1, 0, 81, -6, 0, -6, 0,
+ax_anim 2, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 1, 83, -10, 1, -10, 1,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -10, 1, -10, 1,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -10, 1, -10, 1,
+ax_anim 2, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sScytherAnims_3_8:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 4, 0, 85, 3, -3, 3, -3,
+ax_anim 1, 2, 85, -2, 2, -2, 2,
+ax_anim 1, 0, 85, -6, 6, -6, 6,
+ax_anim 2, 0, 86, -10, 12, -10, 12,
+ax_anim 2, 1, 87, -11, 11, -11, 11,
+ax_anim 2, 0, 87, -10, 12, -10, 12,
+ax_anim 2, 0, 87, -11, 11, -11, 11,
+ax_anim 2, 0, 87, -10, 12, -10, 12,
+ax_anim 2, 0, 87, -11, 11, -11, 11,
+ax_anim 2, 0, 87, -10, 12, -10, 12,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sScytherAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, 1, 0, 1,
+ax_anim 2, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 1, 90, 1, 6, 1, 6,
+ax_anim 2, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 90, 1, 6, 1, 6,
+ax_anim 2, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 90, 1, 6, 1, 6,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sScytherAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 1, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 1, 93, 7, 5, 7, 5,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 7, 5, 7, 5,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 7, 5, 7, 5,
+ax_anim 2, 0, 91, 0, 2, 0, 2,
+ax_anim_terminator
+sScytherAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 1, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 1, 96, 6, 1, 6, 1,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 0, 96, 6, 1, 6, 1,
+ax_anim 2, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 0, 96, 6, 1, 6, 1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 1, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 1, 99, 7, -5, 7, -5,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, 7, -5, 7, -5,
+ax_anim 2, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 0, 99, 7, -5, 7, -5,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim_terminator
+sScytherAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 1, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 1, 102, 1, -6, 1, -6,
+ax_anim 2, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 0, 102, 1, -6, 1, -6,
+ax_anim 2, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 0, 102, 1, -6, 1, -6,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sScytherAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 1, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 1, 105, -7, -5, -7, -5,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, -7, -5, -7, -5,
+ax_anim 2, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 0, 105, -7, -5, -7, -5,
+ax_anim 2, 0, 103, 0, -2, 0, -2,
+ax_anim_terminator
+sScytherAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 1, 108, -6, 1, -6, 1,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 0, 108, -6, 1, -6, 1,
+ax_anim 2, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 0, 108, -6, 1, -6, 1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 1, 111, -7, 5, -7, 5,
+ax_anim 2, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 111, -7, 5, -7, 5,
+ax_anim 2, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 0, 111, -7, 5, -7, 5,
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim_terminator
+.align 2
+sScytherAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sScytherAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sScytherAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sScytherAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sScytherAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sScytherAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sScytherAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sScytherAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sScytherAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 132, 0, 0, 0, 0,
+ax_anim 14, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 136, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 14, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, 0, 0, 0,
+ax_anim 14, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim 14, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 15, 7, 15,
+ax_anim 3, 0, 158, 0, 18, 0, 18,
+ax_anim 2, 3, 159, -7, 15, -7, 15,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 19, 12, 19, 12,
+ax_anim 3, 0, 157, 19, 18, 19, 18,
+ax_anim 2, 3, 158, 9, 19, 9, 19,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 18, -5, 18, -5,
+ax_anim 3, 0, 156, 20, -2, 20, -2,
+ax_anim 2, 3, 157, 18, 3, 18, 3,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 3, 4, 3,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 1, -6, 1, -6,
+ax_anim 2, 0, 161, 2, -16, 2, -16,
+ax_anim 2, 0, 154, 12, -22, 12, -22,
+ax_anim 3, 0, 155, 18, -22, 18, -22,
+ax_anim 2, 3, 156, 20, -15, 20, -15,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -2, -16, -2, -16,
+ax_anim 2, 0, 154, -12, -22, -12, -22,
+ax_anim 3, 0, 161, -18, -22, -18, -22,
+ax_anim 2, 3, 160, -20, -15, -20, -15,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -18, -5, -18, -5,
+ax_anim 3, 0, 160, -20, -2, -20, -2,
+ax_anim 2, 3, 159, -18, 3, -18, 3,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 3, -4, 3,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -19, 12, -19, 12,
+ax_anim 3, 0, 159, -19, 18, -19, 18,
+ax_anim 2, 3, 158, -9, 19, -9, 19,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -26, 0, 0,
+ax_anim 3, 0, 172, 0, -25, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -24, 0, 0,
+ax_anim 3, 0, 175, 0, -23, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -24, 0, 0,
+ax_anim 3, 0, 193, 0, -23, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sScytherAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sScytherGfx1:
+.incbin "baserom.gba", 0xA48488, 0x200
+sScytherSprites1:
+ax_sprite sScytherGfx1, 0x200
+ax_sprite_terminator
+sScytherGfx2:
+.incbin "baserom.gba", 0xA48698, 0x200
+sScytherSprites2:
+ax_sprite sScytherGfx2, 0x200
+ax_sprite_terminator
+sScytherGfx3:
+.incbin "baserom.gba", 0xA488A8, 0x200
+sScytherSprites3:
+ax_sprite sScytherGfx3, 0x200
+ax_sprite_terminator
+sScytherGfx4:
+.incbin "baserom.gba", 0xA48AB8, 0x200
+sScytherSprites4:
+ax_sprite sScytherGfx4, 0x200
+ax_sprite_terminator
+sScytherGfx5:
+.incbin "baserom.gba", 0xA48CC8, 0x200
+sScytherSprites5:
+ax_sprite sScytherGfx5, 0x200
+ax_sprite_terminator
+sScytherGfx6:
+.incbin "baserom.gba", 0xA48ED8, 0x200
+sScytherSprites6:
+ax_sprite sScytherGfx6, 0x200
+ax_sprite_terminator
+sScytherGfx7:
+.incbin "baserom.gba", 0xA490E8, 0x200
+sScytherSprites7:
+ax_sprite sScytherGfx7, 0x200
+ax_sprite_terminator
+sScytherGfx8:
+.incbin "baserom.gba", 0xA492F8, 0x200
+sScytherSprites8:
+ax_sprite sScytherGfx8, 0x200
+ax_sprite_terminator
+sScytherGfx9:
+.incbin "baserom.gba", 0xA49508, 0x200
+sScytherSprites9:
+ax_sprite sScytherGfx9, 0x200
+ax_sprite_terminator
+sScytherGfx10:
+.incbin "baserom.gba", 0xA49718, 0x200
+sScytherSprites10:
+ax_sprite sScytherGfx10, 0x200
+ax_sprite_terminator
+sScytherGfx11:
+.incbin "baserom.gba", 0xA49928, 0x200
+sScytherSprites11:
+ax_sprite sScytherGfx11, 0x200
+ax_sprite_terminator
+sScytherGfx12:
+.incbin "baserom.gba", 0xA49B38, 0x200
+sScytherSprites12:
+ax_sprite sScytherGfx12, 0x200
+ax_sprite_terminator
+sScytherGfx13:
+.incbin "baserom.gba", 0xA49D48, 0x200
+sScytherSprites13:
+ax_sprite sScytherGfx13, 0x200
+ax_sprite_terminator
+sScytherGfx14:
+.incbin "baserom.gba", 0xA49F58, 0x200
+sScytherSprites14:
+ax_sprite sScytherGfx14, 0x200
+ax_sprite_terminator
+sScytherGfx15:
+.incbin "baserom.gba", 0xA4A168, 0x200
+sScytherSprites15:
+ax_sprite sScytherGfx15, 0x200
+ax_sprite_terminator
+sScytherGfx16:
+.incbin "baserom.gba", 0xA4A378, 0x40
+sScytherGfx16_1:
+.incbin "baserom.gba", 0xA4A3B8, 0x160
+sScytherSprites16:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx16_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx17:
+.incbin "baserom.gba", 0xA4A548, 0x40
+sScytherGfx17_1:
+.incbin "baserom.gba", 0xA4A588, 0x160
+sScytherSprites17:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx17_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx18:
+.incbin "baserom.gba", 0xA4A718, 0x40
+sScytherGfx18_1:
+.incbin "baserom.gba", 0xA4A758, 0x60
+sScytherGfx18_2:
+.incbin "baserom.gba", 0xA4A7B8, 0x100
+sScytherSprites18:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx18_2, 0x100
+ax_sprite_terminator
+sScytherGfx19:
+.incbin "baserom.gba", 0xA4A8F0, 0x40
+sScytherGfx19_1:
+.incbin "baserom.gba", 0xA4A930, 0x160
+sScytherSprites19:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx20:
+.incbin "baserom.gba", 0xA4AAC0, 0x40
+sScytherGfx20_1:
+.incbin "baserom.gba", 0xA4AB00, 0x100
+sScytherGfx20_2:
+.incbin "baserom.gba", 0xA4AC00, 0x40
+sScytherSprites20:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx21:
+.incbin "baserom.gba", 0xA4AC80, 0x180
+sScytherGfx21_1:
+.incbin "baserom.gba", 0xA4AE00, 0x20
+sScytherSprites21:
+ax_sprite sScytherGfx21, 0x180
+ax_sprite 0, 0x40
+ax_sprite sScytherGfx21_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx22:
+.incbin "baserom.gba", 0xA4AE48, 0x60
+sScytherGfx22_1:
+.incbin "baserom.gba", 0xA4AEA8, 0xC0
+sScytherSprites22:
+ax_sprite 0, 0xc0
+ax_sprite sScytherGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx22_1, 0xc0
+ax_sprite_terminator
+sScytherGfx23:
+.incbin "baserom.gba", 0xA4AF90, 0x140
+sScytherGfx23_1:
+.incbin "baserom.gba", 0xA4B0D0, 0x40
+sScytherSprites23:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx23, 0x140
+ax_sprite 0, 0x40
+ax_sprite sScytherGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx24:
+.incbin "baserom.gba", 0xA4B140, 0x40
+sScytherGfx24_1:
+.incbin "baserom.gba", 0xA4B180, 0x60
+sScytherGfx24_2:
+.incbin "baserom.gba", 0xA4B1E0, 0xC0
+sScytherSprites24:
+ax_sprite 0, 0x40
+ax_sprite sScytherGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sScytherGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx24_2, 0xc0
+ax_sprite_terminator
+sScytherGfx25:
+.incbin "baserom.gba", 0xA4B2D8, 0x60
+sScytherGfx25_1:
+.incbin "baserom.gba", 0xA4B338, 0x60
+sScytherGfx25_2:
+.incbin "baserom.gba", 0xA4B398, 0x40
+sScytherGfx25_3:
+.incbin "baserom.gba", 0xA4B3D8, 0x80
+sScytherSprites25:
+ax_sprite sScytherGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx25_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sScytherGfx25_3, 0x80
+ax_sprite_terminator
+sScytherGfx26:
+.incbin "baserom.gba", 0xA4B498, 0x40
+sScytherGfx26_1:
+.incbin "baserom.gba", 0xA4B4D8, 0x100
+sScytherGfx26_2:
+.incbin "baserom.gba", 0xA4B5D8, 0x40
+sScytherSprites26:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx27:
+.incbin "baserom.gba", 0xA4B658, 0x40
+sScytherSprites27:
+ax_sprite sScytherGfx27, 0x40
+ax_sprite_terminator
+sScytherGfx28:
+.incbin "baserom.gba", 0xA4B6A8, 0x20
+sScytherGfx28_1:
+.incbin "baserom.gba", 0xA4B6C8, 0xC0
+sScytherSprites28:
+ax_sprite sScytherGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx28_1, 0xc0
+ax_sprite_terminator
+sScytherGfx29:
+.incbin "baserom.gba", 0xA4B7A8, 0xC0
+sScytherGfx29_1:
+.incbin "baserom.gba", 0xA4B868, 0x20
+sScytherSprites29:
+ax_sprite sScytherGfx29, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx29_1, 0x20
+ax_sprite_terminator
+sScytherGfx30:
+.incbin "baserom.gba", 0xA4B8A8, 0x160
+sScytherGfx30_1:
+.incbin "baserom.gba", 0xA4BA08, 0x60
+sScytherSprites30:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx30, 0x160
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx30_1, 0x60
+ax_sprite_terminator
+sScytherGfx31:
+.incbin "baserom.gba", 0xA4BA90, 0x100
+sScytherSprites31:
+ax_sprite sScytherGfx31, 0x100
+ax_sprite_terminator
+sScytherGfx32:
+.incbin "baserom.gba", 0xA4BBA0, 0x80
+sScytherSprites32:
+ax_sprite sScytherGfx32, 0x80
+ax_sprite_terminator
+sScytherGfx33:
+.incbin "baserom.gba", 0xA4BC30, 0xA0
+sScytherGfx33_1:
+.incbin "baserom.gba", 0xA4BCD0, 0x40
+sScytherSprites33:
+ax_sprite sScytherGfx33, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx33_1, 0x40
+ax_sprite_terminator
+sScytherGfx34:
+.incbin "baserom.gba", 0xA4BD30, 0x100
+sScytherGfx34_1:
+.incbin "baserom.gba", 0xA4BE30, 0x40
+sScytherSprites34:
+ax_sprite 0, 0x80
+ax_sprite sScytherGfx34, 0x100
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx34_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx35:
+.incbin "baserom.gba", 0xA4BEA0, 0x40
+sScytherSprites35:
+ax_sprite sScytherGfx35, 0x40
+ax_sprite_terminator
+sScytherGfx36:
+.incbin "baserom.gba", 0xA4BEF0, 0x100
+sScytherSprites36:
+ax_sprite sScytherGfx36, 0x100
+ax_sprite_terminator
+sScytherGfx37:
+.incbin "baserom.gba", 0xA4C000, 0x1E0
+sScytherSprites37:
+ax_sprite sScytherGfx37, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx38:
+.incbin "baserom.gba", 0xA4C1F8, 0x100
+sScytherGfx38_1:
+.incbin "baserom.gba", 0xA4C2F8, 0x60
+sScytherGfx38_2:
+.incbin "baserom.gba", 0xA4C358, 0x60
+sScytherSprites38:
+ax_sprite sScytherGfx38, 0x100
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx38_2, 0x60
+ax_sprite_terminator
+sScytherGfx39:
+.incbin "baserom.gba", 0xA4C3E8, 0x40
+sScytherGfx39_1:
+.incbin "baserom.gba", 0xA4C428, 0x60
+sScytherGfx39_2:
+.incbin "baserom.gba", 0xA4C488, 0x60
+sScytherGfx39_3:
+.incbin "baserom.gba", 0xA4C4E8, 0x60
+sScytherSprites39:
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sScytherGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx39_3, 0x60
+ax_sprite_terminator
+sScytherGfx40:
+.incbin "baserom.gba", 0xA4C590, 0x180
+sScytherGfx40_1:
+.incbin "baserom.gba", 0xA4C710, 0x60
+sScytherSprites40:
+ax_sprite sScytherGfx40, 0x180
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx40_1, 0x60
+ax_sprite_terminator
+sScytherGfx41:
+.incbin "baserom.gba", 0xA4C790, 0x200
+sScytherSprites41:
+ax_sprite sScytherGfx41, 0x200
+ax_sprite_terminator
+sScytherGfx42:
+.incbin "baserom.gba", 0xA4C9A0, 0x180
+sScytherGfx42_1:
+.incbin "baserom.gba", 0xA4CB20, 0x40
+sScytherSprites42:
+ax_sprite sScytherGfx42, 0x180
+ax_sprite 0, 0x20
+ax_sprite sScytherGfx42_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sScytherGfx43:
+.incbin "baserom.gba", 0xA4CB88, 0x200
+sScytherSprites43:
+ax_sprite sScytherGfx43, 0x200
+ax_sprite_terminator
+sScytherGfx44:
+.incbin "baserom.gba", 0xA4CD98, 0x200
+sScytherSprites44:
+ax_sprite sScytherGfx44, 0x200
+ax_sprite_terminator
+sScytherGfx45:
+.incbin "baserom.gba", 0xA4CFA8, 0x200
+sScytherSprites45:
+ax_sprite sScytherGfx45, 0x200
+ax_sprite_terminator
+sScytherGfx46:
+.incbin "baserom.gba", 0xA4D1B8, 0x200
+sScytherSprites46:
+ax_sprite sScytherGfx46, 0x200
+ax_sprite_terminator
+sScytherGfx47:
+.incbin "baserom.gba", 0xA4D3C8, 0x200
+sScytherSprites47:
+ax_sprite sScytherGfx47, 0x200
+ax_sprite_terminator
+sScytherGfx48:
+.incbin "baserom.gba", 0xA4D5D8, 0x200
+sScytherSprites48:
+ax_sprite sScytherGfx48, 0x200
+ax_sprite_terminator
+sScytherGfx49:
+.incbin "baserom.gba", 0xA4D7E8, 0x200
+sScytherSprites49:
+ax_sprite sScytherGfx49, 0x200
+ax_sprite_terminator
+sAxPosesScyther:
+.4byte sScytherPose1
+.4byte sScytherPose2
+.4byte sScytherPose3
+.4byte sScytherPose4
+.4byte sScytherPose5
+.4byte sScytherPose6
+.4byte sScytherPose7
+.4byte sScytherPose8
+.4byte sScytherPose9
+.4byte sScytherPose10
+.4byte sScytherPose11
+.4byte sScytherPose12
+.4byte sScytherPose13
+.4byte sScytherPose14
+.4byte sScytherPose15
+.4byte sScytherPose16
+.4byte sScytherPose17
+.4byte sScytherPose18
+.4byte sScytherPose19
+.4byte sScytherPose20
+.4byte sScytherPose21
+.4byte sScytherPose22
+.4byte sScytherPose23
+.4byte sScytherPose24
+.4byte sScytherPose25
+.4byte sScytherPose26
+.4byte sScytherPose27
+.4byte sScytherPose28
+.4byte sScytherPose29
+.4byte sScytherPose30
+.4byte sScytherPose31
+.4byte sScytherPose32
+.4byte sScytherPose33
+.4byte sScytherPose34
+.4byte sScytherPose35
+.4byte sScytherPose36
+.4byte sScytherPose37
+.4byte sScytherPose38
+.4byte sScytherPose39
+.4byte sScytherPose40
+.4byte sScytherPose41
+.4byte sScytherPose42
+.4byte sScytherPose43
+.4byte sScytherPose44
+.4byte sScytherPose45
+.4byte sScytherPose46
+.4byte sScytherPose47
+.4byte sScytherPose48
+.4byte sScytherPose49
+.4byte sScytherPose50
+.4byte sScytherPose51
+.4byte sScytherPose52
+.4byte sScytherPose53
+.4byte sScytherPose54
+.4byte sScytherPose55
+.4byte sScytherPose56
+.4byte sScytherPose57
+.4byte sScytherPose58
+.4byte sScytherPose59
+.4byte sScytherPose60
+.4byte sScytherPose61
+.4byte sScytherPose62
+.4byte sScytherPose63
+.4byte sScytherPose64
+.4byte sScytherPose65
+.4byte sScytherPose66
+.4byte sScytherPose67
+.4byte sScytherPose68
+.4byte sScytherPose69
+.4byte sScytherPose70
+.4byte sScytherPose71
+.4byte sScytherPose72
+.4byte sScytherPose73
+.4byte sScytherPose74
+.4byte sScytherPose75
+.4byte sScytherPose76
+.4byte sScytherPose77
+.4byte sScytherPose78
+.4byte sScytherPose79
+.4byte sScytherPose80
+.4byte sScytherPose81
+.4byte sScytherPose82
+.4byte sScytherPose83
+.4byte sScytherPose84
+.4byte sScytherPose85
+.4byte sScytherPose86
+.4byte sScytherPose87
+.4byte sScytherPose88
+.4byte sScytherPose89
+.4byte sScytherPose90
+.4byte sScytherPose91
+.4byte sScytherPose92
+.4byte sScytherPose93
+.4byte sScytherPose94
+.4byte sScytherPose95
+.4byte sScytherPose96
+.4byte sScytherPose97
+.4byte sScytherPose98
+.4byte sScytherPose99
+.4byte sScytherPose100
+.4byte sScytherPose101
+.4byte sScytherPose102
+.4byte sScytherPose103
+.4byte sScytherPose104
+.4byte sScytherPose105
+.4byte sScytherPose106
+.4byte sScytherPose107
+.4byte sScytherPose108
+.4byte sScytherPose109
+.4byte sScytherPose110
+.4byte sScytherPose111
+.4byte sScytherPose112
+.4byte sScytherPose113
+.4byte sScytherPose114
+.4byte sScytherPose115
+.4byte sScytherPose116
+.4byte sScytherPose117
+.4byte sScytherPose118
+.4byte sScytherPose119
+.4byte sScytherPose120
+.4byte sScytherPose121
+.4byte sScytherPose122
+.4byte sScytherPose123
+.4byte sScytherPose124
+.4byte sScytherPose125
+.4byte sScytherPose126
+.4byte sScytherPose127
+.4byte sScytherPose128
+.4byte sScytherPose129
+.4byte sScytherPose130
+.4byte sScytherPose131
+.4byte sScytherPose132
+.4byte sScytherPose133
+.4byte sScytherPose134
+.4byte sScytherPose135
+.4byte sScytherPose136
+.4byte sScytherPose137
+.4byte sScytherPose138
+.4byte sScytherPose139
+.4byte sScytherPose140
+.4byte sScytherPose141
+.4byte sScytherPose142
+.4byte sScytherPose143
+.4byte sScytherPose144
+.4byte sScytherPose145
+.4byte sScytherPose146
+.4byte sScytherPose147
+.4byte sScytherPose148
+.4byte sScytherPose149
+.4byte sScytherPose150
+.4byte sScytherPose151
+.4byte sScytherPose152
+.4byte sScytherPose153
+.4byte sScytherPose154
+.4byte sScytherPose155
+.4byte sScytherPose156
+.4byte sScytherPose157
+.4byte sScytherPose158
+.4byte sScytherPose159
+.4byte sScytherPose160
+.4byte sScytherPose161
+.4byte sScytherPose162
+.4byte sScytherPose163
+.4byte sScytherPose164
+.4byte sScytherPose165
+.4byte sScytherPose166
+.4byte sScytherPose167
+.4byte sScytherPose168
+.4byte sScytherPose169
+.4byte sScytherPose170
+.4byte sScytherPose171
+.4byte sScytherPose172
+.4byte sScytherPose173
+.4byte sScytherPose174
+.4byte sScytherPose175
+.4byte sScytherPose176
+.4byte sScytherPose177
+.4byte sScytherPose178
+.4byte sScytherPose179
+.4byte sScytherPose180
+.4byte sScytherPose181
+.4byte sScytherPose182
+.4byte sScytherPose183
+.4byte sScytherPose184
+.4byte sScytherPose185
+.4byte sScytherPose186
+.4byte sScytherPose187
+.4byte sScytherPose188
+.4byte sScytherPose189
+.4byte sScytherPose190
+.4byte sScytherPose191
+.4byte sScytherPose192
+.4byte sScytherPose193
+.4byte sScytherPose194
+.4byte sScytherPose195
+.4byte sScytherPose196
+.4byte sScytherPose197
+.4byte sScytherPose198
+.4byte sScytherPose199
+.4byte sScytherPose200
+.4byte sScytherPose201
+.4byte sScytherPose202
+.4byte sScytherPose203
+.4byte sScytherPose204
+.4byte sScytherPose205
+.4byte sScytherPose206
+.4byte sScytherPose207
+.4byte sScytherPose208
+.4byte sScytherPose209
+.4byte sScytherPose210
+sAxPositionsScyther:
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,   -9, 	 -11,   -5, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -9, 	 -12,  -10, 	  10,   -4, 	   0,   -9
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+.2byte    4,   -9, 	  11,   -8, 	   1,   -4, 	   0,  -10
+.2byte    4,   -9, 	  14,  -12, 	  -1,   -1, 	   0,   -9
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte    9,  -12, 	   7,  -11, 	  11,   -6, 	  -1,  -10
+.2byte    9,  -12, 	  12,  -14, 	   9,   -2, 	  -1,  -10
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    5,  -15, 	   2,  -10, 	  14,  -10, 	  -1,  -10
+.2byte    5,  -15, 	   3,  -17, 	  12,   -6, 	  -1,  -10
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    0,  -15, 	  10,   -7, 	 -12,  -11, 	  -1,  -12
+.2byte    0,  -15, 	  11,  -11, 	 -11,   -8, 	  -1,  -12
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte   -5,  -15, 	  -2,  -10, 	 -14,  -10, 	   1,  -10
+.2byte   -5,  -15, 	  -3,  -17, 	 -12,   -6, 	   1,  -10
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte   -9,  -12, 	  -7,  -11, 	 -11,   -6, 	   1,  -10
+.2byte   -9,  -12, 	 -12,  -14, 	  -9,   -2, 	   1,  -10
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte   -4,   -9, 	 -11,   -8, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -9, 	 -14,  -12, 	   1,   -1, 	   0,   -9
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,   -9, 	 -11,   -5, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -9, 	 -12,  -10, 	  10,   -4, 	   0,   -9
+.2byte    0,    1, 	 -12,  -11, 	  11,  -11, 	  -1,   -6
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+.2byte    4,   -9, 	  11,   -8, 	   1,   -4, 	   0,  -10
+.2byte    4,   -9, 	  14,  -12, 	  -1,   -1, 	   0,   -9
+.2byte    7,   -1, 	  12,  -13, 	 -13,   -8, 	   3,   -8
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte    9,  -12, 	   7,  -11, 	  11,   -6, 	  -1,  -10
+.2byte    9,  -12, 	  12,  -14, 	   9,   -2, 	  -1,  -10
+.2byte    9,   -5, 	  -2,  -14, 	 -12,   -4, 	   0,   -8
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    5,  -15, 	   2,  -10, 	  14,  -10, 	  -1,  -10
+.2byte    5,  -15, 	   3,  -17, 	  12,   -6, 	  -1,  -10
+.2byte    7,  -13, 	 -12,  -16, 	  10,   -3, 	  -1,  -12
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    0,  -15, 	  10,   -7, 	 -12,  -11, 	  -1,  -12
+.2byte    0,  -15, 	  11,  -11, 	 -11,   -8, 	  -1,  -12
+.2byte    0,  -15, 	  13,   -9, 	 -14,   -9, 	   0,  -12
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte   -5,  -15, 	  -2,  -10, 	 -14,  -10, 	   1,  -10
+.2byte   -5,  -15, 	  -3,  -17, 	 -12,   -6, 	   1,  -10
+.2byte   -8,  -13, 	  11,  -16, 	 -11,   -3, 	   0,  -12
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte   -9,  -12, 	  -7,  -11, 	 -11,   -6, 	   1,  -10
+.2byte   -9,  -12, 	 -12,  -14, 	  -9,   -2, 	   1,  -10
+.2byte  -10,   -5, 	   1,  -14, 	  11,   -4, 	  -1,   -8
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte   -4,   -9, 	 -11,   -8, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -9, 	 -14,  -12, 	   1,   -1, 	   0,   -9
+.2byte   -7,   -1, 	 -12,  -13, 	  13,   -8, 	  -3,   -8
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -13, 	  -5,  -10, 	   1,  -10, 	  -1,  -13
+.2byte    0,    1, 	 -12,  -11, 	  11,  -11, 	  -1,   -6
+.2byte    0,    1, 	 -12,  -11, 	  11,  -11, 	  -1,   -6
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+.2byte    4,  -12, 	   8,  -10, 	   4,   -7, 	   0,  -12
+.2byte    7,   -1, 	  12,  -13, 	 -13,   -8, 	   3,   -8
+.2byte    7,   -1, 	  12,  -13, 	 -13,   -8, 	   3,   -8
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte    4,  -13, 	   6,  -12, 	   5,  -11, 	  -4,  -10
+.2byte    9,   -5, 	  -2,  -14, 	 -12,   -4, 	   0,   -8
+.2byte    9,   -5, 	  -2,  -14, 	 -12,   -4, 	   0,   -8
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    2,  -15, 	   4,  -16, 	   6,  -14, 	  -3,  -12
+.2byte    7,  -13, 	 -12,  -16, 	  10,   -3, 	  -1,  -12
+.2byte    7,  -13, 	 -12,  -16, 	  10,   -3, 	  -1,  -12
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    0,  -13, 	   5,  -14, 	  -6,  -14, 	   0,   -8
+.2byte    0,  -15, 	  13,   -9, 	 -14,   -9, 	   0,  -12
+.2byte    0,  -15, 	  13,   -9, 	 -14,   -9, 	   0,  -12
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte   -3,  -15, 	  -5,  -16, 	  -7,  -14, 	   2,  -12
+.2byte   -8,  -13, 	  11,  -16, 	 -11,   -3, 	   0,  -12
+.2byte   -8,  -13, 	  11,  -16, 	 -11,   -3, 	   0,  -12
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte   -5,  -13, 	  -7,  -12, 	  -6,  -11, 	   3,  -10
+.2byte  -10,   -5, 	   1,  -14, 	  11,   -4, 	  -1,   -8
+.2byte  -10,   -5, 	   1,  -14, 	  11,   -4, 	  -1,   -8
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte   -4,  -12, 	  -8,  -10, 	  -4,   -7, 	   0,  -12
+.2byte   -8,   -1, 	 -13,  -13, 	  12,   -8, 	  -4,   -8
+.2byte   -7,   -1, 	 -12,  -13, 	  13,   -8, 	  -3,   -8
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -23, 	 -12,  -22, 	  11,  -21, 	   0,  -14
+.2byte    0,    1, 	 -12,  -11, 	  11,  -11, 	  -1,   -6
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+.2byte   -1,  -23, 	  10,  -24, 	 -10,  -20, 	  -2,  -12
+.2byte    7,   -1, 	  12,  -13, 	 -13,   -8, 	   3,   -8
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte   -2,  -19, 	   3,  -23, 	  -1,  -20, 	  -3,   -9
+.2byte    9,   -5, 	  -2,  -14, 	 -12,   -4, 	   0,   -8
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    0,  -19, 	  -9,  -24, 	   8,  -18, 	  -4,   -8
+.2byte    7,  -13, 	 -12,  -16, 	  10,   -3, 	  -1,  -12
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    0,  -16, 	  12,  -18, 	 -13,  -18, 	   0,   -9
+.2byte    0,  -15, 	  12,   -7, 	 -13,   -6, 	   0,  -11
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte   -1,  -19, 	   8,  -24, 	  -9,  -18, 	   3,   -8
+.2byte   -8,  -13, 	  11,  -16, 	 -11,   -3, 	   0,  -12
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte    1,  -19, 	  -4,  -23, 	   0,  -20, 	   2,   -9
+.2byte  -10,   -5, 	   1,  -14, 	  11,   -4, 	  -1,   -8
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte    1,  -23, 	 -10,  -24, 	  10,  -20, 	   2,  -12
+.2byte   -7,   -1, 	 -12,  -13, 	  13,   -8, 	  -3,   -8
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+.2byte   -4,   -6, 	 -10,   -4, 	  -3,    1, 	   1,   -6
+.2byte   -4,   -5, 	 -10,   -2, 	  -3,    2, 	   2,   -5
+.2byte    0,  -15, 	 -14,  -13, 	  15,   -6, 	   1,  -11
+.2byte    0,  -15, 	   8,  -23, 	 -13,   -2, 	  -1,  -11
+.2byte    3,  -18, 	   9,  -26, 	   1,   -3, 	  -3,  -11
+.2byte    3,  -17, 	  -5,  -23, 	   8,   -4, 	  -1,  -11
+.2byte    1,  -20, 	  11,  -20, 	 -10,   -5, 	   0,  -10
+.2byte   -4,  -17, 	   4,  -23, 	  -9,   -4, 	   0,  -11
+.2byte   -4,  -18, 	 -10,  -26, 	  -2,   -3, 	   2,  -11
+.2byte   -1,  -15, 	  -9,  -23, 	  12,   -2, 	   0,  -11
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,   -9, 	 -11,   -5, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -9, 	 -12,  -10, 	  10,   -4, 	   0,   -9
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+.2byte    4,   -9, 	  11,   -8, 	   1,   -4, 	   0,  -10
+.2byte    4,   -9, 	  14,  -12, 	  -1,   -1, 	   0,   -9
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte    9,  -12, 	   7,  -11, 	  11,   -6, 	  -1,  -10
+.2byte    9,  -12, 	  12,  -14, 	   9,   -2, 	  -1,  -10
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    5,  -15, 	   2,  -10, 	  14,  -10, 	  -1,  -10
+.2byte    5,  -15, 	   3,  -17, 	  12,   -6, 	  -1,  -10
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    0,  -15, 	  10,   -7, 	 -12,  -11, 	  -1,  -12
+.2byte    0,  -15, 	  11,  -11, 	 -11,   -8, 	  -1,  -12
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte   -5,  -15, 	  -2,  -10, 	 -14,  -10, 	   1,  -10
+.2byte   -5,  -15, 	  -3,  -17, 	 -12,   -6, 	   1,  -10
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte   -9,  -12, 	  -7,  -11, 	 -11,   -6, 	   1,  -10
+.2byte   -9,  -12, 	 -12,  -14, 	  -9,   -2, 	   1,  -10
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte   -4,   -9, 	 -11,   -8, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -9, 	 -14,  -12, 	   1,   -1, 	   0,   -9
+.2byte    0,    1, 	 -12,  -11, 	  11,  -11, 	  -1,   -6
+.2byte   -7,   -1, 	 -12,  -13, 	  13,   -8, 	  -3,   -8
+.2byte  -10,   -6, 	   1,  -15, 	  11,   -5, 	  -1,   -9
+.2byte   -8,  -11, 	  11,  -14, 	 -11,   -1, 	   0,  -10
+.2byte    0,  -14, 	  12,   -6, 	 -13,   -5, 	   0,  -10
+.2byte    7,  -11, 	 -12,  -14, 	  10,   -1, 	  -1,  -10
+.2byte    9,   -6, 	  -2,  -15, 	 -12,   -5, 	   0,   -9
+.2byte    7,   -1, 	  12,  -13, 	 -13,   -8, 	   3,   -8
+.2byte    0,  -23, 	 -12,  -22, 	  11,  -21, 	   0,  -14
+.2byte    0,  -23, 	  11,  -24, 	  -9,  -20, 	  -1,  -12
+.2byte    0,  -20, 	   5,  -24, 	   1,  -21, 	  -1,  -10
+.2byte    2,  -21, 	  -7,  -26, 	  10,  -20, 	  -2,  -10
+.2byte    0,  -19, 	  12,  -21, 	 -13,  -21, 	   0,  -12
+.2byte   -3,  -21, 	   6,  -26, 	 -11,  -20, 	   1,  -10
+.2byte   -1,  -20, 	  -6,  -24, 	  -2,  -21, 	   0,  -10
+.2byte    0,  -23, 	 -11,  -24, 	   9,  -20, 	   1,  -12
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -23, 	 -12,  -22, 	  11,  -21, 	   0,  -14
+.2byte    0,    1, 	 -12,  -11, 	  11,  -11, 	  -1,   -6
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+.2byte    0,  -23, 	  11,  -24, 	  -9,  -20, 	  -1,  -12
+.2byte    5,   -1, 	  10,  -13, 	 -15,   -8, 	   1,   -8
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte    0,  -19, 	   5,  -23, 	   1,  -20, 	  -1,   -9
+.2byte    9,   -5, 	  -2,  -14, 	 -12,   -4, 	   0,   -8
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    2,  -19, 	  -7,  -24, 	  10,  -18, 	  -2,   -8
+.2byte    7,  -13, 	 -12,  -16, 	  10,   -3, 	  -1,  -12
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    0,  -16, 	  12,  -18, 	 -13,  -18, 	   0,   -9
+.2byte    0,  -15, 	  12,   -7, 	 -13,   -6, 	   0,  -11
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte   -3,  -19, 	   6,  -24, 	 -11,  -18, 	   1,   -8
+.2byte   -8,  -13, 	  11,  -16, 	 -11,   -3, 	   0,  -12
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte   -1,  -19, 	  -6,  -23, 	  -2,  -20, 	   0,   -9
+.2byte  -10,   -5, 	   1,  -14, 	  11,   -4, 	  -1,   -8
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte    0,  -23, 	 -11,  -24, 	   9,  -20, 	   1,  -12
+.2byte   -5,   -1, 	 -10,  -13, 	  15,   -8, 	  -1,   -8
+.2byte    0,  -11, 	  -5,   -8, 	   1,   -8, 	  -1,  -11
+.2byte   -4,  -11, 	  -8,   -9, 	  -4,   -6, 	   0,  -11
+.2byte   -6,  -13, 	  -8,  -12, 	  -7,  -11, 	   2,  -10
+.2byte   -5,  -15, 	  -7,  -16, 	  -9,  -14, 	   0,  -12
+.2byte    1,  -15, 	   6,  -16, 	  -5,  -16, 	   1,  -10
+.2byte    5,  -15, 	   7,  -16, 	   9,  -14, 	   0,  -12
+.2byte    5,  -12, 	   7,  -11, 	   6,  -10, 	  -3,   -9
+.2byte    2,  -11, 	   6,   -9, 	   2,   -6, 	  -2,  -11
+.2byte   -1,  -10, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte   -4,  -10, 	 -13,  -10, 	   0,   -3, 	   2,  -11
+.2byte   -9,  -13, 	  -3,  -19, 	 -10,   -6, 	   1,  -11
+.2byte   -5,  -16, 	   1,  -16, 	 -13,   -9, 	   2,  -12
+.2byte    0,  -16, 	  10,   -9, 	 -12,   -9, 	  -1,  -13
+.2byte    5,  -16, 	  -1,  -16, 	  13,   -9, 	  -2,  -12
+.2byte    9,  -13, 	   3,  -19, 	  10,   -6, 	  -1,  -11
+.2byte    4,  -10, 	  13,  -10, 	   0,   -3, 	  -2,  -11
+sScytherAnimTable1:
+.4byte sScytherAnims_1_1
+.4byte sScytherAnims_1_2
+.4byte sScytherAnims_1_3
+.4byte sScytherAnims_1_4
+.4byte sScytherAnims_1_5
+.4byte sScytherAnims_1_6
+.4byte sScytherAnims_1_7
+.4byte sScytherAnims_1_8
+sScytherAnimTable2:
+.4byte sScytherAnims_2_1
+.4byte sScytherAnims_2_2
+.4byte sScytherAnims_2_3
+.4byte sScytherAnims_2_4
+.4byte sScytherAnims_2_5
+.4byte sScytherAnims_2_6
+.4byte sScytherAnims_2_7
+.4byte sScytherAnims_2_8
+sScytherAnimTable3:
+.4byte sScytherAnims_3_1
+.4byte sScytherAnims_3_2
+.4byte sScytherAnims_3_3
+.4byte sScytherAnims_3_4
+.4byte sScytherAnims_3_5
+.4byte sScytherAnims_3_6
+.4byte sScytherAnims_3_7
+.4byte sScytherAnims_3_8
+sScytherAnimTable4:
+.4byte sScytherAnims_4_1
+.4byte sScytherAnims_4_2
+.4byte sScytherAnims_4_3
+.4byte sScytherAnims_4_4
+.4byte sScytherAnims_4_5
+.4byte sScytherAnims_4_6
+.4byte sScytherAnims_4_7
+.4byte sScytherAnims_4_8
+sScytherAnimTable5:
+.4byte sScytherAnims_5_1
+.4byte sScytherAnims_5_2
+.4byte sScytherAnims_5_3
+.4byte sScytherAnims_5_4
+.4byte sScytherAnims_5_5
+.4byte sScytherAnims_5_6
+.4byte sScytherAnims_5_7
+.4byte sScytherAnims_5_8
+sScytherAnimTable6:
+.4byte sScytherAnims_6_1
+.4byte sScytherAnims_6_1
+.4byte sScytherAnims_6_1
+.4byte sScytherAnims_6_1
+.4byte sScytherAnims_6_1
+.4byte sScytherAnims_6_1
+.4byte sScytherAnims_6_1
+.4byte sScytherAnims_6_1
+sScytherAnimTable7:
+.4byte sScytherAnims_7_1
+.4byte sScytherAnims_7_2
+.4byte sScytherAnims_7_3
+.4byte sScytherAnims_7_4
+.4byte sScytherAnims_7_5
+.4byte sScytherAnims_7_6
+.4byte sScytherAnims_7_7
+.4byte sScytherAnims_7_8
+sScytherAnimTable8:
+.4byte sScytherAnims_8_1
+.4byte sScytherAnims_8_2
+.4byte sScytherAnims_8_3
+.4byte sScytherAnims_8_4
+.4byte sScytherAnims_8_5
+.4byte sScytherAnims_8_6
+.4byte sScytherAnims_8_7
+.4byte sScytherAnims_8_8
+sScytherAnimTable9:
+.4byte sScytherAnims_9_1
+.4byte sScytherAnims_9_2
+.4byte sScytherAnims_9_3
+.4byte sScytherAnims_9_4
+.4byte sScytherAnims_9_5
+.4byte sScytherAnims_9_6
+.4byte sScytherAnims_9_7
+.4byte sScytherAnims_9_8
+sScytherAnimTable10:
+.4byte sScytherAnims_10_1
+.4byte sScytherAnims_10_2
+.4byte sScytherAnims_10_3
+.4byte sScytherAnims_10_4
+.4byte sScytherAnims_10_5
+.4byte sScytherAnims_10_6
+.4byte sScytherAnims_10_7
+.4byte sScytherAnims_10_8
+sScytherAnimTable11:
+.4byte sScytherAnims_11_1
+.4byte sScytherAnims_11_2
+.4byte sScytherAnims_11_3
+.4byte sScytherAnims_11_4
+.4byte sScytherAnims_11_5
+.4byte sScytherAnims_11_6
+.4byte sScytherAnims_11_7
+.4byte sScytherAnims_11_8
+sScytherAnimTable12:
+.4byte sScytherAnims_12_1
+.4byte sScytherAnims_12_2
+.4byte sScytherAnims_12_3
+.4byte sScytherAnims_12_4
+.4byte sScytherAnims_12_5
+.4byte sScytherAnims_12_6
+.4byte sScytherAnims_12_7
+.4byte sScytherAnims_12_8
+sScytherAnimTable13:
+.4byte sScytherAnims_13_1
+.4byte sScytherAnims_13_2
+.4byte sScytherAnims_13_3
+.4byte sScytherAnims_13_4
+.4byte sScytherAnims_13_5
+.4byte sScytherAnims_13_6
+.4byte sScytherAnims_13_7
+.4byte sScytherAnims_13_8
+sAxAnimationsScyther:
+.4byte sScytherAnimTable1
+.4byte sScytherAnimTable2
+.4byte sScytherAnimTable3
+.4byte sScytherAnimTable4
+.4byte sScytherAnimTable5
+.4byte sScytherAnimTable6
+.4byte sScytherAnimTable7
+.4byte sScytherAnimTable8
+.4byte sScytherAnimTable9
+.4byte sScytherAnimTable10
+.4byte sScytherAnimTable11
+.4byte sScytherAnimTable12
+.4byte sScytherAnimTable13
+sAxSpritesScyther:
+.4byte sScytherSprites1
+.4byte sScytherSprites2
+.4byte sScytherSprites3
+.4byte sScytherSprites4
+.4byte sScytherSprites5
+.4byte sScytherSprites6
+.4byte sScytherSprites7
+.4byte sScytherSprites8
+.4byte sScytherSprites9
+.4byte sScytherSprites10
+.4byte sScytherSprites11
+.4byte sScytherSprites12
+.4byte sScytherSprites13
+.4byte sScytherSprites14
+.4byte sScytherSprites15
+.4byte sScytherSprites16
+.4byte sScytherSprites17
+.4byte sScytherSprites18
+.4byte sScytherSprites19
+.4byte sScytherSprites20
+.4byte sScytherSprites21
+.4byte sScytherSprites22
+.4byte sScytherSprites23
+.4byte sScytherSprites24
+.4byte sScytherSprites25
+.4byte sScytherSprites26
+.4byte sScytherSprites27
+.4byte sScytherSprites28
+.4byte sScytherSprites29
+.4byte sScytherSprites30
+.4byte sScytherSprites31
+.4byte sScytherSprites32
+.4byte sScytherSprites33
+.4byte sScytherSprites34
+.4byte sScytherSprites35
+.4byte sScytherSprites36
+.4byte sScytherSprites37
+.4byte sScytherSprites38
+.4byte sScytherSprites39
+.4byte sScytherSprites40
+.4byte sScytherSprites41
+.4byte sScytherSprites42
+.4byte sScytherSprites43
+.4byte sScytherSprites44
+.4byte sScytherSprites45
+.4byte sScytherSprites46
+.4byte sScytherSprites47
+.4byte sScytherSprites48
+.4byte sScytherSprites49
+sAxMainScyther:
+ax_main sAxPosesScyther, sAxAnimationsScyther, 13, sAxSpritesScyther, sAxPositionsScyther

--- a/data/ax/seadra.inc
+++ b/data/ax/seadra.inc
@@ -1,0 +1,2725 @@
+.global gAxSeadra
+gAxSeadra:
+ax_siro sAxMainSeadra
+sSeadraPose1:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose3:
+ax_pose 2, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose4:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose5:
+ax_pose 4, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sSeadraPose6:
+ax_pose 5, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose7:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose8:
+ax_pose 7, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose9:
+ax_pose 8, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeadraPose10:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose11:
+ax_pose 10, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeadraPose12:
+ax_pose 11, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose14:
+ax_pose 13, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose15:
+ax_pose 14, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose16:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose17:
+ax_pose 10, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose18:
+ax_pose 11, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose19:
+ax_pose 6, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose20:
+ax_pose 7, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose21:
+ax_pose 8, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose22:
+ax_pose 3, 0x01e2, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose23:
+ax_pose 4, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose24:
+ax_pose 5, 0x01e2, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose25:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose26:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose27:
+ax_pose 2, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose28:
+ax_pose 15, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose29:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose30:
+ax_pose 4, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sSeadraPose31:
+ax_pose 5, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose32:
+ax_pose 16, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose33:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose34:
+ax_pose 7, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose35:
+ax_pose 8, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeadraPose36:
+ax_pose 17, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeadraPose37:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose38:
+ax_pose 10, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeadraPose39:
+ax_pose 11, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose40:
+ax_pose 18, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose41:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose42:
+ax_pose 13, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose43:
+ax_pose 14, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose44:
+ax_pose 19, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose45:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose46:
+ax_pose 10, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose47:
+ax_pose 11, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose48:
+ax_pose 18, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose49:
+ax_pose 6, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose50:
+ax_pose 7, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose51:
+ax_pose 8, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose52:
+ax_pose 17, 0x01e2, 0x80ef, 0x0c00
+ax_pose_terminator
+sSeadraPose53:
+ax_pose 3, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose54:
+ax_pose 4, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose55:
+ax_pose 5, 0x01e2, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose56:
+ax_pose 16, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose57:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose58:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose59:
+ax_pose 2, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose60:
+ax_pose 15, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose61:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose62:
+ax_pose 4, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sSeadraPose63:
+ax_pose 5, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose64:
+ax_pose 16, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose65:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose66:
+ax_pose 7, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose67:
+ax_pose 8, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeadraPose68:
+ax_pose 17, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeadraPose69:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose70:
+ax_pose 10, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeadraPose71:
+ax_pose 11, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose72:
+ax_pose 18, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose73:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose74:
+ax_pose 13, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose75:
+ax_pose 14, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose76:
+ax_pose 19, 0x01e7, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose77:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose78:
+ax_pose 10, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose79:
+ax_pose 11, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose80:
+ax_pose 18, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose81:
+ax_pose 6, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose82:
+ax_pose 7, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose83:
+ax_pose 8, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose84:
+ax_pose 17, 0x01e2, 0x80ef, 0x0c00
+ax_pose_terminator
+sSeadraPose85:
+ax_pose 3, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose86:
+ax_pose 4, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose87:
+ax_pose 5, 0x01e2, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose88:
+ax_pose 16, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose89:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose90:
+ax_pose 20, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose91:
+ax_pose 21, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose92:
+ax_pose 22, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose93:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose94:
+ax_pose 23, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sSeadraPose95:
+ax_pose 24, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose96:
+ax_pose 25, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose97:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose98:
+ax_pose 26, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose99:
+ax_pose 27, 0x01e2, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeadraPose100:
+ax_pose 28, 0x01e2, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeadraPose101:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose102:
+ax_pose 29, 0x01e3, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose103:
+ax_pose 30, 0x01e3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose104:
+ax_pose 31, 0x01e3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose105:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose106:
+ax_pose 32, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose107:
+ax_pose 33, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose108:
+ax_pose 34, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose109:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose110:
+ax_pose 29, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose111:
+ax_pose 30, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose112:
+ax_pose 31, 0x01e3, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose113:
+ax_pose 6, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose114:
+ax_pose 26, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose115:
+ax_pose 27, 0x01e2, 0x80ee, 0x0c00
+ax_pose_terminator
+sSeadraPose116:
+ax_pose 28, 0x01e2, 0x80ee, 0x0c00
+ax_pose_terminator
+sSeadraPose117:
+ax_pose 3, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose118:
+ax_pose 23, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose119:
+ax_pose 24, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose120:
+ax_pose 25, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose121:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose122:
+ax_pose 3, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose123:
+ax_pose 6, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose124:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose125:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose126:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose127:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose128:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose129:
+ax_pose 35, 0x01e1, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose130:
+ax_pose 36, 0x01e1, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose131:
+ax_pose 37, 0x01dd, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose132:
+ax_pose 38, 0x01dd, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose133:
+ax_pose 39, 0x01df, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose134:
+ax_pose 40, 0x01df, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose135:
+ax_pose 41, 0x01de, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose136:
+ax_pose 40, 0x01df, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose137:
+ax_pose 39, 0x01df, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose138:
+ax_pose 38, 0x01dd, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose139:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose140:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose141:
+ax_pose 2, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose142:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose143:
+ax_pose 4, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sSeadraPose144:
+ax_pose 5, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose145:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose146:
+ax_pose 7, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose147:
+ax_pose 8, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeadraPose148:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose149:
+ax_pose 10, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose150:
+ax_pose 11, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose151:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose152:
+ax_pose 13, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose153:
+ax_pose 14, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose154:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose155:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose156:
+ax_pose 11, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose157:
+ax_pose 6, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose158:
+ax_pose 7, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose159:
+ax_pose 8, 0x01e2, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeadraPose160:
+ax_pose 3, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose161:
+ax_pose 4, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose162:
+ax_pose 5, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose163:
+ax_pose 15, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose164:
+ax_pose 16, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose165:
+ax_pose 17, 0x01e2, 0x80ef, 0x0c00
+ax_pose_terminator
+sSeadraPose166:
+ax_pose 18, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose167:
+ax_pose 19, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose168:
+ax_pose 18, 0x01e4, 0x90eb, 0x0c00
+ax_pose_terminator
+sSeadraPose169:
+ax_pose 17, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeadraPose170:
+ax_pose 16, 0x01e2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose171:
+ax_pose 20, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose172:
+ax_pose 23, 0x01e1, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeadraPose173:
+ax_pose 26, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose174:
+ax_pose 29, 0x01e1, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose175:
+ax_pose 32, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose176:
+ax_pose 29, 0x01e1, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose177:
+ax_pose 26, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose178:
+ax_pose 23, 0x01e1, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose179:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose180:
+ax_pose 2, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose181:
+ax_pose 1, 0x01e5, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose182:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose183:
+ax_pose 5, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose184:
+ax_pose 4, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sSeadraPose185:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose186:
+ax_pose 8, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeadraPose187:
+ax_pose 7, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose188:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose189:
+ax_pose 11, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose190:
+ax_pose 10, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeadraPose191:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose192:
+ax_pose 14, 0x01e8, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose193:
+ax_pose 13, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose194:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose195:
+ax_pose 11, 0x01e5, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose196:
+ax_pose 10, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose197:
+ax_pose 6, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose198:
+ax_pose 8, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose199:
+ax_pose 7, 0x01e2, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeadraPose200:
+ax_pose 3, 0x01e2, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose201:
+ax_pose 5, 0x01e2, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose202:
+ax_pose 4, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose203:
+ax_pose 2, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose204:
+ax_pose 5, 0x01e0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSeadraPose205:
+ax_pose 8, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeadraPose206:
+ax_pose 11, 0x01e4, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose207:
+ax_pose 14, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose208:
+ax_pose 11, 0x01e4, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose209:
+ax_pose 8, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeadraPose210:
+ax_pose 5, 0x01e0, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose211:
+ax_pose 0, 0x01e2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeadraPose212:
+ax_pose 3, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose213:
+ax_pose 6, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose214:
+ax_pose 9, 0x01e6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeadraPose215:
+ax_pose 12, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeadraPose216:
+ax_pose 9, 0x01e6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSeadraPose217:
+ax_pose 6, 0x01e2, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeadraPose218:
+ax_pose 3, 0x01e2, 0x90ea, 0x0c00
+ax_pose_terminator
+.align 2
+sSeadraAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, -1, 0, -1,
+ax_anim_terminator
+sSeadraAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 10, 0, 4, 2, 2, 2, 2,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, -1, -1, -1, -1,
+ax_anim_terminator
+sSeadraAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 2, 0, 2, 0,
+ax_anim 10, 0, 7, 3, 0, 3, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sSeadraAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 1, -1, 1, -1,
+ax_anim 10, 0, 10, 2, -2, 2, -2,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, -1, 1, -1, 1,
+ax_anim_terminator
+sSeadraAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, -1,
+ax_anim 10, 0, 13, 0, -2, 0, -2,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 1, 0, 1,
+ax_anim_terminator
+sSeadraAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, -2, -2, -2, -2,
+ax_anim 10, 0, 16, -3, -3, -3, -3,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 1, 1, 1, 1,
+ax_anim_terminator
+sSeadraAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, -2, 0, -2, 0,
+ax_anim 10, 0, 19, -3, 0, -3, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 1, 0, 1, 0,
+ax_anim_terminator
+sSeadraAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, -1, 1,
+ax_anim 10, 0, 22, -2, 2, -2, 2,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sSeadraAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 13, 0, 10,
+ax_anim 2, 0, 27, 0, 24, 0, 22,
+ax_anim 2, 1, 27, 1, 24, 1, 22,
+ax_anim 2, 0, 27, 0, 24, 0, 22,
+ax_anim 2, 0, 27, 1, 24, 1, 22,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSeadraAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 4, 0, 30, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 5, 4, 5,
+ax_anim 1, 0, 29, 12, 15, 12, 14,
+ax_anim 2, 0, 31, 20, 25, 20, 23,
+ax_anim 2, 1, 31, 21, 24, 21, 22,
+ax_anim 2, 0, 31, 20, 25, 20, 23,
+ax_anim 2, 0, 31, 21, 24, 21, 22,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sSeadraAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 13, 1, 13, 0,
+ax_anim 2, 0, 35, 18, 2, 18, 0,
+ax_anim 2, 1, 35, 18, 3, 18, 1,
+ax_anim 2, 0, 35, 18, 2, 18, 0,
+ax_anim 2, 0, 35, 18, 3, 18, 1,
+ax_anim 2, 0, 32, 6, 1, 6, 0,
+ax_anim_terminator
+sSeadraAnims_2_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 4, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 6, -5, 6, -6,
+ax_anim 1, 0, 37, 11, -9, 11, -12,
+ax_anim 2, 0, 39, 18, -13, 18, -19,
+ax_anim 2, 1, 39, 19, -12, 19, -18,
+ax_anim 2, 0, 39, 18, -13, 18, -19,
+ax_anim 2, 0, 39, 19, -12, 19, -18,
+ax_anim 2, 0, 36, 7, -5, 7, -6,
+ax_anim_terminator
+sSeadraAnims_2_5:
+ax_anim 2, 0, 42, 0, 1, 0, 1,
+ax_anim 4, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -5,
+ax_anim 1, 0, 41, 0, -11, 0, -13,
+ax_anim 2, 0, 43, 0, -16, 0, -19,
+ax_anim 2, 1, 43, 1, -16, 1, -19,
+ax_anim 2, 0, 43, 0, -16, 0, -19,
+ax_anim 2, 0, 43, 1, -16, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -7,
+ax_anim_terminator
+sSeadraAnims_2_6:
+ax_anim 2, 0, 46, 1, 1, 1, 1,
+ax_anim 4, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -5, -6, -6,
+ax_anim 1, 0, 45, -11, -9, -11, -12,
+ax_anim 2, 0, 47, -18, -13, -18, -19,
+ax_anim 2, 1, 47, -19, -12, -19, -18,
+ax_anim 2, 0, 47, -18, -13, -18, -19,
+ax_anim 2, 0, 47, -19, -12, -19, -18,
+ax_anim 2, 0, 44, -7, -5, -7, -6,
+ax_anim_terminator
+sSeadraAnims_2_7:
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 4, 0, 50, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 49, -13, 1, -13, 0,
+ax_anim 2, 0, 51, -18, 2, -18, 0,
+ax_anim 2, 1, 51, -18, 3, -18, 1,
+ax_anim 2, 0, 51, -18, 2, -18, 0,
+ax_anim 2, 0, 51, -18, 3, -18, 1,
+ax_anim 2, 0, 48, -6, 1, -6, 0,
+ax_anim_terminator
+sSeadraAnims_2_8:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 4, 0, 54, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 5, -4, 5,
+ax_anim 1, 0, 53, -12, 15, -12, 14,
+ax_anim 2, 0, 55, -20, 25, -20, 23,
+ax_anim 2, 1, 55, -21, 24, -21, 22,
+ax_anim 2, 0, 55, -20, 25, -20, 23,
+ax_anim 2, 0, 55, -21, 24, -21, 22,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeadraAnims_3_1:
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 4, 0, 58, 0, -2, 0, -2,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 13, 0, 10,
+ax_anim 2, 0, 59, 0, 24, 0, 22,
+ax_anim 2, 1, 59, 1, 24, 1, 22,
+ax_anim 2, 0, 59, 0, 24, 0, 22,
+ax_anim 2, 0, 59, 1, 24, 1, 22,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sSeadraAnims_3_2:
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 4, 0, 62, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 5, 4, 5,
+ax_anim 1, 0, 61, 12, 15, 12, 14,
+ax_anim 2, 0, 63, 20, 25, 20, 23,
+ax_anim 2, 1, 63, 21, 24, 21, 22,
+ax_anim 2, 0, 63, 20, 25, 20, 23,
+ax_anim 2, 0, 63, 21, 24, 21, 22,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sSeadraAnims_3_3:
+ax_anim 2, 0, 66, -1, 0, -1, 0,
+ax_anim 4, 0, 66, -2, 0, -2, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 65, 13, 1, 13, 0,
+ax_anim 2, 0, 67, 18, 2, 18, 0,
+ax_anim 2, 1, 67, 18, 3, 18, 1,
+ax_anim 2, 0, 67, 18, 2, 18, 0,
+ax_anim 2, 0, 67, 18, 3, 18, 1,
+ax_anim 2, 0, 64, 6, 1, 6, 0,
+ax_anim_terminator
+sSeadraAnims_3_4:
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim 4, 0, 70, -2, 2, -2, 2,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 6, -5, 6, -6,
+ax_anim 1, 0, 69, 11, -9, 11, -12,
+ax_anim 2, 0, 71, 18, -13, 18, -19,
+ax_anim 2, 1, 71, 19, -12, 19, -18,
+ax_anim 2, 0, 71, 18, -13, 18, -19,
+ax_anim 2, 0, 71, 19, -12, 19, -18,
+ax_anim 2, 0, 68, 7, -5, 7, -6,
+ax_anim_terminator
+sSeadraAnims_3_5:
+ax_anim 2, 0, 74, 0, 1, 0, 1,
+ax_anim 4, 0, 74, 0, 2, 0, 2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -5,
+ax_anim 1, 0, 73, 0, -11, 0, -13,
+ax_anim 2, 0, 75, 0, -16, 0, -19,
+ax_anim 2, 1, 75, 1, -16, 1, -19,
+ax_anim 2, 0, 75, 0, -16, 0, -19,
+ax_anim 2, 0, 75, 1, -16, 1, -19,
+ax_anim 2, 0, 72, 0, -6, 0, -7,
+ax_anim_terminator
+sSeadraAnims_3_6:
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim 4, 0, 78, 2, 2, 2, 2,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -6, -5, -6, -6,
+ax_anim 1, 0, 77, -11, -9, -11, -12,
+ax_anim 2, 0, 79, -18, -13, -18, -19,
+ax_anim 2, 1, 79, -19, -12, -19, -18,
+ax_anim 2, 0, 79, -18, -13, -18, -19,
+ax_anim 2, 0, 79, -19, -12, -19, -18,
+ax_anim 2, 0, 76, -7, -5, -7, -6,
+ax_anim_terminator
+sSeadraAnims_3_7:
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 4, 0, 82, 2, 0, 2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 81, -13, 1, -13, 0,
+ax_anim 2, 0, 83, -18, 2, -18, 0,
+ax_anim 2, 1, 83, -18, 3, -18, 1,
+ax_anim 2, 0, 83, -18, 2, -18, 0,
+ax_anim 2, 0, 83, -18, 3, -18, 1,
+ax_anim 2, 0, 80, -6, 1, -6, 0,
+ax_anim_terminator
+sSeadraAnims_3_8:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 4, 0, 86, 2, -2, 2, -2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 5, -4, 5,
+ax_anim 1, 0, 85, -12, 15, -12, 14,
+ax_anim 2, 0, 87, -20, 25, -20, 23,
+ax_anim 2, 1, 87, -21, 24, -21, 22,
+ax_anim 2, 0, 87, -20, 25, -20, 23,
+ax_anim 2, 0, 87, -21, 24, -21, 22,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeadraAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, 1, 0, 1,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 1, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sSeadraAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 2, 93, -3, -3, -3, -3,
+ax_anim 1, 0, 94, 1, 1, 1, 1,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 1, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 0, 95, 5, 5, 5, 5,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sSeadraAnims_4_3:
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim 6, 2, 97, -3, 0, -3, 0,
+ax_anim 1, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 1, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 0, 99, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sSeadraAnims_4_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 6, 2, 101, -3, 3, -3, 3,
+ax_anim 1, 0, 102, 1, -1, 1, -1,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 1, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sSeadraAnims_4_5:
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim 6, 2, 105, 0, 3, 0, 3,
+ax_anim 1, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 1, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 0, 107, 0, -5, 0, -5,
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sSeadraAnims_4_6:
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 6, 2, 109, 3, 3, 3, 3,
+ax_anim 1, 0, 110, -1, -1, -1, -1,
+ax_anim 2, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 1, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 0, 111, -5, -5, -5, -5,
+ax_anim 2, 0, 110, -4, -4, -4, -4,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sSeadraAnims_4_7:
+ax_anim 2, 0, 113, 2, 0, 2, 0,
+ax_anim 6, 2, 113, 3, 0, 3, 0,
+ax_anim 1, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 1, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 0, 115, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sSeadraAnims_4_8:
+ax_anim 2, 0, 117, 2, -2, 2, -2,
+ax_anim 6, 2, 117, 3, -3, 3, -3,
+ax_anim 1, 0, 118, -1, 1, -1, 1,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 1, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 118, -4, 4, -4, 4,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSeadraAnims_5_1:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_5_2:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_5_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_5_4:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_5_6:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_5_7:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_5_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeadraAnims_6_1:
+ax_anim 16, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, -1, 0, 0,
+ax_anim 16, 0, 128, 0, -2, 0, 0,
+ax_anim 16, 0, 129, 0, -2, 0, 0,
+ax_anim 12, 0, 129, 0, -1, 0, 0,
+ax_anim 16, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeadraAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sSeadraAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sSeadraAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sSeadraAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sSeadraAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sSeadraAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sSeadraAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sSeadraAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSeadraAnims_8_1:
+ax_anim 12, 0, 140, 0, 0, 0, 0,
+ax_anim 12, 0, 140, 0, -1, 0, 0,
+ax_anim 12, 0, 140, 0, -2, 0, 0,
+ax_anim 12, 0, 140, 0, -3, 0, 0,
+ax_anim 8, 0, 139, 0, -3, 0, 0,
+ax_anim 8, 0, 139, 0, -2, 0, 0,
+ax_anim 8, 0, 139, 0, -1, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_8_2:
+ax_anim 12, 0, 143, 0, 0, 0, 0,
+ax_anim 12, 0, 143, 0, -1, 0, 0,
+ax_anim 12, 0, 143, 0, -2, 0, 0,
+ax_anim 12, 0, 143, 0, -3, 0, 0,
+ax_anim 8, 0, 142, 0, -3, 0, 0,
+ax_anim 8, 0, 142, 0, -2, 0, 0,
+ax_anim 8, 0, 142, 0, -1, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_8_3:
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, -2, 0, 0,
+ax_anim 12, 0, 146, 0, -3, 0, 0,
+ax_anim 8, 0, 145, 0, -3, 0, 0,
+ax_anim 8, 0, 145, 0, -2, 0, 0,
+ax_anim 8, 0, 145, 0, -1, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_8_4:
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, -2, 0, 0,
+ax_anim 12, 0, 149, 0, -3, 0, 0,
+ax_anim 8, 0, 148, 0, -3, 0, 0,
+ax_anim 8, 0, 148, 0, -2, 0, 0,
+ax_anim 8, 0, 148, 0, -1, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_8_5:
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, -2, 0, 0,
+ax_anim 12, 0, 152, 0, -3, 0, 0,
+ax_anim 8, 0, 151, 0, -3, 0, 0,
+ax_anim 8, 0, 151, 0, -2, 0, 0,
+ax_anim 8, 0, 151, 0, -1, 0, 0,
+ax_anim 8, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_8_6:
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, -2, 0, 0,
+ax_anim 12, 0, 155, 0, -3, 0, 0,
+ax_anim 8, 0, 154, 0, -3, 0, 0,
+ax_anim 8, 0, 154, 0, -2, 0, 0,
+ax_anim 8, 0, 154, 0, -1, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_8_7:
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, -2, 0, 0,
+ax_anim 12, 0, 158, 0, -3, 0, 0,
+ax_anim 8, 0, 157, 0, -3, 0, 0,
+ax_anim 8, 0, 157, 0, -2, 0, 0,
+ax_anim 8, 0, 157, 0, -1, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_8_8:
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, -2, 0, 0,
+ax_anim 12, 0, 161, 0, -3, 0, 0,
+ax_anim 8, 0, 160, 0, -3, 0, 0,
+ax_anim 8, 0, 160, 0, -2, 0, 0,
+ax_anim 8, 0, 160, 0, -1, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeadraAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 18, 7, 16,
+ax_anim 3, 0, 166, 0, 23, 0, 23,
+ax_anim 2, 3, 167, -7, 18, -7, 16,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, 1, 9, 1,
+ax_anim 2, 0, 163, 18, 8, 18, 8,
+ax_anim 2, 0, 164, 19, 16, 19, 16,
+ax_anim 3, 0, 165, 19, 24, 19, 22,
+ax_anim 2, 3, 166, 11, 23, 11, 23,
+ax_anim 2, 0, 167, 3, 19, 3, 19,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 20, 1, 20, 0,
+ax_anim 2, 3, 165, 16, 4, 16, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -18, 12, -18,
+ax_anim 3, 0, 163, 21, -15, 21, -17,
+ax_anim 2, 3, 164, 20, -11, 20, -11,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -10, -9, -10,
+ax_anim 2, 0, 169, -7, -15, -7, -17,
+ax_anim 3, 0, 162, 0, -17, 0, -20,
+ax_anim 2, 3, 163, 7, -15, 7, -17,
+ax_anim 2, 0, 164, 9, -8, 9, -8,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -18, -12, -18,
+ax_anim 3, 0, 169, -21, -15, -21, -17,
+ax_anim 2, 3, 168, -20, -11, -20, -11,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -20, 1, -20, 0,
+ax_anim 2, 3, 167, -16, 4, -16, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, 1, -9, 1,
+ax_anim 2, 0, 169, -18, 8, -18, 8,
+ax_anim 2, 0, 168, -19, 16, -19, 16,
+ax_anim 3, 0, 167, -19, 24, -19, 22,
+ax_anim 2, 3, 166, -11, 23, -11, 23,
+ax_anim 2, 0, 165, -3, 19, -3, 19,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeadraAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeadraAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 3, 0, 0,
+ax_anim_terminator
+sSeadraAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 3, 0, 0,
+ax_anim_terminator
+sSeadraAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 3, 0, 0,
+ax_anim_terminator
+sSeadraAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 4, 0, 0,
+ax_anim_terminator
+sSeadraAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 4, 0, 0,
+ax_anim_terminator
+sSeadraAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 4, 0, 0,
+ax_anim_terminator
+sSeadraAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 3, 0, 0,
+ax_anim_terminator
+sSeadraAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sSeadraAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeadraAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSeadraGfx1:
+.incbin "baserom.gba", 0xA0934C, 0x200
+sSeadraSprites1:
+ax_sprite sSeadraGfx1, 0x200
+ax_sprite_terminator
+sSeadraGfx2:
+.incbin "baserom.gba", 0xA0955C, 0x200
+sSeadraSprites2:
+ax_sprite sSeadraGfx2, 0x200
+ax_sprite_terminator
+sSeadraGfx3:
+.incbin "baserom.gba", 0xA0976C, 0x200
+sSeadraSprites3:
+ax_sprite sSeadraGfx3, 0x200
+ax_sprite_terminator
+sSeadraGfx4:
+.incbin "baserom.gba", 0xA0997C, 0x200
+sSeadraSprites4:
+ax_sprite sSeadraGfx4, 0x200
+ax_sprite_terminator
+sSeadraGfx5:
+.incbin "baserom.gba", 0xA09B8C, 0x200
+sSeadraSprites5:
+ax_sprite sSeadraGfx5, 0x200
+ax_sprite_terminator
+sSeadraGfx6:
+.incbin "baserom.gba", 0xA09D9C, 0x200
+sSeadraSprites6:
+ax_sprite sSeadraGfx6, 0x200
+ax_sprite_terminator
+sSeadraGfx7:
+.incbin "baserom.gba", 0xA09FAC, 0x200
+sSeadraSprites7:
+ax_sprite sSeadraGfx7, 0x200
+ax_sprite_terminator
+sSeadraGfx8:
+.incbin "baserom.gba", 0xA0A1BC, 0x200
+sSeadraSprites8:
+ax_sprite sSeadraGfx8, 0x200
+ax_sprite_terminator
+sSeadraGfx9:
+.incbin "baserom.gba", 0xA0A3CC, 0x200
+sSeadraSprites9:
+ax_sprite sSeadraGfx9, 0x200
+ax_sprite_terminator
+sSeadraGfx10:
+.incbin "baserom.gba", 0xA0A5DC, 0x200
+sSeadraSprites10:
+ax_sprite sSeadraGfx10, 0x200
+ax_sprite_terminator
+sSeadraGfx11:
+.incbin "baserom.gba", 0xA0A7EC, 0x200
+sSeadraSprites11:
+ax_sprite sSeadraGfx11, 0x200
+ax_sprite_terminator
+sSeadraGfx12:
+.incbin "baserom.gba", 0xA0A9FC, 0x200
+sSeadraSprites12:
+ax_sprite sSeadraGfx12, 0x200
+ax_sprite_terminator
+sSeadraGfx13:
+.incbin "baserom.gba", 0xA0AC0C, 0x200
+sSeadraSprites13:
+ax_sprite sSeadraGfx13, 0x200
+ax_sprite_terminator
+sSeadraGfx14:
+.incbin "baserom.gba", 0xA0AE1C, 0x200
+sSeadraSprites14:
+ax_sprite sSeadraGfx14, 0x200
+ax_sprite_terminator
+sSeadraGfx15:
+.incbin "baserom.gba", 0xA0B02C, 0x200
+sSeadraSprites15:
+ax_sprite sSeadraGfx15, 0x200
+ax_sprite_terminator
+sSeadraGfx16:
+.incbin "baserom.gba", 0xA0B23C, 0x60
+sSeadraGfx16_1:
+.incbin "baserom.gba", 0xA0B29C, 0x60
+sSeadraGfx16_2:
+.incbin "baserom.gba", 0xA0B2FC, 0x60
+sSeadraGfx16_3:
+.incbin "baserom.gba", 0xA0B35C, 0x20
+sSeadraSprites16:
+ax_sprite sSeadraGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx16_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeadraGfx17:
+.incbin "baserom.gba", 0xA0B3C4, 0x60
+sSeadraGfx17_1:
+.incbin "baserom.gba", 0xA0B424, 0x160
+sSeadraSprites17:
+ax_sprite sSeadraGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx17_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeadraGfx18:
+.incbin "baserom.gba", 0xA0B5AC, 0x60
+sSeadraGfx18_1:
+.incbin "baserom.gba", 0xA0B60C, 0x100
+sSeadraGfx18_2:
+.incbin "baserom.gba", 0xA0B70C, 0x40
+sSeadraSprites18:
+ax_sprite sSeadraGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx18_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx18_2, 0x40
+ax_sprite_terminator
+sSeadraGfx19:
+.incbin "baserom.gba", 0xA0B77C, 0x60
+sSeadraGfx19_1:
+.incbin "baserom.gba", 0xA0B7DC, 0x60
+sSeadraGfx19_2:
+.incbin "baserom.gba", 0xA0B83C, 0x60
+sSeadraGfx19_3:
+.incbin "baserom.gba", 0xA0B89C, 0x40
+sSeadraSprites19:
+ax_sprite sSeadraGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeadraGfx20:
+.incbin "baserom.gba", 0xA0B924, 0x180
+sSeadraGfx20_1:
+.incbin "baserom.gba", 0xA0BAA4, 0x40
+sSeadraSprites20:
+ax_sprite sSeadraGfx20, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeadraGfx21:
+.incbin "baserom.gba", 0xA0BB0C, 0x60
+sSeadraGfx21_1:
+.incbin "baserom.gba", 0xA0BB6C, 0x60
+sSeadraGfx21_2:
+.incbin "baserom.gba", 0xA0BBCC, 0x60
+sSeadraGfx21_3:
+.incbin "baserom.gba", 0xA0BC2C, 0x20
+sSeadraSprites21:
+ax_sprite sSeadraGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeadraGfx22:
+.incbin "baserom.gba", 0xA0BC94, 0x60
+sSeadraGfx22_1:
+.incbin "baserom.gba", 0xA0BCF4, 0x60
+sSeadraGfx22_2:
+.incbin "baserom.gba", 0xA0BD54, 0x60
+sSeadraGfx22_3:
+.incbin "baserom.gba", 0xA0BDB4, 0x20
+sSeadraSprites22:
+ax_sprite sSeadraGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx22_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeadraGfx23:
+.incbin "baserom.gba", 0xA0BE1C, 0x60
+sSeadraGfx23_1:
+.incbin "baserom.gba", 0xA0BE7C, 0xE0
+sSeadraGfx23_2:
+.incbin "baserom.gba", 0xA0BF5C, 0x20
+sSeadraSprites23:
+ax_sprite sSeadraGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx23_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx23_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeadraGfx24:
+.incbin "baserom.gba", 0xA0BFB4, 0x60
+sSeadraGfx24_1:
+.incbin "baserom.gba", 0xA0C014, 0x140
+sSeadraSprites24:
+ax_sprite sSeadraGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx24_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeadraGfx25:
+.incbin "baserom.gba", 0xA0C17C, 0x60
+sSeadraGfx25_1:
+.incbin "baserom.gba", 0xA0C1DC, 0x100
+sSeadraGfx25_2:
+.incbin "baserom.gba", 0xA0C2DC, 0x40
+sSeadraSprites25:
+ax_sprite sSeadraGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeadraGfx26:
+.incbin "baserom.gba", 0xA0C354, 0x60
+sSeadraGfx26_1:
+.incbin "baserom.gba", 0xA0C3B4, 0xE0
+sSeadraGfx26_2:
+.incbin "baserom.gba", 0xA0C494, 0x40
+sSeadraSprites26:
+ax_sprite sSeadraGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx26_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeadraGfx27:
+.incbin "baserom.gba", 0xA0C50C, 0x160
+sSeadraGfx27_1:
+.incbin "baserom.gba", 0xA0C66C, 0x60
+sSeadraSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx27, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx27_1, 0x60
+ax_sprite_terminator
+sSeadraGfx28:
+.incbin "baserom.gba", 0xA0C6F4, 0x40
+sSeadraGfx28_1:
+.incbin "baserom.gba", 0xA0C734, 0x100
+sSeadraGfx28_2:
+.incbin "baserom.gba", 0xA0C834, 0x40
+sSeadraSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx28_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx28_2, 0x40
+ax_sprite_terminator
+sSeadraGfx29:
+.incbin "baserom.gba", 0xA0C8AC, 0x40
+sSeadraGfx29_1:
+.incbin "baserom.gba", 0xA0C8EC, 0x100
+sSeadraGfx29_2:
+.incbin "baserom.gba", 0xA0C9EC, 0x40
+sSeadraSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx29_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx29_2, 0x40
+ax_sprite_terminator
+sSeadraGfx30:
+.incbin "baserom.gba", 0xA0CA64, 0x60
+sSeadraGfx30_1:
+.incbin "baserom.gba", 0xA0CAC4, 0x140
+sSeadraSprites30:
+ax_sprite sSeadraGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx30_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeadraGfx31:
+.incbin "baserom.gba", 0xA0CC2C, 0x60
+sSeadraGfx31_1:
+.incbin "baserom.gba", 0xA0CC8C, 0x60
+sSeadraGfx31_2:
+.incbin "baserom.gba", 0xA0CCEC, 0x60
+sSeadraGfx31_3:
+.incbin "baserom.gba", 0xA0CD4C, 0x40
+sSeadraSprites31:
+ax_sprite sSeadraGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx31_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeadraGfx32:
+.incbin "baserom.gba", 0xA0CDD4, 0x60
+sSeadraGfx32_1:
+.incbin "baserom.gba", 0xA0CE34, 0x60
+sSeadraGfx32_2:
+.incbin "baserom.gba", 0xA0CE94, 0x60
+sSeadraGfx32_3:
+.incbin "baserom.gba", 0xA0CEF4, 0x40
+sSeadraSprites32:
+ax_sprite sSeadraGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeadraGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeadraGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeadraGfx33:
+.incbin "baserom.gba", 0xA0CF7C, 0x180
+sSeadraSprites33:
+ax_sprite sSeadraGfx33, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSeadraGfx34:
+.incbin "baserom.gba", 0xA0D114, 0x180
+sSeadraSprites34:
+ax_sprite sSeadraGfx34, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSeadraGfx35:
+.incbin "baserom.gba", 0xA0D2AC, 0x180
+sSeadraSprites35:
+ax_sprite sSeadraGfx35, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSeadraGfx36:
+.incbin "baserom.gba", 0xA0D444, 0x200
+sSeadraSprites36:
+ax_sprite sSeadraGfx36, 0x200
+ax_sprite_terminator
+sSeadraGfx37:
+.incbin "baserom.gba", 0xA0D654, 0x200
+sSeadraSprites37:
+ax_sprite sSeadraGfx37, 0x200
+ax_sprite_terminator
+sSeadraGfx38:
+.incbin "baserom.gba", 0xA0D864, 0x200
+sSeadraSprites38:
+ax_sprite sSeadraGfx38, 0x200
+ax_sprite_terminator
+sSeadraGfx39:
+.incbin "baserom.gba", 0xA0DA74, 0x200
+sSeadraSprites39:
+ax_sprite sSeadraGfx39, 0x200
+ax_sprite_terminator
+sSeadraGfx40:
+.incbin "baserom.gba", 0xA0DC84, 0x200
+sSeadraSprites40:
+ax_sprite sSeadraGfx40, 0x200
+ax_sprite_terminator
+sSeadraGfx41:
+.incbin "baserom.gba", 0xA0DE94, 0x200
+sSeadraSprites41:
+ax_sprite sSeadraGfx41, 0x200
+ax_sprite_terminator
+sSeadraGfx42:
+.incbin "baserom.gba", 0xA0E0A4, 0x200
+sSeadraSprites42:
+ax_sprite sSeadraGfx42, 0x200
+ax_sprite_terminator
+sAxPosesSeadra:
+.4byte sSeadraPose1
+.4byte sSeadraPose2
+.4byte sSeadraPose3
+.4byte sSeadraPose4
+.4byte sSeadraPose5
+.4byte sSeadraPose6
+.4byte sSeadraPose7
+.4byte sSeadraPose8
+.4byte sSeadraPose9
+.4byte sSeadraPose10
+.4byte sSeadraPose11
+.4byte sSeadraPose12
+.4byte sSeadraPose13
+.4byte sSeadraPose14
+.4byte sSeadraPose15
+.4byte sSeadraPose16
+.4byte sSeadraPose17
+.4byte sSeadraPose18
+.4byte sSeadraPose19
+.4byte sSeadraPose20
+.4byte sSeadraPose21
+.4byte sSeadraPose22
+.4byte sSeadraPose23
+.4byte sSeadraPose24
+.4byte sSeadraPose25
+.4byte sSeadraPose26
+.4byte sSeadraPose27
+.4byte sSeadraPose28
+.4byte sSeadraPose29
+.4byte sSeadraPose30
+.4byte sSeadraPose31
+.4byte sSeadraPose32
+.4byte sSeadraPose33
+.4byte sSeadraPose34
+.4byte sSeadraPose35
+.4byte sSeadraPose36
+.4byte sSeadraPose37
+.4byte sSeadraPose38
+.4byte sSeadraPose39
+.4byte sSeadraPose40
+.4byte sSeadraPose41
+.4byte sSeadraPose42
+.4byte sSeadraPose43
+.4byte sSeadraPose44
+.4byte sSeadraPose45
+.4byte sSeadraPose46
+.4byte sSeadraPose47
+.4byte sSeadraPose48
+.4byte sSeadraPose49
+.4byte sSeadraPose50
+.4byte sSeadraPose51
+.4byte sSeadraPose52
+.4byte sSeadraPose53
+.4byte sSeadraPose54
+.4byte sSeadraPose55
+.4byte sSeadraPose56
+.4byte sSeadraPose57
+.4byte sSeadraPose58
+.4byte sSeadraPose59
+.4byte sSeadraPose60
+.4byte sSeadraPose61
+.4byte sSeadraPose62
+.4byte sSeadraPose63
+.4byte sSeadraPose64
+.4byte sSeadraPose65
+.4byte sSeadraPose66
+.4byte sSeadraPose67
+.4byte sSeadraPose68
+.4byte sSeadraPose69
+.4byte sSeadraPose70
+.4byte sSeadraPose71
+.4byte sSeadraPose72
+.4byte sSeadraPose73
+.4byte sSeadraPose74
+.4byte sSeadraPose75
+.4byte sSeadraPose76
+.4byte sSeadraPose77
+.4byte sSeadraPose78
+.4byte sSeadraPose79
+.4byte sSeadraPose80
+.4byte sSeadraPose81
+.4byte sSeadraPose82
+.4byte sSeadraPose83
+.4byte sSeadraPose84
+.4byte sSeadraPose85
+.4byte sSeadraPose86
+.4byte sSeadraPose87
+.4byte sSeadraPose88
+.4byte sSeadraPose89
+.4byte sSeadraPose90
+.4byte sSeadraPose91
+.4byte sSeadraPose92
+.4byte sSeadraPose93
+.4byte sSeadraPose94
+.4byte sSeadraPose95
+.4byte sSeadraPose96
+.4byte sSeadraPose97
+.4byte sSeadraPose98
+.4byte sSeadraPose99
+.4byte sSeadraPose100
+.4byte sSeadraPose101
+.4byte sSeadraPose102
+.4byte sSeadraPose103
+.4byte sSeadraPose104
+.4byte sSeadraPose105
+.4byte sSeadraPose106
+.4byte sSeadraPose107
+.4byte sSeadraPose108
+.4byte sSeadraPose109
+.4byte sSeadraPose110
+.4byte sSeadraPose111
+.4byte sSeadraPose112
+.4byte sSeadraPose113
+.4byte sSeadraPose114
+.4byte sSeadraPose115
+.4byte sSeadraPose116
+.4byte sSeadraPose117
+.4byte sSeadraPose118
+.4byte sSeadraPose119
+.4byte sSeadraPose120
+.4byte sSeadraPose121
+.4byte sSeadraPose122
+.4byte sSeadraPose123
+.4byte sSeadraPose124
+.4byte sSeadraPose125
+.4byte sSeadraPose126
+.4byte sSeadraPose127
+.4byte sSeadraPose128
+.4byte sSeadraPose129
+.4byte sSeadraPose130
+.4byte sSeadraPose131
+.4byte sSeadraPose132
+.4byte sSeadraPose133
+.4byte sSeadraPose134
+.4byte sSeadraPose135
+.4byte sSeadraPose136
+.4byte sSeadraPose137
+.4byte sSeadraPose138
+.4byte sSeadraPose139
+.4byte sSeadraPose140
+.4byte sSeadraPose141
+.4byte sSeadraPose142
+.4byte sSeadraPose143
+.4byte sSeadraPose144
+.4byte sSeadraPose145
+.4byte sSeadraPose146
+.4byte sSeadraPose147
+.4byte sSeadraPose148
+.4byte sSeadraPose149
+.4byte sSeadraPose150
+.4byte sSeadraPose151
+.4byte sSeadraPose152
+.4byte sSeadraPose153
+.4byte sSeadraPose154
+.4byte sSeadraPose155
+.4byte sSeadraPose156
+.4byte sSeadraPose157
+.4byte sSeadraPose158
+.4byte sSeadraPose159
+.4byte sSeadraPose160
+.4byte sSeadraPose161
+.4byte sSeadraPose162
+.4byte sSeadraPose163
+.4byte sSeadraPose164
+.4byte sSeadraPose165
+.4byte sSeadraPose166
+.4byte sSeadraPose167
+.4byte sSeadraPose168
+.4byte sSeadraPose169
+.4byte sSeadraPose170
+.4byte sSeadraPose171
+.4byte sSeadraPose172
+.4byte sSeadraPose173
+.4byte sSeadraPose174
+.4byte sSeadraPose175
+.4byte sSeadraPose176
+.4byte sSeadraPose177
+.4byte sSeadraPose178
+.4byte sSeadraPose179
+.4byte sSeadraPose180
+.4byte sSeadraPose181
+.4byte sSeadraPose182
+.4byte sSeadraPose183
+.4byte sSeadraPose184
+.4byte sSeadraPose185
+.4byte sSeadraPose186
+.4byte sSeadraPose187
+.4byte sSeadraPose188
+.4byte sSeadraPose189
+.4byte sSeadraPose190
+.4byte sSeadraPose191
+.4byte sSeadraPose192
+.4byte sSeadraPose193
+.4byte sSeadraPose194
+.4byte sSeadraPose195
+.4byte sSeadraPose196
+.4byte sSeadraPose197
+.4byte sSeadraPose198
+.4byte sSeadraPose199
+.4byte sSeadraPose200
+.4byte sSeadraPose201
+.4byte sSeadraPose202
+.4byte sSeadraPose203
+.4byte sSeadraPose204
+.4byte sSeadraPose205
+.4byte sSeadraPose206
+.4byte sSeadraPose207
+.4byte sSeadraPose208
+.4byte sSeadraPose209
+.4byte sSeadraPose210
+.4byte sSeadraPose211
+.4byte sSeadraPose212
+.4byte sSeadraPose213
+.4byte sSeadraPose214
+.4byte sSeadraPose215
+.4byte sSeadraPose216
+.4byte sSeadraPose217
+.4byte sSeadraPose218
+sAxPositionsSeadra:
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -1,  -11, 	  -7,  -17, 	   5,  -17, 	  -1,  -14
+.2byte   -1,  -15, 	  -9,  -17, 	   6,  -17, 	  -1,  -17
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+.2byte    8,  -13, 	   1,  -23, 	  -6,  -17, 	  -1,  -14
+.2byte    7,  -15, 	   2,  -23, 	  -7,  -15, 	   0,  -15
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte   12,  -17, 	  -7,  -23, 	  -8,  -17, 	  -2,  -13
+.2byte    9,  -20, 	  -5,  -23, 	  -4,  -14, 	  -1,  -14
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte    9,  -25, 	 -10,  -19, 	  -4,  -16, 	  -3,  -14
+.2byte    7,  -25, 	  -9,  -21, 	   6,  -16, 	  -1,  -14
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte   -1,  -22, 	   5,  -16, 	  -7,  -16, 	  -1,  -15
+.2byte   -1,  -19, 	   9,  -16, 	 -11,  -16, 	  -1,  -11
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte  -11,  -24, 	   8,  -18, 	   2,  -15, 	   1,  -13
+.2byte   -9,  -25, 	   7,  -21, 	  -8,  -16, 	  -1,  -14
+.2byte  -11,  -18, 	   4,  -23, 	   6,  -15, 	  -2,  -14
+.2byte  -13,  -17, 	   6,  -23, 	   7,  -17, 	   1,  -13
+.2byte  -10,  -20, 	   4,  -23, 	   3,  -14, 	   0,  -14
+.2byte   -8,  -14, 	  -3,  -23, 	   7,  -15, 	  -1,  -15
+.2byte   -9,  -13, 	  -2,  -23, 	   5,  -17, 	   0,  -14
+.2byte   -8,  -15, 	  -3,  -23, 	   6,  -15, 	  -1,  -15
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -1,  -11, 	  -7,  -17, 	   5,  -17, 	  -1,  -14
+.2byte   -1,  -15, 	  -9,  -17, 	   6,  -17, 	  -1,  -17
+.2byte   -1,   -7, 	  -8,  -18, 	   5,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+.2byte    8,  -13, 	   1,  -23, 	  -6,  -17, 	  -1,  -14
+.2byte    7,  -15, 	   2,  -23, 	  -7,  -15, 	   0,  -15
+.2byte    6,   -7, 	   4,  -22, 	  -8,  -19, 	   0,  -13
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte   12,  -17, 	  -7,  -23, 	  -8,  -17, 	  -2,  -13
+.2byte    9,  -20, 	  -5,  -23, 	  -4,  -14, 	  -1,  -14
+.2byte   10,   -8, 	  -2,  -23, 	  -6,  -17, 	  -2,  -13
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte    9,  -25, 	 -10,  -19, 	  -4,  -16, 	  -3,  -14
+.2byte    7,  -25, 	  -9,  -21, 	   6,  -16, 	  -1,  -14
+.2byte    8,  -14, 	  -5,  -24, 	   6,  -19, 	   0,  -16
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte   -1,  -22, 	   5,  -16, 	  -7,  -16, 	  -1,  -15
+.2byte   -1,  -19, 	   9,  -16, 	 -11,  -16, 	  -1,  -11
+.2byte   -1,  -18, 	   7,  -19, 	  -9,  -19, 	  -1,  -13
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte  -11,  -24, 	   8,  -18, 	   2,  -15, 	   1,  -13
+.2byte   -9,  -25, 	   7,  -21, 	  -8,  -16, 	  -1,  -14
+.2byte  -10,  -14, 	   3,  -24, 	  -8,  -19, 	  -2,  -16
+.2byte  -12,  -18, 	   3,  -23, 	   5,  -15, 	  -3,  -14
+.2byte  -13,  -17, 	   6,  -23, 	   7,  -17, 	   1,  -13
+.2byte  -10,  -20, 	   4,  -23, 	   3,  -14, 	   0,  -14
+.2byte  -12,   -8, 	   0,  -23, 	   4,  -17, 	   0,  -13
+.2byte   -9,  -14, 	  -4,  -23, 	   6,  -15, 	  -2,  -15
+.2byte   -9,  -13, 	  -2,  -23, 	   5,  -17, 	   0,  -14
+.2byte   -8,  -15, 	  -3,  -23, 	   6,  -15, 	  -1,  -15
+.2byte   -8,   -7, 	  -6,  -22, 	   6,  -19, 	  -2,  -13
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -1,  -11, 	  -7,  -17, 	   5,  -17, 	  -1,  -14
+.2byte   -1,  -15, 	  -9,  -17, 	   6,  -17, 	  -1,  -17
+.2byte   -1,   -7, 	  -8,  -18, 	   5,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+.2byte    8,  -13, 	   1,  -23, 	  -6,  -17, 	  -1,  -14
+.2byte    7,  -15, 	   2,  -23, 	  -7,  -15, 	   0,  -15
+.2byte    6,   -7, 	   4,  -22, 	  -8,  -19, 	   0,  -13
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte   12,  -17, 	  -7,  -23, 	  -8,  -17, 	  -2,  -13
+.2byte    9,  -20, 	  -5,  -23, 	  -4,  -14, 	  -1,  -14
+.2byte   10,   -8, 	  -2,  -23, 	  -6,  -17, 	  -2,  -13
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte    9,  -25, 	 -10,  -19, 	  -4,  -16, 	  -3,  -14
+.2byte    7,  -25, 	  -9,  -21, 	   6,  -16, 	  -1,  -14
+.2byte    8,  -14, 	  -5,  -24, 	   6,  -19, 	   0,  -16
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte   -1,  -22, 	   5,  -16, 	  -7,  -16, 	  -1,  -15
+.2byte   -1,  -19, 	   9,  -16, 	 -11,  -16, 	  -1,  -11
+.2byte   -1,  -18, 	   7,  -19, 	  -9,  -19, 	  -1,  -13
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte  -11,  -24, 	   8,  -18, 	   2,  -15, 	   1,  -13
+.2byte   -9,  -25, 	   7,  -21, 	  -8,  -16, 	  -1,  -14
+.2byte  -10,  -14, 	   3,  -24, 	  -8,  -19, 	  -2,  -16
+.2byte  -12,  -18, 	   3,  -23, 	   5,  -15, 	  -3,  -14
+.2byte  -13,  -17, 	   6,  -23, 	   7,  -17, 	   1,  -13
+.2byte  -10,  -20, 	   4,  -23, 	   3,  -14, 	   0,  -14
+.2byte  -12,   -8, 	   0,  -23, 	   4,  -17, 	   0,  -13
+.2byte   -9,  -14, 	  -4,  -23, 	   6,  -15, 	  -2,  -15
+.2byte   -9,  -13, 	  -2,  -23, 	   5,  -17, 	   0,  -14
+.2byte   -8,  -15, 	  -3,  -23, 	   6,  -15, 	  -1,  -15
+.2byte   -8,   -7, 	  -6,  -22, 	   6,  -19, 	  -2,  -13
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -1,  -16, 	  -8,  -21, 	   5,  -21, 	  -1,  -17
+.2byte   -1,   -8, 	  -8,  -19, 	   6,  -19, 	  -1,  -12
+.2byte   -1,   -8, 	  -9,  -18, 	   7,  -18, 	  -1,  -12
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+.2byte    5,  -16, 	  -1,  -23, 	 -10,  -17, 	  -2,  -13
+.2byte    9,  -13, 	   4,  -23, 	  -8,  -20, 	   0,  -15
+.2byte    9,  -13, 	   7,  -21, 	  -8,  -19, 	   0,  -15
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte    8,  -19, 	  -9,  -21, 	 -10,  -14, 	  -3,  -12
+.2byte   15,  -16, 	  -2,  -23, 	  -7,  -18, 	  -1,  -12
+.2byte   14,  -15, 	  -1,  -21, 	  -5,  -16, 	   0,  -12
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte    4,  -23, 	 -11,  -17, 	   1,  -14, 	  -3,  -11
+.2byte   10,  -20, 	  -7,  -24, 	   5,  -18, 	  -1,  -15
+.2byte   10,  -20, 	  -5,  -21, 	   6,  -17, 	  -1,  -15
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte   -1,  -25, 	   8,  -14, 	  -9,  -14, 	  -1,  -12
+.2byte   -1,  -18, 	   7,  -20, 	  -9,  -20, 	  -1,  -14
+.2byte   -1,  -18, 	   8,  -18, 	  -9,  -18, 	  -1,  -14
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte   -6,  -23, 	   9,  -17, 	  -3,  -14, 	   1,  -11
+.2byte  -12,  -20, 	   5,  -24, 	  -7,  -18, 	  -1,  -15
+.2byte  -12,  -20, 	   3,  -21, 	  -8,  -17, 	  -1,  -15
+.2byte  -12,  -18, 	   3,  -23, 	   5,  -15, 	  -3,  -14
+.2byte  -10,  -19, 	   7,  -21, 	   8,  -14, 	   1,  -12
+.2byte  -17,  -16, 	   0,  -23, 	   5,  -18, 	  -1,  -12
+.2byte  -16,  -15, 	  -1,  -21, 	   3,  -16, 	  -2,  -12
+.2byte   -9,  -14, 	  -4,  -23, 	   6,  -15, 	  -2,  -15
+.2byte   -7,  -16, 	  -1,  -23, 	   8,  -17, 	   0,  -13
+.2byte  -11,  -13, 	  -6,  -23, 	   6,  -20, 	  -2,  -15
+.2byte  -11,  -13, 	  -9,  -21, 	   6,  -19, 	  -2,  -15
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -9,  -14, 	  -4,  -23, 	   6,  -15, 	  -2,  -15
+.2byte  -12,  -18, 	   3,  -23, 	   5,  -15, 	  -3,  -14
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+.2byte   -8,  -14, 	  -3,  -25, 	   8,  -21, 	   0,  -15
+.2byte   -8,  -15, 	  -4,  -23, 	   7,  -17, 	   0,  -16
+.2byte   -1,  -12, 	 -11,  -21, 	   8,  -21, 	  -1,  -14
+.2byte    6,  -14, 	   0,  -23, 	  -8,  -17, 	  -1,  -14
+.2byte    7,  -18, 	  -6,  -19, 	  -7,  -13, 	  -2,  -13
+.2byte    7,  -23, 	  -9,  -20, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -24, 	  10,  -16, 	 -10,  -16, 	   0,  -11
+.2byte   -8,  -23, 	   8,  -20, 	  -5,  -16, 	   0,  -12
+.2byte   -8,  -18, 	   5,  -19, 	   6,  -13, 	   1,  -13
+.2byte   -7,  -14, 	  -1,  -23, 	   7,  -17, 	   0,  -14
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -1,  -11, 	  -7,  -17, 	   5,  -17, 	  -1,  -14
+.2byte   -1,  -15, 	  -9,  -17, 	   6,  -17, 	  -1,  -17
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+.2byte    8,  -13, 	   1,  -23, 	  -6,  -17, 	  -1,  -14
+.2byte    7,  -15, 	   2,  -23, 	  -7,  -15, 	   0,  -15
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte   12,  -17, 	  -7,  -23, 	  -8,  -17, 	  -2,  -13
+.2byte    9,  -20, 	  -5,  -23, 	  -4,  -14, 	  -1,  -14
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte   10,  -24, 	  -9,  -18, 	  -3,  -15, 	  -2,  -13
+.2byte    7,  -25, 	  -9,  -21, 	   6,  -16, 	  -1,  -14
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte   -1,  -22, 	   5,  -16, 	  -7,  -16, 	  -1,  -15
+.2byte   -1,  -21, 	   9,  -18, 	 -11,  -18, 	  -1,  -13
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte  -12,  -24, 	   7,  -18, 	   1,  -15, 	   0,  -13
+.2byte   -9,  -25, 	   7,  -21, 	  -8,  -16, 	  -1,  -14
+.2byte  -12,  -18, 	   3,  -23, 	   5,  -15, 	  -3,  -14
+.2byte  -14,  -17, 	   5,  -23, 	   6,  -17, 	   0,  -13
+.2byte  -11,  -20, 	   3,  -23, 	   2,  -14, 	  -1,  -14
+.2byte   -9,  -14, 	  -4,  -23, 	   6,  -15, 	  -2,  -15
+.2byte  -10,  -13, 	  -3,  -23, 	   4,  -17, 	  -1,  -14
+.2byte   -9,  -15, 	  -4,  -23, 	   5,  -15, 	  -2,  -15
+.2byte   -1,   -7, 	  -8,  -18, 	   5,  -18, 	  -1,  -12
+.2byte   -8,   -7, 	  -6,  -22, 	   6,  -19, 	  -2,  -13
+.2byte  -12,   -8, 	   0,  -23, 	   4,  -17, 	   0,  -13
+.2byte   -9,  -12, 	   4,  -22, 	  -7,  -17, 	  -1,  -14
+.2byte   -1,  -19, 	   7,  -20, 	  -9,  -20, 	  -1,  -14
+.2byte    7,  -12, 	  -6,  -22, 	   5,  -17, 	  -1,  -14
+.2byte   10,   -8, 	  -2,  -23, 	  -6,  -17, 	  -2,  -13
+.2byte    6,   -7, 	   4,  -22, 	  -8,  -19, 	   0,  -13
+.2byte   -1,  -16, 	  -8,  -21, 	   5,  -21, 	  -1,  -17
+.2byte    6,  -17, 	   0,  -24, 	  -9,  -18, 	  -1,  -14
+.2byte    8,  -19, 	  -9,  -21, 	 -10,  -14, 	  -3,  -12
+.2byte    4,  -25, 	 -11,  -19, 	   1,  -16, 	  -3,  -13
+.2byte   -1,  -25, 	   8,  -14, 	  -9,  -14, 	  -1,  -12
+.2byte   -6,  -25, 	   9,  -19, 	  -3,  -16, 	   1,  -13
+.2byte  -10,  -19, 	   7,  -21, 	   8,  -14, 	   1,  -12
+.2byte   -8,  -17, 	  -2,  -24, 	   7,  -18, 	  -1,  -14
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -1,  -15, 	  -9,  -17, 	   6,  -17, 	  -1,  -17
+.2byte   -1,  -11, 	  -7,  -17, 	   5,  -17, 	  -1,  -14
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+.2byte    7,  -15, 	   2,  -23, 	  -7,  -15, 	   0,  -15
+.2byte    8,  -13, 	   1,  -23, 	  -6,  -17, 	  -1,  -14
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte    9,  -20, 	  -5,  -23, 	  -4,  -14, 	  -1,  -14
+.2byte   12,  -17, 	  -7,  -23, 	  -8,  -17, 	  -2,  -13
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte    7,  -25, 	  -9,  -21, 	   6,  -16, 	  -1,  -14
+.2byte    9,  -25, 	 -10,  -19, 	  -4,  -16, 	  -3,  -14
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte   -1,  -19, 	   9,  -16, 	 -11,  -16, 	  -1,  -11
+.2byte   -1,  -22, 	   5,  -16, 	  -7,  -16, 	  -1,  -15
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte   -9,  -25, 	   7,  -21, 	  -8,  -16, 	  -1,  -14
+.2byte  -11,  -24, 	   8,  -18, 	   2,  -15, 	   1,  -13
+.2byte  -11,  -18, 	   4,  -23, 	   6,  -15, 	  -2,  -14
+.2byte  -10,  -20, 	   4,  -23, 	   3,  -14, 	   0,  -14
+.2byte  -13,  -17, 	   6,  -23, 	   7,  -17, 	   1,  -13
+.2byte   -8,  -14, 	  -3,  -23, 	   7,  -15, 	  -1,  -15
+.2byte   -8,  -15, 	  -3,  -23, 	   6,  -15, 	  -1,  -15
+.2byte   -9,  -13, 	  -2,  -23, 	   5,  -17, 	   0,  -14
+.2byte   -1,  -15, 	  -9,  -17, 	   6,  -17, 	  -1,  -17
+.2byte   -8,  -17, 	  -3,  -25, 	   6,  -17, 	  -1,  -17
+.2byte  -10,  -20, 	   4,  -23, 	   3,  -14, 	   0,  -14
+.2byte   -9,  -26, 	   7,  -22, 	  -8,  -17, 	  -1,  -15
+.2byte   -1,  -22, 	   9,  -19, 	 -11,  -19, 	  -1,  -14
+.2byte    7,  -26, 	  -9,  -22, 	   6,  -17, 	  -1,  -15
+.2byte    9,  -20, 	  -5,  -23, 	  -4,  -14, 	  -1,  -14
+.2byte    7,  -17, 	   2,  -25, 	  -7,  -17, 	   0,  -17
+.2byte   -1,  -13, 	  -8,  -16, 	   6,  -16, 	  -1,  -16
+.2byte   -9,  -14, 	  -4,  -23, 	   6,  -15, 	  -2,  -15
+.2byte  -12,  -18, 	   3,  -23, 	   5,  -15, 	  -3,  -14
+.2byte  -10,  -24, 	   9,  -20, 	  -4,  -15, 	  -1,  -14
+.2byte   -1,  -19, 	   8,  -17, 	 -10,  -17, 	  -1,  -14
+.2byte    8,  -24, 	 -11,  -20, 	   2,  -15, 	  -1,  -14
+.2byte   10,  -18, 	  -5,  -23, 	  -7,  -15, 	   1,  -14
+.2byte    7,  -14, 	   2,  -23, 	  -8,  -15, 	   0,  -15
+sSeadraAnimTable1:
+.4byte sSeadraAnims_1_1
+.4byte sSeadraAnims_1_2
+.4byte sSeadraAnims_1_3
+.4byte sSeadraAnims_1_4
+.4byte sSeadraAnims_1_5
+.4byte sSeadraAnims_1_6
+.4byte sSeadraAnims_1_7
+.4byte sSeadraAnims_1_8
+sSeadraAnimTable2:
+.4byte sSeadraAnims_2_1
+.4byte sSeadraAnims_2_2
+.4byte sSeadraAnims_2_3
+.4byte sSeadraAnims_2_4
+.4byte sSeadraAnims_2_5
+.4byte sSeadraAnims_2_6
+.4byte sSeadraAnims_2_7
+.4byte sSeadraAnims_2_8
+sSeadraAnimTable3:
+.4byte sSeadraAnims_3_1
+.4byte sSeadraAnims_3_2
+.4byte sSeadraAnims_3_3
+.4byte sSeadraAnims_3_4
+.4byte sSeadraAnims_3_5
+.4byte sSeadraAnims_3_6
+.4byte sSeadraAnims_3_7
+.4byte sSeadraAnims_3_8
+sSeadraAnimTable4:
+.4byte sSeadraAnims_4_1
+.4byte sSeadraAnims_4_2
+.4byte sSeadraAnims_4_3
+.4byte sSeadraAnims_4_4
+.4byte sSeadraAnims_4_5
+.4byte sSeadraAnims_4_6
+.4byte sSeadraAnims_4_7
+.4byte sSeadraAnims_4_8
+sSeadraAnimTable5:
+.4byte sSeadraAnims_5_1
+.4byte sSeadraAnims_5_2
+.4byte sSeadraAnims_5_3
+.4byte sSeadraAnims_5_4
+.4byte sSeadraAnims_5_5
+.4byte sSeadraAnims_5_6
+.4byte sSeadraAnims_5_7
+.4byte sSeadraAnims_5_8
+sSeadraAnimTable6:
+.4byte sSeadraAnims_6_1
+.4byte sSeadraAnims_6_1
+.4byte sSeadraAnims_6_1
+.4byte sSeadraAnims_6_1
+.4byte sSeadraAnims_6_1
+.4byte sSeadraAnims_6_1
+.4byte sSeadraAnims_6_1
+.4byte sSeadraAnims_6_1
+sSeadraAnimTable7:
+.4byte sSeadraAnims_7_1
+.4byte sSeadraAnims_7_2
+.4byte sSeadraAnims_7_3
+.4byte sSeadraAnims_7_4
+.4byte sSeadraAnims_7_5
+.4byte sSeadraAnims_7_6
+.4byte sSeadraAnims_7_7
+.4byte sSeadraAnims_7_8
+sSeadraAnimTable8:
+.4byte sSeadraAnims_8_1
+.4byte sSeadraAnims_8_2
+.4byte sSeadraAnims_8_3
+.4byte sSeadraAnims_8_4
+.4byte sSeadraAnims_8_5
+.4byte sSeadraAnims_8_6
+.4byte sSeadraAnims_8_7
+.4byte sSeadraAnims_8_8
+sSeadraAnimTable9:
+.4byte sSeadraAnims_9_1
+.4byte sSeadraAnims_9_2
+.4byte sSeadraAnims_9_3
+.4byte sSeadraAnims_9_4
+.4byte sSeadraAnims_9_5
+.4byte sSeadraAnims_9_6
+.4byte sSeadraAnims_9_7
+.4byte sSeadraAnims_9_8
+sSeadraAnimTable10:
+.4byte sSeadraAnims_10_1
+.4byte sSeadraAnims_10_2
+.4byte sSeadraAnims_10_3
+.4byte sSeadraAnims_10_4
+.4byte sSeadraAnims_10_5
+.4byte sSeadraAnims_10_6
+.4byte sSeadraAnims_10_7
+.4byte sSeadraAnims_10_8
+sSeadraAnimTable11:
+.4byte sSeadraAnims_11_1
+.4byte sSeadraAnims_11_2
+.4byte sSeadraAnims_11_3
+.4byte sSeadraAnims_11_4
+.4byte sSeadraAnims_11_5
+.4byte sSeadraAnims_11_6
+.4byte sSeadraAnims_11_7
+.4byte sSeadraAnims_11_8
+sSeadraAnimTable12:
+.4byte sSeadraAnims_12_1
+.4byte sSeadraAnims_12_2
+.4byte sSeadraAnims_12_3
+.4byte sSeadraAnims_12_4
+.4byte sSeadraAnims_12_5
+.4byte sSeadraAnims_12_6
+.4byte sSeadraAnims_12_7
+.4byte sSeadraAnims_12_8
+sSeadraAnimTable13:
+.4byte sSeadraAnims_13_1
+.4byte sSeadraAnims_13_2
+.4byte sSeadraAnims_13_3
+.4byte sSeadraAnims_13_4
+.4byte sSeadraAnims_13_5
+.4byte sSeadraAnims_13_6
+.4byte sSeadraAnims_13_7
+.4byte sSeadraAnims_13_8
+sAxAnimationsSeadra:
+.4byte sSeadraAnimTable1
+.4byte sSeadraAnimTable2
+.4byte sSeadraAnimTable3
+.4byte sSeadraAnimTable4
+.4byte sSeadraAnimTable5
+.4byte sSeadraAnimTable6
+.4byte sSeadraAnimTable7
+.4byte sSeadraAnimTable8
+.4byte sSeadraAnimTable9
+.4byte sSeadraAnimTable10
+.4byte sSeadraAnimTable11
+.4byte sSeadraAnimTable12
+.4byte sSeadraAnimTable13
+sAxSpritesSeadra:
+.4byte sSeadraSprites1
+.4byte sSeadraSprites2
+.4byte sSeadraSprites3
+.4byte sSeadraSprites4
+.4byte sSeadraSprites5
+.4byte sSeadraSprites6
+.4byte sSeadraSprites7
+.4byte sSeadraSprites8
+.4byte sSeadraSprites9
+.4byte sSeadraSprites10
+.4byte sSeadraSprites11
+.4byte sSeadraSprites12
+.4byte sSeadraSprites13
+.4byte sSeadraSprites14
+.4byte sSeadraSprites15
+.4byte sSeadraSprites16
+.4byte sSeadraSprites17
+.4byte sSeadraSprites18
+.4byte sSeadraSprites19
+.4byte sSeadraSprites20
+.4byte sSeadraSprites21
+.4byte sSeadraSprites22
+.4byte sSeadraSprites23
+.4byte sSeadraSprites24
+.4byte sSeadraSprites25
+.4byte sSeadraSprites26
+.4byte sSeadraSprites27
+.4byte sSeadraSprites28
+.4byte sSeadraSprites29
+.4byte sSeadraSprites30
+.4byte sSeadraSprites31
+.4byte sSeadraSprites32
+.4byte sSeadraSprites33
+.4byte sSeadraSprites34
+.4byte sSeadraSprites35
+.4byte sSeadraSprites36
+.4byte sSeadraSprites37
+.4byte sSeadraSprites38
+.4byte sSeadraSprites39
+.4byte sSeadraSprites40
+.4byte sSeadraSprites41
+.4byte sSeadraSprites42
+sAxMainSeadra:
+ax_main sAxPosesSeadra, sAxAnimationsSeadra, 13, sAxSpritesSeadra, sAxPositionsSeadra

--- a/data/ax/seaking.inc
+++ b/data/ax/seaking.inc
@@ -1,0 +1,3323 @@
+.global gAxSeaking
+gAxSeaking:
+ax_siro sAxMainSeaking
+sSeakingPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose2:
+ax_pose 1, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose3:
+ax_pose 2, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose4:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose5:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose6:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose7:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose8:
+ax_pose 7, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose9:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose10:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose11:
+ax_pose 10, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose12:
+ax_pose 11, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose13:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose14:
+ax_pose 13, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose15:
+ax_pose 14, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose16:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose17:
+ax_pose 10, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose18:
+ax_pose 11, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose19:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose20:
+ax_pose 7, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose21:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose22:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose23:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose24:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose26:
+ax_pose 1, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose27:
+ax_pose 2, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose28:
+ax_pose 15, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose29:
+ax_pose 16, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose30:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose31:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose32:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose33:
+ax_pose 17, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose34:
+ax_pose 18, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose35:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose36:
+ax_pose 7, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose37:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose38:
+ax_pose 19, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose39:
+ax_pose 20, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose40:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose41:
+ax_pose 10, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose42:
+ax_pose 11, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose43:
+ax_pose 21, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeakingPose44:
+ax_pose 22, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeakingPose45:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose46:
+ax_pose 13, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose47:
+ax_pose 14, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose48:
+ax_pose 23, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose49:
+ax_pose 24, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose50:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose51:
+ax_pose 10, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose52:
+ax_pose 11, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose53:
+ax_pose 21, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeakingPose54:
+ax_pose 22, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeakingPose55:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose56:
+ax_pose 7, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose57:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose58:
+ax_pose 19, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose59:
+ax_pose 20, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose60:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose61:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose62:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose63:
+ax_pose 17, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose64:
+ax_pose 18, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose65:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose66:
+ax_pose 1, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose67:
+ax_pose 2, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose68:
+ax_pose 15, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose69:
+ax_pose 16, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose70:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose71:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose72:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose73:
+ax_pose 17, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose74:
+ax_pose 18, 0x01e3, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose75:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose76:
+ax_pose 7, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose77:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose78:
+ax_pose 19, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose79:
+ax_pose 20, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose80:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose81:
+ax_pose 10, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose82:
+ax_pose 11, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose83:
+ax_pose 21, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeakingPose84:
+ax_pose 22, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeakingPose85:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose86:
+ax_pose 13, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose87:
+ax_pose 14, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose88:
+ax_pose 23, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose89:
+ax_pose 24, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose90:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose91:
+ax_pose 10, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose92:
+ax_pose 11, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose93:
+ax_pose 21, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeakingPose94:
+ax_pose 22, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeakingPose95:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose96:
+ax_pose 7, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose97:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose98:
+ax_pose 19, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose99:
+ax_pose 20, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose100:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose101:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose102:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose103:
+ax_pose 17, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose104:
+ax_pose 18, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose105:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose106:
+ax_pose 1, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose107:
+ax_pose 2, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose108:
+ax_pose 25, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose109:
+ax_pose 26, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose110:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose111:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose112:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose113:
+ax_pose 27, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeakingPose114:
+ax_pose 28, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeakingPose115:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose116:
+ax_pose 7, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose117:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose118:
+ax_pose 29, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose119:
+ax_pose 30, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose120:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose121:
+ax_pose 10, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose122:
+ax_pose 11, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose123:
+ax_pose 31, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose124:
+ax_pose 32, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeakingPose125:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose126:
+ax_pose 13, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose127:
+ax_pose 14, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose128:
+ax_pose 33, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose129:
+ax_pose 34, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose130:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose131:
+ax_pose 10, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose132:
+ax_pose 11, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose133:
+ax_pose 31, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose134:
+ax_pose 32, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeakingPose135:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose136:
+ax_pose 7, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose137:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose138:
+ax_pose 29, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose139:
+ax_pose 30, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose140:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose141:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose142:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose143:
+ax_pose 27, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeakingPose144:
+ax_pose 28, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeakingPose145:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose146:
+ax_pose 25, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose147:
+ax_pose 35, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose148:
+ax_pose 36, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose149:
+ax_pose 37, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose150:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose151:
+ax_pose 27, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose152:
+ax_pose 38, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose153:
+ax_pose 39, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose154:
+ax_pose 40, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose155:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose156:
+ax_pose 29, 0x01e5, 0x90f2, 0x0c00
+ax_pose_terminator
+sSeakingPose157:
+ax_pose 41, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose158:
+ax_pose 42, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose159:
+ax_pose 43, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose160:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose161:
+ax_pose 31, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose162:
+ax_pose 44, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose163:
+ax_pose 45, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose164:
+ax_pose 46, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose165:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose166:
+ax_pose 33, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose167:
+ax_pose 47, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose168:
+ax_pose 48, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose169:
+ax_pose 49, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose170:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose171:
+ax_pose 31, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose172:
+ax_pose 44, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose173:
+ax_pose 45, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose174:
+ax_pose 46, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose175:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose176:
+ax_pose 29, 0x01e5, 0x80ef, 0x0c00
+ax_pose_terminator
+sSeakingPose177:
+ax_pose 41, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose178:
+ax_pose 42, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose179:
+ax_pose 43, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose180:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose181:
+ax_pose 27, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose182:
+ax_pose 38, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose183:
+ax_pose 39, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose184:
+ax_pose 40, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose185:
+ax_pose 50, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose186:
+ax_pose 51, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose187:
+ax_pose 52, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose188:
+ax_pose 53, 0x01e3, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose189:
+ax_pose 54, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose190:
+ax_pose 55, 0x01e4, 0x90ec, 0x0c00
+ax_pose_terminator
+sSeakingPose191:
+ax_pose 56, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose192:
+ax_pose 55, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose193:
+ax_pose 54, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeakingPose194:
+ax_pose 53, 0x01e3, 0x80ef, 0x0c00
+ax_pose_terminator
+sSeakingPose195:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose196:
+ax_pose 1, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose197:
+ax_pose 2, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose198:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose199:
+ax_pose 4, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose200:
+ax_pose 5, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose201:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose202:
+ax_pose 7, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose203:
+ax_pose 8, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose204:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose205:
+ax_pose 10, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose206:
+ax_pose 11, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose207:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose208:
+ax_pose 13, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose209:
+ax_pose 14, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose210:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose211:
+ax_pose 10, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose212:
+ax_pose 11, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose213:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose214:
+ax_pose 7, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose215:
+ax_pose 8, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose216:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose217:
+ax_pose 4, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose218:
+ax_pose 5, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose219:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose220:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose221:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose222:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose223:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose224:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose225:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose226:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose227:
+ax_pose 35, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose228:
+ax_pose 38, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose229:
+ax_pose 41, 0x01e4, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose230:
+ax_pose 44, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose231:
+ax_pose 47, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose232:
+ax_pose 44, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose233:
+ax_pose 41, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose234:
+ax_pose 38, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose235:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose236:
+ax_pose 25, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose237:
+ax_pose 26, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose238:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose239:
+ax_pose 27, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeakingPose240:
+ax_pose 28, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeakingPose241:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose242:
+ax_pose 29, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose243:
+ax_pose 30, 0x01e4, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose244:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose245:
+ax_pose 31, 0x01e5, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose246:
+ax_pose 32, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sSeakingPose247:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose248:
+ax_pose 33, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose249:
+ax_pose 34, 0x01e4, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose250:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose251:
+ax_pose 31, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose252:
+ax_pose 32, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeakingPose253:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose254:
+ax_pose 29, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose255:
+ax_pose 30, 0x01e4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose256:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose257:
+ax_pose 27, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeakingPose258:
+ax_pose 28, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sSeakingPose259:
+ax_pose 25, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose260:
+ax_pose 27, 0x01e6, 0x80f2, 0x0c00
+ax_pose_terminator
+sSeakingPose261:
+ax_pose 29, 0x01e7, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose262:
+ax_pose 31, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose263:
+ax_pose 33, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSeakingPose264:
+ax_pose 31, 0x01e8, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose265:
+ax_pose 29, 0x01e7, 0x90f0, 0x0c00
+ax_pose_terminator
+sSeakingPose266:
+ax_pose 27, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sSeakingPose267:
+ax_pose 0, 0x01e8, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose268:
+ax_pose 3, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose269:
+ax_pose 6, 0x01e9, 0x80f0, 0x0c00
+ax_pose_terminator
+sSeakingPose270:
+ax_pose 9, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSeakingPose271:
+ax_pose 12, 0x01e3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSeakingPose272:
+ax_pose 9, 0x01e3, 0x90ed, 0x0c00
+ax_pose_terminator
+sSeakingPose273:
+ax_pose 6, 0x01e9, 0x90f1, 0x0c00
+ax_pose_terminator
+sSeakingPose274:
+ax_pose 3, 0x01e7, 0x90ed, 0x0c00
+ax_pose_terminator
+.align 2
+sSeakingAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 10, 0, 0, 0, 1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 0,
+ax_anim 10, 0, 3, 0, 1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim 10, 0, 6, 0, 1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim 10, 0, 12, 0, 1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 1, 0, 0,
+ax_anim 10, 0, 18, 0, 1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 1, 0, 0,
+ax_anim 10, 0, 21, 0, 1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeakingAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSeakingAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 9, 11, 9, 11,
+ax_anim 2, 0, 32, 17, 20, 17, 20,
+ax_anim 2, 1, 33, 15, 18, 15, 18,
+ax_anim 2, 0, 32, 17, 20, 17, 20,
+ax_anim 2, 0, 33, 15, 18, 15, 18,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sSeakingAnims_2_3:
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 4, 0, 34, -2, 0, -2, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 9, 0, 9, 0,
+ax_anim 2, 0, 37, 16, 0, 16, 0,
+ax_anim 2, 1, 38, 14, 0, 14, 0,
+ax_anim 2, 0, 37, 16, 0, 16, 0,
+ax_anim 2, 0, 38, 14, 0, 14, 0,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sSeakingAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 4, -4, 4, -4,
+ax_anim 1, 0, 40, 10, -11, 10, -11,
+ax_anim 2, 0, 42, 16, -16, 16, -16,
+ax_anim 2, 1, 43, 14, -14, 14, -14,
+ax_anim 2, 0, 42, 16, -16, 16, -16,
+ax_anim 2, 0, 43, 14, -14, 14, -14,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sSeakingAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, 0, -4, 0, -4,
+ax_anim 1, 0, 45, 0, -8, 0, -8,
+ax_anim 2, 0, 47, 0, -14, 0, -14,
+ax_anim 2, 1, 48, 0, -12, 0, -12,
+ax_anim 2, 0, 47, 0, -14, 0, -14,
+ax_anim 2, 0, 48, 0, -12, 0, -12,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sSeakingAnims_2_6:
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 4, 0, 49, 2, 2, 2, 2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, -4, -4, -4,
+ax_anim 1, 0, 50, -10, -11, -10, -11,
+ax_anim 2, 0, 52, -16, -16, -16, -16,
+ax_anim 2, 1, 53, -14, -14, -14, -14,
+ax_anim 2, 0, 52, -16, -16, -16, -16,
+ax_anim 2, 0, 53, -14, -14, -14, -14,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sSeakingAnims_2_7:
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 4, 0, 54, 2, 0, 2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 56, -4, 0, -4, 0,
+ax_anim 1, 0, 55, -9, 0, -9, 0,
+ax_anim 2, 0, 57, -16, 0, -16, 0,
+ax_anim 2, 1, 58, -14, 0, -14, 0,
+ax_anim 2, 0, 57, -16, 0, -16, 0,
+ax_anim 2, 0, 58, -14, 0, -14, 0,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sSeakingAnims_2_8:
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 4, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, -4, 4, -4, 4,
+ax_anim 1, 0, 60, -9, 11, -9, 11,
+ax_anim 2, 0, 62, -17, 20, -17, 20,
+ax_anim 2, 1, 63, -15, 18, -15, 18,
+ax_anim 2, 0, 62, -17, 20, -17, 20,
+ax_anim 2, 0, 63, -15, 18, -15, 18,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeakingAnims_3_1:
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 64, 0, -2, 0, -2,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 0, 4, 0, 4,
+ax_anim 1, 0, 65, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 2, 1, 68, 0, 18, 0, 18,
+ax_anim 2, 0, 67, 0, 20, 0, 20,
+ax_anim 2, 0, 68, 0, 18, 0, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sSeakingAnims_3_2:
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 4, 0, 69, -2, -2, -2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 4, 4, 4, 4,
+ax_anim 1, 0, 70, 9, 11, 9, 11,
+ax_anim 2, 0, 72, 17, 20, 17, 20,
+ax_anim 2, 1, 73, 15, 18, 15, 18,
+ax_anim 2, 0, 72, 17, 20, 17, 20,
+ax_anim 2, 0, 73, 15, 18, 15, 18,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sSeakingAnims_3_3:
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 4, 0, 74, -2, 0, -2, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 2, 76, 4, 0, 4, 0,
+ax_anim 1, 0, 75, 9, 0, 9, 0,
+ax_anim 2, 0, 77, 16, 0, 16, 0,
+ax_anim 2, 1, 78, 14, 0, 14, 0,
+ax_anim 2, 0, 77, 16, 0, 16, 0,
+ax_anim 2, 0, 78, 14, 0, 14, 0,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sSeakingAnims_3_4:
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 4, 0, 79, -2, 2, -2, 2,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 81, 4, -4, 4, -4,
+ax_anim 1, 0, 80, 10, -11, 10, -11,
+ax_anim 2, 0, 82, 16, -16, 16, -16,
+ax_anim 2, 1, 83, 14, -14, 14, -14,
+ax_anim 2, 0, 82, 16, -16, 16, -16,
+ax_anim 2, 0, 83, 14, -14, 14, -14,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sSeakingAnims_3_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 4, 0, 84, 0, 2, 0, 2,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 86, 0, -4, 0, -4,
+ax_anim 1, 0, 85, 0, -8, 0, -8,
+ax_anim 2, 0, 87, 0, -14, 0, -14,
+ax_anim 2, 1, 88, 0, -12, 0, -12,
+ax_anim 2, 0, 87, 0, -14, 0, -14,
+ax_anim 2, 0, 88, 0, -12, 0, -12,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sSeakingAnims_3_6:
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 4, 0, 89, 2, 2, 2, 2,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 2, 91, -4, -4, -4, -4,
+ax_anim 1, 0, 90, -10, -11, -10, -11,
+ax_anim 2, 0, 92, -16, -16, -16, -16,
+ax_anim 2, 1, 93, -14, -14, -14, -14,
+ax_anim 2, 0, 92, -16, -16, -16, -16,
+ax_anim 2, 0, 93, -14, -14, -14, -14,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sSeakingAnims_3_7:
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 4, 0, 94, 2, 0, 2, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 2, 96, -4, 0, -4, 0,
+ax_anim 1, 0, 95, -9, 0, -9, 0,
+ax_anim 2, 0, 97, -16, 0, -16, 0,
+ax_anim 2, 1, 98, -14, 0, -14, 0,
+ax_anim 2, 0, 97, -16, 0, -16, 0,
+ax_anim 2, 0, 98, -14, 0, -14, 0,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sSeakingAnims_3_8:
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 4, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 2, 101, -4, 4, -4, 4,
+ax_anim 1, 0, 100, -9, 11, -9, 11,
+ax_anim 2, 0, 102, -17, 20, -17, 20,
+ax_anim 2, 1, 103, -15, 18, -15, 18,
+ax_anim 2, 0, 102, -17, 20, -17, 20,
+ax_anim 2, 0, 103, -15, 18, -15, 18,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeakingAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 107, 0, -2, 0, -2,
+ax_anim 6, 2, 107, 0, -3, 0, -3,
+ax_anim 1, 0, 104, 0, -1, 0, -1,
+ax_anim 1, 0, 108, 0, 2, 0, 2,
+ax_anim 2, 1, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 108, -1, 3, -1, 3,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 108, -1, 3, -1, 3,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 108, -1, 3, -1, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sSeakingAnims_4_2:
+ax_anim 2, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 112, -2, -2, -2, -2,
+ax_anim 6, 2, 112, -3, -3, -3, -3,
+ax_anim 1, 0, 109, -1, -1, -1, -1,
+ax_anim 1, 0, 113, 2, 2, 2, 2,
+ax_anim 2, 1, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 113, 4, 2, 4, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 113, 4, 2, 4, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 113, 4, 2, 4, 2,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim_terminator
+sSeakingAnims_4_3:
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 0, 117, -2, 0, -2, 0,
+ax_anim 6, 2, 117, -3, 0, -3, 0,
+ax_anim 1, 0, 114, -1, 0, -1, 0,
+ax_anim 1, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 1, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 118, 3, 1, 3, 1,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 118, 3, 1, 3, 1,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 118, 3, 1, 3, 1,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sSeakingAnims_4_4:
+ax_anim 2, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 0, 122, -2, 2, -2, 2,
+ax_anim 6, 2, 122, -3, 3, -3, 3,
+ax_anim 1, 0, 119, -1, 1, -1, 1,
+ax_anim 1, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 1, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 2, -4, 2, -4,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 2, -4, 2, -4,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 2, -4, 2, -4,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim_terminator
+sSeakingAnims_4_5:
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 0, 127, 0, 2, 0, 2,
+ax_anim 6, 2, 127, 0, 3, 0, 3,
+ax_anim 1, 0, 124, 0, 1, 0, 1,
+ax_anim 1, 0, 128, 0, -2, 0, -2,
+ax_anim 2, 1, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 128, -1, -3, -1, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 128, -1, -3, -1, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 128, -1, -3, -1, -3,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sSeakingAnims_4_6:
+ax_anim 2, 0, 129, 1, 1, 1, 1,
+ax_anim 2, 0, 132, 2, 2, 2, 2,
+ax_anim 6, 2, 132, 3, 3, 3, 3,
+ax_anim 1, 0, 129, 1, 1, 1, 1,
+ax_anim 1, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 1, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 133, -2, -4, -2, -4,
+ax_anim 2, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 133, -2, -4, -2, -4,
+ax_anim 2, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 133, -2, -4, -2, -4,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim_terminator
+sSeakingAnims_4_7:
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim 2, 0, 137, 2, 0, 2, 0,
+ax_anim 6, 2, 137, 3, 0, 3, 0,
+ax_anim 1, 0, 134, 1, 0, 1, 0,
+ax_anim 1, 0, 138, -2, 0, -2, 0,
+ax_anim 2, 1, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 138, -3, 1, -3, 1,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 138, -3, 1, -3, 1,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 138, -3, 1, -3, 1,
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim_terminator
+sSeakingAnims_4_8:
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 142, 2, -2, 2, -2,
+ax_anim 6, 2, 142, 3, -3, 3, -3,
+ax_anim 1, 0, 139, 1, -1, 1, -1,
+ax_anim 1, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 1, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 143, -4, 2, -4, 2,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSeakingAnims_5_1:
+ax_anim 1, 0, 144, 0, 1, 0, 1,
+ax_anim 2, 0, 144, 0, 2, 0, 2,
+ax_anim 2, 0, 145, 0, 2, 0, 2,
+ax_anim 2, 0, 146, 0, 2, 0, 2,
+ax_anim 3, 0, 147, 0, 1, 0, 2,
+ax_anim 3, 2, 146, 0, 0, 0, 2,
+ax_anim 3, 0, 148, 0, -1, 0, 2,
+ax_anim 3, 0, 146, 0, -2, 0, 2,
+ax_anim 3, 0, 147, 0, -3, 0, 2,
+ax_anim 3, 0, 146, 0, -3, 0, 2,
+ax_anim 3, 0, 148, 0, -2, 0, 2,
+ax_anim 2, 0, 145, 0, -1, 0, 1,
+ax_anim_terminator
+sSeakingAnims_5_2:
+ax_anim 1, 0, 149, 1, 1, 1, 1,
+ax_anim 2, 0, 149, 2, 2, 2, 2,
+ax_anim 2, 0, 150, 2, 2, 2, 2,
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 3, 0, 152, 2, 1, 2, 2,
+ax_anim 3, 2, 151, 2, 0, 2, 2,
+ax_anim 3, 0, 153, 2, -1, 2, 2,
+ax_anim 3, 0, 151, 2, -2, 2, 2,
+ax_anim 3, 0, 152, 2, -3, 2, 2,
+ax_anim 3, 0, 151, 2, -3, 2, 2,
+ax_anim 3, 0, 153, 2, -2, 2, 2,
+ax_anim 2, 0, 150, 1, -1, 1, 1,
+ax_anim_terminator
+sSeakingAnims_5_3:
+ax_anim 1, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 2, 0, 2, 0,
+ax_anim 2, 0, 155, 3, 0, 3, 0,
+ax_anim 2, 0, 156, 6, 0, 6, 0,
+ax_anim 3, 0, 157, 6, -1, 6, 0,
+ax_anim 3, 2, 156, 6, -2, 6, 0,
+ax_anim 3, 0, 158, 6, -3, 6, 0,
+ax_anim 3, 0, 156, 6, -4, 6, 0,
+ax_anim 3, 0, 157, 6, -5, 6, 0,
+ax_anim 3, 0, 156, 6, -5, 6, 0,
+ax_anim 3, 0, 158, 6, -4, 6, 0,
+ax_anim 2, 0, 155, 3, -3, 2, 0,
+ax_anim_terminator
+sSeakingAnims_5_4:
+ax_anim 1, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 2, -2, 2, -2,
+ax_anim 2, 0, 160, 3, -3, 2, -2,
+ax_anim 2, 0, 161, 3, -4, 2, -2,
+ax_anim 3, 0, 162, 3, -4, 2, -2,
+ax_anim 3, 2, 161, 3, -5, 2, -2,
+ax_anim 3, 0, 163, 3, -6, 2, -2,
+ax_anim 3, 0, 161, 3, -7, 2, -2,
+ax_anim 3, 0, 162, 3, -8, 2, -2,
+ax_anim 3, 0, 161, 3, -8, 2, -2,
+ax_anim 3, 0, 163, 3, -7, 2, -2,
+ax_anim 2, 0, 160, 1, -3, 1, -1,
+ax_anim_terminator
+sSeakingAnims_5_5:
+ax_anim 1, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, -2, 0, -2,
+ax_anim 2, 0, 165, 0, -2, 0, -2,
+ax_anim 2, 0, 166, 0, -2, 0, -2,
+ax_anim 3, 0, 167, 0, -3, 0, -2,
+ax_anim 3, 2, 166, 0, -4, 0, -2,
+ax_anim 3, 0, 168, 0, -5, 0, -2,
+ax_anim 3, 0, 166, 0, -6, 0, -2,
+ax_anim 3, 0, 167, 0, -7, 0, -2,
+ax_anim 3, 0, 166, 0, -7, 0, -2,
+ax_anim 3, 0, 168, 0, -6, 0, -2,
+ax_anim 2, 0, 165, 0, -5, 0, -1,
+ax_anim_terminator
+sSeakingAnims_5_6:
+ax_anim 1, 0, 169, -1, -1, -1, -1,
+ax_anim 2, 0, 169, -2, -2, -2, -2,
+ax_anim 2, 0, 170, -3, -3, -2, -2,
+ax_anim 2, 0, 171, -3, -4, -2, -2,
+ax_anim 3, 0, 172, -3, -4, -2, -2,
+ax_anim 3, 2, 171, -3, -5, -2, -2,
+ax_anim 3, 0, 173, -3, -6, -2, -2,
+ax_anim 3, 0, 171, -3, -7, -2, -2,
+ax_anim 3, 0, 172, -3, -8, -2, -2,
+ax_anim 3, 0, 171, -3, -8, -2, -2,
+ax_anim 3, 0, 173, -3, -7, -2, -2,
+ax_anim 2, 0, 170, -1, -3, -1, -1,
+ax_anim_terminator
+sSeakingAnims_5_7:
+ax_anim 1, 0, 174, -1, 0, -1, 0,
+ax_anim 2, 0, 174, -2, 0, -2, 0,
+ax_anim 2, 0, 175, -3, 0, -3, 0,
+ax_anim 2, 0, 176, -6, 0, -6, 0,
+ax_anim 3, 0, 177, -6, -1, -6, 0,
+ax_anim 3, 2, 176, -6, -2, -6, 0,
+ax_anim 3, 0, 178, -6, -3, -6, 0,
+ax_anim 3, 0, 176, -6, -4, -6, 0,
+ax_anim 3, 0, 177, -6, -5, -6, 0,
+ax_anim 3, 0, 176, -6, -5, -6, 0,
+ax_anim 3, 0, 178, -6, -4, -6, 0,
+ax_anim 2, 0, 175, -3, -3, -2, 0,
+ax_anim_terminator
+sSeakingAnims_5_8:
+ax_anim 1, 0, 179, -1, 1, -1, 1,
+ax_anim 2, 0, 179, -2, 2, -2, 2,
+ax_anim 2, 0, 180, -2, 2, -2, 2,
+ax_anim 2, 0, 181, -2, 2, -2, 2,
+ax_anim 3, 0, 182, -2, 1, -2, 2,
+ax_anim 3, 2, 181, -2, 0, -2, 2,
+ax_anim 3, 0, 183, -2, -1, -2, 2,
+ax_anim 3, 0, 181, -2, -2, -2, 2,
+ax_anim 3, 0, 182, -2, -3, -2, 2,
+ax_anim 3, 0, 181, -2, -3, -2, 2,
+ax_anim 3, 0, 183, -2, -2, -2, 2,
+ax_anim 2, 0, 180, -1, -1, -1, 1,
+ax_anim_terminator
+.align 2
+sSeakingAnims_6_1:
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, -1, 0, 0,
+ax_anim 10, 0, 185, 0, -2, 0, 0,
+ax_anim 10, 0, 185, 0, -1, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sSeakingAnims_7_1:
+ax_anim 2, 0, 186, 0, -2, 0, -2,
+ax_anim 8, 0, 186, 0, -3, 0, -3,
+ax_anim_terminator
+sSeakingAnims_7_2:
+ax_anim 2, 0, 187, -2, -2, -2, -2,
+ax_anim 8, 0, 187, -3, -3, -3, -3,
+ax_anim_terminator
+sSeakingAnims_7_3:
+ax_anim 2, 0, 188, -2, 0, -2, 0,
+ax_anim 8, 0, 188, -3, 0, -3, 0,
+ax_anim_terminator
+sSeakingAnims_7_4:
+ax_anim 2, 0, 189, -2, 2, -2, 2,
+ax_anim 8, 0, 189, -3, 3, -3, 3,
+ax_anim_terminator
+sSeakingAnims_7_5:
+ax_anim 2, 0, 190, 0, 2, 0, 2,
+ax_anim 8, 0, 190, 0, 3, 0, 3,
+ax_anim_terminator
+sSeakingAnims_7_6:
+ax_anim 2, 0, 191, 2, 2, 2, 2,
+ax_anim 8, 0, 191, 3, 3, 3, 3,
+ax_anim_terminator
+sSeakingAnims_7_7:
+ax_anim 2, 0, 192, 2, 0, 2, 0,
+ax_anim 8, 0, 192, 3, 0, 3, 0,
+ax_anim_terminator
+sSeakingAnims_7_8:
+ax_anim 2, 0, 193, 2, -2, 2, -2,
+ax_anim 8, 0, 193, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSeakingAnims_8_1:
+ax_anim 16, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, -1, 0, 0,
+ax_anim 16, 0, 194, 0, -2, 0, 0,
+ax_anim 10, 0, 194, 0, -1, 0, 0,
+ax_anim 16, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, -1, 0, 0,
+ax_anim 16, 0, 194, 0, -2, 0, 0,
+ax_anim 2, 0, 194, 0, -1, 0, 0,
+ax_anim 4, 0, 195, 0, -1, 0, 0,
+ax_anim 4, 0, 194, 0, -1, 0, 0,
+ax_anim 4, 0, 196, 0, 0, 0, 0,
+ax_anim 12, 0, 194, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, -1, 0, 0,
+ax_anim 16, 0, 194, 0, -2, 0, 0,
+ax_anim 10, 0, 194, 0, -1, 0, 0,
+ax_anim_terminator
+sSeakingAnims_8_2:
+ax_anim 16, 0, 197, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, -1, 0, 0,
+ax_anim 16, 0, 197, 0, -2, 0, 0,
+ax_anim 10, 0, 197, 0, -1, 0, 0,
+ax_anim 16, 0, 197, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, -1, 0, 0,
+ax_anim 16, 0, 197, 0, -2, 0, 0,
+ax_anim 2, 0, 197, 0, -1, 0, 0,
+ax_anim 4, 0, 198, 0, -1, 0, 0,
+ax_anim 4, 0, 197, 0, -1, 0, 0,
+ax_anim 4, 0, 199, 0, 0, 0, 0,
+ax_anim 12, 0, 197, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, -1, 0, 0,
+ax_anim 16, 0, 197, 0, -2, 0, 0,
+ax_anim 10, 0, 197, 0, -1, 0, 0,
+ax_anim_terminator
+sSeakingAnims_8_3:
+ax_anim 16, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, -1, 0, 0,
+ax_anim 16, 0, 200, 0, -2, 0, 0,
+ax_anim 10, 0, 200, 0, -1, 0, 0,
+ax_anim 16, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, -1, 0, 0,
+ax_anim 16, 0, 200, 0, -2, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, 0,
+ax_anim 4, 0, 201, 0, -1, 0, 0,
+ax_anim 4, 0, 200, 0, -1, 0, 0,
+ax_anim 4, 0, 202, 0, 0, 0, 0,
+ax_anim 12, 0, 200, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, -1, 0, 0,
+ax_anim 16, 0, 200, 0, -2, 0, 0,
+ax_anim 10, 0, 200, 0, -1, 0, 0,
+ax_anim_terminator
+sSeakingAnims_8_4:
+ax_anim 16, 0, 203, 0, 0, 0, 0,
+ax_anim 10, 0, 203, 0, -1, 0, 0,
+ax_anim 16, 0, 203, 0, -2, 0, 0,
+ax_anim 10, 0, 203, 0, -1, 0, 0,
+ax_anim 16, 0, 203, 0, 0, 0, 0,
+ax_anim 10, 0, 203, 0, -1, 0, 0,
+ax_anim 16, 0, 203, 0, -2, 0, 0,
+ax_anim 2, 0, 203, 0, -1, 0, 0,
+ax_anim 4, 0, 204, 0, -1, 0, 0,
+ax_anim 4, 0, 203, 0, -1, 0, 0,
+ax_anim 4, 0, 205, 0, 0, 0, 0,
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 10, 0, 203, 0, -1, 0, 0,
+ax_anim 16, 0, 203, 0, -2, 0, 0,
+ax_anim 10, 0, 203, 0, -1, 0, 0,
+ax_anim_terminator
+sSeakingAnims_8_5:
+ax_anim 16, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 206, 0, -1, 0, 0,
+ax_anim 16, 0, 206, 0, -2, 0, 0,
+ax_anim 10, 0, 206, 0, -1, 0, 0,
+ax_anim 16, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 206, 0, -1, 0, 0,
+ax_anim 16, 0, 206, 0, -2, 0, 0,
+ax_anim 2, 0, 206, 0, -1, 0, 0,
+ax_anim 4, 0, 207, 0, -1, 0, 0,
+ax_anim 4, 0, 206, 0, -1, 0, 0,
+ax_anim 4, 0, 208, 0, 0, 0, 0,
+ax_anim 12, 0, 206, 0, 0, 0, 0,
+ax_anim 10, 0, 206, 0, -1, 0, 0,
+ax_anim 16, 0, 206, 0, -2, 0, 0,
+ax_anim 10, 0, 206, 0, -1, 0, 0,
+ax_anim_terminator
+sSeakingAnims_8_6:
+ax_anim 16, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, -1, 0, 0,
+ax_anim 16, 0, 209, 0, -2, 0, 0,
+ax_anim 10, 0, 209, 0, -1, 0, 0,
+ax_anim 16, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, -1, 0, 0,
+ax_anim 16, 0, 209, 0, -2, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, 0,
+ax_anim 4, 0, 210, 0, -1, 0, 0,
+ax_anim 4, 0, 209, 0, -1, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 12, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 209, 0, -1, 0, 0,
+ax_anim 16, 0, 209, 0, -2, 0, 0,
+ax_anim 10, 0, 209, 0, -1, 0, 0,
+ax_anim_terminator
+sSeakingAnims_8_7:
+ax_anim 16, 0, 212, 0, 0, 0, 0,
+ax_anim 10, 0, 212, 0, -1, 0, 0,
+ax_anim 16, 0, 212, 0, -2, 0, 0,
+ax_anim 10, 0, 212, 0, -1, 0, 0,
+ax_anim 16, 0, 212, 0, 0, 0, 0,
+ax_anim 10, 0, 212, 0, -1, 0, 0,
+ax_anim 16, 0, 212, 0, -2, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, 0,
+ax_anim 4, 0, 213, 0, -1, 0, 0,
+ax_anim 4, 0, 212, 0, -1, 0, 0,
+ax_anim 4, 0, 214, 0, 0, 0, 0,
+ax_anim 12, 0, 212, 0, 0, 0, 0,
+ax_anim 10, 0, 212, 0, -1, 0, 0,
+ax_anim 16, 0, 212, 0, -2, 0, 0,
+ax_anim 10, 0, 212, 0, -1, 0, 0,
+ax_anim_terminator
+sSeakingAnims_8_8:
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 215, 0, -1, 0, 0,
+ax_anim 16, 0, 215, 0, -2, 0, 0,
+ax_anim 10, 0, 215, 0, -1, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 215, 0, -1, 0, 0,
+ax_anim 16, 0, 215, 0, -2, 0, 0,
+ax_anim 2, 0, 215, 0, -1, 0, 0,
+ax_anim 4, 0, 216, 0, -1, 0, 0,
+ax_anim 4, 0, 215, 0, -1, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 10, 0, 215, 0, -1, 0, 0,
+ax_anim 16, 0, 215, 0, -2, 0, 0,
+ax_anim 10, 0, 215, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSeakingAnims_9_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 6, 3, 6, 3,
+ax_anim 2, 0, 220, 8, 9, 8, 9,
+ax_anim 2, 0, 221, 7, 17, 7, 17,
+ax_anim 3, 0, 222, 0, 20, 0, 20,
+ax_anim 2, 3, 223, -7, 17, -7, 17,
+ax_anim 2, 0, 224, -8, 9, -8, 9,
+ax_anim 1, 0, 225, -6, 3, -6, 3,
+ax_anim 1, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_9_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 8, 0, 8, 0,
+ax_anim 2, 0, 219, 17, 3, 17, 3,
+ax_anim 2, 0, 220, 19, 12, 19, 12,
+ax_anim 3, 0, 221, 18, 20, 18, 20,
+ax_anim 2, 3, 222, 11, 20, 11, 20,
+ax_anim 2, 0, 223, 3, 15, 3, 15,
+ax_anim 1, 0, 224, 0, 7, 0, 7,
+ax_anim 1, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_9_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 3, -5, 3, -5,
+ax_anim 2, 0, 218, 9, -6, 9, -6,
+ax_anim 2, 0, 219, 14, -5, 14, -5,
+ax_anim 3, 0, 220, 17, 2, 17, 0,
+ax_anim 2, 3, 221, 15, 7, 15, 5,
+ax_anim 2, 0, 222, 9, 8, 9, 6,
+ax_anim 1, 0, 223, 4, 5, 4, 5,
+ax_anim 1, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_9_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, -1, -8, -1, -8,
+ax_anim 2, 0, 225, 4, -16, 4, -16,
+ax_anim 2, 0, 218, 12, -20, 12, -20,
+ax_anim 3, 0, 219, 18, -16, 18, -18,
+ax_anim 2, 3, 220, 20, -9, 20, -10,
+ax_anim 2, 0, 221, 17, -4, 17, -4,
+ax_anim 1, 0, 222, 7, -1, 7, -1,
+ax_anim 1, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_9_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, -8, -4, -8, -4,
+ax_anim 2, 0, 224, -9, -10, -9, -11,
+ax_anim 2, 0, 225, -7, -15, -7, -16,
+ax_anim 3, 0, 218, 0, -17, 0, -19,
+ax_anim 2, 3, 219, 7, -15, 7, -16,
+ax_anim 2, 0, 220, 9, -8, 9, -9,
+ax_anim 1, 0, 221, 8, -4, 8, -4,
+ax_anim 1, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_9_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, -8, 1, -8,
+ax_anim 2, 0, 219, -4, -16, -4, -16,
+ax_anim 2, 0, 218, -12, -20, -12, -20,
+ax_anim 3, 0, 225, -18, -16, -18, -18,
+ax_anim 2, 3, 224, -20, -9, -20, -11,
+ax_anim 2, 0, 223, -17, -4, -17, -4,
+ax_anim 1, 0, 222, -7, -1, -7, -1,
+ax_anim 1, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_9_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 219, -3, -5, -3, -5,
+ax_anim 2, 0, 218, -9, -6, -9, -6,
+ax_anim 2, 0, 225, -14, -5, -14, -5,
+ax_anim 3, 0, 224, -17, 2, -17, 0,
+ax_anim 2, 3, 223, -15, 7, -15, 5,
+ax_anim 2, 0, 222, -9, 8, -9, 6,
+ax_anim 1, 0, 221, -4, 5, -4, 5,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_9_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 218, -8, 0, -8, 0,
+ax_anim 2, 0, 225, -17, 3, -17, 3,
+ax_anim 2, 0, 224, -19, 12, -19, 12,
+ax_anim 3, 0, 223, -18, 20, -18, 20,
+ax_anim 2, 3, 222, -11, 20, -11, 20,
+ax_anim 2, 0, 221, -3, 15, -3, 15,
+ax_anim 1, 0, 220, 0, 7, 0, 7,
+ax_anim 1, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeakingAnims_10_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 3, 0, 226, 13, 0, 13, 0,
+ax_anim 3, 0, 226, -13, 0, -13, 0,
+ax_anim 2, 0, 226, 12, 0, 12, 0,
+ax_anim 3, 0, 226, -12, 0, -12, 0,
+ax_anim 2, 0, 226, 10, 0, 10, 0,
+ax_anim 2, 0, 226, -10, 0, -10, 0,
+ax_anim 2, 0, 226, 6, 0, 6, 0,
+ax_anim 2, 0, 226, -6, 0, -6, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_10_2:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 3, 0, 227, 13, -13, 13, -13,
+ax_anim 3, 0, 227, -13, 13, -13, 13,
+ax_anim 2, 0, 227, 12, -12, 12, -12,
+ax_anim 3, 0, 227, -12, 12, -12, 12,
+ax_anim 2, 0, 227, 10, -10, 10, -10,
+ax_anim 2, 0, 227, -10, 10, -10, 10,
+ax_anim 2, 0, 227, 6, -6, 6, -6,
+ax_anim 2, 0, 227, -6, 6, -6, 6,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_10_3:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 3, 0, 228, 0, -13, 0, -13,
+ax_anim 3, 0, 228, 0, 13, 0, 13,
+ax_anim 2, 0, 228, 0, -12, 0, -12,
+ax_anim 3, 0, 228, 0, 12, 0, 12,
+ax_anim 2, 0, 228, 0, -10, 0, -10,
+ax_anim 2, 0, 228, 0, 10, 0, 10,
+ax_anim 2, 0, 228, 0, -6, 0, -6,
+ax_anim 2, 0, 228, 0, 6, 0, 6,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_10_4:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 3, 0, 229, -13, -13, -13, -13,
+ax_anim 3, 0, 229, 13, 13, 13, 13,
+ax_anim 2, 0, 229, -12, -12, -12, -12,
+ax_anim 3, 0, 229, 12, 12, 12, 12,
+ax_anim 2, 0, 229, -10, -10, -10, -10,
+ax_anim 2, 0, 229, 10, 10, 10, 10,
+ax_anim 2, 0, 229, -6, -6, -6, -6,
+ax_anim 2, 0, 229, 6, 6, 6, 6,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_10_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 3, 0, 230, 13, 0, 13, 0,
+ax_anim 3, 0, 230, -13, 0, -13, 0,
+ax_anim 2, 0, 230, 12, 0, 12, 0,
+ax_anim 3, 0, 230, -12, 0, -12, 0,
+ax_anim 2, 0, 230, 10, 0, 10, 0,
+ax_anim 2, 0, 230, -10, 0, -10, 0,
+ax_anim 2, 0, 230, 6, 0, 6, 0,
+ax_anim 2, 0, 230, -6, 0, -6, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_10_6:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 3, 0, 231, 13, -13, 13, -13,
+ax_anim 3, 0, 231, -13, 13, -13, 13,
+ax_anim 2, 0, 231, 12, -12, 12, -12,
+ax_anim 3, 0, 231, -12, 12, -12, 12,
+ax_anim 2, 0, 231, 10, -10, 10, -10,
+ax_anim 2, 0, 231, -10, 10, -10, 10,
+ax_anim 2, 0, 231, 6, -6, 6, -6,
+ax_anim 2, 0, 231, -6, 6, -6, 6,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_10_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 3, 0, 232, 0, -13, 0, -13,
+ax_anim 3, 0, 232, 0, 13, 0, 13,
+ax_anim 2, 0, 232, 0, -12, 0, -12,
+ax_anim 3, 0, 232, 0, 12, 0, 12,
+ax_anim 2, 0, 232, 0, -10, 0, -10,
+ax_anim 2, 0, 232, 0, 10, 0, 10,
+ax_anim 2, 0, 232, 0, -6, 0, -6,
+ax_anim 2, 0, 232, 0, 6, 0, 6,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_10_8:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 3, 0, 233, -13, -13, -13, -13,
+ax_anim 3, 0, 233, 13, 13, 13, 13,
+ax_anim 2, 0, 233, -12, -12, -12, -12,
+ax_anim 3, 0, 233, 12, 12, 12, 12,
+ax_anim 2, 0, 233, -10, -10, -10, -10,
+ax_anim 2, 0, 233, 10, 10, 10, 10,
+ax_anim 2, 0, 233, -6, -6, -6, -6,
+ax_anim 2, 0, 233, 6, 6, 6, 6,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeakingAnims_11_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -23, 0, 0,
+ax_anim 3, 0, 236, 0, -22, 0, 0,
+ax_anim 2, 0, 236, 0, -18, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 2, 234, 0, 5, 0, 0,
+ax_anim_terminator
+sSeakingAnims_11_2:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 0, -10, 0, 0,
+ax_anim 2, 0, 238, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 4, 0, 238, 0, -21, 0, 0,
+ax_anim 4, 0, 237, 0, -23, 0, 0,
+ax_anim 3, 0, 239, 0, -22, 0, 0,
+ax_anim 2, 0, 239, 0, -18, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 2, 237, 0, 5, 0, 0,
+ax_anim_terminator
+sSeakingAnims_11_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 240, -1, -23, 0, 0,
+ax_anim 3, 0, 242, 0, -22, 0, 0,
+ax_anim 2, 0, 242, 0, -18, 0, 0,
+ax_anim 1, 0, 242, 0, -10, 0, 0,
+ax_anim 2, 2, 240, 0, 5, 0, 0,
+ax_anim_terminator
+sSeakingAnims_11_4:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 244, 0, -10, 0, 0,
+ax_anim 2, 0, 244, 0, -16, 0, 0,
+ax_anim 3, 0, 244, 0, -20, 0, 0,
+ax_anim 4, 0, 244, 0, -21, 0, 0,
+ax_anim 4, 0, 243, 0, -22, 0, 0,
+ax_anim 3, 0, 245, 0, -21, 0, 0,
+ax_anim 2, 0, 245, 0, -17, 0, 0,
+ax_anim 1, 0, 245, 0, -9, 0, 0,
+ax_anim 2, 2, 243, 0, 5, 0, 0,
+ax_anim_terminator
+sSeakingAnims_11_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 247, 0, -10, 0, 0,
+ax_anim 2, 0, 247, 0, -16, 0, 0,
+ax_anim 3, 0, 247, 0, -20, 0, 0,
+ax_anim 4, 0, 247, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -23, 0, 0,
+ax_anim 3, 0, 248, 0, -22, 0, 0,
+ax_anim 2, 0, 248, 0, -18, 0, 0,
+ax_anim 1, 0, 248, 0, -10, 0, 0,
+ax_anim 2, 2, 246, 0, 5, 0, 0,
+ax_anim_terminator
+sSeakingAnims_11_6:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 250, 0, -10, 0, 0,
+ax_anim 2, 0, 250, 0, -16, 0, 0,
+ax_anim 3, 0, 250, 0, -20, 0, 0,
+ax_anim 4, 0, 250, 0, -21, 0, 0,
+ax_anim 4, 0, 249, 0, -22, 0, 0,
+ax_anim 3, 0, 251, 0, -21, 0, 0,
+ax_anim 2, 0, 251, 0, -17, 0, 0,
+ax_anim 1, 0, 251, 0, -9, 0, 0,
+ax_anim 2, 2, 249, 0, 5, 0, 0,
+ax_anim_terminator
+sSeakingAnims_11_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 253, 0, -10, 0, 0,
+ax_anim 2, 0, 253, 0, -16, 0, 0,
+ax_anim 3, 0, 253, 0, -20, 0, 0,
+ax_anim 4, 0, 253, 0, -21, 0, 0,
+ax_anim 4, 0, 252, 1, -23, 0, 0,
+ax_anim 3, 0, 254, 0, -22, 0, 0,
+ax_anim 2, 0, 254, 0, -18, 0, 0,
+ax_anim 1, 0, 254, 0, -10, 0, 0,
+ax_anim 2, 2, 252, 0, 5, 0, 0,
+ax_anim_terminator
+sSeakingAnims_11_8:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 1, 0, 256, 0, -10, 0, 0,
+ax_anim 2, 0, 256, 0, -16, 0, 0,
+ax_anim 3, 0, 256, 0, -20, 0, 0,
+ax_anim 4, 0, 256, 0, -21, 0, 0,
+ax_anim 4, 0, 255, 0, -23, 0, 0,
+ax_anim 3, 0, 257, 0, -22, 0, 0,
+ax_anim 2, 0, 257, 0, -18, 0, 0,
+ax_anim 1, 0, 257, 0, -10, 0, 0,
+ax_anim 2, 2, 255, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sSeakingAnims_12_1:
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 0, 1, 0,
+ax_anim 2, 1, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_12_2:
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 1, -1, 1, -1,
+ax_anim 2, 1, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_12_3:
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -1, 0, -1,
+ax_anim 2, 1, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_12_4:
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, -1, -1, -1, -1,
+ax_anim 2, 1, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_12_5:
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 1, 0, 1, 0,
+ax_anim 2, 1, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_12_6:
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 1, -1, 1, -1,
+ax_anim 2, 1, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_12_7:
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -1, 0, -1,
+ax_anim 2, 1, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_12_8:
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, -1, -1, -1, -1,
+ax_anim 2, 1, 259, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeakingAnims_13_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_13_2:
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_13_3:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 2, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_13_4:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_13_5:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_13_6:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_13_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingAnims_13_8:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sSeakingGfx1:
+.incbin "baserom.gba", 0xA1E768, 0x200
+sSeakingSprites1:
+ax_sprite sSeakingGfx1, 0x200
+ax_sprite_terminator
+sSeakingGfx2:
+.incbin "baserom.gba", 0xA1E978, 0x200
+sSeakingSprites2:
+ax_sprite sSeakingGfx2, 0x200
+ax_sprite_terminator
+sSeakingGfx3:
+.incbin "baserom.gba", 0xA1EB88, 0x200
+sSeakingSprites3:
+ax_sprite sSeakingGfx3, 0x200
+ax_sprite_terminator
+sSeakingGfx4:
+.incbin "baserom.gba", 0xA1ED98, 0x200
+sSeakingSprites4:
+ax_sprite sSeakingGfx4, 0x200
+ax_sprite_terminator
+sSeakingGfx5:
+.incbin "baserom.gba", 0xA1EFA8, 0x200
+sSeakingSprites5:
+ax_sprite sSeakingGfx5, 0x200
+ax_sprite_terminator
+sSeakingGfx6:
+.incbin "baserom.gba", 0xA1F1B8, 0x200
+sSeakingSprites6:
+ax_sprite sSeakingGfx6, 0x200
+ax_sprite_terminator
+sSeakingGfx7:
+.incbin "baserom.gba", 0xA1F3C8, 0x200
+sSeakingSprites7:
+ax_sprite sSeakingGfx7, 0x200
+ax_sprite_terminator
+sSeakingGfx8:
+.incbin "baserom.gba", 0xA1F5D8, 0x200
+sSeakingSprites8:
+ax_sprite sSeakingGfx8, 0x200
+ax_sprite_terminator
+sSeakingGfx9:
+.incbin "baserom.gba", 0xA1F7E8, 0x200
+sSeakingSprites9:
+ax_sprite sSeakingGfx9, 0x200
+ax_sprite_terminator
+sSeakingGfx10:
+.incbin "baserom.gba", 0xA1F9F8, 0x200
+sSeakingSprites10:
+ax_sprite sSeakingGfx10, 0x200
+ax_sprite_terminator
+sSeakingGfx11:
+.incbin "baserom.gba", 0xA1FC08, 0x200
+sSeakingSprites11:
+ax_sprite sSeakingGfx11, 0x200
+ax_sprite_terminator
+sSeakingGfx12:
+.incbin "baserom.gba", 0xA1FE18, 0x200
+sSeakingSprites12:
+ax_sprite sSeakingGfx12, 0x200
+ax_sprite_terminator
+sSeakingGfx13:
+.incbin "baserom.gba", 0xA20028, 0x200
+sSeakingSprites13:
+ax_sprite sSeakingGfx13, 0x200
+ax_sprite_terminator
+sSeakingGfx14:
+.incbin "baserom.gba", 0xA20238, 0x200
+sSeakingSprites14:
+ax_sprite sSeakingGfx14, 0x200
+ax_sprite_terminator
+sSeakingGfx15:
+.incbin "baserom.gba", 0xA20448, 0x200
+sSeakingSprites15:
+ax_sprite sSeakingGfx15, 0x200
+ax_sprite_terminator
+sSeakingGfx16:
+.incbin "baserom.gba", 0xA20658, 0x180
+sSeakingGfx16_1:
+.incbin "baserom.gba", 0xA207D8, 0x40
+sSeakingSprites16:
+ax_sprite sSeakingGfx16, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx17:
+.incbin "baserom.gba", 0xA20840, 0x180
+sSeakingGfx17_1:
+.incbin "baserom.gba", 0xA209C0, 0x40
+sSeakingSprites17:
+ax_sprite sSeakingGfx17, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx18:
+.incbin "baserom.gba", 0xA20A28, 0x40
+sSeakingGfx18_1:
+.incbin "baserom.gba", 0xA20A68, 0x160
+sSeakingSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx18_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx19:
+.incbin "baserom.gba", 0xA20BF8, 0x1C0
+sSeakingSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx19, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx20:
+.incbin "baserom.gba", 0xA20DD8, 0x1A0
+sSeakingSprites20:
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx20, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx21:
+.incbin "baserom.gba", 0xA20F98, 0x1A0
+sSeakingSprites21:
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx21, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx22:
+.incbin "baserom.gba", 0xA21158, 0x40
+sSeakingGfx22_1:
+.incbin "baserom.gba", 0xA21198, 0x160
+sSeakingSprites22:
+ax_sprite sSeakingGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx23:
+.incbin "baserom.gba", 0xA21320, 0x40
+sSeakingGfx23_1:
+.incbin "baserom.gba", 0xA21360, 0x100
+sSeakingGfx23_2:
+.incbin "baserom.gba", 0xA21460, 0x40
+sSeakingSprites23:
+ax_sprite sSeakingGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx24:
+.incbin "baserom.gba", 0xA214D8, 0x40
+sSeakingGfx24_1:
+.incbin "baserom.gba", 0xA21518, 0x60
+sSeakingGfx24_2:
+.incbin "baserom.gba", 0xA21578, 0x80
+sSeakingGfx24_3:
+.incbin "baserom.gba", 0xA215F8, 0x40
+sSeakingSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx24_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx25:
+.incbin "baserom.gba", 0xA21688, 0x40
+sSeakingGfx25_1:
+.incbin "baserom.gba", 0xA216C8, 0x60
+sSeakingGfx25_2:
+.incbin "baserom.gba", 0xA21728, 0x80
+sSeakingGfx25_3:
+.incbin "baserom.gba", 0xA217A8, 0x40
+sSeakingSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx26:
+.incbin "baserom.gba", 0xA21838, 0x40
+sSeakingGfx26_1:
+.incbin "baserom.gba", 0xA21878, 0x100
+sSeakingGfx26_2:
+.incbin "baserom.gba", 0xA21978, 0x40
+sSeakingSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx27:
+.incbin "baserom.gba", 0xA219F8, 0x180
+sSeakingGfx27_1:
+.incbin "baserom.gba", 0xA21B78, 0x40
+sSeakingSprites27:
+ax_sprite sSeakingGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx28:
+.incbin "baserom.gba", 0xA21BE0, 0x40
+sSeakingGfx28_1:
+.incbin "baserom.gba", 0xA21C20, 0x100
+sSeakingGfx28_2:
+.incbin "baserom.gba", 0xA21D20, 0x20
+sSeakingSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx28_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx28_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx29:
+.incbin "baserom.gba", 0xA21D80, 0x40
+sSeakingGfx29_1:
+.incbin "baserom.gba", 0xA21DC0, 0x140
+sSeakingSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx29_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeakingGfx30:
+.incbin "baserom.gba", 0xA21F30, 0x40
+sSeakingGfx30_1:
+.incbin "baserom.gba", 0xA21F70, 0x100
+sSeakingGfx30_2:
+.incbin "baserom.gba", 0xA22070, 0x40
+sSeakingSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx30_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx30_2, 0x40
+ax_sprite_terminator
+sSeakingGfx31:
+.incbin "baserom.gba", 0xA220E8, 0x160
+sSeakingSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx31, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSeakingGfx32:
+.incbin "baserom.gba", 0xA22268, 0x40
+sSeakingGfx32_1:
+.incbin "baserom.gba", 0xA222A8, 0x60
+sSeakingGfx32_2:
+.incbin "baserom.gba", 0xA22308, 0x80
+sSeakingGfx32_3:
+.incbin "baserom.gba", 0xA22388, 0x60
+sSeakingSprites32:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx32_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx32_3, 0x60
+ax_sprite_terminator
+sSeakingGfx33:
+.incbin "baserom.gba", 0xA22430, 0x40
+sSeakingGfx33_1:
+.incbin "baserom.gba", 0xA22470, 0x100
+sSeakingGfx33_2:
+.incbin "baserom.gba", 0xA22570, 0x40
+sSeakingSprites33:
+ax_sprite sSeakingGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx33_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx33_2, 0x40
+ax_sprite_terminator
+sSeakingGfx34:
+.incbin "baserom.gba", 0xA225E0, 0x40
+sSeakingGfx34_1:
+.incbin "baserom.gba", 0xA22620, 0x180
+sSeakingSprites34:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx34_1, 0x180
+ax_sprite_terminator
+sSeakingGfx35:
+.incbin "baserom.gba", 0xA227C8, 0x40
+sSeakingGfx35_1:
+.incbin "baserom.gba", 0xA22808, 0x60
+sSeakingGfx35_2:
+.incbin "baserom.gba", 0xA22868, 0xE0
+sSeakingSprites35:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx35_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx36:
+.incbin "baserom.gba", 0xA22988, 0x40
+sSeakingGfx36_1:
+.incbin "baserom.gba", 0xA229C8, 0x180
+sSeakingSprites36:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx36_1, 0x180
+ax_sprite_terminator
+sSeakingGfx37:
+.incbin "baserom.gba", 0xA22B70, 0x40
+sSeakingGfx37_1:
+.incbin "baserom.gba", 0xA22BB0, 0x160
+sSeakingSprites37:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx37_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx38:
+.incbin "baserom.gba", 0xA22D40, 0x40
+sSeakingGfx38_1:
+.incbin "baserom.gba", 0xA22D80, 0x100
+sSeakingGfx38_2:
+.incbin "baserom.gba", 0xA22E80, 0x60
+sSeakingSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx38_2, 0x60
+ax_sprite_terminator
+sSeakingGfx39:
+.incbin "baserom.gba", 0xA22F18, 0xE0
+sSeakingGfx39_1:
+.incbin "baserom.gba", 0xA22FF8, 0x60
+sSeakingGfx39_2:
+.incbin "baserom.gba", 0xA23058, 0x40
+sSeakingSprites39:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx39, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx39_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx40:
+.incbin "baserom.gba", 0xA230D8, 0x40
+sSeakingGfx40_1:
+.incbin "baserom.gba", 0xA23118, 0x80
+sSeakingGfx40_2:
+.incbin "baserom.gba", 0xA23198, 0x60
+sSeakingGfx40_3:
+.incbin "baserom.gba", 0xA231F8, 0x40
+sSeakingSprites40:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx40_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx40_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx41:
+.incbin "baserom.gba", 0xA23288, 0xE0
+sSeakingGfx41_1:
+.incbin "baserom.gba", 0xA23368, 0x60
+sSeakingGfx41_2:
+.incbin "baserom.gba", 0xA233C8, 0x60
+sSeakingSprites41:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx41, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx41_2, 0x60
+ax_sprite_terminator
+sSeakingGfx42:
+.incbin "baserom.gba", 0xA23460, 0x40
+sSeakingGfx42_1:
+.incbin "baserom.gba", 0xA234A0, 0x60
+sSeakingGfx42_2:
+.incbin "baserom.gba", 0xA23500, 0x60
+sSeakingGfx42_3:
+.incbin "baserom.gba", 0xA23560, 0x60
+sSeakingSprites42:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx42, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx42_3, 0x60
+ax_sprite_terminator
+sSeakingGfx43:
+.incbin "baserom.gba", 0xA23608, 0x40
+sSeakingGfx43_1:
+.incbin "baserom.gba", 0xA23648, 0x60
+sSeakingGfx43_2:
+.incbin "baserom.gba", 0xA236A8, 0x60
+sSeakingGfx43_3:
+.incbin "baserom.gba", 0xA23708, 0x60
+sSeakingSprites43:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx43_3, 0x60
+ax_sprite_terminator
+sSeakingGfx44:
+.incbin "baserom.gba", 0xA237B0, 0x40
+sSeakingGfx44_1:
+.incbin "baserom.gba", 0xA237F0, 0x60
+sSeakingGfx44_2:
+.incbin "baserom.gba", 0xA23850, 0x40
+sSeakingGfx44_3:
+.incbin "baserom.gba", 0xA23890, 0x40
+sSeakingSprites44:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx44_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx45:
+.incbin "baserom.gba", 0xA23920, 0x40
+sSeakingGfx45_1:
+.incbin "baserom.gba", 0xA23960, 0x60
+sSeakingGfx45_2:
+.incbin "baserom.gba", 0xA239C0, 0x60
+sSeakingGfx45_3:
+.incbin "baserom.gba", 0xA23A20, 0x60
+sSeakingSprites45:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx45_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx45_3, 0x60
+ax_sprite_terminator
+sSeakingGfx46:
+.incbin "baserom.gba", 0xA23AC8, 0x40
+sSeakingGfx46_1:
+.incbin "baserom.gba", 0xA23B08, 0x60
+sSeakingGfx46_2:
+.incbin "baserom.gba", 0xA23B68, 0x60
+sSeakingGfx46_3:
+.incbin "baserom.gba", 0xA23BC8, 0x60
+sSeakingSprites46:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx46_3, 0x60
+ax_sprite_terminator
+sSeakingGfx47:
+.incbin "baserom.gba", 0xA23C70, 0x40
+sSeakingGfx47_1:
+.incbin "baserom.gba", 0xA23CB0, 0x60
+sSeakingGfx47_2:
+.incbin "baserom.gba", 0xA23D10, 0x60
+sSeakingGfx47_3:
+.incbin "baserom.gba", 0xA23D70, 0x60
+sSeakingSprites47:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx47, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx47_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx47_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx48:
+.incbin "baserom.gba", 0xA23E20, 0x40
+sSeakingGfx48_1:
+.incbin "baserom.gba", 0xA23E60, 0x180
+sSeakingSprites48:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx48_1, 0x180
+ax_sprite_terminator
+sSeakingGfx49:
+.incbin "baserom.gba", 0xA24008, 0x40
+sSeakingGfx49_1:
+.incbin "baserom.gba", 0xA24048, 0x60
+sSeakingGfx49_2:
+.incbin "baserom.gba", 0xA240A8, 0x60
+sSeakingGfx49_3:
+.incbin "baserom.gba", 0xA24108, 0x60
+sSeakingSprites49:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx49, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeakingGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx49_3, 0x60
+ax_sprite_terminator
+sSeakingGfx50:
+.incbin "baserom.gba", 0xA241B0, 0x40
+sSeakingGfx50_1:
+.incbin "baserom.gba", 0xA241F0, 0x60
+sSeakingGfx50_2:
+.incbin "baserom.gba", 0xA24250, 0x60
+sSeakingGfx50_3:
+.incbin "baserom.gba", 0xA242B0, 0x60
+sSeakingSprites50:
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx50, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeakingGfx50_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeakingGfx51:
+.incbin "baserom.gba", 0xA24360, 0x200
+sSeakingSprites51:
+ax_sprite sSeakingGfx51, 0x200
+ax_sprite_terminator
+sSeakingGfx52:
+.incbin "baserom.gba", 0xA24570, 0x200
+sSeakingSprites52:
+ax_sprite sSeakingGfx52, 0x200
+ax_sprite_terminator
+sSeakingGfx53:
+.incbin "baserom.gba", 0xA24780, 0x200
+sSeakingSprites53:
+ax_sprite sSeakingGfx53, 0x200
+ax_sprite_terminator
+sSeakingGfx54:
+.incbin "baserom.gba", 0xA24990, 0x200
+sSeakingSprites54:
+ax_sprite sSeakingGfx54, 0x200
+ax_sprite_terminator
+sSeakingGfx55:
+.incbin "baserom.gba", 0xA24BA0, 0x200
+sSeakingSprites55:
+ax_sprite sSeakingGfx55, 0x200
+ax_sprite_terminator
+sSeakingGfx56:
+.incbin "baserom.gba", 0xA24DB0, 0x200
+sSeakingSprites56:
+ax_sprite sSeakingGfx56, 0x200
+ax_sprite_terminator
+sSeakingGfx57:
+.incbin "baserom.gba", 0xA24FC0, 0x200
+sSeakingSprites57:
+ax_sprite sSeakingGfx57, 0x200
+ax_sprite_terminator
+sAxPosesSeaking:
+.4byte sSeakingPose1
+.4byte sSeakingPose2
+.4byte sSeakingPose3
+.4byte sSeakingPose4
+.4byte sSeakingPose5
+.4byte sSeakingPose6
+.4byte sSeakingPose7
+.4byte sSeakingPose8
+.4byte sSeakingPose9
+.4byte sSeakingPose10
+.4byte sSeakingPose11
+.4byte sSeakingPose12
+.4byte sSeakingPose13
+.4byte sSeakingPose14
+.4byte sSeakingPose15
+.4byte sSeakingPose16
+.4byte sSeakingPose17
+.4byte sSeakingPose18
+.4byte sSeakingPose19
+.4byte sSeakingPose20
+.4byte sSeakingPose21
+.4byte sSeakingPose22
+.4byte sSeakingPose23
+.4byte sSeakingPose24
+.4byte sSeakingPose25
+.4byte sSeakingPose26
+.4byte sSeakingPose27
+.4byte sSeakingPose28
+.4byte sSeakingPose29
+.4byte sSeakingPose30
+.4byte sSeakingPose31
+.4byte sSeakingPose32
+.4byte sSeakingPose33
+.4byte sSeakingPose34
+.4byte sSeakingPose35
+.4byte sSeakingPose36
+.4byte sSeakingPose37
+.4byte sSeakingPose38
+.4byte sSeakingPose39
+.4byte sSeakingPose40
+.4byte sSeakingPose41
+.4byte sSeakingPose42
+.4byte sSeakingPose43
+.4byte sSeakingPose44
+.4byte sSeakingPose45
+.4byte sSeakingPose46
+.4byte sSeakingPose47
+.4byte sSeakingPose48
+.4byte sSeakingPose49
+.4byte sSeakingPose50
+.4byte sSeakingPose51
+.4byte sSeakingPose52
+.4byte sSeakingPose53
+.4byte sSeakingPose54
+.4byte sSeakingPose55
+.4byte sSeakingPose56
+.4byte sSeakingPose57
+.4byte sSeakingPose58
+.4byte sSeakingPose59
+.4byte sSeakingPose60
+.4byte sSeakingPose61
+.4byte sSeakingPose62
+.4byte sSeakingPose63
+.4byte sSeakingPose64
+.4byte sSeakingPose65
+.4byte sSeakingPose66
+.4byte sSeakingPose67
+.4byte sSeakingPose68
+.4byte sSeakingPose69
+.4byte sSeakingPose70
+.4byte sSeakingPose71
+.4byte sSeakingPose72
+.4byte sSeakingPose73
+.4byte sSeakingPose74
+.4byte sSeakingPose75
+.4byte sSeakingPose76
+.4byte sSeakingPose77
+.4byte sSeakingPose78
+.4byte sSeakingPose79
+.4byte sSeakingPose80
+.4byte sSeakingPose81
+.4byte sSeakingPose82
+.4byte sSeakingPose83
+.4byte sSeakingPose84
+.4byte sSeakingPose85
+.4byte sSeakingPose86
+.4byte sSeakingPose87
+.4byte sSeakingPose88
+.4byte sSeakingPose89
+.4byte sSeakingPose90
+.4byte sSeakingPose91
+.4byte sSeakingPose92
+.4byte sSeakingPose93
+.4byte sSeakingPose94
+.4byte sSeakingPose95
+.4byte sSeakingPose96
+.4byte sSeakingPose97
+.4byte sSeakingPose98
+.4byte sSeakingPose99
+.4byte sSeakingPose100
+.4byte sSeakingPose101
+.4byte sSeakingPose102
+.4byte sSeakingPose103
+.4byte sSeakingPose104
+.4byte sSeakingPose105
+.4byte sSeakingPose106
+.4byte sSeakingPose107
+.4byte sSeakingPose108
+.4byte sSeakingPose109
+.4byte sSeakingPose110
+.4byte sSeakingPose111
+.4byte sSeakingPose112
+.4byte sSeakingPose113
+.4byte sSeakingPose114
+.4byte sSeakingPose115
+.4byte sSeakingPose116
+.4byte sSeakingPose117
+.4byte sSeakingPose118
+.4byte sSeakingPose119
+.4byte sSeakingPose120
+.4byte sSeakingPose121
+.4byte sSeakingPose122
+.4byte sSeakingPose123
+.4byte sSeakingPose124
+.4byte sSeakingPose125
+.4byte sSeakingPose126
+.4byte sSeakingPose127
+.4byte sSeakingPose128
+.4byte sSeakingPose129
+.4byte sSeakingPose130
+.4byte sSeakingPose131
+.4byte sSeakingPose132
+.4byte sSeakingPose133
+.4byte sSeakingPose134
+.4byte sSeakingPose135
+.4byte sSeakingPose136
+.4byte sSeakingPose137
+.4byte sSeakingPose138
+.4byte sSeakingPose139
+.4byte sSeakingPose140
+.4byte sSeakingPose141
+.4byte sSeakingPose142
+.4byte sSeakingPose143
+.4byte sSeakingPose144
+.4byte sSeakingPose145
+.4byte sSeakingPose146
+.4byte sSeakingPose147
+.4byte sSeakingPose148
+.4byte sSeakingPose149
+.4byte sSeakingPose150
+.4byte sSeakingPose151
+.4byte sSeakingPose152
+.4byte sSeakingPose153
+.4byte sSeakingPose154
+.4byte sSeakingPose155
+.4byte sSeakingPose156
+.4byte sSeakingPose157
+.4byte sSeakingPose158
+.4byte sSeakingPose159
+.4byte sSeakingPose160
+.4byte sSeakingPose161
+.4byte sSeakingPose162
+.4byte sSeakingPose163
+.4byte sSeakingPose164
+.4byte sSeakingPose165
+.4byte sSeakingPose166
+.4byte sSeakingPose167
+.4byte sSeakingPose168
+.4byte sSeakingPose169
+.4byte sSeakingPose170
+.4byte sSeakingPose171
+.4byte sSeakingPose172
+.4byte sSeakingPose173
+.4byte sSeakingPose174
+.4byte sSeakingPose175
+.4byte sSeakingPose176
+.4byte sSeakingPose177
+.4byte sSeakingPose178
+.4byte sSeakingPose179
+.4byte sSeakingPose180
+.4byte sSeakingPose181
+.4byte sSeakingPose182
+.4byte sSeakingPose183
+.4byte sSeakingPose184
+.4byte sSeakingPose185
+.4byte sSeakingPose186
+.4byte sSeakingPose187
+.4byte sSeakingPose188
+.4byte sSeakingPose189
+.4byte sSeakingPose190
+.4byte sSeakingPose191
+.4byte sSeakingPose192
+.4byte sSeakingPose193
+.4byte sSeakingPose194
+.4byte sSeakingPose195
+.4byte sSeakingPose196
+.4byte sSeakingPose197
+.4byte sSeakingPose198
+.4byte sSeakingPose199
+.4byte sSeakingPose200
+.4byte sSeakingPose201
+.4byte sSeakingPose202
+.4byte sSeakingPose203
+.4byte sSeakingPose204
+.4byte sSeakingPose205
+.4byte sSeakingPose206
+.4byte sSeakingPose207
+.4byte sSeakingPose208
+.4byte sSeakingPose209
+.4byte sSeakingPose210
+.4byte sSeakingPose211
+.4byte sSeakingPose212
+.4byte sSeakingPose213
+.4byte sSeakingPose214
+.4byte sSeakingPose215
+.4byte sSeakingPose216
+.4byte sSeakingPose217
+.4byte sSeakingPose218
+.4byte sSeakingPose219
+.4byte sSeakingPose220
+.4byte sSeakingPose221
+.4byte sSeakingPose222
+.4byte sSeakingPose223
+.4byte sSeakingPose224
+.4byte sSeakingPose225
+.4byte sSeakingPose226
+.4byte sSeakingPose227
+.4byte sSeakingPose228
+.4byte sSeakingPose229
+.4byte sSeakingPose230
+.4byte sSeakingPose231
+.4byte sSeakingPose232
+.4byte sSeakingPose233
+.4byte sSeakingPose234
+.4byte sSeakingPose235
+.4byte sSeakingPose236
+.4byte sSeakingPose237
+.4byte sSeakingPose238
+.4byte sSeakingPose239
+.4byte sSeakingPose240
+.4byte sSeakingPose241
+.4byte sSeakingPose242
+.4byte sSeakingPose243
+.4byte sSeakingPose244
+.4byte sSeakingPose245
+.4byte sSeakingPose246
+.4byte sSeakingPose247
+.4byte sSeakingPose248
+.4byte sSeakingPose249
+.4byte sSeakingPose250
+.4byte sSeakingPose251
+.4byte sSeakingPose252
+.4byte sSeakingPose253
+.4byte sSeakingPose254
+.4byte sSeakingPose255
+.4byte sSeakingPose256
+.4byte sSeakingPose257
+.4byte sSeakingPose258
+.4byte sSeakingPose259
+.4byte sSeakingPose260
+.4byte sSeakingPose261
+.4byte sSeakingPose262
+.4byte sSeakingPose263
+.4byte sSeakingPose264
+.4byte sSeakingPose265
+.4byte sSeakingPose266
+.4byte sSeakingPose267
+.4byte sSeakingPose268
+.4byte sSeakingPose269
+.4byte sSeakingPose270
+.4byte sSeakingPose271
+.4byte sSeakingPose272
+.4byte sSeakingPose273
+.4byte sSeakingPose274
+sAxPositionsSeaking:
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte    1,   -2, 	  -9,   -9, 	  10,   -9, 	   1,  -11
+.2byte   -1,   -2, 	  -9,   -6, 	   8,   -6, 	  -1,  -11
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte   10,   -6, 	   9,   -9, 	  -2,   -5, 	   1,  -11
+.2byte    8,   -5, 	  10,   -8, 	  -4,   -7, 	   0,  -11
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte   12,  -10, 	   5,  -15, 	   4,   -6, 	   3,  -12
+.2byte   10,   -8, 	   3,  -15, 	   1,   -8, 	   2,  -11
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte    8,  -14, 	  -2,  -16, 	   7,   -9, 	   3,  -14
+.2byte    9,  -14, 	  -1,  -17, 	   9,  -10, 	   3,  -13
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    1,  -15, 	   9,  -15, 	 -10,  -15, 	  -1,  -15
+.2byte   -2,  -15, 	   7,  -11, 	  -8,  -11, 	   0,  -15
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte   -8,  -14, 	   2,  -16, 	  -7,   -9, 	  -3,  -14
+.2byte   -9,  -14, 	   1,  -17, 	  -9,  -10, 	  -3,  -13
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte  -12,  -10, 	  -5,  -15, 	  -4,   -6, 	  -3,  -12
+.2byte  -10,   -8, 	  -3,  -15, 	  -1,   -8, 	  -2,  -11
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte  -10,   -6, 	  -9,   -9, 	   2,   -5, 	  -1,  -11
+.2byte   -8,   -5, 	 -10,   -8, 	   4,   -7, 	   0,  -11
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte    1,   -2, 	  -9,   -9, 	  10,   -9, 	   1,  -11
+.2byte   -1,   -2, 	  -9,   -6, 	   8,   -6, 	  -1,  -11
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -10
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte   10,   -6, 	   9,   -9, 	  -2,   -5, 	   1,  -11
+.2byte    8,   -5, 	  10,   -8, 	  -4,   -7, 	   0,  -11
+.2byte    6,   -3, 	   6,  -10, 	  -5,   -8, 	   1,  -12
+.2byte    6,   -3, 	   5,  -14, 	  -5,   -9, 	   0,  -12
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte   12,  -10, 	   5,  -15, 	   4,   -6, 	   3,  -12
+.2byte   10,   -8, 	   3,  -15, 	   1,   -8, 	   2,  -11
+.2byte    7,   -3, 	   3,  -13, 	  -2,   -5, 	   1,  -11
+.2byte    7,   -3, 	   2,  -12, 	  -4,   -8, 	   0,  -11
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte    8,  -14, 	  -2,  -16, 	   7,   -9, 	   3,  -14
+.2byte    9,  -14, 	  -1,  -17, 	   9,  -10, 	   3,  -13
+.2byte    8,  -10, 	  -2,  -13, 	   4,   -5, 	   3,  -11
+.2byte    7,   -9, 	  -2,  -11, 	   2,   -5, 	   3,  -11
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    1,  -15, 	   9,  -15, 	 -10,  -15, 	  -1,  -15
+.2byte   -2,  -15, 	   7,  -11, 	  -8,  -11, 	   0,  -15
+.2byte    0,  -15, 	   8,  -10, 	  -8,   -9, 	   0,  -14
+.2byte    0,  -15, 	   7,  -10, 	  -6,  -10, 	   0,  -14
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte   -8,  -14, 	   2,  -16, 	  -7,   -9, 	  -3,  -14
+.2byte   -9,  -14, 	   1,  -17, 	  -9,  -10, 	  -3,  -13
+.2byte   -8,  -10, 	   2,  -13, 	  -4,   -5, 	  -3,  -11
+.2byte   -7,   -9, 	   2,  -11, 	  -2,   -5, 	  -3,  -11
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte  -12,  -10, 	  -5,  -15, 	  -4,   -6, 	  -3,  -12
+.2byte  -10,   -8, 	  -3,  -15, 	  -1,   -8, 	  -2,  -11
+.2byte   -7,   -3, 	  -3,  -13, 	   2,   -5, 	  -1,  -11
+.2byte   -7,   -3, 	  -2,  -12, 	   4,   -8, 	   0,  -11
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte  -10,   -6, 	  -9,   -9, 	   2,   -5, 	  -1,  -11
+.2byte   -8,   -5, 	 -10,   -8, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -3, 	  -6,  -10, 	   5,   -8, 	  -1,  -12
+.2byte   -6,   -3, 	  -5,  -14, 	   5,   -9, 	   0,  -12
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte    1,   -2, 	  -9,   -9, 	  10,   -9, 	   1,  -11
+.2byte   -1,   -2, 	  -9,   -6, 	   8,   -6, 	  -1,  -11
+.2byte    0,   -1, 	  -9,   -8, 	   9,   -8, 	   0,  -10
+.2byte    0,   -1, 	  -8,   -8, 	   8,   -8, 	   0,  -10
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte   10,   -6, 	   9,   -9, 	  -2,   -5, 	   1,  -11
+.2byte    8,   -5, 	  10,   -8, 	  -4,   -7, 	   0,  -11
+.2byte    6,   -3, 	   6,  -10, 	  -5,   -8, 	   1,  -12
+.2byte    6,   -3, 	   5,  -14, 	  -5,   -9, 	   0,  -12
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte   12,  -10, 	   5,  -15, 	   4,   -6, 	   3,  -12
+.2byte   10,   -8, 	   3,  -15, 	   1,   -8, 	   2,  -11
+.2byte    7,   -3, 	   3,  -13, 	  -2,   -5, 	   1,  -11
+.2byte    7,   -3, 	   2,  -12, 	  -4,   -8, 	   0,  -11
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte    8,  -14, 	  -2,  -16, 	   7,   -9, 	   3,  -14
+.2byte    9,  -14, 	  -1,  -17, 	   9,  -10, 	   3,  -13
+.2byte    8,  -10, 	  -2,  -13, 	   4,   -5, 	   3,  -11
+.2byte    7,   -9, 	  -2,  -11, 	   2,   -5, 	   3,  -11
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    1,  -15, 	   9,  -15, 	 -10,  -15, 	  -1,  -15
+.2byte   -2,  -15, 	   7,  -11, 	  -8,  -11, 	   0,  -15
+.2byte    0,  -15, 	   8,  -10, 	  -8,   -9, 	   0,  -14
+.2byte    0,  -15, 	   7,  -10, 	  -6,  -10, 	   0,  -14
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte   -8,  -14, 	   2,  -16, 	  -7,   -9, 	  -3,  -14
+.2byte   -9,  -14, 	   1,  -17, 	  -9,  -10, 	  -3,  -13
+.2byte   -8,  -10, 	   2,  -13, 	  -4,   -5, 	  -3,  -11
+.2byte   -7,   -9, 	   2,  -11, 	  -2,   -5, 	  -3,  -11
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte  -12,  -10, 	  -5,  -15, 	  -4,   -6, 	  -3,  -12
+.2byte  -10,   -8, 	  -3,  -15, 	  -1,   -8, 	  -2,  -11
+.2byte   -7,   -3, 	  -3,  -13, 	   2,   -5, 	  -1,  -11
+.2byte   -7,   -3, 	  -2,  -12, 	   4,   -8, 	   0,  -11
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte  -10,   -6, 	  -9,   -9, 	   2,   -5, 	  -1,  -11
+.2byte   -8,   -5, 	 -10,   -8, 	   4,   -7, 	   0,  -11
+.2byte   -6,   -3, 	  -6,  -10, 	   5,   -8, 	  -1,  -12
+.2byte   -6,   -3, 	  -5,  -14, 	   5,   -9, 	   0,  -12
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte    1,   -2, 	  -9,   -9, 	  10,   -9, 	   1,  -11
+.2byte   -1,   -2, 	  -9,   -6, 	   8,   -6, 	  -1,  -11
+.2byte    0,   -9, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte    0,    1, 	  -7,   -7, 	   7,   -7, 	   0,   -6
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte   10,   -6, 	   9,   -9, 	  -2,   -5, 	   1,  -11
+.2byte    8,   -5, 	  10,   -8, 	  -4,   -7, 	   0,  -11
+.2byte    8,  -12, 	   3,   -8, 	  -4,   -6, 	   1,  -12
+.2byte   10,   -3, 	   5,  -12, 	  -3,   -6, 	   2,   -9
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte   12,  -10, 	   5,  -15, 	   4,   -6, 	   3,  -12
+.2byte   10,   -8, 	   3,  -15, 	   1,   -8, 	   2,  -11
+.2byte    9,  -14, 	   2,  -14, 	   2,   -8, 	   1,  -13
+.2byte   10,   -8, 	  -1,  -15, 	  -1,   -9, 	   0,  -11
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte    8,  -14, 	  -2,  -16, 	   7,   -9, 	   3,  -14
+.2byte    9,  -14, 	  -1,  -17, 	   9,  -10, 	   3,  -13
+.2byte    7,  -16, 	  -2,  -16, 	   7,  -10, 	   2,  -14
+.2byte    9,  -12, 	  -1,  -14, 	   5,   -7, 	   2,  -11
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    1,  -15, 	   9,  -15, 	 -10,  -15, 	  -1,  -15
+.2byte   -2,  -15, 	   7,  -11, 	  -8,  -11, 	   0,  -15
+.2byte    0,  -22, 	   9,  -14, 	  -9,  -14, 	   0,  -15
+.2byte    0,  -13, 	   7,  -11, 	  -7,  -11, 	   0,  -15
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte   -8,  -14, 	   2,  -16, 	  -7,   -9, 	  -3,  -14
+.2byte   -9,  -14, 	   1,  -17, 	  -9,  -10, 	  -3,  -13
+.2byte   -7,  -16, 	   2,  -16, 	  -7,  -10, 	  -2,  -14
+.2byte   -9,  -12, 	   1,  -14, 	  -5,   -7, 	  -2,  -11
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte  -12,  -10, 	  -5,  -15, 	  -4,   -6, 	  -3,  -12
+.2byte  -10,   -8, 	  -3,  -15, 	  -1,   -8, 	  -2,  -11
+.2byte   -9,  -14, 	  -2,  -14, 	  -2,   -8, 	  -1,  -13
+.2byte  -10,   -8, 	   1,  -15, 	   1,   -9, 	   0,  -11
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte  -10,   -6, 	  -9,   -9, 	   2,   -5, 	  -1,  -11
+.2byte   -8,   -5, 	 -10,   -8, 	   4,   -7, 	   0,  -11
+.2byte   -8,  -12, 	  -3,   -8, 	   4,   -6, 	  -1,  -12
+.2byte  -10,   -3, 	  -5,  -12, 	   3,   -6, 	  -2,   -9
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte    0,   -9, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte    0,  -25, 	  -9,  -14, 	   9,  -14, 	   0,  -16
+.2byte    2,  -25, 	  -9,  -17, 	   8,  -12, 	  -1,  -16
+.2byte   -2,  -25, 	  -8,  -12, 	   9,  -18, 	   1,  -16
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte    9,  -12, 	   4,   -8, 	  -3,   -6, 	   2,  -12
+.2byte    1,  -24, 	   7,  -14, 	  -7,  -12, 	   1,  -15
+.2byte    0,  -24, 	   8,  -16, 	  -6,  -11, 	   0,  -14
+.2byte    1,  -24, 	   7,  -13, 	  -7,  -15, 	   0,  -15
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte   11,  -14, 	   4,  -14, 	   4,   -8, 	   3,  -13
+.2byte    4,  -24, 	   4,  -15, 	   5,  -13, 	   0,  -15
+.2byte    3,  -24, 	   2,  -18, 	   4,  -12, 	   0,  -14
+.2byte    4,  -24, 	   2,  -16, 	   5,  -16, 	   0,  -15
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte    7,  -16, 	  -2,  -16, 	   7,  -10, 	   2,  -14
+.2byte    2,  -25, 	  -4,  -16, 	   7,  -13, 	   0,  -16
+.2byte    2,  -25, 	  -4,  -15, 	   5,  -12, 	  -1,  -16
+.2byte    0,  -25, 	  -2,  -13, 	   8,  -15, 	   0,  -15
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    0,  -22, 	   9,  -14, 	  -9,  -14, 	   0,  -15
+.2byte    0,  -25, 	   8,  -13, 	  -8,  -13, 	   0,  -15
+.2byte   -3,  -25, 	  10,  -17, 	  -5,  -12, 	   2,  -16
+.2byte    3,  -25, 	   5,  -11, 	  -9,  -17, 	  -1,  -16
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte   -7,  -16, 	   2,  -16, 	  -7,  -10, 	  -2,  -14
+.2byte   -2,  -25, 	   4,  -16, 	  -7,  -13, 	   0,  -16
+.2byte   -2,  -25, 	   4,  -15, 	  -5,  -12, 	   1,  -16
+.2byte    0,  -25, 	   2,  -13, 	  -8,  -15, 	   0,  -15
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte  -11,  -14, 	  -4,  -14, 	  -4,   -8, 	  -3,  -13
+.2byte   -4,  -24, 	  -4,  -15, 	  -5,  -13, 	   0,  -15
+.2byte   -3,  -24, 	  -2,  -18, 	  -4,  -12, 	   0,  -14
+.2byte   -4,  -24, 	  -2,  -16, 	  -5,  -16, 	   0,  -15
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte   -9,  -12, 	  -4,   -8, 	   3,   -6, 	  -2,  -12
+.2byte   -1,  -24, 	  -7,  -14, 	   7,  -12, 	  -1,  -15
+.2byte    0,  -24, 	  -8,  -16, 	   6,  -11, 	   0,  -14
+.2byte   -1,  -24, 	  -7,  -13, 	   7,  -15, 	   0,  -15
+.2byte   -8,   -5, 	  -8,   -8, 	   3,   -5, 	  -1,  -10
+.2byte   -8,   -5, 	  -8,   -9, 	   4,   -5, 	  -1,  -10
+.2byte    0,   -2, 	  -9,   -8, 	   9,   -8, 	   0,  -10
+.2byte    8,   -4, 	   6,   -7, 	  -6,   -5, 	  -1,   -9
+.2byte    9,   -6, 	   0,  -13, 	  -2,   -4, 	   0,   -9
+.2byte    3,  -11, 	  -5,  -12, 	   3,   -3, 	  -1,   -9
+.2byte    0,  -10, 	   9,   -8, 	  -9,   -8, 	   0,  -11
+.2byte   -4,  -11, 	   4,  -12, 	  -4,   -3, 	   0,   -9
+.2byte  -10,   -6, 	  -1,  -13, 	   1,   -4, 	  -1,   -9
+.2byte   -9,   -4, 	  -7,   -7, 	   5,   -5, 	   0,   -9
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte    1,   -2, 	  -9,   -9, 	  10,   -9, 	   1,  -11
+.2byte   -1,   -2, 	  -9,   -6, 	   8,   -6, 	  -1,  -11
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte   10,   -6, 	   9,   -9, 	  -2,   -5, 	   1,  -11
+.2byte    8,   -5, 	  10,   -8, 	  -4,   -7, 	   0,  -11
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte   12,  -10, 	   5,  -15, 	   4,   -6, 	   3,  -12
+.2byte   10,   -8, 	   3,  -15, 	   1,   -8, 	   2,  -11
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte    8,  -14, 	  -2,  -16, 	   7,   -9, 	   3,  -14
+.2byte    9,  -14, 	  -1,  -17, 	   9,  -10, 	   3,  -13
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    1,  -15, 	   9,  -15, 	 -10,  -15, 	  -1,  -15
+.2byte   -2,  -15, 	   7,  -11, 	  -8,  -11, 	   0,  -15
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte   -8,  -14, 	   2,  -16, 	  -7,   -9, 	  -3,  -14
+.2byte   -9,  -14, 	   1,  -17, 	  -9,  -10, 	  -3,  -13
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte  -12,  -10, 	  -5,  -15, 	  -4,   -6, 	  -3,  -12
+.2byte  -10,   -8, 	  -3,  -15, 	  -1,   -8, 	  -2,  -11
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte  -10,   -6, 	  -9,   -9, 	   2,   -5, 	  -1,  -11
+.2byte   -8,   -5, 	 -10,   -8, 	   4,   -7, 	   0,  -11
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte    0,  -25, 	  -9,  -14, 	   9,  -14, 	   0,  -16
+.2byte    1,  -25, 	   7,  -15, 	  -7,  -13, 	   1,  -16
+.2byte    4,  -24, 	   4,  -15, 	   5,  -13, 	   0,  -15
+.2byte    2,  -25, 	  -4,  -16, 	   7,  -13, 	   0,  -16
+.2byte    0,  -25, 	   8,  -13, 	  -8,  -13, 	   0,  -15
+.2byte   -2,  -25, 	   4,  -16, 	  -7,  -13, 	   0,  -16
+.2byte   -4,  -24, 	  -4,  -15, 	  -5,  -13, 	   0,  -15
+.2byte   -1,  -25, 	  -7,  -15, 	   7,  -13, 	  -1,  -16
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte    0,   -9, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte    0,    1, 	  -7,   -7, 	   7,   -7, 	   0,   -6
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+.2byte    8,  -12, 	   3,   -8, 	  -4,   -6, 	   1,  -12
+.2byte   10,   -3, 	   5,  -12, 	  -3,   -6, 	   2,   -9
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte    9,  -14, 	   2,  -14, 	   2,   -8, 	   1,  -13
+.2byte   10,   -8, 	  -1,  -15, 	  -1,   -9, 	   0,  -11
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte    7,  -16, 	  -2,  -16, 	   7,  -10, 	   2,  -14
+.2byte    9,  -12, 	  -1,  -14, 	   5,   -7, 	   2,  -11
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    0,  -22, 	   9,  -14, 	  -9,  -14, 	   0,  -15
+.2byte    0,  -13, 	   7,  -11, 	  -7,  -11, 	   0,  -15
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte   -7,  -16, 	   2,  -16, 	  -7,  -10, 	  -2,  -14
+.2byte   -9,  -12, 	   1,  -14, 	  -5,   -7, 	  -2,  -11
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte   -9,  -14, 	  -2,  -14, 	  -2,   -8, 	  -1,  -13
+.2byte  -10,   -8, 	   1,  -15, 	   1,   -9, 	   0,  -11
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte   -8,  -12, 	  -3,   -8, 	   4,   -6, 	  -1,  -12
+.2byte  -10,   -3, 	  -5,  -12, 	   3,   -6, 	  -2,   -9
+.2byte    0,   -9, 	  -9,  -10, 	   8,  -10, 	   0,  -12
+.2byte   -8,  -12, 	  -3,   -8, 	   4,   -6, 	  -1,  -12
+.2byte   -9,  -12, 	  -2,  -12, 	  -2,   -6, 	  -1,  -11
+.2byte   -6,  -13, 	   3,  -13, 	  -6,   -7, 	  -1,  -11
+.2byte    0,  -20, 	   9,  -12, 	  -9,  -12, 	   0,  -13
+.2byte    6,  -13, 	  -3,  -13, 	   6,   -7, 	   1,  -11
+.2byte    9,  -12, 	   2,  -12, 	   2,   -6, 	   1,  -11
+.2byte    8,  -12, 	   3,   -8, 	  -4,   -6, 	   1,  -12
+.2byte    0,   -2, 	  -9,   -7, 	   9,   -7, 	   0,  -10
+.2byte   -9,   -5, 	  -7,  -10, 	   4,   -6, 	   1,  -11
+.2byte  -11,   -9, 	  -5,  -15, 	  -2,   -7, 	  -3,  -12
+.2byte   -9,  -14, 	   2,  -14, 	  -7,   -8, 	  -4,  -14
+.2byte    0,  -14, 	   9,  -12, 	  -9,  -12, 	   0,  -15
+.2byte    9,  -14, 	  -2,  -14, 	   7,   -8, 	   4,  -14
+.2byte   11,   -9, 	   5,  -15, 	   2,   -7, 	   3,  -12
+.2byte    9,   -5, 	   7,  -10, 	  -4,   -6, 	  -1,  -11
+sSeakingAnimTable1:
+.4byte sSeakingAnims_1_1
+.4byte sSeakingAnims_1_2
+.4byte sSeakingAnims_1_3
+.4byte sSeakingAnims_1_4
+.4byte sSeakingAnims_1_5
+.4byte sSeakingAnims_1_6
+.4byte sSeakingAnims_1_7
+.4byte sSeakingAnims_1_8
+sSeakingAnimTable2:
+.4byte sSeakingAnims_2_1
+.4byte sSeakingAnims_2_2
+.4byte sSeakingAnims_2_3
+.4byte sSeakingAnims_2_4
+.4byte sSeakingAnims_2_5
+.4byte sSeakingAnims_2_6
+.4byte sSeakingAnims_2_7
+.4byte sSeakingAnims_2_8
+sSeakingAnimTable3:
+.4byte sSeakingAnims_3_1
+.4byte sSeakingAnims_3_2
+.4byte sSeakingAnims_3_3
+.4byte sSeakingAnims_3_4
+.4byte sSeakingAnims_3_5
+.4byte sSeakingAnims_3_6
+.4byte sSeakingAnims_3_7
+.4byte sSeakingAnims_3_8
+sSeakingAnimTable4:
+.4byte sSeakingAnims_4_1
+.4byte sSeakingAnims_4_2
+.4byte sSeakingAnims_4_3
+.4byte sSeakingAnims_4_4
+.4byte sSeakingAnims_4_5
+.4byte sSeakingAnims_4_6
+.4byte sSeakingAnims_4_7
+.4byte sSeakingAnims_4_8
+sSeakingAnimTable5:
+.4byte sSeakingAnims_5_1
+.4byte sSeakingAnims_5_2
+.4byte sSeakingAnims_5_3
+.4byte sSeakingAnims_5_4
+.4byte sSeakingAnims_5_5
+.4byte sSeakingAnims_5_6
+.4byte sSeakingAnims_5_7
+.4byte sSeakingAnims_5_8
+sSeakingAnimTable6:
+.4byte sSeakingAnims_6_1
+.4byte sSeakingAnims_6_1
+.4byte sSeakingAnims_6_1
+.4byte sSeakingAnims_6_1
+.4byte sSeakingAnims_6_1
+.4byte sSeakingAnims_6_1
+.4byte sSeakingAnims_6_1
+.4byte sSeakingAnims_6_1
+sSeakingAnimTable7:
+.4byte sSeakingAnims_7_1
+.4byte sSeakingAnims_7_2
+.4byte sSeakingAnims_7_3
+.4byte sSeakingAnims_7_4
+.4byte sSeakingAnims_7_5
+.4byte sSeakingAnims_7_6
+.4byte sSeakingAnims_7_7
+.4byte sSeakingAnims_7_8
+sSeakingAnimTable8:
+.4byte sSeakingAnims_8_1
+.4byte sSeakingAnims_8_2
+.4byte sSeakingAnims_8_3
+.4byte sSeakingAnims_8_4
+.4byte sSeakingAnims_8_5
+.4byte sSeakingAnims_8_6
+.4byte sSeakingAnims_8_7
+.4byte sSeakingAnims_8_8
+sSeakingAnimTable9:
+.4byte sSeakingAnims_9_1
+.4byte sSeakingAnims_9_2
+.4byte sSeakingAnims_9_3
+.4byte sSeakingAnims_9_4
+.4byte sSeakingAnims_9_5
+.4byte sSeakingAnims_9_6
+.4byte sSeakingAnims_9_7
+.4byte sSeakingAnims_9_8
+sSeakingAnimTable10:
+.4byte sSeakingAnims_10_1
+.4byte sSeakingAnims_10_2
+.4byte sSeakingAnims_10_3
+.4byte sSeakingAnims_10_4
+.4byte sSeakingAnims_10_5
+.4byte sSeakingAnims_10_6
+.4byte sSeakingAnims_10_7
+.4byte sSeakingAnims_10_8
+sSeakingAnimTable11:
+.4byte sSeakingAnims_11_1
+.4byte sSeakingAnims_11_2
+.4byte sSeakingAnims_11_3
+.4byte sSeakingAnims_11_4
+.4byte sSeakingAnims_11_5
+.4byte sSeakingAnims_11_6
+.4byte sSeakingAnims_11_7
+.4byte sSeakingAnims_11_8
+sSeakingAnimTable12:
+.4byte sSeakingAnims_12_1
+.4byte sSeakingAnims_12_2
+.4byte sSeakingAnims_12_3
+.4byte sSeakingAnims_12_4
+.4byte sSeakingAnims_12_5
+.4byte sSeakingAnims_12_6
+.4byte sSeakingAnims_12_7
+.4byte sSeakingAnims_12_8
+sSeakingAnimTable13:
+.4byte sSeakingAnims_13_1
+.4byte sSeakingAnims_13_2
+.4byte sSeakingAnims_13_3
+.4byte sSeakingAnims_13_4
+.4byte sSeakingAnims_13_5
+.4byte sSeakingAnims_13_6
+.4byte sSeakingAnims_13_7
+.4byte sSeakingAnims_13_8
+sAxAnimationsSeaking:
+.4byte sSeakingAnimTable1
+.4byte sSeakingAnimTable2
+.4byte sSeakingAnimTable3
+.4byte sSeakingAnimTable4
+.4byte sSeakingAnimTable5
+.4byte sSeakingAnimTable6
+.4byte sSeakingAnimTable7
+.4byte sSeakingAnimTable8
+.4byte sSeakingAnimTable9
+.4byte sSeakingAnimTable10
+.4byte sSeakingAnimTable11
+.4byte sSeakingAnimTable12
+.4byte sSeakingAnimTable13
+sAxSpritesSeaking:
+.4byte sSeakingSprites1
+.4byte sSeakingSprites2
+.4byte sSeakingSprites3
+.4byte sSeakingSprites4
+.4byte sSeakingSprites5
+.4byte sSeakingSprites6
+.4byte sSeakingSprites7
+.4byte sSeakingSprites8
+.4byte sSeakingSprites9
+.4byte sSeakingSprites10
+.4byte sSeakingSprites11
+.4byte sSeakingSprites12
+.4byte sSeakingSprites13
+.4byte sSeakingSprites14
+.4byte sSeakingSprites15
+.4byte sSeakingSprites16
+.4byte sSeakingSprites17
+.4byte sSeakingSprites18
+.4byte sSeakingSprites19
+.4byte sSeakingSprites20
+.4byte sSeakingSprites21
+.4byte sSeakingSprites22
+.4byte sSeakingSprites23
+.4byte sSeakingSprites24
+.4byte sSeakingSprites25
+.4byte sSeakingSprites26
+.4byte sSeakingSprites27
+.4byte sSeakingSprites28
+.4byte sSeakingSprites29
+.4byte sSeakingSprites30
+.4byte sSeakingSprites31
+.4byte sSeakingSprites32
+.4byte sSeakingSprites33
+.4byte sSeakingSprites34
+.4byte sSeakingSprites35
+.4byte sSeakingSprites36
+.4byte sSeakingSprites37
+.4byte sSeakingSprites38
+.4byte sSeakingSprites39
+.4byte sSeakingSprites40
+.4byte sSeakingSprites41
+.4byte sSeakingSprites42
+.4byte sSeakingSprites43
+.4byte sSeakingSprites44
+.4byte sSeakingSprites45
+.4byte sSeakingSprites46
+.4byte sSeakingSprites47
+.4byte sSeakingSprites48
+.4byte sSeakingSprites49
+.4byte sSeakingSprites50
+.4byte sSeakingSprites51
+.4byte sSeakingSprites52
+.4byte sSeakingSprites53
+.4byte sSeakingSprites54
+.4byte sSeakingSprites55
+.4byte sSeakingSprites56
+.4byte sSeakingSprites57
+sAxMainSeaking:
+ax_main sAxPosesSeaking, sAxAnimationsSeaking, 13, sAxSpritesSeaking, sAxPositionsSeaking

--- a/data/ax/sealeo.inc
+++ b/data/ax/sealeo.inc
@@ -1,0 +1,2704 @@
+.global gAxSealeo
+gAxSealeo:
+ax_siro sAxMainSealeo
+sSealeoPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose6:
+ax_pose 5, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose7:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose8:
+ax_pose 7, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose9:
+ax_pose 8, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose10:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose11:
+ax_pose 10, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose12:
+ax_pose 11, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose13:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose16:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose17:
+ax_pose 10, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose18:
+ax_pose 11, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose26:
+ax_pose 15, 0x01eb, 0x80ef, 0x5c00
+ax_pose_terminator
+sSealeoPose27:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose28:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose29:
+ax_pose 17, 0x01ea, 0x90ef, 0x5c00
+ax_pose_terminator
+sSealeoPose30:
+ax_pose 18, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose31:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose32:
+ax_pose 19, 0x41ed, 0x90f0, 0x5c00
+ax_pose 20, 0x41fd, 0x50f0, 0x5c08
+ax_pose 21, 0x01f8, 0x10e8, 0x5c0c
+ax_pose_terminator
+sSealeoPose33:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose34:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose35:
+ax_pose 23, 0x41ec, 0x90f1, 0x5c00
+ax_pose 24, 0x41fc, 0x50f1, 0x5c08
+ax_pose 25, 0x01fc, 0x10e9, 0x5c0c
+ax_pose_terminator
+sSealeoPose36:
+ax_pose 26, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose37:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose38:
+ax_pose 27, 0x01ea, 0x80ef, 0x5c00
+ax_pose_terminator
+sSealeoPose39:
+ax_pose 28, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose40:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose41:
+ax_pose 23, 0x41ec, 0x80ef, 0x5c00
+ax_pose 24, 0x41fc, 0x40ef, 0x5c08
+ax_pose 25, 0x01fc, 0x010f, 0x5c0c
+ax_pose_terminator
+sSealeoPose42:
+ax_pose 26, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose43:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose44:
+ax_pose 19, 0x41ed, 0x80f0, 0x5c00
+ax_pose 20, 0x41fd, 0x40f0, 0x5c08
+ax_pose 21, 0x01f8, 0x0110, 0x5c0c
+ax_pose_terminator
+sSealeoPose45:
+ax_pose 22, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose47:
+ax_pose 17, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose48:
+ax_pose 18, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose50:
+ax_pose 15, 0x01eb, 0x80ef, 0x5c00
+ax_pose_terminator
+sSealeoPose51:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose52:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose53:
+ax_pose 17, 0x01ea, 0x90ef, 0x5c00
+ax_pose_terminator
+sSealeoPose54:
+ax_pose 18, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose55:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose56:
+ax_pose 19, 0x41ed, 0x90f0, 0x5c00
+ax_pose 20, 0x41fd, 0x50f0, 0x5c08
+ax_pose 21, 0x01f8, 0x10e8, 0x5c0c
+ax_pose_terminator
+sSealeoPose57:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose58:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose59:
+ax_pose 23, 0x41ec, 0x90f1, 0x5c00
+ax_pose 24, 0x41fc, 0x50f1, 0x5c08
+ax_pose 25, 0x01fc, 0x10e9, 0x5c0c
+ax_pose_terminator
+sSealeoPose60:
+ax_pose 26, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose61:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose62:
+ax_pose 27, 0x01ea, 0x80ef, 0x5c00
+ax_pose_terminator
+sSealeoPose63:
+ax_pose 28, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose64:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose65:
+ax_pose 23, 0x41ec, 0x80ef, 0x5c00
+ax_pose 24, 0x41fc, 0x40ef, 0x5c08
+ax_pose 25, 0x01fc, 0x010f, 0x5c0c
+ax_pose_terminator
+sSealeoPose66:
+ax_pose 26, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose67:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose68:
+ax_pose 19, 0x41ed, 0x80f0, 0x5c00
+ax_pose 20, 0x41fd, 0x40f0, 0x5c08
+ax_pose 21, 0x01f8, 0x0110, 0x5c0c
+ax_pose_terminator
+sSealeoPose69:
+ax_pose 22, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose71:
+ax_pose 17, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose72:
+ax_pose 18, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose73:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose74:
+ax_pose 29, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose75:
+ax_pose 30, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose76:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose77:
+ax_pose 31, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sSealeoPose78:
+ax_pose 32, 0x01e8, 0x90f2, 0x5c00
+ax_pose_terminator
+sSealeoPose79:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose80:
+ax_pose 33, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose81:
+ax_pose 34, 0x41ec, 0x90ef, 0x5c00
+ax_pose 35, 0x41fc, 0x50ef, 0x5c08
+ax_pose 36, 0x01f7, 0x10e7, 0x5c0c
+ax_pose_terminator
+sSealeoPose82:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose83:
+ax_pose 37, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sSealeoPose84:
+ax_pose 38, 0x41ea, 0x90ef, 0x5c00
+ax_pose 39, 0x41fa, 0x50ef, 0x5c08
+ax_pose 40, 0x01f2, 0x110f, 0x5c0c
+ax_pose_terminator
+sSealeoPose85:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose86:
+ax_pose 41, 0x81e9, 0x80f0, 0x5c00
+ax_pose 42, 0x81e9, 0x4100, 0x5c08
+ax_pose 43, 0x81e9, 0x0108, 0x5c0c
+ax_pose 44, 0x01f9, 0x0108, 0x5c0e
+ax_pose 45, 0x0209, 0x00fc, 0x5c0f
+ax_pose_terminator
+sSealeoPose87:
+ax_pose 46, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose88:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose89:
+ax_pose 37, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose90:
+ax_pose 38, 0x41ea, 0x80f1, 0x5c00
+ax_pose 39, 0x41fa, 0x40f1, 0x5c08
+ax_pose 40, 0x01f2, 0x00e9, 0x5c0c
+ax_pose_terminator
+sSealeoPose91:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose92:
+ax_pose 33, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose93:
+ax_pose 34, 0x41ec, 0x80f1, 0x5c00
+ax_pose 35, 0x41fc, 0x40f1, 0x5c08
+ax_pose 36, 0x01f7, 0x0111, 0x5c0c
+ax_pose_terminator
+sSealeoPose94:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose95:
+ax_pose 31, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sSealeoPose96:
+ax_pose 32, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sSealeoPose97:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose98:
+ax_pose 16, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose99:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose100:
+ax_pose 18, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose101:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose102:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose103:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose104:
+ax_pose 26, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose105:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose106:
+ax_pose 28, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose107:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose108:
+ax_pose 26, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose109:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose110:
+ax_pose 22, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose111:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose112:
+ax_pose 18, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose113:
+ax_pose 47, 0x01f3, 0x80f2, 0x5c00
+ax_pose_terminator
+sSealeoPose114:
+ax_pose 48, 0x01f3, 0x80f2, 0x5c00
+ax_pose_terminator
+sSealeoPose115:
+ax_pose 49, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sSealeoPose116:
+ax_pose 50, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose117:
+ax_pose 51, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose118:
+ax_pose 52, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sSealeoPose119:
+ax_pose 53, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose120:
+ax_pose 52, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose121:
+ax_pose 51, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose122:
+ax_pose 50, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose123:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose124:
+ax_pose 16, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose125:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose126:
+ax_pose 18, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose127:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose128:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose129:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose130:
+ax_pose 26, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose131:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose132:
+ax_pose 28, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose133:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose134:
+ax_pose 26, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose135:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose136:
+ax_pose 22, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose137:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose138:
+ax_pose 18, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose139:
+ax_pose 16, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose140:
+ax_pose 18, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose141:
+ax_pose 22, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSealeoPose142:
+ax_pose 26, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose143:
+ax_pose 28, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose144:
+ax_pose 26, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose145:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose146:
+ax_pose 18, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sSealeoPose147:
+ax_pose 29, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose148:
+ax_pose 31, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sSealeoPose149:
+ax_pose 33, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose150:
+ax_pose 37, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sSealeoPose151:
+ax_pose 41, 0x81e8, 0x80f0, 0x5c00
+ax_pose 42, 0x81e8, 0x4100, 0x5c08
+ax_pose 43, 0x81e8, 0x0108, 0x5c0c
+ax_pose 44, 0x01f8, 0x0108, 0x5c0e
+ax_pose 45, 0x0208, 0x00fc, 0x5c0f
+ax_pose_terminator
+sSealeoPose152:
+ax_pose 37, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose153:
+ax_pose 33, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose154:
+ax_pose 31, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sSealeoPose155:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose156:
+ax_pose 29, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose157:
+ax_pose 30, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose158:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose159:
+ax_pose 31, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose160:
+ax_pose 32, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sSealeoPose161:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose162:
+ax_pose 33, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose163:
+ax_pose 34, 0x41ec, 0x90ee, 0x5c00
+ax_pose 35, 0x41fc, 0x50ee, 0x5c08
+ax_pose 36, 0x01f7, 0x10e6, 0x5c0c
+ax_pose_terminator
+sSealeoPose164:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose165:
+ax_pose 37, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sSealeoPose166:
+ax_pose 38, 0x41ea, 0x90ed, 0x5c00
+ax_pose 39, 0x41fa, 0x50ed, 0x5c08
+ax_pose 40, 0x01f2, 0x110d, 0x5c0c
+ax_pose_terminator
+sSealeoPose167:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose168:
+ax_pose 41, 0x81e9, 0x80f0, 0x5c00
+ax_pose 42, 0x81e9, 0x4100, 0x5c08
+ax_pose 43, 0x81e9, 0x0108, 0x5c0c
+ax_pose 44, 0x01f9, 0x0108, 0x5c0e
+ax_pose 45, 0x0209, 0x00fc, 0x5c0f
+ax_pose_terminator
+sSealeoPose169:
+ax_pose 46, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose170:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose171:
+ax_pose 37, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose172:
+ax_pose 38, 0x41ea, 0x80f3, 0x5c00
+ax_pose 39, 0x41fa, 0x40f3, 0x5c08
+ax_pose 40, 0x01f2, 0x00eb, 0x5c0c
+ax_pose_terminator
+sSealeoPose173:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose174:
+ax_pose 33, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose175:
+ax_pose 34, 0x41ec, 0x80f2, 0x5c00
+ax_pose 35, 0x41fc, 0x40f2, 0x5c08
+ax_pose 36, 0x01f7, 0x0112, 0x5c0c
+ax_pose_terminator
+sSealeoPose176:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose177:
+ax_pose 31, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose178:
+ax_pose 32, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sSealeoPose179:
+ax_pose 30, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose180:
+ax_pose 32, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sSealeoPose181:
+ax_pose 34, 0x41ec, 0x80f1, 0x5c00
+ax_pose 35, 0x41fc, 0x40f1, 0x5c08
+ax_pose 36, 0x01f7, 0x0111, 0x5c0c
+ax_pose 40, 0x01f2, 0x00e9, 0x5c0d
+ax_pose_terminator
+sSealeoPose182:
+ax_pose 38, 0x41ea, 0x80f1, 0x5c00
+ax_pose 39, 0x41fa, 0x40f1, 0x5c08
+ax_pose 40, 0x01f2, 0x00e9, 0x5c0c
+ax_pose_terminator
+sSealeoPose183:
+ax_pose 46, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sSealeoPose184:
+ax_pose 38, 0x41ea, 0x90ef, 0x5c00
+ax_pose 39, 0x41fa, 0x50ef, 0x5c08
+ax_pose 40, 0x01f2, 0x110f, 0x5c0c
+ax_pose_terminator
+sSealeoPose185:
+ax_pose 34, 0x41ec, 0x90ef, 0x5c00
+ax_pose 35, 0x41fc, 0x50ef, 0x5c08
+ax_pose 36, 0x01f7, 0x10e7, 0x5c0c
+ax_pose_terminator
+sSealeoPose186:
+ax_pose 32, 0x01e8, 0x90f2, 0x5c00
+ax_pose_terminator
+sSealeoPose187:
+ax_pose 0, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose188:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose189:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose190:
+ax_pose 9, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose191:
+ax_pose 12, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sSealeoPose192:
+ax_pose 9, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose193:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSealeoPose194:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+.align 2
+sSealeoAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 2, 0, 2,
+ax_anim 6, 0, 2, 0, 2, 0, 3,
+ax_anim 6, 0, 2, 0, 1, 0, 2,
+ax_anim_terminator
+sSealeoAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 2, 1, 2, 1,
+ax_anim 8, 0, 4, 3, 2, 4, 2,
+ax_anim 6, 0, 5, 4, 2, 4, 2,
+ax_anim 6, 0, 5, 2, 1, 2, 1,
+ax_anim_terminator
+sSealeoAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 2, 0,
+ax_anim 8, 0, 7, 4, 0, 4, 0,
+ax_anim 6, 0, 8, 4, 0, 4, 0,
+ax_anim 6, 0, 8, 2, 0, 2, 0,
+ax_anim_terminator
+sSealeoAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 2, 0, 2, -2,
+ax_anim 8, 0, 10, 4, -2, 4, -4,
+ax_anim 6, 0, 11, 4, -2, 3, -2,
+ax_anim 6, 0, 11, 2, -1, 1, -1,
+ax_anim_terminator
+sSealeoAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, -4,
+ax_anim 8, 0, 13, 0, -1, 0, -5,
+ax_anim 6, 0, 14, 0, -2, 0, -2,
+ax_anim 6, 0, 14, 0, -1, 0, -1,
+ax_anim_terminator
+sSealeoAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -2, 0, -2, -2,
+ax_anim 8, 0, 16, -4, -2, -4, -4,
+ax_anim 6, 0, 17, -4, -2, -3, -2,
+ax_anim 6, 0, 17, -2, -1, -1, -1,
+ax_anim_terminator
+sSealeoAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -2, 0, -2, 0,
+ax_anim 8, 0, 19, -4, 0, -4, 0,
+ax_anim 6, 0, 20, -4, 0, -4, 0,
+ax_anim 6, 0, 20, -2, 0, -2, 0,
+ax_anim_terminator
+sSealeoAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -2, 1, -2, 1,
+ax_anim 8, 0, 22, -3, 2, -4, 2,
+ax_anim 6, 0, 23, -4, 2, -4, 2,
+ax_anim 6, 0, 23, -2, 1, -2, 1,
+ax_anim_terminator
+.align 2
+sSealeoAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSealeoAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSealeoAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 16, 0, 16, 0,
+ax_anim 2, 1, 31, 16, 1, 16, 1,
+ax_anim 2, 0, 31, 16, 0, 16, 0,
+ax_anim 2, 0, 31, 16, 1, 16, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSealeoAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 34, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 17, -20, 17, -20,
+ax_anim 2, 1, 34, 18, -19, 18, -19,
+ax_anim 2, 0, 34, 17, -20, 17, -20,
+ax_anim 2, 0, 34, 18, -19, 18, -19,
+ax_anim 2, 0, 33, 5, -7, 5, -7,
+ax_anim_terminator
+sSealeoAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 1, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 37, 0, -19, 0, -19,
+ax_anim 2, 0, 37, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSealeoAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 40, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -17, -20, -17, -20,
+ax_anim 2, 1, 40, -18, -19, -18, -19,
+ax_anim 2, 0, 40, -17, -20, -17, -20,
+ax_anim 2, 0, 40, -18, -19, -18, -19,
+ax_anim 2, 0, 39, -5, -7, -5, -7,
+ax_anim_terminator
+sSealeoAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -16, 0, -16, 0,
+ax_anim 2, 1, 43, -16, 1, -16, 1,
+ax_anim 2, 0, 43, -16, 0, -16, 0,
+ax_anim 2, 0, 43, -16, 1, -16, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSealeoAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 1, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSealeoAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 6, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSealeoAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sSealeoAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 6, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 16, 0, 16, 0,
+ax_anim 2, 1, 55, 16, 1, 16, 1,
+ax_anim 2, 0, 55, 16, 0, 16, 0,
+ax_anim 2, 0, 55, 16, 1, 16, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSealeoAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 6, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 58, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 17, -20, 17, -20,
+ax_anim 2, 1, 58, 18, -19, 18, -19,
+ax_anim 2, 0, 58, 17, -20, 17, -20,
+ax_anim 2, 0, 58, 18, -19, 18, -19,
+ax_anim 2, 0, 57, 5, -7, 5, -7,
+ax_anim_terminator
+sSealeoAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 6, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -19, 0, -19,
+ax_anim 2, 1, 61, 1, -19, 1, -19,
+ax_anim 2, 0, 61, 0, -19, 0, -19,
+ax_anim 2, 0, 61, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSealeoAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 6, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 64, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -17, -20, -17, -20,
+ax_anim 2, 1, 64, -18, -19, -18, -19,
+ax_anim 2, 0, 64, -17, -20, -17, -20,
+ax_anim 2, 0, 64, -18, -19, -18, -19,
+ax_anim 2, 0, 63, -5, -7, -5, -7,
+ax_anim_terminator
+sSealeoAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 6, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -16, 0, -16, 0,
+ax_anim 2, 1, 67, -16, 1, -16, 1,
+ax_anim 2, 0, 67, -16, 0, -16, 0,
+ax_anim 2, 0, 67, -16, 1, -16, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSealeoAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 6, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -18, 18, -18, 18,
+ax_anim 2, 1, 70, -19, 17, -19, 17,
+ax_anim 2, 0, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -19, 17, -19, 17,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSealeoAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sSealeoAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sSealeoAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sSealeoAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sSealeoAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sSealeoAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sSealeoAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sSealeoAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSealeoAnims_5_1:
+ax_anim 3, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_5_2:
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim 8, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_5_3:
+ax_anim 3, 0, 100, 0, 0, 0, 0,
+ax_anim 8, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_5_4:
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim 8, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_5_5:
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim 8, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_5_6:
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 8, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_5_7:
+ax_anim 3, 0, 108, 0, 0, 0, 0,
+ax_anim 8, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_5_8:
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 8, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSealeoAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSealeoAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sSealeoAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sSealeoAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sSealeoAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sSealeoAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sSealeoAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sSealeoAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sSealeoAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSealeoAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 14, 0, 123, 0, 0, 0, 0,
+ax_anim 18, 0, 122, 0, 0, 0, 0,
+ax_anim 14, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_8_2:
+ax_anim 40, 0, 124, 0, 0, 0, 0,
+ax_anim 14, 0, 125, 0, 0, 0, 0,
+ax_anim 18, 0, 124, 0, 0, 0, 0,
+ax_anim 14, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_8_3:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 14, 0, 127, 0, 0, 0, 0,
+ax_anim 18, 0, 126, 0, 0, 0, 0,
+ax_anim 14, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_8_4:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 14, 0, 129, 0, 0, 0, 0,
+ax_anim 18, 0, 128, 0, 0, 0, 0,
+ax_anim 14, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_8_5:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 14, 0, 131, 0, 0, 0, 0,
+ax_anim 18, 0, 130, 0, 0, 0, 0,
+ax_anim 14, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_8_6:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim 18, 0, 132, 0, 0, 0, 0,
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_8_7:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim 18, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_8_8:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 14, 0, 137, 0, 0, 0, 0,
+ax_anim 18, 0, 136, 0, 0, 0, 0,
+ax_anim 14, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSealeoAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 7, 4, 7, 4,
+ax_anim 2, 0, 140, 10, 9, 10, 9,
+ax_anim 2, 0, 141, 9, 16, 9, 16,
+ax_anim 3, 0, 142, 0, 18, 0, 18,
+ax_anim 2, 3, 143, -9, 16, -9, 16,
+ax_anim 2, 0, 144, -10, 9, -10, 9,
+ax_anim 1, 0, 145, -7, 4, -7, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 22, 10, 22, 10,
+ax_anim 3, 0, 141, 20, 19, 20, 19,
+ax_anim 2, 3, 142, 11, 19, 11, 19,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 18, -4, 18, -4,
+ax_anim 3, 0, 140, 20, 0, 20, 0,
+ax_anim 2, 3, 141, 17, 4, 17, 4,
+ax_anim 2, 0, 142, 12, 6, 12, 6,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -22, 12, -22,
+ax_anim 3, 0, 139, 20, -23, 20, -23,
+ax_anim 2, 3, 140, 22, -15, 22, -15,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 8, 0, 8, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -19, -7, -19,
+ax_anim 3, 0, 138, 0, -24, 0, -24,
+ax_anim 2, 3, 139, 7, -19, 7, -19,
+ax_anim 2, 0, 140, 9, -12, 9, -12,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -22, -12, -22,
+ax_anim 3, 0, 145, -20, -23, -20, -23,
+ax_anim 2, 3, 144, -22, -15, -22, -15,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -8, 0, -8, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -18, -4, -18, -4,
+ax_anim 3, 0, 144, -20, 0, -20, 0,
+ax_anim 2, 3, 143, -17, 4, -17, 4,
+ax_anim 2, 0, 142, -12, 6, -12, 6,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -22, 10, -22, 10,
+ax_anim 3, 0, 143, -20, 19, -20, 19,
+ax_anim 2, 3, 142, -11, 19, -11, 19,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSealeoAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSealeoAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -24, 0, 0,
+ax_anim 3, 0, 156, 0, -23, 0, 0,
+ax_anim 2, 0, 156, 0, -19, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -24, 0, 0,
+ax_anim 3, 0, 159, 0, -23, 0, 0,
+ax_anim 2, 0, 159, 0, -19, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -24, 0, 0,
+ax_anim 3, 0, 162, 0, -23, 0, 0,
+ax_anim 2, 0, 162, 0, -19, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -25, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -24, 0, 0,
+ax_anim 3, 0, 174, 0, -23, 0, 0,
+ax_anim 2, 0, 174, 0, -19, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -24, 0, 0,
+ax_anim 3, 0, 177, 0, -23, 0, 0,
+ax_anim 2, 0, 177, 0, -19, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSealeoAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSealeoAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSealeoGfx1:
+.incbin "baserom.gba", 0x1506E9C, 0x200
+sSealeoSprites1:
+ax_sprite sSealeoGfx1, 0x200
+ax_sprite_terminator
+sSealeoGfx2:
+.incbin "baserom.gba", 0x15070AC, 0x200
+sSealeoSprites2:
+ax_sprite sSealeoGfx2, 0x200
+ax_sprite_terminator
+sSealeoGfx3:
+.incbin "baserom.gba", 0x15072BC, 0x200
+sSealeoSprites3:
+ax_sprite sSealeoGfx3, 0x200
+ax_sprite_terminator
+sSealeoGfx4:
+.incbin "baserom.gba", 0x15074CC, 0x200
+sSealeoSprites4:
+ax_sprite sSealeoGfx4, 0x200
+ax_sprite_terminator
+sSealeoGfx5:
+.incbin "baserom.gba", 0x15076DC, 0x200
+sSealeoSprites5:
+ax_sprite sSealeoGfx5, 0x200
+ax_sprite_terminator
+sSealeoGfx6:
+.incbin "baserom.gba", 0x15078EC, 0x200
+sSealeoSprites6:
+ax_sprite sSealeoGfx6, 0x200
+ax_sprite_terminator
+sSealeoGfx7:
+.incbin "baserom.gba", 0x1507AFC, 0x200
+sSealeoSprites7:
+ax_sprite sSealeoGfx7, 0x200
+ax_sprite_terminator
+sSealeoGfx8:
+.incbin "baserom.gba", 0x1507D0C, 0x200
+sSealeoSprites8:
+ax_sprite sSealeoGfx8, 0x200
+ax_sprite_terminator
+sSealeoGfx9:
+.incbin "baserom.gba", 0x1507F1C, 0x200
+sSealeoSprites9:
+ax_sprite sSealeoGfx9, 0x200
+ax_sprite_terminator
+sSealeoGfx10:
+.incbin "baserom.gba", 0x150812C, 0x200
+sSealeoSprites10:
+ax_sprite sSealeoGfx10, 0x200
+ax_sprite_terminator
+sSealeoGfx11:
+.incbin "baserom.gba", 0x150833C, 0x200
+sSealeoSprites11:
+ax_sprite sSealeoGfx11, 0x200
+ax_sprite_terminator
+sSealeoGfx12:
+.incbin "baserom.gba", 0x150854C, 0x200
+sSealeoSprites12:
+ax_sprite sSealeoGfx12, 0x200
+ax_sprite_terminator
+sSealeoGfx13:
+.incbin "baserom.gba", 0x150875C, 0x200
+sSealeoSprites13:
+ax_sprite sSealeoGfx13, 0x200
+ax_sprite_terminator
+sSealeoGfx14:
+.incbin "baserom.gba", 0x150896C, 0x200
+sSealeoSprites14:
+ax_sprite sSealeoGfx14, 0x200
+ax_sprite_terminator
+sSealeoGfx15:
+.incbin "baserom.gba", 0x1508B7C, 0x200
+sSealeoSprites15:
+ax_sprite sSealeoGfx15, 0x200
+ax_sprite_terminator
+sSealeoGfx16:
+.incbin "baserom.gba", 0x1508D8C, 0x40
+sSealeoGfx16_1:
+.incbin "baserom.gba", 0x1508DCC, 0xE0
+sSealeoSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSealeoGfx16_1, 0xe0
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSealeoGfx17:
+.incbin "baserom.gba", 0x1508EDC, 0x60
+sSealeoGfx17_1:
+.incbin "baserom.gba", 0x1508F3C, 0x60
+sSealeoGfx17_2:
+.incbin "baserom.gba", 0x1508F9C, 0x60
+sSealeoSprites17:
+ax_sprite sSealeoGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSealeoGfx18:
+.incbin "baserom.gba", 0x1509034, 0x120
+sSealeoGfx18_1:
+.incbin "baserom.gba", 0x1509154, 0x40
+sSealeoSprites18:
+ax_sprite 0, 0x60
+ax_sprite sSealeoGfx18, 0x120
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx19:
+.incbin "baserom.gba", 0x15091C4, 0x60
+sSealeoGfx19_1:
+.incbin "baserom.gba", 0x1509224, 0x100
+sSealeoGfx19_2:
+.incbin "baserom.gba", 0x1509324, 0x40
+sSealeoSprites19:
+ax_sprite sSealeoGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx19_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx19_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx20:
+.incbin "baserom.gba", 0x150939C, 0x40
+sSealeoGfx20_1:
+.incbin "baserom.gba", 0x15093DC, 0x80
+sSealeoSprites20:
+ax_sprite sSealeoGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSealeoGfx20_1, 0x80
+ax_sprite_terminator
+sSealeoGfx21:
+.incbin "baserom.gba", 0x150947C, 0x80
+sSealeoSprites21:
+ax_sprite sSealeoGfx21, 0x80
+ax_sprite_terminator
+sSealeoGfx22:
+.incbin "baserom.gba", 0x150950C, 0x20
+sSealeoSprites22:
+ax_sprite sSealeoGfx22, 0x20
+ax_sprite_terminator
+sSealeoGfx23:
+.incbin "baserom.gba", 0x150953C, 0x60
+sSealeoGfx23_1:
+.incbin "baserom.gba", 0x150959C, 0x60
+sSealeoGfx23_2:
+.incbin "baserom.gba", 0x15095FC, 0xC0
+sSealeoGfx23_3:
+.incbin "baserom.gba", 0x15096BC, 0x20
+sSealeoSprites23:
+ax_sprite sSealeoGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx23_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx23_3, 0x20
+ax_sprite_terminator
+sSealeoGfx24:
+.incbin "baserom.gba", 0x150971C, 0x60
+sSealeoGfx24_1:
+.incbin "baserom.gba", 0x150977C, 0x80
+sSealeoSprites24:
+ax_sprite sSealeoGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx24_1, 0x80
+ax_sprite_terminator
+sSealeoGfx25:
+.incbin "baserom.gba", 0x150981C, 0x60
+sSealeoSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx25, 0x60
+ax_sprite_terminator
+sSealeoGfx26:
+.incbin "baserom.gba", 0x1509894, 0x20
+sSealeoSprites26:
+ax_sprite sSealeoGfx26, 0x20
+ax_sprite_terminator
+sSealeoGfx27:
+.incbin "baserom.gba", 0x15098C4, 0x60
+sSealeoGfx27_1:
+.incbin "baserom.gba", 0x1509924, 0x60
+sSealeoGfx27_2:
+.incbin "baserom.gba", 0x1509984, 0x80
+sSealeoGfx27_3:
+.incbin "baserom.gba", 0x1509A04, 0x60
+sSealeoSprites27:
+ax_sprite sSealeoGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx27_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx27_3, 0x60
+ax_sprite_terminator
+sSealeoGfx28:
+.incbin "baserom.gba", 0x1509AA4, 0x180
+sSealeoGfx28_1:
+.incbin "baserom.gba", 0x1509C24, 0x40
+sSealeoSprites28:
+ax_sprite sSealeoGfx28, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx29:
+.incbin "baserom.gba", 0x1509C8C, 0x60
+sSealeoGfx29_1:
+.incbin "baserom.gba", 0x1509CEC, 0x60
+sSealeoGfx29_2:
+.incbin "baserom.gba", 0x1509D4C, 0x60
+sSealeoGfx29_3:
+.incbin "baserom.gba", 0x1509DAC, 0x60
+sSealeoSprites29:
+ax_sprite sSealeoGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx30:
+.incbin "baserom.gba", 0x1509E54, 0x80
+sSealeoGfx30_1:
+.incbin "baserom.gba", 0x1509ED4, 0x40
+sSealeoGfx30_2:
+.incbin "baserom.gba", 0x1509F14, 0x80
+sSealeoGfx30_3:
+.incbin "baserom.gba", 0x1509F94, 0x40
+sSealeoSprites30:
+ax_sprite sSealeoGfx30, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx30_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx31:
+.incbin "baserom.gba", 0x150A01C, 0x40
+sSealeoGfx31_1:
+.incbin "baserom.gba", 0x150A05C, 0x60
+sSealeoGfx31_2:
+.incbin "baserom.gba", 0x150A0BC, 0x100
+sSealeoSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx31_2, 0x100
+ax_sprite_terminator
+sSealeoGfx32:
+.incbin "baserom.gba", 0x150A1F4, 0x60
+sSealeoGfx32_1:
+.incbin "baserom.gba", 0x150A254, 0x100
+sSealeoGfx32_2:
+.incbin "baserom.gba", 0x150A354, 0x40
+sSealeoSprites32:
+ax_sprite sSealeoGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx33:
+.incbin "baserom.gba", 0x150A3CC, 0x180
+sSealeoSprites33:
+ax_sprite 0, 0x60
+ax_sprite sSealeoGfx33, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx34:
+.incbin "baserom.gba", 0x150A56C, 0x60
+sSealeoGfx34_1:
+.incbin "baserom.gba", 0x150A5CC, 0x60
+sSealeoGfx34_2:
+.incbin "baserom.gba", 0x150A62C, 0x80
+sSealeoGfx34_3:
+.incbin "baserom.gba", 0x150A6AC, 0x60
+sSealeoSprites34:
+ax_sprite sSealeoGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx34_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx34_3, 0x60
+ax_sprite_terminator
+sSealeoGfx35:
+.incbin "baserom.gba", 0x150A74C, 0x40
+sSealeoGfx35_1:
+.incbin "baserom.gba", 0x150A78C, 0x80
+sSealeoSprites35:
+ax_sprite sSealeoGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSealeoGfx35_1, 0x80
+ax_sprite_terminator
+sSealeoGfx36:
+.incbin "baserom.gba", 0x150A82C, 0x80
+sSealeoSprites36:
+ax_sprite sSealeoGfx36, 0x80
+ax_sprite_terminator
+sSealeoGfx37:
+.incbin "baserom.gba", 0x150A8BC, 0x20
+sSealeoSprites37:
+ax_sprite sSealeoGfx37, 0x20
+ax_sprite_terminator
+sSealeoGfx38:
+.incbin "baserom.gba", 0x150A8EC, 0x60
+sSealeoGfx38_1:
+.incbin "baserom.gba", 0x150A94C, 0x60
+sSealeoGfx38_2:
+.incbin "baserom.gba", 0x150A9AC, 0x80
+sSealeoGfx38_3:
+.incbin "baserom.gba", 0x150AA2C, 0x60
+sSealeoSprites38:
+ax_sprite sSealeoGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx38_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx38_3, 0x60
+ax_sprite_terminator
+sSealeoGfx39:
+.incbin "baserom.gba", 0x150AACC, 0x40
+sSealeoGfx39_1:
+.incbin "baserom.gba", 0x150AB0C, 0x60
+sSealeoSprites39:
+ax_sprite sSealeoGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSealeoGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx40:
+.incbin "baserom.gba", 0x150AB94, 0x80
+sSealeoSprites40:
+ax_sprite sSealeoGfx40, 0x80
+ax_sprite_terminator
+sSealeoGfx41:
+.incbin "baserom.gba", 0x150AC24, 0x20
+sSealeoSprites41:
+ax_sprite sSealeoGfx41, 0x20
+ax_sprite_terminator
+sSealeoGfx42:
+.incbin "baserom.gba", 0x150AC54, 0xC0
+sSealeoGfx42_1:
+.incbin "baserom.gba", 0x150AD14, 0x20
+sSealeoSprites42:
+ax_sprite sSealeoGfx42, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx42_1, 0x20
+ax_sprite_terminator
+sSealeoGfx43:
+.incbin "baserom.gba", 0x150AD54, 0x80
+sSealeoSprites43:
+ax_sprite sSealeoGfx43, 0x80
+ax_sprite_terminator
+sSealeoGfx44:
+.incbin "baserom.gba", 0x150ADE4, 0x40
+sSealeoSprites44:
+ax_sprite sSealeoGfx44, 0x40
+ax_sprite_terminator
+sSealeoGfx45:
+.incbin "baserom.gba", 0x150AE34, 0x20
+sSealeoSprites45:
+ax_sprite sSealeoGfx45, 0x20
+ax_sprite_terminator
+sSealeoGfx46:
+.incbin "baserom.gba", 0x150AE64, 0x20
+sSealeoSprites46:
+ax_sprite sSealeoGfx46, 0x20
+ax_sprite_terminator
+sSealeoGfx47:
+.incbin "baserom.gba", 0x150AE94, 0x40
+sSealeoGfx47_1:
+.incbin "baserom.gba", 0x150AED4, 0x100
+sSealeoGfx47_2:
+.incbin "baserom.gba", 0x150AFD4, 0x40
+sSealeoSprites47:
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx47, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx47_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSealeoGfx47_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSealeoGfx48:
+.incbin "baserom.gba", 0x150B054, 0x200
+sSealeoSprites48:
+ax_sprite sSealeoGfx48, 0x200
+ax_sprite_terminator
+sSealeoGfx49:
+.incbin "baserom.gba", 0x150B264, 0x200
+sSealeoSprites49:
+ax_sprite sSealeoGfx49, 0x200
+ax_sprite_terminator
+sSealeoGfx50:
+.incbin "baserom.gba", 0x150B474, 0x200
+sSealeoSprites50:
+ax_sprite sSealeoGfx50, 0x200
+ax_sprite_terminator
+sSealeoGfx51:
+.incbin "baserom.gba", 0x150B684, 0x200
+sSealeoSprites51:
+ax_sprite sSealeoGfx51, 0x200
+ax_sprite_terminator
+sSealeoGfx52:
+.incbin "baserom.gba", 0x150B894, 0x200
+sSealeoSprites52:
+ax_sprite sSealeoGfx52, 0x200
+ax_sprite_terminator
+sSealeoGfx53:
+.incbin "baserom.gba", 0x150BAA4, 0x200
+sSealeoSprites53:
+ax_sprite sSealeoGfx53, 0x200
+ax_sprite_terminator
+sSealeoGfx54:
+.incbin "baserom.gba", 0x150BCB4, 0x200
+sSealeoSprites54:
+ax_sprite sSealeoGfx54, 0x200
+ax_sprite_terminator
+sAxPosesSealeo:
+.4byte sSealeoPose1
+.4byte sSealeoPose2
+.4byte sSealeoPose3
+.4byte sSealeoPose4
+.4byte sSealeoPose5
+.4byte sSealeoPose6
+.4byte sSealeoPose7
+.4byte sSealeoPose8
+.4byte sSealeoPose9
+.4byte sSealeoPose10
+.4byte sSealeoPose11
+.4byte sSealeoPose12
+.4byte sSealeoPose13
+.4byte sSealeoPose14
+.4byte sSealeoPose15
+.4byte sSealeoPose16
+.4byte sSealeoPose17
+.4byte sSealeoPose18
+.4byte sSealeoPose19
+.4byte sSealeoPose20
+.4byte sSealeoPose21
+.4byte sSealeoPose22
+.4byte sSealeoPose23
+.4byte sSealeoPose24
+.4byte sSealeoPose25
+.4byte sSealeoPose26
+.4byte sSealeoPose27
+.4byte sSealeoPose28
+.4byte sSealeoPose29
+.4byte sSealeoPose30
+.4byte sSealeoPose31
+.4byte sSealeoPose32
+.4byte sSealeoPose33
+.4byte sSealeoPose34
+.4byte sSealeoPose35
+.4byte sSealeoPose36
+.4byte sSealeoPose37
+.4byte sSealeoPose38
+.4byte sSealeoPose39
+.4byte sSealeoPose40
+.4byte sSealeoPose41
+.4byte sSealeoPose42
+.4byte sSealeoPose43
+.4byte sSealeoPose44
+.4byte sSealeoPose45
+.4byte sSealeoPose46
+.4byte sSealeoPose47
+.4byte sSealeoPose48
+.4byte sSealeoPose49
+.4byte sSealeoPose50
+.4byte sSealeoPose51
+.4byte sSealeoPose52
+.4byte sSealeoPose53
+.4byte sSealeoPose54
+.4byte sSealeoPose55
+.4byte sSealeoPose56
+.4byte sSealeoPose57
+.4byte sSealeoPose58
+.4byte sSealeoPose59
+.4byte sSealeoPose60
+.4byte sSealeoPose61
+.4byte sSealeoPose62
+.4byte sSealeoPose63
+.4byte sSealeoPose64
+.4byte sSealeoPose65
+.4byte sSealeoPose66
+.4byte sSealeoPose67
+.4byte sSealeoPose68
+.4byte sSealeoPose69
+.4byte sSealeoPose70
+.4byte sSealeoPose71
+.4byte sSealeoPose72
+.4byte sSealeoPose73
+.4byte sSealeoPose74
+.4byte sSealeoPose75
+.4byte sSealeoPose76
+.4byte sSealeoPose77
+.4byte sSealeoPose78
+.4byte sSealeoPose79
+.4byte sSealeoPose80
+.4byte sSealeoPose81
+.4byte sSealeoPose82
+.4byte sSealeoPose83
+.4byte sSealeoPose84
+.4byte sSealeoPose85
+.4byte sSealeoPose86
+.4byte sSealeoPose87
+.4byte sSealeoPose88
+.4byte sSealeoPose89
+.4byte sSealeoPose90
+.4byte sSealeoPose91
+.4byte sSealeoPose92
+.4byte sSealeoPose93
+.4byte sSealeoPose94
+.4byte sSealeoPose95
+.4byte sSealeoPose96
+.4byte sSealeoPose97
+.4byte sSealeoPose98
+.4byte sSealeoPose99
+.4byte sSealeoPose100
+.4byte sSealeoPose101
+.4byte sSealeoPose102
+.4byte sSealeoPose103
+.4byte sSealeoPose104
+.4byte sSealeoPose105
+.4byte sSealeoPose106
+.4byte sSealeoPose107
+.4byte sSealeoPose108
+.4byte sSealeoPose109
+.4byte sSealeoPose110
+.4byte sSealeoPose111
+.4byte sSealeoPose112
+.4byte sSealeoPose113
+.4byte sSealeoPose114
+.4byte sSealeoPose115
+.4byte sSealeoPose116
+.4byte sSealeoPose117
+.4byte sSealeoPose118
+.4byte sSealeoPose119
+.4byte sSealeoPose120
+.4byte sSealeoPose121
+.4byte sSealeoPose122
+.4byte sSealeoPose123
+.4byte sSealeoPose124
+.4byte sSealeoPose125
+.4byte sSealeoPose126
+.4byte sSealeoPose127
+.4byte sSealeoPose128
+.4byte sSealeoPose129
+.4byte sSealeoPose130
+.4byte sSealeoPose131
+.4byte sSealeoPose132
+.4byte sSealeoPose133
+.4byte sSealeoPose134
+.4byte sSealeoPose135
+.4byte sSealeoPose136
+.4byte sSealeoPose137
+.4byte sSealeoPose138
+.4byte sSealeoPose139
+.4byte sSealeoPose140
+.4byte sSealeoPose141
+.4byte sSealeoPose142
+.4byte sSealeoPose143
+.4byte sSealeoPose144
+.4byte sSealeoPose145
+.4byte sSealeoPose146
+.4byte sSealeoPose147
+.4byte sSealeoPose148
+.4byte sSealeoPose149
+.4byte sSealeoPose150
+.4byte sSealeoPose151
+.4byte sSealeoPose152
+.4byte sSealeoPose153
+.4byte sSealeoPose154
+.4byte sSealeoPose155
+.4byte sSealeoPose156
+.4byte sSealeoPose157
+.4byte sSealeoPose158
+.4byte sSealeoPose159
+.4byte sSealeoPose160
+.4byte sSealeoPose161
+.4byte sSealeoPose162
+.4byte sSealeoPose163
+.4byte sSealeoPose164
+.4byte sSealeoPose165
+.4byte sSealeoPose166
+.4byte sSealeoPose167
+.4byte sSealeoPose168
+.4byte sSealeoPose169
+.4byte sSealeoPose170
+.4byte sSealeoPose171
+.4byte sSealeoPose172
+.4byte sSealeoPose173
+.4byte sSealeoPose174
+.4byte sSealeoPose175
+.4byte sSealeoPose176
+.4byte sSealeoPose177
+.4byte sSealeoPose178
+.4byte sSealeoPose179
+.4byte sSealeoPose180
+.4byte sSealeoPose181
+.4byte sSealeoPose182
+.4byte sSealeoPose183
+.4byte sSealeoPose184
+.4byte sSealeoPose185
+.4byte sSealeoPose186
+.4byte sSealeoPose187
+.4byte sSealeoPose188
+.4byte sSealeoPose189
+.4byte sSealeoPose190
+.4byte sSealeoPose191
+.4byte sSealeoPose192
+.4byte sSealeoPose193
+.4byte sSealeoPose194
+sAxPositionsSealeo:
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte    0,  -12, 	  -8,   -2, 	   7,   -2, 	   0,   -6
+.2byte    0,   -8, 	  -8,    1, 	   7,    1, 	   0,   -4
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+.2byte    3,  -11, 	   4,   -4, 	  -7,    0, 	  -2,   -6
+.2byte    3,   -7, 	   8,   -1, 	  -2,    2, 	  -3,   -5
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte    7,  -13, 	  -1,   -2, 	   0,    1, 	  -1,   -7
+.2byte    9,   -9, 	   7,   -3, 	   7,    1, 	  -1,   -4
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    5,  -15, 	  -6,   -7, 	   3,    0, 	  -1,   -9
+.2byte    5,  -11, 	  -2,   -7, 	   6,   -3, 	  -2,   -5
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -17, 	   7,   -5, 	  -8,   -5, 	   0,  -10
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -6
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte   -6,  -15, 	   5,   -7, 	  -4,    0, 	   0,   -9
+.2byte   -6,  -11, 	   1,   -7, 	  -7,   -3, 	   1,   -5
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte   -8,  -13, 	   0,   -2, 	  -1,    1, 	   0,   -7
+.2byte  -10,   -9, 	  -8,   -3, 	  -8,    1, 	   0,   -4
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -4,  -11, 	  -5,   -4, 	   6,    0, 	   1,   -6
+.2byte   -4,   -7, 	  -9,   -1, 	   1,    2, 	   2,   -5
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte    0,   -4, 	  -9,    0, 	   8,    0, 	  -1,   -4
+.2byte   -1,  -16, 	  -9,   -2, 	   7,   -2, 	   0,   -8
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+.2byte    7,   -4, 	   4,   -2, 	  -4,    1, 	  -1,   -4
+.2byte    4,  -14, 	   6,   -3, 	  -3,    1, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte   13,  -10, 	   2,   -5, 	   2,    0, 	   0,   -5
+.2byte    6,  -16, 	   4,   -5, 	   4,    1, 	  -1,   -6
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    9,  -15, 	  -1,   -6, 	   5,   -2, 	   0,   -7
+.2byte    2,  -19, 	  -3,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -17, 	   7,   -6, 	  -8,   -6, 	   0,   -9
+.2byte   -1,  -16, 	   7,   -5, 	  -8,   -5, 	   0,   -7
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte  -10,  -15, 	   0,   -6, 	  -6,   -2, 	  -1,   -7
+.2byte   -3,  -19, 	   2,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte  -14,  -10, 	  -3,   -5, 	  -3,    0, 	  -1,   -5
+.2byte   -7,  -16, 	  -5,   -5, 	  -5,    1, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -8,   -4, 	  -5,   -2, 	   3,    1, 	   0,   -4
+.2byte   -5,  -14, 	  -7,   -3, 	   2,    1, 	   0,   -6
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte    0,   -4, 	  -9,    0, 	   8,    0, 	  -1,   -4
+.2byte   -1,  -16, 	  -9,   -2, 	   7,   -2, 	   0,   -8
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+.2byte    7,   -4, 	   4,   -2, 	  -4,    1, 	  -1,   -4
+.2byte    4,  -14, 	   6,   -3, 	  -3,    1, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte   13,  -10, 	   2,   -5, 	   2,    0, 	   0,   -5
+.2byte    6,  -16, 	   4,   -5, 	   4,    1, 	  -1,   -6
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    9,  -15, 	  -1,   -6, 	   5,   -2, 	   0,   -7
+.2byte    2,  -19, 	  -3,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -17, 	   7,   -6, 	  -8,   -6, 	   0,   -9
+.2byte   -1,  -16, 	   7,   -5, 	  -8,   -5, 	   0,   -7
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte  -10,  -15, 	   0,   -6, 	  -6,   -2, 	  -1,   -7
+.2byte   -3,  -19, 	   2,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte  -14,  -10, 	  -3,   -5, 	  -3,    0, 	  -1,   -5
+.2byte   -7,  -16, 	  -5,   -5, 	  -5,    1, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -8,   -4, 	  -5,   -2, 	   3,    1, 	   0,   -4
+.2byte   -5,  -14, 	  -7,   -3, 	   2,    1, 	   0,   -6
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte    0,  -19, 	 -11,   -5, 	  10,   -5, 	   0,   -8
+.2byte    0,   -2, 	  -9,    1, 	   7,    1, 	   0,   -4
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+.2byte    3,  -18, 	  10,   -7, 	  -4,   -3, 	  -1,   -6
+.2byte    9,   -3, 	   9,   -1, 	  -1,    2, 	   1,   -4
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte    4,  -18, 	   5,   -9, 	   5,   -3, 	  -2,   -6
+.2byte   12,   -7, 	   6,   -3, 	   4,    1, 	   0,   -5
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    2,  -19, 	  -5,  -11, 	  11,   -9, 	  -2,   -7
+.2byte   10,  -11, 	   0,   -7, 	   7,   -2, 	   1,   -8
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -18, 	   9,   -9, 	  -9,   -9, 	   0,   -7
+.2byte   -1,  -14, 	   7,   -6, 	  -8,   -6, 	   0,   -8
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte   -3,  -19, 	   4,  -11, 	 -12,   -9, 	   1,   -7
+.2byte  -11,  -11, 	  -1,   -7, 	  -8,   -2, 	  -2,   -8
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte   -5,  -18, 	  -6,   -9, 	  -6,   -3, 	   1,   -6
+.2byte  -13,   -7, 	  -7,   -3, 	  -5,    1, 	  -1,   -5
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -4,  -18, 	 -11,   -7, 	   3,   -3, 	   0,   -6
+.2byte  -10,   -3, 	 -10,   -1, 	   0,    2, 	  -2,   -4
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte   -1,  -15, 	  -9,   -1, 	   7,   -1, 	   0,   -7
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+.2byte    4,  -14, 	   6,   -3, 	  -3,    1, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte    6,  -16, 	   4,   -5, 	   4,    1, 	  -1,   -6
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    2,  -19, 	  -3,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -16, 	   7,   -5, 	  -8,   -5, 	   0,   -7
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte   -3,  -19, 	   2,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte   -7,  -16, 	  -5,   -5, 	  -5,    1, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -5,  -14, 	  -7,   -3, 	   2,    1, 	   0,   -6
+.2byte   -8,   -1, 	  -1,   -7, 	   8,   -3, 	   1,   -6
+.2byte   -8,    0, 	  -1,   -7, 	   7,   -3, 	   1,   -6
+.2byte    0,  -16, 	  -8,   -4, 	   9,   -4, 	   1,   -9
+.2byte    2,  -15, 	   7,   -4, 	  -6,   -2, 	   0,   -7
+.2byte    4,  -13, 	  -1,   -4, 	   0,   -1, 	  -1,   -7
+.2byte    1,  -16, 	  -4,   -6, 	   5,   -3, 	  -2,   -8
+.2byte    1,  -16, 	   8,   -6, 	  -7,   -6, 	   1,   -8
+.2byte   -2,  -16, 	   3,   -6, 	  -6,   -3, 	   1,   -8
+.2byte   -5,  -13, 	   0,   -4, 	  -1,   -1, 	   0,   -7
+.2byte   -3,  -15, 	  -8,   -4, 	   5,   -2, 	  -1,   -7
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte   -1,  -15, 	  -9,   -1, 	   7,   -1, 	   0,   -7
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+.2byte    4,  -14, 	   6,   -3, 	  -3,    1, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte    6,  -16, 	   4,   -5, 	   4,    1, 	  -1,   -6
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    3,  -20, 	  -2,   -7, 	   6,   -3, 	   0,   -8
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -18, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte   -4,  -20, 	   1,   -7, 	  -7,   -3, 	  -1,   -8
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte   -7,  -16, 	  -5,   -5, 	  -5,    1, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -5,  -14, 	  -7,   -3, 	   2,    1, 	   0,   -6
+.2byte   -1,  -15, 	  -9,   -1, 	   7,   -1, 	   0,   -7
+.2byte   -5,  -14, 	  -7,   -3, 	   2,    1, 	   0,   -6
+.2byte   -7,  -16, 	  -5,   -5, 	  -5,    1, 	   0,   -6
+.2byte   -3,  -19, 	   2,   -6, 	  -6,   -2, 	   0,   -7
+.2byte   -1,  -16, 	   7,   -5, 	  -8,   -5, 	   0,   -7
+.2byte    2,  -19, 	  -3,   -6, 	   5,   -2, 	  -1,   -7
+.2byte    6,  -16, 	   4,   -5, 	   4,    1, 	  -1,   -6
+.2byte    4,  -14, 	   6,   -3, 	  -3,    1, 	  -1,   -6
+.2byte    0,  -19, 	 -11,   -5, 	  10,   -5, 	   0,   -8
+.2byte    3,  -19, 	  10,   -8, 	  -4,   -4, 	  -1,   -7
+.2byte    4,  -18, 	   5,   -9, 	   5,   -3, 	  -2,   -6
+.2byte    2,  -19, 	  -5,  -11, 	  11,   -9, 	  -2,   -7
+.2byte   -1,  -19, 	   9,  -10, 	  -9,  -10, 	   0,   -8
+.2byte   -3,  -19, 	   4,  -11, 	 -12,   -9, 	   1,   -7
+.2byte   -5,  -18, 	  -6,   -9, 	  -6,   -3, 	   1,   -6
+.2byte   -4,  -19, 	 -11,   -8, 	   3,   -4, 	   0,   -7
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte    0,  -19, 	 -11,   -5, 	  10,   -5, 	   0,   -8
+.2byte    0,   -3, 	  -9,    0, 	   7,    0, 	   0,   -5
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+.2byte    1,  -18, 	   8,   -7, 	  -6,   -3, 	  -3,   -6
+.2byte    6,   -3, 	   6,   -1, 	  -4,    2, 	  -2,   -4
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte    4,  -18, 	   5,   -9, 	   5,   -3, 	  -2,   -6
+.2byte   11,   -7, 	   5,   -3, 	   3,    1, 	  -1,   -5
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    2,  -19, 	  -5,  -11, 	  11,   -9, 	  -2,   -7
+.2byte    8,  -11, 	  -2,   -7, 	   5,   -2, 	  -1,   -8
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte   -1,  -18, 	   9,   -9, 	  -9,   -9, 	   0,   -7
+.2byte   -1,  -14, 	   7,   -6, 	  -8,   -6, 	   0,   -8
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte   -3,  -19, 	   4,  -11, 	 -12,   -9, 	   1,   -7
+.2byte   -9,  -11, 	   1,   -7, 	  -6,   -2, 	   0,   -8
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte   -5,  -18, 	  -6,   -9, 	  -6,   -3, 	   1,   -6
+.2byte  -12,   -7, 	  -6,   -3, 	  -4,    1, 	   0,   -5
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -2,  -18, 	  -9,   -7, 	   5,   -3, 	   2,   -6
+.2byte   -7,   -3, 	  -7,   -1, 	   3,    2, 	   1,   -4
+.2byte    0,   -2, 	  -9,    1, 	   7,    1, 	   0,   -4
+.2byte  -10,   -3, 	 -10,   -1, 	   0,    2, 	  -2,   -4
+.2byte  -13,   -7, 	  -7,   -3, 	  -5,    1, 	  -1,   -5
+.2byte  -11,  -11, 	  -1,   -7, 	  -8,   -2, 	  -2,   -8
+.2byte   -1,  -15, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   10,  -11, 	   0,   -7, 	   7,   -2, 	   1,   -8
+.2byte   12,   -7, 	   6,   -3, 	   4,    1, 	   0,   -5
+.2byte    9,   -3, 	   9,   -1, 	  -1,    2, 	   1,   -4
+.2byte    0,   -9, 	  -8,   -1, 	   8,   -1, 	   0,   -5
+.2byte   -4,   -8, 	  -8,   -3, 	   3,    1, 	   1,   -4
+.2byte   -8,  -10, 	  -5,   -3, 	  -4,    1, 	   1,   -5
+.2byte   -6,  -13, 	   2,   -5, 	  -6,   -2, 	   1,   -7
+.2byte    0,  -13, 	   7,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    5,  -13, 	  -3,   -5, 	   5,   -2, 	  -2,   -7
+.2byte    7,  -10, 	   4,   -3, 	   3,    1, 	  -2,   -5
+.2byte    3,   -8, 	   7,   -3, 	  -4,    1, 	  -2,   -4
+sSealeoAnimTable1:
+.4byte sSealeoAnims_1_1
+.4byte sSealeoAnims_1_2
+.4byte sSealeoAnims_1_3
+.4byte sSealeoAnims_1_4
+.4byte sSealeoAnims_1_5
+.4byte sSealeoAnims_1_6
+.4byte sSealeoAnims_1_7
+.4byte sSealeoAnims_1_8
+sSealeoAnimTable2:
+.4byte sSealeoAnims_2_1
+.4byte sSealeoAnims_2_2
+.4byte sSealeoAnims_2_3
+.4byte sSealeoAnims_2_4
+.4byte sSealeoAnims_2_5
+.4byte sSealeoAnims_2_6
+.4byte sSealeoAnims_2_7
+.4byte sSealeoAnims_2_8
+sSealeoAnimTable3:
+.4byte sSealeoAnims_3_1
+.4byte sSealeoAnims_3_2
+.4byte sSealeoAnims_3_3
+.4byte sSealeoAnims_3_4
+.4byte sSealeoAnims_3_5
+.4byte sSealeoAnims_3_6
+.4byte sSealeoAnims_3_7
+.4byte sSealeoAnims_3_8
+sSealeoAnimTable4:
+.4byte sSealeoAnims_4_1
+.4byte sSealeoAnims_4_2
+.4byte sSealeoAnims_4_3
+.4byte sSealeoAnims_4_4
+.4byte sSealeoAnims_4_5
+.4byte sSealeoAnims_4_6
+.4byte sSealeoAnims_4_7
+.4byte sSealeoAnims_4_8
+sSealeoAnimTable5:
+.4byte sSealeoAnims_5_1
+.4byte sSealeoAnims_5_2
+.4byte sSealeoAnims_5_3
+.4byte sSealeoAnims_5_4
+.4byte sSealeoAnims_5_5
+.4byte sSealeoAnims_5_6
+.4byte sSealeoAnims_5_7
+.4byte sSealeoAnims_5_8
+sSealeoAnimTable6:
+.4byte sSealeoAnims_6_1
+.4byte sSealeoAnims_6_1
+.4byte sSealeoAnims_6_1
+.4byte sSealeoAnims_6_1
+.4byte sSealeoAnims_6_1
+.4byte sSealeoAnims_6_1
+.4byte sSealeoAnims_6_1
+.4byte sSealeoAnims_6_1
+sSealeoAnimTable7:
+.4byte sSealeoAnims_7_1
+.4byte sSealeoAnims_7_2
+.4byte sSealeoAnims_7_3
+.4byte sSealeoAnims_7_4
+.4byte sSealeoAnims_7_5
+.4byte sSealeoAnims_7_6
+.4byte sSealeoAnims_7_7
+.4byte sSealeoAnims_7_8
+sSealeoAnimTable8:
+.4byte sSealeoAnims_8_1
+.4byte sSealeoAnims_8_2
+.4byte sSealeoAnims_8_3
+.4byte sSealeoAnims_8_4
+.4byte sSealeoAnims_8_5
+.4byte sSealeoAnims_8_6
+.4byte sSealeoAnims_8_7
+.4byte sSealeoAnims_8_8
+sSealeoAnimTable9:
+.4byte sSealeoAnims_9_1
+.4byte sSealeoAnims_9_2
+.4byte sSealeoAnims_9_3
+.4byte sSealeoAnims_9_4
+.4byte sSealeoAnims_9_5
+.4byte sSealeoAnims_9_6
+.4byte sSealeoAnims_9_7
+.4byte sSealeoAnims_9_8
+sSealeoAnimTable10:
+.4byte sSealeoAnims_10_1
+.4byte sSealeoAnims_10_2
+.4byte sSealeoAnims_10_3
+.4byte sSealeoAnims_10_4
+.4byte sSealeoAnims_10_5
+.4byte sSealeoAnims_10_6
+.4byte sSealeoAnims_10_7
+.4byte sSealeoAnims_10_8
+sSealeoAnimTable11:
+.4byte sSealeoAnims_11_1
+.4byte sSealeoAnims_11_2
+.4byte sSealeoAnims_11_3
+.4byte sSealeoAnims_11_4
+.4byte sSealeoAnims_11_5
+.4byte sSealeoAnims_11_6
+.4byte sSealeoAnims_11_7
+.4byte sSealeoAnims_11_8
+sSealeoAnimTable12:
+.4byte sSealeoAnims_12_1
+.4byte sSealeoAnims_12_2
+.4byte sSealeoAnims_12_3
+.4byte sSealeoAnims_12_4
+.4byte sSealeoAnims_12_5
+.4byte sSealeoAnims_12_6
+.4byte sSealeoAnims_12_7
+.4byte sSealeoAnims_12_8
+sSealeoAnimTable13:
+.4byte sSealeoAnims_13_1
+.4byte sSealeoAnims_13_2
+.4byte sSealeoAnims_13_3
+.4byte sSealeoAnims_13_4
+.4byte sSealeoAnims_13_5
+.4byte sSealeoAnims_13_6
+.4byte sSealeoAnims_13_7
+.4byte sSealeoAnims_13_8
+sAxAnimationsSealeo:
+.4byte sSealeoAnimTable1
+.4byte sSealeoAnimTable2
+.4byte sSealeoAnimTable3
+.4byte sSealeoAnimTable4
+.4byte sSealeoAnimTable5
+.4byte sSealeoAnimTable6
+.4byte sSealeoAnimTable7
+.4byte sSealeoAnimTable8
+.4byte sSealeoAnimTable9
+.4byte sSealeoAnimTable10
+.4byte sSealeoAnimTable11
+.4byte sSealeoAnimTable12
+.4byte sSealeoAnimTable13
+sAxSpritesSealeo:
+.4byte sSealeoSprites1
+.4byte sSealeoSprites2
+.4byte sSealeoSprites3
+.4byte sSealeoSprites4
+.4byte sSealeoSprites5
+.4byte sSealeoSprites6
+.4byte sSealeoSprites7
+.4byte sSealeoSprites8
+.4byte sSealeoSprites9
+.4byte sSealeoSprites10
+.4byte sSealeoSprites11
+.4byte sSealeoSprites12
+.4byte sSealeoSprites13
+.4byte sSealeoSprites14
+.4byte sSealeoSprites15
+.4byte sSealeoSprites16
+.4byte sSealeoSprites17
+.4byte sSealeoSprites18
+.4byte sSealeoSprites19
+.4byte sSealeoSprites20
+.4byte sSealeoSprites21
+.4byte sSealeoSprites22
+.4byte sSealeoSprites23
+.4byte sSealeoSprites24
+.4byte sSealeoSprites25
+.4byte sSealeoSprites26
+.4byte sSealeoSprites27
+.4byte sSealeoSprites28
+.4byte sSealeoSprites29
+.4byte sSealeoSprites30
+.4byte sSealeoSprites31
+.4byte sSealeoSprites32
+.4byte sSealeoSprites33
+.4byte sSealeoSprites34
+.4byte sSealeoSprites35
+.4byte sSealeoSprites36
+.4byte sSealeoSprites37
+.4byte sSealeoSprites38
+.4byte sSealeoSprites39
+.4byte sSealeoSprites40
+.4byte sSealeoSprites41
+.4byte sSealeoSprites42
+.4byte sSealeoSprites43
+.4byte sSealeoSprites44
+.4byte sSealeoSprites45
+.4byte sSealeoSprites46
+.4byte sSealeoSprites47
+.4byte sSealeoSprites48
+.4byte sSealeoSprites49
+.4byte sSealeoSprites50
+.4byte sSealeoSprites51
+.4byte sSealeoSprites52
+.4byte sSealeoSprites53
+.4byte sSealeoSprites54
+sAxMainSealeo:
+ax_main sAxPosesSealeo, sAxAnimationsSealeo, 13, sAxSpritesSealeo, sAxPositionsSealeo

--- a/data/ax/seedot.inc
+++ b/data/ax/seedot.inc
@@ -1,0 +1,2629 @@
+.global gAxSeedot
+gAxSeedot:
+ax_siro sAxMainSeedot
+sSeedotPose1:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose2:
+ax_pose 1, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose3:
+ax_pose 2, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose4:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose5:
+ax_pose 4, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose6:
+ax_pose 5, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose7:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose8:
+ax_pose 7, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose9:
+ax_pose 8, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose10:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose11:
+ax_pose 10, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose12:
+ax_pose 11, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose13:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose14:
+ax_pose 13, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose15:
+ax_pose 14, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose16:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose17:
+ax_pose 10, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose18:
+ax_pose 11, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose19:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose20:
+ax_pose 7, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose21:
+ax_pose 8, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose22:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose23:
+ax_pose 4, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose24:
+ax_pose 5, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose25:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose26:
+ax_pose 1, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose27:
+ax_pose 2, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose28:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose29:
+ax_pose 16, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose30:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose31:
+ax_pose 4, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose32:
+ax_pose 5, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose33:
+ax_pose 17, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose34:
+ax_pose 18, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose35:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose36:
+ax_pose 7, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose37:
+ax_pose 8, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose38:
+ax_pose 19, 0x81eb, 0x90f6, 0x6c00
+ax_pose_terminator
+sSeedotPose39:
+ax_pose 20, 0x81eb, 0x90fa, 0x6c00
+ax_pose_terminator
+sSeedotPose40:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose41:
+ax_pose 10, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose42:
+ax_pose 11, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose43:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose44:
+ax_pose 22, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose45:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose46:
+ax_pose 13, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose47:
+ax_pose 14, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose48:
+ax_pose 23, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose49:
+ax_pose 24, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose50:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose51:
+ax_pose 10, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose52:
+ax_pose 11, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose53:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose54:
+ax_pose 22, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose55:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose56:
+ax_pose 7, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose57:
+ax_pose 8, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose58:
+ax_pose 19, 0x81eb, 0x80fa, 0x6c00
+ax_pose_terminator
+sSeedotPose59:
+ax_pose 20, 0x81eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sSeedotPose60:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose61:
+ax_pose 4, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose62:
+ax_pose 5, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose63:
+ax_pose 17, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose64:
+ax_pose 18, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose65:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose66:
+ax_pose 1, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose67:
+ax_pose 2, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose68:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose69:
+ax_pose 16, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose70:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose71:
+ax_pose 4, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose72:
+ax_pose 5, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose73:
+ax_pose 17, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose74:
+ax_pose 18, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose75:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose76:
+ax_pose 7, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose77:
+ax_pose 8, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose78:
+ax_pose 19, 0x81eb, 0x90f6, 0x6c00
+ax_pose_terminator
+sSeedotPose79:
+ax_pose 20, 0x81eb, 0x90fa, 0x6c00
+ax_pose_terminator
+sSeedotPose80:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose81:
+ax_pose 10, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose82:
+ax_pose 11, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose83:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose84:
+ax_pose 22, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose85:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose86:
+ax_pose 13, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose87:
+ax_pose 14, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose88:
+ax_pose 23, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose89:
+ax_pose 24, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose90:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose91:
+ax_pose 10, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose92:
+ax_pose 11, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose93:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose94:
+ax_pose 22, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose95:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose96:
+ax_pose 7, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose97:
+ax_pose 8, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose98:
+ax_pose 19, 0x81eb, 0x80fa, 0x6c00
+ax_pose_terminator
+sSeedotPose99:
+ax_pose 20, 0x81eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sSeedotPose100:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose101:
+ax_pose 4, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose102:
+ax_pose 5, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose103:
+ax_pose 17, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose104:
+ax_pose 18, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose105:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose106:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose107:
+ax_pose 25, 0x81e8, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose108:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose109:
+ax_pose 17, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose110:
+ax_pose 26, 0x81ea, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose111:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose112:
+ax_pose 19, 0x81eb, 0x90f6, 0x6c00
+ax_pose_terminator
+sSeedotPose113:
+ax_pose 27, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose114:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose115:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose116:
+ax_pose 28, 0x81ec, 0x90fa, 0x6c00
+ax_pose_terminator
+sSeedotPose117:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose118:
+ax_pose 23, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose119:
+ax_pose 29, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose120:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose121:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose122:
+ax_pose 28, 0x81ec, 0x80f6, 0x6c00
+ax_pose_terminator
+sSeedotPose123:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose124:
+ax_pose 19, 0x81eb, 0x80fa, 0x6c00
+ax_pose_terminator
+sSeedotPose125:
+ax_pose 27, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose126:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose127:
+ax_pose 17, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose128:
+ax_pose 26, 0x81ea, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose129:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose130:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose131:
+ax_pose 16, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose132:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose133:
+ax_pose 17, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose134:
+ax_pose 18, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose135:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose136:
+ax_pose 19, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose137:
+ax_pose 20, 0x81eb, 0x90fa, 0x6c00
+ax_pose_terminator
+sSeedotPose138:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose139:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose140:
+ax_pose 22, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose141:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose142:
+ax_pose 23, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose143:
+ax_pose 24, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose144:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose145:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose146:
+ax_pose 22, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose147:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose148:
+ax_pose 19, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose149:
+ax_pose 20, 0x81eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sSeedotPose150:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose151:
+ax_pose 17, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose152:
+ax_pose 18, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose153:
+ax_pose 30, 0x01ec, 0x80f4, 0x6c00
+ax_pose_terminator
+sSeedotPose154:
+ax_pose 31, 0x01ec, 0x80f4, 0x6c00
+ax_pose_terminator
+sSeedotPose155:
+ax_pose 32, 0x01de, 0x80f0, 0x6c00
+ax_pose_terminator
+sSeedotPose156:
+ax_pose 33, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sSeedotPose157:
+ax_pose 34, 0x01e5, 0x90e9, 0x6c00
+ax_pose_terminator
+sSeedotPose158:
+ax_pose 35, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sSeedotPose159:
+ax_pose 36, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sSeedotPose160:
+ax_pose 35, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sSeedotPose161:
+ax_pose 34, 0x01e5, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose162:
+ax_pose 33, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSeedotPose163:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose164:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose165:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose166:
+ax_pose 17, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose167:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose168:
+ax_pose 19, 0x81eb, 0x90f6, 0x6c00
+ax_pose_terminator
+sSeedotPose169:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose170:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose171:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose172:
+ax_pose 23, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose173:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose174:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose175:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose176:
+ax_pose 19, 0x81eb, 0x80fa, 0x6c00
+ax_pose_terminator
+sSeedotPose177:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose178:
+ax_pose 17, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose179:
+ax_pose 16, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose180:
+ax_pose 18, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose181:
+ax_pose 20, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose182:
+ax_pose 22, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose183:
+ax_pose 24, 0x81ec, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose184:
+ax_pose 22, 0x81ec, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose185:
+ax_pose 20, 0x81ec, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose186:
+ax_pose 18, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose187:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose188:
+ax_pose 17, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose189:
+ax_pose 19, 0x81eb, 0x90f6, 0x6c00
+ax_pose_terminator
+sSeedotPose190:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose191:
+ax_pose 23, 0x81ea, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose192:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose193:
+ax_pose 19, 0x81eb, 0x80fa, 0x6c00
+ax_pose_terminator
+sSeedotPose194:
+ax_pose 17, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose195:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose196:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose197:
+ax_pose 16, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose198:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose199:
+ax_pose 17, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose200:
+ax_pose 18, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose201:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose202:
+ax_pose 19, 0x81eb, 0x90f6, 0x6c00
+ax_pose_terminator
+sSeedotPose203:
+ax_pose 20, 0x81eb, 0x90fa, 0x6c00
+ax_pose_terminator
+sSeedotPose204:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose205:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose206:
+ax_pose 22, 0x81eb, 0x90f9, 0x6c00
+ax_pose_terminator
+sSeedotPose207:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose208:
+ax_pose 23, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose209:
+ax_pose 24, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose210:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose211:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose212:
+ax_pose 22, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose213:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose214:
+ax_pose 19, 0x81eb, 0x80fa, 0x6c00
+ax_pose_terminator
+sSeedotPose215:
+ax_pose 20, 0x81eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sSeedotPose216:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose217:
+ax_pose 17, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose218:
+ax_pose 18, 0x81eb, 0x80f7, 0x6c00
+ax_pose_terminator
+sSeedotPose219:
+ax_pose 15, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose220:
+ax_pose 17, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose221:
+ax_pose 19, 0x81eb, 0x80fa, 0x6c00
+ax_pose_terminator
+sSeedotPose222:
+ax_pose 21, 0x81eb, 0x80f9, 0x6c00
+ax_pose_terminator
+sSeedotPose223:
+ax_pose 23, 0x81ea, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose224:
+ax_pose 21, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose225:
+ax_pose 19, 0x81eb, 0x90f6, 0x6c00
+ax_pose_terminator
+sSeedotPose226:
+ax_pose 17, 0x81eb, 0x90f7, 0x6c00
+ax_pose_terminator
+sSeedotPose227:
+ax_pose 0, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose228:
+ax_pose 3, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose229:
+ax_pose 6, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose230:
+ax_pose 9, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose231:
+ax_pose 12, 0x81eb, 0x80f8, 0x6c00
+ax_pose_terminator
+sSeedotPose232:
+ax_pose 9, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose233:
+ax_pose 6, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+sSeedotPose234:
+ax_pose 3, 0x81eb, 0x90f8, 0x6c00
+ax_pose_terminator
+.align 2
+sSeedotAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sSeedotAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sSeedotAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sSeedotAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sSeedotAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sSeedotAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -3, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sSeedotAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sSeedotAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 22, 0, -3, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sSeedotAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 1, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 0, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSeedotAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 4, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 21, 19, 21, 19,
+ax_anim 2, 1, 33, 22, 18, 22, 18,
+ax_anim 2, 0, 33, 21, 19, 21, 19,
+ax_anim 2, 0, 33, 22, 18, 22, 18,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sSeedotAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 4, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 20, 0, 20, 0,
+ax_anim 2, 1, 38, 20, 1, 20, 1,
+ax_anim 2, 0, 38, 20, 0, 20, 0,
+ax_anim 2, 0, 38, 20, 1, 20, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sSeedotAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 4, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -4, 4, -4,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim 2, 0, 43, 20, -20, 20, -20,
+ax_anim 2, 1, 43, 21, -19, 21, -19,
+ax_anim 2, 0, 43, 20, -20, 20, -20,
+ax_anim 2, 0, 43, 21, -19, 21, -19,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sSeedotAnims_2_5:
+ax_anim 2, 0, 47, 0, 1, 0, 1,
+ax_anim 4, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 0, -4, 0, -4,
+ax_anim 1, 0, 44, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 1, 48, 1, -20, 1, -20,
+ax_anim 2, 0, 48, 0, -20, 0, -20,
+ax_anim 2, 0, 48, 1, -20, 1, -20,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sSeedotAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 4, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 2, 49, -4, -4, -4, -4,
+ax_anim 1, 0, 49, -10, -10, -10, -10,
+ax_anim 2, 0, 53, -20, -20, -20, -20,
+ax_anim 2, 1, 53, -21, -19, -21, -19,
+ax_anim 2, 0, 53, -20, -20, -20, -20,
+ax_anim 2, 0, 53, -21, -19, -21, -19,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sSeedotAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 4, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 0, -4, 0,
+ax_anim 1, 0, 54, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -20, 0, -20, 0,
+ax_anim 2, 1, 58, -20, 1, -20, 1,
+ax_anim 2, 0, 58, -20, 0, -20, 0,
+ax_anim 2, 0, 58, -20, 1, -20, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sSeedotAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 4, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, -4, 4, -4, 4,
+ax_anim 1, 0, 59, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -21, 19, -21, 19,
+ax_anim 2, 1, 63, -22, 18, -22, 18,
+ax_anim 2, 0, 63, -21, 19, -21, 19,
+ax_anim 2, 0, 63, -22, 18, -22, 18,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeedotAnims_3_1:
+ax_anim 2, 0, 67, 0, -1, 0, -1,
+ax_anim 4, 0, 67, 0, -2, 0, -2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 0, 4, 0, 4,
+ax_anim 1, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 1, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 0, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sSeedotAnims_3_2:
+ax_anim 2, 0, 72, -1, -1, -1, -1,
+ax_anim 4, 0, 72, -2, -2, -2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, 4, 4, 4, 4,
+ax_anim 1, 0, 69, 10, 10, 10, 10,
+ax_anim 2, 0, 73, 21, 19, 21, 19,
+ax_anim 2, 1, 73, 22, 18, 22, 18,
+ax_anim 2, 0, 73, 21, 19, 21, 19,
+ax_anim 2, 0, 73, 22, 18, 22, 18,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sSeedotAnims_3_3:
+ax_anim 2, 0, 77, -1, 0, -1, 0,
+ax_anim 4, 0, 77, -2, 0, -2, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 4, 0, 4, 0,
+ax_anim 1, 0, 74, 10, 0, 10, 0,
+ax_anim 2, 0, 78, 20, 0, 20, 0,
+ax_anim 2, 1, 78, 20, 1, 20, 1,
+ax_anim 2, 0, 78, 20, 0, 20, 0,
+ax_anim 2, 0, 78, 20, 1, 20, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sSeedotAnims_3_4:
+ax_anim 2, 0, 82, -1, 1, -1, 1,
+ax_anim 4, 0, 82, -2, 2, -2, 2,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 1, 2, 79, 4, -4, 4, -4,
+ax_anim 1, 0, 79, 10, -10, 10, -10,
+ax_anim 2, 0, 83, 20, -20, 20, -20,
+ax_anim 2, 1, 83, 21, -19, 21, -19,
+ax_anim 2, 0, 83, 20, -20, 20, -20,
+ax_anim 2, 0, 83, 21, -19, 21, -19,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sSeedotAnims_3_5:
+ax_anim 2, 0, 87, 0, 1, 0, 1,
+ax_anim 4, 0, 87, 0, 2, 0, 2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 84, 0, -4, 0, -4,
+ax_anim 1, 0, 84, 0, -11, 0, -11,
+ax_anim 2, 0, 88, 0, -20, 0, -20,
+ax_anim 2, 1, 88, 1, -20, 1, -20,
+ax_anim 2, 0, 88, 0, -20, 0, -20,
+ax_anim 2, 0, 88, 1, -20, 1, -20,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sSeedotAnims_3_6:
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 4, 0, 92, 2, 2, 2, 2,
+ax_anim 1, 0, 89, 0, -1, 0, -1,
+ax_anim 1, 2, 89, -4, -4, -4, -4,
+ax_anim 1, 0, 89, -10, -10, -10, -10,
+ax_anim 2, 0, 93, -20, -20, -20, -20,
+ax_anim 2, 1, 93, -21, -19, -21, -19,
+ax_anim 2, 0, 93, -20, -20, -20, -20,
+ax_anim 2, 0, 93, -21, -19, -21, -19,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sSeedotAnims_3_7:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 4, 0, 97, 2, 0, 2, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 2, 94, -4, 0, -4, 0,
+ax_anim 1, 0, 94, -10, 0, -10, 0,
+ax_anim 2, 0, 98, -20, 0, -20, 0,
+ax_anim 2, 1, 98, -20, 1, -20, 1,
+ax_anim 2, 0, 98, -20, 0, -20, 0,
+ax_anim 2, 0, 98, -20, 1, -20, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sSeedotAnims_3_8:
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 4, 0, 102, 2, -2, 2, -2,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 99, -4, 4, -4, 4,
+ax_anim 1, 0, 99, -10, 10, -10, 10,
+ax_anim 2, 0, 103, -21, 19, -21, 19,
+ax_anim 2, 1, 103, -22, 18, -22, 18,
+ax_anim 2, 0, 103, -21, 19, -21, 19,
+ax_anim 2, 0, 103, -22, 18, -22, 18,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeedotAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sSeedotAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sSeedotAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 4, 0, 4, 0,
+ax_anim 2, 0, 112, 4, 1, 3, 1,
+ax_anim 2, 0, 112, 4, 0, 3, 0,
+ax_anim 2, 0, 112, 4, 1, 3, 1,
+ax_anim 2, 0, 112, 4, 0, 3, 0,
+ax_anim 2, 0, 112, 4, 1, 3, 1,
+ax_anim 2, 0, 112, 4, 0, 3, 0,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sSeedotAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sSeedotAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sSeedotAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sSeedotAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -4, 0, -4, 0,
+ax_anim 2, 0, 124, -4, 1, -3, 1,
+ax_anim 2, 0, 124, -4, 0, -3, 0,
+ax_anim 2, 0, 124, -4, 1, -3, 1,
+ax_anim 2, 0, 124, -4, 0, -3, 0,
+ax_anim 2, 0, 124, -4, 1, -3, 1,
+ax_anim 2, 0, 124, -4, 0, -3, 0,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sSeedotAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSeedotAnims_5_1:
+ax_anim 1, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 4, 2, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 1, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_5_2:
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -5, 0, 0,
+ax_anim 4, 2, 132, 0, -6, 0, 0,
+ax_anim 2, 0, 132, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 1, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_5_3:
+ax_anim 1, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 4, 2, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 1, 136, 0, 1, 0, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_5_4:
+ax_anim 1, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 4, 2, 138, 0, -6, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 1, 139, 1, 1, 1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 1, 1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 1, 1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_5_5:
+ax_anim 1, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 4, 2, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 1, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_5_6:
+ax_anim 1, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -5, 0, 0,
+ax_anim 4, 2, 144, 0, -6, 0, 0,
+ax_anim 2, 0, 144, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 1, 145, -1, 1, -1, 1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 1, -1, 1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 1, -1, 1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_5_7:
+ax_anim 1, 0, 147, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, -5, 0, 0,
+ax_anim 4, 2, 147, 0, -6, 0, 0,
+ax_anim 2, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 1, 148, 0, 1, 0, 1,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 1, 0, 1,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 1, 0, 1,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_5_8:
+ax_anim 1, 0, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, -5, 0, 0,
+ax_anim 4, 2, 150, 0, -6, 0, 0,
+ax_anim 2, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 1, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeedotAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeedotAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sSeedotAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sSeedotAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sSeedotAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sSeedotAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sSeedotAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sSeedotAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sSeedotAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSeedotAnims_8_1:
+ax_anim 36, 0, 162, 0, 0, 0, 0,
+ax_anim 18, 0, 163, 0, 0, 0, -1,
+ax_anim_terminator
+sSeedotAnims_8_2:
+ax_anim 36, 0, 164, 0, 0, 0, 0,
+ax_anim 18, 0, 165, -1, 0, -1, -1,
+ax_anim_terminator
+sSeedotAnims_8_3:
+ax_anim 36, 0, 166, 0, 0, 0, 0,
+ax_anim 18, 0, 167, 0, 0, -1, 0,
+ax_anim_terminator
+sSeedotAnims_8_4:
+ax_anim 36, 0, 168, 0, 0, 0, 0,
+ax_anim 18, 0, 169, 0, 0, -1, 1,
+ax_anim_terminator
+sSeedotAnims_8_5:
+ax_anim 36, 0, 170, 0, 0, 0, 0,
+ax_anim 18, 0, 171, 0, 0, 0, 1,
+ax_anim_terminator
+sSeedotAnims_8_6:
+ax_anim 36, 0, 172, 0, 0, 0, 0,
+ax_anim 18, 0, 173, 0, 0, 1, 1,
+ax_anim_terminator
+sSeedotAnims_8_7:
+ax_anim 36, 0, 174, 0, 0, 0, 0,
+ax_anim 18, 0, 175, 0, 0, 1, 0,
+ax_anim_terminator
+sSeedotAnims_8_8:
+ax_anim 36, 0, 176, 0, 0, 0, 0,
+ax_anim 18, 0, 177, 1, 0, 1, -1,
+ax_anim_terminator
+.align 2
+sSeedotAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 7, 4, 7, 4,
+ax_anim 2, 0, 180, 10, 11, 10, 11,
+ax_anim 2, 0, 181, 8, 16, 8, 16,
+ax_anim 3, 0, 182, 0, 19, 0, 19,
+ax_anim 2, 3, 183, -8, 16, -8, 16,
+ax_anim 2, 0, 184, -10, 11, -10, 11,
+ax_anim 1, 0, 185, -7, 4, -7, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 12, 1, 12, 1,
+ax_anim 2, 0, 179, 20, 7, 20, 7,
+ax_anim 2, 0, 180, 24, 13, 24, 13,
+ax_anim 3, 0, 181, 24, 19, 24, 19,
+ax_anim 2, 3, 182, 15, 20, 15, 20,
+ax_anim 2, 0, 183, 4, 15, 4, 15,
+ax_anim 1, 0, 184, 1, 8, 1, 8,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 5, -4, 5, -4,
+ax_anim 2, 0, 178, 13, -5, 13, -5,
+ax_anim 2, 0, 179, 19, -4, 19, -4,
+ax_anim 3, 0, 180, 25, -1, 25, -1,
+ax_anim 2, 3, 181, 22, 4, 22, 4,
+ax_anim 2, 0, 182, 14, 6, 14, 6,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -10, -1, -10,
+ax_anim 2, 0, 185, 6, -17, 6, -17,
+ax_anim 2, 0, 178, 11, -21, 11, -21,
+ax_anim 3, 0, 179, 23, -23, 23, -23,
+ax_anim 2, 3, 180, 26, -15, 26, -15,
+ax_anim 2, 0, 181, 20, -7, 20, -7,
+ax_anim 1, 0, 182, 13, -3, 13, -3,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -10, -3, -10, -3,
+ax_anim 2, 0, 184, -12, -10, -12, -10,
+ax_anim 2, 0, 185, -8, -18, -8, -18,
+ax_anim 3, 0, 178, 0, -23, 0, -23,
+ax_anim 2, 3, 179, 8, -17, 8, -17,
+ax_anim 2, 0, 180, 12, -10, 12, -10,
+ax_anim 1, 0, 181, 10, -3, 10, -3,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -10, 1, -10,
+ax_anim 2, 0, 179, -6, -17, -6, -17,
+ax_anim 2, 0, 178, -11, -21, -11, -21,
+ax_anim 3, 0, 185, -23, -23, -23, -23,
+ax_anim 2, 3, 184, -26, -15, -26, -15,
+ax_anim 2, 0, 183, -20, -7, -20, -7,
+ax_anim 1, 0, 182, -13, -3, -13, -3,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -5, -4, -5, -4,
+ax_anim 2, 0, 178, -13, -5, -13, -5,
+ax_anim 2, 0, 185, -19, -4, -19, -4,
+ax_anim 3, 0, 184, -25, -1, -25, -1,
+ax_anim 2, 3, 183, -22, 4, -22, 4,
+ax_anim 2, 0, 182, -14, 6, -14, 6,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -12, 1, -12, 1,
+ax_anim 2, 0, 185, -20, 7, -20, 7,
+ax_anim 2, 0, 184, -24, 13, -24, 13,
+ax_anim 3, 0, 183, -24, 19, -24, 19,
+ax_anim 2, 3, 182, -15, 20, -15, 20,
+ax_anim 2, 0, 181, -4, 15, -4, 15,
+ax_anim 1, 0, 180, -1, 8, -1, 8,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeedotAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeedotAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -22, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -22, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeedotAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeedotAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sSeedotGfx1:
+.incbin "baserom.gba", 0x112ACC4, 0x100
+sSeedotSprites1:
+ax_sprite sSeedotGfx1, 0x100
+ax_sprite_terminator
+sSeedotGfx2:
+.incbin "baserom.gba", 0x112ADD4, 0x100
+sSeedotSprites2:
+ax_sprite sSeedotGfx2, 0x100
+ax_sprite_terminator
+sSeedotGfx3:
+.incbin "baserom.gba", 0x112AEE4, 0x100
+sSeedotSprites3:
+ax_sprite sSeedotGfx3, 0x100
+ax_sprite_terminator
+sSeedotGfx4:
+.incbin "baserom.gba", 0x112AFF4, 0x100
+sSeedotSprites4:
+ax_sprite sSeedotGfx4, 0x100
+ax_sprite_terminator
+sSeedotGfx5:
+.incbin "baserom.gba", 0x112B104, 0x100
+sSeedotSprites5:
+ax_sprite sSeedotGfx5, 0x100
+ax_sprite_terminator
+sSeedotGfx6:
+.incbin "baserom.gba", 0x112B214, 0x100
+sSeedotSprites6:
+ax_sprite sSeedotGfx6, 0x100
+ax_sprite_terminator
+sSeedotGfx7:
+.incbin "baserom.gba", 0x112B324, 0x100
+sSeedotSprites7:
+ax_sprite sSeedotGfx7, 0x100
+ax_sprite_terminator
+sSeedotGfx8:
+.incbin "baserom.gba", 0x112B434, 0x100
+sSeedotSprites8:
+ax_sprite sSeedotGfx8, 0x100
+ax_sprite_terminator
+sSeedotGfx9:
+.incbin "baserom.gba", 0x112B544, 0x100
+sSeedotSprites9:
+ax_sprite sSeedotGfx9, 0x100
+ax_sprite_terminator
+sSeedotGfx10:
+.incbin "baserom.gba", 0x112B654, 0x100
+sSeedotSprites10:
+ax_sprite sSeedotGfx10, 0x100
+ax_sprite_terminator
+sSeedotGfx11:
+.incbin "baserom.gba", 0x112B764, 0x100
+sSeedotSprites11:
+ax_sprite sSeedotGfx11, 0x100
+ax_sprite_terminator
+sSeedotGfx12:
+.incbin "baserom.gba", 0x112B874, 0x100
+sSeedotSprites12:
+ax_sprite sSeedotGfx12, 0x100
+ax_sprite_terminator
+sSeedotGfx13:
+.incbin "baserom.gba", 0x112B984, 0x100
+sSeedotSprites13:
+ax_sprite sSeedotGfx13, 0x100
+ax_sprite_terminator
+sSeedotGfx14:
+.incbin "baserom.gba", 0x112BA94, 0x100
+sSeedotSprites14:
+ax_sprite sSeedotGfx14, 0x100
+ax_sprite_terminator
+sSeedotGfx15:
+.incbin "baserom.gba", 0x112BBA4, 0x100
+sSeedotSprites15:
+ax_sprite sSeedotGfx15, 0x100
+ax_sprite_terminator
+sSeedotGfx16:
+.incbin "baserom.gba", 0x112BCB4, 0xC0
+sSeedotSprites16:
+ax_sprite sSeedotGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx17:
+.incbin "baserom.gba", 0x112BD8C, 0xC0
+sSeedotSprites17:
+ax_sprite sSeedotGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx18:
+.incbin "baserom.gba", 0x112BE64, 0xC0
+sSeedotSprites18:
+ax_sprite sSeedotGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx19:
+.incbin "baserom.gba", 0x112BF3C, 0xC0
+sSeedotSprites19:
+ax_sprite sSeedotGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx20:
+.incbin "baserom.gba", 0x112C014, 0xC0
+sSeedotSprites20:
+ax_sprite sSeedotGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx21:
+.incbin "baserom.gba", 0x112C0EC, 0xC0
+sSeedotSprites21:
+ax_sprite sSeedotGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx22:
+.incbin "baserom.gba", 0x112C1C4, 0xC0
+sSeedotSprites22:
+ax_sprite sSeedotGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx23:
+.incbin "baserom.gba", 0x112C29C, 0xC0
+sSeedotSprites23:
+ax_sprite sSeedotGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx24:
+.incbin "baserom.gba", 0x112C374, 0xC0
+sSeedotSprites24:
+ax_sprite sSeedotGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx25:
+.incbin "baserom.gba", 0x112C44C, 0xC0
+sSeedotSprites25:
+ax_sprite sSeedotGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx26:
+.incbin "baserom.gba", 0x112C524, 0x100
+sSeedotSprites26:
+ax_sprite sSeedotGfx26, 0x100
+ax_sprite_terminator
+sSeedotGfx27:
+.incbin "baserom.gba", 0x112C634, 0xC0
+sSeedotGfx27_1:
+.incbin "baserom.gba", 0x112C6F4, 0x20
+sSeedotSprites27:
+ax_sprite sSeedotGfx27, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSeedotGfx27_1, 0x20
+ax_sprite_terminator
+sSeedotGfx28:
+.incbin "baserom.gba", 0x112C734, 0xC0
+sSeedotSprites28:
+ax_sprite sSeedotGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx29:
+.incbin "baserom.gba", 0x112C80C, 0xC0
+sSeedotSprites29:
+ax_sprite sSeedotGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx30:
+.incbin "baserom.gba", 0x112C8E4, 0xC0
+sSeedotSprites30:
+ax_sprite sSeedotGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSeedotGfx31:
+.incbin "baserom.gba", 0x112C9BC, 0x200
+sSeedotSprites31:
+ax_sprite sSeedotGfx31, 0x200
+ax_sprite_terminator
+sSeedotGfx32:
+.incbin "baserom.gba", 0x112CBCC, 0x200
+sSeedotSprites32:
+ax_sprite sSeedotGfx32, 0x200
+ax_sprite_terminator
+sSeedotGfx33:
+.incbin "baserom.gba", 0x112CDDC, 0x200
+sSeedotSprites33:
+ax_sprite sSeedotGfx33, 0x200
+ax_sprite_terminator
+sSeedotGfx34:
+.incbin "baserom.gba", 0x112CFEC, 0x200
+sSeedotSprites34:
+ax_sprite sSeedotGfx34, 0x200
+ax_sprite_terminator
+sSeedotGfx35:
+.incbin "baserom.gba", 0x112D1FC, 0x200
+sSeedotSprites35:
+ax_sprite sSeedotGfx35, 0x200
+ax_sprite_terminator
+sSeedotGfx36:
+.incbin "baserom.gba", 0x112D40C, 0x200
+sSeedotSprites36:
+ax_sprite sSeedotGfx36, 0x200
+ax_sprite_terminator
+sSeedotGfx37:
+.incbin "baserom.gba", 0x112D61C, 0x200
+sSeedotSprites37:
+ax_sprite sSeedotGfx37, 0x200
+ax_sprite_terminator
+sAxPosesSeedot:
+.4byte sSeedotPose1
+.4byte sSeedotPose2
+.4byte sSeedotPose3
+.4byte sSeedotPose4
+.4byte sSeedotPose5
+.4byte sSeedotPose6
+.4byte sSeedotPose7
+.4byte sSeedotPose8
+.4byte sSeedotPose9
+.4byte sSeedotPose10
+.4byte sSeedotPose11
+.4byte sSeedotPose12
+.4byte sSeedotPose13
+.4byte sSeedotPose14
+.4byte sSeedotPose15
+.4byte sSeedotPose16
+.4byte sSeedotPose17
+.4byte sSeedotPose18
+.4byte sSeedotPose19
+.4byte sSeedotPose20
+.4byte sSeedotPose21
+.4byte sSeedotPose22
+.4byte sSeedotPose23
+.4byte sSeedotPose24
+.4byte sSeedotPose25
+.4byte sSeedotPose26
+.4byte sSeedotPose27
+.4byte sSeedotPose28
+.4byte sSeedotPose29
+.4byte sSeedotPose30
+.4byte sSeedotPose31
+.4byte sSeedotPose32
+.4byte sSeedotPose33
+.4byte sSeedotPose34
+.4byte sSeedotPose35
+.4byte sSeedotPose36
+.4byte sSeedotPose37
+.4byte sSeedotPose38
+.4byte sSeedotPose39
+.4byte sSeedotPose40
+.4byte sSeedotPose41
+.4byte sSeedotPose42
+.4byte sSeedotPose43
+.4byte sSeedotPose44
+.4byte sSeedotPose45
+.4byte sSeedotPose46
+.4byte sSeedotPose47
+.4byte sSeedotPose48
+.4byte sSeedotPose49
+.4byte sSeedotPose50
+.4byte sSeedotPose51
+.4byte sSeedotPose52
+.4byte sSeedotPose53
+.4byte sSeedotPose54
+.4byte sSeedotPose55
+.4byte sSeedotPose56
+.4byte sSeedotPose57
+.4byte sSeedotPose58
+.4byte sSeedotPose59
+.4byte sSeedotPose60
+.4byte sSeedotPose61
+.4byte sSeedotPose62
+.4byte sSeedotPose63
+.4byte sSeedotPose64
+.4byte sSeedotPose65
+.4byte sSeedotPose66
+.4byte sSeedotPose67
+.4byte sSeedotPose68
+.4byte sSeedotPose69
+.4byte sSeedotPose70
+.4byte sSeedotPose71
+.4byte sSeedotPose72
+.4byte sSeedotPose73
+.4byte sSeedotPose74
+.4byte sSeedotPose75
+.4byte sSeedotPose76
+.4byte sSeedotPose77
+.4byte sSeedotPose78
+.4byte sSeedotPose79
+.4byte sSeedotPose80
+.4byte sSeedotPose81
+.4byte sSeedotPose82
+.4byte sSeedotPose83
+.4byte sSeedotPose84
+.4byte sSeedotPose85
+.4byte sSeedotPose86
+.4byte sSeedotPose87
+.4byte sSeedotPose88
+.4byte sSeedotPose89
+.4byte sSeedotPose90
+.4byte sSeedotPose91
+.4byte sSeedotPose92
+.4byte sSeedotPose93
+.4byte sSeedotPose94
+.4byte sSeedotPose95
+.4byte sSeedotPose96
+.4byte sSeedotPose97
+.4byte sSeedotPose98
+.4byte sSeedotPose99
+.4byte sSeedotPose100
+.4byte sSeedotPose101
+.4byte sSeedotPose102
+.4byte sSeedotPose103
+.4byte sSeedotPose104
+.4byte sSeedotPose105
+.4byte sSeedotPose106
+.4byte sSeedotPose107
+.4byte sSeedotPose108
+.4byte sSeedotPose109
+.4byte sSeedotPose110
+.4byte sSeedotPose111
+.4byte sSeedotPose112
+.4byte sSeedotPose113
+.4byte sSeedotPose114
+.4byte sSeedotPose115
+.4byte sSeedotPose116
+.4byte sSeedotPose117
+.4byte sSeedotPose118
+.4byte sSeedotPose119
+.4byte sSeedotPose120
+.4byte sSeedotPose121
+.4byte sSeedotPose122
+.4byte sSeedotPose123
+.4byte sSeedotPose124
+.4byte sSeedotPose125
+.4byte sSeedotPose126
+.4byte sSeedotPose127
+.4byte sSeedotPose128
+.4byte sSeedotPose129
+.4byte sSeedotPose130
+.4byte sSeedotPose131
+.4byte sSeedotPose132
+.4byte sSeedotPose133
+.4byte sSeedotPose134
+.4byte sSeedotPose135
+.4byte sSeedotPose136
+.4byte sSeedotPose137
+.4byte sSeedotPose138
+.4byte sSeedotPose139
+.4byte sSeedotPose140
+.4byte sSeedotPose141
+.4byte sSeedotPose142
+.4byte sSeedotPose143
+.4byte sSeedotPose144
+.4byte sSeedotPose145
+.4byte sSeedotPose146
+.4byte sSeedotPose147
+.4byte sSeedotPose148
+.4byte sSeedotPose149
+.4byte sSeedotPose150
+.4byte sSeedotPose151
+.4byte sSeedotPose152
+.4byte sSeedotPose153
+.4byte sSeedotPose154
+.4byte sSeedotPose155
+.4byte sSeedotPose156
+.4byte sSeedotPose157
+.4byte sSeedotPose158
+.4byte sSeedotPose159
+.4byte sSeedotPose160
+.4byte sSeedotPose161
+.4byte sSeedotPose162
+.4byte sSeedotPose163
+.4byte sSeedotPose164
+.4byte sSeedotPose165
+.4byte sSeedotPose166
+.4byte sSeedotPose167
+.4byte sSeedotPose168
+.4byte sSeedotPose169
+.4byte sSeedotPose170
+.4byte sSeedotPose171
+.4byte sSeedotPose172
+.4byte sSeedotPose173
+.4byte sSeedotPose174
+.4byte sSeedotPose175
+.4byte sSeedotPose176
+.4byte sSeedotPose177
+.4byte sSeedotPose178
+.4byte sSeedotPose179
+.4byte sSeedotPose180
+.4byte sSeedotPose181
+.4byte sSeedotPose182
+.4byte sSeedotPose183
+.4byte sSeedotPose184
+.4byte sSeedotPose185
+.4byte sSeedotPose186
+.4byte sSeedotPose187
+.4byte sSeedotPose188
+.4byte sSeedotPose189
+.4byte sSeedotPose190
+.4byte sSeedotPose191
+.4byte sSeedotPose192
+.4byte sSeedotPose193
+.4byte sSeedotPose194
+.4byte sSeedotPose195
+.4byte sSeedotPose196
+.4byte sSeedotPose197
+.4byte sSeedotPose198
+.4byte sSeedotPose199
+.4byte sSeedotPose200
+.4byte sSeedotPose201
+.4byte sSeedotPose202
+.4byte sSeedotPose203
+.4byte sSeedotPose204
+.4byte sSeedotPose205
+.4byte sSeedotPose206
+.4byte sSeedotPose207
+.4byte sSeedotPose208
+.4byte sSeedotPose209
+.4byte sSeedotPose210
+.4byte sSeedotPose211
+.4byte sSeedotPose212
+.4byte sSeedotPose213
+.4byte sSeedotPose214
+.4byte sSeedotPose215
+.4byte sSeedotPose216
+.4byte sSeedotPose217
+.4byte sSeedotPose218
+.4byte sSeedotPose219
+.4byte sSeedotPose220
+.4byte sSeedotPose221
+.4byte sSeedotPose222
+.4byte sSeedotPose223
+.4byte sSeedotPose224
+.4byte sSeedotPose225
+.4byte sSeedotPose226
+.4byte sSeedotPose227
+.4byte sSeedotPose228
+.4byte sSeedotPose229
+.4byte sSeedotPose230
+.4byte sSeedotPose231
+.4byte sSeedotPose232
+.4byte sSeedotPose233
+.4byte sSeedotPose234
+sAxPositionsSeedot:
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -4, 	  -4,   -6, 	   5,   -5, 	   1,   -9
+.2byte   -3,   -4, 	  -5,   -5, 	   1,   -5, 	  -2,   -8
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+.2byte    0,   -4, 	   3,   -6, 	  -6,   -4, 	  -1,   -9
+.2byte    4,   -4, 	   1,   -5, 	   0,   -4, 	   0,   -8
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    3,   -5, 	   0,   -7, 	  -3,   -5, 	  -2,   -8
+.2byte    4,   -5, 	  -2,   -7, 	   2,   -5, 	   0,   -8
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    1,   -4, 	  -3,   -7, 	  -1,   -5, 	  -1,   -9
+.2byte    2,   -5, 	  -5,   -7, 	   6,   -6, 	   0,   -9
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte    1,   -5, 	   6,   -7, 	  -4,   -5, 	   0,   -9
+.2byte   -2,   -5, 	   3,   -5, 	  -7,   -7, 	  -1,   -9
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -3,   -4, 	   1,   -7, 	  -1,   -5, 	  -1,   -9
+.2byte   -2,   -5, 	   5,   -7, 	  -6,   -6, 	   0,   -9
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -4,   -5, 	  -1,   -7, 	   2,   -5, 	   1,   -8
+.2byte   -5,   -5, 	   1,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -1,   -4, 	  -4,   -6, 	   5,   -4, 	   0,   -9
+.2byte   -5,   -4, 	  -2,   -5, 	  -1,   -4, 	  -1,   -8
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -4, 	  -4,   -6, 	   5,   -5, 	   1,   -9
+.2byte   -3,   -4, 	  -5,   -5, 	   1,   -5, 	  -2,   -8
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -1,   -1, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+.2byte    0,   -4, 	   3,   -6, 	  -6,   -4, 	  -1,   -9
+.2byte    4,   -4, 	   1,   -5, 	   0,   -4, 	   0,   -8
+.2byte    2,   -5, 	   3,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    3,   -1, 	   3,   -3, 	  -4,   -4, 	   1,   -6
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    3,   -5, 	   0,   -7, 	  -3,   -5, 	  -2,   -8
+.2byte    4,   -5, 	  -2,   -7, 	   2,   -5, 	   0,   -8
+.2byte    4,   -7, 	   0,   -6, 	  -1,   -5, 	  -2,   -8
+.2byte    3,   -1, 	   2,   -3, 	   0,   -3, 	   0,   -7
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    1,   -4, 	  -3,   -7, 	  -1,   -5, 	  -1,   -9
+.2byte    2,   -5, 	  -5,   -7, 	   6,   -6, 	   0,   -9
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte    2,   -2, 	  -1,   -4, 	   3,   -2, 	  -1,   -7
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte    1,   -5, 	   6,   -7, 	  -4,   -5, 	   0,   -9
+.2byte   -2,   -5, 	   3,   -5, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,   -6, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,   -3, 	   5,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -3,   -4, 	   1,   -7, 	  -1,   -5, 	  -1,   -9
+.2byte   -2,   -5, 	   5,   -7, 	  -6,   -6, 	   0,   -9
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -3,   -2, 	   0,   -4, 	  -4,   -2, 	   0,   -7
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -4,   -5, 	  -1,   -7, 	   2,   -5, 	   1,   -8
+.2byte   -5,   -5, 	   1,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte   -5,   -7, 	  -1,   -6, 	   0,   -5, 	   1,   -8
+.2byte   -4,   -1, 	  -3,   -3, 	  -1,   -3, 	  -1,   -7
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -1,   -4, 	  -4,   -6, 	   5,   -4, 	   0,   -9
+.2byte   -5,   -4, 	  -2,   -5, 	  -1,   -4, 	  -1,   -8
+.2byte   -3,   -5, 	  -4,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -4,   -1, 	  -4,   -3, 	   3,   -4, 	  -2,   -6
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -4, 	  -4,   -6, 	   5,   -5, 	   1,   -9
+.2byte   -3,   -4, 	  -5,   -5, 	   1,   -5, 	  -2,   -8
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -1,   -1, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+.2byte    0,   -4, 	   3,   -6, 	  -6,   -4, 	  -1,   -9
+.2byte    4,   -4, 	   1,   -5, 	   0,   -4, 	   0,   -8
+.2byte    2,   -5, 	   3,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    3,   -1, 	   3,   -3, 	  -4,   -4, 	   1,   -6
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    3,   -5, 	   0,   -7, 	  -3,   -5, 	  -2,   -8
+.2byte    4,   -5, 	  -2,   -7, 	   2,   -5, 	   0,   -8
+.2byte    4,   -7, 	   0,   -6, 	  -1,   -5, 	  -2,   -8
+.2byte    3,   -1, 	   2,   -3, 	   0,   -3, 	   0,   -7
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    1,   -4, 	  -3,   -7, 	  -1,   -5, 	  -1,   -9
+.2byte    2,   -5, 	  -5,   -7, 	   6,   -6, 	   0,   -9
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte    2,   -2, 	  -1,   -4, 	   3,   -2, 	  -1,   -7
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte    1,   -5, 	   6,   -7, 	  -4,   -5, 	   0,   -9
+.2byte   -2,   -5, 	   3,   -5, 	  -7,   -7, 	  -1,   -9
+.2byte   -1,   -6, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,   -3, 	   5,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -3,   -4, 	   1,   -7, 	  -1,   -5, 	  -1,   -9
+.2byte   -2,   -5, 	   5,   -7, 	  -6,   -6, 	   0,   -9
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -3,   -2, 	   0,   -4, 	  -4,   -2, 	   0,   -7
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -4,   -5, 	  -1,   -7, 	   2,   -5, 	   1,   -8
+.2byte   -5,   -5, 	   1,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte   -5,   -7, 	  -1,   -6, 	   0,   -5, 	   1,   -8
+.2byte   -4,   -1, 	  -3,   -3, 	  -1,   -3, 	  -1,   -7
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -1,   -4, 	  -4,   -6, 	   5,   -4, 	   0,   -9
+.2byte   -5,   -4, 	  -2,   -5, 	  -1,   -4, 	  -1,   -8
+.2byte   -3,   -5, 	  -4,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -4,   -1, 	  -4,   -3, 	   3,   -4, 	  -2,   -6
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -1,   -1, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+.2byte    2,   -5, 	   3,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    2,   -1, 	   3,   -3, 	  -4,   -4, 	   0,   -6
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    4,   -7, 	   0,   -6, 	  -1,   -5, 	  -2,   -8
+.2byte    2,   -2, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte    3,   -4, 	   0,   -6, 	   4,   -4, 	   1,   -9
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,   -4, 	   5,   -6, 	  -6,   -6, 	  -1,   -9
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -4,   -4, 	  -1,   -6, 	  -5,   -4, 	  -2,   -9
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -6, 	   0,   -5, 	   1,   -8
+.2byte   -3,   -2, 	  -2,   -4, 	   0,   -4, 	   0,   -8
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -3,   -5, 	  -4,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -3,   -1, 	  -4,   -3, 	   3,   -4, 	  -1,   -6
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -1,   -1, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+.2byte    3,   -5, 	   4,   -6, 	  -3,   -4, 	   0,   -9
+.2byte    3,   -1, 	   3,   -3, 	  -4,   -4, 	   1,   -6
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    5,   -7, 	   1,   -6, 	   0,   -5, 	  -1,   -8
+.2byte    3,   -1, 	   2,   -3, 	   0,   -3, 	   0,   -7
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte    2,   -2, 	  -1,   -4, 	   3,   -2, 	  -1,   -7
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,   -3, 	   5,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -3,   -2, 	   0,   -4, 	  -4,   -2, 	   0,   -7
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -6,   -7, 	  -2,   -6, 	  -1,   -5, 	   0,   -8
+.2byte   -4,   -1, 	  -3,   -3, 	  -1,   -3, 	  -1,   -7
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -4,   -5, 	  -5,   -6, 	   2,   -4, 	  -1,   -9
+.2byte   -4,   -1, 	  -4,   -3, 	   3,   -4, 	  -2,   -6
+.2byte   -1,  -10, 	  -4,  -10, 	   3,   -5, 	   1,   -6
+.2byte   -3,  -10, 	  -5,  -10, 	   2,   -5, 	   0,   -6
+.2byte   -1,  -12, 	  -5,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    2,  -15, 	   5,  -14, 	  -4,  -10, 	  -1,  -12
+.2byte    2,  -15, 	   1,  -15, 	   1,   -7, 	   0,  -12
+.2byte    3,  -17, 	  -5,  -17, 	   4,  -10, 	  -1,  -12
+.2byte   -1,  -18, 	   5,  -14, 	  -6,  -14, 	  -1,  -12
+.2byte   -4,  -17, 	   4,  -17, 	  -5,  -10, 	   0,  -12
+.2byte   -3,  -15, 	  -2,  -15, 	  -2,   -7, 	  -1,  -12
+.2byte   -3,  -15, 	  -6,  -14, 	   3,  -10, 	   0,  -12
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+.2byte    2,   -5, 	   3,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    4,   -7, 	   0,   -6, 	  -1,   -5, 	  -2,   -8
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -6, 	   0,   -5, 	   1,   -8
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -3,   -5, 	  -4,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -1,   -1, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -3,   -1, 	  -3,   -3, 	   4,   -4, 	  -1,   -6
+.2byte   -2,    0, 	  -1,   -2, 	   1,   -2, 	   1,   -6
+.2byte   -2,   -1, 	   1,   -3, 	  -3,   -1, 	   1,   -6
+.2byte   -1,   -2, 	   5,   -3, 	  -6,   -3, 	  -1,   -7
+.2byte    1,   -1, 	  -2,   -3, 	   2,   -1, 	  -2,   -6
+.2byte    1,    0, 	   0,   -2, 	  -2,   -2, 	  -2,   -6
+.2byte    2,   -1, 	   2,   -3, 	  -5,   -4, 	   0,   -6
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte    2,   -5, 	   3,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    4,   -7, 	   0,   -6, 	  -1,   -5, 	  -2,   -8
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	   4,   -6, 	  -5,   -6, 	  -1,  -10
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -5,   -7, 	  -1,   -6, 	   0,   -5, 	   1,   -8
+.2byte   -3,   -5, 	  -4,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -1,   -1, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+.2byte    2,   -5, 	   3,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    3,   -1, 	   3,   -3, 	  -4,   -4, 	   1,   -6
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    4,   -7, 	   0,   -6, 	  -1,   -5, 	  -2,   -8
+.2byte    3,   -1, 	   2,   -3, 	   0,   -3, 	   0,   -7
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte    2,   -2, 	  -1,   -4, 	   3,   -2, 	  -1,   -7
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	   4,   -5, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,   -3, 	   5,   -4, 	  -6,   -4, 	  -1,   -8
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -3,   -2, 	   0,   -4, 	  -4,   -2, 	   0,   -7
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -5,   -7, 	  -1,   -6, 	   0,   -5, 	   1,   -8
+.2byte   -4,   -1, 	  -3,   -3, 	  -1,   -3, 	  -1,   -7
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -3,   -5, 	  -4,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -4,   -1, 	  -4,   -3, 	   3,   -4, 	  -2,   -6
+.2byte   -1,   -5, 	  -5,   -6, 	   4,   -6, 	  -1,   -9
+.2byte   -3,   -5, 	  -4,   -6, 	   3,   -4, 	   0,   -9
+.2byte   -5,   -7, 	  -1,   -6, 	   0,   -5, 	   1,   -8
+.2byte   -2,   -5, 	   3,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -1,   -7, 	   4,   -6, 	  -5,   -6, 	  -1,  -10
+.2byte    1,   -5, 	  -4,   -6, 	   2,   -5, 	  -1,   -7
+.2byte    4,   -7, 	   0,   -6, 	  -1,   -5, 	  -2,   -8
+.2byte    2,   -5, 	   3,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte   -1,   -2, 	  -5,   -3, 	   4,   -3, 	  -1,   -7
+.2byte   -3,   -2, 	  -4,   -4, 	   3,   -3, 	   0,   -6
+.2byte   -4,   -2, 	   0,   -5, 	   0,   -3, 	   0,   -6
+.2byte   -3,   -3, 	   4,   -5, 	  -3,   -4, 	   0,   -7
+.2byte   -1,   -3, 	   5,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte    2,   -3, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    3,   -2, 	  -1,   -5, 	  -1,   -3, 	  -1,   -6
+.2byte    2,   -2, 	   3,   -4, 	  -4,   -3, 	  -1,   -6
+sSeedotAnimTable1:
+.4byte sSeedotAnims_1_1
+.4byte sSeedotAnims_1_2
+.4byte sSeedotAnims_1_3
+.4byte sSeedotAnims_1_4
+.4byte sSeedotAnims_1_5
+.4byte sSeedotAnims_1_6
+.4byte sSeedotAnims_1_7
+.4byte sSeedotAnims_1_8
+sSeedotAnimTable2:
+.4byte sSeedotAnims_2_1
+.4byte sSeedotAnims_2_2
+.4byte sSeedotAnims_2_3
+.4byte sSeedotAnims_2_4
+.4byte sSeedotAnims_2_5
+.4byte sSeedotAnims_2_6
+.4byte sSeedotAnims_2_7
+.4byte sSeedotAnims_2_8
+sSeedotAnimTable3:
+.4byte sSeedotAnims_3_1
+.4byte sSeedotAnims_3_2
+.4byte sSeedotAnims_3_3
+.4byte sSeedotAnims_3_4
+.4byte sSeedotAnims_3_5
+.4byte sSeedotAnims_3_6
+.4byte sSeedotAnims_3_7
+.4byte sSeedotAnims_3_8
+sSeedotAnimTable4:
+.4byte sSeedotAnims_4_1
+.4byte sSeedotAnims_4_2
+.4byte sSeedotAnims_4_3
+.4byte sSeedotAnims_4_4
+.4byte sSeedotAnims_4_5
+.4byte sSeedotAnims_4_6
+.4byte sSeedotAnims_4_7
+.4byte sSeedotAnims_4_8
+sSeedotAnimTable5:
+.4byte sSeedotAnims_5_1
+.4byte sSeedotAnims_5_2
+.4byte sSeedotAnims_5_3
+.4byte sSeedotAnims_5_4
+.4byte sSeedotAnims_5_5
+.4byte sSeedotAnims_5_6
+.4byte sSeedotAnims_5_7
+.4byte sSeedotAnims_5_8
+sSeedotAnimTable6:
+.4byte sSeedotAnims_6_1
+.4byte sSeedotAnims_6_1
+.4byte sSeedotAnims_6_1
+.4byte sSeedotAnims_6_1
+.4byte sSeedotAnims_6_1
+.4byte sSeedotAnims_6_1
+.4byte sSeedotAnims_6_1
+.4byte sSeedotAnims_6_1
+sSeedotAnimTable7:
+.4byte sSeedotAnims_7_1
+.4byte sSeedotAnims_7_2
+.4byte sSeedotAnims_7_3
+.4byte sSeedotAnims_7_4
+.4byte sSeedotAnims_7_5
+.4byte sSeedotAnims_7_6
+.4byte sSeedotAnims_7_7
+.4byte sSeedotAnims_7_8
+sSeedotAnimTable8:
+.4byte sSeedotAnims_8_1
+.4byte sSeedotAnims_8_2
+.4byte sSeedotAnims_8_3
+.4byte sSeedotAnims_8_4
+.4byte sSeedotAnims_8_5
+.4byte sSeedotAnims_8_6
+.4byte sSeedotAnims_8_7
+.4byte sSeedotAnims_8_8
+sSeedotAnimTable9:
+.4byte sSeedotAnims_9_1
+.4byte sSeedotAnims_9_2
+.4byte sSeedotAnims_9_3
+.4byte sSeedotAnims_9_4
+.4byte sSeedotAnims_9_5
+.4byte sSeedotAnims_9_6
+.4byte sSeedotAnims_9_7
+.4byte sSeedotAnims_9_8
+sSeedotAnimTable10:
+.4byte sSeedotAnims_10_1
+.4byte sSeedotAnims_10_2
+.4byte sSeedotAnims_10_3
+.4byte sSeedotAnims_10_4
+.4byte sSeedotAnims_10_5
+.4byte sSeedotAnims_10_6
+.4byte sSeedotAnims_10_7
+.4byte sSeedotAnims_10_8
+sSeedotAnimTable11:
+.4byte sSeedotAnims_11_1
+.4byte sSeedotAnims_11_2
+.4byte sSeedotAnims_11_3
+.4byte sSeedotAnims_11_4
+.4byte sSeedotAnims_11_5
+.4byte sSeedotAnims_11_6
+.4byte sSeedotAnims_11_7
+.4byte sSeedotAnims_11_8
+sSeedotAnimTable12:
+.4byte sSeedotAnims_12_1
+.4byte sSeedotAnims_12_2
+.4byte sSeedotAnims_12_3
+.4byte sSeedotAnims_12_4
+.4byte sSeedotAnims_12_5
+.4byte sSeedotAnims_12_6
+.4byte sSeedotAnims_12_7
+.4byte sSeedotAnims_12_8
+sSeedotAnimTable13:
+.4byte sSeedotAnims_13_1
+.4byte sSeedotAnims_13_2
+.4byte sSeedotAnims_13_3
+.4byte sSeedotAnims_13_4
+.4byte sSeedotAnims_13_5
+.4byte sSeedotAnims_13_6
+.4byte sSeedotAnims_13_7
+.4byte sSeedotAnims_13_8
+sAxAnimationsSeedot:
+.4byte sSeedotAnimTable1
+.4byte sSeedotAnimTable2
+.4byte sSeedotAnimTable3
+.4byte sSeedotAnimTable4
+.4byte sSeedotAnimTable5
+.4byte sSeedotAnimTable6
+.4byte sSeedotAnimTable7
+.4byte sSeedotAnimTable8
+.4byte sSeedotAnimTable9
+.4byte sSeedotAnimTable10
+.4byte sSeedotAnimTable11
+.4byte sSeedotAnimTable12
+.4byte sSeedotAnimTable13
+sAxSpritesSeedot:
+.4byte sSeedotSprites1
+.4byte sSeedotSprites2
+.4byte sSeedotSprites3
+.4byte sSeedotSprites4
+.4byte sSeedotSprites5
+.4byte sSeedotSprites6
+.4byte sSeedotSprites7
+.4byte sSeedotSprites8
+.4byte sSeedotSprites9
+.4byte sSeedotSprites10
+.4byte sSeedotSprites11
+.4byte sSeedotSprites12
+.4byte sSeedotSprites13
+.4byte sSeedotSprites14
+.4byte sSeedotSprites15
+.4byte sSeedotSprites16
+.4byte sSeedotSprites17
+.4byte sSeedotSprites18
+.4byte sSeedotSprites19
+.4byte sSeedotSprites20
+.4byte sSeedotSprites21
+.4byte sSeedotSprites22
+.4byte sSeedotSprites23
+.4byte sSeedotSprites24
+.4byte sSeedotSprites25
+.4byte sSeedotSprites26
+.4byte sSeedotSprites27
+.4byte sSeedotSprites28
+.4byte sSeedotSprites29
+.4byte sSeedotSprites30
+.4byte sSeedotSprites31
+.4byte sSeedotSprites32
+.4byte sSeedotSprites33
+.4byte sSeedotSprites34
+.4byte sSeedotSprites35
+.4byte sSeedotSprites36
+.4byte sSeedotSprites37
+sAxMainSeedot:
+ax_main sAxPosesSeedot, sAxAnimationsSeedot, 13, sAxSpritesSeedot, sAxPositionsSeedot

--- a/data/ax/seel.inc
+++ b/data/ax/seel.inc
@@ -1,0 +1,2536 @@
+.global gAxSeel
+gAxSeel:
+ax_siro sAxMainSeel
+sSeelPose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose4:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose6:
+ax_pose 5, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose7:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose8:
+ax_pose 7, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose9:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose10:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose11:
+ax_pose 10, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose13:
+ax_pose 12, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose22:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose24:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose25:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose26:
+ax_pose 15, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose27:
+ax_pose 16, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose28:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose29:
+ax_pose 17, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose30:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose31:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose32:
+ax_pose 19, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose33:
+ax_pose 20, 0x41f4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose34:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose35:
+ax_pose 21, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose36:
+ax_pose 22, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose38:
+ax_pose 23, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose39:
+ax_pose 24, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose41:
+ax_pose 21, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose42:
+ax_pose 22, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose43:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose44:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose45:
+ax_pose 20, 0x41f4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose46:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose47:
+ax_pose 17, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose48:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose49:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose50:
+ax_pose 15, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose51:
+ax_pose 16, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose52:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose53:
+ax_pose 17, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose54:
+ax_pose 18, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose55:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose56:
+ax_pose 19, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose57:
+ax_pose 20, 0x41f4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose58:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose59:
+ax_pose 21, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose60:
+ax_pose 22, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose61:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose62:
+ax_pose 23, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose63:
+ax_pose 24, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose64:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose65:
+ax_pose 21, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose66:
+ax_pose 22, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose67:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose68:
+ax_pose 19, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose69:
+ax_pose 20, 0x41f4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose70:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose71:
+ax_pose 17, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose72:
+ax_pose 18, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose73:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose74:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose75:
+ax_pose 2, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose76:
+ax_pose 25, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose77:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose78:
+ax_pose 4, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSeelPose79:
+ax_pose 5, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose80:
+ax_pose 26, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose81:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose82:
+ax_pose 7, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose83:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose84:
+ax_pose 27, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose85:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose86:
+ax_pose 10, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose87:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose88:
+ax_pose 28, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose89:
+ax_pose 12, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose90:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose91:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose92:
+ax_pose 29, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose93:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose94:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose95:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose96:
+ax_pose 28, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose97:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose98:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose99:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose100:
+ax_pose 27, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose101:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose102:
+ax_pose 4, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSeelPose103:
+ax_pose 5, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose104:
+ax_pose 26, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose105:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose106:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose107:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose108:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose109:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose110:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose111:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose112:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose113:
+ax_pose 30, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose114:
+ax_pose 31, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose115:
+ax_pose 32, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose116:
+ax_pose 33, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose117:
+ax_pose 34, 0x01e2, 0x90ee, 0x5c00
+ax_pose_terminator
+sSeelPose118:
+ax_pose 35, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose119:
+ax_pose 36, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSeelPose120:
+ax_pose 35, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose121:
+ax_pose 34, 0x01e2, 0x80f2, 0x5c00
+ax_pose_terminator
+sSeelPose122:
+ax_pose 33, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose123:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose124:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose125:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose126:
+ax_pose 4, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose127:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose128:
+ax_pose 7, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSeelPose129:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose130:
+ax_pose 10, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose131:
+ax_pose 12, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose132:
+ax_pose 13, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose133:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose134:
+ax_pose 10, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose135:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose136:
+ax_pose 7, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSeelPose137:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose138:
+ax_pose 4, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose139:
+ax_pose 25, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose140:
+ax_pose 26, 0x01ee, 0x80f2, 0x5c00
+ax_pose_terminator
+sSeelPose141:
+ax_pose 27, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose142:
+ax_pose 28, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose143:
+ax_pose 29, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose144:
+ax_pose 28, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose145:
+ax_pose 27, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose146:
+ax_pose 26, 0x01ee, 0x90ee, 0x5c00
+ax_pose_terminator
+sSeelPose147:
+ax_pose 15, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose148:
+ax_pose 17, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose149:
+ax_pose 19, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose150:
+ax_pose 21, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose151:
+ax_pose 23, 0x01ed, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose152:
+ax_pose 21, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose153:
+ax_pose 19, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose154:
+ax_pose 17, 0x01ed, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose155:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose156:
+ax_pose 15, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose157:
+ax_pose 25, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose158:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose159:
+ax_pose 17, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose160:
+ax_pose 26, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sSeelPose161:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose162:
+ax_pose 19, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose163:
+ax_pose 27, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sSeelPose164:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose165:
+ax_pose 21, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose166:
+ax_pose 28, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSeelPose167:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose168:
+ax_pose 23, 0x01ee, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose169:
+ax_pose 29, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose170:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose171:
+ax_pose 21, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose172:
+ax_pose 28, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose173:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose174:
+ax_pose 19, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSeelPose175:
+ax_pose 27, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sSeelPose176:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose177:
+ax_pose 17, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose178:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSeelPose179:
+ax_pose 1, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose180:
+ax_pose 4, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose181:
+ax_pose 7, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose182:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSeelPose183:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose184:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSeelPose185:
+ax_pose 7, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose186:
+ax_pose 4, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose187:
+ax_pose 0, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose188:
+ax_pose 3, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose189:
+ax_pose 6, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSeelPose190:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose191:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSeelPose192:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSeelPose193:
+ax_pose 6, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSeelPose194:
+ax_pose 3, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sSeelAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 2, 0, 1,
+ax_anim 8, 0, 1, 0, 3, 0, 2,
+ax_anim 10, 0, 1, 0, 4, 0, 3,
+ax_anim 6, 0, 0, 0, 2, 0, 2,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sSeelAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 2, 2, 1, 1,
+ax_anim 8, 0, 4, 3, 3, 2, 2,
+ax_anim 10, 0, 4, 4, 4, 3, 3,
+ax_anim 6, 0, 3, 2, 2, 2, 2,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, -1, -1, 0, 0,
+ax_anim_terminator
+sSeelAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 0,
+ax_anim 8, 0, 7, 3, 0, 2, 0,
+ax_anim 10, 0, 7, 4, 0, 3, 0,
+ax_anim 6, 0, 6, 2, 0, 2, 0,
+ax_anim 6, 0, 8, 0, 0, 1, 0,
+ax_anim 6, 0, 8, -1, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 2, -2, 2, -2,
+ax_anim 8, 0, 10, 3, -3, 3, -3,
+ax_anim 10, 0, 10, 4, -4, 4, -4,
+ax_anim 6, 0, 9, 2, -2, 3, -3,
+ax_anim 6, 0, 11, 1, -1, 2, -2,
+ax_anim 6, 0, 11, -1, 1, 0, 0,
+ax_anim_terminator
+sSeelAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 1, 0, -1,
+ax_anim 8, 0, 13, 0, 0, 0, -2,
+ax_anim 10, 0, 13, 0, -1, 0, -3,
+ax_anim 6, 0, 12, 0, -1, 0, -2,
+ax_anim 6, 0, 14, 0, 2, 0, 0,
+ax_anim 6, 0, 14, 0, 3, 0, 0,
+ax_anim_terminator
+sSeelAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -2, -2, -2, -2,
+ax_anim 8, 0, 16, -3, -3, -3, -3,
+ax_anim 10, 0, 16, -4, -4, -4, -4,
+ax_anim 6, 0, 15, -2, -2, -3, -3,
+ax_anim 6, 0, 17, -1, -1, -2, -2,
+ax_anim 6, 0, 17, 1, 1, 0, 0,
+ax_anim_terminator
+sSeelAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -2, 0, -1, 0,
+ax_anim 8, 0, 19, -3, 0, -2, 0,
+ax_anim 10, 0, 19, -4, 0, -3, 0,
+ax_anim 6, 0, 18, -2, 0, -2, 0,
+ax_anim 6, 0, 20, 0, 0, -1, 0,
+ax_anim 6, 0, 20, 1, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -2, 2, -1, 1,
+ax_anim 8, 0, 22, -3, 3, -2, 2,
+ax_anim 10, 0, 22, -4, 4, -3, 3,
+ax_anim 6, 0, 21, -2, 2, -2, 2,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 1, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 1, 26, 1, 16, 1, 16,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 0, 26, 1, 16, 1, 16,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 0, 26, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSeelAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 18, 19, 18, 19,
+ax_anim 2, 1, 29, 19, 18, 19, 18,
+ax_anim 2, 0, 29, 18, 19, 18, 19,
+ax_anim 2, 0, 29, 19, 18, 19, 18,
+ax_anim 2, 0, 29, 18, 19, 18, 19,
+ax_anim 2, 0, 29, 19, 18, 19, 18,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSeelAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 1, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSeelAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 35, 18, -21, 18, -21,
+ax_anim 2, 1, 35, 19, -20, 19, -20,
+ax_anim 2, 0, 35, 18, -21, 18, -21,
+ax_anim 2, 0, 35, 19, -20, 19, -20,
+ax_anim 2, 0, 35, 18, -21, 18, -21,
+ax_anim 2, 0, 35, 19, -20, 19, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSeelAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 1, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 0, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 0, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSeelAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 41, -18, -21, -18, -21,
+ax_anim 2, 1, 41, -19, -20, -19, -20,
+ax_anim 2, 0, 41, -18, -21, -18, -21,
+ax_anim 2, 0, 41, -19, -20, -19, -20,
+ax_anim 2, 0, 41, -18, -21, -18, -21,
+ax_anim 2, 0, 41, -19, -20, -19, -20,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSeelAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 1, 44, -16, 1, -16, 1,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 0, 44, -16, 1, -16, 1,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 0, 44, -16, 1, -16, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSeelAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 47, -18, 19, -18, 19,
+ax_anim 2, 1, 47, -19, 18, -19, 18,
+ax_anim 2, 0, 47, -18, 19, -18, 19,
+ax_anim 2, 0, 47, -19, 18, -19, 18,
+ax_anim 2, 0, 47, -18, 19, -18, 19,
+ax_anim 2, 0, 47, -19, 18, -19, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeelAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 1, 50, 1, 16, 1, 16,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 0, 50, 1, 16, 1, 16,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 0, 50, 1, 16, 1, 16,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSeelAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 18, 19, 18, 19,
+ax_anim 2, 1, 53, 19, 18, 19, 18,
+ax_anim 2, 0, 53, 18, 19, 18, 19,
+ax_anim 2, 0, 53, 19, 18, 19, 18,
+ax_anim 2, 0, 53, 18, 19, 18, 19,
+ax_anim 2, 0, 53, 19, 18, 19, 18,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sSeelAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 16, 0, 16, 0,
+ax_anim 2, 1, 56, 16, 1, 16, 1,
+ax_anim 2, 0, 56, 16, 0, 16, 0,
+ax_anim 2, 0, 56, 16, 1, 16, 1,
+ax_anim 2, 0, 56, 16, 0, 16, 0,
+ax_anim 2, 0, 56, 16, 1, 16, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSeelAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 59, 18, -21, 18, -21,
+ax_anim 2, 1, 59, 19, -20, 19, -20,
+ax_anim 2, 0, 59, 18, -21, 18, -21,
+ax_anim 2, 0, 59, 19, -20, 19, -20,
+ax_anim 2, 0, 59, 18, -21, 18, -21,
+ax_anim 2, 0, 59, 19, -20, 19, -20,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSeelAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 62, 0, -19, 0, -19,
+ax_anim 2, 1, 62, 1, -19, 1, -19,
+ax_anim 2, 0, 62, 0, -19, 0, -19,
+ax_anim 2, 0, 62, 1, -19, 1, -19,
+ax_anim 2, 0, 62, 0, -19, 0, -19,
+ax_anim 2, 0, 62, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSeelAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 65, -18, -21, -18, -21,
+ax_anim 2, 1, 65, -19, -20, -19, -20,
+ax_anim 2, 0, 65, -18, -21, -18, -21,
+ax_anim 2, 0, 65, -19, -20, -19, -20,
+ax_anim 2, 0, 65, -18, -21, -18, -21,
+ax_anim 2, 0, 65, -19, -20, -19, -20,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSeelAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 68, -16, 0, -16, 0,
+ax_anim 2, 1, 68, -16, 1, -16, 1,
+ax_anim 2, 0, 68, -16, 0, -16, 0,
+ax_anim 2, 0, 68, -16, 1, -16, 1,
+ax_anim 2, 0, 68, -16, 0, -16, 0,
+ax_anim 2, 0, 68, -16, 1, -16, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSeelAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -18, 19, -18, 19,
+ax_anim 2, 1, 71, -19, 18, -19, 18,
+ax_anim 2, 0, 71, -18, 19, -18, 19,
+ax_anim 2, 0, 71, -19, 18, -19, 18,
+ax_anim 2, 0, 71, -18, 19, -18, 19,
+ax_anim 2, 0, 71, -19, 18, -19, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSeelAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 1, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 75, 1, 3, 1, 2,
+ax_anim 2, 0, 75, 0, 3, 0, 2,
+ax_anim 2, 0, 72, 0, 3, 0, 2,
+ax_anim_terminator
+sSeelAnims_4_2:
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 6, 2, 77, -3, -3, -3, -3,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 79, 3, 1, 2, 0,
+ax_anim 2, 0, 79, 2, 2, 1, 1,
+ax_anim 2, 0, 76, 2, 2, 1, 1,
+ax_anim_terminator
+sSeelAnims_4_3:
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 6, 2, 81, -3, 0, -3, 0,
+ax_anim 2, 0, 81, -1, 0, -1, 0,
+ax_anim 2, 1, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sSeelAnims_4_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 6, 2, 85, -3, 3, -3, 3,
+ax_anim 2, 0, 85, -1, 1, -1, 1,
+ax_anim 2, 1, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 87, 3, -1, 2, 0,
+ax_anim 2, 0, 87, 2, -2, 1, -1,
+ax_anim 2, 0, 84, 2, -2, 1, -1,
+ax_anim_terminator
+sSeelAnims_4_5:
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 6, 2, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 0, 1, 0, 1,
+ax_anim 2, 1, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -2,
+ax_anim 2, 0, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -2,
+ax_anim 2, 0, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -2,
+ax_anim 2, 0, 91, 0, -3, 0, -2,
+ax_anim 2, 0, 88, 0, -3, 0, -2,
+ax_anim_terminator
+sSeelAnims_4_6:
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 6, 2, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 1, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 95, -3, -1, -2, 0,
+ax_anim 2, 0, 95, -2, -2, -1, -1,
+ax_anim 2, 0, 92, -2, -2, -1, -1,
+ax_anim_terminator
+sSeelAnims_4_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 6, 2, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 1, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sSeelAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 6, 2, 101, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 1, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 103, -3, 1, -2, 0,
+ax_anim 2, 0, 103, -2, 2, -1, 1,
+ax_anim 2, 0, 100, -2, 2, -1, 1,
+ax_anim_terminator
+.align 2
+sSeelAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sSeelAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sSeelAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sSeelAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sSeelAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sSeelAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sSeelAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sSeelAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSeelAnims_8_1:
+ax_anim 30, 0, 122, 0, 0, 0, 0,
+ax_anim 20, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_8_2:
+ax_anim 30, 0, 124, 0, 0, 0, 0,
+ax_anim 20, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_8_3:
+ax_anim 30, 0, 126, 0, 0, 0, 0,
+ax_anim 20, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_8_4:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 20, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_8_5:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 20, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_8_6:
+ax_anim 30, 0, 132, 0, 0, 0, 0,
+ax_anim 20, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_8_7:
+ax_anim 30, 0, 134, 0, 0, 0, 0,
+ax_anim 20, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_8_8:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 20, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 15, 7, 15,
+ax_anim 3, 0, 142, 0, 19, 0, 19,
+ax_anim 2, 3, 143, -7, 15, -7, 15,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 21, 10, 21, 10,
+ax_anim 3, 0, 141, 22, 19, 22, 19,
+ax_anim 2, 3, 142, 11, 19, 11, 19,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 18, -5, 18, -5,
+ax_anim 3, 0, 140, 21, -2, 21, -2,
+ax_anim 2, 3, 141, 18, 4, 18, 4,
+ax_anim 2, 0, 142, 12, 5, 12, 5,
+ax_anim 1, 0, 143, 4, 4, 4, 4,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 2, -16, 2, -16,
+ax_anim 2, 0, 138, 12, -23, 12, -23,
+ax_anim 3, 0, 139, 21, -23, 21, -23,
+ax_anim 2, 3, 140, 20, -15, 20, -15,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 9, -1, 9, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -18, -7, -18,
+ax_anim 3, 0, 138, 0, -24, 0, -24,
+ax_anim 2, 3, 139, 7, -18, 7, -18,
+ax_anim 2, 0, 140, 9, -10, 9, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -2, -16, -2, -16,
+ax_anim 2, 0, 138, -12, -23, -12, -23,
+ax_anim 3, 0, 145, -21, -23, -21, -23,
+ax_anim 2, 3, 144, -20, -15, -20, -15,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -9, -1, -9, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -18, -5, -18, -5,
+ax_anim 3, 0, 144, -21, -2, -21, -2,
+ax_anim 2, 3, 143, -18, 4, -18, 4,
+ax_anim 2, 0, 142, -12, 5, -12, 5,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -21, 10, -21, 10,
+ax_anim 3, 0, 143, -22, 19, -22, 19,
+ax_anim 2, 3, 142, -11, 19, -11, 19,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeelAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSeelGfx1:
+.incbin "baserom.gba", 0x8AFBF0, 0x200
+sSeelSprites1:
+ax_sprite sSeelGfx1, 0x200
+ax_sprite_terminator
+sSeelGfx2:
+.incbin "baserom.gba", 0x8AFE00, 0x200
+sSeelSprites2:
+ax_sprite sSeelGfx2, 0x200
+ax_sprite_terminator
+sSeelGfx3:
+.incbin "baserom.gba", 0x8B0010, 0x200
+sSeelSprites3:
+ax_sprite sSeelGfx3, 0x200
+ax_sprite_terminator
+sSeelGfx4:
+.incbin "baserom.gba", 0x8B0220, 0x200
+sSeelSprites4:
+ax_sprite sSeelGfx4, 0x200
+ax_sprite_terminator
+sSeelGfx5:
+.incbin "baserom.gba", 0x8B0430, 0x200
+sSeelSprites5:
+ax_sprite sSeelGfx5, 0x200
+ax_sprite_terminator
+sSeelGfx6:
+.incbin "baserom.gba", 0x8B0640, 0x200
+sSeelSprites6:
+ax_sprite sSeelGfx6, 0x200
+ax_sprite_terminator
+sSeelGfx7:
+.incbin "baserom.gba", 0x8B0850, 0x200
+sSeelSprites7:
+ax_sprite sSeelGfx7, 0x200
+ax_sprite_terminator
+sSeelGfx8:
+.incbin "baserom.gba", 0x8B0A60, 0x200
+sSeelSprites8:
+ax_sprite sSeelGfx8, 0x200
+ax_sprite_terminator
+sSeelGfx9:
+.incbin "baserom.gba", 0x8B0C70, 0x200
+sSeelSprites9:
+ax_sprite sSeelGfx9, 0x200
+ax_sprite_terminator
+sSeelGfx10:
+.incbin "baserom.gba", 0x8B0E80, 0x200
+sSeelSprites10:
+ax_sprite sSeelGfx10, 0x200
+ax_sprite_terminator
+sSeelGfx11:
+.incbin "baserom.gba", 0x8B1090, 0x200
+sSeelSprites11:
+ax_sprite sSeelGfx11, 0x200
+ax_sprite_terminator
+sSeelGfx12:
+.incbin "baserom.gba", 0x8B12A0, 0x200
+sSeelSprites12:
+ax_sprite sSeelGfx12, 0x200
+ax_sprite_terminator
+sSeelGfx13:
+.incbin "baserom.gba", 0x8B14B0, 0x200
+sSeelSprites13:
+ax_sprite sSeelGfx13, 0x200
+ax_sprite_terminator
+sSeelGfx14:
+.incbin "baserom.gba", 0x8B16C0, 0x200
+sSeelSprites14:
+ax_sprite sSeelGfx14, 0x200
+ax_sprite_terminator
+sSeelGfx15:
+.incbin "baserom.gba", 0x8B18D0, 0x200
+sSeelSprites15:
+ax_sprite sSeelGfx15, 0x200
+ax_sprite_terminator
+sSeelGfx16:
+.incbin "baserom.gba", 0x8B1AE0, 0x100
+sSeelGfx16_1:
+.incbin "baserom.gba", 0x8B1BE0, 0x40
+sSeelSprites16:
+ax_sprite sSeelGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx16_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSeelGfx17:
+.incbin "baserom.gba", 0x8B1C48, 0x40
+sSeelGfx17_1:
+.incbin "baserom.gba", 0x8B1C88, 0x60
+sSeelGfx17_2:
+.incbin "baserom.gba", 0x8B1CE8, 0x40
+sSeelGfx17_3:
+.incbin "baserom.gba", 0x8B1D28, 0x40
+sSeelSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeelGfx17_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeelGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeelGfx18:
+.incbin "baserom.gba", 0x8B1DB8, 0x60
+sSeelGfx18_1:
+.incbin "baserom.gba", 0x8B1E18, 0x80
+sSeelGfx18_2:
+.incbin "baserom.gba", 0x8B1E98, 0x60
+sSeelSprites18:
+ax_sprite sSeelGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx18_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSeelGfx19:
+.incbin "baserom.gba", 0x8B1F30, 0x140
+sSeelSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx19, 0x140
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSeelGfx20:
+.incbin "baserom.gba", 0x8B2090, 0x40
+sSeelGfx20_1:
+.incbin "baserom.gba", 0x8B20D0, 0x60
+sSeelGfx20_2:
+.incbin "baserom.gba", 0x8B2130, 0x60
+sSeelSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeelGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx20_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSeelGfx21:
+.incbin "baserom.gba", 0x8B21D0, 0xE0
+sSeelSprites21:
+ax_sprite sSeelGfx21, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeelGfx22:
+.incbin "baserom.gba", 0x8B22C8, 0x40
+sSeelGfx22_1:
+.incbin "baserom.gba", 0x8B2308, 0x80
+sSeelGfx22_2:
+.incbin "baserom.gba", 0x8B2388, 0x60
+sSeelGfx22_3:
+.incbin "baserom.gba", 0x8B23E8, 0x20
+sSeelSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx22_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeelGfx22_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeelGfx23:
+.incbin "baserom.gba", 0x8B2458, 0x40
+sSeelGfx23_1:
+.incbin "baserom.gba", 0x8B2498, 0x80
+sSeelGfx23_2:
+.incbin "baserom.gba", 0x8B2518, 0x60
+sSeelGfx23_3:
+.incbin "baserom.gba", 0x8B2578, 0x20
+sSeelSprites23:
+ax_sprite sSeelGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSeelGfx23_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeelGfx23_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeelGfx24:
+.incbin "baserom.gba", 0x8B25E0, 0x160
+sSeelSprites24:
+ax_sprite sSeelGfx24, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSeelGfx25:
+.incbin "baserom.gba", 0x8B2758, 0x40
+sSeelGfx25_1:
+.incbin "baserom.gba", 0x8B2798, 0x60
+sSeelGfx25_2:
+.incbin "baserom.gba", 0x8B27F8, 0x60
+sSeelGfx25_3:
+.incbin "baserom.gba", 0x8B2858, 0x40
+sSeelSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeelGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeelGfx26:
+.incbin "baserom.gba", 0x8B28E8, 0x60
+sSeelGfx26_1:
+.incbin "baserom.gba", 0x8B2948, 0x100
+sSeelGfx26_2:
+.incbin "baserom.gba", 0x8B2A48, 0x40
+sSeelSprites26:
+ax_sprite sSeelGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeelGfx27:
+.incbin "baserom.gba", 0x8B2AC0, 0x40
+sSeelGfx27_1:
+.incbin "baserom.gba", 0x8B2B00, 0x60
+sSeelGfx27_2:
+.incbin "baserom.gba", 0x8B2B60, 0x60
+sSeelSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSeelGfx28:
+.incbin "baserom.gba", 0x8B2C00, 0x40
+sSeelGfx28_1:
+.incbin "baserom.gba", 0x8B2C40, 0x60
+sSeelGfx28_2:
+.incbin "baserom.gba", 0x8B2CA0, 0x60
+sSeelSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSeelGfx29:
+.incbin "baserom.gba", 0x8B2D40, 0x140
+sSeelSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx29, 0x140
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSeelGfx30:
+.incbin "baserom.gba", 0x8B2EA0, 0x40
+sSeelGfx30_1:
+.incbin "baserom.gba", 0x8B2EE0, 0x60
+sSeelGfx30_2:
+.incbin "baserom.gba", 0x8B2F40, 0x80
+sSeelSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeelGfx30_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSeelGfx31:
+.incbin "baserom.gba", 0x8B3000, 0x200
+sSeelSprites31:
+ax_sprite sSeelGfx31, 0x200
+ax_sprite_terminator
+sSeelGfx32:
+.incbin "baserom.gba", 0x8B3210, 0x200
+sSeelSprites32:
+ax_sprite sSeelGfx32, 0x200
+ax_sprite_terminator
+sSeelGfx33:
+.incbin "baserom.gba", 0x8B3420, 0x200
+sSeelSprites33:
+ax_sprite sSeelGfx33, 0x200
+ax_sprite_terminator
+sSeelGfx34:
+.incbin "baserom.gba", 0x8B3630, 0x200
+sSeelSprites34:
+ax_sprite sSeelGfx34, 0x200
+ax_sprite_terminator
+sSeelGfx35:
+.incbin "baserom.gba", 0x8B3840, 0x200
+sSeelSprites35:
+ax_sprite sSeelGfx35, 0x200
+ax_sprite_terminator
+sSeelGfx36:
+.incbin "baserom.gba", 0x8B3A50, 0x200
+sSeelSprites36:
+ax_sprite sSeelGfx36, 0x200
+ax_sprite_terminator
+sSeelGfx37:
+.incbin "baserom.gba", 0x8B3C60, 0x200
+sSeelSprites37:
+ax_sprite sSeelGfx37, 0x200
+ax_sprite_terminator
+sAxPosesSeel:
+.4byte sSeelPose1
+.4byte sSeelPose2
+.4byte sSeelPose3
+.4byte sSeelPose4
+.4byte sSeelPose5
+.4byte sSeelPose6
+.4byte sSeelPose7
+.4byte sSeelPose8
+.4byte sSeelPose9
+.4byte sSeelPose10
+.4byte sSeelPose11
+.4byte sSeelPose12
+.4byte sSeelPose13
+.4byte sSeelPose14
+.4byte sSeelPose15
+.4byte sSeelPose16
+.4byte sSeelPose17
+.4byte sSeelPose18
+.4byte sSeelPose19
+.4byte sSeelPose20
+.4byte sSeelPose21
+.4byte sSeelPose22
+.4byte sSeelPose23
+.4byte sSeelPose24
+.4byte sSeelPose25
+.4byte sSeelPose26
+.4byte sSeelPose27
+.4byte sSeelPose28
+.4byte sSeelPose29
+.4byte sSeelPose30
+.4byte sSeelPose31
+.4byte sSeelPose32
+.4byte sSeelPose33
+.4byte sSeelPose34
+.4byte sSeelPose35
+.4byte sSeelPose36
+.4byte sSeelPose37
+.4byte sSeelPose38
+.4byte sSeelPose39
+.4byte sSeelPose40
+.4byte sSeelPose41
+.4byte sSeelPose42
+.4byte sSeelPose43
+.4byte sSeelPose44
+.4byte sSeelPose45
+.4byte sSeelPose46
+.4byte sSeelPose47
+.4byte sSeelPose48
+.4byte sSeelPose49
+.4byte sSeelPose50
+.4byte sSeelPose51
+.4byte sSeelPose52
+.4byte sSeelPose53
+.4byte sSeelPose54
+.4byte sSeelPose55
+.4byte sSeelPose56
+.4byte sSeelPose57
+.4byte sSeelPose58
+.4byte sSeelPose59
+.4byte sSeelPose60
+.4byte sSeelPose61
+.4byte sSeelPose62
+.4byte sSeelPose63
+.4byte sSeelPose64
+.4byte sSeelPose65
+.4byte sSeelPose66
+.4byte sSeelPose67
+.4byte sSeelPose68
+.4byte sSeelPose69
+.4byte sSeelPose70
+.4byte sSeelPose71
+.4byte sSeelPose72
+.4byte sSeelPose73
+.4byte sSeelPose74
+.4byte sSeelPose75
+.4byte sSeelPose76
+.4byte sSeelPose77
+.4byte sSeelPose78
+.4byte sSeelPose79
+.4byte sSeelPose80
+.4byte sSeelPose81
+.4byte sSeelPose82
+.4byte sSeelPose83
+.4byte sSeelPose84
+.4byte sSeelPose85
+.4byte sSeelPose86
+.4byte sSeelPose87
+.4byte sSeelPose88
+.4byte sSeelPose89
+.4byte sSeelPose90
+.4byte sSeelPose91
+.4byte sSeelPose92
+.4byte sSeelPose93
+.4byte sSeelPose94
+.4byte sSeelPose95
+.4byte sSeelPose96
+.4byte sSeelPose97
+.4byte sSeelPose98
+.4byte sSeelPose99
+.4byte sSeelPose100
+.4byte sSeelPose101
+.4byte sSeelPose102
+.4byte sSeelPose103
+.4byte sSeelPose104
+.4byte sSeelPose105
+.4byte sSeelPose106
+.4byte sSeelPose107
+.4byte sSeelPose108
+.4byte sSeelPose109
+.4byte sSeelPose110
+.4byte sSeelPose111
+.4byte sSeelPose112
+.4byte sSeelPose113
+.4byte sSeelPose114
+.4byte sSeelPose115
+.4byte sSeelPose116
+.4byte sSeelPose117
+.4byte sSeelPose118
+.4byte sSeelPose119
+.4byte sSeelPose120
+.4byte sSeelPose121
+.4byte sSeelPose122
+.4byte sSeelPose123
+.4byte sSeelPose124
+.4byte sSeelPose125
+.4byte sSeelPose126
+.4byte sSeelPose127
+.4byte sSeelPose128
+.4byte sSeelPose129
+.4byte sSeelPose130
+.4byte sSeelPose131
+.4byte sSeelPose132
+.4byte sSeelPose133
+.4byte sSeelPose134
+.4byte sSeelPose135
+.4byte sSeelPose136
+.4byte sSeelPose137
+.4byte sSeelPose138
+.4byte sSeelPose139
+.4byte sSeelPose140
+.4byte sSeelPose141
+.4byte sSeelPose142
+.4byte sSeelPose143
+.4byte sSeelPose144
+.4byte sSeelPose145
+.4byte sSeelPose146
+.4byte sSeelPose147
+.4byte sSeelPose148
+.4byte sSeelPose149
+.4byte sSeelPose150
+.4byte sSeelPose151
+.4byte sSeelPose152
+.4byte sSeelPose153
+.4byte sSeelPose154
+.4byte sSeelPose155
+.4byte sSeelPose156
+.4byte sSeelPose157
+.4byte sSeelPose158
+.4byte sSeelPose159
+.4byte sSeelPose160
+.4byte sSeelPose161
+.4byte sSeelPose162
+.4byte sSeelPose163
+.4byte sSeelPose164
+.4byte sSeelPose165
+.4byte sSeelPose166
+.4byte sSeelPose167
+.4byte sSeelPose168
+.4byte sSeelPose169
+.4byte sSeelPose170
+.4byte sSeelPose171
+.4byte sSeelPose172
+.4byte sSeelPose173
+.4byte sSeelPose174
+.4byte sSeelPose175
+.4byte sSeelPose176
+.4byte sSeelPose177
+.4byte sSeelPose178
+.4byte sSeelPose179
+.4byte sSeelPose180
+.4byte sSeelPose181
+.4byte sSeelPose182
+.4byte sSeelPose183
+.4byte sSeelPose184
+.4byte sSeelPose185
+.4byte sSeelPose186
+.4byte sSeelPose187
+.4byte sSeelPose188
+.4byte sSeelPose189
+.4byte sSeelPose190
+.4byte sSeelPose191
+.4byte sSeelPose192
+.4byte sSeelPose193
+.4byte sSeelPose194
+sAxPositionsSeel:
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -5, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -1, 	  -9,    1, 	   8,    1, 	  -1,   -5
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    7,   -7, 	   7,   -9, 	  -6,   -3, 	  -1,   -7
+.2byte    7,   -3, 	  11,   -4, 	  -2,    1, 	  -1,   -7
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    9,   -8, 	   5,   -7, 	  -2,   -1, 	   0,   -7
+.2byte   10,   -4, 	   9,   -5, 	   3,    0, 	   0,   -6
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    7,  -13, 	  -2,  -10, 	   5,    0, 	   1,   -8
+.2byte    6,   -8, 	  -4,   -9, 	   8,   -3, 	   0,   -7
+.2byte   -1,  -11, 	   8,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -1,  -16, 	   8,   -3, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   8,   -6, 	 -10,   -6, 	  -1,   -7
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -8,  -13, 	   1,  -10, 	  -6,    0, 	  -2,   -8
+.2byte   -7,   -8, 	   3,   -9, 	  -9,   -3, 	  -1,   -7
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte  -10,   -8, 	  -6,   -7, 	   1,   -1, 	  -1,   -7
+.2byte  -11,   -4, 	 -10,   -5, 	  -4,    0, 	  -1,   -6
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte   -8,   -7, 	  -8,   -9, 	   5,   -3, 	   0,   -7
+.2byte   -8,   -3, 	 -12,   -4, 	   1,    1, 	   0,   -7
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,  -19, 	 -11,  -13, 	   9,  -13, 	  -1,   -9
+.2byte   -1,    3, 	  -8,   -9, 	   6,   -9, 	  -1,   -7
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    1,  -18, 	   8,  -15, 	  -6,  -11, 	   1,   -9
+.2byte    3,    0, 	   1,  -12, 	  -5,   -8, 	   2,   -9
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    5,  -19, 	   3,  -18, 	   1,  -12, 	   1,   -7
+.2byte    6,   -1, 	  -4,  -10, 	  -3,   -7, 	   0,   -8
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    2,  -17, 	  -5,  -16, 	   5,  -12, 	  -2,   -7
+.2byte    5,   -5, 	  -7,   -8, 	  -1,   -2, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -5, 	  -9,   -5, 	  -1,   -8
+.2byte   -1,  -19, 	   9,  -11, 	 -10,  -11, 	  -1,   -7
+.2byte   -1,  -15, 	   6,   -6, 	  -8,   -7, 	  -1,   -9
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -3,  -17, 	   4,  -16, 	  -6,  -12, 	   1,   -7
+.2byte   -6,   -5, 	   6,   -8, 	   0,   -2, 	   0,   -8
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte   -6,  -19, 	  -4,  -18, 	  -2,  -12, 	  -2,   -7
+.2byte   -7,   -1, 	   3,  -10, 	   2,   -7, 	  -1,   -8
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte   -2,  -18, 	  -9,  -15, 	   5,  -11, 	  -2,   -9
+.2byte   -4,    0, 	  -2,  -12, 	   4,   -8, 	  -3,   -9
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,  -19, 	 -11,  -13, 	   9,  -13, 	  -1,   -9
+.2byte   -1,    3, 	  -8,   -9, 	   6,   -9, 	  -1,   -7
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    1,  -18, 	   8,  -15, 	  -6,  -11, 	   1,   -9
+.2byte    3,    0, 	   1,  -12, 	  -5,   -8, 	   2,   -9
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    5,  -19, 	   3,  -18, 	   1,  -12, 	   1,   -7
+.2byte    6,   -1, 	  -4,  -10, 	  -3,   -7, 	   0,   -8
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    2,  -17, 	  -5,  -16, 	   5,  -12, 	  -2,   -7
+.2byte    5,   -5, 	  -7,   -8, 	  -1,   -2, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -5, 	  -9,   -5, 	  -1,   -8
+.2byte   -1,  -19, 	   9,  -11, 	 -10,  -11, 	  -1,   -7
+.2byte   -1,  -15, 	   6,   -6, 	  -8,   -7, 	  -1,   -9
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -3,  -17, 	   4,  -16, 	  -6,  -12, 	   1,   -7
+.2byte   -6,   -5, 	   6,   -8, 	   0,   -2, 	   0,   -8
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte   -6,  -19, 	  -4,  -18, 	  -2,  -12, 	  -2,   -7
+.2byte   -7,   -1, 	   3,  -10, 	   2,   -7, 	  -1,   -8
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte   -2,  -18, 	  -9,  -15, 	   5,  -11, 	  -2,   -9
+.2byte   -4,    0, 	  -2,  -12, 	   4,   -8, 	  -3,   -9
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -5, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,   -1, 	  -9,    1, 	   8,    1, 	  -1,   -5
+.2byte   -1,    2, 	 -11,   -3, 	   9,   -3, 	  -1,   -5
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    6,   -7, 	   6,   -9, 	  -7,   -3, 	  -2,   -7
+.2byte    7,   -3, 	  11,   -4, 	  -2,    1, 	  -1,   -7
+.2byte    9,    0, 	   4,   -9, 	  -5,   -2, 	   1,   -7
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    9,   -8, 	   5,   -7, 	  -2,   -1, 	   0,   -7
+.2byte   10,   -4, 	   9,   -5, 	   3,    0, 	   0,   -6
+.2byte   12,   -1, 	   2,   -7, 	  -1,    0, 	   2,   -6
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    7,  -13, 	  -2,  -10, 	   5,    0, 	   1,   -8
+.2byte    6,   -8, 	  -4,   -9, 	   8,   -3, 	   0,   -7
+.2byte    8,   -4, 	  -5,   -8, 	   4,    0, 	   0,   -7
+.2byte   -1,  -11, 	   8,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -1,  -16, 	   8,   -3, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   8,   -6, 	 -10,   -6, 	  -1,   -7
+.2byte   -1,  -13, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -8,  -13, 	   1,  -10, 	  -6,    0, 	  -2,   -8
+.2byte   -7,   -8, 	   3,   -9, 	  -9,   -3, 	  -1,   -7
+.2byte   -9,   -4, 	   4,   -8, 	  -5,    0, 	  -1,   -7
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte  -10,   -8, 	  -6,   -7, 	   1,   -1, 	  -1,   -7
+.2byte  -11,   -4, 	 -10,   -5, 	  -4,    0, 	  -1,   -6
+.2byte  -13,   -1, 	  -3,   -7, 	   0,    0, 	  -3,   -6
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte   -7,   -7, 	  -7,   -9, 	   6,   -3, 	   1,   -7
+.2byte   -8,   -3, 	 -12,   -4, 	   1,    1, 	   0,   -7
+.2byte  -10,    0, 	  -5,   -9, 	   4,   -2, 	  -2,   -7
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -1,  -13, 	   8,   -5, 	  -9,   -5, 	  -1,   -8
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+.2byte   -8,   -1, 	 -12,   -3, 	  -2,    1, 	   0,   -6
+.2byte   -8,   -1, 	 -12,   -3, 	  -2,    0, 	   0,   -7
+.2byte   -1,  -18, 	  -6,   -6, 	   4,   -6, 	  -1,   -9
+.2byte    0,  -17, 	   9,   -5, 	   0,   -2, 	  -1,   -9
+.2byte    5,  -16, 	   7,   -8, 	   8,   -6, 	   0,   -6
+.2byte    3,  -16, 	   2,  -12, 	   9,   -9, 	  -1,   -7
+.2byte   -1,  -18, 	   7,  -12, 	  -9,  -11, 	  -1,   -7
+.2byte   -4,  -16, 	  -3,  -12, 	 -10,   -9, 	   0,   -7
+.2byte   -6,  -16, 	  -8,   -8, 	  -9,   -6, 	  -1,   -6
+.2byte   -1,  -17, 	 -10,   -5, 	  -1,   -2, 	   0,   -9
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,   -5, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    7,   -7, 	   7,   -9, 	  -6,   -3, 	  -1,   -7
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    8,   -8, 	   4,   -7, 	  -3,   -1, 	  -1,   -7
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    7,  -13, 	  -2,  -10, 	   5,    0, 	   1,   -8
+.2byte   -1,  -11, 	   8,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -1,  -14, 	   8,   -1, 	 -10,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -8,  -13, 	   1,  -10, 	  -6,    0, 	  -2,   -8
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte   -9,   -8, 	  -5,   -7, 	   2,   -1, 	   0,   -7
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte   -8,   -7, 	  -8,   -9, 	   5,   -3, 	   0,   -7
+.2byte   -1,    2, 	 -11,   -3, 	   9,   -3, 	  -1,   -5
+.2byte   -8,    2, 	  -3,   -7, 	   6,    0, 	   0,   -5
+.2byte   -9,    0, 	   1,   -6, 	   4,    1, 	   1,   -5
+.2byte   -9,   -2, 	   4,   -6, 	  -5,    2, 	  -1,   -5
+.2byte   -1,  -11, 	   7,   -1, 	  -9,   -1, 	  -1,   -4
+.2byte    8,   -2, 	  -5,   -6, 	   4,    2, 	   0,   -5
+.2byte    8,    0, 	  -2,   -6, 	  -5,    1, 	  -2,   -5
+.2byte    7,    2, 	   2,   -7, 	  -7,    0, 	  -1,   -5
+.2byte   -1,  -17, 	 -11,  -11, 	   9,  -11, 	  -1,   -7
+.2byte    0,  -16, 	   7,  -13, 	  -7,   -9, 	   0,   -7
+.2byte    4,  -18, 	   2,  -17, 	   0,  -11, 	   0,   -6
+.2byte    3,  -16, 	  -4,  -15, 	   6,  -11, 	  -1,   -6
+.2byte   -1,  -18, 	   9,  -10, 	 -10,  -10, 	  -1,   -6
+.2byte   -4,  -16, 	   3,  -15, 	  -7,  -11, 	   0,   -6
+.2byte   -5,  -18, 	  -3,  -17, 	  -1,  -11, 	  -1,   -6
+.2byte   -1,  -16, 	  -8,  -13, 	   6,   -9, 	  -1,   -7
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -1,  -17, 	 -11,  -11, 	   9,  -11, 	  -1,   -7
+.2byte   -1,    2, 	 -11,   -3, 	   9,   -3, 	  -1,   -5
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+.2byte    1,  -17, 	   8,  -14, 	  -6,  -10, 	   1,   -8
+.2byte    7,    0, 	   2,   -9, 	  -7,   -2, 	  -1,   -7
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    4,  -18, 	   2,  -17, 	   0,  -11, 	   0,   -6
+.2byte    9,   -1, 	  -1,   -7, 	  -4,    0, 	  -1,   -6
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    2,  -17, 	  -5,  -16, 	   5,  -12, 	  -2,   -7
+.2byte    8,   -4, 	  -5,   -8, 	   4,    0, 	   0,   -7
+.2byte   -1,  -13, 	   8,   -5, 	  -9,   -5, 	  -1,   -8
+.2byte   -1,  -17, 	   9,   -9, 	 -10,   -9, 	  -1,   -5
+.2byte   -1,  -13, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -3,  -17, 	   4,  -16, 	  -6,  -12, 	   1,   -7
+.2byte   -9,   -4, 	   4,   -8, 	  -5,    0, 	  -1,   -7
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte   -5,  -18, 	  -3,  -17, 	  -1,  -11, 	  -1,   -6
+.2byte  -10,   -1, 	   0,   -7, 	   3,    0, 	   0,   -6
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte   -2,  -17, 	  -9,  -14, 	   5,  -10, 	  -2,   -8
+.2byte   -8,    0, 	  -3,   -9, 	   6,   -2, 	   0,   -7
+.2byte   -1,   -5, 	 -10,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -8,   -6, 	  -8,   -8, 	   5,   -2, 	   0,   -6
+.2byte  -10,   -8, 	  -6,   -7, 	   1,   -1, 	  -1,   -7
+.2byte   -7,  -13, 	   2,  -10, 	  -5,    0, 	  -1,   -8
+.2byte   -1,  -16, 	   8,   -3, 	 -10,   -4, 	  -1,   -9
+.2byte    6,  -13, 	  -3,  -10, 	   4,    0, 	   0,   -8
+.2byte    9,   -8, 	   5,   -7, 	  -2,   -1, 	   0,   -7
+.2byte    7,   -6, 	   7,   -8, 	  -6,   -2, 	  -1,   -6
+.2byte   -1,   -2, 	 -11,   -1, 	   8,   -1, 	  -1,   -8
+.2byte   -8,   -4, 	 -12,   -5, 	   4,    0, 	   1,   -8
+.2byte  -10,   -5, 	  -8,   -6, 	  -2,    0, 	  -1,   -6
+.2byte   -8,  -10, 	   4,   -8, 	  -8,   -2, 	  -1,   -6
+.2byte   -1,  -13, 	   8,   -5, 	  -9,   -5, 	  -1,   -8
+.2byte    7,  -10, 	  -5,   -8, 	   7,   -2, 	   0,   -6
+.2byte    9,   -5, 	   7,   -6, 	   1,    0, 	   0,   -6
+.2byte    7,   -4, 	  11,   -5, 	  -5,    0, 	  -2,   -8
+sSeelAnimTable1:
+.4byte sSeelAnims_1_1
+.4byte sSeelAnims_1_2
+.4byte sSeelAnims_1_3
+.4byte sSeelAnims_1_4
+.4byte sSeelAnims_1_5
+.4byte sSeelAnims_1_6
+.4byte sSeelAnims_1_7
+.4byte sSeelAnims_1_8
+sSeelAnimTable2:
+.4byte sSeelAnims_2_1
+.4byte sSeelAnims_2_2
+.4byte sSeelAnims_2_3
+.4byte sSeelAnims_2_4
+.4byte sSeelAnims_2_5
+.4byte sSeelAnims_2_6
+.4byte sSeelAnims_2_7
+.4byte sSeelAnims_2_8
+sSeelAnimTable3:
+.4byte sSeelAnims_3_1
+.4byte sSeelAnims_3_2
+.4byte sSeelAnims_3_3
+.4byte sSeelAnims_3_4
+.4byte sSeelAnims_3_5
+.4byte sSeelAnims_3_6
+.4byte sSeelAnims_3_7
+.4byte sSeelAnims_3_8
+sSeelAnimTable4:
+.4byte sSeelAnims_4_1
+.4byte sSeelAnims_4_2
+.4byte sSeelAnims_4_3
+.4byte sSeelAnims_4_4
+.4byte sSeelAnims_4_5
+.4byte sSeelAnims_4_6
+.4byte sSeelAnims_4_7
+.4byte sSeelAnims_4_8
+sSeelAnimTable5:
+.4byte sSeelAnims_5_1
+.4byte sSeelAnims_5_2
+.4byte sSeelAnims_5_3
+.4byte sSeelAnims_5_4
+.4byte sSeelAnims_5_5
+.4byte sSeelAnims_5_6
+.4byte sSeelAnims_5_7
+.4byte sSeelAnims_5_8
+sSeelAnimTable6:
+.4byte sSeelAnims_6_1
+.4byte sSeelAnims_6_1
+.4byte sSeelAnims_6_1
+.4byte sSeelAnims_6_1
+.4byte sSeelAnims_6_1
+.4byte sSeelAnims_6_1
+.4byte sSeelAnims_6_1
+.4byte sSeelAnims_6_1
+sSeelAnimTable7:
+.4byte sSeelAnims_7_1
+.4byte sSeelAnims_7_2
+.4byte sSeelAnims_7_3
+.4byte sSeelAnims_7_4
+.4byte sSeelAnims_7_5
+.4byte sSeelAnims_7_6
+.4byte sSeelAnims_7_7
+.4byte sSeelAnims_7_8
+sSeelAnimTable8:
+.4byte sSeelAnims_8_1
+.4byte sSeelAnims_8_2
+.4byte sSeelAnims_8_3
+.4byte sSeelAnims_8_4
+.4byte sSeelAnims_8_5
+.4byte sSeelAnims_8_6
+.4byte sSeelAnims_8_7
+.4byte sSeelAnims_8_8
+sSeelAnimTable9:
+.4byte sSeelAnims_9_1
+.4byte sSeelAnims_9_2
+.4byte sSeelAnims_9_3
+.4byte sSeelAnims_9_4
+.4byte sSeelAnims_9_5
+.4byte sSeelAnims_9_6
+.4byte sSeelAnims_9_7
+.4byte sSeelAnims_9_8
+sSeelAnimTable10:
+.4byte sSeelAnims_10_1
+.4byte sSeelAnims_10_2
+.4byte sSeelAnims_10_3
+.4byte sSeelAnims_10_4
+.4byte sSeelAnims_10_5
+.4byte sSeelAnims_10_6
+.4byte sSeelAnims_10_7
+.4byte sSeelAnims_10_8
+sSeelAnimTable11:
+.4byte sSeelAnims_11_1
+.4byte sSeelAnims_11_2
+.4byte sSeelAnims_11_3
+.4byte sSeelAnims_11_4
+.4byte sSeelAnims_11_5
+.4byte sSeelAnims_11_6
+.4byte sSeelAnims_11_7
+.4byte sSeelAnims_11_8
+sSeelAnimTable12:
+.4byte sSeelAnims_12_1
+.4byte sSeelAnims_12_2
+.4byte sSeelAnims_12_3
+.4byte sSeelAnims_12_4
+.4byte sSeelAnims_12_5
+.4byte sSeelAnims_12_6
+.4byte sSeelAnims_12_7
+.4byte sSeelAnims_12_8
+sSeelAnimTable13:
+.4byte sSeelAnims_13_1
+.4byte sSeelAnims_13_2
+.4byte sSeelAnims_13_3
+.4byte sSeelAnims_13_4
+.4byte sSeelAnims_13_5
+.4byte sSeelAnims_13_6
+.4byte sSeelAnims_13_7
+.4byte sSeelAnims_13_8
+sAxAnimationsSeel:
+.4byte sSeelAnimTable1
+.4byte sSeelAnimTable2
+.4byte sSeelAnimTable3
+.4byte sSeelAnimTable4
+.4byte sSeelAnimTable5
+.4byte sSeelAnimTable6
+.4byte sSeelAnimTable7
+.4byte sSeelAnimTable8
+.4byte sSeelAnimTable9
+.4byte sSeelAnimTable10
+.4byte sSeelAnimTable11
+.4byte sSeelAnimTable12
+.4byte sSeelAnimTable13
+sAxSpritesSeel:
+.4byte sSeelSprites1
+.4byte sSeelSprites2
+.4byte sSeelSprites3
+.4byte sSeelSprites4
+.4byte sSeelSprites5
+.4byte sSeelSprites6
+.4byte sSeelSprites7
+.4byte sSeelSprites8
+.4byte sSeelSprites9
+.4byte sSeelSprites10
+.4byte sSeelSprites11
+.4byte sSeelSprites12
+.4byte sSeelSprites13
+.4byte sSeelSprites14
+.4byte sSeelSprites15
+.4byte sSeelSprites16
+.4byte sSeelSprites17
+.4byte sSeelSprites18
+.4byte sSeelSprites19
+.4byte sSeelSprites20
+.4byte sSeelSprites21
+.4byte sSeelSprites22
+.4byte sSeelSprites23
+.4byte sSeelSprites24
+.4byte sSeelSprites25
+.4byte sSeelSprites26
+.4byte sSeelSprites27
+.4byte sSeelSprites28
+.4byte sSeelSprites29
+.4byte sSeelSprites30
+.4byte sSeelSprites31
+.4byte sSeelSprites32
+.4byte sSeelSprites33
+.4byte sSeelSprites34
+.4byte sSeelSprites35
+.4byte sSeelSprites36
+.4byte sSeelSprites37
+sAxMainSeel:
+ax_main sAxPosesSeel, sAxAnimationsSeel, 13, sAxSpritesSeel, sAxPositionsSeel

--- a/data/ax/sentret.inc
+++ b/data/ax/sentret.inc
@@ -1,0 +1,3192 @@
+.global gAxSentret
+gAxSentret:
+ax_siro sAxMainSentret
+sSentretPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose2:
+ax_pose 1, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sSentretPose3:
+ax_pose 2, 0x01ec, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose4:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose5:
+ax_pose 4, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sSentretPose6:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose7:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose8:
+ax_pose 7, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose9:
+ax_pose 8, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose11:
+ax_pose 10, 0x01ec, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose17:
+ax_pose 10, 0x01ec, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose19:
+ax_pose 6, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose20:
+ax_pose 7, 0x01eb, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose21:
+ax_pose 8, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose22:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose23:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose24:
+ax_pose 5, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose26:
+ax_pose 15, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose27:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose28:
+ax_pose 17, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose29:
+ax_pose 18, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose30:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose31:
+ax_pose 19, 0x01e0, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose32:
+ax_pose 20, 0x01e8, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose33:
+ax_pose 21, 0x01e5, 0x90ed, 0x1c00
+ax_pose_terminator
+sSentretPose34:
+ax_pose 22, 0x01e2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose35:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose36:
+ax_pose 23, 0x01e0, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose37:
+ax_pose 24, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose38:
+ax_pose 25, 0x41e6, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose39:
+ax_pose 26, 0x01e3, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose40:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose41:
+ax_pose 27, 0x01e1, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose42:
+ax_pose 28, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose43:
+ax_pose 29, 0x01e3, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose44:
+ax_pose 30, 0x01e1, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose45:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose46:
+ax_pose 31, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose47:
+ax_pose 32, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose48:
+ax_pose 33, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose49:
+ax_pose 34, 0x01e2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose50:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose51:
+ax_pose 27, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose52:
+ax_pose 28, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose53:
+ax_pose 29, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose54:
+ax_pose 30, 0x01e2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose55:
+ax_pose 6, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose56:
+ax_pose 23, 0x01e0, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose57:
+ax_pose 24, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose58:
+ax_pose 25, 0x41e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose59:
+ax_pose 26, 0x01e4, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose60:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose61:
+ax_pose 19, 0x01e0, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose62:
+ax_pose 20, 0x01e8, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose63:
+ax_pose 21, 0x01e5, 0x80f3, 0x1c00
+ax_pose_terminator
+sSentretPose64:
+ax_pose 22, 0x01e3, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose65:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose66:
+ax_pose 1, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sSentretPose67:
+ax_pose 2, 0x01ec, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose68:
+ax_pose 35, 0x01ea, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose69:
+ax_pose 36, 0x81ea, 0x80f3, 0x1c00
+ax_pose 37, 0x01ea, 0x80f3, 0x1c08
+ax_pose_terminator
+sSentretPose70:
+ax_pose 37, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sSentretPose71:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose72:
+ax_pose 4, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sSentretPose73:
+ax_pose 5, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose74:
+ax_pose 38, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose75:
+ax_pose 39, 0x81e5, 0x90fc, 0x1c00
+ax_pose 40, 0x01eb, 0x90ea, 0x1c08
+ax_pose_terminator
+sSentretPose76:
+ax_pose 40, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose77:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose78:
+ax_pose 7, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose79:
+ax_pose 8, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose80:
+ax_pose 41, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose81:
+ax_pose 42, 0x01eb, 0x90ef, 0x1c00
+ax_pose 43, 0x01eb, 0x90e9, 0x1c10
+ax_pose_terminator
+sSentretPose82:
+ax_pose 43, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose83:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose84:
+ax_pose 10, 0x01ec, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose85:
+ax_pose 11, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose86:
+ax_pose 44, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose87:
+ax_pose 45, 0x01eb, 0x90eb, 0x1c00
+ax_pose 46, 0x41ea, 0x90eb, 0x1c10
+ax_pose_terminator
+sSentretPose88:
+ax_pose 45, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose89:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose90:
+ax_pose 13, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose91:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose92:
+ax_pose 47, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose93:
+ax_pose 48, 0x01ec, 0x80f4, 0x1c00
+ax_pose 49, 0x01e9, 0x80f7, 0x1c10
+ax_pose_terminator
+sSentretPose94:
+ax_pose 48, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose95:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose96:
+ax_pose 10, 0x01ec, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose97:
+ax_pose 11, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose98:
+ax_pose 44, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose99:
+ax_pose 45, 0x01eb, 0x80f4, 0x1c00
+ax_pose 46, 0x41ea, 0x80f4, 0x1c10
+ax_pose_terminator
+sSentretPose100:
+ax_pose 45, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose101:
+ax_pose 6, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose102:
+ax_pose 7, 0x01eb, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose103:
+ax_pose 8, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose104:
+ax_pose 41, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose105:
+ax_pose 42, 0x01eb, 0x80f0, 0x1c00
+ax_pose 43, 0x01eb, 0x80f6, 0x1c10
+ax_pose_terminator
+sSentretPose106:
+ax_pose 43, 0x01eb, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose107:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose108:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose109:
+ax_pose 5, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose110:
+ax_pose 38, 0x01eb, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose111:
+ax_pose 39, 0x81e5, 0x80f4, 0x1c00
+ax_pose 40, 0x01eb, 0x80f6, 0x1c08
+ax_pose_terminator
+sSentretPose112:
+ax_pose 40, 0x01eb, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose113:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose114:
+ax_pose 18, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose115:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose116:
+ax_pose 22, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose117:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose118:
+ax_pose 26, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose119:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose120:
+ax_pose 30, 0x01ec, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose121:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose122:
+ax_pose 34, 0x01ee, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose123:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose124:
+ax_pose 30, 0x01ec, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose125:
+ax_pose 6, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose126:
+ax_pose 26, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose127:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose128:
+ax_pose 22, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose129:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose130:
+ax_pose 15, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose131:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose132:
+ax_pose 19, 0x01e0, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose133:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose134:
+ax_pose 23, 0x01e0, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose135:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose136:
+ax_pose 27, 0x01e1, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose137:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose138:
+ax_pose 31, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose139:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose140:
+ax_pose 27, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose141:
+ax_pose 6, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose142:
+ax_pose 23, 0x01e0, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose143:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose144:
+ax_pose 19, 0x01e0, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose145:
+ax_pose 50, 0x01ec, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose146:
+ax_pose 51, 0x01ec, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose147:
+ax_pose 52, 0x01e2, 0x80f2, 0x1c00
+ax_pose_terminator
+sSentretPose148:
+ax_pose 53, 0x01e3, 0x90e7, 0x1c00
+ax_pose_terminator
+sSentretPose149:
+ax_pose 54, 0x01e3, 0x90e7, 0x1c00
+ax_pose_terminator
+sSentretPose150:
+ax_pose 55, 0x01e9, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose151:
+ax_pose 56, 0x01ea, 0x80f2, 0x1c00
+ax_pose_terminator
+sSentretPose152:
+ax_pose 55, 0x01e9, 0x80f9, 0x1c00
+ax_pose_terminator
+sSentretPose153:
+ax_pose 54, 0x01e3, 0x80f9, 0x1c00
+ax_pose_terminator
+sSentretPose154:
+ax_pose 53, 0x01e3, 0x80fa, 0x1c00
+ax_pose_terminator
+sSentretPose155:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose156:
+ax_pose 15, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose157:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose158:
+ax_pose 17, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose159:
+ax_pose 18, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose160:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose161:
+ax_pose 19, 0x01e0, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose162:
+ax_pose 20, 0x01e8, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose163:
+ax_pose 21, 0x01e5, 0x90ed, 0x1c00
+ax_pose_terminator
+sSentretPose164:
+ax_pose 22, 0x01e2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose165:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose166:
+ax_pose 23, 0x01e0, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose167:
+ax_pose 24, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose168:
+ax_pose 25, 0x41e6, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose169:
+ax_pose 26, 0x01e3, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose170:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose171:
+ax_pose 27, 0x01e1, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose172:
+ax_pose 28, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose173:
+ax_pose 29, 0x01e3, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose174:
+ax_pose 30, 0x01e1, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose175:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose176:
+ax_pose 31, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose177:
+ax_pose 32, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose178:
+ax_pose 33, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose179:
+ax_pose 34, 0x01e2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose180:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose181:
+ax_pose 27, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose182:
+ax_pose 28, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose183:
+ax_pose 29, 0x01e3, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose184:
+ax_pose 30, 0x01e2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose185:
+ax_pose 6, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose186:
+ax_pose 23, 0x01e0, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose187:
+ax_pose 24, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose188:
+ax_pose 25, 0x41e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose189:
+ax_pose 26, 0x01e4, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose190:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose191:
+ax_pose 19, 0x01e0, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose192:
+ax_pose 20, 0x01e8, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose193:
+ax_pose 21, 0x01e5, 0x80f3, 0x1c00
+ax_pose_terminator
+sSentretPose194:
+ax_pose 22, 0x01e3, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose195:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose196:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose197:
+ax_pose 6, 0x01eb, 0x80f8, 0x1c00
+ax_pose_terminator
+sSentretPose198:
+ax_pose 9, 0x01eb, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose199:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose200:
+ax_pose 9, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose201:
+ax_pose 6, 0x01eb, 0x90e7, 0x1c00
+ax_pose_terminator
+sSentretPose202:
+ax_pose 3, 0x01eb, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose203:
+ax_pose 15, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose204:
+ax_pose 19, 0x01e1, 0x90ec, 0x1c00
+ax_pose_terminator
+sSentretPose205:
+ax_pose 23, 0x01e1, 0x90ea, 0x1c00
+ax_pose_terminator
+sSentretPose206:
+ax_pose 27, 0x01e1, 0x90ec, 0x1c00
+ax_pose_terminator
+sSentretPose207:
+ax_pose 31, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose208:
+ax_pose 27, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose209:
+ax_pose 23, 0x01e1, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose210:
+ax_pose 19, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose211:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose212:
+ax_pose 15, 0x01e1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose213:
+ax_pose 18, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose214:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose215:
+ax_pose 19, 0x01e8, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose216:
+ax_pose 22, 0x01e9, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose217:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose218:
+ax_pose 23, 0x01e4, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose219:
+ax_pose 26, 0x01e7, 0x90e7, 0x1c00
+ax_pose_terminator
+sSentretPose220:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose221:
+ax_pose 27, 0x01e9, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose222:
+ax_pose 30, 0x01e9, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose223:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose224:
+ax_pose 31, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose225:
+ax_pose 34, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose226:
+ax_pose 9, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose227:
+ax_pose 27, 0x01e9, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose228:
+ax_pose 30, 0x01e9, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose229:
+ax_pose 6, 0x01eb, 0x80f8, 0x1c00
+ax_pose_terminator
+sSentretPose230:
+ax_pose 23, 0x01e4, 0x80f8, 0x1c00
+ax_pose_terminator
+sSentretPose231:
+ax_pose 26, 0x01e7, 0x80f9, 0x1c00
+ax_pose_terminator
+sSentretPose232:
+ax_pose 3, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose233:
+ax_pose 19, 0x01e8, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose234:
+ax_pose 22, 0x01e9, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose235:
+ax_pose 37, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sSentretPose236:
+ax_pose 40, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sSentretPose237:
+ax_pose 43, 0x01eb, 0x80f6, 0x1c00
+ax_pose_terminator
+sSentretPose238:
+ax_pose 45, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose239:
+ax_pose 48, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose240:
+ax_pose 45, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose241:
+ax_pose 43, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sSentretPose242:
+ax_pose 40, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose243:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose244:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose245:
+ax_pose 6, 0x01eb, 0x80f7, 0x1c00
+ax_pose_terminator
+sSentretPose246:
+ax_pose 9, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose247:
+ax_pose 12, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sSentretPose248:
+ax_pose 9, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sSentretPose249:
+ax_pose 6, 0x01eb, 0x90e8, 0x1c00
+ax_pose_terminator
+sSentretPose250:
+ax_pose 3, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+.align 2
+sSentretAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_2_1:
+ax_anim 6, 0, 25, 0, 0, 0, 0,
+ax_anim 4, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 27, 0, 2, 0, 5,
+ax_anim 1, 2, 27, 0, 6, 0, 11,
+ax_anim 1, 0, 27, 0, 15, 0, 17,
+ax_anim 2, 0, 28, 0, 28, 0, 22,
+ax_anim 2, 1, 28, 1, 28, 1, 22,
+ax_anim 2, 0, 28, 0, 28, 0, 22,
+ax_anim 2, 0, 28, 1, 28, 1, 22,
+ax_anim 2, 0, 28, 0, 28, 0, 22,
+ax_anim 2, 0, 24, 0, 0, 0, 6,
+ax_anim_terminator
+sSentretAnims_2_2:
+ax_anim 6, 0, 30, 0, 0, 0, 0,
+ax_anim 4, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 0, 32, 5, 0, 5, 5,
+ax_anim 1, 2, 32, 11, 9, 11, 11,
+ax_anim 1, 0, 32, 15, 20, 17, 17,
+ax_anim 2, 0, 33, 19, 30, 19, 21,
+ax_anim 2, 1, 33, 20, 29, 20, 20,
+ax_anim 2, 0, 33, 19, 30, 19, 21,
+ax_anim 2, 0, 33, 20, 29, 20, 20,
+ax_anim 2, 0, 33, 19, 30, 19, 21,
+ax_anim 2, 0, 29, 6, 0, 6, 6,
+ax_anim_terminator
+sSentretAnims_2_3:
+ax_anim 6, 0, 35, 0, 0, 0, 0,
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 6, 1, 8, 0,
+ax_anim 1, 2, 37, 13, 3, 13, 0,
+ax_anim 1, 0, 37, 15, 4, 15, 0,
+ax_anim 2, 0, 38, 20, 9, 20, 0,
+ax_anim 2, 1, 38, 20, 10, 20, 1,
+ax_anim 2, 0, 38, 20, 9, 20, 0,
+ax_anim 2, 0, 38, 20, 10, 20, 1,
+ax_anim 2, 0, 38, 20, 9, 20, 0,
+ax_anim 2, 0, 34, 6, -7, 6, 0,
+ax_anim_terminator
+sSentretAnims_2_4:
+ax_anim 6, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 3, -2, 3, -3,
+ax_anim 1, 2, 42, 8, -9, 8, -8,
+ax_anim 1, 0, 42, 15, -11, 15, -15,
+ax_anim 2, 0, 43, 20, -10, 20, -20,
+ax_anim 2, 1, 43, 21, -9, 21, -19,
+ax_anim 2, 0, 43, 20, -10, 20, -20,
+ax_anim 2, 0, 43, 21, -9, 21, -19,
+ax_anim 2, 0, 43, 20, -10, 20, -20,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sSentretAnims_2_5:
+ax_anim 6, 0, 45, 0, 0, 0, 0,
+ax_anim 4, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, -4, 0, -6,
+ax_anim 1, 2, 47, 0, -6, 0, -12,
+ax_anim 1, 0, 47, 0, -9, 0, -17,
+ax_anim 2, 0, 48, 0, -11, 0, -23,
+ax_anim 2, 1, 48, 1, -11, 1, -23,
+ax_anim 2, 0, 48, 0, -11, 0, -23,
+ax_anim 2, 0, 48, 1, -11, 1, -23,
+ax_anim 2, 0, 48, 0, -11, 0, -23,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sSentretAnims_2_6:
+ax_anim 6, 0, 50, 0, 0, 0, 0,
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 52, -3, -2, -3, -3,
+ax_anim 1, 2, 52, -8, -9, -8, -8,
+ax_anim 1, 0, 52, -15, -11, -15, -15,
+ax_anim 2, 0, 53, -20, -10, -20, -20,
+ax_anim 2, 1, 53, -21, -9, -21, -19,
+ax_anim 2, 0, 53, -20, -10, -20, -20,
+ax_anim 2, 0, 53, -21, -9, -21, -19,
+ax_anim 2, 0, 53, -20, -10, -20, -20,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sSentretAnims_2_7:
+ax_anim 6, 0, 55, 0, 0, 0, 0,
+ax_anim 4, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -8, 0, -8, 0,
+ax_anim 1, 2, 57, -13, 3, -13, 0,
+ax_anim 1, 0, 57, -15, 4, -15, 0,
+ax_anim 2, 0, 58, -20, 9, -20, 0,
+ax_anim 2, 1, 58, -20, 10, -20, 1,
+ax_anim 2, 0, 58, -20, 9, -20, 0,
+ax_anim 2, 0, 58, -20, 10, -20, 1,
+ax_anim 2, 0, 58, -20, 9, -20, 0,
+ax_anim 2, 0, 54, -6, -1, -6, 0,
+ax_anim_terminator
+sSentretAnims_2_8:
+ax_anim 6, 0, 60, 0, 0, 0, 0,
+ax_anim 4, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 62, -5, 0, -5, 5,
+ax_anim 1, 2, 62, -11, 9, -11, 11,
+ax_anim 1, 0, 62, -15, 20, -17, 17,
+ax_anim 2, 0, 63, -19, 30, -19, 21,
+ax_anim 2, 1, 63, -20, 29, -20, 20,
+ax_anim 2, 0, 63, -19, 30, -19, 21,
+ax_anim 2, 0, 63, -20, 29, -20, 20,
+ax_anim 2, 0, 63, -19, 30, -19, 21,
+ax_anim 2, 0, 59, -6, 0, -6, 6,
+ax_anim_terminator
+.align 2
+sSentretAnims_3_1:
+ax_anim 2, 0, 66, 0, -2, 0, -2,
+ax_anim 2, 0, 67, 0, -4, 0, -4,
+ax_anim 6, 0, 67, 0, -5, 0, -5,
+ax_anim 1, 2, 67, 0, -2, 0, -2,
+ax_anim 1, 0, 67, 0, 7, 0, 7,
+ax_anim 2, 0, 68, 0, 16, 0, 16,
+ax_anim 2, 1, 69, 1, 16, 1, 16,
+ax_anim 2, 0, 69, 0, 16, 0, 16,
+ax_anim 2, 0, 69, 1, 16, 1, 16,
+ax_anim 2, 0, 69, 0, 16, 0, 16,
+ax_anim 2, 0, 69, 1, 16, 1, 16,
+ax_anim 2, 0, 69, 0, 16, 0, 16,
+ax_anim 2, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sSentretAnims_3_2:
+ax_anim 2, 0, 72, -2, -2, -2, -2,
+ax_anim 2, 0, 73, -4, -4, -4, -4,
+ax_anim 6, 0, 73, -5, -5, -5, -5,
+ax_anim 1, 2, 73, -2, -2, -2, -2,
+ax_anim 1, 0, 73, 7, 9, 7, 9,
+ax_anim 2, 0, 74, 16, 19, 16, 19,
+ax_anim 2, 1, 75, 17, 18, 17, 18,
+ax_anim 2, 0, 75, 16, 19, 16, 19,
+ax_anim 2, 0, 75, 17, 18, 17, 18,
+ax_anim 2, 0, 75, 16, 19, 16, 19,
+ax_anim 2, 0, 75, 17, 18, 17, 18,
+ax_anim 2, 0, 75, 16, 19, 16, 19,
+ax_anim 2, 0, 70, 10, 12, 10, 12,
+ax_anim 2, 0, 70, 4, 5, 4, 5,
+ax_anim_terminator
+sSentretAnims_3_3:
+ax_anim 2, 0, 78, -2, 0, -2, 0,
+ax_anim 2, 0, 79, -4, 0, -4, 0,
+ax_anim 6, 0, 79, -5, 0, -5, 0,
+ax_anim 1, 2, 79, -2, 0, -2, 0,
+ax_anim 1, 0, 79, 7, 0, 7, 0,
+ax_anim 2, 0, 80, 15, 0, 15, 0,
+ax_anim 2, 1, 81, 15, 1, 15, 1,
+ax_anim 2, 0, 81, 15, 0, 15, 0,
+ax_anim 2, 0, 81, 15, 1, 15, 1,
+ax_anim 2, 0, 81, 15, 0, 15, 0,
+ax_anim 2, 0, 81, 15, 1, 15, 1,
+ax_anim 2, 0, 81, 15, 0, 15, 0,
+ax_anim 2, 0, 76, 10, 0, 10, 0,
+ax_anim 2, 0, 76, 4, 0, 4, 0,
+ax_anim_terminator
+sSentretAnims_3_4:
+ax_anim 2, 0, 84, -2, 2, -2, 2,
+ax_anim 2, 0, 85, -4, 4, -4, 4,
+ax_anim 6, 0, 85, -5, 5, -5, 5,
+ax_anim 1, 2, 85, -2, 2, -2, 2,
+ax_anim 1, 0, 85, 8, -9, 8, -9,
+ax_anim 2, 0, 86, 18, -19, 18, -19,
+ax_anim 2, 1, 87, 19, -18, 19, -18,
+ax_anim 2, 0, 87, 18, -19, 18, -19,
+ax_anim 2, 0, 87, 19, -18, 19, -18,
+ax_anim 2, 0, 87, 18, -19, 18, -19,
+ax_anim 2, 0, 87, 19, -18, 19, -18,
+ax_anim 2, 0, 87, 18, -19, 18, -19,
+ax_anim 2, 0, 82, 11, -12, 11, -12,
+ax_anim 2, 0, 82, 4, -5, 4, -5,
+ax_anim_terminator
+sSentretAnims_3_5:
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 6, 0, 91, 0, 5, 0, 5,
+ax_anim 1, 2, 91, 0, 2, 0, 2,
+ax_anim 1, 0, 91, 0, -7, 0, -7,
+ax_anim 2, 0, 92, 0, -16, 0, -16,
+ax_anim 2, 1, 93, 1, -16, 1, -16,
+ax_anim 2, 0, 93, 0, -16, 0, -16,
+ax_anim 2, 0, 93, 1, -16, 1, -16,
+ax_anim 2, 0, 93, 0, -16, 0, -16,
+ax_anim 2, 0, 93, 1, -16, 1, -16,
+ax_anim 2, 0, 93, 0, -16, 0, -16,
+ax_anim 2, 0, 88, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 0, -4, 0, -4,
+ax_anim_terminator
+sSentretAnims_3_6:
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 2, 0, 97, 4, 4, 4, 4,
+ax_anim 6, 0, 97, 5, 5, 5, 5,
+ax_anim 1, 2, 97, 2, 2, 2, 2,
+ax_anim 1, 0, 97, -8, -9, -8, -9,
+ax_anim 2, 0, 98, -18, -19, -18, -19,
+ax_anim 2, 1, 99, -19, -18, -19, -18,
+ax_anim 2, 0, 99, -18, -19, -18, -19,
+ax_anim 2, 0, 99, -19, -18, -19, -18,
+ax_anim 2, 0, 99, -18, -19, -18, -19,
+ax_anim 2, 0, 99, -19, -18, -19, -18,
+ax_anim 2, 0, 99, -18, -19, -18, -19,
+ax_anim 2, 0, 94, -11, -12, -11, -12,
+ax_anim 2, 0, 94, -4, -5, -4, -5,
+ax_anim_terminator
+sSentretAnims_3_7:
+ax_anim 2, 0, 102, 2, 0, 2, 0,
+ax_anim 2, 0, 103, 4, 0, 4, 0,
+ax_anim 6, 0, 103, 5, 0, 5, 0,
+ax_anim 1, 2, 103, 2, 0, 2, 0,
+ax_anim 1, 0, 103, -7, 0, -7, 0,
+ax_anim 2, 0, 104, -15, 0, -15, 0,
+ax_anim 2, 1, 105, -15, 1, -15, 1,
+ax_anim 2, 0, 105, -15, 0, -15, 0,
+ax_anim 2, 0, 105, -15, 1, -15, 1,
+ax_anim 2, 0, 105, -15, 0, -15, 0,
+ax_anim 2, 0, 105, -15, 1, -15, 1,
+ax_anim 2, 0, 105, -15, 0, -15, 0,
+ax_anim 2, 0, 100, -10, 0, -10, 0,
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim_terminator
+sSentretAnims_3_8:
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim 2, 0, 109, 4, -4, 4, -4,
+ax_anim 6, 0, 109, 5, -5, 5, -5,
+ax_anim 1, 2, 109, 2, -2, 2, -2,
+ax_anim 1, 0, 109, -7, 9, -7, 9,
+ax_anim 2, 0, 110, -16, 19, -16, 19,
+ax_anim 2, 1, 111, -17, 18, -17, 18,
+ax_anim 2, 0, 111, -16, 19, -16, 19,
+ax_anim 2, 0, 111, -17, 18, -17, 18,
+ax_anim 2, 0, 111, -16, 19, -16, 19,
+ax_anim 2, 0, 111, -17, 18, -17, 18,
+ax_anim 2, 0, 111, -16, 19, -16, 19,
+ax_anim 2, 0, 106, -10, 12, -10, 12,
+ax_anim 2, 0, 106, -4, 5, -4, 5,
+ax_anim_terminator
+.align 2
+sSentretAnims_4_1:
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim 6, 2, 112, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 1, 113, 0, 3, 0, 2,
+ax_anim 2, 0, 113, 1, 3, 1, 2,
+ax_anim 2, 0, 113, 0, 3, 0, 2,
+ax_anim 2, 0, 113, 1, 3, 1, 2,
+ax_anim 2, 0, 113, 0, 3, 0, 2,
+ax_anim 2, 0, 113, 1, 3, 1, 2,
+ax_anim 2, 0, 113, 0, 3, 0, 2,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim_terminator
+sSentretAnims_4_2:
+ax_anim 2, 0, 114, -2, -2, -2, -2,
+ax_anim 6, 2, 114, -3, -3, -3, -3,
+ax_anim 2, 0, 114, -1, -1, -1, -1,
+ax_anim 2, 1, 115, 2, 2, 1, 1,
+ax_anim 2, 0, 115, 3, 1, 2, 0,
+ax_anim 2, 0, 115, 2, 2, 1, 1,
+ax_anim 2, 0, 115, 3, 1, 2, 0,
+ax_anim 2, 0, 115, 2, 2, 1, 1,
+ax_anim 2, 0, 115, 3, 1, 2, 0,
+ax_anim 2, 0, 115, 2, 2, 1, 1,
+ax_anim 2, 0, 114, 1, 1, 1, 1,
+ax_anim_terminator
+sSentretAnims_4_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 6, 2, 116, -3, 0, -3, 0,
+ax_anim 2, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 1, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 117, 2, 1, 2, 1,
+ax_anim 2, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 117, 2, 1, 2, 1,
+ax_anim 2, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 117, 2, 1, 2, 1,
+ax_anim 2, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim_terminator
+sSentretAnims_4_4:
+ax_anim 2, 0, 118, -2, 2, -2, 2,
+ax_anim 6, 2, 118, -3, 3, -3, 3,
+ax_anim 2, 0, 118, -1, 1, -1, 1,
+ax_anim 2, 1, 119, 2, -2, 1, -1,
+ax_anim 2, 0, 119, 3, -1, 2, 0,
+ax_anim 2, 0, 119, 2, -2, 1, -1,
+ax_anim 2, 0, 119, 3, -1, 2, 0,
+ax_anim 2, 0, 119, 2, -2, 1, -1,
+ax_anim 2, 0, 119, 3, -1, 2, 0,
+ax_anim 2, 0, 119, 2, -2, 1, -1,
+ax_anim 2, 0, 118, 1, -1, 1, -1,
+ax_anim_terminator
+sSentretAnims_4_5:
+ax_anim 2, 0, 120, 0, 2, 0, 2,
+ax_anim 6, 2, 120, 0, 3, 0, 3,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 1, 121, 0, -3, 0, -2,
+ax_anim 2, 0, 121, 1, -3, 1, -2,
+ax_anim 2, 0, 121, 0, -3, 0, -2,
+ax_anim 2, 0, 121, 1, -3, 1, -2,
+ax_anim 2, 0, 121, 0, -3, 0, -2,
+ax_anim 2, 0, 121, 1, -3, 1, -2,
+ax_anim 2, 0, 121, 0, -3, 0, -2,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim_terminator
+sSentretAnims_4_6:
+ax_anim 2, 0, 122, 2, 2, 2, 2,
+ax_anim 6, 2, 122, 3, 3, 3, 3,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim 2, 1, 123, -2, -2, -1, -1,
+ax_anim 2, 0, 123, -3, -1, -2, 0,
+ax_anim 2, 0, 123, -2, -2, -1, -1,
+ax_anim 2, 0, 123, -3, -1, -2, 0,
+ax_anim 2, 0, 123, -2, -2, -1, -1,
+ax_anim 2, 0, 123, -3, -1, -2, 0,
+ax_anim 2, 0, 123, -2, -2, -1, -1,
+ax_anim 2, 0, 122, -1, -1, -1, -1,
+ax_anim_terminator
+sSentretAnims_4_7:
+ax_anim 2, 0, 124, 2, 0, 2, 0,
+ax_anim 6, 2, 124, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 1, 0, 1, 0,
+ax_anim 2, 1, 125, -2, 0, -2, 0,
+ax_anim 2, 0, 125, -2, 1, -2, 1,
+ax_anim 2, 0, 125, -2, 0, -2, 0,
+ax_anim 2, 0, 125, -2, 1, -2, 1,
+ax_anim 2, 0, 125, -2, 0, -2, 0,
+ax_anim 2, 0, 125, -2, 1, -2, 1,
+ax_anim 2, 0, 125, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim_terminator
+sSentretAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 126, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSentretAnims_5_1:
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, -9, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -12, 0, 0,
+ax_anim 2, 0, 128, 0, -8, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_5_2:
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 2, 0, 130, 0, -9, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 1, 1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 131, -1, 1, 1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 1, 1, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -12, 0, 0,
+ax_anim 2, 0, 130, 0, -8, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_5_3:
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -9, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -12, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_5_4:
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -9, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -12, 0, 0,
+ax_anim 2, 0, 134, 0, -8, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_5_5:
+ax_anim 1, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -9, 0, 0,
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -12, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_5_6:
+ax_anim 1, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -9, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -12, 0, 0,
+ax_anim 2, 0, 138, 0, -8, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_5_7:
+ax_anim 1, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -9, 0, 0,
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -12, 0, 0,
+ax_anim 2, 0, 140, 0, -8, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_5_8:
+ax_anim 1, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 142, 0, -9, 0, 0,
+ax_anim 6, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 1, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 1, 1, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 1, -1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -12, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sSentretAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sSentretAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sSentretAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sSentretAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sSentretAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sSentretAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sSentretAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSentretAnims_8_1:
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 3, 0, 155, 0, -5, 0, 0,
+ax_anim 3, 0, 155, 0, -6, 0, 0,
+ax_anim 3, 0, 155, 0, -5, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim_terminator
+sSentretAnims_8_2:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -5, 0, 0,
+ax_anim 3, 0, 160, 0, -6, 0, 0,
+ax_anim 3, 0, 160, 0, -5, 0, 0,
+ax_anim 2, 0, 160, 0, -3, 0, 0,
+ax_anim_terminator
+sSentretAnims_8_3:
+ax_anim 30, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, -3, 0, 0,
+ax_anim 3, 0, 165, 0, -5, 0, 0,
+ax_anim 3, 0, 165, 0, -6, 0, 0,
+ax_anim 3, 0, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -3, 0, 0,
+ax_anim_terminator
+sSentretAnims_8_4:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -3, 0, 0,
+ax_anim 3, 0, 170, 0, -5, 0, 0,
+ax_anim 3, 0, 170, 0, -6, 0, 0,
+ax_anim 3, 0, 170, 0, -5, 0, 0,
+ax_anim 2, 0, 170, 0, -3, 0, 0,
+ax_anim_terminator
+sSentretAnims_8_5:
+ax_anim 30, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, -3, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 3, 0, 175, 0, -6, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 0, -3, 0, 0,
+ax_anim_terminator
+sSentretAnims_8_6:
+ax_anim 30, 0, 180, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -3, 0, 0,
+ax_anim 3, 0, 180, 0, -5, 0, 0,
+ax_anim 3, 0, 180, 0, -6, 0, 0,
+ax_anim 3, 0, 180, 0, -5, 0, 0,
+ax_anim 2, 0, 180, 0, -3, 0, 0,
+ax_anim_terminator
+sSentretAnims_8_7:
+ax_anim 30, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, -3, 0, 0,
+ax_anim 3, 0, 185, 0, -5, 0, 0,
+ax_anim 3, 0, 185, 0, -6, 0, 0,
+ax_anim 3, 0, 185, 0, -5, 0, 0,
+ax_anim 2, 0, 185, 0, -3, 0, 0,
+ax_anim_terminator
+sSentretAnims_8_8:
+ax_anim 30, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, -3, 0, 0,
+ax_anim 3, 0, 190, 0, -5, 0, 0,
+ax_anim 3, 0, 190, 0, -6, 0, 0,
+ax_anim 3, 0, 190, 0, -5, 0, 0,
+ax_anim 2, 0, 190, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 8, 9, 8, 9,
+ax_anim 2, 0, 197, 7, 17, 7, 17,
+ax_anim 3, 0, 198, 0, 20, 0, 20,
+ax_anim 2, 3, 199, -7, 17, -7, 17,
+ax_anim 2, 0, 200, -8, 9, -8, 9,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 19, 10, 19, 10,
+ax_anim 3, 0, 197, 17, 19, 17, 19,
+ax_anim 2, 3, 198, 11, 21, 11, 21,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -5, 3, -5,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -5, 16, -5,
+ax_anim 3, 0, 196, 19, -2, 19, -2,
+ax_anim 2, 3, 197, 16, 4, 16, 4,
+ax_anim 2, 0, 198, 12, 7, 12, 7,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 12, -22, 12, -22,
+ax_anim 3, 0, 195, 19, -21, 19, -21,
+ax_anim 2, 3, 196, 21, -14, 21, -14,
+ax_anim 2, 0, 197, 16, -5, 16, -5,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -7, -4, -7, -4,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -19, -7, -19,
+ax_anim 3, 0, 194, 0, -22, 0, -22,
+ax_anim 2, 3, 195, 7, -19, 7, -19,
+ax_anim 2, 0, 196, 9, -10, 9, -10,
+ax_anim 1, 0, 197, 7, -4, 7, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -6,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -12, -22, -12, -22,
+ax_anim 3, 0, 201, -19, -21, -18, -22,
+ax_anim 2, 3, 200, -21, -14, -20, -15,
+ax_anim 2, 0, 199, -16, -5, -17, -4,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -5, -3, -5,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -5, -16, -5,
+ax_anim 3, 0, 200, -19, -2, -18, -2,
+ax_anim 2, 3, 199, -16, 4, -16, 4,
+ax_anim 2, 0, 198, -12, 7, -12, 5,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -19, 10, -19, 10,
+ax_anim 3, 0, 199, -17, 19, -17, 19,
+ax_anim 2, 3, 198, -11, 21, -11, 19,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -2, 0, 0,
+ax_anim 2, 0, 211, 0, -8, 0, 0,
+ax_anim 3, 0, 211, 0, -12, 0, 0,
+ax_anim 4, 0, 211, 0, -13, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -22, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSentretAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sSentretGfx1:
+.incbin "baserom.gba", 0xC15814, 0x200
+sSentretSprites1:
+ax_sprite sSentretGfx1, 0x200
+ax_sprite_terminator
+sSentretGfx2:
+.incbin "baserom.gba", 0xC15A24, 0x200
+sSentretSprites2:
+ax_sprite sSentretGfx2, 0x200
+ax_sprite_terminator
+sSentretGfx3:
+.incbin "baserom.gba", 0xC15C34, 0x200
+sSentretSprites3:
+ax_sprite sSentretGfx3, 0x200
+ax_sprite_terminator
+sSentretGfx4:
+.incbin "baserom.gba", 0xC15E44, 0x200
+sSentretSprites4:
+ax_sprite sSentretGfx4, 0x200
+ax_sprite_terminator
+sSentretGfx5:
+.incbin "baserom.gba", 0xC16054, 0x200
+sSentretSprites5:
+ax_sprite sSentretGfx5, 0x200
+ax_sprite_terminator
+sSentretGfx6:
+.incbin "baserom.gba", 0xC16264, 0x200
+sSentretSprites6:
+ax_sprite sSentretGfx6, 0x200
+ax_sprite_terminator
+sSentretGfx7:
+.incbin "baserom.gba", 0xC16474, 0x200
+sSentretSprites7:
+ax_sprite sSentretGfx7, 0x200
+ax_sprite_terminator
+sSentretGfx8:
+.incbin "baserom.gba", 0xC16684, 0x200
+sSentretSprites8:
+ax_sprite sSentretGfx8, 0x200
+ax_sprite_terminator
+sSentretGfx9:
+.incbin "baserom.gba", 0xC16894, 0x200
+sSentretSprites9:
+ax_sprite sSentretGfx9, 0x200
+ax_sprite_terminator
+sSentretGfx10:
+.incbin "baserom.gba", 0xC16AA4, 0x200
+sSentretSprites10:
+ax_sprite sSentretGfx10, 0x200
+ax_sprite_terminator
+sSentretGfx11:
+.incbin "baserom.gba", 0xC16CB4, 0x200
+sSentretSprites11:
+ax_sprite sSentretGfx11, 0x200
+ax_sprite_terminator
+sSentretGfx12:
+.incbin "baserom.gba", 0xC16EC4, 0x200
+sSentretSprites12:
+ax_sprite sSentretGfx12, 0x200
+ax_sprite_terminator
+sSentretGfx13:
+.incbin "baserom.gba", 0xC170D4, 0x200
+sSentretSprites13:
+ax_sprite sSentretGfx13, 0x200
+ax_sprite_terminator
+sSentretGfx14:
+.incbin "baserom.gba", 0xC172E4, 0x200
+sSentretSprites14:
+ax_sprite sSentretGfx14, 0x200
+ax_sprite_terminator
+sSentretGfx15:
+.incbin "baserom.gba", 0xC174F4, 0x200
+sSentretSprites15:
+ax_sprite sSentretGfx15, 0x200
+ax_sprite_terminator
+sSentretGfx16:
+.incbin "baserom.gba", 0xC17704, 0x60
+sSentretGfx16_1:
+.incbin "baserom.gba", 0xC17764, 0x60
+sSentretGfx16_2:
+.incbin "baserom.gba", 0xC177C4, 0x60
+sSentretGfx16_3:
+.incbin "baserom.gba", 0xC17824, 0x40
+sSentretSprites16:
+ax_sprite sSentretGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx16_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSentretGfx17:
+.incbin "baserom.gba", 0xC178AC, 0x60
+sSentretGfx17_1:
+.incbin "baserom.gba", 0xC1790C, 0x60
+sSentretGfx17_2:
+.incbin "baserom.gba", 0xC1796C, 0x60
+sSentretSprites17:
+ax_sprite sSentretGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx18:
+.incbin "baserom.gba", 0xC17A04, 0x40
+sSentretGfx18_1:
+.incbin "baserom.gba", 0xC17A44, 0x60
+sSentretGfx18_2:
+.incbin "baserom.gba", 0xC17AA4, 0x60
+sSentretSprites18:
+ax_sprite sSentretGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx19:
+.incbin "baserom.gba", 0xC17B3C, 0x20
+sSentretGfx19_1:
+.incbin "baserom.gba", 0xC17B5C, 0x60
+sSentretGfx19_2:
+.incbin "baserom.gba", 0xC17BBC, 0x60
+sSentretGfx19_3:
+.incbin "baserom.gba", 0xC17C1C, 0x40
+sSentretSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx19_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSentretGfx20:
+.incbin "baserom.gba", 0xC17CAC, 0x60
+sSentretGfx20_1:
+.incbin "baserom.gba", 0xC17D0C, 0x60
+sSentretGfx20_2:
+.incbin "baserom.gba", 0xC17D6C, 0x60
+sSentretGfx20_3:
+.incbin "baserom.gba", 0xC17DCC, 0x40
+sSentretSprites20:
+ax_sprite sSentretGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSentretGfx21:
+.incbin "baserom.gba", 0xC17E54, 0x60
+sSentretGfx21_1:
+.incbin "baserom.gba", 0xC17EB4, 0x60
+sSentretGfx21_2:
+.incbin "baserom.gba", 0xC17F14, 0x60
+sSentretSprites21:
+ax_sprite sSentretGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx22:
+.incbin "baserom.gba", 0xC17FAC, 0x140
+sSentretSprites22:
+ax_sprite sSentretGfx22, 0x140
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSentretGfx23:
+.incbin "baserom.gba", 0xC18104, 0x40
+sSentretGfx23_1:
+.incbin "baserom.gba", 0xC18144, 0xE0
+sSentretSprites23:
+ax_sprite sSentretGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx23_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx24:
+.incbin "baserom.gba", 0xC1824C, 0x40
+sSentretGfx24_1:
+.incbin "baserom.gba", 0xC1828C, 0x40
+sSentretGfx24_2:
+.incbin "baserom.gba", 0xC182CC, 0x60
+sSentretGfx24_3:
+.incbin "baserom.gba", 0xC1832C, 0x60
+sSentretSprites24:
+ax_sprite sSentretGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSentretGfx25:
+.incbin "baserom.gba", 0xC183D4, 0x60
+sSentretGfx25_1:
+.incbin "baserom.gba", 0xC18434, 0x60
+sSentretGfx25_2:
+.incbin "baserom.gba", 0xC18494, 0x60
+sSentretSprites25:
+ax_sprite sSentretGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx26:
+.incbin "baserom.gba", 0xC1852C, 0x100
+sSentretSprites26:
+ax_sprite sSentretGfx26, 0x100
+ax_sprite_terminator
+sSentretGfx27:
+.incbin "baserom.gba", 0xC1863C, 0x40
+sSentretGfx27_1:
+.incbin "baserom.gba", 0xC1867C, 0x100
+sSentretSprites27:
+ax_sprite sSentretGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx27_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSentretGfx28:
+.incbin "baserom.gba", 0xC187A4, 0x60
+sSentretGfx28_1:
+.incbin "baserom.gba", 0xC18804, 0x60
+sSentretGfx28_2:
+.incbin "baserom.gba", 0xC18864, 0x60
+sSentretGfx28_3:
+.incbin "baserom.gba", 0xC188C4, 0x40
+sSentretSprites28:
+ax_sprite sSentretGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSentretGfx29:
+.incbin "baserom.gba", 0xC1894C, 0x60
+sSentretGfx29_1:
+.incbin "baserom.gba", 0xC189AC, 0x60
+sSentretGfx29_2:
+.incbin "baserom.gba", 0xC18A0C, 0x60
+sSentretSprites29:
+ax_sprite sSentretGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx30:
+.incbin "baserom.gba", 0xC18AA4, 0x60
+sSentretGfx30_1:
+.incbin "baserom.gba", 0xC18B04, 0x100
+sSentretSprites30:
+ax_sprite sSentretGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSentretGfx31:
+.incbin "baserom.gba", 0xC18C2C, 0x40
+sSentretGfx31_1:
+.incbin "baserom.gba", 0xC18C6C, 0x60
+sSentretGfx31_2:
+.incbin "baserom.gba", 0xC18CCC, 0x60
+sSentretGfx31_3:
+.incbin "baserom.gba", 0xC18D2C, 0x40
+sSentretSprites31:
+ax_sprite sSentretGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx31_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSentretGfx32:
+.incbin "baserom.gba", 0xC18DB4, 0x60
+sSentretGfx32_1:
+.incbin "baserom.gba", 0xC18E14, 0x60
+sSentretGfx32_2:
+.incbin "baserom.gba", 0xC18E74, 0x60
+sSentretGfx32_3:
+.incbin "baserom.gba", 0xC18ED4, 0x60
+sSentretSprites32:
+ax_sprite sSentretGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx32_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSentretGfx33:
+.incbin "baserom.gba", 0xC18F7C, 0x60
+sSentretGfx33_1:
+.incbin "baserom.gba", 0xC18FDC, 0x60
+sSentretGfx33_2:
+.incbin "baserom.gba", 0xC1903C, 0x40
+sSentretSprites33:
+ax_sprite sSentretGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx33_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSentretGfx34:
+.incbin "baserom.gba", 0xC190B4, 0x60
+sSentretGfx34_1:
+.incbin "baserom.gba", 0xC19114, 0x60
+sSentretGfx34_2:
+.incbin "baserom.gba", 0xC19174, 0x60
+sSentretGfx34_3:
+.incbin "baserom.gba", 0xC191D4, 0x20
+sSentretSprites34:
+ax_sprite sSentretGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx34_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSentretGfx35:
+.incbin "baserom.gba", 0xC1923C, 0x60
+sSentretGfx35_1:
+.incbin "baserom.gba", 0xC1929C, 0x60
+sSentretGfx35_2:
+.incbin "baserom.gba", 0xC192FC, 0x60
+sSentretGfx35_3:
+.incbin "baserom.gba", 0xC1935C, 0x40
+sSentretSprites35:
+ax_sprite sSentretGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx35_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSentretGfx36:
+.incbin "baserom.gba", 0xC193E4, 0x60
+sSentretGfx36_1:
+.incbin "baserom.gba", 0xC19444, 0x60
+sSentretGfx36_2:
+.incbin "baserom.gba", 0xC194A4, 0x60
+sSentretSprites36:
+ax_sprite sSentretGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx37:
+.incbin "baserom.gba", 0xC1953C, 0x20
+sSentretGfx37_1:
+.incbin "baserom.gba", 0xC1955C, 0x20
+sSentretGfx37_2:
+.incbin "baserom.gba", 0xC1957C, 0x80
+sSentretSprites37:
+ax_sprite sSentretGfx37, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx37_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx37_2, 0x80
+ax_sprite_terminator
+sSentretGfx38:
+.incbin "baserom.gba", 0xC1962C, 0x60
+sSentretGfx38_1:
+.incbin "baserom.gba", 0xC1968C, 0x60
+sSentretGfx38_2:
+.incbin "baserom.gba", 0xC196EC, 0x60
+sSentretSprites38:
+ax_sprite sSentretGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx39:
+.incbin "baserom.gba", 0xC19784, 0x60
+sSentretGfx39_1:
+.incbin "baserom.gba", 0xC197E4, 0xE0
+sSentretSprites39:
+ax_sprite sSentretGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx39_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx40:
+.incbin "baserom.gba", 0xC198EC, 0x60
+sSentretGfx40_1:
+.incbin "baserom.gba", 0xC1994C, 0x80
+sSentretSprites40:
+ax_sprite sSentretGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx40_1, 0x80
+ax_sprite_terminator
+sSentretGfx41:
+.incbin "baserom.gba", 0xC199EC, 0x40
+sSentretGfx41_1:
+.incbin "baserom.gba", 0xC19A2C, 0x60
+sSentretGfx41_2:
+.incbin "baserom.gba", 0xC19A8C, 0x60
+sSentretSprites41:
+ax_sprite sSentretGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx41_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx42:
+.incbin "baserom.gba", 0xC19B24, 0x40
+sSentretGfx42_1:
+.incbin "baserom.gba", 0xC19B64, 0x60
+sSentretGfx42_2:
+.incbin "baserom.gba", 0xC19BC4, 0x60
+sSentretSprites42:
+ax_sprite sSentretGfx42, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx42_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx43:
+.incbin "baserom.gba", 0xC19C5C, 0x60
+sSentretGfx43_1:
+.incbin "baserom.gba", 0xC19CBC, 0x40
+sSentretGfx43_2:
+.incbin "baserom.gba", 0xC19CFC, 0x40
+sSentretSprites43:
+ax_sprite sSentretGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx43_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx43_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSentretGfx44:
+.incbin "baserom.gba", 0xC19D74, 0x40
+sSentretGfx44_1:
+.incbin "baserom.gba", 0xC19DB4, 0xE0
+sSentretSprites44:
+ax_sprite sSentretGfx44, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx44_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx45:
+.incbin "baserom.gba", 0xC19EBC, 0x60
+sSentretGfx45_1:
+.incbin "baserom.gba", 0xC19F1C, 0x60
+sSentretGfx45_2:
+.incbin "baserom.gba", 0xC19F7C, 0x60
+sSentretGfx45_3:
+.incbin "baserom.gba", 0xC19FDC, 0x20
+sSentretSprites45:
+ax_sprite sSentretGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx45_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSentretGfx45_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSentretGfx46:
+.incbin "baserom.gba", 0xC1A044, 0x40
+sSentretGfx46_1:
+.incbin "baserom.gba", 0xC1A084, 0x100
+sSentretSprites46:
+ax_sprite sSentretGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSentretGfx46_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSentretGfx47:
+.incbin "baserom.gba", 0xC1A1AC, 0x60
+sSentretGfx47_1:
+.incbin "baserom.gba", 0xC1A20C, 0x80
+sSentretSprites47:
+ax_sprite sSentretGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx47_1, 0x80
+ax_sprite_terminator
+sSentretGfx48:
+.incbin "baserom.gba", 0xC1A2AC, 0x60
+sSentretGfx48_1:
+.incbin "baserom.gba", 0xC1A30C, 0x60
+sSentretGfx48_2:
+.incbin "baserom.gba", 0xC1A36C, 0x60
+sSentretSprites48:
+ax_sprite sSentretGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx48_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx49:
+.incbin "baserom.gba", 0xC1A404, 0x60
+sSentretGfx49_1:
+.incbin "baserom.gba", 0xC1A464, 0x60
+sSentretGfx49_2:
+.incbin "baserom.gba", 0xC1A4C4, 0x60
+sSentretSprites49:
+ax_sprite sSentretGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx49_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSentretGfx50:
+.incbin "baserom.gba", 0xC1A55C, 0x60
+sSentretGfx50_1:
+.incbin "baserom.gba", 0xC1A5BC, 0x60
+sSentretGfx50_2:
+.incbin "baserom.gba", 0xC1A61C, 0x20
+sSentretGfx50_3:
+.incbin "baserom.gba", 0xC1A63C, 0x20
+sSentretSprites50:
+ax_sprite sSentretGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSentretGfx50_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSentretGfx50_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSentretGfx50_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSentretGfx51:
+.incbin "baserom.gba", 0xC1A6A4, 0x200
+sSentretSprites51:
+ax_sprite sSentretGfx51, 0x200
+ax_sprite_terminator
+sSentretGfx52:
+.incbin "baserom.gba", 0xC1A8B4, 0x200
+sSentretSprites52:
+ax_sprite sSentretGfx52, 0x200
+ax_sprite_terminator
+sSentretGfx53:
+.incbin "baserom.gba", 0xC1AAC4, 0x200
+sSentretSprites53:
+ax_sprite sSentretGfx53, 0x200
+ax_sprite_terminator
+sSentretGfx54:
+.incbin "baserom.gba", 0xC1ACD4, 0x200
+sSentretSprites54:
+ax_sprite sSentretGfx54, 0x200
+ax_sprite_terminator
+sSentretGfx55:
+.incbin "baserom.gba", 0xC1AEE4, 0x200
+sSentretSprites55:
+ax_sprite sSentretGfx55, 0x200
+ax_sprite_terminator
+sSentretGfx56:
+.incbin "baserom.gba", 0xC1B0F4, 0x200
+sSentretSprites56:
+ax_sprite sSentretGfx56, 0x200
+ax_sprite_terminator
+sSentretGfx57:
+.incbin "baserom.gba", 0xC1B304, 0x200
+sSentretSprites57:
+ax_sprite sSentretGfx57, 0x200
+ax_sprite_terminator
+sAxPosesSentret:
+.4byte sSentretPose1
+.4byte sSentretPose2
+.4byte sSentretPose3
+.4byte sSentretPose4
+.4byte sSentretPose5
+.4byte sSentretPose6
+.4byte sSentretPose7
+.4byte sSentretPose8
+.4byte sSentretPose9
+.4byte sSentretPose10
+.4byte sSentretPose11
+.4byte sSentretPose12
+.4byte sSentretPose13
+.4byte sSentretPose14
+.4byte sSentretPose15
+.4byte sSentretPose16
+.4byte sSentretPose17
+.4byte sSentretPose18
+.4byte sSentretPose19
+.4byte sSentretPose20
+.4byte sSentretPose21
+.4byte sSentretPose22
+.4byte sSentretPose23
+.4byte sSentretPose24
+.4byte sSentretPose25
+.4byte sSentretPose26
+.4byte sSentretPose27
+.4byte sSentretPose28
+.4byte sSentretPose29
+.4byte sSentretPose30
+.4byte sSentretPose31
+.4byte sSentretPose32
+.4byte sSentretPose33
+.4byte sSentretPose34
+.4byte sSentretPose35
+.4byte sSentretPose36
+.4byte sSentretPose37
+.4byte sSentretPose38
+.4byte sSentretPose39
+.4byte sSentretPose40
+.4byte sSentretPose41
+.4byte sSentretPose42
+.4byte sSentretPose43
+.4byte sSentretPose44
+.4byte sSentretPose45
+.4byte sSentretPose46
+.4byte sSentretPose47
+.4byte sSentretPose48
+.4byte sSentretPose49
+.4byte sSentretPose50
+.4byte sSentretPose51
+.4byte sSentretPose52
+.4byte sSentretPose53
+.4byte sSentretPose54
+.4byte sSentretPose55
+.4byte sSentretPose56
+.4byte sSentretPose57
+.4byte sSentretPose58
+.4byte sSentretPose59
+.4byte sSentretPose60
+.4byte sSentretPose61
+.4byte sSentretPose62
+.4byte sSentretPose63
+.4byte sSentretPose64
+.4byte sSentretPose65
+.4byte sSentretPose66
+.4byte sSentretPose67
+.4byte sSentretPose68
+.4byte sSentretPose69
+.4byte sSentretPose70
+.4byte sSentretPose71
+.4byte sSentretPose72
+.4byte sSentretPose73
+.4byte sSentretPose74
+.4byte sSentretPose75
+.4byte sSentretPose76
+.4byte sSentretPose77
+.4byte sSentretPose78
+.4byte sSentretPose79
+.4byte sSentretPose80
+.4byte sSentretPose81
+.4byte sSentretPose82
+.4byte sSentretPose83
+.4byte sSentretPose84
+.4byte sSentretPose85
+.4byte sSentretPose86
+.4byte sSentretPose87
+.4byte sSentretPose88
+.4byte sSentretPose89
+.4byte sSentretPose90
+.4byte sSentretPose91
+.4byte sSentretPose92
+.4byte sSentretPose93
+.4byte sSentretPose94
+.4byte sSentretPose95
+.4byte sSentretPose96
+.4byte sSentretPose97
+.4byte sSentretPose98
+.4byte sSentretPose99
+.4byte sSentretPose100
+.4byte sSentretPose101
+.4byte sSentretPose102
+.4byte sSentretPose103
+.4byte sSentretPose104
+.4byte sSentretPose105
+.4byte sSentretPose106
+.4byte sSentretPose107
+.4byte sSentretPose108
+.4byte sSentretPose109
+.4byte sSentretPose110
+.4byte sSentretPose111
+.4byte sSentretPose112
+.4byte sSentretPose113
+.4byte sSentretPose114
+.4byte sSentretPose115
+.4byte sSentretPose116
+.4byte sSentretPose117
+.4byte sSentretPose118
+.4byte sSentretPose119
+.4byte sSentretPose120
+.4byte sSentretPose121
+.4byte sSentretPose122
+.4byte sSentretPose123
+.4byte sSentretPose124
+.4byte sSentretPose125
+.4byte sSentretPose126
+.4byte sSentretPose127
+.4byte sSentretPose128
+.4byte sSentretPose129
+.4byte sSentretPose130
+.4byte sSentretPose131
+.4byte sSentretPose132
+.4byte sSentretPose133
+.4byte sSentretPose134
+.4byte sSentretPose135
+.4byte sSentretPose136
+.4byte sSentretPose137
+.4byte sSentretPose138
+.4byte sSentretPose139
+.4byte sSentretPose140
+.4byte sSentretPose141
+.4byte sSentretPose142
+.4byte sSentretPose143
+.4byte sSentretPose144
+.4byte sSentretPose145
+.4byte sSentretPose146
+.4byte sSentretPose147
+.4byte sSentretPose148
+.4byte sSentretPose149
+.4byte sSentretPose150
+.4byte sSentretPose151
+.4byte sSentretPose152
+.4byte sSentretPose153
+.4byte sSentretPose154
+.4byte sSentretPose155
+.4byte sSentretPose156
+.4byte sSentretPose157
+.4byte sSentretPose158
+.4byte sSentretPose159
+.4byte sSentretPose160
+.4byte sSentretPose161
+.4byte sSentretPose162
+.4byte sSentretPose163
+.4byte sSentretPose164
+.4byte sSentretPose165
+.4byte sSentretPose166
+.4byte sSentretPose167
+.4byte sSentretPose168
+.4byte sSentretPose169
+.4byte sSentretPose170
+.4byte sSentretPose171
+.4byte sSentretPose172
+.4byte sSentretPose173
+.4byte sSentretPose174
+.4byte sSentretPose175
+.4byte sSentretPose176
+.4byte sSentretPose177
+.4byte sSentretPose178
+.4byte sSentretPose179
+.4byte sSentretPose180
+.4byte sSentretPose181
+.4byte sSentretPose182
+.4byte sSentretPose183
+.4byte sSentretPose184
+.4byte sSentretPose185
+.4byte sSentretPose186
+.4byte sSentretPose187
+.4byte sSentretPose188
+.4byte sSentretPose189
+.4byte sSentretPose190
+.4byte sSentretPose191
+.4byte sSentretPose192
+.4byte sSentretPose193
+.4byte sSentretPose194
+.4byte sSentretPose195
+.4byte sSentretPose196
+.4byte sSentretPose197
+.4byte sSentretPose198
+.4byte sSentretPose199
+.4byte sSentretPose200
+.4byte sSentretPose201
+.4byte sSentretPose202
+.4byte sSentretPose203
+.4byte sSentretPose204
+.4byte sSentretPose205
+.4byte sSentretPose206
+.4byte sSentretPose207
+.4byte sSentretPose208
+.4byte sSentretPose209
+.4byte sSentretPose210
+.4byte sSentretPose211
+.4byte sSentretPose212
+.4byte sSentretPose213
+.4byte sSentretPose214
+.4byte sSentretPose215
+.4byte sSentretPose216
+.4byte sSentretPose217
+.4byte sSentretPose218
+.4byte sSentretPose219
+.4byte sSentretPose220
+.4byte sSentretPose221
+.4byte sSentretPose222
+.4byte sSentretPose223
+.4byte sSentretPose224
+.4byte sSentretPose225
+.4byte sSentretPose226
+.4byte sSentretPose227
+.4byte sSentretPose228
+.4byte sSentretPose229
+.4byte sSentretPose230
+.4byte sSentretPose231
+.4byte sSentretPose232
+.4byte sSentretPose233
+.4byte sSentretPose234
+.4byte sSentretPose235
+.4byte sSentretPose236
+.4byte sSentretPose237
+.4byte sSentretPose238
+.4byte sSentretPose239
+.4byte sSentretPose240
+.4byte sSentretPose241
+.4byte sSentretPose242
+.4byte sSentretPose243
+.4byte sSentretPose244
+.4byte sSentretPose245
+.4byte sSentretPose246
+.4byte sSentretPose247
+.4byte sSentretPose248
+.4byte sSentretPose249
+.4byte sSentretPose250
+sAxPositionsSentret:
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -2, 	   6,   -5, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -2, 	  -1,   -5
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte    1,   -8, 	   8,   -5, 	  -7,   -4, 	   0,   -5
+.2byte    2,   -8, 	   6,   -8, 	  -2,   -3, 	  -1,   -5
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    4,   -8, 	   7,   -7, 	   1,   -2, 	  -1,   -7
+.2byte    4,   -8, 	   4,  -10, 	   6,   -4, 	  -1,   -6
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    1,   -9, 	  -5,   -8, 	   5,   -2, 	  -2,   -6
+.2byte   -1,  -10, 	  -8,  -10, 	   8,   -8, 	  -1,   -6
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   7,  -10, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -4, 	  -9,  -10, 	  -1,   -7
+.2byte   -3,  -11, 	   2,  -11, 	 -10,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   3,   -8, 	  -7,   -2, 	   0,   -6
+.2byte   -1,  -10, 	   6,  -10, 	 -10,   -8, 	  -1,   -6
+.2byte   -6,   -9, 	  -8,   -9, 	  -6,   -4, 	  -1,   -7
+.2byte   -6,   -8, 	  -9,   -7, 	  -3,   -2, 	  -1,   -7
+.2byte   -6,   -8, 	  -6,  -10, 	  -8,   -4, 	  -1,   -6
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -2,   -8, 	  -9,   -5, 	   6,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -7,   -8, 	   1,   -3, 	   0,   -5
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,  -20, 	 -11,  -21, 	   9,  -21, 	  -1,  -17
+.2byte   -1,  -10, 	  -9,  -11, 	   7,  -11, 	  -1,  -11
+.2byte   -1,   -8, 	 -10,  -11, 	   7,  -11, 	  -1,  -10
+.2byte   -1,   -8, 	 -10,  -13, 	   8,  -13, 	  -1,  -10
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte    1,  -20, 	   7,  -20, 	 -10,  -19, 	  -1,  -17
+.2byte    2,  -14, 	   5,  -16, 	  -3,  -15, 	  -2,  -16
+.2byte    5,  -12, 	  11,  -21, 	  -3,  -14, 	   2,  -16
+.2byte    5,  -16, 	   7,  -23, 	  -7,  -18, 	   2,  -15
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    4,  -20, 	  -1,  -22, 	  -1,  -17, 	  -1,  -18
+.2byte    3,  -12, 	   3,  -17, 	   2,  -11, 	  -3,  -14
+.2byte    8,  -15, 	   4,  -21, 	   3,  -16, 	   1,  -17
+.2byte    8,  -17, 	  -1,  -21, 	  -3,  -18, 	   2,  -16
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    0,  -21, 	  -7,  -23, 	   8,  -18, 	  -2,  -18
+.2byte    0,  -14, 	  -5,  -18, 	   6,  -12, 	  -4,  -14
+.2byte    4,  -19, 	  -6,  -23, 	   9,  -17, 	   0,  -19
+.2byte    2,  -21, 	  -7,  -23, 	   7,  -13, 	  -1,  -19
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,  -21, 	   8,  -20, 	 -10,  -20, 	  -1,  -17
+.2byte   -1,  -13, 	   7,  -12, 	  -9,  -12, 	  -1,  -12
+.2byte   -1,  -22, 	   8,  -21, 	 -10,  -21, 	  -1,  -21
+.2byte   -1,  -21, 	   7,  -18, 	  -9,  -18, 	  -1,  -20
+.2byte   -3,  -11, 	   2,  -11, 	 -10,   -6, 	   0,   -7
+.2byte   -2,  -21, 	   5,  -23, 	 -10,  -18, 	   0,  -18
+.2byte   -2,  -14, 	   3,  -18, 	  -8,  -12, 	   2,  -14
+.2byte   -6,  -19, 	   4,  -23, 	 -11,  -17, 	  -2,  -19
+.2byte   -4,  -20, 	   5,  -22, 	  -9,  -12, 	  -1,  -18
+.2byte   -6,   -9, 	  -8,   -9, 	  -6,   -4, 	  -1,   -7
+.2byte   -6,  -20, 	  -1,  -22, 	  -1,  -17, 	  -1,  -18
+.2byte   -5,  -12, 	  -5,  -17, 	  -4,  -11, 	   1,  -14
+.2byte  -10,  -15, 	  -6,  -21, 	  -5,  -16, 	  -3,  -17
+.2byte  -10,  -16, 	  -1,  -20, 	   1,  -17, 	  -4,  -15
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -2,  -20, 	  -8,  -20, 	   9,  -19, 	   0,  -17
+.2byte   -3,  -14, 	  -6,  -16, 	   2,  -15, 	   1,  -16
+.2byte   -6,  -12, 	 -12,  -21, 	   2,  -14, 	  -3,  -16
+.2byte   -6,  -15, 	  -8,  -22, 	   6,  -17, 	  -3,  -14
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -2, 	   6,   -5, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -2, 	  -1,   -5
+.2byte   -1,   -9, 	  -9,  -13, 	   4,   -5, 	   0,   -7
+.2byte    0,   -6, 	  -2,   -2, 	   8,   -9, 	   0,   -5
+.2byte    0,   -6, 	  -2,   -2, 	   8,   -9, 	   0,   -5
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte    1,   -8, 	   8,   -5, 	  -7,   -4, 	   0,   -5
+.2byte    2,   -8, 	   6,   -8, 	  -2,   -3, 	  -1,   -5
+.2byte    1,   -9, 	   5,  -14, 	  -2,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   2,   -3, 	 -10,   -9, 	  -1,   -8
+.2byte    1,   -7, 	   2,   -3, 	 -10,   -9, 	  -1,   -8
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    4,   -8, 	   7,   -7, 	   1,   -2, 	  -1,   -7
+.2byte    4,   -8, 	   4,  -10, 	   6,   -4, 	  -1,   -6
+.2byte    4,   -9, 	  -6,  -14, 	   6,   -7, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -6, 	  -6,   -7, 	  -2,   -6
+.2byte    3,   -7, 	   7,   -6, 	  -6,   -7, 	  -2,   -6
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    1,   -9, 	  -5,   -8, 	   5,   -2, 	  -2,   -6
+.2byte   -1,  -10, 	  -8,  -10, 	   8,   -8, 	  -1,   -6
+.2byte   -1,   -9, 	  -9,  -13, 	   7,  -10, 	  -1,   -7
+.2byte    1,   -8, 	  -3,   -6, 	   4,   -6, 	  -2,   -6
+.2byte    1,   -8, 	  -3,   -6, 	   4,   -6, 	  -2,   -6
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   7,  -10, 	  -9,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   7,   -4, 	  -9,  -10, 	  -1,   -7
+.2byte   -1,  -10, 	   8,  -12, 	  -6,   -9, 	  -1,   -8
+.2byte   -1,   -8, 	   2,   -6, 	 -10,  -10, 	   0,   -7
+.2byte   -1,   -8, 	   2,   -6, 	 -10,  -10, 	   0,   -7
+.2byte   -3,  -11, 	   2,  -11, 	 -10,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   3,   -8, 	  -7,   -2, 	   0,   -6
+.2byte   -1,  -10, 	   6,  -10, 	 -10,   -8, 	  -1,   -6
+.2byte   -1,   -9, 	   7,  -13, 	  -9,  -10, 	  -1,   -7
+.2byte   -3,   -8, 	   1,   -6, 	  -6,   -6, 	   0,   -6
+.2byte   -3,   -8, 	   1,   -6, 	  -6,   -6, 	   0,   -6
+.2byte   -6,   -9, 	  -8,   -9, 	  -6,   -4, 	  -1,   -7
+.2byte   -6,   -8, 	  -9,   -7, 	  -3,   -2, 	  -1,   -7
+.2byte   -6,   -8, 	  -6,  -10, 	  -8,   -4, 	  -1,   -6
+.2byte   -6,   -9, 	   4,  -14, 	  -8,   -7, 	  -1,   -7
+.2byte   -5,   -7, 	  -9,   -6, 	   4,   -7, 	   0,   -6
+.2byte   -5,   -7, 	  -9,   -6, 	   4,   -7, 	   0,   -6
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -2,   -8, 	  -9,   -5, 	   6,   -4, 	  -1,   -5
+.2byte   -3,   -8, 	  -7,   -8, 	   1,   -3, 	   0,   -5
+.2byte   -2,   -9, 	  -6,  -14, 	   1,   -5, 	   0,   -7
+.2byte   -2,   -7, 	  -3,   -3, 	   9,   -9, 	   0,   -8
+.2byte   -2,   -7, 	  -3,   -3, 	   9,   -9, 	   0,   -8
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,   -4, 	 -10,   -9, 	   8,   -9, 	  -1,   -6
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte    5,   -7, 	   7,  -14, 	  -7,   -9, 	   2,   -6
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    8,   -9, 	  -1,  -13, 	  -3,  -10, 	   2,   -8
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    2,  -10, 	  -7,  -12, 	   7,   -2, 	  -1,   -8
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,   -9, 	   7,   -6, 	  -9,   -6, 	  -1,   -8
+.2byte   -3,  -11, 	   2,  -11, 	 -10,   -6, 	   0,   -7
+.2byte   -4,  -10, 	   5,  -12, 	  -9,   -2, 	  -1,   -8
+.2byte   -6,   -9, 	  -8,   -9, 	  -6,   -4, 	  -1,   -7
+.2byte  -10,   -9, 	  -1,  -13, 	   1,  -10, 	  -4,   -8
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -6,   -7, 	  -8,  -14, 	   6,   -9, 	  -3,   -6
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,  -20, 	 -11,  -21, 	   9,  -21, 	  -1,  -17
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte    1,  -20, 	   7,  -20, 	 -10,  -19, 	  -1,  -17
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    4,  -20, 	  -1,  -22, 	  -1,  -17, 	  -1,  -18
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    0,  -21, 	  -7,  -23, 	   8,  -18, 	  -2,  -18
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,  -21, 	   8,  -20, 	 -10,  -20, 	  -1,  -17
+.2byte   -3,  -11, 	   2,  -11, 	 -10,   -6, 	   0,   -7
+.2byte   -2,  -21, 	   5,  -23, 	 -10,  -18, 	   0,  -18
+.2byte   -6,   -9, 	  -8,   -9, 	  -6,   -4, 	  -1,   -7
+.2byte   -6,  -20, 	  -1,  -22, 	  -1,  -17, 	  -1,  -18
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -2,  -20, 	  -8,  -20, 	   9,  -19, 	   0,  -17
+.2byte    2,   -5, 	  -1,   -5, 	   6,   -2, 	   1,   -5
+.2byte    2,   -5, 	  -1,   -4, 	   6,   -2, 	   1,   -5
+.2byte    0,  -10, 	 -10,  -11, 	  10,  -11, 	   0,   -8
+.2byte   -2,  -10, 	   4,  -14, 	 -14,   -7, 	  -3,   -8
+.2byte    0,  -11, 	 -10,  -13, 	 -10,   -8, 	  -4,   -8
+.2byte   -2,   -9, 	 -11,   -6, 	   2,   -4, 	  -5,   -6
+.2byte    0,   -6, 	   9,   -3, 	  -9,   -3, 	   0,   -4
+.2byte    2,   -9, 	  11,   -6, 	  -2,   -4, 	   5,   -6
+.2byte   -1,  -11, 	   9,  -13, 	   9,   -8, 	   3,   -8
+.2byte    2,  -10, 	  -4,  -14, 	  14,   -7, 	   3,   -8
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,  -20, 	 -11,  -21, 	   9,  -21, 	  -1,  -17
+.2byte   -1,  -10, 	  -9,  -11, 	   7,  -11, 	  -1,  -11
+.2byte   -1,   -8, 	 -10,  -11, 	   7,  -11, 	  -1,  -10
+.2byte   -1,   -8, 	 -10,  -13, 	   8,  -13, 	  -1,  -10
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte    1,  -20, 	   7,  -20, 	 -10,  -19, 	  -1,  -17
+.2byte    2,  -14, 	   5,  -16, 	  -3,  -15, 	  -2,  -16
+.2byte    5,  -12, 	  11,  -21, 	  -3,  -14, 	   2,  -16
+.2byte    5,  -16, 	   7,  -23, 	  -7,  -18, 	   2,  -15
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    4,  -20, 	  -1,  -22, 	  -1,  -17, 	  -1,  -18
+.2byte    3,  -12, 	   3,  -17, 	   2,  -11, 	  -3,  -14
+.2byte    8,  -15, 	   4,  -21, 	   3,  -16, 	   1,  -17
+.2byte    8,  -17, 	  -1,  -21, 	  -3,  -18, 	   2,  -16
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    0,  -21, 	  -7,  -23, 	   8,  -18, 	  -2,  -18
+.2byte    0,  -14, 	  -5,  -18, 	   6,  -12, 	  -4,  -14
+.2byte    4,  -19, 	  -6,  -23, 	   9,  -17, 	   0,  -19
+.2byte    2,  -21, 	  -7,  -23, 	   7,  -13, 	  -1,  -19
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,  -21, 	   8,  -20, 	 -10,  -20, 	  -1,  -17
+.2byte   -1,  -13, 	   7,  -12, 	  -9,  -12, 	  -1,  -12
+.2byte   -1,  -22, 	   8,  -21, 	 -10,  -21, 	  -1,  -21
+.2byte   -1,  -21, 	   7,  -18, 	  -9,  -18, 	  -1,  -20
+.2byte   -3,  -11, 	   2,  -11, 	 -10,   -6, 	   0,   -7
+.2byte   -2,  -21, 	   5,  -23, 	 -10,  -18, 	   0,  -18
+.2byte   -2,  -14, 	   3,  -18, 	  -8,  -12, 	   2,  -14
+.2byte   -6,  -19, 	   4,  -23, 	 -11,  -17, 	  -2,  -19
+.2byte   -4,  -20, 	   5,  -22, 	  -9,  -12, 	  -1,  -18
+.2byte   -6,   -9, 	  -8,   -9, 	  -6,   -4, 	  -1,   -7
+.2byte   -6,  -20, 	  -1,  -22, 	  -1,  -17, 	  -1,  -18
+.2byte   -5,  -12, 	  -5,  -17, 	  -4,  -11, 	   1,  -14
+.2byte  -10,  -15, 	  -6,  -21, 	  -5,  -16, 	  -3,  -17
+.2byte  -10,  -16, 	  -1,  -20, 	   1,  -17, 	  -4,  -15
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -2,  -20, 	  -8,  -20, 	   9,  -19, 	   0,  -17
+.2byte   -3,  -14, 	  -6,  -16, 	   2,  -15, 	   1,  -16
+.2byte   -6,  -12, 	 -12,  -21, 	   2,  -14, 	  -3,  -16
+.2byte   -6,  -15, 	  -8,  -22, 	   6,  -17, 	  -3,  -14
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -5,   -9, 	  -7,   -9, 	  -5,   -4, 	   0,   -7
+.2byte   -1,  -11, 	   4,  -11, 	  -8,   -6, 	   2,   -7
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,  -11, 	  -6,  -11, 	   6,   -6, 	  -4,   -7
+.2byte    3,   -9, 	   5,   -9, 	   3,   -4, 	  -2,   -7
+.2byte    0,   -9, 	   6,   -7, 	  -5,   -2, 	  -2,   -6
+.2byte   -1,  -20, 	 -11,  -21, 	   9,  -21, 	  -1,  -17
+.2byte    2,  -19, 	   8,  -19, 	  -9,  -18, 	   0,  -16
+.2byte    6,  -19, 	   1,  -21, 	   1,  -16, 	   1,  -17
+.2byte    1,  -21, 	  -6,  -23, 	   9,  -18, 	  -1,  -18
+.2byte   -1,  -21, 	   8,  -20, 	 -10,  -20, 	  -1,  -17
+.2byte   -2,  -21, 	   5,  -23, 	 -10,  -18, 	   0,  -18
+.2byte   -7,  -19, 	  -2,  -21, 	  -2,  -16, 	  -2,  -17
+.2byte   -3,  -19, 	  -9,  -19, 	   8,  -18, 	  -1,  -16
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,  -20, 	 -11,  -21, 	   9,  -21, 	  -1,  -17
+.2byte   -1,   -6, 	 -10,  -11, 	   8,  -11, 	  -1,   -8
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte    1,  -12, 	   7,  -12, 	 -10,  -11, 	  -1,   -9
+.2byte    3,   -9, 	   5,  -16, 	  -9,  -11, 	   0,   -8
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    4,  -16, 	  -1,  -18, 	  -1,  -13, 	  -1,  -14
+.2byte    5,  -13, 	  -4,  -17, 	  -6,  -14, 	  -1,  -12
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    0,  -13, 	  -7,  -15, 	   8,  -10, 	  -2,  -10
+.2byte    2,  -13, 	  -7,  -15, 	   7,   -5, 	  -1,  -11
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	   8,  -11, 	 -10,  -11, 	  -1,   -8
+.2byte   -1,  -12, 	   7,   -9, 	  -9,   -9, 	  -1,  -11
+.2byte   -2,  -11, 	   3,  -11, 	  -9,   -6, 	   1,   -7
+.2byte   -1,  -13, 	   6,  -15, 	  -9,  -10, 	   1,  -10
+.2byte   -3,  -13, 	   6,  -15, 	  -8,   -5, 	   0,  -11
+.2byte   -5,   -9, 	  -7,   -9, 	  -5,   -4, 	   0,   -7
+.2byte   -5,  -16, 	   0,  -18, 	   0,  -13, 	   0,  -14
+.2byte   -6,  -13, 	   3,  -17, 	   5,  -14, 	   0,  -12
+.2byte   -2,   -9, 	  -8,   -7, 	   3,   -2, 	   0,   -6
+.2byte   -2,  -12, 	  -8,  -12, 	   9,  -11, 	   0,   -9
+.2byte   -4,   -9, 	  -6,  -16, 	   8,  -11, 	  -1,   -8
+.2byte    0,   -6, 	  -2,   -2, 	   8,   -9, 	   0,   -5
+.2byte   -3,   -7, 	  -4,   -3, 	   8,   -9, 	  -1,   -8
+.2byte   -5,   -7, 	  -9,   -6, 	   4,   -7, 	   0,   -6
+.2byte   -3,   -8, 	   1,   -6, 	  -6,   -6, 	   0,   -6
+.2byte   -1,   -8, 	   2,   -6, 	 -10,  -10, 	   0,   -7
+.2byte    1,   -8, 	  -3,   -6, 	   4,   -6, 	  -2,   -6
+.2byte    3,   -7, 	   7,   -6, 	  -6,   -7, 	  -2,   -6
+.2byte    2,   -7, 	   3,   -3, 	  -9,   -9, 	   0,   -8
+.2byte   -1,   -9, 	  -9,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -3,   -9, 	  -9,   -7, 	   2,   -2, 	  -1,   -6
+.2byte   -6,   -9, 	  -8,   -9, 	  -6,   -4, 	  -1,   -7
+.2byte   -3,  -11, 	   2,  -11, 	 -10,   -6, 	   0,   -7
+.2byte   -1,  -10, 	   7,   -7, 	  -9,   -7, 	  -1,   -8
+.2byte    1,  -11, 	  -4,  -11, 	   8,   -6, 	  -2,   -7
+.2byte    4,   -9, 	   6,   -9, 	   4,   -4, 	  -1,   -7
+.2byte    1,   -9, 	   7,   -7, 	  -4,   -2, 	  -1,   -6
+sSentretAnimTable1:
+.4byte sSentretAnims_1_1
+.4byte sSentretAnims_1_2
+.4byte sSentretAnims_1_3
+.4byte sSentretAnims_1_4
+.4byte sSentretAnims_1_5
+.4byte sSentretAnims_1_6
+.4byte sSentretAnims_1_7
+.4byte sSentretAnims_1_8
+sSentretAnimTable2:
+.4byte sSentretAnims_2_1
+.4byte sSentretAnims_2_2
+.4byte sSentretAnims_2_3
+.4byte sSentretAnims_2_4
+.4byte sSentretAnims_2_5
+.4byte sSentretAnims_2_6
+.4byte sSentretAnims_2_7
+.4byte sSentretAnims_2_8
+sSentretAnimTable3:
+.4byte sSentretAnims_3_1
+.4byte sSentretAnims_3_2
+.4byte sSentretAnims_3_3
+.4byte sSentretAnims_3_4
+.4byte sSentretAnims_3_5
+.4byte sSentretAnims_3_6
+.4byte sSentretAnims_3_7
+.4byte sSentretAnims_3_8
+sSentretAnimTable4:
+.4byte sSentretAnims_4_1
+.4byte sSentretAnims_4_2
+.4byte sSentretAnims_4_3
+.4byte sSentretAnims_4_4
+.4byte sSentretAnims_4_5
+.4byte sSentretAnims_4_6
+.4byte sSentretAnims_4_7
+.4byte sSentretAnims_4_8
+sSentretAnimTable5:
+.4byte sSentretAnims_5_1
+.4byte sSentretAnims_5_2
+.4byte sSentretAnims_5_3
+.4byte sSentretAnims_5_4
+.4byte sSentretAnims_5_5
+.4byte sSentretAnims_5_6
+.4byte sSentretAnims_5_7
+.4byte sSentretAnims_5_8
+sSentretAnimTable6:
+.4byte sSentretAnims_6_1
+.4byte sSentretAnims_6_1
+.4byte sSentretAnims_6_1
+.4byte sSentretAnims_6_1
+.4byte sSentretAnims_6_1
+.4byte sSentretAnims_6_1
+.4byte sSentretAnims_6_1
+.4byte sSentretAnims_6_1
+sSentretAnimTable7:
+.4byte sSentretAnims_7_1
+.4byte sSentretAnims_7_2
+.4byte sSentretAnims_7_3
+.4byte sSentretAnims_7_4
+.4byte sSentretAnims_7_5
+.4byte sSentretAnims_7_6
+.4byte sSentretAnims_7_7
+.4byte sSentretAnims_7_8
+sSentretAnimTable8:
+.4byte sSentretAnims_8_1
+.4byte sSentretAnims_8_2
+.4byte sSentretAnims_8_3
+.4byte sSentretAnims_8_4
+.4byte sSentretAnims_8_5
+.4byte sSentretAnims_8_6
+.4byte sSentretAnims_8_7
+.4byte sSentretAnims_8_8
+sSentretAnimTable9:
+.4byte sSentretAnims_9_1
+.4byte sSentretAnims_9_2
+.4byte sSentretAnims_9_3
+.4byte sSentretAnims_9_4
+.4byte sSentretAnims_9_5
+.4byte sSentretAnims_9_6
+.4byte sSentretAnims_9_7
+.4byte sSentretAnims_9_8
+sSentretAnimTable10:
+.4byte sSentretAnims_10_1
+.4byte sSentretAnims_10_2
+.4byte sSentretAnims_10_3
+.4byte sSentretAnims_10_4
+.4byte sSentretAnims_10_5
+.4byte sSentretAnims_10_6
+.4byte sSentretAnims_10_7
+.4byte sSentretAnims_10_8
+sSentretAnimTable11:
+.4byte sSentretAnims_11_1
+.4byte sSentretAnims_11_2
+.4byte sSentretAnims_11_3
+.4byte sSentretAnims_11_4
+.4byte sSentretAnims_11_5
+.4byte sSentretAnims_11_6
+.4byte sSentretAnims_11_7
+.4byte sSentretAnims_11_8
+sSentretAnimTable12:
+.4byte sSentretAnims_12_1
+.4byte sSentretAnims_12_2
+.4byte sSentretAnims_12_3
+.4byte sSentretAnims_12_4
+.4byte sSentretAnims_12_5
+.4byte sSentretAnims_12_6
+.4byte sSentretAnims_12_7
+.4byte sSentretAnims_12_8
+sSentretAnimTable13:
+.4byte sSentretAnims_13_1
+.4byte sSentretAnims_13_2
+.4byte sSentretAnims_13_3
+.4byte sSentretAnims_13_4
+.4byte sSentretAnims_13_5
+.4byte sSentretAnims_13_6
+.4byte sSentretAnims_13_7
+.4byte sSentretAnims_13_8
+sAxAnimationsSentret:
+.4byte sSentretAnimTable1
+.4byte sSentretAnimTable2
+.4byte sSentretAnimTable3
+.4byte sSentretAnimTable4
+.4byte sSentretAnimTable5
+.4byte sSentretAnimTable6
+.4byte sSentretAnimTable7
+.4byte sSentretAnimTable8
+.4byte sSentretAnimTable9
+.4byte sSentretAnimTable10
+.4byte sSentretAnimTable11
+.4byte sSentretAnimTable12
+.4byte sSentretAnimTable13
+sAxSpritesSentret:
+.4byte sSentretSprites1
+.4byte sSentretSprites2
+.4byte sSentretSprites3
+.4byte sSentretSprites4
+.4byte sSentretSprites5
+.4byte sSentretSprites6
+.4byte sSentretSprites7
+.4byte sSentretSprites8
+.4byte sSentretSprites9
+.4byte sSentretSprites10
+.4byte sSentretSprites11
+.4byte sSentretSprites12
+.4byte sSentretSprites13
+.4byte sSentretSprites14
+.4byte sSentretSprites15
+.4byte sSentretSprites16
+.4byte sSentretSprites17
+.4byte sSentretSprites18
+.4byte sSentretSprites19
+.4byte sSentretSprites20
+.4byte sSentretSprites21
+.4byte sSentretSprites22
+.4byte sSentretSprites23
+.4byte sSentretSprites24
+.4byte sSentretSprites25
+.4byte sSentretSprites26
+.4byte sSentretSprites27
+.4byte sSentretSprites28
+.4byte sSentretSprites29
+.4byte sSentretSprites30
+.4byte sSentretSprites31
+.4byte sSentretSprites32
+.4byte sSentretSprites33
+.4byte sSentretSprites34
+.4byte sSentretSprites35
+.4byte sSentretSprites36
+.4byte sSentretSprites37
+.4byte sSentretSprites38
+.4byte sSentretSprites39
+.4byte sSentretSprites40
+.4byte sSentretSprites41
+.4byte sSentretSprites42
+.4byte sSentretSprites43
+.4byte sSentretSprites44
+.4byte sSentretSprites45
+.4byte sSentretSprites46
+.4byte sSentretSprites47
+.4byte sSentretSprites48
+.4byte sSentretSprites49
+.4byte sSentretSprites50
+.4byte sSentretSprites51
+.4byte sSentretSprites52
+.4byte sSentretSprites53
+.4byte sSentretSprites54
+.4byte sSentretSprites55
+.4byte sSentretSprites56
+.4byte sSentretSprites57
+sAxMainSentret:
+ax_main sAxPosesSentret, sAxAnimationsSentret, 13, sAxSpritesSentret, sAxPositionsSentret

--- a/data/ax/seviper.inc
+++ b/data/ax/seviper.inc
@@ -1,0 +1,3447 @@
+.global gAxSeviper
+gAxSeviper:
+ax_siro sAxMainSeviper
+sSeviperPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose4:
+ax_pose 3, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose5:
+ax_pose 4, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose6:
+ax_pose 5, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose7:
+ax_pose 6, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose8:
+ax_pose 7, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose9:
+ax_pose 8, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose10:
+ax_pose 9, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose11:
+ax_pose 10, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose12:
+ax_pose 11, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose13:
+ax_pose 12, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose14:
+ax_pose 13, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose15:
+ax_pose 14, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose16:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose17:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose18:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose19:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose20:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose21:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose22:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose23:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose24:
+ax_pose 23, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose26:
+ax_pose 24, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose27:
+ax_pose 25, 0x81e6, 0x80f9, 0x2c00
+ax_pose 26, 0x01de, 0x00fc, 0x2c08
+ax_pose 27, 0x0206, 0x40f9, 0x2c09
+ax_pose_terminator
+sSeviperPose28:
+ax_pose 3, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose29:
+ax_pose 28, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose30:
+ax_pose 29, 0x81e7, 0x00e9, 0x2c00
+ax_pose 30, 0x01ef, 0x40f1, 0x2c02
+ax_pose 31, 0x01f7, 0x00e9, 0x2c06
+ax_pose 32, 0x81f7, 0x0101, 0x2c07
+ax_pose 33, 0x01ff, 0x00f9, 0x2c09
+ax_pose 34, 0x01f7, 0x4109, 0x2c0a
+ax_pose 35, 0x4207, 0x0109, 0x2c0e
+ax_pose_terminator
+sSeviperPose31:
+ax_pose 6, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose32:
+ax_pose 36, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSeviperPose33:
+ax_pose 37, 0x41f3, 0x80eb, 0x2c00
+ax_pose 38, 0x01eb, 0x010d, 0x2c08
+ax_pose 39, 0x01fb, 0x00e3, 0x2c09
+ax_pose 40, 0x41f3, 0x00db, 0x2c0a
+ax_pose 41, 0x01f3, 0x410b, 0x2c0c
+ax_pose_terminator
+sSeviperPose34:
+ax_pose 9, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose35:
+ax_pose 42, 0x01e6, 0x80ea, 0x2c00
+ax_pose_terminator
+sSeviperPose36:
+ax_pose 43, 0x01e8, 0x4103, 0x2c00
+ax_pose 44, 0x41f8, 0x0103, 0x2c04
+ax_pose 45, 0x41f0, 0x00f3, 0x2c06
+ax_pose 46, 0x41f8, 0x80e3, 0x2c08
+ax_pose_terminator
+sSeviperPose37:
+ax_pose 12, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose38:
+ax_pose 47, 0x81e6, 0x80f8, 0x2c00
+ax_pose 48, 0x01f6, 0x4108, 0x2c08
+ax_pose 49, 0x0206, 0x00fe, 0x2c0c
+ax_pose_terminator
+sSeviperPose39:
+ax_pose 50, 0x81eb, 0x80f8, 0x2c00
+ax_pose 51, 0x41e3, 0x00f8, 0x2c08
+ax_pose 52, 0x020b, 0x40f8, 0x2c0a
+ax_pose_terminator
+sSeviperPose40:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose41:
+ax_pose 53, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose42:
+ax_pose 54, 0x41f8, 0x80f3, 0x2c00
+ax_pose 55, 0x01e8, 0x40f3, 0x2c08
+ax_pose 56, 0x81eb, 0x00eb, 0x2c0c
+ax_pose 57, 0x81f8, 0x0113, 0x2c0e
+ax_pose_terminator
+sSeviperPose43:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose44:
+ax_pose 58, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sSeviperPose45:
+ax_pose 59, 0x41f3, 0x80f2, 0x2c00
+ax_pose 60, 0x01f3, 0x40e2, 0x2c08
+ax_pose 61, 0x01f3, 0x4112, 0x2c0c
+ax_pose 62, 0x01eb, 0x00ea, 0x2c10
+ax_pose_terminator
+sSeviperPose46:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose47:
+ax_pose 63, 0x01e9, 0x80eb, 0x2c00
+ax_pose_terminator
+sSeviperPose48:
+ax_pose 64, 0x01f6, 0x40f0, 0x2c00
+ax_pose 65, 0x01ee, 0x4100, 0x2c04
+ax_pose 66, 0x01fe, 0x0100, 0x2c08
+ax_pose 67, 0x81f6, 0x00e8, 0x2c09
+ax_pose 68, 0x0206, 0x00ec, 0x2c0b
+ax_pose 69, 0x01ee, 0x0110, 0x2c0c
+ax_pose 70, 0x01e6, 0x0110, 0x2c0d
+ax_pose 71, 0x01e6, 0x0108, 0x2c0e
+ax_pose_terminator
+sSeviperPose49:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose50:
+ax_pose 24, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose51:
+ax_pose 25, 0x81e6, 0x80f9, 0x2c00
+ax_pose 26, 0x01de, 0x00fc, 0x2c08
+ax_pose 27, 0x0206, 0x40f9, 0x2c09
+ax_pose_terminator
+sSeviperPose52:
+ax_pose 72, 0x81ea, 0x80f9, 0x2c00
+ax_pose 73, 0x01e2, 0x00f9, 0x2c08
+ax_pose_terminator
+sSeviperPose53:
+ax_pose 3, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose54:
+ax_pose 28, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose55:
+ax_pose 29, 0x81e7, 0x00e9, 0x2c00
+ax_pose 30, 0x01ef, 0x40f1, 0x2c02
+ax_pose 31, 0x01f7, 0x00e9, 0x2c06
+ax_pose 32, 0x81f7, 0x0101, 0x2c07
+ax_pose 33, 0x01ff, 0x00f9, 0x2c09
+ax_pose 34, 0x01f7, 0x4109, 0x2c0a
+ax_pose 35, 0x4207, 0x0109, 0x2c0e
+ax_pose_terminator
+sSeviperPose56:
+ax_pose 74, 0x41f4, 0x80ed, 0x2c00
+ax_pose 75, 0x41ec, 0x40ed, 0x2c08
+ax_pose 76, 0x01e4, 0x00ed, 0x2c0c
+ax_pose 77, 0x81f4, 0x010d, 0x2c0d
+ax_pose_terminator
+sSeviperPose57:
+ax_pose 6, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose58:
+ax_pose 36, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSeviperPose59:
+ax_pose 37, 0x41f3, 0x80eb, 0x2c00
+ax_pose 38, 0x01eb, 0x010d, 0x2c08
+ax_pose 39, 0x01fb, 0x00e3, 0x2c09
+ax_pose 40, 0x41f3, 0x00db, 0x2c0a
+ax_pose 41, 0x01f3, 0x410b, 0x2c0c
+ax_pose_terminator
+sSeviperPose60:
+ax_pose 78, 0x41f2, 0x80e6, 0x2c00
+ax_pose 79, 0x01f2, 0x4106, 0x2c08
+ax_pose 80, 0x41ea, 0x0106, 0x2c0c
+ax_pose 81, 0x01f1, 0x00de, 0x2c0e
+ax_pose 82, 0x01ea, 0x00e6, 0x2c0f
+ax_pose_terminator
+sSeviperPose61:
+ax_pose 9, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose62:
+ax_pose 42, 0x01e6, 0x80ea, 0x2c00
+ax_pose_terminator
+sSeviperPose63:
+ax_pose 43, 0x01e6, 0x4105, 0x2c00
+ax_pose 44, 0x41f6, 0x0105, 0x2c04
+ax_pose 45, 0x41ee, 0x00f5, 0x2c06
+ax_pose 46, 0x41f6, 0x80e5, 0x2c08
+ax_pose_terminator
+sSeviperPose64:
+ax_pose 83, 0x41f5, 0x80e8, 0x2c00
+ax_pose 84, 0x01e5, 0x40f8, 0x2c08
+ax_pose 85, 0x81eb, 0x0108, 0x2c0c
+ax_pose 86, 0x01f9, 0x00e0, 0x2c0e
+ax_pose_terminator
+sSeviperPose65:
+ax_pose 12, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose66:
+ax_pose 47, 0x81e6, 0x80f8, 0x2c00
+ax_pose 48, 0x01f6, 0x4108, 0x2c08
+ax_pose 49, 0x0206, 0x00fe, 0x2c0c
+ax_pose_terminator
+sSeviperPose67:
+ax_pose 50, 0x81eb, 0x80f8, 0x2c00
+ax_pose 51, 0x41e3, 0x00f8, 0x2c08
+ax_pose 52, 0x020b, 0x40f8, 0x2c0a
+ax_pose_terminator
+sSeviperPose68:
+ax_pose 87, 0x81eb, 0x80f8, 0x2c00
+ax_pose 88, 0x0203, 0x0108, 0x2c08
+ax_pose 89, 0x420b, 0x00fe, 0x2c09
+ax_pose_terminator
+sSeviperPose69:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose70:
+ax_pose 53, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose71:
+ax_pose 54, 0x41f6, 0x80f1, 0x2c00
+ax_pose 55, 0x01e6, 0x40f1, 0x2c08
+ax_pose 56, 0x81e9, 0x00e9, 0x2c0c
+ax_pose 57, 0x81f6, 0x0111, 0x2c0e
+ax_pose_terminator
+sSeviperPose72:
+ax_pose 90, 0x41f5, 0x80f1, 0x2c00
+ax_pose 91, 0x01e5, 0x40f1, 0x2c08
+ax_pose 92, 0x81ed, 0x00e9, 0x2c0c
+ax_pose 93, 0x81f5, 0x0111, 0x2c0e
+ax_pose_terminator
+sSeviperPose73:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose74:
+ax_pose 58, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sSeviperPose75:
+ax_pose 59, 0x41f3, 0x80f2, 0x2c00
+ax_pose 60, 0x01f3, 0x40e2, 0x2c08
+ax_pose 61, 0x01f3, 0x4112, 0x2c0c
+ax_pose 62, 0x01eb, 0x00ea, 0x2c10
+ax_pose_terminator
+sSeviperPose76:
+ax_pose 94, 0x41f2, 0x80f9, 0x2c00
+ax_pose 95, 0x01f2, 0x40e9, 0x2c08
+ax_pose 96, 0x41ea, 0x00e9, 0x2c0c
+ax_pose 97, 0x01ea, 0x0111, 0x2c0e
+ax_pose 98, 0x01f1, 0x0119, 0x2c0f
+ax_pose_terminator
+sSeviperPose77:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose78:
+ax_pose 63, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose79:
+ax_pose 64, 0x01f6, 0x40f0, 0x2c00
+ax_pose 65, 0x01ee, 0x4100, 0x2c04
+ax_pose 66, 0x01fe, 0x0100, 0x2c08
+ax_pose 67, 0x81f6, 0x00e8, 0x2c09
+ax_pose 68, 0x0206, 0x00ec, 0x2c0b
+ax_pose 69, 0x01ee, 0x0110, 0x2c0c
+ax_pose 70, 0x01e6, 0x0110, 0x2c0d
+ax_pose 71, 0x01e6, 0x0108, 0x2c0e
+ax_pose_terminator
+sSeviperPose80:
+ax_pose 99, 0x41ee, 0x80ef, 0x2c00
+ax_pose 100, 0x41fe, 0x00ef, 0x2c08
+ax_pose 101, 0x01fe, 0x00ff, 0x2c0a
+ax_pose 102, 0x01e6, 0x0107, 0x2c0b
+ax_pose 103, 0x01e6, 0x010f, 0x2c0c
+ax_pose 104, 0x01ee, 0x010f, 0x2c0d
+ax_pose_terminator
+sSeviperPose81:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose82:
+ax_pose 24, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose83:
+ax_pose 72, 0x81ea, 0x80f9, 0x2c00
+ax_pose 73, 0x01e2, 0x00f9, 0x2c08
+ax_pose_terminator
+sSeviperPose84:
+ax_pose 3, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose85:
+ax_pose 28, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose86:
+ax_pose 74, 0x41f4, 0x80ed, 0x2c00
+ax_pose 75, 0x41ec, 0x40ed, 0x2c08
+ax_pose 76, 0x01e4, 0x00ed, 0x2c0c
+ax_pose 77, 0x81f4, 0x010d, 0x2c0d
+ax_pose_terminator
+sSeviperPose87:
+ax_pose 6, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose88:
+ax_pose 36, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sSeviperPose89:
+ax_pose 78, 0x41f2, 0x80e6, 0x2c00
+ax_pose 79, 0x01f2, 0x4106, 0x2c08
+ax_pose 80, 0x41ea, 0x0106, 0x2c0c
+ax_pose 81, 0x01f1, 0x00de, 0x2c0e
+ax_pose 82, 0x01ea, 0x00e6, 0x2c0f
+ax_pose_terminator
+sSeviperPose90:
+ax_pose 9, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose91:
+ax_pose 42, 0x01e6, 0x80ec, 0x2c00
+ax_pose_terminator
+sSeviperPose92:
+ax_pose 83, 0x41f5, 0x80e8, 0x2c00
+ax_pose 84, 0x01e5, 0x40f8, 0x2c08
+ax_pose 85, 0x81eb, 0x0108, 0x2c0c
+ax_pose 86, 0x01f9, 0x00e0, 0x2c0e
+ax_pose_terminator
+sSeviperPose93:
+ax_pose 12, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose94:
+ax_pose 47, 0x81e6, 0x80f8, 0x2c00
+ax_pose 48, 0x01f6, 0x4108, 0x2c08
+ax_pose 49, 0x0206, 0x00fe, 0x2c0c
+ax_pose_terminator
+sSeviperPose95:
+ax_pose 87, 0x81e6, 0x80f8, 0x2c00
+ax_pose 88, 0x01fe, 0x0108, 0x2c08
+ax_pose 89, 0x4206, 0x00fe, 0x2c09
+ax_pose_terminator
+sSeviperPose96:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose97:
+ax_pose 53, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSeviperPose98:
+ax_pose 90, 0x41f5, 0x80f1, 0x2c00
+ax_pose 91, 0x01e5, 0x40f1, 0x2c08
+ax_pose 92, 0x81ed, 0x00e9, 0x2c0c
+ax_pose 93, 0x81f5, 0x0111, 0x2c0e
+ax_pose_terminator
+sSeviperPose99:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose100:
+ax_pose 58, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSeviperPose101:
+ax_pose 94, 0x41f2, 0x80f9, 0x2c00
+ax_pose 95, 0x01f2, 0x40e9, 0x2c08
+ax_pose 96, 0x41ea, 0x00e9, 0x2c0c
+ax_pose 97, 0x01ea, 0x0111, 0x2c0e
+ax_pose 98, 0x01f1, 0x0119, 0x2c0f
+ax_pose_terminator
+sSeviperPose102:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose103:
+ax_pose 63, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose104:
+ax_pose 99, 0x41ee, 0x80ef, 0x2c00
+ax_pose 100, 0x41fe, 0x00ef, 0x2c08
+ax_pose 101, 0x01fe, 0x00ff, 0x2c0a
+ax_pose 102, 0x01e6, 0x0107, 0x2c0b
+ax_pose 103, 0x01e6, 0x010f, 0x2c0c
+ax_pose 104, 0x01ee, 0x010f, 0x2c0d
+ax_pose_terminator
+sSeviperPose105:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose106:
+ax_pose 105, 0x81e5, 0x80fb, 0x2c00
+ax_pose 106, 0x81e5, 0x00f3, 0x2c08
+ax_pose 107, 0x01f5, 0x00f3, 0x2c0a
+ax_pose 108, 0x01dd, 0x00f8, 0x2c0b
+ax_pose_terminator
+sSeviperPose107:
+ax_pose 3, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose108:
+ax_pose 109, 0x41e5, 0x80ed, 0x2c00
+ax_pose 110, 0x41f5, 0x40ed, 0x2c08
+ax_pose 111, 0x01dd, 0x00f5, 0x2c0c
+ax_pose 112, 0x41fd, 0x00f5, 0x2c0d
+ax_pose 113, 0x01fd, 0x0105, 0x2c0f
+ax_pose_terminator
+sSeviperPose109:
+ax_pose 6, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose110:
+ax_pose 114, 0x01e2, 0x80ed, 0x2c00
+ax_pose 115, 0x81ea, 0x010d, 0x2c10
+ax_pose_terminator
+sSeviperPose111:
+ax_pose 9, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose112:
+ax_pose 116, 0x01e6, 0x80ed, 0x2c00
+ax_pose_terminator
+sSeviperPose113:
+ax_pose 12, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose114:
+ax_pose 117, 0x81e6, 0x80f8, 0x2c00
+ax_pose 118, 0x01ee, 0x0108, 0x2c08
+ax_pose 119, 0x01de, 0x00fc, 0x2c09
+ax_pose_terminator
+sSeviperPose115:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose116:
+ax_pose 120, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose117:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose118:
+ax_pose 121, 0x01e4, 0x80f2, 0x2c00
+ax_pose 122, 0x81eb, 0x00ea, 0x2c10
+ax_pose_terminator
+sSeviperPose119:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose120:
+ax_pose 123, 0x81e6, 0x80f8, 0x2c00
+ax_pose 124, 0x81e6, 0x40f0, 0x2c08
+ax_pose 125, 0x81e6, 0x0108, 0x2c0c
+ax_pose 126, 0x01f6, 0x0108, 0x2c0e
+ax_pose 127, 0x01de, 0x0106, 0x2c0f
+ax_pose_terminator
+sSeviperPose121:
+ax_pose 128, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose122:
+ax_pose 129, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose123:
+ax_pose 130, 0x41f0, 0x80f2, 0x2c00
+ax_pose 131, 0x8200, 0x0101, 0x2c08
+ax_pose 132, 0x8200, 0x00f9, 0x2c0a
+ax_pose 133, 0x01e0, 0x40fa, 0x2c0c
+ax_pose_terminator
+sSeviperPose124:
+ax_pose 134, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sSeviperPose125:
+ax_pose 135, 0x41e9, 0x0108, 0x2c00
+ax_pose 136, 0x41e9, 0x00e8, 0x2c02
+ax_pose 137, 0x01f1, 0x40e8, 0x2c04
+ax_pose 138, 0x41f1, 0x80f8, 0x2c08
+ax_pose_terminator
+sSeviperPose126:
+ax_pose 139, 0x01e7, 0x4101, 0x2c00
+ax_pose 140, 0x41ff, 0x00e9, 0x2c04
+ax_pose 141, 0x01ef, 0x40e9, 0x2c06
+ax_pose 142, 0x81e7, 0x40f9, 0x2c0a
+ax_pose 143, 0x41f7, 0x0101, 0x2c0e
+ax_pose_terminator
+sSeviperPose127:
+ax_pose 144, 0x81e1, 0x80f7, 0x2c00
+ax_pose 145, 0x4201, 0x00f7, 0x2c08
+ax_pose 146, 0x01e1, 0x0107, 0x2c0a
+ax_pose_terminator
+sSeviperPose128:
+ax_pose 147, 0x01e7, 0x40ef, 0x2c00
+ax_pose 148, 0x41ff, 0x0107, 0x2c04
+ax_pose 149, 0x01ef, 0x4107, 0x2c06
+ax_pose 150, 0x81e7, 0x40ff, 0x2c0a
+ax_pose 151, 0x41f7, 0x00ef, 0x2c0e
+ax_pose_terminator
+sSeviperPose129:
+ax_pose 152, 0x41e9, 0x00e8, 0x2c00
+ax_pose 153, 0x41e9, 0x0108, 0x2c02
+ax_pose 154, 0x01f1, 0x4108, 0x2c04
+ax_pose 155, 0x41f1, 0x80e8, 0x2c08
+ax_pose_terminator
+sSeviperPose130:
+ax_pose 156, 0x01e5, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose131:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose132:
+ax_pose 1, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose133:
+ax_pose 2, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose134:
+ax_pose 3, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose135:
+ax_pose 4, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose136:
+ax_pose 5, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose137:
+ax_pose 6, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose138:
+ax_pose 7, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose139:
+ax_pose 8, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose140:
+ax_pose 9, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose141:
+ax_pose 10, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose142:
+ax_pose 11, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose143:
+ax_pose 12, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose144:
+ax_pose 13, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose145:
+ax_pose 14, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose146:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose147:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose148:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose149:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose150:
+ax_pose 19, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose151:
+ax_pose 20, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose152:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose153:
+ax_pose 22, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose154:
+ax_pose 23, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose155:
+ax_pose 24, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose156:
+ax_pose 63, 0x01e7, 0x80e9, 0x2c00
+ax_pose_terminator
+sSeviperPose157:
+ax_pose 58, 0x01e5, 0x80eb, 0x2c00
+ax_pose_terminator
+sSeviperPose158:
+ax_pose 53, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose159:
+ax_pose 47, 0x81e6, 0x80f8, 0x2c00
+ax_pose 48, 0x01f6, 0x4108, 0x2c08
+ax_pose 49, 0x0206, 0x00fe, 0x2c0c
+ax_pose_terminator
+sSeviperPose160:
+ax_pose 42, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose161:
+ax_pose 36, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sSeviperPose162:
+ax_pose 28, 0x01e7, 0x80f7, 0x2c00
+ax_pose_terminator
+sSeviperPose163:
+ax_pose 72, 0x81ea, 0x80f9, 0x2c00
+ax_pose 73, 0x01e2, 0x00f9, 0x2c08
+ax_pose_terminator
+sSeviperPose164:
+ax_pose 74, 0x41f4, 0x80ed, 0x2c00
+ax_pose 75, 0x41ec, 0x40ed, 0x2c08
+ax_pose 76, 0x01e4, 0x00ed, 0x2c0c
+ax_pose 77, 0x81f4, 0x010d, 0x2c0d
+ax_pose_terminator
+sSeviperPose165:
+ax_pose 78, 0x41f2, 0x80e6, 0x2c00
+ax_pose 79, 0x01f2, 0x4106, 0x2c08
+ax_pose 80, 0x41ea, 0x0106, 0x2c0c
+ax_pose 81, 0x01f1, 0x00de, 0x2c0e
+ax_pose 82, 0x01ea, 0x00e6, 0x2c0f
+ax_pose_terminator
+sSeviperPose166:
+ax_pose 83, 0x41f5, 0x80e8, 0x2c00
+ax_pose 84, 0x01e5, 0x40f8, 0x2c08
+ax_pose 85, 0x81eb, 0x0108, 0x2c0c
+ax_pose 86, 0x01f9, 0x00e0, 0x2c0e
+ax_pose_terminator
+sSeviperPose167:
+ax_pose 87, 0x81e6, 0x80f8, 0x2c00
+ax_pose 88, 0x01fe, 0x0108, 0x2c08
+ax_pose 89, 0x4206, 0x00fe, 0x2c09
+ax_pose_terminator
+sSeviperPose168:
+ax_pose 90, 0x41f5, 0x80f1, 0x2c00
+ax_pose 91, 0x01e5, 0x40f1, 0x2c08
+ax_pose 92, 0x81ed, 0x00e9, 0x2c0c
+ax_pose 93, 0x81f5, 0x0111, 0x2c0e
+ax_pose_terminator
+sSeviperPose169:
+ax_pose 94, 0x41f2, 0x80f9, 0x2c00
+ax_pose 95, 0x01f2, 0x40e9, 0x2c08
+ax_pose 96, 0x41ea, 0x00e9, 0x2c0c
+ax_pose 97, 0x01ea, 0x0111, 0x2c0e
+ax_pose 98, 0x01f1, 0x0119, 0x2c0f
+ax_pose_terminator
+sSeviperPose170:
+ax_pose 99, 0x41ee, 0x80ef, 0x2c00
+ax_pose 100, 0x41fe, 0x00ef, 0x2c08
+ax_pose 101, 0x01fe, 0x00ff, 0x2c0a
+ax_pose 102, 0x01e6, 0x0107, 0x2c0b
+ax_pose 103, 0x01e6, 0x010f, 0x2c0c
+ax_pose 104, 0x01ee, 0x010f, 0x2c0d
+ax_pose_terminator
+sSeviperPose171:
+ax_pose 0, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose172:
+ax_pose 24, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose173:
+ax_pose 72, 0x81e5, 0x80f9, 0x2c00
+ax_pose 73, 0x01dd, 0x00f9, 0x2c08
+ax_pose_terminator
+sSeviperPose174:
+ax_pose 3, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose175:
+ax_pose 28, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose176:
+ax_pose 74, 0x41f4, 0x80ed, 0x2c00
+ax_pose 75, 0x41ec, 0x40ed, 0x2c08
+ax_pose 76, 0x01e4, 0x00ed, 0x2c0c
+ax_pose 77, 0x81f4, 0x010d, 0x2c0d
+ax_pose_terminator
+sSeviperPose177:
+ax_pose 6, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose178:
+ax_pose 36, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose179:
+ax_pose 78, 0x41f2, 0x80e5, 0x2c00
+ax_pose 79, 0x01f2, 0x4105, 0x2c08
+ax_pose 80, 0x41ea, 0x0105, 0x2c0c
+ax_pose 81, 0x01f1, 0x00dd, 0x2c0e
+ax_pose 82, 0x01ea, 0x00e5, 0x2c0f
+ax_pose_terminator
+sSeviperPose180:
+ax_pose 9, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose181:
+ax_pose 42, 0x01e6, 0x80ec, 0x2c00
+ax_pose_terminator
+sSeviperPose182:
+ax_pose 83, 0x41f5, 0x80e8, 0x2c00
+ax_pose 84, 0x01e5, 0x40f8, 0x2c08
+ax_pose 85, 0x81eb, 0x0108, 0x2c0c
+ax_pose 86, 0x01f9, 0x00e0, 0x2c0e
+ax_pose_terminator
+sSeviperPose183:
+ax_pose 12, 0x81e6, 0x80f8, 0x2c00
+ax_pose_terminator
+sSeviperPose184:
+ax_pose 47, 0x81e6, 0x80f8, 0x2c00
+ax_pose 48, 0x01f6, 0x4108, 0x2c08
+ax_pose 49, 0x0206, 0x00fe, 0x2c0c
+ax_pose_terminator
+sSeviperPose185:
+ax_pose 87, 0x81e7, 0x80f8, 0x2c00
+ax_pose 88, 0x01ff, 0x0108, 0x2c08
+ax_pose 89, 0x4207, 0x00fe, 0x2c09
+ax_pose_terminator
+sSeviperPose186:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose187:
+ax_pose 53, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sSeviperPose188:
+ax_pose 90, 0x41f5, 0x80f1, 0x2c00
+ax_pose 91, 0x01e5, 0x40f1, 0x2c08
+ax_pose 92, 0x81ed, 0x00e9, 0x2c0c
+ax_pose 93, 0x81f5, 0x0111, 0x2c0e
+ax_pose_terminator
+sSeviperPose189:
+ax_pose 18, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose190:
+ax_pose 58, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose191:
+ax_pose 94, 0x41f2, 0x80fa, 0x2c00
+ax_pose 95, 0x01f2, 0x40ea, 0x2c08
+ax_pose 96, 0x41ea, 0x00ea, 0x2c0c
+ax_pose 97, 0x01ea, 0x0112, 0x2c0e
+ax_pose 98, 0x01f1, 0x011a, 0x2c0f
+ax_pose_terminator
+sSeviperPose192:
+ax_pose 21, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose193:
+ax_pose 63, 0x01e6, 0x80ec, 0x2c00
+ax_pose_terminator
+sSeviperPose194:
+ax_pose 99, 0x41ee, 0x80ef, 0x2c00
+ax_pose 100, 0x41fe, 0x00ef, 0x2c08
+ax_pose 101, 0x01fe, 0x00ff, 0x2c0a
+ax_pose 102, 0x01e6, 0x0107, 0x2c0b
+ax_pose 103, 0x01e6, 0x010f, 0x2c0c
+ax_pose 104, 0x01ee, 0x010f, 0x2c0d
+ax_pose_terminator
+sSeviperPose195:
+ax_pose 24, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose196:
+ax_pose 63, 0x01e7, 0x80eb, 0x2c00
+ax_pose_terminator
+sSeviperPose197:
+ax_pose 58, 0x01e5, 0x80ed, 0x2c00
+ax_pose_terminator
+sSeviperPose198:
+ax_pose 53, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSeviperPose199:
+ax_pose 47, 0x81e4, 0x80f8, 0x2c00
+ax_pose 48, 0x01f4, 0x4108, 0x2c08
+ax_pose 49, 0x0204, 0x00fe, 0x2c0c
+ax_pose_terminator
+sSeviperPose200:
+ax_pose 42, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose201:
+ax_pose 36, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sSeviperPose202:
+ax_pose 28, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sSeviperPose203:
+ax_pose 0, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSeviperPose204:
+ax_pose 21, 0x01e7, 0x80ed, 0x2c00
+ax_pose_terminator
+sSeviperPose205:
+ax_pose 18, 0x01e6, 0x80ee, 0x2c00
+ax_pose_terminator
+sSeviperPose206:
+ax_pose 15, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSeviperPose207:
+ax_pose 12, 0x81e6, 0x80f9, 0x2c00
+ax_pose_terminator
+sSeviperPose208:
+ax_pose 9, 0x01e6, 0x80ef, 0x2c00
+ax_pose_terminator
+sSeviperPose209:
+ax_pose 6, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSeviperPose210:
+ax_pose 3, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+.align 2
+sSeviperAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_2_1:
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 8, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 2, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, 3, 0, 3,
+ax_anim 2, 0, 26, 0, 8, 0, 8,
+ax_anim 2, 1, 26, 1, 8, 1, 8,
+ax_anim 2, 0, 26, 0, 8, 0, 8,
+ax_anim 2, 0, 26, 1, 8, 1, 8,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSeviperAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -5, -5,
+ax_anim 8, 0, 28, -6, -6, -6, -6,
+ax_anim 1, 0, 27, 2, 2, 2, 2,
+ax_anim 1, 2, 29, 6, 5, 6, 5,
+ax_anim 1, 0, 29, 9, 8, 9, 8,
+ax_anim 2, 0, 29, 12, 12, 12, 12,
+ax_anim 2, 1, 29, 13, 11, 13, 11,
+ax_anim 2, 0, 29, 12, 12, 12, 12,
+ax_anim 2, 0, 29, 13, 11, 13, 11,
+ax_anim 2, 0, 27, 7, 7, 7, 7,
+ax_anim_terminator
+sSeviperAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 8, 0, 31, -6, 0, -6, 0,
+ax_anim 1, 0, 30, 1, 0, 1, 0,
+ax_anim 1, 2, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 32, 2, 0, 2, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim 2, 1, 32, 6, 1, 6, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim 2, 0, 32, 6, 1, 6, 1,
+ax_anim 2, 0, 30, 3, 0, 3, 0,
+ax_anim_terminator
+sSeviperAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 8, 0, 34, -3, 3, -3, 3,
+ax_anim 1, 0, 33, 2, -2, 2, -2,
+ax_anim 1, 2, 35, 6, -7, 6, -7,
+ax_anim 1, 0, 35, 11, -13, 11, -13,
+ax_anim 2, 0, 35, 15, -18, 15, -18,
+ax_anim 2, 1, 35, 16, -17, 16, -17,
+ax_anim 2, 0, 35, 15, -18, 15, -18,
+ax_anim 2, 0, 35, 16, -17, 16, -17,
+ax_anim 2, 0, 33, 7, -8, 7, -8,
+ax_anim_terminator
+sSeviperAnims_2_5:
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 8, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -3, 0, -3,
+ax_anim 1, 0, 38, 0, -7, 0, -7,
+ax_anim 2, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 1, 38, 1, -11, 1, -11,
+ax_anim 2, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 38, 1, -11, 1, -11,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSeviperAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 8, 0, 40, 3, 3, 3, 3,
+ax_anim 1, 0, 39, -2, -2, -2, -2,
+ax_anim 1, 2, 41, -6, -7, -6, -7,
+ax_anim 1, 0, 41, -11, -13, -11, -13,
+ax_anim 2, 0, 41, -15, -18, -15, -18,
+ax_anim 2, 1, 41, -16, -17, -16, -17,
+ax_anim 2, 0, 41, -15, -18, -15, -18,
+ax_anim 2, 0, 41, -16, -17, -16, -17,
+ax_anim 2, 0, 39, -7, -8, -7, -8,
+ax_anim_terminator
+sSeviperAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 8, 0, 43, 6, 0, 6, 0,
+ax_anim 1, 0, 42, -1, 0, -1, 0,
+ax_anim 1, 2, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 44, -2, 0, -2, 0,
+ax_anim 2, 0, 44, -6, 0, -6, 0,
+ax_anim 2, 1, 44, -6, 1, -6, 1,
+ax_anim 2, 0, 44, -6, 0, -6, 0,
+ax_anim 2, 0, 44, -6, 1, -6, 1,
+ax_anim 2, 0, 42, -3, 0, -3, 0,
+ax_anim_terminator
+sSeviperAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 5, -5,
+ax_anim 8, 0, 46, 6, -6, 6, -6,
+ax_anim 1, 0, 45, -2, 2, -2, 2,
+ax_anim 1, 2, 47, -6, 5, -6, 5,
+ax_anim 1, 0, 47, -9, 8, -9, 8,
+ax_anim 2, 0, 47, -12, 12, -12, 12,
+ax_anim 2, 1, 47, -13, 11, -13, 11,
+ax_anim 2, 0, 47, -12, 12, -12, 12,
+ax_anim 2, 0, 47, -13, 11, -13, 11,
+ax_anim 2, 0, 45, -7, 7, -7, 7,
+ax_anim_terminator
+.align 2
+sSeviperAnims_3_1:
+ax_anim 1, 0, 48, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, -5, 0, -5,
+ax_anim 6, 2, 49, 0, -6, 0, -6,
+ax_anim 1, 0, 51, 0, 5, 0, 1,
+ax_anim 2, 1, 50, 0, 8, 0, 5,
+ax_anim 2, 0, 51, 0, 10, 0, 7,
+ax_anim 2, 0, 50, 0, 8, 0, 5,
+ax_anim 2, 0, 51, 0, 10, 0, 7,
+ax_anim 2, 0, 50, 0, 8, 0, 5,
+ax_anim 2, 0, 51, 0, 10, 0, 7,
+ax_anim 2, 0, 48, 0, 8, 0, 5,
+ax_anim 2, 0, 48, 0, 4, 0, 1,
+ax_anim_terminator
+sSeviperAnims_3_2:
+ax_anim 1, 0, 52, -1, -1, 0, 0,
+ax_anim 2, 0, 53, 1, -1, -3, -3,
+ax_anim 6, 2, 53, -1, -4, -4, -4,
+ax_anim 1, 0, 55, 6, 8, 6, 8,
+ax_anim 2, 1, 54, 10, 13, 10, 13,
+ax_anim 2, 0, 55, 11, 14, 11, 14,
+ax_anim 2, 0, 54, 10, 13, 10, 13,
+ax_anim 2, 0, 55, 11, 14, 11, 14,
+ax_anim 2, 0, 54, 10, 13, 10, 13,
+ax_anim 2, 0, 55, 11, 14, 11, 14,
+ax_anim 2, 0, 52, 7, 9, 7, 9,
+ax_anim 2, 0, 52, 2, 2, 2, 2,
+ax_anim_terminator
+sSeviperAnims_3_3:
+ax_anim 1, 0, 56, -1, 0, -1, 0,
+ax_anim 2, 0, 57, -4, 0, -4, 0,
+ax_anim 6, 2, 57, -5, 0, -5, 0,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 1, 58, 6, 0, 6, 0,
+ax_anim 2, 0, 59, 7, 0, 7, 0,
+ax_anim 2, 0, 58, 6, 0, 6, 0,
+ax_anim 2, 0, 59, 7, 0, 7, 0,
+ax_anim 2, 0, 58, 6, 0, 6, 0,
+ax_anim 2, 0, 59, 7, 0, 7, 0,
+ax_anim 2, 0, 56, 5, 0, 5, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim_terminator
+sSeviperAnims_3_4:
+ax_anim 1, 0, 60, -1, 1, -1, 1,
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 6, 2, 61, -4, 4, -4, 4,
+ax_anim 1, 0, 63, 3, -5, 3, -5,
+ax_anim 2, 1, 62, 12, -15, 12, -15,
+ax_anim 2, 0, 63, 13, -16, 13, -16,
+ax_anim 2, 0, 62, 12, -15, 12, -15,
+ax_anim 2, 0, 63, 13, -16, 13, -16,
+ax_anim 2, 0, 62, 12, -15, 12, -15,
+ax_anim 2, 0, 63, 13, -16, 13, -16,
+ax_anim 2, 0, 60, 9, -10, 7, -9,
+ax_anim 2, 0, 60, 4, -5, 3, -3,
+ax_anim_terminator
+sSeviperAnims_3_5:
+ax_anim 1, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 0, 65, 0, 2, 0, 2,
+ax_anim 6, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 67, 0, -4, 0, -4,
+ax_anim 2, 1, 66, 0, -11, 0, -11,
+ax_anim 2, 0, 67, 0, -15, 0, -15,
+ax_anim 2, 0, 66, 0, -11, 0, -11,
+ax_anim 2, 0, 67, 0, -15, 0, -15,
+ax_anim 2, 0, 66, 0, -11, 0, -11,
+ax_anim 2, 0, 67, 0, -15, 0, -15,
+ax_anim 2, 0, 64, 0, -8, 0, -8,
+ax_anim 2, 0, 64, 0, -4, 0, -4,
+ax_anim_terminator
+sSeviperAnims_3_6:
+ax_anim 1, 0, 68, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 6, 2, 69, 4, 4, 4, 4,
+ax_anim 1, 0, 71, -3, -5, -3, -5,
+ax_anim 2, 1, 70, -12, -15, -12, -15,
+ax_anim 2, 0, 71, -13, -16, -13, -16,
+ax_anim 2, 0, 70, -12, -15, -12, -15,
+ax_anim 2, 0, 71, -13, -16, -13, -16,
+ax_anim 2, 0, 70, -12, -15, -12, -15,
+ax_anim 2, 0, 71, -13, -16, -13, -16,
+ax_anim 2, 0, 68, -9, -10, -7, -9,
+ax_anim 2, 0, 68, -4, -5, -3, -3,
+ax_anim_terminator
+sSeviperAnims_3_7:
+ax_anim 1, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 4, 0, 4, 0,
+ax_anim 6, 2, 73, 5, 0, 5, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 74, -6, 0, -6, 0,
+ax_anim 2, 0, 75, -7, 0, -7, 0,
+ax_anim 2, 0, 74, -6, 0, -6, 0,
+ax_anim 2, 0, 75, -7, 0, -7, 0,
+ax_anim 2, 0, 74, -6, 0, -6, 0,
+ax_anim 2, 0, 75, -7, 0, -7, 0,
+ax_anim 2, 0, 72, -5, 0, -5, 0,
+ax_anim 2, 0, 72, -2, 0, -2, 0,
+ax_anim_terminator
+sSeviperAnims_3_8:
+ax_anim 1, 0, 76, 1, -1, 0, 0,
+ax_anim 2, 0, 77, -1, -1, 3, -3,
+ax_anim 6, 2, 77, 1, -4, 4, -4,
+ax_anim 1, 0, 79, -6, 8, -6, 8,
+ax_anim 2, 1, 78, -10, 13, -10, 13,
+ax_anim 2, 0, 79, -11, 14, -11, 14,
+ax_anim 2, 0, 78, -10, 13, -10, 13,
+ax_anim 2, 0, 79, -11, 14, -11, 14,
+ax_anim 2, 0, 78, -10, 13, -10, 13,
+ax_anim 2, 0, 79, -11, 14, -11, 14,
+ax_anim 2, 0, 76, -7, 9, -7, 9,
+ax_anim 2, 0, 76, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSeviperAnims_4_1:
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 6, 2, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim_terminator
+sSeviperAnims_4_2:
+ax_anim 2, 0, 84, 0, -1, -4, -4,
+ax_anim 6, 2, 84, -1, -2, -5, -5,
+ax_anim 2, 0, 83, -1, -1, -3, -2,
+ax_anim 2, 1, 85, 3, 3, 1, 2,
+ax_anim 2, 0, 85, 4, 2, 2, 1,
+ax_anim 2, 0, 85, 3, 3, 1, 2,
+ax_anim 2, 0, 85, 4, 2, 2, 1,
+ax_anim 2, 0, 85, 3, 3, 1, 2,
+ax_anim 2, 0, 85, 4, 2, 2, 1,
+ax_anim 2, 0, 85, 3, 3, 1, 2,
+ax_anim 2, 0, 83, 1, 1, 1, 1,
+ax_anim_terminator
+sSeviperAnims_4_3:
+ax_anim 2, 0, 87, 0, 0, -2, 0,
+ax_anim 6, 2, 87, -1, 0, -3, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 1, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 2, 1, 2, 1,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 2, 1, 2, 1,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 2, 1, 2, 1,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim_terminator
+sSeviperAnims_4_4:
+ax_anim 2, 0, 90, -2, 2, -2, 2,
+ax_anim 6, 2, 90, -3, 3, -3, 3,
+ax_anim 2, 0, 89, -1, 1, -1, 1,
+ax_anim 2, 1, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -3,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -3,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 1, -3, 1, -3,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 89, 1, -1, 1, -1,
+ax_anim_terminator
+sSeviperAnims_4_5:
+ax_anim 2, 0, 93, 0, 2, 0, 1,
+ax_anim 6, 2, 93, 0, 3, 0, 3,
+ax_anim 2, 0, 92, 0, -1, 0, -1,
+ax_anim 2, 1, 94, 0, -6, 0, -6,
+ax_anim 2, 0, 94, 1, -6, 1, -6,
+ax_anim 2, 0, 94, 0, -6, 0, -6,
+ax_anim 2, 0, 94, 1, -6, 1, -6,
+ax_anim 2, 0, 94, 0, -6, 0, -6,
+ax_anim 2, 0, 94, 1, -6, 1, -6,
+ax_anim 2, 0, 94, 0, -6, 0, -6,
+ax_anim 2, 0, 92, 0, -2, 0, -2,
+ax_anim_terminator
+sSeviperAnims_4_6:
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 6, 2, 96, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 1, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -1, -3, -1, -3,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim_terminator
+sSeviperAnims_4_7:
+ax_anim 2, 0, 99, 0, 0, 2, 0,
+ax_anim 6, 2, 99, 1, 0, 3, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 1, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -2, 1, -2, 1,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -2, 1, -2, 1,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -2, 1, -2, 1,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim_terminator
+sSeviperAnims_4_8:
+ax_anim 2, 0, 102, 0, -1, 4, -4,
+ax_anim 6, 2, 102, 1, -2, 5, -5,
+ax_anim 2, 0, 101, 1, -1, 3, -2,
+ax_anim 2, 1, 103, -3, 3, -1, 2,
+ax_anim 2, 0, 103, -4, 2, -2, 1,
+ax_anim 2, 0, 103, -3, 3, -1, 2,
+ax_anim 2, 0, 103, -4, 2, -2, 1,
+ax_anim 2, 0, 103, -3, 3, -1, 2,
+ax_anim 2, 0, 103, -4, 2, -2, 1,
+ax_anim 2, 0, 103, -3, 3, -1, 2,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSeviperAnims_5_1:
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 2, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_5_2:
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 2, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 3, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_5_3:
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 2, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim 3, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_5_4:
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 2, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 3, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_5_5:
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 2, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_5_6:
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 2, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_5_7:
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 2, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_5_8:
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 2, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sSeviperAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sSeviperAnims_7_3:
+ax_anim 2, 0, 124, -6, 0, -6, 0,
+ax_anim 8, 0, 124, -7, 0, -7, 0,
+ax_anim_terminator
+sSeviperAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sSeviperAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sSeviperAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sSeviperAnims_7_7:
+ax_anim 2, 0, 128, 6, 0, 6, 0,
+ax_anim 8, 0, 128, 7, 0, 7, 0,
+ax_anim_terminator
+sSeviperAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSeviperAnims_8_1:
+ax_anim 14, 0, 130, 0, 0, 0, 0,
+ax_anim 18, 0, 131, 0, 0, 0, 0,
+ax_anim 14, 0, 130, 0, 0, 0, 0,
+ax_anim 18, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_8_2:
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim 18, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 133, 0, 0, 0, 0,
+ax_anim 18, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_8_3:
+ax_anim 14, 0, 136, 0, 0, 0, 0,
+ax_anim 18, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 136, 0, 0, 0, 0,
+ax_anim 18, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_8_4:
+ax_anim 14, 0, 139, 0, 0, 0, 0,
+ax_anim 18, 0, 140, 0, 0, 0, 0,
+ax_anim 14, 0, 139, 0, 0, 0, 0,
+ax_anim 18, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_8_5:
+ax_anim 14, 0, 142, 0, 0, 0, 0,
+ax_anim 18, 0, 143, 0, 0, 0, 0,
+ax_anim 14, 0, 142, 0, 0, 0, 0,
+ax_anim 18, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_8_6:
+ax_anim 14, 0, 145, 0, 0, 0, 0,
+ax_anim 18, 0, 146, 0, 0, 0, 0,
+ax_anim 14, 0, 145, 0, 0, 0, 0,
+ax_anim 18, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_8_7:
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim 18, 0, 149, 0, 0, 0, 0,
+ax_anim 14, 0, 148, 0, 0, 0, 0,
+ax_anim 18, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_8_8:
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim 18, 0, 152, 0, 0, 0, 0,
+ax_anim 14, 0, 151, 0, 0, 0, 0,
+ax_anim 18, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 9, 3, 9, 3,
+ax_anim 2, 0, 156, 13, 9, 13, 9,
+ax_anim 2, 0, 157, 10, 15, 10, 15,
+ax_anim 3, 0, 158, 0, 15, 0, 15,
+ax_anim 2, 3, 159, -10, 15, -10, 15,
+ax_anim 2, 0, 160, -13, 9, -13, 9,
+ax_anim 1, 0, 161, -9, 3, -9, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 155, 20, 3, 20, 3,
+ax_anim 2, 0, 156, 26, 13, 26, 13,
+ax_anim 3, 0, 157, 22, 17, 22, 17,
+ax_anim 2, 3, 158, 11, 19, 11, 19,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 10, -6, 10, -6,
+ax_anim 2, 0, 155, 19, -5, 19, -5,
+ax_anim 3, 0, 156, 23, 0, 23, 0,
+ax_anim 2, 3, 157, 21, 3, 21, 3,
+ax_anim 2, 0, 158, 12, 6, 12, 6,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -2, -6, -2, -6,
+ax_anim 2, 0, 161, 2, -16, 2, -16,
+ax_anim 2, 0, 154, 12, -21, 12, -21,
+ax_anim 3, 0, 155, 23, -18, 23, -18,
+ax_anim 2, 3, 156, 27, -10, 27, -10,
+ax_anim 2, 0, 157, 20, -4, 20, -4,
+ax_anim 1, 0, 158, 8, 0, 8, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -3, -8, -3,
+ax_anim 2, 0, 160, -11, -8, -11, -8,
+ax_anim 2, 0, 161, -8, -17, -8, -17,
+ax_anim 3, 0, 154, 0, -20, 0, -20,
+ax_anim 2, 3, 155, 8, -17, 8, -17,
+ax_anim 2, 0, 156, 11, -8, 11, -8,
+ax_anim 1, 0, 157, 8, -3, 8, -3,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 2, -6, 2, -6,
+ax_anim 2, 0, 155, -2, -16, -2, -16,
+ax_anim 2, 0, 154, -12, -21, -12, -21,
+ax_anim 3, 0, 161, -23, -18, -23, -18,
+ax_anim 2, 3, 160, -27, -10, -27, -10,
+ax_anim 2, 0, 159, -20, -4, -20, -4,
+ax_anim 1, 0, 158, -8, 0, -8, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -10, -6, -10, -6,
+ax_anim 2, 0, 161, -19, -5, -19, -5,
+ax_anim 3, 0, 160, -23, 0, -23, 0,
+ax_anim 2, 3, 159, -21, 3, -21, 3,
+ax_anim 2, 0, 158, -12, 6, -12, 6,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 161, -20, 3, -20, 3,
+ax_anim 2, 0, 160, -26, 13, -26, 13,
+ax_anim 3, 0, 159, -22, 17, -22, 17,
+ax_anim 2, 3, 158, -11, 19, -11, 19,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -25, 0, 0,
+ax_anim 3, 0, 172, 0, -23, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -25, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -21, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -24, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -25, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSeviperAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSeviperGfx1:
+.incbin "baserom.gba", 0x13BBA38, 0x200
+sSeviperSprites1:
+ax_sprite sSeviperGfx1, 0x200
+ax_sprite_terminator
+sSeviperGfx2:
+.incbin "baserom.gba", 0x13BBC48, 0x200
+sSeviperSprites2:
+ax_sprite sSeviperGfx2, 0x200
+ax_sprite_terminator
+sSeviperGfx3:
+.incbin "baserom.gba", 0x13BBE58, 0x200
+sSeviperSprites3:
+ax_sprite sSeviperGfx3, 0x200
+ax_sprite_terminator
+sSeviperGfx4:
+.incbin "baserom.gba", 0x13BC068, 0x200
+sSeviperSprites4:
+ax_sprite sSeviperGfx4, 0x200
+ax_sprite_terminator
+sSeviperGfx5:
+.incbin "baserom.gba", 0x13BC278, 0x200
+sSeviperSprites5:
+ax_sprite sSeviperGfx5, 0x200
+ax_sprite_terminator
+sSeviperGfx6:
+.incbin "baserom.gba", 0x13BC488, 0x200
+sSeviperSprites6:
+ax_sprite sSeviperGfx6, 0x200
+ax_sprite_terminator
+sSeviperGfx7:
+.incbin "baserom.gba", 0x13BC698, 0x200
+sSeviperSprites7:
+ax_sprite sSeviperGfx7, 0x200
+ax_sprite_terminator
+sSeviperGfx8:
+.incbin "baserom.gba", 0x13BC8A8, 0x200
+sSeviperSprites8:
+ax_sprite sSeviperGfx8, 0x200
+ax_sprite_terminator
+sSeviperGfx9:
+.incbin "baserom.gba", 0x13BCAB8, 0x200
+sSeviperSprites9:
+ax_sprite sSeviperGfx9, 0x200
+ax_sprite_terminator
+sSeviperGfx10:
+.incbin "baserom.gba", 0x13BCCC8, 0x200
+sSeviperSprites10:
+ax_sprite sSeviperGfx10, 0x200
+ax_sprite_terminator
+sSeviperGfx11:
+.incbin "baserom.gba", 0x13BCED8, 0x200
+sSeviperSprites11:
+ax_sprite sSeviperGfx11, 0x200
+ax_sprite_terminator
+sSeviperGfx12:
+.incbin "baserom.gba", 0x13BD0E8, 0x200
+sSeviperSprites12:
+ax_sprite sSeviperGfx12, 0x200
+ax_sprite_terminator
+sSeviperGfx13:
+.incbin "baserom.gba", 0x13BD2F8, 0x100
+sSeviperSprites13:
+ax_sprite sSeviperGfx13, 0x100
+ax_sprite_terminator
+sSeviperGfx14:
+.incbin "baserom.gba", 0x13BD408, 0x200
+sSeviperSprites14:
+ax_sprite sSeviperGfx14, 0x200
+ax_sprite_terminator
+sSeviperGfx15:
+.incbin "baserom.gba", 0x13BD618, 0x100
+sSeviperSprites15:
+ax_sprite sSeviperGfx15, 0x100
+ax_sprite_terminator
+sSeviperGfx16:
+.incbin "baserom.gba", 0x13BD728, 0x200
+sSeviperSprites16:
+ax_sprite sSeviperGfx16, 0x200
+ax_sprite_terminator
+sSeviperGfx17:
+.incbin "baserom.gba", 0x13BD938, 0x200
+sSeviperSprites17:
+ax_sprite sSeviperGfx17, 0x200
+ax_sprite_terminator
+sSeviperGfx18:
+.incbin "baserom.gba", 0x13BDB48, 0x200
+sSeviperSprites18:
+ax_sprite sSeviperGfx18, 0x200
+ax_sprite_terminator
+sSeviperGfx19:
+.incbin "baserom.gba", 0x13BDD58, 0x200
+sSeviperSprites19:
+ax_sprite sSeviperGfx19, 0x200
+ax_sprite_terminator
+sSeviperGfx20:
+.incbin "baserom.gba", 0x13BDF68, 0x200
+sSeviperSprites20:
+ax_sprite sSeviperGfx20, 0x200
+ax_sprite_terminator
+sSeviperGfx21:
+.incbin "baserom.gba", 0x13BE178, 0x200
+sSeviperSprites21:
+ax_sprite sSeviperGfx21, 0x200
+ax_sprite_terminator
+sSeviperGfx22:
+.incbin "baserom.gba", 0x13BE388, 0x200
+sSeviperSprites22:
+ax_sprite sSeviperGfx22, 0x200
+ax_sprite_terminator
+sSeviperGfx23:
+.incbin "baserom.gba", 0x13BE598, 0x200
+sSeviperSprites23:
+ax_sprite sSeviperGfx23, 0x200
+ax_sprite_terminator
+sSeviperGfx24:
+.incbin "baserom.gba", 0x13BE7A8, 0x200
+sSeviperSprites24:
+ax_sprite sSeviperGfx24, 0x200
+ax_sprite_terminator
+sSeviperGfx25:
+.incbin "baserom.gba", 0x13BE9B8, 0x60
+sSeviperGfx25_1:
+.incbin "baserom.gba", 0x13BEA18, 0x60
+sSeviperGfx25_2:
+.incbin "baserom.gba", 0x13BEA78, 0x60
+sSeviperGfx25_3:
+.incbin "baserom.gba", 0x13BEAD8, 0x40
+sSeviperSprites25:
+ax_sprite sSeviperGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSeviperGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeviperGfx26:
+.incbin "baserom.gba", 0x13BEB60, 0x100
+sSeviperSprites26:
+ax_sprite sSeviperGfx26, 0x100
+ax_sprite_terminator
+sSeviperGfx27:
+.incbin "baserom.gba", 0x13BEC70, 0x20
+sSeviperSprites27:
+ax_sprite sSeviperGfx27, 0x20
+ax_sprite_terminator
+sSeviperGfx28:
+.incbin "baserom.gba", 0x13BECA0, 0x80
+sSeviperSprites28:
+ax_sprite sSeviperGfx28, 0x80
+ax_sprite_terminator
+sSeviperGfx29:
+.incbin "baserom.gba", 0x13BED30, 0x60
+sSeviperGfx29_1:
+.incbin "baserom.gba", 0x13BED90, 0x60
+sSeviperGfx29_2:
+.incbin "baserom.gba", 0x13BEDF0, 0x60
+sSeviperGfx29_3:
+.incbin "baserom.gba", 0x13BEE50, 0x60
+sSeviperSprites29:
+ax_sprite sSeviperGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeviperGfx30:
+.incbin "baserom.gba", 0x13BEEF8, 0x40
+sSeviperSprites30:
+ax_sprite sSeviperGfx30, 0x40
+ax_sprite_terminator
+sSeviperGfx31:
+.incbin "baserom.gba", 0x13BEF48, 0x80
+sSeviperSprites31:
+ax_sprite sSeviperGfx31, 0x80
+ax_sprite_terminator
+sSeviperGfx32:
+.incbin "baserom.gba", 0x13BEFD8, 0x20
+sSeviperSprites32:
+ax_sprite sSeviperGfx32, 0x20
+ax_sprite_terminator
+sSeviperGfx33:
+.incbin "baserom.gba", 0x13BF008, 0x40
+sSeviperSprites33:
+ax_sprite sSeviperGfx33, 0x40
+ax_sprite_terminator
+sSeviperGfx34:
+.incbin "baserom.gba", 0x13BF058, 0x20
+sSeviperSprites34:
+ax_sprite sSeviperGfx34, 0x20
+ax_sprite_terminator
+sSeviperGfx35:
+.incbin "baserom.gba", 0x13BF088, 0x80
+sSeviperSprites35:
+ax_sprite sSeviperGfx35, 0x80
+ax_sprite_terminator
+sSeviperGfx36:
+.incbin "baserom.gba", 0x13BF118, 0x40
+sSeviperSprites36:
+ax_sprite sSeviperGfx36, 0x40
+ax_sprite_terminator
+sSeviperGfx37:
+.incbin "baserom.gba", 0x13BF168, 0x1C0
+sSeviperSprites37:
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx37, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeviperGfx38:
+.incbin "baserom.gba", 0x13BF348, 0x100
+sSeviperSprites38:
+ax_sprite sSeviperGfx38, 0x100
+ax_sprite_terminator
+sSeviperGfx39:
+.incbin "baserom.gba", 0x13BF458, 0x20
+sSeviperSprites39:
+ax_sprite sSeviperGfx39, 0x20
+ax_sprite_terminator
+sSeviperGfx40:
+.incbin "baserom.gba", 0x13BF488, 0x20
+sSeviperSprites40:
+ax_sprite sSeviperGfx40, 0x20
+ax_sprite_terminator
+sSeviperGfx41:
+.incbin "baserom.gba", 0x13BF4B8, 0x40
+sSeviperSprites41:
+ax_sprite sSeviperGfx41, 0x40
+ax_sprite_terminator
+sSeviperGfx42:
+.incbin "baserom.gba", 0x13BF508, 0x80
+sSeviperSprites42:
+ax_sprite sSeviperGfx42, 0x80
+ax_sprite_terminator
+sSeviperGfx43:
+.incbin "baserom.gba", 0x13BF598, 0x1C0
+sSeviperSprites43:
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx43, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSeviperGfx44:
+.incbin "baserom.gba", 0x13BF778, 0x80
+sSeviperSprites44:
+ax_sprite sSeviperGfx44, 0x80
+ax_sprite_terminator
+sSeviperGfx45:
+.incbin "baserom.gba", 0x13BF808, 0x40
+sSeviperSprites45:
+ax_sprite sSeviperGfx45, 0x40
+ax_sprite_terminator
+sSeviperGfx46:
+.incbin "baserom.gba", 0x13BF858, 0x20
+sSeviperSprites46:
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx46, 0x20
+ax_sprite_terminator
+sSeviperGfx47:
+.incbin "baserom.gba", 0x13BF890, 0x100
+sSeviperSprites47:
+ax_sprite sSeviperGfx47, 0x100
+ax_sprite_terminator
+sSeviperGfx48:
+.incbin "baserom.gba", 0x13BF9A0, 0x100
+sSeviperSprites48:
+ax_sprite sSeviperGfx48, 0x100
+ax_sprite_terminator
+sSeviperGfx49:
+.incbin "baserom.gba", 0x13BFAB0, 0x80
+sSeviperSprites49:
+ax_sprite sSeviperGfx49, 0x80
+ax_sprite_terminator
+sSeviperGfx50:
+.incbin "baserom.gba", 0x13BFB40, 0x20
+sSeviperSprites50:
+ax_sprite sSeviperGfx50, 0x20
+ax_sprite_terminator
+sSeviperGfx51:
+.incbin "baserom.gba", 0x13BFB70, 0x100
+sSeviperSprites51:
+ax_sprite sSeviperGfx51, 0x100
+ax_sprite_terminator
+sSeviperGfx52:
+.incbin "baserom.gba", 0x13BFC80, 0x40
+sSeviperSprites52:
+ax_sprite sSeviperGfx52, 0x40
+ax_sprite_terminator
+sSeviperGfx53:
+.incbin "baserom.gba", 0x13BFCD0, 0x80
+sSeviperSprites53:
+ax_sprite sSeviperGfx53, 0x80
+ax_sprite_terminator
+sSeviperGfx54:
+.incbin "baserom.gba", 0x13BFD60, 0x60
+sSeviperGfx54_1:
+.incbin "baserom.gba", 0x13BFDC0, 0x100
+sSeviperGfx54_2:
+.incbin "baserom.gba", 0x13BFEC0, 0x60
+sSeviperSprites54:
+ax_sprite sSeviperGfx54, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx54_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx54_2, 0x60
+ax_sprite_terminator
+sSeviperGfx55:
+.incbin "baserom.gba", 0x13BFF50, 0x80
+sSeviperGfx55_1:
+.incbin "baserom.gba", 0x13BFFD0, 0x60
+sSeviperSprites55:
+ax_sprite sSeviperGfx55, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx55_1, 0x60
+ax_sprite_terminator
+sSeviperGfx56:
+.incbin "baserom.gba", 0x13C0050, 0x20
+sSeviperGfx56_1:
+.incbin "baserom.gba", 0x13C0070, 0x40
+sSeviperSprites56:
+ax_sprite sSeviperGfx56, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx56_1, 0x40
+ax_sprite_terminator
+sSeviperGfx57:
+.incbin "baserom.gba", 0x13C00D0, 0x40
+sSeviperSprites57:
+ax_sprite sSeviperGfx57, 0x40
+ax_sprite_terminator
+sSeviperGfx58:
+.incbin "baserom.gba", 0x13C0120, 0x40
+sSeviperSprites58:
+ax_sprite sSeviperGfx58, 0x40
+ax_sprite_terminator
+sSeviperGfx59:
+.incbin "baserom.gba", 0x13C0170, 0x60
+sSeviperGfx59_1:
+.incbin "baserom.gba", 0x13C01D0, 0x100
+sSeviperGfx59_2:
+.incbin "baserom.gba", 0x13C02D0, 0x60
+sSeviperSprites59:
+ax_sprite sSeviperGfx59, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx59_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx59_2, 0x60
+ax_sprite_terminator
+sSeviperGfx60:
+.incbin "baserom.gba", 0x13C0360, 0x100
+sSeviperSprites60:
+ax_sprite sSeviperGfx60, 0x100
+ax_sprite_terminator
+sSeviperGfx61:
+.incbin "baserom.gba", 0x13C0470, 0x80
+sSeviperSprites61:
+ax_sprite sSeviperGfx61, 0x80
+ax_sprite_terminator
+sSeviperGfx62:
+.incbin "baserom.gba", 0x13C0500, 0x80
+sSeviperSprites62:
+ax_sprite sSeviperGfx62, 0x80
+ax_sprite_terminator
+sSeviperGfx63:
+.incbin "baserom.gba", 0x13C0590, 0x20
+sSeviperSprites63:
+ax_sprite sSeviperGfx63, 0x20
+ax_sprite_terminator
+sSeviperGfx64:
+.incbin "baserom.gba", 0x13C05C0, 0x60
+sSeviperGfx64_1:
+.incbin "baserom.gba", 0x13C0620, 0x60
+sSeviperGfx64_2:
+.incbin "baserom.gba", 0x13C0680, 0x60
+sSeviperGfx64_3:
+.incbin "baserom.gba", 0x13C06E0, 0x60
+sSeviperSprites64:
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx64, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx64_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx64_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx64_3, 0x60
+ax_sprite_terminator
+sSeviperGfx65:
+.incbin "baserom.gba", 0x13C0788, 0x80
+sSeviperSprites65:
+ax_sprite sSeviperGfx65, 0x80
+ax_sprite_terminator
+sSeviperGfx66:
+.incbin "baserom.gba", 0x13C0818, 0x80
+sSeviperSprites66:
+ax_sprite sSeviperGfx66, 0x80
+ax_sprite_terminator
+sSeviperGfx67:
+.incbin "baserom.gba", 0x13C08A8, 0x20
+sSeviperSprites67:
+ax_sprite sSeviperGfx67, 0x20
+ax_sprite_terminator
+sSeviperGfx68:
+.incbin "baserom.gba", 0x13C08D8, 0x40
+sSeviperSprites68:
+ax_sprite sSeviperGfx68, 0x40
+ax_sprite_terminator
+sSeviperGfx69:
+.incbin "baserom.gba", 0x13C0928, 0x20
+sSeviperSprites69:
+ax_sprite sSeviperGfx69, 0x20
+ax_sprite_terminator
+sSeviperGfx70:
+.incbin "baserom.gba", 0x13C0958, 0x20
+sSeviperSprites70:
+ax_sprite sSeviperGfx70, 0x20
+ax_sprite_terminator
+sSeviperGfx71:
+.incbin "baserom.gba", 0x13C0988, 0x20
+sSeviperSprites71:
+ax_sprite sSeviperGfx71, 0x20
+ax_sprite_terminator
+sSeviperGfx72:
+.incbin "baserom.gba", 0x13C09B8, 0x20
+sSeviperSprites72:
+ax_sprite sSeviperGfx72, 0x20
+ax_sprite_terminator
+sSeviperGfx73:
+.incbin "baserom.gba", 0x13C09E8, 0x100
+sSeviperSprites73:
+ax_sprite sSeviperGfx73, 0x100
+ax_sprite_terminator
+sSeviperGfx74:
+.incbin "baserom.gba", 0x13C0AF8, 0x20
+sSeviperSprites74:
+ax_sprite sSeviperGfx74, 0x20
+ax_sprite_terminator
+sSeviperGfx75:
+.incbin "baserom.gba", 0x13C0B28, 0x80
+sSeviperGfx75_1:
+.incbin "baserom.gba", 0x13C0BA8, 0x60
+sSeviperSprites75:
+ax_sprite sSeviperGfx75, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx75_1, 0x60
+ax_sprite_terminator
+sSeviperGfx76:
+.incbin "baserom.gba", 0x13C0C28, 0x80
+sSeviperSprites76:
+ax_sprite sSeviperGfx76, 0x80
+ax_sprite_terminator
+sSeviperGfx77:
+.incbin "baserom.gba", 0x13C0CB8, 0x20
+sSeviperSprites77:
+ax_sprite sSeviperGfx77, 0x20
+ax_sprite_terminator
+sSeviperGfx78:
+.incbin "baserom.gba", 0x13C0CE8, 0x40
+sSeviperSprites78:
+ax_sprite sSeviperGfx78, 0x40
+ax_sprite_terminator
+sSeviperGfx79:
+.incbin "baserom.gba", 0x13C0D38, 0x100
+sSeviperSprites79:
+ax_sprite sSeviperGfx79, 0x100
+ax_sprite_terminator
+sSeviperGfx80:
+.incbin "baserom.gba", 0x13C0E48, 0x80
+sSeviperSprites80:
+ax_sprite sSeviperGfx80, 0x80
+ax_sprite_terminator
+sSeviperGfx81:
+.incbin "baserom.gba", 0x13C0ED8, 0x40
+sSeviperSprites81:
+ax_sprite sSeviperGfx81, 0x40
+ax_sprite_terminator
+sSeviperGfx82:
+.incbin "baserom.gba", 0x13C0F28, 0x20
+sSeviperSprites82:
+ax_sprite sSeviperGfx82, 0x20
+ax_sprite_terminator
+sSeviperGfx83:
+.incbin "baserom.gba", 0x13C0F58, 0x20
+sSeviperSprites83:
+ax_sprite sSeviperGfx83, 0x20
+ax_sprite_terminator
+sSeviperGfx84:
+.incbin "baserom.gba", 0x13C0F88, 0x100
+sSeviperSprites84:
+ax_sprite sSeviperGfx84, 0x100
+ax_sprite_terminator
+sSeviperGfx85:
+.incbin "baserom.gba", 0x13C1098, 0x60
+sSeviperSprites85:
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx85, 0x60
+ax_sprite_terminator
+sSeviperGfx86:
+.incbin "baserom.gba", 0x13C1110, 0x40
+sSeviperSprites86:
+ax_sprite sSeviperGfx86, 0x40
+ax_sprite_terminator
+sSeviperGfx87:
+.incbin "baserom.gba", 0x13C1160, 0x20
+sSeviperSprites87:
+ax_sprite sSeviperGfx87, 0x20
+ax_sprite_terminator
+sSeviperGfx88:
+.incbin "baserom.gba", 0x13C1190, 0x100
+sSeviperSprites88:
+ax_sprite sSeviperGfx88, 0x100
+ax_sprite_terminator
+sSeviperGfx89:
+.incbin "baserom.gba", 0x13C12A0, 0x20
+sSeviperSprites89:
+ax_sprite sSeviperGfx89, 0x20
+ax_sprite_terminator
+sSeviperGfx90:
+.incbin "baserom.gba", 0x13C12D0, 0x40
+sSeviperSprites90:
+ax_sprite sSeviperGfx90, 0x40
+ax_sprite_terminator
+sSeviperGfx91:
+.incbin "baserom.gba", 0x13C1320, 0x60
+sSeviperGfx91_1:
+.incbin "baserom.gba", 0x13C1380, 0x80
+sSeviperSprites91:
+ax_sprite sSeviperGfx91, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSeviperGfx91_1, 0x80
+ax_sprite_terminator
+sSeviperGfx92:
+.incbin "baserom.gba", 0x13C1420, 0x80
+sSeviperSprites92:
+ax_sprite sSeviperGfx92, 0x80
+ax_sprite_terminator
+sSeviperGfx93:
+.incbin "baserom.gba", 0x13C14B0, 0x40
+sSeviperSprites93:
+ax_sprite sSeviperGfx93, 0x40
+ax_sprite_terminator
+sSeviperGfx94:
+.incbin "baserom.gba", 0x13C1500, 0x40
+sSeviperSprites94:
+ax_sprite sSeviperGfx94, 0x40
+ax_sprite_terminator
+sSeviperGfx95:
+.incbin "baserom.gba", 0x13C1550, 0x100
+sSeviperSprites95:
+ax_sprite sSeviperGfx95, 0x100
+ax_sprite_terminator
+sSeviperGfx96:
+.incbin "baserom.gba", 0x13C1660, 0x80
+sSeviperSprites96:
+ax_sprite sSeviperGfx96, 0x80
+ax_sprite_terminator
+sSeviperGfx97:
+.incbin "baserom.gba", 0x13C16F0, 0x40
+sSeviperSprites97:
+ax_sprite sSeviperGfx97, 0x40
+ax_sprite_terminator
+sSeviperGfx98:
+.incbin "baserom.gba", 0x13C1740, 0x20
+sSeviperSprites98:
+ax_sprite sSeviperGfx98, 0x20
+ax_sprite_terminator
+sSeviperGfx99:
+.incbin "baserom.gba", 0x13C1770, 0x20
+sSeviperSprites99:
+ax_sprite sSeviperGfx99, 0x20
+ax_sprite_terminator
+sSeviperGfx100:
+.incbin "baserom.gba", 0x13C17A0, 0x100
+sSeviperSprites100:
+ax_sprite sSeviperGfx100, 0x100
+ax_sprite_terminator
+sSeviperGfx101:
+.incbin "baserom.gba", 0x13C18B0, 0x40
+sSeviperSprites101:
+ax_sprite sSeviperGfx101, 0x40
+ax_sprite_terminator
+sSeviperGfx102:
+.incbin "baserom.gba", 0x13C1900, 0x20
+sSeviperSprites102:
+ax_sprite sSeviperGfx102, 0x20
+ax_sprite_terminator
+sSeviperGfx103:
+.incbin "baserom.gba", 0x13C1930, 0x20
+sSeviperSprites103:
+ax_sprite sSeviperGfx103, 0x20
+ax_sprite_terminator
+sSeviperGfx104:
+.incbin "baserom.gba", 0x13C1960, 0x20
+sSeviperSprites104:
+ax_sprite sSeviperGfx104, 0x20
+ax_sprite_terminator
+sSeviperGfx105:
+.incbin "baserom.gba", 0x13C1990, 0x20
+sSeviperSprites105:
+ax_sprite sSeviperGfx105, 0x20
+ax_sprite_terminator
+sSeviperGfx106:
+.incbin "baserom.gba", 0x13C19C0, 0x100
+sSeviperSprites106:
+ax_sprite sSeviperGfx106, 0x100
+ax_sprite_terminator
+sSeviperGfx107:
+.incbin "baserom.gba", 0x13C1AD0, 0x40
+sSeviperSprites107:
+ax_sprite sSeviperGfx107, 0x40
+ax_sprite_terminator
+sSeviperGfx108:
+.incbin "baserom.gba", 0x13C1B20, 0x20
+sSeviperSprites108:
+ax_sprite sSeviperGfx108, 0x20
+ax_sprite_terminator
+sSeviperGfx109:
+.incbin "baserom.gba", 0x13C1B50, 0x20
+sSeviperSprites109:
+ax_sprite sSeviperGfx109, 0x20
+ax_sprite_terminator
+sSeviperGfx110:
+.incbin "baserom.gba", 0x13C1B80, 0x100
+sSeviperSprites110:
+ax_sprite sSeviperGfx110, 0x100
+ax_sprite_terminator
+sSeviperGfx111:
+.incbin "baserom.gba", 0x13C1C90, 0x80
+sSeviperSprites111:
+ax_sprite sSeviperGfx111, 0x80
+ax_sprite_terminator
+sSeviperGfx112:
+.incbin "baserom.gba", 0x13C1D20, 0x20
+sSeviperSprites112:
+ax_sprite sSeviperGfx112, 0x20
+ax_sprite_terminator
+sSeviperGfx113:
+.incbin "baserom.gba", 0x13C1D50, 0x40
+sSeviperSprites113:
+ax_sprite sSeviperGfx113, 0x40
+ax_sprite_terminator
+sSeviperGfx114:
+.incbin "baserom.gba", 0x13C1DA0, 0x20
+sSeviperSprites114:
+ax_sprite sSeviperGfx114, 0x20
+ax_sprite_terminator
+sSeviperGfx115:
+.incbin "baserom.gba", 0x13C1DD0, 0x200
+sSeviperSprites115:
+ax_sprite sSeviperGfx115, 0x200
+ax_sprite_terminator
+sSeviperGfx116:
+.incbin "baserom.gba", 0x13C1FE0, 0x40
+sSeviperSprites116:
+ax_sprite sSeviperGfx116, 0x40
+ax_sprite_terminator
+sSeviperGfx117:
+.incbin "baserom.gba", 0x13C2030, 0x200
+sSeviperSprites117:
+ax_sprite sSeviperGfx117, 0x200
+ax_sprite_terminator
+sSeviperGfx118:
+.incbin "baserom.gba", 0x13C2240, 0x100
+sSeviperSprites118:
+ax_sprite sSeviperGfx118, 0x100
+ax_sprite_terminator
+sSeviperGfx119:
+.incbin "baserom.gba", 0x13C2350, 0x20
+sSeviperSprites119:
+ax_sprite sSeviperGfx119, 0x20
+ax_sprite_terminator
+sSeviperGfx120:
+.incbin "baserom.gba", 0x13C2380, 0x20
+sSeviperSprites120:
+ax_sprite sSeviperGfx120, 0x20
+ax_sprite_terminator
+sSeviperGfx121:
+.incbin "baserom.gba", 0x13C23B0, 0x200
+sSeviperSprites121:
+ax_sprite sSeviperGfx121, 0x200
+ax_sprite_terminator
+sSeviperGfx122:
+.incbin "baserom.gba", 0x13C25C0, 0x200
+sSeviperSprites122:
+ax_sprite sSeviperGfx122, 0x200
+ax_sprite_terminator
+sSeviperGfx123:
+.incbin "baserom.gba", 0x13C27D0, 0x40
+sSeviperSprites123:
+ax_sprite sSeviperGfx123, 0x40
+ax_sprite_terminator
+sSeviperGfx124:
+.incbin "baserom.gba", 0x13C2820, 0x100
+sSeviperSprites124:
+ax_sprite sSeviperGfx124, 0x100
+ax_sprite_terminator
+sSeviperGfx125:
+.incbin "baserom.gba", 0x13C2930, 0x80
+sSeviperSprites125:
+ax_sprite sSeviperGfx125, 0x80
+ax_sprite_terminator
+sSeviperGfx126:
+.incbin "baserom.gba", 0x13C29C0, 0x40
+sSeviperSprites126:
+ax_sprite sSeviperGfx126, 0x40
+ax_sprite_terminator
+sSeviperGfx127:
+.incbin "baserom.gba", 0x13C2A10, 0x20
+sSeviperSprites127:
+ax_sprite sSeviperGfx127, 0x20
+ax_sprite_terminator
+sSeviperGfx128:
+.incbin "baserom.gba", 0x13C2A40, 0x20
+sSeviperSprites128:
+ax_sprite sSeviperGfx128, 0x20
+ax_sprite_terminator
+sSeviperGfx129:
+.incbin "baserom.gba", 0x13C2A70, 0x200
+sSeviperSprites129:
+ax_sprite sSeviperGfx129, 0x200
+ax_sprite_terminator
+sSeviperGfx130:
+.incbin "baserom.gba", 0x13C2C80, 0x200
+sSeviperSprites130:
+ax_sprite sSeviperGfx130, 0x200
+ax_sprite_terminator
+sSeviperGfx131:
+.incbin "baserom.gba", 0x13C2E90, 0x100
+sSeviperSprites131:
+ax_sprite sSeviperGfx131, 0x100
+ax_sprite_terminator
+sSeviperGfx132:
+.incbin "baserom.gba", 0x13C2FA0, 0x40
+sSeviperSprites132:
+ax_sprite sSeviperGfx132, 0x40
+ax_sprite_terminator
+sSeviperGfx133:
+.incbin "baserom.gba", 0x13C2FF0, 0x40
+sSeviperSprites133:
+ax_sprite sSeviperGfx133, 0x40
+ax_sprite_terminator
+sSeviperGfx134:
+.incbin "baserom.gba", 0x13C3040, 0x80
+sSeviperSprites134:
+ax_sprite sSeviperGfx134, 0x80
+ax_sprite_terminator
+sSeviperGfx135:
+.incbin "baserom.gba", 0x13C30D0, 0x200
+sSeviperSprites135:
+ax_sprite sSeviperGfx135, 0x200
+ax_sprite_terminator
+sSeviperGfx136:
+.incbin "baserom.gba", 0x13C32E0, 0x40
+sSeviperSprites136:
+ax_sprite sSeviperGfx136, 0x40
+ax_sprite_terminator
+sSeviperGfx137:
+.incbin "baserom.gba", 0x13C3330, 0x40
+sSeviperSprites137:
+ax_sprite sSeviperGfx137, 0x40
+ax_sprite_terminator
+sSeviperGfx138:
+.incbin "baserom.gba", 0x13C3380, 0x80
+sSeviperSprites138:
+ax_sprite sSeviperGfx138, 0x80
+ax_sprite_terminator
+sSeviperGfx139:
+.incbin "baserom.gba", 0x13C3410, 0x100
+sSeviperSprites139:
+ax_sprite sSeviperGfx139, 0x100
+ax_sprite_terminator
+sSeviperGfx140:
+.incbin "baserom.gba", 0x13C3520, 0x80
+sSeviperSprites140:
+ax_sprite sSeviperGfx140, 0x80
+ax_sprite_terminator
+sSeviperGfx141:
+.incbin "baserom.gba", 0x13C35B0, 0x40
+sSeviperSprites141:
+ax_sprite sSeviperGfx141, 0x40
+ax_sprite_terminator
+sSeviperGfx142:
+.incbin "baserom.gba", 0x13C3600, 0x80
+sSeviperSprites142:
+ax_sprite sSeviperGfx142, 0x80
+ax_sprite_terminator
+sSeviperGfx143:
+.incbin "baserom.gba", 0x13C3690, 0x80
+sSeviperSprites143:
+ax_sprite sSeviperGfx143, 0x80
+ax_sprite_terminator
+sSeviperGfx144:
+.incbin "baserom.gba", 0x13C3720, 0x40
+sSeviperSprites144:
+ax_sprite sSeviperGfx144, 0x40
+ax_sprite_terminator
+sSeviperGfx145:
+.incbin "baserom.gba", 0x13C3770, 0x100
+sSeviperSprites145:
+ax_sprite sSeviperGfx145, 0x100
+ax_sprite_terminator
+sSeviperGfx146:
+.incbin "baserom.gba", 0x13C3880, 0x40
+sSeviperSprites146:
+ax_sprite sSeviperGfx146, 0x40
+ax_sprite_terminator
+sSeviperGfx147:
+.incbin "baserom.gba", 0x13C38D0, 0x20
+sSeviperSprites147:
+ax_sprite sSeviperGfx147, 0x20
+ax_sprite_terminator
+sSeviperGfx148:
+.incbin "baserom.gba", 0x13C3900, 0x80
+sSeviperSprites148:
+ax_sprite sSeviperGfx148, 0x80
+ax_sprite_terminator
+sSeviperGfx149:
+.incbin "baserom.gba", 0x13C3990, 0x40
+sSeviperSprites149:
+ax_sprite sSeviperGfx149, 0x40
+ax_sprite_terminator
+sSeviperGfx150:
+.incbin "baserom.gba", 0x13C39E0, 0x80
+sSeviperSprites150:
+ax_sprite sSeviperGfx150, 0x80
+ax_sprite_terminator
+sSeviperGfx151:
+.incbin "baserom.gba", 0x13C3A70, 0x80
+sSeviperSprites151:
+ax_sprite sSeviperGfx151, 0x80
+ax_sprite_terminator
+sSeviperGfx152:
+.incbin "baserom.gba", 0x13C3B00, 0x40
+sSeviperSprites152:
+ax_sprite sSeviperGfx152, 0x40
+ax_sprite_terminator
+sSeviperGfx153:
+.incbin "baserom.gba", 0x13C3B50, 0x40
+sSeviperSprites153:
+ax_sprite sSeviperGfx153, 0x40
+ax_sprite_terminator
+sSeviperGfx154:
+.incbin "baserom.gba", 0x13C3BA0, 0x40
+sSeviperSprites154:
+ax_sprite sSeviperGfx154, 0x40
+ax_sprite_terminator
+sSeviperGfx155:
+.incbin "baserom.gba", 0x13C3BF0, 0x80
+sSeviperSprites155:
+ax_sprite sSeviperGfx155, 0x80
+ax_sprite_terminator
+sSeviperGfx156:
+.incbin "baserom.gba", 0x13C3C80, 0x100
+sSeviperSprites156:
+ax_sprite sSeviperGfx156, 0x100
+ax_sprite_terminator
+sSeviperGfx157:
+.incbin "baserom.gba", 0x13C3D90, 0x200
+sSeviperSprites157:
+ax_sprite sSeviperGfx157, 0x200
+ax_sprite_terminator
+sAxPosesSeviper:
+.4byte sSeviperPose1
+.4byte sSeviperPose2
+.4byte sSeviperPose3
+.4byte sSeviperPose4
+.4byte sSeviperPose5
+.4byte sSeviperPose6
+.4byte sSeviperPose7
+.4byte sSeviperPose8
+.4byte sSeviperPose9
+.4byte sSeviperPose10
+.4byte sSeviperPose11
+.4byte sSeviperPose12
+.4byte sSeviperPose13
+.4byte sSeviperPose14
+.4byte sSeviperPose15
+.4byte sSeviperPose16
+.4byte sSeviperPose17
+.4byte sSeviperPose18
+.4byte sSeviperPose19
+.4byte sSeviperPose20
+.4byte sSeviperPose21
+.4byte sSeviperPose22
+.4byte sSeviperPose23
+.4byte sSeviperPose24
+.4byte sSeviperPose25
+.4byte sSeviperPose26
+.4byte sSeviperPose27
+.4byte sSeviperPose28
+.4byte sSeviperPose29
+.4byte sSeviperPose30
+.4byte sSeviperPose31
+.4byte sSeviperPose32
+.4byte sSeviperPose33
+.4byte sSeviperPose34
+.4byte sSeviperPose35
+.4byte sSeviperPose36
+.4byte sSeviperPose37
+.4byte sSeviperPose38
+.4byte sSeviperPose39
+.4byte sSeviperPose40
+.4byte sSeviperPose41
+.4byte sSeviperPose42
+.4byte sSeviperPose43
+.4byte sSeviperPose44
+.4byte sSeviperPose45
+.4byte sSeviperPose46
+.4byte sSeviperPose47
+.4byte sSeviperPose48
+.4byte sSeviperPose49
+.4byte sSeviperPose50
+.4byte sSeviperPose51
+.4byte sSeviperPose52
+.4byte sSeviperPose53
+.4byte sSeviperPose54
+.4byte sSeviperPose55
+.4byte sSeviperPose56
+.4byte sSeviperPose57
+.4byte sSeviperPose58
+.4byte sSeviperPose59
+.4byte sSeviperPose60
+.4byte sSeviperPose61
+.4byte sSeviperPose62
+.4byte sSeviperPose63
+.4byte sSeviperPose64
+.4byte sSeviperPose65
+.4byte sSeviperPose66
+.4byte sSeviperPose67
+.4byte sSeviperPose68
+.4byte sSeviperPose69
+.4byte sSeviperPose70
+.4byte sSeviperPose71
+.4byte sSeviperPose72
+.4byte sSeviperPose73
+.4byte sSeviperPose74
+.4byte sSeviperPose75
+.4byte sSeviperPose76
+.4byte sSeviperPose77
+.4byte sSeviperPose78
+.4byte sSeviperPose79
+.4byte sSeviperPose80
+.4byte sSeviperPose81
+.4byte sSeviperPose82
+.4byte sSeviperPose83
+.4byte sSeviperPose84
+.4byte sSeviperPose85
+.4byte sSeviperPose86
+.4byte sSeviperPose87
+.4byte sSeviperPose88
+.4byte sSeviperPose89
+.4byte sSeviperPose90
+.4byte sSeviperPose91
+.4byte sSeviperPose92
+.4byte sSeviperPose93
+.4byte sSeviperPose94
+.4byte sSeviperPose95
+.4byte sSeviperPose96
+.4byte sSeviperPose97
+.4byte sSeviperPose98
+.4byte sSeviperPose99
+.4byte sSeviperPose100
+.4byte sSeviperPose101
+.4byte sSeviperPose102
+.4byte sSeviperPose103
+.4byte sSeviperPose104
+.4byte sSeviperPose105
+.4byte sSeviperPose106
+.4byte sSeviperPose107
+.4byte sSeviperPose108
+.4byte sSeviperPose109
+.4byte sSeviperPose110
+.4byte sSeviperPose111
+.4byte sSeviperPose112
+.4byte sSeviperPose113
+.4byte sSeviperPose114
+.4byte sSeviperPose115
+.4byte sSeviperPose116
+.4byte sSeviperPose117
+.4byte sSeviperPose118
+.4byte sSeviperPose119
+.4byte sSeviperPose120
+.4byte sSeviperPose121
+.4byte sSeviperPose122
+.4byte sSeviperPose123
+.4byte sSeviperPose124
+.4byte sSeviperPose125
+.4byte sSeviperPose126
+.4byte sSeviperPose127
+.4byte sSeviperPose128
+.4byte sSeviperPose129
+.4byte sSeviperPose130
+.4byte sSeviperPose131
+.4byte sSeviperPose132
+.4byte sSeviperPose133
+.4byte sSeviperPose134
+.4byte sSeviperPose135
+.4byte sSeviperPose136
+.4byte sSeviperPose137
+.4byte sSeviperPose138
+.4byte sSeviperPose139
+.4byte sSeviperPose140
+.4byte sSeviperPose141
+.4byte sSeviperPose142
+.4byte sSeviperPose143
+.4byte sSeviperPose144
+.4byte sSeviperPose145
+.4byte sSeviperPose146
+.4byte sSeviperPose147
+.4byte sSeviperPose148
+.4byte sSeviperPose149
+.4byte sSeviperPose150
+.4byte sSeviperPose151
+.4byte sSeviperPose152
+.4byte sSeviperPose153
+.4byte sSeviperPose154
+.4byte sSeviperPose155
+.4byte sSeviperPose156
+.4byte sSeviperPose157
+.4byte sSeviperPose158
+.4byte sSeviperPose159
+.4byte sSeviperPose160
+.4byte sSeviperPose161
+.4byte sSeviperPose162
+.4byte sSeviperPose163
+.4byte sSeviperPose164
+.4byte sSeviperPose165
+.4byte sSeviperPose166
+.4byte sSeviperPose167
+.4byte sSeviperPose168
+.4byte sSeviperPose169
+.4byte sSeviperPose170
+.4byte sSeviperPose171
+.4byte sSeviperPose172
+.4byte sSeviperPose173
+.4byte sSeviperPose174
+.4byte sSeviperPose175
+.4byte sSeviperPose176
+.4byte sSeviperPose177
+.4byte sSeviperPose178
+.4byte sSeviperPose179
+.4byte sSeviperPose180
+.4byte sSeviperPose181
+.4byte sSeviperPose182
+.4byte sSeviperPose183
+.4byte sSeviperPose184
+.4byte sSeviperPose185
+.4byte sSeviperPose186
+.4byte sSeviperPose187
+.4byte sSeviperPose188
+.4byte sSeviperPose189
+.4byte sSeviperPose190
+.4byte sSeviperPose191
+.4byte sSeviperPose192
+.4byte sSeviperPose193
+.4byte sSeviperPose194
+.4byte sSeviperPose195
+.4byte sSeviperPose196
+.4byte sSeviperPose197
+.4byte sSeviperPose198
+.4byte sSeviperPose199
+.4byte sSeviperPose200
+.4byte sSeviperPose201
+.4byte sSeviperPose202
+.4byte sSeviperPose203
+.4byte sSeviperPose204
+.4byte sSeviperPose205
+.4byte sSeviperPose206
+.4byte sSeviperPose207
+.4byte sSeviperPose208
+.4byte sSeviperPose209
+.4byte sSeviperPose210
+sAxPositionsSeviper:
+.2byte    0,   -6, 	  -3,    2, 	   4,    2, 	   2,   -6
+.2byte    1,   -5, 	  -4,    2, 	   3,    2, 	   2,   -7
+.2byte   -1,   -5, 	  -2,    2, 	   5,    2, 	   2,   -6
+.2byte    6,   -8, 	   0,    2, 	   6,    0, 	  -5,   -8
+.2byte    6,   -6, 	   1,    1, 	   6,   -1, 	  -4,   -6
+.2byte    7,   -6, 	  -1,    3, 	   5,    1, 	  -5,   -8
+.2byte   10,  -12, 	   5,    0, 	   4,   -2, 	  -4,   -6
+.2byte   11,  -10, 	   5,   -1, 	   4,   -3, 	  -3,   -6
+.2byte   11,  -12, 	   5,    1, 	   5,   -1, 	  -3,   -6
+.2byte    6,  -14, 	   5,   -3, 	  -1,   -4, 	  -2,   -6
+.2byte    8,  -12, 	   3,   -3, 	  -2,   -5, 	  -1,   -5
+.2byte    6,  -11, 	   6,   -1, 	  -1,   -3, 	  -2,   -5
+.2byte   -1,  -17, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte   -2,  -16, 	   2,   -3, 	  -5,   -3, 	  -1,   -6
+.2byte    1,  -16, 	   4,   -3, 	  -4,   -3, 	   0,   -5
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte  -11,  -11, 	  -1,   -4, 	  -6,   -3, 	   1,   -6
+.2byte   -9,  -11, 	  -3,   -3, 	  -8,   -1, 	   0,   -6
+.2byte  -12,  -12, 	  -8,   -1, 	  -6,    0, 	   3,   -6
+.2byte  -13,  -10, 	  -9,   -2, 	  -6,   -1, 	   2,   -6
+.2byte  -13,  -12, 	  -9,    0, 	  -6,    1, 	   3,   -6
+.2byte   -8,   -8, 	  -8,    0, 	  -2,    2, 	   4,   -9
+.2byte   -8,   -6, 	  -9,   -1, 	  -3,    1, 	   3,   -7
+.2byte   -9,   -6, 	  -7,    1, 	  -1,    3, 	   2,   -8
+.2byte    0,   -6, 	  -3,    2, 	   4,    2, 	   2,   -6
+.2byte    0,  -12, 	  -3,    0, 	   3,    0, 	   2,   -7
+.2byte    0,   12, 	  -2,   -1, 	   5,   -1, 	   2,   -5
+.2byte    6,   -8, 	   0,    2, 	   6,    0, 	  -5,   -8
+.2byte    6,  -13, 	   2,    2, 	   7,    0, 	  -2,   -6
+.2byte   15,    6, 	   1,    4, 	   7,    2, 	  -2,   -5
+.2byte   10,  -12, 	   5,    0, 	   4,   -2, 	  -4,   -6
+.2byte    5,  -18, 	   6,   -3, 	   7,   -4, 	  -2,   -6
+.2byte   23,   -3, 	   8,    0, 	   9,   -2, 	  -3,   -5
+.2byte    6,  -14, 	   5,   -3, 	  -1,   -4, 	  -2,   -6
+.2byte   -1,  -17, 	   4,   -6, 	   0,   -8, 	  -5,   -6
+.2byte   13,  -11, 	   6,   -3, 	   3,   -5, 	  -3,   -4
+.2byte   -1,  -17, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte   -1,  -22, 	   3,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -1,  -24, 	   3,   -4, 	  -3,   -4, 	  -1,   -4
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte   -3,  -18, 	  -2,   -8, 	  -7,   -6, 	   2,   -5
+.2byte  -16,  -11, 	  -4,   -6, 	  -9,   -3, 	   1,   -4
+.2byte  -12,  -12, 	  -8,   -1, 	  -6,    0, 	   3,   -6
+.2byte   -7,  -18, 	 -10,   -4, 	  -8,   -3, 	   2,   -5
+.2byte  -24,   -3, 	 -11,   -2, 	  -9,    0, 	   2,   -4
+.2byte   -8,   -8, 	  -8,    0, 	  -2,    2, 	   4,   -9
+.2byte   -7,  -14, 	  -9,   -1, 	  -4,    1, 	   2,   -6
+.2byte  -17,    6, 	  -7,    1, 	  -4,    3, 	   4,   -7
+.2byte    0,   -6, 	  -3,    2, 	   4,    2, 	   2,   -6
+.2byte    0,  -12, 	  -3,    0, 	   3,    0, 	   2,   -7
+.2byte    0,   12, 	  -2,   -1, 	   5,   -1, 	   2,   -5
+.2byte    0,    4, 	  -3,    1, 	   3,    1, 	   2,   -7
+.2byte    6,   -8, 	   0,    2, 	   6,    0, 	  -5,   -8
+.2byte    1,  -16, 	  -3,   -1, 	   2,   -3, 	  -7,   -9
+.2byte   15,    6, 	   1,    4, 	   7,    2, 	  -2,   -5
+.2byte   11,   -1, 	   1,    2, 	   7,    0, 	  -2,   -7
+.2byte   10,  -12, 	   5,    0, 	   4,   -2, 	  -4,   -6
+.2byte    5,  -18, 	   6,   -3, 	   7,   -4, 	  -2,   -6
+.2byte   23,   -3, 	   8,    0, 	   9,   -2, 	  -3,   -5
+.2byte   15,   -7, 	   6,    0, 	   5,   -4, 	  -4,   -6
+.2byte    6,  -14, 	   5,   -3, 	  -1,   -4, 	  -2,   -6
+.2byte   -1,  -17, 	   4,   -6, 	   0,   -8, 	  -5,   -6
+.2byte   15,  -13, 	   8,   -5, 	   5,   -7, 	  -1,   -6
+.2byte   10,  -13, 	   5,   -3, 	   3,   -6, 	  -2,   -6
+.2byte   -1,  -17, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte   -1,  -22, 	   3,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -1,  -24, 	   3,   -4, 	  -3,   -4, 	  -1,   -4
+.2byte   -1,  -10, 	   2,    5, 	  -5,    6, 	  -1,    0
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte   -3,  -18, 	  -2,   -8, 	  -7,   -6, 	   2,   -5
+.2byte  -18,  -13, 	  -6,   -8, 	 -11,   -5, 	  -1,   -6
+.2byte  -16,  -14, 	  -5,   -5, 	  -9,   -2, 	   0,   -5
+.2byte  -12,  -12, 	  -8,   -1, 	  -6,    0, 	   3,   -6
+.2byte   -7,  -18, 	 -10,   -4, 	  -8,   -3, 	   2,   -5
+.2byte  -24,   -3, 	 -11,   -2, 	  -9,    0, 	   2,   -4
+.2byte  -17,   -8, 	 -10,   -1, 	  -8,    0, 	   3,   -6
+.2byte   -8,   -8, 	  -8,    0, 	  -2,    2, 	   4,   -9
+.2byte   -2,  -17, 	  -4,   -4, 	   1,   -2, 	   7,   -9
+.2byte  -17,    6, 	  -7,    1, 	  -4,    3, 	   4,   -7
+.2byte  -13,   -3, 	  -8,    0, 	  -3,    2, 	   4,   -9
+.2byte    0,   -6, 	  -3,    2, 	   4,    2, 	   2,   -6
+.2byte    0,  -12, 	  -3,    0, 	   3,    0, 	   2,   -7
+.2byte    0,    4, 	  -3,    1, 	   3,    1, 	   2,   -7
+.2byte    6,   -8, 	   0,    2, 	   6,    0, 	  -5,   -8
+.2byte    1,  -16, 	  -3,   -1, 	   2,   -3, 	  -7,   -9
+.2byte   11,   -1, 	   1,    2, 	   7,    0, 	  -2,   -7
+.2byte   10,  -12, 	   5,    0, 	   4,   -2, 	  -4,   -6
+.2byte    0,  -18, 	   1,   -3, 	   2,   -4, 	  -7,   -6
+.2byte   15,   -7, 	   6,    0, 	   5,   -4, 	  -4,   -6
+.2byte    6,  -14, 	   5,   -3, 	  -1,   -4, 	  -2,   -6
+.2byte    1,  -17, 	   6,   -6, 	   2,   -8, 	  -3,   -6
+.2byte   10,  -13, 	   5,   -3, 	   3,   -6, 	  -2,   -6
+.2byte   -1,  -17, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte   -1,  -22, 	   3,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -1,  -15, 	   2,    0, 	  -5,    1, 	  -1,   -5
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte   -5,  -18, 	  -4,   -8, 	  -9,   -6, 	   0,   -5
+.2byte  -16,  -14, 	  -5,   -5, 	  -9,   -2, 	   0,   -5
+.2byte  -12,  -12, 	  -8,   -1, 	  -6,    0, 	   3,   -6
+.2byte   -2,  -18, 	  -5,   -4, 	  -3,   -3, 	   7,   -5
+.2byte  -17,   -8, 	 -10,   -1, 	  -8,    0, 	   3,   -6
+.2byte   -8,   -8, 	  -8,    0, 	  -2,    2, 	   4,   -9
+.2byte   -2,  -17, 	  -4,   -4, 	   1,   -2, 	   7,   -9
+.2byte  -13,   -3, 	  -8,    0, 	  -3,    2, 	   4,   -9
+.2byte    0,   -6, 	  -3,    2, 	   4,    2, 	   2,   -6
+.2byte    0,   -7, 	  -4,    2, 	   5,    2, 	   1,   -4
+.2byte    6,   -8, 	   0,    2, 	   6,    0, 	  -5,   -8
+.2byte    8,   -8, 	   1,    3, 	   8,    0, 	  -4,   -7
+.2byte   10,  -12, 	   5,    0, 	   4,   -2, 	  -4,   -6
+.2byte   12,  -14, 	   6,    0, 	   6,   -4, 	  -5,   -7
+.2byte    6,  -14, 	   5,   -3, 	  -1,   -4, 	  -2,   -6
+.2byte    8,  -15, 	   7,   -2, 	   3,   -5, 	  -3,   -6
+.2byte   -1,  -17, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte    0,  -23, 	   4,   -9, 	  -2,   -9, 	   0,  -10
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte  -10,  -15, 	  -5,   -5, 	  -9,   -2, 	   1,   -6
+.2byte  -12,  -12, 	  -8,   -1, 	  -6,    0, 	   3,   -6
+.2byte  -15,  -14, 	  -9,   -2, 	  -7,    0, 	   4,   -6
+.2byte   -8,   -8, 	  -8,    0, 	  -2,    2, 	   4,   -9
+.2byte  -10,   -8, 	  -9,    0, 	  -3,    3, 	   6,   -9
+.2byte   -6,  -11, 	  -7,    0, 	  -3,    3, 	   2,   -2
+.2byte   -7,  -10, 	  -7,    0, 	  -3,    2, 	   2,   -2
+.2byte   -2,    3, 	  -3,   -6, 	   4,   -6, 	   0,  -12
+.2byte   13,   -2, 	   0,    1, 	   6,    0, 	  -1,   -8
+.2byte   20,   -8, 	   5,   -1, 	   8,   -2, 	   0,   -8
+.2byte   13,  -13, 	   5,   -3, 	   2,   -4, 	  -1,   -8
+.2byte    0,  -17, 	   4,   -4, 	  -3,   -4, 	   0,   -6
+.2byte  -14,  -12, 	  -1,   -6, 	  -6,   -3, 	   3,   -5
+.2byte  -20,   -7, 	  -8,   -2, 	  -6,   -1, 	   2,   -7
+.2byte  -14,   -2, 	  -7,    0, 	  -1,    2, 	   1,   -6
+.2byte    0,   -6, 	  -3,    2, 	   4,    2, 	   2,   -6
+.2byte    1,   -5, 	  -4,    2, 	   3,    2, 	   2,   -7
+.2byte   -1,   -5, 	  -2,    2, 	   5,    2, 	   2,   -6
+.2byte    6,   -8, 	   0,    2, 	   6,    0, 	  -5,   -8
+.2byte    6,   -6, 	   1,    1, 	   6,   -1, 	  -4,   -6
+.2byte    7,   -6, 	  -1,    3, 	   5,    1, 	  -5,   -8
+.2byte   10,  -12, 	   5,    0, 	   4,   -2, 	  -4,   -6
+.2byte   11,  -10, 	   5,   -1, 	   4,   -3, 	  -3,   -6
+.2byte   11,  -12, 	   5,    1, 	   5,   -1, 	  -3,   -6
+.2byte    6,  -14, 	   5,   -3, 	  -1,   -4, 	  -2,   -6
+.2byte    8,  -12, 	   3,   -3, 	  -2,   -5, 	  -1,   -5
+.2byte    6,  -11, 	   6,   -1, 	  -1,   -3, 	  -2,   -5
+.2byte   -1,  -17, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte   -2,  -16, 	   2,   -3, 	  -5,   -3, 	  -1,   -6
+.2byte    1,  -16, 	   4,   -3, 	  -4,   -3, 	   0,   -5
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte  -11,  -11, 	  -1,   -4, 	  -6,   -3, 	   1,   -6
+.2byte   -9,  -11, 	  -3,   -3, 	  -8,   -1, 	   0,   -6
+.2byte  -12,  -12, 	  -8,   -1, 	  -6,    0, 	   3,   -6
+.2byte  -13,  -10, 	  -9,   -2, 	  -6,   -1, 	   2,   -6
+.2byte  -13,  -12, 	  -9,    0, 	  -6,    1, 	   3,   -6
+.2byte   -8,   -8, 	  -8,    0, 	  -2,    2, 	   4,   -9
+.2byte   -8,   -6, 	  -9,   -1, 	  -3,    1, 	   3,   -7
+.2byte   -9,   -6, 	  -7,    1, 	  -1,    3, 	   2,   -8
+.2byte    0,  -12, 	  -3,    0, 	   3,    0, 	   2,   -7
+.2byte   -9,  -16, 	 -11,   -3, 	  -6,   -1, 	   0,   -8
+.2byte   -9,  -19, 	 -12,   -5, 	 -10,   -4, 	   0,   -6
+.2byte   -7,  -18, 	  -6,   -8, 	 -11,   -6, 	  -2,   -5
+.2byte   -1,  -22, 	   3,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte    5,  -17, 	  10,   -6, 	   6,   -8, 	   1,   -6
+.2byte    8,  -19, 	   9,   -4, 	  10,   -5, 	   1,   -7
+.2byte    9,  -15, 	   5,    0, 	  10,   -2, 	   1,   -8
+.2byte    0,    4, 	  -3,    1, 	   3,    1, 	   2,   -7
+.2byte   11,   -1, 	   1,    2, 	   7,    0, 	  -2,   -7
+.2byte   15,   -7, 	   6,    0, 	   5,   -4, 	  -4,   -6
+.2byte   10,  -13, 	   5,   -3, 	   3,   -6, 	  -2,   -6
+.2byte   -1,  -15, 	   2,    0, 	  -5,    1, 	  -1,   -5
+.2byte  -16,  -14, 	  -5,   -5, 	  -9,   -2, 	   0,   -5
+.2byte  -17,   -8, 	 -10,   -1, 	  -8,    0, 	   3,   -6
+.2byte  -13,   -3, 	  -8,    0, 	  -3,    2, 	   4,   -9
+.2byte    0,   -6, 	  -3,    2, 	   4,    2, 	   2,   -6
+.2byte    0,  -11, 	  -3,    1, 	   3,    1, 	   2,   -6
+.2byte    0,   -1, 	  -3,   -4, 	   3,   -4, 	   2,  -12
+.2byte    6,   -8, 	   0,    2, 	   6,    0, 	  -5,   -8
+.2byte    5,  -16, 	   1,   -1, 	   6,   -3, 	  -3,   -9
+.2byte   11,   -1, 	   1,    2, 	   7,    0, 	  -2,   -7
+.2byte   10,  -12, 	   5,    0, 	   4,   -2, 	  -4,   -6
+.2byte    2,  -18, 	   3,   -3, 	   4,   -4, 	  -5,   -6
+.2byte   14,   -7, 	   5,    0, 	   4,   -4, 	  -5,   -6
+.2byte    6,  -14, 	   5,   -3, 	  -1,   -4, 	  -2,   -6
+.2byte    1,  -17, 	   6,   -6, 	   2,   -8, 	  -3,   -6
+.2byte   10,  -13, 	   5,   -3, 	   3,   -6, 	  -2,   -6
+.2byte   -1,  -17, 	   3,   -4, 	  -4,   -4, 	   0,   -7
+.2byte   -1,  -22, 	   3,   -2, 	  -5,   -2, 	  -1,   -6
+.2byte   -1,  -14, 	   2,    1, 	  -5,    2, 	  -1,   -4
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte   -5,  -18, 	  -4,   -8, 	  -9,   -6, 	   0,   -5
+.2byte  -16,  -14, 	  -5,   -5, 	  -9,   -2, 	   0,   -5
+.2byte  -12,  -12, 	  -8,   -1, 	  -6,    0, 	   3,   -6
+.2byte   -4,  -18, 	  -7,   -4, 	  -5,   -3, 	   5,   -5
+.2byte  -16,   -8, 	  -9,   -1, 	  -7,    0, 	   4,   -6
+.2byte   -8,   -8, 	  -8,    0, 	  -2,    2, 	   4,   -9
+.2byte   -6,  -17, 	  -8,   -4, 	  -3,   -2, 	   3,   -9
+.2byte  -13,   -3, 	  -8,    0, 	  -3,    2, 	   4,   -9
+.2byte    0,  -12, 	  -3,    0, 	   3,    0, 	   2,   -7
+.2byte   -7,  -16, 	  -9,   -3, 	  -4,   -1, 	   2,   -8
+.2byte   -7,  -19, 	 -10,   -5, 	  -8,   -4, 	   2,   -6
+.2byte   -6,  -20, 	  -5,  -10, 	 -10,   -8, 	  -1,   -7
+.2byte   -1,  -24, 	   3,   -4, 	  -5,   -4, 	  -1,   -8
+.2byte    4,  -19, 	   9,   -8, 	   5,  -10, 	   0,   -8
+.2byte    6,  -19, 	   7,   -4, 	   8,   -5, 	  -1,   -7
+.2byte    7,  -15, 	   3,    0, 	   8,   -2, 	  -1,   -8
+.2byte    0,   -5, 	  -3,    3, 	   4,    3, 	   2,   -5
+.2byte  -11,   -7, 	 -11,    1, 	  -5,    3, 	   1,   -8
+.2byte  -14,  -12, 	 -10,   -1, 	  -8,    0, 	   1,   -6
+.2byte   -9,  -13, 	  -1,   -4, 	  -8,   -2, 	   1,   -6
+.2byte    0,  -17, 	   4,   -4, 	  -3,   -4, 	   1,   -7
+.2byte    7,  -14, 	   6,   -3, 	   0,   -4, 	  -1,   -6
+.2byte   12,  -12, 	   7,    0, 	   6,   -2, 	  -2,   -6
+.2byte    9,   -7, 	   3,    3, 	   9,    1, 	  -2,   -7
+sSeviperAnimTable1:
+.4byte sSeviperAnims_1_1
+.4byte sSeviperAnims_1_2
+.4byte sSeviperAnims_1_3
+.4byte sSeviperAnims_1_4
+.4byte sSeviperAnims_1_5
+.4byte sSeviperAnims_1_6
+.4byte sSeviperAnims_1_7
+.4byte sSeviperAnims_1_8
+sSeviperAnimTable2:
+.4byte sSeviperAnims_2_1
+.4byte sSeviperAnims_2_2
+.4byte sSeviperAnims_2_3
+.4byte sSeviperAnims_2_4
+.4byte sSeviperAnims_2_5
+.4byte sSeviperAnims_2_6
+.4byte sSeviperAnims_2_7
+.4byte sSeviperAnims_2_8
+sSeviperAnimTable3:
+.4byte sSeviperAnims_3_1
+.4byte sSeviperAnims_3_2
+.4byte sSeviperAnims_3_3
+.4byte sSeviperAnims_3_4
+.4byte sSeviperAnims_3_5
+.4byte sSeviperAnims_3_6
+.4byte sSeviperAnims_3_7
+.4byte sSeviperAnims_3_8
+sSeviperAnimTable4:
+.4byte sSeviperAnims_4_1
+.4byte sSeviperAnims_4_2
+.4byte sSeviperAnims_4_3
+.4byte sSeviperAnims_4_4
+.4byte sSeviperAnims_4_5
+.4byte sSeviperAnims_4_6
+.4byte sSeviperAnims_4_7
+.4byte sSeviperAnims_4_8
+sSeviperAnimTable5:
+.4byte sSeviperAnims_5_1
+.4byte sSeviperAnims_5_2
+.4byte sSeviperAnims_5_3
+.4byte sSeviperAnims_5_4
+.4byte sSeviperAnims_5_5
+.4byte sSeviperAnims_5_6
+.4byte sSeviperAnims_5_7
+.4byte sSeviperAnims_5_8
+sSeviperAnimTable6:
+.4byte sSeviperAnims_6_1
+.4byte sSeviperAnims_6_1
+.4byte sSeviperAnims_6_1
+.4byte sSeviperAnims_6_1
+.4byte sSeviperAnims_6_1
+.4byte sSeviperAnims_6_1
+.4byte sSeviperAnims_6_1
+.4byte sSeviperAnims_6_1
+sSeviperAnimTable7:
+.4byte sSeviperAnims_7_1
+.4byte sSeviperAnims_7_2
+.4byte sSeviperAnims_7_3
+.4byte sSeviperAnims_7_4
+.4byte sSeviperAnims_7_5
+.4byte sSeviperAnims_7_6
+.4byte sSeviperAnims_7_7
+.4byte sSeviperAnims_7_8
+sSeviperAnimTable8:
+.4byte sSeviperAnims_8_1
+.4byte sSeviperAnims_8_2
+.4byte sSeviperAnims_8_3
+.4byte sSeviperAnims_8_4
+.4byte sSeviperAnims_8_5
+.4byte sSeviperAnims_8_6
+.4byte sSeviperAnims_8_7
+.4byte sSeviperAnims_8_8
+sSeviperAnimTable9:
+.4byte sSeviperAnims_9_1
+.4byte sSeviperAnims_9_2
+.4byte sSeviperAnims_9_3
+.4byte sSeviperAnims_9_4
+.4byte sSeviperAnims_9_5
+.4byte sSeviperAnims_9_6
+.4byte sSeviperAnims_9_7
+.4byte sSeviperAnims_9_8
+sSeviperAnimTable10:
+.4byte sSeviperAnims_10_1
+.4byte sSeviperAnims_10_2
+.4byte sSeviperAnims_10_3
+.4byte sSeviperAnims_10_4
+.4byte sSeviperAnims_10_5
+.4byte sSeviperAnims_10_6
+.4byte sSeviperAnims_10_7
+.4byte sSeviperAnims_10_8
+sSeviperAnimTable11:
+.4byte sSeviperAnims_11_1
+.4byte sSeviperAnims_11_2
+.4byte sSeviperAnims_11_3
+.4byte sSeviperAnims_11_4
+.4byte sSeviperAnims_11_5
+.4byte sSeviperAnims_11_6
+.4byte sSeviperAnims_11_7
+.4byte sSeviperAnims_11_8
+sSeviperAnimTable12:
+.4byte sSeviperAnims_12_1
+.4byte sSeviperAnims_12_2
+.4byte sSeviperAnims_12_3
+.4byte sSeviperAnims_12_4
+.4byte sSeviperAnims_12_5
+.4byte sSeviperAnims_12_6
+.4byte sSeviperAnims_12_7
+.4byte sSeviperAnims_12_8
+sSeviperAnimTable13:
+.4byte sSeviperAnims_13_1
+.4byte sSeviperAnims_13_2
+.4byte sSeviperAnims_13_3
+.4byte sSeviperAnims_13_4
+.4byte sSeviperAnims_13_5
+.4byte sSeviperAnims_13_6
+.4byte sSeviperAnims_13_7
+.4byte sSeviperAnims_13_8
+sAxAnimationsSeviper:
+.4byte sSeviperAnimTable1
+.4byte sSeviperAnimTable2
+.4byte sSeviperAnimTable3
+.4byte sSeviperAnimTable4
+.4byte sSeviperAnimTable5
+.4byte sSeviperAnimTable6
+.4byte sSeviperAnimTable7
+.4byte sSeviperAnimTable8
+.4byte sSeviperAnimTable9
+.4byte sSeviperAnimTable10
+.4byte sSeviperAnimTable11
+.4byte sSeviperAnimTable12
+.4byte sSeviperAnimTable13
+sAxSpritesSeviper:
+.4byte sSeviperSprites1
+.4byte sSeviperSprites2
+.4byte sSeviperSprites3
+.4byte sSeviperSprites4
+.4byte sSeviperSprites5
+.4byte sSeviperSprites6
+.4byte sSeviperSprites7
+.4byte sSeviperSprites8
+.4byte sSeviperSprites9
+.4byte sSeviperSprites10
+.4byte sSeviperSprites11
+.4byte sSeviperSprites12
+.4byte sSeviperSprites13
+.4byte sSeviperSprites14
+.4byte sSeviperSprites15
+.4byte sSeviperSprites16
+.4byte sSeviperSprites17
+.4byte sSeviperSprites18
+.4byte sSeviperSprites19
+.4byte sSeviperSprites20
+.4byte sSeviperSprites21
+.4byte sSeviperSprites22
+.4byte sSeviperSprites23
+.4byte sSeviperSprites24
+.4byte sSeviperSprites25
+.4byte sSeviperSprites26
+.4byte sSeviperSprites27
+.4byte sSeviperSprites28
+.4byte sSeviperSprites29
+.4byte sSeviperSprites30
+.4byte sSeviperSprites31
+.4byte sSeviperSprites32
+.4byte sSeviperSprites33
+.4byte sSeviperSprites34
+.4byte sSeviperSprites35
+.4byte sSeviperSprites36
+.4byte sSeviperSprites37
+.4byte sSeviperSprites38
+.4byte sSeviperSprites39
+.4byte sSeviperSprites40
+.4byte sSeviperSprites41
+.4byte sSeviperSprites42
+.4byte sSeviperSprites43
+.4byte sSeviperSprites44
+.4byte sSeviperSprites45
+.4byte sSeviperSprites46
+.4byte sSeviperSprites47
+.4byte sSeviperSprites48
+.4byte sSeviperSprites49
+.4byte sSeviperSprites50
+.4byte sSeviperSprites51
+.4byte sSeviperSprites52
+.4byte sSeviperSprites53
+.4byte sSeviperSprites54
+.4byte sSeviperSprites55
+.4byte sSeviperSprites56
+.4byte sSeviperSprites57
+.4byte sSeviperSprites58
+.4byte sSeviperSprites59
+.4byte sSeviperSprites60
+.4byte sSeviperSprites61
+.4byte sSeviperSprites62
+.4byte sSeviperSprites63
+.4byte sSeviperSprites64
+.4byte sSeviperSprites65
+.4byte sSeviperSprites66
+.4byte sSeviperSprites67
+.4byte sSeviperSprites68
+.4byte sSeviperSprites69
+.4byte sSeviperSprites70
+.4byte sSeviperSprites71
+.4byte sSeviperSprites72
+.4byte sSeviperSprites73
+.4byte sSeviperSprites74
+.4byte sSeviperSprites75
+.4byte sSeviperSprites76
+.4byte sSeviperSprites77
+.4byte sSeviperSprites78
+.4byte sSeviperSprites79
+.4byte sSeviperSprites80
+.4byte sSeviperSprites81
+.4byte sSeviperSprites82
+.4byte sSeviperSprites83
+.4byte sSeviperSprites84
+.4byte sSeviperSprites85
+.4byte sSeviperSprites86
+.4byte sSeviperSprites87
+.4byte sSeviperSprites88
+.4byte sSeviperSprites89
+.4byte sSeviperSprites90
+.4byte sSeviperSprites91
+.4byte sSeviperSprites92
+.4byte sSeviperSprites93
+.4byte sSeviperSprites94
+.4byte sSeviperSprites95
+.4byte sSeviperSprites96
+.4byte sSeviperSprites97
+.4byte sSeviperSprites98
+.4byte sSeviperSprites99
+.4byte sSeviperSprites100
+.4byte sSeviperSprites101
+.4byte sSeviperSprites102
+.4byte sSeviperSprites103
+.4byte sSeviperSprites104
+.4byte sSeviperSprites105
+.4byte sSeviperSprites106
+.4byte sSeviperSprites107
+.4byte sSeviperSprites108
+.4byte sSeviperSprites109
+.4byte sSeviperSprites110
+.4byte sSeviperSprites111
+.4byte sSeviperSprites112
+.4byte sSeviperSprites113
+.4byte sSeviperSprites114
+.4byte sSeviperSprites115
+.4byte sSeviperSprites116
+.4byte sSeviperSprites117
+.4byte sSeviperSprites118
+.4byte sSeviperSprites119
+.4byte sSeviperSprites120
+.4byte sSeviperSprites121
+.4byte sSeviperSprites122
+.4byte sSeviperSprites123
+.4byte sSeviperSprites124
+.4byte sSeviperSprites125
+.4byte sSeviperSprites126
+.4byte sSeviperSprites127
+.4byte sSeviperSprites128
+.4byte sSeviperSprites129
+.4byte sSeviperSprites130
+.4byte sSeviperSprites131
+.4byte sSeviperSprites132
+.4byte sSeviperSprites133
+.4byte sSeviperSprites134
+.4byte sSeviperSprites135
+.4byte sSeviperSprites136
+.4byte sSeviperSprites137
+.4byte sSeviperSprites138
+.4byte sSeviperSprites139
+.4byte sSeviperSprites140
+.4byte sSeviperSprites141
+.4byte sSeviperSprites142
+.4byte sSeviperSprites143
+.4byte sSeviperSprites144
+.4byte sSeviperSprites145
+.4byte sSeviperSprites146
+.4byte sSeviperSprites147
+.4byte sSeviperSprites148
+.4byte sSeviperSprites149
+.4byte sSeviperSprites150
+.4byte sSeviperSprites151
+.4byte sSeviperSprites152
+.4byte sSeviperSprites153
+.4byte sSeviperSprites154
+.4byte sSeviperSprites155
+.4byte sSeviperSprites156
+.4byte sSeviperSprites157
+sAxMainSeviper:
+ax_main sAxPosesSeviper, sAxAnimationsSeviper, 13, sAxSpritesSeviper, sAxPositionsSeviper

--- a/data/ax/sharpedo.inc
+++ b/data/ax/sharpedo.inc
@@ -1,0 +1,2857 @@
+.global gAxSharpedo
+gAxSharpedo:
+ax_siro sAxMainSharpedo
+sSharpedoPose1:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose2:
+ax_pose 1, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose3:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose4:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose5:
+ax_pose 4, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose6:
+ax_pose 5, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose7:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose8:
+ax_pose 7, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose9:
+ax_pose 8, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose10:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose11:
+ax_pose 10, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sSharpedoPose12:
+ax_pose 11, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sSharpedoPose13:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose14:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose15:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose16:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose17:
+ax_pose 10, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sSharpedoPose18:
+ax_pose 11, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sSharpedoPose19:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose20:
+ax_pose 7, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose21:
+ax_pose 8, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose22:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose23:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose24:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose25:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose26:
+ax_pose 1, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose27:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose28:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose29:
+ax_pose 4, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose30:
+ax_pose 5, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose31:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose32:
+ax_pose 7, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose33:
+ax_pose 8, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose34:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose35:
+ax_pose 10, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sSharpedoPose36:
+ax_pose 11, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sSharpedoPose37:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose38:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose39:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose40:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose41:
+ax_pose 10, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sSharpedoPose42:
+ax_pose 11, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sSharpedoPose43:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose44:
+ax_pose 7, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose45:
+ax_pose 8, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose46:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose47:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose48:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose49:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose50:
+ax_pose 1, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose51:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose52:
+ax_pose 15, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose53:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose54:
+ax_pose 4, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose55:
+ax_pose 5, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose56:
+ax_pose 16, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose57:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose58:
+ax_pose 7, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose59:
+ax_pose 8, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose60:
+ax_pose 17, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose61:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose62:
+ax_pose 10, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sSharpedoPose63:
+ax_pose 11, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sSharpedoPose64:
+ax_pose 18, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose65:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose66:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose67:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose68:
+ax_pose 19, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose69:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose70:
+ax_pose 10, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sSharpedoPose71:
+ax_pose 11, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sSharpedoPose72:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose73:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose74:
+ax_pose 7, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose75:
+ax_pose 8, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose76:
+ax_pose 17, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose77:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose78:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose79:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose80:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose81:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose82:
+ax_pose 1, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose83:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose84:
+ax_pose 20, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose85:
+ax_pose 15, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose86:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose87:
+ax_pose 4, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose88:
+ax_pose 5, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose89:
+ax_pose 21, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose90:
+ax_pose 16, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose91:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose92:
+ax_pose 7, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose93:
+ax_pose 8, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose94:
+ax_pose 22, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose95:
+ax_pose 17, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose96:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose97:
+ax_pose 10, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sSharpedoPose98:
+ax_pose 11, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sSharpedoPose99:
+ax_pose 23, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose100:
+ax_pose 18, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose101:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose102:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose103:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose104:
+ax_pose 24, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose105:
+ax_pose 19, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose106:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose107:
+ax_pose 10, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sSharpedoPose108:
+ax_pose 11, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sSharpedoPose109:
+ax_pose 23, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose110:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose111:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose112:
+ax_pose 7, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose113:
+ax_pose 8, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose114:
+ax_pose 22, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose115:
+ax_pose 17, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose116:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose117:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose118:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose119:
+ax_pose 21, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose120:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose121:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose122:
+ax_pose 25, 0x41f0, 0x80ef, 0x2c00
+ax_pose 26, 0x01e0, 0x40ef, 0x2c08
+ax_pose 27, 0x81e0, 0x00ff, 0x2c0c
+ax_pose 28, 0x01e8, 0x0107, 0x2c0e
+ax_pose 29, 0x01eb, 0x010f, 0x2c0f
+ax_pose_terminator
+sSharpedoPose123:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose124:
+ax_pose 30, 0x81e0, 0x90f8, 0x2c00
+ax_pose 31, 0x01e8, 0x1108, 0x2c08
+ax_pose 32, 0x81f0, 0x1108, 0x2c09
+ax_pose 33, 0x01e8, 0x10f0, 0x2c0b
+ax_pose 34, 0x81f0, 0x10f0, 0x2c0c
+ax_pose 35, 0x01f0, 0x10e8, 0x2c0e
+ax_pose 36, 0x01d8, 0x10f8, 0x2c0f
+ax_pose_terminator
+sSharpedoPose125:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose126:
+ax_pose 37, 0x81df, 0x90f1, 0x2c00
+ax_pose 38, 0x81df, 0x5101, 0x2c08
+ax_pose 39, 0x01ff, 0x10f9, 0x2c0c
+ax_pose 40, 0x01e7, 0x1109, 0x2c0d
+ax_pose 41, 0x81ef, 0x1109, 0x2c0e
+ax_pose_terminator
+sSharpedoPose127:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose128:
+ax_pose 42, 0x41ee, 0x90f1, 0x2c00
+ax_pose 43, 0x41e6, 0x50f1, 0x2c08
+ax_pose 44, 0x01fe, 0x10fa, 0x2c0c
+ax_pose 45, 0x41de, 0x10f9, 0x2c0d
+ax_pose 46, 0x01e6, 0x10e9, 0x2c0f
+ax_pose_terminator
+sSharpedoPose129:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose130:
+ax_pose 47, 0x41e7, 0x40ee, 0x2c00
+ax_pose 48, 0x41ef, 0x80ee, 0x2c04
+ax_pose 49, 0x01ef, 0x010e, 0x2c0c
+ax_pose 50, 0x01ff, 0x00fe, 0x2c0d
+ax_pose 51, 0x41df, 0x00f6, 0x2c0e
+ax_pose_terminator
+sSharpedoPose131:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose132:
+ax_pose 42, 0x41ee, 0x80f0, 0x2c00
+ax_pose 43, 0x41e6, 0x40f0, 0x2c08
+ax_pose 44, 0x01fe, 0x00ff, 0x2c0c
+ax_pose 45, 0x41de, 0x00f8, 0x2c0d
+ax_pose 46, 0x01e6, 0x0110, 0x2c0f
+ax_pose_terminator
+sSharpedoPose133:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose134:
+ax_pose 37, 0x81df, 0x8100, 0x2c00
+ax_pose 38, 0x81df, 0x40f8, 0x2c08
+ax_pose 39, 0x01ff, 0x0100, 0x2c0c
+ax_pose 40, 0x01e7, 0x00f0, 0x2c0d
+ax_pose 41, 0x81ef, 0x00f0, 0x2c0e
+ax_pose_terminator
+sSharpedoPose135:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose136:
+ax_pose 30, 0x81e0, 0x80f9, 0x2c00
+ax_pose 31, 0x01e8, 0x00f1, 0x2c08
+ax_pose 32, 0x81f0, 0x00f1, 0x2c09
+ax_pose 33, 0x01e8, 0x0109, 0x2c0b
+ax_pose 34, 0x81f0, 0x0109, 0x2c0c
+ax_pose 35, 0x01f0, 0x0111, 0x2c0e
+ax_pose 36, 0x01d8, 0x0101, 0x2c0f
+ax_pose_terminator
+sSharpedoPose137:
+ax_pose 52, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sSharpedoPose138:
+ax_pose 53, 0x01e5, 0x80f2, 0x2c00
+ax_pose_terminator
+sSharpedoPose139:
+ax_pose 54, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose140:
+ax_pose 55, 0x01e0, 0x90ec, 0x2c00
+ax_pose_terminator
+sSharpedoPose141:
+ax_pose 56, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sSharpedoPose142:
+ax_pose 57, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sSharpedoPose143:
+ax_pose 58, 0x01df, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose144:
+ax_pose 57, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sSharpedoPose145:
+ax_pose 56, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sSharpedoPose146:
+ax_pose 55, 0x01e0, 0x80f4, 0x2c00
+ax_pose_terminator
+sSharpedoPose147:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose148:
+ax_pose 1, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose149:
+ax_pose 2, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose150:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose151:
+ax_pose 4, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose152:
+ax_pose 5, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose153:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose154:
+ax_pose 7, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose155:
+ax_pose 8, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose156:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose157:
+ax_pose 10, 0x01e2, 0x90ee, 0x2c00
+ax_pose_terminator
+sSharpedoPose158:
+ax_pose 11, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sSharpedoPose159:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose160:
+ax_pose 13, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose161:
+ax_pose 14, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose162:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose163:
+ax_pose 10, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sSharpedoPose164:
+ax_pose 11, 0x01e2, 0x80f4, 0x2c00
+ax_pose_terminator
+sSharpedoPose165:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose166:
+ax_pose 7, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose167:
+ax_pose 8, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose168:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose169:
+ax_pose 4, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose170:
+ax_pose 5, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose171:
+ax_pose 15, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose172:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose173:
+ax_pose 17, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sSharpedoPose174:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose175:
+ax_pose 19, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose176:
+ax_pose 18, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose177:
+ax_pose 17, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sSharpedoPose178:
+ax_pose 16, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose179:
+ax_pose 20, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose180:
+ax_pose 21, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose181:
+ax_pose 22, 0x01e2, 0x90ed, 0x2c00
+ax_pose_terminator
+sSharpedoPose182:
+ax_pose 23, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sSharpedoPose183:
+ax_pose 24, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose184:
+ax_pose 23, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose185:
+ax_pose 22, 0x01e2, 0x80f3, 0x2c00
+ax_pose_terminator
+sSharpedoPose186:
+ax_pose 21, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose187:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose188:
+ax_pose 20, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose189:
+ax_pose 15, 0x01e0, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose190:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose191:
+ax_pose 21, 0x01e2, 0x90f2, 0x2c00
+ax_pose_terminator
+sSharpedoPose192:
+ax_pose 16, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose193:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose194:
+ax_pose 22, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose195:
+ax_pose 17, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose196:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose197:
+ax_pose 23, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose198:
+ax_pose 18, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose199:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose200:
+ax_pose 24, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose201:
+ax_pose 19, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose202:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose203:
+ax_pose 23, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose204:
+ax_pose 18, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose205:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose206:
+ax_pose 22, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose207:
+ax_pose 17, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose208:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose209:
+ax_pose 21, 0x01e2, 0x80ef, 0x2c00
+ax_pose_terminator
+sSharpedoPose210:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose211:
+ax_pose 15, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose212:
+ax_pose 16, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose213:
+ax_pose 17, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sSharpedoPose214:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose215:
+ax_pose 19, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose216:
+ax_pose 18, 0x01e4, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose217:
+ax_pose 17, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sSharpedoPose218:
+ax_pose 16, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose219:
+ax_pose 0, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose220:
+ax_pose 3, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose221:
+ax_pose 6, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose222:
+ax_pose 9, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose223:
+ax_pose 12, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose224:
+ax_pose 9, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+sSharpedoPose225:
+ax_pose 6, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sSharpedoPose226:
+ax_pose 3, 0x01e2, 0x90f1, 0x2c00
+ax_pose_terminator
+.align 2
+sSharpedoAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 10, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 10, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 10, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 10, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 10, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -3, 0, 0,
+ax_anim 10, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -3, 0, 0,
+ax_anim 10, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -3, 0, 0,
+ax_anim 10, 0, 21, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 9,
+ax_anim 2, 0, 24, 0, 22, 0, 19,
+ax_anim 2, 1, 24, 1, 22, 1, 19,
+ax_anim 2, 0, 24, 0, 22, 0, 19,
+ax_anim 2, 0, 24, 1, 22, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSharpedoAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 9, 11, 9, 11,
+ax_anim 2, 0, 27, 18, 23, 18, 21,
+ax_anim 2, 1, 27, 19, 22, 19, 20,
+ax_anim 2, 0, 27, 18, 23, 18, 21,
+ax_anim 2, 0, 27, 19, 22, 19, 20,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSharpedoAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 2, 10, 0,
+ax_anim 2, 0, 30, 18, 3, 18, 0,
+ax_anim 2, 1, 30, 18, 4, 18, 1,
+ax_anim 2, 0, 30, 18, 3, 18, 0,
+ax_anim 2, 0, 30, 18, 4, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSharpedoAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 4, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -5,
+ax_anim 1, 0, 34, 12, -12, 12, -12,
+ax_anim 2, 0, 33, 17, -15, 18, -18,
+ax_anim 2, 1, 33, 18, -14, 19, -17,
+ax_anim 2, 0, 33, 17, -15, 18, -18,
+ax_anim 2, 0, 33, 18, -14, 19, -17,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSharpedoAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 4, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -9, 0, -11,
+ax_anim 2, 0, 36, 0, -14, 0, -20,
+ax_anim 2, 1, 36, 1, -14, 1, -20,
+ax_anim 2, 0, 36, 0, -14, 0, -20,
+ax_anim 2, 0, 36, 1, -14, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSharpedoAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 4, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -5,
+ax_anim 1, 0, 40, -12, -12, -12, -12,
+ax_anim 2, 0, 39, -17, -15, -18, -18,
+ax_anim 2, 1, 39, -18, -14, -19, -17,
+ax_anim 2, 0, 39, -17, -15, -18, -18,
+ax_anim 2, 0, 39, -18, -14, -19, -17,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSharpedoAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 4, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 2, -10, 0,
+ax_anim 2, 0, 42, -18, 3, -18, 0,
+ax_anim 2, 1, 42, -18, 4, -18, 1,
+ax_anim 2, 0, 42, -18, 3, -18, 0,
+ax_anim 2, 0, 42, -18, 4, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSharpedoAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -9, 11, -9, 11,
+ax_anim 2, 0, 45, -18, 23, -18, 21,
+ax_anim 2, 1, 45, -19, 22, -19, 20,
+ax_anim 2, 0, 45, -18, 23, -18, 21,
+ax_anim 2, 0, 45, -19, 22, -19, 20,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_3_1:
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim 6, 0, 48, 0, -3, 0, -3,
+ax_anim 1, 2, 51, 0, 1, 0, 1,
+ax_anim 2, 0, 51, 0, 11, 0, 11,
+ax_anim 4, 0, 51, 0, 21, 0, 19,
+ax_anim 2, 1, 49, 0, 21, 0, 19,
+ax_anim 2, 0, 51, 0, 21, 0, 19,
+ax_anim 2, 0, 49, 0, 21, 0, 19,
+ax_anim 2, 0, 51, 0, 21, 0, 19,
+ax_anim 2, 0, 49, 0, 21, 0, 19,
+ax_anim 2, 0, 48, 0, 13, 0, 13,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sSharpedoAnims_3_2:
+ax_anim 2, 0, 52, -2, -2, -2, -2,
+ax_anim 6, 0, 52, -3, -3, -3, -3,
+ax_anim 1, 2, 55, 1, 1, 1, 1,
+ax_anim 2, 0, 55, 10, 12, 10, 12,
+ax_anim 4, 0, 55, 19, 21, 19, 20,
+ax_anim 2, 1, 53, 19, 21, 20, 20,
+ax_anim 2, 0, 55, 19, 21, 19, 20,
+ax_anim 2, 0, 53, 19, 21, 20, 20,
+ax_anim 2, 0, 55, 19, 21, 19, 20,
+ax_anim 2, 0, 53, 19, 21, 20, 20,
+ax_anim 2, 0, 52, 13, 13, 13, 13,
+ax_anim 2, 0, 52, 4, 4, 4, 4,
+ax_anim_terminator
+sSharpedoAnims_3_3:
+ax_anim 2, 0, 56, -2, 0, -2, 0,
+ax_anim 6, 0, 56, -3, 0, -3, 0,
+ax_anim 1, 2, 59, 1, 1, 1, 0,
+ax_anim 2, 0, 59, 10, 2, 10, 0,
+ax_anim 4, 0, 59, 16, 3, 18, 0,
+ax_anim 2, 1, 57, 16, 3, 18, 0,
+ax_anim 2, 0, 59, 16, 3, 18, 0,
+ax_anim 2, 0, 57, 16, 3, 18, 0,
+ax_anim 2, 0, 59, 16, 3, 18, 0,
+ax_anim 2, 0, 57, 16, 3, 18, 0,
+ax_anim 2, 0, 56, 13, 2, 13, 0,
+ax_anim 2, 0, 56, 4, 0, 4, 0,
+ax_anim_terminator
+sSharpedoAnims_3_4:
+ax_anim 2, 0, 60, -2, 2, -2, 2,
+ax_anim 6, 0, 60, -3, 3, -3, 3,
+ax_anim 1, 2, 63, 1, -1, 1, -1,
+ax_anim 2, 0, 63, 13, -10, 13, -11,
+ax_anim 4, 0, 63, 17, -12, 19, -16,
+ax_anim 2, 1, 61, 17, -12, 19, -16,
+ax_anim 2, 0, 63, 17, -12, 19, -16,
+ax_anim 2, 0, 61, 17, -12, 19, -16,
+ax_anim 2, 0, 63, 17, -12, 19, -16,
+ax_anim 2, 0, 61, 17, -12, 19, -16,
+ax_anim 2, 0, 60, 13, -10, 13, -11,
+ax_anim 2, 0, 60, 5, -4, 5, -4,
+ax_anim_terminator
+sSharpedoAnims_3_5:
+ax_anim 2, 0, 64, 0, 2, 0, 2,
+ax_anim 6, 0, 64, 0, 3, 0, 3,
+ax_anim 1, 2, 67, 0, -1, 0, -1,
+ax_anim 2, 0, 67, 0, -12, 0, -14,
+ax_anim 4, 0, 67, 0, -14, 0, -18,
+ax_anim 2, 1, 65, 0, -14, 0, -18,
+ax_anim 2, 0, 67, 0, -14, 0, -18,
+ax_anim 2, 0, 65, 0, -14, 0, -18,
+ax_anim 2, 0, 67, 0, -14, 0, -18,
+ax_anim 2, 0, 65, 0, -14, 0, -18,
+ax_anim 2, 0, 64, 0, -11, 0, -12,
+ax_anim 2, 0, 64, 0, -4, 0, -4,
+ax_anim_terminator
+sSharpedoAnims_3_6:
+ax_anim 2, 0, 68, 2, 2, 2, 2,
+ax_anim 6, 0, 68, 3, 3, 3, 3,
+ax_anim 1, 2, 71, -1, -1, -1, -1,
+ax_anim 2, 0, 71, -13, -10, -13, -11,
+ax_anim 4, 0, 71, -17, -12, -19, -16,
+ax_anim 2, 1, 69, -17, -12, -19, -16,
+ax_anim 2, 0, 71, -17, -12, -19, -16,
+ax_anim 2, 0, 69, -17, -12, -19, -16,
+ax_anim 2, 0, 71, -17, -12, -19, -16,
+ax_anim 2, 0, 69, -17, -12, -19, -16,
+ax_anim 2, 0, 68, -13, -10, -13, -11,
+ax_anim 2, 0, 68, -5, -4, -5, -4,
+ax_anim_terminator
+sSharpedoAnims_3_7:
+ax_anim 2, 0, 72, 2, 0, 2, 0,
+ax_anim 6, 0, 72, 3, 0, 3, 0,
+ax_anim 1, 2, 75, -1, 1, -1, 0,
+ax_anim 2, 0, 75, -10, 2, -10, 0,
+ax_anim 4, 0, 75, -16, 3, -18, 0,
+ax_anim 2, 1, 73, -16, 3, -18, 0,
+ax_anim 2, 0, 75, -16, 3, -18, 0,
+ax_anim 2, 0, 73, -16, 3, -18, 0,
+ax_anim 2, 0, 75, -16, 3, -18, 0,
+ax_anim 2, 0, 73, -16, 3, -18, 0,
+ax_anim 2, 0, 72, -13, 2, -13, 0,
+ax_anim 2, 0, 72, -4, 0, -4, 0,
+ax_anim_terminator
+sSharpedoAnims_3_8:
+ax_anim 2, 0, 76, 2, -2, 2, -2,
+ax_anim 6, 0, 76, 3, -3, 3, -3,
+ax_anim 1, 2, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 79, -10, 12, -10, 12,
+ax_anim 4, 0, 79, -19, 21, -19, 20,
+ax_anim 2, 1, 77, -19, 21, -20, 20,
+ax_anim 2, 0, 79, -19, 21, -19, 20,
+ax_anim 2, 0, 77, -19, 21, -20, 20,
+ax_anim 2, 0, 79, -19, 21, -19, 20,
+ax_anim 2, 0, 77, -19, 21, -20, 20,
+ax_anim 2, 0, 76, -13, 13, -13, 13,
+ax_anim 2, 0, 76, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_4_1:
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 2, 0, 82, 0, -4, 0, -4,
+ax_anim 6, 2, 80, 0, -5, 0, -5,
+ax_anim 1, 0, 83, 0, 1, 0, 1,
+ax_anim 2, 0, 83, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 1, 84, -1, 5, -1, 5,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, -1, 5, -1, 5,
+ax_anim 2, 0, 84, 0, 5, 0, 5,
+ax_anim 2, 0, 84, -1, 5, -1, 5,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sSharpedoAnims_4_2:
+ax_anim 2, 0, 86, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -4, -4, -4, -4,
+ax_anim 6, 2, 85, -5, -5, -5, -5,
+ax_anim 1, 0, 88, 1, 1, 1, 1,
+ax_anim 2, 0, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 5, 5, 5, 5,
+ax_anim 2, 1, 89, 4, 6, 4, 6,
+ax_anim 2, 0, 89, 5, 5, 5, 5,
+ax_anim 2, 0, 89, 4, 6, 4, 6,
+ax_anim 2, 0, 89, 5, 5, 5, 5,
+ax_anim 2, 0, 89, 4, 6, 4, 6,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim_terminator
+sSharpedoAnims_4_3:
+ax_anim 2, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 6, 2, 90, -5, 0, -5, 0,
+ax_anim 1, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 5, 0, 5, 0,
+ax_anim 2, 1, 94, 5, -1, 5, -1,
+ax_anim 2, 0, 94, 5, 0, 5, 0,
+ax_anim 2, 0, 94, 5, -1, 5, -1,
+ax_anim 2, 0, 94, 5, 0, 5, 0,
+ax_anim 2, 0, 94, 5, -1, 5, -1,
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim_terminator
+sSharpedoAnims_4_4:
+ax_anim 2, 0, 96, -2, 2, -2, 2,
+ax_anim 2, 0, 97, -4, 4, -4, 4,
+ax_anim 6, 2, 95, -5, 5, -5, 5,
+ax_anim 1, 0, 98, 1, -1, 1, -1,
+ax_anim 2, 0, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 1, 99, 4, -6, 4, -6,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 4, -6, 4, -6,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 4, -6, 4, -6,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim_terminator
+sSharpedoAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 2, 0, 102, 0, 4, 0, 4,
+ax_anim 6, 2, 100, 0, 6, 0, 5,
+ax_anim 1, 0, 103, 0, -1, 0, -1,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -5, 0, -5,
+ax_anim 2, 1, 104, -1, -5, -1, -5,
+ax_anim 2, 0, 104, 0, -5, 0, -5,
+ax_anim 2, 0, 104, -1, -5, -1, -5,
+ax_anim 2, 0, 104, 0, -5, 0, -5,
+ax_anim 2, 0, 104, -1, -5, -1, -5,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sSharpedoAnims_4_6:
+ax_anim 2, 0, 106, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 4, 4, 4, 4,
+ax_anim 6, 2, 105, 5, 5, 5, 5,
+ax_anim 1, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 109, -5, -5, -5, -5,
+ax_anim 2, 1, 109, -4, -6, -4, -6,
+ax_anim 2, 0, 109, -5, -5, -5, -5,
+ax_anim 2, 0, 109, -4, -6, -4, -6,
+ax_anim 2, 0, 109, -5, -5, -5, -5,
+ax_anim 2, 0, 109, -4, -6, -4, -6,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim_terminator
+sSharpedoAnims_4_7:
+ax_anim 2, 0, 111, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 6, 2, 110, 5, 0, 5, 0,
+ax_anim 1, 0, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 114, -5, 0, -5, 0,
+ax_anim 2, 1, 114, -5, -1, -5, -1,
+ax_anim 2, 0, 114, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -5, -1, -5, -1,
+ax_anim 2, 0, 114, -5, 0, -5, 0,
+ax_anim 2, 0, 114, -5, -1, -5, -1,
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim_terminator
+sSharpedoAnims_4_8:
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim 2, 0, 117, 4, -4, 4, -4,
+ax_anim 6, 2, 115, 5, -5, 5, -5,
+ax_anim 1, 0, 118, -1, 1, -1, 1,
+ax_anim 2, 0, 118, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 1, 119, -4, 6, -4, 6,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -4, 6, -4, 6,
+ax_anim 2, 0, 119, -5, 5, -5, 5,
+ax_anim 2, 0, 119, -4, 6, -4, 6,
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_5_1:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 0, 121, 1, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 2, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_5_2:
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 2, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_5_3:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 2, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_5_4:
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 2, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_5_5:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 6, 2, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_5_6:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 2, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_5_7:
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 2, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_5_8:
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 6, 2, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_6_1:
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, -1, 0, 0,
+ax_anim 26, 0, 136, 0, -2, 0, 0,
+ax_anim 8, 0, 137, 0, -2, 0, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim 26, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sSharpedoAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sSharpedoAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sSharpedoAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sSharpedoAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sSharpedoAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sSharpedoAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sSharpedoAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_8_1:
+ax_anim 16, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim 16, 0, 146, 0, -1, 0, 0,
+ax_anim 16, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_8_2:
+ax_anim 16, 0, 149, 0, 0, 0, 0,
+ax_anim 16, 0, 150, 0, 0, 0, 0,
+ax_anim 16, 0, 149, 0, -1, 0, 0,
+ax_anim 16, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_8_3:
+ax_anim 16, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim 16, 0, 152, 0, -1, 0, 0,
+ax_anim 16, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_8_4:
+ax_anim 16, 0, 155, 0, 0, 0, 0,
+ax_anim 16, 0, 156, 0, 0, 0, 0,
+ax_anim 16, 0, 155, 0, -1, 0, 0,
+ax_anim 16, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_8_5:
+ax_anim 16, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim 16, 0, 158, 0, -1, 0, 0,
+ax_anim 16, 0, 160, 0, -1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_8_6:
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_8_7:
+ax_anim 16, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 165, 0, 0, 0, 0,
+ax_anim 16, 0, 164, 0, -1, 0, 0,
+ax_anim 16, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_8_8:
+ax_anim 16, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 167, 0, -1, 0, 0,
+ax_anim 16, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 8, 3, 8, 3,
+ax_anim 2, 0, 172, 11, 10, 11, 10,
+ax_anim 2, 0, 173, 9, 18, 9, 18,
+ax_anim 3, 0, 174, 0, 23, 0, 23,
+ax_anim 2, 3, 175, -9, 18, -9, 18,
+ax_anim 2, 0, 176, -11, 10, -11, 10,
+ax_anim 1, 0, 177, -8, 3, -8, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 10, 1, 10, 1,
+ax_anim 2, 0, 171, 17, 6, 17, 6,
+ax_anim 2, 0, 172, 21, 14, 21, 14,
+ax_anim 3, 0, 173, 20, 21, 20, 21,
+ax_anim 2, 3, 174, 10, 23, 10, 23,
+ax_anim 2, 0, 175, 2, 17, 2, 17,
+ax_anim 1, 0, 176, 0, 8, 0, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 4, -4, 4, -4,
+ax_anim 2, 0, 170, 11, -5, 11, -5,
+ax_anim 2, 0, 171, 17, -4, 17, -4,
+ax_anim 3, 0, 172, 22, 2, 22, 2,
+ax_anim 2, 3, 173, 18, 7, 18, 7,
+ax_anim 2, 0, 174, 10, 9, 10, 9,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 1, -8, 1, -8,
+ax_anim 2, 0, 177, 5, -16, 5, -16,
+ax_anim 2, 0, 170, 12, -19, 12, -19,
+ax_anim 3, 0, 171, 21, -17, 21, -17,
+ax_anim 2, 3, 172, 24, -12, 24, -12,
+ax_anim 2, 0, 173, 18, -5, 18, -5,
+ax_anim 1, 0, 174, 10, 0, 10, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -10, -3, -10, -3,
+ax_anim 2, 0, 176, -11, -10, -11, -10,
+ax_anim 2, 0, 177, -8, -16, -8, -16,
+ax_anim 3, 0, 170, 0, -18, 0, -18,
+ax_anim 2, 3, 171, 8, -16, 8, -16,
+ax_anim 2, 0, 172, 11, -10, 11, -10,
+ax_anim 1, 0, 173, 10, -3, 10, -3,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, -1, -8, -1, -8,
+ax_anim 2, 0, 171, -5, -16, -5, -16,
+ax_anim 2, 0, 170, -12, -19, -12, -19,
+ax_anim 3, 0, 177, -21, -17, -21, -17,
+ax_anim 2, 3, 176, -24, -12, -24, -12,
+ax_anim 2, 0, 175, -18, -5, -18, -5,
+ax_anim 1, 0, 174, -10, 0, -10, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -4, -4, -4, -4,
+ax_anim 2, 0, 170, -11, -5, -11, -5,
+ax_anim 2, 0, 177, -17, -4, -17, -4,
+ax_anim 3, 0, 176, -22, 2, -22, 2,
+ax_anim 2, 3, 175, -18, 7, -18, 7,
+ax_anim 2, 0, 174, -10, 9, -10, 9,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -10, 1, -10, 1,
+ax_anim 2, 0, 177, -17, 6, -17, 6,
+ax_anim 2, 0, 176, -21, 14, -21, 14,
+ax_anim 3, 0, 175, -20, 21, -20, 21,
+ax_anim 2, 3, 174, -10, 23, -10, 23,
+ax_anim 2, 0, 173, -2, 17, -2, 17,
+ax_anim 1, 0, 172, 0, 8, 0, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -17, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 2, 189, 0, 1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -15, 0, 0,
+ax_anim 3, 0, 194, 0, -19, 0, 0,
+ax_anim 4, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 2, 192, 0, 1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 1, 0, 196, 0, -9, 0, 0,
+ax_anim 2, 2, 195, 0, 1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -17, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 1, 0, 202, 0, -9, 0, 0,
+ax_anim 2, 2, 201, 0, 1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -15, 0, 0,
+ax_anim 3, 0, 206, 0, -19, 0, 0,
+ax_anim 4, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 2, 204, 0, 1, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -17, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 2, 207, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSharpedoAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSharpedoGfx1:
+.incbin "baserom.gba", 0x12FEC64, 0x200
+sSharpedoSprites1:
+ax_sprite sSharpedoGfx1, 0x200
+ax_sprite_terminator
+sSharpedoGfx2:
+.incbin "baserom.gba", 0x12FEE74, 0x200
+sSharpedoSprites2:
+ax_sprite sSharpedoGfx2, 0x200
+ax_sprite_terminator
+sSharpedoGfx3:
+.incbin "baserom.gba", 0x12FF084, 0x200
+sSharpedoSprites3:
+ax_sprite sSharpedoGfx3, 0x200
+ax_sprite_terminator
+sSharpedoGfx4:
+.incbin "baserom.gba", 0x12FF294, 0x200
+sSharpedoSprites4:
+ax_sprite sSharpedoGfx4, 0x200
+ax_sprite_terminator
+sSharpedoGfx5:
+.incbin "baserom.gba", 0x12FF4A4, 0x200
+sSharpedoSprites5:
+ax_sprite sSharpedoGfx5, 0x200
+ax_sprite_terminator
+sSharpedoGfx6:
+.incbin "baserom.gba", 0x12FF6B4, 0x200
+sSharpedoSprites6:
+ax_sprite sSharpedoGfx6, 0x200
+ax_sprite_terminator
+sSharpedoGfx7:
+.incbin "baserom.gba", 0x12FF8C4, 0x200
+sSharpedoSprites7:
+ax_sprite sSharpedoGfx7, 0x200
+ax_sprite_terminator
+sSharpedoGfx8:
+.incbin "baserom.gba", 0x12FFAD4, 0x200
+sSharpedoSprites8:
+ax_sprite sSharpedoGfx8, 0x200
+ax_sprite_terminator
+sSharpedoGfx9:
+.incbin "baserom.gba", 0x12FFCE4, 0x200
+sSharpedoSprites9:
+ax_sprite sSharpedoGfx9, 0x200
+ax_sprite_terminator
+sSharpedoGfx10:
+.incbin "baserom.gba", 0x12FFEF4, 0x200
+sSharpedoSprites10:
+ax_sprite sSharpedoGfx10, 0x200
+ax_sprite_terminator
+sSharpedoGfx11:
+.incbin "baserom.gba", 0x1300104, 0x200
+sSharpedoSprites11:
+ax_sprite sSharpedoGfx11, 0x200
+ax_sprite_terminator
+sSharpedoGfx12:
+.incbin "baserom.gba", 0x1300314, 0x200
+sSharpedoSprites12:
+ax_sprite sSharpedoGfx12, 0x200
+ax_sprite_terminator
+sSharpedoGfx13:
+.incbin "baserom.gba", 0x1300524, 0x200
+sSharpedoSprites13:
+ax_sprite sSharpedoGfx13, 0x200
+ax_sprite_terminator
+sSharpedoGfx14:
+.incbin "baserom.gba", 0x1300734, 0x200
+sSharpedoSprites14:
+ax_sprite sSharpedoGfx14, 0x200
+ax_sprite_terminator
+sSharpedoGfx15:
+.incbin "baserom.gba", 0x1300944, 0x200
+sSharpedoSprites15:
+ax_sprite sSharpedoGfx15, 0x200
+ax_sprite_terminator
+sSharpedoGfx16:
+.incbin "baserom.gba", 0x1300B54, 0x40
+sSharpedoGfx16_1:
+.incbin "baserom.gba", 0x1300B94, 0x40
+sSharpedoGfx16_2:
+.incbin "baserom.gba", 0x1300BD4, 0x80
+sSharpedoGfx16_3:
+.incbin "baserom.gba", 0x1300C54, 0x40
+sSharpedoSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSharpedoGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx16_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx17:
+.incbin "baserom.gba", 0x1300CE4, 0x20
+sSharpedoGfx17_1:
+.incbin "baserom.gba", 0x1300D04, 0x60
+sSharpedoGfx17_2:
+.incbin "baserom.gba", 0x1300D64, 0x80
+sSharpedoGfx17_3:
+.incbin "baserom.gba", 0x1300DE4, 0x60
+sSharpedoSprites17:
+ax_sprite 0, 0x40
+ax_sprite sSharpedoGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx17_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx17_3, 0x60
+ax_sprite_terminator
+sSharpedoGfx18:
+.incbin "baserom.gba", 0x1300E8C, 0x40
+sSharpedoGfx18_1:
+.incbin "baserom.gba", 0x1300ECC, 0x60
+sSharpedoGfx18_2:
+.incbin "baserom.gba", 0x1300F2C, 0x60
+sSharpedoGfx18_3:
+.incbin "baserom.gba", 0x1300F8C, 0x60
+sSharpedoSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx19:
+.incbin "baserom.gba", 0x130103C, 0x40
+sSharpedoGfx19_1:
+.incbin "baserom.gba", 0x130107C, 0x160
+sSharpedoSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx20:
+.incbin "baserom.gba", 0x130120C, 0x40
+sSharpedoGfx20_1:
+.incbin "baserom.gba", 0x130124C, 0x40
+sSharpedoGfx20_2:
+.incbin "baserom.gba", 0x130128C, 0x80
+sSharpedoGfx20_3:
+.incbin "baserom.gba", 0x130130C, 0x40
+sSharpedoSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSharpedoGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx20_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx21:
+.incbin "baserom.gba", 0x130139C, 0x40
+sSharpedoGfx21_1:
+.incbin "baserom.gba", 0x13013DC, 0x100
+sSharpedoGfx21_2:
+.incbin "baserom.gba", 0x13014DC, 0x40
+sSharpedoSprites21:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx22:
+.incbin "baserom.gba", 0x130155C, 0x40
+sSharpedoGfx22_1:
+.incbin "baserom.gba", 0x130159C, 0x160
+sSharpedoSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx22_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx23:
+.incbin "baserom.gba", 0x130172C, 0x20
+sSharpedoGfx23_1:
+.incbin "baserom.gba", 0x130174C, 0x60
+sSharpedoGfx23_2:
+.incbin "baserom.gba", 0x13017AC, 0x60
+sSharpedoGfx23_3:
+.incbin "baserom.gba", 0x130180C, 0x60
+sSharpedoSprites23:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSharpedoGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx24:
+.incbin "baserom.gba", 0x13018BC, 0x40
+sSharpedoGfx24_1:
+.incbin "baserom.gba", 0x13018FC, 0x160
+sSharpedoSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx24_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx25:
+.incbin "baserom.gba", 0x1301A8C, 0x40
+sSharpedoGfx25_1:
+.incbin "baserom.gba", 0x1301ACC, 0x40
+sSharpedoGfx25_2:
+.incbin "baserom.gba", 0x1301B0C, 0x80
+sSharpedoGfx25_3:
+.incbin "baserom.gba", 0x1301B8C, 0x40
+sSharpedoSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSharpedoGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSharpedoGfx26:
+.incbin "baserom.gba", 0x1301C1C, 0x80
+sSharpedoGfx26_1:
+.incbin "baserom.gba", 0x1301C9C, 0x60
+sSharpedoSprites26:
+ax_sprite sSharpedoGfx26, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx26_1, 0x60
+ax_sprite_terminator
+sSharpedoGfx27:
+.incbin "baserom.gba", 0x1301D1C, 0x60
+sSharpedoSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx27, 0x60
+ax_sprite_terminator
+sSharpedoGfx28:
+.incbin "baserom.gba", 0x1301D94, 0x40
+sSharpedoSprites28:
+ax_sprite sSharpedoGfx28, 0x40
+ax_sprite_terminator
+sSharpedoGfx29:
+.incbin "baserom.gba", 0x1301DE4, 0x20
+sSharpedoSprites29:
+ax_sprite sSharpedoGfx29, 0x20
+ax_sprite_terminator
+sSharpedoGfx30:
+.incbin "baserom.gba", 0x1301E14, 0x20
+sSharpedoSprites30:
+ax_sprite sSharpedoGfx30, 0x20
+ax_sprite_terminator
+sSharpedoGfx31:
+.incbin "baserom.gba", 0x1301E44, 0x100
+sSharpedoSprites31:
+ax_sprite sSharpedoGfx31, 0x100
+ax_sprite_terminator
+sSharpedoGfx32:
+.incbin "baserom.gba", 0x1301F54, 0x20
+sSharpedoSprites32:
+ax_sprite sSharpedoGfx32, 0x20
+ax_sprite_terminator
+sSharpedoGfx33:
+.incbin "baserom.gba", 0x1301F84, 0x40
+sSharpedoSprites33:
+ax_sprite sSharpedoGfx33, 0x40
+ax_sprite_terminator
+sSharpedoGfx34:
+.incbin "baserom.gba", 0x1301FD4, 0x20
+sSharpedoSprites34:
+ax_sprite sSharpedoGfx34, 0x20
+ax_sprite_terminator
+sSharpedoGfx35:
+.incbin "baserom.gba", 0x1302004, 0x40
+sSharpedoSprites35:
+ax_sprite sSharpedoGfx35, 0x40
+ax_sprite_terminator
+sSharpedoGfx36:
+.incbin "baserom.gba", 0x1302054, 0x20
+sSharpedoSprites36:
+ax_sprite sSharpedoGfx36, 0x20
+ax_sprite_terminator
+sSharpedoGfx37:
+.incbin "baserom.gba", 0x1302084, 0x20
+sSharpedoSprites37:
+ax_sprite sSharpedoGfx37, 0x20
+ax_sprite_terminator
+sSharpedoGfx38:
+.incbin "baserom.gba", 0x13020B4, 0x20
+sSharpedoGfx38_1:
+.incbin "baserom.gba", 0x13020D4, 0xC0
+sSharpedoSprites38:
+ax_sprite sSharpedoGfx38, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx38_1, 0xc0
+ax_sprite_terminator
+sSharpedoGfx39:
+.incbin "baserom.gba", 0x13021B4, 0x80
+sSharpedoSprites39:
+ax_sprite sSharpedoGfx39, 0x80
+ax_sprite_terminator
+sSharpedoGfx40:
+.incbin "baserom.gba", 0x1302244, 0x20
+sSharpedoSprites40:
+ax_sprite sSharpedoGfx40, 0x20
+ax_sprite_terminator
+sSharpedoGfx41:
+.incbin "baserom.gba", 0x1302274, 0x20
+sSharpedoSprites41:
+ax_sprite sSharpedoGfx41, 0x20
+ax_sprite_terminator
+sSharpedoGfx42:
+.incbin "baserom.gba", 0x13022A4, 0x40
+sSharpedoSprites42:
+ax_sprite sSharpedoGfx42, 0x40
+ax_sprite_terminator
+sSharpedoGfx43:
+.incbin "baserom.gba", 0x13022F4, 0x100
+sSharpedoSprites43:
+ax_sprite sSharpedoGfx43, 0x100
+ax_sprite_terminator
+sSharpedoGfx44:
+.incbin "baserom.gba", 0x1302404, 0x80
+sSharpedoSprites44:
+ax_sprite sSharpedoGfx44, 0x80
+ax_sprite_terminator
+sSharpedoGfx45:
+.incbin "baserom.gba", 0x1302494, 0x20
+sSharpedoSprites45:
+ax_sprite sSharpedoGfx45, 0x20
+ax_sprite_terminator
+sSharpedoGfx46:
+.incbin "baserom.gba", 0x13024C4, 0x40
+sSharpedoSprites46:
+ax_sprite sSharpedoGfx46, 0x40
+ax_sprite_terminator
+sSharpedoGfx47:
+.incbin "baserom.gba", 0x1302514, 0x20
+sSharpedoSprites47:
+ax_sprite sSharpedoGfx47, 0x20
+ax_sprite_terminator
+sSharpedoGfx48:
+.incbin "baserom.gba", 0x1302544, 0x60
+sSharpedoSprites48:
+ax_sprite 0, 0x20
+ax_sprite sSharpedoGfx48, 0x60
+ax_sprite_terminator
+sSharpedoGfx49:
+.incbin "baserom.gba", 0x13025BC, 0x100
+sSharpedoSprites49:
+ax_sprite sSharpedoGfx49, 0x100
+ax_sprite_terminator
+sSharpedoGfx50:
+.incbin "baserom.gba", 0x13026CC, 0x20
+sSharpedoSprites50:
+ax_sprite sSharpedoGfx50, 0x20
+ax_sprite_terminator
+sSharpedoGfx51:
+.incbin "baserom.gba", 0x13026FC, 0x20
+sSharpedoSprites51:
+ax_sprite sSharpedoGfx51, 0x20
+ax_sprite_terminator
+sSharpedoGfx52:
+.incbin "baserom.gba", 0x130272C, 0x40
+sSharpedoSprites52:
+ax_sprite sSharpedoGfx52, 0x40
+ax_sprite_terminator
+sSharpedoGfx53:
+.incbin "baserom.gba", 0x130277C, 0x200
+sSharpedoSprites53:
+ax_sprite sSharpedoGfx53, 0x200
+ax_sprite_terminator
+sSharpedoGfx54:
+.incbin "baserom.gba", 0x130298C, 0x200
+sSharpedoSprites54:
+ax_sprite sSharpedoGfx54, 0x200
+ax_sprite_terminator
+sSharpedoGfx55:
+.incbin "baserom.gba", 0x1302B9C, 0x200
+sSharpedoSprites55:
+ax_sprite sSharpedoGfx55, 0x200
+ax_sprite_terminator
+sSharpedoGfx56:
+.incbin "baserom.gba", 0x1302DAC, 0x200
+sSharpedoSprites56:
+ax_sprite sSharpedoGfx56, 0x200
+ax_sprite_terminator
+sSharpedoGfx57:
+.incbin "baserom.gba", 0x1302FBC, 0x200
+sSharpedoSprites57:
+ax_sprite sSharpedoGfx57, 0x200
+ax_sprite_terminator
+sSharpedoGfx58:
+.incbin "baserom.gba", 0x13031CC, 0x200
+sSharpedoSprites58:
+ax_sprite sSharpedoGfx58, 0x200
+ax_sprite_terminator
+sSharpedoGfx59:
+.incbin "baserom.gba", 0x13033DC, 0x200
+sSharpedoSprites59:
+ax_sprite sSharpedoGfx59, 0x200
+ax_sprite_terminator
+sAxPosesSharpedo:
+.4byte sSharpedoPose1
+.4byte sSharpedoPose2
+.4byte sSharpedoPose3
+.4byte sSharpedoPose4
+.4byte sSharpedoPose5
+.4byte sSharpedoPose6
+.4byte sSharpedoPose7
+.4byte sSharpedoPose8
+.4byte sSharpedoPose9
+.4byte sSharpedoPose10
+.4byte sSharpedoPose11
+.4byte sSharpedoPose12
+.4byte sSharpedoPose13
+.4byte sSharpedoPose14
+.4byte sSharpedoPose15
+.4byte sSharpedoPose16
+.4byte sSharpedoPose17
+.4byte sSharpedoPose18
+.4byte sSharpedoPose19
+.4byte sSharpedoPose20
+.4byte sSharpedoPose21
+.4byte sSharpedoPose22
+.4byte sSharpedoPose23
+.4byte sSharpedoPose24
+.4byte sSharpedoPose25
+.4byte sSharpedoPose26
+.4byte sSharpedoPose27
+.4byte sSharpedoPose28
+.4byte sSharpedoPose29
+.4byte sSharpedoPose30
+.4byte sSharpedoPose31
+.4byte sSharpedoPose32
+.4byte sSharpedoPose33
+.4byte sSharpedoPose34
+.4byte sSharpedoPose35
+.4byte sSharpedoPose36
+.4byte sSharpedoPose37
+.4byte sSharpedoPose38
+.4byte sSharpedoPose39
+.4byte sSharpedoPose40
+.4byte sSharpedoPose41
+.4byte sSharpedoPose42
+.4byte sSharpedoPose43
+.4byte sSharpedoPose44
+.4byte sSharpedoPose45
+.4byte sSharpedoPose46
+.4byte sSharpedoPose47
+.4byte sSharpedoPose48
+.4byte sSharpedoPose49
+.4byte sSharpedoPose50
+.4byte sSharpedoPose51
+.4byte sSharpedoPose52
+.4byte sSharpedoPose53
+.4byte sSharpedoPose54
+.4byte sSharpedoPose55
+.4byte sSharpedoPose56
+.4byte sSharpedoPose57
+.4byte sSharpedoPose58
+.4byte sSharpedoPose59
+.4byte sSharpedoPose60
+.4byte sSharpedoPose61
+.4byte sSharpedoPose62
+.4byte sSharpedoPose63
+.4byte sSharpedoPose64
+.4byte sSharpedoPose65
+.4byte sSharpedoPose66
+.4byte sSharpedoPose67
+.4byte sSharpedoPose68
+.4byte sSharpedoPose69
+.4byte sSharpedoPose70
+.4byte sSharpedoPose71
+.4byte sSharpedoPose72
+.4byte sSharpedoPose73
+.4byte sSharpedoPose74
+.4byte sSharpedoPose75
+.4byte sSharpedoPose76
+.4byte sSharpedoPose77
+.4byte sSharpedoPose78
+.4byte sSharpedoPose79
+.4byte sSharpedoPose80
+.4byte sSharpedoPose81
+.4byte sSharpedoPose82
+.4byte sSharpedoPose83
+.4byte sSharpedoPose84
+.4byte sSharpedoPose85
+.4byte sSharpedoPose86
+.4byte sSharpedoPose87
+.4byte sSharpedoPose88
+.4byte sSharpedoPose89
+.4byte sSharpedoPose90
+.4byte sSharpedoPose91
+.4byte sSharpedoPose92
+.4byte sSharpedoPose93
+.4byte sSharpedoPose94
+.4byte sSharpedoPose95
+.4byte sSharpedoPose96
+.4byte sSharpedoPose97
+.4byte sSharpedoPose98
+.4byte sSharpedoPose99
+.4byte sSharpedoPose100
+.4byte sSharpedoPose101
+.4byte sSharpedoPose102
+.4byte sSharpedoPose103
+.4byte sSharpedoPose104
+.4byte sSharpedoPose105
+.4byte sSharpedoPose106
+.4byte sSharpedoPose107
+.4byte sSharpedoPose108
+.4byte sSharpedoPose109
+.4byte sSharpedoPose110
+.4byte sSharpedoPose111
+.4byte sSharpedoPose112
+.4byte sSharpedoPose113
+.4byte sSharpedoPose114
+.4byte sSharpedoPose115
+.4byte sSharpedoPose116
+.4byte sSharpedoPose117
+.4byte sSharpedoPose118
+.4byte sSharpedoPose119
+.4byte sSharpedoPose120
+.4byte sSharpedoPose121
+.4byte sSharpedoPose122
+.4byte sSharpedoPose123
+.4byte sSharpedoPose124
+.4byte sSharpedoPose125
+.4byte sSharpedoPose126
+.4byte sSharpedoPose127
+.4byte sSharpedoPose128
+.4byte sSharpedoPose129
+.4byte sSharpedoPose130
+.4byte sSharpedoPose131
+.4byte sSharpedoPose132
+.4byte sSharpedoPose133
+.4byte sSharpedoPose134
+.4byte sSharpedoPose135
+.4byte sSharpedoPose136
+.4byte sSharpedoPose137
+.4byte sSharpedoPose138
+.4byte sSharpedoPose139
+.4byte sSharpedoPose140
+.4byte sSharpedoPose141
+.4byte sSharpedoPose142
+.4byte sSharpedoPose143
+.4byte sSharpedoPose144
+.4byte sSharpedoPose145
+.4byte sSharpedoPose146
+.4byte sSharpedoPose147
+.4byte sSharpedoPose148
+.4byte sSharpedoPose149
+.4byte sSharpedoPose150
+.4byte sSharpedoPose151
+.4byte sSharpedoPose152
+.4byte sSharpedoPose153
+.4byte sSharpedoPose154
+.4byte sSharpedoPose155
+.4byte sSharpedoPose156
+.4byte sSharpedoPose157
+.4byte sSharpedoPose158
+.4byte sSharpedoPose159
+.4byte sSharpedoPose160
+.4byte sSharpedoPose161
+.4byte sSharpedoPose162
+.4byte sSharpedoPose163
+.4byte sSharpedoPose164
+.4byte sSharpedoPose165
+.4byte sSharpedoPose166
+.4byte sSharpedoPose167
+.4byte sSharpedoPose168
+.4byte sSharpedoPose169
+.4byte sSharpedoPose170
+.4byte sSharpedoPose171
+.4byte sSharpedoPose172
+.4byte sSharpedoPose173
+.4byte sSharpedoPose174
+.4byte sSharpedoPose175
+.4byte sSharpedoPose176
+.4byte sSharpedoPose177
+.4byte sSharpedoPose178
+.4byte sSharpedoPose179
+.4byte sSharpedoPose180
+.4byte sSharpedoPose181
+.4byte sSharpedoPose182
+.4byte sSharpedoPose183
+.4byte sSharpedoPose184
+.4byte sSharpedoPose185
+.4byte sSharpedoPose186
+.4byte sSharpedoPose187
+.4byte sSharpedoPose188
+.4byte sSharpedoPose189
+.4byte sSharpedoPose190
+.4byte sSharpedoPose191
+.4byte sSharpedoPose192
+.4byte sSharpedoPose193
+.4byte sSharpedoPose194
+.4byte sSharpedoPose195
+.4byte sSharpedoPose196
+.4byte sSharpedoPose197
+.4byte sSharpedoPose198
+.4byte sSharpedoPose199
+.4byte sSharpedoPose200
+.4byte sSharpedoPose201
+.4byte sSharpedoPose202
+.4byte sSharpedoPose203
+.4byte sSharpedoPose204
+.4byte sSharpedoPose205
+.4byte sSharpedoPose206
+.4byte sSharpedoPose207
+.4byte sSharpedoPose208
+.4byte sSharpedoPose209
+.4byte sSharpedoPose210
+.4byte sSharpedoPose211
+.4byte sSharpedoPose212
+.4byte sSharpedoPose213
+.4byte sSharpedoPose214
+.4byte sSharpedoPose215
+.4byte sSharpedoPose216
+.4byte sSharpedoPose217
+.4byte sSharpedoPose218
+.4byte sSharpedoPose219
+.4byte sSharpedoPose220
+.4byte sSharpedoPose221
+.4byte sSharpedoPose222
+.4byte sSharpedoPose223
+.4byte sSharpedoPose224
+.4byte sSharpedoPose225
+.4byte sSharpedoPose226
+sAxPositionsSharpedo:
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -15, 	  11,  -15, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -11, 	  11,  -11, 	   0,  -13
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+.2byte    7,   -5, 	   8,  -17, 	 -11,  -11, 	   2,  -14
+.2byte    6,   -5, 	   9,  -15, 	 -10,   -7, 	   2,  -13
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte   10,   -9, 	  -4,  -20, 	  -4,   -7, 	   1,  -12
+.2byte    9,   -9, 	  -3,  -19, 	  -3,   -5, 	   0,  -12
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte    9,  -14, 	  -8,  -17, 	  10,   -8, 	   1,  -13
+.2byte    9,  -14, 	  -8,  -14, 	   9,   -4, 	   1,  -13
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    0,  -20, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    0,  -20, 	  12,   -9, 	 -12,   -9, 	   0,  -14
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte   -9,  -14, 	   8,  -17, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -14, 	   8,  -14, 	  -9,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte  -10,   -9, 	   4,  -20, 	   4,   -7, 	  -1,  -12
+.2byte   -9,   -9, 	   3,  -19, 	   3,   -5, 	   0,  -12
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -7,   -5, 	  -8,  -17, 	  11,  -11, 	  -2,  -14
+.2byte   -6,   -5, 	  -9,  -15, 	  10,   -7, 	  -2,  -13
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -15, 	  11,  -15, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -11, 	  11,  -11, 	   0,  -13
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+.2byte    7,   -5, 	   8,  -17, 	 -11,  -11, 	   2,  -14
+.2byte    6,   -5, 	   9,  -15, 	 -10,   -7, 	   2,  -13
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte   10,   -9, 	  -4,  -20, 	  -4,   -7, 	   1,  -12
+.2byte    9,   -9, 	  -3,  -19, 	  -3,   -5, 	   0,  -12
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte    9,  -14, 	  -8,  -17, 	  10,   -8, 	   1,  -13
+.2byte    9,  -14, 	  -8,  -14, 	   9,   -4, 	   1,  -13
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    0,  -20, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    0,  -20, 	  12,   -9, 	 -12,   -9, 	   0,  -14
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte   -9,  -14, 	   8,  -17, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -14, 	   8,  -14, 	  -9,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte  -10,   -9, 	   4,  -20, 	   4,   -7, 	  -1,  -12
+.2byte   -9,   -9, 	   3,  -19, 	   3,   -5, 	   0,  -12
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -7,   -5, 	  -8,  -17, 	  11,  -11, 	  -2,  -14
+.2byte   -6,   -5, 	  -9,  -15, 	  10,   -7, 	  -2,  -13
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -15, 	  11,  -15, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -11, 	  11,  -11, 	   0,  -13
+.2byte    0,   -7, 	 -11,  -13, 	  12,  -13, 	   0,  -15
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+.2byte    7,   -5, 	   8,  -17, 	 -11,  -11, 	   2,  -14
+.2byte    6,   -5, 	   9,  -15, 	 -10,   -7, 	   2,  -13
+.2byte    5,   -6, 	   8,  -16, 	 -12,   -8, 	   1,  -12
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte   10,   -9, 	  -4,  -20, 	  -4,   -7, 	   1,  -12
+.2byte    9,   -9, 	  -3,  -19, 	  -3,   -5, 	   0,  -12
+.2byte    6,   -9, 	  -5,  -18, 	  -3,   -5, 	   1,  -13
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte    9,  -14, 	  -8,  -17, 	  10,   -8, 	   1,  -13
+.2byte    9,  -14, 	  -8,  -14, 	   9,   -4, 	   1,  -13
+.2byte    8,  -14, 	 -11,  -14, 	  10,   -7, 	   0,  -14
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    0,  -20, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    0,  -20, 	  12,   -9, 	 -12,   -9, 	   0,  -14
+.2byte    0,  -21, 	  12,  -11, 	 -12,  -11, 	   0,  -13
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte   -9,  -14, 	   8,  -17, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -14, 	   8,  -14, 	  -9,   -4, 	  -1,  -13
+.2byte   -8,  -14, 	  11,  -14, 	 -10,   -7, 	   0,  -14
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte  -10,   -9, 	   4,  -20, 	   4,   -7, 	  -1,  -12
+.2byte   -9,   -9, 	   3,  -19, 	   3,   -5, 	   0,  -12
+.2byte   -6,   -9, 	   5,  -18, 	   3,   -5, 	  -1,  -13
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -7,   -5, 	  -8,  -17, 	  11,  -11, 	  -2,  -14
+.2byte   -6,   -5, 	  -9,  -15, 	  10,   -7, 	  -2,  -13
+.2byte   -5,   -6, 	  -8,  -16, 	  12,   -8, 	  -1,  -12
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -15, 	  11,  -15, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -11, 	  11,  -11, 	   0,  -13
+.2byte    0,   -2, 	 -11,  -13, 	  12,  -13, 	   0,  -12
+.2byte    0,   -7, 	 -11,  -13, 	  12,  -13, 	   0,  -15
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+.2byte    7,   -5, 	   8,  -17, 	 -11,  -11, 	   2,  -14
+.2byte    6,   -5, 	   9,  -15, 	 -10,   -7, 	   2,  -13
+.2byte    6,   -4, 	   9,  -16, 	 -11,  -11, 	   2,  -15
+.2byte    5,   -6, 	   8,  -16, 	 -12,   -8, 	   1,  -12
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte   10,   -9, 	  -4,  -20, 	  -4,   -7, 	   1,  -12
+.2byte    9,   -9, 	  -3,  -19, 	  -3,   -5, 	   0,  -12
+.2byte    9,   -7, 	  -2,  -20, 	  -4,   -6, 	   1,  -11
+.2byte    6,   -9, 	  -5,  -18, 	  -3,   -5, 	   1,  -13
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte    9,  -14, 	  -8,  -17, 	  10,   -8, 	   1,  -13
+.2byte    9,  -14, 	  -8,  -14, 	   9,   -4, 	   1,  -13
+.2byte    9,  -13, 	  -9,  -17, 	   9,   -5, 	   1,  -13
+.2byte    8,  -14, 	 -11,  -14, 	  10,   -7, 	   0,  -14
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    0,  -20, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    0,  -20, 	  12,   -9, 	 -12,   -9, 	   0,  -14
+.2byte    0,  -16, 	  13,   -9, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -21, 	  12,  -11, 	 -12,  -11, 	   0,  -13
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte   -9,  -14, 	   8,  -17, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -14, 	   8,  -14, 	  -9,   -4, 	  -1,  -13
+.2byte   -9,  -13, 	   9,  -17, 	  -9,   -5, 	  -1,  -13
+.2byte   -8,  -14, 	  11,  -14, 	 -10,   -7, 	   0,  -14
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte  -10,   -9, 	   4,  -20, 	   4,   -7, 	  -1,  -12
+.2byte   -9,   -9, 	   3,  -19, 	   3,   -5, 	   0,  -12
+.2byte   -9,   -7, 	   2,  -20, 	   4,   -6, 	  -1,  -11
+.2byte   -6,   -9, 	   5,  -18, 	   3,   -5, 	  -1,  -13
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -7,   -5, 	  -8,  -17, 	  11,  -11, 	  -2,  -14
+.2byte   -6,   -5, 	  -9,  -15, 	  10,   -7, 	  -2,  -13
+.2byte   -6,   -4, 	  -9,  -16, 	  11,  -11, 	  -2,  -15
+.2byte   -5,   -6, 	  -8,  -16, 	  12,   -8, 	  -1,  -12
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte   -1,   -3, 	 -14,  -16, 	  14,  -16, 	   0,  -16
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+.2byte    7,   -5, 	  12,  -21, 	 -14,  -10, 	   1,  -18
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte   12,  -10, 	  -5,  -23, 	  -6,   -5, 	   0,  -14
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte   11,  -17, 	 -14,  -19, 	  12,   -6, 	   1,  -16
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    0,  -25, 	  15,  -12, 	 -15,  -12, 	   0,  -18
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte  -11,  -17, 	  14,  -19, 	 -12,   -6, 	  -1,  -16
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte  -12,  -10, 	   5,  -23, 	   6,   -5, 	   0,  -14
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -7,   -5, 	 -12,  -21, 	  14,  -10, 	  -1,  -18
+.2byte   -6,   -3, 	  -9,  -15, 	  11,   -7, 	   0,  -11
+.2byte   -6,   -2, 	  -8,  -14, 	  11,   -8, 	   1,  -11
+.2byte    0,  -10, 	 -11,  -11, 	  11,  -11, 	   0,  -15
+.2byte    3,  -10, 	   7,  -14, 	 -12,   -5, 	  -4,  -10
+.2byte    6,  -14, 	   2,  -11, 	   0,   -5, 	  -2,  -10
+.2byte    6,  -16, 	  -8,  -18, 	   8,   -5, 	  -2,  -13
+.2byte    0,  -21, 	  11,  -14, 	 -11,  -14, 	   0,  -13
+.2byte   -7,  -16, 	   7,  -18, 	  -9,   -5, 	   1,  -13
+.2byte   -7,  -14, 	  -3,  -11, 	  -1,   -5, 	   1,  -10
+.2byte   -4,  -10, 	  -8,  -14, 	  11,   -5, 	   3,  -10
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -15, 	  11,  -15, 	   0,  -13
+.2byte    0,   -4, 	 -10,  -11, 	  11,  -11, 	   0,  -13
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+.2byte    7,   -5, 	   8,  -17, 	 -11,  -11, 	   2,  -14
+.2byte    6,   -5, 	   9,  -15, 	 -10,   -7, 	   2,  -13
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte   10,   -9, 	  -4,  -20, 	  -4,   -7, 	   1,  -12
+.2byte    9,   -9, 	  -3,  -19, 	  -3,   -5, 	   0,  -12
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte    9,  -14, 	  -8,  -17, 	  10,   -8, 	   1,  -13
+.2byte    9,  -14, 	  -8,  -14, 	   9,   -4, 	   1,  -13
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    0,  -20, 	  12,  -12, 	 -12,  -12, 	   0,  -14
+.2byte    0,  -20, 	  12,   -9, 	 -12,   -9, 	   0,  -14
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte   -9,  -14, 	   8,  -17, 	 -10,   -8, 	  -1,  -13
+.2byte   -9,  -14, 	   8,  -14, 	  -9,   -4, 	  -1,  -13
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte  -10,   -9, 	   4,  -20, 	   4,   -7, 	  -1,  -12
+.2byte   -9,   -9, 	   3,  -19, 	   3,   -5, 	   0,  -12
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -7,   -5, 	  -8,  -17, 	  11,  -11, 	  -2,  -14
+.2byte   -6,   -5, 	  -9,  -15, 	  10,   -7, 	  -2,  -13
+.2byte    0,   -6, 	 -11,  -12, 	  12,  -12, 	   0,  -14
+.2byte   -5,   -6, 	  -8,  -16, 	  12,   -8, 	  -1,  -12
+.2byte   -5,   -8, 	   6,  -17, 	   4,   -4, 	   0,  -12
+.2byte   -8,  -12, 	  11,  -12, 	 -10,   -5, 	   0,  -12
+.2byte    0,  -20, 	  12,  -10, 	 -12,  -10, 	   0,  -12
+.2byte    7,  -12, 	 -12,  -12, 	   9,   -5, 	  -1,  -12
+.2byte    4,   -8, 	  -7,  -17, 	  -5,   -4, 	  -1,  -12
+.2byte    4,   -6, 	   7,  -16, 	 -13,   -8, 	   0,  -12
+.2byte    0,   -2, 	 -11,  -13, 	  12,  -13, 	   0,  -12
+.2byte    6,   -4, 	   9,  -16, 	 -11,  -11, 	   2,  -15
+.2byte    6,   -7, 	  -5,  -20, 	  -7,   -6, 	  -2,  -11
+.2byte    7,  -13, 	 -11,  -17, 	   7,   -5, 	  -1,  -13
+.2byte    0,  -16, 	  13,   -9, 	 -12,   -9, 	   0,   -9
+.2byte   -8,  -13, 	  10,  -17, 	  -8,   -5, 	   0,  -13
+.2byte   -7,   -7, 	   4,  -20, 	   6,   -6, 	   1,  -11
+.2byte   -6,   -4, 	  -9,  -16, 	  11,  -11, 	  -2,  -15
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte    0,   -2, 	 -11,  -13, 	  12,  -13, 	   0,  -12
+.2byte    0,   -7, 	 -11,  -13, 	  12,  -13, 	   0,  -15
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+.2byte    7,   -4, 	  10,  -16, 	 -10,  -11, 	   3,  -15
+.2byte    5,   -6, 	   8,  -16, 	 -12,   -8, 	   1,  -12
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte    9,   -7, 	  -2,  -20, 	  -4,   -6, 	   1,  -11
+.2byte    6,   -9, 	  -5,  -18, 	  -3,   -5, 	   1,  -13
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte    9,  -13, 	  -9,  -17, 	   9,   -5, 	   1,  -13
+.2byte    8,  -14, 	 -11,  -14, 	  10,   -7, 	   0,  -14
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    0,  -16, 	  13,   -9, 	 -12,   -9, 	   0,   -9
+.2byte    0,  -21, 	  12,  -11, 	 -12,  -11, 	   0,  -13
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte   -9,  -13, 	   9,  -17, 	  -9,   -5, 	  -1,  -13
+.2byte   -8,  -14, 	  11,  -14, 	 -10,   -7, 	   0,  -14
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte   -9,   -7, 	   2,  -20, 	   4,   -6, 	  -1,  -11
+.2byte   -6,   -9, 	   5,  -18, 	   3,   -5, 	  -1,  -13
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -7,   -4, 	 -10,  -16, 	  10,  -11, 	  -3,  -15
+.2byte   -5,   -6, 	  -8,  -16, 	  12,   -8, 	  -1,  -12
+.2byte    0,   -6, 	 -11,  -12, 	  12,  -12, 	   0,  -14
+.2byte   -5,   -6, 	  -8,  -16, 	  12,   -8, 	  -1,  -12
+.2byte   -5,   -8, 	   6,  -17, 	   4,   -4, 	   0,  -12
+.2byte   -8,  -12, 	  11,  -12, 	 -10,   -5, 	   0,  -12
+.2byte    0,  -20, 	  12,  -10, 	 -12,  -10, 	   0,  -12
+.2byte    7,  -12, 	 -12,  -12, 	   9,   -5, 	  -1,  -12
+.2byte    4,   -8, 	  -7,  -17, 	  -5,   -4, 	  -1,  -12
+.2byte    4,   -6, 	   7,  -16, 	 -13,   -8, 	   0,  -12
+.2byte    0,   -4, 	 -12,  -14, 	  12,  -14, 	   0,  -13
+.2byte   -6,   -5, 	  -9,  -17, 	  11,   -9, 	  -2,  -14
+.2byte   -9,   -9, 	   4,  -19, 	   4,   -5, 	  -1,  -12
+.2byte   -9,  -14, 	   9,  -16, 	 -10,   -6, 	  -2,  -13
+.2byte    0,  -20, 	  13,  -10, 	 -13,  -10, 	   0,  -14
+.2byte    9,  -14, 	  -9,  -16, 	  10,   -6, 	   2,  -13
+.2byte    9,   -9, 	  -4,  -19, 	  -4,   -5, 	   1,  -12
+.2byte    6,   -5, 	   9,  -17, 	 -11,   -9, 	   2,  -14
+sSharpedoAnimTable1:
+.4byte sSharpedoAnims_1_1
+.4byte sSharpedoAnims_1_2
+.4byte sSharpedoAnims_1_3
+.4byte sSharpedoAnims_1_4
+.4byte sSharpedoAnims_1_5
+.4byte sSharpedoAnims_1_6
+.4byte sSharpedoAnims_1_7
+.4byte sSharpedoAnims_1_8
+sSharpedoAnimTable2:
+.4byte sSharpedoAnims_2_1
+.4byte sSharpedoAnims_2_2
+.4byte sSharpedoAnims_2_3
+.4byte sSharpedoAnims_2_4
+.4byte sSharpedoAnims_2_5
+.4byte sSharpedoAnims_2_6
+.4byte sSharpedoAnims_2_7
+.4byte sSharpedoAnims_2_8
+sSharpedoAnimTable3:
+.4byte sSharpedoAnims_3_1
+.4byte sSharpedoAnims_3_2
+.4byte sSharpedoAnims_3_3
+.4byte sSharpedoAnims_3_4
+.4byte sSharpedoAnims_3_5
+.4byte sSharpedoAnims_3_6
+.4byte sSharpedoAnims_3_7
+.4byte sSharpedoAnims_3_8
+sSharpedoAnimTable4:
+.4byte sSharpedoAnims_4_1
+.4byte sSharpedoAnims_4_2
+.4byte sSharpedoAnims_4_3
+.4byte sSharpedoAnims_4_4
+.4byte sSharpedoAnims_4_5
+.4byte sSharpedoAnims_4_6
+.4byte sSharpedoAnims_4_7
+.4byte sSharpedoAnims_4_8
+sSharpedoAnimTable5:
+.4byte sSharpedoAnims_5_1
+.4byte sSharpedoAnims_5_2
+.4byte sSharpedoAnims_5_3
+.4byte sSharpedoAnims_5_4
+.4byte sSharpedoAnims_5_5
+.4byte sSharpedoAnims_5_6
+.4byte sSharpedoAnims_5_7
+.4byte sSharpedoAnims_5_8
+sSharpedoAnimTable6:
+.4byte sSharpedoAnims_6_1
+.4byte sSharpedoAnims_6_1
+.4byte sSharpedoAnims_6_1
+.4byte sSharpedoAnims_6_1
+.4byte sSharpedoAnims_6_1
+.4byte sSharpedoAnims_6_1
+.4byte sSharpedoAnims_6_1
+.4byte sSharpedoAnims_6_1
+sSharpedoAnimTable7:
+.4byte sSharpedoAnims_7_1
+.4byte sSharpedoAnims_7_2
+.4byte sSharpedoAnims_7_3
+.4byte sSharpedoAnims_7_4
+.4byte sSharpedoAnims_7_5
+.4byte sSharpedoAnims_7_6
+.4byte sSharpedoAnims_7_7
+.4byte sSharpedoAnims_7_8
+sSharpedoAnimTable8:
+.4byte sSharpedoAnims_8_1
+.4byte sSharpedoAnims_8_2
+.4byte sSharpedoAnims_8_3
+.4byte sSharpedoAnims_8_4
+.4byte sSharpedoAnims_8_5
+.4byte sSharpedoAnims_8_6
+.4byte sSharpedoAnims_8_7
+.4byte sSharpedoAnims_8_8
+sSharpedoAnimTable9:
+.4byte sSharpedoAnims_9_1
+.4byte sSharpedoAnims_9_2
+.4byte sSharpedoAnims_9_3
+.4byte sSharpedoAnims_9_4
+.4byte sSharpedoAnims_9_5
+.4byte sSharpedoAnims_9_6
+.4byte sSharpedoAnims_9_7
+.4byte sSharpedoAnims_9_8
+sSharpedoAnimTable10:
+.4byte sSharpedoAnims_10_1
+.4byte sSharpedoAnims_10_2
+.4byte sSharpedoAnims_10_3
+.4byte sSharpedoAnims_10_4
+.4byte sSharpedoAnims_10_5
+.4byte sSharpedoAnims_10_6
+.4byte sSharpedoAnims_10_7
+.4byte sSharpedoAnims_10_8
+sSharpedoAnimTable11:
+.4byte sSharpedoAnims_11_1
+.4byte sSharpedoAnims_11_2
+.4byte sSharpedoAnims_11_3
+.4byte sSharpedoAnims_11_4
+.4byte sSharpedoAnims_11_5
+.4byte sSharpedoAnims_11_6
+.4byte sSharpedoAnims_11_7
+.4byte sSharpedoAnims_11_8
+sSharpedoAnimTable12:
+.4byte sSharpedoAnims_12_1
+.4byte sSharpedoAnims_12_2
+.4byte sSharpedoAnims_12_3
+.4byte sSharpedoAnims_12_4
+.4byte sSharpedoAnims_12_5
+.4byte sSharpedoAnims_12_6
+.4byte sSharpedoAnims_12_7
+.4byte sSharpedoAnims_12_8
+sSharpedoAnimTable13:
+.4byte sSharpedoAnims_13_1
+.4byte sSharpedoAnims_13_2
+.4byte sSharpedoAnims_13_3
+.4byte sSharpedoAnims_13_4
+.4byte sSharpedoAnims_13_5
+.4byte sSharpedoAnims_13_6
+.4byte sSharpedoAnims_13_7
+.4byte sSharpedoAnims_13_8
+sAxAnimationsSharpedo:
+.4byte sSharpedoAnimTable1
+.4byte sSharpedoAnimTable2
+.4byte sSharpedoAnimTable3
+.4byte sSharpedoAnimTable4
+.4byte sSharpedoAnimTable5
+.4byte sSharpedoAnimTable6
+.4byte sSharpedoAnimTable7
+.4byte sSharpedoAnimTable8
+.4byte sSharpedoAnimTable9
+.4byte sSharpedoAnimTable10
+.4byte sSharpedoAnimTable11
+.4byte sSharpedoAnimTable12
+.4byte sSharpedoAnimTable13
+sAxSpritesSharpedo:
+.4byte sSharpedoSprites1
+.4byte sSharpedoSprites2
+.4byte sSharpedoSprites3
+.4byte sSharpedoSprites4
+.4byte sSharpedoSprites5
+.4byte sSharpedoSprites6
+.4byte sSharpedoSprites7
+.4byte sSharpedoSprites8
+.4byte sSharpedoSprites9
+.4byte sSharpedoSprites10
+.4byte sSharpedoSprites11
+.4byte sSharpedoSprites12
+.4byte sSharpedoSprites13
+.4byte sSharpedoSprites14
+.4byte sSharpedoSprites15
+.4byte sSharpedoSprites16
+.4byte sSharpedoSprites17
+.4byte sSharpedoSprites18
+.4byte sSharpedoSprites19
+.4byte sSharpedoSprites20
+.4byte sSharpedoSprites21
+.4byte sSharpedoSprites22
+.4byte sSharpedoSprites23
+.4byte sSharpedoSprites24
+.4byte sSharpedoSprites25
+.4byte sSharpedoSprites26
+.4byte sSharpedoSprites27
+.4byte sSharpedoSprites28
+.4byte sSharpedoSprites29
+.4byte sSharpedoSprites30
+.4byte sSharpedoSprites31
+.4byte sSharpedoSprites32
+.4byte sSharpedoSprites33
+.4byte sSharpedoSprites34
+.4byte sSharpedoSprites35
+.4byte sSharpedoSprites36
+.4byte sSharpedoSprites37
+.4byte sSharpedoSprites38
+.4byte sSharpedoSprites39
+.4byte sSharpedoSprites40
+.4byte sSharpedoSprites41
+.4byte sSharpedoSprites42
+.4byte sSharpedoSprites43
+.4byte sSharpedoSprites44
+.4byte sSharpedoSprites45
+.4byte sSharpedoSprites46
+.4byte sSharpedoSprites47
+.4byte sSharpedoSprites48
+.4byte sSharpedoSprites49
+.4byte sSharpedoSprites50
+.4byte sSharpedoSprites51
+.4byte sSharpedoSprites52
+.4byte sSharpedoSprites53
+.4byte sSharpedoSprites54
+.4byte sSharpedoSprites55
+.4byte sSharpedoSprites56
+.4byte sSharpedoSprites57
+.4byte sSharpedoSprites58
+.4byte sSharpedoSprites59
+sAxMainSharpedo:
+ax_main sAxPosesSharpedo, sAxAnimationsSharpedo, 13, sAxSpritesSharpedo, sAxPositionsSharpedo

--- a/data/ax/shedinja.inc
+++ b/data/ax/shedinja.inc
@@ -1,0 +1,2879 @@
+.global gAxShedinja
+gAxShedinja:
+ax_siro sAxMainShedinja
+sShedinjaPose1:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose2:
+ax_pose 1, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose3:
+ax_pose 2, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose4:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose5:
+ax_pose 4, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose6:
+ax_pose 5, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose7:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose8:
+ax_pose 7, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose9:
+ax_pose 8, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose10:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose11:
+ax_pose 10, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose12:
+ax_pose 11, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose13:
+ax_pose 12, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose14:
+ax_pose 13, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose15:
+ax_pose 14, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose16:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose17:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose18:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose19:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose20:
+ax_pose 7, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose21:
+ax_pose 8, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose22:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose23:
+ax_pose 4, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose24:
+ax_pose 5, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose25:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose26:
+ax_pose 1, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose27:
+ax_pose 2, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose28:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose29:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose30:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose31:
+ax_pose 4, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose32:
+ax_pose 5, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose33:
+ax_pose 17, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose34:
+ax_pose 18, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose35:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose36:
+ax_pose 7, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose37:
+ax_pose 8, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose38:
+ax_pose 19, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose39:
+ax_pose 20, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose40:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose41:
+ax_pose 10, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose42:
+ax_pose 11, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose43:
+ax_pose 21, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose44:
+ax_pose 22, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose45:
+ax_pose 12, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose48:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose49:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose50:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose51:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose52:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose53:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose54:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose55:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose56:
+ax_pose 7, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose57:
+ax_pose 8, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose58:
+ax_pose 19, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose59:
+ax_pose 20, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose60:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose61:
+ax_pose 4, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose62:
+ax_pose 5, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose63:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose64:
+ax_pose 18, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose65:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose66:
+ax_pose 1, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose67:
+ax_pose 2, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose68:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose69:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose70:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose71:
+ax_pose 4, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose72:
+ax_pose 5, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose73:
+ax_pose 17, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose74:
+ax_pose 18, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose75:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose76:
+ax_pose 7, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose77:
+ax_pose 8, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose78:
+ax_pose 19, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose79:
+ax_pose 20, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose80:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose81:
+ax_pose 10, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose82:
+ax_pose 11, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose83:
+ax_pose 21, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose84:
+ax_pose 22, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose85:
+ax_pose 12, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose86:
+ax_pose 13, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose87:
+ax_pose 14, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose88:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose89:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose90:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose91:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose92:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose93:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose94:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose95:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose96:
+ax_pose 7, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose97:
+ax_pose 8, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose98:
+ax_pose 19, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose99:
+ax_pose 20, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose100:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose101:
+ax_pose 4, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose102:
+ax_pose 5, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose103:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose104:
+ax_pose 18, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose105:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose106:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose107:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose108:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose109:
+ax_pose 17, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose110:
+ax_pose 18, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose111:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose112:
+ax_pose 19, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose113:
+ax_pose 20, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose114:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose115:
+ax_pose 21, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose116:
+ax_pose 22, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose117:
+ax_pose 12, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose118:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose119:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose120:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose121:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose122:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose123:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose124:
+ax_pose 19, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose125:
+ax_pose 20, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose126:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose127:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose128:
+ax_pose 18, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose129:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose130:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose131:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose132:
+ax_pose 17, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose133:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose134:
+ax_pose 19, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose135:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose136:
+ax_pose 21, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sShedinjaPose137:
+ax_pose 12, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose138:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose139:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose140:
+ax_pose 21, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sShedinjaPose141:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose142:
+ax_pose 19, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose143:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose144:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose145:
+ax_pose 25, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose146:
+ax_pose 26, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose147:
+ax_pose 27, 0x01db, 0x80f0, 0x6c00
+ax_pose_terminator
+sShedinjaPose148:
+ax_pose 28, 0x01de, 0x90ea, 0x6c00
+ax_pose_terminator
+sShedinjaPose149:
+ax_pose 29, 0x01dd, 0x90e8, 0x6c00
+ax_pose_terminator
+sShedinjaPose150:
+ax_pose 30, 0x01de, 0x90eb, 0x6c00
+ax_pose_terminator
+sShedinjaPose151:
+ax_pose 31, 0x01dc, 0x80f0, 0x6c00
+ax_pose_terminator
+sShedinjaPose152:
+ax_pose 30, 0x01de, 0x80f5, 0x6c00
+ax_pose_terminator
+sShedinjaPose153:
+ax_pose 29, 0x01dd, 0x80f8, 0x6c00
+ax_pose_terminator
+sShedinjaPose154:
+ax_pose 28, 0x01de, 0x80f6, 0x6c00
+ax_pose_terminator
+sShedinjaPose155:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose156:
+ax_pose 1, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose157:
+ax_pose 2, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose158:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose159:
+ax_pose 4, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose160:
+ax_pose 5, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose161:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose162:
+ax_pose 7, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose163:
+ax_pose 8, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose164:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose165:
+ax_pose 10, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose166:
+ax_pose 11, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose167:
+ax_pose 12, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose168:
+ax_pose 13, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose169:
+ax_pose 14, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose170:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose171:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose172:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose173:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose174:
+ax_pose 7, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose175:
+ax_pose 8, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose176:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose177:
+ax_pose 4, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose178:
+ax_pose 5, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose179:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose180:
+ax_pose 18, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose181:
+ax_pose 20, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose182:
+ax_pose 22, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sShedinjaPose183:
+ax_pose 24, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose184:
+ax_pose 22, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sShedinjaPose185:
+ax_pose 20, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose186:
+ax_pose 18, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose187:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose188:
+ax_pose 17, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose189:
+ax_pose 19, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose190:
+ax_pose 21, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sShedinjaPose191:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose192:
+ax_pose 21, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sShedinjaPose193:
+ax_pose 19, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose194:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose195:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose196:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose197:
+ax_pose 16, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose198:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose199:
+ax_pose 17, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sShedinjaPose200:
+ax_pose 18, 0x01e3, 0x90eb, 0x6c00
+ax_pose_terminator
+sShedinjaPose201:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose202:
+ax_pose 19, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sShedinjaPose203:
+ax_pose 20, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sShedinjaPose204:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose205:
+ax_pose 21, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sShedinjaPose206:
+ax_pose 22, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sShedinjaPose207:
+ax_pose 12, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose208:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose209:
+ax_pose 24, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose210:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose211:
+ax_pose 21, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sShedinjaPose212:
+ax_pose 22, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sShedinjaPose213:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose214:
+ax_pose 19, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sShedinjaPose215:
+ax_pose 20, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sShedinjaPose216:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose217:
+ax_pose 17, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sShedinjaPose218:
+ax_pose 18, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sShedinjaPose219:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose220:
+ax_pose 18, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose221:
+ax_pose 20, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose222:
+ax_pose 22, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sShedinjaPose223:
+ax_pose 24, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose224:
+ax_pose 22, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sShedinjaPose225:
+ax_pose 20, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose226:
+ax_pose 18, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose227:
+ax_pose 0, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose228:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose229:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose230:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose231:
+ax_pose 12, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sShedinjaPose232:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose233:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sShedinjaPose234:
+ax_pose 3, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+.align 2
+sShedinjaAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 2, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 5, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 0, -3, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 4, 0, 4, 0, -2, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 0, -3, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 9, 0, -2, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 11, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 0, -3, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 4, 0, 10, 0, -2, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 12, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 4, 0, 12, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, -1, 0, 0,
+ax_anim 4, 0, 16, 0, -1, 0, 0,
+ax_anim 4, 0, 15, 0, -2, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 4, 0, 17, 0, -3, 0, 0,
+ax_anim 4, 0, 16, 0, -3, 0, 0,
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 16, 0, -3, 0, 0,
+ax_anim 4, 0, 17, 0, -2, 0, 0,
+ax_anim 4, 0, 16, 0, -2, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 4, 0, 16, 0, -1, 0, 0,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, -1, 0, 0,
+ax_anim 4, 0, 19, 0, -1, 0, 0,
+ax_anim 4, 0, 18, 0, -2, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 4, 0, 20, 0, -3, 0, 0,
+ax_anim 4, 0, 19, 0, -3, 0, 0,
+ax_anim 4, 0, 18, 0, -3, 0, 0,
+ax_anim 4, 0, 19, 0, -3, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim 4, 0, 19, 0, -2, 0, 0,
+ax_anim 4, 0, 18, 0, -1, 0, 0,
+ax_anim 4, 0, 19, 0, -1, 0, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, -1, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 4, 0, 21, 0, -2, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 4, 0, 23, 0, -3, 0, 0,
+ax_anim 4, 0, 22, 0, -3, 0, 0,
+ax_anim 4, 0, 21, 0, -3, 0, 0,
+ax_anim 4, 0, 22, 0, -3, 0, 0,
+ax_anim 4, 0, 23, 0, -2, 0, 0,
+ax_anim 4, 0, 22, 0, -2, 0, 0,
+ax_anim 4, 0, 21, 0, -1, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 2, 0, 2,
+ax_anim 1, 2, 25, 0, 6, 0, 6,
+ax_anim 1, 0, 26, 0, 14, 0, 14,
+ax_anim 2, 0, 28, 0, 26, 0, 23,
+ax_anim 2, 1, 28, 1, 26, 1, 23,
+ax_anim 2, 0, 28, 0, 26, 0, 23,
+ax_anim 2, 0, 28, 1, 26, 1, 23,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sShedinjaAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 4, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 2, 2, 2, 2,
+ax_anim 1, 2, 30, 5, 7, 5, 5,
+ax_anim 1, 0, 31, 13, 16, 13, 15,
+ax_anim 2, 0, 33, 19, 26, 19, 22,
+ax_anim 2, 1, 33, 20, 25, 20, 21,
+ax_anim 2, 0, 33, 19, 26, 19, 22,
+ax_anim 2, 0, 33, 20, 25, 20, 21,
+ax_anim 2, 0, 29, 5, 7, 5, 7,
+ax_anim_terminator
+sShedinjaAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 4, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 2, 0, 2, 0,
+ax_anim 1, 2, 35, 6, 1, 6, 0,
+ax_anim 1, 0, 36, 12, 2, 12, 0,
+ax_anim 2, 0, 38, 18, 5, 18, 0,
+ax_anim 2, 1, 38, 18, 6, 18, 1,
+ax_anim 2, 0, 38, 18, 5, 18, 0,
+ax_anim 2, 0, 38, 18, 6, 18, 1,
+ax_anim 2, 0, 34, 6, 1, 6, 0,
+ax_anim_terminator
+sShedinjaAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 4, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 3, -2, 3, -2,
+ax_anim 1, 2, 40, 8, -5, 8, -7,
+ax_anim 1, 0, 41, 14, -9, 14, -13,
+ax_anim 2, 0, 43, 19, -12, 19, -17,
+ax_anim 2, 1, 43, 20, -11, 20, -16,
+ax_anim 2, 0, 43, 19, -12, 19, -17,
+ax_anim 2, 0, 43, 20, -11, 20, -16,
+ax_anim 2, 0, 39, 8, -5, 8, -7,
+ax_anim_terminator
+sShedinjaAnims_2_5:
+ax_anim 2, 0, 47, 0, 1, 0, 1,
+ax_anim 4, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 1, 0, 1,
+ax_anim 1, 2, 45, 0, -4, 0, -5,
+ax_anim 1, 0, 46, 0, -11, 0, -13,
+ax_anim 2, 0, 48, 0, -13, 0, -16,
+ax_anim 2, 1, 48, 1, -13, 1, -16,
+ax_anim 2, 0, 48, 0, -13, 0, -16,
+ax_anim 2, 0, 48, 1, -13, 1, -16,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sShedinjaAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 4, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 49, -3, -2, -3, -2,
+ax_anim 1, 2, 50, -8, -5, -8, -7,
+ax_anim 1, 0, 51, -14, -9, -14, -13,
+ax_anim 2, 0, 53, -19, -12, -19, -17,
+ax_anim 2, 1, 53, -20, -11, -20, -16,
+ax_anim 2, 0, 53, -19, -12, -19, -17,
+ax_anim 2, 0, 53, -20, -11, -20, -16,
+ax_anim 2, 0, 49, -8, -5, -8, -7,
+ax_anim_terminator
+sShedinjaAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 4, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 2, 55, -6, 1, -6, 0,
+ax_anim 1, 0, 56, -12, 2, -12, 0,
+ax_anim 2, 0, 58, -18, 5, -18, 0,
+ax_anim 2, 1, 58, -18, 6, -18, 1,
+ax_anim 2, 0, 58, -18, 5, -18, 0,
+ax_anim 2, 0, 58, -18, 6, -18, 1,
+ax_anim 2, 0, 54, -6, 1, -6, 0,
+ax_anim_terminator
+sShedinjaAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 4, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 2, 60, -5, 7, -5, 5,
+ax_anim 1, 0, 61, -13, 16, -13, 15,
+ax_anim 2, 0, 63, -19, 26, -19, 22,
+ax_anim 2, 1, 63, -20, 25, -20, 21,
+ax_anim 2, 0, 63, -19, 26, -19, 22,
+ax_anim 2, 0, 63, -20, 25, -20, 21,
+ax_anim 2, 0, 59, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_3_1:
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 6, 0, 102, 0, -2, 0, -2,
+ax_anim 1, 0, 99, 0, 2, 0, 2,
+ax_anim 1, 2, 100, 0, 6, 0, 6,
+ax_anim 1, 0, 66, 0, 14, 0, 14,
+ax_anim 2, 0, 73, 0, 26, 0, 23,
+ax_anim 2, 1, 73, 1, 26, 1, 23,
+ax_anim 2, 0, 73, 0, 26, 0, 23,
+ax_anim 2, 0, 73, 1, 26, 1, 23,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sShedinjaAnims_3_2:
+ax_anim 2, 0, 67, -1, -1, -1, -1,
+ax_anim 6, 0, 67, -2, -2, -2, -2,
+ax_anim 1, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 2, 65, 5, 7, 5, 5,
+ax_anim 1, 0, 71, 13, 16, 13, 15,
+ax_anim 2, 0, 78, 19, 24, 19, 24,
+ax_anim 2, 1, 78, 20, 23, 20, 23,
+ax_anim 2, 0, 78, 19, 24, 19, 24,
+ax_anim 2, 0, 78, 20, 23, 20, 23,
+ax_anim 2, 0, 69, 5, 7, 5, 7,
+ax_anim_terminator
+sShedinjaAnims_3_3:
+ax_anim 2, 0, 72, -1, 0, -1, 0,
+ax_anim 6, 0, 72, -2, 0, -2, 0,
+ax_anim 1, 0, 69, 2, 0, 2, 0,
+ax_anim 1, 2, 70, 6, 1, 6, 0,
+ax_anim 1, 0, 76, 12, 2, 12, 0,
+ax_anim 2, 0, 83, 18, 5, 18, 0,
+ax_anim 2, 1, 83, 18, 6, 18, 1,
+ax_anim 2, 0, 83, 18, 5, 18, 0,
+ax_anim 2, 0, 83, 18, 6, 18, 1,
+ax_anim 2, 0, 74, 6, 1, 6, 0,
+ax_anim_terminator
+sShedinjaAnims_3_4:
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 6, 0, 77, -2, 2, -2, 2,
+ax_anim 1, 0, 74, 3, -2, 3, -2,
+ax_anim 1, 2, 75, 8, -5, 8, -7,
+ax_anim 1, 0, 81, 14, -9, 14, -13,
+ax_anim 2, 0, 88, 19, -15, 19, -15,
+ax_anim 2, 1, 88, 20, -14, 20, -14,
+ax_anim 2, 0, 88, 19, -15, 19, -15,
+ax_anim 2, 0, 88, 20, -14, 20, -14,
+ax_anim 2, 0, 79, 8, -5, 8, -7,
+ax_anim_terminator
+sShedinjaAnims_3_5:
+ax_anim 2, 0, 82, 0, 1, 0, 1,
+ax_anim 6, 0, 82, 0, 2, 0, 2,
+ax_anim 1, 0, 79, 0, 1, 0, 1,
+ax_anim 1, 2, 80, 0, -4, 0, -5,
+ax_anim 1, 0, 86, 0, -11, 0, -13,
+ax_anim 2, 0, 93, 0, -13, 0, -16,
+ax_anim 2, 1, 93, 1, -13, 1, -16,
+ax_anim 2, 0, 93, 0, -13, 0, -16,
+ax_anim 2, 0, 93, 1, -13, 1, -16,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sShedinjaAnims_3_6:
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 6, 0, 87, 2, 2, 2, 2,
+ax_anim 1, 0, 84, -3, -2, -3, -2,
+ax_anim 1, 2, 85, -8, -5, -8, -7,
+ax_anim 1, 0, 91, -14, -9, -14, -13,
+ax_anim 2, 0, 98, -19, -12, -19, -17,
+ax_anim 2, 1, 98, -20, -11, -20, -16,
+ax_anim 2, 0, 98, -19, -12, -19, -17,
+ax_anim 2, 0, 98, -20, -11, -20, -16,
+ax_anim 2, 0, 89, -8, -5, -8, -7,
+ax_anim_terminator
+sShedinjaAnims_3_7:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 6, 0, 92, 2, 0, 2, 0,
+ax_anim 1, 0, 89, -2, 0, -2, 0,
+ax_anim 1, 2, 90, -6, 1, -6, 0,
+ax_anim 1, 0, 96, -12, 2, -12, 0,
+ax_anim 2, 0, 103, -18, 5, -18, 0,
+ax_anim 2, 1, 103, -18, 6, -18, 1,
+ax_anim 2, 0, 103, -18, 5, -18, 0,
+ax_anim 2, 0, 103, -18, 6, -18, 1,
+ax_anim 2, 0, 94, -6, 1, -6, 0,
+ax_anim_terminator
+sShedinjaAnims_3_8:
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 6, 0, 97, 2, -2, 2, -2,
+ax_anim 1, 0, 94, -2, 2, -2, 2,
+ax_anim 1, 2, 95, -5, 7, -5, 5,
+ax_anim 1, 0, 101, -13, 16, -13, 15,
+ax_anim 2, 0, 68, -19, 26, -19, 22,
+ax_anim 2, 1, 68, -20, 25, -20, 21,
+ax_anim 2, 0, 68, -19, 26, -19, 22,
+ax_anim 2, 0, 68, -20, 25, -20, 21,
+ax_anim 2, 0, 99, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sShedinjaAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sShedinjaAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sShedinjaAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sShedinjaAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sShedinjaAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sShedinjaAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sShedinjaAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 2, 129, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -1, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_5_2:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 2, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_5_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 2, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 143, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 133, 0, -1, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_5_4:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 2, 135, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -1, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_5_5:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 2, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_5_6:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 2, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -1, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_5_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, 0,
+ax_anim 2, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 2, 141, 0, -6, 0, 0,
+ax_anim 1, 0, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -5, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_5_8:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -1, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 139, 0, -6, 0, 0,
+ax_anim 1, 0, 141, 0, -6, 0, 0,
+ax_anim 1, 2, 143, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_6_1:
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 12, 0, 144, 0, -1, 0, 0,
+ax_anim 16, 0, 144, 0, -2, 0, 0,
+ax_anim 12, 0, 145, 0, -2, 0, 0,
+ax_anim 12, 0, 145, 0, -1, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sShedinjaAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sShedinjaAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sShedinjaAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sShedinjaAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sShedinjaAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sShedinjaAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sShedinjaAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_8_1:
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, -2, 0, 0,
+ax_anim 8, 0, 155, 0, -2, 0, 0,
+ax_anim 8, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, -1, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_8_2:
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 8, 0, 158, 0, -2, 0, 0,
+ax_anim 8, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_8_3:
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 162, 0, -1, 0, 0,
+ax_anim 4, 0, 162, 0, -2, 0, 0,
+ax_anim 8, 0, 161, 0, -2, 0, 0,
+ax_anim 8, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 162, 0, -1, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_8_4:
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, -1, 0, 0,
+ax_anim 4, 0, 165, 0, -1, 0, 0,
+ax_anim 4, 0, 165, 0, -2, 0, 0,
+ax_anim 8, 0, 164, 0, -2, 0, 0,
+ax_anim 8, 0, 163, 0, -2, 0, 0,
+ax_anim 4, 0, 164, 0, -2, 0, 0,
+ax_anim 4, 0, 164, 0, -1, 0, 0,
+ax_anim 4, 0, 165, 0, -1, 0, 0,
+ax_anim 4, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_8_5:
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, -2, 0, 0,
+ax_anim 8, 0, 167, 0, -2, 0, 0,
+ax_anim 8, 0, 166, 0, -2, 0, 0,
+ax_anim 4, 0, 167, 0, -2, 0, 0,
+ax_anim 4, 0, 167, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, -1, 0, 0,
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_8_6:
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -1, 0, 0,
+ax_anim 4, 0, 171, 0, -1, 0, 0,
+ax_anim 4, 0, 171, 0, -2, 0, 0,
+ax_anim 8, 0, 170, 0, -2, 0, 0,
+ax_anim 8, 0, 169, 0, -2, 0, 0,
+ax_anim 4, 0, 170, 0, -2, 0, 0,
+ax_anim 4, 0, 170, 0, -1, 0, 0,
+ax_anim 4, 0, 171, 0, -1, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_8_7:
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, -2, 0, 0,
+ax_anim 8, 0, 173, 0, -2, 0, 0,
+ax_anim 8, 0, 172, 0, -2, 0, 0,
+ax_anim 4, 0, 173, 0, -2, 0, 0,
+ax_anim 4, 0, 173, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, -1, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_8_8:
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim 8, 0, 176, 0, -2, 0, 0,
+ax_anim 8, 0, 175, 0, -2, 0, 0,
+ax_anim 4, 0, 176, 0, -2, 0, 0,
+ax_anim 4, 0, 176, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, -1, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 8, 4, 8, 4,
+ax_anim 2, 0, 180, 14, 14, 14, 13,
+ax_anim 2, 0, 181, 10, 24, 10, 20,
+ax_anim 3, 0, 182, 0, 25, 0, 22,
+ax_anim 2, 3, 183, -10, 24, -10, 20,
+ax_anim 2, 0, 184, -14, 14, -14, 13,
+ax_anim 1, 0, 185, -8, 4, -8, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 10, 4, 10, 4,
+ax_anim 2, 0, 179, 22, 10, 22, 10,
+ax_anim 2, 0, 180, 25, 19, 25, 19,
+ax_anim 3, 0, 181, 22, 26, 22, 23,
+ax_anim 2, 3, 182, 12, 25, 12, 23,
+ax_anim 2, 0, 183, 2, 21, 2, 20,
+ax_anim 1, 0, 184, -3, 9, -3, 9,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 5, -2, 5, -2,
+ax_anim 2, 0, 178, 12, -2, 12, -2,
+ax_anim 2, 0, 179, 19, 0, 19, -2,
+ax_anim 3, 0, 180, 22, 4, 22, 0,
+ax_anim 2, 3, 181, 19, 8, 19, 6,
+ax_anim 2, 0, 182, 10, 8, 10, 8,
+ax_anim 1, 0, 183, 2, 5, 2, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -8, 0, -8,
+ax_anim 2, 0, 185, 5, -15, 5, -15,
+ax_anim 2, 0, 178, 13, -18, 13, -21,
+ax_anim 3, 0, 179, 22, -17, 22, -22,
+ax_anim 2, 3, 180, 23, -11, 23, -13,
+ax_anim 2, 0, 181, 20, -4, 20, -4,
+ax_anim 1, 0, 182, 8, -1, 8, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -3, -8, -3,
+ax_anim 2, 0, 184, -13, -8, -13, -8,
+ax_anim 2, 0, 185, -10, -15, -10, -18,
+ax_anim 3, 0, 178, 0, -17, 0, -22,
+ax_anim 2, 3, 179, 10, -15, 10, -18,
+ax_anim 2, 0, 180, 13, -8, 13, -8,
+ax_anim 1, 0, 181, 8, -3, 8, -3,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -8, 0, -8,
+ax_anim 2, 0, 179, -5, -15, -5, -15,
+ax_anim 2, 0, 178, -13, -18, -13, -21,
+ax_anim 3, 0, 185, -22, -17, -22, -22,
+ax_anim 2, 3, 184, -23, -11, -23, -13,
+ax_anim 2, 0, 183, -20, -4, -20, -4,
+ax_anim 1, 0, 182, -8, -1, -8, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -5, -2, -5, -2,
+ax_anim 2, 0, 178, -12, -2, -12, -2,
+ax_anim 2, 0, 185, -19, 0, -19, -2,
+ax_anim 3, 0, 184, -22, 4, -22, 0,
+ax_anim 2, 3, 183, -19, 8, -19, 6,
+ax_anim 2, 0, 182, -10, 8, -10, 8,
+ax_anim 1, 0, 181, -2, 5, -2, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -10, 4, -10, 4,
+ax_anim 2, 0, 185, -22, 10, -22, 10,
+ax_anim 2, 0, 184, -25, 19, -25, 19,
+ax_anim 3, 0, 183, -22, 26, -22, 23,
+ax_anim 2, 3, 182, -12, 25, -12, 23,
+ax_anim 2, 0, 181, -2, 21, -2, 20,
+ax_anim 1, 0, 180, 3, 9, 3, 9,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 5, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 5, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 5, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 5, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 5, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 5, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShedinjaAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sShedinjaGfx1:
+.incbin "baserom.gba", 0x11E45D8, 0x200
+sShedinjaSprites1:
+ax_sprite sShedinjaGfx1, 0x200
+ax_sprite_terminator
+sShedinjaGfx2:
+.incbin "baserom.gba", 0x11E47E8, 0x200
+sShedinjaSprites2:
+ax_sprite sShedinjaGfx2, 0x200
+ax_sprite_terminator
+sShedinjaGfx3:
+.incbin "baserom.gba", 0x11E49F8, 0x200
+sShedinjaSprites3:
+ax_sprite sShedinjaGfx3, 0x200
+ax_sprite_terminator
+sShedinjaGfx4:
+.incbin "baserom.gba", 0x11E4C08, 0x200
+sShedinjaSprites4:
+ax_sprite sShedinjaGfx4, 0x200
+ax_sprite_terminator
+sShedinjaGfx5:
+.incbin "baserom.gba", 0x11E4E18, 0x200
+sShedinjaSprites5:
+ax_sprite sShedinjaGfx5, 0x200
+ax_sprite_terminator
+sShedinjaGfx6:
+.incbin "baserom.gba", 0x11E5028, 0x200
+sShedinjaSprites6:
+ax_sprite sShedinjaGfx6, 0x200
+ax_sprite_terminator
+sShedinjaGfx7:
+.incbin "baserom.gba", 0x11E5238, 0x200
+sShedinjaSprites7:
+ax_sprite sShedinjaGfx7, 0x200
+ax_sprite_terminator
+sShedinjaGfx8:
+.incbin "baserom.gba", 0x11E5448, 0x200
+sShedinjaSprites8:
+ax_sprite sShedinjaGfx8, 0x200
+ax_sprite_terminator
+sShedinjaGfx9:
+.incbin "baserom.gba", 0x11E5658, 0x200
+sShedinjaSprites9:
+ax_sprite sShedinjaGfx9, 0x200
+ax_sprite_terminator
+sShedinjaGfx10:
+.incbin "baserom.gba", 0x11E5868, 0x200
+sShedinjaSprites10:
+ax_sprite sShedinjaGfx10, 0x200
+ax_sprite_terminator
+sShedinjaGfx11:
+.incbin "baserom.gba", 0x11E5A78, 0x200
+sShedinjaSprites11:
+ax_sprite sShedinjaGfx11, 0x200
+ax_sprite_terminator
+sShedinjaGfx12:
+.incbin "baserom.gba", 0x11E5C88, 0x200
+sShedinjaSprites12:
+ax_sprite sShedinjaGfx12, 0x200
+ax_sprite_terminator
+sShedinjaGfx13:
+.incbin "baserom.gba", 0x11E5E98, 0x200
+sShedinjaSprites13:
+ax_sprite sShedinjaGfx13, 0x200
+ax_sprite_terminator
+sShedinjaGfx14:
+.incbin "baserom.gba", 0x11E60A8, 0x200
+sShedinjaSprites14:
+ax_sprite sShedinjaGfx14, 0x200
+ax_sprite_terminator
+sShedinjaGfx15:
+.incbin "baserom.gba", 0x11E62B8, 0x200
+sShedinjaSprites15:
+ax_sprite sShedinjaGfx15, 0x200
+ax_sprite_terminator
+sShedinjaGfx16:
+.incbin "baserom.gba", 0x11E64C8, 0x40
+sShedinjaGfx16_1:
+.incbin "baserom.gba", 0x11E6508, 0x60
+sShedinjaGfx16_2:
+.incbin "baserom.gba", 0x11E6568, 0x60
+sShedinjaGfx16_3:
+.incbin "baserom.gba", 0x11E65C8, 0x20
+sShedinjaSprites16:
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShedinjaGfx16_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShedinjaGfx17:
+.incbin "baserom.gba", 0x11E6638, 0x60
+sShedinjaGfx17_1:
+.incbin "baserom.gba", 0x11E6698, 0x60
+sShedinjaGfx17_2:
+.incbin "baserom.gba", 0x11E66F8, 0x60
+sShedinjaSprites17:
+ax_sprite sShedinjaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx18:
+.incbin "baserom.gba", 0x11E6790, 0x60
+sShedinjaGfx18_1:
+.incbin "baserom.gba", 0x11E67F0, 0x60
+sShedinjaGfx18_2:
+.incbin "baserom.gba", 0x11E6850, 0x60
+sShedinjaSprites18:
+ax_sprite sShedinjaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx19:
+.incbin "baserom.gba", 0x11E68E8, 0x40
+sShedinjaGfx19_1:
+.incbin "baserom.gba", 0x11E6928, 0x60
+sShedinjaGfx19_2:
+.incbin "baserom.gba", 0x11E6988, 0x60
+sShedinjaSprites19:
+ax_sprite sShedinjaGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShedinjaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx20:
+.incbin "baserom.gba", 0x11E6A20, 0x60
+sShedinjaGfx20_1:
+.incbin "baserom.gba", 0x11E6A80, 0x60
+sShedinjaGfx20_2:
+.incbin "baserom.gba", 0x11E6AE0, 0x60
+sShedinjaSprites20:
+ax_sprite sShedinjaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx21:
+.incbin "baserom.gba", 0x11E6B78, 0x40
+sShedinjaGfx21_1:
+.incbin "baserom.gba", 0x11E6BB8, 0x60
+sShedinjaGfx21_2:
+.incbin "baserom.gba", 0x11E6C18, 0x60
+sShedinjaSprites21:
+ax_sprite sShedinjaGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShedinjaGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx22:
+.incbin "baserom.gba", 0x11E6CB0, 0x40
+sShedinjaGfx22_1:
+.incbin "baserom.gba", 0x11E6CF0, 0x60
+sShedinjaGfx22_2:
+.incbin "baserom.gba", 0x11E6D50, 0x60
+sShedinjaSprites22:
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx23:
+.incbin "baserom.gba", 0x11E6DF0, 0x60
+sShedinjaGfx23_1:
+.incbin "baserom.gba", 0x11E6E50, 0x60
+sShedinjaGfx23_2:
+.incbin "baserom.gba", 0x11E6EB0, 0x60
+sShedinjaSprites23:
+ax_sprite sShedinjaGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx24:
+.incbin "baserom.gba", 0x11E6F48, 0x40
+sShedinjaGfx24_1:
+.incbin "baserom.gba", 0x11E6F88, 0x60
+sShedinjaGfx24_2:
+.incbin "baserom.gba", 0x11E6FE8, 0x60
+sShedinjaSprites24:
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShedinjaGfx25:
+.incbin "baserom.gba", 0x11E7088, 0x60
+sShedinjaGfx25_1:
+.incbin "baserom.gba", 0x11E70E8, 0x60
+sShedinjaGfx25_2:
+.incbin "baserom.gba", 0x11E7148, 0x60
+sShedinjaGfx25_3:
+.incbin "baserom.gba", 0x11E71A8, 0x20
+sShedinjaSprites25:
+ax_sprite sShedinjaGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShedinjaGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShedinjaGfx25_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShedinjaGfx26:
+.incbin "baserom.gba", 0x11E7210, 0x200
+sShedinjaSprites26:
+ax_sprite sShedinjaGfx26, 0x200
+ax_sprite_terminator
+sShedinjaGfx27:
+.incbin "baserom.gba", 0x11E7420, 0x200
+sShedinjaSprites27:
+ax_sprite sShedinjaGfx27, 0x200
+ax_sprite_terminator
+sShedinjaGfx28:
+.incbin "baserom.gba", 0x11E7630, 0x200
+sShedinjaSprites28:
+ax_sprite sShedinjaGfx28, 0x200
+ax_sprite_terminator
+sShedinjaGfx29:
+.incbin "baserom.gba", 0x11E7840, 0x200
+sShedinjaSprites29:
+ax_sprite sShedinjaGfx29, 0x200
+ax_sprite_terminator
+sShedinjaGfx30:
+.incbin "baserom.gba", 0x11E7A50, 0x200
+sShedinjaSprites30:
+ax_sprite sShedinjaGfx30, 0x200
+ax_sprite_terminator
+sShedinjaGfx31:
+.incbin "baserom.gba", 0x11E7C60, 0x200
+sShedinjaSprites31:
+ax_sprite sShedinjaGfx31, 0x200
+ax_sprite_terminator
+sShedinjaGfx32:
+.incbin "baserom.gba", 0x11E7E70, 0x200
+sShedinjaSprites32:
+ax_sprite sShedinjaGfx32, 0x200
+ax_sprite_terminator
+sAxPosesShedinja:
+.4byte sShedinjaPose1
+.4byte sShedinjaPose2
+.4byte sShedinjaPose3
+.4byte sShedinjaPose4
+.4byte sShedinjaPose5
+.4byte sShedinjaPose6
+.4byte sShedinjaPose7
+.4byte sShedinjaPose8
+.4byte sShedinjaPose9
+.4byte sShedinjaPose10
+.4byte sShedinjaPose11
+.4byte sShedinjaPose12
+.4byte sShedinjaPose13
+.4byte sShedinjaPose14
+.4byte sShedinjaPose15
+.4byte sShedinjaPose16
+.4byte sShedinjaPose17
+.4byte sShedinjaPose18
+.4byte sShedinjaPose19
+.4byte sShedinjaPose20
+.4byte sShedinjaPose21
+.4byte sShedinjaPose22
+.4byte sShedinjaPose23
+.4byte sShedinjaPose24
+.4byte sShedinjaPose25
+.4byte sShedinjaPose26
+.4byte sShedinjaPose27
+.4byte sShedinjaPose28
+.4byte sShedinjaPose29
+.4byte sShedinjaPose30
+.4byte sShedinjaPose31
+.4byte sShedinjaPose32
+.4byte sShedinjaPose33
+.4byte sShedinjaPose34
+.4byte sShedinjaPose35
+.4byte sShedinjaPose36
+.4byte sShedinjaPose37
+.4byte sShedinjaPose38
+.4byte sShedinjaPose39
+.4byte sShedinjaPose40
+.4byte sShedinjaPose41
+.4byte sShedinjaPose42
+.4byte sShedinjaPose43
+.4byte sShedinjaPose44
+.4byte sShedinjaPose45
+.4byte sShedinjaPose46
+.4byte sShedinjaPose47
+.4byte sShedinjaPose48
+.4byte sShedinjaPose49
+.4byte sShedinjaPose50
+.4byte sShedinjaPose51
+.4byte sShedinjaPose52
+.4byte sShedinjaPose53
+.4byte sShedinjaPose54
+.4byte sShedinjaPose55
+.4byte sShedinjaPose56
+.4byte sShedinjaPose57
+.4byte sShedinjaPose58
+.4byte sShedinjaPose59
+.4byte sShedinjaPose60
+.4byte sShedinjaPose61
+.4byte sShedinjaPose62
+.4byte sShedinjaPose63
+.4byte sShedinjaPose64
+.4byte sShedinjaPose65
+.4byte sShedinjaPose66
+.4byte sShedinjaPose67
+.4byte sShedinjaPose68
+.4byte sShedinjaPose69
+.4byte sShedinjaPose70
+.4byte sShedinjaPose71
+.4byte sShedinjaPose72
+.4byte sShedinjaPose73
+.4byte sShedinjaPose74
+.4byte sShedinjaPose75
+.4byte sShedinjaPose76
+.4byte sShedinjaPose77
+.4byte sShedinjaPose78
+.4byte sShedinjaPose79
+.4byte sShedinjaPose80
+.4byte sShedinjaPose81
+.4byte sShedinjaPose82
+.4byte sShedinjaPose83
+.4byte sShedinjaPose84
+.4byte sShedinjaPose85
+.4byte sShedinjaPose86
+.4byte sShedinjaPose87
+.4byte sShedinjaPose88
+.4byte sShedinjaPose89
+.4byte sShedinjaPose90
+.4byte sShedinjaPose91
+.4byte sShedinjaPose92
+.4byte sShedinjaPose93
+.4byte sShedinjaPose94
+.4byte sShedinjaPose95
+.4byte sShedinjaPose96
+.4byte sShedinjaPose97
+.4byte sShedinjaPose98
+.4byte sShedinjaPose99
+.4byte sShedinjaPose100
+.4byte sShedinjaPose101
+.4byte sShedinjaPose102
+.4byte sShedinjaPose103
+.4byte sShedinjaPose104
+.4byte sShedinjaPose105
+.4byte sShedinjaPose106
+.4byte sShedinjaPose107
+.4byte sShedinjaPose108
+.4byte sShedinjaPose109
+.4byte sShedinjaPose110
+.4byte sShedinjaPose111
+.4byte sShedinjaPose112
+.4byte sShedinjaPose113
+.4byte sShedinjaPose114
+.4byte sShedinjaPose115
+.4byte sShedinjaPose116
+.4byte sShedinjaPose117
+.4byte sShedinjaPose118
+.4byte sShedinjaPose119
+.4byte sShedinjaPose120
+.4byte sShedinjaPose121
+.4byte sShedinjaPose122
+.4byte sShedinjaPose123
+.4byte sShedinjaPose124
+.4byte sShedinjaPose125
+.4byte sShedinjaPose126
+.4byte sShedinjaPose127
+.4byte sShedinjaPose128
+.4byte sShedinjaPose129
+.4byte sShedinjaPose130
+.4byte sShedinjaPose131
+.4byte sShedinjaPose132
+.4byte sShedinjaPose133
+.4byte sShedinjaPose134
+.4byte sShedinjaPose135
+.4byte sShedinjaPose136
+.4byte sShedinjaPose137
+.4byte sShedinjaPose138
+.4byte sShedinjaPose139
+.4byte sShedinjaPose140
+.4byte sShedinjaPose141
+.4byte sShedinjaPose142
+.4byte sShedinjaPose143
+.4byte sShedinjaPose144
+.4byte sShedinjaPose145
+.4byte sShedinjaPose146
+.4byte sShedinjaPose147
+.4byte sShedinjaPose148
+.4byte sShedinjaPose149
+.4byte sShedinjaPose150
+.4byte sShedinjaPose151
+.4byte sShedinjaPose152
+.4byte sShedinjaPose153
+.4byte sShedinjaPose154
+.4byte sShedinjaPose155
+.4byte sShedinjaPose156
+.4byte sShedinjaPose157
+.4byte sShedinjaPose158
+.4byte sShedinjaPose159
+.4byte sShedinjaPose160
+.4byte sShedinjaPose161
+.4byte sShedinjaPose162
+.4byte sShedinjaPose163
+.4byte sShedinjaPose164
+.4byte sShedinjaPose165
+.4byte sShedinjaPose166
+.4byte sShedinjaPose167
+.4byte sShedinjaPose168
+.4byte sShedinjaPose169
+.4byte sShedinjaPose170
+.4byte sShedinjaPose171
+.4byte sShedinjaPose172
+.4byte sShedinjaPose173
+.4byte sShedinjaPose174
+.4byte sShedinjaPose175
+.4byte sShedinjaPose176
+.4byte sShedinjaPose177
+.4byte sShedinjaPose178
+.4byte sShedinjaPose179
+.4byte sShedinjaPose180
+.4byte sShedinjaPose181
+.4byte sShedinjaPose182
+.4byte sShedinjaPose183
+.4byte sShedinjaPose184
+.4byte sShedinjaPose185
+.4byte sShedinjaPose186
+.4byte sShedinjaPose187
+.4byte sShedinjaPose188
+.4byte sShedinjaPose189
+.4byte sShedinjaPose190
+.4byte sShedinjaPose191
+.4byte sShedinjaPose192
+.4byte sShedinjaPose193
+.4byte sShedinjaPose194
+.4byte sShedinjaPose195
+.4byte sShedinjaPose196
+.4byte sShedinjaPose197
+.4byte sShedinjaPose198
+.4byte sShedinjaPose199
+.4byte sShedinjaPose200
+.4byte sShedinjaPose201
+.4byte sShedinjaPose202
+.4byte sShedinjaPose203
+.4byte sShedinjaPose204
+.4byte sShedinjaPose205
+.4byte sShedinjaPose206
+.4byte sShedinjaPose207
+.4byte sShedinjaPose208
+.4byte sShedinjaPose209
+.4byte sShedinjaPose210
+.4byte sShedinjaPose211
+.4byte sShedinjaPose212
+.4byte sShedinjaPose213
+.4byte sShedinjaPose214
+.4byte sShedinjaPose215
+.4byte sShedinjaPose216
+.4byte sShedinjaPose217
+.4byte sShedinjaPose218
+.4byte sShedinjaPose219
+.4byte sShedinjaPose220
+.4byte sShedinjaPose221
+.4byte sShedinjaPose222
+.4byte sShedinjaPose223
+.4byte sShedinjaPose224
+.4byte sShedinjaPose225
+.4byte sShedinjaPose226
+.4byte sShedinjaPose227
+.4byte sShedinjaPose228
+.4byte sShedinjaPose229
+.4byte sShedinjaPose230
+.4byte sShedinjaPose231
+.4byte sShedinjaPose232
+.4byte sShedinjaPose233
+.4byte sShedinjaPose234
+sAxPositionsShedinja:
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    0,  -12, 	  -4,  -10, 	   4,  -10, 	   0,  -14
+.2byte    0,   -8, 	  -4,   -8, 	   4,   -8, 	   0,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    4,  -13, 	   5,  -11, 	  -1,  -10, 	   0,  -13
+.2byte    5,   -7, 	   3,  -11, 	  -3,   -8, 	  -1,  -11
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    4,  -13, 	   2,  -13, 	   2,  -10, 	  -1,  -13
+.2byte    6,   -9, 	   0,  -11, 	   1,   -8, 	   1,  -13
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    3,  -15, 	  -4,  -13, 	   2,  -12, 	  -3,  -15
+.2byte    5,  -14, 	  -1,  -15, 	   2,  -10, 	  -1,  -16
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -17, 	   4,  -13, 	  -4,  -13, 	   0,  -14
+.2byte    0,  -15, 	   4,  -13, 	  -4,  -13, 	   0,  -16
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -4,  -15, 	   3,  -13, 	  -3,  -12, 	   2,  -15
+.2byte   -6,  -14, 	   0,  -15, 	  -3,  -10, 	   0,  -16
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -5,  -13, 	  -3,  -13, 	  -3,  -10, 	   0,  -13
+.2byte   -7,   -9, 	  -1,  -11, 	  -2,   -8, 	  -2,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -5,  -13, 	  -6,  -11, 	   0,  -10, 	  -1,  -13
+.2byte   -6,   -7, 	  -4,  -11, 	   2,   -8, 	   0,  -11
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    0,  -12, 	  -4,  -10, 	   4,  -10, 	   0,  -14
+.2byte    0,   -8, 	  -4,   -8, 	   4,   -8, 	   0,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    4,  -13, 	   5,  -11, 	  -1,  -10, 	   0,  -13
+.2byte    5,   -7, 	   3,  -11, 	  -3,   -8, 	  -1,  -11
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    4,  -13, 	   2,  -13, 	   2,  -10, 	  -1,  -13
+.2byte    6,   -9, 	   0,  -11, 	   1,   -8, 	   1,  -13
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    3,  -15, 	  -4,  -13, 	   2,  -12, 	  -3,  -15
+.2byte    5,  -14, 	  -1,  -15, 	   2,  -10, 	  -1,  -16
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -17, 	   4,  -13, 	  -4,  -13, 	   0,  -14
+.2byte    0,  -15, 	   4,  -13, 	  -4,  -13, 	   0,  -16
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -4,  -15, 	   3,  -13, 	  -3,  -12, 	   2,  -15
+.2byte   -6,  -14, 	   0,  -15, 	  -3,  -10, 	   0,  -16
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -5,  -13, 	  -3,  -13, 	  -3,  -10, 	   0,  -13
+.2byte   -7,   -9, 	  -1,  -11, 	  -2,   -8, 	  -2,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -5,  -13, 	  -6,  -11, 	   0,  -10, 	  -1,  -13
+.2byte   -6,   -7, 	  -4,  -11, 	   2,   -8, 	   0,  -11
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    0,  -12, 	  -4,  -10, 	   4,  -10, 	   0,  -14
+.2byte    0,   -8, 	  -4,   -8, 	   4,   -8, 	   0,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    4,  -13, 	   5,  -11, 	  -1,  -10, 	   0,  -13
+.2byte    5,   -7, 	   3,  -11, 	  -3,   -8, 	  -1,  -11
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    4,  -13, 	   2,  -13, 	   2,  -10, 	  -1,  -13
+.2byte    6,   -9, 	   0,  -11, 	   1,   -8, 	   1,  -13
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    3,  -15, 	  -4,  -13, 	   2,  -12, 	  -3,  -15
+.2byte    5,  -14, 	  -1,  -15, 	   2,  -10, 	  -1,  -16
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -17, 	   4,  -13, 	  -4,  -13, 	   0,  -14
+.2byte    0,  -15, 	   4,  -13, 	  -4,  -13, 	   0,  -16
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -4,  -15, 	   3,  -13, 	  -3,  -12, 	   2,  -15
+.2byte   -6,  -14, 	   0,  -15, 	  -3,  -10, 	   0,  -16
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -5,  -13, 	  -3,  -13, 	  -3,  -10, 	   0,  -13
+.2byte   -7,   -9, 	  -1,  -11, 	  -2,   -8, 	  -2,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -5,  -13, 	  -6,  -11, 	   0,  -10, 	  -1,  -13
+.2byte   -6,   -7, 	  -4,  -11, 	   2,   -8, 	   0,  -11
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    0,  -12, 	  -4,  -10, 	   4,  -10, 	   0,  -14
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    4,  -13, 	   5,  -11, 	  -1,  -10, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    4,  -13, 	   2,  -13, 	   2,  -10, 	  -1,  -13
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    4,  -15, 	  -3,  -13, 	   3,  -12, 	  -2,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -17, 	   4,  -13, 	  -4,  -13, 	   0,  -14
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -5,  -15, 	   2,  -13, 	  -4,  -12, 	   1,  -15
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -5,  -13, 	  -3,  -13, 	  -3,  -10, 	   0,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -5,  -13, 	  -6,  -11, 	   0,  -10, 	  -1,  -13
+.2byte   -6,  -10, 	  -6,  -11, 	   1,   -9, 	   1,  -11
+.2byte   -6,   -9, 	  -6,  -10, 	   2,   -9, 	   2,  -11
+.2byte   -1,  -16, 	  -5,  -14, 	   3,  -14, 	  -1,  -15
+.2byte    2,  -17, 	   5,  -14, 	  -1,  -11, 	   0,  -14
+.2byte    2,  -15, 	   4,  -14, 	   2,  -12, 	  -2,  -13
+.2byte    4,  -16, 	  -4,  -15, 	   6,  -13, 	  -3,  -14
+.2byte   -1,  -15, 	   3,  -13, 	  -5,  -13, 	  -1,  -13
+.2byte   -5,  -16, 	   3,  -15, 	  -7,  -13, 	   2,  -14
+.2byte   -3,  -15, 	  -5,  -14, 	  -3,  -12, 	   1,  -13
+.2byte   -3,  -17, 	  -6,  -14, 	   0,  -11, 	  -1,  -14
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte    0,   -8, 	  -4,   -8, 	   4,   -8, 	   0,  -12
+.2byte   -6,   -7, 	  -4,  -11, 	   2,   -8, 	   0,  -11
+.2byte   -7,   -8, 	  -1,  -10, 	  -2,   -7, 	  -2,  -12
+.2byte   -7,  -12, 	  -1,  -13, 	  -4,   -8, 	  -1,  -14
+.2byte    0,  -14, 	   4,  -12, 	  -4,  -12, 	   0,  -15
+.2byte    6,  -12, 	   0,  -13, 	   3,   -8, 	   0,  -14
+.2byte    6,   -8, 	   0,  -10, 	   1,   -7, 	   1,  -12
+.2byte    5,   -7, 	   3,  -11, 	  -3,   -8, 	  -1,  -11
+.2byte    0,  -12, 	  -4,  -10, 	   4,  -10, 	   0,  -14
+.2byte    4,  -13, 	   5,  -11, 	  -1,  -10, 	   0,  -13
+.2byte    4,  -13, 	   2,  -13, 	   2,  -10, 	  -1,  -13
+.2byte    4,  -15, 	  -3,  -13, 	   3,  -12, 	  -2,  -15
+.2byte    0,  -17, 	   4,  -13, 	  -4,  -13, 	   0,  -14
+.2byte   -5,  -15, 	   2,  -13, 	  -4,  -12, 	   1,  -15
+.2byte   -5,  -13, 	  -3,  -13, 	  -3,  -10, 	   0,  -13
+.2byte   -5,  -13, 	  -6,  -11, 	   0,  -10, 	  -1,  -13
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    0,  -12, 	  -4,  -10, 	   4,  -10, 	   0,  -14
+.2byte    0,   -9, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+.2byte    3,  -13, 	   4,  -11, 	  -2,  -10, 	  -1,  -13
+.2byte    4,   -8, 	   2,  -12, 	  -4,   -9, 	  -2,  -12
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    3,  -13, 	   1,  -13, 	   1,  -10, 	  -2,  -13
+.2byte    5,   -9, 	  -1,  -11, 	   0,   -8, 	   0,  -13
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    4,  -15, 	  -3,  -13, 	   3,  -12, 	  -2,  -15
+.2byte    4,  -14, 	  -2,  -15, 	   1,  -10, 	  -2,  -16
+.2byte    0,  -16, 	   4,  -14, 	  -4,  -14, 	   0,  -15
+.2byte    0,  -17, 	   4,  -13, 	  -4,  -13, 	   0,  -14
+.2byte    0,  -15, 	   4,  -13, 	  -4,  -13, 	   0,  -16
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte   -5,  -15, 	   2,  -13, 	  -4,  -12, 	   1,  -15
+.2byte   -5,  -14, 	   1,  -15, 	  -2,  -10, 	   1,  -16
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -4,  -13, 	  -2,  -13, 	  -2,  -10, 	   1,  -13
+.2byte   -6,   -9, 	   0,  -11, 	  -1,   -8, 	  -1,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -4,  -13, 	  -5,  -11, 	   1,  -10, 	   0,  -13
+.2byte   -5,   -8, 	  -3,  -12, 	   3,   -9, 	   1,  -12
+.2byte    0,   -8, 	  -4,   -8, 	   4,   -8, 	   0,  -12
+.2byte   -6,   -7, 	  -4,  -11, 	   2,   -8, 	   0,  -11
+.2byte   -7,   -8, 	  -1,  -10, 	  -2,   -7, 	  -2,  -12
+.2byte   -7,  -12, 	  -1,  -13, 	  -4,   -8, 	  -1,  -14
+.2byte    0,  -14, 	   4,  -12, 	  -4,  -12, 	   0,  -15
+.2byte    6,  -12, 	   0,  -13, 	   3,   -8, 	   0,  -14
+.2byte    6,   -8, 	   0,  -10, 	   1,   -7, 	   1,  -12
+.2byte    5,   -7, 	   3,  -11, 	  -3,   -8, 	  -1,  -11
+.2byte    0,  -10, 	  -4,   -9, 	   4,   -9, 	   0,  -13
+.2byte   -6,  -11, 	  -4,  -11, 	   2,   -9, 	   0,  -12
+.2byte   -6,  -11, 	  -2,  -14, 	  -1,   -9, 	  -1,  -13
+.2byte   -7,  -16, 	   3,  -14, 	  -3,  -12, 	   1,  -15
+.2byte    0,  -15, 	   4,  -13, 	  -4,  -13, 	   0,  -14
+.2byte    6,  -16, 	  -4,  -14, 	   2,  -12, 	  -2,  -15
+.2byte    5,  -11, 	   1,  -14, 	   0,   -9, 	   0,  -13
+.2byte    5,  -11, 	   3,  -11, 	  -3,   -9, 	  -1,  -12
+sShedinjaAnimTable1:
+.4byte sShedinjaAnims_1_1
+.4byte sShedinjaAnims_1_2
+.4byte sShedinjaAnims_1_3
+.4byte sShedinjaAnims_1_4
+.4byte sShedinjaAnims_1_5
+.4byte sShedinjaAnims_1_6
+.4byte sShedinjaAnims_1_7
+.4byte sShedinjaAnims_1_8
+sShedinjaAnimTable2:
+.4byte sShedinjaAnims_2_1
+.4byte sShedinjaAnims_2_2
+.4byte sShedinjaAnims_2_3
+.4byte sShedinjaAnims_2_4
+.4byte sShedinjaAnims_2_5
+.4byte sShedinjaAnims_2_6
+.4byte sShedinjaAnims_2_7
+.4byte sShedinjaAnims_2_8
+sShedinjaAnimTable3:
+.4byte sShedinjaAnims_3_1
+.4byte sShedinjaAnims_3_2
+.4byte sShedinjaAnims_3_3
+.4byte sShedinjaAnims_3_4
+.4byte sShedinjaAnims_3_5
+.4byte sShedinjaAnims_3_6
+.4byte sShedinjaAnims_3_7
+.4byte sShedinjaAnims_3_8
+sShedinjaAnimTable4:
+.4byte sShedinjaAnims_4_1
+.4byte sShedinjaAnims_4_2
+.4byte sShedinjaAnims_4_3
+.4byte sShedinjaAnims_4_4
+.4byte sShedinjaAnims_4_5
+.4byte sShedinjaAnims_4_6
+.4byte sShedinjaAnims_4_7
+.4byte sShedinjaAnims_4_8
+sShedinjaAnimTable5:
+.4byte sShedinjaAnims_5_1
+.4byte sShedinjaAnims_5_2
+.4byte sShedinjaAnims_5_3
+.4byte sShedinjaAnims_5_4
+.4byte sShedinjaAnims_5_5
+.4byte sShedinjaAnims_5_6
+.4byte sShedinjaAnims_5_7
+.4byte sShedinjaAnims_5_8
+sShedinjaAnimTable6:
+.4byte sShedinjaAnims_6_1
+.4byte sShedinjaAnims_6_1
+.4byte sShedinjaAnims_6_1
+.4byte sShedinjaAnims_6_1
+.4byte sShedinjaAnims_6_1
+.4byte sShedinjaAnims_6_1
+.4byte sShedinjaAnims_6_1
+.4byte sShedinjaAnims_6_1
+sShedinjaAnimTable7:
+.4byte sShedinjaAnims_7_1
+.4byte sShedinjaAnims_7_2
+.4byte sShedinjaAnims_7_3
+.4byte sShedinjaAnims_7_4
+.4byte sShedinjaAnims_7_5
+.4byte sShedinjaAnims_7_6
+.4byte sShedinjaAnims_7_7
+.4byte sShedinjaAnims_7_8
+sShedinjaAnimTable8:
+.4byte sShedinjaAnims_8_1
+.4byte sShedinjaAnims_8_2
+.4byte sShedinjaAnims_8_3
+.4byte sShedinjaAnims_8_4
+.4byte sShedinjaAnims_8_5
+.4byte sShedinjaAnims_8_6
+.4byte sShedinjaAnims_8_7
+.4byte sShedinjaAnims_8_8
+sShedinjaAnimTable9:
+.4byte sShedinjaAnims_9_1
+.4byte sShedinjaAnims_9_2
+.4byte sShedinjaAnims_9_3
+.4byte sShedinjaAnims_9_4
+.4byte sShedinjaAnims_9_5
+.4byte sShedinjaAnims_9_6
+.4byte sShedinjaAnims_9_7
+.4byte sShedinjaAnims_9_8
+sShedinjaAnimTable10:
+.4byte sShedinjaAnims_10_1
+.4byte sShedinjaAnims_10_2
+.4byte sShedinjaAnims_10_3
+.4byte sShedinjaAnims_10_4
+.4byte sShedinjaAnims_10_5
+.4byte sShedinjaAnims_10_6
+.4byte sShedinjaAnims_10_7
+.4byte sShedinjaAnims_10_8
+sShedinjaAnimTable11:
+.4byte sShedinjaAnims_11_1
+.4byte sShedinjaAnims_11_2
+.4byte sShedinjaAnims_11_3
+.4byte sShedinjaAnims_11_4
+.4byte sShedinjaAnims_11_5
+.4byte sShedinjaAnims_11_6
+.4byte sShedinjaAnims_11_7
+.4byte sShedinjaAnims_11_8
+sShedinjaAnimTable12:
+.4byte sShedinjaAnims_12_1
+.4byte sShedinjaAnims_12_2
+.4byte sShedinjaAnims_12_3
+.4byte sShedinjaAnims_12_4
+.4byte sShedinjaAnims_12_5
+.4byte sShedinjaAnims_12_6
+.4byte sShedinjaAnims_12_7
+.4byte sShedinjaAnims_12_8
+sShedinjaAnimTable13:
+.4byte sShedinjaAnims_13_1
+.4byte sShedinjaAnims_13_2
+.4byte sShedinjaAnims_13_3
+.4byte sShedinjaAnims_13_4
+.4byte sShedinjaAnims_13_5
+.4byte sShedinjaAnims_13_6
+.4byte sShedinjaAnims_13_7
+.4byte sShedinjaAnims_13_8
+sAxAnimationsShedinja:
+.4byte sShedinjaAnimTable1
+.4byte sShedinjaAnimTable2
+.4byte sShedinjaAnimTable3
+.4byte sShedinjaAnimTable4
+.4byte sShedinjaAnimTable5
+.4byte sShedinjaAnimTable6
+.4byte sShedinjaAnimTable7
+.4byte sShedinjaAnimTable8
+.4byte sShedinjaAnimTable9
+.4byte sShedinjaAnimTable10
+.4byte sShedinjaAnimTable11
+.4byte sShedinjaAnimTable12
+.4byte sShedinjaAnimTable13
+sAxSpritesShedinja:
+.4byte sShedinjaSprites1
+.4byte sShedinjaSprites2
+.4byte sShedinjaSprites3
+.4byte sShedinjaSprites4
+.4byte sShedinjaSprites5
+.4byte sShedinjaSprites6
+.4byte sShedinjaSprites7
+.4byte sShedinjaSprites8
+.4byte sShedinjaSprites9
+.4byte sShedinjaSprites10
+.4byte sShedinjaSprites11
+.4byte sShedinjaSprites12
+.4byte sShedinjaSprites13
+.4byte sShedinjaSprites14
+.4byte sShedinjaSprites15
+.4byte sShedinjaSprites16
+.4byte sShedinjaSprites17
+.4byte sShedinjaSprites18
+.4byte sShedinjaSprites19
+.4byte sShedinjaSprites20
+.4byte sShedinjaSprites21
+.4byte sShedinjaSprites22
+.4byte sShedinjaSprites23
+.4byte sShedinjaSprites24
+.4byte sShedinjaSprites25
+.4byte sShedinjaSprites26
+.4byte sShedinjaSprites27
+.4byte sShedinjaSprites28
+.4byte sShedinjaSprites29
+.4byte sShedinjaSprites30
+.4byte sShedinjaSprites31
+.4byte sShedinjaSprites32
+sAxMainShedinja:
+ax_main sAxPosesShedinja, sAxAnimationsShedinja, 13, sAxSpritesShedinja, sAxPositionsShedinja

--- a/data/ax/shelgon.inc
+++ b/data/ax/shelgon.inc
@@ -1,0 +1,2732 @@
+.global gAxShelgon
+gAxShelgon:
+ax_siro sAxMainShelgon
+sShelgonPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose4:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose5:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose7:
+ax_pose 6, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose8:
+ax_pose 7, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose9:
+ax_pose 8, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose10:
+ax_pose 9, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose11:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose12:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose16:
+ax_pose 9, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose17:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose18:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose19:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose20:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose21:
+ax_pose 8, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose22:
+ax_pose 3, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose23:
+ax_pose 4, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose24:
+ax_pose 5, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose28:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose29:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose30:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose31:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose32:
+ax_pose 5, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose33:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose34:
+ax_pose 18, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose35:
+ax_pose 6, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose36:
+ax_pose 7, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose37:
+ax_pose 8, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose38:
+ax_pose 19, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose39:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sShelgonPose40:
+ax_pose 9, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose41:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose42:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose43:
+ax_pose 21, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose44:
+ax_pose 22, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose45:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose46:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose47:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose48:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose49:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose50:
+ax_pose 9, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose51:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose52:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose53:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose54:
+ax_pose 22, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose55:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose56:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose57:
+ax_pose 8, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose58:
+ax_pose 19, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose59:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sShelgonPose60:
+ax_pose 3, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose61:
+ax_pose 4, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose62:
+ax_pose 5, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose63:
+ax_pose 17, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose64:
+ax_pose 18, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose65:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose66:
+ax_pose 1, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose67:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose68:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose69:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose70:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose71:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose72:
+ax_pose 5, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose73:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose74:
+ax_pose 18, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose75:
+ax_pose 6, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose76:
+ax_pose 7, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose77:
+ax_pose 8, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose78:
+ax_pose 19, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose79:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sShelgonPose80:
+ax_pose 9, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose81:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose82:
+ax_pose 11, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose83:
+ax_pose 21, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose84:
+ax_pose 22, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose85:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose86:
+ax_pose 13, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose87:
+ax_pose 14, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose88:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose89:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose90:
+ax_pose 9, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose91:
+ax_pose 10, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose92:
+ax_pose 11, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose93:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose94:
+ax_pose 22, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose95:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose96:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose97:
+ax_pose 8, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose98:
+ax_pose 19, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose99:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sShelgonPose100:
+ax_pose 3, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose101:
+ax_pose 4, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose102:
+ax_pose 5, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose103:
+ax_pose 17, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose104:
+ax_pose 18, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose105:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose106:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose107:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose108:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose109:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose110:
+ax_pose 18, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose111:
+ax_pose 6, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose112:
+ax_pose 19, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose113:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sShelgonPose114:
+ax_pose 9, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose115:
+ax_pose 21, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose116:
+ax_pose 22, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose117:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose118:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose119:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose120:
+ax_pose 9, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose121:
+ax_pose 21, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose122:
+ax_pose 22, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose123:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose124:
+ax_pose 19, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose125:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sShelgonPose126:
+ax_pose 3, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose127:
+ax_pose 17, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose128:
+ax_pose 18, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose129:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose130:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose131:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose132:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose133:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose134:
+ax_pose 18, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose135:
+ax_pose 6, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose136:
+ax_pose 19, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose137:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sShelgonPose138:
+ax_pose 9, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose139:
+ax_pose 21, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose140:
+ax_pose 22, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose141:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose142:
+ax_pose 23, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose143:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose144:
+ax_pose 9, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose145:
+ax_pose 21, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose146:
+ax_pose 22, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose147:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose148:
+ax_pose 19, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose149:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sShelgonPose150:
+ax_pose 3, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose151:
+ax_pose 17, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose152:
+ax_pose 18, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose153:
+ax_pose 25, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose154:
+ax_pose 26, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose155:
+ax_pose 27, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sShelgonPose156:
+ax_pose 28, 0x01e2, 0x90ef, 0x5c00
+ax_pose_terminator
+sShelgonPose157:
+ax_pose 29, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sShelgonPose158:
+ax_pose 30, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose159:
+ax_pose 31, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sShelgonPose160:
+ax_pose 30, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sShelgonPose161:
+ax_pose 29, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sShelgonPose162:
+ax_pose 28, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sShelgonPose163:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose164:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose165:
+ax_pose 16, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose166:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose167:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose168:
+ax_pose 18, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose169:
+ax_pose 6, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose170:
+ax_pose 19, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose171:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sShelgonPose172:
+ax_pose 9, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose173:
+ax_pose 21, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose174:
+ax_pose 22, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose175:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose176:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose177:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose178:
+ax_pose 9, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose179:
+ax_pose 21, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose180:
+ax_pose 22, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose181:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose182:
+ax_pose 19, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose183:
+ax_pose 20, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sShelgonPose184:
+ax_pose 3, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose185:
+ax_pose 17, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose186:
+ax_pose 18, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose187:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose188:
+ax_pose 18, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sShelgonPose189:
+ax_pose 20, 0x01ea, 0x80ee, 0x5c00
+ax_pose_terminator
+sShelgonPose190:
+ax_pose 22, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sShelgonPose191:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose192:
+ax_pose 22, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sShelgonPose193:
+ax_pose 20, 0x01ea, 0x90f1, 0x5c00
+ax_pose_terminator
+sShelgonPose194:
+ax_pose 18, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose195:
+ax_pose 16, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose196:
+ax_pose 18, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose197:
+ax_pose 20, 0x01ea, 0x90f2, 0x5c00
+ax_pose_terminator
+sShelgonPose198:
+ax_pose 22, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sShelgonPose199:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose200:
+ax_pose 22, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sShelgonPose201:
+ax_pose 20, 0x01ea, 0x80ee, 0x5c00
+ax_pose_terminator
+sShelgonPose202:
+ax_pose 18, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sShelgonPose203:
+ax_pose 0, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose204:
+ax_pose 15, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose205:
+ax_pose 16, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose206:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose207:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose208:
+ax_pose 18, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose209:
+ax_pose 6, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose210:
+ax_pose 19, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose211:
+ax_pose 20, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sShelgonPose212:
+ax_pose 9, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose213:
+ax_pose 21, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose214:
+ax_pose 22, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sShelgonPose215:
+ax_pose 12, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose216:
+ax_pose 23, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose217:
+ax_pose 24, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose218:
+ax_pose 9, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose219:
+ax_pose 21, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose220:
+ax_pose 22, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose221:
+ax_pose 6, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose222:
+ax_pose 19, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose223:
+ax_pose 20, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sShelgonPose224:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose225:
+ax_pose 17, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose226:
+ax_pose 18, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sShelgonPose227:
+ax_pose 15, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sShelgonPose228:
+ax_pose 17, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose229:
+ax_pose 19, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose230:
+ax_pose 21, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose231:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose232:
+ax_pose 21, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose233:
+ax_pose 19, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sShelgonPose234:
+ax_pose 17, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sShelgonPose235:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose236:
+ax_pose 3, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sShelgonPose237:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose238:
+ax_pose 9, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose239:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sShelgonPose240:
+ax_pose 9, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose241:
+ax_pose 6, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sShelgonPose242:
+ax_pose 3, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+.align 2
+sShelgonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShelgonAnims_2_1:
+ax_anim 2, 0, 28, 0, -6, 0, -1,
+ax_anim 6, 0, 28, 0, -7, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 18,
+ax_anim 2, 1, 27, 1, 19, 1, 18,
+ax_anim 2, 0, 27, 0, 19, 0, 18,
+ax_anim 2, 0, 27, 1, 19, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sShelgonAnims_2_2:
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 6, 0, 33, -2, -2, -2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 11, 11, 11, 11,
+ax_anim 1, 0, 31, 14, 13, 14, 13,
+ax_anim 2, 0, 32, 19, 19, 19, 19,
+ax_anim 2, 1, 32, 20, 19, 20, 19,
+ax_anim 2, 0, 32, 19, 19, 19, 19,
+ax_anim 2, 0, 32, 20, 19, 20, 19,
+ax_anim 2, 0, 29, 11, 10, 11, 10,
+ax_anim_terminator
+sShelgonAnims_2_3:
+ax_anim 2, 0, 38, -4, 0, -4, 0,
+ax_anim 6, 0, 38, -5, 0, -5, 0,
+ax_anim 1, 0, 36, 4, 0, 4, 0,
+ax_anim 1, 2, 35, 9, 0, 9, 0,
+ax_anim 1, 0, 36, 14, 0, 14, 0,
+ax_anim 2, 0, 37, 19, 0, 19, 0,
+ax_anim 2, 1, 37, 19, 1, 19, 1,
+ax_anim 2, 0, 37, 19, 0, 19, 1,
+ax_anim 2, 0, 37, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 11, 0, 11, 0,
+ax_anim_terminator
+sShelgonAnims_2_4:
+ax_anim 2, 0, 43, -2, 1, -2, 1,
+ax_anim 6, 0, 43, -3, 2, -3, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 10, -10, 10, -10,
+ax_anim 1, 0, 41, 14, -14, 14, -14,
+ax_anim 2, 0, 42, 19, -16, 19, -16,
+ax_anim 2, 1, 42, 20, -16, 20, -16,
+ax_anim 2, 0, 42, 19, -16, 19, -16,
+ax_anim 2, 0, 42, 20, -16, 20, -16,
+ax_anim 2, 0, 39, 9, -10, 9, -10,
+ax_anim_terminator
+sShelgonAnims_2_5:
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim 6, 0, 48, 0, 5, 0, 5,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, -4,
+ax_anim 1, 0, 46, 0, -10, 0, -10,
+ax_anim 2, 0, 47, 0, -16, 0, -16,
+ax_anim 2, 1, 47, 1, -16, 1, -16,
+ax_anim 2, 0, 47, 0, -16, 0, -16,
+ax_anim 2, 0, 47, 1, -16, 1, -16,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sShelgonAnims_2_6:
+ax_anim 2, 0, 53, 2, 1, 2, 1,
+ax_anim 6, 0, 53, 3, 2, 3, 2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -10, -10, -10, -10,
+ax_anim 1, 0, 51, -14, -14, -14, -14,
+ax_anim 2, 0, 52, -19, -16, -19, -16,
+ax_anim 2, 1, 52, -20, -16, -20, -16,
+ax_anim 2, 0, 52, -19, -16, -19, -16,
+ax_anim 2, 0, 52, -20, -16, -20, -16,
+ax_anim 2, 0, 49, -9, -10, -9, -10,
+ax_anim_terminator
+sShelgonAnims_2_7:
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim 6, 0, 58, 5, 0, 5, 0,
+ax_anim 1, 0, 56, -4, 0, -4, 0,
+ax_anim 1, 2, 55, -9, 0, -9, 0,
+ax_anim 1, 0, 56, -14, 0, -14, 0,
+ax_anim 2, 0, 57, -19, 0, -19, 0,
+ax_anim 2, 1, 57, -19, 1, -19, 1,
+ax_anim 2, 0, 57, -19, 0, -19, 1,
+ax_anim 2, 0, 57, -19, 1, -19, 1,
+ax_anim 2, 0, 54, -11, 0, -11, 0,
+ax_anim_terminator
+sShelgonAnims_2_8:
+ax_anim 2, 0, 63, 2, -1, 1, -1,
+ax_anim 6, 0, 63, 3, -2, 2, -2,
+ax_anim 1, 0, 61, 1, 0, 0, 0,
+ax_anim 1, 2, 60, -10, 11, -11, 11,
+ax_anim 1, 0, 61, -13, 13, -14, 13,
+ax_anim 2, 0, 62, -18, 19, -19, 19,
+ax_anim 2, 1, 62, -19, 19, -20, 19,
+ax_anim 2, 0, 62, -18, 19, -19, 19,
+ax_anim 2, 0, 62, -19, 19, -20, 19,
+ax_anim 2, 0, 59, -10, 10, -11, 10,
+ax_anim_terminator
+.align 2
+sShelgonAnims_3_1:
+ax_anim 2, 0, 68, 0, -6, 0, -1,
+ax_anim 6, 0, 68, 0, -7, 0, -2,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 19, 0, 18,
+ax_anim 2, 1, 67, 1, 19, 1, 18,
+ax_anim 2, 0, 67, 0, 19, 0, 18,
+ax_anim 2, 0, 67, 1, 19, 1, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sShelgonAnims_3_2:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 6, 0, 73, -2, -2, -2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 11, 11, 11, 11,
+ax_anim 1, 0, 71, 14, 13, 14, 13,
+ax_anim 2, 0, 72, 19, 19, 19, 19,
+ax_anim 2, 1, 72, 20, 19, 20, 19,
+ax_anim 2, 0, 72, 19, 19, 19, 19,
+ax_anim 2, 0, 72, 20, 19, 20, 19,
+ax_anim 2, 0, 69, 11, 10, 11, 10,
+ax_anim_terminator
+sShelgonAnims_3_3:
+ax_anim 2, 0, 78, -4, 0, -4, 0,
+ax_anim 6, 0, 78, -5, 0, -5, 0,
+ax_anim 1, 0, 76, 4, 0, 4, 0,
+ax_anim 1, 2, 75, 9, 0, 9, 0,
+ax_anim 1, 0, 76, 14, 0, 14, 0,
+ax_anim 2, 0, 77, 19, 0, 19, 0,
+ax_anim 2, 1, 77, 19, 1, 19, 1,
+ax_anim 2, 0, 77, 19, 0, 19, 1,
+ax_anim 2, 0, 77, 19, 1, 19, 1,
+ax_anim 2, 0, 74, 11, 0, 11, 0,
+ax_anim_terminator
+sShelgonAnims_3_4:
+ax_anim 2, 0, 83, -2, 1, -2, 1,
+ax_anim 6, 0, 83, -3, 2, -3, 2,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 2, 80, 10, -10, 10, -10,
+ax_anim 1, 0, 81, 14, -14, 14, -14,
+ax_anim 2, 0, 82, 19, -16, 19, -16,
+ax_anim 2, 1, 82, 20, -16, 20, -16,
+ax_anim 2, 0, 82, 19, -16, 19, -16,
+ax_anim 2, 0, 82, 20, -16, 20, -16,
+ax_anim 2, 0, 79, 9, -10, 9, -10,
+ax_anim_terminator
+sShelgonAnims_3_5:
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim 6, 0, 88, 0, 5, 0, 5,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, 0, -4, 0, -4,
+ax_anim 1, 0, 86, 0, -10, 0, -10,
+ax_anim 2, 0, 87, 0, -16, 0, -16,
+ax_anim 2, 1, 87, 1, -16, 1, -16,
+ax_anim 2, 0, 87, 0, -16, 0, -16,
+ax_anim 2, 0, 87, 1, -16, 1, -16,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sShelgonAnims_3_6:
+ax_anim 2, 0, 93, 2, 1, 2, 1,
+ax_anim 6, 0, 93, 3, 2, 3, 2,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 2, 90, -10, -10, -10, -10,
+ax_anim 1, 0, 91, -14, -14, -14, -14,
+ax_anim 2, 0, 92, -19, -16, -19, -16,
+ax_anim 2, 1, 92, -20, -16, -20, -16,
+ax_anim 2, 0, 92, -19, -16, -19, -16,
+ax_anim 2, 0, 92, -20, -16, -20, -16,
+ax_anim 2, 0, 89, -9, -10, -9, -10,
+ax_anim_terminator
+sShelgonAnims_3_7:
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 6, 0, 98, 5, 0, 5, 0,
+ax_anim 1, 0, 96, -4, 0, -4, 0,
+ax_anim 1, 2, 95, -9, 0, -9, 0,
+ax_anim 1, 0, 96, -14, 0, -14, 0,
+ax_anim 2, 0, 97, -19, 0, -19, 0,
+ax_anim 2, 1, 97, -19, 1, -19, 1,
+ax_anim 2, 0, 97, -19, 0, -19, 1,
+ax_anim 2, 0, 97, -19, 1, -19, 1,
+ax_anim 2, 0, 94, -11, 0, -11, 0,
+ax_anim_terminator
+sShelgonAnims_3_8:
+ax_anim 2, 0, 103, 2, -1, 1, -1,
+ax_anim 6, 0, 103, 3, -2, 2, -2,
+ax_anim 1, 0, 101, 1, 0, 0, 0,
+ax_anim 1, 2, 100, -10, 11, -11, 11,
+ax_anim 1, 0, 101, -13, 13, -14, 13,
+ax_anim 2, 0, 102, -18, 19, -19, 19,
+ax_anim 2, 1, 102, -19, 19, -20, 19,
+ax_anim 2, 0, 102, -18, 19, -19, 19,
+ax_anim 2, 0, 102, -19, 19, -20, 19,
+ax_anim 2, 0, 99, -10, 10, -11, 10,
+ax_anim_terminator
+.align 2
+sShelgonAnims_4_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 4, 2, 106, 0, -3, 0, -3,
+ax_anim 1, 0, 104, 0, 2, 0, -3,
+ax_anim 2, 0, 104, 0, 7, 0, -1,
+ax_anim 2, 0, 105, 0, 7, 0, 3,
+ax_anim 2, 1, 105, 1, 7, 1, 3,
+ax_anim 2, 0, 105, 0, 7, 0, 3,
+ax_anim 2, 0, 105, 1, 7, 1, 3,
+ax_anim 2, 0, 105, 0, 7, 0, 3,
+ax_anim 2, 0, 105, 1, 7, 1, 3,
+ax_anim 2, 0, 105, 0, 7, 0, 3,
+ax_anim 2, 0, 104, 0, 3, 0, 1,
+ax_anim_terminator
+sShelgonAnims_4_2:
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim 4, 2, 109, -2, 0, -2, 0,
+ax_anim 1, 0, 107, 0, 2, 0, 2,
+ax_anim 2, 0, 107, 5, 7, 5, 7,
+ax_anim 2, 0, 108, 7, 7, 7, 7,
+ax_anim 2, 1, 108, 6, 8, 6, 8,
+ax_anim 2, 0, 108, 7, 7, 7, 7,
+ax_anim 2, 0, 108, 6, 8, 6, 8,
+ax_anim 2, 0, 108, 7, 7, 7, 7,
+ax_anim 2, 0, 108, 6, 8, 6, 8,
+ax_anim 2, 0, 108, 7, 7, 7, 7,
+ax_anim 2, 0, 107, 3, 3, 3, 3,
+ax_anim_terminator
+sShelgonAnims_4_3:
+ax_anim 2, 0, 112, -3, 0, -1, 0,
+ax_anim 4, 2, 112, -4, 0, -2, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 5, 0, 5, 0,
+ax_anim 2, 0, 111, 8, 0, 8, 0,
+ax_anim 2, 1, 111, 8, 1, 8, 1,
+ax_anim 2, 0, 111, 8, 0, 8, 0,
+ax_anim 2, 0, 111, 8, 1, 8, 1,
+ax_anim 2, 0, 111, 8, 0, 8, 0,
+ax_anim 2, 0, 111, 8, 1, 8, 1,
+ax_anim 2, 0, 111, 8, 0, 8, 0,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim_terminator
+sShelgonAnims_4_4:
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 4, 2, 115, -2, 0, -2, 0,
+ax_anim 1, 0, 113, 0, -2, 0, -2,
+ax_anim 2, 0, 113, 5, -7, 5, -7,
+ax_anim 2, 0, 114, 7, -7, 7, -7,
+ax_anim 2, 1, 114, 6, -8, 6, -8,
+ax_anim 2, 0, 114, 7, -7, 7, -7,
+ax_anim 2, 0, 114, 6, -8, 6, -8,
+ax_anim 2, 0, 114, 7, -7, 7, -7,
+ax_anim 2, 0, 114, 6, -8, 6, -8,
+ax_anim 2, 0, 114, 7, -7, 7, -7,
+ax_anim 2, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+sShelgonAnims_4_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 4, 2, 118, 0, 3, 0, 3,
+ax_anim 1, 0, 116, 0, -2, 0, -2,
+ax_anim 2, 0, 116, 0, -7, 0, -7,
+ax_anim 2, 0, 117, 0, -7, 0, -7,
+ax_anim 2, 1, 117, 1, -7, 1, -7,
+ax_anim 2, 0, 117, 0, -7, 0, -7,
+ax_anim 2, 0, 117, 1, -7, 1, -7,
+ax_anim 2, 0, 117, 0, -7, 0, -7,
+ax_anim 2, 0, 117, 1, -7, 1, -7,
+ax_anim 2, 0, 117, 0, -7, 0, -7,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim_terminator
+sShelgonAnims_4_6:
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim 4, 2, 121, 2, 0, 2, 0,
+ax_anim 1, 0, 119, 0, -2, 0, -2,
+ax_anim 2, 0, 119, -5, -7, -5, -7,
+ax_anim 2, 0, 120, -7, -7, -7, -7,
+ax_anim 2, 1, 120, -6, -8, -6, -8,
+ax_anim 2, 0, 120, -7, -7, -7, -7,
+ax_anim 2, 0, 120, -6, -8, -6, -8,
+ax_anim 2, 0, 120, -7, -7, -7, -7,
+ax_anim 2, 0, 120, -6, -8, -6, -8,
+ax_anim 2, 0, 120, -7, -7, -7, -7,
+ax_anim 2, 0, 119, -3, -3, -3, -3,
+ax_anim_terminator
+sShelgonAnims_4_7:
+ax_anim 2, 0, 124, 3, 0, 1, 0,
+ax_anim 4, 2, 124, 4, 0, 2, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 123, -8, 0, -8, 0,
+ax_anim 2, 1, 123, -8, 1, -8, 1,
+ax_anim 2, 0, 123, -8, 0, -8, 0,
+ax_anim 2, 0, 123, -8, 1, -8, 1,
+ax_anim 2, 0, 123, -8, 0, -8, 0,
+ax_anim 2, 0, 123, -8, 1, -8, 1,
+ax_anim 2, 0, 123, -8, 0, -8, 0,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim_terminator
+sShelgonAnims_4_8:
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 4, 2, 127, 2, 0, 2, 0,
+ax_anim 1, 0, 125, 0, 2, 0, 2,
+ax_anim 2, 0, 125, -5, 7, -5, 7,
+ax_anim 2, 0, 126, -7, 7, -7, 7,
+ax_anim 2, 1, 126, -6, 8, -6, 8,
+ax_anim 2, 0, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 126, -6, 8, -6, 8,
+ax_anim 2, 0, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 126, -6, 8, -6, 8,
+ax_anim 2, 0, 126, -7, 7, -7, 7,
+ax_anim 2, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sShelgonAnims_5_1:
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 4, 0, 130, 0, -7, 0, 0,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 2, 0, 2,
+ax_anim 2, 2, 129, 1, 2, 1, 2,
+ax_anim 2, 0, 129, 0, 2, 0, 2,
+ax_anim 2, 0, 129, 1, 2, 1, 2,
+ax_anim 2, 0, 129, 0, 2, 0, 2,
+ax_anim 2, 0, 129, 1, 2, 1, 2,
+ax_anim 2, 0, 129, 0, 2, 0, 2,
+ax_anim_terminator
+sShelgonAnims_5_2:
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -6, 0, 0,
+ax_anim 4, 0, 133, 0, -7, 0, 0,
+ax_anim 2, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 2, 2, 2, 2,
+ax_anim 2, 2, 132, 3, 1, 3, 1,
+ax_anim 2, 0, 132, 2, 2, 2, 2,
+ax_anim 2, 0, 132, 3, 1, 3, 1,
+ax_anim 2, 0, 132, 2, 2, 2, 2,
+ax_anim 2, 0, 132, 3, 1, 3, 1,
+ax_anim 2, 0, 132, 2, 2, 2, 2,
+ax_anim_terminator
+sShelgonAnims_5_3:
+ax_anim 1, 0, 136, -3, -3, 0, 0,
+ax_anim 2, 0, 136, -3, -6, 0, 0,
+ax_anim 4, 0, 136, -3, -7, 0, 0,
+ax_anim 2, 0, 136, -3, -6, 0, 0,
+ax_anim 1, 0, 136, -2, -3, 0, 0,
+ax_anim 6, 0, 136, -2, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 0, 1, 0,
+ax_anim 2, 2, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 1, 0, 1, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 1, 0, 1, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 1, 0, 1, 0,
+ax_anim_terminator
+sShelgonAnims_5_4:
+ax_anim 1, 0, 139, -1, -2, 0, 0,
+ax_anim 2, 0, 139, -1, -5, 0, 0,
+ax_anim 4, 0, 139, -1, -6, 0, 0,
+ax_anim 2, 0, 139, -1, -5, 0, 0,
+ax_anim 1, 0, 139, -1, -2, 0, 0,
+ax_anim 6, 0, 139, -2, 2, 0, 0,
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 2, 138, 1, -1, 1, -1,
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 0, 138, 1, -1, 1, -1,
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim 2, 0, 138, 1, -1, 1, -1,
+ax_anim 2, 0, 138, 2, 0, 2, 0,
+ax_anim_terminator
+sShelgonAnims_5_5:
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, 0,
+ax_anim 4, 0, 142, 0, -7, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 6, 0, 142, 0, -1, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 2, 141, 1, -2, 1, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 1, -2, 1, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 1, -2, 1, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sShelgonAnims_5_6:
+ax_anim 1, 0, 145, 1, -2, 0, 0,
+ax_anim 2, 0, 145, 1, -5, 0, 0,
+ax_anim 4, 0, 145, 1, -6, 0, 0,
+ax_anim 2, 0, 145, 1, -5, 0, 0,
+ax_anim 1, 0, 145, 1, -2, 0, 0,
+ax_anim 6, 0, 145, 2, 2, 0, 0,
+ax_anim 2, 0, 144, -2, 0, -2, 0,
+ax_anim 2, 2, 144, -1, -1, -1, -1,
+ax_anim 2, 0, 144, -2, 0, -2, 0,
+ax_anim 2, 0, 144, -1, -1, -1, -1,
+ax_anim 2, 0, 144, -2, 0, -2, 0,
+ax_anim 2, 0, 144, -1, -1, -1, -1,
+ax_anim 2, 0, 144, -2, 0, -2, 0,
+ax_anim_terminator
+sShelgonAnims_5_7:
+ax_anim 1, 0, 148, 3, -3, 0, 0,
+ax_anim 2, 0, 148, 3, -6, 0, 0,
+ax_anim 4, 0, 148, 3, -7, 0, 0,
+ax_anim 2, 0, 148, 3, -6, 0, 0,
+ax_anim 1, 0, 148, 2, -3, 0, 0,
+ax_anim 6, 0, 148, 2, 0, 0, 0,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 2, 147, -1, 1, -1, 1,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 0, 147, -1, 1, -1, 1,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim 2, 0, 147, -1, 1, -1, 1,
+ax_anim 2, 0, 147, -1, 0, -1, 0,
+ax_anim_terminator
+sShelgonAnims_5_8:
+ax_anim 1, 0, 151, 0, -3, 0, 0,
+ax_anim 2, 0, 151, 0, -6, 0, 0,
+ax_anim 4, 0, 151, 0, -7, 0, 0,
+ax_anim 2, 0, 151, 0, -6, 0, 0,
+ax_anim 1, 0, 151, 0, -3, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -2, 2, -2, 2,
+ax_anim 2, 2, 150, -3, 1, -3, 1,
+ax_anim 2, 0, 150, -2, 2, -2, 2,
+ax_anim 2, 0, 150, -3, 1, -3, 1,
+ax_anim 2, 0, 150, -2, 2, -2, 2,
+ax_anim 2, 0, 150, -3, 1, -3, 1,
+ax_anim 2, 0, 150, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sShelgonAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShelgonAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sShelgonAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sShelgonAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sShelgonAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sShelgonAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sShelgonAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sShelgonAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sShelgonAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sShelgonAnims_8_1:
+ax_anim 18, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 18, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_8_2:
+ax_anim 18, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 1, 0, 1, 0,
+ax_anim 18, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 1, 0, 1, 0,
+ax_anim_terminator
+sShelgonAnims_8_3:
+ax_anim 18, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 1, 0, 1, 0,
+ax_anim 18, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 1, 0, 1, 0,
+ax_anim_terminator
+sShelgonAnims_8_4:
+ax_anim 18, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 2, -1, 2, -1,
+ax_anim 18, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 2, -1, 2, -1,
+ax_anim_terminator
+sShelgonAnims_8_5:
+ax_anim 18, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim 18, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_8_6:
+ax_anim 18, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 178, -1, -1, -1, -1,
+ax_anim 18, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 178, -1, -1, -1, -1,
+ax_anim_terminator
+sShelgonAnims_8_7:
+ax_anim 18, 0, 180, 0, 0, 0, 0,
+ax_anim 20, 0, 181, -1, 0, -1, 0,
+ax_anim 18, 0, 180, 0, 0, 0, 0,
+ax_anim 20, 0, 181, -1, 0, -1, 0,
+ax_anim_terminator
+sShelgonAnims_8_8:
+ax_anim 18, 0, 183, 0, 0, 0, 0,
+ax_anim 20, 0, 184, -1, 0, -1, 0,
+ax_anim 18, 0, 183, 0, 0, 0, 0,
+ax_anim 20, 0, 184, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sShelgonAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 10, 12, 10, 12,
+ax_anim 2, 0, 189, 7, 17, 7, 17,
+ax_anim 3, 0, 190, 0, 19, 0, 19,
+ax_anim 2, 3, 191, -7, 17, -7, 17,
+ax_anim 2, 0, 192, -10, 12, -10, 12,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 20, 5, 20, 5,
+ax_anim 2, 0, 188, 25, 14, 25, 14,
+ax_anim 3, 0, 189, 23, 18, 23, 18,
+ax_anim 2, 3, 190, 11, 20, 11, 20,
+ax_anim 2, 0, 191, 3, 14, 3, 14,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 4, -5, 4, -5,
+ax_anim 2, 0, 186, 11, -7, 11, -7,
+ax_anim 2, 0, 187, 19, -5, 19, -5,
+ax_anim 3, 0, 188, 21, 0, 21, 0,
+ax_anim 2, 3, 189, 17, 3, 17, 3,
+ax_anim 2, 0, 190, 10, 5, 10, 5,
+ax_anim 1, 0, 191, 5, 4, 5, 4,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -19, 12, -19,
+ax_anim 3, 0, 187, 20, -17, 20, -17,
+ax_anim 2, 3, 188, 21, -10, 21, -10,
+ax_anim 2, 0, 189, 17, -5, 17, -5,
+ax_anim 1, 0, 190, 7, 0, 7, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -7, -4, -7, -4,
+ax_anim 2, 0, 192, -10, -8, -10, -8,
+ax_anim 2, 0, 193, -7, -16, -7, -16,
+ax_anim 3, 0, 186, 0, -18, 0, -18,
+ax_anim 2, 3, 187, 7, -16, 7, -16,
+ax_anim 2, 0, 188, 10, -8, 10, -8,
+ax_anim 1, 0, 189, 7, -4, 7, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -19, -12, -19,
+ax_anim 3, 0, 193, -20, -17, -20, -17,
+ax_anim 2, 3, 192, -21, -10, -21, -10,
+ax_anim 2, 0, 191, -17, -5, -17, -5,
+ax_anim 1, 0, 190, -7, 0, -7, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -4, -5, -4, -5,
+ax_anim 2, 0, 186, -11, -7, -11, -7,
+ax_anim 2, 0, 193, -19, -5, -19, -5,
+ax_anim 3, 0, 192, -21, 0, -21, 0,
+ax_anim 2, 3, 191, -17, 3, -17, 3,
+ax_anim 2, 0, 190, -10, 5, -10, 5,
+ax_anim 1, 0, 189, -5, 4, -5, 4,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -20, 5, -20, 5,
+ax_anim 2, 0, 192, -25, 14, -25, 14,
+ax_anim 3, 0, 191, -23, 18, -23, 18,
+ax_anim 2, 3, 190, -11, 20, -11, 20,
+ax_anim 2, 0, 189, -3, 16, -3, 16,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShelgonAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShelgonAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -22, 0, 0,
+ax_anim 2, 0, 203, 0, -18, 0, 0,
+ax_anim 1, 0, 203, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -17, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -19, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -19, 0, 0,
+ax_anim 2, 0, 212, 0, -17, 0, 0,
+ax_anim 1, 0, 212, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -22, 0, 0,
+ax_anim 3, 0, 215, 0, -21, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -19, 0, 0,
+ax_anim 2, 0, 218, 0, -17, 0, 0,
+ax_anim 1, 0, 218, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -19, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 1, 0, 221, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -17, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShelgonAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShelgonAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sShelgonGfx1:
+.incbin "baserom.gba", 0x1551C38, 0x200
+sShelgonSprites1:
+ax_sprite sShelgonGfx1, 0x200
+ax_sprite_terminator
+sShelgonGfx2:
+.incbin "baserom.gba", 0x1551E48, 0x200
+sShelgonSprites2:
+ax_sprite sShelgonGfx2, 0x200
+ax_sprite_terminator
+sShelgonGfx3:
+.incbin "baserom.gba", 0x1552058, 0x200
+sShelgonSprites3:
+ax_sprite sShelgonGfx3, 0x200
+ax_sprite_terminator
+sShelgonGfx4:
+.incbin "baserom.gba", 0x1552268, 0x200
+sShelgonSprites4:
+ax_sprite sShelgonGfx4, 0x200
+ax_sprite_terminator
+sShelgonGfx5:
+.incbin "baserom.gba", 0x1552478, 0x200
+sShelgonSprites5:
+ax_sprite sShelgonGfx5, 0x200
+ax_sprite_terminator
+sShelgonGfx6:
+.incbin "baserom.gba", 0x1552688, 0x200
+sShelgonSprites6:
+ax_sprite sShelgonGfx6, 0x200
+ax_sprite_terminator
+sShelgonGfx7:
+.incbin "baserom.gba", 0x1552898, 0x200
+sShelgonSprites7:
+ax_sprite sShelgonGfx7, 0x200
+ax_sprite_terminator
+sShelgonGfx8:
+.incbin "baserom.gba", 0x1552AA8, 0x200
+sShelgonSprites8:
+ax_sprite sShelgonGfx8, 0x200
+ax_sprite_terminator
+sShelgonGfx9:
+.incbin "baserom.gba", 0x1552CB8, 0x200
+sShelgonSprites9:
+ax_sprite sShelgonGfx9, 0x200
+ax_sprite_terminator
+sShelgonGfx10:
+.incbin "baserom.gba", 0x1552EC8, 0x200
+sShelgonSprites10:
+ax_sprite sShelgonGfx10, 0x200
+ax_sprite_terminator
+sShelgonGfx11:
+.incbin "baserom.gba", 0x15530D8, 0x200
+sShelgonSprites11:
+ax_sprite sShelgonGfx11, 0x200
+ax_sprite_terminator
+sShelgonGfx12:
+.incbin "baserom.gba", 0x15532E8, 0x200
+sShelgonSprites12:
+ax_sprite sShelgonGfx12, 0x200
+ax_sprite_terminator
+sShelgonGfx13:
+.incbin "baserom.gba", 0x15534F8, 0x200
+sShelgonSprites13:
+ax_sprite sShelgonGfx13, 0x200
+ax_sprite_terminator
+sShelgonGfx14:
+.incbin "baserom.gba", 0x1553708, 0x200
+sShelgonSprites14:
+ax_sprite sShelgonGfx14, 0x200
+ax_sprite_terminator
+sShelgonGfx15:
+.incbin "baserom.gba", 0x1553918, 0x200
+sShelgonSprites15:
+ax_sprite sShelgonGfx15, 0x200
+ax_sprite_terminator
+sShelgonGfx16:
+.incbin "baserom.gba", 0x1553B28, 0x60
+sShelgonGfx16_1:
+.incbin "baserom.gba", 0x1553B88, 0x60
+sShelgonGfx16_2:
+.incbin "baserom.gba", 0x1553BE8, 0x60
+sShelgonGfx16_3:
+.incbin "baserom.gba", 0x1553C48, 0x20
+sShelgonSprites16:
+ax_sprite sShelgonGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShelgonGfx16_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShelgonGfx17:
+.incbin "baserom.gba", 0x1553CB0, 0x60
+sShelgonGfx17_1:
+.incbin "baserom.gba", 0x1553D10, 0x60
+sShelgonGfx17_2:
+.incbin "baserom.gba", 0x1553D70, 0x60
+sShelgonSprites17:
+ax_sprite sShelgonGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShelgonGfx18:
+.incbin "baserom.gba", 0x1553E08, 0x60
+sShelgonGfx18_1:
+.incbin "baserom.gba", 0x1553E68, 0x60
+sShelgonGfx18_2:
+.incbin "baserom.gba", 0x1553EC8, 0x60
+sShelgonGfx18_3:
+.incbin "baserom.gba", 0x1553F28, 0x60
+sShelgonSprites18:
+ax_sprite sShelgonGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShelgonGfx19:
+.incbin "baserom.gba", 0x1553FD0, 0x60
+sShelgonGfx19_1:
+.incbin "baserom.gba", 0x1554030, 0xE0
+sShelgonGfx19_2:
+.incbin "baserom.gba", 0x1554110, 0x20
+sShelgonSprites19:
+ax_sprite sShelgonGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx19_1, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sShelgonGfx19_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShelgonGfx20:
+.incbin "baserom.gba", 0x1554168, 0x60
+sShelgonGfx20_1:
+.incbin "baserom.gba", 0x15541C8, 0x60
+sShelgonGfx20_2:
+.incbin "baserom.gba", 0x1554228, 0x60
+sShelgonSprites20:
+ax_sprite sShelgonGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShelgonGfx21:
+.incbin "baserom.gba", 0x15542C0, 0x100
+sShelgonGfx21_1:
+.incbin "baserom.gba", 0x15543C0, 0x60
+sShelgonGfx21_2:
+.incbin "baserom.gba", 0x1554420, 0x20
+sShelgonSprites21:
+ax_sprite sShelgonGfx21, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShelgonGfx21_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShelgonGfx22:
+.incbin "baserom.gba", 0x1554478, 0x60
+sShelgonGfx22_1:
+.incbin "baserom.gba", 0x15544D8, 0x60
+sShelgonGfx22_2:
+.incbin "baserom.gba", 0x1554538, 0x60
+sShelgonGfx22_3:
+.incbin "baserom.gba", 0x1554598, 0x60
+sShelgonSprites22:
+ax_sprite sShelgonGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShelgonGfx23:
+.incbin "baserom.gba", 0x1554640, 0x60
+sShelgonGfx23_1:
+.incbin "baserom.gba", 0x15546A0, 0x100
+sShelgonGfx23_2:
+.incbin "baserom.gba", 0x15547A0, 0x40
+sShelgonSprites23:
+ax_sprite sShelgonGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShelgonGfx24:
+.incbin "baserom.gba", 0x1554818, 0x60
+sShelgonGfx24_1:
+.incbin "baserom.gba", 0x1554878, 0x60
+sShelgonGfx24_2:
+.incbin "baserom.gba", 0x15548D8, 0x60
+sShelgonGfx24_3:
+.incbin "baserom.gba", 0x1554938, 0x60
+sShelgonSprites24:
+ax_sprite sShelgonGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShelgonGfx25:
+.incbin "baserom.gba", 0x15549E0, 0x60
+sShelgonGfx25_1:
+.incbin "baserom.gba", 0x1554A40, 0x60
+sShelgonGfx25_2:
+.incbin "baserom.gba", 0x1554AA0, 0x60
+sShelgonGfx25_3:
+.incbin "baserom.gba", 0x1554B00, 0x60
+sShelgonSprites25:
+ax_sprite sShelgonGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShelgonGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShelgonGfx26:
+.incbin "baserom.gba", 0x1554BA8, 0x200
+sShelgonSprites26:
+ax_sprite sShelgonGfx26, 0x200
+ax_sprite_terminator
+sShelgonGfx27:
+.incbin "baserom.gba", 0x1554DB8, 0x200
+sShelgonSprites27:
+ax_sprite sShelgonGfx27, 0x200
+ax_sprite_terminator
+sShelgonGfx28:
+.incbin "baserom.gba", 0x1554FC8, 0x200
+sShelgonSprites28:
+ax_sprite sShelgonGfx28, 0x200
+ax_sprite_terminator
+sShelgonGfx29:
+.incbin "baserom.gba", 0x15551D8, 0x200
+sShelgonSprites29:
+ax_sprite sShelgonGfx29, 0x200
+ax_sprite_terminator
+sShelgonGfx30:
+.incbin "baserom.gba", 0x15553E8, 0x200
+sShelgonSprites30:
+ax_sprite sShelgonGfx30, 0x200
+ax_sprite_terminator
+sShelgonGfx31:
+.incbin "baserom.gba", 0x15555F8, 0x200
+sShelgonSprites31:
+ax_sprite sShelgonGfx31, 0x200
+ax_sprite_terminator
+sShelgonGfx32:
+.incbin "baserom.gba", 0x1555808, 0x200
+sShelgonSprites32:
+ax_sprite sShelgonGfx32, 0x200
+ax_sprite_terminator
+sAxPosesShelgon:
+.4byte sShelgonPose1
+.4byte sShelgonPose2
+.4byte sShelgonPose3
+.4byte sShelgonPose4
+.4byte sShelgonPose5
+.4byte sShelgonPose6
+.4byte sShelgonPose7
+.4byte sShelgonPose8
+.4byte sShelgonPose9
+.4byte sShelgonPose10
+.4byte sShelgonPose11
+.4byte sShelgonPose12
+.4byte sShelgonPose13
+.4byte sShelgonPose14
+.4byte sShelgonPose15
+.4byte sShelgonPose16
+.4byte sShelgonPose17
+.4byte sShelgonPose18
+.4byte sShelgonPose19
+.4byte sShelgonPose20
+.4byte sShelgonPose21
+.4byte sShelgonPose22
+.4byte sShelgonPose23
+.4byte sShelgonPose24
+.4byte sShelgonPose25
+.4byte sShelgonPose26
+.4byte sShelgonPose27
+.4byte sShelgonPose28
+.4byte sShelgonPose29
+.4byte sShelgonPose30
+.4byte sShelgonPose31
+.4byte sShelgonPose32
+.4byte sShelgonPose33
+.4byte sShelgonPose34
+.4byte sShelgonPose35
+.4byte sShelgonPose36
+.4byte sShelgonPose37
+.4byte sShelgonPose38
+.4byte sShelgonPose39
+.4byte sShelgonPose40
+.4byte sShelgonPose41
+.4byte sShelgonPose42
+.4byte sShelgonPose43
+.4byte sShelgonPose44
+.4byte sShelgonPose45
+.4byte sShelgonPose46
+.4byte sShelgonPose47
+.4byte sShelgonPose48
+.4byte sShelgonPose49
+.4byte sShelgonPose50
+.4byte sShelgonPose51
+.4byte sShelgonPose52
+.4byte sShelgonPose53
+.4byte sShelgonPose54
+.4byte sShelgonPose55
+.4byte sShelgonPose56
+.4byte sShelgonPose57
+.4byte sShelgonPose58
+.4byte sShelgonPose59
+.4byte sShelgonPose60
+.4byte sShelgonPose61
+.4byte sShelgonPose62
+.4byte sShelgonPose63
+.4byte sShelgonPose64
+.4byte sShelgonPose65
+.4byte sShelgonPose66
+.4byte sShelgonPose67
+.4byte sShelgonPose68
+.4byte sShelgonPose69
+.4byte sShelgonPose70
+.4byte sShelgonPose71
+.4byte sShelgonPose72
+.4byte sShelgonPose73
+.4byte sShelgonPose74
+.4byte sShelgonPose75
+.4byte sShelgonPose76
+.4byte sShelgonPose77
+.4byte sShelgonPose78
+.4byte sShelgonPose79
+.4byte sShelgonPose80
+.4byte sShelgonPose81
+.4byte sShelgonPose82
+.4byte sShelgonPose83
+.4byte sShelgonPose84
+.4byte sShelgonPose85
+.4byte sShelgonPose86
+.4byte sShelgonPose87
+.4byte sShelgonPose88
+.4byte sShelgonPose89
+.4byte sShelgonPose90
+.4byte sShelgonPose91
+.4byte sShelgonPose92
+.4byte sShelgonPose93
+.4byte sShelgonPose94
+.4byte sShelgonPose95
+.4byte sShelgonPose96
+.4byte sShelgonPose97
+.4byte sShelgonPose98
+.4byte sShelgonPose99
+.4byte sShelgonPose100
+.4byte sShelgonPose101
+.4byte sShelgonPose102
+.4byte sShelgonPose103
+.4byte sShelgonPose104
+.4byte sShelgonPose105
+.4byte sShelgonPose106
+.4byte sShelgonPose107
+.4byte sShelgonPose108
+.4byte sShelgonPose109
+.4byte sShelgonPose110
+.4byte sShelgonPose111
+.4byte sShelgonPose112
+.4byte sShelgonPose113
+.4byte sShelgonPose114
+.4byte sShelgonPose115
+.4byte sShelgonPose116
+.4byte sShelgonPose117
+.4byte sShelgonPose118
+.4byte sShelgonPose119
+.4byte sShelgonPose120
+.4byte sShelgonPose121
+.4byte sShelgonPose122
+.4byte sShelgonPose123
+.4byte sShelgonPose124
+.4byte sShelgonPose125
+.4byte sShelgonPose126
+.4byte sShelgonPose127
+.4byte sShelgonPose128
+.4byte sShelgonPose129
+.4byte sShelgonPose130
+.4byte sShelgonPose131
+.4byte sShelgonPose132
+.4byte sShelgonPose133
+.4byte sShelgonPose134
+.4byte sShelgonPose135
+.4byte sShelgonPose136
+.4byte sShelgonPose137
+.4byte sShelgonPose138
+.4byte sShelgonPose139
+.4byte sShelgonPose140
+.4byte sShelgonPose141
+.4byte sShelgonPose142
+.4byte sShelgonPose143
+.4byte sShelgonPose144
+.4byte sShelgonPose145
+.4byte sShelgonPose146
+.4byte sShelgonPose147
+.4byte sShelgonPose148
+.4byte sShelgonPose149
+.4byte sShelgonPose150
+.4byte sShelgonPose151
+.4byte sShelgonPose152
+.4byte sShelgonPose153
+.4byte sShelgonPose154
+.4byte sShelgonPose155
+.4byte sShelgonPose156
+.4byte sShelgonPose157
+.4byte sShelgonPose158
+.4byte sShelgonPose159
+.4byte sShelgonPose160
+.4byte sShelgonPose161
+.4byte sShelgonPose162
+.4byte sShelgonPose163
+.4byte sShelgonPose164
+.4byte sShelgonPose165
+.4byte sShelgonPose166
+.4byte sShelgonPose167
+.4byte sShelgonPose168
+.4byte sShelgonPose169
+.4byte sShelgonPose170
+.4byte sShelgonPose171
+.4byte sShelgonPose172
+.4byte sShelgonPose173
+.4byte sShelgonPose174
+.4byte sShelgonPose175
+.4byte sShelgonPose176
+.4byte sShelgonPose177
+.4byte sShelgonPose178
+.4byte sShelgonPose179
+.4byte sShelgonPose180
+.4byte sShelgonPose181
+.4byte sShelgonPose182
+.4byte sShelgonPose183
+.4byte sShelgonPose184
+.4byte sShelgonPose185
+.4byte sShelgonPose186
+.4byte sShelgonPose187
+.4byte sShelgonPose188
+.4byte sShelgonPose189
+.4byte sShelgonPose190
+.4byte sShelgonPose191
+.4byte sShelgonPose192
+.4byte sShelgonPose193
+.4byte sShelgonPose194
+.4byte sShelgonPose195
+.4byte sShelgonPose196
+.4byte sShelgonPose197
+.4byte sShelgonPose198
+.4byte sShelgonPose199
+.4byte sShelgonPose200
+.4byte sShelgonPose201
+.4byte sShelgonPose202
+.4byte sShelgonPose203
+.4byte sShelgonPose204
+.4byte sShelgonPose205
+.4byte sShelgonPose206
+.4byte sShelgonPose207
+.4byte sShelgonPose208
+.4byte sShelgonPose209
+.4byte sShelgonPose210
+.4byte sShelgonPose211
+.4byte sShelgonPose212
+.4byte sShelgonPose213
+.4byte sShelgonPose214
+.4byte sShelgonPose215
+.4byte sShelgonPose216
+.4byte sShelgonPose217
+.4byte sShelgonPose218
+.4byte sShelgonPose219
+.4byte sShelgonPose220
+.4byte sShelgonPose221
+.4byte sShelgonPose222
+.4byte sShelgonPose223
+.4byte sShelgonPose224
+.4byte sShelgonPose225
+.4byte sShelgonPose226
+.4byte sShelgonPose227
+.4byte sShelgonPose228
+.4byte sShelgonPose229
+.4byte sShelgonPose230
+.4byte sShelgonPose231
+.4byte sShelgonPose232
+.4byte sShelgonPose233
+.4byte sShelgonPose234
+.4byte sShelgonPose235
+.4byte sShelgonPose236
+.4byte sShelgonPose237
+.4byte sShelgonPose238
+.4byte sShelgonPose239
+.4byte sShelgonPose240
+.4byte sShelgonPose241
+.4byte sShelgonPose242
+sAxPositionsShelgon:
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -11
+.2byte    0,   -3, 	  -6,   -1, 	   6,    3, 	   0,  -10
+.2byte    0,   -3, 	  -6,    3, 	   6,   -1, 	   0,  -10
+.2byte    6,   -5, 	  10,   -2, 	   1,    2, 	   0,  -12
+.2byte    6,   -4, 	  10,    0, 	  -3,    2, 	   0,  -11
+.2byte    6,   -4, 	   7,   -2, 	   3,    3, 	  -1,  -12
+.2byte    9,   -8, 	   9,   -5, 	   8,   -1, 	   0,  -12
+.2byte    9,   -7, 	  11,   -4, 	   4,    0, 	   0,  -12
+.2byte    9,   -7, 	   2,   -4, 	  10,   -1, 	   0,  -12
+.2byte    4,  -10, 	   0,   -7, 	   9,   -4, 	   0,  -12
+.2byte    5,   -8, 	   0,   -7, 	  11,   -6, 	   1,  -12
+.2byte    2,   -9, 	   2,  -10, 	   7,   -1, 	   0,  -11
+.2byte    0,  -14, 	   7,   -9, 	  -7,   -9, 	   0,  -11
+.2byte    0,  -13, 	   8,   -7, 	  -8,   -7, 	   0,  -11
+.2byte    0,  -13, 	   7,  -11, 	  -7,  -11, 	   0,  -11
+.2byte   -4,  -10, 	   0,   -7, 	  -9,   -4, 	   0,  -12
+.2byte   -5,   -8, 	   0,   -7, 	 -11,   -6, 	  -1,  -12
+.2byte   -2,   -9, 	  -2,  -10, 	  -7,   -1, 	   0,  -11
+.2byte   -9,   -8, 	  -9,   -5, 	  -8,   -1, 	   0,  -12
+.2byte   -9,   -7, 	 -11,   -4, 	  -4,    0, 	   0,  -12
+.2byte   -9,   -7, 	  -2,   -4, 	 -10,   -1, 	   0,  -12
+.2byte   -6,   -5, 	 -10,   -2, 	  -1,    2, 	   0,  -12
+.2byte   -6,   -4, 	 -10,    0, 	   3,    2, 	   0,  -11
+.2byte   -6,   -4, 	  -7,   -2, 	  -3,    3, 	   1,  -12
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -11
+.2byte    0,   -3, 	  -6,   -1, 	   6,    3, 	   0,  -10
+.2byte    0,   -3, 	  -6,    3, 	   6,   -1, 	   0,  -10
+.2byte    0,   -2, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -6, 	  -6,    0, 	   6,    0, 	   0,  -10
+.2byte    6,   -5, 	  10,   -2, 	   1,    2, 	   0,  -12
+.2byte    6,   -4, 	  10,    0, 	  -3,    2, 	   0,  -11
+.2byte    6,   -4, 	   7,   -2, 	   3,    3, 	  -1,  -12
+.2byte    7,   -4, 	   9,   -2, 	   0,    2, 	   0,  -10
+.2byte    5,  -11, 	  11,  -11, 	   1,   -7, 	  -1,  -12
+.2byte    9,   -8, 	   9,   -5, 	   8,   -1, 	   0,  -12
+.2byte    9,   -8, 	  11,   -5, 	   4,   -1, 	   0,  -13
+.2byte    9,   -7, 	   2,   -4, 	  10,   -1, 	   0,  -12
+.2byte   11,   -9, 	   7,   -6, 	   7,   -1, 	   2,  -12
+.2byte    6,  -19, 	   9,  -17, 	  12,  -11, 	  -1,  -12
+.2byte    4,  -10, 	   0,   -7, 	   9,   -4, 	   0,  -12
+.2byte    5,   -8, 	   0,   -7, 	  11,   -6, 	   1,  -12
+.2byte    2,   -9, 	   2,  -10, 	   7,   -1, 	   0,  -11
+.2byte    6,  -12, 	  -1,   -7, 	   7,   -3, 	   1,  -14
+.2byte    3,  -17, 	   1,  -16, 	  11,  -11, 	  -2,  -13
+.2byte    0,  -14, 	   7,   -9, 	  -7,   -9, 	   0,  -11
+.2byte    0,  -13, 	   8,   -7, 	  -8,   -7, 	   0,  -11
+.2byte    0,  -13, 	   7,  -11, 	  -7,  -11, 	   0,  -11
+.2byte    0,  -15, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte    0,  -17, 	   8,  -15, 	  -8,  -15, 	   0,  -11
+.2byte   -4,  -10, 	   0,   -7, 	  -9,   -4, 	   0,  -12
+.2byte   -5,   -8, 	   0,   -7, 	 -11,   -6, 	  -1,  -12
+.2byte   -2,   -9, 	  -2,  -10, 	  -7,   -1, 	   0,  -11
+.2byte   -7,  -12, 	   0,   -7, 	  -8,   -3, 	  -2,  -14
+.2byte   -3,  -17, 	  -1,  -16, 	 -11,  -11, 	   2,  -13
+.2byte   -9,   -8, 	  -9,   -5, 	  -8,   -1, 	   0,  -12
+.2byte   -9,   -7, 	 -11,   -4, 	  -4,    0, 	   0,  -12
+.2byte   -9,   -7, 	  -2,   -4, 	 -10,   -1, 	   0,  -12
+.2byte  -11,   -9, 	  -7,   -6, 	  -7,   -1, 	  -2,  -12
+.2byte   -6,  -19, 	  -9,  -17, 	 -12,  -11, 	   1,  -12
+.2byte   -6,   -5, 	 -10,   -2, 	  -1,    2, 	   0,  -12
+.2byte   -6,   -4, 	 -10,    0, 	   3,    2, 	   0,  -11
+.2byte   -6,   -4, 	  -7,   -2, 	  -3,    3, 	   1,  -12
+.2byte   -7,   -4, 	  -9,   -2, 	   0,    2, 	   0,  -10
+.2byte   -5,  -13, 	 -11,  -13, 	  -1,   -9, 	   1,  -14
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -11
+.2byte    0,   -3, 	  -6,   -1, 	   6,    3, 	   0,  -10
+.2byte    0,   -3, 	  -6,    3, 	   6,   -1, 	   0,  -10
+.2byte    0,   -2, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -6, 	  -6,    0, 	   6,    0, 	   0,  -10
+.2byte    6,   -5, 	  10,   -2, 	   1,    2, 	   0,  -12
+.2byte    6,   -4, 	  10,    0, 	  -3,    2, 	   0,  -11
+.2byte    6,   -4, 	   7,   -2, 	   3,    3, 	  -1,  -12
+.2byte    7,   -4, 	   9,   -2, 	   0,    2, 	   0,  -10
+.2byte    5,  -11, 	  11,  -11, 	   1,   -7, 	  -1,  -12
+.2byte    9,   -8, 	   9,   -5, 	   8,   -1, 	   0,  -12
+.2byte    9,   -8, 	  11,   -5, 	   4,   -1, 	   0,  -13
+.2byte    9,   -7, 	   2,   -4, 	  10,   -1, 	   0,  -12
+.2byte   11,   -9, 	   7,   -6, 	   7,   -1, 	   2,  -12
+.2byte    6,  -19, 	   9,  -17, 	  12,  -11, 	  -1,  -12
+.2byte    4,  -10, 	   0,   -7, 	   9,   -4, 	   0,  -12
+.2byte    5,   -8, 	   0,   -7, 	  11,   -6, 	   1,  -12
+.2byte    2,   -9, 	   2,  -10, 	   7,   -1, 	   0,  -11
+.2byte    6,  -12, 	  -1,   -7, 	   7,   -3, 	   1,  -14
+.2byte    3,  -17, 	   1,  -16, 	  11,  -11, 	  -2,  -13
+.2byte    0,  -14, 	   7,   -9, 	  -7,   -9, 	   0,  -11
+.2byte    0,  -13, 	   8,   -7, 	  -8,   -7, 	   0,  -11
+.2byte    0,  -13, 	   7,  -11, 	  -7,  -11, 	   0,  -11
+.2byte    0,  -15, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte    0,  -17, 	   8,  -15, 	  -8,  -15, 	   0,  -11
+.2byte   -4,  -10, 	   0,   -7, 	  -9,   -4, 	   0,  -12
+.2byte   -5,   -8, 	   0,   -7, 	 -11,   -6, 	  -1,  -12
+.2byte   -2,   -9, 	  -2,  -10, 	  -7,   -1, 	   0,  -11
+.2byte   -7,  -12, 	   0,   -7, 	  -8,   -3, 	  -2,  -14
+.2byte   -3,  -17, 	  -1,  -16, 	 -11,  -11, 	   2,  -13
+.2byte   -9,   -8, 	  -9,   -5, 	  -8,   -1, 	   0,  -12
+.2byte   -9,   -7, 	 -11,   -4, 	  -4,    0, 	   0,  -12
+.2byte   -9,   -7, 	  -2,   -4, 	 -10,   -1, 	   0,  -12
+.2byte  -11,   -9, 	  -7,   -6, 	  -7,   -1, 	  -2,  -12
+.2byte   -6,  -19, 	  -9,  -17, 	 -12,  -11, 	   1,  -12
+.2byte   -6,   -5, 	 -10,   -2, 	  -1,    2, 	   0,  -12
+.2byte   -6,   -4, 	 -10,    0, 	   3,    2, 	   0,  -11
+.2byte   -6,   -4, 	  -7,   -2, 	  -3,    3, 	   1,  -12
+.2byte   -7,   -4, 	  -9,   -2, 	   0,    2, 	   0,  -10
+.2byte   -5,  -13, 	 -11,  -13, 	  -1,   -9, 	   1,  -14
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -11
+.2byte    0,   -2, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -6, 	  -6,    0, 	   6,    0, 	   0,  -10
+.2byte    6,   -5, 	  10,   -2, 	   1,    2, 	   0,  -12
+.2byte    7,   -4, 	   9,   -2, 	   0,    2, 	   0,  -10
+.2byte    5,  -13, 	  11,  -13, 	   1,   -9, 	  -1,  -14
+.2byte    9,   -8, 	   9,   -5, 	   8,   -1, 	   0,  -12
+.2byte   11,   -9, 	   7,   -6, 	   7,   -1, 	   2,  -12
+.2byte    6,  -19, 	   9,  -17, 	  12,  -11, 	  -1,  -12
+.2byte    4,  -10, 	   0,   -7, 	   9,   -4, 	   0,  -12
+.2byte    6,  -11, 	  -1,   -6, 	   7,   -2, 	   1,  -13
+.2byte    3,  -17, 	   1,  -16, 	  11,  -11, 	  -2,  -13
+.2byte    0,  -14, 	   7,   -9, 	  -7,   -9, 	   0,  -11
+.2byte    0,  -15, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte    0,  -17, 	   8,  -15, 	  -8,  -15, 	   0,  -11
+.2byte   -4,  -10, 	   0,   -7, 	  -9,   -4, 	   0,  -12
+.2byte   -7,  -11, 	   0,   -6, 	  -8,   -2, 	  -2,  -13
+.2byte   -3,  -17, 	  -1,  -16, 	 -11,  -11, 	   2,  -13
+.2byte   -9,   -8, 	  -9,   -5, 	  -8,   -1, 	   0,  -12
+.2byte  -11,   -9, 	  -7,   -6, 	  -7,   -1, 	  -2,  -12
+.2byte   -6,  -19, 	  -9,  -17, 	 -12,  -11, 	   1,  -12
+.2byte   -6,   -5, 	 -10,   -2, 	  -1,    2, 	   0,  -12
+.2byte   -7,   -4, 	  -9,   -2, 	   0,    2, 	   0,  -10
+.2byte   -5,  -13, 	 -11,  -13, 	  -1,   -9, 	   1,  -14
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -11
+.2byte    0,   -2, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -6, 	  -6,    0, 	   6,    0, 	   0,  -10
+.2byte    6,   -5, 	  10,   -2, 	   1,    2, 	   0,  -12
+.2byte    7,   -4, 	   9,   -2, 	   0,    2, 	   0,  -10
+.2byte    5,  -11, 	  11,  -11, 	   1,   -7, 	  -1,  -12
+.2byte    9,   -8, 	   9,   -5, 	   8,   -1, 	   0,  -12
+.2byte   11,   -9, 	   7,   -6, 	   7,   -1, 	   2,  -12
+.2byte    6,  -19, 	   9,  -17, 	  12,  -11, 	  -1,  -12
+.2byte    4,  -10, 	   0,   -7, 	   9,   -4, 	   0,  -12
+.2byte    6,  -10, 	  -1,   -5, 	   7,   -1, 	   1,  -12
+.2byte    3,  -17, 	   1,  -16, 	  11,  -11, 	  -2,  -13
+.2byte    0,  -14, 	   7,   -9, 	  -7,   -9, 	   0,  -11
+.2byte    0,  -14, 	   6,   -8, 	  -6,   -8, 	   0,  -10
+.2byte    0,  -17, 	   8,  -15, 	  -8,  -15, 	   0,  -11
+.2byte   -4,  -10, 	   0,   -7, 	  -9,   -4, 	   0,  -12
+.2byte   -6,  -10, 	   1,   -5, 	  -7,   -1, 	  -1,  -12
+.2byte   -3,  -17, 	  -1,  -16, 	 -11,  -11, 	   2,  -13
+.2byte   -9,   -8, 	  -9,   -5, 	  -8,   -1, 	   0,  -12
+.2byte  -11,   -9, 	  -7,   -6, 	  -7,   -1, 	  -2,  -12
+.2byte   -6,  -19, 	  -9,  -17, 	 -12,  -11, 	   1,  -12
+.2byte   -6,   -5, 	 -10,   -2, 	  -1,    2, 	   0,  -12
+.2byte   -7,   -4, 	  -9,   -2, 	   0,    2, 	   0,  -10
+.2byte   -5,  -11, 	 -11,  -11, 	  -1,   -7, 	   1,  -12
+.2byte   -6,   -3, 	 -11,   -2, 	   1,    3, 	   2,  -10
+.2byte   -6,   -2, 	 -11,   -2, 	   1,    3, 	   1,   -9
+.2byte    0,   -8, 	  -5,   -2, 	   5,   -2, 	   0,  -13
+.2byte    6,  -12, 	  12,   -8, 	   4,   -5, 	  -2,  -13
+.2byte    8,  -17, 	  11,  -14, 	  12,  -10, 	   0,  -14
+.2byte    5,  -13, 	   0,  -14, 	  11,  -10, 	   0,  -13
+.2byte    0,  -16, 	   8,  -11, 	  -8,  -11, 	   0,  -13
+.2byte   -6,  -13, 	  -1,  -14, 	 -12,  -10, 	  -1,  -13
+.2byte   -9,  -17, 	 -12,  -14, 	 -13,  -10, 	  -1,  -14
+.2byte   -7,  -12, 	 -13,   -8, 	  -5,   -5, 	   1,  -13
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -11
+.2byte    0,   -2, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -6, 	  -6,    0, 	   6,    0, 	   0,  -10
+.2byte    6,   -5, 	  10,   -2, 	   1,    2, 	   0,  -12
+.2byte    7,   -4, 	   9,   -2, 	   0,    2, 	   0,  -10
+.2byte    5,  -13, 	  11,  -13, 	   1,   -9, 	  -1,  -14
+.2byte    9,   -8, 	   9,   -5, 	   8,   -1, 	   0,  -12
+.2byte   11,   -9, 	   7,   -6, 	   7,   -1, 	   2,  -12
+.2byte    6,  -19, 	   9,  -17, 	  12,  -11, 	  -1,  -12
+.2byte    4,  -10, 	   0,   -7, 	   9,   -4, 	   0,  -12
+.2byte    6,  -11, 	  -1,   -6, 	   7,   -2, 	   1,  -13
+.2byte    3,  -17, 	   1,  -16, 	  11,  -11, 	  -2,  -13
+.2byte    0,  -14, 	   7,   -9, 	  -7,   -9, 	   0,  -11
+.2byte    0,  -15, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte    0,  -17, 	   8,  -15, 	  -8,  -15, 	   0,  -11
+.2byte   -4,  -10, 	   0,   -7, 	  -9,   -4, 	   0,  -12
+.2byte   -7,  -11, 	   0,   -6, 	  -8,   -2, 	  -2,  -13
+.2byte   -3,  -17, 	  -1,  -16, 	 -11,  -11, 	   2,  -13
+.2byte   -9,   -8, 	  -9,   -5, 	  -8,   -1, 	   0,  -12
+.2byte  -11,   -9, 	  -7,   -6, 	  -7,   -1, 	  -2,  -12
+.2byte   -6,  -19, 	  -9,  -17, 	 -12,  -11, 	   1,  -12
+.2byte   -6,   -5, 	 -10,   -2, 	  -1,    2, 	   0,  -12
+.2byte   -7,   -4, 	  -9,   -2, 	   0,    2, 	   0,  -10
+.2byte   -5,  -13, 	 -11,  -13, 	  -1,   -9, 	   1,  -14
+.2byte    0,   -9, 	  -6,   -3, 	   6,   -3, 	   0,  -13
+.2byte   -7,  -11, 	 -13,  -11, 	  -3,   -7, 	  -1,  -12
+.2byte   -8,  -18, 	 -11,  -16, 	 -14,  -10, 	  -1,  -11
+.2byte   -5,  -15, 	  -3,  -14, 	 -13,   -9, 	   0,  -11
+.2byte    0,  -17, 	   8,  -15, 	  -8,  -15, 	   0,  -11
+.2byte    4,  -15, 	   2,  -14, 	  12,   -9, 	  -1,  -11
+.2byte    6,  -18, 	   9,  -16, 	  12,  -10, 	  -1,  -11
+.2byte    5,  -11, 	  11,  -11, 	   1,   -7, 	  -1,  -12
+.2byte    0,   -9, 	  -6,   -3, 	   6,   -3, 	   0,  -13
+.2byte    5,  -11, 	  11,  -11, 	   1,   -7, 	  -1,  -12
+.2byte    7,  -18, 	  10,  -16, 	  13,  -10, 	   0,  -11
+.2byte    4,  -15, 	   2,  -14, 	  12,   -9, 	  -1,  -11
+.2byte    0,  -17, 	   8,  -15, 	  -8,  -15, 	   0,  -11
+.2byte   -5,  -15, 	  -3,  -14, 	 -13,   -9, 	   0,  -11
+.2byte   -8,  -18, 	 -11,  -16, 	 -14,  -10, 	  -1,  -11
+.2byte   -6,  -11, 	 -12,  -11, 	  -2,   -7, 	   0,  -12
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -11
+.2byte    0,   -2, 	  -6,    0, 	   6,    0, 	   0,   -9
+.2byte    0,   -7, 	  -6,   -1, 	   6,   -1, 	   0,  -11
+.2byte    6,   -5, 	  10,   -2, 	   1,    2, 	   0,  -12
+.2byte    7,   -4, 	   9,   -2, 	   0,    2, 	   0,  -10
+.2byte    5,   -9, 	  11,   -9, 	   1,   -5, 	  -1,  -10
+.2byte    9,   -8, 	   9,   -5, 	   8,   -1, 	   0,  -12
+.2byte   10,   -9, 	   6,   -6, 	   6,   -1, 	   1,  -12
+.2byte    6,  -19, 	   9,  -17, 	  12,  -11, 	  -1,  -12
+.2byte    3,   -9, 	  -1,   -6, 	   8,   -3, 	  -1,  -11
+.2byte    6,  -10, 	  -1,   -5, 	   7,   -1, 	   1,  -12
+.2byte    3,  -15, 	   1,  -14, 	  11,   -9, 	  -2,  -11
+.2byte    0,  -14, 	   7,   -9, 	  -7,   -9, 	   0,  -11
+.2byte    0,  -14, 	   6,   -8, 	  -6,   -8, 	   0,  -10
+.2byte    0,  -16, 	   8,  -14, 	  -8,  -14, 	   0,  -10
+.2byte   -4,   -9, 	   0,   -6, 	  -9,   -3, 	   0,  -11
+.2byte   -6,  -11, 	   1,   -6, 	  -7,   -2, 	  -1,  -13
+.2byte   -3,  -15, 	  -1,  -14, 	 -11,   -9, 	   2,  -11
+.2byte   -9,   -8, 	  -9,   -5, 	  -8,   -1, 	   0,  -12
+.2byte  -10,   -9, 	  -6,   -6, 	  -6,   -1, 	  -1,  -12
+.2byte   -7,  -19, 	 -10,  -17, 	 -13,  -11, 	   0,  -12
+.2byte   -7,   -5, 	 -11,   -2, 	  -2,    2, 	  -1,  -12
+.2byte   -8,   -4, 	 -10,   -2, 	  -1,    2, 	  -1,  -10
+.2byte   -6,   -9, 	 -12,   -9, 	  -2,   -5, 	   0,  -10
+.2byte   -1,   -1, 	  -7,    1, 	   5,    1, 	  -1,   -8
+.2byte   -7,   -3, 	  -9,   -1, 	   0,    3, 	   0,   -9
+.2byte  -10,   -8, 	  -6,   -5, 	  -6,    0, 	  -1,  -11
+.2byte   -7,  -11, 	   0,   -6, 	  -8,   -2, 	  -2,  -13
+.2byte    0,  -15, 	   6,   -9, 	  -6,   -9, 	   0,  -11
+.2byte    6,  -11, 	  -1,   -6, 	   7,   -2, 	   1,  -13
+.2byte    9,   -8, 	   5,   -5, 	   5,    0, 	   0,  -11
+.2byte    6,   -3, 	   8,   -1, 	  -1,    3, 	  -1,   -9
+.2byte    0,   -3, 	  -7,    1, 	   7,    1, 	   0,  -10
+.2byte   -6,   -4, 	 -10,   -1, 	  -1,    3, 	   0,  -11
+.2byte   -9,   -7, 	  -9,   -4, 	  -8,    0, 	   0,  -11
+.2byte   -4,   -9, 	   0,   -6, 	  -9,   -3, 	   0,  -11
+.2byte    0,  -13, 	   7,   -8, 	  -7,   -8, 	   0,  -10
+.2byte    4,   -9, 	   0,   -6, 	   9,   -3, 	   0,  -11
+.2byte    9,   -7, 	   9,   -4, 	   8,    0, 	   0,  -11
+.2byte    6,   -4, 	  10,   -1, 	   1,    3, 	   0,  -11
+sShelgonAnimTable1:
+.4byte sShelgonAnims_1_1
+.4byte sShelgonAnims_1_2
+.4byte sShelgonAnims_1_3
+.4byte sShelgonAnims_1_4
+.4byte sShelgonAnims_1_5
+.4byte sShelgonAnims_1_6
+.4byte sShelgonAnims_1_7
+.4byte sShelgonAnims_1_8
+sShelgonAnimTable2:
+.4byte sShelgonAnims_2_1
+.4byte sShelgonAnims_2_2
+.4byte sShelgonAnims_2_3
+.4byte sShelgonAnims_2_4
+.4byte sShelgonAnims_2_5
+.4byte sShelgonAnims_2_6
+.4byte sShelgonAnims_2_7
+.4byte sShelgonAnims_2_8
+sShelgonAnimTable3:
+.4byte sShelgonAnims_3_1
+.4byte sShelgonAnims_3_2
+.4byte sShelgonAnims_3_3
+.4byte sShelgonAnims_3_4
+.4byte sShelgonAnims_3_5
+.4byte sShelgonAnims_3_6
+.4byte sShelgonAnims_3_7
+.4byte sShelgonAnims_3_8
+sShelgonAnimTable4:
+.4byte sShelgonAnims_4_1
+.4byte sShelgonAnims_4_2
+.4byte sShelgonAnims_4_3
+.4byte sShelgonAnims_4_4
+.4byte sShelgonAnims_4_5
+.4byte sShelgonAnims_4_6
+.4byte sShelgonAnims_4_7
+.4byte sShelgonAnims_4_8
+sShelgonAnimTable5:
+.4byte sShelgonAnims_5_1
+.4byte sShelgonAnims_5_2
+.4byte sShelgonAnims_5_3
+.4byte sShelgonAnims_5_4
+.4byte sShelgonAnims_5_5
+.4byte sShelgonAnims_5_6
+.4byte sShelgonAnims_5_7
+.4byte sShelgonAnims_5_8
+sShelgonAnimTable6:
+.4byte sShelgonAnims_6_1
+.4byte sShelgonAnims_6_1
+.4byte sShelgonAnims_6_1
+.4byte sShelgonAnims_6_1
+.4byte sShelgonAnims_6_1
+.4byte sShelgonAnims_6_1
+.4byte sShelgonAnims_6_1
+.4byte sShelgonAnims_6_1
+sShelgonAnimTable7:
+.4byte sShelgonAnims_7_1
+.4byte sShelgonAnims_7_2
+.4byte sShelgonAnims_7_3
+.4byte sShelgonAnims_7_4
+.4byte sShelgonAnims_7_5
+.4byte sShelgonAnims_7_6
+.4byte sShelgonAnims_7_7
+.4byte sShelgonAnims_7_8
+sShelgonAnimTable8:
+.4byte sShelgonAnims_8_1
+.4byte sShelgonAnims_8_2
+.4byte sShelgonAnims_8_3
+.4byte sShelgonAnims_8_4
+.4byte sShelgonAnims_8_5
+.4byte sShelgonAnims_8_6
+.4byte sShelgonAnims_8_7
+.4byte sShelgonAnims_8_8
+sShelgonAnimTable9:
+.4byte sShelgonAnims_9_1
+.4byte sShelgonAnims_9_2
+.4byte sShelgonAnims_9_3
+.4byte sShelgonAnims_9_4
+.4byte sShelgonAnims_9_5
+.4byte sShelgonAnims_9_6
+.4byte sShelgonAnims_9_7
+.4byte sShelgonAnims_9_8
+sShelgonAnimTable10:
+.4byte sShelgonAnims_10_1
+.4byte sShelgonAnims_10_2
+.4byte sShelgonAnims_10_3
+.4byte sShelgonAnims_10_4
+.4byte sShelgonAnims_10_5
+.4byte sShelgonAnims_10_6
+.4byte sShelgonAnims_10_7
+.4byte sShelgonAnims_10_8
+sShelgonAnimTable11:
+.4byte sShelgonAnims_11_1
+.4byte sShelgonAnims_11_2
+.4byte sShelgonAnims_11_3
+.4byte sShelgonAnims_11_4
+.4byte sShelgonAnims_11_5
+.4byte sShelgonAnims_11_6
+.4byte sShelgonAnims_11_7
+.4byte sShelgonAnims_11_8
+sShelgonAnimTable12:
+.4byte sShelgonAnims_12_1
+.4byte sShelgonAnims_12_2
+.4byte sShelgonAnims_12_3
+.4byte sShelgonAnims_12_4
+.4byte sShelgonAnims_12_5
+.4byte sShelgonAnims_12_6
+.4byte sShelgonAnims_12_7
+.4byte sShelgonAnims_12_8
+sShelgonAnimTable13:
+.4byte sShelgonAnims_13_1
+.4byte sShelgonAnims_13_2
+.4byte sShelgonAnims_13_3
+.4byte sShelgonAnims_13_4
+.4byte sShelgonAnims_13_5
+.4byte sShelgonAnims_13_6
+.4byte sShelgonAnims_13_7
+.4byte sShelgonAnims_13_8
+sAxAnimationsShelgon:
+.4byte sShelgonAnimTable1
+.4byte sShelgonAnimTable2
+.4byte sShelgonAnimTable3
+.4byte sShelgonAnimTable4
+.4byte sShelgonAnimTable5
+.4byte sShelgonAnimTable6
+.4byte sShelgonAnimTable7
+.4byte sShelgonAnimTable8
+.4byte sShelgonAnimTable9
+.4byte sShelgonAnimTable10
+.4byte sShelgonAnimTable11
+.4byte sShelgonAnimTable12
+.4byte sShelgonAnimTable13
+sAxSpritesShelgon:
+.4byte sShelgonSprites1
+.4byte sShelgonSprites2
+.4byte sShelgonSprites3
+.4byte sShelgonSprites4
+.4byte sShelgonSprites5
+.4byte sShelgonSprites6
+.4byte sShelgonSprites7
+.4byte sShelgonSprites8
+.4byte sShelgonSprites9
+.4byte sShelgonSprites10
+.4byte sShelgonSprites11
+.4byte sShelgonSprites12
+.4byte sShelgonSprites13
+.4byte sShelgonSprites14
+.4byte sShelgonSprites15
+.4byte sShelgonSprites16
+.4byte sShelgonSprites17
+.4byte sShelgonSprites18
+.4byte sShelgonSprites19
+.4byte sShelgonSprites20
+.4byte sShelgonSprites21
+.4byte sShelgonSprites22
+.4byte sShelgonSprites23
+.4byte sShelgonSprites24
+.4byte sShelgonSprites25
+.4byte sShelgonSprites26
+.4byte sShelgonSprites27
+.4byte sShelgonSprites28
+.4byte sShelgonSprites29
+.4byte sShelgonSprites30
+.4byte sShelgonSprites31
+.4byte sShelgonSprites32
+sAxMainShelgon:
+ax_main sAxPosesShelgon, sAxAnimationsShelgon, 13, sAxSpritesShelgon, sAxPositionsShelgon

--- a/data/ax/shellder.inc
+++ b/data/ax/shellder.inc
@@ -1,0 +1,2524 @@
+.global gAxShellder
+gAxShellder:
+ax_siro sAxMainShellder
+sShellderPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose4:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose5:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose7:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose8:
+ax_pose 7, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose9:
+ax_pose 8, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose10:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose11:
+ax_pose 10, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose14:
+ax_pose 13, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose15:
+ax_pose 14, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose19:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose20:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose21:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose23:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose28:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose29:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose30:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose31:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose32:
+ax_pose 7, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose33:
+ax_pose 8, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose34:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose35:
+ax_pose 10, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose36:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose37:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose38:
+ax_pose 13, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose39:
+ax_pose 14, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose40:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose41:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose42:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose43:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose44:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose45:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose46:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose47:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose48:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose49:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose50:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose51:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose52:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose53:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose54:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose55:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose56:
+ax_pose 7, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose57:
+ax_pose 8, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose58:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose59:
+ax_pose 10, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose60:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose61:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose62:
+ax_pose 13, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose63:
+ax_pose 14, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose64:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose65:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose66:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose67:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose68:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose69:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose70:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose71:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose72:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose73:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose74:
+ax_pose 15, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose75:
+ax_pose 16, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose76:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose77:
+ax_pose 17, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose78:
+ax_pose 18, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose79:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose80:
+ax_pose 19, 0x01ed, 0x90ef, 0x2c00
+ax_pose_terminator
+sShellderPose81:
+ax_pose 20, 0x01ed, 0x90ef, 0x2c00
+ax_pose_terminator
+sShellderPose82:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose83:
+ax_pose 21, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sShellderPose84:
+ax_pose 22, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sShellderPose85:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose86:
+ax_pose 23, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose87:
+ax_pose 24, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose88:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose89:
+ax_pose 21, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sShellderPose90:
+ax_pose 22, 0x01ed, 0x80f2, 0x2c00
+ax_pose_terminator
+sShellderPose91:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose92:
+ax_pose 19, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sShellderPose93:
+ax_pose 20, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sShellderPose94:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose95:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose96:
+ax_pose 18, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose97:
+ax_pose 25, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose98:
+ax_pose 26, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose99:
+ax_pose 27, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose100:
+ax_pose 28, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose101:
+ax_pose 29, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose102:
+ax_pose 28, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose103:
+ax_pose 27, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose104:
+ax_pose 26, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose105:
+ax_pose 30, 0x01ef, 0x80f6, 0x2c00
+ax_pose_terminator
+sShellderPose106:
+ax_pose 31, 0x01ef, 0x80f6, 0x2c00
+ax_pose_terminator
+sShellderPose107:
+ax_pose 32, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sShellderPose108:
+ax_pose 33, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sShellderPose109:
+ax_pose 34, 0x01e5, 0x90f1, 0x2c00
+ax_pose_terminator
+sShellderPose110:
+ax_pose 35, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sShellderPose111:
+ax_pose 36, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sShellderPose112:
+ax_pose 35, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sShellderPose113:
+ax_pose 34, 0x01e5, 0x80ef, 0x2c00
+ax_pose_terminator
+sShellderPose114:
+ax_pose 33, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sShellderPose115:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose116:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose117:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose118:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose119:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose120:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose121:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose122:
+ax_pose 7, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose123:
+ax_pose 8, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose124:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose125:
+ax_pose 10, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose126:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose127:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose128:
+ax_pose 13, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose129:
+ax_pose 14, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose130:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose131:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose132:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose133:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose134:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose135:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose136:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose137:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose138:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose139:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose140:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose141:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose142:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose143:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose144:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose145:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose146:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose147:
+ax_pose 15, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose148:
+ax_pose 17, 0x01ed, 0x90ec, 0x2c00
+ax_pose_terminator
+sShellderPose149:
+ax_pose 19, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sShellderPose150:
+ax_pose 21, 0x01ed, 0x90ee, 0x2c00
+ax_pose_terminator
+sShellderPose151:
+ax_pose 23, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose152:
+ax_pose 21, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sShellderPose153:
+ax_pose 19, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sShellderPose154:
+ax_pose 17, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose155:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose156:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose157:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose158:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose159:
+ax_pose 4, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose160:
+ax_pose 5, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose161:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose162:
+ax_pose 7, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose163:
+ax_pose 8, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose164:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose165:
+ax_pose 10, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose166:
+ax_pose 11, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose167:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose168:
+ax_pose 13, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose169:
+ax_pose 14, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose170:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose171:
+ax_pose 10, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose172:
+ax_pose 11, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose173:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose174:
+ax_pose 7, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose175:
+ax_pose 8, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose176:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose177:
+ax_pose 4, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose178:
+ax_pose 5, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose179:
+ax_pose 25, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose180:
+ax_pose 26, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose181:
+ax_pose 27, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose182:
+ax_pose 28, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose183:
+ax_pose 29, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose184:
+ax_pose 28, 0x01ef, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose185:
+ax_pose 27, 0x01ef, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose186:
+ax_pose 26, 0x01ef, 0x90ec, 0x2c00
+ax_pose_terminator
+sShellderPose187:
+ax_pose 0, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose188:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose189:
+ax_pose 6, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose190:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose191:
+ax_pose 12, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sShellderPose192:
+ax_pose 9, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose193:
+ax_pose 6, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+sShellderPose194:
+ax_pose 3, 0x01ed, 0x90eb, 0x2c00
+ax_pose_terminator
+.align 2
+sShellderAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, -1, 0, 0,
+ax_anim 10, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 10, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sShellderAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, -1, 0, 0,
+ax_anim 10, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sShellderAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, -1, 0, 0,
+ax_anim 10, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sShellderAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, -1, 0, 0,
+ax_anim 10, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sShellderAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, -1, 0, 0,
+ax_anim 10, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sShellderAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, -1, 0, 0,
+ax_anim 10, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sShellderAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, -1, 0, 0,
+ax_anim 10, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sShellderAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, -1, 0, 0,
+ax_anim 10, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sShellderAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sShellderAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 1, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 0, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sShellderAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 12, 0, 12, 0,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 1, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 0, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 8, 0, 8, 0,
+ax_anim_terminator
+sShellderAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 34, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 22, -23, 22, -23,
+ax_anim 2, 1, 34, 23, -22, 23, -22,
+ax_anim 2, 0, 34, 22, -23, 22, -23,
+ax_anim 2, 0, 34, 23, -22, 23, -22,
+ax_anim 2, 0, 33, 8, -8, 8, -8,
+ax_anim_terminator
+sShellderAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 1, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 0, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sShellderAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 40, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -21, -23, -21, -23,
+ax_anim 2, 1, 40, -22, -22, -22, -22,
+ax_anim 2, 0, 40, -21, -23, -21, -23,
+ax_anim 2, 0, 40, -22, -22, -22, -22,
+ax_anim 2, 0, 39, -8, -8, -8, -8,
+ax_anim_terminator
+sShellderAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -12, 0, -12, 0,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 1, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 0, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -8, 0, -8, 0,
+ax_anim_terminator
+sShellderAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 1, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 0, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sShellderAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 1, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 0, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sShellderAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 1, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 0, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sShellderAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 12, 0, 12, 0,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 1, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 0, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 8, 0, 8, 0,
+ax_anim_terminator
+sShellderAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -4, 4, -4,
+ax_anim 1, 0, 58, 10, -10, 10, -10,
+ax_anim 2, 0, 58, 22, -23, 22, -23,
+ax_anim 2, 1, 58, 23, -22, 23, -22,
+ax_anim 2, 0, 58, 22, -23, 22, -23,
+ax_anim 2, 0, 58, 23, -22, 23, -22,
+ax_anim 2, 0, 57, 8, -8, 8, -8,
+ax_anim_terminator
+sShellderAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 1, 61, 1, -22, 1, -22,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 0, 61, 1, -22, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sShellderAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -4, -4, -4,
+ax_anim 1, 0, 64, -10, -10, -10, -10,
+ax_anim 2, 0, 64, -21, -23, -21, -23,
+ax_anim 2, 1, 64, -22, -22, -22, -22,
+ax_anim 2, 0, 64, -21, -23, -21, -23,
+ax_anim 2, 0, 64, -22, -22, -22, -22,
+ax_anim 2, 0, 63, -8, -8, -8, -8,
+ax_anim_terminator
+sShellderAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -12, 0, -12, 0,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 1, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 0, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 66, -8, 0, -8, 0,
+ax_anim_terminator
+sShellderAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 1, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 0, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sShellderAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 5, 2, 72, 0, -3, 0, -3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 1, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sShellderAnims_4_2:
+ax_anim 2, 0, 75, -2, -2, -2, -2,
+ax_anim 5, 2, 75, -3, -3, -3, -3,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 1, 76, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 76, 4, 4, 4, 4,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim_terminator
+sShellderAnims_4_3:
+ax_anim 2, 0, 78, -2, 0, -2, 0,
+ax_anim 5, 2, 78, -3, 0, -3, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 1, 79, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 79, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 79, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 79, 4, 0, 4, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sShellderAnims_4_4:
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim 5, 2, 81, -3, 3, -3, 3,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 4, -4, 4, -4,
+ax_anim 2, 1, 82, 4, -4, 4, -4,
+ax_anim 2, 0, 83, 4, -4, 4, -4,
+ax_anim 2, 0, 82, 4, -4, 4, -4,
+ax_anim 2, 0, 83, 4, -4, 4, -4,
+ax_anim 2, 0, 82, 4, -4, 4, -4,
+ax_anim 2, 0, 83, 4, -4, 4, -4,
+ax_anim 2, 0, 82, 4, -4, 4, -4,
+ax_anim 2, 0, 83, 4, -4, 4, -4,
+ax_anim 2, 0, 81, 2, -2, 2, -2,
+ax_anim_terminator
+sShellderAnims_4_5:
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 5, 2, 84, 0, 3, 0, 3,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 1, 85, 0, -4, 0, -4,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 0, 85, 0, -4, 0, -4,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim_terminator
+sShellderAnims_4_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 5, 2, 87, 3, 3, 3, 3,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim 2, 1, 88, -4, -4, -4, -4,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 88, -4, -4, -4, -4,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim_terminator
+sShellderAnims_4_7:
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim 5, 2, 90, 3, 0, 3, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 1, 91, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 91, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 91, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 91, -4, 0, -4, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sShellderAnims_4_8:
+ax_anim 2, 0, 93, 2, -2, 2, -2,
+ax_anim 5, 2, 93, 3, -3, 3, -3,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 1, 94, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sShellderAnims_5_1:
+ax_anim 20, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sShellderAnims_5_2:
+ax_anim 20, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sShellderAnims_5_3:
+ax_anim 20, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 1,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 1, 0, 1,
+ax_anim_terminator
+sShellderAnims_5_4:
+ax_anim 20, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sShellderAnims_5_5:
+ax_anim 20, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim_terminator
+sShellderAnims_5_6:
+ax_anim 20, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim_terminator
+sShellderAnims_5_7:
+ax_anim 20, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim_terminator
+sShellderAnims_5_8:
+ax_anim 20, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sShellderAnims_6_1:
+ax_anim 24, 0, 104, 0, 0, 0, 0,
+ax_anim 10, 0, 104, 0, -1, 0, 0,
+ax_anim 10, 0, 104, 0, -2, 0, 0,
+ax_anim 24, 0, 105, 0, -2, 0, 0,
+ax_anim 10, 0, 105, 0, -1, 0, 0,
+ax_anim 10, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShellderAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sShellderAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sShellderAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sShellderAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sShellderAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sShellderAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sShellderAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sShellderAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sShellderAnims_8_1:
+ax_anim 14, 0, 114, 0, 0, 0, 0,
+ax_anim 40, 0, 116, 0, 0, 0, 0,
+ax_anim 14, 0, 114, 0, 0, 0, 0,
+ax_anim 30, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_8_2:
+ax_anim 14, 0, 117, 0, 0, 0, 0,
+ax_anim 40, 0, 119, 0, 0, 0, 0,
+ax_anim 14, 0, 117, 0, 0, 0, 0,
+ax_anim 30, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_8_3:
+ax_anim 14, 0, 120, 0, 0, 0, 0,
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 14, 0, 120, 0, 0, 0, 0,
+ax_anim 30, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_8_4:
+ax_anim 14, 0, 123, 0, 0, 0, 0,
+ax_anim 40, 0, 125, 0, 0, 0, 0,
+ax_anim 14, 0, 123, 0, 0, 0, 0,
+ax_anim 30, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_8_5:
+ax_anim 14, 0, 126, 0, 0, 0, 0,
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 14, 0, 126, 0, 0, 0, 0,
+ax_anim 30, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_8_6:
+ax_anim 14, 0, 129, 0, 0, 0, 0,
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 14, 0, 129, 0, 0, 0, 0,
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_8_7:
+ax_anim 14, 0, 132, 0, 0, 0, 0,
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 14, 0, 132, 0, 0, 0, 0,
+ax_anim 30, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_8_8:
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 14, 0, 135, 0, 0, 0, 0,
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShellderAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 17, 7, 17,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -7, 17, -7, 17,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 8, 0, 8, 0,
+ax_anim 2, 0, 139, 17, 5, 17, 5,
+ax_anim 2, 0, 140, 21, 14, 21, 14,
+ax_anim 3, 0, 141, 21, 20, 21, 20,
+ax_anim 2, 3, 142, 11, 21, 11, 21,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -5, 3, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 16, -5, 16, -5,
+ax_anim 3, 0, 140, 20, 0, 20, 0,
+ax_anim 2, 3, 141, 16, 4, 16, 4,
+ax_anim 2, 0, 142, 12, 5, 12, 5,
+ax_anim 1, 0, 143, 4, 3, 4, 3,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -8, -1, -8,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 12, -22, 12, -22,
+ax_anim 3, 0, 139, 20, -22, 20, -22,
+ax_anim 2, 3, 140, 21, -13, 21, -13,
+ax_anim 2, 0, 141, 17, -4, 17, -4,
+ax_anim 1, 0, 142, 8, 1, 8, 1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -4, -8, -4,
+ax_anim 2, 0, 144, -9, -12, -9, -12,
+ax_anim 2, 0, 145, -7, -18, -7, -18,
+ax_anim 3, 0, 138, 0, -22, 0, -22,
+ax_anim 2, 3, 139, 7, -18, 7, -18,
+ax_anim 2, 0, 140, 9, -10, 9, -10,
+ax_anim 1, 0, 141, 8, -4, 8, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -12, -22, -12, -22,
+ax_anim 3, 0, 145, -20, -22, -20, -22,
+ax_anim 2, 3, 144, -21, -13, -21, -13,
+ax_anim 2, 0, 143, -17, -4, -17, -4,
+ax_anim 1, 0, 142, -8, -1, -8, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -5, -3, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -16, -5, -16, -5,
+ax_anim 3, 0, 144, -20, 0, -20, 0,
+ax_anim 2, 3, 143, -16, 4, -16, 4,
+ax_anim 2, 0, 142, -12, 5, -12, 5,
+ax_anim 1, 0, 141, -4, 3, -4, 3,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -8, 0, -8, 0,
+ax_anim 2, 0, 145, -17, 5, -17, 5,
+ax_anim 2, 0, 144, -21, 14, -21, 14,
+ax_anim 3, 0, 143, -21, 20, -21, 20,
+ax_anim 2, 3, 142, -11, 21, -11, 21,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShellderAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShellderAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -25, 0, 0,
+ax_anim 3, 0, 162, 0, -23, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -24, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -25, 0, 0,
+ax_anim 3, 0, 174, 0, -23, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShellderAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShellderAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sShellderGfx1:
+.incbin "baserom.gba", 0x8D7614, 0x200
+sShellderSprites1:
+ax_sprite sShellderGfx1, 0x200
+ax_sprite_terminator
+sShellderGfx2:
+.incbin "baserom.gba", 0x8D7824, 0x200
+sShellderSprites2:
+ax_sprite sShellderGfx2, 0x200
+ax_sprite_terminator
+sShellderGfx3:
+.incbin "baserom.gba", 0x8D7A34, 0x200
+sShellderSprites3:
+ax_sprite sShellderGfx3, 0x200
+ax_sprite_terminator
+sShellderGfx4:
+.incbin "baserom.gba", 0x8D7C44, 0x200
+sShellderSprites4:
+ax_sprite sShellderGfx4, 0x200
+ax_sprite_terminator
+sShellderGfx5:
+.incbin "baserom.gba", 0x8D7E54, 0x200
+sShellderSprites5:
+ax_sprite sShellderGfx5, 0x200
+ax_sprite_terminator
+sShellderGfx6:
+.incbin "baserom.gba", 0x8D8064, 0x200
+sShellderSprites6:
+ax_sprite sShellderGfx6, 0x200
+ax_sprite_terminator
+sShellderGfx7:
+.incbin "baserom.gba", 0x8D8274, 0x200
+sShellderSprites7:
+ax_sprite sShellderGfx7, 0x200
+ax_sprite_terminator
+sShellderGfx8:
+.incbin "baserom.gba", 0x8D8484, 0x200
+sShellderSprites8:
+ax_sprite sShellderGfx8, 0x200
+ax_sprite_terminator
+sShellderGfx9:
+.incbin "baserom.gba", 0x8D8694, 0x200
+sShellderSprites9:
+ax_sprite sShellderGfx9, 0x200
+ax_sprite_terminator
+sShellderGfx10:
+.incbin "baserom.gba", 0x8D88A4, 0x200
+sShellderSprites10:
+ax_sprite sShellderGfx10, 0x200
+ax_sprite_terminator
+sShellderGfx11:
+.incbin "baserom.gba", 0x8D8AB4, 0x200
+sShellderSprites11:
+ax_sprite sShellderGfx11, 0x200
+ax_sprite_terminator
+sShellderGfx12:
+.incbin "baserom.gba", 0x8D8CC4, 0x200
+sShellderSprites12:
+ax_sprite sShellderGfx12, 0x200
+ax_sprite_terminator
+sShellderGfx13:
+.incbin "baserom.gba", 0x8D8ED4, 0x200
+sShellderSprites13:
+ax_sprite sShellderGfx13, 0x200
+ax_sprite_terminator
+sShellderGfx14:
+.incbin "baserom.gba", 0x8D90E4, 0x200
+sShellderSprites14:
+ax_sprite sShellderGfx14, 0x200
+ax_sprite_terminator
+sShellderGfx15:
+.incbin "baserom.gba", 0x8D92F4, 0x200
+sShellderSprites15:
+ax_sprite sShellderGfx15, 0x200
+ax_sprite_terminator
+sShellderGfx16:
+.incbin "baserom.gba", 0x8D9504, 0x60
+sShellderGfx16_1:
+.incbin "baserom.gba", 0x8D9564, 0x60
+sShellderGfx16_2:
+.incbin "baserom.gba", 0x8D95C4, 0x60
+sShellderSprites16:
+ax_sprite sShellderGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx17:
+.incbin "baserom.gba", 0x8D965C, 0x60
+sShellderGfx17_1:
+.incbin "baserom.gba", 0x8D96BC, 0x60
+sShellderGfx17_2:
+.incbin "baserom.gba", 0x8D971C, 0x60
+sShellderGfx17_3:
+.incbin "baserom.gba", 0x8D977C, 0x20
+sShellderSprites17:
+ax_sprite sShellderGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShellderGfx17_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShellderGfx18:
+.incbin "baserom.gba", 0x8D97E4, 0x60
+sShellderGfx18_1:
+.incbin "baserom.gba", 0x8D9844, 0x60
+sShellderGfx18_2:
+.incbin "baserom.gba", 0x8D98A4, 0x60
+sShellderSprites18:
+ax_sprite sShellderGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx19:
+.incbin "baserom.gba", 0x8D993C, 0x60
+sShellderGfx19_1:
+.incbin "baserom.gba", 0x8D999C, 0x60
+sShellderGfx19_2:
+.incbin "baserom.gba", 0x8D99FC, 0x60
+sShellderGfx19_3:
+.incbin "baserom.gba", 0x8D9A5C, 0x20
+sShellderSprites19:
+ax_sprite sShellderGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx19_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sShellderGfx20:
+.incbin "baserom.gba", 0x8D9AC4, 0x60
+sShellderGfx20_1:
+.incbin "baserom.gba", 0x8D9B24, 0x80
+sShellderGfx20_2:
+.incbin "baserom.gba", 0x8D9BA4, 0x60
+sShellderSprites20:
+ax_sprite sShellderGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx20_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx20_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sShellderGfx21:
+.incbin "baserom.gba", 0x8D9C3C, 0x40
+sShellderGfx21_1:
+.incbin "baserom.gba", 0x8D9C7C, 0x100
+sShellderSprites21:
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sShellderGfx22:
+.incbin "baserom.gba", 0x8D9DAC, 0x60
+sShellderGfx22_1:
+.incbin "baserom.gba", 0x8D9E0C, 0x60
+sShellderGfx22_2:
+.incbin "baserom.gba", 0x8D9E6C, 0x60
+sShellderSprites22:
+ax_sprite sShellderGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx23:
+.incbin "baserom.gba", 0x8D9F04, 0x60
+sShellderGfx23_1:
+.incbin "baserom.gba", 0x8D9F64, 0x60
+sShellderGfx23_2:
+.incbin "baserom.gba", 0x8D9FC4, 0x60
+sShellderSprites23:
+ax_sprite sShellderGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx24:
+.incbin "baserom.gba", 0x8DA05C, 0x60
+sShellderGfx24_1:
+.incbin "baserom.gba", 0x8DA0BC, 0x60
+sShellderGfx24_2:
+.incbin "baserom.gba", 0x8DA11C, 0x60
+sShellderSprites24:
+ax_sprite sShellderGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx25:
+.incbin "baserom.gba", 0x8DA1B4, 0x60
+sShellderGfx25_1:
+.incbin "baserom.gba", 0x8DA214, 0x60
+sShellderGfx25_2:
+.incbin "baserom.gba", 0x8DA274, 0x60
+sShellderSprites25:
+ax_sprite sShellderGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx26:
+.incbin "baserom.gba", 0x8DA30C, 0x60
+sShellderGfx26_1:
+.incbin "baserom.gba", 0x8DA36C, 0x60
+sShellderGfx26_2:
+.incbin "baserom.gba", 0x8DA3CC, 0x60
+sShellderSprites26:
+ax_sprite sShellderGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx27:
+.incbin "baserom.gba", 0x8DA464, 0x60
+sShellderGfx27_1:
+.incbin "baserom.gba", 0x8DA4C4, 0x60
+sShellderGfx27_2:
+.incbin "baserom.gba", 0x8DA524, 0x60
+sShellderSprites27:
+ax_sprite sShellderGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx28:
+.incbin "baserom.gba", 0x8DA5BC, 0x60
+sShellderGfx28_1:
+.incbin "baserom.gba", 0x8DA61C, 0x60
+sShellderGfx28_2:
+.incbin "baserom.gba", 0x8DA67C, 0x60
+sShellderSprites28:
+ax_sprite sShellderGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx29:
+.incbin "baserom.gba", 0x8DA714, 0x60
+sShellderGfx29_1:
+.incbin "baserom.gba", 0x8DA774, 0x60
+sShellderGfx29_2:
+.incbin "baserom.gba", 0x8DA7D4, 0x60
+sShellderSprites29:
+ax_sprite sShellderGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx30:
+.incbin "baserom.gba", 0x8DA86C, 0x60
+sShellderGfx30_1:
+.incbin "baserom.gba", 0x8DA8CC, 0x60
+sShellderGfx30_2:
+.incbin "baserom.gba", 0x8DA92C, 0x60
+sShellderSprites30:
+ax_sprite sShellderGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShellderGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShellderGfx31:
+.incbin "baserom.gba", 0x8DA9C4, 0x200
+sShellderSprites31:
+ax_sprite sShellderGfx31, 0x200
+ax_sprite_terminator
+sShellderGfx32:
+.incbin "baserom.gba", 0x8DABD4, 0x200
+sShellderSprites32:
+ax_sprite sShellderGfx32, 0x200
+ax_sprite_terminator
+sShellderGfx33:
+.incbin "baserom.gba", 0x8DADE4, 0x200
+sShellderSprites33:
+ax_sprite sShellderGfx33, 0x200
+ax_sprite_terminator
+sShellderGfx34:
+.incbin "baserom.gba", 0x8DAFF4, 0x200
+sShellderSprites34:
+ax_sprite sShellderGfx34, 0x200
+ax_sprite_terminator
+sShellderGfx35:
+.incbin "baserom.gba", 0x8DB204, 0x200
+sShellderSprites35:
+ax_sprite sShellderGfx35, 0x200
+ax_sprite_terminator
+sShellderGfx36:
+.incbin "baserom.gba", 0x8DB414, 0x200
+sShellderSprites36:
+ax_sprite sShellderGfx36, 0x200
+ax_sprite_terminator
+sShellderGfx37:
+.incbin "baserom.gba", 0x8DB624, 0x200
+sShellderSprites37:
+ax_sprite sShellderGfx37, 0x200
+ax_sprite_terminator
+sAxPosesShellder:
+.4byte sShellderPose1
+.4byte sShellderPose2
+.4byte sShellderPose3
+.4byte sShellderPose4
+.4byte sShellderPose5
+.4byte sShellderPose6
+.4byte sShellderPose7
+.4byte sShellderPose8
+.4byte sShellderPose9
+.4byte sShellderPose10
+.4byte sShellderPose11
+.4byte sShellderPose12
+.4byte sShellderPose13
+.4byte sShellderPose14
+.4byte sShellderPose15
+.4byte sShellderPose16
+.4byte sShellderPose17
+.4byte sShellderPose18
+.4byte sShellderPose19
+.4byte sShellderPose20
+.4byte sShellderPose21
+.4byte sShellderPose22
+.4byte sShellderPose23
+.4byte sShellderPose24
+.4byte sShellderPose25
+.4byte sShellderPose26
+.4byte sShellderPose27
+.4byte sShellderPose28
+.4byte sShellderPose29
+.4byte sShellderPose30
+.4byte sShellderPose31
+.4byte sShellderPose32
+.4byte sShellderPose33
+.4byte sShellderPose34
+.4byte sShellderPose35
+.4byte sShellderPose36
+.4byte sShellderPose37
+.4byte sShellderPose38
+.4byte sShellderPose39
+.4byte sShellderPose40
+.4byte sShellderPose41
+.4byte sShellderPose42
+.4byte sShellderPose43
+.4byte sShellderPose44
+.4byte sShellderPose45
+.4byte sShellderPose46
+.4byte sShellderPose47
+.4byte sShellderPose48
+.4byte sShellderPose49
+.4byte sShellderPose50
+.4byte sShellderPose51
+.4byte sShellderPose52
+.4byte sShellderPose53
+.4byte sShellderPose54
+.4byte sShellderPose55
+.4byte sShellderPose56
+.4byte sShellderPose57
+.4byte sShellderPose58
+.4byte sShellderPose59
+.4byte sShellderPose60
+.4byte sShellderPose61
+.4byte sShellderPose62
+.4byte sShellderPose63
+.4byte sShellderPose64
+.4byte sShellderPose65
+.4byte sShellderPose66
+.4byte sShellderPose67
+.4byte sShellderPose68
+.4byte sShellderPose69
+.4byte sShellderPose70
+.4byte sShellderPose71
+.4byte sShellderPose72
+.4byte sShellderPose73
+.4byte sShellderPose74
+.4byte sShellderPose75
+.4byte sShellderPose76
+.4byte sShellderPose77
+.4byte sShellderPose78
+.4byte sShellderPose79
+.4byte sShellderPose80
+.4byte sShellderPose81
+.4byte sShellderPose82
+.4byte sShellderPose83
+.4byte sShellderPose84
+.4byte sShellderPose85
+.4byte sShellderPose86
+.4byte sShellderPose87
+.4byte sShellderPose88
+.4byte sShellderPose89
+.4byte sShellderPose90
+.4byte sShellderPose91
+.4byte sShellderPose92
+.4byte sShellderPose93
+.4byte sShellderPose94
+.4byte sShellderPose95
+.4byte sShellderPose96
+.4byte sShellderPose97
+.4byte sShellderPose98
+.4byte sShellderPose99
+.4byte sShellderPose100
+.4byte sShellderPose101
+.4byte sShellderPose102
+.4byte sShellderPose103
+.4byte sShellderPose104
+.4byte sShellderPose105
+.4byte sShellderPose106
+.4byte sShellderPose107
+.4byte sShellderPose108
+.4byte sShellderPose109
+.4byte sShellderPose110
+.4byte sShellderPose111
+.4byte sShellderPose112
+.4byte sShellderPose113
+.4byte sShellderPose114
+.4byte sShellderPose115
+.4byte sShellderPose116
+.4byte sShellderPose117
+.4byte sShellderPose118
+.4byte sShellderPose119
+.4byte sShellderPose120
+.4byte sShellderPose121
+.4byte sShellderPose122
+.4byte sShellderPose123
+.4byte sShellderPose124
+.4byte sShellderPose125
+.4byte sShellderPose126
+.4byte sShellderPose127
+.4byte sShellderPose128
+.4byte sShellderPose129
+.4byte sShellderPose130
+.4byte sShellderPose131
+.4byte sShellderPose132
+.4byte sShellderPose133
+.4byte sShellderPose134
+.4byte sShellderPose135
+.4byte sShellderPose136
+.4byte sShellderPose137
+.4byte sShellderPose138
+.4byte sShellderPose139
+.4byte sShellderPose140
+.4byte sShellderPose141
+.4byte sShellderPose142
+.4byte sShellderPose143
+.4byte sShellderPose144
+.4byte sShellderPose145
+.4byte sShellderPose146
+.4byte sShellderPose147
+.4byte sShellderPose148
+.4byte sShellderPose149
+.4byte sShellderPose150
+.4byte sShellderPose151
+.4byte sShellderPose152
+.4byte sShellderPose153
+.4byte sShellderPose154
+.4byte sShellderPose155
+.4byte sShellderPose156
+.4byte sShellderPose157
+.4byte sShellderPose158
+.4byte sShellderPose159
+.4byte sShellderPose160
+.4byte sShellderPose161
+.4byte sShellderPose162
+.4byte sShellderPose163
+.4byte sShellderPose164
+.4byte sShellderPose165
+.4byte sShellderPose166
+.4byte sShellderPose167
+.4byte sShellderPose168
+.4byte sShellderPose169
+.4byte sShellderPose170
+.4byte sShellderPose171
+.4byte sShellderPose172
+.4byte sShellderPose173
+.4byte sShellderPose174
+.4byte sShellderPose175
+.4byte sShellderPose176
+.4byte sShellderPose177
+.4byte sShellderPose178
+.4byte sShellderPose179
+.4byte sShellderPose180
+.4byte sShellderPose181
+.4byte sShellderPose182
+.4byte sShellderPose183
+.4byte sShellderPose184
+.4byte sShellderPose185
+.4byte sShellderPose186
+.4byte sShellderPose187
+.4byte sShellderPose188
+.4byte sShellderPose189
+.4byte sShellderPose190
+.4byte sShellderPose191
+.4byte sShellderPose192
+.4byte sShellderPose193
+.4byte sShellderPose194
+sAxPositionsShellder:
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	  -7,   -7, 	   6,   -7, 	  -1,  -10
+.2byte   -1,   -2, 	  -7,   -7, 	   5,   -7, 	  -1,   -9
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+.2byte    4,   -5, 	   3,  -10, 	  -6,   -3, 	  -2,   -9
+.2byte    3,   -2, 	   5,   -8, 	  -5,   -3, 	  -1,   -8
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -7, 	   0,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte    5,   -3, 	   1,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    4,   -8, 	  -6,  -11, 	   3,   -4, 	  -2,   -9
+.2byte    5,   -6, 	  -4,  -12, 	   5,   -4, 	  -2,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -13, 	   5,   -9, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	   4,  -11, 	  -5,   -4, 	   0,   -9
+.2byte   -7,   -6, 	   2,  -12, 	  -7,   -4, 	   0,   -7
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte   -7,   -3, 	  -3,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -6,   -5, 	  -5,  -10, 	   4,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,   -8, 	   3,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	  -7,   -7, 	   6,   -7, 	  -1,  -10
+.2byte   -1,   -2, 	  -7,   -7, 	   5,   -7, 	  -1,   -9
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+.2byte    4,   -5, 	   3,  -10, 	  -6,   -3, 	  -2,   -9
+.2byte    3,   -2, 	   5,   -8, 	  -5,   -3, 	  -1,   -8
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -7, 	   0,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte    5,   -3, 	   1,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    4,   -8, 	  -6,  -11, 	   3,   -4, 	  -2,   -9
+.2byte    5,   -6, 	  -4,  -12, 	   5,   -4, 	  -2,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -13, 	   5,   -9, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	   4,  -11, 	  -5,   -4, 	   0,   -9
+.2byte   -7,   -6, 	   2,  -12, 	  -7,   -4, 	   0,   -7
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte   -7,   -3, 	  -3,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -6,   -5, 	  -5,  -10, 	   4,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,   -8, 	   3,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	  -7,   -7, 	   6,   -7, 	  -1,  -10
+.2byte   -1,   -2, 	  -7,   -7, 	   5,   -7, 	  -1,   -9
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+.2byte    4,   -5, 	   3,  -10, 	  -6,   -3, 	  -2,   -9
+.2byte    3,   -2, 	   5,   -8, 	  -5,   -3, 	  -1,   -8
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -7, 	   0,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte    5,   -3, 	   1,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    4,   -8, 	  -6,  -11, 	   3,   -4, 	  -2,   -9
+.2byte    5,   -6, 	  -4,  -12, 	   5,   -4, 	  -2,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -13, 	   5,   -9, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	   4,  -11, 	  -5,   -4, 	   0,   -9
+.2byte   -7,   -6, 	   2,  -12, 	  -7,   -4, 	   0,   -7
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte   -7,   -3, 	  -3,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -6,   -5, 	  -5,  -10, 	   4,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,   -8, 	   3,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	  -6,   -6, 	   5,   -6, 	  -1,   -8
+.2byte   -1,   -3, 	  -7,   -5, 	   5,   -5, 	  -1,   -6
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+.2byte    5,   -8, 	   2,  -10, 	  -5,   -4, 	  -1,   -8
+.2byte    3,   -3, 	   3,   -8, 	  -5,   -2, 	  -1,   -7
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -7, 	  -1,  -13, 	  -1,   -4, 	  -1,   -8
+.2byte    6,   -5, 	   1,  -11, 	   0,   -2, 	  -1,   -8
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    5,  -10, 	  -7,  -12, 	   2,   -6, 	  -2,  -10
+.2byte    5,   -7, 	  -5,  -13, 	   3,   -4, 	  -2,   -9
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -16, 	   5,  -10, 	  -7,  -10, 	  -1,  -10
+.2byte   -1,  -12, 	   5,  -10, 	  -7,  -10, 	  -1,   -9
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -7,  -10, 	   5,  -12, 	  -4,   -6, 	   0,  -10
+.2byte   -7,   -7, 	   3,  -13, 	  -5,   -4, 	   0,   -9
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	  -1,  -13, 	  -1,   -4, 	  -1,   -8
+.2byte   -8,   -5, 	  -3,  -11, 	  -2,   -2, 	  -1,   -8
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -7,   -8, 	  -4,  -10, 	   3,   -4, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,   -8, 	   3,   -2, 	  -1,   -7
+.2byte   -1,   -4, 	  -7,   -5, 	   5,   -5, 	  -1,   -6
+.2byte    1,   -5, 	   3,   -9, 	  -5,   -3, 	  -2,   -7
+.2byte    3,   -6, 	   0,  -11, 	   0,   -4, 	  -1,   -8
+.2byte    4,   -9, 	  -5,  -10, 	   2,   -5, 	  -2,   -9
+.2byte   -1,  -11, 	   5,   -8, 	  -7,   -8, 	  -1,   -8
+.2byte   -6,   -9, 	   3,  -10, 	  -4,   -5, 	   0,   -9
+.2byte   -5,   -6, 	  -2,  -11, 	  -2,   -4, 	  -1,   -8
+.2byte   -3,   -5, 	  -5,   -9, 	   3,   -3, 	   0,   -7
+.2byte   -4,   -4, 	  -5,  -12, 	   6,   -7, 	  -1,   -9
+.2byte   -4,   -3, 	  -5,  -12, 	   5,   -6, 	   0,   -9
+.2byte    0,  -15, 	  -7,  -12, 	   7,  -12, 	   0,  -10
+.2byte    3,  -14, 	   4,  -16, 	  -5,   -8, 	   0,  -11
+.2byte    3,  -18, 	  -1,  -15, 	   0,   -6, 	  -1,  -10
+.2byte    2,  -17, 	  -4,  -12, 	   4,   -7, 	  -1,   -9
+.2byte    0,  -18, 	   6,  -10, 	  -6,  -10, 	   0,  -10
+.2byte   -3,  -17, 	   3,  -12, 	  -5,   -7, 	   0,   -9
+.2byte   -4,  -18, 	   0,  -15, 	  -1,   -6, 	   0,  -10
+.2byte   -4,  -14, 	  -5,  -16, 	   4,   -8, 	  -1,  -11
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	  -7,   -7, 	   6,   -7, 	  -1,  -10
+.2byte   -1,   -2, 	  -7,   -7, 	   5,   -7, 	  -1,   -9
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+.2byte    4,   -5, 	   3,  -10, 	  -6,   -3, 	  -2,   -9
+.2byte    3,   -2, 	   5,   -8, 	  -5,   -3, 	  -1,   -8
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -7, 	   0,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte    5,   -3, 	   1,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    4,   -8, 	  -6,  -11, 	   3,   -4, 	  -2,   -9
+.2byte    5,   -6, 	  -4,  -12, 	   5,   -4, 	  -2,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -13, 	   5,   -9, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	   4,  -11, 	  -5,   -4, 	   0,   -9
+.2byte   -7,   -6, 	   2,  -12, 	  -7,   -4, 	   0,   -7
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte   -7,   -3, 	  -3,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -6,   -5, 	  -5,  -10, 	   4,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,   -8, 	   3,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+.2byte   -1,   -5, 	  -6,   -6, 	   5,   -6, 	  -1,   -8
+.2byte    6,   -8, 	   3,  -10, 	  -4,   -4, 	   0,   -8
+.2byte    6,   -7, 	   0,  -13, 	   0,   -4, 	   0,   -8
+.2byte    6,  -10, 	  -6,  -12, 	   3,   -6, 	  -1,  -10
+.2byte   -1,  -16, 	   5,  -10, 	  -7,  -10, 	  -1,  -10
+.2byte   -8,  -10, 	   4,  -12, 	  -5,   -6, 	  -1,  -10
+.2byte   -7,   -7, 	  -1,  -13, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,   -8, 	  -4,  -10, 	   3,   -4, 	  -1,   -8
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	  -7,   -7, 	   6,   -7, 	  -1,  -10
+.2byte   -1,   -2, 	  -7,   -7, 	   5,   -7, 	  -1,   -9
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+.2byte    4,   -5, 	   3,  -10, 	  -6,   -3, 	  -2,   -9
+.2byte    3,   -2, 	   5,   -8, 	  -5,   -3, 	  -1,   -8
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    5,   -7, 	   0,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte    5,   -3, 	   1,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    4,   -8, 	  -6,  -11, 	   3,   -4, 	  -2,   -9
+.2byte    5,   -6, 	  -4,  -12, 	   5,   -4, 	  -2,   -7
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -1,  -13, 	   5,   -9, 	  -7,   -9, 	  -1,  -10
+.2byte   -1,  -11, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	   4,  -11, 	  -5,   -4, 	   0,   -9
+.2byte   -7,   -6, 	   2,  -12, 	  -7,   -4, 	   0,   -7
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	  -2,  -12, 	  -1,   -3, 	  -1,   -7
+.2byte   -7,   -3, 	  -3,  -11, 	  -1,   -2, 	  -1,   -7
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -6,   -5, 	  -5,  -10, 	   4,   -3, 	   0,   -9
+.2byte   -5,   -2, 	  -7,   -8, 	   3,   -3, 	  -1,   -8
+.2byte   -1,   -2, 	  -7,   -3, 	   5,   -3, 	  -1,   -4
+.2byte   -3,   -3, 	  -5,   -7, 	   3,   -1, 	   0,   -5
+.2byte   -5,   -4, 	  -2,   -9, 	  -2,   -2, 	  -1,   -6
+.2byte   -6,   -7, 	   3,   -8, 	  -4,   -3, 	   0,   -7
+.2byte   -1,   -9, 	   5,   -6, 	  -7,   -6, 	  -1,   -6
+.2byte    4,   -7, 	  -5,   -8, 	   2,   -3, 	  -2,   -7
+.2byte    3,   -4, 	   0,   -9, 	   0,   -2, 	  -1,   -6
+.2byte    2,   -3, 	   4,   -7, 	  -4,   -1, 	  -1,   -5
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -9
+.2byte   -5,   -4, 	  -5,   -9, 	   4,   -5, 	  -1,   -9
+.2byte   -9,   -5, 	  -2,  -12, 	  -1,   -3, 	  -2,   -8
+.2byte   -7,   -7, 	   3,  -11, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -12, 	   5,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    5,   -7, 	  -5,  -11, 	   3,   -5, 	  -1,   -9
+.2byte    7,   -5, 	   0,  -12, 	  -1,   -3, 	   0,   -8
+.2byte    3,   -4, 	   3,   -9, 	  -6,   -5, 	  -1,   -9
+sShellderAnimTable1:
+.4byte sShellderAnims_1_1
+.4byte sShellderAnims_1_2
+.4byte sShellderAnims_1_3
+.4byte sShellderAnims_1_4
+.4byte sShellderAnims_1_5
+.4byte sShellderAnims_1_6
+.4byte sShellderAnims_1_7
+.4byte sShellderAnims_1_8
+sShellderAnimTable2:
+.4byte sShellderAnims_2_1
+.4byte sShellderAnims_2_2
+.4byte sShellderAnims_2_3
+.4byte sShellderAnims_2_4
+.4byte sShellderAnims_2_5
+.4byte sShellderAnims_2_6
+.4byte sShellderAnims_2_7
+.4byte sShellderAnims_2_8
+sShellderAnimTable3:
+.4byte sShellderAnims_3_1
+.4byte sShellderAnims_3_2
+.4byte sShellderAnims_3_3
+.4byte sShellderAnims_3_4
+.4byte sShellderAnims_3_5
+.4byte sShellderAnims_3_6
+.4byte sShellderAnims_3_7
+.4byte sShellderAnims_3_8
+sShellderAnimTable4:
+.4byte sShellderAnims_4_1
+.4byte sShellderAnims_4_2
+.4byte sShellderAnims_4_3
+.4byte sShellderAnims_4_4
+.4byte sShellderAnims_4_5
+.4byte sShellderAnims_4_6
+.4byte sShellderAnims_4_7
+.4byte sShellderAnims_4_8
+sShellderAnimTable5:
+.4byte sShellderAnims_5_1
+.4byte sShellderAnims_5_2
+.4byte sShellderAnims_5_3
+.4byte sShellderAnims_5_4
+.4byte sShellderAnims_5_5
+.4byte sShellderAnims_5_6
+.4byte sShellderAnims_5_7
+.4byte sShellderAnims_5_8
+sShellderAnimTable6:
+.4byte sShellderAnims_6_1
+.4byte sShellderAnims_6_1
+.4byte sShellderAnims_6_1
+.4byte sShellderAnims_6_1
+.4byte sShellderAnims_6_1
+.4byte sShellderAnims_6_1
+.4byte sShellderAnims_6_1
+.4byte sShellderAnims_6_1
+sShellderAnimTable7:
+.4byte sShellderAnims_7_1
+.4byte sShellderAnims_7_2
+.4byte sShellderAnims_7_3
+.4byte sShellderAnims_7_4
+.4byte sShellderAnims_7_5
+.4byte sShellderAnims_7_6
+.4byte sShellderAnims_7_7
+.4byte sShellderAnims_7_8
+sShellderAnimTable8:
+.4byte sShellderAnims_8_1
+.4byte sShellderAnims_8_2
+.4byte sShellderAnims_8_3
+.4byte sShellderAnims_8_4
+.4byte sShellderAnims_8_5
+.4byte sShellderAnims_8_6
+.4byte sShellderAnims_8_7
+.4byte sShellderAnims_8_8
+sShellderAnimTable9:
+.4byte sShellderAnims_9_1
+.4byte sShellderAnims_9_2
+.4byte sShellderAnims_9_3
+.4byte sShellderAnims_9_4
+.4byte sShellderAnims_9_5
+.4byte sShellderAnims_9_6
+.4byte sShellderAnims_9_7
+.4byte sShellderAnims_9_8
+sShellderAnimTable10:
+.4byte sShellderAnims_10_1
+.4byte sShellderAnims_10_2
+.4byte sShellderAnims_10_3
+.4byte sShellderAnims_10_4
+.4byte sShellderAnims_10_5
+.4byte sShellderAnims_10_6
+.4byte sShellderAnims_10_7
+.4byte sShellderAnims_10_8
+sShellderAnimTable11:
+.4byte sShellderAnims_11_1
+.4byte sShellderAnims_11_2
+.4byte sShellderAnims_11_3
+.4byte sShellderAnims_11_4
+.4byte sShellderAnims_11_5
+.4byte sShellderAnims_11_6
+.4byte sShellderAnims_11_7
+.4byte sShellderAnims_11_8
+sShellderAnimTable12:
+.4byte sShellderAnims_12_1
+.4byte sShellderAnims_12_2
+.4byte sShellderAnims_12_3
+.4byte sShellderAnims_12_4
+.4byte sShellderAnims_12_5
+.4byte sShellderAnims_12_6
+.4byte sShellderAnims_12_7
+.4byte sShellderAnims_12_8
+sShellderAnimTable13:
+.4byte sShellderAnims_13_1
+.4byte sShellderAnims_13_2
+.4byte sShellderAnims_13_3
+.4byte sShellderAnims_13_4
+.4byte sShellderAnims_13_5
+.4byte sShellderAnims_13_6
+.4byte sShellderAnims_13_7
+.4byte sShellderAnims_13_8
+sAxAnimationsShellder:
+.4byte sShellderAnimTable1
+.4byte sShellderAnimTable2
+.4byte sShellderAnimTable3
+.4byte sShellderAnimTable4
+.4byte sShellderAnimTable5
+.4byte sShellderAnimTable6
+.4byte sShellderAnimTable7
+.4byte sShellderAnimTable8
+.4byte sShellderAnimTable9
+.4byte sShellderAnimTable10
+.4byte sShellderAnimTable11
+.4byte sShellderAnimTable12
+.4byte sShellderAnimTable13
+sAxSpritesShellder:
+.4byte sShellderSprites1
+.4byte sShellderSprites2
+.4byte sShellderSprites3
+.4byte sShellderSprites4
+.4byte sShellderSprites5
+.4byte sShellderSprites6
+.4byte sShellderSprites7
+.4byte sShellderSprites8
+.4byte sShellderSprites9
+.4byte sShellderSprites10
+.4byte sShellderSprites11
+.4byte sShellderSprites12
+.4byte sShellderSprites13
+.4byte sShellderSprites14
+.4byte sShellderSprites15
+.4byte sShellderSprites16
+.4byte sShellderSprites17
+.4byte sShellderSprites18
+.4byte sShellderSprites19
+.4byte sShellderSprites20
+.4byte sShellderSprites21
+.4byte sShellderSprites22
+.4byte sShellderSprites23
+.4byte sShellderSprites24
+.4byte sShellderSprites25
+.4byte sShellderSprites26
+.4byte sShellderSprites27
+.4byte sShellderSprites28
+.4byte sShellderSprites29
+.4byte sShellderSprites30
+.4byte sShellderSprites31
+.4byte sShellderSprites32
+.4byte sShellderSprites33
+.4byte sShellderSprites34
+.4byte sShellderSprites35
+.4byte sShellderSprites36
+.4byte sShellderSprites37
+sAxMainShellder:
+ax_main sAxPosesShellder, sAxAnimationsShellder, 13, sAxSpritesShellder, sAxPositionsShellder

--- a/data/ax/shiftry.inc
+++ b/data/ax/shiftry.inc
@@ -1,0 +1,3242 @@
+.global gAxShiftry
+gAxShiftry:
+ax_siro sAxMainShiftry
+sShiftryPose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose4:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose5:
+ax_pose 4, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose6:
+ax_pose 5, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose7:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose8:
+ax_pose 7, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose9:
+ax_pose 8, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose10:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose11:
+ax_pose 10, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose12:
+ax_pose 11, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose14:
+ax_pose 13, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose15:
+ax_pose 14, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose19:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose25:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose28:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose29:
+ax_pose 4, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose30:
+ax_pose 5, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose31:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose32:
+ax_pose 7, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose33:
+ax_pose 8, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose34:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose35:
+ax_pose 10, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose36:
+ax_pose 11, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose37:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose38:
+ax_pose 13, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose39:
+ax_pose 14, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose40:
+ax_pose 9, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose41:
+ax_pose 10, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose42:
+ax_pose 11, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose43:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose44:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose45:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose46:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose47:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose48:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose49:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose52:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose53:
+ax_pose 4, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose54:
+ax_pose 5, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose55:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose56:
+ax_pose 7, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose57:
+ax_pose 8, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose58:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose59:
+ax_pose 10, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose60:
+ax_pose 11, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose61:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose62:
+ax_pose 13, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose63:
+ax_pose 14, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose64:
+ax_pose 9, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose65:
+ax_pose 10, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose66:
+ax_pose 11, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose67:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose68:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose69:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose70:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose71:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose72:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose73:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose74:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose75:
+ax_pose 2, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose76:
+ax_pose 15, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose77:
+ax_pose 16, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose78:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose79:
+ax_pose 4, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose80:
+ax_pose 5, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose81:
+ax_pose 17, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose82:
+ax_pose 18, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose83:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose84:
+ax_pose 7, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose85:
+ax_pose 8, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose86:
+ax_pose 19, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose87:
+ax_pose 20, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose88:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose89:
+ax_pose 10, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose90:
+ax_pose 11, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose91:
+ax_pose 21, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose92:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose93:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose94:
+ax_pose 13, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose95:
+ax_pose 14, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose96:
+ax_pose 23, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose97:
+ax_pose 24, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose98:
+ax_pose 9, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose99:
+ax_pose 10, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose100:
+ax_pose 11, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose101:
+ax_pose 21, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose102:
+ax_pose 22, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose103:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose104:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose105:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose106:
+ax_pose 19, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose107:
+ax_pose 20, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose108:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose109:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose110:
+ax_pose 5, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose111:
+ax_pose 17, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose112:
+ax_pose 18, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose113:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose114:
+ax_pose 25, 0x01e6, 0x80ef, 0x8c00
+ax_pose 26, 0x01e6, 0x80ef, 0x8c10
+ax_pose_terminator
+sShiftryPose115:
+ax_pose 26, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose116:
+ax_pose 25, 0x01e6, 0x90f1, 0x8c00
+ax_pose 27, 0x01e6, 0x80ef, 0x8c10
+ax_pose_terminator
+sShiftryPose117:
+ax_pose 27, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose118:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose119:
+ax_pose 28, 0x81e6, 0x9100, 0x8c00
+ax_pose 29, 0x01e6, 0x90ef, 0x8c08
+ax_pose_terminator
+sShiftryPose120:
+ax_pose 29, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose121:
+ax_pose 30, 0x01e6, 0x90ef, 0x8c00
+ax_pose 31, 0x01e6, 0x90ef, 0x8c10
+ax_pose_terminator
+sShiftryPose122:
+ax_pose 31, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose123:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose124:
+ax_pose 32, 0x01e6, 0x90f3, 0x8c00
+ax_pose 33, 0x01e6, 0x90ef, 0x8c10
+ax_pose_terminator
+sShiftryPose125:
+ax_pose 33, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose126:
+ax_pose 34, 0x01e6, 0x90f6, 0x8c00
+ax_pose 35, 0x01e6, 0x90ef, 0x8c10
+ax_pose_terminator
+sShiftryPose127:
+ax_pose 35, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose128:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose129:
+ax_pose 36, 0x01e6, 0x90ef, 0x8c00
+ax_pose 37, 0x01e3, 0x90ed, 0x8c10
+ax_pose_terminator
+sShiftryPose130:
+ax_pose 36, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose131:
+ax_pose 38, 0x01e6, 0x90ef, 0x8c00
+ax_pose 39, 0x81e6, 0x9103, 0x8c10
+ax_pose_terminator
+sShiftryPose132:
+ax_pose 38, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose133:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose134:
+ax_pose 40, 0x01e6, 0x80f0, 0x8c00
+ax_pose 41, 0x01e2, 0x80f4, 0x8c10
+ax_pose_terminator
+sShiftryPose135:
+ax_pose 40, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose136:
+ax_pose 42, 0x01e6, 0x80f0, 0x8c00
+ax_pose 41, 0x01e2, 0x90ec, 0x8c10
+ax_pose_terminator
+sShiftryPose137:
+ax_pose 42, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose138:
+ax_pose 9, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose139:
+ax_pose 36, 0x01e6, 0x80f1, 0x8c00
+ax_pose 37, 0x01e3, 0x80f3, 0x8c10
+ax_pose_terminator
+sShiftryPose140:
+ax_pose 36, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose141:
+ax_pose 38, 0x01e6, 0x80f1, 0x8c00
+ax_pose 39, 0x81e6, 0x80ed, 0x8c10
+ax_pose_terminator
+sShiftryPose142:
+ax_pose 38, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose143:
+ax_pose 6, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose144:
+ax_pose 32, 0x01e6, 0x80ed, 0x8c00
+ax_pose 33, 0x01e6, 0x80f1, 0x8c10
+ax_pose_terminator
+sShiftryPose145:
+ax_pose 33, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose146:
+ax_pose 34, 0x01e6, 0x80ea, 0x8c00
+ax_pose 35, 0x01e6, 0x80f1, 0x8c10
+ax_pose_terminator
+sShiftryPose147:
+ax_pose 35, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose148:
+ax_pose 3, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose149:
+ax_pose 28, 0x81e6, 0x80f0, 0x8c00
+ax_pose 29, 0x01e6, 0x80f1, 0x8c08
+ax_pose_terminator
+sShiftryPose150:
+ax_pose 29, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose151:
+ax_pose 30, 0x01e6, 0x80f1, 0x8c00
+ax_pose 31, 0x01e6, 0x80f1, 0x8c10
+ax_pose_terminator
+sShiftryPose152:
+ax_pose 31, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose153:
+ax_pose 43, 0x01e7, 0x80f3, 0x8c00
+ax_pose_terminator
+sShiftryPose154:
+ax_pose 44, 0x01e7, 0x80f3, 0x8c00
+ax_pose_terminator
+sShiftryPose155:
+ax_pose 45, 0x81e3, 0x80fd, 0x8c00
+ax_pose 46, 0x81eb, 0x00ed, 0x8c08
+ax_pose 47, 0x81eb, 0x010d, 0x8c0a
+ax_pose 48, 0x81e3, 0x40f5, 0x8c0c
+ax_pose_terminator
+sShiftryPose156:
+ax_pose 49, 0x01e3, 0x90ed, 0x8c00
+ax_pose_terminator
+sShiftryPose157:
+ax_pose 50, 0x01e0, 0x90ec, 0x8c00
+ax_pose_terminator
+sShiftryPose158:
+ax_pose 51, 0x41f1, 0x90ed, 0x8c00
+ax_pose 52, 0x01f1, 0x10e5, 0x8c08
+ax_pose 53, 0x01e9, 0x10e5, 0x8c09
+ax_pose 54, 0x41e9, 0x10fd, 0x8c0a
+ax_pose 55, 0x01e1, 0x50ed, 0x8c0c
+ax_pose_terminator
+sShiftryPose159:
+ax_pose 56, 0x81e2, 0x40f4, 0x8c00
+ax_pose 57, 0x81ea, 0x010c, 0x8c04
+ax_pose 58, 0x81ea, 0x00ec, 0x8c06
+ax_pose 59, 0x81e2, 0x80fc, 0x8c08
+ax_pose_terminator
+sShiftryPose160:
+ax_pose 51, 0x41f1, 0x80f3, 0x8c00
+ax_pose 52, 0x01f1, 0x0113, 0x8c08
+ax_pose 53, 0x01e9, 0x0113, 0x8c09
+ax_pose 54, 0x41e9, 0x00f3, 0x8c0a
+ax_pose 55, 0x01e1, 0x4103, 0x8c0c
+ax_pose_terminator
+sShiftryPose161:
+ax_pose 50, 0x01e0, 0x80f4, 0x8c00
+ax_pose_terminator
+sShiftryPose162:
+ax_pose 49, 0x01e3, 0x80f3, 0x8c00
+ax_pose_terminator
+sShiftryPose163:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose164:
+ax_pose 26, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose165:
+ax_pose 27, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose166:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose167:
+ax_pose 29, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose168:
+ax_pose 31, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose169:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose170:
+ax_pose 33, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose171:
+ax_pose 35, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose172:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose173:
+ax_pose 36, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose174:
+ax_pose 38, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose175:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose176:
+ax_pose 40, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose177:
+ax_pose 42, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose178:
+ax_pose 9, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose179:
+ax_pose 36, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose180:
+ax_pose 38, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose181:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose182:
+ax_pose 33, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose183:
+ax_pose 35, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose184:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose185:
+ax_pose 29, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose186:
+ax_pose 31, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose187:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose188:
+ax_pose 4, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sShiftryPose189:
+ax_pose 7, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sShiftryPose190:
+ax_pose 10, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sShiftryPose191:
+ax_pose 13, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose192:
+ax_pose 10, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sShiftryPose193:
+ax_pose 7, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sShiftryPose194:
+ax_pose 4, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sShiftryPose195:
+ax_pose 16, 0x01e2, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose196:
+ax_pose 18, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sShiftryPose197:
+ax_pose 20, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sShiftryPose198:
+ax_pose 22, 0x01e4, 0x90ee, 0x8c00
+ax_pose_terminator
+sShiftryPose199:
+ax_pose 24, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose200:
+ax_pose 22, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose201:
+ax_pose 20, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sShiftryPose202:
+ax_pose 18, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose203:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose204:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose205:
+ax_pose 15, 0x01e4, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose206:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose207:
+ax_pose 4, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose208:
+ax_pose 17, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose209:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose210:
+ax_pose 7, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose211:
+ax_pose 19, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose212:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose213:
+ax_pose 10, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose214:
+ax_pose 21, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose215:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose216:
+ax_pose 13, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose217:
+ax_pose 23, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose218:
+ax_pose 9, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose219:
+ax_pose 10, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose220:
+ax_pose 21, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose221:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose222:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose223:
+ax_pose 19, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose224:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose225:
+ax_pose 4, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose226:
+ax_pose 17, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose227:
+ax_pose 27, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sShiftryPose228:
+ax_pose 31, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sShiftryPose229:
+ax_pose 35, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sShiftryPose230:
+ax_pose 38, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sShiftryPose231:
+ax_pose 42, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose232:
+ax_pose 38, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sShiftryPose233:
+ax_pose 35, 0x01e6, 0x90ed, 0x8c00
+ax_pose_terminator
+sShiftryPose234:
+ax_pose 31, 0x01e6, 0x90ee, 0x8c00
+ax_pose_terminator
+sShiftryPose235:
+ax_pose 0, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose236:
+ax_pose 3, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose237:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose238:
+ax_pose 9, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose239:
+ax_pose 12, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose240:
+ax_pose 9, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose241:
+ax_pose 6, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose242:
+ax_pose 3, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sShiftryPose243:
+ax_pose 60, 0x41f0, 0x80f0, 0x8c00
+ax_pose 61, 0x4200, 0x40f0, 0x8c08
+ax_pose 62, 0x0208, 0x00fe, 0x8c0c
+ax_pose 63, 0x0200, 0x0110, 0x8c0d
+ax_pose_terminator
+sShiftryPose244:
+ax_pose 64, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose245:
+ax_pose 65, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sShiftryPose246:
+ax_pose 66, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+.align 2
+sShiftryAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 1,
+ax_anim 4, 0, 1, 0, -2, 0, 2,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 1,
+ax_anim 4, 0, 2, 0, -2, 0, 2,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 1, 0, 1, 1,
+ax_anim 4, 0, 4, 2, -1, 2, 2,
+ax_anim 4, 0, 4, 2, 0, 1, 1,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 1, 0, 1, 1,
+ax_anim 4, 0, 5, 2, -1, 2, 2,
+ax_anim 4, 0, 5, 2, 0, 1, 1,
+ax_anim_terminator
+sShiftryAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 1, -1, 1, 0,
+ax_anim 4, 0, 7, 2, -2, 2, 0,
+ax_anim 4, 0, 7, 2, 0, 2, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 1, -1, 1, 0,
+ax_anim 4, 0, 8, 2, -2, 2, 0,
+ax_anim 4, 0, 8, 2, 0, 2, 0,
+ax_anim_terminator
+sShiftryAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 1, -2, 1, -2,
+ax_anim 4, 0, 10, 2, -3, 2, -3,
+ax_anim 4, 0, 10, 2, -1, 2, -1,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 1, -2, 1, -2,
+ax_anim 4, 0, 11, 2, -3, 2, -3,
+ax_anim 4, 0, 11, 2, -1, 2, -1,
+ax_anim_terminator
+sShiftryAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, -2,
+ax_anim 4, 0, 13, 0, -3, 0, -3,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, -2,
+ax_anim 4, 0, 14, 0, -3, 0, -3,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, -1, -2, -1, -2,
+ax_anim 4, 0, 16, -2, -3, -2, -3,
+ax_anim 4, 0, 16, -2, -1, -2, -1,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 17, -1, -2, -1, -2,
+ax_anim 4, 0, 17, -2, -3, -2, -3,
+ax_anim 4, 0, 17, -2, -1, -2, -1,
+ax_anim_terminator
+sShiftryAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -1, -1, -1, 0,
+ax_anim 4, 0, 19, -2, -2, -2, 0,
+ax_anim 4, 0, 19, -2, 0, -2, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 20, -1, -1, -1, 0,
+ax_anim 4, 0, 20, -2, -2, -2, 0,
+ax_anim 4, 0, 20, -2, 0, -2, 0,
+ax_anim_terminator
+sShiftryAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -1, 0, -1, 1,
+ax_anim 4, 0, 22, -2, -1, -2, 2,
+ax_anim 4, 0, 22, -2, 0, -1, 1,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 23, -1, 0, -1, 1,
+ax_anim 4, 0, 23, -2, -1, -2, 2,
+ax_anim 4, 0, 23, -2, 0, -1, 1,
+ax_anim_terminator
+.align 2
+sShiftryAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 2,
+ax_anim 1, 2, 26, 0, 4, 0, 8,
+ax_anim 1, 0, 26, 0, 10, 0, 14,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 1, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 0, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sShiftryAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -2, 0, 0,
+ax_anim 1, 2, 29, 4, -1, 4, 4,
+ax_anim 1, 0, 29, 10, 5, 10, 10,
+ax_anim 2, 0, 29, 17, 20, 17, 18,
+ax_anim 2, 1, 29, 18, 19, 18, 17,
+ax_anim 2, 0, 29, 17, 20, 17, 18,
+ax_anim 2, 0, 29, 18, 19, 18, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sShiftryAnims_2_3:
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 4, 0, 31, -3, 0, -3, 0,
+ax_anim 1, 0, 32, 0, -3, 0, 0,
+ax_anim 1, 2, 32, 4, -5, 4, 0,
+ax_anim 1, 0, 32, 10, -3, 10, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sShiftryAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 4, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -3, 0, -1,
+ax_anim 1, 2, 35, 4, -11, 4, -5,
+ax_anim 1, 0, 35, 11, -18, 11, -13,
+ax_anim 2, 0, 35, 18, -21, 18, -21,
+ax_anim 2, 1, 35, 19, -20, 19, -20,
+ax_anim 2, 0, 35, 18, -21, 18, -21,
+ax_anim 2, 0, 35, 19, -20, 19, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sShiftryAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -2,
+ax_anim 1, 0, 38, 0, -11, 0, -7,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 1, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 38, 0, -19, 0, -19,
+ax_anim 2, 0, 38, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sShiftryAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -3, 0, -1,
+ax_anim 1, 2, 40, -4, -11, -4, -5,
+ax_anim 1, 0, 41, -11, -18, -11, -13,
+ax_anim 2, 0, 40, -18, -21, -18, -23,
+ax_anim 2, 1, 40, -19, -20, -19, -22,
+ax_anim 2, 0, 40, -18, -21, -18, -23,
+ax_anim 2, 0, 40, -19, -20, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sShiftryAnims_2_7:
+ax_anim 2, 0, 42, 2, 0, 2, 0,
+ax_anim 4, 0, 42, 3, 0, 3, 0,
+ax_anim 1, 0, 44, 0, -3, 0, 0,
+ax_anim 1, 2, 43, -4, -5, -4, 0,
+ax_anim 1, 0, 44, -10, -3, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sShiftryAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 4, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, -2, 0, 0,
+ax_anim 1, 2, 47, -4, 1, -4, 4,
+ax_anim 1, 0, 47, -10, 5, -10, 10,
+ax_anim 2, 0, 47, -17, 20, -17, 18,
+ax_anim 2, 1, 47, -18, 19, -18, 17,
+ax_anim 2, 0, 47, -17, 20, -17, 18,
+ax_anim 2, 0, 47, -18, 19, -18, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sShiftryAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 2,
+ax_anim 1, 2, 50, 0, 12, 0, 16,
+ax_anim 1, 0, 50, 0, 26, 0, 30,
+ax_anim 2, 0, 50, 0, 45, 0, 45,
+ax_anim 2, 1, 50, 1, 45, 1, 45,
+ax_anim 2, 0, 50, 0, 45, 0, 45,
+ax_anim 2, 0, 50, 1, 45, 1, 45,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sShiftryAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 2, 53, 12, 7, 12, 12,
+ax_anim 1, 0, 53, 26, 21, 26, 26,
+ax_anim 2, 0, 53, 41, 44, 41, 42,
+ax_anim 2, 1, 53, 42, 43, 42, 41,
+ax_anim 2, 0, 53, 41, 44, 41, 42,
+ax_anim 2, 0, 53, 42, 43, 42, 41,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sShiftryAnims_3_3:
+ax_anim 2, 0, 55, -2, 0, -2, 0,
+ax_anim 4, 0, 55, -3, 0, -3, 0,
+ax_anim 1, 0, 56, 0, -3, 0, 0,
+ax_anim 1, 2, 56, 12, -5, 12, 0,
+ax_anim 1, 0, 56, 26, -3, 26, 0,
+ax_anim 2, 0, 56, 42, 0, 42, 0,
+ax_anim 2, 1, 56, 42, 1, 42, 1,
+ax_anim 2, 0, 56, 42, 0, 42, 0,
+ax_anim 2, 0, 56, 42, 1, 42, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sShiftryAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 4, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -3, 0, -1,
+ax_anim 1, 2, 59, 12, -19, 12, -13,
+ax_anim 1, 0, 59, 27, -34, 27, -29,
+ax_anim 2, 0, 59, 42, -45, 42, -45,
+ax_anim 2, 1, 59, 43, -44, 43, -44,
+ax_anim 2, 0, 59, 42, -45, 42, -45,
+ax_anim 2, 0, 59, 43, -44, 43, -44,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sShiftryAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -12, 0, -10,
+ax_anim 1, 0, 62, 0, -27, 0, -23,
+ax_anim 2, 0, 62, 0, -43, 0, -43,
+ax_anim 2, 1, 62, 1, -43, 1, -43,
+ax_anim 2, 0, 62, 0, -43, 0, -43,
+ax_anim 2, 0, 62, 1, -43, 1, -43,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sShiftryAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -3, 0, -1,
+ax_anim 1, 2, 64, -12, -19, -12, -13,
+ax_anim 1, 0, 65, -27, -34, -27, -29,
+ax_anim 2, 0, 64, -42, -45, -42, -47,
+ax_anim 2, 1, 64, -43, -44, -43, -46,
+ax_anim 2, 0, 64, -42, -45, -42, -47,
+ax_anim 2, 0, 64, -43, -44, -43, -46,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sShiftryAnims_3_7:
+ax_anim 2, 0, 66, 2, 0, 2, 0,
+ax_anim 4, 0, 66, 3, 0, 3, 0,
+ax_anim 1, 0, 68, 0, -3, 0, 0,
+ax_anim 1, 2, 67, -12, -5, -12, 0,
+ax_anim 1, 0, 68, -26, -3, -26, 0,
+ax_anim 2, 0, 67, -42, 0, -42, 0,
+ax_anim 2, 1, 67, -42, 1, -42, 1,
+ax_anim 2, 0, 67, -42, 0, -42, 0,
+ax_anim 2, 0, 67, -42, 1, -42, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sShiftryAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 4, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, -2, 0, 0,
+ax_anim 1, 2, 71, -12, 9, -12, 12,
+ax_anim 1, 0, 71, -26, 21, -26, 26,
+ax_anim 2, 0, 71, -41, 44, -41, 42,
+ax_anim 2, 1, 71, -42, 43, -42, 41,
+ax_anim 2, 0, 71, -41, 44, -41, 42,
+ax_anim 2, 0, 71, -42, 43, -42, 41,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sShiftryAnims_4_1:
+ax_anim 1, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 4, 0, 73, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 1, 0, 74, 0, -1, 0, 0,
+ax_anim 4, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_4_2:
+ax_anim 1, 0, 78, 0, -1, 0, 0,
+ax_anim 2, 0, 78, 0, -3, 0, 0,
+ax_anim 4, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 1, 0, 79, 0, -1, 0, 0,
+ax_anim 4, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_4_3:
+ax_anim 1, 0, 83, 0, -1, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 4, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 1, 0, 84, 0, -1, 0, 0,
+ax_anim 4, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_4_4:
+ax_anim 1, 0, 88, 0, -1, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 4, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 1, 0, 89, 0, -1, 0, 0,
+ax_anim 4, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_4_5:
+ax_anim 1, 0, 93, 0, -1, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 4, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 1, 0, 94, 0, -1, 0, 0,
+ax_anim 4, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_4_6:
+ax_anim 1, 0, 98, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 0, -3, 0, 0,
+ax_anim 4, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 1, 0, 99, 0, -1, 0, 0,
+ax_anim 4, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 1, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_4_7:
+ax_anim 1, 0, 103, 0, -1, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 4, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 104, 0, -1, 0, 0,
+ax_anim 4, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_4_8:
+ax_anim 1, 0, 108, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 4, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 1, 0, 109, 0, -1, 0, 0,
+ax_anim 4, 2, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_5_1:
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim 4, 0, 112, 0, -3, 0, -3,
+ax_anim 1, 0, 113, 0, 2, 0, 2,
+ax_anim 2, 0, 113, 0, 5, 0, 5,
+ax_anim 4, 2, 114, 0, 6, 0, 6,
+ax_anim 1, 0, 112, 0, 4, 0, 4,
+ax_anim 1, 0, 112, 0, 2, 0, 2,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 2, 0, 2,
+ax_anim 2, 0, 115, 0, 5, 0, 5,
+ax_anim 4, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 1, 112, 0, 2, 0, 2,
+ax_anim_terminator
+sShiftryAnims_5_2:
+ax_anim 2, 0, 117, -2, -2, -2, -2,
+ax_anim 4, 0, 117, -3, -3, -3, -3,
+ax_anim 1, 0, 118, 2, 2, 2, 2,
+ax_anim 2, 0, 118, 5, 5, 5, 5,
+ax_anim 4, 2, 119, 6, 6, 6, 6,
+ax_anim 1, 0, 117, 4, 4, 4, 4,
+ax_anim 1, 0, 117, 2, 2, 2, 2,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 2, 0, 120, 5, 5, 5, 5,
+ax_anim 4, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 1, 117, 2, 2, 2, 2,
+ax_anim_terminator
+sShiftryAnims_5_3:
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim 4, 0, 122, -3, 0, -3, 0,
+ax_anim 1, 0, 123, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 5, 0, 5, 0,
+ax_anim 4, 2, 124, 6, 0, 6, 0,
+ax_anim 1, 0, 122, 4, 0, 4, 0,
+ax_anim 1, 0, 122, 2, 0, 2, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 2, 0, 2, 0,
+ax_anim 2, 0, 125, 5, 0, 5, 0,
+ax_anim 4, 0, 126, 6, 0, 6, 0,
+ax_anim 2, 1, 122, 2, 0, 2, 0,
+ax_anim_terminator
+sShiftryAnims_5_4:
+ax_anim 2, 0, 127, -2, 2, -2, 2,
+ax_anim 4, 0, 127, -3, 3, -3, 3,
+ax_anim 1, 0, 128, 2, -2, 2, -2,
+ax_anim 2, 0, 128, 5, -5, 5, -5,
+ax_anim 4, 2, 129, 6, -6, 6, -6,
+ax_anim 1, 0, 127, 4, -4, 4, -4,
+ax_anim 1, 0, 127, 2, -2, 2, -2,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 2, -2, 2, -2,
+ax_anim 2, 0, 130, 5, -5, 5, -5,
+ax_anim 4, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 1, 127, 2, -2, 2, -2,
+ax_anim_terminator
+sShiftryAnims_5_5:
+ax_anim 2, 0, 132, 0, 2, 0, 2,
+ax_anim 4, 0, 132, 0, 3, 0, 3,
+ax_anim 1, 0, 133, 0, -2, 0, -2,
+ax_anim 2, 0, 133, 0, -5, 0, -5,
+ax_anim 4, 2, 134, 0, -6, 0, -6,
+ax_anim 1, 0, 132, 0, -4, 0, -4,
+ax_anim 1, 0, 132, 0, -2, 0, -2,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, -2,
+ax_anim 2, 0, 135, 0, -5, 0, -5,
+ax_anim 4, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 1, 132, 0, -2, 0, -2,
+ax_anim_terminator
+sShiftryAnims_5_6:
+ax_anim 2, 0, 137, 2, 2, 2, 2,
+ax_anim 4, 0, 137, 3, 3, 3, 3,
+ax_anim 1, 0, 138, -2, -2, -2, -2,
+ax_anim 2, 0, 138, -5, -5, -5, -5,
+ax_anim 4, 2, 139, -6, -6, -6, -6,
+ax_anim 1, 0, 137, -4, -4, -4, -4,
+ax_anim 1, 0, 137, -2, -2, -2, -2,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -2, -2, -2, -2,
+ax_anim 2, 0, 140, -5, -5, -5, -5,
+ax_anim 4, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 1, 137, -2, -2, -2, -2,
+ax_anim_terminator
+sShiftryAnims_5_7:
+ax_anim 2, 0, 142, 2, 0, 2, 0,
+ax_anim 4, 0, 142, 3, 0, 3, 0,
+ax_anim 1, 0, 143, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -5, 0, -5, 0,
+ax_anim 4, 2, 144, -6, 0, -6, 0,
+ax_anim 1, 0, 142, -4, 0, -4, 0,
+ax_anim 1, 0, 142, -2, 0, -2, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -2, 0, -2, 0,
+ax_anim 2, 0, 145, -5, 0, -5, 0,
+ax_anim 4, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 1, 142, -2, 0, -2, 0,
+ax_anim_terminator
+sShiftryAnims_5_8:
+ax_anim 2, 0, 147, 2, -2, 2, -2,
+ax_anim 4, 0, 147, 3, -3, 3, -3,
+ax_anim 1, 0, 148, -2, 2, -2, 2,
+ax_anim 2, 0, 148, -5, 5, -5, 5,
+ax_anim 4, 2, 149, -6, 6, -6, 6,
+ax_anim 1, 0, 147, -4, 4, -4, 4,
+ax_anim 1, 0, 147, -2, 2, -2, 2,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -2, 2, -2, 2,
+ax_anim 2, 0, 150, -5, 5, -5, 5,
+ax_anim 4, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 1, 147, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sShiftryAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sShiftryAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sShiftryAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sShiftryAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sShiftryAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sShiftryAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sShiftryAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sShiftryAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sShiftryAnims_8_1:
+ax_anim 24, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 163, 0, -3, 0, 0,
+ax_anim 4, 0, 163, 0, -4, 0, 0,
+ax_anim 4, 0, 163, 0, -3, 0, 0,
+ax_anim 24, 0, 162, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim 4, 0, 164, 0, -4, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim_terminator
+sShiftryAnims_8_2:
+ax_anim 24, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 166, 0, -3, 0, 0,
+ax_anim 4, 0, 166, 0, -4, 0, 0,
+ax_anim 4, 0, 166, 0, -3, 0, 0,
+ax_anim 24, 0, 165, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 4, 0, 167, 0, -4, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim_terminator
+sShiftryAnims_8_3:
+ax_anim 24, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 169, 0, -3, 0, 0,
+ax_anim 4, 0, 169, 0, -4, 0, 0,
+ax_anim 4, 0, 169, 0, -3, 0, 0,
+ax_anim 24, 0, 168, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -3, 0, 0,
+ax_anim 4, 0, 170, 0, -4, 0, 0,
+ax_anim 4, 0, 170, 0, -3, 0, 0,
+ax_anim_terminator
+sShiftryAnims_8_4:
+ax_anim 24, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, -3, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim 4, 0, 172, 0, -3, 0, 0,
+ax_anim 24, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -3, 0, 0,
+ax_anim 4, 0, 173, 0, -4, 0, 0,
+ax_anim 4, 0, 173, 0, -3, 0, 0,
+ax_anim_terminator
+sShiftryAnims_8_5:
+ax_anim 24, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, -3, 0, 0,
+ax_anim 4, 0, 175, 0, -4, 0, 0,
+ax_anim 4, 0, 175, 0, -3, 0, 0,
+ax_anim 24, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 4, 0, 176, 0, -4, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim_terminator
+sShiftryAnims_8_6:
+ax_anim 24, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, -3, 0, 0,
+ax_anim 4, 0, 178, 0, -4, 0, 0,
+ax_anim 4, 0, 178, 0, -3, 0, 0,
+ax_anim 24, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 0, -3, 0, 0,
+ax_anim 4, 0, 179, 0, -4, 0, 0,
+ax_anim 4, 0, 179, 0, -3, 0, 0,
+ax_anim_terminator
+sShiftryAnims_8_7:
+ax_anim 24, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, -3, 0, 0,
+ax_anim 4, 0, 181, 0, -4, 0, 0,
+ax_anim 4, 0, 181, 0, -3, 0, 0,
+ax_anim 24, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, -3, 0, 0,
+ax_anim 4, 0, 182, 0, -4, 0, 0,
+ax_anim 4, 0, 182, 0, -3, 0, 0,
+ax_anim_terminator
+sShiftryAnims_8_8:
+ax_anim 24, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, -3, 0, 0,
+ax_anim 4, 0, 184, 0, -4, 0, 0,
+ax_anim 4, 0, 184, 0, -3, 0, 0,
+ax_anim 24, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, -3, 0, 0,
+ax_anim 4, 0, 185, 0, -4, 0, 0,
+ax_anim 4, 0, 185, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 4, 6, 4,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 19, 7, 19,
+ax_anim 3, 0, 190, 0, 24, 0, 24,
+ax_anim 2, 3, 191, -7, 19, -7, 19,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 4, -6, 4,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 187, 17, 3, 17, 3,
+ax_anim 2, 0, 188, 24, 9, 24, 9,
+ax_anim 3, 0, 189, 23, 21, 23, 21,
+ax_anim 2, 3, 190, 11, 21, 11, 21,
+ax_anim 2, 0, 191, 2, 12, 2, 12,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -4, 3, -4,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 17, -4, 17, -4,
+ax_anim 3, 0, 188, 20, 1, 20, 1,
+ax_anim 2, 3, 189, 17, 5, 17, 5,
+ax_anim 2, 0, 190, 12, 7, 12, 7,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -6, -1, -6,
+ax_anim 2, 0, 193, 2, -16, 2, -16,
+ax_anim 2, 0, 186, 10, -21, 10, -21,
+ax_anim 3, 0, 187, 16, -20, 16, -20,
+ax_anim 2, 3, 188, 18, -12, 18, -12,
+ax_anim 2, 0, 189, 16, -6, 16, -6,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -6, -4, -6, -4,
+ax_anim 2, 0, 192, -8, -10, -8, -10,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -20, 0, -20,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 8, -8, 8, -8,
+ax_anim 1, 0, 189, 6, -4, 6, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -6, 1, -6,
+ax_anim 2, 0, 187, -2, -16, -2, -16,
+ax_anim 2, 0, 186, -10, -21, -10, -21,
+ax_anim 3, 0, 193, -16, -20, -16, -20,
+ax_anim 2, 3, 192, -18, -12, -18, -12,
+ax_anim 2, 0, 191, -16, -6, -16, -6,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -4, -3, -4,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -17, -4, -17, -4,
+ax_anim 3, 0, 192, -20, 1, -20, 1,
+ax_anim 2, 3, 191, -17, 5, -17, 5,
+ax_anim 2, 0, 190, -12, 7, -12, 7,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -24, 9, -24, 9,
+ax_anim 3, 0, 191, -23, 21, -23, 16,
+ax_anim 2, 3, 190, -11, 21, -11, 16,
+ax_anim 2, 0, 189, -2, 12, -4, 12,
+ax_anim 1, 0, 188, 0, 7, -3, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, 0,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_14_1:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_14_2:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_14_3:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_14_4:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_14_5:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_14_6:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_14_7:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_14_8:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShiftryAnims_15_1:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_15_2:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_15_3:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_15_4:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_15_5:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_15_6:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_15_7:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryAnims_15_8:
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sShiftryGfx1:
+.incbin "baserom.gba", 0x113D9CC, 0x200
+sShiftrySprites1:
+ax_sprite sShiftryGfx1, 0x200
+ax_sprite_terminator
+sShiftryGfx2:
+.incbin "baserom.gba", 0x113DBDC, 0x200
+sShiftrySprites2:
+ax_sprite sShiftryGfx2, 0x200
+ax_sprite_terminator
+sShiftryGfx3:
+.incbin "baserom.gba", 0x113DDEC, 0x200
+sShiftrySprites3:
+ax_sprite sShiftryGfx3, 0x200
+ax_sprite_terminator
+sShiftryGfx4:
+.incbin "baserom.gba", 0x113DFFC, 0x200
+sShiftrySprites4:
+ax_sprite sShiftryGfx4, 0x200
+ax_sprite_terminator
+sShiftryGfx5:
+.incbin "baserom.gba", 0x113E20C, 0x200
+sShiftrySprites5:
+ax_sprite sShiftryGfx5, 0x200
+ax_sprite_terminator
+sShiftryGfx6:
+.incbin "baserom.gba", 0x113E41C, 0x200
+sShiftrySprites6:
+ax_sprite sShiftryGfx6, 0x200
+ax_sprite_terminator
+sShiftryGfx7:
+.incbin "baserom.gba", 0x113E62C, 0x200
+sShiftrySprites7:
+ax_sprite sShiftryGfx7, 0x200
+ax_sprite_terminator
+sShiftryGfx8:
+.incbin "baserom.gba", 0x113E83C, 0x200
+sShiftrySprites8:
+ax_sprite sShiftryGfx8, 0x200
+ax_sprite_terminator
+sShiftryGfx9:
+.incbin "baserom.gba", 0x113EA4C, 0x200
+sShiftrySprites9:
+ax_sprite sShiftryGfx9, 0x200
+ax_sprite_terminator
+sShiftryGfx10:
+.incbin "baserom.gba", 0x113EC5C, 0x200
+sShiftrySprites10:
+ax_sprite sShiftryGfx10, 0x200
+ax_sprite_terminator
+sShiftryGfx11:
+.incbin "baserom.gba", 0x113EE6C, 0x200
+sShiftrySprites11:
+ax_sprite sShiftryGfx11, 0x200
+ax_sprite_terminator
+sShiftryGfx12:
+.incbin "baserom.gba", 0x113F07C, 0x200
+sShiftrySprites12:
+ax_sprite sShiftryGfx12, 0x200
+ax_sprite_terminator
+sShiftryGfx13:
+.incbin "baserom.gba", 0x113F28C, 0x200
+sShiftrySprites13:
+ax_sprite sShiftryGfx13, 0x200
+ax_sprite_terminator
+sShiftryGfx14:
+.incbin "baserom.gba", 0x113F49C, 0x200
+sShiftrySprites14:
+ax_sprite sShiftryGfx14, 0x200
+ax_sprite_terminator
+sShiftryGfx15:
+.incbin "baserom.gba", 0x113F6AC, 0x200
+sShiftrySprites15:
+ax_sprite sShiftryGfx15, 0x200
+ax_sprite_terminator
+sShiftryGfx16:
+.incbin "baserom.gba", 0x113F8BC, 0x180
+sShiftrySprites16:
+ax_sprite 0, 0x80
+ax_sprite sShiftryGfx16, 0x180
+ax_sprite_terminator
+sShiftryGfx17:
+.incbin "baserom.gba", 0x113FA54, 0x180
+sShiftrySprites17:
+ax_sprite 0, 0x80
+ax_sprite sShiftryGfx17, 0x180
+ax_sprite_terminator
+sShiftryGfx18:
+.incbin "baserom.gba", 0x113FBEC, 0x40
+sShiftryGfx18_1:
+.incbin "baserom.gba", 0x113FC2C, 0x160
+sShiftrySprites18:
+ax_sprite sShiftryGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx18_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShiftryGfx19:
+.incbin "baserom.gba", 0x113FDB4, 0x60
+sShiftryGfx19_1:
+.incbin "baserom.gba", 0x113FE14, 0x160
+sShiftrySprites19:
+ax_sprite sShiftryGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShiftryGfx20:
+.incbin "baserom.gba", 0x113FF9C, 0x20
+sShiftryGfx20_1:
+.incbin "baserom.gba", 0x113FFBC, 0x180
+sShiftrySprites20:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx20_1, 0x180
+ax_sprite_terminator
+sShiftryGfx21:
+.incbin "baserom.gba", 0x1140164, 0x20
+sShiftryGfx21_1:
+.incbin "baserom.gba", 0x1140184, 0x180
+sShiftrySprites21:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx21_1, 0x180
+ax_sprite_terminator
+sShiftryGfx22:
+.incbin "baserom.gba", 0x114032C, 0x20
+sShiftryGfx22_1:
+.incbin "baserom.gba", 0x114034C, 0x60
+sShiftryGfx22_2:
+.incbin "baserom.gba", 0x11403AC, 0x80
+sShiftryGfx22_3:
+.incbin "baserom.gba", 0x114042C, 0x60
+sShiftrySprites22:
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx22, 0x20
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx22_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx22_3, 0x60
+ax_sprite_terminator
+sShiftryGfx23:
+.incbin "baserom.gba", 0x11404D4, 0x40
+sShiftryGfx23_1:
+.incbin "baserom.gba", 0x1140514, 0x60
+sShiftryGfx23_2:
+.incbin "baserom.gba", 0x1140574, 0x80
+sShiftryGfx23_3:
+.incbin "baserom.gba", 0x11405F4, 0x60
+sShiftrySprites23:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx23_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx23_3, 0x60
+ax_sprite_terminator
+sShiftryGfx24:
+.incbin "baserom.gba", 0x114069C, 0x40
+sShiftryGfx24_1:
+.incbin "baserom.gba", 0x11406DC, 0x100
+sShiftryGfx24_2:
+.incbin "baserom.gba", 0x11407DC, 0x60
+sShiftrySprites24:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx24_2, 0x60
+ax_sprite_terminator
+sShiftryGfx25:
+.incbin "baserom.gba", 0x1140874, 0x40
+sShiftryGfx25_1:
+.incbin "baserom.gba", 0x11408B4, 0x100
+sShiftryGfx25_2:
+.incbin "baserom.gba", 0x11409B4, 0x60
+sShiftrySprites25:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx25_2, 0x60
+ax_sprite_terminator
+sShiftryGfx26:
+.incbin "baserom.gba", 0x1140A4C, 0x20
+sShiftryGfx26_1:
+.incbin "baserom.gba", 0x1140A6C, 0x40
+sShiftryGfx26_2:
+.incbin "baserom.gba", 0x1140AAC, 0x60
+sShiftryGfx26_3:
+.incbin "baserom.gba", 0x1140B0C, 0x40
+sShiftrySprites26:
+ax_sprite sShiftryGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sShiftryGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShiftryGfx27:
+.incbin "baserom.gba", 0x1140B94, 0x160
+sShiftryGfx27_1:
+.incbin "baserom.gba", 0x1140CF4, 0x40
+sShiftrySprites27:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx27, 0x160
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShiftryGfx28:
+.incbin "baserom.gba", 0x1140D64, 0x60
+sShiftryGfx28_1:
+.incbin "baserom.gba", 0x1140DC4, 0x100
+sShiftryGfx28_2:
+.incbin "baserom.gba", 0x1140EC4, 0x60
+sShiftrySprites28:
+ax_sprite sShiftryGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx28_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx28_2, 0x60
+ax_sprite_terminator
+sShiftryGfx29:
+.incbin "baserom.gba", 0x1140F54, 0x60
+sShiftryGfx29_1:
+.incbin "baserom.gba", 0x1140FB4, 0x80
+sShiftrySprites29:
+ax_sprite sShiftryGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx29_1, 0x80
+ax_sprite_terminator
+sShiftryGfx30:
+.incbin "baserom.gba", 0x1141054, 0x1E0
+sShiftrySprites30:
+ax_sprite sShiftryGfx30, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShiftryGfx31:
+.incbin "baserom.gba", 0x114124C, 0xC0
+sShiftryGfx31_1:
+.incbin "baserom.gba", 0x114130C, 0x60
+sShiftryGfx31_2:
+.incbin "baserom.gba", 0x114136C, 0x40
+sShiftrySprites31:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx31, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx31_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShiftryGfx32:
+.incbin "baserom.gba", 0x11413EC, 0x60
+sShiftryGfx32_1:
+.incbin "baserom.gba", 0x114144C, 0x60
+sShiftryGfx32_2:
+.incbin "baserom.gba", 0x11414AC, 0x100
+sShiftrySprites32:
+ax_sprite sShiftryGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx32_2, 0x100
+ax_sprite_terminator
+sShiftryGfx33:
+.incbin "baserom.gba", 0x11415DC, 0x60
+sShiftryGfx33_1:
+.incbin "baserom.gba", 0x114163C, 0x40
+sShiftryGfx33_2:
+.incbin "baserom.gba", 0x114167C, 0x40
+sShiftryGfx33_3:
+.incbin "baserom.gba", 0x11416BC, 0x40
+sShiftrySprites33:
+ax_sprite sShiftryGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx33_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx33_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShiftryGfx34:
+.incbin "baserom.gba", 0x1141744, 0x40
+sShiftryGfx34_1:
+.incbin "baserom.gba", 0x1141784, 0x180
+sShiftrySprites34:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx34_1, 0x180
+ax_sprite_terminator
+sShiftryGfx35:
+.incbin "baserom.gba", 0x114192C, 0x60
+sShiftryGfx35_1:
+.incbin "baserom.gba", 0x114198C, 0x60
+sShiftryGfx35_2:
+.incbin "baserom.gba", 0x11419EC, 0x40
+sShiftryGfx35_3:
+.incbin "baserom.gba", 0x1141A2C, 0x40
+sShiftrySprites35:
+ax_sprite sShiftryGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx35_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx35_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShiftryGfx36:
+.incbin "baserom.gba", 0x1141AB4, 0x40
+sShiftryGfx36_1:
+.incbin "baserom.gba", 0x1141AF4, 0x60
+sShiftryGfx36_2:
+.incbin "baserom.gba", 0x1141B54, 0x60
+sShiftryGfx36_3:
+.incbin "baserom.gba", 0x1141BB4, 0x80
+sShiftrySprites36:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx36_3, 0x80
+ax_sprite_terminator
+sShiftryGfx37:
+.incbin "baserom.gba", 0x1141C7C, 0x60
+sShiftryGfx37_1:
+.incbin "baserom.gba", 0x1141CDC, 0x60
+sShiftryGfx37_2:
+.incbin "baserom.gba", 0x1141D3C, 0x80
+sShiftryGfx37_3:
+.incbin "baserom.gba", 0x1141DBC, 0x60
+sShiftrySprites37:
+ax_sprite sShiftryGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx37_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx37_3, 0x60
+ax_sprite_terminator
+sShiftryGfx38:
+.incbin "baserom.gba", 0x1141E5C, 0xC0
+sShiftryGfx38_1:
+.incbin "baserom.gba", 0x1141F1C, 0x60
+sShiftryGfx38_2:
+.incbin "baserom.gba", 0x1141F7C, 0x40
+sShiftrySprites38:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx38, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sShiftryGfx39:
+.incbin "baserom.gba", 0x1141FFC, 0x140
+sShiftryGfx39_1:
+.incbin "baserom.gba", 0x114213C, 0x80
+sShiftrySprites39:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx39, 0x140
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx39_1, 0x80
+ax_sprite_terminator
+sShiftryGfx40:
+.incbin "baserom.gba", 0x11421E4, 0x100
+sShiftrySprites40:
+ax_sprite sShiftryGfx40, 0x100
+ax_sprite_terminator
+sShiftryGfx41:
+.incbin "baserom.gba", 0x11422F4, 0x60
+sShiftryGfx41_1:
+.incbin "baserom.gba", 0x1142354, 0x180
+sShiftrySprites41:
+ax_sprite sShiftryGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx41_1, 0x180
+ax_sprite_terminator
+sShiftryGfx42:
+.incbin "baserom.gba", 0x11424F4, 0x40
+sShiftryGfx42_1:
+.incbin "baserom.gba", 0x1142534, 0x120
+sShiftrySprites42:
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx42, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShiftryGfx42_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShiftryGfx43:
+.incbin "baserom.gba", 0x1142684, 0x1C0
+sShiftrySprites43:
+ax_sprite 0, 0x20
+ax_sprite sShiftryGfx43, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShiftryGfx44:
+.incbin "baserom.gba", 0x1142864, 0x200
+sShiftrySprites44:
+ax_sprite sShiftryGfx44, 0x200
+ax_sprite_terminator
+sShiftryGfx45:
+.incbin "baserom.gba", 0x1142A74, 0x200
+sShiftrySprites45:
+ax_sprite sShiftryGfx45, 0x200
+ax_sprite_terminator
+sShiftryGfx46:
+.incbin "baserom.gba", 0x1142C84, 0x100
+sShiftrySprites46:
+ax_sprite sShiftryGfx46, 0x100
+ax_sprite_terminator
+sShiftryGfx47:
+.incbin "baserom.gba", 0x1142D94, 0x40
+sShiftrySprites47:
+ax_sprite sShiftryGfx47, 0x40
+ax_sprite_terminator
+sShiftryGfx48:
+.incbin "baserom.gba", 0x1142DE4, 0x40
+sShiftrySprites48:
+ax_sprite sShiftryGfx48, 0x40
+ax_sprite_terminator
+sShiftryGfx49:
+.incbin "baserom.gba", 0x1142E34, 0x80
+sShiftrySprites49:
+ax_sprite sShiftryGfx49, 0x80
+ax_sprite_terminator
+sShiftryGfx50:
+.incbin "baserom.gba", 0x1142EC4, 0x200
+sShiftrySprites50:
+ax_sprite sShiftryGfx50, 0x200
+ax_sprite_terminator
+sShiftryGfx51:
+.incbin "baserom.gba", 0x11430D4, 0x200
+sShiftrySprites51:
+ax_sprite sShiftryGfx51, 0x200
+ax_sprite_terminator
+sShiftryGfx52:
+.incbin "baserom.gba", 0x11432E4, 0x100
+sShiftrySprites52:
+ax_sprite sShiftryGfx52, 0x100
+ax_sprite_terminator
+sShiftryGfx53:
+.incbin "baserom.gba", 0x11433F4, 0x20
+sShiftrySprites53:
+ax_sprite sShiftryGfx53, 0x20
+ax_sprite_terminator
+sShiftryGfx54:
+.incbin "baserom.gba", 0x1143424, 0x20
+sShiftrySprites54:
+ax_sprite sShiftryGfx54, 0x20
+ax_sprite_terminator
+sShiftryGfx55:
+.incbin "baserom.gba", 0x1143454, 0x40
+sShiftrySprites55:
+ax_sprite sShiftryGfx55, 0x40
+ax_sprite_terminator
+sShiftryGfx56:
+.incbin "baserom.gba", 0x11434A4, 0x80
+sShiftrySprites56:
+ax_sprite sShiftryGfx56, 0x80
+ax_sprite_terminator
+sShiftryGfx57:
+.incbin "baserom.gba", 0x1143534, 0x80
+sShiftrySprites57:
+ax_sprite sShiftryGfx57, 0x80
+ax_sprite_terminator
+sShiftryGfx58:
+.incbin "baserom.gba", 0x11435C4, 0x40
+sShiftrySprites58:
+ax_sprite sShiftryGfx58, 0x40
+ax_sprite_terminator
+sShiftryGfx59:
+.incbin "baserom.gba", 0x1143614, 0x40
+sShiftrySprites59:
+ax_sprite sShiftryGfx59, 0x40
+ax_sprite_terminator
+sShiftryGfx60:
+.incbin "baserom.gba", 0x1143664, 0x100
+sShiftrySprites60:
+ax_sprite sShiftryGfx60, 0x100
+ax_sprite_terminator
+sShiftryGfx61:
+.incbin "baserom.gba", 0x1143774, 0x100
+sShiftrySprites61:
+ax_sprite sShiftryGfx61, 0x100
+ax_sprite_terminator
+sShiftryGfx62:
+.incbin "baserom.gba", 0x1143884, 0x80
+sShiftrySprites62:
+ax_sprite sShiftryGfx62, 0x80
+ax_sprite_terminator
+sShiftryGfx63:
+.incbin "baserom.gba", 0x1143914, 0x20
+sShiftrySprites63:
+ax_sprite sShiftryGfx63, 0x20
+ax_sprite_terminator
+sShiftryGfx64:
+.incbin "baserom.gba", 0x1143944, 0x20
+sShiftrySprites64:
+ax_sprite sShiftryGfx64, 0x20
+ax_sprite_terminator
+sShiftryGfx65:
+.incbin "baserom.gba", 0x1143974, 0x200
+sShiftrySprites65:
+ax_sprite sShiftryGfx65, 0x200
+ax_sprite_terminator
+sShiftryGfx66:
+.incbin "baserom.gba", 0x1143B84, 0x200
+sShiftrySprites66:
+ax_sprite sShiftryGfx66, 0x200
+ax_sprite_terminator
+sShiftryGfx67:
+.incbin "baserom.gba", 0x1143D94, 0x200
+sShiftrySprites67:
+ax_sprite sShiftryGfx67, 0x200
+ax_sprite_terminator
+sAxPosesShiftry:
+.4byte sShiftryPose1
+.4byte sShiftryPose2
+.4byte sShiftryPose3
+.4byte sShiftryPose4
+.4byte sShiftryPose5
+.4byte sShiftryPose6
+.4byte sShiftryPose7
+.4byte sShiftryPose8
+.4byte sShiftryPose9
+.4byte sShiftryPose10
+.4byte sShiftryPose11
+.4byte sShiftryPose12
+.4byte sShiftryPose13
+.4byte sShiftryPose14
+.4byte sShiftryPose15
+.4byte sShiftryPose16
+.4byte sShiftryPose17
+.4byte sShiftryPose18
+.4byte sShiftryPose19
+.4byte sShiftryPose20
+.4byte sShiftryPose21
+.4byte sShiftryPose22
+.4byte sShiftryPose23
+.4byte sShiftryPose24
+.4byte sShiftryPose25
+.4byte sShiftryPose26
+.4byte sShiftryPose27
+.4byte sShiftryPose28
+.4byte sShiftryPose29
+.4byte sShiftryPose30
+.4byte sShiftryPose31
+.4byte sShiftryPose32
+.4byte sShiftryPose33
+.4byte sShiftryPose34
+.4byte sShiftryPose35
+.4byte sShiftryPose36
+.4byte sShiftryPose37
+.4byte sShiftryPose38
+.4byte sShiftryPose39
+.4byte sShiftryPose40
+.4byte sShiftryPose41
+.4byte sShiftryPose42
+.4byte sShiftryPose43
+.4byte sShiftryPose44
+.4byte sShiftryPose45
+.4byte sShiftryPose46
+.4byte sShiftryPose47
+.4byte sShiftryPose48
+.4byte sShiftryPose49
+.4byte sShiftryPose50
+.4byte sShiftryPose51
+.4byte sShiftryPose52
+.4byte sShiftryPose53
+.4byte sShiftryPose54
+.4byte sShiftryPose55
+.4byte sShiftryPose56
+.4byte sShiftryPose57
+.4byte sShiftryPose58
+.4byte sShiftryPose59
+.4byte sShiftryPose60
+.4byte sShiftryPose61
+.4byte sShiftryPose62
+.4byte sShiftryPose63
+.4byte sShiftryPose64
+.4byte sShiftryPose65
+.4byte sShiftryPose66
+.4byte sShiftryPose67
+.4byte sShiftryPose68
+.4byte sShiftryPose69
+.4byte sShiftryPose70
+.4byte sShiftryPose71
+.4byte sShiftryPose72
+.4byte sShiftryPose73
+.4byte sShiftryPose74
+.4byte sShiftryPose75
+.4byte sShiftryPose76
+.4byte sShiftryPose77
+.4byte sShiftryPose78
+.4byte sShiftryPose79
+.4byte sShiftryPose80
+.4byte sShiftryPose81
+.4byte sShiftryPose82
+.4byte sShiftryPose83
+.4byte sShiftryPose84
+.4byte sShiftryPose85
+.4byte sShiftryPose86
+.4byte sShiftryPose87
+.4byte sShiftryPose88
+.4byte sShiftryPose89
+.4byte sShiftryPose90
+.4byte sShiftryPose91
+.4byte sShiftryPose92
+.4byte sShiftryPose93
+.4byte sShiftryPose94
+.4byte sShiftryPose95
+.4byte sShiftryPose96
+.4byte sShiftryPose97
+.4byte sShiftryPose98
+.4byte sShiftryPose99
+.4byte sShiftryPose100
+.4byte sShiftryPose101
+.4byte sShiftryPose102
+.4byte sShiftryPose103
+.4byte sShiftryPose104
+.4byte sShiftryPose105
+.4byte sShiftryPose106
+.4byte sShiftryPose107
+.4byte sShiftryPose108
+.4byte sShiftryPose109
+.4byte sShiftryPose110
+.4byte sShiftryPose111
+.4byte sShiftryPose112
+.4byte sShiftryPose113
+.4byte sShiftryPose114
+.4byte sShiftryPose115
+.4byte sShiftryPose116
+.4byte sShiftryPose117
+.4byte sShiftryPose118
+.4byte sShiftryPose119
+.4byte sShiftryPose120
+.4byte sShiftryPose121
+.4byte sShiftryPose122
+.4byte sShiftryPose123
+.4byte sShiftryPose124
+.4byte sShiftryPose125
+.4byte sShiftryPose126
+.4byte sShiftryPose127
+.4byte sShiftryPose128
+.4byte sShiftryPose129
+.4byte sShiftryPose130
+.4byte sShiftryPose131
+.4byte sShiftryPose132
+.4byte sShiftryPose133
+.4byte sShiftryPose134
+.4byte sShiftryPose135
+.4byte sShiftryPose136
+.4byte sShiftryPose137
+.4byte sShiftryPose138
+.4byte sShiftryPose139
+.4byte sShiftryPose140
+.4byte sShiftryPose141
+.4byte sShiftryPose142
+.4byte sShiftryPose143
+.4byte sShiftryPose144
+.4byte sShiftryPose145
+.4byte sShiftryPose146
+.4byte sShiftryPose147
+.4byte sShiftryPose148
+.4byte sShiftryPose149
+.4byte sShiftryPose150
+.4byte sShiftryPose151
+.4byte sShiftryPose152
+.4byte sShiftryPose153
+.4byte sShiftryPose154
+.4byte sShiftryPose155
+.4byte sShiftryPose156
+.4byte sShiftryPose157
+.4byte sShiftryPose158
+.4byte sShiftryPose159
+.4byte sShiftryPose160
+.4byte sShiftryPose161
+.4byte sShiftryPose162
+.4byte sShiftryPose163
+.4byte sShiftryPose164
+.4byte sShiftryPose165
+.4byte sShiftryPose166
+.4byte sShiftryPose167
+.4byte sShiftryPose168
+.4byte sShiftryPose169
+.4byte sShiftryPose170
+.4byte sShiftryPose171
+.4byte sShiftryPose172
+.4byte sShiftryPose173
+.4byte sShiftryPose174
+.4byte sShiftryPose175
+.4byte sShiftryPose176
+.4byte sShiftryPose177
+.4byte sShiftryPose178
+.4byte sShiftryPose179
+.4byte sShiftryPose180
+.4byte sShiftryPose181
+.4byte sShiftryPose182
+.4byte sShiftryPose183
+.4byte sShiftryPose184
+.4byte sShiftryPose185
+.4byte sShiftryPose186
+.4byte sShiftryPose187
+.4byte sShiftryPose188
+.4byte sShiftryPose189
+.4byte sShiftryPose190
+.4byte sShiftryPose191
+.4byte sShiftryPose192
+.4byte sShiftryPose193
+.4byte sShiftryPose194
+.4byte sShiftryPose195
+.4byte sShiftryPose196
+.4byte sShiftryPose197
+.4byte sShiftryPose198
+.4byte sShiftryPose199
+.4byte sShiftryPose200
+.4byte sShiftryPose201
+.4byte sShiftryPose202
+.4byte sShiftryPose203
+.4byte sShiftryPose204
+.4byte sShiftryPose205
+.4byte sShiftryPose206
+.4byte sShiftryPose207
+.4byte sShiftryPose208
+.4byte sShiftryPose209
+.4byte sShiftryPose210
+.4byte sShiftryPose211
+.4byte sShiftryPose212
+.4byte sShiftryPose213
+.4byte sShiftryPose214
+.4byte sShiftryPose215
+.4byte sShiftryPose216
+.4byte sShiftryPose217
+.4byte sShiftryPose218
+.4byte sShiftryPose219
+.4byte sShiftryPose220
+.4byte sShiftryPose221
+.4byte sShiftryPose222
+.4byte sShiftryPose223
+.4byte sShiftryPose224
+.4byte sShiftryPose225
+.4byte sShiftryPose226
+.4byte sShiftryPose227
+.4byte sShiftryPose228
+.4byte sShiftryPose229
+.4byte sShiftryPose230
+.4byte sShiftryPose231
+.4byte sShiftryPose232
+.4byte sShiftryPose233
+.4byte sShiftryPose234
+.4byte sShiftryPose235
+.4byte sShiftryPose236
+.4byte sShiftryPose237
+.4byte sShiftryPose238
+.4byte sShiftryPose239
+.4byte sShiftryPose240
+.4byte sShiftryPose241
+.4byte sShiftryPose242
+.4byte sShiftryPose243
+.4byte sShiftryPose244
+.4byte sShiftryPose245
+.4byte sShiftryPose246
+sAxPositionsShiftry:
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -12,   -7, 	  10,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -12,   -5, 	  10,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte    4,   -7, 	   9,   -8, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -7, 	   6,   -7, 	  -5,   -3, 	   1,  -10
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    7,   -9, 	   6,   -5, 	  -4,   -2, 	   0,  -10
+.2byte    7,   -9, 	  -1,   -6, 	   1,   -2, 	   0,  -10
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,  -13, 	  -2,   -9, 	   4,   -1, 	  -1,  -10
+.2byte    7,  -13, 	  -8,  -10, 	   9,   -2, 	   0,   -9
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	  11,   -8, 	 -12,   -5, 	  -1,  -11
+.2byte   -1,  -12, 	  11,   -5, 	 -11,   -8, 	  -1,  -10
+.2byte   -9,  -12, 	   6,   -7, 	  -9,    1, 	  -2,   -8
+.2byte   -9,  -13, 	   0,   -9, 	  -6,   -1, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -10, 	 -11,   -2, 	  -2,   -9
+.2byte   -9,   -8, 	  -6,   -4, 	  -1,    1, 	  -3,   -8
+.2byte   -9,   -9, 	  -8,   -5, 	   2,   -2, 	  -2,  -10
+.2byte   -9,   -9, 	  -1,   -6, 	  -3,   -2, 	  -2,  -10
+.2byte   -6,   -6, 	 -10,   -6, 	   5,   -1, 	  -3,   -7
+.2byte   -6,   -8, 	 -11,   -9, 	   7,   -4, 	  -1,  -10
+.2byte   -6,   -8, 	  -8,   -8, 	   3,   -4, 	  -3,  -11
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -12,   -7, 	  10,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -12,   -5, 	  10,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte    4,   -7, 	   9,   -8, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -7, 	   6,   -7, 	  -5,   -3, 	   1,  -10
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    7,   -9, 	   6,   -5, 	  -4,   -2, 	   0,  -10
+.2byte    7,   -9, 	  -1,   -6, 	   1,   -2, 	   0,  -10
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,  -13, 	  -2,   -9, 	   4,   -1, 	  -1,  -10
+.2byte    7,  -13, 	  -8,  -10, 	   9,   -2, 	   0,   -9
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	  11,   -8, 	 -12,   -5, 	  -1,  -11
+.2byte   -1,  -12, 	  11,   -5, 	 -11,   -8, 	  -1,  -10
+.2byte   -9,  -12, 	   6,   -7, 	  -9,    1, 	  -2,   -8
+.2byte   -9,  -13, 	   0,   -9, 	  -6,   -1, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -10, 	 -11,   -2, 	  -2,   -9
+.2byte   -9,   -8, 	  -6,   -4, 	  -1,    1, 	  -3,   -8
+.2byte   -9,   -9, 	  -8,   -5, 	   2,   -2, 	  -2,  -10
+.2byte   -9,   -9, 	  -1,   -6, 	  -3,   -2, 	  -2,  -10
+.2byte   -6,   -6, 	 -10,   -6, 	   5,   -1, 	  -3,   -7
+.2byte   -6,   -8, 	 -11,   -9, 	   7,   -4, 	  -1,  -10
+.2byte   -6,   -8, 	  -8,   -8, 	   3,   -4, 	  -3,  -11
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -12,   -7, 	  10,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -12,   -5, 	  10,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte    4,   -7, 	   9,   -8, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -7, 	   6,   -7, 	  -5,   -3, 	   1,  -10
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    7,   -9, 	   6,   -5, 	  -4,   -2, 	   0,  -10
+.2byte    7,   -9, 	  -1,   -6, 	   1,   -2, 	   0,  -10
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,  -13, 	  -2,   -9, 	   4,   -1, 	  -1,  -10
+.2byte    7,  -13, 	  -8,  -10, 	   9,   -2, 	   0,   -9
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	  11,   -8, 	 -12,   -5, 	  -1,  -11
+.2byte   -1,  -12, 	  11,   -5, 	 -11,   -8, 	  -1,  -10
+.2byte   -9,  -12, 	   6,   -7, 	  -9,    1, 	  -2,   -8
+.2byte   -9,  -13, 	   0,   -9, 	  -6,   -1, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -10, 	 -11,   -2, 	  -2,   -9
+.2byte   -9,   -8, 	  -6,   -4, 	  -1,    1, 	  -3,   -8
+.2byte   -9,   -9, 	  -8,   -5, 	   2,   -2, 	  -2,  -10
+.2byte   -9,   -9, 	  -1,   -6, 	  -3,   -2, 	  -2,  -10
+.2byte   -6,   -6, 	 -10,   -6, 	   5,   -1, 	  -3,   -7
+.2byte   -6,   -8, 	 -11,   -9, 	   7,   -4, 	  -1,  -10
+.2byte   -6,   -8, 	  -8,   -8, 	   3,   -4, 	  -3,  -11
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -12,   -7, 	  10,   -5, 	  -1,  -10
+.2byte   -1,   -7, 	 -12,   -5, 	  10,   -7, 	  -1,  -10
+.2byte   -1,   -5, 	 -10,   -6, 	   8,  -16, 	  -1,   -9
+.2byte   -1,   -6, 	 -10,   -6, 	   8,  -16, 	  -1,   -9
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte    4,   -7, 	   9,   -8, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -7, 	   6,   -7, 	  -5,   -3, 	   1,  -10
+.2byte    4,   -4, 	  11,   -5, 	 -13,  -11, 	   0,   -8
+.2byte    4,   -4, 	  11,   -5, 	 -13,  -11, 	   0,   -9
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    7,   -9, 	   6,   -5, 	  -4,   -2, 	   0,  -10
+.2byte    7,   -9, 	  -1,   -6, 	   1,   -2, 	   0,  -10
+.2byte    7,   -5, 	  10,   -6, 	 -11,   -8, 	   0,   -7
+.2byte    7,   -6, 	  10,   -7, 	 -11,   -8, 	  -1,   -8
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,  -13, 	  -2,   -9, 	   4,   -1, 	  -1,  -10
+.2byte    7,  -13, 	  -8,  -10, 	   9,   -2, 	   0,   -9
+.2byte    8,  -11, 	   5,   -5, 	  -1,   -6, 	   0,   -7
+.2byte    8,  -12, 	   5,   -5, 	  -1,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	  11,   -8, 	 -12,   -5, 	  -1,  -11
+.2byte   -1,  -12, 	  11,   -5, 	 -11,   -8, 	  -1,  -10
+.2byte   -3,  -12, 	   8,  -14, 	 -13,  -10, 	   0,   -9
+.2byte   -2,  -12, 	   8,  -14, 	 -13,  -10, 	   0,   -9
+.2byte   -9,  -12, 	   6,   -7, 	  -9,    1, 	  -2,   -8
+.2byte   -9,  -13, 	   0,   -9, 	  -6,   -1, 	  -1,  -10
+.2byte   -9,  -13, 	   6,  -10, 	 -11,   -2, 	  -2,   -9
+.2byte  -10,  -11, 	  -7,   -5, 	  -1,   -6, 	  -2,   -7
+.2byte  -10,  -12, 	  -7,   -5, 	  -1,   -6, 	  -1,   -8
+.2byte   -9,   -8, 	  -6,   -4, 	  -1,    1, 	  -3,   -8
+.2byte   -9,   -9, 	  -8,   -5, 	   2,   -2, 	  -2,  -10
+.2byte   -9,   -9, 	  -1,   -6, 	  -3,   -2, 	  -2,  -10
+.2byte   -9,   -5, 	 -12,   -6, 	   9,   -8, 	  -2,   -7
+.2byte   -9,   -6, 	 -12,   -7, 	   9,   -8, 	  -1,   -8
+.2byte   -6,   -6, 	 -10,   -6, 	   5,   -1, 	  -3,   -7
+.2byte   -6,   -8, 	 -11,   -9, 	   7,   -4, 	  -1,  -10
+.2byte   -6,   -8, 	  -8,   -8, 	   3,   -4, 	  -3,  -11
+.2byte   -6,   -4, 	 -13,   -5, 	  11,  -11, 	  -2,   -8
+.2byte   -6,   -4, 	 -13,   -5, 	  11,  -11, 	  -2,   -9
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -1,   -5, 	   1,    0, 	  10,  -18, 	  -1,   -7
+.2byte   -1,   -5, 	   1,    0, 	  10,  -18, 	  -1,   -7
+.2byte   -1,   -5, 	 -12,  -18, 	  -3,    1, 	  -1,   -7
+.2byte   -1,   -5, 	 -12,  -18, 	  -3,    1, 	  -1,   -7
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte    4,   -5, 	   4,    0, 	 -11,  -15, 	   0,   -7
+.2byte    4,   -5, 	   4,    0, 	 -11,  -15, 	   0,   -7
+.2byte    4,   -5, 	   7,  -22, 	   7,    0, 	   0,   -7
+.2byte    4,   -5, 	   7,  -22, 	   7,    0, 	   0,   -7
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    7,   -7, 	   7,   -2, 	  -6,  -15, 	   1,   -8
+.2byte    7,   -7, 	   7,   -2, 	  -6,  -15, 	   1,   -8
+.2byte    7,   -7, 	  -1,  -22, 	  11,   -2, 	   1,   -8
+.2byte    7,   -7, 	  -1,  -22, 	  11,   -2, 	   1,   -8
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,  -12, 	   4,   -2, 	   9,  -15, 	   1,   -9
+.2byte    7,  -12, 	   4,   -2, 	   9,  -15, 	   1,   -9
+.2byte    7,  -12, 	  -9,  -19, 	   5,   -1, 	   1,   -8
+.2byte    7,  -12, 	  -9,  -19, 	   5,   -1, 	   1,   -8
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   3,   -5, 	 -12,  -19, 	  -1,   -9
+.2byte   -1,  -11, 	   3,   -5, 	 -12,  -19, 	  -1,   -9
+.2byte   -1,  -11, 	  10,  -19, 	  -4,   -5, 	  -1,   -9
+.2byte   -1,  -11, 	  10,  -19, 	  -4,   -5, 	  -1,   -9
+.2byte   -8,  -12, 	   7,   -7, 	  -8,    1, 	  -1,   -8
+.2byte   -8,  -12, 	  -5,   -2, 	 -10,  -15, 	  -2,   -9
+.2byte   -8,  -12, 	  -5,   -2, 	 -10,  -15, 	  -2,   -9
+.2byte   -8,  -12, 	   8,  -19, 	  -6,   -1, 	  -2,   -8
+.2byte   -8,  -12, 	   8,  -19, 	  -6,   -1, 	  -2,   -8
+.2byte   -8,   -8, 	  -5,   -4, 	   0,    1, 	  -2,   -8
+.2byte   -8,   -7, 	  -8,   -2, 	   5,  -15, 	  -2,   -8
+.2byte   -8,   -7, 	  -8,   -2, 	   5,  -15, 	  -2,   -8
+.2byte   -8,   -7, 	   0,  -22, 	 -12,   -2, 	  -2,   -8
+.2byte   -8,   -7, 	   0,  -22, 	 -12,   -2, 	  -2,   -8
+.2byte   -5,   -6, 	  -9,   -6, 	   6,   -1, 	  -2,   -7
+.2byte   -5,   -5, 	  -5,    0, 	  10,  -15, 	  -1,   -7
+.2byte   -5,   -5, 	  -5,    0, 	  10,  -15, 	  -1,   -7
+.2byte   -5,   -5, 	  -8,  -22, 	  -8,    0, 	  -1,   -7
+.2byte   -5,   -5, 	  -8,  -22, 	  -8,    0, 	  -1,   -7
+.2byte   -6,   -3, 	  -8,   -2, 	   6,    3, 	  -2,   -5
+.2byte   -7,   -2, 	  -9,    0, 	   6,    3, 	  -2,   -5
+.2byte    0,   -7, 	 -13,  -12, 	  13,  -12, 	   0,  -13
+.2byte    4,  -10, 	   7,  -19, 	 -10,   -2, 	  -1,  -12
+.2byte    4,  -11, 	  -6,  -20, 	  -6,  -10, 	  -3,  -13
+.2byte    2,  -13, 	  -9,  -18, 	   8,  -12, 	  -3,  -12
+.2byte   -1,  -14, 	  12,  -14, 	 -13,  -14, 	  -1,  -12
+.2byte   -3,  -13, 	   8,  -18, 	  -9,  -12, 	   2,  -12
+.2byte   -5,  -11, 	   5,  -20, 	   5,  -10, 	   2,  -13
+.2byte   -5,  -10, 	  -8,  -19, 	   9,   -2, 	   0,  -12
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -1,   -5, 	   1,    0, 	  10,  -18, 	  -1,   -7
+.2byte   -1,   -5, 	 -12,  -18, 	  -3,    1, 	  -1,   -7
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte    4,   -5, 	   4,    0, 	 -11,  -15, 	   0,   -7
+.2byte    4,   -5, 	   7,  -22, 	   7,    0, 	   0,   -7
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    7,   -7, 	   7,   -2, 	  -6,  -15, 	   1,   -8
+.2byte    7,   -7, 	  -1,  -22, 	  11,   -2, 	   1,   -8
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,  -12, 	   4,   -2, 	   9,  -15, 	   1,   -9
+.2byte    7,  -12, 	  -9,  -19, 	   5,   -1, 	   1,   -8
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   3,   -5, 	 -12,  -19, 	  -1,   -9
+.2byte   -1,  -11, 	  10,  -19, 	  -4,   -5, 	  -1,   -9
+.2byte   -9,  -12, 	   6,   -7, 	  -9,    1, 	  -2,   -8
+.2byte   -9,  -12, 	  -6,   -2, 	 -11,  -15, 	  -3,   -9
+.2byte   -9,  -12, 	   7,  -19, 	  -7,   -1, 	  -3,   -8
+.2byte   -9,   -8, 	  -6,   -4, 	  -1,    1, 	  -3,   -8
+.2byte   -9,   -7, 	  -9,   -2, 	   4,  -15, 	  -3,   -8
+.2byte   -9,   -7, 	  -1,  -22, 	 -13,   -2, 	  -3,   -8
+.2byte   -6,   -6, 	 -10,   -6, 	   5,   -1, 	  -3,   -7
+.2byte   -6,   -5, 	  -6,    0, 	   9,  -15, 	  -2,   -7
+.2byte   -6,   -5, 	  -9,  -22, 	  -9,    0, 	  -2,   -7
+.2byte   -1,   -7, 	 -12,   -7, 	  10,   -5, 	  -1,  -10
+.2byte   -4,   -7, 	  -9,   -8, 	   9,   -3, 	   1,   -9
+.2byte   -7,   -9, 	  -6,   -5, 	   4,   -2, 	   0,  -10
+.2byte   -7,  -13, 	   2,   -9, 	  -4,   -1, 	   1,  -10
+.2byte   -1,  -13, 	  11,   -8, 	 -12,   -5, 	  -1,  -11
+.2byte    6,  -13, 	  -3,   -9, 	   3,   -1, 	  -2,  -10
+.2byte    6,   -9, 	   5,   -5, 	  -5,   -2, 	  -1,  -10
+.2byte    5,   -7, 	  10,   -8, 	  -8,   -3, 	   0,   -9
+.2byte   -1,   -8, 	 -10,   -8, 	   8,  -18, 	  -1,  -11
+.2byte    3,   -6, 	  10,   -7, 	 -14,  -13, 	  -1,  -11
+.2byte    6,   -8, 	   9,   -9, 	 -12,  -10, 	  -2,  -10
+.2byte    7,  -14, 	   4,   -7, 	  -2,   -8, 	  -2,  -10
+.2byte   -2,  -14, 	   8,  -16, 	 -13,  -12, 	   0,  -11
+.2byte   -9,  -14, 	  -6,   -7, 	   0,   -8, 	   0,  -10
+.2byte   -7,   -8, 	 -10,   -9, 	  11,  -10, 	   1,  -10
+.2byte   -5,   -6, 	 -12,   -7, 	  12,  -13, 	  -1,  -11
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -1,   -7, 	 -12,   -7, 	  10,   -5, 	  -1,  -10
+.2byte   -1,   -5, 	 -10,   -6, 	   8,  -16, 	  -1,   -9
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte    4,   -7, 	   9,   -8, 	  -9,   -3, 	  -1,   -9
+.2byte    4,   -4, 	  11,   -5, 	 -13,  -11, 	   0,   -8
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    7,   -9, 	   6,   -5, 	  -4,   -2, 	   0,  -10
+.2byte    7,   -5, 	  10,   -6, 	 -11,   -8, 	   0,   -7
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,  -13, 	  -2,   -9, 	   4,   -1, 	  -1,  -10
+.2byte    8,  -11, 	   5,   -5, 	  -1,   -6, 	   0,   -7
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte   -1,  -13, 	  11,   -8, 	 -12,   -5, 	  -1,  -11
+.2byte   -3,  -12, 	   8,  -14, 	 -13,  -10, 	   0,   -9
+.2byte   -9,  -12, 	   6,   -7, 	  -9,    1, 	  -2,   -8
+.2byte   -9,  -13, 	   0,   -9, 	  -6,   -1, 	  -1,  -10
+.2byte  -10,  -11, 	  -7,   -5, 	  -1,   -6, 	  -2,   -7
+.2byte   -9,   -8, 	  -6,   -4, 	  -1,    1, 	  -3,   -8
+.2byte   -9,   -9, 	  -8,   -5, 	   2,   -2, 	  -2,  -10
+.2byte   -9,   -5, 	 -12,   -6, 	   9,   -8, 	  -2,   -7
+.2byte   -6,   -6, 	 -10,   -6, 	   5,   -1, 	  -3,   -7
+.2byte   -6,   -8, 	 -11,   -9, 	   7,   -4, 	  -1,  -10
+.2byte   -6,   -4, 	 -13,   -5, 	  11,  -11, 	  -2,   -8
+.2byte   -1,   -5, 	 -12,  -18, 	  -3,    1, 	  -1,   -7
+.2byte   -5,   -5, 	  -8,  -22, 	  -8,    0, 	  -1,   -7
+.2byte   -7,   -7, 	   1,  -22, 	 -11,   -2, 	  -1,   -8
+.2byte   -7,  -12, 	   9,  -19, 	  -5,   -1, 	  -1,   -8
+.2byte   -1,  -11, 	  10,  -19, 	  -4,   -5, 	  -1,   -9
+.2byte    6,  -12, 	 -10,  -19, 	   4,   -1, 	   0,   -8
+.2byte    5,   -7, 	  -3,  -22, 	   9,   -2, 	  -1,   -8
+.2byte    3,   -5, 	   6,  -22, 	   6,    0, 	  -1,   -7
+.2byte   -1,   -6, 	 -12,   -4, 	  10,   -3, 	  -1,   -9
+.2byte   -6,   -6, 	 -10,   -6, 	   5,   -1, 	  -3,   -7
+.2byte   -9,   -8, 	  -6,   -4, 	  -1,    1, 	  -3,   -8
+.2byte   -9,  -12, 	   6,   -7, 	  -9,    1, 	  -2,   -8
+.2byte   -1,  -11, 	  10,   -4, 	 -12,   -4, 	  -1,   -9
+.2byte    7,  -12, 	  -8,   -7, 	   7,    1, 	   0,   -8
+.2byte    7,   -8, 	   4,   -4, 	  -1,    1, 	   1,   -8
+.2byte    4,   -6, 	   8,   -6, 	  -7,   -1, 	   1,   -7
+.2byte   -7,   -2, 	 -12,    1, 	  12,    1, 	   0,   -4
+.2byte   -4,   -7, 	  -9,   -7, 	   5,   -5, 	   0,   -9
+.2byte    0,   -9, 	 -10,  -18, 	  11,   -5, 	   0,  -11
+.2byte    0,   -9, 	 -10,  -19, 	  11,   -5, 	   0,  -11
+sShiftryAnimTable1:
+.4byte sShiftryAnims_1_1
+.4byte sShiftryAnims_1_2
+.4byte sShiftryAnims_1_3
+.4byte sShiftryAnims_1_4
+.4byte sShiftryAnims_1_5
+.4byte sShiftryAnims_1_6
+.4byte sShiftryAnims_1_7
+.4byte sShiftryAnims_1_8
+sShiftryAnimTable2:
+.4byte sShiftryAnims_2_1
+.4byte sShiftryAnims_2_2
+.4byte sShiftryAnims_2_3
+.4byte sShiftryAnims_2_4
+.4byte sShiftryAnims_2_5
+.4byte sShiftryAnims_2_6
+.4byte sShiftryAnims_2_7
+.4byte sShiftryAnims_2_8
+sShiftryAnimTable3:
+.4byte sShiftryAnims_3_1
+.4byte sShiftryAnims_3_2
+.4byte sShiftryAnims_3_3
+.4byte sShiftryAnims_3_4
+.4byte sShiftryAnims_3_5
+.4byte sShiftryAnims_3_6
+.4byte sShiftryAnims_3_7
+.4byte sShiftryAnims_3_8
+sShiftryAnimTable4:
+.4byte sShiftryAnims_4_1
+.4byte sShiftryAnims_4_2
+.4byte sShiftryAnims_4_3
+.4byte sShiftryAnims_4_4
+.4byte sShiftryAnims_4_5
+.4byte sShiftryAnims_4_6
+.4byte sShiftryAnims_4_7
+.4byte sShiftryAnims_4_8
+sShiftryAnimTable5:
+.4byte sShiftryAnims_5_1
+.4byte sShiftryAnims_5_2
+.4byte sShiftryAnims_5_3
+.4byte sShiftryAnims_5_4
+.4byte sShiftryAnims_5_5
+.4byte sShiftryAnims_5_6
+.4byte sShiftryAnims_5_7
+.4byte sShiftryAnims_5_8
+sShiftryAnimTable6:
+.4byte sShiftryAnims_6_1
+.4byte sShiftryAnims_6_1
+.4byte sShiftryAnims_6_1
+.4byte sShiftryAnims_6_1
+.4byte sShiftryAnims_6_1
+.4byte sShiftryAnims_6_1
+.4byte sShiftryAnims_6_1
+.4byte sShiftryAnims_6_1
+sShiftryAnimTable7:
+.4byte sShiftryAnims_7_1
+.4byte sShiftryAnims_7_2
+.4byte sShiftryAnims_7_3
+.4byte sShiftryAnims_7_4
+.4byte sShiftryAnims_7_5
+.4byte sShiftryAnims_7_6
+.4byte sShiftryAnims_7_7
+.4byte sShiftryAnims_7_8
+sShiftryAnimTable8:
+.4byte sShiftryAnims_8_1
+.4byte sShiftryAnims_8_2
+.4byte sShiftryAnims_8_3
+.4byte sShiftryAnims_8_4
+.4byte sShiftryAnims_8_5
+.4byte sShiftryAnims_8_6
+.4byte sShiftryAnims_8_7
+.4byte sShiftryAnims_8_8
+sShiftryAnimTable9:
+.4byte sShiftryAnims_9_1
+.4byte sShiftryAnims_9_2
+.4byte sShiftryAnims_9_3
+.4byte sShiftryAnims_9_4
+.4byte sShiftryAnims_9_5
+.4byte sShiftryAnims_9_6
+.4byte sShiftryAnims_9_7
+.4byte sShiftryAnims_9_8
+sShiftryAnimTable10:
+.4byte sShiftryAnims_10_1
+.4byte sShiftryAnims_10_2
+.4byte sShiftryAnims_10_3
+.4byte sShiftryAnims_10_4
+.4byte sShiftryAnims_10_5
+.4byte sShiftryAnims_10_6
+.4byte sShiftryAnims_10_7
+.4byte sShiftryAnims_10_8
+sShiftryAnimTable11:
+.4byte sShiftryAnims_11_1
+.4byte sShiftryAnims_11_2
+.4byte sShiftryAnims_11_3
+.4byte sShiftryAnims_11_4
+.4byte sShiftryAnims_11_5
+.4byte sShiftryAnims_11_6
+.4byte sShiftryAnims_11_7
+.4byte sShiftryAnims_11_8
+sShiftryAnimTable12:
+.4byte sShiftryAnims_12_1
+.4byte sShiftryAnims_12_2
+.4byte sShiftryAnims_12_3
+.4byte sShiftryAnims_12_4
+.4byte sShiftryAnims_12_5
+.4byte sShiftryAnims_12_6
+.4byte sShiftryAnims_12_7
+.4byte sShiftryAnims_12_8
+sShiftryAnimTable13:
+.4byte sShiftryAnims_13_1
+.4byte sShiftryAnims_13_2
+.4byte sShiftryAnims_13_3
+.4byte sShiftryAnims_13_4
+.4byte sShiftryAnims_13_5
+.4byte sShiftryAnims_13_6
+.4byte sShiftryAnims_13_7
+.4byte sShiftryAnims_13_8
+sShiftryAnimTable14:
+.4byte sShiftryAnims_14_1
+.4byte sShiftryAnims_14_2
+.4byte sShiftryAnims_14_3
+.4byte sShiftryAnims_14_4
+.4byte sShiftryAnims_14_5
+.4byte sShiftryAnims_14_6
+.4byte sShiftryAnims_14_7
+.4byte sShiftryAnims_14_8
+sShiftryAnimTable15:
+.4byte sShiftryAnims_15_1
+.4byte sShiftryAnims_15_2
+.4byte sShiftryAnims_15_3
+.4byte sShiftryAnims_15_4
+.4byte sShiftryAnims_15_5
+.4byte sShiftryAnims_15_6
+.4byte sShiftryAnims_15_7
+.4byte sShiftryAnims_15_8
+sAxAnimationsShiftry:
+.4byte sShiftryAnimTable1
+.4byte sShiftryAnimTable2
+.4byte sShiftryAnimTable3
+.4byte sShiftryAnimTable4
+.4byte sShiftryAnimTable5
+.4byte sShiftryAnimTable6
+.4byte sShiftryAnimTable7
+.4byte sShiftryAnimTable8
+.4byte sShiftryAnimTable9
+.4byte sShiftryAnimTable10
+.4byte sShiftryAnimTable11
+.4byte sShiftryAnimTable12
+.4byte sShiftryAnimTable13
+.4byte sShiftryAnimTable14
+.4byte sShiftryAnimTable15
+sAxSpritesShiftry:
+.4byte sShiftrySprites1
+.4byte sShiftrySprites2
+.4byte sShiftrySprites3
+.4byte sShiftrySprites4
+.4byte sShiftrySprites5
+.4byte sShiftrySprites6
+.4byte sShiftrySprites7
+.4byte sShiftrySprites8
+.4byte sShiftrySprites9
+.4byte sShiftrySprites10
+.4byte sShiftrySprites11
+.4byte sShiftrySprites12
+.4byte sShiftrySprites13
+.4byte sShiftrySprites14
+.4byte sShiftrySprites15
+.4byte sShiftrySprites16
+.4byte sShiftrySprites17
+.4byte sShiftrySprites18
+.4byte sShiftrySprites19
+.4byte sShiftrySprites20
+.4byte sShiftrySprites21
+.4byte sShiftrySprites22
+.4byte sShiftrySprites23
+.4byte sShiftrySprites24
+.4byte sShiftrySprites25
+.4byte sShiftrySprites26
+.4byte sShiftrySprites27
+.4byte sShiftrySprites28
+.4byte sShiftrySprites29
+.4byte sShiftrySprites30
+.4byte sShiftrySprites31
+.4byte sShiftrySprites32
+.4byte sShiftrySprites33
+.4byte sShiftrySprites34
+.4byte sShiftrySprites35
+.4byte sShiftrySprites36
+.4byte sShiftrySprites37
+.4byte sShiftrySprites38
+.4byte sShiftrySprites39
+.4byte sShiftrySprites40
+.4byte sShiftrySprites41
+.4byte sShiftrySprites42
+.4byte sShiftrySprites43
+.4byte sShiftrySprites44
+.4byte sShiftrySprites45
+.4byte sShiftrySprites46
+.4byte sShiftrySprites47
+.4byte sShiftrySprites48
+.4byte sShiftrySprites49
+.4byte sShiftrySprites50
+.4byte sShiftrySprites51
+.4byte sShiftrySprites52
+.4byte sShiftrySprites53
+.4byte sShiftrySprites54
+.4byte sShiftrySprites55
+.4byte sShiftrySprites56
+.4byte sShiftrySprites57
+.4byte sShiftrySprites58
+.4byte sShiftrySprites59
+.4byte sShiftrySprites60
+.4byte sShiftrySprites61
+.4byte sShiftrySprites62
+.4byte sShiftrySprites63
+.4byte sShiftrySprites64
+.4byte sShiftrySprites65
+.4byte sShiftrySprites66
+.4byte sShiftrySprites67
+sAxMainShiftry:
+ax_main sAxPosesShiftry, sAxAnimationsShiftry, 15, sAxSpritesShiftry, sAxPositionsShiftry

--- a/data/ax/shroomish.inc
+++ b/data/ax/shroomish.inc
@@ -1,0 +1,2458 @@
+.global gAxShroomish
+gAxShroomish:
+ax_siro sAxMainShroomish
+sShroomishPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose4:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose5:
+ax_pose 4, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose6:
+ax_pose 5, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose7:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose8:
+ax_pose 7, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose9:
+ax_pose 8, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose10:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose11:
+ax_pose 10, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose12:
+ax_pose 11, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose14:
+ax_pose 13, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose15:
+ax_pose 14, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose18:
+ax_pose 11, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose19:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose20:
+ax_pose 7, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose21:
+ax_pose 8, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose23:
+ax_pose 4, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose28:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose29:
+ax_pose 4, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose30:
+ax_pose 5, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose31:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose32:
+ax_pose 7, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose33:
+ax_pose 8, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose34:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose35:
+ax_pose 10, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose36:
+ax_pose 11, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose37:
+ax_pose 12, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose38:
+ax_pose 13, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose39:
+ax_pose 14, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose40:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose41:
+ax_pose 10, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose42:
+ax_pose 11, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose43:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose44:
+ax_pose 7, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose45:
+ax_pose 8, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose46:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose47:
+ax_pose 4, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose48:
+ax_pose 5, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose49:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose50:
+ax_pose 1, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose51:
+ax_pose 2, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose52:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose53:
+ax_pose 4, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose54:
+ax_pose 5, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose55:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose56:
+ax_pose 7, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose57:
+ax_pose 8, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose58:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose59:
+ax_pose 10, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose60:
+ax_pose 11, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose61:
+ax_pose 12, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose62:
+ax_pose 13, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose63:
+ax_pose 14, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose64:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose65:
+ax_pose 10, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose66:
+ax_pose 11, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose67:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose68:
+ax_pose 7, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose69:
+ax_pose 8, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose70:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose71:
+ax_pose 4, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose72:
+ax_pose 5, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose73:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose74:
+ax_pose 1, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose75:
+ax_pose 2, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose76:
+ax_pose 15, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose77:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose78:
+ax_pose 4, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose79:
+ax_pose 5, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose80:
+ax_pose 16, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose81:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose82:
+ax_pose 7, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose83:
+ax_pose 8, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose84:
+ax_pose 17, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose85:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose86:
+ax_pose 10, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose87:
+ax_pose 11, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose88:
+ax_pose 18, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose89:
+ax_pose 12, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose90:
+ax_pose 13, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose91:
+ax_pose 14, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose92:
+ax_pose 19, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose93:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose94:
+ax_pose 10, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose95:
+ax_pose 11, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose96:
+ax_pose 18, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose97:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose98:
+ax_pose 7, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose99:
+ax_pose 8, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose100:
+ax_pose 17, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose101:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose102:
+ax_pose 4, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose103:
+ax_pose 5, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose104:
+ax_pose 16, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose105:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose106:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose107:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose108:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose109:
+ax_pose 12, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose110:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose111:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose112:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose113:
+ax_pose 15, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose114:
+ax_pose 16, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose115:
+ax_pose 17, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose116:
+ax_pose 18, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sShroomishPose117:
+ax_pose 19, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose118:
+ax_pose 18, 0x01e9, 0x90f1, 0x8c00
+ax_pose_terminator
+sShroomishPose119:
+ax_pose 17, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose120:
+ax_pose 16, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose121:
+ax_pose 20, 0x01ee, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose122:
+ax_pose 21, 0x01ee, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose123:
+ax_pose 22, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose124:
+ax_pose 23, 0x01e5, 0x90ed, 0x8c00
+ax_pose_terminator
+sShroomishPose125:
+ax_pose 24, 0x01e6, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose126:
+ax_pose 25, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose127:
+ax_pose 26, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose128:
+ax_pose 25, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose129:
+ax_pose 24, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose130:
+ax_pose 23, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sShroomishPose131:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose132:
+ax_pose 1, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose133:
+ax_pose 2, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose134:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose135:
+ax_pose 4, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose136:
+ax_pose 5, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose137:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose138:
+ax_pose 7, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose139:
+ax_pose 8, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose140:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose141:
+ax_pose 10, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose142:
+ax_pose 11, 0x41f2, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose143:
+ax_pose 12, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose144:
+ax_pose 13, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose145:
+ax_pose 14, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose146:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose147:
+ax_pose 10, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose148:
+ax_pose 11, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose149:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose150:
+ax_pose 7, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose151:
+ax_pose 8, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose152:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose153:
+ax_pose 4, 0x41f2, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose154:
+ax_pose 5, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose155:
+ax_pose 15, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose156:
+ax_pose 16, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose157:
+ax_pose 17, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose158:
+ax_pose 18, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose159:
+ax_pose 19, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose160:
+ax_pose 18, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose161:
+ax_pose 17, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose162:
+ax_pose 16, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose163:
+ax_pose 15, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose164:
+ax_pose 16, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sShroomishPose165:
+ax_pose 17, 0x01e9, 0x90ee, 0x8c00
+ax_pose_terminator
+sShroomishPose166:
+ax_pose 18, 0x01e9, 0x90f0, 0x8c00
+ax_pose_terminator
+sShroomishPose167:
+ax_pose 19, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose168:
+ax_pose 18, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose169:
+ax_pose 17, 0x01e9, 0x80f2, 0x8c00
+ax_pose_terminator
+sShroomishPose170:
+ax_pose 16, 0x01e9, 0x80f1, 0x8c00
+ax_pose_terminator
+sShroomishPose171:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose172:
+ax_pose 15, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose173:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose174:
+ax_pose 16, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sShroomishPose175:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose176:
+ax_pose 17, 0x01e9, 0x90ee, 0x8c00
+ax_pose_terminator
+sShroomishPose177:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose178:
+ax_pose 18, 0x01ec, 0x90ef, 0x8c00
+ax_pose_terminator
+sShroomishPose179:
+ax_pose 12, 0x01ec, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose180:
+ax_pose 19, 0x01ec, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose181:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose182:
+ax_pose 18, 0x01ec, 0x80ef, 0x8c00
+ax_pose_terminator
+sShroomishPose183:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose184:
+ax_pose 17, 0x01e9, 0x80f2, 0x8c00
+ax_pose_terminator
+sShroomishPose185:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose186:
+ax_pose 16, 0x01e9, 0x80f1, 0x8c00
+ax_pose_terminator
+sShroomishPose187:
+ax_pose 15, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose188:
+ax_pose 16, 0x01e9, 0x80f1, 0x8c00
+ax_pose_terminator
+sShroomishPose189:
+ax_pose 17, 0x01e9, 0x80f2, 0x8c00
+ax_pose_terminator
+sShroomishPose190:
+ax_pose 18, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose191:
+ax_pose 19, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sShroomishPose192:
+ax_pose 18, 0x01e9, 0x90f1, 0x8c00
+ax_pose_terminator
+sShroomishPose193:
+ax_pose 17, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sShroomishPose194:
+ax_pose 16, 0x01e9, 0x90ef, 0x8c00
+ax_pose_terminator
+sShroomishPose195:
+ax_pose 0, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose196:
+ax_pose 3, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose197:
+ax_pose 6, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose198:
+ax_pose 9, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose199:
+ax_pose 12, 0x01ed, 0x80f4, 0x8c00
+ax_pose_terminator
+sShroomishPose200:
+ax_pose 9, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose201:
+ax_pose 6, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+sShroomishPose202:
+ax_pose 3, 0x01ed, 0x90ec, 0x8c00
+ax_pose_terminator
+.align 2
+sShroomishAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sShroomishAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 1, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sShroomishAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sShroomishAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 20, -24, 20, -24,
+ax_anim 2, 1, 34, 21, -23, 21, -23,
+ax_anim 2, 0, 34, 20, -24, 20, -24,
+ax_anim 2, 0, 34, 21, -23, 21, -23,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sShroomishAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 1, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 0, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sShroomishAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -20, -24, -20, -24,
+ax_anim 2, 1, 40, -21, -23, -21, -23,
+ax_anim 2, 0, 40, -20, -24, -20, -24,
+ax_anim 2, 0, 40, -21, -23, -21, -23,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sShroomishAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sShroomishAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 1, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sShroomishAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 1, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 0, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sShroomishAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 19, 20, 19, 20,
+ax_anim 2, 1, 52, 20, 19, 20, 19,
+ax_anim 2, 0, 52, 19, 20, 19, 20,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sShroomishAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 1, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sShroomishAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 20, -24, 20, -24,
+ax_anim 2, 1, 58, 21, -23, 21, -23,
+ax_anim 2, 0, 58, 20, -24, 20, -24,
+ax_anim 2, 0, 58, 21, -23, 21, -23,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sShroomishAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -23, 0, -23,
+ax_anim 2, 1, 61, 1, -23, 1, -23,
+ax_anim 2, 0, 61, 0, -23, 0, -23,
+ax_anim 2, 0, 61, 1, -23, 1, -23,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sShroomishAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -20, -24, -20, -24,
+ax_anim 2, 1, 64, -21, -23, -21, -23,
+ax_anim 2, 0, 64, -20, -24, -20, -24,
+ax_anim 2, 0, 64, -21, -23, -21, -23,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sShroomishAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 1, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sShroomishAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -19, 20, -19, 20,
+ax_anim 2, 1, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 70, -19, 20, -19, 20,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sShroomishAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 74, 0, -4, 0, -4,
+ax_anim 6, 2, 72, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -2, 0, -2,
+ax_anim 1, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 1, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, 1, 3, 1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, 1, 3, 1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, 1, 3, 1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sShroomishAnims_4_2:
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 0, 78, -4, -4, -4, -4,
+ax_anim 6, 2, 76, -4, -4, -4, -4,
+ax_anim 1, 0, 79, -2, -2, -2, -2,
+ax_anim 1, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 1, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 4, 2, 4, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 4, 2, 4, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 4, 2, 4, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim_terminator
+sShroomishAnims_4_3:
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 2, 0, 82, -4, 0, -4, 0,
+ax_anim 6, 2, 80, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -2, 0, -2, 0,
+ax_anim 1, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 1, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim_terminator
+sShroomishAnims_4_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -4, 4, -4, 4,
+ax_anim 6, 2, 84, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -2, 2, -2, 2,
+ax_anim 1, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 1, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 4, -2, 4, -2,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 4, -2, 4, -2,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 4, -2, 4, -2,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim_terminator
+sShroomishAnims_4_5:
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 0, 4, 0, 4,
+ax_anim 6, 2, 88, 0, 4, 0, 4,
+ax_anim 1, 0, 91, 0, 2, 0, 2,
+ax_anim 1, 0, 91, 0, -2, 0, -2,
+ax_anim 2, 1, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, 1, -3, 1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, 1, -3, 1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, 1, -3, 1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim_terminator
+sShroomishAnims_4_6:
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 4, 4, 4, 4,
+ax_anim 6, 2, 92, 4, 4, 4, 4,
+ax_anim 1, 0, 95, 2, 2, 2, 2,
+ax_anim 1, 0, 95, -2, -2, -2, -2,
+ax_anim 2, 1, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -4, -2, -4, -2,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -4, -2, -4, -2,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -4, -2, -4, -2,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim_terminator
+sShroomishAnims_4_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 6, 2, 96, 4, 0, 4, 0,
+ax_anim 1, 0, 99, 2, 0, 2, 0,
+ax_anim 1, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 1, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -3, 1, -3, 1,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -3, 1, -3, 1,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -3, 1, -3, 1,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sShroomishAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 4, -4, 4, -4,
+ax_anim 6, 2, 100, 4, -4, 4, -4,
+ax_anim 1, 0, 103, 2, -2, 2, -2,
+ax_anim 1, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 1, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sShroomishAnims_5_1:
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 4, 0, 104, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 1, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_5_2:
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 4, 0, 111, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 1, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_5_3:
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 0, 110, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 1, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_5_4:
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 4, 0, 109, 0, -5, 0, 0,
+ax_anim 2, 0, 109, 0, -4, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 1, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_5_5:
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 4, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 1, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_5_6:
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 4, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 1, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_5_7:
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 4, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 1, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_5_8:
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 4, 0, 105, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 1, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sShroomishAnims_7_2:
+ax_anim 2, 0, 123, -3, -3, -2, -2,
+ax_anim 8, 0, 123, -4, -4, -3, -3,
+ax_anim_terminator
+sShroomishAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sShroomishAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sShroomishAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sShroomishAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sShroomishAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sShroomishAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sShroomishAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, -2, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, -2, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, -2, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, -2, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, -2, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, -2, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, -2, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 12, 12, 8, 9,
+ax_anim 2, 0, 157, 7, 20, 7, 15,
+ax_anim 3, 0, 158, 0, 22, 0, 18,
+ax_anim 2, 3, 159, -7, 20, -7, 15,
+ax_anim 2, 0, 160, -12, 12, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 11, -1, 11, -1,
+ax_anim 2, 0, 155, 22, 4, 22, 4,
+ax_anim 2, 0, 156, 28, 13, 28, 13,
+ax_anim 3, 0, 157, 23, 21, 23, 21,
+ax_anim 2, 3, 158, 12, 22, 12, 22,
+ax_anim 2, 0, 159, 6, 20, 6, 20,
+ax_anim 1, 0, 160, -1, 11, -1, 11,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 4, -5, 4, -5,
+ax_anim 2, 0, 154, 11, -7, 11, -7,
+ax_anim 2, 0, 155, 20, -5, 20, -5,
+ax_anim 3, 0, 156, 23, 0, 23, 0,
+ax_anim 2, 3, 157, 18, 5, 18, 5,
+ax_anim 2, 0, 158, 12, 6, 12, 6,
+ax_anim 1, 0, 159, 5, 5, 5, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -2, -9, -2, -9,
+ax_anim 2, 0, 161, 4, -18, 4, -18,
+ax_anim 2, 0, 154, 12, -23, 12, -23,
+ax_anim 3, 0, 155, 21, -22, 21, -22,
+ax_anim 2, 3, 156, 24, -12, 24, -12,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 8, 0, 8, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -11, -11, -11, -11,
+ax_anim 2, 0, 161, -8, -19, -8, -19,
+ax_anim 3, 0, 154, 0, -23, 0, -23,
+ax_anim 2, 3, 155, 8, -19, 8, -19,
+ax_anim 2, 0, 156, 11, -11, 11, -11,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 2, -9, 2, -9,
+ax_anim 2, 0, 155, -4, -18, -4, -18,
+ax_anim 2, 0, 154, -12, -23, -12, -23,
+ax_anim 3, 0, 161, -21, -22, -21, -22,
+ax_anim 2, 3, 160, -24, -12, -24, -12,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -8, 0, -8, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -4, -5, -4, -5,
+ax_anim 2, 0, 154, -11, -7, -11, -7,
+ax_anim 2, 0, 161, -20, -5, -20, -5,
+ax_anim 3, 0, 160, -23, 0, -23, 0,
+ax_anim 2, 3, 159, -18, 5, -18, 5,
+ax_anim 2, 0, 158, -12, 6, -12, 6,
+ax_anim 1, 0, 157, -5, 5, -5, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -11, -1, -11, -1,
+ax_anim 2, 0, 161, -22, 4, -22, 4,
+ax_anim 2, 0, 160, -28, 13, -28, 13,
+ax_anim 3, 0, 159, -23, 21, -23, 21,
+ax_anim 2, 3, 158, -12, 22, -12, 22,
+ax_anim 2, 0, 157, -6, 20, -6, 20,
+ax_anim 1, 0, 156, 1, 11, 1, 11,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -22, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_11_2:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -19, 0, 0,
+ax_anim 4, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_11_3:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -24, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_11_4:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 177, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -17, 0, 0,
+ax_anim 1, 0, 177, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_11_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -18, 0, 0,
+ax_anim 4, 0, 178, 0, -19, 0, 0,
+ax_anim 4, 0, 179, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_11_6:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_11_7:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -24, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_11_8:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShroomishAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sShroomishGfx1:
+.incbin "baserom.gba", 0x119E074, 0x200
+sShroomishSprites1:
+ax_sprite sShroomishGfx1, 0x200
+ax_sprite_terminator
+sShroomishGfx2:
+.incbin "baserom.gba", 0x119E284, 0x200
+sShroomishSprites2:
+ax_sprite sShroomishGfx2, 0x200
+ax_sprite_terminator
+sShroomishGfx3:
+.incbin "baserom.gba", 0x119E494, 0x200
+sShroomishSprites3:
+ax_sprite sShroomishGfx3, 0x200
+ax_sprite_terminator
+sShroomishGfx4:
+.incbin "baserom.gba", 0x119E6A4, 0x200
+sShroomishSprites4:
+ax_sprite sShroomishGfx4, 0x200
+ax_sprite_terminator
+sShroomishGfx5:
+.incbin "baserom.gba", 0x119E8B4, 0x100
+sShroomishSprites5:
+ax_sprite sShroomishGfx5, 0x100
+ax_sprite_terminator
+sShroomishGfx6:
+.incbin "baserom.gba", 0x119E9C4, 0x200
+sShroomishSprites6:
+ax_sprite sShroomishGfx6, 0x200
+ax_sprite_terminator
+sShroomishGfx7:
+.incbin "baserom.gba", 0x119EBD4, 0x200
+sShroomishSprites7:
+ax_sprite sShroomishGfx7, 0x200
+ax_sprite_terminator
+sShroomishGfx8:
+.incbin "baserom.gba", 0x119EDE4, 0x100
+sShroomishSprites8:
+ax_sprite sShroomishGfx8, 0x100
+ax_sprite_terminator
+sShroomishGfx9:
+.incbin "baserom.gba", 0x119EEF4, 0x100
+sShroomishSprites9:
+ax_sprite sShroomishGfx9, 0x100
+ax_sprite_terminator
+sShroomishGfx10:
+.incbin "baserom.gba", 0x119F004, 0x200
+sShroomishSprites10:
+ax_sprite sShroomishGfx10, 0x200
+ax_sprite_terminator
+sShroomishGfx11:
+.incbin "baserom.gba", 0x119F214, 0x200
+sShroomishSprites11:
+ax_sprite sShroomishGfx11, 0x200
+ax_sprite_terminator
+sShroomishGfx12:
+.incbin "baserom.gba", 0x119F424, 0x100
+sShroomishSprites12:
+ax_sprite sShroomishGfx12, 0x100
+ax_sprite_terminator
+sShroomishGfx13:
+.incbin "baserom.gba", 0x119F534, 0x200
+sShroomishSprites13:
+ax_sprite sShroomishGfx13, 0x200
+ax_sprite_terminator
+sShroomishGfx14:
+.incbin "baserom.gba", 0x119F744, 0x200
+sShroomishSprites14:
+ax_sprite sShroomishGfx14, 0x200
+ax_sprite_terminator
+sShroomishGfx15:
+.incbin "baserom.gba", 0x119F954, 0x200
+sShroomishSprites15:
+ax_sprite sShroomishGfx15, 0x200
+ax_sprite_terminator
+sShroomishGfx16:
+.incbin "baserom.gba", 0x119FB64, 0x100
+sShroomishGfx16_1:
+.incbin "baserom.gba", 0x119FC64, 0x40
+sShroomishSprites16:
+ax_sprite 0, 0x80
+ax_sprite sShroomishGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShroomishGfx17:
+.incbin "baserom.gba", 0x119FCD4, 0x160
+sShroomishSprites17:
+ax_sprite 0, 0x80
+ax_sprite sShroomishGfx17, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShroomishGfx18:
+.incbin "baserom.gba", 0x119FE54, 0x40
+sShroomishGfx18_1:
+.incbin "baserom.gba", 0x119FE94, 0x60
+sShroomishGfx18_2:
+.incbin "baserom.gba", 0x119FEF4, 0x60
+sShroomishGfx18_3:
+.incbin "baserom.gba", 0x119FF54, 0x40
+sShroomishSprites18:
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShroomishGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShroomishGfx19:
+.incbin "baserom.gba", 0x119FFE4, 0x40
+sShroomishGfx19_1:
+.incbin "baserom.gba", 0x11A0024, 0xE0
+sShroomishSprites19:
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx19_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShroomishGfx20:
+.incbin "baserom.gba", 0x11A0134, 0x40
+sShroomishGfx20_1:
+.incbin "baserom.gba", 0x11A0174, 0x100
+sShroomishSprites20:
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShroomishGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sShroomishGfx21:
+.incbin "baserom.gba", 0x11A02A4, 0x200
+sShroomishSprites21:
+ax_sprite sShroomishGfx21, 0x200
+ax_sprite_terminator
+sShroomishGfx22:
+.incbin "baserom.gba", 0x11A04B4, 0x200
+sShroomishSprites22:
+ax_sprite sShroomishGfx22, 0x200
+ax_sprite_terminator
+sShroomishGfx23:
+.incbin "baserom.gba", 0x11A06C4, 0x200
+sShroomishSprites23:
+ax_sprite sShroomishGfx23, 0x200
+ax_sprite_terminator
+sShroomishGfx24:
+.incbin "baserom.gba", 0x11A08D4, 0x200
+sShroomishSprites24:
+ax_sprite sShroomishGfx24, 0x200
+ax_sprite_terminator
+sShroomishGfx25:
+.incbin "baserom.gba", 0x11A0AE4, 0x200
+sShroomishSprites25:
+ax_sprite sShroomishGfx25, 0x200
+ax_sprite_terminator
+sShroomishGfx26:
+.incbin "baserom.gba", 0x11A0CF4, 0x200
+sShroomishSprites26:
+ax_sprite sShroomishGfx26, 0x200
+ax_sprite_terminator
+sShroomishGfx27:
+.incbin "baserom.gba", 0x11A0F04, 0x200
+sShroomishSprites27:
+ax_sprite sShroomishGfx27, 0x200
+ax_sprite_terminator
+sAxPosesShroomish:
+.4byte sShroomishPose1
+.4byte sShroomishPose2
+.4byte sShroomishPose3
+.4byte sShroomishPose4
+.4byte sShroomishPose5
+.4byte sShroomishPose6
+.4byte sShroomishPose7
+.4byte sShroomishPose8
+.4byte sShroomishPose9
+.4byte sShroomishPose10
+.4byte sShroomishPose11
+.4byte sShroomishPose12
+.4byte sShroomishPose13
+.4byte sShroomishPose14
+.4byte sShroomishPose15
+.4byte sShroomishPose16
+.4byte sShroomishPose17
+.4byte sShroomishPose18
+.4byte sShroomishPose19
+.4byte sShroomishPose20
+.4byte sShroomishPose21
+.4byte sShroomishPose22
+.4byte sShroomishPose23
+.4byte sShroomishPose24
+.4byte sShroomishPose25
+.4byte sShroomishPose26
+.4byte sShroomishPose27
+.4byte sShroomishPose28
+.4byte sShroomishPose29
+.4byte sShroomishPose30
+.4byte sShroomishPose31
+.4byte sShroomishPose32
+.4byte sShroomishPose33
+.4byte sShroomishPose34
+.4byte sShroomishPose35
+.4byte sShroomishPose36
+.4byte sShroomishPose37
+.4byte sShroomishPose38
+.4byte sShroomishPose39
+.4byte sShroomishPose40
+.4byte sShroomishPose41
+.4byte sShroomishPose42
+.4byte sShroomishPose43
+.4byte sShroomishPose44
+.4byte sShroomishPose45
+.4byte sShroomishPose46
+.4byte sShroomishPose47
+.4byte sShroomishPose48
+.4byte sShroomishPose49
+.4byte sShroomishPose50
+.4byte sShroomishPose51
+.4byte sShroomishPose52
+.4byte sShroomishPose53
+.4byte sShroomishPose54
+.4byte sShroomishPose55
+.4byte sShroomishPose56
+.4byte sShroomishPose57
+.4byte sShroomishPose58
+.4byte sShroomishPose59
+.4byte sShroomishPose60
+.4byte sShroomishPose61
+.4byte sShroomishPose62
+.4byte sShroomishPose63
+.4byte sShroomishPose64
+.4byte sShroomishPose65
+.4byte sShroomishPose66
+.4byte sShroomishPose67
+.4byte sShroomishPose68
+.4byte sShroomishPose69
+.4byte sShroomishPose70
+.4byte sShroomishPose71
+.4byte sShroomishPose72
+.4byte sShroomishPose73
+.4byte sShroomishPose74
+.4byte sShroomishPose75
+.4byte sShroomishPose76
+.4byte sShroomishPose77
+.4byte sShroomishPose78
+.4byte sShroomishPose79
+.4byte sShroomishPose80
+.4byte sShroomishPose81
+.4byte sShroomishPose82
+.4byte sShroomishPose83
+.4byte sShroomishPose84
+.4byte sShroomishPose85
+.4byte sShroomishPose86
+.4byte sShroomishPose87
+.4byte sShroomishPose88
+.4byte sShroomishPose89
+.4byte sShroomishPose90
+.4byte sShroomishPose91
+.4byte sShroomishPose92
+.4byte sShroomishPose93
+.4byte sShroomishPose94
+.4byte sShroomishPose95
+.4byte sShroomishPose96
+.4byte sShroomishPose97
+.4byte sShroomishPose98
+.4byte sShroomishPose99
+.4byte sShroomishPose100
+.4byte sShroomishPose101
+.4byte sShroomishPose102
+.4byte sShroomishPose103
+.4byte sShroomishPose104
+.4byte sShroomishPose105
+.4byte sShroomishPose106
+.4byte sShroomishPose107
+.4byte sShroomishPose108
+.4byte sShroomishPose109
+.4byte sShroomishPose110
+.4byte sShroomishPose111
+.4byte sShroomishPose112
+.4byte sShroomishPose113
+.4byte sShroomishPose114
+.4byte sShroomishPose115
+.4byte sShroomishPose116
+.4byte sShroomishPose117
+.4byte sShroomishPose118
+.4byte sShroomishPose119
+.4byte sShroomishPose120
+.4byte sShroomishPose121
+.4byte sShroomishPose122
+.4byte sShroomishPose123
+.4byte sShroomishPose124
+.4byte sShroomishPose125
+.4byte sShroomishPose126
+.4byte sShroomishPose127
+.4byte sShroomishPose128
+.4byte sShroomishPose129
+.4byte sShroomishPose130
+.4byte sShroomishPose131
+.4byte sShroomishPose132
+.4byte sShroomishPose133
+.4byte sShroomishPose134
+.4byte sShroomishPose135
+.4byte sShroomishPose136
+.4byte sShroomishPose137
+.4byte sShroomishPose138
+.4byte sShroomishPose139
+.4byte sShroomishPose140
+.4byte sShroomishPose141
+.4byte sShroomishPose142
+.4byte sShroomishPose143
+.4byte sShroomishPose144
+.4byte sShroomishPose145
+.4byte sShroomishPose146
+.4byte sShroomishPose147
+.4byte sShroomishPose148
+.4byte sShroomishPose149
+.4byte sShroomishPose150
+.4byte sShroomishPose151
+.4byte sShroomishPose152
+.4byte sShroomishPose153
+.4byte sShroomishPose154
+.4byte sShroomishPose155
+.4byte sShroomishPose156
+.4byte sShroomishPose157
+.4byte sShroomishPose158
+.4byte sShroomishPose159
+.4byte sShroomishPose160
+.4byte sShroomishPose161
+.4byte sShroomishPose162
+.4byte sShroomishPose163
+.4byte sShroomishPose164
+.4byte sShroomishPose165
+.4byte sShroomishPose166
+.4byte sShroomishPose167
+.4byte sShroomishPose168
+.4byte sShroomishPose169
+.4byte sShroomishPose170
+.4byte sShroomishPose171
+.4byte sShroomishPose172
+.4byte sShroomishPose173
+.4byte sShroomishPose174
+.4byte sShroomishPose175
+.4byte sShroomishPose176
+.4byte sShroomishPose177
+.4byte sShroomishPose178
+.4byte sShroomishPose179
+.4byte sShroomishPose180
+.4byte sShroomishPose181
+.4byte sShroomishPose182
+.4byte sShroomishPose183
+.4byte sShroomishPose184
+.4byte sShroomishPose185
+.4byte sShroomishPose186
+.4byte sShroomishPose187
+.4byte sShroomishPose188
+.4byte sShroomishPose189
+.4byte sShroomishPose190
+.4byte sShroomishPose191
+.4byte sShroomishPose192
+.4byte sShroomishPose193
+.4byte sShroomishPose194
+.4byte sShroomishPose195
+.4byte sShroomishPose196
+.4byte sShroomishPose197
+.4byte sShroomishPose198
+.4byte sShroomishPose199
+.4byte sShroomishPose200
+.4byte sShroomishPose201
+.4byte sShroomishPose202
+sAxPositionsShroomish:
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte    0,   -4, 	  -8,   -3, 	   7,   -4, 	   0,   -5
+.2byte   -1,   -4, 	  -8,   -4, 	   7,   -3, 	  -1,   -5
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    3,   -4, 	   7,   -5, 	  -7,   -2, 	  -1,   -5
+.2byte    5,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    6,   -5, 	   2,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte    7,   -5, 	  -1,   -7, 	  -2,    0, 	  -1,   -6
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -9, 	   5,   -1, 	   0,   -6
+.2byte    2,   -7, 	  -7,   -7, 	   6,   -1, 	   0,   -6
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	   7,   -3, 	  -8,   -5, 	   0,   -6
+.2byte    0,   -5, 	   7,   -4, 	  -8,   -2, 	  -1,   -6
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -4,   -7, 	   3,   -9, 	  -6,   -1, 	  -1,   -6
+.2byte   -3,   -7, 	   6,   -7, 	  -7,   -1, 	  -1,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -7,   -5, 	  -3,   -7, 	   3,   -1, 	   0,   -6
+.2byte   -8,   -5, 	   0,   -7, 	   1,    0, 	   0,   -6
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -4,   -4, 	  -8,   -5, 	   6,   -2, 	   0,   -5
+.2byte   -6,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte    0,   -4, 	  -8,   -3, 	   7,   -4, 	   0,   -5
+.2byte   -1,   -4, 	  -8,   -4, 	   7,   -3, 	  -1,   -5
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    3,   -4, 	   7,   -5, 	  -7,   -2, 	  -1,   -5
+.2byte    5,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    6,   -5, 	   2,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte    7,   -5, 	  -1,   -7, 	  -2,    0, 	  -1,   -6
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -9, 	   5,   -1, 	   0,   -6
+.2byte    2,   -7, 	  -7,   -7, 	   6,   -1, 	   0,   -6
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	   7,   -3, 	  -8,   -5, 	   0,   -6
+.2byte    0,   -5, 	   7,   -4, 	  -8,   -2, 	  -1,   -6
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -4,   -7, 	   3,   -9, 	  -6,   -1, 	  -1,   -6
+.2byte   -3,   -7, 	   6,   -7, 	  -7,   -1, 	  -1,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -7,   -5, 	  -3,   -7, 	   3,   -1, 	   0,   -6
+.2byte   -8,   -5, 	   0,   -7, 	   1,    0, 	   0,   -6
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -4,   -4, 	  -8,   -5, 	   6,   -2, 	   0,   -5
+.2byte   -6,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte    0,   -4, 	  -8,   -3, 	   7,   -4, 	   0,   -5
+.2byte   -1,   -4, 	  -8,   -4, 	   7,   -3, 	  -1,   -5
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    3,   -4, 	   7,   -5, 	  -7,   -2, 	  -1,   -5
+.2byte    5,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    6,   -5, 	   2,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte    7,   -5, 	  -1,   -7, 	  -2,    0, 	  -1,   -6
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -9, 	   5,   -1, 	   0,   -6
+.2byte    2,   -7, 	  -7,   -7, 	   6,   -1, 	   0,   -6
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	   7,   -3, 	  -8,   -5, 	   0,   -6
+.2byte    0,   -5, 	   7,   -4, 	  -8,   -2, 	  -1,   -6
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -4,   -7, 	   3,   -9, 	  -6,   -1, 	  -1,   -6
+.2byte   -3,   -7, 	   6,   -7, 	  -7,   -1, 	  -1,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -7,   -5, 	  -3,   -7, 	   3,   -1, 	   0,   -6
+.2byte   -8,   -5, 	   0,   -7, 	   1,    0, 	   0,   -6
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -4,   -4, 	  -8,   -5, 	   6,   -2, 	   0,   -5
+.2byte   -6,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte    0,   -4, 	  -8,   -3, 	   7,   -4, 	   0,   -5
+.2byte   -1,   -4, 	  -8,   -4, 	   7,   -3, 	  -1,   -5
+.2byte   -1,   -1, 	  -9,   -4, 	   8,   -4, 	  -1,   -5
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    3,   -4, 	   7,   -5, 	  -7,   -2, 	  -1,   -5
+.2byte    5,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    5,   -2, 	   7,   -7, 	  -6,   -3, 	   0,   -6
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    6,   -5, 	   2,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte    7,   -5, 	  -1,   -7, 	  -2,    0, 	  -1,   -6
+.2byte    7,   -4, 	   7,   -8, 	   0,   -2, 	   1,   -8
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -9, 	   5,   -1, 	   0,   -6
+.2byte    2,   -7, 	  -7,   -7, 	   6,   -1, 	   0,   -6
+.2byte    0,   -6, 	  -7,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	   7,   -3, 	  -8,   -5, 	   0,   -6
+.2byte    0,   -5, 	   7,   -4, 	  -8,   -2, 	  -1,   -6
+.2byte   -1,   -7, 	   8,   -8, 	  -9,   -8, 	  -1,  -10
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -4,   -7, 	   3,   -9, 	  -6,   -1, 	  -1,   -6
+.2byte   -3,   -7, 	   6,   -7, 	  -7,   -1, 	  -1,   -6
+.2byte   -1,   -6, 	   6,   -8, 	  -8,   -5, 	   0,   -9
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -7,   -5, 	  -3,   -7, 	   3,   -1, 	   0,   -6
+.2byte   -8,   -5, 	   0,   -7, 	   1,    0, 	   0,   -6
+.2byte   -8,   -4, 	  -8,   -8, 	  -1,   -2, 	  -2,   -8
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -4,   -4, 	  -8,   -5, 	   6,   -2, 	   0,   -5
+.2byte   -6,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -6,   -2, 	  -8,   -7, 	   5,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -4, 	   8,   -4, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,   -7, 	   5,   -3, 	  -1,   -6
+.2byte   -8,   -4, 	  -8,   -8, 	  -1,   -2, 	  -2,   -8
+.2byte   -2,   -6, 	   5,   -8, 	  -9,   -5, 	  -1,   -9
+.2byte   -1,   -7, 	   8,   -8, 	  -9,   -8, 	  -1,  -10
+.2byte    1,   -6, 	  -6,   -8, 	   8,   -5, 	   0,   -9
+.2byte    7,   -4, 	   7,   -8, 	   0,   -2, 	   1,   -8
+.2byte    5,   -2, 	   7,   -7, 	  -6,   -3, 	   0,   -6
+.2byte   -4,   -2, 	  -7,   -5, 	   5,    0, 	   0,   -5
+.2byte   -5,   -1, 	  -7,   -4, 	   6,    1, 	   0,   -4
+.2byte   -1,   -9, 	  -8,   -6, 	   7,   -6, 	  -1,  -10
+.2byte    3,   -9, 	   8,   -9, 	  -7,   -4, 	  -1,   -9
+.2byte    4,  -11, 	   1,   -9, 	   3,   -2, 	  -1,   -9
+.2byte    3,  -13, 	  -5,  -11, 	   3,   -2, 	  -1,   -9
+.2byte   -1,  -13, 	   7,   -8, 	  -8,   -8, 	  -1,   -9
+.2byte   -4,  -13, 	   4,  -11, 	  -4,   -2, 	   0,   -9
+.2byte   -5,  -11, 	  -2,   -9, 	  -4,   -2, 	   0,   -9
+.2byte   -4,   -9, 	  -9,   -9, 	   6,   -4, 	   0,   -9
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte    0,   -4, 	  -8,   -3, 	   7,   -4, 	   0,   -5
+.2byte   -1,   -4, 	  -8,   -4, 	   7,   -3, 	  -1,   -5
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    3,   -4, 	   7,   -5, 	  -7,   -2, 	  -1,   -5
+.2byte    5,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    6,   -5, 	   2,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte    7,   -5, 	  -1,   -7, 	  -2,    0, 	  -1,   -6
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte    3,   -7, 	  -4,   -9, 	   5,   -1, 	   0,   -6
+.2byte    2,   -7, 	  -7,   -7, 	   6,   -1, 	   0,   -6
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	   7,   -3, 	  -8,   -5, 	   0,   -6
+.2byte    0,   -5, 	   7,   -4, 	  -8,   -2, 	  -1,   -6
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -4,   -7, 	   3,   -9, 	  -6,   -1, 	  -1,   -6
+.2byte   -3,   -7, 	   6,   -7, 	  -7,   -1, 	  -1,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -7,   -5, 	  -3,   -7, 	   3,   -1, 	   0,   -6
+.2byte   -8,   -5, 	   0,   -7, 	   1,    0, 	   0,   -6
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -4,   -4, 	  -8,   -5, 	   6,   -2, 	   0,   -5
+.2byte   -6,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -1,   -1, 	  -9,   -4, 	   8,   -4, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,   -7, 	   5,   -3, 	  -1,   -6
+.2byte   -8,   -4, 	  -8,   -8, 	  -1,   -2, 	  -2,   -8
+.2byte   -1,   -6, 	   6,   -8, 	  -8,   -5, 	   0,   -9
+.2byte   -1,   -7, 	   8,   -8, 	  -9,   -8, 	  -1,  -10
+.2byte    0,   -6, 	  -7,   -8, 	   7,   -5, 	  -1,   -9
+.2byte    7,   -4, 	   7,   -8, 	   0,   -2, 	   1,   -8
+.2byte    5,   -2, 	   7,   -7, 	  -6,   -3, 	   0,   -6
+.2byte   -1,   -1, 	  -9,   -4, 	   8,   -4, 	  -1,   -5
+.2byte    4,   -2, 	   6,   -7, 	  -7,   -3, 	  -1,   -6
+.2byte    5,   -4, 	   5,   -8, 	  -2,   -2, 	  -1,   -8
+.2byte    0,   -6, 	  -7,   -8, 	   7,   -5, 	  -1,   -9
+.2byte   -1,   -7, 	   8,   -8, 	  -9,   -8, 	  -1,  -10
+.2byte   -1,   -6, 	   6,   -8, 	  -8,   -5, 	   0,   -9
+.2byte   -6,   -4, 	  -6,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -5,   -2, 	  -7,   -7, 	   6,   -3, 	   0,   -6
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -4, 	   8,   -4, 	  -1,   -5
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+.2byte    4,   -2, 	   6,   -7, 	  -7,   -3, 	  -1,   -6
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    5,   -4, 	   5,   -8, 	  -2,   -2, 	  -1,   -8
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte   -1,   -3, 	  -8,   -5, 	   6,   -2, 	  -2,   -6
+.2byte   -1,   -7, 	   7,   -6, 	  -8,   -6, 	  -1,   -8
+.2byte   -1,   -4, 	   8,   -5, 	  -9,   -5, 	  -1,   -7
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -2,   -3, 	   5,   -5, 	  -9,   -2, 	  -1,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -6,   -4, 	  -6,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -5,   -2, 	  -7,   -7, 	   6,   -3, 	   0,   -6
+.2byte   -1,   -1, 	  -9,   -4, 	   8,   -4, 	  -1,   -5
+.2byte   -5,   -2, 	  -7,   -7, 	   6,   -3, 	   0,   -6
+.2byte   -6,   -4, 	  -6,   -8, 	   1,   -2, 	   0,   -8
+.2byte   -1,   -6, 	   6,   -8, 	  -8,   -5, 	   0,   -9
+.2byte   -1,   -7, 	   8,   -8, 	  -9,   -8, 	  -1,  -10
+.2byte    1,   -6, 	  -6,   -8, 	   8,   -5, 	   0,   -9
+.2byte    6,   -4, 	   6,   -8, 	  -1,   -2, 	   0,   -8
+.2byte    4,   -2, 	   6,   -7, 	  -7,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,   -4, 	   7,   -4, 	  -1,   -6
+.2byte   -5,   -5, 	  -7,   -6, 	   5,   -2, 	   0,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	   2,   -2, 	   0,   -7
+.2byte   -4,   -7, 	   5,   -9, 	  -8,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	   7,   -5, 	  -8,   -5, 	  -1,   -7
+.2byte    3,   -7, 	  -6,   -9, 	   7,   -3, 	   0,   -7
+.2byte    6,   -6, 	   2,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte    4,   -5, 	   6,   -6, 	  -6,   -2, 	  -1,   -6
+sShroomishAnimTable1:
+.4byte sShroomishAnims_1_1
+.4byte sShroomishAnims_1_2
+.4byte sShroomishAnims_1_3
+.4byte sShroomishAnims_1_4
+.4byte sShroomishAnims_1_5
+.4byte sShroomishAnims_1_6
+.4byte sShroomishAnims_1_7
+.4byte sShroomishAnims_1_8
+sShroomishAnimTable2:
+.4byte sShroomishAnims_2_1
+.4byte sShroomishAnims_2_2
+.4byte sShroomishAnims_2_3
+.4byte sShroomishAnims_2_4
+.4byte sShroomishAnims_2_5
+.4byte sShroomishAnims_2_6
+.4byte sShroomishAnims_2_7
+.4byte sShroomishAnims_2_8
+sShroomishAnimTable3:
+.4byte sShroomishAnims_3_1
+.4byte sShroomishAnims_3_2
+.4byte sShroomishAnims_3_3
+.4byte sShroomishAnims_3_4
+.4byte sShroomishAnims_3_5
+.4byte sShroomishAnims_3_6
+.4byte sShroomishAnims_3_7
+.4byte sShroomishAnims_3_8
+sShroomishAnimTable4:
+.4byte sShroomishAnims_4_1
+.4byte sShroomishAnims_4_2
+.4byte sShroomishAnims_4_3
+.4byte sShroomishAnims_4_4
+.4byte sShroomishAnims_4_5
+.4byte sShroomishAnims_4_6
+.4byte sShroomishAnims_4_7
+.4byte sShroomishAnims_4_8
+sShroomishAnimTable5:
+.4byte sShroomishAnims_5_1
+.4byte sShroomishAnims_5_2
+.4byte sShroomishAnims_5_3
+.4byte sShroomishAnims_5_4
+.4byte sShroomishAnims_5_5
+.4byte sShroomishAnims_5_6
+.4byte sShroomishAnims_5_7
+.4byte sShroomishAnims_5_8
+sShroomishAnimTable6:
+.4byte sShroomishAnims_6_1
+.4byte sShroomishAnims_6_1
+.4byte sShroomishAnims_6_1
+.4byte sShroomishAnims_6_1
+.4byte sShroomishAnims_6_1
+.4byte sShroomishAnims_6_1
+.4byte sShroomishAnims_6_1
+.4byte sShroomishAnims_6_1
+sShroomishAnimTable7:
+.4byte sShroomishAnims_7_1
+.4byte sShroomishAnims_7_2
+.4byte sShroomishAnims_7_3
+.4byte sShroomishAnims_7_4
+.4byte sShroomishAnims_7_5
+.4byte sShroomishAnims_7_6
+.4byte sShroomishAnims_7_7
+.4byte sShroomishAnims_7_8
+sShroomishAnimTable8:
+.4byte sShroomishAnims_8_1
+.4byte sShroomishAnims_8_2
+.4byte sShroomishAnims_8_3
+.4byte sShroomishAnims_8_4
+.4byte sShroomishAnims_8_5
+.4byte sShroomishAnims_8_6
+.4byte sShroomishAnims_8_7
+.4byte sShroomishAnims_8_8
+sShroomishAnimTable9:
+.4byte sShroomishAnims_9_1
+.4byte sShroomishAnims_9_2
+.4byte sShroomishAnims_9_3
+.4byte sShroomishAnims_9_4
+.4byte sShroomishAnims_9_5
+.4byte sShroomishAnims_9_6
+.4byte sShroomishAnims_9_7
+.4byte sShroomishAnims_9_8
+sShroomishAnimTable10:
+.4byte sShroomishAnims_10_1
+.4byte sShroomishAnims_10_2
+.4byte sShroomishAnims_10_3
+.4byte sShroomishAnims_10_4
+.4byte sShroomishAnims_10_5
+.4byte sShroomishAnims_10_6
+.4byte sShroomishAnims_10_7
+.4byte sShroomishAnims_10_8
+sShroomishAnimTable11:
+.4byte sShroomishAnims_11_1
+.4byte sShroomishAnims_11_2
+.4byte sShroomishAnims_11_3
+.4byte sShroomishAnims_11_4
+.4byte sShroomishAnims_11_5
+.4byte sShroomishAnims_11_6
+.4byte sShroomishAnims_11_7
+.4byte sShroomishAnims_11_8
+sShroomishAnimTable12:
+.4byte sShroomishAnims_12_1
+.4byte sShroomishAnims_12_2
+.4byte sShroomishAnims_12_3
+.4byte sShroomishAnims_12_4
+.4byte sShroomishAnims_12_5
+.4byte sShroomishAnims_12_6
+.4byte sShroomishAnims_12_7
+.4byte sShroomishAnims_12_8
+sShroomishAnimTable13:
+.4byte sShroomishAnims_13_1
+.4byte sShroomishAnims_13_2
+.4byte sShroomishAnims_13_3
+.4byte sShroomishAnims_13_4
+.4byte sShroomishAnims_13_5
+.4byte sShroomishAnims_13_6
+.4byte sShroomishAnims_13_7
+.4byte sShroomishAnims_13_8
+sAxAnimationsShroomish:
+.4byte sShroomishAnimTable1
+.4byte sShroomishAnimTable2
+.4byte sShroomishAnimTable3
+.4byte sShroomishAnimTable4
+.4byte sShroomishAnimTable5
+.4byte sShroomishAnimTable6
+.4byte sShroomishAnimTable7
+.4byte sShroomishAnimTable8
+.4byte sShroomishAnimTable9
+.4byte sShroomishAnimTable10
+.4byte sShroomishAnimTable11
+.4byte sShroomishAnimTable12
+.4byte sShroomishAnimTable13
+sAxSpritesShroomish:
+.4byte sShroomishSprites1
+.4byte sShroomishSprites2
+.4byte sShroomishSprites3
+.4byte sShroomishSprites4
+.4byte sShroomishSprites5
+.4byte sShroomishSprites6
+.4byte sShroomishSprites7
+.4byte sShroomishSprites8
+.4byte sShroomishSprites9
+.4byte sShroomishSprites10
+.4byte sShroomishSprites11
+.4byte sShroomishSprites12
+.4byte sShroomishSprites13
+.4byte sShroomishSprites14
+.4byte sShroomishSprites15
+.4byte sShroomishSprites16
+.4byte sShroomishSprites17
+.4byte sShroomishSprites18
+.4byte sShroomishSprites19
+.4byte sShroomishSprites20
+.4byte sShroomishSprites21
+.4byte sShroomishSprites22
+.4byte sShroomishSprites23
+.4byte sShroomishSprites24
+.4byte sShroomishSprites25
+.4byte sShroomishSprites26
+.4byte sShroomishSprites27
+sAxMainShroomish:
+ax_main sAxPosesShroomish, sAxAnimationsShroomish, 13, sAxSpritesShroomish, sAxPositionsShroomish

--- a/data/ax/shuckle.inc
+++ b/data/ax/shuckle.inc
@@ -1,0 +1,2859 @@
+.global gAxShuckle
+gAxShuckle:
+ax_siro sAxMainShuckle
+sShucklePose1:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose2:
+ax_pose 1, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose3:
+ax_pose 2, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose4:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose5:
+ax_pose 4, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose6:
+ax_pose 5, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose7:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose8:
+ax_pose 7, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose9:
+ax_pose 8, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose10:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose11:
+ax_pose 10, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose12:
+ax_pose 11, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose16:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose17:
+ax_pose 10, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose18:
+ax_pose 11, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose19:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose20:
+ax_pose 7, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose21:
+ax_pose 8, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose22:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose23:
+ax_pose 4, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose24:
+ax_pose 5, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose25:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose26:
+ax_pose 15, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose27:
+ax_pose 16, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose28:
+ax_pose 17, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose29:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose30:
+ax_pose 18, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose31:
+ax_pose 19, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose32:
+ax_pose 20, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose33:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose34:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose35:
+ax_pose 22, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose36:
+ax_pose 23, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose37:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose38:
+ax_pose 24, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose39:
+ax_pose 25, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose40:
+ax_pose 26, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose42:
+ax_pose 27, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose43:
+ax_pose 28, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose44:
+ax_pose 29, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose45:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose46:
+ax_pose 24, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose47:
+ax_pose 25, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose48:
+ax_pose 26, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose49:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose50:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose51:
+ax_pose 22, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose52:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose53:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose54:
+ax_pose 18, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose55:
+ax_pose 19, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose56:
+ax_pose 20, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose57:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose58:
+ax_pose 15, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose59:
+ax_pose 16, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose60:
+ax_pose 17, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose61:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose62:
+ax_pose 18, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose63:
+ax_pose 19, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose64:
+ax_pose 20, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose65:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose66:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose67:
+ax_pose 22, 0x01f0, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose68:
+ax_pose 23, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose69:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose70:
+ax_pose 24, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose71:
+ax_pose 25, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose72:
+ax_pose 26, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose74:
+ax_pose 27, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose75:
+ax_pose 28, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose76:
+ax_pose 29, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose77:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose78:
+ax_pose 24, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose79:
+ax_pose 25, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose80:
+ax_pose 26, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose81:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose82:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose83:
+ax_pose 22, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose84:
+ax_pose 23, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose85:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose86:
+ax_pose 18, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose87:
+ax_pose 19, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose88:
+ax_pose 20, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose89:
+ax_pose 17, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose90:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose91:
+ax_pose 23, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sShucklePose92:
+ax_pose 26, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose93:
+ax_pose 29, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose94:
+ax_pose 26, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose95:
+ax_pose 23, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sShucklePose96:
+ax_pose 20, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose97:
+ax_pose 30, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose98:
+ax_pose 31, 0x01f1, 0x80ef, 0x0c00
+ax_pose_terminator
+sShucklePose99:
+ax_pose 32, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose100:
+ax_pose 33, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose101:
+ax_pose 34, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose102:
+ax_pose 33, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose103:
+ax_pose 32, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose104:
+ax_pose 31, 0x01f1, 0x90f1, 0x0c00
+ax_pose_terminator
+sShucklePose105:
+ax_pose 35, 0x01ef, 0x80f5, 0x0c00
+ax_pose_terminator
+sShucklePose106:
+ax_pose 36, 0x01ef, 0x80f5, 0x0c00
+ax_pose_terminator
+sShucklePose107:
+ax_pose 37, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose108:
+ax_pose 38, 0x01e8, 0x90e8, 0x0c00
+ax_pose_terminator
+sShucklePose109:
+ax_pose 39, 0x01ed, 0x90e7, 0x0c00
+ax_pose_terminator
+sShucklePose110:
+ax_pose 40, 0x01ee, 0x90e8, 0x0c00
+ax_pose_terminator
+sShucklePose111:
+ax_pose 41, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose112:
+ax_pose 40, 0x01ee, 0x80f8, 0x0c00
+ax_pose_terminator
+sShucklePose113:
+ax_pose 39, 0x01ed, 0x80f9, 0x0c00
+ax_pose_terminator
+sShucklePose114:
+ax_pose 38, 0x01e8, 0x80f8, 0x0c00
+ax_pose_terminator
+sShucklePose115:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose116:
+ax_pose 15, 0x01f1, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose117:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose118:
+ax_pose 18, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose119:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose120:
+ax_pose 21, 0x01ed, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose121:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose122:
+ax_pose 24, 0x01ed, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose123:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose124:
+ax_pose 27, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose125:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose126:
+ax_pose 24, 0x01ed, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose127:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose128:
+ax_pose 21, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose129:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose130:
+ax_pose 18, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose131:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose132:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose133:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose134:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose135:
+ax_pose 12, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose136:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose137:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose138:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose139:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose140:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose141:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose142:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose143:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose144:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose145:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose146:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose147:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose148:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose149:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose150:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose151:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose152:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose153:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose154:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose155:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose156:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose157:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose158:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose159:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose160:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose161:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose162:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose163:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose164:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose165:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose166:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose167:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose168:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose169:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose170:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose171:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose172:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose173:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose174:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose175:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose176:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose177:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose178:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose179:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose180:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose181:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose182:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose183:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose184:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose185:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose186:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose187:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose188:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose189:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose190:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose191:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose192:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose193:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose194:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose195:
+ax_pose 15, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose196:
+ax_pose 18, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose197:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose198:
+ax_pose 24, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose199:
+ax_pose 27, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose200:
+ax_pose 24, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose201:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose202:
+ax_pose 18, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose203:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose204:
+ax_pose 15, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose205:
+ax_pose 16, 0x01f1, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose206:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose207:
+ax_pose 18, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose208:
+ax_pose 19, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose209:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose210:
+ax_pose 21, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose211:
+ax_pose 22, 0x01f1, 0x90ec, 0x0c00
+ax_pose_terminator
+sShucklePose212:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose213:
+ax_pose 24, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose214:
+ax_pose 25, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose215:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose216:
+ax_pose 27, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose217:
+ax_pose 28, 0x01f1, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose218:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose219:
+ax_pose 24, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose220:
+ax_pose 25, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose221:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose222:
+ax_pose 21, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose223:
+ax_pose 22, 0x01f1, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose224:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose225:
+ax_pose 18, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose226:
+ax_pose 19, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose227:
+ax_pose 17, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose228:
+ax_pose 20, 0x01ef, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose229:
+ax_pose 23, 0x01ee, 0x80f1, 0x0c00
+ax_pose_terminator
+sShucklePose230:
+ax_pose 26, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose231:
+ax_pose 29, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose232:
+ax_pose 26, 0x01ea, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose233:
+ax_pose 23, 0x01ee, 0x90ef, 0x0c00
+ax_pose_terminator
+sShucklePose234:
+ax_pose 20, 0x01ef, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose235:
+ax_pose 0, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose236:
+ax_pose 3, 0x01f1, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose237:
+ax_pose 6, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose238:
+ax_pose 9, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sShucklePose239:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sShucklePose240:
+ax_pose 9, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose241:
+ax_pose 6, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sShucklePose242:
+ax_pose 3, 0x01f1, 0x90f0, 0x0c00
+ax_pose_terminator
+.align 2
+sShuckleAnims_1_1:
+ax_anim 14, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_1_2:
+ax_anim 14, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_1_3:
+ax_anim 14, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_1_4:
+ax_anim 14, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_1_5:
+ax_anim 14, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_1_6:
+ax_anim 14, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_1_7:
+ax_anim 14, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_1_8:
+ax_anim 14, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 1, 27, 1, 15, 1, 15,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 0, 27, 1, 15, 1, 15,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sShuckleAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 17, 18, 18,
+ax_anim 2, 1, 31, 20, 16, 19, 17,
+ax_anim 2, 0, 31, 19, 17, 18, 18,
+ax_anim 2, 0, 31, 20, 16, 19, 17,
+ax_anim 2, 0, 28, 7, 6, 7, 6,
+ax_anim_terminator
+sShuckleAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 4, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sShuckleAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 18, -23, 18, -23,
+ax_anim 2, 1, 39, 19, -22, 19, -22,
+ax_anim 2, 0, 39, 18, -23, 18, -23,
+ax_anim 2, 0, 39, 19, -22, 19, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sShuckleAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 4, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 1, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 43, 1, -24, 1, -24,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sShuckleAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 4, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 1, 47, -19, -22, -19, -22,
+ax_anim 2, 0, 47, -18, -23, -18, -23,
+ax_anim 2, 0, 47, -19, -22, -19, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sShuckleAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 4, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sShuckleAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -19, 17, -18, 18,
+ax_anim 2, 1, 55, -20, 16, -19, 17,
+ax_anim 2, 0, 55, -19, 17, -18, 18,
+ax_anim 2, 0, 55, -20, 16, -19, 17,
+ax_anim 2, 0, 52, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sShuckleAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 4, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 1, 59, 1, 15, 1, 15,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 0, 59, 1, 15, 1, 15,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sShuckleAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 4, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 19, 17, 18, 18,
+ax_anim 2, 1, 63, 20, 16, 19, 17,
+ax_anim 2, 0, 63, 19, 17, 18, 18,
+ax_anim 2, 0, 63, 20, 16, 19, 17,
+ax_anim 2, 0, 60, 7, 6, 7, 6,
+ax_anim_terminator
+sShuckleAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 4, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sShuckleAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 4, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 68, 0, -1, 0, -1,
+ax_anim 1, 2, 71, 4, -6, 4, -6,
+ax_anim 1, 0, 71, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 18, -23, 18, -23,
+ax_anim 2, 1, 71, 19, -22, 19, -22,
+ax_anim 2, 0, 71, 18, -23, 18, -23,
+ax_anim 2, 0, 71, 19, -22, 19, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sShuckleAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 4, 0, 73, 0, 2, 0, 2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -24, 0, -24,
+ax_anim 2, 1, 75, 1, -24, 1, -24,
+ax_anim 2, 0, 75, 0, -24, 0, -24,
+ax_anim 2, 0, 75, 1, -24, 1, -24,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sShuckleAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 4, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 76, 0, -1, 0, -1,
+ax_anim 1, 2, 79, -4, -6, -4, -6,
+ax_anim 1, 0, 79, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -18, -23, -18, -23,
+ax_anim 2, 1, 79, -19, -22, -19, -22,
+ax_anim 2, 0, 79, -18, -23, -18, -23,
+ax_anim 2, 0, 79, -19, -22, -19, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sShuckleAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 4, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sShuckleAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 4, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -19, 17, -18, 18,
+ax_anim 2, 1, 87, -20, 16, -19, 17,
+ax_anim 2, 0, 87, -19, 17, -18, 18,
+ax_anim 2, 0, 87, -20, 16, -19, 17,
+ax_anim 2, 0, 84, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sShuckleAnims_4_1:
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_4_2:
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_4_3:
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_4_4:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_4_5:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_4_6:
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_4_7:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_4_8:
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 1, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sShuckleAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 1, 103, 1, -1, 1, -1,
+ax_anim_terminator
+sShuckleAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 1, 102, 0, -1, 0, -1,
+ax_anim_terminator
+sShuckleAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 1, 1, 1, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, 1, 1, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 1, 101, 1, 1, 1, 0,
+ax_anim_terminator
+sShuckleAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 1, 100, 1, 0, 1, 0,
+ax_anim_terminator
+sShuckleAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 99, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 1, 99, -1, 1, -1, 1,
+ax_anim_terminator
+sShuckleAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 1, 98, 0, -1, 0, -1,
+ax_anim_terminator
+sShuckleAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 1, 97, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sShuckleAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sShuckleAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sShuckleAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sShuckleAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sShuckleAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sShuckleAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sShuckleAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sShuckleAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sShuckleAnims_8_1:
+ax_anim 40, 0, 114, 0, 0, 0, 0,
+ax_anim 14, 0, 115, 0, 0, 0, 0,
+ax_anim 20, 0, 114, 0, 0, 0, 0,
+ax_anim 14, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_8_2:
+ax_anim 40, 0, 116, 0, 0, 0, 0,
+ax_anim 14, 0, 117, 0, 0, 0, 0,
+ax_anim 20, 0, 116, 0, 0, 0, 0,
+ax_anim 14, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_8_3:
+ax_anim 40, 0, 118, 0, 0, 0, 0,
+ax_anim 14, 0, 119, 0, 0, 0, 0,
+ax_anim 20, 0, 118, 0, 0, 0, 0,
+ax_anim 14, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_8_4:
+ax_anim 40, 0, 120, 0, 0, 0, 0,
+ax_anim 14, 0, 121, 0, 0, 0, 0,
+ax_anim 20, 0, 120, 0, 0, 0, 0,
+ax_anim 14, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_8_5:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 14, 0, 123, 0, 0, 0, 0,
+ax_anim 20, 0, 122, 0, 0, 0, 0,
+ax_anim 14, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_8_6:
+ax_anim 40, 0, 124, 0, 0, 0, 0,
+ax_anim 14, 0, 125, 0, 0, 0, 0,
+ax_anim 20, 0, 124, 0, 0, 0, 0,
+ax_anim 14, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_8_7:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 14, 0, 127, 0, 0, 0, 0,
+ax_anim 20, 0, 126, 0, 0, 0, 0,
+ax_anim 14, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_8_8:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 14, 0, 129, 0, 0, 0, 0,
+ax_anim 20, 0, 128, 0, 0, 0, 0,
+ax_anim 14, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 3, 6, 3,
+ax_anim 2, 0, 132, 8, 9, 8, 9,
+ax_anim 2, 0, 133, 7, 15, 7, 15,
+ax_anim 3, 0, 134, 0, 17, 0, 17,
+ax_anim 2, 3, 135, -7, 15, -7, 15,
+ax_anim 2, 0, 136, -8, 9, -8, 9,
+ax_anim 1, 0, 137, -6, 3, -6, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 8, 0, 8, 0,
+ax_anim 2, 0, 131, 17, 3, 17, 3,
+ax_anim 2, 0, 132, 21, 10, 21, 10,
+ax_anim 3, 0, 133, 20, 18, 20, 18,
+ax_anim 2, 3, 134, 11, 19, 11, 19,
+ax_anim 2, 0, 135, 3, 15, 3, 15,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -5, 3, -5,
+ax_anim 2, 0, 130, 11, -6, 11, -6,
+ax_anim 2, 0, 131, 17, -5, 17, -5,
+ax_anim 3, 0, 132, 20, -2, 20, -2,
+ax_anim 2, 3, 133, 17, 4, 17, 4,
+ax_anim 2, 0, 134, 12, 5, 12, 5,
+ax_anim 1, 0, 135, 4, 4, 4, 4,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 4, -16, 4, -16,
+ax_anim 2, 0, 130, 12, -23, 12, -23,
+ax_anim 3, 0, 131, 20, -24, 20, -24,
+ax_anim 2, 3, 132, 21, -17, 21, -17,
+ax_anim 2, 0, 133, 16, -5, 16, -5,
+ax_anim 1, 0, 134, 7, -1, 7, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -8, -4, -8, -4,
+ax_anim 2, 0, 136, -9, -12, -9, -12,
+ax_anim 2, 0, 137, -7, -20, -7, -20,
+ax_anim 3, 0, 130, 0, -24, 0, -24,
+ax_anim 2, 3, 131, 7, -20, 7, -20,
+ax_anim 2, 0, 132, 9, -10, 9, -10,
+ax_anim 1, 0, 133, 8, -4, 8, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -8, 1, -6,
+ax_anim 2, 0, 131, -4, -16, -4, -16,
+ax_anim 2, 0, 130, -12, -23, -12, -22,
+ax_anim 3, 0, 137, -20, -24, -18, -22,
+ax_anim 2, 3, 136, -21, -17, -20, -15,
+ax_anim 2, 0, 135, -16, -5, -17, -4,
+ax_anim 1, 0, 134, -7, -1, -7, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -5, -3, -5,
+ax_anim 2, 0, 130, -11, -6, -11, -6,
+ax_anim 2, 0, 137, -17, -5, -16, -5,
+ax_anim 3, 0, 136, -20, -2, -18, -2,
+ax_anim 2, 3, 135, -17, 4, -16, 4,
+ax_anim 2, 0, 134, -12, 5, -12, 5,
+ax_anim 1, 0, 133, -4, 4, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -8, 0, -8, 0,
+ax_anim 2, 0, 137, -17, 3, -17, 3,
+ax_anim 2, 0, 136, -21, 10, -19, 10,
+ax_anim 3, 0, 135, -20, 18, -17, 19,
+ax_anim 2, 3, 134, -11, 19, -11, 19,
+ax_anim 2, 0, 133, -3, 15, -3, 15,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -24, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -24, 0, 0,
+ax_anim 3, 0, 216, 0, -23, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuckleAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sShuckleGfx1:
+.incbin "baserom.gba", 0xE9BB24, 0x200
+sShuckleSprites1:
+ax_sprite sShuckleGfx1, 0x200
+ax_sprite_terminator
+sShuckleGfx2:
+.incbin "baserom.gba", 0xE9BD34, 0x200
+sShuckleSprites2:
+ax_sprite sShuckleGfx2, 0x200
+ax_sprite_terminator
+sShuckleGfx3:
+.incbin "baserom.gba", 0xE9BF44, 0x200
+sShuckleSprites3:
+ax_sprite sShuckleGfx3, 0x200
+ax_sprite_terminator
+sShuckleGfx4:
+.incbin "baserom.gba", 0xE9C154, 0x200
+sShuckleSprites4:
+ax_sprite sShuckleGfx4, 0x200
+ax_sprite_terminator
+sShuckleGfx5:
+.incbin "baserom.gba", 0xE9C364, 0x200
+sShuckleSprites5:
+ax_sprite sShuckleGfx5, 0x200
+ax_sprite_terminator
+sShuckleGfx6:
+.incbin "baserom.gba", 0xE9C574, 0x200
+sShuckleSprites6:
+ax_sprite sShuckleGfx6, 0x200
+ax_sprite_terminator
+sShuckleGfx7:
+.incbin "baserom.gba", 0xE9C784, 0x200
+sShuckleSprites7:
+ax_sprite sShuckleGfx7, 0x200
+ax_sprite_terminator
+sShuckleGfx8:
+.incbin "baserom.gba", 0xE9C994, 0x200
+sShuckleSprites8:
+ax_sprite sShuckleGfx8, 0x200
+ax_sprite_terminator
+sShuckleGfx9:
+.incbin "baserom.gba", 0xE9CBA4, 0x200
+sShuckleSprites9:
+ax_sprite sShuckleGfx9, 0x200
+ax_sprite_terminator
+sShuckleGfx10:
+.incbin "baserom.gba", 0xE9CDB4, 0x200
+sShuckleSprites10:
+ax_sprite sShuckleGfx10, 0x200
+ax_sprite_terminator
+sShuckleGfx11:
+.incbin "baserom.gba", 0xE9CFC4, 0x200
+sShuckleSprites11:
+ax_sprite sShuckleGfx11, 0x200
+ax_sprite_terminator
+sShuckleGfx12:
+.incbin "baserom.gba", 0xE9D1D4, 0x200
+sShuckleSprites12:
+ax_sprite sShuckleGfx12, 0x200
+ax_sprite_terminator
+sShuckleGfx13:
+.incbin "baserom.gba", 0xE9D3E4, 0x200
+sShuckleSprites13:
+ax_sprite sShuckleGfx13, 0x200
+ax_sprite_terminator
+sShuckleGfx14:
+.incbin "baserom.gba", 0xE9D5F4, 0x200
+sShuckleSprites14:
+ax_sprite sShuckleGfx14, 0x200
+ax_sprite_terminator
+sShuckleGfx15:
+.incbin "baserom.gba", 0xE9D804, 0x200
+sShuckleSprites15:
+ax_sprite sShuckleGfx15, 0x200
+ax_sprite_terminator
+sShuckleGfx16:
+.incbin "baserom.gba", 0xE9DA14, 0x60
+sShuckleGfx16_1:
+.incbin "baserom.gba", 0xE9DA74, 0x60
+sShuckleGfx16_2:
+.incbin "baserom.gba", 0xE9DAD4, 0x60
+sShuckleSprites16:
+ax_sprite sShuckleGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx17:
+.incbin "baserom.gba", 0xE9DB6C, 0x60
+sShuckleGfx17_1:
+.incbin "baserom.gba", 0xE9DBCC, 0x60
+sShuckleGfx17_2:
+.incbin "baserom.gba", 0xE9DC2C, 0x60
+sShuckleSprites17:
+ax_sprite sShuckleGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx18:
+.incbin "baserom.gba", 0xE9DCC4, 0x60
+sShuckleGfx18_1:
+.incbin "baserom.gba", 0xE9DD24, 0x60
+sShuckleGfx18_2:
+.incbin "baserom.gba", 0xE9DD84, 0x60
+sShuckleSprites18:
+ax_sprite sShuckleGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx19:
+.incbin "baserom.gba", 0xE9DE1C, 0x40
+sShuckleGfx19_1:
+.incbin "baserom.gba", 0xE9DE5C, 0x80
+sShuckleGfx19_2:
+.incbin "baserom.gba", 0xE9DEDC, 0x40
+sShuckleSprites19:
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx19_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx20:
+.incbin "baserom.gba", 0xE9DF5C, 0x60
+sShuckleGfx20_1:
+.incbin "baserom.gba", 0xE9DFBC, 0xE0
+sShuckleSprites20:
+ax_sprite sShuckleGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx20_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx21:
+.incbin "baserom.gba", 0xE9E0C4, 0x60
+sShuckleGfx21_1:
+.incbin "baserom.gba", 0xE9E124, 0xE0
+sShuckleSprites21:
+ax_sprite sShuckleGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx21_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx22:
+.incbin "baserom.gba", 0xE9E22C, 0x40
+sShuckleGfx22_1:
+.incbin "baserom.gba", 0xE9E26C, 0x60
+sShuckleGfx22_2:
+.incbin "baserom.gba", 0xE9E2CC, 0x60
+sShuckleGfx22_3:
+.incbin "baserom.gba", 0xE9E32C, 0x20
+sShuckleSprites22:
+ax_sprite sShuckleGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx22_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sShuckleGfx22_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShuckleGfx23:
+.incbin "baserom.gba", 0xE9E394, 0x60
+sShuckleGfx23_1:
+.incbin "baserom.gba", 0xE9E3F4, 0x60
+sShuckleGfx23_2:
+.incbin "baserom.gba", 0xE9E454, 0x60
+sShuckleSprites23:
+ax_sprite sShuckleGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx24:
+.incbin "baserom.gba", 0xE9E4EC, 0x60
+sShuckleGfx24_1:
+.incbin "baserom.gba", 0xE9E54C, 0x100
+sShuckleSprites24:
+ax_sprite sShuckleGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx24_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sShuckleGfx25:
+.incbin "baserom.gba", 0xE9E674, 0x40
+sShuckleGfx25_1:
+.incbin "baserom.gba", 0xE9E6B4, 0x100
+sShuckleGfx25_2:
+.incbin "baserom.gba", 0xE9E7B4, 0x40
+sShuckleSprites25:
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShuckleGfx26:
+.incbin "baserom.gba", 0xE9E834, 0x60
+sShuckleGfx26_1:
+.incbin "baserom.gba", 0xE9E894, 0xE0
+sShuckleSprites26:
+ax_sprite sShuckleGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx26_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx27:
+.incbin "baserom.gba", 0xE9E99C, 0x40
+sShuckleGfx27_1:
+.incbin "baserom.gba", 0xE9E9DC, 0x100
+sShuckleGfx27_2:
+.incbin "baserom.gba", 0xE9EADC, 0x40
+sShuckleSprites27:
+ax_sprite sShuckleGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShuckleGfx28:
+.incbin "baserom.gba", 0xE9EB54, 0x20
+sShuckleGfx28_1:
+.incbin "baserom.gba", 0xE9EB74, 0x60
+sShuckleGfx28_2:
+.incbin "baserom.gba", 0xE9EBD4, 0x60
+sShuckleGfx28_3:
+.incbin "baserom.gba", 0xE9EC34, 0x60
+sShuckleSprites28:
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx28, 0x20
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShuckleGfx29:
+.incbin "baserom.gba", 0xE9ECE4, 0x20
+sShuckleGfx29_1:
+.incbin "baserom.gba", 0xE9ED04, 0x60
+sShuckleGfx29_2:
+.incbin "baserom.gba", 0xE9ED64, 0x60
+sShuckleSprites29:
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx30:
+.incbin "baserom.gba", 0xE9EE04, 0x20
+sShuckleGfx30_1:
+.incbin "baserom.gba", 0xE9EE24, 0x60
+sShuckleGfx30_2:
+.incbin "baserom.gba", 0xE9EE84, 0x60
+sShuckleGfx30_3:
+.incbin "baserom.gba", 0xE9EEE4, 0x60
+sShuckleSprites30:
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShuckleGfx31:
+.incbin "baserom.gba", 0xE9EF94, 0x60
+sShuckleGfx31_1:
+.incbin "baserom.gba", 0xE9EFF4, 0x60
+sShuckleGfx31_2:
+.incbin "baserom.gba", 0xE9F054, 0x60
+sShuckleSprites31:
+ax_sprite sShuckleGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx32:
+.incbin "baserom.gba", 0xE9F0EC, 0x40
+sShuckleGfx32_1:
+.incbin "baserom.gba", 0xE9F12C, 0x60
+sShuckleGfx32_2:
+.incbin "baserom.gba", 0xE9F18C, 0x40
+sShuckleSprites32:
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx32_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuckleGfx33:
+.incbin "baserom.gba", 0xE9F20C, 0x20
+sShuckleGfx33_1:
+.incbin "baserom.gba", 0xE9F22C, 0x80
+sShuckleGfx33_2:
+.incbin "baserom.gba", 0xE9F2AC, 0x60
+sShuckleSprites33:
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx33_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx33_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sShuckleGfx34:
+.incbin "baserom.gba", 0xE9F34C, 0x40
+sShuckleGfx34_1:
+.incbin "baserom.gba", 0xE9F38C, 0x60
+sShuckleGfx34_2:
+.incbin "baserom.gba", 0xE9F3EC, 0x40
+sShuckleSprites34:
+ax_sprite 0, 0xa0
+ax_sprite sShuckleGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShuckleGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShuckleGfx35:
+.incbin "baserom.gba", 0xE9F46C, 0x60
+sShuckleGfx35_1:
+.incbin "baserom.gba", 0xE9F4CC, 0x60
+sShuckleGfx35_2:
+.incbin "baserom.gba", 0xE9F52C, 0x60
+sShuckleSprites35:
+ax_sprite 0, 0x80
+ax_sprite sShuckleGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuckleGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sShuckleGfx36:
+.incbin "baserom.gba", 0xE9F5CC, 0x200
+sShuckleSprites36:
+ax_sprite sShuckleGfx36, 0x200
+ax_sprite_terminator
+sShuckleGfx37:
+.incbin "baserom.gba", 0xE9F7DC, 0x200
+sShuckleSprites37:
+ax_sprite sShuckleGfx37, 0x200
+ax_sprite_terminator
+sShuckleGfx38:
+.incbin "baserom.gba", 0xE9F9EC, 0x200
+sShuckleSprites38:
+ax_sprite sShuckleGfx38, 0x200
+ax_sprite_terminator
+sShuckleGfx39:
+.incbin "baserom.gba", 0xE9FBFC, 0x200
+sShuckleSprites39:
+ax_sprite sShuckleGfx39, 0x200
+ax_sprite_terminator
+sShuckleGfx40:
+.incbin "baserom.gba", 0xE9FE0C, 0x200
+sShuckleSprites40:
+ax_sprite sShuckleGfx40, 0x200
+ax_sprite_terminator
+sShuckleGfx41:
+.incbin "baserom.gba", 0xEA001C, 0x200
+sShuckleSprites41:
+ax_sprite sShuckleGfx41, 0x200
+ax_sprite_terminator
+sShuckleGfx42:
+.incbin "baserom.gba", 0xEA022C, 0x200
+sShuckleSprites42:
+ax_sprite sShuckleGfx42, 0x200
+ax_sprite_terminator
+sAxPosesShuckle:
+.4byte sShucklePose1
+.4byte sShucklePose2
+.4byte sShucklePose3
+.4byte sShucklePose4
+.4byte sShucklePose5
+.4byte sShucklePose6
+.4byte sShucklePose7
+.4byte sShucklePose8
+.4byte sShucklePose9
+.4byte sShucklePose10
+.4byte sShucklePose11
+.4byte sShucklePose12
+.4byte sShucklePose13
+.4byte sShucklePose14
+.4byte sShucklePose15
+.4byte sShucklePose16
+.4byte sShucklePose17
+.4byte sShucklePose18
+.4byte sShucklePose19
+.4byte sShucklePose20
+.4byte sShucklePose21
+.4byte sShucklePose22
+.4byte sShucklePose23
+.4byte sShucklePose24
+.4byte sShucklePose25
+.4byte sShucklePose26
+.4byte sShucklePose27
+.4byte sShucklePose28
+.4byte sShucklePose29
+.4byte sShucklePose30
+.4byte sShucklePose31
+.4byte sShucklePose32
+.4byte sShucklePose33
+.4byte sShucklePose34
+.4byte sShucklePose35
+.4byte sShucklePose36
+.4byte sShucklePose37
+.4byte sShucklePose38
+.4byte sShucklePose39
+.4byte sShucklePose40
+.4byte sShucklePose41
+.4byte sShucklePose42
+.4byte sShucklePose43
+.4byte sShucklePose44
+.4byte sShucklePose45
+.4byte sShucklePose46
+.4byte sShucklePose47
+.4byte sShucklePose48
+.4byte sShucklePose49
+.4byte sShucklePose50
+.4byte sShucklePose51
+.4byte sShucklePose52
+.4byte sShucklePose53
+.4byte sShucklePose54
+.4byte sShucklePose55
+.4byte sShucklePose56
+.4byte sShucklePose57
+.4byte sShucklePose58
+.4byte sShucklePose59
+.4byte sShucklePose60
+.4byte sShucklePose61
+.4byte sShucklePose62
+.4byte sShucklePose63
+.4byte sShucklePose64
+.4byte sShucklePose65
+.4byte sShucklePose66
+.4byte sShucklePose67
+.4byte sShucklePose68
+.4byte sShucklePose69
+.4byte sShucklePose70
+.4byte sShucklePose71
+.4byte sShucklePose72
+.4byte sShucklePose73
+.4byte sShucklePose74
+.4byte sShucklePose75
+.4byte sShucklePose76
+.4byte sShucklePose77
+.4byte sShucklePose78
+.4byte sShucklePose79
+.4byte sShucklePose80
+.4byte sShucklePose81
+.4byte sShucklePose82
+.4byte sShucklePose83
+.4byte sShucklePose84
+.4byte sShucklePose85
+.4byte sShucklePose86
+.4byte sShucklePose87
+.4byte sShucklePose88
+.4byte sShucklePose89
+.4byte sShucklePose90
+.4byte sShucklePose91
+.4byte sShucklePose92
+.4byte sShucklePose93
+.4byte sShucklePose94
+.4byte sShucklePose95
+.4byte sShucklePose96
+.4byte sShucklePose97
+.4byte sShucklePose98
+.4byte sShucklePose99
+.4byte sShucklePose100
+.4byte sShucklePose101
+.4byte sShucklePose102
+.4byte sShucklePose103
+.4byte sShucklePose104
+.4byte sShucklePose105
+.4byte sShucklePose106
+.4byte sShucklePose107
+.4byte sShucklePose108
+.4byte sShucklePose109
+.4byte sShucklePose110
+.4byte sShucklePose111
+.4byte sShucklePose112
+.4byte sShucklePose113
+.4byte sShucklePose114
+.4byte sShucklePose115
+.4byte sShucklePose116
+.4byte sShucklePose117
+.4byte sShucklePose118
+.4byte sShucklePose119
+.4byte sShucklePose120
+.4byte sShucklePose121
+.4byte sShucklePose122
+.4byte sShucklePose123
+.4byte sShucklePose124
+.4byte sShucklePose125
+.4byte sShucklePose126
+.4byte sShucklePose127
+.4byte sShucklePose128
+.4byte sShucklePose129
+.4byte sShucklePose130
+.4byte sShucklePose131
+.4byte sShucklePose132
+.4byte sShucklePose133
+.4byte sShucklePose134
+.4byte sShucklePose135
+.4byte sShucklePose136
+.4byte sShucklePose137
+.4byte sShucklePose138
+.4byte sShucklePose139
+.4byte sShucklePose140
+.4byte sShucklePose141
+.4byte sShucklePose142
+.4byte sShucklePose143
+.4byte sShucklePose144
+.4byte sShucklePose145
+.4byte sShucklePose146
+.4byte sShucklePose147
+.4byte sShucklePose148
+.4byte sShucklePose149
+.4byte sShucklePose150
+.4byte sShucklePose151
+.4byte sShucklePose152
+.4byte sShucklePose153
+.4byte sShucklePose154
+.4byte sShucklePose155
+.4byte sShucklePose156
+.4byte sShucklePose157
+.4byte sShucklePose158
+.4byte sShucklePose159
+.4byte sShucklePose160
+.4byte sShucklePose161
+.4byte sShucklePose162
+.4byte sShucklePose163
+.4byte sShucklePose164
+.4byte sShucklePose165
+.4byte sShucklePose166
+.4byte sShucklePose167
+.4byte sShucklePose168
+.4byte sShucklePose169
+.4byte sShucklePose170
+.4byte sShucklePose171
+.4byte sShucklePose172
+.4byte sShucklePose173
+.4byte sShucklePose174
+.4byte sShucklePose175
+.4byte sShucklePose176
+.4byte sShucklePose177
+.4byte sShucklePose178
+.4byte sShucklePose179
+.4byte sShucklePose180
+.4byte sShucklePose181
+.4byte sShucklePose182
+.4byte sShucklePose183
+.4byte sShucklePose184
+.4byte sShucklePose185
+.4byte sShucklePose186
+.4byte sShucklePose187
+.4byte sShucklePose188
+.4byte sShucklePose189
+.4byte sShucklePose190
+.4byte sShucklePose191
+.4byte sShucklePose192
+.4byte sShucklePose193
+.4byte sShucklePose194
+.4byte sShucklePose195
+.4byte sShucklePose196
+.4byte sShucklePose197
+.4byte sShucklePose198
+.4byte sShucklePose199
+.4byte sShucklePose200
+.4byte sShucklePose201
+.4byte sShucklePose202
+.4byte sShucklePose203
+.4byte sShucklePose204
+.4byte sShucklePose205
+.4byte sShucklePose206
+.4byte sShucklePose207
+.4byte sShucklePose208
+.4byte sShucklePose209
+.4byte sShucklePose210
+.4byte sShucklePose211
+.4byte sShucklePose212
+.4byte sShucklePose213
+.4byte sShucklePose214
+.4byte sShucklePose215
+.4byte sShucklePose216
+.4byte sShucklePose217
+.4byte sShucklePose218
+.4byte sShucklePose219
+.4byte sShucklePose220
+.4byte sShucklePose221
+.4byte sShucklePose222
+.4byte sShucklePose223
+.4byte sShucklePose224
+.4byte sShucklePose225
+.4byte sShucklePose226
+.4byte sShucklePose227
+.4byte sShucklePose228
+.4byte sShucklePose229
+.4byte sShucklePose230
+.4byte sShucklePose231
+.4byte sShucklePose232
+.4byte sShucklePose233
+.4byte sShucklePose234
+.4byte sShucklePose235
+.4byte sShucklePose236
+.4byte sShucklePose237
+.4byte sShucklePose238
+.4byte sShucklePose239
+.4byte sShucklePose240
+.4byte sShucklePose241
+.4byte sShucklePose242
+sAxPositionsShuckle:
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -1,   -6, 	  -9,    3, 	   8,    3, 	   0,   -3
+.2byte   -1,   -4, 	  -9,    1, 	   8,    1, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte    7,   -7, 	  10,   -3, 	  -3,    6, 	  -1,   -4
+.2byte    7,   -6, 	   7,   -4, 	  -4,    4, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    7,   -9, 	   7,   -7, 	   7,    5, 	  -1,   -3
+.2byte    8,   -8, 	   4,   -7, 	   4,    6, 	   0,   -3
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    5,  -12, 	   1,   -9, 	  10,    0, 	  -2,   -3
+.2byte    6,  -12, 	  -3,   -6, 	   8,    2, 	  -1,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    0,  -14, 	   9,   -3, 	 -10,   -3, 	   0,   -2
+.2byte    0,  -15, 	   9,   -2, 	 -10,   -2, 	   0,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte   -6,  -12, 	  -2,   -9, 	 -11,    0, 	   1,   -3
+.2byte   -7,  -12, 	   2,   -6, 	  -9,    2, 	   0,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -8,   -9, 	  -8,   -7, 	  -8,    5, 	   0,   -3
+.2byte   -9,   -8, 	  -5,   -7, 	  -5,    6, 	  -1,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -8,   -7, 	 -11,   -3, 	   2,    6, 	   0,   -4
+.2byte   -8,   -6, 	  -8,   -4, 	   3,    4, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -1,   -9, 	  -8,    2, 	   7,    2, 	  -1,   -4
+.2byte   -1,   -6, 	  -8,    4, 	   7,    4, 	   0,   -4
+.2byte   -1,   -3, 	  -9,    4, 	   8,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte    4,   -9, 	  10,   -3, 	  -1,    3, 	  -1,   -4
+.2byte    6,   -7, 	   9,   -2, 	  -2,    5, 	   0,   -5
+.2byte    8,   -5, 	  10,   -1, 	  -2,    5, 	   0,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,  -12, 	   9,   -7, 	   9,    1, 	   0,   -4
+.2byte    7,  -10, 	   9,   -5, 	   8,    4, 	   0,   -4
+.2byte   10,   -9, 	   9,   -6, 	   9,    4, 	   0,   -4
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    4,  -15, 	   0,   -8, 	  10,   -3, 	  -1,   -4
+.2byte    6,  -13, 	   1,   -7, 	   9,    0, 	  -1,   -5
+.2byte    7,  -14, 	   0,   -8, 	  10,   -3, 	   0,   -5
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    0,  -14, 	   8,   -6, 	  -9,   -6, 	   0,   -3
+.2byte    0,  -11, 	   8,   -3, 	  -9,   -3, 	   0,   -2
+.2byte    0,  -16, 	   8,   -6, 	  -9,   -6, 	   0,   -3
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte   -5,  -15, 	  -1,   -8, 	 -11,   -3, 	   0,   -4
+.2byte   -7,  -13, 	  -2,   -7, 	 -10,    0, 	   0,   -5
+.2byte   -8,  -14, 	  -1,   -8, 	 -11,   -3, 	  -1,   -5
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -12, 	 -10,   -7, 	 -10,    1, 	  -1,   -4
+.2byte   -8,  -10, 	 -10,   -5, 	  -9,    4, 	  -1,   -4
+.2byte  -11,   -9, 	 -10,   -6, 	 -10,    4, 	  -1,   -4
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -5,   -9, 	 -11,   -3, 	   0,    3, 	   0,   -4
+.2byte   -7,   -7, 	 -10,   -2, 	   1,    5, 	  -1,   -5
+.2byte   -9,   -5, 	 -11,   -1, 	   1,    5, 	  -1,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -1,   -9, 	  -8,    2, 	   7,    2, 	  -1,   -4
+.2byte   -1,   -6, 	  -8,    4, 	   7,    4, 	   0,   -4
+.2byte   -1,   -3, 	  -9,    4, 	   8,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte    4,   -9, 	  10,   -3, 	  -1,    3, 	  -1,   -4
+.2byte    6,   -7, 	   9,   -2, 	  -2,    5, 	   0,   -5
+.2byte    8,   -5, 	  10,   -1, 	  -2,    5, 	   0,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,  -12, 	   9,   -7, 	   9,    1, 	   0,   -4
+.2byte    7,  -10, 	   9,   -5, 	   8,    4, 	   0,   -4
+.2byte   10,   -9, 	   9,   -6, 	   9,    4, 	   0,   -4
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    4,  -15, 	   0,   -8, 	  10,   -3, 	  -1,   -4
+.2byte    6,  -13, 	   1,   -7, 	   9,    0, 	  -1,   -5
+.2byte    7,  -14, 	   0,   -8, 	  10,   -3, 	   0,   -5
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    0,  -14, 	   8,   -6, 	  -9,   -6, 	   0,   -3
+.2byte    0,  -11, 	   8,   -3, 	  -9,   -3, 	   0,   -2
+.2byte    0,  -16, 	   8,   -6, 	  -9,   -6, 	   0,   -3
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte   -5,  -15, 	  -1,   -8, 	 -11,   -3, 	   0,   -4
+.2byte   -7,  -13, 	  -2,   -7, 	 -10,    0, 	   0,   -5
+.2byte   -8,  -14, 	  -1,   -8, 	 -11,   -3, 	  -1,   -5
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -12, 	 -10,   -7, 	 -10,    1, 	  -1,   -4
+.2byte   -8,  -10, 	 -10,   -5, 	  -9,    4, 	  -1,   -4
+.2byte  -11,   -9, 	 -10,   -6, 	 -10,    4, 	  -1,   -4
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -5,   -9, 	 -11,   -3, 	   0,    3, 	   0,   -4
+.2byte   -7,   -7, 	 -10,   -2, 	   1,    5, 	  -1,   -5
+.2byte   -9,   -5, 	 -11,   -1, 	   1,    5, 	  -1,   -3
+.2byte   -1,   -5, 	  -9,    2, 	   8,    2, 	   0,   -4
+.2byte   -9,   -7, 	 -11,   -3, 	   1,    3, 	  -1,   -5
+.2byte  -10,  -11, 	  -9,   -8, 	  -9,    2, 	   0,   -6
+.2byte   -8,  -16, 	  -1,  -10, 	 -11,   -5, 	  -1,   -7
+.2byte    0,  -19, 	   8,   -9, 	  -9,   -9, 	   0,   -6
+.2byte    7,  -16, 	   0,  -10, 	  10,   -5, 	   0,   -7
+.2byte    9,  -11, 	   8,   -8, 	   8,    2, 	  -1,   -6
+.2byte    8,   -7, 	  10,   -3, 	  -2,    3, 	   0,   -5
+.2byte   -1,   -3, 	  -5,    1, 	   4,    1, 	   0,   -3
+.2byte   -3,   -3, 	  -7,   -1, 	  -2,    2, 	  -2,   -4
+.2byte   -3,   -5, 	  -7,   -4, 	  -5,    1, 	  -1,   -3
+.2byte   -3,   -6, 	   1,   -6, 	  -6,   -2, 	   0,   -3
+.2byte    0,   -7, 	   4,   -5, 	  -5,   -5, 	  -1,   -3
+.2byte    2,   -6, 	  -2,   -6, 	   5,   -2, 	  -1,   -3
+.2byte    2,   -5, 	   6,   -4, 	   4,    1, 	   0,   -3
+.2byte    2,   -3, 	   6,   -1, 	   1,    2, 	   1,   -4
+.2byte   -7,   -7, 	 -10,   -3, 	   0,    4, 	  -1,   -5
+.2byte   -6,   -6, 	  -9,   -3, 	  -1,    3, 	  -1,   -5
+.2byte    0,   -5, 	  -5,   -1, 	   4,   -1, 	  -1,   -6
+.2byte   -1,   -5, 	   3,   -4, 	  -3,    0, 	  -3,   -6
+.2byte    1,   -6, 	   4,   -5, 	   2,    0, 	  -2,   -5
+.2byte    3,   -9, 	  -3,   -7, 	   4,   -2, 	  -2,   -4
+.2byte   -1,   -8, 	   3,   -6, 	  -4,   -6, 	   0,   -3
+.2byte   -4,   -9, 	   2,   -7, 	  -5,   -2, 	   1,   -4
+.2byte   -2,   -6, 	  -5,   -5, 	  -3,    0, 	   1,   -5
+.2byte    0,   -5, 	  -4,   -4, 	   2,    0, 	   2,   -6
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -1,   -8, 	  -8,    3, 	   7,    3, 	  -1,   -3
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte    4,   -8, 	  10,   -2, 	  -1,    4, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,  -11, 	   9,   -6, 	   9,    2, 	   0,   -3
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    4,  -14, 	   0,   -7, 	  10,   -2, 	  -1,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    0,  -13, 	   8,   -5, 	  -9,   -5, 	   0,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte   -5,  -14, 	  -1,   -7, 	 -11,   -2, 	   0,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -11, 	 -10,   -6, 	 -10,    2, 	  -1,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -5,   -8, 	 -11,   -2, 	   0,    4, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -13, 	   8,   -6, 	  -9,   -6, 	   0,   -2
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -1,   -9, 	  -8,    2, 	   7,    2, 	  -1,   -4
+.2byte    4,   -9, 	  10,   -3, 	  -1,    3, 	  -1,   -4
+.2byte    5,  -12, 	   9,   -7, 	   9,    1, 	   0,   -4
+.2byte    4,  -15, 	   0,   -8, 	  10,   -3, 	  -1,   -4
+.2byte    0,  -15, 	   8,   -7, 	  -9,   -7, 	   0,   -4
+.2byte   -5,  -15, 	  -1,   -8, 	 -11,   -3, 	   0,   -4
+.2byte   -6,  -12, 	 -10,   -7, 	 -10,    1, 	  -1,   -4
+.2byte   -5,   -9, 	 -11,   -3, 	   0,    3, 	   0,   -4
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -1,   -9, 	  -8,    2, 	   7,    2, 	  -1,   -4
+.2byte   -1,   -5, 	  -8,    5, 	   7,    5, 	   0,   -3
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+.2byte    4,   -9, 	  10,   -3, 	  -1,    3, 	  -1,   -4
+.2byte    6,   -6, 	   9,   -1, 	  -2,    6, 	   0,   -4
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,  -12, 	   9,   -7, 	   9,    1, 	   0,   -4
+.2byte    7,   -9, 	   9,   -4, 	   8,    5, 	   0,   -3
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    4,  -15, 	   0,   -8, 	  10,   -3, 	  -1,   -4
+.2byte    6,  -12, 	   1,   -6, 	   9,    1, 	  -1,   -4
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    0,  -14, 	   8,   -6, 	  -9,   -6, 	   0,   -3
+.2byte    0,  -10, 	   8,   -2, 	  -9,   -2, 	   0,   -1
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte   -5,  -15, 	  -1,   -8, 	 -11,   -3, 	   0,   -4
+.2byte   -7,  -12, 	  -2,   -6, 	 -10,    1, 	   0,   -4
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -12, 	 -10,   -7, 	 -10,    1, 	  -1,   -4
+.2byte   -8,   -9, 	 -10,   -4, 	  -9,    5, 	  -1,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -5,   -9, 	 -11,   -3, 	   0,    3, 	   0,   -4
+.2byte   -7,   -6, 	 -10,   -1, 	   1,    6, 	  -1,   -4
+.2byte   -1,   -5, 	  -9,    2, 	   8,    2, 	   0,   -4
+.2byte   -9,   -7, 	 -11,   -3, 	   1,    3, 	  -1,   -5
+.2byte  -10,  -11, 	  -9,   -8, 	  -9,    2, 	   0,   -6
+.2byte   -8,  -16, 	  -1,  -10, 	 -11,   -5, 	  -1,   -7
+.2byte    0,  -19, 	   8,   -9, 	  -9,   -9, 	   0,   -6
+.2byte    7,  -16, 	   0,  -10, 	  10,   -5, 	   0,   -7
+.2byte    9,  -11, 	   8,   -8, 	   8,    2, 	  -1,   -6
+.2byte    8,   -7, 	  10,   -3, 	  -2,    3, 	   0,   -5
+.2byte   -1,   -7, 	  -9,    4, 	   8,    4, 	   0,   -3
+.2byte   -6,   -7, 	 -11,   -1, 	   0,    6, 	  -1,   -3
+.2byte   -7,  -10, 	 -10,   -6, 	 -10,    4, 	  -1,   -2
+.2byte   -6,  -13, 	  -2,   -7, 	 -11,   -1, 	   0,   -3
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -1
+.2byte    5,  -13, 	   1,   -7, 	  10,   -1, 	  -1,   -3
+.2byte    6,  -10, 	   9,   -6, 	   9,    4, 	   0,   -2
+.2byte    5,   -7, 	  10,   -1, 	  -1,    6, 	   0,   -3
+sShuckleAnimTable1:
+.4byte sShuckleAnims_1_1
+.4byte sShuckleAnims_1_2
+.4byte sShuckleAnims_1_3
+.4byte sShuckleAnims_1_4
+.4byte sShuckleAnims_1_5
+.4byte sShuckleAnims_1_6
+.4byte sShuckleAnims_1_7
+.4byte sShuckleAnims_1_8
+sShuckleAnimTable2:
+.4byte sShuckleAnims_2_1
+.4byte sShuckleAnims_2_2
+.4byte sShuckleAnims_2_3
+.4byte sShuckleAnims_2_4
+.4byte sShuckleAnims_2_5
+.4byte sShuckleAnims_2_6
+.4byte sShuckleAnims_2_7
+.4byte sShuckleAnims_2_8
+sShuckleAnimTable3:
+.4byte sShuckleAnims_3_1
+.4byte sShuckleAnims_3_2
+.4byte sShuckleAnims_3_3
+.4byte sShuckleAnims_3_4
+.4byte sShuckleAnims_3_5
+.4byte sShuckleAnims_3_6
+.4byte sShuckleAnims_3_7
+.4byte sShuckleAnims_3_8
+sShuckleAnimTable4:
+.4byte sShuckleAnims_4_1
+.4byte sShuckleAnims_4_2
+.4byte sShuckleAnims_4_3
+.4byte sShuckleAnims_4_4
+.4byte sShuckleAnims_4_5
+.4byte sShuckleAnims_4_6
+.4byte sShuckleAnims_4_7
+.4byte sShuckleAnims_4_8
+sShuckleAnimTable5:
+.4byte sShuckleAnims_5_1
+.4byte sShuckleAnims_5_2
+.4byte sShuckleAnims_5_3
+.4byte sShuckleAnims_5_4
+.4byte sShuckleAnims_5_5
+.4byte sShuckleAnims_5_6
+.4byte sShuckleAnims_5_7
+.4byte sShuckleAnims_5_8
+sShuckleAnimTable6:
+.4byte sShuckleAnims_6_1
+.4byte sShuckleAnims_6_1
+.4byte sShuckleAnims_6_1
+.4byte sShuckleAnims_6_1
+.4byte sShuckleAnims_6_1
+.4byte sShuckleAnims_6_1
+.4byte sShuckleAnims_6_1
+.4byte sShuckleAnims_6_1
+sShuckleAnimTable7:
+.4byte sShuckleAnims_7_1
+.4byte sShuckleAnims_7_2
+.4byte sShuckleAnims_7_3
+.4byte sShuckleAnims_7_4
+.4byte sShuckleAnims_7_5
+.4byte sShuckleAnims_7_6
+.4byte sShuckleAnims_7_7
+.4byte sShuckleAnims_7_8
+sShuckleAnimTable8:
+.4byte sShuckleAnims_8_1
+.4byte sShuckleAnims_8_2
+.4byte sShuckleAnims_8_3
+.4byte sShuckleAnims_8_4
+.4byte sShuckleAnims_8_5
+.4byte sShuckleAnims_8_6
+.4byte sShuckleAnims_8_7
+.4byte sShuckleAnims_8_8
+sShuckleAnimTable9:
+.4byte sShuckleAnims_9_1
+.4byte sShuckleAnims_9_2
+.4byte sShuckleAnims_9_3
+.4byte sShuckleAnims_9_4
+.4byte sShuckleAnims_9_5
+.4byte sShuckleAnims_9_6
+.4byte sShuckleAnims_9_7
+.4byte sShuckleAnims_9_8
+sShuckleAnimTable10:
+.4byte sShuckleAnims_10_1
+.4byte sShuckleAnims_10_2
+.4byte sShuckleAnims_10_3
+.4byte sShuckleAnims_10_4
+.4byte sShuckleAnims_10_5
+.4byte sShuckleAnims_10_6
+.4byte sShuckleAnims_10_7
+.4byte sShuckleAnims_10_8
+sShuckleAnimTable11:
+.4byte sShuckleAnims_11_1
+.4byte sShuckleAnims_11_2
+.4byte sShuckleAnims_11_3
+.4byte sShuckleAnims_11_4
+.4byte sShuckleAnims_11_5
+.4byte sShuckleAnims_11_6
+.4byte sShuckleAnims_11_7
+.4byte sShuckleAnims_11_8
+sShuckleAnimTable12:
+.4byte sShuckleAnims_12_1
+.4byte sShuckleAnims_12_2
+.4byte sShuckleAnims_12_3
+.4byte sShuckleAnims_12_4
+.4byte sShuckleAnims_12_5
+.4byte sShuckleAnims_12_6
+.4byte sShuckleAnims_12_7
+.4byte sShuckleAnims_12_8
+sShuckleAnimTable13:
+.4byte sShuckleAnims_13_1
+.4byte sShuckleAnims_13_2
+.4byte sShuckleAnims_13_3
+.4byte sShuckleAnims_13_4
+.4byte sShuckleAnims_13_5
+.4byte sShuckleAnims_13_6
+.4byte sShuckleAnims_13_7
+.4byte sShuckleAnims_13_8
+sAxAnimationsShuckle:
+.4byte sShuckleAnimTable1
+.4byte sShuckleAnimTable2
+.4byte sShuckleAnimTable3
+.4byte sShuckleAnimTable4
+.4byte sShuckleAnimTable5
+.4byte sShuckleAnimTable6
+.4byte sShuckleAnimTable7
+.4byte sShuckleAnimTable8
+.4byte sShuckleAnimTable9
+.4byte sShuckleAnimTable10
+.4byte sShuckleAnimTable11
+.4byte sShuckleAnimTable12
+.4byte sShuckleAnimTable13
+sAxSpritesShuckle:
+.4byte sShuckleSprites1
+.4byte sShuckleSprites2
+.4byte sShuckleSprites3
+.4byte sShuckleSprites4
+.4byte sShuckleSprites5
+.4byte sShuckleSprites6
+.4byte sShuckleSprites7
+.4byte sShuckleSprites8
+.4byte sShuckleSprites9
+.4byte sShuckleSprites10
+.4byte sShuckleSprites11
+.4byte sShuckleSprites12
+.4byte sShuckleSprites13
+.4byte sShuckleSprites14
+.4byte sShuckleSprites15
+.4byte sShuckleSprites16
+.4byte sShuckleSprites17
+.4byte sShuckleSprites18
+.4byte sShuckleSprites19
+.4byte sShuckleSprites20
+.4byte sShuckleSprites21
+.4byte sShuckleSprites22
+.4byte sShuckleSprites23
+.4byte sShuckleSprites24
+.4byte sShuckleSprites25
+.4byte sShuckleSprites26
+.4byte sShuckleSprites27
+.4byte sShuckleSprites28
+.4byte sShuckleSprites29
+.4byte sShuckleSprites30
+.4byte sShuckleSprites31
+.4byte sShuckleSprites32
+.4byte sShuckleSprites33
+.4byte sShuckleSprites34
+.4byte sShuckleSprites35
+.4byte sShuckleSprites36
+.4byte sShuckleSprites37
+.4byte sShuckleSprites38
+.4byte sShuckleSprites39
+.4byte sShuckleSprites40
+.4byte sShuckleSprites41
+.4byte sShuckleSprites42
+sAxMainShuckle:
+ax_main sAxPosesShuckle, sAxAnimationsShuckle, 13, sAxSpritesShuckle, sAxPositionsShuckle

--- a/data/ax/shuppet.inc
+++ b/data/ax/shuppet.inc
@@ -1,0 +1,3131 @@
+.global gAxShuppet
+gAxShuppet:
+ax_siro sAxMainShuppet
+sShuppetPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose4:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose5:
+ax_pose 4, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose6:
+ax_pose 5, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose7:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose8:
+ax_pose 7, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose9:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose10:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose11:
+ax_pose 10, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose12:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose13:
+ax_pose 12, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose14:
+ax_pose 13, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose15:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose16:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose17:
+ax_pose 10, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose18:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose19:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose20:
+ax_pose 7, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose21:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose22:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose23:
+ax_pose 4, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose24:
+ax_pose 5, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose28:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose29:
+ax_pose 4, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose30:
+ax_pose 5, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose31:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose32:
+ax_pose 7, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose33:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose34:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose35:
+ax_pose 10, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose36:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose37:
+ax_pose 12, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose38:
+ax_pose 13, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose39:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose40:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose41:
+ax_pose 10, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose42:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose43:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose44:
+ax_pose 7, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose45:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose46:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose47:
+ax_pose 4, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose48:
+ax_pose 5, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose49:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose50:
+ax_pose 3, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sShuppetPose51:
+ax_pose 6, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose52:
+ax_pose 9, 0x01e8, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose53:
+ax_pose 12, 0x81e6, 0x80f9, 0x9c00
+ax_pose_terminator
+sShuppetPose54:
+ax_pose 9, 0x01e8, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose55:
+ax_pose 6, 0x01e9, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose56:
+ax_pose 3, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sShuppetPose57:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose58:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose59:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose60:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose61:
+ax_pose 15, 0x01e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose62:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose63:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose64:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose65:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose66:
+ax_pose 3, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sShuppetPose67:
+ax_pose 6, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose68:
+ax_pose 9, 0x01e8, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose69:
+ax_pose 12, 0x81e6, 0x80f9, 0x9c00
+ax_pose_terminator
+sShuppetPose70:
+ax_pose 9, 0x01e8, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose71:
+ax_pose 6, 0x01e9, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose72:
+ax_pose 3, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sShuppetPose73:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose74:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose75:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose76:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose77:
+ax_pose 15, 0x01e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose78:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose79:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose80:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose81:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose82:
+ax_pose 1, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose83:
+ax_pose 2, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose84:
+ax_pose 16, 0x01e8, 0x80ef, 0x9c00
+ax_pose_terminator
+sShuppetPose85:
+ax_pose 17, 0x01f3, 0x00fe, 0x9c00
+ax_pose -1, 0x01f3, 0x00f7, 0x9c00
+ax_pose 16, 0x01e8, 0x80ef, 0x9c01
+ax_pose_terminator
+sShuppetPose86:
+ax_pose 18, 0x01f3, 0x00fe, 0x9c00
+ax_pose -1, 0x01f3, 0x00f7, 0x9c00
+ax_pose 16, 0x01e8, 0x80ef, 0x9c01
+ax_pose_terminator
+sShuppetPose87:
+ax_pose 19, 0x01ed, 0x40fa, 0x9c00
+ax_pose -1, 0x01ed, 0x40f3, 0x9c00
+ax_pose 16, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose88:
+ax_pose 20, 0x01ed, 0x40fa, 0x9c00
+ax_pose -1, 0x01ed, 0x40f3, 0x9c00
+ax_pose 16, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose89:
+ax_pose 19, 0x01ed, 0x40fa, 0x9c00
+ax_pose -1, 0x01ed, 0x40f3, 0x9c00
+ax_pose 16, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose90:
+ax_pose 21, 0x01ed, 0x40fa, 0x9c00
+ax_pose -1, 0x01ed, 0x40f3, 0x9c00
+ax_pose 16, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose91:
+ax_pose 22, 0x01f3, 0x00fe, 0x9c00
+ax_pose -1, 0x01f3, 0x00f7, 0x9c00
+ax_pose 16, 0x01e8, 0x80ef, 0x9c01
+ax_pose_terminator
+sShuppetPose92:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose93:
+ax_pose 4, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose94:
+ax_pose 5, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose95:
+ax_pose 23, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sShuppetPose96:
+ax_pose 17, 0x01f2, 0x0104, 0x9c00
+ax_pose -1, 0x01f3, 0x00fd, 0x9c00
+ax_pose 23, 0x01e8, 0x90f0, 0x9c01
+ax_pose_terminator
+sShuppetPose97:
+ax_pose 18, 0x01f2, 0x0105, 0x9c00
+ax_pose -1, 0x01f3, 0x00fd, 0x9c00
+ax_pose 23, 0x01e8, 0x90f0, 0x9c01
+ax_pose_terminator
+sShuppetPose98:
+ax_pose 19, 0x01ec, 0x4101, 0x9c00
+ax_pose -1, 0x01ed, 0x40f9, 0x9c00
+ax_pose 23, 0x01e8, 0x90f0, 0x9c04
+ax_pose_terminator
+sShuppetPose99:
+ax_pose 20, 0x01ec, 0x4101, 0x9c00
+ax_pose -1, 0x01ed, 0x40f9, 0x9c00
+ax_pose 23, 0x01e8, 0x90f0, 0x9c04
+ax_pose_terminator
+sShuppetPose100:
+ax_pose 19, 0x01ec, 0x4101, 0x9c00
+ax_pose -1, 0x01ed, 0x40f9, 0x9c00
+ax_pose 23, 0x01e8, 0x90f0, 0x9c04
+ax_pose_terminator
+sShuppetPose101:
+ax_pose 21, 0x01ec, 0x4101, 0x9c00
+ax_pose -1, 0x01ed, 0x40f9, 0x9c00
+ax_pose 23, 0x01e8, 0x90f0, 0x9c04
+ax_pose_terminator
+sShuppetPose102:
+ax_pose 22, 0x01f2, 0x0105, 0x9c00
+ax_pose -1, 0x01f3, 0x00fd, 0x9c00
+ax_pose 23, 0x01e8, 0x90f0, 0x9c01
+ax_pose_terminator
+sShuppetPose103:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose104:
+ax_pose 7, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose105:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose106:
+ax_pose 24, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose107:
+ax_pose 17, 0x01f3, 0x0102, 0x9c00
+ax_pose 24, 0x01e8, 0x90ef, 0x9c01
+ax_pose -1, 0x01f0, 0x0105, 0x9c00
+ax_pose_terminator
+sShuppetPose108:
+ax_pose 18, 0x01f3, 0x0102, 0x9c00
+ax_pose 24, 0x01e8, 0x90ef, 0x9c01
+ax_pose -1, 0x01f0, 0x0106, 0x9c00
+ax_pose_terminator
+sShuppetPose109:
+ax_pose 19, 0x01ed, 0x40fe, 0x9c00
+ax_pose 24, 0x01e8, 0x90ef, 0x9c04
+ax_pose -1, 0x01ea, 0x4102, 0x9c00
+ax_pose_terminator
+sShuppetPose110:
+ax_pose 20, 0x01ed, 0x40fe, 0x9c00
+ax_pose 24, 0x01e8, 0x90ef, 0x9c04
+ax_pose -1, 0x01ea, 0x4102, 0x9c00
+ax_pose_terminator
+sShuppetPose111:
+ax_pose 19, 0x01ed, 0x40fe, 0x9c00
+ax_pose 24, 0x01e8, 0x90ef, 0x9c04
+ax_pose -1, 0x01ea, 0x4102, 0x9c00
+ax_pose_terminator
+sShuppetPose112:
+ax_pose 21, 0x01ed, 0x40fe, 0x9c00
+ax_pose 24, 0x01e8, 0x90ef, 0x9c04
+ax_pose -1, 0x01ea, 0x4102, 0x9c00
+ax_pose_terminator
+sShuppetPose113:
+ax_pose 22, 0x01f3, 0x0102, 0x9c00
+ax_pose 24, 0x01e8, 0x90ef, 0x9c01
+ax_pose -1, 0x01f0, 0x0106, 0x9c00
+ax_pose_terminator
+sShuppetPose114:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose115:
+ax_pose 10, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose116:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose117:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose 17, 0x01ea, 0x00fb, 0x9c10
+ax_pose -1, 0x01ee, 0x0103, 0x9c10
+ax_pose_terminator
+sShuppetPose118:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose 18, 0x01ea, 0x00fb, 0x9c10
+ax_pose -1, 0x01ee, 0x0104, 0x9c10
+ax_pose_terminator
+sShuppetPose119:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose 19, 0x01e4, 0x40f7, 0x9c10
+ax_pose -1, 0x01e8, 0x4100, 0x9c10
+ax_pose_terminator
+sShuppetPose120:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose 20, 0x01e4, 0x40f7, 0x9c10
+ax_pose -1, 0x01e8, 0x4100, 0x9c10
+ax_pose_terminator
+sShuppetPose121:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose 19, 0x01e4, 0x40f7, 0x9c10
+ax_pose -1, 0x01e8, 0x4100, 0x9c10
+ax_pose_terminator
+sShuppetPose122:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose 21, 0x01e4, 0x40f7, 0x9c10
+ax_pose -1, 0x01e8, 0x4100, 0x9c10
+ax_pose_terminator
+sShuppetPose123:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose 22, 0x01ea, 0x00fb, 0x9c10
+ax_pose -1, 0x01ee, 0x0104, 0x9c10
+ax_pose_terminator
+sShuppetPose124:
+ax_pose 12, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose125:
+ax_pose 13, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose126:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose127:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose 17, 0x01eb, 0x00f5, 0x9c08
+ax_pose -1, 0x01eb, 0x0100, 0x9c08
+ax_pose_terminator
+sShuppetPose128:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose 18, 0x01eb, 0x00f5, 0x9c08
+ax_pose -1, 0x01eb, 0x0100, 0x9c08
+ax_pose_terminator
+sShuppetPose129:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose 19, 0x01e7, 0x40f1, 0x9c08
+ax_pose -1, 0x01e5, 0x40fc, 0x9c08
+ax_pose_terminator
+sShuppetPose130:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose 20, 0x01e7, 0x40f1, 0x9c08
+ax_pose -1, 0x01e5, 0x40fc, 0x9c08
+ax_pose_terminator
+sShuppetPose131:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose 19, 0x01e7, 0x40f1, 0x9c08
+ax_pose -1, 0x01e5, 0x40fc, 0x9c08
+ax_pose_terminator
+sShuppetPose132:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose 21, 0x01e7, 0x40f1, 0x9c08
+ax_pose -1, 0x01e5, 0x40fc, 0x9c08
+ax_pose_terminator
+sShuppetPose133:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose 22, 0x01eb, 0x00f5, 0x9c08
+ax_pose -1, 0x01eb, 0x0100, 0x9c08
+ax_pose_terminator
+sShuppetPose134:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose135:
+ax_pose 10, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose136:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose137:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose 17, 0x01ea, 0x10fc, 0x9c10
+ax_pose -1, 0x01ee, 0x10f4, 0x9c10
+ax_pose_terminator
+sShuppetPose138:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose 18, 0x01ea, 0x10fc, 0x9c10
+ax_pose -1, 0x01ee, 0x10f3, 0x9c10
+ax_pose_terminator
+sShuppetPose139:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose 19, 0x01e4, 0x50f8, 0x9c10
+ax_pose -1, 0x01e8, 0x50ef, 0x9c10
+ax_pose_terminator
+sShuppetPose140:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose 20, 0x01e4, 0x50f8, 0x9c10
+ax_pose -1, 0x01e8, 0x50ef, 0x9c10
+ax_pose_terminator
+sShuppetPose141:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose 19, 0x01e4, 0x50f8, 0x9c10
+ax_pose -1, 0x01e8, 0x50ef, 0x9c10
+ax_pose_terminator
+sShuppetPose142:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose 21, 0x01e4, 0x50f8, 0x9c10
+ax_pose -1, 0x01e8, 0x50ef, 0x9c10
+ax_pose_terminator
+sShuppetPose143:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose 22, 0x01ea, 0x10fc, 0x9c10
+ax_pose -1, 0x01ee, 0x10f3, 0x9c10
+ax_pose_terminator
+sShuppetPose144:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose145:
+ax_pose 7, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose146:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose147:
+ax_pose 24, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose148:
+ax_pose 17, 0x01f3, 0x10f5, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c01
+ax_pose -1, 0x01f0, 0x10f2, 0x9c00
+ax_pose_terminator
+sShuppetPose149:
+ax_pose 18, 0x01f3, 0x10f5, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c01
+ax_pose -1, 0x01f0, 0x10f1, 0x9c00
+ax_pose_terminator
+sShuppetPose150:
+ax_pose 19, 0x01ed, 0x50f1, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c04
+ax_pose -1, 0x01ea, 0x50ed, 0x9c00
+ax_pose_terminator
+sShuppetPose151:
+ax_pose 20, 0x01ed, 0x50f1, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c04
+ax_pose -1, 0x01ea, 0x50ed, 0x9c00
+ax_pose_terminator
+sShuppetPose152:
+ax_pose 19, 0x01ed, 0x50f1, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c04
+ax_pose -1, 0x01ea, 0x50ed, 0x9c00
+ax_pose_terminator
+sShuppetPose153:
+ax_pose 21, 0x01ed, 0x50f1, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c04
+ax_pose -1, 0x01ea, 0x50ed, 0x9c00
+ax_pose_terminator
+sShuppetPose154:
+ax_pose 22, 0x01f3, 0x10f5, 0x9c00
+ax_pose 24, 0x01e8, 0x80f0, 0x9c01
+ax_pose -1, 0x01f0, 0x10f1, 0x9c00
+ax_pose_terminator
+sShuppetPose155:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose156:
+ax_pose 4, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose157:
+ax_pose 5, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose158:
+ax_pose 23, 0x01e8, 0x80ef, 0x9c00
+ax_pose_terminator
+sShuppetPose159:
+ax_pose 17, 0x01f2, 0x10f3, 0x9c00
+ax_pose -1, 0x01f3, 0x10fa, 0x9c00
+ax_pose 23, 0x01e8, 0x80ef, 0x9c01
+ax_pose_terminator
+sShuppetPose160:
+ax_pose 18, 0x01f2, 0x10f2, 0x9c00
+ax_pose -1, 0x01f3, 0x10fa, 0x9c00
+ax_pose 23, 0x01e8, 0x80ef, 0x9c01
+ax_pose_terminator
+sShuppetPose161:
+ax_pose 19, 0x01ec, 0x50ee, 0x9c00
+ax_pose -1, 0x01ed, 0x50f6, 0x9c00
+ax_pose 23, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose162:
+ax_pose 20, 0x01ec, 0x50ee, 0x9c00
+ax_pose -1, 0x01ed, 0x50f6, 0x9c00
+ax_pose 23, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose163:
+ax_pose 19, 0x01ec, 0x50ee, 0x9c00
+ax_pose -1, 0x01ed, 0x50f6, 0x9c00
+ax_pose 23, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose164:
+ax_pose 21, 0x01ec, 0x50ee, 0x9c00
+ax_pose -1, 0x01ed, 0x50f6, 0x9c00
+ax_pose 23, 0x01e8, 0x80ef, 0x9c04
+ax_pose_terminator
+sShuppetPose165:
+ax_pose 22, 0x01f2, 0x10f2, 0x9c00
+ax_pose -1, 0x01f3, 0x10fa, 0x9c00
+ax_pose 23, 0x01e8, 0x80ef, 0x9c01
+ax_pose_terminator
+sShuppetPose166:
+ax_pose 25, 0x81e8, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose167:
+ax_pose 26, 0x81e8, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose168:
+ax_pose 27, 0x01e3, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose169:
+ax_pose 28, 0x01e2, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose170:
+ax_pose 29, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose171:
+ax_pose 30, 0x01e2, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose172:
+ax_pose 31, 0x01e1, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose173:
+ax_pose 30, 0x01e2, 0x80f3, 0x9c00
+ax_pose_terminator
+sShuppetPose174:
+ax_pose 29, 0x01e5, 0x80f1, 0x9c00
+ax_pose_terminator
+sShuppetPose175:
+ax_pose 28, 0x01e2, 0x80f1, 0x9c00
+ax_pose_terminator
+sShuppetPose176:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose177:
+ax_pose 1, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose178:
+ax_pose 2, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose179:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose180:
+ax_pose 4, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose181:
+ax_pose 5, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose182:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose183:
+ax_pose 7, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose184:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose185:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose186:
+ax_pose 10, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose187:
+ax_pose 11, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose188:
+ax_pose 12, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose189:
+ax_pose 13, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose190:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose191:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose192:
+ax_pose 10, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose193:
+ax_pose 11, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose194:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose195:
+ax_pose 7, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose196:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose197:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose198:
+ax_pose 4, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose199:
+ax_pose 5, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose200:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose201:
+ax_pose 3, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sShuppetPose202:
+ax_pose 6, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose203:
+ax_pose 9, 0x01e8, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose204:
+ax_pose 12, 0x81e6, 0x80f9, 0x9c00
+ax_pose_terminator
+sShuppetPose205:
+ax_pose 9, 0x01e8, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose206:
+ax_pose 6, 0x01e9, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose207:
+ax_pose 3, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sShuppetPose208:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose209:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose210:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose211:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose212:
+ax_pose 15, 0x01e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose213:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose214:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose215:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose216:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose217:
+ax_pose 3, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sShuppetPose218:
+ax_pose 6, 0x01e9, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose219:
+ax_pose 9, 0x01e8, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose220:
+ax_pose 12, 0x81e6, 0x80f9, 0x9c00
+ax_pose_terminator
+sShuppetPose221:
+ax_pose 9, 0x01e8, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose222:
+ax_pose 6, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose223:
+ax_pose 3, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sShuppetPose224:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose225:
+ax_pose 1, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose226:
+ax_pose 2, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose227:
+ax_pose 3, 0x01e8, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose228:
+ax_pose 4, 0x01e8, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose229:
+ax_pose 5, 0x01e8, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose230:
+ax_pose 6, 0x01e8, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose231:
+ax_pose 7, 0x01e8, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose232:
+ax_pose 8, 0x01e8, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose233:
+ax_pose 9, 0x01e6, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose234:
+ax_pose 10, 0x01e6, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose235:
+ax_pose 11, 0x01e6, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose236:
+ax_pose 12, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose237:
+ax_pose 13, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose238:
+ax_pose 14, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose239:
+ax_pose 9, 0x01e6, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose240:
+ax_pose 10, 0x01e6, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose241:
+ax_pose 11, 0x01e6, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose242:
+ax_pose 6, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose243:
+ax_pose 7, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose244:
+ax_pose 8, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose245:
+ax_pose 3, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose246:
+ax_pose 4, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose247:
+ax_pose 5, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose248:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose249:
+ax_pose 3, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sShuppetPose250:
+ax_pose 6, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sShuppetPose251:
+ax_pose 9, 0x01e8, 0x80f5, 0x9c00
+ax_pose_terminator
+sShuppetPose252:
+ax_pose 12, 0x81e6, 0x80f9, 0x9c00
+ax_pose_terminator
+sShuppetPose253:
+ax_pose 9, 0x01e8, 0x90ea, 0x9c00
+ax_pose_terminator
+sShuppetPose254:
+ax_pose 6, 0x01e9, 0x90ed, 0x9c00
+ax_pose_terminator
+sShuppetPose255:
+ax_pose 3, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sShuppetPose256:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose257:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose258:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose259:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose260:
+ax_pose 15, 0x01e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose261:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose262:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose263:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose264:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose265:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose266:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose267:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose268:
+ax_pose 12, 0x81e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose269:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose270:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose271:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose272:
+ax_pose 0, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose273:
+ax_pose 3, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose274:
+ax_pose 6, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sShuppetPose275:
+ax_pose 9, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sShuppetPose276:
+ax_pose 15, 0x01e4, 0x80f8, 0x9c00
+ax_pose_terminator
+sShuppetPose277:
+ax_pose 9, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sShuppetPose278:
+ax_pose 6, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sShuppetPose279:
+ax_pose 3, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+.align 2
+sShuppetAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_2_1:
+ax_anim 3, 0, 24, 0, -1, 0, -1,
+ax_anim 3, 0, 25, 0, -2, 0, -2,
+ax_anim 3, 0, 26, 0, -2, 0, -2,
+ax_anim 3, 0, 24, 0, -2, 0, -2,
+ax_anim 3, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 22, 0, 20,
+ax_anim 2, 1, 24, 1, 22, 1, 20,
+ax_anim 2, 0, 25, 0, 22, 0, 20,
+ax_anim 2, 0, 26, 1, 22, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sShuppetAnims_2_2:
+ax_anim 3, 0, 27, -1, -1, -1, -1,
+ax_anim 3, 0, 28, -2, -2, -2, -2,
+ax_anim 3, 0, 29, -2, -2, -2, -2,
+ax_anim 3, 0, 27, -2, -2, -2, -2,
+ax_anim 3, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 20, 24, 21, 22,
+ax_anim 2, 1, 27, 21, 23, 22, 21,
+ax_anim 2, 0, 28, 20, 24, 21, 22,
+ax_anim 2, 0, 29, 21, 23, 22, 21,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sShuppetAnims_2_3:
+ax_anim 3, 0, 30, -1, 0, -1, 0,
+ax_anim 3, 0, 31, -2, 0, -2, 0,
+ax_anim 3, 0, 32, -2, 0, -2, 0,
+ax_anim 3, 0, 30, -2, 0, -2, 0,
+ax_anim 3, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 1, 4, 0,
+ax_anim 1, 0, 31, 10, 2, 10, 0,
+ax_anim 2, 0, 32, 20, 2, 20, 0,
+ax_anim 2, 1, 30, 20, 3, 20, 1,
+ax_anim 2, 0, 31, 20, 2, 20, 0,
+ax_anim 2, 0, 32, 20, 3, 20, 1,
+ax_anim 2, 0, 30, 6, 1, 6, 0,
+ax_anim_terminator
+sShuppetAnims_2_4:
+ax_anim 3, 0, 33, -1, 1, -1, 1,
+ax_anim 3, 0, 34, -2, 2, -2, 2,
+ax_anim 3, 0, 35, -2, 2, -2, 2,
+ax_anim 3, 0, 33, -2, 2, -2, 2,
+ax_anim 3, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 5, -5, 5, -5,
+ax_anim 1, 0, 34, 13, -11, 13, -12,
+ax_anim 2, 0, 35, 21, -16, 21, -19,
+ax_anim 2, 1, 33, 20, -17, 20, -20,
+ax_anim 2, 0, 34, 21, -16, 21, -19,
+ax_anim 2, 0, 35, 20, -17, 20, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sShuppetAnims_2_5:
+ax_anim 3, 0, 36, 0, 1, 0, 1,
+ax_anim 3, 0, 37, 0, 2, 0, 2,
+ax_anim 3, 0, 38, 0, 2, 0, 2,
+ax_anim 3, 0, 36, 0, 2, 0, 2,
+ax_anim 3, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -5,
+ax_anim 1, 0, 37, 0, -9, 0, -11,
+ax_anim 2, 0, 38, 0, -17, 0, -21,
+ax_anim 2, 1, 36, 1, -17, 1, -21,
+ax_anim 2, 0, 37, 0, -17, 0, -21,
+ax_anim 2, 0, 38, 1, -17, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sShuppetAnims_2_6:
+ax_anim 3, 0, 39, 1, 1, 1, 1,
+ax_anim 3, 0, 40, 2, 2, 2, 2,
+ax_anim 3, 0, 41, 2, 2, 2, 2,
+ax_anim 3, 0, 39, 2, 2, 2, 2,
+ax_anim 3, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -5, -5, -5, -5,
+ax_anim 1, 0, 40, -13, -11, -13, -12,
+ax_anim 2, 0, 41, -21, -16, -21, -19,
+ax_anim 2, 1, 39, -20, -17, -20, -20,
+ax_anim 2, 0, 40, -21, -16, -21, -19,
+ax_anim 2, 0, 41, -20, -17, -20, -20,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sShuppetAnims_2_7:
+ax_anim 3, 0, 42, 1, 0, 1, 0,
+ax_anim 3, 0, 43, 2, 0, 2, 0,
+ax_anim 3, 0, 44, 2, 0, 2, 0,
+ax_anim 3, 0, 42, 2, 0, 2, 0,
+ax_anim 3, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 1, -4, 0,
+ax_anim 1, 0, 43, -10, 2, -10, 0,
+ax_anim 2, 0, 44, -20, 2, -20, 0,
+ax_anim 2, 1, 42, -20, 3, -20, 1,
+ax_anim 2, 0, 43, -20, 2, -20, 0,
+ax_anim 2, 0, 44, -20, 3, -20, 1,
+ax_anim 2, 0, 42, -6, 1, -6, 0,
+ax_anim_terminator
+sShuppetAnims_2_8:
+ax_anim 3, 0, 45, 1, -1, 1, -1,
+ax_anim 3, 0, 46, 2, -2, 2, -2,
+ax_anim 3, 0, 47, 2, -2, 2, -2,
+ax_anim 3, 0, 45, 2, -2, 2, -2,
+ax_anim 3, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 47, -20, 24, -21, 22,
+ax_anim 2, 1, 45, -21, 23, -22, 21,
+ax_anim 2, 0, 46, -20, 24, -21, 22,
+ax_anim 2, 0, 47, -21, 23, -22, 21,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sShuppetAnims_3_1:
+ax_anim 1, 0, 48, 0, -1, 0, -1,
+ax_anim 1, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 48, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, -3, 0, -3,
+ax_anim 2, 0, 50, 0, -3, 0, -3,
+ax_anim 2, 0, 51, 0, -3, 0, -3,
+ax_anim 2, 2, 52, 0, -3, 0, -3,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, 7, 0, 7,
+ax_anim 2, 0, 55, 0, 13, 0, 13,
+ax_anim 1, 1, 48, 0, 23, 0, 23,
+ax_anim 1, 0, 49, 0, 23, 0, 23,
+ax_anim 1, 0, 50, 1, 23, 1, 23,
+ax_anim 1, 0, 51, 1, 23, 1, 23,
+ax_anim 1, 0, 52, 0, 23, 0, 23,
+ax_anim 1, 0, 53, 0, 23, 0, 23,
+ax_anim 1, 0, 54, 1, 23, 1, 23,
+ax_anim 1, 0, 55, 1, 23, 1, 23,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sShuppetAnims_3_2:
+ax_anim 1, 0, 55, -1, -1, -1, -1,
+ax_anim 1, 0, 55, -2, -2, -2, -2,
+ax_anim 2, 0, 55, -3, -3, -3, -3,
+ax_anim 2, 0, 48, -3, -3, -3, -3,
+ax_anim 2, 0, 49, -3, -3, -3, -3,
+ax_anim 2, 0, 50, -3, -3, -3, -3,
+ax_anim 2, 2, 51, -3, -3, -3, -3,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 53, 7, 7, 7, 7,
+ax_anim 2, 0, 54, 13, 13, 13, 13,
+ax_anim 1, 1, 55, 21, 23, 21, 23,
+ax_anim 1, 0, 48, 21, 23, 21, 23,
+ax_anim 1, 0, 49, 20, 24, 20, 24,
+ax_anim 1, 0, 50, 20, 24, 20, 24,
+ax_anim 1, 0, 51, 21, 23, 21, 23,
+ax_anim 1, 0, 52, 21, 23, 21, 23,
+ax_anim 1, 0, 53, 20, 24, 20, 24,
+ax_anim 1, 0, 48, 20, 24, 20, 24,
+ax_anim 2, 0, 55, 10, 10, 10, 10,
+ax_anim 2, 0, 55, 4, 4, 4, 4,
+ax_anim_terminator
+sShuppetAnims_3_3:
+ax_anim 1, 0, 54, -1, 0, -1, 0,
+ax_anim 1, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 54, -3, 0, -3, 0,
+ax_anim 2, 0, 55, -3, 0, -3, 0,
+ax_anim 2, 0, 48, -3, 0, -3, 0,
+ax_anim 2, 0, 49, -3, 0, -3, 0,
+ax_anim 2, 2, 50, -3, 0, -3, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 7, 0, 7, 0,
+ax_anim 2, 0, 53, 13, 0, 13, 0,
+ax_anim 1, 1, 54, 20, 0, 20, 0,
+ax_anim 1, 0, 55, 20, 0, 20, 0,
+ax_anim 1, 0, 48, 20, 1, 20, 1,
+ax_anim 1, 0, 49, 20, 1, 20, 1,
+ax_anim 1, 0, 50, 20, 0, 20, 0,
+ax_anim 1, 0, 51, 20, 0, 20, 0,
+ax_anim 1, 0, 52, 20, 1, 20, 1,
+ax_anim 1, 0, 53, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 10, 0, 10, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim_terminator
+sShuppetAnims_3_4:
+ax_anim 1, 0, 53, -1, 1, -1, 1,
+ax_anim 1, 0, 53, -2, 2, -2, 2,
+ax_anim 2, 0, 53, -3, 3, -3, 3,
+ax_anim 2, 0, 54, -3, 3, -3, 3,
+ax_anim 2, 0, 55, -3, 3, -3, 3,
+ax_anim 2, 0, 48, -3, 3, -3, 3,
+ax_anim 2, 2, 49, -3, 3, -3, 3,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 8, -6, 8, -6,
+ax_anim 2, 0, 52, 14, -11, 14, -11,
+ax_anim 1, 1, 53, 21, -17, 21, -17,
+ax_anim 1, 0, 54, 21, -17, 21, -17,
+ax_anim 1, 0, 55, 20, -18, 20, -18,
+ax_anim 1, 0, 48, 20, -18, 20, -18,
+ax_anim 1, 0, 49, 21, -17, 21, -17,
+ax_anim 1, 0, 50, 21, -17, 21, -17,
+ax_anim 1, 0, 51, 20, -18, 20, -18,
+ax_anim 1, 0, 52, 20, -18, 20, -18,
+ax_anim 2, 0, 53, 11, -9, 11, -9,
+ax_anim 2, 0, 53, 5, -3, 5, -3,
+ax_anim_terminator
+sShuppetAnims_3_5:
+ax_anim 1, 0, 52, 0, 1, 0, 1,
+ax_anim 1, 0, 52, 0, 2, 0, 2,
+ax_anim 2, 0, 52, 0, 3, 0, 3,
+ax_anim 2, 0, 53, 0, 3, 0, 3,
+ax_anim 2, 0, 54, 0, 3, 0, 3,
+ax_anim 2, 0, 55, 0, 3, 0, 3,
+ax_anim 2, 2, 48, 0, 3, 0, 3,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 50, 0, -6, 0, -6,
+ax_anim 2, 0, 51, 0, -11, 0, -11,
+ax_anim 1, 1, 52, 0, -17, 0, -17,
+ax_anim 1, 0, 53, 0, -17, 0, -17,
+ax_anim 1, 0, 54, 1, -17, 1, -17,
+ax_anim 1, 0, 55, 1, -17, 1, -17,
+ax_anim 1, 0, 48, 0, -17, 0, -17,
+ax_anim 1, 0, 49, 0, -17, 0, -17,
+ax_anim 1, 0, 50, 1, -17, 1, -17,
+ax_anim 1, 0, 51, 1, -17, 1, -17,
+ax_anim 2, 0, 52, 0, -9, 0, -9,
+ax_anim 2, 0, 52, 0, -3, 0, -3,
+ax_anim_terminator
+sShuppetAnims_3_6:
+ax_anim 1, 0, 51, 1, 1, 1, 1,
+ax_anim 1, 0, 51, 2, 2, 2, 2,
+ax_anim 2, 0, 51, 3, 3, 3, 3,
+ax_anim 2, 0, 52, 3, 3, 3, 3,
+ax_anim 2, 0, 53, 3, 3, 3, 3,
+ax_anim 2, 0, 54, 3, 3, 3, 3,
+ax_anim 2, 2, 55, 3, 3, 3, 3,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 49, -8, -6, -8, -6,
+ax_anim 2, 0, 50, -14, -11, -14, -11,
+ax_anim 1, 1, 51, -21, -17, -21, -17,
+ax_anim 1, 0, 52, -21, -17, -21, -17,
+ax_anim 1, 0, 53, -20, -18, -20, -18,
+ax_anim 1, 0, 54, -20, -18, -20, -18,
+ax_anim 1, 0, 55, -21, -17, -21, -17,
+ax_anim 1, 0, 48, -21, -17, -21, -17,
+ax_anim 1, 0, 49, -20, -18, -20, -18,
+ax_anim 1, 0, 50, -20, -18, -20, -18,
+ax_anim 2, 0, 51, -11, -9, -11, -9,
+ax_anim 2, 0, 51, -5, -3, -5, -3,
+ax_anim_terminator
+sShuppetAnims_3_7:
+ax_anim 1, 0, 50, 1, 0, 1, 0,
+ax_anim 1, 0, 50, 2, 0, 2, 0,
+ax_anim 2, 0, 50, 3, 0, 3, 0,
+ax_anim 2, 0, 51, 3, 0, 3, 0,
+ax_anim 2, 0, 52, 3, 0, 3, 0,
+ax_anim 2, 0, 53, 3, 0, 3, 0,
+ax_anim 2, 2, 54, 3, 0, 3, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 0, 48, -7, 0, -7, 0,
+ax_anim 2, 0, 49, -13, 0, -13, 0,
+ax_anim 1, 1, 50, -20, 0, -20, 0,
+ax_anim 1, 0, 51, -20, 0, -20, 0,
+ax_anim 1, 0, 52, -20, 1, -20, 1,
+ax_anim 1, 0, 53, -20, 1, -20, 1,
+ax_anim 1, 0, 54, -20, 0, -20, 0,
+ax_anim 1, 0, 55, -20, 0, -20, 0,
+ax_anim 1, 0, 48, -20, 1, -20, 1,
+ax_anim 1, 0, 49, -20, 1, -20, 1,
+ax_anim 2, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 50, -4, 0, -4, 0,
+ax_anim_terminator
+sShuppetAnims_3_8:
+ax_anim 1, 0, 49, 1, -1, 1, -1,
+ax_anim 1, 0, 49, 2, -2, 2, -2,
+ax_anim 2, 0, 49, 3, -3, 3, -3,
+ax_anim 2, 0, 50, 3, -3, 3, -3,
+ax_anim 2, 0, 51, 3, -3, 3, -3,
+ax_anim 2, 0, 52, 3, -3, 3, -3,
+ax_anim 2, 2, 53, 3, -3, 3, -3,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 55, -7, 7, -7, 7,
+ax_anim 2, 0, 48, -13, 13, -13, 13,
+ax_anim 1, 1, 49, -21, 23, -21, 23,
+ax_anim 1, 0, 50, -21, 23, -21, 23,
+ax_anim 1, 0, 51, -20, 24, -20, 24,
+ax_anim 1, 0, 52, -20, 24, -20, 24,
+ax_anim 1, 0, 53, -21, 23, -21, 23,
+ax_anim 1, 0, 54, -21, 23, -21, 23,
+ax_anim 1, 0, 55, -20, 24, -20, 24,
+ax_anim 1, 0, 48, -20, 24, -20, 24,
+ax_anim 2, 0, 49, -10, 10, -10, 10,
+ax_anim 2, 0, 49, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sShuppetAnims_4_1:
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 2, 2, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 2, 1, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 1, 0, 1, 0,
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_4_2:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 2, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 1, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_4_3:
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 2, 2, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 2, 1, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, -1,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_4_4:
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 2, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 1, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_4_5:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 2, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 1, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_4_6:
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 2, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 1, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_4_7:
+ax_anim 2, 0, 66, 0, -1, 0, -1,
+ax_anim 2, 2, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, -1,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, -1,
+ax_anim 2, 1, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, -1,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, -1,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_4_8:
+ax_anim 2, 0, 65, -1, -1, -1, -1,
+ax_anim 2, 2, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -1, -1, -1, -1,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -1, -1, -1, -1,
+ax_anim 2, 1, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -1, -1, -1, -1,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -1, -1, -1, -1,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_5_1:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_5_2:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_5_3:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_5_4:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_5_5:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_5_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_5_7:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_5_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_6_1:
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, -1, 0, 0,
+ax_anim 18, 0, 165, 0, -2, 0, 0,
+ax_anim 10, 0, 166, 0, -2, 0, 0,
+ax_anim 10, 0, 166, 0, -1, 0, 0,
+ax_anim 18, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_7_1:
+ax_anim 2, 0, 167, 0, -2, 0, -2,
+ax_anim 8, 0, 167, 0, -3, 0, -3,
+ax_anim_terminator
+sShuppetAnims_7_2:
+ax_anim 2, 0, 168, -2, -2, -2, -2,
+ax_anim 8, 0, 168, -3, -3, -3, -3,
+ax_anim_terminator
+sShuppetAnims_7_3:
+ax_anim 2, 0, 169, -2, 0, -2, 0,
+ax_anim 8, 0, 169, -3, 0, -3, 0,
+ax_anim_terminator
+sShuppetAnims_7_4:
+ax_anim 2, 0, 170, -2, 2, -2, 2,
+ax_anim 8, 0, 170, -3, 3, -3, 3,
+ax_anim_terminator
+sShuppetAnims_7_5:
+ax_anim 2, 0, 171, 0, 2, 0, 2,
+ax_anim 8, 0, 171, 0, 3, 0, 3,
+ax_anim_terminator
+sShuppetAnims_7_6:
+ax_anim 2, 0, 172, 2, 2, 2, 2,
+ax_anim 8, 0, 172, 3, 3, 3, 3,
+ax_anim_terminator
+sShuppetAnims_7_7:
+ax_anim 2, 0, 173, 2, 0, 2, 0,
+ax_anim 8, 0, 173, 3, 0, 3, 0,
+ax_anim_terminator
+sShuppetAnims_7_8:
+ax_anim 2, 0, 174, 2, -2, 2, -2,
+ax_anim 8, 0, 174, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sShuppetAnims_8_1:
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 176, 0, -1, 0, 0,
+ax_anim 10, 0, 177, 0, -2, 0, 0,
+ax_anim 10, 0, 175, 0, -3, 0, 0,
+ax_anim 10, 0, 176, 0, -2, 0, 0,
+ax_anim 10, 0, 177, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_8_2:
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, -1, 0, 0,
+ax_anim 10, 0, 180, 0, -2, 0, 0,
+ax_anim 10, 0, 178, 0, -3, 0, 0,
+ax_anim 10, 0, 179, 0, -2, 0, 0,
+ax_anim 10, 0, 180, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_8_3:
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 10, 0, 182, 0, -1, 0, 0,
+ax_anim 10, 0, 183, 0, -2, 0, 0,
+ax_anim 10, 0, 181, 0, -3, 0, 0,
+ax_anim 10, 0, 182, 0, -2, 0, 0,
+ax_anim 10, 0, 183, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_8_4:
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, -1, 0, 0,
+ax_anim 10, 0, 186, 0, -2, 0, 0,
+ax_anim 10, 0, 184, 0, -3, 0, 0,
+ax_anim 10, 0, 185, 0, -2, 0, 0,
+ax_anim 10, 0, 186, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_8_5:
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, -1, 0, 0,
+ax_anim 10, 0, 189, 0, -2, 0, 0,
+ax_anim 10, 0, 187, 0, -3, 0, 0,
+ax_anim 10, 0, 188, 0, -2, 0, 0,
+ax_anim 10, 0, 189, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_8_6:
+ax_anim 10, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, -1, 0, 0,
+ax_anim 10, 0, 192, 0, -2, 0, 0,
+ax_anim 10, 0, 190, 0, -3, 0, 0,
+ax_anim 10, 0, 191, 0, -2, 0, 0,
+ax_anim 10, 0, 192, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_8_7:
+ax_anim 10, 0, 193, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, -1, 0, 0,
+ax_anim 10, 0, 195, 0, -2, 0, 0,
+ax_anim 10, 0, 193, 0, -3, 0, 0,
+ax_anim 10, 0, 194, 0, -2, 0, 0,
+ax_anim 10, 0, 195, 0, -1, 0, 0,
+ax_anim_terminator
+sShuppetAnims_8_8:
+ax_anim 10, 0, 196, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, -1, 0, 0,
+ax_anim 10, 0, 198, 0, -2, 0, 0,
+ax_anim 10, 0, 196, 0, -3, 0, 0,
+ax_anim 10, 0, 197, 0, -2, 0, 0,
+ax_anim 10, 0, 198, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_9_1:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 6, 3, 6, 3,
+ax_anim 2, 0, 201, 8, 11, 8, 11,
+ax_anim 2, 0, 202, 7, 19, 7, 18,
+ax_anim 3, 0, 203, 0, 24, 0, 22,
+ax_anim 2, 3, 204, -7, 19, -7, 18,
+ax_anim 2, 0, 205, -8, 11, -8, 11,
+ax_anim 1, 0, 206, -6, 3, -6, 3,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_9_2:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 8, 0, 8, 0,
+ax_anim 2, 0, 200, 19, 3, 19, 3,
+ax_anim 2, 0, 201, 23, 12, 23, 11,
+ax_anim 3, 0, 202, 21, 24, 21, 23,
+ax_anim 2, 3, 203, 11, 25, 11, 24,
+ax_anim 2, 0, 204, 3, 17, 3, 17,
+ax_anim 1, 0, 205, 0, 7, 0, 7,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_9_3:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 3, -5, 3, -5,
+ax_anim 2, 0, 199, 11, -6, 11, -6,
+ax_anim 2, 0, 200, 18, -5, 18, -5,
+ax_anim 3, 0, 201, 21, 2, 21, 0,
+ax_anim 2, 3, 202, 20, 7, 20, 5,
+ax_anim 2, 0, 203, 12, 7, 12, 5,
+ax_anim 1, 0, 204, 4, 5, 4, 3,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_9_4:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, -1, -6, -1, -6,
+ax_anim 2, 0, 206, 4, -16, 4, -16,
+ax_anim 2, 0, 199, 12, -22, 12, -22,
+ax_anim 3, 0, 200, 21, -19, 21, -19,
+ax_anim 2, 3, 201, 22, -13, 22, -13,
+ax_anim 2, 0, 202, 17, -4, 17, -4,
+ax_anim 1, 0, 203, 7, -1, 7, -1,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_9_5:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, -8, -4, -8, -4,
+ax_anim 2, 0, 205, -9, -10, -9, -10,
+ax_anim 2, 0, 206, -7, -16, -7, -16,
+ax_anim 3, 0, 199, 0, -19, 0, -19,
+ax_anim 2, 3, 200, 7, -16, 7, -16,
+ax_anim 2, 0, 201, 9, -8, 9, -8,
+ax_anim 1, 0, 202, 8, -4, 8, -4,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_9_6:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 1, -6, 1, -6,
+ax_anim 2, 0, 200, -4, -16, -4, -16,
+ax_anim 2, 0, 199, -12, -22, -12, -22,
+ax_anim 3, 0, 206, -21, -19, -21, -19,
+ax_anim 2, 3, 205, -22, -13, -22, -13,
+ax_anim 2, 0, 204, -17, -4, -17, -4,
+ax_anim 1, 0, 203, -7, -1, -7, -1,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_9_7:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -3, -5, -3, -5,
+ax_anim 2, 0, 199, -11, -6, -11, -6,
+ax_anim 2, 0, 206, -18, -5, -18, -5,
+ax_anim 3, 0, 205, -21, 2, -21, 0,
+ax_anim 2, 3, 204, -20, 7, -20, 5,
+ax_anim 2, 0, 203, -12, 7, -12, 5,
+ax_anim 1, 0, 202, -4, 5, -4, 3,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_9_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -8, 0, -8, 0,
+ax_anim 2, 0, 206, -19, 3, -19, 3,
+ax_anim 2, 0, 205, -23, 12, -23, 11,
+ax_anim 3, 0, 204, -21, 24, -21, 23,
+ax_anim 2, 3, 203, -11, 25, -11, 24,
+ax_anim 2, 0, 202, -3, 17, -3, 17,
+ax_anim 1, 0, 201, 0, 7, 0, 7,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_10_1:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, 0, 6, 0,
+ax_anim 2, 0, 215, -6, 0, -6, 0,
+ax_anim 2, 0, 215, 10, 0, 10, 0,
+ax_anim 2, 0, 215, -10, 0, -10, 0,
+ax_anim 2, 0, 215, 12, 0, 12, 0,
+ax_anim 3, 0, 215, -12, 0, -12, 0,
+ax_anim 3, 0, 215, 13, 0, 13, 0,
+ax_anim 3, 0, 215, -13, 0, -13, 0,
+ax_anim 2, 0, 215, 12, 0, 12, 0,
+ax_anim 3, 0, 215, -12, 0, -12, 0,
+ax_anim 2, 0, 215, 10, 0, 10, 0,
+ax_anim 2, 0, 215, -10, 0, -10, 0,
+ax_anim 2, 0, 215, 6, 0, 6, 0,
+ax_anim 2, 0, 215, -6, 0, -6, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_10_2:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 6, -6, 6, -6,
+ax_anim 2, 0, 216, -6, 6, -6, 6,
+ax_anim 2, 0, 216, 10, -10, 10, -10,
+ax_anim 2, 0, 216, -10, 10, -10, 10,
+ax_anim 2, 0, 216, 12, -12, 12, -12,
+ax_anim 3, 0, 216, -12, 12, -12, 12,
+ax_anim 3, 0, 216, 13, -13, 13, -13,
+ax_anim 3, 0, 216, -13, 13, -13, 13,
+ax_anim 2, 0, 216, 12, -12, 12, -12,
+ax_anim 3, 0, 216, -12, 12, -12, 12,
+ax_anim 2, 0, 216, 10, -10, 10, -10,
+ax_anim 2, 0, 216, -10, 10, -10, 10,
+ax_anim 2, 0, 216, 6, -6, 6, -6,
+ax_anim 2, 0, 216, -6, 6, -6, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_10_3:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, -6, 0, -6,
+ax_anim 2, 0, 217, 0, 6, 0, 6,
+ax_anim 2, 0, 217, 0, -10, 0, -10,
+ax_anim 2, 0, 217, 0, 10, 0, 10,
+ax_anim 2, 0, 217, 0, -12, 0, -12,
+ax_anim 3, 0, 217, 0, 12, 0, 12,
+ax_anim 3, 0, 217, 0, -13, 0, -13,
+ax_anim 3, 0, 217, 0, 13, 0, 13,
+ax_anim 2, 0, 217, 0, -12, 0, -12,
+ax_anim 3, 0, 217, 0, 12, 0, 12,
+ax_anim 2, 0, 217, 0, -10, 0, -10,
+ax_anim 2, 0, 217, 0, 10, 0, 10,
+ax_anim 2, 0, 217, 0, -6, 0, -6,
+ax_anim 2, 0, 217, 0, 6, 0, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_10_4:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, -6, -6, -6, -6,
+ax_anim 2, 0, 218, 6, 6, 6, 6,
+ax_anim 2, 0, 218, -10, -10, -10, -10,
+ax_anim 2, 0, 218, 10, 10, 10, 10,
+ax_anim 2, 0, 218, -12, -12, -12, -12,
+ax_anim 3, 0, 218, 12, 12, 12, 12,
+ax_anim 3, 0, 218, -13, -13, -13, -13,
+ax_anim 3, 0, 218, 13, 13, 13, 13,
+ax_anim 2, 0, 218, -12, -12, -12, -12,
+ax_anim 3, 0, 218, 12, 12, 12, 12,
+ax_anim 2, 0, 218, -10, -10, -10, -10,
+ax_anim 2, 0, 218, 10, 10, 10, 10,
+ax_anim 2, 0, 218, -6, -6, -6, -6,
+ax_anim 2, 0, 218, 6, 6, 6, 6,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_10_5:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, 0, 6, 0,
+ax_anim 2, 0, 219, -6, 0, -6, 0,
+ax_anim 2, 0, 219, 10, 0, 10, 0,
+ax_anim 2, 0, 219, -10, 0, -10, 0,
+ax_anim 2, 0, 219, 12, 0, 12, 0,
+ax_anim 3, 0, 219, -12, 0, -12, 0,
+ax_anim 3, 0, 219, 13, 0, 13, 0,
+ax_anim 3, 0, 219, -13, 0, -13, 0,
+ax_anim 2, 0, 219, 12, 0, 12, 0,
+ax_anim 3, 0, 219, -12, 0, -12, 0,
+ax_anim 2, 0, 219, 10, 0, 10, 0,
+ax_anim 2, 0, 219, -10, 0, -10, 0,
+ax_anim 2, 0, 219, 6, 0, 6, 0,
+ax_anim 2, 0, 219, -6, 0, -6, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_10_6:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 6, -6, 6, -6,
+ax_anim 2, 0, 220, -6, 6, -6, 6,
+ax_anim 2, 0, 220, 10, -10, 10, -10,
+ax_anim 2, 0, 220, -10, 10, -10, 10,
+ax_anim 2, 0, 220, 12, -12, 12, -12,
+ax_anim 3, 0, 220, -12, 12, -12, 12,
+ax_anim 3, 0, 220, 13, -13, 13, -13,
+ax_anim 3, 0, 220, -13, 13, -13, 13,
+ax_anim 2, 0, 220, 12, -12, 12, -12,
+ax_anim 3, 0, 220, -12, 12, -12, 12,
+ax_anim 2, 0, 220, 10, -10, 10, -10,
+ax_anim 2, 0, 220, -10, 10, -10, 10,
+ax_anim 2, 0, 220, 6, -6, 6, -6,
+ax_anim 2, 0, 220, -6, 6, -6, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_10_7:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, -6, 0, -6,
+ax_anim 2, 0, 221, 0, 6, 0, 6,
+ax_anim 2, 0, 221, 0, -10, 0, -10,
+ax_anim 2, 0, 221, 0, 10, 0, 10,
+ax_anim 2, 0, 221, 0, -12, 0, -12,
+ax_anim 3, 0, 221, 0, 12, 0, 12,
+ax_anim 3, 0, 221, 0, -13, 0, -13,
+ax_anim 3, 0, 221, 0, 13, 0, 13,
+ax_anim 2, 0, 221, 0, -12, 0, -12,
+ax_anim 3, 0, 221, 0, 12, 0, 12,
+ax_anim 2, 0, 221, 0, -10, 0, -10,
+ax_anim 2, 0, 221, 0, 10, 0, 10,
+ax_anim 2, 0, 221, 0, -6, 0, -6,
+ax_anim 2, 0, 221, 0, 6, 0, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_10_8:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -6, -6, -6, -6,
+ax_anim 2, 0, 222, 6, 6, 6, 6,
+ax_anim 2, 0, 222, -10, -10, -10, -10,
+ax_anim 2, 0, 222, 10, 10, 10, 10,
+ax_anim 2, 0, 222, -12, -12, -12, -12,
+ax_anim 3, 0, 222, 12, 12, 12, 12,
+ax_anim 3, 0, 222, -13, -13, -13, -13,
+ax_anim 3, 0, 222, 13, 13, 13, 13,
+ax_anim 2, 0, 222, -12, -12, -12, -12,
+ax_anim 3, 0, 222, 12, 12, 12, 12,
+ax_anim 2, 0, 222, -10, -10, -10, -10,
+ax_anim 2, 0, 222, 10, 10, 10, 10,
+ax_anim 2, 0, 222, -6, -6, -6, -6,
+ax_anim 2, 0, 222, 6, 6, 6, 6,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_11_1:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 2, 223, 0, 4, 0, 0,
+ax_anim_terminator
+sShuppetAnims_11_2:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 227, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 2, 226, 0, 4, 0, 0,
+ax_anim_terminator
+sShuppetAnims_11_3:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 229, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 2, 229, 0, 4, 0, 0,
+ax_anim_terminator
+sShuppetAnims_11_4:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -22, 0, 0,
+ax_anim 3, 0, 232, 0, -21, 0, 0,
+ax_anim 2, 0, 233, 0, -17, 0, 0,
+ax_anim 1, 0, 234, 0, -8, 0, 0,
+ax_anim 2, 2, 232, 0, 5, 0, 0,
+ax_anim_terminator
+sShuppetAnims_11_5:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 236, 0, -21, 0, 0,
+ax_anim 4, 0, 237, 0, -23, 0, 0,
+ax_anim 3, 0, 235, 0, -22, 0, 0,
+ax_anim 2, 0, 236, 0, -18, 0, 0,
+ax_anim 1, 0, 237, 0, -9, 0, 0,
+ax_anim 2, 2, 235, 0, 5, 0, 0,
+ax_anim_terminator
+sShuppetAnims_11_6:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -22, 0, 0,
+ax_anim 3, 0, 238, 0, -21, 0, 0,
+ax_anim 2, 0, 239, 0, -17, 0, 0,
+ax_anim 1, 0, 240, 0, -8, 0, 0,
+ax_anim 2, 2, 238, 0, 5, 0, 0,
+ax_anim_terminator
+sShuppetAnims_11_7:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -10, 0, 0,
+ax_anim 2, 0, 243, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 242, 0, -21, 0, 0,
+ax_anim 4, 0, 243, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 242, 0, -18, 0, 0,
+ax_anim 1, 0, 243, 0, -10, 0, 0,
+ax_anim 2, 2, 241, 0, 4, 0, 0,
+ax_anim_terminator
+sShuppetAnims_11_8:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 245, 0, -10, 0, 0,
+ax_anim 2, 0, 246, 0, -16, 0, 0,
+ax_anim 3, 0, 244, 0, -20, 0, 0,
+ax_anim 4, 0, 245, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -23, 0, 0,
+ax_anim 3, 0, 244, 0, -22, 0, 0,
+ax_anim 2, 0, 245, 0, -18, 0, 0,
+ax_anim 1, 0, 246, 0, -10, 0, 0,
+ax_anim 2, 2, 244, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_12_1:
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 1, 0, 1, 0,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_12_2:
+ax_anim 2, 0, 254, 1, -1, 1, -1,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, -1, 1, -1,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, -1, 1, -1,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, -1, 1, -1,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, -1, 1, -1,
+ax_anim 2, 1, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_12_3:
+ax_anim 2, 0, 253, 0, -1, 0, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, -1, 0, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, -1, 0, -1,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, -1, 0, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, -1, 0, -1,
+ax_anim 2, 1, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_12_4:
+ax_anim 2, 0, 252, -1, -1, -1, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, -1, -1, -1, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, -1, -1, -1, -1,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, -1, -1, -1, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, -1, -1, -1, -1,
+ax_anim 2, 1, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_12_5:
+ax_anim 2, 0, 251, 1, 0, 1, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 1, 0, 1, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 1, 0, 1, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 1, 0, 1, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 1, 0, 1, 0,
+ax_anim 2, 1, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_12_6:
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, -1, 1, -1,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_12_7:
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, -1, 0, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_12_8:
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, -1, -1, -1, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sShuppetAnims_13_1:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_13_2:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_13_3:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_13_4:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 2, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_13_5:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_13_6:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_13_7:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetAnims_13_8:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sShuppetGfx1:
+.incbin "baserom.gba", 0x1493010, 0x200
+sShuppetSprites1:
+ax_sprite sShuppetGfx1, 0x200
+ax_sprite_terminator
+sShuppetGfx2:
+.incbin "baserom.gba", 0x1493220, 0x200
+sShuppetSprites2:
+ax_sprite sShuppetGfx2, 0x200
+ax_sprite_terminator
+sShuppetGfx3:
+.incbin "baserom.gba", 0x1493430, 0x200
+sShuppetSprites3:
+ax_sprite sShuppetGfx3, 0x200
+ax_sprite_terminator
+sShuppetGfx4:
+.incbin "baserom.gba", 0x1493640, 0x200
+sShuppetSprites4:
+ax_sprite sShuppetGfx4, 0x200
+ax_sprite_terminator
+sShuppetGfx5:
+.incbin "baserom.gba", 0x1493850, 0x200
+sShuppetSprites5:
+ax_sprite sShuppetGfx5, 0x200
+ax_sprite_terminator
+sShuppetGfx6:
+.incbin "baserom.gba", 0x1493A60, 0x200
+sShuppetSprites6:
+ax_sprite sShuppetGfx6, 0x200
+ax_sprite_terminator
+sShuppetGfx7:
+.incbin "baserom.gba", 0x1493C70, 0x200
+sShuppetSprites7:
+ax_sprite sShuppetGfx7, 0x200
+ax_sprite_terminator
+sShuppetGfx8:
+.incbin "baserom.gba", 0x1493E80, 0x200
+sShuppetSprites8:
+ax_sprite sShuppetGfx8, 0x200
+ax_sprite_terminator
+sShuppetGfx9:
+.incbin "baserom.gba", 0x1494090, 0x200
+sShuppetSprites9:
+ax_sprite sShuppetGfx9, 0x200
+ax_sprite_terminator
+sShuppetGfx10:
+.incbin "baserom.gba", 0x14942A0, 0x200
+sShuppetSprites10:
+ax_sprite sShuppetGfx10, 0x200
+ax_sprite_terminator
+sShuppetGfx11:
+.incbin "baserom.gba", 0x14944B0, 0x200
+sShuppetSprites11:
+ax_sprite sShuppetGfx11, 0x200
+ax_sprite_terminator
+sShuppetGfx12:
+.incbin "baserom.gba", 0x14946C0, 0x200
+sShuppetSprites12:
+ax_sprite sShuppetGfx12, 0x200
+ax_sprite_terminator
+sShuppetGfx13:
+.incbin "baserom.gba", 0x14948D0, 0x100
+sShuppetSprites13:
+ax_sprite sShuppetGfx13, 0x100
+ax_sprite_terminator
+sShuppetGfx14:
+.incbin "baserom.gba", 0x14949E0, 0x100
+sShuppetSprites14:
+ax_sprite sShuppetGfx14, 0x100
+ax_sprite_terminator
+sShuppetGfx15:
+.incbin "baserom.gba", 0x1494AF0, 0x100
+sShuppetSprites15:
+ax_sprite sShuppetGfx15, 0x100
+ax_sprite_terminator
+sShuppetGfx16:
+.incbin "baserom.gba", 0x1494C00, 0x40
+sShuppetGfx16_1:
+.incbin "baserom.gba", 0x1494C40, 0x40
+sShuppetGfx16_2:
+.incbin "baserom.gba", 0x1494C80, 0x40
+sShuppetSprites16:
+ax_sprite sShuppetGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShuppetGfx16_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShuppetGfx16_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sShuppetGfx17:
+.incbin "baserom.gba", 0x1494CF8, 0x40
+sShuppetGfx17_1:
+.incbin "baserom.gba", 0x1494D38, 0x60
+sShuppetGfx17_2:
+.incbin "baserom.gba", 0x1494D98, 0x40
+sShuppetSprites17:
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sShuppetGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuppetGfx18:
+.incbin "baserom.gba", 0x1494E18, 0x20
+sShuppetSprites18:
+ax_sprite sShuppetGfx18, 0x20
+ax_sprite_terminator
+sShuppetGfx19:
+.incbin "baserom.gba", 0x1494E48, 0x20
+sShuppetSprites19:
+ax_sprite sShuppetGfx19, 0x20
+ax_sprite_terminator
+sShuppetGfx20:
+.incbin "baserom.gba", 0x1494E78, 0x80
+sShuppetSprites20:
+ax_sprite sShuppetGfx20, 0x80
+ax_sprite_terminator
+sShuppetGfx21:
+.incbin "baserom.gba", 0x1494F08, 0x60
+sShuppetSprites21:
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx21, 0x60
+ax_sprite_terminator
+sShuppetGfx22:
+.incbin "baserom.gba", 0x1494F80, 0x60
+sShuppetSprites22:
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx22, 0x60
+ax_sprite_terminator
+sShuppetGfx23:
+.incbin "baserom.gba", 0x1494FF8, 0x20
+sShuppetSprites23:
+ax_sprite sShuppetGfx23, 0x20
+ax_sprite_terminator
+sShuppetGfx24:
+.incbin "baserom.gba", 0x1495028, 0x40
+sShuppetGfx24_1:
+.incbin "baserom.gba", 0x1495068, 0x60
+sShuppetGfx24_2:
+.incbin "baserom.gba", 0x14950C8, 0x60
+sShuppetSprites24:
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuppetGfx25:
+.incbin "baserom.gba", 0x1495168, 0x60
+sShuppetGfx25_1:
+.incbin "baserom.gba", 0x14951C8, 0x60
+sShuppetGfx25_2:
+.incbin "baserom.gba", 0x1495228, 0x40
+sShuppetSprites25:
+ax_sprite sShuppetGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sShuppetGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sShuppetGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sShuppetGfx26:
+.incbin "baserom.gba", 0x14952A0, 0x100
+sShuppetSprites26:
+ax_sprite sShuppetGfx26, 0x100
+ax_sprite_terminator
+sShuppetGfx27:
+.incbin "baserom.gba", 0x14953B0, 0x100
+sShuppetSprites27:
+ax_sprite sShuppetGfx27, 0x100
+ax_sprite_terminator
+sShuppetGfx28:
+.incbin "baserom.gba", 0x14954C0, 0x200
+sShuppetSprites28:
+ax_sprite sShuppetGfx28, 0x200
+ax_sprite_terminator
+sShuppetGfx29:
+.incbin "baserom.gba", 0x14956D0, 0x200
+sShuppetSprites29:
+ax_sprite sShuppetGfx29, 0x200
+ax_sprite_terminator
+sShuppetGfx30:
+.incbin "baserom.gba", 0x14958E0, 0x200
+sShuppetSprites30:
+ax_sprite sShuppetGfx30, 0x200
+ax_sprite_terminator
+sShuppetGfx31:
+.incbin "baserom.gba", 0x1495AF0, 0x200
+sShuppetSprites31:
+ax_sprite sShuppetGfx31, 0x200
+ax_sprite_terminator
+sShuppetGfx32:
+.incbin "baserom.gba", 0x1495D00, 0x200
+sShuppetSprites32:
+ax_sprite sShuppetGfx32, 0x200
+ax_sprite_terminator
+sAxPosesShuppet:
+.4byte sShuppetPose1
+.4byte sShuppetPose2
+.4byte sShuppetPose3
+.4byte sShuppetPose4
+.4byte sShuppetPose5
+.4byte sShuppetPose6
+.4byte sShuppetPose7
+.4byte sShuppetPose8
+.4byte sShuppetPose9
+.4byte sShuppetPose10
+.4byte sShuppetPose11
+.4byte sShuppetPose12
+.4byte sShuppetPose13
+.4byte sShuppetPose14
+.4byte sShuppetPose15
+.4byte sShuppetPose16
+.4byte sShuppetPose17
+.4byte sShuppetPose18
+.4byte sShuppetPose19
+.4byte sShuppetPose20
+.4byte sShuppetPose21
+.4byte sShuppetPose22
+.4byte sShuppetPose23
+.4byte sShuppetPose24
+.4byte sShuppetPose25
+.4byte sShuppetPose26
+.4byte sShuppetPose27
+.4byte sShuppetPose28
+.4byte sShuppetPose29
+.4byte sShuppetPose30
+.4byte sShuppetPose31
+.4byte sShuppetPose32
+.4byte sShuppetPose33
+.4byte sShuppetPose34
+.4byte sShuppetPose35
+.4byte sShuppetPose36
+.4byte sShuppetPose37
+.4byte sShuppetPose38
+.4byte sShuppetPose39
+.4byte sShuppetPose40
+.4byte sShuppetPose41
+.4byte sShuppetPose42
+.4byte sShuppetPose43
+.4byte sShuppetPose44
+.4byte sShuppetPose45
+.4byte sShuppetPose46
+.4byte sShuppetPose47
+.4byte sShuppetPose48
+.4byte sShuppetPose49
+.4byte sShuppetPose50
+.4byte sShuppetPose51
+.4byte sShuppetPose52
+.4byte sShuppetPose53
+.4byte sShuppetPose54
+.4byte sShuppetPose55
+.4byte sShuppetPose56
+.4byte sShuppetPose57
+.4byte sShuppetPose58
+.4byte sShuppetPose59
+.4byte sShuppetPose60
+.4byte sShuppetPose61
+.4byte sShuppetPose62
+.4byte sShuppetPose63
+.4byte sShuppetPose64
+.4byte sShuppetPose65
+.4byte sShuppetPose66
+.4byte sShuppetPose67
+.4byte sShuppetPose68
+.4byte sShuppetPose69
+.4byte sShuppetPose70
+.4byte sShuppetPose71
+.4byte sShuppetPose72
+.4byte sShuppetPose73
+.4byte sShuppetPose74
+.4byte sShuppetPose75
+.4byte sShuppetPose76
+.4byte sShuppetPose77
+.4byte sShuppetPose78
+.4byte sShuppetPose79
+.4byte sShuppetPose80
+.4byte sShuppetPose81
+.4byte sShuppetPose82
+.4byte sShuppetPose83
+.4byte sShuppetPose84
+.4byte sShuppetPose85
+.4byte sShuppetPose86
+.4byte sShuppetPose87
+.4byte sShuppetPose88
+.4byte sShuppetPose89
+.4byte sShuppetPose90
+.4byte sShuppetPose91
+.4byte sShuppetPose92
+.4byte sShuppetPose93
+.4byte sShuppetPose94
+.4byte sShuppetPose95
+.4byte sShuppetPose96
+.4byte sShuppetPose97
+.4byte sShuppetPose98
+.4byte sShuppetPose99
+.4byte sShuppetPose100
+.4byte sShuppetPose101
+.4byte sShuppetPose102
+.4byte sShuppetPose103
+.4byte sShuppetPose104
+.4byte sShuppetPose105
+.4byte sShuppetPose106
+.4byte sShuppetPose107
+.4byte sShuppetPose108
+.4byte sShuppetPose109
+.4byte sShuppetPose110
+.4byte sShuppetPose111
+.4byte sShuppetPose112
+.4byte sShuppetPose113
+.4byte sShuppetPose114
+.4byte sShuppetPose115
+.4byte sShuppetPose116
+.4byte sShuppetPose117
+.4byte sShuppetPose118
+.4byte sShuppetPose119
+.4byte sShuppetPose120
+.4byte sShuppetPose121
+.4byte sShuppetPose122
+.4byte sShuppetPose123
+.4byte sShuppetPose124
+.4byte sShuppetPose125
+.4byte sShuppetPose126
+.4byte sShuppetPose127
+.4byte sShuppetPose128
+.4byte sShuppetPose129
+.4byte sShuppetPose130
+.4byte sShuppetPose131
+.4byte sShuppetPose132
+.4byte sShuppetPose133
+.4byte sShuppetPose134
+.4byte sShuppetPose135
+.4byte sShuppetPose136
+.4byte sShuppetPose137
+.4byte sShuppetPose138
+.4byte sShuppetPose139
+.4byte sShuppetPose140
+.4byte sShuppetPose141
+.4byte sShuppetPose142
+.4byte sShuppetPose143
+.4byte sShuppetPose144
+.4byte sShuppetPose145
+.4byte sShuppetPose146
+.4byte sShuppetPose147
+.4byte sShuppetPose148
+.4byte sShuppetPose149
+.4byte sShuppetPose150
+.4byte sShuppetPose151
+.4byte sShuppetPose152
+.4byte sShuppetPose153
+.4byte sShuppetPose154
+.4byte sShuppetPose155
+.4byte sShuppetPose156
+.4byte sShuppetPose157
+.4byte sShuppetPose158
+.4byte sShuppetPose159
+.4byte sShuppetPose160
+.4byte sShuppetPose161
+.4byte sShuppetPose162
+.4byte sShuppetPose163
+.4byte sShuppetPose164
+.4byte sShuppetPose165
+.4byte sShuppetPose166
+.4byte sShuppetPose167
+.4byte sShuppetPose168
+.4byte sShuppetPose169
+.4byte sShuppetPose170
+.4byte sShuppetPose171
+.4byte sShuppetPose172
+.4byte sShuppetPose173
+.4byte sShuppetPose174
+.4byte sShuppetPose175
+.4byte sShuppetPose176
+.4byte sShuppetPose177
+.4byte sShuppetPose178
+.4byte sShuppetPose179
+.4byte sShuppetPose180
+.4byte sShuppetPose181
+.4byte sShuppetPose182
+.4byte sShuppetPose183
+.4byte sShuppetPose184
+.4byte sShuppetPose185
+.4byte sShuppetPose186
+.4byte sShuppetPose187
+.4byte sShuppetPose188
+.4byte sShuppetPose189
+.4byte sShuppetPose190
+.4byte sShuppetPose191
+.4byte sShuppetPose192
+.4byte sShuppetPose193
+.4byte sShuppetPose194
+.4byte sShuppetPose195
+.4byte sShuppetPose196
+.4byte sShuppetPose197
+.4byte sShuppetPose198
+.4byte sShuppetPose199
+.4byte sShuppetPose200
+.4byte sShuppetPose201
+.4byte sShuppetPose202
+.4byte sShuppetPose203
+.4byte sShuppetPose204
+.4byte sShuppetPose205
+.4byte sShuppetPose206
+.4byte sShuppetPose207
+.4byte sShuppetPose208
+.4byte sShuppetPose209
+.4byte sShuppetPose210
+.4byte sShuppetPose211
+.4byte sShuppetPose212
+.4byte sShuppetPose213
+.4byte sShuppetPose214
+.4byte sShuppetPose215
+.4byte sShuppetPose216
+.4byte sShuppetPose217
+.4byte sShuppetPose218
+.4byte sShuppetPose219
+.4byte sShuppetPose220
+.4byte sShuppetPose221
+.4byte sShuppetPose222
+.4byte sShuppetPose223
+.4byte sShuppetPose224
+.4byte sShuppetPose225
+.4byte sShuppetPose226
+.4byte sShuppetPose227
+.4byte sShuppetPose228
+.4byte sShuppetPose229
+.4byte sShuppetPose230
+.4byte sShuppetPose231
+.4byte sShuppetPose232
+.4byte sShuppetPose233
+.4byte sShuppetPose234
+.4byte sShuppetPose235
+.4byte sShuppetPose236
+.4byte sShuppetPose237
+.4byte sShuppetPose238
+.4byte sShuppetPose239
+.4byte sShuppetPose240
+.4byte sShuppetPose241
+.4byte sShuppetPose242
+.4byte sShuppetPose243
+.4byte sShuppetPose244
+.4byte sShuppetPose245
+.4byte sShuppetPose246
+.4byte sShuppetPose247
+.4byte sShuppetPose248
+.4byte sShuppetPose249
+.4byte sShuppetPose250
+.4byte sShuppetPose251
+.4byte sShuppetPose252
+.4byte sShuppetPose253
+.4byte sShuppetPose254
+.4byte sShuppetPose255
+.4byte sShuppetPose256
+.4byte sShuppetPose257
+.4byte sShuppetPose258
+.4byte sShuppetPose259
+.4byte sShuppetPose260
+.4byte sShuppetPose261
+.4byte sShuppetPose262
+.4byte sShuppetPose263
+.4byte sShuppetPose264
+.4byte sShuppetPose265
+.4byte sShuppetPose266
+.4byte sShuppetPose267
+.4byte sShuppetPose268
+.4byte sShuppetPose269
+.4byte sShuppetPose270
+.4byte sShuppetPose271
+.4byte sShuppetPose272
+.4byte sShuppetPose273
+.4byte sShuppetPose274
+.4byte sShuppetPose275
+.4byte sShuppetPose276
+.4byte sShuppetPose277
+.4byte sShuppetPose278
+.4byte sShuppetPose279
+sAxPositionsShuppet:
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -7, 	   4,   -7, 	  -1,  -10
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte    4,   -8, 	   6,   -9, 	  -4,   -7, 	   2,   -9
+.2byte    5,   -8, 	   7,   -9, 	  -3,   -7, 	   2,   -9
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    4,   -8, 	  -2,  -10, 	  -4,   -7, 	   0,  -11
+.2byte    4,   -8, 	  -1,  -10, 	  -2,   -6, 	   0,  -11
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    2,  -14, 	  -5,  -11, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -11, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -4,  -14, 	   3,  -11, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   2,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	  -1,  -10, 	   0,   -6, 	  -2,  -11
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	  -8,   -9, 	   2,   -7, 	  -4,   -9
+.2byte   -7,   -8, 	  -9,   -9, 	   1,   -7, 	  -4,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -7, 	   4,   -7, 	  -1,  -10
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte    4,   -8, 	   6,   -9, 	  -4,   -7, 	   2,   -9
+.2byte    5,   -8, 	   7,   -9, 	  -3,   -7, 	   2,   -9
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    4,   -8, 	  -2,  -10, 	  -4,   -7, 	   0,  -11
+.2byte    4,   -8, 	  -1,  -10, 	  -2,   -6, 	   0,  -11
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    2,  -14, 	  -5,  -11, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -11, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -4,  -14, 	   3,  -11, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   2,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	  -1,  -10, 	   0,   -6, 	  -2,  -11
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	  -8,   -9, 	   2,   -7, 	  -4,   -9
+.2byte   -7,   -8, 	  -9,   -9, 	   1,   -7, 	  -4,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -4,   -7, 	  -5,   -8, 	   4,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,   -9, 	   3,   -5, 	   0,  -10
+.2byte   -3,  -11, 	   3,   -9, 	  -2,   -4, 	  -1,  -10
+.2byte   -1,  -15, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    1,  -11, 	  -5,   -9, 	   0,   -4, 	  -1,  -10
+.2byte    2,   -7, 	  -4,   -9, 	  -5,   -5, 	  -2,  -10
+.2byte    2,   -7, 	   3,   -8, 	  -6,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -4,   -7, 	  -5,   -8, 	   4,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,   -9, 	   3,   -5, 	   0,  -10
+.2byte   -3,  -11, 	   3,   -9, 	  -2,   -4, 	  -1,  -10
+.2byte   -1,  -15, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    1,  -11, 	  -5,   -9, 	   0,   -4, 	  -1,  -10
+.2byte    2,   -7, 	  -4,   -9, 	  -5,   -5, 	  -2,  -10
+.2byte    2,   -7, 	   3,   -8, 	  -6,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -7, 	   4,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -7,   -8, 	   5,   -8, 	  -1,  -10
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte    4,   -8, 	   6,   -9, 	  -4,   -7, 	   2,   -9
+.2byte    5,   -8, 	   7,   -9, 	  -3,   -7, 	   2,   -9
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    5,   -9, 	   7,  -10, 	  -3,   -7, 	   1,  -10
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    4,   -8, 	  -2,  -10, 	  -4,   -7, 	   0,  -11
+.2byte    4,   -8, 	  -1,  -10, 	  -2,   -6, 	   0,  -11
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    3,   -8, 	  -2,  -10, 	  -3,   -7, 	   0,  -10
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    2,  -14, 	  -5,  -11, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -11, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -4,  -14, 	   3,  -11, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   2,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	  -1,  -10, 	   0,   -6, 	  -2,  -11
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -5,   -8, 	   0,  -10, 	   1,   -7, 	  -2,  -10
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	  -8,   -9, 	   2,   -7, 	  -4,   -9
+.2byte   -7,   -8, 	  -9,   -9, 	   1,   -7, 	  -4,   -9
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte   -7,   -9, 	  -9,  -10, 	   1,   -7, 	  -3,  -10
+.2byte    0,   -8, 	  -4,   -6, 	   3,   -6, 	  -1,  -10
+.2byte    0,   -9, 	  -4,   -7, 	   3,   -6, 	  -1,  -11
+.2byte    0,   -9, 	  -4,   -7, 	   4,   -7, 	   0,  -10
+.2byte    2,  -10, 	   4,   -9, 	  -4,   -5, 	  -2,  -10
+.2byte    3,  -11, 	   1,   -9, 	   1,   -4, 	  -1,   -8
+.2byte    1,  -13, 	  -1,   -8, 	   5,   -7, 	   0,   -8
+.2byte    0,  -13, 	   5,   -8, 	  -6,   -8, 	   0,   -8
+.2byte   -2,  -13, 	   0,   -8, 	  -6,   -7, 	  -1,   -8
+.2byte   -4,  -11, 	  -2,   -9, 	  -2,   -4, 	   0,   -8
+.2byte   -3,  -10, 	  -5,   -9, 	   3,   -5, 	   1,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -7, 	   4,   -7, 	  -1,  -10
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte    4,   -8, 	   6,   -9, 	  -4,   -7, 	   2,   -9
+.2byte    5,   -8, 	   7,   -9, 	  -3,   -7, 	   2,   -9
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    4,   -8, 	  -2,  -10, 	  -4,   -7, 	   0,  -11
+.2byte    4,   -8, 	  -1,  -10, 	  -2,   -6, 	   0,  -11
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    2,  -14, 	  -5,  -11, 	   1,   -7, 	   0,  -11
+.2byte    1,  -14, 	  -5,  -10, 	   1,   -7, 	   0,  -11
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -11, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -4,  -14, 	   3,  -11, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -14, 	   3,  -10, 	  -3,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -6,   -8, 	   0,  -10, 	   2,   -7, 	  -2,  -11
+.2byte   -6,   -8, 	  -1,  -10, 	   0,   -6, 	  -2,  -11
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	  -8,   -9, 	   2,   -7, 	  -4,   -9
+.2byte   -7,   -8, 	  -9,   -9, 	   1,   -7, 	  -4,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -4,   -7, 	  -5,   -8, 	   4,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,   -9, 	   3,   -5, 	   0,  -10
+.2byte   -3,  -11, 	   3,   -9, 	  -2,   -4, 	  -1,  -10
+.2byte   -1,  -15, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    1,  -11, 	  -5,   -9, 	   0,   -4, 	  -1,  -10
+.2byte    2,   -7, 	  -4,   -9, 	  -5,   -5, 	  -2,  -10
+.2byte    2,   -7, 	   3,   -8, 	  -6,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte    2,   -7, 	   3,   -8, 	  -6,   -7, 	  -1,   -9
+.2byte    2,   -7, 	  -4,   -9, 	  -5,   -5, 	  -2,  -10
+.2byte    1,  -11, 	  -5,   -9, 	   0,   -4, 	  -1,  -10
+.2byte   -1,  -15, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -3,  -11, 	   3,   -9, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,   -7, 	   2,   -9, 	   3,   -5, 	   0,  -10
+.2byte   -4,   -7, 	  -5,   -8, 	   4,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	  -5,   -7, 	   4,   -7, 	  -1,  -10
+.2byte    3,   -8, 	   4,   -9, 	  -5,   -8, 	   0,  -10
+.2byte    2,   -8, 	   4,   -9, 	  -6,   -7, 	   0,   -9
+.2byte    3,   -8, 	   5,   -9, 	  -5,   -7, 	   0,   -9
+.2byte    2,   -8, 	  -4,  -10, 	  -5,   -6, 	  -2,  -11
+.2byte    2,   -8, 	  -4,  -10, 	  -6,   -7, 	  -2,  -11
+.2byte    2,   -8, 	  -3,  -10, 	  -4,   -6, 	  -2,  -11
+.2byte    1,  -13, 	  -5,  -11, 	   0,   -6, 	  -1,  -12
+.2byte    1,  -14, 	  -6,  -11, 	   0,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -6,  -10, 	   0,   -7, 	  -1,  -11
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -11, 	  -5,   -9, 	  -1,  -12
+.2byte   -2,  -17, 	   3,  -10, 	  -4,   -9, 	  -1,  -12
+.2byte   -3,  -13, 	   3,  -11, 	  -2,   -6, 	  -1,  -12
+.2byte   -3,  -14, 	   4,  -11, 	  -2,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	   4,  -10, 	  -2,   -7, 	  -1,  -11
+.2byte   -4,   -8, 	   2,  -10, 	   3,   -6, 	   0,  -11
+.2byte   -4,   -8, 	   2,  -10, 	   4,   -7, 	   0,  -11
+.2byte   -4,   -8, 	   1,  -10, 	   2,   -6, 	   0,  -11
+.2byte   -5,   -8, 	  -6,   -9, 	   3,   -8, 	  -2,  -10
+.2byte   -4,   -8, 	  -6,   -9, 	   4,   -7, 	  -2,   -9
+.2byte   -5,   -8, 	  -7,   -9, 	   3,   -7, 	  -2,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -4,   -7, 	  -5,   -8, 	   4,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,   -9, 	   3,   -5, 	   0,  -10
+.2byte   -3,  -11, 	   3,   -9, 	  -2,   -4, 	  -1,  -10
+.2byte   -1,  -15, 	   3,   -7, 	  -4,   -7, 	   0,  -10
+.2byte    1,  -11, 	  -5,   -9, 	   0,   -4, 	  -1,  -10
+.2byte    2,   -7, 	  -4,   -9, 	  -5,   -5, 	  -2,  -10
+.2byte    2,   -7, 	   3,   -8, 	  -6,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+.2byte   -1,   -8, 	  -5,   -8, 	   5,   -8, 	  -1,  -10
+.2byte   -7,   -8, 	  -8,   -9, 	   1,   -8, 	  -4,  -10
+.2byte   -6,   -8, 	   0,  -10, 	   1,   -6, 	  -2,  -11
+.2byte   -4,  -13, 	   2,  -11, 	  -3,   -6, 	  -2,  -12
+.2byte   -2,  -17, 	   2,   -9, 	  -5,   -9, 	  -1,  -12
+.2byte    2,  -13, 	  -4,  -11, 	   1,   -6, 	   0,  -12
+.2byte    4,   -8, 	  -2,  -10, 	  -3,   -6, 	   0,  -11
+.2byte    5,   -8, 	   6,   -9, 	  -3,   -8, 	   2,  -10
+sShuppetAnimTable1:
+.4byte sShuppetAnims_1_1
+.4byte sShuppetAnims_1_2
+.4byte sShuppetAnims_1_3
+.4byte sShuppetAnims_1_4
+.4byte sShuppetAnims_1_5
+.4byte sShuppetAnims_1_6
+.4byte sShuppetAnims_1_7
+.4byte sShuppetAnims_1_8
+sShuppetAnimTable2:
+.4byte sShuppetAnims_2_1
+.4byte sShuppetAnims_2_2
+.4byte sShuppetAnims_2_3
+.4byte sShuppetAnims_2_4
+.4byte sShuppetAnims_2_5
+.4byte sShuppetAnims_2_6
+.4byte sShuppetAnims_2_7
+.4byte sShuppetAnims_2_8
+sShuppetAnimTable3:
+.4byte sShuppetAnims_3_1
+.4byte sShuppetAnims_3_2
+.4byte sShuppetAnims_3_3
+.4byte sShuppetAnims_3_4
+.4byte sShuppetAnims_3_5
+.4byte sShuppetAnims_3_6
+.4byte sShuppetAnims_3_7
+.4byte sShuppetAnims_3_8
+sShuppetAnimTable4:
+.4byte sShuppetAnims_4_1
+.4byte sShuppetAnims_4_2
+.4byte sShuppetAnims_4_3
+.4byte sShuppetAnims_4_4
+.4byte sShuppetAnims_4_5
+.4byte sShuppetAnims_4_6
+.4byte sShuppetAnims_4_7
+.4byte sShuppetAnims_4_8
+sShuppetAnimTable5:
+.4byte sShuppetAnims_5_1
+.4byte sShuppetAnims_5_2
+.4byte sShuppetAnims_5_3
+.4byte sShuppetAnims_5_4
+.4byte sShuppetAnims_5_5
+.4byte sShuppetAnims_5_6
+.4byte sShuppetAnims_5_7
+.4byte sShuppetAnims_5_8
+sShuppetAnimTable6:
+.4byte sShuppetAnims_6_1
+.4byte sShuppetAnims_6_1
+.4byte sShuppetAnims_6_1
+.4byte sShuppetAnims_6_1
+.4byte sShuppetAnims_6_1
+.4byte sShuppetAnims_6_1
+.4byte sShuppetAnims_6_1
+.4byte sShuppetAnims_6_1
+sShuppetAnimTable7:
+.4byte sShuppetAnims_7_1
+.4byte sShuppetAnims_7_2
+.4byte sShuppetAnims_7_3
+.4byte sShuppetAnims_7_4
+.4byte sShuppetAnims_7_5
+.4byte sShuppetAnims_7_6
+.4byte sShuppetAnims_7_7
+.4byte sShuppetAnims_7_8
+sShuppetAnimTable8:
+.4byte sShuppetAnims_8_1
+.4byte sShuppetAnims_8_2
+.4byte sShuppetAnims_8_3
+.4byte sShuppetAnims_8_4
+.4byte sShuppetAnims_8_5
+.4byte sShuppetAnims_8_6
+.4byte sShuppetAnims_8_7
+.4byte sShuppetAnims_8_8
+sShuppetAnimTable9:
+.4byte sShuppetAnims_9_1
+.4byte sShuppetAnims_9_2
+.4byte sShuppetAnims_9_3
+.4byte sShuppetAnims_9_4
+.4byte sShuppetAnims_9_5
+.4byte sShuppetAnims_9_6
+.4byte sShuppetAnims_9_7
+.4byte sShuppetAnims_9_8
+sShuppetAnimTable10:
+.4byte sShuppetAnims_10_1
+.4byte sShuppetAnims_10_2
+.4byte sShuppetAnims_10_3
+.4byte sShuppetAnims_10_4
+.4byte sShuppetAnims_10_5
+.4byte sShuppetAnims_10_6
+.4byte sShuppetAnims_10_7
+.4byte sShuppetAnims_10_8
+sShuppetAnimTable11:
+.4byte sShuppetAnims_11_1
+.4byte sShuppetAnims_11_2
+.4byte sShuppetAnims_11_3
+.4byte sShuppetAnims_11_4
+.4byte sShuppetAnims_11_5
+.4byte sShuppetAnims_11_6
+.4byte sShuppetAnims_11_7
+.4byte sShuppetAnims_11_8
+sShuppetAnimTable12:
+.4byte sShuppetAnims_12_1
+.4byte sShuppetAnims_12_2
+.4byte sShuppetAnims_12_3
+.4byte sShuppetAnims_12_4
+.4byte sShuppetAnims_12_5
+.4byte sShuppetAnims_12_6
+.4byte sShuppetAnims_12_7
+.4byte sShuppetAnims_12_8
+sShuppetAnimTable13:
+.4byte sShuppetAnims_13_1
+.4byte sShuppetAnims_13_2
+.4byte sShuppetAnims_13_3
+.4byte sShuppetAnims_13_4
+.4byte sShuppetAnims_13_5
+.4byte sShuppetAnims_13_6
+.4byte sShuppetAnims_13_7
+.4byte sShuppetAnims_13_8
+sAxAnimationsShuppet:
+.4byte sShuppetAnimTable1
+.4byte sShuppetAnimTable2
+.4byte sShuppetAnimTable3
+.4byte sShuppetAnimTable4
+.4byte sShuppetAnimTable5
+.4byte sShuppetAnimTable6
+.4byte sShuppetAnimTable7
+.4byte sShuppetAnimTable8
+.4byte sShuppetAnimTable9
+.4byte sShuppetAnimTable10
+.4byte sShuppetAnimTable11
+.4byte sShuppetAnimTable12
+.4byte sShuppetAnimTable13
+sAxSpritesShuppet:
+.4byte sShuppetSprites1
+.4byte sShuppetSprites2
+.4byte sShuppetSprites3
+.4byte sShuppetSprites4
+.4byte sShuppetSprites5
+.4byte sShuppetSprites6
+.4byte sShuppetSprites7
+.4byte sShuppetSprites8
+.4byte sShuppetSprites9
+.4byte sShuppetSprites10
+.4byte sShuppetSprites11
+.4byte sShuppetSprites12
+.4byte sShuppetSprites13
+.4byte sShuppetSprites14
+.4byte sShuppetSprites15
+.4byte sShuppetSprites16
+.4byte sShuppetSprites17
+.4byte sShuppetSprites18
+.4byte sShuppetSprites19
+.4byte sShuppetSprites20
+.4byte sShuppetSprites21
+.4byte sShuppetSprites22
+.4byte sShuppetSprites23
+.4byte sShuppetSprites24
+.4byte sShuppetSprites25
+.4byte sShuppetSprites26
+.4byte sShuppetSprites27
+.4byte sShuppetSprites28
+.4byte sShuppetSprites29
+.4byte sShuppetSprites30
+.4byte sShuppetSprites31
+.4byte sShuppetSprites32
+sAxMainShuppet:
+ax_main sAxPosesShuppet, sAxAnimationsShuppet, 13, sAxSpritesShuppet, sAxPositionsShuppet

--- a/data/ax/silcoon.inc
+++ b/data/ax/silcoon.inc
@@ -1,0 +1,2023 @@
+.global gAxSilcoon
+gAxSilcoon:
+ax_siro sAxMainSilcoon
+sSilcoonPose1:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose4:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose5:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose6:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose7:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose8:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose9:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose10:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose11:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose12:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose13:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose14:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose15:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose16:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose17:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose18:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose19:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose20:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose21:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose22:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose23:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose24:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose25:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose26:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose27:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose28:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose29:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose30:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose31:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose32:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose33:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose34:
+ax_pose 8, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose35:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose36:
+ax_pose 9, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose37:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose38:
+ax_pose 10, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose39:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose40:
+ax_pose 11, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose41:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose42:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose43:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose44:
+ax_pose 13, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose45:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose46:
+ax_pose 14, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose47:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose48:
+ax_pose 15, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose49:
+ax_pose 16, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose50:
+ax_pose 17, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose51:
+ax_pose 18, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sSilcoonPose52:
+ax_pose 19, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sSilcoonPose53:
+ax_pose 20, 0x01e9, 0x90eb, 0x5c00
+ax_pose_terminator
+sSilcoonPose54:
+ax_pose 21, 0x01e7, 0x90ea, 0x5c00
+ax_pose_terminator
+sSilcoonPose55:
+ax_pose 22, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSilcoonPose56:
+ax_pose 21, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSilcoonPose57:
+ax_pose 20, 0x01e9, 0x80f5, 0x5c00
+ax_pose_terminator
+sSilcoonPose58:
+ax_pose 19, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sSilcoonPose59:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose60:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose61:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose62:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose63:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose64:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose65:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose66:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose67:
+ax_pose 8, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose68:
+ax_pose 15, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose69:
+ax_pose 14, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose70:
+ax_pose 13, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose71:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose72:
+ax_pose 11, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose73:
+ax_pose 10, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose74:
+ax_pose 9, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose75:
+ax_pose 8, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose76:
+ax_pose 9, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose77:
+ax_pose 10, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose78:
+ax_pose 11, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose79:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose80:
+ax_pose 13, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose81:
+ax_pose 14, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose82:
+ax_pose 15, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose83:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose84:
+ax_pose 8, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose85:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose86:
+ax_pose 9, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose87:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose88:
+ax_pose 10, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose89:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose90:
+ax_pose 11, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose91:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose92:
+ax_pose 12, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose93:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose94:
+ax_pose 13, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSilcoonPose95:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose96:
+ax_pose 14, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSilcoonPose97:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose98:
+ax_pose 15, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose99:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose100:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose101:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose102:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose103:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose104:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose105:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose106:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose107:
+ax_pose 0, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose108:
+ax_pose 7, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose109:
+ax_pose 6, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose110:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose111:
+ax_pose 4, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSilcoonPose112:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose113:
+ax_pose 2, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSilcoonPose114:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+.align 2
+sSilcoonAnims_1_1:
+ax_anim 2, 0, 0, 1, 0, 1, 0,
+ax_anim 2, 0, 0, -1, 0, -1, 0,
+ax_anim 120, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_1_2:
+ax_anim 2, 0, 1, -1, 1, -1, 1,
+ax_anim 2, 0, 1, 1, -1, 0, 0,
+ax_anim 120, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_1_3:
+ax_anim 2, 0, 2, 0, 1, 0, 1,
+ax_anim 2, 0, 2, 0, -1, 0, -1,
+ax_anim 120, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_1_4:
+ax_anim 2, 0, 3, 1, 1, 1, 1,
+ax_anim 2, 0, 3, -1, -1, 0, 0,
+ax_anim 120, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_1_5:
+ax_anim 2, 0, 4, -1, 0, -1, 0,
+ax_anim 2, 0, 4, 1, 0, 1, 0,
+ax_anim 120, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_1_6:
+ax_anim 2, 0, 5, -1, 1, -1, 1,
+ax_anim 2, 0, 5, 1, -1, 0, 0,
+ax_anim 120, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_1_7:
+ax_anim 2, 0, 6, 0, 1, 0, 1,
+ax_anim 2, 0, 6, 0, -1, 0, -1,
+ax_anim 120, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_1_8:
+ax_anim 2, 0, 7, 1, 1, 1, 1,
+ax_anim 2, 0, 7, -1, -1, 0, 0,
+ax_anim 120, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 2, 8, 0, 0, 0, 0,
+ax_anim 1, 0, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 10,
+ax_anim 1, 0, 8, 0, 22, 0, 22,
+ax_anim 1, 1, 9, 0, 22, 0, 22,
+ax_anim 1, 0, 10, 1, 22, 1, 22,
+ax_anim 1, 0, 11, 1, 22, 1, 22,
+ax_anim 1, 0, 12, 0, 22, 0, 22,
+ax_anim 1, 0, 13, 0, 22, 0, 22,
+ax_anim 1, 0, 14, 1, 22, 1, 22,
+ax_anim 1, 0, 15, 1, 22, 1, 22,
+ax_anim 1, 0, 8, 0, 22, 0, 22,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sSilcoonAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 2, 9, 0, 0, 0, 0,
+ax_anim 1, 0, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 10,
+ax_anim 1, 0, 9, 19, 22, 19, 22,
+ax_anim 1, 1, 10, 19, 22, 19, 22,
+ax_anim 1, 0, 11, 20, 21, 20, 21,
+ax_anim 1, 0, 12, 20, 21, 20, 21,
+ax_anim 1, 0, 13, 19, 22, 19, 22,
+ax_anim 1, 0, 14, 19, 22, 19, 22,
+ax_anim 1, 0, 15, 20, 21, 20, 21,
+ax_anim 1, 0, 8, 20, 21, 20, 21,
+ax_anim 1, 0, 9, 19, 22, 19, 22,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sSilcoonAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 2, 10, 0, 0, 0, 0,
+ax_anim 1, 0, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 0, 10, 0,
+ax_anim 1, 0, 10, 19, 0, 19, 0,
+ax_anim 1, 1, 11, 19, 0, 19, 0,
+ax_anim 1, 0, 12, 19, 1, 19, 1,
+ax_anim 1, 0, 13, 19, 1, 19, 1,
+ax_anim 1, 0, 14, 19, 0, 19, 0,
+ax_anim 1, 0, 15, 19, 0, 19, 0,
+ax_anim 1, 0, 8, 19, 1, 19, 1,
+ax_anim 1, 0, 9, 19, 1, 19, 1,
+ax_anim 1, 0, 10, 19, 0, 19, 0,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sSilcoonAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 2, 11, 0, 0, 0, 0,
+ax_anim 1, 0, 11, 4, -4, 4, -4,
+ax_anim 1, 0, 11, 10, -10, 10, -10,
+ax_anim 1, 0, 11, 19, -19, 19, -19,
+ax_anim 1, 1, 12, 19, -19, 19, -19,
+ax_anim 1, 0, 13, 20, -18, 20, -18,
+ax_anim 1, 0, 14, 20, -18, 20, -18,
+ax_anim 1, 0, 15, 19, -19, 19, -19,
+ax_anim 1, 0, 8, 19, -19, 19, -19,
+ax_anim 1, 0, 9, 20, -18, 20, -18,
+ax_anim 1, 0, 10, 20, -18, 20, -18,
+ax_anim 1, 0, 11, 19, -19, 19, -19,
+ax_anim 2, 0, 11, 6, -6, 6, -6,
+ax_anim_terminator
+sSilcoonAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 2, 12, 0, 0, 0, 0,
+ax_anim 1, 0, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -10, 0, -10,
+ax_anim 1, 0, 12, 0, -19, 0, -19,
+ax_anim 1, 1, 13, 0, -19, 0, -19,
+ax_anim 1, 0, 14, 0, -18, 0, -18,
+ax_anim 1, 0, 15, 0, -18, 0, -18,
+ax_anim 1, 0, 8, 0, -19, 0, -19,
+ax_anim 1, 0, 9, 0, -19, 0, -19,
+ax_anim 1, 0, 10, 0, -18, 0, -18,
+ax_anim 1, 0, 11, 0, -18, 0, -18,
+ax_anim 1, 0, 12, 0, -19, 0, -19,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sSilcoonAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 2, 13, 0, 0, 0, 0,
+ax_anim 1, 0, 13, -4, -4, -4, -4,
+ax_anim 1, 0, 13, -10, -10, -10, -10,
+ax_anim 1, 0, 13, -19, -19, -19, -19,
+ax_anim 1, 1, 14, -19, -19, -19, -19,
+ax_anim 1, 0, 15, -20, -18, -20, -18,
+ax_anim 1, 0, 8, -20, -18, -20, -18,
+ax_anim 1, 0, 9, -19, -19, -19, -19,
+ax_anim 1, 0, 10, -19, -19, -19, -19,
+ax_anim 1, 0, 11, -20, -18, -20, -18,
+ax_anim 1, 0, 12, -20, -18, -20, -18,
+ax_anim 1, 0, 13, -19, -19, -19, -19,
+ax_anim 2, 0, 13, -6, -6, -6, -6,
+ax_anim_terminator
+sSilcoonAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 2, 14, 0, 0, 0, 0,
+ax_anim 1, 0, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 0, -10, 0,
+ax_anim 1, 0, 14, -19, 0, -19, 0,
+ax_anim 1, 1, 15, -19, 0, -19, 0,
+ax_anim 1, 0, 8, -19, 1, -19, 1,
+ax_anim 1, 0, 9, -19, 1, -19, 1,
+ax_anim 1, 0, 10, -19, 0, -19, 0,
+ax_anim 1, 0, 11, -19, 0, -19, 0,
+ax_anim 1, 0, 12, -19, 1, -19, 1,
+ax_anim 1, 0, 13, -19, 1, -19, 1,
+ax_anim 1, 0, 14, -19, 0, -19, 0,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sSilcoonAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 2, 15, 0, 0, 0, 0,
+ax_anim 1, 0, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 10,
+ax_anim 1, 0, 15, -19, 22, -19, 22,
+ax_anim 1, 1, 8, -19, 22, -19, 22,
+ax_anim 1, 0, 9, -20, 21, -20, 21,
+ax_anim 1, 0, 10, -20, 21, -20, 21,
+ax_anim 1, 0, 11, -19, 22, -19, 22,
+ax_anim 1, 0, 12, -19, 22, -19, 22,
+ax_anim 1, 0, 13, -20, 21, -20, 21,
+ax_anim 1, 0, 14, -20, 21, -20, 21,
+ax_anim 1, 0, 15, -19, 22, -19, 22,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 2, 16, 0, 0, 0, 0,
+ax_anim 1, 0, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 10,
+ax_anim 1, 0, 16, 0, 22, 0, 22,
+ax_anim 1, 1, 17, 0, 22, 0, 22,
+ax_anim 1, 0, 18, 1, 22, 1, 22,
+ax_anim 1, 0, 19, 1, 22, 1, 22,
+ax_anim 1, 0, 20, 0, 22, 0, 22,
+ax_anim 1, 0, 21, 0, 22, 0, 22,
+ax_anim 1, 0, 22, 1, 22, 1, 22,
+ax_anim 1, 0, 23, 1, 22, 1, 22,
+ax_anim 1, 0, 16, 0, 22, 0, 22,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sSilcoonAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 2, 17, 0, 0, 0, 0,
+ax_anim 1, 0, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 10,
+ax_anim 1, 0, 17, 19, 22, 19, 22,
+ax_anim 1, 1, 18, 19, 22, 19, 22,
+ax_anim 1, 0, 19, 20, 21, 20, 21,
+ax_anim 1, 0, 20, 20, 21, 20, 21,
+ax_anim 1, 0, 21, 19, 22, 19, 22,
+ax_anim 1, 0, 22, 19, 22, 19, 22,
+ax_anim 1, 0, 23, 20, 21, 20, 21,
+ax_anim 1, 0, 16, 20, 21, 20, 21,
+ax_anim 1, 0, 17, 19, 22, 19, 22,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sSilcoonAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 2, 18, 0, 0, 0, 0,
+ax_anim 1, 0, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 0, 10, 0,
+ax_anim 1, 0, 18, 19, 0, 19, 0,
+ax_anim 1, 1, 19, 19, 0, 19, 0,
+ax_anim 1, 0, 20, 19, 1, 19, 1,
+ax_anim 1, 0, 21, 19, 1, 19, 1,
+ax_anim 1, 0, 22, 19, 0, 19, 0,
+ax_anim 1, 0, 23, 19, 0, 19, 0,
+ax_anim 1, 0, 16, 19, 1, 19, 1,
+ax_anim 1, 0, 17, 19, 1, 19, 1,
+ax_anim 1, 0, 18, 19, 0, 19, 0,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sSilcoonAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 2, 19, 0, 0, 0, 0,
+ax_anim 1, 0, 19, 4, -4, 4, -4,
+ax_anim 1, 0, 19, 10, -10, 10, -10,
+ax_anim 1, 0, 19, 19, -19, 19, -19,
+ax_anim 1, 1, 20, 19, -19, 19, -19,
+ax_anim 1, 0, 21, 20, -18, 20, -18,
+ax_anim 1, 0, 22, 20, -18, 20, -18,
+ax_anim 1, 0, 23, 19, -19, 19, -19,
+ax_anim 1, 0, 16, 19, -19, 19, -19,
+ax_anim 1, 0, 17, 20, -18, 20, -18,
+ax_anim 1, 0, 18, 20, -18, 20, -18,
+ax_anim 1, 0, 19, 19, -19, 19, -19,
+ax_anim 2, 0, 19, 6, -6, 6, -6,
+ax_anim_terminator
+sSilcoonAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 2, 20, 0, 0, 0, 0,
+ax_anim 1, 0, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -10, 0, -10,
+ax_anim 1, 0, 20, 0, -19, 0, -19,
+ax_anim 1, 1, 21, 0, -19, 0, -19,
+ax_anim 1, 0, 22, 0, -18, 0, -18,
+ax_anim 1, 0, 23, 0, -18, 0, -18,
+ax_anim 1, 0, 16, 0, -19, 0, -19,
+ax_anim 1, 0, 17, 0, -19, 0, -19,
+ax_anim 1, 0, 18, 0, -18, 0, -18,
+ax_anim 1, 0, 19, 0, -18, 0, -18,
+ax_anim 1, 0, 20, 0, -19, 0, -19,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sSilcoonAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 2, 21, 0, 0, 0, 0,
+ax_anim 1, 0, 21, -4, -4, -4, -4,
+ax_anim 1, 0, 21, -10, -10, -10, -10,
+ax_anim 1, 0, 21, -19, -19, -19, -19,
+ax_anim 1, 1, 22, -19, -19, -19, -19,
+ax_anim 1, 0, 23, -20, -18, -20, -18,
+ax_anim 1, 0, 16, -20, -18, -20, -18,
+ax_anim 1, 0, 17, -19, -19, -19, -19,
+ax_anim 1, 0, 18, -19, -19, -19, -19,
+ax_anim 1, 0, 19, -20, -18, -20, -18,
+ax_anim 1, 0, 20, -20, -18, -20, -18,
+ax_anim 1, 0, 21, -19, -19, -19, -19,
+ax_anim 2, 0, 21, -6, -6, -6, -6,
+ax_anim_terminator
+sSilcoonAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 2, 22, 0, 0, 0, 0,
+ax_anim 1, 0, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 0, -10, 0,
+ax_anim 1, 0, 22, -19, 0, -19, 0,
+ax_anim 1, 1, 23, -19, 0, -19, 0,
+ax_anim 1, 0, 16, -19, 1, -19, 1,
+ax_anim 1, 0, 17, -19, 1, -19, 1,
+ax_anim 1, 0, 18, -19, 0, -19, 0,
+ax_anim 1, 0, 19, -19, 0, -19, 0,
+ax_anim 1, 0, 20, -19, 1, -19, 1,
+ax_anim 1, 0, 21, -19, 1, -19, 1,
+ax_anim 1, 0, 22, -19, 0, -19, 0,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sSilcoonAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 2, 23, 0, 0, 0, 0,
+ax_anim 1, 0, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 10,
+ax_anim 1, 0, 23, -19, 22, -19, 22,
+ax_anim 1, 1, 16, -19, 22, -19, 22,
+ax_anim 1, 0, 17, -20, 21, -20, 21,
+ax_anim 1, 0, 18, -20, 21, -20, 21,
+ax_anim 1, 0, 19, -19, 22, -19, 22,
+ax_anim 1, 0, 20, -19, 22, -19, 22,
+ax_anim 1, 0, 21, -20, 21, -20, 21,
+ax_anim 1, 0, 22, -20, 21, -20, 21,
+ax_anim 1, 0, 23, -19, 22, -19, 22,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_4_2:
+ax_anim 2, 0, 31, 1, -1, 1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 1, -1, 1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 1, -1, 1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 1, -1, 1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 1, -1, 1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_4_3:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_4_4:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_4_6:
+ax_anim 2, 0, 27, 1, -1, 1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 1, -1, 1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 1, -1, 1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 1, -1, 1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 1, -1, 1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_4_7:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_4_8:
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, -1, -1, -1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 1, 0, 1, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 1, 0, 1, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 1, 0, 1, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 1, 0, 1, 0,
+ax_anim_terminator
+sSilcoonAnims_5_2:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 4, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 1, -1, 1, -1,
+ax_anim_terminator
+sSilcoonAnims_5_3:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 4, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -1, 0, -1,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -1, 0, -1,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -1, 0, -1,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -1, 0, -1,
+ax_anim_terminator
+sSilcoonAnims_5_4:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim_terminator
+sSilcoonAnims_5_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim 2, 2, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 1, 0, 1, 0,
+ax_anim_terminator
+sSilcoonAnims_5_6:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 4, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 2, 2, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim_terminator
+sSilcoonAnims_5_7:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 2, 2, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 0, -1, 0, -1,
+ax_anim_terminator
+sSilcoonAnims_5_8:
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 4, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, -1, -1, -1,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, -1, -1, -1,
+ax_anim 2, 2, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, -1, -1, -1,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_6_1:
+ax_anim 30, 0, 48, 0, 0, 0, 0,
+ax_anim 35, 0, 49, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_7_1:
+ax_anim 2, 0, 50, 0, -2, 0, -2,
+ax_anim 8, 0, 50, 0, -3, 0, -3,
+ax_anim_terminator
+sSilcoonAnims_7_2:
+ax_anim 2, 0, 51, -2, -2, -2, -2,
+ax_anim 8, 0, 51, -3, -3, -3, -3,
+ax_anim_terminator
+sSilcoonAnims_7_3:
+ax_anim 2, 0, 52, -2, 0, -2, 0,
+ax_anim 8, 0, 52, -3, 0, -3, 0,
+ax_anim_terminator
+sSilcoonAnims_7_4:
+ax_anim 2, 0, 53, -2, 2, -2, 2,
+ax_anim 8, 0, 53, -3, 3, -3, 3,
+ax_anim_terminator
+sSilcoonAnims_7_5:
+ax_anim 2, 0, 54, 0, 2, 0, 2,
+ax_anim 8, 0, 54, 0, 3, 0, 3,
+ax_anim_terminator
+sSilcoonAnims_7_6:
+ax_anim 2, 0, 55, 2, 2, 2, 2,
+ax_anim 8, 0, 55, 3, 3, 3, 3,
+ax_anim_terminator
+sSilcoonAnims_7_7:
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim 8, 0, 56, 3, 0, 3, 0,
+ax_anim_terminator
+sSilcoonAnims_7_8:
+ax_anim 2, 0, 57, 2, -2, 2, -2,
+ax_anim 8, 0, 57, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_8_1:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 2, 0, 58, -1, 0, -1, 0,
+ax_anim 120, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_8_2:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 2, 0, 59, 1, -1, 0, 0,
+ax_anim 120, 0, 59, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_8_3:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 60, 0, -1, 0, -1,
+ax_anim 120, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_8_4:
+ax_anim 2, 0, 61, 1, 1, 1, 1,
+ax_anim 2, 0, 61, -1, -1, 0, 0,
+ax_anim 120, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_8_5:
+ax_anim 2, 0, 62, -1, 0, -1, 0,
+ax_anim 2, 0, 62, 1, 0, 1, 0,
+ax_anim 120, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_8_6:
+ax_anim 2, 0, 63, -1, 1, -1, 1,
+ax_anim 2, 0, 63, 1, -1, 0, 0,
+ax_anim 120, 0, 63, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_8_7:
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 120, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_8_8:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 2, 0, 65, -1, -1, 0, 0,
+ax_anim 120, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_9_1:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 0, 67, 6, 4, 6, 4,
+ax_anim 2, 0, 68, 8, 12, 8, 12,
+ax_anim 2, 0, 69, 7, 19, 7, 19,
+ax_anim 3, 0, 70, 0, 23, 0, 23,
+ax_anim 2, 3, 71, -7, 19, -7, 19,
+ax_anim 2, 0, 72, -8, 12, -8, 12,
+ax_anim 1, 0, 73, -6, 4, -6, 4,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_9_2:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 8, 0, 8, 0,
+ax_anim 2, 0, 67, 17, 5, 17, 5,
+ax_anim 2, 0, 68, 21, 15, 21, 15,
+ax_anim 3, 0, 69, 21, 23, 21, 23,
+ax_anim 2, 3, 70, 13, 24, 13, 24,
+ax_anim 2, 0, 71, 4, 19, 4, 19,
+ax_anim 1, 0, 72, 0, 10, 0, 10,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_9_3:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 3, -5, 3, -5,
+ax_anim 2, 0, 66, 11, -6, 11, -6,
+ax_anim 2, 0, 67, 16, -5, 16, -5,
+ax_anim 3, 0, 68, 21, 0, 21, 0,
+ax_anim 2, 3, 69, 19, 6, 19, 6,
+ax_anim 2, 0, 70, 12, 7, 12, 7,
+ax_anim 1, 0, 71, 4, 5, 4, 5,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_9_4:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 72, -1, -8, -1, -8,
+ax_anim 2, 0, 73, 4, -16, 4, -16,
+ax_anim 2, 0, 66, 12, -22, 12, -22,
+ax_anim 3, 0, 67, 20, -22, 20, -22,
+ax_anim 2, 3, 68, 22, -15, 22, -15,
+ax_anim 2, 0, 69, 17, -4, 17, -4,
+ax_anim 1, 0, 70, 7, -1, 7, -1,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_9_5:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 0, 71, -8, -4, -8, -4,
+ax_anim 2, 0, 72, -9, -12, -9, -12,
+ax_anim 2, 0, 73, -7, -18, -7, -18,
+ax_anim 3, 0, 66, 0, -22, 0, -22,
+ax_anim 2, 3, 67, 7, -18, 7, -18,
+ax_anim 2, 0, 68, 9, -12, 9, -12,
+ax_anim 1, 0, 69, 8, -4, 8, -4,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_9_6:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 1, -8, 1, -8,
+ax_anim 2, 0, 67, -4, -16, -4, -16,
+ax_anim 2, 0, 66, -12, -22, -12, -22,
+ax_anim 3, 0, 73, -20, -22, -20, -22,
+ax_anim 2, 3, 72, -22, -15, -22, -15,
+ax_anim 2, 0, 71, -17, -4, -17, -4,
+ax_anim 1, 0, 70, -7, -1, -7, -1,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_9_7:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 67, -3, -5, -3, -5,
+ax_anim 2, 0, 66, -11, -6, -11, -6,
+ax_anim 2, 0, 73, -16, -5, -16, -5,
+ax_anim 3, 0, 72, -21, 0, -21, 0,
+ax_anim 2, 3, 71, -19, 6, -19, 6,
+ax_anim 2, 0, 70, -12, 7, -12, 7,
+ax_anim 1, 0, 69, -4, 5, -4, 5,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_9_8:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 0, 66, -8, 0, -8, 0,
+ax_anim 2, 0, 73, -17, 5, -17, 5,
+ax_anim 2, 0, 72, -21, 15, -21, 15,
+ax_anim 3, 0, 71, -21, 23, -21, 23,
+ax_anim 2, 3, 70, -13, 24, -13, 24,
+ax_anim 2, 0, 69, -4, 19, -4, 19,
+ax_anim 1, 0, 68, 0, 10, 0, 10,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_10_1:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim 2, 0, 74, -6, 0, -6, 0,
+ax_anim 2, 0, 74, 10, 0, 10, 0,
+ax_anim 2, 0, 74, -10, 0, -10, 0,
+ax_anim 2, 0, 74, 12, 0, 12, 0,
+ax_anim 3, 0, 74, -12, 0, -12, 0,
+ax_anim 3, 0, 74, 13, 0, 13, 0,
+ax_anim 3, 0, 74, -13, 0, -13, 0,
+ax_anim 2, 0, 74, 12, 0, 12, 0,
+ax_anim 3, 0, 74, -12, 0, -12, 0,
+ax_anim 2, 0, 74, 10, 0, 10, 0,
+ax_anim 2, 0, 74, -10, 0, -10, 0,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim 2, 0, 74, -6, 0, -6, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_10_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, -6, 6, -6, 6,
+ax_anim 2, 0, 75, 10, -10, 10, -10,
+ax_anim 2, 0, 75, -10, 10, -10, 10,
+ax_anim 2, 0, 75, 12, -12, 12, -12,
+ax_anim 3, 0, 75, -12, 12, -12, 12,
+ax_anim 3, 0, 75, 13, -13, 13, -13,
+ax_anim 3, 0, 75, -13, 13, -13, 13,
+ax_anim 2, 0, 75, 12, -12, 12, -12,
+ax_anim 3, 0, 75, -12, 12, -12, 12,
+ax_anim 2, 0, 75, 10, -10, 10, -10,
+ax_anim 2, 0, 75, -10, 10, -10, 10,
+ax_anim 2, 0, 75, 6, -6, 6, -6,
+ax_anim 2, 0, 75, -6, 6, -6, 6,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_10_3:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -6, 0, -6,
+ax_anim 2, 0, 76, 0, 6, 0, 6,
+ax_anim 2, 0, 76, 0, -10, 0, -10,
+ax_anim 2, 0, 76, 0, 10, 0, 10,
+ax_anim 2, 0, 76, 0, -12, 0, -12,
+ax_anim 3, 0, 76, 0, 12, 0, 12,
+ax_anim 3, 0, 76, 0, -13, 0, -13,
+ax_anim 3, 0, 76, 0, 13, 0, 13,
+ax_anim 2, 0, 76, 0, -12, 0, -12,
+ax_anim 3, 0, 76, 0, 12, 0, 12,
+ax_anim 2, 0, 76, 0, -10, 0, -10,
+ax_anim 2, 0, 76, 0, 10, 0, 10,
+ax_anim 2, 0, 76, 0, -6, 0, -6,
+ax_anim 2, 0, 76, 0, 6, 0, 6,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_10_4:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -6, -6, -6, -6,
+ax_anim 2, 0, 77, 6, 6, 6, 6,
+ax_anim 2, 0, 77, -10, -10, -10, -10,
+ax_anim 2, 0, 77, 10, 10, 10, 10,
+ax_anim 2, 0, 77, -12, -12, -12, -12,
+ax_anim 3, 0, 77, 12, 12, 12, 12,
+ax_anim 3, 0, 77, -13, -13, -13, -13,
+ax_anim 3, 0, 77, 13, 13, 13, 13,
+ax_anim 2, 0, 77, -12, -12, -12, -12,
+ax_anim 3, 0, 77, 12, 12, 12, 12,
+ax_anim 2, 0, 77, -10, -10, -10, -10,
+ax_anim 2, 0, 77, 10, 10, 10, 10,
+ax_anim 2, 0, 77, -6, -6, -6, -6,
+ax_anim 2, 0, 77, 6, 6, 6, 6,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_10_5:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 6, 0, 6, 0,
+ax_anim 2, 0, 78, -6, 0, -6, 0,
+ax_anim 2, 0, 78, 10, 0, 10, 0,
+ax_anim 2, 0, 78, -10, 0, -10, 0,
+ax_anim 2, 0, 78, 12, 0, 12, 0,
+ax_anim 3, 0, 78, -12, 0, -12, 0,
+ax_anim 3, 0, 78, 13, 0, 13, 0,
+ax_anim 3, 0, 78, -13, 0, -13, 0,
+ax_anim 2, 0, 78, 12, 0, 12, 0,
+ax_anim 3, 0, 78, -12, 0, -12, 0,
+ax_anim 2, 0, 78, 10, 0, 10, 0,
+ax_anim 2, 0, 78, -10, 0, -10, 0,
+ax_anim 2, 0, 78, 6, 0, 6, 0,
+ax_anim 2, 0, 78, -6, 0, -6, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_10_6:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim 2, 0, 79, -6, 6, -6, 6,
+ax_anim 2, 0, 79, 10, -10, 10, -10,
+ax_anim 2, 0, 79, -10, 10, -10, 10,
+ax_anim 2, 0, 79, 12, -12, 12, -12,
+ax_anim 3, 0, 79, -12, 12, -12, 12,
+ax_anim 3, 0, 79, 13, -13, 13, -13,
+ax_anim 3, 0, 79, -13, 13, -13, 13,
+ax_anim 2, 0, 79, 12, -12, 12, -12,
+ax_anim 3, 0, 79, -12, 12, -12, 12,
+ax_anim 2, 0, 79, 10, -10, 10, -10,
+ax_anim 2, 0, 79, -10, 10, -10, 10,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim 2, 0, 79, -6, 6, -6, 6,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_10_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, -6, 0, -6,
+ax_anim 2, 0, 80, 0, 6, 0, 6,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, 10, 0, 10,
+ax_anim 2, 0, 80, 0, -12, 0, -12,
+ax_anim 3, 0, 80, 0, 12, 0, 12,
+ax_anim 3, 0, 80, 0, -13, 0, -13,
+ax_anim 3, 0, 80, 0, 13, 0, 13,
+ax_anim 2, 0, 80, 0, -12, 0, -12,
+ax_anim 3, 0, 80, 0, 12, 0, 12,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, 10, 0, 10,
+ax_anim 2, 0, 80, 0, -6, 0, -6,
+ax_anim 2, 0, 80, 0, 6, 0, 6,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_10_8:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, 6, 6, 6, 6,
+ax_anim 2, 0, 81, -10, -10, -10, -10,
+ax_anim 2, 0, 81, 10, 10, 10, 10,
+ax_anim 2, 0, 81, -12, -12, -12, -12,
+ax_anim 3, 0, 81, 12, 12, 12, 12,
+ax_anim 3, 0, 81, -13, -13, -13, -13,
+ax_anim 3, 0, 81, 13, 13, 13, 13,
+ax_anim 2, 0, 81, -12, -12, -12, -12,
+ax_anim 3, 0, 81, 12, 12, 12, 12,
+ax_anim 2, 0, 81, -10, -10, -10, -10,
+ax_anim 2, 0, 81, 10, 10, 10, 10,
+ax_anim 2, 0, 81, -6, -6, -6, -6,
+ax_anim 2, 0, 81, 6, 6, 6, 6,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_11_1:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, -10, 0, 0,
+ax_anim 2, 0, 83, 0, -16, 0, 0,
+ax_anim 3, 0, 83, 0, -20, 0, 0,
+ax_anim 4, 0, 83, 0, -21, 0, 0,
+ax_anim 4, 0, 82, 0, -22, 0, 0,
+ax_anim 3, 0, 82, 0, -21, 0, 0,
+ax_anim 2, 0, 82, 0, -18, 0, 0,
+ax_anim 1, 0, 82, 0, -12, 0, 0,
+ax_anim 2, 2, 82, 0, 3, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_11_2:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, -10, 0, 0,
+ax_anim 2, 0, 85, 0, -16, 0, 0,
+ax_anim 3, 0, 85, 0, -20, 0, 0,
+ax_anim 4, 0, 85, 0, -21, 0, 0,
+ax_anim 4, 0, 84, 0, -22, 0, 0,
+ax_anim 3, 0, 84, 0, -21, 0, 0,
+ax_anim 2, 0, 84, 0, -18, 0, 0,
+ax_anim 1, 0, 84, 0, -12, 0, 0,
+ax_anim 2, 2, 84, 0, 3, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_11_3:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, -10, 0, 0,
+ax_anim 2, 0, 87, 0, -16, 0, 0,
+ax_anim 3, 0, 87, 0, -20, 0, 0,
+ax_anim 4, 0, 87, 0, -21, 0, 0,
+ax_anim 4, 0, 86, 0, -22, 0, 0,
+ax_anim 3, 0, 86, 0, -21, 0, 0,
+ax_anim 2, 0, 86, 0, -18, 0, 0,
+ax_anim 1, 0, 86, 0, -12, 0, 0,
+ax_anim 2, 2, 86, 0, 3, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_11_4:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -10, 0, 0,
+ax_anim 2, 0, 89, 0, -16, 0, 0,
+ax_anim 3, 0, 89, 0, -20, 0, 0,
+ax_anim 4, 0, 89, 0, -21, 0, 0,
+ax_anim 4, 0, 88, 0, -22, 0, 0,
+ax_anim 3, 0, 88, 0, -21, 0, 0,
+ax_anim 2, 0, 88, 0, -17, 0, 0,
+ax_anim 1, 0, 88, 0, -11, 0, 0,
+ax_anim 2, 2, 88, 0, 3, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_11_5:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -10, 0, 0,
+ax_anim 2, 0, 91, 0, -16, 0, 0,
+ax_anim 3, 0, 91, 0, -20, 0, 0,
+ax_anim 4, 0, 91, 0, -21, 0, 0,
+ax_anim 4, 0, 90, 0, -22, 0, 0,
+ax_anim 3, 0, 90, 0, -21, 0, 0,
+ax_anim 2, 0, 90, 0, -18, 0, 0,
+ax_anim 1, 0, 90, 0, -12, 0, 0,
+ax_anim 2, 2, 90, 0, 3, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_11_6:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -10, 0, 0,
+ax_anim 2, 0, 93, 0, -16, 0, 0,
+ax_anim 3, 0, 93, 0, -20, 0, 0,
+ax_anim 4, 0, 93, 0, -21, 0, 0,
+ax_anim 4, 0, 92, 0, -22, 0, 0,
+ax_anim 3, 0, 92, 0, -21, 0, 0,
+ax_anim 2, 0, 92, 0, -17, 0, 0,
+ax_anim 1, 0, 92, 0, -11, 0, 0,
+ax_anim 2, 2, 92, 0, 3, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_11_7:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -10, 0, 0,
+ax_anim 2, 0, 95, 0, -16, 0, 0,
+ax_anim 3, 0, 95, 0, -20, 0, 0,
+ax_anim 4, 0, 95, 0, -21, 0, 0,
+ax_anim 4, 0, 94, 0, -22, 0, 0,
+ax_anim 3, 0, 94, 0, -21, 0, 0,
+ax_anim 2, 0, 94, 0, -18, 0, 0,
+ax_anim 1, 0, 94, 0, -12, 0, 0,
+ax_anim 2, 2, 94, 0, 3, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_11_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -10, 0, 0,
+ax_anim 2, 0, 97, 0, -16, 0, 0,
+ax_anim 3, 0, 97, 0, -20, 0, 0,
+ax_anim 4, 0, 97, 0, -21, 0, 0,
+ax_anim 4, 0, 96, 0, -22, 0, 0,
+ax_anim 3, 0, 96, 0, -21, 0, 0,
+ax_anim 2, 0, 96, 0, -18, 0, 0,
+ax_anim 1, 0, 96, 0, -12, 0, 0,
+ax_anim 2, 2, 96, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_12_1:
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 1, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_12_2:
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_12_3:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_12_4:
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_12_5:
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 1, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_12_6:
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, -1, 1, -1,
+ax_anim 2, 1, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_12_7:
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 1, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_12_8:
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSilcoonAnims_13_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_13_2:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_13_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_13_4:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_13_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_13_6:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_13_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonAnims_13_8:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sSilcoonGfx1:
+.incbin "baserom.gba", 0x10E9430, 0x200
+sSilcoonSprites1:
+ax_sprite sSilcoonGfx1, 0x200
+ax_sprite_terminator
+sSilcoonGfx2:
+.incbin "baserom.gba", 0x10E9640, 0x200
+sSilcoonSprites2:
+ax_sprite sSilcoonGfx2, 0x200
+ax_sprite_terminator
+sSilcoonGfx3:
+.incbin "baserom.gba", 0x10E9850, 0x200
+sSilcoonSprites3:
+ax_sprite sSilcoonGfx3, 0x200
+ax_sprite_terminator
+sSilcoonGfx4:
+.incbin "baserom.gba", 0x10E9A60, 0x200
+sSilcoonSprites4:
+ax_sprite sSilcoonGfx4, 0x200
+ax_sprite_terminator
+sSilcoonGfx5:
+.incbin "baserom.gba", 0x10E9C70, 0x200
+sSilcoonSprites5:
+ax_sprite sSilcoonGfx5, 0x200
+ax_sprite_terminator
+sSilcoonGfx6:
+.incbin "baserom.gba", 0x10E9E80, 0x200
+sSilcoonSprites6:
+ax_sprite sSilcoonGfx6, 0x200
+ax_sprite_terminator
+sSilcoonGfx7:
+.incbin "baserom.gba", 0x10EA090, 0x200
+sSilcoonSprites7:
+ax_sprite sSilcoonGfx7, 0x200
+ax_sprite_terminator
+sSilcoonGfx8:
+.incbin "baserom.gba", 0x10EA2A0, 0x200
+sSilcoonSprites8:
+ax_sprite sSilcoonGfx8, 0x200
+ax_sprite_terminator
+sSilcoonGfx9:
+.incbin "baserom.gba", 0x10EA4B0, 0x180
+sSilcoonGfx9_1:
+.incbin "baserom.gba", 0x10EA630, 0x20
+sSilcoonSprites9:
+ax_sprite sSilcoonGfx9, 0x180
+ax_sprite 0, 0x40
+ax_sprite sSilcoonGfx9_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSilcoonGfx10:
+.incbin "baserom.gba", 0x10EA678, 0x60
+sSilcoonGfx10_1:
+.incbin "baserom.gba", 0x10EA6D8, 0x60
+sSilcoonGfx10_2:
+.incbin "baserom.gba", 0x10EA738, 0x80
+sSilcoonGfx10_3:
+.incbin "baserom.gba", 0x10EA7B8, 0x20
+sSilcoonSprites10:
+ax_sprite sSilcoonGfx10, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx10_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx10_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx10_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSilcoonGfx11:
+.incbin "baserom.gba", 0x10EA820, 0x160
+sSilcoonSprites11:
+ax_sprite sSilcoonGfx11, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSilcoonGfx12:
+.incbin "baserom.gba", 0x10EA998, 0x60
+sSilcoonGfx12_1:
+.incbin "baserom.gba", 0x10EA9F8, 0x60
+sSilcoonGfx12_2:
+.incbin "baserom.gba", 0x10EAA58, 0x80
+sSilcoonGfx12_3:
+.incbin "baserom.gba", 0x10EAAD8, 0x20
+sSilcoonSprites12:
+ax_sprite sSilcoonGfx12, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx12_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx12_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx12_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSilcoonGfx13:
+.incbin "baserom.gba", 0x10EAB40, 0xE0
+sSilcoonGfx13_1:
+.incbin "baserom.gba", 0x10EAC20, 0x100
+sSilcoonSprites13:
+ax_sprite sSilcoonGfx13, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx13_1, 0x100
+ax_sprite_terminator
+sSilcoonGfx14:
+.incbin "baserom.gba", 0x10EAD40, 0x60
+sSilcoonGfx14_1:
+.incbin "baserom.gba", 0x10EADA0, 0x60
+sSilcoonGfx14_2:
+.incbin "baserom.gba", 0x10EAE00, 0x80
+sSilcoonGfx14_3:
+.incbin "baserom.gba", 0x10EAE80, 0x20
+sSilcoonSprites14:
+ax_sprite sSilcoonGfx14, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx14_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx14_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx14_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSilcoonGfx15:
+.incbin "baserom.gba", 0x10EAEE8, 0x60
+sSilcoonGfx15_1:
+.incbin "baserom.gba", 0x10EAF48, 0x160
+sSilcoonSprites15:
+ax_sprite sSilcoonGfx15, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx15_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSilcoonGfx16:
+.incbin "baserom.gba", 0x10EB0D0, 0xE0
+sSilcoonGfx16_1:
+.incbin "baserom.gba", 0x10EB1B0, 0x80
+sSilcoonGfx16_2:
+.incbin "baserom.gba", 0x10EB230, 0x20
+sSilcoonSprites16:
+ax_sprite sSilcoonGfx16, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSilcoonGfx16_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sSilcoonGfx16_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSilcoonGfx17:
+.incbin "baserom.gba", 0x10EB288, 0x200
+sSilcoonSprites17:
+ax_sprite sSilcoonGfx17, 0x200
+ax_sprite_terminator
+sSilcoonGfx18:
+.incbin "baserom.gba", 0x10EB498, 0x200
+sSilcoonSprites18:
+ax_sprite sSilcoonGfx18, 0x200
+ax_sprite_terminator
+sSilcoonGfx19:
+.incbin "baserom.gba", 0x10EB6A8, 0x200
+sSilcoonSprites19:
+ax_sprite sSilcoonGfx19, 0x200
+ax_sprite_terminator
+sSilcoonGfx20:
+.incbin "baserom.gba", 0x10EB8B8, 0x200
+sSilcoonSprites20:
+ax_sprite sSilcoonGfx20, 0x200
+ax_sprite_terminator
+sSilcoonGfx21:
+.incbin "baserom.gba", 0x10EBAC8, 0x200
+sSilcoonSprites21:
+ax_sprite sSilcoonGfx21, 0x200
+ax_sprite_terminator
+sSilcoonGfx22:
+.incbin "baserom.gba", 0x10EBCD8, 0x200
+sSilcoonSprites22:
+ax_sprite sSilcoonGfx22, 0x200
+ax_sprite_terminator
+sSilcoonGfx23:
+.incbin "baserom.gba", 0x10EBEE8, 0x200
+sSilcoonSprites23:
+ax_sprite sSilcoonGfx23, 0x200
+ax_sprite_terminator
+sAxPosesSilcoon:
+.4byte sSilcoonPose1
+.4byte sSilcoonPose2
+.4byte sSilcoonPose3
+.4byte sSilcoonPose4
+.4byte sSilcoonPose5
+.4byte sSilcoonPose6
+.4byte sSilcoonPose7
+.4byte sSilcoonPose8
+.4byte sSilcoonPose9
+.4byte sSilcoonPose10
+.4byte sSilcoonPose11
+.4byte sSilcoonPose12
+.4byte sSilcoonPose13
+.4byte sSilcoonPose14
+.4byte sSilcoonPose15
+.4byte sSilcoonPose16
+.4byte sSilcoonPose17
+.4byte sSilcoonPose18
+.4byte sSilcoonPose19
+.4byte sSilcoonPose20
+.4byte sSilcoonPose21
+.4byte sSilcoonPose22
+.4byte sSilcoonPose23
+.4byte sSilcoonPose24
+.4byte sSilcoonPose25
+.4byte sSilcoonPose26
+.4byte sSilcoonPose27
+.4byte sSilcoonPose28
+.4byte sSilcoonPose29
+.4byte sSilcoonPose30
+.4byte sSilcoonPose31
+.4byte sSilcoonPose32
+.4byte sSilcoonPose33
+.4byte sSilcoonPose34
+.4byte sSilcoonPose35
+.4byte sSilcoonPose36
+.4byte sSilcoonPose37
+.4byte sSilcoonPose38
+.4byte sSilcoonPose39
+.4byte sSilcoonPose40
+.4byte sSilcoonPose41
+.4byte sSilcoonPose42
+.4byte sSilcoonPose43
+.4byte sSilcoonPose44
+.4byte sSilcoonPose45
+.4byte sSilcoonPose46
+.4byte sSilcoonPose47
+.4byte sSilcoonPose48
+.4byte sSilcoonPose49
+.4byte sSilcoonPose50
+.4byte sSilcoonPose51
+.4byte sSilcoonPose52
+.4byte sSilcoonPose53
+.4byte sSilcoonPose54
+.4byte sSilcoonPose55
+.4byte sSilcoonPose56
+.4byte sSilcoonPose57
+.4byte sSilcoonPose58
+.4byte sSilcoonPose59
+.4byte sSilcoonPose60
+.4byte sSilcoonPose61
+.4byte sSilcoonPose62
+.4byte sSilcoonPose63
+.4byte sSilcoonPose64
+.4byte sSilcoonPose65
+.4byte sSilcoonPose66
+.4byte sSilcoonPose67
+.4byte sSilcoonPose68
+.4byte sSilcoonPose69
+.4byte sSilcoonPose70
+.4byte sSilcoonPose71
+.4byte sSilcoonPose72
+.4byte sSilcoonPose73
+.4byte sSilcoonPose74
+.4byte sSilcoonPose75
+.4byte sSilcoonPose76
+.4byte sSilcoonPose77
+.4byte sSilcoonPose78
+.4byte sSilcoonPose79
+.4byte sSilcoonPose80
+.4byte sSilcoonPose81
+.4byte sSilcoonPose82
+.4byte sSilcoonPose83
+.4byte sSilcoonPose84
+.4byte sSilcoonPose85
+.4byte sSilcoonPose86
+.4byte sSilcoonPose87
+.4byte sSilcoonPose88
+.4byte sSilcoonPose89
+.4byte sSilcoonPose90
+.4byte sSilcoonPose91
+.4byte sSilcoonPose92
+.4byte sSilcoonPose93
+.4byte sSilcoonPose94
+.4byte sSilcoonPose95
+.4byte sSilcoonPose96
+.4byte sSilcoonPose97
+.4byte sSilcoonPose98
+.4byte sSilcoonPose99
+.4byte sSilcoonPose100
+.4byte sSilcoonPose101
+.4byte sSilcoonPose102
+.4byte sSilcoonPose103
+.4byte sSilcoonPose104
+.4byte sSilcoonPose105
+.4byte sSilcoonPose106
+.4byte sSilcoonPose107
+.4byte sSilcoonPose108
+.4byte sSilcoonPose109
+.4byte sSilcoonPose110
+.4byte sSilcoonPose111
+.4byte sSilcoonPose112
+.4byte sSilcoonPose113
+.4byte sSilcoonPose114
+sAxPositionsSilcoon:
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte    3,   -4, 	  -6,   -5, 	   5,   -8, 	  -1,  -10
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    4,   -4, 	  -1,   -4, 	  -1,  -12, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte    3,   -8, 	   6,   -6, 	  -3,  -12, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -4,   -7, 	   4,  -11, 	  -6,   -6, 	   0,   -9
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -5,   -4, 	   0,  -12, 	   0,   -4, 	   0,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -4,   -4, 	  -6,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    3,   -3, 	   5,   -1, 	  -2,   -6, 	  -1,   -5
+.2byte    2,   -4, 	   5,   -1, 	  -2,   -6, 	   0,   -4
+.2byte   -1,    0, 	  -8,   -3, 	   7,   -3, 	  -1,   -5
+.2byte    3,    0, 	   4,   -5, 	  -7,   -3, 	  -1,   -6
+.2byte    3,    0, 	  -1,   -7, 	  -1,    0, 	  -1,   -5
+.2byte    1,   -3, 	  -5,   -7, 	   4,   -2, 	  -2,   -6
+.2byte    0,   -4, 	   6,   -4, 	  -7,   -3, 	   0,   -5
+.2byte   -2,   -3, 	   4,   -7, 	  -5,   -2, 	   1,   -6
+.2byte   -4,    0, 	   0,   -7, 	   0,    0, 	   0,   -5
+.2byte   -4,    0, 	  -5,   -5, 	   6,   -3, 	   0,   -6
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte   -4,   -4, 	  -6,   -8, 	   5,   -5, 	  -1,  -10
+.2byte   -5,   -4, 	   0,  -12, 	   0,   -4, 	   0,   -9
+.2byte   -4,   -7, 	   4,  -11, 	  -6,   -6, 	   0,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -7, 	  -1,   -9
+.2byte    3,   -8, 	   6,   -6, 	  -3,  -12, 	  -1,   -9
+.2byte    4,   -4, 	  -1,   -4, 	  -1,  -12, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,   -8, 	  -1,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,   -8, 	  -1,  -10
+.2byte    4,   -4, 	  -1,   -4, 	  -1,  -12, 	  -1,   -9
+.2byte    3,   -8, 	   6,   -6, 	  -3,  -12, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   4,  -11, 	  -6,   -6, 	   0,   -9
+.2byte   -5,   -4, 	   0,  -12, 	   0,   -4, 	   0,   -9
+.2byte   -4,   -4, 	  -6,   -8, 	   5,   -5, 	  -1,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte    3,   -4, 	  -6,   -5, 	   5,   -8, 	  -1,  -10
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    4,   -4, 	  -1,   -4, 	  -1,  -12, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte    3,   -8, 	   6,   -6, 	  -3,  -12, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -7, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -4,   -7, 	   4,  -11, 	  -6,   -6, 	   0,   -9
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -5,   -4, 	   0,  -12, 	   0,   -4, 	   0,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -4,   -4, 	  -6,   -8, 	   5,   -5, 	  -1,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+.2byte   -1,   -4, 	  -9,   -7, 	   8,   -7, 	  -1,   -9
+.2byte   -4,   -4, 	  -5,  -10, 	   6,   -6, 	  -1,  -10
+.2byte   -5,   -4, 	   0,  -12, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	   2,  -10, 	  -6,   -5, 	  -1,   -9
+.2byte   -1,  -10, 	   7,   -7, 	  -8,   -7, 	  -1,   -9
+.2byte    1,   -9, 	   5,   -6, 	  -5,  -10, 	  -1,   -9
+.2byte    4,   -4, 	  -1,   -5, 	  -1,  -12, 	  -1,   -9
+.2byte    3,   -4, 	  -6,   -5, 	   5,  -10, 	   0,  -10
+sSilcoonAnimTable1:
+.4byte sSilcoonAnims_1_1
+.4byte sSilcoonAnims_1_2
+.4byte sSilcoonAnims_1_3
+.4byte sSilcoonAnims_1_4
+.4byte sSilcoonAnims_1_5
+.4byte sSilcoonAnims_1_6
+.4byte sSilcoonAnims_1_7
+.4byte sSilcoonAnims_1_8
+sSilcoonAnimTable2:
+.4byte sSilcoonAnims_2_1
+.4byte sSilcoonAnims_2_2
+.4byte sSilcoonAnims_2_3
+.4byte sSilcoonAnims_2_4
+.4byte sSilcoonAnims_2_5
+.4byte sSilcoonAnims_2_6
+.4byte sSilcoonAnims_2_7
+.4byte sSilcoonAnims_2_8
+sSilcoonAnimTable3:
+.4byte sSilcoonAnims_3_1
+.4byte sSilcoonAnims_3_2
+.4byte sSilcoonAnims_3_3
+.4byte sSilcoonAnims_3_4
+.4byte sSilcoonAnims_3_5
+.4byte sSilcoonAnims_3_6
+.4byte sSilcoonAnims_3_7
+.4byte sSilcoonAnims_3_8
+sSilcoonAnimTable4:
+.4byte sSilcoonAnims_4_1
+.4byte sSilcoonAnims_4_2
+.4byte sSilcoonAnims_4_3
+.4byte sSilcoonAnims_4_4
+.4byte sSilcoonAnims_4_5
+.4byte sSilcoonAnims_4_6
+.4byte sSilcoonAnims_4_7
+.4byte sSilcoonAnims_4_8
+sSilcoonAnimTable5:
+.4byte sSilcoonAnims_5_1
+.4byte sSilcoonAnims_5_2
+.4byte sSilcoonAnims_5_3
+.4byte sSilcoonAnims_5_4
+.4byte sSilcoonAnims_5_5
+.4byte sSilcoonAnims_5_6
+.4byte sSilcoonAnims_5_7
+.4byte sSilcoonAnims_5_8
+sSilcoonAnimTable6:
+.4byte sSilcoonAnims_6_1
+.4byte sSilcoonAnims_6_1
+.4byte sSilcoonAnims_6_1
+.4byte sSilcoonAnims_6_1
+.4byte sSilcoonAnims_6_1
+.4byte sSilcoonAnims_6_1
+.4byte sSilcoonAnims_6_1
+.4byte sSilcoonAnims_6_1
+sSilcoonAnimTable7:
+.4byte sSilcoonAnims_7_1
+.4byte sSilcoonAnims_7_2
+.4byte sSilcoonAnims_7_3
+.4byte sSilcoonAnims_7_4
+.4byte sSilcoonAnims_7_5
+.4byte sSilcoonAnims_7_6
+.4byte sSilcoonAnims_7_7
+.4byte sSilcoonAnims_7_8
+sSilcoonAnimTable8:
+.4byte sSilcoonAnims_8_1
+.4byte sSilcoonAnims_8_2
+.4byte sSilcoonAnims_8_3
+.4byte sSilcoonAnims_8_4
+.4byte sSilcoonAnims_8_5
+.4byte sSilcoonAnims_8_6
+.4byte sSilcoonAnims_8_7
+.4byte sSilcoonAnims_8_8
+sSilcoonAnimTable9:
+.4byte sSilcoonAnims_9_1
+.4byte sSilcoonAnims_9_2
+.4byte sSilcoonAnims_9_3
+.4byte sSilcoonAnims_9_4
+.4byte sSilcoonAnims_9_5
+.4byte sSilcoonAnims_9_6
+.4byte sSilcoonAnims_9_7
+.4byte sSilcoonAnims_9_8
+sSilcoonAnimTable10:
+.4byte sSilcoonAnims_10_1
+.4byte sSilcoonAnims_10_2
+.4byte sSilcoonAnims_10_3
+.4byte sSilcoonAnims_10_4
+.4byte sSilcoonAnims_10_5
+.4byte sSilcoonAnims_10_6
+.4byte sSilcoonAnims_10_7
+.4byte sSilcoonAnims_10_8
+sSilcoonAnimTable11:
+.4byte sSilcoonAnims_11_1
+.4byte sSilcoonAnims_11_2
+.4byte sSilcoonAnims_11_3
+.4byte sSilcoonAnims_11_4
+.4byte sSilcoonAnims_11_5
+.4byte sSilcoonAnims_11_6
+.4byte sSilcoonAnims_11_7
+.4byte sSilcoonAnims_11_8
+sSilcoonAnimTable12:
+.4byte sSilcoonAnims_12_1
+.4byte sSilcoonAnims_12_2
+.4byte sSilcoonAnims_12_3
+.4byte sSilcoonAnims_12_4
+.4byte sSilcoonAnims_12_5
+.4byte sSilcoonAnims_12_6
+.4byte sSilcoonAnims_12_7
+.4byte sSilcoonAnims_12_8
+sSilcoonAnimTable13:
+.4byte sSilcoonAnims_13_1
+.4byte sSilcoonAnims_13_2
+.4byte sSilcoonAnims_13_3
+.4byte sSilcoonAnims_13_4
+.4byte sSilcoonAnims_13_5
+.4byte sSilcoonAnims_13_6
+.4byte sSilcoonAnims_13_7
+.4byte sSilcoonAnims_13_8
+sAxAnimationsSilcoon:
+.4byte sSilcoonAnimTable1
+.4byte sSilcoonAnimTable2
+.4byte sSilcoonAnimTable3
+.4byte sSilcoonAnimTable4
+.4byte sSilcoonAnimTable5
+.4byte sSilcoonAnimTable6
+.4byte sSilcoonAnimTable7
+.4byte sSilcoonAnimTable8
+.4byte sSilcoonAnimTable9
+.4byte sSilcoonAnimTable10
+.4byte sSilcoonAnimTable11
+.4byte sSilcoonAnimTable12
+.4byte sSilcoonAnimTable13
+sAxSpritesSilcoon:
+.4byte sSilcoonSprites1
+.4byte sSilcoonSprites2
+.4byte sSilcoonSprites3
+.4byte sSilcoonSprites4
+.4byte sSilcoonSprites5
+.4byte sSilcoonSprites6
+.4byte sSilcoonSprites7
+.4byte sSilcoonSprites8
+.4byte sSilcoonSprites9
+.4byte sSilcoonSprites10
+.4byte sSilcoonSprites11
+.4byte sSilcoonSprites12
+.4byte sSilcoonSprites13
+.4byte sSilcoonSprites14
+.4byte sSilcoonSprites15
+.4byte sSilcoonSprites16
+.4byte sSilcoonSprites17
+.4byte sSilcoonSprites18
+.4byte sSilcoonSprites19
+.4byte sSilcoonSprites20
+.4byte sSilcoonSprites21
+.4byte sSilcoonSprites22
+.4byte sSilcoonSprites23
+sAxMainSilcoon:
+ax_main sAxPosesSilcoon, sAxAnimationsSilcoon, 13, sAxSpritesSilcoon, sAxPositionsSilcoon

--- a/data/ax/skarmory.inc
+++ b/data/ax/skarmory.inc
@@ -1,0 +1,3301 @@
+.global gAxSkarmory
+gAxSkarmory:
+ax_siro sAxMainSkarmory
+sSkarmoryPose1:
+ax_pose 0, 0x81e2, 0x80f0, 0x5c00
+ax_pose 1, 0x81e2, 0x4100, 0x5c08
+ax_pose 2, 0x81e2, 0x0108, 0x5c0c
+ax_pose 3, 0x01e2, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose2:
+ax_pose 4, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose3:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose4:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose5:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose6:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose7:
+ax_pose 9, 0x81e2, 0x90f0, 0x5c00
+ax_pose 10, 0x81e2, 0x5100, 0x5c08
+ax_pose 11, 0x81e2, 0x1108, 0x5c0c
+ax_pose 12, 0x01f2, 0x1108, 0x5c0e
+ax_pose 13, 0x01da, 0x1100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose8:
+ax_pose 14, 0x81e2, 0x90f0, 0x5c00
+ax_pose 15, 0x81e2, 0x5100, 0x5c08
+ax_pose 16, 0x01e2, 0x1108, 0x5c0c
+ax_pose 17, 0x01da, 0x1100, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose9:
+ax_pose 18, 0x81e1, 0x80f8, 0x5c00
+ax_pose 19, 0x81e9, 0x0108, 0x5c08
+ax_pose 20, 0x81e9, 0x00f0, 0x5c0a
+ax_pose 21, 0x01d9, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose10:
+ax_pose 22, 0x81e1, 0x80f8, 0x5c00
+ax_pose 23, 0x81e9, 0x0108, 0x5c08
+ax_pose 24, 0x81e9, 0x00f0, 0x5c0a
+ax_pose 25, 0x01d9, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose11:
+ax_pose 9, 0x81e2, 0x8100, 0x5c00
+ax_pose 10, 0x81e2, 0x40f8, 0x5c08
+ax_pose 11, 0x81e2, 0x00f0, 0x5c0c
+ax_pose 12, 0x01f2, 0x00f0, 0x5c0e
+ax_pose 13, 0x01da, 0x00f8, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose12:
+ax_pose 14, 0x81e2, 0x8100, 0x5c00
+ax_pose 15, 0x81e2, 0x40f8, 0x5c08
+ax_pose 16, 0x01e2, 0x00f0, 0x5c0c
+ax_pose 17, 0x01da, 0x00f8, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose13:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose14:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose15:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose16:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose17:
+ax_pose 0, 0x81e2, 0x80f0, 0x5c00
+ax_pose 1, 0x81e2, 0x4100, 0x5c08
+ax_pose 2, 0x81e2, 0x0108, 0x5c0c
+ax_pose 3, 0x01e2, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose18:
+ax_pose 4, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose19:
+ax_pose 26, 0x41ec, 0x80f0, 0x5c00
+ax_pose 27, 0x41fc, 0x00f8, 0x5c08
+ax_pose 28, 0x01f1, 0x00e8, 0x5c0a
+ax_pose 29, 0x01f1, 0x0110, 0x5c0b
+ax_pose_terminator
+sSkarmoryPose20:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose21:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose22:
+ax_pose 30, 0x01e4, 0x90f2, 0x5c00
+ax_pose_terminator
+sSkarmoryPose23:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose24:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose25:
+ax_pose 31, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose26:
+ax_pose 9, 0x81e2, 0x90f0, 0x5c00
+ax_pose 10, 0x81e2, 0x5100, 0x5c08
+ax_pose 11, 0x81e2, 0x1108, 0x5c0c
+ax_pose 12, 0x01f2, 0x1108, 0x5c0e
+ax_pose 13, 0x01da, 0x1100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose27:
+ax_pose 14, 0x81e2, 0x90f0, 0x5c00
+ax_pose 15, 0x81e2, 0x5100, 0x5c08
+ax_pose 16, 0x01e2, 0x1108, 0x5c0c
+ax_pose 17, 0x01da, 0x1100, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose28:
+ax_pose 32, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose29:
+ax_pose 18, 0x81e1, 0x80f8, 0x5c00
+ax_pose 19, 0x81e9, 0x0108, 0x5c08
+ax_pose 20, 0x81e9, 0x00f0, 0x5c0a
+ax_pose 21, 0x01d9, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose30:
+ax_pose 22, 0x81e1, 0x80f8, 0x5c00
+ax_pose 23, 0x81e9, 0x0108, 0x5c08
+ax_pose 24, 0x81e9, 0x00f0, 0x5c0a
+ax_pose 25, 0x01d9, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose31:
+ax_pose 33, 0x81e3, 0x80f8, 0x5c00
+ax_pose 34, 0x81eb, 0x00f0, 0x5c08
+ax_pose 35, 0x81eb, 0x0108, 0x5c0a
+ax_pose 36, 0x01ef, 0x00e8, 0x5c0c
+ax_pose 37, 0x01ef, 0x0110, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose32:
+ax_pose 9, 0x81e2, 0x8100, 0x5c00
+ax_pose 10, 0x81e2, 0x40f8, 0x5c08
+ax_pose 11, 0x81e2, 0x00f0, 0x5c0c
+ax_pose 12, 0x01f2, 0x00f0, 0x5c0e
+ax_pose 13, 0x01da, 0x00f8, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose33:
+ax_pose 14, 0x81e2, 0x8100, 0x5c00
+ax_pose 15, 0x81e2, 0x40f8, 0x5c08
+ax_pose 16, 0x01e2, 0x00f0, 0x5c0c
+ax_pose 17, 0x01da, 0x00f8, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose34:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose35:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose36:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose37:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose38:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose39:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose40:
+ax_pose 30, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose41:
+ax_pose 0, 0x81e2, 0x80f0, 0x5c00
+ax_pose 1, 0x81e2, 0x4100, 0x5c08
+ax_pose 2, 0x81e2, 0x0108, 0x5c0c
+ax_pose 3, 0x01e2, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose42:
+ax_pose 4, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose43:
+ax_pose 26, 0x41ec, 0x80f0, 0x5c00
+ax_pose 27, 0x41fc, 0x00f8, 0x5c08
+ax_pose 28, 0x01f1, 0x00e8, 0x5c0a
+ax_pose 29, 0x01f1, 0x0110, 0x5c0b
+ax_pose_terminator
+sSkarmoryPose44:
+ax_pose 5, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose45:
+ax_pose 6, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose46:
+ax_pose 30, 0x01e4, 0x90f2, 0x5c00
+ax_pose_terminator
+sSkarmoryPose47:
+ax_pose 7, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose48:
+ax_pose 8, 0x01e2, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose49:
+ax_pose 31, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose50:
+ax_pose 9, 0x81e2, 0x90f0, 0x5c00
+ax_pose 10, 0x81e2, 0x5100, 0x5c08
+ax_pose 11, 0x81e2, 0x1108, 0x5c0c
+ax_pose 12, 0x01f2, 0x1108, 0x5c0e
+ax_pose 13, 0x01da, 0x1100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose51:
+ax_pose 14, 0x81e2, 0x90f0, 0x5c00
+ax_pose 15, 0x81e2, 0x5100, 0x5c08
+ax_pose 16, 0x01e2, 0x1108, 0x5c0c
+ax_pose 17, 0x01da, 0x1100, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose52:
+ax_pose 32, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose53:
+ax_pose 18, 0x81e1, 0x80f8, 0x5c00
+ax_pose 19, 0x81e9, 0x0108, 0x5c08
+ax_pose 20, 0x81e9, 0x00f0, 0x5c0a
+ax_pose 21, 0x01d9, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose54:
+ax_pose 22, 0x81e1, 0x80f8, 0x5c00
+ax_pose 23, 0x81e9, 0x0108, 0x5c08
+ax_pose 24, 0x81e9, 0x00f0, 0x5c0a
+ax_pose 25, 0x01d9, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose55:
+ax_pose 33, 0x81e3, 0x80f8, 0x5c00
+ax_pose 34, 0x81eb, 0x00f0, 0x5c08
+ax_pose 35, 0x81eb, 0x0108, 0x5c0a
+ax_pose 36, 0x01ef, 0x00e8, 0x5c0c
+ax_pose 37, 0x01ef, 0x0110, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose56:
+ax_pose 9, 0x81e2, 0x8100, 0x5c00
+ax_pose 10, 0x81e2, 0x40f8, 0x5c08
+ax_pose 11, 0x81e2, 0x00f0, 0x5c0c
+ax_pose 12, 0x01f2, 0x00f0, 0x5c0e
+ax_pose 13, 0x01da, 0x00f8, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose57:
+ax_pose 14, 0x81e2, 0x8100, 0x5c00
+ax_pose 15, 0x81e2, 0x40f8, 0x5c08
+ax_pose 16, 0x01e2, 0x00f0, 0x5c0c
+ax_pose 17, 0x01da, 0x00f8, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose58:
+ax_pose 32, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose59:
+ax_pose 7, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose60:
+ax_pose 8, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose61:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose62:
+ax_pose 5, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose63:
+ax_pose 6, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose64:
+ax_pose 30, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose65:
+ax_pose 38, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose66:
+ax_pose 39, 0x81e4, 0x80f8, 0x5c00
+ax_pose 40, 0x81f4, 0x00f0, 0x5c08
+ax_pose 41, 0x81f4, 0x0108, 0x5c0a
+ax_pose 42, 0x01ec, 0x0108, 0x5c0c
+ax_pose 43, 0x01ec, 0x00f0, 0x5c0d
+ax_pose 44, 0x01ec, 0x00e8, 0x5c0e
+ax_pose 45, 0x01ec, 0x0110, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose67:
+ax_pose 46, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose68:
+ax_pose 47, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose69:
+ax_pose 48, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose70:
+ax_pose 49, 0x81e4, 0x9101, 0x5c00
+ax_pose 50, 0x81e4, 0x50f9, 0x5c08
+ax_pose 51, 0x01ec, 0x1111, 0x5c0c
+ax_pose 52, 0x01ec, 0x10f1, 0x5c0d
+ax_pose 53, 0x81f4, 0x10f1, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose71:
+ax_pose 54, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose72:
+ax_pose 55, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose73:
+ax_pose 56, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose74:
+ax_pose 57, 0x81e3, 0x80f8, 0x5c00
+ax_pose 58, 0x81eb, 0x00f0, 0x5c08
+ax_pose 59, 0x81eb, 0x0108, 0x5c0a
+ax_pose 60, 0x01fb, 0x0108, 0x5c0c
+ax_pose 61, 0x01eb, 0x00e8, 0x5c0d
+ax_pose 62, 0x01ed, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose75:
+ax_pose 54, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose76:
+ax_pose 55, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose77:
+ax_pose 48, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose78:
+ax_pose 49, 0x81e4, 0x80f0, 0x5c00
+ax_pose 50, 0x81e4, 0x4100, 0x5c08
+ax_pose 51, 0x01ec, 0x00e8, 0x5c0c
+ax_pose 52, 0x01ec, 0x0108, 0x5c0d
+ax_pose 53, 0x81f4, 0x0108, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose79:
+ax_pose 46, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose80:
+ax_pose 47, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose81:
+ax_pose 38, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose82:
+ax_pose 46, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose83:
+ax_pose 48, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose84:
+ax_pose 54, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose85:
+ax_pose 56, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose86:
+ax_pose 54, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose87:
+ax_pose 48, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose88:
+ax_pose 46, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose89:
+ax_pose 63, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sSkarmoryPose90:
+ax_pose 64, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sSkarmoryPose91:
+ax_pose 65, 0x01df, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose92:
+ax_pose 66, 0x01df, 0x90ee, 0x5c00
+ax_pose_terminator
+sSkarmoryPose93:
+ax_pose 67, 0x01df, 0x90ee, 0x5c00
+ax_pose_terminator
+sSkarmoryPose94:
+ax_pose 68, 0x01e0, 0x90ed, 0x5c00
+ax_pose_terminator
+sSkarmoryPose95:
+ax_pose 69, 0x01e0, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose96:
+ax_pose 68, 0x01e0, 0x80f3, 0x5c00
+ax_pose_terminator
+sSkarmoryPose97:
+ax_pose 67, 0x01df, 0x80f3, 0x5c00
+ax_pose_terminator
+sSkarmoryPose98:
+ax_pose 66, 0x01df, 0x80f2, 0x5c00
+ax_pose_terminator
+sSkarmoryPose99:
+ax_pose 38, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose100:
+ax_pose 0, 0x81e4, 0x80f0, 0x5c00
+ax_pose 1, 0x81e4, 0x4100, 0x5c08
+ax_pose 2, 0x81e4, 0x0108, 0x5c0c
+ax_pose 3, 0x01e4, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose101:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose102:
+ax_pose 46, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose103:
+ax_pose 5, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose104:
+ax_pose 6, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose105:
+ax_pose 48, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose106:
+ax_pose 7, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose107:
+ax_pose 8, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose108:
+ax_pose 54, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose109:
+ax_pose 9, 0x81e4, 0x90f0, 0x5c00
+ax_pose 10, 0x81e4, 0x5100, 0x5c08
+ax_pose 11, 0x81e4, 0x1108, 0x5c0c
+ax_pose 12, 0x01f4, 0x1108, 0x5c0e
+ax_pose 13, 0x01dc, 0x1100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose110:
+ax_pose 14, 0x81e4, 0x90f0, 0x5c00
+ax_pose 15, 0x81e4, 0x5100, 0x5c08
+ax_pose 16, 0x01e4, 0x1108, 0x5c0c
+ax_pose 17, 0x01dc, 0x1100, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose111:
+ax_pose 56, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose112:
+ax_pose 18, 0x81e3, 0x80f8, 0x5c00
+ax_pose 19, 0x81eb, 0x0108, 0x5c08
+ax_pose 20, 0x81eb, 0x00f0, 0x5c0a
+ax_pose 21, 0x01db, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose113:
+ax_pose 22, 0x81e3, 0x80f8, 0x5c00
+ax_pose 23, 0x81eb, 0x0108, 0x5c08
+ax_pose 24, 0x81eb, 0x00f0, 0x5c0a
+ax_pose 25, 0x01db, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose114:
+ax_pose 54, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose115:
+ax_pose 9, 0x81e4, 0x8100, 0x5c00
+ax_pose 10, 0x81e4, 0x40f8, 0x5c08
+ax_pose 11, 0x81e4, 0x00f0, 0x5c0c
+ax_pose 12, 0x01f4, 0x00f0, 0x5c0e
+ax_pose 13, 0x01dc, 0x00f8, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose116:
+ax_pose 14, 0x81e4, 0x8100, 0x5c00
+ax_pose 15, 0x81e4, 0x40f8, 0x5c08
+ax_pose 16, 0x01e4, 0x00f0, 0x5c0c
+ax_pose 17, 0x01dc, 0x00f8, 0x5c0d
+ax_pose_terminator
+sSkarmoryPose117:
+ax_pose 48, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose118:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose119:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose120:
+ax_pose 46, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose121:
+ax_pose 5, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose122:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose123:
+ax_pose 39, 0x81e4, 0x80f8, 0x5c00
+ax_pose 40, 0x81f4, 0x00f0, 0x5c08
+ax_pose 41, 0x81f4, 0x0108, 0x5c0a
+ax_pose 42, 0x01ec, 0x0108, 0x5c0c
+ax_pose 43, 0x01ec, 0x00f0, 0x5c0d
+ax_pose 44, 0x01ec, 0x00e8, 0x5c0e
+ax_pose 45, 0x01ec, 0x0110, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose124:
+ax_pose 47, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSkarmoryPose125:
+ax_pose 49, 0x81e4, 0x80f1, 0x5c00
+ax_pose 50, 0x81e4, 0x4101, 0x5c08
+ax_pose 51, 0x01ec, 0x00e9, 0x5c0c
+ax_pose 52, 0x01ec, 0x0109, 0x5c0d
+ax_pose 53, 0x81f4, 0x0109, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose126:
+ax_pose 55, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose127:
+ax_pose 57, 0x81e3, 0x80f8, 0x5c00
+ax_pose 58, 0x81eb, 0x00f0, 0x5c08
+ax_pose 59, 0x81eb, 0x0108, 0x5c0a
+ax_pose 60, 0x01fb, 0x0108, 0x5c0c
+ax_pose 61, 0x01eb, 0x00e8, 0x5c0d
+ax_pose 62, 0x01ed, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose128:
+ax_pose 55, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose129:
+ax_pose 49, 0x81e4, 0x9101, 0x5c00
+ax_pose 50, 0x81e4, 0x50f9, 0x5c08
+ax_pose 51, 0x01ec, 0x1111, 0x5c0c
+ax_pose 52, 0x01ec, 0x10f1, 0x5c0d
+ax_pose 53, 0x81f4, 0x10f1, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose130:
+ax_pose 47, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sSkarmoryPose131:
+ax_pose 39, 0x81e4, 0x80f8, 0x5c00
+ax_pose 40, 0x81f4, 0x00f0, 0x5c08
+ax_pose 41, 0x81f4, 0x0108, 0x5c0a
+ax_pose 42, 0x01ec, 0x0108, 0x5c0c
+ax_pose 43, 0x01ec, 0x00f0, 0x5c0d
+ax_pose 44, 0x01ec, 0x00e8, 0x5c0e
+ax_pose 45, 0x01ec, 0x0110, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose132:
+ax_pose 47, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sSkarmoryPose133:
+ax_pose 49, 0x81e4, 0x9101, 0x5c00
+ax_pose 50, 0x81e4, 0x50f9, 0x5c08
+ax_pose 51, 0x01ec, 0x1111, 0x5c0c
+ax_pose 52, 0x01ec, 0x10f1, 0x5c0d
+ax_pose 53, 0x81f4, 0x10f1, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose134:
+ax_pose 55, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose135:
+ax_pose 57, 0x81e3, 0x80f8, 0x5c00
+ax_pose 58, 0x81eb, 0x00f0, 0x5c08
+ax_pose 59, 0x81eb, 0x0108, 0x5c0a
+ax_pose 60, 0x01fb, 0x0108, 0x5c0c
+ax_pose 61, 0x01eb, 0x00e8, 0x5c0d
+ax_pose 62, 0x01ed, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose136:
+ax_pose 55, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose137:
+ax_pose 49, 0x81e4, 0x80f1, 0x5c00
+ax_pose 50, 0x81e4, 0x4101, 0x5c08
+ax_pose 51, 0x01ec, 0x00e9, 0x5c0c
+ax_pose 52, 0x01ec, 0x0109, 0x5c0d
+ax_pose 53, 0x81f4, 0x0109, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose138:
+ax_pose 47, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSkarmoryPose139:
+ax_pose 38, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose140:
+ax_pose 39, 0x81e4, 0x80f8, 0x5c00
+ax_pose 40, 0x81f4, 0x00f0, 0x5c08
+ax_pose 41, 0x81f4, 0x0108, 0x5c0a
+ax_pose 42, 0x01ec, 0x0108, 0x5c0c
+ax_pose 43, 0x01ec, 0x00f0, 0x5c0d
+ax_pose 44, 0x01ec, 0x00e8, 0x5c0e
+ax_pose 45, 0x01ec, 0x0110, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose141:
+ax_pose 0, 0x81e5, 0x80f0, 0x5c00
+ax_pose 1, 0x81e5, 0x4100, 0x5c08
+ax_pose 2, 0x81e5, 0x0108, 0x5c0c
+ax_pose 3, 0x01e5, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose142:
+ax_pose 46, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose143:
+ax_pose 47, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose144:
+ax_pose 5, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose145:
+ax_pose 48, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose146:
+ax_pose 49, 0x81e4, 0x9101, 0x5c00
+ax_pose 50, 0x81e4, 0x50f9, 0x5c08
+ax_pose 51, 0x01ec, 0x1111, 0x5c0c
+ax_pose 52, 0x01ec, 0x10f1, 0x5c0d
+ax_pose 53, 0x81f4, 0x10f1, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose147:
+ax_pose 7, 0x01e5, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose148:
+ax_pose 54, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose149:
+ax_pose 55, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose150:
+ax_pose 9, 0x81e5, 0x90f0, 0x5c00
+ax_pose 10, 0x81e5, 0x5100, 0x5c08
+ax_pose 11, 0x81e5, 0x1108, 0x5c0c
+ax_pose 12, 0x01f5, 0x1108, 0x5c0e
+ax_pose 13, 0x01dd, 0x1100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose151:
+ax_pose 56, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose152:
+ax_pose 57, 0x81e3, 0x80f8, 0x5c00
+ax_pose 58, 0x81eb, 0x00f0, 0x5c08
+ax_pose 59, 0x81eb, 0x0108, 0x5c0a
+ax_pose 60, 0x01fb, 0x0108, 0x5c0c
+ax_pose 61, 0x01eb, 0x00e8, 0x5c0d
+ax_pose 62, 0x01ed, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose153:
+ax_pose 18, 0x81e4, 0x80f8, 0x5c00
+ax_pose 19, 0x81ec, 0x0108, 0x5c08
+ax_pose 20, 0x81ec, 0x00f0, 0x5c0a
+ax_pose 21, 0x01dc, 0x00ff, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose154:
+ax_pose 54, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose155:
+ax_pose 55, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose156:
+ax_pose 9, 0x81e5, 0x8100, 0x5c00
+ax_pose 10, 0x81e5, 0x40f8, 0x5c08
+ax_pose 11, 0x81e5, 0x00f0, 0x5c0c
+ax_pose 12, 0x01f5, 0x00f0, 0x5c0e
+ax_pose 13, 0x01dd, 0x00f8, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose157:
+ax_pose 48, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose158:
+ax_pose 49, 0x81e4, 0x80f0, 0x5c00
+ax_pose 50, 0x81e4, 0x4100, 0x5c08
+ax_pose 51, 0x01ec, 0x00e8, 0x5c0c
+ax_pose 52, 0x01ec, 0x0108, 0x5c0d
+ax_pose 53, 0x81f4, 0x0108, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose159:
+ax_pose 7, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose160:
+ax_pose 46, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose161:
+ax_pose 47, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose162:
+ax_pose 5, 0x01e5, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose163:
+ax_pose 39, 0x81e4, 0x80f8, 0x5c00
+ax_pose 40, 0x81f4, 0x00f0, 0x5c08
+ax_pose 41, 0x81f4, 0x0108, 0x5c0a
+ax_pose 42, 0x01ec, 0x0108, 0x5c0c
+ax_pose 43, 0x01ec, 0x00f0, 0x5c0d
+ax_pose 44, 0x01ec, 0x00e8, 0x5c0e
+ax_pose 45, 0x01ec, 0x0110, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose164:
+ax_pose 47, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSkarmoryPose165:
+ax_pose 49, 0x81e4, 0x80f1, 0x5c00
+ax_pose 50, 0x81e4, 0x4101, 0x5c08
+ax_pose 51, 0x01ec, 0x00e9, 0x5c0c
+ax_pose 52, 0x01ec, 0x0109, 0x5c0d
+ax_pose 53, 0x81f4, 0x0109, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose166:
+ax_pose 55, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose167:
+ax_pose 57, 0x81e3, 0x80f8, 0x5c00
+ax_pose 58, 0x81eb, 0x00f0, 0x5c08
+ax_pose 59, 0x81eb, 0x0108, 0x5c0a
+ax_pose 60, 0x01fb, 0x0108, 0x5c0c
+ax_pose 61, 0x01eb, 0x00e8, 0x5c0d
+ax_pose 62, 0x01ed, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose168:
+ax_pose 55, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose169:
+ax_pose 49, 0x81e4, 0x9101, 0x5c00
+ax_pose 50, 0x81e4, 0x50f9, 0x5c08
+ax_pose 51, 0x01ec, 0x1111, 0x5c0c
+ax_pose 52, 0x01ec, 0x10f1, 0x5c0d
+ax_pose 53, 0x81f4, 0x10f1, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose170:
+ax_pose 47, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sSkarmoryPose171:
+ax_pose 38, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose172:
+ax_pose 46, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose173:
+ax_pose 48, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose174:
+ax_pose 54, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose175:
+ax_pose 56, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose176:
+ax_pose 54, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose177:
+ax_pose 48, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose178:
+ax_pose 46, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSkarmoryPose179:
+ax_pose 70, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose180:
+ax_pose 71, 0x41e4, 0x80f0, 0x5c00
+ax_pose 72, 0x41f4, 0x40f0, 0x5c08
+ax_pose 73, 0x01fc, 0x0108, 0x5c0c
+ax_pose 74, 0x41fc, 0x00f8, 0x5c0d
+ax_pose 75, 0x01dc, 0x0100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose181:
+ax_pose 76, 0x41e2, 0x80f0, 0x5c00
+ax_pose 77, 0x41f2, 0x40f0, 0x5c08
+ax_pose 78, 0x41fa, 0x00f8, 0x5c0c
+ax_pose 79, 0x01e2, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose182:
+ax_pose 80, 0x41ea, 0x80f0, 0x5c00
+ax_pose 81, 0x41e2, 0x00f8, 0x5c08
+ax_pose 82, 0x41fa, 0x00f8, 0x5c0a
+ax_pose 83, 0x01ea, 0x0110, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose183:
+ax_pose 70, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose184:
+ax_pose 71, 0x41e4, 0x80f0, 0x5c00
+ax_pose 72, 0x41f4, 0x40f0, 0x5c08
+ax_pose 73, 0x01fc, 0x0108, 0x5c0c
+ax_pose 74, 0x41fc, 0x00f8, 0x5c0d
+ax_pose 75, 0x01dc, 0x0100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose185:
+ax_pose 0, 0x81e2, 0x80f0, 0x5c00
+ax_pose 1, 0x81e2, 0x4100, 0x5c08
+ax_pose 2, 0x81e2, 0x0108, 0x5c0c
+ax_pose 3, 0x01e2, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose186:
+ax_pose 4, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose187:
+ax_pose 76, 0x41e2, 0x80f0, 0x5c00
+ax_pose 77, 0x41f2, 0x40f0, 0x5c08
+ax_pose 78, 0x41fa, 0x00f8, 0x5c0c
+ax_pose 79, 0x01e2, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose188:
+ax_pose 80, 0x41ea, 0x80f0, 0x5c00
+ax_pose 81, 0x41e2, 0x00f8, 0x5c08
+ax_pose 82, 0x41fa, 0x00f8, 0x5c0a
+ax_pose 83, 0x01ea, 0x0110, 0x5c0c
+ax_pose_terminator
+sSkarmoryPose189:
+ax_pose 70, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSkarmoryPose190:
+ax_pose 71, 0x41e4, 0x80f0, 0x5c00
+ax_pose 72, 0x41f4, 0x40f0, 0x5c08
+ax_pose 73, 0x01fc, 0x0108, 0x5c0c
+ax_pose 74, 0x41fc, 0x00f8, 0x5c0d
+ax_pose 75, 0x01dc, 0x0100, 0x5c0f
+ax_pose_terminator
+sSkarmoryPose191:
+ax_pose 0, 0x81e2, 0x80f0, 0x5c00
+ax_pose 1, 0x81e2, 0x4100, 0x5c08
+ax_pose 2, 0x81e2, 0x0108, 0x5c0c
+ax_pose 3, 0x01e2, 0x0110, 0x5c0e
+ax_pose_terminator
+sSkarmoryPose192:
+ax_pose 4, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+.align 2
+sSkarmoryAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 4, 0, 0, 0, -1, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, -1, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim 4, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 4, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 4, 0, 6, 0, -1, 0, 0,
+ax_anim 4, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -1, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim 4, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 4, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 4, 0, 12, 0, -1, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, -1, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim 4, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 2, 0, 17, 0, -3, 0, -2,
+ax_anim 2, 0, 16, 0, -6, 0, -4,
+ax_anim 2, 0, 17, 0, -6, 0, -4,
+ax_anim 2, 0, 16, 0, -6, 0, -4,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 0, 4, 0, 4,
+ax_anim 1, 0, 18, 0, 10, 0, 10,
+ax_anim 2, 0, 18, 0, 23, 0, 23,
+ax_anim 2, 1, 18, 1, 23, 1, 23,
+ax_anim 2, 0, 18, 0, 23, 0, 23,
+ax_anim 2, 0, 18, 1, 23, 1, 23,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sSkarmoryAnims_2_2:
+ax_anim 2, 0, 19, -1, -1, -1, -1,
+ax_anim 2, 0, 20, -2, -3, -2, -2,
+ax_anim 2, 0, 19, -4, -7, -4, -4,
+ax_anim 2, 0, 20, -4, -7, -4, -4,
+ax_anim 2, 0, 19, -4, -7, -4, -4,
+ax_anim 1, 0, 21, 0, -2, 0, 0,
+ax_anim 1, 2, 21, 6, 10, 6, 8,
+ax_anim 1, 0, 21, 12, 16, 12, 14,
+ax_anim 2, 0, 21, 18, 23, 18, 23,
+ax_anim 2, 1, 21, 19, 22, 19, 22,
+ax_anim 2, 0, 21, 18, 23, 18, 23,
+ax_anim 2, 0, 21, 19, 22, 19, 22,
+ax_anim 2, 0, 19, 6, 6, 6, 6,
+ax_anim_terminator
+sSkarmoryAnims_2_3:
+ax_anim 2, 0, 22, -1, -1, -1, 0,
+ax_anim 2, 0, 23, -2, -3, -2, 0,
+ax_anim 2, 0, 22, -4, -6, -4, 0,
+ax_anim 2, 0, 23, -4, -6, -4, 0,
+ax_anim 2, 0, 22, -4, -6, -4, 0,
+ax_anim 1, 0, 24, 0, -4, 0, 0,
+ax_anim 1, 2, 24, 4, -2, 4, 0,
+ax_anim 1, 0, 24, 9, 0, 9, 0,
+ax_anim 2, 0, 24, 14, 0, 14, 0,
+ax_anim 2, 1, 24, 14, -1, 14, -1,
+ax_anim 2, 0, 24, 14, 0, 14, 0,
+ax_anim 2, 0, 24, 14, -1, 14, -1,
+ax_anim 2, 0, 22, 6, 0, 6, 0,
+ax_anim_terminator
+sSkarmoryAnims_2_4:
+ax_anim 2, 0, 25, -1, -1, -1, 1,
+ax_anim 2, 0, 26, -2, -2, -2, 2,
+ax_anim 2, 0, 25, -4, -3, -4, 4,
+ax_anim 2, 0, 26, -4, -3, -4, 4,
+ax_anim 2, 0, 25, -4, -3, -4, 4,
+ax_anim 1, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 27, 4, -4, 4, -4,
+ax_anim 1, 0, 27, 9, -11, 9, -9,
+ax_anim 2, 0, 27, 14, -19, 14, -19,
+ax_anim 2, 1, 27, 13, -20, 13, -20,
+ax_anim 2, 0, 27, 14, -19, 14, -19,
+ax_anim 2, 0, 27, 13, -20, 13, -20,
+ax_anim 2, 0, 25, 6, -6, 6, -6,
+ax_anim_terminator
+sSkarmoryAnims_2_5:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 2, 0, 29, 0, 2, 0, 3,
+ax_anim 2, 0, 28, 0, 3, 0, 5,
+ax_anim 2, 0, 29, 0, 3, 0, 5,
+ax_anim 2, 0, 28, 0, 3, 0, 5,
+ax_anim 1, 0, 30, 0, 0, 0, 2,
+ax_anim 1, 2, 30, 0, -4, 0, -4,
+ax_anim 1, 0, 30, 0, -9, 0, -9,
+ax_anim 2, 0, 30, 0, -19, 0, -19,
+ax_anim 2, 1, 30, -1, -19, -1, -19,
+ax_anim 2, 0, 30, 0, -19, 0, -19,
+ax_anim 2, 0, 30, -1, -19, -1, -19,
+ax_anim 2, 0, 28, 0, -6, 0, -6,
+ax_anim_terminator
+sSkarmoryAnims_2_6:
+ax_anim 2, 0, 31, 1, -1, 1, 1,
+ax_anim 2, 0, 32, 2, -2, 2, 2,
+ax_anim 2, 0, 31, 4, -3, 4, 4,
+ax_anim 2, 0, 32, 4, -3, 4, 4,
+ax_anim 2, 0, 31, 4, -3, 4, 4,
+ax_anim 1, 0, 33, 0, -5, 0, 0,
+ax_anim 1, 2, 33, -4, -4, -4, -4,
+ax_anim 1, 0, 33, -9, -11, -9, -9,
+ax_anim 2, 0, 33, -14, -19, -14, -19,
+ax_anim 2, 1, 33, -13, -20, -13, -20,
+ax_anim 2, 0, 33, -14, -19, -14, -19,
+ax_anim 2, 0, 33, -13, -20, -13, -20,
+ax_anim 2, 0, 31, -6, -6, -6, -6,
+ax_anim_terminator
+sSkarmoryAnims_2_7:
+ax_anim 2, 0, 34, 1, -1, 1, 0,
+ax_anim 2, 0, 35, 2, -3, 2, 0,
+ax_anim 2, 0, 34, 4, -6, 4, 0,
+ax_anim 2, 0, 35, 4, -6, 4, 0,
+ax_anim 2, 0, 34, 4, -6, 4, 0,
+ax_anim 1, 0, 36, 0, -4, 0, 0,
+ax_anim 1, 2, 36, -4, -2, -4, 0,
+ax_anim 1, 0, 36, -9, 0, -9, 0,
+ax_anim 2, 0, 36, -14, 0, -14, 0,
+ax_anim 2, 1, 36, -14, -1, -14, -1,
+ax_anim 2, 0, 36, -14, 0, -14, 0,
+ax_anim 2, 0, 36, -14, -1, -14, -1,
+ax_anim 2, 0, 34, -6, 0, -6, 0,
+ax_anim_terminator
+sSkarmoryAnims_2_8:
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 2, 0, 38, 2, -3, 2, -2,
+ax_anim 2, 0, 37, 4, -7, 4, -4,
+ax_anim 2, 0, 38, 4, -7, 4, -4,
+ax_anim 2, 0, 37, 4, -7, 4, -4,
+ax_anim 1, 0, 39, 0, -2, 0, 0,
+ax_anim 1, 2, 39, -6, 10, -6, 8,
+ax_anim 1, 0, 39, -12, 16, -12, 14,
+ax_anim 2, 0, 39, -18, 23, -18, 23,
+ax_anim 2, 1, 39, -19, 22, -19, 22,
+ax_anim 2, 0, 39, -18, 23, -18, 23,
+ax_anim 2, 0, 39, -19, 22, -19, 22,
+ax_anim 2, 0, 37, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, -1,
+ax_anim 2, 0, 41, 0, -3, 0, -2,
+ax_anim 2, 0, 40, 0, -6, 0, -4,
+ax_anim 2, 0, 41, 0, -6, 0, -4,
+ax_anim 2, 0, 40, 0, -6, 0, -4,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, 4, 0, 4,
+ax_anim 1, 0, 42, 0, 10, 0, 10,
+ax_anim 2, 0, 42, 0, 23, 0, 23,
+ax_anim 2, 1, 42, 1, 23, 1, 23,
+ax_anim 2, 0, 42, 0, 23, 0, 23,
+ax_anim 2, 0, 42, 1, 23, 1, 23,
+ax_anim 2, 0, 40, 0, 6, 0, 6,
+ax_anim_terminator
+sSkarmoryAnims_3_2:
+ax_anim 2, 0, 43, -1, -1, -1, -1,
+ax_anim 2, 0, 44, -2, -3, -2, -2,
+ax_anim 2, 0, 43, -4, -7, -4, -4,
+ax_anim 2, 0, 44, -4, -7, -4, -4,
+ax_anim 2, 0, 43, -4, -7, -4, -4,
+ax_anim 1, 0, 45, 0, -2, 0, 0,
+ax_anim 1, 2, 45, 6, 10, 6, 8,
+ax_anim 1, 0, 45, 12, 16, 12, 14,
+ax_anim 2, 0, 45, 18, 23, 18, 23,
+ax_anim 2, 1, 45, 19, 22, 19, 22,
+ax_anim 2, 0, 45, 18, 23, 18, 23,
+ax_anim 2, 0, 45, 19, 22, 19, 22,
+ax_anim 2, 0, 43, 6, 6, 6, 6,
+ax_anim_terminator
+sSkarmoryAnims_3_3:
+ax_anim 2, 0, 46, -1, -1, -1, 0,
+ax_anim 2, 0, 47, -2, -3, -2, 0,
+ax_anim 2, 0, 46, -4, -6, -4, 0,
+ax_anim 2, 0, 47, -4, -6, -4, 0,
+ax_anim 2, 0, 46, -4, -6, -4, 0,
+ax_anim 1, 0, 48, 0, -4, 0, 0,
+ax_anim 1, 2, 48, 4, -2, 4, 0,
+ax_anim 1, 0, 48, 9, 0, 9, 0,
+ax_anim 2, 0, 48, 14, 0, 14, 0,
+ax_anim 2, 1, 48, 14, -1, 14, -1,
+ax_anim 2, 0, 48, 14, 0, 14, 0,
+ax_anim 2, 0, 48, 14, -1, 14, -1,
+ax_anim 2, 0, 46, 6, 0, 6, 0,
+ax_anim_terminator
+sSkarmoryAnims_3_4:
+ax_anim 2, 0, 49, -1, -1, -1, 1,
+ax_anim 2, 0, 50, -2, -2, -2, 2,
+ax_anim 2, 0, 49, -4, -3, -4, 4,
+ax_anim 2, 0, 50, -4, -3, -4, 4,
+ax_anim 2, 0, 49, -4, -3, -4, 4,
+ax_anim 1, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 51, 4, -4, 4, -4,
+ax_anim 1, 0, 51, 9, -11, 9, -9,
+ax_anim 2, 0, 51, 14, -19, 14, -19,
+ax_anim 2, 1, 51, 13, -20, 13, -20,
+ax_anim 2, 0, 51, 14, -19, 14, -19,
+ax_anim 2, 0, 51, 13, -20, 13, -20,
+ax_anim 2, 0, 49, 6, -6, 6, -6,
+ax_anim_terminator
+sSkarmoryAnims_3_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 2, 0, 53, 0, 2, 0, 3,
+ax_anim 2, 0, 52, 0, 3, 0, 5,
+ax_anim 2, 0, 53, 0, 3, 0, 5,
+ax_anim 2, 0, 52, 0, 3, 0, 5,
+ax_anim 1, 0, 54, 0, 0, 0, 2,
+ax_anim 1, 2, 54, 0, -4, 0, -4,
+ax_anim 1, 0, 54, 0, -9, 0, -9,
+ax_anim 2, 0, 54, 0, -19, 0, -19,
+ax_anim 2, 1, 54, -1, -19, -1, -19,
+ax_anim 2, 0, 54, 0, -19, 0, -19,
+ax_anim 2, 0, 54, -1, -19, -1, -19,
+ax_anim 2, 0, 52, 0, -6, 0, -6,
+ax_anim_terminator
+sSkarmoryAnims_3_6:
+ax_anim 2, 0, 55, 1, -1, 1, 1,
+ax_anim 2, 0, 56, 2, -2, 2, 2,
+ax_anim 2, 0, 55, 4, -3, 4, 4,
+ax_anim 2, 0, 56, 4, -3, 4, 4,
+ax_anim 2, 0, 55, 4, -3, 4, 4,
+ax_anim 1, 0, 57, 0, -5, 0, 0,
+ax_anim 1, 2, 57, -4, -4, -4, -4,
+ax_anim 1, 0, 57, -9, -11, -9, -9,
+ax_anim 2, 0, 57, -14, -19, -14, -19,
+ax_anim 2, 1, 57, -13, -20, -13, -20,
+ax_anim 2, 0, 57, -14, -19, -14, -19,
+ax_anim 2, 0, 57, -13, -20, -13, -20,
+ax_anim 2, 0, 55, -6, -6, -6, -6,
+ax_anim_terminator
+sSkarmoryAnims_3_7:
+ax_anim 2, 0, 58, 1, -1, 1, 0,
+ax_anim 2, 0, 59, 2, -3, 2, 0,
+ax_anim 2, 0, 58, 4, -6, 4, 0,
+ax_anim 2, 0, 59, 4, -6, 4, 0,
+ax_anim 2, 0, 58, 4, -6, 4, 0,
+ax_anim 1, 0, 60, 0, -4, 0, 0,
+ax_anim 1, 2, 60, -4, -2, -4, 0,
+ax_anim 1, 0, 60, -9, 0, -9, 0,
+ax_anim 2, 0, 60, -14, 0, -14, 0,
+ax_anim 2, 1, 60, -14, -1, -14, -1,
+ax_anim 2, 0, 60, -14, 0, -14, 0,
+ax_anim 2, 0, 60, -14, -1, -14, -1,
+ax_anim 2, 0, 58, -6, 0, -6, 0,
+ax_anim_terminator
+sSkarmoryAnims_3_8:
+ax_anim 2, 0, 61, 1, -1, 1, -1,
+ax_anim 2, 0, 62, 2, -3, 2, -2,
+ax_anim 2, 0, 61, 4, -7, 4, -4,
+ax_anim 2, 0, 62, 4, -7, 4, -4,
+ax_anim 2, 0, 61, 4, -7, 4, -4,
+ax_anim 1, 0, 63, 0, -2, 0, 0,
+ax_anim 1, 2, 63, -6, 10, -6, 8,
+ax_anim 1, 0, 63, -12, 16, -12, 14,
+ax_anim 2, 0, 63, -18, 23, -18, 23,
+ax_anim 2, 1, 63, -19, 22, -19, 22,
+ax_anim 2, 0, 63, -18, 23, -18, 23,
+ax_anim 2, 0, 63, -19, 22, -19, 22,
+ax_anim 2, 0, 61, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_4_1:
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -4, 0, -4,
+ax_anim 6, 0, 64, 0, -5, 0, -5,
+ax_anim 2, 0, 65, 0, -4, 0, -4,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 2, 2, 65, 0, 1, 0, -1,
+ax_anim 2, 0, 65, -1, 1, -1, -1,
+ax_anim 2, 0, 65, 0, 1, 0, -1,
+ax_anim 2, 0, 65, -1, 1, -1, -1,
+ax_anim 2, 1, 65, 0, 1, 0, -1,
+ax_anim 2, 0, 65, -1, 1, -1, -1,
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_4_2:
+ax_anim 2, 0, 66, -2, -2, -2, -2,
+ax_anim 2, 0, 66, -4, -4, -4, -4,
+ax_anim 6, 0, 66, -5, -5, -5, -5,
+ax_anim 2, 0, 67, -4, -4, -4, -4,
+ax_anim 1, 0, 67, -1, -1, -1, -1,
+ax_anim 2, 2, 67, 1, 1, 1, 1,
+ax_anim 2, 0, 67, 0, 2, 0, 2,
+ax_anim 2, 0, 67, 1, 1, 1, 1,
+ax_anim 2, 0, 67, 0, 2, 0, 2,
+ax_anim 2, 1, 67, 1, 1, 1, 1,
+ax_anim 2, 0, 67, 0, 2, 0, 2,
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_4_3:
+ax_anim 2, 0, 68, -2, 0, -2, 0,
+ax_anim 2, 0, 68, -4, 0, -4, 0,
+ax_anim 6, 0, 68, -5, 0, -5, 0,
+ax_anim 2, 0, 69, -4, 0, -4, 0,
+ax_anim 1, 0, 69, -1, 0, -1, 0,
+ax_anim 2, 2, 69, 1, 0, 1, 0,
+ax_anim 2, 0, 69, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 1, 0, 1, 0,
+ax_anim 2, 0, 69, 1, 1, 1, 1,
+ax_anim 2, 1, 69, 1, 0, 1, 0,
+ax_anim 2, 0, 69, 1, 1, 1, 1,
+ax_anim 4, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_4_4:
+ax_anim 2, 0, 70, -2, 2, -2, 2,
+ax_anim 2, 0, 70, -4, 4, -4, 4,
+ax_anim 6, 0, 70, -5, 5, -5, 5,
+ax_anim 2, 0, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -1, 1, -1, 1,
+ax_anim 2, 2, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 0, -2, 0, -2,
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 0, -2, 0, -2,
+ax_anim 2, 1, 71, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 0, -2, 0, -2,
+ax_anim 4, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_4_5:
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 72, 0, 4, 0, 4,
+ax_anim 6, 0, 72, 0, 5, 0, 5,
+ax_anim 2, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 2, 73, 0, -1, 0, -1,
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 1, 73, 0, -1, 0, -1,
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_4_6:
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim 2, 0, 74, 4, 4, 4, 4,
+ax_anim 6, 0, 74, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 4, 4, 4, 4,
+ax_anim 1, 0, 75, 1, 1, 1, 1,
+ax_anim 2, 2, 75, -1, -1, -1, -1,
+ax_anim 2, 0, 75, 0, -2, 0, -2,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 0, 75, 0, -2, 0, -2,
+ax_anim 2, 1, 75, -1, -1, -1, -1,
+ax_anim 2, 0, 75, 0, -2, 0, -2,
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_4_7:
+ax_anim 2, 0, 76, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 4, 0, 4, 0,
+ax_anim 6, 0, 76, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 4, 0, 4, 0,
+ax_anim 1, 0, 77, 1, 0, 1, 0,
+ax_anim 2, 2, 77, -1, 0, -1, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 0, 77, -1, 0, -1, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 2, 1, 77, -1, 0, -1, 0,
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_4_8:
+ax_anim 2, 0, 78, 2, -2, 2, -2,
+ax_anim 2, 0, 78, 4, -4, 4, -4,
+ax_anim 6, 0, 78, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim 1, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 79, 0, 2, 0, 2,
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 79, 0, 2, 0, 2,
+ax_anim 2, 1, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 79, 0, 2, 0, 2,
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_5_1:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_5_2:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_5_3:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_5_4:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_5_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_5_6:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_5_7:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_5_8:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_6_1:
+ax_anim 30, 0, 88, 0, 0, 0, 0,
+ax_anim 35, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_7_1:
+ax_anim 2, 0, 90, 0, -4, 0, -4,
+ax_anim 8, 0, 90, 0, -5, 0, -5,
+ax_anim_terminator
+sSkarmoryAnims_7_2:
+ax_anim 2, 0, 91, -4, -4, -4, -4,
+ax_anim 8, 0, 91, -5, -5, -5, -5,
+ax_anim_terminator
+sSkarmoryAnims_7_3:
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 8, 0, 92, -5, 0, -5, 0,
+ax_anim_terminator
+sSkarmoryAnims_7_4:
+ax_anim 2, 0, 93, -4, 4, -4, 4,
+ax_anim 8, 0, 93, -5, 5, -5, 5,
+ax_anim_terminator
+sSkarmoryAnims_7_5:
+ax_anim 2, 0, 94, 0, 4, 0, 4,
+ax_anim 8, 0, 94, 0, 5, 0, 5,
+ax_anim_terminator
+sSkarmoryAnims_7_6:
+ax_anim 2, 0, 95, 4, 4, 4, 4,
+ax_anim 8, 0, 95, 5, 5, 5, 5,
+ax_anim_terminator
+sSkarmoryAnims_7_7:
+ax_anim 2, 0, 96, 4, 0, 4, 0,
+ax_anim 8, 0, 96, 5, 0, 5, 0,
+ax_anim_terminator
+sSkarmoryAnims_7_8:
+ax_anim 2, 0, 97, 4, -4, 4, -4,
+ax_anim 8, 0, 97, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_8_1:
+ax_anim 40, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, -1, 0, 0,
+ax_anim 4, 0, 99, 0, -2, 0, 0,
+ax_anim 4, 0, 100, 0, -2, 0, 0,
+ax_anim 4, 0, 99, 0, -1, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_8_2:
+ax_anim 40, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, -1, 0, 0,
+ax_anim 4, 0, 102, 0, -2, 0, 0,
+ax_anim 4, 0, 103, 0, -2, 0, 0,
+ax_anim 4, 0, 102, 0, -1, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_8_3:
+ax_anim 40, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, -1, 0, 0,
+ax_anim 4, 0, 105, 0, -2, 0, 0,
+ax_anim 4, 0, 106, 0, -2, 0, 0,
+ax_anim 4, 0, 105, 0, -1, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_8_4:
+ax_anim 40, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, -1, 0, 0,
+ax_anim 4, 0, 108, 0, -2, 0, 0,
+ax_anim 4, 0, 109, 0, -2, 0, 0,
+ax_anim 4, 0, 108, 0, -1, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_8_5:
+ax_anim 40, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, -1, 0, 0,
+ax_anim 4, 0, 111, 0, -2, 0, 0,
+ax_anim 4, 0, 112, 0, -2, 0, 0,
+ax_anim 4, 0, 111, 0, -1, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_8_6:
+ax_anim 40, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, -1, 0, 0,
+ax_anim 4, 0, 114, 0, -2, 0, 0,
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 0, 114, 0, -1, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_8_7:
+ax_anim 40, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, -1, 0, 0,
+ax_anim 4, 0, 117, 0, -2, 0, 0,
+ax_anim 4, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 117, 0, -1, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_8_8:
+ax_anim 40, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, -1, 0, 0,
+ax_anim 4, 0, 120, 0, -2, 0, 0,
+ax_anim 4, 0, 121, 0, -2, 0, 0,
+ax_anim 4, 0, 120, 0, -1, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 6, 4, 6, 4,
+ax_anim 2, 0, 124, 8, 9, 8, 9,
+ax_anim 2, 0, 125, 7, 17, 7, 17,
+ax_anim 3, 0, 126, 0, 21, 0, 21,
+ax_anim 2, 3, 127, -7, 17, -7, 17,
+ax_anim 2, 0, 128, -8, 9, -8, 9,
+ax_anim 1, 0, 129, -6, 4, -6, 4,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 6, 0, 6, 0,
+ax_anim 2, 0, 123, 17, 3, 17, 3,
+ax_anim 2, 0, 124, 22, 10, 22, 10,
+ax_anim 3, 0, 125, 19, 21, 19, 21,
+ax_anim 2, 3, 126, 11, 22, 11, 22,
+ax_anim 2, 0, 127, 3, 15, 3, 15,
+ax_anim 1, 0, 128, -2, 7, -2, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 3, -4, 3, -4,
+ax_anim 2, 0, 122, 11, -6, 11, -6,
+ax_anim 2, 0, 123, 17, -4, 17, -4,
+ax_anim 3, 0, 124, 20, 1, 20, 1,
+ax_anim 2, 3, 125, 17, 5, 17, 5,
+ax_anim 2, 0, 126, 12, 7, 12, 7,
+ax_anim 1, 0, 127, 4, 5, 4, 5,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, -1, -6, -1, -6,
+ax_anim 2, 0, 129, 4, -16, 4, -16,
+ax_anim 2, 0, 122, 10, -21, 11, -20,
+ax_anim 3, 0, 123, 18, -22, 16, -20,
+ax_anim 2, 3, 124, 18, -12, 18, -12,
+ax_anim 2, 0, 125, 16, -6, 16, -6,
+ax_anim 1, 0, 126, 7, -1, 7, -1,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -6, -4, -6, -4,
+ax_anim 2, 0, 128, -8, -10, -8, -10,
+ax_anim 2, 0, 129, -7, -18, -7, -18,
+ax_anim 3, 0, 122, 0, -22, 0, -22,
+ax_anim 2, 3, 123, 7, -18, 7, -18,
+ax_anim 2, 0, 124, 8, -8, 8, -8,
+ax_anim 1, 0, 125, 6, -4, 6, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 1, -6, 1, -6,
+ax_anim 2, 0, 123, -4, -16, -4, -16,
+ax_anim 2, 0, 122, -10, -21, -10, -21,
+ax_anim 3, 0, 129, -18, -22, -18, -22,
+ax_anim 2, 3, 128, -18, -12, -18, -12,
+ax_anim 2, 0, 127, -16, -6, -16, -6,
+ax_anim 1, 0, 126, -7, -1, -7, -1,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -3, -4, -3, -4,
+ax_anim 2, 0, 122, -11, -6, -11, -6,
+ax_anim 2, 0, 129, -17, -4, -17, -4,
+ax_anim 3, 0, 128, -20, 1, -20, 1,
+ax_anim 2, 3, 127, -17, 5, -17, 5,
+ax_anim 2, 0, 126, -12, 7, -12, 7,
+ax_anim 1, 0, 125, -4, 5, -4, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -6, 0, -6, 0,
+ax_anim 2, 0, 129, -17, 3, -17, 3,
+ax_anim 2, 0, 128, -22, 10, -22, 10,
+ax_anim 3, 0, 127, -19, 21, -19, 21,
+ax_anim 2, 3, 126, -11, 22, -11, 22,
+ax_anim 2, 0, 125, -3, 15, -3, 15,
+ax_anim 1, 0, 124, 0, 7, 0, 7,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -10, 0, 0,
+ax_anim 2, 0, 140, 0, -16, 0, 0,
+ax_anim 3, 0, 140, 0, -20, 0, 0,
+ax_anim 4, 0, 140, 0, -21, 0, 0,
+ax_anim 4, 0, 139, 0, -25, 0, 0,
+ax_anim 3, 0, 139, 0, -24, 0, 0,
+ax_anim 2, 0, 139, 0, -18, 0, 0,
+ax_anim 1, 0, 139, 0, -12, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_11_2:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 0, 143, 0, -16, 0, 0,
+ax_anim 3, 0, 143, 0, -20, 0, 0,
+ax_anim 4, 0, 143, 0, -21, 0, 0,
+ax_anim 4, 0, 142, 0, -25, 0, 0,
+ax_anim 3, 0, 142, 0, -24, 0, 0,
+ax_anim 2, 0, 142, 0, -18, 0, 0,
+ax_anim 1, 0, 142, 0, -12, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_11_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 0, 146, 0, -16, 0, 0,
+ax_anim 3, 0, 146, 0, -20, 0, 0,
+ax_anim 4, 0, 146, 0, -21, 0, 0,
+ax_anim 4, 0, 145, 0, -25, 0, 0,
+ax_anim 3, 0, 145, 0, -24, 0, 0,
+ax_anim 2, 0, 145, 0, -18, 0, 0,
+ax_anim 1, 0, 145, 0, -12, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_11_4:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -25, 0, 0,
+ax_anim 3, 0, 148, 0, -24, 0, 0,
+ax_anim 2, 0, 148, 0, -17, 0, 0,
+ax_anim 1, 0, 148, 0, -11, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 4, 0, 151, 0, -25, 0, 0,
+ax_anim 3, 0, 151, 0, -24, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_11_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -25, 0, 0,
+ax_anim 3, 0, 154, 0, -24, 0, 0,
+ax_anim 2, 0, 154, 0, -17, 0, 0,
+ax_anim 1, 0, 154, 0, -11, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_11_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -25, 0, 0,
+ax_anim 3, 0, 157, 0, -24, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -25, 0, 0,
+ax_anim 3, 0, 160, 0, -24, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, 0,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_14_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_14_2:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_14_3:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_14_4:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_14_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_14_6:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_14_7:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryAnims_14_8:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -1, 0, -1, 0,
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_15_1:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 3, 0, 180, 0, 1, 0, 0,
+ax_anim 2, 0, 181, 0, 1, 0, 0,
+ax_anim 2, 0, 180, 0, 1, 0, 0,
+ax_anim 2, 0, 181, 0, 1, 0, 0,
+ax_anim 2, 0, 180, 0, 1, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, 0,
+ax_anim 2, 0, 181, 0, -1, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, 0,
+ax_anim 2, 0, 181, 0, -1, 0, 0,
+ax_anim 2, 0, 180, 0, -2, 0, 0,
+ax_anim 2, 0, 181, 0, -2, 0, 0,
+ax_anim 2, 0, 180, 0, -3, 0, 0,
+ax_anim 2, 0, 180, 0, -4, 0, 0,
+ax_anim 2, 0, 181, 0, -5, 0, 0,
+ax_anim 2, 0, 181, 0, -7, 0, 0,
+ax_anim 2, 0, 180, 0, -9, 0, 0,
+ax_anim 2, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 0, 181, 0, -15, 0, 0,
+ax_anim 2, 0, 181, 0, -19, 0, 0,
+ax_anim 2, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -26, 0, 0,
+ax_anim 2, 0, 185, 0, -30, 0, 0,
+ax_anim 2, 0, 185, 0, -35, 0, 0,
+ax_anim 2, 0, 184, 0, -40, 0, 0,
+ax_anim 2, 0, 184, 0, -46, 0, 0,
+ax_anim 2, 0, 185, 0, -52, 0, 0,
+ax_anim 2, 0, 185, 0, -59, 0, 0,
+ax_anim 2, 0, 184, 0, -66, 0, 0,
+ax_anim 2, 0, 184, 0, -74, 0, 0,
+ax_anim 2, 0, 185, 0, -82, 0, 0,
+ax_anim 2, 0, 185, 0, -90, 0, 0,
+ax_anim 2, 0, 184, 0, -98, 0, 0,
+ax_anim 2, 0, 184, 0, -106, 0, 0,
+ax_anim 2, 0, 185, 0, -114, 0, 0,
+ax_anim 2, 0, 185, 0, -122, 0, 0,
+ax_anim 2, 0, 184, 0, -130, 0, 0,
+ax_anim 2, 0, 184, 0, -138, 0, 0,
+ax_anim_terminator
+.align 2
+sSkarmoryAnims_16_1:
+ax_anim 1, 0, 190, 0, -136, 0, 0,
+ax_anim 1, 0, 190, 0, -132, 0, 0,
+ax_anim 1, 0, 190, 0, -128, 0, 0,
+ax_anim 1, 0, 190, 0, -124, 0, 0,
+ax_anim 1, 0, 190, 0, -120, 0, 0,
+ax_anim 1, 0, 190, 0, -116, 0, 0,
+ax_anim 1, 0, 190, 0, -112, 0, 0,
+ax_anim 1, 0, 190, 0, -108, 0, 0,
+ax_anim 1, 0, 190, 0, -104, 0, 0,
+ax_anim 1, 0, 190, 0, -100, 0, 0,
+ax_anim 1, 0, 190, 0, -96, 0, 0,
+ax_anim 1, 0, 190, 0, -92, 0, 0,
+ax_anim 1, 0, 190, 0, -88, 0, 0,
+ax_anim 1, 0, 190, 0, -84, 0, 0,
+ax_anim 1, 0, 190, 0, -80, 0, 0,
+ax_anim 1, 0, 190, 0, -76, 0, 0,
+ax_anim 1, 0, 190, 0, -72, 0, 0,
+ax_anim 1, 0, 190, 0, -68, 0, 0,
+ax_anim 1, 0, 190, 0, -64, 0, 0,
+ax_anim 1, 0, 190, 0, -60, 0, 0,
+ax_anim 1, 0, 190, 0, -56, 0, 0,
+ax_anim 1, 0, 190, 0, -52, 0, 0,
+ax_anim 1, 0, 190, 0, -48, 0, 0,
+ax_anim 1, 0, 190, 0, -44, 0, 0,
+ax_anim 1, 0, 190, 0, -40, 0, 0,
+ax_anim 1, 0, 190, 0, -36, 0, 0,
+ax_anim 1, 0, 190, 0, -32, 0, 0,
+ax_anim 1, 0, 190, 0, -28, 0, 0,
+ax_anim 1, 0, 190, 0, -24, 0, 0,
+ax_anim 2, 0, 191, 0, -20, 0, 0,
+ax_anim 2, 0, 190, 0, -17, 0, 0,
+ax_anim 2, 0, 191, 0, -14, 0, 0,
+ax_anim 2, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 0, 191, 0, -11, 0, 0,
+ax_anim 2, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -11, 0, 0,
+ax_anim 3, 0, 191, 0, -12, 0, 0,
+ax_anim 3, 0, 190, 0, -13, 0, 0,
+ax_anim 3, 0, 190, 0, -14, 0, 0,
+ax_anim 3, 0, 190, 0, -15, 0, 0,
+ax_anim 3, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -17, 0, 0,
+ax_anim 3, 0, 189, 0, -12, 0, 0,
+ax_anim 2, 0, 189, 0, -8, 0, 0,
+ax_anim 3, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSkarmoryGfx1:
+.incbin "baserom.gba", 0xF37724, 0x100
+sSkarmorySprites1:
+ax_sprite sSkarmoryGfx1, 0x100
+ax_sprite_terminator
+sSkarmoryGfx2:
+.incbin "baserom.gba", 0xF37834, 0x80
+sSkarmorySprites2:
+ax_sprite sSkarmoryGfx2, 0x80
+ax_sprite_terminator
+sSkarmoryGfx3:
+.incbin "baserom.gba", 0xF378C4, 0x40
+sSkarmorySprites3:
+ax_sprite sSkarmoryGfx3, 0x40
+ax_sprite_terminator
+sSkarmoryGfx4:
+.incbin "baserom.gba", 0xF37914, 0x20
+sSkarmorySprites4:
+ax_sprite sSkarmoryGfx4, 0x20
+ax_sprite_terminator
+sSkarmoryGfx5:
+.incbin "baserom.gba", 0xF37944, 0x200
+sSkarmorySprites5:
+ax_sprite sSkarmoryGfx5, 0x200
+ax_sprite_terminator
+sSkarmoryGfx6:
+.incbin "baserom.gba", 0xF37B54, 0x200
+sSkarmorySprites6:
+ax_sprite sSkarmoryGfx6, 0x200
+ax_sprite_terminator
+sSkarmoryGfx7:
+.incbin "baserom.gba", 0xF37D64, 0x200
+sSkarmorySprites7:
+ax_sprite sSkarmoryGfx7, 0x200
+ax_sprite_terminator
+sSkarmoryGfx8:
+.incbin "baserom.gba", 0xF37F74, 0x200
+sSkarmorySprites8:
+ax_sprite sSkarmoryGfx8, 0x200
+ax_sprite_terminator
+sSkarmoryGfx9:
+.incbin "baserom.gba", 0xF38184, 0x200
+sSkarmorySprites9:
+ax_sprite sSkarmoryGfx9, 0x200
+ax_sprite_terminator
+sSkarmoryGfx10:
+.incbin "baserom.gba", 0xF38394, 0x100
+sSkarmorySprites10:
+ax_sprite sSkarmoryGfx10, 0x100
+ax_sprite_terminator
+sSkarmoryGfx11:
+.incbin "baserom.gba", 0xF384A4, 0x80
+sSkarmorySprites11:
+ax_sprite sSkarmoryGfx11, 0x80
+ax_sprite_terminator
+sSkarmoryGfx12:
+.incbin "baserom.gba", 0xF38534, 0x40
+sSkarmorySprites12:
+ax_sprite sSkarmoryGfx12, 0x40
+ax_sprite_terminator
+sSkarmoryGfx13:
+.incbin "baserom.gba", 0xF38584, 0x20
+sSkarmorySprites13:
+ax_sprite sSkarmoryGfx13, 0x20
+ax_sprite_terminator
+sSkarmoryGfx14:
+.incbin "baserom.gba", 0xF385B4, 0x20
+sSkarmorySprites14:
+ax_sprite sSkarmoryGfx14, 0x20
+ax_sprite_terminator
+sSkarmoryGfx15:
+.incbin "baserom.gba", 0xF385E4, 0x100
+sSkarmorySprites15:
+ax_sprite sSkarmoryGfx15, 0x100
+ax_sprite_terminator
+sSkarmoryGfx16:
+.incbin "baserom.gba", 0xF386F4, 0x80
+sSkarmorySprites16:
+ax_sprite sSkarmoryGfx16, 0x80
+ax_sprite_terminator
+sSkarmoryGfx17:
+.incbin "baserom.gba", 0xF38784, 0x20
+sSkarmorySprites17:
+ax_sprite sSkarmoryGfx17, 0x20
+ax_sprite_terminator
+sSkarmoryGfx18:
+.incbin "baserom.gba", 0xF387B4, 0x20
+sSkarmorySprites18:
+ax_sprite sSkarmoryGfx18, 0x20
+ax_sprite_terminator
+sSkarmoryGfx19:
+.incbin "baserom.gba", 0xF387E4, 0x100
+sSkarmorySprites19:
+ax_sprite sSkarmoryGfx19, 0x100
+ax_sprite_terminator
+sSkarmoryGfx20:
+.incbin "baserom.gba", 0xF388F4, 0x40
+sSkarmorySprites20:
+ax_sprite sSkarmoryGfx20, 0x40
+ax_sprite_terminator
+sSkarmoryGfx21:
+.incbin "baserom.gba", 0xF38944, 0x40
+sSkarmorySprites21:
+ax_sprite sSkarmoryGfx21, 0x40
+ax_sprite_terminator
+sSkarmoryGfx22:
+.incbin "baserom.gba", 0xF38994, 0x20
+sSkarmorySprites22:
+ax_sprite sSkarmoryGfx22, 0x20
+ax_sprite_terminator
+sSkarmoryGfx23:
+.incbin "baserom.gba", 0xF389C4, 0x100
+sSkarmorySprites23:
+ax_sprite sSkarmoryGfx23, 0x100
+ax_sprite_terminator
+sSkarmoryGfx24:
+.incbin "baserom.gba", 0xF38AD4, 0x40
+sSkarmorySprites24:
+ax_sprite sSkarmoryGfx24, 0x40
+ax_sprite_terminator
+sSkarmoryGfx25:
+.incbin "baserom.gba", 0xF38B24, 0x40
+sSkarmorySprites25:
+ax_sprite sSkarmoryGfx25, 0x40
+ax_sprite_terminator
+sSkarmoryGfx26:
+.incbin "baserom.gba", 0xF38B74, 0x20
+sSkarmorySprites26:
+ax_sprite sSkarmoryGfx26, 0x20
+ax_sprite_terminator
+sSkarmoryGfx27:
+.incbin "baserom.gba", 0xF38BA4, 0x100
+sSkarmorySprites27:
+ax_sprite sSkarmoryGfx27, 0x100
+ax_sprite_terminator
+sSkarmoryGfx28:
+.incbin "baserom.gba", 0xF38CB4, 0x40
+sSkarmorySprites28:
+ax_sprite sSkarmoryGfx28, 0x40
+ax_sprite_terminator
+sSkarmoryGfx29:
+.incbin "baserom.gba", 0xF38D04, 0x20
+sSkarmorySprites29:
+ax_sprite sSkarmoryGfx29, 0x20
+ax_sprite_terminator
+sSkarmoryGfx30:
+.incbin "baserom.gba", 0xF38D34, 0x20
+sSkarmorySprites30:
+ax_sprite sSkarmoryGfx30, 0x20
+ax_sprite_terminator
+sSkarmoryGfx31:
+.incbin "baserom.gba", 0xF38D64, 0x20
+sSkarmoryGfx31_1:
+.incbin "baserom.gba", 0xF38D84, 0x100
+sSkarmoryGfx31_2:
+.incbin "baserom.gba", 0xF38E84, 0x40
+sSkarmorySprites31:
+ax_sprite 0, 0x40
+ax_sprite sSkarmoryGfx31, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkarmoryGfx32:
+.incbin "baserom.gba", 0xF38F04, 0x100
+sSkarmoryGfx32_1:
+.incbin "baserom.gba", 0xF39004, 0x60
+sSkarmorySprites32:
+ax_sprite 0, 0x80
+ax_sprite sSkarmoryGfx32, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx32_1, 0x60
+ax_sprite_terminator
+sSkarmoryGfx33:
+.incbin "baserom.gba", 0xF3908C, 0x20
+sSkarmoryGfx33_1:
+.incbin "baserom.gba", 0xF390AC, 0x180
+sSkarmorySprites33:
+ax_sprite sSkarmoryGfx33, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSkarmoryGfx33_1, 0x180
+ax_sprite_terminator
+sSkarmoryGfx34:
+.incbin "baserom.gba", 0xF3924C, 0x100
+sSkarmorySprites34:
+ax_sprite sSkarmoryGfx34, 0x100
+ax_sprite_terminator
+sSkarmoryGfx35:
+.incbin "baserom.gba", 0xF3935C, 0x40
+sSkarmorySprites35:
+ax_sprite sSkarmoryGfx35, 0x40
+ax_sprite_terminator
+sSkarmoryGfx36:
+.incbin "baserom.gba", 0xF393AC, 0x40
+sSkarmorySprites36:
+ax_sprite sSkarmoryGfx36, 0x40
+ax_sprite_terminator
+sSkarmoryGfx37:
+.incbin "baserom.gba", 0xF393FC, 0x20
+sSkarmorySprites37:
+ax_sprite sSkarmoryGfx37, 0x20
+ax_sprite_terminator
+sSkarmoryGfx38:
+.incbin "baserom.gba", 0xF3942C, 0x20
+sSkarmorySprites38:
+ax_sprite sSkarmoryGfx38, 0x20
+ax_sprite_terminator
+sSkarmoryGfx39:
+.incbin "baserom.gba", 0xF3945C, 0x180
+sSkarmoryGfx39_1:
+.incbin "baserom.gba", 0xF395DC, 0x60
+sSkarmorySprites39:
+ax_sprite sSkarmoryGfx39, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx39_1, 0x60
+ax_sprite_terminator
+sSkarmoryGfx40:
+.incbin "baserom.gba", 0xF3965C, 0xE0
+sSkarmorySprites40:
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx40, 0xe0
+ax_sprite_terminator
+sSkarmoryGfx41:
+.incbin "baserom.gba", 0xF39754, 0x40
+sSkarmorySprites41:
+ax_sprite sSkarmoryGfx41, 0x40
+ax_sprite_terminator
+sSkarmoryGfx42:
+.incbin "baserom.gba", 0xF397A4, 0x40
+sSkarmorySprites42:
+ax_sprite sSkarmoryGfx42, 0x40
+ax_sprite_terminator
+sSkarmoryGfx43:
+.incbin "baserom.gba", 0xF397F4, 0x20
+sSkarmorySprites43:
+ax_sprite sSkarmoryGfx43, 0x20
+ax_sprite_terminator
+sSkarmoryGfx44:
+.incbin "baserom.gba", 0xF39824, 0x20
+sSkarmorySprites44:
+ax_sprite sSkarmoryGfx44, 0x20
+ax_sprite_terminator
+sSkarmoryGfx45:
+.incbin "baserom.gba", 0xF39854, 0x20
+sSkarmorySprites45:
+ax_sprite sSkarmoryGfx45, 0x20
+ax_sprite_terminator
+sSkarmoryGfx46:
+.incbin "baserom.gba", 0xF39884, 0x20
+sSkarmorySprites46:
+ax_sprite sSkarmoryGfx46, 0x20
+ax_sprite_terminator
+sSkarmoryGfx47:
+.incbin "baserom.gba", 0xF398B4, 0xE0
+sSkarmoryGfx47_1:
+.incbin "baserom.gba", 0xF39994, 0x60
+sSkarmoryGfx47_2:
+.incbin "baserom.gba", 0xF399F4, 0x40
+sSkarmorySprites47:
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx47, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx47_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkarmoryGfx48:
+.incbin "baserom.gba", 0xF39A74, 0x40
+sSkarmoryGfx48_1:
+.incbin "baserom.gba", 0xF39AB4, 0x160
+sSkarmorySprites48:
+ax_sprite sSkarmoryGfx48, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSkarmoryGfx48_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkarmoryGfx49:
+.incbin "baserom.gba", 0xF39C3C, 0x100
+sSkarmoryGfx49_1:
+.incbin "baserom.gba", 0xF39D3C, 0x60
+sSkarmoryGfx49_2:
+.incbin "baserom.gba", 0xF39D9C, 0x40
+sSkarmorySprites49:
+ax_sprite sSkarmoryGfx49, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx49_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkarmoryGfx50:
+.incbin "baserom.gba", 0xF39E14, 0xC0
+sSkarmoryGfx50_1:
+.incbin "baserom.gba", 0xF39ED4, 0x20
+sSkarmorySprites50:
+ax_sprite sSkarmoryGfx50, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx50_1, 0x20
+ax_sprite_terminator
+sSkarmoryGfx51:
+.incbin "baserom.gba", 0xF39F14, 0x80
+sSkarmorySprites51:
+ax_sprite sSkarmoryGfx51, 0x80
+ax_sprite_terminator
+sSkarmoryGfx52:
+.incbin "baserom.gba", 0xF39FA4, 0x20
+sSkarmorySprites52:
+ax_sprite sSkarmoryGfx52, 0x20
+ax_sprite_terminator
+sSkarmoryGfx53:
+.incbin "baserom.gba", 0xF39FD4, 0x20
+sSkarmorySprites53:
+ax_sprite sSkarmoryGfx53, 0x20
+ax_sprite_terminator
+sSkarmoryGfx54:
+.incbin "baserom.gba", 0xF3A004, 0x40
+sSkarmorySprites54:
+ax_sprite sSkarmoryGfx54, 0x40
+ax_sprite_terminator
+sSkarmoryGfx55:
+.incbin "baserom.gba", 0xF3A054, 0x100
+sSkarmoryGfx55_1:
+.incbin "baserom.gba", 0xF3A154, 0x60
+sSkarmoryGfx55_2:
+.incbin "baserom.gba", 0xF3A1B4, 0x40
+sSkarmorySprites55:
+ax_sprite sSkarmoryGfx55, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx55_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkarmoryGfx56:
+.incbin "baserom.gba", 0xF3A22C, 0x20
+sSkarmoryGfx56_1:
+.incbin "baserom.gba", 0xF3A24C, 0x1A0
+sSkarmorySprites56:
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx56, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx56_1, 0x1a0
+ax_sprite_terminator
+sSkarmoryGfx57:
+.incbin "baserom.gba", 0xF3A414, 0x180
+sSkarmoryGfx57_1:
+.incbin "baserom.gba", 0xF3A594, 0x40
+sSkarmorySprites57:
+ax_sprite sSkarmoryGfx57, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSkarmoryGfx57_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkarmoryGfx58:
+.incbin "baserom.gba", 0xF3A5FC, 0x100
+sSkarmorySprites58:
+ax_sprite sSkarmoryGfx58, 0x100
+ax_sprite_terminator
+sSkarmoryGfx59:
+.incbin "baserom.gba", 0xF3A70C, 0x40
+sSkarmorySprites59:
+ax_sprite sSkarmoryGfx59, 0x40
+ax_sprite_terminator
+sSkarmoryGfx60:
+.incbin "baserom.gba", 0xF3A75C, 0x40
+sSkarmorySprites60:
+ax_sprite sSkarmoryGfx60, 0x40
+ax_sprite_terminator
+sSkarmoryGfx61:
+.incbin "baserom.gba", 0xF3A7AC, 0x20
+sSkarmorySprites61:
+ax_sprite sSkarmoryGfx61, 0x20
+ax_sprite_terminator
+sSkarmoryGfx62:
+.incbin "baserom.gba", 0xF3A7DC, 0x20
+sSkarmorySprites62:
+ax_sprite sSkarmoryGfx62, 0x20
+ax_sprite_terminator
+sSkarmoryGfx63:
+.incbin "baserom.gba", 0xF3A80C, 0x20
+sSkarmorySprites63:
+ax_sprite sSkarmoryGfx63, 0x20
+ax_sprite_terminator
+sSkarmoryGfx64:
+.incbin "baserom.gba", 0xF3A83C, 0x200
+sSkarmorySprites64:
+ax_sprite sSkarmoryGfx64, 0x200
+ax_sprite_terminator
+sSkarmoryGfx65:
+.incbin "baserom.gba", 0xF3AA4C, 0x200
+sSkarmorySprites65:
+ax_sprite sSkarmoryGfx65, 0x200
+ax_sprite_terminator
+sSkarmoryGfx66:
+.incbin "baserom.gba", 0xF3AC5C, 0x200
+sSkarmorySprites66:
+ax_sprite sSkarmoryGfx66, 0x200
+ax_sprite_terminator
+sSkarmoryGfx67:
+.incbin "baserom.gba", 0xF3AE6C, 0x200
+sSkarmorySprites67:
+ax_sprite sSkarmoryGfx67, 0x200
+ax_sprite_terminator
+sSkarmoryGfx68:
+.incbin "baserom.gba", 0xF3B07C, 0x200
+sSkarmorySprites68:
+ax_sprite sSkarmoryGfx68, 0x200
+ax_sprite_terminator
+sSkarmoryGfx69:
+.incbin "baserom.gba", 0xF3B28C, 0x200
+sSkarmorySprites69:
+ax_sprite sSkarmoryGfx69, 0x200
+ax_sprite_terminator
+sSkarmoryGfx70:
+.incbin "baserom.gba", 0xF3B49C, 0x200
+sSkarmorySprites70:
+ax_sprite sSkarmoryGfx70, 0x200
+ax_sprite_terminator
+sSkarmoryGfx71:
+.incbin "baserom.gba", 0xF3B6AC, 0x200
+sSkarmorySprites71:
+ax_sprite sSkarmoryGfx71, 0x200
+ax_sprite_terminator
+sSkarmoryGfx72:
+.incbin "baserom.gba", 0xF3B8BC, 0x100
+sSkarmorySprites72:
+ax_sprite sSkarmoryGfx72, 0x100
+ax_sprite_terminator
+sSkarmoryGfx73:
+.incbin "baserom.gba", 0xF3B9CC, 0x80
+sSkarmorySprites73:
+ax_sprite sSkarmoryGfx73, 0x80
+ax_sprite_terminator
+sSkarmoryGfx74:
+.incbin "baserom.gba", 0xF3BA5C, 0x20
+sSkarmorySprites74:
+ax_sprite sSkarmoryGfx74, 0x20
+ax_sprite_terminator
+sSkarmoryGfx75:
+.incbin "baserom.gba", 0xF3BA8C, 0x40
+sSkarmorySprites75:
+ax_sprite sSkarmoryGfx75, 0x40
+ax_sprite_terminator
+sSkarmoryGfx76:
+.incbin "baserom.gba", 0xF3BADC, 0x20
+sSkarmorySprites76:
+ax_sprite sSkarmoryGfx76, 0x20
+ax_sprite_terminator
+sSkarmoryGfx77:
+.incbin "baserom.gba", 0xF3BB0C, 0x100
+sSkarmorySprites77:
+ax_sprite sSkarmoryGfx77, 0x100
+ax_sprite_terminator
+sSkarmoryGfx78:
+.incbin "baserom.gba", 0xF3BC1C, 0x80
+sSkarmorySprites78:
+ax_sprite sSkarmoryGfx78, 0x80
+ax_sprite_terminator
+sSkarmoryGfx79:
+.incbin "baserom.gba", 0xF3BCAC, 0x40
+sSkarmorySprites79:
+ax_sprite sSkarmoryGfx79, 0x40
+ax_sprite_terminator
+sSkarmoryGfx80:
+.incbin "baserom.gba", 0xF3BCFC, 0x20
+sSkarmorySprites80:
+ax_sprite sSkarmoryGfx80, 0x20
+ax_sprite_terminator
+sSkarmoryGfx81:
+.incbin "baserom.gba", 0xF3BD2C, 0x100
+sSkarmorySprites81:
+ax_sprite sSkarmoryGfx81, 0x100
+ax_sprite_terminator
+sSkarmoryGfx82:
+.incbin "baserom.gba", 0xF3BE3C, 0x40
+sSkarmorySprites82:
+ax_sprite sSkarmoryGfx82, 0x40
+ax_sprite_terminator
+sSkarmoryGfx83:
+.incbin "baserom.gba", 0xF3BE8C, 0x40
+sSkarmorySprites83:
+ax_sprite sSkarmoryGfx83, 0x40
+ax_sprite_terminator
+sSkarmoryGfx84:
+.incbin "baserom.gba", 0xF3BEDC, 0x20
+sSkarmorySprites84:
+ax_sprite sSkarmoryGfx84, 0x20
+ax_sprite_terminator
+sAxPosesSkarmory:
+.4byte sSkarmoryPose1
+.4byte sSkarmoryPose2
+.4byte sSkarmoryPose3
+.4byte sSkarmoryPose4
+.4byte sSkarmoryPose5
+.4byte sSkarmoryPose6
+.4byte sSkarmoryPose7
+.4byte sSkarmoryPose8
+.4byte sSkarmoryPose9
+.4byte sSkarmoryPose10
+.4byte sSkarmoryPose11
+.4byte sSkarmoryPose12
+.4byte sSkarmoryPose13
+.4byte sSkarmoryPose14
+.4byte sSkarmoryPose15
+.4byte sSkarmoryPose16
+.4byte sSkarmoryPose17
+.4byte sSkarmoryPose18
+.4byte sSkarmoryPose19
+.4byte sSkarmoryPose20
+.4byte sSkarmoryPose21
+.4byte sSkarmoryPose22
+.4byte sSkarmoryPose23
+.4byte sSkarmoryPose24
+.4byte sSkarmoryPose25
+.4byte sSkarmoryPose26
+.4byte sSkarmoryPose27
+.4byte sSkarmoryPose28
+.4byte sSkarmoryPose29
+.4byte sSkarmoryPose30
+.4byte sSkarmoryPose31
+.4byte sSkarmoryPose32
+.4byte sSkarmoryPose33
+.4byte sSkarmoryPose34
+.4byte sSkarmoryPose35
+.4byte sSkarmoryPose36
+.4byte sSkarmoryPose37
+.4byte sSkarmoryPose38
+.4byte sSkarmoryPose39
+.4byte sSkarmoryPose40
+.4byte sSkarmoryPose41
+.4byte sSkarmoryPose42
+.4byte sSkarmoryPose43
+.4byte sSkarmoryPose44
+.4byte sSkarmoryPose45
+.4byte sSkarmoryPose46
+.4byte sSkarmoryPose47
+.4byte sSkarmoryPose48
+.4byte sSkarmoryPose49
+.4byte sSkarmoryPose50
+.4byte sSkarmoryPose51
+.4byte sSkarmoryPose52
+.4byte sSkarmoryPose53
+.4byte sSkarmoryPose54
+.4byte sSkarmoryPose55
+.4byte sSkarmoryPose56
+.4byte sSkarmoryPose57
+.4byte sSkarmoryPose58
+.4byte sSkarmoryPose59
+.4byte sSkarmoryPose60
+.4byte sSkarmoryPose61
+.4byte sSkarmoryPose62
+.4byte sSkarmoryPose63
+.4byte sSkarmoryPose64
+.4byte sSkarmoryPose65
+.4byte sSkarmoryPose66
+.4byte sSkarmoryPose67
+.4byte sSkarmoryPose68
+.4byte sSkarmoryPose69
+.4byte sSkarmoryPose70
+.4byte sSkarmoryPose71
+.4byte sSkarmoryPose72
+.4byte sSkarmoryPose73
+.4byte sSkarmoryPose74
+.4byte sSkarmoryPose75
+.4byte sSkarmoryPose76
+.4byte sSkarmoryPose77
+.4byte sSkarmoryPose78
+.4byte sSkarmoryPose79
+.4byte sSkarmoryPose80
+.4byte sSkarmoryPose81
+.4byte sSkarmoryPose82
+.4byte sSkarmoryPose83
+.4byte sSkarmoryPose84
+.4byte sSkarmoryPose85
+.4byte sSkarmoryPose86
+.4byte sSkarmoryPose87
+.4byte sSkarmoryPose88
+.4byte sSkarmoryPose89
+.4byte sSkarmoryPose90
+.4byte sSkarmoryPose91
+.4byte sSkarmoryPose92
+.4byte sSkarmoryPose93
+.4byte sSkarmoryPose94
+.4byte sSkarmoryPose95
+.4byte sSkarmoryPose96
+.4byte sSkarmoryPose97
+.4byte sSkarmoryPose98
+.4byte sSkarmoryPose99
+.4byte sSkarmoryPose100
+.4byte sSkarmoryPose101
+.4byte sSkarmoryPose102
+.4byte sSkarmoryPose103
+.4byte sSkarmoryPose104
+.4byte sSkarmoryPose105
+.4byte sSkarmoryPose106
+.4byte sSkarmoryPose107
+.4byte sSkarmoryPose108
+.4byte sSkarmoryPose109
+.4byte sSkarmoryPose110
+.4byte sSkarmoryPose111
+.4byte sSkarmoryPose112
+.4byte sSkarmoryPose113
+.4byte sSkarmoryPose114
+.4byte sSkarmoryPose115
+.4byte sSkarmoryPose116
+.4byte sSkarmoryPose117
+.4byte sSkarmoryPose118
+.4byte sSkarmoryPose119
+.4byte sSkarmoryPose120
+.4byte sSkarmoryPose121
+.4byte sSkarmoryPose122
+.4byte sSkarmoryPose123
+.4byte sSkarmoryPose124
+.4byte sSkarmoryPose125
+.4byte sSkarmoryPose126
+.4byte sSkarmoryPose127
+.4byte sSkarmoryPose128
+.4byte sSkarmoryPose129
+.4byte sSkarmoryPose130
+.4byte sSkarmoryPose131
+.4byte sSkarmoryPose132
+.4byte sSkarmoryPose133
+.4byte sSkarmoryPose134
+.4byte sSkarmoryPose135
+.4byte sSkarmoryPose136
+.4byte sSkarmoryPose137
+.4byte sSkarmoryPose138
+.4byte sSkarmoryPose139
+.4byte sSkarmoryPose140
+.4byte sSkarmoryPose141
+.4byte sSkarmoryPose142
+.4byte sSkarmoryPose143
+.4byte sSkarmoryPose144
+.4byte sSkarmoryPose145
+.4byte sSkarmoryPose146
+.4byte sSkarmoryPose147
+.4byte sSkarmoryPose148
+.4byte sSkarmoryPose149
+.4byte sSkarmoryPose150
+.4byte sSkarmoryPose151
+.4byte sSkarmoryPose152
+.4byte sSkarmoryPose153
+.4byte sSkarmoryPose154
+.4byte sSkarmoryPose155
+.4byte sSkarmoryPose156
+.4byte sSkarmoryPose157
+.4byte sSkarmoryPose158
+.4byte sSkarmoryPose159
+.4byte sSkarmoryPose160
+.4byte sSkarmoryPose161
+.4byte sSkarmoryPose162
+.4byte sSkarmoryPose163
+.4byte sSkarmoryPose164
+.4byte sSkarmoryPose165
+.4byte sSkarmoryPose166
+.4byte sSkarmoryPose167
+.4byte sSkarmoryPose168
+.4byte sSkarmoryPose169
+.4byte sSkarmoryPose170
+.4byte sSkarmoryPose171
+.4byte sSkarmoryPose172
+.4byte sSkarmoryPose173
+.4byte sSkarmoryPose174
+.4byte sSkarmoryPose175
+.4byte sSkarmoryPose176
+.4byte sSkarmoryPose177
+.4byte sSkarmoryPose178
+.4byte sSkarmoryPose179
+.4byte sSkarmoryPose180
+.4byte sSkarmoryPose181
+.4byte sSkarmoryPose182
+.4byte sSkarmoryPose183
+.4byte sSkarmoryPose184
+.4byte sSkarmoryPose185
+.4byte sSkarmoryPose186
+.4byte sSkarmoryPose187
+.4byte sSkarmoryPose188
+.4byte sSkarmoryPose189
+.4byte sSkarmoryPose190
+.4byte sSkarmoryPose191
+.4byte sSkarmoryPose192
+sAxPositionsSkarmory:
+.2byte    0,  -17, 	 -13,  -24, 	  13,  -24, 	   0,  -14
+.2byte    0,  -17, 	 -12,  -19, 	  12,  -19, 	   0,  -14
+.2byte   12,  -18, 	   1,  -25, 	 -13,  -24, 	   0,  -14
+.2byte   12,  -18, 	  -2,  -21, 	 -13,  -18, 	   0,  -13
+.2byte   15,  -21, 	  -8,  -26, 	 -12,  -21, 	   1,  -14
+.2byte   15,  -21, 	 -11,  -21, 	 -13,  -17, 	   2,  -15
+.2byte   12,  -26, 	 -12,  -23, 	   7,  -17, 	   1,  -17
+.2byte   12,  -26, 	 -13,  -18, 	   5,  -10, 	   1,  -16
+.2byte    0,  -28, 	  14,  -20, 	 -14,  -20, 	   0,  -14
+.2byte    0,  -28, 	  13,  -14, 	 -14,  -14, 	   0,  -16
+.2byte  -13,  -26, 	  11,  -23, 	  -8,  -17, 	  -2,  -17
+.2byte  -13,  -26, 	  12,  -18, 	  -6,  -10, 	  -2,  -16
+.2byte  -15,  -21, 	   8,  -26, 	  12,  -21, 	  -1,  -14
+.2byte  -15,  -21, 	  11,  -21, 	  13,  -17, 	  -2,  -15
+.2byte  -12,  -18, 	  -1,  -25, 	  13,  -24, 	   0,  -14
+.2byte  -12,  -18, 	   2,  -21, 	  13,  -18, 	   0,  -13
+.2byte    0,  -17, 	 -13,  -24, 	  13,  -24, 	   0,  -14
+.2byte    0,  -17, 	 -12,  -19, 	  12,  -19, 	   0,  -14
+.2byte    0,   -7, 	 -18,  -10, 	  18,  -10, 	   0,  -10
+.2byte   12,  -18, 	   1,  -25, 	 -13,  -24, 	   0,  -14
+.2byte   12,  -18, 	  -2,  -21, 	 -13,  -18, 	   0,  -13
+.2byte   14,   -7, 	   8,  -17, 	 -12,   -7, 	   3,   -9
+.2byte   15,  -21, 	  -8,  -26, 	 -12,  -21, 	   1,  -14
+.2byte   15,  -21, 	 -11,  -21, 	 -13,  -17, 	   2,  -15
+.2byte   14,   -8, 	   1,  -15, 	  -1,   -4, 	   0,   -8
+.2byte   12,  -26, 	 -12,  -23, 	   7,  -17, 	   1,  -17
+.2byte   12,  -26, 	 -13,  -18, 	   5,  -10, 	   1,  -16
+.2byte   11,  -11, 	  -5,  -16, 	  13,   -7, 	   2,   -9
+.2byte    0,  -28, 	  14,  -20, 	 -14,  -20, 	   0,  -14
+.2byte    0,  -28, 	  13,  -14, 	 -14,  -14, 	   0,  -16
+.2byte    0,  -17, 	  17,  -13, 	 -17,  -13, 	   0,  -12
+.2byte  -13,  -26, 	  11,  -23, 	  -8,  -17, 	  -2,  -17
+.2byte  -13,  -26, 	  12,  -18, 	  -6,  -10, 	  -2,  -16
+.2byte  -12,  -11, 	   4,  -16, 	 -14,   -7, 	  -3,   -9
+.2byte  -15,  -21, 	   8,  -26, 	  12,  -21, 	  -1,  -14
+.2byte  -15,  -21, 	  11,  -21, 	  13,  -17, 	  -2,  -15
+.2byte  -14,   -8, 	  -1,  -15, 	   1,   -4, 	   0,   -8
+.2byte  -12,  -18, 	  -1,  -25, 	  13,  -24, 	   0,  -14
+.2byte  -12,  -18, 	   2,  -21, 	  13,  -18, 	   0,  -13
+.2byte  -12,   -7, 	  -6,  -17, 	  14,   -7, 	  -1,   -9
+.2byte    0,  -17, 	 -13,  -24, 	  13,  -24, 	   0,  -14
+.2byte    0,  -17, 	 -12,  -19, 	  12,  -19, 	   0,  -14
+.2byte    0,   -7, 	 -18,  -10, 	  18,  -10, 	   0,  -10
+.2byte   12,  -18, 	   1,  -25, 	 -13,  -24, 	   0,  -14
+.2byte   12,  -18, 	  -2,  -21, 	 -13,  -18, 	   0,  -13
+.2byte   14,   -7, 	   8,  -17, 	 -12,   -7, 	   3,   -9
+.2byte   15,  -21, 	  -8,  -26, 	 -12,  -21, 	   1,  -14
+.2byte   15,  -21, 	 -11,  -21, 	 -13,  -17, 	   2,  -15
+.2byte   14,   -8, 	   1,  -15, 	  -1,   -4, 	   0,   -8
+.2byte   12,  -26, 	 -12,  -23, 	   7,  -17, 	   1,  -17
+.2byte   12,  -26, 	 -13,  -18, 	   5,  -10, 	   1,  -16
+.2byte   11,  -11, 	  -5,  -16, 	  13,   -7, 	   2,   -9
+.2byte    0,  -28, 	  14,  -20, 	 -14,  -20, 	   0,  -14
+.2byte    0,  -28, 	  13,  -14, 	 -14,  -14, 	   0,  -16
+.2byte    0,  -17, 	  17,  -13, 	 -17,  -13, 	   0,  -12
+.2byte  -13,  -26, 	  11,  -23, 	  -8,  -17, 	  -2,  -17
+.2byte  -13,  -26, 	  12,  -18, 	  -6,  -10, 	  -2,  -16
+.2byte  -12,  -11, 	   4,  -16, 	 -14,   -7, 	  -3,   -9
+.2byte  -15,  -21, 	   8,  -26, 	  12,  -21, 	  -1,  -14
+.2byte  -15,  -21, 	  11,  -21, 	  13,  -17, 	  -2,  -15
+.2byte  -14,   -8, 	  -1,  -15, 	   1,   -4, 	   0,   -8
+.2byte  -12,  -18, 	  -1,  -25, 	  13,  -24, 	   0,  -14
+.2byte  -12,  -18, 	   2,  -21, 	  13,  -18, 	   0,  -13
+.2byte  -12,   -7, 	  -6,  -17, 	  14,   -7, 	  -1,   -9
+.2byte    0,  -14, 	 -12,  -24, 	  12,  -24, 	   0,  -11
+.2byte    0,   -7, 	 -17,  -18, 	  17,  -18, 	   0,   -9
+.2byte   11,  -15, 	   1,  -22, 	 -11,  -23, 	   0,  -10
+.2byte   10,   -9, 	   4,  -20, 	 -13,  -18, 	   1,   -8
+.2byte   14,  -18, 	  -6,  -25, 	 -12,  -21, 	   0,   -9
+.2byte   12,  -11, 	  -4,  -20, 	 -12,  -16, 	   2,   -8
+.2byte   11,  -21, 	 -10,  -24, 	   7,  -17, 	   1,  -12
+.2byte   12,  -17, 	 -13,  -19, 	  13,  -14, 	   0,  -10
+.2byte    0,  -23, 	  13,  -22, 	 -13,  -22, 	   0,  -11
+.2byte    0,  -18, 	  16,  -17, 	 -16,  -17, 	   0,  -10
+.2byte  -12,  -21, 	   9,  -24, 	  -8,  -17, 	  -2,  -12
+.2byte  -13,  -17, 	  12,  -19, 	 -14,  -14, 	  -1,  -10
+.2byte  -14,  -18, 	   6,  -25, 	  12,  -21, 	   0,   -9
+.2byte  -12,  -11, 	   4,  -20, 	  12,  -16, 	  -2,   -8
+.2byte  -11,  -15, 	  -1,  -22, 	  11,  -23, 	   0,  -10
+.2byte  -10,   -9, 	  -4,  -20, 	  13,  -18, 	  -1,   -8
+.2byte    0,  -14, 	 -12,  -24, 	  12,  -24, 	   0,  -11
+.2byte  -11,  -15, 	  -1,  -22, 	  11,  -23, 	   0,  -10
+.2byte  -14,  -18, 	   6,  -25, 	  12,  -21, 	   0,   -9
+.2byte  -12,  -21, 	   9,  -24, 	  -8,  -17, 	  -2,  -12
+.2byte    0,  -23, 	  13,  -22, 	 -13,  -22, 	   0,  -11
+.2byte   11,  -21, 	 -10,  -24, 	   7,  -17, 	   1,  -12
+.2byte   14,  -18, 	  -6,  -25, 	 -12,  -21, 	   0,   -9
+.2byte   11,  -15, 	   1,  -22, 	 -11,  -23, 	   0,  -10
+.2byte    9,  -16, 	  -9,  -11, 	  -4,  -11, 	  -1,  -10
+.2byte   10,  -15, 	  -9,  -11, 	  -4,  -11, 	  -1,   -9
+.2byte    0,  -24, 	 -12,  -21, 	  12,  -21, 	   0,  -12
+.2byte   -2,  -26, 	   7,  -21, 	 -15,  -22, 	  -2,  -13
+.2byte    2,  -25, 	 -11,  -21, 	 -11,  -18, 	   1,  -11
+.2byte    2,  -24, 	 -12,  -21, 	   6,  -18, 	  -2,  -11
+.2byte    0,  -24, 	  13,  -19, 	 -13,  -19, 	   0,  -11
+.2byte   -3,  -24, 	  11,  -21, 	  -7,  -18, 	   1,  -11
+.2byte   -2,  -25, 	  11,  -21, 	  11,  -18, 	  -1,  -11
+.2byte    1,  -26, 	  -8,  -21, 	  14,  -22, 	   1,  -13
+.2byte    0,  -14, 	 -12,  -24, 	  12,  -24, 	   0,  -11
+.2byte    0,  -15, 	 -13,  -22, 	  13,  -22, 	   0,  -12
+.2byte    0,  -15, 	 -12,  -17, 	  12,  -17, 	   0,  -12
+.2byte   11,  -15, 	   1,  -22, 	 -11,  -23, 	   0,  -10
+.2byte   12,  -16, 	   1,  -23, 	 -13,  -22, 	   0,  -12
+.2byte   12,  -16, 	  -2,  -19, 	 -13,  -16, 	   0,  -11
+.2byte   14,  -18, 	  -6,  -25, 	 -12,  -21, 	   0,   -9
+.2byte   15,  -19, 	  -8,  -24, 	 -12,  -19, 	   1,  -12
+.2byte   15,  -19, 	 -11,  -19, 	 -13,  -15, 	   2,  -13
+.2byte   11,  -21, 	 -10,  -24, 	   7,  -17, 	   1,  -12
+.2byte   12,  -24, 	 -12,  -21, 	   7,  -15, 	   1,  -15
+.2byte   12,  -24, 	 -13,  -16, 	   5,   -8, 	   1,  -14
+.2byte    0,  -23, 	  13,  -22, 	 -13,  -22, 	   0,  -11
+.2byte    0,  -26, 	  14,  -18, 	 -14,  -18, 	   0,  -12
+.2byte    0,  -26, 	  13,  -12, 	 -14,  -12, 	   0,  -14
+.2byte  -12,  -21, 	   9,  -24, 	  -8,  -17, 	  -2,  -12
+.2byte  -13,  -24, 	  11,  -21, 	  -8,  -15, 	  -2,  -15
+.2byte  -13,  -24, 	  12,  -16, 	  -6,   -8, 	  -2,  -14
+.2byte  -14,  -18, 	   6,  -25, 	  12,  -21, 	   0,   -9
+.2byte  -15,  -19, 	   8,  -24, 	  12,  -19, 	  -1,  -12
+.2byte  -15,  -19, 	  11,  -19, 	  13,  -15, 	  -2,  -13
+.2byte  -11,  -15, 	  -1,  -22, 	  11,  -23, 	   0,  -10
+.2byte  -12,  -16, 	  -1,  -23, 	  13,  -22, 	   0,  -12
+.2byte  -12,  -16, 	   2,  -19, 	  13,  -16, 	   0,  -11
+.2byte    0,   -7, 	 -17,  -18, 	  17,  -18, 	   0,   -9
+.2byte   -9,   -9, 	  -3,  -20, 	  14,  -18, 	   0,   -8
+.2byte  -11,  -11, 	   5,  -20, 	  13,  -16, 	  -1,   -8
+.2byte  -12,  -17, 	  13,  -19, 	 -13,  -14, 	   0,  -10
+.2byte    0,  -18, 	  16,  -17, 	 -16,  -17, 	   0,  -10
+.2byte   12,  -17, 	 -13,  -19, 	  13,  -14, 	   0,  -10
+.2byte   12,  -11, 	  -4,  -20, 	 -12,  -16, 	   2,   -8
+.2byte    9,   -9, 	   3,  -20, 	 -14,  -18, 	   0,   -8
+.2byte    0,   -7, 	 -17,  -18, 	  17,  -18, 	   0,   -9
+.2byte    9,   -9, 	   3,  -20, 	 -14,  -18, 	   0,   -8
+.2byte   12,  -11, 	  -4,  -20, 	 -12,  -16, 	   2,   -8
+.2byte   12,  -17, 	 -13,  -19, 	  13,  -14, 	   0,  -10
+.2byte    0,  -18, 	  16,  -17, 	 -16,  -17, 	   0,  -10
+.2byte  -12,  -17, 	  13,  -19, 	 -13,  -14, 	   0,  -10
+.2byte  -11,  -11, 	   5,  -20, 	  13,  -16, 	  -1,   -8
+.2byte   -9,   -9, 	  -3,  -20, 	  14,  -18, 	   0,   -8
+.2byte    0,  -14, 	 -12,  -24, 	  12,  -24, 	   0,  -11
+.2byte    0,   -7, 	 -17,  -18, 	  17,  -18, 	   0,   -9
+.2byte    0,  -14, 	 -13,  -21, 	  13,  -21, 	   0,  -11
+.2byte   11,  -15, 	   1,  -22, 	 -11,  -23, 	   0,  -10
+.2byte   10,   -9, 	   4,  -20, 	 -13,  -18, 	   1,   -8
+.2byte   12,  -15, 	   1,  -22, 	 -13,  -21, 	   0,  -11
+.2byte   14,  -18, 	  -6,  -25, 	 -12,  -21, 	   0,   -9
+.2byte   12,  -11, 	  -4,  -20, 	 -12,  -16, 	   2,   -8
+.2byte   15,  -18, 	  -8,  -23, 	 -12,  -18, 	   1,  -11
+.2byte   11,  -21, 	 -10,  -24, 	   7,  -17, 	   1,  -12
+.2byte   12,  -17, 	 -13,  -19, 	  13,  -14, 	   0,  -10
+.2byte   12,  -23, 	 -12,  -20, 	   7,  -14, 	   1,  -14
+.2byte    0,  -23, 	  13,  -22, 	 -13,  -22, 	   0,  -11
+.2byte    0,  -18, 	  16,  -17, 	 -16,  -17, 	   0,  -10
+.2byte    0,  -25, 	  14,  -17, 	 -14,  -17, 	   0,  -11
+.2byte  -12,  -21, 	   9,  -24, 	  -8,  -17, 	  -2,  -12
+.2byte  -13,  -17, 	  12,  -19, 	 -14,  -14, 	  -1,  -10
+.2byte  -13,  -23, 	  11,  -20, 	  -8,  -14, 	  -2,  -14
+.2byte  -14,  -18, 	   6,  -25, 	  12,  -21, 	   0,   -9
+.2byte  -12,  -11, 	   4,  -20, 	  12,  -16, 	  -2,   -8
+.2byte  -15,  -18, 	   8,  -23, 	  12,  -18, 	  -1,  -11
+.2byte  -11,  -15, 	  -1,  -22, 	  11,  -23, 	   0,  -10
+.2byte  -10,   -9, 	  -4,  -20, 	  13,  -18, 	  -1,   -8
+.2byte  -12,  -15, 	  -1,  -22, 	  13,  -21, 	   0,  -11
+.2byte    0,   -7, 	 -17,  -18, 	  17,  -18, 	   0,   -9
+.2byte   -9,   -9, 	  -3,  -20, 	  14,  -18, 	   0,   -8
+.2byte  -11,  -11, 	   5,  -20, 	  13,  -16, 	  -1,   -8
+.2byte  -12,  -17, 	  13,  -19, 	 -13,  -14, 	   0,  -10
+.2byte    0,  -18, 	  16,  -17, 	 -16,  -17, 	   0,  -10
+.2byte   12,  -17, 	 -13,  -19, 	  13,  -14, 	   0,  -10
+.2byte   12,  -11, 	  -4,  -20, 	 -12,  -16, 	   2,   -8
+.2byte    9,   -9, 	   3,  -20, 	 -14,  -18, 	   0,   -8
+.2byte    0,  -14, 	 -12,  -24, 	  12,  -24, 	   0,  -11
+.2byte  -11,  -15, 	  -1,  -22, 	  11,  -23, 	   0,  -10
+.2byte  -14,  -18, 	   6,  -25, 	  12,  -21, 	   0,   -9
+.2byte  -12,  -21, 	   9,  -24, 	  -8,  -17, 	  -2,  -12
+.2byte    0,  -23, 	  13,  -22, 	 -13,  -22, 	   0,  -11
+.2byte   11,  -21, 	 -10,  -24, 	   7,  -17, 	   1,  -12
+.2byte   14,  -18, 	  -6,  -25, 	 -12,  -21, 	   0,   -9
+.2byte   11,  -15, 	   1,  -22, 	 -11,  -23, 	   0,  -10
+.2byte    0,  -20, 	 -12,  -22, 	  12,  -22, 	   0,  -10
+.2byte    0,  -19, 	 -12,  -24, 	  12,  -24, 	   0,  -10
+.2byte    0,  -22, 	 -13,  -23, 	  13,  -23, 	   0,  -11
+.2byte    0,  -22, 	 -13,  -18, 	  13,  -18, 	   0,  -11
+.2byte    0,  -20, 	 -12,  -22, 	  12,  -22, 	   0,  -10
+.2byte    0,  -19, 	 -12,  -24, 	  12,  -24, 	   0,  -10
+.2byte    0,  -17, 	 -13,  -24, 	  13,  -24, 	   0,  -14
+.2byte    0,  -17, 	 -12,  -19, 	  12,  -19, 	   0,  -14
+.2byte    0,  -22, 	 -13,  -23, 	  13,  -23, 	   0,  -11
+.2byte    0,  -22, 	 -13,  -18, 	  13,  -18, 	   0,  -11
+.2byte    0,  -20, 	 -12,  -22, 	  12,  -22, 	   0,  -10
+.2byte    0,  -19, 	 -12,  -24, 	  12,  -24, 	   0,  -10
+.2byte    0,  -17, 	 -13,  -24, 	  13,  -24, 	   0,  -14
+.2byte    0,  -17, 	 -12,  -19, 	  12,  -19, 	   0,  -14
+sSkarmoryAnimTable1:
+.4byte sSkarmoryAnims_1_1
+.4byte sSkarmoryAnims_1_2
+.4byte sSkarmoryAnims_1_3
+.4byte sSkarmoryAnims_1_4
+.4byte sSkarmoryAnims_1_5
+.4byte sSkarmoryAnims_1_6
+.4byte sSkarmoryAnims_1_7
+.4byte sSkarmoryAnims_1_8
+sSkarmoryAnimTable2:
+.4byte sSkarmoryAnims_2_1
+.4byte sSkarmoryAnims_2_2
+.4byte sSkarmoryAnims_2_3
+.4byte sSkarmoryAnims_2_4
+.4byte sSkarmoryAnims_2_5
+.4byte sSkarmoryAnims_2_6
+.4byte sSkarmoryAnims_2_7
+.4byte sSkarmoryAnims_2_8
+sSkarmoryAnimTable3:
+.4byte sSkarmoryAnims_3_1
+.4byte sSkarmoryAnims_3_2
+.4byte sSkarmoryAnims_3_3
+.4byte sSkarmoryAnims_3_4
+.4byte sSkarmoryAnims_3_5
+.4byte sSkarmoryAnims_3_6
+.4byte sSkarmoryAnims_3_7
+.4byte sSkarmoryAnims_3_8
+sSkarmoryAnimTable4:
+.4byte sSkarmoryAnims_4_1
+.4byte sSkarmoryAnims_4_2
+.4byte sSkarmoryAnims_4_3
+.4byte sSkarmoryAnims_4_4
+.4byte sSkarmoryAnims_4_5
+.4byte sSkarmoryAnims_4_6
+.4byte sSkarmoryAnims_4_7
+.4byte sSkarmoryAnims_4_8
+sSkarmoryAnimTable5:
+.4byte sSkarmoryAnims_5_1
+.4byte sSkarmoryAnims_5_2
+.4byte sSkarmoryAnims_5_3
+.4byte sSkarmoryAnims_5_4
+.4byte sSkarmoryAnims_5_5
+.4byte sSkarmoryAnims_5_6
+.4byte sSkarmoryAnims_5_7
+.4byte sSkarmoryAnims_5_8
+sSkarmoryAnimTable6:
+.4byte sSkarmoryAnims_6_1
+.4byte sSkarmoryAnims_6_1
+.4byte sSkarmoryAnims_6_1
+.4byte sSkarmoryAnims_6_1
+.4byte sSkarmoryAnims_6_1
+.4byte sSkarmoryAnims_6_1
+.4byte sSkarmoryAnims_6_1
+.4byte sSkarmoryAnims_6_1
+sSkarmoryAnimTable7:
+.4byte sSkarmoryAnims_7_1
+.4byte sSkarmoryAnims_7_2
+.4byte sSkarmoryAnims_7_3
+.4byte sSkarmoryAnims_7_4
+.4byte sSkarmoryAnims_7_5
+.4byte sSkarmoryAnims_7_6
+.4byte sSkarmoryAnims_7_7
+.4byte sSkarmoryAnims_7_8
+sSkarmoryAnimTable8:
+.4byte sSkarmoryAnims_8_1
+.4byte sSkarmoryAnims_8_2
+.4byte sSkarmoryAnims_8_3
+.4byte sSkarmoryAnims_8_4
+.4byte sSkarmoryAnims_8_5
+.4byte sSkarmoryAnims_8_6
+.4byte sSkarmoryAnims_8_7
+.4byte sSkarmoryAnims_8_8
+sSkarmoryAnimTable9:
+.4byte sSkarmoryAnims_9_1
+.4byte sSkarmoryAnims_9_2
+.4byte sSkarmoryAnims_9_3
+.4byte sSkarmoryAnims_9_4
+.4byte sSkarmoryAnims_9_5
+.4byte sSkarmoryAnims_9_6
+.4byte sSkarmoryAnims_9_7
+.4byte sSkarmoryAnims_9_8
+sSkarmoryAnimTable10:
+.4byte sSkarmoryAnims_10_1
+.4byte sSkarmoryAnims_10_2
+.4byte sSkarmoryAnims_10_3
+.4byte sSkarmoryAnims_10_4
+.4byte sSkarmoryAnims_10_5
+.4byte sSkarmoryAnims_10_6
+.4byte sSkarmoryAnims_10_7
+.4byte sSkarmoryAnims_10_8
+sSkarmoryAnimTable11:
+.4byte sSkarmoryAnims_11_1
+.4byte sSkarmoryAnims_11_2
+.4byte sSkarmoryAnims_11_3
+.4byte sSkarmoryAnims_11_4
+.4byte sSkarmoryAnims_11_5
+.4byte sSkarmoryAnims_11_6
+.4byte sSkarmoryAnims_11_7
+.4byte sSkarmoryAnims_11_8
+sSkarmoryAnimTable12:
+.4byte sSkarmoryAnims_12_1
+.4byte sSkarmoryAnims_12_2
+.4byte sSkarmoryAnims_12_3
+.4byte sSkarmoryAnims_12_4
+.4byte sSkarmoryAnims_12_5
+.4byte sSkarmoryAnims_12_6
+.4byte sSkarmoryAnims_12_7
+.4byte sSkarmoryAnims_12_8
+sSkarmoryAnimTable13:
+.4byte sSkarmoryAnims_13_1
+.4byte sSkarmoryAnims_13_2
+.4byte sSkarmoryAnims_13_3
+.4byte sSkarmoryAnims_13_4
+.4byte sSkarmoryAnims_13_5
+.4byte sSkarmoryAnims_13_6
+.4byte sSkarmoryAnims_13_7
+.4byte sSkarmoryAnims_13_8
+sSkarmoryAnimTable14:
+.4byte sSkarmoryAnims_14_1
+.4byte sSkarmoryAnims_14_2
+.4byte sSkarmoryAnims_14_3
+.4byte sSkarmoryAnims_14_4
+.4byte sSkarmoryAnims_14_5
+.4byte sSkarmoryAnims_14_6
+.4byte sSkarmoryAnims_14_7
+.4byte sSkarmoryAnims_14_8
+sSkarmoryAnimTable15:
+.4byte sSkarmoryAnims_15_1
+.4byte sSkarmoryAnims_15_1
+.4byte sSkarmoryAnims_15_1
+.4byte sSkarmoryAnims_15_1
+.4byte sSkarmoryAnims_15_1
+.4byte sSkarmoryAnims_15_1
+.4byte sSkarmoryAnims_15_1
+.4byte sSkarmoryAnims_15_1
+sSkarmoryAnimTable16:
+.4byte sSkarmoryAnims_16_1
+.4byte sSkarmoryAnims_16_1
+.4byte sSkarmoryAnims_16_1
+.4byte sSkarmoryAnims_16_1
+.4byte sSkarmoryAnims_16_1
+.4byte sSkarmoryAnims_16_1
+.4byte sSkarmoryAnims_16_1
+.4byte sSkarmoryAnims_16_1
+sAxAnimationsSkarmory:
+.4byte sSkarmoryAnimTable1
+.4byte sSkarmoryAnimTable2
+.4byte sSkarmoryAnimTable3
+.4byte sSkarmoryAnimTable4
+.4byte sSkarmoryAnimTable5
+.4byte sSkarmoryAnimTable6
+.4byte sSkarmoryAnimTable7
+.4byte sSkarmoryAnimTable8
+.4byte sSkarmoryAnimTable9
+.4byte sSkarmoryAnimTable10
+.4byte sSkarmoryAnimTable11
+.4byte sSkarmoryAnimTable12
+.4byte sSkarmoryAnimTable13
+.4byte sSkarmoryAnimTable14
+.4byte sSkarmoryAnimTable15
+.4byte sSkarmoryAnimTable16
+sAxSpritesSkarmory:
+.4byte sSkarmorySprites1
+.4byte sSkarmorySprites2
+.4byte sSkarmorySprites3
+.4byte sSkarmorySprites4
+.4byte sSkarmorySprites5
+.4byte sSkarmorySprites6
+.4byte sSkarmorySprites7
+.4byte sSkarmorySprites8
+.4byte sSkarmorySprites9
+.4byte sSkarmorySprites10
+.4byte sSkarmorySprites11
+.4byte sSkarmorySprites12
+.4byte sSkarmorySprites13
+.4byte sSkarmorySprites14
+.4byte sSkarmorySprites15
+.4byte sSkarmorySprites16
+.4byte sSkarmorySprites17
+.4byte sSkarmorySprites18
+.4byte sSkarmorySprites19
+.4byte sSkarmorySprites20
+.4byte sSkarmorySprites21
+.4byte sSkarmorySprites22
+.4byte sSkarmorySprites23
+.4byte sSkarmorySprites24
+.4byte sSkarmorySprites25
+.4byte sSkarmorySprites26
+.4byte sSkarmorySprites27
+.4byte sSkarmorySprites28
+.4byte sSkarmorySprites29
+.4byte sSkarmorySprites30
+.4byte sSkarmorySprites31
+.4byte sSkarmorySprites32
+.4byte sSkarmorySprites33
+.4byte sSkarmorySprites34
+.4byte sSkarmorySprites35
+.4byte sSkarmorySprites36
+.4byte sSkarmorySprites37
+.4byte sSkarmorySprites38
+.4byte sSkarmorySprites39
+.4byte sSkarmorySprites40
+.4byte sSkarmorySprites41
+.4byte sSkarmorySprites42
+.4byte sSkarmorySprites43
+.4byte sSkarmorySprites44
+.4byte sSkarmorySprites45
+.4byte sSkarmorySprites46
+.4byte sSkarmorySprites47
+.4byte sSkarmorySprites48
+.4byte sSkarmorySprites49
+.4byte sSkarmorySprites50
+.4byte sSkarmorySprites51
+.4byte sSkarmorySprites52
+.4byte sSkarmorySprites53
+.4byte sSkarmorySprites54
+.4byte sSkarmorySprites55
+.4byte sSkarmorySprites56
+.4byte sSkarmorySprites57
+.4byte sSkarmorySprites58
+.4byte sSkarmorySprites59
+.4byte sSkarmorySprites60
+.4byte sSkarmorySprites61
+.4byte sSkarmorySprites62
+.4byte sSkarmorySprites63
+.4byte sSkarmorySprites64
+.4byte sSkarmorySprites65
+.4byte sSkarmorySprites66
+.4byte sSkarmorySprites67
+.4byte sSkarmorySprites68
+.4byte sSkarmorySprites69
+.4byte sSkarmorySprites70
+.4byte sSkarmorySprites71
+.4byte sSkarmorySprites72
+.4byte sSkarmorySprites73
+.4byte sSkarmorySprites74
+.4byte sSkarmorySprites75
+.4byte sSkarmorySprites76
+.4byte sSkarmorySprites77
+.4byte sSkarmorySprites78
+.4byte sSkarmorySprites79
+.4byte sSkarmorySprites80
+.4byte sSkarmorySprites81
+.4byte sSkarmorySprites82
+.4byte sSkarmorySprites83
+.4byte sSkarmorySprites84
+sAxMainSkarmory:
+ax_main sAxPosesSkarmory, sAxAnimationsSkarmory, 16, sAxSpritesSkarmory, sAxPositionsSkarmory

--- a/data/ax/skiploom.inc
+++ b/data/ax/skiploom.inc
@@ -1,0 +1,2738 @@
+.global gAxSkiploom
+gAxSkiploom:
+ax_siro sAxMainSkiploom
+sSkiploomPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose2:
+ax_pose 1, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose3:
+ax_pose 2, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose4:
+ax_pose 3, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose5:
+ax_pose 4, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose6:
+ax_pose 5, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose7:
+ax_pose 6, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose8:
+ax_pose 7, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose9:
+ax_pose 8, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose10:
+ax_pose 9, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose11:
+ax_pose 10, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose12:
+ax_pose 11, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose13:
+ax_pose 12, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose14:
+ax_pose 13, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose15:
+ax_pose 14, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose16:
+ax_pose 9, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose17:
+ax_pose 10, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose18:
+ax_pose 11, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose19:
+ax_pose 6, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose20:
+ax_pose 7, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose21:
+ax_pose 8, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose22:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose23:
+ax_pose 4, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose24:
+ax_pose 5, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose26:
+ax_pose 1, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose27:
+ax_pose 2, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose28:
+ax_pose 15, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose29:
+ax_pose 3, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose30:
+ax_pose 4, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose31:
+ax_pose 5, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose32:
+ax_pose 16, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose33:
+ax_pose 6, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose34:
+ax_pose 7, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose35:
+ax_pose 8, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose36:
+ax_pose 17, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose37:
+ax_pose 9, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose38:
+ax_pose 10, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose39:
+ax_pose 11, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose40:
+ax_pose 18, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose41:
+ax_pose 12, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose42:
+ax_pose 13, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose43:
+ax_pose 14, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose44:
+ax_pose 19, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose45:
+ax_pose 9, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose46:
+ax_pose 10, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose47:
+ax_pose 11, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose48:
+ax_pose 18, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose49:
+ax_pose 6, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose50:
+ax_pose 7, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose51:
+ax_pose 8, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose52:
+ax_pose 17, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose53:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose54:
+ax_pose 4, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose55:
+ax_pose 5, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose56:
+ax_pose 16, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose57:
+ax_pose 0, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose58:
+ax_pose 1, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose59:
+ax_pose 2, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose60:
+ax_pose 15, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose61:
+ax_pose 3, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose62:
+ax_pose 4, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose63:
+ax_pose 5, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose64:
+ax_pose 16, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose65:
+ax_pose 6, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose66:
+ax_pose 7, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose67:
+ax_pose 8, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose68:
+ax_pose 17, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose69:
+ax_pose 9, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose70:
+ax_pose 10, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose71:
+ax_pose 11, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose72:
+ax_pose 18, 0x01e9, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose73:
+ax_pose 12, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose74:
+ax_pose 13, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose75:
+ax_pose 14, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose76:
+ax_pose 19, 0x01e9, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose77:
+ax_pose 9, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose78:
+ax_pose 10, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose79:
+ax_pose 11, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose80:
+ax_pose 18, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose81:
+ax_pose 6, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose82:
+ax_pose 7, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose83:
+ax_pose 8, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose84:
+ax_pose 17, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose85:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose86:
+ax_pose 4, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose87:
+ax_pose 5, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose88:
+ax_pose 16, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose89:
+ax_pose 0, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose90:
+ax_pose 1, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose91:
+ax_pose 2, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose92:
+ax_pose 20, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose93:
+ax_pose 3, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose94:
+ax_pose 4, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose95:
+ax_pose 5, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose96:
+ax_pose 21, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose97:
+ax_pose 6, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose98:
+ax_pose 7, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose99:
+ax_pose 8, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose100:
+ax_pose 22, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose101:
+ax_pose 9, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose102:
+ax_pose 10, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose103:
+ax_pose 11, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose104:
+ax_pose 23, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose105:
+ax_pose 12, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose106:
+ax_pose 13, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose107:
+ax_pose 14, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose108:
+ax_pose 24, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose109:
+ax_pose 9, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose110:
+ax_pose 10, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose111:
+ax_pose 11, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose112:
+ax_pose 23, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose113:
+ax_pose 6, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose114:
+ax_pose 7, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose115:
+ax_pose 8, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose116:
+ax_pose 22, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose117:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose118:
+ax_pose 4, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose119:
+ax_pose 5, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose120:
+ax_pose 21, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose121:
+ax_pose 15, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose122:
+ax_pose 16, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose123:
+ax_pose 17, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose124:
+ax_pose 18, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose125:
+ax_pose 19, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose126:
+ax_pose 18, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose127:
+ax_pose 17, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose128:
+ax_pose 16, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose129:
+ax_pose 25, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose130:
+ax_pose 26, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose131:
+ax_pose 27, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sSkiploomPose132:
+ax_pose 28, 0x01e1, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose133:
+ax_pose 29, 0x01e0, 0x90ea, 0x3c00
+ax_pose_terminator
+sSkiploomPose134:
+ax_pose 30, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose135:
+ax_pose 31, 0x01e1, 0x80f0, 0x3c00
+ax_pose_terminator
+sSkiploomPose136:
+ax_pose 30, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose137:
+ax_pose 29, 0x01e0, 0x80f6, 0x3c00
+ax_pose_terminator
+sSkiploomPose138:
+ax_pose 28, 0x01e1, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose139:
+ax_pose 0, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose140:
+ax_pose 1, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose141:
+ax_pose 2, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose142:
+ax_pose 3, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose143:
+ax_pose 4, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose144:
+ax_pose 5, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose145:
+ax_pose 6, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose146:
+ax_pose 7, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose147:
+ax_pose 8, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose148:
+ax_pose 9, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose149:
+ax_pose 10, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose150:
+ax_pose 11, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose151:
+ax_pose 12, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose152:
+ax_pose 13, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose153:
+ax_pose 14, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose154:
+ax_pose 9, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose155:
+ax_pose 10, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose156:
+ax_pose 11, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose157:
+ax_pose 6, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose158:
+ax_pose 7, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose159:
+ax_pose 8, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose160:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose161:
+ax_pose 4, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose162:
+ax_pose 5, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose163:
+ax_pose 20, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose164:
+ax_pose 21, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose165:
+ax_pose 22, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose166:
+ax_pose 23, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose167:
+ax_pose 24, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose168:
+ax_pose 23, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose169:
+ax_pose 22, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose170:
+ax_pose 21, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose171:
+ax_pose 20, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose172:
+ax_pose 21, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose173:
+ax_pose 22, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose174:
+ax_pose 23, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose175:
+ax_pose 24, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose176:
+ax_pose 23, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose177:
+ax_pose 22, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose178:
+ax_pose 21, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose179:
+ax_pose 0, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose180:
+ax_pose 1, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose181:
+ax_pose 2, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose182:
+ax_pose 3, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose183:
+ax_pose 4, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose184:
+ax_pose 5, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose185:
+ax_pose 6, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose186:
+ax_pose 7, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose187:
+ax_pose 8, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose188:
+ax_pose 9, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose189:
+ax_pose 10, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose190:
+ax_pose 11, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose191:
+ax_pose 12, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose192:
+ax_pose 13, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose193:
+ax_pose 14, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose194:
+ax_pose 9, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose195:
+ax_pose 10, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose196:
+ax_pose 11, 0x01e8, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose197:
+ax_pose 6, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose198:
+ax_pose 7, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose199:
+ax_pose 8, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose200:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose201:
+ax_pose 4, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose202:
+ax_pose 5, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose203:
+ax_pose 15, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose204:
+ax_pose 16, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose205:
+ax_pose 17, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose206:
+ax_pose 18, 0x01e8, 0x80f4, 0x3c00
+ax_pose_terminator
+sSkiploomPose207:
+ax_pose 19, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose208:
+ax_pose 18, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose209:
+ax_pose 17, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose210:
+ax_pose 16, 0x01e8, 0x90ec, 0x3c00
+ax_pose_terminator
+sSkiploomPose211:
+ax_pose 0, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose212:
+ax_pose 3, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose213:
+ax_pose 6, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose214:
+ax_pose 9, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSkiploomPose215:
+ax_pose 12, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sSkiploomPose216:
+ax_pose 9, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose217:
+ax_pose 6, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSkiploomPose218:
+ax_pose 3, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+.align 2
+sSkiploomAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -3, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -3, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 8, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, 0,
+ax_anim 2, 0, 25, 0, -2, 0, 0,
+ax_anim 2, 0, 24, 0, -3, 0, 0,
+ax_anim 2, 0, 26, 0, -4, 0, 0,
+ax_anim 2, 0, 24, 0, -5, 0, 0,
+ax_anim 2, 0, 25, 0, -6, 0, 0,
+ax_anim 1, 0, 27, 0, -2, 0, 3,
+ax_anim 1, 0, 27, 0, 2, 0, 6,
+ax_anim 1, 2, 27, 0, 6, 0, 9,
+ax_anim 1, 0, 27, 0, 14, 0, 12,
+ax_anim 2, 0, 27, 0, 22, 0, 16,
+ax_anim 2, 1, 27, -1, 22, -1, 16,
+ax_anim 2, 0, 27, 0, 22, 0, 16,
+ax_anim 2, 0, 27, -1, 22, -1, 16,
+ax_anim 2, 0, 27, 0, 22, 0, 16,
+ax_anim 1, 0, 26, 0, 8, 0, 0,
+ax_anim 1, 0, 24, 0, 2, 0, 0,
+ax_anim 1, 0, 25, 0, 1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_2_2:
+ax_anim 2, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 29, 0, -2, 0, 0,
+ax_anim 2, 0, 28, 0, -3, 0, 0,
+ax_anim 2, 0, 30, 0, -4, 0, 0,
+ax_anim 2, 0, 28, 0, -5, 0, 0,
+ax_anim 2, 0, 29, 0, -6, 0, 0,
+ax_anim 1, 0, 31, 3, -2, 3, 3,
+ax_anim 1, 0, 31, 6, 2, 6, 6,
+ax_anim 1, 2, 31, 9, 6, 9, 8,
+ax_anim 1, 0, 31, 14, 14, 12, 10,
+ax_anim 2, 0, 31, 22, 22, 22, 19,
+ax_anim 2, 1, 31, 21, 23, 21, 20,
+ax_anim 2, 0, 31, 22, 22, 22, 19,
+ax_anim 2, 0, 31, 21, 23, 21, 20,
+ax_anim 2, 0, 31, 22, 22, 22, 19,
+ax_anim 1, 0, 30, 8, 4, 8, 8,
+ax_anim 1, 0, 28, 4, 0, 4, 4,
+ax_anim 1, 0, 29, 2, -1, 2, 2,
+ax_anim_terminator
+sSkiploomAnims_2_3:
+ax_anim 2, 0, 32, 0, -1, 0, 0,
+ax_anim 2, 0, 33, 0, -2, 0, 0,
+ax_anim 2, 0, 32, 0, -3, 0, 0,
+ax_anim 2, 0, 34, 0, -4, 0, 0,
+ax_anim 2, 0, 32, 0, -5, 0, 0,
+ax_anim 2, 0, 33, 0, -6, 0, 0,
+ax_anim 1, 0, 35, 3, -5, 3, 0,
+ax_anim 1, 0, 35, 6, -4, 6, 0,
+ax_anim 1, 2, 35, 9, -3, 9, 0,
+ax_anim 1, 0, 35, 12, -2, 12, 0,
+ax_anim 2, 0, 35, 18, -1, 18, 0,
+ax_anim 2, 1, 35, 18, -2, 17, 0,
+ax_anim 2, 0, 35, 18, -1, 18, 0,
+ax_anim 2, 0, 35, 18, -2, 17, 0,
+ax_anim 2, 0, 35, 18, -1, 18, 0,
+ax_anim 1, 0, 34, 8, -3, 8, 0,
+ax_anim 1, 0, 32, 4, -2, 4, 0,
+ax_anim 1, 0, 33, 2, -1, 2, 0,
+ax_anim_terminator
+sSkiploomAnims_2_4:
+ax_anim 2, 0, 36, 0, -1, 0, 0,
+ax_anim 2, 0, 37, 0, -2, 0, 0,
+ax_anim 2, 0, 36, 0, -3, 0, 0,
+ax_anim 2, 0, 38, 0, -4, 0, 0,
+ax_anim 2, 0, 36, 0, -5, 0, 0,
+ax_anim 2, 0, 37, 0, -6, 0, 0,
+ax_anim 1, 0, 39, 3, -8, 3, -3,
+ax_anim 1, 0, 39, 6, -10, 6, -6,
+ax_anim 1, 2, 39, 9, -13, 9, -9,
+ax_anim 1, 0, 39, 12, -15, 12, -12,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 1, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 1, 0, 38, 8, -12, 8, -8,
+ax_anim 1, 0, 36, 4, -8, 4, -4,
+ax_anim 1, 0, 37, 2, -4, 2, -2,
+ax_anim_terminator
+sSkiploomAnims_2_5:
+ax_anim 2, 0, 40, 0, -1, 0, 0,
+ax_anim 2, 0, 41, 0, -2, 0, 0,
+ax_anim 2, 0, 40, 0, -3, 0, 0,
+ax_anim 2, 0, 42, 0, -4, 0, 0,
+ax_anim 2, 0, 40, 0, -5, 0, 0,
+ax_anim 2, 0, 41, 0, -6, 0, 0,
+ax_anim 1, 0, 43, 0, -8, 0, -3,
+ax_anim 1, 0, 43, 0, -10, 0, -6,
+ax_anim 1, 2, 43, 0, -13, 0, -9,
+ax_anim 1, 0, 43, 0, -15, 0, -12,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, -1, -18, -1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, -1, -18, -1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 1, 0, 42, 0, -12, 0, -8,
+ax_anim 1, 0, 40, 0, -8, 0, -4,
+ax_anim 1, 0, 41, 0, -4, 0, -2,
+ax_anim_terminator
+sSkiploomAnims_2_6:
+ax_anim 2, 0, 44, 0, -1, 0, 0,
+ax_anim 2, 0, 45, 0, -2, 0, 0,
+ax_anim 2, 0, 44, 0, -3, 0, 0,
+ax_anim 2, 0, 46, 0, -4, 0, 0,
+ax_anim 2, 0, 44, 0, -5, 0, 0,
+ax_anim 2, 0, 45, 0, -6, 0, 0,
+ax_anim 1, 0, 47, -3, -8, -3, -3,
+ax_anim 1, 0, 47, -6, -10, -6, -6,
+ax_anim 1, 2, 47, -9, -13, -9, -9,
+ax_anim 1, 0, 47, -12, -15, -12, -12,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 1, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 1, 0, 46, -8, -12, -8, -8,
+ax_anim 1, 0, 44, -4, -8, -4, -4,
+ax_anim 1, 0, 45, -2, -4, -2, -2,
+ax_anim_terminator
+sSkiploomAnims_2_7:
+ax_anim 2, 0, 48, 0, -1, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 0, 48, 0, -3, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 0, 48, 0, -5, 0, 0,
+ax_anim 2, 0, 49, 0, -6, 0, 0,
+ax_anim 1, 0, 51, -3, -5, -3, 0,
+ax_anim 1, 0, 51, -6, -4, -6, 0,
+ax_anim 1, 2, 51, -9, -3, -9, 0,
+ax_anim 1, 0, 51, -12, -2, -12, 0,
+ax_anim 2, 0, 51, -18, -1, -18, 0,
+ax_anim 2, 1, 51, -18, -2, -17, 0,
+ax_anim 2, 0, 51, -18, -1, -18, 0,
+ax_anim 2, 0, 51, -18, -2, -17, 0,
+ax_anim 2, 0, 51, -18, -1, -18, 0,
+ax_anim 1, 0, 50, -8, -3, -8, 0,
+ax_anim 1, 0, 48, -4, -2, -4, 0,
+ax_anim 1, 0, 49, -2, -1, -2, 0,
+ax_anim_terminator
+sSkiploomAnims_2_8:
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 53, 0, -2, 0, 0,
+ax_anim 2, 0, 52, 0, -3, 0, 0,
+ax_anim 2, 0, 54, 0, -4, 0, 0,
+ax_anim 2, 0, 52, 0, -5, 0, 0,
+ax_anim 2, 0, 53, 0, -6, 0, 0,
+ax_anim 1, 0, 55, -3, -2, -3, 3,
+ax_anim 1, 0, 55, -6, 2, -6, 6,
+ax_anim 1, 2, 55, -9, 6, -9, 8,
+ax_anim 1, 0, 55, -14, 14, -12, 10,
+ax_anim 2, 0, 55, -22, 22, -22, 19,
+ax_anim 2, 1, 55, -21, 23, -21, 20,
+ax_anim 2, 0, 55, -22, 22, -22, 19,
+ax_anim 2, 0, 55, -21, 23, -21, 20,
+ax_anim 2, 0, 55, -22, 22, -22, 19,
+ax_anim 1, 0, 54, -8, 4, -8, 8,
+ax_anim 1, 0, 52, -4, 0, -4, 4,
+ax_anim 1, 0, 53, -2, -1, -2, 2,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, 0,
+ax_anim 2, 0, 57, 0, -2, 0, 0,
+ax_anim 2, 0, 56, 0, -3, 0, 0,
+ax_anim 2, 0, 58, 0, -4, 0, 0,
+ax_anim 2, 0, 56, 0, -5, 0, 0,
+ax_anim 2, 0, 57, 0, -6, 0, 0,
+ax_anim 1, 0, 59, 0, -2, 0, 3,
+ax_anim 1, 0, 59, 0, 2, 0, 6,
+ax_anim 1, 2, 59, 0, 6, 0, 9,
+ax_anim 1, 0, 59, 0, 14, 0, 12,
+ax_anim 2, 0, 59, 0, 22, 0, 16,
+ax_anim 2, 1, 59, -1, 22, -1, 16,
+ax_anim 2, 0, 59, 0, 22, 0, 16,
+ax_anim 2, 0, 59, -1, 22, -1, 16,
+ax_anim 2, 0, 59, 0, 22, 0, 16,
+ax_anim 1, 0, 58, 0, 8, 0, 0,
+ax_anim 1, 0, 56, 0, 2, 0, 0,
+ax_anim 1, 0, 57, 0, 1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_3_2:
+ax_anim 2, 0, 60, 0, -1, 0, 0,
+ax_anim 2, 0, 61, 0, -2, 0, 0,
+ax_anim 2, 0, 60, 0, -3, 0, 0,
+ax_anim 2, 0, 62, 0, -4, 0, 0,
+ax_anim 2, 0, 60, 0, -5, 0, 0,
+ax_anim 2, 0, 61, 0, -6, 0, 0,
+ax_anim 1, 0, 63, 3, -2, 3, 3,
+ax_anim 1, 0, 63, 6, 2, 6, 6,
+ax_anim 1, 2, 63, 9, 6, 9, 8,
+ax_anim 1, 0, 63, 14, 14, 12, 10,
+ax_anim 2, 0, 63, 22, 22, 22, 19,
+ax_anim 2, 1, 63, 21, 23, 21, 20,
+ax_anim 2, 0, 63, 22, 22, 22, 19,
+ax_anim 2, 0, 63, 21, 23, 21, 20,
+ax_anim 2, 0, 63, 22, 22, 22, 19,
+ax_anim 1, 0, 62, 8, 4, 8, 8,
+ax_anim 1, 0, 60, 4, 0, 4, 4,
+ax_anim 1, 0, 61, 2, -1, 2, 2,
+ax_anim_terminator
+sSkiploomAnims_3_3:
+ax_anim 2, 0, 64, 0, -1, 0, 0,
+ax_anim 2, 0, 65, 0, -2, 0, 0,
+ax_anim 2, 0, 64, 0, -3, 0, 0,
+ax_anim 2, 0, 66, 0, -4, 0, 0,
+ax_anim 2, 0, 64, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 0, -6, 0, 0,
+ax_anim 1, 0, 67, 3, -5, 3, 0,
+ax_anim 1, 0, 67, 6, -4, 6, 0,
+ax_anim 1, 2, 67, 9, -3, 9, 0,
+ax_anim 1, 0, 67, 12, -2, 12, 0,
+ax_anim 2, 0, 67, 18, -1, 18, 0,
+ax_anim 2, 1, 67, 18, -2, 17, 0,
+ax_anim 2, 0, 67, 18, -1, 18, 0,
+ax_anim 2, 0, 67, 18, -2, 17, 0,
+ax_anim 2, 0, 67, 18, -1, 18, 0,
+ax_anim 1, 0, 66, 8, -3, 8, 0,
+ax_anim 1, 0, 64, 4, -2, 4, 0,
+ax_anim 1, 0, 65, 2, -1, 2, 0,
+ax_anim_terminator
+sSkiploomAnims_3_4:
+ax_anim 2, 0, 68, 0, -1, 0, 0,
+ax_anim 2, 0, 69, 0, -2, 0, 0,
+ax_anim 2, 0, 68, 0, -3, 0, 0,
+ax_anim 2, 0, 70, 0, -4, 0, 0,
+ax_anim 2, 0, 68, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, 0,
+ax_anim 1, 0, 71, 3, -8, 3, -3,
+ax_anim 1, 0, 71, 6, -10, 6, -6,
+ax_anim 1, 2, 71, 9, -13, 9, -9,
+ax_anim 1, 0, 71, 12, -15, 12, -12,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 2, 1, 71, 17, -19, 17, -19,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 2, 0, 71, 17, -19, 17, -19,
+ax_anim 2, 0, 71, 18, -18, 18, -18,
+ax_anim 1, 0, 70, 8, -12, 8, -8,
+ax_anim 1, 0, 68, 4, -8, 4, -4,
+ax_anim 1, 0, 69, 2, -4, 2, -2,
+ax_anim_terminator
+sSkiploomAnims_3_5:
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 72, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -4, 0, 0,
+ax_anim 2, 0, 72, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -6, 0, 0,
+ax_anim 1, 0, 75, 0, -8, 0, -3,
+ax_anim 1, 0, 75, 0, -10, 0, -6,
+ax_anim 1, 2, 75, 0, -13, 0, -9,
+ax_anim 1, 0, 75, 0, -15, 0, -12,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, -1, -18, -1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, -1, -18, -1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 1, 0, 74, 0, -12, 0, -8,
+ax_anim 1, 0, 72, 0, -8, 0, -4,
+ax_anim 1, 0, 73, 0, -4, 0, -2,
+ax_anim_terminator
+sSkiploomAnims_3_6:
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, 0,
+ax_anim 1, 0, 79, -3, -8, -3, -3,
+ax_anim 1, 0, 79, -6, -10, -6, -6,
+ax_anim 1, 2, 79, -9, -13, -9, -9,
+ax_anim 1, 0, 79, -12, -15, -12, -12,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 1, 79, -17, -19, -17, -19,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 2, 0, 79, -17, -19, -17, -19,
+ax_anim 2, 0, 79, -18, -18, -18, -18,
+ax_anim 1, 0, 78, -8, -12, -8, -8,
+ax_anim 1, 0, 76, -4, -8, -4, -4,
+ax_anim 1, 0, 77, -2, -4, -2, -2,
+ax_anim_terminator
+sSkiploomAnims_3_7:
+ax_anim 2, 0, 80, 0, -1, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -5, 0, 0,
+ax_anim 2, 0, 81, 0, -6, 0, 0,
+ax_anim 1, 0, 83, -3, -5, -3, 0,
+ax_anim 1, 0, 83, -6, -4, -6, 0,
+ax_anim 1, 2, 83, -9, -3, -9, 0,
+ax_anim 1, 0, 83, -12, -2, -12, 0,
+ax_anim 2, 0, 83, -18, -1, -18, 0,
+ax_anim 2, 1, 83, -18, -2, -17, 0,
+ax_anim 2, 0, 83, -18, -1, -18, 0,
+ax_anim 2, 0, 83, -18, -2, -17, 0,
+ax_anim 2, 0, 83, -18, -1, -18, 0,
+ax_anim 1, 0, 82, -8, -3, -8, 0,
+ax_anim 1, 0, 80, -4, -2, -4, 0,
+ax_anim 1, 0, 81, -2, -1, -2, 0,
+ax_anim_terminator
+sSkiploomAnims_3_8:
+ax_anim 2, 0, 84, 0, -1, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, 0,
+ax_anim 1, 0, 87, -3, -2, -3, 3,
+ax_anim 1, 0, 87, -6, 2, -6, 6,
+ax_anim 1, 2, 87, -9, 6, -9, 8,
+ax_anim 1, 0, 87, -14, 14, -12, 10,
+ax_anim 2, 0, 87, -22, 22, -22, 19,
+ax_anim 2, 1, 87, -21, 23, -21, 20,
+ax_anim 2, 0, 87, -22, 22, -22, 19,
+ax_anim 2, 0, 87, -21, 23, -21, 20,
+ax_anim 2, 0, 87, -22, 22, -22, 19,
+ax_anim 1, 0, 86, -8, 4, -8, 8,
+ax_anim 1, 0, 84, -4, 0, -4, 4,
+ax_anim 1, 0, 85, -2, -1, -2, 2,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_4_1:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 6, 2, 90, 0, -2, 0, -2,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 1, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sSkiploomAnims_4_2:
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 6, 2, 94, -2, -2, -2, -2,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 1, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 4, 2, 4, 2,
+ax_anim 2, 0, 95, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sSkiploomAnims_4_3:
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 6, 2, 98, -2, 0, -2, 0,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 1, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 3, 1, 3, 1,
+ax_anim 2, 0, 99, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sSkiploomAnims_4_4:
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim 6, 2, 102, -2, 2, -2, 2,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 1, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 4, -2, 4, -2,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sSkiploomAnims_4_5:
+ax_anim 2, 0, 106, 0, 1, 0, 1,
+ax_anim 6, 2, 106, 0, 2, 0, 2,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 1, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 107, 1, -3, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sSkiploomAnims_4_6:
+ax_anim 2, 0, 110, 1, 1, 1, 1,
+ax_anim 6, 2, 110, 2, 2, 2, 2,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 1, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 111, -4, -2, -4, -2,
+ax_anim 2, 0, 111, -3, -3, -3, -3,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sSkiploomAnims_4_7:
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 6, 2, 114, 2, 0, 2, 0,
+ax_anim 1, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 1, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, 1, -3, 1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sSkiploomAnims_4_8:
+ax_anim 2, 0, 118, 1, -1, 1, -1,
+ax_anim 6, 2, 118, 2, -2, 2, -2,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 1, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -3, 3, -3, 3,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_5_1:
+ax_anim 1, 0, 120, 0, -1, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 1, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 123, 0, -6, 0, 0,
+ax_anim 1, 0, 124, 0, -7, 0, 0,
+ax_anim 1, 0, 125, 0, -8, 0, 0,
+ax_anim 1, 0, 126, 0, -9, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 1, 2, 121, 0, -9, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 2, 0, 123, 0, -9, 0, 0,
+ax_anim 2, 0, 124, 0, -9, 0, 0,
+ax_anim 2, 0, 125, 0, -8, 0, 0,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 4, 0, 120, 0, -1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_5_2:
+ax_anim 1, 0, 127, 0, -1, 0, 0,
+ax_anim 1, 0, 120, 0, -3, 0, 0,
+ax_anim 1, 0, 121, 0, -5, 0, 0,
+ax_anim 1, 0, 122, 0, -6, 0, 0,
+ax_anim 1, 0, 123, 0, -7, 0, 0,
+ax_anim 1, 0, 124, 0, -8, 0, 0,
+ax_anim 1, 0, 125, 0, -9, 0, 0,
+ax_anim 1, 0, 126, 0, -9, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 1, 2, 120, 0, -9, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 2, 0, 122, 0, -9, 0, 0,
+ax_anim 2, 0, 123, 0, -9, 0, 0,
+ax_anim 2, 0, 124, 0, -8, 0, 0,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -3, 0, 0,
+ax_anim 4, 0, 127, 0, -1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_5_3:
+ax_anim 1, 0, 126, 0, -1, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim 1, 0, 120, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -6, 0, 0,
+ax_anim 1, 0, 122, 0, -7, 0, 0,
+ax_anim 1, 0, 123, 0, -8, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 1, 0, 125, 0, -9, 0, 0,
+ax_anim 1, 0, 126, 0, -9, 0, 0,
+ax_anim 1, 2, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 2, 0, 121, 0, -9, 0, 0,
+ax_anim 2, 0, 122, 0, -9, 0, 0,
+ax_anim 2, 0, 123, 0, -8, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_5_4:
+ax_anim 1, 0, 125, 0, -1, 0, 0,
+ax_anim 1, 0, 126, 0, -3, 0, 0,
+ax_anim 1, 0, 127, 0, -5, 0, 0,
+ax_anim 1, 0, 120, 0, -6, 0, 0,
+ax_anim 1, 0, 121, 0, -7, 0, 0,
+ax_anim 1, 0, 122, 0, -8, 0, 0,
+ax_anim 1, 0, 123, 0, -9, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 1, 0, 125, 0, -9, 0, 0,
+ax_anim 1, 2, 126, 0, -9, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 2, 0, 120, 0, -9, 0, 0,
+ax_anim 2, 0, 121, 0, -9, 0, 0,
+ax_anim 2, 0, 122, 0, -8, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -3, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_5_5:
+ax_anim 1, 0, 124, 0, -1, 0, 0,
+ax_anim 1, 0, 125, 0, -3, 0, 0,
+ax_anim 1, 0, 126, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -6, 0, 0,
+ax_anim 1, 0, 120, 0, -7, 0, 0,
+ax_anim 1, 0, 121, 0, -8, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 123, 0, -9, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 1, 2, 125, 0, -9, 0, 0,
+ax_anim 1, 0, 126, 0, -9, 0, 0,
+ax_anim 2, 0, 127, 0, -9, 0, 0,
+ax_anim 2, 0, 120, 0, -9, 0, 0,
+ax_anim 2, 0, 121, 0, -8, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_5_6:
+ax_anim 1, 0, 123, 0, -1, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 1, 0, 125, 0, -5, 0, 0,
+ax_anim 1, 0, 126, 0, -6, 0, 0,
+ax_anim 1, 0, 127, 0, -7, 0, 0,
+ax_anim 1, 0, 120, 0, -8, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 123, 0, -9, 0, 0,
+ax_anim 1, 2, 124, 0, -9, 0, 0,
+ax_anim 1, 0, 125, 0, -9, 0, 0,
+ax_anim 2, 0, 126, 0, -9, 0, 0,
+ax_anim 2, 0, 127, 0, -9, 0, 0,
+ax_anim 2, 0, 120, 0, -8, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -3, 0, 0,
+ax_anim 4, 0, 123, 0, -1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_5_7:
+ax_anim 1, 0, 122, 0, -1, 0, 0,
+ax_anim 1, 0, 123, 0, -3, 0, 0,
+ax_anim 1, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 125, 0, -6, 0, 0,
+ax_anim 1, 0, 126, 0, -7, 0, 0,
+ax_anim 1, 0, 127, 0, -8, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 1, 0, 122, 0, -9, 0, 0,
+ax_anim 1, 2, 123, 0, -9, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, 0,
+ax_anim 2, 0, 125, 0, -9, 0, 0,
+ax_anim 2, 0, 126, 0, -9, 0, 0,
+ax_anim 2, 0, 127, 0, -8, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_5_8:
+ax_anim 1, 0, 121, 0, -1, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 1, 0, 123, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -6, 0, 0,
+ax_anim 1, 0, 125, 0, -7, 0, 0,
+ax_anim 1, 0, 126, 0, -8, 0, 0,
+ax_anim 1, 0, 127, 0, -9, 0, 0,
+ax_anim 1, 0, 120, 0, -9, 0, 0,
+ax_anim 1, 0, 121, 0, -9, 0, 0,
+ax_anim 1, 2, 122, 0, -9, 0, 0,
+ax_anim 1, 0, 123, 0, -9, 0, 0,
+ax_anim 2, 0, 124, 0, -9, 0, 0,
+ax_anim 2, 0, 125, 0, -9, 0, 0,
+ax_anim 2, 0, 126, 0, -8, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -3, 0, 0,
+ax_anim 4, 0, 121, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_6_1:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, -1, 0, 0,
+ax_anim 26, 0, 128, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -2, 0, 0,
+ax_anim 8, 0, 129, 0, -1, 0, 0,
+ax_anim 26, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sSkiploomAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sSkiploomAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sSkiploomAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sSkiploomAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sSkiploomAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sSkiploomAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sSkiploomAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_8_1:
+ax_anim 20, 0, 138, 0, 3, 0, 0,
+ax_anim 20, 0, 139, 0, 3, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_8_2:
+ax_anim 20, 0, 141, 0, 3, 0, 0,
+ax_anim 20, 0, 142, 0, 3, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_8_3:
+ax_anim 20, 0, 144, 0, 3, 0, 0,
+ax_anim 20, 0, 145, 0, 3, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_8_4:
+ax_anim 20, 0, 147, 0, 3, 0, 0,
+ax_anim 20, 0, 148, 0, 3, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_8_5:
+ax_anim 20, 0, 150, 0, 3, 0, 0,
+ax_anim 20, 0, 151, 0, 3, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_8_6:
+ax_anim 20, 0, 153, 0, 3, 0, 0,
+ax_anim 20, 0, 154, 0, 3, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_8_7:
+ax_anim 20, 0, 156, 0, 3, 0, 0,
+ax_anim 20, 0, 157, 0, 3, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_8_8:
+ax_anim 20, 0, 159, 0, 3, 0, 0,
+ax_anim 20, 0, 160, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 11, 8, 11,
+ax_anim 2, 0, 165, 7, 20, 7, 20,
+ax_anim 3, 0, 166, 0, 23, 0, 22,
+ax_anim 2, 3, 167, -7, 20, -7, 20,
+ax_anim 2, 0, 168, -8, 11, -8, 11,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 18, 5, 18, 5,
+ax_anim 2, 0, 164, 21, 13, 21, 13,
+ax_anim 3, 0, 165, 21, 22, 21, 21,
+ax_anim 2, 3, 166, 11, 25, 11, 23,
+ax_anim 2, 0, 167, 4, 18, 4, 18,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -3, 17, -3,
+ax_anim 3, 0, 164, 20, 2, 20, 0,
+ax_anim 2, 3, 165, 18, 7, 18, 6,
+ax_anim 2, 0, 166, 12, 8, 12, 8,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -8, 0, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -20, 12, -21,
+ax_anim 3, 0, 163, 21, -20, 21, -22,
+ax_anim 2, 3, 164, 21, -12, 21, -13,
+ax_anim 2, 0, 165, 18, -4, 18, -4,
+ax_anim 1, 0, 166, 8, 0, 8, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -10, -9, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -19,
+ax_anim 3, 0, 162, 0, -21, 0, -23,
+ax_anim 2, 3, 163, 7, -18, 7, -19,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -8, 0, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -20, -12, -19,
+ax_anim 3, 0, 169, -21, -20, -21, -22,
+ax_anim 2, 3, 168, -21, -12, -21, -11,
+ax_anim 2, 0, 167, -18, -4, -18, -4,
+ax_anim 1, 0, 166, -8, 0, -8, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -3, -17, -3,
+ax_anim 3, 0, 168, -20, 2, -20, 0,
+ax_anim 2, 3, 167, -18, 7, -18, 6,
+ax_anim 2, 0, 166, -12, 8, -12, 8,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -18, 5, -18, 5,
+ax_anim 2, 0, 168, -21, 13, -21, 13,
+ax_anim 3, 0, 167, -21, 22, -21, 21,
+ax_anim 2, 3, 166, -11, 25, -11, 23,
+ax_anim 2, 0, 165, -4, 18, -4, 18,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 1, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 2, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 2, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 2, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 2, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 2, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 2, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkiploomAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkiploomGfx1:
+.incbin "baserom.gba", 0xD1D02C, 0x200
+sSkiploomSprites1:
+ax_sprite sSkiploomGfx1, 0x200
+ax_sprite_terminator
+sSkiploomGfx2:
+.incbin "baserom.gba", 0xD1D23C, 0x200
+sSkiploomSprites2:
+ax_sprite sSkiploomGfx2, 0x200
+ax_sprite_terminator
+sSkiploomGfx3:
+.incbin "baserom.gba", 0xD1D44C, 0x200
+sSkiploomSprites3:
+ax_sprite sSkiploomGfx3, 0x200
+ax_sprite_terminator
+sSkiploomGfx4:
+.incbin "baserom.gba", 0xD1D65C, 0x200
+sSkiploomSprites4:
+ax_sprite sSkiploomGfx4, 0x200
+ax_sprite_terminator
+sSkiploomGfx5:
+.incbin "baserom.gba", 0xD1D86C, 0x200
+sSkiploomSprites5:
+ax_sprite sSkiploomGfx5, 0x200
+ax_sprite_terminator
+sSkiploomGfx6:
+.incbin "baserom.gba", 0xD1DA7C, 0x200
+sSkiploomSprites6:
+ax_sprite sSkiploomGfx6, 0x200
+ax_sprite_terminator
+sSkiploomGfx7:
+.incbin "baserom.gba", 0xD1DC8C, 0x200
+sSkiploomSprites7:
+ax_sprite sSkiploomGfx7, 0x200
+ax_sprite_terminator
+sSkiploomGfx8:
+.incbin "baserom.gba", 0xD1DE9C, 0x200
+sSkiploomSprites8:
+ax_sprite sSkiploomGfx8, 0x200
+ax_sprite_terminator
+sSkiploomGfx9:
+.incbin "baserom.gba", 0xD1E0AC, 0x200
+sSkiploomSprites9:
+ax_sprite sSkiploomGfx9, 0x200
+ax_sprite_terminator
+sSkiploomGfx10:
+.incbin "baserom.gba", 0xD1E2BC, 0x200
+sSkiploomSprites10:
+ax_sprite sSkiploomGfx10, 0x200
+ax_sprite_terminator
+sSkiploomGfx11:
+.incbin "baserom.gba", 0xD1E4CC, 0x200
+sSkiploomSprites11:
+ax_sprite sSkiploomGfx11, 0x200
+ax_sprite_terminator
+sSkiploomGfx12:
+.incbin "baserom.gba", 0xD1E6DC, 0x200
+sSkiploomSprites12:
+ax_sprite sSkiploomGfx12, 0x200
+ax_sprite_terminator
+sSkiploomGfx13:
+.incbin "baserom.gba", 0xD1E8EC, 0x200
+sSkiploomSprites13:
+ax_sprite sSkiploomGfx13, 0x200
+ax_sprite_terminator
+sSkiploomGfx14:
+.incbin "baserom.gba", 0xD1EAFC, 0x200
+sSkiploomSprites14:
+ax_sprite sSkiploomGfx14, 0x200
+ax_sprite_terminator
+sSkiploomGfx15:
+.incbin "baserom.gba", 0xD1ED0C, 0x200
+sSkiploomSprites15:
+ax_sprite sSkiploomGfx15, 0x200
+ax_sprite_terminator
+sSkiploomGfx16:
+.incbin "baserom.gba", 0xD1EF1C, 0x60
+sSkiploomGfx16_1:
+.incbin "baserom.gba", 0xD1EF7C, 0xE0
+sSkiploomSprites16:
+ax_sprite sSkiploomGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx16_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx17:
+.incbin "baserom.gba", 0xD1F084, 0x60
+sSkiploomGfx17_1:
+.incbin "baserom.gba", 0xD1F0E4, 0xE0
+sSkiploomSprites17:
+ax_sprite sSkiploomGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx17_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx18:
+.incbin "baserom.gba", 0xD1F1EC, 0x60
+sSkiploomGfx18_1:
+.incbin "baserom.gba", 0xD1F24C, 0x60
+sSkiploomGfx18_2:
+.incbin "baserom.gba", 0xD1F2AC, 0x60
+sSkiploomSprites18:
+ax_sprite sSkiploomGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx19:
+.incbin "baserom.gba", 0xD1F344, 0x60
+sSkiploomGfx19_1:
+.incbin "baserom.gba", 0xD1F3A4, 0x60
+sSkiploomGfx19_2:
+.incbin "baserom.gba", 0xD1F404, 0x60
+sSkiploomSprites19:
+ax_sprite sSkiploomGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx20:
+.incbin "baserom.gba", 0xD1F49C, 0x60
+sSkiploomGfx20_1:
+.incbin "baserom.gba", 0xD1F4FC, 0xE0
+sSkiploomSprites20:
+ax_sprite sSkiploomGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx20_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx21:
+.incbin "baserom.gba", 0xD1F604, 0x60
+sSkiploomGfx21_1:
+.incbin "baserom.gba", 0xD1F664, 0xE0
+sSkiploomSprites21:
+ax_sprite sSkiploomGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx21_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx22:
+.incbin "baserom.gba", 0xD1F76C, 0x40
+sSkiploomGfx22_1:
+.incbin "baserom.gba", 0xD1F7AC, 0x100
+sSkiploomSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx22_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSkiploomGfx23:
+.incbin "baserom.gba", 0xD1F8DC, 0x40
+sSkiploomGfx23_1:
+.incbin "baserom.gba", 0xD1F91C, 0x60
+sSkiploomGfx23_2:
+.incbin "baserom.gba", 0xD1F97C, 0x60
+sSkiploomSprites23:
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx24:
+.incbin "baserom.gba", 0xD1FA1C, 0x60
+sSkiploomGfx24_1:
+.incbin "baserom.gba", 0xD1FA7C, 0xE0
+sSkiploomSprites24:
+ax_sprite sSkiploomGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx24_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx25:
+.incbin "baserom.gba", 0xD1FB84, 0x60
+sSkiploomGfx25_1:
+.incbin "baserom.gba", 0xD1FBE4, 0xE0
+sSkiploomSprites25:
+ax_sprite sSkiploomGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkiploomGfx25_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkiploomGfx26:
+.incbin "baserom.gba", 0xD1FCEC, 0x200
+sSkiploomSprites26:
+ax_sprite sSkiploomGfx26, 0x200
+ax_sprite_terminator
+sSkiploomGfx27:
+.incbin "baserom.gba", 0xD1FEFC, 0x200
+sSkiploomSprites27:
+ax_sprite sSkiploomGfx27, 0x200
+ax_sprite_terminator
+sSkiploomGfx28:
+.incbin "baserom.gba", 0xD2010C, 0x200
+sSkiploomSprites28:
+ax_sprite sSkiploomGfx28, 0x200
+ax_sprite_terminator
+sSkiploomGfx29:
+.incbin "baserom.gba", 0xD2031C, 0x200
+sSkiploomSprites29:
+ax_sprite sSkiploomGfx29, 0x200
+ax_sprite_terminator
+sSkiploomGfx30:
+.incbin "baserom.gba", 0xD2052C, 0x200
+sSkiploomSprites30:
+ax_sprite sSkiploomGfx30, 0x200
+ax_sprite_terminator
+sSkiploomGfx31:
+.incbin "baserom.gba", 0xD2073C, 0x200
+sSkiploomSprites31:
+ax_sprite sSkiploomGfx31, 0x200
+ax_sprite_terminator
+sSkiploomGfx32:
+.incbin "baserom.gba", 0xD2094C, 0x200
+sSkiploomSprites32:
+ax_sprite sSkiploomGfx32, 0x200
+ax_sprite_terminator
+sAxPosesSkiploom:
+.4byte sSkiploomPose1
+.4byte sSkiploomPose2
+.4byte sSkiploomPose3
+.4byte sSkiploomPose4
+.4byte sSkiploomPose5
+.4byte sSkiploomPose6
+.4byte sSkiploomPose7
+.4byte sSkiploomPose8
+.4byte sSkiploomPose9
+.4byte sSkiploomPose10
+.4byte sSkiploomPose11
+.4byte sSkiploomPose12
+.4byte sSkiploomPose13
+.4byte sSkiploomPose14
+.4byte sSkiploomPose15
+.4byte sSkiploomPose16
+.4byte sSkiploomPose17
+.4byte sSkiploomPose18
+.4byte sSkiploomPose19
+.4byte sSkiploomPose20
+.4byte sSkiploomPose21
+.4byte sSkiploomPose22
+.4byte sSkiploomPose23
+.4byte sSkiploomPose24
+.4byte sSkiploomPose25
+.4byte sSkiploomPose26
+.4byte sSkiploomPose27
+.4byte sSkiploomPose28
+.4byte sSkiploomPose29
+.4byte sSkiploomPose30
+.4byte sSkiploomPose31
+.4byte sSkiploomPose32
+.4byte sSkiploomPose33
+.4byte sSkiploomPose34
+.4byte sSkiploomPose35
+.4byte sSkiploomPose36
+.4byte sSkiploomPose37
+.4byte sSkiploomPose38
+.4byte sSkiploomPose39
+.4byte sSkiploomPose40
+.4byte sSkiploomPose41
+.4byte sSkiploomPose42
+.4byte sSkiploomPose43
+.4byte sSkiploomPose44
+.4byte sSkiploomPose45
+.4byte sSkiploomPose46
+.4byte sSkiploomPose47
+.4byte sSkiploomPose48
+.4byte sSkiploomPose49
+.4byte sSkiploomPose50
+.4byte sSkiploomPose51
+.4byte sSkiploomPose52
+.4byte sSkiploomPose53
+.4byte sSkiploomPose54
+.4byte sSkiploomPose55
+.4byte sSkiploomPose56
+.4byte sSkiploomPose57
+.4byte sSkiploomPose58
+.4byte sSkiploomPose59
+.4byte sSkiploomPose60
+.4byte sSkiploomPose61
+.4byte sSkiploomPose62
+.4byte sSkiploomPose63
+.4byte sSkiploomPose64
+.4byte sSkiploomPose65
+.4byte sSkiploomPose66
+.4byte sSkiploomPose67
+.4byte sSkiploomPose68
+.4byte sSkiploomPose69
+.4byte sSkiploomPose70
+.4byte sSkiploomPose71
+.4byte sSkiploomPose72
+.4byte sSkiploomPose73
+.4byte sSkiploomPose74
+.4byte sSkiploomPose75
+.4byte sSkiploomPose76
+.4byte sSkiploomPose77
+.4byte sSkiploomPose78
+.4byte sSkiploomPose79
+.4byte sSkiploomPose80
+.4byte sSkiploomPose81
+.4byte sSkiploomPose82
+.4byte sSkiploomPose83
+.4byte sSkiploomPose84
+.4byte sSkiploomPose85
+.4byte sSkiploomPose86
+.4byte sSkiploomPose87
+.4byte sSkiploomPose88
+.4byte sSkiploomPose89
+.4byte sSkiploomPose90
+.4byte sSkiploomPose91
+.4byte sSkiploomPose92
+.4byte sSkiploomPose93
+.4byte sSkiploomPose94
+.4byte sSkiploomPose95
+.4byte sSkiploomPose96
+.4byte sSkiploomPose97
+.4byte sSkiploomPose98
+.4byte sSkiploomPose99
+.4byte sSkiploomPose100
+.4byte sSkiploomPose101
+.4byte sSkiploomPose102
+.4byte sSkiploomPose103
+.4byte sSkiploomPose104
+.4byte sSkiploomPose105
+.4byte sSkiploomPose106
+.4byte sSkiploomPose107
+.4byte sSkiploomPose108
+.4byte sSkiploomPose109
+.4byte sSkiploomPose110
+.4byte sSkiploomPose111
+.4byte sSkiploomPose112
+.4byte sSkiploomPose113
+.4byte sSkiploomPose114
+.4byte sSkiploomPose115
+.4byte sSkiploomPose116
+.4byte sSkiploomPose117
+.4byte sSkiploomPose118
+.4byte sSkiploomPose119
+.4byte sSkiploomPose120
+.4byte sSkiploomPose121
+.4byte sSkiploomPose122
+.4byte sSkiploomPose123
+.4byte sSkiploomPose124
+.4byte sSkiploomPose125
+.4byte sSkiploomPose126
+.4byte sSkiploomPose127
+.4byte sSkiploomPose128
+.4byte sSkiploomPose129
+.4byte sSkiploomPose130
+.4byte sSkiploomPose131
+.4byte sSkiploomPose132
+.4byte sSkiploomPose133
+.4byte sSkiploomPose134
+.4byte sSkiploomPose135
+.4byte sSkiploomPose136
+.4byte sSkiploomPose137
+.4byte sSkiploomPose138
+.4byte sSkiploomPose139
+.4byte sSkiploomPose140
+.4byte sSkiploomPose141
+.4byte sSkiploomPose142
+.4byte sSkiploomPose143
+.4byte sSkiploomPose144
+.4byte sSkiploomPose145
+.4byte sSkiploomPose146
+.4byte sSkiploomPose147
+.4byte sSkiploomPose148
+.4byte sSkiploomPose149
+.4byte sSkiploomPose150
+.4byte sSkiploomPose151
+.4byte sSkiploomPose152
+.4byte sSkiploomPose153
+.4byte sSkiploomPose154
+.4byte sSkiploomPose155
+.4byte sSkiploomPose156
+.4byte sSkiploomPose157
+.4byte sSkiploomPose158
+.4byte sSkiploomPose159
+.4byte sSkiploomPose160
+.4byte sSkiploomPose161
+.4byte sSkiploomPose162
+.4byte sSkiploomPose163
+.4byte sSkiploomPose164
+.4byte sSkiploomPose165
+.4byte sSkiploomPose166
+.4byte sSkiploomPose167
+.4byte sSkiploomPose168
+.4byte sSkiploomPose169
+.4byte sSkiploomPose170
+.4byte sSkiploomPose171
+.4byte sSkiploomPose172
+.4byte sSkiploomPose173
+.4byte sSkiploomPose174
+.4byte sSkiploomPose175
+.4byte sSkiploomPose176
+.4byte sSkiploomPose177
+.4byte sSkiploomPose178
+.4byte sSkiploomPose179
+.4byte sSkiploomPose180
+.4byte sSkiploomPose181
+.4byte sSkiploomPose182
+.4byte sSkiploomPose183
+.4byte sSkiploomPose184
+.4byte sSkiploomPose185
+.4byte sSkiploomPose186
+.4byte sSkiploomPose187
+.4byte sSkiploomPose188
+.4byte sSkiploomPose189
+.4byte sSkiploomPose190
+.4byte sSkiploomPose191
+.4byte sSkiploomPose192
+.4byte sSkiploomPose193
+.4byte sSkiploomPose194
+.4byte sSkiploomPose195
+.4byte sSkiploomPose196
+.4byte sSkiploomPose197
+.4byte sSkiploomPose198
+.4byte sSkiploomPose199
+.4byte sSkiploomPose200
+.4byte sSkiploomPose201
+.4byte sSkiploomPose202
+.4byte sSkiploomPose203
+.4byte sSkiploomPose204
+.4byte sSkiploomPose205
+.4byte sSkiploomPose206
+.4byte sSkiploomPose207
+.4byte sSkiploomPose208
+.4byte sSkiploomPose209
+.4byte sSkiploomPose210
+.4byte sSkiploomPose211
+.4byte sSkiploomPose212
+.4byte sSkiploomPose213
+.4byte sSkiploomPose214
+.4byte sSkiploomPose215
+.4byte sSkiploomPose216
+.4byte sSkiploomPose217
+.4byte sSkiploomPose218
+sAxPositionsSkiploom:
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	  -1,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -2,  -10
+.2byte    3,  -11, 	   0,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    2,  -10, 	   0,  -10, 	   3,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -1,  -11, 	   2,  -10, 	   0,  -11
+.2byte    0,  -11, 	   3,   -8, 	  -4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte   -4,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -3,  -10, 	  -1,  -10, 	  -4,   -8, 	   0,  -10
+.2byte   -2,  -10, 	   0,  -11, 	  -3,  -10, 	  -1,  -11
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte   -1,   -6, 	  -3,   -4, 	   2,   -4, 	   0,   -8
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	  -1,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -2,  -10
+.2byte    6,   -8, 	   5,   -9, 	   5,   -5, 	  -1,  -11
+.2byte    3,  -11, 	   0,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    2,  -10, 	   0,  -10, 	   3,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -1,  -11, 	   2,  -10, 	   0,  -11
+.2byte    1,  -11, 	  -2,   -9, 	   1,   -8, 	  -1,  -11
+.2byte    0,  -11, 	   3,   -8, 	  -4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	   0,  -11
+.2byte   -4,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -3,  -10, 	  -1,  -10, 	  -4,   -8, 	   0,  -10
+.2byte   -2,  -10, 	   0,  -11, 	  -3,  -10, 	  -1,  -11
+.2byte   -2,  -11, 	   1,   -9, 	  -2,   -8, 	   0,  -11
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   1,  -10
+.2byte   -7,   -8, 	  -6,   -9, 	  -6,   -5, 	   0,  -11
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte   -1,   -6, 	  -3,   -4, 	   2,   -4, 	   0,   -8
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	  -1,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -2,  -10
+.2byte    6,   -8, 	   5,   -9, 	   5,   -5, 	  -1,  -11
+.2byte    3,  -11, 	   0,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    2,  -10, 	   0,  -10, 	   3,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -1,  -11, 	   2,  -10, 	   0,  -11
+.2byte    1,  -11, 	  -2,   -9, 	   1,   -8, 	  -1,  -11
+.2byte    0,  -11, 	   3,   -8, 	  -4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	   0,  -11
+.2byte   -4,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -3,  -10, 	  -1,  -10, 	  -4,   -8, 	   0,  -10
+.2byte   -2,  -10, 	   0,  -11, 	  -3,  -10, 	  -1,  -11
+.2byte   -2,  -11, 	   1,   -9, 	  -2,   -8, 	   0,  -11
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   1,  -10
+.2byte   -7,   -8, 	  -6,   -9, 	  -6,   -5, 	   0,  -11
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte   -1,   -7, 	  -6,   -6, 	   5,   -6, 	   0,   -9
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	  -1,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    2,   -7, 	   7,   -7, 	  -2,   -4, 	   0,  -11
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -2,  -10
+.2byte    6,   -8, 	   5,   -8, 	   4,   -5, 	  -1,  -12
+.2byte    3,  -11, 	   0,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    2,  -10, 	   0,  -10, 	   3,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -1,  -11, 	   2,  -10, 	   0,  -11
+.2byte    1,  -12, 	  -4,  -12, 	   5,   -9, 	  -1,  -13
+.2byte    0,  -11, 	   3,   -8, 	  -4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -14, 	   4,   -9, 	  -5,   -9, 	   0,  -12
+.2byte   -4,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -3,  -10, 	  -1,  -10, 	  -4,   -8, 	   0,  -10
+.2byte   -2,  -10, 	   0,  -11, 	  -3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	   3,  -12, 	  -6,   -9, 	   0,  -13
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   1,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -5,   -5, 	   0,  -12
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -3,   -7, 	  -8,   -7, 	   1,   -4, 	  -1,  -11
+.2byte   -1,   -6, 	  -3,   -4, 	   2,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -7,   -8, 	  -6,   -9, 	  -6,   -5, 	   0,  -11
+.2byte   -2,  -12, 	   1,  -10, 	  -2,   -9, 	   0,  -12
+.2byte    0,  -13, 	   2,   -8, 	  -3,   -8, 	   0,  -12
+.2byte    1,  -12, 	  -2,  -10, 	   1,   -9, 	  -1,  -12
+.2byte    6,   -8, 	   5,   -9, 	   5,   -5, 	  -1,  -11
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte   -1,   -6, 	  -4,   -4, 	   3,   -4, 	   0,  -10
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	   0,  -10
+.2byte    0,  -12, 	  -3,   -7, 	   2,   -7, 	  -1,  -12
+.2byte    2,  -14, 	   6,  -10, 	   1,   -9, 	   0,  -11
+.2byte    6,  -15, 	   6,  -14, 	   6,  -11, 	  -1,  -13
+.2byte    2,  -14, 	  -1,  -15, 	   5,  -12, 	  -2,  -12
+.2byte    0,  -12, 	   3,  -11, 	  -4,  -11, 	  -1,  -12
+.2byte   -3,  -14, 	   0,  -15, 	  -6,  -12, 	   1,  -12
+.2byte   -7,  -15, 	  -7,  -14, 	  -7,  -11, 	   0,  -13
+.2byte   -3,  -14, 	  -7,  -10, 	  -2,   -9, 	  -1,  -11
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	  -1,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -2,  -10
+.2byte    3,  -11, 	   0,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    2,  -10, 	   0,  -10, 	   3,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -1,  -11, 	   2,  -10, 	   0,  -11
+.2byte    0,  -11, 	   3,   -8, 	  -4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte   -4,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -3,  -10, 	  -1,  -10, 	  -4,   -8, 	   0,  -10
+.2byte   -2,  -10, 	   0,  -11, 	  -3,  -10, 	  -1,  -11
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -1,   -7, 	  -6,   -6, 	   5,   -6, 	   0,   -9
+.2byte   -3,   -7, 	  -8,   -7, 	   1,   -4, 	  -1,  -11
+.2byte   -7,   -8, 	  -6,   -8, 	  -5,   -5, 	   0,  -12
+.2byte   -2,  -11, 	   3,  -11, 	  -6,   -8, 	   0,  -12
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,  -11
+.2byte    1,  -11, 	  -4,  -11, 	   5,   -8, 	  -1,  -12
+.2byte    6,   -8, 	   5,   -8, 	   4,   -5, 	  -1,  -12
+.2byte    2,   -7, 	   7,   -7, 	  -2,   -4, 	   0,  -11
+.2byte   -1,   -7, 	  -6,   -6, 	   5,   -6, 	   0,   -9
+.2byte    2,   -7, 	   7,   -7, 	  -2,   -4, 	   0,  -11
+.2byte    6,   -8, 	   5,   -8, 	   4,   -5, 	  -1,  -12
+.2byte    1,  -11, 	  -4,  -11, 	   5,   -8, 	  -1,  -12
+.2byte    0,  -13, 	   4,   -8, 	  -5,   -8, 	   0,  -11
+.2byte   -2,  -11, 	   3,  -11, 	  -6,   -8, 	   0,  -12
+.2byte   -7,   -8, 	  -6,   -8, 	  -5,   -5, 	   0,  -12
+.2byte   -3,   -7, 	  -8,   -7, 	   1,   -4, 	  -1,  -11
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	  -1,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -2,  -10
+.2byte    3,  -11, 	   0,  -10, 	   4,   -8, 	  -1,  -10
+.2byte    2,  -10, 	   0,  -10, 	   3,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -1,  -11, 	   2,  -10, 	   0,  -11
+.2byte    0,  -11, 	   3,   -8, 	  -4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte    0,  -11, 	   3,  -10, 	  -4,  -10, 	   0,   -9
+.2byte   -4,  -11, 	  -1,  -10, 	  -5,   -8, 	   0,  -10
+.2byte   -3,  -10, 	  -1,  -10, 	  -4,   -8, 	   0,  -10
+.2byte   -2,  -10, 	   0,  -11, 	  -3,  -10, 	  -1,  -11
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	   0,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -1,   -6, 	  -3,   -4, 	   2,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -7,   -8, 	  -6,   -9, 	  -6,   -5, 	   0,  -11
+.2byte   -2,  -12, 	   1,  -10, 	  -2,   -9, 	   0,  -12
+.2byte    0,  -13, 	   2,   -8, 	  -3,   -8, 	   0,  -12
+.2byte    1,  -12, 	  -2,  -10, 	   1,   -9, 	  -1,  -12
+.2byte    6,   -8, 	   5,   -9, 	   5,   -5, 	  -1,  -11
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -4, 	   2,   -4, 	   0,  -10
+.2byte   -4,   -6, 	  -6,   -5, 	  -1,   -4, 	  -1,  -10
+.2byte   -7,   -8, 	  -6,   -8, 	  -6,   -5, 	   0,  -10
+.2byte   -4,  -12, 	  -1,  -11, 	  -5,   -9, 	   0,  -11
+.2byte    0,  -12, 	   3,   -9, 	  -4,   -9, 	  -1,  -10
+.2byte    3,  -12, 	   0,  -11, 	   4,   -9, 	  -1,  -11
+.2byte    6,   -8, 	   5,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    3,   -6, 	   5,   -5, 	   0,   -4, 	   0,  -10
+sSkiploomAnimTable1:
+.4byte sSkiploomAnims_1_1
+.4byte sSkiploomAnims_1_2
+.4byte sSkiploomAnims_1_3
+.4byte sSkiploomAnims_1_4
+.4byte sSkiploomAnims_1_5
+.4byte sSkiploomAnims_1_6
+.4byte sSkiploomAnims_1_7
+.4byte sSkiploomAnims_1_8
+sSkiploomAnimTable2:
+.4byte sSkiploomAnims_2_1
+.4byte sSkiploomAnims_2_2
+.4byte sSkiploomAnims_2_3
+.4byte sSkiploomAnims_2_4
+.4byte sSkiploomAnims_2_5
+.4byte sSkiploomAnims_2_6
+.4byte sSkiploomAnims_2_7
+.4byte sSkiploomAnims_2_8
+sSkiploomAnimTable3:
+.4byte sSkiploomAnims_3_1
+.4byte sSkiploomAnims_3_2
+.4byte sSkiploomAnims_3_3
+.4byte sSkiploomAnims_3_4
+.4byte sSkiploomAnims_3_5
+.4byte sSkiploomAnims_3_6
+.4byte sSkiploomAnims_3_7
+.4byte sSkiploomAnims_3_8
+sSkiploomAnimTable4:
+.4byte sSkiploomAnims_4_1
+.4byte sSkiploomAnims_4_2
+.4byte sSkiploomAnims_4_3
+.4byte sSkiploomAnims_4_4
+.4byte sSkiploomAnims_4_5
+.4byte sSkiploomAnims_4_6
+.4byte sSkiploomAnims_4_7
+.4byte sSkiploomAnims_4_8
+sSkiploomAnimTable5:
+.4byte sSkiploomAnims_5_1
+.4byte sSkiploomAnims_5_2
+.4byte sSkiploomAnims_5_3
+.4byte sSkiploomAnims_5_4
+.4byte sSkiploomAnims_5_5
+.4byte sSkiploomAnims_5_6
+.4byte sSkiploomAnims_5_7
+.4byte sSkiploomAnims_5_8
+sSkiploomAnimTable6:
+.4byte sSkiploomAnims_6_1
+.4byte sSkiploomAnims_6_1
+.4byte sSkiploomAnims_6_1
+.4byte sSkiploomAnims_6_1
+.4byte sSkiploomAnims_6_1
+.4byte sSkiploomAnims_6_1
+.4byte sSkiploomAnims_6_1
+.4byte sSkiploomAnims_6_1
+sSkiploomAnimTable7:
+.4byte sSkiploomAnims_7_1
+.4byte sSkiploomAnims_7_2
+.4byte sSkiploomAnims_7_3
+.4byte sSkiploomAnims_7_4
+.4byte sSkiploomAnims_7_5
+.4byte sSkiploomAnims_7_6
+.4byte sSkiploomAnims_7_7
+.4byte sSkiploomAnims_7_8
+sSkiploomAnimTable8:
+.4byte sSkiploomAnims_8_1
+.4byte sSkiploomAnims_8_2
+.4byte sSkiploomAnims_8_3
+.4byte sSkiploomAnims_8_4
+.4byte sSkiploomAnims_8_5
+.4byte sSkiploomAnims_8_6
+.4byte sSkiploomAnims_8_7
+.4byte sSkiploomAnims_8_8
+sSkiploomAnimTable9:
+.4byte sSkiploomAnims_9_1
+.4byte sSkiploomAnims_9_2
+.4byte sSkiploomAnims_9_3
+.4byte sSkiploomAnims_9_4
+.4byte sSkiploomAnims_9_5
+.4byte sSkiploomAnims_9_6
+.4byte sSkiploomAnims_9_7
+.4byte sSkiploomAnims_9_8
+sSkiploomAnimTable10:
+.4byte sSkiploomAnims_10_1
+.4byte sSkiploomAnims_10_2
+.4byte sSkiploomAnims_10_3
+.4byte sSkiploomAnims_10_4
+.4byte sSkiploomAnims_10_5
+.4byte sSkiploomAnims_10_6
+.4byte sSkiploomAnims_10_7
+.4byte sSkiploomAnims_10_8
+sSkiploomAnimTable11:
+.4byte sSkiploomAnims_11_1
+.4byte sSkiploomAnims_11_2
+.4byte sSkiploomAnims_11_3
+.4byte sSkiploomAnims_11_4
+.4byte sSkiploomAnims_11_5
+.4byte sSkiploomAnims_11_6
+.4byte sSkiploomAnims_11_7
+.4byte sSkiploomAnims_11_8
+sSkiploomAnimTable12:
+.4byte sSkiploomAnims_12_1
+.4byte sSkiploomAnims_12_2
+.4byte sSkiploomAnims_12_3
+.4byte sSkiploomAnims_12_4
+.4byte sSkiploomAnims_12_5
+.4byte sSkiploomAnims_12_6
+.4byte sSkiploomAnims_12_7
+.4byte sSkiploomAnims_12_8
+sSkiploomAnimTable13:
+.4byte sSkiploomAnims_13_1
+.4byte sSkiploomAnims_13_2
+.4byte sSkiploomAnims_13_3
+.4byte sSkiploomAnims_13_4
+.4byte sSkiploomAnims_13_5
+.4byte sSkiploomAnims_13_6
+.4byte sSkiploomAnims_13_7
+.4byte sSkiploomAnims_13_8
+sAxAnimationsSkiploom:
+.4byte sSkiploomAnimTable1
+.4byte sSkiploomAnimTable2
+.4byte sSkiploomAnimTable3
+.4byte sSkiploomAnimTable4
+.4byte sSkiploomAnimTable5
+.4byte sSkiploomAnimTable6
+.4byte sSkiploomAnimTable7
+.4byte sSkiploomAnimTable8
+.4byte sSkiploomAnimTable9
+.4byte sSkiploomAnimTable10
+.4byte sSkiploomAnimTable11
+.4byte sSkiploomAnimTable12
+.4byte sSkiploomAnimTable13
+sAxSpritesSkiploom:
+.4byte sSkiploomSprites1
+.4byte sSkiploomSprites2
+.4byte sSkiploomSprites3
+.4byte sSkiploomSprites4
+.4byte sSkiploomSprites5
+.4byte sSkiploomSprites6
+.4byte sSkiploomSprites7
+.4byte sSkiploomSprites8
+.4byte sSkiploomSprites9
+.4byte sSkiploomSprites10
+.4byte sSkiploomSprites11
+.4byte sSkiploomSprites12
+.4byte sSkiploomSprites13
+.4byte sSkiploomSprites14
+.4byte sSkiploomSprites15
+.4byte sSkiploomSprites16
+.4byte sSkiploomSprites17
+.4byte sSkiploomSprites18
+.4byte sSkiploomSprites19
+.4byte sSkiploomSprites20
+.4byte sSkiploomSprites21
+.4byte sSkiploomSprites22
+.4byte sSkiploomSprites23
+.4byte sSkiploomSprites24
+.4byte sSkiploomSprites25
+.4byte sSkiploomSprites26
+.4byte sSkiploomSprites27
+.4byte sSkiploomSprites28
+.4byte sSkiploomSprites29
+.4byte sSkiploomSprites30
+.4byte sSkiploomSprites31
+.4byte sSkiploomSprites32
+sAxMainSkiploom:
+ax_main sAxPosesSkiploom, sAxAnimationsSkiploom, 13, sAxSpritesSkiploom, sAxPositionsSkiploom

--- a/data/ax/skitty.inc
+++ b/data/ax/skitty.inc
@@ -1,0 +1,3952 @@
+.global gAxSkitty
+gAxSkitty:
+ax_siro sAxMainSkitty
+sSkittyPose1:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose2:
+ax_pose 1, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose3:
+ax_pose 2, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose4:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose5:
+ax_pose 4, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose6:
+ax_pose 5, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose7:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose8:
+ax_pose 7, 0x01e8, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose9:
+ax_pose 8, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose10:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose11:
+ax_pose 10, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose12:
+ax_pose 11, 0x01ee, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose13:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose14:
+ax_pose 13, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose15:
+ax_pose 14, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose16:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose17:
+ax_pose 10, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose18:
+ax_pose 11, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose19:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose20:
+ax_pose 7, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose21:
+ax_pose 8, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose22:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose23:
+ax_pose 4, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose24:
+ax_pose 5, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose25:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose26:
+ax_pose 1, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose27:
+ax_pose 2, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose28:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose29:
+ax_pose 4, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose30:
+ax_pose 5, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose31:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose32:
+ax_pose 7, 0x01e8, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose33:
+ax_pose 8, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose34:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose35:
+ax_pose 10, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose36:
+ax_pose 11, 0x01ee, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose37:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose38:
+ax_pose 13, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose39:
+ax_pose 14, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose40:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose41:
+ax_pose 10, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose42:
+ax_pose 11, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose43:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose44:
+ax_pose 7, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose45:
+ax_pose 8, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose46:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose47:
+ax_pose 4, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose48:
+ax_pose 5, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose49:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose50:
+ax_pose 1, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose51:
+ax_pose 2, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose52:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose53:
+ax_pose 4, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose54:
+ax_pose 5, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose55:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose56:
+ax_pose 7, 0x01e8, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose57:
+ax_pose 8, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose58:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose59:
+ax_pose 10, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose60:
+ax_pose 11, 0x01ee, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose61:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose62:
+ax_pose 13, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose63:
+ax_pose 14, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose64:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose65:
+ax_pose 10, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose66:
+ax_pose 11, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose67:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose68:
+ax_pose 7, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose69:
+ax_pose 8, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose70:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose71:
+ax_pose 4, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose72:
+ax_pose 5, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose73:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose74:
+ax_pose 15, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose75:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose76:
+ax_pose 16, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose77:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose78:
+ax_pose 17, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose79:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose80:
+ax_pose 18, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose81:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose82:
+ax_pose 19, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose83:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose84:
+ax_pose 18, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose85:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose86:
+ax_pose 17, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose87:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose88:
+ax_pose 16, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose89:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose90:
+ax_pose 1, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose91:
+ax_pose 2, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose92:
+ax_pose 20, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose93:
+ax_pose 21, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose94:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose95:
+ax_pose 4, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose96:
+ax_pose 5, 0x01e4, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose97:
+ax_pose 22, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose98:
+ax_pose 23, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose99:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose100:
+ax_pose 7, 0x01e8, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose101:
+ax_pose 8, 0x01e5, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose102:
+ax_pose 24, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose103:
+ax_pose 25, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose104:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose105:
+ax_pose 10, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose106:
+ax_pose 11, 0x01ec, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose107:
+ax_pose 26, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose108:
+ax_pose 27, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose109:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose110:
+ax_pose 13, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose111:
+ax_pose 14, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose112:
+ax_pose 28, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose113:
+ax_pose 29, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose114:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose115:
+ax_pose 10, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose116:
+ax_pose 11, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose117:
+ax_pose 26, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose118:
+ax_pose 27, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose119:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose120:
+ax_pose 7, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose121:
+ax_pose 8, 0x01e5, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose122:
+ax_pose 24, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose123:
+ax_pose 25, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose124:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose125:
+ax_pose 4, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose126:
+ax_pose 5, 0x01e4, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose127:
+ax_pose 22, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose128:
+ax_pose 23, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose129:
+ax_pose 30, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sSkittyPose130:
+ax_pose 31, 0x01eb, 0x80f5, 0xbc00
+ax_pose_terminator
+sSkittyPose131:
+ax_pose 32, 0x01e1, 0x80f1, 0xbc00
+ax_pose_terminator
+sSkittyPose132:
+ax_pose 33, 0x01e7, 0x90eb, 0xbc00
+ax_pose_terminator
+sSkittyPose133:
+ax_pose 34, 0x01e7, 0x90ea, 0xbc00
+ax_pose_terminator
+sSkittyPose134:
+ax_pose 35, 0x01eb, 0x90e6, 0xbc00
+ax_pose_terminator
+sSkittyPose135:
+ax_pose 36, 0x01e8, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose136:
+ax_pose 35, 0x01eb, 0x80fb, 0xbc00
+ax_pose_terminator
+sSkittyPose137:
+ax_pose 34, 0x01e7, 0x80f7, 0xbc00
+ax_pose_terminator
+sSkittyPose138:
+ax_pose 33, 0x01e7, 0x80f6, 0xbc00
+ax_pose_terminator
+sSkittyPose139:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose140:
+ax_pose 15, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose141:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose142:
+ax_pose 16, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose143:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose144:
+ax_pose 17, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose145:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose146:
+ax_pose 18, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose147:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose148:
+ax_pose 19, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose149:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose150:
+ax_pose 18, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose151:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose152:
+ax_pose 17, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose153:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose154:
+ax_pose 16, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose155:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose156:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose157:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose158:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose159:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose160:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose161:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose162:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose163:
+ax_pose 15, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose164:
+ax_pose 16, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose165:
+ax_pose 17, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose166:
+ax_pose 18, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose167:
+ax_pose 19, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose168:
+ax_pose 18, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose169:
+ax_pose 17, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose170:
+ax_pose 16, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose171:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose172:
+ax_pose 1, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose173:
+ax_pose 2, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose174:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose175:
+ax_pose 4, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose176:
+ax_pose 5, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose177:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose178:
+ax_pose 7, 0x01e8, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose179:
+ax_pose 8, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose180:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose181:
+ax_pose 10, 0x01e6, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose182:
+ax_pose 11, 0x01ee, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose183:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose184:
+ax_pose 13, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose185:
+ax_pose 14, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose186:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose187:
+ax_pose 10, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose188:
+ax_pose 11, 0x01ee, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose189:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose190:
+ax_pose 7, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose191:
+ax_pose 8, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose192:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose193:
+ax_pose 4, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose194:
+ax_pose 5, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose195:
+ax_pose 15, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose196:
+ax_pose 16, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose197:
+ax_pose 17, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose198:
+ax_pose 18, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose199:
+ax_pose 19, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose200:
+ax_pose 18, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose201:
+ax_pose 17, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose202:
+ax_pose 16, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose203:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose204:
+ax_pose 3, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose205:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose206:
+ax_pose 9, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose207:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose208:
+ax_pose 9, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose209:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose210:
+ax_pose 3, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose211:
+ax_pose 37, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose212:
+ax_pose 38, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose213:
+ax_pose 37, 0x01f0, 0x90f0, 0xbc00
+ax_pose_terminator
+sSkittyPose214:
+ax_pose 38, 0x01f0, 0x90f0, 0xbc00
+ax_pose_terminator
+sSkittyPose215:
+ax_pose 37, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose216:
+ax_pose 39, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose217:
+ax_pose 40, 0x01f0, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose218:
+ax_pose 41, 0x01ec, 0x80f2, 0xbc00
+ax_pose_terminator
+sSkittyPose219:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose220:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose221:
+ax_pose 42, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose222:
+ax_pose 43, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose223:
+ax_pose 44, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose224:
+ax_pose 45, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose225:
+ax_pose 46, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose226:
+ax_pose 47, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose227:
+ax_pose 48, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose228:
+ax_pose 49, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose229:
+ax_pose 50, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose230:
+ax_pose 50, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose231:
+ax_pose 51, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose232:
+ax_pose 52, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose233:
+ax_pose 53, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose234:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose235:
+ax_pose 54, 0x01e7, 0x80f2, 0xbc00
+ax_pose_terminator
+sSkittyPose236:
+ax_pose 55, 0x01e7, 0x80f4, 0xbc00
+ax_pose_terminator
+sSkittyPose237:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose238:
+ax_pose 56, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose239:
+ax_pose 57, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose240:
+ax_pose 0, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose241:
+ax_pose 45, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose242:
+ax_pose 58, 0x01e6, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose243:
+ax_pose 6, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose244:
+ax_pose 59, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose245:
+ax_pose 6, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose246:
+ax_pose 59, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose247:
+ax_pose 12, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose248:
+ax_pose 60, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose249:
+ax_pose 61, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose250:
+ax_pose 62, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose251:
+ax_pose 63, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose252:
+ax_pose 64, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose253:
+ax_pose 65, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSkittyPose254:
+ax_pose 61, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose255:
+ax_pose 62, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose256:
+ax_pose 63, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose257:
+ax_pose 64, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose258:
+ax_pose 65, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSkittyPose259:
+ax_pose 66, 0x01e8, 0x90f0, 0xbc00
+ax_pose_terminator
+sSkittyPose260:
+ax_pose 37, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose261:
+ax_pose 38, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose262:
+ax_pose 37, 0x01f0, 0x90f0, 0xbc00
+ax_pose_terminator
+sSkittyPose263:
+ax_pose 38, 0x01f0, 0x90f0, 0xbc00
+ax_pose_terminator
+sSkittyPose264:
+ax_pose 37, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose265:
+ax_pose 38, 0x01f0, 0x80f0, 0xbc00
+ax_pose_terminator
+sSkittyPose266:
+ax_pose 37, 0x01f0, 0x90f0, 0xbc00
+ax_pose_terminator
+sSkittyPose267:
+ax_pose 38, 0x01f0, 0x90f0, 0xbc00
+ax_pose_terminator
+.align 2
+sSkittyAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 5, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 1,
+ax_anim 6, 0, 2, 0, -2, 0, 2,
+ax_anim 6, 0, 2, 0, 1, 0, 2,
+ax_anim 5, 0, 2, 0, 2, 0, 3,
+ax_anim 4, 0, 0, 0, 1, 0, 1,
+ax_anim_terminator
+sSkittyAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 5, 0, 4, 2, 2, 1, 1,
+ax_anim 6, 0, 4, 4, 3, 2, 2,
+ax_anim 6, 0, 5, 4, -3, 3, 3,
+ax_anim 6, 0, 5, 4, 0, 3, 3,
+ax_anim 5, 0, 5, 4, 2, 4, 4,
+ax_anim 4, 0, 3, 2, 1, 2, 2,
+ax_anim_terminator
+sSkittyAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 5, 0, 7, 1, 0, 1, 0,
+ax_anim 6, 0, 7, 2, 0, 2, 0,
+ax_anim 6, 0, 8, 2, -5, 3, 0,
+ax_anim 6, 0, 8, 3, -3, 3, 0,
+ax_anim 5, 0, 8, 4, -2, 4, 0,
+ax_anim 4, 0, 6, 2, 0, 2, 0,
+ax_anim_terminator
+sSkittyAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 5, 0, 10, 1, 0, 1, -1,
+ax_anim 6, 0, 10, 2, -1, 2, -2,
+ax_anim 6, 0, 11, 3, -8, 3, -3,
+ax_anim 6, 0, 11, 4, -6, 3, -3,
+ax_anim 5, 0, 11, 4, -4, 4, -4,
+ax_anim 4, 0, 9, 2, 0, 2, -2,
+ax_anim_terminator
+sSkittyAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 5, 0, 13, 0, 0, 0, -1,
+ax_anim 6, 0, 13, 0, -1, 0, -2,
+ax_anim 6, 0, 12, 0, -4, 0, -3,
+ax_anim 6, 0, 14, 0, -5, 0, -3,
+ax_anim 5, 0, 14, 0, -3, 0, -4,
+ax_anim 4, 0, 12, 0, -1, 0, -2,
+ax_anim_terminator
+sSkittyAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 5, 0, 16, -1, 0, -1, -1,
+ax_anim 6, 0, 16, -2, -1, -2, -2,
+ax_anim 6, 0, 17, -3, -8, -3, -3,
+ax_anim 6, 0, 17, -4, -6, -3, -3,
+ax_anim 5, 0, 17, -4, -4, -4, -4,
+ax_anim 4, 0, 15, -2, 0, -2, -2,
+ax_anim_terminator
+sSkittyAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 5, 0, 19, -1, 0, -1, 0,
+ax_anim 6, 0, 19, -2, 0, -2, 0,
+ax_anim 6, 0, 20, -2, -5, -3, 0,
+ax_anim 6, 0, 20, -3, -3, -3, 0,
+ax_anim 5, 0, 20, -4, -2, -4, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim_terminator
+sSkittyAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 5, 0, 22, -2, 2, -1, 1,
+ax_anim 6, 0, 22, -4, 3, -2, 2,
+ax_anim 6, 0, 23, -4, -3, -3, 3,
+ax_anim 6, 0, 23, -4, 0, -3, 3,
+ax_anim 5, 0, 23, -4, 2, -4, 4,
+ax_anim 4, 0, 21, -2, 1, -2, 2,
+ax_anim_terminator
+.align 2
+sSkittyAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, 2, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSkittyAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 1, 4, 4,
+ax_anim 2, 2, 29, 12, 4, 10, 8,
+ax_anim 2, 0, 29, 19, 16, 19, 16,
+ax_anim 2, 1, 29, 20, 15, 20, 15,
+ax_anim 2, 0, 29, 19, 16, 19, 16,
+ax_anim 2, 0, 29, 20, 15, 20, 15,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sSkittyAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 2, 0, 31, 4, -3, 4, 0,
+ax_anim 2, 2, 32, 10, -4, 10, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSkittyAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 0, -3, 0, -1,
+ax_anim 2, 0, 34, 4, -10, 4, -6,
+ax_anim 2, 2, 35, 11, -20, 11, -15,
+ax_anim 2, 0, 35, 20, -25, 20, -25,
+ax_anim 2, 1, 35, 21, -24, 21, -24,
+ax_anim 2, 0, 35, 20, -25, 20, -25,
+ax_anim 2, 0, 35, 21, -24, 21, -24,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSkittyAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -6, 0, -4,
+ax_anim 2, 2, 38, 0, -18, 0, -11,
+ax_anim 2, 0, 38, 0, -25, 0, -25,
+ax_anim 2, 1, 38, 1, -25, 1, -25,
+ax_anim 2, 0, 38, 0, -25, 0, -25,
+ax_anim 2, 0, 38, 1, -25, 1, -25,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSkittyAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, 0, -3, 0, -1,
+ax_anim 2, 0, 40, -4, -10, -4, -6,
+ax_anim 2, 2, 41, -11, -20, -11, -15,
+ax_anim 2, 0, 41, -20, -25, -20, -25,
+ax_anim 2, 1, 41, -21, -24, -21, -24,
+ax_anim 2, 0, 41, -20, -25, -20, -25,
+ax_anim 2, 0, 41, -21, -24, -21, -24,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSkittyAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 0, -1, 0, 0,
+ax_anim 2, 0, 43, -4, -3, -4, 0,
+ax_anim 2, 2, 44, -10, -4, -10, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSkittyAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 46, -4, 1, -4, 4,
+ax_anim 2, 2, 47, -12, 4, -10, 8,
+ax_anim 2, 0, 47, -19, 16, -19, 16,
+ax_anim 2, 1, 47, -20, 15, -20, 15,
+ax_anim 2, 0, 47, -19, 16, -19, 16,
+ax_anim 2, 0, 47, -20, 15, -20, 15,
+ax_anim 4, 0, 45, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sSkittyAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, 2, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSkittyAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 4, 1, 4, 4,
+ax_anim 2, 2, 53, 12, 4, 10, 8,
+ax_anim 2, 0, 53, 19, 16, 19, 16,
+ax_anim 2, 1, 53, 20, 15, 20, 15,
+ax_anim 2, 0, 53, 19, 16, 19, 16,
+ax_anim 2, 0, 53, 20, 15, 20, 15,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sSkittyAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 0, -1, 0, 0,
+ax_anim 2, 0, 55, 4, -3, 4, 0,
+ax_anim 2, 2, 56, 10, -4, 10, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSkittyAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 0, -3, 0, -1,
+ax_anim 2, 0, 58, 4, -10, 4, -6,
+ax_anim 2, 2, 59, 11, -20, 11, -15,
+ax_anim 2, 0, 59, 20, -25, 20, -25,
+ax_anim 2, 1, 59, 21, -24, 21, -24,
+ax_anim 2, 0, 59, 20, -25, 20, -25,
+ax_anim 2, 0, 59, 21, -24, 21, -24,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSkittyAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -6, 0, -4,
+ax_anim 2, 2, 62, 0, -18, 0, -11,
+ax_anim 2, 0, 62, 0, -25, 0, -25,
+ax_anim 2, 1, 62, 1, -25, 1, -25,
+ax_anim 2, 0, 62, 0, -25, 0, -25,
+ax_anim 2, 0, 62, 1, -25, 1, -25,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSkittyAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, 0, -3, 0, -1,
+ax_anim 2, 0, 64, -4, -10, -4, -6,
+ax_anim 2, 2, 65, -11, -20, -11, -15,
+ax_anim 2, 0, 65, -20, -25, -20, -25,
+ax_anim 2, 1, 65, -21, -24, -21, -24,
+ax_anim 2, 0, 65, -20, -25, -20, -25,
+ax_anim 2, 0, 65, -21, -24, -21, -24,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSkittyAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 0, -1, 0, 0,
+ax_anim 2, 0, 67, -4, -3, -4, 0,
+ax_anim 2, 2, 68, -10, -4, -10, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSkittyAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 70, -4, 1, -4, 4,
+ax_anim 2, 2, 71, -12, 4, -10, 8,
+ax_anim 2, 0, 71, -19, 16, -19, 16,
+ax_anim 2, 1, 71, -20, 15, -20, 15,
+ax_anim 2, 0, 71, -19, 16, -19, 16,
+ax_anim 2, 0, 71, -20, 15, -20, 15,
+ax_anim 4, 0, 69, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sSkittyAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 6, 2, 72, 0, -3, 0, -3,
+ax_anim 1, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 1, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 2, 0, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 2, 0, 73, 0, 5, 0, 5,
+ax_anim 2, 0, 73, -1, 5, -1, 5,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sSkittyAnims_4_2:
+ax_anim 2, 0, 74, -2, -2, -2, -2,
+ax_anim 6, 2, 74, -3, -3, -3, -3,
+ax_anim 1, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim 2, 1, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 6, 4, 6, 4,
+ax_anim 2, 0, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 6, 4, 6, 4,
+ax_anim 2, 0, 75, 5, 5, 5, 5,
+ax_anim 2, 0, 75, 6, 4, 6, 4,
+ax_anim 4, 0, 74, 2, 2, 2, 2,
+ax_anim_terminator
+sSkittyAnims_4_3:
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 6, 2, 76, -3, 0, -3, 0,
+ax_anim 1, 0, 77, -1, 0, -1, 0,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 1, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 5, 1, 5, 1,
+ax_anim 2, 0, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 5, 1, 5, 1,
+ax_anim 2, 0, 77, 5, 0, 5, 0,
+ax_anim 2, 0, 77, 5, 1, 5, 1,
+ax_anim 4, 0, 76, 2, 0, 2, 0,
+ax_anim_terminator
+sSkittyAnims_4_4:
+ax_anim 2, 0, 78, -2, 2, -2, 2,
+ax_anim 6, 2, 78, -3, 3, -3, 3,
+ax_anim 1, 0, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 79, 2, -2, 2, -2,
+ax_anim 2, 1, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 6, -4, 6, -4,
+ax_anim 2, 0, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 6, -4, 6, -4,
+ax_anim 2, 0, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 6, -4, 6, -4,
+ax_anim 4, 0, 78, 2, -2, 2, -2,
+ax_anim_terminator
+sSkittyAnims_4_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 6, 2, 80, 0, 3, 0, 3,
+ax_anim 1, 0, 81, 0, 1, 0, 1,
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 2, 1, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 81, -1, -5, -1, -5,
+ax_anim 2, 0, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 81, -1, -5, -1, -5,
+ax_anim 2, 0, 81, 0, -5, 0, -5,
+ax_anim 2, 0, 81, -1, -5, -1, -5,
+ax_anim 4, 0, 80, 0, -2, 0, -2,
+ax_anim_terminator
+sSkittyAnims_4_6:
+ax_anim 2, 0, 82, 2, 2, 2, 2,
+ax_anim 6, 2, 82, 3, 3, 3, 3,
+ax_anim 1, 0, 83, 1, 1, 1, 1,
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 2, 1, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 83, -6, -4, -6, -4,
+ax_anim 2, 0, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 83, -6, -4, -6, -4,
+ax_anim 2, 0, 83, -5, -5, -5, -5,
+ax_anim 2, 0, 83, -6, -4, -6, -4,
+ax_anim 4, 0, 82, -2, -2, -2, -2,
+ax_anim_terminator
+sSkittyAnims_4_7:
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 6, 2, 84, 3, 0, 3, 0,
+ax_anim 1, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, -2, 0, -2, 0,
+ax_anim 2, 1, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 85, -5, 1, -5, 1,
+ax_anim 2, 0, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 85, -5, 1, -5, 1,
+ax_anim 2, 0, 85, -5, 0, -5, 0,
+ax_anim 2, 0, 85, -5, 1, -5, 1,
+ax_anim 4, 0, 84, -2, 0, -2, 0,
+ax_anim_terminator
+sSkittyAnims_4_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 6, 2, 86, 3, -3, 3, -3,
+ax_anim 1, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, -2, 2, -2, 2,
+ax_anim 2, 1, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 87, -6, 4, -6, 4,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 87, -6, 4, -6, 4,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim 2, 0, 87, -6, 4, -6, 4,
+ax_anim 4, 0, 86, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSkittyAnims_5_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 6, 0, 88, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 90, 0, 2, 0, 2,
+ax_anim 4, 0, 91, 0, 5, 0, 4,
+ax_anim 4, 2, 92, 0, 5, 0, 4,
+ax_anim 4, 0, 91, 0, 5, 0, 4,
+ax_anim 4, 0, 92, 0, 5, 0, 4,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sSkittyAnims_5_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 0, 93, -3, -3, -3, -3,
+ax_anim 1, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, 2, 2, 2, 2,
+ax_anim 4, 0, 96, 5, 5, 5, 5,
+ax_anim 4, 2, 97, 5, 5, 5, 5,
+ax_anim 4, 0, 96, 5, 5, 5, 5,
+ax_anim 4, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sSkittyAnims_5_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 6, 0, 98, -3, 0, -3, 0,
+ax_anim 1, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 4, 0, 101, 5, 0, 5, 0,
+ax_anim 4, 2, 102, 5, 0, 5, 0,
+ax_anim 4, 0, 101, 5, 0, 5, 0,
+ax_anim 4, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sSkittyAnims_5_4:
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 6, 0, 103, -3, 3, -3, 3,
+ax_anim 1, 0, 105, -3, 3, -3, 3,
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 4, 0, 106, 5, -5, 5, -5,
+ax_anim 4, 2, 107, 5, -5, 5, -5,
+ax_anim 4, 0, 106, 5, -5, 5, -5,
+ax_anim 4, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sSkittyAnims_5_5:
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim 6, 0, 108, 0, 3, 0, 3,
+ax_anim 1, 0, 110, 0, 3, 0, 3,
+ax_anim 2, 0, 110, 0, -2, 0, -2,
+ax_anim 4, 0, 111, 0, -5, 0, -4,
+ax_anim 4, 2, 112, 0, -5, 0, -4,
+ax_anim 4, 0, 111, 0, -5, 0, -4,
+ax_anim 4, 0, 112, 0, -5, 0, -4,
+ax_anim 2, 0, 108, 0, -2, 0, -2,
+ax_anim_terminator
+sSkittyAnims_5_6:
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 6, 0, 113, 3, 3, 3, 3,
+ax_anim 1, 0, 115, 3, 3, 3, 3,
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 4, 0, 116, -5, -5, -5, -5,
+ax_anim 4, 2, 117, -5, -5, -5, -5,
+ax_anim 4, 0, 116, -5, -5, -5, -5,
+ax_anim 4, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sSkittyAnims_5_7:
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 6, 0, 118, 3, 0, 3, 0,
+ax_anim 1, 0, 120, 3, 0, 3, 0,
+ax_anim 2, 0, 120, -2, 0, -2, 0,
+ax_anim 4, 0, 121, -5, 0, -5, 0,
+ax_anim 4, 2, 122, -5, 0, -5, 0,
+ax_anim 4, 0, 121, -5, 0, -5, 0,
+ax_anim 4, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sSkittyAnims_5_8:
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 6, 0, 123, 3, -3, 3, -3,
+ax_anim 1, 0, 125, 3, -3, 3, -3,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 4, 0, 126, -5, 5, -5, 5,
+ax_anim 4, 2, 127, -5, 5, -5, 5,
+ax_anim 4, 0, 126, -5, 5, -5, 5,
+ax_anim 4, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSkittyAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sSkittyAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sSkittyAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sSkittyAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sSkittyAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sSkittyAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sSkittyAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sSkittyAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSkittyAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, -1, 0, 0,
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, -1, 0, 0,
+ax_anim_terminator
+sSkittyAnims_8_2:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_8_3:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_8_4:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_8_5:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_8_6:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_8_7:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_8_8:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, 0, 0, 0,
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 19, 7, 19,
+ax_anim 3, 0, 158, 0, 22, 0, 22,
+ax_anim 2, 3, 159, -7, 19, -7, 19,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 24, 9, 24, 9,
+ax_anim 3, 0, 157, 23, 21, 23, 21,
+ax_anim 2, 3, 158, 11, 21, 11, 21,
+ax_anim 2, 0, 159, 2, 12, 2, 12,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -4, 3, -4,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 19, -4, 19, -4,
+ax_anim 3, 0, 156, 23, 1, 23, 1,
+ax_anim 2, 3, 157, 19, 5, 19, 5,
+ax_anim 2, 0, 158, 12, 7, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 3, -17, 3, -17,
+ax_anim 2, 0, 154, 10, -22, 10, -22,
+ax_anim 3, 0, 155, 18, -24, 18, -24,
+ax_anim 2, 3, 156, 21, -15, 21, -15,
+ax_anim 2, 0, 157, 16, -6, 16, -6,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -8, -10, -8, -10,
+ax_anim 2, 0, 161, -7, -20, -7, -20,
+ax_anim 3, 0, 154, 0, -25, 0, -25,
+ax_anim 2, 3, 155, 7, -20, 7, -20,
+ax_anim 2, 0, 156, 8, -8, 8, -8,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -3, -17, -3, -17,
+ax_anim 2, 0, 154, -10, -22, -10, -22,
+ax_anim 3, 0, 161, -17, -24, -17, -24,
+ax_anim 2, 3, 160, -21, -15, -21, -15,
+ax_anim 2, 0, 159, -16, -6, -16, -6,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -4, -3, -4,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -19, -4, -19, -4,
+ax_anim 3, 0, 160, -23, 1, -23, 1,
+ax_anim 2, 3, 159, -19, 5, -19, 5,
+ax_anim 2, 0, 158, -12, 7, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -24, 9, -24, 9,
+ax_anim 3, 0, 159, -23, 21, -23, 16,
+ax_anim 2, 3, 158, -11, 21, -11, 16,
+ax_anim 2, 0, 157, -2, 12, -4, 12,
+ax_anim 1, 0, 156, 0, 7, -3, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_14_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_14_2:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_14_3:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_14_4:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_14_5:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_14_6:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_14_7:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_14_8:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 35, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_15_1:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_15_2:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_15_3:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_15_4:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_15_5:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_15_6:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_15_7:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_15_8:
+ax_anim 8, 0, 214, 0, 0, 0, 0,
+ax_anim 16, 0, 215, 0, 0, 0, 0,
+ax_anim 4, 0, 216, 0, 0, 0, 0,
+ax_anim 4, 0, 217, 0, 0, 0, 0,
+ax_anim 10, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_16_1:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_16_2:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_16_3:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_16_4:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_16_5:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_16_6:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_16_7:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_16_8:
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 3, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_17_1:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sSkittyAnims_17_2:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sSkittyAnims_17_3:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sSkittyAnims_17_4:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sSkittyAnims_17_5:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sSkittyAnims_17_6:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sSkittyAnims_17_7:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+sSkittyAnims_17_8:
+ax_anim 12, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_18_1:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_18_2:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_18_3:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_18_4:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_18_5:
+ax_anim 12, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_18_6:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_18_7:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_18_8:
+ax_anim 12, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_19_1:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_19_2:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_19_3:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_19_4:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_19_5:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_19_6:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_19_7:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_19_8:
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 231, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim 10, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_20_1:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -1, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 1, 0, 0,
+ax_anim 2, 0, 235, 1, 1, 1, 0,
+ax_anim 2, 0, 235, 0, 1, 0, 0,
+ax_anim 2, 0, 235, 1, 1, 1, 0,
+ax_anim 2, 0, 235, 0, 1, 0, 0,
+ax_anim 2, 0, 235, 1, 1, 1, 0,
+ax_anim_terminator
+sSkittyAnims_20_2:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sSkittyAnims_20_3:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sSkittyAnims_20_4:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sSkittyAnims_20_5:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sSkittyAnims_20_6:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sSkittyAnims_20_7:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+sSkittyAnims_20_8:
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -2, 0, 0,
+ax_anim 1, 0, 234, 0, -4, 0, 0,
+ax_anim 2, 0, 235, 0, -4, 0, 0,
+ax_anim 1, 0, 235, 0, -2, 0, 0,
+ax_anim 4, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_21_1:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_21_2:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_21_3:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_21_4:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_21_5:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_21_6:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_21_7:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_21_8:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_22_1:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_22_2:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_22_3:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_22_4:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_22_5:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_22_6:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_22_7:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_22_8:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 34, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_23_1:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_23_2:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_23_3:
+ax_anim 10, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_23_4:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_23_5:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_23_6:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_23_7:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_23_8:
+ax_anim 10, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_24_1:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_24_2:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_24_3:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_24_4:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_24_5:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_24_6:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_24_7:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_24_8:
+ax_anim 4, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_25_1:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_25_2:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_25_3:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_25_4:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_25_5:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_25_6:
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_25_7:
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_25_8:
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_26_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sSkittyAnims_26_2:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sSkittyAnims_26_3:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sSkittyAnims_26_4:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sSkittyAnims_26_5:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sSkittyAnims_26_6:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sSkittyAnims_26_7:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+sSkittyAnims_26_8:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sSkittyAnims_27_1:
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 16, 0, 259, -1, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 1, 0, 0, 0,
+ax_anim 16, 0, 259, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSkittyAnims_28_1:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_28_2:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_28_3:
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_28_4:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_28_5:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_28_6:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_28_7:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyAnims_28_8:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSkittyGfx1:
+.incbin "baserom.gba", 0x1230410, 0x200
+sSkittySprites1:
+ax_sprite sSkittyGfx1, 0x200
+ax_sprite_terminator
+sSkittyGfx2:
+.incbin "baserom.gba", 0x1230620, 0x200
+sSkittySprites2:
+ax_sprite sSkittyGfx2, 0x200
+ax_sprite_terminator
+sSkittyGfx3:
+.incbin "baserom.gba", 0x1230830, 0x200
+sSkittySprites3:
+ax_sprite sSkittyGfx3, 0x200
+ax_sprite_terminator
+sSkittyGfx4:
+.incbin "baserom.gba", 0x1230A40, 0x200
+sSkittySprites4:
+ax_sprite sSkittyGfx4, 0x200
+ax_sprite_terminator
+sSkittyGfx5:
+.incbin "baserom.gba", 0x1230C50, 0x200
+sSkittySprites5:
+ax_sprite sSkittyGfx5, 0x200
+ax_sprite_terminator
+sSkittyGfx6:
+.incbin "baserom.gba", 0x1230E60, 0x200
+sSkittySprites6:
+ax_sprite sSkittyGfx6, 0x200
+ax_sprite_terminator
+sSkittyGfx7:
+.incbin "baserom.gba", 0x1231070, 0x200
+sSkittySprites7:
+ax_sprite sSkittyGfx7, 0x200
+ax_sprite_terminator
+sSkittyGfx8:
+.incbin "baserom.gba", 0x1231280, 0x200
+sSkittySprites8:
+ax_sprite sSkittyGfx8, 0x200
+ax_sprite_terminator
+sSkittyGfx9:
+.incbin "baserom.gba", 0x1231490, 0x200
+sSkittySprites9:
+ax_sprite sSkittyGfx9, 0x200
+ax_sprite_terminator
+sSkittyGfx10:
+.incbin "baserom.gba", 0x12316A0, 0x200
+sSkittySprites10:
+ax_sprite sSkittyGfx10, 0x200
+ax_sprite_terminator
+sSkittyGfx11:
+.incbin "baserom.gba", 0x12318B0, 0x200
+sSkittySprites11:
+ax_sprite sSkittyGfx11, 0x200
+ax_sprite_terminator
+sSkittyGfx12:
+.incbin "baserom.gba", 0x1231AC0, 0x200
+sSkittySprites12:
+ax_sprite sSkittyGfx12, 0x200
+ax_sprite_terminator
+sSkittyGfx13:
+.incbin "baserom.gba", 0x1231CD0, 0x200
+sSkittySprites13:
+ax_sprite sSkittyGfx13, 0x200
+ax_sprite_terminator
+sSkittyGfx14:
+.incbin "baserom.gba", 0x1231EE0, 0x200
+sSkittySprites14:
+ax_sprite sSkittyGfx14, 0x200
+ax_sprite_terminator
+sSkittyGfx15:
+.incbin "baserom.gba", 0x12320F0, 0x200
+sSkittySprites15:
+ax_sprite sSkittyGfx15, 0x200
+ax_sprite_terminator
+sSkittyGfx16:
+.incbin "baserom.gba", 0x1232300, 0x40
+sSkittyGfx16_1:
+.incbin "baserom.gba", 0x1232340, 0x60
+sSkittyGfx16_2:
+.incbin "baserom.gba", 0x12323A0, 0x60
+sSkittyGfx16_3:
+.incbin "baserom.gba", 0x1232400, 0x40
+sSkittySprites16:
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkittyGfx17:
+.incbin "baserom.gba", 0x1232490, 0x60
+sSkittyGfx17_1:
+.incbin "baserom.gba", 0x12324F0, 0x60
+sSkittyGfx17_2:
+.incbin "baserom.gba", 0x1232550, 0x60
+sSkittySprites17:
+ax_sprite sSkittyGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx18:
+.incbin "baserom.gba", 0x12325E8, 0x180
+sSkittySprites18:
+ax_sprite sSkittyGfx18, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSkittyGfx19:
+.incbin "baserom.gba", 0x1232780, 0x60
+sSkittyGfx19_1:
+.incbin "baserom.gba", 0x12327E0, 0x60
+sSkittyGfx19_2:
+.incbin "baserom.gba", 0x1232840, 0x60
+sSkittySprites19:
+ax_sprite sSkittyGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx20:
+.incbin "baserom.gba", 0x12328D8, 0x60
+sSkittyGfx20_1:
+.incbin "baserom.gba", 0x1232938, 0x60
+sSkittyGfx20_2:
+.incbin "baserom.gba", 0x1232998, 0x40
+sSkittySprites20:
+ax_sprite sSkittyGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx20_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx21:
+.incbin "baserom.gba", 0x1232A10, 0x40
+sSkittyGfx21_1:
+.incbin "baserom.gba", 0x1232A50, 0x60
+sSkittyGfx21_2:
+.incbin "baserom.gba", 0x1232AB0, 0x60
+sSkittyGfx21_3:
+.incbin "baserom.gba", 0x1232B10, 0x40
+sSkittySprites21:
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkittyGfx22:
+.incbin "baserom.gba", 0x1232BA0, 0x20
+sSkittyGfx22_1:
+.incbin "baserom.gba", 0x1232BC0, 0xE0
+sSkittyGfx22_2:
+.incbin "baserom.gba", 0x1232CA0, 0x40
+sSkittySprites22:
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx22_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSkittyGfx23:
+.incbin "baserom.gba", 0x1232D20, 0x160
+sSkittySprites23:
+ax_sprite sSkittyGfx23, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx24:
+.incbin "baserom.gba", 0x1232E98, 0x60
+sSkittyGfx24_1:
+.incbin "baserom.gba", 0x1232EF8, 0x60
+sSkittyGfx24_2:
+.incbin "baserom.gba", 0x1232F58, 0x60
+sSkittySprites24:
+ax_sprite sSkittyGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx25:
+.incbin "baserom.gba", 0x1232FF0, 0x180
+sSkittySprites25:
+ax_sprite sSkittyGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSkittyGfx26:
+.incbin "baserom.gba", 0x1233188, 0x160
+sSkittySprites26:
+ax_sprite sSkittyGfx26, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx27:
+.incbin "baserom.gba", 0x1233300, 0x60
+sSkittyGfx27_1:
+.incbin "baserom.gba", 0x1233360, 0x60
+sSkittyGfx27_2:
+.incbin "baserom.gba", 0x12333C0, 0x40
+sSkittySprites27:
+ax_sprite sSkittyGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx28:
+.incbin "baserom.gba", 0x1233438, 0x60
+sSkittyGfx28_1:
+.incbin "baserom.gba", 0x1233498, 0x100
+sSkittySprites28:
+ax_sprite sSkittyGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx28_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSkittyGfx29:
+.incbin "baserom.gba", 0x12335C0, 0x60
+sSkittyGfx29_1:
+.incbin "baserom.gba", 0x1233620, 0x60
+sSkittyGfx29_2:
+.incbin "baserom.gba", 0x1233680, 0x40
+sSkittySprites29:
+ax_sprite sSkittyGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx29_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx30:
+.incbin "baserom.gba", 0x12336F8, 0x60
+sSkittyGfx30_1:
+.incbin "baserom.gba", 0x1233758, 0x60
+sSkittyGfx30_2:
+.incbin "baserom.gba", 0x12337B8, 0x40
+sSkittySprites30:
+ax_sprite sSkittyGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSkittyGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSkittyGfx30_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSkittyGfx31:
+.incbin "baserom.gba", 0x1233830, 0x200
+sSkittySprites31:
+ax_sprite sSkittyGfx31, 0x200
+ax_sprite_terminator
+sSkittyGfx32:
+.incbin "baserom.gba", 0x1233A40, 0x200
+sSkittySprites32:
+ax_sprite sSkittyGfx32, 0x200
+ax_sprite_terminator
+sSkittyGfx33:
+.incbin "baserom.gba", 0x1233C50, 0x200
+sSkittySprites33:
+ax_sprite sSkittyGfx33, 0x200
+ax_sprite_terminator
+sSkittyGfx34:
+.incbin "baserom.gba", 0x1233E60, 0x200
+sSkittySprites34:
+ax_sprite sSkittyGfx34, 0x200
+ax_sprite_terminator
+sSkittyGfx35:
+.incbin "baserom.gba", 0x1234070, 0x200
+sSkittySprites35:
+ax_sprite sSkittyGfx35, 0x200
+ax_sprite_terminator
+sSkittyGfx36:
+.incbin "baserom.gba", 0x1234280, 0x200
+sSkittySprites36:
+ax_sprite sSkittyGfx36, 0x200
+ax_sprite_terminator
+sSkittyGfx37:
+.incbin "baserom.gba", 0x1234490, 0x200
+sSkittySprites37:
+ax_sprite sSkittyGfx37, 0x200
+ax_sprite_terminator
+sSkittyGfx38:
+.incbin "baserom.gba", 0x12346A0, 0x200
+sSkittySprites38:
+ax_sprite sSkittyGfx38, 0x200
+ax_sprite_terminator
+sSkittyGfx39:
+.incbin "baserom.gba", 0x12348B0, 0x200
+sSkittySprites39:
+ax_sprite sSkittyGfx39, 0x200
+ax_sprite_terminator
+sSkittyGfx40:
+.incbin "baserom.gba", 0x1234AC0, 0x200
+sSkittySprites40:
+ax_sprite sSkittyGfx40, 0x200
+ax_sprite_terminator
+sSkittyGfx41:
+.incbin "baserom.gba", 0x1234CD0, 0x200
+sSkittySprites41:
+ax_sprite sSkittyGfx41, 0x200
+ax_sprite_terminator
+sSkittyGfx42:
+.incbin "baserom.gba", 0x1234EE0, 0x200
+sSkittySprites42:
+ax_sprite sSkittyGfx42, 0x200
+ax_sprite_terminator
+sSkittyGfx43:
+.incbin "baserom.gba", 0x12350F0, 0x200
+sSkittySprites43:
+ax_sprite sSkittyGfx43, 0x200
+ax_sprite_terminator
+sSkittyGfx44:
+.incbin "baserom.gba", 0x1235300, 0x200
+sSkittySprites44:
+ax_sprite sSkittyGfx44, 0x200
+ax_sprite_terminator
+sSkittyGfx45:
+.incbin "baserom.gba", 0x1235510, 0x200
+sSkittySprites45:
+ax_sprite sSkittyGfx45, 0x200
+ax_sprite_terminator
+sSkittyGfx46:
+.incbin "baserom.gba", 0x1235720, 0x200
+sSkittySprites46:
+ax_sprite sSkittyGfx46, 0x200
+ax_sprite_terminator
+sSkittyGfx47:
+.incbin "baserom.gba", 0x1235930, 0x200
+sSkittySprites47:
+ax_sprite sSkittyGfx47, 0x200
+ax_sprite_terminator
+sSkittyGfx48:
+.incbin "baserom.gba", 0x1235B40, 0x200
+sSkittySprites48:
+ax_sprite sSkittyGfx48, 0x200
+ax_sprite_terminator
+sSkittyGfx49:
+.incbin "baserom.gba", 0x1235D50, 0x200
+sSkittySprites49:
+ax_sprite sSkittyGfx49, 0x200
+ax_sprite_terminator
+sSkittyGfx50:
+.incbin "baserom.gba", 0x1235F60, 0x200
+sSkittySprites50:
+ax_sprite sSkittyGfx50, 0x200
+ax_sprite_terminator
+sSkittyGfx51:
+.incbin "baserom.gba", 0x1236170, 0x200
+sSkittySprites51:
+ax_sprite sSkittyGfx51, 0x200
+ax_sprite_terminator
+sSkittyGfx52:
+.incbin "baserom.gba", 0x1236380, 0x200
+sSkittySprites52:
+ax_sprite sSkittyGfx52, 0x200
+ax_sprite_terminator
+sSkittyGfx53:
+.incbin "baserom.gba", 0x1236590, 0x200
+sSkittySprites53:
+ax_sprite sSkittyGfx53, 0x200
+ax_sprite_terminator
+sSkittyGfx54:
+.incbin "baserom.gba", 0x12367A0, 0x200
+sSkittySprites54:
+ax_sprite sSkittyGfx54, 0x200
+ax_sprite_terminator
+sSkittyGfx55:
+.incbin "baserom.gba", 0x12369B0, 0x200
+sSkittySprites55:
+ax_sprite sSkittyGfx55, 0x200
+ax_sprite_terminator
+sSkittyGfx56:
+.incbin "baserom.gba", 0x1236BC0, 0x200
+sSkittySprites56:
+ax_sprite sSkittyGfx56, 0x200
+ax_sprite_terminator
+sSkittyGfx57:
+.incbin "baserom.gba", 0x1236DD0, 0x200
+sSkittySprites57:
+ax_sprite sSkittyGfx57, 0x200
+ax_sprite_terminator
+sSkittyGfx58:
+.incbin "baserom.gba", 0x1236FE0, 0x200
+sSkittySprites58:
+ax_sprite sSkittyGfx58, 0x200
+ax_sprite_terminator
+sSkittyGfx59:
+.incbin "baserom.gba", 0x12371F0, 0x200
+sSkittySprites59:
+ax_sprite sSkittyGfx59, 0x200
+ax_sprite_terminator
+sSkittyGfx60:
+.incbin "baserom.gba", 0x1237400, 0x200
+sSkittySprites60:
+ax_sprite sSkittyGfx60, 0x200
+ax_sprite_terminator
+sSkittyGfx61:
+.incbin "baserom.gba", 0x1237610, 0x200
+sSkittySprites61:
+ax_sprite sSkittyGfx61, 0x200
+ax_sprite_terminator
+sSkittyGfx62:
+.incbin "baserom.gba", 0x1237820, 0x200
+sSkittySprites62:
+ax_sprite sSkittyGfx62, 0x200
+ax_sprite_terminator
+sSkittyGfx63:
+.incbin "baserom.gba", 0x1237A30, 0x200
+sSkittySprites63:
+ax_sprite sSkittyGfx63, 0x200
+ax_sprite_terminator
+sSkittyGfx64:
+.incbin "baserom.gba", 0x1237C40, 0x200
+sSkittySprites64:
+ax_sprite sSkittyGfx64, 0x200
+ax_sprite_terminator
+sSkittyGfx65:
+.incbin "baserom.gba", 0x1237E50, 0x200
+sSkittySprites65:
+ax_sprite sSkittyGfx65, 0x200
+ax_sprite_terminator
+sSkittyGfx66:
+.incbin "baserom.gba", 0x1238060, 0x200
+sSkittySprites66:
+ax_sprite sSkittyGfx66, 0x200
+ax_sprite_terminator
+sSkittyGfx67:
+.incbin "baserom.gba", 0x1238270, 0x200
+sSkittySprites67:
+ax_sprite sSkittyGfx67, 0x200
+ax_sprite_terminator
+sAxPosesSkitty:
+.4byte sSkittyPose1
+.4byte sSkittyPose2
+.4byte sSkittyPose3
+.4byte sSkittyPose4
+.4byte sSkittyPose5
+.4byte sSkittyPose6
+.4byte sSkittyPose7
+.4byte sSkittyPose8
+.4byte sSkittyPose9
+.4byte sSkittyPose10
+.4byte sSkittyPose11
+.4byte sSkittyPose12
+.4byte sSkittyPose13
+.4byte sSkittyPose14
+.4byte sSkittyPose15
+.4byte sSkittyPose16
+.4byte sSkittyPose17
+.4byte sSkittyPose18
+.4byte sSkittyPose19
+.4byte sSkittyPose20
+.4byte sSkittyPose21
+.4byte sSkittyPose22
+.4byte sSkittyPose23
+.4byte sSkittyPose24
+.4byte sSkittyPose25
+.4byte sSkittyPose26
+.4byte sSkittyPose27
+.4byte sSkittyPose28
+.4byte sSkittyPose29
+.4byte sSkittyPose30
+.4byte sSkittyPose31
+.4byte sSkittyPose32
+.4byte sSkittyPose33
+.4byte sSkittyPose34
+.4byte sSkittyPose35
+.4byte sSkittyPose36
+.4byte sSkittyPose37
+.4byte sSkittyPose38
+.4byte sSkittyPose39
+.4byte sSkittyPose40
+.4byte sSkittyPose41
+.4byte sSkittyPose42
+.4byte sSkittyPose43
+.4byte sSkittyPose44
+.4byte sSkittyPose45
+.4byte sSkittyPose46
+.4byte sSkittyPose47
+.4byte sSkittyPose48
+.4byte sSkittyPose49
+.4byte sSkittyPose50
+.4byte sSkittyPose51
+.4byte sSkittyPose52
+.4byte sSkittyPose53
+.4byte sSkittyPose54
+.4byte sSkittyPose55
+.4byte sSkittyPose56
+.4byte sSkittyPose57
+.4byte sSkittyPose58
+.4byte sSkittyPose59
+.4byte sSkittyPose60
+.4byte sSkittyPose61
+.4byte sSkittyPose62
+.4byte sSkittyPose63
+.4byte sSkittyPose64
+.4byte sSkittyPose65
+.4byte sSkittyPose66
+.4byte sSkittyPose67
+.4byte sSkittyPose68
+.4byte sSkittyPose69
+.4byte sSkittyPose70
+.4byte sSkittyPose71
+.4byte sSkittyPose72
+.4byte sSkittyPose73
+.4byte sSkittyPose74
+.4byte sSkittyPose75
+.4byte sSkittyPose76
+.4byte sSkittyPose77
+.4byte sSkittyPose78
+.4byte sSkittyPose79
+.4byte sSkittyPose80
+.4byte sSkittyPose81
+.4byte sSkittyPose82
+.4byte sSkittyPose83
+.4byte sSkittyPose84
+.4byte sSkittyPose85
+.4byte sSkittyPose86
+.4byte sSkittyPose87
+.4byte sSkittyPose88
+.4byte sSkittyPose89
+.4byte sSkittyPose90
+.4byte sSkittyPose91
+.4byte sSkittyPose92
+.4byte sSkittyPose93
+.4byte sSkittyPose94
+.4byte sSkittyPose95
+.4byte sSkittyPose96
+.4byte sSkittyPose97
+.4byte sSkittyPose98
+.4byte sSkittyPose99
+.4byte sSkittyPose100
+.4byte sSkittyPose101
+.4byte sSkittyPose102
+.4byte sSkittyPose103
+.4byte sSkittyPose104
+.4byte sSkittyPose105
+.4byte sSkittyPose106
+.4byte sSkittyPose107
+.4byte sSkittyPose108
+.4byte sSkittyPose109
+.4byte sSkittyPose110
+.4byte sSkittyPose111
+.4byte sSkittyPose112
+.4byte sSkittyPose113
+.4byte sSkittyPose114
+.4byte sSkittyPose115
+.4byte sSkittyPose116
+.4byte sSkittyPose117
+.4byte sSkittyPose118
+.4byte sSkittyPose119
+.4byte sSkittyPose120
+.4byte sSkittyPose121
+.4byte sSkittyPose122
+.4byte sSkittyPose123
+.4byte sSkittyPose124
+.4byte sSkittyPose125
+.4byte sSkittyPose126
+.4byte sSkittyPose127
+.4byte sSkittyPose128
+.4byte sSkittyPose129
+.4byte sSkittyPose130
+.4byte sSkittyPose131
+.4byte sSkittyPose132
+.4byte sSkittyPose133
+.4byte sSkittyPose134
+.4byte sSkittyPose135
+.4byte sSkittyPose136
+.4byte sSkittyPose137
+.4byte sSkittyPose138
+.4byte sSkittyPose139
+.4byte sSkittyPose140
+.4byte sSkittyPose141
+.4byte sSkittyPose142
+.4byte sSkittyPose143
+.4byte sSkittyPose144
+.4byte sSkittyPose145
+.4byte sSkittyPose146
+.4byte sSkittyPose147
+.4byte sSkittyPose148
+.4byte sSkittyPose149
+.4byte sSkittyPose150
+.4byte sSkittyPose151
+.4byte sSkittyPose152
+.4byte sSkittyPose153
+.4byte sSkittyPose154
+.4byte sSkittyPose155
+.4byte sSkittyPose156
+.4byte sSkittyPose157
+.4byte sSkittyPose158
+.4byte sSkittyPose159
+.4byte sSkittyPose160
+.4byte sSkittyPose161
+.4byte sSkittyPose162
+.4byte sSkittyPose163
+.4byte sSkittyPose164
+.4byte sSkittyPose165
+.4byte sSkittyPose166
+.4byte sSkittyPose167
+.4byte sSkittyPose168
+.4byte sSkittyPose169
+.4byte sSkittyPose170
+.4byte sSkittyPose171
+.4byte sSkittyPose172
+.4byte sSkittyPose173
+.4byte sSkittyPose174
+.4byte sSkittyPose175
+.4byte sSkittyPose176
+.4byte sSkittyPose177
+.4byte sSkittyPose178
+.4byte sSkittyPose179
+.4byte sSkittyPose180
+.4byte sSkittyPose181
+.4byte sSkittyPose182
+.4byte sSkittyPose183
+.4byte sSkittyPose184
+.4byte sSkittyPose185
+.4byte sSkittyPose186
+.4byte sSkittyPose187
+.4byte sSkittyPose188
+.4byte sSkittyPose189
+.4byte sSkittyPose190
+.4byte sSkittyPose191
+.4byte sSkittyPose192
+.4byte sSkittyPose193
+.4byte sSkittyPose194
+.4byte sSkittyPose195
+.4byte sSkittyPose196
+.4byte sSkittyPose197
+.4byte sSkittyPose198
+.4byte sSkittyPose199
+.4byte sSkittyPose200
+.4byte sSkittyPose201
+.4byte sSkittyPose202
+.4byte sSkittyPose203
+.4byte sSkittyPose204
+.4byte sSkittyPose205
+.4byte sSkittyPose206
+.4byte sSkittyPose207
+.4byte sSkittyPose208
+.4byte sSkittyPose209
+.4byte sSkittyPose210
+.4byte sSkittyPose211
+.4byte sSkittyPose212
+.4byte sSkittyPose213
+.4byte sSkittyPose214
+.4byte sSkittyPose215
+.4byte sSkittyPose216
+.4byte sSkittyPose217
+.4byte sSkittyPose218
+.4byte sSkittyPose219
+.4byte sSkittyPose220
+.4byte sSkittyPose221
+.4byte sSkittyPose222
+.4byte sSkittyPose223
+.4byte sSkittyPose224
+.4byte sSkittyPose225
+.4byte sSkittyPose226
+.4byte sSkittyPose227
+.4byte sSkittyPose228
+.4byte sSkittyPose229
+.4byte sSkittyPose230
+.4byte sSkittyPose231
+.4byte sSkittyPose232
+.4byte sSkittyPose233
+.4byte sSkittyPose234
+.4byte sSkittyPose235
+.4byte sSkittyPose236
+.4byte sSkittyPose237
+.4byte sSkittyPose238
+.4byte sSkittyPose239
+.4byte sSkittyPose240
+.4byte sSkittyPose241
+.4byte sSkittyPose242
+.4byte sSkittyPose243
+.4byte sSkittyPose244
+.4byte sSkittyPose245
+.4byte sSkittyPose246
+.4byte sSkittyPose247
+.4byte sSkittyPose248
+.4byte sSkittyPose249
+.4byte sSkittyPose250
+.4byte sSkittyPose251
+.4byte sSkittyPose252
+.4byte sSkittyPose253
+.4byte sSkittyPose254
+.4byte sSkittyPose255
+.4byte sSkittyPose256
+.4byte sSkittyPose257
+.4byte sSkittyPose258
+.4byte sSkittyPose259
+.4byte sSkittyPose260
+.4byte sSkittyPose261
+.4byte sSkittyPose262
+.4byte sSkittyPose263
+.4byte sSkittyPose264
+.4byte sSkittyPose265
+.4byte sSkittyPose266
+.4byte sSkittyPose267
+sAxPositionsSkitty:
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -8, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,    1, 	  -2,    2, 	   2,    2, 	   0,   -5
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    5,   -7, 	   5,   -5, 	   2,   -5, 	   1,  -10
+.2byte    5,    0, 	   2,    2, 	   0,    2, 	   2,   -6
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    7,   -8, 	   5,   -6, 	   4,   -6, 	   2,  -10
+.2byte    8,   -2, 	   5,   -1, 	   4,    1, 	   2,   -4
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte    8,  -14, 	   3,  -10, 	   6,   -8, 	   0,  -10
+.2byte    8,   -7, 	   0,   -1, 	   3,    1, 	   1,   -6
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -14, 	   4,   -8, 	  -4,   -8, 	   0,  -11
+.2byte    0,   -5, 	   4,   -3, 	  -4,   -3, 	   0,   -7
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte   -8,  -14, 	  -3,  -10, 	  -6,   -8, 	   0,  -10
+.2byte   -8,   -7, 	   0,   -1, 	  -3,    1, 	  -1,   -6
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -6, 	  -4,   -6, 	  -2,  -10
+.2byte   -8,   -2, 	  -5,   -1, 	  -4,    1, 	  -2,   -4
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -5,   -7, 	  -5,   -5, 	  -2,   -5, 	  -1,  -10
+.2byte   -5,    0, 	  -2,    2, 	   0,    2, 	  -2,   -6
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -8, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,    1, 	  -2,    2, 	   2,    2, 	   0,   -5
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    5,   -7, 	   5,   -5, 	   2,   -5, 	   1,  -10
+.2byte    5,    0, 	   2,    2, 	   0,    2, 	   2,   -6
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    7,   -8, 	   5,   -6, 	   4,   -6, 	   2,  -10
+.2byte    8,   -4, 	   5,   -3, 	   4,   -1, 	   2,   -6
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte    8,  -14, 	   3,  -10, 	   6,   -8, 	   0,  -10
+.2byte    8,   -7, 	   0,   -1, 	   3,    1, 	   1,   -6
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -14, 	   4,   -8, 	  -4,   -8, 	   0,  -11
+.2byte    0,   -5, 	   4,   -3, 	  -4,   -3, 	   0,   -7
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte   -8,  -14, 	  -3,  -10, 	  -6,   -8, 	   0,  -10
+.2byte   -8,   -7, 	   0,   -1, 	  -3,    1, 	  -1,   -6
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -6, 	  -4,   -6, 	  -2,  -10
+.2byte   -8,   -4, 	  -5,   -3, 	  -4,   -1, 	  -2,   -6
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -5,   -7, 	  -5,   -5, 	  -2,   -5, 	  -1,  -10
+.2byte   -5,    0, 	  -2,    2, 	   0,    2, 	  -2,   -6
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -8, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,    1, 	  -2,    2, 	   2,    2, 	   0,   -5
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    5,   -7, 	   5,   -5, 	   2,   -5, 	   1,  -10
+.2byte    5,    0, 	   2,    2, 	   0,    2, 	   2,   -6
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    7,   -8, 	   5,   -6, 	   4,   -6, 	   2,  -10
+.2byte    8,   -4, 	   5,   -3, 	   4,   -1, 	   2,   -6
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte    8,  -14, 	   3,  -10, 	   6,   -8, 	   0,  -10
+.2byte    8,   -7, 	   0,   -1, 	   3,    1, 	   1,   -6
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -14, 	   4,   -8, 	  -4,   -8, 	   0,  -11
+.2byte    0,   -5, 	   4,   -3, 	  -4,   -3, 	   0,   -7
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte   -8,  -14, 	  -3,  -10, 	  -6,   -8, 	   0,  -10
+.2byte   -8,   -7, 	   0,   -1, 	  -3,    1, 	  -1,   -6
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -6, 	  -4,   -6, 	  -2,  -10
+.2byte   -8,   -4, 	  -5,   -3, 	  -4,   -1, 	  -2,   -6
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -5,   -7, 	  -5,   -5, 	  -2,   -5, 	  -1,  -10
+.2byte   -5,    0, 	  -2,    2, 	   0,    2, 	  -2,   -6
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -5, 	  -1,    0, 	   1,    0, 	   0,   -6
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    6,   -4, 	   3,    0, 	   1,    0, 	   3,   -7
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte   10,   -6, 	   3,   -1, 	   2,    0, 	   4,   -7
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte   10,  -11, 	   1,   -3, 	   2,   -1, 	   1,   -8
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -12, 	   3,   -1, 	  -3,   -1, 	   0,   -8
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte  -10,  -11, 	  -1,   -3, 	  -2,   -1, 	  -1,   -8
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte  -10,   -6, 	  -3,   -1, 	  -2,    0, 	  -4,   -7
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -6,   -4, 	  -3,    0, 	  -1,    0, 	  -3,   -7
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -8, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,    1, 	  -2,    2, 	   2,    2, 	   0,   -5
+.2byte    0,   -5, 	  -1,   -2, 	   2,   -1, 	   0,   -6
+.2byte    0,   -5, 	  -1,   -1, 	   1,   -2, 	   0,   -6
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    5,   -7, 	   5,   -5, 	   2,   -5, 	   1,  -10
+.2byte    5,   -2, 	   2,    0, 	   0,    0, 	   2,   -8
+.2byte    4,   -5, 	   4,   -2, 	   1,   -1, 	   0,   -8
+.2byte    5,   -5, 	   3,   -1, 	   2,   -2, 	   1,   -9
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    7,   -8, 	   5,   -6, 	   4,   -6, 	   2,  -10
+.2byte    8,   -3, 	   5,   -2, 	   4,    0, 	   2,   -5
+.2byte    8,   -6, 	   4,   -3, 	   3,   -2, 	   1,   -8
+.2byte    6,   -5, 	   4,   -3, 	   3,   -3, 	   1,   -7
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte    8,  -14, 	   3,  -10, 	   6,   -8, 	   0,  -10
+.2byte    8,   -9, 	   0,   -3, 	   3,   -1, 	   1,   -8
+.2byte    8,  -11, 	   1,   -6, 	   4,   -3, 	  -1,   -9
+.2byte    8,   -9, 	   1,   -5, 	   4,   -4, 	  -1,   -7
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -14, 	   4,   -8, 	  -4,   -8, 	   0,  -11
+.2byte    0,   -5, 	   4,   -3, 	  -4,   -3, 	   0,   -7
+.2byte    2,   -9, 	   3,    0, 	  -3,    0, 	   0,   -8
+.2byte   -2,   -9, 	   3,    1, 	  -2,    1, 	   0,   -8
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte   -8,  -14, 	  -3,  -10, 	  -6,   -8, 	   0,  -10
+.2byte   -8,   -9, 	   0,   -3, 	  -3,   -1, 	  -1,   -8
+.2byte   -8,  -11, 	  -1,   -6, 	  -4,   -3, 	   1,   -9
+.2byte   -8,   -9, 	  -1,   -5, 	  -4,   -4, 	   1,   -7
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -6, 	  -4,   -6, 	  -2,  -10
+.2byte   -8,   -3, 	  -5,   -2, 	  -4,    0, 	  -2,   -5
+.2byte   -8,   -6, 	  -4,   -3, 	  -3,   -2, 	  -1,   -8
+.2byte   -6,   -5, 	  -4,   -3, 	  -3,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -5,   -7, 	  -5,   -5, 	  -2,   -5, 	  -1,  -10
+.2byte   -5,   -2, 	  -2,    0, 	   0,    0, 	  -2,   -8
+.2byte   -4,   -5, 	  -4,   -2, 	  -1,   -1, 	   0,   -8
+.2byte   -5,   -5, 	  -3,   -1, 	  -2,   -2, 	  -1,   -9
+.2byte   -4,   -2, 	  -6,   -1, 	  -2,    0, 	   1,   -5
+.2byte   -4,   -2, 	  -6,   -1, 	  -2,    0, 	   1,   -6
+.2byte    0,   -9, 	  -3,   -7, 	   3,   -7, 	   0,  -10
+.2byte    3,   -7, 	   3,   -5, 	   1,   -4, 	  -2,   -8
+.2byte    4,   -7, 	   3,   -7, 	   2,   -6, 	  -1,  -10
+.2byte    4,  -14, 	  -2,  -11, 	   2,   -8, 	  -4,   -9
+.2byte    0,  -11, 	   4,   -4, 	  -4,   -4, 	   0,   -8
+.2byte   -4,  -14, 	   2,  -11, 	  -2,   -8, 	   4,   -9
+.2byte   -4,   -7, 	  -3,   -7, 	  -2,   -6, 	   1,  -10
+.2byte   -3,   -7, 	  -3,   -5, 	  -1,   -4, 	   2,   -8
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -5, 	  -1,    0, 	   1,    0, 	   0,   -6
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    6,   -4, 	   3,    0, 	   1,    0, 	   3,   -7
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte   10,   -6, 	   3,   -1, 	   2,    0, 	   4,   -7
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte   10,  -11, 	   1,   -3, 	   2,   -1, 	   1,   -8
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -12, 	   3,   -1, 	  -3,   -1, 	   0,   -8
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte  -10,  -11, 	  -1,   -3, 	  -2,   -1, 	  -1,   -8
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte  -10,   -6, 	  -3,   -1, 	  -2,    0, 	  -4,   -7
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -6,   -4, 	  -3,    0, 	  -1,    0, 	  -3,   -7
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    0,   -5, 	  -1,    0, 	   1,    0, 	   0,   -6
+.2byte    6,   -4, 	   3,    0, 	   1,    0, 	   3,   -7
+.2byte   10,   -6, 	   3,   -1, 	   2,    0, 	   4,   -7
+.2byte   10,  -11, 	   1,   -3, 	   2,   -1, 	   1,   -8
+.2byte    0,  -12, 	   3,   -1, 	  -3,   -1, 	   0,   -8
+.2byte  -10,  -11, 	  -1,   -3, 	  -2,   -1, 	  -1,   -8
+.2byte  -10,   -6, 	  -3,   -1, 	  -2,    0, 	  -4,   -7
+.2byte   -6,   -4, 	  -3,    0, 	  -1,    0, 	  -3,   -7
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -8, 	  -3,   -6, 	   3,   -6, 	   0,  -11
+.2byte    0,    1, 	  -2,    2, 	   2,    2, 	   0,   -5
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte    5,   -7, 	   5,   -5, 	   2,   -5, 	   1,  -10
+.2byte    5,    0, 	   2,    2, 	   0,    2, 	   2,   -6
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    7,   -8, 	   5,   -6, 	   4,   -6, 	   2,  -10
+.2byte    8,   -2, 	   5,   -1, 	   4,    1, 	   2,   -4
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte    8,  -14, 	   3,  -10, 	   6,   -8, 	   0,  -10
+.2byte    8,   -7, 	   0,   -1, 	   3,    1, 	   1,   -6
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,  -14, 	   4,   -8, 	  -4,   -8, 	   0,  -11
+.2byte    0,   -5, 	   4,   -3, 	  -4,   -3, 	   0,   -7
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte   -8,  -14, 	  -3,  -10, 	  -6,   -8, 	   0,  -10
+.2byte   -8,   -7, 	   0,   -1, 	  -3,    1, 	  -1,   -6
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -7,   -8, 	  -5,   -6, 	  -4,   -6, 	  -2,  -10
+.2byte   -8,   -2, 	  -5,   -1, 	  -4,    1, 	  -2,   -4
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -5,   -7, 	  -5,   -5, 	  -2,   -5, 	  -1,  -10
+.2byte   -5,    0, 	  -2,    2, 	   0,    2, 	  -2,   -6
+.2byte    0,   -5, 	  -1,    0, 	   1,    0, 	   0,   -6
+.2byte   -6,   -4, 	  -3,    0, 	  -1,    0, 	  -3,   -7
+.2byte  -10,   -6, 	  -3,   -1, 	  -2,    0, 	  -4,   -7
+.2byte  -10,  -11, 	  -1,   -3, 	  -2,   -1, 	  -1,   -8
+.2byte    0,  -12, 	   3,   -1, 	  -3,   -1, 	   0,   -8
+.2byte   10,  -11, 	   1,   -3, 	   2,   -1, 	   1,   -8
+.2byte   10,   -6, 	   3,   -1, 	   2,    0, 	   4,   -7
+.2byte    6,   -4, 	   3,    0, 	   1,    0, 	   3,   -7
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte   -5,   -3, 	  -3,    0, 	  -1,    0, 	  -1,   -6
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -8,  -10, 	   0,   -3, 	  -2,   -1, 	   0,   -8
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    8,  -10, 	   0,   -3, 	   2,   -1, 	   0,   -8
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    5,   -3, 	   3,    0, 	   1,    0, 	   1,   -6
+.2byte   -1,   -3, 	   1,    0, 	   1,   -2, 	  -3,   -4
+.2byte   -1,   -3, 	   1,    0, 	   1,   -2, 	  -3,   -4
+.2byte    0,   -3, 	  -2,    0, 	  -2,   -2, 	   2,   -4
+.2byte    0,   -3, 	  -2,    0, 	  -2,   -2, 	   2,   -4
+.2byte   -1,   -3, 	   1,    0, 	   1,   -2, 	  -3,   -4
+.2byte   -1,   -3, 	   2,    0, 	   2,   -2, 	  -3,   -4
+.2byte   -1,    0, 	  -5,    1, 	   4,   -2, 	  -1,   -4
+.2byte    5,   -2, 	  -1,    0, 	   3,    0, 	  -2,   -5
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,   -7, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,   -5, 	   3,   -3, 	  -3,   -3, 	   0,   -7
+.2byte    0,   -1, 	   3,    0, 	  -3,    0, 	   0,   -7
+.2byte    0,   -6, 	  -1,    0, 	   1,    0, 	   0,   -9
+.2byte   -1,   -2, 	  -3,   -1, 	   2,    0, 	  -1,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    1,   -7, 	  -4,   -5, 	   1,    0, 	   1,  -10
+.2byte    0,   -8, 	   3,   -2, 	  -4,   -2, 	  -1,   -8
+.2byte   -2,   -9, 	   5,   -7, 	  -3,   -2, 	  -1,   -9
+.2byte   -2,   -9, 	   5,   -7, 	  -3,   -2, 	  -1,   -9
+.2byte    0,   -7, 	  -3,   -2, 	   3,   -2, 	   0,   -9
+.2byte    0,   -8, 	  -3,   -3, 	   3,   -3, 	   0,  -10
+.2byte    0,   -8, 	  -3,   -3, 	   3,   -3, 	   0,  -10
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -7,   -2, 	  -2,   -1, 	   0,    0, 	  -2,   -5
+.2byte   -6,    0, 	   2,   -1, 	   3,    0, 	  -1,   -4
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,   -7, 	   3,   -2, 	  -3,   -2, 	  -1,   -8
+.2byte    0,   -6, 	   3,   -2, 	  -3,   -2, 	  -1,   -7
+.2byte    0,   -3, 	  -1,    0, 	   1,    0, 	   0,   -7
+.2byte    0,   -6, 	  -1,    0, 	   1,    0, 	   0,   -9
+.2byte    0,   -1, 	  -1,    0, 	   1,    0, 	   0,   -6
+.2byte   -7,   -4, 	  -3,   -2, 	  -2,    0, 	  -2,   -7
+.2byte   -6,   -1, 	  -4,   -1, 	  -2,    0, 	  -3,   -5
+.2byte    7,   -4, 	   3,   -2, 	   2,    0, 	   2,   -7
+.2byte    6,   -1, 	   4,   -1, 	   2,    0, 	   3,   -5
+.2byte    0,  -10, 	   3,   -3, 	  -3,   -3, 	   0,   -8
+.2byte    0,   -5, 	  -3,    0, 	   3,    0, 	   0,   -6
+.2byte   -7,   -3, 	  -2,   -2, 	  -2,    0, 	  -2,   -6
+.2byte   -8,   -5, 	  -4,   -5, 	  -4,   -2, 	  -1,   -7
+.2byte   -6,   -2, 	  -4,   -3, 	  -4,    0, 	  -1,   -4
+.2byte   -6,   -3, 	  -3,   -2, 	  -1,    0, 	   0,   -5
+.2byte   -7,   -2, 	  -4,   -1, 	   0,    0, 	  -1,   -5
+.2byte    7,   -3, 	   2,   -2, 	   2,    0, 	   2,   -6
+.2byte    8,   -5, 	   4,   -5, 	   4,   -2, 	   1,   -7
+.2byte    6,   -2, 	   4,   -3, 	   4,    0, 	   1,   -4
+.2byte    6,   -3, 	   3,   -2, 	   1,    0, 	   0,   -5
+.2byte    7,   -2, 	   4,   -1, 	   0,    0, 	   1,   -5
+.2byte    2,   -9, 	   1,   -7, 	   4,   -6, 	  -3,   -6
+.2byte   -1,   -3, 	   1,    0, 	   1,   -2, 	  -3,   -4
+.2byte   -1,   -3, 	   1,    0, 	   1,   -2, 	  -3,   -4
+.2byte    0,   -3, 	  -2,    0, 	  -2,   -2, 	   2,   -4
+.2byte    0,   -3, 	  -2,    0, 	  -2,   -2, 	   2,   -4
+.2byte   -1,   -3, 	   1,    0, 	   1,   -2, 	  -3,   -4
+.2byte   -1,   -3, 	   1,    0, 	   1,   -2, 	  -3,   -4
+.2byte    0,   -3, 	  -2,    0, 	  -2,   -2, 	   2,   -4
+.2byte    0,   -3, 	  -2,    0, 	  -2,   -2, 	   2,   -4
+sSkittyAnimTable1:
+.4byte sSkittyAnims_1_1
+.4byte sSkittyAnims_1_2
+.4byte sSkittyAnims_1_3
+.4byte sSkittyAnims_1_4
+.4byte sSkittyAnims_1_5
+.4byte sSkittyAnims_1_6
+.4byte sSkittyAnims_1_7
+.4byte sSkittyAnims_1_8
+sSkittyAnimTable2:
+.4byte sSkittyAnims_2_1
+.4byte sSkittyAnims_2_2
+.4byte sSkittyAnims_2_3
+.4byte sSkittyAnims_2_4
+.4byte sSkittyAnims_2_5
+.4byte sSkittyAnims_2_6
+.4byte sSkittyAnims_2_7
+.4byte sSkittyAnims_2_8
+sSkittyAnimTable3:
+.4byte sSkittyAnims_3_1
+.4byte sSkittyAnims_3_2
+.4byte sSkittyAnims_3_3
+.4byte sSkittyAnims_3_4
+.4byte sSkittyAnims_3_5
+.4byte sSkittyAnims_3_6
+.4byte sSkittyAnims_3_7
+.4byte sSkittyAnims_3_8
+sSkittyAnimTable4:
+.4byte sSkittyAnims_4_1
+.4byte sSkittyAnims_4_2
+.4byte sSkittyAnims_4_3
+.4byte sSkittyAnims_4_4
+.4byte sSkittyAnims_4_5
+.4byte sSkittyAnims_4_6
+.4byte sSkittyAnims_4_7
+.4byte sSkittyAnims_4_8
+sSkittyAnimTable5:
+.4byte sSkittyAnims_5_1
+.4byte sSkittyAnims_5_2
+.4byte sSkittyAnims_5_3
+.4byte sSkittyAnims_5_4
+.4byte sSkittyAnims_5_5
+.4byte sSkittyAnims_5_6
+.4byte sSkittyAnims_5_7
+.4byte sSkittyAnims_5_8
+sSkittyAnimTable6:
+.4byte sSkittyAnims_6_1
+.4byte sSkittyAnims_6_1
+.4byte sSkittyAnims_6_1
+.4byte sSkittyAnims_6_1
+.4byte sSkittyAnims_6_1
+.4byte sSkittyAnims_6_1
+.4byte sSkittyAnims_6_1
+.4byte sSkittyAnims_6_1
+sSkittyAnimTable7:
+.4byte sSkittyAnims_7_1
+.4byte sSkittyAnims_7_2
+.4byte sSkittyAnims_7_3
+.4byte sSkittyAnims_7_4
+.4byte sSkittyAnims_7_5
+.4byte sSkittyAnims_7_6
+.4byte sSkittyAnims_7_7
+.4byte sSkittyAnims_7_8
+sSkittyAnimTable8:
+.4byte sSkittyAnims_8_1
+.4byte sSkittyAnims_8_2
+.4byte sSkittyAnims_8_3
+.4byte sSkittyAnims_8_4
+.4byte sSkittyAnims_8_5
+.4byte sSkittyAnims_8_6
+.4byte sSkittyAnims_8_7
+.4byte sSkittyAnims_8_8
+sSkittyAnimTable9:
+.4byte sSkittyAnims_9_1
+.4byte sSkittyAnims_9_2
+.4byte sSkittyAnims_9_3
+.4byte sSkittyAnims_9_4
+.4byte sSkittyAnims_9_5
+.4byte sSkittyAnims_9_6
+.4byte sSkittyAnims_9_7
+.4byte sSkittyAnims_9_8
+sSkittyAnimTable10:
+.4byte sSkittyAnims_10_1
+.4byte sSkittyAnims_10_2
+.4byte sSkittyAnims_10_3
+.4byte sSkittyAnims_10_4
+.4byte sSkittyAnims_10_5
+.4byte sSkittyAnims_10_6
+.4byte sSkittyAnims_10_7
+.4byte sSkittyAnims_10_8
+sSkittyAnimTable11:
+.4byte sSkittyAnims_11_1
+.4byte sSkittyAnims_11_2
+.4byte sSkittyAnims_11_3
+.4byte sSkittyAnims_11_4
+.4byte sSkittyAnims_11_5
+.4byte sSkittyAnims_11_6
+.4byte sSkittyAnims_11_7
+.4byte sSkittyAnims_11_8
+sSkittyAnimTable12:
+.4byte sSkittyAnims_12_1
+.4byte sSkittyAnims_12_2
+.4byte sSkittyAnims_12_3
+.4byte sSkittyAnims_12_4
+.4byte sSkittyAnims_12_5
+.4byte sSkittyAnims_12_6
+.4byte sSkittyAnims_12_7
+.4byte sSkittyAnims_12_8
+sSkittyAnimTable13:
+.4byte sSkittyAnims_13_1
+.4byte sSkittyAnims_13_2
+.4byte sSkittyAnims_13_3
+.4byte sSkittyAnims_13_4
+.4byte sSkittyAnims_13_5
+.4byte sSkittyAnims_13_6
+.4byte sSkittyAnims_13_7
+.4byte sSkittyAnims_13_8
+sSkittyAnimTable14:
+.4byte sSkittyAnims_14_1
+.4byte sSkittyAnims_14_2
+.4byte sSkittyAnims_14_3
+.4byte sSkittyAnims_14_4
+.4byte sSkittyAnims_14_5
+.4byte sSkittyAnims_14_6
+.4byte sSkittyAnims_14_7
+.4byte sSkittyAnims_14_8
+sSkittyAnimTable15:
+.4byte sSkittyAnims_15_1
+.4byte sSkittyAnims_15_2
+.4byte sSkittyAnims_15_3
+.4byte sSkittyAnims_15_4
+.4byte sSkittyAnims_15_5
+.4byte sSkittyAnims_15_6
+.4byte sSkittyAnims_15_7
+.4byte sSkittyAnims_15_8
+sSkittyAnimTable16:
+.4byte sSkittyAnims_16_1
+.4byte sSkittyAnims_16_2
+.4byte sSkittyAnims_16_3
+.4byte sSkittyAnims_16_4
+.4byte sSkittyAnims_16_5
+.4byte sSkittyAnims_16_6
+.4byte sSkittyAnims_16_7
+.4byte sSkittyAnims_16_8
+sSkittyAnimTable17:
+.4byte sSkittyAnims_17_1
+.4byte sSkittyAnims_17_2
+.4byte sSkittyAnims_17_3
+.4byte sSkittyAnims_17_4
+.4byte sSkittyAnims_17_5
+.4byte sSkittyAnims_17_6
+.4byte sSkittyAnims_17_7
+.4byte sSkittyAnims_17_8
+sSkittyAnimTable18:
+.4byte sSkittyAnims_18_1
+.4byte sSkittyAnims_18_2
+.4byte sSkittyAnims_18_3
+.4byte sSkittyAnims_18_4
+.4byte sSkittyAnims_18_5
+.4byte sSkittyAnims_18_6
+.4byte sSkittyAnims_18_7
+.4byte sSkittyAnims_18_8
+sSkittyAnimTable19:
+.4byte sSkittyAnims_19_1
+.4byte sSkittyAnims_19_2
+.4byte sSkittyAnims_19_3
+.4byte sSkittyAnims_19_4
+.4byte sSkittyAnims_19_5
+.4byte sSkittyAnims_19_6
+.4byte sSkittyAnims_19_7
+.4byte sSkittyAnims_19_8
+sSkittyAnimTable20:
+.4byte sSkittyAnims_20_1
+.4byte sSkittyAnims_20_2
+.4byte sSkittyAnims_20_3
+.4byte sSkittyAnims_20_4
+.4byte sSkittyAnims_20_5
+.4byte sSkittyAnims_20_6
+.4byte sSkittyAnims_20_7
+.4byte sSkittyAnims_20_8
+sSkittyAnimTable21:
+.4byte sSkittyAnims_21_1
+.4byte sSkittyAnims_21_2
+.4byte sSkittyAnims_21_3
+.4byte sSkittyAnims_21_4
+.4byte sSkittyAnims_21_5
+.4byte sSkittyAnims_21_6
+.4byte sSkittyAnims_21_7
+.4byte sSkittyAnims_21_8
+sSkittyAnimTable22:
+.4byte sSkittyAnims_22_1
+.4byte sSkittyAnims_22_2
+.4byte sSkittyAnims_22_3
+.4byte sSkittyAnims_22_4
+.4byte sSkittyAnims_22_5
+.4byte sSkittyAnims_22_6
+.4byte sSkittyAnims_22_7
+.4byte sSkittyAnims_22_8
+sSkittyAnimTable23:
+.4byte sSkittyAnims_23_1
+.4byte sSkittyAnims_23_2
+.4byte sSkittyAnims_23_3
+.4byte sSkittyAnims_23_4
+.4byte sSkittyAnims_23_5
+.4byte sSkittyAnims_23_6
+.4byte sSkittyAnims_23_7
+.4byte sSkittyAnims_23_8
+sSkittyAnimTable24:
+.4byte sSkittyAnims_24_1
+.4byte sSkittyAnims_24_2
+.4byte sSkittyAnims_24_3
+.4byte sSkittyAnims_24_4
+.4byte sSkittyAnims_24_5
+.4byte sSkittyAnims_24_6
+.4byte sSkittyAnims_24_7
+.4byte sSkittyAnims_24_8
+sSkittyAnimTable25:
+.4byte sSkittyAnims_25_1
+.4byte sSkittyAnims_25_2
+.4byte sSkittyAnims_25_3
+.4byte sSkittyAnims_25_4
+.4byte sSkittyAnims_25_5
+.4byte sSkittyAnims_25_6
+.4byte sSkittyAnims_25_7
+.4byte sSkittyAnims_25_8
+sSkittyAnimTable26:
+.4byte sSkittyAnims_26_1
+.4byte sSkittyAnims_26_2
+.4byte sSkittyAnims_26_3
+.4byte sSkittyAnims_26_4
+.4byte sSkittyAnims_26_5
+.4byte sSkittyAnims_26_6
+.4byte sSkittyAnims_26_7
+.4byte sSkittyAnims_26_8
+sSkittyAnimTable27:
+.4byte sSkittyAnims_27_1
+.4byte sSkittyAnims_27_1
+.4byte sSkittyAnims_27_1
+.4byte sSkittyAnims_27_1
+.4byte sSkittyAnims_27_1
+.4byte sSkittyAnims_27_1
+.4byte sSkittyAnims_27_1
+.4byte sSkittyAnims_27_1
+sSkittyAnimTable28:
+.4byte sSkittyAnims_28_1
+.4byte sSkittyAnims_28_2
+.4byte sSkittyAnims_28_3
+.4byte sSkittyAnims_28_4
+.4byte sSkittyAnims_28_5
+.4byte sSkittyAnims_28_6
+.4byte sSkittyAnims_28_7
+.4byte sSkittyAnims_28_8
+sAxAnimationsSkitty:
+.4byte sSkittyAnimTable1
+.4byte sSkittyAnimTable2
+.4byte sSkittyAnimTable3
+.4byte sSkittyAnimTable4
+.4byte sSkittyAnimTable5
+.4byte sSkittyAnimTable6
+.4byte sSkittyAnimTable7
+.4byte sSkittyAnimTable8
+.4byte sSkittyAnimTable9
+.4byte sSkittyAnimTable10
+.4byte sSkittyAnimTable11
+.4byte sSkittyAnimTable12
+.4byte sSkittyAnimTable13
+.4byte sSkittyAnimTable14
+.4byte sSkittyAnimTable15
+.4byte sSkittyAnimTable16
+.4byte sSkittyAnimTable17
+.4byte sSkittyAnimTable18
+.4byte sSkittyAnimTable19
+.4byte sSkittyAnimTable20
+.4byte sSkittyAnimTable21
+.4byte sSkittyAnimTable22
+.4byte sSkittyAnimTable23
+.4byte sSkittyAnimTable24
+.4byte sSkittyAnimTable25
+.4byte sSkittyAnimTable26
+.4byte sSkittyAnimTable27
+.4byte sSkittyAnimTable28
+sAxSpritesSkitty:
+.4byte sSkittySprites1
+.4byte sSkittySprites2
+.4byte sSkittySprites3
+.4byte sSkittySprites4
+.4byte sSkittySprites5
+.4byte sSkittySprites6
+.4byte sSkittySprites7
+.4byte sSkittySprites8
+.4byte sSkittySprites9
+.4byte sSkittySprites10
+.4byte sSkittySprites11
+.4byte sSkittySprites12
+.4byte sSkittySprites13
+.4byte sSkittySprites14
+.4byte sSkittySprites15
+.4byte sSkittySprites16
+.4byte sSkittySprites17
+.4byte sSkittySprites18
+.4byte sSkittySprites19
+.4byte sSkittySprites20
+.4byte sSkittySprites21
+.4byte sSkittySprites22
+.4byte sSkittySprites23
+.4byte sSkittySprites24
+.4byte sSkittySprites25
+.4byte sSkittySprites26
+.4byte sSkittySprites27
+.4byte sSkittySprites28
+.4byte sSkittySprites29
+.4byte sSkittySprites30
+.4byte sSkittySprites31
+.4byte sSkittySprites32
+.4byte sSkittySprites33
+.4byte sSkittySprites34
+.4byte sSkittySprites35
+.4byte sSkittySprites36
+.4byte sSkittySprites37
+.4byte sSkittySprites38
+.4byte sSkittySprites39
+.4byte sSkittySprites40
+.4byte sSkittySprites41
+.4byte sSkittySprites42
+.4byte sSkittySprites43
+.4byte sSkittySprites44
+.4byte sSkittySprites45
+.4byte sSkittySprites46
+.4byte sSkittySprites47
+.4byte sSkittySprites48
+.4byte sSkittySprites49
+.4byte sSkittySprites50
+.4byte sSkittySprites51
+.4byte sSkittySprites52
+.4byte sSkittySprites53
+.4byte sSkittySprites54
+.4byte sSkittySprites55
+.4byte sSkittySprites56
+.4byte sSkittySprites57
+.4byte sSkittySprites58
+.4byte sSkittySprites59
+.4byte sSkittySprites60
+.4byte sSkittySprites61
+.4byte sSkittySprites62
+.4byte sSkittySprites63
+.4byte sSkittySprites64
+.4byte sSkittySprites65
+.4byte sSkittySprites66
+.4byte sSkittySprites67
+sAxMainSkitty:
+ax_main sAxPosesSkitty, sAxAnimationsSkitty, 28, sAxSpritesSkitty, sAxPositionsSkitty

--- a/data/ax/slaking.inc
+++ b/data/ax/slaking.inc
@@ -1,0 +1,2805 @@
+.global gAxSlaking
+gAxSlaking:
+ax_siro sAxMainSlaking
+sSlakingPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose4:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose5:
+ax_pose 4, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose6:
+ax_pose 5, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose7:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose8:
+ax_pose 7, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose9:
+ax_pose 8, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose10:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose11:
+ax_pose 10, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose12:
+ax_pose 11, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose14:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose15:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose16:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose17:
+ax_pose 10, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose19:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose24:
+ax_pose 5, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose28:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose29:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose30:
+ax_pose 4, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose31:
+ax_pose 5, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose32:
+ax_pose 16, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose33:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose34:
+ax_pose 7, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose35:
+ax_pose 8, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose36:
+ax_pose 17, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakingPose37:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose38:
+ax_pose 10, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose39:
+ax_pose 11, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose40:
+ax_pose 18, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose41:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose42:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose43:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose44:
+ax_pose 19, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose45:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose46:
+ax_pose 10, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose47:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose48:
+ax_pose 18, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose49:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose50:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose51:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose52:
+ax_pose 17, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose53:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose54:
+ax_pose 4, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose55:
+ax_pose 5, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose56:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose57:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose58:
+ax_pose 1, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose59:
+ax_pose 2, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose60:
+ax_pose 20, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose61:
+ax_pose 21, 0x01e9, 0x80f0, 0x4c00
+ax_pose 22, 0x01e5, 0x80f0, 0x4c10
+ax_pose_terminator
+sSlakingPose62:
+ax_pose 22, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose63:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose64:
+ax_pose 4, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose65:
+ax_pose 5, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose66:
+ax_pose 23, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose67:
+ax_pose 24, 0x01e8, 0x90f5, 0x4c00
+ax_pose 25, 0x01e5, 0x90f1, 0x4c10
+ax_pose_terminator
+sSlakingPose68:
+ax_pose 25, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose69:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose70:
+ax_pose 7, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose71:
+ax_pose 8, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose72:
+ax_pose 26, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakingPose73:
+ax_pose 27, 0x01e5, 0x90f7, 0x4c00
+ax_pose 28, 0x01e5, 0x90f0, 0x4c10
+ax_pose_terminator
+sSlakingPose74:
+ax_pose 28, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakingPose75:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose76:
+ax_pose 10, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose77:
+ax_pose 11, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose78:
+ax_pose 29, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose79:
+ax_pose 30, 0x01e5, 0x90f2, 0x4c00
+ax_pose 31, 0x01e5, 0x90ef, 0x4c10
+ax_pose_terminator
+sSlakingPose80:
+ax_pose 31, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose81:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose82:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose83:
+ax_pose 14, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose84:
+ax_pose 32, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose85:
+ax_pose 33, 0x01e5, 0x80f0, 0x4c00
+ax_pose 34, 0x01e5, 0x80f0, 0x4c10
+ax_pose_terminator
+sSlakingPose86:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose87:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose88:
+ax_pose 10, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose89:
+ax_pose 11, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose90:
+ax_pose 29, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose91:
+ax_pose 30, 0x01e5, 0x80ef, 0x4c00
+ax_pose 31, 0x01e5, 0x80f2, 0x4c10
+ax_pose_terminator
+sSlakingPose92:
+ax_pose 31, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose93:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose94:
+ax_pose 7, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose95:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose96:
+ax_pose 26, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose97:
+ax_pose 27, 0x01e5, 0x80ea, 0x4c00
+ax_pose 28, 0x01e5, 0x80f1, 0x4c10
+ax_pose_terminator
+sSlakingPose98:
+ax_pose 28, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose99:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose100:
+ax_pose 4, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose101:
+ax_pose 5, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose102:
+ax_pose 23, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose103:
+ax_pose 24, 0x01e8, 0x80ec, 0x4c00
+ax_pose 25, 0x01e5, 0x80f0, 0x4c10
+ax_pose_terminator
+sSlakingPose104:
+ax_pose 25, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose105:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose106:
+ax_pose 35, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose107:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose108:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose109:
+ax_pose 36, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose110:
+ax_pose 16, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose111:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose112:
+ax_pose 37, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakingPose113:
+ax_pose 17, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakingPose114:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose115:
+ax_pose 38, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose116:
+ax_pose 18, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose117:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose118:
+ax_pose 39, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose119:
+ax_pose 19, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose120:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose121:
+ax_pose 38, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose122:
+ax_pose 18, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose123:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose124:
+ax_pose 37, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose125:
+ax_pose 17, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose126:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose127:
+ax_pose 36, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose128:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose129:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose130:
+ax_pose 40, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose131:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose132:
+ax_pose 41, 0x01e3, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose133:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose134:
+ax_pose 42, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose135:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose136:
+ax_pose 43, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose137:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose138:
+ax_pose 44, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose139:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose140:
+ax_pose 43, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose141:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose142:
+ax_pose 42, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose143:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose144:
+ax_pose 41, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose145:
+ax_pose 45, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose146:
+ax_pose 46, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose147:
+ax_pose 47, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose148:
+ax_pose 48, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sSlakingPose149:
+ax_pose 49, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sSlakingPose150:
+ax_pose 50, 0x01e3, 0x90ed, 0x4c00
+ax_pose_terminator
+sSlakingPose151:
+ax_pose 51, 0x01e1, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose152:
+ax_pose 50, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sSlakingPose153:
+ax_pose 49, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose154:
+ax_pose 48, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose155:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose156:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose157:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose158:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose159:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose160:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose161:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose162:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose163:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose164:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose165:
+ax_pose 17, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose166:
+ax_pose 18, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose167:
+ax_pose 19, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose168:
+ax_pose 18, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose169:
+ax_pose 17, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakingPose170:
+ax_pose 16, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose171:
+ax_pose 35, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose172:
+ax_pose 36, 0x01e6, 0x90f2, 0x4c00
+ax_pose_terminator
+sSlakingPose173:
+ax_pose 37, 0x01e6, 0x90f2, 0x4c00
+ax_pose_terminator
+sSlakingPose174:
+ax_pose 38, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose175:
+ax_pose 39, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose176:
+ax_pose 38, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose177:
+ax_pose 37, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakingPose178:
+ax_pose 36, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakingPose179:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose180:
+ax_pose 40, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose181:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose182:
+ax_pose 41, 0x01e3, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose183:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose184:
+ax_pose 42, 0x01e4, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose185:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose186:
+ax_pose 43, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose187:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose188:
+ax_pose 44, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose189:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose190:
+ax_pose 43, 0x01e3, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose191:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose192:
+ax_pose 42, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose193:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose194:
+ax_pose 41, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose195:
+ax_pose 15, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose196:
+ax_pose 16, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose197:
+ax_pose 17, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakingPose198:
+ax_pose 18, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakingPose199:
+ax_pose 19, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose200:
+ax_pose 18, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakingPose201:
+ax_pose 17, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakingPose202:
+ax_pose 16, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakingPose203:
+ax_pose 0, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose204:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose205:
+ax_pose 6, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose206:
+ax_pose 9, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sSlakingPose207:
+ax_pose 12, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakingPose208:
+ax_pose 9, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose209:
+ax_pose 6, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sSlakingPose210:
+ax_pose 3, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+.align 2
+sSlakingAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 16, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 16, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 16, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 16, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 16, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 16, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 16, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 16, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 16, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 16, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 16, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 16, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 16, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 16, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 16, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 16, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSlakingAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 1, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 31, 16, 19, 16, 19,
+ax_anim 2, 0, 31, 17, 18, 17, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sSlakingAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSlakingAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 1, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sSlakingAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 1, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 1, -17, 1, -17,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sSlakingAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 1, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sSlakingAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sSlakingAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -16, 19, -16, 19,
+ax_anim 2, 1, 55, -17, 18, -17, 18,
+ax_anim 2, 0, 55, -16, 19, -16, 19,
+ax_anim 2, 0, 55, -17, 18, -17, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlakingAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 59, 0, -4, 0, -4,
+ax_anim 6, 0, 59, 0, -5, 0, -5,
+ax_anim 1, 2, 59, 0, -3, 0, -3,
+ax_anim 1, 0, 59, 0, 2, 0, 2,
+ax_anim 2, 0, 60, 0, 14, 0, 14,
+ax_anim 2, 1, 61, 1, 14, 1, 14,
+ax_anim 2, 0, 61, 0, 14, 0, 14,
+ax_anim 2, 0, 61, 1, 14, 1, 14,
+ax_anim 2, 0, 61, 0, 14, 0, 14,
+ax_anim 2, 0, 56, 0, 7, 0, 7,
+ax_anim 2, 0, 56, 0, 3, 0, 3,
+ax_anim_terminator
+sSlakingAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 65, -4, -4, -4, -4,
+ax_anim 6, 0, 65, -5, -5, -5, -5,
+ax_anim 1, 2, 65, -1, -1, -1, -1,
+ax_anim 1, 0, 65, 5, 7, 5, 7,
+ax_anim 2, 0, 66, 12, 15, 12, 15,
+ax_anim 2, 1, 67, 13, 14, 13, 14,
+ax_anim 2, 0, 67, 12, 15, 12, 15,
+ax_anim 2, 0, 67, 13, 14, 13, 14,
+ax_anim 2, 0, 67, 12, 15, 12, 15,
+ax_anim 2, 0, 62, 6, 8, 6, 8,
+ax_anim 2, 0, 62, 3, 3, 3, 3,
+ax_anim_terminator
+sSlakingAnims_3_3:
+ax_anim 2, 0, 68, -2, 0, -2, 0,
+ax_anim 2, 0, 71, -4, 0, -4, 0,
+ax_anim 6, 0, 71, -5, 0, -5, 0,
+ax_anim 1, 2, 71, -1, 0, -1, 0,
+ax_anim 1, 0, 71, 6, 0, 6, 0,
+ax_anim 2, 0, 72, 12, 0, 12, 0,
+ax_anim 2, 1, 73, 12, 1, 12, 1,
+ax_anim 2, 0, 73, 12, 0, 12, 0,
+ax_anim 2, 0, 73, 12, 1, 12, 1,
+ax_anim 2, 0, 73, 12, 0, 12, 0,
+ax_anim 2, 0, 68, 7, 0, 7, 0,
+ax_anim 2, 0, 68, 3, 0, 3, 0,
+ax_anim_terminator
+sSlakingAnims_3_4:
+ax_anim 2, 0, 74, -2, 2, -2, 2,
+ax_anim 2, 0, 77, -4, 4, -4, 4,
+ax_anim 6, 0, 77, -5, 5, -5, 5,
+ax_anim 1, 2, 77, -1, 1, -1, 1,
+ax_anim 1, 0, 77, 7, -6, 7, -6,
+ax_anim 2, 0, 78, 15, -13, 15, -13,
+ax_anim 2, 1, 79, 16, -12, 16, -12,
+ax_anim 2, 0, 79, 15, -13, 15, -13,
+ax_anim 2, 0, 79, 16, -12, 16, -12,
+ax_anim 2, 0, 79, 15, -13, 15, -13,
+ax_anim 2, 0, 74, 8, -7, 8, -7,
+ax_anim 2, 0, 74, 3, -3, 3, -3,
+ax_anim_terminator
+sSlakingAnims_3_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 6, 0, 83, 0, 5, 0, 5,
+ax_anim 1, 2, 83, 0, 3, 0, 3,
+ax_anim 1, 0, 83, 0, -2, 0, -2,
+ax_anim 2, 0, 84, 0, -14, 0, -14,
+ax_anim 2, 1, 85, 1, -14, 1, -14,
+ax_anim 2, 0, 85, 0, -14, 0, -14,
+ax_anim 2, 0, 85, 1, -14, 1, -14,
+ax_anim 2, 0, 85, 0, -14, 0, -14,
+ax_anim 2, 0, 80, 0, -7, 0, -7,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim_terminator
+sSlakingAnims_3_6:
+ax_anim 2, 0, 86, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 4, 4, 4, 4,
+ax_anim 6, 0, 89, 5, 5, 5, 5,
+ax_anim 1, 2, 89, 1, 1, 1, 1,
+ax_anim 1, 0, 89, -7, -6, -7, -6,
+ax_anim 2, 0, 90, -15, -13, -15, -13,
+ax_anim 2, 1, 91, -16, -12, -16, -12,
+ax_anim 2, 0, 91, -15, -13, -15, -13,
+ax_anim 2, 0, 91, -16, -12, -16, -12,
+ax_anim 2, 0, 91, -15, -13, -15, -13,
+ax_anim 2, 0, 86, -8, -7, -8, -7,
+ax_anim 2, 0, 86, -3, -3, -3, -3,
+ax_anim_terminator
+sSlakingAnims_3_7:
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 4, 0, 4, 0,
+ax_anim 6, 0, 95, 5, 0, 5, 0,
+ax_anim 1, 2, 95, 1, 0, 1, 0,
+ax_anim 1, 0, 95, -6, 0, -6, 0,
+ax_anim 2, 0, 96, -12, 0, -12, 0,
+ax_anim 2, 1, 97, -12, 1, -12, 1,
+ax_anim 2, 0, 97, -12, 0, -12, 0,
+ax_anim 2, 0, 97, -12, 1, -12, 1,
+ax_anim 2, 0, 97, -12, 0, -12, 0,
+ax_anim 2, 0, 92, -7, 0, -7, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim_terminator
+sSlakingAnims_3_8:
+ax_anim 2, 0, 98, 2, -2, 2, -2,
+ax_anim 2, 0, 101, 4, -4, 4, -4,
+ax_anim 6, 0, 101, 5, -5, 5, -5,
+ax_anim 1, 2, 101, 1, -1, 1, -1,
+ax_anim 1, 0, 101, -5, 7, -5, 7,
+ax_anim 2, 0, 102, -12, 15, -12, 15,
+ax_anim 2, 1, 103, -13, 14, -13, 14,
+ax_anim 2, 0, 103, -12, 15, -12, 15,
+ax_anim 2, 0, 103, -13, 14, -13, 14,
+ax_anim 2, 0, 103, -12, 15, -12, 15,
+ax_anim 2, 0, 98, -6, 8, -6, 8,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sSlakingAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sSlakingAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sSlakingAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sSlakingAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sSlakingAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sSlakingAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sSlakingAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sSlakingAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSlakingAnims_5_1:
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 4, 0, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 4, 2, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 4, 0, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_5_2:
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 2, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_5_3:
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 4, 0, 133, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 2, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 4, 0, 133, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_5_4:
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 4, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 4, 2, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 4, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_5_5:
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 2, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_5_6:
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 4, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 2, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 4, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_5_7:
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 4, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 4, 2, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 4, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_5_8:
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 4, 0, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 2, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 4, 0, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sSlakingAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sSlakingAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sSlakingAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sSlakingAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sSlakingAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sSlakingAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sSlakingAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSlakingAnims_8_1:
+ax_anim 50, 0, 154, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim 6, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_8_2:
+ax_anim 50, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, -2, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim 6, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim 2, 0, 161, 0, -1, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_8_3:
+ax_anim 50, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, 0,
+ax_anim 6, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_8_4:
+ax_anim 50, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, -1, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, -1, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_8_5:
+ax_anim 50, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 6, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_8_6:
+ax_anim 50, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_8_7:
+ax_anim 50, 0, 156, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_8_8:
+ax_anim 50, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, -2, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim 6, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -2, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 7, 4, 7, 4,
+ax_anim 2, 0, 164, 12, 11, 12, 11,
+ax_anim 2, 0, 165, 8, 19, 8, 19,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -8, 19, -8, 19,
+ax_anim 2, 0, 168, -12, 11, -12, 11,
+ax_anim 1, 0, 169, -7, 4, -7, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, -1, 8, -1,
+ax_anim 2, 0, 163, 17, 7, 17, 7,
+ax_anim 2, 0, 164, 21, 15, 21, 15,
+ax_anim 3, 0, 165, 19, 21, 19, 21,
+ax_anim 2, 3, 166, 10, 21, 10, 21,
+ax_anim 2, 0, 167, 0, 17, 0, 17,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -3, 3, -3,
+ax_anim 2, 0, 162, 10, -6, 10, -6,
+ax_anim 2, 0, 163, 17, -3, 17, -3,
+ax_anim 3, 0, 164, 18, 0, 18, 0,
+ax_anim 2, 3, 165, 15, 5, 15, 5,
+ax_anim 2, 0, 166, 9, 7, 9, 7,
+ax_anim 1, 0, 167, 3, 5, 3, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 3, -17, 3, -17,
+ax_anim 2, 0, 162, 10, -22, 10, -22,
+ax_anim 3, 0, 163, 18, -22, 18, -22,
+ax_anim 2, 3, 164, 22, -18, 22, -18,
+ax_anim 2, 0, 165, 18, -8, 18, -8,
+ax_anim 1, 0, 166, 9, -2, 9, -2,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -9, -4, -9, -4,
+ax_anim 2, 0, 168, -11, -12, -11, -12,
+ax_anim 2, 0, 169, -8, -19, -8, -19,
+ax_anim 3, 0, 162, 0, -23, 0, -23,
+ax_anim 2, 3, 163, 8, -19, 8, -19,
+ax_anim 2, 0, 164, 11, -12, 11, -12,
+ax_anim 1, 0, 165, 9, -4, 9, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -2, -17, -2, -17,
+ax_anim 2, 0, 162, -10, -23, -10, -23,
+ax_anim 3, 0, 169, -18, -22, -18, -22,
+ax_anim 2, 3, 168, -22, -16, -22, -16,
+ax_anim 2, 0, 167, -19, -6, -19, -6,
+ax_anim 1, 0, 166, -9, -1, -9, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -3, -3, -3,
+ax_anim 2, 0, 162, -10, -6, -10, -6,
+ax_anim 2, 0, 169, -16, -4, -16, -4,
+ax_anim 3, 0, 168, -18, 0, -18, 0,
+ax_anim 2, 3, 167, -15, 5, -15, 5,
+ax_anim 2, 0, 166, -9, 5, -9, 5,
+ax_anim 1, 0, 165, -3, 5, -3, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, -1, -8, -1,
+ax_anim 2, 0, 169, -18, 7, -18, 7,
+ax_anim 2, 0, 168, -21, 14, -21, 14,
+ax_anim 3, 0, 167, -19, 21, -19, 21,
+ax_anim 2, 3, 166, -10, 21, -10, 21,
+ax_anim 2, 0, 165, -3, 16, -3, 16,
+ax_anim 1, 0, 164, 1, 7, 1, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_11_1:
+ax_anim 2, 0, 178, 0, 2, 0, 0,
+ax_anim 1, 0, 179, 0, -7, 0, 0,
+ax_anim 2, 0, 179, 0, -13, 0, 0,
+ax_anim 3, 0, 179, 0, -17, 0, 0,
+ax_anim 4, 0, 179, 0, -18, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_11_2:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -6, 0, 0,
+ax_anim 2, 0, 181, 0, -12, 0, 0,
+ax_anim 3, 0, 181, 0, -16, 0, 0,
+ax_anim 4, 0, 181, 0, -17, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_11_3:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -8, 0, 0,
+ax_anim 2, 0, 183, 0, -14, 0, 0,
+ax_anim 3, 0, 183, 0, -18, 0, 0,
+ax_anim 4, 0, 183, 0, -19, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_11_4:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -7, 0, 0,
+ax_anim 2, 0, 185, 0, -13, 0, 0,
+ax_anim 3, 0, 185, 0, -17, 0, 0,
+ax_anim 4, 0, 185, 0, -18, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_11_5:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -8, 0, 0,
+ax_anim 2, 0, 187, 0, -14, 0, 0,
+ax_anim 3, 0, 187, 0, -18, 0, 0,
+ax_anim 4, 0, 187, 0, -19, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_11_6:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -7, 0, 0,
+ax_anim 2, 0, 189, 0, -13, 0, 0,
+ax_anim 3, 0, 189, 0, -17, 0, 0,
+ax_anim 4, 0, 189, 0, -18, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_11_7:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -8, 0, 0,
+ax_anim 2, 0, 191, 0, -14, 0, 0,
+ax_anim 3, 0, 191, 0, -18, 0, 0,
+ax_anim 4, 0, 191, 0, -19, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_11_8:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -6, 0, 0,
+ax_anim 2, 0, 193, 0, -12, 0, 0,
+ax_anim 3, 0, 193, 0, -16, 0, 0,
+ax_anim 4, 0, 193, 0, -17, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakingAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakingGfx1:
+.incbin "baserom.gba", 0x11C5104, 0x200
+sSlakingSprites1:
+ax_sprite sSlakingGfx1, 0x200
+ax_sprite_terminator
+sSlakingGfx2:
+.incbin "baserom.gba", 0x11C5314, 0x200
+sSlakingSprites2:
+ax_sprite sSlakingGfx2, 0x200
+ax_sprite_terminator
+sSlakingGfx3:
+.incbin "baserom.gba", 0x11C5524, 0x200
+sSlakingSprites3:
+ax_sprite sSlakingGfx3, 0x200
+ax_sprite_terminator
+sSlakingGfx4:
+.incbin "baserom.gba", 0x11C5734, 0x200
+sSlakingSprites4:
+ax_sprite sSlakingGfx4, 0x200
+ax_sprite_terminator
+sSlakingGfx5:
+.incbin "baserom.gba", 0x11C5944, 0x200
+sSlakingSprites5:
+ax_sprite sSlakingGfx5, 0x200
+ax_sprite_terminator
+sSlakingGfx6:
+.incbin "baserom.gba", 0x11C5B54, 0x200
+sSlakingSprites6:
+ax_sprite sSlakingGfx6, 0x200
+ax_sprite_terminator
+sSlakingGfx7:
+.incbin "baserom.gba", 0x11C5D64, 0x200
+sSlakingSprites7:
+ax_sprite sSlakingGfx7, 0x200
+ax_sprite_terminator
+sSlakingGfx8:
+.incbin "baserom.gba", 0x11C5F74, 0x200
+sSlakingSprites8:
+ax_sprite sSlakingGfx8, 0x200
+ax_sprite_terminator
+sSlakingGfx9:
+.incbin "baserom.gba", 0x11C6184, 0x200
+sSlakingSprites9:
+ax_sprite sSlakingGfx9, 0x200
+ax_sprite_terminator
+sSlakingGfx10:
+.incbin "baserom.gba", 0x11C6394, 0x200
+sSlakingSprites10:
+ax_sprite sSlakingGfx10, 0x200
+ax_sprite_terminator
+sSlakingGfx11:
+.incbin "baserom.gba", 0x11C65A4, 0x200
+sSlakingSprites11:
+ax_sprite sSlakingGfx11, 0x200
+ax_sprite_terminator
+sSlakingGfx12:
+.incbin "baserom.gba", 0x11C67B4, 0x200
+sSlakingSprites12:
+ax_sprite sSlakingGfx12, 0x200
+ax_sprite_terminator
+sSlakingGfx13:
+.incbin "baserom.gba", 0x11C69C4, 0x200
+sSlakingSprites13:
+ax_sprite sSlakingGfx13, 0x200
+ax_sprite_terminator
+sSlakingGfx14:
+.incbin "baserom.gba", 0x11C6BD4, 0x200
+sSlakingSprites14:
+ax_sprite sSlakingGfx14, 0x200
+ax_sprite_terminator
+sSlakingGfx15:
+.incbin "baserom.gba", 0x11C6DE4, 0x200
+sSlakingSprites15:
+ax_sprite sSlakingGfx15, 0x200
+ax_sprite_terminator
+sSlakingGfx16:
+.incbin "baserom.gba", 0x11C6FF4, 0x40
+sSlakingGfx16_1:
+.incbin "baserom.gba", 0x11C7034, 0x160
+sSlakingSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx16_1, 0x160
+ax_sprite_terminator
+sSlakingGfx17:
+.incbin "baserom.gba", 0x11C71BC, 0x20
+sSlakingGfx17_1:
+.incbin "baserom.gba", 0x11C71DC, 0x180
+sSlakingSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx17_1, 0x180
+ax_sprite_terminator
+sSlakingGfx18:
+.incbin "baserom.gba", 0x11C7384, 0x40
+sSlakingGfx18_1:
+.incbin "baserom.gba", 0x11C73C4, 0x180
+sSlakingSprites18:
+ax_sprite sSlakingGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx18_1, 0x180
+ax_sprite_terminator
+sSlakingGfx19:
+.incbin "baserom.gba", 0x11C7564, 0x40
+sSlakingGfx19_1:
+.incbin "baserom.gba", 0x11C75A4, 0x60
+sSlakingGfx19_2:
+.incbin "baserom.gba", 0x11C7604, 0x100
+sSlakingSprites19:
+ax_sprite sSlakingGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx19_2, 0x100
+ax_sprite_terminator
+sSlakingGfx20:
+.incbin "baserom.gba", 0x11C7734, 0x40
+sSlakingGfx20_1:
+.incbin "baserom.gba", 0x11C7774, 0x180
+sSlakingSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx20_1, 0x180
+ax_sprite_terminator
+sSlakingGfx21:
+.incbin "baserom.gba", 0x11C791C, 0x60
+sSlakingGfx21_1:
+.incbin "baserom.gba", 0x11C797C, 0x80
+sSlakingGfx21_2:
+.incbin "baserom.gba", 0x11C79FC, 0x60
+sSlakingGfx21_3:
+.incbin "baserom.gba", 0x11C7A5C, 0x60
+sSlakingSprites21:
+ax_sprite sSlakingGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx21_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx21_3, 0x60
+ax_sprite_terminator
+sSlakingGfx22:
+.incbin "baserom.gba", 0x11C7AFC, 0x20
+sSlakingGfx22_1:
+.incbin "baserom.gba", 0x11C7B1C, 0x20
+sSlakingGfx22_2:
+.incbin "baserom.gba", 0x11C7B3C, 0x20
+sSlakingGfx22_3:
+.incbin "baserom.gba", 0x11C7B5C, 0xC0
+sSlakingSprites22:
+ax_sprite sSlakingGfx22, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSlakingGfx22_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSlakingGfx22_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx22_3, 0xc0
+ax_sprite_terminator
+sSlakingGfx23:
+.incbin "baserom.gba", 0x11C7C5C, 0x1C0
+sSlakingSprites23:
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx23, 0x1c0
+ax_sprite_terminator
+sSlakingGfx24:
+.incbin "baserom.gba", 0x11C7E34, 0x160
+sSlakingGfx24_1:
+.incbin "baserom.gba", 0x11C7F94, 0x60
+sSlakingSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx24, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx24_1, 0x60
+ax_sprite_terminator
+sSlakingGfx25:
+.incbin "baserom.gba", 0x11C801C, 0x40
+sSlakingGfx25_1:
+.incbin "baserom.gba", 0x11C805C, 0x20
+sSlakingGfx25_2:
+.incbin "baserom.gba", 0x11C807C, 0x20
+sSlakingGfx25_3:
+.incbin "baserom.gba", 0x11C809C, 0x20
+sSlakingGfx25_4:
+.incbin "baserom.gba", 0x11C80BC, 0x80
+sSlakingSprites25:
+ax_sprite sSlakingGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx25_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSlakingGfx25_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx25_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx25_4, 0x80
+ax_sprite_terminator
+sSlakingGfx26:
+.incbin "baserom.gba", 0x11C818C, 0x40
+sSlakingGfx26_1:
+.incbin "baserom.gba", 0x11C81CC, 0x100
+sSlakingGfx26_2:
+.incbin "baserom.gba", 0x11C82CC, 0x60
+sSlakingSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx26_2, 0x60
+ax_sprite_terminator
+sSlakingGfx27:
+.incbin "baserom.gba", 0x11C8364, 0x160
+sSlakingGfx27_1:
+.incbin "baserom.gba", 0x11C84C4, 0x60
+sSlakingSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx27, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx27_1, 0x60
+ax_sprite_terminator
+sSlakingGfx28:
+.incbin "baserom.gba", 0x11C854C, 0xC0
+sSlakingGfx28_1:
+.incbin "baserom.gba", 0x11C860C, 0x60
+sSlakingGfx28_2:
+.incbin "baserom.gba", 0x11C866C, 0x60
+sSlakingSprites28:
+ax_sprite sSlakingGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlakingGfx29:
+.incbin "baserom.gba", 0x11C8704, 0x40
+sSlakingGfx29_1:
+.incbin "baserom.gba", 0x11C8744, 0x180
+sSlakingSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx29_1, 0x180
+ax_sprite_terminator
+sSlakingGfx30:
+.incbin "baserom.gba", 0x11C88EC, 0x1E0
+sSlakingSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx30, 0x1e0
+ax_sprite_terminator
+sSlakingGfx31:
+.incbin "baserom.gba", 0x11C8AE4, 0xA0
+sSlakingGfx31_1:
+.incbin "baserom.gba", 0x11C8B84, 0x60
+sSlakingGfx31_2:
+.incbin "baserom.gba", 0x11C8BE4, 0x20
+sSlakingSprites31:
+ax_sprite sSlakingGfx31, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx31_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSlakingGfx32:
+.incbin "baserom.gba", 0x11C8C3C, 0x20
+sSlakingGfx32_1:
+.incbin "baserom.gba", 0x11C8C5C, 0x180
+sSlakingSprites32:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx32, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx32_1, 0x180
+ax_sprite_terminator
+sSlakingGfx33:
+.incbin "baserom.gba", 0x11C8E04, 0x140
+sSlakingGfx33_1:
+.incbin "baserom.gba", 0x11C8F44, 0x60
+sSlakingSprites33:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx33, 0x140
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlakingGfx34:
+.incbin "baserom.gba", 0x11C8FD4, 0x120
+sSlakingSprites34:
+ax_sprite sSlakingGfx34, 0x120
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sSlakingGfx35:
+.incbin "baserom.gba", 0x11C910C, 0x40
+sSlakingGfx35_1:
+.incbin "baserom.gba", 0x11C914C, 0x60
+sSlakingGfx35_2:
+.incbin "baserom.gba", 0x11C91AC, 0x100
+sSlakingSprites35:
+ax_sprite sSlakingGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlakingGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx35_2, 0x100
+ax_sprite_terminator
+sSlakingGfx36:
+.incbin "baserom.gba", 0x11C92DC, 0x40
+sSlakingGfx36_1:
+.incbin "baserom.gba", 0x11C931C, 0x180
+sSlakingSprites36:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx36_1, 0x180
+ax_sprite_terminator
+sSlakingGfx37:
+.incbin "baserom.gba", 0x11C94C4, 0x40
+sSlakingGfx37_1:
+.incbin "baserom.gba", 0x11C9504, 0x100
+sSlakingGfx37_2:
+.incbin "baserom.gba", 0x11C9604, 0x60
+sSlakingSprites37:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx37_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx37_2, 0x60
+ax_sprite_terminator
+sSlakingGfx38:
+.incbin "baserom.gba", 0x11C969C, 0x40
+sSlakingGfx38_1:
+.incbin "baserom.gba", 0x11C96DC, 0x100
+sSlakingGfx38_2:
+.incbin "baserom.gba", 0x11C97DC, 0x60
+sSlakingSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx38_2, 0x60
+ax_sprite_terminator
+sSlakingGfx39:
+.incbin "baserom.gba", 0x11C9874, 0x40
+sSlakingGfx39_1:
+.incbin "baserom.gba", 0x11C98B4, 0x100
+sSlakingGfx39_2:
+.incbin "baserom.gba", 0x11C99B4, 0x60
+sSlakingSprites39:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx39_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx39_2, 0x60
+ax_sprite_terminator
+sSlakingGfx40:
+.incbin "baserom.gba", 0x11C9A4C, 0x40
+sSlakingGfx40_1:
+.incbin "baserom.gba", 0x11C9A8C, 0x180
+sSlakingSprites40:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx40_1, 0x180
+ax_sprite_terminator
+sSlakingGfx41:
+.incbin "baserom.gba", 0x11C9C34, 0x1E0
+sSlakingSprites41:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx41, 0x1e0
+ax_sprite_terminator
+sSlakingGfx42:
+.incbin "baserom.gba", 0x11C9E2C, 0x40
+sSlakingGfx42_1:
+.incbin "baserom.gba", 0x11C9E6C, 0x180
+sSlakingSprites42:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx42_1, 0x180
+ax_sprite_terminator
+sSlakingGfx43:
+.incbin "baserom.gba", 0x11CA014, 0x60
+sSlakingGfx43_1:
+.incbin "baserom.gba", 0x11CA074, 0x100
+sSlakingGfx43_2:
+.incbin "baserom.gba", 0x11CA174, 0x60
+sSlakingSprites43:
+ax_sprite sSlakingGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx43_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx43_2, 0x60
+ax_sprite_terminator
+sSlakingGfx44:
+.incbin "baserom.gba", 0x11CA204, 0x60
+sSlakingGfx44_1:
+.incbin "baserom.gba", 0x11CA264, 0x180
+sSlakingSprites44:
+ax_sprite sSlakingGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx44_1, 0x180
+ax_sprite_terminator
+sSlakingGfx45:
+.incbin "baserom.gba", 0x11CA404, 0x40
+sSlakingGfx45_1:
+.incbin "baserom.gba", 0x11CA444, 0x180
+sSlakingSprites45:
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakingGfx45_1, 0x180
+ax_sprite_terminator
+sSlakingGfx46:
+.incbin "baserom.gba", 0x11CA5EC, 0x200
+sSlakingSprites46:
+ax_sprite sSlakingGfx46, 0x200
+ax_sprite_terminator
+sSlakingGfx47:
+.incbin "baserom.gba", 0x11CA7FC, 0x200
+sSlakingSprites47:
+ax_sprite sSlakingGfx47, 0x200
+ax_sprite_terminator
+sSlakingGfx48:
+.incbin "baserom.gba", 0x11CAA0C, 0x200
+sSlakingSprites48:
+ax_sprite sSlakingGfx48, 0x200
+ax_sprite_terminator
+sSlakingGfx49:
+.incbin "baserom.gba", 0x11CAC1C, 0x200
+sSlakingSprites49:
+ax_sprite sSlakingGfx49, 0x200
+ax_sprite_terminator
+sSlakingGfx50:
+.incbin "baserom.gba", 0x11CAE2C, 0x200
+sSlakingSprites50:
+ax_sprite sSlakingGfx50, 0x200
+ax_sprite_terminator
+sSlakingGfx51:
+.incbin "baserom.gba", 0x11CB03C, 0x200
+sSlakingSprites51:
+ax_sprite sSlakingGfx51, 0x200
+ax_sprite_terminator
+sSlakingGfx52:
+.incbin "baserom.gba", 0x11CB24C, 0x200
+sSlakingSprites52:
+ax_sprite sSlakingGfx52, 0x200
+ax_sprite_terminator
+sAxPosesSlaking:
+.4byte sSlakingPose1
+.4byte sSlakingPose2
+.4byte sSlakingPose3
+.4byte sSlakingPose4
+.4byte sSlakingPose5
+.4byte sSlakingPose6
+.4byte sSlakingPose7
+.4byte sSlakingPose8
+.4byte sSlakingPose9
+.4byte sSlakingPose10
+.4byte sSlakingPose11
+.4byte sSlakingPose12
+.4byte sSlakingPose13
+.4byte sSlakingPose14
+.4byte sSlakingPose15
+.4byte sSlakingPose16
+.4byte sSlakingPose17
+.4byte sSlakingPose18
+.4byte sSlakingPose19
+.4byte sSlakingPose20
+.4byte sSlakingPose21
+.4byte sSlakingPose22
+.4byte sSlakingPose23
+.4byte sSlakingPose24
+.4byte sSlakingPose25
+.4byte sSlakingPose26
+.4byte sSlakingPose27
+.4byte sSlakingPose28
+.4byte sSlakingPose29
+.4byte sSlakingPose30
+.4byte sSlakingPose31
+.4byte sSlakingPose32
+.4byte sSlakingPose33
+.4byte sSlakingPose34
+.4byte sSlakingPose35
+.4byte sSlakingPose36
+.4byte sSlakingPose37
+.4byte sSlakingPose38
+.4byte sSlakingPose39
+.4byte sSlakingPose40
+.4byte sSlakingPose41
+.4byte sSlakingPose42
+.4byte sSlakingPose43
+.4byte sSlakingPose44
+.4byte sSlakingPose45
+.4byte sSlakingPose46
+.4byte sSlakingPose47
+.4byte sSlakingPose48
+.4byte sSlakingPose49
+.4byte sSlakingPose50
+.4byte sSlakingPose51
+.4byte sSlakingPose52
+.4byte sSlakingPose53
+.4byte sSlakingPose54
+.4byte sSlakingPose55
+.4byte sSlakingPose56
+.4byte sSlakingPose57
+.4byte sSlakingPose58
+.4byte sSlakingPose59
+.4byte sSlakingPose60
+.4byte sSlakingPose61
+.4byte sSlakingPose62
+.4byte sSlakingPose63
+.4byte sSlakingPose64
+.4byte sSlakingPose65
+.4byte sSlakingPose66
+.4byte sSlakingPose67
+.4byte sSlakingPose68
+.4byte sSlakingPose69
+.4byte sSlakingPose70
+.4byte sSlakingPose71
+.4byte sSlakingPose72
+.4byte sSlakingPose73
+.4byte sSlakingPose74
+.4byte sSlakingPose75
+.4byte sSlakingPose76
+.4byte sSlakingPose77
+.4byte sSlakingPose78
+.4byte sSlakingPose79
+.4byte sSlakingPose80
+.4byte sSlakingPose81
+.4byte sSlakingPose82
+.4byte sSlakingPose83
+.4byte sSlakingPose84
+.4byte sSlakingPose85
+.4byte sSlakingPose86
+.4byte sSlakingPose87
+.4byte sSlakingPose88
+.4byte sSlakingPose89
+.4byte sSlakingPose90
+.4byte sSlakingPose91
+.4byte sSlakingPose92
+.4byte sSlakingPose93
+.4byte sSlakingPose94
+.4byte sSlakingPose95
+.4byte sSlakingPose96
+.4byte sSlakingPose97
+.4byte sSlakingPose98
+.4byte sSlakingPose99
+.4byte sSlakingPose100
+.4byte sSlakingPose101
+.4byte sSlakingPose102
+.4byte sSlakingPose103
+.4byte sSlakingPose104
+.4byte sSlakingPose105
+.4byte sSlakingPose106
+.4byte sSlakingPose107
+.4byte sSlakingPose108
+.4byte sSlakingPose109
+.4byte sSlakingPose110
+.4byte sSlakingPose111
+.4byte sSlakingPose112
+.4byte sSlakingPose113
+.4byte sSlakingPose114
+.4byte sSlakingPose115
+.4byte sSlakingPose116
+.4byte sSlakingPose117
+.4byte sSlakingPose118
+.4byte sSlakingPose119
+.4byte sSlakingPose120
+.4byte sSlakingPose121
+.4byte sSlakingPose122
+.4byte sSlakingPose123
+.4byte sSlakingPose124
+.4byte sSlakingPose125
+.4byte sSlakingPose126
+.4byte sSlakingPose127
+.4byte sSlakingPose128
+.4byte sSlakingPose129
+.4byte sSlakingPose130
+.4byte sSlakingPose131
+.4byte sSlakingPose132
+.4byte sSlakingPose133
+.4byte sSlakingPose134
+.4byte sSlakingPose135
+.4byte sSlakingPose136
+.4byte sSlakingPose137
+.4byte sSlakingPose138
+.4byte sSlakingPose139
+.4byte sSlakingPose140
+.4byte sSlakingPose141
+.4byte sSlakingPose142
+.4byte sSlakingPose143
+.4byte sSlakingPose144
+.4byte sSlakingPose145
+.4byte sSlakingPose146
+.4byte sSlakingPose147
+.4byte sSlakingPose148
+.4byte sSlakingPose149
+.4byte sSlakingPose150
+.4byte sSlakingPose151
+.4byte sSlakingPose152
+.4byte sSlakingPose153
+.4byte sSlakingPose154
+.4byte sSlakingPose155
+.4byte sSlakingPose156
+.4byte sSlakingPose157
+.4byte sSlakingPose158
+.4byte sSlakingPose159
+.4byte sSlakingPose160
+.4byte sSlakingPose161
+.4byte sSlakingPose162
+.4byte sSlakingPose163
+.4byte sSlakingPose164
+.4byte sSlakingPose165
+.4byte sSlakingPose166
+.4byte sSlakingPose167
+.4byte sSlakingPose168
+.4byte sSlakingPose169
+.4byte sSlakingPose170
+.4byte sSlakingPose171
+.4byte sSlakingPose172
+.4byte sSlakingPose173
+.4byte sSlakingPose174
+.4byte sSlakingPose175
+.4byte sSlakingPose176
+.4byte sSlakingPose177
+.4byte sSlakingPose178
+.4byte sSlakingPose179
+.4byte sSlakingPose180
+.4byte sSlakingPose181
+.4byte sSlakingPose182
+.4byte sSlakingPose183
+.4byte sSlakingPose184
+.4byte sSlakingPose185
+.4byte sSlakingPose186
+.4byte sSlakingPose187
+.4byte sSlakingPose188
+.4byte sSlakingPose189
+.4byte sSlakingPose190
+.4byte sSlakingPose191
+.4byte sSlakingPose192
+.4byte sSlakingPose193
+.4byte sSlakingPose194
+.4byte sSlakingPose195
+.4byte sSlakingPose196
+.4byte sSlakingPose197
+.4byte sSlakingPose198
+.4byte sSlakingPose199
+.4byte sSlakingPose200
+.4byte sSlakingPose201
+.4byte sSlakingPose202
+.4byte sSlakingPose203
+.4byte sSlakingPose204
+.4byte sSlakingPose205
+.4byte sSlakingPose206
+.4byte sSlakingPose207
+.4byte sSlakingPose208
+.4byte sSlakingPose209
+.4byte sSlakingPose210
+sAxPositionsSlaking:
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte   -1,   -8, 	  -8,    3, 	   8,    1, 	  -1,   -7
+.2byte    1,   -8, 	  -8,    1, 	   9,    3, 	   1,   -7
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+.2byte    7,   -8, 	  12,    0, 	  -2,    1, 	   0,  -10
+.2byte    6,   -7, 	   6,   -1, 	   1,    3, 	  -1,   -9
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    9,  -11, 	  10,   -4, 	   2,    0, 	   0,  -11
+.2byte    9,  -10, 	   2,   -4, 	   8,    0, 	   0,  -10
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    2,  -14, 	  -2,  -11, 	   6,   -1, 	  -3,  -13
+.2byte    5,  -14, 	  -8,   -6, 	  10,   -3, 	  -1,  -12
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    1,  -14, 	  10,   -6, 	 -10,   -3, 	   0,  -10
+.2byte   -1,  -14, 	  10,   -3, 	 -10,   -6, 	   0,  -10
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte   -2,  -14, 	   2,  -11, 	  -6,   -1, 	   3,  -13
+.2byte   -5,  -14, 	   8,   -6, 	 -10,   -3, 	   1,  -12
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -9,  -11, 	 -10,   -4, 	  -2,    0, 	   0,  -11
+.2byte   -9,  -10, 	  -2,   -4, 	  -8,    0, 	   0,  -10
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -7,   -8, 	 -12,    0, 	   2,    1, 	   0,  -10
+.2byte   -6,   -7, 	  -6,   -1, 	  -1,    3, 	   1,   -9
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte   -1,   -8, 	  -8,    3, 	   8,    1, 	  -1,   -7
+.2byte    1,   -8, 	  -8,    1, 	   9,    3, 	   1,   -7
+.2byte    0,   -5, 	  -9,    1, 	   9,    1, 	   0,   -7
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+.2byte    7,   -8, 	  12,    0, 	  -2,    1, 	   0,  -10
+.2byte    6,   -7, 	   6,   -1, 	   1,    3, 	  -1,   -9
+.2byte    6,   -7, 	  11,   -1, 	  -1,    2, 	   0,  -11
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    9,  -11, 	  10,   -4, 	   2,    0, 	   0,  -11
+.2byte    9,  -10, 	   2,   -4, 	   8,    0, 	   0,  -10
+.2byte    9,   -9, 	   5,   -3, 	   5,    1, 	   1,  -10
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    2,  -14, 	  -2,  -11, 	   6,   -1, 	  -3,  -13
+.2byte    5,  -14, 	  -8,   -6, 	  10,   -3, 	  -1,  -12
+.2byte    6,  -13, 	  -6,   -8, 	   8,   -2, 	   0,  -13
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    1,  -14, 	  10,   -6, 	 -10,   -3, 	   0,  -10
+.2byte   -1,  -14, 	  10,   -3, 	 -10,   -6, 	   0,  -10
+.2byte    0,  -14, 	  11,   -5, 	 -11,   -5, 	   0,  -12
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte   -2,  -14, 	   2,  -11, 	  -6,   -1, 	   3,  -13
+.2byte   -5,  -14, 	   8,   -6, 	 -10,   -3, 	   1,  -12
+.2byte   -6,  -13, 	   6,   -8, 	  -8,   -2, 	   0,  -13
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -9,  -11, 	 -10,   -4, 	  -2,    0, 	   0,  -11
+.2byte   -9,  -10, 	  -2,   -4, 	  -8,    0, 	   0,  -10
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,  -10
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -7,   -8, 	 -12,    0, 	   2,    1, 	   0,  -10
+.2byte   -6,   -7, 	  -6,   -1, 	  -1,    3, 	   1,   -9
+.2byte   -6,   -7, 	 -11,   -1, 	   1,    2, 	   0,  -11
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte   -1,   -8, 	  -8,    3, 	   8,    1, 	  -1,   -7
+.2byte    1,   -8, 	  -8,    1, 	   9,    3, 	   1,   -7
+.2byte   -5,  -10, 	  -8,  -23, 	  -3,   -1, 	   2,  -12
+.2byte    7,   -8, 	  10,   -2, 	  11,  -16, 	  -2,   -9
+.2byte    7,   -8, 	  10,   -2, 	  11,  -16, 	  -2,   -9
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+.2byte    7,   -8, 	  12,    0, 	  -2,    1, 	   0,  -10
+.2byte    6,   -7, 	   6,   -1, 	   1,    3, 	  -1,   -9
+.2byte    7,  -12, 	  -4,  -24, 	   7,   -3, 	  -2,  -13
+.2byte   -1,   -8, 	  -3,    1, 	 -12,  -13, 	  -1,   -7
+.2byte   -1,   -8, 	  -3,    1, 	 -12,  -13, 	  -1,   -7
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    9,  -11, 	  10,   -4, 	   2,    0, 	   0,  -11
+.2byte    9,  -10, 	   2,   -4, 	   8,    0, 	   0,  -10
+.2byte    4,  -15, 	  -8,  -23, 	   5,   -7, 	  -2,  -14
+.2byte    5,   -7, 	   2,    0, 	 -10,  -10, 	  -1,   -9
+.2byte    5,   -7, 	   2,    0, 	 -10,  -10, 	  -1,   -9
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    2,  -14, 	  -2,  -11, 	   6,   -1, 	  -3,  -13
+.2byte    5,  -14, 	  -8,   -6, 	  10,   -3, 	  -1,  -12
+.2byte   -1,  -15, 	 -12,  -20, 	   4,   -7, 	  -1,  -11
+.2byte    7,  -10, 	  11,   -2, 	  -3,   -8, 	  -2,  -10
+.2byte    7,  -10, 	  11,   -2, 	  -3,   -8, 	  -2,  -10
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    1,  -14, 	  10,   -6, 	 -10,   -3, 	   0,  -10
+.2byte   -1,  -14, 	  10,   -3, 	 -10,   -6, 	   0,  -10
+.2byte    2,  -15, 	   9,  -20, 	  -3,   -7, 	  -3,  -11
+.2byte   -6,  -12, 	 -13,   -6, 	  -5,   -1, 	  -1,  -12
+.2byte   -6,  -12, 	 -13,   -6, 	  -5,   -1, 	  -1,  -12
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte   -2,  -14, 	   2,  -11, 	  -6,   -1, 	   3,  -13
+.2byte   -5,  -14, 	   8,   -6, 	 -10,   -3, 	   1,  -12
+.2byte    1,  -15, 	  12,  -20, 	  -4,   -7, 	   1,  -11
+.2byte   -7,  -10, 	 -11,   -2, 	   3,   -8, 	   2,  -10
+.2byte   -7,  -10, 	 -11,   -2, 	   3,   -8, 	   2,  -10
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -9,  -11, 	 -10,   -4, 	  -2,    0, 	   0,  -11
+.2byte   -9,  -10, 	  -2,   -4, 	  -8,    0, 	   0,  -10
+.2byte   -4,  -15, 	   8,  -23, 	  -5,   -7, 	   2,  -14
+.2byte   -5,   -7, 	  -2,    0, 	  10,  -10, 	   1,   -9
+.2byte   -5,   -7, 	  -2,    0, 	  10,  -10, 	   1,   -9
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -7,   -8, 	 -12,    0, 	   2,    1, 	   0,  -10
+.2byte   -6,   -7, 	  -6,   -1, 	  -1,    3, 	   1,   -9
+.2byte   -7,  -12, 	   4,  -24, 	  -7,   -3, 	   2,  -13
+.2byte    1,   -8, 	   3,    1, 	  12,  -13, 	   1,   -7
+.2byte    1,   -8, 	   3,    1, 	  12,  -13, 	   1,   -7
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,  -12
+.2byte    0,   -5, 	  -9,    1, 	   9,    1, 	   0,   -7
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+.2byte    6,  -14, 	  11,  -10, 	  -4,   -5, 	  -1,  -13
+.2byte    6,   -7, 	  11,   -1, 	  -1,    2, 	   0,  -11
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    6,  -14, 	   8,  -11, 	   4,   -6, 	  -2,  -13
+.2byte    9,   -9, 	   5,   -3, 	   5,    1, 	   1,  -10
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    2,  -16, 	  -5,  -15, 	   8,  -10, 	  -4,  -14
+.2byte    6,  -13, 	  -6,   -8, 	   8,   -2, 	   0,  -13
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    0,  -16, 	  11,  -13, 	 -11,  -13, 	   0,  -11
+.2byte    0,  -14, 	  11,   -5, 	 -11,   -5, 	   0,  -12
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte   -2,  -16, 	   5,  -15, 	  -8,  -10, 	   4,  -14
+.2byte   -6,  -13, 	   6,   -8, 	  -8,   -2, 	   0,  -13
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -6,  -14, 	  -8,  -11, 	  -4,   -6, 	   2,  -13
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,  -10
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -6,  -14, 	 -11,  -10, 	   4,   -5, 	   1,  -13
+.2byte   -6,   -7, 	 -11,   -1, 	   1,    2, 	   0,  -11
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte    0,  -13, 	 -10,   -4, 	  10,   -4, 	   0,  -12
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+.2byte    6,  -14, 	   9,   -7, 	  -7,   -2, 	  -2,  -15
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    6,  -14, 	   0,   -8, 	   0,   -2, 	  -3,  -14
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    3,  -18, 	  -7,  -14, 	   8,   -5, 	  -3,  -14
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    0,  -18, 	  10,   -7, 	 -10,   -7, 	   0,  -13
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte   -3,  -18, 	   7,  -14, 	  -8,   -5, 	   3,  -14
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -6,  -14, 	   0,   -8, 	   0,   -2, 	   3,  -14
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -6,  -14, 	  -9,   -7, 	   7,   -2, 	   2,  -15
+.2byte    0,   -6, 	  -9,   -9, 	  10,   -7, 	  -2,   -7
+.2byte   -1,   -6, 	  -9,   -8, 	   9,   -7, 	  -3,   -7
+.2byte    0,  -12, 	 -11,  -11, 	  12,  -16, 	   0,  -11
+.2byte   -1,  -16, 	  10,  -17, 	 -13,  -10, 	   1,  -12
+.2byte    2,  -14, 	   7,  -19, 	  -7,  -10, 	   1,  -11
+.2byte   -1,  -15, 	  -3,  -22, 	   8,  -16, 	  -2,  -10
+.2byte    0,  -14, 	  10,  -17, 	  -8,  -20, 	   0,  -10
+.2byte    1,  -15, 	   3,  -22, 	  -8,  -16, 	   2,  -10
+.2byte   -3,  -14, 	  -8,  -19, 	   6,  -10, 	  -2,  -11
+.2byte    0,  -16, 	 -11,  -17, 	  12,  -10, 	  -2,  -12
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+.2byte    0,   -5, 	  -9,    1, 	   9,    1, 	   0,   -7
+.2byte   -6,   -7, 	 -11,   -1, 	   1,    2, 	   0,  -11
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,  -10
+.2byte   -6,  -13, 	   6,   -8, 	  -8,   -2, 	   0,  -13
+.2byte    0,  -14, 	  11,   -5, 	 -11,   -5, 	   0,  -12
+.2byte    6,  -13, 	  -6,   -8, 	   8,   -2, 	   0,  -13
+.2byte    9,   -9, 	   5,   -3, 	   5,    1, 	   1,  -10
+.2byte    6,   -7, 	  11,   -1, 	  -1,    2, 	   0,  -11
+.2byte    0,  -13, 	 -12,   -7, 	  12,   -7, 	   0,  -12
+.2byte    7,  -13, 	  12,   -9, 	  -3,   -4, 	   0,  -12
+.2byte    8,  -13, 	  10,  -10, 	   6,   -5, 	   0,  -12
+.2byte    4,  -15, 	  -3,  -14, 	  10,   -9, 	  -2,  -13
+.2byte    0,  -16, 	  11,  -13, 	 -11,  -13, 	   0,  -11
+.2byte   -4,  -15, 	   3,  -14, 	 -10,   -9, 	   2,  -13
+.2byte   -8,  -13, 	 -10,  -10, 	  -6,   -5, 	   0,  -12
+.2byte   -7,  -13, 	 -12,   -9, 	   3,   -4, 	   0,  -12
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte    0,  -13, 	 -10,   -4, 	  10,   -4, 	   0,  -12
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+.2byte    6,  -14, 	   9,   -7, 	  -7,   -2, 	  -2,  -15
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    8,  -14, 	   2,   -8, 	   2,   -2, 	  -1,  -14
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    3,  -18, 	  -7,  -14, 	   8,   -5, 	  -3,  -14
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    0,  -18, 	  10,   -7, 	 -10,   -7, 	   0,  -13
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte   -3,  -18, 	   7,  -14, 	  -8,   -5, 	   3,  -14
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -8,  -14, 	  -2,   -8, 	  -2,   -2, 	   1,  -14
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -6,  -14, 	  -9,   -7, 	   7,   -2, 	   2,  -15
+.2byte    0,   -5, 	  -9,    1, 	   9,    1, 	   0,   -7
+.2byte   -6,   -7, 	 -11,   -1, 	   1,    2, 	   0,  -11
+.2byte   -9,   -9, 	  -5,   -3, 	  -5,    1, 	  -1,  -10
+.2byte   -6,  -13, 	   6,   -8, 	  -8,   -2, 	   0,  -13
+.2byte    0,  -14, 	  11,   -5, 	 -11,   -5, 	   0,  -12
+.2byte    6,  -13, 	  -6,   -8, 	   8,   -2, 	   0,  -13
+.2byte    9,   -9, 	   5,   -3, 	   5,    1, 	   1,  -10
+.2byte    6,   -7, 	  11,   -1, 	  -1,    2, 	   0,  -11
+.2byte    0,   -9, 	  -7,    0, 	   7,    0, 	   0,   -8
+.2byte   -6,   -9, 	 -10,   -2, 	   0,    1, 	   1,  -11
+.2byte   -8,  -11, 	  -4,   -4, 	  -4,    0, 	   1,  -11
+.2byte   -3,  -14, 	   8,   -8, 	  -7,   -2, 	   2,  -13
+.2byte    0,  -14, 	  10,   -5, 	 -10,   -5, 	   0,  -11
+.2byte    3,  -14, 	  -8,   -8, 	   7,   -2, 	  -2,  -13
+.2byte    8,  -11, 	   4,   -4, 	   4,    0, 	  -1,  -11
+.2byte    6,   -9, 	  10,   -2, 	   0,    1, 	  -1,  -11
+sSlakingAnimTable1:
+.4byte sSlakingAnims_1_1
+.4byte sSlakingAnims_1_2
+.4byte sSlakingAnims_1_3
+.4byte sSlakingAnims_1_4
+.4byte sSlakingAnims_1_5
+.4byte sSlakingAnims_1_6
+.4byte sSlakingAnims_1_7
+.4byte sSlakingAnims_1_8
+sSlakingAnimTable2:
+.4byte sSlakingAnims_2_1
+.4byte sSlakingAnims_2_2
+.4byte sSlakingAnims_2_3
+.4byte sSlakingAnims_2_4
+.4byte sSlakingAnims_2_5
+.4byte sSlakingAnims_2_6
+.4byte sSlakingAnims_2_7
+.4byte sSlakingAnims_2_8
+sSlakingAnimTable3:
+.4byte sSlakingAnims_3_1
+.4byte sSlakingAnims_3_2
+.4byte sSlakingAnims_3_3
+.4byte sSlakingAnims_3_4
+.4byte sSlakingAnims_3_5
+.4byte sSlakingAnims_3_6
+.4byte sSlakingAnims_3_7
+.4byte sSlakingAnims_3_8
+sSlakingAnimTable4:
+.4byte sSlakingAnims_4_1
+.4byte sSlakingAnims_4_2
+.4byte sSlakingAnims_4_3
+.4byte sSlakingAnims_4_4
+.4byte sSlakingAnims_4_5
+.4byte sSlakingAnims_4_6
+.4byte sSlakingAnims_4_7
+.4byte sSlakingAnims_4_8
+sSlakingAnimTable5:
+.4byte sSlakingAnims_5_1
+.4byte sSlakingAnims_5_2
+.4byte sSlakingAnims_5_3
+.4byte sSlakingAnims_5_4
+.4byte sSlakingAnims_5_5
+.4byte sSlakingAnims_5_6
+.4byte sSlakingAnims_5_7
+.4byte sSlakingAnims_5_8
+sSlakingAnimTable6:
+.4byte sSlakingAnims_6_1
+.4byte sSlakingAnims_6_1
+.4byte sSlakingAnims_6_1
+.4byte sSlakingAnims_6_1
+.4byte sSlakingAnims_6_1
+.4byte sSlakingAnims_6_1
+.4byte sSlakingAnims_6_1
+.4byte sSlakingAnims_6_1
+sSlakingAnimTable7:
+.4byte sSlakingAnims_7_1
+.4byte sSlakingAnims_7_2
+.4byte sSlakingAnims_7_3
+.4byte sSlakingAnims_7_4
+.4byte sSlakingAnims_7_5
+.4byte sSlakingAnims_7_6
+.4byte sSlakingAnims_7_7
+.4byte sSlakingAnims_7_8
+sSlakingAnimTable8:
+.4byte sSlakingAnims_8_1
+.4byte sSlakingAnims_8_2
+.4byte sSlakingAnims_8_3
+.4byte sSlakingAnims_8_4
+.4byte sSlakingAnims_8_5
+.4byte sSlakingAnims_8_6
+.4byte sSlakingAnims_8_7
+.4byte sSlakingAnims_8_8
+sSlakingAnimTable9:
+.4byte sSlakingAnims_9_1
+.4byte sSlakingAnims_9_2
+.4byte sSlakingAnims_9_3
+.4byte sSlakingAnims_9_4
+.4byte sSlakingAnims_9_5
+.4byte sSlakingAnims_9_6
+.4byte sSlakingAnims_9_7
+.4byte sSlakingAnims_9_8
+sSlakingAnimTable10:
+.4byte sSlakingAnims_10_1
+.4byte sSlakingAnims_10_2
+.4byte sSlakingAnims_10_3
+.4byte sSlakingAnims_10_4
+.4byte sSlakingAnims_10_5
+.4byte sSlakingAnims_10_6
+.4byte sSlakingAnims_10_7
+.4byte sSlakingAnims_10_8
+sSlakingAnimTable11:
+.4byte sSlakingAnims_11_1
+.4byte sSlakingAnims_11_2
+.4byte sSlakingAnims_11_3
+.4byte sSlakingAnims_11_4
+.4byte sSlakingAnims_11_5
+.4byte sSlakingAnims_11_6
+.4byte sSlakingAnims_11_7
+.4byte sSlakingAnims_11_8
+sSlakingAnimTable12:
+.4byte sSlakingAnims_12_1
+.4byte sSlakingAnims_12_2
+.4byte sSlakingAnims_12_3
+.4byte sSlakingAnims_12_4
+.4byte sSlakingAnims_12_5
+.4byte sSlakingAnims_12_6
+.4byte sSlakingAnims_12_7
+.4byte sSlakingAnims_12_8
+sSlakingAnimTable13:
+.4byte sSlakingAnims_13_1
+.4byte sSlakingAnims_13_2
+.4byte sSlakingAnims_13_3
+.4byte sSlakingAnims_13_4
+.4byte sSlakingAnims_13_5
+.4byte sSlakingAnims_13_6
+.4byte sSlakingAnims_13_7
+.4byte sSlakingAnims_13_8
+sAxAnimationsSlaking:
+.4byte sSlakingAnimTable1
+.4byte sSlakingAnimTable2
+.4byte sSlakingAnimTable3
+.4byte sSlakingAnimTable4
+.4byte sSlakingAnimTable5
+.4byte sSlakingAnimTable6
+.4byte sSlakingAnimTable7
+.4byte sSlakingAnimTable8
+.4byte sSlakingAnimTable9
+.4byte sSlakingAnimTable10
+.4byte sSlakingAnimTable11
+.4byte sSlakingAnimTable12
+.4byte sSlakingAnimTable13
+sAxSpritesSlaking:
+.4byte sSlakingSprites1
+.4byte sSlakingSprites2
+.4byte sSlakingSprites3
+.4byte sSlakingSprites4
+.4byte sSlakingSprites5
+.4byte sSlakingSprites6
+.4byte sSlakingSprites7
+.4byte sSlakingSprites8
+.4byte sSlakingSprites9
+.4byte sSlakingSprites10
+.4byte sSlakingSprites11
+.4byte sSlakingSprites12
+.4byte sSlakingSprites13
+.4byte sSlakingSprites14
+.4byte sSlakingSprites15
+.4byte sSlakingSprites16
+.4byte sSlakingSprites17
+.4byte sSlakingSprites18
+.4byte sSlakingSprites19
+.4byte sSlakingSprites20
+.4byte sSlakingSprites21
+.4byte sSlakingSprites22
+.4byte sSlakingSprites23
+.4byte sSlakingSprites24
+.4byte sSlakingSprites25
+.4byte sSlakingSprites26
+.4byte sSlakingSprites27
+.4byte sSlakingSprites28
+.4byte sSlakingSprites29
+.4byte sSlakingSprites30
+.4byte sSlakingSprites31
+.4byte sSlakingSprites32
+.4byte sSlakingSprites33
+.4byte sSlakingSprites34
+.4byte sSlakingSprites35
+.4byte sSlakingSprites36
+.4byte sSlakingSprites37
+.4byte sSlakingSprites38
+.4byte sSlakingSprites39
+.4byte sSlakingSprites40
+.4byte sSlakingSprites41
+.4byte sSlakingSprites42
+.4byte sSlakingSprites43
+.4byte sSlakingSprites44
+.4byte sSlakingSprites45
+.4byte sSlakingSprites46
+.4byte sSlakingSprites47
+.4byte sSlakingSprites48
+.4byte sSlakingSprites49
+.4byte sSlakingSprites50
+.4byte sSlakingSprites51
+.4byte sSlakingSprites52
+sAxMainSlaking:
+ax_main sAxPosesSlaking, sAxAnimationsSlaking, 13, sAxSpritesSlaking, sAxPositionsSlaking

--- a/data/ax/slakoth.inc
+++ b/data/ax/slakoth.inc
@@ -1,0 +1,2537 @@
+.global gAxSlakoth
+gAxSlakoth:
+ax_siro sAxMainSlakoth
+sSlakothPose1:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose2:
+ax_pose 1, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose3:
+ax_pose 2, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose4:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose5:
+ax_pose 4, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose6:
+ax_pose 5, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose7:
+ax_pose 6, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose8:
+ax_pose 7, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose9:
+ax_pose 8, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose10:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose11:
+ax_pose 10, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose12:
+ax_pose 11, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose13:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose14:
+ax_pose 13, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose15:
+ax_pose 14, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose16:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose17:
+ax_pose 10, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose18:
+ax_pose 11, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose19:
+ax_pose 6, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose20:
+ax_pose 7, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose21:
+ax_pose 8, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose22:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose23:
+ax_pose 4, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose24:
+ax_pose 5, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose25:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose26:
+ax_pose 1, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose27:
+ax_pose 2, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose28:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose29:
+ax_pose 4, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose30:
+ax_pose 5, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose31:
+ax_pose 6, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose32:
+ax_pose 7, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose33:
+ax_pose 8, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose34:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose35:
+ax_pose 10, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose36:
+ax_pose 11, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose37:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose38:
+ax_pose 13, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose39:
+ax_pose 14, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose40:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose41:
+ax_pose 10, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose42:
+ax_pose 11, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose43:
+ax_pose 6, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose44:
+ax_pose 7, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose45:
+ax_pose 8, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose46:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose47:
+ax_pose 4, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose48:
+ax_pose 5, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose49:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose50:
+ax_pose 1, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose51:
+ax_pose 2, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose52:
+ax_pose 15, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose53:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose54:
+ax_pose 4, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose55:
+ax_pose 5, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose56:
+ax_pose 16, 0x01f0, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose57:
+ax_pose 6, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose58:
+ax_pose 7, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose59:
+ax_pose 8, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose60:
+ax_pose 17, 0x01ef, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose61:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose62:
+ax_pose 10, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose63:
+ax_pose 11, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose64:
+ax_pose 18, 0x01ee, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose65:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose66:
+ax_pose 13, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose67:
+ax_pose 14, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose68:
+ax_pose 19, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose69:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose70:
+ax_pose 10, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose71:
+ax_pose 11, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose72:
+ax_pose 18, 0x01ee, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose73:
+ax_pose 6, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose74:
+ax_pose 7, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose75:
+ax_pose 8, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose76:
+ax_pose 17, 0x01ef, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose77:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose78:
+ax_pose 4, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose79:
+ax_pose 5, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose80:
+ax_pose 16, 0x01f0, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose81:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose82:
+ax_pose 1, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose83:
+ax_pose 2, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose84:
+ax_pose 20, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose85:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose86:
+ax_pose 4, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose87:
+ax_pose 5, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose88:
+ax_pose 21, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose89:
+ax_pose 6, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose90:
+ax_pose 7, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose91:
+ax_pose 8, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose92:
+ax_pose 22, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose93:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose94:
+ax_pose 10, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose95:
+ax_pose 11, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose96:
+ax_pose 23, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose97:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose98:
+ax_pose 13, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose99:
+ax_pose 14, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose100:
+ax_pose 24, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose101:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose102:
+ax_pose 10, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose103:
+ax_pose 11, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose104:
+ax_pose 23, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose105:
+ax_pose 6, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose106:
+ax_pose 7, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose107:
+ax_pose 8, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose108:
+ax_pose 22, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose109:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose110:
+ax_pose 4, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose111:
+ax_pose 5, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose112:
+ax_pose 21, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose113:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose114:
+ax_pose 1, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose115:
+ax_pose 2, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose116:
+ax_pose 20, 0x01f4, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose117:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose118:
+ax_pose 4, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose119:
+ax_pose 5, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose120:
+ax_pose 21, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose121:
+ax_pose 6, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose122:
+ax_pose 7, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose123:
+ax_pose 8, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose124:
+ax_pose 22, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose125:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose126:
+ax_pose 10, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose127:
+ax_pose 11, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose128:
+ax_pose 23, 0x01f1, 0x90f2, 0x4c00
+ax_pose_terminator
+sSlakothPose129:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose130:
+ax_pose 13, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose131:
+ax_pose 14, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose132:
+ax_pose 24, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose133:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose134:
+ax_pose 10, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose135:
+ax_pose 11, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose136:
+ax_pose 23, 0x01f1, 0x80ed, 0x4c00
+ax_pose_terminator
+sSlakothPose137:
+ax_pose 6, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose138:
+ax_pose 7, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose139:
+ax_pose 8, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose140:
+ax_pose 22, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose141:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose142:
+ax_pose 4, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose143:
+ax_pose 5, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose144:
+ax_pose 21, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose145:
+ax_pose 25, 0x01f4, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose146:
+ax_pose 26, 0x01f4, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose147:
+ax_pose 27, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakothPose148:
+ax_pose 28, 0x01ea, 0x90f2, 0x4c00
+ax_pose_terminator
+sSlakothPose149:
+ax_pose 29, 0x01e9, 0x90ee, 0x4c00
+ax_pose_terminator
+sSlakothPose150:
+ax_pose 30, 0x01e8, 0x90ed, 0x4c00
+ax_pose_terminator
+sSlakothPose151:
+ax_pose 31, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakothPose152:
+ax_pose 30, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSlakothPose153:
+ax_pose 29, 0x01e9, 0x80f2, 0x4c00
+ax_pose_terminator
+sSlakothPose154:
+ax_pose 28, 0x01ea, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose155:
+ax_pose 32, 0x01f4, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose156:
+ax_pose 33, 0x01f4, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose157:
+ax_pose 34, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose158:
+ax_pose 35, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose159:
+ax_pose 36, 0x01f1, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose160:
+ax_pose 35, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose161:
+ax_pose 34, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose162:
+ax_pose 33, 0x01f4, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose163:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose164:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose165:
+ax_pose 6, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose166:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose167:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose168:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose169:
+ax_pose 6, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose170:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose171:
+ax_pose 20, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose172:
+ax_pose 21, 0x01f2, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose173:
+ax_pose 22, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose174:
+ax_pose 23, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose175:
+ax_pose 24, 0x01f1, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose176:
+ax_pose 23, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose177:
+ax_pose 22, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose178:
+ax_pose 21, 0x01f2, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose179:
+ax_pose 20, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose180:
+ax_pose 21, 0x01f2, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose181:
+ax_pose 22, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose182:
+ax_pose 23, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose183:
+ax_pose 24, 0x01f1, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose184:
+ax_pose 23, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose185:
+ax_pose 22, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose186:
+ax_pose 21, 0x01f2, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose187:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose188:
+ax_pose 15, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose189:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose190:
+ax_pose 16, 0x01f2, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose191:
+ax_pose 6, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose192:
+ax_pose 17, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose193:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose194:
+ax_pose 18, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose195:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose196:
+ax_pose 19, 0x01f2, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose197:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose198:
+ax_pose 18, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose199:
+ax_pose 6, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose200:
+ax_pose 17, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose201:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose202:
+ax_pose 16, 0x01f2, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose203:
+ax_pose 0, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose204:
+ax_pose 3, 0x01f3, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose205:
+ax_pose 6, 0x01f3, 0x80f1, 0x4c00
+ax_pose_terminator
+sSlakothPose206:
+ax_pose 9, 0x01f1, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose207:
+ax_pose 12, 0x01f0, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose208:
+ax_pose 9, 0x01f1, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose209:
+ax_pose 6, 0x01f3, 0x90ee, 0x4c00
+ax_pose_terminator
+sSlakothPose210:
+ax_pose 3, 0x01f3, 0x90f0, 0x4c00
+ax_pose_terminator
+sSlakothPose211:
+ax_pose 32, 0x01f4, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose212:
+ax_pose 33, 0x01f4, 0x80ef, 0x4c00
+ax_pose_terminator
+sSlakothPose213:
+ax_pose 34, 0x01f3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose214:
+ax_pose 35, 0x01f2, 0x80ee, 0x4c00
+ax_pose_terminator
+sSlakothPose215:
+ax_pose 36, 0x01f1, 0x80f0, 0x4c00
+ax_pose_terminator
+sSlakothPose216:
+ax_pose 35, 0x01f2, 0x90f1, 0x4c00
+ax_pose_terminator
+sSlakothPose217:
+ax_pose 34, 0x01f3, 0x90ef, 0x4c00
+ax_pose_terminator
+sSlakothPose218:
+ax_pose 33, 0x01f4, 0x90f0, 0x4c00
+ax_pose_terminator
+.align 2
+sSlakothAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 3, 0, 25, 0, 16, 0, 16,
+ax_anim 3, 1, 26, 0, 16, 0, 16,
+ax_anim 3, 0, 25, 0, 16, 0, 16,
+ax_anim 3, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSlakothAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 10, 10, 10, 10,
+ax_anim 3, 0, 28, 19, 16, 19, 16,
+ax_anim 3, 1, 29, 20, 15, 20, 15,
+ax_anim 3, 0, 28, 19, 16, 19, 16,
+ax_anim 3, 0, 29, 20, 15, 20, 15,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSlakothAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 10, 0, 10, 0,
+ax_anim 3, 0, 31, 18, 0, 18, 0,
+ax_anim 3, 1, 32, 18, 1, 18, 1,
+ax_anim 3, 0, 31, 18, 0, 18, 0,
+ax_anim 3, 0, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSlakothAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -6, 4, -6,
+ax_anim 2, 2, 35, 10, -13, 10, -13,
+ax_anim 3, 0, 34, 18, -23, 18, -23,
+ax_anim 3, 1, 35, 19, -22, 19, -22,
+ax_anim 3, 0, 34, 18, -23, 18, -23,
+ax_anim 3, 0, 35, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSlakothAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 38, 0, -11, 0, -11,
+ax_anim 3, 0, 37, 0, -21, 0, -21,
+ax_anim 3, 1, 38, 1, -21, 1, -21,
+ax_anim 3, 0, 37, 0, -21, 0, -21,
+ax_anim 3, 0, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSlakothAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 2, 0, 40, -4, -6, -4, -6,
+ax_anim 2, 2, 41, -10, -13, -10, -13,
+ax_anim 3, 0, 40, -18, -23, -18, -23,
+ax_anim 3, 1, 41, -19, -22, -19, -22,
+ax_anim 3, 0, 40, -18, -23, -18, -23,
+ax_anim 3, 0, 41, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSlakothAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -10, 0, -10, 0,
+ax_anim 3, 0, 43, -18, 0, -18, 0,
+ax_anim 3, 1, 44, -18, 1, -18, 1,
+ax_anim 3, 0, 43, -18, 0, -18, 0,
+ax_anim 3, 0, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSlakothAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 46, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -10, 10, -10, 10,
+ax_anim 3, 0, 46, -19, 16, -19, 16,
+ax_anim 3, 1, 47, -20, 15, -20, 15,
+ax_anim 3, 0, 46, -19, 16, -19, 16,
+ax_anim 3, 0, 47, -20, 15, -20, 15,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlakothAnims_3_1:
+ax_anim 3, 0, 49, 0, 0, 0, 0,
+ax_anim 3, 0, 48, 0, 0, 0, 0,
+ax_anim 3, 0, 50, 0, 0, 0, 0,
+ax_anim 3, 0, 48, 0, 0, 0, 0,
+ax_anim 3, 0, 51, 0, 0, 0, 0,
+ax_anim 3, 2, 51, 0, -1, 0, 0,
+ax_anim 3, 0, 51, 0, 0, 0, 0,
+ax_anim 3, 0, 48, 0, 0, 0, 0,
+ax_anim 3, 0, 49, 0, 0, 0, 0,
+ax_anim 3, 1, 48, 0, 0, 0, 0,
+ax_anim 3, 0, 50, 0, 0, 0, 0,
+ax_anim 3, 0, 48, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_3_2:
+ax_anim 3, 0, 53, 0, 0, 0, 0,
+ax_anim 3, 0, 52, 0, 0, 0, 0,
+ax_anim 3, 0, 54, 0, 0, 0, 0,
+ax_anim 3, 0, 52, 0, 0, 0, 0,
+ax_anim 3, 0, 55, 0, 0, 0, 0,
+ax_anim 3, 2, 55, 0, -1, 0, 0,
+ax_anim 3, 0, 55, 0, 0, 0, 0,
+ax_anim 3, 0, 52, 0, 0, 0, 0,
+ax_anim 3, 0, 53, 0, 0, 0, 0,
+ax_anim 3, 1, 52, 0, 0, 0, 0,
+ax_anim 3, 0, 54, 0, 0, 0, 0,
+ax_anim 3, 0, 52, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_3_3:
+ax_anim 3, 0, 57, 0, 0, 0, 0,
+ax_anim 3, 0, 56, 0, 0, 0, 0,
+ax_anim 3, 0, 58, 0, 0, 0, 0,
+ax_anim 3, 0, 56, 0, 0, 0, 0,
+ax_anim 3, 0, 59, 0, 0, 0, 0,
+ax_anim 3, 2, 59, 0, -1, 0, 0,
+ax_anim 3, 0, 59, 0, 0, 0, 0,
+ax_anim 3, 0, 56, 0, 0, 0, 0,
+ax_anim 3, 0, 57, 0, 0, 0, 0,
+ax_anim 3, 1, 56, 0, 0, 0, 0,
+ax_anim 3, 0, 58, 0, 0, 0, 0,
+ax_anim 3, 0, 56, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_3_4:
+ax_anim 3, 0, 61, 0, 0, 0, 0,
+ax_anim 3, 0, 60, 0, 0, 0, 0,
+ax_anim 3, 0, 62, 0, 0, 0, 0,
+ax_anim 3, 0, 60, 0, 0, 0, 0,
+ax_anim 3, 0, 63, 0, 0, 0, 0,
+ax_anim 3, 2, 63, 0, -1, 0, 0,
+ax_anim 3, 0, 63, 0, 0, 0, 0,
+ax_anim 3, 0, 60, 0, 0, 0, 0,
+ax_anim 3, 0, 61, 0, 0, 0, 0,
+ax_anim 3, 1, 60, 0, 0, 0, 0,
+ax_anim 3, 0, 62, 0, 0, 0, 0,
+ax_anim 3, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_3_5:
+ax_anim 3, 0, 65, 0, 0, 0, 0,
+ax_anim 3, 0, 64, 0, 0, 0, 0,
+ax_anim 3, 0, 66, 0, 0, 0, 0,
+ax_anim 3, 0, 64, 0, 0, 0, 0,
+ax_anim 3, 0, 67, 0, 0, 0, 0,
+ax_anim 3, 2, 67, 0, -1, 0, 0,
+ax_anim 3, 0, 67, 0, 0, 0, 0,
+ax_anim 3, 0, 64, 0, 0, 0, 0,
+ax_anim 3, 0, 65, 0, 0, 0, 0,
+ax_anim 3, 1, 64, 0, 0, 0, 0,
+ax_anim 3, 0, 66, 0, 0, 0, 0,
+ax_anim 3, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_3_6:
+ax_anim 3, 0, 69, 0, 0, 0, 0,
+ax_anim 3, 0, 68, 0, 0, 0, 0,
+ax_anim 3, 0, 70, 0, 0, 0, 0,
+ax_anim 3, 0, 68, 0, 0, 0, 0,
+ax_anim 3, 0, 71, 0, 0, 0, 0,
+ax_anim 3, 2, 71, 0, -1, 0, 0,
+ax_anim 3, 0, 71, 0, 0, 0, 0,
+ax_anim 3, 0, 68, 0, 0, 0, 0,
+ax_anim 3, 0, 69, 0, 0, 0, 0,
+ax_anim 3, 1, 68, 0, 0, 0, 0,
+ax_anim 3, 0, 70, 0, 0, 0, 0,
+ax_anim 3, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_3_7:
+ax_anim 3, 0, 73, 0, 0, 0, 0,
+ax_anim 3, 0, 72, 0, 0, 0, 0,
+ax_anim 3, 0, 74, 0, 0, 0, 0,
+ax_anim 3, 0, 72, 0, 0, 0, 0,
+ax_anim 3, 0, 75, 0, 0, 0, 0,
+ax_anim 3, 2, 75, 0, -1, 0, 0,
+ax_anim 3, 0, 75, 0, 0, 0, 0,
+ax_anim 3, 0, 72, 0, 0, 0, 0,
+ax_anim 3, 0, 73, 0, 0, 0, 0,
+ax_anim 3, 1, 72, 0, 0, 0, 0,
+ax_anim 3, 0, 74, 0, 0, 0, 0,
+ax_anim 3, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_3_8:
+ax_anim 3, 0, 77, 0, 0, 0, 0,
+ax_anim 3, 0, 76, 0, 0, 0, 0,
+ax_anim 3, 0, 78, 0, 0, 0, 0,
+ax_anim 3, 0, 76, 0, 0, 0, 0,
+ax_anim 3, 0, 79, 0, 0, 0, 0,
+ax_anim 3, 2, 79, 0, -1, 0, 0,
+ax_anim 3, 0, 79, 0, 0, 0, 0,
+ax_anim 3, 0, 76, 0, 0, 0, 0,
+ax_anim 3, 0, 77, 0, 0, 0, 0,
+ax_anim 3, 1, 76, 0, 0, 0, 0,
+ax_anim 3, 0, 78, 0, 0, 0, 0,
+ax_anim 3, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_4_1:
+ax_anim 4, 0, 81, 0, -2, 0, -2,
+ax_anim 4, 0, 82, 0, -3, 0, -3,
+ax_anim 6, 2, 80, 0, -4, 0, -4,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 2, 0, 2,
+ax_anim 2, 0, 83, 1, 2, 1, 2,
+ax_anim 2, 0, 83, 0, 2, 0, 2,
+ax_anim 2, 0, 83, 1, 2, 1, 2,
+ax_anim 2, 0, 83, 0, 2, 0, 2,
+ax_anim 2, 0, 83, 1, 2, 1, 2,
+ax_anim_terminator
+sSlakothAnims_4_2:
+ax_anim 4, 0, 85, -2, -2, -2, -2,
+ax_anim 4, 0, 86, -3, -3, -3, -3,
+ax_anim 6, 2, 84, -4, -4, -4, -4,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim 2, 1, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 87, 3, 1, 3, 1,
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 87, 3, 1, 3, 1,
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 87, 3, 1, 3, 1,
+ax_anim_terminator
+sSlakothAnims_4_3:
+ax_anim 4, 0, 89, -2, 0, -2, -2,
+ax_anim 4, 0, 90, -3, 0, -3, -3,
+ax_anim 6, 2, 88, -4, 0, -4, -4,
+ax_anim 2, 0, 91, -1, 0, -1, -1,
+ax_anim 2, 1, 91, 2, 0, 2, 2,
+ax_anim 2, 0, 91, 3, 0, 3, 1,
+ax_anim 2, 0, 91, 2, 0, 2, 2,
+ax_anim 2, 0, 91, 3, 0, 3, 1,
+ax_anim 2, 0, 91, 2, 0, 2, 2,
+ax_anim 2, 0, 91, 3, 0, 3, 1,
+ax_anim_terminator
+sSlakothAnims_4_4:
+ax_anim 4, 0, 93, -2, 2, -2, 2,
+ax_anim 4, 0, 94, -3, 3, -3, 3,
+ax_anim 6, 2, 92, -4, 4, -4, 4,
+ax_anim 2, 0, 95, -1, 1, -1, 1,
+ax_anim 2, 1, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 3, -1, 3, -1,
+ax_anim_terminator
+sSlakothAnims_4_5:
+ax_anim 4, 0, 97, 0, 2, 0, 2,
+ax_anim 4, 0, 98, 0, 5, 0, 5,
+ax_anim 6, 2, 96, 0, 6, 0, 6,
+ax_anim 2, 0, 99, 0, 1, 0, 1,
+ax_anim 2, 1, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 1, -2, 1, -2,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 1, -2, 1, -2,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 1, -2, 1, -2,
+ax_anim_terminator
+sSlakothAnims_4_6:
+ax_anim 4, 0, 101, 2, 2, 2, 2,
+ax_anim 4, 0, 102, 3, 3, 3, 3,
+ax_anim 6, 2, 100, 4, 4, 4, 4,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 103, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -3, -1, -3, -1,
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -3, -1, -3, -1,
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -3, -1, -3, -1,
+ax_anim_terminator
+sSlakothAnims_4_7:
+ax_anim 4, 0, 105, 2, 0, 2, -2,
+ax_anim 4, 0, 106, 3, 0, 3, -3,
+ax_anim 6, 2, 104, 4, 0, 4, -4,
+ax_anim 2, 0, 107, 1, 0, 1, -1,
+ax_anim 2, 1, 107, -2, 0, -2, 2,
+ax_anim 2, 0, 107, -3, 0, -3, 1,
+ax_anim 2, 0, 107, -2, 0, -2, 2,
+ax_anim 2, 0, 107, -3, 0, -3, 1,
+ax_anim 2, 0, 107, -2, 0, -2, 2,
+ax_anim 2, 0, 107, -3, 0, -3, 1,
+ax_anim_terminator
+sSlakothAnims_4_8:
+ax_anim 4, 0, 109, 2, -2, 2, -2,
+ax_anim 4, 0, 110, 3, -3, 3, -3,
+ax_anim 6, 2, 108, 4, -4, 4, -4,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim_terminator
+.align 2
+sSlakothAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 6, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 2, 115, -1, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 115, -1, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 4, 0, 112, 0, 1, 0, 1,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_5_2:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 4, 0, 119, 0, -2, 0, 0,
+ax_anim 6, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 2, 119, -1, -3, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 119, -1, -3, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 4, 0, 116, 0, 1, 0, 1,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_5_3:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -1, 0, 0,
+ax_anim 4, 0, 123, 0, -2, 0, 0,
+ax_anim 6, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 2, 123, -1, -3, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 123, -1, -3, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 4, 0, 120, 0, 1, 0, 1,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_5_4:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, -2, 0, 0,
+ax_anim 6, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 2, 127, -1, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 127, -1, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 4, 0, 124, 0, 1, 0, 1,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_5_5:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, 0,
+ax_anim 4, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 2, 131, -1, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, -1, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 128, 0, 1, 0, 1,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_5_6:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -1, 0, 0,
+ax_anim 4, 0, 135, 0, -2, 0, 0,
+ax_anim 6, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 2, 135, -1, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, -1, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 4, 0, 132, 0, 1, 0, 1,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_5_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -1, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 6, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 2, 139, -1, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, -1, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 136, 0, 1, 0, 1,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_5_8:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 2, 143, -1, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, -1, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, 1, 0, 1,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sSlakothAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sSlakothAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sSlakothAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sSlakothAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sSlakothAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sSlakothAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sSlakothAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSlakothAnims_8_1:
+ax_anim 60, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_8_2:
+ax_anim 60, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_8_3:
+ax_anim 60, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_8_4:
+ax_anim 60, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_8_5:
+ax_anim 60, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_8_6:
+ax_anim 60, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_8_7:
+ax_anim 60, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_8_8:
+ax_anim 60, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 2, 7, 2,
+ax_anim 2, 0, 172, 13, 9, 13, 9,
+ax_anim 2, 0, 173, 7, 13, 7, 13,
+ax_anim 3, 0, 174, 0, 14, 0, 14,
+ax_anim 2, 3, 175, -7, 13, -7, 13,
+ax_anim 2, 0, 176, -13, 9, -13, 9,
+ax_anim 1, 0, 177, -7, 2, -7, 2,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 9, 2, 9, 2,
+ax_anim 2, 0, 171, 19, 5, 19, 5,
+ax_anim 2, 0, 172, 24, 11, 24, 11,
+ax_anim 3, 0, 173, 20, 15, 20, 15,
+ax_anim 2, 3, 174, 12, 15, 12, 15,
+ax_anim 2, 0, 175, 6, 12, 6, 12,
+ax_anim 1, 0, 176, 1, 8, 1, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 2, -5, 2, -5,
+ax_anim 2, 0, 170, 9, -7, 9, -7,
+ax_anim 2, 0, 171, 15, -5, 15, -5,
+ax_anim 3, 0, 172, 19, 0, 19, 0,
+ax_anim 2, 3, 173, 15, 4, 15, 4,
+ax_anim 2, 0, 174, 8, 6, 8, 6,
+ax_anim 1, 0, 175, 4, 4, 4, 4,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 3, -19, 3, -19,
+ax_anim 2, 0, 170, 12, -25, 12, -25,
+ax_anim 3, 0, 171, 20, -25, 20, -25,
+ax_anim 2, 3, 172, 23, -16, 23, -16,
+ax_anim 2, 0, 173, 18, -6, 18, -6,
+ax_anim 1, 0, 174, 10, -1, 10, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -14, -12, -14, -12,
+ax_anim 2, 0, 177, -9, -22, -9, -22,
+ax_anim 3, 0, 170, 0, -25, 0, -25,
+ax_anim 2, 3, 171, 9, -22, 9, -22,
+ax_anim 2, 0, 172, 14, -12, 14, -12,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -3, -19, -3, -19,
+ax_anim 2, 0, 170, -12, -25, -12, -25,
+ax_anim 3, 0, 177, -20, -25, -20, -25,
+ax_anim 2, 3, 176, -23, -16, -23, -16,
+ax_anim 2, 0, 175, -18, -6, -18, -6,
+ax_anim 1, 0, 174, -10, -1, -10, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -2, -5, -2, -5,
+ax_anim 2, 0, 170, -9, -7, -9, -7,
+ax_anim 2, 0, 177, -15, -5, -15, -5,
+ax_anim 3, 0, 176, -19, 0, -19, 0,
+ax_anim 2, 3, 175, -15, 4, -15, 4,
+ax_anim 2, 0, 174, -8, 6, -8, 6,
+ax_anim 1, 0, 173, -4, 4, -4, 4,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -9, 2, -9, 2,
+ax_anim 2, 0, 177, -19, 5, -19, 5,
+ax_anim 2, 0, 176, -24, 11, -24, 11,
+ax_anim 3, 0, 175, -20, 15, -20, 15,
+ax_anim 2, 3, 174, -12, 15, -12, 15,
+ax_anim 2, 0, 173, -6, 12, -6, 12,
+ax_anim 1, 0, 172, -1, 8, -1, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_11_2:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -24, 0, 0,
+ax_anim 3, 0, 188, 0, -23, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_11_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_11_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -17, 0, 0,
+ax_anim 1, 0, 192, 0, -11, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -17, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_11_6:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_11_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -24, 0, 0,
+ax_anim 3, 0, 200, 0, -23, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlakothAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSlakothGfx1:
+.incbin "baserom.gba", 0x11B039C, 0x200
+sSlakothSprites1:
+ax_sprite sSlakothGfx1, 0x200
+ax_sprite_terminator
+sSlakothGfx2:
+.incbin "baserom.gba", 0x11B05AC, 0x200
+sSlakothSprites2:
+ax_sprite sSlakothGfx2, 0x200
+ax_sprite_terminator
+sSlakothGfx3:
+.incbin "baserom.gba", 0x11B07BC, 0x200
+sSlakothSprites3:
+ax_sprite sSlakothGfx3, 0x200
+ax_sprite_terminator
+sSlakothGfx4:
+.incbin "baserom.gba", 0x11B09CC, 0x200
+sSlakothSprites4:
+ax_sprite sSlakothGfx4, 0x200
+ax_sprite_terminator
+sSlakothGfx5:
+.incbin "baserom.gba", 0x11B0BDC, 0x200
+sSlakothSprites5:
+ax_sprite sSlakothGfx5, 0x200
+ax_sprite_terminator
+sSlakothGfx6:
+.incbin "baserom.gba", 0x11B0DEC, 0x200
+sSlakothSprites6:
+ax_sprite sSlakothGfx6, 0x200
+ax_sprite_terminator
+sSlakothGfx7:
+.incbin "baserom.gba", 0x11B0FFC, 0x200
+sSlakothSprites7:
+ax_sprite sSlakothGfx7, 0x200
+ax_sprite_terminator
+sSlakothGfx8:
+.incbin "baserom.gba", 0x11B120C, 0x200
+sSlakothSprites8:
+ax_sprite sSlakothGfx8, 0x200
+ax_sprite_terminator
+sSlakothGfx9:
+.incbin "baserom.gba", 0x11B141C, 0x200
+sSlakothSprites9:
+ax_sprite sSlakothGfx9, 0x200
+ax_sprite_terminator
+sSlakothGfx10:
+.incbin "baserom.gba", 0x11B162C, 0x200
+sSlakothSprites10:
+ax_sprite sSlakothGfx10, 0x200
+ax_sprite_terminator
+sSlakothGfx11:
+.incbin "baserom.gba", 0x11B183C, 0x200
+sSlakothSprites11:
+ax_sprite sSlakothGfx11, 0x200
+ax_sprite_terminator
+sSlakothGfx12:
+.incbin "baserom.gba", 0x11B1A4C, 0x200
+sSlakothSprites12:
+ax_sprite sSlakothGfx12, 0x200
+ax_sprite_terminator
+sSlakothGfx13:
+.incbin "baserom.gba", 0x11B1C5C, 0x200
+sSlakothSprites13:
+ax_sprite sSlakothGfx13, 0x200
+ax_sprite_terminator
+sSlakothGfx14:
+.incbin "baserom.gba", 0x11B1E6C, 0x200
+sSlakothSprites14:
+ax_sprite sSlakothGfx14, 0x200
+ax_sprite_terminator
+sSlakothGfx15:
+.incbin "baserom.gba", 0x11B207C, 0x200
+sSlakothSprites15:
+ax_sprite sSlakothGfx15, 0x200
+ax_sprite_terminator
+sSlakothGfx16:
+.incbin "baserom.gba", 0x11B228C, 0x120
+sSlakothGfx16_1:
+.incbin "baserom.gba", 0x11B23AC, 0x20
+sSlakothSprites16:
+ax_sprite sSlakothGfx16, 0x120
+ax_sprite 0, 0x40
+ax_sprite sSlakothGfx16_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlakothGfx17:
+.incbin "baserom.gba", 0x11B23F4, 0x160
+sSlakothSprites17:
+ax_sprite sSlakothGfx17, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlakothGfx18:
+.incbin "baserom.gba", 0x11B256C, 0x100
+sSlakothGfx18_1:
+.incbin "baserom.gba", 0x11B266C, 0x40
+sSlakothSprites18:
+ax_sprite sSlakothGfx18, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx18_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlakothGfx19:
+.incbin "baserom.gba", 0x11B26D4, 0x180
+sSlakothSprites19:
+ax_sprite sSlakothGfx19, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlakothGfx20:
+.incbin "baserom.gba", 0x11B286C, 0x40
+sSlakothGfx20_1:
+.incbin "baserom.gba", 0x11B28AC, 0x100
+sSlakothSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlakothGfx21:
+.incbin "baserom.gba", 0x11B29DC, 0x60
+sSlakothGfx21_1:
+.incbin "baserom.gba", 0x11B2A3C, 0x100
+sSlakothSprites21:
+ax_sprite sSlakothGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx21_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlakothGfx22:
+.incbin "baserom.gba", 0x11B2B64, 0x60
+sSlakothGfx22_1:
+.incbin "baserom.gba", 0x11B2BC4, 0x100
+sSlakothSprites22:
+ax_sprite sSlakothGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx22_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlakothGfx23:
+.incbin "baserom.gba", 0x11B2CEC, 0x100
+sSlakothGfx23_1:
+.incbin "baserom.gba", 0x11B2DEC, 0x20
+sSlakothGfx23_2:
+.incbin "baserom.gba", 0x11B2E0C, 0x20
+sSlakothSprites23:
+ax_sprite sSlakothGfx23, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx23_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx23_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlakothGfx24:
+.incbin "baserom.gba", 0x11B2E64, 0x160
+sSlakothSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx24, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlakothGfx25:
+.incbin "baserom.gba", 0x11B2FE4, 0x40
+sSlakothGfx25_1:
+.incbin "baserom.gba", 0x11B3024, 0xE0
+sSlakothSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlakothGfx25_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlakothGfx26:
+.incbin "baserom.gba", 0x11B3134, 0x200
+sSlakothSprites26:
+ax_sprite sSlakothGfx26, 0x200
+ax_sprite_terminator
+sSlakothGfx27:
+.incbin "baserom.gba", 0x11B3344, 0x200
+sSlakothSprites27:
+ax_sprite sSlakothGfx27, 0x200
+ax_sprite_terminator
+sSlakothGfx28:
+.incbin "baserom.gba", 0x11B3554, 0x200
+sSlakothSprites28:
+ax_sprite sSlakothGfx28, 0x200
+ax_sprite_terminator
+sSlakothGfx29:
+.incbin "baserom.gba", 0x11B3764, 0x200
+sSlakothSprites29:
+ax_sprite sSlakothGfx29, 0x200
+ax_sprite_terminator
+sSlakothGfx30:
+.incbin "baserom.gba", 0x11B3974, 0x200
+sSlakothSprites30:
+ax_sprite sSlakothGfx30, 0x200
+ax_sprite_terminator
+sSlakothGfx31:
+.incbin "baserom.gba", 0x11B3B84, 0x200
+sSlakothSprites31:
+ax_sprite sSlakothGfx31, 0x200
+ax_sprite_terminator
+sSlakothGfx32:
+.incbin "baserom.gba", 0x11B3D94, 0x200
+sSlakothSprites32:
+ax_sprite sSlakothGfx32, 0x200
+ax_sprite_terminator
+sSlakothGfx33:
+.incbin "baserom.gba", 0x11B3FA4, 0x200
+sSlakothSprites33:
+ax_sprite sSlakothGfx33, 0x200
+ax_sprite_terminator
+sSlakothGfx34:
+.incbin "baserom.gba", 0x11B41B4, 0x200
+sSlakothSprites34:
+ax_sprite sSlakothGfx34, 0x200
+ax_sprite_terminator
+sSlakothGfx35:
+.incbin "baserom.gba", 0x11B43C4, 0x200
+sSlakothSprites35:
+ax_sprite sSlakothGfx35, 0x200
+ax_sprite_terminator
+sSlakothGfx36:
+.incbin "baserom.gba", 0x11B45D4, 0x200
+sSlakothSprites36:
+ax_sprite sSlakothGfx36, 0x200
+ax_sprite_terminator
+sSlakothGfx37:
+.incbin "baserom.gba", 0x11B47E4, 0x200
+sSlakothSprites37:
+ax_sprite sSlakothGfx37, 0x200
+ax_sprite_terminator
+sAxPosesSlakoth:
+.4byte sSlakothPose1
+.4byte sSlakothPose2
+.4byte sSlakothPose3
+.4byte sSlakothPose4
+.4byte sSlakothPose5
+.4byte sSlakothPose6
+.4byte sSlakothPose7
+.4byte sSlakothPose8
+.4byte sSlakothPose9
+.4byte sSlakothPose10
+.4byte sSlakothPose11
+.4byte sSlakothPose12
+.4byte sSlakothPose13
+.4byte sSlakothPose14
+.4byte sSlakothPose15
+.4byte sSlakothPose16
+.4byte sSlakothPose17
+.4byte sSlakothPose18
+.4byte sSlakothPose19
+.4byte sSlakothPose20
+.4byte sSlakothPose21
+.4byte sSlakothPose22
+.4byte sSlakothPose23
+.4byte sSlakothPose24
+.4byte sSlakothPose25
+.4byte sSlakothPose26
+.4byte sSlakothPose27
+.4byte sSlakothPose28
+.4byte sSlakothPose29
+.4byte sSlakothPose30
+.4byte sSlakothPose31
+.4byte sSlakothPose32
+.4byte sSlakothPose33
+.4byte sSlakothPose34
+.4byte sSlakothPose35
+.4byte sSlakothPose36
+.4byte sSlakothPose37
+.4byte sSlakothPose38
+.4byte sSlakothPose39
+.4byte sSlakothPose40
+.4byte sSlakothPose41
+.4byte sSlakothPose42
+.4byte sSlakothPose43
+.4byte sSlakothPose44
+.4byte sSlakothPose45
+.4byte sSlakothPose46
+.4byte sSlakothPose47
+.4byte sSlakothPose48
+.4byte sSlakothPose49
+.4byte sSlakothPose50
+.4byte sSlakothPose51
+.4byte sSlakothPose52
+.4byte sSlakothPose53
+.4byte sSlakothPose54
+.4byte sSlakothPose55
+.4byte sSlakothPose56
+.4byte sSlakothPose57
+.4byte sSlakothPose58
+.4byte sSlakothPose59
+.4byte sSlakothPose60
+.4byte sSlakothPose61
+.4byte sSlakothPose62
+.4byte sSlakothPose63
+.4byte sSlakothPose64
+.4byte sSlakothPose65
+.4byte sSlakothPose66
+.4byte sSlakothPose67
+.4byte sSlakothPose68
+.4byte sSlakothPose69
+.4byte sSlakothPose70
+.4byte sSlakothPose71
+.4byte sSlakothPose72
+.4byte sSlakothPose73
+.4byte sSlakothPose74
+.4byte sSlakothPose75
+.4byte sSlakothPose76
+.4byte sSlakothPose77
+.4byte sSlakothPose78
+.4byte sSlakothPose79
+.4byte sSlakothPose80
+.4byte sSlakothPose81
+.4byte sSlakothPose82
+.4byte sSlakothPose83
+.4byte sSlakothPose84
+.4byte sSlakothPose85
+.4byte sSlakothPose86
+.4byte sSlakothPose87
+.4byte sSlakothPose88
+.4byte sSlakothPose89
+.4byte sSlakothPose90
+.4byte sSlakothPose91
+.4byte sSlakothPose92
+.4byte sSlakothPose93
+.4byte sSlakothPose94
+.4byte sSlakothPose95
+.4byte sSlakothPose96
+.4byte sSlakothPose97
+.4byte sSlakothPose98
+.4byte sSlakothPose99
+.4byte sSlakothPose100
+.4byte sSlakothPose101
+.4byte sSlakothPose102
+.4byte sSlakothPose103
+.4byte sSlakothPose104
+.4byte sSlakothPose105
+.4byte sSlakothPose106
+.4byte sSlakothPose107
+.4byte sSlakothPose108
+.4byte sSlakothPose109
+.4byte sSlakothPose110
+.4byte sSlakothPose111
+.4byte sSlakothPose112
+.4byte sSlakothPose113
+.4byte sSlakothPose114
+.4byte sSlakothPose115
+.4byte sSlakothPose116
+.4byte sSlakothPose117
+.4byte sSlakothPose118
+.4byte sSlakothPose119
+.4byte sSlakothPose120
+.4byte sSlakothPose121
+.4byte sSlakothPose122
+.4byte sSlakothPose123
+.4byte sSlakothPose124
+.4byte sSlakothPose125
+.4byte sSlakothPose126
+.4byte sSlakothPose127
+.4byte sSlakothPose128
+.4byte sSlakothPose129
+.4byte sSlakothPose130
+.4byte sSlakothPose131
+.4byte sSlakothPose132
+.4byte sSlakothPose133
+.4byte sSlakothPose134
+.4byte sSlakothPose135
+.4byte sSlakothPose136
+.4byte sSlakothPose137
+.4byte sSlakothPose138
+.4byte sSlakothPose139
+.4byte sSlakothPose140
+.4byte sSlakothPose141
+.4byte sSlakothPose142
+.4byte sSlakothPose143
+.4byte sSlakothPose144
+.4byte sSlakothPose145
+.4byte sSlakothPose146
+.4byte sSlakothPose147
+.4byte sSlakothPose148
+.4byte sSlakothPose149
+.4byte sSlakothPose150
+.4byte sSlakothPose151
+.4byte sSlakothPose152
+.4byte sSlakothPose153
+.4byte sSlakothPose154
+.4byte sSlakothPose155
+.4byte sSlakothPose156
+.4byte sSlakothPose157
+.4byte sSlakothPose158
+.4byte sSlakothPose159
+.4byte sSlakothPose160
+.4byte sSlakothPose161
+.4byte sSlakothPose162
+.4byte sSlakothPose163
+.4byte sSlakothPose164
+.4byte sSlakothPose165
+.4byte sSlakothPose166
+.4byte sSlakothPose167
+.4byte sSlakothPose168
+.4byte sSlakothPose169
+.4byte sSlakothPose170
+.4byte sSlakothPose171
+.4byte sSlakothPose172
+.4byte sSlakothPose173
+.4byte sSlakothPose174
+.4byte sSlakothPose175
+.4byte sSlakothPose176
+.4byte sSlakothPose177
+.4byte sSlakothPose178
+.4byte sSlakothPose179
+.4byte sSlakothPose180
+.4byte sSlakothPose181
+.4byte sSlakothPose182
+.4byte sSlakothPose183
+.4byte sSlakothPose184
+.4byte sSlakothPose185
+.4byte sSlakothPose186
+.4byte sSlakothPose187
+.4byte sSlakothPose188
+.4byte sSlakothPose189
+.4byte sSlakothPose190
+.4byte sSlakothPose191
+.4byte sSlakothPose192
+.4byte sSlakothPose193
+.4byte sSlakothPose194
+.4byte sSlakothPose195
+.4byte sSlakothPose196
+.4byte sSlakothPose197
+.4byte sSlakothPose198
+.4byte sSlakothPose199
+.4byte sSlakothPose200
+.4byte sSlakothPose201
+.4byte sSlakothPose202
+.4byte sSlakothPose203
+.4byte sSlakothPose204
+.4byte sSlakothPose205
+.4byte sSlakothPose206
+.4byte sSlakothPose207
+.4byte sSlakothPose208
+.4byte sSlakothPose209
+.4byte sSlakothPose210
+.4byte sSlakothPose211
+.4byte sSlakothPose212
+.4byte sSlakothPose213
+.4byte sSlakothPose214
+.4byte sSlakothPose215
+.4byte sSlakothPose216
+.4byte sSlakothPose217
+.4byte sSlakothPose218
+sAxPositionsSlakoth:
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -2,    4, 	 -12,   -1, 	   9,    4, 	  -2,   -2
+.2byte    0,    4, 	 -12,    4, 	  10,   -1, 	   0,   -2
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte    6,    3, 	   9,   -4, 	  -4,    7, 	  -1,   -4
+.2byte    5,    3, 	  13,    1, 	  -9,    5, 	  -1,   -4
+.2byte   11,   -3, 	   3,  -10, 	   3,    5, 	   0,   -5
+.2byte   11,   -3, 	   0,   -8, 	   6,    6, 	   0,   -4
+.2byte   10,   -1, 	   8,   -7, 	   1,    6, 	   0,   -4
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte    5,   -8, 	  -5,   -3, 	  12,    2, 	   0,   -5
+.2byte    5,   -8, 	   2,   -8, 	   8,    4, 	   0,   -5
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -1,   -7, 	   8,    0, 	 -10,   -4, 	  -1,   -4
+.2byte   -1,   -7, 	   8,   -4, 	 -10,    0, 	  -1,   -4
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -7,   -8, 	   3,   -3, 	 -14,    2, 	  -2,   -5
+.2byte   -7,   -8, 	  -4,   -8, 	 -10,    4, 	  -2,   -5
+.2byte  -13,   -3, 	  -5,  -10, 	  -5,    5, 	  -2,   -5
+.2byte  -13,   -3, 	  -2,   -8, 	  -8,    6, 	  -2,   -4
+.2byte  -12,   -1, 	 -10,   -7, 	  -3,    6, 	  -2,   -4
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte   -8,    3, 	 -11,   -4, 	   2,    7, 	  -1,   -4
+.2byte   -7,    3, 	 -15,    1, 	   7,    5, 	  -1,   -4
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -2,    4, 	 -12,   -1, 	   9,    4, 	  -2,   -2
+.2byte    0,    4, 	 -12,    4, 	  10,   -1, 	   0,   -2
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte    6,    3, 	   9,   -4, 	  -4,    7, 	  -1,   -4
+.2byte    5,    3, 	  13,    1, 	  -9,    5, 	  -1,   -4
+.2byte   11,   -3, 	   3,  -10, 	   3,    5, 	   0,   -5
+.2byte   11,   -3, 	   0,   -8, 	   6,    6, 	   0,   -4
+.2byte   10,   -1, 	   8,   -7, 	   1,    6, 	   0,   -4
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte    5,   -8, 	  -5,   -3, 	  12,    2, 	   0,   -5
+.2byte    5,   -8, 	   2,   -8, 	   8,    4, 	   0,   -5
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -1,   -7, 	   8,    0, 	 -10,   -4, 	  -1,   -4
+.2byte   -1,   -7, 	   8,   -4, 	 -10,    0, 	  -1,   -4
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -7,   -8, 	   3,   -3, 	 -14,    2, 	  -2,   -5
+.2byte   -7,   -8, 	  -4,   -8, 	 -10,    4, 	  -2,   -5
+.2byte  -13,   -3, 	  -5,  -10, 	  -5,    5, 	  -2,   -5
+.2byte  -13,   -3, 	  -2,   -8, 	  -8,    6, 	  -2,   -4
+.2byte  -12,   -1, 	 -10,   -7, 	  -3,    6, 	  -2,   -4
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte   -8,    3, 	 -11,   -4, 	   2,    7, 	  -1,   -4
+.2byte   -7,    3, 	 -15,    1, 	   7,    5, 	  -1,   -4
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -2,    4, 	 -12,   -1, 	   9,    4, 	  -2,   -2
+.2byte    0,    4, 	 -12,    4, 	  10,   -1, 	   0,   -2
+.2byte   -1,   -5, 	 -12,   -2, 	  10,   -2, 	  -1,   -8
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte    6,    3, 	   9,   -4, 	  -4,    7, 	  -1,   -4
+.2byte    5,    3, 	  13,    1, 	  -9,    5, 	  -1,   -4
+.2byte    2,   -1, 	  11,   -1, 	  -6,    1, 	   0,   -9
+.2byte   11,   -3, 	   3,  -10, 	   3,    5, 	   0,   -5
+.2byte   11,   -3, 	   0,   -8, 	   6,    6, 	   0,   -4
+.2byte   10,   -1, 	   8,   -7, 	   1,    6, 	   0,   -4
+.2byte    4,   -6, 	   4,  -10, 	   3,    0, 	   2,  -12
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte    5,   -8, 	  -5,   -3, 	  12,    2, 	   0,   -5
+.2byte    5,   -8, 	   2,   -8, 	   8,    4, 	   0,   -5
+.2byte    4,  -10, 	  -7,   -9, 	   8,    0, 	   0,  -11
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -1,   -7, 	   8,    0, 	 -10,   -4, 	  -1,   -4
+.2byte   -1,   -7, 	   8,   -4, 	 -10,    0, 	  -1,   -4
+.2byte   -1,  -10, 	   9,   -4, 	 -11,   -4, 	  -1,   -9
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -7,   -8, 	   3,   -3, 	 -14,    2, 	  -2,   -5
+.2byte   -7,   -8, 	  -4,   -8, 	 -10,    4, 	  -2,   -5
+.2byte   -6,  -10, 	   5,   -9, 	 -10,    0, 	  -2,  -11
+.2byte  -13,   -3, 	  -5,  -10, 	  -5,    5, 	  -2,   -5
+.2byte  -13,   -3, 	  -2,   -8, 	  -8,    6, 	  -2,   -4
+.2byte  -12,   -1, 	 -10,   -7, 	  -3,    6, 	  -2,   -4
+.2byte   -6,   -6, 	  -6,  -10, 	  -5,    0, 	  -4,  -12
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte   -8,    3, 	 -11,   -4, 	   2,    7, 	  -1,   -4
+.2byte   -7,    3, 	 -15,    1, 	   7,    5, 	  -1,   -4
+.2byte   -4,   -1, 	 -13,   -1, 	   4,    1, 	  -2,   -9
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -2,    4, 	 -12,   -1, 	   9,    4, 	  -2,   -2
+.2byte    0,    4, 	 -12,    4, 	  10,   -1, 	   0,   -2
+.2byte   -1,    1, 	 -12,    2, 	  10,    2, 	  -1,   -4
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte    6,    3, 	   9,   -4, 	  -4,    7, 	  -1,   -4
+.2byte    5,    3, 	  13,    1, 	  -9,    5, 	  -1,   -4
+.2byte    6,    2, 	  11,   -1, 	  -7,    7, 	  -2,   -4
+.2byte   11,   -3, 	   3,  -10, 	   3,    5, 	   0,   -5
+.2byte   11,   -3, 	   0,   -8, 	   6,    6, 	   0,   -4
+.2byte   10,   -1, 	   8,   -7, 	   1,    6, 	   0,   -4
+.2byte    8,   -1, 	   4,   -7, 	   4,    5, 	  -1,   -6
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte    5,   -8, 	  -5,   -3, 	  12,    2, 	   0,   -5
+.2byte    5,   -8, 	   2,   -8, 	   8,    4, 	   0,   -5
+.2byte    6,   -7, 	  -6,   -7, 	  11,    1, 	  -1,   -5
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -1,   -7, 	   8,    0, 	 -10,   -4, 	  -1,   -4
+.2byte   -1,   -7, 	   8,   -4, 	 -10,    0, 	  -1,   -4
+.2byte   -1,   -8, 	  11,   -4, 	 -13,   -4, 	  -1,   -4
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -7,   -8, 	   3,   -3, 	 -14,    2, 	  -2,   -5
+.2byte   -7,   -8, 	  -4,   -8, 	 -10,    4, 	  -2,   -5
+.2byte   -8,   -7, 	   4,   -7, 	 -13,    1, 	  -1,   -5
+.2byte  -13,   -3, 	  -5,  -10, 	  -5,    5, 	  -2,   -5
+.2byte  -13,   -3, 	  -2,   -8, 	  -8,    6, 	  -2,   -4
+.2byte  -12,   -1, 	 -10,   -7, 	  -3,    6, 	  -2,   -4
+.2byte  -10,   -1, 	  -6,   -7, 	  -6,    5, 	  -1,   -6
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte   -8,    3, 	 -11,   -4, 	   2,    7, 	  -1,   -4
+.2byte   -7,    3, 	 -15,    1, 	   7,    5, 	  -1,   -4
+.2byte   -8,    2, 	 -13,   -1, 	   5,    7, 	   0,   -4
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -2,    4, 	 -12,   -1, 	   9,    4, 	  -2,   -2
+.2byte    0,    4, 	 -12,    4, 	  10,   -1, 	   0,   -2
+.2byte   -1,    2, 	 -12,    3, 	  10,    3, 	  -1,   -3
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte    6,    3, 	   9,   -4, 	  -4,    7, 	  -1,   -4
+.2byte    5,    3, 	  13,    1, 	  -9,    5, 	  -1,   -4
+.2byte    6,    2, 	  11,   -1, 	  -7,    7, 	  -2,   -4
+.2byte   11,   -3, 	   3,  -10, 	   3,    5, 	   0,   -5
+.2byte   11,   -3, 	   0,   -8, 	   6,    6, 	   0,   -4
+.2byte   10,   -1, 	   8,   -7, 	   1,    6, 	   0,   -4
+.2byte    9,   -1, 	   5,   -7, 	   5,    5, 	   0,   -6
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte    5,   -8, 	  -5,   -3, 	  12,    2, 	   0,   -5
+.2byte    5,   -8, 	   2,   -8, 	   8,    4, 	   0,   -5
+.2byte    7,   -8, 	  -5,   -8, 	  12,    0, 	   0,   -6
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -1,   -7, 	   8,    0, 	 -10,   -4, 	  -1,   -4
+.2byte   -1,   -7, 	   8,   -4, 	 -10,    0, 	  -1,   -4
+.2byte   -1,  -10, 	  11,   -6, 	 -13,   -6, 	  -1,   -6
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -7,   -8, 	   3,   -3, 	 -14,    2, 	  -2,   -5
+.2byte   -7,   -8, 	  -4,   -8, 	 -10,    4, 	  -2,   -5
+.2byte   -9,   -8, 	   3,   -8, 	 -14,    0, 	  -2,   -6
+.2byte  -13,   -3, 	  -5,  -10, 	  -5,    5, 	  -2,   -5
+.2byte  -13,   -3, 	  -2,   -8, 	  -8,    6, 	  -2,   -4
+.2byte  -12,   -1, 	 -10,   -7, 	  -3,    6, 	  -2,   -4
+.2byte  -11,   -1, 	  -7,   -7, 	  -7,    5, 	  -2,   -6
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte   -8,    3, 	 -11,   -4, 	   2,    7, 	  -1,   -4
+.2byte   -7,    3, 	 -15,    1, 	   7,    5, 	  -1,   -4
+.2byte   -8,    2, 	 -13,   -1, 	   5,    7, 	   0,   -4
+.2byte   -7,    4, 	 -11,    1, 	  -4,    4, 	  -1,   -4
+.2byte   -7,    4, 	 -11,    1, 	  -4,    4, 	  -1,   -4
+.2byte    0,    1, 	  -4,   -7, 	   4,   -7, 	   0,   -5
+.2byte    6,    2, 	   8,   -7, 	   0,   -6, 	   1,   -5
+.2byte   10,    0, 	   4,  -11, 	   4,   -5, 	   1,   -5
+.2byte    5,   -6, 	   1,  -12, 	   8,   -8, 	   2,   -6
+.2byte    0,   -7, 	   5,  -11, 	  -5,  -11, 	   0,   -5
+.2byte   -6,   -6, 	  -2,  -12, 	  -9,   -8, 	  -3,   -6
+.2byte  -11,    0, 	  -5,  -11, 	  -5,   -5, 	  -2,   -5
+.2byte   -7,    2, 	  -9,   -7, 	  -1,   -6, 	  -2,   -5
+.2byte   -1,    4, 	 -14,    3, 	  12,    3, 	  -1,   -2
+.2byte   -7,    3, 	 -15,   -3, 	   6,    8, 	  -1,   -4
+.2byte  -13,   -2, 	 -10,  -12, 	  -9,    7, 	  -2,   -4
+.2byte   -7,   -8, 	   4,  -11, 	 -16,   -2, 	  -2,   -5
+.2byte   -1,   -7, 	  12,   -7, 	 -14,   -7, 	  -1,   -4
+.2byte    5,   -8, 	  -6,  -11, 	  14,   -2, 	   0,   -5
+.2byte   11,   -2, 	   8,  -12, 	   7,    7, 	   0,   -4
+.2byte    5,    3, 	  13,   -3, 	  -8,    8, 	  -1,   -4
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte  -13,   -3, 	  -5,  -10, 	  -5,    5, 	  -2,   -5
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte   11,   -3, 	   3,  -10, 	   3,    5, 	   0,   -5
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte   -1,    1, 	 -12,    2, 	  10,    2, 	  -1,   -4
+.2byte   -8,    1, 	 -13,   -2, 	   5,    6, 	   0,   -5
+.2byte  -10,   -1, 	  -6,   -7, 	  -6,    5, 	  -1,   -6
+.2byte   -8,   -8, 	   4,   -8, 	 -13,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  11,   -3, 	 -13,   -3, 	  -1,   -3
+.2byte    6,   -8, 	  -6,   -8, 	  11,    0, 	  -1,   -6
+.2byte    8,   -1, 	   4,   -7, 	   4,    5, 	  -1,   -6
+.2byte    6,    1, 	  11,   -2, 	  -7,    6, 	  -2,   -5
+.2byte   -1,    1, 	 -12,    2, 	  10,    2, 	  -1,   -4
+.2byte    6,    1, 	  11,   -2, 	  -7,    6, 	  -2,   -5
+.2byte    8,   -1, 	   4,   -7, 	   4,    5, 	  -1,   -6
+.2byte    6,   -8, 	  -6,   -8, 	  11,    0, 	  -1,   -6
+.2byte   -1,   -7, 	  11,   -3, 	 -13,   -3, 	  -1,   -3
+.2byte   -8,   -8, 	   4,   -8, 	 -13,    0, 	  -1,   -6
+.2byte  -10,   -1, 	  -6,   -7, 	  -6,    5, 	  -1,   -6
+.2byte   -8,    1, 	 -13,   -2, 	   5,    6, 	   0,   -5
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -1,   -2, 	 -12,    1, 	  10,    1, 	  -1,   -5
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte    2,    1, 	  11,    1, 	  -6,    3, 	   0,   -7
+.2byte   11,   -3, 	   3,  -10, 	   3,    5, 	   0,   -5
+.2byte    4,   -2, 	   4,   -6, 	   3,    4, 	   2,   -8
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte    4,   -6, 	  -7,   -5, 	   8,    4, 	   0,   -7
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte   -1,   -6, 	   9,    0, 	 -11,    0, 	  -1,   -5
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -6,   -6, 	   5,   -5, 	 -10,    4, 	  -2,   -7
+.2byte  -13,   -3, 	  -5,  -10, 	  -5,    5, 	  -2,   -5
+.2byte   -6,   -2, 	  -6,   -6, 	  -5,    4, 	  -4,   -8
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte   -4,    1, 	 -13,    1, 	   4,    3, 	  -2,   -7
+.2byte   -1,    3, 	 -13,    2, 	  11,    2, 	  -1,   -3
+.2byte   -7,    2, 	 -14,   -1, 	   5,    6, 	  -1,   -5
+.2byte  -12,   -3, 	  -4,  -10, 	  -4,    5, 	  -1,   -5
+.2byte   -7,   -9, 	   2,   -7, 	 -13,    2, 	  -2,   -6
+.2byte   -1,   -8, 	   9,   -2, 	 -11,   -2, 	  -1,   -5
+.2byte    5,   -9, 	  -4,   -7, 	  11,    2, 	   0,   -6
+.2byte   10,   -3, 	   2,  -10, 	   2,    5, 	  -1,   -5
+.2byte    5,    2, 	  12,   -1, 	  -7,    6, 	  -1,   -5
+.2byte   -1,    4, 	 -14,    3, 	  12,    3, 	  -1,   -2
+.2byte   -7,    3, 	 -15,   -3, 	   6,    8, 	  -1,   -4
+.2byte  -13,   -2, 	 -10,  -12, 	  -9,    7, 	  -2,   -4
+.2byte   -7,   -8, 	   4,  -11, 	 -16,   -2, 	  -2,   -5
+.2byte   -1,   -7, 	  12,   -7, 	 -14,   -7, 	  -1,   -4
+.2byte    5,   -8, 	  -6,  -11, 	  14,   -2, 	   0,   -5
+.2byte   11,   -2, 	   8,  -12, 	   7,    7, 	   0,   -4
+.2byte    5,    3, 	  13,   -3, 	  -8,    8, 	  -1,   -4
+sSlakothAnimTable1:
+.4byte sSlakothAnims_1_1
+.4byte sSlakothAnims_1_2
+.4byte sSlakothAnims_1_3
+.4byte sSlakothAnims_1_4
+.4byte sSlakothAnims_1_5
+.4byte sSlakothAnims_1_6
+.4byte sSlakothAnims_1_7
+.4byte sSlakothAnims_1_8
+sSlakothAnimTable2:
+.4byte sSlakothAnims_2_1
+.4byte sSlakothAnims_2_2
+.4byte sSlakothAnims_2_3
+.4byte sSlakothAnims_2_4
+.4byte sSlakothAnims_2_5
+.4byte sSlakothAnims_2_6
+.4byte sSlakothAnims_2_7
+.4byte sSlakothAnims_2_8
+sSlakothAnimTable3:
+.4byte sSlakothAnims_3_1
+.4byte sSlakothAnims_3_2
+.4byte sSlakothAnims_3_3
+.4byte sSlakothAnims_3_4
+.4byte sSlakothAnims_3_5
+.4byte sSlakothAnims_3_6
+.4byte sSlakothAnims_3_7
+.4byte sSlakothAnims_3_8
+sSlakothAnimTable4:
+.4byte sSlakothAnims_4_1
+.4byte sSlakothAnims_4_2
+.4byte sSlakothAnims_4_3
+.4byte sSlakothAnims_4_4
+.4byte sSlakothAnims_4_5
+.4byte sSlakothAnims_4_6
+.4byte sSlakothAnims_4_7
+.4byte sSlakothAnims_4_8
+sSlakothAnimTable5:
+.4byte sSlakothAnims_5_1
+.4byte sSlakothAnims_5_2
+.4byte sSlakothAnims_5_3
+.4byte sSlakothAnims_5_4
+.4byte sSlakothAnims_5_5
+.4byte sSlakothAnims_5_6
+.4byte sSlakothAnims_5_7
+.4byte sSlakothAnims_5_8
+sSlakothAnimTable6:
+.4byte sSlakothAnims_6_1
+.4byte sSlakothAnims_6_1
+.4byte sSlakothAnims_6_1
+.4byte sSlakothAnims_6_1
+.4byte sSlakothAnims_6_1
+.4byte sSlakothAnims_6_1
+.4byte sSlakothAnims_6_1
+.4byte sSlakothAnims_6_1
+sSlakothAnimTable7:
+.4byte sSlakothAnims_7_1
+.4byte sSlakothAnims_7_2
+.4byte sSlakothAnims_7_3
+.4byte sSlakothAnims_7_4
+.4byte sSlakothAnims_7_5
+.4byte sSlakothAnims_7_6
+.4byte sSlakothAnims_7_7
+.4byte sSlakothAnims_7_8
+sSlakothAnimTable8:
+.4byte sSlakothAnims_8_1
+.4byte sSlakothAnims_8_2
+.4byte sSlakothAnims_8_3
+.4byte sSlakothAnims_8_4
+.4byte sSlakothAnims_8_5
+.4byte sSlakothAnims_8_6
+.4byte sSlakothAnims_8_7
+.4byte sSlakothAnims_8_8
+sSlakothAnimTable9:
+.4byte sSlakothAnims_9_1
+.4byte sSlakothAnims_9_2
+.4byte sSlakothAnims_9_3
+.4byte sSlakothAnims_9_4
+.4byte sSlakothAnims_9_5
+.4byte sSlakothAnims_9_6
+.4byte sSlakothAnims_9_7
+.4byte sSlakothAnims_9_8
+sSlakothAnimTable10:
+.4byte sSlakothAnims_10_1
+.4byte sSlakothAnims_10_2
+.4byte sSlakothAnims_10_3
+.4byte sSlakothAnims_10_4
+.4byte sSlakothAnims_10_5
+.4byte sSlakothAnims_10_6
+.4byte sSlakothAnims_10_7
+.4byte sSlakothAnims_10_8
+sSlakothAnimTable11:
+.4byte sSlakothAnims_11_1
+.4byte sSlakothAnims_11_2
+.4byte sSlakothAnims_11_3
+.4byte sSlakothAnims_11_4
+.4byte sSlakothAnims_11_5
+.4byte sSlakothAnims_11_6
+.4byte sSlakothAnims_11_7
+.4byte sSlakothAnims_11_8
+sSlakothAnimTable12:
+.4byte sSlakothAnims_12_1
+.4byte sSlakothAnims_12_2
+.4byte sSlakothAnims_12_3
+.4byte sSlakothAnims_12_4
+.4byte sSlakothAnims_12_5
+.4byte sSlakothAnims_12_6
+.4byte sSlakothAnims_12_7
+.4byte sSlakothAnims_12_8
+sSlakothAnimTable13:
+.4byte sSlakothAnims_13_1
+.4byte sSlakothAnims_13_2
+.4byte sSlakothAnims_13_3
+.4byte sSlakothAnims_13_4
+.4byte sSlakothAnims_13_5
+.4byte sSlakothAnims_13_6
+.4byte sSlakothAnims_13_7
+.4byte sSlakothAnims_13_8
+sAxAnimationsSlakoth:
+.4byte sSlakothAnimTable1
+.4byte sSlakothAnimTable2
+.4byte sSlakothAnimTable3
+.4byte sSlakothAnimTable4
+.4byte sSlakothAnimTable5
+.4byte sSlakothAnimTable6
+.4byte sSlakothAnimTable7
+.4byte sSlakothAnimTable8
+.4byte sSlakothAnimTable9
+.4byte sSlakothAnimTable10
+.4byte sSlakothAnimTable11
+.4byte sSlakothAnimTable12
+.4byte sSlakothAnimTable13
+sAxSpritesSlakoth:
+.4byte sSlakothSprites1
+.4byte sSlakothSprites2
+.4byte sSlakothSprites3
+.4byte sSlakothSprites4
+.4byte sSlakothSprites5
+.4byte sSlakothSprites6
+.4byte sSlakothSprites7
+.4byte sSlakothSprites8
+.4byte sSlakothSprites9
+.4byte sSlakothSprites10
+.4byte sSlakothSprites11
+.4byte sSlakothSprites12
+.4byte sSlakothSprites13
+.4byte sSlakothSprites14
+.4byte sSlakothSprites15
+.4byte sSlakothSprites16
+.4byte sSlakothSprites17
+.4byte sSlakothSprites18
+.4byte sSlakothSprites19
+.4byte sSlakothSprites20
+.4byte sSlakothSprites21
+.4byte sSlakothSprites22
+.4byte sSlakothSprites23
+.4byte sSlakothSprites24
+.4byte sSlakothSprites25
+.4byte sSlakothSprites26
+.4byte sSlakothSprites27
+.4byte sSlakothSprites28
+.4byte sSlakothSprites29
+.4byte sSlakothSprites30
+.4byte sSlakothSprites31
+.4byte sSlakothSprites32
+.4byte sSlakothSprites33
+.4byte sSlakothSprites34
+.4byte sSlakothSprites35
+.4byte sSlakothSprites36
+.4byte sSlakothSprites37
+sAxMainSlakoth:
+ax_main sAxPosesSlakoth, sAxAnimationsSlakoth, 13, sAxSpritesSlakoth, sAxPositionsSlakoth

--- a/data/ax/slowbro.inc
+++ b/data/ax/slowbro.inc
@@ -1,0 +1,3220 @@
+.global gAxSlowbro
+gAxSlowbro:
+ax_siro sAxMainSlowbro
+sSlowbroPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose4:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose5:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose6:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose7:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose8:
+ax_pose 7, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose9:
+ax_pose 8, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose10:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose11:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose12:
+ax_pose 11, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose16:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose17:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose18:
+ax_pose 11, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose23:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose26:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose27:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose28:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose29:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose30:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose31:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose32:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose33:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose34:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose35:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose36:
+ax_pose 7, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose37:
+ax_pose 8, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose38:
+ax_pose 19, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowbroPose39:
+ax_pose 20, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose40:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose41:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose42:
+ax_pose 11, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose43:
+ax_pose 21, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose44:
+ax_pose 22, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose45:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose46:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose47:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose48:
+ax_pose 23, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose49:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose50:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose51:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose52:
+ax_pose 11, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose53:
+ax_pose 21, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose54:
+ax_pose 22, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose55:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose56:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose57:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose58:
+ax_pose 19, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose59:
+ax_pose 20, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose60:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose61:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose62:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose63:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose64:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose65:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose66:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose67:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose68:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose69:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose70:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose71:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose72:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose73:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose74:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose75:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose76:
+ax_pose 7, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose77:
+ax_pose 8, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose78:
+ax_pose 19, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowbroPose79:
+ax_pose 20, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose80:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose81:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose82:
+ax_pose 11, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose83:
+ax_pose 21, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose84:
+ax_pose 22, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose85:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose86:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose87:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose88:
+ax_pose 23, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose89:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose90:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose91:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose92:
+ax_pose 11, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose93:
+ax_pose 21, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose94:
+ax_pose 22, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose95:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose96:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose97:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose98:
+ax_pose 19, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose99:
+ax_pose 20, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose100:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose101:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose102:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose103:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose104:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose105:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose106:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose107:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose108:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose109:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose110:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose111:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose112:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose113:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose114:
+ax_pose 18, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose115:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose116:
+ax_pose 7, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose117:
+ax_pose 8, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose118:
+ax_pose 19, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowbroPose119:
+ax_pose 20, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose120:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose121:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose122:
+ax_pose 11, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose123:
+ax_pose 21, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose124:
+ax_pose 22, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose125:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose126:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose127:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose128:
+ax_pose 23, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose129:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose130:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose131:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose132:
+ax_pose 11, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose133:
+ax_pose 21, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose134:
+ax_pose 22, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose135:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose136:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose137:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose138:
+ax_pose 19, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose139:
+ax_pose 20, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose140:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose141:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose142:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose143:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose144:
+ax_pose 18, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose145:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose146:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose147:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose148:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose149:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose150:
+ax_pose 25, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose151:
+ax_pose 26, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose152:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose153:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose154:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose155:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose156:
+ax_pose 18, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose157:
+ax_pose 27, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowbroPose158:
+ax_pose 28, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowbroPose159:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose160:
+ax_pose 7, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose161:
+ax_pose 8, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose162:
+ax_pose 19, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowbroPose163:
+ax_pose 20, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose164:
+ax_pose 29, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose165:
+ax_pose 30, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose166:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose167:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose168:
+ax_pose 11, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose169:
+ax_pose 21, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose170:
+ax_pose 22, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose171:
+ax_pose 31, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose172:
+ax_pose 32, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose173:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose174:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose175:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose176:
+ax_pose 23, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose177:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose178:
+ax_pose 33, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose179:
+ax_pose 34, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose180:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose181:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose182:
+ax_pose 11, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose183:
+ax_pose 21, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose184:
+ax_pose 22, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose185:
+ax_pose 31, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose186:
+ax_pose 32, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose187:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose188:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose189:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose190:
+ax_pose 19, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose191:
+ax_pose 20, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose192:
+ax_pose 29, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose193:
+ax_pose 30, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose194:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose195:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose196:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose197:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose198:
+ax_pose 18, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose199:
+ax_pose 27, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose200:
+ax_pose 28, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose201:
+ax_pose 35, 0x01ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose202:
+ax_pose 36, 0x01ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose203:
+ax_pose 37, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose204:
+ax_pose 38, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose205:
+ax_pose 39, 0x01e5, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose206:
+ax_pose 40, 0x01e8, 0x90e9, 0x5c00
+ax_pose_terminator
+sSlowbroPose207:
+ax_pose 41, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose208:
+ax_pose 40, 0x01e8, 0x80f6, 0x5c00
+ax_pose_terminator
+sSlowbroPose209:
+ax_pose 39, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose210:
+ax_pose 38, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose211:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose212:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose213:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose214:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose215:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose216:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose217:
+ax_pose 4, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose218:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose219:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose220:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose221:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose222:
+ax_pose 7, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose223:
+ax_pose 8, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose224:
+ax_pose 19, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowbroPose225:
+ax_pose 20, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowbroPose226:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose227:
+ax_pose 10, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose228:
+ax_pose 11, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose229:
+ax_pose 21, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose230:
+ax_pose 22, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose231:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose232:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose233:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose234:
+ax_pose 23, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose235:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose236:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose237:
+ax_pose 10, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose238:
+ax_pose 11, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose239:
+ax_pose 21, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose240:
+ax_pose 22, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose241:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose242:
+ax_pose 7, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose243:
+ax_pose 8, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose244:
+ax_pose 19, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose245:
+ax_pose 20, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowbroPose246:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose247:
+ax_pose 4, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose248:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose249:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose250:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose251:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose252:
+ax_pose 18, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose253:
+ax_pose 20, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose254:
+ax_pose 22, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose255:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose256:
+ax_pose 22, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose257:
+ax_pose 20, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose258:
+ax_pose 18, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose259:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose260:
+ax_pose 18, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose261:
+ax_pose 20, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose262:
+ax_pose 22, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose263:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose264:
+ax_pose 22, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose265:
+ax_pose 20, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose266:
+ax_pose 18, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose267:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose268:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose269:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose270:
+ax_pose 18, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose271:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose272:
+ax_pose 20, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose273:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose274:
+ax_pose 22, 0x01ec, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose275:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose276:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose277:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose278:
+ax_pose 22, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose279:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose280:
+ax_pose 20, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose281:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose282:
+ax_pose 18, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose283:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose284:
+ax_pose 18, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sSlowbroPose285:
+ax_pose 20, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose286:
+ax_pose 22, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose287:
+ax_pose 24, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowbroPose288:
+ax_pose 22, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose289:
+ax_pose 20, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose290:
+ax_pose 18, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sSlowbroPose291:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose292:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose293:
+ax_pose 6, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose294:
+ax_pose 9, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose295:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowbroPose296:
+ax_pose 9, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose297:
+ax_pose 6, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowbroPose298:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sSlowbroAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_2_1:
+ax_anim 6, 0, 27, 0, 0, 0, 0,
+ax_anim 6, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 0, -11, 0, 0,
+ax_anim 1, 0, 33, 0, -14, 0, 0,
+ax_anim 1, 0, 38, 0, -15, 0, 0,
+ax_anim 2, 0, 43, 0, -16, 0, 0,
+ax_anim 2, 0, 48, 0, -16, 0, 0,
+ax_anim 1, 0, 53, 0, -15, 0, 0,
+ax_anim 1, 0, 58, 0, -14, 0, 0,
+ax_anim 1, 0, 63, 0, -11, 0, 0,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 9, 0, 9,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 1, 25, -1, 19, -1, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 25, -1, 19, -1, 19,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim_terminator
+sSlowbroAnims_2_2:
+ax_anim 6, 0, 32, 0, 0, 0, 0,
+ax_anim 6, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 0, -11, 0, 0,
+ax_anim 1, 0, 38, 0, -14, 0, 0,
+ax_anim 1, 0, 43, 0, -15, 0, 0,
+ax_anim 2, 0, 48, 0, -16, 0, 0,
+ax_anim 2, 0, 53, 0, -16, 0, 0,
+ax_anim 1, 0, 58, 0, -15, 0, 0,
+ax_anim 1, 0, 63, 0, -14, 0, 0,
+ax_anim 1, 0, 28, 0, -11, 0, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 2, 2, 2, 2,
+ax_anim 1, 0, 30, 9, 9, 9, 9,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 30, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 30, 20, 18, 20, 18,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim_terminator
+sSlowbroAnims_2_3:
+ax_anim 6, 0, 37, 0, 0, 0, 0,
+ax_anim 6, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 0, 38, 0, -11, 0, 0,
+ax_anim 1, 0, 43, 0, -14, 0, 0,
+ax_anim 1, 0, 48, 0, -15, 0, 0,
+ax_anim 2, 0, 53, 0, -16, 0, 0,
+ax_anim 2, 0, 58, 0, -16, 0, 0,
+ax_anim 1, 0, 63, 0, -15, 0, 0,
+ax_anim 1, 0, 28, 0, -14, 0, 0,
+ax_anim 1, 0, 33, 0, -11, 0, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 2, 0, 2, 0,
+ax_anim 1, 0, 35, 9, 0, 9, 0,
+ax_anim 2, 0, 36, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, -1, 19, -1,
+ax_anim 2, 0, 36, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, -1, 19, -1,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim_terminator
+sSlowbroAnims_2_4:
+ax_anim 6, 0, 42, 0, 0, 0, 0,
+ax_anim 6, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 0, 43, 0, -11, 0, 0,
+ax_anim 1, 0, 48, 0, -14, 0, 0,
+ax_anim 1, 0, 53, 0, -15, 0, 0,
+ax_anim 2, 0, 58, 0, -16, 0, 0,
+ax_anim 2, 0, 63, 0, -16, 0, 0,
+ax_anim 1, 0, 28, 0, -15, 0, 0,
+ax_anim 1, 0, 33, 0, -14, 0, 0,
+ax_anim 1, 0, 38, 0, -11, 0, 0,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 2, -2, 2, -2,
+ax_anim 1, 0, 40, 9, -9, 9, -9,
+ax_anim 2, 0, 41, 19, -19, 19, -19,
+ax_anim 2, 1, 40, 20, -18, 20, -18,
+ax_anim 2, 0, 41, 19, -19, 19, -19,
+ax_anim 2, 0, 40, 20, -18, 20, -18,
+ax_anim 1, 0, 39, 10, -10, 10, -10,
+ax_anim_terminator
+sSlowbroAnims_2_5:
+ax_anim 6, 0, 47, 0, 0, 0, 0,
+ax_anim 6, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, -11, 0, 0,
+ax_anim 1, 0, 53, 0, -14, 0, 0,
+ax_anim 1, 0, 58, 0, -15, 0, 0,
+ax_anim 2, 0, 63, 0, -16, 0, 0,
+ax_anim 2, 0, 28, 0, -16, 0, 0,
+ax_anim 1, 0, 33, 0, -15, 0, 0,
+ax_anim 1, 0, 38, 0, -14, 0, 0,
+ax_anim 1, 0, 43, 0, -11, 0, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, 0, -2, 0, -2,
+ax_anim 1, 0, 45, 0, -9, 0, -9,
+ax_anim 2, 0, 46, 0, -19, 0, -19,
+ax_anim 2, 1, 45, 0, -18, 0, -18,
+ax_anim 2, 0, 46, 0, -19, 0, -19,
+ax_anim 2, 0, 45, 0, -18, 0, -18,
+ax_anim 1, 0, 44, 0, -10, 0, -10,
+ax_anim_terminator
+sSlowbroAnims_2_6:
+ax_anim 6, 0, 52, 0, 0, 0, 0,
+ax_anim 6, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 53, 0, -11, 0, 0,
+ax_anim 1, 0, 58, 0, -14, 0, 0,
+ax_anim 1, 0, 63, 0, -15, 0, 0,
+ax_anim 2, 0, 28, 0, -16, 0, 0,
+ax_anim 2, 0, 33, 0, -16, 0, 0,
+ax_anim 1, 0, 38, 0, -15, 0, 0,
+ax_anim 1, 0, 43, 0, -14, 0, 0,
+ax_anim 1, 0, 48, 0, -11, 0, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 50, -9, -9, -9, -9,
+ax_anim 2, 0, 51, -19, -19, -19, -19,
+ax_anim 2, 1, 50, -20, -18, -20, -18,
+ax_anim 2, 0, 51, -19, -19, -19, -19,
+ax_anim 2, 0, 50, -20, -18, -20, -18,
+ax_anim 1, 0, 49, -10, -10, -10, -10,
+ax_anim_terminator
+sSlowbroAnims_2_7:
+ax_anim 6, 0, 57, 0, 0, 0, 0,
+ax_anim 6, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 0, -11, 0, 0,
+ax_anim 1, 0, 63, 0, -14, 0, 0,
+ax_anim 1, 0, 28, 0, -15, 0, 0,
+ax_anim 2, 0, 33, 0, -16, 0, 0,
+ax_anim 2, 0, 38, 0, -16, 0, 0,
+ax_anim 1, 0, 43, 0, -15, 0, 0,
+ax_anim 1, 0, 48, 0, -14, 0, 0,
+ax_anim 1, 0, 53, 0, -11, 0, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 55, -9, 0, -9, 0,
+ax_anim 2, 0, 56, -19, 0, -19, 0,
+ax_anim 2, 1, 55, -19, -1, -19, -1,
+ax_anim 2, 0, 56, -19, 0, -19, 0,
+ax_anim 2, 0, 55, -19, -1, -19, -1,
+ax_anim 1, 0, 54, -10, 0, -10, 0,
+ax_anim_terminator
+sSlowbroAnims_2_8:
+ax_anim 6, 0, 62, 0, 0, 0, 0,
+ax_anim 6, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 0, -11, 0, 0,
+ax_anim 1, 0, 28, 0, -14, 0, 0,
+ax_anim 1, 0, 33, 0, -15, 0, 0,
+ax_anim 2, 0, 38, 0, -16, 0, 0,
+ax_anim 2, 0, 43, 0, -16, 0, 0,
+ax_anim 1, 0, 48, 0, -15, 0, 0,
+ax_anim 1, 0, 53, 0, -14, 0, 0,
+ax_anim 1, 0, 58, 0, -11, 0, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, -2, 2, -2, 2,
+ax_anim 1, 0, 60, -9, 9, -9, 9,
+ax_anim 2, 0, 61, -19, 19, -19, 19,
+ax_anim 2, 1, 60, -20, 18, -20, 18,
+ax_anim 2, 0, 61, -19, 19, -19, 19,
+ax_anim 2, 0, 60, -20, 18, -20, 18,
+ax_anim 1, 0, 59, -10, 10, -10, 10,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_3_1:
+ax_anim 6, 0, 67, 0, 0, 0, 0,
+ax_anim 6, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 68, 0, -11, 0, 0,
+ax_anim 1, 0, 73, 0, -14, 0, 0,
+ax_anim 1, 0, 78, 0, -15, 0, 0,
+ax_anim 2, 0, 83, 0, -16, 0, 0,
+ax_anim 2, 0, 88, 0, -16, 0, 0,
+ax_anim 1, 0, 93, 0, -15, 0, 0,
+ax_anim 1, 0, 98, 0, -14, 0, 0,
+ax_anim 1, 0, 103, 0, -11, 0, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 0, 2, 0, 2,
+ax_anim 1, 0, 65, 0, 9, 0, 9,
+ax_anim 2, 0, 66, 0, 19, 0, 19,
+ax_anim 2, 1, 65, -1, 19, -1, 19,
+ax_anim 2, 0, 66, 0, 19, 0, 19,
+ax_anim 2, 0, 65, -1, 19, -1, 19,
+ax_anim 1, 0, 64, 0, 10, 0, 10,
+ax_anim_terminator
+sSlowbroAnims_3_2:
+ax_anim 6, 0, 72, 0, 0, 0, 0,
+ax_anim 6, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -11, 0, 0,
+ax_anim 1, 0, 78, 0, -14, 0, 0,
+ax_anim 1, 0, 83, 0, -15, 0, 0,
+ax_anim 2, 0, 88, 0, -16, 0, 0,
+ax_anim 2, 0, 93, 0, -16, 0, 0,
+ax_anim 1, 0, 98, 0, -15, 0, 0,
+ax_anim 1, 0, 103, 0, -14, 0, 0,
+ax_anim 1, 0, 68, 0, -11, 0, 0,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 2, 2, 2, 2,
+ax_anim 1, 0, 70, 9, 9, 9, 9,
+ax_anim 2, 0, 71, 19, 19, 19, 19,
+ax_anim 2, 1, 70, 20, 18, 20, 18,
+ax_anim 2, 0, 71, 19, 19, 19, 19,
+ax_anim 2, 0, 70, 20, 18, 20, 18,
+ax_anim 1, 0, 69, 10, 10, 10, 10,
+ax_anim_terminator
+sSlowbroAnims_3_3:
+ax_anim 6, 0, 77, 0, 0, 0, 0,
+ax_anim 6, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -11, 0, 0,
+ax_anim 1, 0, 83, 0, -14, 0, 0,
+ax_anim 1, 0, 88, 0, -15, 0, 0,
+ax_anim 2, 0, 93, 0, -16, 0, 0,
+ax_anim 2, 0, 98, 0, -16, 0, 0,
+ax_anim 1, 0, 103, 0, -15, 0, 0,
+ax_anim 1, 0, 68, 0, -14, 0, 0,
+ax_anim 1, 0, 73, 0, -11, 0, 0,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 2, 76, 2, 0, 2, 0,
+ax_anim 1, 0, 75, 9, 0, 9, 0,
+ax_anim 2, 0, 76, 19, 0, 19, 0,
+ax_anim 2, 1, 75, 19, -1, 19, -1,
+ax_anim 2, 0, 76, 19, 0, 19, 0,
+ax_anim 2, 0, 75, 19, -1, 19, -1,
+ax_anim 1, 0, 74, 10, 0, 10, 0,
+ax_anim_terminator
+sSlowbroAnims_3_4:
+ax_anim 6, 0, 82, 0, 0, 0, 0,
+ax_anim 6, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, -11, 0, 0,
+ax_anim 1, 0, 88, 0, -14, 0, 0,
+ax_anim 1, 0, 93, 0, -15, 0, 0,
+ax_anim 2, 0, 98, 0, -16, 0, 0,
+ax_anim 2, 0, 103, 0, -16, 0, 0,
+ax_anim 1, 0, 68, 0, -15, 0, 0,
+ax_anim 1, 0, 73, 0, -14, 0, 0,
+ax_anim 1, 0, 78, 0, -11, 0, 0,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 2, 81, 2, -2, 2, -2,
+ax_anim 1, 0, 80, 9, -9, 9, -9,
+ax_anim 2, 0, 81, 19, -19, 19, -19,
+ax_anim 2, 1, 80, 20, -18, 20, -18,
+ax_anim 2, 0, 81, 19, -19, 19, -19,
+ax_anim 2, 0, 80, 20, -18, 20, -18,
+ax_anim 1, 0, 79, 10, -10, 10, -10,
+ax_anim_terminator
+sSlowbroAnims_3_5:
+ax_anim 6, 0, 87, 0, 0, 0, 0,
+ax_anim 6, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -11, 0, 0,
+ax_anim 1, 0, 93, 0, -14, 0, 0,
+ax_anim 1, 0, 98, 0, -15, 0, 0,
+ax_anim 2, 0, 103, 0, -16, 0, 0,
+ax_anim 2, 0, 68, 0, -16, 0, 0,
+ax_anim 1, 0, 73, 0, -15, 0, 0,
+ax_anim 1, 0, 78, 0, -14, 0, 0,
+ax_anim 1, 0, 83, 0, -11, 0, 0,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 2, 86, 0, -2, 0, -2,
+ax_anim 1, 0, 85, 0, -9, 0, -9,
+ax_anim 2, 0, 86, 0, -19, 0, -19,
+ax_anim 2, 1, 85, 0, -18, 0, -18,
+ax_anim 2, 0, 86, 0, -19, 0, -19,
+ax_anim 2, 0, 85, 0, -18, 0, -18,
+ax_anim 1, 0, 84, 0, -10, 0, -10,
+ax_anim_terminator
+sSlowbroAnims_3_6:
+ax_anim 6, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -11, 0, 0,
+ax_anim 1, 0, 98, 0, -14, 0, 0,
+ax_anim 1, 0, 103, 0, -15, 0, 0,
+ax_anim 2, 0, 68, 0, -16, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 1, 0, 78, 0, -15, 0, 0,
+ax_anim 1, 0, 83, 0, -14, 0, 0,
+ax_anim 1, 0, 88, 0, -11, 0, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 2, 91, -2, -2, -2, -2,
+ax_anim 1, 0, 90, -9, -9, -9, -9,
+ax_anim 2, 0, 91, -19, -19, -19, -19,
+ax_anim 2, 1, 90, -20, -18, -20, -18,
+ax_anim 2, 0, 91, -19, -19, -19, -19,
+ax_anim 2, 0, 90, -20, -18, -20, -18,
+ax_anim 1, 0, 89, -10, -10, -10, -10,
+ax_anim_terminator
+sSlowbroAnims_3_7:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -11, 0, 0,
+ax_anim 1, 0, 103, 0, -14, 0, 0,
+ax_anim 1, 0, 68, 0, -15, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 1, 0, 83, 0, -15, 0, 0,
+ax_anim 1, 0, 88, 0, -14, 0, 0,
+ax_anim 1, 0, 93, 0, -11, 0, 0,
+ax_anim 1, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 2, 96, -2, 0, -2, 0,
+ax_anim 1, 0, 95, -9, 0, -9, 0,
+ax_anim 2, 0, 96, -19, 0, -19, 0,
+ax_anim 2, 1, 95, -19, -1, -19, -1,
+ax_anim 2, 0, 96, -19, 0, -19, 0,
+ax_anim 2, 0, 95, -19, -1, -19, -1,
+ax_anim 1, 0, 94, -10, 0, -10, 0,
+ax_anim_terminator
+sSlowbroAnims_3_8:
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -11, 0, 0,
+ax_anim 1, 0, 68, 0, -14, 0, 0,
+ax_anim 1, 0, 73, 0, -15, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 2, 0, 83, 0, -16, 0, 0,
+ax_anim 1, 0, 88, 0, -15, 0, 0,
+ax_anim 1, 0, 93, 0, -14, 0, 0,
+ax_anim 1, 0, 98, 0, -11, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 2, 101, -2, 2, -2, 2,
+ax_anim 1, 0, 100, -9, 9, -9, 9,
+ax_anim 2, 0, 101, -19, 19, -19, 19,
+ax_anim 2, 1, 100, -20, 18, -20, 18,
+ax_anim 2, 0, 101, -19, 19, -19, 19,
+ax_anim 2, 0, 100, -20, 18, -20, 18,
+ax_anim 1, 0, 99, -10, 10, -10, 10,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_4_1:
+ax_anim 8, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 4, 0, 4,
+ax_anim 2, 2, 108, 1, 4, 1, 4,
+ax_anim 2, 0, 108, 0, 4, 0, 4,
+ax_anim 2, 0, 108, 1, 4, 1, 4,
+ax_anim 2, 0, 108, 0, 4, 0, 4,
+ax_anim 2, 1, 108, 1, 4, 1, 4,
+ax_anim 2, 0, 108, 0, 4, 0, 4,
+ax_anim 2, 0, 108, 1, 4, 1, 4,
+ax_anim 2, 0, 108, 0, 4, 0, 4,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sSlowbroAnims_4_2:
+ax_anim 8, 0, 112, 0, 0, 0, 0,
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 2, 113, 5, 4, 5, 4,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 4, 5, 4,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 1, 113, 5, 4, 5, 4,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 113, 5, 4, 5, 4,
+ax_anim 2, 0, 113, 4, 4, 4, 4,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim_terminator
+sSlowbroAnims_4_3:
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 118, 4, 0, 4, 0,
+ax_anim 2, 2, 118, 5, 0, 5, 0,
+ax_anim 2, 0, 118, 4, 0, 4, 0,
+ax_anim 2, 0, 118, 5, 0, 5, 0,
+ax_anim 2, 0, 118, 4, 0, 4, 0,
+ax_anim 2, 1, 118, 5, 0, 5, 0,
+ax_anim 2, 0, 118, 4, 0, 4, 0,
+ax_anim 2, 0, 118, 5, 0, 5, 0,
+ax_anim 2, 0, 118, 4, 0, 4, 0,
+ax_anim 2, 0, 114, 2, 0, 2, 0,
+ax_anim_terminator
+sSlowbroAnims_4_4:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 4, -4, 4, -4,
+ax_anim 2, 2, 123, 5, -4, 5, -4,
+ax_anim 2, 0, 123, 4, -4, 4, -4,
+ax_anim 2, 0, 123, 5, -4, 5, -4,
+ax_anim 2, 0, 123, 4, -4, 4, -4,
+ax_anim 2, 1, 123, 5, -4, 5, -4,
+ax_anim 2, 0, 123, 4, -4, 4, -4,
+ax_anim 2, 0, 123, 5, -4, 5, -4,
+ax_anim 2, 0, 123, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim_terminator
+sSlowbroAnims_4_5:
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim 2, 2, 128, -1, -4, -1, -4,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim 2, 0, 128, -1, -4, -1, -4,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim 2, 1, 128, -1, -4, -1, -4,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim 2, 0, 128, -1, -4, -1, -4,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim 2, 0, 124, 0, -2, 0, -2,
+ax_anim_terminator
+sSlowbroAnims_4_6:
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 133, -4, -4, -4, -4,
+ax_anim 2, 2, 133, -5, -4, -5, -4,
+ax_anim 2, 0, 133, -4, -4, -4, -4,
+ax_anim 2, 0, 133, -5, -4, -5, -4,
+ax_anim 2, 0, 133, -4, -4, -4, -4,
+ax_anim 2, 1, 133, -5, -4, -5, -4,
+ax_anim 2, 0, 133, -4, -4, -4, -4,
+ax_anim 2, 0, 133, -5, -4, -5, -4,
+ax_anim 2, 0, 133, -4, -4, -4, -4,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim_terminator
+sSlowbroAnims_4_7:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 138, -4, 0, -4, 0,
+ax_anim 2, 2, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -4, 0, -4, 0,
+ax_anim 2, 0, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -4, 0, -4, 0,
+ax_anim 2, 1, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -4, 0, -4, 0,
+ax_anim 2, 0, 138, -5, 0, -5, 0,
+ax_anim 2, 0, 138, -4, 0, -4, 0,
+ax_anim 2, 0, 134, -2, 0, -2, 0,
+ax_anim_terminator
+sSlowbroAnims_4_8:
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 143, -4, 4, -4, 4,
+ax_anim 2, 2, 143, -5, 4, -5, 4,
+ax_anim 2, 0, 143, -4, 4, -4, 4,
+ax_anim 2, 0, 143, -5, 4, -5, 4,
+ax_anim 2, 0, 143, -4, 4, -4, 4,
+ax_anim 2, 1, 143, -5, 4, -5, 4,
+ax_anim 2, 0, 143, -4, 4, -4, 4,
+ax_anim 2, 0, 143, -5, 4, -5, 4,
+ax_anim 2, 0, 143, -4, 4, -4, 4,
+ax_anim 2, 0, 139, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_5_1:
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -5, 0, 0,
+ax_anim 2, 0, 148, 0, -8, 0, 0,
+ax_anim 3, 0, 150, 0, -9, 0, 0,
+ax_anim 3, 0, 149, 0, -10, 0, 0,
+ax_anim 3, 0, 150, 0, -10, 0, 0,
+ax_anim 3, 0, 149, 0, -9, 0, 0,
+ax_anim 2, 0, 150, 0, -8, 0, 0,
+ax_anim 1, 0, 148, 0, -6, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_5_2:
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 2, 0, 155, 0, -8, 0, 0,
+ax_anim 3, 0, 157, 0, -9, 0, 0,
+ax_anim 3, 0, 156, 0, -10, 0, 0,
+ax_anim 3, 0, 157, 0, -10, 0, 0,
+ax_anim 3, 0, 156, 0, -9, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 1, 0, 155, 0, -6, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_5_3:
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -5, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 3, 0, 164, 0, -9, 0, 0,
+ax_anim 3, 0, 163, 0, -10, 0, 0,
+ax_anim 3, 0, 164, 0, -10, 0, 0,
+ax_anim 3, 0, 163, 0, -9, 0, 0,
+ax_anim 2, 0, 164, 0, -8, 0, 0,
+ax_anim 1, 0, 162, 0, -6, 0, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_5_4:
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -8, 0, 0,
+ax_anim 3, 0, 171, 0, -9, 0, 0,
+ax_anim 3, 0, 170, 0, -10, 0, 0,
+ax_anim 3, 0, 171, 0, -10, 0, 0,
+ax_anim 3, 0, 170, 0, -9, 0, 0,
+ax_anim 2, 0, 171, 0, -8, 0, 0,
+ax_anim 1, 0, 169, 0, -6, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_5_5:
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -5, 0, 0,
+ax_anim 2, 0, 176, 0, -8, 0, 0,
+ax_anim 3, 0, 178, 0, -9, 0, 0,
+ax_anim 3, 0, 177, 0, -10, 0, 0,
+ax_anim 3, 0, 178, 0, -10, 0, 0,
+ax_anim 3, 0, 177, 0, -9, 0, 0,
+ax_anim 2, 0, 178, 0, -8, 0, 0,
+ax_anim 1, 0, 176, 0, -6, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_5_6:
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -5, 0, 0,
+ax_anim 2, 0, 183, 0, -8, 0, 0,
+ax_anim 3, 0, 185, 0, -9, 0, 0,
+ax_anim 3, 0, 184, 0, -10, 0, 0,
+ax_anim 3, 0, 185, 0, -10, 0, 0,
+ax_anim 3, 0, 184, 0, -9, 0, 0,
+ax_anim 2, 0, 185, 0, -8, 0, 0,
+ax_anim 1, 0, 183, 0, -6, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_5_7:
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -5, 0, 0,
+ax_anim 2, 0, 190, 0, -8, 0, 0,
+ax_anim 3, 0, 192, 0, -9, 0, 0,
+ax_anim 3, 0, 191, 0, -10, 0, 0,
+ax_anim 3, 0, 192, 0, -10, 0, 0,
+ax_anim 3, 0, 191, 0, -9, 0, 0,
+ax_anim 2, 0, 192, 0, -8, 0, 0,
+ax_anim 1, 0, 190, 0, -6, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_5_8:
+ax_anim 4, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -5, 0, 0,
+ax_anim 2, 0, 197, 0, -8, 0, 0,
+ax_anim 3, 0, 199, 0, -9, 0, 0,
+ax_anim 3, 0, 198, 0, -10, 0, 0,
+ax_anim 3, 0, 199, 0, -10, 0, 0,
+ax_anim 3, 0, 198, 0, -9, 0, 0,
+ax_anim 2, 0, 199, 0, -8, 0, 0,
+ax_anim 1, 0, 197, 0, -6, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_6_1:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 35, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_7_1:
+ax_anim 2, 0, 202, 0, -2, 0, -2,
+ax_anim 8, 0, 202, 0, -3, 0, -3,
+ax_anim_terminator
+sSlowbroAnims_7_2:
+ax_anim 2, 0, 203, -2, -2, -2, -2,
+ax_anim 8, 0, 203, -3, -3, -3, -3,
+ax_anim_terminator
+sSlowbroAnims_7_3:
+ax_anim 2, 0, 204, -2, 0, -2, 0,
+ax_anim 8, 0, 204, -3, 0, -3, 0,
+ax_anim_terminator
+sSlowbroAnims_7_4:
+ax_anim 2, 0, 205, -2, 2, -2, 2,
+ax_anim 8, 0, 205, -3, 3, -3, 3,
+ax_anim_terminator
+sSlowbroAnims_7_5:
+ax_anim 2, 0, 206, 0, 2, 0, 2,
+ax_anim 8, 0, 206, 0, 3, 0, 3,
+ax_anim_terminator
+sSlowbroAnims_7_6:
+ax_anim 2, 0, 207, 2, 2, 2, 2,
+ax_anim 8, 0, 207, 3, 3, 3, 3,
+ax_anim_terminator
+sSlowbroAnims_7_7:
+ax_anim 2, 0, 208, 2, 0, 2, 0,
+ax_anim 8, 0, 208, 3, 0, 3, 0,
+ax_anim_terminator
+sSlowbroAnims_7_8:
+ax_anim 2, 0, 209, 2, -2, 2, -2,
+ax_anim 8, 0, 209, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_8_1:
+ax_anim 30, 0, 210, 0, 0, 0, 0,
+ax_anim 30, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_8_2:
+ax_anim 30, 0, 215, 0, 0, 0, 0,
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_8_3:
+ax_anim 30, 0, 220, 0, 0, 0, 0,
+ax_anim 30, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_8_4:
+ax_anim 30, 0, 225, 0, 0, 0, 0,
+ax_anim 30, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_8_5:
+ax_anim 30, 0, 230, 0, 0, 0, 0,
+ax_anim 30, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_8_6:
+ax_anim 30, 0, 235, 0, 0, 0, 0,
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_8_7:
+ax_anim 30, 0, 240, 0, 0, 0, 0,
+ax_anim 30, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_8_8:
+ax_anim 30, 0, 245, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_9_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 1, 0, 251, 6, 3, 6, 3,
+ax_anim 2, 0, 252, 8, 9, 8, 9,
+ax_anim 2, 0, 253, 7, 17, 7, 17,
+ax_anim 3, 0, 254, 0, 20, 0, 20,
+ax_anim 2, 3, 255, -7, 17, -7, 17,
+ax_anim 2, 0, 256, -8, 9, -8, 9,
+ax_anim 1, 0, 257, -6, 3, -6, 3,
+ax_anim 1, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_9_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 250, 8, 0, 8, 0,
+ax_anim 2, 0, 251, 17, 3, 17, 3,
+ax_anim 2, 0, 252, 21, 12, 21, 12,
+ax_anim 3, 0, 253, 20, 20, 20, 20,
+ax_anim 2, 3, 254, 11, 21, 11, 21,
+ax_anim 2, 0, 255, 2, 17, 2, 17,
+ax_anim 1, 0, 256, -1, 10, -1, 10,
+ax_anim 1, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_9_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 3, -5, 3, -5,
+ax_anim 2, 0, 250, 11, -6, 11, -6,
+ax_anim 2, 0, 251, 16, -5, 16, -5,
+ax_anim 3, 0, 252, 18, -2, 18, -2,
+ax_anim 2, 3, 253, 16, 2, 16, 2,
+ax_anim 2, 0, 254, 10, 4, 10, 4,
+ax_anim 1, 0, 255, 4, 3, 4, 3,
+ax_anim 1, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_9_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 1, 0, 256, -1, -8, -1, -8,
+ax_anim 2, 0, 257, 4, -16, 4, -16,
+ax_anim 2, 0, 250, 12, -22, 12, -22,
+ax_anim 3, 0, 251, 18, -20, 18, -20,
+ax_anim 2, 3, 252, 20, -10, 20, -10,
+ax_anim 2, 0, 253, 17, -4, 17, -4,
+ax_anim 1, 0, 254, 9, 0, 9, 0,
+ax_anim 1, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_9_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 255, -8, -4, -8, -4,
+ax_anim 2, 0, 256, -10, -12, -10, -12,
+ax_anim 2, 0, 257, -7, -16, -7, -16,
+ax_anim 3, 0, 250, 0, -20, 0, -20,
+ax_anim 2, 3, 251, 7, -16, 7, -16,
+ax_anim 2, 0, 252, 10, -10, 10, -10,
+ax_anim 1, 0, 253, 8, -4, 8, -4,
+ax_anim 1, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_9_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 1, 0, 252, 1, -8, 1, -8,
+ax_anim 2, 0, 251, -4, -16, -4, -16,
+ax_anim 2, 0, 250, -12, -22, -12, -22,
+ax_anim 3, 0, 257, -18, -20, -18, -20,
+ax_anim 2, 3, 256, -20, -10, -20, -10,
+ax_anim 2, 0, 255, -17, -4, -17, -4,
+ax_anim 1, 0, 254, -8, 0, -8, 0,
+ax_anim 1, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_9_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 1, 0, 251, -3, -5, -3, -5,
+ax_anim 2, 0, 250, -11, -6, -11, -6,
+ax_anim 2, 0, 257, -16, -5, -16, -5,
+ax_anim 3, 0, 256, -18, -2, -18, -2,
+ax_anim 2, 3, 255, -16, 2, -16, 2,
+ax_anim 2, 0, 254, -10, 4, -10, 4,
+ax_anim 1, 0, 253, -4, 3, -4, 3,
+ax_anim 1, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_9_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 1, 0, 250, -8, 0, -8, 0,
+ax_anim 2, 0, 257, -17, 3, -17, 3,
+ax_anim 2, 0, 256, -21, 12, -21, 12,
+ax_anim 3, 0, 255, -20, 20, -20, 20,
+ax_anim 2, 3, 254, -11, 21, -11, 21,
+ax_anim 2, 0, 253, -2, 17, -2, 17,
+ax_anim 1, 0, 252, 1, 10, 1, 10,
+ax_anim 1, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_10_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 6, 0, 6, 0,
+ax_anim 2, 0, 258, -6, 0, -6, 0,
+ax_anim 2, 0, 258, 10, 0, 10, 0,
+ax_anim 2, 0, 258, -10, 0, -10, 0,
+ax_anim 2, 0, 258, 12, 0, 12, 0,
+ax_anim 3, 0, 258, -12, 0, -12, 0,
+ax_anim 3, 0, 258, 13, 0, 13, 0,
+ax_anim 3, 0, 258, -13, 0, -13, 0,
+ax_anim 2, 0, 258, 12, 0, 12, 0,
+ax_anim 3, 0, 258, -12, 0, -12, 0,
+ax_anim 2, 0, 258, 10, 0, 10, 0,
+ax_anim 2, 0, 258, -10, 0, -10, 0,
+ax_anim 2, 0, 258, 6, 0, 6, 0,
+ax_anim 2, 0, 258, -6, 0, -6, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_10_2:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 6, -6, 6, -6,
+ax_anim 2, 0, 259, -6, 6, -6, 6,
+ax_anim 2, 0, 259, 10, -10, 10, -10,
+ax_anim 2, 0, 259, -10, 10, -10, 10,
+ax_anim 2, 0, 259, 12, -12, 12, -12,
+ax_anim 3, 0, 259, -12, 12, -12, 12,
+ax_anim 3, 0, 259, 13, -13, 13, -13,
+ax_anim 3, 0, 259, -13, 13, -13, 13,
+ax_anim 2, 0, 259, 12, -12, 12, -12,
+ax_anim 3, 0, 259, -12, 12, -12, 12,
+ax_anim 2, 0, 259, 10, -10, 10, -10,
+ax_anim 2, 0, 259, -10, 10, -10, 10,
+ax_anim 2, 0, 259, 6, -6, 6, -6,
+ax_anim 2, 0, 259, -6, 6, -6, 6,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_10_3:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, -6, 0, -6,
+ax_anim 2, 0, 260, 0, 6, 0, 6,
+ax_anim 2, 0, 260, 0, -10, 0, -10,
+ax_anim 2, 0, 260, 0, 10, 0, 10,
+ax_anim 2, 0, 260, 0, -12, 0, -12,
+ax_anim 3, 0, 260, 0, 12, 0, 12,
+ax_anim 3, 0, 260, 0, -13, 0, -13,
+ax_anim 3, 0, 260, 0, 13, 0, 13,
+ax_anim 2, 0, 260, 0, -12, 0, -12,
+ax_anim 3, 0, 260, 0, 12, 0, 12,
+ax_anim 2, 0, 260, 0, -10, 0, -10,
+ax_anim 2, 0, 260, 0, 10, 0, 10,
+ax_anim 2, 0, 260, 0, -6, 0, -6,
+ax_anim 2, 0, 260, 0, 6, 0, 6,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_10_4:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 261, -6, -6, -6, -6,
+ax_anim 2, 0, 261, 6, 6, 6, 6,
+ax_anim 2, 0, 261, -10, -10, -10, -10,
+ax_anim 2, 0, 261, 10, 10, 10, 10,
+ax_anim 2, 0, 261, -12, -12, -12, -12,
+ax_anim 3, 0, 261, 12, 12, 12, 12,
+ax_anim 3, 0, 261, -13, -13, -13, -13,
+ax_anim 3, 0, 261, 13, 13, 13, 13,
+ax_anim 2, 0, 261, -12, -12, -12, -12,
+ax_anim 3, 0, 261, 12, 12, 12, 12,
+ax_anim 2, 0, 261, -10, -10, -10, -10,
+ax_anim 2, 0, 261, 10, 10, 10, 10,
+ax_anim 2, 0, 261, -6, -6, -6, -6,
+ax_anim 2, 0, 261, 6, 6, 6, 6,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_10_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 6, 0, 6, 0,
+ax_anim 2, 0, 262, -6, 0, -6, 0,
+ax_anim 2, 0, 262, 10, 0, 10, 0,
+ax_anim 2, 0, 262, -10, 0, -10, 0,
+ax_anim 2, 0, 262, 12, 0, 12, 0,
+ax_anim 3, 0, 262, -12, 0, -12, 0,
+ax_anim 3, 0, 262, 13, 0, 13, 0,
+ax_anim 3, 0, 262, -13, 0, -13, 0,
+ax_anim 2, 0, 262, 12, 0, 12, 0,
+ax_anim 3, 0, 262, -12, 0, -12, 0,
+ax_anim 2, 0, 262, 10, 0, 10, 0,
+ax_anim 2, 0, 262, -10, 0, -10, 0,
+ax_anim 2, 0, 262, 6, 0, 6, 0,
+ax_anim 2, 0, 262, -6, 0, -6, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_10_6:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 6, -6, 6, -6,
+ax_anim 2, 0, 263, -6, 6, -6, 6,
+ax_anim 2, 0, 263, 10, -10, 10, -10,
+ax_anim 2, 0, 263, -10, 10, -10, 10,
+ax_anim 2, 0, 263, 12, -12, 12, -12,
+ax_anim 3, 0, 263, -12, 12, -12, 12,
+ax_anim 3, 0, 263, 13, -13, 13, -13,
+ax_anim 3, 0, 263, -13, 13, -13, 13,
+ax_anim 2, 0, 263, 12, -12, 12, -12,
+ax_anim 3, 0, 263, -12, 12, -12, 12,
+ax_anim 2, 0, 263, 10, -10, 10, -10,
+ax_anim 2, 0, 263, -10, 10, -10, 10,
+ax_anim 2, 0, 263, 6, -6, 6, -6,
+ax_anim 2, 0, 263, -6, 6, -6, 6,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_10_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, -6, 0, -6,
+ax_anim 2, 0, 264, 0, 6, 0, 6,
+ax_anim 2, 0, 264, 0, -10, 0, -10,
+ax_anim 2, 0, 264, 0, 10, 0, 10,
+ax_anim 2, 0, 264, 0, -12, 0, -12,
+ax_anim 3, 0, 264, 0, 12, 0, 12,
+ax_anim 3, 0, 264, 0, -13, 0, -13,
+ax_anim 3, 0, 264, 0, 13, 0, 13,
+ax_anim 2, 0, 264, 0, -12, 0, -12,
+ax_anim 3, 0, 264, 0, 12, 0, 12,
+ax_anim 2, 0, 264, 0, -10, 0, -10,
+ax_anim 2, 0, 264, 0, 10, 0, 10,
+ax_anim 2, 0, 264, 0, -6, 0, -6,
+ax_anim 2, 0, 264, 0, 6, 0, 6,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_10_8:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 265, -6, -6, -6, -6,
+ax_anim 2, 0, 265, 6, 6, 6, 6,
+ax_anim 2, 0, 265, -10, -10, -10, -10,
+ax_anim 2, 0, 265, 10, 10, 10, 10,
+ax_anim 2, 0, 265, -12, -12, -12, -12,
+ax_anim 3, 0, 265, 12, 12, 12, 12,
+ax_anim 3, 0, 265, -13, -13, -13, -13,
+ax_anim 3, 0, 265, 13, 13, 13, 13,
+ax_anim 2, 0, 265, -12, -12, -12, -12,
+ax_anim 3, 0, 265, 12, 12, 12, 12,
+ax_anim 2, 0, 265, -10, -10, -10, -10,
+ax_anim 2, 0, 265, 10, 10, 10, 10,
+ax_anim 2, 0, 265, -6, -6, -6, -6,
+ax_anim 2, 0, 265, 6, 6, 6, 6,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_11_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 267, 0, -23, 0, 0,
+ax_anim 3, 0, 267, 0, -22, 0, 0,
+ax_anim 2, 0, 267, 0, -18, 0, 0,
+ax_anim 1, 0, 267, 0, -12, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_11_2:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 268, 0, -10, 0, 0,
+ax_anim 2, 0, 268, 0, -16, 0, 0,
+ax_anim 3, 0, 268, 0, -20, 0, 0,
+ax_anim 4, 0, 268, 0, -21, 0, 0,
+ax_anim 4, 0, 269, 0, -23, 0, 0,
+ax_anim 3, 0, 269, 0, -22, 0, 0,
+ax_anim 2, 0, 269, 0, -18, 0, 0,
+ax_anim 1, 0, 269, 0, -12, 0, 0,
+ax_anim 2, 2, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_11_3:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 1, 0, 270, 0, -10, 0, 0,
+ax_anim 2, 0, 270, 0, -16, 0, 0,
+ax_anim 3, 0, 270, 0, -20, 0, 0,
+ax_anim 4, 0, 270, 0, -21, 0, 0,
+ax_anim 4, 0, 271, 0, -23, 0, 0,
+ax_anim 3, 0, 271, 0, -22, 0, 0,
+ax_anim 2, 0, 271, 0, -18, 0, 0,
+ax_anim 1, 0, 271, 0, -12, 0, 0,
+ax_anim 2, 2, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_11_4:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 273, 0, -22, 0, 0,
+ax_anim 3, 0, 273, 0, -21, 0, 0,
+ax_anim 2, 0, 273, 0, -17, 0, 0,
+ax_anim 1, 0, 273, 0, -11, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_11_5:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -10, 0, 0,
+ax_anim 2, 0, 274, 0, -16, 0, 0,
+ax_anim 3, 0, 274, 0, -20, 0, 0,
+ax_anim 4, 0, 274, 0, -21, 0, 0,
+ax_anim 4, 0, 275, 0, -23, 0, 0,
+ax_anim 3, 0, 275, 0, -22, 0, 0,
+ax_anim 2, 0, 275, 0, -18, 0, 0,
+ax_anim 1, 0, 275, 0, -12, 0, 0,
+ax_anim 2, 2, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_11_6:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 1, 0, 276, 0, -10, 0, 0,
+ax_anim 2, 0, 276, 0, -16, 0, 0,
+ax_anim 3, 0, 276, 0, -20, 0, 0,
+ax_anim 4, 0, 276, 0, -21, 0, 0,
+ax_anim 4, 0, 277, 0, -22, 0, 0,
+ax_anim 3, 0, 277, 0, -21, 0, 0,
+ax_anim 2, 0, 277, 0, -17, 0, 0,
+ax_anim 1, 0, 277, 0, -11, 0, 0,
+ax_anim 2, 2, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_11_7:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 1, 0, 278, 0, -10, 0, 0,
+ax_anim 2, 0, 278, 0, -16, 0, 0,
+ax_anim 3, 0, 278, 0, -20, 0, 0,
+ax_anim 4, 0, 278, 0, -21, 0, 0,
+ax_anim 4, 0, 279, 0, -23, 0, 0,
+ax_anim 3, 0, 279, 0, -22, 0, 0,
+ax_anim 2, 0, 279, 0, -18, 0, 0,
+ax_anim 1, 0, 279, 0, -12, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_11_8:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 1, 0, 280, 0, -10, 0, 0,
+ax_anim 2, 0, 280, 0, -16, 0, 0,
+ax_anim 3, 0, 280, 0, -20, 0, 0,
+ax_anim 4, 0, 280, 0, -21, 0, 0,
+ax_anim 4, 0, 281, 0, -23, 0, 0,
+ax_anim 3, 0, 281, 0, -22, 0, 0,
+ax_anim 2, 0, 281, 0, -18, 0, 0,
+ax_anim 1, 0, 281, 0, -12, 0, 0,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_12_1:
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 1, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_12_2:
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 1, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_12_3:
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 1, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_12_4:
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 1, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_12_5:
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 1, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_12_6:
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 1, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_12_7:
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 1, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_12_8:
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 1, 283, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowbroAnims_13_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 2, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_13_2:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 2, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_13_3:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 2, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_13_4:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 2, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_13_5:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 2, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_13_6:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 2, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_13_7:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 2, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroAnims_13_8:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 2, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowbroGfx1:
+.incbin "baserom.gba", 0x8721AC, 0x200
+sSlowbroSprites1:
+ax_sprite sSlowbroGfx1, 0x200
+ax_sprite_terminator
+sSlowbroGfx2:
+.incbin "baserom.gba", 0x8723BC, 0x200
+sSlowbroSprites2:
+ax_sprite sSlowbroGfx2, 0x200
+ax_sprite_terminator
+sSlowbroGfx3:
+.incbin "baserom.gba", 0x8725CC, 0x200
+sSlowbroSprites3:
+ax_sprite sSlowbroGfx3, 0x200
+ax_sprite_terminator
+sSlowbroGfx4:
+.incbin "baserom.gba", 0x8727DC, 0x200
+sSlowbroSprites4:
+ax_sprite sSlowbroGfx4, 0x200
+ax_sprite_terminator
+sSlowbroGfx5:
+.incbin "baserom.gba", 0x8729EC, 0x200
+sSlowbroSprites5:
+ax_sprite sSlowbroGfx5, 0x200
+ax_sprite_terminator
+sSlowbroGfx6:
+.incbin "baserom.gba", 0x872BFC, 0x200
+sSlowbroSprites6:
+ax_sprite sSlowbroGfx6, 0x200
+ax_sprite_terminator
+sSlowbroGfx7:
+.incbin "baserom.gba", 0x872E0C, 0x200
+sSlowbroSprites7:
+ax_sprite sSlowbroGfx7, 0x200
+ax_sprite_terminator
+sSlowbroGfx8:
+.incbin "baserom.gba", 0x87301C, 0x200
+sSlowbroSprites8:
+ax_sprite sSlowbroGfx8, 0x200
+ax_sprite_terminator
+sSlowbroGfx9:
+.incbin "baserom.gba", 0x87322C, 0x200
+sSlowbroSprites9:
+ax_sprite sSlowbroGfx9, 0x200
+ax_sprite_terminator
+sSlowbroGfx10:
+.incbin "baserom.gba", 0x87343C, 0x200
+sSlowbroSprites10:
+ax_sprite sSlowbroGfx10, 0x200
+ax_sprite_terminator
+sSlowbroGfx11:
+.incbin "baserom.gba", 0x87364C, 0x200
+sSlowbroSprites11:
+ax_sprite sSlowbroGfx11, 0x200
+ax_sprite_terminator
+sSlowbroGfx12:
+.incbin "baserom.gba", 0x87385C, 0x200
+sSlowbroSprites12:
+ax_sprite sSlowbroGfx12, 0x200
+ax_sprite_terminator
+sSlowbroGfx13:
+.incbin "baserom.gba", 0x873A6C, 0x200
+sSlowbroSprites13:
+ax_sprite sSlowbroGfx13, 0x200
+ax_sprite_terminator
+sSlowbroGfx14:
+.incbin "baserom.gba", 0x873C7C, 0x200
+sSlowbroSprites14:
+ax_sprite sSlowbroGfx14, 0x200
+ax_sprite_terminator
+sSlowbroGfx15:
+.incbin "baserom.gba", 0x873E8C, 0x200
+sSlowbroSprites15:
+ax_sprite sSlowbroGfx15, 0x200
+ax_sprite_terminator
+sSlowbroGfx16:
+.incbin "baserom.gba", 0x87409C, 0x60
+sSlowbroGfx16_1:
+.incbin "baserom.gba", 0x8740FC, 0x60
+sSlowbroGfx16_2:
+.incbin "baserom.gba", 0x87415C, 0x60
+sSlowbroGfx16_3:
+.incbin "baserom.gba", 0x8741BC, 0x60
+sSlowbroSprites16:
+ax_sprite sSlowbroGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx17:
+.incbin "baserom.gba", 0x874264, 0x20
+sSlowbroGfx17_1:
+.incbin "baserom.gba", 0x874284, 0x60
+sSlowbroGfx17_2:
+.incbin "baserom.gba", 0x8742E4, 0x60
+sSlowbroGfx17_3:
+.incbin "baserom.gba", 0x874344, 0x60
+sSlowbroSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSlowbroGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx18:
+.incbin "baserom.gba", 0x8743F4, 0x140
+sSlowbroGfx18_1:
+.incbin "baserom.gba", 0x874534, 0x40
+sSlowbroSprites18:
+ax_sprite 0, 0x40
+ax_sprite sSlowbroGfx18, 0x140
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx19:
+.incbin "baserom.gba", 0x8745A4, 0x1A0
+sSlowbroSprites19:
+ax_sprite 0, 0x40
+ax_sprite sSlowbroGfx19, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx20:
+.incbin "baserom.gba", 0x874764, 0x180
+sSlowbroSprites20:
+ax_sprite sSlowbroGfx20, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlowbroGfx21:
+.incbin "baserom.gba", 0x8748FC, 0x180
+sSlowbroSprites21:
+ax_sprite sSlowbroGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlowbroGfx22:
+.incbin "baserom.gba", 0x874A94, 0x100
+sSlowbroGfx22_1:
+.incbin "baserom.gba", 0x874B94, 0x60
+sSlowbroSprites22:
+ax_sprite sSlowbroGfx22, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx22_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlowbroGfx23:
+.incbin "baserom.gba", 0x874C1C, 0x180
+sSlowbroSprites23:
+ax_sprite sSlowbroGfx23, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlowbroGfx24:
+.incbin "baserom.gba", 0x874DB4, 0x60
+sSlowbroGfx24_1:
+.incbin "baserom.gba", 0x874E14, 0x60
+sSlowbroGfx24_2:
+.incbin "baserom.gba", 0x874E74, 0x60
+sSlowbroGfx24_3:
+.incbin "baserom.gba", 0x874ED4, 0x40
+sSlowbroSprites24:
+ax_sprite sSlowbroGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlowbroGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx25:
+.incbin "baserom.gba", 0x874F5C, 0x60
+sSlowbroGfx25_1:
+.incbin "baserom.gba", 0x874FBC, 0x60
+sSlowbroGfx25_2:
+.incbin "baserom.gba", 0x87501C, 0x60
+sSlowbroSprites25:
+ax_sprite sSlowbroGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlowbroGfx26:
+.incbin "baserom.gba", 0x8750B4, 0x40
+sSlowbroGfx26_1:
+.incbin "baserom.gba", 0x8750F4, 0x60
+sSlowbroGfx26_2:
+.incbin "baserom.gba", 0x875154, 0x60
+sSlowbroGfx26_3:
+.incbin "baserom.gba", 0x8751B4, 0x60
+sSlowbroSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx27:
+.incbin "baserom.gba", 0x875264, 0x60
+sSlowbroGfx27_1:
+.incbin "baserom.gba", 0x8752C4, 0x60
+sSlowbroGfx27_2:
+.incbin "baserom.gba", 0x875324, 0x60
+sSlowbroSprites27:
+ax_sprite 0, 0x80
+ax_sprite sSlowbroGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx28:
+.incbin "baserom.gba", 0x8753C4, 0x40
+sSlowbroGfx28_1:
+.incbin "baserom.gba", 0x875404, 0x180
+sSlowbroSprites28:
+ax_sprite sSlowbroGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlowbroGfx28_1, 0x180
+ax_sprite_terminator
+sSlowbroGfx29:
+.incbin "baserom.gba", 0x8755A4, 0x40
+sSlowbroGfx29_1:
+.incbin "baserom.gba", 0x8755E4, 0x60
+sSlowbroGfx29_2:
+.incbin "baserom.gba", 0x875644, 0x60
+sSlowbroGfx29_3:
+.incbin "baserom.gba", 0x8756A4, 0x60
+sSlowbroSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowbroGfx30:
+.incbin "baserom.gba", 0x875754, 0x40
+sSlowbroGfx30_1:
+.incbin "baserom.gba", 0x875794, 0x120
+sSlowbroSprites30:
+ax_sprite sSlowbroGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx30_1, 0x120
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlowbroGfx31:
+.incbin "baserom.gba", 0x8758DC, 0x160
+sSlowbroGfx31_1:
+.incbin "baserom.gba", 0x875A3C, 0x20
+sSlowbroSprites31:
+ax_sprite sSlowbroGfx31, 0x160
+ax_sprite 0, 0x40
+ax_sprite sSlowbroGfx31_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlowbroGfx32:
+.incbin "baserom.gba", 0x875A84, 0x40
+sSlowbroGfx32_1:
+.incbin "baserom.gba", 0x875AC4, 0x60
+sSlowbroGfx32_2:
+.incbin "baserom.gba", 0x875B24, 0x60
+sSlowbroSprites32:
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlowbroGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx32_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlowbroGfx33:
+.incbin "baserom.gba", 0x875BC4, 0x180
+sSlowbroSprites33:
+ax_sprite sSlowbroGfx33, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlowbroGfx34:
+.incbin "baserom.gba", 0x875D5C, 0x40
+sSlowbroGfx34_1:
+.incbin "baserom.gba", 0x875D9C, 0x60
+sSlowbroGfx34_2:
+.incbin "baserom.gba", 0x875DFC, 0x60
+sSlowbroGfx34_3:
+.incbin "baserom.gba", 0x875E5C, 0x40
+sSlowbroSprites34:
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx34_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlowbroGfx35:
+.incbin "baserom.gba", 0x875EEC, 0x60
+sSlowbroGfx35_1:
+.incbin "baserom.gba", 0x875F4C, 0x60
+sSlowbroGfx35_2:
+.incbin "baserom.gba", 0x875FAC, 0x80
+sSlowbroGfx35_3:
+.incbin "baserom.gba", 0x87602C, 0x60
+sSlowbroSprites35:
+ax_sprite sSlowbroGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx35_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSlowbroGfx35_3, 0x60
+ax_sprite_terminator
+sSlowbroGfx36:
+.incbin "baserom.gba", 0x8760CC, 0x200
+sSlowbroSprites36:
+ax_sprite sSlowbroGfx36, 0x200
+ax_sprite_terminator
+sSlowbroGfx37:
+.incbin "baserom.gba", 0x8762DC, 0x200
+sSlowbroSprites37:
+ax_sprite sSlowbroGfx37, 0x200
+ax_sprite_terminator
+sSlowbroGfx38:
+.incbin "baserom.gba", 0x8764EC, 0x200
+sSlowbroSprites38:
+ax_sprite sSlowbroGfx38, 0x200
+ax_sprite_terminator
+sSlowbroGfx39:
+.incbin "baserom.gba", 0x8766FC, 0x200
+sSlowbroSprites39:
+ax_sprite sSlowbroGfx39, 0x200
+ax_sprite_terminator
+sSlowbroGfx40:
+.incbin "baserom.gba", 0x87690C, 0x200
+sSlowbroSprites40:
+ax_sprite sSlowbroGfx40, 0x200
+ax_sprite_terminator
+sSlowbroGfx41:
+.incbin "baserom.gba", 0x876B1C, 0x200
+sSlowbroSprites41:
+ax_sprite sSlowbroGfx41, 0x200
+ax_sprite_terminator
+sSlowbroGfx42:
+.incbin "baserom.gba", 0x876D2C, 0x200
+sSlowbroSprites42:
+ax_sprite sSlowbroGfx42, 0x200
+ax_sprite_terminator
+sAxPosesSlowbro:
+.4byte sSlowbroPose1
+.4byte sSlowbroPose2
+.4byte sSlowbroPose3
+.4byte sSlowbroPose4
+.4byte sSlowbroPose5
+.4byte sSlowbroPose6
+.4byte sSlowbroPose7
+.4byte sSlowbroPose8
+.4byte sSlowbroPose9
+.4byte sSlowbroPose10
+.4byte sSlowbroPose11
+.4byte sSlowbroPose12
+.4byte sSlowbroPose13
+.4byte sSlowbroPose14
+.4byte sSlowbroPose15
+.4byte sSlowbroPose16
+.4byte sSlowbroPose17
+.4byte sSlowbroPose18
+.4byte sSlowbroPose19
+.4byte sSlowbroPose20
+.4byte sSlowbroPose21
+.4byte sSlowbroPose22
+.4byte sSlowbroPose23
+.4byte sSlowbroPose24
+.4byte sSlowbroPose25
+.4byte sSlowbroPose26
+.4byte sSlowbroPose27
+.4byte sSlowbroPose28
+.4byte sSlowbroPose29
+.4byte sSlowbroPose30
+.4byte sSlowbroPose31
+.4byte sSlowbroPose32
+.4byte sSlowbroPose33
+.4byte sSlowbroPose34
+.4byte sSlowbroPose35
+.4byte sSlowbroPose36
+.4byte sSlowbroPose37
+.4byte sSlowbroPose38
+.4byte sSlowbroPose39
+.4byte sSlowbroPose40
+.4byte sSlowbroPose41
+.4byte sSlowbroPose42
+.4byte sSlowbroPose43
+.4byte sSlowbroPose44
+.4byte sSlowbroPose45
+.4byte sSlowbroPose46
+.4byte sSlowbroPose47
+.4byte sSlowbroPose48
+.4byte sSlowbroPose49
+.4byte sSlowbroPose50
+.4byte sSlowbroPose51
+.4byte sSlowbroPose52
+.4byte sSlowbroPose53
+.4byte sSlowbroPose54
+.4byte sSlowbroPose55
+.4byte sSlowbroPose56
+.4byte sSlowbroPose57
+.4byte sSlowbroPose58
+.4byte sSlowbroPose59
+.4byte sSlowbroPose60
+.4byte sSlowbroPose61
+.4byte sSlowbroPose62
+.4byte sSlowbroPose63
+.4byte sSlowbroPose64
+.4byte sSlowbroPose65
+.4byte sSlowbroPose66
+.4byte sSlowbroPose67
+.4byte sSlowbroPose68
+.4byte sSlowbroPose69
+.4byte sSlowbroPose70
+.4byte sSlowbroPose71
+.4byte sSlowbroPose72
+.4byte sSlowbroPose73
+.4byte sSlowbroPose74
+.4byte sSlowbroPose75
+.4byte sSlowbroPose76
+.4byte sSlowbroPose77
+.4byte sSlowbroPose78
+.4byte sSlowbroPose79
+.4byte sSlowbroPose80
+.4byte sSlowbroPose81
+.4byte sSlowbroPose82
+.4byte sSlowbroPose83
+.4byte sSlowbroPose84
+.4byte sSlowbroPose85
+.4byte sSlowbroPose86
+.4byte sSlowbroPose87
+.4byte sSlowbroPose88
+.4byte sSlowbroPose89
+.4byte sSlowbroPose90
+.4byte sSlowbroPose91
+.4byte sSlowbroPose92
+.4byte sSlowbroPose93
+.4byte sSlowbroPose94
+.4byte sSlowbroPose95
+.4byte sSlowbroPose96
+.4byte sSlowbroPose97
+.4byte sSlowbroPose98
+.4byte sSlowbroPose99
+.4byte sSlowbroPose100
+.4byte sSlowbroPose101
+.4byte sSlowbroPose102
+.4byte sSlowbroPose103
+.4byte sSlowbroPose104
+.4byte sSlowbroPose105
+.4byte sSlowbroPose106
+.4byte sSlowbroPose107
+.4byte sSlowbroPose108
+.4byte sSlowbroPose109
+.4byte sSlowbroPose110
+.4byte sSlowbroPose111
+.4byte sSlowbroPose112
+.4byte sSlowbroPose113
+.4byte sSlowbroPose114
+.4byte sSlowbroPose115
+.4byte sSlowbroPose116
+.4byte sSlowbroPose117
+.4byte sSlowbroPose118
+.4byte sSlowbroPose119
+.4byte sSlowbroPose120
+.4byte sSlowbroPose121
+.4byte sSlowbroPose122
+.4byte sSlowbroPose123
+.4byte sSlowbroPose124
+.4byte sSlowbroPose125
+.4byte sSlowbroPose126
+.4byte sSlowbroPose127
+.4byte sSlowbroPose128
+.4byte sSlowbroPose129
+.4byte sSlowbroPose130
+.4byte sSlowbroPose131
+.4byte sSlowbroPose132
+.4byte sSlowbroPose133
+.4byte sSlowbroPose134
+.4byte sSlowbroPose135
+.4byte sSlowbroPose136
+.4byte sSlowbroPose137
+.4byte sSlowbroPose138
+.4byte sSlowbroPose139
+.4byte sSlowbroPose140
+.4byte sSlowbroPose141
+.4byte sSlowbroPose142
+.4byte sSlowbroPose143
+.4byte sSlowbroPose144
+.4byte sSlowbroPose145
+.4byte sSlowbroPose146
+.4byte sSlowbroPose147
+.4byte sSlowbroPose148
+.4byte sSlowbroPose149
+.4byte sSlowbroPose150
+.4byte sSlowbroPose151
+.4byte sSlowbroPose152
+.4byte sSlowbroPose153
+.4byte sSlowbroPose154
+.4byte sSlowbroPose155
+.4byte sSlowbroPose156
+.4byte sSlowbroPose157
+.4byte sSlowbroPose158
+.4byte sSlowbroPose159
+.4byte sSlowbroPose160
+.4byte sSlowbroPose161
+.4byte sSlowbroPose162
+.4byte sSlowbroPose163
+.4byte sSlowbroPose164
+.4byte sSlowbroPose165
+.4byte sSlowbroPose166
+.4byte sSlowbroPose167
+.4byte sSlowbroPose168
+.4byte sSlowbroPose169
+.4byte sSlowbroPose170
+.4byte sSlowbroPose171
+.4byte sSlowbroPose172
+.4byte sSlowbroPose173
+.4byte sSlowbroPose174
+.4byte sSlowbroPose175
+.4byte sSlowbroPose176
+.4byte sSlowbroPose177
+.4byte sSlowbroPose178
+.4byte sSlowbroPose179
+.4byte sSlowbroPose180
+.4byte sSlowbroPose181
+.4byte sSlowbroPose182
+.4byte sSlowbroPose183
+.4byte sSlowbroPose184
+.4byte sSlowbroPose185
+.4byte sSlowbroPose186
+.4byte sSlowbroPose187
+.4byte sSlowbroPose188
+.4byte sSlowbroPose189
+.4byte sSlowbroPose190
+.4byte sSlowbroPose191
+.4byte sSlowbroPose192
+.4byte sSlowbroPose193
+.4byte sSlowbroPose194
+.4byte sSlowbroPose195
+.4byte sSlowbroPose196
+.4byte sSlowbroPose197
+.4byte sSlowbroPose198
+.4byte sSlowbroPose199
+.4byte sSlowbroPose200
+.4byte sSlowbroPose201
+.4byte sSlowbroPose202
+.4byte sSlowbroPose203
+.4byte sSlowbroPose204
+.4byte sSlowbroPose205
+.4byte sSlowbroPose206
+.4byte sSlowbroPose207
+.4byte sSlowbroPose208
+.4byte sSlowbroPose209
+.4byte sSlowbroPose210
+.4byte sSlowbroPose211
+.4byte sSlowbroPose212
+.4byte sSlowbroPose213
+.4byte sSlowbroPose214
+.4byte sSlowbroPose215
+.4byte sSlowbroPose216
+.4byte sSlowbroPose217
+.4byte sSlowbroPose218
+.4byte sSlowbroPose219
+.4byte sSlowbroPose220
+.4byte sSlowbroPose221
+.4byte sSlowbroPose222
+.4byte sSlowbroPose223
+.4byte sSlowbroPose224
+.4byte sSlowbroPose225
+.4byte sSlowbroPose226
+.4byte sSlowbroPose227
+.4byte sSlowbroPose228
+.4byte sSlowbroPose229
+.4byte sSlowbroPose230
+.4byte sSlowbroPose231
+.4byte sSlowbroPose232
+.4byte sSlowbroPose233
+.4byte sSlowbroPose234
+.4byte sSlowbroPose235
+.4byte sSlowbroPose236
+.4byte sSlowbroPose237
+.4byte sSlowbroPose238
+.4byte sSlowbroPose239
+.4byte sSlowbroPose240
+.4byte sSlowbroPose241
+.4byte sSlowbroPose242
+.4byte sSlowbroPose243
+.4byte sSlowbroPose244
+.4byte sSlowbroPose245
+.4byte sSlowbroPose246
+.4byte sSlowbroPose247
+.4byte sSlowbroPose248
+.4byte sSlowbroPose249
+.4byte sSlowbroPose250
+.4byte sSlowbroPose251
+.4byte sSlowbroPose252
+.4byte sSlowbroPose253
+.4byte sSlowbroPose254
+.4byte sSlowbroPose255
+.4byte sSlowbroPose256
+.4byte sSlowbroPose257
+.4byte sSlowbroPose258
+.4byte sSlowbroPose259
+.4byte sSlowbroPose260
+.4byte sSlowbroPose261
+.4byte sSlowbroPose262
+.4byte sSlowbroPose263
+.4byte sSlowbroPose264
+.4byte sSlowbroPose265
+.4byte sSlowbroPose266
+.4byte sSlowbroPose267
+.4byte sSlowbroPose268
+.4byte sSlowbroPose269
+.4byte sSlowbroPose270
+.4byte sSlowbroPose271
+.4byte sSlowbroPose272
+.4byte sSlowbroPose273
+.4byte sSlowbroPose274
+.4byte sSlowbroPose275
+.4byte sSlowbroPose276
+.4byte sSlowbroPose277
+.4byte sSlowbroPose278
+.4byte sSlowbroPose279
+.4byte sSlowbroPose280
+.4byte sSlowbroPose281
+.4byte sSlowbroPose282
+.4byte sSlowbroPose283
+.4byte sSlowbroPose284
+.4byte sSlowbroPose285
+.4byte sSlowbroPose286
+.4byte sSlowbroPose287
+.4byte sSlowbroPose288
+.4byte sSlowbroPose289
+.4byte sSlowbroPose290
+.4byte sSlowbroPose291
+.4byte sSlowbroPose292
+.4byte sSlowbroPose293
+.4byte sSlowbroPose294
+.4byte sSlowbroPose295
+.4byte sSlowbroPose296
+.4byte sSlowbroPose297
+.4byte sSlowbroPose298
+sAxPositionsSlowbro:
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte    0,   -4, 	  -7,   -6, 	   2,   -2, 	   0,   -7
+.2byte   -1,   -4, 	  -3,   -2, 	   6,   -6, 	  -1,   -7
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    6,   -4, 	   2,   -7, 	   5,   -3, 	   1,   -6
+.2byte    8,   -5, 	   7,   -3, 	  -1,   -3, 	   1,   -5
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte    8,   -7, 	   1,   -8, 	   7,   -5, 	   1,   -6
+.2byte    9,   -7, 	   7,   -4, 	   2,   -3, 	   1,   -6
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    6,  -12, 	  -2,   -9, 	   6,   -6, 	   1,   -6
+.2byte    6,  -12, 	   2,  -10, 	   5,   -5, 	   1,   -6
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   8,  -10, 	  -7,   -5, 	   1,   -6
+.2byte   -1,  -15, 	   6,   -5, 	  -9,  -10, 	  -2,   -7
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte   -7,  -12, 	   1,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -7,  -12, 	  -3,  -10, 	  -6,   -5, 	  -2,   -6
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte  -10,   -7, 	  -8,   -4, 	  -3,   -3, 	  -2,   -6
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -7,   -4, 	  -3,   -7, 	  -6,   -3, 	  -2,   -6
+.2byte   -9,   -5, 	  -8,   -3, 	   0,   -3, 	  -2,   -5
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte    0,   -4, 	  -7,   -6, 	   2,   -2, 	   0,   -7
+.2byte   -1,   -4, 	  -3,   -2, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   2,   -3, 	  -1,  -12
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    6,   -4, 	   2,   -7, 	   5,   -3, 	   1,   -6
+.2byte    8,   -5, 	   7,   -3, 	  -1,   -3, 	   1,   -5
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    8,   -5, 	   7,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte    8,   -7, 	   1,   -8, 	   7,   -5, 	   1,   -6
+.2byte    9,   -7, 	   7,   -4, 	   2,   -3, 	   1,   -6
+.2byte    9,   -9, 	   6,   -6, 	   5,   -4, 	   2,   -7
+.2byte   10,   -9, 	   2,  -11, 	   2,   -6, 	   1,   -7
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    6,  -12, 	  -2,   -9, 	   6,   -6, 	   1,   -6
+.2byte    6,  -12, 	   2,  -10, 	   5,   -5, 	   1,   -6
+.2byte    8,  -13, 	   2,  -11, 	   7,   -8, 	   1,   -8
+.2byte   10,  -15, 	  -2,  -12, 	   6,   -7, 	   1,   -8
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   8,  -10, 	  -7,   -5, 	   1,   -6
+.2byte   -1,  -15, 	   6,   -5, 	  -9,  -10, 	  -2,   -7
+.2byte   -1,  -16, 	   6,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte   -7,  -12, 	   1,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -7,  -12, 	  -3,  -10, 	  -6,   -5, 	  -2,   -6
+.2byte   -9,  -13, 	  -3,  -11, 	  -8,   -8, 	  -2,   -8
+.2byte  -11,  -15, 	   1,  -12, 	  -7,   -7, 	  -2,   -8
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte  -10,   -7, 	  -8,   -4, 	  -3,   -3, 	  -2,   -6
+.2byte  -10,   -9, 	  -7,   -6, 	  -6,   -4, 	  -3,   -7
+.2byte  -11,   -9, 	  -3,  -11, 	  -3,   -6, 	  -2,   -7
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -7,   -4, 	  -3,   -7, 	  -6,   -3, 	  -2,   -6
+.2byte   -9,   -5, 	  -8,   -3, 	   0,   -3, 	  -2,   -5
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -9,   -5, 	  -8,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte    0,   -4, 	  -7,   -6, 	   2,   -2, 	   0,   -7
+.2byte   -1,   -4, 	  -3,   -2, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   2,   -3, 	  -1,  -12
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    6,   -4, 	   2,   -7, 	   5,   -3, 	   1,   -6
+.2byte    8,   -5, 	   7,   -3, 	  -1,   -3, 	   1,   -5
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    8,   -5, 	   7,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte    8,   -7, 	   1,   -8, 	   7,   -5, 	   1,   -6
+.2byte    9,   -7, 	   7,   -4, 	   2,   -3, 	   1,   -6
+.2byte    9,   -9, 	   6,   -6, 	   5,   -4, 	   2,   -7
+.2byte   10,   -9, 	   2,  -11, 	   2,   -6, 	   1,   -7
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    6,  -12, 	  -2,   -9, 	   6,   -6, 	   1,   -6
+.2byte    6,  -12, 	   2,  -10, 	   5,   -5, 	   1,   -6
+.2byte    8,  -13, 	   2,  -11, 	   7,   -8, 	   1,   -8
+.2byte   10,  -15, 	  -2,  -12, 	   6,   -7, 	   1,   -8
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   8,  -10, 	  -7,   -5, 	   1,   -6
+.2byte   -1,  -15, 	   6,   -5, 	  -9,  -10, 	  -2,   -7
+.2byte   -1,  -16, 	   6,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte   -7,  -12, 	   1,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -7,  -12, 	  -3,  -10, 	  -6,   -5, 	  -2,   -6
+.2byte   -9,  -13, 	  -3,  -11, 	  -8,   -8, 	  -2,   -8
+.2byte  -11,  -15, 	   1,  -12, 	  -7,   -7, 	  -2,   -8
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte  -10,   -7, 	  -8,   -4, 	  -3,   -3, 	  -2,   -6
+.2byte  -10,   -9, 	  -7,   -6, 	  -6,   -4, 	  -3,   -7
+.2byte  -11,   -9, 	  -3,  -11, 	  -3,   -6, 	  -2,   -7
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -7,   -4, 	  -3,   -7, 	  -6,   -3, 	  -2,   -6
+.2byte   -9,   -5, 	  -8,   -3, 	   0,   -3, 	  -2,   -5
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -9,   -5, 	  -8,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte    0,   -4, 	  -7,   -6, 	   2,   -2, 	   0,   -7
+.2byte   -1,   -4, 	  -3,   -2, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   2,   -3, 	  -1,  -12
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    6,   -4, 	   2,   -7, 	   5,   -3, 	   1,   -6
+.2byte    8,   -5, 	   7,   -3, 	  -1,   -3, 	   1,   -5
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    9,   -5, 	   8,   -8, 	  -2,   -3, 	   1,   -6
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte    8,   -7, 	   1,   -8, 	   7,   -5, 	   1,   -6
+.2byte    9,   -7, 	   7,   -4, 	   2,   -3, 	   1,   -6
+.2byte    9,   -9, 	   6,   -6, 	   5,   -4, 	   2,   -7
+.2byte   12,   -9, 	   4,  -11, 	   4,   -6, 	   3,   -7
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    6,  -12, 	  -2,   -9, 	   6,   -6, 	   1,   -6
+.2byte    6,  -12, 	   2,  -10, 	   5,   -5, 	   1,   -6
+.2byte    8,  -13, 	   2,  -11, 	   7,   -8, 	   1,   -8
+.2byte   10,  -15, 	  -2,  -12, 	   6,   -7, 	   1,   -8
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   8,  -10, 	  -7,   -5, 	   1,   -6
+.2byte   -1,  -15, 	   6,   -5, 	  -9,  -10, 	  -2,   -7
+.2byte   -1,  -16, 	   6,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte   -7,  -12, 	   1,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -7,  -12, 	  -3,  -10, 	  -6,   -5, 	  -2,   -6
+.2byte   -9,  -13, 	  -3,  -11, 	  -8,   -8, 	  -2,   -8
+.2byte  -11,  -15, 	   1,  -12, 	  -7,   -7, 	  -2,   -8
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte  -10,   -7, 	  -8,   -4, 	  -3,   -3, 	  -2,   -6
+.2byte  -10,   -9, 	  -7,   -6, 	  -6,   -4, 	  -3,   -7
+.2byte  -13,   -9, 	  -5,  -11, 	  -5,   -6, 	  -4,   -7
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -7,   -4, 	  -3,   -7, 	  -6,   -3, 	  -2,   -6
+.2byte   -9,   -5, 	  -8,   -3, 	   0,   -3, 	  -2,   -5
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte  -10,   -5, 	  -9,   -8, 	   1,   -3, 	  -2,   -6
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte    0,   -4, 	  -7,   -6, 	   2,   -2, 	   0,   -7
+.2byte   -1,   -4, 	  -3,   -2, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   2,   -3, 	  -1,  -12
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte   -5,  -13, 	  -8,  -11, 	   0,   -8, 	   1,  -12
+.2byte    5,  -16, 	  -2,   -9, 	   8,  -13, 	   1,  -10
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    6,   -4, 	   2,   -7, 	   5,   -3, 	   1,   -6
+.2byte    8,   -5, 	   7,   -3, 	  -1,   -3, 	   1,   -5
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    7,   -5, 	   6,   -8, 	  -4,   -3, 	  -1,   -6
+.2byte    7,  -13, 	   9,  -13, 	   3,   -9, 	  -1,  -11
+.2byte    2,  -15, 	   3,  -10, 	  -5,  -13, 	   0,   -9
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte    8,   -7, 	   1,   -8, 	   7,   -5, 	   1,   -6
+.2byte    9,   -7, 	   7,   -4, 	   2,   -3, 	   1,   -6
+.2byte    9,   -9, 	   6,   -6, 	   5,   -4, 	   2,   -7
+.2byte   10,   -9, 	   2,  -11, 	   2,   -6, 	   1,   -7
+.2byte    7,  -14, 	   3,  -13, 	   7,   -8, 	   1,   -8
+.2byte    5,  -13, 	   6,   -9, 	   0,  -12, 	   2,   -7
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    6,  -12, 	  -2,   -9, 	   6,   -6, 	   1,   -6
+.2byte    6,  -12, 	   2,  -10, 	   5,   -5, 	   1,   -6
+.2byte    8,  -13, 	   2,  -11, 	   7,   -8, 	   1,   -8
+.2byte    8,  -15, 	  -4,  -12, 	   4,   -7, 	  -1,   -8
+.2byte   -2,  -14, 	  -4,  -15, 	   5,  -11, 	  -1,   -7
+.2byte    4,  -13, 	   4,  -10, 	   0,  -12, 	  -1,   -7
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   8,  -10, 	  -7,   -5, 	   1,   -6
+.2byte   -1,  -15, 	   6,   -5, 	  -9,  -10, 	  -2,   -7
+.2byte   -1,  -16, 	   6,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte    6,  -18, 	   6,  -17, 	   2,  -19, 	  -1,  -11
+.2byte   -3,  -19, 	   3,  -18, 	  -5,  -16, 	   1,  -10
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte   -7,  -12, 	   1,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -7,  -12, 	  -3,  -10, 	  -6,   -5, 	  -2,   -6
+.2byte   -9,  -13, 	  -3,  -11, 	  -8,   -8, 	  -2,   -8
+.2byte   -9,  -15, 	   3,  -12, 	  -5,   -7, 	   0,   -8
+.2byte    1,  -14, 	   3,  -15, 	  -6,  -11, 	   0,   -7
+.2byte   -5,  -13, 	  -5,  -10, 	  -1,  -12, 	   0,   -7
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte  -10,   -7, 	  -8,   -4, 	  -3,   -3, 	  -2,   -6
+.2byte  -10,   -9, 	  -7,   -6, 	  -6,   -4, 	  -3,   -7
+.2byte  -11,   -9, 	  -3,  -11, 	  -3,   -6, 	  -2,   -7
+.2byte   -8,  -14, 	  -4,  -13, 	  -8,   -8, 	  -2,   -8
+.2byte   -6,  -13, 	  -7,   -9, 	  -1,  -12, 	  -3,   -7
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -7,   -4, 	  -3,   -7, 	  -6,   -3, 	  -2,   -6
+.2byte   -9,   -5, 	  -8,   -3, 	   0,   -3, 	  -2,   -5
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -8,   -5, 	  -7,   -8, 	   3,   -3, 	   0,   -6
+.2byte   -8,  -13, 	 -10,  -13, 	  -4,   -9, 	   0,  -11
+.2byte   -3,  -15, 	  -4,  -10, 	   4,  -13, 	  -1,   -9
+.2byte   -9,    1, 	 -12,    0, 	  -2,    2, 	   2,   -6
+.2byte   -9,    1, 	 -12,    0, 	  -2,    2, 	   2,   -7
+.2byte    1,    1, 	  -8,    0, 	   9,    0, 	   0,   -7
+.2byte    9,    1, 	   6,   -5, 	  -3,    0, 	   1,   -5
+.2byte   10,   -1, 	   1,   -5, 	   1,    0, 	  -1,   -6
+.2byte    5,   -9, 	  -6,   -6, 	   5,   -1, 	  -3,   -5
+.2byte   -1,  -10, 	   8,   -1, 	  -9,   -1, 	  -1,   -1
+.2byte   -7,   -9, 	   4,   -6, 	  -7,   -1, 	   1,   -5
+.2byte  -11,   -1, 	  -2,   -5, 	  -2,    0, 	   0,   -6
+.2byte  -10,    1, 	  -7,   -5, 	   2,    0, 	  -2,   -5
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte    0,   -4, 	  -7,   -6, 	   2,   -2, 	   0,   -7
+.2byte   -1,   -4, 	  -3,   -2, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   2,   -3, 	  -1,  -12
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    6,   -4, 	   2,   -7, 	   5,   -3, 	   1,   -6
+.2byte    8,   -5, 	   7,   -3, 	  -1,   -3, 	   1,   -5
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    8,   -5, 	   7,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte    8,   -7, 	   1,   -8, 	   7,   -5, 	   1,   -6
+.2byte    9,   -7, 	   7,   -4, 	   2,   -3, 	   1,   -6
+.2byte    9,   -9, 	   6,   -6, 	   5,   -4, 	   2,   -7
+.2byte   10,   -9, 	   2,  -11, 	   2,   -6, 	   1,   -7
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    6,  -12, 	  -2,   -9, 	   6,   -6, 	   1,   -6
+.2byte    6,  -12, 	   2,  -10, 	   5,   -5, 	   1,   -6
+.2byte    8,  -13, 	   2,  -11, 	   7,   -8, 	   1,   -8
+.2byte   10,  -15, 	  -2,  -12, 	   6,   -7, 	   1,   -8
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   8,  -10, 	  -7,   -5, 	   1,   -6
+.2byte   -1,  -15, 	   6,   -5, 	  -9,  -10, 	  -2,   -7
+.2byte   -1,  -16, 	   6,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte   -7,  -12, 	   1,   -9, 	  -7,   -6, 	  -2,   -6
+.2byte   -7,  -12, 	  -3,  -10, 	  -6,   -5, 	  -2,   -6
+.2byte   -9,  -13, 	  -3,  -11, 	  -8,   -8, 	  -2,   -8
+.2byte  -11,  -15, 	   1,  -12, 	  -7,   -7, 	  -2,   -8
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte   -9,   -7, 	  -2,   -8, 	  -8,   -5, 	  -2,   -6
+.2byte  -10,   -7, 	  -8,   -4, 	  -3,   -3, 	  -2,   -6
+.2byte  -10,   -9, 	  -7,   -6, 	  -6,   -4, 	  -3,   -7
+.2byte  -11,   -9, 	  -3,  -11, 	  -3,   -6, 	  -2,   -7
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -7,   -4, 	  -3,   -7, 	  -6,   -3, 	  -2,   -6
+.2byte   -9,   -5, 	  -8,   -3, 	   0,   -3, 	  -2,   -5
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -9,   -5, 	  -8,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte  -10,   -5, 	  -9,   -8, 	   1,   -3, 	  -2,   -6
+.2byte  -13,   -9, 	  -5,  -11, 	  -5,   -6, 	  -4,   -7
+.2byte  -11,  -15, 	   1,  -12, 	  -7,   -7, 	  -2,   -8
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte   10,  -15, 	  -2,  -12, 	   6,   -7, 	   1,   -8
+.2byte   12,   -9, 	   4,  -11, 	   4,   -6, 	   3,   -7
+.2byte    9,   -5, 	   8,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte    9,   -5, 	   8,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   12,   -9, 	   4,  -11, 	   4,   -6, 	   3,   -7
+.2byte   10,  -15, 	  -2,  -12, 	   6,   -7, 	   1,   -8
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte  -11,  -15, 	   1,  -12, 	  -7,   -7, 	  -2,   -8
+.2byte  -13,   -9, 	  -5,  -11, 	  -5,   -6, 	  -4,   -7
+.2byte  -10,   -5, 	  -9,   -8, 	   1,   -3, 	  -2,   -6
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+.2byte    8,   -5, 	   7,   -8, 	  -3,   -3, 	   0,   -6
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte   11,   -9, 	   3,  -11, 	   3,   -6, 	   2,   -7
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    9,  -15, 	  -3,  -12, 	   5,   -7, 	   0,   -8
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte  -10,  -15, 	   2,  -12, 	  -6,   -7, 	  -1,   -8
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte  -12,   -9, 	  -4,  -11, 	  -4,   -6, 	  -3,   -7
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte   -9,   -5, 	  -8,   -8, 	   2,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	 -10,   -6, 	   9,   -6, 	  -1,  -10
+.2byte  -10,   -5, 	  -9,   -8, 	   1,   -3, 	  -2,   -6
+.2byte  -13,   -9, 	  -5,  -11, 	  -5,   -6, 	  -4,   -7
+.2byte  -11,  -15, 	   1,  -12, 	  -7,   -7, 	  -2,   -8
+.2byte   -1,  -19, 	   8,  -14, 	  -9,  -14, 	   0,   -8
+.2byte   10,  -15, 	  -2,  -12, 	   6,   -7, 	   1,   -8
+.2byte   12,   -9, 	   4,  -11, 	   4,   -6, 	   3,   -7
+.2byte    9,   -5, 	   8,   -8, 	  -2,   -3, 	   1,   -6
+.2byte   -1,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -9
+.2byte   -8,   -7, 	 -10,   -5, 	  -4,   -4, 	  -1,   -7
+.2byte  -10,   -9, 	  -7,   -7, 	  -6,   -4, 	  -2,   -7
+.2byte   -6,  -14, 	   1,   -9, 	  -8,   -7, 	  -2,   -8
+.2byte   -1,  -16, 	   6,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    5,  -14, 	  -2,   -9, 	   7,   -7, 	   1,   -8
+.2byte    9,   -9, 	   6,   -7, 	   5,   -4, 	   1,   -7
+.2byte    7,   -7, 	   9,   -5, 	   3,   -4, 	   0,   -7
+sSlowbroAnimTable1:
+.4byte sSlowbroAnims_1_1
+.4byte sSlowbroAnims_1_2
+.4byte sSlowbroAnims_1_3
+.4byte sSlowbroAnims_1_4
+.4byte sSlowbroAnims_1_5
+.4byte sSlowbroAnims_1_6
+.4byte sSlowbroAnims_1_7
+.4byte sSlowbroAnims_1_8
+sSlowbroAnimTable2:
+.4byte sSlowbroAnims_2_1
+.4byte sSlowbroAnims_2_2
+.4byte sSlowbroAnims_2_3
+.4byte sSlowbroAnims_2_4
+.4byte sSlowbroAnims_2_5
+.4byte sSlowbroAnims_2_6
+.4byte sSlowbroAnims_2_7
+.4byte sSlowbroAnims_2_8
+sSlowbroAnimTable3:
+.4byte sSlowbroAnims_3_1
+.4byte sSlowbroAnims_3_2
+.4byte sSlowbroAnims_3_3
+.4byte sSlowbroAnims_3_4
+.4byte sSlowbroAnims_3_5
+.4byte sSlowbroAnims_3_6
+.4byte sSlowbroAnims_3_7
+.4byte sSlowbroAnims_3_8
+sSlowbroAnimTable4:
+.4byte sSlowbroAnims_4_1
+.4byte sSlowbroAnims_4_2
+.4byte sSlowbroAnims_4_3
+.4byte sSlowbroAnims_4_4
+.4byte sSlowbroAnims_4_5
+.4byte sSlowbroAnims_4_6
+.4byte sSlowbroAnims_4_7
+.4byte sSlowbroAnims_4_8
+sSlowbroAnimTable5:
+.4byte sSlowbroAnims_5_1
+.4byte sSlowbroAnims_5_2
+.4byte sSlowbroAnims_5_3
+.4byte sSlowbroAnims_5_4
+.4byte sSlowbroAnims_5_5
+.4byte sSlowbroAnims_5_6
+.4byte sSlowbroAnims_5_7
+.4byte sSlowbroAnims_5_8
+sSlowbroAnimTable6:
+.4byte sSlowbroAnims_6_1
+.4byte sSlowbroAnims_6_1
+.4byte sSlowbroAnims_6_1
+.4byte sSlowbroAnims_6_1
+.4byte sSlowbroAnims_6_1
+.4byte sSlowbroAnims_6_1
+.4byte sSlowbroAnims_6_1
+.4byte sSlowbroAnims_6_1
+sSlowbroAnimTable7:
+.4byte sSlowbroAnims_7_1
+.4byte sSlowbroAnims_7_2
+.4byte sSlowbroAnims_7_3
+.4byte sSlowbroAnims_7_4
+.4byte sSlowbroAnims_7_5
+.4byte sSlowbroAnims_7_6
+.4byte sSlowbroAnims_7_7
+.4byte sSlowbroAnims_7_8
+sSlowbroAnimTable8:
+.4byte sSlowbroAnims_8_1
+.4byte sSlowbroAnims_8_2
+.4byte sSlowbroAnims_8_3
+.4byte sSlowbroAnims_8_4
+.4byte sSlowbroAnims_8_5
+.4byte sSlowbroAnims_8_6
+.4byte sSlowbroAnims_8_7
+.4byte sSlowbroAnims_8_8
+sSlowbroAnimTable9:
+.4byte sSlowbroAnims_9_1
+.4byte sSlowbroAnims_9_2
+.4byte sSlowbroAnims_9_3
+.4byte sSlowbroAnims_9_4
+.4byte sSlowbroAnims_9_5
+.4byte sSlowbroAnims_9_6
+.4byte sSlowbroAnims_9_7
+.4byte sSlowbroAnims_9_8
+sSlowbroAnimTable10:
+.4byte sSlowbroAnims_10_1
+.4byte sSlowbroAnims_10_2
+.4byte sSlowbroAnims_10_3
+.4byte sSlowbroAnims_10_4
+.4byte sSlowbroAnims_10_5
+.4byte sSlowbroAnims_10_6
+.4byte sSlowbroAnims_10_7
+.4byte sSlowbroAnims_10_8
+sSlowbroAnimTable11:
+.4byte sSlowbroAnims_11_1
+.4byte sSlowbroAnims_11_2
+.4byte sSlowbroAnims_11_3
+.4byte sSlowbroAnims_11_4
+.4byte sSlowbroAnims_11_5
+.4byte sSlowbroAnims_11_6
+.4byte sSlowbroAnims_11_7
+.4byte sSlowbroAnims_11_8
+sSlowbroAnimTable12:
+.4byte sSlowbroAnims_12_1
+.4byte sSlowbroAnims_12_2
+.4byte sSlowbroAnims_12_3
+.4byte sSlowbroAnims_12_4
+.4byte sSlowbroAnims_12_5
+.4byte sSlowbroAnims_12_6
+.4byte sSlowbroAnims_12_7
+.4byte sSlowbroAnims_12_8
+sSlowbroAnimTable13:
+.4byte sSlowbroAnims_13_1
+.4byte sSlowbroAnims_13_2
+.4byte sSlowbroAnims_13_3
+.4byte sSlowbroAnims_13_4
+.4byte sSlowbroAnims_13_5
+.4byte sSlowbroAnims_13_6
+.4byte sSlowbroAnims_13_7
+.4byte sSlowbroAnims_13_8
+sAxAnimationsSlowbro:
+.4byte sSlowbroAnimTable1
+.4byte sSlowbroAnimTable2
+.4byte sSlowbroAnimTable3
+.4byte sSlowbroAnimTable4
+.4byte sSlowbroAnimTable5
+.4byte sSlowbroAnimTable6
+.4byte sSlowbroAnimTable7
+.4byte sSlowbroAnimTable8
+.4byte sSlowbroAnimTable9
+.4byte sSlowbroAnimTable10
+.4byte sSlowbroAnimTable11
+.4byte sSlowbroAnimTable12
+.4byte sSlowbroAnimTable13
+sAxSpritesSlowbro:
+.4byte sSlowbroSprites1
+.4byte sSlowbroSprites2
+.4byte sSlowbroSprites3
+.4byte sSlowbroSprites4
+.4byte sSlowbroSprites5
+.4byte sSlowbroSprites6
+.4byte sSlowbroSprites7
+.4byte sSlowbroSprites8
+.4byte sSlowbroSprites9
+.4byte sSlowbroSprites10
+.4byte sSlowbroSprites11
+.4byte sSlowbroSprites12
+.4byte sSlowbroSprites13
+.4byte sSlowbroSprites14
+.4byte sSlowbroSprites15
+.4byte sSlowbroSprites16
+.4byte sSlowbroSprites17
+.4byte sSlowbroSprites18
+.4byte sSlowbroSprites19
+.4byte sSlowbroSprites20
+.4byte sSlowbroSprites21
+.4byte sSlowbroSprites22
+.4byte sSlowbroSprites23
+.4byte sSlowbroSprites24
+.4byte sSlowbroSprites25
+.4byte sSlowbroSprites26
+.4byte sSlowbroSprites27
+.4byte sSlowbroSprites28
+.4byte sSlowbroSprites29
+.4byte sSlowbroSprites30
+.4byte sSlowbroSprites31
+.4byte sSlowbroSprites32
+.4byte sSlowbroSprites33
+.4byte sSlowbroSprites34
+.4byte sSlowbroSprites35
+.4byte sSlowbroSprites36
+.4byte sSlowbroSprites37
+.4byte sSlowbroSprites38
+.4byte sSlowbroSprites39
+.4byte sSlowbroSprites40
+.4byte sSlowbroSprites41
+.4byte sSlowbroSprites42
+sAxMainSlowbro:
+ax_main sAxPosesSlowbro, sAxAnimationsSlowbro, 13, sAxSpritesSlowbro, sAxPositionsSlowbro

--- a/data/ax/slowking.inc
+++ b/data/ax/slowking.inc
@@ -1,0 +1,2846 @@
+.global gAxSlowking
+gAxSlowking:
+ax_siro sAxMainSlowking
+sSlowkingPose1:
+ax_pose 0, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose2:
+ax_pose 1, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose3:
+ax_pose 2, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose4:
+ax_pose 3, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose5:
+ax_pose 4, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose6:
+ax_pose 5, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose7:
+ax_pose 6, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose8:
+ax_pose 7, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose9:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose10:
+ax_pose 9, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose11:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose12:
+ax_pose 11, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose13:
+ax_pose 12, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose14:
+ax_pose 13, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose15:
+ax_pose 14, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose16:
+ax_pose 9, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose17:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose18:
+ax_pose 11, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose19:
+ax_pose 6, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose20:
+ax_pose 7, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose21:
+ax_pose 8, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose22:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose23:
+ax_pose 4, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose24:
+ax_pose 5, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose25:
+ax_pose 0, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose26:
+ax_pose 1, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose27:
+ax_pose 2, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose28:
+ax_pose 15, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose29:
+ax_pose 16, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose30:
+ax_pose 3, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose31:
+ax_pose 4, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose32:
+ax_pose 5, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose33:
+ax_pose 17, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose34:
+ax_pose 18, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose35:
+ax_pose 6, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose36:
+ax_pose 7, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose37:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose38:
+ax_pose 19, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose39:
+ax_pose 20, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose40:
+ax_pose 9, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose41:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose42:
+ax_pose 11, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose43:
+ax_pose 21, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose44:
+ax_pose 22, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose45:
+ax_pose 12, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose46:
+ax_pose 13, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose47:
+ax_pose 14, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose48:
+ax_pose 23, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose49:
+ax_pose 24, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose50:
+ax_pose 9, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose51:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose52:
+ax_pose 11, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose53:
+ax_pose 21, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose54:
+ax_pose 22, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose55:
+ax_pose 6, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose56:
+ax_pose 7, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose57:
+ax_pose 8, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose58:
+ax_pose 19, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose59:
+ax_pose 20, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose60:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose61:
+ax_pose 4, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose62:
+ax_pose 5, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose63:
+ax_pose 17, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose64:
+ax_pose 18, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose65:
+ax_pose 0, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose66:
+ax_pose 1, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose67:
+ax_pose 2, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose68:
+ax_pose 15, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose69:
+ax_pose 16, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose70:
+ax_pose 3, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose71:
+ax_pose 4, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose72:
+ax_pose 5, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose73:
+ax_pose 17, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose74:
+ax_pose 18, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose75:
+ax_pose 6, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose76:
+ax_pose 7, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose77:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose78:
+ax_pose 19, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose79:
+ax_pose 20, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose80:
+ax_pose 9, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose81:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose82:
+ax_pose 11, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose83:
+ax_pose 21, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose84:
+ax_pose 22, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose85:
+ax_pose 12, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose86:
+ax_pose 13, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose87:
+ax_pose 14, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose88:
+ax_pose 23, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose89:
+ax_pose 24, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose90:
+ax_pose 9, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose91:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose92:
+ax_pose 11, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose93:
+ax_pose 21, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose94:
+ax_pose 22, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose95:
+ax_pose 6, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose96:
+ax_pose 7, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose97:
+ax_pose 8, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose98:
+ax_pose 19, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose99:
+ax_pose 20, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose100:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose101:
+ax_pose 4, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose102:
+ax_pose 5, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose103:
+ax_pose 17, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose104:
+ax_pose 18, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose105:
+ax_pose 0, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose106:
+ax_pose 15, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose107:
+ax_pose 16, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose108:
+ax_pose 3, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose109:
+ax_pose 17, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose110:
+ax_pose 18, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose111:
+ax_pose 6, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose112:
+ax_pose 19, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose113:
+ax_pose 20, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose114:
+ax_pose 9, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose115:
+ax_pose 21, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose116:
+ax_pose 22, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose117:
+ax_pose 12, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose118:
+ax_pose 23, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose119:
+ax_pose 24, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose120:
+ax_pose 9, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose121:
+ax_pose 21, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose122:
+ax_pose 22, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose123:
+ax_pose 6, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose124:
+ax_pose 19, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose125:
+ax_pose 20, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose126:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose127:
+ax_pose 17, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose128:
+ax_pose 18, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose129:
+ax_pose 16, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose130:
+ax_pose 25, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose131:
+ax_pose 18, 0x01e5, 0x90eb, 0x6c00
+ax_pose_terminator
+sSlowkingPose132:
+ax_pose 26, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose133:
+ax_pose 20, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose134:
+ax_pose 27, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sSlowkingPose135:
+ax_pose 22, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose136:
+ax_pose 28, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose137:
+ax_pose 24, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose138:
+ax_pose 29, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose139:
+ax_pose 22, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose140:
+ax_pose 28, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose141:
+ax_pose 20, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose142:
+ax_pose 27, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose143:
+ax_pose 18, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose144:
+ax_pose 26, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose145:
+ax_pose 30, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose146:
+ax_pose 31, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose147:
+ax_pose 32, 0x01e1, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose148:
+ax_pose 33, 0x01e3, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose149:
+ax_pose 34, 0x01e2, 0x90e9, 0x6c00
+ax_pose_terminator
+sSlowkingPose150:
+ax_pose 35, 0x01e5, 0x90ea, 0x6c00
+ax_pose_terminator
+sSlowkingPose151:
+ax_pose 36, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose152:
+ax_pose 35, 0x01e5, 0x80f6, 0x6c00
+ax_pose_terminator
+sSlowkingPose153:
+ax_pose 34, 0x01e2, 0x80f7, 0x6c00
+ax_pose_terminator
+sSlowkingPose154:
+ax_pose 33, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose155:
+ax_pose 0, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose156:
+ax_pose 1, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose157:
+ax_pose 2, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose158:
+ax_pose 3, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose159:
+ax_pose 4, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose160:
+ax_pose 5, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose161:
+ax_pose 6, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose162:
+ax_pose 7, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose163:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose164:
+ax_pose 9, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose165:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose166:
+ax_pose 11, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose167:
+ax_pose 12, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose168:
+ax_pose 13, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose169:
+ax_pose 14, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose170:
+ax_pose 9, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose171:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose172:
+ax_pose 11, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose173:
+ax_pose 6, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose174:
+ax_pose 7, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose175:
+ax_pose 8, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose176:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose177:
+ax_pose 4, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose178:
+ax_pose 5, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose179:
+ax_pose 25, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose180:
+ax_pose 26, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose181:
+ax_pose 27, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose182:
+ax_pose 28, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose183:
+ax_pose 29, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose184:
+ax_pose 28, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose185:
+ax_pose 27, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose186:
+ax_pose 26, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sSlowkingPose187:
+ax_pose 16, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose188:
+ax_pose 18, 0x01e5, 0x90eb, 0x6c00
+ax_pose_terminator
+sSlowkingPose189:
+ax_pose 20, 0x01e5, 0x90eb, 0x6c00
+ax_pose_terminator
+sSlowkingPose190:
+ax_pose 22, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose191:
+ax_pose 24, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose192:
+ax_pose 22, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose193:
+ax_pose 20, 0x01e5, 0x80f5, 0x6c00
+ax_pose_terminator
+sSlowkingPose194:
+ax_pose 18, 0x01e5, 0x80f5, 0x6c00
+ax_pose_terminator
+sSlowkingPose195:
+ax_pose 0, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose196:
+ax_pose 1, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose197:
+ax_pose 2, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose198:
+ax_pose 3, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose199:
+ax_pose 4, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose200:
+ax_pose 5, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose201:
+ax_pose 6, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose202:
+ax_pose 7, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose203:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose204:
+ax_pose 9, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose205:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose206:
+ax_pose 11, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose207:
+ax_pose 12, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose208:
+ax_pose 13, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose209:
+ax_pose 14, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose210:
+ax_pose 9, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose211:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose212:
+ax_pose 11, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose213:
+ax_pose 6, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose214:
+ax_pose 7, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose215:
+ax_pose 8, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose216:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose217:
+ax_pose 4, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose218:
+ax_pose 5, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose219:
+ax_pose 25, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose220:
+ax_pose 26, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose221:
+ax_pose 27, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose222:
+ax_pose 28, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose223:
+ax_pose 29, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSlowkingPose224:
+ax_pose 28, 0x01e6, 0x90ed, 0x6c00
+ax_pose_terminator
+sSlowkingPose225:
+ax_pose 27, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose226:
+ax_pose 26, 0x01e5, 0x90ed, 0x6c00
+ax_pose_terminator
+sSlowkingPose227:
+ax_pose 0, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose228:
+ax_pose 3, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose229:
+ax_pose 6, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose230:
+ax_pose 9, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSlowkingPose231:
+ax_pose 12, 0x01e5, 0x80f2, 0x6c00
+ax_pose_terminator
+sSlowkingPose232:
+ax_pose 9, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose233:
+ax_pose 6, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSlowkingPose234:
+ax_pose 3, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+.align 2
+sSlowkingAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 1, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 0, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSlowkingAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 6, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 19, 20, 19, 20,
+ax_anim 2, 1, 33, 20, 19, 20, 19,
+ax_anim 2, 0, 33, 19, 20, 19, 20,
+ax_anim 2, 0, 33, 20, 19, 20, 19,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sSlowkingAnims_2_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 6, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 19, 0, 19, 0,
+ax_anim 2, 1, 38, 19, 1, 19, 1,
+ax_anim 2, 0, 38, 19, 0, 19, 0,
+ax_anim 2, 0, 38, 19, 1, 19, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sSlowkingAnims_2_4:
+ax_anim 2, 0, 42, -1, 1, -1, 1,
+ax_anim 6, 0, 42, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 6, -6, 6, -6,
+ax_anim 1, 0, 39, 13, -13, 13, -13,
+ax_anim 2, 0, 43, 19, -19, 19, -19,
+ax_anim 2, 1, 43, 20, -18, 20, -18,
+ax_anim 2, 0, 43, 19, -19, 19, -19,
+ax_anim 2, 0, 43, 20, -18, 20, -18,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sSlowkingAnims_2_5:
+ax_anim 2, 0, 47, 0, 1, 0, 1,
+ax_anim 6, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 44, 0, -4, 0, -4,
+ax_anim 1, 0, 44, 0, -9, 0, -9,
+ax_anim 2, 0, 48, 0, -15, 0, -15,
+ax_anim 2, 1, 48, 1, -15, 1, -15,
+ax_anim 2, 0, 48, 0, -15, 0, -15,
+ax_anim 2, 0, 48, 1, -15, 1, -15,
+ax_anim 2, 0, 44, 0, -7, 0, -7,
+ax_anim_terminator
+sSlowkingAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 6, 0, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -6, -6, -6, -6,
+ax_anim 1, 0, 49, -13, -13, -13, -13,
+ax_anim 2, 0, 53, -19, -19, -19, -19,
+ax_anim 2, 1, 53, -20, -18, -20, -18,
+ax_anim 2, 0, 53, -19, -19, -19, -19,
+ax_anim 2, 0, 53, -20, -18, -20, -18,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sSlowkingAnims_2_7:
+ax_anim 2, 0, 57, 1, 0, 1, 0,
+ax_anim 6, 0, 57, 2, 0, 2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 0, -4, 0,
+ax_anim 1, 0, 54, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -19, 0, -19, 0,
+ax_anim 2, 1, 58, -19, 1, -19, 1,
+ax_anim 2, 0, 58, -19, 0, -19, 0,
+ax_anim 2, 0, 58, -19, 1, -19, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sSlowkingAnims_2_8:
+ax_anim 2, 0, 62, 1, -1, 1, -1,
+ax_anim 6, 0, 62, 2, -2, 2, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, -4, 4, -4, 4,
+ax_anim 1, 0, 59, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -19, 20, -19, 20,
+ax_anim 2, 1, 63, -20, 19, -20, 19,
+ax_anim 2, 0, 63, -19, 20, -19, 20,
+ax_anim 2, 0, 63, -20, 19, -20, 19,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_3_1:
+ax_anim 2, 0, 67, 0, -1, 0, -1,
+ax_anim 6, 0, 67, 0, -2, 0, -2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 64, 0, 4, 0, 4,
+ax_anim 1, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 1, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 0, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sSlowkingAnims_3_2:
+ax_anim 2, 0, 72, -1, -1, -1, -1,
+ax_anim 6, 0, 72, -2, -2, -2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, 4, 4, 4, 4,
+ax_anim 1, 0, 69, 10, 10, 10, 10,
+ax_anim 2, 0, 73, 19, 20, 19, 20,
+ax_anim 2, 1, 73, 20, 19, 20, 19,
+ax_anim 2, 0, 73, 19, 20, 19, 20,
+ax_anim 2, 0, 73, 20, 19, 20, 19,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sSlowkingAnims_3_3:
+ax_anim 2, 0, 77, -1, 0, -1, 0,
+ax_anim 6, 0, 77, -2, 0, -2, 0,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 4, 0, 4, 0,
+ax_anim 1, 0, 74, 10, 0, 10, 0,
+ax_anim 2, 0, 78, 19, 0, 19, 0,
+ax_anim 2, 1, 78, 19, 1, 19, 1,
+ax_anim 2, 0, 78, 19, 0, 19, 0,
+ax_anim 2, 0, 78, 19, 1, 19, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sSlowkingAnims_3_4:
+ax_anim 2, 0, 82, -1, 1, -1, 1,
+ax_anim 6, 0, 82, -2, 2, -2, 2,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 2, 79, 6, -6, 6, -6,
+ax_anim 1, 0, 79, 13, -13, 13, -13,
+ax_anim 2, 0, 83, 19, -19, 19, -19,
+ax_anim 2, 1, 83, 20, -18, 20, -18,
+ax_anim 2, 0, 83, 19, -19, 19, -19,
+ax_anim 2, 0, 83, 20, -18, 20, -18,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sSlowkingAnims_3_5:
+ax_anim 2, 0, 87, 0, 1, 0, 1,
+ax_anim 6, 0, 87, 0, 2, 0, 2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 84, 0, -4, 0, -4,
+ax_anim 1, 0, 84, 0, -9, 0, -9,
+ax_anim 2, 0, 88, 0, -15, 0, -15,
+ax_anim 2, 1, 88, 1, -15, 1, -15,
+ax_anim 2, 0, 88, 0, -15, 0, -15,
+ax_anim 2, 0, 88, 1, -15, 1, -15,
+ax_anim 2, 0, 84, 0, -7, 0, -7,
+ax_anim_terminator
+sSlowkingAnims_3_6:
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 6, 0, 92, 2, 2, 2, 2,
+ax_anim 1, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 2, 89, -6, -6, -6, -6,
+ax_anim 1, 0, 89, -13, -13, -13, -13,
+ax_anim 2, 0, 93, -19, -19, -19, -19,
+ax_anim 2, 1, 93, -20, -18, -20, -18,
+ax_anim 2, 0, 93, -19, -19, -19, -19,
+ax_anim 2, 0, 93, -20, -18, -20, -18,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sSlowkingAnims_3_7:
+ax_anim 2, 0, 97, 1, 0, 1, 0,
+ax_anim 6, 0, 97, 2, 0, 2, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 2, 94, -4, 0, -4, 0,
+ax_anim 1, 0, 94, -10, 0, -10, 0,
+ax_anim 2, 0, 98, -19, 0, -19, 0,
+ax_anim 2, 1, 98, -19, 1, -19, 1,
+ax_anim 2, 0, 98, -19, 0, -19, 0,
+ax_anim 2, 0, 98, -19, 1, -19, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sSlowkingAnims_3_8:
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 6, 0, 102, 2, -2, 2, -2,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 99, -4, 4, -4, 4,
+ax_anim 1, 0, 99, -10, 10, -10, 10,
+ax_anim 2, 0, 103, -19, 20, -19, 20,
+ax_anim 2, 1, 103, -20, 19, -20, 19,
+ax_anim 2, 0, 103, -19, 20, -19, 20,
+ax_anim 2, 0, 103, -20, 19, -20, 19,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sSlowkingAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sSlowkingAnims_4_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sSlowkingAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 115, 3, -1, 2, 0,
+ax_anim 2, 0, 115, 2, -2, 1, -1,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sSlowkingAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 118, 1, -3, 1, -2,
+ax_anim 2, 0, 118, 0, -3, 0, -2,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sSlowkingAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 121, -3, -1, -2, 0,
+ax_anim 2, 0, 121, -2, -2, -1, -1,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sSlowkingAnims_4_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -2, 1, -2, 1,
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sSlowkingAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_5_1:
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -3, 0, 0,
+ax_anim 4, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -3, 0, 0,
+ax_anim 1, 0, 129, 0, -2, 0, 0,
+ax_anim 4, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim_terminator
+sSlowkingAnims_5_2:
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 4, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 1, -1, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 1, -1, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 1, -1, 1,
+ax_anim_terminator
+sSlowkingAnims_5_3:
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -3, 0, 0,
+ax_anim 1, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim_terminator
+sSlowkingAnims_5_4:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 4, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -3, 0, 0,
+ax_anim 1, 0, 135, 0, -2, 0, 0,
+ax_anim 4, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+sSlowkingAnims_5_5:
+ax_anim 6, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 1, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 2, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 1, 0, 1, 0,
+ax_anim_terminator
+sSlowkingAnims_5_6:
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 1, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, -1, 1, -1,
+ax_anim_terminator
+sSlowkingAnims_5_7:
+ax_anim 6, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 4, 0, 141, 0, -4, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 1, 0, 141, 0, -2, 0, 0,
+ax_anim 4, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim_terminator
+sSlowkingAnims_5_8:
+ax_anim 6, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -3, 0, 0,
+ax_anim 1, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 1, 1, 1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 1, 1, 1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sSlowkingAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sSlowkingAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sSlowkingAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sSlowkingAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sSlowkingAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sSlowkingAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sSlowkingAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_8_1:
+ax_anim 20, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim 20, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_8_2:
+ax_anim 20, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 20, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_8_3:
+ax_anim 20, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim 20, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_8_4:
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim 20, 0, 163, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 8, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_8_5:
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, 0, 0, 0,
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_8_6:
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 170, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_8_7:
+ax_anim 20, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim 12, 0, 172, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 172, 0, 0, 0, 0,
+ax_anim 12, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_8_8:
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim 12, 0, 175, 0, 0, 0, 0,
+ax_anim 12, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 12, 0, 175, 0, 0, 0, 0,
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 7, 3, 7, 3,
+ax_anim 2, 0, 180, 11, 11, 11, 11,
+ax_anim 2, 0, 181, 7, 16, 7, 16,
+ax_anim 3, 0, 182, 0, 20, 0, 20,
+ax_anim 2, 3, 183, -7, 16, -7, 16,
+ax_anim 2, 0, 184, -11, 11, -11, 11,
+ax_anim 1, 0, 185, -7, 3, -7, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 11, -3, 11, -3,
+ax_anim 2, 0, 179, 19, 1, 19, 1,
+ax_anim 2, 0, 180, 23, 10, 23, 10,
+ax_anim 3, 0, 181, 22, 19, 22, 19,
+ax_anim 2, 3, 182, 14, 21, 14, 21,
+ax_anim 2, 0, 183, 4, 16, 4, 16,
+ax_anim 1, 0, 184, -2, 11, -2, 11,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 5, -4, 5, -4,
+ax_anim 2, 0, 178, 13, -8, 13, -8,
+ax_anim 2, 0, 179, 19, -5, 19, -5,
+ax_anim 3, 0, 180, 22, -1, 22, -1,
+ax_anim 2, 3, 181, 19, 4, 19, 4,
+ax_anim 2, 0, 182, 14, 6, 14, 6,
+ax_anim 1, 0, 183, 7, 4, 7, 4,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -2, -5, -2, -5,
+ax_anim 2, 0, 185, 3, -14, 3, -14,
+ax_anim 2, 0, 178, 11, -18, 11, -18,
+ax_anim 3, 0, 179, 21, -18, 21, -18,
+ax_anim 2, 3, 180, 26, -10, 26, -10,
+ax_anim 2, 0, 181, 22, -3, 22, -3,
+ax_anim 1, 0, 182, 14, 0, 14, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -12, -9, -12, -9,
+ax_anim 2, 0, 185, -9, -17, -9, -17,
+ax_anim 3, 0, 178, 0, -20, 0, -21,
+ax_anim 2, 3, 179, 9, -17, 9, -17,
+ax_anim 2, 0, 180, 12, -9, 12, -9,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 2, -5, 2, -5,
+ax_anim 2, 0, 179, -3, -14, -3, -14,
+ax_anim 2, 0, 178, -11, -18, -11, -18,
+ax_anim 3, 0, 185, -21, -18, -21, -18,
+ax_anim 2, 3, 184, -26, -10, -26, -10,
+ax_anim 2, 0, 183, -22, -3, -22, -3,
+ax_anim 1, 0, 182, -14, 0, -14, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -5, -4, -5, -4,
+ax_anim 2, 0, 178, -13, -8, -13, -8,
+ax_anim 2, 0, 185, -19, -5, -19, -5,
+ax_anim 3, 0, 184, -22, -1, -22, -1,
+ax_anim 2, 3, 183, -19, 4, -19, 4,
+ax_anim 2, 0, 182, -14, 6, -14, 6,
+ax_anim 1, 0, 181, -7, 4, -7, 4,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -11, -3, -11, -3,
+ax_anim 2, 0, 185, -19, 1, -19, 1,
+ax_anim 2, 0, 184, -23, 10, -23, 10,
+ax_anim 3, 0, 183, -22, 19, -22, 19,
+ax_anim 2, 3, 182, -14, 21, -14, 21,
+ax_anim 2, 0, 181, -4, 16, -4, 16,
+ax_anim 1, 0, 180, 2, 11, 2, 11,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowkingAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowkingGfx1:
+.incbin "baserom.gba", 0xD8126C, 0x200
+sSlowkingSprites1:
+ax_sprite sSlowkingGfx1, 0x200
+ax_sprite_terminator
+sSlowkingGfx2:
+.incbin "baserom.gba", 0xD8147C, 0x200
+sSlowkingSprites2:
+ax_sprite sSlowkingGfx2, 0x200
+ax_sprite_terminator
+sSlowkingGfx3:
+.incbin "baserom.gba", 0xD8168C, 0x200
+sSlowkingSprites3:
+ax_sprite sSlowkingGfx3, 0x200
+ax_sprite_terminator
+sSlowkingGfx4:
+.incbin "baserom.gba", 0xD8189C, 0x200
+sSlowkingSprites4:
+ax_sprite sSlowkingGfx4, 0x200
+ax_sprite_terminator
+sSlowkingGfx5:
+.incbin "baserom.gba", 0xD81AAC, 0x200
+sSlowkingSprites5:
+ax_sprite sSlowkingGfx5, 0x200
+ax_sprite_terminator
+sSlowkingGfx6:
+.incbin "baserom.gba", 0xD81CBC, 0x200
+sSlowkingSprites6:
+ax_sprite sSlowkingGfx6, 0x200
+ax_sprite_terminator
+sSlowkingGfx7:
+.incbin "baserom.gba", 0xD81ECC, 0x200
+sSlowkingSprites7:
+ax_sprite sSlowkingGfx7, 0x200
+ax_sprite_terminator
+sSlowkingGfx8:
+.incbin "baserom.gba", 0xD820DC, 0x200
+sSlowkingSprites8:
+ax_sprite sSlowkingGfx8, 0x200
+ax_sprite_terminator
+sSlowkingGfx9:
+.incbin "baserom.gba", 0xD822EC, 0x200
+sSlowkingSprites9:
+ax_sprite sSlowkingGfx9, 0x200
+ax_sprite_terminator
+sSlowkingGfx10:
+.incbin "baserom.gba", 0xD824FC, 0x200
+sSlowkingSprites10:
+ax_sprite sSlowkingGfx10, 0x200
+ax_sprite_terminator
+sSlowkingGfx11:
+.incbin "baserom.gba", 0xD8270C, 0x200
+sSlowkingSprites11:
+ax_sprite sSlowkingGfx11, 0x200
+ax_sprite_terminator
+sSlowkingGfx12:
+.incbin "baserom.gba", 0xD8291C, 0x200
+sSlowkingSprites12:
+ax_sprite sSlowkingGfx12, 0x200
+ax_sprite_terminator
+sSlowkingGfx13:
+.incbin "baserom.gba", 0xD82B2C, 0x200
+sSlowkingSprites13:
+ax_sprite sSlowkingGfx13, 0x200
+ax_sprite_terminator
+sSlowkingGfx14:
+.incbin "baserom.gba", 0xD82D3C, 0x200
+sSlowkingSprites14:
+ax_sprite sSlowkingGfx14, 0x200
+ax_sprite_terminator
+sSlowkingGfx15:
+.incbin "baserom.gba", 0xD82F4C, 0x200
+sSlowkingSprites15:
+ax_sprite sSlowkingGfx15, 0x200
+ax_sprite_terminator
+sSlowkingGfx16:
+.incbin "baserom.gba", 0xD8315C, 0x40
+sSlowkingGfx16_1:
+.incbin "baserom.gba", 0xD8319C, 0x60
+sSlowkingGfx16_2:
+.incbin "baserom.gba", 0xD831FC, 0x60
+sSlowkingGfx16_3:
+.incbin "baserom.gba", 0xD8325C, 0x60
+sSlowkingSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx16_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx17:
+.incbin "baserom.gba", 0xD8330C, 0x40
+sSlowkingGfx17_1:
+.incbin "baserom.gba", 0xD8334C, 0x60
+sSlowkingGfx17_2:
+.incbin "baserom.gba", 0xD833AC, 0x60
+sSlowkingGfx17_3:
+.incbin "baserom.gba", 0xD8340C, 0x60
+sSlowkingSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx18:
+.incbin "baserom.gba", 0xD834BC, 0x40
+sSlowkingGfx18_1:
+.incbin "baserom.gba", 0xD834FC, 0x60
+sSlowkingGfx18_2:
+.incbin "baserom.gba", 0xD8355C, 0x60
+sSlowkingGfx18_3:
+.incbin "baserom.gba", 0xD835BC, 0x60
+sSlowkingSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx19:
+.incbin "baserom.gba", 0xD8366C, 0x40
+sSlowkingGfx19_1:
+.incbin "baserom.gba", 0xD836AC, 0x60
+sSlowkingGfx19_2:
+.incbin "baserom.gba", 0xD8370C, 0x60
+sSlowkingGfx19_3:
+.incbin "baserom.gba", 0xD8376C, 0x60
+sSlowkingSprites19:
+ax_sprite sSlowkingGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlowkingGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx20:
+.incbin "baserom.gba", 0xD83814, 0x40
+sSlowkingGfx20_1:
+.incbin "baserom.gba", 0xD83854, 0x60
+sSlowkingGfx20_2:
+.incbin "baserom.gba", 0xD838B4, 0x60
+sSlowkingGfx20_3:
+.incbin "baserom.gba", 0xD83914, 0x60
+sSlowkingSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx21:
+.incbin "baserom.gba", 0xD839C4, 0x40
+sSlowkingGfx21_1:
+.incbin "baserom.gba", 0xD83A04, 0x40
+sSlowkingGfx21_2:
+.incbin "baserom.gba", 0xD83A44, 0x60
+sSlowkingGfx21_3:
+.incbin "baserom.gba", 0xD83AA4, 0x60
+sSlowkingSprites21:
+ax_sprite sSlowkingGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlowkingGfx21_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlowkingGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx22:
+.incbin "baserom.gba", 0xD83B4C, 0x40
+sSlowkingGfx22_1:
+.incbin "baserom.gba", 0xD83B8C, 0x60
+sSlowkingGfx22_2:
+.incbin "baserom.gba", 0xD83BEC, 0x60
+sSlowkingGfx22_3:
+.incbin "baserom.gba", 0xD83C4C, 0x60
+sSlowkingSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx23:
+.incbin "baserom.gba", 0xD83CFC, 0x40
+sSlowkingGfx23_1:
+.incbin "baserom.gba", 0xD83D3C, 0x40
+sSlowkingGfx23_2:
+.incbin "baserom.gba", 0xD83D7C, 0x60
+sSlowkingGfx23_3:
+.incbin "baserom.gba", 0xD83DDC, 0x60
+sSlowkingSprites23:
+ax_sprite sSlowkingGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlowkingGfx23_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlowkingGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx24:
+.incbin "baserom.gba", 0xD83E84, 0x40
+sSlowkingGfx24_1:
+.incbin "baserom.gba", 0xD83EC4, 0x60
+sSlowkingGfx24_2:
+.incbin "baserom.gba", 0xD83F24, 0x60
+sSlowkingGfx24_3:
+.incbin "baserom.gba", 0xD83F84, 0x60
+sSlowkingSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx25:
+.incbin "baserom.gba", 0xD84034, 0x60
+sSlowkingGfx25_1:
+.incbin "baserom.gba", 0xD84094, 0x60
+sSlowkingGfx25_2:
+.incbin "baserom.gba", 0xD840F4, 0x60
+sSlowkingGfx25_3:
+.incbin "baserom.gba", 0xD84154, 0x60
+sSlowkingSprites25:
+ax_sprite sSlowkingGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx26:
+.incbin "baserom.gba", 0xD841FC, 0x40
+sSlowkingGfx26_1:
+.incbin "baserom.gba", 0xD8423C, 0x60
+sSlowkingGfx26_2:
+.incbin "baserom.gba", 0xD8429C, 0x60
+sSlowkingGfx26_3:
+.incbin "baserom.gba", 0xD842FC, 0x60
+sSlowkingSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx27:
+.incbin "baserom.gba", 0xD843AC, 0x40
+sSlowkingGfx27_1:
+.incbin "baserom.gba", 0xD843EC, 0x60
+sSlowkingGfx27_2:
+.incbin "baserom.gba", 0xD8444C, 0x60
+sSlowkingGfx27_3:
+.incbin "baserom.gba", 0xD844AC, 0x60
+sSlowkingSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx28:
+.incbin "baserom.gba", 0xD8455C, 0x40
+sSlowkingGfx28_1:
+.incbin "baserom.gba", 0xD8459C, 0x60
+sSlowkingGfx28_2:
+.incbin "baserom.gba", 0xD845FC, 0x60
+sSlowkingGfx28_3:
+.incbin "baserom.gba", 0xD8465C, 0x60
+sSlowkingSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx29:
+.incbin "baserom.gba", 0xD8470C, 0x40
+sSlowkingGfx29_1:
+.incbin "baserom.gba", 0xD8474C, 0x60
+sSlowkingGfx29_2:
+.incbin "baserom.gba", 0xD847AC, 0x60
+sSlowkingGfx29_3:
+.incbin "baserom.gba", 0xD8480C, 0x60
+sSlowkingSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx30:
+.incbin "baserom.gba", 0xD848BC, 0x40
+sSlowkingGfx30_1:
+.incbin "baserom.gba", 0xD848FC, 0x60
+sSlowkingGfx30_2:
+.incbin "baserom.gba", 0xD8495C, 0xE0
+sSlowkingSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowkingGfx30_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowkingGfx31:
+.incbin "baserom.gba", 0xD84A7C, 0x200
+sSlowkingSprites31:
+ax_sprite sSlowkingGfx31, 0x200
+ax_sprite_terminator
+sSlowkingGfx32:
+.incbin "baserom.gba", 0xD84C8C, 0x200
+sSlowkingSprites32:
+ax_sprite sSlowkingGfx32, 0x200
+ax_sprite_terminator
+sSlowkingGfx33:
+.incbin "baserom.gba", 0xD84E9C, 0x200
+sSlowkingSprites33:
+ax_sprite sSlowkingGfx33, 0x200
+ax_sprite_terminator
+sSlowkingGfx34:
+.incbin "baserom.gba", 0xD850AC, 0x200
+sSlowkingSprites34:
+ax_sprite sSlowkingGfx34, 0x200
+ax_sprite_terminator
+sSlowkingGfx35:
+.incbin "baserom.gba", 0xD852BC, 0x200
+sSlowkingSprites35:
+ax_sprite sSlowkingGfx35, 0x200
+ax_sprite_terminator
+sSlowkingGfx36:
+.incbin "baserom.gba", 0xD854CC, 0x200
+sSlowkingSprites36:
+ax_sprite sSlowkingGfx36, 0x200
+ax_sprite_terminator
+sSlowkingGfx37:
+.incbin "baserom.gba", 0xD856DC, 0x200
+sSlowkingSprites37:
+ax_sprite sSlowkingGfx37, 0x200
+ax_sprite_terminator
+sAxPosesSlowking:
+.4byte sSlowkingPose1
+.4byte sSlowkingPose2
+.4byte sSlowkingPose3
+.4byte sSlowkingPose4
+.4byte sSlowkingPose5
+.4byte sSlowkingPose6
+.4byte sSlowkingPose7
+.4byte sSlowkingPose8
+.4byte sSlowkingPose9
+.4byte sSlowkingPose10
+.4byte sSlowkingPose11
+.4byte sSlowkingPose12
+.4byte sSlowkingPose13
+.4byte sSlowkingPose14
+.4byte sSlowkingPose15
+.4byte sSlowkingPose16
+.4byte sSlowkingPose17
+.4byte sSlowkingPose18
+.4byte sSlowkingPose19
+.4byte sSlowkingPose20
+.4byte sSlowkingPose21
+.4byte sSlowkingPose22
+.4byte sSlowkingPose23
+.4byte sSlowkingPose24
+.4byte sSlowkingPose25
+.4byte sSlowkingPose26
+.4byte sSlowkingPose27
+.4byte sSlowkingPose28
+.4byte sSlowkingPose29
+.4byte sSlowkingPose30
+.4byte sSlowkingPose31
+.4byte sSlowkingPose32
+.4byte sSlowkingPose33
+.4byte sSlowkingPose34
+.4byte sSlowkingPose35
+.4byte sSlowkingPose36
+.4byte sSlowkingPose37
+.4byte sSlowkingPose38
+.4byte sSlowkingPose39
+.4byte sSlowkingPose40
+.4byte sSlowkingPose41
+.4byte sSlowkingPose42
+.4byte sSlowkingPose43
+.4byte sSlowkingPose44
+.4byte sSlowkingPose45
+.4byte sSlowkingPose46
+.4byte sSlowkingPose47
+.4byte sSlowkingPose48
+.4byte sSlowkingPose49
+.4byte sSlowkingPose50
+.4byte sSlowkingPose51
+.4byte sSlowkingPose52
+.4byte sSlowkingPose53
+.4byte sSlowkingPose54
+.4byte sSlowkingPose55
+.4byte sSlowkingPose56
+.4byte sSlowkingPose57
+.4byte sSlowkingPose58
+.4byte sSlowkingPose59
+.4byte sSlowkingPose60
+.4byte sSlowkingPose61
+.4byte sSlowkingPose62
+.4byte sSlowkingPose63
+.4byte sSlowkingPose64
+.4byte sSlowkingPose65
+.4byte sSlowkingPose66
+.4byte sSlowkingPose67
+.4byte sSlowkingPose68
+.4byte sSlowkingPose69
+.4byte sSlowkingPose70
+.4byte sSlowkingPose71
+.4byte sSlowkingPose72
+.4byte sSlowkingPose73
+.4byte sSlowkingPose74
+.4byte sSlowkingPose75
+.4byte sSlowkingPose76
+.4byte sSlowkingPose77
+.4byte sSlowkingPose78
+.4byte sSlowkingPose79
+.4byte sSlowkingPose80
+.4byte sSlowkingPose81
+.4byte sSlowkingPose82
+.4byte sSlowkingPose83
+.4byte sSlowkingPose84
+.4byte sSlowkingPose85
+.4byte sSlowkingPose86
+.4byte sSlowkingPose87
+.4byte sSlowkingPose88
+.4byte sSlowkingPose89
+.4byte sSlowkingPose90
+.4byte sSlowkingPose91
+.4byte sSlowkingPose92
+.4byte sSlowkingPose93
+.4byte sSlowkingPose94
+.4byte sSlowkingPose95
+.4byte sSlowkingPose96
+.4byte sSlowkingPose97
+.4byte sSlowkingPose98
+.4byte sSlowkingPose99
+.4byte sSlowkingPose100
+.4byte sSlowkingPose101
+.4byte sSlowkingPose102
+.4byte sSlowkingPose103
+.4byte sSlowkingPose104
+.4byte sSlowkingPose105
+.4byte sSlowkingPose106
+.4byte sSlowkingPose107
+.4byte sSlowkingPose108
+.4byte sSlowkingPose109
+.4byte sSlowkingPose110
+.4byte sSlowkingPose111
+.4byte sSlowkingPose112
+.4byte sSlowkingPose113
+.4byte sSlowkingPose114
+.4byte sSlowkingPose115
+.4byte sSlowkingPose116
+.4byte sSlowkingPose117
+.4byte sSlowkingPose118
+.4byte sSlowkingPose119
+.4byte sSlowkingPose120
+.4byte sSlowkingPose121
+.4byte sSlowkingPose122
+.4byte sSlowkingPose123
+.4byte sSlowkingPose124
+.4byte sSlowkingPose125
+.4byte sSlowkingPose126
+.4byte sSlowkingPose127
+.4byte sSlowkingPose128
+.4byte sSlowkingPose129
+.4byte sSlowkingPose130
+.4byte sSlowkingPose131
+.4byte sSlowkingPose132
+.4byte sSlowkingPose133
+.4byte sSlowkingPose134
+.4byte sSlowkingPose135
+.4byte sSlowkingPose136
+.4byte sSlowkingPose137
+.4byte sSlowkingPose138
+.4byte sSlowkingPose139
+.4byte sSlowkingPose140
+.4byte sSlowkingPose141
+.4byte sSlowkingPose142
+.4byte sSlowkingPose143
+.4byte sSlowkingPose144
+.4byte sSlowkingPose145
+.4byte sSlowkingPose146
+.4byte sSlowkingPose147
+.4byte sSlowkingPose148
+.4byte sSlowkingPose149
+.4byte sSlowkingPose150
+.4byte sSlowkingPose151
+.4byte sSlowkingPose152
+.4byte sSlowkingPose153
+.4byte sSlowkingPose154
+.4byte sSlowkingPose155
+.4byte sSlowkingPose156
+.4byte sSlowkingPose157
+.4byte sSlowkingPose158
+.4byte sSlowkingPose159
+.4byte sSlowkingPose160
+.4byte sSlowkingPose161
+.4byte sSlowkingPose162
+.4byte sSlowkingPose163
+.4byte sSlowkingPose164
+.4byte sSlowkingPose165
+.4byte sSlowkingPose166
+.4byte sSlowkingPose167
+.4byte sSlowkingPose168
+.4byte sSlowkingPose169
+.4byte sSlowkingPose170
+.4byte sSlowkingPose171
+.4byte sSlowkingPose172
+.4byte sSlowkingPose173
+.4byte sSlowkingPose174
+.4byte sSlowkingPose175
+.4byte sSlowkingPose176
+.4byte sSlowkingPose177
+.4byte sSlowkingPose178
+.4byte sSlowkingPose179
+.4byte sSlowkingPose180
+.4byte sSlowkingPose181
+.4byte sSlowkingPose182
+.4byte sSlowkingPose183
+.4byte sSlowkingPose184
+.4byte sSlowkingPose185
+.4byte sSlowkingPose186
+.4byte sSlowkingPose187
+.4byte sSlowkingPose188
+.4byte sSlowkingPose189
+.4byte sSlowkingPose190
+.4byte sSlowkingPose191
+.4byte sSlowkingPose192
+.4byte sSlowkingPose193
+.4byte sSlowkingPose194
+.4byte sSlowkingPose195
+.4byte sSlowkingPose196
+.4byte sSlowkingPose197
+.4byte sSlowkingPose198
+.4byte sSlowkingPose199
+.4byte sSlowkingPose200
+.4byte sSlowkingPose201
+.4byte sSlowkingPose202
+.4byte sSlowkingPose203
+.4byte sSlowkingPose204
+.4byte sSlowkingPose205
+.4byte sSlowkingPose206
+.4byte sSlowkingPose207
+.4byte sSlowkingPose208
+.4byte sSlowkingPose209
+.4byte sSlowkingPose210
+.4byte sSlowkingPose211
+.4byte sSlowkingPose212
+.4byte sSlowkingPose213
+.4byte sSlowkingPose214
+.4byte sSlowkingPose215
+.4byte sSlowkingPose216
+.4byte sSlowkingPose217
+.4byte sSlowkingPose218
+.4byte sSlowkingPose219
+.4byte sSlowkingPose220
+.4byte sSlowkingPose221
+.4byte sSlowkingPose222
+.4byte sSlowkingPose223
+.4byte sSlowkingPose224
+.4byte sSlowkingPose225
+.4byte sSlowkingPose226
+.4byte sSlowkingPose227
+.4byte sSlowkingPose228
+.4byte sSlowkingPose229
+.4byte sSlowkingPose230
+.4byte sSlowkingPose231
+.4byte sSlowkingPose232
+.4byte sSlowkingPose233
+.4byte sSlowkingPose234
+sAxPositionsSlowking:
+.2byte   -2,   -9, 	  -5,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    0,   -8, 	  -5,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -8, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   1,   -9, 	  -3,   -8, 	   0,   -8
+.2byte    3,   -8, 	   0,   -8, 	  -5,   -7, 	   0,   -7
+.2byte    4,   -8, 	   1,   -8, 	  -4,   -7, 	   1,   -7
+.2byte    6,  -10, 	  -4,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    6,   -9, 	  -3,   -8, 	  -5,   -7, 	   1,   -7
+.2byte    6,   -9, 	  -4,   -9, 	  -4,   -6, 	   0,   -8
+.2byte    4,  -13, 	  -6,   -6, 	  -3,   -5, 	   0,   -9
+.2byte    4,  -12, 	  -7,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    4,  -12, 	  -6,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -2,  -16, 	   0,   -4, 	  -3,   -5, 	  -2,  -10
+.2byte   -2,  -14, 	   1,   -3, 	  -2,   -4, 	  -1,   -9
+.2byte    0,  -14, 	  -1,   -3, 	  -4,   -4, 	  -1,   -9
+.2byte   -6,  -13, 	   4,   -6, 	   1,   -5, 	  -2,   -9
+.2byte   -6,  -12, 	   5,   -6, 	   2,   -4, 	  -1,   -9
+.2byte   -6,  -12, 	   4,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -8,  -10, 	   2,  -10, 	   2,   -8, 	  -3,   -8
+.2byte   -8,   -9, 	   1,   -8, 	   3,   -7, 	  -3,   -7
+.2byte   -8,   -9, 	   2,   -9, 	   2,   -6, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -9, 	   1,   -8, 	  -2,   -8
+.2byte   -5,   -8, 	  -2,   -8, 	   3,   -7, 	  -2,   -7
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -7, 	  -3,   -7
+.2byte   -2,   -9, 	  -5,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    0,   -8, 	  -5,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -8, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte   -2,  -10, 	  -9,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -5, 	   6,   -5, 	  -1,   -7
+.2byte    4,   -9, 	   1,   -9, 	  -3,   -8, 	   0,   -8
+.2byte    3,   -8, 	   0,   -8, 	  -5,   -7, 	   0,   -7
+.2byte    4,   -8, 	   1,   -8, 	  -4,   -7, 	   1,   -7
+.2byte    3,  -12, 	   5,   -6, 	  -2,   -3, 	   0,   -8
+.2byte    6,   -6, 	   6,   -9, 	  -6,   -5, 	   1,   -6
+.2byte    6,  -10, 	  -4,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    6,   -9, 	  -3,   -8, 	  -5,   -7, 	   1,   -7
+.2byte    6,   -9, 	  -4,   -9, 	  -4,   -6, 	   0,   -8
+.2byte    5,  -12, 	   2,   -7, 	   0,   -3, 	   0,   -8
+.2byte    7,   -8, 	  -4,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    4,  -13, 	  -6,   -6, 	  -3,   -5, 	   0,   -9
+.2byte    4,  -12, 	  -7,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    4,  -12, 	  -6,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte    2,  -15, 	  -4,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    5,  -10, 	  -8,   -8, 	   3,   -3, 	   0,   -9
+.2byte   -2,  -16, 	   0,   -4, 	  -3,   -5, 	  -2,  -10
+.2byte   -2,  -14, 	   1,   -3, 	  -2,   -4, 	  -1,   -9
+.2byte    0,  -14, 	  -1,   -3, 	  -4,   -4, 	  -1,   -9
+.2byte   -2,  -16, 	   5,   -6, 	  -8,   -6, 	  -2,   -9
+.2byte   -2,  -18, 	   8,   -6, 	 -11,   -6, 	  -1,  -10
+.2byte   -6,  -13, 	   4,   -6, 	   1,   -5, 	  -2,   -9
+.2byte   -6,  -12, 	   5,   -6, 	   2,   -4, 	  -1,   -9
+.2byte   -6,  -12, 	   4,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,  -15, 	   2,   -8, 	  -7,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	   6,   -8, 	  -5,   -3, 	  -2,   -9
+.2byte   -8,  -10, 	   2,  -10, 	   2,   -8, 	  -3,   -8
+.2byte   -8,   -9, 	   1,   -8, 	   3,   -7, 	  -3,   -7
+.2byte   -8,   -9, 	   2,   -9, 	   2,   -6, 	  -2,   -8
+.2byte   -7,  -12, 	  -4,   -7, 	  -2,   -3, 	  -2,   -8
+.2byte   -9,   -8, 	   2,   -8, 	   3,   -3, 	  -3,   -7
+.2byte   -6,   -9, 	  -3,   -9, 	   1,   -8, 	  -2,   -8
+.2byte   -5,   -8, 	  -2,   -8, 	   3,   -7, 	  -2,   -7
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -7, 	  -3,   -7
+.2byte   -5,  -12, 	  -7,   -6, 	   0,   -3, 	  -2,   -8
+.2byte   -8,   -6, 	  -8,   -9, 	   4,   -5, 	  -3,   -6
+.2byte   -2,   -9, 	  -5,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    0,   -8, 	  -5,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -8, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte   -2,  -10, 	  -9,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -5, 	   6,   -5, 	  -1,   -7
+.2byte    4,   -9, 	   1,   -9, 	  -3,   -8, 	   0,   -8
+.2byte    3,   -8, 	   0,   -8, 	  -5,   -7, 	   0,   -7
+.2byte    4,   -8, 	   1,   -8, 	  -4,   -7, 	   1,   -7
+.2byte    3,  -12, 	   5,   -6, 	  -2,   -3, 	   0,   -8
+.2byte    6,   -6, 	   6,   -9, 	  -6,   -5, 	   1,   -6
+.2byte    6,  -10, 	  -4,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    6,   -9, 	  -3,   -8, 	  -5,   -7, 	   1,   -7
+.2byte    6,   -9, 	  -4,   -9, 	  -4,   -6, 	   0,   -8
+.2byte    5,  -12, 	   2,   -7, 	   0,   -3, 	   0,   -8
+.2byte    7,   -8, 	  -4,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    4,  -13, 	  -6,   -6, 	  -3,   -5, 	   0,   -9
+.2byte    4,  -12, 	  -7,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    4,  -12, 	  -6,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte    2,  -15, 	  -4,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    5,  -10, 	  -8,   -8, 	   3,   -3, 	   0,   -9
+.2byte   -2,  -16, 	   0,   -4, 	  -3,   -5, 	  -2,  -10
+.2byte   -2,  -14, 	   1,   -3, 	  -2,   -4, 	  -1,   -9
+.2byte    0,  -14, 	  -1,   -3, 	  -4,   -4, 	  -1,   -9
+.2byte   -2,  -16, 	   5,   -6, 	  -8,   -6, 	  -2,   -9
+.2byte   -2,  -18, 	   8,   -6, 	 -11,   -6, 	  -1,  -10
+.2byte   -6,  -13, 	   4,   -6, 	   1,   -5, 	  -2,   -9
+.2byte   -6,  -12, 	   5,   -6, 	   2,   -4, 	  -1,   -9
+.2byte   -6,  -12, 	   4,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -4,  -15, 	   2,   -8, 	  -7,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	   6,   -8, 	  -5,   -3, 	  -2,   -9
+.2byte   -8,  -10, 	   2,  -10, 	   2,   -8, 	  -3,   -8
+.2byte   -8,   -9, 	   1,   -8, 	   3,   -7, 	  -3,   -7
+.2byte   -8,   -9, 	   2,   -9, 	   2,   -6, 	  -2,   -8
+.2byte   -7,  -12, 	  -4,   -7, 	  -2,   -3, 	  -2,   -8
+.2byte   -9,   -8, 	   2,   -8, 	   3,   -3, 	  -3,   -7
+.2byte   -6,   -9, 	  -3,   -9, 	   1,   -8, 	  -2,   -8
+.2byte   -5,   -8, 	  -2,   -8, 	   3,   -7, 	  -2,   -7
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -7, 	  -3,   -7
+.2byte   -5,  -12, 	  -7,   -6, 	   0,   -3, 	  -2,   -8
+.2byte   -8,   -6, 	  -8,   -9, 	   4,   -5, 	  -3,   -6
+.2byte   -2,   -9, 	  -5,   -6, 	   2,   -6, 	  -1,   -7
+.2byte   -2,  -10, 	  -9,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -5, 	   6,   -5, 	  -1,   -7
+.2byte    4,   -9, 	   1,   -9, 	  -3,   -8, 	   0,   -8
+.2byte    3,  -12, 	   5,   -6, 	  -2,   -3, 	   0,   -8
+.2byte    6,   -6, 	   6,   -9, 	  -6,   -5, 	   1,   -6
+.2byte    6,  -10, 	  -4,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    5,  -12, 	   2,   -7, 	   0,   -3, 	   0,   -8
+.2byte    7,   -8, 	  -4,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    4,  -13, 	  -6,   -6, 	  -3,   -5, 	   0,   -9
+.2byte    2,  -15, 	  -4,   -8, 	   5,   -5, 	  -1,  -10
+.2byte    5,  -10, 	  -8,   -8, 	   3,   -3, 	   0,   -9
+.2byte   -2,  -16, 	   0,   -4, 	  -3,   -5, 	  -2,  -10
+.2byte   -2,  -16, 	   5,   -6, 	  -8,   -6, 	  -2,   -9
+.2byte   -2,  -18, 	   8,   -6, 	 -11,   -6, 	  -1,  -10
+.2byte   -6,  -13, 	   4,   -6, 	   1,   -5, 	  -2,   -9
+.2byte   -4,  -15, 	   2,   -8, 	  -7,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	   6,   -8, 	  -5,   -3, 	  -2,   -9
+.2byte   -8,  -10, 	   2,  -10, 	   2,   -8, 	  -3,   -8
+.2byte   -7,  -12, 	  -4,   -7, 	  -2,   -3, 	  -2,   -8
+.2byte   -9,   -8, 	   2,   -8, 	   3,   -3, 	  -3,   -7
+.2byte   -6,   -9, 	  -3,   -9, 	   1,   -8, 	  -2,   -8
+.2byte   -5,  -12, 	  -7,   -6, 	   0,   -3, 	  -2,   -8
+.2byte   -8,   -6, 	  -8,   -9, 	   4,   -5, 	  -3,   -6
+.2byte   -1,   -6, 	  -9,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -2,  -10, 	 -11,   -7, 	   8,   -7, 	  -1,   -9
+.2byte    5,   -6, 	   5,   -9, 	  -7,   -5, 	   0,   -6
+.2byte    3,  -12, 	   4,   -7, 	  -8,   -3, 	   0,   -7
+.2byte    7,   -8, 	  -4,   -8, 	  -5,   -3, 	   1,   -7
+.2byte    6,  -12, 	  -3,   -7, 	  -3,   -1, 	   1,   -8
+.2byte    5,  -10, 	  -8,   -8, 	   3,   -3, 	   0,   -9
+.2byte    2,  -14, 	  -9,   -8, 	   7,   -6, 	  -2,  -10
+.2byte   -2,  -18, 	   8,   -6, 	 -11,   -6, 	  -1,  -10
+.2byte   -2,  -17, 	   9,   -8, 	 -12,   -8, 	  -1,  -10
+.2byte   -7,  -10, 	   6,   -8, 	  -5,   -3, 	  -2,   -9
+.2byte   -4,  -14, 	   7,   -8, 	  -9,   -6, 	   0,  -10
+.2byte   -9,   -8, 	   2,   -8, 	   3,   -3, 	  -3,   -7
+.2byte   -8,  -12, 	   1,   -7, 	   1,   -1, 	  -3,   -8
+.2byte   -8,   -6, 	  -8,   -9, 	   4,   -5, 	  -3,   -6
+.2byte   -4,  -12, 	  -5,   -7, 	   7,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -4, 	   3,   -4, 	   0,   -6
+.2byte    0,   -5, 	  -4,   -3, 	   3,   -3, 	  -1,   -5
+.2byte   -1,  -11, 	  -8,  -11, 	   7,  -11, 	   0,  -10
+.2byte    1,  -10, 	   5,  -14, 	  -7,   -9, 	  -1,   -9
+.2byte    3,  -11, 	  -2,  -14, 	  -2,   -8, 	  -2,   -9
+.2byte    1,  -11, 	  -7,  -13, 	   7,  -11, 	  -1,   -9
+.2byte    0,  -16, 	   9,  -11, 	  -8,  -11, 	   0,   -9
+.2byte   -2,  -11, 	   6,  -13, 	  -8,  -11, 	   0,   -9
+.2byte   -4,  -11, 	   1,  -14, 	   1,   -8, 	   1,   -9
+.2byte   -2,  -10, 	  -6,  -14, 	   6,   -9, 	   0,   -9
+.2byte   -2,   -9, 	  -5,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    0,   -8, 	  -5,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -8, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   1,   -9, 	  -3,   -8, 	   0,   -8
+.2byte    3,   -8, 	   0,   -8, 	  -5,   -7, 	   0,   -7
+.2byte    4,   -8, 	   1,   -8, 	  -4,   -7, 	   1,   -7
+.2byte    6,  -10, 	  -4,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    6,   -9, 	  -3,   -8, 	  -5,   -7, 	   1,   -7
+.2byte    6,   -9, 	  -4,   -9, 	  -4,   -6, 	   0,   -8
+.2byte    4,  -13, 	  -6,   -6, 	  -3,   -5, 	   0,   -9
+.2byte    4,  -12, 	  -7,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    4,  -12, 	  -6,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -2,  -16, 	   0,   -4, 	  -3,   -5, 	  -2,  -10
+.2byte   -2,  -14, 	   1,   -3, 	  -2,   -4, 	  -1,   -9
+.2byte    0,  -14, 	  -1,   -3, 	  -4,   -4, 	  -1,   -9
+.2byte   -6,  -13, 	   4,   -6, 	   1,   -5, 	  -2,   -9
+.2byte   -6,  -12, 	   5,   -6, 	   2,   -4, 	  -1,   -9
+.2byte   -6,  -12, 	   4,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -8,  -10, 	   2,  -10, 	   2,   -8, 	  -3,   -8
+.2byte   -8,   -9, 	   1,   -8, 	   3,   -7, 	  -3,   -7
+.2byte   -8,   -9, 	   2,   -9, 	   2,   -6, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -9, 	   1,   -8, 	  -2,   -8
+.2byte   -5,   -8, 	  -2,   -8, 	   3,   -7, 	  -2,   -7
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -7, 	  -3,   -7
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,   -9
+.2byte   -5,  -12, 	  -6,   -7, 	   6,   -3, 	  -2,   -7
+.2byte   -6,  -12, 	   3,   -7, 	   3,   -1, 	  -1,   -8
+.2byte   -4,  -14, 	   7,   -8, 	  -9,   -6, 	   0,  -10
+.2byte   -1,  -17, 	  10,   -8, 	 -11,   -8, 	   0,  -10
+.2byte    2,  -14, 	  -9,   -8, 	   7,   -6, 	  -2,  -10
+.2byte    5,  -12, 	  -4,   -7, 	  -4,   -1, 	   0,   -8
+.2byte    4,  -12, 	   5,   -7, 	  -7,   -3, 	   1,   -7
+.2byte    0,   -6, 	  -8,   -5, 	   7,   -5, 	   0,   -7
+.2byte    5,   -6, 	   5,   -9, 	  -7,   -5, 	   0,   -6
+.2byte    6,   -8, 	  -5,   -8, 	  -6,   -3, 	   0,   -7
+.2byte    5,  -10, 	  -8,   -8, 	   3,   -3, 	   0,   -9
+.2byte   -1,  -17, 	   9,   -5, 	 -10,   -5, 	   0,   -9
+.2byte   -6,  -10, 	   7,   -8, 	  -4,   -3, 	  -1,   -9
+.2byte   -7,   -8, 	   4,   -8, 	   5,   -3, 	  -1,   -7
+.2byte   -6,   -6, 	  -6,   -9, 	   6,   -5, 	  -1,   -6
+.2byte   -2,   -9, 	  -5,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    0,   -8, 	  -5,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -2,   -8, 	  -5,   -5, 	   2,   -4, 	  -1,   -7
+.2byte    4,   -9, 	   1,   -9, 	  -3,   -8, 	   0,   -8
+.2byte    3,   -8, 	   0,   -8, 	  -5,   -7, 	   0,   -7
+.2byte    4,   -8, 	   1,   -8, 	  -4,   -7, 	   1,   -7
+.2byte    6,  -10, 	  -4,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    6,   -9, 	  -3,   -8, 	  -5,   -7, 	   1,   -7
+.2byte    6,   -9, 	  -4,   -9, 	  -4,   -6, 	   0,   -8
+.2byte    4,  -13, 	  -6,   -6, 	  -3,   -5, 	   0,   -9
+.2byte    4,  -12, 	  -7,   -6, 	  -4,   -4, 	  -1,   -9
+.2byte    4,  -12, 	  -6,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	   1,   -4, 	  -2,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   2,   -3, 	  -1,   -4, 	   0,   -9
+.2byte    1,  -14, 	   0,   -3, 	  -3,   -4, 	   0,   -9
+.2byte   -6,  -13, 	   4,   -6, 	   1,   -5, 	  -2,   -9
+.2byte   -6,  -12, 	   5,   -6, 	   2,   -4, 	  -1,   -9
+.2byte   -6,  -12, 	   4,   -5, 	  -1,   -4, 	  -1,   -9
+.2byte   -8,  -10, 	   2,  -10, 	   2,   -8, 	  -3,   -8
+.2byte   -8,   -9, 	   1,   -8, 	   3,   -7, 	  -3,   -7
+.2byte   -8,   -9, 	   2,   -9, 	   2,   -6, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -9, 	   1,   -8, 	  -2,   -8
+.2byte   -5,   -8, 	  -2,   -8, 	   3,   -7, 	  -2,   -7
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -7, 	  -3,   -7
+.2byte   -1,  -10, 	 -10,   -7, 	   9,   -7, 	   0,   -9
+.2byte   -5,  -12, 	  -6,   -7, 	   6,   -3, 	  -2,   -7
+.2byte   -6,  -12, 	   3,   -7, 	   3,   -1, 	  -1,   -8
+.2byte   -4,  -14, 	   7,   -8, 	  -9,   -6, 	   0,  -10
+.2byte    0,  -17, 	  11,   -8, 	 -10,   -8, 	   1,  -10
+.2byte    3,  -14, 	  -8,   -8, 	   8,   -6, 	  -1,  -10
+.2byte    5,  -12, 	  -4,   -7, 	  -4,   -1, 	   0,   -8
+.2byte    4,  -12, 	   5,   -7, 	  -7,   -3, 	   1,   -7
+.2byte   -2,   -9, 	  -5,   -6, 	   2,   -6, 	  -1,   -7
+.2byte   -6,   -9, 	  -3,   -9, 	   1,   -8, 	  -2,   -8
+.2byte   -8,  -10, 	   2,  -10, 	   2,   -8, 	  -3,   -8
+.2byte   -6,  -13, 	   4,   -6, 	   1,   -5, 	  -2,   -9
+.2byte   -2,  -16, 	   0,   -4, 	  -3,   -5, 	  -2,  -10
+.2byte    4,  -13, 	  -6,   -6, 	  -3,   -5, 	   0,   -9
+.2byte    6,  -10, 	  -4,  -10, 	  -4,   -8, 	   1,   -8
+.2byte    4,   -9, 	   1,   -9, 	  -3,   -8, 	   0,   -8
+sSlowkingAnimTable1:
+.4byte sSlowkingAnims_1_1
+.4byte sSlowkingAnims_1_2
+.4byte sSlowkingAnims_1_3
+.4byte sSlowkingAnims_1_4
+.4byte sSlowkingAnims_1_5
+.4byte sSlowkingAnims_1_6
+.4byte sSlowkingAnims_1_7
+.4byte sSlowkingAnims_1_8
+sSlowkingAnimTable2:
+.4byte sSlowkingAnims_2_1
+.4byte sSlowkingAnims_2_2
+.4byte sSlowkingAnims_2_3
+.4byte sSlowkingAnims_2_4
+.4byte sSlowkingAnims_2_5
+.4byte sSlowkingAnims_2_6
+.4byte sSlowkingAnims_2_7
+.4byte sSlowkingAnims_2_8
+sSlowkingAnimTable3:
+.4byte sSlowkingAnims_3_1
+.4byte sSlowkingAnims_3_2
+.4byte sSlowkingAnims_3_3
+.4byte sSlowkingAnims_3_4
+.4byte sSlowkingAnims_3_5
+.4byte sSlowkingAnims_3_6
+.4byte sSlowkingAnims_3_7
+.4byte sSlowkingAnims_3_8
+sSlowkingAnimTable4:
+.4byte sSlowkingAnims_4_1
+.4byte sSlowkingAnims_4_2
+.4byte sSlowkingAnims_4_3
+.4byte sSlowkingAnims_4_4
+.4byte sSlowkingAnims_4_5
+.4byte sSlowkingAnims_4_6
+.4byte sSlowkingAnims_4_7
+.4byte sSlowkingAnims_4_8
+sSlowkingAnimTable5:
+.4byte sSlowkingAnims_5_1
+.4byte sSlowkingAnims_5_2
+.4byte sSlowkingAnims_5_3
+.4byte sSlowkingAnims_5_4
+.4byte sSlowkingAnims_5_5
+.4byte sSlowkingAnims_5_6
+.4byte sSlowkingAnims_5_7
+.4byte sSlowkingAnims_5_8
+sSlowkingAnimTable6:
+.4byte sSlowkingAnims_6_1
+.4byte sSlowkingAnims_6_1
+.4byte sSlowkingAnims_6_1
+.4byte sSlowkingAnims_6_1
+.4byte sSlowkingAnims_6_1
+.4byte sSlowkingAnims_6_1
+.4byte sSlowkingAnims_6_1
+.4byte sSlowkingAnims_6_1
+sSlowkingAnimTable7:
+.4byte sSlowkingAnims_7_1
+.4byte sSlowkingAnims_7_2
+.4byte sSlowkingAnims_7_3
+.4byte sSlowkingAnims_7_4
+.4byte sSlowkingAnims_7_5
+.4byte sSlowkingAnims_7_6
+.4byte sSlowkingAnims_7_7
+.4byte sSlowkingAnims_7_8
+sSlowkingAnimTable8:
+.4byte sSlowkingAnims_8_1
+.4byte sSlowkingAnims_8_2
+.4byte sSlowkingAnims_8_3
+.4byte sSlowkingAnims_8_4
+.4byte sSlowkingAnims_8_5
+.4byte sSlowkingAnims_8_6
+.4byte sSlowkingAnims_8_7
+.4byte sSlowkingAnims_8_8
+sSlowkingAnimTable9:
+.4byte sSlowkingAnims_9_1
+.4byte sSlowkingAnims_9_2
+.4byte sSlowkingAnims_9_3
+.4byte sSlowkingAnims_9_4
+.4byte sSlowkingAnims_9_5
+.4byte sSlowkingAnims_9_6
+.4byte sSlowkingAnims_9_7
+.4byte sSlowkingAnims_9_8
+sSlowkingAnimTable10:
+.4byte sSlowkingAnims_10_1
+.4byte sSlowkingAnims_10_2
+.4byte sSlowkingAnims_10_3
+.4byte sSlowkingAnims_10_4
+.4byte sSlowkingAnims_10_5
+.4byte sSlowkingAnims_10_6
+.4byte sSlowkingAnims_10_7
+.4byte sSlowkingAnims_10_8
+sSlowkingAnimTable11:
+.4byte sSlowkingAnims_11_1
+.4byte sSlowkingAnims_11_2
+.4byte sSlowkingAnims_11_3
+.4byte sSlowkingAnims_11_4
+.4byte sSlowkingAnims_11_5
+.4byte sSlowkingAnims_11_6
+.4byte sSlowkingAnims_11_7
+.4byte sSlowkingAnims_11_8
+sSlowkingAnimTable12:
+.4byte sSlowkingAnims_12_1
+.4byte sSlowkingAnims_12_2
+.4byte sSlowkingAnims_12_3
+.4byte sSlowkingAnims_12_4
+.4byte sSlowkingAnims_12_5
+.4byte sSlowkingAnims_12_6
+.4byte sSlowkingAnims_12_7
+.4byte sSlowkingAnims_12_8
+sSlowkingAnimTable13:
+.4byte sSlowkingAnims_13_1
+.4byte sSlowkingAnims_13_2
+.4byte sSlowkingAnims_13_3
+.4byte sSlowkingAnims_13_4
+.4byte sSlowkingAnims_13_5
+.4byte sSlowkingAnims_13_6
+.4byte sSlowkingAnims_13_7
+.4byte sSlowkingAnims_13_8
+sAxAnimationsSlowking:
+.4byte sSlowkingAnimTable1
+.4byte sSlowkingAnimTable2
+.4byte sSlowkingAnimTable3
+.4byte sSlowkingAnimTable4
+.4byte sSlowkingAnimTable5
+.4byte sSlowkingAnimTable6
+.4byte sSlowkingAnimTable7
+.4byte sSlowkingAnimTable8
+.4byte sSlowkingAnimTable9
+.4byte sSlowkingAnimTable10
+.4byte sSlowkingAnimTable11
+.4byte sSlowkingAnimTable12
+.4byte sSlowkingAnimTable13
+sAxSpritesSlowking:
+.4byte sSlowkingSprites1
+.4byte sSlowkingSprites2
+.4byte sSlowkingSprites3
+.4byte sSlowkingSprites4
+.4byte sSlowkingSprites5
+.4byte sSlowkingSprites6
+.4byte sSlowkingSprites7
+.4byte sSlowkingSprites8
+.4byte sSlowkingSprites9
+.4byte sSlowkingSprites10
+.4byte sSlowkingSprites11
+.4byte sSlowkingSprites12
+.4byte sSlowkingSprites13
+.4byte sSlowkingSprites14
+.4byte sSlowkingSprites15
+.4byte sSlowkingSprites16
+.4byte sSlowkingSprites17
+.4byte sSlowkingSprites18
+.4byte sSlowkingSprites19
+.4byte sSlowkingSprites20
+.4byte sSlowkingSprites21
+.4byte sSlowkingSprites22
+.4byte sSlowkingSprites23
+.4byte sSlowkingSprites24
+.4byte sSlowkingSprites25
+.4byte sSlowkingSprites26
+.4byte sSlowkingSprites27
+.4byte sSlowkingSprites28
+.4byte sSlowkingSprites29
+.4byte sSlowkingSprites30
+.4byte sSlowkingSprites31
+.4byte sSlowkingSprites32
+.4byte sSlowkingSprites33
+.4byte sSlowkingSprites34
+.4byte sSlowkingSprites35
+.4byte sSlowkingSprites36
+.4byte sSlowkingSprites37
+sAxMainSlowking:
+ax_main sAxPosesSlowking, sAxAnimationsSlowking, 13, sAxSpritesSlowking, sAxPositionsSlowking

--- a/data/ax/slowpoke.inc
+++ b/data/ax/slowpoke.inc
@@ -1,0 +1,2377 @@
+.global gAxSlowpoke
+gAxSlowpoke:
+ax_siro sAxMainSlowpoke
+sSlowpokePose1:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose2:
+ax_pose 1, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose3:
+ax_pose 2, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose4:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose5:
+ax_pose 4, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose6:
+ax_pose 5, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose7:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose8:
+ax_pose 7, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose9:
+ax_pose 8, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose10:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose11:
+ax_pose 10, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose12:
+ax_pose 11, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose13:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose14:
+ax_pose 13, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose15:
+ax_pose 14, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose16:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose17:
+ax_pose 10, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose18:
+ax_pose 11, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose19:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose20:
+ax_pose 7, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose21:
+ax_pose 8, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose22:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose23:
+ax_pose 4, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose24:
+ax_pose 5, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose25:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose26:
+ax_pose 1, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose27:
+ax_pose 2, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose28:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose29:
+ax_pose 4, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose30:
+ax_pose 5, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose31:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose32:
+ax_pose 7, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose33:
+ax_pose 8, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose34:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose35:
+ax_pose 10, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose36:
+ax_pose 11, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose37:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose38:
+ax_pose 13, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose39:
+ax_pose 14, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose40:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose41:
+ax_pose 10, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose42:
+ax_pose 11, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose43:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose44:
+ax_pose 7, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose45:
+ax_pose 8, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose46:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose47:
+ax_pose 4, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose48:
+ax_pose 5, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose49:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose50:
+ax_pose 1, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose51:
+ax_pose 2, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose52:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose53:
+ax_pose 4, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose54:
+ax_pose 5, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose55:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose56:
+ax_pose 7, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose57:
+ax_pose 8, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose58:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose59:
+ax_pose 10, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose60:
+ax_pose 11, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose61:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose62:
+ax_pose 13, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose63:
+ax_pose 14, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose64:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose65:
+ax_pose 10, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose66:
+ax_pose 11, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose67:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose68:
+ax_pose 7, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose69:
+ax_pose 8, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose70:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose71:
+ax_pose 4, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose72:
+ax_pose 5, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose73:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose74:
+ax_pose 1, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose75:
+ax_pose 2, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose76:
+ax_pose 15, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose77:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose78:
+ax_pose 4, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose79:
+ax_pose 5, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose80:
+ax_pose 16, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose81:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose82:
+ax_pose 7, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose83:
+ax_pose 8, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose84:
+ax_pose 17, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose85:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose86:
+ax_pose 10, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose87:
+ax_pose 11, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose88:
+ax_pose 18, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowpokePose89:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose90:
+ax_pose 13, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose91:
+ax_pose 14, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose92:
+ax_pose 19, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose93:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose94:
+ax_pose 10, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose95:
+ax_pose 11, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose96:
+ax_pose 18, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowpokePose97:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose98:
+ax_pose 7, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose99:
+ax_pose 8, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose100:
+ax_pose 17, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose101:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose102:
+ax_pose 4, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose103:
+ax_pose 5, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose104:
+ax_pose 16, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose105:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose106:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose107:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose108:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose109:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose110:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose111:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose112:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose113:
+ax_pose 20, 0x41f4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose114:
+ax_pose 21, 0x41f4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose115:
+ax_pose 22, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose116:
+ax_pose 23, 0x01e6, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose117:
+ax_pose 24, 0x01e5, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose118:
+ax_pose 25, 0x01eb, 0x90ea, 0x5c00
+ax_pose_terminator
+sSlowpokePose119:
+ax_pose 26, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowpokePose120:
+ax_pose 25, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSlowpokePose121:
+ax_pose 24, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose122:
+ax_pose 23, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose123:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose124:
+ax_pose 1, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose125:
+ax_pose 2, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose126:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose127:
+ax_pose 4, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose128:
+ax_pose 5, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose129:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose130:
+ax_pose 7, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose131:
+ax_pose 8, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose132:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose133:
+ax_pose 10, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose134:
+ax_pose 11, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose135:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose136:
+ax_pose 13, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose137:
+ax_pose 14, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose138:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose139:
+ax_pose 10, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose140:
+ax_pose 11, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose141:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose142:
+ax_pose 7, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose143:
+ax_pose 8, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose144:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose145:
+ax_pose 4, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose146:
+ax_pose 5, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose147:
+ax_pose 15, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose148:
+ax_pose 16, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose149:
+ax_pose 17, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose150:
+ax_pose 18, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowpokePose151:
+ax_pose 19, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose152:
+ax_pose 18, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowpokePose153:
+ax_pose 17, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose154:
+ax_pose 16, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose155:
+ax_pose 15, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose156:
+ax_pose 16, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose157:
+ax_pose 17, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose158:
+ax_pose 18, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowpokePose159:
+ax_pose 19, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose160:
+ax_pose 18, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowpokePose161:
+ax_pose 17, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose162:
+ax_pose 16, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose163:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose164:
+ax_pose 15, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose165:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose166:
+ax_pose 16, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sSlowpokePose167:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose168:
+ax_pose 17, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowpokePose169:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose170:
+ax_pose 18, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose171:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose172:
+ax_pose 19, 0x01ed, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose173:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose174:
+ax_pose 18, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose175:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose176:
+ax_pose 17, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowpokePose177:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose178:
+ax_pose 16, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sSlowpokePose179:
+ax_pose 15, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose180:
+ax_pose 16, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose181:
+ax_pose 17, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose182:
+ax_pose 18, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sSlowpokePose183:
+ax_pose 19, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose184:
+ax_pose 18, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sSlowpokePose185:
+ax_pose 17, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSlowpokePose186:
+ax_pose 16, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSlowpokePose187:
+ax_pose 0, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose188:
+ax_pose 3, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sSlowpokePose189:
+ax_pose 6, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose190:
+ax_pose 9, 0x01ef, 0x80f5, 0x5c00
+ax_pose_terminator
+sSlowpokePose191:
+ax_pose 12, 0x01ef, 0x80f4, 0x5c00
+ax_pose_terminator
+sSlowpokePose192:
+ax_pose 9, 0x01ef, 0x90eb, 0x5c00
+ax_pose_terminator
+sSlowpokePose193:
+ax_pose 6, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSlowpokePose194:
+ax_pose 3, 0x01ef, 0x90ee, 0x5c00
+ax_pose_terminator
+.align 2
+sSlowpokeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSlowpokeAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSlowpokeAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSlowpokeAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 0, 34, 4, -6, 4, -6,
+ax_anim 2, 2, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSlowpokeAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 1, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 0, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSlowpokeAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 0, 40, -4, -6, -4, -6,
+ax_anim 2, 2, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSlowpokeAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSlowpokeAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSlowpokeAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 4, 4, 4, 4,
+ax_anim 2, 2, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sSlowpokeAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSlowpokeAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 0, 58, 4, -6, 4, -6,
+ax_anim 2, 2, 59, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 1, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 58, 18, -23, 18, -23,
+ax_anim 2, 0, 58, 19, -22, 19, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSlowpokeAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 61, 0, -4, 0, -4,
+ax_anim 2, 2, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 1, 61, 1, -22, 1, -22,
+ax_anim 2, 0, 61, 0, -22, 0, -22,
+ax_anim 2, 0, 61, 1, -22, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSlowpokeAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 0, 64, -4, -6, -4, -6,
+ax_anim 2, 2, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 1, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 0, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSlowpokeAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSlowpokeAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 70, -4, 4, -4, 4,
+ax_anim 2, 2, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 73, 0, -3, 0, -3,
+ax_anim 4, 2, 72, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -2, 0, -2,
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 0, 75, -1, 2, -1, 2,
+ax_anim 2, 1, 75, 0, 2, 0, 2,
+ax_anim 2, 0, 75, -1, 2, -1, 2,
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 0, 75, -1, 2, -1, 2,
+ax_anim 2, 0, 75, 0, 2, 0, 2,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sSlowpokeAnims_4_2:
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 2, 0, 77, -3, -3, -3, -3,
+ax_anim 4, 2, 76, -4, -4, -4, -4,
+ax_anim 1, 0, 79, -2, -2, -2, -2,
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 1, 3, 1, 3,
+ax_anim 2, 1, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 1, 3, 1, 3,
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 79, 1, 3, 1, 3,
+ax_anim 2, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim_terminator
+sSlowpokeAnims_4_3:
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 2, 0, 81, -3, 0, -3, 0,
+ax_anim 4, 2, 80, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -2, 0, -2, 0,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 1, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 83, 2, 1, 2, 1,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim_terminator
+sSlowpokeAnims_4_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 2, 0, 85, -3, 3, -3, 3,
+ax_anim 4, 2, 84, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -2, 2, -2, 2,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 1, -3, 1, -3,
+ax_anim 2, 1, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 1, -3, 1, -3,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 1, -3, 1, -3,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim_terminator
+sSlowpokeAnims_4_5:
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 4, 2, 88, 0, 4, 0, 4,
+ax_anim 1, 0, 91, 0, 2, 0, 2,
+ax_anim 2, 0, 91, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 1, -2, 1, -2,
+ax_anim 2, 1, 91, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 1, -2, 1, -2,
+ax_anim 2, 0, 91, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 1, -2, 1, -2,
+ax_anim 2, 0, 91, 0, -2, 0, -2,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim_terminator
+sSlowpokeAnims_4_6:
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 4, 2, 92, 4, 4, 4, 4,
+ax_anim 1, 0, 95, 2, 2, 2, 2,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -3, -1, -3,
+ax_anim 2, 1, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -3, -1, -3,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 95, -1, -3, -1, -3,
+ax_anim 2, 0, 95, -2, -2, -2, -2,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim_terminator
+sSlowpokeAnims_4_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 2, 0, 97, 3, 0, 3, 0,
+ax_anim 4, 2, 96, 4, 0, 4, 0,
+ax_anim 1, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 1, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 99, -2, 1, -2, 1,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sSlowpokeAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 101, 3, -3, 3, -3,
+ax_anim 4, 2, 100, 4, -4, 4, -4,
+ax_anim 1, 0, 103, 2, -2, 2, -2,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -1, 3, -1, 3,
+ax_anim 2, 1, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -1, 3, -1, 3,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -1, 3, -1, 3,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sSlowpokeAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sSlowpokeAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sSlowpokeAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sSlowpokeAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sSlowpokeAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sSlowpokeAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sSlowpokeAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_8_2:
+ax_anim 40, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_8_3:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_8_4:
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_8_5:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_8_6:
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_8_7:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_8_8:
+ax_anim 40, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 15, 7, 15,
+ax_anim 3, 0, 150, 0, 18, 0, 18,
+ax_anim 2, 3, 151, -7, 15, -7, 15,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 18, 3,
+ax_anim 2, 0, 148, 19, 10, 21, 10,
+ax_anim 3, 0, 149, 19, 19, 19, 20,
+ax_anim 2, 3, 150, 11, 19, 11, 19,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 18, -5, 18, -5,
+ax_anim 3, 0, 148, 21, -2, 21, -2,
+ax_anim 2, 3, 149, 16, 4, 16, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 20, -25, 20, -25,
+ax_anim 2, 3, 148, 20, -15, 20, -15,
+ax_anim 2, 0, 149, 15, -7, 15, -7,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -11, -12, -11, -12,
+ax_anim 2, 0, 153, -7, -21, -7, -21,
+ax_anim 3, 0, 146, 0, -26, 0, -26,
+ax_anim 2, 3, 147, 7, -21, 7, -21,
+ax_anim 2, 0, 148, 11, -10, 11, -10,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -20, -25, -20, -25,
+ax_anim 2, 3, 152, -20, -15, -20, -15,
+ax_anim 2, 0, 151, -15, -7, -15, -7,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -18, -5, -18, -5,
+ax_anim 3, 0, 152, -21, -2, -21, -2,
+ax_anim 2, 3, 151, -16, 4, -16, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -19, 10, -19, 10,
+ax_anim 3, 0, 151, -19, 19, -19, 19,
+ax_anim 2, 3, 150, -11, 19, -11, 19,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -23, 0, 0,
+ax_anim 3, 0, 163, 0, -22, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_11_2:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_11_3:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_11_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -17, 0, 0,
+ax_anim 1, 0, 169, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_11_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_11_6:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_11_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_11_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlowpokeAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSlowpokeGfx1:
+.incbin "baserom.gba", 0x86941C, 0x200
+sSlowpokeSprites1:
+ax_sprite sSlowpokeGfx1, 0x200
+ax_sprite_terminator
+sSlowpokeGfx2:
+.incbin "baserom.gba", 0x86962C, 0x200
+sSlowpokeSprites2:
+ax_sprite sSlowpokeGfx2, 0x200
+ax_sprite_terminator
+sSlowpokeGfx3:
+.incbin "baserom.gba", 0x86983C, 0x200
+sSlowpokeSprites3:
+ax_sprite sSlowpokeGfx3, 0x200
+ax_sprite_terminator
+sSlowpokeGfx4:
+.incbin "baserom.gba", 0x869A4C, 0x200
+sSlowpokeSprites4:
+ax_sprite sSlowpokeGfx4, 0x200
+ax_sprite_terminator
+sSlowpokeGfx5:
+.incbin "baserom.gba", 0x869C5C, 0x200
+sSlowpokeSprites5:
+ax_sprite sSlowpokeGfx5, 0x200
+ax_sprite_terminator
+sSlowpokeGfx6:
+.incbin "baserom.gba", 0x869E6C, 0x200
+sSlowpokeSprites6:
+ax_sprite sSlowpokeGfx6, 0x200
+ax_sprite_terminator
+sSlowpokeGfx7:
+.incbin "baserom.gba", 0x86A07C, 0x200
+sSlowpokeSprites7:
+ax_sprite sSlowpokeGfx7, 0x200
+ax_sprite_terminator
+sSlowpokeGfx8:
+.incbin "baserom.gba", 0x86A28C, 0x200
+sSlowpokeSprites8:
+ax_sprite sSlowpokeGfx8, 0x200
+ax_sprite_terminator
+sSlowpokeGfx9:
+.incbin "baserom.gba", 0x86A49C, 0x200
+sSlowpokeSprites9:
+ax_sprite sSlowpokeGfx9, 0x200
+ax_sprite_terminator
+sSlowpokeGfx10:
+.incbin "baserom.gba", 0x86A6AC, 0x200
+sSlowpokeSprites10:
+ax_sprite sSlowpokeGfx10, 0x200
+ax_sprite_terminator
+sSlowpokeGfx11:
+.incbin "baserom.gba", 0x86A8BC, 0x200
+sSlowpokeSprites11:
+ax_sprite sSlowpokeGfx11, 0x200
+ax_sprite_terminator
+sSlowpokeGfx12:
+.incbin "baserom.gba", 0x86AACC, 0x200
+sSlowpokeSprites12:
+ax_sprite sSlowpokeGfx12, 0x200
+ax_sprite_terminator
+sSlowpokeGfx13:
+.incbin "baserom.gba", 0x86ACDC, 0x200
+sSlowpokeSprites13:
+ax_sprite sSlowpokeGfx13, 0x200
+ax_sprite_terminator
+sSlowpokeGfx14:
+.incbin "baserom.gba", 0x86AEEC, 0x200
+sSlowpokeSprites14:
+ax_sprite sSlowpokeGfx14, 0x200
+ax_sprite_terminator
+sSlowpokeGfx15:
+.incbin "baserom.gba", 0x86B0FC, 0x200
+sSlowpokeSprites15:
+ax_sprite sSlowpokeGfx15, 0x200
+ax_sprite_terminator
+sSlowpokeGfx16:
+.incbin "baserom.gba", 0x86B30C, 0x20
+sSlowpokeGfx16_1:
+.incbin "baserom.gba", 0x86B32C, 0x60
+sSlowpokeGfx16_2:
+.incbin "baserom.gba", 0x86B38C, 0x60
+sSlowpokeGfx16_3:
+.incbin "baserom.gba", 0x86B3EC, 0x40
+sSlowpokeSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSlowpokeGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlowpokeGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowpokeGfx17:
+.incbin "baserom.gba", 0x86B47C, 0x20
+sSlowpokeGfx17_1:
+.incbin "baserom.gba", 0x86B49C, 0x60
+sSlowpokeGfx17_2:
+.incbin "baserom.gba", 0x86B4FC, 0xE0
+sSlowpokeSprites17:
+ax_sprite 0, 0x40
+ax_sprite sSlowpokeGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx17_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlowpokeGfx18:
+.incbin "baserom.gba", 0x86B61C, 0x20
+sSlowpokeGfx18_1:
+.incbin "baserom.gba", 0x86B63C, 0x60
+sSlowpokeGfx18_2:
+.incbin "baserom.gba", 0x86B69C, 0x60
+sSlowpokeSprites18:
+ax_sprite 0, 0x40
+ax_sprite sSlowpokeGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlowpokeGfx19:
+.incbin "baserom.gba", 0x86B73C, 0x60
+sSlowpokeGfx19_1:
+.incbin "baserom.gba", 0x86B79C, 0x60
+sSlowpokeGfx19_2:
+.incbin "baserom.gba", 0x86B7FC, 0x60
+sSlowpokeGfx19_3:
+.incbin "baserom.gba", 0x86B85C, 0x20
+sSlowpokeSprites19:
+ax_sprite sSlowpokeGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlowpokeGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlowpokeGfx20:
+.incbin "baserom.gba", 0x86B8C4, 0x40
+sSlowpokeGfx20_1:
+.incbin "baserom.gba", 0x86B904, 0x60
+sSlowpokeGfx20_2:
+.incbin "baserom.gba", 0x86B964, 0x60
+sSlowpokeSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlowpokeGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlowpokeGfx21:
+.incbin "baserom.gba", 0x86BA04, 0x100
+sSlowpokeSprites21:
+ax_sprite sSlowpokeGfx21, 0x100
+ax_sprite_terminator
+sSlowpokeGfx22:
+.incbin "baserom.gba", 0x86BB14, 0x100
+sSlowpokeSprites22:
+ax_sprite sSlowpokeGfx22, 0x100
+ax_sprite_terminator
+sSlowpokeGfx23:
+.incbin "baserom.gba", 0x86BC24, 0x200
+sSlowpokeSprites23:
+ax_sprite sSlowpokeGfx23, 0x200
+ax_sprite_terminator
+sSlowpokeGfx24:
+.incbin "baserom.gba", 0x86BE34, 0x200
+sSlowpokeSprites24:
+ax_sprite sSlowpokeGfx24, 0x200
+ax_sprite_terminator
+sSlowpokeGfx25:
+.incbin "baserom.gba", 0x86C044, 0x200
+sSlowpokeSprites25:
+ax_sprite sSlowpokeGfx25, 0x200
+ax_sprite_terminator
+sSlowpokeGfx26:
+.incbin "baserom.gba", 0x86C254, 0x200
+sSlowpokeSprites26:
+ax_sprite sSlowpokeGfx26, 0x200
+ax_sprite_terminator
+sSlowpokeGfx27:
+.incbin "baserom.gba", 0x86C464, 0x200
+sSlowpokeSprites27:
+ax_sprite sSlowpokeGfx27, 0x200
+ax_sprite_terminator
+sAxPosesSlowpoke:
+.4byte sSlowpokePose1
+.4byte sSlowpokePose2
+.4byte sSlowpokePose3
+.4byte sSlowpokePose4
+.4byte sSlowpokePose5
+.4byte sSlowpokePose6
+.4byte sSlowpokePose7
+.4byte sSlowpokePose8
+.4byte sSlowpokePose9
+.4byte sSlowpokePose10
+.4byte sSlowpokePose11
+.4byte sSlowpokePose12
+.4byte sSlowpokePose13
+.4byte sSlowpokePose14
+.4byte sSlowpokePose15
+.4byte sSlowpokePose16
+.4byte sSlowpokePose17
+.4byte sSlowpokePose18
+.4byte sSlowpokePose19
+.4byte sSlowpokePose20
+.4byte sSlowpokePose21
+.4byte sSlowpokePose22
+.4byte sSlowpokePose23
+.4byte sSlowpokePose24
+.4byte sSlowpokePose25
+.4byte sSlowpokePose26
+.4byte sSlowpokePose27
+.4byte sSlowpokePose28
+.4byte sSlowpokePose29
+.4byte sSlowpokePose30
+.4byte sSlowpokePose31
+.4byte sSlowpokePose32
+.4byte sSlowpokePose33
+.4byte sSlowpokePose34
+.4byte sSlowpokePose35
+.4byte sSlowpokePose36
+.4byte sSlowpokePose37
+.4byte sSlowpokePose38
+.4byte sSlowpokePose39
+.4byte sSlowpokePose40
+.4byte sSlowpokePose41
+.4byte sSlowpokePose42
+.4byte sSlowpokePose43
+.4byte sSlowpokePose44
+.4byte sSlowpokePose45
+.4byte sSlowpokePose46
+.4byte sSlowpokePose47
+.4byte sSlowpokePose48
+.4byte sSlowpokePose49
+.4byte sSlowpokePose50
+.4byte sSlowpokePose51
+.4byte sSlowpokePose52
+.4byte sSlowpokePose53
+.4byte sSlowpokePose54
+.4byte sSlowpokePose55
+.4byte sSlowpokePose56
+.4byte sSlowpokePose57
+.4byte sSlowpokePose58
+.4byte sSlowpokePose59
+.4byte sSlowpokePose60
+.4byte sSlowpokePose61
+.4byte sSlowpokePose62
+.4byte sSlowpokePose63
+.4byte sSlowpokePose64
+.4byte sSlowpokePose65
+.4byte sSlowpokePose66
+.4byte sSlowpokePose67
+.4byte sSlowpokePose68
+.4byte sSlowpokePose69
+.4byte sSlowpokePose70
+.4byte sSlowpokePose71
+.4byte sSlowpokePose72
+.4byte sSlowpokePose73
+.4byte sSlowpokePose74
+.4byte sSlowpokePose75
+.4byte sSlowpokePose76
+.4byte sSlowpokePose77
+.4byte sSlowpokePose78
+.4byte sSlowpokePose79
+.4byte sSlowpokePose80
+.4byte sSlowpokePose81
+.4byte sSlowpokePose82
+.4byte sSlowpokePose83
+.4byte sSlowpokePose84
+.4byte sSlowpokePose85
+.4byte sSlowpokePose86
+.4byte sSlowpokePose87
+.4byte sSlowpokePose88
+.4byte sSlowpokePose89
+.4byte sSlowpokePose90
+.4byte sSlowpokePose91
+.4byte sSlowpokePose92
+.4byte sSlowpokePose93
+.4byte sSlowpokePose94
+.4byte sSlowpokePose95
+.4byte sSlowpokePose96
+.4byte sSlowpokePose97
+.4byte sSlowpokePose98
+.4byte sSlowpokePose99
+.4byte sSlowpokePose100
+.4byte sSlowpokePose101
+.4byte sSlowpokePose102
+.4byte sSlowpokePose103
+.4byte sSlowpokePose104
+.4byte sSlowpokePose105
+.4byte sSlowpokePose106
+.4byte sSlowpokePose107
+.4byte sSlowpokePose108
+.4byte sSlowpokePose109
+.4byte sSlowpokePose110
+.4byte sSlowpokePose111
+.4byte sSlowpokePose112
+.4byte sSlowpokePose113
+.4byte sSlowpokePose114
+.4byte sSlowpokePose115
+.4byte sSlowpokePose116
+.4byte sSlowpokePose117
+.4byte sSlowpokePose118
+.4byte sSlowpokePose119
+.4byte sSlowpokePose120
+.4byte sSlowpokePose121
+.4byte sSlowpokePose122
+.4byte sSlowpokePose123
+.4byte sSlowpokePose124
+.4byte sSlowpokePose125
+.4byte sSlowpokePose126
+.4byte sSlowpokePose127
+.4byte sSlowpokePose128
+.4byte sSlowpokePose129
+.4byte sSlowpokePose130
+.4byte sSlowpokePose131
+.4byte sSlowpokePose132
+.4byte sSlowpokePose133
+.4byte sSlowpokePose134
+.4byte sSlowpokePose135
+.4byte sSlowpokePose136
+.4byte sSlowpokePose137
+.4byte sSlowpokePose138
+.4byte sSlowpokePose139
+.4byte sSlowpokePose140
+.4byte sSlowpokePose141
+.4byte sSlowpokePose142
+.4byte sSlowpokePose143
+.4byte sSlowpokePose144
+.4byte sSlowpokePose145
+.4byte sSlowpokePose146
+.4byte sSlowpokePose147
+.4byte sSlowpokePose148
+.4byte sSlowpokePose149
+.4byte sSlowpokePose150
+.4byte sSlowpokePose151
+.4byte sSlowpokePose152
+.4byte sSlowpokePose153
+.4byte sSlowpokePose154
+.4byte sSlowpokePose155
+.4byte sSlowpokePose156
+.4byte sSlowpokePose157
+.4byte sSlowpokePose158
+.4byte sSlowpokePose159
+.4byte sSlowpokePose160
+.4byte sSlowpokePose161
+.4byte sSlowpokePose162
+.4byte sSlowpokePose163
+.4byte sSlowpokePose164
+.4byte sSlowpokePose165
+.4byte sSlowpokePose166
+.4byte sSlowpokePose167
+.4byte sSlowpokePose168
+.4byte sSlowpokePose169
+.4byte sSlowpokePose170
+.4byte sSlowpokePose171
+.4byte sSlowpokePose172
+.4byte sSlowpokePose173
+.4byte sSlowpokePose174
+.4byte sSlowpokePose175
+.4byte sSlowpokePose176
+.4byte sSlowpokePose177
+.4byte sSlowpokePose178
+.4byte sSlowpokePose179
+.4byte sSlowpokePose180
+.4byte sSlowpokePose181
+.4byte sSlowpokePose182
+.4byte sSlowpokePose183
+.4byte sSlowpokePose184
+.4byte sSlowpokePose185
+.4byte sSlowpokePose186
+.4byte sSlowpokePose187
+.4byte sSlowpokePose188
+.4byte sSlowpokePose189
+.4byte sSlowpokePose190
+.4byte sSlowpokePose191
+.4byte sSlowpokePose192
+.4byte sSlowpokePose193
+.4byte sSlowpokePose194
+sAxPositionsSlowpoke:
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte    0,    3, 	  -9,    0, 	   7,    3, 	   0,   -5
+.2byte    0,    4, 	  -8,    3, 	   8,    0, 	   0,   -5
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+.2byte    6,    2, 	   6,   -2, 	  -1,    4, 	  -1,   -5
+.2byte    6,    3, 	   9,    0, 	  -5,    1, 	  -1,   -5
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    8,   -2, 	   2,   -1, 	   6,    2, 	  -1,   -5
+.2byte    8,   -1, 	   6,   -1, 	   1,    3, 	  -1,   -5
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    6,   -7, 	  -4,   -5, 	   7,   -2, 	  -1,   -5
+.2byte    7,   -7, 	   0,   -7, 	   4,    1, 	  -1,   -5
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    0,   -7, 	   8,   -2, 	  -9,   -6, 	   0,   -5
+.2byte    0,   -7, 	   8,   -6, 	  -9,   -2, 	   0,   -5
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte   -7,   -7, 	   3,   -5, 	  -8,   -2, 	   0,   -5
+.2byte   -8,   -7, 	  -1,   -7, 	  -5,    1, 	   0,   -5
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte   -9,   -2, 	  -3,   -1, 	  -7,    2, 	   0,   -5
+.2byte   -9,   -1, 	  -7,   -1, 	  -2,    3, 	   0,   -5
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -7,    2, 	  -7,   -2, 	   0,    4, 	   0,   -5
+.2byte   -7,    3, 	 -10,    0, 	   4,    1, 	   0,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte    0,    3, 	  -9,    0, 	   7,    3, 	   0,   -5
+.2byte    0,    4, 	  -8,    3, 	   8,    0, 	   0,   -5
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+.2byte    6,    2, 	   6,   -2, 	  -1,    4, 	  -1,   -5
+.2byte    6,    3, 	   9,    0, 	  -5,    1, 	  -1,   -5
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    8,   -2, 	   2,   -1, 	   6,    2, 	  -1,   -5
+.2byte    8,   -1, 	   6,   -1, 	   1,    3, 	  -1,   -5
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    6,   -7, 	  -4,   -5, 	   7,   -2, 	  -1,   -5
+.2byte    7,   -7, 	   0,   -7, 	   4,    1, 	  -1,   -5
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    0,   -7, 	   8,   -2, 	  -9,   -6, 	   0,   -5
+.2byte    0,   -7, 	   8,   -6, 	  -9,   -2, 	   0,   -5
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte   -7,   -7, 	   3,   -5, 	  -8,   -2, 	   0,   -5
+.2byte   -8,   -7, 	  -1,   -7, 	  -5,    1, 	   0,   -5
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte   -9,   -2, 	  -3,   -1, 	  -7,    2, 	   0,   -5
+.2byte   -9,   -1, 	  -7,   -1, 	  -2,    3, 	   0,   -5
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -7,    2, 	  -7,   -2, 	   0,    4, 	   0,   -5
+.2byte   -7,    3, 	 -10,    0, 	   4,    1, 	   0,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte    0,    3, 	  -9,    0, 	   7,    3, 	   0,   -5
+.2byte    0,    4, 	  -8,    3, 	   8,    0, 	   0,   -5
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+.2byte    6,    2, 	   6,   -2, 	  -1,    4, 	  -1,   -5
+.2byte    6,    3, 	   9,    0, 	  -5,    1, 	  -1,   -5
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    8,   -2, 	   2,   -1, 	   6,    2, 	  -1,   -5
+.2byte    8,   -1, 	   6,   -1, 	   1,    3, 	  -1,   -5
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    6,   -7, 	  -4,   -5, 	   7,   -2, 	  -1,   -5
+.2byte    7,   -7, 	   0,   -7, 	   4,    1, 	  -1,   -5
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    0,   -7, 	   8,   -2, 	  -9,   -6, 	   0,   -5
+.2byte    0,   -7, 	   8,   -6, 	  -9,   -2, 	   0,   -5
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte   -7,   -7, 	   3,   -5, 	  -8,   -2, 	   0,   -5
+.2byte   -8,   -7, 	  -1,   -7, 	  -5,    1, 	   0,   -5
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte   -9,   -2, 	  -3,   -1, 	  -7,    2, 	   0,   -5
+.2byte   -9,   -1, 	  -7,   -1, 	  -2,    3, 	   0,   -5
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -7,    2, 	  -7,   -2, 	   0,    4, 	   0,   -5
+.2byte   -7,    3, 	 -10,    0, 	   4,    1, 	   0,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte    0,    3, 	  -9,    0, 	   7,    3, 	   0,   -5
+.2byte    0,    4, 	  -8,    3, 	   8,    0, 	   0,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -5
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+.2byte    6,    2, 	   6,   -2, 	  -1,    4, 	  -1,   -5
+.2byte    6,    3, 	   9,    0, 	  -5,    1, 	  -1,   -5
+.2byte    7,    1, 	   8,   -2, 	  -3,    2, 	   1,   -5
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    8,   -2, 	   2,   -1, 	   6,    2, 	  -1,   -5
+.2byte    8,   -1, 	   6,   -1, 	   1,    3, 	  -1,   -5
+.2byte   10,   -3, 	   6,   -2, 	   4,    1, 	   1,   -6
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    6,   -7, 	  -4,   -5, 	   7,   -2, 	  -1,   -5
+.2byte    7,   -7, 	   0,   -7, 	   4,    1, 	  -1,   -5
+.2byte    7,   -9, 	  -4,   -7, 	   6,   -1, 	   0,   -7
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    0,   -7, 	   8,   -2, 	  -9,   -6, 	   0,   -5
+.2byte    0,   -7, 	   8,   -6, 	  -9,   -2, 	   0,   -5
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -8
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte   -7,   -7, 	   3,   -5, 	  -8,   -2, 	   0,   -5
+.2byte   -8,   -7, 	  -1,   -7, 	  -5,    1, 	   0,   -5
+.2byte   -8,   -9, 	   3,   -7, 	  -7,   -1, 	  -1,   -7
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte   -9,   -2, 	  -3,   -1, 	  -7,    2, 	   0,   -5
+.2byte   -9,   -1, 	  -7,   -1, 	  -2,    3, 	   0,   -5
+.2byte  -11,   -3, 	  -7,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -7,    2, 	  -7,   -2, 	   0,    4, 	   0,   -5
+.2byte   -7,    3, 	 -10,    0, 	   4,    1, 	   0,   -5
+.2byte   -8,    1, 	  -9,   -2, 	   2,    2, 	  -2,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+.2byte   -8,    2, 	 -12,    0, 	  -2,    2, 	   0,   -6
+.2byte   -8,    2, 	 -12,    0, 	  -2,    2, 	   0,   -6
+.2byte    0,    0, 	 -10,   -4, 	   9,   -4, 	   0,   -8
+.2byte    3,    2, 	   6,   -4, 	  -8,    0, 	  -4,   -6
+.2byte    5,   -2, 	   0,   -2, 	  -1,    1, 	  -4,   -5
+.2byte    4,   -3, 	  -6,   -3, 	   4,    4, 	  -3,   -1
+.2byte    0,   -3, 	   9,   -1, 	 -10,   -1, 	   0,   -1
+.2byte   -5,   -3, 	   5,   -3, 	  -5,    4, 	   2,   -1
+.2byte   -6,   -2, 	  -1,   -2, 	   0,    1, 	   3,   -5
+.2byte   -4,    2, 	  -7,   -4, 	   7,    0, 	   3,   -6
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte    0,    3, 	  -9,    0, 	   7,    3, 	   0,   -5
+.2byte    0,    4, 	  -8,    3, 	   8,    0, 	   0,   -5
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+.2byte    6,    2, 	   6,   -2, 	  -1,    4, 	  -1,   -5
+.2byte    6,    3, 	   9,    0, 	  -5,    1, 	  -1,   -5
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    8,   -2, 	   2,   -1, 	   6,    2, 	  -1,   -5
+.2byte    8,   -1, 	   6,   -1, 	   1,    3, 	  -1,   -5
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    6,   -7, 	  -4,   -5, 	   7,   -2, 	  -1,   -5
+.2byte    7,   -7, 	   0,   -7, 	   4,    1, 	  -1,   -5
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    0,   -7, 	   8,   -2, 	  -9,   -6, 	   0,   -5
+.2byte    0,   -7, 	   8,   -6, 	  -9,   -2, 	   0,   -5
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte   -7,   -7, 	   3,   -5, 	  -8,   -2, 	   0,   -5
+.2byte   -8,   -7, 	  -1,   -7, 	  -5,    1, 	   0,   -5
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte   -9,   -2, 	  -3,   -1, 	  -7,    2, 	   0,   -5
+.2byte   -9,   -1, 	  -7,   -1, 	  -2,    3, 	   0,   -5
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -7,    2, 	  -7,   -2, 	   0,    4, 	   0,   -5
+.2byte   -7,    3, 	 -10,    0, 	   4,    1, 	   0,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -5
+.2byte   -8,    1, 	  -9,   -2, 	   2,    2, 	  -2,   -5
+.2byte  -11,   -3, 	  -7,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -8,   -9, 	   3,   -7, 	  -7,   -1, 	  -1,   -7
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -8
+.2byte    7,   -9, 	  -4,   -7, 	   6,   -1, 	   0,   -7
+.2byte   10,   -3, 	   6,   -2, 	   4,    1, 	   1,   -6
+.2byte    7,    1, 	   8,   -2, 	  -3,    2, 	   1,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -5
+.2byte    7,    1, 	   8,   -2, 	  -3,    2, 	   1,   -5
+.2byte   10,   -3, 	   6,   -2, 	   4,    1, 	   1,   -6
+.2byte    7,   -9, 	  -4,   -7, 	   6,   -1, 	   0,   -7
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -8
+.2byte   -8,   -9, 	   3,   -7, 	  -7,   -1, 	  -1,   -7
+.2byte  -11,   -3, 	  -7,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -8,    1, 	  -9,   -2, 	   2,    2, 	  -2,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -5
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+.2byte    6,    1, 	   7,   -2, 	  -4,    2, 	   0,   -5
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    9,   -3, 	   5,   -2, 	   3,    1, 	   0,   -6
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    6,   -8, 	  -5,   -6, 	   5,    0, 	  -1,   -6
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    0,  -11, 	   8,   -4, 	  -9,   -4, 	   0,   -7
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte   -7,   -8, 	   4,   -6, 	  -6,    0, 	   0,   -6
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte  -10,   -3, 	  -6,   -2, 	  -4,    1, 	  -1,   -6
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -7,    1, 	  -8,   -2, 	   3,    2, 	  -1,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -5
+.2byte   -8,    1, 	  -9,   -2, 	   2,    2, 	  -2,   -5
+.2byte  -11,   -3, 	  -7,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -8,   -9, 	   3,   -7, 	  -7,   -1, 	  -1,   -7
+.2byte    0,  -12, 	   8,   -5, 	  -9,   -5, 	   0,   -8
+.2byte    7,   -9, 	  -4,   -7, 	   6,   -1, 	   0,   -7
+.2byte   10,   -3, 	   6,   -2, 	   4,    1, 	   1,   -6
+.2byte    7,    1, 	   8,   -2, 	  -3,    2, 	   1,   -5
+.2byte    0,    3, 	  -9,    1, 	   8,    1, 	   0,   -6
+.2byte   -7,    2, 	  -9,   -1, 	   2,    2, 	   0,   -6
+.2byte   -9,   -2, 	  -5,   -2, 	  -5,    1, 	   0,   -6
+.2byte   -8,   -8, 	   2,   -6, 	  -7,   -1, 	   0,   -6
+.2byte    0,   -8, 	   8,   -5, 	  -9,   -5, 	   0,   -6
+.2byte    7,   -8, 	  -3,   -6, 	   6,   -1, 	  -1,   -6
+.2byte    8,   -2, 	   4,   -2, 	   4,    1, 	  -1,   -6
+.2byte    6,    2, 	   8,   -1, 	  -3,    2, 	  -1,   -6
+sSlowpokeAnimTable1:
+.4byte sSlowpokeAnims_1_1
+.4byte sSlowpokeAnims_1_2
+.4byte sSlowpokeAnims_1_3
+.4byte sSlowpokeAnims_1_4
+.4byte sSlowpokeAnims_1_5
+.4byte sSlowpokeAnims_1_6
+.4byte sSlowpokeAnims_1_7
+.4byte sSlowpokeAnims_1_8
+sSlowpokeAnimTable2:
+.4byte sSlowpokeAnims_2_1
+.4byte sSlowpokeAnims_2_2
+.4byte sSlowpokeAnims_2_3
+.4byte sSlowpokeAnims_2_4
+.4byte sSlowpokeAnims_2_5
+.4byte sSlowpokeAnims_2_6
+.4byte sSlowpokeAnims_2_7
+.4byte sSlowpokeAnims_2_8
+sSlowpokeAnimTable3:
+.4byte sSlowpokeAnims_3_1
+.4byte sSlowpokeAnims_3_2
+.4byte sSlowpokeAnims_3_3
+.4byte sSlowpokeAnims_3_4
+.4byte sSlowpokeAnims_3_5
+.4byte sSlowpokeAnims_3_6
+.4byte sSlowpokeAnims_3_7
+.4byte sSlowpokeAnims_3_8
+sSlowpokeAnimTable4:
+.4byte sSlowpokeAnims_4_1
+.4byte sSlowpokeAnims_4_2
+.4byte sSlowpokeAnims_4_3
+.4byte sSlowpokeAnims_4_4
+.4byte sSlowpokeAnims_4_5
+.4byte sSlowpokeAnims_4_6
+.4byte sSlowpokeAnims_4_7
+.4byte sSlowpokeAnims_4_8
+sSlowpokeAnimTable5:
+.4byte sSlowpokeAnims_5_1
+.4byte sSlowpokeAnims_5_2
+.4byte sSlowpokeAnims_5_3
+.4byte sSlowpokeAnims_5_4
+.4byte sSlowpokeAnims_5_5
+.4byte sSlowpokeAnims_5_6
+.4byte sSlowpokeAnims_5_7
+.4byte sSlowpokeAnims_5_8
+sSlowpokeAnimTable6:
+.4byte sSlowpokeAnims_6_1
+.4byte sSlowpokeAnims_6_1
+.4byte sSlowpokeAnims_6_1
+.4byte sSlowpokeAnims_6_1
+.4byte sSlowpokeAnims_6_1
+.4byte sSlowpokeAnims_6_1
+.4byte sSlowpokeAnims_6_1
+.4byte sSlowpokeAnims_6_1
+sSlowpokeAnimTable7:
+.4byte sSlowpokeAnims_7_1
+.4byte sSlowpokeAnims_7_2
+.4byte sSlowpokeAnims_7_3
+.4byte sSlowpokeAnims_7_4
+.4byte sSlowpokeAnims_7_5
+.4byte sSlowpokeAnims_7_6
+.4byte sSlowpokeAnims_7_7
+.4byte sSlowpokeAnims_7_8
+sSlowpokeAnimTable8:
+.4byte sSlowpokeAnims_8_1
+.4byte sSlowpokeAnims_8_2
+.4byte sSlowpokeAnims_8_3
+.4byte sSlowpokeAnims_8_4
+.4byte sSlowpokeAnims_8_5
+.4byte sSlowpokeAnims_8_6
+.4byte sSlowpokeAnims_8_7
+.4byte sSlowpokeAnims_8_8
+sSlowpokeAnimTable9:
+.4byte sSlowpokeAnims_9_1
+.4byte sSlowpokeAnims_9_2
+.4byte sSlowpokeAnims_9_3
+.4byte sSlowpokeAnims_9_4
+.4byte sSlowpokeAnims_9_5
+.4byte sSlowpokeAnims_9_6
+.4byte sSlowpokeAnims_9_7
+.4byte sSlowpokeAnims_9_8
+sSlowpokeAnimTable10:
+.4byte sSlowpokeAnims_10_1
+.4byte sSlowpokeAnims_10_2
+.4byte sSlowpokeAnims_10_3
+.4byte sSlowpokeAnims_10_4
+.4byte sSlowpokeAnims_10_5
+.4byte sSlowpokeAnims_10_6
+.4byte sSlowpokeAnims_10_7
+.4byte sSlowpokeAnims_10_8
+sSlowpokeAnimTable11:
+.4byte sSlowpokeAnims_11_1
+.4byte sSlowpokeAnims_11_2
+.4byte sSlowpokeAnims_11_3
+.4byte sSlowpokeAnims_11_4
+.4byte sSlowpokeAnims_11_5
+.4byte sSlowpokeAnims_11_6
+.4byte sSlowpokeAnims_11_7
+.4byte sSlowpokeAnims_11_8
+sSlowpokeAnimTable12:
+.4byte sSlowpokeAnims_12_1
+.4byte sSlowpokeAnims_12_2
+.4byte sSlowpokeAnims_12_3
+.4byte sSlowpokeAnims_12_4
+.4byte sSlowpokeAnims_12_5
+.4byte sSlowpokeAnims_12_6
+.4byte sSlowpokeAnims_12_7
+.4byte sSlowpokeAnims_12_8
+sSlowpokeAnimTable13:
+.4byte sSlowpokeAnims_13_1
+.4byte sSlowpokeAnims_13_2
+.4byte sSlowpokeAnims_13_3
+.4byte sSlowpokeAnims_13_4
+.4byte sSlowpokeAnims_13_5
+.4byte sSlowpokeAnims_13_6
+.4byte sSlowpokeAnims_13_7
+.4byte sSlowpokeAnims_13_8
+sAxAnimationsSlowpoke:
+.4byte sSlowpokeAnimTable1
+.4byte sSlowpokeAnimTable2
+.4byte sSlowpokeAnimTable3
+.4byte sSlowpokeAnimTable4
+.4byte sSlowpokeAnimTable5
+.4byte sSlowpokeAnimTable6
+.4byte sSlowpokeAnimTable7
+.4byte sSlowpokeAnimTable8
+.4byte sSlowpokeAnimTable9
+.4byte sSlowpokeAnimTable10
+.4byte sSlowpokeAnimTable11
+.4byte sSlowpokeAnimTable12
+.4byte sSlowpokeAnimTable13
+sAxSpritesSlowpoke:
+.4byte sSlowpokeSprites1
+.4byte sSlowpokeSprites2
+.4byte sSlowpokeSprites3
+.4byte sSlowpokeSprites4
+.4byte sSlowpokeSprites5
+.4byte sSlowpokeSprites6
+.4byte sSlowpokeSprites7
+.4byte sSlowpokeSprites8
+.4byte sSlowpokeSprites9
+.4byte sSlowpokeSprites10
+.4byte sSlowpokeSprites11
+.4byte sSlowpokeSprites12
+.4byte sSlowpokeSprites13
+.4byte sSlowpokeSprites14
+.4byte sSlowpokeSprites15
+.4byte sSlowpokeSprites16
+.4byte sSlowpokeSprites17
+.4byte sSlowpokeSprites18
+.4byte sSlowpokeSprites19
+.4byte sSlowpokeSprites20
+.4byte sSlowpokeSprites21
+.4byte sSlowpokeSprites22
+.4byte sSlowpokeSprites23
+.4byte sSlowpokeSprites24
+.4byte sSlowpokeSprites25
+.4byte sSlowpokeSprites26
+.4byte sSlowpokeSprites27
+sAxMainSlowpoke:
+ax_main sAxPosesSlowpoke, sAxAnimationsSlowpoke, 13, sAxSpritesSlowpoke, sAxPositionsSlowpoke

--- a/data/ax/slugma.inc
+++ b/data/ax/slugma.inc
@@ -1,0 +1,2723 @@
+.global gAxSlugma
+gAxSlugma:
+ax_siro sAxMainSlugma
+sSlugmaPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose4:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose5:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose6:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose7:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose8:
+ax_pose 7, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose9:
+ax_pose 8, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose10:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose11:
+ax_pose 10, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose12:
+ax_pose 11, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose16:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose17:
+ax_pose 10, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose18:
+ax_pose 11, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose19:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose22:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose23:
+ax_pose 4, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose24:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose28:
+ax_pose 15, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose29:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose30:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose31:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose32:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose33:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose34:
+ax_pose 7, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose35:
+ax_pose 8, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose36:
+ax_pose 17, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose37:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose38:
+ax_pose 10, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose39:
+ax_pose 11, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose40:
+ax_pose 18, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sSlugmaPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose42:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose43:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose44:
+ax_pose 19, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose45:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose46:
+ax_pose 10, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose47:
+ax_pose 11, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose48:
+ax_pose 18, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sSlugmaPose49:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose50:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose51:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose52:
+ax_pose 17, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose53:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose54:
+ax_pose 4, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose55:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose56:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose57:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose58:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose59:
+ax_pose 2, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose60:
+ax_pose 15, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose61:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose62:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose63:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose64:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose65:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose66:
+ax_pose 7, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose67:
+ax_pose 8, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose68:
+ax_pose 17, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose69:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose70:
+ax_pose 10, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose71:
+ax_pose 11, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose72:
+ax_pose 18, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sSlugmaPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose74:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose75:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose76:
+ax_pose 19, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose77:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose78:
+ax_pose 10, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose79:
+ax_pose 11, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose80:
+ax_pose 18, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sSlugmaPose81:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose82:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose83:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose84:
+ax_pose 17, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose85:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose86:
+ax_pose 4, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose87:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose88:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose89:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose90:
+ax_pose 15, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose91:
+ax_pose 20, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose92:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose93:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose94:
+ax_pose 21, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose95:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose96:
+ax_pose 17, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose97:
+ax_pose 22, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose98:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose99:
+ax_pose 18, 0x81ea, 0x90f7, 0x0c00
+ax_pose_terminator
+sSlugmaPose100:
+ax_pose 23, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose102:
+ax_pose 19, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose103:
+ax_pose 24, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose104:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose105:
+ax_pose 18, 0x81ea, 0x80f9, 0x0c00
+ax_pose_terminator
+sSlugmaPose106:
+ax_pose 23, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose107:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose108:
+ax_pose 17, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose109:
+ax_pose 22, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose110:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose111:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose112:
+ax_pose 21, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose113:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose114:
+ax_pose 25, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose115:
+ax_pose 26, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose116:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose117:
+ax_pose 27, 0x01ea, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose118:
+ax_pose 28, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose119:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose120:
+ax_pose 29, 0x01e8, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose121:
+ax_pose 30, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose122:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose123:
+ax_pose 31, 0x01e8, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose124:
+ax_pose 32, 0x01e8, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose125:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose126:
+ax_pose 33, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose127:
+ax_pose 34, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose128:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose129:
+ax_pose 31, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose130:
+ax_pose 32, 0x01e8, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose131:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose132:
+ax_pose 29, 0x01e8, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose133:
+ax_pose 30, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose134:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose135:
+ax_pose 27, 0x01ea, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose136:
+ax_pose 28, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose137:
+ax_pose 35, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose138:
+ax_pose 36, 0x01ef, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose139:
+ax_pose 37, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sSlugmaPose140:
+ax_pose 38, 0x01ea, 0x90ef, 0x0c00
+ax_pose_terminator
+sSlugmaPose141:
+ax_pose 39, 0x01e6, 0x90ef, 0x0c00
+ax_pose_terminator
+sSlugmaPose142:
+ax_pose 40, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose143:
+ax_pose 41, 0x01e8, 0x80f1, 0x0c00
+ax_pose_terminator
+sSlugmaPose144:
+ax_pose 40, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose145:
+ax_pose 39, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSlugmaPose146:
+ax_pose 38, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sSlugmaPose147:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose148:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose149:
+ax_pose 2, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose150:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose151:
+ax_pose 4, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose152:
+ax_pose 5, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose153:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose154:
+ax_pose 7, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose155:
+ax_pose 8, 0x01eb, 0x90f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose156:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose157:
+ax_pose 10, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose158:
+ax_pose 11, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose159:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose160:
+ax_pose 13, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose161:
+ax_pose 14, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose162:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose163:
+ax_pose 10, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose164:
+ax_pose 11, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose165:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose166:
+ax_pose 7, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose167:
+ax_pose 8, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sSlugmaPose168:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose169:
+ax_pose 4, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose170:
+ax_pose 5, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose171:
+ax_pose 20, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose172:
+ax_pose 21, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose173:
+ax_pose 22, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose174:
+ax_pose 23, 0x01ee, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose175:
+ax_pose 24, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose176:
+ax_pose 23, 0x01ee, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose177:
+ax_pose 22, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose178:
+ax_pose 21, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose179:
+ax_pose 15, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose180:
+ax_pose 16, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sSlugmaPose181:
+ax_pose 17, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose182:
+ax_pose 18, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose183:
+ax_pose 19, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose184:
+ax_pose 18, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose185:
+ax_pose 17, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose186:
+ax_pose 16, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSlugmaPose187:
+ax_pose 0, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose188:
+ax_pose 1, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose189:
+ax_pose 15, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose190:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose191:
+ax_pose 4, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose192:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose193:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose194:
+ax_pose 7, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose195:
+ax_pose 17, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose196:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose197:
+ax_pose 10, 0x01ea, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose198:
+ax_pose 18, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose199:
+ax_pose 12, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose200:
+ax_pose 13, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose201:
+ax_pose 19, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose202:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose203:
+ax_pose 10, 0x01ea, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose204:
+ax_pose 18, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose205:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose206:
+ax_pose 7, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose207:
+ax_pose 17, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose208:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose209:
+ax_pose 4, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose210:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose211:
+ax_pose 15, 0x81ed, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose212:
+ax_pose 16, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose213:
+ax_pose 17, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose214:
+ax_pose 18, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose215:
+ax_pose 19, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose216:
+ax_pose 18, 0x81ea, 0x90f8, 0x0c00
+ax_pose_terminator
+sSlugmaPose217:
+ax_pose 17, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose218:
+ax_pose 16, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose219:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose220:
+ax_pose 3, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose221:
+ax_pose 6, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSlugmaPose222:
+ax_pose 9, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sSlugmaPose223:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSlugmaPose224:
+ax_pose 9, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sSlugmaPose225:
+ax_pose 6, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sSlugmaPose226:
+ax_pose 3, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sSlugmaAnims_1_1:
+ax_anim 14, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 16, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_1_2:
+ax_anim 14, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 16, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_1_3:
+ax_anim 14, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 16, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_1_4:
+ax_anim 14, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 16, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_1_5:
+ax_anim 14, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 16, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_1_6:
+ax_anim 14, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 16, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_1_7:
+ax_anim 14, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 16, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_1_8:
+ax_anim 14, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 16, 0, 23, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 17, 0, 17,
+ax_anim 2, 1, 24, -1, 17, -1, 17,
+ax_anim 2, 0, 24, 0, 17, 0, 17,
+ax_anim 2, 0, 24, -1, 17, -1, 17,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sSlugmaAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 6, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 17, 17, 17, 17,
+ax_anim 2, 1, 28, 18, 16, 18, 16,
+ax_anim 2, 0, 28, 17, 17, 17, 17,
+ax_anim 2, 0, 28, 18, 16, 18, 16,
+ax_anim 2, 0, 30, 6, 6, 6, 6,
+ax_anim_terminator
+sSlugmaAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 6, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 1, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sSlugmaAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 4, -4, 4, -4,
+ax_anim 1, 0, 37, 9, -10, 9, -10,
+ax_anim 2, 0, 36, 17, -19, 17, -19,
+ax_anim 2, 1, 36, 18, -18, 18, -18,
+ax_anim 2, 0, 36, 17, -19, 17, -19,
+ax_anim 2, 0, 36, 18, -18, 18, -18,
+ax_anim 2, 0, 38, 6, -6, 6, -6,
+ax_anim_terminator
+sSlugmaAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 6, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 41, 0, -10, 0, -10,
+ax_anim 2, 0, 40, 0, -18, 0, -18,
+ax_anim 2, 1, 40, -1, -18, -1, -18,
+ax_anim 2, 0, 40, 0, -18, 0, -18,
+ax_anim 2, 0, 40, -1, -18, -1, -18,
+ax_anim 2, 0, 42, 0, -6, 0, -6,
+ax_anim_terminator
+sSlugmaAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 6, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, -4, -4, -4,
+ax_anim 1, 0, 45, -9, -10, -9, -10,
+ax_anim 2, 0, 44, -17, -19, -17, -19,
+ax_anim 2, 1, 44, -18, -18, -18, -18,
+ax_anim 2, 0, 44, -17, -19, -17, -19,
+ax_anim 2, 0, 44, -18, -18, -18, -18,
+ax_anim 2, 0, 46, -6, -6, -6, -6,
+ax_anim_terminator
+sSlugmaAnims_2_7:
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 6, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 49, -10, 0, -10, 0,
+ax_anim 2, 0, 48, -16, 0, -16, 0,
+ax_anim 2, 1, 48, -16, 1, -16, 1,
+ax_anim 2, 0, 48, -16, 0, -16, 0,
+ax_anim 2, 0, 48, -16, 1, -16, 1,
+ax_anim 2, 0, 50, -6, 0, -6, 0,
+ax_anim_terminator
+sSlugmaAnims_2_8:
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 6, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 53, -10, 10, -10, 10,
+ax_anim 2, 0, 52, -17, 17, -17, 17,
+ax_anim 2, 1, 52, -18, 16, -18, 16,
+ax_anim 2, 0, 52, -17, 17, -17, 17,
+ax_anim 2, 0, 52, -18, 16, -18, 16,
+ax_anim 2, 0, 54, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_3_1:
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 6, 0, 59, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 17, 0, 17,
+ax_anim 2, 1, 56, -1, 17, -1, 17,
+ax_anim 2, 0, 56, 0, 17, 0, 17,
+ax_anim 2, 0, 56, -1, 17, -1, 17,
+ax_anim 2, 0, 58, 0, 6, 0, 6,
+ax_anim_terminator
+sSlugmaAnims_3_2:
+ax_anim 2, 0, 63, -1, -1, -1, -1,
+ax_anim 6, 0, 63, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 61, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 17, 17, 17, 17,
+ax_anim 2, 1, 60, 18, 16, 18, 16,
+ax_anim 2, 0, 60, 17, 17, 17, 17,
+ax_anim 2, 0, 60, 18, 16, 18, 16,
+ax_anim 2, 0, 62, 6, 6, 6, 6,
+ax_anim_terminator
+sSlugmaAnims_3_3:
+ax_anim 2, 0, 67, -1, 0, -1, 0,
+ax_anim 6, 0, 67, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 16, 0, 16, 0,
+ax_anim 2, 1, 64, 16, 1, 16, 1,
+ax_anim 2, 0, 64, 16, 0, 16, 0,
+ax_anim 2, 0, 64, 16, 1, 16, 1,
+ax_anim 2, 0, 66, 6, 0, 6, 0,
+ax_anim_terminator
+sSlugmaAnims_3_4:
+ax_anim 2, 0, 71, -1, 1, -1, 1,
+ax_anim 6, 0, 71, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 69, 4, -4, 4, -4,
+ax_anim 1, 0, 69, 9, -10, 9, -10,
+ax_anim 2, 0, 68, 17, -19, 17, -19,
+ax_anim 2, 1, 68, 18, -18, 18, -18,
+ax_anim 2, 0, 68, 17, -19, 17, -19,
+ax_anim 2, 0, 68, 18, -18, 18, -18,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim_terminator
+sSlugmaAnims_3_5:
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 6, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 73, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -18, 0, -18,
+ax_anim 2, 1, 72, -1, -18, -1, -18,
+ax_anim 2, 0, 72, 0, -18, 0, -18,
+ax_anim 2, 0, 72, -1, -18, -1, -18,
+ax_anim 2, 0, 74, 0, -6, 0, -6,
+ax_anim_terminator
+sSlugmaAnims_3_6:
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 6, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 2, 77, -4, -4, -4, -4,
+ax_anim 1, 0, 77, -9, -10, -9, -10,
+ax_anim 2, 0, 76, -17, -19, -17, -19,
+ax_anim 2, 1, 76, -18, -18, -18, -18,
+ax_anim 2, 0, 76, -17, -19, -17, -19,
+ax_anim 2, 0, 76, -18, -18, -18, -18,
+ax_anim 2, 0, 78, -6, -6, -6, -6,
+ax_anim_terminator
+sSlugmaAnims_3_7:
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 6, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 81, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -16, 0, -16, 0,
+ax_anim 2, 1, 80, -16, 1, -16, 1,
+ax_anim 2, 0, 80, -16, 0, -16, 0,
+ax_anim 2, 0, 80, -16, 1, -16, 1,
+ax_anim 2, 0, 82, -6, 0, -6, 0,
+ax_anim_terminator
+sSlugmaAnims_3_8:
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 6, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 85, -10, 10, -10, 10,
+ax_anim 2, 0, 84, -17, 17, -17, 17,
+ax_anim 2, 1, 84, -18, 16, -18, 16,
+ax_anim 2, 0, 84, -17, 17, -17, 17,
+ax_anim 2, 0, 84, -18, 16, -18, 16,
+ax_anim 2, 0, 86, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_4_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, -1, 0, -1,
+ax_anim 1, 0, 90, 0, 2, 0, 2,
+ax_anim 2, 1, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, -1, 5, -1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, -1, 5, -1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, -1, 5, -1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sSlugmaAnims_4_2:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 1, 0, 91, -1, -1, -1, -1,
+ax_anim 1, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 1, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 4, 6, 4, 6,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 4, 6, 4, 6,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 4, 6, 4, 6,
+ax_anim 2, 0, 93, 5, 5, 5, 5,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim_terminator
+sSlugmaAnims_4_3:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 1, 0, 94, -1, 0, -1, 0,
+ax_anim 1, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 1, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, 1, 5, 1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, 1, 5, 1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 96, 5, 1, 5, 1,
+ax_anim 2, 0, 96, 5, 0, 5, 0,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim_terminator
+sSlugmaAnims_4_4:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 1, 0, 97, -1, 1, -1, 1,
+ax_anim 1, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 1, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 4, -6, 4, -6,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 4, -6, 4, -6,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 99, 4, -6, 4, -6,
+ax_anim 2, 0, 99, 5, -5, 5, -5,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim_terminator
+sSlugmaAnims_4_5:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 1, 0, 100, 0, 1, 0, 1,
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 1, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, -1, -5, -1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, -1, -5, -1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 102, -1, -5, -1, -5,
+ax_anim 2, 0, 102, 0, -5, 0, -5,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sSlugmaAnims_4_6:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 1, 0, 103, 1, 1, 1, 1,
+ax_anim 1, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 1, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -4, -6, -4, -6,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -4, -6, -4, -6,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 105, -4, -6, -4, -6,
+ax_anim 2, 0, 105, -5, -5, -5, -5,
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim_terminator
+sSlugmaAnims_4_7:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 106, 1, 0, 1, 0,
+ax_anim 1, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 1, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, 1, -5, 1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, 1, -5, 1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -5, 1, -5, 1,
+ax_anim 2, 0, 108, -5, 0, -5, 0,
+ax_anim 2, 0, 106, -2, 0, -2, 0,
+ax_anim_terminator
+sSlugmaAnims_4_8:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 109, 1, -1, 1, -1,
+ax_anim 1, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 1, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -4, 6, -4, 6,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -4, 6, -4, 6,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 111, -4, 6, -4, 6,
+ax_anim 2, 0, 111, -5, 5, -5, 5,
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_5_1:
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_5_2:
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_5_3:
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_5_4:
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_5_5:
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_5_6:
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_5_7:
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_5_8:
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sSlugmaAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sSlugmaAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sSlugmaAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sSlugmaAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sSlugmaAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sSlugmaAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sSlugmaAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_8_1:
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 34, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_8_2:
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 34, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_8_3:
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 34, 0, 154, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_8_4:
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 34, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_8_5:
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 34, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_8_6:
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim 34, 0, 163, 0, 0, 0, 0,
+ax_anim 6, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_8_7:
+ax_anim 10, 0, 164, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, 0, 0, 0,
+ax_anim 34, 0, 166, 0, 0, 0, 0,
+ax_anim 6, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_8_8:
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim 6, 0, 168, 0, 0, 0, 0,
+ax_anim 34, 0, 169, 0, 0, 0, 0,
+ax_anim 6, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 3, 7, 3,
+ax_anim 2, 0, 172, 10, 8, 10, 8,
+ax_anim 2, 0, 173, 9, 15, 9, 15,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -9, 15, -9, 15,
+ax_anim 2, 0, 176, -10, 8, -10, 8,
+ax_anim 1, 0, 177, -7, 3, -7, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 10, -2, 10, -2,
+ax_anim 2, 0, 171, 18, 3, 18, 3,
+ax_anim 2, 0, 172, 22, 10, 22, 10,
+ax_anim 3, 0, 173, 22, 17, 22, 17,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 1, 12, 1, 12,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 6, -4, 6, -4,
+ax_anim 2, 0, 170, 12, -6, 12, -6,
+ax_anim 2, 0, 171, 18, -4, 18, -4,
+ax_anim 3, 0, 172, 22, 0, 22, 0,
+ax_anim 2, 3, 173, 20, 3, 20, 3,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 5, 3, 5, 3,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -8, 0, -8,
+ax_anim 2, 0, 177, 3, -13, 3, -13,
+ax_anim 2, 0, 170, 11, -21, 11, -21,
+ax_anim 3, 0, 171, 21, -24, 21, -24,
+ax_anim 2, 3, 172, 24, -15, 24, -15,
+ax_anim 2, 0, 173, 21, -5, 21, -5,
+ax_anim 1, 0, 174, 10, 2, 10, 2,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -11, -9, -11,
+ax_anim 2, 0, 177, -6, -19, -6, -19,
+ax_anim 3, 0, 170, 0, -25, 0, -25,
+ax_anim 2, 3, 171, 6, -19, 6, -19,
+ax_anim 2, 0, 172, 9, -11, 9, -11,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -8, 0, -8,
+ax_anim 2, 0, 171, -3, -13, -3, -13,
+ax_anim 2, 0, 170, -11, -21, -11, -21,
+ax_anim 3, 0, 177, -21, -24, -21, -24,
+ax_anim 2, 3, 176, -24, -15, -24, -15,
+ax_anim 2, 0, 175, -21, -5, -21, -5,
+ax_anim 1, 0, 174, -10, 2, -10, 2,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -6, -4, -6, -4,
+ax_anim 2, 0, 170, -12, -6, -12, -6,
+ax_anim 2, 0, 177, -18, -4, -18, -4,
+ax_anim 3, 0, 176, -22, 0, -22, 0,
+ax_anim 2, 3, 175, -20, 3, -20, 3,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -5, 3, -5, 3,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -10, -2, -10, -2,
+ax_anim 2, 0, 177, -18, 3, -18, 3,
+ax_anim 2, 0, 176, -22, 10, -22, 10,
+ax_anim 3, 0, 175, -22, 17, -22, 17,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -1, 12, -1, 12,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -22, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSlugmaAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSlugmaGfx1:
+.incbin "baserom.gba", 0xED94F8, 0x200
+sSlugmaSprites1:
+ax_sprite sSlugmaGfx1, 0x200
+ax_sprite_terminator
+sSlugmaGfx2:
+.incbin "baserom.gba", 0xED9708, 0x200
+sSlugmaSprites2:
+ax_sprite sSlugmaGfx2, 0x200
+ax_sprite_terminator
+sSlugmaGfx3:
+.incbin "baserom.gba", 0xED9918, 0x200
+sSlugmaSprites3:
+ax_sprite sSlugmaGfx3, 0x200
+ax_sprite_terminator
+sSlugmaGfx4:
+.incbin "baserom.gba", 0xED9B28, 0x200
+sSlugmaSprites4:
+ax_sprite sSlugmaGfx4, 0x200
+ax_sprite_terminator
+sSlugmaGfx5:
+.incbin "baserom.gba", 0xED9D38, 0x200
+sSlugmaSprites5:
+ax_sprite sSlugmaGfx5, 0x200
+ax_sprite_terminator
+sSlugmaGfx6:
+.incbin "baserom.gba", 0xED9F48, 0x200
+sSlugmaSprites6:
+ax_sprite sSlugmaGfx6, 0x200
+ax_sprite_terminator
+sSlugmaGfx7:
+.incbin "baserom.gba", 0xEDA158, 0x200
+sSlugmaSprites7:
+ax_sprite sSlugmaGfx7, 0x200
+ax_sprite_terminator
+sSlugmaGfx8:
+.incbin "baserom.gba", 0xEDA368, 0x200
+sSlugmaSprites8:
+ax_sprite sSlugmaGfx8, 0x200
+ax_sprite_terminator
+sSlugmaGfx9:
+.incbin "baserom.gba", 0xEDA578, 0x200
+sSlugmaSprites9:
+ax_sprite sSlugmaGfx9, 0x200
+ax_sprite_terminator
+sSlugmaGfx10:
+.incbin "baserom.gba", 0xEDA788, 0x200
+sSlugmaSprites10:
+ax_sprite sSlugmaGfx10, 0x200
+ax_sprite_terminator
+sSlugmaGfx11:
+.incbin "baserom.gba", 0xEDA998, 0x200
+sSlugmaSprites11:
+ax_sprite sSlugmaGfx11, 0x200
+ax_sprite_terminator
+sSlugmaGfx12:
+.incbin "baserom.gba", 0xEDABA8, 0x200
+sSlugmaSprites12:
+ax_sprite sSlugmaGfx12, 0x200
+ax_sprite_terminator
+sSlugmaGfx13:
+.incbin "baserom.gba", 0xEDADB8, 0x200
+sSlugmaSprites13:
+ax_sprite sSlugmaGfx13, 0x200
+ax_sprite_terminator
+sSlugmaGfx14:
+.incbin "baserom.gba", 0xEDAFC8, 0x200
+sSlugmaSprites14:
+ax_sprite sSlugmaGfx14, 0x200
+ax_sprite_terminator
+sSlugmaGfx15:
+.incbin "baserom.gba", 0xEDB1D8, 0x200
+sSlugmaSprites15:
+ax_sprite sSlugmaGfx15, 0x200
+ax_sprite_terminator
+sSlugmaGfx16:
+.incbin "baserom.gba", 0xEDB3E8, 0xC0
+sSlugmaSprites16:
+ax_sprite sSlugmaGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlugmaGfx17:
+.incbin "baserom.gba", 0xEDB4C0, 0x40
+sSlugmaGfx17_1:
+.incbin "baserom.gba", 0xEDB500, 0x60
+sSlugmaGfx17_2:
+.incbin "baserom.gba", 0xEDB560, 0x60
+sSlugmaSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlugmaGfx18:
+.incbin "baserom.gba", 0xEDB600, 0x60
+sSlugmaGfx18_1:
+.incbin "baserom.gba", 0xEDB660, 0x60
+sSlugmaGfx18_2:
+.incbin "baserom.gba", 0xEDB6C0, 0x60
+sSlugmaSprites18:
+ax_sprite sSlugmaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlugmaGfx19:
+.incbin "baserom.gba", 0xEDB758, 0xC0
+sSlugmaGfx19_1:
+.incbin "baserom.gba", 0xEDB818, 0x20
+sSlugmaSprites19:
+ax_sprite sSlugmaGfx19, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx19_1, 0x20
+ax_sprite_terminator
+sSlugmaGfx20:
+.incbin "baserom.gba", 0xEDB858, 0x100
+sSlugmaSprites20:
+ax_sprite sSlugmaGfx20, 0x100
+ax_sprite_terminator
+sSlugmaGfx21:
+.incbin "baserom.gba", 0xEDB968, 0x100
+sSlugmaSprites21:
+ax_sprite sSlugmaGfx21, 0x100
+ax_sprite_terminator
+sSlugmaGfx22:
+.incbin "baserom.gba", 0xEDBA78, 0x40
+sSlugmaGfx22_1:
+.incbin "baserom.gba", 0xEDBAB8, 0x60
+sSlugmaGfx22_2:
+.incbin "baserom.gba", 0xEDBB18, 0x60
+sSlugmaGfx22_3:
+.incbin "baserom.gba", 0xEDBB78, 0x20
+sSlugmaSprites22:
+ax_sprite sSlugmaGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx22_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx22_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlugmaGfx23:
+.incbin "baserom.gba", 0xEDBBE0, 0x40
+sSlugmaGfx23_1:
+.incbin "baserom.gba", 0xEDBC20, 0x60
+sSlugmaGfx23_2:
+.incbin "baserom.gba", 0xEDBC80, 0x80
+sSlugmaSprites23:
+ax_sprite sSlugmaGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx23_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSlugmaGfx24:
+.incbin "baserom.gba", 0xEDBD38, 0x40
+sSlugmaGfx24_1:
+.incbin "baserom.gba", 0xEDBD78, 0x60
+sSlugmaGfx24_2:
+.incbin "baserom.gba", 0xEDBDD8, 0x60
+sSlugmaSprites24:
+ax_sprite sSlugmaGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlugmaGfx25:
+.incbin "baserom.gba", 0xEDBE70, 0xC0
+sSlugmaSprites25:
+ax_sprite sSlugmaGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlugmaGfx26:
+.incbin "baserom.gba", 0xEDBF48, 0x100
+sSlugmaSprites26:
+ax_sprite sSlugmaGfx26, 0x100
+ax_sprite_terminator
+sSlugmaGfx27:
+.incbin "baserom.gba", 0xEDC058, 0xC0
+sSlugmaSprites27:
+ax_sprite sSlugmaGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlugmaGfx28:
+.incbin "baserom.gba", 0xEDC130, 0x40
+sSlugmaGfx28_1:
+.incbin "baserom.gba", 0xEDC170, 0x60
+sSlugmaGfx28_2:
+.incbin "baserom.gba", 0xEDC1D0, 0x60
+sSlugmaGfx28_3:
+.incbin "baserom.gba", 0xEDC230, 0x20
+sSlugmaSprites28:
+ax_sprite sSlugmaGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx28_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlugmaGfx29:
+.incbin "baserom.gba", 0xEDC298, 0x40
+sSlugmaGfx29_1:
+.incbin "baserom.gba", 0xEDC2D8, 0x60
+sSlugmaGfx29_2:
+.incbin "baserom.gba", 0xEDC338, 0x60
+sSlugmaSprites29:
+ax_sprite sSlugmaGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlugmaGfx30:
+.incbin "baserom.gba", 0xEDC3D0, 0x40
+sSlugmaGfx30_1:
+.incbin "baserom.gba", 0xEDC410, 0x40
+sSlugmaGfx30_2:
+.incbin "baserom.gba", 0xEDC450, 0x60
+sSlugmaGfx30_3:
+.incbin "baserom.gba", 0xEDC4B0, 0x60
+sSlugmaSprites30:
+ax_sprite sSlugmaGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx30_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlugmaGfx31:
+.incbin "baserom.gba", 0xEDC558, 0x40
+sSlugmaGfx31_1:
+.incbin "baserom.gba", 0xEDC598, 0x60
+sSlugmaGfx31_2:
+.incbin "baserom.gba", 0xEDC5F8, 0x60
+sSlugmaSprites31:
+ax_sprite sSlugmaGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSlugmaGfx32:
+.incbin "baserom.gba", 0xEDC690, 0x40
+sSlugmaGfx32_1:
+.incbin "baserom.gba", 0xEDC6D0, 0x60
+sSlugmaGfx32_2:
+.incbin "baserom.gba", 0xEDC730, 0x60
+sSlugmaGfx32_3:
+.incbin "baserom.gba", 0xEDC790, 0x40
+sSlugmaSprites32:
+ax_sprite sSlugmaGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlugmaGfx33:
+.incbin "baserom.gba", 0xEDC818, 0x20
+sSlugmaGfx33_1:
+.incbin "baserom.gba", 0xEDC838, 0x60
+sSlugmaGfx33_2:
+.incbin "baserom.gba", 0xEDC898, 0x60
+sSlugmaGfx33_3:
+.incbin "baserom.gba", 0xEDC8F8, 0x40
+sSlugmaSprites33:
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx33, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSlugmaGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSlugmaGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSlugmaGfx34:
+.incbin "baserom.gba", 0xEDC988, 0x100
+sSlugmaSprites34:
+ax_sprite sSlugmaGfx34, 0x100
+ax_sprite_terminator
+sSlugmaGfx35:
+.incbin "baserom.gba", 0xEDCA98, 0xC0
+sSlugmaSprites35:
+ax_sprite sSlugmaGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSlugmaGfx36:
+.incbin "baserom.gba", 0xEDCB70, 0x200
+sSlugmaSprites36:
+ax_sprite sSlugmaGfx36, 0x200
+ax_sprite_terminator
+sSlugmaGfx37:
+.incbin "baserom.gba", 0xEDCD80, 0x200
+sSlugmaSprites37:
+ax_sprite sSlugmaGfx37, 0x200
+ax_sprite_terminator
+sSlugmaGfx38:
+.incbin "baserom.gba", 0xEDCF90, 0x200
+sSlugmaSprites38:
+ax_sprite sSlugmaGfx38, 0x200
+ax_sprite_terminator
+sSlugmaGfx39:
+.incbin "baserom.gba", 0xEDD1A0, 0x200
+sSlugmaSprites39:
+ax_sprite sSlugmaGfx39, 0x200
+ax_sprite_terminator
+sSlugmaGfx40:
+.incbin "baserom.gba", 0xEDD3B0, 0x200
+sSlugmaSprites40:
+ax_sprite sSlugmaGfx40, 0x200
+ax_sprite_terminator
+sSlugmaGfx41:
+.incbin "baserom.gba", 0xEDD5C0, 0x200
+sSlugmaSprites41:
+ax_sprite sSlugmaGfx41, 0x200
+ax_sprite_terminator
+sSlugmaGfx42:
+.incbin "baserom.gba", 0xEDD7D0, 0x200
+sSlugmaSprites42:
+ax_sprite sSlugmaGfx42, 0x200
+ax_sprite_terminator
+sAxPosesSlugma:
+.4byte sSlugmaPose1
+.4byte sSlugmaPose2
+.4byte sSlugmaPose3
+.4byte sSlugmaPose4
+.4byte sSlugmaPose5
+.4byte sSlugmaPose6
+.4byte sSlugmaPose7
+.4byte sSlugmaPose8
+.4byte sSlugmaPose9
+.4byte sSlugmaPose10
+.4byte sSlugmaPose11
+.4byte sSlugmaPose12
+.4byte sSlugmaPose13
+.4byte sSlugmaPose14
+.4byte sSlugmaPose15
+.4byte sSlugmaPose16
+.4byte sSlugmaPose17
+.4byte sSlugmaPose18
+.4byte sSlugmaPose19
+.4byte sSlugmaPose20
+.4byte sSlugmaPose21
+.4byte sSlugmaPose22
+.4byte sSlugmaPose23
+.4byte sSlugmaPose24
+.4byte sSlugmaPose25
+.4byte sSlugmaPose26
+.4byte sSlugmaPose27
+.4byte sSlugmaPose28
+.4byte sSlugmaPose29
+.4byte sSlugmaPose30
+.4byte sSlugmaPose31
+.4byte sSlugmaPose32
+.4byte sSlugmaPose33
+.4byte sSlugmaPose34
+.4byte sSlugmaPose35
+.4byte sSlugmaPose36
+.4byte sSlugmaPose37
+.4byte sSlugmaPose38
+.4byte sSlugmaPose39
+.4byte sSlugmaPose40
+.4byte sSlugmaPose41
+.4byte sSlugmaPose42
+.4byte sSlugmaPose43
+.4byte sSlugmaPose44
+.4byte sSlugmaPose45
+.4byte sSlugmaPose46
+.4byte sSlugmaPose47
+.4byte sSlugmaPose48
+.4byte sSlugmaPose49
+.4byte sSlugmaPose50
+.4byte sSlugmaPose51
+.4byte sSlugmaPose52
+.4byte sSlugmaPose53
+.4byte sSlugmaPose54
+.4byte sSlugmaPose55
+.4byte sSlugmaPose56
+.4byte sSlugmaPose57
+.4byte sSlugmaPose58
+.4byte sSlugmaPose59
+.4byte sSlugmaPose60
+.4byte sSlugmaPose61
+.4byte sSlugmaPose62
+.4byte sSlugmaPose63
+.4byte sSlugmaPose64
+.4byte sSlugmaPose65
+.4byte sSlugmaPose66
+.4byte sSlugmaPose67
+.4byte sSlugmaPose68
+.4byte sSlugmaPose69
+.4byte sSlugmaPose70
+.4byte sSlugmaPose71
+.4byte sSlugmaPose72
+.4byte sSlugmaPose73
+.4byte sSlugmaPose74
+.4byte sSlugmaPose75
+.4byte sSlugmaPose76
+.4byte sSlugmaPose77
+.4byte sSlugmaPose78
+.4byte sSlugmaPose79
+.4byte sSlugmaPose80
+.4byte sSlugmaPose81
+.4byte sSlugmaPose82
+.4byte sSlugmaPose83
+.4byte sSlugmaPose84
+.4byte sSlugmaPose85
+.4byte sSlugmaPose86
+.4byte sSlugmaPose87
+.4byte sSlugmaPose88
+.4byte sSlugmaPose89
+.4byte sSlugmaPose90
+.4byte sSlugmaPose91
+.4byte sSlugmaPose92
+.4byte sSlugmaPose93
+.4byte sSlugmaPose94
+.4byte sSlugmaPose95
+.4byte sSlugmaPose96
+.4byte sSlugmaPose97
+.4byte sSlugmaPose98
+.4byte sSlugmaPose99
+.4byte sSlugmaPose100
+.4byte sSlugmaPose101
+.4byte sSlugmaPose102
+.4byte sSlugmaPose103
+.4byte sSlugmaPose104
+.4byte sSlugmaPose105
+.4byte sSlugmaPose106
+.4byte sSlugmaPose107
+.4byte sSlugmaPose108
+.4byte sSlugmaPose109
+.4byte sSlugmaPose110
+.4byte sSlugmaPose111
+.4byte sSlugmaPose112
+.4byte sSlugmaPose113
+.4byte sSlugmaPose114
+.4byte sSlugmaPose115
+.4byte sSlugmaPose116
+.4byte sSlugmaPose117
+.4byte sSlugmaPose118
+.4byte sSlugmaPose119
+.4byte sSlugmaPose120
+.4byte sSlugmaPose121
+.4byte sSlugmaPose122
+.4byte sSlugmaPose123
+.4byte sSlugmaPose124
+.4byte sSlugmaPose125
+.4byte sSlugmaPose126
+.4byte sSlugmaPose127
+.4byte sSlugmaPose128
+.4byte sSlugmaPose129
+.4byte sSlugmaPose130
+.4byte sSlugmaPose131
+.4byte sSlugmaPose132
+.4byte sSlugmaPose133
+.4byte sSlugmaPose134
+.4byte sSlugmaPose135
+.4byte sSlugmaPose136
+.4byte sSlugmaPose137
+.4byte sSlugmaPose138
+.4byte sSlugmaPose139
+.4byte sSlugmaPose140
+.4byte sSlugmaPose141
+.4byte sSlugmaPose142
+.4byte sSlugmaPose143
+.4byte sSlugmaPose144
+.4byte sSlugmaPose145
+.4byte sSlugmaPose146
+.4byte sSlugmaPose147
+.4byte sSlugmaPose148
+.4byte sSlugmaPose149
+.4byte sSlugmaPose150
+.4byte sSlugmaPose151
+.4byte sSlugmaPose152
+.4byte sSlugmaPose153
+.4byte sSlugmaPose154
+.4byte sSlugmaPose155
+.4byte sSlugmaPose156
+.4byte sSlugmaPose157
+.4byte sSlugmaPose158
+.4byte sSlugmaPose159
+.4byte sSlugmaPose160
+.4byte sSlugmaPose161
+.4byte sSlugmaPose162
+.4byte sSlugmaPose163
+.4byte sSlugmaPose164
+.4byte sSlugmaPose165
+.4byte sSlugmaPose166
+.4byte sSlugmaPose167
+.4byte sSlugmaPose168
+.4byte sSlugmaPose169
+.4byte sSlugmaPose170
+.4byte sSlugmaPose171
+.4byte sSlugmaPose172
+.4byte sSlugmaPose173
+.4byte sSlugmaPose174
+.4byte sSlugmaPose175
+.4byte sSlugmaPose176
+.4byte sSlugmaPose177
+.4byte sSlugmaPose178
+.4byte sSlugmaPose179
+.4byte sSlugmaPose180
+.4byte sSlugmaPose181
+.4byte sSlugmaPose182
+.4byte sSlugmaPose183
+.4byte sSlugmaPose184
+.4byte sSlugmaPose185
+.4byte sSlugmaPose186
+.4byte sSlugmaPose187
+.4byte sSlugmaPose188
+.4byte sSlugmaPose189
+.4byte sSlugmaPose190
+.4byte sSlugmaPose191
+.4byte sSlugmaPose192
+.4byte sSlugmaPose193
+.4byte sSlugmaPose194
+.4byte sSlugmaPose195
+.4byte sSlugmaPose196
+.4byte sSlugmaPose197
+.4byte sSlugmaPose198
+.4byte sSlugmaPose199
+.4byte sSlugmaPose200
+.4byte sSlugmaPose201
+.4byte sSlugmaPose202
+.4byte sSlugmaPose203
+.4byte sSlugmaPose204
+.4byte sSlugmaPose205
+.4byte sSlugmaPose206
+.4byte sSlugmaPose207
+.4byte sSlugmaPose208
+.4byte sSlugmaPose209
+.4byte sSlugmaPose210
+.4byte sSlugmaPose211
+.4byte sSlugmaPose212
+.4byte sSlugmaPose213
+.4byte sSlugmaPose214
+.4byte sSlugmaPose215
+.4byte sSlugmaPose216
+.4byte sSlugmaPose217
+.4byte sSlugmaPose218
+.4byte sSlugmaPose219
+.4byte sSlugmaPose220
+.4byte sSlugmaPose221
+.4byte sSlugmaPose222
+.4byte sSlugmaPose223
+.4byte sSlugmaPose224
+.4byte sSlugmaPose225
+.4byte sSlugmaPose226
+sAxPositionsSlugma:
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -2
+.2byte    0,   -3, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -5, 	  -5,    1, 	   5,    1, 	   0,   -4
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+.2byte    7,   -2, 	   7,    1, 	  -1,    0, 	   1,   -4
+.2byte    7,   -1, 	   8,    1, 	   1,    1, 	   3,   -4
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte   11,   -5, 	   4,   -4, 	   4,    0, 	   2,   -5
+.2byte   10,   -6, 	   6,   -4, 	   6,    0, 	   4,   -6
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    4,   -9, 	  -1,   -6, 	   5,   -4, 	   1,   -6
+.2byte    5,  -10, 	   2,   -7, 	   6,   -4, 	   3,   -9
+.2byte    0,   -9, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte    0,  -10, 	   4,   -7, 	  -3,   -7, 	   0,   -6
+.2byte    0,  -12, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -4, 	  -2,   -6
+.2byte   -6,  -10, 	  -3,   -7, 	  -7,   -4, 	  -4,   -9
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte  -12,   -5, 	  -5,   -4, 	  -5,    0, 	  -3,   -5
+.2byte  -11,   -6, 	  -7,   -4, 	  -7,    0, 	  -5,   -6
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -8,   -2, 	  -8,    1, 	   0,    0, 	  -2,   -4
+.2byte   -8,   -1, 	  -9,    1, 	  -2,    1, 	  -4,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -2
+.2byte    0,   -3, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -5, 	  -5,    1, 	   5,    1, 	   0,   -4
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,   -4
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+.2byte    7,   -2, 	   7,    1, 	  -1,    0, 	   1,   -4
+.2byte    7,   -1, 	   8,    1, 	   1,    1, 	   3,   -4
+.2byte    3,   -7, 	   5,   -2, 	  -3,    1, 	  -1,   -5
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte   11,   -5, 	   4,   -4, 	   4,    0, 	   2,   -5
+.2byte   10,   -6, 	   6,   -4, 	   6,    0, 	   4,   -6
+.2byte    4,  -10, 	   2,   -4, 	   2,    0, 	  -2,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    4,   -9, 	  -1,   -6, 	   5,   -4, 	   1,   -6
+.2byte    5,  -10, 	   2,   -7, 	   6,   -4, 	   3,   -9
+.2byte    0,   -9, 	  -3,   -5, 	   3,   -3, 	  -2,   -7
+.2byte    0,   -9, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte    0,  -10, 	   4,   -7, 	  -3,   -7, 	   0,   -6
+.2byte    0,  -12, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte    0,   -8, 	   4,   -6, 	  -4,   -6, 	   0,   -6
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -4, 	  -2,   -6
+.2byte   -6,  -10, 	  -3,   -7, 	  -7,   -4, 	  -4,   -9
+.2byte   -1,   -9, 	   2,   -5, 	  -4,   -3, 	   1,   -7
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte  -12,   -5, 	  -5,   -4, 	  -5,    0, 	  -3,   -5
+.2byte  -11,   -6, 	  -7,   -4, 	  -7,    0, 	  -5,   -6
+.2byte   -5,  -10, 	  -3,   -4, 	  -3,    0, 	   1,   -7
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -8,   -2, 	  -8,    1, 	   0,    0, 	  -2,   -4
+.2byte   -8,   -1, 	  -9,    1, 	  -2,    1, 	  -4,   -4
+.2byte   -4,   -7, 	  -6,   -2, 	   2,    1, 	   0,   -5
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -2
+.2byte    0,   -3, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -5, 	  -5,    1, 	   5,    1, 	   0,   -4
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,   -4
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+.2byte    7,   -2, 	   7,    1, 	  -1,    0, 	   1,   -4
+.2byte    7,   -1, 	   8,    1, 	   1,    1, 	   3,   -4
+.2byte    3,   -7, 	   5,   -2, 	  -3,    1, 	  -1,   -5
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte   11,   -5, 	   4,   -4, 	   4,    0, 	   2,   -5
+.2byte   10,   -6, 	   6,   -4, 	   6,    0, 	   4,   -6
+.2byte    4,  -10, 	   2,   -4, 	   2,    0, 	  -2,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    4,   -9, 	  -1,   -6, 	   5,   -4, 	   1,   -6
+.2byte    5,  -10, 	   2,   -7, 	   6,   -4, 	   3,   -9
+.2byte    0,   -9, 	  -3,   -5, 	   3,   -3, 	  -2,   -7
+.2byte    0,   -9, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte    0,  -10, 	   4,   -7, 	  -3,   -7, 	   0,   -6
+.2byte    0,  -12, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte    0,   -8, 	   4,   -6, 	  -4,   -6, 	   0,   -6
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -4, 	  -2,   -6
+.2byte   -6,  -10, 	  -3,   -7, 	  -7,   -4, 	  -4,   -9
+.2byte   -1,   -9, 	   2,   -5, 	  -4,   -3, 	   1,   -7
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte  -12,   -5, 	  -5,   -4, 	  -5,    0, 	  -3,   -5
+.2byte  -11,   -6, 	  -7,   -4, 	  -7,    0, 	  -5,   -6
+.2byte   -5,  -10, 	  -3,   -4, 	  -3,    0, 	   1,   -7
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -8,   -2, 	  -8,    1, 	   0,    0, 	  -2,   -4
+.2byte   -8,   -1, 	  -9,    1, 	  -2,    1, 	  -4,   -4
+.2byte   -4,   -7, 	  -6,   -2, 	   2,    1, 	   0,   -5
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -2
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,   -4
+.2byte    0,    0, 	  -4,    1, 	   4,    1, 	   0,   -1
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+.2byte    3,   -7, 	   5,   -2, 	  -3,    1, 	  -1,   -5
+.2byte    8,   -2, 	   6,   -1, 	   0,    1, 	   3,   -4
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte    4,  -10, 	   2,   -4, 	   2,    0, 	  -2,   -7
+.2byte   10,   -3, 	   4,   -4, 	   4,    0, 	   3,   -6
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    0,   -9, 	  -3,   -5, 	   3,   -3, 	  -2,   -7
+.2byte    4,   -9, 	  -1,   -6, 	   5,   -3, 	   2,   -8
+.2byte    0,   -9, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte    0,   -8, 	   4,   -6, 	  -4,   -6, 	   0,   -6
+.2byte    0,  -11, 	   4,   -7, 	  -4,   -7, 	   0,   -8
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -1,   -9, 	   2,   -5, 	  -4,   -3, 	   1,   -7
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -3, 	  -3,   -8
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte   -5,  -10, 	  -3,   -4, 	  -3,    0, 	   1,   -7
+.2byte  -11,   -3, 	  -5,   -4, 	  -5,    0, 	  -4,   -6
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -4,   -7, 	  -6,   -2, 	   2,    1, 	   0,   -5
+.2byte   -9,   -2, 	  -7,   -1, 	  -1,    1, 	  -4,   -4
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -2
+.2byte    0,   -7, 	  -5,    0, 	   4,    0, 	   0,   -5
+.2byte    0,    1, 	  -5,    2, 	   4,    2, 	   0,   -2
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+.2byte    7,   -7, 	   4,   -1, 	  -1,    0, 	   0,   -6
+.2byte    7,    0, 	   6,   -2, 	   2,    1, 	   2,   -3
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte    7,   -9, 	   3,   -4, 	   3,    0, 	   0,   -8
+.2byte    7,   -3, 	   4,   -5, 	   3,    0, 	   1,   -5
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    4,  -11, 	  -2,   -5, 	   4,   -4, 	   1,  -10
+.2byte    2,   -6, 	  -2,   -4, 	   3,   -3, 	  -1,   -6
+.2byte    0,   -9, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte    0,  -11, 	   4,   -5, 	  -3,   -5, 	   0,   -8
+.2byte    0,   -8, 	   4,   -4, 	  -4,   -4, 	   0,   -5
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -5,  -11, 	   1,   -5, 	  -5,   -4, 	  -2,  -10
+.2byte   -3,   -6, 	   1,   -4, 	  -4,   -3, 	   0,   -6
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte   -8,   -9, 	  -4,   -4, 	  -4,    0, 	  -1,   -8
+.2byte   -8,   -3, 	  -5,   -5, 	  -4,    0, 	  -2,   -5
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -8,   -7, 	  -5,   -1, 	   0,    0, 	  -1,   -6
+.2byte   -8,    0, 	  -7,   -2, 	  -3,    1, 	  -3,   -3
+.2byte   -5,    0, 	  -6,    0, 	   0,    2, 	  -2,   -2
+.2byte   -6,    0, 	  -6,    1, 	  -1,    2, 	  -2,   -1
+.2byte    0,   -4, 	  -4,    2, 	   4,    2, 	   0,   -3
+.2byte    3,   -2, 	   5,    0, 	   0,    1, 	  -1,   -5
+.2byte    4,   -6, 	   6,   -3, 	   6,    1, 	   1,   -6
+.2byte    2,   -9, 	   0,   -5, 	   7,   -4, 	   0,   -6
+.2byte    0,   -6, 	   4,   -5, 	  -4,   -5, 	   1,   -4
+.2byte   -3,   -9, 	  -1,   -5, 	  -8,   -4, 	  -1,   -6
+.2byte   -5,   -6, 	  -7,   -3, 	  -7,    1, 	  -2,   -6
+.2byte   -4,   -2, 	  -6,    0, 	  -1,    1, 	   0,   -5
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -2
+.2byte    0,   -3, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -5, 	  -5,    1, 	   5,    1, 	   0,   -4
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+.2byte    7,   -2, 	   7,    1, 	  -1,    0, 	   1,   -4
+.2byte    7,   -1, 	   8,    1, 	   1,    1, 	   3,   -4
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte   11,   -5, 	   4,   -4, 	   4,    0, 	   2,   -5
+.2byte   10,   -6, 	   6,   -4, 	   6,    0, 	   4,   -6
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    4,   -9, 	  -1,   -6, 	   5,   -4, 	   1,   -6
+.2byte    5,  -10, 	   2,   -7, 	   6,   -4, 	   3,   -9
+.2byte    0,   -9, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte    0,  -10, 	   4,   -7, 	  -3,   -7, 	   0,   -6
+.2byte    0,  -12, 	   4,   -8, 	  -4,   -8, 	   0,   -7
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -6,   -4, 	  -2,   -6
+.2byte   -6,  -10, 	  -3,   -7, 	  -7,   -4, 	  -4,   -9
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte  -12,   -5, 	  -5,   -4, 	  -5,    0, 	  -3,   -5
+.2byte  -11,   -6, 	  -7,   -4, 	  -7,    0, 	  -5,   -6
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -8,   -2, 	  -8,    1, 	   0,    0, 	  -2,   -4
+.2byte   -8,   -1, 	  -9,    1, 	  -2,    1, 	  -4,   -4
+.2byte    0,   -1, 	  -4,    0, 	   4,    0, 	   0,   -2
+.2byte   -6,   -2, 	  -4,   -1, 	   2,    1, 	  -1,   -4
+.2byte   -8,   -2, 	  -2,   -3, 	  -2,    1, 	  -1,   -5
+.2byte   -4,   -6, 	   1,   -3, 	  -5,    0, 	  -2,   -5
+.2byte    0,   -9, 	   4,   -5, 	  -4,   -5, 	   0,   -6
+.2byte    3,   -6, 	  -2,   -3, 	   4,    0, 	   1,   -5
+.2byte    7,   -2, 	   1,   -3, 	   1,    1, 	   0,   -5
+.2byte    5,   -2, 	   3,   -1, 	  -3,    1, 	   0,   -4
+.2byte    0,   -6, 	  -5,   -1, 	   5,   -1, 	   0,   -5
+.2byte    4,   -7, 	   6,   -2, 	  -2,    1, 	   0,   -5
+.2byte    5,  -10, 	   3,   -4, 	   3,    0, 	  -1,   -7
+.2byte    1,   -9, 	  -2,   -5, 	   4,   -3, 	  -1,   -7
+.2byte    0,   -9, 	   4,   -7, 	  -4,   -7, 	   0,   -7
+.2byte   -2,   -9, 	   1,   -5, 	  -5,   -3, 	   0,   -7
+.2byte   -6,  -10, 	  -4,   -4, 	  -4,    0, 	   0,   -7
+.2byte   -5,   -7, 	  -7,   -2, 	   1,    1, 	  -1,   -5
+.2byte    0,   -1, 	  -4,    1, 	   4,    1, 	   0,   -2
+.2byte    0,   -3, 	  -4,    1, 	   4,    1, 	   0,   -4
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,   -4
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+.2byte    6,   -2, 	   6,    1, 	  -2,    0, 	   0,   -4
+.2byte    3,   -7, 	   5,   -2, 	  -3,    1, 	  -1,   -5
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte    9,   -5, 	   2,   -4, 	   2,    0, 	   0,   -5
+.2byte    4,  -10, 	   2,   -4, 	   2,    0, 	  -2,   -7
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    3,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    1,   -9, 	  -2,   -5, 	   4,   -3, 	  -1,   -7
+.2byte    0,   -6, 	   4,   -2, 	  -3,   -2, 	   0,   -2
+.2byte    0,   -4, 	   4,   -1, 	  -3,   -1, 	   0,    0
+.2byte    0,   -8, 	   4,   -6, 	  -4,   -6, 	   0,   -6
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -4,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte   -2,   -9, 	   1,   -5, 	  -5,   -3, 	   0,   -7
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte  -10,   -5, 	  -3,   -4, 	  -3,    0, 	  -1,   -5
+.2byte   -5,  -10, 	  -3,   -4, 	  -3,    0, 	   1,   -7
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -7,   -2, 	  -7,    1, 	   1,    0, 	  -1,   -4
+.2byte   -4,   -7, 	  -6,   -2, 	   2,    1, 	   0,   -5
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,   -4
+.2byte   -4,   -7, 	  -6,   -2, 	   2,    1, 	   0,   -5
+.2byte   -5,  -10, 	  -3,   -4, 	  -3,    0, 	   1,   -7
+.2byte   -2,   -9, 	   1,   -5, 	  -5,   -3, 	   0,   -7
+.2byte    0,   -9, 	   4,   -7, 	  -4,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -2,   -5, 	   4,   -3, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -4, 	   3,    0, 	  -1,   -7
+.2byte    3,   -7, 	   5,   -2, 	  -3,    1, 	  -1,   -5
+.2byte    0,   -2, 	  -4,    0, 	   4,    0, 	   0,   -3
+.2byte   -7,   -2, 	  -6,    0, 	   1,    0, 	  -1,   -3
+.2byte   -9,   -6, 	  -5,   -3, 	  -3,    0, 	  -1,   -4
+.2byte   -3,   -8, 	   1,   -5, 	  -5,   -3, 	  -1,   -5
+.2byte    0,   -9, 	   4,   -5, 	  -3,   -5, 	   0,   -5
+.2byte    2,   -8, 	  -2,   -5, 	   4,   -3, 	   0,   -5
+.2byte    8,   -6, 	   4,   -3, 	   2,    0, 	   0,   -4
+.2byte    6,   -2, 	   5,    0, 	  -2,    0, 	   0,   -3
+sSlugmaAnimTable1:
+.4byte sSlugmaAnims_1_1
+.4byte sSlugmaAnims_1_2
+.4byte sSlugmaAnims_1_3
+.4byte sSlugmaAnims_1_4
+.4byte sSlugmaAnims_1_5
+.4byte sSlugmaAnims_1_6
+.4byte sSlugmaAnims_1_7
+.4byte sSlugmaAnims_1_8
+sSlugmaAnimTable2:
+.4byte sSlugmaAnims_2_1
+.4byte sSlugmaAnims_2_2
+.4byte sSlugmaAnims_2_3
+.4byte sSlugmaAnims_2_4
+.4byte sSlugmaAnims_2_5
+.4byte sSlugmaAnims_2_6
+.4byte sSlugmaAnims_2_7
+.4byte sSlugmaAnims_2_8
+sSlugmaAnimTable3:
+.4byte sSlugmaAnims_3_1
+.4byte sSlugmaAnims_3_2
+.4byte sSlugmaAnims_3_3
+.4byte sSlugmaAnims_3_4
+.4byte sSlugmaAnims_3_5
+.4byte sSlugmaAnims_3_6
+.4byte sSlugmaAnims_3_7
+.4byte sSlugmaAnims_3_8
+sSlugmaAnimTable4:
+.4byte sSlugmaAnims_4_1
+.4byte sSlugmaAnims_4_2
+.4byte sSlugmaAnims_4_3
+.4byte sSlugmaAnims_4_4
+.4byte sSlugmaAnims_4_5
+.4byte sSlugmaAnims_4_6
+.4byte sSlugmaAnims_4_7
+.4byte sSlugmaAnims_4_8
+sSlugmaAnimTable5:
+.4byte sSlugmaAnims_5_1
+.4byte sSlugmaAnims_5_2
+.4byte sSlugmaAnims_5_3
+.4byte sSlugmaAnims_5_4
+.4byte sSlugmaAnims_5_5
+.4byte sSlugmaAnims_5_6
+.4byte sSlugmaAnims_5_7
+.4byte sSlugmaAnims_5_8
+sSlugmaAnimTable6:
+.4byte sSlugmaAnims_6_1
+.4byte sSlugmaAnims_6_1
+.4byte sSlugmaAnims_6_1
+.4byte sSlugmaAnims_6_1
+.4byte sSlugmaAnims_6_1
+.4byte sSlugmaAnims_6_1
+.4byte sSlugmaAnims_6_1
+.4byte sSlugmaAnims_6_1
+sSlugmaAnimTable7:
+.4byte sSlugmaAnims_7_1
+.4byte sSlugmaAnims_7_2
+.4byte sSlugmaAnims_7_3
+.4byte sSlugmaAnims_7_4
+.4byte sSlugmaAnims_7_5
+.4byte sSlugmaAnims_7_6
+.4byte sSlugmaAnims_7_7
+.4byte sSlugmaAnims_7_8
+sSlugmaAnimTable8:
+.4byte sSlugmaAnims_8_1
+.4byte sSlugmaAnims_8_2
+.4byte sSlugmaAnims_8_3
+.4byte sSlugmaAnims_8_4
+.4byte sSlugmaAnims_8_5
+.4byte sSlugmaAnims_8_6
+.4byte sSlugmaAnims_8_7
+.4byte sSlugmaAnims_8_8
+sSlugmaAnimTable9:
+.4byte sSlugmaAnims_9_1
+.4byte sSlugmaAnims_9_2
+.4byte sSlugmaAnims_9_3
+.4byte sSlugmaAnims_9_4
+.4byte sSlugmaAnims_9_5
+.4byte sSlugmaAnims_9_6
+.4byte sSlugmaAnims_9_7
+.4byte sSlugmaAnims_9_8
+sSlugmaAnimTable10:
+.4byte sSlugmaAnims_10_1
+.4byte sSlugmaAnims_10_2
+.4byte sSlugmaAnims_10_3
+.4byte sSlugmaAnims_10_4
+.4byte sSlugmaAnims_10_5
+.4byte sSlugmaAnims_10_6
+.4byte sSlugmaAnims_10_7
+.4byte sSlugmaAnims_10_8
+sSlugmaAnimTable11:
+.4byte sSlugmaAnims_11_1
+.4byte sSlugmaAnims_11_2
+.4byte sSlugmaAnims_11_3
+.4byte sSlugmaAnims_11_4
+.4byte sSlugmaAnims_11_5
+.4byte sSlugmaAnims_11_6
+.4byte sSlugmaAnims_11_7
+.4byte sSlugmaAnims_11_8
+sSlugmaAnimTable12:
+.4byte sSlugmaAnims_12_1
+.4byte sSlugmaAnims_12_2
+.4byte sSlugmaAnims_12_3
+.4byte sSlugmaAnims_12_4
+.4byte sSlugmaAnims_12_5
+.4byte sSlugmaAnims_12_6
+.4byte sSlugmaAnims_12_7
+.4byte sSlugmaAnims_12_8
+sSlugmaAnimTable13:
+.4byte sSlugmaAnims_13_1
+.4byte sSlugmaAnims_13_2
+.4byte sSlugmaAnims_13_3
+.4byte sSlugmaAnims_13_4
+.4byte sSlugmaAnims_13_5
+.4byte sSlugmaAnims_13_6
+.4byte sSlugmaAnims_13_7
+.4byte sSlugmaAnims_13_8
+sAxAnimationsSlugma:
+.4byte sSlugmaAnimTable1
+.4byte sSlugmaAnimTable2
+.4byte sSlugmaAnimTable3
+.4byte sSlugmaAnimTable4
+.4byte sSlugmaAnimTable5
+.4byte sSlugmaAnimTable6
+.4byte sSlugmaAnimTable7
+.4byte sSlugmaAnimTable8
+.4byte sSlugmaAnimTable9
+.4byte sSlugmaAnimTable10
+.4byte sSlugmaAnimTable11
+.4byte sSlugmaAnimTable12
+.4byte sSlugmaAnimTable13
+sAxSpritesSlugma:
+.4byte sSlugmaSprites1
+.4byte sSlugmaSprites2
+.4byte sSlugmaSprites3
+.4byte sSlugmaSprites4
+.4byte sSlugmaSprites5
+.4byte sSlugmaSprites6
+.4byte sSlugmaSprites7
+.4byte sSlugmaSprites8
+.4byte sSlugmaSprites9
+.4byte sSlugmaSprites10
+.4byte sSlugmaSprites11
+.4byte sSlugmaSprites12
+.4byte sSlugmaSprites13
+.4byte sSlugmaSprites14
+.4byte sSlugmaSprites15
+.4byte sSlugmaSprites16
+.4byte sSlugmaSprites17
+.4byte sSlugmaSprites18
+.4byte sSlugmaSprites19
+.4byte sSlugmaSprites20
+.4byte sSlugmaSprites21
+.4byte sSlugmaSprites22
+.4byte sSlugmaSprites23
+.4byte sSlugmaSprites24
+.4byte sSlugmaSprites25
+.4byte sSlugmaSprites26
+.4byte sSlugmaSprites27
+.4byte sSlugmaSprites28
+.4byte sSlugmaSprites29
+.4byte sSlugmaSprites30
+.4byte sSlugmaSprites31
+.4byte sSlugmaSprites32
+.4byte sSlugmaSprites33
+.4byte sSlugmaSprites34
+.4byte sSlugmaSprites35
+.4byte sSlugmaSprites36
+.4byte sSlugmaSprites37
+.4byte sSlugmaSprites38
+.4byte sSlugmaSprites39
+.4byte sSlugmaSprites40
+.4byte sSlugmaSprites41
+.4byte sSlugmaSprites42
+sAxMainSlugma:
+ax_main sAxPosesSlugma, sAxAnimationsSlugma, 13, sAxSpritesSlugma, sAxPositionsSlugma

--- a/data/ax/smeargle.inc
+++ b/data/ax/smeargle.inc
@@ -1,0 +1,3189 @@
+.global gAxSmeargle
+gAxSmeargle:
+ax_siro sAxMainSmeargle
+sSmearglePose1:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose4:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose5:
+ax_pose 4, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose6:
+ax_pose 5, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose7:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose8:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose9:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose10:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose11:
+ax_pose 10, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose12:
+ax_pose 11, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose13:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose14:
+ax_pose 13, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose15:
+ax_pose 14, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose16:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose17:
+ax_pose 16, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose18:
+ax_pose 17, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose19:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose20:
+ax_pose 19, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose21:
+ax_pose 20, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose22:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose23:
+ax_pose 22, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose24:
+ax_pose 23, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose25:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose28:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose29:
+ax_pose 4, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose30:
+ax_pose 5, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose31:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose32:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose33:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose34:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose35:
+ax_pose 10, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose36:
+ax_pose 11, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose37:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose38:
+ax_pose 13, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose39:
+ax_pose 14, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose40:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose41:
+ax_pose 16, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose42:
+ax_pose 17, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose43:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose44:
+ax_pose 19, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose45:
+ax_pose 20, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose46:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose47:
+ax_pose 22, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose48:
+ax_pose 23, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose49:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose52:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose53:
+ax_pose 4, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose54:
+ax_pose 5, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose55:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose56:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose57:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose58:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose59:
+ax_pose 10, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose60:
+ax_pose 11, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose61:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose62:
+ax_pose 13, 0x01eb, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose63:
+ax_pose 14, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose64:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose65:
+ax_pose 16, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose66:
+ax_pose 17, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose67:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose68:
+ax_pose 19, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose69:
+ax_pose 20, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose70:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose71:
+ax_pose 22, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose72:
+ax_pose 23, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose73:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose74:
+ax_pose 24, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose75:
+ax_pose 25, 0x01e9, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose76:
+ax_pose 26, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose77:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose78:
+ax_pose 27, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose79:
+ax_pose 28, 0x01ea, 0x80f6, 0x8c00
+ax_pose_terminator
+sSmearglePose80:
+ax_pose 29, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose81:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose82:
+ax_pose 30, 0x01e9, 0x80eb, 0x8c00
+ax_pose_terminator
+sSmearglePose83:
+ax_pose 31, 0x01f4, 0x0117, 0x8c00
+ax_pose 32, 0x81e4, 0x80f7, 0x8c01
+ax_pose 33, 0x01f1, 0x4107, 0x8c09
+ax_pose_terminator
+sSmearglePose84:
+ax_pose 34, 0x01e9, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose85:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose86:
+ax_pose 35, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sSmearglePose87:
+ax_pose 36, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose88:
+ax_pose 37, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose89:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose90:
+ax_pose 38, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose91:
+ax_pose 39, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose92:
+ax_pose 40, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose93:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose94:
+ax_pose 41, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose95:
+ax_pose 42, 0x01e8, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose96:
+ax_pose 43, 0x01e8, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose97:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose98:
+ax_pose 44, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose99:
+ax_pose 45, 0x81eb, 0x80fa, 0x8c00
+ax_pose 46, 0x01ef, 0x40ea, 0x8c08
+ax_pose 47, 0x01f3, 0x00e2, 0x8c0c
+ax_pose_terminator
+sSmearglePose100:
+ax_pose 48, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose101:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose102:
+ax_pose 49, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose103:
+ax_pose 50, 0x81e8, 0x80fb, 0x8c00
+ax_pose 51, 0x81e8, 0x40f3, 0x8c08
+ax_pose 52, 0x81f8, 0x00eb, 0x8c0c
+ax_pose 53, 0x0200, 0x00e3, 0x8c0e
+ax_pose_terminator
+sSmearglePose104:
+ax_pose 54, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sSmearglePose105:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose106:
+ax_pose 24, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose107:
+ax_pose 26, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose108:
+ax_pose 55, 0x41f6, 0x80f1, 0x8c00
+ax_pose 56, 0x01e9, 0x80f0, 0x8c08
+ax_pose_terminator
+sSmearglePose109:
+ax_pose 56, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose110:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose111:
+ax_pose 27, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose112:
+ax_pose 29, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose113:
+ax_pose 57, 0x41f3, 0x80f7, 0x8c00
+ax_pose 58, 0x01e8, 0x80f4, 0x8c08
+ax_pose_terminator
+sSmearglePose114:
+ax_pose 58, 0x01e8, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose115:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose116:
+ax_pose 30, 0x01e9, 0x80eb, 0x8c00
+ax_pose_terminator
+sSmearglePose117:
+ax_pose 34, 0x01e9, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose118:
+ax_pose 59, 0x81e9, 0x8102, 0x8c00
+ax_pose 60, 0x01e8, 0x80f3, 0x8c08
+ax_pose_terminator
+sSmearglePose119:
+ax_pose 60, 0x01e8, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose120:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose121:
+ax_pose 35, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sSmearglePose122:
+ax_pose 37, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose123:
+ax_pose 61, 0x41f1, 0x80f5, 0x8c00
+ax_pose 62, 0x01e6, 0x80f1, 0x8c08
+ax_pose_terminator
+sSmearglePose124:
+ax_pose 62, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose125:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose126:
+ax_pose 38, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose127:
+ax_pose 40, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose128:
+ax_pose 63, 0x01e5, 0x80ef, 0x8c00
+ax_pose 64, 0x01e9, 0x80f0, 0x8c10
+ax_pose_terminator
+sSmearglePose129:
+ax_pose 64, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose130:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose131:
+ax_pose 41, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose132:
+ax_pose 43, 0x01e8, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose133:
+ax_pose 65, 0x81e7, 0x80f0, 0x8c00
+ax_pose 66, 0x01e8, 0x80f1, 0x8c08
+ax_pose_terminator
+sSmearglePose134:
+ax_pose 66, 0x01e8, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose135:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose136:
+ax_pose 44, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose137:
+ax_pose 48, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose138:
+ax_pose 67, 0x81e9, 0x80ed, 0x8c00
+ax_pose 68, 0x01e8, 0x80ee, 0x8c08
+ax_pose_terminator
+sSmearglePose139:
+ax_pose 68, 0x01e8, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose140:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose141:
+ax_pose 49, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose142:
+ax_pose 54, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sSmearglePose143:
+ax_pose 69, 0x01ef, 0x80ef, 0x8c00
+ax_pose 70, 0x01e7, 0x80f1, 0x8c10
+ax_pose_terminator
+sSmearglePose144:
+ax_pose 70, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose145:
+ax_pose 71, 0x01eb, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose146:
+ax_pose 72, 0x01eb, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose147:
+ax_pose 73, 0x01e1, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose148:
+ax_pose 74, 0x01e3, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose149:
+ax_pose 75, 0x01e4, 0x80ed, 0x8c00
+ax_pose_terminator
+sSmearglePose150:
+ax_pose 76, 0x01e5, 0x80ed, 0x8c00
+ax_pose_terminator
+sSmearglePose151:
+ax_pose 77, 0x01e3, 0x80f2, 0x8c00
+ax_pose_terminator
+sSmearglePose152:
+ax_pose 78, 0x01e2, 0x80f7, 0x8c00
+ax_pose_terminator
+sSmearglePose153:
+ax_pose 79, 0x01e2, 0x80f7, 0x8c00
+ax_pose_terminator
+sSmearglePose154:
+ax_pose 80, 0x01e2, 0x80f6, 0x8c00
+ax_pose_terminator
+sSmearglePose155:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose156:
+ax_pose 24, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose157:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose158:
+ax_pose 27, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose159:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose160:
+ax_pose 30, 0x01e9, 0x80ec, 0x8c00
+ax_pose_terminator
+sSmearglePose161:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose162:
+ax_pose 35, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sSmearglePose163:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose164:
+ax_pose 38, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose165:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose166:
+ax_pose 41, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose167:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose168:
+ax_pose 44, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose169:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose170:
+ax_pose 49, 0x01e7, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose171:
+ax_pose 26, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose172:
+ax_pose 54, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sSmearglePose173:
+ax_pose 48, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose174:
+ax_pose 43, 0x01e8, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose175:
+ax_pose 40, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose176:
+ax_pose 37, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose177:
+ax_pose 34, 0x01e9, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose178:
+ax_pose 29, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose179:
+ax_pose 24, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose180:
+ax_pose 49, 0x01e7, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose181:
+ax_pose 44, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose182:
+ax_pose 41, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose183:
+ax_pose 38, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose184:
+ax_pose 35, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sSmearglePose185:
+ax_pose 30, 0x01e9, 0x80ec, 0x8c00
+ax_pose_terminator
+sSmearglePose186:
+ax_pose 27, 0x01e6, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose187:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose188:
+ax_pose 24, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose189:
+ax_pose 26, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose190:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose191:
+ax_pose 27, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose192:
+ax_pose 29, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose193:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose194:
+ax_pose 30, 0x01e9, 0x80eb, 0x8c00
+ax_pose_terminator
+sSmearglePose195:
+ax_pose 34, 0x01e9, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose196:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose197:
+ax_pose 35, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sSmearglePose198:
+ax_pose 37, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose199:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose200:
+ax_pose 38, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose201:
+ax_pose 40, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose202:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose203:
+ax_pose 41, 0x01e9, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose204:
+ax_pose 43, 0x01e8, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose205:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose206:
+ax_pose 44, 0x01e9, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose207:
+ax_pose 48, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose208:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose209:
+ax_pose 49, 0x01e6, 0x80ee, 0x8c00
+ax_pose_terminator
+sSmearglePose210:
+ax_pose 54, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sSmearglePose211:
+ax_pose 25, 0x01e9, 0x80f1, 0x8c00
+ax_pose_terminator
+sSmearglePose212:
+ax_pose 28, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose213:
+ax_pose 31, 0x01f4, 0x0115, 0x8c00
+ax_pose 32, 0x81e4, 0x80f5, 0x8c01
+ax_pose 33, 0x01f1, 0x4105, 0x8c09
+ax_pose_terminator
+sSmearglePose214:
+ax_pose 36, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose215:
+ax_pose 39, 0x01e4, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose216:
+ax_pose 42, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sSmearglePose217:
+ax_pose 45, 0x81eb, 0x80fc, 0x8c00
+ax_pose 46, 0x01ef, 0x40ec, 0x8c08
+ax_pose 47, 0x01f3, 0x00e4, 0x8c0c
+ax_pose_terminator
+sSmearglePose218:
+ax_pose 50, 0x81e8, 0x80fc, 0x8c00
+ax_pose 51, 0x81e8, 0x40f4, 0x8c08
+ax_pose 52, 0x81f8, 0x00ec, 0x8c0c
+ax_pose 53, 0x0200, 0x00e4, 0x8c0e
+ax_pose_terminator
+sSmearglePose219:
+ax_pose 0, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose220:
+ax_pose 21, 0x01e6, 0x80f4, 0x8c00
+ax_pose_terminator
+sSmearglePose221:
+ax_pose 18, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSmearglePose222:
+ax_pose 15, 0x01ea, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose223:
+ax_pose 12, 0x01ea, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose224:
+ax_pose 9, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSmearglePose225:
+ax_pose 6, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSmearglePose226:
+ax_pose 3, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+.align 2
+sSmeargleAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 47, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 29, 0, 19, 0, 19,
+ax_anim 2, 1, 29, 1, 19, 1, 19,
+ax_anim 2, 0, 29, 0, 19, 0, 19,
+ax_anim 2, 0, 29, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSmeargleAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 26, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 5, 4, 5, 4,
+ax_anim 1, 0, 29, 12, 10, 12, 10,
+ax_anim 2, 0, 32, 21, 18, 21, 19,
+ax_anim 2, 1, 32, 22, 17, 22, 18,
+ax_anim 2, 0, 32, 21, 18, 21, 19,
+ax_anim 2, 0, 32, 22, 17, 22, 18,
+ax_anim 2, 0, 27, 7, 6, 7, 6,
+ax_anim_terminator
+sSmeargleAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 29, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSmeargleAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 32, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 6, -6, 6, -6,
+ax_anim 1, 0, 35, 12, -13, 12, -13,
+ax_anim 2, 0, 38, 18, -20, 18, -20,
+ax_anim 2, 1, 38, 19, -19, 19, -19,
+ax_anim 2, 0, 38, 18, -20, 18, -20,
+ax_anim 2, 0, 38, 19, -19, 19, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSmeargleAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 35, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 1, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSmeargleAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 38, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -6, -6, -6, -6,
+ax_anim 1, 0, 41, -12, -13, -12, -13,
+ax_anim 2, 0, 44, -18, -20, -18, -20,
+ax_anim 2, 1, 44, -19, -19, -19, -19,
+ax_anim 2, 0, 44, -18, -20, -18, -20,
+ax_anim 2, 0, 44, -19, -19, -19, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSmeargleAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 41, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 47, -20, 0, -20, 0,
+ax_anim 2, 1, 47, -20, 1, -20, 1,
+ax_anim 2, 0, 47, -20, 0, -20, 0,
+ax_anim 2, 0, 47, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSmeargleAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 44, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -5, 4, -5, 4,
+ax_anim 1, 0, 47, -12, 10, -12, 10,
+ax_anim 2, 0, 26, -21, 18, -21, 19,
+ax_anim 2, 1, 26, -22, 17, -22, 18,
+ax_anim 2, 0, 26, -21, 18, -21, 19,
+ax_anim 2, 0, 26, -22, 17, -22, 18,
+ax_anim 2, 0, 45, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 71, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 1, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 53, 0, 19, 0, 19,
+ax_anim 2, 0, 53, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSmeargleAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 50, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 5, 4, 5, 4,
+ax_anim 1, 0, 53, 12, 10, 12, 10,
+ax_anim 2, 0, 56, 21, 18, 21, 19,
+ax_anim 2, 1, 56, 22, 17, 22, 18,
+ax_anim 2, 0, 56, 21, 18, 21, 19,
+ax_anim 2, 0, 56, 22, 17, 22, 18,
+ax_anim 2, 0, 51, 7, 6, 7, 6,
+ax_anim_terminator
+sSmeargleAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 53, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 59, 20, 0, 20, 0,
+ax_anim 2, 1, 59, 20, 1, 20, 1,
+ax_anim 2, 0, 59, 20, 0, 20, 0,
+ax_anim 2, 0, 59, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSmeargleAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 56, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 6, -6, 6, -6,
+ax_anim 1, 0, 59, 12, -13, 12, -13,
+ax_anim 2, 0, 62, 18, -20, 18, -20,
+ax_anim 2, 1, 62, 19, -19, 19, -19,
+ax_anim 2, 0, 62, 18, -20, 18, -20,
+ax_anim 2, 0, 62, 19, -19, 19, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSmeargleAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 59, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 65, 0, -19, 0, -19,
+ax_anim 2, 1, 65, 1, -19, 1, -19,
+ax_anim 2, 0, 65, 0, -19, 0, -19,
+ax_anim 2, 0, 65, 1, -19, 1, -19,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSmeargleAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 62, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -6, -6, -6, -6,
+ax_anim 1, 0, 65, -12, -13, -12, -13,
+ax_anim 2, 0, 68, -18, -20, -18, -20,
+ax_anim 2, 1, 68, -19, -19, -19, -19,
+ax_anim 2, 0, 68, -18, -20, -18, -20,
+ax_anim 2, 0, 68, -19, -19, -19, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSmeargleAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 65, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 71, -20, 0, -20, 0,
+ax_anim 2, 1, 71, -20, 1, -20, 1,
+ax_anim 2, 0, 71, -20, 0, -20, 0,
+ax_anim 2, 0, 71, -20, 1, -20, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSmeargleAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 68, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -5, 4, -5, 4,
+ax_anim 1, 0, 71, -12, 10, -12, 10,
+ax_anim 2, 0, 50, -21, 18, -21, 19,
+ax_anim 2, 1, 50, -22, 17, -22, 18,
+ax_anim 2, 0, 50, -21, 18, -21, 19,
+ax_anim 2, 0, 50, -22, 17, -22, 18,
+ax_anim 2, 0, 69, -7, 6, -7, 6,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 1, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 0, 12, 0, 12,
+ax_anim 2, 1, 74, 0, 14, 0, 14,
+ax_anim 2, 0, 74, 1, 14, 1, 14,
+ax_anim 2, 0, 74, 0, 14, 0, 14,
+ax_anim 2, 0, 75, 0, 14, 0, 14,
+ax_anim 2, 0, 74, 0, 14, 0, 14,
+ax_anim 2, 0, 75, 0, 14, 0, 14,
+ax_anim 2, 0, 75, 0, 7, 0, 7,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim_terminator
+sSmeargleAnims_4_2:
+ax_anim 2, 0, 77, -2, -2, -2, -2,
+ax_anim 6, 2, 77, -3, -3, -3, -3,
+ax_anim 1, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 78, 6, 8, 6, 8,
+ax_anim 2, 1, 78, 10, 13, 10, 13,
+ax_anim 2, 0, 78, 11, 12, 11, 12,
+ax_anim 2, 0, 78, 10, 13, 10, 13,
+ax_anim 2, 0, 79, 10, 13, 10, 13,
+ax_anim 2, 0, 78, 10, 13, 10, 13,
+ax_anim 2, 0, 79, 10, 13, 10, 13,
+ax_anim 2, 0, 79, 5, 6, 5, 6,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sSmeargleAnims_4_3:
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 6, 2, 81, -3, 0, -3, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim 2, 1, 82, 4, 0, 4, 0,
+ax_anim 2, 0, 82, 4, 1, 4, 1,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 4, 0, 4, 0,
+ax_anim 2, 0, 83, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim_terminator
+sSmeargleAnims_4_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 6, 2, 85, -3, 3, -3, 3,
+ax_anim 1, 0, 85, 2, -3, 2, -3,
+ax_anim 2, 0, 86, 5, -8, 5, -8,
+ax_anim 2, 1, 86, 11, -17, 11, -17,
+ax_anim 2, 0, 86, 12, -16, 12, -16,
+ax_anim 2, 0, 86, 11, -17, 11, -17,
+ax_anim 2, 0, 87, 11, -17, 11, -17,
+ax_anim 2, 0, 86, 11, -17, 11, -17,
+ax_anim 2, 0, 87, 11, -17, 11, -17,
+ax_anim 2, 0, 87, 6, -8, 6, -8,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sSmeargleAnims_4_5:
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 6, 2, 89, 0, 3, 0, 3,
+ax_anim 1, 0, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 90, 0, -12, 0, -12,
+ax_anim 2, 1, 90, 0, -14, 0, -14,
+ax_anim 2, 0, 90, 1, -14, 1, -14,
+ax_anim 2, 0, 90, 0, -14, 0, -14,
+ax_anim 2, 0, 91, 0, -14, 0, -14,
+ax_anim 2, 0, 90, 0, -14, 0, -14,
+ax_anim 2, 0, 91, 0, -14, 0, -14,
+ax_anim 2, 0, 91, 0, -7, 0, -7,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim_terminator
+sSmeargleAnims_4_6:
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 6, 2, 93, 3, 3, 3, 3,
+ax_anim 1, 0, 93, -2, -3, -2, -3,
+ax_anim 2, 0, 94, -5, -8, -5, -8,
+ax_anim 2, 1, 94, -11, -17, -11, -17,
+ax_anim 2, 0, 94, -12, -16, -12, -16,
+ax_anim 2, 0, 94, -11, -17, -11, -17,
+ax_anim 2, 0, 95, -11, -17, -11, -17,
+ax_anim 2, 0, 94, -11, -17, -11, -17,
+ax_anim 2, 0, 95, -11, -17, -11, -17,
+ax_anim 2, 0, 95, -6, -8, -6, -8,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sSmeargleAnims_4_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 6, 2, 97, 3, 0, 3, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 2, 1, 98, -4, 0, -4, 0,
+ax_anim 2, 0, 98, -4, 1, -4, 1,
+ax_anim 2, 0, 98, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 98, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sSmeargleAnims_4_8:
+ax_anim 2, 0, 101, 1, -2, 1, -2,
+ax_anim 6, 2, 101, 2, -3, 2, -3,
+ax_anim 1, 0, 101, -2, 3, -2, 3,
+ax_anim 2, 0, 102, -6, 10, -6, 10,
+ax_anim 2, 1, 102, -9, 15, -9, 15,
+ax_anim 2, 0, 102, -10, 14, -10, 14,
+ax_anim 2, 0, 102, -9, 15, -9, 15,
+ax_anim 2, 0, 103, -9, 15, -9, 15,
+ax_anim 2, 0, 102, -9, 15, -9, 15,
+ax_anim 2, 0, 103, -9, 15, -9, 15,
+ax_anim 2, 0, 103, -6, 9, -6, 9,
+ax_anim 2, 0, 100, -1, 2, -1, 2,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_5_1:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, -2,
+ax_anim 6, 0, 140, 0, -3, 0, -3,
+ax_anim 1, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 2, 2, 141, 0, 2, 0, 2,
+ax_anim 2, 0, 107, 0, 2, 0, 2,
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim 2, 0, 108, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sSmeargleAnims_5_2:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 6, 0, 105, -3, -3, -3, -3,
+ax_anim 1, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 116, 2, 2, 2, 2,
+ax_anim 2, 2, 106, 2, 2, 2, 2,
+ax_anim 2, 0, 112, 2, 2, 2, 2,
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 2, 0, 113, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 1, 1, 1, 1,
+ax_anim_terminator
+sSmeargleAnims_5_3:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 6, 0, 110, -3, 0, -3, 0,
+ax_anim 1, 0, 116, -1, 0, -1, 0,
+ax_anim 2, 0, 121, 2, 0, 2, 0,
+ax_anim 2, 2, 111, 2, 0, 2, 0,
+ax_anim 2, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim_terminator
+sSmeargleAnims_5_4:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim 6, 0, 115, -3, 3, -3, 3,
+ax_anim 1, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 2, 2, 116, 2, -2, 2, -2,
+ax_anim 2, 0, 122, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -3, 3, -3,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim_terminator
+sSmeargleAnims_5_5:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 2, 0, 2,
+ax_anim 6, 0, 120, 0, 3, 0, 3,
+ax_anim 1, 0, 126, 0, 1, 0, 1,
+ax_anim 2, 0, 131, 0, -2, 0, -2,
+ax_anim 2, 2, 121, 0, -2, 0, -2,
+ax_anim 2, 0, 127, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 128, 0, -4, 0, -4,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sSmeargleAnims_5_6:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 6, 0, 125, 3, 3, 3, 3,
+ax_anim 1, 0, 131, 1, 1, 1, 1,
+ax_anim 2, 0, 136, -2, -2, -2, -2,
+ax_anim 2, 2, 126, -2, -2, -2, -2,
+ax_anim 2, 0, 132, -2, -2, -2, -2,
+ax_anim 2, 0, 133, -2, -2, -2, -2,
+ax_anim 2, 0, 133, -3, -3, -3, -3,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim_terminator
+sSmeargleAnims_5_7:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 2, 0, 2, 0,
+ax_anim 6, 0, 130, 3, 0, 3, 0,
+ax_anim 1, 0, 136, 1, 0, 1, 0,
+ax_anim 2, 0, 141, -2, 0, -2, 0,
+ax_anim 2, 2, 131, -2, 0, -2, 0,
+ax_anim 2, 0, 137, -2, 0, -2, 0,
+ax_anim 2, 0, 138, -2, 0, -2, 0,
+ax_anim 2, 0, 138, -3, 0, -3, 0,
+ax_anim 2, 0, 134, -1, 0, -1, 0,
+ax_anim_terminator
+sSmeargleAnims_5_8:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 2, -3, 2, -3,
+ax_anim 6, 0, 135, 3, -4, 3, -4,
+ax_anim 1, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 2, 2, 136, -2, 2, -2, 2,
+ax_anim 2, 0, 142, -2, 2, -2, 2,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 0, 143, -3, 3, -3, 3,
+ax_anim 2, 0, 139, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sSmeargleAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sSmeargleAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sSmeargleAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sSmeargleAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sSmeargleAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sSmeargleAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sSmeargleAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_8_1:
+ax_anim 36, 0, 154, 0, 0, 0, 0,
+ax_anim 16, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_8_2:
+ax_anim 36, 0, 156, 0, 0, 0, 0,
+ax_anim 16, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_8_3:
+ax_anim 36, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_8_4:
+ax_anim 36, 0, 160, 0, 0, 0, 0,
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_8_5:
+ax_anim 36, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_8_6:
+ax_anim 36, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_8_7:
+ax_anim 36, 0, 166, 0, 0, 0, 0,
+ax_anim 16, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_8_8:
+ax_anim 36, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 10, 8, 10,
+ax_anim 2, 0, 173, 7, 18, 7, 18,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 18, -7, 18,
+ax_anim 2, 0, 176, -8, 10, -8, 10,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 22, 11, 22, 11,
+ax_anim 3, 0, 173, 22, 20, 22, 20,
+ax_anim 2, 3, 174, 11, 20, 11, 20,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 19, -5, 19, -5,
+ax_anim 3, 0, 172, 23, -2, 23, -2,
+ax_anim 2, 3, 173, 19, 4, 19, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 23, -22, 23, -22,
+ax_anim 2, 3, 172, 23, -16, 23, -16,
+ax_anim 2, 0, 173, 19, -6, 19, -6,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -12, 9, -12,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -23, -22, -23, -22,
+ax_anim 2, 3, 176, -23, -16, -23, -16,
+ax_anim 2, 0, 175, -19, -6, -19, -6,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -19, -5, -19, -5,
+ax_anim 3, 0, 176, -23, -2, -23, -2,
+ax_anim 2, 3, 175, -19, 4, -19, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -22, 11, -22, 11,
+ax_anim 3, 0, 175, -22, 20, -22, 20,
+ax_anim 2, 3, 174, -11, 20, -11, 20,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_10_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 6, -6, 6, -6,
+ax_anim 2, 0, 185, -6, 6, -6, 6,
+ax_anim 2, 0, 185, 10, -10, 10, -10,
+ax_anim 2, 0, 185, -10, 10, -10, 10,
+ax_anim 2, 0, 185, 12, -12, 12, -12,
+ax_anim 3, 0, 185, -12, 12, -12, 12,
+ax_anim 3, 0, 185, 13, -13, 13, -13,
+ax_anim 3, 0, 185, -13, 13, -13, 13,
+ax_anim 2, 0, 185, 12, -12, 12, -12,
+ax_anim 3, 0, 185, -12, 12, -12, 12,
+ax_anim 2, 0, 185, 10, -10, 10, -10,
+ax_anim 2, 0, 185, -10, 10, -10, 10,
+ax_anim 2, 0, 185, 6, -6, 6, -6,
+ax_anim 2, 0, 185, -6, 6, -6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_10_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_10_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -6, -6, -6, -6,
+ax_anim 2, 0, 183, 6, 6, 6, 6,
+ax_anim 2, 0, 183, -10, -10, -10, -10,
+ax_anim 2, 0, 183, 10, 10, 10, 10,
+ax_anim 2, 0, 183, -12, -12, -12, -12,
+ax_anim 3, 0, 183, 12, 12, 12, 12,
+ax_anim 3, 0, 183, -13, -13, -13, -13,
+ax_anim 3, 0, 183, 13, 13, 13, 13,
+ax_anim 2, 0, 183, -12, -12, -12, -12,
+ax_anim 3, 0, 183, 12, 12, 12, 12,
+ax_anim 2, 0, 183, -10, -10, -10, -10,
+ax_anim 2, 0, 183, 10, 10, 10, 10,
+ax_anim 2, 0, 183, -6, -6, -6, -6,
+ax_anim 2, 0, 183, 6, 6, 6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_10_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 6, -6, 6, -6,
+ax_anim 2, 0, 181, -6, 6, -6, 6,
+ax_anim 2, 0, 181, 10, -10, 10, -10,
+ax_anim 2, 0, 181, -10, 10, -10, 10,
+ax_anim 2, 0, 181, 12, -12, 12, -12,
+ax_anim 3, 0, 181, -12, 12, -12, 12,
+ax_anim 3, 0, 181, 13, -13, 13, -13,
+ax_anim 3, 0, 181, -13, 13, -13, 13,
+ax_anim 2, 0, 181, 12, -12, 12, -12,
+ax_anim 3, 0, 181, -12, 12, -12, 12,
+ax_anim 2, 0, 181, 10, -10, 10, -10,
+ax_anim 2, 0, 181, -10, 10, -10, 10,
+ax_anim 2, 0, 181, 6, -6, 6, -6,
+ax_anim 2, 0, 181, -6, 6, -6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_10_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_10_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 3, 0, 179, -13, -13, -13, -13,
+ax_anim 3, 0, 179, 13, 13, 13, 13,
+ax_anim 2, 0, 179, -12, -12, -12, -12,
+ax_anim 3, 0, 179, 12, 12, 12, 12,
+ax_anim 2, 0, 179, -10, -10, -10, -10,
+ax_anim 2, 0, 179, 10, 10, 10, 10,
+ax_anim 2, 0, 179, -6, -6, -6, -6,
+ax_anim 2, 0, 179, 6, 6, 6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -22, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -19, 0, 0,
+ax_anim 4, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_12_2:
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 1, -1, 1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_12_3:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_12_4:
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -1, -1, -1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_12_6:
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, -1, 1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_12_7:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_12_8:
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -1, -1, -1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmeargleAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSmeargleGfx1:
+.incbin "baserom.gba", 0xF8693C, 0x200
+sSmeargleSprites1:
+ax_sprite sSmeargleGfx1, 0x200
+ax_sprite_terminator
+sSmeargleGfx2:
+.incbin "baserom.gba", 0xF86B4C, 0x200
+sSmeargleSprites2:
+ax_sprite sSmeargleGfx2, 0x200
+ax_sprite_terminator
+sSmeargleGfx3:
+.incbin "baserom.gba", 0xF86D5C, 0x200
+sSmeargleSprites3:
+ax_sprite sSmeargleGfx3, 0x200
+ax_sprite_terminator
+sSmeargleGfx4:
+.incbin "baserom.gba", 0xF86F6C, 0x200
+sSmeargleSprites4:
+ax_sprite sSmeargleGfx4, 0x200
+ax_sprite_terminator
+sSmeargleGfx5:
+.incbin "baserom.gba", 0xF8717C, 0x200
+sSmeargleSprites5:
+ax_sprite sSmeargleGfx5, 0x200
+ax_sprite_terminator
+sSmeargleGfx6:
+.incbin "baserom.gba", 0xF8738C, 0x200
+sSmeargleSprites6:
+ax_sprite sSmeargleGfx6, 0x200
+ax_sprite_terminator
+sSmeargleGfx7:
+.incbin "baserom.gba", 0xF8759C, 0x200
+sSmeargleSprites7:
+ax_sprite sSmeargleGfx7, 0x200
+ax_sprite_terminator
+sSmeargleGfx8:
+.incbin "baserom.gba", 0xF877AC, 0x200
+sSmeargleSprites8:
+ax_sprite sSmeargleGfx8, 0x200
+ax_sprite_terminator
+sSmeargleGfx9:
+.incbin "baserom.gba", 0xF879BC, 0x200
+sSmeargleSprites9:
+ax_sprite sSmeargleGfx9, 0x200
+ax_sprite_terminator
+sSmeargleGfx10:
+.incbin "baserom.gba", 0xF87BCC, 0x200
+sSmeargleSprites10:
+ax_sprite sSmeargleGfx10, 0x200
+ax_sprite_terminator
+sSmeargleGfx11:
+.incbin "baserom.gba", 0xF87DDC, 0x200
+sSmeargleSprites11:
+ax_sprite sSmeargleGfx11, 0x200
+ax_sprite_terminator
+sSmeargleGfx12:
+.incbin "baserom.gba", 0xF87FEC, 0x200
+sSmeargleSprites12:
+ax_sprite sSmeargleGfx12, 0x200
+ax_sprite_terminator
+sSmeargleGfx13:
+.incbin "baserom.gba", 0xF881FC, 0x200
+sSmeargleSprites13:
+ax_sprite sSmeargleGfx13, 0x200
+ax_sprite_terminator
+sSmeargleGfx14:
+.incbin "baserom.gba", 0xF8840C, 0x200
+sSmeargleSprites14:
+ax_sprite sSmeargleGfx14, 0x200
+ax_sprite_terminator
+sSmeargleGfx15:
+.incbin "baserom.gba", 0xF8861C, 0x200
+sSmeargleSprites15:
+ax_sprite sSmeargleGfx15, 0x200
+ax_sprite_terminator
+sSmeargleGfx16:
+.incbin "baserom.gba", 0xF8882C, 0x200
+sSmeargleSprites16:
+ax_sprite sSmeargleGfx16, 0x200
+ax_sprite_terminator
+sSmeargleGfx17:
+.incbin "baserom.gba", 0xF88A3C, 0x200
+sSmeargleSprites17:
+ax_sprite sSmeargleGfx17, 0x200
+ax_sprite_terminator
+sSmeargleGfx18:
+.incbin "baserom.gba", 0xF88C4C, 0x200
+sSmeargleSprites18:
+ax_sprite sSmeargleGfx18, 0x200
+ax_sprite_terminator
+sSmeargleGfx19:
+.incbin "baserom.gba", 0xF88E5C, 0x200
+sSmeargleSprites19:
+ax_sprite sSmeargleGfx19, 0x200
+ax_sprite_terminator
+sSmeargleGfx20:
+.incbin "baserom.gba", 0xF8906C, 0x200
+sSmeargleSprites20:
+ax_sprite sSmeargleGfx20, 0x200
+ax_sprite_terminator
+sSmeargleGfx21:
+.incbin "baserom.gba", 0xF8927C, 0x200
+sSmeargleSprites21:
+ax_sprite sSmeargleGfx21, 0x200
+ax_sprite_terminator
+sSmeargleGfx22:
+.incbin "baserom.gba", 0xF8948C, 0x200
+sSmeargleSprites22:
+ax_sprite sSmeargleGfx22, 0x200
+ax_sprite_terminator
+sSmeargleGfx23:
+.incbin "baserom.gba", 0xF8969C, 0x200
+sSmeargleSprites23:
+ax_sprite sSmeargleGfx23, 0x200
+ax_sprite_terminator
+sSmeargleGfx24:
+.incbin "baserom.gba", 0xF898AC, 0x200
+sSmeargleSprites24:
+ax_sprite sSmeargleGfx24, 0x200
+ax_sprite_terminator
+sSmeargleGfx25:
+.incbin "baserom.gba", 0xF89ABC, 0x40
+sSmeargleGfx25_1:
+.incbin "baserom.gba", 0xF89AFC, 0x100
+sSmeargleGfx25_2:
+.incbin "baserom.gba", 0xF89BFC, 0x40
+sSmeargleSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx26:
+.incbin "baserom.gba", 0xF89C7C, 0x40
+sSmeargleGfx26_1:
+.incbin "baserom.gba", 0xF89CBC, 0xE0
+sSmeargleGfx26_2:
+.incbin "baserom.gba", 0xF89D9C, 0x60
+sSmeargleSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx26_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx27:
+.incbin "baserom.gba", 0xF89E3C, 0x40
+sSmeargleGfx27_1:
+.incbin "baserom.gba", 0xF89E7C, 0x80
+sSmeargleGfx27_2:
+.incbin "baserom.gba", 0xF89EFC, 0x60
+sSmeargleGfx27_3:
+.incbin "baserom.gba", 0xF89F5C, 0x40
+sSmeargleSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx28:
+.incbin "baserom.gba", 0xF89FEC, 0x40
+sSmeargleGfx28_1:
+.incbin "baserom.gba", 0xF8A02C, 0x40
+sSmeargleGfx28_2:
+.incbin "baserom.gba", 0xF8A06C, 0x60
+sSmeargleGfx28_3:
+.incbin "baserom.gba", 0xF8A0CC, 0x60
+sSmeargleSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx28_3, 0x60
+ax_sprite_terminator
+sSmeargleGfx29:
+.incbin "baserom.gba", 0xF8A174, 0x60
+sSmeargleGfx29_1:
+.incbin "baserom.gba", 0xF8A1D4, 0x60
+sSmeargleGfx29_2:
+.incbin "baserom.gba", 0xF8A234, 0x80
+sSmeargleGfx29_3:
+.incbin "baserom.gba", 0xF8A2B4, 0x60
+sSmeargleSprites29:
+ax_sprite sSmeargleGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx29_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx29_3, 0x60
+ax_sprite_terminator
+sSmeargleGfx30:
+.incbin "baserom.gba", 0xF8A354, 0x40
+sSmeargleGfx30_1:
+.incbin "baserom.gba", 0xF8A394, 0x40
+sSmeargleGfx30_2:
+.incbin "baserom.gba", 0xF8A3D4, 0x60
+sSmeargleGfx30_3:
+.incbin "baserom.gba", 0xF8A434, 0x60
+sSmeargleSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx30_3, 0x60
+ax_sprite_terminator
+sSmeargleGfx31:
+.incbin "baserom.gba", 0xF8A4DC, 0x60
+sSmeargleGfx31_1:
+.incbin "baserom.gba", 0xF8A53C, 0x60
+sSmeargleGfx31_2:
+.incbin "baserom.gba", 0xF8A59C, 0x60
+sSmeargleGfx31_3:
+.incbin "baserom.gba", 0xF8A5FC, 0x40
+sSmeargleSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx32:
+.incbin "baserom.gba", 0xF8A68C, 0x20
+sSmeargleSprites32:
+ax_sprite sSmeargleGfx32, 0x20
+ax_sprite_terminator
+sSmeargleGfx33:
+.incbin "baserom.gba", 0xF8A6BC, 0x20
+sSmeargleGfx33_1:
+.incbin "baserom.gba", 0xF8A6DC, 0xC0
+sSmeargleSprites33:
+ax_sprite sSmeargleGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx33_1, 0xc0
+ax_sprite_terminator
+sSmeargleGfx34:
+.incbin "baserom.gba", 0xF8A7BC, 0x80
+sSmeargleSprites34:
+ax_sprite sSmeargleGfx34, 0x80
+ax_sprite_terminator
+sSmeargleGfx35:
+.incbin "baserom.gba", 0xF8A84C, 0x60
+sSmeargleGfx35_1:
+.incbin "baserom.gba", 0xF8A8AC, 0x140
+sSmeargleSprites35:
+ax_sprite sSmeargleGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx35_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmeargleGfx36:
+.incbin "baserom.gba", 0xF8AA14, 0x20
+sSmeargleGfx36_1:
+.incbin "baserom.gba", 0xF8AA34, 0x60
+sSmeargleGfx36_2:
+.incbin "baserom.gba", 0xF8AA94, 0x60
+sSmeargleGfx36_3:
+.incbin "baserom.gba", 0xF8AAF4, 0x60
+sSmeargleSprites36:
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx36_3, 0x60
+ax_sprite_terminator
+sSmeargleGfx37:
+.incbin "baserom.gba", 0xF8AB9C, 0x20
+sSmeargleGfx37_1:
+.incbin "baserom.gba", 0xF8ABBC, 0x140
+sSmeargleSprites37:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx37, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx37_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmeargleGfx38:
+.incbin "baserom.gba", 0xF8AD2C, 0x40
+sSmeargleGfx38_1:
+.incbin "baserom.gba", 0xF8AD6C, 0xE0
+sSmeargleGfx38_2:
+.incbin "baserom.gba", 0xF8AE4C, 0x40
+sSmeargleSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx38_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx39:
+.incbin "baserom.gba", 0xF8AECC, 0x40
+sSmeargleGfx39_1:
+.incbin "baserom.gba", 0xF8AF0C, 0x60
+sSmeargleGfx39_2:
+.incbin "baserom.gba", 0xF8AF6C, 0x60
+sSmeargleGfx39_3:
+.incbin "baserom.gba", 0xF8AFCC, 0x40
+sSmeargleSprites39:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx40:
+.incbin "baserom.gba", 0xF8B05C, 0x40
+sSmeargleGfx40_1:
+.incbin "baserom.gba", 0xF8B09C, 0x160
+sSmeargleSprites40:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx40_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx41:
+.incbin "baserom.gba", 0xF8B22C, 0x40
+sSmeargleGfx41_1:
+.incbin "baserom.gba", 0xF8B26C, 0xE0
+sSmeargleGfx41_2:
+.incbin "baserom.gba", 0xF8B34C, 0x40
+sSmeargleSprites41:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx41_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx41_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx42:
+.incbin "baserom.gba", 0xF8B3CC, 0x40
+sSmeargleGfx42_1:
+.incbin "baserom.gba", 0xF8B40C, 0x60
+sSmeargleGfx42_2:
+.incbin "baserom.gba", 0xF8B46C, 0x60
+sSmeargleGfx42_3:
+.incbin "baserom.gba", 0xF8B4CC, 0x60
+sSmeargleSprites42:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx42, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx42_3, 0x60
+ax_sprite_terminator
+sSmeargleGfx43:
+.incbin "baserom.gba", 0xF8B574, 0x60
+sSmeargleGfx43_1:
+.incbin "baserom.gba", 0xF8B5D4, 0x80
+sSmeargleGfx43_2:
+.incbin "baserom.gba", 0xF8B654, 0x60
+sSmeargleGfx43_3:
+.incbin "baserom.gba", 0xF8B6B4, 0x40
+sSmeargleSprites43:
+ax_sprite sSmeargleGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx43_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx43_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx44:
+.incbin "baserom.gba", 0xF8B73C, 0x40
+sSmeargleGfx44_1:
+.incbin "baserom.gba", 0xF8B77C, 0x60
+sSmeargleGfx44_2:
+.incbin "baserom.gba", 0xF8B7DC, 0x40
+sSmeargleGfx44_3:
+.incbin "baserom.gba", 0xF8B81C, 0x40
+sSmeargleSprites44:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx44_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx44_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx45:
+.incbin "baserom.gba", 0xF8B8AC, 0x40
+sSmeargleGfx45_1:
+.incbin "baserom.gba", 0xF8B8EC, 0x100
+sSmeargleGfx45_2:
+.incbin "baserom.gba", 0xF8B9EC, 0x60
+sSmeargleSprites45:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx45_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx45_2, 0x60
+ax_sprite_terminator
+sSmeargleGfx46:
+.incbin "baserom.gba", 0xF8BA84, 0xC0
+sSmeargleSprites46:
+ax_sprite sSmeargleGfx46, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmeargleGfx47:
+.incbin "baserom.gba", 0xF8BB5C, 0x80
+sSmeargleSprites47:
+ax_sprite sSmeargleGfx47, 0x80
+ax_sprite_terminator
+sSmeargleGfx48:
+.incbin "baserom.gba", 0xF8BBEC, 0x20
+sSmeargleSprites48:
+ax_sprite sSmeargleGfx48, 0x20
+ax_sprite_terminator
+sSmeargleGfx49:
+.incbin "baserom.gba", 0xF8BC1C, 0x40
+sSmeargleGfx49_1:
+.incbin "baserom.gba", 0xF8BC5C, 0x60
+sSmeargleGfx49_2:
+.incbin "baserom.gba", 0xF8BCBC, 0x80
+sSmeargleGfx49_3:
+.incbin "baserom.gba", 0xF8BD3C, 0x40
+sSmeargleSprites49:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx49_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx49_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx50:
+.incbin "baserom.gba", 0xF8BDCC, 0x40
+sSmeargleGfx50_1:
+.incbin "baserom.gba", 0xF8BE0C, 0x60
+sSmeargleGfx50_2:
+.incbin "baserom.gba", 0xF8BE6C, 0x60
+sSmeargleGfx50_3:
+.incbin "baserom.gba", 0xF8BECC, 0x60
+sSmeargleSprites50:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx50, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx50_3, 0x60
+ax_sprite_terminator
+sSmeargleGfx51:
+.incbin "baserom.gba", 0xF8BF74, 0x100
+sSmeargleSprites51:
+ax_sprite sSmeargleGfx51, 0x100
+ax_sprite_terminator
+sSmeargleGfx52:
+.incbin "baserom.gba", 0xF8C084, 0x60
+sSmeargleSprites52:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx52, 0x60
+ax_sprite_terminator
+sSmeargleGfx53:
+.incbin "baserom.gba", 0xF8C0FC, 0x40
+sSmeargleSprites53:
+ax_sprite sSmeargleGfx53, 0x40
+ax_sprite_terminator
+sSmeargleGfx54:
+.incbin "baserom.gba", 0xF8C14C, 0x20
+sSmeargleSprites54:
+ax_sprite sSmeargleGfx54, 0x20
+ax_sprite_terminator
+sSmeargleGfx55:
+.incbin "baserom.gba", 0xF8C17C, 0x40
+sSmeargleGfx55_1:
+.incbin "baserom.gba", 0xF8C1BC, 0x60
+sSmeargleGfx55_2:
+.incbin "baserom.gba", 0xF8C21C, 0xE0
+sSmeargleSprites55:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx55, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx55_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx56:
+.incbin "baserom.gba", 0xF8C33C, 0x60
+sSmeargleGfx56_1:
+.incbin "baserom.gba", 0xF8C39C, 0x60
+sSmeargleSprites56:
+ax_sprite sSmeargleGfx56, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx56_1, 0x60
+ax_sprite_terminator
+sSmeargleGfx57:
+.incbin "baserom.gba", 0xF8C41C, 0x40
+sSmeargleGfx57_1:
+.incbin "baserom.gba", 0xF8C45C, 0x100
+sSmeargleGfx57_2:
+.incbin "baserom.gba", 0xF8C55C, 0x60
+sSmeargleSprites57:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx57, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx57_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx57_2, 0x60
+ax_sprite_terminator
+sSmeargleGfx58:
+.incbin "baserom.gba", 0xF8C5F4, 0x60
+sSmeargleGfx58_1:
+.incbin "baserom.gba", 0xF8C654, 0x40
+sSmeargleSprites58:
+ax_sprite sSmeargleGfx58, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx58_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx59:
+.incbin "baserom.gba", 0xF8C6BC, 0x40
+sSmeargleGfx59_1:
+.incbin "baserom.gba", 0xF8C6FC, 0x60
+sSmeargleGfx59_2:
+.incbin "baserom.gba", 0xF8C75C, 0x60
+sSmeargleGfx59_3:
+.incbin "baserom.gba", 0xF8C7BC, 0x40
+sSmeargleSprites59:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx59_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx59_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx59_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmeargleGfx60:
+.incbin "baserom.gba", 0xF8C84C, 0x20
+sSmeargleGfx60_1:
+.incbin "baserom.gba", 0xF8C86C, 0xC0
+sSmeargleSprites60:
+ax_sprite sSmeargleGfx60, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx60_1, 0xc0
+ax_sprite_terminator
+sSmeargleGfx61:
+.incbin "baserom.gba", 0xF8C94C, 0x60
+sSmeargleGfx61_1:
+.incbin "baserom.gba", 0xF8C9AC, 0x60
+sSmeargleGfx61_2:
+.incbin "baserom.gba", 0xF8CA0C, 0x60
+sSmeargleGfx61_3:
+.incbin "baserom.gba", 0xF8CA6C, 0x60
+sSmeargleSprites61:
+ax_sprite sSmeargleGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx61_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx61_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx61_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx62:
+.incbin "baserom.gba", 0xF8CB14, 0x20
+sSmeargleGfx62_1:
+.incbin "baserom.gba", 0xF8CB34, 0xC0
+sSmeargleSprites62:
+ax_sprite sSmeargleGfx62, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx62_1, 0xc0
+ax_sprite_terminator
+sSmeargleGfx63:
+.incbin "baserom.gba", 0xF8CC14, 0x40
+sSmeargleGfx63_1:
+.incbin "baserom.gba", 0xF8CC54, 0x40
+sSmeargleGfx63_2:
+.incbin "baserom.gba", 0xF8CC94, 0x40
+sSmeargleGfx63_3:
+.incbin "baserom.gba", 0xF8CCD4, 0x40
+sSmeargleSprites63:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx63, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx63_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx63_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx63_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx64:
+.incbin "baserom.gba", 0xF8CD64, 0x140
+sSmeargleSprites64:
+ax_sprite 0, 0x80
+ax_sprite sSmeargleGfx64, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmeargleGfx65:
+.incbin "baserom.gba", 0xF8CEC4, 0x40
+sSmeargleGfx65_1:
+.incbin "baserom.gba", 0xF8CF04, 0x40
+sSmeargleGfx65_2:
+.incbin "baserom.gba", 0xF8CF44, 0x60
+sSmeargleGfx65_3:
+.incbin "baserom.gba", 0xF8CFA4, 0x40
+sSmeargleSprites65:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx65, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx65_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx65_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx65_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx66:
+.incbin "baserom.gba", 0xF8D034, 0x80
+sSmeargleSprites66:
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx66, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmeargleGfx67:
+.incbin "baserom.gba", 0xF8D0D4, 0x40
+sSmeargleGfx67_1:
+.incbin "baserom.gba", 0xF8D114, 0x40
+sSmeargleGfx67_2:
+.incbin "baserom.gba", 0xF8D154, 0x60
+sSmeargleGfx67_3:
+.incbin "baserom.gba", 0xF8D1B4, 0x40
+sSmeargleSprites67:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx67, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx67_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx67_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx67_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx68:
+.incbin "baserom.gba", 0xF8D244, 0xC0
+sSmeargleSprites68:
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx68, 0xc0
+ax_sprite_terminator
+sSmeargleGfx69:
+.incbin "baserom.gba", 0xF8D31C, 0x40
+sSmeargleGfx69_1:
+.incbin "baserom.gba", 0xF8D35C, 0x140
+sSmeargleSprites69:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx69, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx69_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx70:
+.incbin "baserom.gba", 0xF8D4CC, 0x40
+sSmeargleGfx70_1:
+.incbin "baserom.gba", 0xF8D50C, 0x60
+sSmeargleGfx70_2:
+.incbin "baserom.gba", 0xF8D56C, 0x60
+sSmeargleSprites70:
+ax_sprite sSmeargleGfx70, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx70_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx70_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmeargleGfx71:
+.incbin "baserom.gba", 0xF8D604, 0x40
+sSmeargleGfx71_1:
+.incbin "baserom.gba", 0xF8D644, 0x40
+sSmeargleGfx71_2:
+.incbin "baserom.gba", 0xF8D684, 0x60
+sSmeargleGfx71_3:
+.incbin "baserom.gba", 0xF8D6E4, 0x40
+sSmeargleSprites71:
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx71, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx71_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmeargleGfx71_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmeargleGfx71_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSmeargleGfx72:
+.incbin "baserom.gba", 0xF8D774, 0x200
+sSmeargleSprites72:
+ax_sprite sSmeargleGfx72, 0x200
+ax_sprite_terminator
+sSmeargleGfx73:
+.incbin "baserom.gba", 0xF8D984, 0x200
+sSmeargleSprites73:
+ax_sprite sSmeargleGfx73, 0x200
+ax_sprite_terminator
+sSmeargleGfx74:
+.incbin "baserom.gba", 0xF8DB94, 0x200
+sSmeargleSprites74:
+ax_sprite sSmeargleGfx74, 0x200
+ax_sprite_terminator
+sSmeargleGfx75:
+.incbin "baserom.gba", 0xF8DDA4, 0x200
+sSmeargleSprites75:
+ax_sprite sSmeargleGfx75, 0x200
+ax_sprite_terminator
+sSmeargleGfx76:
+.incbin "baserom.gba", 0xF8DFB4, 0x200
+sSmeargleSprites76:
+ax_sprite sSmeargleGfx76, 0x200
+ax_sprite_terminator
+sSmeargleGfx77:
+.incbin "baserom.gba", 0xF8E1C4, 0x200
+sSmeargleSprites77:
+ax_sprite sSmeargleGfx77, 0x200
+ax_sprite_terminator
+sSmeargleGfx78:
+.incbin "baserom.gba", 0xF8E3D4, 0x200
+sSmeargleSprites78:
+ax_sprite sSmeargleGfx78, 0x200
+ax_sprite_terminator
+sSmeargleGfx79:
+.incbin "baserom.gba", 0xF8E5E4, 0x200
+sSmeargleSprites79:
+ax_sprite sSmeargleGfx79, 0x200
+ax_sprite_terminator
+sSmeargleGfx80:
+.incbin "baserom.gba", 0xF8E7F4, 0x200
+sSmeargleSprites80:
+ax_sprite sSmeargleGfx80, 0x200
+ax_sprite_terminator
+sSmeargleGfx81:
+.incbin "baserom.gba", 0xF8EA04, 0x200
+sSmeargleSprites81:
+ax_sprite sSmeargleGfx81, 0x200
+ax_sprite_terminator
+sAxPosesSmeargle:
+.4byte sSmearglePose1
+.4byte sSmearglePose2
+.4byte sSmearglePose3
+.4byte sSmearglePose4
+.4byte sSmearglePose5
+.4byte sSmearglePose6
+.4byte sSmearglePose7
+.4byte sSmearglePose8
+.4byte sSmearglePose9
+.4byte sSmearglePose10
+.4byte sSmearglePose11
+.4byte sSmearglePose12
+.4byte sSmearglePose13
+.4byte sSmearglePose14
+.4byte sSmearglePose15
+.4byte sSmearglePose16
+.4byte sSmearglePose17
+.4byte sSmearglePose18
+.4byte sSmearglePose19
+.4byte sSmearglePose20
+.4byte sSmearglePose21
+.4byte sSmearglePose22
+.4byte sSmearglePose23
+.4byte sSmearglePose24
+.4byte sSmearglePose25
+.4byte sSmearglePose26
+.4byte sSmearglePose27
+.4byte sSmearglePose28
+.4byte sSmearglePose29
+.4byte sSmearglePose30
+.4byte sSmearglePose31
+.4byte sSmearglePose32
+.4byte sSmearglePose33
+.4byte sSmearglePose34
+.4byte sSmearglePose35
+.4byte sSmearglePose36
+.4byte sSmearglePose37
+.4byte sSmearglePose38
+.4byte sSmearglePose39
+.4byte sSmearglePose40
+.4byte sSmearglePose41
+.4byte sSmearglePose42
+.4byte sSmearglePose43
+.4byte sSmearglePose44
+.4byte sSmearglePose45
+.4byte sSmearglePose46
+.4byte sSmearglePose47
+.4byte sSmearglePose48
+.4byte sSmearglePose49
+.4byte sSmearglePose50
+.4byte sSmearglePose51
+.4byte sSmearglePose52
+.4byte sSmearglePose53
+.4byte sSmearglePose54
+.4byte sSmearglePose55
+.4byte sSmearglePose56
+.4byte sSmearglePose57
+.4byte sSmearglePose58
+.4byte sSmearglePose59
+.4byte sSmearglePose60
+.4byte sSmearglePose61
+.4byte sSmearglePose62
+.4byte sSmearglePose63
+.4byte sSmearglePose64
+.4byte sSmearglePose65
+.4byte sSmearglePose66
+.4byte sSmearglePose67
+.4byte sSmearglePose68
+.4byte sSmearglePose69
+.4byte sSmearglePose70
+.4byte sSmearglePose71
+.4byte sSmearglePose72
+.4byte sSmearglePose73
+.4byte sSmearglePose74
+.4byte sSmearglePose75
+.4byte sSmearglePose76
+.4byte sSmearglePose77
+.4byte sSmearglePose78
+.4byte sSmearglePose79
+.4byte sSmearglePose80
+.4byte sSmearglePose81
+.4byte sSmearglePose82
+.4byte sSmearglePose83
+.4byte sSmearglePose84
+.4byte sSmearglePose85
+.4byte sSmearglePose86
+.4byte sSmearglePose87
+.4byte sSmearglePose88
+.4byte sSmearglePose89
+.4byte sSmearglePose90
+.4byte sSmearglePose91
+.4byte sSmearglePose92
+.4byte sSmearglePose93
+.4byte sSmearglePose94
+.4byte sSmearglePose95
+.4byte sSmearglePose96
+.4byte sSmearglePose97
+.4byte sSmearglePose98
+.4byte sSmearglePose99
+.4byte sSmearglePose100
+.4byte sSmearglePose101
+.4byte sSmearglePose102
+.4byte sSmearglePose103
+.4byte sSmearglePose104
+.4byte sSmearglePose105
+.4byte sSmearglePose106
+.4byte sSmearglePose107
+.4byte sSmearglePose108
+.4byte sSmearglePose109
+.4byte sSmearglePose110
+.4byte sSmearglePose111
+.4byte sSmearglePose112
+.4byte sSmearglePose113
+.4byte sSmearglePose114
+.4byte sSmearglePose115
+.4byte sSmearglePose116
+.4byte sSmearglePose117
+.4byte sSmearglePose118
+.4byte sSmearglePose119
+.4byte sSmearglePose120
+.4byte sSmearglePose121
+.4byte sSmearglePose122
+.4byte sSmearglePose123
+.4byte sSmearglePose124
+.4byte sSmearglePose125
+.4byte sSmearglePose126
+.4byte sSmearglePose127
+.4byte sSmearglePose128
+.4byte sSmearglePose129
+.4byte sSmearglePose130
+.4byte sSmearglePose131
+.4byte sSmearglePose132
+.4byte sSmearglePose133
+.4byte sSmearglePose134
+.4byte sSmearglePose135
+.4byte sSmearglePose136
+.4byte sSmearglePose137
+.4byte sSmearglePose138
+.4byte sSmearglePose139
+.4byte sSmearglePose140
+.4byte sSmearglePose141
+.4byte sSmearglePose142
+.4byte sSmearglePose143
+.4byte sSmearglePose144
+.4byte sSmearglePose145
+.4byte sSmearglePose146
+.4byte sSmearglePose147
+.4byte sSmearglePose148
+.4byte sSmearglePose149
+.4byte sSmearglePose150
+.4byte sSmearglePose151
+.4byte sSmearglePose152
+.4byte sSmearglePose153
+.4byte sSmearglePose154
+.4byte sSmearglePose155
+.4byte sSmearglePose156
+.4byte sSmearglePose157
+.4byte sSmearglePose158
+.4byte sSmearglePose159
+.4byte sSmearglePose160
+.4byte sSmearglePose161
+.4byte sSmearglePose162
+.4byte sSmearglePose163
+.4byte sSmearglePose164
+.4byte sSmearglePose165
+.4byte sSmearglePose166
+.4byte sSmearglePose167
+.4byte sSmearglePose168
+.4byte sSmearglePose169
+.4byte sSmearglePose170
+.4byte sSmearglePose171
+.4byte sSmearglePose172
+.4byte sSmearglePose173
+.4byte sSmearglePose174
+.4byte sSmearglePose175
+.4byte sSmearglePose176
+.4byte sSmearglePose177
+.4byte sSmearglePose178
+.4byte sSmearglePose179
+.4byte sSmearglePose180
+.4byte sSmearglePose181
+.4byte sSmearglePose182
+.4byte sSmearglePose183
+.4byte sSmearglePose184
+.4byte sSmearglePose185
+.4byte sSmearglePose186
+.4byte sSmearglePose187
+.4byte sSmearglePose188
+.4byte sSmearglePose189
+.4byte sSmearglePose190
+.4byte sSmearglePose191
+.4byte sSmearglePose192
+.4byte sSmearglePose193
+.4byte sSmearglePose194
+.4byte sSmearglePose195
+.4byte sSmearglePose196
+.4byte sSmearglePose197
+.4byte sSmearglePose198
+.4byte sSmearglePose199
+.4byte sSmearglePose200
+.4byte sSmearglePose201
+.4byte sSmearglePose202
+.4byte sSmearglePose203
+.4byte sSmearglePose204
+.4byte sSmearglePose205
+.4byte sSmearglePose206
+.4byte sSmearglePose207
+.4byte sSmearglePose208
+.4byte sSmearglePose209
+.4byte sSmearglePose210
+.4byte sSmearglePose211
+.4byte sSmearglePose212
+.4byte sSmearglePose213
+.4byte sSmearglePose214
+.4byte sSmearglePose215
+.4byte sSmearglePose216
+.4byte sSmearglePose217
+.4byte sSmearglePose218
+.4byte sSmearglePose219
+.4byte sSmearglePose220
+.4byte sSmearglePose221
+.4byte sSmearglePose222
+.4byte sSmearglePose223
+.4byte sSmearglePose224
+.4byte sSmearglePose225
+.4byte sSmearglePose226
+sAxPositionsSmeargle:
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte    1,   -7, 	  -9,   -8, 	   4,   -3, 	   0,   -6
+.2byte   -1,   -7, 	  -9,   -5, 	   7,   -4, 	   0,   -6
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+.2byte    4,   -8, 	  -8,   -7, 	   7,   -3, 	   1,   -7
+.2byte    5,   -9, 	  -5,   -6, 	  -1,   -5, 	   1,   -7
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    5,   -9, 	  -6,   -5, 	   6,   -3, 	   1,   -7
+.2byte    4,  -10, 	   3,   -5, 	  -7,   -3, 	   0,   -7
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    6,  -11, 	   4,   -4, 	   0,   -5, 	   1,   -9
+.2byte    4,  -10, 	   7,   -7, 	  -7,   -5, 	   0,   -8
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte   -1,  -10, 	  10,   -7, 	  -6,   -6, 	   0,   -8
+.2byte    1,  -10, 	   9,  -10, 	  -6,   -4, 	   1,   -8
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte   -6,  -11, 	   8,  -10, 	  -6,   -6, 	  -1,   -9
+.2byte   -4,  -11, 	   0,  -10, 	   1,   -3, 	   0,   -8
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -5,   -9, 	   0,   -9, 	  -4,   -3, 	   0,   -6
+.2byte   -6,  -10, 	  -8,   -7, 	   6,   -3, 	  -1,   -7
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -3,   -8, 	  -5,   -6, 	   0,   -2, 	  -1,   -7
+.2byte   -4,   -9, 	  -9,   -7, 	   9,   -5, 	   0,   -7
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte    1,   -7, 	  -9,   -8, 	   4,   -3, 	   0,   -6
+.2byte   -1,   -7, 	  -9,   -5, 	   7,   -4, 	   0,   -6
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+.2byte    4,   -8, 	  -8,   -7, 	   7,   -3, 	   1,   -7
+.2byte    5,   -9, 	  -5,   -6, 	  -1,   -5, 	   1,   -7
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    5,   -9, 	  -6,   -5, 	   6,   -3, 	   1,   -7
+.2byte    4,  -10, 	   3,   -5, 	  -7,   -3, 	   0,   -7
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    6,  -11, 	   4,   -4, 	   0,   -5, 	   1,   -9
+.2byte    4,  -10, 	   7,   -7, 	  -7,   -5, 	   0,   -8
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte   -1,  -10, 	  10,   -7, 	  -6,   -6, 	   0,   -8
+.2byte    1,  -10, 	   9,  -10, 	  -6,   -4, 	   1,   -8
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte   -6,  -11, 	   8,  -10, 	  -6,   -6, 	  -1,   -9
+.2byte   -4,  -11, 	   0,  -10, 	   1,   -3, 	   0,   -8
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -5,   -9, 	   0,   -9, 	  -4,   -3, 	   0,   -6
+.2byte   -6,  -10, 	  -8,   -7, 	   6,   -3, 	  -1,   -7
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -3,   -8, 	  -5,   -6, 	   0,   -2, 	  -1,   -7
+.2byte   -4,   -9, 	  -9,   -7, 	   9,   -5, 	   0,   -7
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte    1,   -7, 	  -9,   -8, 	   4,   -3, 	   0,   -6
+.2byte   -1,   -7, 	  -9,   -5, 	   7,   -4, 	   0,   -6
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+.2byte    4,   -8, 	  -8,   -7, 	   7,   -3, 	   1,   -7
+.2byte    5,   -9, 	  -5,   -6, 	  -1,   -5, 	   1,   -7
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    5,   -9, 	  -6,   -5, 	   6,   -3, 	   1,   -7
+.2byte    4,  -10, 	   3,   -5, 	  -7,   -3, 	   0,   -7
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    6,  -11, 	   4,   -4, 	   0,   -5, 	   1,   -9
+.2byte    4,  -10, 	   7,   -7, 	  -7,   -5, 	   0,   -8
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte   -1,  -10, 	  10,   -7, 	  -6,   -6, 	   0,   -8
+.2byte    1,  -10, 	   9,  -10, 	  -6,   -4, 	   1,   -8
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte   -6,  -11, 	   8,  -10, 	  -6,   -6, 	  -1,   -9
+.2byte   -4,  -11, 	   0,  -10, 	   1,   -3, 	   0,   -8
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -5,   -9, 	   0,   -9, 	  -4,   -3, 	   0,   -6
+.2byte   -6,  -10, 	  -8,   -7, 	   6,   -3, 	  -1,   -7
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -3,   -8, 	  -5,   -6, 	   0,   -2, 	  -1,   -7
+.2byte   -4,   -9, 	  -9,   -7, 	   9,   -5, 	   0,   -7
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte   -1,  -10, 	  -7,   -5, 	   6,   -8, 	   0,   -8
+.2byte   -4,    7, 	  -5,   -5, 	  10,  -10, 	   0,   -7
+.2byte   -4,   -2, 	  -5,   -5, 	  10,  -10, 	   0,   -7
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+.2byte    3,  -10, 	  -6,   -4, 	   7,   -8, 	   0,   -7
+.2byte   17,    8, 	   1,   -2, 	   3,   -7, 	   0,   -7
+.2byte    8,    0, 	   1,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    3,  -11, 	  -5,   -3, 	   6,  -11, 	  -1,   -6
+.2byte   27,   -8, 	   7,   -5, 	   1,  -10, 	   0,   -8
+.2byte   14,   -7, 	   6,   -6, 	  -3,   -6, 	   0,   -7
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    4,  -12, 	  -3,   -3, 	   3,   -6, 	   0,   -7
+.2byte   19,  -17, 	   5,   -7, 	  -8,   -9, 	   0,  -10
+.2byte   10,  -11, 	   5,   -7, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte    0,  -12, 	   4,   -2, 	  -5,  -12, 	   0,   -5
+.2byte    5,  -23, 	   7,   -6, 	  -8,   -4, 	   0,   -7
+.2byte    7,  -10, 	   6,   -6, 	  -8,   -4, 	   0,   -7
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte   -5,  -12, 	   6,   -3, 	  -7,  -10, 	   0,   -8
+.2byte  -17,  -19, 	  -4,   -8, 	  -5,   -3, 	   0,   -8
+.2byte  -10,  -13, 	  -5,   -9, 	  -5,   -3, 	   0,   -8
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -2,  -10, 	   6,   -7, 	  -9,   -9, 	   1,   -6
+.2byte  -26,   -9, 	  -7,   -7, 	   4,   -4, 	   1,   -8
+.2byte  -14,   -8, 	  -6,   -7, 	   4,   -4, 	   1,   -7
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -4,  -11, 	   1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte  -21,    6, 	  -7,   -6, 	   8,   -7, 	  -1,   -7
+.2byte  -11,   -2, 	  -8,   -5, 	   8,   -7, 	  -1,   -7
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte   -1,  -10, 	  -7,   -5, 	   6,   -8, 	   0,   -8
+.2byte   -4,   -2, 	  -5,   -5, 	  10,  -10, 	   0,   -7
+.2byte   -1,   -8, 	  -1,    0, 	   7,   -8, 	  -1,   -7
+.2byte   -1,   -8, 	  -1,    0, 	   7,   -8, 	  -1,   -7
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+.2byte    3,  -10, 	  -6,   -4, 	   7,   -8, 	   0,   -7
+.2byte    8,    0, 	   1,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    4,   -9, 	   2,   -3, 	  -3,   -6, 	  -1,   -8
+.2byte    4,   -9, 	   2,   -3, 	  -3,   -6, 	  -1,   -8
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    3,  -11, 	  -5,   -3, 	   6,  -11, 	  -1,   -6
+.2byte   14,   -7, 	   6,   -6, 	  -3,   -6, 	   0,   -7
+.2byte    4,  -10, 	   4,   -3, 	  -8,   -5, 	  -1,   -9
+.2byte    4,  -10, 	   4,   -3, 	  -8,   -5, 	  -1,   -9
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    4,  -12, 	  -3,   -3, 	   3,   -6, 	   0,   -7
+.2byte   10,  -11, 	   5,   -7, 	  -8,   -8, 	   0,   -9
+.2byte    5,  -12, 	   5,   -7, 	  -5,   -5, 	   0,  -11
+.2byte    5,  -12, 	   5,   -7, 	  -5,   -5, 	   0,  -11
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte    0,  -12, 	   4,   -2, 	  -5,  -12, 	   0,   -5
+.2byte    7,  -10, 	   6,   -6, 	  -8,   -4, 	   0,   -7
+.2byte    0,  -10, 	  -3,   -4, 	  -7,   -3, 	   0,   -7
+.2byte    0,  -10, 	  -3,   -4, 	  -7,   -3, 	   0,   -7
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte   -5,  -12, 	   6,   -3, 	  -7,  -10, 	   0,   -8
+.2byte  -10,  -13, 	  -5,   -9, 	  -5,   -3, 	   0,   -8
+.2byte   -4,  -11, 	  -3,   -7, 	  -1,   -3, 	   1,   -9
+.2byte   -4,  -11, 	  -3,   -7, 	  -1,   -3, 	   1,   -9
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -2,  -10, 	   6,   -7, 	  -9,   -9, 	   1,   -6
+.2byte  -14,   -8, 	  -6,   -7, 	   4,   -4, 	   1,   -7
+.2byte   -4,   -9, 	  -5,   -3, 	   3,   -2, 	   0,   -7
+.2byte   -4,   -9, 	  -5,   -3, 	   3,   -2, 	   0,   -7
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -4,  -11, 	   1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte  -11,   -2, 	  -8,   -5, 	   8,   -7, 	  -1,   -7
+.2byte   -3,   -8, 	  -5,   -3, 	   8,   -6, 	   0,   -7
+.2byte   -3,   -8, 	  -5,   -3, 	   8,   -6, 	   0,   -7
+.2byte   -2,   -8, 	  -4,   -5, 	   5,    1, 	   2,   -7
+.2byte   -2,   -7, 	  -4,   -5, 	   5,    1, 	   2,   -5
+.2byte    0,  -12, 	 -11,  -13, 	   9,  -13, 	   0,   -8
+.2byte    1,  -12, 	  -9,  -11, 	   2,  -15, 	   0,   -8
+.2byte    1,  -13, 	  -8,  -10, 	  -6,  -16, 	  -1,   -8
+.2byte    2,  -13, 	   4,  -11, 	 -10,  -16, 	  -1,   -6
+.2byte    0,  -10, 	  11,  -10, 	 -11,  -11, 	   0,   -7
+.2byte   -2,  -12, 	   5,  -13, 	  -4,  -11, 	   1,   -7
+.2byte    0,  -11, 	   5,  -12, 	   9,   -9, 	   2,   -8
+.2byte    1,  -11, 	  -4,  -14, 	  10,  -12, 	   2,   -8
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte   -2,  -10, 	  -8,   -5, 	   5,   -8, 	  -1,   -8
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+.2byte    3,  -10, 	  -6,   -4, 	   7,   -8, 	   0,   -7
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    4,  -11, 	  -4,   -3, 	   7,  -11, 	   0,   -6
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    4,  -12, 	  -3,   -3, 	   3,   -6, 	   0,   -7
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte    0,  -14, 	   4,   -4, 	  -5,  -14, 	   0,   -7
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte   -5,  -12, 	   6,   -3, 	  -7,  -10, 	   0,   -8
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -3,  -10, 	   5,   -7, 	 -10,   -9, 	   0,   -6
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -4,  -10, 	   1,  -11, 	  -5,   -8, 	  -1,   -8
+.2byte   -4,   -2, 	  -5,   -5, 	  10,  -10, 	   0,   -7
+.2byte  -11,   -2, 	  -8,   -5, 	   8,   -7, 	  -1,   -7
+.2byte  -15,   -8, 	  -7,   -7, 	   3,   -4, 	   0,   -7
+.2byte  -10,  -13, 	  -5,   -9, 	  -5,   -3, 	   0,   -8
+.2byte    7,  -11, 	   6,   -7, 	  -8,   -5, 	   0,   -8
+.2byte   10,  -10, 	   5,   -6, 	  -8,   -7, 	   0,   -8
+.2byte   14,   -7, 	   6,   -6, 	  -3,   -6, 	   0,   -7
+.2byte    8,    0, 	   1,   -2, 	   3,   -7, 	  -1,   -7
+.2byte   -1,  -10, 	  -7,   -5, 	   6,   -8, 	   0,   -8
+.2byte   -4,  -10, 	   1,  -11, 	  -5,   -8, 	  -1,   -8
+.2byte   -3,  -10, 	   5,   -7, 	 -10,   -9, 	   0,   -6
+.2byte   -5,  -12, 	   6,   -3, 	  -7,  -10, 	   0,   -8
+.2byte    0,  -14, 	   4,   -4, 	  -5,  -14, 	   0,   -7
+.2byte    4,  -12, 	  -3,   -3, 	   3,   -6, 	   0,   -7
+.2byte    4,  -11, 	  -4,   -3, 	   7,  -11, 	   0,   -6
+.2byte    4,  -10, 	  -5,   -4, 	   8,   -8, 	   1,   -7
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte   -1,  -10, 	  -7,   -5, 	   6,   -8, 	   0,   -8
+.2byte   -4,   -4, 	  -5,   -7, 	  10,  -12, 	   0,   -9
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+.2byte    3,  -10, 	  -6,   -4, 	   7,   -8, 	   0,   -7
+.2byte    8,    0, 	   1,   -2, 	   3,   -7, 	  -1,   -7
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    3,  -11, 	  -5,   -3, 	   6,  -11, 	  -1,   -6
+.2byte   14,   -7, 	   6,   -6, 	  -3,   -6, 	   0,   -7
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    4,  -12, 	  -3,   -3, 	   3,   -6, 	   0,   -7
+.2byte   10,  -11, 	   5,   -7, 	  -8,   -8, 	   0,   -9
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte    0,  -12, 	   4,   -2, 	  -5,  -12, 	   0,   -5
+.2byte    7,  -10, 	   6,   -6, 	  -8,   -4, 	   0,   -7
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte   -5,  -12, 	   6,   -3, 	  -7,  -10, 	   0,   -8
+.2byte  -10,  -13, 	  -5,   -9, 	  -5,   -3, 	   0,   -8
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -2,  -10, 	   6,   -7, 	  -9,   -9, 	   1,   -6
+.2byte  -14,   -8, 	  -6,   -7, 	   4,   -4, 	   1,   -7
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -4,  -11, 	   1,  -12, 	  -5,   -9, 	  -1,   -9
+.2byte  -11,   -2, 	  -8,   -5, 	   8,   -7, 	  -1,   -7
+.2byte   -4,    7, 	  -5,   -5, 	  10,  -10, 	   0,   -7
+.2byte   16,    8, 	   0,   -2, 	   2,   -7, 	  -1,   -7
+.2byte   25,   -8, 	   5,   -5, 	  -1,  -10, 	  -2,   -8
+.2byte   18,  -16, 	   4,   -6, 	  -9,   -8, 	  -1,   -9
+.2byte    5,  -24, 	   7,   -7, 	  -8,   -5, 	   0,   -8
+.2byte  -16,  -19, 	  -3,   -8, 	  -4,   -3, 	   1,   -8
+.2byte  -24,   -9, 	  -5,   -7, 	   6,   -4, 	   3,   -8
+.2byte  -20,    6, 	  -6,   -6, 	   9,   -7, 	   0,   -7
+.2byte    0,   -9, 	 -11,   -7, 	   7,   -3, 	   0,   -8
+.2byte   -3,  -10, 	  -8,  -10, 	   5,   -2, 	   0,   -8
+.2byte   -4,  -10, 	  -3,  -11, 	   2,   -2, 	  -1,   -7
+.2byte   -5,  -12, 	   6,  -12, 	  -5,   -3, 	   0,   -8
+.2byte    0,  -12, 	  11,   -8, 	  -7,   -4, 	   0,  -10
+.2byte    5,  -12, 	   7,   -6, 	  -5,   -5, 	   1,  -10
+.2byte    5,  -11, 	  -4,   -6, 	   1,   -5, 	   1,   -8
+.2byte    4,  -10, 	  -8,   -6, 	   5,   -4, 	   1,   -9
+sSmeargleAnimTable1:
+.4byte sSmeargleAnims_1_1
+.4byte sSmeargleAnims_1_2
+.4byte sSmeargleAnims_1_3
+.4byte sSmeargleAnims_1_4
+.4byte sSmeargleAnims_1_5
+.4byte sSmeargleAnims_1_6
+.4byte sSmeargleAnims_1_7
+.4byte sSmeargleAnims_1_8
+sSmeargleAnimTable2:
+.4byte sSmeargleAnims_2_1
+.4byte sSmeargleAnims_2_2
+.4byte sSmeargleAnims_2_3
+.4byte sSmeargleAnims_2_4
+.4byte sSmeargleAnims_2_5
+.4byte sSmeargleAnims_2_6
+.4byte sSmeargleAnims_2_7
+.4byte sSmeargleAnims_2_8
+sSmeargleAnimTable3:
+.4byte sSmeargleAnims_3_1
+.4byte sSmeargleAnims_3_2
+.4byte sSmeargleAnims_3_3
+.4byte sSmeargleAnims_3_4
+.4byte sSmeargleAnims_3_5
+.4byte sSmeargleAnims_3_6
+.4byte sSmeargleAnims_3_7
+.4byte sSmeargleAnims_3_8
+sSmeargleAnimTable4:
+.4byte sSmeargleAnims_4_1
+.4byte sSmeargleAnims_4_2
+.4byte sSmeargleAnims_4_3
+.4byte sSmeargleAnims_4_4
+.4byte sSmeargleAnims_4_5
+.4byte sSmeargleAnims_4_6
+.4byte sSmeargleAnims_4_7
+.4byte sSmeargleAnims_4_8
+sSmeargleAnimTable5:
+.4byte sSmeargleAnims_5_1
+.4byte sSmeargleAnims_5_2
+.4byte sSmeargleAnims_5_3
+.4byte sSmeargleAnims_5_4
+.4byte sSmeargleAnims_5_5
+.4byte sSmeargleAnims_5_6
+.4byte sSmeargleAnims_5_7
+.4byte sSmeargleAnims_5_8
+sSmeargleAnimTable6:
+.4byte sSmeargleAnims_6_1
+.4byte sSmeargleAnims_6_1
+.4byte sSmeargleAnims_6_1
+.4byte sSmeargleAnims_6_1
+.4byte sSmeargleAnims_6_1
+.4byte sSmeargleAnims_6_1
+.4byte sSmeargleAnims_6_1
+.4byte sSmeargleAnims_6_1
+sSmeargleAnimTable7:
+.4byte sSmeargleAnims_7_1
+.4byte sSmeargleAnims_7_2
+.4byte sSmeargleAnims_7_3
+.4byte sSmeargleAnims_7_4
+.4byte sSmeargleAnims_7_5
+.4byte sSmeargleAnims_7_6
+.4byte sSmeargleAnims_7_7
+.4byte sSmeargleAnims_7_8
+sSmeargleAnimTable8:
+.4byte sSmeargleAnims_8_1
+.4byte sSmeargleAnims_8_2
+.4byte sSmeargleAnims_8_3
+.4byte sSmeargleAnims_8_4
+.4byte sSmeargleAnims_8_5
+.4byte sSmeargleAnims_8_6
+.4byte sSmeargleAnims_8_7
+.4byte sSmeargleAnims_8_8
+sSmeargleAnimTable9:
+.4byte sSmeargleAnims_9_1
+.4byte sSmeargleAnims_9_2
+.4byte sSmeargleAnims_9_3
+.4byte sSmeargleAnims_9_4
+.4byte sSmeargleAnims_9_5
+.4byte sSmeargleAnims_9_6
+.4byte sSmeargleAnims_9_7
+.4byte sSmeargleAnims_9_8
+sSmeargleAnimTable10:
+.4byte sSmeargleAnims_10_1
+.4byte sSmeargleAnims_10_2
+.4byte sSmeargleAnims_10_3
+.4byte sSmeargleAnims_10_4
+.4byte sSmeargleAnims_10_5
+.4byte sSmeargleAnims_10_6
+.4byte sSmeargleAnims_10_7
+.4byte sSmeargleAnims_10_8
+sSmeargleAnimTable11:
+.4byte sSmeargleAnims_11_1
+.4byte sSmeargleAnims_11_2
+.4byte sSmeargleAnims_11_3
+.4byte sSmeargleAnims_11_4
+.4byte sSmeargleAnims_11_5
+.4byte sSmeargleAnims_11_6
+.4byte sSmeargleAnims_11_7
+.4byte sSmeargleAnims_11_8
+sSmeargleAnimTable12:
+.4byte sSmeargleAnims_12_1
+.4byte sSmeargleAnims_12_2
+.4byte sSmeargleAnims_12_3
+.4byte sSmeargleAnims_12_4
+.4byte sSmeargleAnims_12_5
+.4byte sSmeargleAnims_12_6
+.4byte sSmeargleAnims_12_7
+.4byte sSmeargleAnims_12_8
+sSmeargleAnimTable13:
+.4byte sSmeargleAnims_13_1
+.4byte sSmeargleAnims_13_2
+.4byte sSmeargleAnims_13_3
+.4byte sSmeargleAnims_13_4
+.4byte sSmeargleAnims_13_5
+.4byte sSmeargleAnims_13_6
+.4byte sSmeargleAnims_13_7
+.4byte sSmeargleAnims_13_8
+sAxAnimationsSmeargle:
+.4byte sSmeargleAnimTable1
+.4byte sSmeargleAnimTable2
+.4byte sSmeargleAnimTable3
+.4byte sSmeargleAnimTable4
+.4byte sSmeargleAnimTable5
+.4byte sSmeargleAnimTable6
+.4byte sSmeargleAnimTable7
+.4byte sSmeargleAnimTable8
+.4byte sSmeargleAnimTable9
+.4byte sSmeargleAnimTable10
+.4byte sSmeargleAnimTable11
+.4byte sSmeargleAnimTable12
+.4byte sSmeargleAnimTable13
+sAxSpritesSmeargle:
+.4byte sSmeargleSprites1
+.4byte sSmeargleSprites2
+.4byte sSmeargleSprites3
+.4byte sSmeargleSprites4
+.4byte sSmeargleSprites5
+.4byte sSmeargleSprites6
+.4byte sSmeargleSprites7
+.4byte sSmeargleSprites8
+.4byte sSmeargleSprites9
+.4byte sSmeargleSprites10
+.4byte sSmeargleSprites11
+.4byte sSmeargleSprites12
+.4byte sSmeargleSprites13
+.4byte sSmeargleSprites14
+.4byte sSmeargleSprites15
+.4byte sSmeargleSprites16
+.4byte sSmeargleSprites17
+.4byte sSmeargleSprites18
+.4byte sSmeargleSprites19
+.4byte sSmeargleSprites20
+.4byte sSmeargleSprites21
+.4byte sSmeargleSprites22
+.4byte sSmeargleSprites23
+.4byte sSmeargleSprites24
+.4byte sSmeargleSprites25
+.4byte sSmeargleSprites26
+.4byte sSmeargleSprites27
+.4byte sSmeargleSprites28
+.4byte sSmeargleSprites29
+.4byte sSmeargleSprites30
+.4byte sSmeargleSprites31
+.4byte sSmeargleSprites32
+.4byte sSmeargleSprites33
+.4byte sSmeargleSprites34
+.4byte sSmeargleSprites35
+.4byte sSmeargleSprites36
+.4byte sSmeargleSprites37
+.4byte sSmeargleSprites38
+.4byte sSmeargleSprites39
+.4byte sSmeargleSprites40
+.4byte sSmeargleSprites41
+.4byte sSmeargleSprites42
+.4byte sSmeargleSprites43
+.4byte sSmeargleSprites44
+.4byte sSmeargleSprites45
+.4byte sSmeargleSprites46
+.4byte sSmeargleSprites47
+.4byte sSmeargleSprites48
+.4byte sSmeargleSprites49
+.4byte sSmeargleSprites50
+.4byte sSmeargleSprites51
+.4byte sSmeargleSprites52
+.4byte sSmeargleSprites53
+.4byte sSmeargleSprites54
+.4byte sSmeargleSprites55
+.4byte sSmeargleSprites56
+.4byte sSmeargleSprites57
+.4byte sSmeargleSprites58
+.4byte sSmeargleSprites59
+.4byte sSmeargleSprites60
+.4byte sSmeargleSprites61
+.4byte sSmeargleSprites62
+.4byte sSmeargleSprites63
+.4byte sSmeargleSprites64
+.4byte sSmeargleSprites65
+.4byte sSmeargleSprites66
+.4byte sSmeargleSprites67
+.4byte sSmeargleSprites68
+.4byte sSmeargleSprites69
+.4byte sSmeargleSprites70
+.4byte sSmeargleSprites71
+.4byte sSmeargleSprites72
+.4byte sSmeargleSprites73
+.4byte sSmeargleSprites74
+.4byte sSmeargleSprites75
+.4byte sSmeargleSprites76
+.4byte sSmeargleSprites77
+.4byte sSmeargleSprites78
+.4byte sSmeargleSprites79
+.4byte sSmeargleSprites80
+.4byte sSmeargleSprites81
+sAxMainSmeargle:
+ax_main sAxPosesSmeargle, sAxAnimationsSmeargle, 13, sAxSpritesSmeargle, sAxPositionsSmeargle

--- a/data/ax/smoochum.inc
+++ b/data/ax/smoochum.inc
@@ -1,0 +1,2716 @@
+.global gAxSmoochum
+gAxSmoochum:
+ax_siro sAxMainSmoochum
+sSmoochumPose1:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose3:
+ax_pose 2, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose4:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose5:
+ax_pose 4, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose6:
+ax_pose 5, 0x81ec, 0x90f8, 0x0c00
+ax_pose 6, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose7:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose8:
+ax_pose 8, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose9:
+ax_pose 9, 0x81ec, 0x90f7, 0x0c00
+ax_pose 10, 0x01f4, 0x10ef, 0x0c08
+ax_pose_terminator
+sSmoochumPose10:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose11:
+ax_pose 12, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose12:
+ax_pose 13, 0x81ec, 0x90f8, 0x0c00
+ax_pose 14, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose13:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose14:
+ax_pose 16, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose15:
+ax_pose 17, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose16:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose17:
+ax_pose 12, 0x81ec, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose18:
+ax_pose 13, 0x81ec, 0x80f7, 0x0c00
+ax_pose 14, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose19:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose20:
+ax_pose 8, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose21:
+ax_pose 9, 0x81ec, 0x80f8, 0x0c00
+ax_pose 10, 0x01f4, 0x0108, 0x0c08
+ax_pose_terminator
+sSmoochumPose22:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose23:
+ax_pose 4, 0x81ec, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose24:
+ax_pose 5, 0x81ec, 0x80f7, 0x0c00
+ax_pose 6, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose25:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose26:
+ax_pose 18, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose27:
+ax_pose 2, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose28:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose29:
+ax_pose 19, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose30:
+ax_pose 5, 0x81ec, 0x90f8, 0x0c00
+ax_pose 6, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose31:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose32:
+ax_pose 20, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose33:
+ax_pose 9, 0x81ec, 0x90f7, 0x0c00
+ax_pose 10, 0x01f4, 0x10ef, 0x0c08
+ax_pose_terminator
+sSmoochumPose34:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose35:
+ax_pose 21, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sSmoochumPose36:
+ax_pose 13, 0x81ec, 0x90f8, 0x0c00
+ax_pose 14, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose37:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose38:
+ax_pose 22, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose39:
+ax_pose 17, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose40:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose41:
+ax_pose 21, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSmoochumPose42:
+ax_pose 13, 0x81ec, 0x80f7, 0x0c00
+ax_pose 14, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose43:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose44:
+ax_pose 20, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose45:
+ax_pose 9, 0x81ec, 0x80f8, 0x0c00
+ax_pose 10, 0x01f4, 0x0108, 0x0c08
+ax_pose_terminator
+sSmoochumPose46:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose47:
+ax_pose 19, 0x01ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose48:
+ax_pose 5, 0x81ec, 0x80f7, 0x0c00
+ax_pose 6, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose49:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose50:
+ax_pose 18, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose51:
+ax_pose 2, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose52:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose53:
+ax_pose 19, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose54:
+ax_pose 5, 0x81ec, 0x90f8, 0x0c00
+ax_pose 6, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose55:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose56:
+ax_pose 20, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose57:
+ax_pose 9, 0x81ec, 0x90f7, 0x0c00
+ax_pose 10, 0x01f4, 0x10ef, 0x0c08
+ax_pose_terminator
+sSmoochumPose58:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose59:
+ax_pose 21, 0x81eb, 0x90fb, 0x0c00
+ax_pose_terminator
+sSmoochumPose60:
+ax_pose 13, 0x81ec, 0x90f8, 0x0c00
+ax_pose 14, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose61:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose62:
+ax_pose 22, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose63:
+ax_pose 17, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose64:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose65:
+ax_pose 21, 0x81eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSmoochumPose66:
+ax_pose 13, 0x81ec, 0x80f7, 0x0c00
+ax_pose 14, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose67:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose68:
+ax_pose 20, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose69:
+ax_pose 9, 0x81ec, 0x80f8, 0x0c00
+ax_pose 10, 0x01f4, 0x0108, 0x0c08
+ax_pose_terminator
+sSmoochumPose70:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose71:
+ax_pose 19, 0x01ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose72:
+ax_pose 5, 0x81ec, 0x80f7, 0x0c00
+ax_pose 6, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose73:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose74:
+ax_pose 23, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose75:
+ax_pose 18, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose76:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose77:
+ax_pose 24, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose78:
+ax_pose 19, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose79:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose80:
+ax_pose 25, 0x81ec, 0x90f4, 0x0c00
+ax_pose_terminator
+sSmoochumPose81:
+ax_pose 20, 0x81ec, 0x90fa, 0x0c00
+ax_pose_terminator
+sSmoochumPose82:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose83:
+ax_pose 26, 0x81eb, 0x90f4, 0x0c00
+ax_pose_terminator
+sSmoochumPose84:
+ax_pose 27, 0x01eb, 0x90ec, 0x0c00
+ax_pose_terminator
+sSmoochumPose85:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose86:
+ax_pose 28, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose87:
+ax_pose 22, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose88:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose89:
+ax_pose 26, 0x81eb, 0x80fb, 0x0c00
+ax_pose_terminator
+sSmoochumPose90:
+ax_pose 27, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sSmoochumPose91:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose92:
+ax_pose 25, 0x81ec, 0x80fb, 0x0c00
+ax_pose_terminator
+sSmoochumPose93:
+ax_pose 20, 0x81ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sSmoochumPose94:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose95:
+ax_pose 24, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose96:
+ax_pose 19, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose97:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose98:
+ax_pose 29, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose99:
+ax_pose 30, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose100:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose101:
+ax_pose 31, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose102:
+ax_pose 32, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose103:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose104:
+ax_pose 33, 0x01ea, 0x90e8, 0x0c00
+ax_pose_terminator
+sSmoochumPose105:
+ax_pose 34, 0x01ea, 0x90e8, 0x0c00
+ax_pose_terminator
+sSmoochumPose106:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose107:
+ax_pose 35, 0x01e9, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose108:
+ax_pose 36, 0x01e9, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose109:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose110:
+ax_pose 37, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose111:
+ax_pose 38, 0x01ea, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose112:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose113:
+ax_pose 35, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose114:
+ax_pose 36, 0x01e9, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose115:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose116:
+ax_pose 33, 0x01ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose117:
+ax_pose 34, 0x01ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose118:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose119:
+ax_pose 31, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose120:
+ax_pose 32, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose121:
+ax_pose 39, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSmoochumPose122:
+ax_pose 40, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSmoochumPose123:
+ax_pose 41, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose124:
+ax_pose 42, 0x01e2, 0x90eb, 0x0c00
+ax_pose_terminator
+sSmoochumPose125:
+ax_pose 43, 0x01e3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSmoochumPose126:
+ax_pose 44, 0x01e3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSmoochumPose127:
+ax_pose 45, 0x01e3, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose128:
+ax_pose 44, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSmoochumPose129:
+ax_pose 43, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSmoochumPose130:
+ax_pose 42, 0x01e2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSmoochumPose131:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose132:
+ax_pose 1, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose133:
+ax_pose 2, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose134:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose135:
+ax_pose 4, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose136:
+ax_pose 5, 0x81ec, 0x90f8, 0x0c00
+ax_pose 6, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose137:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose138:
+ax_pose 8, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose139:
+ax_pose 9, 0x81ec, 0x90f7, 0x0c00
+ax_pose 10, 0x01f4, 0x10ef, 0x0c08
+ax_pose_terminator
+sSmoochumPose140:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose141:
+ax_pose 12, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose142:
+ax_pose 13, 0x81ec, 0x90f8, 0x0c00
+ax_pose 14, 0x01f4, 0x10f0, 0x0c08
+ax_pose_terminator
+sSmoochumPose143:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose144:
+ax_pose 16, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose145:
+ax_pose 17, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose146:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose147:
+ax_pose 12, 0x81ec, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose148:
+ax_pose 13, 0x81ec, 0x80f7, 0x0c00
+ax_pose 14, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose149:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose150:
+ax_pose 8, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose151:
+ax_pose 9, 0x81ec, 0x80f8, 0x0c00
+ax_pose 10, 0x01f4, 0x0108, 0x0c08
+ax_pose_terminator
+sSmoochumPose152:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose153:
+ax_pose 4, 0x81ec, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose154:
+ax_pose 5, 0x81ec, 0x80f7, 0x0c00
+ax_pose 6, 0x01f4, 0x0107, 0x0c08
+ax_pose_terminator
+sSmoochumPose155:
+ax_pose 18, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose156:
+ax_pose 19, 0x01ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose157:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose158:
+ax_pose 27, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose159:
+ax_pose 22, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose160:
+ax_pose 27, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sSmoochumPose161:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose162:
+ax_pose 19, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose163:
+ax_pose 23, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose164:
+ax_pose 24, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sSmoochumPose165:
+ax_pose 25, 0x81ec, 0x90f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose166:
+ax_pose 26, 0x81eb, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose167:
+ax_pose 28, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose168:
+ax_pose 26, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sSmoochumPose169:
+ax_pose 25, 0x81eb, 0x80fa, 0x0c00
+ax_pose_terminator
+sSmoochumPose170:
+ax_pose 24, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sSmoochumPose171:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose172:
+ax_pose 23, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose173:
+ax_pose 18, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose174:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose175:
+ax_pose 24, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose176:
+ax_pose 19, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose177:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose178:
+ax_pose 25, 0x81ec, 0x90f5, 0x0c00
+ax_pose_terminator
+sSmoochumPose179:
+ax_pose 20, 0x81ec, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose180:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose181:
+ax_pose 26, 0x81eb, 0x90f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose182:
+ax_pose 27, 0x01eb, 0x90ea, 0x0c00
+ax_pose_terminator
+sSmoochumPose183:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose184:
+ax_pose 28, 0x81ea, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose185:
+ax_pose 22, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose186:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose187:
+ax_pose 26, 0x81eb, 0x80f9, 0x0c00
+ax_pose_terminator
+sSmoochumPose188:
+ax_pose 27, 0x01eb, 0x80f5, 0x0c00
+ax_pose_terminator
+sSmoochumPose189:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose190:
+ax_pose 25, 0x81ec, 0x80fa, 0x0c00
+ax_pose_terminator
+sSmoochumPose191:
+ax_pose 20, 0x81ec, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose192:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose193:
+ax_pose 24, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose194:
+ax_pose 19, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose195:
+ax_pose 18, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sSmoochumPose196:
+ax_pose 19, 0x01ea, 0x80f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose197:
+ax_pose 20, 0x81eb, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose198:
+ax_pose 27, 0x01ea, 0x80f6, 0x0c00
+ax_pose_terminator
+sSmoochumPose199:
+ax_pose 22, 0x01ea, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose200:
+ax_pose 27, 0x01ea, 0x90ea, 0x0c00
+ax_pose_terminator
+sSmoochumPose201:
+ax_pose 20, 0x81eb, 0x90f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose202:
+ax_pose 19, 0x01ea, 0x90e9, 0x0c00
+ax_pose_terminator
+sSmoochumPose203:
+ax_pose 0, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose204:
+ax_pose 3, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose205:
+ax_pose 7, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose206:
+ax_pose 11, 0x81ec, 0x80f8, 0x0c00
+ax_pose_terminator
+sSmoochumPose207:
+ax_pose 15, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sSmoochumPose208:
+ax_pose 11, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose209:
+ax_pose 7, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+sSmoochumPose210:
+ax_pose 3, 0x81ec, 0x90f7, 0x0c00
+ax_pose_terminator
+.align 2
+sSmoochumAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSmoochumAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 11, 10, 11, 10,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 1, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 0, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSmoochumAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 1, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 0, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 8, 0, 8, 0,
+ax_anim_terminator
+sSmoochumAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 12, -14, 12, -14,
+ax_anim 2, 0, 34, 23, -23, 23, -23,
+ax_anim 2, 1, 34, 24, -22, 24, -22,
+ax_anim 2, 0, 34, 23, -23, 23, -23,
+ax_anim 2, 0, 34, 24, -22, 24, -22,
+ax_anim 2, 0, 33, 8, -8, 8, -8,
+ax_anim_terminator
+sSmoochumAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSmoochumAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -12, -14, -12, -14,
+ax_anim 2, 0, 40, -23, -23, -23, -23,
+ax_anim 2, 1, 40, -24, -22, -24, -22,
+ax_anim 2, 0, 40, -23, -23, -23, -23,
+ax_anim 2, 0, 40, -24, -22, -24, -22,
+ax_anim 2, 0, 39, -8, -8, -8, -8,
+ax_anim_terminator
+sSmoochumAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 1, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 0, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -8, 0, -8, 0,
+ax_anim_terminator
+sSmoochumAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -11, 10, -11, 10,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 1, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 0, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 1, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSmoochumAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 11, 10, 11, 10,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 1, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 0, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sSmoochumAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 12, 0, 12, 0,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 1, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 0, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 8, 0, 8, 0,
+ax_anim_terminator
+sSmoochumAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 59, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 12, -14, 12, -14,
+ax_anim 2, 0, 58, 23, -23, 23, -23,
+ax_anim 2, 1, 58, 24, -22, 24, -22,
+ax_anim 2, 0, 58, 23, -23, 23, -23,
+ax_anim 2, 0, 58, 24, -22, 24, -22,
+ax_anim 2, 0, 57, 8, -8, 8, -8,
+ax_anim_terminator
+sSmoochumAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 1, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 0, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSmoochumAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 65, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -12, -14, -12, -14,
+ax_anim 2, 0, 64, -23, -23, -23, -23,
+ax_anim 2, 1, 64, -24, -22, -24, -22,
+ax_anim 2, 0, 64, -23, -23, -23, -23,
+ax_anim 2, 0, 64, -24, -22, -24, -22,
+ax_anim 2, 0, 63, -8, -8, -8, -8,
+ax_anim_terminator
+sSmoochumAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -12, 0, -12, 0,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 1, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 0, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 66, -8, 0, -8, 0,
+ax_anim_terminator
+sSmoochumAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -11, 10, -11, 10,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 1, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 0, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 1, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 1, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sSmoochumAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 1, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 1, 77, 4, 2, 4, 2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 4, 2, 4, 2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 4, 2, 4, 2,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sSmoochumAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 1, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 1, 80, 3, -1, 3, -1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, -1, 3, -1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, -1, 3, -1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sSmoochumAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 1, 0, 83, -1, 1, -1, 1,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 1, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 4, -2, 4, -2,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sSmoochumAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 1, 0, 86, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 1, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sSmoochumAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 1, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 1, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -4, -2, -4, -2,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sSmoochumAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 1, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 1, 92, -3, -1, -3, -1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, -1, -3, -1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, -1, -3, -1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sSmoochumAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 1, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 1, 95, -4, 2, -4, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -4, 2, -4, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -4, 2, -4, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_5_1:
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 4, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 2, 116, 0, -3, 0, 0,
+ax_anim 4, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_5_2:
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 4, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 2, 119, 0, -3, 0, 0,
+ax_anim 4, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 98, 0, -3, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_5_3:
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, -2, 0, 0,
+ax_anim 2, 2, 98, 0, -3, 0, 0,
+ax_anim 4, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -3, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_5_4:
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 4, 0, 112, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 2, 101, 0, -3, 0, 0,
+ax_anim 4, 0, 104, 0, -4, 0, 0,
+ax_anim 2, 0, 104, 0, -3, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_5_5:
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 4, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 2, 104, 0, -3, 0, 0,
+ax_anim 4, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_5_6:
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 4, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 1, 0, 100, 0, -2, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 2, 2, 107, 0, -3, 0, 0,
+ax_anim 4, 0, 110, 0, -4, 0, 0,
+ax_anim 2, 0, 110, 0, -3, 0, 0,
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_5_7:
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, 0,
+ax_anim 4, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -3, 0, 0,
+ax_anim 1, 0, 103, 0, -2, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 2, 110, 0, -3, 0, 0,
+ax_anim 4, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_5_8:
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 4, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 2, 113, 0, -3, 0, 0,
+ax_anim 4, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sSmoochumAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sSmoochumAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sSmoochumAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sSmoochumAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sSmoochumAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sSmoochumAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sSmoochumAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 131, 0, -3, 0, 0,
+ax_anim 6, 0, 132, 0, -3, 0, 0,
+ax_anim 6, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 134, 0, -3, 0, 0,
+ax_anim 6, 0, 135, 0, -3, 0, 0,
+ax_anim 6, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 137, 0, -3, 0, 0,
+ax_anim 6, 0, 138, 0, -3, 0, 0,
+ax_anim 6, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 140, 0, -3, 0, 0,
+ax_anim 6, 0, 141, 0, -3, 0, 0,
+ax_anim 6, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 143, 0, -3, 0, 0,
+ax_anim 6, 0, 144, 0, -3, 0, 0,
+ax_anim 6, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 146, 0, -3, 0, 0,
+ax_anim 6, 0, 147, 0, -3, 0, 0,
+ax_anim 6, 0, 147, 0, -2, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 149, 0, -3, 0, 0,
+ax_anim 6, 0, 150, 0, -3, 0, 0,
+ax_anim 6, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, -2, 0, 0,
+ax_anim 6, 0, 152, 0, -3, 0, 0,
+ax_anim 6, 0, 153, 0, -3, 0, 0,
+ax_anim 6, 0, 153, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 7, 4, 7, 4,
+ax_anim 2, 0, 156, 9, 10, 9, 10,
+ax_anim 2, 0, 157, 7, 18, 7, 18,
+ax_anim 3, 0, 158, 0, 22, 0, 22,
+ax_anim 2, 3, 159, -7, 18, -7, 18,
+ax_anim 2, 0, 160, -9, 10, -9, 10,
+ax_anim 1, 0, 161, -7, 4, -7, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 22, 12, 22, 12,
+ax_anim 3, 0, 157, 22, 21, 22, 21,
+ax_anim 2, 3, 158, 12, 22, 12, 22,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 2, -5, 2, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 17, -5, 17, -5,
+ax_anim 3, 0, 156, 22, 0, 22, 0,
+ax_anim 2, 3, 157, 18, 5, 18, 5,
+ax_anim 2, 0, 158, 12, 6, 12, 6,
+ax_anim 1, 0, 159, 3, 5, 3, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 1, -17, 1, -17,
+ax_anim 2, 0, 154, 12, -23, 12, -23,
+ax_anim 3, 0, 155, 21, -23, 21, -23,
+ax_anim 2, 3, 156, 22, -13, 22, -13,
+ax_anim 2, 0, 157, 18, -5, 18, -5,
+ax_anim 1, 0, 158, 10, 0, 10, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -8, -19, -8, -19,
+ax_anim 3, 0, 154, 0, -23, 0, -23,
+ax_anim 2, 3, 155, 8, -19, 8, -19,
+ax_anim 2, 0, 156, 9, -12, 9, -12,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -1, -17, -1, -17,
+ax_anim 2, 0, 154, -12, -23, -12, -23,
+ax_anim 3, 0, 161, -21, -23, -21, -23,
+ax_anim 2, 3, 160, -22, -13, -22, -13,
+ax_anim 2, 0, 159, -18, -5, -18, -5,
+ax_anim 1, 0, 158, -10, 0, -10, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -2, -5, -2, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -17, -5, -17, -5,
+ax_anim 3, 0, 160, -22, 0, -22, 0,
+ax_anim 2, 3, 159, -18, 5, -18, 5,
+ax_anim 2, 0, 158, -12, 6, -12, 6,
+ax_anim 1, 0, 157, -3, 5, -3, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -22, 12, -22, 12,
+ax_anim 3, 0, 159, -23, 21, -23, 21,
+ax_anim 2, 3, 158, -12, 22, -12, 22,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 172, 0, -21, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -22, 0, 0,
+ax_anim 3, 0, 175, 0, -21, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -21, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 184, 0, -21, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSmoochumAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSmoochumGfx1:
+.incbin "baserom.gba", 0xFA63B8, 0x200
+sSmoochumSprites1:
+ax_sprite sSmoochumGfx1, 0x200
+ax_sprite_terminator
+sSmoochumGfx2:
+.incbin "baserom.gba", 0xFA65C8, 0x200
+sSmoochumSprites2:
+ax_sprite sSmoochumGfx2, 0x200
+ax_sprite_terminator
+sSmoochumGfx3:
+.incbin "baserom.gba", 0xFA67D8, 0x200
+sSmoochumSprites3:
+ax_sprite sSmoochumGfx3, 0x200
+ax_sprite_terminator
+sSmoochumGfx4:
+.incbin "baserom.gba", 0xFA69E8, 0x100
+sSmoochumSprites4:
+ax_sprite sSmoochumGfx4, 0x100
+ax_sprite_terminator
+sSmoochumGfx5:
+.incbin "baserom.gba", 0xFA6AF8, 0x100
+sSmoochumSprites5:
+ax_sprite sSmoochumGfx5, 0x100
+ax_sprite_terminator
+sSmoochumGfx6:
+.incbin "baserom.gba", 0xFA6C08, 0x100
+sSmoochumSprites6:
+ax_sprite sSmoochumGfx6, 0x100
+ax_sprite_terminator
+sSmoochumGfx7:
+.incbin "baserom.gba", 0xFA6D18, 0x20
+sSmoochumSprites7:
+ax_sprite sSmoochumGfx7, 0x20
+ax_sprite_terminator
+sSmoochumGfx8:
+.incbin "baserom.gba", 0xFA6D48, 0x100
+sSmoochumSprites8:
+ax_sprite sSmoochumGfx8, 0x100
+ax_sprite_terminator
+sSmoochumGfx9:
+.incbin "baserom.gba", 0xFA6E58, 0x100
+sSmoochumSprites9:
+ax_sprite sSmoochumGfx9, 0x100
+ax_sprite_terminator
+sSmoochumGfx10:
+.incbin "baserom.gba", 0xFA6F68, 0x100
+sSmoochumSprites10:
+ax_sprite sSmoochumGfx10, 0x100
+ax_sprite_terminator
+sSmoochumGfx11:
+.incbin "baserom.gba", 0xFA7078, 0x20
+sSmoochumSprites11:
+ax_sprite sSmoochumGfx11, 0x20
+ax_sprite_terminator
+sSmoochumGfx12:
+.incbin "baserom.gba", 0xFA70A8, 0x100
+sSmoochumSprites12:
+ax_sprite sSmoochumGfx12, 0x100
+ax_sprite_terminator
+sSmoochumGfx13:
+.incbin "baserom.gba", 0xFA71B8, 0x100
+sSmoochumSprites13:
+ax_sprite sSmoochumGfx13, 0x100
+ax_sprite_terminator
+sSmoochumGfx14:
+.incbin "baserom.gba", 0xFA72C8, 0x100
+sSmoochumSprites14:
+ax_sprite sSmoochumGfx14, 0x100
+ax_sprite_terminator
+sSmoochumGfx15:
+.incbin "baserom.gba", 0xFA73D8, 0x20
+sSmoochumSprites15:
+ax_sprite sSmoochumGfx15, 0x20
+ax_sprite_terminator
+sSmoochumGfx16:
+.incbin "baserom.gba", 0xFA7408, 0x200
+sSmoochumSprites16:
+ax_sprite sSmoochumGfx16, 0x200
+ax_sprite_terminator
+sSmoochumGfx17:
+.incbin "baserom.gba", 0xFA7618, 0x200
+sSmoochumSprites17:
+ax_sprite sSmoochumGfx17, 0x200
+ax_sprite_terminator
+sSmoochumGfx18:
+.incbin "baserom.gba", 0xFA7828, 0x200
+sSmoochumSprites18:
+ax_sprite sSmoochumGfx18, 0x200
+ax_sprite_terminator
+sSmoochumGfx19:
+.incbin "baserom.gba", 0xFA7A38, 0x60
+sSmoochumGfx19_1:
+.incbin "baserom.gba", 0xFA7A98, 0x60
+sSmoochumGfx19_2:
+.incbin "baserom.gba", 0xFA7AF8, 0x40
+sSmoochumSprites19:
+ax_sprite sSmoochumGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx19_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx20:
+.incbin "baserom.gba", 0xFA7B70, 0x40
+sSmoochumGfx20_1:
+.incbin "baserom.gba", 0xFA7BB0, 0x60
+sSmoochumGfx20_2:
+.incbin "baserom.gba", 0xFA7C10, 0x40
+sSmoochumSprites20:
+ax_sprite sSmoochumGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx20_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSmoochumGfx21:
+.incbin "baserom.gba", 0xFA7C88, 0xC0
+sSmoochumSprites21:
+ax_sprite sSmoochumGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmoochumGfx22:
+.incbin "baserom.gba", 0xFA7D60, 0xC0
+sSmoochumSprites22:
+ax_sprite sSmoochumGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmoochumGfx23:
+.incbin "baserom.gba", 0xFA7E38, 0x40
+sSmoochumGfx23_1:
+.incbin "baserom.gba", 0xFA7E78, 0x60
+sSmoochumGfx23_2:
+.incbin "baserom.gba", 0xFA7ED8, 0x40
+sSmoochumSprites23:
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx24:
+.incbin "baserom.gba", 0xFA7F58, 0x60
+sSmoochumGfx24_1:
+.incbin "baserom.gba", 0xFA7FB8, 0x60
+sSmoochumGfx24_2:
+.incbin "baserom.gba", 0xFA8018, 0x40
+sSmoochumSprites24:
+ax_sprite sSmoochumGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx25:
+.incbin "baserom.gba", 0xFA8090, 0x60
+sSmoochumGfx25_1:
+.incbin "baserom.gba", 0xFA80F0, 0x60
+sSmoochumGfx25_2:
+.incbin "baserom.gba", 0xFA8150, 0x60
+sSmoochumSprites25:
+ax_sprite sSmoochumGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx26:
+.incbin "baserom.gba", 0xFA81E8, 0xC0
+sSmoochumSprites26:
+ax_sprite sSmoochumGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmoochumGfx27:
+.incbin "baserom.gba", 0xFA82C0, 0xC0
+sSmoochumSprites27:
+ax_sprite sSmoochumGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmoochumGfx28:
+.incbin "baserom.gba", 0xFA8398, 0x40
+sSmoochumGfx28_1:
+.incbin "baserom.gba", 0xFA83D8, 0x60
+sSmoochumGfx28_2:
+.incbin "baserom.gba", 0xFA8438, 0x40
+sSmoochumSprites28:
+ax_sprite sSmoochumGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx28_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSmoochumGfx29:
+.incbin "baserom.gba", 0xFA84B0, 0xC0
+sSmoochumSprites29:
+ax_sprite sSmoochumGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmoochumGfx30:
+.incbin "baserom.gba", 0xFA8588, 0x60
+sSmoochumGfx30_1:
+.incbin "baserom.gba", 0xFA85E8, 0x60
+sSmoochumGfx30_2:
+.incbin "baserom.gba", 0xFA8648, 0x40
+sSmoochumSprites30:
+ax_sprite sSmoochumGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx30_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx31:
+.incbin "baserom.gba", 0xFA86C0, 0x60
+sSmoochumGfx31_1:
+.incbin "baserom.gba", 0xFA8720, 0x60
+sSmoochumGfx31_2:
+.incbin "baserom.gba", 0xFA8780, 0x40
+sSmoochumSprites31:
+ax_sprite sSmoochumGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx31_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx32:
+.incbin "baserom.gba", 0xFA87F8, 0x60
+sSmoochumGfx32_1:
+.incbin "baserom.gba", 0xFA8858, 0x60
+sSmoochumGfx32_2:
+.incbin "baserom.gba", 0xFA88B8, 0x40
+sSmoochumSprites32:
+ax_sprite sSmoochumGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx32_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSmoochumGfx33:
+.incbin "baserom.gba", 0xFA8930, 0x60
+sSmoochumGfx33_1:
+.incbin "baserom.gba", 0xFA8990, 0x60
+sSmoochumGfx33_2:
+.incbin "baserom.gba", 0xFA89F0, 0x40
+sSmoochumSprites33:
+ax_sprite sSmoochumGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx33_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSmoochumGfx34:
+.incbin "baserom.gba", 0xFA8A68, 0x60
+sSmoochumGfx34_1:
+.incbin "baserom.gba", 0xFA8AC8, 0x60
+sSmoochumGfx34_2:
+.incbin "baserom.gba", 0xFA8B28, 0x40
+sSmoochumSprites34:
+ax_sprite sSmoochumGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx34_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSmoochumGfx35:
+.incbin "baserom.gba", 0xFA8BA0, 0x60
+sSmoochumGfx35_1:
+.incbin "baserom.gba", 0xFA8C00, 0x60
+sSmoochumGfx35_2:
+.incbin "baserom.gba", 0xFA8C60, 0x40
+sSmoochumSprites35:
+ax_sprite sSmoochumGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx35_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSmoochumGfx36:
+.incbin "baserom.gba", 0xFA8CD8, 0x60
+sSmoochumGfx36_1:
+.incbin "baserom.gba", 0xFA8D38, 0x60
+sSmoochumGfx36_2:
+.incbin "baserom.gba", 0xFA8D98, 0x40
+sSmoochumGfx36_3:
+.incbin "baserom.gba", 0xFA8DD8, 0x20
+sSmoochumSprites36:
+ax_sprite sSmoochumGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx36_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sSmoochumGfx36_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSmoochumGfx37:
+.incbin "baserom.gba", 0xFA8E40, 0x60
+sSmoochumGfx37_1:
+.incbin "baserom.gba", 0xFA8EA0, 0x60
+sSmoochumGfx37_2:
+.incbin "baserom.gba", 0xFA8F00, 0x40
+sSmoochumSprites37:
+ax_sprite sSmoochumGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx37_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSmoochumGfx38:
+.incbin "baserom.gba", 0xFA8F78, 0x60
+sSmoochumGfx38_1:
+.incbin "baserom.gba", 0xFA8FD8, 0x60
+sSmoochumGfx38_2:
+.incbin "baserom.gba", 0xFA9038, 0x40
+sSmoochumSprites38:
+ax_sprite sSmoochumGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx38_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx38_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx39:
+.incbin "baserom.gba", 0xFA90B0, 0x60
+sSmoochumGfx39_1:
+.incbin "baserom.gba", 0xFA9110, 0x60
+sSmoochumGfx39_2:
+.incbin "baserom.gba", 0xFA9170, 0x40
+sSmoochumSprites39:
+ax_sprite sSmoochumGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSmoochumGfx39_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSmoochumGfx39_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSmoochumGfx40:
+.incbin "baserom.gba", 0xFA91E8, 0x200
+sSmoochumSprites40:
+ax_sprite sSmoochumGfx40, 0x200
+ax_sprite_terminator
+sSmoochumGfx41:
+.incbin "baserom.gba", 0xFA93F8, 0x200
+sSmoochumSprites41:
+ax_sprite sSmoochumGfx41, 0x200
+ax_sprite_terminator
+sSmoochumGfx42:
+.incbin "baserom.gba", 0xFA9608, 0x200
+sSmoochumSprites42:
+ax_sprite sSmoochumGfx42, 0x200
+ax_sprite_terminator
+sSmoochumGfx43:
+.incbin "baserom.gba", 0xFA9818, 0x200
+sSmoochumSprites43:
+ax_sprite sSmoochumGfx43, 0x200
+ax_sprite_terminator
+sSmoochumGfx44:
+.incbin "baserom.gba", 0xFA9A28, 0x200
+sSmoochumSprites44:
+ax_sprite sSmoochumGfx44, 0x200
+ax_sprite_terminator
+sSmoochumGfx45:
+.incbin "baserom.gba", 0xFA9C38, 0x200
+sSmoochumSprites45:
+ax_sprite sSmoochumGfx45, 0x200
+ax_sprite_terminator
+sSmoochumGfx46:
+.incbin "baserom.gba", 0xFA9E48, 0x200
+sSmoochumSprites46:
+ax_sprite sSmoochumGfx46, 0x200
+ax_sprite_terminator
+sAxPosesSmoochum:
+.4byte sSmoochumPose1
+.4byte sSmoochumPose2
+.4byte sSmoochumPose3
+.4byte sSmoochumPose4
+.4byte sSmoochumPose5
+.4byte sSmoochumPose6
+.4byte sSmoochumPose7
+.4byte sSmoochumPose8
+.4byte sSmoochumPose9
+.4byte sSmoochumPose10
+.4byte sSmoochumPose11
+.4byte sSmoochumPose12
+.4byte sSmoochumPose13
+.4byte sSmoochumPose14
+.4byte sSmoochumPose15
+.4byte sSmoochumPose16
+.4byte sSmoochumPose17
+.4byte sSmoochumPose18
+.4byte sSmoochumPose19
+.4byte sSmoochumPose20
+.4byte sSmoochumPose21
+.4byte sSmoochumPose22
+.4byte sSmoochumPose23
+.4byte sSmoochumPose24
+.4byte sSmoochumPose25
+.4byte sSmoochumPose26
+.4byte sSmoochumPose27
+.4byte sSmoochumPose28
+.4byte sSmoochumPose29
+.4byte sSmoochumPose30
+.4byte sSmoochumPose31
+.4byte sSmoochumPose32
+.4byte sSmoochumPose33
+.4byte sSmoochumPose34
+.4byte sSmoochumPose35
+.4byte sSmoochumPose36
+.4byte sSmoochumPose37
+.4byte sSmoochumPose38
+.4byte sSmoochumPose39
+.4byte sSmoochumPose40
+.4byte sSmoochumPose41
+.4byte sSmoochumPose42
+.4byte sSmoochumPose43
+.4byte sSmoochumPose44
+.4byte sSmoochumPose45
+.4byte sSmoochumPose46
+.4byte sSmoochumPose47
+.4byte sSmoochumPose48
+.4byte sSmoochumPose49
+.4byte sSmoochumPose50
+.4byte sSmoochumPose51
+.4byte sSmoochumPose52
+.4byte sSmoochumPose53
+.4byte sSmoochumPose54
+.4byte sSmoochumPose55
+.4byte sSmoochumPose56
+.4byte sSmoochumPose57
+.4byte sSmoochumPose58
+.4byte sSmoochumPose59
+.4byte sSmoochumPose60
+.4byte sSmoochumPose61
+.4byte sSmoochumPose62
+.4byte sSmoochumPose63
+.4byte sSmoochumPose64
+.4byte sSmoochumPose65
+.4byte sSmoochumPose66
+.4byte sSmoochumPose67
+.4byte sSmoochumPose68
+.4byte sSmoochumPose69
+.4byte sSmoochumPose70
+.4byte sSmoochumPose71
+.4byte sSmoochumPose72
+.4byte sSmoochumPose73
+.4byte sSmoochumPose74
+.4byte sSmoochumPose75
+.4byte sSmoochumPose76
+.4byte sSmoochumPose77
+.4byte sSmoochumPose78
+.4byte sSmoochumPose79
+.4byte sSmoochumPose80
+.4byte sSmoochumPose81
+.4byte sSmoochumPose82
+.4byte sSmoochumPose83
+.4byte sSmoochumPose84
+.4byte sSmoochumPose85
+.4byte sSmoochumPose86
+.4byte sSmoochumPose87
+.4byte sSmoochumPose88
+.4byte sSmoochumPose89
+.4byte sSmoochumPose90
+.4byte sSmoochumPose91
+.4byte sSmoochumPose92
+.4byte sSmoochumPose93
+.4byte sSmoochumPose94
+.4byte sSmoochumPose95
+.4byte sSmoochumPose96
+.4byte sSmoochumPose97
+.4byte sSmoochumPose98
+.4byte sSmoochumPose99
+.4byte sSmoochumPose100
+.4byte sSmoochumPose101
+.4byte sSmoochumPose102
+.4byte sSmoochumPose103
+.4byte sSmoochumPose104
+.4byte sSmoochumPose105
+.4byte sSmoochumPose106
+.4byte sSmoochumPose107
+.4byte sSmoochumPose108
+.4byte sSmoochumPose109
+.4byte sSmoochumPose110
+.4byte sSmoochumPose111
+.4byte sSmoochumPose112
+.4byte sSmoochumPose113
+.4byte sSmoochumPose114
+.4byte sSmoochumPose115
+.4byte sSmoochumPose116
+.4byte sSmoochumPose117
+.4byte sSmoochumPose118
+.4byte sSmoochumPose119
+.4byte sSmoochumPose120
+.4byte sSmoochumPose121
+.4byte sSmoochumPose122
+.4byte sSmoochumPose123
+.4byte sSmoochumPose124
+.4byte sSmoochumPose125
+.4byte sSmoochumPose126
+.4byte sSmoochumPose127
+.4byte sSmoochumPose128
+.4byte sSmoochumPose129
+.4byte sSmoochumPose130
+.4byte sSmoochumPose131
+.4byte sSmoochumPose132
+.4byte sSmoochumPose133
+.4byte sSmoochumPose134
+.4byte sSmoochumPose135
+.4byte sSmoochumPose136
+.4byte sSmoochumPose137
+.4byte sSmoochumPose138
+.4byte sSmoochumPose139
+.4byte sSmoochumPose140
+.4byte sSmoochumPose141
+.4byte sSmoochumPose142
+.4byte sSmoochumPose143
+.4byte sSmoochumPose144
+.4byte sSmoochumPose145
+.4byte sSmoochumPose146
+.4byte sSmoochumPose147
+.4byte sSmoochumPose148
+.4byte sSmoochumPose149
+.4byte sSmoochumPose150
+.4byte sSmoochumPose151
+.4byte sSmoochumPose152
+.4byte sSmoochumPose153
+.4byte sSmoochumPose154
+.4byte sSmoochumPose155
+.4byte sSmoochumPose156
+.4byte sSmoochumPose157
+.4byte sSmoochumPose158
+.4byte sSmoochumPose159
+.4byte sSmoochumPose160
+.4byte sSmoochumPose161
+.4byte sSmoochumPose162
+.4byte sSmoochumPose163
+.4byte sSmoochumPose164
+.4byte sSmoochumPose165
+.4byte sSmoochumPose166
+.4byte sSmoochumPose167
+.4byte sSmoochumPose168
+.4byte sSmoochumPose169
+.4byte sSmoochumPose170
+.4byte sSmoochumPose171
+.4byte sSmoochumPose172
+.4byte sSmoochumPose173
+.4byte sSmoochumPose174
+.4byte sSmoochumPose175
+.4byte sSmoochumPose176
+.4byte sSmoochumPose177
+.4byte sSmoochumPose178
+.4byte sSmoochumPose179
+.4byte sSmoochumPose180
+.4byte sSmoochumPose181
+.4byte sSmoochumPose182
+.4byte sSmoochumPose183
+.4byte sSmoochumPose184
+.4byte sSmoochumPose185
+.4byte sSmoochumPose186
+.4byte sSmoochumPose187
+.4byte sSmoochumPose188
+.4byte sSmoochumPose189
+.4byte sSmoochumPose190
+.4byte sSmoochumPose191
+.4byte sSmoochumPose192
+.4byte sSmoochumPose193
+.4byte sSmoochumPose194
+.4byte sSmoochumPose195
+.4byte sSmoochumPose196
+.4byte sSmoochumPose197
+.4byte sSmoochumPose198
+.4byte sSmoochumPose199
+.4byte sSmoochumPose200
+.4byte sSmoochumPose201
+.4byte sSmoochumPose202
+.4byte sSmoochumPose203
+.4byte sSmoochumPose204
+.4byte sSmoochumPose205
+.4byte sSmoochumPose206
+.4byte sSmoochumPose207
+.4byte sSmoochumPose208
+.4byte sSmoochumPose209
+.4byte sSmoochumPose210
+sAxPositionsSmoochum:
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -4, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -2, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+.2byte    2,   -6, 	   1,   -3, 	   0,   -3, 	  -1,   -6
+.2byte    2,   -6, 	   5,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    4,   -5, 	  -2,   -2, 	   4,   -2, 	  -2,   -7
+.2byte    4,   -5, 	   2,   -3, 	  -2,   -2, 	  -2,   -7
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    1,   -7, 	  -5,   -2, 	   5,   -3, 	  -2,   -7
+.2byte    3,   -7, 	  -2,   -3, 	   3,    0, 	  -2,   -7
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	   5,   -3, 	  -6,   -6, 	  -1,   -9
+.2byte   -1,   -8, 	   4,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -3,   -7, 	   3,   -2, 	  -7,   -3, 	   0,   -7
+.2byte   -5,   -7, 	   0,   -3, 	  -5,    0, 	   0,   -7
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -6,   -5, 	   0,   -2, 	  -6,   -2, 	   0,   -7
+.2byte   -6,   -5, 	  -4,   -3, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -4,   -6, 	  -3,   -3, 	  -2,   -3, 	  -1,   -6
+.2byte   -4,   -6, 	  -7,   -4, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -2, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+.2byte    4,   -5, 	   4,   -6, 	  -6,   -7, 	   0,   -6
+.2byte    2,   -6, 	   5,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    5,   -4, 	  -5,   -4, 	  -3,   -3, 	  -1,   -7
+.2byte    4,   -5, 	   2,   -3, 	  -2,   -2, 	  -2,   -7
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    5,   -7, 	  -5,   -5, 	  -1,   -4, 	   1,   -9
+.2byte    3,   -7, 	  -2,   -3, 	   3,    0, 	  -2,   -7
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	   5,   -6, 	  -7,   -6, 	  -1,  -11
+.2byte   -1,   -8, 	   4,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -6,   -7, 	   4,   -5, 	   0,   -4, 	  -2,   -9
+.2byte   -5,   -7, 	   0,   -3, 	  -5,    0, 	   0,   -7
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -6,   -4, 	   4,   -4, 	   2,   -3, 	   0,   -7
+.2byte   -6,   -5, 	  -4,   -3, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -5,   -5, 	  -5,   -6, 	   5,   -7, 	  -1,   -6
+.2byte   -4,   -6, 	  -7,   -4, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -2, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+.2byte    4,   -5, 	   4,   -6, 	  -6,   -7, 	   0,   -6
+.2byte    2,   -6, 	   5,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    5,   -4, 	  -5,   -4, 	  -3,   -3, 	  -1,   -7
+.2byte    4,   -5, 	   2,   -3, 	  -2,   -2, 	  -2,   -7
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    5,   -7, 	  -5,   -5, 	  -1,   -4, 	   1,   -9
+.2byte    3,   -7, 	  -2,   -3, 	   3,    0, 	  -2,   -7
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	   5,   -6, 	  -7,   -6, 	  -1,  -11
+.2byte   -1,   -8, 	   4,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -6,   -7, 	   4,   -5, 	   0,   -4, 	  -2,   -9
+.2byte   -5,   -7, 	   0,   -3, 	  -5,    0, 	   0,   -7
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -6,   -4, 	   4,   -4, 	   2,   -3, 	   0,   -7
+.2byte   -6,   -5, 	  -4,   -3, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -5,   -5, 	  -5,   -6, 	   5,   -7, 	  -1,   -6
+.2byte   -4,   -6, 	  -7,   -4, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	  -5,   -8, 	   3,   -8, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+.2byte   -1,   -8, 	   4,   -8, 	  -2,   -6, 	  -3,   -8
+.2byte    4,   -5, 	   4,   -6, 	  -6,   -7, 	   0,   -6
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    1,   -7, 	  -3,   -7, 	  -2,   -7, 	  -5,   -8
+.2byte    7,   -4, 	  -3,   -4, 	  -1,   -3, 	   1,   -7
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    0,   -9, 	  -3,   -8, 	   3,   -8, 	  -4,   -9
+.2byte    6,   -7, 	  -4,   -5, 	   0,   -4, 	   2,   -9
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,   -6, 	   5,   -6, 	  -7,   -6, 	  -1,   -7
+.2byte   -1,  -10, 	   5,   -6, 	  -7,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -2,   -9, 	   1,   -8, 	  -5,   -8, 	   2,   -9
+.2byte   -8,   -7, 	   2,   -5, 	  -2,   -4, 	  -4,   -9
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -3,   -7, 	   1,   -7, 	   0,   -7, 	   3,   -8
+.2byte   -9,   -4, 	   1,   -4, 	  -1,   -3, 	  -3,   -7
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -1,   -8, 	  -6,   -8, 	   0,   -6, 	   1,   -8
+.2byte   -6,   -5, 	  -6,   -6, 	   4,   -7, 	  -2,   -6
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -8, 	  -6,   -3, 	   5,   -8, 	  -1,   -9
+.2byte   -1,   -8, 	  -7,   -8, 	   4,   -3, 	  -1,   -9
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+.2byte    2,   -8, 	   5,   -7, 	  -6,   -4, 	   0,   -8
+.2byte    2,   -8, 	   1,   -5, 	  -2,   -9, 	   0,   -9
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    4,   -7, 	   2,   -5, 	  -3,   -2, 	  -1,  -10
+.2byte    4,   -7, 	  -4,   -5, 	   0,   -9, 	  -1,  -10
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    3,  -10, 	  -7,   -5, 	   3,   -9, 	  -1,  -11
+.2byte    3,  -10, 	  -6,   -8, 	   0,   -3, 	  -1,  -12
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	   5,   -4, 	  -6,   -8, 	  -1,  -11
+.2byte   -1,  -10, 	   3,   -8, 	  -7,   -3, 	  -1,  -11
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -5,  -10, 	   5,   -5, 	  -5,   -9, 	  -1,  -11
+.2byte   -5,  -10, 	   4,   -8, 	  -2,   -3, 	  -1,  -12
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -6,   -7, 	  -4,   -5, 	   1,   -2, 	  -1,  -10
+.2byte   -6,   -7, 	   2,   -5, 	  -2,   -9, 	  -1,  -10
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -4,   -8, 	  -7,   -7, 	   4,   -4, 	  -2,   -8
+.2byte   -4,   -8, 	  -3,   -5, 	   0,   -9, 	  -2,   -9
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -7
+.2byte   -1,   -5, 	  -3,   -2, 	   1,   -2, 	  -1,   -6
+.2byte    0,   -9, 	  -6,   -7, 	   6,   -7, 	   0,  -10
+.2byte    2,   -9, 	   5,   -8, 	  -6,   -7, 	  -1,   -9
+.2byte    4,   -8, 	  -3,   -7, 	  -3,   -6, 	  -1,  -10
+.2byte    3,  -10, 	   0,   -9, 	   5,   -6, 	  -2,  -11
+.2byte    0,  -11, 	   6,   -7, 	  -6,   -7, 	   0,  -12
+.2byte   -4,  -10, 	  -1,   -9, 	  -6,   -6, 	   1,  -11
+.2byte   -5,   -8, 	   2,   -7, 	   2,   -6, 	   0,  -10
+.2byte   -3,   -9, 	  -6,   -8, 	   5,   -7, 	   0,   -9
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -6, 	  -7,   -4, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -2, 	   5,   -4, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+.2byte    2,   -6, 	   1,   -3, 	   0,   -3, 	  -1,   -6
+.2byte    2,   -6, 	   5,   -4, 	  -6,   -3, 	  -1,   -6
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    4,   -5, 	  -2,   -2, 	   4,   -2, 	  -2,   -7
+.2byte    4,   -5, 	   2,   -3, 	  -2,   -2, 	  -2,   -7
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    1,   -7, 	  -5,   -2, 	   5,   -3, 	  -2,   -7
+.2byte    3,   -7, 	  -2,   -3, 	   3,    0, 	  -2,   -7
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	   5,   -3, 	  -6,   -6, 	  -1,   -9
+.2byte   -1,   -8, 	   4,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -3,   -7, 	   3,   -2, 	  -7,   -3, 	   0,   -7
+.2byte   -5,   -7, 	   0,   -3, 	  -5,    0, 	   0,   -7
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -6,   -5, 	   0,   -2, 	  -6,   -2, 	   0,   -7
+.2byte   -6,   -5, 	  -4,   -3, 	   0,   -2, 	   0,   -7
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -4,   -6, 	  -3,   -3, 	  -2,   -3, 	  -1,   -6
+.2byte   -4,   -6, 	  -7,   -4, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -5, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -5,   -5, 	  -5,   -6, 	   5,   -7, 	  -1,   -6
+.2byte   -6,   -5, 	   4,   -5, 	   2,   -4, 	   0,   -8
+.2byte   -5,   -8, 	   5,   -6, 	   1,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   5,   -6, 	  -7,   -6, 	  -1,  -11
+.2byte    4,   -8, 	  -6,   -6, 	  -2,   -5, 	   0,  -10
+.2byte    5,   -5, 	  -5,   -5, 	  -3,   -4, 	  -1,   -8
+.2byte    4,   -5, 	   4,   -6, 	  -6,   -7, 	   0,   -6
+.2byte   -1,   -9, 	  -5,   -8, 	   3,   -8, 	  -1,   -8
+.2byte    1,   -8, 	   6,   -8, 	   0,   -6, 	  -1,   -8
+.2byte    3,   -7, 	  -1,   -7, 	   0,   -7, 	  -3,   -8
+.2byte    3,   -9, 	   0,   -8, 	   6,   -8, 	  -1,   -9
+.2byte   -1,   -6, 	   5,   -6, 	  -7,   -6, 	  -1,   -7
+.2byte   -4,   -9, 	  -1,   -8, 	  -7,   -8, 	   0,   -9
+.2byte   -4,   -8, 	   0,   -8, 	  -1,   -8, 	   2,   -9
+.2byte   -2,   -8, 	  -7,   -8, 	  -1,   -6, 	   0,   -8
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	  -5,   -8, 	   3,   -8, 	  -1,   -8
+.2byte   -1,   -5, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+.2byte   -1,   -8, 	   4,   -8, 	  -2,   -6, 	  -3,   -8
+.2byte    4,   -5, 	   4,   -6, 	  -6,   -7, 	   0,   -6
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    2,   -7, 	  -2,   -7, 	  -1,   -7, 	  -4,   -8
+.2byte    5,   -4, 	  -5,   -4, 	  -3,   -3, 	  -1,   -7
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    2,   -9, 	  -1,   -8, 	   5,   -8, 	  -2,   -9
+.2byte    4,   -7, 	  -6,   -5, 	  -2,   -4, 	   0,   -9
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,   -6, 	   5,   -6, 	  -7,   -6, 	  -1,   -7
+.2byte   -1,  -10, 	   5,   -6, 	  -7,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -4,   -9, 	  -1,   -8, 	  -7,   -8, 	   0,   -9
+.2byte   -6,   -7, 	   4,   -5, 	   0,   -4, 	  -2,   -9
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -4,   -7, 	   0,   -7, 	  -1,   -7, 	   2,   -8
+.2byte   -7,   -4, 	   3,   -4, 	   1,   -3, 	  -1,   -7
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -1,   -8, 	  -6,   -8, 	   0,   -6, 	   1,   -8
+.2byte   -6,   -5, 	  -6,   -6, 	   4,   -7, 	  -2,   -6
+.2byte   -1,   -5, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -5,   -5, 	  -5,   -6, 	   5,   -7, 	  -1,   -6
+.2byte   -6,   -5, 	   4,   -5, 	   2,   -4, 	   0,   -8
+.2byte   -5,   -8, 	   5,   -6, 	   1,   -5, 	  -1,  -10
+.2byte   -1,  -10, 	   5,   -6, 	  -7,   -6, 	  -1,  -11
+.2byte    4,   -8, 	  -6,   -6, 	  -2,   -5, 	   0,  -10
+.2byte    5,   -5, 	  -5,   -5, 	  -3,   -4, 	  -1,   -8
+.2byte    4,   -5, 	   4,   -6, 	  -6,   -7, 	   0,   -6
+.2byte   -1,   -7, 	  -7,   -4, 	   5,   -3, 	  -1,   -8
+.2byte   -4,   -7, 	  -6,   -4, 	   3,   -2, 	  -2,   -7
+.2byte   -6,   -6, 	  -1,   -2, 	  -2,   -2, 	  -1,   -8
+.2byte   -3,   -8, 	   3,   -3, 	  -6,   -2, 	   0,   -8
+.2byte   -1,   -8, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte    1,   -8, 	  -5,   -3, 	   4,   -2, 	  -2,   -8
+.2byte    4,   -6, 	  -1,   -2, 	   0,   -2, 	  -1,   -8
+.2byte    2,   -7, 	   4,   -4, 	  -5,   -2, 	   0,   -7
+sSmoochumAnimTable1:
+.4byte sSmoochumAnims_1_1
+.4byte sSmoochumAnims_1_2
+.4byte sSmoochumAnims_1_3
+.4byte sSmoochumAnims_1_4
+.4byte sSmoochumAnims_1_5
+.4byte sSmoochumAnims_1_6
+.4byte sSmoochumAnims_1_7
+.4byte sSmoochumAnims_1_8
+sSmoochumAnimTable2:
+.4byte sSmoochumAnims_2_1
+.4byte sSmoochumAnims_2_2
+.4byte sSmoochumAnims_2_3
+.4byte sSmoochumAnims_2_4
+.4byte sSmoochumAnims_2_5
+.4byte sSmoochumAnims_2_6
+.4byte sSmoochumAnims_2_7
+.4byte sSmoochumAnims_2_8
+sSmoochumAnimTable3:
+.4byte sSmoochumAnims_3_1
+.4byte sSmoochumAnims_3_2
+.4byte sSmoochumAnims_3_3
+.4byte sSmoochumAnims_3_4
+.4byte sSmoochumAnims_3_5
+.4byte sSmoochumAnims_3_6
+.4byte sSmoochumAnims_3_7
+.4byte sSmoochumAnims_3_8
+sSmoochumAnimTable4:
+.4byte sSmoochumAnims_4_1
+.4byte sSmoochumAnims_4_2
+.4byte sSmoochumAnims_4_3
+.4byte sSmoochumAnims_4_4
+.4byte sSmoochumAnims_4_5
+.4byte sSmoochumAnims_4_6
+.4byte sSmoochumAnims_4_7
+.4byte sSmoochumAnims_4_8
+sSmoochumAnimTable5:
+.4byte sSmoochumAnims_5_1
+.4byte sSmoochumAnims_5_2
+.4byte sSmoochumAnims_5_3
+.4byte sSmoochumAnims_5_4
+.4byte sSmoochumAnims_5_5
+.4byte sSmoochumAnims_5_6
+.4byte sSmoochumAnims_5_7
+.4byte sSmoochumAnims_5_8
+sSmoochumAnimTable6:
+.4byte sSmoochumAnims_6_1
+.4byte sSmoochumAnims_6_1
+.4byte sSmoochumAnims_6_1
+.4byte sSmoochumAnims_6_1
+.4byte sSmoochumAnims_6_1
+.4byte sSmoochumAnims_6_1
+.4byte sSmoochumAnims_6_1
+.4byte sSmoochumAnims_6_1
+sSmoochumAnimTable7:
+.4byte sSmoochumAnims_7_1
+.4byte sSmoochumAnims_7_2
+.4byte sSmoochumAnims_7_3
+.4byte sSmoochumAnims_7_4
+.4byte sSmoochumAnims_7_5
+.4byte sSmoochumAnims_7_6
+.4byte sSmoochumAnims_7_7
+.4byte sSmoochumAnims_7_8
+sSmoochumAnimTable8:
+.4byte sSmoochumAnims_8_1
+.4byte sSmoochumAnims_8_2
+.4byte sSmoochumAnims_8_3
+.4byte sSmoochumAnims_8_4
+.4byte sSmoochumAnims_8_5
+.4byte sSmoochumAnims_8_6
+.4byte sSmoochumAnims_8_7
+.4byte sSmoochumAnims_8_8
+sSmoochumAnimTable9:
+.4byte sSmoochumAnims_9_1
+.4byte sSmoochumAnims_9_2
+.4byte sSmoochumAnims_9_3
+.4byte sSmoochumAnims_9_4
+.4byte sSmoochumAnims_9_5
+.4byte sSmoochumAnims_9_6
+.4byte sSmoochumAnims_9_7
+.4byte sSmoochumAnims_9_8
+sSmoochumAnimTable10:
+.4byte sSmoochumAnims_10_1
+.4byte sSmoochumAnims_10_2
+.4byte sSmoochumAnims_10_3
+.4byte sSmoochumAnims_10_4
+.4byte sSmoochumAnims_10_5
+.4byte sSmoochumAnims_10_6
+.4byte sSmoochumAnims_10_7
+.4byte sSmoochumAnims_10_8
+sSmoochumAnimTable11:
+.4byte sSmoochumAnims_11_1
+.4byte sSmoochumAnims_11_2
+.4byte sSmoochumAnims_11_3
+.4byte sSmoochumAnims_11_4
+.4byte sSmoochumAnims_11_5
+.4byte sSmoochumAnims_11_6
+.4byte sSmoochumAnims_11_7
+.4byte sSmoochumAnims_11_8
+sSmoochumAnimTable12:
+.4byte sSmoochumAnims_12_1
+.4byte sSmoochumAnims_12_2
+.4byte sSmoochumAnims_12_3
+.4byte sSmoochumAnims_12_4
+.4byte sSmoochumAnims_12_5
+.4byte sSmoochumAnims_12_6
+.4byte sSmoochumAnims_12_7
+.4byte sSmoochumAnims_12_8
+sSmoochumAnimTable13:
+.4byte sSmoochumAnims_13_1
+.4byte sSmoochumAnims_13_2
+.4byte sSmoochumAnims_13_3
+.4byte sSmoochumAnims_13_4
+.4byte sSmoochumAnims_13_5
+.4byte sSmoochumAnims_13_6
+.4byte sSmoochumAnims_13_7
+.4byte sSmoochumAnims_13_8
+sAxAnimationsSmoochum:
+.4byte sSmoochumAnimTable1
+.4byte sSmoochumAnimTable2
+.4byte sSmoochumAnimTable3
+.4byte sSmoochumAnimTable4
+.4byte sSmoochumAnimTable5
+.4byte sSmoochumAnimTable6
+.4byte sSmoochumAnimTable7
+.4byte sSmoochumAnimTable8
+.4byte sSmoochumAnimTable9
+.4byte sSmoochumAnimTable10
+.4byte sSmoochumAnimTable11
+.4byte sSmoochumAnimTable12
+.4byte sSmoochumAnimTable13
+sAxSpritesSmoochum:
+.4byte sSmoochumSprites1
+.4byte sSmoochumSprites2
+.4byte sSmoochumSprites3
+.4byte sSmoochumSprites4
+.4byte sSmoochumSprites5
+.4byte sSmoochumSprites6
+.4byte sSmoochumSprites7
+.4byte sSmoochumSprites8
+.4byte sSmoochumSprites9
+.4byte sSmoochumSprites10
+.4byte sSmoochumSprites11
+.4byte sSmoochumSprites12
+.4byte sSmoochumSprites13
+.4byte sSmoochumSprites14
+.4byte sSmoochumSprites15
+.4byte sSmoochumSprites16
+.4byte sSmoochumSprites17
+.4byte sSmoochumSprites18
+.4byte sSmoochumSprites19
+.4byte sSmoochumSprites20
+.4byte sSmoochumSprites21
+.4byte sSmoochumSprites22
+.4byte sSmoochumSprites23
+.4byte sSmoochumSprites24
+.4byte sSmoochumSprites25
+.4byte sSmoochumSprites26
+.4byte sSmoochumSprites27
+.4byte sSmoochumSprites28
+.4byte sSmoochumSprites29
+.4byte sSmoochumSprites30
+.4byte sSmoochumSprites31
+.4byte sSmoochumSprites32
+.4byte sSmoochumSprites33
+.4byte sSmoochumSprites34
+.4byte sSmoochumSprites35
+.4byte sSmoochumSprites36
+.4byte sSmoochumSprites37
+.4byte sSmoochumSprites38
+.4byte sSmoochumSprites39
+.4byte sSmoochumSprites40
+.4byte sSmoochumSprites41
+.4byte sSmoochumSprites42
+.4byte sSmoochumSprites43
+.4byte sSmoochumSprites44
+.4byte sSmoochumSprites45
+.4byte sSmoochumSprites46
+sAxMainSmoochum:
+ax_main sAxPosesSmoochum, sAxAnimationsSmoochum, 13, sAxSpritesSmoochum, sAxPositionsSmoochum

--- a/data/ax/sneasel.inc
+++ b/data/ax/sneasel.inc
@@ -1,0 +1,3580 @@
+.global gAxSneasel
+gAxSneasel:
+ax_siro sAxMainSneasel
+sSneaselPose1:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose2:
+ax_pose 1, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose4:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose5:
+ax_pose 4, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose6:
+ax_pose 5, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose7:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose8:
+ax_pose 7, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose9:
+ax_pose 8, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose10:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose11:
+ax_pose 10, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose12:
+ax_pose 11, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose14:
+ax_pose 13, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose16:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose17:
+ax_pose 16, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose18:
+ax_pose 17, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose19:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose20:
+ax_pose 19, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose21:
+ax_pose 20, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose22:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose23:
+ax_pose 22, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose24:
+ax_pose 23, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose25:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose26:
+ax_pose 24, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose27:
+ax_pose 25, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose28:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose29:
+ax_pose 26, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose30:
+ax_pose 27, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sSneaselPose31:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose32:
+ax_pose 28, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose33:
+ax_pose 29, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sSneaselPose34:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose35:
+ax_pose 30, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose36:
+ax_pose 31, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose37:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose38:
+ax_pose 32, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose39:
+ax_pose 33, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose40:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose41:
+ax_pose 34, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose42:
+ax_pose 35, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sSneaselPose43:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose44:
+ax_pose 36, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose45:
+ax_pose 37, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose46:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose47:
+ax_pose 38, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose48:
+ax_pose 39, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose49:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose50:
+ax_pose 1, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose51:
+ax_pose 2, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose52:
+ax_pose 24, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose53:
+ax_pose 40, 0x81e7, 0x8100, 0x2c00
+ax_pose 41, 0x01df, 0x0108, 0x2c08
+ax_pose 42, 0x01f8, 0x40f0, 0x2c09
+ax_pose 43, 0x01e4, 0x80f0, 0x2c0d
+ax_pose_terminator
+sSneaselPose54:
+ax_pose 43, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose55:
+ax_pose 44, 0x81e7, 0x80f0, 0x2c00
+ax_pose 45, 0x01f7, 0x4100, 0x2c08
+ax_pose 46, 0x01df, 0x00f0, 0x2c0c
+ax_pose 47, 0x01e4, 0x80f0, 0x2c0d
+ax_pose_terminator
+sSneaselPose56:
+ax_pose 47, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose57:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose58:
+ax_pose 4, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose59:
+ax_pose 5, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose60:
+ax_pose 26, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose61:
+ax_pose 48, 0x81e3, 0x8101, 0x2c00
+ax_pose 49, 0x01db, 0x0101, 0x2c08
+ax_pose 50, 0x01fb, 0x00f9, 0x2c09
+ax_pose 51, 0x01e4, 0x80f1, 0x2c0a
+ax_pose_terminator
+sSneaselPose62:
+ax_pose 51, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose63:
+ax_pose 52, 0x01e4, 0x80f1, 0x2c00
+ax_pose 53, 0x01e4, 0x80f1, 0x2c10
+ax_pose_terminator
+sSneaselPose64:
+ax_pose 53, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose65:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose66:
+ax_pose 7, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose67:
+ax_pose 8, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose68:
+ax_pose 28, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose69:
+ax_pose 54, 0x01e4, 0x80f0, 0x2c00
+ax_pose 55, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sSneaselPose70:
+ax_pose 55, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose71:
+ax_pose 56, 0x01e2, 0x80f0, 0x2c00
+ax_pose 57, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sSneaselPose72:
+ax_pose 57, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose73:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose74:
+ax_pose 10, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose75:
+ax_pose 11, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose76:
+ax_pose 30, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose77:
+ax_pose 58, 0x01e4, 0x80f1, 0x2c00
+ax_pose 59, 0x01e4, 0x80f1, 0x2c10
+ax_pose_terminator
+sSneaselPose78:
+ax_pose 59, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose79:
+ax_pose 60, 0x01e6, 0x80f1, 0x2c00
+ax_pose 61, 0x01e4, 0x80f1, 0x2c10
+ax_pose_terminator
+sSneaselPose80:
+ax_pose 61, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose81:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose82:
+ax_pose 13, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose83:
+ax_pose 14, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose84:
+ax_pose 32, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose85:
+ax_pose 62, 0x01e4, 0x80f0, 0x2c00
+ax_pose 63, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sSneaselPose86:
+ax_pose 63, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose87:
+ax_pose 64, 0x01e4, 0x80f0, 0x2c00
+ax_pose 65, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sSneaselPose88:
+ax_pose 65, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose89:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose90:
+ax_pose 16, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose91:
+ax_pose 17, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose92:
+ax_pose 34, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose93:
+ax_pose 66, 0x01e6, 0x80ef, 0x2c00
+ax_pose 67, 0x01e4, 0x80ef, 0x2c10
+ax_pose_terminator
+sSneaselPose94:
+ax_pose 67, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sSneaselPose95:
+ax_pose 68, 0x01e4, 0x80ef, 0x2c00
+ax_pose 69, 0x01e4, 0x80ef, 0x2c10
+ax_pose_terminator
+sSneaselPose96:
+ax_pose 69, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sSneaselPose97:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose98:
+ax_pose 19, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose99:
+ax_pose 20, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose100:
+ax_pose 36, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose101:
+ax_pose 70, 0x01df, 0x80f0, 0x2c00
+ax_pose 71, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sSneaselPose102:
+ax_pose 71, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose103:
+ax_pose 72, 0x01e4, 0x80f0, 0x2c00
+ax_pose 73, 0x01e4, 0x80f0, 0x2c10
+ax_pose_terminator
+sSneaselPose104:
+ax_pose 73, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose105:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose106:
+ax_pose 22, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose107:
+ax_pose 23, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose108:
+ax_pose 38, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose109:
+ax_pose 74, 0x01e4, 0x80f1, 0x2c00
+ax_pose 75, 0x01e4, 0x80f1, 0x2c10
+ax_pose_terminator
+sSneaselPose110:
+ax_pose 75, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose111:
+ax_pose 76, 0x0204, 0x00f9, 0x2c00
+ax_pose 77, 0x81e4, 0x80f1, 0x2c01
+ax_pose 78, 0x01fc, 0x0101, 0x2c09
+ax_pose 79, 0x01e4, 0x80f1, 0x2c0a
+ax_pose_terminator
+sSneaselPose112:
+ax_pose 79, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose113:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose114:
+ax_pose 24, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose115:
+ax_pose 80, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose116:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose117:
+ax_pose 26, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose118:
+ax_pose 81, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose119:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose120:
+ax_pose 28, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose121:
+ax_pose 82, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose122:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose123:
+ax_pose 30, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose124:
+ax_pose 83, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose125:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose126:
+ax_pose 32, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose127:
+ax_pose 84, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose128:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose129:
+ax_pose 34, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose130:
+ax_pose 85, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose131:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose132:
+ax_pose 36, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose133:
+ax_pose 86, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose134:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose135:
+ax_pose 38, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose136:
+ax_pose 87, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose137:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose138:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose139:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose140:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose141:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose142:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose143:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose144:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose145:
+ax_pose 88, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose146:
+ax_pose 89, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose147:
+ax_pose 90, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose148:
+ax_pose 91, 0x81e4, 0x00ef, 0x2c00
+ax_pose 92, 0x01e4, 0x00e7, 0x2c02
+ax_pose 93, 0x01f4, 0x00ef, 0x2c03
+ax_pose 94, 0x81e4, 0x40f7, 0x2c04
+ax_pose 95, 0x81e4, 0x80ff, 0x2c08
+ax_pose_terminator
+sSneaselPose149:
+ax_pose 96, 0x81e4, 0x40f5, 0x2c00
+ax_pose 97, 0x81e4, 0x00e5, 0x2c04
+ax_pose 98, 0x81e4, 0x00ed, 0x2c06
+ax_pose 99, 0x81e4, 0x80fd, 0x2c08
+ax_pose_terminator
+sSneaselPose150:
+ax_pose 100, 0x01e1, 0x80ed, 0x2c00
+ax_pose_terminator
+sSneaselPose151:
+ax_pose 101, 0x01e1, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose152:
+ax_pose 102, 0x01e1, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose153:
+ax_pose 103, 0x81e3, 0x4103, 0x2c00
+ax_pose 104, 0x81e3, 0x0113, 0x2c04
+ax_pose 105, 0x81e3, 0x010b, 0x2c06
+ax_pose 106, 0x81e3, 0x80f3, 0x2c08
+ax_pose_terminator
+sSneaselPose154:
+ax_pose 107, 0x81e4, 0x0109, 0x2c00
+ax_pose 108, 0x01e4, 0x0111, 0x2c02
+ax_pose 109, 0x01f4, 0x0109, 0x2c03
+ax_pose 110, 0x81e4, 0x4101, 0x2c04
+ax_pose 111, 0x81e4, 0x80f1, 0x2c08
+ax_pose_terminator
+sSneaselPose155:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose156:
+ax_pose 24, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose157:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose158:
+ax_pose 26, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose159:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose160:
+ax_pose 28, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose161:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose162:
+ax_pose 30, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose163:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose164:
+ax_pose 32, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose165:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose166:
+ax_pose 34, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose167:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose168:
+ax_pose 36, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose169:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose170:
+ax_pose 38, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose171:
+ax_pose 80, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sSneaselPose172:
+ax_pose 87, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose173:
+ax_pose 86, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose174:
+ax_pose 85, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose175:
+ax_pose 84, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose176:
+ax_pose 83, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose177:
+ax_pose 82, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose178:
+ax_pose 81, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose179:
+ax_pose 80, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sSneaselPose180:
+ax_pose 81, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose181:
+ax_pose 82, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose182:
+ax_pose 83, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose183:
+ax_pose 84, 0x01e3, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose184:
+ax_pose 85, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose185:
+ax_pose 86, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose186:
+ax_pose 87, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose187:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose188:
+ax_pose 24, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose189:
+ax_pose 80, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose190:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose191:
+ax_pose 26, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose192:
+ax_pose 81, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose193:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose194:
+ax_pose 28, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose195:
+ax_pose 82, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose196:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose197:
+ax_pose 30, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose198:
+ax_pose 83, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose199:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose200:
+ax_pose 32, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose201:
+ax_pose 84, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose202:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose203:
+ax_pose 34, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose204:
+ax_pose 85, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose205:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose206:
+ax_pose 36, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose207:
+ax_pose 86, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose208:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose209:
+ax_pose 38, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose210:
+ax_pose 87, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sSneaselPose211:
+ax_pose 24, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sSneaselPose212:
+ax_pose 38, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose213:
+ax_pose 36, 0x01e4, 0x80ef, 0x2c00
+ax_pose_terminator
+sSneaselPose214:
+ax_pose 34, 0x01e3, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose215:
+ax_pose 32, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose216:
+ax_pose 30, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sSneaselPose217:
+ax_pose 28, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose218:
+ax_pose 26, 0x01e4, 0x80f6, 0x2c00
+ax_pose_terminator
+sSneaselPose219:
+ax_pose 0, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose220:
+ax_pose 21, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sSneaselPose221:
+ax_pose 18, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose222:
+ax_pose 15, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sSneaselPose223:
+ax_pose 12, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose224:
+ax_pose 9, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSneaselPose225:
+ax_pose 6, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sSneaselPose226:
+ax_pose 3, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+.align 2
+sSneaselAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 1, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 0, 26, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSneaselAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 11, 10, 11,
+ax_anim 2, 0, 29, 18, 20, 18, 20,
+ax_anim 2, 1, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 29, 18, 20, 18, 20,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 27, 6, 7, 6, 7,
+ax_anim_terminator
+sSneaselAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 17, 0, 17, 0,
+ax_anim 2, 1, 32, 17, 1, 17, 1,
+ax_anim 2, 0, 32, 17, 0, 17, 0,
+ax_anim 2, 0, 32, 17, 1, 17, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSneaselAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 11, -11, 11, -11,
+ax_anim 2, 0, 35, 18, -16, 18, -16,
+ax_anim 2, 1, 35, 19, -15, 19, -15,
+ax_anim 2, 0, 35, 18, -16, 18, -16,
+ax_anim 2, 0, 35, 19, -15, 19, -15,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSneaselAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -9, 0, -9,
+ax_anim 2, 0, 38, 0, -16, 0, -16,
+ax_anim 2, 1, 38, 1, -16, 1, -16,
+ax_anim 2, 0, 38, 0, -16, 0, -16,
+ax_anim 2, 0, 38, 1, -16, 1, -16,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSneaselAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -5, -6, -5, -6,
+ax_anim 1, 0, 41, -11, -11, -11, -11,
+ax_anim 2, 0, 41, -18, -16, -18, -16,
+ax_anim 2, 1, 41, -19, -15, -19, -15,
+ax_anim 2, 0, 41, -18, -16, -18, -16,
+ax_anim 2, 0, 41, -19, -15, -19, -15,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSneaselAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 1, 44, -17, 1, -17, 1,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 44, -17, 1, -17, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSneaselAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 11, -10, 11,
+ax_anim 2, 0, 47, -18, 20, -18, 20,
+ax_anim 2, 1, 47, -19, 19, -19, 19,
+ax_anim 2, 0, 47, -18, 20, -18, 20,
+ax_anim 2, 0, 47, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -6, 7, -6, 7,
+ax_anim_terminator
+.align 2
+sSneaselAnims_3_1:
+ax_anim 1, 0, 51, 0, -2, 0, -2,
+ax_anim 2, 0, 59, 0, -4, 0, -4,
+ax_anim 4, 0, 63, 0, -5, 0, -5,
+ax_anim 1, 2, 63, 0, 2, 0, 2,
+ax_anim 1, 0, 55, 0, 10, 0, 10,
+ax_anim 2, 0, 52, 0, 16, 0, 16,
+ax_anim 4, 1, 109, -1, 17, -1, 17,
+ax_anim 1, 0, 53, 0, 17, 0, 17,
+ax_anim 2, 0, 54, 2, 18, 2, 18,
+ax_anim 4, 0, 63, 3, 18, 3, 18,
+ax_anim 1, 0, 55, 0, 18, 0, 18,
+ax_anim 2, 0, 52, 0, 16, 0, 16,
+ax_anim 4, 0, 109, -1, 18, -1, 18,
+ax_anim 1, 0, 53, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sSneaselAnims_3_2:
+ax_anim 1, 0, 59, -2, -2, -2, -2,
+ax_anim 2, 0, 67, -4, -4, -4, -4,
+ax_anim 4, 0, 71, -5, -5, -5, -5,
+ax_anim 1, 2, 71, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 14, 20, 14, 20,
+ax_anim 4, 1, 53, 14, 21, 14, 21,
+ax_anim 1, 0, 61, 15, 21, 15, 21,
+ax_anim 2, 0, 62, 18, 21, 18, 21,
+ax_anim 4, 0, 71, 19, 19, 19, 19,
+ax_anim 1, 0, 63, 16, 20, 16, 20,
+ax_anim 2, 0, 60, 13, 22, 13, 22,
+ax_anim 4, 0, 53, 14, 21, 14, 21,
+ax_anim 1, 0, 61, 8, 11, 8, 11,
+ax_anim 2, 0, 56, 4, 5, 4, 5,
+ax_anim_terminator
+sSneaselAnims_3_3:
+ax_anim 1, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 79, -4, 0, -4, 0,
+ax_anim 4, 0, 79, -5, 0, -5, 0,
+ax_anim 1, 2, 79, 2, 0, 2, 0,
+ax_anim 1, 0, 71, 10, 0, 10, 0,
+ax_anim 2, 0, 68, 14, 0, 14, 0,
+ax_anim 4, 1, 61, 13, 1, 13, 1,
+ax_anim 1, 0, 69, 15, 0, 15, 0,
+ax_anim 2, 0, 70, 14, 0, 14, 0,
+ax_anim 4, 0, 79, 13, 0, 13, 0,
+ax_anim 1, 0, 71, 15, 0, 15, 0,
+ax_anim 2, 0, 68, 14, 0, 14, 0,
+ax_anim 4, 0, 61, 15, 0, 15, 0,
+ax_anim 1, 0, 69, 8, 0, 8, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sSneaselAnims_3_4:
+ax_anim 1, 0, 75, -2, 2, -2, 2,
+ax_anim 2, 0, 87, -4, 4, -4, 4,
+ax_anim 4, 0, 87, -5, 5, -5, 5,
+ax_anim 1, 2, 87, 2, -2, 2, -2,
+ax_anim 1, 0, 79, 10, -10, 10, -10,
+ax_anim 2, 0, 76, 14, -14, 14, -14,
+ax_anim 4, 1, 69, 17, -15, 17, -15,
+ax_anim 1, 0, 77, 17, -17, 17, -17,
+ax_anim 2, 0, 78, 16, -18, 16, -18,
+ax_anim 4, 0, 87, 17, -19, 17, -19,
+ax_anim 1, 0, 79, 16, -18, 16, -18,
+ax_anim 2, 0, 76, 18, -17, 18, -17,
+ax_anim 4, 0, 69, 21, -17, 21, -17,
+ax_anim 1, 0, 77, 9, -10, 9, -10,
+ax_anim 2, 0, 72, 4, -5, 4, -5,
+ax_anim_terminator
+sSneaselAnims_3_5:
+ax_anim 1, 0, 83, 0, 2, 0, 2,
+ax_anim 2, 0, 95, 0, 4, 0, 4,
+ax_anim 4, 0, 95, 0, 5, 0, 5,
+ax_anim 1, 2, 95, 0, -2, 0, -2,
+ax_anim 1, 0, 87, 0, -8, 0, -8,
+ax_anim 2, 0, 84, 0, -13, 0, -13,
+ax_anim 4, 1, 77, 1, -14, 1, -14,
+ax_anim 1, 0, 85, 0, -16, 0, -16,
+ax_anim 2, 0, 86, 0, -18, 0, -18,
+ax_anim 4, 0, 95, -3, -19, -3, -19,
+ax_anim 1, 0, 87, -1, -20, -1, -20,
+ax_anim 2, 0, 84, 1, -20, 1, -20,
+ax_anim 4, 0, 77, 0, -19, 0, -19,
+ax_anim 1, 0, 85, 0, -8, 0, -8,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sSneaselAnims_3_6:
+ax_anim 1, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 103, 4, 4, 4, 4,
+ax_anim 4, 0, 103, 5, 5, 5, 5,
+ax_anim 1, 2, 103, -2, -2, -2, -2,
+ax_anim 1, 0, 95, -10, -10, -10, -10,
+ax_anim 2, 0, 92, -11, -14, -11, -14,
+ax_anim 4, 1, 85, -12, -15, -12, -15,
+ax_anim 1, 0, 93, -13, -16, -13, -16,
+ax_anim 2, 0, 94, -14, -17, -14, -17,
+ax_anim 4, 0, 103, -17, -17, -17, -17,
+ax_anim 1, 0, 95, -16, -18, -16, -18,
+ax_anim 2, 0, 92, -16, -20, -16, -20,
+ax_anim 4, 0, 85, -17, -20, -17, -20,
+ax_anim 1, 0, 93, -9, -10, -9, -10,
+ax_anim 2, 0, 88, -4, -5, -4, -5,
+ax_anim_terminator
+sSneaselAnims_3_7:
+ax_anim 1, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 111, 4, 0, 4, 0,
+ax_anim 4, 0, 111, 5, 0, 5, 0,
+ax_anim 1, 2, 111, -2, 0, -2, 0,
+ax_anim 1, 0, 103, -8, 0, -8, 0,
+ax_anim 2, 0, 100, -14, 0, -14, 0,
+ax_anim 4, 1, 93, -15, 0, -15, 0,
+ax_anim 1, 0, 101, -16, 0, -16, 0,
+ax_anim 2, 0, 102, -17, 0, -17, 0,
+ax_anim 4, 0, 111, -17, 0, -17, 0,
+ax_anim 1, 0, 103, -18, 0, -18, 0,
+ax_anim 2, 0, 100, -19, 0, -19, 0,
+ax_anim 4, 0, 93, -18, 0, -18, 0,
+ax_anim 1, 0, 101, -8, 0, -8, 0,
+ax_anim 2, 0, 96, -4, 0, -4, 0,
+ax_anim_terminator
+sSneaselAnims_3_8:
+ax_anim 1, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 55, 4, -4, 4, -4,
+ax_anim 4, 0, 55, 5, -5, 5, -5,
+ax_anim 1, 2, 55, -2, 2, -2, 2,
+ax_anim 1, 0, 111, -8, 9, -8, 9,
+ax_anim 2, 0, 108, -12, 15, -12, 15,
+ax_anim 4, 1, 101, -14, 16, -14, 16,
+ax_anim 1, 0, 109, -13, 18, -13, 18,
+ax_anim 2, 0, 110, -13, 21, -13, 21,
+ax_anim 4, 0, 55, -13, 22, -13, 22,
+ax_anim 1, 0, 111, -14, 22, -14, 22,
+ax_anim 2, 0, 108, -16, 22, -16, 22,
+ax_anim 4, 0, 101, -18, 21, -18, 21,
+ax_anim 1, 0, 109, -8, 11, -8, 11,
+ax_anim 2, 0, 104, -4, 5, -4, 5,
+ax_anim_terminator
+.align 2
+sSneaselAnims_4_1:
+ax_anim 2, 0, 113, 0, -2, 0, -2,
+ax_anim 6, 2, 113, 0, -3, 0, -3,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 1, 114, 0, 3, 0, 3,
+ax_anim 2, 0, 114, 1, 3, 1, 3,
+ax_anim 2, 0, 114, 0, 3, 0, 3,
+ax_anim 2, 0, 114, 1, 3, 1, 3,
+ax_anim 2, 0, 114, 0, 3, 0, 3,
+ax_anim 2, 0, 114, 1, 3, 1, 3,
+ax_anim 2, 0, 114, 0, 3, 0, 3,
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim_terminator
+sSneaselAnims_4_2:
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim 6, 2, 116, -3, -3, -3, -3,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 1, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 3, 1, 3, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 3, 1, 3, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 3, 1, 3, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 115, 1, 1, 1, 1,
+ax_anim_terminator
+sSneaselAnims_4_3:
+ax_anim 2, 0, 119, -2, 0, -2, 0,
+ax_anim 6, 2, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim 2, 1, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 2, 1, 2, 1,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim_terminator
+sSneaselAnims_4_4:
+ax_anim 2, 0, 122, -2, 2, -2, 2,
+ax_anim 6, 2, 122, -3, 3, -3, 3,
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 2, 1, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -1, 3, -1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -1, 3, -1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 123, 3, -1, 3, -1,
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 121, 1, -1, 1, -1,
+ax_anim_terminator
+sSneaselAnims_4_5:
+ax_anim 2, 0, 125, 0, 2, 0, 2,
+ax_anim 6, 2, 125, 0, 3, 0, 3,
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 2, 1, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 126, 1, -3, 1, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 126, 1, -3, 1, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 126, 1, -3, 1, -3,
+ax_anim 2, 0, 126, 0, -3, 0, -3,
+ax_anim 2, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sSneaselAnims_4_6:
+ax_anim 2, 0, 128, 2, 2, 2, 2,
+ax_anim 6, 2, 128, 3, 3, 3, 3,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 1, 129, -2, -2, -2, -2,
+ax_anim 2, 0, 129, -3, -1, -3, -1,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 2, 0, 129, -3, -1, -3, -1,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 2, 0, 129, -3, -1, -3, -1,
+ax_anim 2, 0, 129, -2, -2, -2, -2,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+sSneaselAnims_4_7:
+ax_anim 2, 0, 131, 2, 0, 2, 0,
+ax_anim 6, 2, 131, 3, 0, 3, 0,
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 2, 1, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 132, -2, 1, -2, 1,
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim_terminator
+sSneaselAnims_4_8:
+ax_anim 2, 0, 134, 2, -2, 2, -2,
+ax_anim 6, 2, 134, 3, -3, 3, -3,
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 2, 1, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 135, -2, 2, -2, 2,
+ax_anim 2, 0, 133, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSneaselAnims_5_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_5_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_5_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_5_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sSneaselAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sSneaselAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sSneaselAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sSneaselAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sSneaselAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sSneaselAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sSneaselAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSneaselAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -2, 0, 0,
+ax_anim 2, 0, 155, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, -5, 0, 0,
+ax_anim 2, 0, 155, 0, -4, 0, 0,
+ax_anim 2, 0, 155, 0, -2, 0, 0,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_8_2:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, -4, 0, 0,
+ax_anim 4, 0, 157, 0, -5, 0, 0,
+ax_anim 2, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 157, 0, -2, 0, 0,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_8_3:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 4, 0, 159, 0, -5, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_8_4:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -3, 0, 0,
+ax_anim 2, 0, 161, 0, -5, 0, 0,
+ax_anim 4, 0, 161, 0, -6, 0, 0,
+ax_anim 2, 0, 161, 0, -5, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_8_5:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 4, 0, 163, 0, -5, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 2, 0, 163, 0, -2, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_8_6:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -3, 0, 0,
+ax_anim 2, 0, 165, 0, -5, 0, 0,
+ax_anim 4, 0, 165, 0, -6, 0, 0,
+ax_anim 2, 0, 165, 0, -5, 0, 0,
+ax_anim 2, 0, 165, 0, -3, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_8_7:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -2, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 4, 0, 167, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 2, 0, 167, 0, -2, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_8_8:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim 2, 0, 169, 0, -4, 0, 0,
+ax_anim 4, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -4, 0, 0,
+ax_anim 2, 0, 169, 0, -2, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 18, 3, 18, 3,
+ax_anim 2, 0, 172, 21, 11, 21, 11,
+ax_anim 3, 0, 173, 22, 19, 22, 19,
+ax_anim 2, 3, 174, 11, 20, 11, 20,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 21, -2, 21, -2,
+ax_anim 2, 3, 173, 19, 4, 19, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 21, -19, 21, -19,
+ax_anim 2, 3, 172, 22, -12, 22, -12,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -21, 0, -21,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -12, 9, -12,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -21, -19, -21, -19,
+ax_anim 2, 3, 176, -22, -12, -22, -12,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -21, -2, -21, -2,
+ax_anim 2, 3, 175, -19, 4, -19, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -18, 3, -18, 3,
+ax_anim 2, 0, 176, -21, 11, -21, 11,
+ax_anim 3, 0, 175, -22, 19, -22, 19,
+ax_anim 2, 3, 174, -11, 20, -11, 20,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSneaselAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSneaselGfx1:
+.incbin "baserom.gba", 0xEB1E48, 0x200
+sSneaselSprites1:
+ax_sprite sSneaselGfx1, 0x200
+ax_sprite_terminator
+sSneaselGfx2:
+.incbin "baserom.gba", 0xEB2058, 0x200
+sSneaselSprites2:
+ax_sprite sSneaselGfx2, 0x200
+ax_sprite_terminator
+sSneaselGfx3:
+.incbin "baserom.gba", 0xEB2268, 0x200
+sSneaselSprites3:
+ax_sprite sSneaselGfx3, 0x200
+ax_sprite_terminator
+sSneaselGfx4:
+.incbin "baserom.gba", 0xEB2478, 0x200
+sSneaselSprites4:
+ax_sprite sSneaselGfx4, 0x200
+ax_sprite_terminator
+sSneaselGfx5:
+.incbin "baserom.gba", 0xEB2688, 0x200
+sSneaselSprites5:
+ax_sprite sSneaselGfx5, 0x200
+ax_sprite_terminator
+sSneaselGfx6:
+.incbin "baserom.gba", 0xEB2898, 0x200
+sSneaselSprites6:
+ax_sprite sSneaselGfx6, 0x200
+ax_sprite_terminator
+sSneaselGfx7:
+.incbin "baserom.gba", 0xEB2AA8, 0x200
+sSneaselSprites7:
+ax_sprite sSneaselGfx7, 0x200
+ax_sprite_terminator
+sSneaselGfx8:
+.incbin "baserom.gba", 0xEB2CB8, 0x200
+sSneaselSprites8:
+ax_sprite sSneaselGfx8, 0x200
+ax_sprite_terminator
+sSneaselGfx9:
+.incbin "baserom.gba", 0xEB2EC8, 0x200
+sSneaselSprites9:
+ax_sprite sSneaselGfx9, 0x200
+ax_sprite_terminator
+sSneaselGfx10:
+.incbin "baserom.gba", 0xEB30D8, 0x200
+sSneaselSprites10:
+ax_sprite sSneaselGfx10, 0x200
+ax_sprite_terminator
+sSneaselGfx11:
+.incbin "baserom.gba", 0xEB32E8, 0x200
+sSneaselSprites11:
+ax_sprite sSneaselGfx11, 0x200
+ax_sprite_terminator
+sSneaselGfx12:
+.incbin "baserom.gba", 0xEB34F8, 0x200
+sSneaselSprites12:
+ax_sprite sSneaselGfx12, 0x200
+ax_sprite_terminator
+sSneaselGfx13:
+.incbin "baserom.gba", 0xEB3708, 0x200
+sSneaselSprites13:
+ax_sprite sSneaselGfx13, 0x200
+ax_sprite_terminator
+sSneaselGfx14:
+.incbin "baserom.gba", 0xEB3918, 0x200
+sSneaselSprites14:
+ax_sprite sSneaselGfx14, 0x200
+ax_sprite_terminator
+sSneaselGfx15:
+.incbin "baserom.gba", 0xEB3B28, 0x200
+sSneaselSprites15:
+ax_sprite sSneaselGfx15, 0x200
+ax_sprite_terminator
+sSneaselGfx16:
+.incbin "baserom.gba", 0xEB3D38, 0x200
+sSneaselSprites16:
+ax_sprite sSneaselGfx16, 0x200
+ax_sprite_terminator
+sSneaselGfx17:
+.incbin "baserom.gba", 0xEB3F48, 0x200
+sSneaselSprites17:
+ax_sprite sSneaselGfx17, 0x200
+ax_sprite_terminator
+sSneaselGfx18:
+.incbin "baserom.gba", 0xEB4158, 0x200
+sSneaselSprites18:
+ax_sprite sSneaselGfx18, 0x200
+ax_sprite_terminator
+sSneaselGfx19:
+.incbin "baserom.gba", 0xEB4368, 0x200
+sSneaselSprites19:
+ax_sprite sSneaselGfx19, 0x200
+ax_sprite_terminator
+sSneaselGfx20:
+.incbin "baserom.gba", 0xEB4578, 0x200
+sSneaselSprites20:
+ax_sprite sSneaselGfx20, 0x200
+ax_sprite_terminator
+sSneaselGfx21:
+.incbin "baserom.gba", 0xEB4788, 0x200
+sSneaselSprites21:
+ax_sprite sSneaselGfx21, 0x200
+ax_sprite_terminator
+sSneaselGfx22:
+.incbin "baserom.gba", 0xEB4998, 0x200
+sSneaselSprites22:
+ax_sprite sSneaselGfx22, 0x200
+ax_sprite_terminator
+sSneaselGfx23:
+.incbin "baserom.gba", 0xEB4BA8, 0x200
+sSneaselSprites23:
+ax_sprite sSneaselGfx23, 0x200
+ax_sprite_terminator
+sSneaselGfx24:
+.incbin "baserom.gba", 0xEB4DB8, 0x200
+sSneaselSprites24:
+ax_sprite sSneaselGfx24, 0x200
+ax_sprite_terminator
+sSneaselGfx25:
+.incbin "baserom.gba", 0xEB4FC8, 0x160
+sSneaselGfx25_1:
+.incbin "baserom.gba", 0xEB5128, 0x60
+sSneaselSprites25:
+ax_sprite sSneaselGfx25, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx26:
+.incbin "baserom.gba", 0xEB51B0, 0x20
+sSneaselGfx26_1:
+.incbin "baserom.gba", 0xEB51D0, 0x160
+sSneaselSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx26, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx26_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx27:
+.incbin "baserom.gba", 0xEB5360, 0x60
+sSneaselGfx27_1:
+.incbin "baserom.gba", 0xEB53C0, 0x60
+sSneaselGfx27_2:
+.incbin "baserom.gba", 0xEB5420, 0x60
+sSneaselGfx27_3:
+.incbin "baserom.gba", 0xEB5480, 0x40
+sSneaselSprites27:
+ax_sprite sSneaselGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx27_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSneaselGfx28:
+.incbin "baserom.gba", 0xEB5508, 0x40
+sSneaselGfx28_1:
+.incbin "baserom.gba", 0xEB5548, 0x180
+sSneaselSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx28_1, 0x180
+ax_sprite_terminator
+sSneaselGfx29:
+.incbin "baserom.gba", 0xEB56F0, 0x60
+sSneaselGfx29_1:
+.incbin "baserom.gba", 0xEB5750, 0x140
+sSneaselSprites29:
+ax_sprite sSneaselGfx29, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx29_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx30:
+.incbin "baserom.gba", 0xEB58B8, 0x1A0
+sSneaselSprites30:
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx30, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx31:
+.incbin "baserom.gba", 0xEB5A78, 0x40
+sSneaselGfx31_1:
+.incbin "baserom.gba", 0xEB5AB8, 0x60
+sSneaselGfx31_2:
+.incbin "baserom.gba", 0xEB5B18, 0x60
+sSneaselGfx31_3:
+.incbin "baserom.gba", 0xEB5B78, 0x60
+sSneaselSprites31:
+ax_sprite sSneaselGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx32:
+.incbin "baserom.gba", 0xEB5C20, 0x1C0
+sSneaselSprites32:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx32, 0x1c0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx33:
+.incbin "baserom.gba", 0xEB5E00, 0x40
+sSneaselGfx33_1:
+.incbin "baserom.gba", 0xEB5E40, 0x100
+sSneaselGfx33_2:
+.incbin "baserom.gba", 0xEB5F40, 0x40
+sSneaselSprites33:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx34:
+.incbin "baserom.gba", 0xEB5FC0, 0x60
+sSneaselGfx34_1:
+.incbin "baserom.gba", 0xEB6020, 0xE0
+sSneaselGfx34_2:
+.incbin "baserom.gba", 0xEB6100, 0x40
+sSneaselSprites34:
+ax_sprite sSneaselGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx34_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx35:
+.incbin "baserom.gba", 0xEB6178, 0x20
+sSneaselGfx35_1:
+.incbin "baserom.gba", 0xEB6198, 0x60
+sSneaselGfx35_2:
+.incbin "baserom.gba", 0xEB61F8, 0x60
+sSneaselGfx35_3:
+.incbin "baserom.gba", 0xEB6258, 0x40
+sSneaselSprites35:
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx35, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx36:
+.incbin "baserom.gba", 0xEB62E8, 0x40
+sSneaselGfx36_1:
+.incbin "baserom.gba", 0xEB6328, 0x60
+sSneaselGfx36_2:
+.incbin "baserom.gba", 0xEB6388, 0x60
+sSneaselGfx36_3:
+.incbin "baserom.gba", 0xEB63E8, 0x60
+sSneaselSprites36:
+ax_sprite sSneaselGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx36_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx37:
+.incbin "baserom.gba", 0xEB6490, 0x160
+sSneaselGfx37_1:
+.incbin "baserom.gba", 0xEB65F0, 0x60
+sSneaselSprites37:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx37, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx37_1, 0x60
+ax_sprite_terminator
+sSneaselGfx38:
+.incbin "baserom.gba", 0xEB6678, 0x40
+sSneaselGfx38_1:
+.incbin "baserom.gba", 0xEB66B8, 0x60
+sSneaselGfx38_2:
+.incbin "baserom.gba", 0xEB6718, 0x80
+sSneaselGfx38_3:
+.incbin "baserom.gba", 0xEB6798, 0x60
+sSneaselSprites38:
+ax_sprite sSneaselGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx38_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx38_3, 0x60
+ax_sprite_terminator
+sSneaselGfx39:
+.incbin "baserom.gba", 0xEB6838, 0x140
+sSneaselGfx39_1:
+.incbin "baserom.gba", 0xEB6978, 0x60
+sSneaselSprites39:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx39, 0x140
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx40:
+.incbin "baserom.gba", 0xEB6A08, 0x60
+sSneaselGfx40_1:
+.incbin "baserom.gba", 0xEB6A68, 0x100
+sSneaselSprites40:
+ax_sprite 0, 0x80
+ax_sprite sSneaselGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx40_1, 0x100
+ax_sprite_terminator
+sSneaselGfx41:
+.incbin "baserom.gba", 0xEB6B90, 0xC0
+sSneaselSprites41:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx41, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx42:
+.incbin "baserom.gba", 0xEB6C70, 0x20
+sSneaselSprites42:
+ax_sprite sSneaselGfx42, 0x20
+ax_sprite_terminator
+sSneaselGfx43:
+.incbin "baserom.gba", 0xEB6CA0, 0x80
+sSneaselSprites43:
+ax_sprite sSneaselGfx43, 0x80
+ax_sprite_terminator
+sSneaselGfx44:
+.incbin "baserom.gba", 0xEB6D30, 0x20
+sSneaselGfx44_1:
+.incbin "baserom.gba", 0xEB6D50, 0x60
+sSneaselGfx44_2:
+.incbin "baserom.gba", 0xEB6DB0, 0xE0
+sSneaselSprites44:
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx44, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx44_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx45:
+.incbin "baserom.gba", 0xEB6ED0, 0x20
+sSneaselGfx45_1:
+.incbin "baserom.gba", 0xEB6EF0, 0x80
+sSneaselGfx45_2:
+.incbin "baserom.gba", 0xEB6F70, 0x20
+sSneaselSprites45:
+ax_sprite sSneaselGfx45, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx45_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx45_2, 0x20
+ax_sprite_terminator
+sSneaselGfx46:
+.incbin "baserom.gba", 0xEB6FC0, 0x20
+sSneaselGfx46_1:
+.incbin "baserom.gba", 0xEB6FE0, 0x40
+sSneaselSprites46:
+ax_sprite sSneaselGfx46, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx46_1, 0x40
+ax_sprite_terminator
+sSneaselGfx47:
+.incbin "baserom.gba", 0xEB7040, 0x20
+sSneaselSprites47:
+ax_sprite sSneaselGfx47, 0x20
+ax_sprite_terminator
+sSneaselGfx48:
+.incbin "baserom.gba", 0xEB7070, 0x180
+sSneaselSprites48:
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx48, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx49:
+.incbin "baserom.gba", 0xEB7210, 0x40
+sSneaselGfx49_1:
+.incbin "baserom.gba", 0xEB7250, 0xA0
+sSneaselSprites49:
+ax_sprite sSneaselGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx49_1, 0xa0
+ax_sprite_terminator
+sSneaselGfx50:
+.incbin "baserom.gba", 0xEB7310, 0x20
+sSneaselSprites50:
+ax_sprite sSneaselGfx50, 0x20
+ax_sprite_terminator
+sSneaselGfx51:
+.incbin "baserom.gba", 0xEB7340, 0x20
+sSneaselSprites51:
+ax_sprite sSneaselGfx51, 0x20
+ax_sprite_terminator
+sSneaselGfx52:
+.incbin "baserom.gba", 0xEB7370, 0x140
+sSneaselGfx52_1:
+.incbin "baserom.gba", 0xEB74B0, 0x40
+sSneaselSprites52:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx52, 0x140
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx52_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx53:
+.incbin "baserom.gba", 0xEB7520, 0x20
+sSneaselGfx53_1:
+.incbin "baserom.gba", 0xEB7540, 0x20
+sSneaselGfx53_2:
+.incbin "baserom.gba", 0xEB7560, 0x80
+sSneaselGfx53_3:
+.incbin "baserom.gba", 0xEB75E0, 0x60
+sSneaselSprites53:
+ax_sprite sSneaselGfx53, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx53_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx53_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx53_3, 0x60
+ax_sprite_terminator
+sSneaselGfx54:
+.incbin "baserom.gba", 0xEB7680, 0x40
+sSneaselGfx54_1:
+.incbin "baserom.gba", 0xEB76C0, 0x100
+sSneaselGfx54_2:
+.incbin "baserom.gba", 0xEB77C0, 0x60
+sSneaselSprites54:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx54, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx54_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx54_2, 0x60
+ax_sprite_terminator
+sSneaselGfx55:
+.incbin "baserom.gba", 0xEB7858, 0x80
+sSneaselGfx55_1:
+.incbin "baserom.gba", 0xEB78D8, 0x40
+sSneaselGfx55_2:
+.incbin "baserom.gba", 0xEB7918, 0x40
+sSneaselGfx55_3:
+.incbin "baserom.gba", 0xEB7958, 0x60
+sSneaselSprites55:
+ax_sprite sSneaselGfx55, 0x80
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx55_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx55_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx55_3, 0x60
+ax_sprite_terminator
+sSneaselGfx56:
+.incbin "baserom.gba", 0xEB79F8, 0x40
+sSneaselGfx56_1:
+.incbin "baserom.gba", 0xEB7A38, 0x100
+sSneaselGfx56_2:
+.incbin "baserom.gba", 0xEB7B38, 0x40
+sSneaselSprites56:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx56_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx56_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx57:
+.incbin "baserom.gba", 0xEB7BB8, 0x80
+sSneaselGfx57_1:
+.incbin "baserom.gba", 0xEB7C38, 0x60
+sSneaselGfx57_2:
+.incbin "baserom.gba", 0xEB7C98, 0x40
+sSneaselSprites57:
+ax_sprite 0, 0x80
+ax_sprite sSneaselGfx57, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx57_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx57_2, 0x40
+ax_sprite_terminator
+sSneaselGfx58:
+.incbin "baserom.gba", 0xEB7D10, 0x160
+sSneaselGfx58_1:
+.incbin "baserom.gba", 0xEB7E70, 0x60
+sSneaselSprites58:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx58, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx58_1, 0x60
+ax_sprite_terminator
+sSneaselGfx59:
+.incbin "baserom.gba", 0xEB7EF8, 0x100
+sSneaselGfx59_1:
+.incbin "baserom.gba", 0xEB7FF8, 0x40
+sSneaselGfx59_2:
+.incbin "baserom.gba", 0xEB8038, 0x20
+sSneaselSprites59:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx59, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx59_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx59_2, 0x20
+ax_sprite_terminator
+sSneaselGfx60:
+.incbin "baserom.gba", 0xEB8090, 0x40
+sSneaselGfx60_1:
+.incbin "baserom.gba", 0xEB80D0, 0x180
+sSneaselSprites60:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx60, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx60_1, 0x180
+ax_sprite_terminator
+sSneaselGfx61:
+.incbin "baserom.gba", 0xEB8278, 0x20
+sSneaselGfx61_1:
+.incbin "baserom.gba", 0xEB8298, 0x40
+sSneaselGfx61_2:
+.incbin "baserom.gba", 0xEB82D8, 0x40
+sSneaselGfx61_3:
+.incbin "baserom.gba", 0xEB8318, 0x40
+sSneaselSprites61:
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx61, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx61_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx61_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx61_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx62:
+.incbin "baserom.gba", 0xEB83A8, 0x60
+sSneaselGfx62_1:
+.incbin "baserom.gba", 0xEB8408, 0x60
+sSneaselGfx62_2:
+.incbin "baserom.gba", 0xEB8468, 0x60
+sSneaselGfx62_3:
+.incbin "baserom.gba", 0xEB84C8, 0x40
+sSneaselSprites62:
+ax_sprite sSneaselGfx62, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx62_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx62_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx62_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx63:
+.incbin "baserom.gba", 0xEB8550, 0x60
+sSneaselGfx63_1:
+.incbin "baserom.gba", 0xEB85B0, 0xA0
+sSneaselGfx63_2:
+.incbin "baserom.gba", 0xEB8650, 0x60
+sSneaselGfx63_3:
+.incbin "baserom.gba", 0xEB86B0, 0x20
+sSneaselSprites63:
+ax_sprite sSneaselGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx63_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx63_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx63_3, 0x20
+ax_sprite_terminator
+sSneaselGfx64:
+.incbin "baserom.gba", 0xEB8710, 0x20
+sSneaselGfx64_1:
+.incbin "baserom.gba", 0xEB8730, 0x60
+sSneaselGfx64_2:
+.incbin "baserom.gba", 0xEB8790, 0x60
+sSneaselGfx64_3:
+.incbin "baserom.gba", 0xEB87F0, 0x40
+sSneaselSprites64:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx64, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx64_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx64_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx64_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx65:
+.incbin "baserom.gba", 0xEB8880, 0x60
+sSneaselGfx65_1:
+.incbin "baserom.gba", 0xEB88E0, 0x80
+sSneaselGfx65_2:
+.incbin "baserom.gba", 0xEB8960, 0x40
+sSneaselGfx65_3:
+.incbin "baserom.gba", 0xEB89A0, 0x20
+sSneaselSprites65:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx65, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx65_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx65_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx65_3, 0x20
+ax_sprite_terminator
+sSneaselGfx66:
+.incbin "baserom.gba", 0xEB8A08, 0x40
+sSneaselGfx66_1:
+.incbin "baserom.gba", 0xEB8A48, 0x60
+sSneaselGfx66_2:
+.incbin "baserom.gba", 0xEB8AA8, 0x60
+sSneaselGfx66_3:
+.incbin "baserom.gba", 0xEB8B08, 0x40
+sSneaselSprites66:
+ax_sprite sSneaselGfx66, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx66_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx66_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx66_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx67:
+.incbin "baserom.gba", 0xEB8B90, 0x20
+sSneaselGfx67_1:
+.incbin "baserom.gba", 0xEB8BB0, 0x40
+sSneaselGfx67_2:
+.incbin "baserom.gba", 0xEB8BF0, 0x40
+sSneaselGfx67_3:
+.incbin "baserom.gba", 0xEB8C30, 0x40
+sSneaselSprites67:
+ax_sprite sSneaselGfx67, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx67_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx67_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx67_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx68:
+.incbin "baserom.gba", 0xEB8CB8, 0x60
+sSneaselGfx68_1:
+.incbin "baserom.gba", 0xEB8D18, 0x80
+sSneaselGfx68_2:
+.incbin "baserom.gba", 0xEB8D98, 0x60
+sSneaselGfx68_3:
+.incbin "baserom.gba", 0xEB8DF8, 0x40
+sSneaselSprites68:
+ax_sprite sSneaselGfx68, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx68_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx68_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx68_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx69:
+.incbin "baserom.gba", 0xEB8E80, 0x60
+sSneaselGfx69_1:
+.incbin "baserom.gba", 0xEB8EE0, 0xC0
+sSneaselGfx69_2:
+.incbin "baserom.gba", 0xEB8FA0, 0x60
+sSneaselGfx69_3:
+.incbin "baserom.gba", 0xEB9000, 0x20
+sSneaselSprites69:
+ax_sprite sSneaselGfx69, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx69_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx69_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx69_3, 0x20
+ax_sprite_terminator
+sSneaselGfx70:
+.incbin "baserom.gba", 0xEB9060, 0x40
+sSneaselGfx70_1:
+.incbin "baserom.gba", 0xEB90A0, 0x100
+sSneaselGfx70_2:
+.incbin "baserom.gba", 0xEB91A0, 0x40
+sSneaselSprites70:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx70, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx70_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx70_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx71:
+.incbin "baserom.gba", 0xEB9220, 0xC0
+sSneaselGfx71_1:
+.incbin "baserom.gba", 0xEB92E0, 0x40
+sSneaselSprites71:
+ax_sprite 0, 0x80
+ax_sprite sSneaselGfx71, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx71_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSneaselGfx72:
+.incbin "baserom.gba", 0xEB9350, 0x40
+sSneaselGfx72_1:
+.incbin "baserom.gba", 0xEB9390, 0x60
+sSneaselGfx72_2:
+.incbin "baserom.gba", 0xEB93F0, 0xE0
+sSneaselSprites72:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx72, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx72_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx72_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx73:
+.incbin "baserom.gba", 0xEB9510, 0x60
+sSneaselGfx73_1:
+.incbin "baserom.gba", 0xEB9570, 0x20
+sSneaselGfx73_2:
+.incbin "baserom.gba", 0xEB9590, 0x40
+sSneaselGfx73_3:
+.incbin "baserom.gba", 0xEB95D0, 0x60
+sSneaselSprites73:
+ax_sprite sSneaselGfx73, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx73_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx73_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx73_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx74:
+.incbin "baserom.gba", 0xEB9678, 0x60
+sSneaselGfx74_1:
+.incbin "baserom.gba", 0xEB96D8, 0x100
+sSneaselGfx74_2:
+.incbin "baserom.gba", 0xEB97D8, 0x60
+sSneaselSprites74:
+ax_sprite sSneaselGfx74, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx74_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx74_2, 0x60
+ax_sprite_terminator
+sSneaselGfx75:
+.incbin "baserom.gba", 0xEB9868, 0x20
+sSneaselGfx75_1:
+.incbin "baserom.gba", 0xEB9888, 0x100
+sSneaselSprites75:
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx75, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSneaselGfx75_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx76:
+.incbin "baserom.gba", 0xEB99B8, 0x60
+sSneaselGfx76_1:
+.incbin "baserom.gba", 0xEB9A18, 0x60
+sSneaselGfx76_2:
+.incbin "baserom.gba", 0xEB9A78, 0xE0
+sSneaselSprites76:
+ax_sprite sSneaselGfx76, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx76_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx76_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx77:
+.incbin "baserom.gba", 0xEB9B90, 0x20
+sSneaselSprites77:
+ax_sprite sSneaselGfx77, 0x20
+ax_sprite_terminator
+sSneaselGfx78:
+.incbin "baserom.gba", 0xEB9BC0, 0x60
+sSneaselGfx78_1:
+.incbin "baserom.gba", 0xEB9C20, 0x80
+sSneaselSprites78:
+ax_sprite sSneaselGfx78, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx78_1, 0x80
+ax_sprite_terminator
+sSneaselGfx79:
+.incbin "baserom.gba", 0xEB9CC0, 0x20
+sSneaselSprites79:
+ax_sprite sSneaselGfx79, 0x20
+ax_sprite_terminator
+sSneaselGfx80:
+.incbin "baserom.gba", 0xEB9CF0, 0x60
+sSneaselGfx80_1:
+.incbin "baserom.gba", 0xEB9D50, 0xE0
+sSneaselGfx80_2:
+.incbin "baserom.gba", 0xEB9E30, 0x60
+sSneaselSprites80:
+ax_sprite sSneaselGfx80, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx80_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx80_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx81:
+.incbin "baserom.gba", 0xEB9EC8, 0x1A0
+sSneaselSprites81:
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx81, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx82:
+.incbin "baserom.gba", 0xEBA088, 0x40
+sSneaselGfx82_1:
+.incbin "baserom.gba", 0xEBA0C8, 0x140
+sSneaselSprites82:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx82, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx82_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSneaselGfx83:
+.incbin "baserom.gba", 0xEBA238, 0x40
+sSneaselGfx83_1:
+.incbin "baserom.gba", 0xEBA278, 0x100
+sSneaselGfx83_2:
+.incbin "baserom.gba", 0xEBA378, 0x40
+sSneaselSprites83:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx83, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx83_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx83_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx84:
+.incbin "baserom.gba", 0xEBA3F8, 0x60
+sSneaselGfx84_1:
+.incbin "baserom.gba", 0xEBA458, 0x60
+sSneaselGfx84_2:
+.incbin "baserom.gba", 0xEBA4B8, 0xE0
+sSneaselSprites84:
+ax_sprite sSneaselGfx84, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx84_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx84_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx85:
+.incbin "baserom.gba", 0xEBA5D0, 0x60
+sSneaselGfx85_1:
+.incbin "baserom.gba", 0xEBA630, 0x100
+sSneaselGfx85_2:
+.incbin "baserom.gba", 0xEBA730, 0x40
+sSneaselSprites85:
+ax_sprite sSneaselGfx85, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx85_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx85_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx86:
+.incbin "baserom.gba", 0xEBA7A8, 0x40
+sSneaselGfx86_1:
+.incbin "baserom.gba", 0xEBA7E8, 0x60
+sSneaselGfx86_2:
+.incbin "baserom.gba", 0xEBA848, 0x60
+sSneaselGfx86_3:
+.incbin "baserom.gba", 0xEBA8A8, 0x60
+sSneaselSprites86:
+ax_sprite sSneaselGfx86, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSneaselGfx86_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx86_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx86_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx87:
+.incbin "baserom.gba", 0xEBA950, 0x40
+sSneaselGfx87_1:
+.incbin "baserom.gba", 0xEBA990, 0x100
+sSneaselGfx87_2:
+.incbin "baserom.gba", 0xEBAA90, 0x40
+sSneaselSprites87:
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx87, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx87_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx87_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx88:
+.incbin "baserom.gba", 0xEBAB10, 0x60
+sSneaselGfx88_1:
+.incbin "baserom.gba", 0xEBAB70, 0x60
+sSneaselGfx88_2:
+.incbin "baserom.gba", 0xEBABD0, 0x60
+sSneaselGfx88_3:
+.incbin "baserom.gba", 0xEBAC30, 0x60
+sSneaselSprites88:
+ax_sprite sSneaselGfx88, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx88_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx88_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSneaselGfx88_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSneaselGfx89:
+.incbin "baserom.gba", 0xEBACD8, 0x200
+sSneaselSprites89:
+ax_sprite sSneaselGfx89, 0x200
+ax_sprite_terminator
+sSneaselGfx90:
+.incbin "baserom.gba", 0xEBAEE8, 0x200
+sSneaselSprites90:
+ax_sprite sSneaselGfx90, 0x200
+ax_sprite_terminator
+sSneaselGfx91:
+.incbin "baserom.gba", 0xEBB0F8, 0x200
+sSneaselSprites91:
+ax_sprite sSneaselGfx91, 0x200
+ax_sprite_terminator
+sSneaselGfx92:
+.incbin "baserom.gba", 0xEBB308, 0x40
+sSneaselSprites92:
+ax_sprite sSneaselGfx92, 0x40
+ax_sprite_terminator
+sSneaselGfx93:
+.incbin "baserom.gba", 0xEBB358, 0x20
+sSneaselSprites93:
+ax_sprite sSneaselGfx93, 0x20
+ax_sprite_terminator
+sSneaselGfx94:
+.incbin "baserom.gba", 0xEBB388, 0x20
+sSneaselSprites94:
+ax_sprite sSneaselGfx94, 0x20
+ax_sprite_terminator
+sSneaselGfx95:
+.incbin "baserom.gba", 0xEBB3B8, 0x80
+sSneaselSprites95:
+ax_sprite sSneaselGfx95, 0x80
+ax_sprite_terminator
+sSneaselGfx96:
+.incbin "baserom.gba", 0xEBB448, 0x100
+sSneaselSprites96:
+ax_sprite sSneaselGfx96, 0x100
+ax_sprite_terminator
+sSneaselGfx97:
+.incbin "baserom.gba", 0xEBB558, 0x80
+sSneaselSprites97:
+ax_sprite sSneaselGfx97, 0x80
+ax_sprite_terminator
+sSneaselGfx98:
+.incbin "baserom.gba", 0xEBB5E8, 0x40
+sSneaselSprites98:
+ax_sprite sSneaselGfx98, 0x40
+ax_sprite_terminator
+sSneaselGfx99:
+.incbin "baserom.gba", 0xEBB638, 0x40
+sSneaselSprites99:
+ax_sprite sSneaselGfx99, 0x40
+ax_sprite_terminator
+sSneaselGfx100:
+.incbin "baserom.gba", 0xEBB688, 0x100
+sSneaselSprites100:
+ax_sprite sSneaselGfx100, 0x100
+ax_sprite_terminator
+sSneaselGfx101:
+.incbin "baserom.gba", 0xEBB798, 0x200
+sSneaselSprites101:
+ax_sprite sSneaselGfx101, 0x200
+ax_sprite_terminator
+sSneaselGfx102:
+.incbin "baserom.gba", 0xEBB9A8, 0x200
+sSneaselSprites102:
+ax_sprite sSneaselGfx102, 0x200
+ax_sprite_terminator
+sSneaselGfx103:
+.incbin "baserom.gba", 0xEBBBB8, 0x200
+sSneaselSprites103:
+ax_sprite sSneaselGfx103, 0x200
+ax_sprite_terminator
+sSneaselGfx104:
+.incbin "baserom.gba", 0xEBBDC8, 0x80
+sSneaselSprites104:
+ax_sprite sSneaselGfx104, 0x80
+ax_sprite_terminator
+sSneaselGfx105:
+.incbin "baserom.gba", 0xEBBE58, 0x40
+sSneaselSprites105:
+ax_sprite sSneaselGfx105, 0x40
+ax_sprite_terminator
+sSneaselGfx106:
+.incbin "baserom.gba", 0xEBBEA8, 0x40
+sSneaselSprites106:
+ax_sprite sSneaselGfx106, 0x40
+ax_sprite_terminator
+sSneaselGfx107:
+.incbin "baserom.gba", 0xEBBEF8, 0x100
+sSneaselSprites107:
+ax_sprite sSneaselGfx107, 0x100
+ax_sprite_terminator
+sSneaselGfx108:
+.incbin "baserom.gba", 0xEBC008, 0x40
+sSneaselSprites108:
+ax_sprite sSneaselGfx108, 0x40
+ax_sprite_terminator
+sSneaselGfx109:
+.incbin "baserom.gba", 0xEBC058, 0x20
+sSneaselSprites109:
+ax_sprite sSneaselGfx109, 0x20
+ax_sprite_terminator
+sSneaselGfx110:
+.incbin "baserom.gba", 0xEBC088, 0x20
+sSneaselSprites110:
+ax_sprite sSneaselGfx110, 0x20
+ax_sprite_terminator
+sSneaselGfx111:
+.incbin "baserom.gba", 0xEBC0B8, 0x80
+sSneaselSprites111:
+ax_sprite sSneaselGfx111, 0x80
+ax_sprite_terminator
+sSneaselGfx112:
+.incbin "baserom.gba", 0xEBC148, 0x100
+sSneaselSprites112:
+ax_sprite sSneaselGfx112, 0x100
+ax_sprite_terminator
+sAxPosesSneasel:
+.4byte sSneaselPose1
+.4byte sSneaselPose2
+.4byte sSneaselPose3
+.4byte sSneaselPose4
+.4byte sSneaselPose5
+.4byte sSneaselPose6
+.4byte sSneaselPose7
+.4byte sSneaselPose8
+.4byte sSneaselPose9
+.4byte sSneaselPose10
+.4byte sSneaselPose11
+.4byte sSneaselPose12
+.4byte sSneaselPose13
+.4byte sSneaselPose14
+.4byte sSneaselPose15
+.4byte sSneaselPose16
+.4byte sSneaselPose17
+.4byte sSneaselPose18
+.4byte sSneaselPose19
+.4byte sSneaselPose20
+.4byte sSneaselPose21
+.4byte sSneaselPose22
+.4byte sSneaselPose23
+.4byte sSneaselPose24
+.4byte sSneaselPose25
+.4byte sSneaselPose26
+.4byte sSneaselPose27
+.4byte sSneaselPose28
+.4byte sSneaselPose29
+.4byte sSneaselPose30
+.4byte sSneaselPose31
+.4byte sSneaselPose32
+.4byte sSneaselPose33
+.4byte sSneaselPose34
+.4byte sSneaselPose35
+.4byte sSneaselPose36
+.4byte sSneaselPose37
+.4byte sSneaselPose38
+.4byte sSneaselPose39
+.4byte sSneaselPose40
+.4byte sSneaselPose41
+.4byte sSneaselPose42
+.4byte sSneaselPose43
+.4byte sSneaselPose44
+.4byte sSneaselPose45
+.4byte sSneaselPose46
+.4byte sSneaselPose47
+.4byte sSneaselPose48
+.4byte sSneaselPose49
+.4byte sSneaselPose50
+.4byte sSneaselPose51
+.4byte sSneaselPose52
+.4byte sSneaselPose53
+.4byte sSneaselPose54
+.4byte sSneaselPose55
+.4byte sSneaselPose56
+.4byte sSneaselPose57
+.4byte sSneaselPose58
+.4byte sSneaselPose59
+.4byte sSneaselPose60
+.4byte sSneaselPose61
+.4byte sSneaselPose62
+.4byte sSneaselPose63
+.4byte sSneaselPose64
+.4byte sSneaselPose65
+.4byte sSneaselPose66
+.4byte sSneaselPose67
+.4byte sSneaselPose68
+.4byte sSneaselPose69
+.4byte sSneaselPose70
+.4byte sSneaselPose71
+.4byte sSneaselPose72
+.4byte sSneaselPose73
+.4byte sSneaselPose74
+.4byte sSneaselPose75
+.4byte sSneaselPose76
+.4byte sSneaselPose77
+.4byte sSneaselPose78
+.4byte sSneaselPose79
+.4byte sSneaselPose80
+.4byte sSneaselPose81
+.4byte sSneaselPose82
+.4byte sSneaselPose83
+.4byte sSneaselPose84
+.4byte sSneaselPose85
+.4byte sSneaselPose86
+.4byte sSneaselPose87
+.4byte sSneaselPose88
+.4byte sSneaselPose89
+.4byte sSneaselPose90
+.4byte sSneaselPose91
+.4byte sSneaselPose92
+.4byte sSneaselPose93
+.4byte sSneaselPose94
+.4byte sSneaselPose95
+.4byte sSneaselPose96
+.4byte sSneaselPose97
+.4byte sSneaselPose98
+.4byte sSneaselPose99
+.4byte sSneaselPose100
+.4byte sSneaselPose101
+.4byte sSneaselPose102
+.4byte sSneaselPose103
+.4byte sSneaselPose104
+.4byte sSneaselPose105
+.4byte sSneaselPose106
+.4byte sSneaselPose107
+.4byte sSneaselPose108
+.4byte sSneaselPose109
+.4byte sSneaselPose110
+.4byte sSneaselPose111
+.4byte sSneaselPose112
+.4byte sSneaselPose113
+.4byte sSneaselPose114
+.4byte sSneaselPose115
+.4byte sSneaselPose116
+.4byte sSneaselPose117
+.4byte sSneaselPose118
+.4byte sSneaselPose119
+.4byte sSneaselPose120
+.4byte sSneaselPose121
+.4byte sSneaselPose122
+.4byte sSneaselPose123
+.4byte sSneaselPose124
+.4byte sSneaselPose125
+.4byte sSneaselPose126
+.4byte sSneaselPose127
+.4byte sSneaselPose128
+.4byte sSneaselPose129
+.4byte sSneaselPose130
+.4byte sSneaselPose131
+.4byte sSneaselPose132
+.4byte sSneaselPose133
+.4byte sSneaselPose134
+.4byte sSneaselPose135
+.4byte sSneaselPose136
+.4byte sSneaselPose137
+.4byte sSneaselPose138
+.4byte sSneaselPose139
+.4byte sSneaselPose140
+.4byte sSneaselPose141
+.4byte sSneaselPose142
+.4byte sSneaselPose143
+.4byte sSneaselPose144
+.4byte sSneaselPose145
+.4byte sSneaselPose146
+.4byte sSneaselPose147
+.4byte sSneaselPose148
+.4byte sSneaselPose149
+.4byte sSneaselPose150
+.4byte sSneaselPose151
+.4byte sSneaselPose152
+.4byte sSneaselPose153
+.4byte sSneaselPose154
+.4byte sSneaselPose155
+.4byte sSneaselPose156
+.4byte sSneaselPose157
+.4byte sSneaselPose158
+.4byte sSneaselPose159
+.4byte sSneaselPose160
+.4byte sSneaselPose161
+.4byte sSneaselPose162
+.4byte sSneaselPose163
+.4byte sSneaselPose164
+.4byte sSneaselPose165
+.4byte sSneaselPose166
+.4byte sSneaselPose167
+.4byte sSneaselPose168
+.4byte sSneaselPose169
+.4byte sSneaselPose170
+.4byte sSneaselPose171
+.4byte sSneaselPose172
+.4byte sSneaselPose173
+.4byte sSneaselPose174
+.4byte sSneaselPose175
+.4byte sSneaselPose176
+.4byte sSneaselPose177
+.4byte sSneaselPose178
+.4byte sSneaselPose179
+.4byte sSneaselPose180
+.4byte sSneaselPose181
+.4byte sSneaselPose182
+.4byte sSneaselPose183
+.4byte sSneaselPose184
+.4byte sSneaselPose185
+.4byte sSneaselPose186
+.4byte sSneaselPose187
+.4byte sSneaselPose188
+.4byte sSneaselPose189
+.4byte sSneaselPose190
+.4byte sSneaselPose191
+.4byte sSneaselPose192
+.4byte sSneaselPose193
+.4byte sSneaselPose194
+.4byte sSneaselPose195
+.4byte sSneaselPose196
+.4byte sSneaselPose197
+.4byte sSneaselPose198
+.4byte sSneaselPose199
+.4byte sSneaselPose200
+.4byte sSneaselPose201
+.4byte sSneaselPose202
+.4byte sSneaselPose203
+.4byte sSneaselPose204
+.4byte sSneaselPose205
+.4byte sSneaselPose206
+.4byte sSneaselPose207
+.4byte sSneaselPose208
+.4byte sSneaselPose209
+.4byte sSneaselPose210
+.4byte sSneaselPose211
+.4byte sSneaselPose212
+.4byte sSneaselPose213
+.4byte sSneaselPose214
+.4byte sSneaselPose215
+.4byte sSneaselPose216
+.4byte sSneaselPose217
+.4byte sSneaselPose218
+.4byte sSneaselPose219
+.4byte sSneaselPose220
+.4byte sSneaselPose221
+.4byte sSneaselPose222
+.4byte sSneaselPose223
+.4byte sSneaselPose224
+.4byte sSneaselPose225
+.4byte sSneaselPose226
+sAxPositionsSneasel:
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,  -10, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	 -12,  -14, 	   6,   -6, 	  -1,   -9
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+.2byte    4,  -10, 	   1,  -10, 	  10,   -7, 	   1,   -9
+.2byte    4,   -9, 	   1,   -6, 	  10,  -10, 	   1,  -10
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    5,  -10, 	   9,  -11, 	   2,  -11, 	  -2,   -8
+.2byte    6,  -10, 	   9,   -7, 	   3,  -10, 	  -1,   -9
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    2,  -12, 	  10,  -14, 	   1,  -14, 	   0,   -7
+.2byte    3,  -11, 	  10,   -9, 	   0,   -9, 	   0,   -8
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,  -13, 	   8,  -11, 	  -9,  -11, 	  -1,   -8
+.2byte   -1,  -13, 	  10,  -14, 	  -8,   -8, 	  -1,   -9
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -3,  -11, 	  -2,  -13, 	 -10,  -10, 	   0,   -9
+.2byte   -4,  -11, 	  -3,  -12, 	  -9,   -7, 	  -1,   -9
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -7,  -11, 	 -10,  -12, 	  -7,   -7, 	  -1,   -9
+.2byte   -7,  -11, 	  -9,  -16, 	  -6,   -4, 	   0,   -9
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -6,   -9, 	 -13,  -11, 	  -2,   -7, 	  -1,   -9
+.2byte   -7,   -9, 	 -13,  -15, 	  -2,   -4, 	  -1,   -9
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -1,  -14, 	 -10,  -11, 	   6,   -8, 	  -1,  -10
+.2byte   -1,   -7, 	   5,   -5, 	  10,  -12, 	  -1,   -9
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+.2byte    3,  -15, 	   3,  -10, 	   8,   -9, 	   0,  -12
+.2byte    7,   -5, 	  12,   -9, 	  10,  -15, 	   0,  -10
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,  -13, 	   9,  -13, 	   7,  -12, 	  -2,  -11
+.2byte    9,   -8, 	   9,  -11, 	   0,  -17, 	   3,  -11
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    2,  -13, 	   8,  -14, 	  -2,  -14, 	  -1,  -10
+.2byte    7,  -12, 	  10,  -12, 	  -1,  -16, 	   2,  -12
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,  -15, 	   7,  -12, 	  -8,  -11, 	  -1,  -10
+.2byte   -1,  -14, 	 -10,  -14, 	 -11,   -9, 	  -1,  -11
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -2,  -13, 	   1,  -15, 	  -9,  -12, 	   0,   -8
+.2byte   -8,  -10, 	 -11,   -6, 	  -8,  -11, 	  -2,  -11
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -5,  -14, 	  -7,  -14, 	  -8,   -7, 	   2,  -10
+.2byte  -10,   -9, 	  -8,   -6, 	  -1,  -12, 	  -4,   -9
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -4,  -15, 	 -12,  -11, 	  -4,   -6, 	   0,  -10
+.2byte  -10,   -7, 	  -3,   -5, 	   3,   -9, 	  -2,   -8
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -1,   -8, 	 -10,  -10, 	   8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	 -12,  -14, 	   6,   -6, 	  -1,   -9
+.2byte   -1,  -14, 	 -10,  -11, 	   6,   -8, 	  -1,  -10
+.2byte   -5,   -5, 	 -14,  -13, 	  -6,   -2, 	  -3,   -8
+.2byte   -5,   -5, 	 -14,  -13, 	  -6,   -2, 	  -3,   -8
+.2byte    2,   -7, 	   2,   -3, 	  11,  -14, 	  -2,   -8
+.2byte    2,   -7, 	   2,   -3, 	  11,  -14, 	  -2,   -8
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+.2byte    4,  -10, 	   1,  -10, 	  10,   -7, 	   1,   -9
+.2byte    4,   -9, 	   1,   -6, 	  10,  -10, 	   1,  -10
+.2byte    3,  -15, 	   3,  -10, 	   8,   -9, 	   0,  -12
+.2byte    2,   -8, 	  -8,  -15, 	   0,   -4, 	   0,   -8
+.2byte    2,   -8, 	  -8,  -15, 	   0,   -4, 	   0,   -8
+.2byte    6,   -9, 	   8,   -4, 	  11,  -18, 	   2,  -10
+.2byte    6,   -9, 	   8,   -4, 	  11,  -18, 	   2,  -10
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    5,  -10, 	   9,  -11, 	   2,  -11, 	  -2,   -8
+.2byte    6,  -10, 	   9,   -7, 	   3,  -10, 	  -1,   -9
+.2byte    4,  -13, 	   9,  -13, 	   7,  -12, 	  -2,  -11
+.2byte    5,   -8, 	  -3,  -17, 	   1,   -2, 	  -1,  -10
+.2byte    5,   -8, 	  -3,  -17, 	   1,   -2, 	  -1,  -10
+.2byte    4,  -11, 	   6,   -5, 	   5,  -22, 	   0,  -10
+.2byte    4,  -11, 	   6,   -5, 	   5,  -22, 	   0,  -10
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    2,  -12, 	  10,  -14, 	   1,  -14, 	   0,   -7
+.2byte    3,  -11, 	  10,   -9, 	   0,   -9, 	   0,   -8
+.2byte    2,  -13, 	   8,  -14, 	  -2,  -14, 	  -1,  -10
+.2byte    6,  -12, 	   5,  -18, 	   7,   -5, 	   2,  -11
+.2byte    6,  -12, 	   5,  -18, 	   7,   -5, 	   2,  -11
+.2byte    1,  -13, 	   1,   -7, 	  -8,  -20, 	   1,  -10
+.2byte    1,  -13, 	   1,   -7, 	  -8,  -20, 	   1,  -10
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,  -13, 	   8,  -11, 	  -9,  -11, 	  -1,   -8
+.2byte   -1,  -13, 	  10,  -14, 	  -8,   -8, 	  -1,   -9
+.2byte   -1,  -15, 	   7,  -12, 	  -8,  -11, 	  -1,  -10
+.2byte    2,  -12, 	   8,  -16, 	  -1,   -8, 	   1,  -10
+.2byte    2,  -12, 	   8,  -16, 	  -1,   -8, 	   1,  -10
+.2byte   -3,  -12, 	  -3,   -7, 	 -11,  -16, 	  -2,  -10
+.2byte   -3,  -12, 	  -3,   -7, 	 -11,  -16, 	  -2,  -10
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -3,  -11, 	  -2,  -13, 	 -10,  -10, 	   0,   -9
+.2byte   -4,  -11, 	  -3,  -12, 	  -9,   -7, 	  -1,   -9
+.2byte   -2,  -13, 	   1,  -15, 	  -9,  -12, 	   0,   -8
+.2byte   -5,  -12, 	   6,  -19, 	  -1,   -6, 	  -2,  -10
+.2byte   -5,  -12, 	   6,  -19, 	  -1,   -6, 	  -2,  -10
+.2byte   -7,  -10, 	  -7,   -4, 	  -5,  -16, 	  -2,   -9
+.2byte   -7,  -10, 	  -7,   -4, 	  -5,  -16, 	  -2,   -9
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -7,  -11, 	 -10,  -12, 	  -7,   -7, 	  -1,   -9
+.2byte   -7,  -11, 	  -9,  -16, 	  -6,   -4, 	   0,   -9
+.2byte   -5,  -14, 	  -7,  -14, 	  -8,   -7, 	   2,  -10
+.2byte   -7,  -10, 	  -7,  -20, 	  -8,   -5, 	  -1,  -10
+.2byte   -7,  -10, 	  -7,  -20, 	  -8,   -5, 	  -1,  -10
+.2byte   -5,   -9, 	  -2,   -2, 	   2,  -17, 	  -1,   -9
+.2byte   -5,   -9, 	  -2,   -2, 	   2,  -17, 	  -1,   -9
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -6,   -9, 	 -13,  -11, 	  -2,   -7, 	  -1,   -9
+.2byte   -7,   -9, 	 -13,  -15, 	  -2,   -4, 	  -1,   -9
+.2byte   -4,  -15, 	 -12,  -11, 	  -4,   -6, 	   0,  -10
+.2byte   -6,   -9, 	 -13,  -17, 	  -7,   -5, 	  -2,   -9
+.2byte   -6,   -9, 	 -13,  -17, 	  -7,   -5, 	  -2,   -9
+.2byte   -4,   -9, 	   0,   -4, 	   7,  -15, 	   0,   -9
+.2byte   -4,   -9, 	   0,   -4, 	   7,  -15, 	   0,   -9
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -1,  -14, 	 -10,  -11, 	   6,   -8, 	  -1,  -10
+.2byte   -1,   -9, 	 -13,  -15, 	  10,  -10, 	  -1,   -8
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+.2byte    3,  -15, 	   3,  -10, 	   8,   -9, 	   0,  -12
+.2byte    6,  -10, 	  -2,   -6, 	  12,  -13, 	   1,  -11
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,  -13, 	   9,  -13, 	   7,  -12, 	  -2,  -11
+.2byte    6,  -11, 	   5,   -7, 	   5,  -11, 	   0,  -10
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    2,  -13, 	   8,  -14, 	  -2,  -14, 	  -1,  -10
+.2byte    3,  -13, 	  10,  -10, 	  -4,  -12, 	   0,  -11
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,  -15, 	   7,  -12, 	  -8,  -11, 	  -1,  -10
+.2byte   -1,  -13, 	  11,  -11, 	 -11,   -9, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -2,  -13, 	   1,  -15, 	  -9,  -12, 	   0,   -8
+.2byte   -8,  -12, 	   3,  -16, 	  -8,   -5, 	  -2,  -10
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -5,  -14, 	  -7,  -14, 	  -8,   -7, 	   2,  -10
+.2byte   -6,  -11, 	  -6,  -15, 	  -2,   -5, 	  -1,  -10
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -4,  -15, 	 -12,  -11, 	  -4,   -6, 	   0,  -10
+.2byte   -7,  -10, 	 -13,  -14, 	  -1,   -6, 	  -1,  -10
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+.2byte   -1,   -6, 	  -9,   -1, 	   7,   -1, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -1, 	   7,   -1, 	  -1,   -7
+.2byte    0,  -18, 	 -13,  -10, 	  13,  -10, 	   0,  -13
+.2byte    0,  -16, 	   0,   -8, 	  12,  -16, 	   0,  -12
+.2byte   -1,  -16, 	   9,  -16, 	   9,  -18, 	   0,  -11
+.2byte    0,  -17, 	   9,  -17, 	  -2,  -22, 	   0,  -11
+.2byte    0,  -14, 	  13,  -17, 	 -13,  -16, 	   0,   -9
+.2byte   -1,  -19, 	   1,  -23, 	 -10,  -17, 	   0,  -11
+.2byte    0,  -17, 	 -10,  -19, 	  -9,  -17, 	   0,  -13
+.2byte   -1,  -18, 	 -13,  -16, 	  -1,   -8, 	   0,  -12
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -1,  -14, 	 -10,  -11, 	   6,   -8, 	  -1,  -10
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+.2byte    3,  -15, 	   3,  -10, 	   8,   -9, 	   0,  -12
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,  -13, 	   9,  -13, 	   7,  -12, 	  -2,  -11
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    2,  -13, 	   8,  -14, 	  -2,  -14, 	  -1,  -10
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,  -15, 	   7,  -12, 	  -8,  -11, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -2,  -13, 	   1,  -15, 	  -9,  -12, 	   0,   -8
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -5,  -14, 	  -7,  -14, 	  -8,   -7, 	   2,  -10
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -4,  -15, 	 -12,  -11, 	  -4,   -6, 	   0,  -10
+.2byte    0,   -9, 	 -12,  -15, 	  11,  -10, 	   0,   -8
+.2byte   -5,  -10, 	 -11,  -14, 	   1,   -6, 	   1,  -10
+.2byte   -6,  -11, 	  -6,  -15, 	  -2,   -5, 	  -1,  -10
+.2byte   -7,  -12, 	   4,  -16, 	  -7,   -5, 	  -1,  -10
+.2byte    0,  -13, 	  12,  -11, 	 -10,   -9, 	   0,  -10
+.2byte    2,  -13, 	   9,  -10, 	  -5,  -12, 	  -1,  -11
+.2byte    6,  -11, 	   5,   -7, 	   5,  -11, 	   0,  -10
+.2byte    4,  -10, 	  -4,   -6, 	  10,  -13, 	  -1,  -11
+.2byte    0,   -9, 	 -12,  -15, 	  11,  -10, 	   0,   -8
+.2byte    4,  -10, 	  -4,   -6, 	  10,  -13, 	  -1,  -11
+.2byte    6,  -11, 	   5,   -7, 	   5,  -11, 	   0,  -10
+.2byte    2,  -13, 	   9,  -10, 	  -5,  -12, 	  -1,  -11
+.2byte    0,  -14, 	  12,  -12, 	 -10,  -10, 	   0,  -11
+.2byte   -7,  -12, 	   4,  -16, 	  -7,   -5, 	  -1,  -10
+.2byte   -6,  -11, 	  -6,  -15, 	  -2,   -5, 	  -1,  -10
+.2byte   -5,  -10, 	 -11,  -14, 	   1,   -6, 	   1,  -10
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -1,  -14, 	 -10,  -11, 	   6,   -8, 	  -1,  -10
+.2byte   -1,   -9, 	 -13,  -15, 	  10,  -10, 	  -1,   -8
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+.2byte    3,  -15, 	   3,  -10, 	   8,   -9, 	   0,  -12
+.2byte    5,  -10, 	  -3,   -6, 	  11,  -13, 	   0,  -11
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,  -13, 	   9,  -13, 	   7,  -12, 	  -2,  -11
+.2byte    6,  -11, 	   5,   -7, 	   5,  -11, 	   0,  -10
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    2,  -13, 	   8,  -14, 	  -2,  -14, 	  -1,  -10
+.2byte    3,  -13, 	  10,  -10, 	  -4,  -12, 	   0,  -11
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,  -15, 	   7,  -12, 	  -8,  -11, 	  -1,  -10
+.2byte   -1,  -13, 	  11,  -11, 	 -11,   -9, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -2,  -13, 	   1,  -15, 	  -9,  -12, 	   0,   -8
+.2byte   -8,  -12, 	   3,  -16, 	  -8,   -5, 	  -2,  -10
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -5,  -14, 	  -7,  -14, 	  -8,   -7, 	   2,  -10
+.2byte   -6,  -11, 	  -6,  -15, 	  -2,   -5, 	  -1,  -10
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -4,  -15, 	 -12,  -11, 	  -4,   -6, 	   0,  -10
+.2byte   -6,  -10, 	 -12,  -14, 	   0,   -6, 	   0,  -10
+.2byte    0,  -14, 	  -9,  -11, 	   7,   -8, 	   0,  -10
+.2byte   -4,  -15, 	 -12,  -11, 	  -4,   -6, 	   0,  -10
+.2byte   -6,  -14, 	  -8,  -14, 	  -9,   -7, 	   1,  -10
+.2byte   -2,  -14, 	   1,  -16, 	  -9,  -13, 	   0,   -9
+.2byte   -1,  -16, 	   7,  -13, 	  -8,  -12, 	  -1,  -11
+.2byte    2,  -14, 	   8,  -15, 	  -2,  -15, 	  -1,  -11
+.2byte    5,  -13, 	  10,  -13, 	   8,  -12, 	  -1,  -11
+.2byte    4,  -15, 	   4,  -10, 	   9,   -9, 	   1,  -12
+.2byte   -1,   -8, 	 -11,  -13, 	   7,   -8, 	  -1,   -9
+.2byte   -6,  -10, 	 -13,  -14, 	  -2,   -6, 	  -1,   -9
+.2byte   -7,  -12, 	 -10,  -15, 	  -7,   -6, 	   0,  -10
+.2byte   -4,  -13, 	  -3,  -13, 	 -10,   -9, 	   0,   -9
+.2byte   -2,  -13, 	   9,  -14, 	  -9,  -10, 	  -1,   -8
+.2byte    3,  -13, 	  10,  -12, 	   1,  -13, 	   0,   -9
+.2byte    6,  -10, 	   9,  -10, 	   4,  -10, 	  -1,   -9
+.2byte    4,  -10, 	   1,   -8, 	  10,   -9, 	   1,  -11
+sSneaselAnimTable1:
+.4byte sSneaselAnims_1_1
+.4byte sSneaselAnims_1_2
+.4byte sSneaselAnims_1_3
+.4byte sSneaselAnims_1_4
+.4byte sSneaselAnims_1_5
+.4byte sSneaselAnims_1_6
+.4byte sSneaselAnims_1_7
+.4byte sSneaselAnims_1_8
+sSneaselAnimTable2:
+.4byte sSneaselAnims_2_1
+.4byte sSneaselAnims_2_2
+.4byte sSneaselAnims_2_3
+.4byte sSneaselAnims_2_4
+.4byte sSneaselAnims_2_5
+.4byte sSneaselAnims_2_6
+.4byte sSneaselAnims_2_7
+.4byte sSneaselAnims_2_8
+sSneaselAnimTable3:
+.4byte sSneaselAnims_3_1
+.4byte sSneaselAnims_3_2
+.4byte sSneaselAnims_3_3
+.4byte sSneaselAnims_3_4
+.4byte sSneaselAnims_3_5
+.4byte sSneaselAnims_3_6
+.4byte sSneaselAnims_3_7
+.4byte sSneaselAnims_3_8
+sSneaselAnimTable4:
+.4byte sSneaselAnims_4_1
+.4byte sSneaselAnims_4_2
+.4byte sSneaselAnims_4_3
+.4byte sSneaselAnims_4_4
+.4byte sSneaselAnims_4_5
+.4byte sSneaselAnims_4_6
+.4byte sSneaselAnims_4_7
+.4byte sSneaselAnims_4_8
+sSneaselAnimTable5:
+.4byte sSneaselAnims_5_1
+.4byte sSneaselAnims_5_2
+.4byte sSneaselAnims_5_3
+.4byte sSneaselAnims_5_4
+.4byte sSneaselAnims_5_5
+.4byte sSneaselAnims_5_6
+.4byte sSneaselAnims_5_7
+.4byte sSneaselAnims_5_8
+sSneaselAnimTable6:
+.4byte sSneaselAnims_6_1
+.4byte sSneaselAnims_6_1
+.4byte sSneaselAnims_6_1
+.4byte sSneaselAnims_6_1
+.4byte sSneaselAnims_6_1
+.4byte sSneaselAnims_6_1
+.4byte sSneaselAnims_6_1
+.4byte sSneaselAnims_6_1
+sSneaselAnimTable7:
+.4byte sSneaselAnims_7_1
+.4byte sSneaselAnims_7_2
+.4byte sSneaselAnims_7_3
+.4byte sSneaselAnims_7_4
+.4byte sSneaselAnims_7_5
+.4byte sSneaselAnims_7_6
+.4byte sSneaselAnims_7_7
+.4byte sSneaselAnims_7_8
+sSneaselAnimTable8:
+.4byte sSneaselAnims_8_1
+.4byte sSneaselAnims_8_2
+.4byte sSneaselAnims_8_3
+.4byte sSneaselAnims_8_4
+.4byte sSneaselAnims_8_5
+.4byte sSneaselAnims_8_6
+.4byte sSneaselAnims_8_7
+.4byte sSneaselAnims_8_8
+sSneaselAnimTable9:
+.4byte sSneaselAnims_9_1
+.4byte sSneaselAnims_9_2
+.4byte sSneaselAnims_9_3
+.4byte sSneaselAnims_9_4
+.4byte sSneaselAnims_9_5
+.4byte sSneaselAnims_9_6
+.4byte sSneaselAnims_9_7
+.4byte sSneaselAnims_9_8
+sSneaselAnimTable10:
+.4byte sSneaselAnims_10_1
+.4byte sSneaselAnims_10_2
+.4byte sSneaselAnims_10_3
+.4byte sSneaselAnims_10_4
+.4byte sSneaselAnims_10_5
+.4byte sSneaselAnims_10_6
+.4byte sSneaselAnims_10_7
+.4byte sSneaselAnims_10_8
+sSneaselAnimTable11:
+.4byte sSneaselAnims_11_1
+.4byte sSneaselAnims_11_2
+.4byte sSneaselAnims_11_3
+.4byte sSneaselAnims_11_4
+.4byte sSneaselAnims_11_5
+.4byte sSneaselAnims_11_6
+.4byte sSneaselAnims_11_7
+.4byte sSneaselAnims_11_8
+sSneaselAnimTable12:
+.4byte sSneaselAnims_12_1
+.4byte sSneaselAnims_12_2
+.4byte sSneaselAnims_12_3
+.4byte sSneaselAnims_12_4
+.4byte sSneaselAnims_12_5
+.4byte sSneaselAnims_12_6
+.4byte sSneaselAnims_12_7
+.4byte sSneaselAnims_12_8
+sSneaselAnimTable13:
+.4byte sSneaselAnims_13_1
+.4byte sSneaselAnims_13_2
+.4byte sSneaselAnims_13_3
+.4byte sSneaselAnims_13_4
+.4byte sSneaselAnims_13_5
+.4byte sSneaselAnims_13_6
+.4byte sSneaselAnims_13_7
+.4byte sSneaselAnims_13_8
+sAxAnimationsSneasel:
+.4byte sSneaselAnimTable1
+.4byte sSneaselAnimTable2
+.4byte sSneaselAnimTable3
+.4byte sSneaselAnimTable4
+.4byte sSneaselAnimTable5
+.4byte sSneaselAnimTable6
+.4byte sSneaselAnimTable7
+.4byte sSneaselAnimTable8
+.4byte sSneaselAnimTable9
+.4byte sSneaselAnimTable10
+.4byte sSneaselAnimTable11
+.4byte sSneaselAnimTable12
+.4byte sSneaselAnimTable13
+sAxSpritesSneasel:
+.4byte sSneaselSprites1
+.4byte sSneaselSprites2
+.4byte sSneaselSprites3
+.4byte sSneaselSprites4
+.4byte sSneaselSprites5
+.4byte sSneaselSprites6
+.4byte sSneaselSprites7
+.4byte sSneaselSprites8
+.4byte sSneaselSprites9
+.4byte sSneaselSprites10
+.4byte sSneaselSprites11
+.4byte sSneaselSprites12
+.4byte sSneaselSprites13
+.4byte sSneaselSprites14
+.4byte sSneaselSprites15
+.4byte sSneaselSprites16
+.4byte sSneaselSprites17
+.4byte sSneaselSprites18
+.4byte sSneaselSprites19
+.4byte sSneaselSprites20
+.4byte sSneaselSprites21
+.4byte sSneaselSprites22
+.4byte sSneaselSprites23
+.4byte sSneaselSprites24
+.4byte sSneaselSprites25
+.4byte sSneaselSprites26
+.4byte sSneaselSprites27
+.4byte sSneaselSprites28
+.4byte sSneaselSprites29
+.4byte sSneaselSprites30
+.4byte sSneaselSprites31
+.4byte sSneaselSprites32
+.4byte sSneaselSprites33
+.4byte sSneaselSprites34
+.4byte sSneaselSprites35
+.4byte sSneaselSprites36
+.4byte sSneaselSprites37
+.4byte sSneaselSprites38
+.4byte sSneaselSprites39
+.4byte sSneaselSprites40
+.4byte sSneaselSprites41
+.4byte sSneaselSprites42
+.4byte sSneaselSprites43
+.4byte sSneaselSprites44
+.4byte sSneaselSprites45
+.4byte sSneaselSprites46
+.4byte sSneaselSprites47
+.4byte sSneaselSprites48
+.4byte sSneaselSprites49
+.4byte sSneaselSprites50
+.4byte sSneaselSprites51
+.4byte sSneaselSprites52
+.4byte sSneaselSprites53
+.4byte sSneaselSprites54
+.4byte sSneaselSprites55
+.4byte sSneaselSprites56
+.4byte sSneaselSprites57
+.4byte sSneaselSprites58
+.4byte sSneaselSprites59
+.4byte sSneaselSprites60
+.4byte sSneaselSprites61
+.4byte sSneaselSprites62
+.4byte sSneaselSprites63
+.4byte sSneaselSprites64
+.4byte sSneaselSprites65
+.4byte sSneaselSprites66
+.4byte sSneaselSprites67
+.4byte sSneaselSprites68
+.4byte sSneaselSprites69
+.4byte sSneaselSprites70
+.4byte sSneaselSprites71
+.4byte sSneaselSprites72
+.4byte sSneaselSprites73
+.4byte sSneaselSprites74
+.4byte sSneaselSprites75
+.4byte sSneaselSprites76
+.4byte sSneaselSprites77
+.4byte sSneaselSprites78
+.4byte sSneaselSprites79
+.4byte sSneaselSprites80
+.4byte sSneaselSprites81
+.4byte sSneaselSprites82
+.4byte sSneaselSprites83
+.4byte sSneaselSprites84
+.4byte sSneaselSprites85
+.4byte sSneaselSprites86
+.4byte sSneaselSprites87
+.4byte sSneaselSprites88
+.4byte sSneaselSprites89
+.4byte sSneaselSprites90
+.4byte sSneaselSprites91
+.4byte sSneaselSprites92
+.4byte sSneaselSprites93
+.4byte sSneaselSprites94
+.4byte sSneaselSprites95
+.4byte sSneaselSprites96
+.4byte sSneaselSprites97
+.4byte sSneaselSprites98
+.4byte sSneaselSprites99
+.4byte sSneaselSprites100
+.4byte sSneaselSprites101
+.4byte sSneaselSprites102
+.4byte sSneaselSprites103
+.4byte sSneaselSprites104
+.4byte sSneaselSprites105
+.4byte sSneaselSprites106
+.4byte sSneaselSprites107
+.4byte sSneaselSprites108
+.4byte sSneaselSprites109
+.4byte sSneaselSprites110
+.4byte sSneaselSprites111
+.4byte sSneaselSprites112
+sAxMainSneasel:
+ax_main sAxPosesSneasel, sAxAnimationsSneasel, 13, sAxSpritesSneasel, sAxPositionsSneasel

--- a/data/ax/snorlax.inc
+++ b/data/ax/snorlax.inc
@@ -1,0 +1,2946 @@
+.global gAxSnorlax
+gAxSnorlax:
+ax_siro sAxMainSnorlax
+sSnorlaxPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose4:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose5:
+ax_pose 4, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose6:
+ax_pose 5, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose7:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose8:
+ax_pose 7, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose9:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose10:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose11:
+ax_pose 10, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose12:
+ax_pose 11, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose16:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose18:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose19:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose20:
+ax_pose 7, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose21:
+ax_pose 8, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose22:
+ax_pose 3, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose23:
+ax_pose 4, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose24:
+ax_pose 5, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose26:
+ax_pose 15, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose28:
+ax_pose 16, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose29:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose30:
+ax_pose 17, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose31:
+ax_pose 5, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose32:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose33:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose34:
+ax_pose 19, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose35:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose36:
+ax_pose 20, 0x81e5, 0x90f0, 0x6c00
+ax_pose 21, 0x81e5, 0x5100, 0x6c08
+ax_pose 22, 0x01f5, 0x1108, 0x6c0c
+ax_pose 23, 0x0205, 0x1100, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose37:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose38:
+ax_pose 24, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose39:
+ax_pose 11, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose40:
+ax_pose 25, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose41:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose42:
+ax_pose 26, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose43:
+ax_pose 14, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose44:
+ax_pose 27, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose45:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose46:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose47:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose48:
+ax_pose 25, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sSnorlaxPose49:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose50:
+ax_pose 19, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose51:
+ax_pose 8, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose52:
+ax_pose 20, 0x81e3, 0x80ff, 0x6c00
+ax_pose 21, 0x81e3, 0x40f7, 0x6c08
+ax_pose 22, 0x01f3, 0x00ef, 0x6c0c
+ax_pose 23, 0x0203, 0x00f7, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose53:
+ax_pose 3, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose54:
+ax_pose 17, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose55:
+ax_pose 5, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose56:
+ax_pose 18, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose57:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose58:
+ax_pose 1, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose59:
+ax_pose 2, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose60:
+ax_pose 15, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose61:
+ax_pose 16, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose62:
+ax_pose 28, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose63:
+ax_pose 29, 0x01e4, 0x80f1, 0x6c00
+ax_pose 30, 0x01e4, 0x80f0, 0x6c10
+ax_pose_terminator
+sSnorlaxPose64:
+ax_pose 30, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose65:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose66:
+ax_pose 4, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose67:
+ax_pose 5, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose68:
+ax_pose 17, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose69:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose70:
+ax_pose 31, 0x01e4, 0x90f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose71:
+ax_pose 32, 0x01e4, 0x90f1, 0x6c00
+ax_pose 33, 0x01e4, 0x90f1, 0x6c10
+ax_pose_terminator
+sSnorlaxPose72:
+ax_pose 33, 0x01e4, 0x90f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose73:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose74:
+ax_pose 7, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose75:
+ax_pose 8, 0x01e5, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose76:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose77:
+ax_pose 20, 0x81e4, 0x90f0, 0x6c00
+ax_pose 21, 0x81e4, 0x5100, 0x6c08
+ax_pose 22, 0x01f4, 0x1108, 0x6c0c
+ax_pose 23, 0x0204, 0x1100, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose78:
+ax_pose 34, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose79:
+ax_pose 35, 0x81e6, 0x9100, 0x6c00
+ax_pose 36, 0x01e6, 0x90f0, 0x6c08
+ax_pose_terminator
+sSnorlaxPose80:
+ax_pose 36, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose81:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose82:
+ax_pose 10, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose83:
+ax_pose 11, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose84:
+ax_pose 24, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose85:
+ax_pose 25, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose86:
+ax_pose 37, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose87:
+ax_pose 38, 0x41e5, 0x90f1, 0x6c00
+ax_pose 39, 0x01e5, 0x90f1, 0x6c08
+ax_pose_terminator
+sSnorlaxPose88:
+ax_pose 39, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose89:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose90:
+ax_pose 13, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose91:
+ax_pose 14, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose92:
+ax_pose 26, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose93:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose94:
+ax_pose 40, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose95:
+ax_pose 41, 0x01e4, 0x80f0, 0x6c00
+ax_pose 42, 0x01e4, 0x80f0, 0x6c10
+ax_pose_terminator
+sSnorlaxPose96:
+ax_pose 42, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose97:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose98:
+ax_pose 10, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose99:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose100:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose101:
+ax_pose 25, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose102:
+ax_pose 37, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose103:
+ax_pose 38, 0x41e5, 0x80ef, 0x6c00
+ax_pose 39, 0x01e5, 0x80ef, 0x6c08
+ax_pose_terminator
+sSnorlaxPose104:
+ax_pose 39, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sSnorlaxPose105:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose106:
+ax_pose 7, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose107:
+ax_pose 8, 0x01e5, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose108:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose109:
+ax_pose 20, 0x81e4, 0x8100, 0x6c00
+ax_pose 21, 0x81e4, 0x40f8, 0x6c08
+ax_pose 22, 0x01f4, 0x00f0, 0x6c0c
+ax_pose 23, 0x0204, 0x00f8, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose110:
+ax_pose 34, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose111:
+ax_pose 35, 0x81e6, 0x80f0, 0x6c00
+ax_pose 36, 0x01e6, 0x80f0, 0x6c08
+ax_pose_terminator
+sSnorlaxPose112:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose113:
+ax_pose 3, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose114:
+ax_pose 4, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose115:
+ax_pose 5, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose116:
+ax_pose 17, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose117:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose118:
+ax_pose 31, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sSnorlaxPose119:
+ax_pose 32, 0x01e4, 0x80ef, 0x6c00
+ax_pose 33, 0x01e4, 0x80ef, 0x6c10
+ax_pose_terminator
+sSnorlaxPose120:
+ax_pose 33, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sSnorlaxPose121:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose122:
+ax_pose 16, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose123:
+ax_pose 15, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose124:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose125:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose126:
+ax_pose 17, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose127:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose128:
+ax_pose 20, 0x81e4, 0x90ef, 0x6c00
+ax_pose 21, 0x81e4, 0x50ff, 0x6c08
+ax_pose 22, 0x01f4, 0x1107, 0x6c0c
+ax_pose 23, 0x0204, 0x10ff, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose129:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose130:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose131:
+ax_pose 25, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose132:
+ax_pose 24, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose133:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose134:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose135:
+ax_pose 26, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose136:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose137:
+ax_pose 25, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose138:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose139:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose140:
+ax_pose 20, 0x81e4, 0x8101, 0x6c00
+ax_pose 21, 0x81e4, 0x40f9, 0x6c08
+ax_pose 22, 0x01f4, 0x00f1, 0x6c0c
+ax_pose 23, 0x0204, 0x00f9, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose141:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose142:
+ax_pose 3, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose143:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose144:
+ax_pose 17, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose145:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose146:
+ax_pose 3, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose147:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose148:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose149:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose150:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose151:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose152:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose153:
+ax_pose 43, 0x81eb, 0x80f2, 0x6c00
+ax_pose 44, 0x81eb, 0x4102, 0x6c08
+ax_pose 45, 0x81f3, 0x010a, 0x6c0c
+ax_pose 46, 0x01fb, 0x00ea, 0x6c0e
+ax_pose_terminator
+sSnorlaxPose154:
+ax_pose 47, 0x81eb, 0x80f2, 0x6c00
+ax_pose 48, 0x81eb, 0x4102, 0x6c08
+ax_pose 49, 0x81f3, 0x010a, 0x6c0c
+ax_pose 50, 0x01fb, 0x00ea, 0x6c0e
+ax_pose_terminator
+sSnorlaxPose155:
+ax_pose 51, 0x01e1, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose156:
+ax_pose 52, 0x01e1, 0x90ef, 0x6c00
+ax_pose_terminator
+sSnorlaxPose157:
+ax_pose 53, 0x01e1, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose158:
+ax_pose 54, 0x01e1, 0x90ee, 0x6c00
+ax_pose_terminator
+sSnorlaxPose159:
+ax_pose 55, 0x01e1, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose160:
+ax_pose 54, 0x01e1, 0x80f2, 0x6c00
+ax_pose_terminator
+sSnorlaxPose161:
+ax_pose 53, 0x01e1, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose162:
+ax_pose 52, 0x01e1, 0x80f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose163:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose164:
+ax_pose 16, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose165:
+ax_pose 15, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose166:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose167:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose168:
+ax_pose 17, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose169:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose170:
+ax_pose 20, 0x81e4, 0x90f0, 0x6c00
+ax_pose 21, 0x81e4, 0x5100, 0x6c08
+ax_pose 22, 0x01f4, 0x1108, 0x6c0c
+ax_pose 23, 0x0204, 0x1100, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose171:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose172:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose173:
+ax_pose 25, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose174:
+ax_pose 24, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose175:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose176:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose177:
+ax_pose 26, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose178:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose179:
+ax_pose 25, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose180:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose181:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose182:
+ax_pose 20, 0x81e4, 0x8100, 0x6c00
+ax_pose 21, 0x81e4, 0x40f8, 0x6c08
+ax_pose 22, 0x01f4, 0x00f0, 0x6c0c
+ax_pose 23, 0x0204, 0x00f8, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose183:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose184:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose185:
+ax_pose 18, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose186:
+ax_pose 17, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose187:
+ax_pose 15, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose188:
+ax_pose 17, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose189:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose190:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose191:
+ax_pose 26, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose192:
+ax_pose 24, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose193:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose194:
+ax_pose 17, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose195:
+ax_pose 16, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose196:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose197:
+ax_pose 20, 0x81e4, 0x90f1, 0x6c00
+ax_pose 21, 0x81e4, 0x5101, 0x6c08
+ax_pose 22, 0x01f4, 0x1109, 0x6c0c
+ax_pose 23, 0x0204, 0x1101, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose198:
+ax_pose 25, 0x01e5, 0x90f1, 0x6c00
+ax_pose_terminator
+sSnorlaxPose199:
+ax_pose 27, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose200:
+ax_pose 25, 0x01e5, 0x80ef, 0x6c00
+ax_pose_terminator
+sSnorlaxPose201:
+ax_pose 20, 0x81e4, 0x80ff, 0x6c00
+ax_pose 21, 0x81e4, 0x40f7, 0x6c08
+ax_pose 22, 0x01f4, 0x00ef, 0x6c0c
+ax_pose 23, 0x0204, 0x00f7, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose202:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose203:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose204:
+ax_pose 16, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose205:
+ax_pose 15, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose206:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sSnorlaxPose207:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose208:
+ax_pose 17, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose209:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose210:
+ax_pose 20, 0x81e4, 0x90ef, 0x6c00
+ax_pose 21, 0x81e4, 0x50ff, 0x6c08
+ax_pose 22, 0x01f4, 0x1107, 0x6c0c
+ax_pose 23, 0x0204, 0x10ff, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose211:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose212:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose213:
+ax_pose 25, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose214:
+ax_pose 24, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose215:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose216:
+ax_pose 27, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose217:
+ax_pose 26, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose218:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose219:
+ax_pose 25, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose220:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose221:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose222:
+ax_pose 20, 0x81e4, 0x8101, 0x6c00
+ax_pose 21, 0x81e4, 0x40f9, 0x6c08
+ax_pose 22, 0x01f4, 0x00f1, 0x6c0c
+ax_pose 23, 0x0204, 0x00f9, 0x6c0d
+ax_pose_terminator
+sSnorlaxPose223:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose224:
+ax_pose 3, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose225:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose226:
+ax_pose 17, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose227:
+ax_pose 15, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose228:
+ax_pose 17, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose229:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose230:
+ax_pose 24, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose231:
+ax_pose 26, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose232:
+ax_pose 24, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose233:
+ax_pose 19, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose234:
+ax_pose 17, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose235:
+ax_pose 0, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose236:
+ax_pose 3, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSnorlaxPose237:
+ax_pose 6, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose238:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSnorlaxPose239:
+ax_pose 12, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sSnorlaxPose240:
+ax_pose 9, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose241:
+ax_pose 6, 0x01e4, 0x90ec, 0x6c00
+ax_pose_terminator
+sSnorlaxPose242:
+ax_pose 3, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+.align 2
+sSnorlaxAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_2_1:
+ax_anim 2, 0, 27, 0, -2, 0, -2,
+ax_anim 8, 0, 27, 0, -3, 0, -3,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSnorlaxAnims_2_2:
+ax_anim 2, 0, 31, -2, -2, -2, -2,
+ax_anim 8, 0, 31, -3, -3, -3, -3,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 11, 10, 11,
+ax_anim 2, 0, 29, 18, 20, 18, 20,
+ax_anim 2, 1, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 29, 18, 20, 18, 20,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sSnorlaxAnims_2_3:
+ax_anim 2, 0, 35, -2, 0, -2, 0,
+ax_anim 8, 0, 35, -3, 0, -3, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 1, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSnorlaxAnims_2_4:
+ax_anim 2, 0, 39, -2, 2, -2, 2,
+ax_anim 8, 0, 39, -3, 3, -3, 3,
+ax_anim 1, 0, 36, 0, -1, 0, -1,
+ax_anim 1, 2, 36, 4, -6, 4, -6,
+ax_anim 1, 0, 36, 10, -11, 10, -11,
+ax_anim 2, 0, 37, 18, -19, 18, -19,
+ax_anim 2, 1, 37, 19, -18, 19, -18,
+ax_anim 2, 0, 37, 18, -19, 18, -19,
+ax_anim 2, 0, 37, 19, -18, 19, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sSnorlaxAnims_2_5:
+ax_anim 2, 0, 43, 0, 2, 0, 2,
+ax_anim 8, 0, 43, 0, 3, 0, 3,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 0, -4, 0, -4,
+ax_anim 1, 0, 40, 0, -11, 0, -11,
+ax_anim 2, 0, 41, 0, -18, 0, -18,
+ax_anim 2, 1, 41, 1, -18, 1, -18,
+ax_anim 2, 0, 41, 0, -18, 0, -18,
+ax_anim 2, 0, 41, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sSnorlaxAnims_2_6:
+ax_anim 2, 0, 47, 2, 2, 2, 2,
+ax_anim 8, 0, 47, 3, 3, 3, 3,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 2, 44, -4, -6, -4, -6,
+ax_anim 1, 0, 44, -10, -11, -10, -11,
+ax_anim 2, 0, 45, -18, -19, -18, -19,
+ax_anim 2, 1, 45, -19, -18, -19, -18,
+ax_anim 2, 0, 45, -18, -19, -18, -19,
+ax_anim 2, 0, 45, -19, -18, -19, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sSnorlaxAnims_2_7:
+ax_anim 2, 0, 51, 2, 0, 2, 0,
+ax_anim 8, 0, 51, 3, 0, 3, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, -4, 0, -4, 0,
+ax_anim 1, 0, 48, -10, 0, -10, 0,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 1, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sSnorlaxAnims_2_8:
+ax_anim 2, 0, 55, 2, -2, 2, -2,
+ax_anim 8, 0, 55, 3, -3, 3, -3,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, -4, 4, -4, 4,
+ax_anim 1, 0, 52, -10, 11, -10, 11,
+ax_anim 2, 0, 53, -18, 20, -18, 20,
+ax_anim 2, 1, 53, -19, 19, -19, 19,
+ax_anim 2, 0, 53, -18, 20, -18, 20,
+ax_anim 2, 0, 53, -19, 19, -19, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_3_1:
+ax_anim 6, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, -4, 0, 2,
+ax_anim 2, 0, 60, 0, -5, 0, 4,
+ax_anim 3, 0, 61, 0, -7, 0, 8,
+ax_anim 2, 2, 61, 0, -5, 0, 12,
+ax_anim 1, 0, 61, 0, 5, 0, 16,
+ax_anim 1, 0, 61, 0, 12, 0, 20,
+ax_anim 2, 1, 79, -1, 22, -1, 22,
+ax_anim 2, 0, 79, 0, 22, 0, 22,
+ax_anim 2, 0, 79, -1, 22, -1, 22,
+ax_anim 2, 0, 79, 0, 22, 0, 22,
+ax_anim 2, 0, 61, 0, 8, 0, 18,
+ax_anim 2, 0, 61, 0, 1, 0, 13,
+ax_anim 2, 0, 56, 0, -1, 0, 4,
+ax_anim_terminator
+sSnorlaxAnims_3_2:
+ax_anim 6, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 2, -4, 2, 2,
+ax_anim 2, 0, 68, 4, -5, 4, 4,
+ax_anim 3, 0, 69, 8, -7, 8, 8,
+ax_anim 2, 2, 69, 12, -5, 12, 12,
+ax_anim 1, 0, 69, 16, 5, 16, 16,
+ax_anim 1, 0, 69, 20, 12, 20, 20,
+ax_anim 2, 1, 119, 22, 22, 22, 22,
+ax_anim 2, 0, 119, 23, 21, 23, 21,
+ax_anim 2, 0, 119, 22, 22, 22, 22,
+ax_anim 2, 0, 119, 23, 21, 23, 21,
+ax_anim 2, 0, 69, 18, 8, 18, 18,
+ax_anim 2, 0, 69, 13, 1, 13, 13,
+ax_anim 2, 0, 64, 4, -1, 4, 4,
+ax_anim_terminator
+sSnorlaxAnims_3_3:
+ax_anim 6, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 2, -6, 2, 0,
+ax_anim 2, 0, 76, 4, -9, 4, 0,
+ax_anim 3, 0, 77, 8, -10, 8, 0,
+ax_anim 2, 2, 77, 12, -11, 12, 0,
+ax_anim 1, 0, 77, 16, -9, 16, 0,
+ax_anim 1, 0, 77, 20, -7, 20, 0,
+ax_anim 2, 1, 63, 22, 0, 22, 0,
+ax_anim 2, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 0, 63, 22, 0, 22, 0,
+ax_anim 2, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 0, 77, 18, -8, 18, 0,
+ax_anim 2, 0, 77, 13, -6, 13, 0,
+ax_anim 2, 0, 72, 4, -2, 4, 0,
+ax_anim_terminator
+sSnorlaxAnims_3_4:
+ax_anim 6, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 2, -8, 2, -2,
+ax_anim 2, 0, 84, 4, -13, 4, -4,
+ax_anim 3, 0, 85, 8, -19, 8, -8,
+ax_anim 2, 2, 85, 12, -24, 12, -12,
+ax_anim 1, 0, 85, 16, -25, 16, -16,
+ax_anim 1, 0, 85, 20, -24, 20, -20,
+ax_anim 2, 1, 71, 22, -22, 22, -22,
+ax_anim 2, 0, 71, 23, -21, 23, -21,
+ax_anim 2, 0, 71, 22, -22, 22, -22,
+ax_anim 2, 0, 71, 23, -21, 23, -21,
+ax_anim 2, 0, 85, 18, -26, 18, -18,
+ax_anim 2, 0, 85, 13, -18, 13, -13,
+ax_anim 2, 0, 80, 4, -6, 4, -4,
+ax_anim_terminator
+sSnorlaxAnims_3_5:
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -8, 0, -2,
+ax_anim 2, 0, 92, 0, -13, 0, -4,
+ax_anim 3, 0, 93, 0, -19, 0, -8,
+ax_anim 2, 2, 93, 0, -24, 0, -12,
+ax_anim 1, 0, 93, 0, -25, 0, -16,
+ax_anim 1, 0, 93, 0, -24, 0, -20,
+ax_anim 2, 1, 111, 0, -22, 0, -22,
+ax_anim 2, 0, 111, 1, -22, 0, -22,
+ax_anim 2, 0, 111, 0, -22, 0, -22,
+ax_anim 2, 0, 111, 1, -22, 0, -22,
+ax_anim 2, 0, 93, 0, -26, 0, -18,
+ax_anim 2, 0, 93, 0, -18, 0, -13,
+ax_anim 2, 0, 88, 0, -6, 0, -4,
+ax_anim_terminator
+sSnorlaxAnims_3_6:
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -2, -8, -2, -2,
+ax_anim 2, 0, 100, -4, -13, -4, -4,
+ax_anim 3, 0, 101, -8, -19, -8, -8,
+ax_anim 2, 2, 101, -12, -24, -12, -12,
+ax_anim 1, 0, 101, -16, -25, -16, -16,
+ax_anim 1, 0, 101, -20, -24, -20, -20,
+ax_anim 2, 1, 119, -22, -22, -22, -22,
+ax_anim 2, 0, 119, -23, -21, -23, -21,
+ax_anim 2, 0, 119, -22, -22, -22, -22,
+ax_anim 2, 0, 119, -23, -21, -23, -21,
+ax_anim 2, 0, 101, -18, -26, -18, -18,
+ax_anim 2, 0, 101, -13, -18, -13, -13,
+ax_anim 2, 0, 96, -4, -6, -4, -4,
+ax_anim_terminator
+sSnorlaxAnims_3_7:
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, -2, -6, -2, 0,
+ax_anim 2, 0, 108, -4, -9, -4, 0,
+ax_anim 3, 0, 109, -8, -10, -8, 0,
+ax_anim 2, 2, 109, -12, -11, -12, 0,
+ax_anim 1, 0, 109, -16, -9, -16, 0,
+ax_anim 1, 0, 109, -20, -7, -20, 0,
+ax_anim 2, 1, 63, -22, 0, -22, 0,
+ax_anim 2, 0, 63, -23, 0, -23, 0,
+ax_anim 2, 0, 63, -22, 0, -22, 0,
+ax_anim 2, 0, 63, -23, 0, -23, 0,
+ax_anim 2, 0, 109, -18, -8, -18, 0,
+ax_anim 2, 0, 109, -13, -6, -13, 0,
+ax_anim 2, 0, 104, -4, -2, -4, 0,
+ax_anim_terminator
+sSnorlaxAnims_3_8:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -2, -4, -2, 2,
+ax_anim 2, 0, 116, -4, -5, -4, 4,
+ax_anim 3, 0, 117, -8, -7, -8, 8,
+ax_anim 2, 2, 117, -12, -5, -12, 12,
+ax_anim 1, 0, 117, -16, 5, -16, 16,
+ax_anim 1, 0, 117, -20, 12, -20, 20,
+ax_anim 2, 1, 71, -22, 22, -22, 22,
+ax_anim 2, 0, 71, -23, 21, -23, 21,
+ax_anim 2, 0, 71, -22, 22, -22, 22,
+ax_anim 2, 0, 71, -23, 21, -23, 21,
+ax_anim 2, 0, 117, -18, 8, -18, 18,
+ax_anim 2, 0, 117, -13, 1, -13, 13,
+ax_anim 2, 0, 112, -4, -1, -4, 4,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_4_1:
+ax_anim 2, 0, 121, 0, -1, 0, -1,
+ax_anim 2, 0, 121, 0, -3, 0, -3,
+ax_anim 6, 2, 121, 0, -4, 0, -4,
+ax_anim 1, 0, 122, 0, -2, 0, -2,
+ax_anim 1, 0, 122, 0, 2, 0, 2,
+ax_anim 2, 1, 122, 1, 2, 1, 2,
+ax_anim 2, 0, 122, 0, 2, 0, 2,
+ax_anim 2, 0, 122, 1, 2, 1, 2,
+ax_anim 2, 0, 122, 0, 2, 0, 2,
+ax_anim 2, 0, 122, 1, 2, 1, 2,
+ax_anim 2, 0, 122, 0, 2, 0, 2,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sSnorlaxAnims_4_2:
+ax_anim 2, 0, 124, -1, -1, -1, -1,
+ax_anim 2, 0, 124, -3, -3, -3, -3,
+ax_anim 6, 2, 124, -4, -4, -4, -4,
+ax_anim 1, 0, 125, -2, -2, -2, -2,
+ax_anim 1, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 1, 125, 3, 1, 3, 1,
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 125, 3, 1, 3, 1,
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 125, 3, 1, 3, 1,
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 123, 1, 1, 1, 1,
+ax_anim_terminator
+sSnorlaxAnims_4_3:
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, -3, 0, -3, 0,
+ax_anim 6, 2, 127, -4, 0, -4, 0,
+ax_anim 1, 0, 128, -2, 0, -2, 0,
+ax_anim 1, 0, 128, 2, 0, 2, 0,
+ax_anim 2, 1, 128, 2, -1, 2, -1,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 2, 0, 128, 2, -1, 2, -1,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 2, 0, 128, 2, -1, 2, -1,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 2, 0, 126, 1, 0, 1, 0,
+ax_anim_terminator
+sSnorlaxAnims_4_4:
+ax_anim 2, 0, 130, -1, 1, -1, 1,
+ax_anim 2, 0, 130, -3, 3, -3, 3,
+ax_anim 6, 2, 130, -4, 4, -4, 4,
+ax_anim 1, 0, 131, -2, 2, -2, 2,
+ax_anim 1, 0, 131, 2, -2, 2, -2,
+ax_anim 2, 1, 131, 3, -1, 3, -1,
+ax_anim 2, 0, 131, 2, -2, 2, -2,
+ax_anim 2, 0, 131, 3, -1, 3, -1,
+ax_anim 2, 0, 131, 2, -2, 2, -2,
+ax_anim 2, 0, 131, 3, -1, 3, -1,
+ax_anim 2, 0, 131, 2, -2, 2, -2,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim_terminator
+sSnorlaxAnims_4_5:
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 3, 0, 3,
+ax_anim 6, 2, 133, 0, 4, 0, 4,
+ax_anim 1, 0, 134, 0, 2, 0, 2,
+ax_anim 1, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 1, 134, 1, -2, 1, -2,
+ax_anim 2, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 0, 134, 1, -2, 1, -2,
+ax_anim 2, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 0, 134, 1, -2, 1, -2,
+ax_anim 2, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 0, 132, 0, -1, 0, -1,
+ax_anim_terminator
+sSnorlaxAnims_4_6:
+ax_anim 2, 0, 136, 1, 1, 1, 1,
+ax_anim 2, 0, 136, 3, 3, 3, 3,
+ax_anim 6, 2, 136, 4, 4, 4, 4,
+ax_anim 1, 0, 137, 2, 2, 2, 2,
+ax_anim 1, 0, 137, -2, -2, -2, -2,
+ax_anim 2, 1, 137, -3, -1, -3, -1,
+ax_anim 2, 0, 137, -2, -2, -2, -2,
+ax_anim 2, 0, 137, -3, -1, -3, -1,
+ax_anim 2, 0, 137, -2, -2, -2, -2,
+ax_anim 2, 0, 137, -3, -1, -3, -1,
+ax_anim 2, 0, 137, -2, -2, -2, -2,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+sSnorlaxAnims_4_7:
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 0, 139, 3, 0, 3, 0,
+ax_anim 6, 2, 139, 4, 0, 4, 0,
+ax_anim 1, 0, 140, 2, 0, 2, 0,
+ax_anim 1, 0, 140, -2, 0, -2, 0,
+ax_anim 2, 1, 140, -2, -1, -2, -1,
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 2, 0, 140, -2, -1, -2, -1,
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 2, 0, 140, -2, -1, -2, -1,
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 2, 0, 138, -1, 0, -1, 0,
+ax_anim_terminator
+sSnorlaxAnims_4_8:
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, 3, -3, 3, -3,
+ax_anim 6, 2, 142, 4, -4, 4, -4,
+ax_anim 1, 0, 143, 2, -2, 2, -2,
+ax_anim 1, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 1, 143, -3, 1, -3, 1,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 0, 143, -3, 1, -3, 1,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 0, 143, -3, 1, -3, 1,
+ax_anim 2, 0, 143, -2, 2, -2, 2,
+ax_anim 2, 0, 141, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_5_1:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_5_2:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_5_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_5_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_5_5:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_5_6:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_5_7:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_5_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sSnorlaxAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sSnorlaxAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sSnorlaxAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sSnorlaxAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sSnorlaxAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sSnorlaxAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sSnorlaxAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -1, 0, 0,
+ax_anim 3, 0, 163, 0, -3, 0, 0,
+ax_anim 4, 0, 163, 0, -4, 0, 0,
+ax_anim 3, 0, 163, 0, -3, 0, 0,
+ax_anim 1, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_8_2:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -1, 0, 0,
+ax_anim 3, 0, 166, 0, -3, 0, 0,
+ax_anim 4, 0, 166, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -3, 0, 0,
+ax_anim 1, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim 3, 0, 169, 0, -4, 0, 0,
+ax_anim 4, 0, 169, 0, -5, 0, 0,
+ax_anim 3, 0, 169, 0, -4, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_8_4:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -1, 0, 0,
+ax_anim 3, 0, 172, 0, -3, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim 3, 0, 172, 0, -3, 0, 0,
+ax_anim 1, 0, 172, 0, -1, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_8_5:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -1, 0, 0,
+ax_anim 3, 0, 175, 0, -3, 0, 0,
+ax_anim 4, 0, 175, 0, -4, 0, 0,
+ax_anim 3, 0, 175, 0, -3, 0, 0,
+ax_anim 1, 0, 175, 0, -1, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_8_6:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -1, 0, 0,
+ax_anim 3, 0, 178, 0, -3, 0, 0,
+ax_anim 4, 0, 178, 0, -4, 0, 0,
+ax_anim 3, 0, 178, 0, -3, 0, 0,
+ax_anim 1, 0, 178, 0, -1, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_8_7:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -2, 0, 0,
+ax_anim 3, 0, 181, 0, -4, 0, 0,
+ax_anim 4, 0, 181, 0, -5, 0, 0,
+ax_anim 3, 0, 181, 0, -4, 0, 0,
+ax_anim 1, 0, 181, 0, -2, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_8_8:
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -1, 0, 0,
+ax_anim 3, 0, 184, 0, -3, 0, 0,
+ax_anim 4, 0, 184, 0, -4, 0, 0,
+ax_anim 3, 0, 184, 0, -3, 0, 0,
+ax_anim 1, 0, 184, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 18, 7, 18,
+ax_anim 3, 0, 190, 0, 22, 0, 22,
+ax_anim 2, 3, 191, -7, 18, -7, 18,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 6, 17, 6,
+ax_anim 2, 0, 188, 22, 14, 22, 14,
+ax_anim 3, 0, 189, 20, 22, 20, 22,
+ax_anim 2, 3, 190, 14, 23, 14, 23,
+ax_anim 2, 0, 191, 4, 15, 4, 15,
+ax_anim 1, 0, 192, 1, 7, 1, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 17, -5, 17, -5,
+ax_anim 3, 0, 188, 19, 0, 19, 0,
+ax_anim 2, 3, 189, 17, 5, 17, 5,
+ax_anim 2, 0, 190, 12, 8, 12, 8,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 1, -8, 1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -22, 12, -22,
+ax_anim 3, 0, 187, 21, -20, 21, -20,
+ax_anim 2, 3, 188, 22, -13, 22, -13,
+ax_anim 2, 0, 189, 17, -5, 17, -5,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -6, -4, -6, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -9, -18, -9, -18,
+ax_anim 3, 0, 186, 0, -20, 0, -20,
+ax_anim 2, 3, 187, 9, -18, 9, -18,
+ax_anim 2, 0, 188, 9, -10, 9, -10,
+ax_anim 1, 0, 189, 6, -4, 6, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -22, -12, -22,
+ax_anim 3, 0, 193, -21, -20, -21, -20,
+ax_anim 2, 3, 192, -22, -13, -22, -13,
+ax_anim 2, 0, 191, -17, -5, -17, -5,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -17, -5, -17, -5,
+ax_anim 3, 0, 192, -19, 0, -19, 0,
+ax_anim 2, 3, 191, -17, 5, -17, 5,
+ax_anim 2, 0, 190, -12, 8, -12, 8,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 6, -17, 6,
+ax_anim 2, 0, 192, -22, 14, -22, 14,
+ax_anim 3, 0, 191, -20, 22, -20, 22,
+ax_anim 2, 3, 190, -14, 23, -14, 23,
+ax_anim 2, 0, 189, -4, 15, -4, 15,
+ax_anim 1, 0, 188, 1, 7, 1, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnorlaxAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sSnorlaxGfx1:
+.incbin "baserom.gba", 0xB29424, 0x200
+sSnorlaxSprites1:
+ax_sprite sSnorlaxGfx1, 0x200
+ax_sprite_terminator
+sSnorlaxGfx2:
+.incbin "baserom.gba", 0xB29634, 0x200
+sSnorlaxSprites2:
+ax_sprite sSnorlaxGfx2, 0x200
+ax_sprite_terminator
+sSnorlaxGfx3:
+.incbin "baserom.gba", 0xB29844, 0x200
+sSnorlaxSprites3:
+ax_sprite sSnorlaxGfx3, 0x200
+ax_sprite_terminator
+sSnorlaxGfx4:
+.incbin "baserom.gba", 0xB29A54, 0x200
+sSnorlaxSprites4:
+ax_sprite sSnorlaxGfx4, 0x200
+ax_sprite_terminator
+sSnorlaxGfx5:
+.incbin "baserom.gba", 0xB29C64, 0x200
+sSnorlaxSprites5:
+ax_sprite sSnorlaxGfx5, 0x200
+ax_sprite_terminator
+sSnorlaxGfx6:
+.incbin "baserom.gba", 0xB29E74, 0x200
+sSnorlaxSprites6:
+ax_sprite sSnorlaxGfx6, 0x200
+ax_sprite_terminator
+sSnorlaxGfx7:
+.incbin "baserom.gba", 0xB2A084, 0x200
+sSnorlaxSprites7:
+ax_sprite sSnorlaxGfx7, 0x200
+ax_sprite_terminator
+sSnorlaxGfx8:
+.incbin "baserom.gba", 0xB2A294, 0x200
+sSnorlaxSprites8:
+ax_sprite sSnorlaxGfx8, 0x200
+ax_sprite_terminator
+sSnorlaxGfx9:
+.incbin "baserom.gba", 0xB2A4A4, 0x200
+sSnorlaxSprites9:
+ax_sprite sSnorlaxGfx9, 0x200
+ax_sprite_terminator
+sSnorlaxGfx10:
+.incbin "baserom.gba", 0xB2A6B4, 0x200
+sSnorlaxSprites10:
+ax_sprite sSnorlaxGfx10, 0x200
+ax_sprite_terminator
+sSnorlaxGfx11:
+.incbin "baserom.gba", 0xB2A8C4, 0x200
+sSnorlaxSprites11:
+ax_sprite sSnorlaxGfx11, 0x200
+ax_sprite_terminator
+sSnorlaxGfx12:
+.incbin "baserom.gba", 0xB2AAD4, 0x200
+sSnorlaxSprites12:
+ax_sprite sSnorlaxGfx12, 0x200
+ax_sprite_terminator
+sSnorlaxGfx13:
+.incbin "baserom.gba", 0xB2ACE4, 0x200
+sSnorlaxSprites13:
+ax_sprite sSnorlaxGfx13, 0x200
+ax_sprite_terminator
+sSnorlaxGfx14:
+.incbin "baserom.gba", 0xB2AEF4, 0x200
+sSnorlaxSprites14:
+ax_sprite sSnorlaxGfx14, 0x200
+ax_sprite_terminator
+sSnorlaxGfx15:
+.incbin "baserom.gba", 0xB2B104, 0x200
+sSnorlaxSprites15:
+ax_sprite sSnorlaxGfx15, 0x200
+ax_sprite_terminator
+sSnorlaxGfx16:
+.incbin "baserom.gba", 0xB2B314, 0x40
+sSnorlaxGfx16_1:
+.incbin "baserom.gba", 0xB2B354, 0x180
+sSnorlaxSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx16_1, 0x180
+ax_sprite_terminator
+sSnorlaxGfx17:
+.incbin "baserom.gba", 0xB2B4FC, 0x40
+sSnorlaxGfx17_1:
+.incbin "baserom.gba", 0xB2B53C, 0x180
+sSnorlaxSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx17_1, 0x180
+ax_sprite_terminator
+sSnorlaxGfx18:
+.incbin "baserom.gba", 0xB2B6E4, 0x40
+sSnorlaxGfx18_1:
+.incbin "baserom.gba", 0xB2B724, 0x180
+sSnorlaxSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx18_1, 0x180
+ax_sprite_terminator
+sSnorlaxGfx19:
+.incbin "baserom.gba", 0xB2B8CC, 0x200
+sSnorlaxSprites19:
+ax_sprite sSnorlaxGfx19, 0x200
+ax_sprite_terminator
+sSnorlaxGfx20:
+.incbin "baserom.gba", 0xB2BADC, 0x60
+sSnorlaxGfx20_1:
+.incbin "baserom.gba", 0xB2BB3C, 0x180
+sSnorlaxSprites20:
+ax_sprite sSnorlaxGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx20_1, 0x180
+ax_sprite_terminator
+sSnorlaxGfx21:
+.incbin "baserom.gba", 0xB2BCDC, 0x100
+sSnorlaxSprites21:
+ax_sprite sSnorlaxGfx21, 0x100
+ax_sprite_terminator
+sSnorlaxGfx22:
+.incbin "baserom.gba", 0xB2BDEC, 0x80
+sSnorlaxSprites22:
+ax_sprite sSnorlaxGfx22, 0x80
+ax_sprite_terminator
+sSnorlaxGfx23:
+.incbin "baserom.gba", 0xB2BE7C, 0x20
+sSnorlaxSprites23:
+ax_sprite sSnorlaxGfx23, 0x20
+ax_sprite_terminator
+sSnorlaxGfx24:
+.incbin "baserom.gba", 0xB2BEAC, 0x20
+sSnorlaxSprites24:
+ax_sprite sSnorlaxGfx24, 0x20
+ax_sprite_terminator
+sSnorlaxGfx25:
+.incbin "baserom.gba", 0xB2BEDC, 0x60
+sSnorlaxGfx25_1:
+.incbin "baserom.gba", 0xB2BF3C, 0x180
+sSnorlaxSprites25:
+ax_sprite sSnorlaxGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx25_1, 0x180
+ax_sprite_terminator
+sSnorlaxGfx26:
+.incbin "baserom.gba", 0xB2C0DC, 0x160
+sSnorlaxGfx26_1:
+.incbin "baserom.gba", 0xB2C23C, 0x60
+sSnorlaxSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx26, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx26_1, 0x60
+ax_sprite_terminator
+sSnorlaxGfx27:
+.incbin "baserom.gba", 0xB2C2C4, 0x40
+sSnorlaxGfx27_1:
+.incbin "baserom.gba", 0xB2C304, 0x180
+sSnorlaxSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx27_1, 0x180
+ax_sprite_terminator
+sSnorlaxGfx28:
+.incbin "baserom.gba", 0xB2C4AC, 0x40
+sSnorlaxGfx28_1:
+.incbin "baserom.gba", 0xB2C4EC, 0x180
+sSnorlaxSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx28_1, 0x180
+ax_sprite_terminator
+sSnorlaxGfx29:
+.incbin "baserom.gba", 0xB2C694, 0x60
+sSnorlaxGfx29_1:
+.incbin "baserom.gba", 0xB2C6F4, 0x100
+sSnorlaxGfx29_2:
+.incbin "baserom.gba", 0xB2C7F4, 0x40
+sSnorlaxSprites29:
+ax_sprite sSnorlaxGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx29_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSnorlaxGfx30:
+.incbin "baserom.gba", 0xB2C86C, 0x60
+sSnorlaxGfx30_1:
+.incbin "baserom.gba", 0xB2C8CC, 0x20
+sSnorlaxGfx30_2:
+.incbin "baserom.gba", 0xB2C8EC, 0x20
+sSnorlaxGfx30_3:
+.incbin "baserom.gba", 0xB2C90C, 0x20
+sSnorlaxSprites30:
+ax_sprite sSnorlaxGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx30_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSnorlaxGfx30_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSnorlaxGfx30_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSnorlaxGfx31:
+.incbin "baserom.gba", 0xB2C974, 0x180
+sSnorlaxSprites31:
+ax_sprite 0, 0x80
+ax_sprite sSnorlaxGfx31, 0x180
+ax_sprite_terminator
+sSnorlaxGfx32:
+.incbin "baserom.gba", 0xB2CB0C, 0x60
+sSnorlaxGfx32_1:
+.incbin "baserom.gba", 0xB2CB6C, 0x100
+sSnorlaxGfx32_2:
+.incbin "baserom.gba", 0xB2CC6C, 0x40
+sSnorlaxSprites32:
+ax_sprite sSnorlaxGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx32_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx32_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSnorlaxGfx33:
+.incbin "baserom.gba", 0xB2CCE4, 0xC0
+sSnorlaxGfx33_1:
+.incbin "baserom.gba", 0xB2CDA4, 0x20
+sSnorlaxSprites33:
+ax_sprite sSnorlaxGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSnorlaxGfx33_1, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sSnorlaxGfx34:
+.incbin "baserom.gba", 0xB2CDEC, 0x180
+sSnorlaxSprites34:
+ax_sprite 0, 0x80
+ax_sprite sSnorlaxGfx34, 0x180
+ax_sprite_terminator
+sSnorlaxGfx35:
+.incbin "baserom.gba", 0xB2CF84, 0x1E0
+sSnorlaxSprites35:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx35, 0x1e0
+ax_sprite_terminator
+sSnorlaxGfx36:
+.incbin "baserom.gba", 0xB2D17C, 0xC0
+sSnorlaxSprites36:
+ax_sprite sSnorlaxGfx36, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSnorlaxGfx37:
+.incbin "baserom.gba", 0xB2D254, 0x180
+sSnorlaxSprites37:
+ax_sprite 0, 0x80
+ax_sprite sSnorlaxGfx37, 0x180
+ax_sprite_terminator
+sSnorlaxGfx38:
+.incbin "baserom.gba", 0xB2D3EC, 0x180
+sSnorlaxGfx38_1:
+.incbin "baserom.gba", 0xB2D56C, 0x40
+sSnorlaxSprites38:
+ax_sprite sSnorlaxGfx38, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx38_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSnorlaxGfx39:
+.incbin "baserom.gba", 0xB2D5D4, 0x60
+sSnorlaxGfx39_1:
+.incbin "baserom.gba", 0xB2D634, 0x40
+sSnorlaxSprites39:
+ax_sprite sSnorlaxGfx39, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSnorlaxGfx39_1, 0x40
+ax_sprite_terminator
+sSnorlaxGfx40:
+.incbin "baserom.gba", 0xB2D694, 0x40
+sSnorlaxGfx40_1:
+.incbin "baserom.gba", 0xB2D6D4, 0x100
+sSnorlaxGfx40_2:
+.incbin "baserom.gba", 0xB2D7D4, 0x60
+sSnorlaxSprites40:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx40_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx40_2, 0x60
+ax_sprite_terminator
+sSnorlaxGfx41:
+.incbin "baserom.gba", 0xB2D86C, 0x160
+sSnorlaxGfx41_1:
+.incbin "baserom.gba", 0xB2D9CC, 0x40
+sSnorlaxSprites41:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx41, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx41_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSnorlaxGfx42:
+.incbin "baserom.gba", 0xB2DA3C, 0x60
+sSnorlaxGfx42_1:
+.incbin "baserom.gba", 0xB2DA9C, 0x20
+sSnorlaxGfx42_2:
+.incbin "baserom.gba", 0xB2DABC, 0x20
+sSnorlaxSprites42:
+ax_sprite 0, 0x20
+ax_sprite sSnorlaxGfx42, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSnorlaxGfx42_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSnorlaxGfx42_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSnorlaxGfx43:
+.incbin "baserom.gba", 0xB2DB1C, 0x180
+sSnorlaxSprites43:
+ax_sprite 0, 0x80
+ax_sprite sSnorlaxGfx43, 0x180
+ax_sprite_terminator
+sSnorlaxGfx44:
+.incbin "baserom.gba", 0xB2DCB4, 0x100
+sSnorlaxSprites44:
+ax_sprite sSnorlaxGfx44, 0x100
+ax_sprite_terminator
+sSnorlaxGfx45:
+.incbin "baserom.gba", 0xB2DDC4, 0x80
+sSnorlaxSprites45:
+ax_sprite sSnorlaxGfx45, 0x80
+ax_sprite_terminator
+sSnorlaxGfx46:
+.incbin "baserom.gba", 0xB2DE54, 0x40
+sSnorlaxSprites46:
+ax_sprite sSnorlaxGfx46, 0x40
+ax_sprite_terminator
+sSnorlaxGfx47:
+.incbin "baserom.gba", 0xB2DEA4, 0x20
+sSnorlaxSprites47:
+ax_sprite sSnorlaxGfx47, 0x20
+ax_sprite_terminator
+sSnorlaxGfx48:
+.incbin "baserom.gba", 0xB2DED4, 0x100
+sSnorlaxSprites48:
+ax_sprite sSnorlaxGfx48, 0x100
+ax_sprite_terminator
+sSnorlaxGfx49:
+.incbin "baserom.gba", 0xB2DFE4, 0x80
+sSnorlaxSprites49:
+ax_sprite sSnorlaxGfx49, 0x80
+ax_sprite_terminator
+sSnorlaxGfx50:
+.incbin "baserom.gba", 0xB2E074, 0x40
+sSnorlaxSprites50:
+ax_sprite sSnorlaxGfx50, 0x40
+ax_sprite_terminator
+sSnorlaxGfx51:
+.incbin "baserom.gba", 0xB2E0C4, 0x20
+sSnorlaxSprites51:
+ax_sprite sSnorlaxGfx51, 0x20
+ax_sprite_terminator
+sSnorlaxGfx52:
+.incbin "baserom.gba", 0xB2E0F4, 0x200
+sSnorlaxSprites52:
+ax_sprite sSnorlaxGfx52, 0x200
+ax_sprite_terminator
+sSnorlaxGfx53:
+.incbin "baserom.gba", 0xB2E304, 0x200
+sSnorlaxSprites53:
+ax_sprite sSnorlaxGfx53, 0x200
+ax_sprite_terminator
+sSnorlaxGfx54:
+.incbin "baserom.gba", 0xB2E514, 0x200
+sSnorlaxSprites54:
+ax_sprite sSnorlaxGfx54, 0x200
+ax_sprite_terminator
+sSnorlaxGfx55:
+.incbin "baserom.gba", 0xB2E724, 0x200
+sSnorlaxSprites55:
+ax_sprite sSnorlaxGfx55, 0x200
+ax_sprite_terminator
+sSnorlaxGfx56:
+.incbin "baserom.gba", 0xB2E934, 0x200
+sSnorlaxSprites56:
+ax_sprite sSnorlaxGfx56, 0x200
+ax_sprite_terminator
+sAxPosesSnorlax:
+.4byte sSnorlaxPose1
+.4byte sSnorlaxPose2
+.4byte sSnorlaxPose3
+.4byte sSnorlaxPose4
+.4byte sSnorlaxPose5
+.4byte sSnorlaxPose6
+.4byte sSnorlaxPose7
+.4byte sSnorlaxPose8
+.4byte sSnorlaxPose9
+.4byte sSnorlaxPose10
+.4byte sSnorlaxPose11
+.4byte sSnorlaxPose12
+.4byte sSnorlaxPose13
+.4byte sSnorlaxPose14
+.4byte sSnorlaxPose15
+.4byte sSnorlaxPose16
+.4byte sSnorlaxPose17
+.4byte sSnorlaxPose18
+.4byte sSnorlaxPose19
+.4byte sSnorlaxPose20
+.4byte sSnorlaxPose21
+.4byte sSnorlaxPose22
+.4byte sSnorlaxPose23
+.4byte sSnorlaxPose24
+.4byte sSnorlaxPose25
+.4byte sSnorlaxPose26
+.4byte sSnorlaxPose27
+.4byte sSnorlaxPose28
+.4byte sSnorlaxPose29
+.4byte sSnorlaxPose30
+.4byte sSnorlaxPose31
+.4byte sSnorlaxPose32
+.4byte sSnorlaxPose33
+.4byte sSnorlaxPose34
+.4byte sSnorlaxPose35
+.4byte sSnorlaxPose36
+.4byte sSnorlaxPose37
+.4byte sSnorlaxPose38
+.4byte sSnorlaxPose39
+.4byte sSnorlaxPose40
+.4byte sSnorlaxPose41
+.4byte sSnorlaxPose42
+.4byte sSnorlaxPose43
+.4byte sSnorlaxPose44
+.4byte sSnorlaxPose45
+.4byte sSnorlaxPose46
+.4byte sSnorlaxPose47
+.4byte sSnorlaxPose48
+.4byte sSnorlaxPose49
+.4byte sSnorlaxPose50
+.4byte sSnorlaxPose51
+.4byte sSnorlaxPose52
+.4byte sSnorlaxPose53
+.4byte sSnorlaxPose54
+.4byte sSnorlaxPose55
+.4byte sSnorlaxPose56
+.4byte sSnorlaxPose57
+.4byte sSnorlaxPose58
+.4byte sSnorlaxPose59
+.4byte sSnorlaxPose60
+.4byte sSnorlaxPose61
+.4byte sSnorlaxPose62
+.4byte sSnorlaxPose63
+.4byte sSnorlaxPose64
+.4byte sSnorlaxPose65
+.4byte sSnorlaxPose66
+.4byte sSnorlaxPose67
+.4byte sSnorlaxPose68
+.4byte sSnorlaxPose69
+.4byte sSnorlaxPose70
+.4byte sSnorlaxPose71
+.4byte sSnorlaxPose72
+.4byte sSnorlaxPose73
+.4byte sSnorlaxPose74
+.4byte sSnorlaxPose75
+.4byte sSnorlaxPose76
+.4byte sSnorlaxPose77
+.4byte sSnorlaxPose78
+.4byte sSnorlaxPose79
+.4byte sSnorlaxPose80
+.4byte sSnorlaxPose81
+.4byte sSnorlaxPose82
+.4byte sSnorlaxPose83
+.4byte sSnorlaxPose84
+.4byte sSnorlaxPose85
+.4byte sSnorlaxPose86
+.4byte sSnorlaxPose87
+.4byte sSnorlaxPose88
+.4byte sSnorlaxPose89
+.4byte sSnorlaxPose90
+.4byte sSnorlaxPose91
+.4byte sSnorlaxPose92
+.4byte sSnorlaxPose93
+.4byte sSnorlaxPose94
+.4byte sSnorlaxPose95
+.4byte sSnorlaxPose96
+.4byte sSnorlaxPose97
+.4byte sSnorlaxPose98
+.4byte sSnorlaxPose99
+.4byte sSnorlaxPose100
+.4byte sSnorlaxPose101
+.4byte sSnorlaxPose102
+.4byte sSnorlaxPose103
+.4byte sSnorlaxPose104
+.4byte sSnorlaxPose105
+.4byte sSnorlaxPose106
+.4byte sSnorlaxPose107
+.4byte sSnorlaxPose108
+.4byte sSnorlaxPose109
+.4byte sSnorlaxPose110
+.4byte sSnorlaxPose111
+.4byte sSnorlaxPose112
+.4byte sSnorlaxPose113
+.4byte sSnorlaxPose114
+.4byte sSnorlaxPose115
+.4byte sSnorlaxPose116
+.4byte sSnorlaxPose117
+.4byte sSnorlaxPose118
+.4byte sSnorlaxPose119
+.4byte sSnorlaxPose120
+.4byte sSnorlaxPose121
+.4byte sSnorlaxPose122
+.4byte sSnorlaxPose123
+.4byte sSnorlaxPose124
+.4byte sSnorlaxPose125
+.4byte sSnorlaxPose126
+.4byte sSnorlaxPose127
+.4byte sSnorlaxPose128
+.4byte sSnorlaxPose129
+.4byte sSnorlaxPose130
+.4byte sSnorlaxPose131
+.4byte sSnorlaxPose132
+.4byte sSnorlaxPose133
+.4byte sSnorlaxPose134
+.4byte sSnorlaxPose135
+.4byte sSnorlaxPose136
+.4byte sSnorlaxPose137
+.4byte sSnorlaxPose138
+.4byte sSnorlaxPose139
+.4byte sSnorlaxPose140
+.4byte sSnorlaxPose141
+.4byte sSnorlaxPose142
+.4byte sSnorlaxPose143
+.4byte sSnorlaxPose144
+.4byte sSnorlaxPose145
+.4byte sSnorlaxPose146
+.4byte sSnorlaxPose147
+.4byte sSnorlaxPose148
+.4byte sSnorlaxPose149
+.4byte sSnorlaxPose150
+.4byte sSnorlaxPose151
+.4byte sSnorlaxPose152
+.4byte sSnorlaxPose153
+.4byte sSnorlaxPose154
+.4byte sSnorlaxPose155
+.4byte sSnorlaxPose156
+.4byte sSnorlaxPose157
+.4byte sSnorlaxPose158
+.4byte sSnorlaxPose159
+.4byte sSnorlaxPose160
+.4byte sSnorlaxPose161
+.4byte sSnorlaxPose162
+.4byte sSnorlaxPose163
+.4byte sSnorlaxPose164
+.4byte sSnorlaxPose165
+.4byte sSnorlaxPose166
+.4byte sSnorlaxPose167
+.4byte sSnorlaxPose168
+.4byte sSnorlaxPose169
+.4byte sSnorlaxPose170
+.4byte sSnorlaxPose171
+.4byte sSnorlaxPose172
+.4byte sSnorlaxPose173
+.4byte sSnorlaxPose174
+.4byte sSnorlaxPose175
+.4byte sSnorlaxPose176
+.4byte sSnorlaxPose177
+.4byte sSnorlaxPose178
+.4byte sSnorlaxPose179
+.4byte sSnorlaxPose180
+.4byte sSnorlaxPose181
+.4byte sSnorlaxPose182
+.4byte sSnorlaxPose183
+.4byte sSnorlaxPose184
+.4byte sSnorlaxPose185
+.4byte sSnorlaxPose186
+.4byte sSnorlaxPose187
+.4byte sSnorlaxPose188
+.4byte sSnorlaxPose189
+.4byte sSnorlaxPose190
+.4byte sSnorlaxPose191
+.4byte sSnorlaxPose192
+.4byte sSnorlaxPose193
+.4byte sSnorlaxPose194
+.4byte sSnorlaxPose195
+.4byte sSnorlaxPose196
+.4byte sSnorlaxPose197
+.4byte sSnorlaxPose198
+.4byte sSnorlaxPose199
+.4byte sSnorlaxPose200
+.4byte sSnorlaxPose201
+.4byte sSnorlaxPose202
+.4byte sSnorlaxPose203
+.4byte sSnorlaxPose204
+.4byte sSnorlaxPose205
+.4byte sSnorlaxPose206
+.4byte sSnorlaxPose207
+.4byte sSnorlaxPose208
+.4byte sSnorlaxPose209
+.4byte sSnorlaxPose210
+.4byte sSnorlaxPose211
+.4byte sSnorlaxPose212
+.4byte sSnorlaxPose213
+.4byte sSnorlaxPose214
+.4byte sSnorlaxPose215
+.4byte sSnorlaxPose216
+.4byte sSnorlaxPose217
+.4byte sSnorlaxPose218
+.4byte sSnorlaxPose219
+.4byte sSnorlaxPose220
+.4byte sSnorlaxPose221
+.4byte sSnorlaxPose222
+.4byte sSnorlaxPose223
+.4byte sSnorlaxPose224
+.4byte sSnorlaxPose225
+.4byte sSnorlaxPose226
+.4byte sSnorlaxPose227
+.4byte sSnorlaxPose228
+.4byte sSnorlaxPose229
+.4byte sSnorlaxPose230
+.4byte sSnorlaxPose231
+.4byte sSnorlaxPose232
+.4byte sSnorlaxPose233
+.4byte sSnorlaxPose234
+.4byte sSnorlaxPose235
+.4byte sSnorlaxPose236
+.4byte sSnorlaxPose237
+.4byte sSnorlaxPose238
+.4byte sSnorlaxPose239
+.4byte sSnorlaxPose240
+.4byte sSnorlaxPose241
+.4byte sSnorlaxPose242
+sAxPositionsSnorlax:
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -13, 	  -9,   -6, 	  11,   -9, 	   0,   -9
+.2byte   -2,  -13, 	 -12,   -9, 	   8,   -5, 	  -2,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+.2byte    5,  -14, 	   2,   -9, 	  -3,   -4, 	   0,  -10
+.2byte    4,  -13, 	  10,  -10, 	 -12,   -6, 	  -1,   -9
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    6,  -14, 	  -4,   -8, 	   2,   -5, 	  -2,   -9
+.2byte    6,  -14, 	   7,   -7, 	  -7,   -4, 	  -1,   -8
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    1,  -18, 	 -12,   -9, 	   9,   -7, 	  -3,  -10
+.2byte    4,  -17, 	   3,   -9, 	   3,   -2, 	  -3,   -9
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte    1,  -17, 	   9,  -11, 	 -11,   -9, 	   0,  -11
+.2byte   -2,  -17, 	  10,   -9, 	 -11,  -10, 	  -1,  -11
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -2,  -18, 	  11,   -9, 	 -10,   -7, 	   2,  -10
+.2byte   -5,  -17, 	  -4,   -9, 	  -4,   -2, 	   2,   -9
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -7,  -14, 	   3,   -8, 	  -3,   -5, 	   1,   -9
+.2byte   -7,  -14, 	  -8,   -7, 	   6,   -4, 	   0,   -8
+.2byte   -5,  -15, 	  -9,  -11, 	   8,   -5, 	   0,  -10
+.2byte   -6,  -14, 	  -3,   -9, 	   2,   -4, 	  -1,  -10
+.2byte   -5,  -13, 	 -11,  -10, 	  11,   -6, 	   0,   -9
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte   -1,  -10, 	 -13,  -12, 	  12,  -12, 	   0,   -7
+.2byte   -2,  -13, 	 -12,   -9, 	   8,   -5, 	  -2,   -9
+.2byte    0,  -18, 	 -13,  -17, 	  12,  -17, 	   0,  -10
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+.2byte    5,  -12, 	   6,  -17, 	 -13,  -10, 	  -2,   -9
+.2byte    4,  -13, 	  10,  -10, 	 -12,   -6, 	  -1,   -9
+.2byte    1,  -19, 	   8,  -20, 	  -9,  -14, 	   0,  -12
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    5,  -13, 	  -8,  -14, 	 -10,   -8, 	  -5,  -10
+.2byte    6,  -14, 	   7,   -7, 	  -7,   -4, 	  -1,   -8
+.2byte    4,  -17, 	  -3,  -19, 	  -4,  -12, 	  -2,  -10
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    5,  -17, 	 -11,  -15, 	   5,   -7, 	  -1,  -12
+.2byte    4,  -17, 	   3,   -9, 	   3,   -2, 	  -3,   -9
+.2byte    1,  -18, 	  -9,  -18, 	   9,  -14, 	  -1,  -11
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte   -1,  -18, 	  12,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte   -2,  -17, 	  10,   -9, 	 -11,  -10, 	  -1,  -11
+.2byte   -1,  -18, 	  11,  -16, 	 -12,  -16, 	   0,   -9
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -6,  -17, 	  10,  -15, 	  -6,   -7, 	   0,  -12
+.2byte   -5,  -17, 	  -4,   -9, 	  -4,   -2, 	   2,   -9
+.2byte   -2,  -18, 	   8,  -18, 	 -10,  -14, 	   0,  -11
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -6,  -13, 	   7,  -14, 	   9,   -8, 	   4,  -10
+.2byte   -7,  -14, 	  -8,   -7, 	   6,   -4, 	   0,   -8
+.2byte   -6,  -19, 	   1,  -21, 	   2,  -14, 	   0,  -12
+.2byte   -5,  -15, 	  -9,  -11, 	   8,   -5, 	   0,  -10
+.2byte   -6,  -12, 	  -7,  -17, 	  12,  -10, 	   1,   -9
+.2byte   -5,  -13, 	 -11,  -10, 	  11,   -6, 	   0,   -9
+.2byte   -1,  -19, 	  -8,  -20, 	   9,  -14, 	   0,  -12
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -13, 	  -9,   -6, 	  11,   -9, 	   0,   -9
+.2byte   -2,  -13, 	 -12,   -9, 	   8,   -5, 	  -2,   -9
+.2byte   -1,  -10, 	 -13,  -12, 	  12,  -12, 	   0,   -7
+.2byte    0,  -18, 	 -13,  -17, 	  12,  -17, 	   0,  -10
+.2byte   -5,  -14, 	 -13,  -10, 	   0,  -23, 	  -2,  -12
+.2byte    1,  -12, 	  13,   -9, 	 -12,   -9, 	   1,   -9
+.2byte    1,  -12, 	  13,   -9, 	 -12,   -9, 	   1,   -9
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+.2byte    5,  -14, 	   2,   -9, 	  -3,   -4, 	   0,  -10
+.2byte    4,  -13, 	  10,  -10, 	 -12,   -6, 	  -1,   -9
+.2byte    8,  -12, 	   9,  -17, 	 -10,  -10, 	   1,   -9
+.2byte    1,  -19, 	   8,  -20, 	  -9,  -14, 	   0,  -12
+.2byte    5,  -16, 	  11,  -14, 	  -2,  -22, 	  -1,  -12
+.2byte   -6,  -14, 	 -13,   -8, 	   3,  -15, 	  -1,  -13
+.2byte   -6,  -14, 	 -13,   -8, 	   3,  -15, 	  -1,  -13
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    6,  -14, 	  -4,   -8, 	   2,   -5, 	  -2,   -9
+.2byte    6,  -14, 	   7,   -7, 	  -7,   -4, 	  -1,   -8
+.2byte    9,  -14, 	  -4,  -15, 	  -6,   -9, 	  -1,  -11
+.2byte    4,  -18, 	  -3,  -20, 	  -4,  -13, 	  -2,  -11
+.2byte    4,  -18, 	   1,  -21, 	  -3,  -20, 	  -1,  -12
+.2byte   -5,   -1, 	  -3,   -2, 	  -4,   -6, 	   0,   -9
+.2byte   -5,   -1, 	  -3,   -2, 	  -4,   -6, 	   0,   -9
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    1,  -18, 	 -12,   -9, 	   9,   -7, 	  -3,  -10
+.2byte    4,  -17, 	   3,   -9, 	   3,   -2, 	  -3,   -9
+.2byte    5,  -17, 	 -11,  -15, 	   5,   -7, 	  -1,  -12
+.2byte    0,  -19, 	 -10,  -19, 	   8,  -15, 	  -2,  -12
+.2byte   -1,  -20, 	 -12,  -17, 	   5,  -24, 	   0,  -12
+.2byte   -6,   -5, 	   1,    1, 	 -13,   -9, 	  -1,  -10
+.2byte   -6,   -5, 	   1,    1, 	 -13,   -9, 	  -1,  -10
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte    1,  -17, 	   9,  -11, 	 -11,   -9, 	   0,  -11
+.2byte   -2,  -17, 	  10,   -9, 	 -11,  -10, 	  -1,  -11
+.2byte   -1,  -18, 	  12,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte   -1,  -20, 	  11,  -18, 	 -12,  -18, 	   0,  -11
+.2byte    5,  -19, 	  12,  -10, 	  -2,  -26, 	   1,  -14
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,  -11
+.2byte   -1,   -3, 	 -12,   -3, 	  11,   -3, 	  -1,  -11
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -2,  -18, 	  11,   -9, 	 -10,   -7, 	   2,  -10
+.2byte   -5,  -17, 	  -4,   -9, 	  -4,   -2, 	   2,   -9
+.2byte   -6,  -17, 	  10,  -15, 	  -6,   -7, 	   0,  -12
+.2byte   -1,  -19, 	   9,  -19, 	  -9,  -15, 	   1,  -12
+.2byte    0,  -20, 	  11,  -17, 	  -6,  -24, 	  -1,  -12
+.2byte    5,   -5, 	  -2,    1, 	  12,   -9, 	   0,  -10
+.2byte    5,   -5, 	  -2,    1, 	  12,   -9, 	   0,  -10
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -7,  -14, 	   3,   -8, 	  -3,   -5, 	   1,   -9
+.2byte   -7,  -14, 	  -8,   -7, 	   6,   -4, 	   0,   -8
+.2byte  -10,  -14, 	   3,  -15, 	   5,   -9, 	   0,  -11
+.2byte   -5,  -18, 	   2,  -20, 	   3,  -13, 	   1,  -11
+.2byte   -5,  -18, 	  -2,  -21, 	   2,  -20, 	   0,  -12
+.2byte    4,   -1, 	   2,   -2, 	   3,   -6, 	  -1,   -9
+.2byte    4,   -1, 	   2,   -2, 	   3,   -6, 	  -1,   -9
+.2byte   -5,  -15, 	  -9,  -11, 	   8,   -5, 	   0,  -10
+.2byte   -6,  -14, 	  -3,   -9, 	   2,   -4, 	  -1,  -10
+.2byte   -5,  -13, 	 -11,  -10, 	  11,   -6, 	   0,   -9
+.2byte   -9,  -12, 	 -10,  -17, 	   9,  -10, 	  -2,   -9
+.2byte   -2,  -19, 	  -9,  -20, 	   8,  -14, 	  -1,  -12
+.2byte   -6,  -16, 	 -12,  -14, 	   1,  -22, 	   0,  -12
+.2byte    5,  -14, 	  12,   -8, 	  -4,  -15, 	   0,  -13
+.2byte    5,  -14, 	  12,   -8, 	  -4,  -15, 	   0,  -13
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -18, 	 -13,  -17, 	  12,  -17, 	   0,  -10
+.2byte   -1,  -10, 	 -13,  -12, 	  12,  -12, 	   0,   -7
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+.2byte    1,  -19, 	   8,  -20, 	  -9,  -14, 	   0,  -12
+.2byte    8,  -12, 	   9,  -17, 	 -10,  -10, 	   1,   -9
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    3,  -18, 	  -4,  -20, 	  -5,  -13, 	  -3,  -11
+.2byte    9,  -14, 	  -4,  -15, 	  -6,   -9, 	  -1,  -11
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    0,  -19, 	 -10,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    5,  -17, 	 -11,  -15, 	   5,   -7, 	  -1,  -12
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte   -1,  -20, 	  11,  -18, 	 -12,  -18, 	   0,  -11
+.2byte   -1,  -18, 	  12,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -1,  -19, 	   9,  -19, 	  -9,  -15, 	   1,  -12
+.2byte   -6,  -17, 	  10,  -15, 	  -6,   -7, 	   0,  -12
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -4,  -18, 	   3,  -20, 	   4,  -13, 	   2,  -11
+.2byte  -10,  -14, 	   3,  -15, 	   5,   -9, 	   0,  -11
+.2byte   -5,  -15, 	  -9,  -11, 	   8,   -5, 	   0,  -10
+.2byte   -2,  -19, 	  -9,  -20, 	   8,  -14, 	  -1,  -12
+.2byte   -9,  -12, 	 -10,  -17, 	   9,  -10, 	  -2,   -9
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte   -5,  -15, 	  -9,  -11, 	   8,   -5, 	   0,  -10
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+.2byte    5,  -11, 	   0,  -10, 	  -4,   -1, 	   1,   -5
+.2byte    5,  -11, 	   0,  -10, 	  -3,    0, 	   2,   -4
+.2byte   -1,  -16, 	 -13,  -13, 	  12,  -13, 	  -1,  -11
+.2byte    1,  -15, 	   9,  -18, 	 -13,   -6, 	  -2,  -11
+.2byte    4,  -16, 	  -2,  -16, 	  -2,   -8, 	   0,  -10
+.2byte    1,  -17, 	 -10,  -16, 	   6,   -6, 	  -2,  -10
+.2byte   -1,  -17, 	  11,  -12, 	 -13,  -12, 	  -1,  -10
+.2byte   -2,  -17, 	   9,  -16, 	  -7,   -6, 	   1,  -10
+.2byte   -5,  -16, 	   1,  -16, 	   1,   -8, 	  -1,  -10
+.2byte   -2,  -15, 	 -10,  -18, 	  12,   -6, 	   1,  -11
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -18, 	 -13,  -17, 	  12,  -17, 	   0,  -10
+.2byte   -1,  -10, 	 -13,  -12, 	  12,  -12, 	   0,   -7
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+.2byte    1,  -19, 	   8,  -20, 	  -9,  -14, 	   0,  -12
+.2byte    8,  -12, 	   9,  -17, 	 -10,  -10, 	   1,   -9
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    4,  -18, 	  -3,  -20, 	  -4,  -13, 	  -2,  -11
+.2byte    9,  -14, 	  -4,  -15, 	  -6,   -9, 	  -1,  -11
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    0,  -19, 	 -10,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    5,  -17, 	 -11,  -15, 	   5,   -7, 	  -1,  -12
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte   -1,  -20, 	  11,  -18, 	 -12,  -18, 	   0,  -11
+.2byte   -1,  -18, 	  12,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -1,  -20, 	   9,  -20, 	  -9,  -16, 	   1,  -13
+.2byte   -6,  -17, 	  10,  -15, 	  -6,   -7, 	   0,  -12
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -5,  -18, 	   2,  -20, 	   3,  -13, 	   1,  -11
+.2byte  -10,  -14, 	   3,  -15, 	   5,   -9, 	   0,  -11
+.2byte   -4,  -15, 	  -8,  -11, 	   9,   -5, 	   1,  -10
+.2byte   -1,  -19, 	  -8,  -20, 	   9,  -14, 	   0,  -12
+.2byte   -8,  -12, 	  -9,  -17, 	  10,  -10, 	  -1,   -9
+.2byte   -1,  -10, 	 -13,  -12, 	  12,  -12, 	   0,   -7
+.2byte   -9,  -12, 	 -10,  -17, 	   9,  -10, 	  -2,   -9
+.2byte  -10,  -14, 	   3,  -15, 	   5,   -9, 	   0,  -11
+.2byte   -6,  -17, 	  10,  -15, 	  -6,   -7, 	   0,  -12
+.2byte   -1,  -18, 	  12,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte    5,  -17, 	 -11,  -15, 	   5,   -7, 	  -1,  -12
+.2byte    9,  -14, 	  -4,  -15, 	  -6,   -9, 	  -1,  -11
+.2byte    8,  -12, 	   9,  -17, 	 -10,  -10, 	   1,   -9
+.2byte    0,  -18, 	 -13,  -17, 	  12,  -17, 	   0,  -10
+.2byte    1,  -19, 	   8,  -20, 	  -9,  -14, 	   0,  -12
+.2byte    5,  -18, 	  -2,  -20, 	  -3,  -13, 	  -1,  -11
+.2byte    1,  -18, 	  -9,  -18, 	   9,  -14, 	  -1,  -11
+.2byte   -1,  -18, 	  11,  -16, 	 -12,  -16, 	   0,   -9
+.2byte   -2,  -18, 	   8,  -18, 	 -10,  -14, 	   0,  -11
+.2byte   -6,  -18, 	   1,  -20, 	   2,  -13, 	   0,  -11
+.2byte   -2,  -19, 	  -9,  -20, 	   8,  -14, 	  -1,  -12
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte    0,  -18, 	 -13,  -17, 	  12,  -17, 	   0,  -10
+.2byte   -1,  -10, 	 -13,  -12, 	  12,  -12, 	   0,   -7
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+.2byte    1,  -19, 	   8,  -20, 	  -9,  -14, 	   0,  -12
+.2byte    8,  -12, 	   9,  -17, 	 -10,  -10, 	   1,   -9
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    3,  -18, 	  -4,  -20, 	  -5,  -13, 	  -3,  -11
+.2byte    9,  -14, 	  -4,  -15, 	  -6,   -9, 	  -1,  -11
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    0,  -19, 	 -10,  -19, 	   8,  -15, 	  -2,  -12
+.2byte    5,  -17, 	 -11,  -15, 	   5,   -7, 	  -1,  -12
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte   -1,  -20, 	  11,  -18, 	 -12,  -18, 	   0,  -11
+.2byte   -1,  -18, 	  12,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -1,  -19, 	   9,  -19, 	  -9,  -15, 	   1,  -12
+.2byte   -6,  -17, 	  10,  -15, 	  -6,   -7, 	   0,  -12
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -4,  -18, 	   3,  -20, 	   4,  -13, 	   2,  -11
+.2byte  -10,  -14, 	   3,  -15, 	   5,   -9, 	   0,  -11
+.2byte   -5,  -15, 	  -9,  -11, 	   8,   -5, 	   0,  -10
+.2byte   -2,  -19, 	  -9,  -20, 	   8,  -14, 	  -1,  -12
+.2byte   -9,  -12, 	 -10,  -17, 	   9,  -10, 	  -2,   -9
+.2byte   -1,  -10, 	 -13,  -12, 	  12,  -12, 	   0,   -7
+.2byte   -9,  -12, 	 -10,  -17, 	   9,  -10, 	  -2,   -9
+.2byte  -10,  -14, 	   3,  -15, 	   5,   -9, 	   0,  -11
+.2byte   -6,  -17, 	  10,  -15, 	  -6,   -7, 	   0,  -12
+.2byte   -1,  -18, 	  12,  -13, 	 -13,  -13, 	  -1,  -11
+.2byte    5,  -17, 	 -11,  -15, 	   5,   -7, 	  -1,  -12
+.2byte    9,  -14, 	  -4,  -15, 	  -6,   -9, 	  -1,  -11
+.2byte    8,  -12, 	   9,  -17, 	 -10,  -10, 	   1,   -9
+.2byte   -1,  -14, 	 -12,   -8, 	  11,   -8, 	   0,  -10
+.2byte   -5,  -15, 	  -9,  -11, 	   8,   -5, 	   0,  -10
+.2byte   -7,  -16, 	   0,   -8, 	   2,   -5, 	   0,  -10
+.2byte   -4,  -19, 	   8,  -12, 	  -7,   -5, 	   1,  -10
+.2byte   -1,  -18, 	  11,   -8, 	 -12,   -9, 	  -1,  -11
+.2byte    3,  -19, 	  -9,  -12, 	   6,   -5, 	  -2,  -10
+.2byte    6,  -16, 	  -1,   -8, 	  -3,   -5, 	  -1,  -10
+.2byte    4,  -15, 	   8,  -11, 	  -9,   -5, 	  -1,  -10
+sSnorlaxAnimTable1:
+.4byte sSnorlaxAnims_1_1
+.4byte sSnorlaxAnims_1_2
+.4byte sSnorlaxAnims_1_3
+.4byte sSnorlaxAnims_1_4
+.4byte sSnorlaxAnims_1_5
+.4byte sSnorlaxAnims_1_6
+.4byte sSnorlaxAnims_1_7
+.4byte sSnorlaxAnims_1_8
+sSnorlaxAnimTable2:
+.4byte sSnorlaxAnims_2_1
+.4byte sSnorlaxAnims_2_2
+.4byte sSnorlaxAnims_2_3
+.4byte sSnorlaxAnims_2_4
+.4byte sSnorlaxAnims_2_5
+.4byte sSnorlaxAnims_2_6
+.4byte sSnorlaxAnims_2_7
+.4byte sSnorlaxAnims_2_8
+sSnorlaxAnimTable3:
+.4byte sSnorlaxAnims_3_1
+.4byte sSnorlaxAnims_3_2
+.4byte sSnorlaxAnims_3_3
+.4byte sSnorlaxAnims_3_4
+.4byte sSnorlaxAnims_3_5
+.4byte sSnorlaxAnims_3_6
+.4byte sSnorlaxAnims_3_7
+.4byte sSnorlaxAnims_3_8
+sSnorlaxAnimTable4:
+.4byte sSnorlaxAnims_4_1
+.4byte sSnorlaxAnims_4_2
+.4byte sSnorlaxAnims_4_3
+.4byte sSnorlaxAnims_4_4
+.4byte sSnorlaxAnims_4_5
+.4byte sSnorlaxAnims_4_6
+.4byte sSnorlaxAnims_4_7
+.4byte sSnorlaxAnims_4_8
+sSnorlaxAnimTable5:
+.4byte sSnorlaxAnims_5_1
+.4byte sSnorlaxAnims_5_2
+.4byte sSnorlaxAnims_5_3
+.4byte sSnorlaxAnims_5_4
+.4byte sSnorlaxAnims_5_5
+.4byte sSnorlaxAnims_5_6
+.4byte sSnorlaxAnims_5_7
+.4byte sSnorlaxAnims_5_8
+sSnorlaxAnimTable6:
+.4byte sSnorlaxAnims_6_1
+.4byte sSnorlaxAnims_6_1
+.4byte sSnorlaxAnims_6_1
+.4byte sSnorlaxAnims_6_1
+.4byte sSnorlaxAnims_6_1
+.4byte sSnorlaxAnims_6_1
+.4byte sSnorlaxAnims_6_1
+.4byte sSnorlaxAnims_6_1
+sSnorlaxAnimTable7:
+.4byte sSnorlaxAnims_7_1
+.4byte sSnorlaxAnims_7_2
+.4byte sSnorlaxAnims_7_3
+.4byte sSnorlaxAnims_7_4
+.4byte sSnorlaxAnims_7_5
+.4byte sSnorlaxAnims_7_6
+.4byte sSnorlaxAnims_7_7
+.4byte sSnorlaxAnims_7_8
+sSnorlaxAnimTable8:
+.4byte sSnorlaxAnims_8_1
+.4byte sSnorlaxAnims_8_2
+.4byte sSnorlaxAnims_8_3
+.4byte sSnorlaxAnims_8_4
+.4byte sSnorlaxAnims_8_5
+.4byte sSnorlaxAnims_8_6
+.4byte sSnorlaxAnims_8_7
+.4byte sSnorlaxAnims_8_8
+sSnorlaxAnimTable9:
+.4byte sSnorlaxAnims_9_1
+.4byte sSnorlaxAnims_9_2
+.4byte sSnorlaxAnims_9_3
+.4byte sSnorlaxAnims_9_4
+.4byte sSnorlaxAnims_9_5
+.4byte sSnorlaxAnims_9_6
+.4byte sSnorlaxAnims_9_7
+.4byte sSnorlaxAnims_9_8
+sSnorlaxAnimTable10:
+.4byte sSnorlaxAnims_10_1
+.4byte sSnorlaxAnims_10_2
+.4byte sSnorlaxAnims_10_3
+.4byte sSnorlaxAnims_10_4
+.4byte sSnorlaxAnims_10_5
+.4byte sSnorlaxAnims_10_6
+.4byte sSnorlaxAnims_10_7
+.4byte sSnorlaxAnims_10_8
+sSnorlaxAnimTable11:
+.4byte sSnorlaxAnims_11_1
+.4byte sSnorlaxAnims_11_2
+.4byte sSnorlaxAnims_11_3
+.4byte sSnorlaxAnims_11_4
+.4byte sSnorlaxAnims_11_5
+.4byte sSnorlaxAnims_11_6
+.4byte sSnorlaxAnims_11_7
+.4byte sSnorlaxAnims_11_8
+sSnorlaxAnimTable12:
+.4byte sSnorlaxAnims_12_1
+.4byte sSnorlaxAnims_12_2
+.4byte sSnorlaxAnims_12_3
+.4byte sSnorlaxAnims_12_4
+.4byte sSnorlaxAnims_12_5
+.4byte sSnorlaxAnims_12_6
+.4byte sSnorlaxAnims_12_7
+.4byte sSnorlaxAnims_12_8
+sSnorlaxAnimTable13:
+.4byte sSnorlaxAnims_13_1
+.4byte sSnorlaxAnims_13_2
+.4byte sSnorlaxAnims_13_3
+.4byte sSnorlaxAnims_13_4
+.4byte sSnorlaxAnims_13_5
+.4byte sSnorlaxAnims_13_6
+.4byte sSnorlaxAnims_13_7
+.4byte sSnorlaxAnims_13_8
+sAxAnimationsSnorlax:
+.4byte sSnorlaxAnimTable1
+.4byte sSnorlaxAnimTable2
+.4byte sSnorlaxAnimTable3
+.4byte sSnorlaxAnimTable4
+.4byte sSnorlaxAnimTable5
+.4byte sSnorlaxAnimTable6
+.4byte sSnorlaxAnimTable7
+.4byte sSnorlaxAnimTable8
+.4byte sSnorlaxAnimTable9
+.4byte sSnorlaxAnimTable10
+.4byte sSnorlaxAnimTable11
+.4byte sSnorlaxAnimTable12
+.4byte sSnorlaxAnimTable13
+sAxSpritesSnorlax:
+.4byte sSnorlaxSprites1
+.4byte sSnorlaxSprites2
+.4byte sSnorlaxSprites3
+.4byte sSnorlaxSprites4
+.4byte sSnorlaxSprites5
+.4byte sSnorlaxSprites6
+.4byte sSnorlaxSprites7
+.4byte sSnorlaxSprites8
+.4byte sSnorlaxSprites9
+.4byte sSnorlaxSprites10
+.4byte sSnorlaxSprites11
+.4byte sSnorlaxSprites12
+.4byte sSnorlaxSprites13
+.4byte sSnorlaxSprites14
+.4byte sSnorlaxSprites15
+.4byte sSnorlaxSprites16
+.4byte sSnorlaxSprites17
+.4byte sSnorlaxSprites18
+.4byte sSnorlaxSprites19
+.4byte sSnorlaxSprites20
+.4byte sSnorlaxSprites21
+.4byte sSnorlaxSprites22
+.4byte sSnorlaxSprites23
+.4byte sSnorlaxSprites24
+.4byte sSnorlaxSprites25
+.4byte sSnorlaxSprites26
+.4byte sSnorlaxSprites27
+.4byte sSnorlaxSprites28
+.4byte sSnorlaxSprites29
+.4byte sSnorlaxSprites30
+.4byte sSnorlaxSprites31
+.4byte sSnorlaxSprites32
+.4byte sSnorlaxSprites33
+.4byte sSnorlaxSprites34
+.4byte sSnorlaxSprites35
+.4byte sSnorlaxSprites36
+.4byte sSnorlaxSprites37
+.4byte sSnorlaxSprites38
+.4byte sSnorlaxSprites39
+.4byte sSnorlaxSprites40
+.4byte sSnorlaxSprites41
+.4byte sSnorlaxSprites42
+.4byte sSnorlaxSprites43
+.4byte sSnorlaxSprites44
+.4byte sSnorlaxSprites45
+.4byte sSnorlaxSprites46
+.4byte sSnorlaxSprites47
+.4byte sSnorlaxSprites48
+.4byte sSnorlaxSprites49
+.4byte sSnorlaxSprites50
+.4byte sSnorlaxSprites51
+.4byte sSnorlaxSprites52
+.4byte sSnorlaxSprites53
+.4byte sSnorlaxSprites54
+.4byte sSnorlaxSprites55
+.4byte sSnorlaxSprites56
+sAxMainSnorlax:
+ax_main sAxPosesSnorlax, sAxAnimationsSnorlax, 13, sAxSpritesSnorlax, sAxPositionsSnorlax

--- a/data/ax/snorunt.inc
+++ b/data/ax/snorunt.inc
@@ -1,0 +1,2591 @@
+.global gAxSnorunt
+gAxSnorunt:
+ax_siro sAxMainSnorunt
+sSnoruntPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose4:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose5:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose6:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose8:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose26:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose27:
+ax_pose 16, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose28:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose29:
+ax_pose 17, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose30:
+ax_pose 18, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose31:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose32:
+ax_pose 19, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose33:
+ax_pose 20, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose34:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose35:
+ax_pose 21, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose36:
+ax_pose 22, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose37:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose38:
+ax_pose 23, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose39:
+ax_pose 24, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose40:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose41:
+ax_pose 21, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose42:
+ax_pose 22, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose43:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose44:
+ax_pose 19, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose45:
+ax_pose 20, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose46:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose47:
+ax_pose 17, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose48:
+ax_pose 18, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose50:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose51:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose52:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose53:
+ax_pose 16, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose54:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose55:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose56:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose57:
+ax_pose 17, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose58:
+ax_pose 18, 0x01ed, 0x90ed, 0x5c00
+ax_pose_terminator
+sSnoruntPose59:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose60:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose61:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose62:
+ax_pose 19, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose63:
+ax_pose 20, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSnoruntPose64:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose65:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose66:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose67:
+ax_pose 21, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose68:
+ax_pose 22, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sSnoruntPose69:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose70:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose71:
+ax_pose 14, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose72:
+ax_pose 23, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose73:
+ax_pose 24, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose74:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose75:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose76:
+ax_pose 11, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose77:
+ax_pose 21, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose78:
+ax_pose 22, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose79:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose80:
+ax_pose 7, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose81:
+ax_pose 8, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose82:
+ax_pose 19, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose83:
+ax_pose 20, 0x01eb, 0x80f2, 0x5c00
+ax_pose_terminator
+sSnoruntPose84:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose85:
+ax_pose 4, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose86:
+ax_pose 5, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose87:
+ax_pose 17, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose88:
+ax_pose 18, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose89:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose90:
+ax_pose 16, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose91:
+ax_pose 25, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose92:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose93:
+ax_pose 18, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose94:
+ax_pose 26, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose95:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose96:
+ax_pose 20, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose97:
+ax_pose 27, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose98:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose99:
+ax_pose 22, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose100:
+ax_pose 21, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose101:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose102:
+ax_pose 24, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose103:
+ax_pose 23, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose104:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose105:
+ax_pose 22, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose106:
+ax_pose 21, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose107:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose108:
+ax_pose 20, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose109:
+ax_pose 27, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose110:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose111:
+ax_pose 18, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose112:
+ax_pose 26, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose113:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose114:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose115:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose116:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose117:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose118:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose119:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose120:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose121:
+ax_pose 28, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose122:
+ax_pose 29, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose123:
+ax_pose 30, 0x01e1, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose124:
+ax_pose 31, 0x01e1, 0x90e8, 0x5c00
+ax_pose_terminator
+sSnoruntPose125:
+ax_pose 32, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sSnoruntPose126:
+ax_pose 33, 0x01e4, 0x90e9, 0x5c00
+ax_pose_terminator
+sSnoruntPose127:
+ax_pose 34, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose128:
+ax_pose 33, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sSnoruntPose129:
+ax_pose 32, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sSnoruntPose130:
+ax_pose 31, 0x01e1, 0x80f8, 0x5c00
+ax_pose_terminator
+sSnoruntPose131:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose132:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose133:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose134:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose135:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose136:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose137:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose138:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose139:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose140:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose141:
+ax_pose 10, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose142:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose143:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose144:
+ax_pose 13, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose145:
+ax_pose 14, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose146:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose147:
+ax_pose 10, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose148:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose149:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose150:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose151:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose152:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose153:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose154:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose155:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose156:
+ax_pose 17, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose157:
+ax_pose 19, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose158:
+ax_pose 21, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose159:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose160:
+ax_pose 21, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose161:
+ax_pose 19, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose162:
+ax_pose 17, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose163:
+ax_pose 16, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose164:
+ax_pose 18, 0x01ed, 0x90ed, 0x5c00
+ax_pose_terminator
+sSnoruntPose165:
+ax_pose 20, 0x01ec, 0x90ee, 0x5c00
+ax_pose_terminator
+sSnoruntPose166:
+ax_pose 22, 0x01ed, 0x90ed, 0x5c00
+ax_pose_terminator
+sSnoruntPose167:
+ax_pose 24, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose168:
+ax_pose 22, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose169:
+ax_pose 20, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sSnoruntPose170:
+ax_pose 18, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose171:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose172:
+ax_pose 16, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose173:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose174:
+ax_pose 3, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose175:
+ax_pose 18, 0x01ed, 0x90ed, 0x5c00
+ax_pose_terminator
+sSnoruntPose176:
+ax_pose 17, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose177:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose178:
+ax_pose 20, 0x01eb, 0x90ee, 0x5c00
+ax_pose_terminator
+sSnoruntPose179:
+ax_pose 19, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose180:
+ax_pose 9, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose181:
+ax_pose 22, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sSnoruntPose182:
+ax_pose 21, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose183:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose184:
+ax_pose 24, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose185:
+ax_pose 23, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose186:
+ax_pose 9, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose187:
+ax_pose 22, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose188:
+ax_pose 21, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose189:
+ax_pose 6, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose190:
+ax_pose 20, 0x01eb, 0x80f1, 0x5c00
+ax_pose_terminator
+sSnoruntPose191:
+ax_pose 19, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose192:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose193:
+ax_pose 18, 0x01ed, 0x80f3, 0x5c00
+ax_pose_terminator
+sSnoruntPose194:
+ax_pose 17, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose195:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose196:
+ax_pose 17, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sSnoruntPose197:
+ax_pose 19, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose198:
+ax_pose 21, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose199:
+ax_pose 23, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose200:
+ax_pose 21, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose201:
+ax_pose 19, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sSnoruntPose202:
+ax_pose 17, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose203:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose204:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose205:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose206:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose207:
+ax_pose 12, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSnoruntPose208:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose209:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSnoruntPose210:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+.align 2
+sSnoruntAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSnoruntAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 1, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 19, 20, 19, 20,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSnoruntAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 19, 0, 19, 0,
+ax_anim 2, 1, 31, 19, 1, 19, 1,
+ax_anim 2, 0, 31, 19, 0, 19, 0,
+ax_anim 2, 0, 31, 19, 1, 19, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSnoruntAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 6, -5, 6, -5,
+ax_anim 1, 0, 34, 12, -11, 12, -11,
+ax_anim 2, 0, 34, 20, -18, 20, -18,
+ax_anim 2, 1, 34, 21, -17, 21, -17,
+ax_anim 2, 0, 34, 20, -18, 20, -18,
+ax_anim 2, 0, 34, 21, -17, 21, -17,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSnoruntAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSnoruntAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -6, -5, -6, -5,
+ax_anim 1, 0, 40, -12, -11, -12, -11,
+ax_anim 2, 0, 40, -20, -18, -20, -18,
+ax_anim 2, 1, 40, -21, -17, -21, -17,
+ax_anim 2, 0, 40, -20, -18, -20, -18,
+ax_anim 2, 0, 40, -21, -17, -21, -17,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSnoruntAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 1, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 43, -19, 0, -19, 0,
+ax_anim 2, 0, 43, -19, 1, -19, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSnoruntAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 1, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -19, 20, -19, 20,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_3_1:
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, -1, 0, -1,
+ax_anim 6, 0, 52, 0, -3, 0, -3,
+ax_anim 2, 0, 52, 0, 2, 0, 2,
+ax_anim 2, 2, 52, 0, 10, 0, 10,
+ax_anim 2, 0, 51, 0, 19, 0, 19,
+ax_anim 2, 0, 51, 1, 19, 1, 19,
+ax_anim 2, 1, 51, 0, 19, 0, 19,
+ax_anim 2, 0, 51, 1, 19, 1, 19,
+ax_anim 2, 0, 51, 0, 19, 0, 19,
+ax_anim 2, 0, 51, 1, 19, 1, 19,
+ax_anim 2, 0, 51, 0, 19, 0, 19,
+ax_anim 2, 0, 48, 0, 12, 0, 12,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sSnoruntAnims_3_2:
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -2, -2, -2, -2,
+ax_anim 6, 0, 57, -3, -3, -3, -3,
+ax_anim 2, 0, 57, 4, 4, 4, 4,
+ax_anim 2, 2, 57, 12, 12, 12, 12,
+ax_anim 2, 0, 56, 20, 20, 20, 20,
+ax_anim 2, 0, 56, 21, 19, 21, 19,
+ax_anim 2, 1, 56, 20, 20, 20, 20,
+ax_anim 2, 0, 56, 21, 19, 21, 19,
+ax_anim 2, 0, 56, 20, 20, 20, 20,
+ax_anim 2, 0, 56, 21, 19, 21, 19,
+ax_anim 2, 0, 56, 20, 20, 20, 20,
+ax_anim 2, 0, 53, 12, 12, 12, 12,
+ax_anim 2, 0, 53, 4, 4, 4, 4,
+ax_anim_terminator
+sSnoruntAnims_3_3:
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 62, -4, 0, -4, 0,
+ax_anim 6, 0, 62, -5, 0, -5, 0,
+ax_anim 2, 0, 62, 1, 0, 1, 0,
+ax_anim 2, 2, 62, 8, 0, 8, 0,
+ax_anim 2, 0, 61, 20, 0, 20, 0,
+ax_anim 2, 0, 61, 20, 1, 20, 1,
+ax_anim 2, 1, 61, 20, 0, 20, 0,
+ax_anim 2, 0, 61, 20, 1, 20, 1,
+ax_anim 2, 0, 61, 20, 0, 20, 0,
+ax_anim 2, 0, 61, 20, 1, 20, 1,
+ax_anim 2, 0, 61, 20, 0, 20, 0,
+ax_anim 2, 0, 58, 12, 0, 12, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim_terminator
+sSnoruntAnims_3_4:
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -3, 3, -3, 3,
+ax_anim 6, 0, 67, -4, 4, -4, 4,
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 2, 67, 7, -7, 7, -7,
+ax_anim 2, 0, 66, 21, -21, 21, -21,
+ax_anim 2, 0, 66, 22, -20, 22, -20,
+ax_anim 2, 1, 66, 21, -21, 21, -21,
+ax_anim 2, 0, 66, 22, -20, 22, -20,
+ax_anim 2, 0, 66, 21, -21, 21, -21,
+ax_anim 2, 0, 66, 22, -20, 22, -20,
+ax_anim 2, 0, 66, 21, -21, 21, -21,
+ax_anim 2, 0, 63, 12, -12, 12, -12,
+ax_anim 2, 0, 63, 4, -4, 4, -4,
+ax_anim_terminator
+sSnoruntAnims_3_5:
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 6, 0, 72, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim 2, 2, 72, 0, -9, 0, -9,
+ax_anim 2, 0, 71, 0, -19, 0, -19,
+ax_anim 2, 0, 71, 1, -19, 1, -19,
+ax_anim 2, 1, 71, 0, -19, 0, -19,
+ax_anim 2, 0, 71, 1, -19, 1, -19,
+ax_anim 2, 0, 71, 0, -19, 0, -19,
+ax_anim 2, 0, 71, 1, -19, 1, -19,
+ax_anim 2, 0, 71, 0, -19, 0, -19,
+ax_anim 2, 0, 68, 0, -12, 0, -12,
+ax_anim 2, 0, 68, 0, -4, 0, -4,
+ax_anim_terminator
+sSnoruntAnims_3_6:
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 6, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, -7, -7, -7, -7,
+ax_anim 2, 0, 76, -21, -21, -21, -21,
+ax_anim 2, 0, 76, -22, -20, -22, -20,
+ax_anim 2, 1, 76, -21, -21, -21, -21,
+ax_anim 2, 0, 76, -22, -20, -22, -20,
+ax_anim 2, 0, 76, -21, -21, -21, -21,
+ax_anim 2, 0, 76, -22, -20, -22, -20,
+ax_anim 2, 0, 76, -21, -21, -21, -21,
+ax_anim 2, 0, 73, -12, -12, -12, -12,
+ax_anim 2, 0, 73, -4, -4, -4, -4,
+ax_anim_terminator
+sSnoruntAnims_3_7:
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 6, 0, 82, 5, 0, 5, 0,
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 2, 2, 82, -8, 0, -8, 0,
+ax_anim 2, 0, 81, -20, 0, -20, 0,
+ax_anim 2, 0, 81, -20, 1, -20, 1,
+ax_anim 2, 1, 81, -20, 0, -20, 0,
+ax_anim 2, 0, 81, -20, 1, -20, 1,
+ax_anim 2, 0, 81, -20, 0, -20, 0,
+ax_anim 2, 0, 81, -20, 1, -20, 1,
+ax_anim 2, 0, 81, -20, 0, -20, 0,
+ax_anim 2, 0, 78, -12, 0, -12, 0,
+ax_anim 2, 0, 78, -4, 0, -4, 0,
+ax_anim_terminator
+sSnoruntAnims_3_8:
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 2, -2, 2, -2,
+ax_anim 6, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, -4, 4, -4, 4,
+ax_anim 2, 2, 87, -12, 12, -12, 12,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 86, -21, 19, -21, 19,
+ax_anim 2, 1, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 86, -21, 19, -21, 19,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 86, -21, 19, -21, 19,
+ax_anim 2, 0, 86, -20, 20, -20, 20,
+ax_anim 2, 0, 83, -12, 12, -12, 12,
+ax_anim 2, 0, 83, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sSnoruntAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sSnoruntAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sSnoruntAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sSnoruntAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sSnoruntAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sSnoruntAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sSnoruntAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sSnoruntAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sSnoruntAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sSnoruntAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sSnoruntAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sSnoruntAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sSnoruntAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sSnoruntAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, -2, 0, 0,
+ax_anim 6, 0, 130, 0, -3, 0, 0,
+ax_anim 6, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 0, 133, 0, -3, 0, 0,
+ax_anim 6, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, -2, 0, 0,
+ax_anim 6, 0, 136, 0, -3, 0, 0,
+ax_anim 6, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 139, 0, -3, 0, 0,
+ax_anim 6, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 142, 0, -3, 0, 0,
+ax_anim 6, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 145, 0, -3, 0, 0,
+ax_anim 6, 0, 147, 0, -2, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 148, 0, -3, 0, 0,
+ax_anim 6, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, -2, 0, 0,
+ax_anim 6, 0, 151, 0, -3, 0, 0,
+ax_anim 6, 0, 153, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 9, 13, 9, 13,
+ax_anim 2, 0, 157, 7, 19, 7, 19,
+ax_anim 3, 0, 158, 0, 21, 0, 21,
+ax_anim 2, 3, 159, -7, 19, -7, 19,
+ax_anim 2, 0, 160, -9, 13, -9, 13,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 155, 21, 6, 21, 6,
+ax_anim 2, 0, 156, 24, 17, 24, 17,
+ax_anim 3, 0, 157, 22, 21, 22, 21,
+ax_anim 2, 3, 158, 13, 21, 13, 21,
+ax_anim 2, 0, 159, 5, 15, 5, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 4, -5, 4, -5,
+ax_anim 2, 0, 154, 13, -7, 13, -7,
+ax_anim 2, 0, 155, 19, -5, 19, -5,
+ax_anim 3, 0, 156, 22, 0, 22, 0,
+ax_anim 2, 3, 157, 18, 5, 18, 5,
+ax_anim 2, 0, 158, 11, 8, 11, 8,
+ax_anim 1, 0, 159, 5, 5, 5, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 3, -16, 3, -16,
+ax_anim 2, 0, 154, 11, -20, 11, -20,
+ax_anim 3, 0, 155, 21, -20, 21, -20,
+ax_anim 2, 3, 156, 22, -12, 22, -12,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 10, 2, 10, 2,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -7, -4, -7, -4,
+ax_anim 2, 0, 160, -9, -10, -9, -10,
+ax_anim 2, 0, 161, -7, -17, -7, -17,
+ax_anim 3, 0, 154, 0, -21, 0, -21,
+ax_anim 2, 3, 155, 7, -17, 7, -17,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 7, -4, 7, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -3, -16, -3, -16,
+ax_anim 2, 0, 154, -11, -20, -11, -20,
+ax_anim 3, 0, 161, -21, -20, -21, -20,
+ax_anim 2, 3, 160, -22, -12, -22, -12,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -10, -2, -10, -2,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -4, -5, -4, -5,
+ax_anim 2, 0, 154, -13, -7, -13, -7,
+ax_anim 2, 0, 161, -19, -5, -19, -5,
+ax_anim 3, 0, 160, -22, 0, -22, 0,
+ax_anim 2, 3, 159, -18, 5, -18, 5,
+ax_anim 2, 0, 158, -11, 8, -11, 8,
+ax_anim 1, 0, 157, -5, 5, -5, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 161, -21, 6, -21, 6,
+ax_anim 2, 0, 160, -24, 17, -24, 17,
+ax_anim 3, 0, 159, -22, 21, -22, 21,
+ax_anim 2, 3, 158, -13, 21, -13, 21,
+ax_anim 2, 0, 157, -5, 15, -5, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnoruntAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSnoruntGfx1:
+.incbin "baserom.gba", 0x14EB9D8, 0x200
+sSnoruntSprites1:
+ax_sprite sSnoruntGfx1, 0x200
+ax_sprite_terminator
+sSnoruntGfx2:
+.incbin "baserom.gba", 0x14EBBE8, 0x200
+sSnoruntSprites2:
+ax_sprite sSnoruntGfx2, 0x200
+ax_sprite_terminator
+sSnoruntGfx3:
+.incbin "baserom.gba", 0x14EBDF8, 0x200
+sSnoruntSprites3:
+ax_sprite sSnoruntGfx3, 0x200
+ax_sprite_terminator
+sSnoruntGfx4:
+.incbin "baserom.gba", 0x14EC008, 0x200
+sSnoruntSprites4:
+ax_sprite sSnoruntGfx4, 0x200
+ax_sprite_terminator
+sSnoruntGfx5:
+.incbin "baserom.gba", 0x14EC218, 0x200
+sSnoruntSprites5:
+ax_sprite sSnoruntGfx5, 0x200
+ax_sprite_terminator
+sSnoruntGfx6:
+.incbin "baserom.gba", 0x14EC428, 0x200
+sSnoruntSprites6:
+ax_sprite sSnoruntGfx6, 0x200
+ax_sprite_terminator
+sSnoruntGfx7:
+.incbin "baserom.gba", 0x14EC638, 0x200
+sSnoruntSprites7:
+ax_sprite sSnoruntGfx7, 0x200
+ax_sprite_terminator
+sSnoruntGfx8:
+.incbin "baserom.gba", 0x14EC848, 0x200
+sSnoruntSprites8:
+ax_sprite sSnoruntGfx8, 0x200
+ax_sprite_terminator
+sSnoruntGfx9:
+.incbin "baserom.gba", 0x14ECA58, 0x200
+sSnoruntSprites9:
+ax_sprite sSnoruntGfx9, 0x200
+ax_sprite_terminator
+sSnoruntGfx10:
+.incbin "baserom.gba", 0x14ECC68, 0x200
+sSnoruntSprites10:
+ax_sprite sSnoruntGfx10, 0x200
+ax_sprite_terminator
+sSnoruntGfx11:
+.incbin "baserom.gba", 0x14ECE78, 0x200
+sSnoruntSprites11:
+ax_sprite sSnoruntGfx11, 0x200
+ax_sprite_terminator
+sSnoruntGfx12:
+.incbin "baserom.gba", 0x14ED088, 0x200
+sSnoruntSprites12:
+ax_sprite sSnoruntGfx12, 0x200
+ax_sprite_terminator
+sSnoruntGfx13:
+.incbin "baserom.gba", 0x14ED298, 0x200
+sSnoruntSprites13:
+ax_sprite sSnoruntGfx13, 0x200
+ax_sprite_terminator
+sSnoruntGfx14:
+.incbin "baserom.gba", 0x14ED4A8, 0x200
+sSnoruntSprites14:
+ax_sprite sSnoruntGfx14, 0x200
+ax_sprite_terminator
+sSnoruntGfx15:
+.incbin "baserom.gba", 0x14ED6B8, 0x200
+sSnoruntSprites15:
+ax_sprite sSnoruntGfx15, 0x200
+ax_sprite_terminator
+sSnoruntGfx16:
+.incbin "baserom.gba", 0x14ED8C8, 0x60
+sSnoruntGfx16_1:
+.incbin "baserom.gba", 0x14ED928, 0x60
+sSnoruntGfx16_2:
+.incbin "baserom.gba", 0x14ED988, 0x60
+sSnoruntSprites16:
+ax_sprite sSnoruntGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx17:
+.incbin "baserom.gba", 0x14EDA20, 0x60
+sSnoruntGfx17_1:
+.incbin "baserom.gba", 0x14EDA80, 0x60
+sSnoruntGfx17_2:
+.incbin "baserom.gba", 0x14EDAE0, 0x60
+sSnoruntSprites17:
+ax_sprite sSnoruntGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx18:
+.incbin "baserom.gba", 0x14EDB78, 0x60
+sSnoruntGfx18_1:
+.incbin "baserom.gba", 0x14EDBD8, 0x60
+sSnoruntGfx18_2:
+.incbin "baserom.gba", 0x14EDC38, 0x60
+sSnoruntSprites18:
+ax_sprite sSnoruntGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx19:
+.incbin "baserom.gba", 0x14EDCD0, 0x40
+sSnoruntGfx19_1:
+.incbin "baserom.gba", 0x14EDD10, 0x60
+sSnoruntGfx19_2:
+.incbin "baserom.gba", 0x14EDD70, 0x60
+sSnoruntSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx20:
+.incbin "baserom.gba", 0x14EDE10, 0x60
+sSnoruntGfx20_1:
+.incbin "baserom.gba", 0x14EDE70, 0x60
+sSnoruntGfx20_2:
+.incbin "baserom.gba", 0x14EDED0, 0x60
+sSnoruntSprites20:
+ax_sprite sSnoruntGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx21:
+.incbin "baserom.gba", 0x14EDF68, 0x40
+sSnoruntGfx21_1:
+.incbin "baserom.gba", 0x14EDFA8, 0x60
+sSnoruntGfx21_2:
+.incbin "baserom.gba", 0x14EE008, 0x40
+sSnoruntSprites21:
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSnoruntGfx21_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx22:
+.incbin "baserom.gba", 0x14EE088, 0x60
+sSnoruntGfx22_1:
+.incbin "baserom.gba", 0x14EE0E8, 0x60
+sSnoruntGfx22_2:
+.incbin "baserom.gba", 0x14EE148, 0x60
+sSnoruntSprites22:
+ax_sprite sSnoruntGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx23:
+.incbin "baserom.gba", 0x14EE1E0, 0x60
+sSnoruntGfx23_1:
+.incbin "baserom.gba", 0x14EE240, 0x60
+sSnoruntGfx23_2:
+.incbin "baserom.gba", 0x14EE2A0, 0x60
+sSnoruntSprites23:
+ax_sprite sSnoruntGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx24:
+.incbin "baserom.gba", 0x14EE338, 0x60
+sSnoruntGfx24_1:
+.incbin "baserom.gba", 0x14EE398, 0x60
+sSnoruntGfx24_2:
+.incbin "baserom.gba", 0x14EE3F8, 0x60
+sSnoruntSprites24:
+ax_sprite sSnoruntGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx25:
+.incbin "baserom.gba", 0x14EE490, 0x60
+sSnoruntGfx25_1:
+.incbin "baserom.gba", 0x14EE4F0, 0x60
+sSnoruntGfx25_2:
+.incbin "baserom.gba", 0x14EE550, 0x60
+sSnoruntSprites25:
+ax_sprite sSnoruntGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx26:
+.incbin "baserom.gba", 0x14EE5E8, 0x60
+sSnoruntGfx26_1:
+.incbin "baserom.gba", 0x14EE648, 0x60
+sSnoruntGfx26_2:
+.incbin "baserom.gba", 0x14EE6A8, 0x60
+sSnoruntSprites26:
+ax_sprite sSnoruntGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx27:
+.incbin "baserom.gba", 0x14EE740, 0x60
+sSnoruntGfx27_1:
+.incbin "baserom.gba", 0x14EE7A0, 0x60
+sSnoruntGfx27_2:
+.incbin "baserom.gba", 0x14EE800, 0x60
+sSnoruntSprites27:
+ax_sprite sSnoruntGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx28:
+.incbin "baserom.gba", 0x14EE898, 0x60
+sSnoruntGfx28_1:
+.incbin "baserom.gba", 0x14EE8F8, 0x60
+sSnoruntGfx28_2:
+.incbin "baserom.gba", 0x14EE958, 0x60
+sSnoruntSprites28:
+ax_sprite sSnoruntGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnoruntGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnoruntGfx29:
+.incbin "baserom.gba", 0x14EE9F0, 0x200
+sSnoruntSprites29:
+ax_sprite sSnoruntGfx29, 0x200
+ax_sprite_terminator
+sSnoruntGfx30:
+.incbin "baserom.gba", 0x14EEC00, 0x200
+sSnoruntSprites30:
+ax_sprite sSnoruntGfx30, 0x200
+ax_sprite_terminator
+sSnoruntGfx31:
+.incbin "baserom.gba", 0x14EEE10, 0x200
+sSnoruntSprites31:
+ax_sprite sSnoruntGfx31, 0x200
+ax_sprite_terminator
+sSnoruntGfx32:
+.incbin "baserom.gba", 0x14EF020, 0x200
+sSnoruntSprites32:
+ax_sprite sSnoruntGfx32, 0x200
+ax_sprite_terminator
+sSnoruntGfx33:
+.incbin "baserom.gba", 0x14EF230, 0x200
+sSnoruntSprites33:
+ax_sprite sSnoruntGfx33, 0x200
+ax_sprite_terminator
+sSnoruntGfx34:
+.incbin "baserom.gba", 0x14EF440, 0x200
+sSnoruntSprites34:
+ax_sprite sSnoruntGfx34, 0x200
+ax_sprite_terminator
+sSnoruntGfx35:
+.incbin "baserom.gba", 0x14EF650, 0x200
+sSnoruntSprites35:
+ax_sprite sSnoruntGfx35, 0x200
+ax_sprite_terminator
+sAxPosesSnorunt:
+.4byte sSnoruntPose1
+.4byte sSnoruntPose2
+.4byte sSnoruntPose3
+.4byte sSnoruntPose4
+.4byte sSnoruntPose5
+.4byte sSnoruntPose6
+.4byte sSnoruntPose7
+.4byte sSnoruntPose8
+.4byte sSnoruntPose9
+.4byte sSnoruntPose10
+.4byte sSnoruntPose11
+.4byte sSnoruntPose12
+.4byte sSnoruntPose13
+.4byte sSnoruntPose14
+.4byte sSnoruntPose15
+.4byte sSnoruntPose16
+.4byte sSnoruntPose17
+.4byte sSnoruntPose18
+.4byte sSnoruntPose19
+.4byte sSnoruntPose20
+.4byte sSnoruntPose21
+.4byte sSnoruntPose22
+.4byte sSnoruntPose23
+.4byte sSnoruntPose24
+.4byte sSnoruntPose25
+.4byte sSnoruntPose26
+.4byte sSnoruntPose27
+.4byte sSnoruntPose28
+.4byte sSnoruntPose29
+.4byte sSnoruntPose30
+.4byte sSnoruntPose31
+.4byte sSnoruntPose32
+.4byte sSnoruntPose33
+.4byte sSnoruntPose34
+.4byte sSnoruntPose35
+.4byte sSnoruntPose36
+.4byte sSnoruntPose37
+.4byte sSnoruntPose38
+.4byte sSnoruntPose39
+.4byte sSnoruntPose40
+.4byte sSnoruntPose41
+.4byte sSnoruntPose42
+.4byte sSnoruntPose43
+.4byte sSnoruntPose44
+.4byte sSnoruntPose45
+.4byte sSnoruntPose46
+.4byte sSnoruntPose47
+.4byte sSnoruntPose48
+.4byte sSnoruntPose49
+.4byte sSnoruntPose50
+.4byte sSnoruntPose51
+.4byte sSnoruntPose52
+.4byte sSnoruntPose53
+.4byte sSnoruntPose54
+.4byte sSnoruntPose55
+.4byte sSnoruntPose56
+.4byte sSnoruntPose57
+.4byte sSnoruntPose58
+.4byte sSnoruntPose59
+.4byte sSnoruntPose60
+.4byte sSnoruntPose61
+.4byte sSnoruntPose62
+.4byte sSnoruntPose63
+.4byte sSnoruntPose64
+.4byte sSnoruntPose65
+.4byte sSnoruntPose66
+.4byte sSnoruntPose67
+.4byte sSnoruntPose68
+.4byte sSnoruntPose69
+.4byte sSnoruntPose70
+.4byte sSnoruntPose71
+.4byte sSnoruntPose72
+.4byte sSnoruntPose73
+.4byte sSnoruntPose74
+.4byte sSnoruntPose75
+.4byte sSnoruntPose76
+.4byte sSnoruntPose77
+.4byte sSnoruntPose78
+.4byte sSnoruntPose79
+.4byte sSnoruntPose80
+.4byte sSnoruntPose81
+.4byte sSnoruntPose82
+.4byte sSnoruntPose83
+.4byte sSnoruntPose84
+.4byte sSnoruntPose85
+.4byte sSnoruntPose86
+.4byte sSnoruntPose87
+.4byte sSnoruntPose88
+.4byte sSnoruntPose89
+.4byte sSnoruntPose90
+.4byte sSnoruntPose91
+.4byte sSnoruntPose92
+.4byte sSnoruntPose93
+.4byte sSnoruntPose94
+.4byte sSnoruntPose95
+.4byte sSnoruntPose96
+.4byte sSnoruntPose97
+.4byte sSnoruntPose98
+.4byte sSnoruntPose99
+.4byte sSnoruntPose100
+.4byte sSnoruntPose101
+.4byte sSnoruntPose102
+.4byte sSnoruntPose103
+.4byte sSnoruntPose104
+.4byte sSnoruntPose105
+.4byte sSnoruntPose106
+.4byte sSnoruntPose107
+.4byte sSnoruntPose108
+.4byte sSnoruntPose109
+.4byte sSnoruntPose110
+.4byte sSnoruntPose111
+.4byte sSnoruntPose112
+.4byte sSnoruntPose113
+.4byte sSnoruntPose114
+.4byte sSnoruntPose115
+.4byte sSnoruntPose116
+.4byte sSnoruntPose117
+.4byte sSnoruntPose118
+.4byte sSnoruntPose119
+.4byte sSnoruntPose120
+.4byte sSnoruntPose121
+.4byte sSnoruntPose122
+.4byte sSnoruntPose123
+.4byte sSnoruntPose124
+.4byte sSnoruntPose125
+.4byte sSnoruntPose126
+.4byte sSnoruntPose127
+.4byte sSnoruntPose128
+.4byte sSnoruntPose129
+.4byte sSnoruntPose130
+.4byte sSnoruntPose131
+.4byte sSnoruntPose132
+.4byte sSnoruntPose133
+.4byte sSnoruntPose134
+.4byte sSnoruntPose135
+.4byte sSnoruntPose136
+.4byte sSnoruntPose137
+.4byte sSnoruntPose138
+.4byte sSnoruntPose139
+.4byte sSnoruntPose140
+.4byte sSnoruntPose141
+.4byte sSnoruntPose142
+.4byte sSnoruntPose143
+.4byte sSnoruntPose144
+.4byte sSnoruntPose145
+.4byte sSnoruntPose146
+.4byte sSnoruntPose147
+.4byte sSnoruntPose148
+.4byte sSnoruntPose149
+.4byte sSnoruntPose150
+.4byte sSnoruntPose151
+.4byte sSnoruntPose152
+.4byte sSnoruntPose153
+.4byte sSnoruntPose154
+.4byte sSnoruntPose155
+.4byte sSnoruntPose156
+.4byte sSnoruntPose157
+.4byte sSnoruntPose158
+.4byte sSnoruntPose159
+.4byte sSnoruntPose160
+.4byte sSnoruntPose161
+.4byte sSnoruntPose162
+.4byte sSnoruntPose163
+.4byte sSnoruntPose164
+.4byte sSnoruntPose165
+.4byte sSnoruntPose166
+.4byte sSnoruntPose167
+.4byte sSnoruntPose168
+.4byte sSnoruntPose169
+.4byte sSnoruntPose170
+.4byte sSnoruntPose171
+.4byte sSnoruntPose172
+.4byte sSnoruntPose173
+.4byte sSnoruntPose174
+.4byte sSnoruntPose175
+.4byte sSnoruntPose176
+.4byte sSnoruntPose177
+.4byte sSnoruntPose178
+.4byte sSnoruntPose179
+.4byte sSnoruntPose180
+.4byte sSnoruntPose181
+.4byte sSnoruntPose182
+.4byte sSnoruntPose183
+.4byte sSnoruntPose184
+.4byte sSnoruntPose185
+.4byte sSnoruntPose186
+.4byte sSnoruntPose187
+.4byte sSnoruntPose188
+.4byte sSnoruntPose189
+.4byte sSnoruntPose190
+.4byte sSnoruntPose191
+.4byte sSnoruntPose192
+.4byte sSnoruntPose193
+.4byte sSnoruntPose194
+.4byte sSnoruntPose195
+.4byte sSnoruntPose196
+.4byte sSnoruntPose197
+.4byte sSnoruntPose198
+.4byte sSnoruntPose199
+.4byte sSnoruntPose200
+.4byte sSnoruntPose201
+.4byte sSnoruntPose202
+.4byte sSnoruntPose203
+.4byte sSnoruntPose204
+.4byte sSnoruntPose205
+.4byte sSnoruntPose206
+.4byte sSnoruntPose207
+.4byte sSnoruntPose208
+.4byte sSnoruntPose209
+.4byte sSnoruntPose210
+sAxPositionsSnorunt:
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -2,   -5, 	  -3,   -1, 	   0,   -2, 	  -1,   -7
+.2byte    0,   -5, 	  -1,   -1, 	   2,   -2, 	  -1,   -7
+.2byte    2,   -6, 	   4,   -2, 	   2,   -4, 	  -1,   -8
+.2byte    3,   -5, 	   5,   -1, 	   3,   -3, 	  -1,   -7
+.2byte    1,   -5, 	   3,   -1, 	   1,   -3, 	  -1,   -7
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    5,   -6, 	   5,   -4, 	   7,   -5, 	  -1,   -7
+.2byte    5,   -6, 	   6,   -4, 	   7,   -5, 	   0,   -7
+.2byte    1,   -9, 	   3,   -9, 	   4,   -8, 	  -2,   -9
+.2byte    0,   -8, 	   2,   -8, 	   3,   -7, 	  -2,   -8
+.2byte    2,   -8, 	   4,   -8, 	   5,   -7, 	  -2,   -8
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte    0,   -9, 	   1,   -7, 	  -1,   -7, 	  -2,   -9
+.2byte   -2,   -8, 	   1,   -7, 	  -2,   -7, 	   0,   -8
+.2byte   -3,   -9, 	  -5,   -9, 	  -6,   -8, 	   0,   -9
+.2byte   -2,   -8, 	  -4,   -8, 	  -5,   -7, 	   0,   -8
+.2byte   -4,   -8, 	  -6,   -8, 	  -7,   -7, 	   0,   -8
+.2byte   -7,   -7, 	  -9,   -4, 	  -9,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	  -7,   -4, 	  -9,   -5, 	  -1,   -7
+.2byte   -7,   -6, 	  -8,   -4, 	  -9,   -5, 	  -2,   -7
+.2byte   -4,   -6, 	  -6,   -2, 	  -4,   -4, 	  -1,   -8
+.2byte   -5,   -5, 	  -7,   -1, 	  -5,   -3, 	  -1,   -7
+.2byte   -3,   -5, 	  -5,   -1, 	  -3,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -1,   -3, 	  -2,    0, 	   0,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	  -3,   -7, 	   1,   -8, 	  -1,   -9
+.2byte    2,   -6, 	   4,   -2, 	   2,   -4, 	  -1,   -8
+.2byte    3,   -3, 	   4,   -2, 	   3,   -1, 	   0,   -8
+.2byte   -1,  -11, 	   2,   -9, 	  -1,   -8, 	  -5,   -9
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    4,   -5, 	   2,   -3, 	   4,   -3, 	   1,  -10
+.2byte    0,  -12, 	   3,   -8, 	   4,   -9, 	  -5,   -9
+.2byte    1,   -9, 	   3,   -9, 	   4,   -8, 	  -2,   -9
+.2byte    2,  -10, 	  -1,   -6, 	   1,   -7, 	   0,  -11
+.2byte    1,  -15, 	   0,  -13, 	   3,  -13, 	  -4,  -10
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte   -1,   -7, 	   1,   -6, 	  -2,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   1,  -13, 	  -3,  -13, 	  -1,   -6
+.2byte   -3,   -9, 	  -5,   -9, 	  -6,   -8, 	   0,   -9
+.2byte   -4,  -10, 	  -1,   -6, 	  -3,   -7, 	  -2,  -11
+.2byte   -3,  -15, 	  -2,  -13, 	  -5,  -13, 	   2,  -10
+.2byte   -7,   -7, 	  -9,   -4, 	  -9,   -5, 	  -1,   -8
+.2byte   -6,   -5, 	  -4,   -3, 	  -6,   -3, 	  -3,  -10
+.2byte   -2,  -12, 	  -5,   -8, 	  -6,   -9, 	   3,   -9
+.2byte   -4,   -6, 	  -6,   -2, 	  -4,   -4, 	  -1,   -8
+.2byte   -5,   -3, 	  -6,   -2, 	  -5,   -1, 	  -2,   -8
+.2byte   -1,  -11, 	  -4,   -9, 	  -1,   -8, 	   3,   -9
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -2,   -5, 	  -3,   -1, 	   0,   -2, 	  -1,   -7
+.2byte    0,   -5, 	  -1,   -1, 	   2,   -2, 	  -1,   -7
+.2byte   -1,   -3, 	  -2,    0, 	   0,   -1, 	  -1,   -7
+.2byte   -1,  -11, 	  -3,   -7, 	   1,   -8, 	  -1,   -9
+.2byte    2,   -6, 	   4,   -2, 	   2,   -4, 	  -1,   -8
+.2byte    3,   -5, 	   5,   -1, 	   3,   -3, 	  -1,   -7
+.2byte    1,   -5, 	   3,   -1, 	   1,   -3, 	  -1,   -7
+.2byte    3,   -3, 	   4,   -2, 	   3,   -1, 	   0,   -8
+.2byte    1,   -9, 	   4,   -7, 	   1,   -6, 	  -3,   -7
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    5,   -6, 	   5,   -4, 	   7,   -5, 	  -1,   -7
+.2byte    5,   -6, 	   6,   -4, 	   7,   -5, 	   0,   -7
+.2byte    4,   -5, 	   2,   -3, 	   4,   -3, 	   1,  -10
+.2byte    3,  -12, 	   6,   -8, 	   7,   -9, 	  -2,   -9
+.2byte    1,   -8, 	   3,   -8, 	   4,   -7, 	  -2,   -8
+.2byte    0,   -7, 	   2,   -7, 	   3,   -6, 	  -2,   -7
+.2byte    2,   -7, 	   4,   -7, 	   5,   -6, 	  -2,   -7
+.2byte    2,   -8, 	  -1,   -4, 	   1,   -5, 	   0,   -9
+.2byte    3,  -14, 	   2,  -12, 	   5,  -12, 	  -2,   -9
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte    0,   -9, 	   1,   -7, 	  -1,   -7, 	  -2,   -9
+.2byte   -2,   -8, 	   1,   -7, 	  -2,   -7, 	   0,   -8
+.2byte   -1,   -7, 	   1,   -6, 	  -2,   -5, 	  -1,  -10
+.2byte   -1,  -12, 	   1,  -12, 	  -3,  -12, 	  -1,   -5
+.2byte   -2,   -8, 	  -4,   -8, 	  -5,   -7, 	   1,   -8
+.2byte   -1,   -7, 	  -3,   -7, 	  -4,   -6, 	   1,   -7
+.2byte   -3,   -7, 	  -5,   -7, 	  -6,   -6, 	   1,   -7
+.2byte   -3,   -8, 	   0,   -4, 	  -2,   -5, 	  -1,   -9
+.2byte   -4,  -14, 	  -3,  -12, 	  -6,  -12, 	   1,   -9
+.2byte   -6,   -7, 	  -8,   -4, 	  -8,   -5, 	   0,   -8
+.2byte   -6,   -6, 	  -6,   -4, 	  -8,   -5, 	   0,   -7
+.2byte   -6,   -6, 	  -7,   -4, 	  -8,   -5, 	  -1,   -7
+.2byte   -5,   -5, 	  -3,   -3, 	  -5,   -3, 	  -2,  -10
+.2byte   -4,  -12, 	  -7,   -8, 	  -8,   -9, 	   1,   -9
+.2byte   -3,   -6, 	  -5,   -2, 	  -3,   -4, 	   0,   -8
+.2byte   -4,   -5, 	  -6,   -1, 	  -4,   -3, 	   0,   -7
+.2byte   -2,   -5, 	  -4,   -1, 	  -2,   -3, 	   0,   -7
+.2byte   -4,   -3, 	  -5,   -2, 	  -4,   -1, 	  -1,   -8
+.2byte   -2,   -9, 	  -5,   -7, 	  -2,   -6, 	   2,   -7
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -1,  -11, 	  -3,   -7, 	   1,   -8, 	  -1,   -9
+.2byte   -1,   -3, 	  -2,    0, 	   0,   -1, 	  -1,   -6
+.2byte    2,   -6, 	   4,   -2, 	   2,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	   2,   -9, 	  -1,   -8, 	  -5,   -9
+.2byte    4,   -3, 	   4,   -1, 	   3,    0, 	   0,   -8
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    0,  -12, 	   3,   -8, 	   4,   -9, 	  -5,   -9
+.2byte    4,   -5, 	   2,   -2, 	   4,   -3, 	   1,  -10
+.2byte    1,   -9, 	   3,   -9, 	   4,   -8, 	  -2,   -9
+.2byte    1,  -15, 	   0,  -13, 	   3,  -13, 	  -4,  -10
+.2byte    2,  -10, 	  -1,   -6, 	   1,   -7, 	   0,  -11
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte   -1,  -13, 	   1,  -13, 	  -3,  -13, 	  -1,   -6
+.2byte   -1,   -7, 	   1,   -6, 	  -2,   -5, 	  -1,  -10
+.2byte   -3,   -9, 	  -5,   -9, 	  -6,   -8, 	   0,   -9
+.2byte   -3,  -15, 	  -2,  -13, 	  -5,  -13, 	   2,  -10
+.2byte   -4,  -10, 	  -1,   -6, 	  -3,   -7, 	  -2,  -11
+.2byte   -7,   -7, 	  -9,   -4, 	  -9,   -5, 	  -1,   -8
+.2byte   -2,  -12, 	  -5,   -8, 	  -6,   -9, 	   3,   -9
+.2byte   -6,   -5, 	  -4,   -2, 	  -6,   -3, 	  -3,  -10
+.2byte   -4,   -6, 	  -6,   -2, 	  -4,   -4, 	  -1,   -8
+.2byte   -1,  -11, 	  -4,   -9, 	  -1,   -8, 	   3,   -9
+.2byte   -6,   -3, 	  -6,   -1, 	  -5,    0, 	  -2,   -8
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,   -2, 	  -4,   -4, 	  -1,   -8
+.2byte   -7,   -7, 	  -9,   -4, 	  -9,   -5, 	  -1,   -8
+.2byte   -3,   -9, 	  -5,   -9, 	  -6,   -8, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte    1,   -9, 	   3,   -9, 	   4,   -8, 	  -2,   -9
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    2,   -6, 	   4,   -2, 	   2,   -4, 	  -1,   -8
+.2byte   -3,   -5, 	  -6,   -3, 	  -3,   -2, 	   0,   -6
+.2byte   -3,   -4, 	  -6,   -2, 	  -3,   -1, 	   0,   -4
+.2byte   -1,   -8, 	  -2,   -5, 	   0,   -7, 	  -1,  -10
+.2byte   -2,   -9, 	   1,   -6, 	   0,   -7, 	  -4,  -10
+.2byte    1,   -9, 	   3,   -8, 	   4,   -9, 	  -5,   -7
+.2byte    0,   -7, 	   2,   -6, 	   3,   -7, 	  -2,   -5
+.2byte   -1,   -7, 	   1,   -5, 	  -2,   -5, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -6, 	  -4,   -7, 	   1,   -5
+.2byte   -2,   -9, 	  -4,   -8, 	  -5,   -9, 	   4,   -7
+.2byte    1,   -9, 	  -2,   -6, 	  -1,   -7, 	   3,  -10
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -2,   -5, 	  -3,   -1, 	   0,   -2, 	  -1,   -7
+.2byte    0,   -5, 	  -1,   -1, 	   2,   -2, 	  -1,   -7
+.2byte    2,   -6, 	   4,   -2, 	   2,   -4, 	  -1,   -8
+.2byte    3,   -5, 	   5,   -1, 	   3,   -3, 	  -1,   -7
+.2byte    1,   -5, 	   3,   -1, 	   1,   -3, 	  -1,   -7
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    5,   -6, 	   5,   -4, 	   7,   -5, 	  -1,   -7
+.2byte    5,   -6, 	   6,   -4, 	   7,   -5, 	   0,   -7
+.2byte    1,   -9, 	   3,   -9, 	   4,   -8, 	  -2,   -9
+.2byte    0,   -8, 	   2,   -8, 	   3,   -7, 	  -2,   -8
+.2byte    2,   -8, 	   4,   -8, 	   5,   -7, 	  -2,   -8
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte    0,   -9, 	   1,   -7, 	  -1,   -7, 	  -2,   -9
+.2byte   -2,   -8, 	   1,   -7, 	  -2,   -7, 	   0,   -8
+.2byte   -3,   -9, 	  -5,   -9, 	  -6,   -8, 	   0,   -9
+.2byte   -2,   -8, 	  -4,   -8, 	  -5,   -7, 	   0,   -8
+.2byte   -4,   -8, 	  -6,   -8, 	  -7,   -7, 	   0,   -8
+.2byte   -7,   -7, 	  -9,   -4, 	  -9,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	  -7,   -4, 	  -9,   -5, 	  -1,   -7
+.2byte   -7,   -6, 	  -8,   -4, 	  -9,   -5, 	  -2,   -7
+.2byte   -4,   -6, 	  -6,   -2, 	  -4,   -4, 	  -1,   -8
+.2byte   -5,   -5, 	  -7,   -1, 	  -5,   -3, 	  -1,   -7
+.2byte   -3,   -5, 	  -5,   -1, 	  -3,   -3, 	  -1,   -7
+.2byte   -1,   -3, 	  -2,    0, 	   0,   -1, 	  -1,   -7
+.2byte   -4,   -3, 	  -5,   -2, 	  -4,   -1, 	  -1,   -8
+.2byte   -5,   -5, 	  -3,   -3, 	  -5,   -3, 	  -2,  -10
+.2byte   -3,   -9, 	   0,   -5, 	  -2,   -6, 	  -1,  -10
+.2byte   -1,   -6, 	   1,   -5, 	  -2,   -4, 	  -1,   -9
+.2byte    2,   -9, 	  -1,   -5, 	   1,   -6, 	   0,  -10
+.2byte    4,   -5, 	   2,   -3, 	   4,   -3, 	   1,  -10
+.2byte    3,   -3, 	   4,   -2, 	   3,   -1, 	   0,   -8
+.2byte   -1,   -9, 	  -3,   -5, 	   1,   -6, 	  -1,   -7
+.2byte    1,   -9, 	   4,   -7, 	   1,   -6, 	  -3,   -7
+.2byte    3,  -11, 	   6,   -7, 	   7,   -8, 	  -2,   -8
+.2byte    3,  -13, 	   2,  -11, 	   5,  -11, 	  -2,   -8
+.2byte   -1,  -12, 	   1,  -12, 	  -3,  -12, 	  -1,   -5
+.2byte   -4,  -13, 	  -3,  -11, 	  -6,  -11, 	   1,   -8
+.2byte   -4,  -11, 	  -7,   -7, 	  -8,   -8, 	   1,   -8
+.2byte   -2,   -9, 	  -5,   -7, 	  -2,   -6, 	   2,   -7
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -1,  -11, 	  -3,   -7, 	   1,   -8, 	  -1,   -9
+.2byte   -1,   -3, 	  -2,    0, 	   0,   -1, 	  -1,   -7
+.2byte    2,   -5, 	   4,   -1, 	   2,   -3, 	  -1,   -7
+.2byte    1,   -9, 	   4,   -7, 	   1,   -6, 	  -3,   -7
+.2byte    4,   -2, 	   5,   -1, 	   4,    0, 	   1,   -7
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    3,  -12, 	   6,   -8, 	   7,   -9, 	  -2,   -9
+.2byte    4,   -5, 	   2,   -3, 	   4,   -3, 	   1,  -10
+.2byte    1,   -8, 	   3,   -8, 	   4,   -7, 	  -2,   -8
+.2byte    3,  -14, 	   2,  -12, 	   5,  -12, 	  -2,   -9
+.2byte    2,   -8, 	  -1,   -4, 	   1,   -5, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte   -1,  -12, 	   1,  -12, 	  -3,  -12, 	  -1,   -5
+.2byte   -1,   -7, 	   1,   -6, 	  -2,   -5, 	  -1,  -10
+.2byte   -2,   -8, 	  -4,   -8, 	  -5,   -7, 	   1,   -8
+.2byte   -4,  -14, 	  -3,  -12, 	  -6,  -12, 	   1,   -9
+.2byte   -3,   -8, 	   0,   -4, 	  -2,   -5, 	  -1,   -9
+.2byte   -6,   -7, 	  -8,   -4, 	  -8,   -5, 	   0,   -8
+.2byte   -5,  -12, 	  -8,   -8, 	  -9,   -9, 	   0,   -9
+.2byte   -5,   -5, 	  -3,   -3, 	  -5,   -3, 	  -2,  -10
+.2byte   -3,   -6, 	  -5,   -2, 	  -3,   -4, 	   0,   -8
+.2byte   -2,   -9, 	  -5,   -7, 	  -2,   -6, 	   2,   -7
+.2byte   -4,   -3, 	  -5,   -2, 	  -4,   -1, 	  -1,   -8
+.2byte   -1,   -3, 	  -2,    0, 	   0,   -1, 	  -1,   -7
+.2byte   -4,   -2, 	  -5,   -1, 	  -4,    0, 	  -1,   -7
+.2byte   -5,   -3, 	  -3,   -1, 	  -5,   -1, 	  -2,   -8
+.2byte   -4,   -8, 	  -1,   -4, 	  -3,   -5, 	  -2,   -9
+.2byte   -1,   -6, 	   1,   -5, 	  -2,   -4, 	  -1,   -9
+.2byte    3,   -8, 	   0,   -4, 	   2,   -5, 	   1,   -9
+.2byte    4,   -3, 	   2,   -1, 	   4,   -1, 	   1,   -8
+.2byte    3,   -2, 	   4,   -1, 	   3,    0, 	   0,   -7
+.2byte   -1,   -6, 	  -2,   -2, 	   1,   -3, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,   -2, 	  -4,   -4, 	  -1,   -8
+.2byte   -7,   -7, 	  -9,   -4, 	  -9,   -5, 	  -1,   -8
+.2byte   -3,   -9, 	  -5,   -9, 	  -6,   -8, 	   0,   -9
+.2byte   -1,  -10, 	   1,   -9, 	  -2,   -9, 	  -1,   -9
+.2byte    1,   -9, 	   3,   -9, 	   4,   -8, 	  -2,   -9
+.2byte    5,   -7, 	   7,   -4, 	   7,   -5, 	  -1,   -8
+.2byte    2,   -6, 	   4,   -2, 	   2,   -4, 	  -1,   -8
+sSnoruntAnimTable1:
+.4byte sSnoruntAnims_1_1
+.4byte sSnoruntAnims_1_2
+.4byte sSnoruntAnims_1_3
+.4byte sSnoruntAnims_1_4
+.4byte sSnoruntAnims_1_5
+.4byte sSnoruntAnims_1_6
+.4byte sSnoruntAnims_1_7
+.4byte sSnoruntAnims_1_8
+sSnoruntAnimTable2:
+.4byte sSnoruntAnims_2_1
+.4byte sSnoruntAnims_2_2
+.4byte sSnoruntAnims_2_3
+.4byte sSnoruntAnims_2_4
+.4byte sSnoruntAnims_2_5
+.4byte sSnoruntAnims_2_6
+.4byte sSnoruntAnims_2_7
+.4byte sSnoruntAnims_2_8
+sSnoruntAnimTable3:
+.4byte sSnoruntAnims_3_1
+.4byte sSnoruntAnims_3_2
+.4byte sSnoruntAnims_3_3
+.4byte sSnoruntAnims_3_4
+.4byte sSnoruntAnims_3_5
+.4byte sSnoruntAnims_3_6
+.4byte sSnoruntAnims_3_7
+.4byte sSnoruntAnims_3_8
+sSnoruntAnimTable4:
+.4byte sSnoruntAnims_4_1
+.4byte sSnoruntAnims_4_2
+.4byte sSnoruntAnims_4_3
+.4byte sSnoruntAnims_4_4
+.4byte sSnoruntAnims_4_5
+.4byte sSnoruntAnims_4_6
+.4byte sSnoruntAnims_4_7
+.4byte sSnoruntAnims_4_8
+sSnoruntAnimTable5:
+.4byte sSnoruntAnims_5_1
+.4byte sSnoruntAnims_5_2
+.4byte sSnoruntAnims_5_3
+.4byte sSnoruntAnims_5_4
+.4byte sSnoruntAnims_5_5
+.4byte sSnoruntAnims_5_6
+.4byte sSnoruntAnims_5_7
+.4byte sSnoruntAnims_5_8
+sSnoruntAnimTable6:
+.4byte sSnoruntAnims_6_1
+.4byte sSnoruntAnims_6_1
+.4byte sSnoruntAnims_6_1
+.4byte sSnoruntAnims_6_1
+.4byte sSnoruntAnims_6_1
+.4byte sSnoruntAnims_6_1
+.4byte sSnoruntAnims_6_1
+.4byte sSnoruntAnims_6_1
+sSnoruntAnimTable7:
+.4byte sSnoruntAnims_7_1
+.4byte sSnoruntAnims_7_2
+.4byte sSnoruntAnims_7_3
+.4byte sSnoruntAnims_7_4
+.4byte sSnoruntAnims_7_5
+.4byte sSnoruntAnims_7_6
+.4byte sSnoruntAnims_7_7
+.4byte sSnoruntAnims_7_8
+sSnoruntAnimTable8:
+.4byte sSnoruntAnims_8_1
+.4byte sSnoruntAnims_8_2
+.4byte sSnoruntAnims_8_3
+.4byte sSnoruntAnims_8_4
+.4byte sSnoruntAnims_8_5
+.4byte sSnoruntAnims_8_6
+.4byte sSnoruntAnims_8_7
+.4byte sSnoruntAnims_8_8
+sSnoruntAnimTable9:
+.4byte sSnoruntAnims_9_1
+.4byte sSnoruntAnims_9_2
+.4byte sSnoruntAnims_9_3
+.4byte sSnoruntAnims_9_4
+.4byte sSnoruntAnims_9_5
+.4byte sSnoruntAnims_9_6
+.4byte sSnoruntAnims_9_7
+.4byte sSnoruntAnims_9_8
+sSnoruntAnimTable10:
+.4byte sSnoruntAnims_10_1
+.4byte sSnoruntAnims_10_2
+.4byte sSnoruntAnims_10_3
+.4byte sSnoruntAnims_10_4
+.4byte sSnoruntAnims_10_5
+.4byte sSnoruntAnims_10_6
+.4byte sSnoruntAnims_10_7
+.4byte sSnoruntAnims_10_8
+sSnoruntAnimTable11:
+.4byte sSnoruntAnims_11_1
+.4byte sSnoruntAnims_11_2
+.4byte sSnoruntAnims_11_3
+.4byte sSnoruntAnims_11_4
+.4byte sSnoruntAnims_11_5
+.4byte sSnoruntAnims_11_6
+.4byte sSnoruntAnims_11_7
+.4byte sSnoruntAnims_11_8
+sSnoruntAnimTable12:
+.4byte sSnoruntAnims_12_1
+.4byte sSnoruntAnims_12_2
+.4byte sSnoruntAnims_12_3
+.4byte sSnoruntAnims_12_4
+.4byte sSnoruntAnims_12_5
+.4byte sSnoruntAnims_12_6
+.4byte sSnoruntAnims_12_7
+.4byte sSnoruntAnims_12_8
+sSnoruntAnimTable13:
+.4byte sSnoruntAnims_13_1
+.4byte sSnoruntAnims_13_2
+.4byte sSnoruntAnims_13_3
+.4byte sSnoruntAnims_13_4
+.4byte sSnoruntAnims_13_5
+.4byte sSnoruntAnims_13_6
+.4byte sSnoruntAnims_13_7
+.4byte sSnoruntAnims_13_8
+sAxAnimationsSnorunt:
+.4byte sSnoruntAnimTable1
+.4byte sSnoruntAnimTable2
+.4byte sSnoruntAnimTable3
+.4byte sSnoruntAnimTable4
+.4byte sSnoruntAnimTable5
+.4byte sSnoruntAnimTable6
+.4byte sSnoruntAnimTable7
+.4byte sSnoruntAnimTable8
+.4byte sSnoruntAnimTable9
+.4byte sSnoruntAnimTable10
+.4byte sSnoruntAnimTable11
+.4byte sSnoruntAnimTable12
+.4byte sSnoruntAnimTable13
+sAxSpritesSnorunt:
+.4byte sSnoruntSprites1
+.4byte sSnoruntSprites2
+.4byte sSnoruntSprites3
+.4byte sSnoruntSprites4
+.4byte sSnoruntSprites5
+.4byte sSnoruntSprites6
+.4byte sSnoruntSprites7
+.4byte sSnoruntSprites8
+.4byte sSnoruntSprites9
+.4byte sSnoruntSprites10
+.4byte sSnoruntSprites11
+.4byte sSnoruntSprites12
+.4byte sSnoruntSprites13
+.4byte sSnoruntSprites14
+.4byte sSnoruntSprites15
+.4byte sSnoruntSprites16
+.4byte sSnoruntSprites17
+.4byte sSnoruntSprites18
+.4byte sSnoruntSprites19
+.4byte sSnoruntSprites20
+.4byte sSnoruntSprites21
+.4byte sSnoruntSprites22
+.4byte sSnoruntSprites23
+.4byte sSnoruntSprites24
+.4byte sSnoruntSprites25
+.4byte sSnoruntSprites26
+.4byte sSnoruntSprites27
+.4byte sSnoruntSprites28
+.4byte sSnoruntSprites29
+.4byte sSnoruntSprites30
+.4byte sSnoruntSprites31
+.4byte sSnoruntSprites32
+.4byte sSnoruntSprites33
+.4byte sSnoruntSprites34
+.4byte sSnoruntSprites35
+sAxMainSnorunt:
+ax_main sAxPosesSnorunt, sAxAnimationsSnorunt, 13, sAxSpritesSnorunt, sAxPositionsSnorunt

--- a/data/ax/snubbull.inc
+++ b/data/ax/snubbull.inc
@@ -1,0 +1,2912 @@
+.global gAxSnubbull
+gAxSnubbull:
+ax_siro sAxMainSnubbull
+sSnubbullPose1:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose2:
+ax_pose 1, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose3:
+ax_pose 2, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose4:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose5:
+ax_pose 4, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose6:
+ax_pose 5, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose8:
+ax_pose 7, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose10:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose11:
+ax_pose 10, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose13:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose14:
+ax_pose 13, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose15:
+ax_pose 14, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose25:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose26:
+ax_pose 1, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose27:
+ax_pose 2, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose28:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose29:
+ax_pose 4, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose30:
+ax_pose 5, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose31:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose32:
+ax_pose 7, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose33:
+ax_pose 8, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose34:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose35:
+ax_pose 10, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose36:
+ax_pose 11, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose37:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose38:
+ax_pose 13, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose39:
+ax_pose 14, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose40:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose41:
+ax_pose 10, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose42:
+ax_pose 11, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose43:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose44:
+ax_pose 7, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose45:
+ax_pose 8, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose47:
+ax_pose 4, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose48:
+ax_pose 5, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose49:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose50:
+ax_pose 1, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose51:
+ax_pose 2, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose52:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose53:
+ax_pose 4, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose54:
+ax_pose 5, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose55:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose56:
+ax_pose 7, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose57:
+ax_pose 8, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose58:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose59:
+ax_pose 10, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose60:
+ax_pose 11, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose61:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose62:
+ax_pose 13, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose63:
+ax_pose 14, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose64:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose65:
+ax_pose 10, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose66:
+ax_pose 11, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose67:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose68:
+ax_pose 7, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose69:
+ax_pose 8, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose71:
+ax_pose 4, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose72:
+ax_pose 5, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose73:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose74:
+ax_pose 15, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose75:
+ax_pose 16, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose76:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose77:
+ax_pose 17, 0x01ec, 0x90ef, 0xbc00
+ax_pose_terminator
+sSnubbullPose78:
+ax_pose 18, 0x01ec, 0x90ef, 0xbc00
+ax_pose_terminator
+sSnubbullPose79:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose80:
+ax_pose 19, 0x01ea, 0x90ef, 0xbc00
+ax_pose_terminator
+sSnubbullPose81:
+ax_pose 20, 0x01ea, 0x90ef, 0xbc00
+ax_pose_terminator
+sSnubbullPose82:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose83:
+ax_pose 21, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSnubbullPose84:
+ax_pose 22, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSnubbullPose85:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose86:
+ax_pose 23, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose87:
+ax_pose 24, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose88:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose89:
+ax_pose 21, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sSnubbullPose90:
+ax_pose 22, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sSnubbullPose91:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose92:
+ax_pose 19, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sSnubbullPose93:
+ax_pose 20, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sSnubbullPose94:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose95:
+ax_pose 17, 0x01ec, 0x80f0, 0xbc00
+ax_pose_terminator
+sSnubbullPose96:
+ax_pose 18, 0x01ec, 0x80f0, 0xbc00
+ax_pose_terminator
+sSnubbullPose97:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose98:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose99:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose100:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose101:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose102:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose103:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose104:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose105:
+ax_pose 1, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose106:
+ax_pose 2, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose107:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose108:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose109:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose110:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose111:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose112:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose113:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose114:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose115:
+ax_pose 4, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose116:
+ax_pose 5, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose117:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose118:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose119:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose120:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose121:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose122:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose123:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose124:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose125:
+ax_pose 7, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose126:
+ax_pose 8, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose127:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose128:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose129:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose130:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose131:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose132:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose133:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose134:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose135:
+ax_pose 10, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose136:
+ax_pose 11, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose137:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose138:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose139:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose140:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose141:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose142:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose143:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose144:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose145:
+ax_pose 13, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose146:
+ax_pose 14, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose147:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose148:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose149:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose150:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose151:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose152:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose153:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose154:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose155:
+ax_pose 10, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose156:
+ax_pose 11, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose157:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose158:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose159:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose160:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose161:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose162:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose163:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose164:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose165:
+ax_pose 7, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose166:
+ax_pose 8, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose167:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose168:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose169:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose170:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose171:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose172:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose173:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose174:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose175:
+ax_pose 4, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose176:
+ax_pose 5, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose177:
+ax_pose 25, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose178:
+ax_pose 26, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose179:
+ax_pose 27, 0x01e1, 0x80f1, 0xbc00
+ax_pose_terminator
+sSnubbullPose180:
+ax_pose 28, 0x01e2, 0x90e9, 0xbc00
+ax_pose_terminator
+sSnubbullPose181:
+ax_pose 29, 0x01e3, 0x90ea, 0xbc00
+ax_pose_terminator
+sSnubbullPose182:
+ax_pose 30, 0x01e3, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose183:
+ax_pose 31, 0x01e4, 0x80f1, 0xbc00
+ax_pose_terminator
+sSnubbullPose184:
+ax_pose 30, 0x01e3, 0x80f5, 0xbc00
+ax_pose_terminator
+sSnubbullPose185:
+ax_pose 29, 0x01e3, 0x80f6, 0xbc00
+ax_pose_terminator
+sSnubbullPose186:
+ax_pose 28, 0x01e2, 0x80f7, 0xbc00
+ax_pose_terminator
+sSnubbullPose187:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose188:
+ax_pose 1, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose189:
+ax_pose 2, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose190:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose191:
+ax_pose 4, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose192:
+ax_pose 5, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose193:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose194:
+ax_pose 7, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose195:
+ax_pose 8, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose196:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose197:
+ax_pose 10, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose198:
+ax_pose 11, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose199:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose200:
+ax_pose 13, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose201:
+ax_pose 14, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose202:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose203:
+ax_pose 10, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose204:
+ax_pose 11, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose205:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose206:
+ax_pose 7, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose207:
+ax_pose 8, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose208:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose209:
+ax_pose 4, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose210:
+ax_pose 5, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose211:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose212:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose213:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose214:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose215:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose216:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose217:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose218:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose219:
+ax_pose 15, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose220:
+ax_pose 17, 0x01ec, 0x90ee, 0xbc00
+ax_pose_terminator
+sSnubbullPose221:
+ax_pose 19, 0x01ea, 0x90ed, 0xbc00
+ax_pose_terminator
+sSnubbullPose222:
+ax_pose 21, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSnubbullPose223:
+ax_pose 23, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose224:
+ax_pose 21, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose225:
+ax_pose 19, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose226:
+ax_pose 17, 0x01ec, 0x80f2, 0xbc00
+ax_pose_terminator
+sSnubbullPose227:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose228:
+ax_pose 15, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose229:
+ax_pose 16, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose230:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose231:
+ax_pose 17, 0x01ec, 0x90ed, 0xbc00
+ax_pose_terminator
+sSnubbullPose232:
+ax_pose 18, 0x01ec, 0x90ed, 0xbc00
+ax_pose_terminator
+sSnubbullPose233:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose234:
+ax_pose 19, 0x01ea, 0x90ec, 0xbc00
+ax_pose_terminator
+sSnubbullPose235:
+ax_pose 20, 0x01ea, 0x90ec, 0xbc00
+ax_pose_terminator
+sSnubbullPose236:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose237:
+ax_pose 21, 0x01ea, 0x90ed, 0xbc00
+ax_pose_terminator
+sSnubbullPose238:
+ax_pose 22, 0x01ea, 0x90ed, 0xbc00
+ax_pose_terminator
+sSnubbullPose239:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose240:
+ax_pose 23, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose241:
+ax_pose 24, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose242:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose243:
+ax_pose 21, 0x01ea, 0x80f2, 0xbc00
+ax_pose_terminator
+sSnubbullPose244:
+ax_pose 22, 0x01ea, 0x80f2, 0xbc00
+ax_pose_terminator
+sSnubbullPose245:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose246:
+ax_pose 19, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose247:
+ax_pose 20, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose248:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose249:
+ax_pose 17, 0x01ec, 0x80f2, 0xbc00
+ax_pose_terminator
+sSnubbullPose250:
+ax_pose 18, 0x01ec, 0x80f2, 0xbc00
+ax_pose_terminator
+sSnubbullPose251:
+ax_pose 16, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose252:
+ax_pose 18, 0x01ec, 0x80f2, 0xbc00
+ax_pose_terminator
+sSnubbullPose253:
+ax_pose 20, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose254:
+ax_pose 22, 0x01ea, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose255:
+ax_pose 24, 0x01ec, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose256:
+ax_pose 22, 0x01ea, 0x90ee, 0xbc00
+ax_pose_terminator
+sSnubbullPose257:
+ax_pose 20, 0x01ea, 0x90ed, 0xbc00
+ax_pose_terminator
+sSnubbullPose258:
+ax_pose 18, 0x01ec, 0x90ee, 0xbc00
+ax_pose_terminator
+sSnubbullPose259:
+ax_pose 0, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose260:
+ax_pose 3, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose261:
+ax_pose 6, 0x01eb, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose262:
+ax_pose 9, 0x01ed, 0x80f4, 0xbc00
+ax_pose_terminator
+sSnubbullPose263:
+ax_pose 12, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sSnubbullPose264:
+ax_pose 9, 0x01ed, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose265:
+ax_pose 6, 0x01eb, 0x90eb, 0xbc00
+ax_pose_terminator
+sSnubbullPose266:
+ax_pose 3, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+.align 2
+sSnubbullAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSnubbullAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 3, 4, 3,
+ax_anim 1, 0, 29, 10, 8, 10, 8,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 1, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sSnubbullAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 1, 31, 22, 1, 22, 1,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 0, 31, 22, 1, 22, 1,
+ax_anim 2, 0, 30, 8, 0, 8, 0,
+ax_anim_terminator
+sSnubbullAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -12, 11, -12,
+ax_anim 2, 0, 34, 20, -23, 18, -23,
+ax_anim 2, 1, 34, 21, -22, 19, -22,
+ax_anim 2, 0, 34, 20, -23, 18, -23,
+ax_anim 2, 0, 34, 21, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSnubbullAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSnubbullAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -12, -10, -12,
+ax_anim 2, 0, 40, -20, -23, -20, -23,
+ax_anim 2, 1, 40, -21, -22, -21, -22,
+ax_anim 2, 0, 40, -20, -23, -20, -23,
+ax_anim 2, 0, 40, -21, -22, -21, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSnubbullAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -12, 0, -12, 0,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 1, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 0, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -8, 0, -8, 0,
+ax_anim_terminator
+sSnubbullAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, 3, -4, 3,
+ax_anim 1, 0, 47, -10, 8, -10, 8,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 1, 46, -21, 18, -21, 18,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSnubbullAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 1, 2, 52, 4, 3, 4, 3,
+ax_anim 1, 0, 53, 10, 8, 10, 8,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 1, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 0, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sSnubbullAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 12, 0, 12, 0,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 1, 55, 22, 1, 22, 1,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 0, 55, 22, 1, 22, 1,
+ax_anim 2, 0, 54, 8, 0, 8, 0,
+ax_anim_terminator
+sSnubbullAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -12, 11, -12,
+ax_anim 2, 0, 58, 20, -23, 18, -23,
+ax_anim 2, 1, 58, 21, -22, 19, -22,
+ax_anim 2, 0, 58, 20, -23, 18, -23,
+ax_anim 2, 0, 58, 21, -22, 19, -22,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSnubbullAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 1, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 0, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSnubbullAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -12, -10, -12,
+ax_anim 2, 0, 64, -20, -23, -20, -23,
+ax_anim 2, 1, 64, -21, -22, -21, -22,
+ax_anim 2, 0, 64, -20, -23, -20, -23,
+ax_anim 2, 0, 64, -21, -22, -21, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSnubbullAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -12, 0, -12, 0,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 1, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 0, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -8, 0, -8, 0,
+ax_anim_terminator
+sSnubbullAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 71, -4, 3, -4, 3,
+ax_anim 1, 0, 71, -10, 8, -10, 8,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 1, 70, -21, 18, -21, 18,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 4, 0, 72, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 4, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sSnubbullAnims_4_2:
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 4, 0, 75, 0, -3, 0, 0,
+ax_anim 2, 0, 75, 0, -2, 0, 0,
+ax_anim 4, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 1, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 2, 0, 77, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim_terminator
+sSnubbullAnims_4_3:
+ax_anim 2, 0, 78, 0, -2, 0, -2,
+ax_anim 4, 0, 78, 0, -3, 0, -3,
+ax_anim 2, 0, 78, 0, -2, 0, -2,
+ax_anim 4, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 0, 1, 0,
+ax_anim 2, 0, 79, 2, 0, 2, 0,
+ax_anim 2, 1, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 79, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 79, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 79, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 79, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim_terminator
+sSnubbullAnims_4_4:
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 4, 0, 81, 0, -3, 0, 0,
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 4, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 2, -2, 2, -2,
+ax_anim 2, 1, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 82, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 82, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 82, 3, -3, 3, -3,
+ax_anim 2, 0, 83, 3, -3, 3, -3,
+ax_anim 2, 0, 82, 3, -3, 3, -3,
+ax_anim 2, 0, 81, 2, -2, 2, -2,
+ax_anim_terminator
+sSnubbullAnims_4_5:
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 4, 0, 84, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 4, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, -1,
+ax_anim 2, 0, 85, 0, -2, 0, -2,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -2, 0, -2,
+ax_anim_terminator
+sSnubbullAnims_4_6:
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 4, 0, 87, 0, -3, 0, 0,
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 4, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, -2, -2, -2, -2,
+ax_anim 2, 1, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 88, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 88, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 88, -3, -3, -3, -3,
+ax_anim 2, 0, 89, -3, -3, -3, -3,
+ax_anim 2, 0, 88, -3, -3, -3, -3,
+ax_anim 2, 0, 87, -2, -2, -2, -2,
+ax_anim_terminator
+sSnubbullAnims_4_7:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 4, 0, 90, 0, -3, 0, -3,
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 4, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, 0, -1, 0,
+ax_anim 2, 0, 91, -2, 0, -2, 0,
+ax_anim 2, 1, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 91, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 91, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 91, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 91, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim_terminator
+sSnubbullAnims_4_8:
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 2, 0, 94, -2, 2, -2, 2,
+ax_anim 2, 1, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 94, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 94, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 94, -3, 3, -3, 3,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 2, 0, 94, -3, 3, -3, 3,
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_5_1:
+ax_anim 3, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 1, 0, 98, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 2, 100, 0, -6, 0, 0,
+ax_anim 1, 0, 101, 0, -6, 0, 0,
+ax_anim 1, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 0, 103, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -3, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, 0,
+ax_anim 1, 0, 98, 0, -1, 0, 0,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 3, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_5_2:
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -3, 0, 0,
+ax_anim 1, 0, 107, 0, -4, 0, 0,
+ax_anim 1, 0, 108, 0, -5, 0, 0,
+ax_anim 1, 2, 109, 0, -6, 0, 0,
+ax_anim 1, 0, 110, 0, -6, 0, 0,
+ax_anim 1, 0, 111, 0, -5, 0, 0,
+ax_anim 1, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 113, 0, -3, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, -1, 0, 0,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_5_3:
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 1, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 0, -5, 0, 0,
+ax_anim 1, 2, 118, 0, -6, 0, 0,
+ax_anim 1, 0, 119, 0, -6, 0, 0,
+ax_anim 1, 0, 120, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -4, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 1, 0, 123, 0, -2, 0, 0,
+ax_anim 1, 0, 116, 0, -1, 0, 0,
+ax_anim 1, 0, 117, 0, 0, 0, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_5_4:
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -3, 0, 0,
+ax_anim 1, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -5, 0, 0,
+ax_anim 1, 2, 127, 0, -6, 0, 0,
+ax_anim 1, 0, 128, 0, -6, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 1, 0, 133, 0, -1, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_5_5:
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 1, 0, 142, 0, -4, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 2, 136, 0, -6, 0, 0,
+ax_anim 1, 0, 137, 0, -6, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -4, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 1, 0, 141, 0, -2, 0, 0,
+ax_anim 1, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_5_6:
+ax_anim 3, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, -3, 0, 0,
+ax_anim 1, 0, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 152, 0, -5, 0, 0,
+ax_anim 1, 2, 153, 0, -6, 0, 0,
+ax_anim 1, 0, 146, 0, -6, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 0, 148, 0, -4, 0, 0,
+ax_anim 1, 0, 149, 0, -3, 0, 0,
+ax_anim 1, 0, 150, 0, -2, 0, 0,
+ax_anim 1, 0, 151, 0, -1, 0, 0,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_5_7:
+ax_anim 3, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, -3, 0, 0,
+ax_anim 1, 0, 160, 0, -4, 0, 0,
+ax_anim 1, 0, 161, 0, -5, 0, 0,
+ax_anim 1, 2, 162, 0, -6, 0, 0,
+ax_anim 1, 0, 163, 0, -6, 0, 0,
+ax_anim 1, 0, 156, 0, -5, 0, 0,
+ax_anim 1, 0, 157, 0, -4, 0, 0,
+ax_anim 1, 0, 158, 0, -3, 0, 0,
+ax_anim 1, 0, 159, 0, -2, 0, 0,
+ax_anim 1, 0, 160, 0, -1, 0, 0,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_5_8:
+ax_anim 3, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, -2, 0, 0,
+ax_anim 2, 0, 168, 0, -3, 0, 0,
+ax_anim 1, 0, 169, 0, -4, 0, 0,
+ax_anim 1, 0, 170, 0, -5, 0, 0,
+ax_anim 1, 2, 171, 0, -6, 0, 0,
+ax_anim 1, 0, 172, 0, -6, 0, 0,
+ax_anim 1, 0, 173, 0, -5, 0, 0,
+ax_anim 1, 0, 166, 0, -4, 0, 0,
+ax_anim 1, 0, 167, 0, -3, 0, 0,
+ax_anim 1, 0, 168, 0, -2, 0, 0,
+ax_anim 1, 0, 169, 0, -1, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 3, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_7_1:
+ax_anim 2, 0, 178, 0, -4, 0, -4,
+ax_anim 8, 0, 178, 0, -5, 0, -5,
+ax_anim_terminator
+sSnubbullAnims_7_2:
+ax_anim 2, 0, 179, -4, -4, -4, -4,
+ax_anim 8, 0, 179, -5, -5, -5, -5,
+ax_anim_terminator
+sSnubbullAnims_7_3:
+ax_anim 2, 0, 180, -4, 0, -4, 0,
+ax_anim 8, 0, 180, -5, 0, -5, 0,
+ax_anim_terminator
+sSnubbullAnims_7_4:
+ax_anim 2, 0, 181, -4, 4, -4, 4,
+ax_anim 8, 0, 181, -5, 5, -5, 5,
+ax_anim_terminator
+sSnubbullAnims_7_5:
+ax_anim 2, 0, 182, 0, 4, 0, 4,
+ax_anim 8, 0, 182, 0, 5, 0, 5,
+ax_anim_terminator
+sSnubbullAnims_7_6:
+ax_anim 2, 0, 183, 4, 4, 4, 4,
+ax_anim 8, 0, 183, 5, 5, 5, 5,
+ax_anim_terminator
+sSnubbullAnims_7_7:
+ax_anim 2, 0, 184, 4, 0, 4, 0,
+ax_anim 8, 0, 184, 5, 0, 5, 0,
+ax_anim_terminator
+sSnubbullAnims_7_8:
+ax_anim 2, 0, 185, 4, -4, 4, -4,
+ax_anim 8, 0, 185, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_8_1:
+ax_anim 30, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, -3, 0, 0,
+ax_anim 3, 0, 187, 0, -4, 0, 0,
+ax_anim 4, 0, 186, 0, -4, 0, 0,
+ax_anim 3, 0, 188, 0, -4, 0, 0,
+ax_anim 2, 0, 188, 0, -3, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_8_2:
+ax_anim 30, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, -3, 0, 0,
+ax_anim 3, 0, 190, 0, -4, 0, 0,
+ax_anim 4, 0, 189, 0, -4, 0, 0,
+ax_anim 3, 0, 191, 0, -4, 0, 0,
+ax_anim 2, 0, 191, 0, -3, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_8_3:
+ax_anim 30, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 193, 0, -4, 0, 0,
+ax_anim 4, 0, 192, 0, -4, 0, 0,
+ax_anim 3, 0, 194, 0, -4, 0, 0,
+ax_anim 2, 0, 194, 0, -3, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_8_4:
+ax_anim 30, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -3, 0, 0,
+ax_anim 3, 0, 196, 0, -4, 0, 0,
+ax_anim 4, 0, 195, 0, -4, 0, 0,
+ax_anim 3, 0, 197, 0, -4, 0, 0,
+ax_anim 2, 0, 197, 0, -3, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_8_5:
+ax_anim 30, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -3, 0, 0,
+ax_anim 3, 0, 199, 0, -4, 0, 0,
+ax_anim 4, 0, 198, 0, -4, 0, 0,
+ax_anim 3, 0, 200, 0, -4, 0, 0,
+ax_anim 2, 0, 200, 0, -3, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_8_6:
+ax_anim 30, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -3, 0, 0,
+ax_anim 3, 0, 202, 0, -4, 0, 0,
+ax_anim 4, 0, 201, 0, -4, 0, 0,
+ax_anim 3, 0, 203, 0, -4, 0, 0,
+ax_anim 2, 0, 203, 0, -3, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_8_7:
+ax_anim 30, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -3, 0, 0,
+ax_anim 3, 0, 205, 0, -4, 0, 0,
+ax_anim 4, 0, 204, 0, -4, 0, 0,
+ax_anim 3, 0, 206, 0, -4, 0, 0,
+ax_anim 2, 0, 206, 0, -3, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_8_8:
+ax_anim 30, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -3, 0, 0,
+ax_anim 3, 0, 208, 0, -4, 0, 0,
+ax_anim 4, 0, 207, 0, -4, 0, 0,
+ax_anim 3, 0, 209, 0, -4, 0, 0,
+ax_anim 2, 0, 209, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 6, 4, 6, 4,
+ax_anim 2, 0, 212, 8, 9, 8, 9,
+ax_anim 2, 0, 213, 7, 19, 7, 19,
+ax_anim 3, 0, 214, 0, 22, 0, 22,
+ax_anim 2, 3, 215, -7, 19, -7, 19,
+ax_anim 2, 0, 216, -8, 9, -8, 9,
+ax_anim 1, 0, 217, -6, 4, -6, 4,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 211, 17, 3, 17, 3,
+ax_anim 2, 0, 212, 24, 9, 24, 9,
+ax_anim 3, 0, 213, 23, 21, 23, 21,
+ax_anim 2, 3, 214, 11, 21, 11, 21,
+ax_anim 2, 0, 215, 2, 12, 2, 12,
+ax_anim 1, 0, 216, 0, 7, 0, 7,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 3, -4, 3, -4,
+ax_anim 2, 0, 210, 11, -6, 11, -6,
+ax_anim 2, 0, 211, 19, -4, 19, -4,
+ax_anim 3, 0, 212, 24, 1, 24, 1,
+ax_anim 2, 3, 213, 19, 5, 19, 5,
+ax_anim 2, 0, 214, 12, 7, 12, 7,
+ax_anim 1, 0, 215, 4, 5, 4, 5,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, -1, -6, -1, -6,
+ax_anim 2, 0, 217, 4, -16, 4, -16,
+ax_anim 2, 0, 210, 11, -22, 11, -22,
+ax_anim 3, 0, 211, 19, -24, 16, -20,
+ax_anim 2, 3, 212, 22, -12, 22, -12,
+ax_anim 2, 0, 213, 18, -5, 18, -5,
+ax_anim 1, 0, 214, 7, 0, 7, 0,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -6, -4, -6, -4,
+ax_anim 2, 0, 216, -8, -10, -8, -10,
+ax_anim 2, 0, 217, -7, -18, -7, -18,
+ax_anim 3, 0, 210, 0, -22, 0, -22,
+ax_anim 2, 3, 211, 7, -18, 7, -18,
+ax_anim 2, 0, 212, 8, -8, 8, -8,
+ax_anim 1, 0, 213, 6, -4, 6, -4,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 1, -6, 1, -6,
+ax_anim 2, 0, 211, -4, -16, -4, -16,
+ax_anim 2, 0, 210, -11, -22, -11, -22,
+ax_anim 3, 0, 217, -19, -24, -16, -20,
+ax_anim 2, 3, 216, -22, -12, -22, -12,
+ax_anim 2, 0, 215, -18, -5, -18, -5,
+ax_anim 1, 0, 214, -7, 0, -7, 0,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, -3, -4, -3, -4,
+ax_anim 2, 0, 210, -11, -6, -11, -6,
+ax_anim 2, 0, 217, -19, -4, -19, -4,
+ax_anim 3, 0, 216, -24, 1, -24, 1,
+ax_anim 2, 3, 215, -19, 5, -19, 5,
+ax_anim 2, 0, 214, -12, 7, -12, 7,
+ax_anim 1, 0, 213, -4, 5, -4, 5,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 217, -17, 3, -17, 3,
+ax_anim 2, 0, 216, -24, 9, -24, 9,
+ax_anim 3, 0, 215, -23, 21, -23, 16,
+ax_anim 2, 3, 214, -11, 21, -11, 16,
+ax_anim 2, 0, 213, -2, 12, -4, 12,
+ax_anim 1, 0, 212, 0, 7, -3, 7,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_10_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 3, 0, 218, 13, 0, 13, 0,
+ax_anim 3, 0, 218, -13, 0, -13, 0,
+ax_anim 2, 0, 218, 12, 0, 12, 0,
+ax_anim 3, 0, 218, -12, 0, -12, 0,
+ax_anim 2, 0, 218, 10, 0, 10, 0,
+ax_anim 2, 0, 218, -10, 0, -10, 0,
+ax_anim 2, 0, 218, 6, 0, 6, 0,
+ax_anim 2, 0, 218, -6, 0, -6, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_10_2:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 3, 0, 219, 13, -13, 13, -13,
+ax_anim 3, 0, 219, -13, 13, -13, 13,
+ax_anim 2, 0, 219, 12, -12, 12, -12,
+ax_anim 3, 0, 219, -12, 12, -12, 12,
+ax_anim 2, 0, 219, 10, -10, 10, -10,
+ax_anim 2, 0, 219, -10, 10, -10, 10,
+ax_anim 2, 0, 219, 6, -6, 6, -6,
+ax_anim 2, 0, 219, -6, 6, -6, 6,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_10_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 3, 0, 220, 0, -13, 0, -13,
+ax_anim 3, 0, 220, 0, 13, 0, 13,
+ax_anim 2, 0, 220, 0, -12, 0, -12,
+ax_anim 3, 0, 220, 0, 12, 0, 12,
+ax_anim 2, 0, 220, 0, -10, 0, -10,
+ax_anim 2, 0, 220, 0, 10, 0, 10,
+ax_anim 2, 0, 220, 0, -6, 0, -6,
+ax_anim 2, 0, 220, 0, 6, 0, 6,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_10_4:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 3, 0, 221, -13, -13, -13, -13,
+ax_anim 3, 0, 221, 13, 13, 13, 13,
+ax_anim 2, 0, 221, -12, -12, -12, -12,
+ax_anim 3, 0, 221, 12, 12, 12, 12,
+ax_anim 2, 0, 221, -10, -10, -10, -10,
+ax_anim 2, 0, 221, 10, 10, 10, 10,
+ax_anim 2, 0, 221, -6, -6, -6, -6,
+ax_anim 2, 0, 221, 6, 6, 6, 6,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_10_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 3, 0, 222, 13, 0, 13, 0,
+ax_anim 3, 0, 222, -13, 0, -13, 0,
+ax_anim 2, 0, 222, 12, 0, 12, 0,
+ax_anim 3, 0, 222, -12, 0, -12, 0,
+ax_anim 2, 0, 222, 10, 0, 10, 0,
+ax_anim 2, 0, 222, -10, 0, -10, 0,
+ax_anim 2, 0, 222, 6, 0, 6, 0,
+ax_anim 2, 0, 222, -6, 0, -6, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_10_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 3, 0, 223, 13, -13, 13, -13,
+ax_anim 3, 0, 223, -13, 13, -13, 13,
+ax_anim 2, 0, 223, 12, -12, 12, -12,
+ax_anim 3, 0, 223, -12, 12, -12, 12,
+ax_anim 2, 0, 223, 10, -10, 10, -10,
+ax_anim 2, 0, 223, -10, 10, -10, 10,
+ax_anim 2, 0, 223, 6, -6, 6, -6,
+ax_anim 2, 0, 223, -6, 6, -6, 6,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_10_7:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 3, 0, 224, 0, -13, 0, -13,
+ax_anim 3, 0, 224, 0, 13, 0, 13,
+ax_anim 2, 0, 224, 0, -12, 0, -12,
+ax_anim 3, 0, 224, 0, 12, 0, 12,
+ax_anim 2, 0, 224, 0, -10, 0, -10,
+ax_anim 2, 0, 224, 0, 10, 0, 10,
+ax_anim 2, 0, 224, 0, -6, 0, -6,
+ax_anim 2, 0, 224, 0, 6, 0, 6,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_10_8:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 3, 0, 225, -13, -13, -13, -13,
+ax_anim 3, 0, 225, 13, 13, 13, 13,
+ax_anim 2, 0, 225, -12, -12, -12, -12,
+ax_anim 3, 0, 225, 12, 12, 12, 12,
+ax_anim 2, 0, 225, -10, -10, -10, -10,
+ax_anim 2, 0, 225, 10, 10, 10, 10,
+ax_anim 2, 0, 225, -6, -6, -6, -6,
+ax_anim 2, 0, 225, 6, 6, 6, 6,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_11_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -23, 0, 0,
+ax_anim 3, 0, 228, 0, -22, 0, 0,
+ax_anim 2, 0, 228, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_11_2:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 230, 0, -16, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -23, 0, 0,
+ax_anim 3, 0, 231, 0, -22, 0, 0,
+ax_anim 2, 0, 231, 0, -18, 0, 0,
+ax_anim 1, 0, 231, 0, -12, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_11_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -23, 0, 0,
+ax_anim 3, 0, 234, 0, -22, 0, 0,
+ax_anim 2, 0, 234, 0, -18, 0, 0,
+ax_anim 1, 0, 234, 0, -12, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_11_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 236, 0, -16, 0, 0,
+ax_anim 3, 0, 236, 0, -20, 0, 0,
+ax_anim 4, 0, 236, 0, -21, 0, 0,
+ax_anim 4, 0, 237, 0, -22, 0, 0,
+ax_anim 3, 0, 237, 0, -21, 0, 0,
+ax_anim 2, 0, 237, 0, -17, 0, 0,
+ax_anim 1, 0, 237, 0, -11, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_11_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 239, 0, -16, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -21, 0, 0,
+ax_anim 4, 0, 240, 0, -23, 0, 0,
+ax_anim 3, 0, 240, 0, -22, 0, 0,
+ax_anim 2, 0, 240, 0, -18, 0, 0,
+ax_anim 1, 0, 240, 0, -12, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_11_6:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 0, -10, 0, 0,
+ax_anim 2, 0, 242, 0, -16, 0, 0,
+ax_anim 3, 0, 242, 0, -20, 0, 0,
+ax_anim 4, 0, 242, 0, -21, 0, 0,
+ax_anim 4, 0, 243, 0, -22, 0, 0,
+ax_anim 3, 0, 243, 0, -21, 0, 0,
+ax_anim 2, 0, 243, 0, -17, 0, 0,
+ax_anim 1, 0, 243, 0, -11, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_11_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 245, 0, -10, 0, 0,
+ax_anim 2, 0, 245, 0, -16, 0, 0,
+ax_anim 3, 0, 245, 0, -20, 0, 0,
+ax_anim 4, 0, 245, 0, -21, 0, 0,
+ax_anim 4, 0, 246, 0, -23, 0, 0,
+ax_anim 3, 0, 246, 0, -22, 0, 0,
+ax_anim 2, 0, 246, 0, -18, 0, 0,
+ax_anim 1, 0, 246, 0, -12, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_11_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -10, 0, 0,
+ax_anim 2, 0, 248, 0, -16, 0, 0,
+ax_anim 3, 0, 248, 0, -20, 0, 0,
+ax_anim 4, 0, 248, 0, -21, 0, 0,
+ax_anim 4, 0, 249, 0, -23, 0, 0,
+ax_anim 3, 0, 249, 0, -22, 0, 0,
+ax_anim 2, 0, 249, 0, -18, 0, 0,
+ax_anim 1, 0, 249, 0, -12, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_12_1:
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 0, 1, 0,
+ax_anim 2, 1, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_12_2:
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 1, -1, 1, 0,
+ax_anim 2, 1, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_12_3:
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -1, 0, -1,
+ax_anim 2, 1, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_12_4:
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, -1, -1, -1, -1,
+ax_anim 2, 1, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_12_5:
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 1, 0, 1, 0,
+ax_anim 2, 1, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_12_6:
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 1, -1, 1, -1,
+ax_anim 2, 1, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_12_7:
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -1, 0, -1,
+ax_anim 2, 1, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_12_8:
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, -1, -1, -1, -1,
+ax_anim 2, 1, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSnubbullAnims_13_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_13_2:
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 265, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_13_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_13_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_13_5:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_13_6:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_13_7:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullAnims_13_8:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 265, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sSnubbullGfx1:
+.incbin "baserom.gba", 0xE73D20, 0x200
+sSnubbullSprites1:
+ax_sprite sSnubbullGfx1, 0x200
+ax_sprite_terminator
+sSnubbullGfx2:
+.incbin "baserom.gba", 0xE73F30, 0x200
+sSnubbullSprites2:
+ax_sprite sSnubbullGfx2, 0x200
+ax_sprite_terminator
+sSnubbullGfx3:
+.incbin "baserom.gba", 0xE74140, 0x200
+sSnubbullSprites3:
+ax_sprite sSnubbullGfx3, 0x200
+ax_sprite_terminator
+sSnubbullGfx4:
+.incbin "baserom.gba", 0xE74350, 0x200
+sSnubbullSprites4:
+ax_sprite sSnubbullGfx4, 0x200
+ax_sprite_terminator
+sSnubbullGfx5:
+.incbin "baserom.gba", 0xE74560, 0x200
+sSnubbullSprites5:
+ax_sprite sSnubbullGfx5, 0x200
+ax_sprite_terminator
+sSnubbullGfx6:
+.incbin "baserom.gba", 0xE74770, 0x200
+sSnubbullSprites6:
+ax_sprite sSnubbullGfx6, 0x200
+ax_sprite_terminator
+sSnubbullGfx7:
+.incbin "baserom.gba", 0xE74980, 0x200
+sSnubbullSprites7:
+ax_sprite sSnubbullGfx7, 0x200
+ax_sprite_terminator
+sSnubbullGfx8:
+.incbin "baserom.gba", 0xE74B90, 0x200
+sSnubbullSprites8:
+ax_sprite sSnubbullGfx8, 0x200
+ax_sprite_terminator
+sSnubbullGfx9:
+.incbin "baserom.gba", 0xE74DA0, 0x200
+sSnubbullSprites9:
+ax_sprite sSnubbullGfx9, 0x200
+ax_sprite_terminator
+sSnubbullGfx10:
+.incbin "baserom.gba", 0xE74FB0, 0x200
+sSnubbullSprites10:
+ax_sprite sSnubbullGfx10, 0x200
+ax_sprite_terminator
+sSnubbullGfx11:
+.incbin "baserom.gba", 0xE751C0, 0x200
+sSnubbullSprites11:
+ax_sprite sSnubbullGfx11, 0x200
+ax_sprite_terminator
+sSnubbullGfx12:
+.incbin "baserom.gba", 0xE753D0, 0x200
+sSnubbullSprites12:
+ax_sprite sSnubbullGfx12, 0x200
+ax_sprite_terminator
+sSnubbullGfx13:
+.incbin "baserom.gba", 0xE755E0, 0x200
+sSnubbullSprites13:
+ax_sprite sSnubbullGfx13, 0x200
+ax_sprite_terminator
+sSnubbullGfx14:
+.incbin "baserom.gba", 0xE757F0, 0x200
+sSnubbullSprites14:
+ax_sprite sSnubbullGfx14, 0x200
+ax_sprite_terminator
+sSnubbullGfx15:
+.incbin "baserom.gba", 0xE75A00, 0x200
+sSnubbullSprites15:
+ax_sprite sSnubbullGfx15, 0x200
+ax_sprite_terminator
+sSnubbullGfx16:
+.incbin "baserom.gba", 0xE75C10, 0x60
+sSnubbullGfx16_1:
+.incbin "baserom.gba", 0xE75C70, 0x60
+sSnubbullGfx16_2:
+.incbin "baserom.gba", 0xE75CD0, 0x60
+sSnubbullSprites16:
+ax_sprite sSnubbullGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx17:
+.incbin "baserom.gba", 0xE75D68, 0x60
+sSnubbullGfx17_1:
+.incbin "baserom.gba", 0xE75DC8, 0x60
+sSnubbullGfx17_2:
+.incbin "baserom.gba", 0xE75E28, 0x60
+sSnubbullSprites17:
+ax_sprite sSnubbullGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx18:
+.incbin "baserom.gba", 0xE75EC0, 0x60
+sSnubbullGfx18_1:
+.incbin "baserom.gba", 0xE75F20, 0x60
+sSnubbullGfx18_2:
+.incbin "baserom.gba", 0xE75F80, 0x60
+sSnubbullSprites18:
+ax_sprite sSnubbullGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx19:
+.incbin "baserom.gba", 0xE76018, 0x60
+sSnubbullGfx19_1:
+.incbin "baserom.gba", 0xE76078, 0x60
+sSnubbullGfx19_2:
+.incbin "baserom.gba", 0xE760D8, 0x60
+sSnubbullSprites19:
+ax_sprite sSnubbullGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx20:
+.incbin "baserom.gba", 0xE76170, 0x40
+sSnubbullGfx20_1:
+.incbin "baserom.gba", 0xE761B0, 0x60
+sSnubbullGfx20_2:
+.incbin "baserom.gba", 0xE76210, 0x60
+sSnubbullSprites20:
+ax_sprite sSnubbullGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSnubbullGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx21:
+.incbin "baserom.gba", 0xE762A8, 0x60
+sSnubbullGfx21_1:
+.incbin "baserom.gba", 0xE76308, 0x60
+sSnubbullGfx21_2:
+.incbin "baserom.gba", 0xE76368, 0x60
+sSnubbullSprites21:
+ax_sprite sSnubbullGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx22:
+.incbin "baserom.gba", 0xE76400, 0x60
+sSnubbullGfx22_1:
+.incbin "baserom.gba", 0xE76460, 0x60
+sSnubbullGfx22_2:
+.incbin "baserom.gba", 0xE764C0, 0x40
+sSnubbullSprites22:
+ax_sprite sSnubbullGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSnubbullGfx22_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx23:
+.incbin "baserom.gba", 0xE76538, 0x60
+sSnubbullGfx23_1:
+.incbin "baserom.gba", 0xE76598, 0x60
+sSnubbullGfx23_2:
+.incbin "baserom.gba", 0xE765F8, 0x40
+sSnubbullSprites23:
+ax_sprite sSnubbullGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSnubbullGfx23_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx24:
+.incbin "baserom.gba", 0xE76670, 0x60
+sSnubbullGfx24_1:
+.incbin "baserom.gba", 0xE766D0, 0x60
+sSnubbullGfx24_2:
+.incbin "baserom.gba", 0xE76730, 0x60
+sSnubbullSprites24:
+ax_sprite sSnubbullGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx25:
+.incbin "baserom.gba", 0xE767C8, 0x60
+sSnubbullGfx25_1:
+.incbin "baserom.gba", 0xE76828, 0x60
+sSnubbullGfx25_2:
+.incbin "baserom.gba", 0xE76888, 0x60
+sSnubbullSprites25:
+ax_sprite sSnubbullGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSnubbullGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSnubbullGfx26:
+.incbin "baserom.gba", 0xE76920, 0x200
+sSnubbullSprites26:
+ax_sprite sSnubbullGfx26, 0x200
+ax_sprite_terminator
+sSnubbullGfx27:
+.incbin "baserom.gba", 0xE76B30, 0x200
+sSnubbullSprites27:
+ax_sprite sSnubbullGfx27, 0x200
+ax_sprite_terminator
+sSnubbullGfx28:
+.incbin "baserom.gba", 0xE76D40, 0x200
+sSnubbullSprites28:
+ax_sprite sSnubbullGfx28, 0x200
+ax_sprite_terminator
+sSnubbullGfx29:
+.incbin "baserom.gba", 0xE76F50, 0x200
+sSnubbullSprites29:
+ax_sprite sSnubbullGfx29, 0x200
+ax_sprite_terminator
+sSnubbullGfx30:
+.incbin "baserom.gba", 0xE77160, 0x200
+sSnubbullSprites30:
+ax_sprite sSnubbullGfx30, 0x200
+ax_sprite_terminator
+sSnubbullGfx31:
+.incbin "baserom.gba", 0xE77370, 0x200
+sSnubbullSprites31:
+ax_sprite sSnubbullGfx31, 0x200
+ax_sprite_terminator
+sSnubbullGfx32:
+.incbin "baserom.gba", 0xE77580, 0x200
+sSnubbullSprites32:
+ax_sprite sSnubbullGfx32, 0x200
+ax_sprite_terminator
+sAxPosesSnubbull:
+.4byte sSnubbullPose1
+.4byte sSnubbullPose2
+.4byte sSnubbullPose3
+.4byte sSnubbullPose4
+.4byte sSnubbullPose5
+.4byte sSnubbullPose6
+.4byte sSnubbullPose7
+.4byte sSnubbullPose8
+.4byte sSnubbullPose9
+.4byte sSnubbullPose10
+.4byte sSnubbullPose11
+.4byte sSnubbullPose12
+.4byte sSnubbullPose13
+.4byte sSnubbullPose14
+.4byte sSnubbullPose15
+.4byte sSnubbullPose16
+.4byte sSnubbullPose17
+.4byte sSnubbullPose18
+.4byte sSnubbullPose19
+.4byte sSnubbullPose20
+.4byte sSnubbullPose21
+.4byte sSnubbullPose22
+.4byte sSnubbullPose23
+.4byte sSnubbullPose24
+.4byte sSnubbullPose25
+.4byte sSnubbullPose26
+.4byte sSnubbullPose27
+.4byte sSnubbullPose28
+.4byte sSnubbullPose29
+.4byte sSnubbullPose30
+.4byte sSnubbullPose31
+.4byte sSnubbullPose32
+.4byte sSnubbullPose33
+.4byte sSnubbullPose34
+.4byte sSnubbullPose35
+.4byte sSnubbullPose36
+.4byte sSnubbullPose37
+.4byte sSnubbullPose38
+.4byte sSnubbullPose39
+.4byte sSnubbullPose40
+.4byte sSnubbullPose41
+.4byte sSnubbullPose42
+.4byte sSnubbullPose43
+.4byte sSnubbullPose44
+.4byte sSnubbullPose45
+.4byte sSnubbullPose46
+.4byte sSnubbullPose47
+.4byte sSnubbullPose48
+.4byte sSnubbullPose49
+.4byte sSnubbullPose50
+.4byte sSnubbullPose51
+.4byte sSnubbullPose52
+.4byte sSnubbullPose53
+.4byte sSnubbullPose54
+.4byte sSnubbullPose55
+.4byte sSnubbullPose56
+.4byte sSnubbullPose57
+.4byte sSnubbullPose58
+.4byte sSnubbullPose59
+.4byte sSnubbullPose60
+.4byte sSnubbullPose61
+.4byte sSnubbullPose62
+.4byte sSnubbullPose63
+.4byte sSnubbullPose64
+.4byte sSnubbullPose65
+.4byte sSnubbullPose66
+.4byte sSnubbullPose67
+.4byte sSnubbullPose68
+.4byte sSnubbullPose69
+.4byte sSnubbullPose70
+.4byte sSnubbullPose71
+.4byte sSnubbullPose72
+.4byte sSnubbullPose73
+.4byte sSnubbullPose74
+.4byte sSnubbullPose75
+.4byte sSnubbullPose76
+.4byte sSnubbullPose77
+.4byte sSnubbullPose78
+.4byte sSnubbullPose79
+.4byte sSnubbullPose80
+.4byte sSnubbullPose81
+.4byte sSnubbullPose82
+.4byte sSnubbullPose83
+.4byte sSnubbullPose84
+.4byte sSnubbullPose85
+.4byte sSnubbullPose86
+.4byte sSnubbullPose87
+.4byte sSnubbullPose88
+.4byte sSnubbullPose89
+.4byte sSnubbullPose90
+.4byte sSnubbullPose91
+.4byte sSnubbullPose92
+.4byte sSnubbullPose93
+.4byte sSnubbullPose94
+.4byte sSnubbullPose95
+.4byte sSnubbullPose96
+.4byte sSnubbullPose97
+.4byte sSnubbullPose98
+.4byte sSnubbullPose99
+.4byte sSnubbullPose100
+.4byte sSnubbullPose101
+.4byte sSnubbullPose102
+.4byte sSnubbullPose103
+.4byte sSnubbullPose104
+.4byte sSnubbullPose105
+.4byte sSnubbullPose106
+.4byte sSnubbullPose107
+.4byte sSnubbullPose108
+.4byte sSnubbullPose109
+.4byte sSnubbullPose110
+.4byte sSnubbullPose111
+.4byte sSnubbullPose112
+.4byte sSnubbullPose113
+.4byte sSnubbullPose114
+.4byte sSnubbullPose115
+.4byte sSnubbullPose116
+.4byte sSnubbullPose117
+.4byte sSnubbullPose118
+.4byte sSnubbullPose119
+.4byte sSnubbullPose120
+.4byte sSnubbullPose121
+.4byte sSnubbullPose122
+.4byte sSnubbullPose123
+.4byte sSnubbullPose124
+.4byte sSnubbullPose125
+.4byte sSnubbullPose126
+.4byte sSnubbullPose127
+.4byte sSnubbullPose128
+.4byte sSnubbullPose129
+.4byte sSnubbullPose130
+.4byte sSnubbullPose131
+.4byte sSnubbullPose132
+.4byte sSnubbullPose133
+.4byte sSnubbullPose134
+.4byte sSnubbullPose135
+.4byte sSnubbullPose136
+.4byte sSnubbullPose137
+.4byte sSnubbullPose138
+.4byte sSnubbullPose139
+.4byte sSnubbullPose140
+.4byte sSnubbullPose141
+.4byte sSnubbullPose142
+.4byte sSnubbullPose143
+.4byte sSnubbullPose144
+.4byte sSnubbullPose145
+.4byte sSnubbullPose146
+.4byte sSnubbullPose147
+.4byte sSnubbullPose148
+.4byte sSnubbullPose149
+.4byte sSnubbullPose150
+.4byte sSnubbullPose151
+.4byte sSnubbullPose152
+.4byte sSnubbullPose153
+.4byte sSnubbullPose154
+.4byte sSnubbullPose155
+.4byte sSnubbullPose156
+.4byte sSnubbullPose157
+.4byte sSnubbullPose158
+.4byte sSnubbullPose159
+.4byte sSnubbullPose160
+.4byte sSnubbullPose161
+.4byte sSnubbullPose162
+.4byte sSnubbullPose163
+.4byte sSnubbullPose164
+.4byte sSnubbullPose165
+.4byte sSnubbullPose166
+.4byte sSnubbullPose167
+.4byte sSnubbullPose168
+.4byte sSnubbullPose169
+.4byte sSnubbullPose170
+.4byte sSnubbullPose171
+.4byte sSnubbullPose172
+.4byte sSnubbullPose173
+.4byte sSnubbullPose174
+.4byte sSnubbullPose175
+.4byte sSnubbullPose176
+.4byte sSnubbullPose177
+.4byte sSnubbullPose178
+.4byte sSnubbullPose179
+.4byte sSnubbullPose180
+.4byte sSnubbullPose181
+.4byte sSnubbullPose182
+.4byte sSnubbullPose183
+.4byte sSnubbullPose184
+.4byte sSnubbullPose185
+.4byte sSnubbullPose186
+.4byte sSnubbullPose187
+.4byte sSnubbullPose188
+.4byte sSnubbullPose189
+.4byte sSnubbullPose190
+.4byte sSnubbullPose191
+.4byte sSnubbullPose192
+.4byte sSnubbullPose193
+.4byte sSnubbullPose194
+.4byte sSnubbullPose195
+.4byte sSnubbullPose196
+.4byte sSnubbullPose197
+.4byte sSnubbullPose198
+.4byte sSnubbullPose199
+.4byte sSnubbullPose200
+.4byte sSnubbullPose201
+.4byte sSnubbullPose202
+.4byte sSnubbullPose203
+.4byte sSnubbullPose204
+.4byte sSnubbullPose205
+.4byte sSnubbullPose206
+.4byte sSnubbullPose207
+.4byte sSnubbullPose208
+.4byte sSnubbullPose209
+.4byte sSnubbullPose210
+.4byte sSnubbullPose211
+.4byte sSnubbullPose212
+.4byte sSnubbullPose213
+.4byte sSnubbullPose214
+.4byte sSnubbullPose215
+.4byte sSnubbullPose216
+.4byte sSnubbullPose217
+.4byte sSnubbullPose218
+.4byte sSnubbullPose219
+.4byte sSnubbullPose220
+.4byte sSnubbullPose221
+.4byte sSnubbullPose222
+.4byte sSnubbullPose223
+.4byte sSnubbullPose224
+.4byte sSnubbullPose225
+.4byte sSnubbullPose226
+.4byte sSnubbullPose227
+.4byte sSnubbullPose228
+.4byte sSnubbullPose229
+.4byte sSnubbullPose230
+.4byte sSnubbullPose231
+.4byte sSnubbullPose232
+.4byte sSnubbullPose233
+.4byte sSnubbullPose234
+.4byte sSnubbullPose235
+.4byte sSnubbullPose236
+.4byte sSnubbullPose237
+.4byte sSnubbullPose238
+.4byte sSnubbullPose239
+.4byte sSnubbullPose240
+.4byte sSnubbullPose241
+.4byte sSnubbullPose242
+.4byte sSnubbullPose243
+.4byte sSnubbullPose244
+.4byte sSnubbullPose245
+.4byte sSnubbullPose246
+.4byte sSnubbullPose247
+.4byte sSnubbullPose248
+.4byte sSnubbullPose249
+.4byte sSnubbullPose250
+.4byte sSnubbullPose251
+.4byte sSnubbullPose252
+.4byte sSnubbullPose253
+.4byte sSnubbullPose254
+.4byte sSnubbullPose255
+.4byte sSnubbullPose256
+.4byte sSnubbullPose257
+.4byte sSnubbullPose258
+.4byte sSnubbullPose259
+.4byte sSnubbullPose260
+.4byte sSnubbullPose261
+.4byte sSnubbullPose262
+.4byte sSnubbullPose263
+.4byte sSnubbullPose264
+.4byte sSnubbullPose265
+.4byte sSnubbullPose266
+sAxPositionsSnubbull:
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -3, 	   5,   -5, 	  -1,   -6
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -6, 	   4,   -5, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -7, 	   5,   -6, 	  -6,   -3, 	   0,   -7
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    4,   -7, 	  -2,   -2, 	   1,   -3, 	  -1,   -7
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    5,  -10, 	  -7,   -4, 	   4,   -4, 	  -2,   -8
+.2byte    5,   -9, 	  -4,   -4, 	   0,   -3, 	  -2,   -8
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -2,  -11, 	  -8,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    1,  -11, 	  -7,   -4, 	   6,   -6, 	   0,   -7
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -7,  -10, 	   5,   -4, 	  -6,   -4, 	   0,   -8
+.2byte   -7,   -9, 	   2,   -4, 	  -2,   -3, 	   0,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -6,   -7, 	   0,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -2, 	   1,   -3, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -3, 	  -2,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   4,   -3, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -3, 	   5,   -5, 	  -1,   -6
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -6, 	   4,   -5, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -7, 	   5,   -6, 	  -6,   -3, 	   0,   -7
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    4,   -7, 	  -2,   -2, 	   1,   -3, 	  -1,   -7
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    5,  -10, 	  -7,   -4, 	   4,   -4, 	  -2,   -8
+.2byte    5,   -9, 	  -4,   -4, 	   0,   -3, 	  -2,   -8
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -2,  -11, 	  -8,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    1,  -11, 	  -7,   -4, 	   6,   -6, 	   0,   -7
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -7,  -10, 	   5,   -4, 	  -6,   -4, 	   0,   -8
+.2byte   -7,   -9, 	   2,   -4, 	  -2,   -3, 	   0,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -6,   -7, 	   0,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -2, 	   1,   -3, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -3, 	  -2,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   4,   -3, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -3, 	   5,   -5, 	  -1,   -6
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -6, 	   4,   -5, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -7, 	   5,   -6, 	  -6,   -3, 	   0,   -7
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    4,   -7, 	  -2,   -2, 	   1,   -3, 	  -1,   -7
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    5,  -10, 	  -7,   -4, 	   4,   -4, 	  -2,   -8
+.2byte    5,   -9, 	  -4,   -4, 	   0,   -3, 	  -2,   -8
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -2,  -11, 	  -8,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    1,  -11, 	  -7,   -4, 	   6,   -6, 	   0,   -7
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -7,  -10, 	   5,   -4, 	  -6,   -4, 	   0,   -8
+.2byte   -7,   -9, 	   2,   -4, 	  -2,   -3, 	   0,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -6,   -7, 	   0,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -2, 	   1,   -3, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -3, 	  -2,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   4,   -3, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -4, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    6,   -5, 	   5,   -4, 	  -4,   -5, 	   2,   -6
+.2byte    6,   -5, 	   6,   -7, 	  -3,   -5, 	   2,   -6
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    9,   -8, 	   2,   -8, 	   0,   -5, 	   4,   -8
+.2byte    9,   -8, 	   4,   -9, 	   1,   -7, 	   5,   -9
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    5,  -12, 	  -5,   -7, 	   4,   -5, 	   1,   -8
+.2byte    7,  -10, 	  -3,  -10, 	   5,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,   -9
+.2byte   -1,  -11, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -8,  -12, 	   2,   -7, 	  -7,   -5, 	  -4,   -8
+.2byte  -10,  -10, 	   0,  -10, 	  -8,   -7, 	  -3,   -9
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte  -11,   -8, 	  -4,   -8, 	  -2,   -5, 	  -6,   -8
+.2byte  -11,   -8, 	  -6,   -9, 	  -3,   -7, 	  -7,   -9
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -8,   -5, 	  -7,   -4, 	   2,   -5, 	  -4,   -6
+.2byte   -8,   -5, 	  -8,   -7, 	   1,   -5, 	  -4,   -6
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -3, 	   5,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -6, 	   4,   -5, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -7, 	   5,   -6, 	  -6,   -3, 	   0,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    4,   -7, 	  -2,   -2, 	   1,   -3, 	  -1,   -7
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    5,  -10, 	  -7,   -4, 	   4,   -4, 	  -2,   -8
+.2byte    5,   -9, 	  -4,   -4, 	   0,   -3, 	  -2,   -8
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte   -2,  -11, 	  -8,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    1,  -11, 	  -7,   -4, 	   6,   -6, 	   0,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte   -7,  -10, 	   5,   -4, 	  -6,   -4, 	   0,   -8
+.2byte   -7,   -9, 	   2,   -4, 	  -2,   -3, 	   0,   -8
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte   -6,   -7, 	   0,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -2, 	   1,   -3, 	  -1,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -3, 	  -2,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   4,   -3, 	  -2,   -7
+.2byte   -3,   -6, 	  -6,   -5, 	   5,   -3, 	  -1,   -5
+.2byte   -3,   -5, 	  -6,   -5, 	   5,   -3, 	  -1,   -5
+.2byte    0,   -9, 	  -5,   -8, 	   5,   -8, 	   0,   -8
+.2byte    0,   -9, 	   2,   -8, 	  -4,   -6, 	  -2,  -10
+.2byte    3,  -11, 	   2,  -11, 	   0,   -7, 	  -1,   -7
+.2byte    2,  -12, 	   0,  -10, 	   3,   -9, 	   0,   -7
+.2byte    0,   -9, 	  -3,   -8, 	   3,   -8, 	   0,   -6
+.2byte   -3,  -12, 	  -1,  -10, 	  -4,   -9, 	  -1,   -7
+.2byte   -4,  -11, 	  -3,  -11, 	  -1,   -7, 	   0,   -7
+.2byte   -1,   -9, 	  -3,   -8, 	   3,   -6, 	   1,  -10
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -3, 	   5,   -5, 	  -1,   -6
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    2,   -6, 	   4,   -5, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -7, 	   5,   -6, 	  -6,   -3, 	   0,   -7
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    4,   -7, 	  -2,   -2, 	   1,   -3, 	  -1,   -7
+.2byte    3,   -7, 	   1,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    5,  -10, 	  -7,   -4, 	   4,   -4, 	  -2,   -8
+.2byte    5,   -9, 	  -4,   -4, 	   0,   -3, 	  -2,   -8
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -2,  -11, 	  -8,   -6, 	   5,   -4, 	  -1,   -7
+.2byte    1,  -11, 	  -7,   -4, 	   6,   -6, 	   0,   -7
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -7,  -10, 	   5,   -4, 	  -6,   -4, 	   0,   -8
+.2byte   -7,   -9, 	   2,   -4, 	  -2,   -3, 	   0,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -6,   -7, 	   0,   -2, 	  -3,   -3, 	  -1,   -7
+.2byte   -5,   -7, 	  -3,   -2, 	   1,   -3, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -4,   -6, 	  -6,   -5, 	   1,   -3, 	  -2,   -6
+.2byte   -4,   -7, 	  -7,   -6, 	   4,   -3, 	  -2,   -7
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte   -1,   -4, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte    5,   -5, 	   4,   -4, 	  -5,   -5, 	   1,   -6
+.2byte    7,   -8, 	   0,   -8, 	  -2,   -5, 	   2,   -8
+.2byte    5,  -12, 	  -5,   -7, 	   4,   -5, 	   1,   -8
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,   -9
+.2byte   -5,  -12, 	   5,   -7, 	  -4,   -5, 	  -1,   -8
+.2byte   -7,   -8, 	   0,   -8, 	   2,   -5, 	  -2,   -8
+.2byte   -6,   -5, 	  -5,   -4, 	   4,   -5, 	  -2,   -6
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -1,   -4, 	  -8,   -5, 	   6,   -5, 	  -1,   -6
+.2byte   -1,   -5, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+.2byte    4,   -5, 	   3,   -4, 	  -6,   -5, 	   0,   -6
+.2byte    4,   -5, 	   4,   -7, 	  -5,   -5, 	   0,   -6
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -8, 	  -3,   -5, 	   1,   -8
+.2byte    6,   -8, 	   1,   -9, 	  -2,   -7, 	   2,   -9
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,  -12, 	  -6,   -7, 	   3,   -5, 	   0,   -8
+.2byte    6,  -10, 	  -4,  -10, 	   4,   -7, 	  -1,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte   -1,  -10, 	  -7,   -8, 	   5,   -8, 	  -1,   -9
+.2byte   -1,  -11, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -6,  -12, 	   4,   -7, 	  -5,   -5, 	  -2,   -8
+.2byte   -8,  -10, 	   2,  -10, 	  -6,   -7, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -8,   -8, 	  -1,   -8, 	   1,   -5, 	  -3,   -8
+.2byte   -8,   -8, 	  -3,   -9, 	   0,   -7, 	  -4,   -9
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -5, 	  -5,   -4, 	   4,   -5, 	  -2,   -6
+.2byte   -6,   -5, 	  -6,   -7, 	   3,   -5, 	  -2,   -6
+.2byte   -1,   -5, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -6,   -5, 	  -6,   -7, 	   3,   -5, 	  -2,   -6
+.2byte   -7,   -8, 	  -2,   -9, 	   1,   -7, 	  -3,   -9
+.2byte   -7,  -10, 	   3,  -10, 	  -5,   -7, 	   0,   -9
+.2byte   -1,  -11, 	  -7,  -10, 	   5,  -10, 	  -1,  -10
+.2byte    7,  -10, 	  -3,  -10, 	   5,   -7, 	   0,   -9
+.2byte    7,   -8, 	   2,   -9, 	  -1,   -7, 	   3,   -9
+.2byte    5,   -5, 	   5,   -7, 	  -4,   -5, 	   1,   -6
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,   -6, 	   3,   -4, 	  -2,   -8
+.2byte   -6,   -9, 	  -3,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte   -7,  -11, 	   4,   -5, 	  -4,   -4, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -5, 	   6,   -5, 	  -1,   -8
+.2byte    5,  -11, 	  -6,   -5, 	   2,   -4, 	  -2,   -9
+.2byte    4,   -9, 	   1,   -4, 	  -1,   -4, 	  -1,   -8
+.2byte    2,   -8, 	   4,   -6, 	  -5,   -4, 	   0,   -8
+sSnubbullAnimTable1:
+.4byte sSnubbullAnims_1_1
+.4byte sSnubbullAnims_1_2
+.4byte sSnubbullAnims_1_3
+.4byte sSnubbullAnims_1_4
+.4byte sSnubbullAnims_1_5
+.4byte sSnubbullAnims_1_6
+.4byte sSnubbullAnims_1_7
+.4byte sSnubbullAnims_1_8
+sSnubbullAnimTable2:
+.4byte sSnubbullAnims_2_1
+.4byte sSnubbullAnims_2_2
+.4byte sSnubbullAnims_2_3
+.4byte sSnubbullAnims_2_4
+.4byte sSnubbullAnims_2_5
+.4byte sSnubbullAnims_2_6
+.4byte sSnubbullAnims_2_7
+.4byte sSnubbullAnims_2_8
+sSnubbullAnimTable3:
+.4byte sSnubbullAnims_3_1
+.4byte sSnubbullAnims_3_2
+.4byte sSnubbullAnims_3_3
+.4byte sSnubbullAnims_3_4
+.4byte sSnubbullAnims_3_5
+.4byte sSnubbullAnims_3_6
+.4byte sSnubbullAnims_3_7
+.4byte sSnubbullAnims_3_8
+sSnubbullAnimTable4:
+.4byte sSnubbullAnims_4_1
+.4byte sSnubbullAnims_4_2
+.4byte sSnubbullAnims_4_3
+.4byte sSnubbullAnims_4_4
+.4byte sSnubbullAnims_4_5
+.4byte sSnubbullAnims_4_6
+.4byte sSnubbullAnims_4_7
+.4byte sSnubbullAnims_4_8
+sSnubbullAnimTable5:
+.4byte sSnubbullAnims_5_1
+.4byte sSnubbullAnims_5_2
+.4byte sSnubbullAnims_5_3
+.4byte sSnubbullAnims_5_4
+.4byte sSnubbullAnims_5_5
+.4byte sSnubbullAnims_5_6
+.4byte sSnubbullAnims_5_7
+.4byte sSnubbullAnims_5_8
+sSnubbullAnimTable6:
+.4byte sSnubbullAnims_6_1
+.4byte sSnubbullAnims_6_1
+.4byte sSnubbullAnims_6_1
+.4byte sSnubbullAnims_6_1
+.4byte sSnubbullAnims_6_1
+.4byte sSnubbullAnims_6_1
+.4byte sSnubbullAnims_6_1
+.4byte sSnubbullAnims_6_1
+sSnubbullAnimTable7:
+.4byte sSnubbullAnims_7_1
+.4byte sSnubbullAnims_7_2
+.4byte sSnubbullAnims_7_3
+.4byte sSnubbullAnims_7_4
+.4byte sSnubbullAnims_7_5
+.4byte sSnubbullAnims_7_6
+.4byte sSnubbullAnims_7_7
+.4byte sSnubbullAnims_7_8
+sSnubbullAnimTable8:
+.4byte sSnubbullAnims_8_1
+.4byte sSnubbullAnims_8_2
+.4byte sSnubbullAnims_8_3
+.4byte sSnubbullAnims_8_4
+.4byte sSnubbullAnims_8_5
+.4byte sSnubbullAnims_8_6
+.4byte sSnubbullAnims_8_7
+.4byte sSnubbullAnims_8_8
+sSnubbullAnimTable9:
+.4byte sSnubbullAnims_9_1
+.4byte sSnubbullAnims_9_2
+.4byte sSnubbullAnims_9_3
+.4byte sSnubbullAnims_9_4
+.4byte sSnubbullAnims_9_5
+.4byte sSnubbullAnims_9_6
+.4byte sSnubbullAnims_9_7
+.4byte sSnubbullAnims_9_8
+sSnubbullAnimTable10:
+.4byte sSnubbullAnims_10_1
+.4byte sSnubbullAnims_10_2
+.4byte sSnubbullAnims_10_3
+.4byte sSnubbullAnims_10_4
+.4byte sSnubbullAnims_10_5
+.4byte sSnubbullAnims_10_6
+.4byte sSnubbullAnims_10_7
+.4byte sSnubbullAnims_10_8
+sSnubbullAnimTable11:
+.4byte sSnubbullAnims_11_1
+.4byte sSnubbullAnims_11_2
+.4byte sSnubbullAnims_11_3
+.4byte sSnubbullAnims_11_4
+.4byte sSnubbullAnims_11_5
+.4byte sSnubbullAnims_11_6
+.4byte sSnubbullAnims_11_7
+.4byte sSnubbullAnims_11_8
+sSnubbullAnimTable12:
+.4byte sSnubbullAnims_12_1
+.4byte sSnubbullAnims_12_2
+.4byte sSnubbullAnims_12_3
+.4byte sSnubbullAnims_12_4
+.4byte sSnubbullAnims_12_5
+.4byte sSnubbullAnims_12_6
+.4byte sSnubbullAnims_12_7
+.4byte sSnubbullAnims_12_8
+sSnubbullAnimTable13:
+.4byte sSnubbullAnims_13_1
+.4byte sSnubbullAnims_13_2
+.4byte sSnubbullAnims_13_3
+.4byte sSnubbullAnims_13_4
+.4byte sSnubbullAnims_13_5
+.4byte sSnubbullAnims_13_6
+.4byte sSnubbullAnims_13_7
+.4byte sSnubbullAnims_13_8
+sAxAnimationsSnubbull:
+.4byte sSnubbullAnimTable1
+.4byte sSnubbullAnimTable2
+.4byte sSnubbullAnimTable3
+.4byte sSnubbullAnimTable4
+.4byte sSnubbullAnimTable5
+.4byte sSnubbullAnimTable6
+.4byte sSnubbullAnimTable7
+.4byte sSnubbullAnimTable8
+.4byte sSnubbullAnimTable9
+.4byte sSnubbullAnimTable10
+.4byte sSnubbullAnimTable11
+.4byte sSnubbullAnimTable12
+.4byte sSnubbullAnimTable13
+sAxSpritesSnubbull:
+.4byte sSnubbullSprites1
+.4byte sSnubbullSprites2
+.4byte sSnubbullSprites3
+.4byte sSnubbullSprites4
+.4byte sSnubbullSprites5
+.4byte sSnubbullSprites6
+.4byte sSnubbullSprites7
+.4byte sSnubbullSprites8
+.4byte sSnubbullSprites9
+.4byte sSnubbullSprites10
+.4byte sSnubbullSprites11
+.4byte sSnubbullSprites12
+.4byte sSnubbullSprites13
+.4byte sSnubbullSprites14
+.4byte sSnubbullSprites15
+.4byte sSnubbullSprites16
+.4byte sSnubbullSprites17
+.4byte sSnubbullSprites18
+.4byte sSnubbullSprites19
+.4byte sSnubbullSprites20
+.4byte sSnubbullSprites21
+.4byte sSnubbullSprites22
+.4byte sSnubbullSprites23
+.4byte sSnubbullSprites24
+.4byte sSnubbullSprites25
+.4byte sSnubbullSprites26
+.4byte sSnubbullSprites27
+.4byte sSnubbullSprites28
+.4byte sSnubbullSprites29
+.4byte sSnubbullSprites30
+.4byte sSnubbullSprites31
+.4byte sSnubbullSprites32
+sAxMainSnubbull:
+ax_main sAxPosesSnubbull, sAxAnimationsSnubbull, 13, sAxSpritesSnubbull, sAxPositionsSnubbull

--- a/data/ax/solrock.inc
+++ b/data/ax/solrock.inc
@@ -1,0 +1,2261 @@
+.global gAxSolrock
+gAxSolrock:
+ax_siro sAxMainSolrock
+sSolrockPose1:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose3:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose4:
+ax_pose 3, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose5:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose6:
+ax_pose 5, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose7:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose8:
+ax_pose 7, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose9:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose10:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose11:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose12:
+ax_pose 7, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose13:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose14:
+ax_pose 5, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose15:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose16:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose17:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose18:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose19:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose20:
+ax_pose 3, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose21:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose22:
+ax_pose 5, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose23:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose24:
+ax_pose 7, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose25:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose26:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose27:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose28:
+ax_pose 7, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose29:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose30:
+ax_pose 5, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose31:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose32:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose33:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose34:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose35:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose36:
+ax_pose 3, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose37:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose38:
+ax_pose 5, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose39:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose40:
+ax_pose 7, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose41:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose42:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose43:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose44:
+ax_pose 7, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose45:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose46:
+ax_pose 5, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose47:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose48:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose49:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose50:
+ax_pose 10, 0x41e6, 0x80ee, 0x4c00
+ax_pose 11, 0x41f6, 0x40ee, 0x4c08
+ax_pose 12, 0x01fe, 0x00fe, 0x4c0c
+ax_pose_terminator
+sSolrockPose51:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose52:
+ax_pose 13, 0x81e7, 0x90fa, 0x4c00
+ax_pose 14, 0x81ef, 0x10f2, 0x4c08
+ax_pose_terminator
+sSolrockPose53:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose54:
+ax_pose 15, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose55:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose56:
+ax_pose 16, 0x81e7, 0x90f5, 0x4c00
+ax_pose 17, 0x81ef, 0x1105, 0x4c08
+ax_pose_terminator
+sSolrockPose57:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose58:
+ax_pose 18, 0x41eb, 0x80ef, 0x4c00
+ax_pose 19, 0x01fb, 0x00ff, 0x4c08
+ax_pose_terminator
+sSolrockPose59:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose60:
+ax_pose 16, 0x81e7, 0x80fc, 0x4c00
+ax_pose 17, 0x81ef, 0x00f4, 0x4c08
+ax_pose_terminator
+sSolrockPose61:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose62:
+ax_pose 15, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose63:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose64:
+ax_pose 13, 0x81e7, 0x80f7, 0x4c00
+ax_pose 14, 0x81ef, 0x0107, 0x4c08
+ax_pose_terminator
+sSolrockPose65:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose66:
+ax_pose 10, 0x41e6, 0x80ee, 0x4c00
+ax_pose 11, 0x41f6, 0x40ee, 0x4c08
+ax_pose 12, 0x01fe, 0x00fe, 0x4c0c
+ax_pose_terminator
+sSolrockPose67:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose68:
+ax_pose 13, 0x81e7, 0x90fa, 0x4c00
+ax_pose 14, 0x81ef, 0x10f2, 0x4c08
+ax_pose_terminator
+sSolrockPose69:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose70:
+ax_pose 15, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose71:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose72:
+ax_pose 16, 0x81e7, 0x90f5, 0x4c00
+ax_pose 17, 0x81ef, 0x1105, 0x4c08
+ax_pose_terminator
+sSolrockPose73:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose74:
+ax_pose 18, 0x41eb, 0x80ef, 0x4c00
+ax_pose 19, 0x01fb, 0x00ff, 0x4c08
+ax_pose_terminator
+sSolrockPose75:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose76:
+ax_pose 16, 0x81e7, 0x80fc, 0x4c00
+ax_pose 17, 0x81ef, 0x00f4, 0x4c08
+ax_pose_terminator
+sSolrockPose77:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose78:
+ax_pose 15, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose79:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose80:
+ax_pose 13, 0x81e7, 0x80f7, 0x4c00
+ax_pose 14, 0x81ef, 0x0107, 0x4c08
+ax_pose_terminator
+sSolrockPose81:
+ax_pose 20, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sSolrockPose82:
+ax_pose 21, 0x01e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sSolrockPose83:
+ax_pose 22, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose84:
+ax_pose 23, 0x01e1, 0x90ec, 0x4c00
+ax_pose_terminator
+sSolrockPose85:
+ax_pose 24, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sSolrockPose86:
+ax_pose 25, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sSolrockPose87:
+ax_pose 26, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose88:
+ax_pose 25, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose89:
+ax_pose 24, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sSolrockPose90:
+ax_pose 23, 0x01e1, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose91:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose92:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose93:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose94:
+ax_pose 3, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose95:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose96:
+ax_pose 5, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose97:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose98:
+ax_pose 7, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose99:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose100:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose101:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose102:
+ax_pose 7, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose103:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose104:
+ax_pose 5, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose105:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose106:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose107:
+ax_pose 10, 0x41e6, 0x80ee, 0x4c00
+ax_pose 11, 0x41f6, 0x40ee, 0x4c08
+ax_pose 12, 0x01fe, 0x00fe, 0x4c0c
+ax_pose_terminator
+sSolrockPose108:
+ax_pose 13, 0x81e7, 0x80f7, 0x4c00
+ax_pose 14, 0x81ef, 0x0107, 0x4c08
+ax_pose_terminator
+sSolrockPose109:
+ax_pose 15, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose110:
+ax_pose 16, 0x81e7, 0x80fc, 0x4c00
+ax_pose 17, 0x81ef, 0x00f4, 0x4c08
+ax_pose_terminator
+sSolrockPose111:
+ax_pose 18, 0x41eb, 0x80ef, 0x4c00
+ax_pose 19, 0x01fb, 0x00ff, 0x4c08
+ax_pose_terminator
+sSolrockPose112:
+ax_pose 16, 0x81e7, 0x90f5, 0x4c00
+ax_pose 17, 0x81ef, 0x1105, 0x4c08
+ax_pose_terminator
+sSolrockPose113:
+ax_pose 15, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose114:
+ax_pose 13, 0x81e7, 0x90fa, 0x4c00
+ax_pose 14, 0x81ef, 0x10f2, 0x4c08
+ax_pose_terminator
+sSolrockPose115:
+ax_pose 1, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose116:
+ax_pose 3, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose117:
+ax_pose 5, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose118:
+ax_pose 7, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose119:
+ax_pose 9, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose120:
+ax_pose 7, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose121:
+ax_pose 5, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose122:
+ax_pose 3, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose123:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose124:
+ax_pose 10, 0x41e6, 0x80ee, 0x4c00
+ax_pose 11, 0x41f6, 0x40ee, 0x4c08
+ax_pose 12, 0x01fe, 0x00fe, 0x4c0c
+ax_pose_terminator
+sSolrockPose125:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose126:
+ax_pose 13, 0x81e7, 0x90fa, 0x4c00
+ax_pose 14, 0x81ef, 0x10f2, 0x4c08
+ax_pose_terminator
+sSolrockPose127:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose128:
+ax_pose 15, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose129:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose130:
+ax_pose 16, 0x81e7, 0x90f5, 0x4c00
+ax_pose 17, 0x81ef, 0x1105, 0x4c08
+ax_pose_terminator
+sSolrockPose131:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose132:
+ax_pose 18, 0x41eb, 0x80ef, 0x4c00
+ax_pose 19, 0x01fb, 0x00ff, 0x4c08
+ax_pose_terminator
+sSolrockPose133:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose134:
+ax_pose 16, 0x81e7, 0x80fc, 0x4c00
+ax_pose 17, 0x81ef, 0x00f4, 0x4c08
+ax_pose_terminator
+sSolrockPose135:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose136:
+ax_pose 15, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose137:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose138:
+ax_pose 13, 0x81e7, 0x80f7, 0x4c00
+ax_pose 14, 0x81ef, 0x0107, 0x4c08
+ax_pose_terminator
+sSolrockPose139:
+ax_pose 10, 0x41e6, 0x80ee, 0x4c00
+ax_pose 11, 0x41f6, 0x40ee, 0x4c08
+ax_pose 12, 0x01fe, 0x00fe, 0x4c0c
+ax_pose_terminator
+sSolrockPose140:
+ax_pose 13, 0x81e7, 0x80f7, 0x4c00
+ax_pose 14, 0x81ef, 0x0107, 0x4c08
+ax_pose_terminator
+sSolrockPose141:
+ax_pose 15, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose142:
+ax_pose 16, 0x81e7, 0x80fc, 0x4c00
+ax_pose 17, 0x81ef, 0x00f4, 0x4c08
+ax_pose_terminator
+sSolrockPose143:
+ax_pose 18, 0x41eb, 0x80ef, 0x4c00
+ax_pose 19, 0x01fb, 0x00ff, 0x4c08
+ax_pose_terminator
+sSolrockPose144:
+ax_pose 16, 0x81e7, 0x90f5, 0x4c00
+ax_pose 17, 0x81ef, 0x1105, 0x4c08
+ax_pose_terminator
+sSolrockPose145:
+ax_pose 15, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose146:
+ax_pose 13, 0x81e7, 0x90fa, 0x4c00
+ax_pose 14, 0x81ef, 0x10f2, 0x4c08
+ax_pose_terminator
+sSolrockPose147:
+ax_pose 0, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose148:
+ax_pose 2, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose149:
+ax_pose 4, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sSolrockPose150:
+ax_pose 6, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sSolrockPose151:
+ax_pose 8, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sSolrockPose152:
+ax_pose 6, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+sSolrockPose153:
+ax_pose 4, 0x81e7, 0x90f9, 0x4c00
+ax_pose_terminator
+sSolrockPose154:
+ax_pose 2, 0x01e7, 0x90ed, 0x4c00
+ax_pose_terminator
+.align 2
+sSolrockAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -4, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_1_2:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -4, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_1_3:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -4, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_1_4:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -4, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 1, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_1_5:
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -4, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_1_6:
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 6, 0, 11, 0, -4, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_1_7:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -4, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 1, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_1_8:
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -4, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_2_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 17, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 9,
+ax_anim 2, 0, 17, 0, 24, 0, 21,
+ax_anim 2, 1, 18, 0, 24, 0, 21,
+ax_anim 2, 0, 17, 0, 24, 0, 21,
+ax_anim 2, 0, 30, 0, 24, 0, 21,
+ax_anim 2, 0, 17, 0, 24, 0, 21,
+ax_anim 2, 0, 17, 0, 12, 0, 12,
+ax_anim 2, 0, 17, 0, 4, 0, 4,
+ax_anim_terminator
+sSolrockAnims_2_2:
+ax_anim 2, 0, 18, -1, -1, -1, -1,
+ax_anim 6, 0, 19, -2, -2, -2, -2,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 4, 4, 4, 4,
+ax_anim 1, 0, 18, 10, 11, 10, 10,
+ax_anim 2, 0, 19, 22, 24, 22, 22,
+ax_anim 2, 1, 20, 22, 24, 22, 22,
+ax_anim 2, 0, 19, 22, 24, 22, 22,
+ax_anim 2, 0, 16, 22, 24, 22, 22,
+ax_anim 2, 0, 19, 22, 24, 22, 22,
+ax_anim 2, 0, 19, 12, 13, 12, 12,
+ax_anim 2, 0, 19, 4, 4, 4, 4,
+ax_anim_terminator
+sSolrockAnims_2_3:
+ax_anim 2, 0, 20, -1, 0, -1, 0,
+ax_anim 6, 0, 21, -2, 0, -2, 0,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 21, 4, 0, 4, 0,
+ax_anim 1, 0, 20, 10, 1, 10, 0,
+ax_anim 2, 0, 21, 20, 2, 20, 0,
+ax_anim 2, 1, 22, 20, 2, 20, 0,
+ax_anim 2, 0, 21, 20, 2, 20, 0,
+ax_anim 2, 0, 18, 20, 2, 20, 0,
+ax_anim 2, 0, 21, 20, 2, 20, 0,
+ax_anim 2, 0, 21, 12, 1, 12, 0,
+ax_anim 2, 0, 21, 4, 0, 4, 0,
+ax_anim_terminator
+sSolrockAnims_2_4:
+ax_anim 2, 0, 22, -1, 1, -1, 1,
+ax_anim 6, 0, 23, -2, 2, -2, 2,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 23, 5, -3, 5, -4,
+ax_anim 1, 0, 22, 12, -8, 12, -9,
+ax_anim 2, 0, 23, 21, -14, 21, -16,
+ax_anim 2, 1, 24, 21, -14, 21, -16,
+ax_anim 2, 0, 23, 21, -14, 21, -16,
+ax_anim 2, 0, 20, 21, -14, 21, -16,
+ax_anim 2, 0, 23, 21, -14, 21, -16,
+ax_anim 2, 0, 23, 13, -9, 13, -10,
+ax_anim 2, 0, 23, 5, -3, 5, -4,
+ax_anim_terminator
+sSolrockAnims_2_5:
+ax_anim 2, 0, 24, 0, 1, 0, 1,
+ax_anim 6, 0, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, -4, 0, -4,
+ax_anim 1, 0, 24, 0, -12, 0, -13,
+ax_anim 2, 0, 25, 0, -15, 0, -18,
+ax_anim 2, 1, 26, 0, -15, 0, -18,
+ax_anim 2, 0, 25, 0, -15, 0, -18,
+ax_anim 2, 0, 22, 0, -15, 0, -18,
+ax_anim 2, 0, 25, 0, -15, 0, -18,
+ax_anim 2, 0, 25, 0, -10, 0, -11,
+ax_anim 2, 0, 25, 0, -4, 0, -4,
+ax_anim_terminator
+sSolrockAnims_2_6:
+ax_anim 2, 0, 26, 1, 1, 1, 1,
+ax_anim 6, 0, 27, 2, 2, 2, 2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 27, -5, -3, -5, -4,
+ax_anim 1, 0, 26, -12, -8, -12, -9,
+ax_anim 2, 0, 27, -21, -14, -21, -16,
+ax_anim 2, 1, 28, -21, -14, -21, -16,
+ax_anim 2, 0, 27, -21, -14, -21, -16,
+ax_anim 2, 0, 24, -21, -14, -21, -16,
+ax_anim 2, 0, 27, -21, -14, -21, -16,
+ax_anim 2, 0, 27, -13, -9, -13, -10,
+ax_anim 2, 0, 27, -5, -3, -5, -4,
+ax_anim_terminator
+sSolrockAnims_2_7:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 6, 0, 29, 2, 0, 2, 0,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 29, -4, 0, -4, 0,
+ax_anim 1, 0, 28, -10, 1, -10, 0,
+ax_anim 2, 0, 29, -20, 2, -20, 0,
+ax_anim 2, 1, 30, -20, 2, -20, 0,
+ax_anim 2, 0, 29, -20, 2, -20, 0,
+ax_anim 2, 0, 26, -20, 2, -20, 0,
+ax_anim 2, 0, 29, -20, 2, -20, 0,
+ax_anim 2, 0, 29, -12, 1, -12, 0,
+ax_anim 2, 0, 29, -4, 0, -4, 0,
+ax_anim_terminator
+sSolrockAnims_2_8:
+ax_anim 2, 0, 30, 1, -1, 1, -1,
+ax_anim 6, 0, 31, 2, -2, 2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, -4, 4, -4, 4,
+ax_anim 1, 0, 30, -10, 11, -10, 10,
+ax_anim 2, 0, 31, -22, 24, -22, 22,
+ax_anim 2, 1, 16, -22, 24, -22, 22,
+ax_anim 2, 0, 31, -22, 24, -22, 22,
+ax_anim 2, 0, 28, -22, 24, -22, 22,
+ax_anim 2, 0, 31, -22, 24, -22, 22,
+ax_anim 2, 0, 31, -12, 13, -12, 12,
+ax_anim 2, 0, 31, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSolrockAnims_3_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 6, 0, 33, 0, -2, 0, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, 4, 0, 4,
+ax_anim 1, 0, 32, 0, 10, 0, 9,
+ax_anim 2, 0, 33, 0, 24, 0, 21,
+ax_anim 2, 1, 34, 0, 24, 0, 21,
+ax_anim 2, 0, 33, 0, 24, 0, 21,
+ax_anim 2, 0, 46, 0, 24, 0, 21,
+ax_anim 2, 0, 33, 0, 24, 0, 21,
+ax_anim 2, 0, 33, 0, 12, 0, 12,
+ax_anim 2, 0, 33, 0, 4, 0, 4,
+ax_anim_terminator
+sSolrockAnims_3_2:
+ax_anim 2, 0, 34, -1, -1, -1, -1,
+ax_anim 6, 0, 35, -2, -2, -2, -2,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 4, 4, 4,
+ax_anim 1, 0, 34, 10, 11, 10, 10,
+ax_anim 2, 0, 35, 22, 24, 22, 22,
+ax_anim 2, 1, 36, 22, 24, 22, 22,
+ax_anim 2, 0, 35, 22, 24, 22, 22,
+ax_anim 2, 0, 32, 22, 24, 22, 22,
+ax_anim 2, 0, 35, 22, 24, 22, 22,
+ax_anim 2, 0, 35, 12, 13, 12, 12,
+ax_anim 2, 0, 35, 4, 4, 4, 4,
+ax_anim_terminator
+sSolrockAnims_3_3:
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 6, 0, 37, -2, 0, -2, 0,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 4, 0, 4, 0,
+ax_anim 1, 0, 36, 10, 1, 10, 0,
+ax_anim 2, 0, 37, 20, 2, 20, 0,
+ax_anim 2, 1, 38, 20, 2, 20, 0,
+ax_anim 2, 0, 37, 20, 2, 20, 0,
+ax_anim 2, 0, 34, 20, 2, 20, 0,
+ax_anim 2, 0, 37, 20, 2, 20, 0,
+ax_anim 2, 0, 37, 12, 1, 12, 0,
+ax_anim 2, 0, 37, 4, 0, 4, 0,
+ax_anim_terminator
+sSolrockAnims_3_4:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 5, -3, 5, -4,
+ax_anim 1, 0, 38, 12, -8, 12, -9,
+ax_anim 2, 0, 39, 21, -14, 21, -16,
+ax_anim 2, 1, 40, 21, -14, 21, -16,
+ax_anim 2, 0, 39, 21, -14, 21, -16,
+ax_anim 2, 0, 36, 21, -14, 21, -16,
+ax_anim 2, 0, 39, 21, -14, 21, -16,
+ax_anim 2, 0, 39, 13, -9, 13, -10,
+ax_anim 2, 0, 39, 5, -3, 5, -4,
+ax_anim_terminator
+sSolrockAnims_3_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 2, 0, 2,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 40, 0, -12, 0, -13,
+ax_anim 2, 0, 41, 0, -15, 0, -18,
+ax_anim 2, 1, 42, 0, -15, 0, -18,
+ax_anim 2, 0, 41, 0, -15, 0, -18,
+ax_anim 2, 0, 38, 0, -15, 0, -18,
+ax_anim 2, 0, 41, 0, -15, 0, -18,
+ax_anim 2, 0, 41, 0, -10, 0, -11,
+ax_anim 2, 0, 41, 0, -4, 0, -4,
+ax_anim_terminator
+sSolrockAnims_3_6:
+ax_anim 2, 0, 42, 1, 1, 1, 1,
+ax_anim 6, 0, 43, 2, 2, 2, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -5, -3, -5, -4,
+ax_anim 1, 0, 42, -12, -8, -12, -9,
+ax_anim 2, 0, 43, -21, -14, -21, -16,
+ax_anim 2, 1, 44, -21, -14, -21, -16,
+ax_anim 2, 0, 43, -21, -14, -21, -16,
+ax_anim 2, 0, 40, -21, -14, -21, -16,
+ax_anim 2, 0, 43, -21, -14, -21, -16,
+ax_anim 2, 0, 43, -13, -9, -13, -10,
+ax_anim 2, 0, 43, -5, -3, -5, -4,
+ax_anim_terminator
+sSolrockAnims_3_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 45, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 1, -10, 0,
+ax_anim 2, 0, 45, -20, 2, -20, 0,
+ax_anim 2, 1, 46, -20, 2, -20, 0,
+ax_anim 2, 0, 45, -20, 2, -20, 0,
+ax_anim 2, 0, 42, -20, 2, -20, 0,
+ax_anim 2, 0, 45, -20, 2, -20, 0,
+ax_anim 2, 0, 45, -12, 1, -12, 0,
+ax_anim 2, 0, 45, -4, 0, -4, 0,
+ax_anim_terminator
+sSolrockAnims_3_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 11, -10, 10,
+ax_anim 2, 0, 47, -22, 24, -22, 22,
+ax_anim 2, 1, 32, -22, 24, -22, 22,
+ax_anim 2, 0, 47, -22, 24, -22, 22,
+ax_anim 2, 0, 44, -22, 24, -22, 22,
+ax_anim 2, 0, 47, -22, 24, -22, 22,
+ax_anim 2, 0, 47, -12, 13, -12, 12,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSolrockAnims_4_1:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 2, 2, 48, 0, 3, 0, 3,
+ax_anim 5, 0, 48, 0, 4, 0, 4,
+ax_anim 1, 1, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, -5, 0, -5,
+ax_anim 1, 0, 49, 0, -8, 0, -8,
+ax_anim 4, 0, 49, 0, -9, 0, -9,
+ax_anim 2, 0, 48, 0, -7, 0, -7,
+ax_anim 2, 0, 48, 0, -4, 0, -4,
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim_terminator
+sSolrockAnims_4_2:
+ax_anim 2, 0, 50, 1, 1, 1, 1,
+ax_anim 2, 2, 50, 3, 3, 3, 3,
+ax_anim 5, 0, 50, 4, 4, 4, 4,
+ax_anim 1, 1, 50, 4, 4, 4, 4,
+ax_anim 1, 0, 51, -5, -5, -5, -5,
+ax_anim 1, 0, 51, -8, -8, -8, -8,
+ax_anim 4, 0, 51, -9, -9, -9, -9,
+ax_anim 2, 0, 50, -7, -7, -7, -7,
+ax_anim 2, 0, 50, -4, -4, -4, -4,
+ax_anim 2, 0, 50, -2, -2, -2, -2,
+ax_anim_terminator
+sSolrockAnims_4_3:
+ax_anim 2, 0, 52, 1, 0, 1, 0,
+ax_anim 2, 2, 52, 3, 0, 3, 0,
+ax_anim 5, 0, 52, 4, 0, 4, 0,
+ax_anim 1, 1, 52, 4, 0, 4, 0,
+ax_anim 1, 0, 53, -5, 0, -5, 0,
+ax_anim 1, 0, 53, -8, 0, -8, 0,
+ax_anim 4, 0, 53, -9, 0, -9, 0,
+ax_anim 2, 0, 52, -7, 0, -7, 0,
+ax_anim 2, 0, 52, -4, 0, -4, 0,
+ax_anim 2, 0, 52, -2, 0, -2, 0,
+ax_anim_terminator
+sSolrockAnims_4_4:
+ax_anim 2, 0, 54, 1, -1, 1, -1,
+ax_anim 2, 2, 54, 3, -3, 3, -3,
+ax_anim 5, 0, 54, 4, -4, 4, -4,
+ax_anim 1, 1, 54, 4, -4, 4, -4,
+ax_anim 1, 0, 55, -5, 5, -5, 5,
+ax_anim 1, 0, 55, -8, 8, -8, 8,
+ax_anim 4, 0, 55, -9, 9, -9, 9,
+ax_anim 2, 0, 54, -7, 7, -7, 7,
+ax_anim 2, 0, 54, -4, 4, -4, 4,
+ax_anim 2, 0, 54, -2, 2, -2, 2,
+ax_anim_terminator
+sSolrockAnims_4_5:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 2, 2, 56, 0, -3, 0, -3,
+ax_anim 5, 0, 56, 0, -4, 0, -4,
+ax_anim 1, 1, 56, 0, -4, 0, -4,
+ax_anim 1, 0, 57, 0, 5, 0, 5,
+ax_anim 1, 0, 57, 0, 8, 0, 8,
+ax_anim 4, 0, 57, 0, 9, 0, 9,
+ax_anim 2, 0, 56, 0, 7, 0, 7,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim 2, 0, 56, 0, 2, 0, 2,
+ax_anim_terminator
+sSolrockAnims_4_6:
+ax_anim 2, 0, 58, -1, -1, -1, -1,
+ax_anim 2, 2, 58, -3, -3, -3, -3,
+ax_anim 5, 0, 58, -4, -4, -4, -4,
+ax_anim 1, 1, 58, -4, -4, -4, -4,
+ax_anim 1, 0, 59, 5, 5, 5, 5,
+ax_anim 1, 0, 59, 8, 8, 8, 8,
+ax_anim 4, 0, 59, 9, 9, 9, 9,
+ax_anim 2, 0, 58, 7, 7, 7, 7,
+ax_anim 2, 0, 58, 4, 4, 4, 4,
+ax_anim 2, 0, 58, 2, 2, 2, 2,
+ax_anim_terminator
+sSolrockAnims_4_7:
+ax_anim 2, 0, 60, -1, 0, -1, 0,
+ax_anim 2, 2, 60, -3, 0, -3, 0,
+ax_anim 5, 0, 60, -4, 0, -4, 0,
+ax_anim 1, 1, 60, -4, 0, -4, 0,
+ax_anim 1, 0, 61, 5, 0, 5, 0,
+ax_anim 1, 0, 61, 8, 0, 8, 0,
+ax_anim 4, 0, 61, 9, 0, 9, 0,
+ax_anim 2, 0, 60, 7, 0, 7, 0,
+ax_anim 2, 0, 60, 4, 0, 4, 0,
+ax_anim 2, 0, 60, 2, 0, 2, 0,
+ax_anim_terminator
+sSolrockAnims_4_8:
+ax_anim 2, 0, 62, -1, 1, -1, 1,
+ax_anim 2, 2, 62, -3, 3, -3, 3,
+ax_anim 5, 0, 62, -4, 4, -4, 4,
+ax_anim 1, 1, 62, -4, 4, -4, 4,
+ax_anim 1, 0, 63, 5, -5, 5, -5,
+ax_anim 1, 0, 63, 8, -8, 8, -8,
+ax_anim 4, 0, 63, 9, -9, 9, -9,
+ax_anim 2, 0, 62, 7, -7, 7, -7,
+ax_anim 2, 0, 62, 4, -4, 4, -4,
+ax_anim 2, 0, 62, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sSolrockAnims_5_1:
+ax_anim 2, 0, 64, 0, -2, 0, 0,
+ax_anim 2, 0, 65, 0, -4, 0, 0,
+ax_anim 8, 2, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 1, -5, 1, 0,
+ax_anim 2, 0, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 1, -5, 1, 0,
+ax_anim 2, 0, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 1, -5, 1, 0,
+ax_anim 2, 0, 65, 0, -5, 0, 0,
+ax_anim 2, 0, 65, 0, -3, 0, 0,
+ax_anim 2, 0, 64, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_5_2:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 8, 2, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 1, -6, 1, -1,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 1, -6, 1, -1,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 1, -6, 1, -1,
+ax_anim 2, 0, 67, 0, -5, 0, 0,
+ax_anim 2, 0, 67, 0, -3, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_5_3:
+ax_anim 2, 0, 68, 0, -2, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 8, 2, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, -1,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, -1,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -6, 0, -1,
+ax_anim 2, 0, 69, 0, -5, 0, 0,
+ax_anim 2, 0, 69, 0, -3, 0, 0,
+ax_anim 2, 0, 68, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_5_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 8, 2, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, -1, -6, -1, -1,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, -1, -6, -1, -1,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, -1, -6, -1, -1,
+ax_anim 2, 0, 71, 0, -5, 0, 0,
+ax_anim 2, 0, 71, 0, -3, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_5_5:
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -4, 0, 0,
+ax_anim 8, 2, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 1, -5, 1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 1, -5, 1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 1, -5, 1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_5_6:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 8, 2, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 1, -6, 1, -1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 1, -6, 1, -1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 1, -6, 1, -1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_5_7:
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -4, 0, 0,
+ax_anim 8, 2, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_5_8:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 8, 2, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_6_1:
+ax_anim 16, 0, 80, 0, 0, 0, 0,
+ax_anim 12, 0, 80, 0, -1, 0, 0,
+ax_anim 16, 0, 80, 0, -2, 0, 0,
+ax_anim 16, 0, 81, 0, -2, 0, 0,
+ax_anim 12, 0, 81, 0, -1, 0, 0,
+ax_anim 16, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_7_1:
+ax_anim 2, 0, 82, 0, -2, 0, -2,
+ax_anim 8, 0, 82, 0, -3, 0, -3,
+ax_anim_terminator
+sSolrockAnims_7_2:
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 8, 0, 83, -3, -3, -3, -3,
+ax_anim_terminator
+sSolrockAnims_7_3:
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 8, 0, 84, -3, 0, -3, 0,
+ax_anim_terminator
+sSolrockAnims_7_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 8, 0, 85, -3, 3, -3, 3,
+ax_anim_terminator
+sSolrockAnims_7_5:
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 8, 0, 86, 0, 3, 0, 3,
+ax_anim_terminator
+sSolrockAnims_7_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 8, 0, 87, 3, 3, 3, 3,
+ax_anim_terminator
+sSolrockAnims_7_7:
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 8, 0, 88, 3, 0, 3, 0,
+ax_anim_terminator
+sSolrockAnims_7_8:
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim 8, 0, 89, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSolrockAnims_8_1:
+ax_anim 8, 0, 90, 0, 0, 0, 0,
+ax_anim 8, 0, 91, 0, -1, 0, 0,
+ax_anim 8, 0, 90, 0, -2, 0, 0,
+ax_anim 8, 0, 91, 0, -2, 0, 0,
+ax_anim 8, 0, 90, 0, -2, 0, 0,
+ax_anim 8, 0, 91, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_8_2:
+ax_anim 8, 0, 92, 0, 0, 0, 0,
+ax_anim 8, 0, 93, 0, -1, 0, 0,
+ax_anim 8, 0, 92, 0, -2, 0, 0,
+ax_anim 8, 0, 93, 0, -2, 0, 0,
+ax_anim 8, 0, 92, 0, -2, 0, 0,
+ax_anim 8, 0, 93, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_8_3:
+ax_anim 8, 0, 94, 0, 0, 0, 0,
+ax_anim 8, 0, 95, 0, -1, 0, 0,
+ax_anim 8, 0, 94, 0, -2, 0, 0,
+ax_anim 8, 0, 95, 0, -2, 0, 0,
+ax_anim 8, 0, 94, 0, -2, 0, 0,
+ax_anim 8, 0, 95, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_8_4:
+ax_anim 8, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 0, 97, 0, -1, 0, 0,
+ax_anim 8, 0, 96, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -2, 0, 0,
+ax_anim 8, 0, 96, 0, -2, 0, 0,
+ax_anim 8, 0, 97, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_8_5:
+ax_anim 8, 0, 98, 0, 0, 0, 0,
+ax_anim 8, 0, 99, 0, -1, 0, 0,
+ax_anim 8, 0, 98, 0, -2, 0, 0,
+ax_anim 8, 0, 99, 0, -2, 0, 0,
+ax_anim 8, 0, 98, 0, -2, 0, 0,
+ax_anim 8, 0, 99, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_8_6:
+ax_anim 8, 0, 100, 0, 0, 0, 0,
+ax_anim 8, 0, 101, 0, -1, 0, 0,
+ax_anim 8, 0, 100, 0, -2, 0, 0,
+ax_anim 8, 0, 101, 0, -2, 0, 0,
+ax_anim 8, 0, 100, 0, -2, 0, 0,
+ax_anim 8, 0, 101, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_8_7:
+ax_anim 8, 0, 102, 0, 0, 0, 0,
+ax_anim 8, 0, 103, 0, -1, 0, 0,
+ax_anim 8, 0, 102, 0, -2, 0, 0,
+ax_anim 8, 0, 103, 0, -2, 0, 0,
+ax_anim 8, 0, 102, 0, -2, 0, 0,
+ax_anim 8, 0, 103, 0, -1, 0, 0,
+ax_anim_terminator
+sSolrockAnims_8_8:
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim 8, 0, 105, 0, -1, 0, 0,
+ax_anim 8, 0, 104, 0, -2, 0, 0,
+ax_anim 8, 0, 105, 0, -2, 0, 0,
+ax_anim 8, 0, 104, 0, -2, 0, 0,
+ax_anim 8, 0, 105, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_9_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 8, 4, 8, 4,
+ax_anim 2, 0, 108, 11, 11, 11, 11,
+ax_anim 2, 0, 109, 10, 19, 10, 17,
+ax_anim 3, 0, 110, 0, 25, 0, 23,
+ax_anim 2, 3, 111, -10, 19, -10, 17,
+ax_anim 2, 0, 112, -11, 11, -11, 11,
+ax_anim 1, 0, 113, -8, 4, -8, 4,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_9_2:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 9, 1, 9, 1,
+ax_anim 2, 0, 107, 16, 6, 16, 6,
+ax_anim 2, 0, 108, 22, 14, 22, 14,
+ax_anim 3, 0, 109, 23, 23, 23, 23,
+ax_anim 2, 3, 110, 13, 25, 13, 25,
+ax_anim 2, 0, 111, 6, 19, 6, 19,
+ax_anim 1, 0, 112, 2, 10, 2, 10,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_9_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 4, -5, 4, -5,
+ax_anim 2, 0, 106, 11, -5, 11, -5,
+ax_anim 2, 0, 107, 19, -2, 19, -3,
+ax_anim 3, 0, 108, 24, 3, 24, 1,
+ax_anim 2, 3, 109, 19, 6, 19, 6,
+ax_anim 2, 0, 110, 12, 8, 12, 8,
+ax_anim 1, 0, 111, 4, 5, 4, 5,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_9_4:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, -1, -8, -1, -8,
+ax_anim 2, 0, 113, 5, -16, 5, -16,
+ax_anim 2, 0, 106, 12, -18, 12, -18,
+ax_anim 3, 0, 107, 21, -18, 21, -18,
+ax_anim 2, 3, 108, 23, -13, 23, -13,
+ax_anim 2, 0, 109, 18, -4, 18, -4,
+ax_anim 1, 0, 110, 9, 1, 9, 1,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_9_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, -9, -4, -9, -4,
+ax_anim 2, 0, 112, -11, -10, -11, -10,
+ax_anim 2, 0, 113, -7, -15, -7, -15,
+ax_anim 3, 0, 106, 0, -17, 0, -19,
+ax_anim 2, 3, 107, 7, -15, 7, -15,
+ax_anim 2, 0, 108, 11, -10, 11, -10,
+ax_anim 1, 0, 109, 9, -4, 9, -4,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_9_6:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 1, -8, 1, -8,
+ax_anim 2, 0, 107, -5, -16, -5, -16,
+ax_anim 2, 0, 106, -12, -18, -12, -18,
+ax_anim 3, 0, 113, -21, -18, -21, -18,
+ax_anim 2, 3, 112, -23, -13, -23, -13,
+ax_anim 2, 0, 111, -18, -4, -18, -4,
+ax_anim 1, 0, 110, -9, -1, -9, -1,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_9_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, -4, -5, -4, -5,
+ax_anim 2, 0, 106, -11, -5, -11, -5,
+ax_anim 2, 0, 113, -19, -2, -19, -3,
+ax_anim 3, 0, 112, -24, 3, -24, 1,
+ax_anim 2, 3, 111, -19, 6, -19, 6,
+ax_anim 2, 0, 110, -12, 8, -12, 8,
+ax_anim 1, 0, 109, -4, 5, -4, 5,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_9_8:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, -9, 1, -9, 1,
+ax_anim 2, 0, 113, -16, 6, -16, 6,
+ax_anim 2, 0, 112, -22, 14, -22, 14,
+ax_anim 3, 0, 111, -23, 23, -23, 23,
+ax_anim 2, 3, 110, -13, 25, -13, 25,
+ax_anim 2, 0, 109, -6, 19, -6, 19,
+ax_anim 1, 0, 108, -2, 10, -2, 10,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_10_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 3, 0, 114, 13, 0, 13, 0,
+ax_anim 3, 0, 114, -13, 0, -13, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_10_2:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 3, 0, 115, 13, -13, 13, -13,
+ax_anim 3, 0, 115, -13, 13, -13, 13,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_10_3:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 3, 0, 116, 0, -13, 0, -13,
+ax_anim 3, 0, 116, 0, 13, 0, 13,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_10_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 3, 0, 117, -13, -13, -13, -13,
+ax_anim 3, 0, 117, 13, 13, 13, 13,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_10_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 3, 0, 118, 13, 0, 13, 0,
+ax_anim 3, 0, 118, -13, 0, -13, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_10_6:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 3, 0, 119, 13, -13, 13, -13,
+ax_anim 3, 0, 119, -13, 13, -13, 13,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_10_7:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 3, 0, 120, 0, -13, 0, -13,
+ax_anim 3, 0, 120, 0, 13, 0, 13,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_10_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 3, 0, 121, -13, -13, -13, -13,
+ax_anim 3, 0, 121, 13, 13, 13, 13,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_11_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, -10, 0, 0,
+ax_anim 2, 0, 123, 0, -16, 0, 0,
+ax_anim 3, 0, 123, 0, -20, 0, 0,
+ax_anim 4, 0, 123, 0, -21, 0, 0,
+ax_anim 4, 0, 122, 0, -22, 0, 0,
+ax_anim 3, 0, 122, 0, -21, 0, 0,
+ax_anim 2, 0, 122, 0, -17, 0, 0,
+ax_anim 1, 0, 122, 0, -10, 0, 0,
+ax_anim 2, 2, 122, 0, 2, 0, 0,
+ax_anim_terminator
+sSolrockAnims_11_2:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 125, 0, -10, 0, 0,
+ax_anim 2, 0, 125, 0, -16, 0, 0,
+ax_anim 3, 0, 125, 0, -20, 0, 0,
+ax_anim 4, 0, 125, 0, -21, 0, 0,
+ax_anim 4, 0, 124, 0, -22, 0, 0,
+ax_anim 3, 0, 124, 0, -21, 0, 0,
+ax_anim 2, 0, 124, 0, -17, 0, 0,
+ax_anim 1, 0, 124, 0, -10, 0, 0,
+ax_anim 2, 2, 124, 0, 2, 0, 0,
+ax_anim_terminator
+sSolrockAnims_11_3:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 0, -10, 0, 0,
+ax_anim 2, 0, 127, 0, -16, 0, 0,
+ax_anim 3, 0, 127, 0, -20, 0, 0,
+ax_anim 4, 0, 127, 0, -21, 0, 0,
+ax_anim 4, 0, 126, 0, -22, 0, 0,
+ax_anim 3, 0, 126, 0, -21, 0, 0,
+ax_anim 2, 0, 126, 0, -17, 0, 0,
+ax_anim 1, 0, 126, 0, -10, 0, 0,
+ax_anim 2, 2, 126, 0, 2, 0, 0,
+ax_anim_terminator
+sSolrockAnims_11_4:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 2, 0, 129, 0, -16, 0, 0,
+ax_anim 3, 0, 129, 0, -20, 0, 0,
+ax_anim 4, 0, 129, 0, -21, 0, 0,
+ax_anim 4, 0, 128, 0, -22, 0, 0,
+ax_anim 3, 0, 128, 0, -21, 0, 0,
+ax_anim 2, 0, 128, 0, -17, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 2, 2, 128, 0, 2, 0, 0,
+ax_anim_terminator
+sSolrockAnims_11_5:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 2, 0, 131, 0, -16, 0, 0,
+ax_anim 3, 0, 131, 0, -20, 0, 0,
+ax_anim 4, 0, 131, 0, -21, 0, 0,
+ax_anim 4, 0, 130, 0, -21, 0, 0,
+ax_anim 3, 0, 130, 0, -20, 0, 0,
+ax_anim 2, 0, 130, 0, -17, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 2, 2, 130, 0, 2, 0, 0,
+ax_anim_terminator
+sSolrockAnims_11_6:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 2, 0, 133, 0, -16, 0, 0,
+ax_anim 3, 0, 133, 0, -20, 0, 0,
+ax_anim 4, 0, 133, 0, -21, 0, 0,
+ax_anim 4, 0, 132, 0, -22, 0, 0,
+ax_anim 3, 0, 132, 0, -21, 0, 0,
+ax_anim 2, 0, 132, 0, -17, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 2, 2, 132, 0, 2, 0, 0,
+ax_anim_terminator
+sSolrockAnims_11_7:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 2, 0, 135, 0, -16, 0, 0,
+ax_anim 3, 0, 135, 0, -20, 0, 0,
+ax_anim 4, 0, 135, 0, -21, 0, 0,
+ax_anim 4, 0, 134, 0, -22, 0, 0,
+ax_anim 3, 0, 134, 0, -21, 0, 0,
+ax_anim 2, 0, 134, 0, -17, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 2, 2, 134, 0, 2, 0, 0,
+ax_anim_terminator
+sSolrockAnims_11_8:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -10, 0, 0,
+ax_anim 2, 0, 137, 0, -16, 0, 0,
+ax_anim 3, 0, 137, 0, -20, 0, 0,
+ax_anim 4, 0, 137, 0, -21, 0, 0,
+ax_anim 4, 0, 136, 0, -22, 0, 0,
+ax_anim 3, 0, 136, 0, -21, 0, 0,
+ax_anim 2, 0, 136, 0, -17, 0, 0,
+ax_anim 1, 0, 136, 0, -10, 0, 0,
+ax_anim 2, 2, 136, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_12_1:
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 1, 0, 1, 0,
+ax_anim 2, 1, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_12_2:
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 1, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_12_3:
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_12_4:
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_12_5:
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 0, 1, 0,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_12_6:
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 1, -1, 1, -1,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_12_7:
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim 2, 1, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_12_8:
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSolrockAnims_13_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_13_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_13_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_13_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_13_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_13_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_13_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockAnims_13_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSolrockGfx1:
+.incbin "baserom.gba", 0x13D00D4, 0x200
+sSolrockSprites1:
+ax_sprite sSolrockGfx1, 0x200
+ax_sprite_terminator
+sSolrockGfx2:
+.incbin "baserom.gba", 0x13D02E4, 0x200
+sSolrockSprites2:
+ax_sprite sSolrockGfx2, 0x200
+ax_sprite_terminator
+sSolrockGfx3:
+.incbin "baserom.gba", 0x13D04F4, 0x200
+sSolrockSprites3:
+ax_sprite sSolrockGfx3, 0x200
+ax_sprite_terminator
+sSolrockGfx4:
+.incbin "baserom.gba", 0x13D0704, 0x200
+sSolrockSprites4:
+ax_sprite sSolrockGfx4, 0x200
+ax_sprite_terminator
+sSolrockGfx5:
+.incbin "baserom.gba", 0x13D0914, 0x100
+sSolrockSprites5:
+ax_sprite sSolrockGfx5, 0x100
+ax_sprite_terminator
+sSolrockGfx6:
+.incbin "baserom.gba", 0x13D0A24, 0x100
+sSolrockSprites6:
+ax_sprite sSolrockGfx6, 0x100
+ax_sprite_terminator
+sSolrockGfx7:
+.incbin "baserom.gba", 0x13D0B34, 0x200
+sSolrockSprites7:
+ax_sprite sSolrockGfx7, 0x200
+ax_sprite_terminator
+sSolrockGfx8:
+.incbin "baserom.gba", 0x13D0D44, 0x200
+sSolrockSprites8:
+ax_sprite sSolrockGfx8, 0x200
+ax_sprite_terminator
+sSolrockGfx9:
+.incbin "baserom.gba", 0x13D0F54, 0x200
+sSolrockSprites9:
+ax_sprite sSolrockGfx9, 0x200
+ax_sprite_terminator
+sSolrockGfx10:
+.incbin "baserom.gba", 0x13D1164, 0x200
+sSolrockSprites10:
+ax_sprite sSolrockGfx10, 0x200
+ax_sprite_terminator
+sSolrockGfx11:
+.incbin "baserom.gba", 0x13D1374, 0xE0
+sSolrockSprites11:
+ax_sprite 0, 0x20
+ax_sprite sSolrockGfx11, 0xe0
+ax_sprite_terminator
+sSolrockGfx12:
+.incbin "baserom.gba", 0x13D146C, 0x60
+sSolrockSprites12:
+ax_sprite 0, 0x20
+ax_sprite sSolrockGfx12, 0x60
+ax_sprite_terminator
+sSolrockGfx13:
+.incbin "baserom.gba", 0x13D14E4, 0x20
+sSolrockSprites13:
+ax_sprite sSolrockGfx13, 0x20
+ax_sprite_terminator
+sSolrockGfx14:
+.incbin "baserom.gba", 0x13D1514, 0xC0
+sSolrockSprites14:
+ax_sprite sSolrockGfx14, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSolrockGfx15:
+.incbin "baserom.gba", 0x13D15EC, 0x40
+sSolrockSprites15:
+ax_sprite sSolrockGfx15, 0x40
+ax_sprite_terminator
+sSolrockGfx16:
+.incbin "baserom.gba", 0x13D163C, 0xC0
+sSolrockSprites16:
+ax_sprite sSolrockGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSolrockGfx17:
+.incbin "baserom.gba", 0x13D1714, 0xC0
+sSolrockSprites17:
+ax_sprite sSolrockGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSolrockGfx18:
+.incbin "baserom.gba", 0x13D17EC, 0x40
+sSolrockSprites18:
+ax_sprite sSolrockGfx18, 0x40
+ax_sprite_terminator
+sSolrockGfx19:
+.incbin "baserom.gba", 0x13D183C, 0xE0
+sSolrockSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSolrockGfx19, 0xe0
+ax_sprite_terminator
+sSolrockGfx20:
+.incbin "baserom.gba", 0x13D1934, 0x20
+sSolrockSprites20:
+ax_sprite sSolrockGfx20, 0x20
+ax_sprite_terminator
+sSolrockGfx21:
+.incbin "baserom.gba", 0x13D1964, 0x200
+sSolrockSprites21:
+ax_sprite sSolrockGfx21, 0x200
+ax_sprite_terminator
+sSolrockGfx22:
+.incbin "baserom.gba", 0x13D1B74, 0x200
+sSolrockSprites22:
+ax_sprite sSolrockGfx22, 0x200
+ax_sprite_terminator
+sSolrockGfx23:
+.incbin "baserom.gba", 0x13D1D84, 0x200
+sSolrockSprites23:
+ax_sprite sSolrockGfx23, 0x200
+ax_sprite_terminator
+sSolrockGfx24:
+.incbin "baserom.gba", 0x13D1F94, 0x200
+sSolrockSprites24:
+ax_sprite sSolrockGfx24, 0x200
+ax_sprite_terminator
+sSolrockGfx25:
+.incbin "baserom.gba", 0x13D21A4, 0x200
+sSolrockSprites25:
+ax_sprite sSolrockGfx25, 0x200
+ax_sprite_terminator
+sSolrockGfx26:
+.incbin "baserom.gba", 0x13D23B4, 0x200
+sSolrockSprites26:
+ax_sprite sSolrockGfx26, 0x200
+ax_sprite_terminator
+sSolrockGfx27:
+.incbin "baserom.gba", 0x13D25C4, 0x200
+sSolrockSprites27:
+ax_sprite sSolrockGfx27, 0x200
+ax_sprite_terminator
+sAxPosesSolrock:
+.4byte sSolrockPose1
+.4byte sSolrockPose2
+.4byte sSolrockPose3
+.4byte sSolrockPose4
+.4byte sSolrockPose5
+.4byte sSolrockPose6
+.4byte sSolrockPose7
+.4byte sSolrockPose8
+.4byte sSolrockPose9
+.4byte sSolrockPose10
+.4byte sSolrockPose11
+.4byte sSolrockPose12
+.4byte sSolrockPose13
+.4byte sSolrockPose14
+.4byte sSolrockPose15
+.4byte sSolrockPose16
+.4byte sSolrockPose17
+.4byte sSolrockPose18
+.4byte sSolrockPose19
+.4byte sSolrockPose20
+.4byte sSolrockPose21
+.4byte sSolrockPose22
+.4byte sSolrockPose23
+.4byte sSolrockPose24
+.4byte sSolrockPose25
+.4byte sSolrockPose26
+.4byte sSolrockPose27
+.4byte sSolrockPose28
+.4byte sSolrockPose29
+.4byte sSolrockPose30
+.4byte sSolrockPose31
+.4byte sSolrockPose32
+.4byte sSolrockPose33
+.4byte sSolrockPose34
+.4byte sSolrockPose35
+.4byte sSolrockPose36
+.4byte sSolrockPose37
+.4byte sSolrockPose38
+.4byte sSolrockPose39
+.4byte sSolrockPose40
+.4byte sSolrockPose41
+.4byte sSolrockPose42
+.4byte sSolrockPose43
+.4byte sSolrockPose44
+.4byte sSolrockPose45
+.4byte sSolrockPose46
+.4byte sSolrockPose47
+.4byte sSolrockPose48
+.4byte sSolrockPose49
+.4byte sSolrockPose50
+.4byte sSolrockPose51
+.4byte sSolrockPose52
+.4byte sSolrockPose53
+.4byte sSolrockPose54
+.4byte sSolrockPose55
+.4byte sSolrockPose56
+.4byte sSolrockPose57
+.4byte sSolrockPose58
+.4byte sSolrockPose59
+.4byte sSolrockPose60
+.4byte sSolrockPose61
+.4byte sSolrockPose62
+.4byte sSolrockPose63
+.4byte sSolrockPose64
+.4byte sSolrockPose65
+.4byte sSolrockPose66
+.4byte sSolrockPose67
+.4byte sSolrockPose68
+.4byte sSolrockPose69
+.4byte sSolrockPose70
+.4byte sSolrockPose71
+.4byte sSolrockPose72
+.4byte sSolrockPose73
+.4byte sSolrockPose74
+.4byte sSolrockPose75
+.4byte sSolrockPose76
+.4byte sSolrockPose77
+.4byte sSolrockPose78
+.4byte sSolrockPose79
+.4byte sSolrockPose80
+.4byte sSolrockPose81
+.4byte sSolrockPose82
+.4byte sSolrockPose83
+.4byte sSolrockPose84
+.4byte sSolrockPose85
+.4byte sSolrockPose86
+.4byte sSolrockPose87
+.4byte sSolrockPose88
+.4byte sSolrockPose89
+.4byte sSolrockPose90
+.4byte sSolrockPose91
+.4byte sSolrockPose92
+.4byte sSolrockPose93
+.4byte sSolrockPose94
+.4byte sSolrockPose95
+.4byte sSolrockPose96
+.4byte sSolrockPose97
+.4byte sSolrockPose98
+.4byte sSolrockPose99
+.4byte sSolrockPose100
+.4byte sSolrockPose101
+.4byte sSolrockPose102
+.4byte sSolrockPose103
+.4byte sSolrockPose104
+.4byte sSolrockPose105
+.4byte sSolrockPose106
+.4byte sSolrockPose107
+.4byte sSolrockPose108
+.4byte sSolrockPose109
+.4byte sSolrockPose110
+.4byte sSolrockPose111
+.4byte sSolrockPose112
+.4byte sSolrockPose113
+.4byte sSolrockPose114
+.4byte sSolrockPose115
+.4byte sSolrockPose116
+.4byte sSolrockPose117
+.4byte sSolrockPose118
+.4byte sSolrockPose119
+.4byte sSolrockPose120
+.4byte sSolrockPose121
+.4byte sSolrockPose122
+.4byte sSolrockPose123
+.4byte sSolrockPose124
+.4byte sSolrockPose125
+.4byte sSolrockPose126
+.4byte sSolrockPose127
+.4byte sSolrockPose128
+.4byte sSolrockPose129
+.4byte sSolrockPose130
+.4byte sSolrockPose131
+.4byte sSolrockPose132
+.4byte sSolrockPose133
+.4byte sSolrockPose134
+.4byte sSolrockPose135
+.4byte sSolrockPose136
+.4byte sSolrockPose137
+.4byte sSolrockPose138
+.4byte sSolrockPose139
+.4byte sSolrockPose140
+.4byte sSolrockPose141
+.4byte sSolrockPose142
+.4byte sSolrockPose143
+.4byte sSolrockPose144
+.4byte sSolrockPose145
+.4byte sSolrockPose146
+.4byte sSolrockPose147
+.4byte sSolrockPose148
+.4byte sSolrockPose149
+.4byte sSolrockPose150
+.4byte sSolrockPose151
+.4byte sSolrockPose152
+.4byte sSolrockPose153
+.4byte sSolrockPose154
+sAxPositionsSolrock:
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -13, 	   9,  -13, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -13, 	   9,  -13, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -13, 	   9,  -13, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -12, 	  10,  -12, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   7,  -16, 	  -7,   -8, 	   0,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    5,  -10, 	  -1,  -12, 	   1,   -8, 	  -1,  -10
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    4,  -11, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    0,  -13, 	   9,  -12, 	  -9,  -12, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,  -11, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -5,  -10, 	   1,  -12, 	  -1,   -8, 	   1,  -10
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -4,   -9, 	  -7,  -16, 	   7,   -8, 	   0,  -11
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -12, 	  10,  -12, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   7,  -16, 	  -7,   -8, 	   0,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    5,  -10, 	  -1,  -12, 	   1,   -8, 	  -1,  -10
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    4,  -11, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    0,  -13, 	   9,  -12, 	  -9,  -12, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,  -11, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -5,  -10, 	   1,  -12, 	  -1,   -8, 	   1,  -10
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -4,   -9, 	  -7,  -16, 	   7,   -8, 	   0,  -11
+.2byte   -5,  -10, 	  -6,  -17, 	   7,   -7, 	   0,  -11
+.2byte   -5,   -9, 	  -6,  -17, 	   7,   -7, 	   0,  -11
+.2byte    0,  -10, 	  -9,  -10, 	  10,  -10, 	   0,  -12
+.2byte    4,  -10, 	   5,  -18, 	  -9,   -8, 	  -1,  -11
+.2byte    4,  -11, 	  -2,  -13, 	   1,   -9, 	  -1,  -11
+.2byte    2,  -13, 	  -8,  -14, 	   6,  -10, 	  -1,  -10
+.2byte    0,  -12, 	  10,  -10, 	  -9,  -10, 	   0,   -8
+.2byte   -3,  -13, 	   7,  -14, 	  -7,  -10, 	   0,  -10
+.2byte   -5,  -11, 	   1,  -13, 	  -2,   -9, 	   0,  -11
+.2byte   -5,  -10, 	  -6,  -18, 	   8,   -8, 	   0,  -11
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -13, 	   9,  -13, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -12, 	  10,  -12, 	   0,  -11
+.2byte   -4,   -9, 	  -7,  -16, 	   7,   -8, 	   0,  -11
+.2byte   -5,  -10, 	   1,  -12, 	  -1,   -8, 	   1,  -10
+.2byte   -4,  -11, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte    0,  -13, 	   9,  -12, 	  -9,  -12, 	   0,  -11
+.2byte    4,  -11, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    5,  -10, 	  -1,  -12, 	   1,   -8, 	  -1,  -10
+.2byte    4,   -9, 	   7,  -16, 	  -7,   -8, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -13, 	   9,  -13, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -14, 	   0,   -8, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -12, 	  10,  -12, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+.2byte    4,   -9, 	   7,  -16, 	  -7,   -8, 	   0,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    5,  -10, 	  -1,  -12, 	   1,   -8, 	  -1,  -10
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    4,  -11, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    0,  -13, 	   9,  -12, 	  -9,  -12, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,  -11, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -5,  -10, 	   1,  -12, 	  -1,   -8, 	   1,  -10
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -4,   -9, 	  -7,  -16, 	   7,   -8, 	   0,  -11
+.2byte    0,   -9, 	  -9,  -12, 	  10,  -12, 	   0,  -11
+.2byte   -4,   -9, 	  -7,  -16, 	   7,   -8, 	   0,  -11
+.2byte   -5,  -10, 	   1,  -12, 	  -1,   -8, 	   1,  -10
+.2byte   -4,  -11, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte    0,  -13, 	   9,  -12, 	  -9,  -12, 	   0,  -11
+.2byte    4,  -11, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    5,  -10, 	  -1,  -12, 	   1,   -8, 	  -1,  -10
+.2byte    4,   -9, 	   7,  -16, 	  -7,   -8, 	   0,  -11
+.2byte    0,   -9, 	  -8,  -13, 	   9,  -13, 	   0,  -11
+.2byte   -3,   -8, 	  -7,  -16, 	   7,  -10, 	   0,  -11
+.2byte   -4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte   -2,  -10, 	   7,  -16, 	  -7,  -10, 	   1,  -11
+.2byte    0,  -12, 	   9,  -13, 	  -9,  -13, 	   0,  -11
+.2byte    2,  -10, 	  -7,  -16, 	   7,  -10, 	  -1,  -11
+.2byte    4,   -9, 	   0,  -13, 	   0,   -8, 	   0,  -11
+.2byte    3,   -8, 	   7,  -16, 	  -7,  -10, 	   0,  -11
+sSolrockAnimTable1:
+.4byte sSolrockAnims_1_1
+.4byte sSolrockAnims_1_2
+.4byte sSolrockAnims_1_3
+.4byte sSolrockAnims_1_4
+.4byte sSolrockAnims_1_5
+.4byte sSolrockAnims_1_6
+.4byte sSolrockAnims_1_7
+.4byte sSolrockAnims_1_8
+sSolrockAnimTable2:
+.4byte sSolrockAnims_2_1
+.4byte sSolrockAnims_2_2
+.4byte sSolrockAnims_2_3
+.4byte sSolrockAnims_2_4
+.4byte sSolrockAnims_2_5
+.4byte sSolrockAnims_2_6
+.4byte sSolrockAnims_2_7
+.4byte sSolrockAnims_2_8
+sSolrockAnimTable3:
+.4byte sSolrockAnims_3_1
+.4byte sSolrockAnims_3_2
+.4byte sSolrockAnims_3_3
+.4byte sSolrockAnims_3_4
+.4byte sSolrockAnims_3_5
+.4byte sSolrockAnims_3_6
+.4byte sSolrockAnims_3_7
+.4byte sSolrockAnims_3_8
+sSolrockAnimTable4:
+.4byte sSolrockAnims_4_1
+.4byte sSolrockAnims_4_2
+.4byte sSolrockAnims_4_3
+.4byte sSolrockAnims_4_4
+.4byte sSolrockAnims_4_5
+.4byte sSolrockAnims_4_6
+.4byte sSolrockAnims_4_7
+.4byte sSolrockAnims_4_8
+sSolrockAnimTable5:
+.4byte sSolrockAnims_5_1
+.4byte sSolrockAnims_5_2
+.4byte sSolrockAnims_5_3
+.4byte sSolrockAnims_5_4
+.4byte sSolrockAnims_5_5
+.4byte sSolrockAnims_5_6
+.4byte sSolrockAnims_5_7
+.4byte sSolrockAnims_5_8
+sSolrockAnimTable6:
+.4byte sSolrockAnims_6_1
+.4byte sSolrockAnims_6_1
+.4byte sSolrockAnims_6_1
+.4byte sSolrockAnims_6_1
+.4byte sSolrockAnims_6_1
+.4byte sSolrockAnims_6_1
+.4byte sSolrockAnims_6_1
+.4byte sSolrockAnims_6_1
+sSolrockAnimTable7:
+.4byte sSolrockAnims_7_1
+.4byte sSolrockAnims_7_2
+.4byte sSolrockAnims_7_3
+.4byte sSolrockAnims_7_4
+.4byte sSolrockAnims_7_5
+.4byte sSolrockAnims_7_6
+.4byte sSolrockAnims_7_7
+.4byte sSolrockAnims_7_8
+sSolrockAnimTable8:
+.4byte sSolrockAnims_8_1
+.4byte sSolrockAnims_8_2
+.4byte sSolrockAnims_8_3
+.4byte sSolrockAnims_8_4
+.4byte sSolrockAnims_8_5
+.4byte sSolrockAnims_8_6
+.4byte sSolrockAnims_8_7
+.4byte sSolrockAnims_8_8
+sSolrockAnimTable9:
+.4byte sSolrockAnims_9_1
+.4byte sSolrockAnims_9_2
+.4byte sSolrockAnims_9_3
+.4byte sSolrockAnims_9_4
+.4byte sSolrockAnims_9_5
+.4byte sSolrockAnims_9_6
+.4byte sSolrockAnims_9_7
+.4byte sSolrockAnims_9_8
+sSolrockAnimTable10:
+.4byte sSolrockAnims_10_1
+.4byte sSolrockAnims_10_2
+.4byte sSolrockAnims_10_3
+.4byte sSolrockAnims_10_4
+.4byte sSolrockAnims_10_5
+.4byte sSolrockAnims_10_6
+.4byte sSolrockAnims_10_7
+.4byte sSolrockAnims_10_8
+sSolrockAnimTable11:
+.4byte sSolrockAnims_11_1
+.4byte sSolrockAnims_11_2
+.4byte sSolrockAnims_11_3
+.4byte sSolrockAnims_11_4
+.4byte sSolrockAnims_11_5
+.4byte sSolrockAnims_11_6
+.4byte sSolrockAnims_11_7
+.4byte sSolrockAnims_11_8
+sSolrockAnimTable12:
+.4byte sSolrockAnims_12_1
+.4byte sSolrockAnims_12_2
+.4byte sSolrockAnims_12_3
+.4byte sSolrockAnims_12_4
+.4byte sSolrockAnims_12_5
+.4byte sSolrockAnims_12_6
+.4byte sSolrockAnims_12_7
+.4byte sSolrockAnims_12_8
+sSolrockAnimTable13:
+.4byte sSolrockAnims_13_1
+.4byte sSolrockAnims_13_2
+.4byte sSolrockAnims_13_3
+.4byte sSolrockAnims_13_4
+.4byte sSolrockAnims_13_5
+.4byte sSolrockAnims_13_6
+.4byte sSolrockAnims_13_7
+.4byte sSolrockAnims_13_8
+sAxAnimationsSolrock:
+.4byte sSolrockAnimTable1
+.4byte sSolrockAnimTable2
+.4byte sSolrockAnimTable3
+.4byte sSolrockAnimTable4
+.4byte sSolrockAnimTable5
+.4byte sSolrockAnimTable6
+.4byte sSolrockAnimTable7
+.4byte sSolrockAnimTable8
+.4byte sSolrockAnimTable9
+.4byte sSolrockAnimTable10
+.4byte sSolrockAnimTable11
+.4byte sSolrockAnimTable12
+.4byte sSolrockAnimTable13
+sAxSpritesSolrock:
+.4byte sSolrockSprites1
+.4byte sSolrockSprites2
+.4byte sSolrockSprites3
+.4byte sSolrockSprites4
+.4byte sSolrockSprites5
+.4byte sSolrockSprites6
+.4byte sSolrockSprites7
+.4byte sSolrockSprites8
+.4byte sSolrockSprites9
+.4byte sSolrockSprites10
+.4byte sSolrockSprites11
+.4byte sSolrockSprites12
+.4byte sSolrockSprites13
+.4byte sSolrockSprites14
+.4byte sSolrockSprites15
+.4byte sSolrockSprites16
+.4byte sSolrockSprites17
+.4byte sSolrockSprites18
+.4byte sSolrockSprites19
+.4byte sSolrockSprites20
+.4byte sSolrockSprites21
+.4byte sSolrockSprites22
+.4byte sSolrockSprites23
+.4byte sSolrockSprites24
+.4byte sSolrockSprites25
+.4byte sSolrockSprites26
+.4byte sSolrockSprites27
+sAxMainSolrock:
+ax_main sAxPosesSolrock, sAxAnimationsSolrock, 13, sAxSpritesSolrock, sAxPositionsSolrock

--- a/data/ax/spearow.inc
+++ b/data/ax/spearow.inc
@@ -1,0 +1,2908 @@
+.global gAxSpearow
+gAxSpearow:
+ax_siro sAxMainSpearow
+sSpearowPose1:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose2:
+ax_pose 1, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose3:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose4:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose5:
+ax_pose 4, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose6:
+ax_pose 5, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose7:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose8:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose9:
+ax_pose 8, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose10:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose11:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose12:
+ax_pose 11, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose13:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose14:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose15:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose16:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose17:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose18:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose19:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose20:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose21:
+ax_pose 8, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose22:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose23:
+ax_pose 4, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose24:
+ax_pose 5, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose25:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose26:
+ax_pose 15, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose27:
+ax_pose 16, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose28:
+ax_pose 17, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose29:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose30:
+ax_pose 18, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose31:
+ax_pose 19, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose32:
+ax_pose 20, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose33:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose34:
+ax_pose 21, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose35:
+ax_pose 22, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose36:
+ax_pose 23, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose37:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose38:
+ax_pose 24, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose39:
+ax_pose 25, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose40:
+ax_pose 26, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose41:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose42:
+ax_pose 27, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose43:
+ax_pose 28, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose44:
+ax_pose 29, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose45:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose46:
+ax_pose 24, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose47:
+ax_pose 25, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose48:
+ax_pose 26, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose49:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose50:
+ax_pose 21, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose51:
+ax_pose 22, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose52:
+ax_pose 23, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose53:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose54:
+ax_pose 18, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose55:
+ax_pose 19, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose56:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose57:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose58:
+ax_pose 15, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose59:
+ax_pose 16, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose60:
+ax_pose 17, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose61:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose62:
+ax_pose 18, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose63:
+ax_pose 19, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose64:
+ax_pose 20, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose65:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose66:
+ax_pose 21, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose67:
+ax_pose 22, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose68:
+ax_pose 23, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose69:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose70:
+ax_pose 24, 0x01e8, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose71:
+ax_pose 25, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose72:
+ax_pose 26, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose73:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose74:
+ax_pose 27, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose75:
+ax_pose 28, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose76:
+ax_pose 29, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose77:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose78:
+ax_pose 24, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose79:
+ax_pose 25, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose80:
+ax_pose 26, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose81:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose82:
+ax_pose 21, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose83:
+ax_pose 22, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose84:
+ax_pose 23, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose85:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose86:
+ax_pose 18, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose87:
+ax_pose 19, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose88:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose89:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose90:
+ax_pose 30, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose91:
+ax_pose 16, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose92:
+ax_pose 17, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose93:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose94:
+ax_pose 31, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose95:
+ax_pose 19, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose96:
+ax_pose 20, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose97:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose98:
+ax_pose 32, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose99:
+ax_pose 22, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose100:
+ax_pose 23, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose101:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose102:
+ax_pose 33, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose103:
+ax_pose 25, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose104:
+ax_pose 26, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose105:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose106:
+ax_pose 34, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose107:
+ax_pose 28, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose108:
+ax_pose 29, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose109:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose110:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose111:
+ax_pose 25, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose112:
+ax_pose 26, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose113:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose114:
+ax_pose 32, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose115:
+ax_pose 22, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose116:
+ax_pose 23, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose117:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose118:
+ax_pose 31, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose119:
+ax_pose 19, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose120:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose121:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose122:
+ax_pose 16, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose123:
+ax_pose 17, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose124:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose125:
+ax_pose 19, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose126:
+ax_pose 20, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose127:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose128:
+ax_pose 22, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose129:
+ax_pose 23, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose130:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose131:
+ax_pose 25, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose132:
+ax_pose 26, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose133:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose134:
+ax_pose 28, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose135:
+ax_pose 29, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose136:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose137:
+ax_pose 25, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose138:
+ax_pose 26, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose139:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose140:
+ax_pose 22, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose141:
+ax_pose 23, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose142:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose143:
+ax_pose 19, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose144:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose145:
+ax_pose 35, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose146:
+ax_pose 36, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose147:
+ax_pose 37, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose148:
+ax_pose 38, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose149:
+ax_pose 39, 0x01e5, 0x90e8, 0x4c00
+ax_pose_terminator
+sSpearowPose150:
+ax_pose 40, 0x01e6, 0x90e9, 0x4c00
+ax_pose_terminator
+sSpearowPose151:
+ax_pose 41, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose152:
+ax_pose 40, 0x01e6, 0x80f7, 0x4c00
+ax_pose_terminator
+sSpearowPose153:
+ax_pose 39, 0x01e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose154:
+ax_pose 38, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose155:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose156:
+ax_pose 1, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose157:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose158:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose159:
+ax_pose 4, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose160:
+ax_pose 5, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose161:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose162:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose163:
+ax_pose 8, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose164:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose165:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose166:
+ax_pose 11, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose167:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose168:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose169:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose170:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose171:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose172:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose173:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose174:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose175:
+ax_pose 8, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose176:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose177:
+ax_pose 4, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose178:
+ax_pose 5, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose179:
+ax_pose 30, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose180:
+ax_pose 31, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose181:
+ax_pose 32, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose182:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose183:
+ax_pose 34, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose184:
+ax_pose 33, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose185:
+ax_pose 32, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose186:
+ax_pose 31, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose187:
+ax_pose 30, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose188:
+ax_pose 31, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose189:
+ax_pose 32, 0x01e9, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose190:
+ax_pose 33, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose191:
+ax_pose 34, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose192:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose193:
+ax_pose 32, 0x01e9, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose194:
+ax_pose 31, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sSpearowPose195:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose196:
+ax_pose 30, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose197:
+ax_pose 17, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose198:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose199:
+ax_pose 31, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose200:
+ax_pose 20, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose201:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose202:
+ax_pose 32, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose203:
+ax_pose 23, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose204:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose205:
+ax_pose 33, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose206:
+ax_pose 26, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose207:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose208:
+ax_pose 34, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose209:
+ax_pose 29, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose210:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose211:
+ax_pose 33, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose212:
+ax_pose 26, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose213:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose214:
+ax_pose 32, 0x01ea, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose215:
+ax_pose 23, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose216:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose217:
+ax_pose 31, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose218:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose219:
+ax_pose 16, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose220:
+ax_pose 19, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sSpearowPose221:
+ax_pose 22, 0x01e8, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose222:
+ax_pose 25, 0x01e8, 0x80f1, 0x4c00
+ax_pose_terminator
+sSpearowPose223:
+ax_pose 28, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose224:
+ax_pose 25, 0x01e8, 0x90ee, 0x4c00
+ax_pose_terminator
+sSpearowPose225:
+ax_pose 22, 0x01e8, 0x90ec, 0x4c00
+ax_pose_terminator
+sSpearowPose226:
+ax_pose 19, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sSpearowPose227:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose228:
+ax_pose 3, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sSpearowPose229:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sSpearowPose230:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sSpearowPose231:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sSpearowPose232:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sSpearowPose233:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sSpearowPose234:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+.align 2
+sSpearowAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 1,
+ax_anim 4, 0, 1, 0, 1, 0, 2,
+ax_anim 4, 0, 2, 0, 2, 0, 2,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 1, 0, 1, 1,
+ax_anim 4, 0, 4, 2, -1, 2, 2,
+ax_anim 4, 0, 5, 1, 1, 2, 2,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 2, -2, 2, 0,
+ax_anim 4, 0, 8, 1, -1, 1, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, -1,
+ax_anim 4, 0, 10, 2, -2, 3, -3,
+ax_anim 4, 0, 11, 1, -1, 2, -1,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, -1,
+ax_anim 4, 0, 13, 0, -2, 0, -4,
+ax_anim 4, 0, 14, 0, -2, 0, -2,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, -1,
+ax_anim 4, 0, 16, -2, -2, -3, -3,
+ax_anim 4, 0, 17, -1, -1, -2, -1,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -2, -2, -2, 0,
+ax_anim 4, 0, 20, -1, -1, -1, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -1, 0, -1, 1,
+ax_anim 4, 0, 22, -2, -1, -2, 2,
+ax_anim 4, 0, 23, -1, 1, -2, 2,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, 0,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 4, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 5, 0, 5,
+ax_anim_terminator
+sSpearowAnims_2_2:
+ax_anim 2, 0, 30, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 4, 0, 31, 0, -5, 0, 0,
+ax_anim 1, 2, 29, 2, -1, 2, 2,
+ax_anim 1, 0, 29, 10, 10, 10, 12,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 1, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 29, 19, 22, 19, 22,
+ax_anim 2, 0, 29, 20, 21, 20, 21,
+ax_anim 2, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 5, 5, 5, 5,
+ax_anim_terminator
+sSpearowAnims_2_3:
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 4, 0, 35, 0, -5, 0, 0,
+ax_anim 1, 2, 33, 2, -5, 2, 2,
+ax_anim 1, 0, 33, 10, -3, 10, 0,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 1, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 33, 18, -1, 18, -1,
+ax_anim 2, 0, 35, 12, -2, 12, 0,
+ax_anim 2, 0, 35, 5, -3, 5, 0,
+ax_anim_terminator
+sSpearowAnims_2_4:
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 2, 0, 39, 0, -4, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 4, 0, 39, 0, -5, 0, 0,
+ax_anim 1, 2, 37, 2, -4, 2, -2,
+ax_anim 1, 0, 37, 10, -11, 10, -10,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 1, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 37, 19, -22, 19, -22,
+ax_anim 2, 0, 37, 18, -23, 18, -23,
+ax_anim 2, 0, 39, 12, -12, 12, -12,
+ax_anim 2, 0, 39, 5, -5, 5, -5,
+ax_anim_terminator
+sSpearowAnims_2_5:
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 4, 0, 43, 0, -5, 0, 0,
+ax_anim 1, 2, 41, 0, -8, 0, -2,
+ax_anim 1, 0, 41, 0, -12, 0, -8,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 1, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 41, 0, -19, 0, -19,
+ax_anim 2, 0, 41, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 43, 0, -5, 0, -5,
+ax_anim_terminator
+sSpearowAnims_2_6:
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 4, 0, 47, 0, -5, 0, 0,
+ax_anim 1, 2, 45, -2, -4, -2, -2,
+ax_anim 1, 0, 45, -10, -11, -10, -10,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 1, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 45, -19, -22, -19, -22,
+ax_anim 2, 0, 45, -18, -23, -18, -23,
+ax_anim 2, 0, 47, -12, -12, -12, -12,
+ax_anim 2, 0, 47, -5, -5, -5, -5,
+ax_anim_terminator
+sSpearowAnims_2_7:
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 49, -2, -5, -2, 2,
+ax_anim 1, 0, 49, -10, -3, -10, 0,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 1, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -18, -1, -18, -1,
+ax_anim 2, 0, 51, -12, -2, -12, 0,
+ax_anim 2, 0, 51, -5, -3, -5, 0,
+ax_anim_terminator
+sSpearowAnims_2_8:
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 4, 0, 55, 0, -5, 0, 0,
+ax_anim 1, 2, 53, -2, -3, -2, 2,
+ax_anim 1, 0, 53, -10, 9, -10, 12,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 1, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 0, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 53, -19, 22, -19, 22,
+ax_anim 2, 0, 53, -20, 21, -20, 21,
+ax_anim 2, 0, 55, -12, 12, -12, 12,
+ax_anim 2, 0, 55, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sSpearowAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 4, 0, 59, 0, -5, 0, 0,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 1, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 57, 0, 20, 0, 20,
+ax_anim 2, 0, 57, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 5, 0, 5,
+ax_anim_terminator
+sSpearowAnims_3_2:
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 63, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -5, 0, 0,
+ax_anim 4, 0, 63, 0, -5, 0, 0,
+ax_anim 1, 2, 61, 2, -1, 2, 2,
+ax_anim 1, 0, 61, 10, 10, 10, 12,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 1, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 0, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 61, 19, 22, 19, 22,
+ax_anim 2, 0, 61, 20, 21, 20, 21,
+ax_anim 2, 0, 63, 12, 12, 12, 12,
+ax_anim 2, 0, 63, 5, 5, 5, 5,
+ax_anim_terminator
+sSpearowAnims_3_3:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 4, 0, 67, 0, -5, 0, 0,
+ax_anim 1, 2, 65, 2, -5, 2, 2,
+ax_anim 1, 0, 65, 10, -3, 10, 0,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 1, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 0, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 0, 65, 18, -1, 18, -1,
+ax_anim 2, 0, 67, 12, -2, 12, 0,
+ax_anim 2, 0, 67, 5, -3, 5, 0,
+ax_anim_terminator
+sSpearowAnims_3_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 4, 0, 71, 0, -5, 0, 0,
+ax_anim 1, 2, 69, 2, -4, 2, -2,
+ax_anim 1, 0, 69, 10, -11, 10, -10,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 1, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 0, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 69, 19, -22, 19, -22,
+ax_anim 2, 0, 69, 18, -23, 18, -23,
+ax_anim 2, 0, 71, 12, -12, 12, -12,
+ax_anim 2, 0, 71, 5, -5, 5, -5,
+ax_anim_terminator
+sSpearowAnims_3_5:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 4, 0, 75, 0, -5, 0, 0,
+ax_anim 1, 2, 73, 0, -8, 0, -2,
+ax_anim 1, 0, 73, 0, -12, 0, -8,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 1, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 73, 0, -19, 0, -19,
+ax_anim 2, 0, 73, 1, -19, 1, -19,
+ax_anim 2, 0, 75, 0, -12, 0, -12,
+ax_anim 2, 0, 75, 0, -5, 0, -5,
+ax_anim_terminator
+sSpearowAnims_3_6:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 4, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 2, 77, -2, -4, -2, -2,
+ax_anim 1, 0, 77, -10, -11, -10, -10,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 1, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 0, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 77, -19, -22, -19, -22,
+ax_anim 2, 0, 77, -18, -23, -18, -23,
+ax_anim 2, 0, 79, -12, -12, -12, -12,
+ax_anim 2, 0, 79, -5, -5, -5, -5,
+ax_anim_terminator
+sSpearowAnims_3_7:
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 0, 83, 0, -5, 0, 0,
+ax_anim 1, 2, 81, -2, -5, -2, 2,
+ax_anim 1, 0, 81, -10, -3, -10, 0,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 1, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 0, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 0, 81, -18, -1, -18, -1,
+ax_anim 2, 0, 83, -12, -2, -12, 0,
+ax_anim 2, 0, 83, -5, -3, -5, 0,
+ax_anim_terminator
+sSpearowAnims_3_8:
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 4, 0, 87, 0, -5, 0, 0,
+ax_anim 1, 2, 85, -2, -3, -2, 2,
+ax_anim 1, 0, 85, -10, 9, -10, 12,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 1, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 0, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 85, -19, 22, -19, 22,
+ax_anim 2, 0, 85, -20, 21, -20, 21,
+ax_anim 2, 0, 87, -12, 12, -12, 12,
+ax_anim 2, 0, 87, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sSpearowAnims_4_1:
+ax_anim 2, 0, 90, 0, -2, 0, 0,
+ax_anim 3, 0, 91, 0, -4, 0, 0,
+ax_anim 3, 0, 90, 0, -5, 0, 0,
+ax_anim 3, 2, 91, 0, -5, 0, 0,
+ax_anim 3, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 2,
+ax_anim 2, 1, 89, 1, -2, 1, 2,
+ax_anim 2, 0, 89, 0, -2, 0, 2,
+ax_anim 2, 0, 89, 1, -2, 1, 2,
+ax_anim 2, 0, 89, 0, -2, 0, 2,
+ax_anim 2, 0, 89, 1, -2, 1, 2,
+ax_anim 2, 0, 91, 0, -4, 0, 0,
+ax_anim_terminator
+sSpearowAnims_4_2:
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 3, 0, 95, 0, -4, 0, 0,
+ax_anim 3, 0, 94, 0, -5, 0, 0,
+ax_anim 3, 2, 95, 0, -5, 0, 0,
+ax_anim 3, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 2, -2, 2, 2,
+ax_anim 2, 1, 93, 3, -3, 3, 1,
+ax_anim 2, 0, 93, 2, -2, 2, 2,
+ax_anim 2, 0, 93, 3, -3, 3, 1,
+ax_anim 2, 0, 93, 2, -2, 2, 2,
+ax_anim 2, 0, 93, 3, -3, 3, 1,
+ax_anim 2, 0, 95, 0, -4, 0, 0,
+ax_anim_terminator
+sSpearowAnims_4_3:
+ax_anim 2, 0, 98, 0, -2, 0, 0,
+ax_anim 3, 0, 99, 0, -4, 0, 0,
+ax_anim 3, 0, 98, 0, -5, 0, 0,
+ax_anim 3, 2, 99, 0, -5, 0, 0,
+ax_anim 3, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 3, -5, 3, 0,
+ax_anim 2, 1, 97, 3, -6, 3, -1,
+ax_anim 2, 0, 97, 3, -5, 3, 0,
+ax_anim 2, 0, 97, 3, -6, 3, -1,
+ax_anim 2, 0, 97, 3, -5, 3, 0,
+ax_anim 2, 0, 97, 3, -6, 3, -1,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim_terminator
+sSpearowAnims_4_4:
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 3, 0, 103, 0, -4, 0, 0,
+ax_anim 3, 0, 102, 0, -5, 0, 0,
+ax_anim 3, 2, 103, 0, -5, 0, 0,
+ax_anim 3, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 2, -7, 2, -2,
+ax_anim 2, 1, 101, 3, -6, 3, -1,
+ax_anim 2, 0, 101, 2, -7, 2, -2,
+ax_anim 2, 0, 101, 3, -6, 3, -1,
+ax_anim 2, 0, 101, 2, -7, 2, -2,
+ax_anim 2, 0, 101, 3, -6, 3, -1,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_4_5:
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 3, 0, 107, 0, -4, 0, 0,
+ax_anim 3, 0, 106, 0, -5, 0, 0,
+ax_anim 3, 2, 107, 0, -5, 0, 0,
+ax_anim 3, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 105, 0, -8, 0, -3,
+ax_anim 2, 1, 105, 1, -8, 1, -3,
+ax_anim 2, 0, 105, 0, -8, 0, -3,
+ax_anim 2, 0, 105, 1, -8, 1, -3,
+ax_anim 2, 0, 105, 0, -8, 0, -3,
+ax_anim 2, 0, 105, 1, -8, 1, -3,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_4_6:
+ax_anim 2, 0, 110, 0, -2, 0, 0,
+ax_anim 3, 0, 111, 0, -4, 0, 0,
+ax_anim 3, 0, 110, 0, -5, 0, 0,
+ax_anim 3, 2, 111, 0, -5, 0, 0,
+ax_anim 3, 0, 110, 0, -5, 0, 0,
+ax_anim 2, 0, 109, -2, -7, -2, -2,
+ax_anim 2, 1, 109, -3, -6, -3, -1,
+ax_anim 2, 0, 109, -2, -7, -2, -2,
+ax_anim 2, 0, 109, -3, -6, -3, -1,
+ax_anim 2, 0, 109, -2, -7, -2, -2,
+ax_anim 2, 0, 109, -3, -6, -3, -1,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_4_7:
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 3, 0, 115, 0, -4, 0, 0,
+ax_anim 3, 0, 114, 0, -5, 0, 0,
+ax_anim 3, 2, 115, 0, -5, 0, 0,
+ax_anim 3, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 113, -3, -5, -3, 0,
+ax_anim 2, 1, 113, -3, -6, -3, -1,
+ax_anim 2, 0, 113, -3, -5, -3, 0,
+ax_anim 2, 0, 113, -3, -6, -3, -1,
+ax_anim 2, 0, 113, -3, -5, -3, 0,
+ax_anim 2, 0, 113, -3, -6, -3, -1,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim_terminator
+sSpearowAnims_4_8:
+ax_anim 2, 0, 118, 0, -2, 0, 0,
+ax_anim 3, 0, 119, 0, -4, 0, 0,
+ax_anim 3, 0, 118, 0, -5, 0, 0,
+ax_anim 3, 2, 119, 0, -5, 0, 0,
+ax_anim 3, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 117, -2, -2, -2, 2,
+ax_anim 2, 1, 117, -3, -3, -3, 1,
+ax_anim 2, 0, 117, -2, -2, -2, 2,
+ax_anim 2, 0, 117, -3, -3, -3, 1,
+ax_anim 2, 0, 117, -2, -2, -2, 2,
+ax_anim 2, 0, 117, -3, -3, -3, 1,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_5_1:
+ax_anim 3, 0, 121, 0, -2, 0, 0,
+ax_anim 3, 0, 122, 0, -4, 0, 0,
+ax_anim 3, 0, 121, 0, -5, 0, 0,
+ax_anim 3, 0, 122, 0, -6, 0, 0,
+ax_anim 3, 0, 121, 0, -7, 0, 0,
+ax_anim 3, 2, 122, 0, -7, 0, 0,
+ax_anim 3, 0, 121, 0, -7, 0, 0,
+ax_anim 3, 0, 122, 0, -7, 0, 0,
+ax_anim 3, 0, 121, 0, -7, 0, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_5_2:
+ax_anim 3, 0, 124, 0, -2, 0, 0,
+ax_anim 3, 0, 125, 0, -4, 0, 0,
+ax_anim 3, 0, 124, 0, -5, 0, 0,
+ax_anim 3, 0, 125, 0, -6, 0, 0,
+ax_anim 3, 0, 124, 0, -7, 0, 0,
+ax_anim 3, 2, 125, 0, -7, 0, 0,
+ax_anim 3, 0, 124, 0, -7, 0, 0,
+ax_anim 3, 0, 125, 0, -7, 0, 0,
+ax_anim 3, 0, 124, 0, -7, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_5_3:
+ax_anim 3, 0, 127, 0, -2, 0, 0,
+ax_anim 3, 0, 128, 0, -4, 0, 0,
+ax_anim 3, 0, 127, 0, -5, 0, 0,
+ax_anim 3, 0, 128, 0, -6, 0, 0,
+ax_anim 3, 0, 127, 0, -7, 0, 0,
+ax_anim 3, 2, 128, 0, -7, 0, 0,
+ax_anim 3, 0, 127, 0, -7, 0, 0,
+ax_anim 3, 0, 128, 0, -7, 0, 0,
+ax_anim 3, 0, 127, 0, -7, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 1, 0, 127, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_5_4:
+ax_anim 3, 0, 130, 0, -2, 0, 0,
+ax_anim 3, 0, 131, 0, -4, 0, 0,
+ax_anim 3, 0, 130, 0, -5, 0, 0,
+ax_anim 3, 0, 131, 0, -6, 0, 0,
+ax_anim 3, 0, 130, 0, -7, 0, 0,
+ax_anim 3, 2, 131, 0, -7, 0, 0,
+ax_anim 3, 0, 130, 0, -7, 0, 0,
+ax_anim 3, 0, 131, 0, -7, 0, 0,
+ax_anim 3, 0, 130, 0, -7, 0, 0,
+ax_anim 2, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_5_5:
+ax_anim 3, 0, 133, 0, -2, 0, 0,
+ax_anim 3, 0, 134, 0, -4, 0, 0,
+ax_anim 3, 0, 133, 0, -5, 0, 0,
+ax_anim 3, 0, 134, 0, -6, 0, 0,
+ax_anim 3, 0, 133, 0, -7, 0, 0,
+ax_anim 3, 2, 134, 0, -7, 0, 0,
+ax_anim 3, 0, 133, 0, -7, 0, 0,
+ax_anim 3, 0, 134, 0, -7, 0, 0,
+ax_anim 3, 0, 133, 0, -7, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_5_6:
+ax_anim 3, 0, 136, 0, -2, 0, 0,
+ax_anim 3, 0, 137, 0, -4, 0, 0,
+ax_anim 3, 0, 136, 0, -5, 0, 0,
+ax_anim 3, 0, 137, 0, -6, 0, 0,
+ax_anim 3, 0, 136, 0, -7, 0, 0,
+ax_anim 3, 2, 137, 0, -7, 0, 0,
+ax_anim 3, 0, 136, 0, -7, 0, 0,
+ax_anim 3, 0, 137, 0, -7, 0, 0,
+ax_anim 3, 0, 136, 0, -7, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 1, 0, 136, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_5_7:
+ax_anim 3, 0, 139, 0, -2, 0, 0,
+ax_anim 3, 0, 140, 0, -4, 0, 0,
+ax_anim 3, 0, 139, 0, -5, 0, 0,
+ax_anim 3, 0, 140, 0, -6, 0, 0,
+ax_anim 3, 0, 139, 0, -7, 0, 0,
+ax_anim 3, 2, 140, 0, -7, 0, 0,
+ax_anim 3, 0, 139, 0, -7, 0, 0,
+ax_anim 3, 0, 140, 0, -7, 0, 0,
+ax_anim 3, 0, 139, 0, -7, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim_terminator
+sSpearowAnims_5_8:
+ax_anim 3, 0, 142, 0, -2, 0, 0,
+ax_anim 3, 0, 143, 0, -4, 0, 0,
+ax_anim 3, 0, 142, 0, -5, 0, 0,
+ax_anim 3, 0, 143, 0, -6, 0, 0,
+ax_anim 3, 0, 142, 0, -7, 0, 0,
+ax_anim 3, 2, 143, 0, -7, 0, 0,
+ax_anim 3, 0, 142, 0, -7, 0, 0,
+ax_anim 3, 0, 143, 0, -7, 0, 0,
+ax_anim 3, 0, 142, 0, -7, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sSpearowAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sSpearowAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sSpearowAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sSpearowAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sSpearowAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sSpearowAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sSpearowAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSpearowAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 3, 0, 155, 0, -2, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 158, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 3, 0, 158, 0, -2, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 3, 0, 161, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 3, 0, 161, 0, -2, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 3, 0, 164, 0, -2, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim 3, 0, 164, 0, -2, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 167, 0, -2, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 3, 0, 167, 0, -2, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 3, 0, 170, 0, -2, 0, 0,
+ax_anim 4, 0, 170, 0, -3, 0, 0,
+ax_anim 3, 0, 170, 0, -2, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 3, 0, 173, 0, -2, 0, 0,
+ax_anim 4, 0, 173, 0, -3, 0, 0,
+ax_anim 3, 0, 173, 0, -2, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 3, 0, 176, 0, -2, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 3, 0, 176, 0, -2, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 4, 6, 4,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 19, 7, 19,
+ax_anim 3, 0, 182, 0, 22, 0, 22,
+ax_anim 2, 3, 183, -7, 19, -7, 19,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 4, -6, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 24, 9, 24, 9,
+ax_anim 3, 0, 181, 23, 21, 23, 21,
+ax_anim 2, 3, 182, 11, 21, 11, 21,
+ax_anim 2, 0, 183, 2, 12, 2, 12,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -4, 3, -4,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 19, -4, 19, -4,
+ax_anim 3, 0, 180, 23, 1, 23, 1,
+ax_anim 2, 3, 181, 19, 5, 19, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -8, -1, -8,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 13, -22, 13, -22,
+ax_anim 3, 0, 179, 21, -23, 21, -23,
+ax_anim 2, 3, 180, 22, -14, 22, -14,
+ax_anim 2, 0, 181, 16, -4, 16, -4,
+ax_anim 1, 0, 182, 7, 0, 7, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -6, -4, -6, -4,
+ax_anim 2, 0, 184, -8, -10, -8, -10,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 8, -8, 8, -8,
+ax_anim 1, 0, 181, 6, -4, 6, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -13, -22, -13, -22,
+ax_anim 3, 0, 185, -21, -23, -21, -23,
+ax_anim 2, 3, 184, -22, -14, -22, -14,
+ax_anim 2, 0, 183, -16, -4, -16, -4,
+ax_anim 1, 0, 182, -7, 0, -7, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -4, -3, -4,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -19, -4, -19, -4,
+ax_anim 3, 0, 184, -23, 1, -23, 1,
+ax_anim 2, 3, 183, -19, 5, -19, 5,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -24, 9, -24, 9,
+ax_anim 3, 0, 183, -23, 21, -23, 16,
+ax_anim 2, 3, 182, -11, 21, -11, 16,
+ax_anim 2, 0, 181, -2, 12, -4, 12,
+ax_anim 1, 0, 180, 0, 7, -3, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -18, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -22, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 1, 0, 204, 0, -11, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 210, 0, -21, 0, 0,
+ax_anim 2, 0, 210, 0, -17, 0, 0,
+ax_anim 1, 0, 210, 0, -11, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpearowAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sSpearowGfx1:
+.incbin "baserom.gba", 0x5ED4E0, 0x100
+sSpearowSprites1:
+ax_sprite sSpearowGfx1, 0x100
+ax_sprite_terminator
+sSpearowGfx2:
+.incbin "baserom.gba", 0x5ED5F0, 0x100
+sSpearowSprites2:
+ax_sprite sSpearowGfx2, 0x100
+ax_sprite_terminator
+sSpearowGfx3:
+.incbin "baserom.gba", 0x5ED700, 0x100
+sSpearowSprites3:
+ax_sprite sSpearowGfx3, 0x100
+ax_sprite_terminator
+sSpearowGfx4:
+.incbin "baserom.gba", 0x5ED810, 0x200
+sSpearowSprites4:
+ax_sprite sSpearowGfx4, 0x200
+ax_sprite_terminator
+sSpearowGfx5:
+.incbin "baserom.gba", 0x5EDA20, 0x200
+sSpearowSprites5:
+ax_sprite sSpearowGfx5, 0x200
+ax_sprite_terminator
+sSpearowGfx6:
+.incbin "baserom.gba", 0x5EDC30, 0x200
+sSpearowSprites6:
+ax_sprite sSpearowGfx6, 0x200
+ax_sprite_terminator
+sSpearowGfx7:
+.incbin "baserom.gba", 0x5EDE40, 0x200
+sSpearowSprites7:
+ax_sprite sSpearowGfx7, 0x200
+ax_sprite_terminator
+sSpearowGfx8:
+.incbin "baserom.gba", 0x5EE050, 0x200
+sSpearowSprites8:
+ax_sprite sSpearowGfx8, 0x200
+ax_sprite_terminator
+sSpearowGfx9:
+.incbin "baserom.gba", 0x5EE260, 0x200
+sSpearowSprites9:
+ax_sprite sSpearowGfx9, 0x200
+ax_sprite_terminator
+sSpearowGfx10:
+.incbin "baserom.gba", 0x5EE470, 0x200
+sSpearowSprites10:
+ax_sprite sSpearowGfx10, 0x200
+ax_sprite_terminator
+sSpearowGfx11:
+.incbin "baserom.gba", 0x5EE680, 0x200
+sSpearowSprites11:
+ax_sprite sSpearowGfx11, 0x200
+ax_sprite_terminator
+sSpearowGfx12:
+.incbin "baserom.gba", 0x5EE890, 0x200
+sSpearowSprites12:
+ax_sprite sSpearowGfx12, 0x200
+ax_sprite_terminator
+sSpearowGfx13:
+.incbin "baserom.gba", 0x5EEAA0, 0x100
+sSpearowSprites13:
+ax_sprite sSpearowGfx13, 0x100
+ax_sprite_terminator
+sSpearowGfx14:
+.incbin "baserom.gba", 0x5EEBB0, 0x100
+sSpearowSprites14:
+ax_sprite sSpearowGfx14, 0x100
+ax_sprite_terminator
+sSpearowGfx15:
+.incbin "baserom.gba", 0x5EECC0, 0x100
+sSpearowSprites15:
+ax_sprite sSpearowGfx15, 0x100
+ax_sprite_terminator
+sSpearowGfx16:
+.incbin "baserom.gba", 0x5EEDD0, 0x40
+sSpearowGfx16_1:
+.incbin "baserom.gba", 0x5EEE10, 0xE0
+sSpearowSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx16_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx17:
+.incbin "baserom.gba", 0x5EEF20, 0x100
+sSpearowGfx17_1:
+.incbin "baserom.gba", 0x5EF020, 0x40
+sSpearowSprites17:
+ax_sprite sSpearowGfx17, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx17_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx18:
+.incbin "baserom.gba", 0x5EF088, 0x40
+sSpearowGfx18_1:
+.incbin "baserom.gba", 0x5EF0C8, 0x60
+sSpearowGfx18_2:
+.incbin "baserom.gba", 0x5EF128, 0x80
+sSpearowSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx18_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSpearowGfx19:
+.incbin "baserom.gba", 0x5EF1E8, 0x60
+sSpearowGfx19_1:
+.incbin "baserom.gba", 0x5EF248, 0xE0
+sSpearowSprites19:
+ax_sprite sSpearowGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx19_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx20:
+.incbin "baserom.gba", 0x5EF350, 0x60
+sSpearowGfx20_1:
+.incbin "baserom.gba", 0x5EF3B0, 0x60
+sSpearowGfx20_2:
+.incbin "baserom.gba", 0x5EF410, 0x60
+sSpearowSprites20:
+ax_sprite sSpearowGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx21:
+.incbin "baserom.gba", 0x5EF4A8, 0x40
+sSpearowGfx21_1:
+.incbin "baserom.gba", 0x5EF4E8, 0x60
+sSpearowGfx21_2:
+.incbin "baserom.gba", 0x5EF548, 0x60
+sSpearowSprites21:
+ax_sprite sSpearowGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx22:
+.incbin "baserom.gba", 0x5EF5E0, 0x20
+sSpearowGfx22_1:
+.incbin "baserom.gba", 0x5EF600, 0x60
+sSpearowGfx22_2:
+.incbin "baserom.gba", 0x5EF660, 0x60
+sSpearowSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx23:
+.incbin "baserom.gba", 0x5EF700, 0x20
+sSpearowGfx23_1:
+.incbin "baserom.gba", 0x5EF720, 0x60
+sSpearowGfx23_2:
+.incbin "baserom.gba", 0x5EF780, 0x60
+sSpearowGfx23_3:
+.incbin "baserom.gba", 0x5EF7E0, 0x40
+sSpearowSprites23:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx23, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpearowGfx24:
+.incbin "baserom.gba", 0x5EF870, 0x20
+sSpearowGfx24_1:
+.incbin "baserom.gba", 0x5EF890, 0x40
+sSpearowGfx24_2:
+.incbin "baserom.gba", 0x5EF8D0, 0x60
+sSpearowGfx24_3:
+.incbin "baserom.gba", 0x5EF930, 0x40
+sSpearowSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx24, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpearowGfx25:
+.incbin "baserom.gba", 0x5EF9C0, 0x20
+sSpearowGfx25_1:
+.incbin "baserom.gba", 0x5EF9E0, 0xE0
+sSpearowSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx25_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx26:
+.incbin "baserom.gba", 0x5EFAF0, 0x20
+sSpearowGfx26_1:
+.incbin "baserom.gba", 0x5EFB10, 0x60
+sSpearowGfx26_2:
+.incbin "baserom.gba", 0x5EFB70, 0x60
+sSpearowGfx26_3:
+.incbin "baserom.gba", 0x5EFBD0, 0x20
+sSpearowSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx26, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx26_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSpearowGfx26_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpearowGfx27:
+.incbin "baserom.gba", 0x5EFC40, 0x20
+sSpearowGfx27_1:
+.incbin "baserom.gba", 0x5EFC60, 0x60
+sSpearowGfx27_2:
+.incbin "baserom.gba", 0x5EFCC0, 0x60
+sSpearowGfx27_3:
+.incbin "baserom.gba", 0x5EFD20, 0x60
+sSpearowSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpearowGfx28:
+.incbin "baserom.gba", 0x5EFDD0, 0x40
+sSpearowGfx28_1:
+.incbin "baserom.gba", 0x5EFE10, 0x100
+sSpearowSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx28_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSpearowGfx29:
+.incbin "baserom.gba", 0x5EFF40, 0x40
+sSpearowGfx29_1:
+.incbin "baserom.gba", 0x5EFF80, 0xE0
+sSpearowGfx29_2:
+.incbin "baserom.gba", 0x5F0060, 0x40
+sSpearowSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx29_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpearowGfx30:
+.incbin "baserom.gba", 0x5F00E0, 0x40
+sSpearowGfx30_1:
+.incbin "baserom.gba", 0x5F0120, 0x40
+sSpearowGfx30_2:
+.incbin "baserom.gba", 0x5F0160, 0x80
+sSpearowGfx30_3:
+.incbin "baserom.gba", 0x5F01E0, 0x40
+sSpearowSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx30_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpearowGfx31:
+.incbin "baserom.gba", 0x5F0270, 0x40
+sSpearowGfx31_1:
+.incbin "baserom.gba", 0x5F02B0, 0x80
+sSpearowGfx31_2:
+.incbin "baserom.gba", 0x5F0330, 0x40
+sSpearowSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx31_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx31_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx32:
+.incbin "baserom.gba", 0x5F03B0, 0x40
+sSpearowGfx32_1:
+.incbin "baserom.gba", 0x5F03F0, 0x60
+sSpearowGfx32_2:
+.incbin "baserom.gba", 0x5F0450, 0x60
+sSpearowSprites32:
+ax_sprite sSpearowGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx33:
+.incbin "baserom.gba", 0x5F04E8, 0x40
+sSpearowGfx33_1:
+.incbin "baserom.gba", 0x5F0528, 0x60
+sSpearowGfx33_2:
+.incbin "baserom.gba", 0x5F0588, 0x60
+sSpearowGfx33_3:
+.incbin "baserom.gba", 0x5F05E8, 0x20
+sSpearowSprites33:
+ax_sprite sSpearowGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpearowGfx33_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSpearowGfx34:
+.incbin "baserom.gba", 0x5F0650, 0x40
+sSpearowGfx34_1:
+.incbin "baserom.gba", 0x5F0690, 0x60
+sSpearowGfx34_2:
+.incbin "baserom.gba", 0x5F06F0, 0x60
+sSpearowSprites34:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpearowGfx35:
+.incbin "baserom.gba", 0x5F0790, 0x40
+sSpearowGfx35_1:
+.incbin "baserom.gba", 0x5F07D0, 0x100
+sSpearowSprites35:
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpearowGfx35_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSpearowGfx36:
+.incbin "baserom.gba", 0x5F0900, 0x200
+sSpearowSprites36:
+ax_sprite sSpearowGfx36, 0x200
+ax_sprite_terminator
+sSpearowGfx37:
+.incbin "baserom.gba", 0x5F0B10, 0x200
+sSpearowSprites37:
+ax_sprite sSpearowGfx37, 0x200
+ax_sprite_terminator
+sSpearowGfx38:
+.incbin "baserom.gba", 0x5F0D20, 0x200
+sSpearowSprites38:
+ax_sprite sSpearowGfx38, 0x200
+ax_sprite_terminator
+sSpearowGfx39:
+.incbin "baserom.gba", 0x5F0F30, 0x200
+sSpearowSprites39:
+ax_sprite sSpearowGfx39, 0x200
+ax_sprite_terminator
+sSpearowGfx40:
+.incbin "baserom.gba", 0x5F1140, 0x200
+sSpearowSprites40:
+ax_sprite sSpearowGfx40, 0x200
+ax_sprite_terminator
+sSpearowGfx41:
+.incbin "baserom.gba", 0x5F1350, 0x200
+sSpearowSprites41:
+ax_sprite sSpearowGfx41, 0x200
+ax_sprite_terminator
+sSpearowGfx42:
+.incbin "baserom.gba", 0x5F1560, 0x200
+sSpearowSprites42:
+ax_sprite sSpearowGfx42, 0x200
+ax_sprite_terminator
+sAxPosesSpearow:
+.4byte sSpearowPose1
+.4byte sSpearowPose2
+.4byte sSpearowPose3
+.4byte sSpearowPose4
+.4byte sSpearowPose5
+.4byte sSpearowPose6
+.4byte sSpearowPose7
+.4byte sSpearowPose8
+.4byte sSpearowPose9
+.4byte sSpearowPose10
+.4byte sSpearowPose11
+.4byte sSpearowPose12
+.4byte sSpearowPose13
+.4byte sSpearowPose14
+.4byte sSpearowPose15
+.4byte sSpearowPose16
+.4byte sSpearowPose17
+.4byte sSpearowPose18
+.4byte sSpearowPose19
+.4byte sSpearowPose20
+.4byte sSpearowPose21
+.4byte sSpearowPose22
+.4byte sSpearowPose23
+.4byte sSpearowPose24
+.4byte sSpearowPose25
+.4byte sSpearowPose26
+.4byte sSpearowPose27
+.4byte sSpearowPose28
+.4byte sSpearowPose29
+.4byte sSpearowPose30
+.4byte sSpearowPose31
+.4byte sSpearowPose32
+.4byte sSpearowPose33
+.4byte sSpearowPose34
+.4byte sSpearowPose35
+.4byte sSpearowPose36
+.4byte sSpearowPose37
+.4byte sSpearowPose38
+.4byte sSpearowPose39
+.4byte sSpearowPose40
+.4byte sSpearowPose41
+.4byte sSpearowPose42
+.4byte sSpearowPose43
+.4byte sSpearowPose44
+.4byte sSpearowPose45
+.4byte sSpearowPose46
+.4byte sSpearowPose47
+.4byte sSpearowPose48
+.4byte sSpearowPose49
+.4byte sSpearowPose50
+.4byte sSpearowPose51
+.4byte sSpearowPose52
+.4byte sSpearowPose53
+.4byte sSpearowPose54
+.4byte sSpearowPose55
+.4byte sSpearowPose56
+.4byte sSpearowPose57
+.4byte sSpearowPose58
+.4byte sSpearowPose59
+.4byte sSpearowPose60
+.4byte sSpearowPose61
+.4byte sSpearowPose62
+.4byte sSpearowPose63
+.4byte sSpearowPose64
+.4byte sSpearowPose65
+.4byte sSpearowPose66
+.4byte sSpearowPose67
+.4byte sSpearowPose68
+.4byte sSpearowPose69
+.4byte sSpearowPose70
+.4byte sSpearowPose71
+.4byte sSpearowPose72
+.4byte sSpearowPose73
+.4byte sSpearowPose74
+.4byte sSpearowPose75
+.4byte sSpearowPose76
+.4byte sSpearowPose77
+.4byte sSpearowPose78
+.4byte sSpearowPose79
+.4byte sSpearowPose80
+.4byte sSpearowPose81
+.4byte sSpearowPose82
+.4byte sSpearowPose83
+.4byte sSpearowPose84
+.4byte sSpearowPose85
+.4byte sSpearowPose86
+.4byte sSpearowPose87
+.4byte sSpearowPose88
+.4byte sSpearowPose89
+.4byte sSpearowPose90
+.4byte sSpearowPose91
+.4byte sSpearowPose92
+.4byte sSpearowPose93
+.4byte sSpearowPose94
+.4byte sSpearowPose95
+.4byte sSpearowPose96
+.4byte sSpearowPose97
+.4byte sSpearowPose98
+.4byte sSpearowPose99
+.4byte sSpearowPose100
+.4byte sSpearowPose101
+.4byte sSpearowPose102
+.4byte sSpearowPose103
+.4byte sSpearowPose104
+.4byte sSpearowPose105
+.4byte sSpearowPose106
+.4byte sSpearowPose107
+.4byte sSpearowPose108
+.4byte sSpearowPose109
+.4byte sSpearowPose110
+.4byte sSpearowPose111
+.4byte sSpearowPose112
+.4byte sSpearowPose113
+.4byte sSpearowPose114
+.4byte sSpearowPose115
+.4byte sSpearowPose116
+.4byte sSpearowPose117
+.4byte sSpearowPose118
+.4byte sSpearowPose119
+.4byte sSpearowPose120
+.4byte sSpearowPose121
+.4byte sSpearowPose122
+.4byte sSpearowPose123
+.4byte sSpearowPose124
+.4byte sSpearowPose125
+.4byte sSpearowPose126
+.4byte sSpearowPose127
+.4byte sSpearowPose128
+.4byte sSpearowPose129
+.4byte sSpearowPose130
+.4byte sSpearowPose131
+.4byte sSpearowPose132
+.4byte sSpearowPose133
+.4byte sSpearowPose134
+.4byte sSpearowPose135
+.4byte sSpearowPose136
+.4byte sSpearowPose137
+.4byte sSpearowPose138
+.4byte sSpearowPose139
+.4byte sSpearowPose140
+.4byte sSpearowPose141
+.4byte sSpearowPose142
+.4byte sSpearowPose143
+.4byte sSpearowPose144
+.4byte sSpearowPose145
+.4byte sSpearowPose146
+.4byte sSpearowPose147
+.4byte sSpearowPose148
+.4byte sSpearowPose149
+.4byte sSpearowPose150
+.4byte sSpearowPose151
+.4byte sSpearowPose152
+.4byte sSpearowPose153
+.4byte sSpearowPose154
+.4byte sSpearowPose155
+.4byte sSpearowPose156
+.4byte sSpearowPose157
+.4byte sSpearowPose158
+.4byte sSpearowPose159
+.4byte sSpearowPose160
+.4byte sSpearowPose161
+.4byte sSpearowPose162
+.4byte sSpearowPose163
+.4byte sSpearowPose164
+.4byte sSpearowPose165
+.4byte sSpearowPose166
+.4byte sSpearowPose167
+.4byte sSpearowPose168
+.4byte sSpearowPose169
+.4byte sSpearowPose170
+.4byte sSpearowPose171
+.4byte sSpearowPose172
+.4byte sSpearowPose173
+.4byte sSpearowPose174
+.4byte sSpearowPose175
+.4byte sSpearowPose176
+.4byte sSpearowPose177
+.4byte sSpearowPose178
+.4byte sSpearowPose179
+.4byte sSpearowPose180
+.4byte sSpearowPose181
+.4byte sSpearowPose182
+.4byte sSpearowPose183
+.4byte sSpearowPose184
+.4byte sSpearowPose185
+.4byte sSpearowPose186
+.4byte sSpearowPose187
+.4byte sSpearowPose188
+.4byte sSpearowPose189
+.4byte sSpearowPose190
+.4byte sSpearowPose191
+.4byte sSpearowPose192
+.4byte sSpearowPose193
+.4byte sSpearowPose194
+.4byte sSpearowPose195
+.4byte sSpearowPose196
+.4byte sSpearowPose197
+.4byte sSpearowPose198
+.4byte sSpearowPose199
+.4byte sSpearowPose200
+.4byte sSpearowPose201
+.4byte sSpearowPose202
+.4byte sSpearowPose203
+.4byte sSpearowPose204
+.4byte sSpearowPose205
+.4byte sSpearowPose206
+.4byte sSpearowPose207
+.4byte sSpearowPose208
+.4byte sSpearowPose209
+.4byte sSpearowPose210
+.4byte sSpearowPose211
+.4byte sSpearowPose212
+.4byte sSpearowPose213
+.4byte sSpearowPose214
+.4byte sSpearowPose215
+.4byte sSpearowPose216
+.4byte sSpearowPose217
+.4byte sSpearowPose218
+.4byte sSpearowPose219
+.4byte sSpearowPose220
+.4byte sSpearowPose221
+.4byte sSpearowPose222
+.4byte sSpearowPose223
+.4byte sSpearowPose224
+.4byte sSpearowPose225
+.4byte sSpearowPose226
+.4byte sSpearowPose227
+.4byte sSpearowPose228
+.4byte sSpearowPose229
+.4byte sSpearowPose230
+.4byte sSpearowPose231
+.4byte sSpearowPose232
+.4byte sSpearowPose233
+.4byte sSpearowPose234
+sAxPositionsSpearow:
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -1,    0, 	  -7,   -4, 	   5,   -4, 	  -1,   -3
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+.2byte    6,   -8, 	  -2,  -11, 	  -5,   -9, 	  -2,   -8
+.2byte    8,   -3, 	   0,   -8, 	  -6,   -4, 	   1,   -4
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    9,  -11, 	  -5,   -9, 	  -6,   -6, 	   0,   -9
+.2byte   11,   -6, 	  -3,   -5, 	  -4,   -1, 	   0,   -5
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    7,  -13, 	  -5,   -8, 	  -3,   -6, 	   0,   -9
+.2byte    9,   -8, 	  -4,   -3, 	  -1,   -1, 	   1,   -6
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	   0,   -6, 	  -2,   -6, 	  -1,  -10
+.2byte   -1,   -8, 	   3,   -2, 	  -5,   -2, 	  -1,   -7
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -9,  -13, 	   3,   -8, 	   1,   -6, 	  -2,   -9
+.2byte  -11,   -8, 	   2,   -3, 	  -1,   -1, 	  -3,   -6
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte  -11,  -11, 	   3,   -9, 	   4,   -6, 	  -2,   -9
+.2byte  -13,   -6, 	   1,   -5, 	   2,   -1, 	  -2,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -8,   -8, 	   0,  -11, 	   3,   -9, 	   0,   -8
+.2byte  -10,   -3, 	  -2,   -8, 	   4,   -4, 	  -3,   -4
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,    2, 	 -13,   -8, 	  11,   -8, 	  -1,   -5
+.2byte   -1,   -5, 	  -9,  -14, 	   7,  -14, 	  -1,   -7
+.2byte   -1,   -5, 	 -10,    0, 	   8,    0, 	  -1,   -6
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+.2byte    1,   -2, 	   6,  -14, 	 -12,   -8, 	  -1,   -9
+.2byte    5,   -6, 	   3,  -18, 	  -8,  -15, 	   0,   -7
+.2byte    5,   -6, 	   9,   -4, 	  -7,    2, 	   0,   -7
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    4,   -2, 	   0,  -15, 	  -5,    0, 	   0,   -8
+.2byte    8,   -8, 	  -3,  -17, 	  -7,  -12, 	   0,   -6
+.2byte    8,   -8, 	   0,    2, 	  -3,    5, 	   0,   -5
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    4,   -9, 	 -10,  -12, 	   9,   -3, 	   0,  -10
+.2byte    7,  -10, 	  -9,  -15, 	   3,  -13, 	   0,   -9
+.2byte    7,  -10, 	  -5,   -4, 	   6,    0, 	   0,   -9
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte   -1,   -7, 	  11,   -6, 	 -13,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	   7,  -15, 	  -9,  -15, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -2, 	 -10,   -2, 	  -1,   -9
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -6,   -9, 	   8,  -12, 	 -11,   -3, 	  -2,  -10
+.2byte   -9,  -10, 	   7,  -15, 	  -5,  -13, 	  -2,   -9
+.2byte   -9,  -10, 	   3,   -4, 	  -8,    0, 	  -2,   -9
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte   -6,   -2, 	  -2,  -15, 	   3,    0, 	  -2,   -8
+.2byte  -10,   -8, 	   1,  -17, 	   5,  -12, 	  -2,   -6
+.2byte  -10,   -8, 	  -2,    2, 	   1,    5, 	  -2,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -3,   -2, 	  -8,  -14, 	  10,   -8, 	  -1,   -9
+.2byte   -7,   -6, 	  -5,  -18, 	   6,  -15, 	  -2,   -7
+.2byte   -7,   -6, 	 -11,   -4, 	   5,    2, 	  -2,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,    2, 	 -13,   -8, 	  11,   -8, 	  -1,   -5
+.2byte   -1,   -5, 	  -9,  -14, 	   7,  -14, 	  -1,   -7
+.2byte   -1,   -5, 	 -10,    0, 	   8,    0, 	  -1,   -6
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+.2byte    1,   -2, 	   6,  -14, 	 -12,   -8, 	  -1,   -9
+.2byte    5,   -6, 	   3,  -18, 	  -8,  -15, 	   0,   -7
+.2byte    5,   -6, 	   9,   -4, 	  -7,    2, 	   0,   -7
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    4,   -2, 	   0,  -15, 	  -5,    0, 	   0,   -8
+.2byte    8,   -8, 	  -3,  -17, 	  -7,  -12, 	   0,   -6
+.2byte    8,   -8, 	   0,    2, 	  -3,    5, 	   0,   -5
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    4,   -9, 	 -10,  -12, 	   9,   -3, 	   0,  -10
+.2byte    7,  -10, 	  -9,  -15, 	   3,  -13, 	   0,   -9
+.2byte    7,  -10, 	  -5,   -4, 	   6,    0, 	   0,   -9
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte   -1,   -7, 	  11,   -6, 	 -13,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	   7,  -15, 	  -9,  -15, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -2, 	 -10,   -2, 	  -1,   -9
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -6,   -9, 	   8,  -12, 	 -11,   -3, 	  -2,  -10
+.2byte   -9,  -10, 	   7,  -15, 	  -5,  -13, 	  -2,   -9
+.2byte   -9,  -10, 	   3,   -4, 	  -8,    0, 	  -2,   -9
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte   -6,   -2, 	  -2,  -15, 	   3,    0, 	  -2,   -8
+.2byte  -10,   -8, 	   1,  -17, 	   5,  -12, 	  -2,   -6
+.2byte  -10,   -8, 	  -2,    2, 	   1,    5, 	  -2,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -3,   -2, 	  -8,  -14, 	  10,   -8, 	  -1,   -9
+.2byte   -7,   -6, 	  -5,  -18, 	   6,  -15, 	  -2,   -7
+.2byte   -7,   -6, 	 -11,   -4, 	   5,    2, 	  -2,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,  -14, 	   7,  -14, 	  -1,   -7
+.2byte   -1,   -5, 	 -10,    0, 	   8,    0, 	  -1,   -6
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+.2byte    4,   -6, 	   9,  -15, 	 -11,   -9, 	   0,   -7
+.2byte    5,   -6, 	   3,  -18, 	  -8,  -15, 	   0,   -7
+.2byte    5,   -6, 	   9,   -4, 	  -7,    2, 	   0,   -7
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    7,   -7, 	   1,  -12, 	  -6,   -7, 	   0,   -6
+.2byte    8,   -8, 	  -3,  -17, 	  -7,  -12, 	   0,   -6
+.2byte    8,   -8, 	   0,    2, 	  -3,    5, 	   0,   -5
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    6,  -10, 	  -8,  -12, 	  10,   -9, 	   0,   -8
+.2byte    7,  -10, 	  -9,  -15, 	   3,  -13, 	   0,   -9
+.2byte    7,  -10, 	  -5,   -4, 	   6,    0, 	   0,   -9
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte   -1,  -12, 	  10,  -11, 	 -12,  -11, 	  -1,   -9
+.2byte   -1,  -11, 	   7,  -15, 	  -9,  -15, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -2, 	 -10,   -2, 	  -1,   -9
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -8,  -10, 	   6,  -12, 	 -12,   -9, 	  -2,   -8
+.2byte   -9,  -10, 	   7,  -15, 	  -5,  -13, 	  -2,   -9
+.2byte   -9,  -10, 	   3,   -4, 	  -8,    0, 	  -2,   -9
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte   -9,   -7, 	  -3,  -12, 	   4,   -7, 	  -2,   -6
+.2byte  -10,   -8, 	   1,  -17, 	   5,  -12, 	  -2,   -6
+.2byte  -10,   -8, 	  -2,    2, 	   1,    5, 	  -2,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -6,   -6, 	 -11,  -15, 	   9,   -9, 	  -2,   -7
+.2byte   -7,   -6, 	  -5,  -18, 	   6,  -15, 	  -2,   -7
+.2byte   -7,   -6, 	 -11,   -4, 	   5,    2, 	  -2,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -5, 	  -9,  -14, 	   7,  -14, 	  -1,   -7
+.2byte   -1,   -5, 	 -10,    0, 	   8,    0, 	  -1,   -6
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+.2byte    5,   -6, 	   3,  -18, 	  -8,  -15, 	   0,   -7
+.2byte    5,   -6, 	   9,   -4, 	  -7,    2, 	   0,   -7
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    8,   -8, 	  -3,  -17, 	  -7,  -12, 	   0,   -6
+.2byte    8,   -8, 	   0,    2, 	  -3,    5, 	   0,   -5
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    7,  -10, 	  -9,  -15, 	   3,  -13, 	   0,   -9
+.2byte    7,  -10, 	  -5,   -4, 	   6,    0, 	   0,   -9
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte   -1,  -11, 	   7,  -15, 	  -9,  -15, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -2, 	 -10,   -2, 	  -1,   -9
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -9,  -10, 	   7,  -15, 	  -5,  -13, 	  -2,   -9
+.2byte   -9,  -10, 	   3,   -4, 	  -8,    0, 	  -2,   -9
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte  -10,   -8, 	   1,  -17, 	   5,  -12, 	  -2,   -6
+.2byte  -10,   -8, 	  -2,    2, 	   1,    5, 	  -2,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -7,   -6, 	  -5,  -18, 	   6,  -15, 	  -2,   -7
+.2byte   -7,   -6, 	 -11,   -4, 	   5,    2, 	  -2,   -7
+.2byte   -8,   -4, 	   0,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -8,   -3, 	   0,   -7, 	   3,   -5, 	  -2,   -5
+.2byte   -1,   -8, 	 -10,   -9, 	   8,  -10, 	  -1,   -9
+.2byte    5,   -8, 	   7,   -9, 	  -8,   -5, 	  -1,   -8
+.2byte    6,  -11, 	  -5,   -6, 	  -8,   -3, 	  -2,   -7
+.2byte    6,  -10, 	  -8,   -8, 	   7,   -4, 	  -1,   -7
+.2byte    0,  -11, 	   9,   -6, 	  -9,   -7, 	   0,   -8
+.2byte   -7,  -10, 	   7,   -8, 	  -8,   -4, 	   0,   -7
+.2byte   -7,  -11, 	   4,   -6, 	   7,   -3, 	   1,   -7
+.2byte   -6,   -8, 	  -8,   -9, 	   7,   -5, 	   0,   -8
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -1,    0, 	  -7,   -4, 	   5,   -4, 	  -1,   -3
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+.2byte    6,   -8, 	  -2,  -11, 	  -5,   -9, 	  -2,   -8
+.2byte    8,   -3, 	   0,   -8, 	  -6,   -4, 	   1,   -4
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    9,  -11, 	  -5,   -9, 	  -6,   -6, 	   0,   -9
+.2byte   11,   -6, 	  -3,   -5, 	  -4,   -1, 	   0,   -5
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    7,  -13, 	  -5,   -8, 	  -3,   -6, 	   0,   -9
+.2byte    9,   -8, 	  -4,   -3, 	  -1,   -1, 	   1,   -6
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	   0,   -6, 	  -2,   -6, 	  -1,  -10
+.2byte   -1,   -8, 	   3,   -2, 	  -5,   -2, 	  -1,   -7
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -9,  -13, 	   3,   -8, 	   1,   -6, 	  -2,   -9
+.2byte  -11,   -8, 	   2,   -3, 	  -1,   -1, 	  -3,   -6
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte  -11,  -11, 	   3,   -9, 	   4,   -6, 	  -2,   -9
+.2byte  -13,   -6, 	   1,   -5, 	   2,   -1, 	  -2,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -8,   -8, 	   0,  -11, 	   3,   -9, 	   0,   -8
+.2byte  -10,   -3, 	  -2,   -8, 	   4,   -4, 	  -3,   -4
+.2byte   -1,   -6, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte   -6,   -6, 	 -11,  -15, 	   9,   -9, 	  -2,   -7
+.2byte   -9,   -7, 	  -3,  -12, 	   4,   -7, 	  -2,   -6
+.2byte   -8,  -10, 	   6,  -12, 	 -12,   -9, 	  -2,   -8
+.2byte   -1,  -12, 	  10,  -11, 	 -12,  -11, 	  -1,   -9
+.2byte    6,  -10, 	  -8,  -12, 	  10,   -9, 	   0,   -8
+.2byte    7,   -7, 	   1,  -12, 	  -6,   -7, 	   0,   -6
+.2byte    4,   -6, 	   9,  -15, 	 -11,   -9, 	   0,   -7
+.2byte   -1,   -6, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte    4,   -6, 	   9,  -15, 	 -11,   -9, 	   0,   -7
+.2byte    7,   -8, 	   1,  -13, 	  -6,   -8, 	   0,   -7
+.2byte    6,  -10, 	  -8,  -12, 	  10,   -9, 	   0,   -8
+.2byte   -1,  -12, 	  10,  -11, 	 -12,  -11, 	  -1,   -9
+.2byte   -8,  -10, 	   6,  -12, 	 -12,   -9, 	  -2,   -8
+.2byte   -9,   -8, 	  -3,  -13, 	   4,   -8, 	  -2,   -7
+.2byte   -5,   -6, 	 -10,  -15, 	  10,   -9, 	  -1,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte   -1,   -5, 	 -10,    0, 	   8,    0, 	  -1,   -6
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+.2byte    4,   -6, 	   9,  -15, 	 -11,   -9, 	   0,   -7
+.2byte    5,   -6, 	   9,   -4, 	  -7,    2, 	   0,   -7
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    7,   -7, 	   1,  -12, 	  -6,   -7, 	   0,   -6
+.2byte    8,   -8, 	   0,    2, 	  -3,    5, 	   0,   -5
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    6,  -10, 	  -8,  -12, 	  10,   -9, 	   0,   -8
+.2byte    7,  -10, 	  -5,   -4, 	   6,    0, 	   0,   -9
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte   -1,  -12, 	  10,  -11, 	 -12,  -11, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -2, 	 -10,   -2, 	  -1,   -9
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -8,  -10, 	   6,  -12, 	 -12,   -9, 	  -2,   -8
+.2byte   -9,  -10, 	   3,   -4, 	  -8,    0, 	  -2,   -9
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte   -9,   -7, 	  -3,  -12, 	   4,   -7, 	  -2,   -6
+.2byte  -10,   -8, 	  -2,    2, 	   1,    5, 	  -2,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte   -6,   -6, 	 -11,  -15, 	   9,   -9, 	  -2,   -7
+.2byte   -7,   -6, 	 -11,   -4, 	   5,    2, 	  -2,   -7
+.2byte   -1,   -5, 	  -9,  -14, 	   7,  -14, 	  -1,   -7
+.2byte   -7,   -6, 	  -5,  -18, 	   6,  -15, 	  -2,   -7
+.2byte  -10,   -8, 	   1,  -17, 	   5,  -12, 	  -2,   -6
+.2byte   -9,  -10, 	   7,  -15, 	  -5,  -13, 	  -2,   -9
+.2byte   -1,  -11, 	   7,  -15, 	  -9,  -15, 	  -1,   -9
+.2byte    7,  -10, 	  -9,  -15, 	   3,  -13, 	   0,   -9
+.2byte    8,   -8, 	  -3,  -17, 	  -7,  -12, 	   0,   -6
+.2byte    5,   -6, 	   3,  -18, 	  -8,  -15, 	   0,   -7
+.2byte   -1,   -3, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -8,   -5, 	  -1,   -8, 	   3,   -6, 	  -2,   -6
+.2byte  -11,   -8, 	   3,   -6, 	   4,   -3, 	  -2,   -6
+.2byte   -9,  -10, 	   3,   -5, 	   1,   -3, 	  -2,   -7
+.2byte   -1,  -10, 	   0,   -3, 	  -2,   -3, 	  -1,   -8
+.2byte    7,  -10, 	  -5,   -5, 	  -3,   -3, 	   0,   -7
+.2byte    9,   -8, 	  -5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte    6,   -5, 	  -1,   -8, 	  -5,   -6, 	   0,   -6
+sSpearowAnimTable1:
+.4byte sSpearowAnims_1_1
+.4byte sSpearowAnims_1_2
+.4byte sSpearowAnims_1_3
+.4byte sSpearowAnims_1_4
+.4byte sSpearowAnims_1_5
+.4byte sSpearowAnims_1_6
+.4byte sSpearowAnims_1_7
+.4byte sSpearowAnims_1_8
+sSpearowAnimTable2:
+.4byte sSpearowAnims_2_1
+.4byte sSpearowAnims_2_2
+.4byte sSpearowAnims_2_3
+.4byte sSpearowAnims_2_4
+.4byte sSpearowAnims_2_5
+.4byte sSpearowAnims_2_6
+.4byte sSpearowAnims_2_7
+.4byte sSpearowAnims_2_8
+sSpearowAnimTable3:
+.4byte sSpearowAnims_3_1
+.4byte sSpearowAnims_3_2
+.4byte sSpearowAnims_3_3
+.4byte sSpearowAnims_3_4
+.4byte sSpearowAnims_3_5
+.4byte sSpearowAnims_3_6
+.4byte sSpearowAnims_3_7
+.4byte sSpearowAnims_3_8
+sSpearowAnimTable4:
+.4byte sSpearowAnims_4_1
+.4byte sSpearowAnims_4_2
+.4byte sSpearowAnims_4_3
+.4byte sSpearowAnims_4_4
+.4byte sSpearowAnims_4_5
+.4byte sSpearowAnims_4_6
+.4byte sSpearowAnims_4_7
+.4byte sSpearowAnims_4_8
+sSpearowAnimTable5:
+.4byte sSpearowAnims_5_1
+.4byte sSpearowAnims_5_2
+.4byte sSpearowAnims_5_3
+.4byte sSpearowAnims_5_4
+.4byte sSpearowAnims_5_5
+.4byte sSpearowAnims_5_6
+.4byte sSpearowAnims_5_7
+.4byte sSpearowAnims_5_8
+sSpearowAnimTable6:
+.4byte sSpearowAnims_6_1
+.4byte sSpearowAnims_6_1
+.4byte sSpearowAnims_6_1
+.4byte sSpearowAnims_6_1
+.4byte sSpearowAnims_6_1
+.4byte sSpearowAnims_6_1
+.4byte sSpearowAnims_6_1
+.4byte sSpearowAnims_6_1
+sSpearowAnimTable7:
+.4byte sSpearowAnims_7_1
+.4byte sSpearowAnims_7_2
+.4byte sSpearowAnims_7_3
+.4byte sSpearowAnims_7_4
+.4byte sSpearowAnims_7_5
+.4byte sSpearowAnims_7_6
+.4byte sSpearowAnims_7_7
+.4byte sSpearowAnims_7_8
+sSpearowAnimTable8:
+.4byte sSpearowAnims_8_1
+.4byte sSpearowAnims_8_2
+.4byte sSpearowAnims_8_3
+.4byte sSpearowAnims_8_4
+.4byte sSpearowAnims_8_5
+.4byte sSpearowAnims_8_6
+.4byte sSpearowAnims_8_7
+.4byte sSpearowAnims_8_8
+sSpearowAnimTable9:
+.4byte sSpearowAnims_9_1
+.4byte sSpearowAnims_9_2
+.4byte sSpearowAnims_9_3
+.4byte sSpearowAnims_9_4
+.4byte sSpearowAnims_9_5
+.4byte sSpearowAnims_9_6
+.4byte sSpearowAnims_9_7
+.4byte sSpearowAnims_9_8
+sSpearowAnimTable10:
+.4byte sSpearowAnims_10_1
+.4byte sSpearowAnims_10_2
+.4byte sSpearowAnims_10_3
+.4byte sSpearowAnims_10_4
+.4byte sSpearowAnims_10_5
+.4byte sSpearowAnims_10_6
+.4byte sSpearowAnims_10_7
+.4byte sSpearowAnims_10_8
+sSpearowAnimTable11:
+.4byte sSpearowAnims_11_1
+.4byte sSpearowAnims_11_2
+.4byte sSpearowAnims_11_3
+.4byte sSpearowAnims_11_4
+.4byte sSpearowAnims_11_5
+.4byte sSpearowAnims_11_6
+.4byte sSpearowAnims_11_7
+.4byte sSpearowAnims_11_8
+sSpearowAnimTable12:
+.4byte sSpearowAnims_12_1
+.4byte sSpearowAnims_12_2
+.4byte sSpearowAnims_12_3
+.4byte sSpearowAnims_12_4
+.4byte sSpearowAnims_12_5
+.4byte sSpearowAnims_12_6
+.4byte sSpearowAnims_12_7
+.4byte sSpearowAnims_12_8
+sSpearowAnimTable13:
+.4byte sSpearowAnims_13_1
+.4byte sSpearowAnims_13_2
+.4byte sSpearowAnims_13_3
+.4byte sSpearowAnims_13_4
+.4byte sSpearowAnims_13_5
+.4byte sSpearowAnims_13_6
+.4byte sSpearowAnims_13_7
+.4byte sSpearowAnims_13_8
+sAxAnimationsSpearow:
+.4byte sSpearowAnimTable1
+.4byte sSpearowAnimTable2
+.4byte sSpearowAnimTable3
+.4byte sSpearowAnimTable4
+.4byte sSpearowAnimTable5
+.4byte sSpearowAnimTable6
+.4byte sSpearowAnimTable7
+.4byte sSpearowAnimTable8
+.4byte sSpearowAnimTable9
+.4byte sSpearowAnimTable10
+.4byte sSpearowAnimTable11
+.4byte sSpearowAnimTable12
+.4byte sSpearowAnimTable13
+sAxSpritesSpearow:
+.4byte sSpearowSprites1
+.4byte sSpearowSprites2
+.4byte sSpearowSprites3
+.4byte sSpearowSprites4
+.4byte sSpearowSprites5
+.4byte sSpearowSprites6
+.4byte sSpearowSprites7
+.4byte sSpearowSprites8
+.4byte sSpearowSprites9
+.4byte sSpearowSprites10
+.4byte sSpearowSprites11
+.4byte sSpearowSprites12
+.4byte sSpearowSprites13
+.4byte sSpearowSprites14
+.4byte sSpearowSprites15
+.4byte sSpearowSprites16
+.4byte sSpearowSprites17
+.4byte sSpearowSprites18
+.4byte sSpearowSprites19
+.4byte sSpearowSprites20
+.4byte sSpearowSprites21
+.4byte sSpearowSprites22
+.4byte sSpearowSprites23
+.4byte sSpearowSprites24
+.4byte sSpearowSprites25
+.4byte sSpearowSprites26
+.4byte sSpearowSprites27
+.4byte sSpearowSprites28
+.4byte sSpearowSprites29
+.4byte sSpearowSprites30
+.4byte sSpearowSprites31
+.4byte sSpearowSprites32
+.4byte sSpearowSprites33
+.4byte sSpearowSprites34
+.4byte sSpearowSprites35
+.4byte sSpearowSprites36
+.4byte sSpearowSprites37
+.4byte sSpearowSprites38
+.4byte sSpearowSprites39
+.4byte sSpearowSprites40
+.4byte sSpearowSprites41
+.4byte sSpearowSprites42
+sAxMainSpearow:
+ax_main sAxPosesSpearow, sAxAnimationsSpearow, 13, sAxSpritesSpearow, sAxPositionsSpearow

--- a/data/ax/spheal.inc
+++ b/data/ax/spheal.inc
@@ -1,0 +1,2716 @@
+.global gAxSpheal
+gAxSpheal:
+ax_siro sAxMainSpheal
+sSphealPose1:
+ax_pose 0, 0x41f1, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose2:
+ax_pose 1, 0x41f1, 0xa0f5, 0x5c00
+ax_pose_terminator
+sSphealPose3:
+ax_pose 1, 0x41f2, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose4:
+ax_pose 0, 0x41f2, 0xa0f5, 0x5c00
+ax_pose_terminator
+sSphealPose5:
+ax_pose 2, 0x41f0, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose6:
+ax_pose 3, 0x41f3, 0xa0f4, 0x5c00
+ax_pose_terminator
+sSphealPose7:
+ax_pose 4, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose8:
+ax_pose 5, 0x01e9, 0xa0f4, 0x5c00
+ax_pose_terminator
+sSphealPose9:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose10:
+ax_pose 4, 0x41f1, 0xa0f4, 0x5c00
+ax_pose_terminator
+sSphealPose11:
+ax_pose 6, 0x41f1, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose12:
+ax_pose 7, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose13:
+ax_pose 8, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose14:
+ax_pose 9, 0x01e9, 0xa0f0, 0x5c00
+ax_pose_terminator
+sSphealPose15:
+ax_pose 9, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose16:
+ax_pose 8, 0x01f1, 0x60f8, 0x5c00
+ax_pose_terminator
+sSphealPose17:
+ax_pose 9, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose18:
+ax_pose 9, 0x01e9, 0xb0f0, 0x5c00
+ax_pose_terminator
+sSphealPose19:
+ax_pose 4, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose20:
+ax_pose 5, 0x01e9, 0xb0ec, 0x5c00
+ax_pose_terminator
+sSphealPose21:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose22:
+ax_pose 4, 0x41f1, 0xb0ec, 0x5c00
+ax_pose_terminator
+sSphealPose23:
+ax_pose 6, 0x41f1, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose24:
+ax_pose 7, 0x01ee, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose25:
+ax_pose 0, 0x41f1, 0x90eb, 0x5c00
+ax_pose_terminator
+sSphealPose26:
+ax_pose 1, 0x41f1, 0xb0eb, 0x5c00
+ax_pose_terminator
+sSphealPose27:
+ax_pose 1, 0x41f2, 0x90eb, 0x5c00
+ax_pose_terminator
+sSphealPose28:
+ax_pose 0, 0x41f2, 0xb0eb, 0x5c00
+ax_pose_terminator
+sSphealPose29:
+ax_pose 2, 0x41f0, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose30:
+ax_pose 3, 0x41f3, 0xb0ec, 0x5c00
+ax_pose_terminator
+sSphealPose31:
+ax_pose 10, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose32:
+ax_pose 11, 0x41f2, 0x90eb, 0x5c00
+ax_pose_terminator
+sSphealPose33:
+ax_pose 12, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose34:
+ax_pose 13, 0x01f1, 0x90eb, 0x5c00
+ax_pose_terminator
+sSphealPose35:
+ax_pose 14, 0x81ec, 0x90f7, 0x5c00
+ax_pose_terminator
+sSphealPose36:
+ax_pose 15, 0x01ed, 0x90e9, 0x5c00
+ax_pose_terminator
+sSphealPose37:
+ax_pose 16, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose38:
+ax_pose 17, 0x01e8, 0xa0f0, 0x5c00
+ax_pose_terminator
+sSphealPose39:
+ax_pose 17, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose40:
+ax_pose 16, 0x01f1, 0x60f8, 0x5c00
+ax_pose_terminator
+sSphealPose41:
+ax_pose 17, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose42:
+ax_pose 17, 0x01e9, 0xb0f0, 0x5c00
+ax_pose_terminator
+sSphealPose43:
+ax_pose 10, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose44:
+ax_pose 11, 0x41f2, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose45:
+ax_pose 12, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose46:
+ax_pose 13, 0x01f1, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose47:
+ax_pose 14, 0x81ec, 0x80f9, 0x5c00
+ax_pose_terminator
+sSphealPose48:
+ax_pose 15, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sSphealPose49:
+ax_pose 18, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose50:
+ax_pose 19, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose51:
+ax_pose 8, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose52:
+ax_pose 20, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose53:
+ax_pose 21, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose54:
+ax_pose 4, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose55:
+ax_pose 22, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSphealPose56:
+ax_pose 23, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose57:
+ax_pose 0, 0x41f1, 0x90eb, 0x5c00
+ax_pose_terminator
+sSphealPose58:
+ax_pose 24, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose59:
+ax_pose 25, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose60:
+ax_pose 10, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose61:
+ax_pose 26, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose62:
+ax_pose 27, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose63:
+ax_pose 16, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose64:
+ax_pose 24, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose65:
+ax_pose 25, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose66:
+ax_pose 10, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose67:
+ax_pose 22, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSphealPose68:
+ax_pose 23, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose69:
+ax_pose 0, 0x41f1, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose70:
+ax_pose 20, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose71:
+ax_pose 21, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose72:
+ax_pose 4, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose73:
+ax_pose 18, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose74:
+ax_pose 19, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose75:
+ax_pose 8, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose76:
+ax_pose 20, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose77:
+ax_pose 21, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose78:
+ax_pose 4, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose79:
+ax_pose 22, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSphealPose80:
+ax_pose 23, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose81:
+ax_pose 0, 0x41f1, 0x90eb, 0x5c00
+ax_pose_terminator
+sSphealPose82:
+ax_pose 24, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose83:
+ax_pose 25, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose84:
+ax_pose 10, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose85:
+ax_pose 26, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose86:
+ax_pose 27, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose87:
+ax_pose 16, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose88:
+ax_pose 24, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose89:
+ax_pose 25, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose90:
+ax_pose 10, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose91:
+ax_pose 22, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSphealPose92:
+ax_pose 23, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose93:
+ax_pose 0, 0x41f1, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose94:
+ax_pose 20, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose95:
+ax_pose 21, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose96:
+ax_pose 4, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose97:
+ax_pose 18, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose98:
+ax_pose 28, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose99:
+ax_pose 29, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose100:
+ax_pose 20, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose101:
+ax_pose 30, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose102:
+ax_pose 31, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose103:
+ax_pose 22, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSphealPose104:
+ax_pose 32, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose105:
+ax_pose 33, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sSphealPose106:
+ax_pose 24, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose107:
+ax_pose 34, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose108:
+ax_pose 35, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sSphealPose109:
+ax_pose 26, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose110:
+ax_pose 36, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose111:
+ax_pose 37, 0x41f1, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose112:
+ax_pose 24, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose113:
+ax_pose 34, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose114:
+ax_pose 35, 0x41f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose115:
+ax_pose 22, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSphealPose116:
+ax_pose 32, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose117:
+ax_pose 33, 0x41f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose118:
+ax_pose 20, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose119:
+ax_pose 30, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose120:
+ax_pose 31, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose121:
+ax_pose 18, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose122:
+ax_pose 19, 0x81e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose123:
+ax_pose 20, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose124:
+ax_pose 21, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose125:
+ax_pose 22, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSphealPose126:
+ax_pose 23, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose127:
+ax_pose 24, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose128:
+ax_pose 25, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose129:
+ax_pose 26, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose130:
+ax_pose 27, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose131:
+ax_pose 24, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose132:
+ax_pose 25, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose133:
+ax_pose 22, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSphealPose134:
+ax_pose 23, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose135:
+ax_pose 20, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose136:
+ax_pose 21, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose137:
+ax_pose 38, 0x01ee, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose138:
+ax_pose 39, 0x01ee, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose139:
+ax_pose 40, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose140:
+ax_pose 41, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sSphealPose141:
+ax_pose 42, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose142:
+ax_pose 43, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sSphealPose143:
+ax_pose 44, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose144:
+ax_pose 43, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sSphealPose145:
+ax_pose 42, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose146:
+ax_pose 41, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sSphealPose147:
+ax_pose 22, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSphealPose148:
+ax_pose 0, 0x41f1, 0x80f5, 0x5c00
+ax_pose_terminator
+sSphealPose149:
+ax_pose 20, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose150:
+ax_pose 4, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose151:
+ax_pose 18, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose152:
+ax_pose 8, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose153:
+ax_pose 20, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose154:
+ax_pose 4, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose155:
+ax_pose 22, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSphealPose156:
+ax_pose 0, 0x41f1, 0x90eb, 0x5c00
+ax_pose_terminator
+sSphealPose157:
+ax_pose 24, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose158:
+ax_pose 10, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose159:
+ax_pose 26, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose160:
+ax_pose 16, 0x01f2, 0x40f8, 0x5c00
+ax_pose_terminator
+sSphealPose161:
+ax_pose 24, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose162:
+ax_pose 10, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose163:
+ax_pose 28, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose164:
+ax_pose 30, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose165:
+ax_pose 32, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose166:
+ax_pose 34, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose167:
+ax_pose 36, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose168:
+ax_pose 34, 0x01eb, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose169:
+ax_pose 32, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose170:
+ax_pose 30, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose171:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose172:
+ax_pose 21, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose173:
+ax_pose 23, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose174:
+ax_pose 25, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose175:
+ax_pose 27, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose176:
+ax_pose 25, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose177:
+ax_pose 23, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose178:
+ax_pose 21, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose179:
+ax_pose 18, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose180:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose181:
+ax_pose 29, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose182:
+ax_pose 20, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose183:
+ax_pose 21, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose184:
+ax_pose 31, 0x41f3, 0x90ef, 0x5c00
+ax_pose_terminator
+sSphealPose185:
+ax_pose 22, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSphealPose186:
+ax_pose 23, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose187:
+ax_pose 33, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sSphealPose188:
+ax_pose 24, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose189:
+ax_pose 25, 0x01ea, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose190:
+ax_pose 35, 0x41f2, 0x90ef, 0x5c00
+ax_pose_terminator
+sSphealPose191:
+ax_pose 26, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose192:
+ax_pose 27, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sSphealPose193:
+ax_pose 37, 0x41f1, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose194:
+ax_pose 24, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose195:
+ax_pose 25, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose196:
+ax_pose 35, 0x41f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose197:
+ax_pose 22, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSphealPose198:
+ax_pose 23, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose199:
+ax_pose 33, 0x41f2, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose200:
+ax_pose 20, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose201:
+ax_pose 21, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose202:
+ax_pose 31, 0x41f3, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose203:
+ax_pose 29, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose204:
+ax_pose 31, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose205:
+ax_pose 33, 0x41f3, 0x80f1, 0x5c00
+ax_pose_terminator
+sSphealPose206:
+ax_pose 35, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose207:
+ax_pose 37, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSphealPose208:
+ax_pose 35, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose209:
+ax_pose 33, 0x41f3, 0x90ef, 0x5c00
+ax_pose_terminator
+sSphealPose210:
+ax_pose 31, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSphealPose211:
+ax_pose 18, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose212:
+ax_pose 20, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose213:
+ax_pose 22, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSphealPose214:
+ax_pose 24, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose215:
+ax_pose 26, 0x41f2, 0x80f4, 0x5c00
+ax_pose_terminator
+sSphealPose216:
+ax_pose 24, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSphealPose217:
+ax_pose 22, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSphealPose218:
+ax_pose 20, 0x41f2, 0x90ec, 0x5c00
+ax_pose_terminator
+.align 2
+sSphealAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_1_2:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_1_3:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_1_4:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_1_5:
+ax_anim 6, 0, 24, 0, 0, 0, 0,
+ax_anim 6, 0, 29, 0, -1, 0, 0,
+ax_anim 6, 0, 28, 0, -2, 0, 0,
+ax_anim 6, 0, 27, 0, -2, 0, 0,
+ax_anim 6, 0, 26, 0, -1, 0, 0,
+ax_anim 6, 0, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_1_6:
+ax_anim 6, 0, 30, 0, 0, 0, 0,
+ax_anim 6, 0, 31, 0, -1, 0, 0,
+ax_anim 6, 0, 32, 0, -2, 0, 0,
+ax_anim 6, 0, 33, 0, -2, 0, 0,
+ax_anim 6, 0, 34, 0, -1, 0, 0,
+ax_anim 6, 0, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_1_7:
+ax_anim 6, 0, 36, 0, 0, 0, 0,
+ax_anim 6, 0, 41, 0, -1, 0, 0,
+ax_anim 6, 0, 40, 0, -2, 0, 0,
+ax_anim 6, 0, 39, 0, -2, 0, 0,
+ax_anim 6, 0, 38, 0, -1, 0, 0,
+ax_anim 6, 0, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_1_8:
+ax_anim 6, 0, 42, 0, 0, 0, 0,
+ax_anim 6, 0, 47, 0, -1, 0, 0,
+ax_anim 6, 0, 46, 0, -2, 0, 0,
+ax_anim 6, 0, 45, 0, -2, 0, 0,
+ax_anim 6, 0, 44, 0, -1, 0, 0,
+ax_anim 6, 0, 43, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_2_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSphealAnims_2_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 4, 4, 4, 4,
+ax_anim 2, 2, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 51, 21, 20, 21, 20,
+ax_anim 2, 1, 51, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 21, 20, 21, 20,
+ax_anim 2, 0, 51, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sSphealAnims_2_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 12, 0, 12, 0,
+ax_anim 2, 0, 54, 22, 0, 22, 0,
+ax_anim 2, 1, 54, 22, 1, 22, 1,
+ax_anim 2, 0, 54, 22, 0, 22, 0,
+ax_anim 2, 0, 54, 22, 1, 22, 1,
+ax_anim 2, 0, 54, 8, 0, 8, 0,
+ax_anim_terminator
+sSphealAnims_2_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 2, 0, 59, 4, -6, 4, -6,
+ax_anim 2, 2, 59, 13, -15, 13, -15,
+ax_anim 2, 0, 57, 21, -23, 21, -23,
+ax_anim 2, 1, 57, 22, -22, 22, -22,
+ax_anim 2, 0, 57, 21, -23, 21, -23,
+ax_anim 2, 0, 57, 22, -22, 22, -22,
+ax_anim 2, 0, 57, 5, -6, 5, -6,
+ax_anim_terminator
+sSphealAnims_2_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 61, 0, 4, 0, 4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 0, -4, 0, -4,
+ax_anim 2, 2, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 60, 0, -24, 0, -24,
+ax_anim 2, 1, 60, 1, -24, 1, -24,
+ax_anim 2, 0, 60, 0, -24, 0, -24,
+ax_anim 2, 0, 60, 1, -24, 1, -24,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSphealAnims_2_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 2, 0, 65, -4, -6, -4, -6,
+ax_anim 2, 2, 65, -13, -15, -13, -15,
+ax_anim 2, 0, 63, -21, -23, -21, -23,
+ax_anim 2, 1, 63, -22, -22, -22, -22,
+ax_anim 2, 0, 63, -21, -23, -21, -23,
+ax_anim 2, 0, 63, -22, -22, -22, -22,
+ax_anim 2, 0, 63, -5, -6, -5, -6,
+ax_anim_terminator
+sSphealAnims_2_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -12, 0, -12, 0,
+ax_anim 2, 0, 66, -22, 0, -22, 0,
+ax_anim 2, 1, 66, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -22, 0, -22, 0,
+ax_anim 2, 0, 66, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -8, 0, -8, 0,
+ax_anim_terminator
+sSphealAnims_2_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, -4, 4, -4, 4,
+ax_anim 2, 2, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 69, -21, 20, -21, 20,
+ax_anim 2, 1, 69, -22, 19, -22, 19,
+ax_anim 2, 0, 69, -21, 20, -21, 20,
+ax_anim 2, 0, 69, -22, 19, -22, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSphealAnims_3_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 6, 0, 73, 0, -2, 0, -2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 2, 2, 74, 0, 10, 0, 10,
+ax_anim 2, 0, 72, 0, 20, 0, 20,
+ax_anim 2, 1, 72, 1, 20, 1, 20,
+ax_anim 2, 0, 72, 0, 20, 0, 20,
+ax_anim 2, 0, 72, 1, 20, 1, 20,
+ax_anim 2, 0, 72, 0, 6, 0, 6,
+ax_anim_terminator
+sSphealAnims_3_2:
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 6, 0, 76, -2, -2, -2, -2,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 4, 4, 4, 4,
+ax_anim 2, 2, 77, 10, 10, 10, 10,
+ax_anim 2, 0, 75, 21, 20, 21, 20,
+ax_anim 2, 1, 75, 22, 19, 22, 19,
+ax_anim 2, 0, 75, 21, 20, 21, 20,
+ax_anim 2, 0, 75, 22, 19, 22, 19,
+ax_anim 2, 0, 75, 6, 6, 6, 6,
+ax_anim_terminator
+sSphealAnims_3_3:
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 6, 0, 79, -4, 0, -4, 0,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 4, 0, 4, 0,
+ax_anim 2, 2, 80, 12, 0, 12, 0,
+ax_anim 2, 0, 78, 22, 0, 22, 0,
+ax_anim 2, 1, 78, 22, 1, 22, 1,
+ax_anim 2, 0, 78, 22, 0, 22, 0,
+ax_anim 2, 0, 78, 22, 1, 22, 1,
+ax_anim 2, 0, 78, 8, 0, 8, 0,
+ax_anim_terminator
+sSphealAnims_3_4:
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 6, 0, 82, -2, 2, -2, 2,
+ax_anim 1, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 4, -6, 4, -6,
+ax_anim 2, 2, 83, 13, -15, 13, -15,
+ax_anim 2, 0, 81, 21, -23, 21, -23,
+ax_anim 2, 1, 81, 22, -22, 22, -22,
+ax_anim 2, 0, 81, 21, -23, 21, -23,
+ax_anim 2, 0, 81, 22, -22, 22, -22,
+ax_anim 2, 0, 81, 5, -6, 5, -6,
+ax_anim_terminator
+sSphealAnims_3_5:
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 6, 0, 85, 0, 4, 0, 4,
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 2, 86, 0, -11, 0, -11,
+ax_anim 2, 0, 84, 0, -24, 0, -24,
+ax_anim 2, 1, 84, 1, -24, 1, -24,
+ax_anim 2, 0, 84, 0, -24, 0, -24,
+ax_anim 2, 0, 84, 1, -24, 1, -24,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sSphealAnims_3_6:
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 6, 0, 88, 2, 2, 2, 2,
+ax_anim 1, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, -4, -6, -4, -6,
+ax_anim 2, 2, 89, -13, -15, -13, -15,
+ax_anim 2, 0, 87, -21, -23, -21, -23,
+ax_anim 2, 1, 87, -22, -22, -22, -22,
+ax_anim 2, 0, 87, -21, -23, -21, -23,
+ax_anim 2, 0, 87, -22, -22, -22, -22,
+ax_anim 2, 0, 87, -5, -6, -5, -6,
+ax_anim_terminator
+sSphealAnims_3_7:
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 6, 0, 91, 4, 0, 4, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim 2, 2, 92, -12, 0, -12, 0,
+ax_anim 2, 0, 90, -22, 0, -22, 0,
+ax_anim 2, 1, 90, -22, 1, -22, 1,
+ax_anim 2, 0, 90, -22, 0, -22, 0,
+ax_anim 2, 0, 90, -22, 1, -22, 1,
+ax_anim 2, 0, 90, -8, 0, -8, 0,
+ax_anim_terminator
+sSphealAnims_3_8:
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 6, 0, 94, 2, -2, 2, -2,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 2, 95, -10, 10, -10, 10,
+ax_anim 2, 0, 93, -21, 20, -21, 20,
+ax_anim 2, 1, 93, -22, 19, -22, 19,
+ax_anim 2, 0, 93, -21, 20, -21, 20,
+ax_anim 2, 0, 93, -22, 19, -22, 19,
+ax_anim 2, 0, 93, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSphealAnims_4_1:
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 6, 2, 97, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 98, 1, 3, 1, 3,
+ax_anim 2, 0, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim_terminator
+sSphealAnims_4_2:
+ax_anim 2, 0, 100, -2, -2, -2, -2,
+ax_anim 6, 2, 100, -3, -3, -3, -3,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 1, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 101, 3, 1, 3, 1,
+ax_anim 2, 0, 101, 2, 2, 2, 2,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sSphealAnims_4_3:
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim 6, 2, 103, -3, 0, -3, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 2, 1, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 104, 2, 1, 2, 1,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim_terminator
+sSphealAnims_4_4:
+ax_anim 2, 0, 106, -2, 2, -2, 2,
+ax_anim 6, 2, 106, -3, 3, -3, 3,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 2, 1, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 107, 3, -1, 3, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim_terminator
+sSphealAnims_4_5:
+ax_anim 2, 0, 109, 0, 2, 0, 2,
+ax_anim 6, 2, 109, 0, 3, 0, 3,
+ax_anim 2, 0, 108, 0, 1, 0, 1,
+ax_anim 2, 1, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 0, -3, 0, -3,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sSphealAnims_4_6:
+ax_anim 2, 0, 112, 2, 2, 2, 2,
+ax_anim 6, 2, 112, 3, 3, 3, 3,
+ax_anim 2, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 1, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+sSphealAnims_4_7:
+ax_anim 2, 0, 115, 2, 0, 2, 0,
+ax_anim 6, 2, 115, 3, 0, 3, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 116, -2, 1, -2, 1,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -1, 0, -1, 0,
+ax_anim_terminator
+sSphealAnims_4_8:
+ax_anim 2, 0, 118, 2, -2, 2, -2,
+ax_anim 6, 2, 118, 3, -3, 3, -3,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 119, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 117, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSphealAnims_5_1:
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 8, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -1, 0, -1, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_5_2:
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_5_3:
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, -1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -1, 0, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_5_4:
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_5_5:
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 0, -1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 0, -1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 0, -1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, 0, -1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_5_6:
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_5_7:
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -1, 0, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -1, 0, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -1, 0, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -1, 0, -1,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_5_8:
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sSphealAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sSphealAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sSphealAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sSphealAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sSphealAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sSphealAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sSphealAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSphealAnims_8_1:
+ax_anim 16, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, -2, 0, 0,
+ax_anim 6, 0, 151, 0, -3, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, -2, 0, 0,
+ax_anim 6, 0, 151, 0, -3, 0, 0,
+ax_anim_terminator
+sSphealAnims_8_2:
+ax_anim 16, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, -2, 0, 0,
+ax_anim 6, 0, 153, 0, -3, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, -2, 0, 0,
+ax_anim 6, 0, 153, 0, -3, 0, 0,
+ax_anim_terminator
+sSphealAnims_8_3:
+ax_anim 16, 0, 154, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, -2, 0, 0,
+ax_anim 6, 0, 155, 0, -3, 0, 0,
+ax_anim 6, 0, 155, 0, 0, 0, 0,
+ax_anim 6, 0, 155, 0, -2, 0, 0,
+ax_anim 6, 0, 155, 0, -3, 0, 0,
+ax_anim_terminator
+sSphealAnims_8_4:
+ax_anim 16, 0, 156, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, -2, 0, 0,
+ax_anim 6, 0, 157, 0, -3, 0, 0,
+ax_anim 6, 0, 157, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, -2, 0, 0,
+ax_anim 6, 0, 157, 0, -3, 0, 0,
+ax_anim_terminator
+sSphealAnims_8_5:
+ax_anim 16, 0, 158, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, -2, 0, 0,
+ax_anim 6, 0, 159, 0, -3, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 159, 0, -2, 0, 0,
+ax_anim 6, 0, 159, 0, -3, 0, 0,
+ax_anim_terminator
+sSphealAnims_8_6:
+ax_anim 16, 0, 160, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, -2, 0, 0,
+ax_anim 6, 0, 161, 0, -3, 0, 0,
+ax_anim 6, 0, 161, 0, 0, 0, 0,
+ax_anim 6, 0, 161, 0, -2, 0, 0,
+ax_anim 6, 0, 161, 0, -3, 0, 0,
+ax_anim_terminator
+sSphealAnims_8_7:
+ax_anim 16, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, -2, 0, 0,
+ax_anim 6, 0, 147, 0, -3, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, -2, 0, 0,
+ax_anim 6, 0, 147, 0, -3, 0, 0,
+ax_anim_terminator
+sSphealAnims_8_8:
+ax_anim 16, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 149, 0, -3, 0, 0,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 6, 0, 149, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 15, 7, 15,
+ax_anim 3, 0, 166, 0, 19, 0, 19,
+ax_anim 2, 3, 167, -7, 15, -7, 15,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 20, 19, 20, 19,
+ax_anim 2, 3, 166, 11, 19, 11, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 20, 0, 20, 0,
+ax_anim 2, 3, 165, 16, 4, 16, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 3, -16, 3, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 20, -22, 20, -22,
+ax_anim 2, 3, 164, 21, -15, 21, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 10, 0, 10, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -8, -18, -8, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 8, -18, 8, -18,
+ax_anim 2, 0, 164, 9, -12, 9, -12,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -3, -16, -3, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -20, -22, -20, -22,
+ax_anim 2, 3, 168, -21, -15, -21, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -10, 0, -10, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -20, 0, -20, 0,
+ax_anim 2, 3, 167, -16, 4, -16, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -20, 19, -20, 19,
+ax_anim 2, 3, 166, -11, 19, -11, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -21, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 183, 0, -21, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -22, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSphealAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSphealGfx1:
+.incbin "baserom.gba", 0x14FE058, 0x100
+sSphealSprites1:
+ax_sprite sSphealGfx1, 0x100
+ax_sprite_terminator
+sSphealGfx2:
+.incbin "baserom.gba", 0x14FE168, 0x100
+sSphealSprites2:
+ax_sprite sSphealGfx2, 0x100
+ax_sprite_terminator
+sSphealGfx3:
+.incbin "baserom.gba", 0x14FE278, 0x100
+sSphealSprites3:
+ax_sprite sSphealGfx3, 0x100
+ax_sprite_terminator
+sSphealGfx4:
+.incbin "baserom.gba", 0x14FE388, 0x100
+sSphealSprites4:
+ax_sprite sSphealGfx4, 0x100
+ax_sprite_terminator
+sSphealGfx5:
+.incbin "baserom.gba", 0x14FE498, 0x100
+sSphealSprites5:
+ax_sprite sSphealGfx5, 0x100
+ax_sprite_terminator
+sSphealGfx6:
+.incbin "baserom.gba", 0x14FE5A8, 0x200
+sSphealSprites6:
+ax_sprite sSphealGfx6, 0x200
+ax_sprite_terminator
+sSphealGfx7:
+.incbin "baserom.gba", 0x14FE7B8, 0x100
+sSphealSprites7:
+ax_sprite sSphealGfx7, 0x100
+ax_sprite_terminator
+sSphealGfx8:
+.incbin "baserom.gba", 0x14FE8C8, 0x200
+sSphealSprites8:
+ax_sprite sSphealGfx8, 0x200
+ax_sprite_terminator
+sSphealGfx9:
+.incbin "baserom.gba", 0x14FEAD8, 0x80
+sSphealSprites9:
+ax_sprite sSphealGfx9, 0x80
+ax_sprite_terminator
+sSphealGfx10:
+.incbin "baserom.gba", 0x14FEB68, 0x200
+sSphealSprites10:
+ax_sprite sSphealGfx10, 0x200
+ax_sprite_terminator
+sSphealGfx11:
+.incbin "baserom.gba", 0x14FED78, 0x100
+sSphealSprites11:
+ax_sprite sSphealGfx11, 0x100
+ax_sprite_terminator
+sSphealGfx12:
+.incbin "baserom.gba", 0x14FEE88, 0x100
+sSphealSprites12:
+ax_sprite sSphealGfx12, 0x100
+ax_sprite_terminator
+sSphealGfx13:
+.incbin "baserom.gba", 0x14FEF98, 0x100
+sSphealSprites13:
+ax_sprite sSphealGfx13, 0x100
+ax_sprite_terminator
+sSphealGfx14:
+.incbin "baserom.gba", 0x14FF0A8, 0x200
+sSphealSprites14:
+ax_sprite sSphealGfx14, 0x200
+ax_sprite_terminator
+sSphealGfx15:
+.incbin "baserom.gba", 0x14FF2B8, 0x100
+sSphealSprites15:
+ax_sprite sSphealGfx15, 0x100
+ax_sprite_terminator
+sSphealGfx16:
+.incbin "baserom.gba", 0x14FF3C8, 0x200
+sSphealSprites16:
+ax_sprite sSphealGfx16, 0x200
+ax_sprite_terminator
+sSphealGfx17:
+.incbin "baserom.gba", 0x14FF5D8, 0x80
+sSphealSprites17:
+ax_sprite sSphealGfx17, 0x80
+ax_sprite_terminator
+sSphealGfx18:
+.incbin "baserom.gba", 0x14FF668, 0x200
+sSphealSprites18:
+ax_sprite sSphealGfx18, 0x200
+ax_sprite_terminator
+sSphealGfx19:
+.incbin "baserom.gba", 0x14FF878, 0x60
+sSphealGfx19_1:
+.incbin "baserom.gba", 0x14FF8D8, 0x60
+sSphealSprites19:
+ax_sprite sSphealGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSphealGfx20:
+.incbin "baserom.gba", 0x14FF960, 0xC0
+sSphealSprites20:
+ax_sprite sSphealGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSphealGfx21:
+.incbin "baserom.gba", 0x14FFA38, 0x60
+sSphealGfx21_1:
+.incbin "baserom.gba", 0x14FFA98, 0x60
+sSphealSprites21:
+ax_sprite sSphealGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSphealGfx22:
+.incbin "baserom.gba", 0x14FFB20, 0x40
+sSphealGfx22_1:
+.incbin "baserom.gba", 0x14FFB60, 0x60
+sSphealGfx22_2:
+.incbin "baserom.gba", 0x14FFBC0, 0x60
+sSphealSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx22_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSphealGfx23:
+.incbin "baserom.gba", 0x14FFC60, 0x40
+sSphealGfx23_1:
+.incbin "baserom.gba", 0x14FFCA0, 0x60
+sSphealGfx23_2:
+.incbin "baserom.gba", 0x14FFD00, 0x60
+sSphealSprites23:
+ax_sprite sSphealGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSphealGfx24:
+.incbin "baserom.gba", 0x14FFD98, 0x40
+sSphealGfx24_1:
+.incbin "baserom.gba", 0x14FFDD8, 0x60
+sSphealGfx24_2:
+.incbin "baserom.gba", 0x14FFE38, 0x60
+sSphealSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx24_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSphealGfx25:
+.incbin "baserom.gba", 0x14FFED8, 0x60
+sSphealGfx25_1:
+.incbin "baserom.gba", 0x14FFF38, 0x60
+sSphealSprites25:
+ax_sprite sSphealGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSphealGfx26:
+.incbin "baserom.gba", 0x14FFFC0, 0x40
+sSphealGfx26_1:
+.incbin "baserom.gba", 0x1500000, 0x60
+sSphealGfx26_2:
+.incbin "baserom.gba", 0x1500060, 0x60
+sSphealGfx26_3:
+.incbin "baserom.gba", 0x15000C0, 0x20
+sSphealSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx26_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSphealGfx27:
+.incbin "baserom.gba", 0x1500130, 0x60
+sSphealGfx27_1:
+.incbin "baserom.gba", 0x1500190, 0x60
+sSphealSprites27:
+ax_sprite sSphealGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSphealGfx28:
+.incbin "baserom.gba", 0x1500218, 0x100
+sSphealSprites28:
+ax_sprite sSphealGfx28, 0x100
+ax_sprite_terminator
+sSphealGfx29:
+.incbin "baserom.gba", 0x1500328, 0x40
+sSphealGfx29_1:
+.incbin "baserom.gba", 0x1500368, 0x40
+sSphealGfx29_2:
+.incbin "baserom.gba", 0x15003A8, 0x80
+sSphealSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx29_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSphealGfx30:
+.incbin "baserom.gba", 0x1500468, 0x40
+sSphealGfx30_1:
+.incbin "baserom.gba", 0x15004A8, 0x80
+sSphealSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx30_1, 0x80
+ax_sprite_terminator
+sSphealGfx31:
+.incbin "baserom.gba", 0x1500550, 0x40
+sSphealGfx31_1:
+.incbin "baserom.gba", 0x1500590, 0x60
+sSphealGfx31_2:
+.incbin "baserom.gba", 0x15005F0, 0x60
+sSphealSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx31_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSphealGfx32:
+.incbin "baserom.gba", 0x1500690, 0x100
+sSphealSprites32:
+ax_sprite sSphealGfx32, 0x100
+ax_sprite_terminator
+sSphealGfx33:
+.incbin "baserom.gba", 0x15007A0, 0x40
+sSphealGfx33_1:
+.incbin "baserom.gba", 0x15007E0, 0x60
+sSphealGfx33_2:
+.incbin "baserom.gba", 0x1500840, 0x60
+sSphealSprites33:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx33_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSphealGfx34:
+.incbin "baserom.gba", 0x15008E0, 0x100
+sSphealSprites34:
+ax_sprite sSphealGfx34, 0x100
+ax_sprite_terminator
+sSphealGfx35:
+.incbin "baserom.gba", 0x15009F0, 0x40
+sSphealGfx35_1:
+.incbin "baserom.gba", 0x1500A30, 0x60
+sSphealGfx35_2:
+.incbin "baserom.gba", 0x1500A90, 0x60
+sSphealGfx35_3:
+.incbin "baserom.gba", 0x1500AF0, 0x20
+sSphealSprites35:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx35_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSphealGfx36:
+.incbin "baserom.gba", 0x1500B60, 0x80
+sSphealGfx36_1:
+.incbin "baserom.gba", 0x1500BE0, 0x60
+sSphealSprites36:
+ax_sprite sSphealGfx36, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx36_1, 0x60
+ax_sprite_terminator
+sSphealGfx37:
+.incbin "baserom.gba", 0x1500C60, 0x40
+sSphealGfx37_1:
+.incbin "baserom.gba", 0x1500CA0, 0x40
+sSphealGfx37_2:
+.incbin "baserom.gba", 0x1500CE0, 0x80
+sSphealGfx37_3:
+.incbin "baserom.gba", 0x1500D60, 0x40
+sSphealSprites37:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSphealGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx37_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSphealGfx38:
+.incbin "baserom.gba", 0x1500DF0, 0x40
+sSphealGfx38_1:
+.incbin "baserom.gba", 0x1500E30, 0x80
+sSphealSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSphealGfx38_1, 0x80
+ax_sprite_terminator
+sSphealGfx39:
+.incbin "baserom.gba", 0x1500ED8, 0x200
+sSphealSprites39:
+ax_sprite sSphealGfx39, 0x200
+ax_sprite_terminator
+sSphealGfx40:
+.incbin "baserom.gba", 0x15010E8, 0x200
+sSphealSprites40:
+ax_sprite sSphealGfx40, 0x200
+ax_sprite_terminator
+sSphealGfx41:
+.incbin "baserom.gba", 0x15012F8, 0x200
+sSphealSprites41:
+ax_sprite sSphealGfx41, 0x200
+ax_sprite_terminator
+sSphealGfx42:
+.incbin "baserom.gba", 0x1501508, 0x200
+sSphealSprites42:
+ax_sprite sSphealGfx42, 0x200
+ax_sprite_terminator
+sSphealGfx43:
+.incbin "baserom.gba", 0x1501718, 0x200
+sSphealSprites43:
+ax_sprite sSphealGfx43, 0x200
+ax_sprite_terminator
+sSphealGfx44:
+.incbin "baserom.gba", 0x1501928, 0x200
+sSphealSprites44:
+ax_sprite sSphealGfx44, 0x200
+ax_sprite_terminator
+sSphealGfx45:
+.incbin "baserom.gba", 0x1501B38, 0x200
+sSphealSprites45:
+ax_sprite sSphealGfx45, 0x200
+ax_sprite_terminator
+sAxPosesSpheal:
+.4byte sSphealPose1
+.4byte sSphealPose2
+.4byte sSphealPose3
+.4byte sSphealPose4
+.4byte sSphealPose5
+.4byte sSphealPose6
+.4byte sSphealPose7
+.4byte sSphealPose8
+.4byte sSphealPose9
+.4byte sSphealPose10
+.4byte sSphealPose11
+.4byte sSphealPose12
+.4byte sSphealPose13
+.4byte sSphealPose14
+.4byte sSphealPose15
+.4byte sSphealPose16
+.4byte sSphealPose17
+.4byte sSphealPose18
+.4byte sSphealPose19
+.4byte sSphealPose20
+.4byte sSphealPose21
+.4byte sSphealPose22
+.4byte sSphealPose23
+.4byte sSphealPose24
+.4byte sSphealPose25
+.4byte sSphealPose26
+.4byte sSphealPose27
+.4byte sSphealPose28
+.4byte sSphealPose29
+.4byte sSphealPose30
+.4byte sSphealPose31
+.4byte sSphealPose32
+.4byte sSphealPose33
+.4byte sSphealPose34
+.4byte sSphealPose35
+.4byte sSphealPose36
+.4byte sSphealPose37
+.4byte sSphealPose38
+.4byte sSphealPose39
+.4byte sSphealPose40
+.4byte sSphealPose41
+.4byte sSphealPose42
+.4byte sSphealPose43
+.4byte sSphealPose44
+.4byte sSphealPose45
+.4byte sSphealPose46
+.4byte sSphealPose47
+.4byte sSphealPose48
+.4byte sSphealPose49
+.4byte sSphealPose50
+.4byte sSphealPose51
+.4byte sSphealPose52
+.4byte sSphealPose53
+.4byte sSphealPose54
+.4byte sSphealPose55
+.4byte sSphealPose56
+.4byte sSphealPose57
+.4byte sSphealPose58
+.4byte sSphealPose59
+.4byte sSphealPose60
+.4byte sSphealPose61
+.4byte sSphealPose62
+.4byte sSphealPose63
+.4byte sSphealPose64
+.4byte sSphealPose65
+.4byte sSphealPose66
+.4byte sSphealPose67
+.4byte sSphealPose68
+.4byte sSphealPose69
+.4byte sSphealPose70
+.4byte sSphealPose71
+.4byte sSphealPose72
+.4byte sSphealPose73
+.4byte sSphealPose74
+.4byte sSphealPose75
+.4byte sSphealPose76
+.4byte sSphealPose77
+.4byte sSphealPose78
+.4byte sSphealPose79
+.4byte sSphealPose80
+.4byte sSphealPose81
+.4byte sSphealPose82
+.4byte sSphealPose83
+.4byte sSphealPose84
+.4byte sSphealPose85
+.4byte sSphealPose86
+.4byte sSphealPose87
+.4byte sSphealPose88
+.4byte sSphealPose89
+.4byte sSphealPose90
+.4byte sSphealPose91
+.4byte sSphealPose92
+.4byte sSphealPose93
+.4byte sSphealPose94
+.4byte sSphealPose95
+.4byte sSphealPose96
+.4byte sSphealPose97
+.4byte sSphealPose98
+.4byte sSphealPose99
+.4byte sSphealPose100
+.4byte sSphealPose101
+.4byte sSphealPose102
+.4byte sSphealPose103
+.4byte sSphealPose104
+.4byte sSphealPose105
+.4byte sSphealPose106
+.4byte sSphealPose107
+.4byte sSphealPose108
+.4byte sSphealPose109
+.4byte sSphealPose110
+.4byte sSphealPose111
+.4byte sSphealPose112
+.4byte sSphealPose113
+.4byte sSphealPose114
+.4byte sSphealPose115
+.4byte sSphealPose116
+.4byte sSphealPose117
+.4byte sSphealPose118
+.4byte sSphealPose119
+.4byte sSphealPose120
+.4byte sSphealPose121
+.4byte sSphealPose122
+.4byte sSphealPose123
+.4byte sSphealPose124
+.4byte sSphealPose125
+.4byte sSphealPose126
+.4byte sSphealPose127
+.4byte sSphealPose128
+.4byte sSphealPose129
+.4byte sSphealPose130
+.4byte sSphealPose131
+.4byte sSphealPose132
+.4byte sSphealPose133
+.4byte sSphealPose134
+.4byte sSphealPose135
+.4byte sSphealPose136
+.4byte sSphealPose137
+.4byte sSphealPose138
+.4byte sSphealPose139
+.4byte sSphealPose140
+.4byte sSphealPose141
+.4byte sSphealPose142
+.4byte sSphealPose143
+.4byte sSphealPose144
+.4byte sSphealPose145
+.4byte sSphealPose146
+.4byte sSphealPose147
+.4byte sSphealPose148
+.4byte sSphealPose149
+.4byte sSphealPose150
+.4byte sSphealPose151
+.4byte sSphealPose152
+.4byte sSphealPose153
+.4byte sSphealPose154
+.4byte sSphealPose155
+.4byte sSphealPose156
+.4byte sSphealPose157
+.4byte sSphealPose158
+.4byte sSphealPose159
+.4byte sSphealPose160
+.4byte sSphealPose161
+.4byte sSphealPose162
+.4byte sSphealPose163
+.4byte sSphealPose164
+.4byte sSphealPose165
+.4byte sSphealPose166
+.4byte sSphealPose167
+.4byte sSphealPose168
+.4byte sSphealPose169
+.4byte sSphealPose170
+.4byte sSphealPose171
+.4byte sSphealPose172
+.4byte sSphealPose173
+.4byte sSphealPose174
+.4byte sSphealPose175
+.4byte sSphealPose176
+.4byte sSphealPose177
+.4byte sSphealPose178
+.4byte sSphealPose179
+.4byte sSphealPose180
+.4byte sSphealPose181
+.4byte sSphealPose182
+.4byte sSphealPose183
+.4byte sSphealPose184
+.4byte sSphealPose185
+.4byte sSphealPose186
+.4byte sSphealPose187
+.4byte sSphealPose188
+.4byte sSphealPose189
+.4byte sSphealPose190
+.4byte sSphealPose191
+.4byte sSphealPose192
+.4byte sSphealPose193
+.4byte sSphealPose194
+.4byte sSphealPose195
+.4byte sSphealPose196
+.4byte sSphealPose197
+.4byte sSphealPose198
+.4byte sSphealPose199
+.4byte sSphealPose200
+.4byte sSphealPose201
+.4byte sSphealPose202
+.4byte sSphealPose203
+.4byte sSphealPose204
+.4byte sSphealPose205
+.4byte sSphealPose206
+.4byte sSphealPose207
+.4byte sSphealPose208
+.4byte sSphealPose209
+.4byte sSphealPose210
+.4byte sSphealPose211
+.4byte sSphealPose212
+.4byte sSphealPose213
+.4byte sSphealPose214
+.4byte sSphealPose215
+.4byte sSphealPose216
+.4byte sSphealPose217
+.4byte sSphealPose218
+sAxPositionsSpheal:
+.2byte   -5,   -4, 	  -1,   -4, 	   0,   -1, 	   0,   -7
+.2byte   -5,   -3, 	   1,   -2, 	   0,   -9, 	   0,   -8
+.2byte   -5,  -11, 	   1,  -12, 	   0,   -5, 	   0,   -6
+.2byte   -5,  -10, 	  -1,  -10, 	   0,  -13, 	   0,   -7
+.2byte   -5,   -9, 	  -1,   -9, 	   0,  -15, 	   0,   -7
+.2byte   -5,   -6, 	  -1,  -10, 	  -1,    1, 	   0,   -6
+.2byte   -5,   -4, 	  -4,   -5, 	   3,   -1, 	   0,   -6
+.2byte   -6,   -7, 	   1,   -2, 	  -4,  -10, 	  -1,   -8
+.2byte   -6,   -7, 	   1,  -12, 	  -4,   -4, 	  -1,   -6
+.2byte   -5,  -10, 	  -4,   -9, 	   3,  -13, 	   0,   -8
+.2byte   -4,   -7, 	   1,   -2, 	   1,  -14, 	   1,   -7
+.2byte   -3,   -4, 	  -5,   -1, 	   4,   -6, 	   0,   -5
+.2byte   -1,   -2, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte   -4,   -6, 	  -2,    0, 	  -8,   -8, 	  -1,   -8
+.2byte   -4,   -8, 	  -2,  -14, 	  -8,   -6, 	  -1,   -6
+.2byte   -1,  -12, 	  -5,  -13, 	   4,  -13, 	   0,   -9
+.2byte    3,   -9, 	   1,  -15, 	   7,   -7, 	   0,   -7
+.2byte    3,   -6, 	   1,    0, 	   7,   -8, 	   0,   -8
+.2byte    4,   -4, 	   3,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte    5,   -7, 	  -2,   -2, 	   3,  -10, 	   0,   -8
+.2byte    5,   -7, 	  -2,  -12, 	   3,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -9, 	  -4,  -13, 	  -1,   -8
+.2byte    3,   -7, 	  -2,   -2, 	  -2,  -14, 	  -2,   -7
+.2byte    2,   -4, 	   4,   -1, 	  -5,   -6, 	  -1,   -5
+.2byte    4,   -4, 	   0,   -4, 	  -1,   -1, 	  -1,   -7
+.2byte    4,   -3, 	  -2,   -2, 	  -1,   -9, 	  -1,   -8
+.2byte    4,  -11, 	  -2,  -12, 	  -1,   -5, 	  -1,   -6
+.2byte    4,  -10, 	   0,  -10, 	  -1,  -13, 	  -1,   -7
+.2byte    4,   -9, 	   0,   -9, 	  -1,  -15, 	  -1,   -7
+.2byte    4,   -6, 	   0,  -10, 	   0,    1, 	  -1,   -6
+.2byte    2,   -7, 	  -5,   -8, 	   3,   -1, 	  -1,   -6
+.2byte    3,   -7, 	  -5,   -7, 	   5,   -4, 	  -1,   -6
+.2byte    3,  -10, 	   3,   -2, 	  -5,  -11, 	  -1,   -6
+.2byte    3,  -11, 	   1,  -10, 	  -6,  -12, 	   0,   -7
+.2byte    1,  -13, 	  -7,  -12, 	   0,   -5, 	  -2,   -8
+.2byte    2,  -10, 	  -6,  -10, 	   2,   -4, 	   0,   -7
+.2byte   -1,   -6, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    3,  -11, 	  -7,  -11, 	   3,   -2, 	   0,   -8
+.2byte    3,   -5, 	  -7,   -5, 	   3,  -14, 	   0,   -8
+.2byte   -1,   -8, 	   6,   -8, 	  -7,   -8, 	   0,   -8
+.2byte   -4,   -5, 	   6,   -5, 	  -4,  -14, 	  -1,   -8
+.2byte   -4,  -10, 	   6,  -10, 	  -4,   -1, 	  -1,   -7
+.2byte   -3,   -7, 	   4,   -8, 	  -4,   -1, 	   0,   -6
+.2byte   -4,   -7, 	   4,   -7, 	  -6,   -4, 	   0,   -6
+.2byte   -4,  -10, 	  -4,   -2, 	   4,  -11, 	   0,   -6
+.2byte   -4,  -11, 	  -2,  -10, 	   5,  -12, 	  -1,   -7
+.2byte   -2,  -13, 	   6,  -12, 	  -1,   -5, 	   1,   -8
+.2byte   -3,  -10, 	   5,  -10, 	  -3,   -4, 	  -1,   -7
+.2byte   -1,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte   -1,  -11, 	  -5,   -1, 	   4,   -1, 	   0,   -7
+.2byte   -1,   -2, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    3,   -3, 	   5,   -2, 	  -5,   -1, 	  -1,   -6
+.2byte    3,   -9, 	   4,   -2, 	  -1,    0, 	   0,   -6
+.2byte    4,   -4, 	   3,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte    4,   -4, 	   1,   -4, 	   0,    0, 	  -1,   -6
+.2byte    4,   -9, 	   0,   -2, 	   3,    0, 	  -1,   -6
+.2byte    4,   -4, 	   0,   -4, 	  -1,   -1, 	  -1,   -7
+.2byte    2,   -7, 	  -3,   -6, 	   5,   -1, 	  -1,   -7
+.2byte    4,  -10, 	  -2,   -3, 	   3,    0, 	  -1,   -7
+.2byte    2,   -7, 	  -5,   -8, 	   3,   -1, 	  -1,   -6
+.2byte   -1,  -10, 	   6,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -7,   -3, 	   0,   -7
+.2byte   -1,   -6, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -3,   -7, 	   2,   -6, 	  -6,   -1, 	   0,   -7
+.2byte   -5,  -10, 	   1,   -3, 	  -4,    0, 	   0,   -7
+.2byte   -3,   -7, 	   4,   -8, 	  -4,   -1, 	   0,   -6
+.2byte   -5,   -4, 	  -2,   -4, 	  -1,    0, 	   0,   -6
+.2byte   -5,   -9, 	  -1,   -2, 	  -4,    0, 	   0,   -6
+.2byte   -5,   -4, 	  -1,   -4, 	   0,   -1, 	   0,   -7
+.2byte   -4,   -3, 	  -6,   -2, 	   4,   -1, 	   0,   -6
+.2byte   -4,   -9, 	  -5,   -2, 	   0,    0, 	  -1,   -6
+.2byte   -5,   -4, 	  -4,   -5, 	   3,   -1, 	   0,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte   -1,  -11, 	  -5,   -1, 	   4,   -1, 	   0,   -7
+.2byte   -1,   -2, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    3,   -3, 	   5,   -2, 	  -5,   -1, 	  -1,   -6
+.2byte    3,   -9, 	   4,   -2, 	  -1,    0, 	   0,   -6
+.2byte    4,   -4, 	   3,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte    4,   -4, 	   1,   -4, 	   0,    0, 	  -1,   -6
+.2byte    4,   -9, 	   0,   -2, 	   3,    0, 	  -1,   -6
+.2byte    4,   -4, 	   0,   -4, 	  -1,   -1, 	  -1,   -7
+.2byte    2,   -7, 	  -3,   -6, 	   5,   -1, 	  -1,   -7
+.2byte    4,  -10, 	  -2,   -3, 	   3,    0, 	  -1,   -7
+.2byte    2,   -7, 	  -5,   -8, 	   3,   -1, 	  -1,   -6
+.2byte   -1,  -10, 	   6,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -7,   -3, 	   0,   -7
+.2byte   -1,   -6, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -3,   -7, 	   2,   -6, 	  -6,   -1, 	   0,   -7
+.2byte   -5,  -10, 	   1,   -3, 	  -4,    0, 	   0,   -7
+.2byte   -3,   -7, 	   4,   -8, 	  -4,   -1, 	   0,   -6
+.2byte   -5,   -4, 	  -2,   -4, 	  -1,    0, 	   0,   -6
+.2byte   -5,   -9, 	  -1,   -2, 	  -4,    0, 	   0,   -6
+.2byte   -5,   -4, 	  -1,   -4, 	   0,   -1, 	   0,   -7
+.2byte   -4,   -3, 	  -6,   -2, 	   4,   -1, 	   0,   -6
+.2byte   -4,   -9, 	  -5,   -2, 	   0,    0, 	  -1,   -6
+.2byte   -5,   -4, 	  -4,   -5, 	   3,   -1, 	   0,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte    0,  -12, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte    0,   -2, 	  -7,    0, 	   6,    0, 	   0,   -5
+.2byte    3,   -3, 	   5,   -2, 	  -5,   -1, 	  -1,   -6
+.2byte    0,  -13, 	   5,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte    4,   -3, 	   6,   -1, 	  -4,    0, 	   0,   -5
+.2byte    4,   -4, 	   1,   -4, 	   0,    0, 	  -1,   -6
+.2byte    1,  -12, 	   1,   -4, 	   0,   -1, 	  -1,   -7
+.2byte    5,   -4, 	   1,   -2, 	  -1,    0, 	   0,   -6
+.2byte    2,   -7, 	  -3,   -6, 	   5,   -1, 	  -1,   -7
+.2byte    2,  -12, 	  -5,   -5, 	   5,   -1, 	  -1,   -6
+.2byte    4,   -6, 	  -3,   -4, 	   3,   -1, 	  -1,   -6
+.2byte   -1,  -10, 	   6,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte    0,  -13, 	   6,   -3, 	  -7,   -3, 	   0,   -7
+.2byte    0,  -11, 	   6,   -3, 	  -7,   -3, 	   0,   -8
+.2byte   -3,   -7, 	   2,   -6, 	  -6,   -1, 	   0,   -7
+.2byte   -3,  -12, 	   4,   -5, 	  -6,   -1, 	   0,   -6
+.2byte   -5,   -6, 	   2,   -4, 	  -4,   -1, 	   0,   -6
+.2byte   -5,   -4, 	  -2,   -4, 	  -1,    0, 	   0,   -6
+.2byte   -2,  -12, 	  -2,   -4, 	  -1,   -1, 	   0,   -7
+.2byte   -6,   -4, 	  -2,   -2, 	   0,    0, 	  -1,   -6
+.2byte   -4,   -3, 	  -6,   -2, 	   4,   -1, 	   0,   -6
+.2byte   -1,  -13, 	  -6,   -3, 	   4,   -1, 	   0,   -6
+.2byte   -5,   -3, 	  -7,   -1, 	   3,    0, 	  -1,   -5
+.2byte   -1,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte   -1,  -11, 	  -5,   -1, 	   4,   -1, 	   0,   -7
+.2byte    3,   -3, 	   5,   -2, 	  -5,   -1, 	  -1,   -6
+.2byte    3,   -9, 	   4,   -2, 	  -1,    0, 	   0,   -6
+.2byte    4,   -4, 	   1,   -4, 	   0,    0, 	  -1,   -6
+.2byte    4,   -9, 	   0,   -2, 	   3,    0, 	  -1,   -6
+.2byte    2,   -7, 	  -3,   -6, 	   5,   -1, 	  -1,   -7
+.2byte    4,  -10, 	  -2,   -3, 	   3,    0, 	  -1,   -7
+.2byte   -1,  -10, 	   6,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -7,   -3, 	   0,   -7
+.2byte   -3,   -7, 	   2,   -6, 	  -6,   -1, 	   0,   -7
+.2byte   -5,  -10, 	   1,   -3, 	  -4,    0, 	   0,   -7
+.2byte   -5,   -4, 	  -2,   -4, 	  -1,    0, 	   0,   -6
+.2byte   -5,   -9, 	  -1,   -2, 	  -4,    0, 	   0,   -6
+.2byte   -4,   -3, 	  -6,   -2, 	   4,   -1, 	   0,   -6
+.2byte   -4,   -9, 	  -5,   -2, 	   0,    0, 	  -1,   -6
+.2byte   -4,   -3, 	  -4,   -1, 	   1,    0, 	   0,   -6
+.2byte   -4,   -2, 	  -5,   -1, 	   1,    0, 	   0,   -5
+.2byte   -1,   -8, 	  -7,   -1, 	   6,   -1, 	   0,   -5
+.2byte    3,   -6, 	   8,   -6, 	  -1,   -1, 	   0,   -6
+.2byte    5,   -6, 	   5,   -5, 	   4,   -2, 	  -1,   -6
+.2byte    3,  -11, 	  -3,   -9, 	   7,   -4, 	  -1,   -6
+.2byte    0,  -11, 	   7,   -6, 	  -8,   -6, 	   0,   -5
+.2byte   -4,  -11, 	   2,   -9, 	  -8,   -4, 	   0,   -6
+.2byte   -6,   -6, 	  -6,   -5, 	  -5,   -2, 	   0,   -6
+.2byte   -4,   -6, 	  -9,   -6, 	   0,   -1, 	  -1,   -6
+.2byte   -5,   -4, 	  -2,   -4, 	  -1,    0, 	   0,   -6
+.2byte   -5,   -4, 	  -1,   -4, 	   0,   -1, 	   0,   -7
+.2byte   -4,   -3, 	  -6,   -2, 	   4,   -1, 	   0,   -6
+.2byte   -5,   -4, 	  -4,   -5, 	   3,   -1, 	   0,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte   -1,   -2, 	  -5,   -1, 	   4,   -1, 	   0,   -5
+.2byte    3,   -3, 	   5,   -2, 	  -5,   -1, 	  -1,   -6
+.2byte    4,   -4, 	   3,   -5, 	  -4,   -1, 	  -1,   -6
+.2byte    4,   -4, 	   1,   -4, 	   0,    0, 	  -1,   -6
+.2byte    4,   -4, 	   0,   -4, 	  -1,   -1, 	  -1,   -7
+.2byte    2,   -7, 	  -3,   -6, 	   5,   -1, 	  -1,   -7
+.2byte    2,   -7, 	  -5,   -8, 	   3,   -1, 	  -1,   -6
+.2byte   -1,  -10, 	   6,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte   -3,   -7, 	   2,   -6, 	  -6,   -1, 	   0,   -7
+.2byte   -3,   -7, 	   4,   -8, 	  -4,   -1, 	   0,   -6
+.2byte    0,  -12, 	  -7,   -1, 	   6,   -1, 	   0,   -7
+.2byte   -1,  -13, 	  -6,   -3, 	   4,   -1, 	   0,   -6
+.2byte   -2,  -12, 	  -2,   -4, 	  -1,   -1, 	   0,   -7
+.2byte   -3,  -12, 	   4,   -5, 	  -6,   -1, 	   0,   -6
+.2byte    0,  -13, 	   6,   -3, 	  -7,   -3, 	   0,   -7
+.2byte    2,  -12, 	  -5,   -5, 	   5,   -1, 	  -1,   -6
+.2byte    1,  -12, 	   1,   -4, 	   0,   -1, 	  -1,   -7
+.2byte    0,  -13, 	   5,   -3, 	  -5,   -1, 	  -1,   -6
+.2byte   -1,  -10, 	  -5,    0, 	   4,    0, 	   0,   -6
+.2byte    3,   -9, 	   4,   -2, 	  -1,    0, 	   0,   -6
+.2byte    4,   -9, 	   0,   -2, 	   3,    0, 	  -1,   -6
+.2byte    4,  -10, 	  -2,   -3, 	   3,    0, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -7,   -3, 	   0,   -7
+.2byte   -5,  -10, 	   1,   -3, 	  -4,    0, 	   0,   -7
+.2byte   -5,   -9, 	  -1,   -2, 	  -4,    0, 	   0,   -6
+.2byte   -4,   -9, 	  -5,   -2, 	   0,    0, 	  -1,   -6
+.2byte   -1,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte   -1,  -10, 	  -5,    0, 	   4,    0, 	   0,   -6
+.2byte    0,   -2, 	  -7,    0, 	   6,    0, 	   0,   -5
+.2byte    3,   -3, 	   5,   -2, 	  -5,   -1, 	  -1,   -6
+.2byte    3,   -9, 	   4,   -2, 	  -1,    0, 	   0,   -6
+.2byte    3,   -3, 	   5,   -1, 	  -5,    0, 	  -1,   -5
+.2byte    4,   -4, 	   1,   -4, 	   0,    0, 	  -1,   -6
+.2byte    4,   -9, 	   0,   -2, 	   3,    0, 	  -1,   -6
+.2byte    5,   -4, 	   1,   -2, 	  -1,    0, 	   0,   -6
+.2byte    2,   -7, 	  -3,   -6, 	   5,   -1, 	  -1,   -7
+.2byte    4,  -10, 	  -2,   -3, 	   3,    0, 	  -1,   -7
+.2byte    4,   -6, 	  -3,   -4, 	   3,   -1, 	  -1,   -6
+.2byte   -1,  -10, 	   6,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   6,   -3, 	  -7,   -3, 	   0,   -7
+.2byte    0,  -11, 	   6,   -3, 	  -7,   -3, 	   0,   -8
+.2byte   -3,   -7, 	   2,   -6, 	  -6,   -1, 	   0,   -7
+.2byte   -5,  -10, 	   1,   -3, 	  -4,    0, 	   0,   -7
+.2byte   -5,   -6, 	   2,   -4, 	  -4,   -1, 	   0,   -6
+.2byte   -5,   -4, 	  -2,   -4, 	  -1,    0, 	   0,   -6
+.2byte   -5,   -9, 	  -1,   -2, 	  -4,    0, 	   0,   -6
+.2byte   -6,   -4, 	  -2,   -2, 	   0,    0, 	  -1,   -6
+.2byte   -4,   -3, 	  -6,   -2, 	   4,   -1, 	   0,   -6
+.2byte   -4,   -9, 	  -5,   -2, 	   0,    0, 	  -1,   -6
+.2byte   -4,   -3, 	  -6,   -1, 	   4,    0, 	   0,   -5
+.2byte    0,   -2, 	  -7,    0, 	   6,    0, 	   0,   -5
+.2byte   -5,   -3, 	  -7,   -1, 	   3,    0, 	  -1,   -5
+.2byte   -6,   -3, 	  -2,   -1, 	   0,    1, 	  -1,   -5
+.2byte   -6,   -5, 	   1,   -3, 	  -5,    0, 	  -1,   -5
+.2byte    0,   -9, 	   6,   -1, 	  -7,   -1, 	   0,   -6
+.2byte    5,   -5, 	  -2,   -3, 	   4,    0, 	   0,   -5
+.2byte    5,   -3, 	   1,   -1, 	  -1,    1, 	   0,   -5
+.2byte    4,   -3, 	   6,   -1, 	  -4,    0, 	   0,   -5
+.2byte   -1,   -2, 	  -6,   -1, 	   5,   -1, 	   0,   -5
+.2byte   -4,   -3, 	  -6,   -2, 	   4,   -1, 	   0,   -6
+.2byte   -5,   -4, 	  -2,   -4, 	  -1,    0, 	   0,   -6
+.2byte   -3,   -7, 	   2,   -6, 	  -6,   -1, 	   0,   -7
+.2byte   -1,  -10, 	   6,   -3, 	  -7,   -3, 	  -1,   -7
+.2byte    2,   -7, 	  -3,   -6, 	   5,   -1, 	  -1,   -7
+.2byte    4,   -4, 	   1,   -4, 	   0,    0, 	  -1,   -6
+.2byte    3,   -3, 	   5,   -2, 	  -5,   -1, 	  -1,   -6
+sSphealAnimTable1:
+.4byte sSphealAnims_1_1
+.4byte sSphealAnims_1_2
+.4byte sSphealAnims_1_3
+.4byte sSphealAnims_1_4
+.4byte sSphealAnims_1_5
+.4byte sSphealAnims_1_6
+.4byte sSphealAnims_1_7
+.4byte sSphealAnims_1_8
+sSphealAnimTable2:
+.4byte sSphealAnims_2_1
+.4byte sSphealAnims_2_2
+.4byte sSphealAnims_2_3
+.4byte sSphealAnims_2_4
+.4byte sSphealAnims_2_5
+.4byte sSphealAnims_2_6
+.4byte sSphealAnims_2_7
+.4byte sSphealAnims_2_8
+sSphealAnimTable3:
+.4byte sSphealAnims_3_1
+.4byte sSphealAnims_3_2
+.4byte sSphealAnims_3_3
+.4byte sSphealAnims_3_4
+.4byte sSphealAnims_3_5
+.4byte sSphealAnims_3_6
+.4byte sSphealAnims_3_7
+.4byte sSphealAnims_3_8
+sSphealAnimTable4:
+.4byte sSphealAnims_4_1
+.4byte sSphealAnims_4_2
+.4byte sSphealAnims_4_3
+.4byte sSphealAnims_4_4
+.4byte sSphealAnims_4_5
+.4byte sSphealAnims_4_6
+.4byte sSphealAnims_4_7
+.4byte sSphealAnims_4_8
+sSphealAnimTable5:
+.4byte sSphealAnims_5_1
+.4byte sSphealAnims_5_2
+.4byte sSphealAnims_5_3
+.4byte sSphealAnims_5_4
+.4byte sSphealAnims_5_5
+.4byte sSphealAnims_5_6
+.4byte sSphealAnims_5_7
+.4byte sSphealAnims_5_8
+sSphealAnimTable6:
+.4byte sSphealAnims_6_1
+.4byte sSphealAnims_6_1
+.4byte sSphealAnims_6_1
+.4byte sSphealAnims_6_1
+.4byte sSphealAnims_6_1
+.4byte sSphealAnims_6_1
+.4byte sSphealAnims_6_1
+.4byte sSphealAnims_6_1
+sSphealAnimTable7:
+.4byte sSphealAnims_7_1
+.4byte sSphealAnims_7_2
+.4byte sSphealAnims_7_3
+.4byte sSphealAnims_7_4
+.4byte sSphealAnims_7_5
+.4byte sSphealAnims_7_6
+.4byte sSphealAnims_7_7
+.4byte sSphealAnims_7_8
+sSphealAnimTable8:
+.4byte sSphealAnims_8_1
+.4byte sSphealAnims_8_2
+.4byte sSphealAnims_8_3
+.4byte sSphealAnims_8_4
+.4byte sSphealAnims_8_5
+.4byte sSphealAnims_8_6
+.4byte sSphealAnims_8_7
+.4byte sSphealAnims_8_8
+sSphealAnimTable9:
+.4byte sSphealAnims_9_1
+.4byte sSphealAnims_9_2
+.4byte sSphealAnims_9_3
+.4byte sSphealAnims_9_4
+.4byte sSphealAnims_9_5
+.4byte sSphealAnims_9_6
+.4byte sSphealAnims_9_7
+.4byte sSphealAnims_9_8
+sSphealAnimTable10:
+.4byte sSphealAnims_10_1
+.4byte sSphealAnims_10_2
+.4byte sSphealAnims_10_3
+.4byte sSphealAnims_10_4
+.4byte sSphealAnims_10_5
+.4byte sSphealAnims_10_6
+.4byte sSphealAnims_10_7
+.4byte sSphealAnims_10_8
+sSphealAnimTable11:
+.4byte sSphealAnims_11_1
+.4byte sSphealAnims_11_2
+.4byte sSphealAnims_11_3
+.4byte sSphealAnims_11_4
+.4byte sSphealAnims_11_5
+.4byte sSphealAnims_11_6
+.4byte sSphealAnims_11_7
+.4byte sSphealAnims_11_8
+sSphealAnimTable12:
+.4byte sSphealAnims_12_1
+.4byte sSphealAnims_12_2
+.4byte sSphealAnims_12_3
+.4byte sSphealAnims_12_4
+.4byte sSphealAnims_12_5
+.4byte sSphealAnims_12_6
+.4byte sSphealAnims_12_7
+.4byte sSphealAnims_12_8
+sSphealAnimTable13:
+.4byte sSphealAnims_13_1
+.4byte sSphealAnims_13_2
+.4byte sSphealAnims_13_3
+.4byte sSphealAnims_13_4
+.4byte sSphealAnims_13_5
+.4byte sSphealAnims_13_6
+.4byte sSphealAnims_13_7
+.4byte sSphealAnims_13_8
+sAxAnimationsSpheal:
+.4byte sSphealAnimTable1
+.4byte sSphealAnimTable2
+.4byte sSphealAnimTable3
+.4byte sSphealAnimTable4
+.4byte sSphealAnimTable5
+.4byte sSphealAnimTable6
+.4byte sSphealAnimTable7
+.4byte sSphealAnimTable8
+.4byte sSphealAnimTable9
+.4byte sSphealAnimTable10
+.4byte sSphealAnimTable11
+.4byte sSphealAnimTable12
+.4byte sSphealAnimTable13
+sAxSpritesSpheal:
+.4byte sSphealSprites1
+.4byte sSphealSprites2
+.4byte sSphealSprites3
+.4byte sSphealSprites4
+.4byte sSphealSprites5
+.4byte sSphealSprites6
+.4byte sSphealSprites7
+.4byte sSphealSprites8
+.4byte sSphealSprites9
+.4byte sSphealSprites10
+.4byte sSphealSprites11
+.4byte sSphealSprites12
+.4byte sSphealSprites13
+.4byte sSphealSprites14
+.4byte sSphealSprites15
+.4byte sSphealSprites16
+.4byte sSphealSprites17
+.4byte sSphealSprites18
+.4byte sSphealSprites19
+.4byte sSphealSprites20
+.4byte sSphealSprites21
+.4byte sSphealSprites22
+.4byte sSphealSprites23
+.4byte sSphealSprites24
+.4byte sSphealSprites25
+.4byte sSphealSprites26
+.4byte sSphealSprites27
+.4byte sSphealSprites28
+.4byte sSphealSprites29
+.4byte sSphealSprites30
+.4byte sSphealSprites31
+.4byte sSphealSprites32
+.4byte sSphealSprites33
+.4byte sSphealSprites34
+.4byte sSphealSprites35
+.4byte sSphealSprites36
+.4byte sSphealSprites37
+.4byte sSphealSprites38
+.4byte sSphealSprites39
+.4byte sSphealSprites40
+.4byte sSphealSprites41
+.4byte sSphealSprites42
+.4byte sSphealSprites43
+.4byte sSphealSprites44
+.4byte sSphealSprites45
+sAxMainSpheal:
+ax_main sAxPosesSpheal, sAxAnimationsSpheal, 13, sAxSpritesSpheal, sAxPositionsSpheal

--- a/data/ax/spinarak.inc
+++ b/data/ax/spinarak.inc
@@ -1,0 +1,2615 @@
+.global gAxSpinarak
+gAxSpinarak:
+ax_siro sAxMainSpinarak
+sSpinarakPose1:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose2:
+ax_pose 1, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose3:
+ax_pose 2, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose4:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose5:
+ax_pose 4, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose6:
+ax_pose 5, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose7:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose8:
+ax_pose 7, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose9:
+ax_pose 8, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose10:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose11:
+ax_pose 10, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose12:
+ax_pose 11, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose16:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose17:
+ax_pose 10, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose18:
+ax_pose 11, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose19:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose20:
+ax_pose 7, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose21:
+ax_pose 8, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose22:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose23:
+ax_pose 4, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose24:
+ax_pose 5, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose25:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose26:
+ax_pose 1, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose27:
+ax_pose 2, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose28:
+ax_pose 15, 0x01f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose29:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose30:
+ax_pose 4, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose31:
+ax_pose 5, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose32:
+ax_pose 16, 0x01f0, 0x90ee, 0x3c00
+ax_pose_terminator
+sSpinarakPose33:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose34:
+ax_pose 7, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose35:
+ax_pose 8, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose36:
+ax_pose 17, 0x01f0, 0x90ef, 0x3c00
+ax_pose_terminator
+sSpinarakPose37:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose38:
+ax_pose 10, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose39:
+ax_pose 11, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose40:
+ax_pose 18, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose42:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose43:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose44:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose45:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose46:
+ax_pose 10, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose47:
+ax_pose 11, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose48:
+ax_pose 18, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose49:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose50:
+ax_pose 7, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose51:
+ax_pose 8, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose52:
+ax_pose 17, 0x01f0, 0x80f2, 0x3c00
+ax_pose_terminator
+sSpinarakPose53:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose54:
+ax_pose 4, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose55:
+ax_pose 5, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose56:
+ax_pose 16, 0x01f0, 0x80f2, 0x3c00
+ax_pose_terminator
+sSpinarakPose57:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose58:
+ax_pose 1, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose59:
+ax_pose 2, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose60:
+ax_pose 15, 0x01f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose61:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose62:
+ax_pose 4, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose63:
+ax_pose 5, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose64:
+ax_pose 16, 0x01f0, 0x90ee, 0x3c00
+ax_pose_terminator
+sSpinarakPose65:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose66:
+ax_pose 7, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose67:
+ax_pose 8, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose68:
+ax_pose 17, 0x01f0, 0x90ef, 0x3c00
+ax_pose_terminator
+sSpinarakPose69:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose70:
+ax_pose 10, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose71:
+ax_pose 11, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose72:
+ax_pose 18, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose74:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose75:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose76:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose77:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose78:
+ax_pose 10, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose79:
+ax_pose 11, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose80:
+ax_pose 18, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose81:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose82:
+ax_pose 7, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose83:
+ax_pose 8, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose84:
+ax_pose 17, 0x01f0, 0x80f2, 0x3c00
+ax_pose_terminator
+sSpinarakPose85:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose86:
+ax_pose 4, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose87:
+ax_pose 5, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose88:
+ax_pose 16, 0x01f0, 0x80f2, 0x3c00
+ax_pose_terminator
+sSpinarakPose89:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose90:
+ax_pose 20, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose91:
+ax_pose 21, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose92:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose93:
+ax_pose 22, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose94:
+ax_pose 23, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose95:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose96:
+ax_pose 24, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose97:
+ax_pose 25, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose98:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose99:
+ax_pose 26, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose100:
+ax_pose 27, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose102:
+ax_pose 28, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose103:
+ax_pose 29, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose104:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose105:
+ax_pose 26, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose106:
+ax_pose 27, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose107:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose108:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose109:
+ax_pose 25, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose110:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose111:
+ax_pose 22, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose112:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose113:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose114:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose115:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose116:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose117:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose118:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose119:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose120:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose121:
+ax_pose 30, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose122:
+ax_pose 31, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose123:
+ax_pose 32, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sSpinarakPose124:
+ax_pose 33, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSpinarakPose125:
+ax_pose 34, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sSpinarakPose126:
+ax_pose 35, 0x01e9, 0x90ee, 0x3c00
+ax_pose_terminator
+sSpinarakPose127:
+ax_pose 36, 0x01ea, 0x80f3, 0x3c00
+ax_pose_terminator
+sSpinarakPose128:
+ax_pose 35, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sSpinarakPose129:
+ax_pose 34, 0x01e9, 0x80f1, 0x3c00
+ax_pose_terminator
+sSpinarakPose130:
+ax_pose 33, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sSpinarakPose131:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose132:
+ax_pose 37, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose133:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose134:
+ax_pose 38, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose135:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose136:
+ax_pose 39, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose137:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose138:
+ax_pose 40, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose139:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose140:
+ax_pose 41, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose141:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose142:
+ax_pose 40, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose143:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose144:
+ax_pose 39, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose145:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose146:
+ax_pose 38, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose147:
+ax_pose 21, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose148:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose149:
+ax_pose 25, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose150:
+ax_pose 27, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose151:
+ax_pose 29, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose152:
+ax_pose 27, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose153:
+ax_pose 25, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose154:
+ax_pose 23, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose155:
+ax_pose 21, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose156:
+ax_pose 23, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose157:
+ax_pose 25, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose158:
+ax_pose 27, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose159:
+ax_pose 29, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose160:
+ax_pose 27, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose161:
+ax_pose 25, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose162:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose163:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose164:
+ax_pose 20, 0x41f1, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose165:
+ax_pose 21, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose166:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose167:
+ax_pose 22, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose168:
+ax_pose 23, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose169:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose170:
+ax_pose 24, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose171:
+ax_pose 25, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose172:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose173:
+ax_pose 26, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose174:
+ax_pose 27, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose175:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose176:
+ax_pose 28, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose177:
+ax_pose 29, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose178:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose179:
+ax_pose 26, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose180:
+ax_pose 27, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose181:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose182:
+ax_pose 24, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose183:
+ax_pose 25, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose184:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose185:
+ax_pose 22, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose186:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose187:
+ax_pose 21, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose188:
+ax_pose 23, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose189:
+ax_pose 25, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose190:
+ax_pose 27, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose191:
+ax_pose 29, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose192:
+ax_pose 27, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose193:
+ax_pose 25, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose194:
+ax_pose 23, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose195:
+ax_pose 0, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose196:
+ax_pose 3, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose197:
+ax_pose 6, 0x01f0, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose198:
+ax_pose 9, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sSpinarakPose199:
+ax_pose 12, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sSpinarakPose200:
+ax_pose 9, 0x01f0, 0x90ec, 0x3c00
+ax_pose_terminator
+sSpinarakPose201:
+ax_pose 6, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+sSpinarakPose202:
+ax_pose 3, 0x01f0, 0x90ed, 0x3c00
+ax_pose_terminator
+.align 2
+sSpinarakAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -4, 0, -3,
+ax_anim 2, 0, 26, 0, -8, 0, -6,
+ax_anim 6, 0, 24, 0, -8, 0, -8,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 1, 27, 1, 15, 1, 15,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 0, 27, 1, 15, 1, 15,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSpinarakAnims_2_2:
+ax_anim 4, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -6, -3, -3,
+ax_anim 2, 0, 30, -6, -9, -6, -6,
+ax_anim 6, 0, 28, -8, -8, -8, -8,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 15, 15, 15, 15,
+ax_anim 2, 1, 31, 16, 14, 16, 14,
+ax_anim 2, 0, 31, 15, 15, 15, 15,
+ax_anim 2, 0, 31, 16, 14, 16, 14,
+ax_anim 4, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sSpinarakAnims_2_3:
+ax_anim 4, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, -4, -1, 0,
+ax_anim 2, 0, 34, -7, -4, -7, 0,
+ax_anim 6, 0, 32, -8, 0, -8, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 1, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 0, 35, 15, 1, 15, 1,
+ax_anim 4, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSpinarakAnims_2_4:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 2, 0, 38, -5, 2, -5, 5,
+ax_anim 6, 0, 36, -8, 8, -8, 8,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 4, -8, 4, -8,
+ax_anim 1, 0, 39, 10, -17, 10, -17,
+ax_anim 2, 0, 39, 14, -24, 14, -24,
+ax_anim 2, 1, 39, 15, -23, 15, -23,
+ax_anim 2, 0, 39, 14, -24, 14, -24,
+ax_anim 2, 0, 39, 15, -23, 15, -23,
+ax_anim 4, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sSpinarakAnims_2_5:
+ax_anim 4, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, -2, 0, 1,
+ax_anim 2, 0, 42, 0, 6, 0, 4,
+ax_anim 6, 0, 40, 0, 8, 0, 8,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -8, 0, -8,
+ax_anim 1, 0, 43, 0, -17, 0, -17,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 1, 43, -1, -24, -1, -24,
+ax_anim 2, 0, 43, 0, -24, 0, -24,
+ax_anim 2, 0, 43, -1, -24, -1, -24,
+ax_anim 4, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sSpinarakAnims_2_6:
+ax_anim 4, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 46, 5, 2, 5, 5,
+ax_anim 6, 0, 44, 8, 8, 8, 8,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, -8, -4, -8,
+ax_anim 1, 0, 47, -10, -17, -10, -17,
+ax_anim 2, 0, 47, -15, -25, -15, -25,
+ax_anim 2, 1, 47, -16, -24, -16, -24,
+ax_anim 2, 0, 47, -15, -25, -15, -25,
+ax_anim 2, 0, 47, -16, -24, -16, -24,
+ax_anim 4, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sSpinarakAnims_2_7:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, -4, 1, 0,
+ax_anim 2, 0, 50, 7, -4, 7, 0,
+ax_anim 6, 0, 48, 8, 0, 8, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 1, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -15, 1, -15, 1,
+ax_anim 4, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sSpinarakAnims_2_8:
+ax_anim 4, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -6, 3, -3,
+ax_anim 2, 0, 54, 6, -9, 6, -6,
+ax_anim 6, 0, 52, 8, -8, 8, -8,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -15, 15, -15, 15,
+ax_anim 2, 1, 55, -16, 14, -16, 14,
+ax_anim 2, 0, 55, -15, 15, -15, 15,
+ax_anim 2, 0, 55, -16, 14, -16, 14,
+ax_anim 4, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_3_1:
+ax_anim 4, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, -4, 0, -3,
+ax_anim 2, 0, 58, 0, -8, 0, -6,
+ax_anim 6, 0, 56, 0, -8, 0, -8,
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 1, 59, 1, 15, 1, 15,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 0, 59, 1, 15, 1, 15,
+ax_anim 4, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sSpinarakAnims_3_2:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 61, -1, -6, -3, -3,
+ax_anim 2, 0, 62, -6, -9, -6, -6,
+ax_anim 6, 0, 60, -8, -8, -8, -8,
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 15, 15, 15, 15,
+ax_anim 2, 1, 63, 16, 14, 16, 14,
+ax_anim 2, 0, 63, 15, 15, 15, 15,
+ax_anim 2, 0, 63, 16, 14, 16, 14,
+ax_anim 4, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sSpinarakAnims_3_3:
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -1, -4, -1, 0,
+ax_anim 2, 0, 66, -7, -4, -7, 0,
+ax_anim 6, 0, 64, -8, 0, -8, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 1, 67, 15, 1, 15, 1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 67, 15, 1, 15, 1,
+ax_anim 4, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sSpinarakAnims_3_4:
+ax_anim 4, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 0, 70, -5, 2, -5, 5,
+ax_anim 6, 0, 68, -8, 8, -8, 8,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 71, 4, -8, 4, -8,
+ax_anim 1, 0, 71, 10, -17, 10, -17,
+ax_anim 2, 0, 71, 14, -24, 14, -24,
+ax_anim 2, 1, 71, 15, -23, 15, -23,
+ax_anim 2, 0, 71, 14, -24, 14, -24,
+ax_anim 2, 0, 71, 15, -23, 15, -23,
+ax_anim 4, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sSpinarakAnims_3_5:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 1,
+ax_anim 2, 0, 74, 0, 6, 0, 4,
+ax_anim 6, 0, 72, 0, 8, 0, 8,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -8, 0, -8,
+ax_anim 1, 0, 75, 0, -17, 0, -17,
+ax_anim 2, 0, 75, 0, -24, 0, -24,
+ax_anim 2, 1, 75, -1, -24, -1, -24,
+ax_anim 2, 0, 75, 0, -24, 0, -24,
+ax_anim 2, 0, 75, -1, -24, -1, -24,
+ax_anim 4, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sSpinarakAnims_3_6:
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim 2, 0, 78, 5, 2, 5, 5,
+ax_anim 6, 0, 76, 8, 8, 8, 8,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 2, 79, -4, -8, -4, -8,
+ax_anim 1, 0, 79, -10, -17, -10, -17,
+ax_anim 2, 0, 79, -15, -25, -15, -25,
+ax_anim 2, 1, 79, -16, -24, -16, -24,
+ax_anim 2, 0, 79, -15, -25, -15, -25,
+ax_anim 2, 0, 79, -16, -24, -16, -24,
+ax_anim 4, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sSpinarakAnims_3_7:
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, -4, 1, 0,
+ax_anim 2, 0, 82, 7, -4, 7, 0,
+ax_anim 6, 0, 80, 8, 0, 8, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 1, 83, -15, 1, -15, 1,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 83, -15, 1, -15, 1,
+ax_anim 4, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sSpinarakAnims_3_8:
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, -6, 3, -3,
+ax_anim 2, 0, 86, 6, -9, 6, -6,
+ax_anim 6, 0, 84, 8, -8, 8, -8,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -15, 15, -15, 15,
+ax_anim 2, 1, 87, -16, 14, -16, 14,
+ax_anim 2, 0, 87, -15, 15, -15, 15,
+ax_anim 2, 0, 87, -16, 14, -16, 14,
+ax_anim 4, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_4_1:
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim 6, 0, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 2, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 1, 90, -1, 3, -1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, -1, 3, -1, 3,
+ax_anim 4, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sSpinarakAnims_4_2:
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 6, 0, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -3, -3, -3, -3,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 2, 93, 4, 2, 4, 2,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 4, 2, 4, 2,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 1, 93, 4, 2, 4, 2,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 4, 2, 4, 2,
+ax_anim 4, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sSpinarakAnims_4_3:
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 6, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -3, 0, -3, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 2, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 1, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 4, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sSpinarakAnims_4_4:
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 6, 0, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -3, 3, -3, 3,
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 2, 99, 4, -2, 4, -2,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 4, -2, 4, -2,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 1, 99, 4, -2, 4, -2,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 4, -2, 4, -2,
+ax_anim 4, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sSpinarakAnims_4_5:
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 6, 0, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 3, 0, 3,
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 2, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 1, 102, -1, -3, -1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, -1, -3, -1, -3,
+ax_anim 4, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sSpinarakAnims_4_6:
+ax_anim 2, 0, 104, 1, 1, 1, 1,
+ax_anim 6, 0, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 3, 3, 3, 3,
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 2, 105, -4, -2, -4, -2,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -4, -2, -4, -2,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 1, 105, -4, -2, -4, -2,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -4, -2, -4, -2,
+ax_anim 4, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sSpinarakAnims_4_7:
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 6, 0, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 3, 0, 3, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 2, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 1, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 4, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sSpinarakAnims_4_8:
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 6, 0, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 3, -3, 3, -3,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 2, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 1, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 2, -4, 2,
+ax_anim 4, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sSpinarakAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sSpinarakAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sSpinarakAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sSpinarakAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sSpinarakAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sSpinarakAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sSpinarakAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_8_2:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_8_3:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_8_4:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_8_5:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_8_6:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_8_7:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_8_8:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 17, 7, 17,
+ax_anim 3, 0, 150, 0, 21, 0, 21,
+ax_anim 2, 3, 151, -7, 17, -7, 17,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 22, 9, 22, 9,
+ax_anim 3, 0, 149, 21, 17, 21, 17,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 0, 12, 0, 12,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 17, -4, 17, -4,
+ax_anim 3, 0, 148, 20, 0, 20, 0,
+ax_anim 2, 3, 149, 17, 5, 17, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -18, 4, -18,
+ax_anim 2, 0, 146, 8, -26, 8, -26,
+ax_anim 3, 0, 147, 19, -26, 19, -26,
+ax_anim 2, 3, 148, 21, -12, 21, -12,
+ax_anim 2, 0, 149, 18, -5, 18, -5,
+ax_anim 1, 0, 150, 8, 1, 8, 1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -10, -10, -10, -10,
+ax_anim 2, 0, 153, -9, -18, -9, -18,
+ax_anim 3, 0, 146, -1, -25, -1, -25,
+ax_anim 2, 3, 147, 8, -18, 8, -18,
+ax_anim 2, 0, 148, 10, -10, 10, -10,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -18, -4, -18,
+ax_anim 2, 0, 146, -9, -26, -9, -26,
+ax_anim 3, 0, 153, -19, -26, -19, -26,
+ax_anim 2, 3, 152, -21, -12, -21, -12,
+ax_anim 2, 0, 151, -18, -5, -18, -5,
+ax_anim 1, 0, 150, -8, 1, -8, 1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -17, -4, -17, -4,
+ax_anim 3, 0, 152, -20, 0, -20, 0,
+ax_anim 2, 3, 151, -17, 5, -17, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -22, 9, -22, 9,
+ax_anim 3, 0, 151, -21, 17, -21, 17,
+ax_anim 2, 3, 150, -11, 21, -11, 21,
+ax_anim 2, 0, 149, 0, 12, 0, 12,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpinarakAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sSpinarakGfx1:
+.incbin "baserom.gba", 0xC53CAC, 0x200
+sSpinarakSprites1:
+ax_sprite sSpinarakGfx1, 0x200
+ax_sprite_terminator
+sSpinarakGfx2:
+.incbin "baserom.gba", 0xC53EBC, 0x200
+sSpinarakSprites2:
+ax_sprite sSpinarakGfx2, 0x200
+ax_sprite_terminator
+sSpinarakGfx3:
+.incbin "baserom.gba", 0xC540CC, 0x200
+sSpinarakSprites3:
+ax_sprite sSpinarakGfx3, 0x200
+ax_sprite_terminator
+sSpinarakGfx4:
+.incbin "baserom.gba", 0xC542DC, 0x200
+sSpinarakSprites4:
+ax_sprite sSpinarakGfx4, 0x200
+ax_sprite_terminator
+sSpinarakGfx5:
+.incbin "baserom.gba", 0xC544EC, 0x200
+sSpinarakSprites5:
+ax_sprite sSpinarakGfx5, 0x200
+ax_sprite_terminator
+sSpinarakGfx6:
+.incbin "baserom.gba", 0xC546FC, 0x200
+sSpinarakSprites6:
+ax_sprite sSpinarakGfx6, 0x200
+ax_sprite_terminator
+sSpinarakGfx7:
+.incbin "baserom.gba", 0xC5490C, 0x200
+sSpinarakSprites7:
+ax_sprite sSpinarakGfx7, 0x200
+ax_sprite_terminator
+sSpinarakGfx8:
+.incbin "baserom.gba", 0xC54B1C, 0x200
+sSpinarakSprites8:
+ax_sprite sSpinarakGfx8, 0x200
+ax_sprite_terminator
+sSpinarakGfx9:
+.incbin "baserom.gba", 0xC54D2C, 0x200
+sSpinarakSprites9:
+ax_sprite sSpinarakGfx9, 0x200
+ax_sprite_terminator
+sSpinarakGfx10:
+.incbin "baserom.gba", 0xC54F3C, 0x200
+sSpinarakSprites10:
+ax_sprite sSpinarakGfx10, 0x200
+ax_sprite_terminator
+sSpinarakGfx11:
+.incbin "baserom.gba", 0xC5514C, 0x200
+sSpinarakSprites11:
+ax_sprite sSpinarakGfx11, 0x200
+ax_sprite_terminator
+sSpinarakGfx12:
+.incbin "baserom.gba", 0xC5535C, 0x200
+sSpinarakSprites12:
+ax_sprite sSpinarakGfx12, 0x200
+ax_sprite_terminator
+sSpinarakGfx13:
+.incbin "baserom.gba", 0xC5556C, 0x200
+sSpinarakSprites13:
+ax_sprite sSpinarakGfx13, 0x200
+ax_sprite_terminator
+sSpinarakGfx14:
+.incbin "baserom.gba", 0xC5577C, 0x200
+sSpinarakSprites14:
+ax_sprite sSpinarakGfx14, 0x200
+ax_sprite_terminator
+sSpinarakGfx15:
+.incbin "baserom.gba", 0xC5598C, 0x200
+sSpinarakSprites15:
+ax_sprite sSpinarakGfx15, 0x200
+ax_sprite_terminator
+sSpinarakGfx16:
+.incbin "baserom.gba", 0xC55B9C, 0x60
+sSpinarakGfx16_1:
+.incbin "baserom.gba", 0xC55BFC, 0x60
+sSpinarakGfx16_2:
+.incbin "baserom.gba", 0xC55C5C, 0x60
+sSpinarakSprites16:
+ax_sprite sSpinarakGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx17:
+.incbin "baserom.gba", 0xC55CF4, 0x60
+sSpinarakGfx17_1:
+.incbin "baserom.gba", 0xC55D54, 0x60
+sSpinarakGfx17_2:
+.incbin "baserom.gba", 0xC55DB4, 0x60
+sSpinarakSprites17:
+ax_sprite sSpinarakGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx18:
+.incbin "baserom.gba", 0xC55E4C, 0x60
+sSpinarakGfx18_1:
+.incbin "baserom.gba", 0xC55EAC, 0x60
+sSpinarakGfx18_2:
+.incbin "baserom.gba", 0xC55F0C, 0x60
+sSpinarakSprites18:
+ax_sprite sSpinarakGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx19:
+.incbin "baserom.gba", 0xC55FA4, 0x60
+sSpinarakGfx19_1:
+.incbin "baserom.gba", 0xC56004, 0x60
+sSpinarakGfx19_2:
+.incbin "baserom.gba", 0xC56064, 0x60
+sSpinarakSprites19:
+ax_sprite sSpinarakGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx20:
+.incbin "baserom.gba", 0xC560FC, 0x20
+sSpinarakGfx20_1:
+.incbin "baserom.gba", 0xC5611C, 0x60
+sSpinarakGfx20_2:
+.incbin "baserom.gba", 0xC5617C, 0x60
+sSpinarakSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpinarakGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx21:
+.incbin "baserom.gba", 0xC5621C, 0x60
+sSpinarakGfx21_1:
+.incbin "baserom.gba", 0xC5627C, 0x60
+sSpinarakSprites21:
+ax_sprite sSpinarakGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpinarakGfx22:
+.incbin "baserom.gba", 0xC56304, 0x60
+sSpinarakGfx22_1:
+.incbin "baserom.gba", 0xC56364, 0x60
+sSpinarakGfx22_2:
+.incbin "baserom.gba", 0xC563C4, 0x60
+sSpinarakSprites22:
+ax_sprite sSpinarakGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx23:
+.incbin "baserom.gba", 0xC5645C, 0x60
+sSpinarakGfx23_1:
+.incbin "baserom.gba", 0xC564BC, 0x60
+sSpinarakGfx23_2:
+.incbin "baserom.gba", 0xC5651C, 0x20
+sSpinarakSprites23:
+ax_sprite sSpinarakGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx23_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSpinarakGfx23_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx24:
+.incbin "baserom.gba", 0xC56574, 0x60
+sSpinarakGfx24_1:
+.incbin "baserom.gba", 0xC565D4, 0x60
+sSpinarakGfx24_2:
+.incbin "baserom.gba", 0xC56634, 0x60
+sSpinarakSprites24:
+ax_sprite sSpinarakGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx25:
+.incbin "baserom.gba", 0xC566CC, 0x60
+sSpinarakGfx25_1:
+.incbin "baserom.gba", 0xC5672C, 0x60
+sSpinarakGfx25_2:
+.incbin "baserom.gba", 0xC5678C, 0x40
+sSpinarakSprites25:
+ax_sprite sSpinarakGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpinarakGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx26:
+.incbin "baserom.gba", 0xC56804, 0x60
+sSpinarakGfx26_1:
+.incbin "baserom.gba", 0xC56864, 0x60
+sSpinarakGfx26_2:
+.incbin "baserom.gba", 0xC568C4, 0x60
+sSpinarakSprites26:
+ax_sprite sSpinarakGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx27:
+.incbin "baserom.gba", 0xC5695C, 0x60
+sSpinarakGfx27_1:
+.incbin "baserom.gba", 0xC569BC, 0x60
+sSpinarakGfx27_2:
+.incbin "baserom.gba", 0xC56A1C, 0x60
+sSpinarakSprites27:
+ax_sprite sSpinarakGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx28:
+.incbin "baserom.gba", 0xC56AB4, 0x60
+sSpinarakGfx28_1:
+.incbin "baserom.gba", 0xC56B14, 0x60
+sSpinarakGfx28_2:
+.incbin "baserom.gba", 0xC56B74, 0x40
+sSpinarakSprites28:
+ax_sprite sSpinarakGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx28_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSpinarakGfx29:
+.incbin "baserom.gba", 0xC56BEC, 0x60
+sSpinarakGfx29_1:
+.incbin "baserom.gba", 0xC56C4C, 0x60
+sSpinarakGfx29_2:
+.incbin "baserom.gba", 0xC56CAC, 0x60
+sSpinarakSprites29:
+ax_sprite sSpinarakGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx30:
+.incbin "baserom.gba", 0xC56D44, 0x20
+sSpinarakGfx30_1:
+.incbin "baserom.gba", 0xC56D64, 0x60
+sSpinarakGfx30_2:
+.incbin "baserom.gba", 0xC56DC4, 0x60
+sSpinarakSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpinarakGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpinarakGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSpinarakGfx31:
+.incbin "baserom.gba", 0xC56E64, 0x200
+sSpinarakSprites31:
+ax_sprite sSpinarakGfx31, 0x200
+ax_sprite_terminator
+sSpinarakGfx32:
+.incbin "baserom.gba", 0xC57074, 0x200
+sSpinarakSprites32:
+ax_sprite sSpinarakGfx32, 0x200
+ax_sprite_terminator
+sSpinarakGfx33:
+.incbin "baserom.gba", 0xC57284, 0x200
+sSpinarakSprites33:
+ax_sprite sSpinarakGfx33, 0x200
+ax_sprite_terminator
+sSpinarakGfx34:
+.incbin "baserom.gba", 0xC57494, 0x200
+sSpinarakSprites34:
+ax_sprite sSpinarakGfx34, 0x200
+ax_sprite_terminator
+sSpinarakGfx35:
+.incbin "baserom.gba", 0xC576A4, 0x200
+sSpinarakSprites35:
+ax_sprite sSpinarakGfx35, 0x200
+ax_sprite_terminator
+sSpinarakGfx36:
+.incbin "baserom.gba", 0xC578B4, 0x200
+sSpinarakSprites36:
+ax_sprite sSpinarakGfx36, 0x200
+ax_sprite_terminator
+sSpinarakGfx37:
+.incbin "baserom.gba", 0xC57AC4, 0x200
+sSpinarakSprites37:
+ax_sprite sSpinarakGfx37, 0x200
+ax_sprite_terminator
+sSpinarakGfx38:
+.incbin "baserom.gba", 0xC57CD4, 0x200
+sSpinarakSprites38:
+ax_sprite sSpinarakGfx38, 0x200
+ax_sprite_terminator
+sSpinarakGfx39:
+.incbin "baserom.gba", 0xC57EE4, 0x200
+sSpinarakSprites39:
+ax_sprite sSpinarakGfx39, 0x200
+ax_sprite_terminator
+sSpinarakGfx40:
+.incbin "baserom.gba", 0xC580F4, 0x200
+sSpinarakSprites40:
+ax_sprite sSpinarakGfx40, 0x200
+ax_sprite_terminator
+sSpinarakGfx41:
+.incbin "baserom.gba", 0xC58304, 0x200
+sSpinarakSprites41:
+ax_sprite sSpinarakGfx41, 0x200
+ax_sprite_terminator
+sSpinarakGfx42:
+.incbin "baserom.gba", 0xC58514, 0x200
+sSpinarakSprites42:
+ax_sprite sSpinarakGfx42, 0x200
+ax_sprite_terminator
+sAxPosesSpinarak:
+.4byte sSpinarakPose1
+.4byte sSpinarakPose2
+.4byte sSpinarakPose3
+.4byte sSpinarakPose4
+.4byte sSpinarakPose5
+.4byte sSpinarakPose6
+.4byte sSpinarakPose7
+.4byte sSpinarakPose8
+.4byte sSpinarakPose9
+.4byte sSpinarakPose10
+.4byte sSpinarakPose11
+.4byte sSpinarakPose12
+.4byte sSpinarakPose13
+.4byte sSpinarakPose14
+.4byte sSpinarakPose15
+.4byte sSpinarakPose16
+.4byte sSpinarakPose17
+.4byte sSpinarakPose18
+.4byte sSpinarakPose19
+.4byte sSpinarakPose20
+.4byte sSpinarakPose21
+.4byte sSpinarakPose22
+.4byte sSpinarakPose23
+.4byte sSpinarakPose24
+.4byte sSpinarakPose25
+.4byte sSpinarakPose26
+.4byte sSpinarakPose27
+.4byte sSpinarakPose28
+.4byte sSpinarakPose29
+.4byte sSpinarakPose30
+.4byte sSpinarakPose31
+.4byte sSpinarakPose32
+.4byte sSpinarakPose33
+.4byte sSpinarakPose34
+.4byte sSpinarakPose35
+.4byte sSpinarakPose36
+.4byte sSpinarakPose37
+.4byte sSpinarakPose38
+.4byte sSpinarakPose39
+.4byte sSpinarakPose40
+.4byte sSpinarakPose41
+.4byte sSpinarakPose42
+.4byte sSpinarakPose43
+.4byte sSpinarakPose44
+.4byte sSpinarakPose45
+.4byte sSpinarakPose46
+.4byte sSpinarakPose47
+.4byte sSpinarakPose48
+.4byte sSpinarakPose49
+.4byte sSpinarakPose50
+.4byte sSpinarakPose51
+.4byte sSpinarakPose52
+.4byte sSpinarakPose53
+.4byte sSpinarakPose54
+.4byte sSpinarakPose55
+.4byte sSpinarakPose56
+.4byte sSpinarakPose57
+.4byte sSpinarakPose58
+.4byte sSpinarakPose59
+.4byte sSpinarakPose60
+.4byte sSpinarakPose61
+.4byte sSpinarakPose62
+.4byte sSpinarakPose63
+.4byte sSpinarakPose64
+.4byte sSpinarakPose65
+.4byte sSpinarakPose66
+.4byte sSpinarakPose67
+.4byte sSpinarakPose68
+.4byte sSpinarakPose69
+.4byte sSpinarakPose70
+.4byte sSpinarakPose71
+.4byte sSpinarakPose72
+.4byte sSpinarakPose73
+.4byte sSpinarakPose74
+.4byte sSpinarakPose75
+.4byte sSpinarakPose76
+.4byte sSpinarakPose77
+.4byte sSpinarakPose78
+.4byte sSpinarakPose79
+.4byte sSpinarakPose80
+.4byte sSpinarakPose81
+.4byte sSpinarakPose82
+.4byte sSpinarakPose83
+.4byte sSpinarakPose84
+.4byte sSpinarakPose85
+.4byte sSpinarakPose86
+.4byte sSpinarakPose87
+.4byte sSpinarakPose88
+.4byte sSpinarakPose89
+.4byte sSpinarakPose90
+.4byte sSpinarakPose91
+.4byte sSpinarakPose92
+.4byte sSpinarakPose93
+.4byte sSpinarakPose94
+.4byte sSpinarakPose95
+.4byte sSpinarakPose96
+.4byte sSpinarakPose97
+.4byte sSpinarakPose98
+.4byte sSpinarakPose99
+.4byte sSpinarakPose100
+.4byte sSpinarakPose101
+.4byte sSpinarakPose102
+.4byte sSpinarakPose103
+.4byte sSpinarakPose104
+.4byte sSpinarakPose105
+.4byte sSpinarakPose106
+.4byte sSpinarakPose107
+.4byte sSpinarakPose108
+.4byte sSpinarakPose109
+.4byte sSpinarakPose110
+.4byte sSpinarakPose111
+.4byte sSpinarakPose112
+.4byte sSpinarakPose113
+.4byte sSpinarakPose114
+.4byte sSpinarakPose115
+.4byte sSpinarakPose116
+.4byte sSpinarakPose117
+.4byte sSpinarakPose118
+.4byte sSpinarakPose119
+.4byte sSpinarakPose120
+.4byte sSpinarakPose121
+.4byte sSpinarakPose122
+.4byte sSpinarakPose123
+.4byte sSpinarakPose124
+.4byte sSpinarakPose125
+.4byte sSpinarakPose126
+.4byte sSpinarakPose127
+.4byte sSpinarakPose128
+.4byte sSpinarakPose129
+.4byte sSpinarakPose130
+.4byte sSpinarakPose131
+.4byte sSpinarakPose132
+.4byte sSpinarakPose133
+.4byte sSpinarakPose134
+.4byte sSpinarakPose135
+.4byte sSpinarakPose136
+.4byte sSpinarakPose137
+.4byte sSpinarakPose138
+.4byte sSpinarakPose139
+.4byte sSpinarakPose140
+.4byte sSpinarakPose141
+.4byte sSpinarakPose142
+.4byte sSpinarakPose143
+.4byte sSpinarakPose144
+.4byte sSpinarakPose145
+.4byte sSpinarakPose146
+.4byte sSpinarakPose147
+.4byte sSpinarakPose148
+.4byte sSpinarakPose149
+.4byte sSpinarakPose150
+.4byte sSpinarakPose151
+.4byte sSpinarakPose152
+.4byte sSpinarakPose153
+.4byte sSpinarakPose154
+.4byte sSpinarakPose155
+.4byte sSpinarakPose156
+.4byte sSpinarakPose157
+.4byte sSpinarakPose158
+.4byte sSpinarakPose159
+.4byte sSpinarakPose160
+.4byte sSpinarakPose161
+.4byte sSpinarakPose162
+.4byte sSpinarakPose163
+.4byte sSpinarakPose164
+.4byte sSpinarakPose165
+.4byte sSpinarakPose166
+.4byte sSpinarakPose167
+.4byte sSpinarakPose168
+.4byte sSpinarakPose169
+.4byte sSpinarakPose170
+.4byte sSpinarakPose171
+.4byte sSpinarakPose172
+.4byte sSpinarakPose173
+.4byte sSpinarakPose174
+.4byte sSpinarakPose175
+.4byte sSpinarakPose176
+.4byte sSpinarakPose177
+.4byte sSpinarakPose178
+.4byte sSpinarakPose179
+.4byte sSpinarakPose180
+.4byte sSpinarakPose181
+.4byte sSpinarakPose182
+.4byte sSpinarakPose183
+.4byte sSpinarakPose184
+.4byte sSpinarakPose185
+.4byte sSpinarakPose186
+.4byte sSpinarakPose187
+.4byte sSpinarakPose188
+.4byte sSpinarakPose189
+.4byte sSpinarakPose190
+.4byte sSpinarakPose191
+.4byte sSpinarakPose192
+.4byte sSpinarakPose193
+.4byte sSpinarakPose194
+.4byte sSpinarakPose195
+.4byte sSpinarakPose196
+.4byte sSpinarakPose197
+.4byte sSpinarakPose198
+.4byte sSpinarakPose199
+.4byte sSpinarakPose200
+.4byte sSpinarakPose201
+.4byte sSpinarakPose202
+sAxPositionsSpinarak:
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte    0,    3, 	  -7,    1, 	   8,    4, 	   0,   -6
+.2byte    0,    1, 	  -8,    3, 	   7,    1, 	   0,   -5
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte    6,    1, 	   8,   -7, 	  -2,    2, 	   0,   -6
+.2byte    7,    0, 	  11,   -1, 	  -1,    0, 	   0,   -6
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    8,   -3, 	   7,   -9, 	   5,    1, 	  -1,   -7
+.2byte    9,   -6, 	   4,   -7, 	   5,   -1, 	   0,   -7
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   9,   -1, 	  -1,   -6
+.2byte    5,  -10, 	  -3,   -7, 	   7,   -2, 	  -1,   -6
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    0,   -7, 	   6,   -9, 	  -6,  -12, 	   0,   -6
+.2byte    0,   -9, 	   6,  -10, 	  -6,   -7, 	   0,   -6
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte   -4,   -8, 	   2,   -9, 	  -9,   -1, 	   1,   -6
+.2byte   -5,  -10, 	   3,   -7, 	  -7,   -2, 	   1,   -6
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -8,   -3, 	  -7,   -9, 	  -5,    1, 	   1,   -7
+.2byte   -9,   -6, 	  -4,   -7, 	  -5,   -1, 	   0,   -7
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -6,    1, 	  -8,   -7, 	   2,    2, 	   0,   -6
+.2byte   -7,    0, 	 -11,   -1, 	   1,    0, 	   0,   -6
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte    0,    3, 	  -7,    1, 	   8,    4, 	   0,   -6
+.2byte    0,    1, 	  -8,    3, 	   7,    1, 	   0,   -5
+.2byte    0,    3, 	  -8,    2, 	   8,    2, 	   0,   -4
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte    6,    1, 	   8,   -7, 	  -2,    2, 	   0,   -6
+.2byte    7,    0, 	  11,   -1, 	  -1,    0, 	   0,   -6
+.2byte    7,    1, 	   8,   -4, 	  -1,    2, 	   1,   -6
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    8,   -3, 	   7,   -9, 	   5,    1, 	  -1,   -7
+.2byte    9,   -6, 	   4,   -7, 	   5,   -1, 	   0,   -7
+.2byte   10,   -4, 	   5,   -8, 	   6,    1, 	   2,   -6
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   9,   -1, 	  -1,   -6
+.2byte    5,  -10, 	  -3,   -7, 	   7,   -2, 	  -1,   -6
+.2byte    6,   -8, 	  -1,   -7, 	   9,   -1, 	   0,   -6
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    0,   -7, 	   6,   -9, 	  -6,  -12, 	   0,   -6
+.2byte    0,   -9, 	   6,  -10, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte   -4,   -8, 	   2,   -9, 	  -9,   -1, 	   1,   -6
+.2byte   -5,  -10, 	   3,   -7, 	  -7,   -2, 	   1,   -6
+.2byte   -6,   -8, 	   1,   -7, 	  -9,   -1, 	   0,   -6
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -8,   -3, 	  -7,   -9, 	  -5,    1, 	   1,   -7
+.2byte   -9,   -6, 	  -4,   -7, 	  -5,   -1, 	   0,   -7
+.2byte  -10,   -4, 	  -5,   -8, 	  -6,    1, 	  -2,   -6
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -6,    1, 	  -8,   -7, 	   2,    2, 	   0,   -6
+.2byte   -7,    0, 	 -11,   -1, 	   1,    0, 	   0,   -6
+.2byte   -8,    1, 	  -9,   -4, 	   0,    2, 	  -2,   -6
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte    0,    3, 	  -7,    1, 	   8,    4, 	   0,   -6
+.2byte    0,    1, 	  -8,    3, 	   7,    1, 	   0,   -5
+.2byte    0,    3, 	  -8,    2, 	   8,    2, 	   0,   -4
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte    6,    1, 	   8,   -7, 	  -2,    2, 	   0,   -6
+.2byte    7,    0, 	  11,   -1, 	  -1,    0, 	   0,   -6
+.2byte    7,    1, 	   8,   -4, 	  -1,    2, 	   1,   -6
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    8,   -3, 	   7,   -9, 	   5,    1, 	  -1,   -7
+.2byte    9,   -6, 	   4,   -7, 	   5,   -1, 	   0,   -7
+.2byte   10,   -4, 	   5,   -8, 	   6,    1, 	   2,   -6
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   9,   -1, 	  -1,   -6
+.2byte    5,  -10, 	  -3,   -7, 	   7,   -2, 	  -1,   -6
+.2byte    6,   -8, 	  -1,   -7, 	   9,   -1, 	   0,   -6
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    0,   -7, 	   6,   -9, 	  -6,  -12, 	   0,   -6
+.2byte    0,   -9, 	   6,  -10, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte   -4,   -8, 	   2,   -9, 	  -9,   -1, 	   1,   -6
+.2byte   -5,  -10, 	   3,   -7, 	  -7,   -2, 	   1,   -6
+.2byte   -6,   -8, 	   1,   -7, 	  -9,   -1, 	   0,   -6
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -8,   -3, 	  -7,   -9, 	  -5,    1, 	   1,   -7
+.2byte   -9,   -6, 	  -4,   -7, 	  -5,   -1, 	   0,   -7
+.2byte  -10,   -4, 	  -5,   -8, 	  -6,    1, 	  -2,   -6
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -6,    1, 	  -8,   -7, 	   2,    2, 	   0,   -6
+.2byte   -7,    0, 	 -11,   -1, 	   1,    0, 	   0,   -6
+.2byte   -8,    1, 	  -9,   -4, 	   0,    2, 	  -2,   -6
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -2, 	   7,   -2, 	   0,   -6
+.2byte    0,  -14, 	  -8,    2, 	   8,    2, 	   0,   -5
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte    5,   -5, 	   5,   -6, 	  -1,   -2, 	  -1,   -7
+.2byte    0,  -13, 	   9,   -5, 	   0,    3, 	   1,   -6
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    6,  -11, 	   4,   -8, 	   5,   -4, 	  -2,   -8
+.2byte   -2,  -14, 	   7,   -7, 	   7,    1, 	   0,   -6
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    3,  -12, 	  -4,   -9, 	   6,   -5, 	  -2,   -6
+.2byte   -4,  -11, 	  -2,   -6, 	   9,   -2, 	  -1,   -5
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -12, 	   7,  -11, 	  -7,  -11, 	   0,   -5
+.2byte    0,  -11, 	   8,   -8, 	  -7,   -9, 	   0,   -9
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte   -3,  -12, 	   4,   -9, 	  -6,   -5, 	   2,   -6
+.2byte    4,  -11, 	   2,   -6, 	  -9,   -2, 	   1,   -5
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -6,  -11, 	  -4,   -8, 	  -5,   -4, 	   2,   -8
+.2byte    2,  -14, 	  -7,   -7, 	  -7,    1, 	   0,   -6
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -5,   -5, 	  -5,   -6, 	   1,   -2, 	   1,   -7
+.2byte    0,  -13, 	  -9,   -5, 	   0,    3, 	  -1,   -6
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -6,    1, 	  -7,   -3, 	  -1,    3, 	   0,   -6
+.2byte   -6,    1, 	  -7,   -3, 	  -1,    3, 	   0,   -6
+.2byte    0,    1, 	 -12,   -2, 	   1,    0, 	  -1,   -8
+.2byte    5,    1, 	  11,  -10, 	   5,    0, 	  -2,   -7
+.2byte    6,    0, 	   9,  -12, 	   7,   -1, 	  -1,   -5
+.2byte    4,   -5, 	   4,  -14, 	   7,   -1, 	  -1,   -4
+.2byte    0,   -7, 	   8,   -9, 	  -7,   -3, 	   0,   -6
+.2byte   -5,   -5, 	  -5,  -14, 	  -8,   -1, 	   0,   -4
+.2byte   -5,    0, 	  -8,  -12, 	  -6,   -1, 	   2,   -5
+.2byte   -6,    3, 	 -12,   -8, 	  -6,    2, 	   1,   -5
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -5
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte    7,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    8,   -5, 	   5,   -9, 	   7,    1, 	   0,   -7
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    5,   -9, 	  -2,   -8, 	   9,   -2, 	   0,   -6
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte   -5,   -9, 	   2,   -8, 	  -9,   -2, 	   0,   -6
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -8,   -5, 	  -5,   -9, 	  -7,    1, 	   0,   -7
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -7,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte    0,  -14, 	  -8,    2, 	   8,    2, 	   0,   -5
+.2byte    0,  -13, 	  -9,   -5, 	   0,    3, 	  -1,   -6
+.2byte    2,  -14, 	  -7,   -7, 	  -7,    1, 	   0,   -6
+.2byte    3,  -11, 	   1,   -6, 	 -10,   -2, 	   0,   -5
+.2byte    0,  -11, 	   8,   -8, 	  -7,   -9, 	   0,   -9
+.2byte   -3,  -11, 	  -1,   -6, 	  10,   -2, 	   0,   -5
+.2byte   -2,  -14, 	   7,   -7, 	   7,    1, 	   0,   -6
+.2byte    0,  -13, 	   9,   -5, 	   0,    3, 	   1,   -6
+.2byte    0,  -14, 	  -8,    2, 	   8,    2, 	   0,   -5
+.2byte    0,  -13, 	   9,   -5, 	   0,    3, 	   1,   -6
+.2byte   -2,  -14, 	   7,   -7, 	   7,    1, 	   0,   -6
+.2byte   -3,  -11, 	  -1,   -6, 	  10,   -2, 	   0,   -5
+.2byte    0,  -10, 	   8,   -7, 	  -7,   -8, 	   0,   -8
+.2byte    3,  -11, 	   1,   -6, 	 -10,   -2, 	   0,   -5
+.2byte    2,  -14, 	  -7,   -7, 	  -7,    1, 	   0,   -6
+.2byte    0,  -13, 	  -9,   -5, 	   0,    3, 	  -1,   -6
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte    0,   -2, 	  -7,   -2, 	   7,   -2, 	   0,   -6
+.2byte    0,  -14, 	  -8,    2, 	   8,    2, 	   0,   -5
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+.2byte    5,   -5, 	   5,   -6, 	  -1,   -2, 	  -1,   -7
+.2byte    0,  -13, 	   9,   -5, 	   0,    3, 	   1,   -6
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    6,  -11, 	   4,   -8, 	   5,   -4, 	  -2,   -8
+.2byte   -2,  -14, 	   7,   -7, 	   7,    1, 	   0,   -6
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    3,  -12, 	  -4,   -9, 	   6,   -5, 	  -2,   -6
+.2byte   -4,  -11, 	  -2,   -6, 	   9,   -2, 	  -1,   -5
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    0,  -12, 	   7,  -11, 	  -7,  -11, 	   0,   -5
+.2byte    0,  -11, 	   8,   -8, 	  -7,   -9, 	   0,   -9
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte   -3,  -12, 	   4,   -9, 	  -6,   -5, 	   2,   -6
+.2byte    4,  -11, 	   2,   -6, 	  -9,   -2, 	   1,   -5
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -6,  -11, 	  -4,   -8, 	  -5,   -4, 	   2,   -8
+.2byte    2,  -14, 	  -7,   -7, 	  -7,    1, 	   0,   -6
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -5,   -5, 	  -5,   -6, 	   1,   -2, 	   1,   -7
+.2byte    0,  -13, 	  -9,   -5, 	   0,    3, 	  -1,   -6
+.2byte    0,  -14, 	  -8,    2, 	   8,    2, 	   0,   -5
+.2byte    0,  -13, 	  -9,   -5, 	   0,    3, 	  -1,   -6
+.2byte    2,  -14, 	  -7,   -7, 	  -7,    1, 	   0,   -6
+.2byte    3,  -11, 	   1,   -6, 	 -10,   -2, 	   0,   -5
+.2byte    0,  -10, 	   8,   -7, 	  -7,   -8, 	   0,   -8
+.2byte   -3,  -11, 	  -1,   -6, 	  10,   -2, 	   0,   -5
+.2byte   -2,  -14, 	   7,   -7, 	   7,    1, 	   0,   -6
+.2byte    0,  -13, 	   9,   -5, 	   0,    3, 	   1,   -6
+.2byte    0,    2, 	  -8,    2, 	   8,    2, 	   0,   -6
+.2byte   -6,    0, 	  -9,   -5, 	   0,    3, 	   0,   -6
+.2byte   -8,   -5, 	  -6,   -8, 	  -7,    1, 	   1,   -7
+.2byte   -5,   -9, 	   1,   -7, 	  -9,   -2, 	   2,   -5
+.2byte    0,   -9, 	   7,  -10, 	  -7,  -10, 	   0,   -6
+.2byte    5,   -9, 	  -1,   -7, 	   9,   -2, 	  -2,   -5
+.2byte    8,   -5, 	   6,   -8, 	   7,    1, 	  -1,   -7
+.2byte    6,    0, 	   9,   -5, 	   0,    3, 	   0,   -6
+sSpinarakAnimTable1:
+.4byte sSpinarakAnims_1_1
+.4byte sSpinarakAnims_1_2
+.4byte sSpinarakAnims_1_3
+.4byte sSpinarakAnims_1_4
+.4byte sSpinarakAnims_1_5
+.4byte sSpinarakAnims_1_6
+.4byte sSpinarakAnims_1_7
+.4byte sSpinarakAnims_1_8
+sSpinarakAnimTable2:
+.4byte sSpinarakAnims_2_1
+.4byte sSpinarakAnims_2_2
+.4byte sSpinarakAnims_2_3
+.4byte sSpinarakAnims_2_4
+.4byte sSpinarakAnims_2_5
+.4byte sSpinarakAnims_2_6
+.4byte sSpinarakAnims_2_7
+.4byte sSpinarakAnims_2_8
+sSpinarakAnimTable3:
+.4byte sSpinarakAnims_3_1
+.4byte sSpinarakAnims_3_2
+.4byte sSpinarakAnims_3_3
+.4byte sSpinarakAnims_3_4
+.4byte sSpinarakAnims_3_5
+.4byte sSpinarakAnims_3_6
+.4byte sSpinarakAnims_3_7
+.4byte sSpinarakAnims_3_8
+sSpinarakAnimTable4:
+.4byte sSpinarakAnims_4_1
+.4byte sSpinarakAnims_4_2
+.4byte sSpinarakAnims_4_3
+.4byte sSpinarakAnims_4_4
+.4byte sSpinarakAnims_4_5
+.4byte sSpinarakAnims_4_6
+.4byte sSpinarakAnims_4_7
+.4byte sSpinarakAnims_4_8
+sSpinarakAnimTable5:
+.4byte sSpinarakAnims_5_1
+.4byte sSpinarakAnims_5_2
+.4byte sSpinarakAnims_5_3
+.4byte sSpinarakAnims_5_4
+.4byte sSpinarakAnims_5_5
+.4byte sSpinarakAnims_5_6
+.4byte sSpinarakAnims_5_7
+.4byte sSpinarakAnims_5_8
+sSpinarakAnimTable6:
+.4byte sSpinarakAnims_6_1
+.4byte sSpinarakAnims_6_1
+.4byte sSpinarakAnims_6_1
+.4byte sSpinarakAnims_6_1
+.4byte sSpinarakAnims_6_1
+.4byte sSpinarakAnims_6_1
+.4byte sSpinarakAnims_6_1
+.4byte sSpinarakAnims_6_1
+sSpinarakAnimTable7:
+.4byte sSpinarakAnims_7_1
+.4byte sSpinarakAnims_7_2
+.4byte sSpinarakAnims_7_3
+.4byte sSpinarakAnims_7_4
+.4byte sSpinarakAnims_7_5
+.4byte sSpinarakAnims_7_6
+.4byte sSpinarakAnims_7_7
+.4byte sSpinarakAnims_7_8
+sSpinarakAnimTable8:
+.4byte sSpinarakAnims_8_1
+.4byte sSpinarakAnims_8_2
+.4byte sSpinarakAnims_8_3
+.4byte sSpinarakAnims_8_4
+.4byte sSpinarakAnims_8_5
+.4byte sSpinarakAnims_8_6
+.4byte sSpinarakAnims_8_7
+.4byte sSpinarakAnims_8_8
+sSpinarakAnimTable9:
+.4byte sSpinarakAnims_9_1
+.4byte sSpinarakAnims_9_2
+.4byte sSpinarakAnims_9_3
+.4byte sSpinarakAnims_9_4
+.4byte sSpinarakAnims_9_5
+.4byte sSpinarakAnims_9_6
+.4byte sSpinarakAnims_9_7
+.4byte sSpinarakAnims_9_8
+sSpinarakAnimTable10:
+.4byte sSpinarakAnims_10_1
+.4byte sSpinarakAnims_10_2
+.4byte sSpinarakAnims_10_3
+.4byte sSpinarakAnims_10_4
+.4byte sSpinarakAnims_10_5
+.4byte sSpinarakAnims_10_6
+.4byte sSpinarakAnims_10_7
+.4byte sSpinarakAnims_10_8
+sSpinarakAnimTable11:
+.4byte sSpinarakAnims_11_1
+.4byte sSpinarakAnims_11_2
+.4byte sSpinarakAnims_11_3
+.4byte sSpinarakAnims_11_4
+.4byte sSpinarakAnims_11_5
+.4byte sSpinarakAnims_11_6
+.4byte sSpinarakAnims_11_7
+.4byte sSpinarakAnims_11_8
+sSpinarakAnimTable12:
+.4byte sSpinarakAnims_12_1
+.4byte sSpinarakAnims_12_2
+.4byte sSpinarakAnims_12_3
+.4byte sSpinarakAnims_12_4
+.4byte sSpinarakAnims_12_5
+.4byte sSpinarakAnims_12_6
+.4byte sSpinarakAnims_12_7
+.4byte sSpinarakAnims_12_8
+sSpinarakAnimTable13:
+.4byte sSpinarakAnims_13_1
+.4byte sSpinarakAnims_13_2
+.4byte sSpinarakAnims_13_3
+.4byte sSpinarakAnims_13_4
+.4byte sSpinarakAnims_13_5
+.4byte sSpinarakAnims_13_6
+.4byte sSpinarakAnims_13_7
+.4byte sSpinarakAnims_13_8
+sAxAnimationsSpinarak:
+.4byte sSpinarakAnimTable1
+.4byte sSpinarakAnimTable2
+.4byte sSpinarakAnimTable3
+.4byte sSpinarakAnimTable4
+.4byte sSpinarakAnimTable5
+.4byte sSpinarakAnimTable6
+.4byte sSpinarakAnimTable7
+.4byte sSpinarakAnimTable8
+.4byte sSpinarakAnimTable9
+.4byte sSpinarakAnimTable10
+.4byte sSpinarakAnimTable11
+.4byte sSpinarakAnimTable12
+.4byte sSpinarakAnimTable13
+sAxSpritesSpinarak:
+.4byte sSpinarakSprites1
+.4byte sSpinarakSprites2
+.4byte sSpinarakSprites3
+.4byte sSpinarakSprites4
+.4byte sSpinarakSprites5
+.4byte sSpinarakSprites6
+.4byte sSpinarakSprites7
+.4byte sSpinarakSprites8
+.4byte sSpinarakSprites9
+.4byte sSpinarakSprites10
+.4byte sSpinarakSprites11
+.4byte sSpinarakSprites12
+.4byte sSpinarakSprites13
+.4byte sSpinarakSprites14
+.4byte sSpinarakSprites15
+.4byte sSpinarakSprites16
+.4byte sSpinarakSprites17
+.4byte sSpinarakSprites18
+.4byte sSpinarakSprites19
+.4byte sSpinarakSprites20
+.4byte sSpinarakSprites21
+.4byte sSpinarakSprites22
+.4byte sSpinarakSprites23
+.4byte sSpinarakSprites24
+.4byte sSpinarakSprites25
+.4byte sSpinarakSprites26
+.4byte sSpinarakSprites27
+.4byte sSpinarakSprites28
+.4byte sSpinarakSprites29
+.4byte sSpinarakSprites30
+.4byte sSpinarakSprites31
+.4byte sSpinarakSprites32
+.4byte sSpinarakSprites33
+.4byte sSpinarakSprites34
+.4byte sSpinarakSprites35
+.4byte sSpinarakSprites36
+.4byte sSpinarakSprites37
+.4byte sSpinarakSprites38
+.4byte sSpinarakSprites39
+.4byte sSpinarakSprites40
+.4byte sSpinarakSprites41
+.4byte sSpinarakSprites42
+sAxMainSpinarak:
+ax_main sAxPosesSpinarak, sAxAnimationsSpinarak, 13, sAxSpritesSpinarak, sAxPositionsSpinarak

--- a/data/ax/spinda.inc
+++ b/data/ax/spinda.inc
@@ -1,0 +1,3447 @@
+.global gAxSpinda
+gAxSpinda:
+ax_siro sAxMainSpinda
+sSpindaPose1:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose2:
+ax_pose 1, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose3:
+ax_pose 2, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose4:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose5:
+ax_pose 4, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose6:
+ax_pose 5, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose7:
+ax_pose 6, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose8:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose9:
+ax_pose 6, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose10:
+ax_pose 8, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose11:
+ax_pose 5, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose12:
+ax_pose 9, 0x01e1, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose13:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose14:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose15:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose16:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose17:
+ax_pose 13, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose18:
+ax_pose 14, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose19:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose20:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose21:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose22:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose23:
+ax_pose 19, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose24:
+ax_pose 20, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose25:
+ax_pose 21, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose26:
+ax_pose 17, 0x01e1, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose27:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose28:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose29:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose30:
+ax_pose 20, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose31:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose32:
+ax_pose 1, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose33:
+ax_pose 2, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose34:
+ax_pose 24, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose35:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose36:
+ax_pose 4, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose37:
+ax_pose 5, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose38:
+ax_pose 25, 0x01e3, 0x80ef, 0x6c00
+ax_pose_terminator
+sSpindaPose39:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose40:
+ax_pose 6, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose41:
+ax_pose 8, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose42:
+ax_pose 26, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose43:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose44:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose45:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose46:
+ax_pose 27, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose47:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose48:
+ax_pose 13, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose49:
+ax_pose 14, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose50:
+ax_pose 28, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose51:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose52:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose53:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose54:
+ax_pose 29, 0x01e4, 0x80f6, 0x6c00
+ax_pose_terminator
+sSpindaPose55:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose56:
+ax_pose 19, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose57:
+ax_pose 20, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose58:
+ax_pose 30, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose59:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose60:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose61:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose62:
+ax_pose 31, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sSpindaPose63:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose64:
+ax_pose 1, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose65:
+ax_pose 2, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose66:
+ax_pose 24, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose67:
+ax_pose 32, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose68:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose69:
+ax_pose 4, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose70:
+ax_pose 5, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose71:
+ax_pose 25, 0x01e3, 0x80ef, 0x6c00
+ax_pose_terminator
+sSpindaPose72:
+ax_pose 33, 0x01e3, 0x80ed, 0x6c00
+ax_pose_terminator
+sSpindaPose73:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose74:
+ax_pose 6, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose75:
+ax_pose 8, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose76:
+ax_pose 26, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose77:
+ax_pose 34, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sSpindaPose78:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose79:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose80:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose81:
+ax_pose 27, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose82:
+ax_pose 35, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sSpindaPose83:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose84:
+ax_pose 13, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose85:
+ax_pose 14, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose86:
+ax_pose 28, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose87:
+ax_pose 36, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose88:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose89:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose90:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose91:
+ax_pose 29, 0x01e4, 0x80f6, 0x6c00
+ax_pose_terminator
+sSpindaPose92:
+ax_pose 37, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose93:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose94:
+ax_pose 19, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose95:
+ax_pose 20, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose96:
+ax_pose 30, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose97:
+ax_pose 38, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose98:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose99:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose100:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose101:
+ax_pose 31, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sSpindaPose102:
+ax_pose 39, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose103:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose104:
+ax_pose 24, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose105:
+ax_pose 40, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose106:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose107:
+ax_pose 25, 0x01e3, 0x80ef, 0x6c00
+ax_pose_terminator
+sSpindaPose108:
+ax_pose 41, 0x01e3, 0x80ec, 0x6c00
+ax_pose_terminator
+sSpindaPose109:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose110:
+ax_pose 26, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose111:
+ax_pose 42, 0x01e4, 0x80ee, 0x6c00
+ax_pose_terminator
+sSpindaPose112:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose113:
+ax_pose 27, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose114:
+ax_pose 43, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sSpindaPose115:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose116:
+ax_pose 28, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose117:
+ax_pose 44, 0x01e5, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose118:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose119:
+ax_pose 29, 0x01e4, 0x80f6, 0x6c00
+ax_pose_terminator
+sSpindaPose120:
+ax_pose 45, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose121:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose122:
+ax_pose 30, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose123:
+ax_pose 46, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose124:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose125:
+ax_pose 31, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sSpindaPose126:
+ax_pose 47, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose127:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose128:
+ax_pose 1, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose129:
+ax_pose 2, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose130:
+ax_pose 48, 0x01e2, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose131:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose132:
+ax_pose 4, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose133:
+ax_pose 5, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose134:
+ax_pose 49, 0x01e3, 0x80ee, 0x6c00
+ax_pose_terminator
+sSpindaPose135:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose136:
+ax_pose 6, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose137:
+ax_pose 8, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose138:
+ax_pose 50, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sSpindaPose139:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose140:
+ax_pose 9, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose141:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose142:
+ax_pose 51, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sSpindaPose143:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose144:
+ax_pose 13, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose145:
+ax_pose 14, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose146:
+ax_pose 52, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose147:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose148:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose149:
+ax_pose 17, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose150:
+ax_pose 53, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose151:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose152:
+ax_pose 19, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose153:
+ax_pose 20, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose154:
+ax_pose 54, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sSpindaPose155:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose156:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose157:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose158:
+ax_pose 55, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose159:
+ax_pose 56, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose160:
+ax_pose 57, 0x01ee, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose161:
+ax_pose 58, 0x01e0, 0x80f0, 0x6c00
+ax_pose_terminator
+sSpindaPose162:
+ax_pose 59, 0x01e2, 0x80e8, 0x6c00
+ax_pose_terminator
+sSpindaPose163:
+ax_pose 60, 0x01e3, 0x80e7, 0x6c00
+ax_pose_terminator
+sSpindaPose164:
+ax_pose 61, 0x01e5, 0x90e8, 0x6c00
+ax_pose_terminator
+sSpindaPose165:
+ax_pose 62, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sSpindaPose166:
+ax_pose 61, 0x01e5, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose167:
+ax_pose 63, 0x01e3, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose168:
+ax_pose 64, 0x01e2, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose169:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose170:
+ax_pose 1, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose171:
+ax_pose 2, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose172:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose173:
+ax_pose 4, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose174:
+ax_pose 5, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose175:
+ax_pose 6, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose176:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose177:
+ax_pose 6, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose178:
+ax_pose 8, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose179:
+ax_pose 5, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose180:
+ax_pose 9, 0x01e1, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose181:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose182:
+ax_pose 9, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose183:
+ax_pose 11, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose184:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose185:
+ax_pose 13, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose186:
+ax_pose 14, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose187:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose188:
+ax_pose 17, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose189:
+ax_pose 16, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose190:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose191:
+ax_pose 19, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose192:
+ax_pose 20, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose193:
+ax_pose 21, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose194:
+ax_pose 17, 0x01e1, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose195:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose196:
+ax_pose 21, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose197:
+ax_pose 23, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose198:
+ax_pose 20, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose199:
+ax_pose 40, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose200:
+ax_pose 47, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose201:
+ax_pose 46, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sSpindaPose202:
+ax_pose 45, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sSpindaPose203:
+ax_pose 44, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose204:
+ax_pose 43, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sSpindaPose205:
+ax_pose 42, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sSpindaPose206:
+ax_pose 41, 0x01e3, 0x80ed, 0x6c00
+ax_pose_terminator
+sSpindaPose207:
+ax_pose 24, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose208:
+ax_pose 25, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sSpindaPose209:
+ax_pose 26, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose210:
+ax_pose 27, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose211:
+ax_pose 28, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose212:
+ax_pose 29, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose213:
+ax_pose 30, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose214:
+ax_pose 31, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sSpindaPose215:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose216:
+ax_pose 24, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose217:
+ax_pose 32, 0x01e2, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose218:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose219:
+ax_pose 25, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sSpindaPose220:
+ax_pose 33, 0x01e3, 0x80ec, 0x6c00
+ax_pose_terminator
+sSpindaPose221:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose222:
+ax_pose 26, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose223:
+ax_pose 34, 0x01e4, 0x80ed, 0x6c00
+ax_pose_terminator
+sSpindaPose224:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose225:
+ax_pose 27, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose226:
+ax_pose 35, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sSpindaPose227:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose228:
+ax_pose 28, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose229:
+ax_pose 36, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose230:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose231:
+ax_pose 29, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose232:
+ax_pose 37, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose233:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose234:
+ax_pose 30, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose235:
+ax_pose 38, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose236:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose237:
+ax_pose 31, 0x01e3, 0x80ef, 0x6c00
+ax_pose_terminator
+sSpindaPose238:
+ax_pose 39, 0x01e3, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose239:
+ax_pose 40, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose240:
+ax_pose 47, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose241:
+ax_pose 46, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose242:
+ax_pose 45, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sSpindaPose243:
+ax_pose 44, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose244:
+ax_pose 43, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sSpindaPose245:
+ax_pose 42, 0x01e4, 0x80ed, 0x6c00
+ax_pose_terminator
+sSpindaPose246:
+ax_pose 41, 0x01e3, 0x80eb, 0x6c00
+ax_pose_terminator
+sSpindaPose247:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose248:
+ax_pose 22, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose249:
+ax_pose 18, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose250:
+ax_pose 15, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose251:
+ax_pose 12, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose252:
+ax_pose 10, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose253:
+ax_pose 7, 0x81e4, 0x80f8, 0x6c00
+ax_pose_terminator
+sSpindaPose254:
+ax_pose 3, 0x01e4, 0x80f4, 0x6c00
+ax_pose_terminator
+sSpindaPose255:
+ax_pose 0, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sSpindaPose256:
+ax_pose 65, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sSpindaPose257:
+ax_pose 66, 0x01f3, 0x80f4, 0x6c00
+ax_pose_terminator
+.align 2
+sSpindaAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 1, 0, 1, 0,
+ax_anim 12, 0, 1, 2, 0, 2, 0,
+ax_anim 14, 0, 1, 3, 1, 3, 1,
+ax_anim 12, 0, 0, 1, 1, 1, 1,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim 10, 0, 1, -2, 1, -2, 1,
+ax_anim 12, 0, 2, -3, 0, -3, 0,
+ax_anim 14, 0, 2, -4, 1, -4, 1,
+ax_anim 12, 0, 0, -2, 0, -2, 0,
+ax_anim 10, 0, 1, -1, 0, -1, 0,
+ax_anim_terminator
+sSpindaAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 1, -1, 1, -1,
+ax_anim 12, 0, 5, 2, -2, 2, -2,
+ax_anim 14, 0, 5, 3, -2, 3, -2,
+ax_anim 12, 0, 3, 2, 0, 2, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 5, -2, 1, -2, 1,
+ax_anim 12, 0, 6, -3, 1, -3, 1,
+ax_anim 14, 0, 6, -4, 2, -4, 2,
+ax_anim 12, 0, 3, -2, 1, -2, 1,
+ax_anim 10, 0, 5, -1, 0, -1, 0,
+ax_anim_terminator
+sSpindaAnims_1_3:
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 1, -1, 1, -1,
+ax_anim 12, 0, 10, 2, -2, 2, -2,
+ax_anim 14, 0, 10, 3, -3, 3, -3,
+ax_anim 12, 0, 7, 2, 0, 2, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim 10, 0, 9, -2, 1, -2, 1,
+ax_anim 12, 0, 8, -2, 1, -2, 1,
+ax_anim 14, 0, 8, -2, 2, -2, 2,
+ax_anim 12, 0, 7, -2, 1, -2, 1,
+ax_anim 10, 0, 9, -1, 0, -1, 0,
+ax_anim_terminator
+sSpindaAnims_1_4:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, -1, -1, -1, -1,
+ax_anim 12, 0, 14, -2, -2, -2, -2,
+ax_anim 14, 0, 14, -3, -2, -3, -2,
+ax_anim 12, 0, 12, -2, 0, -2, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 2, 1, 2, 1,
+ax_anim 12, 0, 13, 3, 1, 3, 1,
+ax_anim 14, 0, 13, 4, 2, 4, 2,
+ax_anim 12, 0, 12, 2, 1, 2, 1,
+ax_anim 10, 0, 14, 1, 0, 1, 0,
+ax_anim_terminator
+sSpindaAnims_1_5:
+ax_anim 10, 0, 15, 0, -1, 0, -1,
+ax_anim 10, 0, 17, -1, -1, -1, -1,
+ax_anim 12, 0, 16, -2, -1, -2, -1,
+ax_anim 14, 0, 16, -3, -2, -3, -2,
+ax_anim 12, 0, 15, -1, -2, -1, -2,
+ax_anim 10, 0, 17, 0, -1, 0, -1,
+ax_anim 10, 0, 16, 2, -2, 2, -2,
+ax_anim 12, 0, 17, 3, -1, 3, -1,
+ax_anim 14, 0, 17, 4, -2, 4, -2,
+ax_anim 12, 0, 15, 2, -1, 2, -1,
+ax_anim 10, 0, 16, 1, -1, 1, -1,
+ax_anim_terminator
+sSpindaAnims_1_6:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 1, -1, 1, -1,
+ax_anim 12, 0, 19, 2, -2, 2, -2,
+ax_anim 14, 0, 19, 3, -2, 3, -2,
+ax_anim 12, 0, 18, 2, 0, 2, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim 10, 0, 19, -2, 1, -2, 1,
+ax_anim 12, 0, 20, -3, 1, -3, 1,
+ax_anim 14, 0, 20, -4, 2, -4, 2,
+ax_anim 12, 0, 18, -2, 1, -2, 1,
+ax_anim 10, 0, 19, -1, 0, -1, 0,
+ax_anim_terminator
+sSpindaAnims_1_7:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, -1, -1, -1, -1,
+ax_anim 12, 0, 24, -2, -2, -2, -2,
+ax_anim 14, 0, 24, -3, -3, -3, -3,
+ax_anim 12, 0, 21, -2, 0, -2, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 2, 1, 2, 1,
+ax_anim 12, 0, 22, 2, 1, 2, 1,
+ax_anim 14, 0, 22, 2, 2, 2, 2,
+ax_anim 12, 0, 21, 2, 1, 2, 1,
+ax_anim 10, 0, 23, 1, 0, 1, 0,
+ax_anim_terminator
+sSpindaAnims_1_8:
+ax_anim 10, 0, 26, 0, 0, 0, 0,
+ax_anim 10, 0, 28, -1, -1, -1, -1,
+ax_anim 12, 0, 27, -2, -2, -2, -2,
+ax_anim 14, 0, 27, -3, -2, -3, -2,
+ax_anim 12, 0, 26, -2, 0, -2, 0,
+ax_anim 10, 0, 28, 0, 0, 0, 0,
+ax_anim 10, 0, 27, 2, 1, 2, 1,
+ax_anim 12, 0, 29, 3, 1, 3, 1,
+ax_anim 14, 0, 29, 4, 2, 4, 2,
+ax_anim 12, 0, 26, 2, 1, 2, 1,
+ax_anim 10, 0, 27, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 6, 0, 31, 0, -2, 0, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 0, 4, 0, 4,
+ax_anim 2, 2, 32, 0, 10, 0, 10,
+ax_anim 2, 0, 33, 0, 21, 0, 21,
+ax_anim 2, 1, 33, 1, 21, 1, 21,
+ax_anim 2, 0, 33, 0, 21, 0, 21,
+ax_anim 2, 0, 33, 1, 21, 1, 21,
+ax_anim 2, 0, 31, 0, 10, 0, 10,
+ax_anim 2, 0, 32, 0, 4, 0, 4,
+ax_anim_terminator
+sSpindaAnims_2_2:
+ax_anim 2, 0, 36, -1, -1, -1, -1,
+ax_anim 6, 0, 35, -2, -2, -2, -2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 35, 5, 4, 5, 4,
+ax_anim 2, 2, 36, 12, 11, 12, 11,
+ax_anim 2, 0, 37, 23, 21, 23, 21,
+ax_anim 2, 1, 37, 24, 20, 24, 20,
+ax_anim 2, 0, 37, 23, 21, 23, 21,
+ax_anim 2, 0, 37, 24, 20, 24, 20,
+ax_anim 2, 0, 35, 12, 11, 12, 11,
+ax_anim 2, 0, 36, 4, 4, 4, 4,
+ax_anim_terminator
+sSpindaAnims_2_3:
+ax_anim 2, 0, 40, -1, 0, -1, 0,
+ax_anim 6, 0, 39, -2, 0, -2, 0,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 0, 39, 4, 0, 4, 0,
+ax_anim 2, 2, 40, 10, 0, 10, 0,
+ax_anim 2, 0, 41, 24, 0, 24, 0,
+ax_anim 2, 1, 41, 24, 1, 24, 1,
+ax_anim 2, 0, 41, 24, 0, 24, 0,
+ax_anim 2, 0, 41, 24, 1, 24, 1,
+ax_anim 2, 0, 39, 10, 0, 10, 0,
+ax_anim 2, 0, 40, 4, 0, 4, 0,
+ax_anim_terminator
+sSpindaAnims_2_4:
+ax_anim 2, 0, 44, -1, 1, -1, 1,
+ax_anim 6, 0, 43, -2, 2, -2, 2,
+ax_anim 1, 0, 44, 0, -1, 0, -1,
+ax_anim 1, 0, 43, 6, -6, 6, -6,
+ax_anim 2, 2, 44, 12, -12, 12, -12,
+ax_anim 2, 0, 45, 23, -22, 23, -22,
+ax_anim 2, 1, 45, 24, -21, 24, -21,
+ax_anim 2, 0, 45, 23, -22, 23, -22,
+ax_anim 2, 0, 45, 24, -21, 24, -21,
+ax_anim 2, 0, 43, 10, -10, 10, -10,
+ax_anim 2, 0, 44, 4, -4, 4, -4,
+ax_anim_terminator
+sSpindaAnims_2_5:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 6, 0, 47, 0, 2, 0, 2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 47, 0, -4, 0, -4,
+ax_anim 2, 2, 48, 0, -13, 0, -13,
+ax_anim 2, 0, 49, 0, -23, 0, -23,
+ax_anim 2, 1, 49, 1, -23, 1, -23,
+ax_anim 2, 0, 49, 0, -23, 0, -23,
+ax_anim 2, 0, 49, 1, -23, 1, -23,
+ax_anim 2, 0, 47, 0, -10, 0, -10,
+ax_anim 2, 0, 47, 0, -4, 0, -4,
+ax_anim_terminator
+sSpindaAnims_2_6:
+ax_anim 2, 0, 52, 1, 1, 1, 1,
+ax_anim 6, 0, 51, 2, 2, 2, 2,
+ax_anim 1, 0, 52, 0, -1, 0, -1,
+ax_anim 1, 0, 51, -6, -6, -6, -6,
+ax_anim 2, 2, 52, -12, -12, -12, -12,
+ax_anim 2, 0, 53, -23, -22, -23, -22,
+ax_anim 2, 1, 53, -24, -21, -24, -21,
+ax_anim 2, 0, 53, -23, -22, -23, -22,
+ax_anim 2, 0, 53, -24, -21, -24, -21,
+ax_anim 2, 0, 51, -10, -10, -10, -10,
+ax_anim 2, 0, 52, -4, -4, -4, -4,
+ax_anim_terminator
+sSpindaAnims_2_7:
+ax_anim 2, 0, 56, 1, 0, 1, 0,
+ax_anim 6, 0, 55, 2, 0, 2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 0, 55, -4, 0, -4, 0,
+ax_anim 2, 2, 56, -10, 0, -10, 0,
+ax_anim 2, 0, 57, -24, 0, -24, 0,
+ax_anim 2, 1, 57, -24, 1, -24, 1,
+ax_anim 2, 0, 57, -24, 0, -24, 0,
+ax_anim 2, 0, 57, -24, 1, -24, 1,
+ax_anim 2, 0, 55, -10, 0, -10, 0,
+ax_anim 2, 0, 56, -4, 0, -4, 0,
+ax_anim_terminator
+sSpindaAnims_2_8:
+ax_anim 2, 0, 60, 1, -1, 1, -1,
+ax_anim 6, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -5, 4, -5, 4,
+ax_anim 2, 2, 60, -12, 11, -12, 11,
+ax_anim 2, 0, 61, -23, 21, -23, 21,
+ax_anim 2, 1, 61, -24, 20, -24, 20,
+ax_anim 2, 0, 61, -23, 21, -23, 21,
+ax_anim 2, 0, 61, -24, 20, -24, 20,
+ax_anim 2, 0, 59, -12, 11, -12, 11,
+ax_anim 2, 0, 60, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSpindaAnims_3_1:
+ax_anim 2, 0, 65, 0, -1, 0, -1,
+ax_anim 6, 0, 65, 0, -2, 0, -2,
+ax_anim 3, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 0, 4, 0, 4,
+ax_anim 2, 0, 99, -2, 10, -2, 10,
+ax_anim 2, 2, 99, -1, 12, -1, 12,
+ax_anim 2, 0, 66, 0, 19, 0, 19,
+ax_anim 2, 1, 66, 1, 19, 1, 19,
+ax_anim 2, 0, 66, 0, 19, 0, 19,
+ax_anim 2, 0, 66, 1, 19, 1, 19,
+ax_anim 2, 0, 63, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sSpindaAnims_3_2:
+ax_anim 2, 0, 70, -1, -1, -1, -1,
+ax_anim 6, 0, 70, -2, -2, -2, -2,
+ax_anim 3, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 4, 4, 4, 4,
+ax_anim 2, 0, 74, 12, 11, 12, 11,
+ax_anim 2, 2, 74, 13, 13, 12, 13,
+ax_anim 2, 0, 71, 18, 20, 18, 20,
+ax_anim 2, 1, 71, 19, 19, 19, 19,
+ax_anim 2, 0, 71, 18, 20, 18, 20,
+ax_anim 2, 0, 71, 19, 19, 19, 19,
+ax_anim 2, 0, 68, 10, 11, 10, 11,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sSpindaAnims_3_3:
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 6, 0, 75, -2, 0, -2, 0,
+ax_anim 3, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 4, 0, 4, 0,
+ax_anim 2, 0, 69, 10, -2, 10, -2,
+ax_anim 2, 2, 69, 13, -1, 13, -1,
+ax_anim 2, 0, 76, 18, 0, 18, 0,
+ax_anim 2, 1, 76, 18, 1, 18, 1,
+ax_anim 2, 0, 76, 18, 0, 18, 0,
+ax_anim 2, 0, 76, 18, 1, 18, 1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 74, 4, 0, 4, 0,
+ax_anim_terminator
+sSpindaAnims_3_4:
+ax_anim 2, 0, 80, -1, 1, -1, 1,
+ax_anim 6, 0, 80, -2, 2, -2, 2,
+ax_anim 3, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 6, -6, 6, -6,
+ax_anim 2, 0, 84, 12, -13, 12, -13,
+ax_anim 2, 2, 84, 14, -14, 14, -14,
+ax_anim 2, 0, 81, 20, -20, 20, -20,
+ax_anim 2, 1, 81, 21, -19, 21, -19,
+ax_anim 2, 0, 81, 20, -20, 20, -20,
+ax_anim 2, 0, 81, 21, -19, 21, -19,
+ax_anim 2, 0, 78, 10, -10, 10, -10,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sSpindaAnims_3_5:
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim 6, 0, 85, 0, 2, 0, 2,
+ax_anim 3, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, -4,
+ax_anim 2, 0, 89, -2, -13, -2, -13,
+ax_anim 2, 2, 89, -1, -14, -1, -14,
+ax_anim 2, 0, 86, 0, -19, 0, -19,
+ax_anim 2, 1, 86, 1, -19, 1, -19,
+ax_anim 2, 0, 86, 0, -19, 0, -19,
+ax_anim 2, 0, 86, 1, -19, 1, -19,
+ax_anim 2, 0, 83, 0, -10, 0, -10,
+ax_anim 2, 0, 83, 0, -4, 0, -4,
+ax_anim_terminator
+sSpindaAnims_3_6:
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim 6, 0, 90, 2, 2, 2, 2,
+ax_anim 3, 0, 84, 0, -1, 0, -1,
+ax_anim 2, 0, 88, -6, -6, -6, -6,
+ax_anim 2, 0, 94, -12, -14, -12, -14,
+ax_anim 2, 2, 94, -15, -15, -15, -15,
+ax_anim 2, 0, 91, -20, -20, -20, -20,
+ax_anim 2, 1, 91, -21, -19, -21, -19,
+ax_anim 2, 0, 91, -20, -20, -20, -20,
+ax_anim 2, 0, 91, -21, -19, -21, -19,
+ax_anim 2, 0, 88, -10, -10, -10, -10,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sSpindaAnims_3_7:
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 6, 0, 95, 2, 0, 2, 0,
+ax_anim 3, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -4, 0, -4, 0,
+ax_anim 2, 0, 99, -10, 2, -10, 2,
+ax_anim 2, 2, 99, -12, 1, -12, 1,
+ax_anim 2, 0, 96, -18, 0, -18, 0,
+ax_anim 2, 1, 96, -18, 1, -18, 1,
+ax_anim 2, 0, 96, -18, 0, -18, 0,
+ax_anim 2, 0, 96, -18, 1, -18, 1,
+ax_anim 2, 0, 93, -10, 0, -10, 0,
+ax_anim 2, 0, 94, -4, 0, -4, 0,
+ax_anim_terminator
+sSpindaAnims_3_8:
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 6, 0, 100, 2, -2, 2, -2,
+ax_anim 3, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 98, -4, 4, -4, 4,
+ax_anim 2, 0, 94, -10, 13, -10, 13,
+ax_anim 2, 2, 94, -12, 14, -12, 14,
+ax_anim 2, 0, 101, -18, 20, -18, 20,
+ax_anim 2, 1, 101, -19, 19, -19, 19,
+ax_anim 2, 0, 101, -18, 20, -18, 20,
+ax_anim 2, 0, 101, -19, 19, -19, 19,
+ax_anim 2, 0, 98, -10, 11, -10, 11,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sSpindaAnims_4_1:
+ax_anim 2, 0, 103, 0, -2, 0, -2,
+ax_anim 6, 2, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 0, -1, 0, -1,
+ax_anim 2, 1, 104, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 1, 3, 1, 3,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 1, 3, 1, 3,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 1, 3, 1, 3,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim_terminator
+sSpindaAnims_4_2:
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim 6, 2, 106, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 1, 107, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 3, 1, 3, 1,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 3, 1, 3, 1,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 3, 1, 3, 1,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim_terminator
+sSpindaAnims_4_3:
+ax_anim 2, 0, 109, -2, 0, -2, 0,
+ax_anim 6, 2, 109, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 1, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 3, 1, 3, 1,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 3, 1, 3, 1,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 110, 3, 1, 3, 1,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim_terminator
+sSpindaAnims_4_4:
+ax_anim 2, 0, 112, -2, 2, -2, 2,
+ax_anim 6, 2, 112, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 1, 113, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 3, -1, 3, -1,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 3, -1, 3, -1,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 3, -1, 3, -1,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim_terminator
+sSpindaAnims_4_5:
+ax_anim 2, 0, 115, 0, 2, 0, 2,
+ax_anim 6, 2, 115, 0, 3, 0, 3,
+ax_anim 2, 0, 114, 0, 1, 0, 1,
+ax_anim 2, 1, 116, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 1, -3, 1, -3,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 1, -3, 1, -3,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 1, -3, 1, -3,
+ax_anim 2, 0, 116, 0, -3, 0, -3,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim_terminator
+sSpindaAnims_4_6:
+ax_anim 2, 0, 118, 2, 2, 2, 2,
+ax_anim 6, 2, 118, 3, 3, 3, 3,
+ax_anim 2, 0, 117, 1, 1, 1, 1,
+ax_anim 2, 1, 119, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -3, -1, -3, -1,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -3, -1, -3, -1,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -3, -1, -3, -1,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim_terminator
+sSpindaAnims_4_7:
+ax_anim 2, 0, 121, 2, 0, 2, 0,
+ax_anim 6, 2, 121, 3, 0, 3, 0,
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 1, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -3, 0, -3, 0,
+ax_anim 2, 0, 120, -1, 0, -1, 0,
+ax_anim_terminator
+sSpindaAnims_4_8:
+ax_anim 2, 0, 124, 2, -2, 2, -2,
+ax_anim 6, 2, 124, 3, -3, 3, -3,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 1, 125, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -3, 1, -3, 1,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -3, 1, -3, 1,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 2, 0, 125, -3, 1, -3, 1,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSpindaAnims_5_1:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, -1, 0, 0,
+ax_anim 2, 0, 135, 0, -1, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 3, 0, 148, 0, -2, 0, 0,
+ax_anim 3, 2, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_5_2:
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 2, 155, 0, -1, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_5_3:
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -1, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, -2, 0, 0,
+ax_anim 3, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_5_4:
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_5_5:
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, -1, 0, 0,
+ax_anim 2, 0, 128, 0, 1, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 3, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sSpindaAnims_5_6:
+ax_anim 8, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 2, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sSpindaAnims_5_7:
+ax_anim 8, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, -1, 0, 0,
+ax_anim 3, 2, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_5_8:
+ax_anim 8, 0, 157, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 1, 0, 0,
+ax_anim 2, 0, 139, 0, -1, 0, 0,
+ax_anim 3, 0, 144, 0, -1, 0, 0,
+ax_anim 3, 2, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 155, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_6_1:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 35, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_7_1:
+ax_anim 2, 0, 160, 0, -2, 0, -2,
+ax_anim 8, 0, 160, 0, -3, 0, -3,
+ax_anim_terminator
+sSpindaAnims_7_2:
+ax_anim 2, 0, 161, -2, -2, -2, -2,
+ax_anim 8, 0, 161, -3, -3, -3, -3,
+ax_anim_terminator
+sSpindaAnims_7_3:
+ax_anim 2, 0, 162, -2, 0, -2, 0,
+ax_anim 8, 0, 162, -3, 0, -3, 0,
+ax_anim_terminator
+sSpindaAnims_7_4:
+ax_anim 2, 0, 163, -2, 2, -2, 2,
+ax_anim 8, 0, 163, -3, 3, -3, 3,
+ax_anim_terminator
+sSpindaAnims_7_5:
+ax_anim 2, 0, 164, 0, 2, 0, 2,
+ax_anim 8, 0, 164, 0, 3, 0, 3,
+ax_anim_terminator
+sSpindaAnims_7_6:
+ax_anim 2, 0, 165, 2, 2, 2, 2,
+ax_anim 8, 0, 165, 3, 3, 3, 3,
+ax_anim_terminator
+sSpindaAnims_7_7:
+ax_anim 2, 0, 166, 2, 0, 2, 0,
+ax_anim 8, 0, 166, 3, 0, 3, 0,
+ax_anim_terminator
+sSpindaAnims_7_8:
+ax_anim 2, 0, 167, 2, -2, 2, -2,
+ax_anim 8, 0, 167, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSpindaAnims_8_1:
+ax_anim 4, 0, 169, 1, 0, 1, 0,
+ax_anim 8, 0, 170, 2, 0, 2, 0,
+ax_anim 14, 0, 168, 2, 0, 2, 0,
+ax_anim 4, 0, 170, 1, 0, 1, 0,
+ax_anim 5, 0, 169, 0, 0, 0, 0,
+ax_anim 6, 0, 170, -1, 0, -1, 0,
+ax_anim 8, 0, 170, -2, 0, -2, 0,
+ax_anim 14, 0, 168, -2, 0, -2, 0,
+ax_anim 6, 0, 169, -1, 0, -1, 0,
+ax_anim_terminator
+sSpindaAnims_8_2:
+ax_anim 4, 0, 172, 1, -1, 1, -1,
+ax_anim 8, 0, 173, 2, -2, 2, -2,
+ax_anim 14, 0, 171, 2, -2, 2, -2,
+ax_anim 4, 0, 173, 1, -1, 1, -1,
+ax_anim 5, 0, 172, 0, 0, 0, 0,
+ax_anim 6, 0, 174, -1, 1, -1, 1,
+ax_anim 8, 0, 174, -2, 2, -2, 2,
+ax_anim 14, 0, 171, -2, 2, -2, 2,
+ax_anim 6, 0, 172, -1, 1, -1, 1,
+ax_anim_terminator
+sSpindaAnims_8_3:
+ax_anim 4, 0, 175, 0, -1, 0, -1,
+ax_anim 8, 0, 178, 0, -2, 0, -2,
+ax_anim 14, 0, 175, 0, -2, 0, -2,
+ax_anim 4, 0, 177, 0, -1, 0, -1,
+ax_anim 5, 0, 176, 0, 0, 0, 0,
+ax_anim 6, 0, 176, 0, 1, 0, 1,
+ax_anim 8, 0, 177, 0, 2, 0, 2,
+ax_anim 14, 0, 175, 0, 2, 0, 2,
+ax_anim 6, 0, 179, 0, 1, 0, 1,
+ax_anim_terminator
+sSpindaAnims_8_4:
+ax_anim 4, 0, 182, 1, 1, 1, 1,
+ax_anim 8, 0, 181, 2, 2, 2, 2,
+ax_anim 14, 0, 180, 2, 2, 2, 2,
+ax_anim 4, 0, 182, 1, 1, 1, 1,
+ax_anim 5, 0, 181, 0, 0, 0, 0,
+ax_anim 6, 0, 182, -1, -1, -1, -1,
+ax_anim 8, 0, 182, -2, -2, -2, -2,
+ax_anim 14, 0, 180, -2, -2, -2, -2,
+ax_anim 6, 0, 181, -1, -1, -1, -1,
+ax_anim_terminator
+sSpindaAnims_8_5:
+ax_anim 4, 0, 184, 1, 0, 1, 0,
+ax_anim 8, 0, 185, 2, 0, 2, 0,
+ax_anim 14, 0, 183, 2, 0, 2, 0,
+ax_anim 4, 0, 185, 1, 0, 1, 0,
+ax_anim 5, 0, 184, 0, 0, 0, 0,
+ax_anim 6, 0, 185, -1, 0, -1, 0,
+ax_anim 8, 0, 185, -2, 0, -2, 0,
+ax_anim 14, 0, 183, -2, 0, -2, 0,
+ax_anim 6, 0, 184, -1, 0, -1, 0,
+ax_anim_terminator
+sSpindaAnims_8_6:
+ax_anim 4, 0, 188, -1, 1, -1, 1,
+ax_anim 8, 0, 187, -2, 2, -2, 2,
+ax_anim 14, 0, 186, -2, 2, -2, 2,
+ax_anim 4, 0, 188, -1, 1, -1, 1,
+ax_anim 5, 0, 187, 0, 0, 0, 0,
+ax_anim 6, 0, 188, 1, -1, 1, -1,
+ax_anim 8, 0, 188, 2, -2, 2, -2,
+ax_anim 14, 0, 186, 2, -2, 2, -2,
+ax_anim 6, 0, 187, 1, -1, 1, -1,
+ax_anim_terminator
+sSpindaAnims_8_7:
+ax_anim 4, 0, 189, 0, -1, 0, -1,
+ax_anim 8, 0, 192, 0, -2, 0, -2,
+ax_anim 14, 0, 189, 0, -2, 0, -2,
+ax_anim 4, 0, 191, 0, -1, 0, -1,
+ax_anim 5, 0, 190, 0, 0, 0, 0,
+ax_anim 6, 0, 190, 0, 1, 0, 1,
+ax_anim 8, 0, 191, 0, 2, 0, 2,
+ax_anim 14, 0, 189, 0, 2, 0, 2,
+ax_anim 6, 0, 193, 0, 1, 0, 1,
+ax_anim_terminator
+sSpindaAnims_8_8:
+ax_anim 4, 0, 195, -1, -1, -1, -1,
+ax_anim 8, 0, 196, -2, -2, -2, -2,
+ax_anim 14, 0, 194, -2, -2, -2, -2,
+ax_anim 4, 0, 196, -1, -1, -1, -1,
+ax_anim 5, 0, 195, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 1, 1, 1, 1,
+ax_anim 8, 0, 197, 2, 2, 2, 2,
+ax_anim 14, 0, 194, 2, 2, 2, 2,
+ax_anim 6, 0, 195, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sSpindaAnims_9_1:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 6, 3, 6, 3,
+ax_anim 2, 0, 200, 10, 9, 10, 9,
+ax_anim 2, 0, 201, 9, 16, 9, 16,
+ax_anim 3, 0, 202, 0, 19, 0, 19,
+ax_anim 2, 3, 203, -8, 16, -8, 16,
+ax_anim 2, 0, 204, -10, 9, -10, 9,
+ax_anim 1, 0, 205, -6, 3, -6, 3,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_9_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 8, 0, 8, 0,
+ax_anim 2, 0, 199, 17, 3, 17, 3,
+ax_anim 2, 0, 200, 22, 12, 22, 12,
+ax_anim 3, 0, 201, 22, 20, 22, 20,
+ax_anim 2, 3, 202, 11, 20, 11, 20,
+ax_anim 2, 0, 203, 3, 15, 3, 15,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_9_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 3, -5, 3, -5,
+ax_anim 2, 0, 198, 12, -7, 12, -7,
+ax_anim 2, 0, 199, 18, -5, 18, -5,
+ax_anim 3, 0, 200, 22, 0, 22, 0,
+ax_anim 2, 3, 201, 19, 5, 19, 5,
+ax_anim 2, 0, 202, 12, 6, 12, 6,
+ax_anim 1, 0, 203, 4, 5, 4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_9_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, -1, -8, -1, -8,
+ax_anim 2, 0, 205, 4, -16, 4, -16,
+ax_anim 2, 0, 198, 12, -23, 12, -23,
+ax_anim 3, 0, 199, 23, -23, 23, -23,
+ax_anim 2, 3, 200, 24, -14, 24, -14,
+ax_anim 2, 0, 201, 19, -6, 19, -6,
+ax_anim 1, 0, 202, 9, -1, 9, -1,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_9_5:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -8, -3, -8, -3,
+ax_anim 2, 0, 204, -10, -12, -10, -12,
+ax_anim 2, 0, 205, -8, -20, -8, -20,
+ax_anim 3, 0, 198, 0, -24, 0, -24,
+ax_anim 2, 3, 199, 8, -20, 8, -20,
+ax_anim 2, 0, 200, 10, -12, 10, -12,
+ax_anim 1, 0, 201, 8, -3, 8, -3,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_9_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 1, -8, 1, -8,
+ax_anim 2, 0, 199, -4, -16, -4, -16,
+ax_anim 2, 0, 198, -12, -23, -12, -23,
+ax_anim 3, 0, 205, -23, -23, -23, -23,
+ax_anim 2, 3, 204, -24, -14, -24, -14,
+ax_anim 2, 0, 203, -19, -6, -19, -6,
+ax_anim 1, 0, 202, -9, -1, -9, -1,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_9_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -3, -5, -3, -5,
+ax_anim 2, 0, 198, -12, -7, -12, -7,
+ax_anim 2, 0, 205, -18, -5, -18, -5,
+ax_anim 3, 0, 204, -22, 0, -22, 0,
+ax_anim 2, 3, 203, -19, 5, -19, 5,
+ax_anim 2, 0, 202, -12, 6, -12, 6,
+ax_anim 1, 0, 201, -4, 5, -4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_9_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 198, -8, 0, -8, 0,
+ax_anim 2, 0, 205, -17, 3, -17, 3,
+ax_anim 2, 0, 204, -22, 12, -22, 12,
+ax_anim 3, 0, 203, -22, 20, -22, 20,
+ax_anim 2, 3, 202, -11, 20, -11, 20,
+ax_anim 2, 0, 201, -3, 15, -3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_10_1:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_10_2:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_10_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_10_4:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_10_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_10_6:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_10_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_10_8:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_11_1:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -27, 0, 0,
+ax_anim 2, 0, 216, 0, -23, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_11_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -28, 0, 0,
+ax_anim 2, 0, 219, 0, -22, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_11_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -24, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_11_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -22, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 2, 0, 225, 0, -17, 0, 0,
+ax_anim 1, 0, 225, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_11_5:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -22, 0, 0,
+ax_anim 4, 0, 227, 0, -23, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_11_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 230, 0, -16, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -22, 0, 0,
+ax_anim 3, 0, 231, 0, -21, 0, 0,
+ax_anim 2, 0, 231, 0, -17, 0, 0,
+ax_anim 1, 0, 231, 0, -11, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_11_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 234, 0, -24, 0, 0,
+ax_anim 2, 0, 234, 0, -18, 0, 0,
+ax_anim 1, 0, 234, 0, -12, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_11_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 236, 0, -16, 0, 0,
+ax_anim 3, 0, 236, 0, -20, 0, 0,
+ax_anim 4, 0, 236, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -23, 0, 0,
+ax_anim 3, 0, 237, 0, -28, 0, 0,
+ax_anim 2, 0, 237, 0, -22, 0, 0,
+ax_anim 1, 0, 237, 0, -12, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_12_1:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_12_2:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_12_3:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_12_4:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_12_5:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_12_6:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_12_7:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_12_8:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_13_1:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_13_2:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_13_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_13_4:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_13_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_13_6:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_13_7:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sSpindaAnims_13_8:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpindaAnims_14_1:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaAnims_14_2:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaAnims_14_3:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaAnims_14_4:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaAnims_14_5:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaAnims_14_6:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaAnims_14_7:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaAnims_14_8:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, -2, 0, 0,
+ax_anim 6, 0, 255, 0, -4, 0, 1,
+ax_anim 4, 0, 255, 0, -3, 0, 2,
+ax_anim 2, 0, 255, 0, -1, 0, 2,
+ax_anim 1, 0, 256, 0, 1, 0, 2,
+ax_anim 3, 0, 256, 0, -1, 0, 2,
+ax_anim 4, 0, 256, 0, 0, 0, 2,
+ax_anim 4, 0, 256, 0, 1, 0, 2,
+ax_anim_terminator
+sSpindaGfx1:
+.incbin "baserom.gba", 0x13579F4, 0x200
+sSpindaSprites1:
+ax_sprite sSpindaGfx1, 0x200
+ax_sprite_terminator
+sSpindaGfx2:
+.incbin "baserom.gba", 0x1357C04, 0x200
+sSpindaSprites2:
+ax_sprite sSpindaGfx2, 0x200
+ax_sprite_terminator
+sSpindaGfx3:
+.incbin "baserom.gba", 0x1357E14, 0x200
+sSpindaSprites3:
+ax_sprite sSpindaGfx3, 0x200
+ax_sprite_terminator
+sSpindaGfx4:
+.incbin "baserom.gba", 0x1358024, 0x200
+sSpindaSprites4:
+ax_sprite sSpindaGfx4, 0x200
+ax_sprite_terminator
+sSpindaGfx5:
+.incbin "baserom.gba", 0x1358234, 0x200
+sSpindaSprites5:
+ax_sprite sSpindaGfx5, 0x200
+ax_sprite_terminator
+sSpindaGfx6:
+.incbin "baserom.gba", 0x1358444, 0x200
+sSpindaSprites6:
+ax_sprite sSpindaGfx6, 0x200
+ax_sprite_terminator
+sSpindaGfx7:
+.incbin "baserom.gba", 0x1358654, 0x100
+sSpindaSprites7:
+ax_sprite sSpindaGfx7, 0x100
+ax_sprite_terminator
+sSpindaGfx8:
+.incbin "baserom.gba", 0x1358764, 0x100
+sSpindaSprites8:
+ax_sprite sSpindaGfx8, 0x100
+ax_sprite_terminator
+sSpindaGfx9:
+.incbin "baserom.gba", 0x1358874, 0x100
+sSpindaSprites9:
+ax_sprite sSpindaGfx9, 0x100
+ax_sprite_terminator
+sSpindaGfx10:
+.incbin "baserom.gba", 0x1358984, 0x200
+sSpindaSprites10:
+ax_sprite sSpindaGfx10, 0x200
+ax_sprite_terminator
+sSpindaGfx11:
+.incbin "baserom.gba", 0x1358B94, 0x200
+sSpindaSprites11:
+ax_sprite sSpindaGfx11, 0x200
+ax_sprite_terminator
+sSpindaGfx12:
+.incbin "baserom.gba", 0x1358DA4, 0x200
+sSpindaSprites12:
+ax_sprite sSpindaGfx12, 0x200
+ax_sprite_terminator
+sSpindaGfx13:
+.incbin "baserom.gba", 0x1358FB4, 0x200
+sSpindaSprites13:
+ax_sprite sSpindaGfx13, 0x200
+ax_sprite_terminator
+sSpindaGfx14:
+.incbin "baserom.gba", 0x13591C4, 0x200
+sSpindaSprites14:
+ax_sprite sSpindaGfx14, 0x200
+ax_sprite_terminator
+sSpindaGfx15:
+.incbin "baserom.gba", 0x13593D4, 0x200
+sSpindaSprites15:
+ax_sprite sSpindaGfx15, 0x200
+ax_sprite_terminator
+sSpindaGfx16:
+.incbin "baserom.gba", 0x13595E4, 0x200
+sSpindaSprites16:
+ax_sprite sSpindaGfx16, 0x200
+ax_sprite_terminator
+sSpindaGfx17:
+.incbin "baserom.gba", 0x13597F4, 0x200
+sSpindaSprites17:
+ax_sprite sSpindaGfx17, 0x200
+ax_sprite_terminator
+sSpindaGfx18:
+.incbin "baserom.gba", 0x1359A04, 0x200
+sSpindaSprites18:
+ax_sprite sSpindaGfx18, 0x200
+ax_sprite_terminator
+sSpindaGfx19:
+.incbin "baserom.gba", 0x1359C14, 0x100
+sSpindaSprites19:
+ax_sprite sSpindaGfx19, 0x100
+ax_sprite_terminator
+sSpindaGfx20:
+.incbin "baserom.gba", 0x1359D24, 0x100
+sSpindaSprites20:
+ax_sprite sSpindaGfx20, 0x100
+ax_sprite_terminator
+sSpindaGfx21:
+.incbin "baserom.gba", 0x1359E34, 0x100
+sSpindaSprites21:
+ax_sprite sSpindaGfx21, 0x100
+ax_sprite_terminator
+sSpindaGfx22:
+.incbin "baserom.gba", 0x1359F44, 0x200
+sSpindaSprites22:
+ax_sprite sSpindaGfx22, 0x200
+ax_sprite_terminator
+sSpindaGfx23:
+.incbin "baserom.gba", 0x135A154, 0x200
+sSpindaSprites23:
+ax_sprite sSpindaGfx23, 0x200
+ax_sprite_terminator
+sSpindaGfx24:
+.incbin "baserom.gba", 0x135A364, 0x200
+sSpindaSprites24:
+ax_sprite sSpindaGfx24, 0x200
+ax_sprite_terminator
+sSpindaGfx25:
+.incbin "baserom.gba", 0x135A574, 0x160
+sSpindaGfx25_1:
+.incbin "baserom.gba", 0x135A6D4, 0x60
+sSpindaSprites25:
+ax_sprite sSpindaGfx25, 0x160
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx26:
+.incbin "baserom.gba", 0x135A75C, 0x60
+sSpindaGfx26_1:
+.incbin "baserom.gba", 0x135A7BC, 0x60
+sSpindaGfx26_2:
+.incbin "baserom.gba", 0x135A81C, 0x60
+sSpindaGfx26_3:
+.incbin "baserom.gba", 0x135A87C, 0x40
+sSpindaSprites26:
+ax_sprite sSpindaGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx27:
+.incbin "baserom.gba", 0x135A904, 0x40
+sSpindaGfx27_1:
+.incbin "baserom.gba", 0x135A944, 0x60
+sSpindaGfx27_2:
+.incbin "baserom.gba", 0x135A9A4, 0x60
+sSpindaGfx27_3:
+.incbin "baserom.gba", 0x135AA04, 0x60
+sSpindaSprites27:
+ax_sprite sSpindaGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx27_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx28:
+.incbin "baserom.gba", 0x135AAAC, 0x60
+sSpindaGfx28_1:
+.incbin "baserom.gba", 0x135AB0C, 0x60
+sSpindaGfx28_2:
+.incbin "baserom.gba", 0x135AB6C, 0x60
+sSpindaSprites28:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx29:
+.incbin "baserom.gba", 0x135AC0C, 0x60
+sSpindaGfx29_1:
+.incbin "baserom.gba", 0x135AC6C, 0x60
+sSpindaGfx29_2:
+.incbin "baserom.gba", 0x135ACCC, 0x60
+sSpindaSprites29:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx30:
+.incbin "baserom.gba", 0x135AD6C, 0x60
+sSpindaGfx30_1:
+.incbin "baserom.gba", 0x135ADCC, 0x60
+sSpindaGfx30_2:
+.incbin "baserom.gba", 0x135AE2C, 0x60
+sSpindaSprites30:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx31:
+.incbin "baserom.gba", 0x135AECC, 0x40
+sSpindaGfx31_1:
+.incbin "baserom.gba", 0x135AF0C, 0x60
+sSpindaGfx31_2:
+.incbin "baserom.gba", 0x135AF6C, 0x60
+sSpindaGfx31_3:
+.incbin "baserom.gba", 0x135AFCC, 0x60
+sSpindaSprites31:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx32:
+.incbin "baserom.gba", 0x135B07C, 0x60
+sSpindaGfx32_1:
+.incbin "baserom.gba", 0x135B0DC, 0x60
+sSpindaGfx32_2:
+.incbin "baserom.gba", 0x135B13C, 0x60
+sSpindaGfx32_3:
+.incbin "baserom.gba", 0x135B19C, 0x40
+sSpindaSprites32:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx33:
+.incbin "baserom.gba", 0x135B22C, 0x60
+sSpindaGfx33_1:
+.incbin "baserom.gba", 0x135B28C, 0x60
+sSpindaGfx33_2:
+.incbin "baserom.gba", 0x135B2EC, 0x60
+sSpindaSprites33:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx34:
+.incbin "baserom.gba", 0x135B38C, 0x20
+sSpindaGfx34_1:
+.incbin "baserom.gba", 0x135B3AC, 0x60
+sSpindaGfx34_2:
+.incbin "baserom.gba", 0x135B40C, 0x60
+sSpindaSprites34:
+ax_sprite 0, 0xe0
+ax_sprite sSpindaGfx34, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx34_2, 0x60
+ax_sprite_terminator
+sSpindaGfx35:
+.incbin "baserom.gba", 0x135B4A4, 0x40
+sSpindaGfx35_1:
+.incbin "baserom.gba", 0x135B4E4, 0x60
+sSpindaGfx35_2:
+.incbin "baserom.gba", 0x135B544, 0x60
+sSpindaSprites35:
+ax_sprite 0, 0xc0
+ax_sprite sSpindaGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx35_2, 0x60
+ax_sprite_terminator
+sSpindaGfx36:
+.incbin "baserom.gba", 0x135B5DC, 0x40
+sSpindaGfx36_1:
+.incbin "baserom.gba", 0x135B61C, 0x60
+sSpindaGfx36_2:
+.incbin "baserom.gba", 0x135B67C, 0x60
+sSpindaGfx36_3:
+.incbin "baserom.gba", 0x135B6DC, 0x40
+sSpindaSprites36:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx37:
+.incbin "baserom.gba", 0x135B76C, 0x60
+sSpindaGfx37_1:
+.incbin "baserom.gba", 0x135B7CC, 0x60
+sSpindaGfx37_2:
+.incbin "baserom.gba", 0x135B82C, 0x60
+sSpindaGfx37_3:
+.incbin "baserom.gba", 0x135B88C, 0x60
+sSpindaSprites37:
+ax_sprite sSpindaGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx38:
+.incbin "baserom.gba", 0x135B934, 0x40
+sSpindaGfx38_1:
+.incbin "baserom.gba", 0x135B974, 0x60
+sSpindaGfx38_2:
+.incbin "baserom.gba", 0x135B9D4, 0x60
+sSpindaGfx38_3:
+.incbin "baserom.gba", 0x135BA34, 0x40
+sSpindaSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx38_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx39:
+.incbin "baserom.gba", 0x135BAC4, 0x40
+sSpindaGfx39_1:
+.incbin "baserom.gba", 0x135BB04, 0x60
+sSpindaGfx39_2:
+.incbin "baserom.gba", 0x135BB64, 0x60
+sSpindaSprites39:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx40:
+.incbin "baserom.gba", 0x135BC04, 0x20
+sSpindaGfx40_1:
+.incbin "baserom.gba", 0x135BC24, 0x60
+sSpindaGfx40_2:
+.incbin "baserom.gba", 0x135BC84, 0x60
+sSpindaSprites40:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx40, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSpindaGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx41:
+.incbin "baserom.gba", 0x135BD24, 0x60
+sSpindaGfx41_1:
+.incbin "baserom.gba", 0x135BD84, 0x60
+sSpindaGfx41_2:
+.incbin "baserom.gba", 0x135BDE4, 0x60
+sSpindaSprites41:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx42:
+.incbin "baserom.gba", 0x135BE84, 0x60
+sSpindaGfx42_1:
+.incbin "baserom.gba", 0x135BEE4, 0x60
+sSpindaGfx42_2:
+.incbin "baserom.gba", 0x135BF44, 0x60
+sSpindaSprites42:
+ax_sprite 0, 0xa0
+ax_sprite sSpindaGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx42_2, 0x60
+ax_sprite_terminator
+sSpindaGfx43:
+.incbin "baserom.gba", 0x135BFDC, 0x20
+sSpindaGfx43_1:
+.incbin "baserom.gba", 0x135BFFC, 0x60
+sSpindaGfx43_2:
+.incbin "baserom.gba", 0x135C05C, 0x60
+sSpindaGfx43_3:
+.incbin "baserom.gba", 0x135C0BC, 0x60
+sSpindaSprites43:
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx43, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx43_3, 0x60
+ax_sprite_terminator
+sSpindaGfx44:
+.incbin "baserom.gba", 0x135C164, 0x60
+sSpindaGfx44_1:
+.incbin "baserom.gba", 0x135C1C4, 0x60
+sSpindaGfx44_2:
+.incbin "baserom.gba", 0x135C224, 0x60
+sSpindaGfx44_3:
+.incbin "baserom.gba", 0x135C284, 0x60
+sSpindaSprites44:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx44_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx44_3, 0x60
+ax_sprite_terminator
+sSpindaGfx45:
+.incbin "baserom.gba", 0x135C32C, 0x60
+sSpindaGfx45_1:
+.incbin "baserom.gba", 0x135C38C, 0x60
+sSpindaGfx45_2:
+.incbin "baserom.gba", 0x135C3EC, 0x60
+sSpindaGfx45_3:
+.incbin "baserom.gba", 0x135C44C, 0x60
+sSpindaSprites45:
+ax_sprite sSpindaGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx45_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx46:
+.incbin "baserom.gba", 0x135C4F4, 0x60
+sSpindaGfx46_1:
+.incbin "baserom.gba", 0x135C554, 0x60
+sSpindaGfx46_2:
+.incbin "baserom.gba", 0x135C5B4, 0x60
+sSpindaGfx46_3:
+.incbin "baserom.gba", 0x135C614, 0x60
+sSpindaSprites46:
+ax_sprite sSpindaGfx46, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx46_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx47:
+.incbin "baserom.gba", 0x135C6BC, 0x20
+sSpindaGfx47_1:
+.incbin "baserom.gba", 0x135C6DC, 0x60
+sSpindaGfx47_2:
+.incbin "baserom.gba", 0x135C73C, 0x60
+sSpindaGfx47_3:
+.incbin "baserom.gba", 0x135C79C, 0x60
+sSpindaSprites47:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx47, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx47_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx47_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx48:
+.incbin "baserom.gba", 0x135C84C, 0x60
+sSpindaGfx48_1:
+.incbin "baserom.gba", 0x135C8AC, 0x60
+sSpindaGfx48_2:
+.incbin "baserom.gba", 0x135C90C, 0x60
+sSpindaSprites48:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx49:
+.incbin "baserom.gba", 0x135C9AC, 0x60
+sSpindaGfx49_1:
+.incbin "baserom.gba", 0x135CA0C, 0x60
+sSpindaGfx49_2:
+.incbin "baserom.gba", 0x135CA6C, 0x60
+sSpindaSprites49:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx50:
+.incbin "baserom.gba", 0x135CB0C, 0x20
+sSpindaGfx50_1:
+.incbin "baserom.gba", 0x135CB2C, 0x60
+sSpindaGfx50_2:
+.incbin "baserom.gba", 0x135CB8C, 0x60
+sSpindaSprites50:
+ax_sprite 0, 0xe0
+ax_sprite sSpindaGfx50, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx50_2, 0x60
+ax_sprite_terminator
+sSpindaGfx51:
+.incbin "baserom.gba", 0x135CC24, 0x40
+sSpindaGfx51_1:
+.incbin "baserom.gba", 0x135CC64, 0x60
+sSpindaGfx51_2:
+.incbin "baserom.gba", 0x135CCC4, 0x60
+sSpindaSprites51:
+ax_sprite 0, 0xc0
+ax_sprite sSpindaGfx51, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx51_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx51_2, 0x60
+ax_sprite_terminator
+sSpindaGfx52:
+.incbin "baserom.gba", 0x135CD5C, 0x40
+sSpindaGfx52_1:
+.incbin "baserom.gba", 0x135CD9C, 0x60
+sSpindaGfx52_2:
+.incbin "baserom.gba", 0x135CDFC, 0x60
+sSpindaGfx52_3:
+.incbin "baserom.gba", 0x135CE5C, 0x60
+sSpindaSprites52:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx52, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx52_3, 0x60
+ax_sprite_terminator
+sSpindaGfx53:
+.incbin "baserom.gba", 0x135CF04, 0x60
+sSpindaGfx53_1:
+.incbin "baserom.gba", 0x135CF64, 0x60
+sSpindaGfx53_2:
+.incbin "baserom.gba", 0x135CFC4, 0x60
+sSpindaGfx53_3:
+.incbin "baserom.gba", 0x135D024, 0x60
+sSpindaSprites53:
+ax_sprite sSpindaGfx53, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx53_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx53_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx53_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx54:
+.incbin "baserom.gba", 0x135D0CC, 0x40
+sSpindaGfx54_1:
+.incbin "baserom.gba", 0x135D10C, 0x60
+sSpindaGfx54_2:
+.incbin "baserom.gba", 0x135D16C, 0x60
+sSpindaGfx54_3:
+.incbin "baserom.gba", 0x135D1CC, 0x60
+sSpindaSprites54:
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx54, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx54_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx54_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx55:
+.incbin "baserom.gba", 0x135D27C, 0x40
+sSpindaGfx55_1:
+.incbin "baserom.gba", 0x135D2BC, 0x60
+sSpindaGfx55_2:
+.incbin "baserom.gba", 0x135D31C, 0x60
+sSpindaSprites55:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx55, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpindaGfx55_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx55_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx56:
+.incbin "baserom.gba", 0x135D3BC, 0x20
+sSpindaGfx56_1:
+.incbin "baserom.gba", 0x135D3DC, 0x60
+sSpindaGfx56_2:
+.incbin "baserom.gba", 0x135D43C, 0x60
+sSpindaSprites56:
+ax_sprite 0, 0x80
+ax_sprite sSpindaGfx56, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSpindaGfx56_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSpindaGfx56_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpindaGfx57:
+.incbin "baserom.gba", 0x135D4DC, 0x200
+sSpindaSprites57:
+ax_sprite sSpindaGfx57, 0x200
+ax_sprite_terminator
+sSpindaGfx58:
+.incbin "baserom.gba", 0x135D6EC, 0x200
+sSpindaSprites58:
+ax_sprite sSpindaGfx58, 0x200
+ax_sprite_terminator
+sSpindaGfx59:
+.incbin "baserom.gba", 0x135D8FC, 0x200
+sSpindaSprites59:
+ax_sprite sSpindaGfx59, 0x200
+ax_sprite_terminator
+sSpindaGfx60:
+.incbin "baserom.gba", 0x135DB0C, 0x200
+sSpindaSprites60:
+ax_sprite sSpindaGfx60, 0x200
+ax_sprite_terminator
+sSpindaGfx61:
+.incbin "baserom.gba", 0x135DD1C, 0x200
+sSpindaSprites61:
+ax_sprite sSpindaGfx61, 0x200
+ax_sprite_terminator
+sSpindaGfx62:
+.incbin "baserom.gba", 0x135DF2C, 0x200
+sSpindaSprites62:
+ax_sprite sSpindaGfx62, 0x200
+ax_sprite_terminator
+sSpindaGfx63:
+.incbin "baserom.gba", 0x135E13C, 0x200
+sSpindaSprites63:
+ax_sprite sSpindaGfx63, 0x200
+ax_sprite_terminator
+sSpindaGfx64:
+.incbin "baserom.gba", 0x135E34C, 0x200
+sSpindaSprites64:
+ax_sprite sSpindaGfx64, 0x200
+ax_sprite_terminator
+sSpindaGfx65:
+.incbin "baserom.gba", 0x135E55C, 0x200
+sSpindaSprites65:
+ax_sprite sSpindaGfx65, 0x200
+ax_sprite_terminator
+sSpindaGfx66:
+.incbin "baserom.gba", 0x135E76C, 0x200
+sSpindaSprites66:
+ax_sprite sSpindaGfx66, 0x200
+ax_sprite_terminator
+sSpindaGfx67:
+.incbin "baserom.gba", 0x135E97C, 0x200
+sSpindaSprites67:
+ax_sprite sSpindaGfx67, 0x200
+ax_sprite_terminator
+sAxPosesSpinda:
+.4byte sSpindaPose1
+.4byte sSpindaPose2
+.4byte sSpindaPose3
+.4byte sSpindaPose4
+.4byte sSpindaPose5
+.4byte sSpindaPose6
+.4byte sSpindaPose7
+.4byte sSpindaPose8
+.4byte sSpindaPose9
+.4byte sSpindaPose10
+.4byte sSpindaPose11
+.4byte sSpindaPose12
+.4byte sSpindaPose13
+.4byte sSpindaPose14
+.4byte sSpindaPose15
+.4byte sSpindaPose16
+.4byte sSpindaPose17
+.4byte sSpindaPose18
+.4byte sSpindaPose19
+.4byte sSpindaPose20
+.4byte sSpindaPose21
+.4byte sSpindaPose22
+.4byte sSpindaPose23
+.4byte sSpindaPose24
+.4byte sSpindaPose25
+.4byte sSpindaPose26
+.4byte sSpindaPose27
+.4byte sSpindaPose28
+.4byte sSpindaPose29
+.4byte sSpindaPose30
+.4byte sSpindaPose31
+.4byte sSpindaPose32
+.4byte sSpindaPose33
+.4byte sSpindaPose34
+.4byte sSpindaPose35
+.4byte sSpindaPose36
+.4byte sSpindaPose37
+.4byte sSpindaPose38
+.4byte sSpindaPose39
+.4byte sSpindaPose40
+.4byte sSpindaPose41
+.4byte sSpindaPose42
+.4byte sSpindaPose43
+.4byte sSpindaPose44
+.4byte sSpindaPose45
+.4byte sSpindaPose46
+.4byte sSpindaPose47
+.4byte sSpindaPose48
+.4byte sSpindaPose49
+.4byte sSpindaPose50
+.4byte sSpindaPose51
+.4byte sSpindaPose52
+.4byte sSpindaPose53
+.4byte sSpindaPose54
+.4byte sSpindaPose55
+.4byte sSpindaPose56
+.4byte sSpindaPose57
+.4byte sSpindaPose58
+.4byte sSpindaPose59
+.4byte sSpindaPose60
+.4byte sSpindaPose61
+.4byte sSpindaPose62
+.4byte sSpindaPose63
+.4byte sSpindaPose64
+.4byte sSpindaPose65
+.4byte sSpindaPose66
+.4byte sSpindaPose67
+.4byte sSpindaPose68
+.4byte sSpindaPose69
+.4byte sSpindaPose70
+.4byte sSpindaPose71
+.4byte sSpindaPose72
+.4byte sSpindaPose73
+.4byte sSpindaPose74
+.4byte sSpindaPose75
+.4byte sSpindaPose76
+.4byte sSpindaPose77
+.4byte sSpindaPose78
+.4byte sSpindaPose79
+.4byte sSpindaPose80
+.4byte sSpindaPose81
+.4byte sSpindaPose82
+.4byte sSpindaPose83
+.4byte sSpindaPose84
+.4byte sSpindaPose85
+.4byte sSpindaPose86
+.4byte sSpindaPose87
+.4byte sSpindaPose88
+.4byte sSpindaPose89
+.4byte sSpindaPose90
+.4byte sSpindaPose91
+.4byte sSpindaPose92
+.4byte sSpindaPose93
+.4byte sSpindaPose94
+.4byte sSpindaPose95
+.4byte sSpindaPose96
+.4byte sSpindaPose97
+.4byte sSpindaPose98
+.4byte sSpindaPose99
+.4byte sSpindaPose100
+.4byte sSpindaPose101
+.4byte sSpindaPose102
+.4byte sSpindaPose103
+.4byte sSpindaPose104
+.4byte sSpindaPose105
+.4byte sSpindaPose106
+.4byte sSpindaPose107
+.4byte sSpindaPose108
+.4byte sSpindaPose109
+.4byte sSpindaPose110
+.4byte sSpindaPose111
+.4byte sSpindaPose112
+.4byte sSpindaPose113
+.4byte sSpindaPose114
+.4byte sSpindaPose115
+.4byte sSpindaPose116
+.4byte sSpindaPose117
+.4byte sSpindaPose118
+.4byte sSpindaPose119
+.4byte sSpindaPose120
+.4byte sSpindaPose121
+.4byte sSpindaPose122
+.4byte sSpindaPose123
+.4byte sSpindaPose124
+.4byte sSpindaPose125
+.4byte sSpindaPose126
+.4byte sSpindaPose127
+.4byte sSpindaPose128
+.4byte sSpindaPose129
+.4byte sSpindaPose130
+.4byte sSpindaPose131
+.4byte sSpindaPose132
+.4byte sSpindaPose133
+.4byte sSpindaPose134
+.4byte sSpindaPose135
+.4byte sSpindaPose136
+.4byte sSpindaPose137
+.4byte sSpindaPose138
+.4byte sSpindaPose139
+.4byte sSpindaPose140
+.4byte sSpindaPose141
+.4byte sSpindaPose142
+.4byte sSpindaPose143
+.4byte sSpindaPose144
+.4byte sSpindaPose145
+.4byte sSpindaPose146
+.4byte sSpindaPose147
+.4byte sSpindaPose148
+.4byte sSpindaPose149
+.4byte sSpindaPose150
+.4byte sSpindaPose151
+.4byte sSpindaPose152
+.4byte sSpindaPose153
+.4byte sSpindaPose154
+.4byte sSpindaPose155
+.4byte sSpindaPose156
+.4byte sSpindaPose157
+.4byte sSpindaPose158
+.4byte sSpindaPose159
+.4byte sSpindaPose160
+.4byte sSpindaPose161
+.4byte sSpindaPose162
+.4byte sSpindaPose163
+.4byte sSpindaPose164
+.4byte sSpindaPose165
+.4byte sSpindaPose166
+.4byte sSpindaPose167
+.4byte sSpindaPose168
+.4byte sSpindaPose169
+.4byte sSpindaPose170
+.4byte sSpindaPose171
+.4byte sSpindaPose172
+.4byte sSpindaPose173
+.4byte sSpindaPose174
+.4byte sSpindaPose175
+.4byte sSpindaPose176
+.4byte sSpindaPose177
+.4byte sSpindaPose178
+.4byte sSpindaPose179
+.4byte sSpindaPose180
+.4byte sSpindaPose181
+.4byte sSpindaPose182
+.4byte sSpindaPose183
+.4byte sSpindaPose184
+.4byte sSpindaPose185
+.4byte sSpindaPose186
+.4byte sSpindaPose187
+.4byte sSpindaPose188
+.4byte sSpindaPose189
+.4byte sSpindaPose190
+.4byte sSpindaPose191
+.4byte sSpindaPose192
+.4byte sSpindaPose193
+.4byte sSpindaPose194
+.4byte sSpindaPose195
+.4byte sSpindaPose196
+.4byte sSpindaPose197
+.4byte sSpindaPose198
+.4byte sSpindaPose199
+.4byte sSpindaPose200
+.4byte sSpindaPose201
+.4byte sSpindaPose202
+.4byte sSpindaPose203
+.4byte sSpindaPose204
+.4byte sSpindaPose205
+.4byte sSpindaPose206
+.4byte sSpindaPose207
+.4byte sSpindaPose208
+.4byte sSpindaPose209
+.4byte sSpindaPose210
+.4byte sSpindaPose211
+.4byte sSpindaPose212
+.4byte sSpindaPose213
+.4byte sSpindaPose214
+.4byte sSpindaPose215
+.4byte sSpindaPose216
+.4byte sSpindaPose217
+.4byte sSpindaPose218
+.4byte sSpindaPose219
+.4byte sSpindaPose220
+.4byte sSpindaPose221
+.4byte sSpindaPose222
+.4byte sSpindaPose223
+.4byte sSpindaPose224
+.4byte sSpindaPose225
+.4byte sSpindaPose226
+.4byte sSpindaPose227
+.4byte sSpindaPose228
+.4byte sSpindaPose229
+.4byte sSpindaPose230
+.4byte sSpindaPose231
+.4byte sSpindaPose232
+.4byte sSpindaPose233
+.4byte sSpindaPose234
+.4byte sSpindaPose235
+.4byte sSpindaPose236
+.4byte sSpindaPose237
+.4byte sSpindaPose238
+.4byte sSpindaPose239
+.4byte sSpindaPose240
+.4byte sSpindaPose241
+.4byte sSpindaPose242
+.4byte sSpindaPose243
+.4byte sSpindaPose244
+.4byte sSpindaPose245
+.4byte sSpindaPose246
+.4byte sSpindaPose247
+.4byte sSpindaPose248
+.4byte sSpindaPose249
+.4byte sSpindaPose250
+.4byte sSpindaPose251
+.4byte sSpindaPose252
+.4byte sSpindaPose253
+.4byte sSpindaPose254
+.4byte sSpindaPose255
+.4byte sSpindaPose256
+.4byte sSpindaPose257
+sAxPositionsSpinda:
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -2,   -7, 	  -8,   -8, 	   7,   -3, 	   0,   -6
+.2byte    1,   -7, 	  -8,   -4, 	   7,   -8, 	   0,   -6
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    5,   -9, 	  -1,   -3, 	   3,   -6, 	   1,   -6
+.2byte    3,   -8, 	  -8,   -7, 	   7,   -6, 	   1,   -6
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -5
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -5
+.2byte    4,   -7, 	  -4,   -1, 	   4,   -5, 	   0,   -5
+.2byte    3,   -8, 	  -8,   -7, 	   7,   -6, 	   1,   -6
+.2byte    6,  -12, 	  10,   -9, 	  -3,   -6, 	   3,   -8
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   6,   -6, 	  -7,   -3, 	  -1,   -5
+.2byte    2,   -9, 	   4,   -1, 	  -3,   -4, 	  -2,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte   -1,  -11, 	   7,   -7, 	  -8,   -1, 	   0,   -5
+.2byte    0,  -11, 	   7,   -2, 	  -8,   -7, 	  -1,   -5
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -9, 	   1,   -4, 	  -5,   -1, 	   1,   -5
+.2byte   -3,   -8, 	   6,   -3, 	  -8,   -6, 	   1,   -5
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -4, 	   3,   -1, 	   0,   -6
+.2byte   -5,   -7, 	   2,   -4, 	  -3,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -7, 	   7,   -7, 	  -1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -8,   -9, 	   1,   -8
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -4,   -7, 	  -8,   -6, 	   7,   -6, 	  -1,   -5
+.2byte   -5,   -8, 	  -1,   -6, 	   1,   -2, 	   0,   -5
+.2byte   -5,   -7, 	   2,   -4, 	  -3,   -6, 	   0,   -6
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -2,   -7, 	  -8,   -8, 	   7,   -3, 	   0,   -6
+.2byte    1,   -7, 	  -8,   -4, 	   7,   -8, 	   0,   -6
+.2byte   -2,  -10, 	  -8,   -9, 	   7,   -8, 	  -1,   -7
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    5,   -9, 	  -1,   -3, 	   3,   -6, 	   1,   -6
+.2byte    3,   -8, 	  -8,   -7, 	   7,   -6, 	   1,   -6
+.2byte    1,  -12, 	  -8,   -7, 	   3,   -8, 	   0,   -8
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -5
+.2byte    4,   -7, 	  -4,   -1, 	   4,   -5, 	   0,   -5
+.2byte    2,  -11, 	  -3,   -4, 	  -5,   -5, 	   0,   -6
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   6,   -6, 	  -7,   -3, 	  -1,   -5
+.2byte    2,   -9, 	   4,   -1, 	  -3,   -4, 	  -2,   -5
+.2byte    0,  -11, 	   5,   -3, 	 -10,  -10, 	  -2,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte   -1,  -11, 	   7,   -7, 	  -8,   -1, 	   0,   -5
+.2byte    0,  -11, 	   7,   -2, 	  -8,   -7, 	  -1,   -5
+.2byte    0,  -10, 	   7,   -6, 	  -8,   -7, 	   0,   -5
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -9, 	   1,   -4, 	  -5,   -1, 	   1,   -5
+.2byte   -3,   -8, 	   6,   -3, 	  -8,   -6, 	   1,   -5
+.2byte   -1,  -11, 	   9,   -9, 	  -6,   -3, 	   2,   -5
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -4, 	   3,   -1, 	   0,   -6
+.2byte   -5,   -7, 	   2,   -4, 	  -3,   -6, 	   0,   -6
+.2byte   -3,  -11, 	   4,   -5, 	   2,   -4, 	   0,   -6
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -4,   -7, 	  -8,   -6, 	   7,   -6, 	  -1,   -5
+.2byte   -5,   -8, 	  -1,   -6, 	   1,   -2, 	   0,   -5
+.2byte   -2,  -11, 	  -4,   -9, 	   7,   -6, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -2,   -7, 	  -8,   -8, 	   7,   -3, 	   0,   -6
+.2byte    1,   -7, 	  -8,   -4, 	   7,   -8, 	   0,   -6
+.2byte   -2,  -10, 	  -8,   -9, 	   7,   -8, 	  -1,   -7
+.2byte    0,    1, 	  -9,   -5, 	   6,   -5, 	  -1,   -4
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    5,   -9, 	  -1,   -3, 	   3,   -6, 	   1,   -6
+.2byte    3,   -8, 	  -8,   -7, 	   7,   -6, 	   1,   -6
+.2byte    1,  -12, 	  -8,   -7, 	   3,   -8, 	   0,   -8
+.2byte    6,   -2, 	  -5,   -5, 	   5,   -8, 	   1,   -4
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -5
+.2byte    4,   -7, 	  -4,   -1, 	   4,   -5, 	   0,   -5
+.2byte    2,  -11, 	  -3,   -4, 	  -5,   -5, 	   0,   -6
+.2byte    8,   -4, 	  -4,   -4, 	  -3,  -11, 	   0,   -6
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   6,   -6, 	  -7,   -3, 	  -1,   -5
+.2byte    2,   -9, 	   4,   -1, 	  -3,   -4, 	  -2,   -5
+.2byte    0,  -11, 	   5,   -3, 	 -10,  -10, 	  -2,   -5
+.2byte    5,  -10, 	   0,   -2, 	  -7,   -7, 	  -1,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte   -1,  -11, 	   7,   -7, 	  -8,   -1, 	   0,   -5
+.2byte    0,  -11, 	   7,   -2, 	  -8,   -7, 	  -1,   -5
+.2byte    0,  -10, 	   7,   -6, 	  -8,   -7, 	   0,   -5
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -9, 	   1,   -4, 	  -5,   -1, 	   1,   -5
+.2byte   -3,   -8, 	   6,   -3, 	  -8,   -6, 	   1,   -5
+.2byte   -1,  -11, 	   9,   -9, 	  -6,   -3, 	   2,   -5
+.2byte   -5,   -9, 	   6,   -8, 	  -1,   -2, 	   0,   -7
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -4, 	   3,   -1, 	   0,   -6
+.2byte   -5,   -7, 	   2,   -4, 	  -3,   -6, 	   0,   -6
+.2byte   -3,  -11, 	   4,   -5, 	   2,   -4, 	   0,   -6
+.2byte   -7,   -3, 	   3,  -11, 	   3,   -4, 	  -1,   -6
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -4,   -7, 	  -8,   -6, 	   7,   -6, 	  -1,   -5
+.2byte   -5,   -8, 	  -1,   -6, 	   1,   -2, 	   0,   -5
+.2byte   -2,  -11, 	  -4,   -9, 	   7,   -6, 	   0,   -8
+.2byte   -6,   -1, 	  -4,   -7, 	   4,   -5, 	  -3,   -4
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -2,  -10, 	  -8,   -9, 	   7,   -8, 	  -1,   -7
+.2byte    0,    0, 	  -9,   -7, 	   8,   -4, 	  -1,   -4
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    1,  -12, 	  -8,   -7, 	   3,   -8, 	   0,   -8
+.2byte    7,   -2, 	  -5,    0, 	   5,   -7, 	  -1,   -4
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    2,  -11, 	  -3,   -4, 	  -5,   -5, 	   0,   -6
+.2byte    9,   -4, 	   0,    0, 	  -5,  -12, 	  -1,   -7
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    0,  -11, 	   5,   -3, 	 -10,  -10, 	  -2,   -5
+.2byte    6,   -9, 	   5,   -1, 	  -7,   -9, 	  -1,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte    0,  -10, 	   7,   -6, 	  -8,   -7, 	   0,   -5
+.2byte    0,  -13, 	   7,   -9, 	  -9,   -6, 	  -1,   -7
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -1,  -11, 	   9,   -9, 	  -6,   -3, 	   2,   -5
+.2byte   -7,   -8, 	   5,   -8, 	  -6,   -1, 	   0,   -6
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -3,  -11, 	   4,   -5, 	   2,   -4, 	   0,   -6
+.2byte   -9,   -4, 	   3,  -12, 	   0,    0, 	   1,   -6
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -2,  -11, 	  -4,   -9, 	   7,   -6, 	   0,   -8
+.2byte   -8,   -2, 	  -3,   -3, 	   5,    0, 	  -1,   -4
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -2,   -7, 	  -8,   -8, 	   7,   -3, 	   0,   -6
+.2byte    1,   -7, 	  -8,   -4, 	   7,   -8, 	   0,   -6
+.2byte    1,   -1, 	  -4,    0, 	   7,   -7, 	   1,   -5
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    5,   -9, 	  -1,   -3, 	   3,   -6, 	   1,   -6
+.2byte    3,   -8, 	  -8,   -7, 	   7,   -6, 	   1,   -6
+.2byte    7,   -2, 	   0,    1, 	   5,   -6, 	   1,   -4
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -5
+.2byte    4,   -7, 	  -4,   -1, 	   4,   -5, 	   0,   -5
+.2byte   11,   -4, 	   5,   -1, 	   4,   -5, 	   2,   -6
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   6,   -6, 	  -7,   -3, 	  -1,   -5
+.2byte    2,   -9, 	   4,   -1, 	  -3,   -4, 	  -2,   -5
+.2byte    4,  -10, 	   5,   -1, 	  -2,   -5, 	  -1,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte   -1,  -11, 	   7,   -7, 	  -8,   -1, 	   0,   -5
+.2byte    0,  -11, 	   7,   -2, 	  -8,   -7, 	  -1,   -5
+.2byte    0,  -14, 	   4,   -6, 	  -6,   -7, 	   0,   -7
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -3,   -9, 	   1,   -4, 	  -5,   -1, 	   1,   -5
+.2byte   -3,   -8, 	   6,   -3, 	  -8,   -6, 	   1,   -5
+.2byte   -5,   -8, 	   2,   -5, 	  -6,   -1, 	   0,   -6
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -4, 	   3,   -1, 	   0,   -6
+.2byte   -5,   -7, 	   2,   -4, 	  -3,   -6, 	   0,   -6
+.2byte  -10,   -3, 	  -6,   -4, 	  -5,   -1, 	  -2,   -6
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -4,   -7, 	  -8,   -6, 	   7,   -6, 	  -1,   -5
+.2byte   -5,   -8, 	  -1,   -6, 	   1,   -2, 	   0,   -5
+.2byte   -7,   -1, 	  -7,   -3, 	  -1,    1, 	  -3,   -4
+.2byte    0,   -6, 	  -6,   -6, 	   2,    2, 	  -2,   -3
+.2byte    0,   -5, 	  -6,   -6, 	   2,    2, 	  -2,   -3
+.2byte   -1,  -11, 	  -7,   -9, 	   7,   -9, 	   0,   -9
+.2byte   -2,  -10, 	  -8,   -3, 	   4,  -13, 	  -1,   -8
+.2byte    1,  -11, 	  -5,   -7, 	  -2,   -9, 	   0,   -8
+.2byte    1,  -13, 	  -6,   -8, 	   6,   -7, 	  -1,   -5
+.2byte    0,   -9, 	   8,   -8, 	  -9,   -8, 	   0,   -5
+.2byte   -2,  -13, 	   5,   -8, 	  -7,   -7, 	   0,   -5
+.2byte   -3,  -12, 	   1,   -8, 	   3,   -6, 	  -1,   -8
+.2byte    1,  -10, 	  -5,  -13, 	   7,   -2, 	   0,   -8
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -2,   -7, 	  -8,   -8, 	   7,   -3, 	   0,   -6
+.2byte    1,   -7, 	  -8,   -4, 	   7,   -8, 	   0,   -6
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    5,   -9, 	  -1,   -3, 	   3,   -6, 	   1,   -6
+.2byte    3,   -8, 	  -8,   -7, 	   7,   -6, 	   1,   -6
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -5
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    4,   -7, 	   2,   -6, 	  -2,   -3, 	   0,   -5
+.2byte    4,   -7, 	  -4,   -1, 	   4,   -5, 	   0,   -5
+.2byte    3,   -8, 	  -8,   -7, 	   7,   -6, 	   1,   -6
+.2byte    3,  -12, 	   7,   -9, 	  -6,   -6, 	   0,   -8
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    3,  -10, 	   7,   -7, 	  -6,   -4, 	   0,   -6
+.2byte    2,   -9, 	   4,   -1, 	  -3,   -4, 	  -2,   -5
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -8, 	  -8,   -2, 	   0,   -6
+.2byte    0,  -12, 	   7,   -3, 	  -8,   -8, 	  -1,   -6
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -4,   -9, 	   5,   -4, 	  -9,   -7, 	   0,   -6
+.2byte   -3,   -9, 	   1,   -4, 	  -5,   -1, 	   1,   -5
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -5,   -8, 	  -5,   -4, 	   3,   -1, 	   0,   -6
+.2byte   -5,   -7, 	   2,   -4, 	  -3,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -8,   -7, 	   7,   -7, 	  -1,   -6
+.2byte   -3,  -11, 	   6,   -6, 	  -8,   -9, 	   1,   -8
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -4,   -7, 	  -8,   -6, 	   7,   -6, 	  -1,   -5
+.2byte   -5,   -8, 	  -1,   -6, 	   1,   -2, 	   0,   -5
+.2byte   -5,   -7, 	   2,   -4, 	  -3,   -6, 	   0,   -6
+.2byte    0,    0, 	  -9,   -7, 	   8,   -4, 	  -1,   -4
+.2byte   -9,   -2, 	  -4,   -3, 	   4,    0, 	  -2,   -4
+.2byte  -10,   -4, 	   2,  -12, 	  -1,    0, 	   0,   -6
+.2byte   -8,   -8, 	   4,   -8, 	  -7,   -1, 	  -1,   -6
+.2byte    0,  -11, 	   7,   -7, 	  -9,   -4, 	  -1,   -5
+.2byte    7,   -9, 	   6,   -1, 	  -6,   -9, 	   0,   -5
+.2byte   10,   -4, 	   1,    0, 	  -4,  -12, 	   0,   -7
+.2byte    8,   -2, 	  -4,    0, 	   6,   -7, 	   0,   -4
+.2byte   -2,  -10, 	  -8,   -9, 	   7,   -8, 	  -1,   -7
+.2byte    2,  -12, 	  -7,   -7, 	   4,   -8, 	   1,   -8
+.2byte    3,  -11, 	  -2,   -4, 	  -4,   -5, 	   1,   -6
+.2byte    1,  -11, 	   6,   -3, 	  -9,  -10, 	  -1,   -5
+.2byte    0,  -10, 	   7,   -6, 	  -8,   -7, 	   0,   -5
+.2byte   -2,  -11, 	   8,   -9, 	  -7,   -3, 	   1,   -5
+.2byte   -4,  -11, 	   3,   -5, 	   1,   -4, 	  -1,   -6
+.2byte   -3,  -11, 	  -5,   -9, 	   6,   -6, 	  -1,   -8
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -2,  -10, 	  -8,   -9, 	   7,   -8, 	  -1,   -7
+.2byte    0,   -1, 	  -9,   -7, 	   6,   -7, 	  -1,   -6
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    3,  -12, 	  -6,   -7, 	   5,   -8, 	   2,   -8
+.2byte    5,   -2, 	  -6,   -5, 	   4,   -8, 	   0,   -4
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    2,  -11, 	  -3,   -4, 	  -5,   -5, 	   0,   -6
+.2byte    7,   -4, 	  -5,   -4, 	  -4,  -11, 	  -1,   -6
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    1,  -11, 	   6,   -3, 	  -9,  -10, 	  -1,   -5
+.2byte    4,  -10, 	  -1,   -2, 	  -8,   -7, 	  -2,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte    0,  -10, 	   7,   -6, 	  -8,   -7, 	   0,   -5
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	   0,   -8
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -2,  -11, 	   8,   -9, 	  -7,   -3, 	   1,   -5
+.2byte   -4,   -9, 	   7,   -8, 	   0,   -2, 	   1,   -7
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -3,  -11, 	   4,   -5, 	   2,   -4, 	   0,   -6
+.2byte   -4,   -3, 	   6,  -11, 	   6,   -4, 	   2,   -6
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -4,  -11, 	  -6,   -9, 	   5,   -6, 	  -2,   -8
+.2byte   -5,   -1, 	  -3,   -7, 	   5,   -5, 	  -2,   -4
+.2byte    0,    0, 	  -9,   -7, 	   8,   -4, 	  -1,   -4
+.2byte   -7,   -2, 	  -2,   -3, 	   6,    0, 	   0,   -4
+.2byte   -8,   -4, 	   4,  -12, 	   1,    0, 	   2,   -6
+.2byte   -7,   -8, 	   5,   -8, 	  -6,   -1, 	   0,   -6
+.2byte    0,  -12, 	   7,   -8, 	  -9,   -5, 	  -1,   -6
+.2byte    6,   -9, 	   5,   -1, 	  -7,   -9, 	  -1,   -5
+.2byte    8,   -4, 	  -1,    0, 	  -6,  -12, 	  -2,   -7
+.2byte    6,   -2, 	  -6,    0, 	   4,   -7, 	  -2,   -4
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -5,   -9, 	  -7,   -8, 	   5,   -4, 	  -2,   -6
+.2byte   -6,   -9, 	   0,   -5, 	   0,   -3, 	   0,   -7
+.2byte   -3,  -10, 	   5,   -6, 	  -6,   -3, 	   0,   -6
+.2byte   -1,  -12, 	   7,   -4, 	  -8,   -4, 	   0,   -6
+.2byte    2,  -10, 	   4,   -3, 	  -6,   -5, 	  -1,   -6
+.2byte    4,   -8, 	  -2,   -3, 	  -1,   -5, 	   0,   -6
+.2byte    4,   -8, 	  -6,   -4, 	   6,   -7, 	   1,   -6
+.2byte    0,   -7, 	  -8,   -5, 	   7,   -5, 	  -1,   -6
+.2byte   -1,    0, 	  -8,  -10, 	   7,    1, 	   1,   -5
+.2byte    0,    3, 	  -9,    0, 	   8,    0, 	   0,   -2
+sSpindaAnimTable1:
+.4byte sSpindaAnims_1_1
+.4byte sSpindaAnims_1_2
+.4byte sSpindaAnims_1_3
+.4byte sSpindaAnims_1_4
+.4byte sSpindaAnims_1_5
+.4byte sSpindaAnims_1_6
+.4byte sSpindaAnims_1_7
+.4byte sSpindaAnims_1_8
+sSpindaAnimTable2:
+.4byte sSpindaAnims_2_1
+.4byte sSpindaAnims_2_2
+.4byte sSpindaAnims_2_3
+.4byte sSpindaAnims_2_4
+.4byte sSpindaAnims_2_5
+.4byte sSpindaAnims_2_6
+.4byte sSpindaAnims_2_7
+.4byte sSpindaAnims_2_8
+sSpindaAnimTable3:
+.4byte sSpindaAnims_3_1
+.4byte sSpindaAnims_3_2
+.4byte sSpindaAnims_3_3
+.4byte sSpindaAnims_3_4
+.4byte sSpindaAnims_3_5
+.4byte sSpindaAnims_3_6
+.4byte sSpindaAnims_3_7
+.4byte sSpindaAnims_3_8
+sSpindaAnimTable4:
+.4byte sSpindaAnims_4_1
+.4byte sSpindaAnims_4_2
+.4byte sSpindaAnims_4_3
+.4byte sSpindaAnims_4_4
+.4byte sSpindaAnims_4_5
+.4byte sSpindaAnims_4_6
+.4byte sSpindaAnims_4_7
+.4byte sSpindaAnims_4_8
+sSpindaAnimTable5:
+.4byte sSpindaAnims_5_1
+.4byte sSpindaAnims_5_2
+.4byte sSpindaAnims_5_3
+.4byte sSpindaAnims_5_4
+.4byte sSpindaAnims_5_5
+.4byte sSpindaAnims_5_6
+.4byte sSpindaAnims_5_7
+.4byte sSpindaAnims_5_8
+sSpindaAnimTable6:
+.4byte sSpindaAnims_6_1
+.4byte sSpindaAnims_6_1
+.4byte sSpindaAnims_6_1
+.4byte sSpindaAnims_6_1
+.4byte sSpindaAnims_6_1
+.4byte sSpindaAnims_6_1
+.4byte sSpindaAnims_6_1
+.4byte sSpindaAnims_6_1
+sSpindaAnimTable7:
+.4byte sSpindaAnims_7_1
+.4byte sSpindaAnims_7_2
+.4byte sSpindaAnims_7_3
+.4byte sSpindaAnims_7_4
+.4byte sSpindaAnims_7_5
+.4byte sSpindaAnims_7_6
+.4byte sSpindaAnims_7_7
+.4byte sSpindaAnims_7_8
+sSpindaAnimTable8:
+.4byte sSpindaAnims_8_1
+.4byte sSpindaAnims_8_2
+.4byte sSpindaAnims_8_3
+.4byte sSpindaAnims_8_4
+.4byte sSpindaAnims_8_5
+.4byte sSpindaAnims_8_6
+.4byte sSpindaAnims_8_7
+.4byte sSpindaAnims_8_8
+sSpindaAnimTable9:
+.4byte sSpindaAnims_9_1
+.4byte sSpindaAnims_9_2
+.4byte sSpindaAnims_9_3
+.4byte sSpindaAnims_9_4
+.4byte sSpindaAnims_9_5
+.4byte sSpindaAnims_9_6
+.4byte sSpindaAnims_9_7
+.4byte sSpindaAnims_9_8
+sSpindaAnimTable10:
+.4byte sSpindaAnims_10_1
+.4byte sSpindaAnims_10_2
+.4byte sSpindaAnims_10_3
+.4byte sSpindaAnims_10_4
+.4byte sSpindaAnims_10_5
+.4byte sSpindaAnims_10_6
+.4byte sSpindaAnims_10_7
+.4byte sSpindaAnims_10_8
+sSpindaAnimTable11:
+.4byte sSpindaAnims_11_1
+.4byte sSpindaAnims_11_2
+.4byte sSpindaAnims_11_3
+.4byte sSpindaAnims_11_4
+.4byte sSpindaAnims_11_5
+.4byte sSpindaAnims_11_6
+.4byte sSpindaAnims_11_7
+.4byte sSpindaAnims_11_8
+sSpindaAnimTable12:
+.4byte sSpindaAnims_12_1
+.4byte sSpindaAnims_12_2
+.4byte sSpindaAnims_12_3
+.4byte sSpindaAnims_12_4
+.4byte sSpindaAnims_12_5
+.4byte sSpindaAnims_12_6
+.4byte sSpindaAnims_12_7
+.4byte sSpindaAnims_12_8
+sSpindaAnimTable13:
+.4byte sSpindaAnims_13_1
+.4byte sSpindaAnims_13_2
+.4byte sSpindaAnims_13_3
+.4byte sSpindaAnims_13_4
+.4byte sSpindaAnims_13_5
+.4byte sSpindaAnims_13_6
+.4byte sSpindaAnims_13_7
+.4byte sSpindaAnims_13_8
+sSpindaAnimTable14:
+.4byte sSpindaAnims_14_1
+.4byte sSpindaAnims_14_2
+.4byte sSpindaAnims_14_3
+.4byte sSpindaAnims_14_4
+.4byte sSpindaAnims_14_5
+.4byte sSpindaAnims_14_6
+.4byte sSpindaAnims_14_7
+.4byte sSpindaAnims_14_8
+sAxAnimationsSpinda:
+.4byte sSpindaAnimTable1
+.4byte sSpindaAnimTable2
+.4byte sSpindaAnimTable3
+.4byte sSpindaAnimTable4
+.4byte sSpindaAnimTable5
+.4byte sSpindaAnimTable6
+.4byte sSpindaAnimTable7
+.4byte sSpindaAnimTable8
+.4byte sSpindaAnimTable9
+.4byte sSpindaAnimTable10
+.4byte sSpindaAnimTable11
+.4byte sSpindaAnimTable12
+.4byte sSpindaAnimTable13
+.4byte sSpindaAnimTable14
+sAxSpritesSpinda:
+.4byte sSpindaSprites1
+.4byte sSpindaSprites2
+.4byte sSpindaSprites3
+.4byte sSpindaSprites4
+.4byte sSpindaSprites5
+.4byte sSpindaSprites6
+.4byte sSpindaSprites7
+.4byte sSpindaSprites8
+.4byte sSpindaSprites9
+.4byte sSpindaSprites10
+.4byte sSpindaSprites11
+.4byte sSpindaSprites12
+.4byte sSpindaSprites13
+.4byte sSpindaSprites14
+.4byte sSpindaSprites15
+.4byte sSpindaSprites16
+.4byte sSpindaSprites17
+.4byte sSpindaSprites18
+.4byte sSpindaSprites19
+.4byte sSpindaSprites20
+.4byte sSpindaSprites21
+.4byte sSpindaSprites22
+.4byte sSpindaSprites23
+.4byte sSpindaSprites24
+.4byte sSpindaSprites25
+.4byte sSpindaSprites26
+.4byte sSpindaSprites27
+.4byte sSpindaSprites28
+.4byte sSpindaSprites29
+.4byte sSpindaSprites30
+.4byte sSpindaSprites31
+.4byte sSpindaSprites32
+.4byte sSpindaSprites33
+.4byte sSpindaSprites34
+.4byte sSpindaSprites35
+.4byte sSpindaSprites36
+.4byte sSpindaSprites37
+.4byte sSpindaSprites38
+.4byte sSpindaSprites39
+.4byte sSpindaSprites40
+.4byte sSpindaSprites41
+.4byte sSpindaSprites42
+.4byte sSpindaSprites43
+.4byte sSpindaSprites44
+.4byte sSpindaSprites45
+.4byte sSpindaSprites46
+.4byte sSpindaSprites47
+.4byte sSpindaSprites48
+.4byte sSpindaSprites49
+.4byte sSpindaSprites50
+.4byte sSpindaSprites51
+.4byte sSpindaSprites52
+.4byte sSpindaSprites53
+.4byte sSpindaSprites54
+.4byte sSpindaSprites55
+.4byte sSpindaSprites56
+.4byte sSpindaSprites57
+.4byte sSpindaSprites58
+.4byte sSpindaSprites59
+.4byte sSpindaSprites60
+.4byte sSpindaSprites61
+.4byte sSpindaSprites62
+.4byte sSpindaSprites63
+.4byte sSpindaSprites64
+.4byte sSpindaSprites65
+.4byte sSpindaSprites66
+.4byte sSpindaSprites67
+sAxMainSpinda:
+ax_main sAxPosesSpinda, sAxAnimationsSpinda, 14, sAxSpritesSpinda, sAxPositionsSpinda

--- a/data/ax/spoink.inc
+++ b/data/ax/spoink.inc
@@ -1,0 +1,2974 @@
+.global gAxSpoink
+gAxSpoink:
+ax_siro sAxMainSpoink
+sSpoinkPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose4:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose5:
+ax_pose 4, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose6:
+ax_pose 5, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose7:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose8:
+ax_pose 7, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose9:
+ax_pose 8, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose10:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose11:
+ax_pose 10, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose12:
+ax_pose 11, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose16:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose17:
+ax_pose 10, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose18:
+ax_pose 11, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose19:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose20:
+ax_pose 7, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose21:
+ax_pose 8, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose22:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose23:
+ax_pose 4, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose24:
+ax_pose 5, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose28:
+ax_pose 15, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose29:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose30:
+ax_pose 4, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose31:
+ax_pose 5, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose32:
+ax_pose 16, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose33:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose34:
+ax_pose 7, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose35:
+ax_pose 8, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose36:
+ax_pose 17, 0x81e4, 0x90fa, 0xac00
+ax_pose_terminator
+sSpoinkPose37:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose38:
+ax_pose 10, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose39:
+ax_pose 11, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose40:
+ax_pose 18, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose41:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose42:
+ax_pose 13, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose43:
+ax_pose 14, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose44:
+ax_pose 19, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose45:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose46:
+ax_pose 10, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose47:
+ax_pose 11, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose48:
+ax_pose 18, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose49:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose50:
+ax_pose 7, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose51:
+ax_pose 8, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose52:
+ax_pose 17, 0x81e4, 0x80f6, 0xac00
+ax_pose_terminator
+sSpoinkPose53:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose54:
+ax_pose 4, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose55:
+ax_pose 5, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose56:
+ax_pose 16, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose57:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose58:
+ax_pose 1, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose59:
+ax_pose 2, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose60:
+ax_pose 15, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose61:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose62:
+ax_pose 4, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose63:
+ax_pose 5, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose64:
+ax_pose 16, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose65:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose66:
+ax_pose 7, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose67:
+ax_pose 8, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose68:
+ax_pose 17, 0x81e4, 0x90fa, 0xac00
+ax_pose_terminator
+sSpoinkPose69:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose70:
+ax_pose 10, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose71:
+ax_pose 11, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose72:
+ax_pose 18, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose73:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose74:
+ax_pose 13, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose75:
+ax_pose 14, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose76:
+ax_pose 19, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose77:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose78:
+ax_pose 10, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose79:
+ax_pose 11, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose80:
+ax_pose 18, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose81:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose82:
+ax_pose 7, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose83:
+ax_pose 8, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose84:
+ax_pose 17, 0x81e4, 0x80f6, 0xac00
+ax_pose_terminator
+sSpoinkPose85:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose86:
+ax_pose 4, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose87:
+ax_pose 5, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose88:
+ax_pose 16, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose89:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose90:
+ax_pose 1, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose91:
+ax_pose 2, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose92:
+ax_pose 15, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose93:
+ax_pose 20, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose94:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose95:
+ax_pose 4, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose96:
+ax_pose 5, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose97:
+ax_pose 16, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose98:
+ax_pose 21, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose99:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose100:
+ax_pose 7, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose101:
+ax_pose 8, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose102:
+ax_pose 17, 0x81e4, 0x90fa, 0xac00
+ax_pose_terminator
+sSpoinkPose103:
+ax_pose 22, 0x81e4, 0x90fa, 0xac00
+ax_pose_terminator
+sSpoinkPose104:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose105:
+ax_pose 10, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose106:
+ax_pose 11, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose107:
+ax_pose 18, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose108:
+ax_pose 23, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose109:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose110:
+ax_pose 13, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose111:
+ax_pose 14, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose112:
+ax_pose 19, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose113:
+ax_pose 24, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose114:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose115:
+ax_pose 10, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose116:
+ax_pose 11, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose117:
+ax_pose 18, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose118:
+ax_pose 23, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose119:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose120:
+ax_pose 7, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose121:
+ax_pose 8, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose122:
+ax_pose 17, 0x81e4, 0x80f6, 0xac00
+ax_pose_terminator
+sSpoinkPose123:
+ax_pose 22, 0x81e4, 0x80f6, 0xac00
+ax_pose_terminator
+sSpoinkPose124:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose125:
+ax_pose 4, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose126:
+ax_pose 5, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose127:
+ax_pose 16, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose128:
+ax_pose 21, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose129:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose130:
+ax_pose 1, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose131:
+ax_pose 2, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose132:
+ax_pose 25, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose133:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose134:
+ax_pose 4, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose135:
+ax_pose 5, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose136:
+ax_pose 26, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose137:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose138:
+ax_pose 7, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose139:
+ax_pose 8, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose140:
+ax_pose 27, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose141:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose142:
+ax_pose 10, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose143:
+ax_pose 11, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose144:
+ax_pose 28, 0x81e4, 0x90f8, 0xac00
+ax_pose_terminator
+sSpoinkPose145:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose146:
+ax_pose 13, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose147:
+ax_pose 14, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose148:
+ax_pose 29, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose149:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose150:
+ax_pose 10, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose151:
+ax_pose 11, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose152:
+ax_pose 28, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose153:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose154:
+ax_pose 7, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose155:
+ax_pose 8, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose156:
+ax_pose 27, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose157:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose158:
+ax_pose 4, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose159:
+ax_pose 5, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose160:
+ax_pose 26, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose161:
+ax_pose 30, 0x81e6, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose162:
+ax_pose 31, 0x81e5, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose163:
+ax_pose 32, 0x01e2, 0x80f1, 0xac00
+ax_pose_terminator
+sSpoinkPose164:
+ax_pose 33, 0x01e3, 0x90ef, 0xac00
+ax_pose_terminator
+sSpoinkPose165:
+ax_pose 34, 0x01e2, 0x90eb, 0xac00
+ax_pose_terminator
+sSpoinkPose166:
+ax_pose 35, 0x01e1, 0x90ea, 0xac00
+ax_pose_terminator
+sSpoinkPose167:
+ax_pose 36, 0x01e0, 0x80f1, 0xac00
+ax_pose_terminator
+sSpoinkPose168:
+ax_pose 35, 0x01e1, 0x80f6, 0xac00
+ax_pose_terminator
+sSpoinkPose169:
+ax_pose 34, 0x01e2, 0x80f5, 0xac00
+ax_pose_terminator
+sSpoinkPose170:
+ax_pose 33, 0x01e3, 0x80f1, 0xac00
+ax_pose_terminator
+sSpoinkPose171:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose172:
+ax_pose 1, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose173:
+ax_pose 2, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose174:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose175:
+ax_pose 4, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose176:
+ax_pose 5, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose177:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose178:
+ax_pose 7, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose179:
+ax_pose 8, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose180:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose181:
+ax_pose 10, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose182:
+ax_pose 11, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose183:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose184:
+ax_pose 13, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose185:
+ax_pose 14, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose186:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose187:
+ax_pose 10, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose188:
+ax_pose 11, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose189:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose190:
+ax_pose 7, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose191:
+ax_pose 8, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose192:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose193:
+ax_pose 4, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose194:
+ax_pose 5, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose195:
+ax_pose 20, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose196:
+ax_pose 21, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose197:
+ax_pose 22, 0x81e4, 0x80f6, 0xac00
+ax_pose_terminator
+sSpoinkPose198:
+ax_pose 23, 0x81e4, 0x80f7, 0xac00
+ax_pose_terminator
+sSpoinkPose199:
+ax_pose 24, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose200:
+ax_pose 23, 0x81e4, 0x90f8, 0xac00
+ax_pose_terminator
+sSpoinkPose201:
+ax_pose 22, 0x81e4, 0x90f9, 0xac00
+ax_pose_terminator
+sSpoinkPose202:
+ax_pose 21, 0x81e4, 0x90f8, 0xac00
+ax_pose_terminator
+sSpoinkPose203:
+ax_pose 2, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose204:
+ax_pose 5, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose205:
+ax_pose 8, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose206:
+ax_pose 11, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose207:
+ax_pose 14, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose208:
+ax_pose 11, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose209:
+ax_pose 8, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose210:
+ax_pose 5, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose211:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose212:
+ax_pose 2, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose213:
+ax_pose 1, 0x01e2, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose214:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose215:
+ax_pose 5, 0x81e7, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose216:
+ax_pose 4, 0x81e2, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose217:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose218:
+ax_pose 8, 0x81e7, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose219:
+ax_pose 7, 0x81e2, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose220:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose221:
+ax_pose 11, 0x81e7, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose222:
+ax_pose 10, 0x81e2, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose223:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose224:
+ax_pose 14, 0x01e7, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose225:
+ax_pose 13, 0x01e2, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose226:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose227:
+ax_pose 11, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose228:
+ax_pose 10, 0x81e2, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose229:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose230:
+ax_pose 8, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose231:
+ax_pose 7, 0x81e2, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose232:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose233:
+ax_pose 5, 0x81e7, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose234:
+ax_pose 4, 0x81e2, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose235:
+ax_pose 1, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose236:
+ax_pose 4, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose237:
+ax_pose 7, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose238:
+ax_pose 10, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose239:
+ax_pose 13, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose240:
+ax_pose 10, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose241:
+ax_pose 7, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose242:
+ax_pose 4, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose243:
+ax_pose 0, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose244:
+ax_pose 3, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose245:
+ax_pose 6, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose246:
+ax_pose 9, 0x81e4, 0x80f8, 0xac00
+ax_pose_terminator
+sSpoinkPose247:
+ax_pose 12, 0x01e4, 0x80f0, 0xac00
+ax_pose_terminator
+sSpoinkPose248:
+ax_pose 9, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose249:
+ax_pose 6, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+sSpoinkPose250:
+ax_pose 3, 0x81e4, 0x90f7, 0xac00
+ax_pose_terminator
+.align 2
+sSpoinkAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, -7, 0, 0,
+ax_anim 6, 0, 2, 1, -8, 1, 0,
+ax_anim 4, 0, 2, 2, -5, 2, 0,
+ax_anim 4, 0, 2, 2, -2, 2, 0,
+ax_anim 4, 0, 0, 2, 0, 2, 0,
+ax_anim 6, 0, 1, 2, 0, 2, 0,
+ax_anim 4, 0, 2, 2, -7, 2, 0,
+ax_anim 6, 0, 2, 1, -8, 1, 0,
+ax_anim 4, 0, 2, 0, -5, 0, 0,
+ax_anim 4, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, -6, 0, 0,
+ax_anim 6, 0, 5, -1, -8, -1, 1,
+ax_anim 4, 0, 5, -2, -8, -2, 2,
+ax_anim 4, 0, 5, -2, -4, -2, 2,
+ax_anim 4, 0, 3, -2, 2, -2, 2,
+ax_anim 6, 0, 4, -2, 2, -2, 2,
+ax_anim 4, 0, 5, -2, -6, -2, 2,
+ax_anim 6, 0, 5, -1, -7, -1, 1,
+ax_anim 4, 0, 5, 0, -6, 0, 0,
+ax_anim 4, 0, 5, 0, -4, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, -6, 0, 0,
+ax_anim 6, 0, 8, 0, -8, 0, 1,
+ax_anim 4, 0, 8, 0, -5, 0, 2,
+ax_anim 4, 0, 8, 0, 0, 0, 2,
+ax_anim 4, 0, 6, 0, 2, 0, 2,
+ax_anim 6, 0, 7, 0, 2, 0, 2,
+ax_anim 4, 0, 8, 0, -6, 0, 2,
+ax_anim 6, 0, 8, 0, -7, 0, 1,
+ax_anim 4, 0, 8, 0, -5, 0, 0,
+ax_anim 4, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, -6, 0, 0,
+ax_anim 6, 0, 11, 1, -7, 1, 1,
+ax_anim 4, 0, 11, 2, -6, 2, 2,
+ax_anim 4, 0, 11, 2, -2, 2, 2,
+ax_anim 4, 0, 9, 2, 2, 2, 2,
+ax_anim 6, 0, 10, 2, 2, 2, 2,
+ax_anim 4, 0, 11, 2, -6, 2, 2,
+ax_anim 6, 0, 11, 1, -8, 1, 1,
+ax_anim 4, 0, 11, 0, -7, 0, 0,
+ax_anim 4, 0, 11, 0, -4, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, -7, 0, 0,
+ax_anim 6, 0, 14, 1, -8, 1, 0,
+ax_anim 4, 0, 14, 2, -5, 2, 0,
+ax_anim 4, 0, 14, 2, -2, 2, 0,
+ax_anim 4, 0, 12, 2, 0, 2, 0,
+ax_anim 6, 0, 13, 2, 0, 2, 0,
+ax_anim 4, 0, 14, 2, -7, 2, 0,
+ax_anim 6, 0, 14, 1, -8, 1, 0,
+ax_anim 4, 0, 14, 0, -5, 0, 0,
+ax_anim 4, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 17, 0, -6, 0, 0,
+ax_anim 6, 0, 17, -1, -7, -1, 1,
+ax_anim 4, 0, 17, -2, -6, -2, 2,
+ax_anim 4, 0, 17, -2, -2, -2, 2,
+ax_anim 4, 0, 15, -2, 2, -2, 2,
+ax_anim 6, 0, 16, -2, 2, -2, 2,
+ax_anim 4, 0, 17, -2, -6, -2, 2,
+ax_anim 6, 0, 17, -1, -8, -1, 1,
+ax_anim 4, 0, 17, 0, -7, 0, 0,
+ax_anim 4, 0, 17, 0, -4, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 20, 0, -6, 0, 0,
+ax_anim 6, 0, 20, 0, -8, 0, 1,
+ax_anim 4, 0, 20, 0, -5, 0, 2,
+ax_anim 4, 0, 20, 0, 0, 0, 2,
+ax_anim 4, 0, 18, 0, 2, 0, 2,
+ax_anim 6, 0, 19, 0, 2, 0, 2,
+ax_anim 4, 0, 20, 0, -6, 0, 2,
+ax_anim 6, 0, 20, 0, -7, 0, 1,
+ax_anim 4, 0, 20, 0, -5, 0, 0,
+ax_anim 4, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 23, 0, -6, 0, 0,
+ax_anim 6, 0, 23, 1, -8, 1, 1,
+ax_anim 4, 0, 23, 2, -8, 2, 2,
+ax_anim 4, 0, 23, 2, -4, 2, 2,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 6, 0, 22, 2, 2, 2, 2,
+ax_anim 4, 0, 23, 2, -6, 2, 2,
+ax_anim 6, 0, 23, 1, -7, 1, 1,
+ax_anim 4, 0, 23, 0, -6, 0, 0,
+ax_anim 4, 0, 23, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 6, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 0, 26, 0, -3, 0, 1,
+ax_anim 1, 0, 26, 0, -5, 0, 3,
+ax_anim 2, 0, 27, 0, 4, 0, 8,
+ax_anim 2, 2, 27, 0, 10, 0, 13,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 26, 0, 12, 0, 15,
+ax_anim 2, 0, 26, 0, -2, 0, 2,
+ax_anim 4, 0, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 6, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 0, 30, 2, -3, 2, 1,
+ax_anim 1, 0, 30, 9, -1, 9, 8,
+ax_anim 2, 0, 31, 14, 3, 14, 14,
+ax_anim 2, 2, 31, 18, 13, 18, 18,
+ax_anim 2, 0, 31, 20, 21, 20, 21,
+ax_anim 2, 1, 31, 21, 20, 21, 20,
+ax_anim 2, 0, 31, 20, 21, 20, 21,
+ax_anim 2, 0, 31, 21, 20, 21, 20,
+ax_anim 2, 0, 30, 17, 8, 17, 17,
+ax_anim 2, 0, 30, 7, 0, 7, 7,
+ax_anim 4, 0, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 6, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 34, 2, -3, 2, 0,
+ax_anim 1, 0, 34, 7, -5, 7, 0,
+ax_anim 2, 0, 35, 12, -6, 12, 0,
+ax_anim 2, 2, 35, 16, -4, 16, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 34, 14, -2, 14, 0,
+ax_anim 2, 0, 34, 5, -3, 5, 0,
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 6, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 0, 38, 2, -3, 2, -2,
+ax_anim 1, 0, 38, 5, -9, 5, -6,
+ax_anim 2, 0, 39, 11, -18, 11, -11,
+ax_anim 2, 2, 39, 16, -20, 16, -16,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 2, 1, 39, 20, -18, 20, -18,
+ax_anim 2, 0, 39, 19, -19, 19, -19,
+ax_anim 2, 0, 39, 20, -18, 20, -18,
+ax_anim 2, 0, 38, 13, -15, 13, -13,
+ax_anim 2, 0, 38, 5, -5, 5, -5,
+ax_anim 4, 0, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 6, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 0, 42, 0, -3, 0, -1,
+ax_anim 1, 0, 42, 0, -6, 0, -5,
+ax_anim 2, 0, 43, 0, -16, 0, -13,
+ax_anim 2, 2, 43, 0, -19, 0, -18,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 42, 0, -12, 0, -14,
+ax_anim 2, 0, 42, 0, -2, 0, -4,
+ax_anim 4, 0, 41, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 6, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 0, 46, -2, -3, -2, -2,
+ax_anim 1, 0, 46, -5, -9, -5, -6,
+ax_anim 2, 0, 47, -11, -18, -11, -11,
+ax_anim 2, 2, 47, -16, -20, -16, -16,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 1, 47, -20, -18, -20, -18,
+ax_anim 2, 0, 47, -19, -19, -19, -19,
+ax_anim 2, 0, 47, -20, -18, -20, -18,
+ax_anim 2, 0, 46, -13, -15, -13, -13,
+ax_anim 2, 0, 46, -5, -5, -5, -5,
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 6, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 50, -2, -3, -2, 0,
+ax_anim 1, 0, 50, -7, -5, -7, 0,
+ax_anim 2, 0, 51, -12, -6, -12, 0,
+ax_anim 2, 2, 51, -16, -4, -16, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 50, -14, -2, -14, 0,
+ax_anim 2, 0, 50, -5, -3, -5, 0,
+ax_anim 4, 0, 49, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 6, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 54, -2, -3, -2, 1,
+ax_anim 1, 0, 54, -9, -1, -9, 8,
+ax_anim 2, 0, 55, -14, 3, -14, 14,
+ax_anim 2, 2, 55, -18, 13, -18, 18,
+ax_anim 2, 0, 55, -20, 21, -20, 21,
+ax_anim 2, 1, 55, -21, 20, -21, 20,
+ax_anim 2, 0, 55, -20, 21, -20, 21,
+ax_anim 2, 0, 55, -21, 20, -21, 20,
+ax_anim 2, 0, 54, -17, 8, -17, 17,
+ax_anim 2, 0, 54, -7, 0, -7, 7,
+ax_anim 4, 0, 53, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 6, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 0, -3, 0, 1,
+ax_anim 1, 0, 58, 0, -5, 0, 3,
+ax_anim 2, 0, 59, 0, 4, 0, 8,
+ax_anim 2, 2, 59, 0, 10, 0, 13,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 1, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 59, 0, 21, 0, 21,
+ax_anim 2, 0, 59, 1, 21, 1, 21,
+ax_anim 2, 0, 58, 0, 12, 0, 15,
+ax_anim 2, 0, 58, 0, -2, 0, 2,
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 6, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 62, 2, -3, 2, 1,
+ax_anim 1, 0, 62, 9, -1, 9, 8,
+ax_anim 2, 0, 63, 14, 3, 14, 14,
+ax_anim 2, 2, 63, 18, 13, 18, 18,
+ax_anim 2, 0, 63, 20, 21, 20, 21,
+ax_anim 2, 1, 63, 21, 20, 21, 20,
+ax_anim 2, 0, 63, 20, 21, 20, 21,
+ax_anim 2, 0, 63, 21, 20, 21, 20,
+ax_anim 2, 0, 62, 17, 8, 17, 17,
+ax_anim 2, 0, 62, 7, 0, 7, 7,
+ax_anim 4, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 6, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 66, 2, -3, 2, 0,
+ax_anim 1, 0, 66, 7, -5, 7, 0,
+ax_anim 2, 0, 67, 12, -6, 12, 0,
+ax_anim 2, 2, 67, 16, -4, 16, 0,
+ax_anim 2, 0, 67, 20, 0, 20, 0,
+ax_anim 2, 1, 67, 20, 1, 20, 1,
+ax_anim 2, 0, 67, 20, 0, 20, 0,
+ax_anim 2, 0, 67, 20, 1, 20, 1,
+ax_anim 2, 0, 66, 14, -2, 14, 0,
+ax_anim 2, 0, 66, 5, -3, 5, 0,
+ax_anim 4, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 6, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 0, 70, 2, -3, 2, -2,
+ax_anim 1, 0, 70, 5, -9, 5, -6,
+ax_anim 2, 0, 71, 11, -18, 11, -11,
+ax_anim 2, 2, 71, 16, -20, 16, -16,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 1, 71, 20, -18, 20, -18,
+ax_anim 2, 0, 71, 19, -19, 19, -19,
+ax_anim 2, 0, 71, 20, -18, 20, -18,
+ax_anim 2, 0, 70, 13, -15, 13, -13,
+ax_anim 2, 0, 70, 5, -5, 5, -5,
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 6, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -3, 0, -1,
+ax_anim 1, 0, 74, 0, -6, 0, -5,
+ax_anim 2, 0, 75, 0, -16, 0, -13,
+ax_anim 2, 2, 75, 0, -19, 0, -18,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 1, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 1, -21, 1, -21,
+ax_anim 2, 0, 74, 0, -12, 0, -14,
+ax_anim 2, 0, 74, 0, -2, 0, -4,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 6, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 78, -2, -3, -2, -2,
+ax_anim 1, 0, 78, -5, -9, -5, -6,
+ax_anim 2, 0, 79, -11, -18, -11, -11,
+ax_anim 2, 2, 79, -16, -20, -16, -16,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 2, 1, 79, -20, -18, -20, -18,
+ax_anim 2, 0, 79, -19, -19, -19, -19,
+ax_anim 2, 0, 79, -20, -18, -20, -18,
+ax_anim 2, 0, 78, -13, -15, -13, -13,
+ax_anim 2, 0, 78, -5, -5, -5, -5,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 6, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 82, -2, -3, -2, 0,
+ax_anim 1, 0, 82, -7, -5, -7, 0,
+ax_anim 2, 0, 83, -12, -6, -12, 0,
+ax_anim 2, 2, 83, -16, -4, -16, 0,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 1, 83, -20, 1, -20, 1,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 0, 83, -20, 1, -20, 1,
+ax_anim 2, 0, 82, -14, -2, -14, 0,
+ax_anim 2, 0, 82, -5, -3, -5, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 6, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 86, -2, -3, -2, 1,
+ax_anim 1, 0, 86, -9, -1, -9, 8,
+ax_anim 2, 0, 87, -14, 3, -14, 14,
+ax_anim 2, 2, 87, -18, 13, -18, 18,
+ax_anim 2, 0, 87, -20, 21, -20, 21,
+ax_anim 2, 1, 87, -21, 20, -21, 20,
+ax_anim 2, 0, 87, -20, 21, -20, 21,
+ax_anim 2, 0, 87, -21, 20, -21, 20,
+ax_anim 2, 0, 86, -17, 8, -17, 17,
+ax_anim 2, 0, 86, -7, 0, -7, 7,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 2, 0, 88, 0, -5, 0, -3,
+ax_anim 2, 0, 88, 0, -4, 0, -4,
+ax_anim 6, 2, 89, 0, -4, 0, -4,
+ax_anim 1, 0, 91, 0, -1, 0, -1,
+ax_anim 1, 0, 91, 0, 3, 0, 3,
+ax_anim 2, 1, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sSpoinkAnims_4_2:
+ax_anim 2, 0, 93, -2, -4, -2, -2,
+ax_anim 2, 0, 93, -3, -5, -3, -3,
+ax_anim 2, 0, 93, -4, -4, -4, -4,
+ax_anim 6, 2, 94, -4, -4, -4, -4,
+ax_anim 1, 0, 96, -1, -1, -1, -1,
+ax_anim 1, 0, 96, 3, 3, 3, 3,
+ax_anim 2, 1, 96, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 96, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 96, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim_terminator
+sSpoinkAnims_4_3:
+ax_anim 2, 0, 98, -1, -2, -1, 0,
+ax_anim 2, 0, 98, -3, -2, -3, 0,
+ax_anim 2, 0, 98, -4, 0, -4, 0,
+ax_anim 6, 2, 99, -4, 0, -4, 0,
+ax_anim 1, 0, 101, -1, 0, -1, 0,
+ax_anim 1, 0, 101, 3, 0, 3, 0,
+ax_anim 2, 1, 101, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 101, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 101, 5, 0, 5, 0,
+ax_anim 2, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim_terminator
+sSpoinkAnims_4_4:
+ax_anim 2, 0, 103, -2, -1, -2, 1,
+ax_anim 2, 0, 103, -3, 0, -3, 3,
+ax_anim 2, 0, 103, -4, 3, -4, 4,
+ax_anim 6, 2, 104, -4, 4, -4, 4,
+ax_anim 1, 0, 106, -1, 1, -1, 1,
+ax_anim 1, 0, 106, 3, -3, 3, -3,
+ax_anim 2, 1, 106, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 106, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 106, 5, -5, 5, -5,
+ax_anim 2, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim_terminator
+sSpoinkAnims_4_5:
+ax_anim 2, 0, 108, 0, -1, 0, 1,
+ax_anim 2, 0, 108, 0, 2, 0, 3,
+ax_anim 2, 0, 108, 0, 4, 0, 4,
+ax_anim 6, 2, 109, 0, 4, 0, 4,
+ax_anim 1, 0, 111, 0, 1, 0, 1,
+ax_anim 1, 0, 111, 0, -3, 0, -3,
+ax_anim 2, 1, 111, 0, -5, 0, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 111, 0, -5, 0, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 111, 0, -5, 0, -5,
+ax_anim 2, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 0, 108, 0, -1, 0, -1,
+ax_anim_terminator
+sSpoinkAnims_4_6:
+ax_anim 2, 0, 113, 2, -1, 2, 1,
+ax_anim 2, 0, 113, 3, 0, 3, 3,
+ax_anim 2, 0, 113, 4, 3, 4, 4,
+ax_anim 6, 2, 114, 4, 4, 4, 4,
+ax_anim 1, 0, 116, 1, 1, 1, 1,
+ax_anim 1, 0, 116, -3, -3, -3, -3,
+ax_anim 2, 1, 116, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 116, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 116, -5, -5, -5, -5,
+ax_anim 2, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sSpoinkAnims_4_7:
+ax_anim 2, 0, 118, 1, -2, 1, 0,
+ax_anim 2, 0, 118, 3, -2, 3, 0,
+ax_anim 2, 0, 118, 4, 0, 4, 0,
+ax_anim 6, 2, 119, 4, 0, 4, 0,
+ax_anim 1, 0, 121, 1, 0, 1, 0,
+ax_anim 1, 0, 121, -3, 0, -3, 0,
+ax_anim 2, 1, 121, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 121, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 121, -5, 0, -5, 0,
+ax_anim 2, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 0, 118, -2, 0, -2, 0,
+ax_anim_terminator
+sSpoinkAnims_4_8:
+ax_anim 2, 0, 123, 2, -4, 2, -2,
+ax_anim 2, 0, 123, 3, -5, 3, -3,
+ax_anim 2, 0, 123, 4, -4, 4, -4,
+ax_anim 6, 2, 124, 4, -4, 4, -4,
+ax_anim 1, 0, 126, 1, -1, 1, -1,
+ax_anim 1, 0, 126, -3, 3, -3, 3,
+ax_anim 2, 1, 126, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 126, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 126, -5, 5, -5, 5,
+ax_anim 2, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 0, 123, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_5_1:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -1, 0, 0,
+ax_anim 1, 0, 135, 0, -1, 0, 0,
+ax_anim 1, 0, 138, 0, -3, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 146, 0, -5, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 151, 0, -5, 0, 0,
+ax_anim 1, 0, 154, 0, -5, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 1, 0, 158, 0, -4, 0, 0,
+ax_anim 1, 2, 159, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 1, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 4, 1, 128, 0, -3, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_5_2:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, -1, 0, 0,
+ax_anim 1, 0, 139, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 1, 0, 146, 0, -5, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 151, 0, -5, 0, 0,
+ax_anim 1, 0, 154, 0, -5, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 1, 0, 158, 0, -5, 0, 0,
+ax_anim 1, 0, 159, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 2, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 4, 1, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_5_3:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 1, 0, 146, 0, -3, 0, 0,
+ax_anim 1, 0, 147, 0, -3, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 151, 0, -5, 0, 0,
+ax_anim 1, 0, 154, 0, -5, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 1, 0, 158, 0, -5, 0, 0,
+ax_anim 1, 0, 159, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 2, 135, 0, -4, 0, 0,
+ax_anim 1, 0, 138, 0, -2, 0, 0,
+ax_anim 1, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 1, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -1, 0, 0,
+ax_anim 1, 0, 147, 0, -1, 0, 0,
+ax_anim 1, 0, 150, 0, -3, 0, 0,
+ax_anim 1, 0, 151, 0, -3, 0, 0,
+ax_anim 1, 0, 154, 0, -5, 0, 0,
+ax_anim 1, 0, 155, 0, -5, 0, 0,
+ax_anim 1, 0, 158, 0, -5, 0, 0,
+ax_anim 1, 0, 159, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -4, 0, 0,
+ax_anim 1, 2, 139, 0, -4, 0, 0,
+ax_anim 1, 0, 142, 0, -2, 0, 0,
+ax_anim 1, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 1, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_5_5:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -1, 0, 0,
+ax_anim 1, 0, 151, 0, -1, 0, 0,
+ax_anim 1, 0, 154, 0, -3, 0, 0,
+ax_anim 1, 0, 155, 0, -3, 0, 0,
+ax_anim 1, 0, 158, 0, -5, 0, 0,
+ax_anim 1, 0, 159, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -4, 0, 0,
+ax_anim 1, 2, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 146, 0, -2, 0, 0,
+ax_anim 1, 0, 147, 0, -2, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 4, 1, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_5_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -1, 0, 0,
+ax_anim 1, 0, 155, 0, -1, 0, 0,
+ax_anim 1, 0, 158, 0, -3, 0, 0,
+ax_anim 1, 0, 159, 0, -3, 0, 0,
+ax_anim 1, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 146, 0, -4, 0, 0,
+ax_anim 1, 2, 147, 0, -4, 0, 0,
+ax_anim 1, 0, 150, 0, -2, 0, 0,
+ax_anim 1, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 1, 148, 0, -3, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_5_7:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -1, 0, 0,
+ax_anim 1, 0, 159, 0, -1, 0, 0,
+ax_anim 1, 0, 130, 0, -3, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 146, 0, -5, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 0, 150, 0, -4, 0, 0,
+ax_anim 1, 2, 151, 0, -4, 0, 0,
+ax_anim 1, 0, 154, 0, -2, 0, 0,
+ax_anim 1, 0, 155, 0, -2, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 1, 152, 0, -3, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_5_8:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -1, 0, 0,
+ax_anim 1, 0, 131, 0, -1, 0, 0,
+ax_anim 1, 0, 134, 0, -3, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 1, 0, 138, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 142, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 146, 0, -5, 0, 0,
+ax_anim 1, 0, 147, 0, -5, 0, 0,
+ax_anim 1, 0, 150, 0, -5, 0, 0,
+ax_anim 1, 0, 151, 0, -5, 0, 0,
+ax_anim 1, 0, 154, 0, -4, 0, 0,
+ax_anim 1, 2, 155, 0, -4, 0, 0,
+ax_anim 1, 0, 158, 0, -2, 0, 0,
+ax_anim 1, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 4, 1, 156, 0, -3, 0, 0,
+ax_anim 2, 0, 156, 0, -2, 0, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_6_1:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_7_1:
+ax_anim 2, 0, 162, 0, -4, 0, -4,
+ax_anim 8, 0, 162, 0, -5, 0, -5,
+ax_anim_terminator
+sSpoinkAnims_7_2:
+ax_anim 2, 0, 163, -4, -4, -4, -4,
+ax_anim 8, 0, 163, -5, -5, -5, -5,
+ax_anim_terminator
+sSpoinkAnims_7_3:
+ax_anim 2, 0, 164, -4, 0, -4, 0,
+ax_anim 8, 0, 164, -5, 0, -5, 0,
+ax_anim_terminator
+sSpoinkAnims_7_4:
+ax_anim 2, 0, 165, -4, 4, -4, 4,
+ax_anim 8, 0, 165, -5, 5, -5, 5,
+ax_anim_terminator
+sSpoinkAnims_7_5:
+ax_anim 2, 0, 166, 0, 4, 0, 4,
+ax_anim 8, 0, 166, 0, 5, 0, 5,
+ax_anim_terminator
+sSpoinkAnims_7_6:
+ax_anim 2, 0, 167, 4, 4, 4, 4,
+ax_anim 8, 0, 167, 5, 5, 5, 5,
+ax_anim_terminator
+sSpoinkAnims_7_7:
+ax_anim 2, 0, 168, 4, 0, 4, 0,
+ax_anim 8, 0, 168, 5, 0, 5, 0,
+ax_anim_terminator
+sSpoinkAnims_7_8:
+ax_anim 2, 0, 169, 4, -4, 4, -4,
+ax_anim 8, 0, 169, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_8_1:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, -1, 0, 0,
+ax_anim 8, 0, 172, 0, -3, 0, 0,
+ax_anim 4, 0, 172, 0, -2, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -2, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_8_2:
+ax_anim 30, 0, 173, 0, 0, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 175, 0, -1, 0, 0,
+ax_anim 8, 0, 175, 0, -3, 0, 0,
+ax_anim 4, 0, 175, 0, -2, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -2, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_8_3:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 178, 0, -1, 0, 0,
+ax_anim 8, 0, 178, 0, -3, 0, 0,
+ax_anim 4, 0, 178, 0, -2, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -2, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_8_4:
+ax_anim 30, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 181, 0, -1, 0, 0,
+ax_anim 8, 0, 181, 0, -3, 0, 0,
+ax_anim 4, 0, 181, 0, -2, 0, 0,
+ax_anim 4, 0, 180, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 0, -2, 0, 0,
+ax_anim 4, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_8_5:
+ax_anim 30, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 184, 0, -1, 0, 0,
+ax_anim 8, 0, 184, 0, -3, 0, 0,
+ax_anim 4, 0, 184, 0, -2, 0, 0,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, -2, 0, 0,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_8_6:
+ax_anim 30, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 186, 0, 0, 0, 0,
+ax_anim 4, 0, 187, 0, -1, 0, 0,
+ax_anim 8, 0, 187, 0, -3, 0, 0,
+ax_anim 4, 0, 187, 0, -2, 0, 0,
+ax_anim 4, 0, 186, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, -2, 0, 0,
+ax_anim 4, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_8_7:
+ax_anim 30, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim 4, 0, 190, 0, -1, 0, 0,
+ax_anim 8, 0, 190, 0, -3, 0, 0,
+ax_anim 4, 0, 190, 0, -2, 0, 0,
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim 4, 0, 188, 0, -2, 0, 0,
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_8_8:
+ax_anim 30, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 192, 0, 0, 0, 0,
+ax_anim 4, 0, 193, 0, -1, 0, 0,
+ax_anim 8, 0, 193, 0, -3, 0, 0,
+ax_anim 4, 0, 193, 0, -2, 0, 0,
+ax_anim 4, 0, 192, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, -2, 0, 0,
+ax_anim 4, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 6, 6, 6,
+ax_anim 2, 0, 196, 10, 15, 10, 15,
+ax_anim 2, 0, 197, 7, 21, 7, 21,
+ax_anim 3, 0, 198, 0, 22, 0, 22,
+ax_anim 2, 3, 199, -7, 21, -7, 21,
+ax_anim 2, 0, 200, -10, 15, -10, 15,
+ax_anim 1, 0, 201, -6, 6, -6, 6,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 11, 2, 11, 2,
+ax_anim 2, 0, 195, 22, 8, 22, 8,
+ax_anim 2, 0, 196, 27, 16, 27, 16,
+ax_anim 3, 0, 197, 23, 22, 23, 22,
+ax_anim 2, 3, 198, 14, 21, 14, 21,
+ax_anim 2, 0, 199, 5, 18, 5, 18,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 5, -3, 5, -3,
+ax_anim 2, 0, 194, 14, -5, 14, -5,
+ax_anim 2, 0, 195, 21, -3, 21, -3,
+ax_anim 3, 0, 196, 24, 0, 24, 0,
+ax_anim 2, 3, 197, 22, 5, 22, 5,
+ax_anim 2, 0, 198, 14, 6, 14, 6,
+ax_anim 1, 0, 199, 6, 4, 6, 4,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 1, -8, 1, -8,
+ax_anim 2, 0, 201, 6, -19, 6, -19,
+ax_anim 2, 0, 194, 15, -25, 15, -25,
+ax_anim 3, 0, 195, 24, -23, 24, -23,
+ax_anim 2, 3, 196, 26, -16, 26, -16,
+ax_anim 2, 0, 197, 20, -9, 20, -9,
+ax_anim 1, 0, 198, 10, -4, 10, -4,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -7, -5, -7, -5,
+ax_anim 2, 0, 200, -12, -13, -12, -13,
+ax_anim 2, 0, 201, -9, -20, -9, -20,
+ax_anim 3, 0, 194, 0, -24, 0, -24,
+ax_anim 2, 3, 195, 9, -20, 9, -20,
+ax_anim 2, 0, 196, 12, -13, 12, -13,
+ax_anim 1, 0, 197, 7, -5, 7, -5,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -6, -19, -6, -19,
+ax_anim 2, 0, 194, -15, -25, -15, -25,
+ax_anim 3, 0, 201, -24, -23, -24, -23,
+ax_anim 2, 3, 200, -26, -16, -26, -16,
+ax_anim 2, 0, 199, -20, -9, -20, -9,
+ax_anim 1, 0, 198, -10, -4, -10, -4,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -5, -3, -5, -3,
+ax_anim 2, 0, 194, -14, -5, -14, -5,
+ax_anim 2, 0, 201, -21, -3, -21, -3,
+ax_anim 3, 0, 200, -24, 0, -24, 0,
+ax_anim 2, 3, 199, -22, 5, -22, 5,
+ax_anim 2, 0, 198, -14, 6, -14, 6,
+ax_anim 1, 0, 197, -6, 4, -6, 4,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -11, 2, -11, 2,
+ax_anim 2, 0, 201, -22, 8, -22, 8,
+ax_anim 2, 0, 200, -27, 16, -27, 16,
+ax_anim 3, 0, 199, -23, 22, -23, 22,
+ax_anim 2, 3, 198, -14, 21, -14, 21,
+ax_anim 2, 0, 197, -5, 18, -5, 18,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 215, 0, -21, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -21, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -22, 0, 0,
+ax_anim 3, 0, 224, 0, -21, 0, 0,
+ax_anim 2, 0, 224, 0, -17, 0, 0,
+ax_anim 1, 0, 224, 0, -11, 0, 0,
+ax_anim 2, 2, 224, 0, 2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 228, 0, -22, 0, 0,
+ax_anim 3, 0, 230, 0, -21, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 2, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -22, 0, 0,
+ax_anim 3, 0, 233, 0, -21, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSpoinkAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sSpoinkGfx1:
+.incbin "baserom.gba", 0x13448D8, 0x200
+sSpoinkSprites1:
+ax_sprite sSpoinkGfx1, 0x200
+ax_sprite_terminator
+sSpoinkGfx2:
+.incbin "baserom.gba", 0x1344AE8, 0x200
+sSpoinkSprites2:
+ax_sprite sSpoinkGfx2, 0x200
+ax_sprite_terminator
+sSpoinkGfx3:
+.incbin "baserom.gba", 0x1344CF8, 0x200
+sSpoinkSprites3:
+ax_sprite sSpoinkGfx3, 0x200
+ax_sprite_terminator
+sSpoinkGfx4:
+.incbin "baserom.gba", 0x1344F08, 0x100
+sSpoinkSprites4:
+ax_sprite sSpoinkGfx4, 0x100
+ax_sprite_terminator
+sSpoinkGfx5:
+.incbin "baserom.gba", 0x1345018, 0x100
+sSpoinkSprites5:
+ax_sprite sSpoinkGfx5, 0x100
+ax_sprite_terminator
+sSpoinkGfx6:
+.incbin "baserom.gba", 0x1345128, 0x100
+sSpoinkSprites6:
+ax_sprite sSpoinkGfx6, 0x100
+ax_sprite_terminator
+sSpoinkGfx7:
+.incbin "baserom.gba", 0x1345238, 0x100
+sSpoinkSprites7:
+ax_sprite sSpoinkGfx7, 0x100
+ax_sprite_terminator
+sSpoinkGfx8:
+.incbin "baserom.gba", 0x1345348, 0x100
+sSpoinkSprites8:
+ax_sprite sSpoinkGfx8, 0x100
+ax_sprite_terminator
+sSpoinkGfx9:
+.incbin "baserom.gba", 0x1345458, 0x100
+sSpoinkSprites9:
+ax_sprite sSpoinkGfx9, 0x100
+ax_sprite_terminator
+sSpoinkGfx10:
+.incbin "baserom.gba", 0x1345568, 0x100
+sSpoinkSprites10:
+ax_sprite sSpoinkGfx10, 0x100
+ax_sprite_terminator
+sSpoinkGfx11:
+.incbin "baserom.gba", 0x1345678, 0x100
+sSpoinkSprites11:
+ax_sprite sSpoinkGfx11, 0x100
+ax_sprite_terminator
+sSpoinkGfx12:
+.incbin "baserom.gba", 0x1345788, 0x100
+sSpoinkSprites12:
+ax_sprite sSpoinkGfx12, 0x100
+ax_sprite_terminator
+sSpoinkGfx13:
+.incbin "baserom.gba", 0x1345898, 0x200
+sSpoinkSprites13:
+ax_sprite sSpoinkGfx13, 0x200
+ax_sprite_terminator
+sSpoinkGfx14:
+.incbin "baserom.gba", 0x1345AA8, 0x200
+sSpoinkSprites14:
+ax_sprite sSpoinkGfx14, 0x200
+ax_sprite_terminator
+sSpoinkGfx15:
+.incbin "baserom.gba", 0x1345CB8, 0x200
+sSpoinkSprites15:
+ax_sprite sSpoinkGfx15, 0x200
+ax_sprite_terminator
+sSpoinkGfx16:
+.incbin "baserom.gba", 0x1345EC8, 0x40
+sSpoinkGfx16_1:
+.incbin "baserom.gba", 0x1345F08, 0x80
+sSpoinkGfx16_2:
+.incbin "baserom.gba", 0x1345F88, 0x40
+sSpoinkSprites16:
+ax_sprite 0, 0xa0
+ax_sprite sSpoinkGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx16_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpoinkGfx17:
+.incbin "baserom.gba", 0x1346008, 0xC0
+sSpoinkSprites17:
+ax_sprite 0, 0x40
+ax_sprite sSpoinkGfx17, 0xc0
+ax_sprite_terminator
+sSpoinkGfx18:
+.incbin "baserom.gba", 0x13460E0, 0x20
+sSpoinkGfx18_1:
+.incbin "baserom.gba", 0x1346100, 0xC0
+sSpoinkSprites18:
+ax_sprite sSpoinkGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx18_1, 0xc0
+ax_sprite_terminator
+sSpoinkGfx19:
+.incbin "baserom.gba", 0x13461E0, 0x20
+sSpoinkGfx19_1:
+.incbin "baserom.gba", 0x1346200, 0xC0
+sSpoinkSprites19:
+ax_sprite sSpoinkGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx19_1, 0xc0
+ax_sprite_terminator
+sSpoinkGfx20:
+.incbin "baserom.gba", 0x13462E0, 0x40
+sSpoinkGfx20_1:
+.incbin "baserom.gba", 0x1346320, 0x80
+sSpoinkGfx20_2:
+.incbin "baserom.gba", 0x13463A0, 0x40
+sSpoinkSprites20:
+ax_sprite 0, 0xa0
+ax_sprite sSpoinkGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx20_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpoinkGfx21:
+.incbin "baserom.gba", 0x1346420, 0x40
+sSpoinkGfx21_1:
+.incbin "baserom.gba", 0x1346460, 0x60
+sSpoinkGfx21_2:
+.incbin "baserom.gba", 0x13464C0, 0x40
+sSpoinkSprites21:
+ax_sprite 0, 0xa0
+ax_sprite sSpoinkGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpoinkGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpoinkGfx22:
+.incbin "baserom.gba", 0x1346540, 0xC0
+sSpoinkSprites22:
+ax_sprite 0, 0x40
+ax_sprite sSpoinkGfx22, 0xc0
+ax_sprite_terminator
+sSpoinkGfx23:
+.incbin "baserom.gba", 0x1346618, 0x20
+sSpoinkGfx23_1:
+.incbin "baserom.gba", 0x1346638, 0xC0
+sSpoinkSprites23:
+ax_sprite sSpoinkGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx23_1, 0xc0
+ax_sprite_terminator
+sSpoinkGfx24:
+.incbin "baserom.gba", 0x1346718, 0x100
+sSpoinkSprites24:
+ax_sprite sSpoinkGfx24, 0x100
+ax_sprite_terminator
+sSpoinkGfx25:
+.incbin "baserom.gba", 0x1346828, 0x40
+sSpoinkGfx25_1:
+.incbin "baserom.gba", 0x1346868, 0x40
+sSpoinkGfx25_2:
+.incbin "baserom.gba", 0x13468A8, 0x60
+sSpoinkGfx25_3:
+.incbin "baserom.gba", 0x1346908, 0x40
+sSpoinkSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSpoinkGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSpoinkGfx25_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSpoinkGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSpoinkGfx26:
+.incbin "baserom.gba", 0x1346998, 0x100
+sSpoinkSprites26:
+ax_sprite sSpoinkGfx26, 0x100
+ax_sprite_terminator
+sSpoinkGfx27:
+.incbin "baserom.gba", 0x1346AA8, 0x100
+sSpoinkSprites27:
+ax_sprite sSpoinkGfx27, 0x100
+ax_sprite_terminator
+sSpoinkGfx28:
+.incbin "baserom.gba", 0x1346BB8, 0x100
+sSpoinkSprites28:
+ax_sprite sSpoinkGfx28, 0x100
+ax_sprite_terminator
+sSpoinkGfx29:
+.incbin "baserom.gba", 0x1346CC8, 0x100
+sSpoinkSprites29:
+ax_sprite sSpoinkGfx29, 0x100
+ax_sprite_terminator
+sSpoinkGfx30:
+.incbin "baserom.gba", 0x1346DD8, 0x100
+sSpoinkSprites30:
+ax_sprite sSpoinkGfx30, 0x100
+ax_sprite_terminator
+sSpoinkGfx31:
+.incbin "baserom.gba", 0x1346EE8, 0x100
+sSpoinkSprites31:
+ax_sprite sSpoinkGfx31, 0x100
+ax_sprite_terminator
+sSpoinkGfx32:
+.incbin "baserom.gba", 0x1346FF8, 0x100
+sSpoinkSprites32:
+ax_sprite sSpoinkGfx32, 0x100
+ax_sprite_terminator
+sSpoinkGfx33:
+.incbin "baserom.gba", 0x1347108, 0x200
+sSpoinkSprites33:
+ax_sprite sSpoinkGfx33, 0x200
+ax_sprite_terminator
+sSpoinkGfx34:
+.incbin "baserom.gba", 0x1347318, 0x200
+sSpoinkSprites34:
+ax_sprite sSpoinkGfx34, 0x200
+ax_sprite_terminator
+sSpoinkGfx35:
+.incbin "baserom.gba", 0x1347528, 0x200
+sSpoinkSprites35:
+ax_sprite sSpoinkGfx35, 0x200
+ax_sprite_terminator
+sSpoinkGfx36:
+.incbin "baserom.gba", 0x1347738, 0x200
+sSpoinkSprites36:
+ax_sprite sSpoinkGfx36, 0x200
+ax_sprite_terminator
+sSpoinkGfx37:
+.incbin "baserom.gba", 0x1347948, 0x200
+sSpoinkSprites37:
+ax_sprite sSpoinkGfx37, 0x200
+ax_sprite_terminator
+sAxPosesSpoink:
+.4byte sSpoinkPose1
+.4byte sSpoinkPose2
+.4byte sSpoinkPose3
+.4byte sSpoinkPose4
+.4byte sSpoinkPose5
+.4byte sSpoinkPose6
+.4byte sSpoinkPose7
+.4byte sSpoinkPose8
+.4byte sSpoinkPose9
+.4byte sSpoinkPose10
+.4byte sSpoinkPose11
+.4byte sSpoinkPose12
+.4byte sSpoinkPose13
+.4byte sSpoinkPose14
+.4byte sSpoinkPose15
+.4byte sSpoinkPose16
+.4byte sSpoinkPose17
+.4byte sSpoinkPose18
+.4byte sSpoinkPose19
+.4byte sSpoinkPose20
+.4byte sSpoinkPose21
+.4byte sSpoinkPose22
+.4byte sSpoinkPose23
+.4byte sSpoinkPose24
+.4byte sSpoinkPose25
+.4byte sSpoinkPose26
+.4byte sSpoinkPose27
+.4byte sSpoinkPose28
+.4byte sSpoinkPose29
+.4byte sSpoinkPose30
+.4byte sSpoinkPose31
+.4byte sSpoinkPose32
+.4byte sSpoinkPose33
+.4byte sSpoinkPose34
+.4byte sSpoinkPose35
+.4byte sSpoinkPose36
+.4byte sSpoinkPose37
+.4byte sSpoinkPose38
+.4byte sSpoinkPose39
+.4byte sSpoinkPose40
+.4byte sSpoinkPose41
+.4byte sSpoinkPose42
+.4byte sSpoinkPose43
+.4byte sSpoinkPose44
+.4byte sSpoinkPose45
+.4byte sSpoinkPose46
+.4byte sSpoinkPose47
+.4byte sSpoinkPose48
+.4byte sSpoinkPose49
+.4byte sSpoinkPose50
+.4byte sSpoinkPose51
+.4byte sSpoinkPose52
+.4byte sSpoinkPose53
+.4byte sSpoinkPose54
+.4byte sSpoinkPose55
+.4byte sSpoinkPose56
+.4byte sSpoinkPose57
+.4byte sSpoinkPose58
+.4byte sSpoinkPose59
+.4byte sSpoinkPose60
+.4byte sSpoinkPose61
+.4byte sSpoinkPose62
+.4byte sSpoinkPose63
+.4byte sSpoinkPose64
+.4byte sSpoinkPose65
+.4byte sSpoinkPose66
+.4byte sSpoinkPose67
+.4byte sSpoinkPose68
+.4byte sSpoinkPose69
+.4byte sSpoinkPose70
+.4byte sSpoinkPose71
+.4byte sSpoinkPose72
+.4byte sSpoinkPose73
+.4byte sSpoinkPose74
+.4byte sSpoinkPose75
+.4byte sSpoinkPose76
+.4byte sSpoinkPose77
+.4byte sSpoinkPose78
+.4byte sSpoinkPose79
+.4byte sSpoinkPose80
+.4byte sSpoinkPose81
+.4byte sSpoinkPose82
+.4byte sSpoinkPose83
+.4byte sSpoinkPose84
+.4byte sSpoinkPose85
+.4byte sSpoinkPose86
+.4byte sSpoinkPose87
+.4byte sSpoinkPose88
+.4byte sSpoinkPose89
+.4byte sSpoinkPose90
+.4byte sSpoinkPose91
+.4byte sSpoinkPose92
+.4byte sSpoinkPose93
+.4byte sSpoinkPose94
+.4byte sSpoinkPose95
+.4byte sSpoinkPose96
+.4byte sSpoinkPose97
+.4byte sSpoinkPose98
+.4byte sSpoinkPose99
+.4byte sSpoinkPose100
+.4byte sSpoinkPose101
+.4byte sSpoinkPose102
+.4byte sSpoinkPose103
+.4byte sSpoinkPose104
+.4byte sSpoinkPose105
+.4byte sSpoinkPose106
+.4byte sSpoinkPose107
+.4byte sSpoinkPose108
+.4byte sSpoinkPose109
+.4byte sSpoinkPose110
+.4byte sSpoinkPose111
+.4byte sSpoinkPose112
+.4byte sSpoinkPose113
+.4byte sSpoinkPose114
+.4byte sSpoinkPose115
+.4byte sSpoinkPose116
+.4byte sSpoinkPose117
+.4byte sSpoinkPose118
+.4byte sSpoinkPose119
+.4byte sSpoinkPose120
+.4byte sSpoinkPose121
+.4byte sSpoinkPose122
+.4byte sSpoinkPose123
+.4byte sSpoinkPose124
+.4byte sSpoinkPose125
+.4byte sSpoinkPose126
+.4byte sSpoinkPose127
+.4byte sSpoinkPose128
+.4byte sSpoinkPose129
+.4byte sSpoinkPose130
+.4byte sSpoinkPose131
+.4byte sSpoinkPose132
+.4byte sSpoinkPose133
+.4byte sSpoinkPose134
+.4byte sSpoinkPose135
+.4byte sSpoinkPose136
+.4byte sSpoinkPose137
+.4byte sSpoinkPose138
+.4byte sSpoinkPose139
+.4byte sSpoinkPose140
+.4byte sSpoinkPose141
+.4byte sSpoinkPose142
+.4byte sSpoinkPose143
+.4byte sSpoinkPose144
+.4byte sSpoinkPose145
+.4byte sSpoinkPose146
+.4byte sSpoinkPose147
+.4byte sSpoinkPose148
+.4byte sSpoinkPose149
+.4byte sSpoinkPose150
+.4byte sSpoinkPose151
+.4byte sSpoinkPose152
+.4byte sSpoinkPose153
+.4byte sSpoinkPose154
+.4byte sSpoinkPose155
+.4byte sSpoinkPose156
+.4byte sSpoinkPose157
+.4byte sSpoinkPose158
+.4byte sSpoinkPose159
+.4byte sSpoinkPose160
+.4byte sSpoinkPose161
+.4byte sSpoinkPose162
+.4byte sSpoinkPose163
+.4byte sSpoinkPose164
+.4byte sSpoinkPose165
+.4byte sSpoinkPose166
+.4byte sSpoinkPose167
+.4byte sSpoinkPose168
+.4byte sSpoinkPose169
+.4byte sSpoinkPose170
+.4byte sSpoinkPose171
+.4byte sSpoinkPose172
+.4byte sSpoinkPose173
+.4byte sSpoinkPose174
+.4byte sSpoinkPose175
+.4byte sSpoinkPose176
+.4byte sSpoinkPose177
+.4byte sSpoinkPose178
+.4byte sSpoinkPose179
+.4byte sSpoinkPose180
+.4byte sSpoinkPose181
+.4byte sSpoinkPose182
+.4byte sSpoinkPose183
+.4byte sSpoinkPose184
+.4byte sSpoinkPose185
+.4byte sSpoinkPose186
+.4byte sSpoinkPose187
+.4byte sSpoinkPose188
+.4byte sSpoinkPose189
+.4byte sSpoinkPose190
+.4byte sSpoinkPose191
+.4byte sSpoinkPose192
+.4byte sSpoinkPose193
+.4byte sSpoinkPose194
+.4byte sSpoinkPose195
+.4byte sSpoinkPose196
+.4byte sSpoinkPose197
+.4byte sSpoinkPose198
+.4byte sSpoinkPose199
+.4byte sSpoinkPose200
+.4byte sSpoinkPose201
+.4byte sSpoinkPose202
+.4byte sSpoinkPose203
+.4byte sSpoinkPose204
+.4byte sSpoinkPose205
+.4byte sSpoinkPose206
+.4byte sSpoinkPose207
+.4byte sSpoinkPose208
+.4byte sSpoinkPose209
+.4byte sSpoinkPose210
+.4byte sSpoinkPose211
+.4byte sSpoinkPose212
+.4byte sSpoinkPose213
+.4byte sSpoinkPose214
+.4byte sSpoinkPose215
+.4byte sSpoinkPose216
+.4byte sSpoinkPose217
+.4byte sSpoinkPose218
+.4byte sSpoinkPose219
+.4byte sSpoinkPose220
+.4byte sSpoinkPose221
+.4byte sSpoinkPose222
+.4byte sSpoinkPose223
+.4byte sSpoinkPose224
+.4byte sSpoinkPose225
+.4byte sSpoinkPose226
+.4byte sSpoinkPose227
+.4byte sSpoinkPose228
+.4byte sSpoinkPose229
+.4byte sSpoinkPose230
+.4byte sSpoinkPose231
+.4byte sSpoinkPose232
+.4byte sSpoinkPose233
+.4byte sSpoinkPose234
+.4byte sSpoinkPose235
+.4byte sSpoinkPose236
+.4byte sSpoinkPose237
+.4byte sSpoinkPose238
+.4byte sSpoinkPose239
+.4byte sSpoinkPose240
+.4byte sSpoinkPose241
+.4byte sSpoinkPose242
+.4byte sSpoinkPose243
+.4byte sSpoinkPose244
+.4byte sSpoinkPose245
+.4byte sSpoinkPose246
+.4byte sSpoinkPose247
+.4byte sSpoinkPose248
+.4byte sSpoinkPose249
+.4byte sSpoinkPose250
+sAxPositionsSpoink:
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	  -8,  -11, 	   6,  -11, 	  -1,  -13
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+.2byte    3,   -5, 	   4,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    3,  -10, 	   4,  -11, 	  -6,   -9, 	  -1,  -13
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   0,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte    4,  -11, 	   0,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    1,   -8, 	  -5,   -9, 	   5,   -7, 	  -2,   -7
+.2byte    1,  -13, 	  -4,  -11, 	   4,   -9, 	  -3,  -13
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,   -8, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -9, 	   1,  -13
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -6,   -6, 	  -2,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -5,   -5, 	  -6,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -5,  -10, 	  -6,  -11, 	   4,   -9, 	  -1,  -13
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	  -8,  -11, 	   6,  -11, 	  -1,  -13
+.2byte   -1,   -2, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+.2byte    3,   -5, 	   4,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    3,  -10, 	   4,  -11, 	  -6,   -9, 	  -1,  -13
+.2byte    4,   -3, 	   6,   -7, 	  -5,   -5, 	   2,   -6
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   0,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte    4,  -11, 	   0,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   3,   -6, 	   2,   -4, 	   2,   -7
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    1,   -8, 	  -5,   -9, 	   5,   -7, 	  -2,   -7
+.2byte    1,  -13, 	  -4,  -11, 	   4,   -9, 	  -3,  -13
+.2byte    3,   -7, 	  -2,   -9, 	   7,   -5, 	   0,   -7
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,   -9, 	   7,   -8, 	  -9,   -8, 	  -1,   -7
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,   -8, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -9, 	   1,  -13
+.2byte   -4,   -7, 	   1,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -6,   -6, 	  -2,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte   -7,   -4, 	  -4,   -6, 	  -3,   -4, 	  -3,   -7
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -5,   -5, 	  -6,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -5,  -10, 	  -6,  -11, 	   4,   -9, 	  -1,  -13
+.2byte   -5,   -3, 	  -7,   -7, 	   4,   -5, 	  -3,   -6
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	  -8,  -11, 	   6,  -11, 	  -1,  -13
+.2byte   -1,   -2, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+.2byte    3,   -5, 	   4,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    3,  -10, 	   4,  -11, 	  -6,   -9, 	  -1,  -13
+.2byte    4,   -3, 	   6,   -7, 	  -5,   -5, 	   2,   -6
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   0,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte    4,  -11, 	   0,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   3,   -6, 	   2,   -4, 	   2,   -7
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    1,   -8, 	  -5,   -9, 	   5,   -7, 	  -2,   -7
+.2byte    1,  -13, 	  -4,  -11, 	   4,   -9, 	  -3,  -13
+.2byte    3,   -7, 	  -2,   -9, 	   7,   -5, 	   0,   -7
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,   -9, 	   7,   -8, 	  -9,   -8, 	  -1,   -7
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,   -8, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -9, 	   1,  -13
+.2byte   -4,   -7, 	   1,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -6,   -6, 	  -2,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte   -7,   -4, 	  -4,   -6, 	  -3,   -4, 	  -3,   -7
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -5,   -5, 	  -6,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -5,  -10, 	  -6,  -11, 	   4,   -9, 	  -1,  -13
+.2byte   -5,   -3, 	  -7,   -7, 	   4,   -5, 	  -3,   -6
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	  -8,  -11, 	   6,  -11, 	  -1,  -13
+.2byte   -1,   -2, 	  -8,   -7, 	   6,   -7, 	  -1,   -6
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -6
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+.2byte    3,   -5, 	   4,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    3,  -10, 	   4,  -11, 	  -6,   -9, 	  -1,  -13
+.2byte    4,   -3, 	   6,   -7, 	  -5,   -5, 	   2,   -6
+.2byte    4,   -4, 	   5,   -7, 	  -3,   -5, 	   1,   -7
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   0,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte    4,  -11, 	   0,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte    6,   -4, 	   3,   -6, 	   2,   -4, 	   2,   -7
+.2byte    6,   -5, 	   3,   -8, 	   3,   -6, 	   1,   -8
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    1,   -8, 	  -5,   -9, 	   5,   -7, 	  -2,   -7
+.2byte    1,  -13, 	  -4,  -11, 	   4,   -9, 	  -3,  -13
+.2byte    3,   -7, 	  -2,   -9, 	   7,   -5, 	   0,   -7
+.2byte    3,   -8, 	  -1,  -10, 	   7,   -7, 	   0,   -8
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,   -9, 	   7,   -8, 	  -9,   -8, 	  -1,   -7
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,   -8, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -9, 	   1,  -13
+.2byte   -4,   -7, 	   1,   -9, 	  -8,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	   0,  -10, 	  -8,   -7, 	  -1,   -8
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -6,   -6, 	  -2,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte   -7,   -4, 	  -4,   -6, 	  -3,   -4, 	  -3,   -7
+.2byte   -7,   -5, 	  -4,   -8, 	  -4,   -6, 	  -2,   -8
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -5,   -5, 	  -6,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -5,  -10, 	  -6,  -11, 	   4,   -9, 	  -1,  -13
+.2byte   -5,   -3, 	  -7,   -7, 	   4,   -5, 	  -3,   -6
+.2byte   -5,   -4, 	  -6,   -7, 	   2,   -5, 	  -2,   -7
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	  -8,  -11, 	   6,  -11, 	  -1,  -13
+.2byte   -1,  -10, 	  -7,  -12, 	   5,  -12, 	  -1,  -13
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+.2byte    3,   -5, 	   4,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    3,  -10, 	   4,  -11, 	  -6,   -9, 	  -1,  -13
+.2byte    2,  -10, 	   3,  -11, 	  -3,   -9, 	  -1,  -13
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   0,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte    4,  -11, 	   0,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte    4,  -11, 	   1,  -12, 	   1,  -10, 	  -1,  -13
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    1,   -8, 	  -5,   -9, 	   5,   -7, 	  -2,   -7
+.2byte    1,  -13, 	  -4,  -11, 	   4,   -9, 	  -3,  -13
+.2byte    2,  -13, 	  -4,  -12, 	   6,  -10, 	  -1,  -12
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -1,  -14, 	   5,  -14, 	  -7,  -14, 	  -1,  -12
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,   -8, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -9, 	   1,  -13
+.2byte   -4,  -13, 	   2,  -12, 	  -8,  -10, 	  -1,  -12
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -6,   -6, 	  -2,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte   -6,  -11, 	  -3,  -12, 	  -3,  -10, 	  -1,  -13
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -5,   -5, 	  -6,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -5,  -10, 	  -6,  -11, 	   4,   -9, 	  -1,  -13
+.2byte   -4,  -10, 	  -5,  -11, 	   1,   -9, 	  -1,  -13
+.2byte   -5,   -8, 	  -6,  -12, 	   5,  -10, 	  -1,  -10
+.2byte   -5,   -6, 	  -7,   -9, 	   5,   -6, 	  -1,   -8
+.2byte    0,  -12, 	  -7,  -14, 	   7,  -14, 	   0,  -11
+.2byte    2,  -11, 	   1,  -14, 	  -8,  -10, 	  -2,  -11
+.2byte    3,  -13, 	  -4,  -15, 	  -5,  -12, 	  -2,  -12
+.2byte    2,  -14, 	  -9,  -16, 	   3,  -14, 	  -3,  -12
+.2byte    0,  -14, 	   7,  -16, 	  -7,  -16, 	   0,  -13
+.2byte   -3,  -14, 	   8,  -16, 	  -4,  -14, 	   2,  -12
+.2byte   -4,  -13, 	   3,  -15, 	   4,  -12, 	   1,  -12
+.2byte   -3,  -11, 	  -2,  -14, 	   7,  -10, 	   1,  -11
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	  -8,  -11, 	   6,  -11, 	  -1,  -13
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+.2byte    3,   -5, 	   4,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte    3,  -10, 	   4,  -11, 	  -6,   -9, 	  -1,  -13
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    4,   -6, 	   0,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte    4,  -11, 	   0,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    1,   -8, 	  -5,   -9, 	   5,   -7, 	  -2,   -7
+.2byte    1,  -13, 	  -4,  -11, 	   4,   -9, 	  -3,  -13
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,   -8, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -9, 	   1,  -13
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -6,   -6, 	  -2,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte   -6,  -11, 	  -2,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -5,   -5, 	  -6,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -5,  -10, 	  -6,  -11, 	   4,   -9, 	  -1,  -13
+.2byte   -1,   -3, 	  -8,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -5,   -4, 	  -6,   -7, 	   2,   -5, 	  -2,   -7
+.2byte   -7,   -5, 	  -4,   -8, 	  -4,   -6, 	  -2,   -8
+.2byte   -4,   -8, 	   0,  -10, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,  -10, 	   6,  -11, 	  -8,  -11, 	  -1,   -8
+.2byte    2,   -8, 	  -2,  -10, 	   6,   -7, 	  -1,   -8
+.2byte    5,   -5, 	   2,   -8, 	   2,   -6, 	   0,   -8
+.2byte    3,   -4, 	   4,   -7, 	  -4,   -5, 	   0,   -7
+.2byte   -1,  -10, 	  -8,  -11, 	   6,  -11, 	  -1,  -13
+.2byte    3,  -10, 	   4,  -11, 	  -6,   -9, 	  -1,  -13
+.2byte    4,  -11, 	   0,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte    1,  -13, 	  -4,  -11, 	   4,   -9, 	  -3,  -13
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -12
+.2byte   -3,  -13, 	   2,  -11, 	  -6,   -9, 	   1,  -13
+.2byte   -6,  -11, 	  -2,  -11, 	  -1,   -9, 	  -1,  -13
+.2byte   -5,  -10, 	  -6,  -11, 	   4,   -9, 	  -1,  -13
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -1,   -7, 	  -8,   -8, 	   6,   -8, 	  -1,  -10
+.2byte   -1,   -7, 	  -8,  -10, 	   6,  -10, 	  -1,  -10
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+.2byte    3,   -7, 	   4,   -8, 	  -6,   -6, 	  -1,  -10
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -9, 	  -1,   -9
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    4,   -8, 	   0,   -8, 	  -1,   -6, 	  -1,  -10
+.2byte    4,   -8, 	   0,  -10, 	  -1,   -8, 	  -1,  -10
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    1,  -10, 	  -4,   -8, 	   4,   -6, 	  -3,  -10
+.2byte    1,  -10, 	  -5,  -11, 	   5,   -9, 	  -2,   -9
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte   -1,  -10, 	   6,   -8, 	  -8,   -8, 	  -1,   -9
+.2byte   -1,  -10, 	   6,  -10, 	  -8,  -10, 	  -1,   -9
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -3,  -10, 	   2,   -8, 	  -6,   -6, 	   1,  -10
+.2byte   -3,  -10, 	   3,  -11, 	  -7,   -9, 	   0,   -9
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -6,   -8, 	  -2,   -8, 	  -1,   -6, 	  -1,  -10
+.2byte   -6,   -8, 	  -2,  -10, 	  -1,   -8, 	  -1,  -10
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -5,   -7, 	  -6,   -8, 	   4,   -6, 	  -1,  -10
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -9, 	  -1,   -9
+.2byte   -1,   -5, 	  -8,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -5,   -5, 	  -6,   -7, 	   5,   -7, 	  -1,   -7
+.2byte   -6,   -6, 	  -2,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte   -3,   -8, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -1,   -8, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte    1,   -8, 	  -5,   -9, 	   5,   -7, 	  -2,   -7
+.2byte    4,   -6, 	   0,   -8, 	  -1,   -6, 	  -1,   -8
+.2byte    3,   -5, 	   4,   -7, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	  -8,   -9, 	   6,   -9, 	  -1,   -9
+.2byte   -5,   -7, 	  -6,   -9, 	   5,   -7, 	  -1,   -9
+.2byte   -6,   -8, 	  -2,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte   -3,  -10, 	   3,   -9, 	  -7,   -7, 	   0,  -10
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -9
+.2byte    1,  -10, 	  -5,   -9, 	   5,   -7, 	  -2,  -10
+.2byte    4,   -8, 	   0,   -9, 	  -1,   -7, 	  -1,  -10
+.2byte    3,   -7, 	   4,   -9, 	  -7,   -7, 	  -1,   -9
+sSpoinkAnimTable1:
+.4byte sSpoinkAnims_1_1
+.4byte sSpoinkAnims_1_2
+.4byte sSpoinkAnims_1_3
+.4byte sSpoinkAnims_1_4
+.4byte sSpoinkAnims_1_5
+.4byte sSpoinkAnims_1_6
+.4byte sSpoinkAnims_1_7
+.4byte sSpoinkAnims_1_8
+sSpoinkAnimTable2:
+.4byte sSpoinkAnims_2_1
+.4byte sSpoinkAnims_2_2
+.4byte sSpoinkAnims_2_3
+.4byte sSpoinkAnims_2_4
+.4byte sSpoinkAnims_2_5
+.4byte sSpoinkAnims_2_6
+.4byte sSpoinkAnims_2_7
+.4byte sSpoinkAnims_2_8
+sSpoinkAnimTable3:
+.4byte sSpoinkAnims_3_1
+.4byte sSpoinkAnims_3_2
+.4byte sSpoinkAnims_3_3
+.4byte sSpoinkAnims_3_4
+.4byte sSpoinkAnims_3_5
+.4byte sSpoinkAnims_3_6
+.4byte sSpoinkAnims_3_7
+.4byte sSpoinkAnims_3_8
+sSpoinkAnimTable4:
+.4byte sSpoinkAnims_4_1
+.4byte sSpoinkAnims_4_2
+.4byte sSpoinkAnims_4_3
+.4byte sSpoinkAnims_4_4
+.4byte sSpoinkAnims_4_5
+.4byte sSpoinkAnims_4_6
+.4byte sSpoinkAnims_4_7
+.4byte sSpoinkAnims_4_8
+sSpoinkAnimTable5:
+.4byte sSpoinkAnims_5_1
+.4byte sSpoinkAnims_5_2
+.4byte sSpoinkAnims_5_3
+.4byte sSpoinkAnims_5_4
+.4byte sSpoinkAnims_5_5
+.4byte sSpoinkAnims_5_6
+.4byte sSpoinkAnims_5_7
+.4byte sSpoinkAnims_5_8
+sSpoinkAnimTable6:
+.4byte sSpoinkAnims_6_1
+.4byte sSpoinkAnims_6_1
+.4byte sSpoinkAnims_6_1
+.4byte sSpoinkAnims_6_1
+.4byte sSpoinkAnims_6_1
+.4byte sSpoinkAnims_6_1
+.4byte sSpoinkAnims_6_1
+.4byte sSpoinkAnims_6_1
+sSpoinkAnimTable7:
+.4byte sSpoinkAnims_7_1
+.4byte sSpoinkAnims_7_2
+.4byte sSpoinkAnims_7_3
+.4byte sSpoinkAnims_7_4
+.4byte sSpoinkAnims_7_5
+.4byte sSpoinkAnims_7_6
+.4byte sSpoinkAnims_7_7
+.4byte sSpoinkAnims_7_8
+sSpoinkAnimTable8:
+.4byte sSpoinkAnims_8_1
+.4byte sSpoinkAnims_8_2
+.4byte sSpoinkAnims_8_3
+.4byte sSpoinkAnims_8_4
+.4byte sSpoinkAnims_8_5
+.4byte sSpoinkAnims_8_6
+.4byte sSpoinkAnims_8_7
+.4byte sSpoinkAnims_8_8
+sSpoinkAnimTable9:
+.4byte sSpoinkAnims_9_1
+.4byte sSpoinkAnims_9_2
+.4byte sSpoinkAnims_9_3
+.4byte sSpoinkAnims_9_4
+.4byte sSpoinkAnims_9_5
+.4byte sSpoinkAnims_9_6
+.4byte sSpoinkAnims_9_7
+.4byte sSpoinkAnims_9_8
+sSpoinkAnimTable10:
+.4byte sSpoinkAnims_10_1
+.4byte sSpoinkAnims_10_2
+.4byte sSpoinkAnims_10_3
+.4byte sSpoinkAnims_10_4
+.4byte sSpoinkAnims_10_5
+.4byte sSpoinkAnims_10_6
+.4byte sSpoinkAnims_10_7
+.4byte sSpoinkAnims_10_8
+sSpoinkAnimTable11:
+.4byte sSpoinkAnims_11_1
+.4byte sSpoinkAnims_11_2
+.4byte sSpoinkAnims_11_3
+.4byte sSpoinkAnims_11_4
+.4byte sSpoinkAnims_11_5
+.4byte sSpoinkAnims_11_6
+.4byte sSpoinkAnims_11_7
+.4byte sSpoinkAnims_11_8
+sSpoinkAnimTable12:
+.4byte sSpoinkAnims_12_1
+.4byte sSpoinkAnims_12_2
+.4byte sSpoinkAnims_12_3
+.4byte sSpoinkAnims_12_4
+.4byte sSpoinkAnims_12_5
+.4byte sSpoinkAnims_12_6
+.4byte sSpoinkAnims_12_7
+.4byte sSpoinkAnims_12_8
+sSpoinkAnimTable13:
+.4byte sSpoinkAnims_13_1
+.4byte sSpoinkAnims_13_2
+.4byte sSpoinkAnims_13_3
+.4byte sSpoinkAnims_13_4
+.4byte sSpoinkAnims_13_5
+.4byte sSpoinkAnims_13_6
+.4byte sSpoinkAnims_13_7
+.4byte sSpoinkAnims_13_8
+sAxAnimationsSpoink:
+.4byte sSpoinkAnimTable1
+.4byte sSpoinkAnimTable2
+.4byte sSpoinkAnimTable3
+.4byte sSpoinkAnimTable4
+.4byte sSpoinkAnimTable5
+.4byte sSpoinkAnimTable6
+.4byte sSpoinkAnimTable7
+.4byte sSpoinkAnimTable8
+.4byte sSpoinkAnimTable9
+.4byte sSpoinkAnimTable10
+.4byte sSpoinkAnimTable11
+.4byte sSpoinkAnimTable12
+.4byte sSpoinkAnimTable13
+sAxSpritesSpoink:
+.4byte sSpoinkSprites1
+.4byte sSpoinkSprites2
+.4byte sSpoinkSprites3
+.4byte sSpoinkSprites4
+.4byte sSpoinkSprites5
+.4byte sSpoinkSprites6
+.4byte sSpoinkSprites7
+.4byte sSpoinkSprites8
+.4byte sSpoinkSprites9
+.4byte sSpoinkSprites10
+.4byte sSpoinkSprites11
+.4byte sSpoinkSprites12
+.4byte sSpoinkSprites13
+.4byte sSpoinkSprites14
+.4byte sSpoinkSprites15
+.4byte sSpoinkSprites16
+.4byte sSpoinkSprites17
+.4byte sSpoinkSprites18
+.4byte sSpoinkSprites19
+.4byte sSpoinkSprites20
+.4byte sSpoinkSprites21
+.4byte sSpoinkSprites22
+.4byte sSpoinkSprites23
+.4byte sSpoinkSprites24
+.4byte sSpoinkSprites25
+.4byte sSpoinkSprites26
+.4byte sSpoinkSprites27
+.4byte sSpoinkSprites28
+.4byte sSpoinkSprites29
+.4byte sSpoinkSprites30
+.4byte sSpoinkSprites31
+.4byte sSpoinkSprites32
+.4byte sSpoinkSprites33
+.4byte sSpoinkSprites34
+.4byte sSpoinkSprites35
+.4byte sSpoinkSprites36
+.4byte sSpoinkSprites37
+sAxMainSpoink:
+ax_main sAxPosesSpoink, sAxAnimationsSpoink, 13, sAxSpritesSpoink, sAxPositionsSpoink

--- a/data/ax/squirtle.inc
+++ b/data/ax/squirtle.inc
@@ -1,0 +1,3952 @@
+.global gAxSquirtle
+gAxSquirtle:
+ax_siro sAxMainSquirtle
+sSquirtlePose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose4:
+ax_pose 3, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose5:
+ax_pose 4, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose7:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose8:
+ax_pose 7, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose9:
+ax_pose 8, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose10:
+ax_pose 9, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose11:
+ax_pose 10, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose13:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose14:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose15:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose19:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose20:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose21:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose23:
+ax_pose 4, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose28:
+ax_pose 3, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose29:
+ax_pose 4, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose30:
+ax_pose 5, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose31:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose32:
+ax_pose 7, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose33:
+ax_pose 8, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose34:
+ax_pose 9, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose35:
+ax_pose 10, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose36:
+ax_pose 11, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose37:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose38:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose39:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose40:
+ax_pose 9, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose41:
+ax_pose 10, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose42:
+ax_pose 11, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose43:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose44:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose45:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose46:
+ax_pose 3, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose47:
+ax_pose 4, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose48:
+ax_pose 5, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose50:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose51:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose52:
+ax_pose 3, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose53:
+ax_pose 4, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose54:
+ax_pose 5, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose55:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose56:
+ax_pose 7, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose57:
+ax_pose 8, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose58:
+ax_pose 9, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose59:
+ax_pose 10, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose60:
+ax_pose 11, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose61:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose62:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose63:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose64:
+ax_pose 9, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose65:
+ax_pose 10, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose66:
+ax_pose 11, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose67:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose68:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose69:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose70:
+ax_pose 3, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose71:
+ax_pose 4, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose72:
+ax_pose 5, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose73:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose74:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose75:
+ax_pose 16, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose76:
+ax_pose 17, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose77:
+ax_pose 3, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose78:
+ax_pose 18, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose79:
+ax_pose 19, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose80:
+ax_pose 20, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose81:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose82:
+ax_pose 21, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose83:
+ax_pose 22, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose84:
+ax_pose 23, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose85:
+ax_pose 9, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose86:
+ax_pose 24, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose87:
+ax_pose 25, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose88:
+ax_pose 26, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose89:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose90:
+ax_pose 27, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose91:
+ax_pose 28, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose92:
+ax_pose 29, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose93:
+ax_pose 9, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose94:
+ax_pose 24, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose95:
+ax_pose 25, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose96:
+ax_pose 26, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose97:
+ax_pose 6, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose98:
+ax_pose 21, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose99:
+ax_pose 22, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose100:
+ax_pose 23, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose101:
+ax_pose 3, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose102:
+ax_pose 18, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose103:
+ax_pose 19, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose104:
+ax_pose 20, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose105:
+ax_pose 30, 0x01f4, 0x40f8, 0x5c00
+ax_pose_terminator
+sSquirtlePose106:
+ax_pose 31, 0x01f4, 0x40f8, 0x5c00
+ax_pose_terminator
+sSquirtlePose107:
+ax_pose 32, 0x01f4, 0x40f8, 0x5c00
+ax_pose_terminator
+sSquirtlePose108:
+ax_pose 33, 0x01f4, 0x40f8, 0x5c00
+ax_pose_terminator
+sSquirtlePose109:
+ax_pose 34, 0x01f4, 0x40f8, 0x5c00
+ax_pose_terminator
+sSquirtlePose110:
+ax_pose 33, 0x01f4, 0x50f9, 0x5c00
+ax_pose_terminator
+sSquirtlePose111:
+ax_pose 32, 0x01f4, 0x50f9, 0x5c00
+ax_pose_terminator
+sSquirtlePose112:
+ax_pose 31, 0x01f4, 0x50f9, 0x5c00
+ax_pose_terminator
+sSquirtlePose113:
+ax_pose 35, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose114:
+ax_pose 36, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose115:
+ax_pose 37, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose116:
+ax_pose 38, 0x01e6, 0x90e8, 0x5c00
+ax_pose_terminator
+sSquirtlePose117:
+ax_pose 39, 0x01e8, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose118:
+ax_pose 40, 0x01e4, 0x90e8, 0x5c00
+ax_pose_terminator
+sSquirtlePose119:
+ax_pose 41, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose120:
+ax_pose 40, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose121:
+ax_pose 39, 0x01e8, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose122:
+ax_pose 38, 0x01e6, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose123:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose124:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose125:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose126:
+ax_pose 3, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose127:
+ax_pose 4, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose128:
+ax_pose 5, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose129:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose130:
+ax_pose 7, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose131:
+ax_pose 8, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose132:
+ax_pose 9, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose133:
+ax_pose 10, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose134:
+ax_pose 11, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose135:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose136:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose137:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose138:
+ax_pose 9, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose139:
+ax_pose 10, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose140:
+ax_pose 11, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose141:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose142:
+ax_pose 7, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose143:
+ax_pose 8, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose144:
+ax_pose 3, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose145:
+ax_pose 4, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose146:
+ax_pose 5, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose147:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose148:
+ax_pose 18, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose149:
+ax_pose 21, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSquirtlePose150:
+ax_pose 24, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose151:
+ax_pose 27, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose152:
+ax_pose 24, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSquirtlePose153:
+ax_pose 21, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose154:
+ax_pose 18, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose155:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose156:
+ax_pose 18, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose157:
+ax_pose 21, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose158:
+ax_pose 24, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSquirtlePose159:
+ax_pose 27, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose160:
+ax_pose 24, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose161:
+ax_pose 21, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSquirtlePose162:
+ax_pose 18, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose163:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose164:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose165:
+ax_pose 16, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose166:
+ax_pose 3, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose167:
+ax_pose 18, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose168:
+ax_pose 19, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose169:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose170:
+ax_pose 21, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose171:
+ax_pose 22, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose172:
+ax_pose 9, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose173:
+ax_pose 24, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose174:
+ax_pose 25, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose175:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose176:
+ax_pose 27, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose177:
+ax_pose 28, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose178:
+ax_pose 9, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose179:
+ax_pose 24, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose180:
+ax_pose 25, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose181:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose182:
+ax_pose 21, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSquirtlePose183:
+ax_pose 22, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSquirtlePose184:
+ax_pose 3, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose185:
+ax_pose 18, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose186:
+ax_pose 19, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose187:
+ax_pose 15, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose188:
+ax_pose 18, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose189:
+ax_pose 21, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSquirtlePose190:
+ax_pose 24, 0x01ec, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose191:
+ax_pose 27, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose192:
+ax_pose 24, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sSquirtlePose193:
+ax_pose 21, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSquirtlePose194:
+ax_pose 18, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose195:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose196:
+ax_pose 3, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose197:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose198:
+ax_pose 9, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose199:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose200:
+ax_pose 9, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose201:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose202:
+ax_pose 3, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose203:
+ax_pose 42, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose204:
+ax_pose 43, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose205:
+ax_pose 42, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose206:
+ax_pose 43, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose207:
+ax_pose 42, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose208:
+ax_pose 44, 0x01eb, 0x80ee, 0x5c00
+ax_pose_terminator
+sSquirtlePose209:
+ax_pose 45, 0x41f3, 0x80ed, 0x5c00
+ax_pose_terminator
+sSquirtlePose210:
+ax_pose 46, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose211:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose212:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose213:
+ax_pose 47, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose214:
+ax_pose 48, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose215:
+ax_pose 49, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sSquirtlePose216:
+ax_pose 50, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose217:
+ax_pose 51, 0x01ec, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose218:
+ax_pose 52, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose219:
+ax_pose 53, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sSquirtlePose220:
+ax_pose 54, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose221:
+ax_pose 55, 0x81ef, 0x1103, 0x5c00
+ax_pose 56, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sSquirtlePose222:
+ax_pose 56, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose223:
+ax_pose 57, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose224:
+ax_pose 58, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose225:
+ax_pose 59, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose226:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose227:
+ax_pose 60, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose228:
+ax_pose 61, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sSquirtlePose229:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose230:
+ax_pose 62, 0x81ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose231:
+ax_pose 63, 0x81f1, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose232:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose233:
+ax_pose 50, 0x01eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose234:
+ax_pose 64, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose235:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose236:
+ax_pose 65, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sSquirtlePose237:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose238:
+ax_pose 65, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose239:
+ax_pose 12, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose240:
+ax_pose 66, 0x01ee, 0x80f7, 0x5c00
+ax_pose_terminator
+sSquirtlePose241:
+ax_pose 67, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose242:
+ax_pose 68, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose243:
+ax_pose 69, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose244:
+ax_pose 70, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose245:
+ax_pose 71, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSquirtlePose246:
+ax_pose 67, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose247:
+ax_pose 68, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose248:
+ax_pose 69, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose249:
+ax_pose 70, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose250:
+ax_pose 71, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSquirtlePose251:
+ax_pose 72, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sSquirtlePose252:
+ax_pose 42, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose253:
+ax_pose 43, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose254:
+ax_pose 42, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose255:
+ax_pose 43, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose256:
+ax_pose 42, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose257:
+ax_pose 43, 0x41f3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose258:
+ax_pose 42, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSquirtlePose259:
+ax_pose 43, 0x41f3, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sSquirtleAnims_1_1:
+ax_anim 12, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 12, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_1_2:
+ax_anim 12, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 12, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_1_3:
+ax_anim 12, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 12, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_1_4:
+ax_anim 12, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 12, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_1_5:
+ax_anim 12, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 12, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_1_6:
+ax_anim 12, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 12, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_1_7:
+ax_anim 12, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 12, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_1_8:
+ax_anim 12, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 12, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSquirtleAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sSquirtleAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSquirtleAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -2, 0, -2,
+ax_anim 1, 2, 34, 4, -7, 4, -7,
+ax_anim 1, 0, 35, 10, -14, 10, -14,
+ax_anim 2, 0, 34, 18, -24, 18, -24,
+ax_anim 2, 1, 34, 19, -23, 19, -23,
+ax_anim 2, 0, 34, 18, -24, 18, -24,
+ax_anim 2, 0, 34, 19, -23, 19, -23,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSquirtleAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -5, 0, -5,
+ax_anim 1, 0, 38, 0, -13, 0, -13,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 1, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 0, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSquirtleAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -2, 0, -2,
+ax_anim 1, 2, 40, -4, -7, -4, -7,
+ax_anim 1, 0, 41, -10, -14, -10, -14,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 1, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 40, -18, -24, -18, -24,
+ax_anim 2, 0, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSquirtleAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSquirtleAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSquirtleAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sSquirtleAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSquirtleAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -2, 0, -2,
+ax_anim 1, 2, 58, 4, -7, 4, -7,
+ax_anim 1, 0, 59, 10, -14, 10, -14,
+ax_anim 2, 0, 58, 18, -24, 18, -24,
+ax_anim 2, 1, 58, 19, -23, 19, -23,
+ax_anim 2, 0, 58, 18, -24, 18, -24,
+ax_anim 2, 0, 58, 19, -23, 19, -23,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSquirtleAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -5, 0, -5,
+ax_anim 1, 0, 62, 0, -13, 0, -13,
+ax_anim 2, 0, 61, 0, -24, 0, -24,
+ax_anim 2, 1, 61, 1, -24, 1, -24,
+ax_anim 2, 0, 61, 0, -24, 0, -24,
+ax_anim 2, 0, 61, 1, -24, 1, -24,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSquirtleAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -2, 0, -2,
+ax_anim 1, 2, 64, -4, -7, -4, -7,
+ax_anim 1, 0, 65, -10, -14, -10, -14,
+ax_anim 2, 0, 64, -18, -24, -18, -24,
+ax_anim 2, 1, 64, -19, -23, -19, -23,
+ax_anim 2, 0, 64, -18, -24, -18, -24,
+ax_anim 2, 0, 64, -19, -23, -19, -23,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSquirtleAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSquirtleAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 6, 0, 72, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 2, 2, 74, 0, 1, 0, 1,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 2, 1, 74, 0, 1, 0, 1,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim_terminator
+sSquirtleAnims_4_2:
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim 6, 0, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 2, 78, 1, 1, 1, 1,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 1, 78, 1, 1, 1, 1,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_4_3:
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 6, 0, 80, -3, 0, -3, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 2, 82, 1, 0, 1, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 1, 82, 1, 0, 1, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_4_4:
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 6, 0, 84, -3, 3, -3, 3,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim_terminator
+sSquirtleAnims_4_5:
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 6, 0, 88, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 2, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim_terminator
+sSquirtleAnims_4_6:
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 6, 0, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 2, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 1, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim_terminator
+sSquirtleAnims_4_7:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 6, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 2, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 1, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_4_8:
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 6, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 2, 102, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 1, 102, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 101, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_5_1:
+ax_anim 20, 0, 104, 0, 0, 1, 0,
+ax_anim 2, 2, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 0, 0, 1, 0,
+ax_anim 1, 0, 104, 1, 0, 2, 0,
+ax_anim 1, 0, 104, 0, 0, 1, 0,
+ax_anim 2, 0, 104, 1, 0, 2, 0,
+ax_anim 2, 0, 104, 0, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_5_2:
+ax_anim 20, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 1, 0, 1, 0,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_5_3:
+ax_anim 20, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 1, 0, 1, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_5_4:
+ax_anim 20, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 1, 0, 1, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_5_5:
+ax_anim 20, 0, 108, 0, 0, 1, 0,
+ax_anim 2, 2, 108, 1, 0, 2, 0,
+ax_anim 2, 0, 108, 0, 0, 1, 0,
+ax_anim 1, 0, 108, 1, 0, 2, 0,
+ax_anim 1, 0, 108, 0, 0, 1, 0,
+ax_anim 2, 0, 108, 1, 0, 2, 0,
+ax_anim 2, 0, 108, 0, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_5_6:
+ax_anim 20, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 1, 0, 1, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_5_7:
+ax_anim 20, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 1, 0, 1, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_5_8:
+ax_anim 20, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 1, 0, 1, 0,
+ax_anim 1, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sSquirtleAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sSquirtleAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sSquirtleAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sSquirtleAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sSquirtleAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sSquirtleAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sSquirtleAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_8_1:
+ax_anim 30, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 4, 0, 124, 0, -4, 0, 0,
+ax_anim 4, 0, 123, 0, -4, 0, 0,
+ax_anim 4, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_8_2:
+ax_anim 30, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 4, 0, 126, 0, -4, 0, 0,
+ax_anim 4, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -2, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_8_3:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 4, 0, 130, 0, -4, 0, 0,
+ax_anim 4, 0, 129, 0, -4, 0, 0,
+ax_anim 4, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_8_4:
+ax_anim 30, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 133, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_8_5:
+ax_anim 30, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 4, 0, 136, 0, -4, 0, 0,
+ax_anim 4, 0, 135, 0, -4, 0, 0,
+ax_anim 4, 0, 136, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_8_6:
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 139, 0, -4, 0, 0,
+ax_anim 4, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_8_7:
+ax_anim 30, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 141, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 141, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_8_8:
+ax_anim 30, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 145, 0, -4, 0, 0,
+ax_anim 4, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 145, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 16, 7, 16,
+ax_anim 3, 0, 150, 0, 19, 0, 19,
+ax_anim 2, 3, 151, -7, 16, -7, 16,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 7, -1, 7, -1,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 24, 9, 24, 9,
+ax_anim 3, 0, 149, 22, 18, 22, 18,
+ax_anim 2, 3, 150, 12, 19, 12, 19,
+ax_anim 2, 0, 151, 2, 12, 2, 12,
+ax_anim 1, 0, 152, -1, 7, -1, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 19, -4, 19, -4,
+ax_anim 3, 0, 148, 23, 1, 23, 1,
+ax_anim 2, 3, 149, 17, 7, 17, 7,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 3, -16, 3, -16,
+ax_anim 2, 0, 146, 11, -26, 11, -26,
+ax_anim 3, 0, 147, 20, -27, 20, -27,
+ax_anim 2, 3, 148, 21, -13, 21, -13,
+ax_anim 2, 0, 149, 16, -6, 16, -6,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -10, -8, -10,
+ax_anim 2, 0, 153, -7, -18, -7, -18,
+ax_anim 3, 0, 146, 0, -27, 0, -27,
+ax_anim 2, 3, 147, 7, -18, 7, -18,
+ax_anim 2, 0, 148, 8, -8, 8, -8,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -3, -16, -3, -16,
+ax_anim 2, 0, 146, -11, -26, -11, -26,
+ax_anim 3, 0, 153, -19, -27, -19, -27,
+ax_anim 2, 3, 152, -21, -13, -21, -13,
+ax_anim 2, 0, 151, -16, -6, -16, -6,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -19, -4, -19, -4,
+ax_anim 3, 0, 152, -23, 1, -23, 1,
+ax_anim 2, 3, 151, -17, 7, -17, 7,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -7, -1, -7, -1,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -24, 9, -24, 9,
+ax_anim 3, 0, 151, -22, 18, -22, 18,
+ax_anim 2, 3, 150, -12, 19, -12, 19,
+ax_anim 2, 0, 149, -2, 12, -2, 12,
+ax_anim 1, 0, 148, 1, 7, 1, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -22, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_14_1:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_14_2:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_14_3:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_14_4:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_14_5:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_14_6:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_14_7:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_14_8:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_15_1:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_15_2:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_15_3:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_15_4:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_15_5:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_15_6:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_15_7:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_15_8:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 10, 0, 208, 0, 0, 0, 0,
+ax_anim 8, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_16_1:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_16_2:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_16_3:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_16_4:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_16_5:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_16_6:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_16_7:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_16_8:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_17_1:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_17_2:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_17_3:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_17_4:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_17_5:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_17_6:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_17_7:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sSquirtleAnims_17_8:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_18_1:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_18_2:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_18_3:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_18_4:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_18_5:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 8, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_18_6:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_18_7:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_18_8:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 8, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_19_1:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_19_2:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_19_3:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_19_4:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_19_5:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_19_6:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_19_7:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_19_8:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_20_1:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 1, 0, 0,
+ax_anim 2, 0, 227, 1, 1, 1, 0,
+ax_anim 2, 0, 227, 0, 1, 0, 0,
+ax_anim 2, 0, 227, 1, 1, 1, 0,
+ax_anim 2, 0, 227, 0, 1, 0, 0,
+ax_anim 2, 0, 227, 1, 1, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_20_2:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_20_3:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_20_4:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_20_5:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_20_6:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_20_7:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sSquirtleAnims_20_8:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_21_1:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_21_2:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_21_3:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_21_4:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_21_5:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_21_6:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_21_7:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_21_8:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_22_1:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_22_2:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_22_3:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_22_4:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_22_5:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_22_6:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_22_7:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_22_8:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_23_1:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_23_2:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_23_3:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_23_4:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_23_5:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_23_6:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_23_7:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_23_8:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_24_1:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_24_2:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_24_3:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_24_4:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_24_5:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_24_6:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_24_7:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_24_8:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_25_1:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_25_2:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_25_3:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_25_4:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_25_5:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_25_6:
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 10, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_25_7:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_25_8:
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_26_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_26_2:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_26_3:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_26_4:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_26_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_26_6:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_26_7:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sSquirtleAnims_26_8:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_27_1:
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 16, 0, 251, -1, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 1, 0, 0, 0,
+ax_anim 16, 0, 251, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSquirtleAnims_28_1:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_28_2:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_28_3:
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_28_4:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_28_5:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_28_6:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_28_7:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleAnims_28_8:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSquirtleGfx1:
+.incbin "baserom.gba", 0x56247C, 0x200
+sSquirtleSprites1:
+ax_sprite sSquirtleGfx1, 0x200
+ax_sprite_terminator
+sSquirtleGfx2:
+.incbin "baserom.gba", 0x56268C, 0x200
+sSquirtleSprites2:
+ax_sprite sSquirtleGfx2, 0x200
+ax_sprite_terminator
+sSquirtleGfx3:
+.incbin "baserom.gba", 0x56289C, 0x200
+sSquirtleSprites3:
+ax_sprite sSquirtleGfx3, 0x200
+ax_sprite_terminator
+sSquirtleGfx4:
+.incbin "baserom.gba", 0x562AAC, 0x200
+sSquirtleSprites4:
+ax_sprite sSquirtleGfx4, 0x200
+ax_sprite_terminator
+sSquirtleGfx5:
+.incbin "baserom.gba", 0x562CBC, 0x200
+sSquirtleSprites5:
+ax_sprite sSquirtleGfx5, 0x200
+ax_sprite_terminator
+sSquirtleGfx6:
+.incbin "baserom.gba", 0x562ECC, 0x200
+sSquirtleSprites6:
+ax_sprite sSquirtleGfx6, 0x200
+ax_sprite_terminator
+sSquirtleGfx7:
+.incbin "baserom.gba", 0x5630DC, 0x200
+sSquirtleSprites7:
+ax_sprite sSquirtleGfx7, 0x200
+ax_sprite_terminator
+sSquirtleGfx8:
+.incbin "baserom.gba", 0x5632EC, 0x200
+sSquirtleSprites8:
+ax_sprite sSquirtleGfx8, 0x200
+ax_sprite_terminator
+sSquirtleGfx9:
+.incbin "baserom.gba", 0x5634FC, 0x200
+sSquirtleSprites9:
+ax_sprite sSquirtleGfx9, 0x200
+ax_sprite_terminator
+sSquirtleGfx10:
+.incbin "baserom.gba", 0x56370C, 0x200
+sSquirtleSprites10:
+ax_sprite sSquirtleGfx10, 0x200
+ax_sprite_terminator
+sSquirtleGfx11:
+.incbin "baserom.gba", 0x56391C, 0x200
+sSquirtleSprites11:
+ax_sprite sSquirtleGfx11, 0x200
+ax_sprite_terminator
+sSquirtleGfx12:
+.incbin "baserom.gba", 0x563B2C, 0x200
+sSquirtleSprites12:
+ax_sprite sSquirtleGfx12, 0x200
+ax_sprite_terminator
+sSquirtleGfx13:
+.incbin "baserom.gba", 0x563D3C, 0x100
+sSquirtleSprites13:
+ax_sprite sSquirtleGfx13, 0x100
+ax_sprite_terminator
+sSquirtleGfx14:
+.incbin "baserom.gba", 0x563E4C, 0x100
+sSquirtleSprites14:
+ax_sprite sSquirtleGfx14, 0x100
+ax_sprite_terminator
+sSquirtleGfx15:
+.incbin "baserom.gba", 0x563F5C, 0x100
+sSquirtleSprites15:
+ax_sprite sSquirtleGfx15, 0x100
+ax_sprite_terminator
+sSquirtleGfx16:
+.incbin "baserom.gba", 0x56406C, 0x40
+sSquirtleGfx16_1:
+.incbin "baserom.gba", 0x5640AC, 0x60
+sSquirtleGfx16_2:
+.incbin "baserom.gba", 0x56410C, 0x60
+sSquirtleSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx17:
+.incbin "baserom.gba", 0x5641AC, 0x20
+sSquirtleGfx17_1:
+.incbin "baserom.gba", 0x5641CC, 0x60
+sSquirtleGfx17_2:
+.incbin "baserom.gba", 0x56422C, 0x60
+sSquirtleSprites17:
+ax_sprite sSquirtleGfx17, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSquirtleGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx18:
+.incbin "baserom.gba", 0x5642C4, 0x20
+sSquirtleGfx18_1:
+.incbin "baserom.gba", 0x5642E4, 0x60
+sSquirtleGfx18_2:
+.incbin "baserom.gba", 0x564344, 0x60
+sSquirtleSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx19:
+.incbin "baserom.gba", 0x5643E4, 0x40
+sSquirtleGfx19_1:
+.incbin "baserom.gba", 0x564424, 0xE0
+sSquirtleSprites19:
+ax_sprite sSquirtleGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx19_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx20:
+.incbin "baserom.gba", 0x56452C, 0x60
+sSquirtleGfx20_1:
+.incbin "baserom.gba", 0x56458C, 0x60
+sSquirtleGfx20_2:
+.incbin "baserom.gba", 0x5645EC, 0x60
+sSquirtleSprites20:
+ax_sprite sSquirtleGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx21:
+.incbin "baserom.gba", 0x564684, 0x60
+sSquirtleGfx21_1:
+.incbin "baserom.gba", 0x5646E4, 0x60
+sSquirtleGfx21_2:
+.incbin "baserom.gba", 0x564744, 0x60
+sSquirtleSprites21:
+ax_sprite sSquirtleGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx22:
+.incbin "baserom.gba", 0x5647DC, 0x40
+sSquirtleGfx22_1:
+.incbin "baserom.gba", 0x56481C, 0x60
+sSquirtleGfx22_2:
+.incbin "baserom.gba", 0x56487C, 0x80
+sSquirtleSprites22:
+ax_sprite sSquirtleGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx22_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSquirtleGfx23:
+.incbin "baserom.gba", 0x564934, 0x40
+sSquirtleGfx23_1:
+.incbin "baserom.gba", 0x564974, 0xE0
+sSquirtleSprites23:
+ax_sprite sSquirtleGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx23_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx24:
+.incbin "baserom.gba", 0x564A7C, 0x40
+sSquirtleGfx24_1:
+.incbin "baserom.gba", 0x564ABC, 0x100
+sSquirtleSprites24:
+ax_sprite sSquirtleGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx24_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSquirtleGfx25:
+.incbin "baserom.gba", 0x564BE4, 0x40
+sSquirtleGfx25_1:
+.incbin "baserom.gba", 0x564C24, 0x60
+sSquirtleGfx25_2:
+.incbin "baserom.gba", 0x564C84, 0x60
+sSquirtleSprites25:
+ax_sprite sSquirtleGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx26:
+.incbin "baserom.gba", 0x564D1C, 0x40
+sSquirtleGfx26_1:
+.incbin "baserom.gba", 0x564D5C, 0x60
+sSquirtleGfx26_2:
+.incbin "baserom.gba", 0x564DBC, 0x60
+sSquirtleSprites26:
+ax_sprite sSquirtleGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx27:
+.incbin "baserom.gba", 0x564E54, 0x40
+sSquirtleGfx27_1:
+.incbin "baserom.gba", 0x564E94, 0x60
+sSquirtleGfx27_2:
+.incbin "baserom.gba", 0x564EF4, 0x60
+sSquirtleSprites27:
+ax_sprite sSquirtleGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSquirtleGfx28:
+.incbin "baserom.gba", 0x564F8C, 0x40
+sSquirtleGfx28_1:
+.incbin "baserom.gba", 0x564FCC, 0x40
+sSquirtleGfx28_2:
+.incbin "baserom.gba", 0x56500C, 0x60
+sSquirtleGfx28_3:
+.incbin "baserom.gba", 0x56506C, 0x40
+sSquirtleSprites28:
+ax_sprite sSquirtleGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx28_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSquirtleGfx29:
+.incbin "baserom.gba", 0x5650F4, 0x40
+sSquirtleGfx29_1:
+.incbin "baserom.gba", 0x565134, 0x60
+sSquirtleGfx29_2:
+.incbin "baserom.gba", 0x565194, 0x40
+sSquirtleGfx29_3:
+.incbin "baserom.gba", 0x5651D4, 0x20
+sSquirtleSprites29:
+ax_sprite sSquirtleGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx29_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sSquirtleGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSquirtleGfx30:
+.incbin "baserom.gba", 0x56523C, 0x40
+sSquirtleGfx30_1:
+.incbin "baserom.gba", 0x56527C, 0x40
+sSquirtleGfx30_2:
+.incbin "baserom.gba", 0x5652BC, 0x60
+sSquirtleGfx30_3:
+.incbin "baserom.gba", 0x56531C, 0x40
+sSquirtleSprites30:
+ax_sprite sSquirtleGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx30_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSquirtleGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSquirtleGfx30_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSquirtleGfx31:
+.incbin "baserom.gba", 0x5653A4, 0x80
+sSquirtleSprites31:
+ax_sprite sSquirtleGfx31, 0x80
+ax_sprite_terminator
+sSquirtleGfx32:
+.incbin "baserom.gba", 0x565434, 0x80
+sSquirtleSprites32:
+ax_sprite sSquirtleGfx32, 0x80
+ax_sprite_terminator
+sSquirtleGfx33:
+.incbin "baserom.gba", 0x5654C4, 0x80
+sSquirtleSprites33:
+ax_sprite sSquirtleGfx33, 0x80
+ax_sprite_terminator
+sSquirtleGfx34:
+.incbin "baserom.gba", 0x565554, 0x80
+sSquirtleSprites34:
+ax_sprite sSquirtleGfx34, 0x80
+ax_sprite_terminator
+sSquirtleGfx35:
+.incbin "baserom.gba", 0x5655E4, 0x80
+sSquirtleSprites35:
+ax_sprite sSquirtleGfx35, 0x80
+ax_sprite_terminator
+sSquirtleGfx36:
+.incbin "baserom.gba", 0x565674, 0x200
+sSquirtleSprites36:
+ax_sprite sSquirtleGfx36, 0x200
+ax_sprite_terminator
+sSquirtleGfx37:
+.incbin "baserom.gba", 0x565884, 0x200
+sSquirtleSprites37:
+ax_sprite sSquirtleGfx37, 0x200
+ax_sprite_terminator
+sSquirtleGfx38:
+.incbin "baserom.gba", 0x565A94, 0x200
+sSquirtleSprites38:
+ax_sprite sSquirtleGfx38, 0x200
+ax_sprite_terminator
+sSquirtleGfx39:
+.incbin "baserom.gba", 0x565CA4, 0x200
+sSquirtleSprites39:
+ax_sprite sSquirtleGfx39, 0x200
+ax_sprite_terminator
+sSquirtleGfx40:
+.incbin "baserom.gba", 0x565EB4, 0x200
+sSquirtleSprites40:
+ax_sprite sSquirtleGfx40, 0x200
+ax_sprite_terminator
+sSquirtleGfx41:
+.incbin "baserom.gba", 0x5660C4, 0x200
+sSquirtleSprites41:
+ax_sprite sSquirtleGfx41, 0x200
+ax_sprite_terminator
+sSquirtleGfx42:
+.incbin "baserom.gba", 0x5662D4, 0x200
+sSquirtleSprites42:
+ax_sprite sSquirtleGfx42, 0x200
+ax_sprite_terminator
+sSquirtleGfx43:
+.incbin "baserom.gba", 0x5664E4, 0x100
+sSquirtleSprites43:
+ax_sprite sSquirtleGfx43, 0x100
+ax_sprite_terminator
+sSquirtleGfx44:
+.incbin "baserom.gba", 0x5665F4, 0x100
+sSquirtleSprites44:
+ax_sprite sSquirtleGfx44, 0x100
+ax_sprite_terminator
+sSquirtleGfx45:
+.incbin "baserom.gba", 0x566704, 0x200
+sSquirtleSprites45:
+ax_sprite sSquirtleGfx45, 0x200
+ax_sprite_terminator
+sSquirtleGfx46:
+.incbin "baserom.gba", 0x566914, 0x100
+sSquirtleSprites46:
+ax_sprite sSquirtleGfx46, 0x100
+ax_sprite_terminator
+sSquirtleGfx47:
+.incbin "baserom.gba", 0x566A24, 0x200
+sSquirtleSprites47:
+ax_sprite sSquirtleGfx47, 0x200
+ax_sprite_terminator
+sSquirtleGfx48:
+.incbin "baserom.gba", 0x566C34, 0x100
+sSquirtleSprites48:
+ax_sprite sSquirtleGfx48, 0x100
+ax_sprite_terminator
+sSquirtleGfx49:
+.incbin "baserom.gba", 0x566D44, 0x200
+sSquirtleSprites49:
+ax_sprite sSquirtleGfx49, 0x200
+ax_sprite_terminator
+sSquirtleGfx50:
+.incbin "baserom.gba", 0x566F54, 0x80
+sSquirtleSprites50:
+ax_sprite sSquirtleGfx50, 0x80
+ax_sprite_terminator
+sSquirtleGfx51:
+.incbin "baserom.gba", 0x566FE4, 0x200
+sSquirtleSprites51:
+ax_sprite sSquirtleGfx51, 0x200
+ax_sprite_terminator
+sSquirtleGfx52:
+.incbin "baserom.gba", 0x5671F4, 0x200
+sSquirtleSprites52:
+ax_sprite sSquirtleGfx52, 0x200
+ax_sprite_terminator
+sSquirtleGfx53:
+.incbin "baserom.gba", 0x567404, 0x200
+sSquirtleSprites53:
+ax_sprite sSquirtleGfx53, 0x200
+ax_sprite_terminator
+sSquirtleGfx54:
+.incbin "baserom.gba", 0x567614, 0x100
+sSquirtleSprites54:
+ax_sprite sSquirtleGfx54, 0x100
+ax_sprite_terminator
+sSquirtleGfx55:
+.incbin "baserom.gba", 0x567724, 0x200
+sSquirtleSprites55:
+ax_sprite sSquirtleGfx55, 0x200
+ax_sprite_terminator
+sSquirtleGfx56:
+.incbin "baserom.gba", 0x567934, 0x40
+sSquirtleSprites56:
+ax_sprite sSquirtleGfx56, 0x40
+ax_sprite_terminator
+sSquirtleGfx57:
+.incbin "baserom.gba", 0x567984, 0x100
+sSquirtleSprites57:
+ax_sprite sSquirtleGfx57, 0x100
+ax_sprite_terminator
+sSquirtleGfx58:
+.incbin "baserom.gba", 0x567A94, 0x200
+sSquirtleSprites58:
+ax_sprite sSquirtleGfx58, 0x200
+ax_sprite_terminator
+sSquirtleGfx59:
+.incbin "baserom.gba", 0x567CA4, 0x100
+sSquirtleSprites59:
+ax_sprite sSquirtleGfx59, 0x100
+ax_sprite_terminator
+sSquirtleGfx60:
+.incbin "baserom.gba", 0x567DB4, 0x100
+sSquirtleSprites60:
+ax_sprite sSquirtleGfx60, 0x100
+ax_sprite_terminator
+sSquirtleGfx61:
+.incbin "baserom.gba", 0x567EC4, 0x200
+sSquirtleSprites61:
+ax_sprite sSquirtleGfx61, 0x200
+ax_sprite_terminator
+sSquirtleGfx62:
+.incbin "baserom.gba", 0x5680D4, 0x200
+sSquirtleSprites62:
+ax_sprite sSquirtleGfx62, 0x200
+ax_sprite_terminator
+sSquirtleGfx63:
+.incbin "baserom.gba", 0x5682E4, 0x100
+sSquirtleSprites63:
+ax_sprite sSquirtleGfx63, 0x100
+ax_sprite_terminator
+sSquirtleGfx64:
+.incbin "baserom.gba", 0x5683F4, 0x100
+sSquirtleSprites64:
+ax_sprite sSquirtleGfx64, 0x100
+ax_sprite_terminator
+sSquirtleGfx65:
+.incbin "baserom.gba", 0x568504, 0x100
+sSquirtleSprites65:
+ax_sprite sSquirtleGfx65, 0x100
+ax_sprite_terminator
+sSquirtleGfx66:
+.incbin "baserom.gba", 0x568614, 0x200
+sSquirtleSprites66:
+ax_sprite sSquirtleGfx66, 0x200
+ax_sprite_terminator
+sSquirtleGfx67:
+.incbin "baserom.gba", 0x568824, 0x200
+sSquirtleSprites67:
+ax_sprite sSquirtleGfx67, 0x200
+ax_sprite_terminator
+sSquirtleGfx68:
+.incbin "baserom.gba", 0x568A34, 0x200
+sSquirtleSprites68:
+ax_sprite sSquirtleGfx68, 0x200
+ax_sprite_terminator
+sSquirtleGfx69:
+.incbin "baserom.gba", 0x568C44, 0x200
+sSquirtleSprites69:
+ax_sprite sSquirtleGfx69, 0x200
+ax_sprite_terminator
+sSquirtleGfx70:
+.incbin "baserom.gba", 0x568E54, 0x200
+sSquirtleSprites70:
+ax_sprite sSquirtleGfx70, 0x200
+ax_sprite_terminator
+sSquirtleGfx71:
+.incbin "baserom.gba", 0x569064, 0x200
+sSquirtleSprites71:
+ax_sprite sSquirtleGfx71, 0x200
+ax_sprite_terminator
+sSquirtleGfx72:
+.incbin "baserom.gba", 0x569274, 0x200
+sSquirtleSprites72:
+ax_sprite sSquirtleGfx72, 0x200
+ax_sprite_terminator
+sSquirtleGfx73:
+.incbin "baserom.gba", 0x569484, 0x200
+sSquirtleSprites73:
+ax_sprite sSquirtleGfx73, 0x200
+ax_sprite_terminator
+sAxPosesSquirtle:
+.4byte sSquirtlePose1
+.4byte sSquirtlePose2
+.4byte sSquirtlePose3
+.4byte sSquirtlePose4
+.4byte sSquirtlePose5
+.4byte sSquirtlePose6
+.4byte sSquirtlePose7
+.4byte sSquirtlePose8
+.4byte sSquirtlePose9
+.4byte sSquirtlePose10
+.4byte sSquirtlePose11
+.4byte sSquirtlePose12
+.4byte sSquirtlePose13
+.4byte sSquirtlePose14
+.4byte sSquirtlePose15
+.4byte sSquirtlePose16
+.4byte sSquirtlePose17
+.4byte sSquirtlePose18
+.4byte sSquirtlePose19
+.4byte sSquirtlePose20
+.4byte sSquirtlePose21
+.4byte sSquirtlePose22
+.4byte sSquirtlePose23
+.4byte sSquirtlePose24
+.4byte sSquirtlePose25
+.4byte sSquirtlePose26
+.4byte sSquirtlePose27
+.4byte sSquirtlePose28
+.4byte sSquirtlePose29
+.4byte sSquirtlePose30
+.4byte sSquirtlePose31
+.4byte sSquirtlePose32
+.4byte sSquirtlePose33
+.4byte sSquirtlePose34
+.4byte sSquirtlePose35
+.4byte sSquirtlePose36
+.4byte sSquirtlePose37
+.4byte sSquirtlePose38
+.4byte sSquirtlePose39
+.4byte sSquirtlePose40
+.4byte sSquirtlePose41
+.4byte sSquirtlePose42
+.4byte sSquirtlePose43
+.4byte sSquirtlePose44
+.4byte sSquirtlePose45
+.4byte sSquirtlePose46
+.4byte sSquirtlePose47
+.4byte sSquirtlePose48
+.4byte sSquirtlePose49
+.4byte sSquirtlePose50
+.4byte sSquirtlePose51
+.4byte sSquirtlePose52
+.4byte sSquirtlePose53
+.4byte sSquirtlePose54
+.4byte sSquirtlePose55
+.4byte sSquirtlePose56
+.4byte sSquirtlePose57
+.4byte sSquirtlePose58
+.4byte sSquirtlePose59
+.4byte sSquirtlePose60
+.4byte sSquirtlePose61
+.4byte sSquirtlePose62
+.4byte sSquirtlePose63
+.4byte sSquirtlePose64
+.4byte sSquirtlePose65
+.4byte sSquirtlePose66
+.4byte sSquirtlePose67
+.4byte sSquirtlePose68
+.4byte sSquirtlePose69
+.4byte sSquirtlePose70
+.4byte sSquirtlePose71
+.4byte sSquirtlePose72
+.4byte sSquirtlePose73
+.4byte sSquirtlePose74
+.4byte sSquirtlePose75
+.4byte sSquirtlePose76
+.4byte sSquirtlePose77
+.4byte sSquirtlePose78
+.4byte sSquirtlePose79
+.4byte sSquirtlePose80
+.4byte sSquirtlePose81
+.4byte sSquirtlePose82
+.4byte sSquirtlePose83
+.4byte sSquirtlePose84
+.4byte sSquirtlePose85
+.4byte sSquirtlePose86
+.4byte sSquirtlePose87
+.4byte sSquirtlePose88
+.4byte sSquirtlePose89
+.4byte sSquirtlePose90
+.4byte sSquirtlePose91
+.4byte sSquirtlePose92
+.4byte sSquirtlePose93
+.4byte sSquirtlePose94
+.4byte sSquirtlePose95
+.4byte sSquirtlePose96
+.4byte sSquirtlePose97
+.4byte sSquirtlePose98
+.4byte sSquirtlePose99
+.4byte sSquirtlePose100
+.4byte sSquirtlePose101
+.4byte sSquirtlePose102
+.4byte sSquirtlePose103
+.4byte sSquirtlePose104
+.4byte sSquirtlePose105
+.4byte sSquirtlePose106
+.4byte sSquirtlePose107
+.4byte sSquirtlePose108
+.4byte sSquirtlePose109
+.4byte sSquirtlePose110
+.4byte sSquirtlePose111
+.4byte sSquirtlePose112
+.4byte sSquirtlePose113
+.4byte sSquirtlePose114
+.4byte sSquirtlePose115
+.4byte sSquirtlePose116
+.4byte sSquirtlePose117
+.4byte sSquirtlePose118
+.4byte sSquirtlePose119
+.4byte sSquirtlePose120
+.4byte sSquirtlePose121
+.4byte sSquirtlePose122
+.4byte sSquirtlePose123
+.4byte sSquirtlePose124
+.4byte sSquirtlePose125
+.4byte sSquirtlePose126
+.4byte sSquirtlePose127
+.4byte sSquirtlePose128
+.4byte sSquirtlePose129
+.4byte sSquirtlePose130
+.4byte sSquirtlePose131
+.4byte sSquirtlePose132
+.4byte sSquirtlePose133
+.4byte sSquirtlePose134
+.4byte sSquirtlePose135
+.4byte sSquirtlePose136
+.4byte sSquirtlePose137
+.4byte sSquirtlePose138
+.4byte sSquirtlePose139
+.4byte sSquirtlePose140
+.4byte sSquirtlePose141
+.4byte sSquirtlePose142
+.4byte sSquirtlePose143
+.4byte sSquirtlePose144
+.4byte sSquirtlePose145
+.4byte sSquirtlePose146
+.4byte sSquirtlePose147
+.4byte sSquirtlePose148
+.4byte sSquirtlePose149
+.4byte sSquirtlePose150
+.4byte sSquirtlePose151
+.4byte sSquirtlePose152
+.4byte sSquirtlePose153
+.4byte sSquirtlePose154
+.4byte sSquirtlePose155
+.4byte sSquirtlePose156
+.4byte sSquirtlePose157
+.4byte sSquirtlePose158
+.4byte sSquirtlePose159
+.4byte sSquirtlePose160
+.4byte sSquirtlePose161
+.4byte sSquirtlePose162
+.4byte sSquirtlePose163
+.4byte sSquirtlePose164
+.4byte sSquirtlePose165
+.4byte sSquirtlePose166
+.4byte sSquirtlePose167
+.4byte sSquirtlePose168
+.4byte sSquirtlePose169
+.4byte sSquirtlePose170
+.4byte sSquirtlePose171
+.4byte sSquirtlePose172
+.4byte sSquirtlePose173
+.4byte sSquirtlePose174
+.4byte sSquirtlePose175
+.4byte sSquirtlePose176
+.4byte sSquirtlePose177
+.4byte sSquirtlePose178
+.4byte sSquirtlePose179
+.4byte sSquirtlePose180
+.4byte sSquirtlePose181
+.4byte sSquirtlePose182
+.4byte sSquirtlePose183
+.4byte sSquirtlePose184
+.4byte sSquirtlePose185
+.4byte sSquirtlePose186
+.4byte sSquirtlePose187
+.4byte sSquirtlePose188
+.4byte sSquirtlePose189
+.4byte sSquirtlePose190
+.4byte sSquirtlePose191
+.4byte sSquirtlePose192
+.4byte sSquirtlePose193
+.4byte sSquirtlePose194
+.4byte sSquirtlePose195
+.4byte sSquirtlePose196
+.4byte sSquirtlePose197
+.4byte sSquirtlePose198
+.4byte sSquirtlePose199
+.4byte sSquirtlePose200
+.4byte sSquirtlePose201
+.4byte sSquirtlePose202
+.4byte sSquirtlePose203
+.4byte sSquirtlePose204
+.4byte sSquirtlePose205
+.4byte sSquirtlePose206
+.4byte sSquirtlePose207
+.4byte sSquirtlePose208
+.4byte sSquirtlePose209
+.4byte sSquirtlePose210
+.4byte sSquirtlePose211
+.4byte sSquirtlePose212
+.4byte sSquirtlePose213
+.4byte sSquirtlePose214
+.4byte sSquirtlePose215
+.4byte sSquirtlePose216
+.4byte sSquirtlePose217
+.4byte sSquirtlePose218
+.4byte sSquirtlePose219
+.4byte sSquirtlePose220
+.4byte sSquirtlePose221
+.4byte sSquirtlePose222
+.4byte sSquirtlePose223
+.4byte sSquirtlePose224
+.4byte sSquirtlePose225
+.4byte sSquirtlePose226
+.4byte sSquirtlePose227
+.4byte sSquirtlePose228
+.4byte sSquirtlePose229
+.4byte sSquirtlePose230
+.4byte sSquirtlePose231
+.4byte sSquirtlePose232
+.4byte sSquirtlePose233
+.4byte sSquirtlePose234
+.4byte sSquirtlePose235
+.4byte sSquirtlePose236
+.4byte sSquirtlePose237
+.4byte sSquirtlePose238
+.4byte sSquirtlePose239
+.4byte sSquirtlePose240
+.4byte sSquirtlePose241
+.4byte sSquirtlePose242
+.4byte sSquirtlePose243
+.4byte sSquirtlePose244
+.4byte sSquirtlePose245
+.4byte sSquirtlePose246
+.4byte sSquirtlePose247
+.4byte sSquirtlePose248
+.4byte sSquirtlePose249
+.4byte sSquirtlePose250
+.4byte sSquirtlePose251
+.4byte sSquirtlePose252
+.4byte sSquirtlePose253
+.4byte sSquirtlePose254
+.4byte sSquirtlePose255
+.4byte sSquirtlePose256
+.4byte sSquirtlePose257
+.4byte sSquirtlePose258
+.4byte sSquirtlePose259
+sAxPositionsSquirtle:
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -7, 	  -5,   -4, 	   5,   -5, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -8, 	   7,   -6, 	  -2,   -4, 	  -2,   -7
+.2byte    3,   -7, 	   6,   -5, 	   0,   -4, 	  -1,   -6
+.2byte    3,   -7, 	   8,   -4, 	  -3,   -3, 	  -1,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    6,   -8, 	   4,   -3, 	   1,   -3, 	  -2,   -5
+.2byte    6,   -8, 	   1,   -6, 	   3,   -3, 	  -2,   -6
+.2byte    5,  -12, 	  -5,   -8, 	   5,   -4, 	  -2,   -5
+.2byte    5,  -11, 	  -3,   -8, 	   4,   -3, 	  -2,   -4
+.2byte    5,  -12, 	  -5,   -7, 	   5,   -4, 	  -2,   -4
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	  -1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -7,   -4, 	   0,   -5
+.2byte   -7,  -11, 	   1,   -8, 	  -6,   -3, 	   0,   -4
+.2byte   -7,  -12, 	   3,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -8,   -8, 	  -6,   -3, 	  -3,   -3, 	   0,   -5
+.2byte   -8,   -8, 	  -3,   -6, 	  -5,   -3, 	   0,   -6
+.2byte   -5,   -8, 	  -9,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -5,   -7, 	  -8,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -5,   -7, 	 -10,   -4, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -7, 	  -5,   -4, 	   5,   -5, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -8, 	   7,   -6, 	  -2,   -4, 	  -2,   -7
+.2byte    3,   -7, 	   6,   -5, 	   0,   -4, 	  -1,   -6
+.2byte    3,   -7, 	   8,   -4, 	  -3,   -3, 	  -1,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    6,   -8, 	   4,   -3, 	   1,   -3, 	  -2,   -5
+.2byte    6,   -8, 	   1,   -6, 	   3,   -3, 	  -2,   -6
+.2byte    5,  -12, 	  -5,   -8, 	   5,   -4, 	  -2,   -5
+.2byte    5,  -11, 	  -3,   -8, 	   4,   -3, 	  -2,   -4
+.2byte    5,  -12, 	  -5,   -7, 	   5,   -4, 	  -2,   -4
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	  -1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -7,   -4, 	   0,   -5
+.2byte   -7,  -11, 	   1,   -8, 	  -6,   -3, 	   0,   -4
+.2byte   -7,  -12, 	   3,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -8,   -8, 	  -6,   -3, 	  -3,   -3, 	   0,   -5
+.2byte   -8,   -8, 	  -3,   -6, 	  -5,   -3, 	   0,   -6
+.2byte   -5,   -8, 	  -9,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -5,   -7, 	  -8,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -5,   -7, 	 -10,   -4, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -7, 	  -5,   -4, 	   5,   -5, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -8, 	   7,   -6, 	  -2,   -4, 	  -2,   -7
+.2byte    3,   -7, 	   6,   -5, 	   0,   -4, 	  -1,   -6
+.2byte    3,   -7, 	   8,   -4, 	  -3,   -3, 	  -1,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    6,   -8, 	   4,   -3, 	   1,   -3, 	  -2,   -5
+.2byte    6,   -8, 	   1,   -6, 	   3,   -3, 	  -2,   -6
+.2byte    5,  -12, 	  -5,   -8, 	   5,   -4, 	  -2,   -5
+.2byte    5,  -11, 	  -3,   -8, 	   4,   -3, 	  -2,   -4
+.2byte    5,  -12, 	  -5,   -7, 	   5,   -4, 	  -2,   -4
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	  -1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -7,   -4, 	   0,   -5
+.2byte   -7,  -11, 	   1,   -8, 	  -6,   -3, 	   0,   -4
+.2byte   -7,  -12, 	   3,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -8,   -8, 	  -6,   -3, 	  -3,   -3, 	   0,   -5
+.2byte   -8,   -8, 	  -3,   -6, 	  -5,   -3, 	   0,   -6
+.2byte   -5,   -8, 	  -9,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -5,   -7, 	  -8,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -5,   -7, 	 -10,   -4, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -3, 	  -9,   -5, 	   7,   -3, 	  -1,   -6
+.2byte   -1,   -2, 	  -9,   -2, 	   7,   -5, 	  -1,   -4
+.2byte   -1,   -3, 	  -9,   -5, 	   7,   -3, 	  -1,   -7
+.2byte    3,   -8, 	   7,   -6, 	  -2,   -4, 	  -2,   -7
+.2byte    5,   -5, 	   6,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte    5,   -4, 	   8,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    5,   -5, 	   7,   -6, 	  -3,   -3, 	   0,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    6,   -6, 	   2,   -6, 	   2,   -2, 	  -2,   -6
+.2byte    6,   -6, 	   1,   -7, 	   0,   -3, 	  -2,   -5
+.2byte    5,   -6, 	   1,   -8, 	   2,   -2, 	  -1,   -5
+.2byte    5,  -12, 	  -5,   -8, 	   5,   -4, 	  -2,   -5
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -2, 	   0,   -4
+.2byte    5,   -8, 	  -4,   -7, 	   5,   -2, 	  -1,   -4
+.2byte    5,  -10, 	  -2,   -7, 	   6,   -2, 	  -1,   -5
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   6,   -5, 	  -8,   -6, 	  -1,   -5
+.2byte   -1,  -12, 	   6,   -7, 	  -8,   -5, 	  -1,   -5
+.2byte   -1,  -12, 	   6,   -5, 	  -8,   -6, 	  -1,   -5
+.2byte   -6,  -12, 	   4,   -8, 	  -6,   -4, 	   1,   -5
+.2byte   -6,   -9, 	   1,   -6, 	  -7,   -2, 	  -1,   -4
+.2byte   -6,   -8, 	   3,   -7, 	  -6,   -2, 	   0,   -4
+.2byte   -6,  -10, 	   1,   -7, 	  -7,   -2, 	   0,   -5
+.2byte   -7,   -9, 	  -5,   -5, 	  -3,   -4, 	   1,   -6
+.2byte   -7,   -6, 	  -3,   -6, 	  -3,   -2, 	   1,   -6
+.2byte   -7,   -6, 	  -2,   -7, 	  -1,   -3, 	   1,   -5
+.2byte   -6,   -6, 	  -2,   -8, 	  -3,   -2, 	   0,   -5
+.2byte   -4,   -8, 	  -8,   -6, 	   1,   -4, 	   1,   -7
+.2byte   -6,   -5, 	  -7,   -6, 	   2,   -2, 	   0,   -6
+.2byte   -6,   -4, 	  -9,   -3, 	   4,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -8,   -6, 	   2,   -3, 	  -1,   -6
+.2byte   -1,   -1, 	  -4,   -3, 	   4,   -3, 	   0,   -5
+.2byte   -4,   -3, 	  -4,   -6, 	   0,   -1, 	   0,   -5
+.2byte   -4,   -4, 	  -2,   -8, 	   3,   -3, 	   0,   -5
+.2byte   -2,   -7, 	   4,   -6, 	  -4,   -4, 	   0,   -5
+.2byte    0,   -8, 	   4,   -5, 	  -4,   -5, 	   0,   -5
+.2byte    2,   -7, 	  -4,   -6, 	   4,   -4, 	   0,   -5
+.2byte    4,   -4, 	   2,   -8, 	  -3,   -3, 	   0,   -5
+.2byte    4,   -3, 	   4,   -6, 	   0,   -1, 	   0,   -5
+.2byte   -5,   -6, 	  -8,   -3, 	   3,   -1, 	   0,   -5
+.2byte   -6,   -4, 	  -7,   -2, 	   2,   -1, 	  -1,   -5
+.2byte   -1,   -8, 	  -7,   -7, 	   5,   -7, 	  -1,   -7
+.2byte    0,   -9, 	   4,  -10, 	  -2,   -9, 	  -2,   -7
+.2byte    4,   -9, 	   3,  -12, 	   3,   -9, 	  -1,   -6
+.2byte    1,  -14, 	  -5,  -11, 	   5,  -11, 	  -1,   -7
+.2byte   -1,  -15, 	   5,  -11, 	  -6,  -12, 	  -1,   -7
+.2byte   -3,  -14, 	   3,  -11, 	  -7,  -11, 	  -1,   -7
+.2byte   -6,   -9, 	  -5,  -12, 	  -5,   -9, 	  -1,   -6
+.2byte   -2,   -9, 	  -6,  -10, 	   0,   -9, 	   0,   -7
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -7, 	  -5,   -4, 	   5,   -5, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -5, 	   5,   -4, 	  -1,   -6
+.2byte    3,   -8, 	   7,   -6, 	  -2,   -4, 	  -2,   -7
+.2byte    3,   -7, 	   6,   -5, 	   0,   -4, 	  -1,   -6
+.2byte    3,   -7, 	   8,   -4, 	  -3,   -3, 	  -1,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    6,   -8, 	   4,   -3, 	   1,   -3, 	  -2,   -5
+.2byte    6,   -8, 	   1,   -6, 	   3,   -3, 	  -2,   -6
+.2byte    5,  -12, 	  -5,   -8, 	   5,   -4, 	  -2,   -5
+.2byte    5,  -11, 	  -3,   -8, 	   4,   -3, 	  -2,   -4
+.2byte    5,  -12, 	  -5,   -7, 	   5,   -4, 	  -2,   -4
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	   0,   -5
+.2byte   -1,  -13, 	   5,   -6, 	  -7,   -6, 	  -1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -7,   -4, 	   0,   -5
+.2byte   -7,  -11, 	   1,   -8, 	  -6,   -3, 	   0,   -4
+.2byte   -7,  -12, 	   3,   -7, 	  -7,   -4, 	   0,   -4
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -8,   -8, 	  -6,   -3, 	  -3,   -3, 	   0,   -5
+.2byte   -8,   -8, 	  -3,   -6, 	  -5,   -3, 	   0,   -6
+.2byte   -5,   -8, 	  -9,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -5,   -7, 	  -8,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -5,   -7, 	 -10,   -4, 	   1,   -3, 	  -1,   -6
+.2byte   -1,   -3, 	  -9,   -5, 	   7,   -3, 	  -1,   -6
+.2byte   -7,   -5, 	  -8,   -6, 	   1,   -2, 	  -1,   -6
+.2byte   -8,   -6, 	  -4,   -6, 	  -4,   -2, 	   0,   -6
+.2byte   -5,  -10, 	   2,   -7, 	  -6,   -3, 	   0,   -5
+.2byte   -1,  -12, 	   6,   -5, 	  -8,   -6, 	  -1,   -5
+.2byte    4,  -10, 	  -3,   -7, 	   5,   -3, 	  -1,   -5
+.2byte    6,   -6, 	   2,   -6, 	   2,   -2, 	  -2,   -6
+.2byte    5,   -5, 	   6,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,   -3, 	  -9,   -5, 	   7,   -3, 	  -1,   -6
+.2byte    5,   -5, 	   6,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte    6,   -6, 	   2,   -6, 	   2,   -2, 	  -2,   -6
+.2byte    4,  -10, 	  -3,   -7, 	   5,   -3, 	  -1,   -5
+.2byte   -1,  -12, 	   6,   -5, 	  -8,   -6, 	  -1,   -5
+.2byte   -5,  -10, 	   2,   -7, 	  -6,   -3, 	   0,   -5
+.2byte   -8,   -6, 	  -4,   -6, 	  -4,   -2, 	   0,   -6
+.2byte   -7,   -5, 	  -8,   -6, 	   1,   -2, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,   -3, 	  -9,   -5, 	   7,   -3, 	  -1,   -6
+.2byte   -1,   -2, 	  -9,   -2, 	   7,   -5, 	  -1,   -4
+.2byte    3,   -8, 	   7,   -6, 	  -2,   -4, 	  -2,   -7
+.2byte    5,   -5, 	   6,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte    5,   -4, 	   8,   -3, 	  -5,   -3, 	   0,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    6,   -6, 	   2,   -6, 	   2,   -2, 	  -2,   -6
+.2byte    6,   -6, 	   1,   -7, 	   0,   -3, 	  -2,   -5
+.2byte    5,  -12, 	  -5,   -8, 	   5,   -4, 	  -2,   -5
+.2byte    5,   -9, 	  -2,   -6, 	   6,   -2, 	   0,   -4
+.2byte    5,   -8, 	  -4,   -7, 	   5,   -2, 	  -1,   -4
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   6,   -5, 	  -8,   -6, 	  -1,   -5
+.2byte   -1,  -12, 	   6,   -7, 	  -8,   -5, 	  -1,   -5
+.2byte   -7,  -12, 	   3,   -8, 	  -7,   -4, 	   0,   -5
+.2byte   -7,   -9, 	   0,   -6, 	  -8,   -2, 	  -2,   -4
+.2byte   -7,   -8, 	   2,   -7, 	  -7,   -2, 	  -1,   -4
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -8,   -6, 	  -4,   -6, 	  -4,   -2, 	   0,   -6
+.2byte   -8,   -6, 	  -3,   -7, 	  -2,   -3, 	   0,   -5
+.2byte   -5,   -8, 	  -9,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -7,   -5, 	  -8,   -6, 	   1,   -2, 	  -1,   -6
+.2byte   -7,   -4, 	 -10,   -3, 	   3,   -3, 	  -2,   -6
+.2byte   -1,   -3, 	  -9,   -5, 	   7,   -3, 	  -1,   -6
+.2byte   -7,   -5, 	  -8,   -6, 	   1,   -2, 	  -1,   -6
+.2byte   -8,   -6, 	  -4,   -6, 	  -4,   -2, 	   0,   -6
+.2byte   -5,  -10, 	   2,   -7, 	  -6,   -3, 	   0,   -5
+.2byte   -1,  -12, 	   6,   -5, 	  -8,   -6, 	  -1,   -5
+.2byte    4,  -10, 	  -3,   -7, 	   5,   -3, 	  -1,   -5
+.2byte    6,   -6, 	   2,   -6, 	   2,   -2, 	  -2,   -6
+.2byte    5,   -5, 	   6,   -6, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -5,   -8, 	  -9,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -7,  -12, 	   3,   -8, 	  -7,   -4, 	   0,   -5
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte    5,  -12, 	  -5,   -8, 	   5,   -4, 	  -2,   -5
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    3,   -8, 	   7,   -6, 	  -2,   -4, 	  -2,   -7
+.2byte   -6,   -7, 	  -4,    1, 	   0,   -7, 	   0,   -4
+.2byte   -5,   -8, 	  -4,    0, 	   0,   -7, 	   0,   -4
+.2byte    5,   -7, 	   3,    1, 	  -1,   -7, 	  -1,   -4
+.2byte    4,   -8, 	   3,    0, 	  -1,   -7, 	  -1,   -4
+.2byte   -6,   -7, 	  -4,    1, 	   0,   -7, 	   0,   -4
+.2byte   -3,   -5, 	  -4,    0, 	   0,   -6, 	   0,   -4
+.2byte   -2,   -2, 	  -5,    0, 	   4,   -2, 	   1,   -4
+.2byte    3,   -4, 	  -5,   -3, 	   4,   -5, 	   0,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -6, 	  -7,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	  -8,  -11, 	   6,  -11, 	  -1,   -7
+.2byte   -3,   -5, 	  -7,   -5, 	   1,   -4, 	   0,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    1,   -8, 	  -5,  -11, 	   6,   -5, 	   1,   -6
+.2byte    2,  -10, 	   5,   -5, 	  -3,   -8, 	  -1,   -6
+.2byte   -2,  -12, 	   5,  -13, 	  -7,   -5, 	   0,   -8
+.2byte   -2,  -12, 	   5,  -13, 	  -7,   -5, 	   0,   -8
+.2byte   -1,   -6, 	  -7,   -4, 	   5,   -4, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -4, 	   5,   -4, 	  -1,   -6
+.2byte   -1,   -5, 	  -7,   -4, 	   5,   -4, 	  -1,   -6
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -3,  -10, 	  -7,  -10, 	  -1,   -8, 	   1,   -8
+.2byte    0,   -9, 	  -6,   -9, 	   7,   -6, 	   1,   -5
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   5,   -6, 	  -7,   -6, 	  -1,   -5
+.2byte   -1,   -7, 	   4,   -3, 	  -6,   -3, 	  -1,   -3
+.2byte   -1,   -8, 	  -8,   -6, 	   6,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	  -8,  -11, 	   6,  -11, 	  -1,   -7
+.2byte   -1,   -6, 	  -4,   -5, 	   2,   -5, 	  -1,   -7
+.2byte   -8,   -9, 	  -6,   -5, 	  -4,   -4, 	   0,   -6
+.2byte   -5,   -3, 	  -2,   -3, 	  -1,   -2, 	  -1,   -6
+.2byte    6,   -9, 	   4,   -5, 	   2,   -4, 	  -2,   -6
+.2byte    3,   -3, 	   0,   -3, 	  -1,   -2, 	  -1,   -6
+.2byte   -1,  -14, 	   5,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -8, 	  -7,   -8, 	  -1,   -5
+.2byte   -5,   -6, 	  -2,   -5, 	   0,   -4, 	   1,   -6
+.2byte   -2,   -9, 	  -5,   -8, 	   4,   -5, 	   1,   -7
+.2byte   -6,   -6, 	  -7,   -4, 	   0,   -3, 	   1,   -6
+.2byte   -2,   -9, 	  -2,   -7, 	  -1,   -6, 	   2,   -7
+.2byte   -6,   -6, 	  -4,   -4, 	  -3,   -3, 	   0,   -6
+.2byte    3,   -6, 	   0,   -5, 	  -2,   -4, 	  -3,   -6
+.2byte    0,   -9, 	   3,   -8, 	  -6,   -5, 	  -3,   -7
+.2byte    4,   -6, 	   5,   -4, 	  -2,   -3, 	  -3,   -6
+.2byte    0,   -9, 	   0,   -7, 	  -1,   -6, 	  -4,   -7
+.2byte    4,   -6, 	   2,   -4, 	   1,   -3, 	  -2,   -6
+.2byte    1,  -10, 	  -5,  -10, 	   3,   -7, 	  -3,   -7
+.2byte   -6,   -7, 	  -4,    1, 	   0,   -7, 	   0,   -4
+.2byte   -5,   -8, 	  -4,    0, 	   0,   -7, 	   0,   -4
+.2byte    5,   -7, 	   3,    1, 	  -1,   -7, 	  -1,   -4
+.2byte    4,   -8, 	   3,    0, 	  -1,   -7, 	  -1,   -4
+.2byte   -6,   -7, 	  -4,    1, 	   0,   -7, 	   0,   -4
+.2byte   -5,   -8, 	  -4,    0, 	   0,   -7, 	   0,   -4
+.2byte    5,   -7, 	   3,    1, 	  -1,   -7, 	  -1,   -4
+.2byte    4,   -8, 	   3,    0, 	  -1,   -7, 	  -1,   -4
+sSquirtleAnimTable1:
+.4byte sSquirtleAnims_1_1
+.4byte sSquirtleAnims_1_2
+.4byte sSquirtleAnims_1_3
+.4byte sSquirtleAnims_1_4
+.4byte sSquirtleAnims_1_5
+.4byte sSquirtleAnims_1_6
+.4byte sSquirtleAnims_1_7
+.4byte sSquirtleAnims_1_8
+sSquirtleAnimTable2:
+.4byte sSquirtleAnims_2_1
+.4byte sSquirtleAnims_2_2
+.4byte sSquirtleAnims_2_3
+.4byte sSquirtleAnims_2_4
+.4byte sSquirtleAnims_2_5
+.4byte sSquirtleAnims_2_6
+.4byte sSquirtleAnims_2_7
+.4byte sSquirtleAnims_2_8
+sSquirtleAnimTable3:
+.4byte sSquirtleAnims_3_1
+.4byte sSquirtleAnims_3_2
+.4byte sSquirtleAnims_3_3
+.4byte sSquirtleAnims_3_4
+.4byte sSquirtleAnims_3_5
+.4byte sSquirtleAnims_3_6
+.4byte sSquirtleAnims_3_7
+.4byte sSquirtleAnims_3_8
+sSquirtleAnimTable4:
+.4byte sSquirtleAnims_4_1
+.4byte sSquirtleAnims_4_2
+.4byte sSquirtleAnims_4_3
+.4byte sSquirtleAnims_4_4
+.4byte sSquirtleAnims_4_5
+.4byte sSquirtleAnims_4_6
+.4byte sSquirtleAnims_4_7
+.4byte sSquirtleAnims_4_8
+sSquirtleAnimTable5:
+.4byte sSquirtleAnims_5_1
+.4byte sSquirtleAnims_5_2
+.4byte sSquirtleAnims_5_3
+.4byte sSquirtleAnims_5_4
+.4byte sSquirtleAnims_5_5
+.4byte sSquirtleAnims_5_6
+.4byte sSquirtleAnims_5_7
+.4byte sSquirtleAnims_5_8
+sSquirtleAnimTable6:
+.4byte sSquirtleAnims_6_1
+.4byte sSquirtleAnims_6_1
+.4byte sSquirtleAnims_6_1
+.4byte sSquirtleAnims_6_1
+.4byte sSquirtleAnims_6_1
+.4byte sSquirtleAnims_6_1
+.4byte sSquirtleAnims_6_1
+.4byte sSquirtleAnims_6_1
+sSquirtleAnimTable7:
+.4byte sSquirtleAnims_7_1
+.4byte sSquirtleAnims_7_2
+.4byte sSquirtleAnims_7_3
+.4byte sSquirtleAnims_7_4
+.4byte sSquirtleAnims_7_5
+.4byte sSquirtleAnims_7_6
+.4byte sSquirtleAnims_7_7
+.4byte sSquirtleAnims_7_8
+sSquirtleAnimTable8:
+.4byte sSquirtleAnims_8_1
+.4byte sSquirtleAnims_8_2
+.4byte sSquirtleAnims_8_3
+.4byte sSquirtleAnims_8_4
+.4byte sSquirtleAnims_8_5
+.4byte sSquirtleAnims_8_6
+.4byte sSquirtleAnims_8_7
+.4byte sSquirtleAnims_8_8
+sSquirtleAnimTable9:
+.4byte sSquirtleAnims_9_1
+.4byte sSquirtleAnims_9_2
+.4byte sSquirtleAnims_9_3
+.4byte sSquirtleAnims_9_4
+.4byte sSquirtleAnims_9_5
+.4byte sSquirtleAnims_9_6
+.4byte sSquirtleAnims_9_7
+.4byte sSquirtleAnims_9_8
+sSquirtleAnimTable10:
+.4byte sSquirtleAnims_10_1
+.4byte sSquirtleAnims_10_2
+.4byte sSquirtleAnims_10_3
+.4byte sSquirtleAnims_10_4
+.4byte sSquirtleAnims_10_5
+.4byte sSquirtleAnims_10_6
+.4byte sSquirtleAnims_10_7
+.4byte sSquirtleAnims_10_8
+sSquirtleAnimTable11:
+.4byte sSquirtleAnims_11_1
+.4byte sSquirtleAnims_11_2
+.4byte sSquirtleAnims_11_3
+.4byte sSquirtleAnims_11_4
+.4byte sSquirtleAnims_11_5
+.4byte sSquirtleAnims_11_6
+.4byte sSquirtleAnims_11_7
+.4byte sSquirtleAnims_11_8
+sSquirtleAnimTable12:
+.4byte sSquirtleAnims_12_1
+.4byte sSquirtleAnims_12_2
+.4byte sSquirtleAnims_12_3
+.4byte sSquirtleAnims_12_4
+.4byte sSquirtleAnims_12_5
+.4byte sSquirtleAnims_12_6
+.4byte sSquirtleAnims_12_7
+.4byte sSquirtleAnims_12_8
+sSquirtleAnimTable13:
+.4byte sSquirtleAnims_13_1
+.4byte sSquirtleAnims_13_2
+.4byte sSquirtleAnims_13_3
+.4byte sSquirtleAnims_13_4
+.4byte sSquirtleAnims_13_5
+.4byte sSquirtleAnims_13_6
+.4byte sSquirtleAnims_13_7
+.4byte sSquirtleAnims_13_8
+sSquirtleAnimTable14:
+.4byte sSquirtleAnims_14_1
+.4byte sSquirtleAnims_14_2
+.4byte sSquirtleAnims_14_3
+.4byte sSquirtleAnims_14_4
+.4byte sSquirtleAnims_14_5
+.4byte sSquirtleAnims_14_6
+.4byte sSquirtleAnims_14_7
+.4byte sSquirtleAnims_14_8
+sSquirtleAnimTable15:
+.4byte sSquirtleAnims_15_1
+.4byte sSquirtleAnims_15_2
+.4byte sSquirtleAnims_15_3
+.4byte sSquirtleAnims_15_4
+.4byte sSquirtleAnims_15_5
+.4byte sSquirtleAnims_15_6
+.4byte sSquirtleAnims_15_7
+.4byte sSquirtleAnims_15_8
+sSquirtleAnimTable16:
+.4byte sSquirtleAnims_16_1
+.4byte sSquirtleAnims_16_2
+.4byte sSquirtleAnims_16_3
+.4byte sSquirtleAnims_16_4
+.4byte sSquirtleAnims_16_5
+.4byte sSquirtleAnims_16_6
+.4byte sSquirtleAnims_16_7
+.4byte sSquirtleAnims_16_8
+sSquirtleAnimTable17:
+.4byte sSquirtleAnims_17_1
+.4byte sSquirtleAnims_17_2
+.4byte sSquirtleAnims_17_3
+.4byte sSquirtleAnims_17_4
+.4byte sSquirtleAnims_17_5
+.4byte sSquirtleAnims_17_6
+.4byte sSquirtleAnims_17_7
+.4byte sSquirtleAnims_17_8
+sSquirtleAnimTable18:
+.4byte sSquirtleAnims_18_1
+.4byte sSquirtleAnims_18_2
+.4byte sSquirtleAnims_18_3
+.4byte sSquirtleAnims_18_4
+.4byte sSquirtleAnims_18_5
+.4byte sSquirtleAnims_18_6
+.4byte sSquirtleAnims_18_7
+.4byte sSquirtleAnims_18_8
+sSquirtleAnimTable19:
+.4byte sSquirtleAnims_19_1
+.4byte sSquirtleAnims_19_2
+.4byte sSquirtleAnims_19_3
+.4byte sSquirtleAnims_19_4
+.4byte sSquirtleAnims_19_5
+.4byte sSquirtleAnims_19_6
+.4byte sSquirtleAnims_19_7
+.4byte sSquirtleAnims_19_8
+sSquirtleAnimTable20:
+.4byte sSquirtleAnims_20_1
+.4byte sSquirtleAnims_20_2
+.4byte sSquirtleAnims_20_3
+.4byte sSquirtleAnims_20_4
+.4byte sSquirtleAnims_20_5
+.4byte sSquirtleAnims_20_6
+.4byte sSquirtleAnims_20_7
+.4byte sSquirtleAnims_20_8
+sSquirtleAnimTable21:
+.4byte sSquirtleAnims_21_1
+.4byte sSquirtleAnims_21_2
+.4byte sSquirtleAnims_21_3
+.4byte sSquirtleAnims_21_4
+.4byte sSquirtleAnims_21_5
+.4byte sSquirtleAnims_21_6
+.4byte sSquirtleAnims_21_7
+.4byte sSquirtleAnims_21_8
+sSquirtleAnimTable22:
+.4byte sSquirtleAnims_22_1
+.4byte sSquirtleAnims_22_2
+.4byte sSquirtleAnims_22_3
+.4byte sSquirtleAnims_22_4
+.4byte sSquirtleAnims_22_5
+.4byte sSquirtleAnims_22_6
+.4byte sSquirtleAnims_22_7
+.4byte sSquirtleAnims_22_8
+sSquirtleAnimTable23:
+.4byte sSquirtleAnims_23_1
+.4byte sSquirtleAnims_23_2
+.4byte sSquirtleAnims_23_3
+.4byte sSquirtleAnims_23_4
+.4byte sSquirtleAnims_23_5
+.4byte sSquirtleAnims_23_6
+.4byte sSquirtleAnims_23_7
+.4byte sSquirtleAnims_23_8
+sSquirtleAnimTable24:
+.4byte sSquirtleAnims_24_1
+.4byte sSquirtleAnims_24_2
+.4byte sSquirtleAnims_24_3
+.4byte sSquirtleAnims_24_4
+.4byte sSquirtleAnims_24_5
+.4byte sSquirtleAnims_24_6
+.4byte sSquirtleAnims_24_7
+.4byte sSquirtleAnims_24_8
+sSquirtleAnimTable25:
+.4byte sSquirtleAnims_25_1
+.4byte sSquirtleAnims_25_2
+.4byte sSquirtleAnims_25_3
+.4byte sSquirtleAnims_25_4
+.4byte sSquirtleAnims_25_5
+.4byte sSquirtleAnims_25_6
+.4byte sSquirtleAnims_25_7
+.4byte sSquirtleAnims_25_8
+sSquirtleAnimTable26:
+.4byte sSquirtleAnims_26_1
+.4byte sSquirtleAnims_26_2
+.4byte sSquirtleAnims_26_3
+.4byte sSquirtleAnims_26_4
+.4byte sSquirtleAnims_26_5
+.4byte sSquirtleAnims_26_6
+.4byte sSquirtleAnims_26_7
+.4byte sSquirtleAnims_26_8
+sSquirtleAnimTable27:
+.4byte sSquirtleAnims_27_1
+.4byte sSquirtleAnims_27_1
+.4byte sSquirtleAnims_27_1
+.4byte sSquirtleAnims_27_1
+.4byte sSquirtleAnims_27_1
+.4byte sSquirtleAnims_27_1
+.4byte sSquirtleAnims_27_1
+.4byte sSquirtleAnims_27_1
+sSquirtleAnimTable28:
+.4byte sSquirtleAnims_28_1
+.4byte sSquirtleAnims_28_2
+.4byte sSquirtleAnims_28_3
+.4byte sSquirtleAnims_28_4
+.4byte sSquirtleAnims_28_5
+.4byte sSquirtleAnims_28_6
+.4byte sSquirtleAnims_28_7
+.4byte sSquirtleAnims_28_8
+sAxAnimationsSquirtle:
+.4byte sSquirtleAnimTable1
+.4byte sSquirtleAnimTable2
+.4byte sSquirtleAnimTable3
+.4byte sSquirtleAnimTable4
+.4byte sSquirtleAnimTable5
+.4byte sSquirtleAnimTable6
+.4byte sSquirtleAnimTable7
+.4byte sSquirtleAnimTable8
+.4byte sSquirtleAnimTable9
+.4byte sSquirtleAnimTable10
+.4byte sSquirtleAnimTable11
+.4byte sSquirtleAnimTable12
+.4byte sSquirtleAnimTable13
+.4byte sSquirtleAnimTable14
+.4byte sSquirtleAnimTable15
+.4byte sSquirtleAnimTable16
+.4byte sSquirtleAnimTable17
+.4byte sSquirtleAnimTable18
+.4byte sSquirtleAnimTable19
+.4byte sSquirtleAnimTable20
+.4byte sSquirtleAnimTable21
+.4byte sSquirtleAnimTable22
+.4byte sSquirtleAnimTable23
+.4byte sSquirtleAnimTable24
+.4byte sSquirtleAnimTable25
+.4byte sSquirtleAnimTable26
+.4byte sSquirtleAnimTable27
+.4byte sSquirtleAnimTable28
+sAxSpritesSquirtle:
+.4byte sSquirtleSprites1
+.4byte sSquirtleSprites2
+.4byte sSquirtleSprites3
+.4byte sSquirtleSprites4
+.4byte sSquirtleSprites5
+.4byte sSquirtleSprites6
+.4byte sSquirtleSprites7
+.4byte sSquirtleSprites8
+.4byte sSquirtleSprites9
+.4byte sSquirtleSprites10
+.4byte sSquirtleSprites11
+.4byte sSquirtleSprites12
+.4byte sSquirtleSprites13
+.4byte sSquirtleSprites14
+.4byte sSquirtleSprites15
+.4byte sSquirtleSprites16
+.4byte sSquirtleSprites17
+.4byte sSquirtleSprites18
+.4byte sSquirtleSprites19
+.4byte sSquirtleSprites20
+.4byte sSquirtleSprites21
+.4byte sSquirtleSprites22
+.4byte sSquirtleSprites23
+.4byte sSquirtleSprites24
+.4byte sSquirtleSprites25
+.4byte sSquirtleSprites26
+.4byte sSquirtleSprites27
+.4byte sSquirtleSprites28
+.4byte sSquirtleSprites29
+.4byte sSquirtleSprites30
+.4byte sSquirtleSprites31
+.4byte sSquirtleSprites32
+.4byte sSquirtleSprites33
+.4byte sSquirtleSprites34
+.4byte sSquirtleSprites35
+.4byte sSquirtleSprites36
+.4byte sSquirtleSprites37
+.4byte sSquirtleSprites38
+.4byte sSquirtleSprites39
+.4byte sSquirtleSprites40
+.4byte sSquirtleSprites41
+.4byte sSquirtleSprites42
+.4byte sSquirtleSprites43
+.4byte sSquirtleSprites44
+.4byte sSquirtleSprites45
+.4byte sSquirtleSprites46
+.4byte sSquirtleSprites47
+.4byte sSquirtleSprites48
+.4byte sSquirtleSprites49
+.4byte sSquirtleSprites50
+.4byte sSquirtleSprites51
+.4byte sSquirtleSprites52
+.4byte sSquirtleSprites53
+.4byte sSquirtleSprites54
+.4byte sSquirtleSprites55
+.4byte sSquirtleSprites56
+.4byte sSquirtleSprites57
+.4byte sSquirtleSprites58
+.4byte sSquirtleSprites59
+.4byte sSquirtleSprites60
+.4byte sSquirtleSprites61
+.4byte sSquirtleSprites62
+.4byte sSquirtleSprites63
+.4byte sSquirtleSprites64
+.4byte sSquirtleSprites65
+.4byte sSquirtleSprites66
+.4byte sSquirtleSprites67
+.4byte sSquirtleSprites68
+.4byte sSquirtleSprites69
+.4byte sSquirtleSprites70
+.4byte sSquirtleSprites71
+.4byte sSquirtleSprites72
+.4byte sSquirtleSprites73
+sAxMainSquirtle:
+ax_main sAxPosesSquirtle, sAxAnimationsSquirtle, 28, sAxSpritesSquirtle, sAxPositionsSquirtle

--- a/data/ax/stantler.inc
+++ b/data/ax/stantler.inc
@@ -1,0 +1,3041 @@
+.global gAxStantler
+gAxStantler:
+ax_siro sAxMainStantler
+sStantlerPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose2:
+ax_pose 1, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose5:
+ax_pose 4, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose8:
+ax_pose 7, 0x01e1, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose10:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose11:
+ax_pose 10, 0x81e5, 0x90f8, 0x4c00
+ax_pose 11, 0x81e5, 0x1108, 0x4c08
+ax_pose 12, 0x01dd, 0x10f8, 0x4c0a
+ax_pose_terminator
+sStantlerPose12:
+ax_pose 13, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose13:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose14:
+ax_pose 15, 0x01e1, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose15:
+ax_pose 16, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose17:
+ax_pose 10, 0x81e5, 0x80f8, 0x4c00
+ax_pose 11, 0x81e5, 0x00f0, 0x0c08
+ax_pose 12, 0x01dd, 0x0100, 0x0c0a
+ax_pose_terminator
+sStantlerPose18:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose20:
+ax_pose 7, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose23:
+ax_pose 4, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose26:
+ax_pose 1, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose27:
+ax_pose 2, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose28:
+ax_pose 17, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose29:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose30:
+ax_pose 4, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose31:
+ax_pose 5, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose32:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose33:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose34:
+ax_pose 7, 0x01e1, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose35:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose36:
+ax_pose 19, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose37:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose38:
+ax_pose 10, 0x81e5, 0x90f8, 0x4c00
+ax_pose 11, 0x81e5, 0x1108, 0x4c08
+ax_pose 12, 0x01dd, 0x10f8, 0x4c0a
+ax_pose_terminator
+sStantlerPose39:
+ax_pose 13, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose40:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose41:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose42:
+ax_pose 15, 0x01e1, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose43:
+ax_pose 16, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose44:
+ax_pose 21, 0x81e4, 0x80f4, 0x4c00
+ax_pose 22, 0x81e4, 0x4104, 0x4c08
+ax_pose 23, 0x01dc, 0x00f4, 0x4c0c
+ax_pose 24, 0x01dc, 0x0104, 0x4c0d
+ax_pose_terminator
+sStantlerPose45:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose46:
+ax_pose 10, 0x81e5, 0x80f8, 0x4c00
+ax_pose 11, 0x81e5, 0x00f0, 0x0c08
+ax_pose 12, 0x01dd, 0x0100, 0x0c0a
+ax_pose_terminator
+sStantlerPose47:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose48:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose49:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose50:
+ax_pose 7, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose51:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose52:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose53:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose54:
+ax_pose 4, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose55:
+ax_pose 5, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose56:
+ax_pose 18, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose57:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose58:
+ax_pose 1, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose59:
+ax_pose 2, 0x01e6, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose60:
+ax_pose 17, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose61:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose62:
+ax_pose 4, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose63:
+ax_pose 5, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose64:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose65:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose66:
+ax_pose 7, 0x01e1, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose67:
+ax_pose 8, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose68:
+ax_pose 19, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose69:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose70:
+ax_pose 10, 0x81e5, 0x90f8, 0x4c00
+ax_pose 11, 0x81e5, 0x1108, 0x4c08
+ax_pose 12, 0x01dd, 0x10f8, 0x4c0a
+ax_pose_terminator
+sStantlerPose71:
+ax_pose 13, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose72:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose73:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose74:
+ax_pose 15, 0x01e1, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose75:
+ax_pose 16, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose76:
+ax_pose 21, 0x81e4, 0x80f4, 0x4c00
+ax_pose 22, 0x81e4, 0x4104, 0x4c08
+ax_pose 23, 0x01dc, 0x00f4, 0x4c0c
+ax_pose 24, 0x01dc, 0x0104, 0x4c0d
+ax_pose_terminator
+sStantlerPose77:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose78:
+ax_pose 10, 0x81e5, 0x80f8, 0x4c00
+ax_pose 11, 0x81e5, 0x00f0, 0x0c08
+ax_pose 12, 0x01dd, 0x0100, 0x0c0a
+ax_pose_terminator
+sStantlerPose79:
+ax_pose 13, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose80:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose81:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose82:
+ax_pose 7, 0x01e1, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose83:
+ax_pose 8, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose84:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose85:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose86:
+ax_pose 4, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose87:
+ax_pose 5, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose88:
+ax_pose 18, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose89:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose90:
+ax_pose 25, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose91:
+ax_pose 17, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose92:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose93:
+ax_pose 26, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose94:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose95:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose96:
+ax_pose 27, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose97:
+ax_pose 19, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose98:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose99:
+ax_pose 28, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose100:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose101:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose102:
+ax_pose 29, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose103:
+ax_pose 21, 0x81e4, 0x80f4, 0x4c00
+ax_pose 22, 0x81e4, 0x4104, 0x4c08
+ax_pose 23, 0x01dc, 0x00f4, 0x4c0c
+ax_pose 24, 0x01dc, 0x0104, 0x4c0d
+ax_pose_terminator
+sStantlerPose104:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose105:
+ax_pose 28, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose106:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose107:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose108:
+ax_pose 27, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose109:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose110:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose111:
+ax_pose 26, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose112:
+ax_pose 18, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose113:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose114:
+ax_pose 25, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose115:
+ax_pose 30, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose116:
+ax_pose 31, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose117:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose118:
+ax_pose 26, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose119:
+ax_pose 32, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose120:
+ax_pose 33, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose121:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose122:
+ax_pose 27, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose123:
+ax_pose 34, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose124:
+ax_pose 35, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose125:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose126:
+ax_pose 28, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose127:
+ax_pose 36, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose128:
+ax_pose 37, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose129:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose130:
+ax_pose 29, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose131:
+ax_pose 38, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose132:
+ax_pose 39, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose133:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose134:
+ax_pose 28, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose135:
+ax_pose 36, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose136:
+ax_pose 37, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose137:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose138:
+ax_pose 27, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose139:
+ax_pose 34, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose140:
+ax_pose 35, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose141:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose142:
+ax_pose 26, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose143:
+ax_pose 32, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose144:
+ax_pose 33, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose145:
+ax_pose 40, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sStantlerPose146:
+ax_pose 41, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sStantlerPose147:
+ax_pose 42, 0x81d8, 0x4105, 0x4c00
+ax_pose 43, 0x01f8, 0x00fd, 0x4c04
+ax_pose 44, 0x81d8, 0x80f5, 0x4c05
+ax_pose_terminator
+sStantlerPose148:
+ax_pose 45, 0x01e1, 0x90e8, 0x4c00
+ax_pose_terminator
+sStantlerPose149:
+ax_pose 46, 0x01e2, 0x90ea, 0x4c00
+ax_pose_terminator
+sStantlerPose150:
+ax_pose 47, 0x01eb, 0x50f7, 0x4c00
+ax_pose 48, 0x41fb, 0x10f7, 0x4c04
+ax_pose 49, 0x41db, 0x90e7, 0x4c06
+ax_pose_terminator
+sStantlerPose151:
+ax_pose 50, 0x41eb, 0x40f5, 0x4c00
+ax_pose 51, 0x41fb, 0x00f5, 0x4c04
+ax_pose 52, 0x41f3, 0x00f5, 0x4c06
+ax_pose 53, 0x41db, 0x80f5, 0x4c08
+ax_pose_terminator
+sStantlerPose152:
+ax_pose 47, 0x01eb, 0x40f9, 0x4c00
+ax_pose 48, 0x41fb, 0x00f9, 0x4c04
+ax_pose 49, 0x41db, 0x80f9, 0x4c06
+ax_pose_terminator
+sStantlerPose153:
+ax_pose 46, 0x01e2, 0x80f6, 0x4c00
+ax_pose_terminator
+sStantlerPose154:
+ax_pose 45, 0x01e1, 0x80f8, 0x4c00
+ax_pose_terminator
+sStantlerPose155:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose156:
+ax_pose 17, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose157:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose158:
+ax_pose 18, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose159:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose160:
+ax_pose 19, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose161:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose162:
+ax_pose 20, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose163:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose164:
+ax_pose 21, 0x81e6, 0x80f4, 0x4c00
+ax_pose 22, 0x81e6, 0x4104, 0x4c08
+ax_pose 23, 0x01de, 0x00f4, 0x4c0c
+ax_pose 24, 0x01de, 0x0104, 0x4c0d
+ax_pose_terminator
+sStantlerPose165:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose166:
+ax_pose 20, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose167:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose168:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose169:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose170:
+ax_pose 18, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose171:
+ax_pose 17, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose172:
+ax_pose 18, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sStantlerPose173:
+ax_pose 19, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose174:
+ax_pose 20, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sStantlerPose175:
+ax_pose 21, 0x81e5, 0x80f4, 0x4c00
+ax_pose 22, 0x81e5, 0x4104, 0x4c08
+ax_pose 23, 0x01dd, 0x00f4, 0x4c0c
+ax_pose 24, 0x01dd, 0x0104, 0x4c0d
+ax_pose_terminator
+sStantlerPose176:
+ax_pose 20, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sStantlerPose177:
+ax_pose 19, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose178:
+ax_pose 18, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sStantlerPose179:
+ax_pose 25, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose180:
+ax_pose 26, 0x01e4, 0x90f1, 0x4c00
+ax_pose_terminator
+sStantlerPose181:
+ax_pose 27, 0x01e5, 0x90f2, 0x4c00
+ax_pose_terminator
+sStantlerPose182:
+ax_pose 28, 0x01e4, 0x90f1, 0x4c00
+ax_pose_terminator
+sStantlerPose183:
+ax_pose 29, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose184:
+ax_pose 28, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sStantlerPose185:
+ax_pose 27, 0x01e5, 0x80ee, 0x4c00
+ax_pose_terminator
+sStantlerPose186:
+ax_pose 26, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sStantlerPose187:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose188:
+ax_pose 25, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose189:
+ax_pose 17, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose190:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose191:
+ax_pose 26, 0x01e3, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose192:
+ax_pose 18, 0x01e6, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose193:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose194:
+ax_pose 27, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose195:
+ax_pose 19, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose196:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose197:
+ax_pose 28, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose198:
+ax_pose 20, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose199:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose200:
+ax_pose 29, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose201:
+ax_pose 21, 0x81e4, 0x80f4, 0x4c00
+ax_pose 22, 0x81e4, 0x4104, 0x4c08
+ax_pose 23, 0x01dc, 0x00f4, 0x4c0c
+ax_pose 24, 0x01dc, 0x0104, 0x4c0d
+ax_pose_terminator
+sStantlerPose202:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose203:
+ax_pose 28, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose204:
+ax_pose 20, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose205:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose206:
+ax_pose 27, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose207:
+ax_pose 19, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose208:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose209:
+ax_pose 26, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose210:
+ax_pose 18, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose211:
+ax_pose 17, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose212:
+ax_pose 18, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sStantlerPose213:
+ax_pose 19, 0x01e3, 0x80f1, 0x4c00
+ax_pose_terminator
+sStantlerPose214:
+ax_pose 20, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sStantlerPose215:
+ax_pose 21, 0x81e6, 0x80f4, 0x4c00
+ax_pose 22, 0x81e6, 0x4104, 0x4c08
+ax_pose 23, 0x01de, 0x00f4, 0x4c0c
+ax_pose 24, 0x01de, 0x0104, 0x4c0d
+ax_pose_terminator
+sStantlerPose216:
+ax_pose 20, 0x01e6, 0x90ee, 0x4c00
+ax_pose_terminator
+sStantlerPose217:
+ax_pose 19, 0x01e3, 0x90ef, 0x4c00
+ax_pose_terminator
+sStantlerPose218:
+ax_pose 18, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sStantlerPose219:
+ax_pose 0, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose220:
+ax_pose 3, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose221:
+ax_pose 6, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose222:
+ax_pose 9, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sStantlerPose223:
+ax_pose 14, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sStantlerPose224:
+ax_pose 9, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose225:
+ax_pose 6, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sStantlerPose226:
+ax_pose 3, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+.align 2
+sStantlerAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 2,
+ax_anim 6, 0, 2, 0, -5, 0, 3,
+ax_anim 6, 0, 2, 0, -3, 0, 3,
+ax_anim 6, 0, 2, 0, 1, 0, 4,
+ax_anim 6, 0, 0, 0, 1, 0, 2,
+ax_anim_terminator
+sStantlerAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, -1, 0, 0,
+ax_anim 6, 0, 4, 2, -2, 1, 1,
+ax_anim 6, 0, 5, 3, -2, 2, 2,
+ax_anim 6, 0, 5, 4, 3, 3, 3,
+ax_anim 6, 0, 3, 2, 1, 2, 1,
+ax_anim_terminator
+sStantlerAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -1, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 1, 0,
+ax_anim 6, 0, 8, 1, -3, 2, 0,
+ax_anim 6, 0, 8, 2, 0, 3, 0,
+ax_anim 6, 0, 6, 1, 0, 1, 0,
+ax_anim_terminator
+sStantlerAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, -1, 1, -1,
+ax_anim 6, 0, 10, 2, -4, 3, -3,
+ax_anim 6, 0, 11, 3, -7, 4, -4,
+ax_anim 6, 0, 11, 3, -5, 4, -4,
+ax_anim 6, 0, 9, 2, -2, 2, -2,
+ax_anim_terminator
+sStantlerAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, -1,
+ax_anim 6, 0, 13, 0, -2, 0, -3,
+ax_anim 6, 0, 14, 0, -7, 0, -4,
+ax_anim 6, 0, 14, 0, -5, 0, -5,
+ax_anim 6, 0, 12, 0, -1, 0, -1,
+ax_anim_terminator
+sStantlerAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -1, -1, -1,
+ax_anim 6, 0, 16, -2, -4, -3, -3,
+ax_anim 6, 0, 17, -3, -7, -4, -4,
+ax_anim 6, 0, 17, -3, -5, -4, -4,
+ax_anim 6, 0, 15, -2, -2, -2, -2,
+ax_anim_terminator
+sStantlerAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 1, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, -1, 0,
+ax_anim 6, 0, 20, -1, -3, -2, 0,
+ax_anim 6, 0, 20, -2, 0, -3, 0,
+ax_anim 6, 0, 18, -1, 0, -1, 0,
+ax_anim_terminator
+sStantlerAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, -1, 0, 0,
+ax_anim 6, 0, 22, -2, -2, -1, 1,
+ax_anim 6, 0, 23, -3, -2, -2, 2,
+ax_anim 6, 0, 23, -4, 3, -3, 3,
+ax_anim 6, 0, 21, -2, 1, -2, 1,
+ax_anim_terminator
+.align 2
+sStantlerAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, -2, 0, 0,
+ax_anim 2, 2, 25, 0, 4, 0, 4,
+ax_anim 2, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sStantlerAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 2, 29, 4, 0, 4, 4,
+ax_anim 2, 0, 30, 10, 6, 10, 10,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 1, 31, 20, 16, 20, 16,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 20, 16, 20, 16,
+ax_anim 2, 0, 28, 8, 8, 6, 6,
+ax_anim_terminator
+sStantlerAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 4, -2, 4, 0,
+ax_anim 2, 0, 34, 10, -3, 10, 0,
+ax_anim 2, 0, 35, 17, -1, 17, -1,
+ax_anim 2, 1, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 35, 17, -1, 17, -1,
+ax_anim 2, 0, 35, 17, 0, 17, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sStantlerAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 0, -1, 0, -1,
+ax_anim 2, 2, 37, 4, -8, 4, -4,
+ax_anim 2, 0, 38, 10, -15, 10, -15,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 2, 1, 39, 21, -19, 21, -19,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 2, 0, 39, 21, -19, 21, -19,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sStantlerAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 2, 41, 0, -6, 0, -6,
+ax_anim 2, 0, 42, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 1, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sStantlerAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 0, -1, 0, -1,
+ax_anim 2, 2, 45, -4, -8, -4, -4,
+ax_anim 2, 0, 46, -10, -15, -10, -15,
+ax_anim 2, 0, 47, -20, -20, -20, -20,
+ax_anim 2, 1, 47, -21, -19, -21, -19,
+ax_anim 2, 0, 47, -20, -20, -20, -20,
+ax_anim 2, 0, 47, -21, -19, -21, -19,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sStantlerAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 49, -4, -2, -4, 0,
+ax_anim 2, 0, 50, -10, -3, -10, 0,
+ax_anim 2, 0, 51, -17, -1, -17, -1,
+ax_anim 2, 1, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 51, -17, -1, -17, -1,
+ax_anim 2, 0, 51, -17, 0, -17, 0,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sStantlerAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 2, 53, -4, 0, -4, 4,
+ax_anim 2, 0, 54, -10, 6, -10, 10,
+ax_anim 2, 0, 55, -19, 17, -19, 17,
+ax_anim 2, 1, 55, -20, 16, -20, 16,
+ax_anim 2, 0, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 55, -20, 16, -20, 16,
+ax_anim 2, 0, 52, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sStantlerAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, -2, 0, 0,
+ax_anim 2, 2, 57, 0, 4, 0, 4,
+ax_anim 2, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sStantlerAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 0, -1, 0, 0,
+ax_anim 2, 2, 61, 4, 0, 4, 4,
+ax_anim 2, 0, 62, 10, 6, 10, 10,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 1, 63, 20, 16, 20, 16,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 63, 20, 16, 20, 16,
+ax_anim 2, 0, 60, 8, 8, 6, 6,
+ax_anim_terminator
+sStantlerAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 65, 4, -2, 4, 0,
+ax_anim 2, 0, 66, 10, -3, 10, 0,
+ax_anim 2, 0, 67, 17, -1, 17, -1,
+ax_anim 2, 1, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 67, 17, -1, 17, -1,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sStantlerAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 0, -1, 0, -1,
+ax_anim 2, 2, 69, 4, -8, 4, -4,
+ax_anim 2, 0, 70, 10, -15, 10, -15,
+ax_anim 2, 0, 71, 20, -20, 20, -20,
+ax_anim 2, 1, 71, 21, -19, 21, -19,
+ax_anim 2, 0, 71, 20, -20, 20, -20,
+ax_anim 2, 0, 71, 21, -19, 21, -19,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sStantlerAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 0, -6, 0, -6,
+ax_anim 2, 0, 74, 0, -15, 0, -15,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 1, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 0, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sStantlerAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, 0, -1, 0, -1,
+ax_anim 2, 2, 77, -4, -8, -4, -4,
+ax_anim 2, 0, 78, -10, -15, -10, -15,
+ax_anim 2, 0, 79, -20, -20, -20, -20,
+ax_anim 2, 1, 79, -21, -19, -21, -19,
+ax_anim 2, 0, 79, -20, -20, -20, -20,
+ax_anim 2, 0, 79, -21, -19, -21, -19,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sStantlerAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 2, 81, -4, -2, -4, 0,
+ax_anim 2, 0, 82, -10, -3, -10, 0,
+ax_anim 2, 0, 83, -17, -1, -17, -1,
+ax_anim 2, 1, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 83, -17, -1, -17, -1,
+ax_anim 2, 0, 83, -17, 0, -17, 0,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sStantlerAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 2, 85, -4, 0, -4, 4,
+ax_anim 2, 0, 86, -10, 6, -10, 10,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 1, 87, -20, 16, -20, 16,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -20, 16, -20, 16,
+ax_anim 2, 0, 84, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sStantlerAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 4, 0, 89, 0, -3, 0, -3,
+ax_anim 4, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 1, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sStantlerAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 4, 0, 92, -3, -3, -3, -3,
+ax_anim 4, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 1, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sStantlerAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 4, 0, 95, -3, 0, -3, 0,
+ax_anim 4, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 1, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sStantlerAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 4, 0, 98, -3, 3, -3, 3,
+ax_anim 4, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 1, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sStantlerAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 4, 0, 101, 0, 3, 0, 3,
+ax_anim 4, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 1, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sStantlerAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 4, 0, 104, 3, 3, 3, 3,
+ax_anim 4, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 1, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sStantlerAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 4, 0, 107, 3, 0, 3, 0,
+ax_anim 4, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 1, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sStantlerAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 4, 0, 110, 3, -3, 3, -3,
+ax_anim 4, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 1, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sStantlerAnims_5_1:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 2, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_5_2:
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 2, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_5_3:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 2, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_5_4:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 2, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_5_5:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 2, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_5_6:
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 2, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_5_7:
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 2, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_5_8:
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 2, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStantlerAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStantlerAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sStantlerAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sStantlerAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sStantlerAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sStantlerAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sStantlerAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sStantlerAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sStantlerAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sStantlerAnims_8_1:
+ax_anim 60, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, 0, -1, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_8_2:
+ax_anim 60, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_8_3:
+ax_anim 60, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 0, -1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 0, -1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 0, -1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 0, -1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 0, -1, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, 0, -1, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_8_4:
+ax_anim 60, 0, 160, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_8_5:
+ax_anim 60, 0, 162, 0, 0, 0, 0,
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 10, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_8_6:
+ax_anim 60, 0, 164, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, 0, -1, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_8_7:
+ax_anim 60, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, 0, -1, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_8_8:
+ax_anim 60, 0, 168, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -1, 0, -1, 0,
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStantlerAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 3, 7, 3,
+ax_anim 2, 0, 172, 10, 9, 10, 9,
+ax_anim 2, 0, 173, 7, 14, 7, 14,
+ax_anim 3, 0, 174, 0, 18, 0, 18,
+ax_anim 2, 3, 175, -7, 14, -7, 14,
+ax_anim 2, 0, 176, -10, 9, -10, 9,
+ax_anim 1, 0, 177, -7, 3, -7, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 12, 0, 12, 0,
+ax_anim 2, 0, 171, 20, 4, 20, 4,
+ax_anim 2, 0, 172, 22, 11, 22, 11,
+ax_anim 3, 0, 173, 20, 18, 20, 18,
+ax_anim 2, 3, 174, 13, 19, 13, 19,
+ax_anim 2, 0, 175, 3, 13, 3, 13,
+ax_anim 1, 0, 176, -1, 8, -1, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -4, 3, -4,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 17, -6, 17, -6,
+ax_anim 3, 0, 172, 20, -1, 20, -1,
+ax_anim 2, 3, 173, 16, 2, 16, 2,
+ax_anim 2, 0, 174, 10, 5, 10, 5,
+ax_anim 1, 0, 175, 4, 3, 4, 3,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 5, -14, 5, -14,
+ax_anim 2, 0, 170, 13, -17, 13, -17,
+ax_anim 3, 0, 171, 22, -19, 22, -19,
+ax_anim 2, 3, 172, 24, -13, 24, -13,
+ax_anim 2, 0, 173, 19, -6, 19, -6,
+ax_anim 1, 0, 174, 12, -2, 12, -2,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -10, -5, -10, -5,
+ax_anim 2, 0, 176, -13, -12, -13, -12,
+ax_anim 2, 0, 177, -9, -17, -9, -17,
+ax_anim 3, 0, 170, 0, -19, 0, -19,
+ax_anim 2, 3, 171, 9, -17, 9, -17,
+ax_anim 2, 0, 172, 13, -12, 13, -12,
+ax_anim 1, 0, 173, 10, -5, 10, -5,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -5, -14, -5, -14,
+ax_anim 2, 0, 170, -13, -17, -13, -17,
+ax_anim 3, 0, 177, -22, -19, -22, -19,
+ax_anim 2, 3, 176, -24, -13, -24, -13,
+ax_anim 2, 0, 175, -19, -6, -19, -6,
+ax_anim 1, 0, 174, -12, -2, -12, -2,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -4, -3, -4,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -17, -6, -17, -6,
+ax_anim 3, 0, 176, -20, -1, -20, -1,
+ax_anim 2, 3, 175, -16, 2, -16, 2,
+ax_anim 2, 0, 174, -10, 5, -10, 5,
+ax_anim 1, 0, 173, -4, 3, -4, 3,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 177, -20, 4, -20, 4,
+ax_anim 2, 0, 176, -22, 11, -24, 11,
+ax_anim 3, 0, 175, -20, 18, -20, 16,
+ax_anim 2, 3, 174, -13, 19, -13, 20,
+ax_anim 2, 0, 173, -3, 13, -3, 13,
+ax_anim 1, 0, 172, 1, 8, 1, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStantlerAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStantlerAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -24, 0, 0,
+ax_anim 3, 0, 188, 0, -23, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -25, 0, 0,
+ax_anim 3, 0, 191, 0, -23, 0, 0,
+ax_anim 2, 0, 191, 0, -19, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -24, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -24, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -24, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -25, 0, 0,
+ax_anim 3, 0, 209, 0, -23, 0, 0,
+ax_anim 2, 0, 209, 0, -19, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStantlerAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStantlerAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sStantlerGfx1:
+.incbin "baserom.gba", 0xF7CA44, 0x200
+sStantlerSprites1:
+ax_sprite sStantlerGfx1, 0x200
+ax_sprite_terminator
+sStantlerGfx2:
+.incbin "baserom.gba", 0xF7CC54, 0x200
+sStantlerSprites2:
+ax_sprite sStantlerGfx2, 0x200
+ax_sprite_terminator
+sStantlerGfx3:
+.incbin "baserom.gba", 0xF7CE64, 0x200
+sStantlerSprites3:
+ax_sprite sStantlerGfx3, 0x200
+ax_sprite_terminator
+sStantlerGfx4:
+.incbin "baserom.gba", 0xF7D074, 0x200
+sStantlerSprites4:
+ax_sprite sStantlerGfx4, 0x200
+ax_sprite_terminator
+sStantlerGfx5:
+.incbin "baserom.gba", 0xF7D284, 0x200
+sStantlerSprites5:
+ax_sprite sStantlerGfx5, 0x200
+ax_sprite_terminator
+sStantlerGfx6:
+.incbin "baserom.gba", 0xF7D494, 0x200
+sStantlerSprites6:
+ax_sprite sStantlerGfx6, 0x200
+ax_sprite_terminator
+sStantlerGfx7:
+.incbin "baserom.gba", 0xF7D6A4, 0x200
+sStantlerSprites7:
+ax_sprite sStantlerGfx7, 0x200
+ax_sprite_terminator
+sStantlerGfx8:
+.incbin "baserom.gba", 0xF7D8B4, 0x200
+sStantlerSprites8:
+ax_sprite sStantlerGfx8, 0x200
+ax_sprite_terminator
+sStantlerGfx9:
+.incbin "baserom.gba", 0xF7DAC4, 0x200
+sStantlerSprites9:
+ax_sprite sStantlerGfx9, 0x200
+ax_sprite_terminator
+sStantlerGfx10:
+.incbin "baserom.gba", 0xF7DCD4, 0x200
+sStantlerSprites10:
+ax_sprite sStantlerGfx10, 0x200
+ax_sprite_terminator
+sStantlerGfx11:
+.incbin "baserom.gba", 0xF7DEE4, 0x100
+sStantlerSprites11:
+ax_sprite sStantlerGfx11, 0x100
+ax_sprite_terminator
+sStantlerGfx12:
+.incbin "baserom.gba", 0xF7DFF4, 0x40
+sStantlerSprites12:
+ax_sprite sStantlerGfx12, 0x40
+ax_sprite_terminator
+sStantlerGfx13:
+.incbin "baserom.gba", 0xF7E044, 0x20
+sStantlerSprites13:
+ax_sprite sStantlerGfx13, 0x20
+ax_sprite_terminator
+sStantlerGfx14:
+.incbin "baserom.gba", 0xF7E074, 0x200
+sStantlerSprites14:
+ax_sprite sStantlerGfx14, 0x200
+ax_sprite_terminator
+sStantlerGfx15:
+.incbin "baserom.gba", 0xF7E284, 0x200
+sStantlerSprites15:
+ax_sprite sStantlerGfx15, 0x200
+ax_sprite_terminator
+sStantlerGfx16:
+.incbin "baserom.gba", 0xF7E494, 0x200
+sStantlerSprites16:
+ax_sprite sStantlerGfx16, 0x200
+ax_sprite_terminator
+sStantlerGfx17:
+.incbin "baserom.gba", 0xF7E6A4, 0x200
+sStantlerSprites17:
+ax_sprite sStantlerGfx17, 0x200
+ax_sprite_terminator
+sStantlerGfx18:
+.incbin "baserom.gba", 0xF7E8B4, 0x20
+sStantlerGfx18_1:
+.incbin "baserom.gba", 0xF7E8D4, 0x20
+sStantlerGfx18_2:
+.incbin "baserom.gba", 0xF7E8F4, 0x60
+sStantlerGfx18_3:
+.incbin "baserom.gba", 0xF7E954, 0x60
+sStantlerGfx18_4:
+.incbin "baserom.gba", 0xF7E9B4, 0x60
+sStantlerSprites18:
+ax_sprite sStantlerGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx18_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx18_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx19:
+.incbin "baserom.gba", 0xF7EA6C, 0x20
+sStantlerGfx19_1:
+.incbin "baserom.gba", 0xF7EA8C, 0x60
+sStantlerGfx19_2:
+.incbin "baserom.gba", 0xF7EAEC, 0x60
+sStantlerGfx19_3:
+.incbin "baserom.gba", 0xF7EB4C, 0x60
+sStantlerSprites19:
+ax_sprite sStantlerGfx19, 0x20
+ax_sprite 0, 0x60
+ax_sprite sStantlerGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx20:
+.incbin "baserom.gba", 0xF7EBF4, 0x40
+sStantlerGfx20_1:
+.incbin "baserom.gba", 0xF7EC34, 0x60
+sStantlerGfx20_2:
+.incbin "baserom.gba", 0xF7EC94, 0x100
+sStantlerSprites20:
+ax_sprite sStantlerGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx20_2, 0x100
+ax_sprite_terminator
+sStantlerGfx21:
+.incbin "baserom.gba", 0xF7EDC4, 0x60
+sStantlerGfx21_1:
+.incbin "baserom.gba", 0xF7EE24, 0x60
+sStantlerGfx21_2:
+.incbin "baserom.gba", 0xF7EE84, 0x60
+sStantlerGfx21_3:
+.incbin "baserom.gba", 0xF7EEE4, 0x60
+sStantlerSprites21:
+ax_sprite sStantlerGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx22:
+.incbin "baserom.gba", 0xF7EF8C, 0x100
+sStantlerSprites22:
+ax_sprite sStantlerGfx22, 0x100
+ax_sprite_terminator
+sStantlerGfx23:
+.incbin "baserom.gba", 0xF7F09C, 0x60
+sStantlerSprites23:
+ax_sprite sStantlerGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx24:
+.incbin "baserom.gba", 0xF7F114, 0x20
+sStantlerSprites24:
+ax_sprite sStantlerGfx24, 0x20
+ax_sprite_terminator
+sStantlerGfx25:
+.incbin "baserom.gba", 0xF7F144, 0x20
+sStantlerSprites25:
+ax_sprite sStantlerGfx25, 0x20
+ax_sprite_terminator
+sStantlerGfx26:
+.incbin "baserom.gba", 0xF7F174, 0x60
+sStantlerGfx26_1:
+.incbin "baserom.gba", 0xF7F1D4, 0x60
+sStantlerGfx26_2:
+.incbin "baserom.gba", 0xF7F234, 0x20
+sStantlerGfx26_3:
+.incbin "baserom.gba", 0xF7F254, 0x20
+sStantlerSprites26:
+ax_sprite sStantlerGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx26_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sStantlerGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStantlerGfx27:
+.incbin "baserom.gba", 0xF7F2BC, 0x60
+sStantlerGfx27_1:
+.incbin "baserom.gba", 0xF7F31C, 0x60
+sStantlerGfx27_2:
+.incbin "baserom.gba", 0xF7F37C, 0x40
+sStantlerGfx27_3:
+.incbin "baserom.gba", 0xF7F3BC, 0x40
+sStantlerSprites27:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx27_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx28:
+.incbin "baserom.gba", 0xF7F44C, 0x60
+sStantlerGfx28_1:
+.incbin "baserom.gba", 0xF7F4AC, 0x60
+sStantlerGfx28_2:
+.incbin "baserom.gba", 0xF7F50C, 0x60
+sStantlerGfx28_3:
+.incbin "baserom.gba", 0xF7F56C, 0x40
+sStantlerSprites28:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx28_3, 0x40
+ax_sprite_terminator
+sStantlerGfx29:
+.incbin "baserom.gba", 0xF7F5F4, 0x60
+sStantlerGfx29_1:
+.incbin "baserom.gba", 0xF7F654, 0x60
+sStantlerGfx29_2:
+.incbin "baserom.gba", 0xF7F6B4, 0x40
+sStantlerGfx29_3:
+.incbin "baserom.gba", 0xF7F6F4, 0x40
+sStantlerSprites29:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx30:
+.incbin "baserom.gba", 0xF7F784, 0x60
+sStantlerGfx30_1:
+.incbin "baserom.gba", 0xF7F7E4, 0x60
+sStantlerGfx30_2:
+.incbin "baserom.gba", 0xF7F844, 0x40
+sStantlerGfx30_3:
+.incbin "baserom.gba", 0xF7F884, 0x40
+sStantlerSprites30:
+ax_sprite sStantlerGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx30_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx30_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStantlerGfx31:
+.incbin "baserom.gba", 0xF7F90C, 0x60
+sStantlerGfx31_1:
+.incbin "baserom.gba", 0xF7F96C, 0x60
+sStantlerGfx31_2:
+.incbin "baserom.gba", 0xF7F9CC, 0x40
+sStantlerGfx31_3:
+.incbin "baserom.gba", 0xF7FA0C, 0x20
+sStantlerSprites31:
+ax_sprite sStantlerGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx31_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sStantlerGfx31_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStantlerGfx32:
+.incbin "baserom.gba", 0xF7FA74, 0x60
+sStantlerGfx32_1:
+.incbin "baserom.gba", 0xF7FAD4, 0x60
+sStantlerGfx32_2:
+.incbin "baserom.gba", 0xF7FB34, 0x20
+sStantlerGfx32_3:
+.incbin "baserom.gba", 0xF7FB54, 0x20
+sStantlerSprites32:
+ax_sprite sStantlerGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx32_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx32_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sStantlerGfx32_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStantlerGfx33:
+.incbin "baserom.gba", 0xF7FBBC, 0x60
+sStantlerGfx33_1:
+.incbin "baserom.gba", 0xF7FC1C, 0x60
+sStantlerGfx33_2:
+.incbin "baserom.gba", 0xF7FC7C, 0x40
+sStantlerGfx33_3:
+.incbin "baserom.gba", 0xF7FCBC, 0x40
+sStantlerSprites33:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx34:
+.incbin "baserom.gba", 0xF7FD4C, 0x60
+sStantlerGfx34_1:
+.incbin "baserom.gba", 0xF7FDAC, 0x60
+sStantlerGfx34_2:
+.incbin "baserom.gba", 0xF7FE0C, 0x40
+sStantlerGfx34_3:
+.incbin "baserom.gba", 0xF7FE4C, 0x40
+sStantlerSprites34:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx34_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx35:
+.incbin "baserom.gba", 0xF7FEDC, 0x60
+sStantlerGfx35_1:
+.incbin "baserom.gba", 0xF7FF3C, 0x60
+sStantlerGfx35_2:
+.incbin "baserom.gba", 0xF7FF9C, 0x60
+sStantlerGfx35_3:
+.incbin "baserom.gba", 0xF7FFFC, 0x40
+sStantlerSprites35:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx35_3, 0x40
+ax_sprite_terminator
+sStantlerGfx36:
+.incbin "baserom.gba", 0xF80084, 0x60
+sStantlerGfx36_1:
+.incbin "baserom.gba", 0xF800E4, 0x60
+sStantlerGfx36_2:
+.incbin "baserom.gba", 0xF80144, 0x60
+sStantlerGfx36_3:
+.incbin "baserom.gba", 0xF801A4, 0x40
+sStantlerSprites36:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx36_3, 0x40
+ax_sprite_terminator
+sStantlerGfx37:
+.incbin "baserom.gba", 0xF8022C, 0x60
+sStantlerGfx37_1:
+.incbin "baserom.gba", 0xF8028C, 0x60
+sStantlerGfx37_2:
+.incbin "baserom.gba", 0xF802EC, 0x40
+sStantlerGfx37_3:
+.incbin "baserom.gba", 0xF8032C, 0x40
+sStantlerSprites37:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx37_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx38:
+.incbin "baserom.gba", 0xF803BC, 0x60
+sStantlerGfx38_1:
+.incbin "baserom.gba", 0xF8041C, 0x60
+sStantlerGfx38_2:
+.incbin "baserom.gba", 0xF8047C, 0x40
+sStantlerGfx38_3:
+.incbin "baserom.gba", 0xF804BC, 0x40
+sStantlerSprites38:
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStantlerGfx39:
+.incbin "baserom.gba", 0xF8054C, 0x60
+sStantlerGfx39_1:
+.incbin "baserom.gba", 0xF805AC, 0x60
+sStantlerGfx39_2:
+.incbin "baserom.gba", 0xF8060C, 0x40
+sStantlerGfx39_3:
+.incbin "baserom.gba", 0xF8064C, 0x40
+sStantlerSprites39:
+ax_sprite sStantlerGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx39_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx39_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStantlerGfx40:
+.incbin "baserom.gba", 0xF806D4, 0x60
+sStantlerGfx40_1:
+.incbin "baserom.gba", 0xF80734, 0x60
+sStantlerGfx40_2:
+.incbin "baserom.gba", 0xF80794, 0x40
+sStantlerGfx40_3:
+.incbin "baserom.gba", 0xF807D4, 0x40
+sStantlerSprites40:
+ax_sprite sStantlerGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStantlerGfx40_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStantlerGfx40_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStantlerGfx41:
+.incbin "baserom.gba", 0xF8085C, 0x200
+sStantlerSprites41:
+ax_sprite sStantlerGfx41, 0x200
+ax_sprite_terminator
+sStantlerGfx42:
+.incbin "baserom.gba", 0xF80A6C, 0x200
+sStantlerSprites42:
+ax_sprite sStantlerGfx42, 0x200
+ax_sprite_terminator
+sStantlerGfx43:
+.incbin "baserom.gba", 0xF80C7C, 0x80
+sStantlerSprites43:
+ax_sprite sStantlerGfx43, 0x80
+ax_sprite_terminator
+sStantlerGfx44:
+.incbin "baserom.gba", 0xF80D0C, 0x20
+sStantlerSprites44:
+ax_sprite sStantlerGfx44, 0x20
+ax_sprite_terminator
+sStantlerGfx45:
+.incbin "baserom.gba", 0xF80D3C, 0x100
+sStantlerSprites45:
+ax_sprite sStantlerGfx45, 0x100
+ax_sprite_terminator
+sStantlerGfx46:
+.incbin "baserom.gba", 0xF80E4C, 0x200
+sStantlerSprites46:
+ax_sprite sStantlerGfx46, 0x200
+ax_sprite_terminator
+sStantlerGfx47:
+.incbin "baserom.gba", 0xF8105C, 0x200
+sStantlerSprites47:
+ax_sprite sStantlerGfx47, 0x200
+ax_sprite_terminator
+sStantlerGfx48:
+.incbin "baserom.gba", 0xF8126C, 0x80
+sStantlerSprites48:
+ax_sprite sStantlerGfx48, 0x80
+ax_sprite_terminator
+sStantlerGfx49:
+.incbin "baserom.gba", 0xF812FC, 0x40
+sStantlerSprites49:
+ax_sprite sStantlerGfx49, 0x40
+ax_sprite_terminator
+sStantlerGfx50:
+.incbin "baserom.gba", 0xF8134C, 0x100
+sStantlerSprites50:
+ax_sprite sStantlerGfx50, 0x100
+ax_sprite_terminator
+sStantlerGfx51:
+.incbin "baserom.gba", 0xF8145C, 0x80
+sStantlerSprites51:
+ax_sprite sStantlerGfx51, 0x80
+ax_sprite_terminator
+sStantlerGfx52:
+.incbin "baserom.gba", 0xF814EC, 0x40
+sStantlerSprites52:
+ax_sprite sStantlerGfx52, 0x40
+ax_sprite_terminator
+sStantlerGfx53:
+.incbin "baserom.gba", 0xF8153C, 0x40
+sStantlerSprites53:
+ax_sprite sStantlerGfx53, 0x40
+ax_sprite_terminator
+sStantlerGfx54:
+.incbin "baserom.gba", 0xF8158C, 0x100
+sStantlerSprites54:
+ax_sprite sStantlerGfx54, 0x100
+ax_sprite_terminator
+sAxPosesStantler:
+.4byte sStantlerPose1
+.4byte sStantlerPose2
+.4byte sStantlerPose3
+.4byte sStantlerPose4
+.4byte sStantlerPose5
+.4byte sStantlerPose6
+.4byte sStantlerPose7
+.4byte sStantlerPose8
+.4byte sStantlerPose9
+.4byte sStantlerPose10
+.4byte sStantlerPose11
+.4byte sStantlerPose12
+.4byte sStantlerPose13
+.4byte sStantlerPose14
+.4byte sStantlerPose15
+.4byte sStantlerPose16
+.4byte sStantlerPose17
+.4byte sStantlerPose18
+.4byte sStantlerPose19
+.4byte sStantlerPose20
+.4byte sStantlerPose21
+.4byte sStantlerPose22
+.4byte sStantlerPose23
+.4byte sStantlerPose24
+.4byte sStantlerPose25
+.4byte sStantlerPose26
+.4byte sStantlerPose27
+.4byte sStantlerPose28
+.4byte sStantlerPose29
+.4byte sStantlerPose30
+.4byte sStantlerPose31
+.4byte sStantlerPose32
+.4byte sStantlerPose33
+.4byte sStantlerPose34
+.4byte sStantlerPose35
+.4byte sStantlerPose36
+.4byte sStantlerPose37
+.4byte sStantlerPose38
+.4byte sStantlerPose39
+.4byte sStantlerPose40
+.4byte sStantlerPose41
+.4byte sStantlerPose42
+.4byte sStantlerPose43
+.4byte sStantlerPose44
+.4byte sStantlerPose45
+.4byte sStantlerPose46
+.4byte sStantlerPose47
+.4byte sStantlerPose48
+.4byte sStantlerPose49
+.4byte sStantlerPose50
+.4byte sStantlerPose51
+.4byte sStantlerPose52
+.4byte sStantlerPose53
+.4byte sStantlerPose54
+.4byte sStantlerPose55
+.4byte sStantlerPose56
+.4byte sStantlerPose57
+.4byte sStantlerPose58
+.4byte sStantlerPose59
+.4byte sStantlerPose60
+.4byte sStantlerPose61
+.4byte sStantlerPose62
+.4byte sStantlerPose63
+.4byte sStantlerPose64
+.4byte sStantlerPose65
+.4byte sStantlerPose66
+.4byte sStantlerPose67
+.4byte sStantlerPose68
+.4byte sStantlerPose69
+.4byte sStantlerPose70
+.4byte sStantlerPose71
+.4byte sStantlerPose72
+.4byte sStantlerPose73
+.4byte sStantlerPose74
+.4byte sStantlerPose75
+.4byte sStantlerPose76
+.4byte sStantlerPose77
+.4byte sStantlerPose78
+.4byte sStantlerPose79
+.4byte sStantlerPose80
+.4byte sStantlerPose81
+.4byte sStantlerPose82
+.4byte sStantlerPose83
+.4byte sStantlerPose84
+.4byte sStantlerPose85
+.4byte sStantlerPose86
+.4byte sStantlerPose87
+.4byte sStantlerPose88
+.4byte sStantlerPose89
+.4byte sStantlerPose90
+.4byte sStantlerPose91
+.4byte sStantlerPose92
+.4byte sStantlerPose93
+.4byte sStantlerPose94
+.4byte sStantlerPose95
+.4byte sStantlerPose96
+.4byte sStantlerPose97
+.4byte sStantlerPose98
+.4byte sStantlerPose99
+.4byte sStantlerPose100
+.4byte sStantlerPose101
+.4byte sStantlerPose102
+.4byte sStantlerPose103
+.4byte sStantlerPose104
+.4byte sStantlerPose105
+.4byte sStantlerPose106
+.4byte sStantlerPose107
+.4byte sStantlerPose108
+.4byte sStantlerPose109
+.4byte sStantlerPose110
+.4byte sStantlerPose111
+.4byte sStantlerPose112
+.4byte sStantlerPose113
+.4byte sStantlerPose114
+.4byte sStantlerPose115
+.4byte sStantlerPose116
+.4byte sStantlerPose117
+.4byte sStantlerPose118
+.4byte sStantlerPose119
+.4byte sStantlerPose120
+.4byte sStantlerPose121
+.4byte sStantlerPose122
+.4byte sStantlerPose123
+.4byte sStantlerPose124
+.4byte sStantlerPose125
+.4byte sStantlerPose126
+.4byte sStantlerPose127
+.4byte sStantlerPose128
+.4byte sStantlerPose129
+.4byte sStantlerPose130
+.4byte sStantlerPose131
+.4byte sStantlerPose132
+.4byte sStantlerPose133
+.4byte sStantlerPose134
+.4byte sStantlerPose135
+.4byte sStantlerPose136
+.4byte sStantlerPose137
+.4byte sStantlerPose138
+.4byte sStantlerPose139
+.4byte sStantlerPose140
+.4byte sStantlerPose141
+.4byte sStantlerPose142
+.4byte sStantlerPose143
+.4byte sStantlerPose144
+.4byte sStantlerPose145
+.4byte sStantlerPose146
+.4byte sStantlerPose147
+.4byte sStantlerPose148
+.4byte sStantlerPose149
+.4byte sStantlerPose150
+.4byte sStantlerPose151
+.4byte sStantlerPose152
+.4byte sStantlerPose153
+.4byte sStantlerPose154
+.4byte sStantlerPose155
+.4byte sStantlerPose156
+.4byte sStantlerPose157
+.4byte sStantlerPose158
+.4byte sStantlerPose159
+.4byte sStantlerPose160
+.4byte sStantlerPose161
+.4byte sStantlerPose162
+.4byte sStantlerPose163
+.4byte sStantlerPose164
+.4byte sStantlerPose165
+.4byte sStantlerPose166
+.4byte sStantlerPose167
+.4byte sStantlerPose168
+.4byte sStantlerPose169
+.4byte sStantlerPose170
+.4byte sStantlerPose171
+.4byte sStantlerPose172
+.4byte sStantlerPose173
+.4byte sStantlerPose174
+.4byte sStantlerPose175
+.4byte sStantlerPose176
+.4byte sStantlerPose177
+.4byte sStantlerPose178
+.4byte sStantlerPose179
+.4byte sStantlerPose180
+.4byte sStantlerPose181
+.4byte sStantlerPose182
+.4byte sStantlerPose183
+.4byte sStantlerPose184
+.4byte sStantlerPose185
+.4byte sStantlerPose186
+.4byte sStantlerPose187
+.4byte sStantlerPose188
+.4byte sStantlerPose189
+.4byte sStantlerPose190
+.4byte sStantlerPose191
+.4byte sStantlerPose192
+.4byte sStantlerPose193
+.4byte sStantlerPose194
+.4byte sStantlerPose195
+.4byte sStantlerPose196
+.4byte sStantlerPose197
+.4byte sStantlerPose198
+.4byte sStantlerPose199
+.4byte sStantlerPose200
+.4byte sStantlerPose201
+.4byte sStantlerPose202
+.4byte sStantlerPose203
+.4byte sStantlerPose204
+.4byte sStantlerPose205
+.4byte sStantlerPose206
+.4byte sStantlerPose207
+.4byte sStantlerPose208
+.4byte sStantlerPose209
+.4byte sStantlerPose210
+.4byte sStantlerPose211
+.4byte sStantlerPose212
+.4byte sStantlerPose213
+.4byte sStantlerPose214
+.4byte sStantlerPose215
+.4byte sStantlerPose216
+.4byte sStantlerPose217
+.4byte sStantlerPose218
+.4byte sStantlerPose219
+.4byte sStantlerPose220
+.4byte sStantlerPose221
+.4byte sStantlerPose222
+.4byte sStantlerPose223
+.4byte sStantlerPose224
+.4byte sStantlerPose225
+.4byte sStantlerPose226
+sAxPositionsStantler:
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,  -10, 	  -3,   -3, 	   1,   -3, 	  -1,   -8
+.2byte   -1,   -2, 	  -3,    4, 	   1,    4, 	  -1,   -3
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+.2byte    6,  -12, 	   6,   -2, 	   3,   -1, 	   1,   -7
+.2byte    8,   -8, 	   6,    1, 	   2,    3, 	   2,   -6
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte    8,  -15, 	   6,   -6, 	   6,   -5, 	   1,   -9
+.2byte   12,  -10, 	   6,   -2, 	   4,    1, 	   2,   -6
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    5,  -15, 	   0,   -7, 	   3,   -6, 	   0,   -8
+.2byte    8,  -12, 	   2,   -4, 	   6,   -2, 	   1,   -6
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte   -1,  -16, 	   2,  -10, 	  -4,  -10, 	  -1,  -12
+.2byte   -1,  -12, 	   0,    0, 	  -2,    0, 	  -1,   -9
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -6,  -15, 	  -1,   -7, 	  -4,   -6, 	  -1,   -8
+.2byte   -9,  -12, 	  -3,   -4, 	  -7,   -2, 	  -2,   -6
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -9,  -15, 	  -7,   -6, 	  -7,   -5, 	  -2,   -9
+.2byte  -13,  -10, 	  -7,   -2, 	  -5,    1, 	  -3,   -6
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte   -7,  -12, 	  -7,   -2, 	  -4,   -1, 	  -2,   -7
+.2byte   -9,   -8, 	  -7,    1, 	  -3,    3, 	  -3,   -6
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,  -10, 	  -3,   -3, 	   1,   -3, 	  -1,   -8
+.2byte   -1,   -2, 	  -3,    4, 	   1,    4, 	  -1,   -3
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,   -4
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+.2byte    6,  -12, 	   6,   -2, 	   3,   -1, 	   1,   -7
+.2byte    8,   -8, 	   6,    1, 	   2,    3, 	   2,   -6
+.2byte    9,   -5, 	   6,    1, 	   0,    4, 	   1,   -5
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte    8,  -15, 	   6,   -6, 	   6,   -5, 	   1,   -9
+.2byte   12,  -10, 	   6,   -2, 	   4,    1, 	   2,   -6
+.2byte   12,   -8, 	   7,   -3, 	   6,    1, 	   1,   -6
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    5,  -15, 	   0,   -7, 	   3,   -6, 	   0,   -8
+.2byte    8,  -12, 	   2,   -4, 	   6,   -2, 	   1,   -6
+.2byte    8,  -11, 	   2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte   -1,  -16, 	   2,  -10, 	  -4,  -10, 	  -1,  -12
+.2byte   -1,  -12, 	   0,    0, 	  -2,    0, 	  -1,   -9
+.2byte   -1,  -17, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -6,  -15, 	  -1,   -7, 	  -4,   -6, 	  -1,   -8
+.2byte   -9,  -12, 	  -3,   -4, 	  -7,   -2, 	  -2,   -6
+.2byte   -9,  -11, 	  -3,   -5, 	  -7,   -3, 	   0,   -8
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -9,  -15, 	  -7,   -6, 	  -7,   -5, 	  -2,   -9
+.2byte  -13,  -10, 	  -7,   -2, 	  -5,    1, 	  -3,   -6
+.2byte  -13,   -8, 	  -8,   -3, 	  -7,    1, 	  -2,   -6
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte   -7,  -12, 	  -7,   -2, 	  -4,   -1, 	  -2,   -7
+.2byte   -9,   -8, 	  -7,    1, 	  -3,    3, 	  -3,   -6
+.2byte  -10,   -5, 	  -7,    1, 	  -1,    4, 	  -2,   -5
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,  -10, 	  -3,   -3, 	   1,   -3, 	  -1,   -8
+.2byte   -1,   -2, 	  -3,    4, 	   1,    4, 	  -1,   -3
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,   -4
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+.2byte    6,  -12, 	   6,   -2, 	   3,   -1, 	   1,   -7
+.2byte    8,   -8, 	   6,    1, 	   2,    3, 	   2,   -6
+.2byte    9,   -5, 	   6,    1, 	   0,    4, 	   1,   -5
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte    8,  -15, 	   6,   -6, 	   6,   -5, 	   1,   -9
+.2byte   12,  -10, 	   6,   -2, 	   4,    1, 	   2,   -6
+.2byte   12,   -8, 	   7,   -3, 	   6,    1, 	   1,   -6
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    5,  -15, 	   0,   -7, 	   3,   -6, 	   0,   -8
+.2byte    8,  -12, 	   2,   -4, 	   6,   -2, 	   1,   -6
+.2byte    8,  -11, 	   2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte   -1,  -16, 	   2,  -10, 	  -4,  -10, 	  -1,  -12
+.2byte   -1,  -12, 	   0,    0, 	  -2,    0, 	  -1,   -9
+.2byte   -1,  -17, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -6,  -15, 	  -1,   -7, 	  -4,   -6, 	  -1,   -8
+.2byte   -9,  -12, 	  -3,   -4, 	  -7,   -2, 	  -2,   -6
+.2byte   -9,  -11, 	  -3,   -5, 	  -7,   -3, 	   0,   -8
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -9,  -15, 	  -7,   -6, 	  -7,   -5, 	  -2,   -9
+.2byte  -13,  -10, 	  -7,   -2, 	  -5,    1, 	  -3,   -6
+.2byte  -13,   -8, 	  -8,   -3, 	  -7,    1, 	  -2,   -6
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte   -7,  -12, 	  -7,   -2, 	  -4,   -1, 	  -2,   -7
+.2byte   -9,   -8, 	  -7,    1, 	  -3,    3, 	  -3,   -6
+.2byte  -10,   -5, 	  -7,    1, 	  -1,    4, 	  -2,   -5
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,  -21, 	  -3,  -10, 	   1,  -10, 	  -1,  -12
+.2byte   -1,   -4, 	  -5,    3, 	   3,    3, 	  -1,   -3
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+.2byte    2,  -23, 	   4,  -10, 	   1,   -8, 	  -1,  -11
+.2byte    9,   -5, 	   6,    1, 	   0,    4, 	   1,   -5
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte    1,  -20, 	   2,   -9, 	   2,   -8, 	  -2,   -9
+.2byte   12,   -8, 	   7,   -3, 	   6,    1, 	   1,   -6
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    1,  -21, 	   1,  -12, 	   4,  -10, 	  -1,  -11
+.2byte    8,  -11, 	   2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte   -1,  -24, 	   1,  -10, 	  -3,  -10, 	  -1,  -10
+.2byte   -1,  -17, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -2,  -21, 	  -2,  -12, 	  -5,  -10, 	   0,  -11
+.2byte   -9,  -11, 	  -3,   -5, 	  -7,   -3, 	   0,   -8
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -2,  -20, 	  -3,   -9, 	  -3,   -8, 	   1,   -9
+.2byte  -13,   -8, 	  -8,   -3, 	  -7,    1, 	  -2,   -6
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte   -3,  -23, 	  -5,  -10, 	  -2,   -8, 	   0,  -11
+.2byte  -10,   -5, 	  -7,    1, 	  -1,    4, 	  -2,   -5
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,  -21, 	  -3,  -10, 	   1,  -10, 	  -1,  -12
+.2byte   -1,  -21, 	  -3,   -8, 	   1,  -14, 	  -1,  -13
+.2byte   -1,  -21, 	  -3,  -14, 	   1,   -8, 	  -1,  -13
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+.2byte    2,  -23, 	   4,  -10, 	   1,   -8, 	  -1,  -11
+.2byte    2,  -23, 	   5,   -9, 	   3,  -12, 	  -1,  -11
+.2byte    2,  -23, 	   5,  -13, 	   3,   -7, 	   0,  -12
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte    1,  -20, 	   2,   -9, 	   2,   -8, 	  -2,   -9
+.2byte    1,  -20, 	   3,   -7, 	   4,  -12, 	  -3,   -9
+.2byte    1,  -20, 	   2,  -13, 	   6,   -8, 	  -3,   -9
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    1,  -21, 	   1,  -12, 	   4,  -10, 	  -1,  -11
+.2byte    1,  -21, 	   1,  -15, 	   5,  -14, 	  -1,  -12
+.2byte    1,  -22, 	   3,  -14, 	   6,   -9, 	  -1,  -11
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte   -1,  -24, 	   1,  -10, 	  -3,  -10, 	  -1,  -10
+.2byte   -1,  -24, 	   1,   -6, 	  -3,  -11, 	  -1,   -9
+.2byte   -1,  -24, 	   1,  -11, 	  -3,   -6, 	  -1,   -9
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -2,  -21, 	  -2,  -12, 	  -5,  -10, 	   0,  -11
+.2byte   -2,  -21, 	  -2,  -15, 	  -6,  -14, 	   0,  -12
+.2byte   -2,  -22, 	  -4,  -14, 	  -7,   -9, 	   0,  -11
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -2,  -20, 	  -3,   -9, 	  -3,   -8, 	   1,   -9
+.2byte   -2,  -20, 	  -4,   -7, 	  -5,  -12, 	   2,   -9
+.2byte   -2,  -20, 	  -3,  -13, 	  -7,   -8, 	   2,   -9
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte   -3,  -23, 	  -5,  -10, 	  -2,   -8, 	   0,  -11
+.2byte   -3,  -23, 	  -6,   -9, 	  -4,  -12, 	   0,  -11
+.2byte   -3,  -23, 	  -6,  -13, 	  -4,   -7, 	  -1,  -12
+.2byte   -6,   -6, 	  -4,    1, 	  -2,    2, 	  -1,   -3
+.2byte   -7,   -5, 	  -5,    1, 	  -2,    2, 	  -1,   -3
+.2byte    0,  -18, 	  -2,   -7, 	   2,   -7, 	   0,  -13
+.2byte   -1,  -19, 	   5,  -11, 	   2,   -8, 	  -2,  -11
+.2byte    3,  -20, 	   7,  -10, 	   5,   -8, 	   0,  -11
+.2byte    2,  -19, 	  -2,  -10, 	   2,   -9, 	  -2,  -11
+.2byte    0,  -18, 	   2,   -7, 	  -2,   -7, 	   0,  -10
+.2byte   -3,  -19, 	   1,  -10, 	  -3,   -9, 	   1,  -11
+.2byte   -4,  -20, 	  -8,  -10, 	  -6,   -8, 	  -1,  -11
+.2byte    0,  -19, 	  -6,  -11, 	  -3,   -8, 	   1,  -11
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,   -4, 	  -5,    3, 	   3,    3, 	  -1,   -3
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+.2byte    9,   -5, 	   6,    1, 	   0,    4, 	   1,   -5
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte   12,   -8, 	   7,   -3, 	   6,    1, 	   1,   -6
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    8,  -10, 	   2,   -4, 	   6,   -2, 	  -1,   -7
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte   -1,  -15, 	   4,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -9,  -10, 	  -3,   -4, 	  -7,   -2, 	   0,   -7
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte  -13,   -8, 	  -8,   -3, 	  -7,    1, 	  -2,   -6
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte  -10,   -5, 	  -7,    1, 	  -1,    4, 	  -2,   -5
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,   -4
+.2byte   -9,   -6, 	  -6,    0, 	   0,    3, 	  -1,   -6
+.2byte  -12,   -9, 	  -7,   -4, 	  -6,    0, 	  -1,   -7
+.2byte   -8,  -11, 	  -2,   -5, 	  -6,   -3, 	   1,   -8
+.2byte   -1,  -16, 	   4,   -6, 	  -6,   -6, 	  -1,   -8
+.2byte    7,  -11, 	   1,   -5, 	   5,   -3, 	  -2,   -8
+.2byte   11,   -9, 	   6,   -4, 	   5,    0, 	   0,   -7
+.2byte    8,   -6, 	   5,    0, 	  -1,    3, 	   0,   -6
+.2byte   -1,  -21, 	  -3,  -10, 	   1,  -10, 	  -1,  -12
+.2byte    3,  -22, 	   5,   -9, 	   2,   -7, 	   0,  -10
+.2byte    3,  -20, 	   4,   -9, 	   4,   -8, 	   0,   -9
+.2byte    2,  -22, 	   2,  -13, 	   5,  -11, 	   0,  -12
+.2byte   -1,  -26, 	   1,  -12, 	  -3,  -12, 	  -1,  -12
+.2byte   -3,  -22, 	  -3,  -13, 	  -6,  -11, 	  -1,  -12
+.2byte   -4,  -20, 	  -5,   -9, 	  -5,   -8, 	  -1,   -9
+.2byte   -4,  -22, 	  -6,   -9, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -1,  -21, 	  -3,  -10, 	   1,  -10, 	  -1,  -12
+.2byte   -1,   -4, 	  -5,    3, 	   3,    3, 	  -1,   -3
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+.2byte    2,  -23, 	   4,  -10, 	   1,   -8, 	  -1,  -11
+.2byte   10,   -5, 	   7,    1, 	   1,    4, 	   2,   -5
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte    1,  -20, 	   2,   -9, 	   2,   -8, 	  -2,   -9
+.2byte   12,   -8, 	   7,   -3, 	   6,    1, 	   1,   -6
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    1,  -21, 	   1,  -12, 	   4,  -10, 	  -1,  -11
+.2byte    8,  -11, 	   2,   -5, 	   6,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte   -1,  -24, 	   1,  -10, 	  -3,  -10, 	  -1,  -10
+.2byte   -1,  -17, 	   4,   -7, 	  -6,   -7, 	  -1,   -9
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -2,  -21, 	  -2,  -12, 	  -5,  -10, 	   0,  -11
+.2byte   -9,  -11, 	  -3,   -5, 	  -7,   -3, 	   0,   -8
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -2,  -20, 	  -3,   -9, 	  -3,   -8, 	   1,   -9
+.2byte  -13,   -8, 	  -8,   -3, 	  -7,    1, 	  -2,   -6
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte   -3,  -23, 	  -5,  -10, 	  -2,   -8, 	   0,  -11
+.2byte  -11,   -5, 	  -8,    1, 	  -2,    4, 	  -3,   -5
+.2byte   -1,   -5, 	  -5,    2, 	   3,    2, 	  -1,   -4
+.2byte   -9,   -6, 	  -6,    0, 	   0,    3, 	  -1,   -6
+.2byte  -12,   -9, 	  -7,   -4, 	  -6,    0, 	  -1,   -7
+.2byte   -8,  -11, 	  -2,   -5, 	  -6,   -3, 	   1,   -8
+.2byte   -1,  -15, 	   4,   -5, 	  -6,   -5, 	  -1,   -7
+.2byte    7,  -11, 	   1,   -5, 	   5,   -3, 	  -2,   -8
+.2byte   11,   -9, 	   6,   -4, 	   5,    0, 	   0,   -7
+.2byte    8,   -6, 	   5,    0, 	  -1,    3, 	   0,   -6
+.2byte   -1,   -8, 	  -3,    2, 	   1,    2, 	  -1,   -6
+.2byte   -8,  -10, 	  -6,    1, 	  -2,    3, 	  -3,   -6
+.2byte  -10,  -11, 	  -6,   -2, 	  -5,    1, 	  -2,   -6
+.2byte   -7,  -13, 	  -1,   -4, 	  -6,   -2, 	  -1,   -7
+.2byte   -1,  -13, 	   1,   -3, 	  -3,   -3, 	  -1,   -8
+.2byte    6,  -13, 	   0,   -4, 	   5,   -2, 	   0,   -7
+.2byte    9,  -11, 	   5,   -2, 	   4,    1, 	   1,   -6
+.2byte    7,  -10, 	   5,    1, 	   1,    3, 	   2,   -6
+sStantlerAnimTable1:
+.4byte sStantlerAnims_1_1
+.4byte sStantlerAnims_1_2
+.4byte sStantlerAnims_1_3
+.4byte sStantlerAnims_1_4
+.4byte sStantlerAnims_1_5
+.4byte sStantlerAnims_1_6
+.4byte sStantlerAnims_1_7
+.4byte sStantlerAnims_1_8
+sStantlerAnimTable2:
+.4byte sStantlerAnims_2_1
+.4byte sStantlerAnims_2_2
+.4byte sStantlerAnims_2_3
+.4byte sStantlerAnims_2_4
+.4byte sStantlerAnims_2_5
+.4byte sStantlerAnims_2_6
+.4byte sStantlerAnims_2_7
+.4byte sStantlerAnims_2_8
+sStantlerAnimTable3:
+.4byte sStantlerAnims_3_1
+.4byte sStantlerAnims_3_2
+.4byte sStantlerAnims_3_3
+.4byte sStantlerAnims_3_4
+.4byte sStantlerAnims_3_5
+.4byte sStantlerAnims_3_6
+.4byte sStantlerAnims_3_7
+.4byte sStantlerAnims_3_8
+sStantlerAnimTable4:
+.4byte sStantlerAnims_4_1
+.4byte sStantlerAnims_4_2
+.4byte sStantlerAnims_4_3
+.4byte sStantlerAnims_4_4
+.4byte sStantlerAnims_4_5
+.4byte sStantlerAnims_4_6
+.4byte sStantlerAnims_4_7
+.4byte sStantlerAnims_4_8
+sStantlerAnimTable5:
+.4byte sStantlerAnims_5_1
+.4byte sStantlerAnims_5_2
+.4byte sStantlerAnims_5_3
+.4byte sStantlerAnims_5_4
+.4byte sStantlerAnims_5_5
+.4byte sStantlerAnims_5_6
+.4byte sStantlerAnims_5_7
+.4byte sStantlerAnims_5_8
+sStantlerAnimTable6:
+.4byte sStantlerAnims_6_1
+.4byte sStantlerAnims_6_1
+.4byte sStantlerAnims_6_1
+.4byte sStantlerAnims_6_1
+.4byte sStantlerAnims_6_1
+.4byte sStantlerAnims_6_1
+.4byte sStantlerAnims_6_1
+.4byte sStantlerAnims_6_1
+sStantlerAnimTable7:
+.4byte sStantlerAnims_7_1
+.4byte sStantlerAnims_7_2
+.4byte sStantlerAnims_7_3
+.4byte sStantlerAnims_7_4
+.4byte sStantlerAnims_7_5
+.4byte sStantlerAnims_7_6
+.4byte sStantlerAnims_7_7
+.4byte sStantlerAnims_7_8
+sStantlerAnimTable8:
+.4byte sStantlerAnims_8_1
+.4byte sStantlerAnims_8_2
+.4byte sStantlerAnims_8_3
+.4byte sStantlerAnims_8_4
+.4byte sStantlerAnims_8_5
+.4byte sStantlerAnims_8_6
+.4byte sStantlerAnims_8_7
+.4byte sStantlerAnims_8_8
+sStantlerAnimTable9:
+.4byte sStantlerAnims_9_1
+.4byte sStantlerAnims_9_2
+.4byte sStantlerAnims_9_3
+.4byte sStantlerAnims_9_4
+.4byte sStantlerAnims_9_5
+.4byte sStantlerAnims_9_6
+.4byte sStantlerAnims_9_7
+.4byte sStantlerAnims_9_8
+sStantlerAnimTable10:
+.4byte sStantlerAnims_10_1
+.4byte sStantlerAnims_10_2
+.4byte sStantlerAnims_10_3
+.4byte sStantlerAnims_10_4
+.4byte sStantlerAnims_10_5
+.4byte sStantlerAnims_10_6
+.4byte sStantlerAnims_10_7
+.4byte sStantlerAnims_10_8
+sStantlerAnimTable11:
+.4byte sStantlerAnims_11_1
+.4byte sStantlerAnims_11_2
+.4byte sStantlerAnims_11_3
+.4byte sStantlerAnims_11_4
+.4byte sStantlerAnims_11_5
+.4byte sStantlerAnims_11_6
+.4byte sStantlerAnims_11_7
+.4byte sStantlerAnims_11_8
+sStantlerAnimTable12:
+.4byte sStantlerAnims_12_1
+.4byte sStantlerAnims_12_2
+.4byte sStantlerAnims_12_3
+.4byte sStantlerAnims_12_4
+.4byte sStantlerAnims_12_5
+.4byte sStantlerAnims_12_6
+.4byte sStantlerAnims_12_7
+.4byte sStantlerAnims_12_8
+sStantlerAnimTable13:
+.4byte sStantlerAnims_13_1
+.4byte sStantlerAnims_13_2
+.4byte sStantlerAnims_13_3
+.4byte sStantlerAnims_13_4
+.4byte sStantlerAnims_13_5
+.4byte sStantlerAnims_13_6
+.4byte sStantlerAnims_13_7
+.4byte sStantlerAnims_13_8
+sAxAnimationsStantler:
+.4byte sStantlerAnimTable1
+.4byte sStantlerAnimTable2
+.4byte sStantlerAnimTable3
+.4byte sStantlerAnimTable4
+.4byte sStantlerAnimTable5
+.4byte sStantlerAnimTable6
+.4byte sStantlerAnimTable7
+.4byte sStantlerAnimTable8
+.4byte sStantlerAnimTable9
+.4byte sStantlerAnimTable10
+.4byte sStantlerAnimTable11
+.4byte sStantlerAnimTable12
+.4byte sStantlerAnimTable13
+sAxSpritesStantler:
+.4byte sStantlerSprites1
+.4byte sStantlerSprites2
+.4byte sStantlerSprites3
+.4byte sStantlerSprites4
+.4byte sStantlerSprites5
+.4byte sStantlerSprites6
+.4byte sStantlerSprites7
+.4byte sStantlerSprites8
+.4byte sStantlerSprites9
+.4byte sStantlerSprites10
+.4byte sStantlerSprites11
+.4byte sStantlerSprites12
+.4byte sStantlerSprites13
+.4byte sStantlerSprites14
+.4byte sStantlerSprites15
+.4byte sStantlerSprites16
+.4byte sStantlerSprites17
+.4byte sStantlerSprites18
+.4byte sStantlerSprites19
+.4byte sStantlerSprites20
+.4byte sStantlerSprites21
+.4byte sStantlerSprites22
+.4byte sStantlerSprites23
+.4byte sStantlerSprites24
+.4byte sStantlerSprites25
+.4byte sStantlerSprites26
+.4byte sStantlerSprites27
+.4byte sStantlerSprites28
+.4byte sStantlerSprites29
+.4byte sStantlerSprites30
+.4byte sStantlerSprites31
+.4byte sStantlerSprites32
+.4byte sStantlerSprites33
+.4byte sStantlerSprites34
+.4byte sStantlerSprites35
+.4byte sStantlerSprites36
+.4byte sStantlerSprites37
+.4byte sStantlerSprites38
+.4byte sStantlerSprites39
+.4byte sStantlerSprites40
+.4byte sStantlerSprites41
+.4byte sStantlerSprites42
+.4byte sStantlerSprites43
+.4byte sStantlerSprites44
+.4byte sStantlerSprites45
+.4byte sStantlerSprites46
+.4byte sStantlerSprites47
+.4byte sStantlerSprites48
+.4byte sStantlerSprites49
+.4byte sStantlerSprites50
+.4byte sStantlerSprites51
+.4byte sStantlerSprites52
+.4byte sStantlerSprites53
+.4byte sStantlerSprites54
+sAxMainStantler:
+ax_main sAxPosesStantler, sAxAnimationsStantler, 13, sAxSpritesStantler, sAxPositionsStantler

--- a/data/ax/starmie.inc
+++ b/data/ax/starmie.inc
@@ -1,0 +1,2564 @@
+.global gAxStarmie
+gAxStarmie:
+ax_siro sAxMainStarmie
+sStarmiePose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose4:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose5:
+ax_pose 4, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose6:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose7:
+ax_pose 6, 0x81eb, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose8:
+ax_pose 7, 0x81eb, 0x90f8, 0x2c00
+ax_pose_terminator
+sStarmiePose9:
+ax_pose 8, 0x81ec, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sStarmiePose11:
+ax_pose 10, 0x01eb, 0x90ee, 0x2c00
+ax_pose_terminator
+sStarmiePose12:
+ax_pose 11, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose13:
+ax_pose 12, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose14:
+ax_pose 13, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose15:
+ax_pose 14, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose19:
+ax_pose 6, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose20:
+ax_pose 7, 0x81eb, 0x80f9, 0x2c00
+ax_pose_terminator
+sStarmiePose21:
+ax_pose 8, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose26:
+ax_pose 15, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose27:
+ax_pose 16, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose28:
+ax_pose 17, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose29:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose30:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sStarmiePose31:
+ax_pose 19, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sStarmiePose32:
+ax_pose 6, 0x81eb, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose33:
+ax_pose 20, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sStarmiePose34:
+ax_pose 9, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sStarmiePose35:
+ax_pose 21, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sStarmiePose36:
+ax_pose 12, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose37:
+ax_pose 22, 0x41ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sStarmiePose38:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose39:
+ax_pose 21, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sStarmiePose40:
+ax_pose 6, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose41:
+ax_pose 20, 0x01e9, 0x80f5, 0x2c00
+ax_pose_terminator
+sStarmiePose42:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose43:
+ax_pose 18, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose44:
+ax_pose 0, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose45:
+ax_pose 15, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose46:
+ax_pose 16, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose47:
+ax_pose 17, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose48:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose49:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sStarmiePose50:
+ax_pose 19, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sStarmiePose51:
+ax_pose 6, 0x81eb, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose52:
+ax_pose 20, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sStarmiePose53:
+ax_pose 9, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sStarmiePose54:
+ax_pose 21, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sStarmiePose55:
+ax_pose 12, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose56:
+ax_pose 22, 0x41ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sStarmiePose57:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose58:
+ax_pose 21, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sStarmiePose59:
+ax_pose 6, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose60:
+ax_pose 20, 0x01e9, 0x80f5, 0x2c00
+ax_pose_terminator
+sStarmiePose61:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose62:
+ax_pose 18, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose63:
+ax_pose 0, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose64:
+ax_pose 1, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose65:
+ax_pose 2, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose66:
+ax_pose 23, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose67:
+ax_pose 24, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose68:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose69:
+ax_pose 4, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose70:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose71:
+ax_pose 19, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sStarmiePose72:
+ax_pose 25, 0x01ea, 0x90f0, 0x2c00
+ax_pose_terminator
+sStarmiePose73:
+ax_pose 6, 0x81eb, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose74:
+ax_pose 7, 0x81eb, 0x90f8, 0x2c00
+ax_pose_terminator
+sStarmiePose75:
+ax_pose 8, 0x81ec, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose76:
+ax_pose 26, 0x81e9, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose77:
+ax_pose 27, 0x81e9, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose78:
+ax_pose 9, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sStarmiePose79:
+ax_pose 10, 0x01eb, 0x90ee, 0x2c00
+ax_pose_terminator
+sStarmiePose80:
+ax_pose 11, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose81:
+ax_pose 28, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose82:
+ax_pose 29, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose83:
+ax_pose 12, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose84:
+ax_pose 13, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose85:
+ax_pose 14, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose86:
+ax_pose 30, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose87:
+ax_pose 31, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose88:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose89:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose90:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose91:
+ax_pose 28, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose92:
+ax_pose 29, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose93:
+ax_pose 6, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose94:
+ax_pose 7, 0x81eb, 0x80f9, 0x2c00
+ax_pose_terminator
+sStarmiePose95:
+ax_pose 8, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose96:
+ax_pose 26, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose97:
+ax_pose 27, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose98:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose99:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose100:
+ax_pose 5, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose101:
+ax_pose 19, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sStarmiePose102:
+ax_pose 25, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sStarmiePose103:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose104:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose105:
+ax_pose 6, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose106:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose107:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose108:
+ax_pose 9, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose109:
+ax_pose 6, 0x81ed, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose110:
+ax_pose 3, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose111:
+ax_pose 32, 0x01f1, 0x80f5, 0x2c00
+ax_pose_terminator
+sStarmiePose112:
+ax_pose 33, 0x01f1, 0x80f5, 0x2c00
+ax_pose_terminator
+sStarmiePose113:
+ax_pose 34, 0x01e4, 0x80f3, 0x2c00
+ax_pose_terminator
+sStarmiePose114:
+ax_pose 35, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sStarmiePose115:
+ax_pose 36, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sStarmiePose116:
+ax_pose 37, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose117:
+ax_pose 38, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sStarmiePose118:
+ax_pose 37, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sStarmiePose119:
+ax_pose 36, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose120:
+ax_pose 35, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sStarmiePose121:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose122:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose123:
+ax_pose 6, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose124:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose125:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose126:
+ax_pose 9, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose127:
+ax_pose 6, 0x81ed, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose128:
+ax_pose 3, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose129:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose130:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose131:
+ax_pose 6, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose132:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose133:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose134:
+ax_pose 9, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose135:
+ax_pose 6, 0x81ed, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose136:
+ax_pose 3, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose137:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose138:
+ax_pose 3, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose139:
+ax_pose 6, 0x81ed, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose140:
+ax_pose 9, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose141:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose142:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose143:
+ax_pose 6, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose144:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose145:
+ax_pose 0, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose146:
+ax_pose 15, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose147:
+ax_pose 3, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose148:
+ax_pose 18, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose149:
+ax_pose 6, 0x81eb, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose150:
+ax_pose 20, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sStarmiePose151:
+ax_pose 9, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sStarmiePose152:
+ax_pose 21, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sStarmiePose153:
+ax_pose 12, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose154:
+ax_pose 22, 0x41ef, 0x80f3, 0x2c00
+ax_pose_terminator
+sStarmiePose155:
+ax_pose 9, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose156:
+ax_pose 21, 0x01e9, 0x80f1, 0x2c00
+ax_pose_terminator
+sStarmiePose157:
+ax_pose 6, 0x81eb, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose158:
+ax_pose 20, 0x01e9, 0x80f5, 0x2c00
+ax_pose_terminator
+sStarmiePose159:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose160:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose161:
+ax_pose 23, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose162:
+ax_pose 19, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose163:
+ax_pose 26, 0x81e9, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose164:
+ax_pose 28, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose165:
+ax_pose 30, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sStarmiePose166:
+ax_pose 28, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sStarmiePose167:
+ax_pose 26, 0x81e9, 0x90f8, 0x2c00
+ax_pose_terminator
+sStarmiePose168:
+ax_pose 19, 0x01e9, 0x90ee, 0x2c00
+ax_pose_terminator
+sStarmiePose169:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose170:
+ax_pose 3, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose171:
+ax_pose 6, 0x81ed, 0x80f8, 0x2c00
+ax_pose_terminator
+sStarmiePose172:
+ax_pose 9, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose173:
+ax_pose 12, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sStarmiePose174:
+ax_pose 9, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+sStarmiePose175:
+ax_pose 6, 0x81ed, 0x90f9, 0x2c00
+ax_pose_terminator
+sStarmiePose176:
+ax_pose 3, 0x01ed, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sStarmieAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_2_1:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 4, 0, 26, 0, -5, 0, -5,
+ax_anim 2, 0, 27, 0, -5, 0, -5,
+ax_anim 2, 2, 26, 0, -5, 0, -5,
+ax_anim 1, 0, 27, 0, 2, 0, 2,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 1, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sStarmieAnims_2_2:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 4, 0, 26, -5, -5, -5, -5,
+ax_anim 2, 0, 27, -5, -5, -5, -5,
+ax_anim 2, 2, 26, -5, -5, -5, -5,
+ax_anim 1, 0, 27, 2, 2, 2, 2,
+ax_anim 1, 0, 26, 10, 10, 10, 10,
+ax_anim 1, 0, 27, 20, 19, 20, 19,
+ax_anim 2, 1, 26, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 20, 19, 20, 19,
+ax_anim 2, 0, 26, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 20, 19, 20, 19,
+ax_anim 2, 0, 26, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 12, 12, 12, 12,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sStarmieAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -3, 0, -3, 0,
+ax_anim 4, 0, 26, -5, 0, -5, 0,
+ax_anim 2, 0, 27, -5, 0, -5, 0,
+ax_anim 2, 2, 26, -5, 0, -5, 0,
+ax_anim 1, 0, 27, 2, 0, 2, 0,
+ax_anim 1, 0, 26, 10, 0, 10, 0,
+ax_anim 1, 0, 27, 20, 0, 20, 0,
+ax_anim 2, 1, 26, 20, 0, 20, 0,
+ax_anim 2, 0, 27, 20, 0, 20, 0,
+ax_anim 2, 0, 26, 20, 0, 20, 0,
+ax_anim 2, 0, 27, 20, 0, 20, 0,
+ax_anim 2, 0, 26, 20, 0, 20, 0,
+ax_anim 2, 0, 27, 12, 0, 12, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim_terminator
+sStarmieAnims_2_4:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, -3, 3, -3, 3,
+ax_anim 4, 0, 26, -5, 5, -5, 5,
+ax_anim 2, 0, 27, -5, 5, -5, 5,
+ax_anim 2, 2, 26, -5, 5, -5, 5,
+ax_anim 1, 0, 27, 2, -2, 2, -2,
+ax_anim 1, 0, 26, 10, -10, 10, -10,
+ax_anim 1, 0, 27, 20, -19, 20, -19,
+ax_anim 2, 1, 26, 20, -19, 20, -19,
+ax_anim 2, 0, 27, 20, -19, 20, -19,
+ax_anim 2, 0, 26, 20, -19, 20, -19,
+ax_anim 2, 0, 27, 20, -19, 20, -19,
+ax_anim 2, 0, 26, 20, -19, 20, -19,
+ax_anim 2, 0, 27, 12, -12, 12, -12,
+ax_anim 2, 0, 33, 4, -4, 4, -4,
+ax_anim_terminator
+sStarmieAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 3, 0, 3,
+ax_anim 4, 0, 26, 0, 5, 0, 5,
+ax_anim 2, 0, 27, 0, 5, 0, 5,
+ax_anim 2, 2, 26, 0, 5, 0, 5,
+ax_anim 1, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, -10, 0, -10,
+ax_anim 1, 0, 27, 0, -19, 0, -19,
+ax_anim 2, 1, 26, 0, -19, 0, -19,
+ax_anim 2, 0, 27, 0, -19, 0, -19,
+ax_anim 2, 0, 26, 0, -19, 0, -19,
+ax_anim 2, 0, 27, 0, -19, 0, -19,
+ax_anim 2, 0, 26, 0, -19, 0, -19,
+ax_anim 2, 0, 27, 0, -12, 0, -12,
+ax_anim 2, 0, 35, 0, -4, 0, -4,
+ax_anim_terminator
+sStarmieAnims_2_6:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 3, 3, 3, 3,
+ax_anim 4, 0, 26, 5, 5, 5, 5,
+ax_anim 2, 0, 27, 5, 5, 5, 5,
+ax_anim 2, 2, 26, 5, 5, 5, 5,
+ax_anim 1, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 26, -10, -10, -10, -10,
+ax_anim 1, 0, 27, -20, -19, -20, -19,
+ax_anim 2, 1, 26, -20, -19, -20, -19,
+ax_anim 2, 0, 27, -20, -19, -20, -19,
+ax_anim 2, 0, 26, -20, -19, -20, -19,
+ax_anim 2, 0, 27, -20, -19, -20, -19,
+ax_anim 2, 0, 26, -20, -19, -20, -19,
+ax_anim 2, 0, 27, -12, -12, -12, -12,
+ax_anim 2, 0, 37, -4, -4, -4, -4,
+ax_anim_terminator
+sStarmieAnims_2_7:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 3, 0, 3, 0,
+ax_anim 4, 0, 26, 5, 0, 5, 0,
+ax_anim 2, 0, 27, 5, 0, 5, 0,
+ax_anim 2, 2, 26, 5, 0, 5, 0,
+ax_anim 1, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 26, -10, 0, -10, 0,
+ax_anim 1, 0, 27, -20, 0, -20, 0,
+ax_anim 2, 1, 26, -20, 0, -20, 0,
+ax_anim 2, 0, 27, -20, 0, -20, 0,
+ax_anim 2, 0, 26, -20, 0, -20, 0,
+ax_anim 2, 0, 27, -20, 0, -20, 0,
+ax_anim 2, 0, 26, -20, 0, -20, 0,
+ax_anim 2, 0, 27, -12, 0, -12, 0,
+ax_anim 2, 0, 39, -4, 0, -4, 0,
+ax_anim_terminator
+sStarmieAnims_2_8:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 3, -3, 3, -3,
+ax_anim 4, 0, 26, 5, -5, 5, -5,
+ax_anim 2, 0, 27, 5, -5, 5, -5,
+ax_anim 2, 2, 26, 5, -5, 5, -5,
+ax_anim 1, 0, 27, -2, 2, -2, 2,
+ax_anim 1, 0, 26, -10, 10, -10, 10,
+ax_anim 1, 0, 27, -20, 19, -20, 19,
+ax_anim 2, 1, 26, -20, 19, -20, 19,
+ax_anim 2, 0, 27, -20, 19, -20, 19,
+ax_anim 2, 0, 26, -20, 19, -20, 19,
+ax_anim 2, 0, 27, -20, 19, -20, 19,
+ax_anim 2, 0, 26, -20, 19, -20, 19,
+ax_anim 2, 0, 27, -12, 12, -12, 12,
+ax_anim 2, 0, 41, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sStarmieAnims_3_1:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, -3, 0, -3,
+ax_anim 4, 0, 45, 0, -5, 0, -5,
+ax_anim 2, 0, 46, 0, -5, 0, -5,
+ax_anim 2, 2, 45, 0, -5, 0, -5,
+ax_anim 1, 0, 46, 0, 2, 0, 2,
+ax_anim 1, 0, 45, 0, 10, 0, 10,
+ax_anim 1, 0, 46, 0, 19, 0, 19,
+ax_anim 2, 1, 45, 0, 19, 0, 19,
+ax_anim 2, 0, 46, 0, 19, 0, 19,
+ax_anim 2, 0, 45, 0, 19, 0, 19,
+ax_anim 2, 0, 46, 0, 19, 0, 19,
+ax_anim 2, 0, 45, 0, 19, 0, 19,
+ax_anim 2, 0, 46, 0, 12, 0, 12,
+ax_anim 2, 0, 43, 0, 4, 0, 4,
+ax_anim_terminator
+sStarmieAnims_3_2:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, -3, -3, -3, -3,
+ax_anim 4, 0, 45, -5, -5, -5, -5,
+ax_anim 2, 0, 46, -5, -5, -5, -5,
+ax_anim 2, 2, 45, -5, -5, -5, -5,
+ax_anim 1, 0, 46, 2, 2, 2, 2,
+ax_anim 1, 0, 45, 10, 10, 10, 10,
+ax_anim 1, 0, 46, 20, 19, 20, 19,
+ax_anim 2, 1, 45, 20, 19, 20, 19,
+ax_anim 2, 0, 46, 20, 19, 20, 19,
+ax_anim 2, 0, 45, 20, 19, 20, 19,
+ax_anim 2, 0, 46, 20, 19, 20, 19,
+ax_anim 2, 0, 45, 20, 19, 20, 19,
+ax_anim 2, 0, 46, 12, 12, 12, 12,
+ax_anim 2, 0, 47, 4, 4, 4, 4,
+ax_anim_terminator
+sStarmieAnims_3_3:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -3, 0, -3, 0,
+ax_anim 4, 0, 45, -5, 0, -5, 0,
+ax_anim 2, 0, 46, -5, 0, -5, 0,
+ax_anim 2, 2, 45, -5, 0, -5, 0,
+ax_anim 1, 0, 46, 2, 0, 2, 0,
+ax_anim 1, 0, 45, 10, 0, 10, 0,
+ax_anim 1, 0, 46, 20, 0, 20, 0,
+ax_anim 2, 1, 45, 20, 0, 20, 0,
+ax_anim 2, 0, 46, 20, 0, 20, 0,
+ax_anim 2, 0, 45, 20, 0, 20, 0,
+ax_anim 2, 0, 46, 20, 0, 20, 0,
+ax_anim 2, 0, 45, 20, 0, 20, 0,
+ax_anim 2, 0, 46, 12, 0, 12, 0,
+ax_anim 2, 0, 50, 4, 0, 4, 0,
+ax_anim_terminator
+sStarmieAnims_3_4:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, -3, 3, -3, 3,
+ax_anim 4, 0, 45, -5, 5, -5, 5,
+ax_anim 2, 0, 46, -5, 5, -5, 5,
+ax_anim 2, 2, 45, -5, 5, -5, 5,
+ax_anim 1, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 10, -10, 10, -10,
+ax_anim 1, 0, 46, 20, -19, 20, -19,
+ax_anim 2, 1, 45, 20, -19, 20, -19,
+ax_anim 2, 0, 46, 20, -19, 20, -19,
+ax_anim 2, 0, 45, 20, -19, 20, -19,
+ax_anim 2, 0, 46, 20, -19, 20, -19,
+ax_anim 2, 0, 45, 20, -19, 20, -19,
+ax_anim 2, 0, 46, 12, -12, 12, -12,
+ax_anim 2, 0, 52, 4, -4, 4, -4,
+ax_anim_terminator
+sStarmieAnims_3_5:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 3, 0, 3,
+ax_anim 4, 0, 45, 0, 5, 0, 5,
+ax_anim 2, 0, 46, 0, 5, 0, 5,
+ax_anim 2, 2, 45, 0, 5, 0, 5,
+ax_anim 1, 0, 46, 0, -2, 0, -2,
+ax_anim 1, 0, 45, 0, -10, 0, -10,
+ax_anim 1, 0, 46, 0, -19, 0, -19,
+ax_anim 2, 1, 45, 0, -19, 0, -19,
+ax_anim 2, 0, 46, 0, -19, 0, -19,
+ax_anim 2, 0, 45, 0, -19, 0, -19,
+ax_anim 2, 0, 46, 0, -19, 0, -19,
+ax_anim 2, 0, 45, 0, -19, 0, -19,
+ax_anim 2, 0, 46, 0, -12, 0, -12,
+ax_anim 2, 0, 54, 0, -4, 0, -4,
+ax_anim_terminator
+sStarmieAnims_3_6:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 3, 3, 3, 3,
+ax_anim 4, 0, 45, 5, 5, 5, 5,
+ax_anim 2, 0, 46, 5, 5, 5, 5,
+ax_anim 2, 2, 45, 5, 5, 5, 5,
+ax_anim 1, 0, 46, -2, -2, -2, -2,
+ax_anim 1, 0, 45, -10, -10, -10, -10,
+ax_anim 1, 0, 46, -20, -19, -20, -19,
+ax_anim 2, 1, 45, -20, -19, -20, -19,
+ax_anim 2, 0, 46, -20, -19, -20, -19,
+ax_anim 2, 0, 45, -20, -19, -20, -19,
+ax_anim 2, 0, 46, -20, -19, -20, -19,
+ax_anim 2, 0, 45, -20, -19, -20, -19,
+ax_anim 2, 0, 46, -12, -12, -12, -12,
+ax_anim 2, 0, 56, -4, -4, -4, -4,
+ax_anim_terminator
+sStarmieAnims_3_7:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 3, 0, 3, 0,
+ax_anim 4, 0, 45, 5, 0, 5, 0,
+ax_anim 2, 0, 46, 5, 0, 5, 0,
+ax_anim 2, 2, 45, 5, 0, 5, 0,
+ax_anim 1, 0, 46, -2, 0, -2, 0,
+ax_anim 1, 0, 45, -10, 0, -10, 0,
+ax_anim 1, 0, 46, -20, 0, -20, 0,
+ax_anim 2, 1, 45, -20, 0, -20, 0,
+ax_anim 2, 0, 46, -20, 0, -20, 0,
+ax_anim 2, 0, 45, -20, 0, -20, 0,
+ax_anim 2, 0, 46, -20, 0, -20, 0,
+ax_anim 2, 0, 45, -20, 0, -20, 0,
+ax_anim 2, 0, 46, -12, 0, -12, 0,
+ax_anim 2, 0, 58, -4, 0, -4, 0,
+ax_anim_terminator
+sStarmieAnims_3_8:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 3, -3, 3, -3,
+ax_anim 4, 0, 45, 5, -5, 5, -5,
+ax_anim 2, 0, 46, 5, -5, 5, -5,
+ax_anim 2, 2, 45, 5, -5, 5, -5,
+ax_anim 1, 0, 46, -2, 2, -2, 2,
+ax_anim 1, 0, 45, -10, 10, -10, 10,
+ax_anim 1, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 1, 45, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -12, 12, -12, 12,
+ax_anim 2, 0, 60, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sStarmieAnims_4_1:
+ax_anim 2, 0, 63, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim 6, 2, 62, 0, -3, 0, -3,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 1, 66, 0, 3, 0, 3,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 0, 66, 0, 3, 0, 3,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 0, 66, 0, 3, 0, 3,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim_terminator
+sStarmieAnims_4_2:
+ax_anim 2, 0, 68, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -3, -3, -3, -3,
+ax_anim 6, 2, 67, -3, -3, -3, -3,
+ax_anim 1, 0, 70, -1, -1, -1, -1,
+ax_anim 2, 0, 70, 3, 3, 3, 3,
+ax_anim 2, 1, 71, 3, 3, 3, 3,
+ax_anim 2, 0, 70, 3, 3, 3, 3,
+ax_anim 2, 0, 71, 3, 3, 3, 3,
+ax_anim 2, 0, 70, 3, 3, 3, 3,
+ax_anim 2, 0, 71, 3, 3, 3, 3,
+ax_anim 2, 0, 70, 3, 3, 3, 3,
+ax_anim 2, 0, 67, 1, 1, 1, 1,
+ax_anim_terminator
+sStarmieAnims_4_3:
+ax_anim 2, 0, 73, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -4, 0, -4, 0,
+ax_anim 6, 2, 72, -5, 0, -5, 0,
+ax_anim 1, 0, 75, -1, 0, -1, 0,
+ax_anim 2, 0, 75, 3, 0, 3, 0,
+ax_anim 2, 1, 76, 3, 0, 3, 0,
+ax_anim 2, 0, 75, 3, 0, 3, 0,
+ax_anim 2, 0, 76, 3, 0, 3, 0,
+ax_anim 2, 0, 75, 3, 0, 3, 0,
+ax_anim 2, 0, 76, 3, 0, 3, 0,
+ax_anim 2, 0, 75, 3, 0, 3, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim_terminator
+sStarmieAnims_4_4:
+ax_anim 2, 0, 78, -2, 2, -2, 2,
+ax_anim 2, 0, 79, -3, 3, -3, 3,
+ax_anim 6, 2, 77, -3, 3, -3, 3,
+ax_anim 1, 0, 80, -1, 1, -1, 1,
+ax_anim 2, 0, 80, 3, -3, 3, -3,
+ax_anim 2, 1, 81, 3, -3, 3, -3,
+ax_anim 2, 0, 80, 3, -3, 3, -3,
+ax_anim 2, 0, 81, 3, -3, 3, -3,
+ax_anim 2, 0, 80, 3, -3, 3, -3,
+ax_anim 2, 0, 81, 3, -3, 3, -3,
+ax_anim 2, 0, 80, 3, -3, 3, -3,
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim_terminator
+sStarmieAnims_4_5:
+ax_anim 2, 0, 83, 0, 2, 0, 2,
+ax_anim 2, 0, 84, 0, 3, 0, 3,
+ax_anim 6, 2, 82, 0, 3, 0, 3,
+ax_anim 1, 0, 85, 0, 1, 0, 1,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 85, 0, -3, 0, -3,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim_terminator
+sStarmieAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 3, 3, 3, 3,
+ax_anim 6, 2, 87, 3, 3, 3, 3,
+ax_anim 1, 0, 90, 1, 1, 1, 1,
+ax_anim 2, 0, 90, -3, -3, -3, -3,
+ax_anim 2, 1, 91, -3, -3, -3, -3,
+ax_anim 2, 0, 90, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -3, -3, -3, -3,
+ax_anim 2, 0, 90, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -3, -3, -3, -3,
+ax_anim 2, 0, 90, -3, -3, -3, -3,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sStarmieAnims_4_7:
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim 6, 2, 92, 5, 0, 5, 0,
+ax_anim 1, 0, 95, 1, 0, 1, 0,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 1, 96, -3, 0, -3, 0,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 96, -3, 0, -3, 0,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 96, -3, 0, -3, 0,
+ax_anim 2, 0, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -1, 0, -1, 0,
+ax_anim_terminator
+sStarmieAnims_4_8:
+ax_anim 2, 0, 98, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 6, 2, 97, 3, -3, 3, -3,
+ax_anim 1, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 100, -3, 3, -3, 3,
+ax_anim 2, 1, 101, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -3, 3, -3, 3,
+ax_anim 2, 0, 101, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -3, 3, -3, 3,
+ax_anim 2, 0, 101, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sStarmieAnims_5_1:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_5_2:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_5_3:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_5_4:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_5_5:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_5_6:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_5_7:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_5_8:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_6_1:
+ax_anim 30, 0, 110, 0, 0, 0, 0,
+ax_anim 35, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_7_1:
+ax_anim 2, 0, 112, 0, -4, 0, -4,
+ax_anim 8, 0, 112, 0, -5, 0, -5,
+ax_anim_terminator
+sStarmieAnims_7_2:
+ax_anim 2, 0, 113, -4, -4, -4, -4,
+ax_anim 8, 0, 113, -5, -5, -5, -5,
+ax_anim_terminator
+sStarmieAnims_7_3:
+ax_anim 2, 0, 114, -4, 0, -4, 0,
+ax_anim 8, 0, 114, -5, 0, -5, 0,
+ax_anim_terminator
+sStarmieAnims_7_4:
+ax_anim 2, 0, 115, -4, 4, -4, 4,
+ax_anim 8, 0, 115, -5, 5, -5, 5,
+ax_anim_terminator
+sStarmieAnims_7_5:
+ax_anim 2, 0, 116, 0, 4, 0, 4,
+ax_anim 8, 0, 116, 0, 5, 0, 5,
+ax_anim_terminator
+sStarmieAnims_7_6:
+ax_anim 2, 0, 117, 4, 4, 4, 4,
+ax_anim 8, 0, 117, 5, 5, 5, 5,
+ax_anim_terminator
+sStarmieAnims_7_7:
+ax_anim 2, 0, 118, 4, 0, 4, 0,
+ax_anim 8, 0, 118, 5, 0, 5, 0,
+ax_anim_terminator
+sStarmieAnims_7_8:
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 8, 0, 119, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sStarmieAnims_8_1:
+ax_anim 60, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_8_2:
+ax_anim 60, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_8_3:
+ax_anim 60, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_8_4:
+ax_anim 60, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_8_5:
+ax_anim 60, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_8_6:
+ax_anim 60, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_8_7:
+ax_anim 60, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_8_8:
+ax_anim 60, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_9_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 6, 3, 6, 3,
+ax_anim 2, 0, 130, 8, 9, 8, 9,
+ax_anim 2, 0, 131, 7, 17, 7, 17,
+ax_anim 3, 0, 132, 0, 20, 0, 20,
+ax_anim 2, 3, 133, -7, 17, -7, 17,
+ax_anim 2, 0, 134, -8, 9, -8, 9,
+ax_anim 1, 0, 135, -6, 3, -6, 3,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_9_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 8, 0, 8, 0,
+ax_anim 2, 0, 129, 17, 3, 17, 3,
+ax_anim 2, 0, 130, 20, 11, 20, 11,
+ax_anim 3, 0, 131, 21, 19, 21, 19,
+ax_anim 2, 3, 132, 11, 21, 11, 21,
+ax_anim 2, 0, 133, 3, 15, 3, 15,
+ax_anim 1, 0, 134, 0, 7, 0, 7,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_9_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 3, -5, 3, -5,
+ax_anim 2, 0, 128, 11, -6, 11, -6,
+ax_anim 2, 0, 129, 19, -5, 19, -5,
+ax_anim 3, 0, 130, 22, -2, 22, -2,
+ax_anim 2, 3, 131, 20, 4, 20, 4,
+ax_anim 2, 0, 132, 12, 7, 12, 7,
+ax_anim 1, 0, 133, 4, 5, 4, 5,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_9_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, -1, -8, -1, -8,
+ax_anim 2, 0, 135, 4, -16, 4, -16,
+ax_anim 2, 0, 128, 12, -21, 12, -21,
+ax_anim 3, 0, 129, 20, -20, 20, -20,
+ax_anim 2, 3, 130, 20, -13, 20, -13,
+ax_anim 2, 0, 131, 17, -4, 17, -4,
+ax_anim 1, 0, 132, 7, -1, 7, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_9_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, -8, -4, -8, -4,
+ax_anim 2, 0, 134, -9, -12, -9, -12,
+ax_anim 2, 0, 135, -7, -18, -7, -18,
+ax_anim 3, 0, 128, 0, -21, 0, -21,
+ax_anim 2, 3, 129, 7, -18, 7, -18,
+ax_anim 2, 0, 130, 9, -10, 9, -10,
+ax_anim 1, 0, 131, 8, -4, 8, -4,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_9_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 1, -8, 1, -8,
+ax_anim 2, 0, 129, -4, -16, -4, -16,
+ax_anim 2, 0, 128, -12, -21, -12, -21,
+ax_anim 3, 0, 135, -20, -20, -20, -20,
+ax_anim 2, 3, 134, -20, -13, -20, -13,
+ax_anim 2, 0, 133, -17, -4, -17, -4,
+ax_anim 1, 0, 132, -7, -1, -7, -1,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_9_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 129, -3, -5, -3, -5,
+ax_anim 2, 0, 128, -11, -6, -11, -6,
+ax_anim 2, 0, 135, -19, -5, -19, -5,
+ax_anim 3, 0, 134, -22, -2, -22, -2,
+ax_anim 2, 3, 133, -20, 4, -20, 4,
+ax_anim 2, 0, 132, -12, 7, -12, 7,
+ax_anim 1, 0, 131, -4, 5, -4, 5,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_9_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 128, -8, 0, -8, 0,
+ax_anim 2, 0, 135, -17, 3, -17, 3,
+ax_anim 2, 0, 134, -20, 11, -20, 11,
+ax_anim 3, 0, 133, -21, 19, -21, 19,
+ax_anim 2, 3, 132, -11, 21, -11, 21,
+ax_anim 2, 0, 131, -3, 15, -3, 15,
+ax_anim 1, 0, 130, 0, 7, 0, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_10_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 6, 0, 6, 0,
+ax_anim 2, 0, 136, -6, 0, -6, 0,
+ax_anim 2, 0, 136, 10, 0, 10, 0,
+ax_anim 2, 0, 136, -10, 0, -10, 0,
+ax_anim 2, 0, 136, 12, 0, 12, 0,
+ax_anim 3, 0, 136, -12, 0, -12, 0,
+ax_anim 3, 0, 136, 13, 0, 13, 0,
+ax_anim 3, 0, 136, -13, 0, -13, 0,
+ax_anim 2, 0, 136, 12, 0, 12, 0,
+ax_anim 3, 0, 136, -12, 0, -12, 0,
+ax_anim 2, 0, 136, 10, 0, 10, 0,
+ax_anim 2, 0, 136, -10, 0, -10, 0,
+ax_anim 2, 0, 136, 6, 0, 6, 0,
+ax_anim 2, 0, 136, -6, 0, -6, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_10_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 6, -6, 6, -6,
+ax_anim 2, 0, 137, -6, 6, -6, 6,
+ax_anim 2, 0, 137, 10, -10, 10, -10,
+ax_anim 2, 0, 137, -10, 10, -10, 10,
+ax_anim 2, 0, 137, 12, -12, 12, -12,
+ax_anim 3, 0, 137, -12, 12, -12, 12,
+ax_anim 3, 0, 137, 13, -13, 13, -13,
+ax_anim 3, 0, 137, -13, 13, -13, 13,
+ax_anim 2, 0, 137, 12, -12, 12, -12,
+ax_anim 3, 0, 137, -12, 12, -12, 12,
+ax_anim 2, 0, 137, 10, -10, 10, -10,
+ax_anim 2, 0, 137, -10, 10, -10, 10,
+ax_anim 2, 0, 137, 6, -6, 6, -6,
+ax_anim 2, 0, 137, -6, 6, -6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_10_3:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -6, 0, -6,
+ax_anim 2, 0, 138, 0, 6, 0, 6,
+ax_anim 2, 0, 138, 0, -10, 0, -10,
+ax_anim 2, 0, 138, 0, 10, 0, 10,
+ax_anim 2, 0, 138, 0, -12, 0, -12,
+ax_anim 3, 0, 138, 0, 12, 0, 12,
+ax_anim 3, 0, 138, 0, -13, 0, -13,
+ax_anim 3, 0, 138, 0, 13, 0, 13,
+ax_anim 2, 0, 138, 0, -12, 0, -12,
+ax_anim 3, 0, 138, 0, 12, 0, 12,
+ax_anim 2, 0, 138, 0, -10, 0, -10,
+ax_anim 2, 0, 138, 0, 10, 0, 10,
+ax_anim 2, 0, 138, 0, -6, 0, -6,
+ax_anim 2, 0, 138, 0, 6, 0, 6,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_10_4:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -6, -6, -6, -6,
+ax_anim 2, 0, 139, 6, 6, 6, 6,
+ax_anim 2, 0, 139, -10, -10, -10, -10,
+ax_anim 2, 0, 139, 10, 10, 10, 10,
+ax_anim 2, 0, 139, -12, -12, -12, -12,
+ax_anim 3, 0, 139, 12, 12, 12, 12,
+ax_anim 3, 0, 139, -13, -13, -13, -13,
+ax_anim 3, 0, 139, 13, 13, 13, 13,
+ax_anim 2, 0, 139, -12, -12, -12, -12,
+ax_anim 3, 0, 139, 12, 12, 12, 12,
+ax_anim 2, 0, 139, -10, -10, -10, -10,
+ax_anim 2, 0, 139, 10, 10, 10, 10,
+ax_anim 2, 0, 139, -6, -6, -6, -6,
+ax_anim 2, 0, 139, 6, 6, 6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_10_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 6, 0, 6, 0,
+ax_anim 2, 0, 140, -6, 0, -6, 0,
+ax_anim 2, 0, 140, 10, 0, 10, 0,
+ax_anim 2, 0, 140, -10, 0, -10, 0,
+ax_anim 2, 0, 140, 12, 0, 12, 0,
+ax_anim 3, 0, 140, -12, 0, -12, 0,
+ax_anim 3, 0, 140, 13, 0, 13, 0,
+ax_anim 3, 0, 140, -13, 0, -13, 0,
+ax_anim 2, 0, 140, 12, 0, 12, 0,
+ax_anim 3, 0, 140, -12, 0, -12, 0,
+ax_anim 2, 0, 140, 10, 0, 10, 0,
+ax_anim 2, 0, 140, -10, 0, -10, 0,
+ax_anim 2, 0, 140, 6, 0, 6, 0,
+ax_anim 2, 0, 140, -6, 0, -6, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_10_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 6, -6, 6, -6,
+ax_anim 2, 0, 141, -6, 6, -6, 6,
+ax_anim 2, 0, 141, 10, -10, 10, -10,
+ax_anim 2, 0, 141, -10, 10, -10, 10,
+ax_anim 2, 0, 141, 12, -12, 12, -12,
+ax_anim 3, 0, 141, -12, 12, -12, 12,
+ax_anim 3, 0, 141, 13, -13, 13, -13,
+ax_anim 3, 0, 141, -13, 13, -13, 13,
+ax_anim 2, 0, 141, 12, -12, 12, -12,
+ax_anim 3, 0, 141, -12, 12, -12, 12,
+ax_anim 2, 0, 141, 10, -10, 10, -10,
+ax_anim 2, 0, 141, -10, 10, -10, 10,
+ax_anim 2, 0, 141, 6, -6, 6, -6,
+ax_anim 2, 0, 141, -6, 6, -6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_10_7:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, -6,
+ax_anim 2, 0, 142, 0, 6, 0, 6,
+ax_anim 2, 0, 142, 0, -10, 0, -10,
+ax_anim 2, 0, 142, 0, 10, 0, 10,
+ax_anim 2, 0, 142, 0, -12, 0, -12,
+ax_anim 3, 0, 142, 0, 12, 0, 12,
+ax_anim 3, 0, 142, 0, -13, 0, -13,
+ax_anim 3, 0, 142, 0, 13, 0, 13,
+ax_anim 2, 0, 142, 0, -12, 0, -12,
+ax_anim 3, 0, 142, 0, 12, 0, 12,
+ax_anim 2, 0, 142, 0, -10, 0, -10,
+ax_anim 2, 0, 142, 0, 10, 0, 10,
+ax_anim 2, 0, 142, 0, -6, 0, -6,
+ax_anim 2, 0, 142, 0, 6, 0, 6,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_10_8:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, -6, -6, -6, -6,
+ax_anim 2, 0, 143, 6, 6, 6, 6,
+ax_anim 2, 0, 143, -10, -10, -10, -10,
+ax_anim 2, 0, 143, 10, 10, 10, 10,
+ax_anim 2, 0, 143, -12, -12, -12, -12,
+ax_anim 3, 0, 143, 12, 12, 12, 12,
+ax_anim 3, 0, 143, -13, -13, -13, -13,
+ax_anim 3, 0, 143, 13, 13, 13, 13,
+ax_anim 2, 0, 143, -12, -12, -12, -12,
+ax_anim 3, 0, 143, 12, 12, 12, 12,
+ax_anim 2, 0, 143, -10, -10, -10, -10,
+ax_anim 2, 0, 143, 10, 10, 10, 10,
+ax_anim 2, 0, 143, -6, -6, -6, -6,
+ax_anim 2, 0, 143, 6, 6, 6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_11_1:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -23, 0, 0,
+ax_anim 3, 0, 144, 0, -22, 0, 0,
+ax_anim 2, 0, 144, 0, -18, 0, 0,
+ax_anim 1, 0, 144, 0, -12, 0, 0,
+ax_anim 2, 2, 144, 0, 2, 0, 0,
+ax_anim_terminator
+sStarmieAnims_11_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -23, 0, 0,
+ax_anim 3, 0, 146, 0, -22, 0, 0,
+ax_anim 2, 0, 146, 0, -18, 0, 0,
+ax_anim 1, 0, 146, 0, -12, 0, 0,
+ax_anim 2, 2, 146, 0, 2, 0, 0,
+ax_anim_terminator
+sStarmieAnims_11_3:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -23, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 2, 0, 0,
+ax_anim_terminator
+sStarmieAnims_11_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -22, 0, 0,
+ax_anim 3, 0, 150, 0, -21, 0, 0,
+ax_anim 2, 0, 150, 0, -17, 0, 0,
+ax_anim 1, 0, 150, 0, -11, 0, 0,
+ax_anim 2, 2, 150, 0, 2, 0, 0,
+ax_anim_terminator
+sStarmieAnims_11_5:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -23, 0, 0,
+ax_anim 3, 0, 152, 0, -22, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 2, 0, 0,
+ax_anim_terminator
+sStarmieAnims_11_6:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 154, 0, -22, 0, 0,
+ax_anim 3, 0, 154, 0, -21, 0, 0,
+ax_anim 2, 0, 154, 0, -17, 0, 0,
+ax_anim 1, 0, 154, 0, -11, 0, 0,
+ax_anim 2, 2, 154, 0, 2, 0, 0,
+ax_anim_terminator
+sStarmieAnims_11_7:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 2, 0, 0,
+ax_anim_terminator
+sStarmieAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 158, 0, -23, 0, 0,
+ax_anim 3, 0, 158, 0, -22, 0, 0,
+ax_anim 2, 0, 158, 0, -18, 0, 0,
+ax_anim 1, 0, 158, 0, -12, 0, 0,
+ax_anim 2, 2, 158, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_12_1:
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_12_2:
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 1, -1, 1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_12_3:
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, -1, 0, -1,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_12_4:
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -1, -1, -1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_12_5:
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 1, 0, 1, 0,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_12_6:
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_12_7:
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_12_8:
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 1, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStarmieAnims_13_1:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_13_2:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_13_3:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_13_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_13_5:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_13_6:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_13_7:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieAnims_13_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sStarmieGfx1:
+.incbin "baserom.gba", 0xA33978, 0x200
+sStarmieSprites1:
+ax_sprite sStarmieGfx1, 0x200
+ax_sprite_terminator
+sStarmieGfx2:
+.incbin "baserom.gba", 0xA33B88, 0x200
+sStarmieSprites2:
+ax_sprite sStarmieGfx2, 0x200
+ax_sprite_terminator
+sStarmieGfx3:
+.incbin "baserom.gba", 0xA33D98, 0x200
+sStarmieSprites3:
+ax_sprite sStarmieGfx3, 0x200
+ax_sprite_terminator
+sStarmieGfx4:
+.incbin "baserom.gba", 0xA33FA8, 0x200
+sStarmieSprites4:
+ax_sprite sStarmieGfx4, 0x200
+ax_sprite_terminator
+sStarmieGfx5:
+.incbin "baserom.gba", 0xA341B8, 0x200
+sStarmieSprites5:
+ax_sprite sStarmieGfx5, 0x200
+ax_sprite_terminator
+sStarmieGfx6:
+.incbin "baserom.gba", 0xA343C8, 0x200
+sStarmieSprites6:
+ax_sprite sStarmieGfx6, 0x200
+ax_sprite_terminator
+sStarmieGfx7:
+.incbin "baserom.gba", 0xA345D8, 0x100
+sStarmieSprites7:
+ax_sprite sStarmieGfx7, 0x100
+ax_sprite_terminator
+sStarmieGfx8:
+.incbin "baserom.gba", 0xA346E8, 0x100
+sStarmieSprites8:
+ax_sprite sStarmieGfx8, 0x100
+ax_sprite_terminator
+sStarmieGfx9:
+.incbin "baserom.gba", 0xA347F8, 0x100
+sStarmieSprites9:
+ax_sprite sStarmieGfx9, 0x100
+ax_sprite_terminator
+sStarmieGfx10:
+.incbin "baserom.gba", 0xA34908, 0x200
+sStarmieSprites10:
+ax_sprite sStarmieGfx10, 0x200
+ax_sprite_terminator
+sStarmieGfx11:
+.incbin "baserom.gba", 0xA34B18, 0x200
+sStarmieSprites11:
+ax_sprite sStarmieGfx11, 0x200
+ax_sprite_terminator
+sStarmieGfx12:
+.incbin "baserom.gba", 0xA34D28, 0x200
+sStarmieSprites12:
+ax_sprite sStarmieGfx12, 0x200
+ax_sprite_terminator
+sStarmieGfx13:
+.incbin "baserom.gba", 0xA34F38, 0x200
+sStarmieSprites13:
+ax_sprite sStarmieGfx13, 0x200
+ax_sprite_terminator
+sStarmieGfx14:
+.incbin "baserom.gba", 0xA35148, 0x200
+sStarmieSprites14:
+ax_sprite sStarmieGfx14, 0x200
+ax_sprite_terminator
+sStarmieGfx15:
+.incbin "baserom.gba", 0xA35358, 0x200
+sStarmieSprites15:
+ax_sprite sStarmieGfx15, 0x200
+ax_sprite_terminator
+sStarmieGfx16:
+.incbin "baserom.gba", 0xA35568, 0x60
+sStarmieGfx16_1:
+.incbin "baserom.gba", 0xA355C8, 0x60
+sStarmieGfx16_2:
+.incbin "baserom.gba", 0xA35628, 0x60
+sStarmieSprites16:
+ax_sprite sStarmieGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStarmieGfx17:
+.incbin "baserom.gba", 0xA356C0, 0x60
+sStarmieGfx17_1:
+.incbin "baserom.gba", 0xA35720, 0x60
+sStarmieGfx17_2:
+.incbin "baserom.gba", 0xA35780, 0x60
+sStarmieSprites17:
+ax_sprite sStarmieGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStarmieGfx18:
+.incbin "baserom.gba", 0xA35818, 0x60
+sStarmieGfx18_1:
+.incbin "baserom.gba", 0xA35878, 0x60
+sStarmieGfx18_2:
+.incbin "baserom.gba", 0xA358D8, 0x60
+sStarmieGfx18_3:
+.incbin "baserom.gba", 0xA35938, 0x20
+sStarmieSprites18:
+ax_sprite sStarmieGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStarmieGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStarmieGfx19:
+.incbin "baserom.gba", 0xA359A0, 0x40
+sStarmieGfx19_1:
+.incbin "baserom.gba", 0xA359E0, 0xE0
+sStarmieSprites19:
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx19_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStarmieGfx20:
+.incbin "baserom.gba", 0xA35AF0, 0x60
+sStarmieGfx20_1:
+.incbin "baserom.gba", 0xA35B50, 0x100
+sStarmieSprites20:
+ax_sprite sStarmieGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sStarmieGfx21:
+.incbin "baserom.gba", 0xA35C78, 0x40
+sStarmieGfx21_1:
+.incbin "baserom.gba", 0xA35CB8, 0x60
+sStarmieGfx21_2:
+.incbin "baserom.gba", 0xA35D18, 0x40
+sStarmieGfx21_3:
+.incbin "baserom.gba", 0xA35D58, 0x20
+sStarmieSprites21:
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx21_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sStarmieGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStarmieGfx22:
+.incbin "baserom.gba", 0xA35DC8, 0x40
+sStarmieGfx22_1:
+.incbin "baserom.gba", 0xA35E08, 0x60
+sStarmieGfx22_2:
+.incbin "baserom.gba", 0xA35E68, 0x60
+sStarmieSprites22:
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStarmieGfx23:
+.incbin "baserom.gba", 0xA35F08, 0x60
+sStarmieGfx23_1:
+.incbin "baserom.gba", 0xA35F68, 0x60
+sStarmieSprites23:
+ax_sprite sStarmieGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStarmieGfx24:
+.incbin "baserom.gba", 0xA35FF0, 0x60
+sStarmieGfx24_1:
+.incbin "baserom.gba", 0xA36050, 0x60
+sStarmieGfx24_2:
+.incbin "baserom.gba", 0xA360B0, 0x60
+sStarmieSprites24:
+ax_sprite sStarmieGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStarmieGfx25:
+.incbin "baserom.gba", 0xA36148, 0x60
+sStarmieGfx25_1:
+.incbin "baserom.gba", 0xA361A8, 0x60
+sStarmieGfx25_2:
+.incbin "baserom.gba", 0xA36208, 0x60
+sStarmieSprites25:
+ax_sprite sStarmieGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStarmieGfx26:
+.incbin "baserom.gba", 0xA362A0, 0x60
+sStarmieGfx26_1:
+.incbin "baserom.gba", 0xA36300, 0xE0
+sStarmieSprites26:
+ax_sprite sStarmieGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx26_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStarmieGfx27:
+.incbin "baserom.gba", 0xA36408, 0xC0
+sStarmieGfx27_1:
+.incbin "baserom.gba", 0xA364C8, 0x20
+sStarmieSprites27:
+ax_sprite sStarmieGfx27, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx27_1, 0x20
+ax_sprite_terminator
+sStarmieGfx28:
+.incbin "baserom.gba", 0xA36508, 0xC0
+sStarmieGfx28_1:
+.incbin "baserom.gba", 0xA365C8, 0x20
+sStarmieSprites28:
+ax_sprite sStarmieGfx28, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx28_1, 0x20
+ax_sprite_terminator
+sStarmieGfx29:
+.incbin "baserom.gba", 0xA36608, 0x40
+sStarmieGfx29_1:
+.incbin "baserom.gba", 0xA36648, 0x60
+sStarmieGfx29_2:
+.incbin "baserom.gba", 0xA366A8, 0x60
+sStarmieGfx29_3:
+.incbin "baserom.gba", 0xA36708, 0x20
+sStarmieSprites29:
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStarmieGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStarmieGfx30:
+.incbin "baserom.gba", 0xA36778, 0x40
+sStarmieGfx30_1:
+.incbin "baserom.gba", 0xA367B8, 0x60
+sStarmieGfx30_2:
+.incbin "baserom.gba", 0xA36818, 0x60
+sStarmieGfx30_3:
+.incbin "baserom.gba", 0xA36878, 0x20
+sStarmieSprites30:
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStarmieGfx30_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStarmieGfx31:
+.incbin "baserom.gba", 0xA368E8, 0x40
+sStarmieGfx31_1:
+.incbin "baserom.gba", 0xA36928, 0xE0
+sStarmieGfx31_2:
+.incbin "baserom.gba", 0xA36A08, 0x20
+sStarmieSprites31:
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx31_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sStarmieGfx31_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStarmieGfx32:
+.incbin "baserom.gba", 0xA36A68, 0x40
+sStarmieGfx32_1:
+.incbin "baserom.gba", 0xA36AA8, 0x100
+sStarmieGfx32_2:
+.incbin "baserom.gba", 0xA36BA8, 0x20
+sStarmieSprites32:
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStarmieGfx32_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sStarmieGfx32_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStarmieGfx33:
+.incbin "baserom.gba", 0xA36C08, 0x200
+sStarmieSprites33:
+ax_sprite sStarmieGfx33, 0x200
+ax_sprite_terminator
+sStarmieGfx34:
+.incbin "baserom.gba", 0xA36E18, 0x200
+sStarmieSprites34:
+ax_sprite sStarmieGfx34, 0x200
+ax_sprite_terminator
+sStarmieGfx35:
+.incbin "baserom.gba", 0xA37028, 0x200
+sStarmieSprites35:
+ax_sprite sStarmieGfx35, 0x200
+ax_sprite_terminator
+sStarmieGfx36:
+.incbin "baserom.gba", 0xA37238, 0x200
+sStarmieSprites36:
+ax_sprite sStarmieGfx36, 0x200
+ax_sprite_terminator
+sStarmieGfx37:
+.incbin "baserom.gba", 0xA37448, 0x200
+sStarmieSprites37:
+ax_sprite sStarmieGfx37, 0x200
+ax_sprite_terminator
+sStarmieGfx38:
+.incbin "baserom.gba", 0xA37658, 0x200
+sStarmieSprites38:
+ax_sprite sStarmieGfx38, 0x200
+ax_sprite_terminator
+sStarmieGfx39:
+.incbin "baserom.gba", 0xA37868, 0x200
+sStarmieSprites39:
+ax_sprite sStarmieGfx39, 0x200
+ax_sprite_terminator
+sAxPosesStarmie:
+.4byte sStarmiePose1
+.4byte sStarmiePose2
+.4byte sStarmiePose3
+.4byte sStarmiePose4
+.4byte sStarmiePose5
+.4byte sStarmiePose6
+.4byte sStarmiePose7
+.4byte sStarmiePose8
+.4byte sStarmiePose9
+.4byte sStarmiePose10
+.4byte sStarmiePose11
+.4byte sStarmiePose12
+.4byte sStarmiePose13
+.4byte sStarmiePose14
+.4byte sStarmiePose15
+.4byte sStarmiePose16
+.4byte sStarmiePose17
+.4byte sStarmiePose18
+.4byte sStarmiePose19
+.4byte sStarmiePose20
+.4byte sStarmiePose21
+.4byte sStarmiePose22
+.4byte sStarmiePose23
+.4byte sStarmiePose24
+.4byte sStarmiePose25
+.4byte sStarmiePose26
+.4byte sStarmiePose27
+.4byte sStarmiePose28
+.4byte sStarmiePose29
+.4byte sStarmiePose30
+.4byte sStarmiePose31
+.4byte sStarmiePose32
+.4byte sStarmiePose33
+.4byte sStarmiePose34
+.4byte sStarmiePose35
+.4byte sStarmiePose36
+.4byte sStarmiePose37
+.4byte sStarmiePose38
+.4byte sStarmiePose39
+.4byte sStarmiePose40
+.4byte sStarmiePose41
+.4byte sStarmiePose42
+.4byte sStarmiePose43
+.4byte sStarmiePose44
+.4byte sStarmiePose45
+.4byte sStarmiePose46
+.4byte sStarmiePose47
+.4byte sStarmiePose48
+.4byte sStarmiePose49
+.4byte sStarmiePose50
+.4byte sStarmiePose51
+.4byte sStarmiePose52
+.4byte sStarmiePose53
+.4byte sStarmiePose54
+.4byte sStarmiePose55
+.4byte sStarmiePose56
+.4byte sStarmiePose57
+.4byte sStarmiePose58
+.4byte sStarmiePose59
+.4byte sStarmiePose60
+.4byte sStarmiePose61
+.4byte sStarmiePose62
+.4byte sStarmiePose63
+.4byte sStarmiePose64
+.4byte sStarmiePose65
+.4byte sStarmiePose66
+.4byte sStarmiePose67
+.4byte sStarmiePose68
+.4byte sStarmiePose69
+.4byte sStarmiePose70
+.4byte sStarmiePose71
+.4byte sStarmiePose72
+.4byte sStarmiePose73
+.4byte sStarmiePose74
+.4byte sStarmiePose75
+.4byte sStarmiePose76
+.4byte sStarmiePose77
+.4byte sStarmiePose78
+.4byte sStarmiePose79
+.4byte sStarmiePose80
+.4byte sStarmiePose81
+.4byte sStarmiePose82
+.4byte sStarmiePose83
+.4byte sStarmiePose84
+.4byte sStarmiePose85
+.4byte sStarmiePose86
+.4byte sStarmiePose87
+.4byte sStarmiePose88
+.4byte sStarmiePose89
+.4byte sStarmiePose90
+.4byte sStarmiePose91
+.4byte sStarmiePose92
+.4byte sStarmiePose93
+.4byte sStarmiePose94
+.4byte sStarmiePose95
+.4byte sStarmiePose96
+.4byte sStarmiePose97
+.4byte sStarmiePose98
+.4byte sStarmiePose99
+.4byte sStarmiePose100
+.4byte sStarmiePose101
+.4byte sStarmiePose102
+.4byte sStarmiePose103
+.4byte sStarmiePose104
+.4byte sStarmiePose105
+.4byte sStarmiePose106
+.4byte sStarmiePose107
+.4byte sStarmiePose108
+.4byte sStarmiePose109
+.4byte sStarmiePose110
+.4byte sStarmiePose111
+.4byte sStarmiePose112
+.4byte sStarmiePose113
+.4byte sStarmiePose114
+.4byte sStarmiePose115
+.4byte sStarmiePose116
+.4byte sStarmiePose117
+.4byte sStarmiePose118
+.4byte sStarmiePose119
+.4byte sStarmiePose120
+.4byte sStarmiePose121
+.4byte sStarmiePose122
+.4byte sStarmiePose123
+.4byte sStarmiePose124
+.4byte sStarmiePose125
+.4byte sStarmiePose126
+.4byte sStarmiePose127
+.4byte sStarmiePose128
+.4byte sStarmiePose129
+.4byte sStarmiePose130
+.4byte sStarmiePose131
+.4byte sStarmiePose132
+.4byte sStarmiePose133
+.4byte sStarmiePose134
+.4byte sStarmiePose135
+.4byte sStarmiePose136
+.4byte sStarmiePose137
+.4byte sStarmiePose138
+.4byte sStarmiePose139
+.4byte sStarmiePose140
+.4byte sStarmiePose141
+.4byte sStarmiePose142
+.4byte sStarmiePose143
+.4byte sStarmiePose144
+.4byte sStarmiePose145
+.4byte sStarmiePose146
+.4byte sStarmiePose147
+.4byte sStarmiePose148
+.4byte sStarmiePose149
+.4byte sStarmiePose150
+.4byte sStarmiePose151
+.4byte sStarmiePose152
+.4byte sStarmiePose153
+.4byte sStarmiePose154
+.4byte sStarmiePose155
+.4byte sStarmiePose156
+.4byte sStarmiePose157
+.4byte sStarmiePose158
+.4byte sStarmiePose159
+.4byte sStarmiePose160
+.4byte sStarmiePose161
+.4byte sStarmiePose162
+.4byte sStarmiePose163
+.4byte sStarmiePose164
+.4byte sStarmiePose165
+.4byte sStarmiePose166
+.4byte sStarmiePose167
+.4byte sStarmiePose168
+.4byte sStarmiePose169
+.4byte sStarmiePose170
+.4byte sStarmiePose171
+.4byte sStarmiePose172
+.4byte sStarmiePose173
+.4byte sStarmiePose174
+.4byte sStarmiePose175
+.4byte sStarmiePose176
+sAxPositionsStarmie:
+.2byte    0,   -7, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    1,   -6, 	  -7,  -12, 	   7,  -10, 	   0,   -9
+.2byte   -1,   -6, 	  -7,  -10, 	   6,  -12, 	   1,   -9
+.2byte    3,   -8, 	   6,  -15, 	  -7,  -10, 	   0,  -10
+.2byte    2,   -7, 	   7,  -13, 	  -7,   -9, 	   0,   -9
+.2byte    4,   -7, 	   6,  -12, 	  -5,  -10, 	   0,   -9
+.2byte    5,   -8, 	   2,  -15, 	  -2,   -9, 	   0,   -9
+.2byte    5,   -7, 	   5,  -15, 	  -3,   -7, 	   0,   -8
+.2byte    4,  -10, 	   2,  -12, 	   1,  -11, 	  -1,   -7
+.2byte   -1,  -12, 	  -7,  -14, 	   5,  -10, 	  -3,  -10
+.2byte    4,  -10, 	  -4,  -13, 	   7,   -7, 	   0,   -9
+.2byte   -3,  -12, 	  -8,  -14, 	   7,   -9, 	  -2,   -9
+.2byte    0,  -12, 	   8,  -13, 	  -8,  -13, 	   0,  -10
+.2byte   -2,  -11, 	   5,  -14, 	  -8,  -10, 	   1,  -10
+.2byte    2,  -11, 	   8,  -10, 	  -5,  -14, 	  -1,   -9
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -10, 	   1,  -10
+.2byte   -3,  -10, 	   5,  -13, 	  -6,   -7, 	   1,   -9
+.2byte    3,  -12, 	   8,  -14, 	  -7,   -9, 	   2,   -9
+.2byte   -5,   -8, 	  -2,  -15, 	   2,   -9, 	   0,   -9
+.2byte   -5,   -7, 	  -5,  -15, 	   3,   -7, 	   0,   -8
+.2byte   -4,  -11, 	  -2,  -13, 	  -1,  -12, 	   1,   -8
+.2byte   -3,   -8, 	  -6,  -15, 	   7,  -10, 	   0,  -10
+.2byte   -2,   -7, 	  -7,  -13, 	   7,   -9, 	   0,   -9
+.2byte   -4,   -7, 	  -6,  -12, 	   5,  -10, 	   0,   -9
+.2byte    0,   -7, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    0,   -9, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -9
+.2byte    0,  -10, 	  -6,  -15, 	   8,   -6, 	   0,   -9
+.2byte    3,   -8, 	   6,  -15, 	  -7,  -10, 	   0,  -10
+.2byte    2,  -10, 	   5,  -15, 	  -7,   -7, 	   2,   -9
+.2byte    4,   -7, 	   8,  -15, 	  -7,  -10, 	   2,   -9
+.2byte    5,   -8, 	   2,  -15, 	  -2,   -9, 	   0,   -9
+.2byte    4,  -13, 	   0,  -17, 	  -1,   -7, 	   1,  -11
+.2byte   -1,  -12, 	  -7,  -14, 	   5,  -10, 	  -3,  -10
+.2byte    4,  -13, 	  -6,  -15, 	   6,   -6, 	   0,  -10
+.2byte    0,  -12, 	   8,  -13, 	  -8,  -13, 	   0,  -10
+.2byte    0,  -16, 	   8,  -12, 	  -9,  -12, 	   0,  -12
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -10, 	   1,  -10
+.2byte   -6,  -13, 	   4,  -15, 	  -8,   -6, 	  -2,  -10
+.2byte   -5,   -8, 	  -2,  -15, 	   2,   -9, 	   0,   -9
+.2byte   -4,  -13, 	   0,  -17, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -6,  -15, 	   7,  -10, 	   0,  -10
+.2byte   -2,  -10, 	  -5,  -15, 	   7,   -7, 	  -2,   -9
+.2byte    0,   -7, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    0,   -9, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -9
+.2byte    0,  -10, 	  -6,  -15, 	   8,   -6, 	   0,   -9
+.2byte    3,   -8, 	   6,  -15, 	  -7,  -10, 	   0,  -10
+.2byte    2,  -10, 	   5,  -15, 	  -7,   -7, 	   2,   -9
+.2byte    4,   -7, 	   8,  -15, 	  -7,  -10, 	   2,   -9
+.2byte    5,   -8, 	   2,  -15, 	  -2,   -9, 	   0,   -9
+.2byte    4,  -13, 	   0,  -17, 	  -1,   -7, 	   1,  -11
+.2byte   -1,  -12, 	  -7,  -14, 	   5,  -10, 	  -3,  -10
+.2byte    4,  -13, 	  -6,  -15, 	   6,   -6, 	   0,  -10
+.2byte    0,  -12, 	   8,  -13, 	  -8,  -13, 	   0,  -10
+.2byte    0,  -16, 	   8,  -12, 	  -9,  -12, 	   0,  -12
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -10, 	   1,  -10
+.2byte   -6,  -13, 	   4,  -15, 	  -8,   -6, 	  -2,  -10
+.2byte   -5,   -8, 	  -2,  -15, 	   2,   -9, 	   0,   -9
+.2byte   -4,  -13, 	   0,  -17, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -6,  -15, 	   7,  -10, 	   0,  -10
+.2byte   -2,  -10, 	  -5,  -15, 	   7,   -7, 	  -2,   -9
+.2byte    0,   -7, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    1,   -6, 	  -7,  -12, 	   7,  -10, 	   0,   -9
+.2byte   -1,   -6, 	  -7,  -10, 	   6,  -12, 	   1,   -9
+.2byte    0,   -7, 	  -9,  -14, 	   9,  -14, 	   0,   -9
+.2byte    0,   -7, 	  -9,  -14, 	   9,  -14, 	   0,   -9
+.2byte    3,   -8, 	   6,  -15, 	  -7,  -10, 	   0,  -10
+.2byte    2,   -7, 	   7,  -13, 	  -7,   -9, 	   0,   -9
+.2byte    4,   -7, 	   6,  -12, 	  -5,  -10, 	   0,   -9
+.2byte    4,   -7, 	   8,  -15, 	  -7,  -10, 	   2,   -9
+.2byte    4,   -7, 	   8,  -16, 	  -7,  -10, 	   1,   -8
+.2byte    5,   -8, 	   2,  -15, 	  -2,   -9, 	   0,   -9
+.2byte    5,   -7, 	   5,  -15, 	  -3,   -7, 	   0,   -8
+.2byte    4,  -10, 	   2,  -12, 	   1,  -11, 	  -1,   -7
+.2byte    6,   -8, 	  -3,  -16, 	  -2,   -8, 	   2,   -9
+.2byte    6,   -8, 	  -2,  -18, 	  -2,   -8, 	   2,   -9
+.2byte   -1,  -12, 	  -7,  -14, 	   5,  -10, 	  -3,  -10
+.2byte    4,  -10, 	  -4,  -13, 	   7,   -7, 	   0,   -9
+.2byte   -3,  -12, 	  -8,  -14, 	   7,   -9, 	  -2,   -9
+.2byte   -1,   -9, 	  -8,  -14, 	   5,  -10, 	  -2,  -10
+.2byte   -1,  -11, 	  -8,  -14, 	   5,   -9, 	  -2,  -10
+.2byte    0,  -12, 	   8,  -13, 	  -8,  -13, 	   0,  -10
+.2byte   -2,  -11, 	   5,  -14, 	  -8,  -10, 	   1,  -10
+.2byte    2,  -11, 	   8,  -10, 	  -5,  -14, 	  -1,   -9
+.2byte   -1,  -10, 	   8,  -12, 	  -8,  -12, 	   1,  -11
+.2byte    3,  -10, 	   8,  -11, 	  -7,  -13, 	  -1,  -11
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -10, 	   1,  -10
+.2byte   -3,  -10, 	   5,  -13, 	  -6,   -7, 	   1,   -9
+.2byte    3,  -12, 	   8,  -14, 	  -7,   -9, 	   2,   -9
+.2byte   -1,   -9, 	   6,  -14, 	  -7,  -10, 	   0,  -10
+.2byte   -1,  -11, 	   6,  -14, 	  -7,   -9, 	   0,  -10
+.2byte   -5,   -8, 	  -2,  -15, 	   2,   -9, 	   0,   -9
+.2byte   -5,   -7, 	  -5,  -15, 	   3,   -7, 	   0,   -8
+.2byte   -4,  -11, 	  -2,  -13, 	  -1,  -12, 	   1,   -8
+.2byte   -6,   -8, 	   3,  -16, 	   2,   -8, 	  -2,   -9
+.2byte   -6,   -8, 	   2,  -18, 	   2,   -8, 	  -2,   -9
+.2byte   -3,   -8, 	  -6,  -15, 	   7,  -10, 	   0,  -10
+.2byte   -2,   -7, 	  -7,  -13, 	   7,   -9, 	   0,   -9
+.2byte   -4,   -7, 	  -6,  -12, 	   5,  -10, 	   0,   -9
+.2byte   -4,   -7, 	  -8,  -15, 	   7,  -10, 	  -2,   -9
+.2byte   -4,   -7, 	  -8,  -16, 	   7,  -10, 	  -1,   -8
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte   -3,   -6, 	  -6,  -13, 	   7,   -8, 	   0,   -8
+.2byte   -5,   -6, 	  -2,  -13, 	   2,   -7, 	   0,   -7
+.2byte   -1,  -10, 	   5,  -12, 	  -7,   -8, 	   1,   -8
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -12, 	   7,   -8, 	  -1,   -8
+.2byte    5,   -6, 	   2,  -13, 	  -2,   -7, 	   0,   -7
+.2byte    3,   -6, 	   6,  -13, 	  -7,   -8, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -9, 	   8,   -3, 	   0,   -4
+.2byte    0,   -5, 	  -3,   -9, 	   9,   -2, 	   0,   -3
+.2byte   -1,   -9, 	  -8,   -9, 	   7,   -8, 	  -1,  -10
+.2byte    3,   -7, 	   5,  -14, 	  -6,   -8, 	  -1,   -9
+.2byte    3,  -12, 	   0,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte    2,  -13, 	  -2,  -18, 	   4,   -6, 	  -1,   -9
+.2byte    0,  -14, 	   7,  -10, 	  -8,  -10, 	   0,   -9
+.2byte   -3,  -13, 	   1,  -18, 	  -5,   -6, 	   0,   -9
+.2byte   -4,  -12, 	  -1,  -17, 	   3,   -7, 	   0,  -10
+.2byte   -4,   -7, 	  -6,  -14, 	   5,   -8, 	   0,   -9
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte   -3,   -6, 	  -6,  -13, 	   7,   -8, 	   0,   -8
+.2byte   -5,   -6, 	  -2,  -13, 	   2,   -7, 	   0,   -7
+.2byte   -1,  -10, 	   5,  -12, 	  -7,   -8, 	   1,   -8
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -12, 	   7,   -8, 	  -1,   -8
+.2byte    5,   -6, 	   2,  -13, 	  -2,   -7, 	   0,   -7
+.2byte    3,   -6, 	   6,  -13, 	  -7,   -8, 	   0,   -8
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte   -3,   -6, 	  -6,  -13, 	   7,   -8, 	   0,   -8
+.2byte   -5,   -6, 	  -2,  -13, 	   2,   -7, 	   0,   -7
+.2byte   -1,  -10, 	   5,  -12, 	  -7,   -8, 	   1,   -8
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -12, 	   7,   -8, 	  -1,   -8
+.2byte    5,   -6, 	   2,  -13, 	  -2,   -7, 	   0,   -7
+.2byte    3,   -6, 	   6,  -13, 	  -7,   -8, 	   0,   -8
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte    3,   -6, 	   6,  -13, 	  -7,   -8, 	   0,   -8
+.2byte    5,   -6, 	   2,  -13, 	  -2,   -7, 	   0,   -7
+.2byte    1,  -10, 	  -5,  -12, 	   7,   -8, 	  -1,   -8
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -8
+.2byte   -1,  -10, 	   5,  -12, 	  -7,   -8, 	   1,   -8
+.2byte   -5,   -6, 	  -2,  -13, 	   2,   -7, 	   0,   -7
+.2byte   -3,   -6, 	  -6,  -13, 	   7,   -8, 	   0,   -8
+.2byte    0,   -7, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    0,   -9, 	  -8,  -13, 	   8,  -13, 	   0,  -10
+.2byte    3,   -8, 	   6,  -15, 	  -7,  -10, 	   0,  -10
+.2byte    0,  -10, 	   3,  -15, 	  -9,   -7, 	   0,   -9
+.2byte    5,   -8, 	   2,  -15, 	  -2,   -9, 	   0,   -9
+.2byte    4,  -13, 	   0,  -17, 	  -1,   -7, 	   1,  -11
+.2byte   -1,  -12, 	  -7,  -14, 	   5,  -10, 	  -3,  -10
+.2byte    4,  -13, 	  -6,  -15, 	   6,   -6, 	   0,  -10
+.2byte    0,  -12, 	   8,  -13, 	  -8,  -13, 	   0,  -10
+.2byte    0,  -16, 	   8,  -12, 	  -9,  -12, 	   0,  -12
+.2byte   -1,  -12, 	   5,  -14, 	  -7,  -10, 	   1,  -10
+.2byte   -6,  -13, 	   4,  -15, 	  -8,   -6, 	  -2,  -10
+.2byte   -5,   -8, 	  -2,  -15, 	   2,   -9, 	   0,   -9
+.2byte   -4,  -13, 	   0,  -17, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -6,  -15, 	   7,  -10, 	   0,  -10
+.2byte    0,  -10, 	  -3,  -15, 	   9,   -7, 	   0,   -9
+.2byte    0,   -7, 	  -9,  -14, 	   9,  -14, 	   0,   -9
+.2byte   -3,   -8, 	  -7,  -16, 	   8,  -11, 	  -1,  -10
+.2byte   -6,   -8, 	   3,  -16, 	   2,   -8, 	  -2,   -9
+.2byte   -1,   -9, 	   6,  -14, 	  -7,  -10, 	   0,  -10
+.2byte   -1,  -10, 	   8,  -12, 	  -8,  -12, 	   1,  -11
+.2byte    1,   -9, 	  -6,  -14, 	   7,  -10, 	   0,  -10
+.2byte    5,   -8, 	  -4,  -16, 	  -3,   -8, 	   1,   -9
+.2byte    2,   -8, 	   6,  -16, 	  -9,  -11, 	   0,  -10
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte   -3,   -6, 	  -6,  -13, 	   7,   -8, 	   0,   -8
+.2byte   -5,   -6, 	  -2,  -13, 	   2,   -7, 	   0,   -7
+.2byte   -1,  -10, 	   5,  -12, 	  -7,   -8, 	   1,   -8
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -8
+.2byte    1,  -10, 	  -5,  -12, 	   7,   -8, 	  -1,   -8
+.2byte    5,   -6, 	   2,  -13, 	  -2,   -7, 	   0,   -7
+.2byte    3,   -6, 	   6,  -13, 	  -7,   -8, 	   0,   -8
+sStarmieAnimTable1:
+.4byte sStarmieAnims_1_1
+.4byte sStarmieAnims_1_2
+.4byte sStarmieAnims_1_3
+.4byte sStarmieAnims_1_4
+.4byte sStarmieAnims_1_5
+.4byte sStarmieAnims_1_6
+.4byte sStarmieAnims_1_7
+.4byte sStarmieAnims_1_8
+sStarmieAnimTable2:
+.4byte sStarmieAnims_2_1
+.4byte sStarmieAnims_2_2
+.4byte sStarmieAnims_2_3
+.4byte sStarmieAnims_2_4
+.4byte sStarmieAnims_2_5
+.4byte sStarmieAnims_2_6
+.4byte sStarmieAnims_2_7
+.4byte sStarmieAnims_2_8
+sStarmieAnimTable3:
+.4byte sStarmieAnims_3_1
+.4byte sStarmieAnims_3_2
+.4byte sStarmieAnims_3_3
+.4byte sStarmieAnims_3_4
+.4byte sStarmieAnims_3_5
+.4byte sStarmieAnims_3_6
+.4byte sStarmieAnims_3_7
+.4byte sStarmieAnims_3_8
+sStarmieAnimTable4:
+.4byte sStarmieAnims_4_1
+.4byte sStarmieAnims_4_2
+.4byte sStarmieAnims_4_3
+.4byte sStarmieAnims_4_4
+.4byte sStarmieAnims_4_5
+.4byte sStarmieAnims_4_6
+.4byte sStarmieAnims_4_7
+.4byte sStarmieAnims_4_8
+sStarmieAnimTable5:
+.4byte sStarmieAnims_5_1
+.4byte sStarmieAnims_5_2
+.4byte sStarmieAnims_5_3
+.4byte sStarmieAnims_5_4
+.4byte sStarmieAnims_5_5
+.4byte sStarmieAnims_5_6
+.4byte sStarmieAnims_5_7
+.4byte sStarmieAnims_5_8
+sStarmieAnimTable6:
+.4byte sStarmieAnims_6_1
+.4byte sStarmieAnims_6_1
+.4byte sStarmieAnims_6_1
+.4byte sStarmieAnims_6_1
+.4byte sStarmieAnims_6_1
+.4byte sStarmieAnims_6_1
+.4byte sStarmieAnims_6_1
+.4byte sStarmieAnims_6_1
+sStarmieAnimTable7:
+.4byte sStarmieAnims_7_1
+.4byte sStarmieAnims_7_2
+.4byte sStarmieAnims_7_3
+.4byte sStarmieAnims_7_4
+.4byte sStarmieAnims_7_5
+.4byte sStarmieAnims_7_6
+.4byte sStarmieAnims_7_7
+.4byte sStarmieAnims_7_8
+sStarmieAnimTable8:
+.4byte sStarmieAnims_8_1
+.4byte sStarmieAnims_8_2
+.4byte sStarmieAnims_8_3
+.4byte sStarmieAnims_8_4
+.4byte sStarmieAnims_8_5
+.4byte sStarmieAnims_8_6
+.4byte sStarmieAnims_8_7
+.4byte sStarmieAnims_8_8
+sStarmieAnimTable9:
+.4byte sStarmieAnims_9_1
+.4byte sStarmieAnims_9_2
+.4byte sStarmieAnims_9_3
+.4byte sStarmieAnims_9_4
+.4byte sStarmieAnims_9_5
+.4byte sStarmieAnims_9_6
+.4byte sStarmieAnims_9_7
+.4byte sStarmieAnims_9_8
+sStarmieAnimTable10:
+.4byte sStarmieAnims_10_1
+.4byte sStarmieAnims_10_2
+.4byte sStarmieAnims_10_3
+.4byte sStarmieAnims_10_4
+.4byte sStarmieAnims_10_5
+.4byte sStarmieAnims_10_6
+.4byte sStarmieAnims_10_7
+.4byte sStarmieAnims_10_8
+sStarmieAnimTable11:
+.4byte sStarmieAnims_11_1
+.4byte sStarmieAnims_11_2
+.4byte sStarmieAnims_11_3
+.4byte sStarmieAnims_11_4
+.4byte sStarmieAnims_11_5
+.4byte sStarmieAnims_11_6
+.4byte sStarmieAnims_11_7
+.4byte sStarmieAnims_11_8
+sStarmieAnimTable12:
+.4byte sStarmieAnims_12_1
+.4byte sStarmieAnims_12_2
+.4byte sStarmieAnims_12_3
+.4byte sStarmieAnims_12_4
+.4byte sStarmieAnims_12_5
+.4byte sStarmieAnims_12_6
+.4byte sStarmieAnims_12_7
+.4byte sStarmieAnims_12_8
+sStarmieAnimTable13:
+.4byte sStarmieAnims_13_1
+.4byte sStarmieAnims_13_2
+.4byte sStarmieAnims_13_3
+.4byte sStarmieAnims_13_4
+.4byte sStarmieAnims_13_5
+.4byte sStarmieAnims_13_6
+.4byte sStarmieAnims_13_7
+.4byte sStarmieAnims_13_8
+sAxAnimationsStarmie:
+.4byte sStarmieAnimTable1
+.4byte sStarmieAnimTable2
+.4byte sStarmieAnimTable3
+.4byte sStarmieAnimTable4
+.4byte sStarmieAnimTable5
+.4byte sStarmieAnimTable6
+.4byte sStarmieAnimTable7
+.4byte sStarmieAnimTable8
+.4byte sStarmieAnimTable9
+.4byte sStarmieAnimTable10
+.4byte sStarmieAnimTable11
+.4byte sStarmieAnimTable12
+.4byte sStarmieAnimTable13
+sAxSpritesStarmie:
+.4byte sStarmieSprites1
+.4byte sStarmieSprites2
+.4byte sStarmieSprites3
+.4byte sStarmieSprites4
+.4byte sStarmieSprites5
+.4byte sStarmieSprites6
+.4byte sStarmieSprites7
+.4byte sStarmieSprites8
+.4byte sStarmieSprites9
+.4byte sStarmieSprites10
+.4byte sStarmieSprites11
+.4byte sStarmieSprites12
+.4byte sStarmieSprites13
+.4byte sStarmieSprites14
+.4byte sStarmieSprites15
+.4byte sStarmieSprites16
+.4byte sStarmieSprites17
+.4byte sStarmieSprites18
+.4byte sStarmieSprites19
+.4byte sStarmieSprites20
+.4byte sStarmieSprites21
+.4byte sStarmieSprites22
+.4byte sStarmieSprites23
+.4byte sStarmieSprites24
+.4byte sStarmieSprites25
+.4byte sStarmieSprites26
+.4byte sStarmieSprites27
+.4byte sStarmieSprites28
+.4byte sStarmieSprites29
+.4byte sStarmieSprites30
+.4byte sStarmieSprites31
+.4byte sStarmieSprites32
+.4byte sStarmieSprites33
+.4byte sStarmieSprites34
+.4byte sStarmieSprites35
+.4byte sStarmieSprites36
+.4byte sStarmieSprites37
+.4byte sStarmieSprites38
+.4byte sStarmieSprites39
+sAxMainStarmie:
+ax_main sAxPosesStarmie, sAxAnimationsStarmie, 13, sAxSpritesStarmie, sAxPositionsStarmie

--- a/data/ax/staryu.inc
+++ b/data/ax/staryu.inc
@@ -1,0 +1,2485 @@
+.global gAxStaryu
+gAxStaryu:
+ax_siro sAxMainStaryu
+sStaryuPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose4:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose5:
+ax_pose 4, 0x01ee, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose6:
+ax_pose 5, 0x01ee, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose7:
+ax_pose 6, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose8:
+ax_pose 7, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose9:
+ax_pose 8, 0x81ee, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose10:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose11:
+ax_pose 10, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose12:
+ax_pose 11, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sStaryuPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose16:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose17:
+ax_pose 16, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose18:
+ax_pose 17, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose19:
+ax_pose 6, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose20:
+ax_pose 7, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose21:
+ax_pose 8, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose22:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose23:
+ax_pose 4, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose24:
+ax_pose 5, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose26:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose27:
+ax_pose 19, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose28:
+ax_pose 20, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose29:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose30:
+ax_pose 21, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose31:
+ax_pose 6, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose32:
+ax_pose 22, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sStaryuPose33:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose34:
+ax_pose 23, 0x01f3, 0x40f7, 0x4c00
+ax_pose_terminator
+sStaryuPose35:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose36:
+ax_pose 24, 0x41f3, 0x80f3, 0x4c00
+ax_pose_terminator
+sStaryuPose37:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose38:
+ax_pose 25, 0x01f3, 0x40f9, 0x4c00
+ax_pose_terminator
+sStaryuPose39:
+ax_pose 6, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose40:
+ax_pose 22, 0x01ed, 0x80f6, 0x4c00
+ax_pose_terminator
+sStaryuPose41:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose42:
+ax_pose 21, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose43:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose44:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose45:
+ax_pose 19, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose46:
+ax_pose 20, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose47:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose48:
+ax_pose 21, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose49:
+ax_pose 6, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose50:
+ax_pose 22, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sStaryuPose51:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose52:
+ax_pose 23, 0x01f3, 0x40f7, 0x4c00
+ax_pose_terminator
+sStaryuPose53:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose54:
+ax_pose 24, 0x41f3, 0x80f3, 0x4c00
+ax_pose_terminator
+sStaryuPose55:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose56:
+ax_pose 25, 0x01f3, 0x40f9, 0x4c00
+ax_pose_terminator
+sStaryuPose57:
+ax_pose 6, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose58:
+ax_pose 22, 0x01ed, 0x80f6, 0x4c00
+ax_pose_terminator
+sStaryuPose59:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose60:
+ax_pose 21, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose61:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose62:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose63:
+ax_pose 2, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose64:
+ax_pose 26, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose65:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose66:
+ax_pose 4, 0x01ee, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose67:
+ax_pose 5, 0x01ee, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose68:
+ax_pose 27, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose69:
+ax_pose 6, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose70:
+ax_pose 7, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose71:
+ax_pose 8, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose72:
+ax_pose 28, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose73:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose74:
+ax_pose 10, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose75:
+ax_pose 11, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sStaryuPose76:
+ax_pose 29, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sStaryuPose77:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose78:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose79:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose80:
+ax_pose 30, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose81:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose82:
+ax_pose 16, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose83:
+ax_pose 17, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose84:
+ax_pose 31, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose85:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose86:
+ax_pose 7, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose87:
+ax_pose 8, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose88:
+ax_pose 28, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose89:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose90:
+ax_pose 4, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose91:
+ax_pose 5, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose92:
+ax_pose 27, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose93:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose94:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose95:
+ax_pose 6, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose96:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose97:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose98:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose99:
+ax_pose 6, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose100:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose101:
+ax_pose 32, 0x01f1, 0x80f5, 0x4c00
+ax_pose_terminator
+sStaryuPose102:
+ax_pose 33, 0x01f1, 0x80f5, 0x4c00
+ax_pose_terminator
+sStaryuPose103:
+ax_pose 34, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sStaryuPose104:
+ax_pose 35, 0x01e4, 0x80ec, 0x4c00
+ax_pose_terminator
+sStaryuPose105:
+ax_pose 36, 0x01e2, 0x90eb, 0x4c00
+ax_pose_terminator
+sStaryuPose106:
+ax_pose 37, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sStaryuPose107:
+ax_pose 38, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sStaryuPose108:
+ax_pose 39, 0x01e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose109:
+ax_pose 36, 0x01e3, 0x80f5, 0x4c00
+ax_pose_terminator
+sStaryuPose110:
+ax_pose 40, 0x01e4, 0x80f5, 0x4c00
+ax_pose_terminator
+sStaryuPose111:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose112:
+ax_pose 26, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose113:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose114:
+ax_pose 27, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose115:
+ax_pose 6, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose116:
+ax_pose 28, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose117:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose118:
+ax_pose 29, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sStaryuPose119:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose120:
+ax_pose 30, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose121:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose122:
+ax_pose 31, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose123:
+ax_pose 6, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose124:
+ax_pose 28, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose125:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose126:
+ax_pose 27, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose127:
+ax_pose 26, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose128:
+ax_pose 27, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose129:
+ax_pose 28, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose130:
+ax_pose 31, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose131:
+ax_pose 30, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose132:
+ax_pose 29, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose133:
+ax_pose 28, 0x81ec, 0x90f8, 0x4c00
+ax_pose_terminator
+sStaryuPose134:
+ax_pose 27, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sStaryuPose135:
+ax_pose 26, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose136:
+ax_pose 27, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sStaryuPose137:
+ax_pose 28, 0x81ec, 0x90f8, 0x4c00
+ax_pose_terminator
+sStaryuPose138:
+ax_pose 29, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose139:
+ax_pose 30, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose140:
+ax_pose 31, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose141:
+ax_pose 28, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose142:
+ax_pose 27, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose143:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose144:
+ax_pose 18, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose145:
+ax_pose 26, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose146:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose147:
+ax_pose 21, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose148:
+ax_pose 27, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sStaryuPose149:
+ax_pose 6, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose150:
+ax_pose 22, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sStaryuPose151:
+ax_pose 28, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose152:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose153:
+ax_pose 23, 0x01f3, 0x40f7, 0x4c00
+ax_pose_terminator
+sStaryuPose154:
+ax_pose 29, 0x81ee, 0x80f9, 0x4c00
+ax_pose_terminator
+sStaryuPose155:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose156:
+ax_pose 24, 0x41f3, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose157:
+ax_pose 30, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose158:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose159:
+ax_pose 25, 0x01f3, 0x40f9, 0x4c00
+ax_pose_terminator
+sStaryuPose160:
+ax_pose 31, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose161:
+ax_pose 6, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose162:
+ax_pose 22, 0x01ed, 0x80f6, 0x4c00
+ax_pose_terminator
+sStaryuPose163:
+ax_pose 28, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose164:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose165:
+ax_pose 21, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose166:
+ax_pose 27, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose167:
+ax_pose 26, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose168:
+ax_pose 27, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose169:
+ax_pose 28, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose170:
+ax_pose 31, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose171:
+ax_pose 30, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose172:
+ax_pose 29, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose173:
+ax_pose 28, 0x81ec, 0x90f8, 0x4c00
+ax_pose_terminator
+sStaryuPose174:
+ax_pose 27, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sStaryuPose175:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose176:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose177:
+ax_pose 6, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sStaryuPose178:
+ax_pose 15, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose179:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose180:
+ax_pose 9, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sStaryuPose181:
+ax_pose 6, 0x81ed, 0x90f9, 0x4c00
+ax_pose_terminator
+sStaryuPose182:
+ax_pose 3, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+.align 2
+sStaryuAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_2_1:
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 4, 0, 26, 0, -5, 0, -5,
+ax_anim 2, 0, 27, 0, -5, 0, -5,
+ax_anim 2, 2, 26, 0, -5, 0, -5,
+ax_anim 1, 0, 27, 0, 2, 0, 2,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 1, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 26, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sStaryuAnims_2_2:
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 4, 0, 26, -5, -5, -5, -5,
+ax_anim 2, 0, 27, -5, -5, -5, -5,
+ax_anim 2, 2, 26, -5, -5, -5, -5,
+ax_anim 1, 0, 27, 2, 2, 2, 2,
+ax_anim 1, 0, 26, 10, 10, 10, 10,
+ax_anim 1, 0, 27, 20, 19, 20, 19,
+ax_anim 2, 1, 26, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 20, 19, 20, 19,
+ax_anim 2, 0, 26, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 20, 19, 20, 19,
+ax_anim 2, 0, 26, 20, 19, 20, 19,
+ax_anim 2, 0, 27, 12, 12, 12, 12,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sStaryuAnims_2_3:
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -3, 0, -3, 0,
+ax_anim 4, 0, 26, -5, 0, -5, 0,
+ax_anim 2, 0, 27, -5, 0, -5, 0,
+ax_anim 2, 2, 26, -5, 0, -5, 0,
+ax_anim 1, 0, 27, 2, 0, 2, 0,
+ax_anim 1, 0, 26, 10, 0, 10, 0,
+ax_anim 1, 0, 27, 20, 0, 20, 0,
+ax_anim 2, 1, 26, 20, 0, 20, 0,
+ax_anim 2, 0, 27, 20, 0, 20, 0,
+ax_anim 2, 0, 26, 20, 0, 20, 0,
+ax_anim 2, 0, 27, 20, 0, 20, 0,
+ax_anim 2, 0, 26, 20, 0, 20, 0,
+ax_anim 2, 0, 27, 12, 0, 12, 0,
+ax_anim 2, 0, 30, 4, 0, 4, 0,
+ax_anim_terminator
+sStaryuAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -3, 3, -3, 3,
+ax_anim 4, 0, 26, -5, 5, -5, 5,
+ax_anim 2, 0, 27, -5, 5, -5, 5,
+ax_anim 2, 2, 26, -5, 5, -5, 5,
+ax_anim 1, 0, 27, 2, -2, 2, -2,
+ax_anim 1, 0, 26, 10, -10, 10, -10,
+ax_anim 1, 0, 27, 20, -19, 20, -19,
+ax_anim 2, 1, 26, 20, -19, 20, -19,
+ax_anim 2, 0, 27, 20, -19, 20, -19,
+ax_anim 2, 0, 26, 20, -19, 20, -19,
+ax_anim 2, 0, 27, 20, -19, 20, -19,
+ax_anim 2, 0, 26, 20, -19, 20, -19,
+ax_anim 2, 0, 27, 12, -12, 12, -12,
+ax_anim 2, 0, 32, 4, -4, 4, -4,
+ax_anim_terminator
+sStaryuAnims_2_5:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 3, 0, 3,
+ax_anim 4, 0, 26, 0, 5, 0, 5,
+ax_anim 2, 0, 27, 0, 5, 0, 5,
+ax_anim 2, 2, 26, 0, 5, 0, 5,
+ax_anim 1, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, -10, 0, -10,
+ax_anim 1, 0, 27, 0, -19, 0, -19,
+ax_anim 2, 1, 26, 0, -19, 0, -19,
+ax_anim 2, 0, 27, 0, -19, 0, -19,
+ax_anim 2, 0, 26, 0, -19, 0, -19,
+ax_anim 2, 0, 27, 0, -19, 0, -19,
+ax_anim 2, 0, 26, 0, -19, 0, -19,
+ax_anim 2, 0, 27, 0, -12, 0, -12,
+ax_anim 2, 0, 34, 0, -4, 0, -4,
+ax_anim_terminator
+sStaryuAnims_2_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 3, 3, 3, 3,
+ax_anim 4, 0, 26, 5, 5, 5, 5,
+ax_anim 2, 0, 27, 5, 5, 5, 5,
+ax_anim 2, 2, 26, 5, 5, 5, 5,
+ax_anim 1, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 26, -10, -10, -10, -10,
+ax_anim 1, 0, 27, -20, -19, -20, -19,
+ax_anim 2, 1, 26, -20, -19, -20, -19,
+ax_anim 2, 0, 27, -20, -19, -20, -19,
+ax_anim 2, 0, 26, -20, -19, -20, -19,
+ax_anim 2, 0, 27, -20, -19, -20, -19,
+ax_anim 2, 0, 26, -20, -19, -20, -19,
+ax_anim 2, 0, 27, -12, -12, -12, -12,
+ax_anim 2, 0, 36, -4, -4, -4, -4,
+ax_anim_terminator
+sStaryuAnims_2_7:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 3, 0, 3, 0,
+ax_anim 4, 0, 26, 5, 0, 5, 0,
+ax_anim 2, 0, 27, 5, 0, 5, 0,
+ax_anim 2, 2, 26, 5, 0, 5, 0,
+ax_anim 1, 0, 27, -2, 0, -2, 0,
+ax_anim 1, 0, 26, -10, 0, -10, 0,
+ax_anim 1, 0, 27, -20, 0, -20, 0,
+ax_anim 2, 1, 26, -20, 0, -20, 0,
+ax_anim 2, 0, 27, -20, 0, -20, 0,
+ax_anim 2, 0, 26, -20, 0, -20, 0,
+ax_anim 2, 0, 27, -20, 0, -20, 0,
+ax_anim 2, 0, 26, -20, 0, -20, 0,
+ax_anim 2, 0, 27, -12, 0, -12, 0,
+ax_anim 2, 0, 38, -4, 0, -4, 0,
+ax_anim_terminator
+sStaryuAnims_2_8:
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 3, -3, 3, -3,
+ax_anim 4, 0, 26, 5, -5, 5, -5,
+ax_anim 2, 0, 27, 5, -5, 5, -5,
+ax_anim 2, 2, 26, 5, -5, 5, -5,
+ax_anim 1, 0, 27, -2, 2, -2, 2,
+ax_anim 1, 0, 26, -10, 10, -10, 10,
+ax_anim 1, 0, 27, -20, 19, -20, 19,
+ax_anim 2, 1, 26, -20, 19, -20, 19,
+ax_anim 2, 0, 27, -20, 19, -20, 19,
+ax_anim 2, 0, 26, -20, 19, -20, 19,
+ax_anim 2, 0, 27, -20, 19, -20, 19,
+ax_anim 2, 0, 26, -20, 19, -20, 19,
+ax_anim 2, 0, 27, -12, 12, -12, 12,
+ax_anim 2, 0, 40, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sStaryuAnims_3_1:
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 0, -3, 0, -3,
+ax_anim 4, 0, 44, 0, -5, 0, -5,
+ax_anim 2, 0, 45, 0, -5, 0, -5,
+ax_anim 2, 2, 44, 0, -5, 0, -5,
+ax_anim 1, 0, 45, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 10, 0, 10,
+ax_anim 1, 0, 45, 0, 19, 0, 19,
+ax_anim 2, 1, 44, 0, 19, 0, 19,
+ax_anim 2, 0, 45, 0, 19, 0, 19,
+ax_anim 2, 0, 44, 0, 19, 0, 19,
+ax_anim 2, 0, 45, 0, 19, 0, 19,
+ax_anim 2, 0, 44, 0, 19, 0, 19,
+ax_anim 2, 0, 45, 0, 12, 0, 12,
+ax_anim 2, 0, 42, 0, 4, 0, 4,
+ax_anim_terminator
+sStaryuAnims_3_2:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -3, -3, -3, -3,
+ax_anim 4, 0, 44, -5, -5, -5, -5,
+ax_anim 2, 0, 45, -5, -5, -5, -5,
+ax_anim 2, 2, 44, -5, -5, -5, -5,
+ax_anim 1, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 44, 10, 10, 10, 10,
+ax_anim 1, 0, 45, 20, 19, 20, 19,
+ax_anim 2, 1, 44, 20, 19, 20, 19,
+ax_anim 2, 0, 45, 20, 19, 20, 19,
+ax_anim 2, 0, 44, 20, 19, 20, 19,
+ax_anim 2, 0, 45, 20, 19, 20, 19,
+ax_anim 2, 0, 44, 20, 19, 20, 19,
+ax_anim 2, 0, 45, 12, 12, 12, 12,
+ax_anim 2, 0, 46, 4, 4, 4, 4,
+ax_anim_terminator
+sStaryuAnims_3_3:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, -3, 0, -3, 0,
+ax_anim 4, 0, 44, -5, 0, -5, 0,
+ax_anim 2, 0, 45, -5, 0, -5, 0,
+ax_anim 2, 2, 44, -5, 0, -5, 0,
+ax_anim 1, 0, 45, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 10, 0, 10, 0,
+ax_anim 1, 0, 45, 20, 0, 20, 0,
+ax_anim 2, 1, 44, 20, 0, 20, 0,
+ax_anim 2, 0, 45, 20, 0, 20, 0,
+ax_anim 2, 0, 44, 20, 0, 20, 0,
+ax_anim 2, 0, 45, 20, 0, 20, 0,
+ax_anim 2, 0, 44, 20, 0, 20, 0,
+ax_anim 2, 0, 45, 12, 0, 12, 0,
+ax_anim 2, 0, 48, 4, 0, 4, 0,
+ax_anim_terminator
+sStaryuAnims_3_4:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -3, 3, -3, 3,
+ax_anim 4, 0, 44, -5, 5, -5, 5,
+ax_anim 2, 0, 45, -5, 5, -5, 5,
+ax_anim 2, 2, 44, -5, 5, -5, 5,
+ax_anim 1, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 44, 10, -10, 10, -10,
+ax_anim 1, 0, 45, 20, -19, 20, -19,
+ax_anim 2, 1, 44, 20, -19, 20, -19,
+ax_anim 2, 0, 45, 20, -19, 20, -19,
+ax_anim 2, 0, 44, 20, -19, 20, -19,
+ax_anim 2, 0, 45, 20, -19, 20, -19,
+ax_anim 2, 0, 44, 20, -19, 20, -19,
+ax_anim 2, 0, 45, 12, -12, 12, -12,
+ax_anim 2, 0, 50, 4, -4, 4, -4,
+ax_anim_terminator
+sStaryuAnims_3_5:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 3, 0, 3,
+ax_anim 4, 0, 44, 0, 5, 0, 5,
+ax_anim 2, 0, 45, 0, 5, 0, 5,
+ax_anim 2, 2, 44, 0, 5, 0, 5,
+ax_anim 1, 0, 45, 0, -2, 0, -2,
+ax_anim 1, 0, 44, 0, -10, 0, -10,
+ax_anim 1, 0, 45, 0, -19, 0, -19,
+ax_anim 2, 1, 44, 0, -19, 0, -19,
+ax_anim 2, 0, 45, 0, -19, 0, -19,
+ax_anim 2, 0, 44, 0, -19, 0, -19,
+ax_anim 2, 0, 45, 0, -19, 0, -19,
+ax_anim 2, 0, 44, 0, -19, 0, -19,
+ax_anim 2, 0, 45, 0, -12, 0, -12,
+ax_anim 2, 0, 52, 0, -4, 0, -4,
+ax_anim_terminator
+sStaryuAnims_3_6:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 3, 3, 3, 3,
+ax_anim 4, 0, 44, 5, 5, 5, 5,
+ax_anim 2, 0, 45, 5, 5, 5, 5,
+ax_anim 2, 2, 44, 5, 5, 5, 5,
+ax_anim 1, 0, 45, -2, -2, -2, -2,
+ax_anim 1, 0, 44, -10, -10, -10, -10,
+ax_anim 1, 0, 45, -20, -19, -20, -19,
+ax_anim 2, 1, 44, -20, -19, -20, -19,
+ax_anim 2, 0, 45, -20, -19, -20, -19,
+ax_anim 2, 0, 44, -20, -19, -20, -19,
+ax_anim 2, 0, 45, -20, -19, -20, -19,
+ax_anim 2, 0, 44, -20, -19, -20, -19,
+ax_anim 2, 0, 45, -12, -12, -12, -12,
+ax_anim 2, 0, 54, -4, -4, -4, -4,
+ax_anim_terminator
+sStaryuAnims_3_7:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 3, 0, 3, 0,
+ax_anim 4, 0, 44, 5, 0, 5, 0,
+ax_anim 2, 0, 45, 5, 0, 5, 0,
+ax_anim 2, 2, 44, 5, 0, 5, 0,
+ax_anim 1, 0, 45, -2, 0, -2, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 1, 0, 45, -20, 0, -20, 0,
+ax_anim 2, 1, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 45, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 45, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 45, -12, 0, -12, 0,
+ax_anim 2, 0, 56, -4, 0, -4, 0,
+ax_anim_terminator
+sStaryuAnims_3_8:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 3, -3, 3, -3,
+ax_anim 4, 0, 44, 5, -5, 5, -5,
+ax_anim 2, 0, 45, 5, -5, 5, -5,
+ax_anim 2, 2, 44, 5, -5, 5, -5,
+ax_anim 1, 0, 45, -2, 2, -2, 2,
+ax_anim 1, 0, 44, -10, 10, -10, 10,
+ax_anim 1, 0, 45, -20, 19, -20, 19,
+ax_anim 2, 1, 44, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -20, 19, -20, 19,
+ax_anim 2, 0, 44, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -20, 19, -20, 19,
+ax_anim 2, 0, 44, -20, 19, -20, 19,
+ax_anim 2, 0, 45, -12, 12, -12, 12,
+ax_anim 2, 0, 58, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sStaryuAnims_4_1:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 8, 2, 63, 0, 0, 0, 0,
+ax_anim 1, 1, 60, 0, -3, 0, -3,
+ax_anim 1, 0, 60, 0, -5, 0, -5,
+ax_anim 1, 0, 60, 0, -6, 0, -6,
+ax_anim 4, 0, 60, 0, -7, 0, -7,
+ax_anim 2, 0, 61, 0, -7, 0, -7,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim 2, 0, 62, 0, -4, 0, -3,
+ax_anim_terminator
+sStaryuAnims_4_2:
+ax_anim 4, 0, 64, 0, 0, 0, 0,
+ax_anim 8, 2, 67, 0, 0, 0, 0,
+ax_anim 1, 1, 64, -3, -3, -3, -3,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 1, 0, 64, -6, -6, -6, -6,
+ax_anim 4, 0, 64, -7, -7, -7, -7,
+ax_anim 2, 0, 65, -7, -6, -7, -6,
+ax_anim 2, 0, 64, -4, -4, -4, -4,
+ax_anim 2, 0, 66, -3, -3, -3, -3,
+ax_anim_terminator
+sStaryuAnims_4_3:
+ax_anim 4, 0, 68, 0, 0, 0, 0,
+ax_anim 8, 2, 71, 0, 0, 0, 0,
+ax_anim 1, 1, 68, -3, 0, -3, 0,
+ax_anim 1, 0, 68, -5, 0, -5, 0,
+ax_anim 1, 0, 68, -6, 0, -6, 0,
+ax_anim 4, 0, 68, -7, 0, -7, 0,
+ax_anim 2, 0, 69, -4, 0, -4, 0,
+ax_anim 2, 0, 68, -2, 0, -2, 0,
+ax_anim 2, 0, 70, -1, 0, -1, 0,
+ax_anim_terminator
+sStaryuAnims_4_4:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 8, 2, 75, 0, 0, 0, 0,
+ax_anim 1, 1, 72, -3, 3, -3, 3,
+ax_anim 1, 0, 72, -5, 5, -5, 5,
+ax_anim 1, 0, 72, -6, 6, -6, 6,
+ax_anim 4, 0, 72, -7, 7, -7, 7,
+ax_anim 2, 0, 73, -5, 5, -5, 5,
+ax_anim 2, 0, 72, -4, 4, -4, 4,
+ax_anim 2, 0, 74, -1, 1, -1, 1,
+ax_anim_terminator
+sStaryuAnims_4_5:
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 8, 2, 79, 0, 0, 0, 0,
+ax_anim 1, 1, 76, 0, 3, 0, 3,
+ax_anim 1, 0, 76, 0, 5, 0, 5,
+ax_anim 1, 0, 76, 0, 6, 0, 6,
+ax_anim 4, 0, 76, 0, 7, 0, 7,
+ax_anim 2, 0, 77, 0, 4, 0, 4,
+ax_anim 2, 0, 76, 0, 3, 0, 3,
+ax_anim 2, 0, 78, 0, 1, 0, 1,
+ax_anim_terminator
+sStaryuAnims_4_6:
+ax_anim 4, 0, 80, 0, 0, 0, 0,
+ax_anim 8, 2, 83, 0, 0, 0, 0,
+ax_anim 1, 1, 80, 3, 3, 3, 3,
+ax_anim 1, 0, 80, 5, 5, 5, 5,
+ax_anim 1, 0, 80, 6, 6, 6, 6,
+ax_anim 4, 0, 80, 7, 7, 7, 7,
+ax_anim 2, 0, 81, 5, 5, 5, 5,
+ax_anim 2, 0, 80, 4, 4, 4, 4,
+ax_anim 2, 0, 82, 1, 1, 1, 1,
+ax_anim_terminator
+sStaryuAnims_4_7:
+ax_anim 4, 0, 84, 0, 0, 0, 0,
+ax_anim 8, 2, 87, 0, 0, 0, 0,
+ax_anim 1, 1, 84, 3, 0, 3, 0,
+ax_anim 1, 0, 84, 5, 0, 5, 0,
+ax_anim 1, 0, 84, 6, 0, 6, 0,
+ax_anim 4, 0, 84, 7, 0, 7, 0,
+ax_anim 2, 0, 85, 4, 0, 4, 0,
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim_terminator
+sStaryuAnims_4_8:
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 8, 2, 91, 0, 0, 0, 0,
+ax_anim 1, 1, 88, 3, -3, 3, -3,
+ax_anim 1, 0, 88, 5, -5, 5, -5,
+ax_anim 1, 0, 88, 6, -6, 6, -6,
+ax_anim 4, 0, 88, 7, -7, 7, -7,
+ax_anim 2, 0, 89, 7, -6, 7, -6,
+ax_anim 2, 0, 88, 4, -4, 4, -4,
+ax_anim 2, 0, 90, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sStaryuAnims_5_1:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_5_2:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_5_3:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_5_4:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_5_5:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_5_6:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_5_7:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_5_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_6_1:
+ax_anim 30, 0, 100, 0, 0, 0, 0,
+ax_anim 35, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_7_1:
+ax_anim 2, 0, 102, 0, -2, 0, -2,
+ax_anim 8, 0, 102, 0, -3, 0, -3,
+ax_anim_terminator
+sStaryuAnims_7_2:
+ax_anim 2, 0, 103, -2, -2, -2, -2,
+ax_anim 8, 0, 103, -3, -3, -3, -3,
+ax_anim_terminator
+sStaryuAnims_7_3:
+ax_anim 2, 0, 104, -2, 0, -2, 0,
+ax_anim 8, 0, 104, -3, 0, -3, 0,
+ax_anim_terminator
+sStaryuAnims_7_4:
+ax_anim 2, 0, 105, -2, 2, -2, 2,
+ax_anim 8, 0, 105, -3, 3, -3, 3,
+ax_anim_terminator
+sStaryuAnims_7_5:
+ax_anim 2, 0, 106, 0, 2, 0, 2,
+ax_anim 8, 0, 106, 0, 3, 0, 3,
+ax_anim_terminator
+sStaryuAnims_7_6:
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim 8, 0, 107, 3, 3, 3, 3,
+ax_anim_terminator
+sStaryuAnims_7_7:
+ax_anim 2, 0, 108, 2, 0, 2, 0,
+ax_anim 8, 0, 108, 3, 0, 3, 0,
+ax_anim_terminator
+sStaryuAnims_7_8:
+ax_anim 2, 0, 109, 2, -2, 2, -2,
+ax_anim 8, 0, 109, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sStaryuAnims_8_1:
+ax_anim 36, 0, 110, 0, 0, 0, 0,
+ax_anim 10, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 10, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_8_2:
+ax_anim 36, 0, 112, 0, 0, 0, 0,
+ax_anim 10, 0, 113, 0, 0, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 10, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_8_3:
+ax_anim 36, 0, 114, 0, 0, 0, 0,
+ax_anim 10, 0, 115, 0, 0, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 10, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_8_4:
+ax_anim 36, 0, 116, 0, 0, 0, 0,
+ax_anim 10, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 10, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_8_5:
+ax_anim 36, 0, 118, 0, 0, 0, 0,
+ax_anim 10, 0, 119, 0, 0, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 10, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_8_6:
+ax_anim 36, 0, 120, 0, 0, 0, 0,
+ax_anim 10, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 10, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_8_7:
+ax_anim 36, 0, 122, 0, 0, 0, 0,
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_8_8:
+ax_anim 36, 0, 124, 0, 0, 0, 0,
+ax_anim 10, 0, 125, 0, 0, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 10, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_9_1:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, 6, 3, 6, 3,
+ax_anim 2, 0, 128, 8, 10, 8, 10,
+ax_anim 2, 0, 129, 7, 18, 7, 18,
+ax_anim 3, 0, 130, 0, 21, 0, 21,
+ax_anim 2, 3, 131, -7, 18, -7, 18,
+ax_anim 2, 0, 132, -8, 10, -8, 10,
+ax_anim 1, 0, 133, -6, 3, -6, 3,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_9_2:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 8, 0, 8, 0,
+ax_anim 2, 0, 127, 17, 3, 17, 3,
+ax_anim 2, 0, 128, 21, 12, 21, 12,
+ax_anim 3, 0, 129, 22, 20, 22, 20,
+ax_anim 2, 3, 130, 12, 23, 12, 23,
+ax_anim 2, 0, 131, 3, 15, 3, 15,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_9_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 3, -5, 3, -5,
+ax_anim 2, 0, 126, 11, -6, 11, -6,
+ax_anim 2, 0, 127, 20, -5, 20, -5,
+ax_anim 3, 0, 128, 24, -2, 24, -2,
+ax_anim 2, 3, 129, 21, 5, 21, 5,
+ax_anim 2, 0, 130, 12, 7, 12, 7,
+ax_anim 1, 0, 131, 4, 4, 4, 4,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_9_4:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, -1, -8, -1, -8,
+ax_anim 2, 0, 133, 4, -16, 4, -16,
+ax_anim 2, 0, 126, 14, -23, 14, -23,
+ax_anim 3, 0, 127, 22, -22, 22, -22,
+ax_anim 2, 3, 128, 23, -14, 23, -14,
+ax_anim 2, 0, 129, 17, -4, 17, -4,
+ax_anim 1, 0, 130, 7, -1, 7, -1,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_9_5:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -8, -4, -8, -4,
+ax_anim 2, 0, 132, -9, -12, -9, -12,
+ax_anim 2, 0, 133, -7, -20, -7, -20,
+ax_anim 3, 0, 126, 0, -25, 0, -25,
+ax_anim 2, 3, 127, 7, -20, 7, -20,
+ax_anim 2, 0, 128, 9, -10, 9, -10,
+ax_anim 1, 0, 129, 8, -4, 8, -4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_9_6:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 1, -8, 1, -8,
+ax_anim 2, 0, 127, -4, -16, -4, -16,
+ax_anim 2, 0, 126, -14, -23, -14, -23,
+ax_anim 3, 0, 133, -22, -22, -22, -22,
+ax_anim 2, 3, 132, -23, -14, -23, -14,
+ax_anim 2, 0, 131, -17, -4, -17, -4,
+ax_anim 1, 0, 130, -7, -1, -7, -1,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_9_7:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -3, -5, -3, -5,
+ax_anim 2, 0, 126, -11, -6, -11, -6,
+ax_anim 2, 0, 133, -20, -5, -20, -5,
+ax_anim 3, 0, 132, -24, -2, -24, -2,
+ax_anim 2, 3, 131, -21, 5, -21, 5,
+ax_anim 2, 0, 130, -12, 7, -12, 7,
+ax_anim 1, 0, 129, -4, 4, -4, 4,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_9_8:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, -8, 0, -8, 0,
+ax_anim 2, 0, 133, -17, 3, -17, 3,
+ax_anim 2, 0, 132, -21, 12, -21, 12,
+ax_anim 3, 0, 131, -22, 20, -22, 20,
+ax_anim 2, 3, 130, -12, 23, -12, 23,
+ax_anim 2, 0, 129, -3, 15, -3, 15,
+ax_anim 1, 0, 128, 0, 7, 0, 7,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_10_1:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_10_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_10_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_10_4:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_10_5:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_10_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_10_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_10_8:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_11_1:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 0, 143, 0, -16, 0, 0,
+ax_anim 3, 0, 143, 0, -20, 0, 0,
+ax_anim 4, 0, 143, 0, -21, 0, 0,
+ax_anim 4, 0, 142, 0, -23, 0, 0,
+ax_anim 3, 0, 144, 0, -22, 0, 0,
+ax_anim 2, 0, 144, 0, -18, 0, 0,
+ax_anim 1, 0, 144, 0, -12, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_11_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 0, 146, 0, -16, 0, 0,
+ax_anim 3, 0, 146, 0, -20, 0, 0,
+ax_anim 4, 0, 146, 0, -21, 0, 0,
+ax_anim 4, 0, 145, 0, -23, 0, 0,
+ax_anim 3, 0, 147, 0, -22, 0, 0,
+ax_anim 2, 0, 147, 0, -18, 0, 0,
+ax_anim 1, 0, 147, 0, -12, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_11_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -23, 0, 0,
+ax_anim 3, 0, 150, 0, -22, 0, 0,
+ax_anim 2, 0, 150, 0, -18, 0, 0,
+ax_anim 1, 0, 150, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_11_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 4, 0, 151, 0, -22, 0, 0,
+ax_anim 3, 0, 153, 0, -21, 0, 0,
+ax_anim 2, 0, 153, 0, -17, 0, 0,
+ax_anim 1, 0, 153, 0, -11, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_11_5:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_11_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -22, 0, 0,
+ax_anim 3, 0, 159, 0, -21, 0, 0,
+ax_anim 2, 0, 159, 0, -17, 0, 0,
+ax_anim 1, 0, 159, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_11_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_11_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 163, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_12_1:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_12_2:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_12_3:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_12_4:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_12_5:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_12_6:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_12_7:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_12_8:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStaryuAnims_13_1:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_13_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_13_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_13_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_13_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_13_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_13_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuAnims_13_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sStaryuGfx1:
+.incbin "baserom.gba", 0xA2A6F0, 0x200
+sStaryuSprites1:
+ax_sprite sStaryuGfx1, 0x200
+ax_sprite_terminator
+sStaryuGfx2:
+.incbin "baserom.gba", 0xA2A900, 0x200
+sStaryuSprites2:
+ax_sprite sStaryuGfx2, 0x200
+ax_sprite_terminator
+sStaryuGfx3:
+.incbin "baserom.gba", 0xA2AB10, 0x200
+sStaryuSprites3:
+ax_sprite sStaryuGfx3, 0x200
+ax_sprite_terminator
+sStaryuGfx4:
+.incbin "baserom.gba", 0xA2AD20, 0x200
+sStaryuSprites4:
+ax_sprite sStaryuGfx4, 0x200
+ax_sprite_terminator
+sStaryuGfx5:
+.incbin "baserom.gba", 0xA2AF30, 0x200
+sStaryuSprites5:
+ax_sprite sStaryuGfx5, 0x200
+ax_sprite_terminator
+sStaryuGfx6:
+.incbin "baserom.gba", 0xA2B140, 0x200
+sStaryuSprites6:
+ax_sprite sStaryuGfx6, 0x200
+ax_sprite_terminator
+sStaryuGfx7:
+.incbin "baserom.gba", 0xA2B350, 0x100
+sStaryuSprites7:
+ax_sprite sStaryuGfx7, 0x100
+ax_sprite_terminator
+sStaryuGfx8:
+.incbin "baserom.gba", 0xA2B460, 0x100
+sStaryuSprites8:
+ax_sprite sStaryuGfx8, 0x100
+ax_sprite_terminator
+sStaryuGfx9:
+.incbin "baserom.gba", 0xA2B570, 0x100
+sStaryuSprites9:
+ax_sprite sStaryuGfx9, 0x100
+ax_sprite_terminator
+sStaryuGfx10:
+.incbin "baserom.gba", 0xA2B680, 0x200
+sStaryuSprites10:
+ax_sprite sStaryuGfx10, 0x200
+ax_sprite_terminator
+sStaryuGfx11:
+.incbin "baserom.gba", 0xA2B890, 0x200
+sStaryuSprites11:
+ax_sprite sStaryuGfx11, 0x200
+ax_sprite_terminator
+sStaryuGfx12:
+.incbin "baserom.gba", 0xA2BAA0, 0x200
+sStaryuSprites12:
+ax_sprite sStaryuGfx12, 0x200
+ax_sprite_terminator
+sStaryuGfx13:
+.incbin "baserom.gba", 0xA2BCB0, 0x200
+sStaryuSprites13:
+ax_sprite sStaryuGfx13, 0x200
+ax_sprite_terminator
+sStaryuGfx14:
+.incbin "baserom.gba", 0xA2BEC0, 0x200
+sStaryuSprites14:
+ax_sprite sStaryuGfx14, 0x200
+ax_sprite_terminator
+sStaryuGfx15:
+.incbin "baserom.gba", 0xA2C0D0, 0x200
+sStaryuSprites15:
+ax_sprite sStaryuGfx15, 0x200
+ax_sprite_terminator
+sStaryuGfx16:
+.incbin "baserom.gba", 0xA2C2E0, 0x200
+sStaryuSprites16:
+ax_sprite sStaryuGfx16, 0x200
+ax_sprite_terminator
+sStaryuGfx17:
+.incbin "baserom.gba", 0xA2C4F0, 0x200
+sStaryuSprites17:
+ax_sprite sStaryuGfx17, 0x200
+ax_sprite_terminator
+sStaryuGfx18:
+.incbin "baserom.gba", 0xA2C700, 0x200
+sStaryuSprites18:
+ax_sprite sStaryuGfx18, 0x200
+ax_sprite_terminator
+sStaryuGfx19:
+.incbin "baserom.gba", 0xA2C910, 0x20
+sStaryuGfx19_1:
+.incbin "baserom.gba", 0xA2C930, 0x60
+sStaryuGfx19_2:
+.incbin "baserom.gba", 0xA2C990, 0x60
+sStaryuSprites19:
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sStaryuGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStaryuGfx20:
+.incbin "baserom.gba", 0xA2CA30, 0x60
+sStaryuGfx20_1:
+.incbin "baserom.gba", 0xA2CA90, 0x60
+sStaryuGfx20_2:
+.incbin "baserom.gba", 0xA2CAF0, 0x60
+sStaryuSprites20:
+ax_sprite sStaryuGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStaryuGfx21:
+.incbin "baserom.gba", 0xA2CB88, 0x60
+sStaryuGfx21_1:
+.incbin "baserom.gba", 0xA2CBE8, 0x60
+sStaryuGfx21_2:
+.incbin "baserom.gba", 0xA2CC48, 0x20
+sStaryuSprites21:
+ax_sprite sStaryuGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sStaryuGfx21_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sStaryuGfx22:
+.incbin "baserom.gba", 0xA2CCA0, 0x40
+sStaryuGfx22_1:
+.incbin "baserom.gba", 0xA2CCE0, 0x60
+sStaryuGfx22_2:
+.incbin "baserom.gba", 0xA2CD40, 0x60
+sStaryuSprites22:
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStaryuGfx23:
+.incbin "baserom.gba", 0xA2CDE0, 0x40
+sStaryuGfx23_1:
+.incbin "baserom.gba", 0xA2CE20, 0x60
+sStaryuGfx23_2:
+.incbin "baserom.gba", 0xA2CE80, 0x40
+sStaryuSprites23:
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx23_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sStaryuGfx24:
+.incbin "baserom.gba", 0xA2CF00, 0x80
+sStaryuSprites24:
+ax_sprite sStaryuGfx24, 0x80
+ax_sprite_terminator
+sStaryuGfx25:
+.incbin "baserom.gba", 0xA2CF90, 0x60
+sStaryuGfx25_1:
+.incbin "baserom.gba", 0xA2CFF0, 0x60
+sStaryuSprites25:
+ax_sprite sStaryuGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sStaryuGfx26:
+.incbin "baserom.gba", 0xA2D078, 0x80
+sStaryuSprites26:
+ax_sprite sStaryuGfx26, 0x80
+ax_sprite_terminator
+sStaryuGfx27:
+.incbin "baserom.gba", 0xA2D108, 0x20
+sStaryuGfx27_1:
+.incbin "baserom.gba", 0xA2D128, 0x60
+sStaryuGfx27_2:
+.incbin "baserom.gba", 0xA2D188, 0x60
+sStaryuSprites27:
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sStaryuGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStaryuGfx28:
+.incbin "baserom.gba", 0xA2D228, 0x40
+sStaryuGfx28_1:
+.incbin "baserom.gba", 0xA2D268, 0x60
+sStaryuGfx28_2:
+.incbin "baserom.gba", 0xA2D2C8, 0x60
+sStaryuSprites28:
+ax_sprite sStaryuGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sStaryuGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStaryuGfx29:
+.incbin "baserom.gba", 0xA2D360, 0xC0
+sStaryuSprites29:
+ax_sprite sStaryuGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStaryuGfx30:
+.incbin "baserom.gba", 0xA2D438, 0xC0
+sStaryuSprites30:
+ax_sprite sStaryuGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStaryuGfx31:
+.incbin "baserom.gba", 0xA2D510, 0x20
+sStaryuGfx31_1:
+.incbin "baserom.gba", 0xA2D530, 0x60
+sStaryuGfx31_2:
+.incbin "baserom.gba", 0xA2D590, 0x60
+sStaryuSprites31:
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx31, 0x20
+ax_sprite 0, 0x40
+ax_sprite sStaryuGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sStaryuGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sStaryuGfx32:
+.incbin "baserom.gba", 0xA2D630, 0xC0
+sStaryuSprites32:
+ax_sprite sStaryuGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sStaryuGfx33:
+.incbin "baserom.gba", 0xA2D708, 0x200
+sStaryuSprites33:
+ax_sprite sStaryuGfx33, 0x200
+ax_sprite_terminator
+sStaryuGfx34:
+.incbin "baserom.gba", 0xA2D918, 0x200
+sStaryuSprites34:
+ax_sprite sStaryuGfx34, 0x200
+ax_sprite_terminator
+sStaryuGfx35:
+.incbin "baserom.gba", 0xA2DB28, 0x200
+sStaryuSprites35:
+ax_sprite sStaryuGfx35, 0x200
+ax_sprite_terminator
+sStaryuGfx36:
+.incbin "baserom.gba", 0xA2DD38, 0x200
+sStaryuSprites36:
+ax_sprite sStaryuGfx36, 0x200
+ax_sprite_terminator
+sStaryuGfx37:
+.incbin "baserom.gba", 0xA2DF48, 0x200
+sStaryuSprites37:
+ax_sprite sStaryuGfx37, 0x200
+ax_sprite_terminator
+sStaryuGfx38:
+.incbin "baserom.gba", 0xA2E158, 0x200
+sStaryuSprites38:
+ax_sprite sStaryuGfx38, 0x200
+ax_sprite_terminator
+sStaryuGfx39:
+.incbin "baserom.gba", 0xA2E368, 0x200
+sStaryuSprites39:
+ax_sprite sStaryuGfx39, 0x200
+ax_sprite_terminator
+sStaryuGfx40:
+.incbin "baserom.gba", 0xA2E578, 0x200
+sStaryuSprites40:
+ax_sprite sStaryuGfx40, 0x200
+ax_sprite_terminator
+sStaryuGfx41:
+.incbin "baserom.gba", 0xA2E788, 0x200
+sStaryuSprites41:
+ax_sprite sStaryuGfx41, 0x200
+ax_sprite_terminator
+sAxPosesStaryu:
+.4byte sStaryuPose1
+.4byte sStaryuPose2
+.4byte sStaryuPose3
+.4byte sStaryuPose4
+.4byte sStaryuPose5
+.4byte sStaryuPose6
+.4byte sStaryuPose7
+.4byte sStaryuPose8
+.4byte sStaryuPose9
+.4byte sStaryuPose10
+.4byte sStaryuPose11
+.4byte sStaryuPose12
+.4byte sStaryuPose13
+.4byte sStaryuPose14
+.4byte sStaryuPose15
+.4byte sStaryuPose16
+.4byte sStaryuPose17
+.4byte sStaryuPose18
+.4byte sStaryuPose19
+.4byte sStaryuPose20
+.4byte sStaryuPose21
+.4byte sStaryuPose22
+.4byte sStaryuPose23
+.4byte sStaryuPose24
+.4byte sStaryuPose25
+.4byte sStaryuPose26
+.4byte sStaryuPose27
+.4byte sStaryuPose28
+.4byte sStaryuPose29
+.4byte sStaryuPose30
+.4byte sStaryuPose31
+.4byte sStaryuPose32
+.4byte sStaryuPose33
+.4byte sStaryuPose34
+.4byte sStaryuPose35
+.4byte sStaryuPose36
+.4byte sStaryuPose37
+.4byte sStaryuPose38
+.4byte sStaryuPose39
+.4byte sStaryuPose40
+.4byte sStaryuPose41
+.4byte sStaryuPose42
+.4byte sStaryuPose43
+.4byte sStaryuPose44
+.4byte sStaryuPose45
+.4byte sStaryuPose46
+.4byte sStaryuPose47
+.4byte sStaryuPose48
+.4byte sStaryuPose49
+.4byte sStaryuPose50
+.4byte sStaryuPose51
+.4byte sStaryuPose52
+.4byte sStaryuPose53
+.4byte sStaryuPose54
+.4byte sStaryuPose55
+.4byte sStaryuPose56
+.4byte sStaryuPose57
+.4byte sStaryuPose58
+.4byte sStaryuPose59
+.4byte sStaryuPose60
+.4byte sStaryuPose61
+.4byte sStaryuPose62
+.4byte sStaryuPose63
+.4byte sStaryuPose64
+.4byte sStaryuPose65
+.4byte sStaryuPose66
+.4byte sStaryuPose67
+.4byte sStaryuPose68
+.4byte sStaryuPose69
+.4byte sStaryuPose70
+.4byte sStaryuPose71
+.4byte sStaryuPose72
+.4byte sStaryuPose73
+.4byte sStaryuPose74
+.4byte sStaryuPose75
+.4byte sStaryuPose76
+.4byte sStaryuPose77
+.4byte sStaryuPose78
+.4byte sStaryuPose79
+.4byte sStaryuPose80
+.4byte sStaryuPose81
+.4byte sStaryuPose82
+.4byte sStaryuPose83
+.4byte sStaryuPose84
+.4byte sStaryuPose85
+.4byte sStaryuPose86
+.4byte sStaryuPose87
+.4byte sStaryuPose88
+.4byte sStaryuPose89
+.4byte sStaryuPose90
+.4byte sStaryuPose91
+.4byte sStaryuPose92
+.4byte sStaryuPose93
+.4byte sStaryuPose94
+.4byte sStaryuPose95
+.4byte sStaryuPose96
+.4byte sStaryuPose97
+.4byte sStaryuPose98
+.4byte sStaryuPose99
+.4byte sStaryuPose100
+.4byte sStaryuPose101
+.4byte sStaryuPose102
+.4byte sStaryuPose103
+.4byte sStaryuPose104
+.4byte sStaryuPose105
+.4byte sStaryuPose106
+.4byte sStaryuPose107
+.4byte sStaryuPose108
+.4byte sStaryuPose109
+.4byte sStaryuPose110
+.4byte sStaryuPose111
+.4byte sStaryuPose112
+.4byte sStaryuPose113
+.4byte sStaryuPose114
+.4byte sStaryuPose115
+.4byte sStaryuPose116
+.4byte sStaryuPose117
+.4byte sStaryuPose118
+.4byte sStaryuPose119
+.4byte sStaryuPose120
+.4byte sStaryuPose121
+.4byte sStaryuPose122
+.4byte sStaryuPose123
+.4byte sStaryuPose124
+.4byte sStaryuPose125
+.4byte sStaryuPose126
+.4byte sStaryuPose127
+.4byte sStaryuPose128
+.4byte sStaryuPose129
+.4byte sStaryuPose130
+.4byte sStaryuPose131
+.4byte sStaryuPose132
+.4byte sStaryuPose133
+.4byte sStaryuPose134
+.4byte sStaryuPose135
+.4byte sStaryuPose136
+.4byte sStaryuPose137
+.4byte sStaryuPose138
+.4byte sStaryuPose139
+.4byte sStaryuPose140
+.4byte sStaryuPose141
+.4byte sStaryuPose142
+.4byte sStaryuPose143
+.4byte sStaryuPose144
+.4byte sStaryuPose145
+.4byte sStaryuPose146
+.4byte sStaryuPose147
+.4byte sStaryuPose148
+.4byte sStaryuPose149
+.4byte sStaryuPose150
+.4byte sStaryuPose151
+.4byte sStaryuPose152
+.4byte sStaryuPose153
+.4byte sStaryuPose154
+.4byte sStaryuPose155
+.4byte sStaryuPose156
+.4byte sStaryuPose157
+.4byte sStaryuPose158
+.4byte sStaryuPose159
+.4byte sStaryuPose160
+.4byte sStaryuPose161
+.4byte sStaryuPose162
+.4byte sStaryuPose163
+.4byte sStaryuPose164
+.4byte sStaryuPose165
+.4byte sStaryuPose166
+.4byte sStaryuPose167
+.4byte sStaryuPose168
+.4byte sStaryuPose169
+.4byte sStaryuPose170
+.4byte sStaryuPose171
+.4byte sStaryuPose172
+.4byte sStaryuPose173
+.4byte sStaryuPose174
+.4byte sStaryuPose175
+.4byte sStaryuPose176
+.4byte sStaryuPose177
+.4byte sStaryuPose178
+.4byte sStaryuPose179
+.4byte sStaryuPose180
+.4byte sStaryuPose181
+.4byte sStaryuPose182
+sAxPositionsStaryu:
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte    1,   -4, 	  -8,  -10, 	   7,   -8, 	   0,   -6
+.2byte   -1,   -4, 	  -7,   -8, 	   8,  -10, 	   1,   -6
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+.2byte    2,   -4, 	   7,  -12, 	  -7,   -7, 	   1,   -6
+.2byte    4,   -4, 	   6,  -10, 	  -6,   -8, 	   1,   -6
+.2byte    5,   -6, 	   3,  -13, 	  -2,   -6, 	   0,   -7
+.2byte    4,   -4, 	   5,  -13, 	  -4,   -5, 	   1,   -6
+.2byte    4,   -6, 	   3,  -10, 	   0,   -8, 	   1,   -5
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    0,  -10, 	   7,  -10, 	  -6,   -9, 	   0,   -8
+.2byte    4,   -7, 	   6,   -5, 	  -3,  -13, 	   1,   -6
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -10, 	   6,  -12, 	  -8,   -7, 	   0,   -8
+.2byte    1,  -10, 	   7,   -7, 	  -6,  -12, 	   0,   -7
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -2,   -6, 	   3,  -13, 	  -6,   -5, 	   0,   -8
+.2byte    1,   -8, 	   7,   -9, 	  -6,   -9, 	   0,   -8
+.2byte   -5,   -6, 	  -3,  -13, 	   2,   -6, 	   0,   -7
+.2byte   -4,   -4, 	  -5,  -13, 	   4,   -5, 	  -1,   -6
+.2byte   -4,   -6, 	  -3,  -10, 	   0,   -8, 	  -1,   -5
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte   -2,   -4, 	  -7,  -12, 	   7,   -7, 	  -1,   -6
+.2byte   -4,   -4, 	  -6,  -10, 	   6,   -8, 	  -1,   -6
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte    0,   -7, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte    0,   -9, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte    0,   -9, 	  -5,  -13, 	   8,   -6, 	   0,   -8
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+.2byte    0,   -8, 	   3,  -13, 	  -9,   -4, 	  -1,   -7
+.2byte    5,   -6, 	   3,  -13, 	  -2,   -6, 	   0,   -7
+.2byte    3,   -9, 	  -1,  -13, 	  -2,   -3, 	   0,   -7
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    2,  -10, 	   4,   -1, 	  -6,  -11, 	   1,   -7
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -12, 	   8,   -8, 	  -9,   -8, 	  -1,   -7
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -3,  -10, 	   5,  -11, 	  -5,   -2, 	  -1,   -7
+.2byte   -5,   -6, 	  -3,  -13, 	   2,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   1,  -13, 	   2,   -3, 	   0,   -7
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte    0,   -8, 	  -3,  -13, 	   9,   -4, 	   1,   -7
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte    0,   -7, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte    0,   -9, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte    0,   -9, 	  -5,  -13, 	   8,   -6, 	   0,   -8
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+.2byte    0,   -8, 	   3,  -13, 	  -9,   -4, 	  -1,   -7
+.2byte    5,   -6, 	   3,  -13, 	  -2,   -6, 	   0,   -7
+.2byte    3,   -9, 	  -1,  -13, 	  -2,   -3, 	   0,   -7
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    2,  -10, 	   4,   -1, 	  -6,  -11, 	   1,   -7
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -12, 	   8,   -8, 	  -9,   -8, 	  -1,   -7
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -3,  -10, 	   5,  -11, 	  -5,   -2, 	  -1,   -7
+.2byte   -5,   -6, 	  -3,  -13, 	   2,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   1,  -13, 	   2,   -3, 	   0,   -7
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte    0,   -8, 	  -3,  -13, 	   9,   -4, 	   1,   -7
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte    1,   -4, 	  -8,  -10, 	   7,   -8, 	   0,   -6
+.2byte   -1,   -4, 	  -7,   -8, 	   8,  -10, 	   1,   -6
+.2byte    0,   -3, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+.2byte    2,   -4, 	   7,  -12, 	  -7,   -7, 	   1,   -6
+.2byte    4,   -4, 	   6,  -10, 	  -6,   -8, 	   1,   -6
+.2byte    4,   -4, 	   8,  -14, 	  -6,   -8, 	   2,   -5
+.2byte    5,   -7, 	   3,  -14, 	  -2,   -7, 	   0,   -8
+.2byte    4,   -6, 	   5,  -15, 	  -4,   -7, 	   1,   -8
+.2byte    4,   -8, 	   3,  -12, 	   0,  -10, 	   1,   -7
+.2byte    6,   -6, 	  -2,  -15, 	  -3,   -7, 	   1,   -8
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    0,  -10, 	   7,  -10, 	  -6,   -9, 	   0,   -8
+.2byte    4,   -7, 	   6,   -5, 	  -3,  -13, 	   1,   -6
+.2byte    4,  -10, 	   7,   -8, 	  -5,  -13, 	   2,   -9
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte   -1,  -10, 	   6,  -12, 	  -8,   -7, 	   0,   -8
+.2byte    1,  -10, 	   7,   -7, 	  -6,  -12, 	   0,   -7
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -8, 	   0,   -8
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -2,   -6, 	   3,  -13, 	  -6,   -5, 	   0,   -8
+.2byte    1,   -8, 	   7,   -9, 	  -6,   -9, 	   0,   -8
+.2byte   -2,  -10, 	   5,  -13, 	  -7,   -8, 	  -1,   -9
+.2byte   -5,   -7, 	  -3,  -14, 	   2,   -7, 	   0,   -8
+.2byte   -4,   -6, 	  -5,  -15, 	   4,   -7, 	  -1,   -8
+.2byte   -4,   -8, 	  -3,  -12, 	   0,  -10, 	  -1,   -7
+.2byte   -6,   -6, 	   2,  -15, 	   3,   -7, 	  -1,   -8
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte   -2,   -4, 	  -7,  -12, 	   7,   -7, 	  -1,   -6
+.2byte   -4,   -4, 	  -6,  -10, 	   6,   -8, 	  -1,   -6
+.2byte   -4,   -4, 	  -8,  -14, 	   6,   -8, 	  -2,   -5
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte   -5,   -6, 	  -3,  -13, 	   2,   -6, 	   0,   -7
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    5,   -6, 	   3,  -13, 	  -2,   -6, 	   0,   -7
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+.2byte   -2,   -7, 	  -6,   -9, 	   8,   -3, 	   0,   -5
+.2byte   -2,   -5, 	  -6,   -8, 	   9,   -3, 	   0,   -3
+.2byte    0,   -9, 	  -7,  -16, 	   7,  -16, 	   0,  -11
+.2byte    2,   -9, 	  -9,  -12, 	   2,  -18, 	  -1,  -10
+.2byte    4,  -11, 	  -1,  -18, 	  -6,  -13, 	   0,  -12
+.2byte    1,  -12, 	   4,  -14, 	  -3,  -16, 	  -1,  -10
+.2byte    0,  -11, 	   7,  -13, 	  -7,  -13, 	   0,   -9
+.2byte    0,  -10, 	   5,  -16, 	  -5,  -14, 	   1,  -11
+.2byte   -5,  -10, 	   0,  -17, 	   5,  -12, 	  -1,  -11
+.2byte   -2,   -9, 	  -2,  -17, 	  10,  -12, 	   1,  -10
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte    0,   -3, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+.2byte    4,   -4, 	   8,  -14, 	  -6,   -8, 	   2,   -5
+.2byte    5,   -6, 	   3,  -13, 	  -2,   -6, 	   0,   -7
+.2byte    6,   -5, 	  -2,  -14, 	  -3,   -6, 	   1,   -7
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    4,  -10, 	   7,   -8, 	  -5,  -13, 	   2,   -9
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -8, 	   0,   -8
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -2,  -10, 	   5,  -13, 	  -7,   -8, 	  -1,   -9
+.2byte   -5,   -6, 	  -3,  -13, 	   2,   -6, 	   0,   -7
+.2byte   -6,   -5, 	   2,  -14, 	   3,   -6, 	  -1,   -7
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte   -4,   -4, 	  -8,  -14, 	   6,   -8, 	  -2,   -5
+.2byte    0,   -3, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte   -4,   -4, 	  -8,  -14, 	   6,   -8, 	  -2,   -5
+.2byte   -6,   -6, 	   2,  -15, 	   3,   -7, 	  -1,   -8
+.2byte   -2,  -10, 	   5,  -13, 	  -7,   -8, 	  -1,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -8, 	   0,   -8
+.2byte    3,  -10, 	   6,   -8, 	  -6,  -13, 	   1,   -9
+.2byte    5,   -6, 	  -3,  -15, 	  -4,   -7, 	   0,   -8
+.2byte    3,   -4, 	   7,  -14, 	  -7,   -8, 	   1,   -5
+.2byte    0,   -3, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -4, 	   7,  -14, 	  -7,   -8, 	   1,   -5
+.2byte    5,   -6, 	  -3,  -15, 	  -4,   -7, 	   0,   -8
+.2byte    3,  -10, 	   6,   -8, 	  -6,  -13, 	   1,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -8, 	   0,   -8
+.2byte   -2,  -10, 	   5,  -13, 	  -7,   -8, 	  -1,   -9
+.2byte   -6,   -6, 	   2,  -15, 	   3,   -7, 	  -1,   -8
+.2byte   -4,   -4, 	  -8,  -14, 	   6,   -8, 	  -2,   -5
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte    0,   -7, 	  -8,  -11, 	   8,  -11, 	   0,   -8
+.2byte    0,   -3, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+.2byte    0,  -11, 	   3,  -16, 	  -9,   -7, 	  -1,  -10
+.2byte    4,   -4, 	   8,  -14, 	  -6,   -8, 	   2,   -5
+.2byte    5,   -6, 	   3,  -13, 	  -2,   -6, 	   0,   -7
+.2byte    3,   -9, 	  -1,  -13, 	  -2,   -3, 	   0,   -7
+.2byte    6,   -5, 	  -2,  -14, 	  -3,   -6, 	   1,   -7
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    2,  -10, 	   4,   -1, 	  -6,  -11, 	   1,   -7
+.2byte    4,   -9, 	   7,   -7, 	  -5,  -12, 	   2,   -8
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte    0,  -12, 	   9,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -8, 	   0,   -8
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -3,  -10, 	   5,  -11, 	  -5,   -2, 	  -1,   -7
+.2byte   -2,   -9, 	   5,  -12, 	  -7,   -7, 	  -1,   -8
+.2byte   -5,   -6, 	  -3,  -13, 	   2,   -6, 	   0,   -7
+.2byte   -3,   -9, 	   1,  -13, 	   2,   -3, 	   0,   -7
+.2byte   -6,   -5, 	   2,  -14, 	   3,   -6, 	  -1,   -7
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte    0,  -11, 	  -3,  -16, 	   9,   -7, 	   1,  -10
+.2byte   -4,   -4, 	  -8,  -14, 	   6,   -8, 	  -2,   -5
+.2byte    0,   -3, 	  -8,   -9, 	   7,   -9, 	   0,   -5
+.2byte   -4,   -4, 	  -8,  -14, 	   6,   -8, 	  -2,   -5
+.2byte   -6,   -6, 	   2,  -15, 	   3,   -7, 	  -1,   -8
+.2byte   -2,  -10, 	   5,  -13, 	  -7,   -8, 	  -1,   -9
+.2byte    0,  -13, 	   8,   -9, 	  -8,   -8, 	   0,   -8
+.2byte    3,  -10, 	   6,   -8, 	  -6,  -13, 	   1,   -9
+.2byte    5,   -6, 	  -3,  -15, 	  -4,   -7, 	   0,   -8
+.2byte    3,   -4, 	   7,  -14, 	  -7,   -8, 	   1,   -5
+.2byte    0,   -5, 	  -8,  -11, 	   8,  -11, 	   0,   -7
+.2byte   -3,   -5, 	  -6,  -13, 	   7,   -8, 	   0,   -7
+.2byte   -5,   -6, 	  -3,  -13, 	   2,   -6, 	   0,   -7
+.2byte   -1,   -8, 	   5,  -12, 	  -7,   -8, 	   0,   -9
+.2byte    0,  -11, 	   8,  -11, 	  -7,  -11, 	   0,   -8
+.2byte    2,  -10, 	   7,   -7, 	  -5,  -13, 	   0,   -8
+.2byte    5,   -6, 	   3,  -13, 	  -2,   -6, 	   0,   -7
+.2byte    3,   -5, 	   6,  -13, 	  -7,   -8, 	   0,   -7
+sStaryuAnimTable1:
+.4byte sStaryuAnims_1_1
+.4byte sStaryuAnims_1_2
+.4byte sStaryuAnims_1_3
+.4byte sStaryuAnims_1_4
+.4byte sStaryuAnims_1_5
+.4byte sStaryuAnims_1_6
+.4byte sStaryuAnims_1_7
+.4byte sStaryuAnims_1_8
+sStaryuAnimTable2:
+.4byte sStaryuAnims_2_1
+.4byte sStaryuAnims_2_2
+.4byte sStaryuAnims_2_3
+.4byte sStaryuAnims_2_4
+.4byte sStaryuAnims_2_5
+.4byte sStaryuAnims_2_6
+.4byte sStaryuAnims_2_7
+.4byte sStaryuAnims_2_8
+sStaryuAnimTable3:
+.4byte sStaryuAnims_3_1
+.4byte sStaryuAnims_3_2
+.4byte sStaryuAnims_3_3
+.4byte sStaryuAnims_3_4
+.4byte sStaryuAnims_3_5
+.4byte sStaryuAnims_3_6
+.4byte sStaryuAnims_3_7
+.4byte sStaryuAnims_3_8
+sStaryuAnimTable4:
+.4byte sStaryuAnims_4_1
+.4byte sStaryuAnims_4_2
+.4byte sStaryuAnims_4_3
+.4byte sStaryuAnims_4_4
+.4byte sStaryuAnims_4_5
+.4byte sStaryuAnims_4_6
+.4byte sStaryuAnims_4_7
+.4byte sStaryuAnims_4_8
+sStaryuAnimTable5:
+.4byte sStaryuAnims_5_1
+.4byte sStaryuAnims_5_2
+.4byte sStaryuAnims_5_3
+.4byte sStaryuAnims_5_4
+.4byte sStaryuAnims_5_5
+.4byte sStaryuAnims_5_6
+.4byte sStaryuAnims_5_7
+.4byte sStaryuAnims_5_8
+sStaryuAnimTable6:
+.4byte sStaryuAnims_6_1
+.4byte sStaryuAnims_6_1
+.4byte sStaryuAnims_6_1
+.4byte sStaryuAnims_6_1
+.4byte sStaryuAnims_6_1
+.4byte sStaryuAnims_6_1
+.4byte sStaryuAnims_6_1
+.4byte sStaryuAnims_6_1
+sStaryuAnimTable7:
+.4byte sStaryuAnims_7_1
+.4byte sStaryuAnims_7_2
+.4byte sStaryuAnims_7_3
+.4byte sStaryuAnims_7_4
+.4byte sStaryuAnims_7_5
+.4byte sStaryuAnims_7_6
+.4byte sStaryuAnims_7_7
+.4byte sStaryuAnims_7_8
+sStaryuAnimTable8:
+.4byte sStaryuAnims_8_1
+.4byte sStaryuAnims_8_2
+.4byte sStaryuAnims_8_3
+.4byte sStaryuAnims_8_4
+.4byte sStaryuAnims_8_5
+.4byte sStaryuAnims_8_6
+.4byte sStaryuAnims_8_7
+.4byte sStaryuAnims_8_8
+sStaryuAnimTable9:
+.4byte sStaryuAnims_9_1
+.4byte sStaryuAnims_9_2
+.4byte sStaryuAnims_9_3
+.4byte sStaryuAnims_9_4
+.4byte sStaryuAnims_9_5
+.4byte sStaryuAnims_9_6
+.4byte sStaryuAnims_9_7
+.4byte sStaryuAnims_9_8
+sStaryuAnimTable10:
+.4byte sStaryuAnims_10_1
+.4byte sStaryuAnims_10_2
+.4byte sStaryuAnims_10_3
+.4byte sStaryuAnims_10_4
+.4byte sStaryuAnims_10_5
+.4byte sStaryuAnims_10_6
+.4byte sStaryuAnims_10_7
+.4byte sStaryuAnims_10_8
+sStaryuAnimTable11:
+.4byte sStaryuAnims_11_1
+.4byte sStaryuAnims_11_2
+.4byte sStaryuAnims_11_3
+.4byte sStaryuAnims_11_4
+.4byte sStaryuAnims_11_5
+.4byte sStaryuAnims_11_6
+.4byte sStaryuAnims_11_7
+.4byte sStaryuAnims_11_8
+sStaryuAnimTable12:
+.4byte sStaryuAnims_12_1
+.4byte sStaryuAnims_12_2
+.4byte sStaryuAnims_12_3
+.4byte sStaryuAnims_12_4
+.4byte sStaryuAnims_12_5
+.4byte sStaryuAnims_12_6
+.4byte sStaryuAnims_12_7
+.4byte sStaryuAnims_12_8
+sStaryuAnimTable13:
+.4byte sStaryuAnims_13_1
+.4byte sStaryuAnims_13_2
+.4byte sStaryuAnims_13_3
+.4byte sStaryuAnims_13_4
+.4byte sStaryuAnims_13_5
+.4byte sStaryuAnims_13_6
+.4byte sStaryuAnims_13_7
+.4byte sStaryuAnims_13_8
+sAxAnimationsStaryu:
+.4byte sStaryuAnimTable1
+.4byte sStaryuAnimTable2
+.4byte sStaryuAnimTable3
+.4byte sStaryuAnimTable4
+.4byte sStaryuAnimTable5
+.4byte sStaryuAnimTable6
+.4byte sStaryuAnimTable7
+.4byte sStaryuAnimTable8
+.4byte sStaryuAnimTable9
+.4byte sStaryuAnimTable10
+.4byte sStaryuAnimTable11
+.4byte sStaryuAnimTable12
+.4byte sStaryuAnimTable13
+sAxSpritesStaryu:
+.4byte sStaryuSprites1
+.4byte sStaryuSprites2
+.4byte sStaryuSprites3
+.4byte sStaryuSprites4
+.4byte sStaryuSprites5
+.4byte sStaryuSprites6
+.4byte sStaryuSprites7
+.4byte sStaryuSprites8
+.4byte sStaryuSprites9
+.4byte sStaryuSprites10
+.4byte sStaryuSprites11
+.4byte sStaryuSprites12
+.4byte sStaryuSprites13
+.4byte sStaryuSprites14
+.4byte sStaryuSprites15
+.4byte sStaryuSprites16
+.4byte sStaryuSprites17
+.4byte sStaryuSprites18
+.4byte sStaryuSprites19
+.4byte sStaryuSprites20
+.4byte sStaryuSprites21
+.4byte sStaryuSprites22
+.4byte sStaryuSprites23
+.4byte sStaryuSprites24
+.4byte sStaryuSprites25
+.4byte sStaryuSprites26
+.4byte sStaryuSprites27
+.4byte sStaryuSprites28
+.4byte sStaryuSprites29
+.4byte sStaryuSprites30
+.4byte sStaryuSprites31
+.4byte sStaryuSprites32
+.4byte sStaryuSprites33
+.4byte sStaryuSprites34
+.4byte sStaryuSprites35
+.4byte sStaryuSprites36
+.4byte sStaryuSprites37
+.4byte sStaryuSprites38
+.4byte sStaryuSprites39
+.4byte sStaryuSprites40
+.4byte sStaryuSprites41
+sAxMainStaryu:
+ax_main sAxPosesStaryu, sAxAnimationsStaryu, 13, sAxSpritesStaryu, sAxPositionsStaryu

--- a/data/ax/statue.inc
+++ b/data/ax/statue.inc
@@ -1,0 +1,262 @@
+.global gAxStatue
+gAxStatue:
+ax_siro sAxMainStatue
+sStatuePose1:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose2:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose3:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose4:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose5:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose6:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose7:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose8:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose9:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose10:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose11:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose12:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+sStatuePose13:
+ax_pose 0, 0x01e6, 0x84f0, 0xdc00
+ax_pose_terminator
+.align 2
+sStatueAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_2_1:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_3_1:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_4_1:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_5_1:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_6_1:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_7_1:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_8_1:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_9_1:
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_10_1:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_11_1:
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_12_1:
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sStatueAnims_13_1:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim_terminator
+sStatueGfx1:
+.incbin "baserom.gba", 0x1659D1C, 0x200
+sStatueSprites1:
+ax_sprite sStatueGfx1, 0x200
+ax_sprite_terminator
+sAxPosesStatue:
+.4byte sStatuePose1
+.4byte sStatuePose2
+.4byte sStatuePose3
+.4byte sStatuePose4
+.4byte sStatuePose5
+.4byte sStatuePose6
+.4byte sStatuePose7
+.4byte sStatuePose8
+.4byte sStatuePose9
+.4byte sStatuePose10
+.4byte sStatuePose11
+.4byte sStatuePose12
+.4byte sStatuePose13
+sAxPositionsStatue:
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+.2byte   -1,  -11, 	 -12,  -11, 	  12,  -11, 	  -1,   -6
+sStatueAnimTable1:
+.4byte sStatueAnims_1_1
+.4byte sStatueAnims_1_1
+.4byte sStatueAnims_1_1
+.4byte sStatueAnims_1_1
+.4byte sStatueAnims_1_1
+.4byte sStatueAnims_1_1
+.4byte sStatueAnims_1_1
+.4byte sStatueAnims_1_1
+sStatueAnimTable2:
+.4byte sStatueAnims_2_1
+.4byte sStatueAnims_2_1
+.4byte sStatueAnims_2_1
+.4byte sStatueAnims_2_1
+.4byte sStatueAnims_2_1
+.4byte sStatueAnims_2_1
+.4byte sStatueAnims_2_1
+.4byte sStatueAnims_2_1
+sStatueAnimTable3:
+.4byte sStatueAnims_3_1
+.4byte sStatueAnims_3_1
+.4byte sStatueAnims_3_1
+.4byte sStatueAnims_3_1
+.4byte sStatueAnims_3_1
+.4byte sStatueAnims_3_1
+.4byte sStatueAnims_3_1
+.4byte sStatueAnims_3_1
+sStatueAnimTable4:
+.4byte sStatueAnims_4_1
+.4byte sStatueAnims_4_1
+.4byte sStatueAnims_4_1
+.4byte sStatueAnims_4_1
+.4byte sStatueAnims_4_1
+.4byte sStatueAnims_4_1
+.4byte sStatueAnims_4_1
+.4byte sStatueAnims_4_1
+sStatueAnimTable5:
+.4byte sStatueAnims_5_1
+.4byte sStatueAnims_5_1
+.4byte sStatueAnims_5_1
+.4byte sStatueAnims_5_1
+.4byte sStatueAnims_5_1
+.4byte sStatueAnims_5_1
+.4byte sStatueAnims_5_1
+.4byte sStatueAnims_5_1
+sStatueAnimTable6:
+.4byte sStatueAnims_6_1
+.4byte sStatueAnims_6_1
+.4byte sStatueAnims_6_1
+.4byte sStatueAnims_6_1
+.4byte sStatueAnims_6_1
+.4byte sStatueAnims_6_1
+.4byte sStatueAnims_6_1
+.4byte sStatueAnims_6_1
+sStatueAnimTable7:
+.4byte sStatueAnims_7_1
+.4byte sStatueAnims_7_1
+.4byte sStatueAnims_7_1
+.4byte sStatueAnims_7_1
+.4byte sStatueAnims_7_1
+.4byte sStatueAnims_7_1
+.4byte sStatueAnims_7_1
+.4byte sStatueAnims_7_1
+sStatueAnimTable8:
+.4byte sStatueAnims_8_1
+.4byte sStatueAnims_8_1
+.4byte sStatueAnims_8_1
+.4byte sStatueAnims_8_1
+.4byte sStatueAnims_8_1
+.4byte sStatueAnims_8_1
+.4byte sStatueAnims_8_1
+.4byte sStatueAnims_8_1
+sStatueAnimTable9:
+.4byte sStatueAnims_9_1
+.4byte sStatueAnims_9_1
+.4byte sStatueAnims_9_1
+.4byte sStatueAnims_9_1
+.4byte sStatueAnims_9_1
+.4byte sStatueAnims_9_1
+.4byte sStatueAnims_9_1
+.4byte sStatueAnims_9_1
+sStatueAnimTable10:
+.4byte sStatueAnims_10_1
+.4byte sStatueAnims_10_1
+.4byte sStatueAnims_10_1
+.4byte sStatueAnims_10_1
+.4byte sStatueAnims_10_1
+.4byte sStatueAnims_10_1
+.4byte sStatueAnims_10_1
+.4byte sStatueAnims_10_1
+sStatueAnimTable11:
+.4byte sStatueAnims_11_1
+.4byte sStatueAnims_11_1
+.4byte sStatueAnims_11_1
+.4byte sStatueAnims_11_1
+.4byte sStatueAnims_11_1
+.4byte sStatueAnims_11_1
+.4byte sStatueAnims_11_1
+.4byte sStatueAnims_11_1
+sStatueAnimTable12:
+.4byte sStatueAnims_12_1
+.4byte sStatueAnims_12_1
+.4byte sStatueAnims_12_1
+.4byte sStatueAnims_12_1
+.4byte sStatueAnims_12_1
+.4byte sStatueAnims_12_1
+.4byte sStatueAnims_12_1
+.4byte sStatueAnims_12_1
+sStatueAnimTable13:
+.4byte sStatueAnims_13_1
+.4byte sStatueAnims_13_1
+.4byte sStatueAnims_13_1
+.4byte sStatueAnims_13_1
+.4byte sStatueAnims_13_1
+.4byte sStatueAnims_13_1
+.4byte sStatueAnims_13_1
+.4byte sStatueAnims_13_1
+sAxAnimationsStatue:
+.4byte sStatueAnimTable1
+.4byte sStatueAnimTable2
+.4byte sStatueAnimTable3
+.4byte sStatueAnimTable4
+.4byte sStatueAnimTable5
+.4byte sStatueAnimTable6
+.4byte sStatueAnimTable7
+.4byte sStatueAnimTable8
+.4byte sStatueAnimTable9
+.4byte sStatueAnimTable10
+.4byte sStatueAnimTable11
+.4byte sStatueAnimTable12
+.4byte sStatueAnimTable13
+sAxSpritesStatue:
+.4byte sStatueSprites1
+sAxMainStatue:
+ax_main sAxPosesStatue, sAxAnimationsStatue, 13, sAxSpritesStatue, sAxPositionsStatue

--- a/data/ax/steelix.inc
+++ b/data/ax/steelix.inc
@@ -1,0 +1,3568 @@
+.global gAxSteelix
+gAxSteelix:
+ax_siro sAxMainSteelix
+sSteelixPose1:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose2:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose3:
+ax_pose 2, 0x01c3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose4:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose5:
+ax_pose 4, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose6:
+ax_pose 5, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose7:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose8:
+ax_pose 7, 0x01c6, 0x9106, 0x5c00
+ax_pose 8, 0x81c6, 0x90f6, 0x5c10
+ax_pose 9, 0x01e6, 0x90e6, 0x5c18
+ax_pose 10, 0x81e6, 0x10de, 0x5c28
+ax_pose_terminator
+sSteelixPose9:
+ax_pose 11, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose10:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose11:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose12:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose13:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose14:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose15:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose16:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose17:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose18:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose19:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose20:
+ax_pose 7, 0x01c6, 0x80da, 0x5c00
+ax_pose 8, 0x81c6, 0x80fa, 0x5c10
+ax_pose 9, 0x01e6, 0x80fa, 0x5c18
+ax_pose 10, 0x81e6, 0x011a, 0x5c28
+ax_pose_terminator
+sSteelixPose21:
+ax_pose 11, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose22:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose23:
+ax_pose 4, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose24:
+ax_pose 5, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose25:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose26:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose27:
+ax_pose 2, 0x01c3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose28:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose29:
+ax_pose 4, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose30:
+ax_pose 5, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose31:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose32:
+ax_pose 7, 0x01c6, 0x9106, 0x5c00
+ax_pose 8, 0x81c6, 0x90f6, 0x5c10
+ax_pose 9, 0x01e6, 0x90e6, 0x5c18
+ax_pose 10, 0x81e6, 0x10de, 0x5c28
+ax_pose_terminator
+sSteelixPose33:
+ax_pose 11, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose34:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose35:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose36:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose37:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose38:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose39:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose40:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose41:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose42:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose43:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose44:
+ax_pose 7, 0x01c6, 0x80da, 0x5c00
+ax_pose 8, 0x81c6, 0x80fa, 0x5c10
+ax_pose 9, 0x01e6, 0x80fa, 0x5c18
+ax_pose 10, 0x81e6, 0x011a, 0x5c28
+ax_pose_terminator
+sSteelixPose45:
+ax_pose 11, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose46:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose47:
+ax_pose 4, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose48:
+ax_pose 5, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose49:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose50:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose51:
+ax_pose 2, 0x01c3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose52:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose53:
+ax_pose 4, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose54:
+ax_pose 5, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose55:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose56:
+ax_pose 7, 0x01c6, 0x9106, 0x5c00
+ax_pose 8, 0x81c6, 0x90f6, 0x5c10
+ax_pose 9, 0x01e6, 0x90e6, 0x5c18
+ax_pose 10, 0x81e6, 0x10de, 0x5c28
+ax_pose_terminator
+sSteelixPose57:
+ax_pose 11, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose58:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose59:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose60:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose61:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose62:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose63:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose64:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose65:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose66:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose67:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose68:
+ax_pose 7, 0x01c6, 0x80da, 0x5c00
+ax_pose 8, 0x81c6, 0x80fa, 0x5c10
+ax_pose 9, 0x01e6, 0x80fa, 0x5c18
+ax_pose 10, 0x81e6, 0x011a, 0x5c28
+ax_pose_terminator
+sSteelixPose69:
+ax_pose 11, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose70:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose71:
+ax_pose 4, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose72:
+ax_pose 5, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose73:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose74:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose75:
+ax_pose 2, 0x01c3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose76:
+ax_pose 18, 0x81c2, 0xc0ec, 0x5c00
+ax_pose 19, 0x81e2, 0x810c, 0x5c20
+ax_pose_terminator
+sSteelixPose77:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose78:
+ax_pose 4, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose79:
+ax_pose 5, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose80:
+ax_pose 20, 0x41df, 0xd0e5, 0x5c00
+ax_pose 21, 0x81de, 0x90d5, 0x5c20
+ax_pose_terminator
+sSteelixPose81:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose82:
+ax_pose 7, 0x01c6, 0x9106, 0x5c00
+ax_pose 8, 0x81c6, 0x90f6, 0x5c10
+ax_pose 9, 0x01e6, 0x90e6, 0x5c18
+ax_pose 10, 0x81e6, 0x10de, 0x5c28
+ax_pose_terminator
+sSteelixPose83:
+ax_pose 11, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose84:
+ax_pose 22, 0x41d1, 0x90ea, 0x5c00
+ax_pose 23, 0x41d1, 0x910a, 0x5c08
+ax_pose 24, 0x41f1, 0x90ca, 0x5c10
+ax_pose 25, 0x01e8, 0x50d1, 0x5c18
+ax_pose 26, 0x41e1, 0xd0ea, 0x5c1c
+ax_pose_terminator
+sSteelixPose85:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose86:
+ax_pose 13, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose87:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose88:
+ax_pose 27, 0x01c7, 0xd0e2, 0x5c00
+ax_pose_terminator
+sSteelixPose89:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose90:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose91:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose92:
+ax_pose 28, 0x81c4, 0xc0ee, 0x5c00
+ax_pose 29, 0x4204, 0x00f5, 0x5c20
+ax_pose 30, 0x01e4, 0x010e, 0x5c22
+ax_pose 31, 0x01d2, 0x010e, 0x5c23
+ax_pose_terminator
+sSteelixPose93:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose94:
+ax_pose 13, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose95:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose96:
+ax_pose 27, 0x01c7, 0xc0de, 0x5c00
+ax_pose_terminator
+sSteelixPose97:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose98:
+ax_pose 7, 0x01c6, 0x80da, 0x5c00
+ax_pose 8, 0x81c6, 0x80fa, 0x5c10
+ax_pose 9, 0x01e6, 0x80fa, 0x5c18
+ax_pose 10, 0x81e6, 0x011a, 0x5c28
+ax_pose_terminator
+sSteelixPose99:
+ax_pose 11, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose100:
+ax_pose 22, 0x41d1, 0x80f6, 0x5c00
+ax_pose 23, 0x41d1, 0x80d6, 0x5c08
+ax_pose 24, 0x41f1, 0x8116, 0x5c10
+ax_pose 25, 0x01e8, 0x411f, 0x5c18
+ax_pose 26, 0x41e1, 0xc0d6, 0x5c1c
+ax_pose_terminator
+sSteelixPose101:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose102:
+ax_pose 4, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose103:
+ax_pose 5, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose104:
+ax_pose 20, 0x41df, 0xc0db, 0x5c00
+ax_pose 21, 0x81de, 0x811b, 0x5c20
+ax_pose_terminator
+sSteelixPose105:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose106:
+ax_pose 32, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose107:
+ax_pose 33, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose108:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose109:
+ax_pose 34, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose110:
+ax_pose 35, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose111:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose112:
+ax_pose 36, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose113:
+ax_pose 37, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose114:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose115:
+ax_pose 38, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose116:
+ax_pose 39, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose117:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose118:
+ax_pose 40, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose119:
+ax_pose 41, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose120:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose121:
+ax_pose 38, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose122:
+ax_pose 39, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose123:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose124:
+ax_pose 36, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose125:
+ax_pose 37, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose126:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose127:
+ax_pose 34, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose128:
+ax_pose 35, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose129:
+ax_pose 42, 0x81e5, 0x810c, 0x5c00
+ax_pose 43, 0x01e5, 0x80ec, 0x5c08
+ax_pose 44, 0x4205, 0x40ec, 0x5c18
+ax_pose_terminator
+sSteelixPose130:
+ax_pose 45, 0x01e5, 0x80ec, 0x5c00
+ax_pose 46, 0x81e5, 0x810c, 0x5c10
+ax_pose 47, 0x4205, 0x40ec, 0x5c18
+ax_pose_terminator
+sSteelixPose131:
+ax_pose 48, 0x01e5, 0x80f0, 0x5c00
+ax_pose 49, 0x41c5, 0xc0e0, 0x5c10
+ax_pose_terminator
+sSteelixPose132:
+ax_pose 50, 0x01c4, 0xd0e4, 0x5c00
+ax_pose_terminator
+sSteelixPose133:
+ax_pose 51, 0x01c6, 0xd0e4, 0x5c00
+ax_pose_terminator
+sSteelixPose134:
+ax_pose 52, 0x41c5, 0xd0e2, 0x5c00
+ax_pose 53, 0x01e5, 0x90ec, 0x5c20
+ax_pose_terminator
+sSteelixPose135:
+ax_pose 54, 0x01e5, 0x80f0, 0x5c00
+ax_pose 55, 0x0205, 0x00fd, 0x5c10
+ax_pose 56, 0x41c5, 0xc0e0, 0x5c11
+ax_pose_terminator
+sSteelixPose136:
+ax_pose 52, 0x41c5, 0xc0de, 0x5c00
+ax_pose 53, 0x01e5, 0x80f4, 0x5c20
+ax_pose_terminator
+sSteelixPose137:
+ax_pose 51, 0x01c6, 0xc0dc, 0x5c00
+ax_pose_terminator
+sSteelixPose138:
+ax_pose 50, 0x01c4, 0xc0dc, 0x5c00
+ax_pose_terminator
+sSteelixPose139:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose140:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose141:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose142:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose143:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose144:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose145:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose146:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose147:
+ax_pose 18, 0x81c2, 0xc0ec, 0x5c00
+ax_pose 19, 0x81e2, 0x810c, 0x5c20
+ax_pose_terminator
+sSteelixPose148:
+ax_pose 20, 0x41db, 0xc0db, 0x5c00
+ax_pose 21, 0x81da, 0x811b, 0x5c20
+ax_pose_terminator
+sSteelixPose149:
+ax_pose 22, 0x41d1, 0x80f6, 0x5c00
+ax_pose 23, 0x41d1, 0x80d6, 0x5c08
+ax_pose 24, 0x41f1, 0x8116, 0x5c10
+ax_pose 25, 0x01e8, 0x411f, 0x5c18
+ax_pose 26, 0x41e1, 0xc0d6, 0x5c1c
+ax_pose_terminator
+sSteelixPose150:
+ax_pose 27, 0x01c7, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose151:
+ax_pose 28, 0x81c6, 0xc0ee, 0x5c00
+ax_pose 29, 0x4206, 0x00f5, 0x5c20
+ax_pose 30, 0x01e6, 0x010e, 0x5c22
+ax_pose 31, 0x01d4, 0x010e, 0x5c23
+ax_pose_terminator
+sSteelixPose152:
+ax_pose 27, 0x01c7, 0xd0e1, 0x5c00
+ax_pose_terminator
+sSteelixPose153:
+ax_pose 22, 0x41d1, 0x90eb, 0x5c00
+ax_pose 23, 0x41d1, 0x910b, 0x5c08
+ax_pose 24, 0x41f1, 0x90cb, 0x5c10
+ax_pose 25, 0x01e8, 0x50d2, 0x5c18
+ax_pose 26, 0x41e1, 0xd0eb, 0x5c1c
+ax_pose_terminator
+sSteelixPose154:
+ax_pose 20, 0x41db, 0xd0e5, 0x5c00
+ax_pose 21, 0x81da, 0x90d5, 0x5c20
+ax_pose_terminator
+sSteelixPose155:
+ax_pose 2, 0x01c5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose156:
+ax_pose 5, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose157:
+ax_pose 11, 0x01c4, 0xd0e1, 0x5c00
+ax_pose_terminator
+sSteelixPose158:
+ax_pose 14, 0x01c6, 0xd0e2, 0x5c00
+ax_pose_terminator
+sSteelixPose159:
+ax_pose 17, 0x01c8, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose160:
+ax_pose 14, 0x01c6, 0xc0df, 0x5c00
+ax_pose_terminator
+sSteelixPose161:
+ax_pose 11, 0x01c4, 0xc0de, 0x5c00
+ax_pose_terminator
+sSteelixPose162:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose163:
+ax_pose 4, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose164:
+ax_pose 5, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose165:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose166:
+ax_pose 1, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose167:
+ax_pose 2, 0x01c3, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose168:
+ax_pose 18, 0x81c2, 0xc0ec, 0x5c00
+ax_pose 19, 0x81e2, 0x810c, 0x5c20
+ax_pose_terminator
+sSteelixPose169:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose170:
+ax_pose 4, 0x01c4, 0xd0de, 0x5c00
+ax_pose_terminator
+sSteelixPose171:
+ax_pose 5, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose172:
+ax_pose 20, 0x41df, 0xd0e4, 0x5c00
+ax_pose 21, 0x81de, 0x90d4, 0x5c20
+ax_pose_terminator
+sSteelixPose173:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose174:
+ax_pose 7, 0x01c6, 0x9106, 0x5c00
+ax_pose 8, 0x81c6, 0x90f6, 0x5c10
+ax_pose 9, 0x01e6, 0x90e6, 0x5c18
+ax_pose 10, 0x81e6, 0x10de, 0x5c28
+ax_pose_terminator
+sSteelixPose175:
+ax_pose 11, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose176:
+ax_pose 22, 0x41d1, 0x90ec, 0x5c00
+ax_pose 23, 0x41d1, 0x910c, 0x5c08
+ax_pose 24, 0x41f1, 0x90cc, 0x5c10
+ax_pose 25, 0x01e8, 0x50d3, 0x5c18
+ax_pose 26, 0x41e1, 0xd0ec, 0x5c1c
+ax_pose_terminator
+sSteelixPose177:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose178:
+ax_pose 13, 0x01c6, 0xd0df, 0x5c00
+ax_pose_terminator
+sSteelixPose179:
+ax_pose 14, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose180:
+ax_pose 27, 0x01c7, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose181:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose182:
+ax_pose 16, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose183:
+ax_pose 17, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose184:
+ax_pose 28, 0x81c4, 0xc0ee, 0x5c00
+ax_pose 29, 0x4204, 0x00f5, 0x5c20
+ax_pose 30, 0x01e4, 0x010e, 0x5c22
+ax_pose 31, 0x01d2, 0x010e, 0x5c23
+ax_pose_terminator
+sSteelixPose185:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose186:
+ax_pose 13, 0x01c6, 0xc0e1, 0x5c00
+ax_pose_terminator
+sSteelixPose187:
+ax_pose 14, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose188:
+ax_pose 27, 0x01c7, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose189:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose190:
+ax_pose 7, 0x01c6, 0x80da, 0x5c00
+ax_pose 8, 0x81c6, 0x80fa, 0x5c10
+ax_pose 9, 0x01e6, 0x80fa, 0x5c18
+ax_pose 10, 0x81e6, 0x011a, 0x5c28
+ax_pose_terminator
+sSteelixPose191:
+ax_pose 11, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose192:
+ax_pose 22, 0x41d1, 0x80f4, 0x5c00
+ax_pose 23, 0x41d1, 0x80d4, 0x5c08
+ax_pose 24, 0x41f1, 0x8114, 0x5c10
+ax_pose 25, 0x01e8, 0x411d, 0x5c18
+ax_pose 26, 0x41e1, 0xc0d4, 0x5c1c
+ax_pose_terminator
+sSteelixPose193:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose194:
+ax_pose 4, 0x01c4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sSteelixPose195:
+ax_pose 5, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose196:
+ax_pose 20, 0x41df, 0xc0dc, 0x5c00
+ax_pose 21, 0x81de, 0x811c, 0x5c20
+ax_pose_terminator
+sSteelixPose197:
+ax_pose 32, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose198:
+ax_pose 34, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose199:
+ax_pose 36, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose200:
+ax_pose 38, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose201:
+ax_pose 40, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose202:
+ax_pose 38, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose203:
+ax_pose 36, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose204:
+ax_pose 34, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose205:
+ax_pose 0, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose206:
+ax_pose 3, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose207:
+ax_pose 6, 0x01c4, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose208:
+ax_pose 12, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose209:
+ax_pose 15, 0x01c6, 0xc0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose210:
+ax_pose 12, 0x01c6, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose211:
+ax_pose 6, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+sSteelixPose212:
+ax_pose 3, 0x01c4, 0xd0e0, 0x5c00
+ax_pose_terminator
+.align 2
+sSteelixAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 25, 0, 25,
+ax_anim 2, 1, 25, 1, 25, 1, 25,
+ax_anim 2, 0, 25, 0, 25, 0, 25,
+ax_anim 2, 0, 25, 1, 25, 1, 25,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sSteelixAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 23, 23, 23, 23,
+ax_anim 2, 1, 28, 22, 24, 22, 24,
+ax_anim 2, 0, 28, 23, 23, 23, 23,
+ax_anim 2, 0, 28, 22, 24, 22, 24,
+ax_anim 2, 0, 27, 12, 12, 12, 12,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sSteelixAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 1, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 31, 23, 0, 23, 0,
+ax_anim 2, 0, 31, 23, 1, 23, 1,
+ax_anim 2, 0, 30, 12, 0, 12, 0,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSteelixAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 34, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 22, -20, 22, -20,
+ax_anim 2, 1, 34, 21, -21, 21, -21,
+ax_anim 2, 0, 34, 22, -20, 22, -20,
+ax_anim 2, 0, 34, 21, -21, 21, -21,
+ax_anim 2, 0, 33, 12, -12, 12, -12,
+ax_anim 2, 0, 35, 6, -6, 6, -6,
+ax_anim_terminator
+sSteelixAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 1, 37, -1, -20, 0, -21,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 0, 37, -1, -20, 0, -21,
+ax_anim 2, 0, 36, 0, -12, 0, -6,
+ax_anim 2, 0, 38, 0, -6, 0, -6,
+ax_anim_terminator
+sSteelixAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 40, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -22, -20, -22, -20,
+ax_anim 2, 1, 40, -21, -21, -21, -21,
+ax_anim 2, 0, 40, -22, -20, -22, -20,
+ax_anim 2, 0, 40, -21, -21, -21, -21,
+ax_anim 2, 0, 39, -12, -12, -12, -12,
+ax_anim 2, 0, 41, -6, -6, -6, -6,
+ax_anim_terminator
+sSteelixAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 1, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 43, -23, 0, -23, 0,
+ax_anim 2, 0, 43, -23, 1, -23, 1,
+ax_anim 2, 0, 42, -12, 0, -12, 0,
+ax_anim 2, 0, 44, -6, 0, -6, 0,
+ax_anim_terminator
+sSteelixAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -23, 23, -23, 23,
+ax_anim 2, 1, 46, -22, 24, -22, 24,
+ax_anim 2, 0, 46, -23, 23, -23, 23,
+ax_anim 2, 0, 46, -22, 24, -22, 24,
+ax_anim 2, 0, 45, -12, 12, -12, 12,
+ax_anim 2, 0, 47, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSteelixAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 6, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 25, 0, 25,
+ax_anim 2, 1, 49, 1, 25, 1, 25,
+ax_anim 2, 0, 49, 0, 25, 0, 25,
+ax_anim 2, 0, 49, 1, 25, 1, 25,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 6, 0, 6,
+ax_anim_terminator
+sSteelixAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 23, 23, 23, 23,
+ax_anim 2, 1, 52, 22, 24, 22, 24,
+ax_anim 2, 0, 52, 23, 23, 23, 23,
+ax_anim 2, 0, 52, 22, 24, 22, 24,
+ax_anim 2, 0, 51, 12, 12, 12, 12,
+ax_anim 2, 0, 53, 6, 6, 6, 6,
+ax_anim_terminator
+sSteelixAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 6, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 1, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 55, 23, 0, 23, 0,
+ax_anim 2, 0, 55, 23, 1, 23, 1,
+ax_anim 2, 0, 54, 12, 0, 12, 0,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim_terminator
+sSteelixAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 6, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 4, -4, 4, -4,
+ax_anim 1, 0, 58, 10, -10, 10, -10,
+ax_anim 2, 0, 58, 22, -20, 22, -20,
+ax_anim 2, 1, 58, 21, -21, 21, -21,
+ax_anim 2, 0, 58, 22, -20, 22, -20,
+ax_anim 2, 0, 58, 21, -21, 21, -21,
+ax_anim 2, 0, 57, 12, -12, 12, -12,
+ax_anim 2, 0, 59, 6, -6, 6, -6,
+ax_anim_terminator
+sSteelixAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 6, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -10, 0, -10,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 1, 61, -1, -20, 0, -21,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 0, 61, -1, -20, 0, -21,
+ax_anim 2, 0, 60, 0, -12, 0, -6,
+ax_anim 2, 0, 62, 0, -6, 0, -6,
+ax_anim_terminator
+sSteelixAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 6, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 64, -4, -4, -4, -4,
+ax_anim 1, 0, 64, -10, -10, -10, -10,
+ax_anim 2, 0, 64, -22, -20, -22, -20,
+ax_anim 2, 1, 64, -21, -21, -21, -21,
+ax_anim 2, 0, 64, -22, -20, -22, -20,
+ax_anim 2, 0, 64, -21, -21, -21, -21,
+ax_anim 2, 0, 63, -12, -12, -12, -12,
+ax_anim 2, 0, 65, -6, -6, -6, -6,
+ax_anim_terminator
+sSteelixAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 6, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 1, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 67, -23, 0, -23, 0,
+ax_anim 2, 0, 67, -23, 1, -23, 1,
+ax_anim 2, 0, 66, -12, 0, -12, 0,
+ax_anim 2, 0, 68, -6, 0, -6, 0,
+ax_anim_terminator
+sSteelixAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 6, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -23, 23, -23, 23,
+ax_anim 2, 1, 70, -22, 24, -22, 24,
+ax_anim 2, 0, 70, -23, 23, -23, 23,
+ax_anim 2, 0, 70, -22, 24, -22, 24,
+ax_anim 2, 0, 69, -12, 12, -12, 12,
+ax_anim 2, 0, 71, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSteelixAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 2, 0, 74, 0, -5, 0, -5,
+ax_anim 6, 2, 74, 0, -6, 0, -6,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 2, 1, 75, -1, 3, -1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, -1, 3, -1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, -1, 3, -1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, -1, 3, -1, 3,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim_terminator
+sSteelixAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 2, 0, 78, -5, -5, -5, -5,
+ax_anim 6, 2, 78, -6, -6, -6, -6,
+ax_anim 2, 0, 79, 3, 3, 3, 1,
+ax_anim 2, 1, 79, 2, 4, 2, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 1,
+ax_anim 2, 0, 79, 2, 4, 2, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 1,
+ax_anim 2, 0, 79, 2, 4, 2, 2,
+ax_anim 2, 0, 79, 3, 3, 3, 1,
+ax_anim 2, 0, 79, 2, 4, 2, 2,
+ax_anim 2, 0, 76, 3, 3, 3, 1,
+ax_anim_terminator
+sSteelixAnims_4_3:
+ax_anim 2, 0, 80, -2, 0, -2, 0,
+ax_anim 2, 0, 82, -5, 0, -5, 0,
+ax_anim 6, 2, 82, -6, 0, -6, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 1, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim_terminator
+sSteelixAnims_4_4:
+ax_anim 2, 0, 84, -2, 2, -2, 2,
+ax_anim 2, 0, 86, -5, 5, -5, 5,
+ax_anim 6, 2, 86, -6, 6, -6, 6,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 1, 87, 2, -4, 2, -4,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 2, -4, 2, -4,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 2, -4, 2, -4,
+ax_anim 2, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 2, -4, 2, -4,
+ax_anim 2, 0, 84, 3, -3, 3, -3,
+ax_anim_terminator
+sSteelixAnims_4_5:
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 6, 2, 90, 0, 6, 0, 6,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 1, 91, -1, -3, -1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, -1, -3, -1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, -1, -3, -1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, -1, -3, -1, -3,
+ax_anim 2, 0, 88, 0, -3, 0, -3,
+ax_anim_terminator
+sSteelixAnims_4_6:
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 0, 94, 5, 5, 5, 5,
+ax_anim 6, 2, 94, 6, 6, 6, 6,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 1, 95, -2, -4, -2, -4,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -2, -4, -2, -4,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -2, -4, -2, -4,
+ax_anim 2, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -2, -4, -2, -4,
+ax_anim 2, 0, 92, -3, -3, -3, -3,
+ax_anim_terminator
+sSteelixAnims_4_7:
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 5, 0, 5, 0,
+ax_anim 6, 2, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 1, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -3, -1, -3, -1,
+ax_anim 2, 0, 96, -3, 0, -3, 0,
+ax_anim_terminator
+sSteelixAnims_4_8:
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim 2, 0, 102, 5, -5, 5, -5,
+ax_anim 6, 2, 102, 6, -6, 6, -6,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 1, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 100, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sSteelixAnims_5_1:
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 8, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 8, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_5_2:
+ax_anim 8, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 8, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 8, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_5_3:
+ax_anim 8, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 8, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 8, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_5_4:
+ax_anim 8, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 8, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 8, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_5_5:
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 8, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_5_6:
+ax_anim 8, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 8, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 8, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_5_7:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_5_8:
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sSteelixAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sSteelixAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sSteelixAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sSteelixAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sSteelixAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sSteelixAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sSteelixAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSteelixAnims_8_1:
+ax_anim 18, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, -1, 0, 0,
+ax_anim 18, 0, 138, 0, -2, 0, 0,
+ax_anim 8, 0, 138, 0, -1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_8_2:
+ax_anim 18, 0, 145, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, -1, 0, 0,
+ax_anim 18, 0, 145, 0, -2, 0, 0,
+ax_anim 8, 0, 145, 0, -1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_8_3:
+ax_anim 18, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, -1, 0, 0,
+ax_anim 18, 0, 144, 0, -2, 0, 0,
+ax_anim 8, 0, 144, 0, -1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_8_4:
+ax_anim 18, 0, 143, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, -1, 0, 0,
+ax_anim 18, 0, 143, 0, -2, 0, 0,
+ax_anim 8, 0, 143, 0, -1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_8_5:
+ax_anim 18, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, -1, 0, 0,
+ax_anim 18, 0, 142, 0, -2, 0, 0,
+ax_anim 8, 0, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_8_6:
+ax_anim 18, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, -1, 0, 0,
+ax_anim 18, 0, 141, 0, -2, 0, 0,
+ax_anim 8, 0, 141, 0, -1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_8_7:
+ax_anim 18, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, -1, 0, 0,
+ax_anim 18, 0, 140, 0, -2, 0, 0,
+ax_anim 8, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_8_8:
+ax_anim 18, 0, 139, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, -1, 0, 0,
+ax_anim 18, 0, 139, 0, -2, 0, 0,
+ax_anim 8, 0, 139, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 15, 7, 15,
+ax_anim 3, 0, 150, 0, 18, 0, 18,
+ax_anim 2, 3, 151, -7, 15, -7, 15,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 17, 10, 17, 10,
+ax_anim 3, 0, 149, 14, 19, 14, 19,
+ax_anim 2, 3, 150, 11, 19, 11, 19,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 2, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 14, -5, 12, -5,
+ax_anim 3, 0, 148, 12, -2, 14, -2,
+ax_anim 2, 3, 149, 14, 4, 12, 4,
+ax_anim 2, 0, 150, 10, 5, 10, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 1, -15, 1, -15,
+ax_anim 2, 0, 146, 8, -17, 8, -17,
+ax_anim 3, 0, 147, 15, -15, 15, -15,
+ax_anim 2, 3, 148, 17, -12, 17, -12,
+ax_anim 2, 0, 149, 15, -4, 15, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -8, -9, -8,
+ax_anim 2, 0, 153, -7, -13, -7, -13,
+ax_anim 3, 0, 146, 0, -16, 0, -16,
+ax_anim 2, 3, 147, 7, -13, 7, -13,
+ax_anim 2, 0, 148, 9, -8, 9, -8,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -1, -15, -1, -15,
+ax_anim 2, 0, 146, -8, -17, -8, -17,
+ax_anim 3, 0, 153, -15, -15, -15, -15,
+ax_anim 2, 3, 152, -17, -12, -17, -12,
+ax_anim 2, 0, 151, -15, -4, -15, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -14, -5, -12, -5,
+ax_anim 3, 0, 152, -12, -2, -14, -2,
+ax_anim 2, 3, 151, -14, 4, -12, 4,
+ax_anim 2, 0, 150, -10, 5, -10, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -17, 10, -17, 10,
+ax_anim 3, 0, 151, -14, 19, -14, 19,
+ax_anim 2, 3, 150, -11, 19, -11, 19,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, -2, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_11_1:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -24, 0, 0,
+ax_anim 3, 0, 167, 0, -23, 0, 0,
+ax_anim 2, 0, 167, 0, -19, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_11_2:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -24, 0, 0,
+ax_anim 2, 0, 171, 0, -20, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 2, 0, 0,
+ax_anim_terminator
+sSteelixAnims_11_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 175, 0, -24, 0, 0,
+ax_anim 2, 0, 175, 0, -20, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_11_4:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_11_5:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_11_6:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -24, 0, 0,
+ax_anim 2, 0, 191, 0, -20, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 1, 0, 0,
+ax_anim_terminator
+sSteelixAnims_11_8:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -24, 0, 0,
+ax_anim 2, 0, 195, 0, -20, 0, 0,
+ax_anim 1, 0, 195, 0, -12, 0, 0,
+ax_anim 2, 2, 195, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_12_1:
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 1, 0, 1, 0,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_12_2:
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, -1, 1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_12_3:
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, -1, 0, -1,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_12_4:
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -1, -1, -1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_12_5:
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 1, 0, 1, 0,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_12_6:
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 1, -1, 1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_12_7:
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, -1, 0, -1,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_12_8:
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, -1, -1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSteelixAnims_13_1:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_13_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_13_3:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_13_4:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_13_5:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_13_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_13_7:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixAnims_13_8:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSteelixGfx1:
+.incbin "baserom.gba", 0xE63670, 0x40
+sSteelixGfx1_1:
+.incbin "baserom.gba", 0xE636B0, 0x80
+sSteelixGfx1_2:
+.incbin "baserom.gba", 0xE63730, 0xC0
+sSteelixGfx1_3:
+.incbin "baserom.gba", 0xE637F0, 0xA0
+sSteelixGfx1_4:
+.incbin "baserom.gba", 0xE63890, 0xA0
+sSteelixGfx1_5:
+.incbin "baserom.gba", 0xE63930, 0x60
+sSteelixGfx1_6:
+.incbin "baserom.gba", 0xE63990, 0x40
+sSteelixSprites1:
+ax_sprite 0, 0x160
+ax_sprite sSteelixGfx1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx1_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx1_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx1_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx1_4, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx1_5, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx1_6, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx2:
+.incbin "baserom.gba", 0xE63A50, 0x40
+sSteelixGfx2_1:
+.incbin "baserom.gba", 0xE63A90, 0xA0
+sSteelixGfx2_2:
+.incbin "baserom.gba", 0xE63B30, 0xC0
+sSteelixGfx2_3:
+.incbin "baserom.gba", 0xE63BF0, 0xC0
+sSteelixGfx2_4:
+.incbin "baserom.gba", 0xE63CB0, 0x80
+sSteelixGfx2_5:
+.incbin "baserom.gba", 0xE63D30, 0x60
+sSteelixSprites2:
+ax_sprite 0, 0x160
+ax_sprite sSteelixGfx2, 0x40
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx2_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx2_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx2_3, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx2_4, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx2_5, 0x60
+ax_sprite 0, 0x140
+ax_sprite_terminator
+sSteelixGfx3:
+.incbin "baserom.gba", 0xE63E00, 0x80
+sSteelixGfx3_1:
+.incbin "baserom.gba", 0xE63E80, 0xC0
+sSteelixGfx3_2:
+.incbin "baserom.gba", 0xE63F40, 0xC0
+sSteelixGfx3_3:
+.incbin "baserom.gba", 0xE64000, 0x80
+sSteelixGfx3_4:
+.incbin "baserom.gba", 0xE64080, 0x60
+sSteelixGfx3_5:
+.incbin "baserom.gba", 0xE640E0, 0x80
+sSteelixGfx3_6:
+.incbin "baserom.gba", 0xE64160, 0x40
+sSteelixSprites3:
+ax_sprite 0, 0x140
+ax_sprite sSteelixGfx3, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx3_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx3_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx3_3, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx3_4, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx3_5, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx3_6, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx4:
+.incbin "baserom.gba", 0xE64220, 0x80
+sSteelixGfx4_1:
+.incbin "baserom.gba", 0xE642A0, 0x80
+sSteelixGfx4_2:
+.incbin "baserom.gba", 0xE64320, 0xE0
+sSteelixGfx4_3:
+.incbin "baserom.gba", 0xE64400, 0xE0
+sSteelixGfx4_4:
+.incbin "baserom.gba", 0xE644E0, 0xC0
+sSteelixGfx4_5:
+.incbin "baserom.gba", 0xE645A0, 0x80
+sSteelixGfx4_6:
+.incbin "baserom.gba", 0xE64620, 0x40
+sSteelixSprites4:
+ax_sprite 0, 0x120
+ax_sprite sSteelixGfx4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx4_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx4_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx4_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx4_4, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx4_5, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx4_6, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx5:
+.incbin "baserom.gba", 0xE646E0, 0xA0
+sSteelixGfx5_1:
+.incbin "baserom.gba", 0xE64780, 0xA0
+sSteelixGfx5_2:
+.incbin "baserom.gba", 0xE64820, 0x240
+sSteelixGfx5_3:
+.incbin "baserom.gba", 0xE64A60, 0x80
+sSteelixGfx5_4:
+.incbin "baserom.gba", 0xE64AE0, 0x20
+sSteelixSprites5:
+ax_sprite 0, 0x200
+ax_sprite sSteelixGfx5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx5_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx5_2, 0x240
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx5_3, 0x80
+ax_sprite 0, 0xc0
+ax_sprite sSteelixGfx5_4, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx6:
+.incbin "baserom.gba", 0xE64B60, 0xA0
+sSteelixGfx6_1:
+.incbin "baserom.gba", 0xE64C00, 0xA0
+sSteelixGfx6_2:
+.incbin "baserom.gba", 0xE64CA0, 0xA0
+sSteelixGfx6_3:
+.incbin "baserom.gba", 0xE64D40, 0xC0
+sSteelixGfx6_4:
+.incbin "baserom.gba", 0xE64E00, 0xA0
+sSteelixGfx6_5:
+.incbin "baserom.gba", 0xE64EA0, 0xA0
+sSteelixGfx6_6:
+.incbin "baserom.gba", 0xE64F40, 0x60
+sSteelixSprites6:
+ax_sprite 0, 0x120
+ax_sprite sSteelixGfx6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx6_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx6_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx6_3, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx6_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx6_5, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx6_6, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx7:
+.incbin "baserom.gba", 0xE65020, 0xA0
+sSteelixGfx7_1:
+.incbin "baserom.gba", 0xE650C0, 0xC0
+sSteelixGfx7_2:
+.incbin "baserom.gba", 0xE65180, 0xC0
+sSteelixGfx7_3:
+.incbin "baserom.gba", 0xE65240, 0x80
+sSteelixGfx7_4:
+.incbin "baserom.gba", 0xE652C0, 0x20
+sSteelixGfx7_5:
+.incbin "baserom.gba", 0xE652E0, 0xC0
+sSteelixGfx7_6:
+.incbin "baserom.gba", 0xE653A0, 0xA0
+sSteelixGfx7_7:
+.incbin "baserom.gba", 0xE65440, 0x60
+sSteelixSprites7:
+ax_sprite 0, 0x100
+ax_sprite sSteelixGfx7, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx7_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx7_2, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx7_3, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx7_4, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx7_5, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx7_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx7_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx8:
+.incbin "baserom.gba", 0xE65530, 0x180
+sSteelixSprites8:
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx8, 0x180
+ax_sprite_terminator
+sSteelixGfx9:
+.incbin "baserom.gba", 0xE656C8, 0x20
+sSteelixGfx9_1:
+.incbin "baserom.gba", 0xE656E8, 0x80
+sSteelixSprites9:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx9, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx9_1, 0x80
+ax_sprite_terminator
+sSteelixGfx10:
+.incbin "baserom.gba", 0xE65790, 0x60
+sSteelixGfx10_1:
+.incbin "baserom.gba", 0xE657F0, 0x100
+sSteelixSprites10:
+ax_sprite sSteelixGfx10, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx10_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSteelixGfx11:
+.incbin "baserom.gba", 0xE65918, 0x40
+sSteelixSprites11:
+ax_sprite sSteelixGfx11, 0x40
+ax_sprite_terminator
+sSteelixGfx12:
+.incbin "baserom.gba", 0xE65968, 0xA0
+sSteelixGfx12_1:
+.incbin "baserom.gba", 0xE65A08, 0xC0
+sSteelixGfx12_2:
+.incbin "baserom.gba", 0xE65AC8, 0xA0
+sSteelixGfx12_3:
+.incbin "baserom.gba", 0xE65B68, 0xA0
+sSteelixGfx12_4:
+.incbin "baserom.gba", 0xE65C08, 0xA0
+sSteelixGfx12_5:
+.incbin "baserom.gba", 0xE65CA8, 0xA0
+sSteelixGfx12_6:
+.incbin "baserom.gba", 0xE65D48, 0x60
+sSteelixSprites12:
+ax_sprite 0, 0x120
+ax_sprite sSteelixGfx12, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx12_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx12_2, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx12_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx12_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx12_5, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx12_6, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx13:
+.incbin "baserom.gba", 0xE65E28, 0x60
+sSteelixGfx13_1:
+.incbin "baserom.gba", 0xE65E88, 0x80
+sSteelixGfx13_2:
+.incbin "baserom.gba", 0xE65F08, 0xA0
+sSteelixGfx13_3:
+.incbin "baserom.gba", 0xE65FA8, 0xC0
+sSteelixGfx13_4:
+.incbin "baserom.gba", 0xE66068, 0xA0
+sSteelixGfx13_5:
+.incbin "baserom.gba", 0xE66108, 0xA0
+sSteelixGfx13_6:
+.incbin "baserom.gba", 0xE661A8, 0xC0
+sSteelixGfx13_7:
+.incbin "baserom.gba", 0xE66268, 0x80
+sSteelixSprites13:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx13, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx13_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx13_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx13_3, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx13_4, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx13_5, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx13_6, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx13_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx14:
+.incbin "baserom.gba", 0xE66378, 0x80
+sSteelixGfx14_1:
+.incbin "baserom.gba", 0xE663F8, 0xA0
+sSteelixGfx14_2:
+.incbin "baserom.gba", 0xE66498, 0xC0
+sSteelixGfx14_3:
+.incbin "baserom.gba", 0xE66558, 0xA0
+sSteelixGfx14_4:
+.incbin "baserom.gba", 0xE665F8, 0x60
+sSteelixGfx14_5:
+.incbin "baserom.gba", 0xE66658, 0xA0
+sSteelixGfx14_6:
+.incbin "baserom.gba", 0xE666F8, 0xA0
+sSteelixGfx14_7:
+.incbin "baserom.gba", 0xE66798, 0x60
+sSteelixSprites14:
+ax_sprite sSteelixGfx14, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx14_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx14_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx14_3, 0xa0
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx14_4, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx14_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx14_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx14_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx15:
+.incbin "baserom.gba", 0xE66880, 0x60
+sSteelixGfx15_1:
+.incbin "baserom.gba", 0xE668E0, 0xA0
+sSteelixGfx15_2:
+.incbin "baserom.gba", 0xE66980, 0xA0
+sSteelixGfx15_3:
+.incbin "baserom.gba", 0xE66A20, 0x80
+sSteelixGfx15_4:
+.incbin "baserom.gba", 0xE66AA0, 0xA0
+sSteelixGfx15_5:
+.incbin "baserom.gba", 0xE66B40, 0x80
+sSteelixGfx15_6:
+.incbin "baserom.gba", 0xE66BC0, 0xA0
+sSteelixGfx15_7:
+.incbin "baserom.gba", 0xE66C60, 0x80
+sSteelixSprites15:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx15, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx15_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx15_2, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx15_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx15_4, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx15_5, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx15_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx15_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx16:
+.incbin "baserom.gba", 0xE66D70, 0x80
+sSteelixGfx16_1:
+.incbin "baserom.gba", 0xE66DF0, 0xC0
+sSteelixGfx16_2:
+.incbin "baserom.gba", 0xE66EB0, 0xC0
+sSteelixGfx16_3:
+.incbin "baserom.gba", 0xE66F70, 0x80
+sSteelixGfx16_4:
+.incbin "baserom.gba", 0xE66FF0, 0x60
+sSteelixGfx16_5:
+.incbin "baserom.gba", 0xE67050, 0x80
+sSteelixGfx16_6:
+.incbin "baserom.gba", 0xE670D0, 0x80
+sSteelixGfx16_7:
+.incbin "baserom.gba", 0xE67150, 0x80
+sSteelixSprites16:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx16, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx16_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx16_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx16_3, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx16_4, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx16_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx16_6, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx16_7, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx17:
+.incbin "baserom.gba", 0xE67260, 0x80
+sSteelixGfx17_1:
+.incbin "baserom.gba", 0xE672E0, 0xC0
+sSteelixGfx17_2:
+.incbin "baserom.gba", 0xE673A0, 0xC0
+sSteelixGfx17_3:
+.incbin "baserom.gba", 0xE67460, 0x80
+sSteelixGfx17_4:
+.incbin "baserom.gba", 0xE674E0, 0x80
+sSteelixGfx17_5:
+.incbin "baserom.gba", 0xE67560, 0x40
+sSteelixGfx17_6:
+.incbin "baserom.gba", 0xE675A0, 0x60
+sSteelixGfx17_7:
+.incbin "baserom.gba", 0xE67600, 0x60
+sSteelixSprites17:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx17, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx17_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx17_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx17_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx17_4, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx17_5, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sSteelixGfx17_6, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx17_7, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx18:
+.incbin "baserom.gba", 0xE676F0, 0x80
+sSteelixGfx18_1:
+.incbin "baserom.gba", 0xE67770, 0x80
+sSteelixGfx18_2:
+.incbin "baserom.gba", 0xE677F0, 0xC0
+sSteelixGfx18_3:
+.incbin "baserom.gba", 0xE678B0, 0x80
+sSteelixGfx18_4:
+.incbin "baserom.gba", 0xE67930, 0x60
+sSteelixGfx18_5:
+.incbin "baserom.gba", 0xE67990, 0x60
+sSteelixGfx18_6:
+.incbin "baserom.gba", 0xE679F0, 0x80
+sSteelixGfx18_7:
+.incbin "baserom.gba", 0xE67A70, 0x40
+sSteelixSprites18:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx18, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx18_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx18_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx18_3, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx18_4, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx18_5, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx18_6, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx18_7, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx19:
+.incbin "baserom.gba", 0xE67B40, 0x40
+sSteelixGfx19_1:
+.incbin "baserom.gba", 0xE67B80, 0x260
+sSteelixGfx19_2:
+.incbin "baserom.gba", 0xE67DE0, 0x60
+sSteelixSprites19:
+ax_sprite 0, 0xc0
+ax_sprite sSteelixGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx19_1, 0x260
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx19_2, 0x60
+ax_sprite_terminator
+sSteelixGfx20:
+.incbin "baserom.gba", 0xE67E78, 0x20
+sSteelixGfx20_1:
+.incbin "baserom.gba", 0xE67E98, 0x60
+sSteelixSprites20:
+ax_sprite sSteelixGfx20, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx20_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx21:
+.incbin "baserom.gba", 0xE67F20, 0xC0
+sSteelixGfx21_1:
+.incbin "baserom.gba", 0xE67FE0, 0x320
+sSteelixSprites21:
+ax_sprite sSteelixGfx21, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx21_1, 0x320
+ax_sprite_terminator
+sSteelixGfx22:
+.incbin "baserom.gba", 0xE68320, 0x20
+sSteelixGfx22_1:
+.incbin "baserom.gba", 0xE68340, 0x20
+sSteelixGfx22_2:
+.incbin "baserom.gba", 0xE68360, 0x20
+sSteelixSprites22:
+ax_sprite sSteelixGfx22, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx22_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx22_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx23:
+.incbin "baserom.gba", 0xE683B8, 0x60
+sSteelixSprites23:
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx24:
+.incbin "baserom.gba", 0xE68438, 0xE0
+sSteelixSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx24, 0xe0
+ax_sprite_terminator
+sSteelixGfx25:
+.incbin "baserom.gba", 0xE68530, 0x60
+sSteelixGfx25_1:
+.incbin "baserom.gba", 0xE68590, 0x40
+sSteelixSprites25:
+ax_sprite sSteelixGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx25_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx26:
+.incbin "baserom.gba", 0xE685F8, 0x80
+sSteelixSprites26:
+ax_sprite sSteelixGfx26, 0x80
+ax_sprite_terminator
+sSteelixGfx27:
+.incbin "baserom.gba", 0xE68688, 0xE0
+sSteelixGfx27_1:
+.incbin "baserom.gba", 0xE68768, 0x100
+sSteelixGfx27_2:
+.incbin "baserom.gba", 0xE68868, 0x80
+sSteelixGfx27_3:
+.incbin "baserom.gba", 0xE688E8, 0x40
+sSteelixSprites27:
+ax_sprite sSteelixGfx27, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx27_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx27_2, 0x80
+ax_sprite 0, 0xc0
+ax_sprite sSteelixGfx27_3, 0x40
+ax_sprite_terminator
+sSteelixGfx28:
+.incbin "baserom.gba", 0xE68968, 0x60
+sSteelixGfx28_1:
+.incbin "baserom.gba", 0xE689C8, 0x80
+sSteelixGfx28_2:
+.incbin "baserom.gba", 0xE68A48, 0xA0
+sSteelixGfx28_3:
+.incbin "baserom.gba", 0xE68AE8, 0xC0
+sSteelixGfx28_4:
+.incbin "baserom.gba", 0xE68BA8, 0x80
+sSteelixGfx28_5:
+.incbin "baserom.gba", 0xE68C28, 0x80
+sSteelixGfx28_6:
+.incbin "baserom.gba", 0xE68CA8, 0x20
+sSteelixGfx28_7:
+.incbin "baserom.gba", 0xE68CC8, 0xA0
+sSteelixGfx28_8:
+.incbin "baserom.gba", 0xE68D68, 0x80
+sSteelixSprites28:
+ax_sprite sSteelixGfx28, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx28_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx28_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx28_3, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx28_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx28_5, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx28_6, 0x20
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx28_7, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx28_8, 0x80
+ax_sprite_terminator
+sSteelixGfx29:
+.incbin "baserom.gba", 0xE68E78, 0x260
+sSteelixGfx29_1:
+.incbin "baserom.gba", 0xE690D8, 0x60
+sSteelixGfx29_2:
+.incbin "baserom.gba", 0xE69138, 0x60
+sSteelixGfx29_3:
+.incbin "baserom.gba", 0xE69198, 0x60
+sSteelixSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx29, 0x260
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx29_3, 0x60
+ax_sprite_terminator
+sSteelixGfx30:
+.incbin "baserom.gba", 0xE69240, 0x40
+sSteelixSprites30:
+ax_sprite sSteelixGfx30, 0x40
+ax_sprite_terminator
+sSteelixGfx31:
+.incbin "baserom.gba", 0xE69290, 0x20
+sSteelixSprites31:
+ax_sprite sSteelixGfx31, 0x20
+ax_sprite_terminator
+sSteelixGfx32:
+.incbin "baserom.gba", 0xE692C0, 0x20
+sSteelixSprites32:
+ax_sprite sSteelixGfx32, 0x20
+ax_sprite_terminator
+sSteelixGfx33:
+.incbin "baserom.gba", 0xE692F0, 0x60
+sSteelixGfx33_1:
+.incbin "baserom.gba", 0xE69350, 0xA0
+sSteelixGfx33_2:
+.incbin "baserom.gba", 0xE693F0, 0xA0
+sSteelixGfx33_3:
+.incbin "baserom.gba", 0xE69490, 0x80
+sSteelixGfx33_4:
+.incbin "baserom.gba", 0xE69510, 0x80
+sSteelixGfx33_5:
+.incbin "baserom.gba", 0xE69590, 0x80
+sSteelixGfx33_6:
+.incbin "baserom.gba", 0xE69610, 0x40
+sSteelixSprites33:
+ax_sprite 0, 0x140
+ax_sprite sSteelixGfx33, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx33_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx33_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx33_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx33_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx33_5, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx33_6, 0x40
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx34:
+.incbin "baserom.gba", 0xE696D0, 0x60
+sSteelixGfx34_1:
+.incbin "baserom.gba", 0xE69730, 0xA0
+sSteelixGfx34_2:
+.incbin "baserom.gba", 0xE697D0, 0xA0
+sSteelixGfx34_3:
+.incbin "baserom.gba", 0xE69870, 0xA0
+sSteelixGfx34_4:
+.incbin "baserom.gba", 0xE69910, 0xA0
+sSteelixGfx34_5:
+.incbin "baserom.gba", 0xE699B0, 0x80
+sSteelixGfx34_6:
+.incbin "baserom.gba", 0xE69A30, 0x20
+sSteelixSprites34:
+ax_sprite 0, 0x160
+ax_sprite sSteelixGfx34, 0x60
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx34_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx34_2, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx34_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx34_4, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx34_5, 0x80
+ax_sprite 0, 0xc0
+ax_sprite sSteelixGfx34_6, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx35:
+.incbin "baserom.gba", 0xE69AD0, 0x60
+sSteelixGfx35_1:
+.incbin "baserom.gba", 0xE69B30, 0x60
+sSteelixGfx35_2:
+.incbin "baserom.gba", 0xE69B90, 0xE0
+sSteelixGfx35_3:
+.incbin "baserom.gba", 0xE69C70, 0xE0
+sSteelixGfx35_4:
+.incbin "baserom.gba", 0xE69D50, 0xA0
+sSteelixGfx35_5:
+.incbin "baserom.gba", 0xE69DF0, 0x80
+sSteelixGfx35_6:
+.incbin "baserom.gba", 0xE69E70, 0x20
+sSteelixSprites35:
+ax_sprite 0, 0x140
+ax_sprite sSteelixGfx35, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx35_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx35_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx35_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx35_4, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx35_5, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx35_6, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx36:
+.incbin "baserom.gba", 0xE69F10, 0xA0
+sSteelixGfx36_1:
+.incbin "baserom.gba", 0xE69FB0, 0xC0
+sSteelixGfx36_2:
+.incbin "baserom.gba", 0xE6A070, 0xE0
+sSteelixGfx36_3:
+.incbin "baserom.gba", 0xE6A150, 0xE0
+sSteelixGfx36_4:
+.incbin "baserom.gba", 0xE6A230, 0x80
+sSteelixGfx36_5:
+.incbin "baserom.gba", 0xE6A2B0, 0x80
+sSteelixGfx36_6:
+.incbin "baserom.gba", 0xE6A330, 0x60
+sSteelixSprites36:
+ax_sprite 0, 0x100
+ax_sprite sSteelixGfx36, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx36_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx36_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx36_3, 0xe0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx36_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx36_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx36_6, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx37:
+.incbin "baserom.gba", 0xE6A410, 0xA0
+sSteelixGfx37_1:
+.incbin "baserom.gba", 0xE6A4B0, 0xC0
+sSteelixGfx37_2:
+.incbin "baserom.gba", 0xE6A570, 0xC0
+sSteelixGfx37_3:
+.incbin "baserom.gba", 0xE6A630, 0xC0
+sSteelixGfx37_4:
+.incbin "baserom.gba", 0xE6A6F0, 0xC0
+sSteelixGfx37_5:
+.incbin "baserom.gba", 0xE6A7B0, 0xA0
+sSteelixGfx37_6:
+.incbin "baserom.gba", 0xE6A850, 0x80
+sSteelixSprites37:
+ax_sprite 0, 0x120
+ax_sprite sSteelixGfx37, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx37_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx37_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx37_3, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx37_4, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx37_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx37_6, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx38:
+.incbin "baserom.gba", 0xE6A950, 0x60
+sSteelixGfx38_1:
+.incbin "baserom.gba", 0xE6A9B0, 0x80
+sSteelixGfx38_2:
+.incbin "baserom.gba", 0xE6AA30, 0xC0
+sSteelixGfx38_3:
+.incbin "baserom.gba", 0xE6AAF0, 0xE0
+sSteelixGfx38_4:
+.incbin "baserom.gba", 0xE6ABD0, 0xC0
+sSteelixGfx38_5:
+.incbin "baserom.gba", 0xE6AC90, 0xC0
+sSteelixGfx38_6:
+.incbin "baserom.gba", 0xE6AD50, 0xA0
+sSteelixGfx38_7:
+.incbin "baserom.gba", 0xE6ADF0, 0x60
+sSteelixSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx38, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx38_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx38_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx38_3, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx38_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx38_5, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx38_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx38_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx39:
+.incbin "baserom.gba", 0xE6AEE0, 0x60
+sSteelixGfx39_1:
+.incbin "baserom.gba", 0xE6AF40, 0xC0
+sSteelixGfx39_2:
+.incbin "baserom.gba", 0xE6B000, 0xC0
+sSteelixGfx39_3:
+.incbin "baserom.gba", 0xE6B0C0, 0xA0
+sSteelixGfx39_4:
+.incbin "baserom.gba", 0xE6B160, 0x80
+sSteelixGfx39_5:
+.incbin "baserom.gba", 0xE6B1E0, 0x60
+sSteelixGfx39_6:
+.incbin "baserom.gba", 0xE6B240, 0xA0
+sSteelixGfx39_7:
+.incbin "baserom.gba", 0xE6B2E0, 0x60
+sSteelixSprites39:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx39, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx39_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx39_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx39_3, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx39_4, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx39_5, 0x60
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx39_6, 0xa0
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx39_7, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx40:
+.incbin "baserom.gba", 0xE6B3D0, 0x80
+sSteelixGfx40_1:
+.incbin "baserom.gba", 0xE6B450, 0x80
+sSteelixGfx40_2:
+.incbin "baserom.gba", 0xE6B4D0, 0x80
+sSteelixGfx40_3:
+.incbin "baserom.gba", 0xE6B550, 0xC0
+sSteelixGfx40_4:
+.incbin "baserom.gba", 0xE6B610, 0x80
+sSteelixGfx40_5:
+.incbin "baserom.gba", 0xE6B690, 0xC0
+sSteelixGfx40_6:
+.incbin "baserom.gba", 0xE6B750, 0xC0
+sSteelixGfx40_7:
+.incbin "baserom.gba", 0xE6B810, 0x80
+sSteelixSprites40:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx40, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx40_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx40_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx40_3, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx40_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx40_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx40_6, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx40_7, 0x80
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx41:
+.incbin "baserom.gba", 0xE6B920, 0x80
+sSteelixGfx41_1:
+.incbin "baserom.gba", 0xE6B9A0, 0xA0
+sSteelixGfx41_2:
+.incbin "baserom.gba", 0xE6BA40, 0xA0
+sSteelixGfx41_3:
+.incbin "baserom.gba", 0xE6BAE0, 0x80
+sSteelixGfx41_4:
+.incbin "baserom.gba", 0xE6BB60, 0x80
+sSteelixGfx41_5:
+.incbin "baserom.gba", 0xE6BBE0, 0x80
+sSteelixGfx41_6:
+.incbin "baserom.gba", 0xE6BC60, 0x80
+sSteelixGfx41_7:
+.incbin "baserom.gba", 0xE6BCE0, 0x60
+sSteelixSprites41:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx41, 0x80
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx41_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx41_2, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx41_3, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx41_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx41_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx41_6, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx41_7, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sSteelixGfx42:
+.incbin "baserom.gba", 0xE6BDD0, 0x80
+sSteelixGfx42_1:
+.incbin "baserom.gba", 0xE6BE50, 0xA0
+sSteelixGfx42_2:
+.incbin "baserom.gba", 0xE6BEF0, 0xA0
+sSteelixGfx42_3:
+.incbin "baserom.gba", 0xE6BF90, 0x80
+sSteelixGfx42_4:
+.incbin "baserom.gba", 0xE6C010, 0x60
+sSteelixGfx42_5:
+.incbin "baserom.gba", 0xE6C070, 0x60
+sSteelixGfx42_6:
+.incbin "baserom.gba", 0xE6C0D0, 0x60
+sSteelixGfx42_7:
+.incbin "baserom.gba", 0xE6C130, 0x60
+sSteelixSprites42:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx42, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx42_1, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx42_2, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx42_3, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx42_4, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx42_5, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx42_6, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx42_7, 0x60
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx43:
+.incbin "baserom.gba", 0xE6C220, 0x20
+sSteelixGfx43_1:
+.incbin "baserom.gba", 0xE6C240, 0xA0
+sSteelixSprites43:
+ax_sprite sSteelixGfx43, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx43_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx44:
+.incbin "baserom.gba", 0xE6C308, 0x1E0
+sSteelixSprites44:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx44, 0x1e0
+ax_sprite_terminator
+sSteelixGfx45:
+.incbin "baserom.gba", 0xE6C500, 0x80
+sSteelixSprites45:
+ax_sprite sSteelixGfx45, 0x80
+ax_sprite_terminator
+sSteelixGfx46:
+.incbin "baserom.gba", 0xE6C590, 0x1E0
+sSteelixSprites46:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx46, 0x1e0
+ax_sprite_terminator
+sSteelixGfx47:
+.incbin "baserom.gba", 0xE6C788, 0x20
+sSteelixGfx47_1:
+.incbin "baserom.gba", 0xE6C7A8, 0xA0
+sSteelixSprites47:
+ax_sprite sSteelixGfx47, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx47_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx48:
+.incbin "baserom.gba", 0xE6C870, 0x80
+sSteelixSprites48:
+ax_sprite sSteelixGfx48, 0x80
+ax_sprite_terminator
+sSteelixGfx49:
+.incbin "baserom.gba", 0xE6C900, 0x60
+sSteelixGfx49_1:
+.incbin "baserom.gba", 0xE6C960, 0xE0
+sSteelixGfx49_2:
+.incbin "baserom.gba", 0xE6CA40, 0x40
+sSteelixSprites49:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx49_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx49_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSteelixGfx50:
+.incbin "baserom.gba", 0xE6CAC0, 0x40
+sSteelixGfx50_1:
+.incbin "baserom.gba", 0xE6CB00, 0x40
+sSteelixGfx50_2:
+.incbin "baserom.gba", 0xE6CB40, 0x100
+sSteelixGfx50_3:
+.incbin "baserom.gba", 0xE6CC40, 0xC0
+sSteelixGfx50_4:
+.incbin "baserom.gba", 0xE6CD00, 0x80
+sSteelixSprites50:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx50, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx50_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx50_2, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx50_3, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx50_4, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx51:
+.incbin "baserom.gba", 0xE6CDE0, 0xA0
+sSteelixGfx51_1:
+.incbin "baserom.gba", 0xE6CE80, 0xC0
+sSteelixGfx51_2:
+.incbin "baserom.gba", 0xE6CF40, 0xC0
+sSteelixGfx51_3:
+.incbin "baserom.gba", 0xE6D000, 0xE0
+sSteelixGfx51_4:
+.incbin "baserom.gba", 0xE6D0E0, 0x80
+sSteelixGfx51_5:
+.incbin "baserom.gba", 0xE6D160, 0x80
+sSteelixGfx51_6:
+.incbin "baserom.gba", 0xE6D1E0, 0xA0
+sSteelixGfx51_7:
+.incbin "baserom.gba", 0xE6D280, 0xA0
+sSteelixSprites51:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx51, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx51_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx51_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx51_3, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx51_4, 0x80
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx51_5, 0x80
+ax_sprite 0, 0xa0
+ax_sprite sSteelixGfx51_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx51_7, 0xa0
+ax_sprite_terminator
+sSteelixGfx52:
+.incbin "baserom.gba", 0xE6D3A8, 0xA0
+sSteelixGfx52_1:
+.incbin "baserom.gba", 0xE6D448, 0xE0
+sSteelixGfx52_2:
+.incbin "baserom.gba", 0xE6D528, 0xE0
+sSteelixGfx52_3:
+.incbin "baserom.gba", 0xE6D608, 0xA0
+sSteelixGfx52_4:
+.incbin "baserom.gba", 0xE6D6A8, 0xA0
+sSteelixGfx52_5:
+.incbin "baserom.gba", 0xE6D748, 0x40
+sSteelixGfx52_6:
+.incbin "baserom.gba", 0xE6D788, 0xA0
+sSteelixGfx52_7:
+.incbin "baserom.gba", 0xE6D828, 0xA0
+sSteelixSprites52:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx52, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx52_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx52_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx52_3, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx52_4, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sSteelixGfx52_5, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sSteelixGfx52_6, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx52_7, 0xa0
+ax_sprite_terminator
+sSteelixGfx53:
+.incbin "baserom.gba", 0xE6D950, 0xA0
+sSteelixGfx53_1:
+.incbin "baserom.gba", 0xE6D9F0, 0xE0
+sSteelixGfx53_2:
+.incbin "baserom.gba", 0xE6DAD0, 0xE0
+sSteelixGfx53_3:
+.incbin "baserom.gba", 0xE6DBB0, 0x80
+sSteelixSprites53:
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx53, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx53_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx53_2, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx53_3, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSteelixGfx54:
+.incbin "baserom.gba", 0xE6DC80, 0xE0
+sSteelixGfx54_1:
+.incbin "baserom.gba", 0xE6DD60, 0x80
+sSteelixGfx54_2:
+.incbin "baserom.gba", 0xE6DDE0, 0x60
+sSteelixSprites54:
+ax_sprite sSteelixGfx54, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx54_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx54_2, 0x60
+ax_sprite_terminator
+sSteelixGfx55:
+.incbin "baserom.gba", 0xE6DE70, 0x60
+sSteelixGfx55_1:
+.incbin "baserom.gba", 0xE6DED0, 0xC0
+sSteelixGfx55_2:
+.incbin "baserom.gba", 0xE6DF90, 0x60
+sSteelixSprites55:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx55_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sSteelixGfx55_2, 0x60
+ax_sprite_terminator
+sSteelixGfx56:
+.incbin "baserom.gba", 0xE6E028, 0x20
+sSteelixSprites56:
+ax_sprite sSteelixGfx56, 0x20
+ax_sprite_terminator
+sSteelixGfx57:
+.incbin "baserom.gba", 0xE6E058, 0xC0
+sSteelixGfx57_1:
+.incbin "baserom.gba", 0xE6E118, 0x100
+sSteelixGfx57_2:
+.incbin "baserom.gba", 0xE6E218, 0xC0
+sSteelixGfx57_3:
+.incbin "baserom.gba", 0xE6E2D8, 0x80
+sSteelixSprites57:
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx57, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx57_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSteelixGfx57_2, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sSteelixGfx57_3, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sAxPosesSteelix:
+.4byte sSteelixPose1
+.4byte sSteelixPose2
+.4byte sSteelixPose3
+.4byte sSteelixPose4
+.4byte sSteelixPose5
+.4byte sSteelixPose6
+.4byte sSteelixPose7
+.4byte sSteelixPose8
+.4byte sSteelixPose9
+.4byte sSteelixPose10
+.4byte sSteelixPose11
+.4byte sSteelixPose12
+.4byte sSteelixPose13
+.4byte sSteelixPose14
+.4byte sSteelixPose15
+.4byte sSteelixPose16
+.4byte sSteelixPose17
+.4byte sSteelixPose18
+.4byte sSteelixPose19
+.4byte sSteelixPose20
+.4byte sSteelixPose21
+.4byte sSteelixPose22
+.4byte sSteelixPose23
+.4byte sSteelixPose24
+.4byte sSteelixPose25
+.4byte sSteelixPose26
+.4byte sSteelixPose27
+.4byte sSteelixPose28
+.4byte sSteelixPose29
+.4byte sSteelixPose30
+.4byte sSteelixPose31
+.4byte sSteelixPose32
+.4byte sSteelixPose33
+.4byte sSteelixPose34
+.4byte sSteelixPose35
+.4byte sSteelixPose36
+.4byte sSteelixPose37
+.4byte sSteelixPose38
+.4byte sSteelixPose39
+.4byte sSteelixPose40
+.4byte sSteelixPose41
+.4byte sSteelixPose42
+.4byte sSteelixPose43
+.4byte sSteelixPose44
+.4byte sSteelixPose45
+.4byte sSteelixPose46
+.4byte sSteelixPose47
+.4byte sSteelixPose48
+.4byte sSteelixPose49
+.4byte sSteelixPose50
+.4byte sSteelixPose51
+.4byte sSteelixPose52
+.4byte sSteelixPose53
+.4byte sSteelixPose54
+.4byte sSteelixPose55
+.4byte sSteelixPose56
+.4byte sSteelixPose57
+.4byte sSteelixPose58
+.4byte sSteelixPose59
+.4byte sSteelixPose60
+.4byte sSteelixPose61
+.4byte sSteelixPose62
+.4byte sSteelixPose63
+.4byte sSteelixPose64
+.4byte sSteelixPose65
+.4byte sSteelixPose66
+.4byte sSteelixPose67
+.4byte sSteelixPose68
+.4byte sSteelixPose69
+.4byte sSteelixPose70
+.4byte sSteelixPose71
+.4byte sSteelixPose72
+.4byte sSteelixPose73
+.4byte sSteelixPose74
+.4byte sSteelixPose75
+.4byte sSteelixPose76
+.4byte sSteelixPose77
+.4byte sSteelixPose78
+.4byte sSteelixPose79
+.4byte sSteelixPose80
+.4byte sSteelixPose81
+.4byte sSteelixPose82
+.4byte sSteelixPose83
+.4byte sSteelixPose84
+.4byte sSteelixPose85
+.4byte sSteelixPose86
+.4byte sSteelixPose87
+.4byte sSteelixPose88
+.4byte sSteelixPose89
+.4byte sSteelixPose90
+.4byte sSteelixPose91
+.4byte sSteelixPose92
+.4byte sSteelixPose93
+.4byte sSteelixPose94
+.4byte sSteelixPose95
+.4byte sSteelixPose96
+.4byte sSteelixPose97
+.4byte sSteelixPose98
+.4byte sSteelixPose99
+.4byte sSteelixPose100
+.4byte sSteelixPose101
+.4byte sSteelixPose102
+.4byte sSteelixPose103
+.4byte sSteelixPose104
+.4byte sSteelixPose105
+.4byte sSteelixPose106
+.4byte sSteelixPose107
+.4byte sSteelixPose108
+.4byte sSteelixPose109
+.4byte sSteelixPose110
+.4byte sSteelixPose111
+.4byte sSteelixPose112
+.4byte sSteelixPose113
+.4byte sSteelixPose114
+.4byte sSteelixPose115
+.4byte sSteelixPose116
+.4byte sSteelixPose117
+.4byte sSteelixPose118
+.4byte sSteelixPose119
+.4byte sSteelixPose120
+.4byte sSteelixPose121
+.4byte sSteelixPose122
+.4byte sSteelixPose123
+.4byte sSteelixPose124
+.4byte sSteelixPose125
+.4byte sSteelixPose126
+.4byte sSteelixPose127
+.4byte sSteelixPose128
+.4byte sSteelixPose129
+.4byte sSteelixPose130
+.4byte sSteelixPose131
+.4byte sSteelixPose132
+.4byte sSteelixPose133
+.4byte sSteelixPose134
+.4byte sSteelixPose135
+.4byte sSteelixPose136
+.4byte sSteelixPose137
+.4byte sSteelixPose138
+.4byte sSteelixPose139
+.4byte sSteelixPose140
+.4byte sSteelixPose141
+.4byte sSteelixPose142
+.4byte sSteelixPose143
+.4byte sSteelixPose144
+.4byte sSteelixPose145
+.4byte sSteelixPose146
+.4byte sSteelixPose147
+.4byte sSteelixPose148
+.4byte sSteelixPose149
+.4byte sSteelixPose150
+.4byte sSteelixPose151
+.4byte sSteelixPose152
+.4byte sSteelixPose153
+.4byte sSteelixPose154
+.4byte sSteelixPose155
+.4byte sSteelixPose156
+.4byte sSteelixPose157
+.4byte sSteelixPose158
+.4byte sSteelixPose159
+.4byte sSteelixPose160
+.4byte sSteelixPose161
+.4byte sSteelixPose162
+.4byte sSteelixPose163
+.4byte sSteelixPose164
+.4byte sSteelixPose165
+.4byte sSteelixPose166
+.4byte sSteelixPose167
+.4byte sSteelixPose168
+.4byte sSteelixPose169
+.4byte sSteelixPose170
+.4byte sSteelixPose171
+.4byte sSteelixPose172
+.4byte sSteelixPose173
+.4byte sSteelixPose174
+.4byte sSteelixPose175
+.4byte sSteelixPose176
+.4byte sSteelixPose177
+.4byte sSteelixPose178
+.4byte sSteelixPose179
+.4byte sSteelixPose180
+.4byte sSteelixPose181
+.4byte sSteelixPose182
+.4byte sSteelixPose183
+.4byte sSteelixPose184
+.4byte sSteelixPose185
+.4byte sSteelixPose186
+.4byte sSteelixPose187
+.4byte sSteelixPose188
+.4byte sSteelixPose189
+.4byte sSteelixPose190
+.4byte sSteelixPose191
+.4byte sSteelixPose192
+.4byte sSteelixPose193
+.4byte sSteelixPose194
+.4byte sSteelixPose195
+.4byte sSteelixPose196
+.4byte sSteelixPose197
+.4byte sSteelixPose198
+.4byte sSteelixPose199
+.4byte sSteelixPose200
+.4byte sSteelixPose201
+.4byte sSteelixPose202
+.4byte sSteelixPose203
+.4byte sSteelixPose204
+.4byte sSteelixPose205
+.4byte sSteelixPose206
+.4byte sSteelixPose207
+.4byte sSteelixPose208
+.4byte sSteelixPose209
+.4byte sSteelixPose210
+.4byte sSteelixPose211
+.4byte sSteelixPose212
+sAxPositionsSteelix:
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte    0,  -17, 	 -17,  -34, 	  18,  -21, 	   0,  -25
+.2byte    0,  -27, 	  -9,  -48, 	  11,  -20, 	   0,  -29
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+.2byte   24,  -24, 	  13,  -34, 	  -9,  -21, 	  -1,  -28
+.2byte   14,  -29, 	 -13,  -32, 	   4,  -20, 	  -5,  -25
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   30,  -39, 	  -1,  -35, 	   0,  -19, 	  -3,  -28
+.2byte   19,  -40, 	 -18,  -21, 	   8,  -28, 	  -5,  -24
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   21,  -50, 	 -11,  -33, 	   5,  -21, 	  -4,  -26
+.2byte   14,  -48, 	 -17,  -17, 	   8,  -28, 	  -5,  -22
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte    1,  -42, 	  13,  -25, 	 -12,  -27, 	   1,  -26
+.2byte   -1,  -38, 	   7,  -15, 	  -1,  -30, 	   1,  -24
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte  -22,  -50, 	  10,  -33, 	  -6,  -21, 	   3,  -26
+.2byte  -15,  -48, 	  16,  -17, 	  -9,  -28, 	   4,  -22
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -31,  -39, 	   0,  -35, 	  -1,  -19, 	   2,  -28
+.2byte  -20,  -40, 	  17,  -21, 	  -9,  -28, 	   4,  -24
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -25,  -24, 	 -14,  -34, 	   8,  -21, 	   0,  -28
+.2byte  -15,  -29, 	  12,  -32, 	  -5,  -20, 	   4,  -25
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte    0,  -17, 	 -17,  -34, 	  18,  -21, 	   0,  -25
+.2byte    0,  -27, 	  -9,  -48, 	  11,  -20, 	   0,  -29
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+.2byte   24,  -24, 	  13,  -34, 	  -9,  -21, 	  -1,  -28
+.2byte   14,  -29, 	 -13,  -32, 	   4,  -20, 	  -5,  -25
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   30,  -39, 	  -1,  -35, 	   0,  -19, 	  -3,  -28
+.2byte   19,  -40, 	 -18,  -21, 	   8,  -28, 	  -5,  -24
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   21,  -50, 	 -11,  -33, 	   5,  -21, 	  -4,  -26
+.2byte   14,  -48, 	 -17,  -17, 	   8,  -28, 	  -5,  -22
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte    1,  -42, 	  13,  -25, 	 -12,  -27, 	   1,  -26
+.2byte   -1,  -38, 	   7,  -15, 	  -1,  -30, 	   1,  -24
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte  -22,  -50, 	  10,  -33, 	  -6,  -21, 	   3,  -26
+.2byte  -15,  -48, 	  16,  -17, 	  -9,  -28, 	   4,  -22
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -31,  -39, 	   0,  -35, 	  -1,  -19, 	   2,  -28
+.2byte  -20,  -40, 	  17,  -21, 	  -9,  -28, 	   4,  -24
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -25,  -24, 	 -14,  -34, 	   8,  -21, 	   0,  -28
+.2byte  -15,  -29, 	  12,  -32, 	  -5,  -20, 	   4,  -25
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte    0,  -17, 	 -17,  -34, 	  18,  -21, 	   0,  -25
+.2byte    0,  -27, 	  -9,  -48, 	  11,  -20, 	   0,  -29
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+.2byte   24,  -24, 	  13,  -34, 	  -9,  -21, 	  -1,  -28
+.2byte   14,  -29, 	 -13,  -32, 	   4,  -20, 	  -5,  -25
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   30,  -39, 	  -1,  -35, 	   0,  -19, 	  -3,  -28
+.2byte   19,  -40, 	 -18,  -21, 	   8,  -28, 	  -5,  -24
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   21,  -50, 	 -11,  -33, 	   5,  -21, 	  -4,  -26
+.2byte   14,  -48, 	 -17,  -17, 	   8,  -28, 	  -5,  -22
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte    1,  -42, 	  13,  -25, 	 -12,  -27, 	   1,  -26
+.2byte   -1,  -38, 	   7,  -15, 	  -1,  -30, 	   1,  -24
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte  -22,  -50, 	  10,  -33, 	  -6,  -21, 	   3,  -26
+.2byte  -15,  -48, 	  16,  -17, 	  -9,  -28, 	   4,  -22
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -31,  -39, 	   0,  -35, 	  -1,  -19, 	   2,  -28
+.2byte  -20,  -40, 	  17,  -21, 	  -9,  -28, 	   4,  -24
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -25,  -24, 	 -14,  -34, 	   8,  -21, 	   0,  -28
+.2byte  -15,  -29, 	  12,  -32, 	  -5,  -20, 	   4,  -25
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte    0,  -17, 	 -17,  -34, 	  18,  -21, 	   0,  -25
+.2byte    0,  -27, 	  -9,  -48, 	  11,  -20, 	   0,  -29
+.2byte    0,   -9, 	 -18,  -31, 	  18,  -19, 	   0,  -29
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+.2byte   24,  -24, 	  13,  -34, 	  -9,  -21, 	  -1,  -28
+.2byte   14,  -29, 	 -13,  -32, 	   4,  -20, 	  -5,  -25
+.2byte   25,  -12, 	   8,  -31, 	  -6,  -15, 	   0,  -23
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   30,  -39, 	  -1,  -35, 	   0,  -19, 	  -3,  -28
+.2byte   19,  -40, 	 -18,  -21, 	   8,  -28, 	  -5,  -24
+.2byte   34,  -28, 	  -3,  -32, 	   0,  -16, 	  -4,  -26
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   21,  -50, 	 -11,  -33, 	   5,  -21, 	  -4,  -26
+.2byte   14,  -48, 	 -17,  -17, 	   8,  -28, 	  -5,  -22
+.2byte   24,  -40, 	  -5,  -30, 	  11,  -17, 	   2,  -26
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte    1,  -42, 	  13,  -25, 	 -12,  -27, 	   1,  -26
+.2byte   -1,  -38, 	   7,  -15, 	  -1,  -30, 	   1,  -24
+.2byte    0,  -46, 	  13,  -26, 	 -12,  -27, 	   1,  -26
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte  -22,  -50, 	  10,  -33, 	  -6,  -21, 	   3,  -26
+.2byte  -15,  -48, 	  16,  -17, 	  -9,  -28, 	   4,  -22
+.2byte  -25,  -40, 	   4,  -30, 	 -12,  -17, 	  -3,  -26
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -31,  -39, 	   0,  -35, 	  -1,  -19, 	   2,  -28
+.2byte  -20,  -40, 	  17,  -21, 	  -9,  -28, 	   4,  -24
+.2byte  -35,  -28, 	   2,  -32, 	  -1,  -16, 	   3,  -26
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -25,  -24, 	 -14,  -34, 	   8,  -21, 	   0,  -28
+.2byte  -15,  -29, 	  12,  -32, 	  -5,  -20, 	   4,  -25
+.2byte  -26,  -12, 	  -9,  -31, 	   5,  -15, 	  -1,  -23
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte    3,  -23, 	 -14,  -42, 	  13,  -22, 	   1,  -30
+.2byte   -4,  -23, 	 -13,  -40, 	  15,  -20, 	   1,  -30
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+.2byte   12,  -24, 	   2,  -35, 	  -8,  -16, 	  -3,  -26
+.2byte   22,  -30, 	  -6,  -35, 	   3,  -22, 	  -3,  -29
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   23,  -36, 	 -13,  -31, 	   7,  -19, 	  -3,  -26
+.2byte   23,  -44, 	 -15,  -35, 	   7,  -22, 	  -6,  -28
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   22,  -49, 	 -13,  -26, 	  12,  -27, 	  -2,  -24
+.2byte   16,  -51, 	 -15,  -30, 	   7,  -23, 	  -5,  -26
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte   -4,  -41, 	   9,  -19, 	 -15,  -29, 	  -2,  -25
+.2byte    2,  -41, 	  13,  -19, 	  -7,  -32, 	   4,  -25
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte  -23,  -49, 	  12,  -26, 	 -13,  -27, 	   1,  -24
+.2byte  -17,  -51, 	  14,  -30, 	  -8,  -23, 	   4,  -26
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -24,  -36, 	  12,  -31, 	  -8,  -19, 	   2,  -26
+.2byte  -24,  -44, 	  14,  -35, 	  -8,  -22, 	   5,  -28
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -13,  -24, 	  -3,  -35, 	   7,  -16, 	   2,  -26
+.2byte  -23,  -30, 	   5,  -35, 	  -4,  -22, 	   2,  -29
+.2byte   -9,   -7, 	  21,  -12, 	   0,    0, 	  13,   -4
+.2byte   -9,   -5, 	  20,  -11, 	   1,    1, 	  13,   -5
+.2byte   -1,  -32, 	  -8,  -36, 	   9,  -21, 	   0,  -25
+.2byte    9,  -36, 	  -8,  -32, 	   5,  -20, 	  -3,  -25
+.2byte   16,  -42, 	 -13,  -28, 	  12,  -28, 	  -1,  -26
+.2byte   12,  -49, 	 -13,  -21, 	  11,  -32, 	  -2,  -27
+.2byte   -1,  -54, 	   7,  -16, 	  -2,  -30, 	   1,  -25
+.2byte  -13,  -49, 	  12,  -21, 	 -12,  -32, 	   1,  -27
+.2byte  -17,  -42, 	  12,  -28, 	 -13,  -28, 	   0,  -26
+.2byte  -10,  -36, 	   7,  -32, 	  -6,  -20, 	   2,  -25
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+.2byte    0,   -9, 	 -18,  -31, 	  18,  -19, 	   0,  -29
+.2byte  -26,  -16, 	  -9,  -35, 	   5,  -19, 	  -1,  -27
+.2byte  -35,  -28, 	   2,  -32, 	  -1,  -16, 	   3,  -26
+.2byte  -23,  -40, 	   6,  -30, 	 -10,  -17, 	  -1,  -26
+.2byte    0,  -44, 	  13,  -24, 	 -12,  -25, 	   1,  -24
+.2byte   23,  -40, 	  -6,  -30, 	  10,  -17, 	   1,  -26
+.2byte   35,  -28, 	  -2,  -32, 	   1,  -16, 	  -3,  -26
+.2byte   25,  -16, 	   8,  -35, 	  -6,  -19, 	   0,  -27
+.2byte    0,  -25, 	  -9,  -46, 	  11,  -18, 	   0,  -27
+.2byte   14,  -29, 	 -13,  -32, 	   4,  -20, 	  -5,  -25
+.2byte   20,  -40, 	 -17,  -21, 	   9,  -28, 	  -4,  -24
+.2byte   16,  -48, 	 -15,  -17, 	  10,  -28, 	  -3,  -22
+.2byte   -1,  -36, 	   7,  -13, 	  -1,  -28, 	   1,  -22
+.2byte  -16,  -48, 	  15,  -17, 	 -10,  -28, 	   3,  -22
+.2byte  -22,  -40, 	  15,  -21, 	 -11,  -28, 	   2,  -24
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -25,  -24, 	 -14,  -34, 	   8,  -21, 	   0,  -28
+.2byte  -15,  -29, 	  12,  -32, 	  -5,  -20, 	   4,  -25
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte    0,  -17, 	 -17,  -34, 	  18,  -21, 	   0,  -25
+.2byte    0,  -27, 	  -9,  -48, 	  11,  -20, 	   0,  -29
+.2byte    0,   -9, 	 -18,  -31, 	  18,  -19, 	   0,  -29
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+.2byte   22,  -24, 	  11,  -34, 	 -11,  -21, 	  -3,  -28
+.2byte   14,  -29, 	 -13,  -32, 	   4,  -20, 	  -5,  -25
+.2byte   24,  -12, 	   7,  -31, 	  -7,  -15, 	  -1,  -23
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   30,  -39, 	  -1,  -35, 	   0,  -19, 	  -3,  -28
+.2byte   19,  -40, 	 -18,  -21, 	   8,  -28, 	  -5,  -24
+.2byte   36,  -28, 	  -1,  -32, 	   2,  -16, 	  -2,  -26
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   20,  -50, 	 -12,  -33, 	   4,  -21, 	  -5,  -26
+.2byte   14,  -48, 	 -17,  -17, 	   8,  -28, 	  -5,  -22
+.2byte   22,  -40, 	  -7,  -30, 	   9,  -17, 	   0,  -26
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte    1,  -42, 	  13,  -25, 	 -12,  -27, 	   1,  -26
+.2byte   -1,  -38, 	   7,  -15, 	  -1,  -30, 	   1,  -24
+.2byte    0,  -46, 	  13,  -26, 	 -12,  -27, 	   1,  -26
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte  -21,  -50, 	  11,  -33, 	  -5,  -21, 	   4,  -26
+.2byte  -15,  -48, 	  16,  -17, 	  -9,  -28, 	   4,  -22
+.2byte  -23,  -40, 	   6,  -30, 	 -10,  -17, 	  -1,  -26
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -31,  -39, 	   0,  -35, 	  -1,  -19, 	   2,  -28
+.2byte  -20,  -40, 	  17,  -21, 	  -9,  -28, 	   4,  -24
+.2byte  -37,  -28, 	   0,  -32, 	  -3,  -16, 	   1,  -26
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -23,  -24, 	 -12,  -34, 	  10,  -21, 	   2,  -28
+.2byte  -15,  -29, 	  12,  -32, 	  -5,  -20, 	   4,  -25
+.2byte  -25,  -12, 	  -8,  -31, 	   6,  -15, 	   0,  -23
+.2byte    3,  -23, 	 -14,  -42, 	  13,  -22, 	   1,  -30
+.2byte  -13,  -24, 	  -3,  -35, 	   7,  -16, 	   2,  -26
+.2byte  -24,  -36, 	  12,  -31, 	  -8,  -19, 	   2,  -26
+.2byte  -23,  -49, 	  12,  -26, 	 -13,  -27, 	   1,  -24
+.2byte   -4,  -41, 	   9,  -19, 	 -15,  -29, 	  -2,  -25
+.2byte   22,  -49, 	 -13,  -26, 	  12,  -27, 	  -2,  -24
+.2byte   23,  -36, 	 -13,  -31, 	   7,  -19, 	  -3,  -26
+.2byte   12,  -24, 	   2,  -35, 	  -8,  -16, 	  -3,  -26
+.2byte   -1,  -23, 	 -12,  -42, 	  16,  -21, 	   0,  -28
+.2byte  -18,  -27, 	   5,  -37, 	  -1,  -17, 	   1,  -26
+.2byte  -24,  -40, 	  13,  -33, 	  -9,  -21, 	   3,  -26
+.2byte  -20,  -51, 	  15,  -26, 	 -12,  -26, 	   2,  -23
+.2byte    0,  -42, 	  10,  -18, 	 -10,  -32, 	   0,  -25
+.2byte   19,  -51, 	 -16,  -26, 	  11,  -26, 	  -3,  -23
+.2byte   23,  -40, 	 -14,  -33, 	   8,  -21, 	  -4,  -26
+.2byte   17,  -27, 	  -6,  -37, 	   0,  -17, 	  -2,  -26
+sSteelixAnimTable1:
+.4byte sSteelixAnims_1_1
+.4byte sSteelixAnims_1_2
+.4byte sSteelixAnims_1_3
+.4byte sSteelixAnims_1_4
+.4byte sSteelixAnims_1_5
+.4byte sSteelixAnims_1_6
+.4byte sSteelixAnims_1_7
+.4byte sSteelixAnims_1_8
+sSteelixAnimTable2:
+.4byte sSteelixAnims_2_1
+.4byte sSteelixAnims_2_2
+.4byte sSteelixAnims_2_3
+.4byte sSteelixAnims_2_4
+.4byte sSteelixAnims_2_5
+.4byte sSteelixAnims_2_6
+.4byte sSteelixAnims_2_7
+.4byte sSteelixAnims_2_8
+sSteelixAnimTable3:
+.4byte sSteelixAnims_3_1
+.4byte sSteelixAnims_3_2
+.4byte sSteelixAnims_3_3
+.4byte sSteelixAnims_3_4
+.4byte sSteelixAnims_3_5
+.4byte sSteelixAnims_3_6
+.4byte sSteelixAnims_3_7
+.4byte sSteelixAnims_3_8
+sSteelixAnimTable4:
+.4byte sSteelixAnims_4_1
+.4byte sSteelixAnims_4_2
+.4byte sSteelixAnims_4_3
+.4byte sSteelixAnims_4_4
+.4byte sSteelixAnims_4_5
+.4byte sSteelixAnims_4_6
+.4byte sSteelixAnims_4_7
+.4byte sSteelixAnims_4_8
+sSteelixAnimTable5:
+.4byte sSteelixAnims_5_1
+.4byte sSteelixAnims_5_2
+.4byte sSteelixAnims_5_3
+.4byte sSteelixAnims_5_4
+.4byte sSteelixAnims_5_5
+.4byte sSteelixAnims_5_6
+.4byte sSteelixAnims_5_7
+.4byte sSteelixAnims_5_8
+sSteelixAnimTable6:
+.4byte sSteelixAnims_6_1
+.4byte sSteelixAnims_6_1
+.4byte sSteelixAnims_6_1
+.4byte sSteelixAnims_6_1
+.4byte sSteelixAnims_6_1
+.4byte sSteelixAnims_6_1
+.4byte sSteelixAnims_6_1
+.4byte sSteelixAnims_6_1
+sSteelixAnimTable7:
+.4byte sSteelixAnims_7_1
+.4byte sSteelixAnims_7_2
+.4byte sSteelixAnims_7_3
+.4byte sSteelixAnims_7_4
+.4byte sSteelixAnims_7_5
+.4byte sSteelixAnims_7_6
+.4byte sSteelixAnims_7_7
+.4byte sSteelixAnims_7_8
+sSteelixAnimTable8:
+.4byte sSteelixAnims_8_1
+.4byte sSteelixAnims_8_2
+.4byte sSteelixAnims_8_3
+.4byte sSteelixAnims_8_4
+.4byte sSteelixAnims_8_5
+.4byte sSteelixAnims_8_6
+.4byte sSteelixAnims_8_7
+.4byte sSteelixAnims_8_8
+sSteelixAnimTable9:
+.4byte sSteelixAnims_9_1
+.4byte sSteelixAnims_9_2
+.4byte sSteelixAnims_9_3
+.4byte sSteelixAnims_9_4
+.4byte sSteelixAnims_9_5
+.4byte sSteelixAnims_9_6
+.4byte sSteelixAnims_9_7
+.4byte sSteelixAnims_9_8
+sSteelixAnimTable10:
+.4byte sSteelixAnims_10_1
+.4byte sSteelixAnims_10_2
+.4byte sSteelixAnims_10_3
+.4byte sSteelixAnims_10_4
+.4byte sSteelixAnims_10_5
+.4byte sSteelixAnims_10_6
+.4byte sSteelixAnims_10_7
+.4byte sSteelixAnims_10_8
+sSteelixAnimTable11:
+.4byte sSteelixAnims_11_1
+.4byte sSteelixAnims_11_2
+.4byte sSteelixAnims_11_3
+.4byte sSteelixAnims_11_4
+.4byte sSteelixAnims_11_5
+.4byte sSteelixAnims_11_6
+.4byte sSteelixAnims_11_7
+.4byte sSteelixAnims_11_8
+sSteelixAnimTable12:
+.4byte sSteelixAnims_12_1
+.4byte sSteelixAnims_12_2
+.4byte sSteelixAnims_12_3
+.4byte sSteelixAnims_12_4
+.4byte sSteelixAnims_12_5
+.4byte sSteelixAnims_12_6
+.4byte sSteelixAnims_12_7
+.4byte sSteelixAnims_12_8
+sSteelixAnimTable13:
+.4byte sSteelixAnims_13_1
+.4byte sSteelixAnims_13_2
+.4byte sSteelixAnims_13_3
+.4byte sSteelixAnims_13_4
+.4byte sSteelixAnims_13_5
+.4byte sSteelixAnims_13_6
+.4byte sSteelixAnims_13_7
+.4byte sSteelixAnims_13_8
+sAxAnimationsSteelix:
+.4byte sSteelixAnimTable1
+.4byte sSteelixAnimTable2
+.4byte sSteelixAnimTable3
+.4byte sSteelixAnimTable4
+.4byte sSteelixAnimTable5
+.4byte sSteelixAnimTable6
+.4byte sSteelixAnimTable7
+.4byte sSteelixAnimTable8
+.4byte sSteelixAnimTable9
+.4byte sSteelixAnimTable10
+.4byte sSteelixAnimTable11
+.4byte sSteelixAnimTable12
+.4byte sSteelixAnimTable13
+sAxSpritesSteelix:
+.4byte sSteelixSprites1
+.4byte sSteelixSprites2
+.4byte sSteelixSprites3
+.4byte sSteelixSprites4
+.4byte sSteelixSprites5
+.4byte sSteelixSprites6
+.4byte sSteelixSprites7
+.4byte sSteelixSprites8
+.4byte sSteelixSprites9
+.4byte sSteelixSprites10
+.4byte sSteelixSprites11
+.4byte sSteelixSprites12
+.4byte sSteelixSprites13
+.4byte sSteelixSprites14
+.4byte sSteelixSprites15
+.4byte sSteelixSprites16
+.4byte sSteelixSprites17
+.4byte sSteelixSprites18
+.4byte sSteelixSprites19
+.4byte sSteelixSprites20
+.4byte sSteelixSprites21
+.4byte sSteelixSprites22
+.4byte sSteelixSprites23
+.4byte sSteelixSprites24
+.4byte sSteelixSprites25
+.4byte sSteelixSprites26
+.4byte sSteelixSprites27
+.4byte sSteelixSprites28
+.4byte sSteelixSprites29
+.4byte sSteelixSprites30
+.4byte sSteelixSprites31
+.4byte sSteelixSprites32
+.4byte sSteelixSprites33
+.4byte sSteelixSprites34
+.4byte sSteelixSprites35
+.4byte sSteelixSprites36
+.4byte sSteelixSprites37
+.4byte sSteelixSprites38
+.4byte sSteelixSprites39
+.4byte sSteelixSprites40
+.4byte sSteelixSprites41
+.4byte sSteelixSprites42
+.4byte sSteelixSprites43
+.4byte sSteelixSprites44
+.4byte sSteelixSprites45
+.4byte sSteelixSprites46
+.4byte sSteelixSprites47
+.4byte sSteelixSprites48
+.4byte sSteelixSprites49
+.4byte sSteelixSprites50
+.4byte sSteelixSprites51
+.4byte sSteelixSprites52
+.4byte sSteelixSprites53
+.4byte sSteelixSprites54
+.4byte sSteelixSprites55
+.4byte sSteelixSprites56
+.4byte sSteelixSprites57
+sAxMainSteelix:
+ax_main sAxPosesSteelix, sAxAnimationsSteelix, 13, sAxSpritesSteelix, sAxPositionsSteelix

--- a/data/ax/sudowoodo.inc
+++ b/data/ax/sudowoodo.inc
@@ -1,0 +1,3057 @@
+.global gAxSudowoodo
+gAxSudowoodo:
+ax_siro sAxMainSudowoodo
+sSudowoodoPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose3:
+ax_pose 0, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose4:
+ax_pose 2, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose5:
+ax_pose 3, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose6:
+ax_pose 4, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose7:
+ax_pose 5, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose8:
+ax_pose 6, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose9:
+ax_pose 7, 0x81e5, 0x80f9, 0x8c00
+ax_pose_terminator
+sSudowoodoPose10:
+ax_pose 8, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose11:
+ax_pose 9, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose12:
+ax_pose 10, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose13:
+ax_pose 11, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose14:
+ax_pose 12, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose15:
+ax_pose 13, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose16:
+ax_pose 14, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose17:
+ax_pose 15, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose18:
+ax_pose 16, 0x01e9, 0x80f6, 0x8c00
+ax_pose_terminator
+sSudowoodoPose19:
+ax_pose 15, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose20:
+ax_pose 17, 0x01e9, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose21:
+ax_pose 11, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose22:
+ax_pose 12, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose23:
+ax_pose 13, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose24:
+ax_pose 14, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose25:
+ax_pose 9, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose26:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose27:
+ax_pose 7, 0x81e5, 0x90f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose28:
+ax_pose 18, 0x01e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose29:
+ax_pose 5, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose30:
+ax_pose 4, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose31:
+ax_pose 3, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose32:
+ax_pose 6, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose33:
+ax_pose 0, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose34:
+ax_pose 1, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose35:
+ax_pose 0, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose36:
+ax_pose 2, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose37:
+ax_pose 19, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose38:
+ax_pose 3, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose39:
+ax_pose 4, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose40:
+ax_pose 5, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose41:
+ax_pose 6, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose42:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose43:
+ax_pose 7, 0x81e5, 0x80f9, 0x8c00
+ax_pose_terminator
+sSudowoodoPose44:
+ax_pose 8, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose45:
+ax_pose 9, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose46:
+ax_pose 10, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose47:
+ax_pose 21, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose48:
+ax_pose 11, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose49:
+ax_pose 12, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose50:
+ax_pose 13, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose51:
+ax_pose 14, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose52:
+ax_pose 22, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose53:
+ax_pose 15, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose54:
+ax_pose 16, 0x01e9, 0x80f6, 0x8c00
+ax_pose_terminator
+sSudowoodoPose55:
+ax_pose 15, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose56:
+ax_pose 17, 0x01e9, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose57:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose58:
+ax_pose 11, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose59:
+ax_pose 12, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose60:
+ax_pose 13, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose61:
+ax_pose 14, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose62:
+ax_pose 24, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose63:
+ax_pose 9, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose64:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose65:
+ax_pose 7, 0x81e5, 0x90f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose66:
+ax_pose 18, 0x01e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose67:
+ax_pose 25, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose68:
+ax_pose 5, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose69:
+ax_pose 4, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose70:
+ax_pose 3, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose71:
+ax_pose 6, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose72:
+ax_pose 26, 0x01e7, 0x80ef, 0x8c00
+ax_pose_terminator
+sSudowoodoPose73:
+ax_pose 0, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose74:
+ax_pose 1, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose75:
+ax_pose 0, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose76:
+ax_pose 2, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose77:
+ax_pose 19, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose78:
+ax_pose 27, 0x01e9, 0x80f0, 0x8c00
+ax_pose 28, 0x01e6, 0x80f1, 0x8c10
+ax_pose_terminator
+sSudowoodoPose79:
+ax_pose 28, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose80:
+ax_pose 3, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose81:
+ax_pose 4, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose82:
+ax_pose 5, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose83:
+ax_pose 6, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose84:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose85:
+ax_pose 29, 0x01e9, 0x90f1, 0x8c00
+ax_pose 30, 0x01e5, 0x80ef, 0x8c10
+ax_pose_terminator
+sSudowoodoPose86:
+ax_pose 30, 0x01e5, 0x80ef, 0x8c00
+ax_pose_terminator
+sSudowoodoPose87:
+ax_pose 7, 0x81e5, 0x80f9, 0x8c00
+ax_pose_terminator
+sSudowoodoPose88:
+ax_pose 8, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose89:
+ax_pose 9, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose90:
+ax_pose 10, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose91:
+ax_pose 21, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose92:
+ax_pose 31, 0x01e4, 0x90f1, 0x8c00
+ax_pose 32, 0x41f4, 0x80f3, 0x8c10
+ax_pose_terminator
+sSudowoodoPose93:
+ax_pose 32, 0x41f4, 0x80f3, 0x8c00
+ax_pose_terminator
+sSudowoodoPose94:
+ax_pose 11, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose95:
+ax_pose 12, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose96:
+ax_pose 13, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose97:
+ax_pose 14, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose98:
+ax_pose 22, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose99:
+ax_pose 33, 0x01e7, 0x90f1, 0x8c00
+ax_pose 34, 0x01e8, 0x80ef, 0x8c10
+ax_pose_terminator
+sSudowoodoPose100:
+ax_pose 34, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sSudowoodoPose101:
+ax_pose 15, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose102:
+ax_pose 16, 0x01e9, 0x80f6, 0x8c00
+ax_pose_terminator
+sSudowoodoPose103:
+ax_pose 15, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose104:
+ax_pose 17, 0x01e9, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose105:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose106:
+ax_pose 35, 0x01e6, 0x80f1, 0x8c00
+ax_pose 36, 0x01ec, 0x80f1, 0x8c10
+ax_pose_terminator
+sSudowoodoPose107:
+ax_pose 35, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose108:
+ax_pose 11, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose109:
+ax_pose 12, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose110:
+ax_pose 13, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose111:
+ax_pose 14, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose112:
+ax_pose 24, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose113:
+ax_pose 33, 0x01e8, 0x80f0, 0x8c00
+ax_pose 37, 0x01e8, 0x80f1, 0x8c10
+ax_pose_terminator
+sSudowoodoPose114:
+ax_pose 37, 0x01e8, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose115:
+ax_pose 9, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose116:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose117:
+ax_pose 7, 0x81e5, 0x90f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose118:
+ax_pose 18, 0x01e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose119:
+ax_pose 25, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose120:
+ax_pose 31, 0x01e4, 0x80f0, 0x8c00
+ax_pose 38, 0x41f4, 0x80f1, 0x8c10
+ax_pose_terminator
+sSudowoodoPose121:
+ax_pose 38, 0x41f4, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose122:
+ax_pose 5, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose123:
+ax_pose 4, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose124:
+ax_pose 3, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose125:
+ax_pose 6, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose126:
+ax_pose 26, 0x01e7, 0x80ef, 0x8c00
+ax_pose_terminator
+sSudowoodoPose127:
+ax_pose 29, 0x01e9, 0x80f0, 0x8c00
+ax_pose 39, 0x01e6, 0x80f2, 0x8c10
+ax_pose_terminator
+sSudowoodoPose128:
+ax_pose 39, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose129:
+ax_pose 1, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose130:
+ax_pose 4, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose131:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose132:
+ax_pose 12, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose133:
+ax_pose 16, 0x01eb, 0x80f6, 0x8c00
+ax_pose_terminator
+sSudowoodoPose134:
+ax_pose 12, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose135:
+ax_pose 8, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose136:
+ax_pose 4, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose137:
+ax_pose 0, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose138:
+ax_pose 40, 0x01e9, 0x80f3, 0x8c00
+ax_pose_terminator
+sSudowoodoPose139:
+ax_pose 3, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose140:
+ax_pose 41, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose141:
+ax_pose 7, 0x81e5, 0x80f9, 0x8c00
+ax_pose_terminator
+sSudowoodoPose142:
+ax_pose 42, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose143:
+ax_pose 11, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose144:
+ax_pose 43, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose145:
+ax_pose 15, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose146:
+ax_pose 44, 0x01e9, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose147:
+ax_pose 11, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose148:
+ax_pose 45, 0x01e6, 0x80f3, 0x8c00
+ax_pose_terminator
+sSudowoodoPose149:
+ax_pose 9, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose150:
+ax_pose 46, 0x01e5, 0x80f6, 0x8c00
+ax_pose_terminator
+sSudowoodoPose151:
+ax_pose 5, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose152:
+ax_pose 47, 0x81e5, 0x40fc, 0x8c00
+ax_pose_terminator
+sSudowoodoPose153:
+ax_pose 48, 0x01ef, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose154:
+ax_pose 49, 0x01ef, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose155:
+ax_pose 50, 0x01df, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose156:
+ax_pose 51, 0x01e0, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose157:
+ax_pose 52, 0x01e1, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose158:
+ax_pose 53, 0x01e2, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose159:
+ax_pose 54, 0x01e1, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose160:
+ax_pose 53, 0x01e2, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose161:
+ax_pose 52, 0x01e1, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose162:
+ax_pose 51, 0x01e0, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose163:
+ax_pose 0, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose164:
+ax_pose 1, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose165:
+ax_pose 0, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose166:
+ax_pose 2, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose167:
+ax_pose 3, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose168:
+ax_pose 4, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose169:
+ax_pose 5, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose170:
+ax_pose 6, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose171:
+ax_pose 7, 0x81e5, 0x80f9, 0x8c00
+ax_pose_terminator
+sSudowoodoPose172:
+ax_pose 8, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose173:
+ax_pose 9, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose174:
+ax_pose 10, 0x81e5, 0x90f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose175:
+ax_pose 11, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose176:
+ax_pose 12, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose177:
+ax_pose 13, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose178:
+ax_pose 14, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose179:
+ax_pose 15, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose180:
+ax_pose 16, 0x01e9, 0x80f6, 0x8c00
+ax_pose_terminator
+sSudowoodoPose181:
+ax_pose 15, 0x01e9, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose182:
+ax_pose 17, 0x01e9, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose183:
+ax_pose 11, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose184:
+ax_pose 12, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose185:
+ax_pose 13, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose186:
+ax_pose 14, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose187:
+ax_pose 9, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose188:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose189:
+ax_pose 7, 0x81e5, 0x90f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose190:
+ax_pose 18, 0x01e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose191:
+ax_pose 5, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose192:
+ax_pose 4, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose193:
+ax_pose 3, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose194:
+ax_pose 6, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose195:
+ax_pose 19, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose196:
+ax_pose 26, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sSudowoodoPose197:
+ax_pose 25, 0x01e6, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose198:
+ax_pose 24, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose199:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose200:
+ax_pose 22, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose201:
+ax_pose 21, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose202:
+ax_pose 20, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose203:
+ax_pose 19, 0x01e7, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose204:
+ax_pose 20, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose205:
+ax_pose 21, 0x01e5, 0x80f3, 0x8c00
+ax_pose_terminator
+sSudowoodoPose206:
+ax_pose 22, 0x01e6, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose207:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose208:
+ax_pose 24, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose209:
+ax_pose 25, 0x01e7, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose210:
+ax_pose 26, 0x01e8, 0x80ef, 0x8c00
+ax_pose_terminator
+sSudowoodoPose211:
+ax_pose 0, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose212:
+ax_pose 19, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose213:
+ax_pose 28, 0x01e4, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose214:
+ax_pose 3, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose215:
+ax_pose 20, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose216:
+ax_pose 30, 0x01e3, 0x80ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose217:
+ax_pose 7, 0x81e5, 0x80f9, 0x8c00
+ax_pose_terminator
+sSudowoodoPose218:
+ax_pose 21, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose219:
+ax_pose 32, 0x41f4, 0x80f3, 0x8c00
+ax_pose_terminator
+sSudowoodoPose220:
+ax_pose 11, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose221:
+ax_pose 22, 0x01e5, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose222:
+ax_pose 34, 0x01e7, 0x80ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose223:
+ax_pose 15, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose224:
+ax_pose 23, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose225:
+ax_pose 35, 0x01e6, 0x80f1, 0x8c00
+ax_pose_terminator
+sSudowoodoPose226:
+ax_pose 11, 0x01e5, 0x90ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose227:
+ax_pose 24, 0x01e5, 0x80ee, 0x8c00
+ax_pose_terminator
+sSudowoodoPose228:
+ax_pose 37, 0x01e7, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose229:
+ax_pose 9, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose230:
+ax_pose 25, 0x01e5, 0x80f7, 0x8c00
+ax_pose_terminator
+sSudowoodoPose231:
+ax_pose 38, 0x41f4, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose232:
+ax_pose 5, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose233:
+ax_pose 26, 0x01e7, 0x80ef, 0x8c00
+ax_pose_terminator
+sSudowoodoPose234:
+ax_pose 39, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose235:
+ax_pose 1, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose236:
+ax_pose 4, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose237:
+ax_pose 8, 0x01e5, 0x80f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose238:
+ax_pose 12, 0x01e5, 0x80f5, 0x8c00
+ax_pose_terminator
+sSudowoodoPose239:
+ax_pose 16, 0x01eb, 0x80f6, 0x8c00
+ax_pose_terminator
+sSudowoodoPose240:
+ax_pose 12, 0x01e5, 0x90eb, 0x8c00
+ax_pose_terminator
+sSudowoodoPose241:
+ax_pose 8, 0x01e5, 0x90f0, 0x8c00
+ax_pose_terminator
+sSudowoodoPose242:
+ax_pose 4, 0x01e5, 0x90ec, 0x8c00
+ax_pose_terminator
+sSudowoodoPose243:
+ax_pose 0, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose244:
+ax_pose 5, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose245:
+ax_pose 9, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose246:
+ax_pose 13, 0x01e5, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose247:
+ax_pose 15, 0x01e9, 0x80f4, 0x8c00
+ax_pose_terminator
+sSudowoodoPose248:
+ax_pose 11, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+sSudowoodoPose249:
+ax_pose 7, 0x81e5, 0x80f8, 0x8c00
+ax_pose_terminator
+sSudowoodoPose250:
+ax_pose 3, 0x01e5, 0x80f2, 0x8c00
+ax_pose_terminator
+.align 2
+sSudowoodoAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_1_2:
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_1_3:
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_1_4:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_1_5:
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_1_6:
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_1_7:
+ax_anim 8, 0, 24, 0, 0, 0, 0,
+ax_anim 10, 0, 25, 0, 0, 0, 0,
+ax_anim 8, 0, 26, 0, 0, 0, 0,
+ax_anim 10, 0, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_1_8:
+ax_anim 8, 0, 28, 0, 0, 0, 0,
+ax_anim 10, 0, 29, 0, 0, 0, 0,
+ax_anim 8, 0, 30, 0, 0, 0, 0,
+ax_anim 10, 0, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_2_1:
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 2, 0, 32, 0, -2, 0, -2,
+ax_anim 6, 0, 33, 0, -3, 0, -3,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 0, 4, 0, 4,
+ax_anim 1, 0, 35, 0, 10, 0, 10,
+ax_anim 2, 0, 36, 0, 20, 0, 20,
+ax_anim 2, 1, 36, 1, 20, 1, 20,
+ax_anim 2, 0, 36, 0, 20, 0, 20,
+ax_anim 2, 0, 36, 1, 20, 1, 20,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sSudowoodoAnims_2_2:
+ax_anim 2, 0, 37, -1, -1, -1, -1,
+ax_anim 2, 0, 37, -2, -2, -2, -2,
+ax_anim 6, 0, 38, -3, -3, -3, -3,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, 4, 4, 4,
+ax_anim 1, 0, 40, 10, 10, 10, 10,
+ax_anim 2, 0, 41, 20, 20, 20, 20,
+ax_anim 2, 1, 41, 21, 19, 21, 19,
+ax_anim 2, 0, 41, 20, 20, 20, 20,
+ax_anim 2, 0, 41, 21, 19, 21, 19,
+ax_anim 2, 0, 37, 6, 6, 6, 6,
+ax_anim_terminator
+sSudowoodoAnims_2_3:
+ax_anim 2, 0, 42, -1, 0, -1, 0,
+ax_anim 2, 0, 42, -2, 0, -2, 0,
+ax_anim 6, 0, 43, -3, 0, -3, 0,
+ax_anim 1, 0, 45, 2, 0, 2, 0,
+ax_anim 1, 2, 43, 6, 0, 6, 0,
+ax_anim 1, 0, 45, 14, 0, 14, 0,
+ax_anim 2, 0, 46, 24, 0, 24, 0,
+ax_anim 2, 1, 46, 24, 1, 24, 1,
+ax_anim 2, 0, 46, 24, 0, 24, 0,
+ax_anim 2, 0, 46, 24, 1, 24, 1,
+ax_anim 2, 0, 42, 6, 0, 6, 0,
+ax_anim_terminator
+sSudowoodoAnims_2_4:
+ax_anim 2, 0, 47, -1, 1, -1, 1,
+ax_anim 2, 0, 47, -2, 2, -2, 2,
+ax_anim 6, 0, 48, -3, 3, -3, 3,
+ax_anim 1, 0, 50, 0, -1, 0, -1,
+ax_anim 1, 2, 48, 6, -6, 6, -6,
+ax_anim 1, 0, 50, 13, -12, 13, -12,
+ax_anim 2, 0, 51, 22, -19, 22, -19,
+ax_anim 2, 1, 51, 23, -18, 23, -18,
+ax_anim 2, 0, 51, 22, -19, 22, -19,
+ax_anim 2, 0, 51, 23, -18, 23, -18,
+ax_anim 2, 0, 47, 6, -6, 6, -6,
+ax_anim_terminator
+sSudowoodoAnims_2_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 2, 0, 52, 0, 2, 0, 2,
+ax_anim 6, 0, 53, 0, 4, 0, 4,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 0, -4, 0, -4,
+ax_anim 1, 0, 55, 0, -10, 0, -10,
+ax_anim 2, 0, 56, 0, -18, 0, -18,
+ax_anim 2, 1, 56, 1, -18, 1, -18,
+ax_anim 2, 0, 56, 0, -18, 0, -18,
+ax_anim 2, 0, 56, 1, -18, 1, -18,
+ax_anim 2, 0, 52, 0, -6, 0, -6,
+ax_anim_terminator
+sSudowoodoAnims_2_6:
+ax_anim 2, 0, 57, 1, 1, 1, 1,
+ax_anim 2, 0, 57, 2, 2, 2, 2,
+ax_anim 6, 0, 58, 3, 3, 3, 3,
+ax_anim 1, 0, 60, 0, -1, 0, -1,
+ax_anim 1, 2, 58, -6, -6, -6, -6,
+ax_anim 1, 0, 60, -13, -12, -13, -12,
+ax_anim 2, 0, 61, -22, -19, -22, -19,
+ax_anim 2, 1, 61, -23, -18, -23, -18,
+ax_anim 2, 0, 61, -22, -19, -22, -19,
+ax_anim 2, 0, 61, -23, -18, -23, -18,
+ax_anim 2, 0, 57, -6, -6, -6, -6,
+ax_anim_terminator
+sSudowoodoAnims_2_7:
+ax_anim 2, 0, 62, 1, 0, 1, 0,
+ax_anim 2, 0, 62, 2, 0, 2, 0,
+ax_anim 6, 0, 63, 3, 0, 3, 0,
+ax_anim 1, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 2, 63, -6, 0, -6, 0,
+ax_anim 1, 0, 65, -14, 0, -14, 0,
+ax_anim 2, 0, 66, -24, 0, -24, 0,
+ax_anim 2, 1, 66, -24, 1, -24, 1,
+ax_anim 2, 0, 66, -24, 0, -24, 0,
+ax_anim 2, 0, 66, -24, 1, -24, 1,
+ax_anim 2, 0, 62, -6, 0, -6, 0,
+ax_anim_terminator
+sSudowoodoAnims_2_8:
+ax_anim 2, 0, 67, 1, -1, 1, -1,
+ax_anim 2, 0, 67, 2, -2, 2, -2,
+ax_anim 6, 0, 68, 3, -3, 3, -3,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -20, 20, -20, 20,
+ax_anim 2, 1, 71, -21, 19, -21, 19,
+ax_anim 2, 0, 71, -20, 20, -20, 20,
+ax_anim 2, 0, 71, -21, 19, -21, 19,
+ax_anim 2, 0, 67, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_3_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 2, 0, 76, 0, -3, 0, -3,
+ax_anim 6, 0, 76, 0, -4, 0, -4,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 2, 76, 0, 10, 0, 10,
+ax_anim 2, 0, 77, 0, 16, 0, 16,
+ax_anim 2, 1, 78, -1, 16, -1, 16,
+ax_anim 2, 0, 78, 0, 16, 0, 16,
+ax_anim 2, 0, 78, -1, 16, -1, 16,
+ax_anim 2, 0, 78, 0, 16, 0, 16,
+ax_anim 2, 0, 78, -1, 16, -1, 16,
+ax_anim 2, 0, 72, 0, 9, 0, 9,
+ax_anim 2, 0, 72, 0, 3, 0, 3,
+ax_anim_terminator
+sSudowoodoAnims_3_2:
+ax_anim 2, 0, 79, -2, -2, -2, -2,
+ax_anim 2, 0, 83, -3, -3, -3, -3,
+ax_anim 6, 0, 83, -4, -4, -4, -4,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 10, 11, 10, 11,
+ax_anim 2, 0, 84, 16, 18, 16, 18,
+ax_anim 2, 1, 85, 15, 19, 15, 19,
+ax_anim 2, 0, 85, 16, 18, 16, 18,
+ax_anim 2, 0, 85, 15, 19, 15, 19,
+ax_anim 2, 0, 85, 16, 18, 16, 18,
+ax_anim 2, 0, 85, 15, 19, 15, 19,
+ax_anim 2, 0, 79, 9, 10, 9, 10,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim_terminator
+sSudowoodoAnims_3_3:
+ax_anim 2, 0, 86, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -3, 0, -3, 0,
+ax_anim 6, 0, 90, -4, 0, -4, 0,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 8, 0, 8, 0,
+ax_anim 2, 0, 91, 14, 0, 14, 0,
+ax_anim 2, 1, 92, 14, 1, 14, 1,
+ax_anim 2, 0, 92, 14, 0, 14, 0,
+ax_anim 2, 0, 92, 14, 1, 14, 1,
+ax_anim 2, 0, 92, 14, 0, 14, 0,
+ax_anim 2, 0, 92, 14, 1, 14, 1,
+ax_anim 2, 0, 86, 9, 0, 9, 0,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim_terminator
+sSudowoodoAnims_3_4:
+ax_anim 2, 0, 93, -2, 2, -2, 2,
+ax_anim 2, 0, 97, -3, 3, -3, 3,
+ax_anim 6, 0, 97, -4, 4, -4, 4,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 8, -11, 8, -11,
+ax_anim 2, 0, 98, 15, -21, 15, -21,
+ax_anim 2, 1, 99, 16, -20, 16, -20,
+ax_anim 2, 0, 99, 15, -21, 15, -21,
+ax_anim 2, 0, 99, 16, -20, 16, -20,
+ax_anim 2, 0, 99, 15, -21, 15, -21,
+ax_anim 2, 0, 99, 16, -20, 16, -20,
+ax_anim 2, 0, 93, 10, -10, 10, -10,
+ax_anim 2, 0, 93, 3, -4, 3, -4,
+ax_anim_terminator
+sSudowoodoAnims_3_5:
+ax_anim 2, 0, 100, 0, 2, 0, 2,
+ax_anim 2, 0, 104, 0, 3, 0, 3,
+ax_anim 6, 0, 104, 0, 4, 0, 4,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, -10, 0, -10,
+ax_anim 2, 0, 105, 0, -22, 0, -22,
+ax_anim 2, 1, 106, -1, -22, -1, -22,
+ax_anim 2, 0, 106, 0, -22, 0, -22,
+ax_anim 2, 0, 106, -1, -22, -1, -22,
+ax_anim 2, 0, 106, 0, -22, 0, -22,
+ax_anim 2, 0, 106, -1, -22, -1, -22,
+ax_anim 2, 0, 100, 0, -9, 0, -9,
+ax_anim 2, 0, 100, 0, -3, 0, -3,
+ax_anim_terminator
+sSudowoodoAnims_3_6:
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim 2, 0, 111, 3, 3, 3, 3,
+ax_anim 6, 0, 111, 4, 4, 4, 4,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 111, -8, -11, -8, -11,
+ax_anim 2, 0, 112, -14, -22, -14, -22,
+ax_anim 2, 1, 113, -15, -21, -15, -21,
+ax_anim 2, 0, 113, -14, -22, -14, -22,
+ax_anim 2, 0, 113, -15, -21, -15, -21,
+ax_anim 2, 0, 113, -14, -22, -14, -22,
+ax_anim 2, 0, 113, -15, -21, -15, -21,
+ax_anim 2, 0, 107, -10, -10, -10, -10,
+ax_anim 2, 0, 107, -3, -4, -3, -4,
+ax_anim_terminator
+sSudowoodoAnims_3_7:
+ax_anim 2, 0, 114, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 3, 0, 3, 0,
+ax_anim 6, 0, 118, 4, 0, 4, 0,
+ax_anim 1, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 118, -8, 0, -8, 0,
+ax_anim 2, 0, 119, -14, 0, -14, 0,
+ax_anim 2, 1, 120, -14, 1, -14, 1,
+ax_anim 2, 0, 120, -14, 0, -14, 0,
+ax_anim 2, 0, 120, -14, 1, -14, 1,
+ax_anim 2, 0, 120, -14, 0, -14, 0,
+ax_anim 2, 0, 120, -14, 1, -14, 1,
+ax_anim 2, 0, 114, -9, 0, -9, 0,
+ax_anim 2, 0, 114, -3, 0, -3, 0,
+ax_anim_terminator
+sSudowoodoAnims_3_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 2, 0, 125, 3, -3, 3, -3,
+ax_anim 6, 0, 125, 4, -4, 4, -4,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 125, -10, 11, -10, 11,
+ax_anim 2, 0, 126, -16, 18, -16, 18,
+ax_anim 2, 1, 127, -15, 19, -15, 19,
+ax_anim 2, 0, 127, -16, 18, -16, 18,
+ax_anim 2, 0, 127, -15, 19, -15, 19,
+ax_anim 2, 0, 127, -16, 18, -16, 18,
+ax_anim 2, 0, 127, -15, 19, -15, 19,
+ax_anim 2, 0, 121, -9, 10, -9, 10,
+ax_anim 2, 0, 121, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_4_1:
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 1, 0, 1, 0,
+ax_anim 2, 1, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_4_2:
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, -1, 1, -1,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_4_3:
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -1, 0, -1,
+ax_anim 2, 1, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_4_4:
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, -1, -1, -1,
+ax_anim 2, 1, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_4_5:
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_4_6:
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 1, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_4_7:
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -1, 0, -1,
+ax_anim 2, 1, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_4_8:
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, -1, -1, -1, -1,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_5_1:
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, -1, 0, 0,
+ax_anim 1, 0, 150, 0, -2, 0, 0,
+ax_anim 1, 0, 148, 0, -3, 0, 0,
+ax_anim 1, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 2, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 1, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_5_2:
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, -1, 0, 0,
+ax_anim 1, 0, 140, 0, -2, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 1, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 2, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 1, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_5_3:
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, -2, 0, 0,
+ax_anim 1, 0, 144, 0, -3, 0, 0,
+ax_anim 1, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 2, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 1, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_5_4:
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -1, 0, 0,
+ax_anim 1, 0, 144, 0, -2, 0, 0,
+ax_anim 1, 0, 146, 0, -3, 0, 0,
+ax_anim 1, 0, 148, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 2, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 1, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_5_5:
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 0, -1, 0, 0,
+ax_anim 1, 0, 142, 0, -2, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 1, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 2, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 146, 0, -1, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 1, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_5_6:
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -1, 0, 0,
+ax_anim 1, 0, 144, 0, -2, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 1, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 2, 150, 0, -2, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 8, 1, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_5_7:
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -1, 0, 0,
+ax_anim 1, 0, 146, 0, -2, 0, 0,
+ax_anim 1, 0, 144, 0, -3, 0, 0,
+ax_anim 1, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 2, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, -1, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 8, 1, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_5_8:
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -1, 0, 0,
+ax_anim 1, 0, 150, 0, -2, 0, 0,
+ax_anim 1, 0, 148, 0, -3, 0, 0,
+ax_anim 1, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 2, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -1, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 1, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sSudowoodoAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sSudowoodoAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sSudowoodoAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sSudowoodoAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sSudowoodoAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sSudowoodoAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sSudowoodoAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_8_1:
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_8_2:
+ax_anim 8, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_8_3:
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_8_4:
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_8_5:
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_8_6:
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_8_7:
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_8_8:
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 3, 6, 3,
+ax_anim 2, 0, 196, 9, 9, 9, 9,
+ax_anim 2, 0, 197, 9, 17, 9, 17,
+ax_anim 3, 0, 198, 0, 22, 0, 22,
+ax_anim 2, 3, 199, -9, 17, -9, 17,
+ax_anim 2, 0, 200, -9, 9, -9, 9,
+ax_anim 1, 0, 201, -6, 3, -6, 3,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 8, 0, 8, 0,
+ax_anim 2, 0, 195, 17, 4, 17, 4,
+ax_anim 2, 0, 196, 21, 11, 21, 11,
+ax_anim 3, 0, 197, 22, 20, 22, 20,
+ax_anim 2, 3, 198, 11, 22, 11, 22,
+ax_anim 2, 0, 199, 3, 15, 3, 15,
+ax_anim 1, 0, 200, 0, 7, 0, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -4, 3, -4,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 16, -5, 16, -5,
+ax_anim 3, 0, 196, 22, 0, 22, 0,
+ax_anim 2, 3, 197, 20, 5, 20, 5,
+ax_anim 2, 0, 198, 12, 7, 12, 7,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -1, -8, -1, -8,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 12, -22, 12, -22,
+ax_anim 3, 0, 195, 21, -20, 21, -20,
+ax_anim 2, 3, 196, 22, -14, 22, -14,
+ax_anim 2, 0, 197, 19, -5, 19, -5,
+ax_anim 1, 0, 198, 9, -1, 9, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -9, -3, -9, -3,
+ax_anim 2, 0, 200, -9, -12, -9, -12,
+ax_anim 2, 0, 201, -7, -18, -7, -18,
+ax_anim 3, 0, 194, 0, -21, 0, -21,
+ax_anim 2, 3, 195, 7, -18, 7, -18,
+ax_anim 2, 0, 196, 9, -12, 9, -12,
+ax_anim 1, 0, 197, 9, -3, 9, -3,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 1, -8, 1, -8,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -12, -22, -12, -22,
+ax_anim 3, 0, 201, -21, -20, -21, -20,
+ax_anim 2, 3, 200, -22, -14, -22, -14,
+ax_anim 2, 0, 199, -19, -5, -19, -5,
+ax_anim 1, 0, 198, -9, -1, -9, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -4, -3, -4,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -16, -5, -16, -5,
+ax_anim 3, 0, 200, -22, 0, -22, 0,
+ax_anim 2, 3, 199, -20, 5, -20, 5,
+ax_anim 2, 0, 198, -12, 7, -12, 7,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -8, 0, -8, 0,
+ax_anim 2, 0, 201, -17, 4, -17, 4,
+ax_anim 2, 0, 200, -20, 11, -20, 11,
+ax_anim 3, 0, 199, -22, 20, -22, 20,
+ax_anim 2, 3, 198, -11, 22, -11, 22,
+ax_anim 2, 0, 197, -3, 15, -3, 15,
+ax_anim 1, 0, 196, 0, 7, 0, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -23, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 214, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -22, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -19, 0, 0,
+ax_anim 4, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -20, 0, 0,
+ax_anim 3, 0, 224, 0, -19, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 225, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -19, 0, 0,
+ax_anim 4, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 231, 0, -22, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSudowoodoAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sSudowoodoGfx1:
+.incbin "baserom.gba", 0xCFCE9C, 0x200
+sSudowoodoSprites1:
+ax_sprite sSudowoodoGfx1, 0x200
+ax_sprite_terminator
+sSudowoodoGfx2:
+.incbin "baserom.gba", 0xCFD0AC, 0x200
+sSudowoodoSprites2:
+ax_sprite sSudowoodoGfx2, 0x200
+ax_sprite_terminator
+sSudowoodoGfx3:
+.incbin "baserom.gba", 0xCFD2BC, 0x200
+sSudowoodoSprites3:
+ax_sprite sSudowoodoGfx3, 0x200
+ax_sprite_terminator
+sSudowoodoGfx4:
+.incbin "baserom.gba", 0xCFD4CC, 0x200
+sSudowoodoSprites4:
+ax_sprite sSudowoodoGfx4, 0x200
+ax_sprite_terminator
+sSudowoodoGfx5:
+.incbin "baserom.gba", 0xCFD6DC, 0x200
+sSudowoodoSprites5:
+ax_sprite sSudowoodoGfx5, 0x200
+ax_sprite_terminator
+sSudowoodoGfx6:
+.incbin "baserom.gba", 0xCFD8EC, 0x200
+sSudowoodoSprites6:
+ax_sprite sSudowoodoGfx6, 0x200
+ax_sprite_terminator
+sSudowoodoGfx7:
+.incbin "baserom.gba", 0xCFDAFC, 0x200
+sSudowoodoSprites7:
+ax_sprite sSudowoodoGfx7, 0x200
+ax_sprite_terminator
+sSudowoodoGfx8:
+.incbin "baserom.gba", 0xCFDD0C, 0x100
+sSudowoodoSprites8:
+ax_sprite sSudowoodoGfx8, 0x100
+ax_sprite_terminator
+sSudowoodoGfx9:
+.incbin "baserom.gba", 0xCFDE1C, 0x200
+sSudowoodoSprites9:
+ax_sprite sSudowoodoGfx9, 0x200
+ax_sprite_terminator
+sSudowoodoGfx10:
+.incbin "baserom.gba", 0xCFE02C, 0x100
+sSudowoodoSprites10:
+ax_sprite sSudowoodoGfx10, 0x100
+ax_sprite_terminator
+sSudowoodoGfx11:
+.incbin "baserom.gba", 0xCFE13C, 0x100
+sSudowoodoSprites11:
+ax_sprite sSudowoodoGfx11, 0x100
+ax_sprite_terminator
+sSudowoodoGfx12:
+.incbin "baserom.gba", 0xCFE24C, 0x200
+sSudowoodoSprites12:
+ax_sprite sSudowoodoGfx12, 0x200
+ax_sprite_terminator
+sSudowoodoGfx13:
+.incbin "baserom.gba", 0xCFE45C, 0x200
+sSudowoodoSprites13:
+ax_sprite sSudowoodoGfx13, 0x200
+ax_sprite_terminator
+sSudowoodoGfx14:
+.incbin "baserom.gba", 0xCFE66C, 0x200
+sSudowoodoSprites14:
+ax_sprite sSudowoodoGfx14, 0x200
+ax_sprite_terminator
+sSudowoodoGfx15:
+.incbin "baserom.gba", 0xCFE87C, 0x200
+sSudowoodoSprites15:
+ax_sprite sSudowoodoGfx15, 0x200
+ax_sprite_terminator
+sSudowoodoGfx16:
+.incbin "baserom.gba", 0xCFEA8C, 0x200
+sSudowoodoSprites16:
+ax_sprite sSudowoodoGfx16, 0x200
+ax_sprite_terminator
+sSudowoodoGfx17:
+.incbin "baserom.gba", 0xCFEC9C, 0x200
+sSudowoodoSprites17:
+ax_sprite sSudowoodoGfx17, 0x200
+ax_sprite_terminator
+sSudowoodoGfx18:
+.incbin "baserom.gba", 0xCFEEAC, 0x200
+sSudowoodoSprites18:
+ax_sprite sSudowoodoGfx18, 0x200
+ax_sprite_terminator
+sSudowoodoGfx19:
+.incbin "baserom.gba", 0xCFF0BC, 0x200
+sSudowoodoSprites19:
+ax_sprite sSudowoodoGfx19, 0x200
+ax_sprite_terminator
+sSudowoodoGfx20:
+.incbin "baserom.gba", 0xCFF2CC, 0x100
+sSudowoodoGfx20_1:
+.incbin "baserom.gba", 0xCFF3CC, 0x40
+sSudowoodoGfx20_2:
+.incbin "baserom.gba", 0xCFF40C, 0x60
+sSudowoodoSprites20:
+ax_sprite sSudowoodoGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx20_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx21:
+.incbin "baserom.gba", 0xCFF4A4, 0x60
+sSudowoodoGfx21_1:
+.incbin "baserom.gba", 0xCFF504, 0x60
+sSudowoodoGfx21_2:
+.incbin "baserom.gba", 0xCFF564, 0x60
+sSudowoodoGfx21_3:
+.incbin "baserom.gba", 0xCFF5C4, 0x40
+sSudowoodoSprites21:
+ax_sprite sSudowoodoGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx22:
+.incbin "baserom.gba", 0xCFF64C, 0x40
+sSudowoodoGfx22_1:
+.incbin "baserom.gba", 0xCFF68C, 0x40
+sSudowoodoGfx22_2:
+.incbin "baserom.gba", 0xCFF6CC, 0x40
+sSudowoodoGfx22_3:
+.incbin "baserom.gba", 0xCFF70C, 0x40
+sSudowoodoSprites22:
+ax_sprite sSudowoodoGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx22_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sSudowoodoGfx22_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx23:
+.incbin "baserom.gba", 0xCFF794, 0x40
+sSudowoodoGfx23_1:
+.incbin "baserom.gba", 0xCFF7D4, 0x60
+sSudowoodoGfx23_2:
+.incbin "baserom.gba", 0xCFF834, 0x40
+sSudowoodoGfx23_3:
+.incbin "baserom.gba", 0xCFF874, 0x40
+sSudowoodoSprites23:
+ax_sprite sSudowoodoGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx23_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx23_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx24:
+.incbin "baserom.gba", 0xCFF8FC, 0x60
+sSudowoodoGfx24_1:
+.incbin "baserom.gba", 0xCFF95C, 0xE0
+sSudowoodoGfx24_2:
+.incbin "baserom.gba", 0xCFFA3C, 0x60
+sSudowoodoSprites24:
+ax_sprite sSudowoodoGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx24_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx25:
+.incbin "baserom.gba", 0xCFFAD4, 0x40
+sSudowoodoGfx25_1:
+.incbin "baserom.gba", 0xCFFB14, 0x60
+sSudowoodoGfx25_2:
+.incbin "baserom.gba", 0xCFFB74, 0x60
+sSudowoodoGfx25_3:
+.incbin "baserom.gba", 0xCFFBD4, 0x40
+sSudowoodoSprites25:
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx26:
+.incbin "baserom.gba", 0xCFFC64, 0x40
+sSudowoodoGfx26_1:
+.incbin "baserom.gba", 0xCFFCA4, 0x40
+sSudowoodoGfx26_2:
+.incbin "baserom.gba", 0xCFFCE4, 0x40
+sSudowoodoGfx26_3:
+.incbin "baserom.gba", 0xCFFD24, 0x40
+sSudowoodoSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx26_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx26_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSudowoodoGfx27:
+.incbin "baserom.gba", 0xCFFDB4, 0x60
+sSudowoodoGfx27_1:
+.incbin "baserom.gba", 0xCFFE14, 0x60
+sSudowoodoGfx27_2:
+.incbin "baserom.gba", 0xCFFE74, 0x40
+sSudowoodoGfx27_3:
+.incbin "baserom.gba", 0xCFFEB4, 0x20
+sSudowoodoSprites27:
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx27_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sSudowoodoGfx27_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx28:
+.incbin "baserom.gba", 0xCFFF24, 0xA0
+sSudowoodoGfx28_1:
+.incbin "baserom.gba", 0xCFFFC4, 0x120
+sSudowoodoSprites28:
+ax_sprite sSudowoodoGfx28, 0xa0
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx28_1, 0x120
+ax_sprite_terminator
+sSudowoodoGfx29:
+.incbin "baserom.gba", 0xD00104, 0x40
+sSudowoodoGfx29_1:
+.incbin "baserom.gba", 0xD00144, 0x40
+sSudowoodoGfx29_2:
+.incbin "baserom.gba", 0xD00184, 0x80
+sSudowoodoSprites29:
+ax_sprite 0, 0xa0
+ax_sprite sSudowoodoGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx29_2, 0x80
+ax_sprite_terminator
+sSudowoodoGfx30:
+.incbin "baserom.gba", 0xD0023C, 0xE0
+sSudowoodoGfx30_1:
+.incbin "baserom.gba", 0xD0031C, 0x60
+sSudowoodoGfx30_2:
+.incbin "baserom.gba", 0xD0037C, 0x20
+sSudowoodoSprites30:
+ax_sprite sSudowoodoGfx30, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx30_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSudowoodoGfx31:
+.incbin "baserom.gba", 0xD003D4, 0x40
+sSudowoodoGfx31_1:
+.incbin "baserom.gba", 0xD00414, 0x60
+sSudowoodoGfx31_2:
+.incbin "baserom.gba", 0xD00474, 0x60
+sSudowoodoSprites31:
+ax_sprite 0, 0xa0
+ax_sprite sSudowoodoGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx31_2, 0x60
+ax_sprite_terminator
+sSudowoodoGfx32:
+.incbin "baserom.gba", 0xD0050C, 0x60
+sSudowoodoGfx32_1:
+.incbin "baserom.gba", 0xD0056C, 0x60
+sSudowoodoGfx32_2:
+.incbin "baserom.gba", 0xD005CC, 0x40
+sSudowoodoGfx32_3:
+.incbin "baserom.gba", 0xD0060C, 0x40
+sSudowoodoSprites32:
+ax_sprite sSudowoodoGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx32_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx32_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSudowoodoGfx33:
+.incbin "baserom.gba", 0xD00694, 0x100
+sSudowoodoSprites33:
+ax_sprite sSudowoodoGfx33, 0x100
+ax_sprite_terminator
+sSudowoodoGfx34:
+.incbin "baserom.gba", 0xD007A4, 0xC0
+sSudowoodoGfx34_1:
+.incbin "baserom.gba", 0xD00864, 0x80
+sSudowoodoSprites34:
+ax_sprite sSudowoodoGfx34, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx34_1, 0x80
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSudowoodoGfx35:
+.incbin "baserom.gba", 0xD0090C, 0x60
+sSudowoodoGfx35_1:
+.incbin "baserom.gba", 0xD0096C, 0x60
+sSudowoodoGfx35_2:
+.incbin "baserom.gba", 0xD009CC, 0x40
+sSudowoodoSprites35:
+ax_sprite 0, 0xa0
+ax_sprite sSudowoodoGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx36:
+.incbin "baserom.gba", 0xD00A4C, 0x40
+sSudowoodoGfx36_1:
+.incbin "baserom.gba", 0xD00A8C, 0xE0
+sSudowoodoSprites36:
+ax_sprite 0, 0xa0
+ax_sprite sSudowoodoGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx36_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx37:
+.incbin "baserom.gba", 0xD00B9C, 0x120
+sSudowoodoGfx37_1:
+.incbin "baserom.gba", 0xD00CBC, 0x20
+sSudowoodoSprites37:
+ax_sprite sSudowoodoGfx37, 0x120
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx37_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSudowoodoGfx38:
+.incbin "baserom.gba", 0xD00D04, 0x40
+sSudowoodoGfx38_1:
+.incbin "baserom.gba", 0xD00D44, 0x60
+sSudowoodoGfx38_2:
+.incbin "baserom.gba", 0xD00DA4, 0x40
+sSudowoodoSprites38:
+ax_sprite 0, 0x80
+ax_sprite sSudowoodoGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx38_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx39:
+.incbin "baserom.gba", 0xD00E24, 0x60
+sSudowoodoGfx39_1:
+.incbin "baserom.gba", 0xD00E84, 0x80
+sSudowoodoSprites39:
+ax_sprite sSudowoodoGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx39_1, 0x80
+ax_sprite_terminator
+sSudowoodoGfx40:
+.incbin "baserom.gba", 0xD00F24, 0x40
+sSudowoodoGfx40_1:
+.incbin "baserom.gba", 0xD00F64, 0x60
+sSudowoodoGfx40_2:
+.incbin "baserom.gba", 0xD00FC4, 0x60
+sSudowoodoSprites40:
+ax_sprite 0, 0xa0
+ax_sprite sSudowoodoGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx41:
+.incbin "baserom.gba", 0xD01064, 0x40
+sSudowoodoGfx41_1:
+.incbin "baserom.gba", 0xD010A4, 0x60
+sSudowoodoGfx41_2:
+.incbin "baserom.gba", 0xD01104, 0x40
+sSudowoodoGfx41_3:
+.incbin "baserom.gba", 0xD01144, 0x40
+sSudowoodoSprites41:
+ax_sprite sSudowoodoGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx41_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx41_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx41_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx42:
+.incbin "baserom.gba", 0xD011CC, 0x100
+sSudowoodoSprites42:
+ax_sprite sSudowoodoGfx42, 0x100
+ax_sprite_terminator
+sSudowoodoGfx43:
+.incbin "baserom.gba", 0xD012DC, 0x40
+sSudowoodoGfx43_1:
+.incbin "baserom.gba", 0xD0131C, 0x60
+sSudowoodoGfx43_2:
+.incbin "baserom.gba", 0xD0137C, 0x60
+sSudowoodoGfx43_3:
+.incbin "baserom.gba", 0xD013DC, 0x40
+sSudowoodoSprites43:
+ax_sprite sSudowoodoGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx43_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSudowoodoGfx44:
+.incbin "baserom.gba", 0xD01464, 0x40
+sSudowoodoGfx44_1:
+.incbin "baserom.gba", 0xD014A4, 0x100
+sSudowoodoGfx44_2:
+.incbin "baserom.gba", 0xD015A4, 0x40
+sSudowoodoSprites44:
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx44_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx44_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx45:
+.incbin "baserom.gba", 0xD01624, 0x60
+sSudowoodoGfx45_1:
+.incbin "baserom.gba", 0xD01684, 0x60
+sSudowoodoGfx45_2:
+.incbin "baserom.gba", 0xD016E4, 0x60
+sSudowoodoGfx45_3:
+.incbin "baserom.gba", 0xD01744, 0x40
+sSudowoodoSprites45:
+ax_sprite sSudowoodoGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx45_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx45_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx46:
+.incbin "baserom.gba", 0xD017CC, 0x40
+sSudowoodoGfx46_1:
+.incbin "baserom.gba", 0xD0180C, 0xE0
+sSudowoodoGfx46_2:
+.incbin "baserom.gba", 0xD018EC, 0x60
+sSudowoodoSprites46:
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx46, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx46_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx46_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSudowoodoGfx47:
+.incbin "baserom.gba", 0xD0198C, 0x60
+sSudowoodoGfx47_1:
+.incbin "baserom.gba", 0xD019EC, 0x60
+sSudowoodoGfx47_2:
+.incbin "baserom.gba", 0xD01A4C, 0x40
+sSudowoodoGfx47_3:
+.incbin "baserom.gba", 0xD01A8C, 0x40
+sSudowoodoSprites47:
+ax_sprite sSudowoodoGfx47, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSudowoodoGfx47_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSudowoodoGfx47_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSudowoodoGfx48:
+.incbin "baserom.gba", 0xD01B14, 0x80
+sSudowoodoSprites48:
+ax_sprite sSudowoodoGfx48, 0x80
+ax_sprite_terminator
+sSudowoodoGfx49:
+.incbin "baserom.gba", 0xD01BA4, 0x200
+sSudowoodoSprites49:
+ax_sprite sSudowoodoGfx49, 0x200
+ax_sprite_terminator
+sSudowoodoGfx50:
+.incbin "baserom.gba", 0xD01DB4, 0x200
+sSudowoodoSprites50:
+ax_sprite sSudowoodoGfx50, 0x200
+ax_sprite_terminator
+sSudowoodoGfx51:
+.incbin "baserom.gba", 0xD01FC4, 0x200
+sSudowoodoSprites51:
+ax_sprite sSudowoodoGfx51, 0x200
+ax_sprite_terminator
+sSudowoodoGfx52:
+.incbin "baserom.gba", 0xD021D4, 0x200
+sSudowoodoSprites52:
+ax_sprite sSudowoodoGfx52, 0x200
+ax_sprite_terminator
+sSudowoodoGfx53:
+.incbin "baserom.gba", 0xD023E4, 0x200
+sSudowoodoSprites53:
+ax_sprite sSudowoodoGfx53, 0x200
+ax_sprite_terminator
+sSudowoodoGfx54:
+.incbin "baserom.gba", 0xD025F4, 0x200
+sSudowoodoSprites54:
+ax_sprite sSudowoodoGfx54, 0x200
+ax_sprite_terminator
+sSudowoodoGfx55:
+.incbin "baserom.gba", 0xD02804, 0x200
+sSudowoodoSprites55:
+ax_sprite sSudowoodoGfx55, 0x200
+ax_sprite_terminator
+sAxPosesSudowoodo:
+.4byte sSudowoodoPose1
+.4byte sSudowoodoPose2
+.4byte sSudowoodoPose3
+.4byte sSudowoodoPose4
+.4byte sSudowoodoPose5
+.4byte sSudowoodoPose6
+.4byte sSudowoodoPose7
+.4byte sSudowoodoPose8
+.4byte sSudowoodoPose9
+.4byte sSudowoodoPose10
+.4byte sSudowoodoPose11
+.4byte sSudowoodoPose12
+.4byte sSudowoodoPose13
+.4byte sSudowoodoPose14
+.4byte sSudowoodoPose15
+.4byte sSudowoodoPose16
+.4byte sSudowoodoPose17
+.4byte sSudowoodoPose18
+.4byte sSudowoodoPose19
+.4byte sSudowoodoPose20
+.4byte sSudowoodoPose21
+.4byte sSudowoodoPose22
+.4byte sSudowoodoPose23
+.4byte sSudowoodoPose24
+.4byte sSudowoodoPose25
+.4byte sSudowoodoPose26
+.4byte sSudowoodoPose27
+.4byte sSudowoodoPose28
+.4byte sSudowoodoPose29
+.4byte sSudowoodoPose30
+.4byte sSudowoodoPose31
+.4byte sSudowoodoPose32
+.4byte sSudowoodoPose33
+.4byte sSudowoodoPose34
+.4byte sSudowoodoPose35
+.4byte sSudowoodoPose36
+.4byte sSudowoodoPose37
+.4byte sSudowoodoPose38
+.4byte sSudowoodoPose39
+.4byte sSudowoodoPose40
+.4byte sSudowoodoPose41
+.4byte sSudowoodoPose42
+.4byte sSudowoodoPose43
+.4byte sSudowoodoPose44
+.4byte sSudowoodoPose45
+.4byte sSudowoodoPose46
+.4byte sSudowoodoPose47
+.4byte sSudowoodoPose48
+.4byte sSudowoodoPose49
+.4byte sSudowoodoPose50
+.4byte sSudowoodoPose51
+.4byte sSudowoodoPose52
+.4byte sSudowoodoPose53
+.4byte sSudowoodoPose54
+.4byte sSudowoodoPose55
+.4byte sSudowoodoPose56
+.4byte sSudowoodoPose57
+.4byte sSudowoodoPose58
+.4byte sSudowoodoPose59
+.4byte sSudowoodoPose60
+.4byte sSudowoodoPose61
+.4byte sSudowoodoPose62
+.4byte sSudowoodoPose63
+.4byte sSudowoodoPose64
+.4byte sSudowoodoPose65
+.4byte sSudowoodoPose66
+.4byte sSudowoodoPose67
+.4byte sSudowoodoPose68
+.4byte sSudowoodoPose69
+.4byte sSudowoodoPose70
+.4byte sSudowoodoPose71
+.4byte sSudowoodoPose72
+.4byte sSudowoodoPose73
+.4byte sSudowoodoPose74
+.4byte sSudowoodoPose75
+.4byte sSudowoodoPose76
+.4byte sSudowoodoPose77
+.4byte sSudowoodoPose78
+.4byte sSudowoodoPose79
+.4byte sSudowoodoPose80
+.4byte sSudowoodoPose81
+.4byte sSudowoodoPose82
+.4byte sSudowoodoPose83
+.4byte sSudowoodoPose84
+.4byte sSudowoodoPose85
+.4byte sSudowoodoPose86
+.4byte sSudowoodoPose87
+.4byte sSudowoodoPose88
+.4byte sSudowoodoPose89
+.4byte sSudowoodoPose90
+.4byte sSudowoodoPose91
+.4byte sSudowoodoPose92
+.4byte sSudowoodoPose93
+.4byte sSudowoodoPose94
+.4byte sSudowoodoPose95
+.4byte sSudowoodoPose96
+.4byte sSudowoodoPose97
+.4byte sSudowoodoPose98
+.4byte sSudowoodoPose99
+.4byte sSudowoodoPose100
+.4byte sSudowoodoPose101
+.4byte sSudowoodoPose102
+.4byte sSudowoodoPose103
+.4byte sSudowoodoPose104
+.4byte sSudowoodoPose105
+.4byte sSudowoodoPose106
+.4byte sSudowoodoPose107
+.4byte sSudowoodoPose108
+.4byte sSudowoodoPose109
+.4byte sSudowoodoPose110
+.4byte sSudowoodoPose111
+.4byte sSudowoodoPose112
+.4byte sSudowoodoPose113
+.4byte sSudowoodoPose114
+.4byte sSudowoodoPose115
+.4byte sSudowoodoPose116
+.4byte sSudowoodoPose117
+.4byte sSudowoodoPose118
+.4byte sSudowoodoPose119
+.4byte sSudowoodoPose120
+.4byte sSudowoodoPose121
+.4byte sSudowoodoPose122
+.4byte sSudowoodoPose123
+.4byte sSudowoodoPose124
+.4byte sSudowoodoPose125
+.4byte sSudowoodoPose126
+.4byte sSudowoodoPose127
+.4byte sSudowoodoPose128
+.4byte sSudowoodoPose129
+.4byte sSudowoodoPose130
+.4byte sSudowoodoPose131
+.4byte sSudowoodoPose132
+.4byte sSudowoodoPose133
+.4byte sSudowoodoPose134
+.4byte sSudowoodoPose135
+.4byte sSudowoodoPose136
+.4byte sSudowoodoPose137
+.4byte sSudowoodoPose138
+.4byte sSudowoodoPose139
+.4byte sSudowoodoPose140
+.4byte sSudowoodoPose141
+.4byte sSudowoodoPose142
+.4byte sSudowoodoPose143
+.4byte sSudowoodoPose144
+.4byte sSudowoodoPose145
+.4byte sSudowoodoPose146
+.4byte sSudowoodoPose147
+.4byte sSudowoodoPose148
+.4byte sSudowoodoPose149
+.4byte sSudowoodoPose150
+.4byte sSudowoodoPose151
+.4byte sSudowoodoPose152
+.4byte sSudowoodoPose153
+.4byte sSudowoodoPose154
+.4byte sSudowoodoPose155
+.4byte sSudowoodoPose156
+.4byte sSudowoodoPose157
+.4byte sSudowoodoPose158
+.4byte sSudowoodoPose159
+.4byte sSudowoodoPose160
+.4byte sSudowoodoPose161
+.4byte sSudowoodoPose162
+.4byte sSudowoodoPose163
+.4byte sSudowoodoPose164
+.4byte sSudowoodoPose165
+.4byte sSudowoodoPose166
+.4byte sSudowoodoPose167
+.4byte sSudowoodoPose168
+.4byte sSudowoodoPose169
+.4byte sSudowoodoPose170
+.4byte sSudowoodoPose171
+.4byte sSudowoodoPose172
+.4byte sSudowoodoPose173
+.4byte sSudowoodoPose174
+.4byte sSudowoodoPose175
+.4byte sSudowoodoPose176
+.4byte sSudowoodoPose177
+.4byte sSudowoodoPose178
+.4byte sSudowoodoPose179
+.4byte sSudowoodoPose180
+.4byte sSudowoodoPose181
+.4byte sSudowoodoPose182
+.4byte sSudowoodoPose183
+.4byte sSudowoodoPose184
+.4byte sSudowoodoPose185
+.4byte sSudowoodoPose186
+.4byte sSudowoodoPose187
+.4byte sSudowoodoPose188
+.4byte sSudowoodoPose189
+.4byte sSudowoodoPose190
+.4byte sSudowoodoPose191
+.4byte sSudowoodoPose192
+.4byte sSudowoodoPose193
+.4byte sSudowoodoPose194
+.4byte sSudowoodoPose195
+.4byte sSudowoodoPose196
+.4byte sSudowoodoPose197
+.4byte sSudowoodoPose198
+.4byte sSudowoodoPose199
+.4byte sSudowoodoPose200
+.4byte sSudowoodoPose201
+.4byte sSudowoodoPose202
+.4byte sSudowoodoPose203
+.4byte sSudowoodoPose204
+.4byte sSudowoodoPose205
+.4byte sSudowoodoPose206
+.4byte sSudowoodoPose207
+.4byte sSudowoodoPose208
+.4byte sSudowoodoPose209
+.4byte sSudowoodoPose210
+.4byte sSudowoodoPose211
+.4byte sSudowoodoPose212
+.4byte sSudowoodoPose213
+.4byte sSudowoodoPose214
+.4byte sSudowoodoPose215
+.4byte sSudowoodoPose216
+.4byte sSudowoodoPose217
+.4byte sSudowoodoPose218
+.4byte sSudowoodoPose219
+.4byte sSudowoodoPose220
+.4byte sSudowoodoPose221
+.4byte sSudowoodoPose222
+.4byte sSudowoodoPose223
+.4byte sSudowoodoPose224
+.4byte sSudowoodoPose225
+.4byte sSudowoodoPose226
+.4byte sSudowoodoPose227
+.4byte sSudowoodoPose228
+.4byte sSudowoodoPose229
+.4byte sSudowoodoPose230
+.4byte sSudowoodoPose231
+.4byte sSudowoodoPose232
+.4byte sSudowoodoPose233
+.4byte sSudowoodoPose234
+.4byte sSudowoodoPose235
+.4byte sSudowoodoPose236
+.4byte sSudowoodoPose237
+.4byte sSudowoodoPose238
+.4byte sSudowoodoPose239
+.4byte sSudowoodoPose240
+.4byte sSudowoodoPose241
+.4byte sSudowoodoPose242
+.4byte sSudowoodoPose243
+.4byte sSudowoodoPose244
+.4byte sSudowoodoPose245
+.4byte sSudowoodoPose246
+.4byte sSudowoodoPose247
+.4byte sSudowoodoPose248
+.4byte sSudowoodoPose249
+.4byte sSudowoodoPose250
+sAxPositionsSudowoodo:
+.2byte    0,  -13, 	  -9,  -16, 	   8,  -15, 	   0,  -10
+.2byte   -1,  -12, 	  -8,  -14, 	   8,  -11, 	  -1,   -9
+.2byte   -1,  -13, 	   8,  -16, 	  -9,  -15, 	  -1,  -10
+.2byte    0,  -12, 	  -9,  -11, 	   7,  -15, 	   0,   -9
+.2byte    0,  -13, 	  -7,  -14, 	   5,  -17, 	   0,  -10
+.2byte    0,  -12, 	   7,  -15, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   4,  -17, 	  -8,  -12, 	  -1,  -10
+.2byte    0,  -13, 	   2,  -14, 	  -4,  -12, 	   0,   -8
+.2byte    1,  -13, 	  -3,  -13, 	   2,  -18, 	   0,  -11
+.2byte    1,  -12, 	   5,  -16, 	  -5,   -8, 	  -1,  -10
+.2byte    1,  -13, 	   2,  -20, 	  -3,  -12, 	  -1,  -10
+.2byte    1,  -13, 	  -2,  -18, 	   2,  -11, 	  -1,  -10
+.2byte    0,  -13, 	   5,  -13, 	  -7,  -17, 	  -1,  -10
+.2byte   -1,  -12, 	  -3,  -19, 	   2,   -8, 	  -1,   -9
+.2byte    1,  -13, 	  -6,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    0,  -12, 	  -8,  -14, 	   7,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte   -1,  -14, 	   9,  -12, 	  -7,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    0,  -14, 	   7,  -17, 	 -10,  -12, 	   0,  -11
+.2byte   -1,  -13, 	  -6,  -13, 	   6,  -17, 	   0,  -10
+.2byte    0,  -12, 	   2,  -19, 	  -3,   -8, 	   0,   -9
+.2byte   -2,  -13, 	   5,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -1,  -12, 	   7,  -14, 	  -8,  -12, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -20, 	   2,  -12, 	   0,  -10
+.2byte   -2,  -12, 	  -6,  -16, 	   4,   -8, 	   0,  -10
+.2byte   -2,  -13, 	   2,  -13, 	  -3,  -18, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -18, 	  -3,  -11, 	   0,  -10
+.2byte    0,  -13, 	  -5,  -17, 	   7,  -12, 	   0,  -10
+.2byte    0,  -12, 	  -7,  -15, 	   9,  -10, 	   1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -6,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	  -4,  -14, 	   2,  -12, 	  -2,   -8
+.2byte    0,  -13, 	  -9,  -16, 	   8,  -15, 	   0,  -10
+.2byte   -1,  -12, 	  -8,  -14, 	   8,  -11, 	  -1,   -9
+.2byte   -1,  -13, 	   8,  -16, 	  -9,  -15, 	  -1,  -10
+.2byte    0,  -12, 	  -9,  -11, 	   7,  -15, 	   0,   -9
+.2byte    0,  -14, 	  -7,  -19, 	   7,  -19, 	  -1,  -10
+.2byte    0,  -13, 	  -7,  -14, 	   5,  -17, 	   0,  -10
+.2byte    0,  -12, 	   7,  -15, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   4,  -17, 	  -8,  -12, 	  -1,  -10
+.2byte    0,  -13, 	   2,  -14, 	  -4,  -12, 	   0,   -8
+.2byte   -2,  -14, 	 -12,  -16, 	   0,  -22, 	  -1,  -11
+.2byte    1,  -13, 	  -3,  -13, 	   2,  -18, 	   0,  -11
+.2byte    1,  -12, 	   5,  -16, 	  -5,   -8, 	  -1,  -10
+.2byte    1,  -13, 	   2,  -20, 	  -3,  -12, 	  -1,  -10
+.2byte    1,  -13, 	  -2,  -18, 	   2,  -11, 	  -1,  -10
+.2byte   -1,  -13, 	 -11,  -16, 	  -8,  -20, 	  -1,  -10
+.2byte    0,  -13, 	   5,  -13, 	  -7,  -17, 	  -1,  -10
+.2byte   -1,  -12, 	  -3,  -19, 	   2,   -8, 	  -1,   -9
+.2byte    1,  -13, 	  -6,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    0,  -12, 	  -8,  -14, 	   7,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	   2,   -9, 	 -12,  -18, 	  -1,   -9
+.2byte   -1,  -13, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte   -1,  -14, 	   9,  -12, 	  -7,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    0,  -14, 	   7,  -17, 	 -10,  -12, 	   0,  -11
+.2byte   -1,  -12, 	   7,  -18, 	  -8,  -17, 	  -1,  -10
+.2byte   -1,  -13, 	  -6,  -13, 	   6,  -17, 	   0,  -10
+.2byte    0,  -12, 	   2,  -19, 	  -3,   -8, 	   0,   -9
+.2byte   -2,  -13, 	   5,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -1,  -12, 	   7,  -14, 	  -8,  -12, 	   0,  -10
+.2byte   -1,  -12, 	  10,  -17, 	  -4,   -8, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -20, 	   2,  -12, 	   0,  -10
+.2byte   -2,  -12, 	  -6,  -16, 	   4,   -8, 	   0,  -10
+.2byte   -2,  -13, 	   2,  -13, 	  -3,  -18, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -18, 	  -3,  -11, 	   0,  -10
+.2byte    1,  -13, 	   8,  -20, 	  10,  -16, 	   1,  -11
+.2byte    0,  -13, 	  -5,  -17, 	   7,  -12, 	   0,  -10
+.2byte    0,  -12, 	  -7,  -15, 	   9,  -10, 	   1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -6,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	  -4,  -14, 	   2,  -12, 	  -2,   -8
+.2byte    2,  -13, 	   0,  -22, 	  11,  -15, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -16, 	   8,  -15, 	   0,  -10
+.2byte   -1,  -12, 	  -8,  -14, 	   8,  -11, 	  -1,   -9
+.2byte   -1,  -13, 	   8,  -16, 	  -9,  -15, 	  -1,  -10
+.2byte    0,  -12, 	  -9,  -11, 	   7,  -15, 	   0,   -9
+.2byte    0,  -14, 	  -7,  -19, 	   7,  -19, 	  -1,  -10
+.2byte   -1,   -2, 	  -6,    1, 	   5,    1, 	  -1,   -7
+.2byte   -1,   -2, 	  -6,    1, 	   5,    1, 	  -1,   -7
+.2byte    0,  -13, 	  -7,  -14, 	   5,  -17, 	   0,  -10
+.2byte    0,  -12, 	   7,  -15, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   4,  -17, 	  -8,  -12, 	  -1,  -10
+.2byte    0,  -13, 	   2,  -14, 	  -4,  -12, 	   0,   -8
+.2byte   -2,  -14, 	 -12,  -16, 	   0,  -22, 	  -1,  -11
+.2byte    1,   -8, 	   4,    1, 	  10,   -3, 	   1,   -9
+.2byte    1,   -8, 	   4,    1, 	  10,   -3, 	   1,   -9
+.2byte    1,  -13, 	  -3,  -13, 	   2,  -18, 	   0,  -11
+.2byte    1,  -12, 	   5,  -16, 	  -5,   -8, 	  -1,  -10
+.2byte    1,  -13, 	   2,  -20, 	  -3,  -12, 	  -1,  -10
+.2byte    1,  -13, 	  -2,  -18, 	   2,  -11, 	  -1,  -10
+.2byte   -1,  -13, 	 -11,  -16, 	  -8,  -20, 	  -1,  -10
+.2byte    1,   -8, 	   8,   -1, 	  12,   -5, 	   0,   -9
+.2byte    1,   -8, 	   8,   -1, 	  12,   -5, 	   0,   -9
+.2byte    0,  -13, 	   5,  -13, 	  -7,  -17, 	  -1,  -10
+.2byte   -1,  -12, 	  -3,  -19, 	   2,   -8, 	  -1,   -9
+.2byte    1,  -13, 	  -6,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    0,  -12, 	  -8,  -14, 	   7,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	   2,   -9, 	 -12,  -18, 	  -1,   -9
+.2byte    2,   -8, 	  11,   -6, 	   6,  -12, 	   1,   -8
+.2byte    2,   -8, 	  11,   -6, 	   6,  -12, 	   1,   -8
+.2byte   -1,  -13, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte   -1,  -14, 	   9,  -12, 	  -7,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    0,  -14, 	   7,  -17, 	 -10,  -12, 	   0,  -11
+.2byte   -1,  -12, 	   7,  -18, 	  -8,  -17, 	  -1,  -10
+.2byte    0,  -10, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte    0,  -10, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte   -1,  -13, 	  -6,  -13, 	   6,  -17, 	   0,  -10
+.2byte    0,  -12, 	   2,  -19, 	  -3,   -8, 	   0,   -9
+.2byte   -2,  -13, 	   5,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -1,  -12, 	   7,  -14, 	  -8,  -12, 	   0,  -10
+.2byte   -1,  -12, 	  10,  -17, 	  -4,   -8, 	   0,  -10
+.2byte   -4,   -8, 	  -6,  -12, 	 -12,   -5, 	  -1,   -7
+.2byte   -4,   -8, 	  -6,  -12, 	 -12,   -5, 	  -1,   -7
+.2byte   -2,  -13, 	  -3,  -20, 	   2,  -12, 	   0,  -10
+.2byte   -2,  -12, 	  -6,  -16, 	   4,   -8, 	   0,  -10
+.2byte   -2,  -13, 	   2,  -13, 	  -3,  -18, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -18, 	  -3,  -11, 	   0,  -10
+.2byte    1,  -13, 	   8,  -20, 	  10,  -16, 	   1,  -11
+.2byte    0,   -7, 	 -12,   -5, 	  -8,   -1, 	   1,   -8
+.2byte    0,   -7, 	 -12,   -5, 	  -8,   -1, 	   1,   -8
+.2byte    0,  -13, 	  -5,  -17, 	   7,  -12, 	   0,  -10
+.2byte    0,  -12, 	  -7,  -15, 	   9,  -10, 	   1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -6,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	  -4,  -14, 	   2,  -12, 	  -2,   -8
+.2byte    2,  -13, 	   0,  -22, 	  11,  -15, 	   0,  -11
+.2byte   -1,   -6, 	 -10,   -2, 	  -3,    2, 	   0,   -7
+.2byte   -1,   -6, 	 -10,   -2, 	  -3,    2, 	   0,   -7
+.2byte   -1,  -12, 	  -8,  -14, 	   8,  -11, 	  -1,   -9
+.2byte   -1,  -12, 	  -8,  -15, 	   8,  -10, 	   0,   -9
+.2byte   -2,  -12, 	  -6,  -16, 	   4,   -8, 	   0,  -10
+.2byte    0,  -12, 	   2,  -19, 	  -3,   -8, 	   0,   -9
+.2byte   -1,  -12, 	   9,  -10, 	  -7,  -14, 	   0,   -9
+.2byte   -1,  -12, 	  -3,  -19, 	   2,   -8, 	  -1,   -9
+.2byte    1,  -12, 	   5,  -16, 	  -5,   -8, 	  -1,  -10
+.2byte    0,  -12, 	   7,  -15, 	  -9,  -10, 	  -1,   -9
+.2byte    0,  -13, 	  -9,  -16, 	   8,  -15, 	   0,  -10
+.2byte   -2,  -12, 	  -7,  -15, 	   5,   -9, 	  -1,  -10
+.2byte    0,  -13, 	  -7,  -14, 	   5,  -17, 	   0,  -10
+.2byte    0,  -13, 	   0,   -9, 	  -1,  -18, 	  -1,  -11
+.2byte    1,  -13, 	  -3,  -13, 	   2,  -18, 	   0,  -11
+.2byte   -1,  -13, 	   5,  -10, 	  -6,  -16, 	  -1,  -10
+.2byte    0,  -13, 	   5,  -13, 	  -7,  -17, 	  -1,  -10
+.2byte   -2,  -12, 	   6,  -12, 	 -10,  -14, 	  -2,  -10
+.2byte   -1,  -13, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,  -13, 	   8,  -12, 	  -6,  -15, 	   0,  -11
+.2byte   -1,  -13, 	  -6,  -13, 	   6,  -17, 	   0,  -10
+.2byte    0,  -12, 	   8,  -14, 	  -8,  -12, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -20, 	   2,  -12, 	   0,  -10
+.2byte    0,  -14, 	   6,  -17, 	  -6,  -10, 	   1,  -11
+.2byte    0,  -13, 	  -5,  -17, 	   7,  -12, 	   0,  -10
+.2byte   -1,  -13, 	   0,  -18, 	  -1,   -9, 	   0,  -10
+.2byte    5,   -3, 	  -3,   -6, 	  11,   -3, 	   3,   -2
+.2byte    5,   -3, 	  -3,   -6, 	  11,   -3, 	   2,   -2
+.2byte    0,  -14, 	  -8,  -15, 	   9,  -16, 	   0,  -11
+.2byte   -3,  -13, 	   3,  -18, 	 -11,  -10, 	  -2,  -10
+.2byte   -2,  -11, 	  -2,  -17, 	  -6,   -9, 	  -3,  -10
+.2byte   -2,  -12, 	  -9,  -16, 	   2,   -9, 	  -3,  -10
+.2byte   -1,  -11, 	   8,  -12, 	 -10,  -11, 	  -1,   -9
+.2byte    1,  -12, 	   8,  -16, 	  -3,   -9, 	   2,  -10
+.2byte    1,  -11, 	   1,  -17, 	   5,   -9, 	   2,  -10
+.2byte    2,  -13, 	  -4,  -18, 	  10,  -10, 	   1,  -10
+.2byte    0,  -13, 	  -9,  -16, 	   8,  -15, 	   0,  -10
+.2byte   -1,  -12, 	  -8,  -14, 	   8,  -11, 	  -1,   -9
+.2byte   -1,  -13, 	   8,  -16, 	  -9,  -15, 	  -1,  -10
+.2byte    0,  -12, 	  -9,  -11, 	   7,  -15, 	   0,   -9
+.2byte    0,  -13, 	  -7,  -14, 	   5,  -17, 	   0,  -10
+.2byte    0,  -12, 	   7,  -15, 	  -9,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	   4,  -17, 	  -8,  -12, 	  -1,  -10
+.2byte    0,  -13, 	   2,  -14, 	  -4,  -12, 	   0,   -8
+.2byte    1,  -13, 	  -3,  -13, 	   2,  -18, 	   0,  -11
+.2byte    1,  -12, 	   5,  -16, 	  -5,   -8, 	  -1,  -10
+.2byte    1,  -13, 	   2,  -20, 	  -3,  -12, 	  -1,  -10
+.2byte    1,  -13, 	  -2,  -18, 	   2,  -11, 	  -1,  -10
+.2byte    0,  -13, 	   5,  -13, 	  -7,  -17, 	  -1,  -10
+.2byte   -1,  -12, 	  -3,  -19, 	   2,   -8, 	  -1,   -9
+.2byte    1,  -13, 	  -6,  -19, 	   5,  -11, 	  -1,  -10
+.2byte    0,  -12, 	  -8,  -14, 	   7,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte   -1,  -14, 	   9,  -12, 	  -7,  -16, 	   0,  -11
+.2byte    0,  -13, 	  -9,  -15, 	   7,  -15, 	  -1,  -10
+.2byte    0,  -14, 	   7,  -17, 	 -10,  -12, 	   0,  -11
+.2byte   -1,  -13, 	  -6,  -13, 	   6,  -17, 	   0,  -10
+.2byte    0,  -12, 	   2,  -19, 	  -3,   -8, 	   0,   -9
+.2byte   -2,  -13, 	   5,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -1,  -12, 	   7,  -14, 	  -8,  -12, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -20, 	   2,  -12, 	   0,  -10
+.2byte   -2,  -12, 	  -6,  -16, 	   4,   -8, 	   0,  -10
+.2byte   -2,  -13, 	   2,  -13, 	  -3,  -18, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -18, 	  -3,  -11, 	   0,  -10
+.2byte    0,  -13, 	  -5,  -17, 	   7,  -12, 	   0,  -10
+.2byte    0,  -12, 	  -7,  -15, 	   9,  -10, 	   1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -6,  -17, 	  -1,  -10
+.2byte   -2,  -13, 	  -4,  -14, 	   2,  -12, 	  -2,   -8
+.2byte    0,  -13, 	  -7,  -18, 	   7,  -18, 	  -1,   -9
+.2byte    2,  -12, 	   0,  -21, 	  11,  -14, 	   0,  -10
+.2byte   -1,  -12, 	   6,  -19, 	   8,  -15, 	  -1,  -10
+.2byte   -1,  -12, 	  10,  -17, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -12, 	   7,  -18, 	  -8,  -17, 	  -1,  -10
+.2byte   -1,  -12, 	   2,   -9, 	 -12,  -18, 	  -1,   -9
+.2byte   -1,  -13, 	 -11,  -16, 	  -8,  -20, 	  -1,  -10
+.2byte   -2,  -13, 	 -12,  -15, 	   0,  -21, 	  -1,  -10
+.2byte    0,  -13, 	  -7,  -18, 	   7,  -18, 	  -1,   -9
+.2byte   -2,  -13, 	 -12,  -15, 	   0,  -21, 	  -1,  -10
+.2byte    0,  -13, 	 -10,  -16, 	  -7,  -20, 	   0,  -10
+.2byte    0,  -11, 	   3,   -8, 	 -11,  -17, 	   0,   -8
+.2byte   -1,  -12, 	   7,  -18, 	  -8,  -17, 	  -1,  -10
+.2byte   -1,  -12, 	  10,  -17, 	  -4,   -8, 	   0,  -10
+.2byte   -1,  -11, 	   6,  -18, 	   8,  -14, 	  -1,   -9
+.2byte    2,  -12, 	   0,  -21, 	  11,  -14, 	   0,  -10
+.2byte    0,  -13, 	  -9,  -16, 	   8,  -15, 	   0,  -10
+.2byte    0,  -14, 	  -7,  -19, 	   7,  -19, 	  -1,  -10
+.2byte   -1,   -4, 	  -6,   -1, 	   5,   -1, 	  -1,   -9
+.2byte    0,  -13, 	  -7,  -14, 	   5,  -17, 	   0,  -10
+.2byte   -2,  -14, 	 -12,  -16, 	   0,  -22, 	  -1,  -11
+.2byte    0,  -10, 	   3,   -1, 	   9,   -5, 	   0,  -11
+.2byte    1,  -13, 	  -3,  -13, 	   2,  -18, 	   0,  -11
+.2byte   -1,  -13, 	 -11,  -16, 	  -8,  -20, 	  -1,  -10
+.2byte    1,   -8, 	   8,   -1, 	  12,   -5, 	   0,   -9
+.2byte    0,  -13, 	   5,  -13, 	  -7,  -17, 	  -1,  -10
+.2byte   -1,  -12, 	   2,   -9, 	 -12,  -18, 	  -1,   -9
+.2byte    1,   -9, 	  10,   -7, 	   5,  -13, 	   0,   -9
+.2byte   -1,  -13, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte   -1,  -12, 	   7,  -18, 	  -8,  -17, 	  -1,  -10
+.2byte    0,  -10, 	   6,   -8, 	  -6,   -8, 	   0,   -9
+.2byte   -1,  -13, 	  -6,  -13, 	   6,  -17, 	   0,  -10
+.2byte   -1,  -12, 	  10,  -17, 	  -4,   -8, 	   0,  -10
+.2byte   -3,   -9, 	  -5,  -13, 	 -11,   -6, 	   0,   -8
+.2byte   -2,  -13, 	  -3,  -20, 	   2,  -12, 	   0,  -10
+.2byte    1,  -13, 	   8,  -20, 	  10,  -16, 	   1,  -11
+.2byte   -1,   -7, 	 -13,   -5, 	  -9,   -1, 	   0,   -8
+.2byte    0,  -13, 	  -5,  -17, 	   7,  -12, 	   0,  -10
+.2byte    2,  -13, 	   0,  -22, 	  11,  -15, 	   0,  -11
+.2byte   -1,   -8, 	 -10,   -4, 	  -3,    0, 	   0,   -9
+.2byte   -1,  -12, 	  -8,  -14, 	   8,  -11, 	  -1,   -9
+.2byte   -1,  -12, 	  -8,  -15, 	   8,  -10, 	   0,   -9
+.2byte   -2,  -12, 	  -6,  -16, 	   4,   -8, 	   0,  -10
+.2byte    0,  -12, 	   2,  -19, 	  -3,   -8, 	   0,   -9
+.2byte   -1,  -12, 	   9,  -10, 	  -7,  -14, 	   0,   -9
+.2byte   -1,  -12, 	  -3,  -19, 	   2,   -8, 	  -1,   -9
+.2byte    1,  -12, 	   5,  -16, 	  -5,   -8, 	  -1,  -10
+.2byte    0,  -12, 	   7,  -15, 	  -9,  -10, 	  -1,   -9
+.2byte    0,  -13, 	  -9,  -16, 	   8,  -15, 	   0,  -10
+.2byte   -1,  -13, 	  -6,  -17, 	   6,  -12, 	  -1,  -10
+.2byte   -2,  -13, 	  -3,  -20, 	   2,  -12, 	   0,  -10
+.2byte   -2,  -13, 	   5,  -19, 	  -6,  -11, 	   0,  -10
+.2byte   -1,  -13, 	   8,  -15, 	  -8,  -15, 	   0,  -10
+.2byte    0,  -13, 	   5,  -13, 	  -7,  -17, 	  -1,  -10
+.2byte    0,  -13, 	  -4,  -13, 	   1,  -18, 	  -1,  -11
+.2byte    0,  -13, 	  -7,  -14, 	   5,  -17, 	   0,  -10
+sSudowoodoAnimTable1:
+.4byte sSudowoodoAnims_1_1
+.4byte sSudowoodoAnims_1_2
+.4byte sSudowoodoAnims_1_3
+.4byte sSudowoodoAnims_1_4
+.4byte sSudowoodoAnims_1_5
+.4byte sSudowoodoAnims_1_6
+.4byte sSudowoodoAnims_1_7
+.4byte sSudowoodoAnims_1_8
+sSudowoodoAnimTable2:
+.4byte sSudowoodoAnims_2_1
+.4byte sSudowoodoAnims_2_2
+.4byte sSudowoodoAnims_2_3
+.4byte sSudowoodoAnims_2_4
+.4byte sSudowoodoAnims_2_5
+.4byte sSudowoodoAnims_2_6
+.4byte sSudowoodoAnims_2_7
+.4byte sSudowoodoAnims_2_8
+sSudowoodoAnimTable3:
+.4byte sSudowoodoAnims_3_1
+.4byte sSudowoodoAnims_3_2
+.4byte sSudowoodoAnims_3_3
+.4byte sSudowoodoAnims_3_4
+.4byte sSudowoodoAnims_3_5
+.4byte sSudowoodoAnims_3_6
+.4byte sSudowoodoAnims_3_7
+.4byte sSudowoodoAnims_3_8
+sSudowoodoAnimTable4:
+.4byte sSudowoodoAnims_4_1
+.4byte sSudowoodoAnims_4_2
+.4byte sSudowoodoAnims_4_3
+.4byte sSudowoodoAnims_4_4
+.4byte sSudowoodoAnims_4_5
+.4byte sSudowoodoAnims_4_6
+.4byte sSudowoodoAnims_4_7
+.4byte sSudowoodoAnims_4_8
+sSudowoodoAnimTable5:
+.4byte sSudowoodoAnims_5_1
+.4byte sSudowoodoAnims_5_2
+.4byte sSudowoodoAnims_5_3
+.4byte sSudowoodoAnims_5_4
+.4byte sSudowoodoAnims_5_5
+.4byte sSudowoodoAnims_5_6
+.4byte sSudowoodoAnims_5_7
+.4byte sSudowoodoAnims_5_8
+sSudowoodoAnimTable6:
+.4byte sSudowoodoAnims_6_1
+.4byte sSudowoodoAnims_6_1
+.4byte sSudowoodoAnims_6_1
+.4byte sSudowoodoAnims_6_1
+.4byte sSudowoodoAnims_6_1
+.4byte sSudowoodoAnims_6_1
+.4byte sSudowoodoAnims_6_1
+.4byte sSudowoodoAnims_6_1
+sSudowoodoAnimTable7:
+.4byte sSudowoodoAnims_7_1
+.4byte sSudowoodoAnims_7_2
+.4byte sSudowoodoAnims_7_3
+.4byte sSudowoodoAnims_7_4
+.4byte sSudowoodoAnims_7_5
+.4byte sSudowoodoAnims_7_6
+.4byte sSudowoodoAnims_7_7
+.4byte sSudowoodoAnims_7_8
+sSudowoodoAnimTable8:
+.4byte sSudowoodoAnims_8_1
+.4byte sSudowoodoAnims_8_2
+.4byte sSudowoodoAnims_8_3
+.4byte sSudowoodoAnims_8_4
+.4byte sSudowoodoAnims_8_5
+.4byte sSudowoodoAnims_8_6
+.4byte sSudowoodoAnims_8_7
+.4byte sSudowoodoAnims_8_8
+sSudowoodoAnimTable9:
+.4byte sSudowoodoAnims_9_1
+.4byte sSudowoodoAnims_9_2
+.4byte sSudowoodoAnims_9_3
+.4byte sSudowoodoAnims_9_4
+.4byte sSudowoodoAnims_9_5
+.4byte sSudowoodoAnims_9_6
+.4byte sSudowoodoAnims_9_7
+.4byte sSudowoodoAnims_9_8
+sSudowoodoAnimTable10:
+.4byte sSudowoodoAnims_10_1
+.4byte sSudowoodoAnims_10_2
+.4byte sSudowoodoAnims_10_3
+.4byte sSudowoodoAnims_10_4
+.4byte sSudowoodoAnims_10_5
+.4byte sSudowoodoAnims_10_6
+.4byte sSudowoodoAnims_10_7
+.4byte sSudowoodoAnims_10_8
+sSudowoodoAnimTable11:
+.4byte sSudowoodoAnims_11_1
+.4byte sSudowoodoAnims_11_2
+.4byte sSudowoodoAnims_11_3
+.4byte sSudowoodoAnims_11_4
+.4byte sSudowoodoAnims_11_5
+.4byte sSudowoodoAnims_11_6
+.4byte sSudowoodoAnims_11_7
+.4byte sSudowoodoAnims_11_8
+sSudowoodoAnimTable12:
+.4byte sSudowoodoAnims_12_1
+.4byte sSudowoodoAnims_12_2
+.4byte sSudowoodoAnims_12_3
+.4byte sSudowoodoAnims_12_4
+.4byte sSudowoodoAnims_12_5
+.4byte sSudowoodoAnims_12_6
+.4byte sSudowoodoAnims_12_7
+.4byte sSudowoodoAnims_12_8
+sSudowoodoAnimTable13:
+.4byte sSudowoodoAnims_13_1
+.4byte sSudowoodoAnims_13_2
+.4byte sSudowoodoAnims_13_3
+.4byte sSudowoodoAnims_13_4
+.4byte sSudowoodoAnims_13_5
+.4byte sSudowoodoAnims_13_6
+.4byte sSudowoodoAnims_13_7
+.4byte sSudowoodoAnims_13_8
+sAxAnimationsSudowoodo:
+.4byte sSudowoodoAnimTable1
+.4byte sSudowoodoAnimTable2
+.4byte sSudowoodoAnimTable3
+.4byte sSudowoodoAnimTable4
+.4byte sSudowoodoAnimTable5
+.4byte sSudowoodoAnimTable6
+.4byte sSudowoodoAnimTable7
+.4byte sSudowoodoAnimTable8
+.4byte sSudowoodoAnimTable9
+.4byte sSudowoodoAnimTable10
+.4byte sSudowoodoAnimTable11
+.4byte sSudowoodoAnimTable12
+.4byte sSudowoodoAnimTable13
+sAxSpritesSudowoodo:
+.4byte sSudowoodoSprites1
+.4byte sSudowoodoSprites2
+.4byte sSudowoodoSprites3
+.4byte sSudowoodoSprites4
+.4byte sSudowoodoSprites5
+.4byte sSudowoodoSprites6
+.4byte sSudowoodoSprites7
+.4byte sSudowoodoSprites8
+.4byte sSudowoodoSprites9
+.4byte sSudowoodoSprites10
+.4byte sSudowoodoSprites11
+.4byte sSudowoodoSprites12
+.4byte sSudowoodoSprites13
+.4byte sSudowoodoSprites14
+.4byte sSudowoodoSprites15
+.4byte sSudowoodoSprites16
+.4byte sSudowoodoSprites17
+.4byte sSudowoodoSprites18
+.4byte sSudowoodoSprites19
+.4byte sSudowoodoSprites20
+.4byte sSudowoodoSprites21
+.4byte sSudowoodoSprites22
+.4byte sSudowoodoSprites23
+.4byte sSudowoodoSprites24
+.4byte sSudowoodoSprites25
+.4byte sSudowoodoSprites26
+.4byte sSudowoodoSprites27
+.4byte sSudowoodoSprites28
+.4byte sSudowoodoSprites29
+.4byte sSudowoodoSprites30
+.4byte sSudowoodoSprites31
+.4byte sSudowoodoSprites32
+.4byte sSudowoodoSprites33
+.4byte sSudowoodoSprites34
+.4byte sSudowoodoSprites35
+.4byte sSudowoodoSprites36
+.4byte sSudowoodoSprites37
+.4byte sSudowoodoSprites38
+.4byte sSudowoodoSprites39
+.4byte sSudowoodoSprites40
+.4byte sSudowoodoSprites41
+.4byte sSudowoodoSprites42
+.4byte sSudowoodoSprites43
+.4byte sSudowoodoSprites44
+.4byte sSudowoodoSprites45
+.4byte sSudowoodoSprites46
+.4byte sSudowoodoSprites47
+.4byte sSudowoodoSprites48
+.4byte sSudowoodoSprites49
+.4byte sSudowoodoSprites50
+.4byte sSudowoodoSprites51
+.4byte sSudowoodoSprites52
+.4byte sSudowoodoSprites53
+.4byte sSudowoodoSprites54
+.4byte sSudowoodoSprites55
+sAxMainSudowoodo:
+ax_main sAxPosesSudowoodo, sAxAnimationsSudowoodo, 13, sAxSpritesSudowoodo, sAxPositionsSudowoodo

--- a/data/ax/suicune.inc
+++ b/data/ax/suicune.inc
@@ -1,0 +1,3542 @@
+.global gAxSuicune
+gAxSuicune:
+ax_siro sAxMainSuicune
+sSuicunePose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose2:
+ax_pose 1, 0x81e4, 0x8100, 0x7c00
+ax_pose 2, 0x81e4, 0x40f8, 0x7c08
+ax_pose 3, 0x81f4, 0x00f0, 0x7c0c
+ax_pose 4, 0x01ec, 0x00f0, 0x7c0e
+ax_pose 5, 0x0204, 0x00f8, 0x7c0f
+ax_pose_terminator
+sSuicunePose3:
+ax_pose 6, 0x81e4, 0x80f0, 0x7c00
+ax_pose 7, 0x81e4, 0x4100, 0x7c08
+ax_pose 8, 0x81f4, 0x0108, 0x7c0c
+ax_pose 9, 0x01ec, 0x0108, 0x7c0e
+ax_pose 10, 0x0204, 0x0100, 0x7c0f
+ax_pose_terminator
+sSuicunePose4:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose5:
+ax_pose 12, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose6:
+ax_pose 13, 0x41f2, 0x90f1, 0x7c00
+ax_pose 14, 0x41ea, 0x50f1, 0x7c08
+ax_pose 15, 0x41e2, 0x10f9, 0x7c0c
+ax_pose 16, 0x0202, 0x10ff, 0x7c0e
+ax_pose 17, 0x01ed, 0x10e9, 0x7c0f
+ax_pose_terminator
+sSuicunePose7:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose8:
+ax_pose 19, 0x81e4, 0x9101, 0x7c00
+ax_pose 20, 0x81e4, 0x50f9, 0x7c08
+ax_pose 21, 0x81ec, 0x10f1, 0x7c0c
+ax_pose 22, 0x01fc, 0x10f1, 0x7c0e
+ax_pose 23, 0x01f9, 0x10e9, 0x7c0f
+ax_pose_terminator
+sSuicunePose9:
+ax_pose 24, 0x41e7, 0x90f1, 0x7c00
+ax_pose 25, 0x41f7, 0x50f1, 0x7c08
+ax_pose 26, 0x01ff, 0x1105, 0x7c0c
+ax_pose 27, 0x01f5, 0x10e9, 0x7c0d
+ax_pose 28, 0x01fd, 0x10e9, 0x7c0e
+ax_pose 29, 0x01ff, 0x10f1, 0x7c0f
+ax_pose_terminator
+sSuicunePose10:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose11:
+ax_pose 31, 0x81e5, 0x90ff, 0x7c00
+ax_pose 32, 0x81e5, 0x50f7, 0x7c08
+ax_pose 33, 0x81f5, 0x10ef, 0x7c0c
+ax_pose 34, 0x01ed, 0x10ef, 0x7c0e
+ax_pose 35, 0x01f4, 0x110f, 0x7c0f
+ax_pose_terminator
+sSuicunePose12:
+ax_pose 36, 0x81e4, 0x9100, 0x7c00
+ax_pose 37, 0x81e4, 0x50f8, 0x7c08
+ax_pose 38, 0x81f4, 0x10f0, 0x7c0c
+ax_pose 39, 0x01ec, 0x10f0, 0x7c0e
+ax_pose 40, 0x0204, 0x10f5, 0x7c0f
+ax_pose_terminator
+sSuicunePose13:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose14:
+ax_pose 42, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose15:
+ax_pose 43, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose16:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose17:
+ax_pose 31, 0x81e5, 0x80f0, 0x7c00
+ax_pose 32, 0x81e5, 0x4100, 0x7c08
+ax_pose 33, 0x81f5, 0x0108, 0x7c0c
+ax_pose 34, 0x01ed, 0x0108, 0x7c0e
+ax_pose 35, 0x01f4, 0x00e8, 0x7c0f
+ax_pose_terminator
+sSuicunePose18:
+ax_pose 36, 0x81e4, 0x80ef, 0x7c00
+ax_pose 37, 0x81e4, 0x40ff, 0x7c08
+ax_pose 38, 0x81f4, 0x0107, 0x7c0c
+ax_pose 39, 0x01ec, 0x0107, 0x7c0e
+ax_pose 40, 0x0204, 0x0102, 0x7c0f
+ax_pose_terminator
+sSuicunePose19:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose20:
+ax_pose 19, 0x81e4, 0x80ee, 0x7c00
+ax_pose 20, 0x81e4, 0x40fe, 0x7c08
+ax_pose 21, 0x81ec, 0x0106, 0x7c0c
+ax_pose 22, 0x01fc, 0x0106, 0x7c0e
+ax_pose 23, 0x01f9, 0x010e, 0x7c0f
+ax_pose_terminator
+sSuicunePose21:
+ax_pose 24, 0x41e7, 0x80ee, 0x7c00
+ax_pose 25, 0x41f7, 0x40ee, 0x7c08
+ax_pose 26, 0x01ff, 0x00f2, 0x7c0c
+ax_pose 27, 0x01f5, 0x010e, 0x7c0d
+ax_pose 28, 0x01fd, 0x010e, 0x7c0e
+ax_pose 29, 0x01ff, 0x0106, 0x7c0f
+ax_pose_terminator
+sSuicunePose22:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose23:
+ax_pose 12, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose24:
+ax_pose 13, 0x41f2, 0x80ee, 0x7c00
+ax_pose 14, 0x41ea, 0x40ee, 0x7c08
+ax_pose 15, 0x41e2, 0x00f6, 0x7c0c
+ax_pose 16, 0x0202, 0x00f8, 0x7c0e
+ax_pose 17, 0x01ed, 0x010e, 0x7c0f
+ax_pose_terminator
+sSuicunePose25:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose26:
+ax_pose 44, 0x01e0, 0x80f0, 0x7c00
+ax_pose 45, 0x01f0, 0x00e8, 0x7c10
+ax_pose_terminator
+sSuicunePose27:
+ax_pose 46, 0x81e6, 0x4104, 0x7c00
+ax_pose 47, 0x81e6, 0x80f4, 0x7c04
+ax_pose_terminator
+sSuicunePose28:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose29:
+ax_pose 48, 0x41ea, 0x90ea, 0x7c00
+ax_pose 49, 0x41fa, 0x50ea, 0x7c08
+ax_pose 50, 0x01f2, 0x110a, 0x7c0c
+ax_pose 51, 0x01fa, 0x110a, 0x7c0d
+ax_pose 52, 0x01ea, 0x1112, 0x7c0e
+ax_pose 53, 0x41e2, 0x10fa, 0x7c0f
+ax_pose 54, 0x01ea, 0x110a, 0x7c11
+ax_pose_terminator
+sSuicunePose30:
+ax_pose 55, 0x41f5, 0x90eb, 0x7c00
+ax_pose 56, 0x41ed, 0x50eb, 0x7c08
+ax_pose 57, 0x01fd, 0x110b, 0x7c0c
+ax_pose 58, 0x01f5, 0x110b, 0x7c0d
+ax_pose 59, 0x41e5, 0x10f3, 0x7c0e
+ax_pose 60, 0x01e5, 0x10eb, 0x7c10
+ax_pose_terminator
+sSuicunePose31:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose32:
+ax_pose 61, 0x41f2, 0x90f2, 0x7c00
+ax_pose 62, 0x41ea, 0x50f2, 0x7c08
+ax_pose 63, 0x41e2, 0x1102, 0x7c0c
+ax_pose 64, 0x81f2, 0x10ea, 0x7c0e
+ax_pose 65, 0x01f2, 0x10e2, 0x7c10
+ax_pose 66, 0x01fa, 0x10e2, 0x7c11
+ax_pose_terminator
+sSuicunePose33:
+ax_pose 67, 0x41f4, 0x90f1, 0x7c00
+ax_pose 68, 0x41ec, 0x10f9, 0x7c08
+ax_pose 69, 0x01ec, 0x10f1, 0x7c0a
+ax_pose 70, 0x01ec, 0x10e9, 0x7c0b
+ax_pose 71, 0x01e4, 0x10f1, 0x7c0c
+ax_pose 72, 0x01f4, 0x10e9, 0x7c0d
+ax_pose 73, 0x01ec, 0x1109, 0x7c0e
+ax_pose_terminator
+sSuicunePose34:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose35:
+ax_pose 74, 0x41e6, 0x90ef, 0x7c00
+ax_pose 75, 0x41f6, 0x50ef, 0x7c08
+ax_pose 76, 0x41fe, 0x10ef, 0x7c0c
+ax_pose 77, 0x01f6, 0x10e7, 0x7c0e
+ax_pose 78, 0x01fe, 0x10e7, 0x7c0f
+ax_pose_terminator
+sSuicunePose36:
+ax_pose 79, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sSuicunePose37:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose38:
+ax_pose 80, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose39:
+ax_pose 81, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose40:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose41:
+ax_pose 74, 0x41e6, 0x80f1, 0x7c00
+ax_pose 75, 0x41f6, 0x40f1, 0x7c08
+ax_pose 76, 0x41fe, 0x0101, 0x7c0c
+ax_pose 77, 0x01f6, 0x0111, 0x7c0e
+ax_pose 78, 0x01fe, 0x0111, 0x7c0f
+ax_pose_terminator
+sSuicunePose42:
+ax_pose 79, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sSuicunePose43:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose44:
+ax_pose 61, 0x41f2, 0x80ed, 0x7c00
+ax_pose 62, 0x41ea, 0x40ed, 0x7c08
+ax_pose 63, 0x41e2, 0x00ed, 0x7c0c
+ax_pose 64, 0x81f2, 0x010d, 0x7c0e
+ax_pose 65, 0x01f2, 0x0115, 0x7c10
+ax_pose 66, 0x01fa, 0x0115, 0x7c11
+ax_pose_terminator
+sSuicunePose45:
+ax_pose 67, 0x41f4, 0x80ee, 0x7c00
+ax_pose 68, 0x41ec, 0x00f6, 0x7c08
+ax_pose 69, 0x01ec, 0x0106, 0x7c0a
+ax_pose 71, 0x01e4, 0x0106, 0x7c0b
+ax_pose 70, 0x01ec, 0x010e, 0x7c0c
+ax_pose 72, 0x01f4, 0x010e, 0x7c0d
+ax_pose 73, 0x01ec, 0x00ee, 0x7c0e
+ax_pose_terminator
+sSuicunePose46:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose47:
+ax_pose 48, 0x41ea, 0x80f5, 0x7c00
+ax_pose 49, 0x41fa, 0x40f5, 0x7c08
+ax_pose 50, 0x01f2, 0x00ed, 0x7c0c
+ax_pose 51, 0x01fa, 0x00ed, 0x7c0d
+ax_pose 54, 0x01ea, 0x00ed, 0x7c0e
+ax_pose 52, 0x01ea, 0x00e5, 0x7c0f
+ax_pose 53, 0x41e2, 0x00f5, 0x7c10
+ax_pose_terminator
+sSuicunePose48:
+ax_pose 55, 0x41f5, 0x80f4, 0x7c00
+ax_pose 56, 0x41ed, 0x40f4, 0x7c08
+ax_pose 57, 0x01fd, 0x00ec, 0x7c0c
+ax_pose 58, 0x01f5, 0x00ec, 0x7c0d
+ax_pose 59, 0x41e5, 0x00fc, 0x7c0e
+ax_pose 60, 0x01e5, 0x010c, 0x7c10
+ax_pose_terminator
+sSuicunePose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose50:
+ax_pose 44, 0x01e0, 0x80f0, 0x7c00
+ax_pose 45, 0x01f0, 0x00e8, 0x7c10
+ax_pose_terminator
+sSuicunePose51:
+ax_pose 46, 0x81e6, 0x4104, 0x7c00
+ax_pose 47, 0x81e6, 0x80f4, 0x7c04
+ax_pose_terminator
+sSuicunePose52:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose53:
+ax_pose 48, 0x41ea, 0x90ea, 0x7c00
+ax_pose 49, 0x41fa, 0x50ea, 0x7c08
+ax_pose 50, 0x01f2, 0x110a, 0x7c0c
+ax_pose 51, 0x01fa, 0x110a, 0x7c0d
+ax_pose 52, 0x01ea, 0x1112, 0x7c0e
+ax_pose 53, 0x41e2, 0x10fa, 0x7c0f
+ax_pose 54, 0x01ea, 0x110a, 0x7c11
+ax_pose_terminator
+sSuicunePose54:
+ax_pose 55, 0x41f5, 0x90eb, 0x7c00
+ax_pose 56, 0x41ed, 0x50eb, 0x7c08
+ax_pose 57, 0x01fd, 0x110b, 0x7c0c
+ax_pose 58, 0x01f5, 0x110b, 0x7c0d
+ax_pose 59, 0x41e5, 0x10f3, 0x7c0e
+ax_pose 60, 0x01e5, 0x10eb, 0x7c10
+ax_pose_terminator
+sSuicunePose55:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose56:
+ax_pose 61, 0x41f2, 0x90f2, 0x7c00
+ax_pose 62, 0x41ea, 0x50f2, 0x7c08
+ax_pose 63, 0x41e2, 0x1102, 0x7c0c
+ax_pose 64, 0x81f2, 0x10ea, 0x7c0e
+ax_pose 65, 0x01f2, 0x10e2, 0x7c10
+ax_pose 66, 0x01fa, 0x10e2, 0x7c11
+ax_pose_terminator
+sSuicunePose57:
+ax_pose 67, 0x41f4, 0x90f1, 0x7c00
+ax_pose 68, 0x41ec, 0x10f9, 0x7c08
+ax_pose 69, 0x01ec, 0x10f1, 0x7c0a
+ax_pose 70, 0x01ec, 0x10e9, 0x7c0b
+ax_pose 71, 0x01e4, 0x10f1, 0x7c0c
+ax_pose 72, 0x01f4, 0x10e9, 0x7c0d
+ax_pose 73, 0x01ec, 0x1109, 0x7c0e
+ax_pose_terminator
+sSuicunePose58:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose59:
+ax_pose 74, 0x41e6, 0x90ef, 0x7c00
+ax_pose 75, 0x41f6, 0x50ef, 0x7c08
+ax_pose 76, 0x41fe, 0x10ef, 0x7c0c
+ax_pose 77, 0x01f6, 0x10e7, 0x7c0e
+ax_pose 78, 0x01fe, 0x10e7, 0x7c0f
+ax_pose_terminator
+sSuicunePose60:
+ax_pose 79, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sSuicunePose61:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose62:
+ax_pose 80, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose63:
+ax_pose 81, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose64:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose65:
+ax_pose 74, 0x41e6, 0x80f1, 0x7c00
+ax_pose 75, 0x41f6, 0x40f1, 0x7c08
+ax_pose 76, 0x41fe, 0x0101, 0x7c0c
+ax_pose 77, 0x01f6, 0x0111, 0x7c0e
+ax_pose 78, 0x01fe, 0x0111, 0x7c0f
+ax_pose_terminator
+sSuicunePose66:
+ax_pose 79, 0x01e6, 0x80f1, 0x7c00
+ax_pose_terminator
+sSuicunePose67:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose68:
+ax_pose 61, 0x41f2, 0x80ed, 0x7c00
+ax_pose 62, 0x41ea, 0x40ed, 0x7c08
+ax_pose 63, 0x41e2, 0x00ed, 0x7c0c
+ax_pose 64, 0x81f2, 0x010d, 0x7c0e
+ax_pose 65, 0x01f2, 0x0115, 0x7c10
+ax_pose 66, 0x01fa, 0x0115, 0x7c11
+ax_pose_terminator
+sSuicunePose69:
+ax_pose 67, 0x41f4, 0x80ee, 0x7c00
+ax_pose 68, 0x41ec, 0x00f6, 0x7c08
+ax_pose 69, 0x01ec, 0x0106, 0x7c0a
+ax_pose 71, 0x01e4, 0x0106, 0x7c0b
+ax_pose 70, 0x01ec, 0x010e, 0x7c0c
+ax_pose 72, 0x01f4, 0x010e, 0x7c0d
+ax_pose 73, 0x01ec, 0x00ee, 0x7c0e
+ax_pose_terminator
+sSuicunePose70:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose71:
+ax_pose 48, 0x41ea, 0x80f5, 0x7c00
+ax_pose 49, 0x41fa, 0x40f5, 0x7c08
+ax_pose 50, 0x01f2, 0x00ed, 0x7c0c
+ax_pose 51, 0x01fa, 0x00ed, 0x7c0d
+ax_pose 54, 0x01ea, 0x00ed, 0x7c0e
+ax_pose 52, 0x01ea, 0x00e5, 0x7c0f
+ax_pose 53, 0x41e2, 0x00f5, 0x7c10
+ax_pose_terminator
+sSuicunePose72:
+ax_pose 55, 0x41f5, 0x80f4, 0x7c00
+ax_pose 56, 0x41ed, 0x40f4, 0x7c08
+ax_pose 57, 0x01fd, 0x00ec, 0x7c0c
+ax_pose 58, 0x01f5, 0x00ec, 0x7c0d
+ax_pose 59, 0x41e5, 0x00fc, 0x7c0e
+ax_pose 60, 0x01e5, 0x010c, 0x7c10
+ax_pose_terminator
+sSuicunePose73:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose74:
+ax_pose 82, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose75:
+ax_pose 83, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose76:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose77:
+ax_pose 84, 0x41f5, 0x90f1, 0x7c00
+ax_pose 85, 0x41ed, 0x50f1, 0x7c08
+ax_pose 86, 0x41e5, 0x10f9, 0x7c0c
+ax_pose 87, 0x01e5, 0x10f1, 0x7c0e
+ax_pose_terminator
+sSuicunePose78:
+ax_pose 88, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose79:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose80:
+ax_pose 89, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose81:
+ax_pose 90, 0x41ed, 0x90f5, 0x7c00
+ax_pose 91, 0x41e5, 0x10fd, 0x7c08
+ax_pose 92, 0x01e5, 0x10f5, 0x7c0a
+ax_pose 93, 0x41fd, 0x10fd, 0x7c0b
+ax_pose 94, 0x01fd, 0x10f5, 0x7c0d
+ax_pose 95, 0x01ed, 0x10ed, 0x7c0e
+ax_pose 96, 0x01f5, 0x10ed, 0x7c0f
+ax_pose_terminator
+sSuicunePose82:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose83:
+ax_pose 97, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose84:
+ax_pose 98, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose85:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose86:
+ax_pose 99, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose87:
+ax_pose 100, 0x41e5, 0x80f0, 0x7c00
+ax_pose 101, 0x41f5, 0x40f0, 0x7c08
+ax_pose 102, 0x41fd, 0x00f0, 0x7c0c
+ax_pose 103, 0x01fd, 0x0100, 0x7c0e
+ax_pose_terminator
+sSuicunePose88:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose89:
+ax_pose 97, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose90:
+ax_pose 98, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose91:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose92:
+ax_pose 89, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose93:
+ax_pose 90, 0x41ed, 0x80ea, 0x7c00
+ax_pose 91, 0x41e5, 0x00f2, 0x7c08
+ax_pose 92, 0x01e5, 0x0102, 0x7c0a
+ax_pose 93, 0x41fd, 0x00f2, 0x7c0b
+ax_pose 94, 0x01fd, 0x0102, 0x7c0d
+ax_pose 95, 0x01ed, 0x010a, 0x7c0e
+ax_pose 96, 0x01f5, 0x010a, 0x7c0f
+ax_pose_terminator
+sSuicunePose94:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose95:
+ax_pose 84, 0x41f5, 0x80ee, 0x7c00
+ax_pose 85, 0x41ed, 0x40ee, 0x7c08
+ax_pose 86, 0x41e5, 0x00f6, 0x7c0c
+ax_pose 87, 0x01e5, 0x0106, 0x7c0e
+ax_pose_terminator
+sSuicunePose96:
+ax_pose 88, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose97:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose98:
+ax_pose 104, 0x41e5, 0x80f1, 0x7c00
+ax_pose 105, 0x41f5, 0x40f1, 0x7c08
+ax_pose 106, 0x41fd, 0x00f1, 0x7c0c
+ax_pose 107, 0x01fd, 0x0101, 0x7c0e
+ax_pose 108, 0x01dd, 0x00fb, 0x7c0f
+ax_pose_terminator
+sSuicunePose99:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose100:
+ax_pose 109, 0x41ed, 0x50ef, 0x7c00
+ax_pose 110, 0x41f5, 0x90ef, 0x7c04
+ax_pose 111, 0x41e5, 0x10ff, 0x7c0c
+ax_pose 112, 0x01e5, 0x10f7, 0x7c0e
+ax_pose 113, 0x01dd, 0x00fe, 0x7c0f
+ax_pose_terminator
+sSuicunePose101:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose102:
+ax_pose 114, 0x41f4, 0x90ea, 0x7c00
+ax_pose 115, 0x41ec, 0x50ea, 0x7c08
+ax_pose 116, 0x41e4, 0x10fa, 0x7c0c
+ax_pose 117, 0x01e4, 0x10f2, 0x7c0e
+ax_pose 118, 0x01dc, 0x00fc, 0x7c0f
+ax_pose_terminator
+sSuicunePose103:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose104:
+ax_pose 119, 0x41f6, 0x90ee, 0x7c00
+ax_pose 120, 0x41ee, 0x50ee, 0x7c08
+ax_pose 121, 0x41e6, 0x10f6, 0x7c0c
+ax_pose 122, 0x01de, 0x10f6, 0x7c0e
+ax_pose 123, 0x01de, 0x10fe, 0x7c0f
+ax_pose_terminator
+sSuicunePose105:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose106:
+ax_pose 124, 0x01e6, 0x80ed, 0x7c00
+ax_pose 125, 0x01de, 0x00fc, 0x7c10
+ax_pose_terminator
+sSuicunePose107:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose108:
+ax_pose 119, 0x41f6, 0x80f1, 0x7c00
+ax_pose 120, 0x41ee, 0x40f1, 0x7c08
+ax_pose 121, 0x41e6, 0x00f9, 0x7c0c
+ax_pose 122, 0x01de, 0x0101, 0x7c0e
+ax_pose 123, 0x01de, 0x00f9, 0x7c0f
+ax_pose_terminator
+sSuicunePose109:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose110:
+ax_pose 114, 0x41f4, 0x80f5, 0x7c00
+ax_pose 115, 0x41ec, 0x40f5, 0x7c08
+ax_pose 116, 0x41e4, 0x00f5, 0x7c0c
+ax_pose 117, 0x01e4, 0x0105, 0x7c0e
+ax_pose 118, 0x01dc, 0x10fb, 0x7c0f
+ax_pose_terminator
+sSuicunePose111:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose112:
+ax_pose 109, 0x41ed, 0x40f0, 0x7c00
+ax_pose 110, 0x41f5, 0x80f0, 0x7c04
+ax_pose 111, 0x41e5, 0x00f0, 0x7c0c
+ax_pose 112, 0x01e5, 0x0100, 0x7c0e
+ax_pose 113, 0x01dd, 0x10f9, 0x7c0f
+ax_pose_terminator
+sSuicunePose113:
+ax_pose 126, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose114:
+ax_pose 127, 0x01ed, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose115:
+ax_pose 128, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sSuicunePose116:
+ax_pose 129, 0x01e6, 0x90f3, 0x7c00
+ax_pose_terminator
+sSuicunePose117:
+ax_pose 130, 0x01e3, 0x90f4, 0x7c00
+ax_pose_terminator
+sSuicunePose118:
+ax_pose 131, 0x01e6, 0x90f2, 0x7c00
+ax_pose_terminator
+sSuicunePose119:
+ax_pose 132, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sSuicunePose120:
+ax_pose 131, 0x01e6, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose121:
+ax_pose 130, 0x01e3, 0x80ec, 0x7c00
+ax_pose_terminator
+sSuicunePose122:
+ax_pose 129, 0x01e6, 0x80ed, 0x7c00
+ax_pose_terminator
+sSuicunePose123:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose124:
+ax_pose 82, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose125:
+ax_pose 83, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose126:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose127:
+ax_pose 84, 0x41f5, 0x90f1, 0x7c00
+ax_pose 85, 0x41ed, 0x50f1, 0x7c08
+ax_pose 86, 0x41e5, 0x10f9, 0x7c0c
+ax_pose 87, 0x01e5, 0x10f1, 0x7c0e
+ax_pose_terminator
+sSuicunePose128:
+ax_pose 88, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose129:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose130:
+ax_pose 89, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose131:
+ax_pose 90, 0x41ed, 0x90f5, 0x7c00
+ax_pose 91, 0x41e5, 0x10fd, 0x7c08
+ax_pose 92, 0x01e5, 0x10f5, 0x7c0a
+ax_pose 93, 0x41fd, 0x10fd, 0x7c0b
+ax_pose 94, 0x01fd, 0x10f5, 0x7c0d
+ax_pose 95, 0x01ed, 0x10ed, 0x7c0e
+ax_pose 96, 0x01f5, 0x10ed, 0x7c0f
+ax_pose_terminator
+sSuicunePose132:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose133:
+ax_pose 97, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose134:
+ax_pose 98, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose135:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose136:
+ax_pose 99, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose137:
+ax_pose 100, 0x41e5, 0x80f0, 0x7c00
+ax_pose 101, 0x41f5, 0x40f0, 0x7c08
+ax_pose 102, 0x41fd, 0x00f0, 0x7c0c
+ax_pose 103, 0x01fd, 0x0100, 0x7c0e
+ax_pose_terminator
+sSuicunePose138:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose139:
+ax_pose 97, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose140:
+ax_pose 98, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose141:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose142:
+ax_pose 89, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose143:
+ax_pose 90, 0x41ed, 0x80ea, 0x7c00
+ax_pose 91, 0x41e5, 0x00f2, 0x7c08
+ax_pose 92, 0x01e5, 0x0102, 0x7c0a
+ax_pose 93, 0x41fd, 0x00f2, 0x7c0b
+ax_pose 94, 0x01fd, 0x0102, 0x7c0d
+ax_pose 95, 0x01ed, 0x010a, 0x7c0e
+ax_pose 96, 0x01f5, 0x010a, 0x7c0f
+ax_pose_terminator
+sSuicunePose144:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose145:
+ax_pose 84, 0x41f5, 0x80ee, 0x7c00
+ax_pose 85, 0x41ed, 0x40ee, 0x7c08
+ax_pose 86, 0x41e5, 0x00f6, 0x7c0c
+ax_pose 87, 0x01e5, 0x0106, 0x7c0e
+ax_pose_terminator
+sSuicunePose146:
+ax_pose 88, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose147:
+ax_pose 83, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose148:
+ax_pose 88, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose149:
+ax_pose 90, 0x41ed, 0x80ed, 0x7c00
+ax_pose 91, 0x41e5, 0x00f5, 0x7c08
+ax_pose 92, 0x01e5, 0x0105, 0x7c0a
+ax_pose 93, 0x41fd, 0x00f5, 0x7c0b
+ax_pose 94, 0x01fd, 0x0105, 0x7c0d
+ax_pose 95, 0x01ed, 0x010d, 0x7c0e
+ax_pose 96, 0x01f5, 0x010d, 0x7c0f
+ax_pose_terminator
+sSuicunePose150:
+ax_pose 98, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sSuicunePose151:
+ax_pose 100, 0x41e5, 0x80f0, 0x7c00
+ax_pose 101, 0x41f5, 0x40f0, 0x7c08
+ax_pose 102, 0x41fd, 0x00f0, 0x7c0c
+ax_pose 103, 0x01fd, 0x0100, 0x7c0e
+ax_pose_terminator
+sSuicunePose152:
+ax_pose 98, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose153:
+ax_pose 90, 0x41ed, 0x90f2, 0x7c00
+ax_pose 91, 0x41e5, 0x10fa, 0x7c08
+ax_pose 92, 0x01e5, 0x10f2, 0x7c0a
+ax_pose 93, 0x41fd, 0x10fa, 0x7c0b
+ax_pose 94, 0x01fd, 0x10f2, 0x7c0d
+ax_pose 95, 0x01ed, 0x10ea, 0x7c0e
+ax_pose 96, 0x01f5, 0x10ea, 0x7c0f
+ax_pose_terminator
+sSuicunePose154:
+ax_pose 88, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose155:
+ax_pose 83, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose156:
+ax_pose 88, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose157:
+ax_pose 90, 0x41ed, 0x90f2, 0x7c00
+ax_pose 91, 0x41e5, 0x10fa, 0x7c08
+ax_pose 92, 0x01e5, 0x10f2, 0x7c0a
+ax_pose 93, 0x41fd, 0x10fa, 0x7c0b
+ax_pose 94, 0x01fd, 0x10f2, 0x7c0d
+ax_pose 95, 0x01ed, 0x10ea, 0x7c0e
+ax_pose 96, 0x01f5, 0x10ea, 0x7c0f
+ax_pose_terminator
+sSuicunePose158:
+ax_pose 98, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose159:
+ax_pose 100, 0x41e5, 0x80f0, 0x7c00
+ax_pose 101, 0x41f5, 0x40f0, 0x7c08
+ax_pose 102, 0x41fd, 0x00f0, 0x7c0c
+ax_pose 103, 0x01fd, 0x0100, 0x7c0e
+ax_pose_terminator
+sSuicunePose160:
+ax_pose 98, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sSuicunePose161:
+ax_pose 90, 0x41ed, 0x80ed, 0x7c00
+ax_pose 91, 0x41e5, 0x00f5, 0x7c08
+ax_pose 92, 0x01e5, 0x0105, 0x7c0a
+ax_pose 93, 0x41fd, 0x00f5, 0x7c0b
+ax_pose 94, 0x01fd, 0x0105, 0x7c0d
+ax_pose 95, 0x01ed, 0x010d, 0x7c0e
+ax_pose 96, 0x01f5, 0x010d, 0x7c0f
+ax_pose_terminator
+sSuicunePose162:
+ax_pose 88, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose163:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose164:
+ax_pose 83, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose165:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose166:
+ax_pose 88, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose167:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose168:
+ax_pose 90, 0x41ed, 0x90f2, 0x7c00
+ax_pose 91, 0x41e5, 0x10fa, 0x7c08
+ax_pose 92, 0x01e5, 0x10f2, 0x7c0a
+ax_pose 93, 0x41fd, 0x10fa, 0x7c0b
+ax_pose 94, 0x01fd, 0x10f2, 0x7c0d
+ax_pose 95, 0x01ed, 0x10ea, 0x7c0e
+ax_pose 96, 0x01f5, 0x10ea, 0x7c0f
+ax_pose_terminator
+sSuicunePose169:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose170:
+ax_pose 98, 0x01e5, 0x90ee, 0x7c00
+ax_pose_terminator
+sSuicunePose171:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose172:
+ax_pose 100, 0x41e5, 0x80f0, 0x7c00
+ax_pose 101, 0x41f5, 0x40f0, 0x7c08
+ax_pose 102, 0x41fd, 0x00f0, 0x7c0c
+ax_pose 103, 0x01fd, 0x0100, 0x7c0e
+ax_pose_terminator
+sSuicunePose173:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose174:
+ax_pose 98, 0x01e5, 0x80f1, 0x7c00
+ax_pose_terminator
+sSuicunePose175:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose176:
+ax_pose 90, 0x41ed, 0x80ed, 0x7c00
+ax_pose 91, 0x41e5, 0x00f5, 0x7c08
+ax_pose 92, 0x01e5, 0x0105, 0x7c0a
+ax_pose 93, 0x41fd, 0x00f5, 0x7c0b
+ax_pose 94, 0x01fd, 0x0105, 0x7c0d
+ax_pose 95, 0x01ed, 0x010d, 0x7c0e
+ax_pose 96, 0x01f5, 0x010d, 0x7c0f
+ax_pose_terminator
+sSuicunePose177:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose178:
+ax_pose 88, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose179:
+ax_pose 82, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose180:
+ax_pose 84, 0x41f5, 0x80ee, 0x7c00
+ax_pose 85, 0x41ed, 0x40ee, 0x7c08
+ax_pose 86, 0x41e5, 0x00f6, 0x7c0c
+ax_pose 87, 0x01e5, 0x0106, 0x7c0e
+ax_pose_terminator
+sSuicunePose181:
+ax_pose 89, 0x01e4, 0x80ed, 0x7c00
+ax_pose_terminator
+sSuicunePose182:
+ax_pose 97, 0x01e5, 0x80ef, 0x7c00
+ax_pose_terminator
+sSuicunePose183:
+ax_pose 99, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose184:
+ax_pose 97, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose185:
+ax_pose 89, 0x01e4, 0x90f3, 0x7c00
+ax_pose_terminator
+sSuicunePose186:
+ax_pose 84, 0x41f5, 0x90f2, 0x7c00
+ax_pose 85, 0x41ed, 0x50f2, 0x7c08
+ax_pose 86, 0x41e5, 0x10fa, 0x7c0c
+ax_pose 87, 0x01e5, 0x10f2, 0x7c0e
+ax_pose_terminator
+sSuicunePose187:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose188:
+ax_pose 11, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose189:
+ax_pose 18, 0x01e5, 0x80ee, 0x7c00
+ax_pose_terminator
+sSuicunePose190:
+ax_pose 30, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose191:
+ax_pose 41, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose192:
+ax_pose 30, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sSuicunePose193:
+ax_pose 18, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose194:
+ax_pose 11, 0x01e5, 0x90f1, 0x7c00
+ax_pose_terminator
+sSuicunePose195:
+ax_pose 0, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose196:
+ax_pose 82, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose197:
+ax_pose 83, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sSuicunePose198:
+ax_pose 104, 0x41e5, 0x80f1, 0x7c00
+ax_pose 105, 0x41f5, 0x40f1, 0x7c08
+ax_pose 106, 0x41fd, 0x00f1, 0x7c0c
+ax_pose 107, 0x01fd, 0x0101, 0x7c0e
+ax_pose 108, 0x01dd, 0x00fb, 0x7c0f
+ax_pose_terminator
+.align 2
+sSuicuneAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -2, 0, 2,
+ax_anim 2, 0, 25, 0, 0, 0, 7,
+ax_anim 2, 2, 25, 0, 10, 0, 14,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 1, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 0, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSuicuneAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 6, -3, 6, 6,
+ax_anim 2, 0, 28, 9, -1, 9, 9,
+ax_anim 2, 2, 28, 12, 6, 12, 12,
+ax_anim 2, 0, 29, 17, 17, 17, 17,
+ax_anim 2, 1, 29, 18, 16, 18, 16,
+ax_anim 2, 0, 29, 17, 17, 17, 17,
+ax_anim 2, 0, 29, 18, 16, 18, 16,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sSuicuneAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 3, -7, 3, 0,
+ax_anim 2, 0, 31, 6, -8, 6, 0,
+ax_anim 2, 2, 31, 9, -6, 9, 0,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 1, 32, 16, -1, 16, -1,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 16, -1, 16, -1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSuicuneAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 3, -9, 3, -3,
+ax_anim 2, 0, 34, 8, -19, 8, -8,
+ax_anim 2, 2, 34, 16, -22, 16, -16,
+ax_anim 2, 0, 35, 19, -19, 19, -19,
+ax_anim 2, 1, 35, 20, -18, 20, -18,
+ax_anim 2, 0, 35, 19, -19, 19, -19,
+ax_anim 2, 0, 35, 20, -18, 20, -18,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSuicuneAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, -5, 0, -1,
+ax_anim 2, 0, 37, 0, -11, 0, -6,
+ax_anim 2, 2, 37, 0, -16, 0, -15,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 1, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 38, 0, -22, 0, -22,
+ax_anim 2, 0, 38, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSuicuneAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, -3, -9, -3, -3,
+ax_anim 2, 0, 40, -8, -19, -8, -8,
+ax_anim 2, 2, 40, -16, -22, -16, -16,
+ax_anim 2, 0, 41, -19, -19, -19, -19,
+ax_anim 2, 1, 41, -20, -18, -20, -18,
+ax_anim 2, 0, 41, -19, -19, -19, -19,
+ax_anim 2, 0, 41, -20, -18, -20, -18,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSuicuneAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, -3, -7, -3, 0,
+ax_anim 2, 0, 43, -6, -8, -6, 0,
+ax_anim 2, 2, 43, -9, -6, -9, 0,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 1, 44, -16, -1, -16, -1,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 0, 44, -16, -1, -16, -1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSuicuneAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, -6, -3, -6, 6,
+ax_anim 2, 0, 46, -9, -1, -9, 9,
+ax_anim 2, 2, 46, -12, 6, -12, 12,
+ax_anim 2, 0, 47, -17, 17, -17, 17,
+ax_anim 2, 1, 47, -18, 16, -18, 16,
+ax_anim 2, 0, 47, -17, 17, -17, 17,
+ax_anim 2, 0, 47, -18, 16, -18, 16,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 49, 0, -2, 0, 2,
+ax_anim 2, 0, 49, 0, 0, 0, 7,
+ax_anim 2, 2, 49, 0, 10, 0, 14,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 1, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 0, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSuicuneAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 6, -3, 6, 6,
+ax_anim 2, 0, 52, 9, -1, 9, 9,
+ax_anim 2, 2, 52, 12, 6, 12, 12,
+ax_anim 2, 0, 53, 17, 17, 17, 17,
+ax_anim 2, 1, 53, 18, 16, 18, 16,
+ax_anim 2, 0, 53, 17, 17, 17, 17,
+ax_anim 2, 0, 53, 18, 16, 18, 16,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sSuicuneAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 3, -7, 3, 0,
+ax_anim 2, 0, 55, 6, -8, 6, 0,
+ax_anim 2, 2, 55, 9, -6, 9, 0,
+ax_anim 2, 0, 56, 16, 0, 16, 0,
+ax_anim 2, 1, 56, 16, -1, 16, -1,
+ax_anim 2, 0, 56, 16, 0, 16, 0,
+ax_anim 2, 0, 56, 16, -1, 16, -1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSuicuneAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 3, -9, 3, -3,
+ax_anim 2, 0, 58, 8, -19, 8, -8,
+ax_anim 2, 2, 58, 16, -22, 16, -16,
+ax_anim 2, 0, 59, 19, -19, 19, -19,
+ax_anim 2, 1, 59, 20, -18, 20, -18,
+ax_anim 2, 0, 59, 19, -19, 19, -19,
+ax_anim 2, 0, 59, 20, -18, 20, -18,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSuicuneAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, -5, 0, -1,
+ax_anim 2, 0, 61, 0, -11, 0, -6,
+ax_anim 2, 2, 61, 0, -16, 0, -15,
+ax_anim 2, 0, 62, 0, -22, 0, -22,
+ax_anim 2, 1, 62, 1, -22, 1, -22,
+ax_anim 2, 0, 62, 0, -22, 0, -22,
+ax_anim 2, 0, 62, 1, -22, 1, -22,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSuicuneAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, -3, -9, -3, -3,
+ax_anim 2, 0, 64, -8, -19, -8, -8,
+ax_anim 2, 2, 64, -16, -22, -16, -16,
+ax_anim 2, 0, 65, -19, -19, -19, -19,
+ax_anim 2, 1, 65, -20, -18, -20, -18,
+ax_anim 2, 0, 65, -19, -19, -19, -19,
+ax_anim 2, 0, 65, -20, -18, -20, -18,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSuicuneAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, -3, -7, -3, 0,
+ax_anim 2, 0, 67, -6, -8, -6, 0,
+ax_anim 2, 2, 67, -9, -6, -9, 0,
+ax_anim 2, 0, 68, -16, 0, -16, 0,
+ax_anim 2, 1, 68, -16, -1, -16, -1,
+ax_anim 2, 0, 68, -16, 0, -16, 0,
+ax_anim 2, 0, 68, -16, -1, -16, -1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSuicuneAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, -6, -3, -6, 6,
+ax_anim 2, 0, 70, -9, -1, -9, 9,
+ax_anim 2, 2, 70, -12, 6, -12, 12,
+ax_anim 2, 0, 71, -17, 17, -17, 17,
+ax_anim 2, 1, 71, -18, 16, -18, 16,
+ax_anim 2, 0, 71, -17, 17, -17, 17,
+ax_anim 2, 0, 71, -18, 16, -18, 16,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sSuicuneAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sSuicuneAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 79, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 80, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sSuicuneAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 82, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sSuicuneAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 88, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sSuicuneAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 91, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 92, -3, 1, -3, 1,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sSuicuneAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 1, 0, 1,
+ax_anim 1, 0, 97, 0, 1, 0, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 2, 97, 0, -1, 0, -1,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, -1, 0, -1,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, -1, 0, -1,
+ax_anim 2, 1, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, 0, -1, 0, -1,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_5_2:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 1, 1, 1, 1,
+ax_anim 1, 0, 99, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 2, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 1, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_5_3:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 1, 0, 1, 0,
+ax_anim 1, 0, 101, 1, 0, 1, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 2, 101, -1, 0, -1, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, -1, 0, -1, 0,
+ax_anim 2, 0, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, -1, 0, -1, 0,
+ax_anim 2, 1, 101, -1, -1, -1, -1,
+ax_anim 2, 0, 101, -1, 0, -1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_5_4:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 1, -1, 1, -1,
+ax_anim 1, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 2, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -2, 0, -2, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 1, 103, -2, 0, -2, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_5_5:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, -1, 0, -1,
+ax_anim 1, 0, 105, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 2, 105, 0, 1, 0, 1,
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 2, 0, 105, 0, 1, 0, 1,
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 2, 0, 105, 0, 1, 0, 1,
+ax_anim 2, 1, 105, 1, 1, 1, 1,
+ax_anim 2, 0, 105, 0, 1, 0, 1,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_5_6:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 106, -1, -1, -1, -1,
+ax_anim 1, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 6, 2, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 1, 107, 2, 0, 2, 0,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_5_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 108, -1, 0, -1, 0,
+ax_anim 1, 0, 109, -1, 0, -1, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 6, 2, 109, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 1, 0, 1, 0,
+ax_anim 2, 1, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 109, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_5_8:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 110, -1, 1, -1, 1,
+ax_anim 1, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 2, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -2, 0, -2,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 0, -2, 0, -2,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 1, 111, 0, -2, 0, -2,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_7_1:
+ax_anim 2, 0, 114, 0, -6, 0, -6,
+ax_anim 8, 0, 114, 0, -7, 0, -7,
+ax_anim_terminator
+sSuicuneAnims_7_2:
+ax_anim 2, 0, 115, -6, -6, -6, -6,
+ax_anim 8, 0, 115, -7, -7, -7, -7,
+ax_anim_terminator
+sSuicuneAnims_7_3:
+ax_anim 2, 0, 116, -6, 0, -6, 0,
+ax_anim 8, 0, 116, -7, 0, -7, 0,
+ax_anim_terminator
+sSuicuneAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sSuicuneAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sSuicuneAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sSuicuneAnims_7_7:
+ax_anim 2, 0, 120, 6, 0, 6, 0,
+ax_anim 8, 0, 120, 7, 0, 7, 0,
+ax_anim_terminator
+sSuicuneAnims_7_8:
+ax_anim 2, 0, 121, 6, -6, 6, -6,
+ax_anim 8, 0, 121, 7, -7, 7, -7,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_8_1:
+ax_anim 60, 0, 122, 0, 0, 0, 0,
+ax_anim 10, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim 10, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_8_2:
+ax_anim 60, 0, 125, 0, 0, 0, 0,
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, 0, -1, 0,
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_8_3:
+ax_anim 60, 0, 128, 0, 0, 0, 0,
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, -1, 0, -1, 0,
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_8_4:
+ax_anim 60, 0, 131, 0, 0, 0, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_8_5:
+ax_anim 60, 0, 134, 0, 0, 0, 0,
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 0, -1, 0,
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_8_6:
+ax_anim 60, 0, 137, 0, 0, 0, 0,
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_8_7:
+ax_anim 60, 0, 140, 0, 0, 0, 0,
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, 0, -1, 0,
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_8_8:
+ax_anim 60, 0, 143, 0, 0, 0, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 15, 7, 15,
+ax_anim 3, 0, 150, 0, 18, 0, 18,
+ax_anim 2, 3, 151, -7, 15, -7, 15,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 19, 10, 19, 10,
+ax_anim 3, 0, 149, 17, 19, 17, 19,
+ax_anim 2, 3, 150, 11, 19, 11, 19,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 16, -5, 16, -5,
+ax_anim 3, 0, 148, 18, -2, 18, -2,
+ax_anim 2, 3, 149, 16, 4, 16, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 12, -21, 12, -21,
+ax_anim 3, 0, 147, 18, -19, 18, -19,
+ax_anim 2, 3, 148, 20, -13, 20, -13,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -7, -17, -7, -17,
+ax_anim 3, 0, 146, 0, -20, 0, -20,
+ax_anim 2, 3, 147, 7, -17, 7, -17,
+ax_anim 2, 0, 148, 9, -12, 9, -12,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -21, -12, -21,
+ax_anim 3, 0, 153, -18, -19, -18, -19,
+ax_anim 2, 3, 152, -20, -13, -20, -13,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -16, -5, -16, -5,
+ax_anim 3, 0, 152, -18, -2, -18, -2,
+ax_anim 2, 3, 151, -16, 4, -16, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -19, 10, -19, 10,
+ax_anim 3, 0, 151, -17, 19, -17, 19,
+ax_anim 2, 3, 150, -11, 19, -11, 19,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -18, 0, 0,
+ax_anim 4, 0, 162, 0, -19, 0, 0,
+ax_anim 4, 0, 163, 0, -24, 0, 0,
+ax_anim 3, 0, 163, 0, -22, 0, 0,
+ax_anim 2, 0, 163, 0, -18, 0, 0,
+ax_anim 1, 0, 163, 0, -12, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_11_2:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -19, 0, 0,
+ax_anim 4, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -24, 0, 0,
+ax_anim 3, 0, 165, 0, -23, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_11_3:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -18, 0, 0,
+ax_anim 4, 0, 166, 0, -19, 0, 0,
+ax_anim 4, 0, 167, 0, -24, 0, 0,
+ax_anim 3, 0, 167, 0, -23, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_11_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -19, 0, 0,
+ax_anim 4, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -17, 0, 0,
+ax_anim 1, 0, 169, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_11_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -23, 0, 0,
+ax_anim 3, 0, 171, 0, -22, 0, 0,
+ax_anim 2, 0, 171, 0, -18, 0, 0,
+ax_anim 1, 0, 171, 0, -12, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_11_6:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -19, 0, 0,
+ax_anim 4, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_11_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -18, 0, 0,
+ax_anim 4, 0, 174, 0, -19, 0, 0,
+ax_anim 4, 0, 175, 0, -24, 0, 0,
+ax_anim 3, 0, 175, 0, -23, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_11_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -19, 0, 0,
+ax_anim 4, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -24, 0, 0,
+ax_anim 3, 0, 177, 0, -23, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSuicuneAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSuicuneAnims_14_1:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_14_2:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_14_3:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_14_4:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_14_5:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_14_6:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_14_7:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneAnims_14_8:
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 1, 0, 1,
+ax_anim 4, 0, 196, 0, 1, 0, 1,
+ax_anim 2, 0, 194, 0, 1, 0, 1,
+ax_anim 1, 0, 197, 0, 1, 0, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, -1, 0, -1,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 10, 0, 197, 0, -1, 0, -1,
+ax_anim_terminator
+sSuicuneGfx1:
+.incbin "baserom.gba", 0xFF732C, 0x200
+sSuicuneSprites1:
+ax_sprite sSuicuneGfx1, 0x200
+ax_sprite_terminator
+sSuicuneGfx2:
+.incbin "baserom.gba", 0xFF753C, 0x100
+sSuicuneSprites2:
+ax_sprite sSuicuneGfx2, 0x100
+ax_sprite_terminator
+sSuicuneGfx3:
+.incbin "baserom.gba", 0xFF764C, 0x80
+sSuicuneSprites3:
+ax_sprite sSuicuneGfx3, 0x80
+ax_sprite_terminator
+sSuicuneGfx4:
+.incbin "baserom.gba", 0xFF76DC, 0x40
+sSuicuneSprites4:
+ax_sprite sSuicuneGfx4, 0x40
+ax_sprite_terminator
+sSuicuneGfx5:
+.incbin "baserom.gba", 0xFF772C, 0x20
+sSuicuneSprites5:
+ax_sprite sSuicuneGfx5, 0x20
+ax_sprite_terminator
+sSuicuneGfx6:
+.incbin "baserom.gba", 0xFF775C, 0x20
+sSuicuneSprites6:
+ax_sprite sSuicuneGfx6, 0x20
+ax_sprite_terminator
+sSuicuneGfx7:
+.incbin "baserom.gba", 0xFF778C, 0x100
+sSuicuneSprites7:
+ax_sprite sSuicuneGfx7, 0x100
+ax_sprite_terminator
+sSuicuneGfx8:
+.incbin "baserom.gba", 0xFF789C, 0x80
+sSuicuneSprites8:
+ax_sprite sSuicuneGfx8, 0x80
+ax_sprite_terminator
+sSuicuneGfx9:
+.incbin "baserom.gba", 0xFF792C, 0x40
+sSuicuneSprites9:
+ax_sprite sSuicuneGfx9, 0x40
+ax_sprite_terminator
+sSuicuneGfx10:
+.incbin "baserom.gba", 0xFF797C, 0x20
+sSuicuneSprites10:
+ax_sprite sSuicuneGfx10, 0x20
+ax_sprite_terminator
+sSuicuneGfx11:
+.incbin "baserom.gba", 0xFF79AC, 0x20
+sSuicuneSprites11:
+ax_sprite sSuicuneGfx11, 0x20
+ax_sprite_terminator
+sSuicuneGfx12:
+.incbin "baserom.gba", 0xFF79DC, 0x200
+sSuicuneSprites12:
+ax_sprite sSuicuneGfx12, 0x200
+ax_sprite_terminator
+sSuicuneGfx13:
+.incbin "baserom.gba", 0xFF7BEC, 0x200
+sSuicuneSprites13:
+ax_sprite sSuicuneGfx13, 0x200
+ax_sprite_terminator
+sSuicuneGfx14:
+.incbin "baserom.gba", 0xFF7DFC, 0x100
+sSuicuneSprites14:
+ax_sprite sSuicuneGfx14, 0x100
+ax_sprite_terminator
+sSuicuneGfx15:
+.incbin "baserom.gba", 0xFF7F0C, 0x80
+sSuicuneSprites15:
+ax_sprite sSuicuneGfx15, 0x80
+ax_sprite_terminator
+sSuicuneGfx16:
+.incbin "baserom.gba", 0xFF7F9C, 0x40
+sSuicuneSprites16:
+ax_sprite sSuicuneGfx16, 0x40
+ax_sprite_terminator
+sSuicuneGfx17:
+.incbin "baserom.gba", 0xFF7FEC, 0x20
+sSuicuneSprites17:
+ax_sprite sSuicuneGfx17, 0x20
+ax_sprite_terminator
+sSuicuneGfx18:
+.incbin "baserom.gba", 0xFF801C, 0x20
+sSuicuneSprites18:
+ax_sprite sSuicuneGfx18, 0x20
+ax_sprite_terminator
+sSuicuneGfx19:
+.incbin "baserom.gba", 0xFF804C, 0x200
+sSuicuneSprites19:
+ax_sprite sSuicuneGfx19, 0x200
+ax_sprite_terminator
+sSuicuneGfx20:
+.incbin "baserom.gba", 0xFF825C, 0x100
+sSuicuneSprites20:
+ax_sprite sSuicuneGfx20, 0x100
+ax_sprite_terminator
+sSuicuneGfx21:
+.incbin "baserom.gba", 0xFF836C, 0x80
+sSuicuneSprites21:
+ax_sprite sSuicuneGfx21, 0x80
+ax_sprite_terminator
+sSuicuneGfx22:
+.incbin "baserom.gba", 0xFF83FC, 0x40
+sSuicuneSprites22:
+ax_sprite sSuicuneGfx22, 0x40
+ax_sprite_terminator
+sSuicuneGfx23:
+.incbin "baserom.gba", 0xFF844C, 0x20
+sSuicuneSprites23:
+ax_sprite sSuicuneGfx23, 0x20
+ax_sprite_terminator
+sSuicuneGfx24:
+.incbin "baserom.gba", 0xFF847C, 0x20
+sSuicuneSprites24:
+ax_sprite sSuicuneGfx24, 0x20
+ax_sprite_terminator
+sSuicuneGfx25:
+.incbin "baserom.gba", 0xFF84AC, 0x100
+sSuicuneSprites25:
+ax_sprite sSuicuneGfx25, 0x100
+ax_sprite_terminator
+sSuicuneGfx26:
+.incbin "baserom.gba", 0xFF85BC, 0x80
+sSuicuneSprites26:
+ax_sprite sSuicuneGfx26, 0x80
+ax_sprite_terminator
+sSuicuneGfx27:
+.incbin "baserom.gba", 0xFF864C, 0x20
+sSuicuneSprites27:
+ax_sprite sSuicuneGfx27, 0x20
+ax_sprite_terminator
+sSuicuneGfx28:
+.incbin "baserom.gba", 0xFF867C, 0x20
+sSuicuneSprites28:
+ax_sprite sSuicuneGfx28, 0x20
+ax_sprite_terminator
+sSuicuneGfx29:
+.incbin "baserom.gba", 0xFF86AC, 0x20
+sSuicuneSprites29:
+ax_sprite sSuicuneGfx29, 0x20
+ax_sprite_terminator
+sSuicuneGfx30:
+.incbin "baserom.gba", 0xFF86DC, 0x20
+sSuicuneSprites30:
+ax_sprite sSuicuneGfx30, 0x20
+ax_sprite_terminator
+sSuicuneGfx31:
+.incbin "baserom.gba", 0xFF870C, 0x200
+sSuicuneSprites31:
+ax_sprite sSuicuneGfx31, 0x200
+ax_sprite_terminator
+sSuicuneGfx32:
+.incbin "baserom.gba", 0xFF891C, 0x100
+sSuicuneSprites32:
+ax_sprite sSuicuneGfx32, 0x100
+ax_sprite_terminator
+sSuicuneGfx33:
+.incbin "baserom.gba", 0xFF8A2C, 0x80
+sSuicuneSprites33:
+ax_sprite sSuicuneGfx33, 0x80
+ax_sprite_terminator
+sSuicuneGfx34:
+.incbin "baserom.gba", 0xFF8ABC, 0x40
+sSuicuneSprites34:
+ax_sprite sSuicuneGfx34, 0x40
+ax_sprite_terminator
+sSuicuneGfx35:
+.incbin "baserom.gba", 0xFF8B0C, 0x20
+sSuicuneSprites35:
+ax_sprite sSuicuneGfx35, 0x20
+ax_sprite_terminator
+sSuicuneGfx36:
+.incbin "baserom.gba", 0xFF8B3C, 0x20
+sSuicuneSprites36:
+ax_sprite sSuicuneGfx36, 0x20
+ax_sprite_terminator
+sSuicuneGfx37:
+.incbin "baserom.gba", 0xFF8B6C, 0x100
+sSuicuneSprites37:
+ax_sprite sSuicuneGfx37, 0x100
+ax_sprite_terminator
+sSuicuneGfx38:
+.incbin "baserom.gba", 0xFF8C7C, 0x80
+sSuicuneSprites38:
+ax_sprite sSuicuneGfx38, 0x80
+ax_sprite_terminator
+sSuicuneGfx39:
+.incbin "baserom.gba", 0xFF8D0C, 0x40
+sSuicuneSprites39:
+ax_sprite sSuicuneGfx39, 0x40
+ax_sprite_terminator
+sSuicuneGfx40:
+.incbin "baserom.gba", 0xFF8D5C, 0x20
+sSuicuneSprites40:
+ax_sprite sSuicuneGfx40, 0x20
+ax_sprite_terminator
+sSuicuneGfx41:
+.incbin "baserom.gba", 0xFF8D8C, 0x20
+sSuicuneSprites41:
+ax_sprite sSuicuneGfx41, 0x20
+ax_sprite_terminator
+sSuicuneGfx42:
+.incbin "baserom.gba", 0xFF8DBC, 0x200
+sSuicuneSprites42:
+ax_sprite sSuicuneGfx42, 0x200
+ax_sprite_terminator
+sSuicuneGfx43:
+.incbin "baserom.gba", 0xFF8FCC, 0x200
+sSuicuneSprites43:
+ax_sprite sSuicuneGfx43, 0x200
+ax_sprite_terminator
+sSuicuneGfx44:
+.incbin "baserom.gba", 0xFF91DC, 0x200
+sSuicuneSprites44:
+ax_sprite sSuicuneGfx44, 0x200
+ax_sprite_terminator
+sSuicuneGfx45:
+.incbin "baserom.gba", 0xFF93EC, 0x200
+sSuicuneSprites45:
+ax_sprite sSuicuneGfx45, 0x200
+ax_sprite_terminator
+sSuicuneGfx46:
+.incbin "baserom.gba", 0xFF95FC, 0x20
+sSuicuneSprites46:
+ax_sprite sSuicuneGfx46, 0x20
+ax_sprite_terminator
+sSuicuneGfx47:
+.incbin "baserom.gba", 0xFF962C, 0x80
+sSuicuneSprites47:
+ax_sprite sSuicuneGfx47, 0x80
+ax_sprite_terminator
+sSuicuneGfx48:
+.incbin "baserom.gba", 0xFF96BC, 0x100
+sSuicuneSprites48:
+ax_sprite sSuicuneGfx48, 0x100
+ax_sprite_terminator
+sSuicuneGfx49:
+.incbin "baserom.gba", 0xFF97CC, 0x100
+sSuicuneSprites49:
+ax_sprite sSuicuneGfx49, 0x100
+ax_sprite_terminator
+sSuicuneGfx50:
+.incbin "baserom.gba", 0xFF98DC, 0x80
+sSuicuneSprites50:
+ax_sprite sSuicuneGfx50, 0x80
+ax_sprite_terminator
+sSuicuneGfx51:
+.incbin "baserom.gba", 0xFF996C, 0x20
+sSuicuneSprites51:
+ax_sprite sSuicuneGfx51, 0x20
+ax_sprite_terminator
+sSuicuneGfx52:
+.incbin "baserom.gba", 0xFF999C, 0x20
+sSuicuneSprites52:
+ax_sprite sSuicuneGfx52, 0x20
+ax_sprite_terminator
+sSuicuneGfx53:
+.incbin "baserom.gba", 0xFF99CC, 0x20
+sSuicuneSprites53:
+ax_sprite sSuicuneGfx53, 0x20
+ax_sprite_terminator
+sSuicuneGfx54:
+.incbin "baserom.gba", 0xFF99FC, 0x40
+sSuicuneSprites54:
+ax_sprite sSuicuneGfx54, 0x40
+ax_sprite_terminator
+sSuicuneGfx55:
+.incbin "baserom.gba", 0xFF9A4C, 0x20
+sSuicuneSprites55:
+ax_sprite sSuicuneGfx55, 0x20
+ax_sprite_terminator
+sSuicuneGfx56:
+.incbin "baserom.gba", 0xFF9A7C, 0x100
+sSuicuneSprites56:
+ax_sprite sSuicuneGfx56, 0x100
+ax_sprite_terminator
+sSuicuneGfx57:
+.incbin "baserom.gba", 0xFF9B8C, 0x80
+sSuicuneSprites57:
+ax_sprite sSuicuneGfx57, 0x80
+ax_sprite_terminator
+sSuicuneGfx58:
+.incbin "baserom.gba", 0xFF9C1C, 0x20
+sSuicuneSprites58:
+ax_sprite sSuicuneGfx58, 0x20
+ax_sprite_terminator
+sSuicuneGfx59:
+.incbin "baserom.gba", 0xFF9C4C, 0x20
+sSuicuneSprites59:
+ax_sprite sSuicuneGfx59, 0x20
+ax_sprite_terminator
+sSuicuneGfx60:
+.incbin "baserom.gba", 0xFF9C7C, 0x40
+sSuicuneSprites60:
+ax_sprite sSuicuneGfx60, 0x40
+ax_sprite_terminator
+sSuicuneGfx61:
+.incbin "baserom.gba", 0xFF9CCC, 0x20
+sSuicuneSprites61:
+ax_sprite sSuicuneGfx61, 0x20
+ax_sprite_terminator
+sSuicuneGfx62:
+.incbin "baserom.gba", 0xFF9CFC, 0x100
+sSuicuneSprites62:
+ax_sprite sSuicuneGfx62, 0x100
+ax_sprite_terminator
+sSuicuneGfx63:
+.incbin "baserom.gba", 0xFF9E0C, 0x80
+sSuicuneSprites63:
+ax_sprite sSuicuneGfx63, 0x80
+ax_sprite_terminator
+sSuicuneGfx64:
+.incbin "baserom.gba", 0xFF9E9C, 0x40
+sSuicuneSprites64:
+ax_sprite sSuicuneGfx64, 0x40
+ax_sprite_terminator
+sSuicuneGfx65:
+.incbin "baserom.gba", 0xFF9EEC, 0x40
+sSuicuneSprites65:
+ax_sprite sSuicuneGfx65, 0x40
+ax_sprite_terminator
+sSuicuneGfx66:
+.incbin "baserom.gba", 0xFF9F3C, 0x20
+sSuicuneSprites66:
+ax_sprite sSuicuneGfx66, 0x20
+ax_sprite_terminator
+sSuicuneGfx67:
+.incbin "baserom.gba", 0xFF9F6C, 0x20
+sSuicuneSprites67:
+ax_sprite sSuicuneGfx67, 0x20
+ax_sprite_terminator
+sSuicuneGfx68:
+.incbin "baserom.gba", 0xFF9F9C, 0x100
+sSuicuneSprites68:
+ax_sprite sSuicuneGfx68, 0x100
+ax_sprite_terminator
+sSuicuneGfx69:
+.incbin "baserom.gba", 0xFFA0AC, 0x40
+sSuicuneSprites69:
+ax_sprite sSuicuneGfx69, 0x40
+ax_sprite_terminator
+sSuicuneGfx70:
+.incbin "baserom.gba", 0xFFA0FC, 0x20
+sSuicuneSprites70:
+ax_sprite sSuicuneGfx70, 0x20
+ax_sprite_terminator
+sSuicuneGfx71:
+.incbin "baserom.gba", 0xFFA12C, 0x20
+sSuicuneSprites71:
+ax_sprite sSuicuneGfx71, 0x20
+ax_sprite_terminator
+sSuicuneGfx72:
+.incbin "baserom.gba", 0xFFA15C, 0x20
+sSuicuneSprites72:
+ax_sprite sSuicuneGfx72, 0x20
+ax_sprite_terminator
+sSuicuneGfx73:
+.incbin "baserom.gba", 0xFFA18C, 0x20
+sSuicuneSprites73:
+ax_sprite sSuicuneGfx73, 0x20
+ax_sprite_terminator
+sSuicuneGfx74:
+.incbin "baserom.gba", 0xFFA1BC, 0x20
+sSuicuneSprites74:
+ax_sprite sSuicuneGfx74, 0x20
+ax_sprite_terminator
+sSuicuneGfx75:
+.incbin "baserom.gba", 0xFFA1EC, 0x60
+sSuicuneGfx75_1:
+.incbin "baserom.gba", 0xFFA24C, 0x80
+sSuicuneSprites75:
+ax_sprite sSuicuneGfx75, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx75_1, 0x80
+ax_sprite_terminator
+sSuicuneGfx76:
+.incbin "baserom.gba", 0xFFA2EC, 0x80
+sSuicuneSprites76:
+ax_sprite sSuicuneGfx76, 0x80
+ax_sprite_terminator
+sSuicuneGfx77:
+.incbin "baserom.gba", 0xFFA37C, 0x40
+sSuicuneSprites77:
+ax_sprite sSuicuneGfx77, 0x40
+ax_sprite_terminator
+sSuicuneGfx78:
+.incbin "baserom.gba", 0xFFA3CC, 0x20
+sSuicuneSprites78:
+ax_sprite sSuicuneGfx78, 0x20
+ax_sprite_terminator
+sSuicuneGfx79:
+.incbin "baserom.gba", 0xFFA3FC, 0x20
+sSuicuneSprites79:
+ax_sprite sSuicuneGfx79, 0x20
+ax_sprite_terminator
+sSuicuneGfx80:
+.incbin "baserom.gba", 0xFFA42C, 0x1C0
+sSuicuneSprites80:
+ax_sprite 0, 0x40
+ax_sprite sSuicuneGfx80, 0x1c0
+ax_sprite_terminator
+sSuicuneGfx81:
+.incbin "baserom.gba", 0xFFA604, 0x40
+sSuicuneGfx81_1:
+.incbin "baserom.gba", 0xFFA644, 0x180
+sSuicuneSprites81:
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx81, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx81_1, 0x180
+ax_sprite_terminator
+sSuicuneGfx82:
+.incbin "baserom.gba", 0xFFA7EC, 0x200
+sSuicuneSprites82:
+ax_sprite sSuicuneGfx82, 0x200
+ax_sprite_terminator
+sSuicuneGfx83:
+.incbin "baserom.gba", 0xFFA9FC, 0x200
+sSuicuneSprites83:
+ax_sprite sSuicuneGfx83, 0x200
+ax_sprite_terminator
+sSuicuneGfx84:
+.incbin "baserom.gba", 0xFFAC0C, 0x40
+sSuicuneGfx84_1:
+.incbin "baserom.gba", 0xFFAC4C, 0x160
+sSuicuneSprites84:
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx84, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx84_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSuicuneGfx85:
+.incbin "baserom.gba", 0xFFADDC, 0x100
+sSuicuneSprites85:
+ax_sprite sSuicuneGfx85, 0x100
+ax_sprite_terminator
+sSuicuneGfx86:
+.incbin "baserom.gba", 0xFFAEEC, 0x80
+sSuicuneSprites86:
+ax_sprite sSuicuneGfx86, 0x80
+ax_sprite_terminator
+sSuicuneGfx87:
+.incbin "baserom.gba", 0xFFAF7C, 0x40
+sSuicuneSprites87:
+ax_sprite sSuicuneGfx87, 0x40
+ax_sprite_terminator
+sSuicuneGfx88:
+.incbin "baserom.gba", 0xFFAFCC, 0x20
+sSuicuneSprites88:
+ax_sprite sSuicuneGfx88, 0x20
+ax_sprite_terminator
+sSuicuneGfx89:
+.incbin "baserom.gba", 0xFFAFFC, 0x200
+sSuicuneSprites89:
+ax_sprite sSuicuneGfx89, 0x200
+ax_sprite_terminator
+sSuicuneGfx90:
+.incbin "baserom.gba", 0xFFB20C, 0x1E0
+sSuicuneSprites90:
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx90, 0x1e0
+ax_sprite_terminator
+sSuicuneGfx91:
+.incbin "baserom.gba", 0xFFB404, 0x100
+sSuicuneSprites91:
+ax_sprite sSuicuneGfx91, 0x100
+ax_sprite_terminator
+sSuicuneGfx92:
+.incbin "baserom.gba", 0xFFB514, 0x40
+sSuicuneSprites92:
+ax_sprite sSuicuneGfx92, 0x40
+ax_sprite_terminator
+sSuicuneGfx93:
+.incbin "baserom.gba", 0xFFB564, 0x20
+sSuicuneSprites93:
+ax_sprite sSuicuneGfx93, 0x20
+ax_sprite_terminator
+sSuicuneGfx94:
+.incbin "baserom.gba", 0xFFB594, 0x40
+sSuicuneSprites94:
+ax_sprite sSuicuneGfx94, 0x40
+ax_sprite_terminator
+sSuicuneGfx95:
+.incbin "baserom.gba", 0xFFB5E4, 0x20
+sSuicuneSprites95:
+ax_sprite sSuicuneGfx95, 0x20
+ax_sprite_terminator
+sSuicuneGfx96:
+.incbin "baserom.gba", 0xFFB614, 0x20
+sSuicuneSprites96:
+ax_sprite sSuicuneGfx96, 0x20
+ax_sprite_terminator
+sSuicuneGfx97:
+.incbin "baserom.gba", 0xFFB644, 0x20
+sSuicuneSprites97:
+ax_sprite sSuicuneGfx97, 0x20
+ax_sprite_terminator
+sSuicuneGfx98:
+.incbin "baserom.gba", 0xFFB674, 0x1E0
+sSuicuneSprites98:
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx98, 0x1e0
+ax_sprite_terminator
+sSuicuneGfx99:
+.incbin "baserom.gba", 0xFFB86C, 0x200
+sSuicuneSprites99:
+ax_sprite sSuicuneGfx99, 0x200
+ax_sprite_terminator
+sSuicuneGfx100:
+.incbin "baserom.gba", 0xFFBA7C, 0x40
+sSuicuneGfx100_1:
+.incbin "baserom.gba", 0xFFBABC, 0x180
+sSuicuneSprites100:
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx100, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSuicuneGfx100_1, 0x180
+ax_sprite_terminator
+sSuicuneGfx101:
+.incbin "baserom.gba", 0xFFBC64, 0x100
+sSuicuneSprites101:
+ax_sprite sSuicuneGfx101, 0x100
+ax_sprite_terminator
+sSuicuneGfx102:
+.incbin "baserom.gba", 0xFFBD74, 0x80
+sSuicuneSprites102:
+ax_sprite sSuicuneGfx102, 0x80
+ax_sprite_terminator
+sSuicuneGfx103:
+.incbin "baserom.gba", 0xFFBE04, 0x40
+sSuicuneSprites103:
+ax_sprite sSuicuneGfx103, 0x40
+ax_sprite_terminator
+sSuicuneGfx104:
+.incbin "baserom.gba", 0xFFBE54, 0x20
+sSuicuneSprites104:
+ax_sprite sSuicuneGfx104, 0x20
+ax_sprite_terminator
+sSuicuneGfx105:
+.incbin "baserom.gba", 0xFFBE84, 0x100
+sSuicuneSprites105:
+ax_sprite sSuicuneGfx105, 0x100
+ax_sprite_terminator
+sSuicuneGfx106:
+.incbin "baserom.gba", 0xFFBF94, 0x80
+sSuicuneSprites106:
+ax_sprite sSuicuneGfx106, 0x80
+ax_sprite_terminator
+sSuicuneGfx107:
+.incbin "baserom.gba", 0xFFC024, 0x40
+sSuicuneSprites107:
+ax_sprite sSuicuneGfx107, 0x40
+ax_sprite_terminator
+sSuicuneGfx108:
+.incbin "baserom.gba", 0xFFC074, 0x20
+sSuicuneSprites108:
+ax_sprite sSuicuneGfx108, 0x20
+ax_sprite_terminator
+sSuicuneGfx109:
+.incbin "baserom.gba", 0xFFC0A4, 0x20
+sSuicuneSprites109:
+ax_sprite sSuicuneGfx109, 0x20
+ax_sprite_terminator
+sSuicuneGfx110:
+.incbin "baserom.gba", 0xFFC0D4, 0x80
+sSuicuneSprites110:
+ax_sprite sSuicuneGfx110, 0x80
+ax_sprite_terminator
+sSuicuneGfx111:
+.incbin "baserom.gba", 0xFFC164, 0x100
+sSuicuneSprites111:
+ax_sprite sSuicuneGfx111, 0x100
+ax_sprite_terminator
+sSuicuneGfx112:
+.incbin "baserom.gba", 0xFFC274, 0x40
+sSuicuneSprites112:
+ax_sprite sSuicuneGfx112, 0x40
+ax_sprite_terminator
+sSuicuneGfx113:
+.incbin "baserom.gba", 0xFFC2C4, 0x20
+sSuicuneSprites113:
+ax_sprite sSuicuneGfx113, 0x20
+ax_sprite_terminator
+sSuicuneGfx114:
+.incbin "baserom.gba", 0xFFC2F4, 0x20
+sSuicuneSprites114:
+ax_sprite sSuicuneGfx114, 0x20
+ax_sprite_terminator
+sSuicuneGfx115:
+.incbin "baserom.gba", 0xFFC324, 0x100
+sSuicuneSprites115:
+ax_sprite sSuicuneGfx115, 0x100
+ax_sprite_terminator
+sSuicuneGfx116:
+.incbin "baserom.gba", 0xFFC434, 0x80
+sSuicuneSprites116:
+ax_sprite sSuicuneGfx116, 0x80
+ax_sprite_terminator
+sSuicuneGfx117:
+.incbin "baserom.gba", 0xFFC4C4, 0x40
+sSuicuneSprites117:
+ax_sprite sSuicuneGfx117, 0x40
+ax_sprite_terminator
+sSuicuneGfx118:
+.incbin "baserom.gba", 0xFFC514, 0x20
+sSuicuneSprites118:
+ax_sprite sSuicuneGfx118, 0x20
+ax_sprite_terminator
+sSuicuneGfx119:
+.incbin "baserom.gba", 0xFFC544, 0x20
+sSuicuneSprites119:
+ax_sprite sSuicuneGfx119, 0x20
+ax_sprite_terminator
+sSuicuneGfx120:
+.incbin "baserom.gba", 0xFFC574, 0x100
+sSuicuneSprites120:
+ax_sprite sSuicuneGfx120, 0x100
+ax_sprite_terminator
+sSuicuneGfx121:
+.incbin "baserom.gba", 0xFFC684, 0x80
+sSuicuneSprites121:
+ax_sprite sSuicuneGfx121, 0x80
+ax_sprite_terminator
+sSuicuneGfx122:
+.incbin "baserom.gba", 0xFFC714, 0x40
+sSuicuneSprites122:
+ax_sprite sSuicuneGfx122, 0x40
+ax_sprite_terminator
+sSuicuneGfx123:
+.incbin "baserom.gba", 0xFFC764, 0x20
+sSuicuneSprites123:
+ax_sprite sSuicuneGfx123, 0x20
+ax_sprite_terminator
+sSuicuneGfx124:
+.incbin "baserom.gba", 0xFFC794, 0x20
+sSuicuneSprites124:
+ax_sprite sSuicuneGfx124, 0x20
+ax_sprite_terminator
+sSuicuneGfx125:
+.incbin "baserom.gba", 0xFFC7C4, 0x200
+sSuicuneSprites125:
+ax_sprite sSuicuneGfx125, 0x200
+ax_sprite_terminator
+sSuicuneGfx126:
+.incbin "baserom.gba", 0xFFC9D4, 0x20
+sSuicuneSprites126:
+ax_sprite sSuicuneGfx126, 0x20
+ax_sprite_terminator
+sSuicuneGfx127:
+.incbin "baserom.gba", 0xFFCA04, 0x200
+sSuicuneSprites127:
+ax_sprite sSuicuneGfx127, 0x200
+ax_sprite_terminator
+sSuicuneGfx128:
+.incbin "baserom.gba", 0xFFCC14, 0x200
+sSuicuneSprites128:
+ax_sprite sSuicuneGfx128, 0x200
+ax_sprite_terminator
+sSuicuneGfx129:
+.incbin "baserom.gba", 0xFFCE24, 0x200
+sSuicuneSprites129:
+ax_sprite sSuicuneGfx129, 0x200
+ax_sprite_terminator
+sSuicuneGfx130:
+.incbin "baserom.gba", 0xFFD034, 0x200
+sSuicuneSprites130:
+ax_sprite sSuicuneGfx130, 0x200
+ax_sprite_terminator
+sSuicuneGfx131:
+.incbin "baserom.gba", 0xFFD244, 0x200
+sSuicuneSprites131:
+ax_sprite sSuicuneGfx131, 0x200
+ax_sprite_terminator
+sSuicuneGfx132:
+.incbin "baserom.gba", 0xFFD454, 0x200
+sSuicuneSprites132:
+ax_sprite sSuicuneGfx132, 0x200
+ax_sprite_terminator
+sSuicuneGfx133:
+.incbin "baserom.gba", 0xFFD664, 0x200
+sSuicuneSprites133:
+ax_sprite sSuicuneGfx133, 0x200
+ax_sprite_terminator
+sAxPosesSuicune:
+.4byte sSuicunePose1
+.4byte sSuicunePose2
+.4byte sSuicunePose3
+.4byte sSuicunePose4
+.4byte sSuicunePose5
+.4byte sSuicunePose6
+.4byte sSuicunePose7
+.4byte sSuicunePose8
+.4byte sSuicunePose9
+.4byte sSuicunePose10
+.4byte sSuicunePose11
+.4byte sSuicunePose12
+.4byte sSuicunePose13
+.4byte sSuicunePose14
+.4byte sSuicunePose15
+.4byte sSuicunePose16
+.4byte sSuicunePose17
+.4byte sSuicunePose18
+.4byte sSuicunePose19
+.4byte sSuicunePose20
+.4byte sSuicunePose21
+.4byte sSuicunePose22
+.4byte sSuicunePose23
+.4byte sSuicunePose24
+.4byte sSuicunePose25
+.4byte sSuicunePose26
+.4byte sSuicunePose27
+.4byte sSuicunePose28
+.4byte sSuicunePose29
+.4byte sSuicunePose30
+.4byte sSuicunePose31
+.4byte sSuicunePose32
+.4byte sSuicunePose33
+.4byte sSuicunePose34
+.4byte sSuicunePose35
+.4byte sSuicunePose36
+.4byte sSuicunePose37
+.4byte sSuicunePose38
+.4byte sSuicunePose39
+.4byte sSuicunePose40
+.4byte sSuicunePose41
+.4byte sSuicunePose42
+.4byte sSuicunePose43
+.4byte sSuicunePose44
+.4byte sSuicunePose45
+.4byte sSuicunePose46
+.4byte sSuicunePose47
+.4byte sSuicunePose48
+.4byte sSuicunePose49
+.4byte sSuicunePose50
+.4byte sSuicunePose51
+.4byte sSuicunePose52
+.4byte sSuicunePose53
+.4byte sSuicunePose54
+.4byte sSuicunePose55
+.4byte sSuicunePose56
+.4byte sSuicunePose57
+.4byte sSuicunePose58
+.4byte sSuicunePose59
+.4byte sSuicunePose60
+.4byte sSuicunePose61
+.4byte sSuicunePose62
+.4byte sSuicunePose63
+.4byte sSuicunePose64
+.4byte sSuicunePose65
+.4byte sSuicunePose66
+.4byte sSuicunePose67
+.4byte sSuicunePose68
+.4byte sSuicunePose69
+.4byte sSuicunePose70
+.4byte sSuicunePose71
+.4byte sSuicunePose72
+.4byte sSuicunePose73
+.4byte sSuicunePose74
+.4byte sSuicunePose75
+.4byte sSuicunePose76
+.4byte sSuicunePose77
+.4byte sSuicunePose78
+.4byte sSuicunePose79
+.4byte sSuicunePose80
+.4byte sSuicunePose81
+.4byte sSuicunePose82
+.4byte sSuicunePose83
+.4byte sSuicunePose84
+.4byte sSuicunePose85
+.4byte sSuicunePose86
+.4byte sSuicunePose87
+.4byte sSuicunePose88
+.4byte sSuicunePose89
+.4byte sSuicunePose90
+.4byte sSuicunePose91
+.4byte sSuicunePose92
+.4byte sSuicunePose93
+.4byte sSuicunePose94
+.4byte sSuicunePose95
+.4byte sSuicunePose96
+.4byte sSuicunePose97
+.4byte sSuicunePose98
+.4byte sSuicunePose99
+.4byte sSuicunePose100
+.4byte sSuicunePose101
+.4byte sSuicunePose102
+.4byte sSuicunePose103
+.4byte sSuicunePose104
+.4byte sSuicunePose105
+.4byte sSuicunePose106
+.4byte sSuicunePose107
+.4byte sSuicunePose108
+.4byte sSuicunePose109
+.4byte sSuicunePose110
+.4byte sSuicunePose111
+.4byte sSuicunePose112
+.4byte sSuicunePose113
+.4byte sSuicunePose114
+.4byte sSuicunePose115
+.4byte sSuicunePose116
+.4byte sSuicunePose117
+.4byte sSuicunePose118
+.4byte sSuicunePose119
+.4byte sSuicunePose120
+.4byte sSuicunePose121
+.4byte sSuicunePose122
+.4byte sSuicunePose123
+.4byte sSuicunePose124
+.4byte sSuicunePose125
+.4byte sSuicunePose126
+.4byte sSuicunePose127
+.4byte sSuicunePose128
+.4byte sSuicunePose129
+.4byte sSuicunePose130
+.4byte sSuicunePose131
+.4byte sSuicunePose132
+.4byte sSuicunePose133
+.4byte sSuicunePose134
+.4byte sSuicunePose135
+.4byte sSuicunePose136
+.4byte sSuicunePose137
+.4byte sSuicunePose138
+.4byte sSuicunePose139
+.4byte sSuicunePose140
+.4byte sSuicunePose141
+.4byte sSuicunePose142
+.4byte sSuicunePose143
+.4byte sSuicunePose144
+.4byte sSuicunePose145
+.4byte sSuicunePose146
+.4byte sSuicunePose147
+.4byte sSuicunePose148
+.4byte sSuicunePose149
+.4byte sSuicunePose150
+.4byte sSuicunePose151
+.4byte sSuicunePose152
+.4byte sSuicunePose153
+.4byte sSuicunePose154
+.4byte sSuicunePose155
+.4byte sSuicunePose156
+.4byte sSuicunePose157
+.4byte sSuicunePose158
+.4byte sSuicunePose159
+.4byte sSuicunePose160
+.4byte sSuicunePose161
+.4byte sSuicunePose162
+.4byte sSuicunePose163
+.4byte sSuicunePose164
+.4byte sSuicunePose165
+.4byte sSuicunePose166
+.4byte sSuicunePose167
+.4byte sSuicunePose168
+.4byte sSuicunePose169
+.4byte sSuicunePose170
+.4byte sSuicunePose171
+.4byte sSuicunePose172
+.4byte sSuicunePose173
+.4byte sSuicunePose174
+.4byte sSuicunePose175
+.4byte sSuicunePose176
+.4byte sSuicunePose177
+.4byte sSuicunePose178
+.4byte sSuicunePose179
+.4byte sSuicunePose180
+.4byte sSuicunePose181
+.4byte sSuicunePose182
+.4byte sSuicunePose183
+.4byte sSuicunePose184
+.4byte sSuicunePose185
+.4byte sSuicunePose186
+.4byte sSuicunePose187
+.4byte sSuicunePose188
+.4byte sSuicunePose189
+.4byte sSuicunePose190
+.4byte sSuicunePose191
+.4byte sSuicunePose192
+.4byte sSuicunePose193
+.4byte sSuicunePose194
+.4byte sSuicunePose195
+.4byte sSuicunePose196
+.4byte sSuicunePose197
+.4byte sSuicunePose198
+sAxPositionsSuicune:
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,   -4, 	  -4,    6, 	   3,   -1, 	  -1,  -11
+.2byte   -1,   -4, 	  -5,   -1, 	   2,    6, 	  -1,  -11
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte   10,   -6, 	   9,    3, 	  -5,    0, 	  -1,  -14
+.2byte   10,   -6, 	   3,   -3, 	   3,    5, 	  -3,  -16
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte   13,  -11, 	  11,   -2, 	  -2,    1, 	  -1,  -10
+.2byte   13,  -11, 	  -2,   -3, 	  10,    2, 	  -1,  -13
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte    7,  -16, 	   3,  -10, 	   3,    1, 	  -1,  -13
+.2byte    7,  -17, 	  -4,   -4, 	  10,   -2, 	  -1,  -14
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte   -1,  -15, 	   4,   -3, 	  -7,   -5, 	  -1,  -13
+.2byte   -1,  -14, 	   5,   -7, 	  -6,   -4, 	  -1,  -12
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte   -9,  -16, 	  -5,  -10, 	  -5,    1, 	  -1,  -13
+.2byte   -9,  -17, 	   2,   -4, 	 -12,   -2, 	  -1,  -14
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte  -15,  -11, 	 -13,   -2, 	   0,    1, 	  -1,  -10
+.2byte  -15,  -11, 	   0,   -3, 	 -12,    2, 	  -1,  -13
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte  -12,   -6, 	 -11,    3, 	   3,    0, 	  -1,  -14
+.2byte  -12,   -6, 	  -5,   -3, 	  -5,    5, 	   1,  -16
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,   -5, 	  -8,   -2, 	   6,   -2, 	  -1,  -15
+.2byte   -1,    2, 	  -7,    3, 	   5,    4, 	  -1,   -9
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte   11,   -4, 	  15,   -5, 	   5,    0, 	  -2,  -13
+.2byte    8,    1, 	  12,   -1, 	   1,    3, 	  -3,  -11
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte   14,   -8, 	  16,   -7, 	  12,   -4, 	   1,  -12
+.2byte   12,   -2, 	   7,   -3, 	   7,    2, 	  -2,   -7
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte    9,  -14, 	   3,  -15, 	  12,  -10, 	  -2,  -11
+.2byte    9,   -9, 	   0,   -8, 	   9,   -2, 	  -2,   -9
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte   -1,  -17, 	   6,   -7, 	  -7,   -7, 	  -1,  -15
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -2, 	  -1,   -9
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte  -10,  -14, 	  -4,  -15, 	 -13,  -10, 	   1,  -11
+.2byte  -11,   -9, 	  -2,   -8, 	 -11,   -2, 	   0,   -9
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte  -16,   -8, 	 -18,   -7, 	 -14,   -4, 	  -3,  -12
+.2byte  -14,   -2, 	  -9,   -3, 	  -9,    2, 	   0,   -7
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte  -13,   -4, 	 -17,   -5, 	  -7,    0, 	   0,  -13
+.2byte  -10,    1, 	 -14,   -1, 	  -3,    3, 	   1,  -11
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,   -5, 	  -8,   -2, 	   6,   -2, 	  -1,  -15
+.2byte   -1,    2, 	  -7,    3, 	   5,    4, 	  -1,   -9
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte   11,   -4, 	  15,   -5, 	   5,    0, 	  -2,  -13
+.2byte    8,    1, 	  12,   -1, 	   1,    3, 	  -3,  -11
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte   14,   -8, 	  16,   -7, 	  12,   -4, 	   1,  -12
+.2byte   12,   -2, 	   7,   -3, 	   7,    2, 	  -2,   -7
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte    9,  -14, 	   3,  -15, 	  12,  -10, 	  -2,  -11
+.2byte    9,   -9, 	   0,   -8, 	   9,   -2, 	  -2,   -9
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte   -1,  -17, 	   6,   -7, 	  -7,   -7, 	  -1,  -15
+.2byte   -1,   -5, 	   5,   -4, 	  -7,   -2, 	  -1,   -9
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte  -10,  -14, 	  -4,  -15, 	 -13,  -10, 	   1,  -11
+.2byte  -11,   -9, 	  -2,   -8, 	 -11,   -2, 	   0,   -9
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte  -16,   -8, 	 -18,   -7, 	 -14,   -4, 	  -3,  -12
+.2byte  -14,   -2, 	  -9,   -3, 	  -9,    2, 	   0,   -7
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte  -13,   -4, 	 -17,   -5, 	  -7,    0, 	   0,  -13
+.2byte  -10,    1, 	 -14,   -1, 	  -3,    3, 	   1,  -11
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,    2, 	  -7,    3, 	   5,    3, 	  -1,   -9
+.2byte   -1,    1, 	  -7,    4, 	   5,    3, 	  -1,  -10
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte    6,    0, 	   9,   -1, 	   0,    3, 	  -4,  -12
+.2byte   12,   -2, 	   9,   -1, 	   0,    3, 	   1,  -10
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte    8,   -1, 	   5,   -3, 	   5,    2, 	  -3,   -9
+.2byte   17,   -7, 	   9,   -2, 	   5,    2, 	   2,  -11
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte    5,   -5, 	   1,   -6, 	   9,   -1, 	  -1,  -10
+.2byte   11,  -17, 	   0,   -7, 	   9,   -1, 	   1,  -14
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte   -1,   -5, 	   5,   -2, 	  -7,   -2, 	  -1,  -11
+.2byte   -1,  -20, 	   5,   -3, 	  -7,   -3, 	  -1,  -12
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte   -7,   -5, 	  -3,   -6, 	 -11,   -1, 	  -1,  -10
+.2byte  -13,  -17, 	  -2,   -7, 	 -11,   -1, 	  -3,  -14
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte  -10,   -1, 	  -7,   -3, 	  -7,    2, 	   1,   -9
+.2byte  -19,   -7, 	 -11,   -2, 	  -7,    2, 	  -4,  -11
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte   -8,    0, 	 -11,   -1, 	  -2,    3, 	   2,  -12
+.2byte  -14,   -2, 	 -11,   -1, 	  -2,    3, 	  -3,  -10
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,  -26, 	  -7,    3, 	   5,    3, 	  -1,  -12
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte    2,  -25, 	   9,   -1, 	   0,    3, 	  -1,  -13
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte    3,  -24, 	   5,   -3, 	   5,    2, 	  -5,  -11
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte    4,  -25, 	   0,   -6, 	   9,   -1, 	  -3,  -10
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte   -1,  -27, 	   5,   -4, 	  -7,   -4, 	  -1,   -9
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte   -6,  -25, 	  -2,   -6, 	 -11,   -1, 	   1,  -10
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte   -5,  -24, 	  -7,   -3, 	  -7,    2, 	   3,  -11
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte   -4,  -25, 	 -11,   -1, 	  -2,    3, 	  -1,  -13
+.2byte  -11,   -1, 	 -15,    0, 	 -11,    1, 	   2,   -8
+.2byte  -11,   -1, 	 -15,    0, 	 -11,    1, 	   2,   -8
+.2byte    0,    3, 	  -5,    3, 	   5,    3, 	   0,  -10
+.2byte    8,    2, 	  10,    2, 	   0,    4, 	  -1,  -11
+.2byte   13,   -1, 	  12,   -3, 	  11,    0, 	   0,  -13
+.2byte    7,   -8, 	   2,   -9, 	  12,   -4, 	   0,   -8
+.2byte    0,   -6, 	   6,   -2, 	  -6,   -2, 	   0,  -11
+.2byte   -8,   -8, 	  -3,   -9, 	 -13,   -4, 	  -1,   -8
+.2byte  -14,   -1, 	 -13,   -3, 	 -12,    0, 	  -1,  -13
+.2byte   -9,    2, 	 -11,    2, 	  -1,    4, 	   0,  -11
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,    2, 	  -7,    3, 	   5,    3, 	  -1,   -9
+.2byte   -1,    1, 	  -7,    4, 	   5,    3, 	  -1,  -10
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte    6,    0, 	   9,   -1, 	   0,    3, 	  -4,  -12
+.2byte   12,   -2, 	   9,   -1, 	   0,    3, 	   1,  -10
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte    8,   -1, 	   5,   -3, 	   5,    2, 	  -3,   -9
+.2byte   17,   -7, 	   9,   -2, 	   5,    2, 	   2,  -11
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte    5,   -5, 	   1,   -6, 	   9,   -1, 	  -1,  -10
+.2byte   11,  -17, 	   0,   -7, 	   9,   -1, 	   1,  -14
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte   -1,   -5, 	   5,   -2, 	  -7,   -2, 	  -1,  -11
+.2byte   -1,  -20, 	   5,   -3, 	  -7,   -3, 	  -1,  -12
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte   -7,   -5, 	  -3,   -6, 	 -11,   -1, 	  -1,  -10
+.2byte  -13,  -17, 	  -2,   -7, 	 -11,   -1, 	  -3,  -14
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte  -10,   -1, 	  -7,   -3, 	  -7,    2, 	   1,   -9
+.2byte  -19,   -7, 	 -11,   -2, 	  -7,    2, 	  -4,  -11
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte   -8,    0, 	 -11,   -1, 	  -2,    3, 	   2,  -12
+.2byte  -14,   -2, 	 -11,   -1, 	  -2,    3, 	  -3,  -10
+.2byte   -1,    1, 	  -7,    4, 	   5,    3, 	  -1,  -10
+.2byte  -12,   -2, 	  -9,   -1, 	   0,    3, 	  -1,  -10
+.2byte  -16,   -7, 	  -8,   -2, 	  -4,    2, 	  -1,  -11
+.2byte  -12,  -17, 	  -1,   -7, 	 -10,   -1, 	  -2,  -14
+.2byte   -1,  -20, 	   5,   -3, 	  -7,   -3, 	  -1,  -12
+.2byte   13,  -17, 	   2,   -7, 	  11,   -1, 	   3,  -14
+.2byte   14,   -7, 	   6,   -2, 	   2,    2, 	  -1,  -11
+.2byte   10,   -2, 	   7,   -1, 	  -2,    3, 	  -1,  -10
+.2byte   -1,    1, 	  -7,    4, 	   5,    3, 	  -1,  -10
+.2byte   10,   -2, 	   7,   -1, 	  -2,    3, 	  -1,  -10
+.2byte   14,   -7, 	   6,   -2, 	   2,    2, 	  -1,  -11
+.2byte   13,  -17, 	   2,   -7, 	  11,   -1, 	   3,  -14
+.2byte   -1,  -20, 	   5,   -3, 	  -7,   -3, 	  -1,  -12
+.2byte  -12,  -17, 	  -1,   -7, 	 -10,   -1, 	  -2,  -14
+.2byte  -16,   -7, 	  -8,   -2, 	  -4,    2, 	  -1,  -11
+.2byte  -12,   -2, 	  -9,   -1, 	   0,    3, 	  -1,  -10
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,    1, 	  -7,    4, 	   5,    3, 	  -1,  -10
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte   10,   -2, 	   7,   -1, 	  -2,    3, 	  -1,  -10
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte   14,   -7, 	   6,   -2, 	   2,    2, 	  -1,  -11
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte   10,  -17, 	  -1,   -7, 	   8,   -1, 	   0,  -14
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte   -1,  -20, 	   5,   -3, 	  -7,   -3, 	  -1,  -12
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte  -12,  -17, 	  -1,   -7, 	 -10,   -1, 	  -2,  -14
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte  -16,   -7, 	  -8,   -2, 	  -4,    2, 	  -1,  -11
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte  -12,   -2, 	  -9,   -1, 	   0,    3, 	  -1,  -10
+.2byte   -1,    2, 	  -7,    3, 	   5,    3, 	  -1,   -9
+.2byte   -8,    0, 	 -11,   -1, 	  -2,    3, 	   2,  -12
+.2byte  -11,   -2, 	  -8,   -4, 	  -8,    1, 	   0,  -10
+.2byte   -8,   -5, 	  -4,   -6, 	 -12,   -1, 	  -2,  -10
+.2byte   -1,   -6, 	   5,   -3, 	  -7,   -3, 	  -1,  -12
+.2byte    7,   -5, 	   3,   -6, 	  11,   -1, 	   1,  -10
+.2byte   10,   -2, 	   7,   -4, 	   7,    1, 	  -1,  -10
+.2byte    7,    0, 	  10,   -1, 	   1,    3, 	  -3,  -12
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte  -12,   -8, 	 -10,   -1, 	  -2,    3, 	   0,  -14
+.2byte  -15,  -13, 	  -7,   -3, 	  -7,    2, 	   0,  -12
+.2byte   -9,  -17, 	   0,   -6, 	 -11,   -1, 	   0,  -13
+.2byte   -1,  -16, 	   5,   -6, 	  -7,   -6, 	  -1,  -14
+.2byte    7,  -17, 	  -2,   -6, 	   9,   -1, 	  -2,  -13
+.2byte   13,  -13, 	   5,   -3, 	   5,    2, 	  -2,  -12
+.2byte   10,   -8, 	   8,   -1, 	   0,    3, 	  -2,  -14
+.2byte   -1,   -6, 	  -7,    3, 	   5,    3, 	  -1,  -13
+.2byte   -1,    2, 	  -7,    3, 	   5,    3, 	  -1,   -9
+.2byte   -1,    1, 	  -7,    4, 	   5,    3, 	  -1,  -10
+.2byte   -1,  -26, 	  -7,    3, 	   5,    3, 	  -1,  -12
+sSuicuneAnimTable1:
+.4byte sSuicuneAnims_1_1
+.4byte sSuicuneAnims_1_2
+.4byte sSuicuneAnims_1_3
+.4byte sSuicuneAnims_1_4
+.4byte sSuicuneAnims_1_5
+.4byte sSuicuneAnims_1_6
+.4byte sSuicuneAnims_1_7
+.4byte sSuicuneAnims_1_8
+sSuicuneAnimTable2:
+.4byte sSuicuneAnims_2_1
+.4byte sSuicuneAnims_2_2
+.4byte sSuicuneAnims_2_3
+.4byte sSuicuneAnims_2_4
+.4byte sSuicuneAnims_2_5
+.4byte sSuicuneAnims_2_6
+.4byte sSuicuneAnims_2_7
+.4byte sSuicuneAnims_2_8
+sSuicuneAnimTable3:
+.4byte sSuicuneAnims_3_1
+.4byte sSuicuneAnims_3_2
+.4byte sSuicuneAnims_3_3
+.4byte sSuicuneAnims_3_4
+.4byte sSuicuneAnims_3_5
+.4byte sSuicuneAnims_3_6
+.4byte sSuicuneAnims_3_7
+.4byte sSuicuneAnims_3_8
+sSuicuneAnimTable4:
+.4byte sSuicuneAnims_4_1
+.4byte sSuicuneAnims_4_2
+.4byte sSuicuneAnims_4_3
+.4byte sSuicuneAnims_4_4
+.4byte sSuicuneAnims_4_5
+.4byte sSuicuneAnims_4_6
+.4byte sSuicuneAnims_4_7
+.4byte sSuicuneAnims_4_8
+sSuicuneAnimTable5:
+.4byte sSuicuneAnims_5_1
+.4byte sSuicuneAnims_5_2
+.4byte sSuicuneAnims_5_3
+.4byte sSuicuneAnims_5_4
+.4byte sSuicuneAnims_5_5
+.4byte sSuicuneAnims_5_6
+.4byte sSuicuneAnims_5_7
+.4byte sSuicuneAnims_5_8
+sSuicuneAnimTable6:
+.4byte sSuicuneAnims_6_1
+.4byte sSuicuneAnims_6_1
+.4byte sSuicuneAnims_6_1
+.4byte sSuicuneAnims_6_1
+.4byte sSuicuneAnims_6_1
+.4byte sSuicuneAnims_6_1
+.4byte sSuicuneAnims_6_1
+.4byte sSuicuneAnims_6_1
+sSuicuneAnimTable7:
+.4byte sSuicuneAnims_7_1
+.4byte sSuicuneAnims_7_2
+.4byte sSuicuneAnims_7_3
+.4byte sSuicuneAnims_7_4
+.4byte sSuicuneAnims_7_5
+.4byte sSuicuneAnims_7_6
+.4byte sSuicuneAnims_7_7
+.4byte sSuicuneAnims_7_8
+sSuicuneAnimTable8:
+.4byte sSuicuneAnims_8_1
+.4byte sSuicuneAnims_8_2
+.4byte sSuicuneAnims_8_3
+.4byte sSuicuneAnims_8_4
+.4byte sSuicuneAnims_8_5
+.4byte sSuicuneAnims_8_6
+.4byte sSuicuneAnims_8_7
+.4byte sSuicuneAnims_8_8
+sSuicuneAnimTable9:
+.4byte sSuicuneAnims_9_1
+.4byte sSuicuneAnims_9_2
+.4byte sSuicuneAnims_9_3
+.4byte sSuicuneAnims_9_4
+.4byte sSuicuneAnims_9_5
+.4byte sSuicuneAnims_9_6
+.4byte sSuicuneAnims_9_7
+.4byte sSuicuneAnims_9_8
+sSuicuneAnimTable10:
+.4byte sSuicuneAnims_10_1
+.4byte sSuicuneAnims_10_2
+.4byte sSuicuneAnims_10_3
+.4byte sSuicuneAnims_10_4
+.4byte sSuicuneAnims_10_5
+.4byte sSuicuneAnims_10_6
+.4byte sSuicuneAnims_10_7
+.4byte sSuicuneAnims_10_8
+sSuicuneAnimTable11:
+.4byte sSuicuneAnims_11_1
+.4byte sSuicuneAnims_11_2
+.4byte sSuicuneAnims_11_3
+.4byte sSuicuneAnims_11_4
+.4byte sSuicuneAnims_11_5
+.4byte sSuicuneAnims_11_6
+.4byte sSuicuneAnims_11_7
+.4byte sSuicuneAnims_11_8
+sSuicuneAnimTable12:
+.4byte sSuicuneAnims_12_1
+.4byte sSuicuneAnims_12_2
+.4byte sSuicuneAnims_12_3
+.4byte sSuicuneAnims_12_4
+.4byte sSuicuneAnims_12_5
+.4byte sSuicuneAnims_12_6
+.4byte sSuicuneAnims_12_7
+.4byte sSuicuneAnims_12_8
+sSuicuneAnimTable13:
+.4byte sSuicuneAnims_13_1
+.4byte sSuicuneAnims_13_2
+.4byte sSuicuneAnims_13_3
+.4byte sSuicuneAnims_13_4
+.4byte sSuicuneAnims_13_5
+.4byte sSuicuneAnims_13_6
+.4byte sSuicuneAnims_13_7
+.4byte sSuicuneAnims_13_8
+sSuicuneAnimTable14:
+.4byte sSuicuneAnims_14_1
+.4byte sSuicuneAnims_14_2
+.4byte sSuicuneAnims_14_3
+.4byte sSuicuneAnims_14_4
+.4byte sSuicuneAnims_14_5
+.4byte sSuicuneAnims_14_6
+.4byte sSuicuneAnims_14_7
+.4byte sSuicuneAnims_14_8
+sAxAnimationsSuicune:
+.4byte sSuicuneAnimTable1
+.4byte sSuicuneAnimTable2
+.4byte sSuicuneAnimTable3
+.4byte sSuicuneAnimTable4
+.4byte sSuicuneAnimTable5
+.4byte sSuicuneAnimTable6
+.4byte sSuicuneAnimTable7
+.4byte sSuicuneAnimTable8
+.4byte sSuicuneAnimTable9
+.4byte sSuicuneAnimTable10
+.4byte sSuicuneAnimTable11
+.4byte sSuicuneAnimTable12
+.4byte sSuicuneAnimTable13
+.4byte sSuicuneAnimTable14
+sAxSpritesSuicune:
+.4byte sSuicuneSprites1
+.4byte sSuicuneSprites2
+.4byte sSuicuneSprites3
+.4byte sSuicuneSprites4
+.4byte sSuicuneSprites5
+.4byte sSuicuneSprites6
+.4byte sSuicuneSprites7
+.4byte sSuicuneSprites8
+.4byte sSuicuneSprites9
+.4byte sSuicuneSprites10
+.4byte sSuicuneSprites11
+.4byte sSuicuneSprites12
+.4byte sSuicuneSprites13
+.4byte sSuicuneSprites14
+.4byte sSuicuneSprites15
+.4byte sSuicuneSprites16
+.4byte sSuicuneSprites17
+.4byte sSuicuneSprites18
+.4byte sSuicuneSprites19
+.4byte sSuicuneSprites20
+.4byte sSuicuneSprites21
+.4byte sSuicuneSprites22
+.4byte sSuicuneSprites23
+.4byte sSuicuneSprites24
+.4byte sSuicuneSprites25
+.4byte sSuicuneSprites26
+.4byte sSuicuneSprites27
+.4byte sSuicuneSprites28
+.4byte sSuicuneSprites29
+.4byte sSuicuneSprites30
+.4byte sSuicuneSprites31
+.4byte sSuicuneSprites32
+.4byte sSuicuneSprites33
+.4byte sSuicuneSprites34
+.4byte sSuicuneSprites35
+.4byte sSuicuneSprites36
+.4byte sSuicuneSprites37
+.4byte sSuicuneSprites38
+.4byte sSuicuneSprites39
+.4byte sSuicuneSprites40
+.4byte sSuicuneSprites41
+.4byte sSuicuneSprites42
+.4byte sSuicuneSprites43
+.4byte sSuicuneSprites44
+.4byte sSuicuneSprites45
+.4byte sSuicuneSprites46
+.4byte sSuicuneSprites47
+.4byte sSuicuneSprites48
+.4byte sSuicuneSprites49
+.4byte sSuicuneSprites50
+.4byte sSuicuneSprites51
+.4byte sSuicuneSprites52
+.4byte sSuicuneSprites53
+.4byte sSuicuneSprites54
+.4byte sSuicuneSprites55
+.4byte sSuicuneSprites56
+.4byte sSuicuneSprites57
+.4byte sSuicuneSprites58
+.4byte sSuicuneSprites59
+.4byte sSuicuneSprites60
+.4byte sSuicuneSprites61
+.4byte sSuicuneSprites62
+.4byte sSuicuneSprites63
+.4byte sSuicuneSprites64
+.4byte sSuicuneSprites65
+.4byte sSuicuneSprites66
+.4byte sSuicuneSprites67
+.4byte sSuicuneSprites68
+.4byte sSuicuneSprites69
+.4byte sSuicuneSprites70
+.4byte sSuicuneSprites71
+.4byte sSuicuneSprites72
+.4byte sSuicuneSprites73
+.4byte sSuicuneSprites74
+.4byte sSuicuneSprites75
+.4byte sSuicuneSprites76
+.4byte sSuicuneSprites77
+.4byte sSuicuneSprites78
+.4byte sSuicuneSprites79
+.4byte sSuicuneSprites80
+.4byte sSuicuneSprites81
+.4byte sSuicuneSprites82
+.4byte sSuicuneSprites83
+.4byte sSuicuneSprites84
+.4byte sSuicuneSprites85
+.4byte sSuicuneSprites86
+.4byte sSuicuneSprites87
+.4byte sSuicuneSprites88
+.4byte sSuicuneSprites89
+.4byte sSuicuneSprites90
+.4byte sSuicuneSprites91
+.4byte sSuicuneSprites92
+.4byte sSuicuneSprites93
+.4byte sSuicuneSprites94
+.4byte sSuicuneSprites95
+.4byte sSuicuneSprites96
+.4byte sSuicuneSprites97
+.4byte sSuicuneSprites98
+.4byte sSuicuneSprites99
+.4byte sSuicuneSprites100
+.4byte sSuicuneSprites101
+.4byte sSuicuneSprites102
+.4byte sSuicuneSprites103
+.4byte sSuicuneSprites104
+.4byte sSuicuneSprites105
+.4byte sSuicuneSprites106
+.4byte sSuicuneSprites107
+.4byte sSuicuneSprites108
+.4byte sSuicuneSprites109
+.4byte sSuicuneSprites110
+.4byte sSuicuneSprites111
+.4byte sSuicuneSprites112
+.4byte sSuicuneSprites113
+.4byte sSuicuneSprites114
+.4byte sSuicuneSprites115
+.4byte sSuicuneSprites116
+.4byte sSuicuneSprites117
+.4byte sSuicuneSprites118
+.4byte sSuicuneSprites119
+.4byte sSuicuneSprites120
+.4byte sSuicuneSprites121
+.4byte sSuicuneSprites122
+.4byte sSuicuneSprites123
+.4byte sSuicuneSprites124
+.4byte sSuicuneSprites125
+.4byte sSuicuneSprites126
+.4byte sSuicuneSprites127
+.4byte sSuicuneSprites128
+.4byte sSuicuneSprites129
+.4byte sSuicuneSprites130
+.4byte sSuicuneSprites131
+.4byte sSuicuneSprites132
+.4byte sSuicuneSprites133
+sAxMainSuicune:
+ax_main sAxPosesSuicune, sAxAnimationsSuicune, 14, sAxSpritesSuicune, sAxPositionsSuicune

--- a/data/ax/sunflora.inc
+++ b/data/ax/sunflora.inc
@@ -1,0 +1,3204 @@
+.global gAxSunflora
+gAxSunflora:
+ax_siro sAxMainSunflora
+sSunfloraPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose2:
+ax_pose 1, 0x01e5, 0x80f6, 0x3c00
+ax_pose_terminator
+sSunfloraPose3:
+ax_pose 2, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose4:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose5:
+ax_pose 4, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose7:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose8:
+ax_pose 7, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose9:
+ax_pose 8, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose10:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose11:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose12:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose13:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose16:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose17:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose18:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose19:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose20:
+ax_pose 7, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose21:
+ax_pose 8, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose26:
+ax_pose 1, 0x01e5, 0x80f6, 0x3c00
+ax_pose_terminator
+sSunfloraPose27:
+ax_pose 2, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose28:
+ax_pose 15, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose29:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose30:
+ax_pose 4, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose31:
+ax_pose 5, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose32:
+ax_pose 16, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose33:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose34:
+ax_pose 7, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose35:
+ax_pose 8, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose36:
+ax_pose 17, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose37:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose38:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose39:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose40:
+ax_pose 18, 0x01e5, 0x90f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose41:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose42:
+ax_pose 13, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose43:
+ax_pose 14, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose44:
+ax_pose 19, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose45:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose46:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose47:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose48:
+ax_pose 20, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose49:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose50:
+ax_pose 7, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose51:
+ax_pose 8, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose52:
+ax_pose 21, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose53:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose54:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose55:
+ax_pose 5, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose56:
+ax_pose 22, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose57:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose58:
+ax_pose 1, 0x01e5, 0x80f6, 0x3c00
+ax_pose_terminator
+sSunfloraPose59:
+ax_pose 2, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose60:
+ax_pose 23, 0x81ed, 0x90f2, 0x3c00
+ax_pose 15, 0x01e5, 0x90f1, 0x3c08
+ax_pose_terminator
+sSunfloraPose61:
+ax_pose 24, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose62:
+ax_pose 23, 0x81ed, 0x80fe, 0x3c00
+ax_pose 24, 0x01e5, 0x90f1, 0x3c08
+ax_pose_terminator
+sSunfloraPose63:
+ax_pose 15, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose64:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose65:
+ax_pose 5, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose66:
+ax_pose 4, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose67:
+ax_pose 25, 0x81ed, 0x90f7, 0x3c00
+ax_pose 16, 0x01e5, 0x90f1, 0x3c08
+ax_pose_terminator
+sSunfloraPose68:
+ax_pose 16, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose69:
+ax_pose 26, 0x81ec, 0x9100, 0x3c00
+ax_pose 22, 0x01e5, 0x90f1, 0x3c08
+ax_pose_terminator
+sSunfloraPose70:
+ax_pose 22, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose71:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose72:
+ax_pose 8, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose73:
+ax_pose 7, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose74:
+ax_pose 27, 0x41f1, 0x90f1, 0x3c00
+ax_pose 17, 0x01e5, 0x90f1, 0x3c08
+ax_pose_terminator
+sSunfloraPose75:
+ax_pose 17, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose76:
+ax_pose 21, 0x01e5, 0x90f1, 0x3c00
+ax_pose 28, 0x41eb, 0x90f4, 0x3c10
+ax_pose_terminator
+sSunfloraPose77:
+ax_pose 21, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose78:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose79:
+ax_pose 11, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose80:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose81:
+ax_pose 29, 0x41e7, 0x90f3, 0x3c00
+ax_pose 18, 0x01e5, 0x90f4, 0x3c08
+ax_pose 30, 0x01f3, 0x5103, 0x3c18
+ax_pose_terminator
+sSunfloraPose82:
+ax_pose 18, 0x01e5, 0x90f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose83:
+ax_pose 20, 0x01e5, 0x90f4, 0x3c00
+ax_pose 31, 0x41ec, 0x90ed, 0x3c10
+ax_pose_terminator
+sSunfloraPose84:
+ax_pose 20, 0x01e5, 0x90f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose85:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose86:
+ax_pose 13, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose87:
+ax_pose 14, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose88:
+ax_pose 19, 0x01e5, 0x80ef, 0x3c00
+ax_pose 32, 0x01e5, 0x80f1, 0x3c10
+ax_pose_terminator
+sSunfloraPose89:
+ax_pose 19, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose90:
+ax_pose 33, 0x01e5, 0x80ef, 0x3c00
+ax_pose 32, 0x01e6, 0x90ee, 0x3c10
+ax_pose_terminator
+sSunfloraPose91:
+ax_pose 33, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose92:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose93:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose94:
+ax_pose 11, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose95:
+ax_pose 20, 0x01e5, 0x80ec, 0x3c00
+ax_pose 31, 0x41e9, 0x80f0, 0x3c10
+ax_pose_terminator
+sSunfloraPose96:
+ax_pose 20, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose97:
+ax_pose 29, 0x41e6, 0x80ed, 0x3c00
+ax_pose 18, 0x01e5, 0x80ec, 0x3c08
+ax_pose 30, 0x01f2, 0x40ed, 0x3c18
+ax_pose_terminator
+sSunfloraPose98:
+ax_pose 18, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose99:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose100:
+ax_pose 7, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose101:
+ax_pose 8, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose102:
+ax_pose 21, 0x01e5, 0x80ef, 0x3c00
+ax_pose 28, 0x41ee, 0x80eb, 0x3c10
+ax_pose_terminator
+sSunfloraPose103:
+ax_pose 21, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose104:
+ax_pose 27, 0x41f1, 0x80ef, 0x3c00
+ax_pose 17, 0x01e5, 0x80ef, 0x3c08
+ax_pose_terminator
+sSunfloraPose105:
+ax_pose 17, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose106:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose107:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose108:
+ax_pose 5, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose109:
+ax_pose 26, 0x81ec, 0x80f0, 0x3c00
+ax_pose 22, 0x01e5, 0x80ef, 0x3c08
+ax_pose_terminator
+sSunfloraPose110:
+ax_pose 22, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose111:
+ax_pose 25, 0x81ed, 0x80f9, 0x3c00
+ax_pose 16, 0x01e5, 0x80ef, 0x3c08
+ax_pose_terminator
+sSunfloraPose112:
+ax_pose 16, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose113:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose114:
+ax_pose 34, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose115:
+ax_pose 35, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose116:
+ax_pose 36, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose117:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose118:
+ax_pose 37, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose119:
+ax_pose 38, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose120:
+ax_pose 39, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose121:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose122:
+ax_pose 40, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose123:
+ax_pose 41, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose124:
+ax_pose 42, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose125:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose126:
+ax_pose 43, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose127:
+ax_pose 44, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose128:
+ax_pose 45, 0x01e7, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose129:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose130:
+ax_pose 46, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose131:
+ax_pose 47, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose132:
+ax_pose 48, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose133:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose134:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose135:
+ax_pose 44, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose136:
+ax_pose 45, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose137:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose138:
+ax_pose 40, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose139:
+ax_pose 41, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose140:
+ax_pose 42, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose141:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose142:
+ax_pose 37, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose143:
+ax_pose 38, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose144:
+ax_pose 39, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose145:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose146:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose147:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose148:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose149:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose150:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose151:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose152:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose153:
+ax_pose 49, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose154:
+ax_pose 50, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose155:
+ax_pose 51, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose156:
+ax_pose 52, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sSunfloraPose157:
+ax_pose 53, 0x01e7, 0x90ea, 0x3c00
+ax_pose_terminator
+sSunfloraPose158:
+ax_pose 54, 0x01e6, 0x90eb, 0x3c00
+ax_pose_terminator
+sSunfloraPose159:
+ax_pose 55, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose160:
+ax_pose 54, 0x01e6, 0x80f5, 0x3c00
+ax_pose_terminator
+sSunfloraPose161:
+ax_pose 53, 0x01e7, 0x80f6, 0x3c00
+ax_pose_terminator
+sSunfloraPose162:
+ax_pose 52, 0x01e5, 0x80f5, 0x3c00
+ax_pose_terminator
+sSunfloraPose163:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose164:
+ax_pose 1, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose165:
+ax_pose 2, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose166:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose167:
+ax_pose 4, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose168:
+ax_pose 5, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose169:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose170:
+ax_pose 7, 0x01e4, 0x90ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose171:
+ax_pose 8, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose172:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose173:
+ax_pose 10, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose174:
+ax_pose 11, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose175:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose176:
+ax_pose 13, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose177:
+ax_pose 14, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose178:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose179:
+ax_pose 10, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose180:
+ax_pose 11, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose181:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose182:
+ax_pose 7, 0x01e4, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose183:
+ax_pose 8, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose184:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose185:
+ax_pose 4, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose186:
+ax_pose 5, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose187:
+ax_pose 36, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose188:
+ax_pose 39, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose189:
+ax_pose 42, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose190:
+ax_pose 45, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose191:
+ax_pose 48, 0x01e9, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose192:
+ax_pose 45, 0x01e7, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose193:
+ax_pose 42, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose194:
+ax_pose 39, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose195:
+ax_pose 15, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose196:
+ax_pose 16, 0x01e4, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose197:
+ax_pose 17, 0x01e6, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose198:
+ax_pose 18, 0x01e6, 0x90f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose199:
+ax_pose 19, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose200:
+ax_pose 20, 0x01e6, 0x80eb, 0x3c00
+ax_pose_terminator
+sSunfloraPose201:
+ax_pose 21, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose202:
+ax_pose 22, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose203:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose204:
+ax_pose 34, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose205:
+ax_pose 35, 0x01e5, 0x80ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose206:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sSunfloraPose207:
+ax_pose 37, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose208:
+ax_pose 38, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose209:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose210:
+ax_pose 40, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose211:
+ax_pose 41, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose212:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose213:
+ax_pose 43, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose214:
+ax_pose 44, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose215:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose216:
+ax_pose 46, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose217:
+ax_pose 47, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose218:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose219:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose220:
+ax_pose 44, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose221:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose222:
+ax_pose 40, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose223:
+ax_pose 41, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose224:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose225:
+ax_pose 37, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose226:
+ax_pose 38, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose227:
+ax_pose 34, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose228:
+ax_pose 37, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose229:
+ax_pose 40, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunfloraPose230:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose231:
+ax_pose 46, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose232:
+ax_pose 43, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose233:
+ax_pose 40, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sSunfloraPose234:
+ax_pose 37, 0x01e5, 0x90f0, 0x3c00
+ax_pose_terminator
+sSunfloraPose235:
+ax_pose 0, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose236:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose237:
+ax_pose 6, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sSunfloraPose238:
+ax_pose 9, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sSunfloraPose239:
+ax_pose 12, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunfloraPose240:
+ax_pose 9, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sSunfloraPose241:
+ax_pose 6, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sSunfloraPose242:
+ax_pose 3, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+.align 2
+sSunfloraAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 1, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, -1, 0,
+ax_anim_terminator
+sSunfloraAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, -1, 1,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 1, -1,
+ax_anim_terminator
+sSunfloraAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 1,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, -1,
+ax_anim_terminator
+sSunfloraAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 1, 1,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, -1, -1,
+ax_anim_terminator
+sSunfloraAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, -1, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 1, 0,
+ax_anim_terminator
+sSunfloraAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, -1, 1,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 1, -1,
+ax_anim_terminator
+sSunfloraAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 1,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, -1,
+ax_anim_terminator
+sSunfloraAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 1, 1,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, -1, -1,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 2, 29, -1, 4, 0, 4,
+ax_anim 2, 0, 30, -2, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSunfloraAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 2, 26, 6, 4, 4, 4,
+ax_anim 2, 0, 25, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 1, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 0, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sSunfloraAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 29, 4, 0, 4, 0,
+ax_anim 2, 0, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 20, 1, 20, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSunfloraAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 2, 0, 38, 0, -1, 0, -1,
+ax_anim 2, 2, 33, 4, -6, 4, -6,
+ax_anim 2, 0, 33, 10, -11, 10, -11,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 2, 1, 39, 21, -19, 21, -19,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 2, 0, 39, 21, -19, 21, -19,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sSunfloraAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, -4, 0, -4,
+ax_anim 2, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 1, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 0, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sSunfloraAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 2, 2, 41, -4, -6, -4, -6,
+ax_anim 2, 0, 42, -10, -11, -10, -11,
+ax_anim 2, 0, 47, -20, -20, -20, -20,
+ax_anim 2, 1, 47, -21, -19, -21, -19,
+ax_anim 2, 0, 47, -20, -20, -20, -20,
+ax_anim 2, 0, 47, -21, -19, -21, -19,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sSunfloraAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 2, 45, -4, 0, -4, 0,
+ax_anim 2, 0, 46, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 1, -20, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sSunfloraAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 2, 49, -4, 4, -4, 4,
+ax_anim 2, 0, 50, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -19, 21, -19, 21,
+ax_anim 2, 1, 55, -20, 20, -20, 20,
+ax_anim 2, 0, 55, -19, 21, -19, 21,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_3_1:
+ax_anim 1, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 4, 0, 106, 0, -6, 0, -6,
+ax_anim 1, 2, 106, 0, -3, 0, -3,
+ax_anim 1, 0, 57, -1, 3, -1, 3,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 67, 1, 21, 1, 21,
+ax_anim 4, 0, 67, 2, 20, 2, 20,
+ax_anim 1, 0, 60, 3, 20, 3, 20,
+ax_anim 2, 0, 61, 1, 20, 1, 20,
+ax_anim 4, 0, 111, 1, 20, 1, 20,
+ax_anim 2, 0, 62, -1, 16, -1, 16,
+ax_anim 2, 0, 58, 0, 11, 0, 11,
+ax_anim 2, 0, 57, 0, 3, 0, 3,
+ax_anim_terminator
+sSunfloraAnims_3_2:
+ax_anim 1, 0, 64, -2, -2, -2, -2,
+ax_anim 2, 0, 57, -4, -4, -4, -4,
+ax_anim 4, 0, 57, -6, -6, -6, -6,
+ax_anim 1, 2, 57, -3, -3, -3, -3,
+ax_anim 1, 0, 64, 6, 7, 6, 7,
+ax_anim 2, 0, 66, 18, 20, 18, 20,
+ax_anim 2, 1, 74, 20, 21, 20, 21,
+ax_anim 4, 0, 74, 20, 20, 20, 20,
+ax_anim 1, 0, 67, 21, 21, 21, 21,
+ax_anim 2, 0, 68, 20, 23, 20, 23,
+ax_anim 4, 0, 62, 20, 22, 20, 22,
+ax_anim 2, 0, 69, 17, 16, 17, 16,
+ax_anim 2, 0, 65, 10, 10, 10, 10,
+ax_anim 2, 0, 64, 4, 5, 4, 5,
+ax_anim_terminator
+sSunfloraAnims_3_3:
+ax_anim 1, 0, 71, -2, 0, -2, 0,
+ax_anim 2, 0, 64, -4, 0, -4, 0,
+ax_anim 4, 0, 64, -6, 0, -6, 0,
+ax_anim 1, 2, 64, -3, 0, -3, 0,
+ax_anim 1, 0, 71, 6, 0, 6, 0,
+ax_anim 2, 0, 73, 17, 0, 17, 0,
+ax_anim 2, 1, 81, 18, 1, 18, 1,
+ax_anim 4, 0, 81, 17, 0, 17, 0,
+ax_anim 1, 0, 74, 16, 0, 16, 0,
+ax_anim 2, 0, 75, 18, 0, 18, 0,
+ax_anim 4, 0, 69, 18, -1, 18, -1,
+ax_anim 2, 0, 76, 13, -1, 13, -1,
+ax_anim 2, 0, 72, 9, -1, 9, -1,
+ax_anim 2, 0, 71, 2, 0, 2, 0,
+ax_anim_terminator
+sSunfloraAnims_3_4:
+ax_anim 1, 0, 78, -2, 2, -2, 2,
+ax_anim 2, 0, 71, -4, 4, -4, 4,
+ax_anim 4, 0, 71, -6, 6, -6, 6,
+ax_anim 1, 2, 71, -3, 3, -3, 3,
+ax_anim 1, 0, 78, 9, -9, 9, -9,
+ax_anim 2, 0, 80, 14, -14, 14, -14,
+ax_anim 2, 1, 88, 16, -15, 16, -15,
+ax_anim 4, 0, 88, 14, -14, 14, -14,
+ax_anim 1, 0, 81, 15, -15, 15, -15,
+ax_anim 2, 0, 82, 19, -19, 19, -19,
+ax_anim 4, 0, 76, 19, -18, 19, -18,
+ax_anim 2, 0, 83, 12, -12, 12, -12,
+ax_anim 2, 0, 79, 7, -7, 7, -7,
+ax_anim 2, 0, 78, 3, -2, 3, -2,
+ax_anim_terminator
+sSunfloraAnims_3_5:
+ax_anim 1, 0, 85, 0, 2, 0, 2,
+ax_anim 2, 0, 78, 0, 4, 0, 4,
+ax_anim 4, 0, 78, 0, 6, 0, 6,
+ax_anim 1, 2, 78, 0, 3, 0, 3,
+ax_anim 1, 0, 85, 0, -6, 0, -6,
+ax_anim 2, 0, 87, 0, -16, 0, -16,
+ax_anim 2, 1, 95, -2, -17, -2, -17,
+ax_anim 4, 0, 95, -2, -16, -2, -16,
+ax_anim 1, 0, 88, -2, -17, -2, -17,
+ax_anim 2, 0, 89, -1, -17, -1, -17,
+ax_anim 4, 0, 83, 1, -17, 1, -17,
+ax_anim 2, 0, 90, 0, -12, 0, -12,
+ax_anim 2, 0, 86, 0, -5, 0, -5,
+ax_anim 2, 0, 85, 0, -1, 0, -1,
+ax_anim_terminator
+sSunfloraAnims_3_6:
+ax_anim 1, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 4, 4, 4, 4,
+ax_anim 4, 0, 85, 6, 6, 6, 6,
+ax_anim 1, 2, 85, 3, 3, 3, 3,
+ax_anim 1, 0, 92, -9, -9, -9, -9,
+ax_anim 2, 0, 94, -15, -12, -15, -12,
+ax_anim 2, 1, 102, -14, -12, -14, -12,
+ax_anim 4, 0, 102, -13, -11, -13, -11,
+ax_anim 1, 0, 95, -15, -12, -15, -12,
+ax_anim 2, 0, 96, -17, -17, -17, -17,
+ax_anim 4, 0, 90, -18, -17, -18, -17,
+ax_anim 2, 0, 97, -12, -16, -12, -16,
+ax_anim 2, 0, 93, -7, -7, -7, -7,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sSunfloraAnims_3_7:
+ax_anim 1, 0, 99, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 4, 0, 4, 0,
+ax_anim 4, 0, 92, 6, 0, 6, 0,
+ax_anim 1, 2, 92, 3, 0, 3, 0,
+ax_anim 1, 0, 99, -6, 0, -6, 0,
+ax_anim 2, 0, 101, -17, 0, -17, 0,
+ax_anim 2, 1, 109, -18, 1, -18, 1,
+ax_anim 4, 0, 109, -17, 1, -17, 1,
+ax_anim 1, 0, 102, -17, 1, -17, 1,
+ax_anim 2, 0, 103, -17, 0, -17, 0,
+ax_anim 4, 0, 97, -18, 0, -18, 0,
+ax_anim 2, 0, 104, -11, -1, -11, -1,
+ax_anim 2, 0, 100, -6, 0, -6, 0,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim_terminator
+sSunfloraAnims_3_8:
+ax_anim 1, 0, 106, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 4, 0, 99, 6, -6, 6, -6,
+ax_anim 1, 2, 99, 3, -3, 3, -3,
+ax_anim 1, 0, 106, -6, 7, -6, 7,
+ax_anim 2, 0, 108, -18, 20, -18, 20,
+ax_anim 2, 1, 60, -17, 22, -17, 22,
+ax_anim 4, 0, 60, -16, 21, -16, 21,
+ax_anim 1, 0, 109, -13, 20, -13, 20,
+ax_anim 2, 0, 110, -18, 20, -18, 20,
+ax_anim 4, 0, 104, -19, 21, -19, 21,
+ax_anim 2, 0, 111, -17, 16, -17, 16,
+ax_anim 2, 0, 107, -11, 11, -11, 11,
+ax_anim 2, 0, 106, -2, 3, -2, 3,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_4_1:
+ax_anim 2, 0, 113, 0, -2, 0, -2,
+ax_anim 6, 2, 113, 0, -3, 0, -3,
+ax_anim 1, 0, 112, 0, -1, 0, -1,
+ax_anim 1, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 1, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 115, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 115, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 115, 0, 5, 0, 5,
+ax_anim 2, 0, 114, 0, 5, 0, 5,
+ax_anim 2, 0, 112, 0, 2, 0, 2,
+ax_anim_terminator
+sSunfloraAnims_4_2:
+ax_anim 2, 0, 117, -2, -2, -2, -2,
+ax_anim 6, 2, 117, -3, -3, -3, -3,
+ax_anim 1, 0, 116, -1, -1, -1, -1,
+ax_anim 1, 0, 116, 1, 1, 1, 1,
+ax_anim 2, 1, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 119, 5, 5, 5, 5,
+ax_anim 2, 0, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 119, 5, 5, 5, 5,
+ax_anim 2, 0, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 119, 5, 5, 5, 5,
+ax_anim 2, 0, 118, 5, 5, 5, 5,
+ax_anim 2, 0, 116, 2, 2, 2, 2,
+ax_anim_terminator
+sSunfloraAnims_4_3:
+ax_anim 2, 0, 121, -2, 0, -2, 0,
+ax_anim 6, 2, 121, -3, 0, -3, 0,
+ax_anim 1, 0, 120, -1, 0, -1, 0,
+ax_anim 1, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 1, 122, 7, 0, 7, 0,
+ax_anim 2, 0, 123, 7, 0, 7, 0,
+ax_anim 2, 0, 122, 7, 0, 7, 0,
+ax_anim 2, 0, 123, 7, 0, 7, 0,
+ax_anim 2, 0, 122, 7, 0, 7, 0,
+ax_anim 2, 0, 123, 7, 0, 7, 0,
+ax_anim 2, 0, 122, 7, 0, 7, 0,
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim_terminator
+sSunfloraAnims_4_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 6, 2, 125, -3, 3, -3, 3,
+ax_anim 1, 0, 124, -1, 1, -1, 1,
+ax_anim 1, 0, 124, 1, -1, 1, -1,
+ax_anim 2, 1, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 127, 5, -5, 5, -5,
+ax_anim 2, 0, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 127, 5, -5, 5, -5,
+ax_anim 2, 0, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 127, 5, -5, 5, -5,
+ax_anim 2, 0, 126, 5, -5, 5, -5,
+ax_anim 2, 0, 124, 2, -2, 2, -2,
+ax_anim_terminator
+sSunfloraAnims_4_5:
+ax_anim 2, 0, 129, 0, 2, 0, 2,
+ax_anim 6, 2, 129, 0, 3, 0, 3,
+ax_anim 1, 0, 128, 0, 1, 0, 1,
+ax_anim 1, 0, 128, 0, -1, 0, -1,
+ax_anim 2, 1, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 131, 0, -5, 0, -5,
+ax_anim 2, 0, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 131, 0, -5, 0, -5,
+ax_anim 2, 0, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 131, 0, -5, 0, -5,
+ax_anim 2, 0, 130, 0, -5, 0, -5,
+ax_anim 2, 0, 128, 0, -2, 0, -2,
+ax_anim_terminator
+sSunfloraAnims_4_6:
+ax_anim 2, 0, 133, 2, 2, 2, 2,
+ax_anim 6, 2, 133, 3, 3, 3, 3,
+ax_anim 1, 0, 132, 1, 1, 1, 1,
+ax_anim 1, 0, 132, -1, -1, -1, -1,
+ax_anim 2, 1, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 135, -5, -5, -5, -5,
+ax_anim 2, 0, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 135, -5, -5, -5, -5,
+ax_anim 2, 0, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 135, -5, -5, -5, -5,
+ax_anim 2, 0, 134, -5, -5, -5, -5,
+ax_anim 2, 0, 132, -2, -2, -2, -2,
+ax_anim_terminator
+sSunfloraAnims_4_7:
+ax_anim 2, 0, 137, 2, 0, 2, 0,
+ax_anim 6, 2, 137, 3, 0, 3, 0,
+ax_anim 1, 0, 136, 1, 0, 1, 0,
+ax_anim 1, 0, 136, -1, 0, -1, 0,
+ax_anim 2, 1, 138, -7, 0, -7, 0,
+ax_anim 2, 0, 139, -7, 0, -7, 0,
+ax_anim 2, 0, 138, -7, 0, -7, 0,
+ax_anim 2, 0, 139, -7, 0, -7, 0,
+ax_anim 2, 0, 138, -7, 0, -7, 0,
+ax_anim 2, 0, 139, -7, 0, -7, 0,
+ax_anim 2, 0, 138, -7, 0, -7, 0,
+ax_anim 2, 0, 136, -2, 0, -2, 0,
+ax_anim_terminator
+sSunfloraAnims_4_8:
+ax_anim 2, 0, 141, 2, -2, 2, -2,
+ax_anim 6, 2, 141, 3, -3, 3, -3,
+ax_anim 1, 0, 140, 1, -1, 1, -1,
+ax_anim 1, 0, 140, -1, 1, -1, 1,
+ax_anim 2, 1, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 143, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 143, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 143, -5, 5, -5, 5,
+ax_anim 2, 0, 142, -5, 5, -5, 5,
+ax_anim 2, 0, 140, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_5_1:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_5_2:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_5_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_5_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_5_5:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_5_6:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_5_7:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_5_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sSunfloraAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sSunfloraAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sSunfloraAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sSunfloraAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sSunfloraAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sSunfloraAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sSunfloraAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 3, 0, 163, 0, -5, 0, 0,
+ax_anim 4, 0, 163, 0, -6, 0, 0,
+ax_anim 3, 0, 163, 0, -5, 0, 0,
+ax_anim 2, 0, 163, 0, -4, 0, 0,
+ax_anim 1, 0, 163, 0, -2, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -2, 0, 0,
+ax_anim 2, 0, 164, 0, -4, 0, 0,
+ax_anim 3, 0, 164, 0, -5, 0, 0,
+ax_anim 4, 0, 164, 0, -6, 0, 0,
+ax_anim 3, 0, 164, 0, -5, 0, 0,
+ax_anim 2, 0, 164, 0, -4, 0, 0,
+ax_anim 1, 0, 164, 0, -2, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_8_2:
+ax_anim 40, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -2, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -5, 0, 0,
+ax_anim 4, 0, 166, 0, -6, 0, 0,
+ax_anim 3, 0, 166, 0, -5, 0, 0,
+ax_anim 2, 0, 166, 0, -4, 0, 0,
+ax_anim 1, 0, 166, 0, -2, 0, 0,
+ax_anim 4, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -2, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 3, 0, 167, 0, -5, 0, 0,
+ax_anim 4, 0, 167, 0, -6, 0, 0,
+ax_anim 3, 0, 167, 0, -5, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 1, 0, 167, 0, -2, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim 2, 0, 169, 0, -4, 0, 0,
+ax_anim 3, 0, 169, 0, -5, 0, 0,
+ax_anim 4, 0, 169, 0, -6, 0, 0,
+ax_anim 3, 0, 169, 0, -5, 0, 0,
+ax_anim 2, 0, 169, 0, -4, 0, 0,
+ax_anim 1, 0, 169, 0, -2, 0, 0,
+ax_anim 4, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -2, 0, 0,
+ax_anim 2, 0, 170, 0, -4, 0, 0,
+ax_anim 3, 0, 170, 0, -5, 0, 0,
+ax_anim 4, 0, 170, 0, -6, 0, 0,
+ax_anim 3, 0, 170, 0, -5, 0, 0,
+ax_anim 2, 0, 170, 0, -4, 0, 0,
+ax_anim 1, 0, 170, 0, -2, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_8_4:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -2, 0, 0,
+ax_anim 2, 0, 172, 0, -4, 0, 0,
+ax_anim 3, 0, 172, 0, -5, 0, 0,
+ax_anim 4, 0, 172, 0, -6, 0, 0,
+ax_anim 3, 0, 172, 0, -5, 0, 0,
+ax_anim 2, 0, 172, 0, -4, 0, 0,
+ax_anim 1, 0, 172, 0, -2, 0, 0,
+ax_anim 4, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -2, 0, 0,
+ax_anim 2, 0, 173, 0, -4, 0, 0,
+ax_anim 3, 0, 173, 0, -5, 0, 0,
+ax_anim 4, 0, 173, 0, -6, 0, 0,
+ax_anim 3, 0, 173, 0, -5, 0, 0,
+ax_anim 2, 0, 173, 0, -4, 0, 0,
+ax_anim 1, 0, 173, 0, -2, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_8_5:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -2, 0, 0,
+ax_anim 2, 0, 175, 0, -4, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 4, 0, 175, 0, -6, 0, 0,
+ax_anim 3, 0, 175, 0, -5, 0, 0,
+ax_anim 2, 0, 175, 0, -4, 0, 0,
+ax_anim 1, 0, 175, 0, -2, 0, 0,
+ax_anim 4, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -2, 0, 0,
+ax_anim 2, 0, 176, 0, -4, 0, 0,
+ax_anim 3, 0, 176, 0, -5, 0, 0,
+ax_anim 4, 0, 176, 0, -6, 0, 0,
+ax_anim 3, 0, 176, 0, -5, 0, 0,
+ax_anim 2, 0, 176, 0, -4, 0, 0,
+ax_anim 1, 0, 176, 0, -2, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_8_6:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -2, 0, 0,
+ax_anim 2, 0, 178, 0, -4, 0, 0,
+ax_anim 3, 0, 178, 0, -5, 0, 0,
+ax_anim 4, 0, 178, 0, -6, 0, 0,
+ax_anim 3, 0, 178, 0, -5, 0, 0,
+ax_anim 2, 0, 178, 0, -4, 0, 0,
+ax_anim 1, 0, 178, 0, -2, 0, 0,
+ax_anim 4, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -2, 0, 0,
+ax_anim 2, 0, 179, 0, -4, 0, 0,
+ax_anim 3, 0, 179, 0, -5, 0, 0,
+ax_anim 4, 0, 179, 0, -6, 0, 0,
+ax_anim 3, 0, 179, 0, -5, 0, 0,
+ax_anim 2, 0, 179, 0, -4, 0, 0,
+ax_anim 1, 0, 179, 0, -2, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_8_7:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -2, 0, 0,
+ax_anim 2, 0, 181, 0, -4, 0, 0,
+ax_anim 3, 0, 181, 0, -5, 0, 0,
+ax_anim 4, 0, 181, 0, -6, 0, 0,
+ax_anim 3, 0, 181, 0, -5, 0, 0,
+ax_anim 2, 0, 181, 0, -4, 0, 0,
+ax_anim 1, 0, 181, 0, -2, 0, 0,
+ax_anim 4, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -2, 0, 0,
+ax_anim 2, 0, 182, 0, -4, 0, 0,
+ax_anim 3, 0, 182, 0, -5, 0, 0,
+ax_anim 4, 0, 182, 0, -6, 0, 0,
+ax_anim 3, 0, 182, 0, -5, 0, 0,
+ax_anim 2, 0, 182, 0, -4, 0, 0,
+ax_anim 1, 0, 182, 0, -2, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_8_8:
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -2, 0, 0,
+ax_anim 2, 0, 184, 0, -4, 0, 0,
+ax_anim 3, 0, 184, 0, -5, 0, 0,
+ax_anim 4, 0, 184, 0, -6, 0, 0,
+ax_anim 3, 0, 184, 0, -5, 0, 0,
+ax_anim 2, 0, 184, 0, -4, 0, 0,
+ax_anim 1, 0, 184, 0, -2, 0, 0,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -2, 0, 0,
+ax_anim 2, 0, 185, 0, -4, 0, 0,
+ax_anim 3, 0, 185, 0, -5, 0, 0,
+ax_anim 4, 0, 185, 0, -6, 0, 0,
+ax_anim 3, 0, 185, 0, -5, 0, 0,
+ax_anim 2, 0, 185, 0, -4, 0, 0,
+ax_anim 1, 0, 185, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 16, 7, 16,
+ax_anim 3, 0, 190, 0, 18, 0, 18,
+ax_anim 2, 3, 191, -7, 16, -7, 16,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 11, -5, 11, -5,
+ax_anim 2, 0, 187, 20, 4, 20, 4,
+ax_anim 2, 0, 188, 22, 10, 22, 10,
+ax_anim 3, 0, 189, 22, 18, 22, 18,
+ax_anim 2, 3, 190, 11, 19, 11, 19,
+ax_anim 2, 0, 191, 1, 16, 1, 16,
+ax_anim 1, 0, 192, 0, 8, 0, 8,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 4, -7, 4, -7,
+ax_anim 2, 0, 186, 11, -11, 11, -11,
+ax_anim 2, 0, 187, 18, -7, 18, -7,
+ax_anim 3, 0, 188, 20, -1, 20, -1,
+ax_anim 2, 3, 189, 19, 6, 19, 6,
+ax_anim 2, 0, 190, 12, 8, 12, 8,
+ax_anim 1, 0, 191, 3, 7, 3, 7,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 1, -8, 1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 9, -23, 9, -23,
+ax_anim 3, 0, 187, 18, -23, 18, -23,
+ax_anim 2, 3, 188, 20, -15, 20, -15,
+ax_anim 2, 0, 189, 17, -4, 17, -4,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -3, -8, -3,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -20, -7, -20,
+ax_anim 3, 0, 186, 0, -25, 0, -25,
+ax_anim 2, 3, 187, 7, -20, 7, -20,
+ax_anim 2, 0, 188, 9, -10, 9, -10,
+ax_anim 1, 0, 189, 8, -3, 8, -3,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -9, -23, -9, -23,
+ax_anim 3, 0, 193, -18, -23, -18, -23,
+ax_anim 2, 3, 192, -20, -15, -20, -15,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -4, -7, -4, -7,
+ax_anim 2, 0, 186, -11, -11, -11, -11,
+ax_anim 2, 0, 193, -18, -7, -18, -7,
+ax_anim 3, 0, 192, -20, -1, -20, -1,
+ax_anim 2, 3, 191, -20, 6, -20, 6,
+ax_anim 2, 0, 190, -19, 6, -19, 6,
+ax_anim 1, 0, 189, -3, 7, -3, 7,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -11, -5, -11, -5,
+ax_anim 2, 0, 193, -20, 4, -20, 4,
+ax_anim 2, 0, 192, -22, 10, -22, 10,
+ax_anim 3, 0, 191, -22, 18, -22, 18,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -1, 16, -1, 16,
+ax_anim 1, 0, 188, 0, 8, 0, 8,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -18, 0, 0,
+ax_anim 4, 0, 206, 0, -19, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -18, 0, 0,
+ax_anim 4, 0, 209, 0, -19, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -19, 0, 0,
+ax_anim 4, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -19, 0, 0,
+ax_anim 4, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -18, 0, 0,
+ax_anim 4, 0, 221, 0, -19, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -18, 0, 0,
+ax_anim 4, 0, 224, 0, -19, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 1,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunfloraAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sSunfloraGfx1:
+.incbin "baserom.gba", 0xD41B0C, 0x200
+sSunfloraSprites1:
+ax_sprite sSunfloraGfx1, 0x200
+ax_sprite_terminator
+sSunfloraGfx2:
+.incbin "baserom.gba", 0xD41D1C, 0x200
+sSunfloraSprites2:
+ax_sprite sSunfloraGfx2, 0x200
+ax_sprite_terminator
+sSunfloraGfx3:
+.incbin "baserom.gba", 0xD41F2C, 0x200
+sSunfloraSprites3:
+ax_sprite sSunfloraGfx3, 0x200
+ax_sprite_terminator
+sSunfloraGfx4:
+.incbin "baserom.gba", 0xD4213C, 0x200
+sSunfloraSprites4:
+ax_sprite sSunfloraGfx4, 0x200
+ax_sprite_terminator
+sSunfloraGfx5:
+.incbin "baserom.gba", 0xD4234C, 0x200
+sSunfloraSprites5:
+ax_sprite sSunfloraGfx5, 0x200
+ax_sprite_terminator
+sSunfloraGfx6:
+.incbin "baserom.gba", 0xD4255C, 0x200
+sSunfloraSprites6:
+ax_sprite sSunfloraGfx6, 0x200
+ax_sprite_terminator
+sSunfloraGfx7:
+.incbin "baserom.gba", 0xD4276C, 0x200
+sSunfloraSprites7:
+ax_sprite sSunfloraGfx7, 0x200
+ax_sprite_terminator
+sSunfloraGfx8:
+.incbin "baserom.gba", 0xD4297C, 0x200
+sSunfloraSprites8:
+ax_sprite sSunfloraGfx8, 0x200
+ax_sprite_terminator
+sSunfloraGfx9:
+.incbin "baserom.gba", 0xD42B8C, 0x200
+sSunfloraSprites9:
+ax_sprite sSunfloraGfx9, 0x200
+ax_sprite_terminator
+sSunfloraGfx10:
+.incbin "baserom.gba", 0xD42D9C, 0x200
+sSunfloraSprites10:
+ax_sprite sSunfloraGfx10, 0x200
+ax_sprite_terminator
+sSunfloraGfx11:
+.incbin "baserom.gba", 0xD42FAC, 0x200
+sSunfloraSprites11:
+ax_sprite sSunfloraGfx11, 0x200
+ax_sprite_terminator
+sSunfloraGfx12:
+.incbin "baserom.gba", 0xD431BC, 0x200
+sSunfloraSprites12:
+ax_sprite sSunfloraGfx12, 0x200
+ax_sprite_terminator
+sSunfloraGfx13:
+.incbin "baserom.gba", 0xD433CC, 0x200
+sSunfloraSprites13:
+ax_sprite sSunfloraGfx13, 0x200
+ax_sprite_terminator
+sSunfloraGfx14:
+.incbin "baserom.gba", 0xD435DC, 0x200
+sSunfloraSprites14:
+ax_sprite sSunfloraGfx14, 0x200
+ax_sprite_terminator
+sSunfloraGfx15:
+.incbin "baserom.gba", 0xD437EC, 0x200
+sSunfloraSprites15:
+ax_sprite sSunfloraGfx15, 0x200
+ax_sprite_terminator
+sSunfloraGfx16:
+.incbin "baserom.gba", 0xD439FC, 0x40
+sSunfloraGfx16_1:
+.incbin "baserom.gba", 0xD43A3C, 0x100
+sSunfloraGfx16_2:
+.incbin "baserom.gba", 0xD43B3C, 0x40
+sSunfloraSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx17:
+.incbin "baserom.gba", 0xD43BBC, 0x40
+sSunfloraGfx17_1:
+.incbin "baserom.gba", 0xD43BFC, 0x60
+sSunfloraGfx17_2:
+.incbin "baserom.gba", 0xD43C5C, 0x60
+sSunfloraGfx17_3:
+.incbin "baserom.gba", 0xD43CBC, 0x40
+sSunfloraSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx18:
+.incbin "baserom.gba", 0xD43D4C, 0x40
+sSunfloraGfx18_1:
+.incbin "baserom.gba", 0xD43D8C, 0x60
+sSunfloraGfx18_2:
+.incbin "baserom.gba", 0xD43DEC, 0x60
+sSunfloraGfx18_3:
+.incbin "baserom.gba", 0xD43E4C, 0x40
+sSunfloraSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx19:
+.incbin "baserom.gba", 0xD43EDC, 0x40
+sSunfloraGfx19_1:
+.incbin "baserom.gba", 0xD43F1C, 0x80
+sSunfloraGfx19_2:
+.incbin "baserom.gba", 0xD43F9C, 0x60
+sSunfloraGfx19_3:
+.incbin "baserom.gba", 0xD43FFC, 0x40
+sSunfloraSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx20:
+.incbin "baserom.gba", 0xD4408C, 0x60
+sSunfloraGfx20_1:
+.incbin "baserom.gba", 0xD440EC, 0x60
+sSunfloraGfx20_2:
+.incbin "baserom.gba", 0xD4414C, 0x40
+sSunfloraGfx20_3:
+.incbin "baserom.gba", 0xD4418C, 0x40
+sSunfloraSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx20_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx21:
+.incbin "baserom.gba", 0xD4421C, 0x60
+sSunfloraGfx21_1:
+.incbin "baserom.gba", 0xD4427C, 0x60
+sSunfloraGfx21_2:
+.incbin "baserom.gba", 0xD442DC, 0x60
+sSunfloraGfx21_3:
+.incbin "baserom.gba", 0xD4433C, 0x60
+sSunfloraSprites21:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx21_3, 0x60
+ax_sprite_terminator
+sSunfloraGfx22:
+.incbin "baserom.gba", 0xD443E4, 0x40
+sSunfloraGfx22_1:
+.incbin "baserom.gba", 0xD44424, 0x40
+sSunfloraGfx22_2:
+.incbin "baserom.gba", 0xD44464, 0x80
+sSunfloraGfx22_3:
+.incbin "baserom.gba", 0xD444E4, 0x40
+sSunfloraSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx22_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx22_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx23:
+.incbin "baserom.gba", 0xD44574, 0x40
+sSunfloraGfx23_1:
+.incbin "baserom.gba", 0xD445B4, 0x60
+sSunfloraGfx23_2:
+.incbin "baserom.gba", 0xD44614, 0x60
+sSunfloraGfx23_3:
+.incbin "baserom.gba", 0xD44674, 0x40
+sSunfloraSprites23:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx24:
+.incbin "baserom.gba", 0xD44704, 0xA0
+sSunfloraSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx24, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunfloraGfx25:
+.incbin "baserom.gba", 0xD447C4, 0x60
+sSunfloraGfx25_1:
+.incbin "baserom.gba", 0xD44824, 0x60
+sSunfloraGfx25_2:
+.incbin "baserom.gba", 0xD44884, 0x60
+sSunfloraGfx25_3:
+.incbin "baserom.gba", 0xD448E4, 0x40
+sSunfloraSprites25:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx26:
+.incbin "baserom.gba", 0xD44974, 0xA0
+sSunfloraSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx26, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunfloraGfx27:
+.incbin "baserom.gba", 0xD44A34, 0x20
+sSunfloraGfx27_1:
+.incbin "baserom.gba", 0xD44A54, 0x80
+sSunfloraSprites27:
+ax_sprite sSunfloraGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx27_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunfloraGfx28:
+.incbin "baserom.gba", 0xD44AFC, 0xC0
+sSunfloraSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx28, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx29:
+.incbin "baserom.gba", 0xD44BDC, 0xA0
+sSunfloraSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx29, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunfloraGfx30:
+.incbin "baserom.gba", 0xD44C9C, 0x40
+sSunfloraGfx30_1:
+.incbin "baserom.gba", 0xD44CDC, 0x60
+sSunfloraSprites30:
+ax_sprite sSunfloraGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx31:
+.incbin "baserom.gba", 0xD44D64, 0x40
+sSunfloraSprites31:
+ax_sprite sSunfloraGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunfloraGfx32:
+.incbin "baserom.gba", 0xD44DBC, 0xC0
+sSunfloraSprites32:
+ax_sprite sSunfloraGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunfloraGfx33:
+.incbin "baserom.gba", 0xD44E94, 0x140
+sSunfloraGfx33_1:
+.incbin "baserom.gba", 0xD44FD4, 0x20
+sSunfloraSprites33:
+ax_sprite sSunfloraGfx33, 0x140
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx33_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSunfloraGfx34:
+.incbin "baserom.gba", 0xD4501C, 0x40
+sSunfloraGfx34_1:
+.incbin "baserom.gba", 0xD4505C, 0x80
+sSunfloraGfx34_2:
+.incbin "baserom.gba", 0xD450DC, 0x60
+sSunfloraGfx34_3:
+.incbin "baserom.gba", 0xD4513C, 0x40
+sSunfloraSprites34:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx34_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx35:
+.incbin "baserom.gba", 0xD451CC, 0x80
+sSunfloraGfx35_1:
+.incbin "baserom.gba", 0xD4524C, 0x60
+sSunfloraGfx35_2:
+.incbin "baserom.gba", 0xD452AC, 0x60
+sSunfloraGfx35_3:
+.incbin "baserom.gba", 0xD4530C, 0x40
+sSunfloraSprites35:
+ax_sprite sSunfloraGfx35, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx36:
+.incbin "baserom.gba", 0xD45394, 0xE0
+sSunfloraGfx36_1:
+.incbin "baserom.gba", 0xD45474, 0x60
+sSunfloraSprites36:
+ax_sprite 0, 0xa0
+ax_sprite sSunfloraGfx36, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx36_1, 0x60
+ax_sprite_terminator
+sSunfloraGfx37:
+.incbin "baserom.gba", 0xD454FC, 0x60
+sSunfloraGfx37_1:
+.incbin "baserom.gba", 0xD4555C, 0x60
+sSunfloraGfx37_2:
+.incbin "baserom.gba", 0xD455BC, 0x60
+sSunfloraSprites37:
+ax_sprite 0, 0xa0
+ax_sprite sSunfloraGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx37_2, 0x60
+ax_sprite_terminator
+sSunfloraGfx38:
+.incbin "baserom.gba", 0xD45654, 0x80
+sSunfloraGfx38_1:
+.incbin "baserom.gba", 0xD456D4, 0x40
+sSunfloraGfx38_2:
+.incbin "baserom.gba", 0xD45714, 0x40
+sSunfloraGfx38_3:
+.incbin "baserom.gba", 0xD45754, 0x40
+sSunfloraSprites38:
+ax_sprite sSunfloraGfx38, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx38_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx38_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx38_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx39:
+.incbin "baserom.gba", 0xD457DC, 0x60
+sSunfloraGfx39_1:
+.incbin "baserom.gba", 0xD4583C, 0x60
+sSunfloraGfx39_2:
+.incbin "baserom.gba", 0xD4589C, 0x60
+sSunfloraSprites39:
+ax_sprite 0, 0x80
+ax_sprite sSunfloraGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx40:
+.incbin "baserom.gba", 0xD4593C, 0x160
+sSunfloraSprites40:
+ax_sprite 0, 0x80
+ax_sprite sSunfloraGfx40, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx41:
+.incbin "baserom.gba", 0xD45ABC, 0x80
+sSunfloraGfx41_1:
+.incbin "baserom.gba", 0xD45B3C, 0x40
+sSunfloraGfx41_2:
+.incbin "baserom.gba", 0xD45B7C, 0x40
+sSunfloraGfx41_3:
+.incbin "baserom.gba", 0xD45BBC, 0x40
+sSunfloraSprites41:
+ax_sprite sSunfloraGfx41, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx41_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx41_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx41_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx42:
+.incbin "baserom.gba", 0xD45C44, 0x60
+sSunfloraGfx42_1:
+.incbin "baserom.gba", 0xD45CA4, 0x60
+sSunfloraGfx42_2:
+.incbin "baserom.gba", 0xD45D04, 0x60
+sSunfloraSprites42:
+ax_sprite 0, 0x80
+ax_sprite sSunfloraGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx43:
+.incbin "baserom.gba", 0xD45DA4, 0x20
+sSunfloraGfx43_1:
+.incbin "baserom.gba", 0xD45DC4, 0x20
+sSunfloraGfx43_2:
+.incbin "baserom.gba", 0xD45DE4, 0xE0
+sSunfloraSprites43:
+ax_sprite 0, 0x80
+ax_sprite sSunfloraGfx43, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx43_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx43_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx44:
+.incbin "baserom.gba", 0xD45F04, 0x80
+sSunfloraGfx44_1:
+.incbin "baserom.gba", 0xD45F84, 0x40
+sSunfloraGfx44_2:
+.incbin "baserom.gba", 0xD45FC4, 0x40
+sSunfloraGfx44_3:
+.incbin "baserom.gba", 0xD46004, 0x40
+sSunfloraSprites44:
+ax_sprite sSunfloraGfx44, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx44_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx44_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx44_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx45:
+.incbin "baserom.gba", 0xD4608C, 0x40
+sSunfloraGfx45_1:
+.incbin "baserom.gba", 0xD460CC, 0x60
+sSunfloraGfx45_2:
+.incbin "baserom.gba", 0xD4612C, 0x60
+sSunfloraGfx45_3:
+.incbin "baserom.gba", 0xD4618C, 0x40
+sSunfloraSprites45:
+ax_sprite sSunfloraGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx45_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx45_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx46:
+.incbin "baserom.gba", 0xD46214, 0x40
+sSunfloraGfx46_1:
+.incbin "baserom.gba", 0xD46254, 0x40
+sSunfloraGfx46_2:
+.incbin "baserom.gba", 0xD46294, 0x80
+sSunfloraGfx46_3:
+.incbin "baserom.gba", 0xD46314, 0x40
+sSunfloraSprites46:
+ax_sprite sSunfloraGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx46_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx46_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx46_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx47:
+.incbin "baserom.gba", 0xD4639C, 0x80
+sSunfloraGfx47_1:
+.incbin "baserom.gba", 0xD4641C, 0x60
+sSunfloraGfx47_2:
+.incbin "baserom.gba", 0xD4647C, 0x40
+sSunfloraGfx47_3:
+.incbin "baserom.gba", 0xD464BC, 0x40
+sSunfloraSprites47:
+ax_sprite sSunfloraGfx47, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx47_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx47_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx48:
+.incbin "baserom.gba", 0xD46544, 0x40
+sSunfloraGfx48_1:
+.incbin "baserom.gba", 0xD46584, 0x60
+sSunfloraGfx48_2:
+.incbin "baserom.gba", 0xD465E4, 0x40
+sSunfloraGfx48_3:
+.incbin "baserom.gba", 0xD46624, 0x40
+sSunfloraSprites48:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx48, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx48_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx48_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSunfloraGfx49:
+.incbin "baserom.gba", 0xD466B4, 0x40
+sSunfloraGfx49_1:
+.incbin "baserom.gba", 0xD466F4, 0x60
+sSunfloraGfx49_2:
+.incbin "baserom.gba", 0xD46754, 0x60
+sSunfloraGfx49_3:
+.incbin "baserom.gba", 0xD467B4, 0x60
+sSunfloraSprites49:
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx49, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSunfloraGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSunfloraGfx49_3, 0x60
+ax_sprite_terminator
+sSunfloraGfx50:
+.incbin "baserom.gba", 0xD4685C, 0x200
+sSunfloraSprites50:
+ax_sprite sSunfloraGfx50, 0x200
+ax_sprite_terminator
+sSunfloraGfx51:
+.incbin "baserom.gba", 0xD46A6C, 0x200
+sSunfloraSprites51:
+ax_sprite sSunfloraGfx51, 0x200
+ax_sprite_terminator
+sSunfloraGfx52:
+.incbin "baserom.gba", 0xD46C7C, 0x200
+sSunfloraSprites52:
+ax_sprite sSunfloraGfx52, 0x200
+ax_sprite_terminator
+sSunfloraGfx53:
+.incbin "baserom.gba", 0xD46E8C, 0x200
+sSunfloraSprites53:
+ax_sprite sSunfloraGfx53, 0x200
+ax_sprite_terminator
+sSunfloraGfx54:
+.incbin "baserom.gba", 0xD4709C, 0x200
+sSunfloraSprites54:
+ax_sprite sSunfloraGfx54, 0x200
+ax_sprite_terminator
+sSunfloraGfx55:
+.incbin "baserom.gba", 0xD472AC, 0x200
+sSunfloraSprites55:
+ax_sprite sSunfloraGfx55, 0x200
+ax_sprite_terminator
+sSunfloraGfx56:
+.incbin "baserom.gba", 0xD474BC, 0x200
+sSunfloraSprites56:
+ax_sprite sSunfloraGfx56, 0x200
+ax_sprite_terminator
+sAxPosesSunflora:
+.4byte sSunfloraPose1
+.4byte sSunfloraPose2
+.4byte sSunfloraPose3
+.4byte sSunfloraPose4
+.4byte sSunfloraPose5
+.4byte sSunfloraPose6
+.4byte sSunfloraPose7
+.4byte sSunfloraPose8
+.4byte sSunfloraPose9
+.4byte sSunfloraPose10
+.4byte sSunfloraPose11
+.4byte sSunfloraPose12
+.4byte sSunfloraPose13
+.4byte sSunfloraPose14
+.4byte sSunfloraPose15
+.4byte sSunfloraPose16
+.4byte sSunfloraPose17
+.4byte sSunfloraPose18
+.4byte sSunfloraPose19
+.4byte sSunfloraPose20
+.4byte sSunfloraPose21
+.4byte sSunfloraPose22
+.4byte sSunfloraPose23
+.4byte sSunfloraPose24
+.4byte sSunfloraPose25
+.4byte sSunfloraPose26
+.4byte sSunfloraPose27
+.4byte sSunfloraPose28
+.4byte sSunfloraPose29
+.4byte sSunfloraPose30
+.4byte sSunfloraPose31
+.4byte sSunfloraPose32
+.4byte sSunfloraPose33
+.4byte sSunfloraPose34
+.4byte sSunfloraPose35
+.4byte sSunfloraPose36
+.4byte sSunfloraPose37
+.4byte sSunfloraPose38
+.4byte sSunfloraPose39
+.4byte sSunfloraPose40
+.4byte sSunfloraPose41
+.4byte sSunfloraPose42
+.4byte sSunfloraPose43
+.4byte sSunfloraPose44
+.4byte sSunfloraPose45
+.4byte sSunfloraPose46
+.4byte sSunfloraPose47
+.4byte sSunfloraPose48
+.4byte sSunfloraPose49
+.4byte sSunfloraPose50
+.4byte sSunfloraPose51
+.4byte sSunfloraPose52
+.4byte sSunfloraPose53
+.4byte sSunfloraPose54
+.4byte sSunfloraPose55
+.4byte sSunfloraPose56
+.4byte sSunfloraPose57
+.4byte sSunfloraPose58
+.4byte sSunfloraPose59
+.4byte sSunfloraPose60
+.4byte sSunfloraPose61
+.4byte sSunfloraPose62
+.4byte sSunfloraPose63
+.4byte sSunfloraPose64
+.4byte sSunfloraPose65
+.4byte sSunfloraPose66
+.4byte sSunfloraPose67
+.4byte sSunfloraPose68
+.4byte sSunfloraPose69
+.4byte sSunfloraPose70
+.4byte sSunfloraPose71
+.4byte sSunfloraPose72
+.4byte sSunfloraPose73
+.4byte sSunfloraPose74
+.4byte sSunfloraPose75
+.4byte sSunfloraPose76
+.4byte sSunfloraPose77
+.4byte sSunfloraPose78
+.4byte sSunfloraPose79
+.4byte sSunfloraPose80
+.4byte sSunfloraPose81
+.4byte sSunfloraPose82
+.4byte sSunfloraPose83
+.4byte sSunfloraPose84
+.4byte sSunfloraPose85
+.4byte sSunfloraPose86
+.4byte sSunfloraPose87
+.4byte sSunfloraPose88
+.4byte sSunfloraPose89
+.4byte sSunfloraPose90
+.4byte sSunfloraPose91
+.4byte sSunfloraPose92
+.4byte sSunfloraPose93
+.4byte sSunfloraPose94
+.4byte sSunfloraPose95
+.4byte sSunfloraPose96
+.4byte sSunfloraPose97
+.4byte sSunfloraPose98
+.4byte sSunfloraPose99
+.4byte sSunfloraPose100
+.4byte sSunfloraPose101
+.4byte sSunfloraPose102
+.4byte sSunfloraPose103
+.4byte sSunfloraPose104
+.4byte sSunfloraPose105
+.4byte sSunfloraPose106
+.4byte sSunfloraPose107
+.4byte sSunfloraPose108
+.4byte sSunfloraPose109
+.4byte sSunfloraPose110
+.4byte sSunfloraPose111
+.4byte sSunfloraPose112
+.4byte sSunfloraPose113
+.4byte sSunfloraPose114
+.4byte sSunfloraPose115
+.4byte sSunfloraPose116
+.4byte sSunfloraPose117
+.4byte sSunfloraPose118
+.4byte sSunfloraPose119
+.4byte sSunfloraPose120
+.4byte sSunfloraPose121
+.4byte sSunfloraPose122
+.4byte sSunfloraPose123
+.4byte sSunfloraPose124
+.4byte sSunfloraPose125
+.4byte sSunfloraPose126
+.4byte sSunfloraPose127
+.4byte sSunfloraPose128
+.4byte sSunfloraPose129
+.4byte sSunfloraPose130
+.4byte sSunfloraPose131
+.4byte sSunfloraPose132
+.4byte sSunfloraPose133
+.4byte sSunfloraPose134
+.4byte sSunfloraPose135
+.4byte sSunfloraPose136
+.4byte sSunfloraPose137
+.4byte sSunfloraPose138
+.4byte sSunfloraPose139
+.4byte sSunfloraPose140
+.4byte sSunfloraPose141
+.4byte sSunfloraPose142
+.4byte sSunfloraPose143
+.4byte sSunfloraPose144
+.4byte sSunfloraPose145
+.4byte sSunfloraPose146
+.4byte sSunfloraPose147
+.4byte sSunfloraPose148
+.4byte sSunfloraPose149
+.4byte sSunfloraPose150
+.4byte sSunfloraPose151
+.4byte sSunfloraPose152
+.4byte sSunfloraPose153
+.4byte sSunfloraPose154
+.4byte sSunfloraPose155
+.4byte sSunfloraPose156
+.4byte sSunfloraPose157
+.4byte sSunfloraPose158
+.4byte sSunfloraPose159
+.4byte sSunfloraPose160
+.4byte sSunfloraPose161
+.4byte sSunfloraPose162
+.4byte sSunfloraPose163
+.4byte sSunfloraPose164
+.4byte sSunfloraPose165
+.4byte sSunfloraPose166
+.4byte sSunfloraPose167
+.4byte sSunfloraPose168
+.4byte sSunfloraPose169
+.4byte sSunfloraPose170
+.4byte sSunfloraPose171
+.4byte sSunfloraPose172
+.4byte sSunfloraPose173
+.4byte sSunfloraPose174
+.4byte sSunfloraPose175
+.4byte sSunfloraPose176
+.4byte sSunfloraPose177
+.4byte sSunfloraPose178
+.4byte sSunfloraPose179
+.4byte sSunfloraPose180
+.4byte sSunfloraPose181
+.4byte sSunfloraPose182
+.4byte sSunfloraPose183
+.4byte sSunfloraPose184
+.4byte sSunfloraPose185
+.4byte sSunfloraPose186
+.4byte sSunfloraPose187
+.4byte sSunfloraPose188
+.4byte sSunfloraPose189
+.4byte sSunfloraPose190
+.4byte sSunfloraPose191
+.4byte sSunfloraPose192
+.4byte sSunfloraPose193
+.4byte sSunfloraPose194
+.4byte sSunfloraPose195
+.4byte sSunfloraPose196
+.4byte sSunfloraPose197
+.4byte sSunfloraPose198
+.4byte sSunfloraPose199
+.4byte sSunfloraPose200
+.4byte sSunfloraPose201
+.4byte sSunfloraPose202
+.4byte sSunfloraPose203
+.4byte sSunfloraPose204
+.4byte sSunfloraPose205
+.4byte sSunfloraPose206
+.4byte sSunfloraPose207
+.4byte sSunfloraPose208
+.4byte sSunfloraPose209
+.4byte sSunfloraPose210
+.4byte sSunfloraPose211
+.4byte sSunfloraPose212
+.4byte sSunfloraPose213
+.4byte sSunfloraPose214
+.4byte sSunfloraPose215
+.4byte sSunfloraPose216
+.4byte sSunfloraPose217
+.4byte sSunfloraPose218
+.4byte sSunfloraPose219
+.4byte sSunfloraPose220
+.4byte sSunfloraPose221
+.4byte sSunfloraPose222
+.4byte sSunfloraPose223
+.4byte sSunfloraPose224
+.4byte sSunfloraPose225
+.4byte sSunfloraPose226
+.4byte sSunfloraPose227
+.4byte sSunfloraPose228
+.4byte sSunfloraPose229
+.4byte sSunfloraPose230
+.4byte sSunfloraPose231
+.4byte sSunfloraPose232
+.4byte sSunfloraPose233
+.4byte sSunfloraPose234
+.4byte sSunfloraPose235
+.4byte sSunfloraPose236
+.4byte sSunfloraPose237
+.4byte sSunfloraPose238
+.4byte sSunfloraPose239
+.4byte sSunfloraPose240
+.4byte sSunfloraPose241
+.4byte sSunfloraPose242
+sAxPositionsSunflora:
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    2,  -13, 	  -6,  -10, 	   8,   -4, 	   2,   -9
+.2byte   -4,  -13, 	 -10,   -4, 	   5,  -10, 	  -3,   -9
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+.2byte    3,  -13, 	   3,   -9, 	  -7,   -4, 	  -1,  -10
+.2byte    7,  -13, 	   6,   -6, 	  -5,  -10, 	   2,   -9
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    7,  -11, 	   1,  -11, 	  -6,   -7, 	  -2,   -8
+.2byte    8,  -16, 	  -6,   -8, 	   1,  -11, 	  -2,  -10
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    6,  -13, 	  -5,  -13, 	   5,   -3, 	  -1,   -8
+.2byte    1,  -14, 	  -8,   -6, 	   5,  -10, 	  -3,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte   -3,  -14, 	   9,  -10, 	  -7,   -5, 	   0,   -8
+.2byte    2,  -14, 	   7,   -5, 	  -9,  -10, 	  -1,   -8
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte   -7,  -13, 	   4,  -13, 	  -6,   -3, 	   0,   -8
+.2byte   -2,  -14, 	   7,   -6, 	  -6,  -10, 	   2,   -8
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -8,  -11, 	  -2,  -11, 	   5,   -7, 	   1,   -8
+.2byte   -9,  -16, 	   5,   -8, 	  -2,  -11, 	   1,  -10
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	  -4,   -9, 	   6,   -4, 	   0,  -10
+.2byte   -8,  -13, 	  -7,   -6, 	   4,  -10, 	  -3,   -9
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    2,  -13, 	  -6,  -10, 	   8,   -4, 	   2,   -9
+.2byte   -4,  -13, 	 -10,   -4, 	   5,  -10, 	  -3,   -9
+.2byte   -2,  -11, 	  -7,   -7, 	   2,   -1, 	   0,   -7
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+.2byte    3,  -13, 	   3,   -9, 	  -7,   -4, 	  -1,  -10
+.2byte    7,  -13, 	   6,   -6, 	  -5,  -10, 	   2,   -9
+.2byte    5,  -12, 	   2,   -8, 	   3,   -1, 	   1,   -5
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    7,  -11, 	   1,  -11, 	  -6,   -7, 	  -2,   -8
+.2byte    8,  -16, 	  -6,   -8, 	   1,  -11, 	  -2,  -10
+.2byte    8,  -16, 	  -4,  -13, 	   5,   -5, 	  -1,   -8
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    6,  -13, 	  -5,  -13, 	   5,   -3, 	  -1,   -8
+.2byte    1,  -14, 	  -8,   -6, 	   5,  -10, 	  -3,   -8
+.2byte    5,  -14, 	  -6,  -14, 	   1,   -6, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte   -3,  -14, 	   9,  -10, 	  -7,   -5, 	   0,   -8
+.2byte    2,  -14, 	   7,   -5, 	  -9,  -10, 	  -1,   -8
+.2byte    1,  -15, 	  -4,   -5, 	  -6,  -11, 	   0,   -7
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte   -7,  -13, 	   4,  -13, 	  -6,   -3, 	   0,   -8
+.2byte   -2,  -14, 	   7,   -6, 	  -6,  -10, 	   2,   -8
+.2byte   -2,  -15, 	   0,   -7, 	  -7,  -12, 	   0,   -9
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -8,  -11, 	  -2,  -11, 	   5,   -7, 	   1,   -8
+.2byte   -9,  -16, 	   5,   -8, 	  -2,  -11, 	   1,  -10
+.2byte   -8,  -14, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	  -4,   -9, 	   6,   -4, 	   0,  -10
+.2byte   -8,  -13, 	  -7,   -6, 	   4,  -10, 	  -3,   -9
+.2byte   -4,  -12, 	  -4,   -2, 	   7,   -8, 	   0,   -7
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    2,  -13, 	  -6,  -10, 	   8,   -4, 	   2,   -9
+.2byte   -4,  -13, 	 -10,   -4, 	   5,  -10, 	  -3,   -9
+.2byte    1,  -11, 	   6,   -7, 	  -3,   -1, 	  -1,   -7
+.2byte    1,  -11, 	  -3,   -1, 	   7,   -8, 	   0,   -7
+.2byte   -2,  -11, 	   2,   -1, 	  -8,   -8, 	  -1,   -7
+.2byte   -2,  -11, 	  -7,   -7, 	   2,   -1, 	   0,   -7
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+.2byte    7,  -13, 	   6,   -6, 	  -5,  -10, 	   2,   -9
+.2byte    3,  -13, 	   3,   -9, 	  -7,   -4, 	  -1,  -10
+.2byte    5,  -12, 	   2,   -8, 	   3,   -1, 	   1,   -5
+.2byte    5,  -12, 	   2,   -8, 	   3,   -1, 	   1,   -5
+.2byte    3,  -12, 	   3,   -2, 	  -8,   -8, 	  -1,   -7
+.2byte    3,  -12, 	   3,   -2, 	  -8,   -8, 	  -1,   -7
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    8,  -15, 	  -6,   -7, 	   1,  -10, 	  -2,   -9
+.2byte    7,  -11, 	   1,  -11, 	  -6,   -7, 	  -2,   -8
+.2byte    8,  -16, 	  -4,  -13, 	   5,   -5, 	  -1,   -8
+.2byte    8,  -16, 	  -4,  -13, 	   5,   -5, 	  -1,   -8
+.2byte    7,  -14, 	   6,   -6, 	  -6,   -6, 	   0,   -7
+.2byte    7,  -14, 	   6,   -6, 	  -6,   -6, 	   0,   -7
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    1,  -14, 	  -8,   -6, 	   5,  -10, 	  -3,   -8
+.2byte    6,  -13, 	  -5,  -13, 	   5,   -3, 	  -1,   -8
+.2byte    5,  -14, 	  -6,  -14, 	   1,   -6, 	   0,   -8
+.2byte    5,  -14, 	  -6,  -14, 	   1,   -6, 	   0,   -8
+.2byte    1,  -15, 	  -1,   -7, 	   6,  -12, 	  -1,   -9
+.2byte    1,  -15, 	  -1,   -7, 	   6,  -12, 	  -1,   -9
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte   -3,  -14, 	   9,  -10, 	  -7,   -5, 	   0,   -8
+.2byte    2,  -14, 	   7,   -5, 	  -9,  -10, 	  -1,   -8
+.2byte    1,  -15, 	  -4,   -5, 	  -6,  -11, 	   0,   -7
+.2byte    1,  -15, 	  -4,   -5, 	  -6,  -11, 	   0,   -7
+.2byte   -3,  -15, 	   6,  -12, 	   3,   -5, 	  -1,   -7
+.2byte   -3,  -15, 	   6,  -12, 	   3,   -5, 	  -1,   -7
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte   -7,  -13, 	   4,  -13, 	  -6,   -3, 	   0,   -8
+.2byte   -2,  -14, 	   7,   -6, 	  -6,  -10, 	   2,   -8
+.2byte   -2,  -15, 	   0,   -7, 	  -7,  -12, 	   0,   -9
+.2byte   -2,  -15, 	   0,   -7, 	  -7,  -12, 	   0,   -9
+.2byte   -6,  -14, 	   5,  -14, 	  -2,   -6, 	  -1,   -8
+.2byte   -6,  -14, 	   5,  -14, 	  -2,   -6, 	  -1,   -8
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -8,  -11, 	  -2,  -11, 	   5,   -7, 	   1,   -8
+.2byte   -9,  -15, 	   5,   -7, 	  -2,  -10, 	   1,   -9
+.2byte   -8,  -14, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -8,  -14, 	  -7,   -6, 	   5,   -6, 	  -1,   -7
+.2byte   -9,  -16, 	   3,  -13, 	  -6,   -5, 	   0,   -8
+.2byte   -9,  -16, 	   3,  -13, 	  -6,   -5, 	   0,   -8
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -4,  -13, 	  -4,   -9, 	   6,   -4, 	   0,  -10
+.2byte   -8,  -13, 	  -7,   -6, 	   4,  -10, 	  -3,   -9
+.2byte   -4,  -12, 	  -4,   -2, 	   7,   -8, 	   0,   -7
+.2byte   -4,  -12, 	  -4,   -2, 	   7,   -8, 	   0,   -7
+.2byte   -6,  -12, 	  -3,   -8, 	  -4,   -1, 	  -2,   -5
+.2byte   -6,  -12, 	  -3,   -8, 	  -4,   -1, 	  -2,   -5
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    0,  -23, 	  -7,  -12, 	   6,  -12, 	  -1,  -10
+.2byte    1,    0, 	  -8,   -9, 	   8,  -10, 	   1,   -9
+.2byte    0,    0, 	  -7,  -15, 	   7,  -15, 	   1,  -10
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+.2byte    1,  -24, 	   5,  -12, 	  -2,  -11, 	   1,   -8
+.2byte    9,   -1, 	   3,  -11, 	  -6,   -5, 	  -1,   -9
+.2byte    9,   -1, 	  -1,  -16, 	 -10,  -12, 	  -1,   -9
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    1,  -25, 	   3,  -14, 	   2,  -11, 	   0,   -9
+.2byte   13,   -7, 	   1,  -12, 	   0,   -4, 	  -2,   -7
+.2byte   13,   -5, 	  -6,  -11, 	  -7,   -6, 	  -2,   -7
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    1,  -25, 	  -5,  -14, 	   4,  -11, 	  -1,   -8
+.2byte    6,  -10, 	  -5,  -10, 	   3,   -4, 	  -2,   -6
+.2byte    7,  -10, 	 -10,   -5, 	  -2,    1, 	  -3,   -6
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte   -1,  -26, 	   5,  -14, 	  -6,  -14, 	  -1,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -5,  -11, 	   0,   -8
+.2byte   -1,  -13, 	   6,   -5, 	  -7,   -5, 	  -1,   -8
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte   -2,  -25, 	   4,  -14, 	  -5,  -11, 	   0,   -8
+.2byte   -7,  -10, 	   4,  -10, 	  -4,   -4, 	   1,   -6
+.2byte   -8,  -10, 	   9,   -5, 	   1,    1, 	   2,   -6
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -2,  -25, 	  -4,  -14, 	  -3,  -11, 	  -1,   -9
+.2byte  -14,   -7, 	  -2,  -12, 	  -1,   -4, 	   1,   -7
+.2byte  -14,   -5, 	   5,  -11, 	   6,   -6, 	   1,   -7
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -2,  -24, 	  -6,  -12, 	   1,  -11, 	  -2,   -8
+.2byte  -10,   -1, 	  -4,  -11, 	   5,   -5, 	   0,   -9
+.2byte  -10,   -1, 	   0,  -16, 	   9,  -12, 	   0,   -9
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+.2byte   -1,  -10, 	  -9,   -5, 	   8,   -5, 	   0,   -7
+.2byte   -1,   -9, 	 -10,   -4, 	   9,   -4, 	  -1,   -6
+.2byte    1,  -13, 	   8,   -7, 	  -7,   -7, 	   0,   -7
+.2byte   -8,   -8, 	  -7,   -6, 	   5,  -11, 	  -3,  -10
+.2byte  -15,  -16, 	   1,  -13, 	  -3,   -7, 	  -1,   -9
+.2byte   -9,  -13, 	  -1,  -14, 	   7,  -12, 	   3,   -9
+.2byte   -1,  -14, 	   8,   -9, 	  -9,   -8, 	   0,   -7
+.2byte    8,  -13, 	   0,  -14, 	  -8,  -12, 	  -4,   -9
+.2byte   14,  -16, 	  -2,  -13, 	   2,   -7, 	   0,   -9
+.2byte    7,   -8, 	   6,   -6, 	  -6,  -11, 	   2,  -10
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    0,  -13, 	  -8,  -10, 	   6,   -4, 	   0,   -9
+.2byte   -2,  -13, 	  -8,   -4, 	   7,  -10, 	  -1,   -9
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+.2byte    4,  -13, 	   4,   -9, 	  -6,   -4, 	   0,  -10
+.2byte    6,  -13, 	   5,   -6, 	  -6,  -10, 	   1,   -9
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    8,  -12, 	   2,  -12, 	  -5,   -8, 	  -1,   -9
+.2byte    8,  -15, 	  -6,   -7, 	   1,  -10, 	  -2,   -9
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    6,  -13, 	  -5,  -13, 	   5,   -3, 	  -1,   -8
+.2byte    2,  -14, 	  -7,   -6, 	   6,  -10, 	  -2,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte   -3,  -14, 	   9,  -10, 	  -7,   -5, 	   0,   -8
+.2byte    2,  -14, 	   7,   -5, 	  -9,  -10, 	  -1,   -8
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte   -7,  -13, 	   4,  -13, 	  -6,   -3, 	   0,   -8
+.2byte   -4,  -14, 	   5,   -6, 	  -8,  -10, 	   0,   -8
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -9,  -12, 	  -3,  -12, 	   4,   -8, 	   0,   -9
+.2byte   -9,  -15, 	   5,   -7, 	  -2,  -10, 	   1,   -9
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -5,  -13, 	  -5,   -9, 	   5,   -4, 	  -1,  -10
+.2byte   -6,  -13, 	  -5,   -6, 	   6,  -10, 	  -1,   -9
+.2byte    0,    4, 	  -7,  -11, 	   7,  -11, 	   1,   -6
+.2byte   -9,    1, 	   1,  -14, 	  10,  -10, 	   1,   -7
+.2byte  -13,   -3, 	   6,   -9, 	   7,   -4, 	   2,   -5
+.2byte  -10,  -10, 	   7,   -5, 	  -1,    1, 	   0,   -6
+.2byte   -1,   -9, 	   6,   -1, 	  -7,   -1, 	  -1,   -4
+.2byte    9,  -10, 	  -8,   -5, 	   0,    1, 	  -1,   -6
+.2byte   12,   -3, 	  -7,   -9, 	  -8,   -4, 	  -3,   -5
+.2byte    8,    1, 	  -2,  -14, 	 -11,  -10, 	  -2,   -7
+.2byte   -2,  -11, 	  -7,   -7, 	   2,   -1, 	   0,   -7
+.2byte    4,  -13, 	   1,   -9, 	   2,   -2, 	   0,   -6
+.2byte    7,  -15, 	  -5,  -12, 	   4,   -4, 	  -2,   -7
+.2byte    4,  -13, 	  -7,  -13, 	   0,   -5, 	  -1,   -7
+.2byte    1,  -14, 	  -4,   -4, 	  -6,  -10, 	   0,   -6
+.2byte   -3,  -14, 	  -1,   -6, 	  -8,  -11, 	  -1,   -8
+.2byte   -8,  -13, 	  -7,   -5, 	   5,   -5, 	  -1,   -6
+.2byte   -4,  -12, 	  -4,   -2, 	   7,   -8, 	   0,   -7
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte    0,  -23, 	  -7,  -12, 	   6,  -12, 	  -1,  -10
+.2byte    0,    0, 	  -9,   -9, 	   7,  -10, 	   0,   -9
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+.2byte    1,  -24, 	   5,  -12, 	  -2,  -11, 	   1,   -8
+.2byte    9,   -1, 	   3,  -11, 	  -6,   -5, 	  -1,   -9
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    1,  -25, 	   3,  -14, 	   2,  -11, 	   0,   -9
+.2byte   13,   -7, 	   1,  -12, 	   0,   -4, 	  -2,   -7
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    1,  -25, 	  -5,  -14, 	   4,  -11, 	  -1,   -8
+.2byte    7,  -11, 	  -4,  -11, 	   4,   -5, 	  -1,   -7
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte   -1,  -26, 	   5,  -14, 	  -6,  -14, 	  -1,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -5,  -11, 	   0,   -8
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte   -2,  -25, 	   4,  -14, 	  -5,  -11, 	   0,   -8
+.2byte   -8,  -11, 	   3,  -11, 	  -5,   -5, 	   0,   -7
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -2,  -25, 	  -4,  -14, 	  -3,  -11, 	  -1,   -9
+.2byte  -14,   -7, 	  -2,  -12, 	  -1,   -4, 	   1,   -7
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -2,  -24, 	  -6,  -12, 	   1,  -11, 	  -2,   -8
+.2byte  -10,   -1, 	  -4,  -11, 	   5,   -5, 	   0,   -9
+.2byte    0,  -23, 	  -7,  -12, 	   6,  -12, 	  -1,  -10
+.2byte   -1,  -24, 	  -5,  -12, 	   2,  -11, 	  -1,   -8
+.2byte   -1,  -24, 	  -3,  -13, 	  -2,  -10, 	   0,   -8
+.2byte   -2,  -25, 	   4,  -14, 	  -5,  -11, 	   0,   -8
+.2byte   -1,  -25, 	   5,  -13, 	  -6,  -13, 	  -1,   -9
+.2byte    1,  -25, 	  -5,  -14, 	   4,  -11, 	  -1,   -8
+.2byte    0,  -25, 	   2,  -14, 	   1,  -11, 	  -1,   -9
+.2byte    1,  -24, 	   5,  -12, 	  -2,  -11, 	   1,   -8
+.2byte   -1,  -12, 	  -9,   -6, 	   8,   -6, 	   0,   -9
+.2byte   -6,  -12, 	  -5,   -8, 	   5,   -5, 	  -1,   -9
+.2byte   -9,  -14, 	   2,  -10, 	   2,   -4, 	   0,   -8
+.2byte   -5,  -14, 	   6,  -10, 	  -6,   -5, 	   0,   -8
+.2byte    0,  -15, 	   8,   -8, 	  -9,   -8, 	  -1,   -6
+.2byte    4,  -14, 	  -7,  -10, 	   5,   -5, 	  -1,   -8
+.2byte    8,  -14, 	  -3,  -10, 	  -3,   -4, 	  -1,   -8
+.2byte    5,  -12, 	   4,   -8, 	  -6,   -5, 	   0,   -9
+sSunfloraAnimTable1:
+.4byte sSunfloraAnims_1_1
+.4byte sSunfloraAnims_1_2
+.4byte sSunfloraAnims_1_3
+.4byte sSunfloraAnims_1_4
+.4byte sSunfloraAnims_1_5
+.4byte sSunfloraAnims_1_6
+.4byte sSunfloraAnims_1_7
+.4byte sSunfloraAnims_1_8
+sSunfloraAnimTable2:
+.4byte sSunfloraAnims_2_1
+.4byte sSunfloraAnims_2_2
+.4byte sSunfloraAnims_2_3
+.4byte sSunfloraAnims_2_4
+.4byte sSunfloraAnims_2_5
+.4byte sSunfloraAnims_2_6
+.4byte sSunfloraAnims_2_7
+.4byte sSunfloraAnims_2_8
+sSunfloraAnimTable3:
+.4byte sSunfloraAnims_3_1
+.4byte sSunfloraAnims_3_2
+.4byte sSunfloraAnims_3_3
+.4byte sSunfloraAnims_3_4
+.4byte sSunfloraAnims_3_5
+.4byte sSunfloraAnims_3_6
+.4byte sSunfloraAnims_3_7
+.4byte sSunfloraAnims_3_8
+sSunfloraAnimTable4:
+.4byte sSunfloraAnims_4_1
+.4byte sSunfloraAnims_4_2
+.4byte sSunfloraAnims_4_3
+.4byte sSunfloraAnims_4_4
+.4byte sSunfloraAnims_4_5
+.4byte sSunfloraAnims_4_6
+.4byte sSunfloraAnims_4_7
+.4byte sSunfloraAnims_4_8
+sSunfloraAnimTable5:
+.4byte sSunfloraAnims_5_1
+.4byte sSunfloraAnims_5_2
+.4byte sSunfloraAnims_5_3
+.4byte sSunfloraAnims_5_4
+.4byte sSunfloraAnims_5_5
+.4byte sSunfloraAnims_5_6
+.4byte sSunfloraAnims_5_7
+.4byte sSunfloraAnims_5_8
+sSunfloraAnimTable6:
+.4byte sSunfloraAnims_6_1
+.4byte sSunfloraAnims_6_1
+.4byte sSunfloraAnims_6_1
+.4byte sSunfloraAnims_6_1
+.4byte sSunfloraAnims_6_1
+.4byte sSunfloraAnims_6_1
+.4byte sSunfloraAnims_6_1
+.4byte sSunfloraAnims_6_1
+sSunfloraAnimTable7:
+.4byte sSunfloraAnims_7_1
+.4byte sSunfloraAnims_7_2
+.4byte sSunfloraAnims_7_3
+.4byte sSunfloraAnims_7_4
+.4byte sSunfloraAnims_7_5
+.4byte sSunfloraAnims_7_6
+.4byte sSunfloraAnims_7_7
+.4byte sSunfloraAnims_7_8
+sSunfloraAnimTable8:
+.4byte sSunfloraAnims_8_1
+.4byte sSunfloraAnims_8_2
+.4byte sSunfloraAnims_8_3
+.4byte sSunfloraAnims_8_4
+.4byte sSunfloraAnims_8_5
+.4byte sSunfloraAnims_8_6
+.4byte sSunfloraAnims_8_7
+.4byte sSunfloraAnims_8_8
+sSunfloraAnimTable9:
+.4byte sSunfloraAnims_9_1
+.4byte sSunfloraAnims_9_2
+.4byte sSunfloraAnims_9_3
+.4byte sSunfloraAnims_9_4
+.4byte sSunfloraAnims_9_5
+.4byte sSunfloraAnims_9_6
+.4byte sSunfloraAnims_9_7
+.4byte sSunfloraAnims_9_8
+sSunfloraAnimTable10:
+.4byte sSunfloraAnims_10_1
+.4byte sSunfloraAnims_10_2
+.4byte sSunfloraAnims_10_3
+.4byte sSunfloraAnims_10_4
+.4byte sSunfloraAnims_10_5
+.4byte sSunfloraAnims_10_6
+.4byte sSunfloraAnims_10_7
+.4byte sSunfloraAnims_10_8
+sSunfloraAnimTable11:
+.4byte sSunfloraAnims_11_1
+.4byte sSunfloraAnims_11_2
+.4byte sSunfloraAnims_11_3
+.4byte sSunfloraAnims_11_4
+.4byte sSunfloraAnims_11_5
+.4byte sSunfloraAnims_11_6
+.4byte sSunfloraAnims_11_7
+.4byte sSunfloraAnims_11_8
+sSunfloraAnimTable12:
+.4byte sSunfloraAnims_12_1
+.4byte sSunfloraAnims_12_2
+.4byte sSunfloraAnims_12_3
+.4byte sSunfloraAnims_12_4
+.4byte sSunfloraAnims_12_5
+.4byte sSunfloraAnims_12_6
+.4byte sSunfloraAnims_12_7
+.4byte sSunfloraAnims_12_8
+sSunfloraAnimTable13:
+.4byte sSunfloraAnims_13_1
+.4byte sSunfloraAnims_13_2
+.4byte sSunfloraAnims_13_3
+.4byte sSunfloraAnims_13_4
+.4byte sSunfloraAnims_13_5
+.4byte sSunfloraAnims_13_6
+.4byte sSunfloraAnims_13_7
+.4byte sSunfloraAnims_13_8
+sAxAnimationsSunflora:
+.4byte sSunfloraAnimTable1
+.4byte sSunfloraAnimTable2
+.4byte sSunfloraAnimTable3
+.4byte sSunfloraAnimTable4
+.4byte sSunfloraAnimTable5
+.4byte sSunfloraAnimTable6
+.4byte sSunfloraAnimTable7
+.4byte sSunfloraAnimTable8
+.4byte sSunfloraAnimTable9
+.4byte sSunfloraAnimTable10
+.4byte sSunfloraAnimTable11
+.4byte sSunfloraAnimTable12
+.4byte sSunfloraAnimTable13
+sAxSpritesSunflora:
+.4byte sSunfloraSprites1
+.4byte sSunfloraSprites2
+.4byte sSunfloraSprites3
+.4byte sSunfloraSprites4
+.4byte sSunfloraSprites5
+.4byte sSunfloraSprites6
+.4byte sSunfloraSprites7
+.4byte sSunfloraSprites8
+.4byte sSunfloraSprites9
+.4byte sSunfloraSprites10
+.4byte sSunfloraSprites11
+.4byte sSunfloraSprites12
+.4byte sSunfloraSprites13
+.4byte sSunfloraSprites14
+.4byte sSunfloraSprites15
+.4byte sSunfloraSprites16
+.4byte sSunfloraSprites17
+.4byte sSunfloraSprites18
+.4byte sSunfloraSprites19
+.4byte sSunfloraSprites20
+.4byte sSunfloraSprites21
+.4byte sSunfloraSprites22
+.4byte sSunfloraSprites23
+.4byte sSunfloraSprites24
+.4byte sSunfloraSprites25
+.4byte sSunfloraSprites26
+.4byte sSunfloraSprites27
+.4byte sSunfloraSprites28
+.4byte sSunfloraSprites29
+.4byte sSunfloraSprites30
+.4byte sSunfloraSprites31
+.4byte sSunfloraSprites32
+.4byte sSunfloraSprites33
+.4byte sSunfloraSprites34
+.4byte sSunfloraSprites35
+.4byte sSunfloraSprites36
+.4byte sSunfloraSprites37
+.4byte sSunfloraSprites38
+.4byte sSunfloraSprites39
+.4byte sSunfloraSprites40
+.4byte sSunfloraSprites41
+.4byte sSunfloraSprites42
+.4byte sSunfloraSprites43
+.4byte sSunfloraSprites44
+.4byte sSunfloraSprites45
+.4byte sSunfloraSprites46
+.4byte sSunfloraSprites47
+.4byte sSunfloraSprites48
+.4byte sSunfloraSprites49
+.4byte sSunfloraSprites50
+.4byte sSunfloraSprites51
+.4byte sSunfloraSprites52
+.4byte sSunfloraSprites53
+.4byte sSunfloraSprites54
+.4byte sSunfloraSprites55
+.4byte sSunfloraSprites56
+sAxMainSunflora:
+ax_main sAxPosesSunflora, sAxAnimationsSunflora, 13, sAxSpritesSunflora, sAxPositionsSunflora

--- a/data/ax/sunkern.inc
+++ b/data/ax/sunkern.inc
@@ -1,0 +1,2393 @@
+.global gAxSunkern
+gAxSunkern:
+ax_siro sAxMainSunkern
+sSunkernPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose4:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose5:
+ax_pose 4, 0x01ea, 0x90e7, 0x3c00
+ax_pose_terminator
+sSunkernPose6:
+ax_pose 5, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose7:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose8:
+ax_pose 7, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose9:
+ax_pose 8, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose10:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose11:
+ax_pose 10, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose12:
+ax_pose 11, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose16:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose17:
+ax_pose 10, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose18:
+ax_pose 11, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose19:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose20:
+ax_pose 7, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose21:
+ax_pose 8, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose22:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose23:
+ax_pose 4, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose24:
+ax_pose 5, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose28:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose29:
+ax_pose 4, 0x01ea, 0x90e7, 0x3c00
+ax_pose_terminator
+sSunkernPose30:
+ax_pose 5, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose31:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose32:
+ax_pose 7, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose33:
+ax_pose 8, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose34:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose35:
+ax_pose 10, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose36:
+ax_pose 11, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose37:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose38:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose39:
+ax_pose 14, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose40:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose41:
+ax_pose 10, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose42:
+ax_pose 11, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose43:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose44:
+ax_pose 7, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose45:
+ax_pose 8, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose46:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose47:
+ax_pose 4, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose48:
+ax_pose 5, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose49:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose50:
+ax_pose 1, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose51:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose52:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose53:
+ax_pose 4, 0x01ea, 0x90e7, 0x3c00
+ax_pose_terminator
+sSunkernPose54:
+ax_pose 5, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose55:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose56:
+ax_pose 7, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose57:
+ax_pose 8, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose58:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose59:
+ax_pose 10, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose60:
+ax_pose 11, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose61:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose62:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose63:
+ax_pose 14, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose64:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose65:
+ax_pose 10, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose66:
+ax_pose 11, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose67:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose68:
+ax_pose 7, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose69:
+ax_pose 8, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose70:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose71:
+ax_pose 4, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose72:
+ax_pose 5, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose73:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose74:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose75:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose76:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose77:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose78:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose79:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose80:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose81:
+ax_pose 15, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose82:
+ax_pose 16, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose83:
+ax_pose 17, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose84:
+ax_pose 18, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose85:
+ax_pose 19, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose86:
+ax_pose 18, 0x81e9, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose87:
+ax_pose 17, 0x81e9, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose88:
+ax_pose 16, 0x81e9, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose89:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose90:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose91:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose92:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose93:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose94:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose95:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose96:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose97:
+ax_pose 20, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose98:
+ax_pose 21, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose99:
+ax_pose 22, 0x01de, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunkernPose100:
+ax_pose 23, 0x01e1, 0x90e7, 0x3c00
+ax_pose_terminator
+sSunkernPose101:
+ax_pose 24, 0x01e1, 0x90e8, 0x3c00
+ax_pose_terminator
+sSunkernPose102:
+ax_pose 25, 0x01e2, 0x90ea, 0x3c00
+ax_pose_terminator
+sSunkernPose103:
+ax_pose 26, 0x01e0, 0x80f1, 0x3c00
+ax_pose_terminator
+sSunkernPose104:
+ax_pose 25, 0x01e2, 0x80f6, 0x3c00
+ax_pose_terminator
+sSunkernPose105:
+ax_pose 24, 0x01e1, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose106:
+ax_pose 23, 0x01e1, 0x80f9, 0x3c00
+ax_pose_terminator
+sSunkernPose107:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose108:
+ax_pose 1, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose109:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose110:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose111:
+ax_pose 4, 0x01ea, 0x90e7, 0x3c00
+ax_pose_terminator
+sSunkernPose112:
+ax_pose 5, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose113:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose114:
+ax_pose 7, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose115:
+ax_pose 8, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose116:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose117:
+ax_pose 10, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose118:
+ax_pose 11, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose119:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose120:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose121:
+ax_pose 14, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose122:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose123:
+ax_pose 10, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose124:
+ax_pose 11, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose125:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose126:
+ax_pose 7, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose127:
+ax_pose 8, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose128:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose129:
+ax_pose 4, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose130:
+ax_pose 5, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose131:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose132:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose133:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose134:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose135:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose136:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose137:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose138:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose139:
+ax_pose 15, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose140:
+ax_pose 16, 0x81e9, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose141:
+ax_pose 17, 0x81e9, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose142:
+ax_pose 18, 0x81e9, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose143:
+ax_pose 19, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose144:
+ax_pose 18, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose145:
+ax_pose 17, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose146:
+ax_pose 16, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose147:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose148:
+ax_pose 1, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose149:
+ax_pose 2, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose150:
+ax_pose 15, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose151:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose152:
+ax_pose 4, 0x01ea, 0x90e7, 0x3c00
+ax_pose_terminator
+sSunkernPose153:
+ax_pose 5, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose154:
+ax_pose 16, 0x81e9, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose155:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose156:
+ax_pose 7, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose157:
+ax_pose 8, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose158:
+ax_pose 17, 0x81e9, 0x90f6, 0x3c00
+ax_pose_terminator
+sSunkernPose159:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose160:
+ax_pose 10, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose161:
+ax_pose 11, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose162:
+ax_pose 18, 0x81e9, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose163:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose164:
+ax_pose 13, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose165:
+ax_pose 14, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose166:
+ax_pose 19, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose167:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose168:
+ax_pose 10, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose169:
+ax_pose 11, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose170:
+ax_pose 18, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose171:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose172:
+ax_pose 7, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose173:
+ax_pose 8, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose174:
+ax_pose 17, 0x81e9, 0x80f9, 0x3c00
+ax_pose_terminator
+sSunkernPose175:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose176:
+ax_pose 4, 0x01ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose177:
+ax_pose 5, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose178:
+ax_pose 16, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose179:
+ax_pose 15, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose180:
+ax_pose 16, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose181:
+ax_pose 17, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose182:
+ax_pose 18, 0x81e9, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose183:
+ax_pose 19, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose184:
+ax_pose 18, 0x81e9, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose185:
+ax_pose 17, 0x81e9, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose186:
+ax_pose 16, 0x81e9, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose187:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose188:
+ax_pose 3, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose189:
+ax_pose 6, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sSunkernPose190:
+ax_pose 9, 0x81ea, 0x80f7, 0x3c00
+ax_pose_terminator
+sSunkernPose191:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sSunkernPose192:
+ax_pose 9, 0x81ea, 0x90f8, 0x3c00
+ax_pose_terminator
+sSunkernPose193:
+ax_pose 6, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+sSunkernPose194:
+ax_pose 3, 0x81ea, 0x90f7, 0x3c00
+ax_pose_terminator
+.align 2
+sSunkernAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -4, 0, 0,
+ax_anim 6, 0, 2, 0, -4, 0, 0,
+ax_anim 6, 0, 0, 0, -3, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sSunkernAnims_1_2:
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -4, 0, 0,
+ax_anim 6, 0, 5, 0, -4, 0, 0,
+ax_anim 6, 0, 3, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sSunkernAnims_1_3:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -4, 0, 0,
+ax_anim 6, 0, 8, 0, -4, 0, 0,
+ax_anim 6, 0, 6, 0, -3, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sSunkernAnims_1_4:
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -4, 0, 0,
+ax_anim 6, 0, 11, 0, -4, 0, 0,
+ax_anim 6, 0, 9, 0, -3, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sSunkernAnims_1_5:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -4, 0, 0,
+ax_anim 6, 0, 14, 0, -4, 0, 0,
+ax_anim 6, 0, 12, 0, -3, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sSunkernAnims_1_6:
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -4, 0, 0,
+ax_anim 6, 0, 17, 0, -4, 0, 0,
+ax_anim 6, 0, 15, 0, -3, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sSunkernAnims_1_7:
+ax_anim 4, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -4, 0, 0,
+ax_anim 6, 0, 20, 0, -4, 0, 0,
+ax_anim 6, 0, 18, 0, -3, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sSunkernAnims_1_8:
+ax_anim 4, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -4, 0, 0,
+ax_anim 6, 0, 23, 0, -4, 0, 0,
+ax_anim 6, 0, 21, 0, -3, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 4, 0, 24, 0, -5, 0, -5,
+ax_anim 2, 0, 25, 0, -1, 0, 1,
+ax_anim 2, 0, 25, 0, 2, 0, 7,
+ax_anim 2, 2, 25, 0, 10, 0, 16,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 1, 25, 1, 22, 1, 22,
+ax_anim 2, 0, 25, 0, 22, 0, 22,
+ax_anim 2, 0, 25, 1, 22, 1, 22,
+ax_anim 4, 0, 24, 0, 8, 0, 8,
+ax_anim_terminator
+sSunkernAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -3, -3, -3, -3,
+ax_anim 4, 0, 27, -5, -5, -5, -5,
+ax_anim 2, 0, 28, 1, -5, 1, 0,
+ax_anim 2, 0, 28, 4, -4, 4, 3,
+ax_anim 2, 2, 28, 13, 2, 13, 11,
+ax_anim 2, 0, 28, 22, 19, 22, 19,
+ax_anim 2, 1, 28, 23, 18, 23, 18,
+ax_anim 2, 0, 28, 22, 19, 22, 19,
+ax_anim 2, 0, 28, 23, 18, 23, 18,
+ax_anim 4, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSunkernAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -3, 0, -3, 0,
+ax_anim 4, 0, 30, -5, 0, -5, 0,
+ax_anim 2, 0, 31, 1, -3, 1, 0,
+ax_anim 2, 0, 31, 3, -5, 3, 0,
+ax_anim 2, 2, 31, 10, -6, 10, 0,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 1, 31, 22, 1, 22, 1,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 0, 31, 22, 1, 22, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSunkernAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -3, 3, -3, 3,
+ax_anim 4, 0, 33, -5, 5, -5, 5,
+ax_anim 2, 0, 34, 1, -13, 1, -1,
+ax_anim 2, 0, 34, 5, -18, 5, -6,
+ax_anim 2, 2, 34, 10, -22, 10, -12,
+ax_anim 2, 0, 34, 22, -25, 22, -25,
+ax_anim 2, 1, 34, 23, -24, 23, -24,
+ax_anim 2, 0, 34, 22, -25, 22, -25,
+ax_anim 2, 0, 34, 23, -24, 23, -24,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSunkernAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 3, 0, 3,
+ax_anim 4, 0, 36, 0, 5, 0, 5,
+ax_anim 2, 0, 37, 0, 1, 0, 4,
+ax_anim 2, 0, 37, 0, -2, 0, 1,
+ax_anim 2, 2, 37, 0, -10, 0, -4,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 1, 37, 1, -24, 1, -24,
+ax_anim 2, 0, 37, 0, -24, 0, -24,
+ax_anim 2, 0, 37, 1, -24, 1, -24,
+ax_anim 4, 0, 36, 0, -8, 0, -8,
+ax_anim_terminator
+sSunkernAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 3, 3, 3, 3,
+ax_anim 4, 0, 39, 5, 5, 5, 5,
+ax_anim 2, 0, 40, -1, -13, -1, -1,
+ax_anim 2, 0, 40, -5, -18, -5, -6,
+ax_anim 2, 2, 40, -10, -22, -10, -12,
+ax_anim 2, 0, 40, -22, -25, -22, -25,
+ax_anim 2, 1, 40, -23, -24, -23, -24,
+ax_anim 2, 0, 40, -22, -25, -22, -25,
+ax_anim 2, 0, 40, -23, -24, -23, -24,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSunkernAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 3, 0, 3, 0,
+ax_anim 4, 0, 42, 5, 0, 5, 0,
+ax_anim 2, 0, 43, -1, -3, -1, 0,
+ax_anim 2, 0, 43, -3, -5, -3, 0,
+ax_anim 2, 2, 43, -10, -6, -10, 0,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 1, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 0, 43, -22, 1, -22, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSunkernAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 3, -3, 3, -3,
+ax_anim 4, 0, 45, 5, -5, 5, -5,
+ax_anim 2, 0, 46, -1, -5, -1, 0,
+ax_anim 2, 0, 46, -4, -4, -4, 3,
+ax_anim 2, 2, 46, -13, 2, -13, 11,
+ax_anim 2, 0, 46, -22, 19, -22, 19,
+ax_anim 2, 1, 46, -23, 18, -23, 18,
+ax_anim 2, 0, 46, -22, 19, -22, 19,
+ax_anim 2, 0, 46, -23, 18, -23, 18,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSunkernAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -3, 0, -3,
+ax_anim 4, 0, 48, 0, -5, 0, -5,
+ax_anim 2, 0, 49, 0, -1, 0, 1,
+ax_anim 2, 0, 49, 0, 2, 0, 7,
+ax_anim 2, 2, 49, 0, 10, 0, 16,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 1, 49, 1, 22, 1, 22,
+ax_anim 2, 0, 49, 0, 22, 0, 22,
+ax_anim 2, 0, 49, 1, 22, 1, 22,
+ax_anim 4, 0, 48, 0, 8, 0, 8,
+ax_anim_terminator
+sSunkernAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -3, -3, -3, -3,
+ax_anim 4, 0, 51, -5, -5, -5, -5,
+ax_anim 2, 0, 52, 1, -5, 1, 0,
+ax_anim 2, 0, 52, 4, -4, 4, 3,
+ax_anim 2, 2, 52, 13, 2, 13, 11,
+ax_anim 2, 0, 52, 22, 19, 22, 19,
+ax_anim 2, 1, 52, 23, 18, 23, 18,
+ax_anim 2, 0, 52, 22, 19, 22, 19,
+ax_anim 2, 0, 52, 23, 18, 23, 18,
+ax_anim 4, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sSunkernAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -3, 0, -3, 0,
+ax_anim 4, 0, 54, -5, 0, -5, 0,
+ax_anim 2, 0, 55, 1, -3, 1, 0,
+ax_anim 2, 0, 55, 3, -5, 3, 0,
+ax_anim 2, 2, 55, 10, -6, 10, 0,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 1, 55, 22, 1, 22, 1,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 0, 55, 22, 1, 22, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSunkernAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -3, 3, -3, 3,
+ax_anim 4, 0, 57, -5, 5, -5, 5,
+ax_anim 2, 0, 58, 1, -13, 1, -1,
+ax_anim 2, 0, 58, 5, -18, 5, -6,
+ax_anim 2, 2, 58, 10, -22, 10, -12,
+ax_anim 2, 0, 58, 22, -25, 22, -25,
+ax_anim 2, 1, 58, 23, -24, 23, -24,
+ax_anim 2, 0, 58, 22, -25, 22, -25,
+ax_anim 2, 0, 58, 23, -24, 23, -24,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSunkernAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 3, 0, 3,
+ax_anim 4, 0, 60, 0, 5, 0, 5,
+ax_anim 2, 0, 61, 0, 1, 0, 4,
+ax_anim 2, 0, 61, 0, -2, 0, 1,
+ax_anim 2, 2, 61, 0, -10, 0, -4,
+ax_anim 2, 0, 61, 0, -24, 0, -24,
+ax_anim 2, 1, 61, 1, -24, 1, -24,
+ax_anim 2, 0, 61, 0, -24, 0, -24,
+ax_anim 2, 0, 61, 1, -24, 1, -24,
+ax_anim 4, 0, 60, 0, -8, 0, -8,
+ax_anim_terminator
+sSunkernAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 3, 3, 3, 3,
+ax_anim 4, 0, 63, 5, 5, 5, 5,
+ax_anim 2, 0, 64, -1, -13, -1, -1,
+ax_anim 2, 0, 64, -5, -18, -5, -6,
+ax_anim 2, 2, 64, -10, -22, -10, -12,
+ax_anim 2, 0, 64, -22, -25, -22, -25,
+ax_anim 2, 1, 64, -23, -24, -23, -24,
+ax_anim 2, 0, 64, -22, -25, -22, -25,
+ax_anim 2, 0, 64, -23, -24, -23, -24,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSunkernAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 3, 0, 3, 0,
+ax_anim 4, 0, 66, 5, 0, 5, 0,
+ax_anim 2, 0, 67, -1, -3, -1, 0,
+ax_anim 2, 0, 67, -3, -5, -3, 0,
+ax_anim 2, 2, 67, -10, -6, -10, 0,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 1, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 0, 67, -22, 1, -22, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSunkernAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 3, -3, 3, -3,
+ax_anim 4, 0, 69, 5, -5, 5, -5,
+ax_anim 2, 0, 70, -1, -5, -1, 0,
+ax_anim 2, 0, 70, -4, -4, -4, 3,
+ax_anim 2, 2, 70, -13, 2, -13, 11,
+ax_anim 2, 0, 70, -22, 19, -22, 19,
+ax_anim 2, 1, 70, -23, 18, -23, 18,
+ax_anim 2, 0, 70, -22, 19, -22, 19,
+ax_anim 2, 0, 70, -23, 18, -23, 18,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSunkernAnims_4_1:
+ax_anim 3, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 1, 0, 74, 0, -3, 0, 0,
+ax_anim 1, 0, 75, 0, -5, 0, 0,
+ax_anim 1, 0, 76, 0, -6, 0, 0,
+ax_anim 1, 0, 77, 0, -6, 0, 0,
+ax_anim 1, 0, 78, 0, -5, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 0, 80, 1, 1, 1, 1,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim 2, 1, 80, 1, 1, 1, 1,
+ax_anim 2, 0, 80, 0, 1, 0, 1,
+ax_anim_terminator
+sSunkernAnims_4_2:
+ax_anim 3, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim 1, 0, 73, 0, -3, 0, 0,
+ax_anim 1, 0, 74, 0, -5, 0, 0,
+ax_anim 1, 0, 75, 0, -6, 0, 0,
+ax_anim 1, 0, 76, 0, -6, 0, 0,
+ax_anim 1, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 78, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 0, 87, 0, 2, 0, 2,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 87, 0, 2, 0, 2,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim_terminator
+sSunkernAnims_4_3:
+ax_anim 3, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 1, 0, 72, 0, -3, 0, 0,
+ax_anim 1, 0, 73, 0, -5, 0, 0,
+ax_anim 1, 0, 74, 0, -6, 0, 0,
+ax_anim 1, 0, 75, 0, -6, 0, 0,
+ax_anim 1, 0, 76, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 1, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim_terminator
+sSunkernAnims_4_4:
+ax_anim 3, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, 0,
+ax_anim 1, 0, 79, 0, -3, 0, 0,
+ax_anim 1, 0, 72, 0, -5, 0, 0,
+ax_anim 1, 0, 73, 0, -6, 0, 0,
+ax_anim 1, 0, 74, 0, -6, 0, 0,
+ax_anim 1, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 0, 85, 2, 0, 2, 0,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 2, 1, 85, 2, 0, 2, 0,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim_terminator
+sSunkernAnims_4_5:
+ax_anim 3, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 1, 0, 78, 0, -3, 0, 0,
+ax_anim 1, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 0, 72, 0, -6, 0, 0,
+ax_anim 1, 0, 73, 0, -6, 0, 0,
+ax_anim 1, 0, 74, 0, -5, 0, 0,
+ax_anim 2, 0, 75, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim 2, 1, 84, 1, -1, 1, -1,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sSunkernAnims_4_6:
+ax_anim 3, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim 1, 0, 77, 0, -3, 0, 0,
+ax_anim 1, 0, 78, 0, -5, 0, 0,
+ax_anim 1, 0, 79, 0, -6, 0, 0,
+ax_anim 1, 0, 72, 0, -6, 0, 0,
+ax_anim 1, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 4, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 0, 83, -2, 0, -2, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim 2, 1, 83, -2, 0, -2, 0,
+ax_anim 2, 0, 83, -1, -1, -1, -1,
+ax_anim_terminator
+sSunkernAnims_4_7:
+ax_anim 3, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 1, 0, 76, 0, -3, 0, 0,
+ax_anim 1, 0, 77, 0, -5, 0, 0,
+ax_anim 1, 0, 78, 0, -6, 0, 0,
+ax_anim 1, 0, 79, 0, -6, 0, 0,
+ax_anim 1, 0, 72, 0, -5, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 2, 0, 82, -1, -1, -1, -1,
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim 2, 1, 82, -1, -1, -1, -1,
+ax_anim 2, 0, 82, -1, 0, -1, 0,
+ax_anim_terminator
+sSunkernAnims_4_8:
+ax_anim 3, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim 1, 0, 75, 0, -3, 0, 0,
+ax_anim 1, 0, 76, 0, -5, 0, 0,
+ax_anim 1, 0, 77, 0, -6, 0, 0,
+ax_anim 1, 0, 78, 0, -6, 0, 0,
+ax_anim 1, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 72, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 0, 81, -2, 0, -2, 0,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 81, -2, 0, -2, 0,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSunkernAnims_5_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_5_2:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_5_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_5_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_5_6:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_5_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_5_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_6_1:
+ax_anim 30, 0, 96, 0, 0, 0, 0,
+ax_anim 35, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_7_1:
+ax_anim 2, 0, 98, 0, -4, 0, -4,
+ax_anim 8, 0, 98, 0, -5, 0, -5,
+ax_anim_terminator
+sSunkernAnims_7_2:
+ax_anim 2, 0, 99, -4, -4, -4, -4,
+ax_anim 8, 0, 99, -5, -5, -5, -5,
+ax_anim_terminator
+sSunkernAnims_7_3:
+ax_anim 2, 0, 100, -4, 0, -4, 0,
+ax_anim 8, 0, 100, -5, 0, -5, 0,
+ax_anim_terminator
+sSunkernAnims_7_4:
+ax_anim 2, 0, 101, -4, 4, -4, 4,
+ax_anim 8, 0, 101, -5, 5, -5, 5,
+ax_anim_terminator
+sSunkernAnims_7_5:
+ax_anim 2, 0, 102, 0, 4, 0, 4,
+ax_anim 8, 0, 102, 0, 5, 0, 5,
+ax_anim_terminator
+sSunkernAnims_7_6:
+ax_anim 2, 0, 103, 4, 4, 4, 4,
+ax_anim 8, 0, 103, 5, 5, 5, 5,
+ax_anim_terminator
+sSunkernAnims_7_7:
+ax_anim 2, 0, 104, 4, 0, 4, 0,
+ax_anim 8, 0, 104, 5, 0, 5, 0,
+ax_anim_terminator
+sSunkernAnims_7_8:
+ax_anim 2, 0, 105, 4, -4, 4, -4,
+ax_anim 8, 0, 105, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSunkernAnims_8_1:
+ax_anim 26, 0, 106, 0, 0, 0, 0,
+ax_anim 18, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_8_2:
+ax_anim 26, 0, 109, 0, 0, 0, 0,
+ax_anim 18, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_8_3:
+ax_anim 26, 0, 112, 0, 0, 0, 0,
+ax_anim 18, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_8_4:
+ax_anim 26, 0, 115, 0, 0, 0, 0,
+ax_anim 18, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_8_5:
+ax_anim 26, 0, 118, 0, 0, 0, 0,
+ax_anim 18, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_8_6:
+ax_anim 26, 0, 121, 0, 0, 0, 0,
+ax_anim 18, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_8_7:
+ax_anim 26, 0, 124, 0, 0, 0, 0,
+ax_anim 18, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_8_8:
+ax_anim 26, 0, 127, 0, 0, 0, 0,
+ax_anim 18, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 4, 6, 4,
+ax_anim 2, 0, 132, 8, 9, 8, 9,
+ax_anim 2, 0, 133, 7, 19, 7, 19,
+ax_anim 3, 0, 134, 1, 22, 1, 24,
+ax_anim 2, 3, 135, -6, 19, -6, 19,
+ax_anim 2, 0, 136, -8, 9, -8, 9,
+ax_anim 1, 0, 137, -6, 4, -6, 4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 131, 17, 3, 17, 3,
+ax_anim 2, 0, 132, 24, 9, 24, 9,
+ax_anim 3, 0, 133, 23, 21, 23, 21,
+ax_anim 2, 3, 134, 11, 21, 11, 21,
+ax_anim 2, 0, 135, 2, 12, 2, 12,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -4, 3, -4,
+ax_anim 2, 0, 130, 11, -6, 11, -6,
+ax_anim 2, 0, 131, 17, -4, 17, -4,
+ax_anim 3, 0, 132, 22, 1, 22, 1,
+ax_anim 2, 3, 133, 17, 5, 17, 5,
+ax_anim 2, 0, 134, 12, 7, 12, 7,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -6, -1, -6,
+ax_anim 2, 0, 137, 3, -18, 3, -18,
+ax_anim 2, 0, 130, 11, -23, 11, -23,
+ax_anim 3, 0, 131, 21, -24, 21, -24,
+ax_anim 2, 3, 132, 21, -11, 21, -11,
+ax_anim 2, 0, 133, 16, -6, 16, -6,
+ax_anim 1, 0, 134, 7, -1, 7, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -6, -4, -6, -4,
+ax_anim 2, 0, 136, -8, -10, -8, -10,
+ax_anim 2, 0, 137, -7, -18, -7, -18,
+ax_anim 3, 0, 130, 0, -25, 0, -25,
+ax_anim 2, 3, 131, 7, -20, 7, -20,
+ax_anim 2, 0, 132, 8, -10, 8, -10,
+ax_anim 1, 0, 133, 6, -4, 6, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -6, 1, -6,
+ax_anim 2, 0, 131, -3, -18, -3, -18,
+ax_anim 2, 0, 130, -11, -23, -11, -23,
+ax_anim 3, 0, 137, -21, -24, -21, -24,
+ax_anim 2, 3, 136, -21, -11, -21, -11,
+ax_anim 2, 0, 135, -16, -6, -16, -6,
+ax_anim 1, 0, 134, -7, -1, -7, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -4, -3, -4,
+ax_anim 2, 0, 130, -11, -6, -11, -6,
+ax_anim 2, 0, 137, -17, -4, -17, -4,
+ax_anim 3, 0, 136, -22, 1, -22, 1,
+ax_anim 2, 3, 135, -17, 5, -17, 5,
+ax_anim 2, 0, 134, -12, 7, -12, 7,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 137, -17, 3, -17, 3,
+ax_anim 2, 0, 136, -24, 9, -24, 9,
+ax_anim 3, 0, 135, -23, 21, -23, 16,
+ax_anim 2, 3, 134, -11, 21, -11, 16,
+ax_anim 2, 0, 133, -2, 12, -4, 12,
+ax_anim 1, 0, 132, 0, 7, -3, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 149, 0, -23, 0, 0,
+ax_anim 3, 0, 149, 0, -22, 0, 0,
+ax_anim 2, 0, 149, 0, -18, 0, 0,
+ax_anim 1, 0, 149, 0, -12, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_11_2:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -23, 0, 0,
+ax_anim 3, 0, 153, 0, -22, 0, 0,
+ax_anim 2, 0, 153, 0, -18, 0, 0,
+ax_anim 1, 0, 153, 0, -12, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_11_3:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -23, 0, 0,
+ax_anim 3, 0, 157, 0, -22, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_11_4:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -22, 0, 0,
+ax_anim 3, 0, 161, 0, -21, 0, 0,
+ax_anim 2, 0, 161, 0, -17, 0, 0,
+ax_anim 1, 0, 161, 0, -11, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_11_5:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 165, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_11_6:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 169, 0, -22, 0, 0,
+ax_anim 3, 0, 169, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -17, 0, 0,
+ax_anim 1, 0, 169, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_11_7:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 173, 0, -22, 0, 0,
+ax_anim 2, 0, 173, 0, -18, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_11_8:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSunkernAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSunkernGfx1:
+.incbin "baserom.gba", 0xD39C58, 0x200
+sSunkernSprites1:
+ax_sprite sSunkernGfx1, 0x200
+ax_sprite_terminator
+sSunkernGfx2:
+.incbin "baserom.gba", 0xD39E68, 0x200
+sSunkernSprites2:
+ax_sprite sSunkernGfx2, 0x200
+ax_sprite_terminator
+sSunkernGfx3:
+.incbin "baserom.gba", 0xD3A078, 0x200
+sSunkernSprites3:
+ax_sprite sSunkernGfx3, 0x200
+ax_sprite_terminator
+sSunkernGfx4:
+.incbin "baserom.gba", 0xD3A288, 0x100
+sSunkernSprites4:
+ax_sprite sSunkernGfx4, 0x100
+ax_sprite_terminator
+sSunkernGfx5:
+.incbin "baserom.gba", 0xD3A398, 0x200
+sSunkernSprites5:
+ax_sprite sSunkernGfx5, 0x200
+ax_sprite_terminator
+sSunkernGfx6:
+.incbin "baserom.gba", 0xD3A5A8, 0x100
+sSunkernSprites6:
+ax_sprite sSunkernGfx6, 0x100
+ax_sprite_terminator
+sSunkernGfx7:
+.incbin "baserom.gba", 0xD3A6B8, 0x100
+sSunkernSprites7:
+ax_sprite sSunkernGfx7, 0x100
+ax_sprite_terminator
+sSunkernGfx8:
+.incbin "baserom.gba", 0xD3A7C8, 0x100
+sSunkernSprites8:
+ax_sprite sSunkernGfx8, 0x100
+ax_sprite_terminator
+sSunkernGfx9:
+.incbin "baserom.gba", 0xD3A8D8, 0x100
+sSunkernSprites9:
+ax_sprite sSunkernGfx9, 0x100
+ax_sprite_terminator
+sSunkernGfx10:
+.incbin "baserom.gba", 0xD3A9E8, 0x100
+sSunkernSprites10:
+ax_sprite sSunkernGfx10, 0x100
+ax_sprite_terminator
+sSunkernGfx11:
+.incbin "baserom.gba", 0xD3AAF8, 0x100
+sSunkernSprites11:
+ax_sprite sSunkernGfx11, 0x100
+ax_sprite_terminator
+sSunkernGfx12:
+.incbin "baserom.gba", 0xD3AC08, 0x100
+sSunkernSprites12:
+ax_sprite sSunkernGfx12, 0x100
+ax_sprite_terminator
+sSunkernGfx13:
+.incbin "baserom.gba", 0xD3AD18, 0x200
+sSunkernSprites13:
+ax_sprite sSunkernGfx13, 0x200
+ax_sprite_terminator
+sSunkernGfx14:
+.incbin "baserom.gba", 0xD3AF28, 0x200
+sSunkernSprites14:
+ax_sprite sSunkernGfx14, 0x200
+ax_sprite_terminator
+sSunkernGfx15:
+.incbin "baserom.gba", 0xD3B138, 0x200
+sSunkernSprites15:
+ax_sprite sSunkernGfx15, 0x200
+ax_sprite_terminator
+sSunkernGfx16:
+.incbin "baserom.gba", 0xD3B348, 0xC0
+sSunkernSprites16:
+ax_sprite sSunkernGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunkernGfx17:
+.incbin "baserom.gba", 0xD3B420, 0xC0
+sSunkernSprites17:
+ax_sprite sSunkernGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunkernGfx18:
+.incbin "baserom.gba", 0xD3B4F8, 0x20
+sSunkernGfx18_1:
+.incbin "baserom.gba", 0xD3B518, 0x80
+sSunkernSprites18:
+ax_sprite sSunkernGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSunkernGfx18_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunkernGfx19:
+.incbin "baserom.gba", 0xD3B5C0, 0xC0
+sSunkernSprites19:
+ax_sprite sSunkernGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunkernGfx20:
+.incbin "baserom.gba", 0xD3B698, 0xC0
+sSunkernSprites20:
+ax_sprite sSunkernGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSunkernGfx21:
+.incbin "baserom.gba", 0xD3B770, 0x100
+sSunkernSprites21:
+ax_sprite sSunkernGfx21, 0x100
+ax_sprite_terminator
+sSunkernGfx22:
+.incbin "baserom.gba", 0xD3B880, 0x100
+sSunkernSprites22:
+ax_sprite sSunkernGfx22, 0x100
+ax_sprite_terminator
+sSunkernGfx23:
+.incbin "baserom.gba", 0xD3B990, 0x200
+sSunkernSprites23:
+ax_sprite sSunkernGfx23, 0x200
+ax_sprite_terminator
+sSunkernGfx24:
+.incbin "baserom.gba", 0xD3BBA0, 0x200
+sSunkernSprites24:
+ax_sprite sSunkernGfx24, 0x200
+ax_sprite_terminator
+sSunkernGfx25:
+.incbin "baserom.gba", 0xD3BDB0, 0x200
+sSunkernSprites25:
+ax_sprite sSunkernGfx25, 0x200
+ax_sprite_terminator
+sSunkernGfx26:
+.incbin "baserom.gba", 0xD3BFC0, 0x200
+sSunkernSprites26:
+ax_sprite sSunkernGfx26, 0x200
+ax_sprite_terminator
+sSunkernGfx27:
+.incbin "baserom.gba", 0xD3C1D0, 0x200
+sSunkernSprites27:
+ax_sprite sSunkernGfx27, 0x200
+ax_sprite_terminator
+sAxPosesSunkern:
+.4byte sSunkernPose1
+.4byte sSunkernPose2
+.4byte sSunkernPose3
+.4byte sSunkernPose4
+.4byte sSunkernPose5
+.4byte sSunkernPose6
+.4byte sSunkernPose7
+.4byte sSunkernPose8
+.4byte sSunkernPose9
+.4byte sSunkernPose10
+.4byte sSunkernPose11
+.4byte sSunkernPose12
+.4byte sSunkernPose13
+.4byte sSunkernPose14
+.4byte sSunkernPose15
+.4byte sSunkernPose16
+.4byte sSunkernPose17
+.4byte sSunkernPose18
+.4byte sSunkernPose19
+.4byte sSunkernPose20
+.4byte sSunkernPose21
+.4byte sSunkernPose22
+.4byte sSunkernPose23
+.4byte sSunkernPose24
+.4byte sSunkernPose25
+.4byte sSunkernPose26
+.4byte sSunkernPose27
+.4byte sSunkernPose28
+.4byte sSunkernPose29
+.4byte sSunkernPose30
+.4byte sSunkernPose31
+.4byte sSunkernPose32
+.4byte sSunkernPose33
+.4byte sSunkernPose34
+.4byte sSunkernPose35
+.4byte sSunkernPose36
+.4byte sSunkernPose37
+.4byte sSunkernPose38
+.4byte sSunkernPose39
+.4byte sSunkernPose40
+.4byte sSunkernPose41
+.4byte sSunkernPose42
+.4byte sSunkernPose43
+.4byte sSunkernPose44
+.4byte sSunkernPose45
+.4byte sSunkernPose46
+.4byte sSunkernPose47
+.4byte sSunkernPose48
+.4byte sSunkernPose49
+.4byte sSunkernPose50
+.4byte sSunkernPose51
+.4byte sSunkernPose52
+.4byte sSunkernPose53
+.4byte sSunkernPose54
+.4byte sSunkernPose55
+.4byte sSunkernPose56
+.4byte sSunkernPose57
+.4byte sSunkernPose58
+.4byte sSunkernPose59
+.4byte sSunkernPose60
+.4byte sSunkernPose61
+.4byte sSunkernPose62
+.4byte sSunkernPose63
+.4byte sSunkernPose64
+.4byte sSunkernPose65
+.4byte sSunkernPose66
+.4byte sSunkernPose67
+.4byte sSunkernPose68
+.4byte sSunkernPose69
+.4byte sSunkernPose70
+.4byte sSunkernPose71
+.4byte sSunkernPose72
+.4byte sSunkernPose73
+.4byte sSunkernPose74
+.4byte sSunkernPose75
+.4byte sSunkernPose76
+.4byte sSunkernPose77
+.4byte sSunkernPose78
+.4byte sSunkernPose79
+.4byte sSunkernPose80
+.4byte sSunkernPose81
+.4byte sSunkernPose82
+.4byte sSunkernPose83
+.4byte sSunkernPose84
+.4byte sSunkernPose85
+.4byte sSunkernPose86
+.4byte sSunkernPose87
+.4byte sSunkernPose88
+.4byte sSunkernPose89
+.4byte sSunkernPose90
+.4byte sSunkernPose91
+.4byte sSunkernPose92
+.4byte sSunkernPose93
+.4byte sSunkernPose94
+.4byte sSunkernPose95
+.4byte sSunkernPose96
+.4byte sSunkernPose97
+.4byte sSunkernPose98
+.4byte sSunkernPose99
+.4byte sSunkernPose100
+.4byte sSunkernPose101
+.4byte sSunkernPose102
+.4byte sSunkernPose103
+.4byte sSunkernPose104
+.4byte sSunkernPose105
+.4byte sSunkernPose106
+.4byte sSunkernPose107
+.4byte sSunkernPose108
+.4byte sSunkernPose109
+.4byte sSunkernPose110
+.4byte sSunkernPose111
+.4byte sSunkernPose112
+.4byte sSunkernPose113
+.4byte sSunkernPose114
+.4byte sSunkernPose115
+.4byte sSunkernPose116
+.4byte sSunkernPose117
+.4byte sSunkernPose118
+.4byte sSunkernPose119
+.4byte sSunkernPose120
+.4byte sSunkernPose121
+.4byte sSunkernPose122
+.4byte sSunkernPose123
+.4byte sSunkernPose124
+.4byte sSunkernPose125
+.4byte sSunkernPose126
+.4byte sSunkernPose127
+.4byte sSunkernPose128
+.4byte sSunkernPose129
+.4byte sSunkernPose130
+.4byte sSunkernPose131
+.4byte sSunkernPose132
+.4byte sSunkernPose133
+.4byte sSunkernPose134
+.4byte sSunkernPose135
+.4byte sSunkernPose136
+.4byte sSunkernPose137
+.4byte sSunkernPose138
+.4byte sSunkernPose139
+.4byte sSunkernPose140
+.4byte sSunkernPose141
+.4byte sSunkernPose142
+.4byte sSunkernPose143
+.4byte sSunkernPose144
+.4byte sSunkernPose145
+.4byte sSunkernPose146
+.4byte sSunkernPose147
+.4byte sSunkernPose148
+.4byte sSunkernPose149
+.4byte sSunkernPose150
+.4byte sSunkernPose151
+.4byte sSunkernPose152
+.4byte sSunkernPose153
+.4byte sSunkernPose154
+.4byte sSunkernPose155
+.4byte sSunkernPose156
+.4byte sSunkernPose157
+.4byte sSunkernPose158
+.4byte sSunkernPose159
+.4byte sSunkernPose160
+.4byte sSunkernPose161
+.4byte sSunkernPose162
+.4byte sSunkernPose163
+.4byte sSunkernPose164
+.4byte sSunkernPose165
+.4byte sSunkernPose166
+.4byte sSunkernPose167
+.4byte sSunkernPose168
+.4byte sSunkernPose169
+.4byte sSunkernPose170
+.4byte sSunkernPose171
+.4byte sSunkernPose172
+.4byte sSunkernPose173
+.4byte sSunkernPose174
+.4byte sSunkernPose175
+.4byte sSunkernPose176
+.4byte sSunkernPose177
+.4byte sSunkernPose178
+.4byte sSunkernPose179
+.4byte sSunkernPose180
+.4byte sSunkernPose181
+.4byte sSunkernPose182
+.4byte sSunkernPose183
+.4byte sSunkernPose184
+.4byte sSunkernPose185
+.4byte sSunkernPose186
+.4byte sSunkernPose187
+.4byte sSunkernPose188
+.4byte sSunkernPose189
+.4byte sSunkernPose190
+.4byte sSunkernPose191
+.4byte sSunkernPose192
+.4byte sSunkernPose193
+.4byte sSunkernPose194
+sAxPositionsSunkern:
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,  -19, 	   5,  -19, 	  -1,   -5
+.2byte   -1,   -4, 	  -8,  -13, 	   6,  -13, 	  -1,   -5
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte    1,   -4, 	   4,  -20, 	  -7,  -17, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -15, 	  -6,  -12, 	   0,   -5
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte   -1,   -6, 	  -4,  -18, 	   4,  -17, 	  -2,   -6
+.2byte   -1,   -6, 	  -5,  -16, 	   4,  -11, 	  -2,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -7, 	   5,  -19, 	  -7,  -19, 	  -1,   -6
+.2byte   -1,   -7, 	   6,  -13, 	  -7,  -13, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -6, 	   2,  -18, 	  -6,  -17, 	   0,   -6
+.2byte   -1,   -6, 	   3,  -16, 	  -6,  -11, 	   0,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -3,   -4, 	  -6,  -20, 	   5,  -17, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -15, 	   4,  -12, 	  -2,   -5
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,  -19, 	   5,  -19, 	  -1,   -5
+.2byte   -1,   -4, 	  -8,  -13, 	   6,  -13, 	  -1,   -5
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte    1,   -4, 	   4,  -20, 	  -7,  -17, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -15, 	  -6,  -12, 	   0,   -5
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte   -1,   -6, 	  -4,  -18, 	   4,  -17, 	  -2,   -6
+.2byte   -1,   -6, 	  -5,  -16, 	   4,  -11, 	  -2,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -7, 	   5,  -19, 	  -7,  -19, 	  -1,   -6
+.2byte   -1,   -7, 	   6,  -13, 	  -7,  -13, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -6, 	   2,  -18, 	  -6,  -17, 	   0,   -6
+.2byte   -1,   -6, 	   3,  -16, 	  -6,  -11, 	   0,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -3,   -4, 	  -6,  -20, 	   5,  -17, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -15, 	   4,  -12, 	  -2,   -5
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,  -19, 	   5,  -19, 	  -1,   -5
+.2byte   -1,   -4, 	  -8,  -13, 	   6,  -13, 	  -1,   -5
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte    1,   -4, 	   4,  -20, 	  -7,  -17, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -15, 	  -6,  -12, 	   0,   -5
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte   -1,   -6, 	  -4,  -18, 	   4,  -17, 	  -2,   -6
+.2byte   -1,   -6, 	  -5,  -16, 	   4,  -11, 	  -2,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -7, 	   5,  -19, 	  -7,  -19, 	  -1,   -6
+.2byte   -1,   -7, 	   6,  -13, 	  -7,  -13, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -6, 	   2,  -18, 	  -6,  -17, 	   0,   -6
+.2byte   -1,   -6, 	   3,  -16, 	  -6,  -11, 	   0,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -3,   -4, 	  -6,  -20, 	   5,  -17, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -15, 	   4,  -12, 	  -2,   -5
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -19, 	   2,  -19, 	  -1,   -7
+.2byte   -3,   -5, 	  -6,  -20, 	  -1,  -18, 	  -2,   -6
+.2byte   -5,   -5, 	  -4,  -21, 	  -4,  -18, 	  -2,   -6
+.2byte   -3,   -8, 	  -1,  -20, 	  -6,  -18, 	  -2,   -7
+.2byte   -1,   -8, 	   3,  -21, 	  -5,  -21, 	  -1,   -7
+.2byte    0,   -8, 	  -2,  -20, 	   3,  -18, 	  -1,   -7
+.2byte    3,   -5, 	   2,  -21, 	   2,  -18, 	   0,   -6
+.2byte    1,   -5, 	   4,  -20, 	  -1,  -18, 	   0,   -6
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -15, 	   4,  -10, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -14, 	   4,  -10, 	  -1,   -6
+.2byte    0,   -7, 	  -6,  -20, 	   7,  -20, 	   0,   -8
+.2byte    2,   -8, 	  -7,  -22, 	 -13,  -12, 	   0,   -9
+.2byte    2,   -8, 	 -11,  -18, 	  -8,  -15, 	  -2,   -8
+.2byte    1,  -10, 	  -9,  -20, 	   1,  -17, 	  -1,   -8
+.2byte    0,   -8, 	   7,  -19, 	  -7,  -19, 	   0,   -7
+.2byte   -2,  -10, 	   8,  -20, 	  -2,  -17, 	   0,   -8
+.2byte   -3,   -8, 	  10,  -18, 	   7,  -15, 	   1,   -8
+.2byte   -3,   -8, 	   6,  -22, 	  12,  -12, 	  -1,   -9
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,  -19, 	   5,  -19, 	  -1,   -5
+.2byte   -1,   -4, 	  -8,  -13, 	   6,  -13, 	  -1,   -5
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte    1,   -4, 	   4,  -20, 	  -7,  -17, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -15, 	  -6,  -12, 	   0,   -5
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte   -1,   -6, 	  -4,  -18, 	   4,  -17, 	  -2,   -6
+.2byte   -1,   -6, 	  -5,  -16, 	   4,  -11, 	  -2,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -7, 	   5,  -19, 	  -7,  -19, 	  -1,   -6
+.2byte   -1,   -7, 	   6,  -13, 	  -7,  -13, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -6, 	   2,  -18, 	  -6,  -17, 	   0,   -6
+.2byte   -1,   -6, 	   3,  -16, 	  -6,  -11, 	   0,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -3,   -4, 	  -6,  -20, 	   5,  -17, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -15, 	   4,  -12, 	  -2,   -5
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -19, 	   2,  -19, 	  -1,   -7
+.2byte    1,   -5, 	   4,  -20, 	  -1,  -18, 	   0,   -6
+.2byte    3,   -5, 	   2,  -21, 	   2,  -18, 	   0,   -6
+.2byte    0,   -8, 	  -2,  -20, 	   3,  -18, 	  -1,   -7
+.2byte   -1,   -8, 	   3,  -21, 	  -5,  -21, 	  -1,   -7
+.2byte   -3,   -8, 	  -1,  -20, 	  -6,  -18, 	  -2,   -7
+.2byte   -5,   -5, 	  -4,  -21, 	  -4,  -18, 	  -2,   -6
+.2byte   -3,   -5, 	  -6,  -20, 	  -1,  -18, 	  -2,   -6
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -1,   -4, 	  -7,  -19, 	   5,  -19, 	  -1,   -5
+.2byte   -1,   -4, 	  -8,  -13, 	   6,  -13, 	  -1,   -5
+.2byte   -1,   -6, 	  -4,  -19, 	   2,  -19, 	  -1,   -7
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+.2byte    1,   -4, 	   4,  -20, 	  -7,  -17, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -15, 	  -6,  -12, 	   0,   -5
+.2byte    1,   -5, 	   4,  -20, 	  -1,  -18, 	   0,   -6
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte    2,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte    2,   -5, 	   1,  -21, 	   1,  -18, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte   -1,   -6, 	  -4,  -18, 	   4,  -17, 	  -2,   -6
+.2byte   -1,   -6, 	  -5,  -16, 	   4,  -11, 	  -2,   -6
+.2byte    0,   -8, 	  -2,  -20, 	   3,  -18, 	  -1,   -7
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -7, 	   5,  -19, 	  -7,  -19, 	  -1,   -6
+.2byte   -1,   -7, 	   6,  -13, 	  -7,  -13, 	  -1,   -6
+.2byte   -1,   -8, 	   3,  -21, 	  -5,  -21, 	  -1,   -7
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -6, 	   2,  -18, 	  -6,  -17, 	   0,   -6
+.2byte   -1,   -6, 	   3,  -16, 	  -6,  -11, 	   0,   -6
+.2byte   -2,   -8, 	   0,  -20, 	  -5,  -18, 	  -1,   -7
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -20, 	  -1,  -15, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -17, 	  -1,  -10, 	  -1,   -6
+.2byte   -4,   -5, 	  -3,  -21, 	  -3,  -18, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -3,   -4, 	  -6,  -20, 	   5,  -17, 	  -1,   -6
+.2byte   -3,   -4, 	  -5,  -15, 	   4,  -12, 	  -2,   -5
+.2byte   -3,   -5, 	  -6,  -20, 	  -1,  -18, 	  -2,   -6
+.2byte   -1,   -6, 	  -4,  -19, 	   2,  -19, 	  -1,   -7
+.2byte   -3,   -5, 	  -6,  -20, 	  -1,  -18, 	  -2,   -6
+.2byte   -5,   -5, 	  -4,  -21, 	  -4,  -18, 	  -2,   -6
+.2byte   -3,   -8, 	  -1,  -20, 	  -6,  -18, 	  -2,   -7
+.2byte   -1,   -8, 	   3,  -21, 	  -5,  -21, 	  -1,   -7
+.2byte    0,   -8, 	  -2,  -20, 	   3,  -18, 	  -1,   -7
+.2byte    3,   -5, 	   2,  -21, 	   2,  -18, 	   0,   -6
+.2byte    1,   -5, 	   4,  -20, 	  -1,  -18, 	   0,   -6
+.2byte   -1,   -4, 	  -8,  -15, 	   6,  -15, 	  -1,   -5
+.2byte   -3,   -4, 	  -5,  -17, 	   4,  -13, 	  -1,   -6
+.2byte   -4,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte   -1,   -6, 	   2,  -17, 	  -6,  -13, 	   0,   -6
+.2byte   -1,   -7, 	   6,  -15, 	  -8,  -15, 	  -1,   -6
+.2byte   -1,   -6, 	  -4,  -17, 	   4,  -13, 	  -2,   -6
+.2byte    2,   -4, 	  -1,  -18, 	  -1,  -11, 	  -1,   -6
+.2byte    1,   -4, 	   3,  -17, 	  -6,  -13, 	  -1,   -6
+sSunkernAnimTable1:
+.4byte sSunkernAnims_1_1
+.4byte sSunkernAnims_1_2
+.4byte sSunkernAnims_1_3
+.4byte sSunkernAnims_1_4
+.4byte sSunkernAnims_1_5
+.4byte sSunkernAnims_1_6
+.4byte sSunkernAnims_1_7
+.4byte sSunkernAnims_1_8
+sSunkernAnimTable2:
+.4byte sSunkernAnims_2_1
+.4byte sSunkernAnims_2_2
+.4byte sSunkernAnims_2_3
+.4byte sSunkernAnims_2_4
+.4byte sSunkernAnims_2_5
+.4byte sSunkernAnims_2_6
+.4byte sSunkernAnims_2_7
+.4byte sSunkernAnims_2_8
+sSunkernAnimTable3:
+.4byte sSunkernAnims_3_1
+.4byte sSunkernAnims_3_2
+.4byte sSunkernAnims_3_3
+.4byte sSunkernAnims_3_4
+.4byte sSunkernAnims_3_5
+.4byte sSunkernAnims_3_6
+.4byte sSunkernAnims_3_7
+.4byte sSunkernAnims_3_8
+sSunkernAnimTable4:
+.4byte sSunkernAnims_4_1
+.4byte sSunkernAnims_4_2
+.4byte sSunkernAnims_4_3
+.4byte sSunkernAnims_4_4
+.4byte sSunkernAnims_4_5
+.4byte sSunkernAnims_4_6
+.4byte sSunkernAnims_4_7
+.4byte sSunkernAnims_4_8
+sSunkernAnimTable5:
+.4byte sSunkernAnims_5_1
+.4byte sSunkernAnims_5_2
+.4byte sSunkernAnims_5_3
+.4byte sSunkernAnims_5_4
+.4byte sSunkernAnims_5_5
+.4byte sSunkernAnims_5_6
+.4byte sSunkernAnims_5_7
+.4byte sSunkernAnims_5_8
+sSunkernAnimTable6:
+.4byte sSunkernAnims_6_1
+.4byte sSunkernAnims_6_1
+.4byte sSunkernAnims_6_1
+.4byte sSunkernAnims_6_1
+.4byte sSunkernAnims_6_1
+.4byte sSunkernAnims_6_1
+.4byte sSunkernAnims_6_1
+.4byte sSunkernAnims_6_1
+sSunkernAnimTable7:
+.4byte sSunkernAnims_7_1
+.4byte sSunkernAnims_7_2
+.4byte sSunkernAnims_7_3
+.4byte sSunkernAnims_7_4
+.4byte sSunkernAnims_7_5
+.4byte sSunkernAnims_7_6
+.4byte sSunkernAnims_7_7
+.4byte sSunkernAnims_7_8
+sSunkernAnimTable8:
+.4byte sSunkernAnims_8_1
+.4byte sSunkernAnims_8_2
+.4byte sSunkernAnims_8_3
+.4byte sSunkernAnims_8_4
+.4byte sSunkernAnims_8_5
+.4byte sSunkernAnims_8_6
+.4byte sSunkernAnims_8_7
+.4byte sSunkernAnims_8_8
+sSunkernAnimTable9:
+.4byte sSunkernAnims_9_1
+.4byte sSunkernAnims_9_2
+.4byte sSunkernAnims_9_3
+.4byte sSunkernAnims_9_4
+.4byte sSunkernAnims_9_5
+.4byte sSunkernAnims_9_6
+.4byte sSunkernAnims_9_7
+.4byte sSunkernAnims_9_8
+sSunkernAnimTable10:
+.4byte sSunkernAnims_10_1
+.4byte sSunkernAnims_10_2
+.4byte sSunkernAnims_10_3
+.4byte sSunkernAnims_10_4
+.4byte sSunkernAnims_10_5
+.4byte sSunkernAnims_10_6
+.4byte sSunkernAnims_10_7
+.4byte sSunkernAnims_10_8
+sSunkernAnimTable11:
+.4byte sSunkernAnims_11_1
+.4byte sSunkernAnims_11_2
+.4byte sSunkernAnims_11_3
+.4byte sSunkernAnims_11_4
+.4byte sSunkernAnims_11_5
+.4byte sSunkernAnims_11_6
+.4byte sSunkernAnims_11_7
+.4byte sSunkernAnims_11_8
+sSunkernAnimTable12:
+.4byte sSunkernAnims_12_1
+.4byte sSunkernAnims_12_2
+.4byte sSunkernAnims_12_3
+.4byte sSunkernAnims_12_4
+.4byte sSunkernAnims_12_5
+.4byte sSunkernAnims_12_6
+.4byte sSunkernAnims_12_7
+.4byte sSunkernAnims_12_8
+sSunkernAnimTable13:
+.4byte sSunkernAnims_13_1
+.4byte sSunkernAnims_13_2
+.4byte sSunkernAnims_13_3
+.4byte sSunkernAnims_13_4
+.4byte sSunkernAnims_13_5
+.4byte sSunkernAnims_13_6
+.4byte sSunkernAnims_13_7
+.4byte sSunkernAnims_13_8
+sAxAnimationsSunkern:
+.4byte sSunkernAnimTable1
+.4byte sSunkernAnimTable2
+.4byte sSunkernAnimTable3
+.4byte sSunkernAnimTable4
+.4byte sSunkernAnimTable5
+.4byte sSunkernAnimTable6
+.4byte sSunkernAnimTable7
+.4byte sSunkernAnimTable8
+.4byte sSunkernAnimTable9
+.4byte sSunkernAnimTable10
+.4byte sSunkernAnimTable11
+.4byte sSunkernAnimTable12
+.4byte sSunkernAnimTable13
+sAxSpritesSunkern:
+.4byte sSunkernSprites1
+.4byte sSunkernSprites2
+.4byte sSunkernSprites3
+.4byte sSunkernSprites4
+.4byte sSunkernSprites5
+.4byte sSunkernSprites6
+.4byte sSunkernSprites7
+.4byte sSunkernSprites8
+.4byte sSunkernSprites9
+.4byte sSunkernSprites10
+.4byte sSunkernSprites11
+.4byte sSunkernSprites12
+.4byte sSunkernSprites13
+.4byte sSunkernSprites14
+.4byte sSunkernSprites15
+.4byte sSunkernSprites16
+.4byte sSunkernSprites17
+.4byte sSunkernSprites18
+.4byte sSunkernSprites19
+.4byte sSunkernSprites20
+.4byte sSunkernSprites21
+.4byte sSunkernSprites22
+.4byte sSunkernSprites23
+.4byte sSunkernSprites24
+.4byte sSunkernSprites25
+.4byte sSunkernSprites26
+.4byte sSunkernSprites27
+sAxMainSunkern:
+ax_main sAxPosesSunkern, sAxAnimationsSunkern, 13, sAxSpritesSunkern, sAxPositionsSunkern

--- a/data/ax/surskit.inc
+++ b/data/ax/surskit.inc
@@ -1,0 +1,2421 @@
+.global gAxSurskit
+gAxSurskit:
+ax_siro sAxMainSurskit
+sSurskitPose1:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose2:
+ax_pose 1, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose3:
+ax_pose 2, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose4:
+ax_pose 3, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose5:
+ax_pose 4, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose6:
+ax_pose 5, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose7:
+ax_pose 6, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose8:
+ax_pose 7, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose9:
+ax_pose 8, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose10:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose11:
+ax_pose 10, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose12:
+ax_pose 11, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose13:
+ax_pose 12, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose14:
+ax_pose 13, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose15:
+ax_pose 14, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose16:
+ax_pose 9, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose17:
+ax_pose 10, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose18:
+ax_pose 11, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose19:
+ax_pose 6, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose20:
+ax_pose 7, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose21:
+ax_pose 8, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose22:
+ax_pose 3, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose23:
+ax_pose 4, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose24:
+ax_pose 5, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose25:
+ax_pose 15, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose26:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose27:
+ax_pose 1, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose28:
+ax_pose 2, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose29:
+ax_pose 16, 0x01f0, 0x90f1, 0x0c00
+ax_pose_terminator
+sSurskitPose30:
+ax_pose 3, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose31:
+ax_pose 4, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose32:
+ax_pose 5, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose33:
+ax_pose 17, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose34:
+ax_pose 6, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose35:
+ax_pose 7, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose36:
+ax_pose 8, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose37:
+ax_pose 18, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose38:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose39:
+ax_pose 10, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose40:
+ax_pose 11, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose41:
+ax_pose 19, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose42:
+ax_pose 12, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose43:
+ax_pose 13, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose44:
+ax_pose 14, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose45:
+ax_pose 18, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose46:
+ax_pose 9, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose47:
+ax_pose 10, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose48:
+ax_pose 11, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose49:
+ax_pose 17, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose50:
+ax_pose 6, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose51:
+ax_pose 7, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose52:
+ax_pose 8, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose53:
+ax_pose 16, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose54:
+ax_pose 3, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose55:
+ax_pose 4, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose56:
+ax_pose 5, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose57:
+ax_pose 15, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose58:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose59:
+ax_pose 1, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose60:
+ax_pose 2, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose61:
+ax_pose 16, 0x01f0, 0x90f1, 0x0c00
+ax_pose_terminator
+sSurskitPose62:
+ax_pose 3, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose63:
+ax_pose 4, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose64:
+ax_pose 5, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose65:
+ax_pose 17, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose66:
+ax_pose 6, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose67:
+ax_pose 7, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose68:
+ax_pose 8, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose69:
+ax_pose 18, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose70:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose71:
+ax_pose 10, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose72:
+ax_pose 11, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose73:
+ax_pose 19, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose74:
+ax_pose 12, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose75:
+ax_pose 13, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose76:
+ax_pose 14, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose77:
+ax_pose 18, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose78:
+ax_pose 9, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose79:
+ax_pose 10, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose80:
+ax_pose 11, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose81:
+ax_pose 17, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose82:
+ax_pose 6, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose83:
+ax_pose 7, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose84:
+ax_pose 8, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose85:
+ax_pose 16, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose86:
+ax_pose 3, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose87:
+ax_pose 4, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose88:
+ax_pose 5, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose89:
+ax_pose 15, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose90:
+ax_pose 20, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose91:
+ax_pose 16, 0x01f0, 0x90f1, 0x0c00
+ax_pose_terminator
+sSurskitPose92:
+ax_pose 21, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sSurskitPose93:
+ax_pose 17, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose94:
+ax_pose 22, 0x41f6, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose95:
+ax_pose 18, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose96:
+ax_pose 23, 0x01f0, 0x90ef, 0x0c00
+ax_pose_terminator
+sSurskitPose97:
+ax_pose 19, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose98:
+ax_pose 24, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose99:
+ax_pose 18, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose100:
+ax_pose 23, 0x01f0, 0x80f2, 0x0c00
+ax_pose_terminator
+sSurskitPose101:
+ax_pose 17, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose102:
+ax_pose 22, 0x41f6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose103:
+ax_pose 16, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose104:
+ax_pose 21, 0x01f0, 0x80f1, 0x0c00
+ax_pose_terminator
+sSurskitPose105:
+ax_pose 15, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose106:
+ax_pose 16, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose107:
+ax_pose 17, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose108:
+ax_pose 18, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose109:
+ax_pose 19, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose110:
+ax_pose 18, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose111:
+ax_pose 17, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose112:
+ax_pose 16, 0x01f0, 0x90f1, 0x0c00
+ax_pose_terminator
+sSurskitPose113:
+ax_pose 25, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose114:
+ax_pose 26, 0x01f2, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose115:
+ax_pose 27, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sSurskitPose116:
+ax_pose 28, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sSurskitPose117:
+ax_pose 29, 0x01e7, 0x90ef, 0x0c00
+ax_pose_terminator
+sSurskitPose118:
+ax_pose 30, 0x01e7, 0x90ee, 0x0c00
+ax_pose_terminator
+sSurskitPose119:
+ax_pose 31, 0x01e6, 0x80f1, 0x0c00
+ax_pose_terminator
+sSurskitPose120:
+ax_pose 30, 0x01e7, 0x80f3, 0x0c00
+ax_pose_terminator
+sSurskitPose121:
+ax_pose 29, 0x01e7, 0x80f2, 0x0c00
+ax_pose_terminator
+sSurskitPose122:
+ax_pose 28, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sSurskitPose123:
+ax_pose 15, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose124:
+ax_pose 16, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose125:
+ax_pose 17, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose126:
+ax_pose 18, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose127:
+ax_pose 19, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose128:
+ax_pose 18, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose129:
+ax_pose 17, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose130:
+ax_pose 16, 0x01f0, 0x90f1, 0x0c00
+ax_pose_terminator
+sSurskitPose131:
+ax_pose 20, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose132:
+ax_pose 21, 0x01f0, 0x80f1, 0x0c00
+ax_pose_terminator
+sSurskitPose133:
+ax_pose 22, 0x41f6, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose134:
+ax_pose 23, 0x01f1, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose135:
+ax_pose 24, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose136:
+ax_pose 23, 0x01f1, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose137:
+ax_pose 22, 0x41f6, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose138:
+ax_pose 21, 0x01f0, 0x90ef, 0x0c00
+ax_pose_terminator
+sSurskitPose139:
+ax_pose 0, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose140:
+ax_pose 3, 0x01f3, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose141:
+ax_pose 6, 0x01f0, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose142:
+ax_pose 9, 0x01f2, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose143:
+ax_pose 12, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose144:
+ax_pose 9, 0x01f2, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose145:
+ax_pose 6, 0x01f0, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose146:
+ax_pose 3, 0x01f3, 0x80f5, 0x0c00
+ax_pose_terminator
+sSurskitPose147:
+ax_pose 15, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose148:
+ax_pose 20, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose149:
+ax_pose 16, 0x01f0, 0x90f1, 0x0c00
+ax_pose_terminator
+sSurskitPose150:
+ax_pose 21, 0x01f0, 0x90f0, 0x0c00
+ax_pose_terminator
+sSurskitPose151:
+ax_pose 17, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose152:
+ax_pose 22, 0x41f6, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose153:
+ax_pose 18, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose154:
+ax_pose 23, 0x01f2, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose155:
+ax_pose 19, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose156:
+ax_pose 24, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose157:
+ax_pose 18, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose158:
+ax_pose 23, 0x01f2, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose159:
+ax_pose 17, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose160:
+ax_pose 22, 0x41f6, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose161:
+ax_pose 16, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose162:
+ax_pose 21, 0x01f0, 0x80f1, 0x0c00
+ax_pose_terminator
+sSurskitPose163:
+ax_pose 20, 0x41f4, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose164:
+ax_pose 21, 0x01f1, 0x80f1, 0x0c00
+ax_pose_terminator
+sSurskitPose165:
+ax_pose 22, 0x41f6, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose166:
+ax_pose 23, 0x01f1, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose167:
+ax_pose 24, 0x41f3, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose168:
+ax_pose 23, 0x01f1, 0x90ec, 0x0c00
+ax_pose_terminator
+sSurskitPose169:
+ax_pose 22, 0x41f6, 0x90ea, 0x0c00
+ax_pose_terminator
+sSurskitPose170:
+ax_pose 21, 0x01f1, 0x90ef, 0x0c00
+ax_pose_terminator
+sSurskitPose171:
+ax_pose 15, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose172:
+ax_pose 16, 0x01f0, 0x80f0, 0x0c00
+ax_pose_terminator
+sSurskitPose173:
+ax_pose 17, 0x01ee, 0x80f6, 0x0c00
+ax_pose_terminator
+sSurskitPose174:
+ax_pose 18, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose175:
+ax_pose 19, 0x01f0, 0x80f4, 0x0c00
+ax_pose_terminator
+sSurskitPose176:
+ax_pose 18, 0x01f0, 0x90ed, 0x0c00
+ax_pose_terminator
+sSurskitPose177:
+ax_pose 17, 0x01ee, 0x90eb, 0x0c00
+ax_pose_terminator
+sSurskitPose178:
+ax_pose 16, 0x01f0, 0x90f1, 0x0c00
+ax_pose_terminator
+.align 2
+sSurskitAnims_1_1:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 2, 0, 2, 0,
+ax_anim 6, 0, 1, 3, 0, 3, 0,
+ax_anim 6, 0, 0, 3, 0, 3, 0,
+ax_anim 6, 0, 2, 2, 0, 2, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, -2, 0, -2, 0,
+ax_anim 6, 0, 0, -3, 0, -3, 0,
+ax_anim 6, 0, 1, -2, 0, -2, 0,
+ax_anim_terminator
+sSurskitAnims_1_2:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 2, -2, 2, -2,
+ax_anim 6, 0, 5, 3, -3, 3, -3,
+ax_anim 6, 0, 3, 3, -3, 3, -3,
+ax_anim 6, 0, 4, 2, -2, 2, -2,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, 2, -2, 2,
+ax_anim 6, 0, 3, -3, 3, -3, 3,
+ax_anim 6, 0, 5, -2, 2, -2, 2,
+ax_anim_terminator
+sSurskitAnims_1_3:
+ax_anim 6, 0, 8, 0, 1, 0, 1,
+ax_anim 6, 0, 8, 0, -1, 0, -1,
+ax_anim 6, 0, 8, 0, -2, 0, -2,
+ax_anim 6, 0, 6, 0, -2, 0, -2,
+ax_anim 6, 0, 7, 0, -1, 0, -1,
+ax_anim 6, 0, 7, 0, 1, 0, 1,
+ax_anim 6, 0, 7, 0, 3, 0, 3,
+ax_anim 6, 0, 6, 0, 4, 0, 4,
+ax_anim 6, 0, 8, 0, 3, 0, 3,
+ax_anim_terminator
+sSurskitAnims_1_4:
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 2, 2, 2, 2,
+ax_anim 6, 0, 10, 3, 3, 3, 3,
+ax_anim 6, 0, 9, 3, 3, 3, 3,
+ax_anim 6, 0, 11, 2, 2, 2, 2,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, -2, -2, -2, -2,
+ax_anim 6, 0, 9, -3, -3, -3, -3,
+ax_anim 6, 0, 10, -2, -2, -2, -2,
+ax_anim_terminator
+sSurskitAnims_1_5:
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 13, -2, 0, -2, 0,
+ax_anim 6, 0, 13, -3, 0, -3, 0,
+ax_anim 6, 0, 12, -3, 0, -3, 0,
+ax_anim 6, 0, 14, -2, 0, -2, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 2, 0, 2, 0,
+ax_anim 6, 0, 12, 3, 0, 3, 0,
+ax_anim 6, 0, 13, 2, 0, 2, 0,
+ax_anim_terminator
+sSurskitAnims_1_6:
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -2, 2, -2, 2,
+ax_anim 6, 0, 16, -3, 3, -3, 3,
+ax_anim 6, 0, 15, -3, 3, -3, 3,
+ax_anim 6, 0, 17, -2, 2, -2, 2,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 2, -2, 2, -2,
+ax_anim 6, 0, 15, 3, -3, 3, -3,
+ax_anim 6, 0, 16, 2, -2, 2, -2,
+ax_anim_terminator
+sSurskitAnims_1_7:
+ax_anim 6, 0, 20, 0, 1, 0, 1,
+ax_anim 6, 0, 20, 0, -1, 0, -1,
+ax_anim 6, 0, 20, 0, -2, 0, -2,
+ax_anim 6, 0, 18, 0, -2, 0, -2,
+ax_anim 6, 0, 19, 0, -1, 0, -1,
+ax_anim 6, 0, 19, 0, 1, 0, 1,
+ax_anim 6, 0, 19, 0, 3, 0, 3,
+ax_anim 6, 0, 18, 0, 4, 0, 4,
+ax_anim 6, 0, 20, 0, 3, 0, 3,
+ax_anim_terminator
+sSurskitAnims_1_8:
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, -2, -2, -2, -2,
+ax_anim 6, 0, 23, -3, -3, -3, -3,
+ax_anim 6, 0, 21, -3, -3, -3, -3,
+ax_anim 6, 0, 22, -2, -2, -2, -2,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 2, 2, 2, 2,
+ax_anim 6, 0, 21, 3, 3, 3, 3,
+ax_anim 6, 0, 23, 2, 2, 2, 2,
+ax_anim_terminator
+.align 2
+sSurskitAnims_2_1:
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 4, 5, 4, 5,
+ax_anim 4, 0, 26, 5, 6, 5, 6,
+ax_anim 2, 0, 27, -4, 12, -4, 12,
+ax_anim 4, 2, 27, -5, 13, -5, 13,
+ax_anim 2, 1, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, -1, 20, -1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, -1, 20, -1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, -1, 20, -1, 20,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim_terminator
+sSurskitAnims_2_2:
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 2, 8, 2, 8,
+ax_anim 4, 0, 30, 2, 9, 2, 9,
+ax_anim 2, 0, 31, 16, 8, 16, 8,
+ax_anim 4, 2, 31, 17, 8, 17, 8,
+ax_anim 2, 1, 29, 21, 18, 21, 18,
+ax_anim 2, 0, 29, 20, 19, 20, 19,
+ax_anim 2, 0, 29, 21, 18, 21, 18,
+ax_anim 2, 0, 29, 20, 19, 20, 19,
+ax_anim 2, 0, 29, 21, 18, 21, 18,
+ax_anim 2, 0, 29, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sSurskitAnims_2_3:
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 5, 3, 5, 3,
+ax_anim 4, 0, 34, 6, 4, 6, 4,
+ax_anim 2, 0, 35, 12, -3, 12, -3,
+ax_anim 4, 2, 35, 13, -4, 13, -4,
+ax_anim 2, 1, 33, 21, 0, 21, 0,
+ax_anim 2, 0, 33, 21, -1, 21, -1,
+ax_anim 2, 0, 33, 21, 0, 21, 0,
+ax_anim 2, 0, 33, 21, -1, 21, -1,
+ax_anim 2, 0, 33, 21, 0, 21, 0,
+ax_anim 2, 0, 33, 21, -1, 21, -1,
+ax_anim 2, 0, 32, 8, 0, 8, 0,
+ax_anim_terminator
+sSurskitAnims_2_4:
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 8, -9, 8, -9,
+ax_anim 4, 0, 38, 9, -9, 9, -9,
+ax_anim 2, 0, 39, 6, -18, 6, -18,
+ax_anim 4, 2, 39, 6, -19, 6, -19,
+ax_anim 2, 1, 37, 20, -26, 20, -26,
+ax_anim 2, 0, 37, 19, -27, 19, -27,
+ax_anim 2, 0, 37, 20, -26, 20, -26,
+ax_anim 2, 0, 37, 19, -27, 19, -27,
+ax_anim 2, 0, 37, 20, -26, 20, -26,
+ax_anim 2, 0, 37, 19, -27, 19, -27,
+ax_anim 2, 0, 36, 7, -10, 7, -10,
+ax_anim_terminator
+sSurskitAnims_2_5:
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 42, -4, -7, -4, -5,
+ax_anim 4, 0, 42, -5, -8, -5, -8,
+ax_anim 2, 0, 43, 4, -17, 4, -12,
+ax_anim 4, 2, 43, 5, -17, 5, -17,
+ax_anim 2, 1, 41, 0, -26, 0, -26,
+ax_anim 2, 0, 41, -1, -26, -1, -26,
+ax_anim 2, 0, 41, 0, -26, 0, -26,
+ax_anim 2, 0, 41, -1, -26, -1, -26,
+ax_anim 2, 0, 41, 0, -26, 0, -26,
+ax_anim 2, 0, 41, -1, -26, -1, -26,
+ax_anim 2, 0, 40, 0, -8, 0, -8,
+ax_anim_terminator
+sSurskitAnims_2_6:
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 46, -8, -9, -8, -9,
+ax_anim 4, 0, 46, -9, -10, -9, -10,
+ax_anim 2, 0, 47, -6, -18, -6, -18,
+ax_anim 4, 2, 47, -6, -19, -6, -19,
+ax_anim 2, 1, 45, -20, -26, -20, -26,
+ax_anim 2, 0, 45, -19, -27, -19, -27,
+ax_anim 2, 0, 45, -20, -26, -20, -26,
+ax_anim 2, 0, 45, -19, -27, -19, -27,
+ax_anim 2, 0, 45, -20, -26, -20, -26,
+ax_anim 2, 0, 45, -19, -27, -19, -27,
+ax_anim 2, 0, 44, -7, -10, -7, -10,
+ax_anim_terminator
+sSurskitAnims_2_7:
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, -5, 3, -5, 3,
+ax_anim 4, 0, 50, -6, 4, -6, 4,
+ax_anim 2, 0, 51, -12, -3, -12, -3,
+ax_anim 4, 2, 51, -13, -4, -13, -4,
+ax_anim 2, 1, 49, -21, 0, -21, 0,
+ax_anim 2, 0, 49, -21, -1, -21, -1,
+ax_anim 2, 0, 49, -21, 0, -21, 0,
+ax_anim 2, 0, 49, -21, -1, -21, -1,
+ax_anim 2, 0, 49, -21, 0, -21, 0,
+ax_anim 2, 0, 49, -21, -1, -21, -1,
+ax_anim 2, 0, 48, -8, 0, -8, 0,
+ax_anim_terminator
+sSurskitAnims_2_8:
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -2, 8, -2, 8,
+ax_anim 4, 0, 54, -2, 9, -2, 9,
+ax_anim 2, 0, 55, -16, 8, -16, 8,
+ax_anim 4, 2, 55, -17, 8, -17, 8,
+ax_anim 2, 1, 53, -21, 18, -21, 18,
+ax_anim 2, 0, 53, -20, 19, -20, 19,
+ax_anim 2, 0, 53, -21, 18, -21, 18,
+ax_anim 2, 0, 53, -20, 19, -20, 19,
+ax_anim 2, 0, 53, -21, 18, -21, 18,
+ax_anim 2, 0, 53, -20, 19, -20, 19,
+ax_anim 2, 0, 52, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sSurskitAnims_3_1:
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 58, 4, 13, 4, 13,
+ax_anim 4, 0, 58, 5, 14, 5, 14,
+ax_anim 2, 0, 59, -4, 28, -4, 28,
+ax_anim 4, 2, 59, -5, 29, -5, 29,
+ax_anim 2, 1, 57, 0, 44, 0, 44,
+ax_anim 2, 0, 57, -1, 44, -1, 44,
+ax_anim 2, 0, 57, 0, 44, 0, 44,
+ax_anim 2, 0, 57, -1, 44, -1, 44,
+ax_anim 2, 0, 57, 0, 44, 0, 44,
+ax_anim 2, 0, 57, -1, 20, -1, 20,
+ax_anim 2, 0, 56, 0, 8, 0, 8,
+ax_anim_terminator
+sSurskitAnims_3_2:
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 10, 16, 10, 16,
+ax_anim 4, 0, 62, 10, 17, 10, 17,
+ax_anim 2, 0, 63, 32, 24, 32, 24,
+ax_anim 4, 2, 63, 33, 24, 33, 24,
+ax_anim 2, 1, 61, 45, 42, 45, 42,
+ax_anim 2, 0, 61, 44, 43, 44, 43,
+ax_anim 2, 0, 61, 45, 42, 45, 42,
+ax_anim 2, 0, 61, 44, 43, 44, 43,
+ax_anim 2, 0, 61, 45, 42, 45, 42,
+ax_anim 2, 0, 61, 20, 19, 20, 19,
+ax_anim 2, 0, 60, 8, 8, 8, 8,
+ax_anim_terminator
+sSurskitAnims_3_3:
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 13, 3, 13, 3,
+ax_anim 4, 0, 66, 14, 4, 14, 4,
+ax_anim 2, 0, 67, 28, -3, 28, -3,
+ax_anim 4, 2, 67, 29, -4, 29, -4,
+ax_anim 2, 1, 65, 45, 0, 45, 0,
+ax_anim 2, 0, 65, 45, -1, 45, -1,
+ax_anim 2, 0, 65, 45, 0, 45, 0,
+ax_anim 2, 0, 65, 45, -1, 45, -1,
+ax_anim 2, 0, 65, 45, 0, 45, 0,
+ax_anim 2, 0, 65, 21, -1, 21, -1,
+ax_anim 2, 0, 64, 8, 0, 8, 0,
+ax_anim_terminator
+sSurskitAnims_3_4:
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 16, -17, 16, -17,
+ax_anim 4, 0, 70, 17, -17, 17, -17,
+ax_anim 2, 0, 71, 22, -34, 22, -34,
+ax_anim 4, 2, 71, 22, -35, 22, -35,
+ax_anim 2, 1, 69, 44, -50, 44, -50,
+ax_anim 2, 0, 69, 43, -51, 43, -51,
+ax_anim 2, 0, 69, 44, -50, 44, -50,
+ax_anim 2, 0, 69, 43, -51, 43, -51,
+ax_anim 2, 0, 69, 44, -50, 44, -50,
+ax_anim 2, 0, 69, 19, -27, 19, -27,
+ax_anim 2, 0, 68, 7, -10, 7, -10,
+ax_anim_terminator
+sSurskitAnims_3_5:
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, -4, -15, -4, -15,
+ax_anim 4, 0, 74, -5, -16, -5, -16,
+ax_anim 2, 0, 75, 4, -33, 4, -33,
+ax_anim 4, 2, 75, 5, -33, 5, -33,
+ax_anim 2, 1, 73, 0, -50, 0, -50,
+ax_anim 2, 0, 73, -1, -50, -1, -50,
+ax_anim 2, 0, 73, 0, -50, 0, -50,
+ax_anim 2, 0, 73, -1, -50, -1, -50,
+ax_anim 2, 0, 73, 0, -50, 0, -50,
+ax_anim 2, 0, 73, -1, -26, -1, -26,
+ax_anim 2, 0, 72, 0, -8, 0, -8,
+ax_anim_terminator
+sSurskitAnims_3_6:
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, -16, -17, -16, -17,
+ax_anim 4, 0, 78, -17, -18, -17, -18,
+ax_anim 2, 0, 79, -22, -34, -22, -34,
+ax_anim 4, 2, 79, -22, -35, -22, -35,
+ax_anim 2, 1, 77, -44, -50, -44, -50,
+ax_anim 2, 0, 77, -43, -51, -43, -51,
+ax_anim 2, 0, 77, -44, -50, -44, -50,
+ax_anim 2, 0, 77, -43, -51, -43, -51,
+ax_anim 2, 0, 77, -44, -50, -44, -50,
+ax_anim 2, 0, 77, -19, -27, -19, -27,
+ax_anim 2, 0, 76, -7, -10, -7, -10,
+ax_anim_terminator
+sSurskitAnims_3_7:
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, -13, 3, -13, 3,
+ax_anim 4, 0, 82, -14, 4, -14, 4,
+ax_anim 2, 0, 83, -28, -3, -28, -3,
+ax_anim 4, 2, 83, -29, -4, -29, -4,
+ax_anim 2, 1, 81, -45, 0, -45, 0,
+ax_anim 2, 0, 81, -45, -1, -45, -1,
+ax_anim 2, 0, 81, -45, 0, -45, 0,
+ax_anim 2, 0, 81, -45, -1, -45, -1,
+ax_anim 2, 0, 81, -45, 0, -45, 0,
+ax_anim 2, 0, 81, -21, -1, -21, -1,
+ax_anim 2, 0, 80, -8, 0, -8, 0,
+ax_anim_terminator
+sSurskitAnims_3_8:
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, -10, 16, -10, 16,
+ax_anim 4, 0, 86, -10, 17, -10, 17,
+ax_anim 2, 0, 87, -32, 24, -32, 24,
+ax_anim 4, 2, 87, -33, 24, -33, 24,
+ax_anim 2, 1, 85, -45, 42, -45, 42,
+ax_anim 2, 0, 85, -44, 43, -44, 43,
+ax_anim 2, 0, 85, -45, 42, -45, 42,
+ax_anim 2, 0, 85, -44, 43, -44, 43,
+ax_anim 2, 0, 85, -45, 42, -45, 42,
+ax_anim 2, 0, 85, -20, 19, -20, 19,
+ax_anim 2, 0, 84, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sSurskitAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 6, 2, 88, 0, -2, 0, -2,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 1, 89, -1, 2, -1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, -1, 2, -1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, -1, 2, -1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sSurskitAnims_4_2:
+ax_anim 2, 0, 90, -1, -1, -1, -1,
+ax_anim 6, 2, 90, -2, -2, -2, -2,
+ax_anim 1, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 1, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 3, 1, 3,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim_terminator
+sSurskitAnims_4_3:
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 6, 2, 92, -3, 0, -3, 0,
+ax_anim 1, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 1, 93, 2, -1, 2, -1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, -1, 2, -1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 2, -1, 2, -1,
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim_terminator
+sSurskitAnims_4_4:
+ax_anim 2, 0, 94, -1, 1, -1, 1,
+ax_anim 6, 2, 94, -2, 2, -2, 2,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 1, 95, 1, -3, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 1, -3, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 95, 1, -3, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 1, -1, 1, -1,
+ax_anim_terminator
+sSurskitAnims_4_5:
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 6, 2, 96, 0, 2, 0, 2,
+ax_anim 1, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 1, 97, -1, -2, -1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, -1, -2, -1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 97, -1, -2, -1, -2,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim_terminator
+sSurskitAnims_4_6:
+ax_anim 2, 0, 98, 1, 1, 1, 1,
+ax_anim 6, 2, 98, 2, 2, 2, 2,
+ax_anim 1, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 1, 99, -1, -3, -1, -3,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, -1, -3, -1, -3,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 99, -1, -3, -1, -3,
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 2, 0, 98, -1, -1, -1, -1,
+ax_anim_terminator
+sSurskitAnims_4_7:
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim 6, 2, 100, 3, 0, 3, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 1, 101, -2, -1, -2, -1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, -1, -2, -1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -2, -1, -2, -1,
+ax_anim 2, 0, 101, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim_terminator
+sSurskitAnims_4_8:
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 6, 2, 102, 2, -2, 2, -2,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 1, 103, -1, 3, -1, 3,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -1, 3, -1, 3,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -1, 3, -1, 3,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSurskitAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSurskitAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSurskitAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sSurskitAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sSurskitAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sSurskitAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sSurskitAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sSurskitAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sSurskitAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sSurskitAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSurskitAnims_8_1:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 16, 0, 122, 1, 0, 1, 0,
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 16, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sSurskitAnims_8_2:
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 16, 0, 129, -1, 1, -1, 1,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 16, 0, 129, 1, -1, 1, -1,
+ax_anim_terminator
+sSurskitAnims_8_3:
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 16, 0, 128, 0, 1, 0, 1,
+ax_anim 8, 0, 128, 0, 0, 0, 0,
+ax_anim 16, 0, 128, 0, -1, 0, -1,
+ax_anim_terminator
+sSurskitAnims_8_4:
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 16, 0, 127, 1, 1, 1, 1,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 16, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+sSurskitAnims_8_5:
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 16, 0, 126, -1, 0, -1, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 16, 0, 126, 1, 0, 1, 0,
+ax_anim_terminator
+sSurskitAnims_8_6:
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 16, 0, 125, -1, 1, -1, 1,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 16, 0, 125, 1, -1, 1, -1,
+ax_anim_terminator
+sSurskitAnims_8_7:
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 16, 0, 124, 0, 1, 0, 1,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 16, 0, 124, 0, -1, 0, -1,
+ax_anim_terminator
+sSurskitAnims_8_8:
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 16, 0, 123, 1, 1, 1, 1,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 16, 0, 123, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sSurskitAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 5, 4, 5, 4,
+ax_anim 2, 0, 132, 8, 11, 8, 11,
+ax_anim 2, 0, 133, 7, 17, 7, 17,
+ax_anim 3, 0, 134, 0, 19, 0, 19,
+ax_anim 2, 3, 135, -7, 17, -7, 17,
+ax_anim 2, 0, 136, -8, 11, -8, 11,
+ax_anim 1, 0, 137, -5, 4, -5, 4,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 9, -1, 9, -1,
+ax_anim 2, 0, 131, 20, 4, 20, 4,
+ax_anim 2, 0, 132, 25, 10, 25, 10,
+ax_anim 3, 0, 133, 22, 17, 22, 17,
+ax_anim 2, 3, 134, 11, 19, 11, 19,
+ax_anim 2, 0, 135, 4, 16, 4, 16,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 4, -4, 4, -4,
+ax_anim 2, 0, 130, 10, -7, 10, -7,
+ax_anim 2, 0, 131, 18, -5, 18, -5,
+ax_anim 3, 0, 132, 22, -2, 22, -2,
+ax_anim 2, 3, 133, 18, 3, 18, 3,
+ax_anim 2, 0, 134, 11, 4, 11, 4,
+ax_anim 1, 0, 135, 4, 4, 4, 4,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, -9, 0, -9,
+ax_anim 2, 0, 137, 2, -17, 2, -17,
+ax_anim 2, 0, 130, 10, -25, 10, -25,
+ax_anim 3, 0, 131, 21, -25, 21, -25,
+ax_anim 2, 3, 132, 23, -15, 23, -15,
+ax_anim 2, 0, 133, 17, -4, 17, -4,
+ax_anim 1, 0, 134, 8, -1, 8, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -8, -4, -8, -4,
+ax_anim 2, 0, 136, -9, -11, -9, -11,
+ax_anim 2, 0, 137, -8, -22, -8, -22,
+ax_anim 3, 0, 130, 0, -28, 0, -28,
+ax_anim 2, 3, 131, 8, -22, 8, -22,
+ax_anim 2, 0, 132, 9, -11, 9, -11,
+ax_anim 1, 0, 133, 8, -4, 8, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -9, 0, -9,
+ax_anim 2, 0, 131, -2, -17, -2, -17,
+ax_anim 2, 0, 130, -10, -25, -10, -25,
+ax_anim 3, 0, 137, -21, -25, -21, -25,
+ax_anim 2, 3, 136, -23, -15, -23, -15,
+ax_anim 2, 0, 135, -17, -4, -17, -4,
+ax_anim 1, 0, 134, -8, -1, -8, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -4, -4, -4, -4,
+ax_anim 2, 0, 130, -10, -7, -10, -7,
+ax_anim 2, 0, 137, -18, -5, -18, -5,
+ax_anim 3, 0, 136, -22, -2, -22, -2,
+ax_anim 2, 3, 135, -18, 3, -18, 3,
+ax_anim 2, 0, 134, -11, 4, -11, 4,
+ax_anim 1, 0, 133, -4, 4, -4, 4,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -9, -1, -9, -1,
+ax_anim 2, 0, 137, -20, 4, -20, 4,
+ax_anim 2, 0, 136, -25, 10, -25, 10,
+ax_anim 3, 0, 135, -22, 17, -22, 17,
+ax_anim 2, 3, 134, -11, 19, -11, 19,
+ax_anim 2, 0, 133, -4, 16, -4, 16,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSurskitAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSurskitAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -10, 0, 0,
+ax_anim 2, 0, 146, 0, -16, 0, 0,
+ax_anim 3, 0, 146, 0, -20, 0, 0,
+ax_anim 4, 0, 146, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -24, 0, 0,
+ax_anim 3, 0, 147, 0, -22, 0, 0,
+ax_anim 2, 0, 147, 0, -18, 0, 0,
+ax_anim 1, 0, 147, 0, -12, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_11_2:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 149, 0, -23, 0, 0,
+ax_anim 3, 0, 149, 0, -22, 0, 0,
+ax_anim 2, 0, 149, 0, -18, 0, 0,
+ax_anim 1, 0, 149, 0, -12, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_11_3:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 151, 0, -23, 0, 0,
+ax_anim 3, 0, 151, 0, -22, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_11_4:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -10, 0, 0,
+ax_anim 2, 0, 152, 0, -16, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 4, 0, 152, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -22, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 2, 0, 153, 0, -17, 0, 0,
+ax_anim 1, 0, 153, 0, -11, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_11_5:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 155, 0, -23, 0, 0,
+ax_anim 3, 0, 155, 0, -22, 0, 0,
+ax_anim 2, 0, 155, 0, -18, 0, 0,
+ax_anim 1, 0, 155, 0, -12, 0, 0,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_11_6:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 157, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -21, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_11_7:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_11_8:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -23, 0, 0,
+ax_anim 3, 0, 161, 0, -22, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSurskitAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSurskitAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSurskitGfx1:
+.incbin "baserom.gba", 0x118CF54, 0x200
+sSurskitSprites1:
+ax_sprite sSurskitGfx1, 0x200
+ax_sprite_terminator
+sSurskitGfx2:
+.incbin "baserom.gba", 0x118D164, 0x100
+sSurskitSprites2:
+ax_sprite sSurskitGfx2, 0x100
+ax_sprite_terminator
+sSurskitGfx3:
+.incbin "baserom.gba", 0x118D274, 0x100
+sSurskitSprites3:
+ax_sprite sSurskitGfx3, 0x100
+ax_sprite_terminator
+sSurskitGfx4:
+.incbin "baserom.gba", 0x118D384, 0x200
+sSurskitSprites4:
+ax_sprite sSurskitGfx4, 0x200
+ax_sprite_terminator
+sSurskitGfx5:
+.incbin "baserom.gba", 0x118D594, 0x200
+sSurskitSprites5:
+ax_sprite sSurskitGfx5, 0x200
+ax_sprite_terminator
+sSurskitGfx6:
+.incbin "baserom.gba", 0x118D7A4, 0x200
+sSurskitSprites6:
+ax_sprite sSurskitGfx6, 0x200
+ax_sprite_terminator
+sSurskitGfx7:
+.incbin "baserom.gba", 0x118D9B4, 0x200
+sSurskitSprites7:
+ax_sprite sSurskitGfx7, 0x200
+ax_sprite_terminator
+sSurskitGfx8:
+.incbin "baserom.gba", 0x118DBC4, 0x200
+sSurskitSprites8:
+ax_sprite sSurskitGfx8, 0x200
+ax_sprite_terminator
+sSurskitGfx9:
+.incbin "baserom.gba", 0x118DDD4, 0x200
+sSurskitSprites9:
+ax_sprite sSurskitGfx9, 0x200
+ax_sprite_terminator
+sSurskitGfx10:
+.incbin "baserom.gba", 0x118DFE4, 0x200
+sSurskitSprites10:
+ax_sprite sSurskitGfx10, 0x200
+ax_sprite_terminator
+sSurskitGfx11:
+.incbin "baserom.gba", 0x118E1F4, 0x200
+sSurskitSprites11:
+ax_sprite sSurskitGfx11, 0x200
+ax_sprite_terminator
+sSurskitGfx12:
+.incbin "baserom.gba", 0x118E404, 0x200
+sSurskitSprites12:
+ax_sprite sSurskitGfx12, 0x200
+ax_sprite_terminator
+sSurskitGfx13:
+.incbin "baserom.gba", 0x118E614, 0x200
+sSurskitSprites13:
+ax_sprite sSurskitGfx13, 0x200
+ax_sprite_terminator
+sSurskitGfx14:
+.incbin "baserom.gba", 0x118E824, 0x100
+sSurskitSprites14:
+ax_sprite sSurskitGfx14, 0x100
+ax_sprite_terminator
+sSurskitGfx15:
+.incbin "baserom.gba", 0x118E934, 0x100
+sSurskitSprites15:
+ax_sprite sSurskitGfx15, 0x100
+ax_sprite_terminator
+sSurskitGfx16:
+.incbin "baserom.gba", 0x118EA44, 0x20
+sSurskitGfx16_1:
+.incbin "baserom.gba", 0x118EA64, 0x60
+sSurskitGfx16_2:
+.incbin "baserom.gba", 0x118EAC4, 0x60
+sSurskitSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSurskitGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSurskitGfx17:
+.incbin "baserom.gba", 0x118EB64, 0x40
+sSurskitGfx17_1:
+.incbin "baserom.gba", 0x118EBA4, 0x80
+sSurskitGfx17_2:
+.incbin "baserom.gba", 0x118EC24, 0x20
+sSurskitSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx17_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sSurskitGfx17_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSurskitGfx18:
+.incbin "baserom.gba", 0x118EC84, 0x20
+sSurskitGfx18_1:
+.incbin "baserom.gba", 0x118ECA4, 0x60
+sSurskitGfx18_2:
+.incbin "baserom.gba", 0x118ED04, 0x60
+sSurskitSprites18:
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSurskitGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSurskitGfx19:
+.incbin "baserom.gba", 0x118EDA4, 0x40
+sSurskitGfx19_1:
+.incbin "baserom.gba", 0x118EDE4, 0x60
+sSurskitGfx19_2:
+.incbin "baserom.gba", 0x118EE44, 0x20
+sSurskitSprites19:
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSurskitGfx19_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSurskitGfx20:
+.incbin "baserom.gba", 0x118EEA4, 0x60
+sSurskitGfx20_1:
+.incbin "baserom.gba", 0x118EF04, 0x60
+sSurskitGfx20_2:
+.incbin "baserom.gba", 0x118EF64, 0x20
+sSurskitGfx20_3:
+.incbin "baserom.gba", 0x118EF84, 0x20
+sSurskitSprites20:
+ax_sprite sSurskitGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx20_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx20_3, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSurskitGfx21:
+.incbin "baserom.gba", 0x118EFEC, 0x60
+sSurskitGfx21_1:
+.incbin "baserom.gba", 0x118F04C, 0x60
+sSurskitSprites21:
+ax_sprite sSurskitGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSurskitGfx22:
+.incbin "baserom.gba", 0x118F0D4, 0x20
+sSurskitGfx22_1:
+.incbin "baserom.gba", 0x118F0F4, 0x80
+sSurskitGfx22_2:
+.incbin "baserom.gba", 0x118F174, 0x40
+sSurskitSprites22:
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSurskitGfx22_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx22_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSurskitGfx23:
+.incbin "baserom.gba", 0x118F1F4, 0x60
+sSurskitGfx23_1:
+.incbin "baserom.gba", 0x118F254, 0x60
+sSurskitSprites23:
+ax_sprite sSurskitGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSurskitGfx24:
+.incbin "baserom.gba", 0x118F2DC, 0x60
+sSurskitGfx24_1:
+.incbin "baserom.gba", 0x118F33C, 0x60
+sSurskitGfx24_2:
+.incbin "baserom.gba", 0x118F39C, 0x20
+sSurskitSprites24:
+ax_sprite sSurskitGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSurskitGfx24_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSurskitGfx25:
+.incbin "baserom.gba", 0x118F3F4, 0x60
+sSurskitGfx25_1:
+.incbin "baserom.gba", 0x118F454, 0x60
+sSurskitSprites25:
+ax_sprite sSurskitGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSurskitGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSurskitGfx26:
+.incbin "baserom.gba", 0x118F4DC, 0x200
+sSurskitSprites26:
+ax_sprite sSurskitGfx26, 0x200
+ax_sprite_terminator
+sSurskitGfx27:
+.incbin "baserom.gba", 0x118F6EC, 0x200
+sSurskitSprites27:
+ax_sprite sSurskitGfx27, 0x200
+ax_sprite_terminator
+sSurskitGfx28:
+.incbin "baserom.gba", 0x118F8FC, 0x200
+sSurskitSprites28:
+ax_sprite sSurskitGfx28, 0x200
+ax_sprite_terminator
+sSurskitGfx29:
+.incbin "baserom.gba", 0x118FB0C, 0x200
+sSurskitSprites29:
+ax_sprite sSurskitGfx29, 0x200
+ax_sprite_terminator
+sSurskitGfx30:
+.incbin "baserom.gba", 0x118FD1C, 0x200
+sSurskitSprites30:
+ax_sprite sSurskitGfx30, 0x200
+ax_sprite_terminator
+sSurskitGfx31:
+.incbin "baserom.gba", 0x118FF2C, 0x200
+sSurskitSprites31:
+ax_sprite sSurskitGfx31, 0x200
+ax_sprite_terminator
+sSurskitGfx32:
+.incbin "baserom.gba", 0x119013C, 0x200
+sSurskitSprites32:
+ax_sprite sSurskitGfx32, 0x200
+ax_sprite_terminator
+sAxPosesSurskit:
+.4byte sSurskitPose1
+.4byte sSurskitPose2
+.4byte sSurskitPose3
+.4byte sSurskitPose4
+.4byte sSurskitPose5
+.4byte sSurskitPose6
+.4byte sSurskitPose7
+.4byte sSurskitPose8
+.4byte sSurskitPose9
+.4byte sSurskitPose10
+.4byte sSurskitPose11
+.4byte sSurskitPose12
+.4byte sSurskitPose13
+.4byte sSurskitPose14
+.4byte sSurskitPose15
+.4byte sSurskitPose16
+.4byte sSurskitPose17
+.4byte sSurskitPose18
+.4byte sSurskitPose19
+.4byte sSurskitPose20
+.4byte sSurskitPose21
+.4byte sSurskitPose22
+.4byte sSurskitPose23
+.4byte sSurskitPose24
+.4byte sSurskitPose25
+.4byte sSurskitPose26
+.4byte sSurskitPose27
+.4byte sSurskitPose28
+.4byte sSurskitPose29
+.4byte sSurskitPose30
+.4byte sSurskitPose31
+.4byte sSurskitPose32
+.4byte sSurskitPose33
+.4byte sSurskitPose34
+.4byte sSurskitPose35
+.4byte sSurskitPose36
+.4byte sSurskitPose37
+.4byte sSurskitPose38
+.4byte sSurskitPose39
+.4byte sSurskitPose40
+.4byte sSurskitPose41
+.4byte sSurskitPose42
+.4byte sSurskitPose43
+.4byte sSurskitPose44
+.4byte sSurskitPose45
+.4byte sSurskitPose46
+.4byte sSurskitPose47
+.4byte sSurskitPose48
+.4byte sSurskitPose49
+.4byte sSurskitPose50
+.4byte sSurskitPose51
+.4byte sSurskitPose52
+.4byte sSurskitPose53
+.4byte sSurskitPose54
+.4byte sSurskitPose55
+.4byte sSurskitPose56
+.4byte sSurskitPose57
+.4byte sSurskitPose58
+.4byte sSurskitPose59
+.4byte sSurskitPose60
+.4byte sSurskitPose61
+.4byte sSurskitPose62
+.4byte sSurskitPose63
+.4byte sSurskitPose64
+.4byte sSurskitPose65
+.4byte sSurskitPose66
+.4byte sSurskitPose67
+.4byte sSurskitPose68
+.4byte sSurskitPose69
+.4byte sSurskitPose70
+.4byte sSurskitPose71
+.4byte sSurskitPose72
+.4byte sSurskitPose73
+.4byte sSurskitPose74
+.4byte sSurskitPose75
+.4byte sSurskitPose76
+.4byte sSurskitPose77
+.4byte sSurskitPose78
+.4byte sSurskitPose79
+.4byte sSurskitPose80
+.4byte sSurskitPose81
+.4byte sSurskitPose82
+.4byte sSurskitPose83
+.4byte sSurskitPose84
+.4byte sSurskitPose85
+.4byte sSurskitPose86
+.4byte sSurskitPose87
+.4byte sSurskitPose88
+.4byte sSurskitPose89
+.4byte sSurskitPose90
+.4byte sSurskitPose91
+.4byte sSurskitPose92
+.4byte sSurskitPose93
+.4byte sSurskitPose94
+.4byte sSurskitPose95
+.4byte sSurskitPose96
+.4byte sSurskitPose97
+.4byte sSurskitPose98
+.4byte sSurskitPose99
+.4byte sSurskitPose100
+.4byte sSurskitPose101
+.4byte sSurskitPose102
+.4byte sSurskitPose103
+.4byte sSurskitPose104
+.4byte sSurskitPose105
+.4byte sSurskitPose106
+.4byte sSurskitPose107
+.4byte sSurskitPose108
+.4byte sSurskitPose109
+.4byte sSurskitPose110
+.4byte sSurskitPose111
+.4byte sSurskitPose112
+.4byte sSurskitPose113
+.4byte sSurskitPose114
+.4byte sSurskitPose115
+.4byte sSurskitPose116
+.4byte sSurskitPose117
+.4byte sSurskitPose118
+.4byte sSurskitPose119
+.4byte sSurskitPose120
+.4byte sSurskitPose121
+.4byte sSurskitPose122
+.4byte sSurskitPose123
+.4byte sSurskitPose124
+.4byte sSurskitPose125
+.4byte sSurskitPose126
+.4byte sSurskitPose127
+.4byte sSurskitPose128
+.4byte sSurskitPose129
+.4byte sSurskitPose130
+.4byte sSurskitPose131
+.4byte sSurskitPose132
+.4byte sSurskitPose133
+.4byte sSurskitPose134
+.4byte sSurskitPose135
+.4byte sSurskitPose136
+.4byte sSurskitPose137
+.4byte sSurskitPose138
+.4byte sSurskitPose139
+.4byte sSurskitPose140
+.4byte sSurskitPose141
+.4byte sSurskitPose142
+.4byte sSurskitPose143
+.4byte sSurskitPose144
+.4byte sSurskitPose145
+.4byte sSurskitPose146
+.4byte sSurskitPose147
+.4byte sSurskitPose148
+.4byte sSurskitPose149
+.4byte sSurskitPose150
+.4byte sSurskitPose151
+.4byte sSurskitPose152
+.4byte sSurskitPose153
+.4byte sSurskitPose154
+.4byte sSurskitPose155
+.4byte sSurskitPose156
+.4byte sSurskitPose157
+.4byte sSurskitPose158
+.4byte sSurskitPose159
+.4byte sSurskitPose160
+.4byte sSurskitPose161
+.4byte sSurskitPose162
+.4byte sSurskitPose163
+.4byte sSurskitPose164
+.4byte sSurskitPose165
+.4byte sSurskitPose166
+.4byte sSurskitPose167
+.4byte sSurskitPose168
+.4byte sSurskitPose169
+.4byte sSurskitPose170
+.4byte sSurskitPose171
+.4byte sSurskitPose172
+.4byte sSurskitPose173
+.4byte sSurskitPose174
+.4byte sSurskitPose175
+.4byte sSurskitPose176
+.4byte sSurskitPose177
+.4byte sSurskitPose178
+sAxPositionsSurskit:
+.2byte    0,   -2, 	 -10,    1, 	  10,    1, 	   0,   -5
+.2byte    1,   -1, 	  -9,    1, 	  10,    1, 	   1,   -4
+.2byte   -2,   -1, 	 -11,    1, 	   8,    1, 	  -2,   -4
+.2byte    3,   -2, 	   9,   -1, 	  -4,    3, 	   1,   -5
+.2byte    2,    0, 	   9,   -1, 	  -4,    3, 	   0,   -3
+.2byte    4,   -1, 	   9,   -1, 	  -4,    3, 	   2,   -4
+.2byte    4,   -4, 	   6,   -3, 	   7,    2, 	   0,   -6
+.2byte    4,   -3, 	   6,   -3, 	   7,    2, 	   0,   -5
+.2byte    4,   -5, 	   6,   -3, 	   7,    2, 	   0,   -7
+.2byte    3,   -5, 	   0,   -9, 	   9,   -2, 	   0,   -6
+.2byte    4,   -3, 	   1,   -7, 	  10,   -2, 	   1,   -4
+.2byte    2,   -4, 	  -1,   -8, 	   9,   -2, 	  -1,   -5
+.2byte    0,   -5, 	   9,   -4, 	  -9,   -4, 	   0,   -6
+.2byte   -1,   -4, 	   8,   -4, 	  -9,   -4, 	  -1,   -5
+.2byte    1,   -4, 	   9,   -4, 	  -8,   -4, 	   1,   -5
+.2byte   -3,   -5, 	   0,   -9, 	  -9,   -2, 	   0,   -6
+.2byte   -4,   -3, 	  -1,   -7, 	 -10,   -2, 	  -1,   -4
+.2byte   -2,   -4, 	   1,   -8, 	  -9,   -2, 	   1,   -5
+.2byte   -4,   -4, 	  -6,   -3, 	  -7,    2, 	   0,   -6
+.2byte   -4,   -3, 	  -6,   -3, 	  -7,    2, 	   0,   -5
+.2byte   -4,   -5, 	  -6,   -3, 	  -7,    2, 	   0,   -7
+.2byte   -3,   -2, 	  -9,   -1, 	   4,    3, 	  -1,   -5
+.2byte   -2,    0, 	  -9,   -1, 	   4,    3, 	   0,   -3
+.2byte   -4,   -1, 	  -9,   -1, 	   4,    3, 	  -2,   -4
+.2byte    0,   -4, 	 -10,    1, 	  10,    1, 	   0,   -7
+.2byte    0,   -2, 	 -10,    1, 	  10,    1, 	   0,   -5
+.2byte    1,   -1, 	  -9,    1, 	  10,    1, 	   1,   -4
+.2byte   -2,   -1, 	 -11,    1, 	   8,    1, 	  -2,   -4
+.2byte    3,   -4, 	  10,   -3, 	  -3,    3, 	   1,   -7
+.2byte    3,   -2, 	   9,   -1, 	  -4,    3, 	   1,   -5
+.2byte    2,    0, 	   9,   -1, 	  -4,    3, 	   0,   -3
+.2byte    4,   -1, 	   9,   -1, 	  -4,    3, 	   2,   -4
+.2byte    4,   -5, 	   7,   -5, 	   8,    2, 	   0,   -7
+.2byte    4,   -4, 	   6,   -3, 	   7,    2, 	   0,   -6
+.2byte    4,   -3, 	   6,   -3, 	   7,    2, 	   0,   -5
+.2byte    4,   -5, 	   6,   -3, 	   7,    2, 	   0,   -7
+.2byte    3,   -6, 	   0,  -10, 	  10,   -3, 	   0,   -7
+.2byte    3,   -5, 	   0,   -9, 	   9,   -2, 	   0,   -6
+.2byte    4,   -3, 	   1,   -7, 	  10,   -2, 	   1,   -4
+.2byte    2,   -4, 	  -1,   -8, 	   9,   -2, 	  -1,   -5
+.2byte    0,   -6, 	   9,   -4, 	  -9,   -4, 	   0,   -7
+.2byte    0,   -5, 	   9,   -4, 	  -9,   -4, 	   0,   -6
+.2byte   -1,   -4, 	   8,   -4, 	  -9,   -4, 	  -1,   -5
+.2byte    1,   -4, 	   9,   -4, 	  -8,   -4, 	   1,   -5
+.2byte   -3,   -6, 	   0,  -10, 	 -10,   -3, 	   0,   -7
+.2byte   -3,   -5, 	   0,   -9, 	  -9,   -2, 	   0,   -6
+.2byte   -4,   -3, 	  -1,   -7, 	 -10,   -2, 	  -1,   -4
+.2byte   -2,   -4, 	   1,   -8, 	  -9,   -2, 	   1,   -5
+.2byte   -4,   -5, 	  -7,   -5, 	  -8,    2, 	   0,   -7
+.2byte   -4,   -4, 	  -6,   -3, 	  -7,    2, 	   0,   -6
+.2byte   -4,   -3, 	  -6,   -3, 	  -7,    2, 	   0,   -5
+.2byte   -4,   -5, 	  -6,   -3, 	  -7,    2, 	   0,   -7
+.2byte   -3,   -4, 	 -10,   -3, 	   3,    3, 	  -1,   -7
+.2byte   -3,   -2, 	  -9,   -1, 	   4,    3, 	  -1,   -5
+.2byte   -2,    0, 	  -9,   -1, 	   4,    3, 	   0,   -3
+.2byte   -4,   -1, 	  -9,   -1, 	   4,    3, 	  -2,   -4
+.2byte    0,   -4, 	 -10,    1, 	  10,    1, 	   0,   -7
+.2byte    0,   -2, 	 -10,    1, 	  10,    1, 	   0,   -5
+.2byte    1,   -1, 	  -9,    1, 	  10,    1, 	   1,   -4
+.2byte   -2,   -1, 	 -11,    1, 	   8,    1, 	  -2,   -4
+.2byte    3,   -4, 	  10,   -3, 	  -3,    3, 	   1,   -7
+.2byte    3,   -2, 	   9,   -1, 	  -4,    3, 	   1,   -5
+.2byte    2,    0, 	   9,   -1, 	  -4,    3, 	   0,   -3
+.2byte    4,   -1, 	   9,   -1, 	  -4,    3, 	   2,   -4
+.2byte    4,   -5, 	   7,   -5, 	   8,    2, 	   0,   -7
+.2byte    4,   -4, 	   6,   -3, 	   7,    2, 	   0,   -6
+.2byte    4,   -3, 	   6,   -3, 	   7,    2, 	   0,   -5
+.2byte    4,   -5, 	   6,   -3, 	   7,    2, 	   0,   -7
+.2byte    3,   -6, 	   0,  -10, 	  10,   -3, 	   0,   -7
+.2byte    3,   -5, 	   0,   -9, 	   9,   -2, 	   0,   -6
+.2byte    4,   -3, 	   1,   -7, 	  10,   -2, 	   1,   -4
+.2byte    2,   -4, 	  -1,   -8, 	   9,   -2, 	  -1,   -5
+.2byte    0,   -6, 	   9,   -4, 	  -9,   -4, 	   0,   -7
+.2byte    0,   -5, 	   9,   -4, 	  -9,   -4, 	   0,   -6
+.2byte   -1,   -4, 	   8,   -4, 	  -9,   -4, 	  -1,   -5
+.2byte    1,   -4, 	   9,   -4, 	  -8,   -4, 	   1,   -5
+.2byte   -3,   -6, 	   0,  -10, 	 -10,   -3, 	   0,   -7
+.2byte   -3,   -5, 	   0,   -9, 	  -9,   -2, 	   0,   -6
+.2byte   -4,   -3, 	  -1,   -7, 	 -10,   -2, 	  -1,   -4
+.2byte   -2,   -4, 	   1,   -8, 	  -9,   -2, 	   1,   -5
+.2byte   -4,   -5, 	  -7,   -5, 	  -8,    2, 	   0,   -7
+.2byte   -4,   -4, 	  -6,   -3, 	  -7,    2, 	   0,   -6
+.2byte   -4,   -3, 	  -6,   -3, 	  -7,    2, 	   0,   -5
+.2byte   -4,   -5, 	  -6,   -3, 	  -7,    2, 	   0,   -7
+.2byte   -3,   -4, 	 -10,   -3, 	   3,    3, 	  -1,   -7
+.2byte   -3,   -2, 	  -9,   -1, 	   4,    3, 	  -1,   -5
+.2byte   -2,    0, 	  -9,   -1, 	   4,    3, 	   0,   -3
+.2byte   -4,   -1, 	  -9,   -1, 	   4,    3, 	  -2,   -4
+.2byte    0,   -4, 	 -10,    1, 	  10,    1, 	   0,   -7
+.2byte    0,    1, 	 -10,    1, 	  10,    1, 	   0,   -3
+.2byte    3,   -4, 	  10,   -3, 	  -3,    3, 	   1,   -7
+.2byte    3,    0, 	  10,   -3, 	  -4,    3, 	   2,   -4
+.2byte    4,   -5, 	   7,   -5, 	   8,    2, 	   0,   -7
+.2byte    4,   -1, 	   7,   -6, 	   7,    2, 	   2,   -4
+.2byte    3,   -6, 	   0,  -10, 	  10,   -3, 	   0,   -7
+.2byte    5,   -4, 	   4,   -9, 	  11,   -3, 	   3,   -7
+.2byte    0,   -6, 	   9,   -4, 	  -9,   -4, 	   0,   -7
+.2byte    0,   -4, 	   9,   -4, 	  -9,   -4, 	   0,   -6
+.2byte   -3,   -6, 	   0,  -10, 	 -10,   -3, 	   0,   -7
+.2byte   -5,   -4, 	  -4,   -9, 	 -11,   -3, 	  -3,   -7
+.2byte   -4,   -5, 	  -7,   -5, 	  -8,    2, 	   0,   -7
+.2byte   -4,   -1, 	  -7,   -6, 	  -7,    2, 	  -2,   -4
+.2byte   -3,   -4, 	 -10,   -3, 	   3,    3, 	  -1,   -7
+.2byte   -3,    0, 	 -10,   -3, 	   4,    3, 	  -2,   -4
+.2byte    0,   -4, 	 -10,    1, 	  10,    1, 	   0,   -7
+.2byte   -3,   -4, 	 -10,   -3, 	   3,    3, 	  -1,   -7
+.2byte   -4,   -5, 	  -7,   -5, 	  -8,    2, 	   0,   -7
+.2byte   -3,   -6, 	   0,  -10, 	 -10,   -3, 	   0,   -7
+.2byte    0,   -6, 	   9,   -4, 	  -9,   -4, 	   0,   -7
+.2byte    3,   -6, 	   0,  -10, 	  10,   -3, 	   0,   -7
+.2byte    4,   -5, 	   7,   -5, 	   8,    2, 	   0,   -7
+.2byte    3,   -4, 	  10,   -3, 	  -3,    3, 	   1,   -7
+.2byte   -3,   -1, 	 -10,   -1, 	   4,    5, 	  -1,   -4
+.2byte   -3,   -2, 	 -10,   -1, 	   4,    5, 	  -1,   -4
+.2byte    0,   -1, 	  -8,   -7, 	   8,   -7, 	   0,   -4
+.2byte    3,   -1, 	   8,  -10, 	  -4,  -10, 	   1,   -4
+.2byte    4,   -1, 	   6,  -11, 	   7,   -6, 	   0,   -4
+.2byte    3,   -3, 	   0,  -12, 	   8,   -9, 	   1,   -4
+.2byte    0,   -3, 	   7,  -11, 	  -7,  -11, 	   0,   -4
+.2byte   -3,   -3, 	   0,  -12, 	  -8,   -9, 	  -1,   -4
+.2byte   -4,   -1, 	  -6,  -11, 	  -7,   -6, 	   0,   -4
+.2byte   -3,   -1, 	  -8,  -10, 	   4,  -10, 	  -1,   -4
+.2byte    0,   -4, 	 -10,    1, 	  10,    1, 	   0,   -7
+.2byte   -3,   -4, 	 -10,   -3, 	   3,    3, 	  -1,   -7
+.2byte   -4,   -5, 	  -7,   -5, 	  -8,    2, 	   0,   -7
+.2byte   -3,   -6, 	   0,  -10, 	 -10,   -3, 	   0,   -7
+.2byte    0,   -6, 	   9,   -4, 	  -9,   -4, 	   0,   -7
+.2byte    3,   -6, 	   0,  -10, 	  10,   -3, 	   0,   -7
+.2byte    4,   -5, 	   7,   -5, 	   8,    2, 	   0,   -7
+.2byte    3,   -4, 	  10,   -3, 	  -3,    3, 	   1,   -7
+.2byte    0,    1, 	 -10,    1, 	  10,    1, 	   0,   -3
+.2byte   -3,    0, 	 -10,   -3, 	   4,    3, 	  -2,   -4
+.2byte   -4,   -1, 	  -7,   -6, 	  -7,    2, 	  -2,   -4
+.2byte   -3,   -3, 	  -2,   -8, 	  -9,   -2, 	  -1,   -6
+.2byte    0,   -4, 	   9,   -4, 	  -9,   -4, 	   0,   -6
+.2byte    2,   -3, 	   1,   -8, 	   8,   -2, 	   0,   -6
+.2byte    3,   -1, 	   6,   -6, 	   6,    2, 	   1,   -4
+.2byte    2,    0, 	   9,   -3, 	  -5,    3, 	   1,   -4
+.2byte    0,   -2, 	 -10,    1, 	  10,    1, 	   0,   -5
+.2byte    3,   -2, 	   9,   -1, 	  -4,    3, 	   1,   -5
+.2byte    4,   -4, 	   6,   -3, 	   7,    2, 	   0,   -6
+.2byte    3,   -5, 	   0,   -9, 	   9,   -2, 	   0,   -6
+.2byte    0,   -5, 	   9,   -4, 	  -9,   -4, 	   0,   -6
+.2byte   -3,   -5, 	   0,   -9, 	  -9,   -2, 	   0,   -6
+.2byte   -4,   -4, 	  -6,   -3, 	  -7,    2, 	   0,   -6
+.2byte   -3,   -2, 	  -9,   -1, 	   4,    3, 	  -1,   -5
+.2byte    0,   -4, 	 -10,    1, 	  10,    1, 	   0,   -7
+.2byte    0,    1, 	 -10,    1, 	  10,    1, 	   0,   -3
+.2byte    3,   -4, 	  10,   -3, 	  -3,    3, 	   1,   -7
+.2byte    3,    0, 	  10,   -3, 	  -4,    3, 	   2,   -4
+.2byte    4,   -5, 	   7,   -5, 	   8,    2, 	   0,   -7
+.2byte    4,   -1, 	   7,   -6, 	   7,    2, 	   2,   -4
+.2byte    3,   -6, 	   0,  -10, 	  10,   -3, 	   0,   -7
+.2byte    3,   -2, 	   2,   -7, 	   9,   -1, 	   1,   -5
+.2byte    0,   -6, 	   9,   -4, 	  -9,   -4, 	   0,   -7
+.2byte    0,   -4, 	   9,   -4, 	  -9,   -4, 	   0,   -6
+.2byte   -3,   -6, 	   0,  -10, 	 -10,   -3, 	   0,   -7
+.2byte   -3,   -2, 	  -2,   -7, 	  -9,   -1, 	  -1,   -5
+.2byte   -4,   -5, 	  -7,   -5, 	  -8,    2, 	   0,   -7
+.2byte   -3,   -1, 	  -6,   -6, 	  -6,    2, 	  -1,   -4
+.2byte   -3,   -4, 	 -10,   -3, 	   3,    3, 	  -1,   -7
+.2byte   -3,    0, 	 -10,   -3, 	   4,    3, 	  -2,   -4
+.2byte    0,    1, 	 -10,    1, 	  10,    1, 	   0,   -3
+.2byte   -3,    1, 	 -10,   -2, 	   4,    4, 	  -2,   -3
+.2byte   -3,   -1, 	  -6,   -6, 	  -6,    2, 	  -1,   -4
+.2byte   -3,   -3, 	  -2,   -8, 	  -9,   -2, 	  -1,   -6
+.2byte    0,   -5, 	   9,   -5, 	  -9,   -5, 	   0,   -7
+.2byte    2,   -3, 	   1,   -8, 	   8,   -2, 	   0,   -6
+.2byte    2,   -1, 	   5,   -6, 	   5,    2, 	   0,   -4
+.2byte    2,    1, 	   9,   -2, 	  -5,    4, 	   1,   -3
+.2byte    0,   -4, 	 -10,    1, 	  10,    1, 	   0,   -7
+.2byte   -3,   -4, 	 -10,   -3, 	   3,    3, 	  -1,   -7
+.2byte   -4,   -5, 	  -7,   -5, 	  -8,    2, 	   0,   -7
+.2byte   -3,   -6, 	   0,  -10, 	 -10,   -3, 	   0,   -7
+.2byte    0,   -6, 	   9,   -4, 	  -9,   -4, 	   0,   -7
+.2byte    3,   -6, 	   0,  -10, 	  10,   -3, 	   0,   -7
+.2byte    4,   -5, 	   7,   -5, 	   8,    2, 	   0,   -7
+.2byte    3,   -4, 	  10,   -3, 	  -3,    3, 	   1,   -7
+sSurskitAnimTable1:
+.4byte sSurskitAnims_1_1
+.4byte sSurskitAnims_1_2
+.4byte sSurskitAnims_1_3
+.4byte sSurskitAnims_1_4
+.4byte sSurskitAnims_1_5
+.4byte sSurskitAnims_1_6
+.4byte sSurskitAnims_1_7
+.4byte sSurskitAnims_1_8
+sSurskitAnimTable2:
+.4byte sSurskitAnims_2_1
+.4byte sSurskitAnims_2_2
+.4byte sSurskitAnims_2_3
+.4byte sSurskitAnims_2_4
+.4byte sSurskitAnims_2_5
+.4byte sSurskitAnims_2_6
+.4byte sSurskitAnims_2_7
+.4byte sSurskitAnims_2_8
+sSurskitAnimTable3:
+.4byte sSurskitAnims_3_1
+.4byte sSurskitAnims_3_2
+.4byte sSurskitAnims_3_3
+.4byte sSurskitAnims_3_4
+.4byte sSurskitAnims_3_5
+.4byte sSurskitAnims_3_6
+.4byte sSurskitAnims_3_7
+.4byte sSurskitAnims_3_8
+sSurskitAnimTable4:
+.4byte sSurskitAnims_4_1
+.4byte sSurskitAnims_4_2
+.4byte sSurskitAnims_4_3
+.4byte sSurskitAnims_4_4
+.4byte sSurskitAnims_4_5
+.4byte sSurskitAnims_4_6
+.4byte sSurskitAnims_4_7
+.4byte sSurskitAnims_4_8
+sSurskitAnimTable5:
+.4byte sSurskitAnims_5_1
+.4byte sSurskitAnims_5_2
+.4byte sSurskitAnims_5_3
+.4byte sSurskitAnims_5_4
+.4byte sSurskitAnims_5_5
+.4byte sSurskitAnims_5_6
+.4byte sSurskitAnims_5_7
+.4byte sSurskitAnims_5_8
+sSurskitAnimTable6:
+.4byte sSurskitAnims_6_1
+.4byte sSurskitAnims_6_1
+.4byte sSurskitAnims_6_1
+.4byte sSurskitAnims_6_1
+.4byte sSurskitAnims_6_1
+.4byte sSurskitAnims_6_1
+.4byte sSurskitAnims_6_1
+.4byte sSurskitAnims_6_1
+sSurskitAnimTable7:
+.4byte sSurskitAnims_7_1
+.4byte sSurskitAnims_7_2
+.4byte sSurskitAnims_7_3
+.4byte sSurskitAnims_7_4
+.4byte sSurskitAnims_7_5
+.4byte sSurskitAnims_7_6
+.4byte sSurskitAnims_7_7
+.4byte sSurskitAnims_7_8
+sSurskitAnimTable8:
+.4byte sSurskitAnims_8_1
+.4byte sSurskitAnims_8_2
+.4byte sSurskitAnims_8_3
+.4byte sSurskitAnims_8_4
+.4byte sSurskitAnims_8_5
+.4byte sSurskitAnims_8_6
+.4byte sSurskitAnims_8_7
+.4byte sSurskitAnims_8_8
+sSurskitAnimTable9:
+.4byte sSurskitAnims_9_1
+.4byte sSurskitAnims_9_2
+.4byte sSurskitAnims_9_3
+.4byte sSurskitAnims_9_4
+.4byte sSurskitAnims_9_5
+.4byte sSurskitAnims_9_6
+.4byte sSurskitAnims_9_7
+.4byte sSurskitAnims_9_8
+sSurskitAnimTable10:
+.4byte sSurskitAnims_10_1
+.4byte sSurskitAnims_10_2
+.4byte sSurskitAnims_10_3
+.4byte sSurskitAnims_10_4
+.4byte sSurskitAnims_10_5
+.4byte sSurskitAnims_10_6
+.4byte sSurskitAnims_10_7
+.4byte sSurskitAnims_10_8
+sSurskitAnimTable11:
+.4byte sSurskitAnims_11_1
+.4byte sSurskitAnims_11_2
+.4byte sSurskitAnims_11_3
+.4byte sSurskitAnims_11_4
+.4byte sSurskitAnims_11_5
+.4byte sSurskitAnims_11_6
+.4byte sSurskitAnims_11_7
+.4byte sSurskitAnims_11_8
+sSurskitAnimTable12:
+.4byte sSurskitAnims_12_1
+.4byte sSurskitAnims_12_2
+.4byte sSurskitAnims_12_3
+.4byte sSurskitAnims_12_4
+.4byte sSurskitAnims_12_5
+.4byte sSurskitAnims_12_6
+.4byte sSurskitAnims_12_7
+.4byte sSurskitAnims_12_8
+sSurskitAnimTable13:
+.4byte sSurskitAnims_13_1
+.4byte sSurskitAnims_13_2
+.4byte sSurskitAnims_13_3
+.4byte sSurskitAnims_13_4
+.4byte sSurskitAnims_13_5
+.4byte sSurskitAnims_13_6
+.4byte sSurskitAnims_13_7
+.4byte sSurskitAnims_13_8
+sAxAnimationsSurskit:
+.4byte sSurskitAnimTable1
+.4byte sSurskitAnimTable2
+.4byte sSurskitAnimTable3
+.4byte sSurskitAnimTable4
+.4byte sSurskitAnimTable5
+.4byte sSurskitAnimTable6
+.4byte sSurskitAnimTable7
+.4byte sSurskitAnimTable8
+.4byte sSurskitAnimTable9
+.4byte sSurskitAnimTable10
+.4byte sSurskitAnimTable11
+.4byte sSurskitAnimTable12
+.4byte sSurskitAnimTable13
+sAxSpritesSurskit:
+.4byte sSurskitSprites1
+.4byte sSurskitSprites2
+.4byte sSurskitSprites3
+.4byte sSurskitSprites4
+.4byte sSurskitSprites5
+.4byte sSurskitSprites6
+.4byte sSurskitSprites7
+.4byte sSurskitSprites8
+.4byte sSurskitSprites9
+.4byte sSurskitSprites10
+.4byte sSurskitSprites11
+.4byte sSurskitSprites12
+.4byte sSurskitSprites13
+.4byte sSurskitSprites14
+.4byte sSurskitSprites15
+.4byte sSurskitSprites16
+.4byte sSurskitSprites17
+.4byte sSurskitSprites18
+.4byte sSurskitSprites19
+.4byte sSurskitSprites20
+.4byte sSurskitSprites21
+.4byte sSurskitSprites22
+.4byte sSurskitSprites23
+.4byte sSurskitSprites24
+.4byte sSurskitSprites25
+.4byte sSurskitSprites26
+.4byte sSurskitSprites27
+.4byte sSurskitSprites28
+.4byte sSurskitSprites29
+.4byte sSurskitSprites30
+.4byte sSurskitSprites31
+.4byte sSurskitSprites32
+sAxMainSurskit:
+ax_main sAxPosesSurskit, sAxAnimationsSurskit, 13, sAxSpritesSurskit, sAxPositionsSurskit

--- a/data/ax/swablu.inc
+++ b/data/ax/swablu.inc
@@ -1,0 +1,2864 @@
+.global gAxSwablu
+gAxSwablu:
+ax_siro sAxMainSwablu
+sSwabluPose1:
+ax_pose 0, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose2:
+ax_pose 1, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose3:
+ax_pose 2, 0x41ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose4:
+ax_pose 3, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose5:
+ax_pose 4, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSwabluPose6:
+ax_pose 5, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose7:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose8:
+ax_pose 7, 0x81ef, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose9:
+ax_pose 8, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose10:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose14:
+ax_pose 13, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose15:
+ax_pose 14, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose16:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose17:
+ax_pose 10, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose19:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose20:
+ax_pose 7, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose21:
+ax_pose 8, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose22:
+ax_pose 3, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose23:
+ax_pose 4, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose24:
+ax_pose 5, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose25:
+ax_pose 0, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose26:
+ax_pose 1, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose27:
+ax_pose 2, 0x41ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose28:
+ax_pose 3, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose29:
+ax_pose 4, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSwabluPose30:
+ax_pose 5, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose31:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose32:
+ax_pose 7, 0x81ef, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose33:
+ax_pose 8, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose34:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose35:
+ax_pose 10, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose36:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose37:
+ax_pose 12, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose38:
+ax_pose 13, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose39:
+ax_pose 14, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose40:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose41:
+ax_pose 10, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose42:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose43:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose44:
+ax_pose 7, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose45:
+ax_pose 8, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose46:
+ax_pose 3, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose47:
+ax_pose 4, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose48:
+ax_pose 5, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose49:
+ax_pose 0, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose50:
+ax_pose 1, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose51:
+ax_pose 2, 0x41ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose52:
+ax_pose 3, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose53:
+ax_pose 4, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSwabluPose54:
+ax_pose 5, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose55:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose56:
+ax_pose 7, 0x81ef, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose57:
+ax_pose 8, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose58:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose59:
+ax_pose 10, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose60:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose61:
+ax_pose 12, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose62:
+ax_pose 13, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose63:
+ax_pose 14, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose64:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose65:
+ax_pose 10, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose66:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose67:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose68:
+ax_pose 7, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose69:
+ax_pose 8, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose70:
+ax_pose 3, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose71:
+ax_pose 4, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose72:
+ax_pose 5, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose73:
+ax_pose 0, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose74:
+ax_pose 1, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose75:
+ax_pose 2, 0x41ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose76:
+ax_pose 15, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose77:
+ax_pose 16, 0x41ee, 0x80f0, 0x5c00
+ax_pose 17, 0x41fe, 0x40f0, 0x5c08
+ax_pose_terminator
+sSwabluPose78:
+ax_pose 18, 0x41ee, 0x80f0, 0x5c00
+ax_pose 19, 0x01fe, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose79:
+ax_pose 3, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose80:
+ax_pose 4, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSwabluPose81:
+ax_pose 5, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose82:
+ax_pose 20, 0x41e7, 0x10f9, 0x5c00
+ax_pose 21, 0x41ef, 0x90e9, 0x5c02
+ax_pose_terminator
+sSwabluPose83:
+ax_pose 22, 0x41f3, 0x90ec, 0x5c00
+ax_pose 23, 0x41eb, 0x50ec, 0x5c08
+ax_pose_terminator
+sSwabluPose84:
+ax_pose 24, 0x41ef, 0x90e9, 0x5c00
+ax_pose 25, 0x41e7, 0x10f9, 0x5c08
+ax_pose_terminator
+sSwabluPose85:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose86:
+ax_pose 7, 0x81ef, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose87:
+ax_pose 8, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose88:
+ax_pose 26, 0x81ea, 0x90f7, 0x5c00
+ax_pose 27, 0x01fa, 0x10ef, 0x5c08
+ax_pose_terminator
+sSwabluPose89:
+ax_pose 28, 0x81ef, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose90:
+ax_pose 29, 0x81e7, 0x90f9, 0x5c00
+ax_pose 30, 0x01f7, 0x10f1, 0x5c08
+ax_pose_terminator
+sSwabluPose91:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose92:
+ax_pose 10, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose93:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose94:
+ax_pose 31, 0x41f2, 0x90eb, 0x5c00
+ax_pose 32, 0x41ea, 0x10f3, 0x5c08
+ax_pose_terminator
+sSwabluPose95:
+ax_pose 33, 0x41f3, 0x90eb, 0x5c00
+ax_pose 34, 0x41eb, 0x10f3, 0x5c08
+ax_pose_terminator
+sSwabluPose96:
+ax_pose 35, 0x41f0, 0x90eb, 0x5c00
+ax_pose 36, 0x41e8, 0x10f3, 0x5c08
+ax_pose_terminator
+sSwabluPose97:
+ax_pose 12, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose98:
+ax_pose 13, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose99:
+ax_pose 14, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose100:
+ax_pose 37, 0x41f3, 0x80f0, 0x5c00
+ax_pose 38, 0x41eb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose101:
+ax_pose 39, 0x41f3, 0x80f0, 0x5c00
+ax_pose 40, 0x41eb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose102:
+ax_pose 41, 0x41eb, 0x80f0, 0x5c00
+ax_pose 42, 0x41fb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose103:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose104:
+ax_pose 10, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose105:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose106:
+ax_pose 31, 0x41f2, 0x80f4, 0x5c00
+ax_pose 32, 0x41ea, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose107:
+ax_pose 33, 0x41f3, 0x80f4, 0x5c00
+ax_pose 34, 0x41eb, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose108:
+ax_pose 35, 0x41f0, 0x80f4, 0x5c00
+ax_pose 36, 0x41e8, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose109:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose110:
+ax_pose 7, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose111:
+ax_pose 8, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose112:
+ax_pose 27, 0x01fa, 0x0108, 0x5c00
+ax_pose 26, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sSwabluPose113:
+ax_pose 28, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose114:
+ax_pose 29, 0x81e7, 0x80f6, 0x5c00
+ax_pose 30, 0x01f7, 0x0106, 0x5c08
+ax_pose_terminator
+sSwabluPose115:
+ax_pose 3, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose116:
+ax_pose 4, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose117:
+ax_pose 5, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose118:
+ax_pose 20, 0x41e7, 0x00f6, 0x5c00
+ax_pose 21, 0x41ef, 0x80f6, 0x5c02
+ax_pose_terminator
+sSwabluPose119:
+ax_pose 22, 0x41f3, 0x80f3, 0x5c00
+ax_pose 23, 0x41eb, 0x40f3, 0x5c08
+ax_pose_terminator
+sSwabluPose120:
+ax_pose 24, 0x41ef, 0x80f6, 0x5c00
+ax_pose 25, 0x41e7, 0x00f6, 0x5c08
+ax_pose_terminator
+sSwabluPose121:
+ax_pose 0, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose122:
+ax_pose 1, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose123:
+ax_pose 2, 0x41ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose124:
+ax_pose 3, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose125:
+ax_pose 4, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sSwabluPose126:
+ax_pose 5, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose127:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose128:
+ax_pose 7, 0x81ee, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose129:
+ax_pose 8, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose130:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose131:
+ax_pose 10, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose132:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose133:
+ax_pose 12, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose134:
+ax_pose 13, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose135:
+ax_pose 14, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose136:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose137:
+ax_pose 10, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose138:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose139:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose140:
+ax_pose 7, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose141:
+ax_pose 8, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose142:
+ax_pose 3, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose143:
+ax_pose 4, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose144:
+ax_pose 5, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose145:
+ax_pose 43, 0x01f3, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose146:
+ax_pose 44, 0x01f3, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose147:
+ax_pose 45, 0x01dd, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose148:
+ax_pose 46, 0x01e1, 0x90ed, 0x5c00
+ax_pose_terminator
+sSwabluPose149:
+ax_pose 47, 0x01e2, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose150:
+ax_pose 48, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sSwabluPose151:
+ax_pose 49, 0x01dc, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose152:
+ax_pose 48, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose153:
+ax_pose 47, 0x01e2, 0x80f5, 0x5c00
+ax_pose_terminator
+sSwabluPose154:
+ax_pose 46, 0x01e1, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose155:
+ax_pose 0, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose156:
+ax_pose 1, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose157:
+ax_pose 2, 0x41ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose158:
+ax_pose 3, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose159:
+ax_pose 4, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sSwabluPose160:
+ax_pose 5, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose161:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose162:
+ax_pose 7, 0x81ef, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose163:
+ax_pose 8, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose164:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose165:
+ax_pose 10, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose166:
+ax_pose 11, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose167:
+ax_pose 12, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose168:
+ax_pose 13, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose169:
+ax_pose 14, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose170:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose171:
+ax_pose 10, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose172:
+ax_pose 11, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose173:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose174:
+ax_pose 7, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose175:
+ax_pose 8, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose176:
+ax_pose 3, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose177:
+ax_pose 4, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sSwabluPose178:
+ax_pose 5, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose179:
+ax_pose 18, 0x41ee, 0x80f0, 0x5c00
+ax_pose 19, 0x01fe, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose180:
+ax_pose 24, 0x41ef, 0x80f6, 0x5c00
+ax_pose 25, 0x41e7, 0x00f6, 0x5c08
+ax_pose_terminator
+sSwabluPose181:
+ax_pose 29, 0x81e7, 0x80f6, 0x5c00
+ax_pose 30, 0x01f7, 0x0106, 0x5c08
+ax_pose_terminator
+sSwabluPose182:
+ax_pose 35, 0x41f0, 0x80f4, 0x5c00
+ax_pose 36, 0x41e8, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose183:
+ax_pose 41, 0x41ea, 0x80f0, 0x5c00
+ax_pose 42, 0x41fa, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose184:
+ax_pose 35, 0x41f0, 0x90ec, 0x5c00
+ax_pose 36, 0x41e8, 0x10f4, 0x5c08
+ax_pose_terminator
+sSwabluPose185:
+ax_pose 29, 0x81e7, 0x90f9, 0x5c00
+ax_pose 30, 0x01f7, 0x10f1, 0x5c08
+ax_pose_terminator
+sSwabluPose186:
+ax_pose 24, 0x41ef, 0x90e9, 0x5c00
+ax_pose 25, 0x41e7, 0x10f9, 0x5c08
+ax_pose_terminator
+sSwabluPose187:
+ax_pose 15, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose188:
+ax_pose 20, 0x41e7, 0x10f9, 0x5c00
+ax_pose 21, 0x41ef, 0x90e9, 0x5c02
+ax_pose_terminator
+sSwabluPose189:
+ax_pose 26, 0x81ea, 0x90f7, 0x5c00
+ax_pose 27, 0x01fa, 0x10ef, 0x5c08
+ax_pose_terminator
+sSwabluPose190:
+ax_pose 31, 0x41f2, 0x90eb, 0x5c00
+ax_pose 32, 0x41ea, 0x10f3, 0x5c08
+ax_pose_terminator
+sSwabluPose191:
+ax_pose 37, 0x41f3, 0x80f0, 0x5c00
+ax_pose 38, 0x41eb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose192:
+ax_pose 31, 0x41f2, 0x80f4, 0x5c00
+ax_pose 32, 0x41ea, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose193:
+ax_pose 27, 0x01fa, 0x0108, 0x5c00
+ax_pose 26, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sSwabluPose194:
+ax_pose 20, 0x41e7, 0x00f6, 0x5c00
+ax_pose 21, 0x41ef, 0x80f6, 0x5c02
+ax_pose_terminator
+sSwabluPose195:
+ax_pose 15, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose196:
+ax_pose 16, 0x41ee, 0x80f0, 0x5c00
+ax_pose 17, 0x41fe, 0x40f0, 0x5c08
+ax_pose_terminator
+sSwabluPose197:
+ax_pose 18, 0x41ee, 0x80f0, 0x5c00
+ax_pose 19, 0x01fe, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose198:
+ax_pose 20, 0x41e7, 0x10f9, 0x5c00
+ax_pose 21, 0x41ef, 0x90e9, 0x5c02
+ax_pose_terminator
+sSwabluPose199:
+ax_pose 22, 0x41f3, 0x90ec, 0x5c00
+ax_pose 23, 0x41eb, 0x50ec, 0x5c08
+ax_pose_terminator
+sSwabluPose200:
+ax_pose 24, 0x41ef, 0x90e9, 0x5c00
+ax_pose 25, 0x41e7, 0x10f9, 0x5c08
+ax_pose_terminator
+sSwabluPose201:
+ax_pose 26, 0x81ea, 0x90f7, 0x5c00
+ax_pose 27, 0x01fa, 0x10ef, 0x5c08
+ax_pose_terminator
+sSwabluPose202:
+ax_pose 28, 0x81ef, 0x90f7, 0x5c00
+ax_pose_terminator
+sSwabluPose203:
+ax_pose 29, 0x81e7, 0x90f9, 0x5c00
+ax_pose 30, 0x01f7, 0x10f1, 0x5c08
+ax_pose_terminator
+sSwabluPose204:
+ax_pose 31, 0x41f2, 0x90eb, 0x5c00
+ax_pose 32, 0x41ea, 0x10f3, 0x5c08
+ax_pose_terminator
+sSwabluPose205:
+ax_pose 33, 0x41f3, 0x90eb, 0x5c00
+ax_pose 34, 0x41eb, 0x10f3, 0x5c08
+ax_pose_terminator
+sSwabluPose206:
+ax_pose 35, 0x41f0, 0x90eb, 0x5c00
+ax_pose 36, 0x41e8, 0x10f3, 0x5c08
+ax_pose_terminator
+sSwabluPose207:
+ax_pose 37, 0x41f3, 0x80f0, 0x5c00
+ax_pose 38, 0x41eb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose208:
+ax_pose 39, 0x41f3, 0x80f0, 0x5c00
+ax_pose 40, 0x41eb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose209:
+ax_pose 41, 0x41eb, 0x80f0, 0x5c00
+ax_pose 42, 0x41fb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose210:
+ax_pose 31, 0x41f2, 0x80f4, 0x5c00
+ax_pose 32, 0x41ea, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose211:
+ax_pose 33, 0x41f3, 0x80f4, 0x5c00
+ax_pose 34, 0x41eb, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose212:
+ax_pose 35, 0x41f0, 0x80f4, 0x5c00
+ax_pose 36, 0x41e8, 0x00fc, 0x5c08
+ax_pose_terminator
+sSwabluPose213:
+ax_pose 27, 0x01fa, 0x0108, 0x5c00
+ax_pose 26, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sSwabluPose214:
+ax_pose 28, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose215:
+ax_pose 29, 0x81e7, 0x80f6, 0x5c00
+ax_pose 30, 0x01f7, 0x0106, 0x5c08
+ax_pose_terminator
+sSwabluPose216:
+ax_pose 20, 0x41e7, 0x00f6, 0x5c00
+ax_pose 21, 0x41ef, 0x80f6, 0x5c02
+ax_pose_terminator
+sSwabluPose217:
+ax_pose 22, 0x41f3, 0x80f3, 0x5c00
+ax_pose 23, 0x41eb, 0x40f3, 0x5c08
+ax_pose_terminator
+sSwabluPose218:
+ax_pose 24, 0x41ef, 0x80f6, 0x5c00
+ax_pose 25, 0x41e7, 0x00f6, 0x5c08
+ax_pose_terminator
+sSwabluPose219:
+ax_pose 16, 0x41ee, 0x80f0, 0x5c00
+ax_pose 17, 0x41fe, 0x40f0, 0x5c08
+ax_pose_terminator
+sSwabluPose220:
+ax_pose 22, 0x41f3, 0x80f3, 0x5c00
+ax_pose 23, 0x41eb, 0x40f3, 0x5c08
+ax_pose_terminator
+sSwabluPose221:
+ax_pose 28, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sSwabluPose222:
+ax_pose 33, 0x41f3, 0x80f3, 0x5c00
+ax_pose 34, 0x41eb, 0x00fb, 0x5c08
+ax_pose_terminator
+sSwabluPose223:
+ax_pose 39, 0x41f3, 0x80f0, 0x5c00
+ax_pose 40, 0x41eb, 0x00f8, 0x5c08
+ax_pose_terminator
+sSwabluPose224:
+ax_pose 33, 0x41f3, 0x90ec, 0x5c00
+ax_pose 34, 0x41eb, 0x10f4, 0x5c08
+ax_pose_terminator
+sSwabluPose225:
+ax_pose 28, 0x81ef, 0x90f8, 0x5c00
+ax_pose_terminator
+sSwabluPose226:
+ax_pose 22, 0x41f3, 0x90ed, 0x5c00
+ax_pose 23, 0x41eb, 0x50ed, 0x5c08
+ax_pose_terminator
+sSwabluPose227:
+ax_pose 0, 0x41ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose228:
+ax_pose 3, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose229:
+ax_pose 6, 0x01eb, 0x80f6, 0x5c00
+ax_pose_terminator
+sSwabluPose230:
+ax_pose 9, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sSwabluPose231:
+ax_pose 12, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwabluPose232:
+ax_pose 9, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sSwabluPose233:
+ax_pose 6, 0x01eb, 0x90e9, 0x5c00
+ax_pose_terminator
+sSwabluPose234:
+ax_pose 3, 0x01e7, 0x90e9, 0x5c00
+ax_pose_terminator
+.align 2
+sSwabluAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 9,
+ax_anim 2, 0, 26, 0, 24, 0, 21,
+ax_anim 2, 1, 26, 1, 24, 1, 21,
+ax_anim 2, 0, 26, 0, 24, 0, 21,
+ax_anim 2, 0, 26, 1, 24, 1, 21,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim_terminator
+sSwabluAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 3,
+ax_anim 1, 0, 29, 10, 10, 10, 8,
+ax_anim 2, 0, 29, 23, 24, 23, 20,
+ax_anim 2, 1, 29, 24, 23, 24, 19,
+ax_anim 2, 0, 29, 23, 24, 23, 20,
+ax_anim 2, 0, 29, 24, 23, 24, 19,
+ax_anim 2, 0, 27, 8, 8, 8, 6,
+ax_anim_terminator
+sSwabluAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 1, 10, 0,
+ax_anim 2, 0, 32, 23, 2, 23, 0,
+ax_anim 2, 1, 32, 23, 3, 23, 1,
+ax_anim 2, 0, 32, 23, 2, 23, 0,
+ax_anim 2, 0, 32, 23, 3, 23, 1,
+ax_anim 2, 0, 30, 8, 1, 8, 0,
+ax_anim_terminator
+sSwabluAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 35, 5, -5, 5, -6,
+ax_anim 1, 0, 35, 11, -11, 11, -13,
+ax_anim 2, 0, 35, 22, -21, 21, -25,
+ax_anim 2, 1, 35, 23, -20, 22, -24,
+ax_anim 2, 0, 35, 22, -21, 21, -25,
+ax_anim 2, 0, 35, 23, -20, 22, -24,
+ax_anim 2, 0, 33, 8, -8, 8, -10,
+ax_anim_terminator
+sSwabluAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -13,
+ax_anim 2, 0, 38, 0, -21, 0, -26,
+ax_anim 2, 1, 38, 1, -21, 1, -26,
+ax_anim 2, 0, 38, 0, -21, 0, -26,
+ax_anim 2, 0, 38, 1, -21, 1, -26,
+ax_anim 2, 0, 36, 0, -7, 0, -9,
+ax_anim_terminator
+sSwabluAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 41, -5, -5, -5, -6,
+ax_anim 1, 0, 41, -11, -11, -11, -13,
+ax_anim 2, 0, 41, -22, -21, -21, -25,
+ax_anim 2, 1, 41, -23, -20, -22, -24,
+ax_anim 2, 0, 41, -22, -21, -21, -25,
+ax_anim 2, 0, 41, -23, -20, -22, -24,
+ax_anim 2, 0, 39, -8, -8, -8, -10,
+ax_anim_terminator
+sSwabluAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 1, -10, 0,
+ax_anim 2, 0, 44, -23, 2, -23, 0,
+ax_anim 2, 1, 44, -23, 3, -23, 1,
+ax_anim 2, 0, 44, -23, 2, -23, 0,
+ax_anim 2, 0, 44, -23, 3, -23, 1,
+ax_anim 2, 0, 42, -8, 1, -8, 0,
+ax_anim_terminator
+sSwabluAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 3,
+ax_anim 1, 0, 47, -10, 10, -10, 8,
+ax_anim 2, 0, 47, -23, 24, -23, 20,
+ax_anim 2, 1, 47, -24, 23, -24, 19,
+ax_anim 2, 0, 47, -23, 24, -23, 20,
+ax_anim 2, 0, 47, -24, 23, -24, 19,
+ax_anim 2, 0, 45, -8, 8, -8, 6,
+ax_anim_terminator
+.align 2
+sSwabluAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 9,
+ax_anim 2, 0, 50, 0, 24, 0, 21,
+ax_anim 2, 1, 50, 1, 24, 1, 21,
+ax_anim 2, 0, 50, 0, 24, 0, 21,
+ax_anim 2, 0, 50, 1, 24, 1, 21,
+ax_anim 2, 0, 48, 0, 8, 0, 8,
+ax_anim_terminator
+sSwabluAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 3,
+ax_anim 1, 0, 53, 10, 10, 10, 8,
+ax_anim 2, 0, 53, 23, 24, 23, 20,
+ax_anim 2, 1, 53, 24, 23, 24, 19,
+ax_anim 2, 0, 53, 23, 24, 23, 20,
+ax_anim 2, 0, 53, 24, 23, 24, 19,
+ax_anim 2, 0, 51, 8, 8, 8, 6,
+ax_anim_terminator
+sSwabluAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 1, 10, 0,
+ax_anim 2, 0, 56, 23, 2, 23, 0,
+ax_anim 2, 1, 56, 23, 3, 23, 1,
+ax_anim 2, 0, 56, 23, 2, 23, 0,
+ax_anim 2, 0, 56, 23, 3, 23, 1,
+ax_anim 2, 0, 54, 8, 1, 8, 0,
+ax_anim_terminator
+sSwabluAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 59, 5, -5, 5, -6,
+ax_anim 1, 0, 59, 11, -11, 11, -13,
+ax_anim 2, 0, 59, 22, -21, 21, -25,
+ax_anim 2, 1, 59, 23, -20, 22, -24,
+ax_anim 2, 0, 59, 22, -21, 21, -25,
+ax_anim 2, 0, 59, 23, -20, 22, -24,
+ax_anim 2, 0, 57, 8, -8, 8, -10,
+ax_anim_terminator
+sSwabluAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -13,
+ax_anim 2, 0, 62, 0, -21, 0, -26,
+ax_anim 2, 1, 62, 1, -21, 1, -26,
+ax_anim 2, 0, 62, 0, -21, 0, -26,
+ax_anim 2, 0, 62, 1, -21, 1, -26,
+ax_anim 2, 0, 60, 0, -7, 0, -9,
+ax_anim_terminator
+sSwabluAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 65, -5, -5, -5, -6,
+ax_anim 1, 0, 65, -11, -11, -11, -13,
+ax_anim 2, 0, 65, -22, -21, -21, -25,
+ax_anim 2, 1, 65, -23, -20, -22, -24,
+ax_anim 2, 0, 65, -22, -21, -21, -25,
+ax_anim 2, 0, 65, -23, -20, -22, -24,
+ax_anim 2, 0, 63, -8, -8, -8, -10,
+ax_anim_terminator
+sSwabluAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 1, -10, 0,
+ax_anim 2, 0, 68, -23, 2, -23, 0,
+ax_anim 2, 1, 68, -23, 3, -23, 1,
+ax_anim 2, 0, 68, -23, 2, -23, 0,
+ax_anim 2, 0, 68, -23, 3, -23, 1,
+ax_anim 2, 0, 66, -8, 1, -8, 0,
+ax_anim_terminator
+sSwabluAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 3,
+ax_anim 1, 0, 71, -10, 10, -10, 8,
+ax_anim 2, 0, 71, -23, 24, -23, 20,
+ax_anim 2, 1, 71, -24, 23, -24, 19,
+ax_anim 2, 0, 71, -23, 24, -23, 20,
+ax_anim 2, 0, 71, -24, 23, -24, 19,
+ax_anim 2, 0, 69, -8, 8, -8, 6,
+ax_anim_terminator
+.align 2
+sSwabluAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 74, 0, -3, 0, -3,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 1, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 1, 3, 1, 3,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 1, 3, 1, 3,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 76, 1, 3, 1, 3,
+ax_anim 2, 0, 77, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sSwabluAnims_4_2:
+ax_anim 2, 0, 79, -2, -2, -2, -2,
+ax_anim 6, 2, 80, -3, -3, -3, -3,
+ax_anim 2, 0, 78, -1, -1, -1, -1,
+ax_anim 2, 1, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 82, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 82, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 82, 3, 1, 3, 1,
+ax_anim 2, 0, 83, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 1, 1, 1, 1,
+ax_anim_terminator
+sSwabluAnims_4_3:
+ax_anim 2, 0, 85, -2, 0, -2, 0,
+ax_anim 6, 2, 86, -3, 0, -3, 0,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim 2, 1, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, 1, 3, 1,
+ax_anim 2, 0, 89, 3, 0, 3, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim_terminator
+sSwabluAnims_4_4:
+ax_anim 2, 0, 91, -2, 2, -2, 2,
+ax_anim 6, 2, 92, -3, 3, -3, 3,
+ax_anim 2, 0, 90, -1, 1, -1, 1,
+ax_anim 2, 1, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 2, -2, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 2, -2, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 2, -2, 1, -3,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 90, 1, -1, 1, -1,
+ax_anim_terminator
+sSwabluAnims_4_5:
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 6, 2, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 96, 0, 1, 0, 1,
+ax_anim 2, 1, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim_terminator
+sSwabluAnims_4_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 102, 1, 1, 1, 1,
+ax_anim 2, 1, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -2, -2, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -2, -2, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 106, -2, -2, -1, -3,
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 102, -1, -1, -1, -1,
+ax_anim_terminator
+sSwabluAnims_4_7:
+ax_anim 2, 0, 109, 2, 0, 2, 0,
+ax_anim 6, 2, 110, 3, 0, 3, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 1, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, 1, -3, 1,
+ax_anim 2, 0, 113, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim_terminator
+sSwabluAnims_4_8:
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 6, 2, 116, 3, -3, 3, -3,
+ax_anim 2, 0, 114, 1, -1, 1, -1,
+ax_anim 2, 1, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 118, -3, 1, -3, 1,
+ax_anim 2, 0, 119, -2, 2, -2, 2,
+ax_anim 2, 0, 114, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSwabluAnims_5_1:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_5_2:
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_5_3:
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_5_4:
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_5_5:
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 2, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_5_6:
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_5_7:
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 2, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_5_8:
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sSwabluAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sSwabluAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sSwabluAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sSwabluAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sSwabluAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sSwabluAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sSwabluAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSwabluAnims_8_1:
+ax_anim 4, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -1, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 6, 0, 154, 0, -4, 0, 0,
+ax_anim 8, 0, 156, 0, -3, 0, 0,
+ax_anim 8, 0, 156, 0, -2, 0, 0,
+ax_anim 8, 0, 156, 0, -1, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_8_2:
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -1, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 6, 0, 157, 0, -4, 0, 0,
+ax_anim 8, 0, 159, 0, -3, 0, 0,
+ax_anim 8, 0, 159, 0, -2, 0, 0,
+ax_anim 8, 0, 159, 0, -1, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_8_3:
+ax_anim 4, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -1, 0, 0,
+ax_anim 4, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 6, 0, 160, 0, -4, 0, 0,
+ax_anim 8, 0, 162, 0, -3, 0, 0,
+ax_anim 8, 0, 162, 0, -2, 0, 0,
+ax_anim 8, 0, 162, 0, -1, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_8_4:
+ax_anim 4, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, -1, 0, 0,
+ax_anim 4, 0, 163, 0, -2, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim 6, 0, 163, 0, -4, 0, 0,
+ax_anim 8, 0, 165, 0, -3, 0, 0,
+ax_anim 8, 0, 165, 0, -2, 0, 0,
+ax_anim 8, 0, 165, 0, -1, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_8_5:
+ax_anim 4, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, -1, 0, 0,
+ax_anim 4, 0, 166, 0, -2, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 6, 0, 166, 0, -4, 0, 0,
+ax_anim 8, 0, 168, 0, -3, 0, 0,
+ax_anim 8, 0, 168, 0, -2, 0, 0,
+ax_anim 8, 0, 168, 0, -1, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_8_6:
+ax_anim 4, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -1, 0, 0,
+ax_anim 4, 0, 169, 0, -2, 0, 0,
+ax_anim 4, 0, 170, 0, -3, 0, 0,
+ax_anim 6, 0, 169, 0, -4, 0, 0,
+ax_anim 8, 0, 171, 0, -3, 0, 0,
+ax_anim 8, 0, 171, 0, -2, 0, 0,
+ax_anim 8, 0, 171, 0, -1, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_8_7:
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -1, 0, 0,
+ax_anim 4, 0, 172, 0, -2, 0, 0,
+ax_anim 4, 0, 173, 0, -3, 0, 0,
+ax_anim 6, 0, 172, 0, -4, 0, 0,
+ax_anim 8, 0, 174, 0, -3, 0, 0,
+ax_anim 8, 0, 174, 0, -2, 0, 0,
+ax_anim 8, 0, 174, 0, -1, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_8_8:
+ax_anim 4, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -1, 0, 0,
+ax_anim 4, 0, 175, 0, -2, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 6, 0, 175, 0, -4, 0, 0,
+ax_anim 8, 0, 177, 0, -3, 0, 0,
+ax_anim 8, 0, 177, 0, -2, 0, 0,
+ax_anim 8, 0, 177, 0, -1, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 5, 3, 6, 3,
+ax_anim 2, 0, 180, 9, 12, 8, 9,
+ax_anim 2, 0, 181, 6, 21, 7, 15,
+ax_anim 3, 0, 182, 0, 24, 0, 18,
+ax_anim 2, 3, 183, -6, 21, -7, 15,
+ax_anim 2, 0, 184, -9, 12, -8, 9,
+ax_anim 1, 0, 185, -5, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 19, 6, 19, 6,
+ax_anim 2, 0, 180, 24, 14, 24, 13,
+ax_anim 3, 0, 181, 22, 22, 22, 19,
+ax_anim 2, 3, 182, 13, 25, 13, 23,
+ax_anim 2, 0, 183, 3, 21, 3, 21,
+ax_anim 1, 0, 184, 0, 9, 0, 9,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 4, -6, 4, -6,
+ax_anim 2, 0, 178, 11, -8, 11, -8,
+ax_anim 2, 0, 179, 19, -4, 19, -4,
+ax_anim 3, 0, 180, 23, 3, 23, 0,
+ax_anim 2, 3, 181, 20, 10, 20, 8,
+ax_anim 2, 0, 182, 11, 14, 11, 14,
+ax_anim 1, 0, 183, 2, 10, 2, 10,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -7, 0, -7,
+ax_anim 2, 0, 185, 3, -15, 3, -15,
+ax_anim 2, 0, 178, 11, -21, 11, -21,
+ax_anim 3, 0, 179, 20, -20, 20, -22,
+ax_anim 2, 3, 180, 25, -12, 25, -12,
+ax_anim 2, 0, 181, 20, -2, 20, -2,
+ax_anim 1, 0, 182, 10, 2, 10, 2,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -5, -2, -5, -2,
+ax_anim 2, 0, 184, -8, -9, -8, -9,
+ax_anim 2, 0, 185, -7, -17, -7, -18,
+ax_anim 3, 0, 178, 0, -21, 0, -23,
+ax_anim 2, 3, 179, 7, -17, 7, -18,
+ax_anim 2, 0, 180, 8, -9, 8, -9,
+ax_anim 1, 0, 181, 5, -2, 5, -2,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -7, 0, -7,
+ax_anim 2, 0, 179, -3, -15, -3, -15,
+ax_anim 2, 0, 178, -11, -21, -11, -21,
+ax_anim 3, 0, 185, -20, -20, -20, -22,
+ax_anim 2, 3, 184, -25, -12, -25, -12,
+ax_anim 2, 0, 183, -20, -2, -20, -2,
+ax_anim 1, 0, 182, -10, 2, -10, 2,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -4, -6, -4, -6,
+ax_anim 2, 0, 178, -11, -8, -11, -8,
+ax_anim 2, 0, 185, -19, -4, -19, -4,
+ax_anim 3, 0, 184, -23, 3, -23, 0,
+ax_anim 2, 3, 183, -20, 10, -20, 8,
+ax_anim 2, 0, 182, -11, 14, -11, 14,
+ax_anim 1, 0, 181, -2, 10, -2, 10,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -19, 6, -19, 6,
+ax_anim 2, 0, 184, -24, 14, -24, 13,
+ax_anim 3, 0, 183, -22, 22, -22, 19,
+ax_anim 2, 3, 182, -13, 25, -13, 23,
+ax_anim 2, 0, 181, -3, 21, -3, 21,
+ax_anim 1, 0, 180, 0, 9, 0, 9,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 4, 0, 0,
+ax_anim_terminator
+sSwabluAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 3, 0, 0,
+ax_anim_terminator
+sSwabluAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 3, 0, 0,
+ax_anim_terminator
+sSwabluAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 4, 0, 0,
+ax_anim_terminator
+sSwabluAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 4, 0, 0,
+ax_anim_terminator
+sSwabluAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 4, 0, 0,
+ax_anim_terminator
+sSwabluAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 3, 0, 0,
+ax_anim_terminator
+sSwabluAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwabluAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sSwabluGfx1:
+.incbin "baserom.gba", 0x1398438, 0x100
+sSwabluSprites1:
+ax_sprite sSwabluGfx1, 0x100
+ax_sprite_terminator
+sSwabluGfx2:
+.incbin "baserom.gba", 0x1398548, 0x200
+sSwabluSprites2:
+ax_sprite sSwabluGfx2, 0x200
+ax_sprite_terminator
+sSwabluGfx3:
+.incbin "baserom.gba", 0x1398758, 0x100
+sSwabluSprites3:
+ax_sprite sSwabluGfx3, 0x100
+ax_sprite_terminator
+sSwabluGfx4:
+.incbin "baserom.gba", 0x1398868, 0x200
+sSwabluSprites4:
+ax_sprite sSwabluGfx4, 0x200
+ax_sprite_terminator
+sSwabluGfx5:
+.incbin "baserom.gba", 0x1398A78, 0x200
+sSwabluSprites5:
+ax_sprite sSwabluGfx5, 0x200
+ax_sprite_terminator
+sSwabluGfx6:
+.incbin "baserom.gba", 0x1398C88, 0x200
+sSwabluSprites6:
+ax_sprite sSwabluGfx6, 0x200
+ax_sprite_terminator
+sSwabluGfx7:
+.incbin "baserom.gba", 0x1398E98, 0x200
+sSwabluSprites7:
+ax_sprite sSwabluGfx7, 0x200
+ax_sprite_terminator
+sSwabluGfx8:
+.incbin "baserom.gba", 0x13990A8, 0x100
+sSwabluSprites8:
+ax_sprite sSwabluGfx8, 0x100
+ax_sprite_terminator
+sSwabluGfx9:
+.incbin "baserom.gba", 0x13991B8, 0x200
+sSwabluSprites9:
+ax_sprite sSwabluGfx9, 0x200
+ax_sprite_terminator
+sSwabluGfx10:
+.incbin "baserom.gba", 0x13993C8, 0x200
+sSwabluSprites10:
+ax_sprite sSwabluGfx10, 0x200
+ax_sprite_terminator
+sSwabluGfx11:
+.incbin "baserom.gba", 0x13995D8, 0x200
+sSwabluSprites11:
+ax_sprite sSwabluGfx11, 0x200
+ax_sprite_terminator
+sSwabluGfx12:
+.incbin "baserom.gba", 0x13997E8, 0x200
+sSwabluSprites12:
+ax_sprite sSwabluGfx12, 0x200
+ax_sprite_terminator
+sSwabluGfx13:
+.incbin "baserom.gba", 0x13999F8, 0x200
+sSwabluSprites13:
+ax_sprite sSwabluGfx13, 0x200
+ax_sprite_terminator
+sSwabluGfx14:
+.incbin "baserom.gba", 0x1399C08, 0x200
+sSwabluSprites14:
+ax_sprite sSwabluGfx14, 0x200
+ax_sprite_terminator
+sSwabluGfx15:
+.incbin "baserom.gba", 0x1399E18, 0x200
+sSwabluSprites15:
+ax_sprite sSwabluGfx15, 0x200
+ax_sprite_terminator
+sSwabluGfx16:
+.incbin "baserom.gba", 0x139A028, 0x100
+sSwabluSprites16:
+ax_sprite sSwabluGfx16, 0x100
+ax_sprite_terminator
+sSwabluGfx17:
+.incbin "baserom.gba", 0x139A138, 0x40
+sSwabluGfx17_1:
+.incbin "baserom.gba", 0x139A178, 0x80
+sSwabluSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSwabluGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwabluGfx17_1, 0x80
+ax_sprite_terminator
+sSwabluGfx18:
+.incbin "baserom.gba", 0x139A220, 0x80
+sSwabluSprites18:
+ax_sprite sSwabluGfx18, 0x80
+ax_sprite_terminator
+sSwabluGfx19:
+.incbin "baserom.gba", 0x139A2B0, 0x100
+sSwabluSprites19:
+ax_sprite sSwabluGfx19, 0x100
+ax_sprite_terminator
+sSwabluGfx20:
+.incbin "baserom.gba", 0x139A3C0, 0x20
+sSwabluSprites20:
+ax_sprite sSwabluGfx20, 0x20
+ax_sprite_terminator
+sSwabluGfx21:
+.incbin "baserom.gba", 0x139A3F0, 0x40
+sSwabluSprites21:
+ax_sprite sSwabluGfx21, 0x40
+ax_sprite_terminator
+sSwabluGfx22:
+.incbin "baserom.gba", 0x139A440, 0x60
+sSwabluGfx22_1:
+.incbin "baserom.gba", 0x139A4A0, 0x60
+sSwabluSprites22:
+ax_sprite sSwabluGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwabluGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwabluGfx23:
+.incbin "baserom.gba", 0x139A528, 0x60
+sSwabluGfx23_1:
+.incbin "baserom.gba", 0x139A588, 0x40
+sSwabluSprites23:
+ax_sprite sSwabluGfx23, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSwabluGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwabluGfx24:
+.incbin "baserom.gba", 0x139A5F0, 0x60
+sSwabluSprites24:
+ax_sprite sSwabluGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwabluGfx25:
+.incbin "baserom.gba", 0x139A668, 0x60
+sSwabluGfx25_1:
+.incbin "baserom.gba", 0x139A6C8, 0x60
+sSwabluSprites25:
+ax_sprite sSwabluGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwabluGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwabluGfx26:
+.incbin "baserom.gba", 0x139A750, 0x40
+sSwabluSprites26:
+ax_sprite sSwabluGfx26, 0x40
+ax_sprite_terminator
+sSwabluGfx27:
+.incbin "baserom.gba", 0x139A7A0, 0xC0
+sSwabluSprites27:
+ax_sprite sSwabluGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSwabluGfx28:
+.incbin "baserom.gba", 0x139A878, 0x20
+sSwabluSprites28:
+ax_sprite sSwabluGfx28, 0x20
+ax_sprite_terminator
+sSwabluGfx29:
+.incbin "baserom.gba", 0x139A8A8, 0xC0
+sSwabluSprites29:
+ax_sprite sSwabluGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSwabluGfx30:
+.incbin "baserom.gba", 0x139A980, 0xC0
+sSwabluSprites30:
+ax_sprite sSwabluGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSwabluGfx31:
+.incbin "baserom.gba", 0x139AA58, 0x20
+sSwabluSprites31:
+ax_sprite sSwabluGfx31, 0x20
+ax_sprite_terminator
+sSwabluGfx32:
+.incbin "baserom.gba", 0x139AA88, 0x60
+sSwabluGfx32_1:
+.incbin "baserom.gba", 0x139AAE8, 0x60
+sSwabluSprites32:
+ax_sprite sSwabluGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwabluGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwabluGfx33:
+.incbin "baserom.gba", 0x139AB70, 0x40
+sSwabluSprites33:
+ax_sprite sSwabluGfx33, 0x40
+ax_sprite_terminator
+sSwabluGfx34:
+.incbin "baserom.gba", 0x139ABC0, 0x60
+sSwabluGfx34_1:
+.incbin "baserom.gba", 0x139AC20, 0x60
+sSwabluSprites34:
+ax_sprite sSwabluGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwabluGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwabluGfx35:
+.incbin "baserom.gba", 0x139ACA8, 0x40
+sSwabluSprites35:
+ax_sprite sSwabluGfx35, 0x40
+ax_sprite_terminator
+sSwabluGfx36:
+.incbin "baserom.gba", 0x139ACF8, 0x60
+sSwabluGfx36_1:
+.incbin "baserom.gba", 0x139AD58, 0x60
+sSwabluSprites36:
+ax_sprite sSwabluGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwabluGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwabluGfx37:
+.incbin "baserom.gba", 0x139ADE0, 0x40
+sSwabluSprites37:
+ax_sprite sSwabluGfx37, 0x40
+ax_sprite_terminator
+sSwabluGfx38:
+.incbin "baserom.gba", 0x139AE30, 0x100
+sSwabluSprites38:
+ax_sprite sSwabluGfx38, 0x100
+ax_sprite_terminator
+sSwabluGfx39:
+.incbin "baserom.gba", 0x139AF40, 0x40
+sSwabluSprites39:
+ax_sprite sSwabluGfx39, 0x40
+ax_sprite_terminator
+sSwabluGfx40:
+.incbin "baserom.gba", 0x139AF90, 0x100
+sSwabluSprites40:
+ax_sprite sSwabluGfx40, 0x100
+ax_sprite_terminator
+sSwabluGfx41:
+.incbin "baserom.gba", 0x139B0A0, 0x40
+sSwabluSprites41:
+ax_sprite sSwabluGfx41, 0x40
+ax_sprite_terminator
+sSwabluGfx42:
+.incbin "baserom.gba", 0x139B0F0, 0x100
+sSwabluSprites42:
+ax_sprite sSwabluGfx42, 0x100
+ax_sprite_terminator
+sSwabluGfx43:
+.incbin "baserom.gba", 0x139B200, 0x40
+sSwabluSprites43:
+ax_sprite sSwabluGfx43, 0x40
+ax_sprite_terminator
+sSwabluGfx44:
+.incbin "baserom.gba", 0x139B250, 0x200
+sSwabluSprites44:
+ax_sprite sSwabluGfx44, 0x200
+ax_sprite_terminator
+sSwabluGfx45:
+.incbin "baserom.gba", 0x139B460, 0x200
+sSwabluSprites45:
+ax_sprite sSwabluGfx45, 0x200
+ax_sprite_terminator
+sSwabluGfx46:
+.incbin "baserom.gba", 0x139B670, 0x200
+sSwabluSprites46:
+ax_sprite sSwabluGfx46, 0x200
+ax_sprite_terminator
+sSwabluGfx47:
+.incbin "baserom.gba", 0x139B880, 0x200
+sSwabluSprites47:
+ax_sprite sSwabluGfx47, 0x200
+ax_sprite_terminator
+sSwabluGfx48:
+.incbin "baserom.gba", 0x139BA90, 0x200
+sSwabluSprites48:
+ax_sprite sSwabluGfx48, 0x200
+ax_sprite_terminator
+sSwabluGfx49:
+.incbin "baserom.gba", 0x139BCA0, 0x200
+sSwabluSprites49:
+ax_sprite sSwabluGfx49, 0x200
+ax_sprite_terminator
+sSwabluGfx50:
+.incbin "baserom.gba", 0x139BEB0, 0x200
+sSwabluSprites50:
+ax_sprite sSwabluGfx50, 0x200
+ax_sprite_terminator
+sAxPosesSwablu:
+.4byte sSwabluPose1
+.4byte sSwabluPose2
+.4byte sSwabluPose3
+.4byte sSwabluPose4
+.4byte sSwabluPose5
+.4byte sSwabluPose6
+.4byte sSwabluPose7
+.4byte sSwabluPose8
+.4byte sSwabluPose9
+.4byte sSwabluPose10
+.4byte sSwabluPose11
+.4byte sSwabluPose12
+.4byte sSwabluPose13
+.4byte sSwabluPose14
+.4byte sSwabluPose15
+.4byte sSwabluPose16
+.4byte sSwabluPose17
+.4byte sSwabluPose18
+.4byte sSwabluPose19
+.4byte sSwabluPose20
+.4byte sSwabluPose21
+.4byte sSwabluPose22
+.4byte sSwabluPose23
+.4byte sSwabluPose24
+.4byte sSwabluPose25
+.4byte sSwabluPose26
+.4byte sSwabluPose27
+.4byte sSwabluPose28
+.4byte sSwabluPose29
+.4byte sSwabluPose30
+.4byte sSwabluPose31
+.4byte sSwabluPose32
+.4byte sSwabluPose33
+.4byte sSwabluPose34
+.4byte sSwabluPose35
+.4byte sSwabluPose36
+.4byte sSwabluPose37
+.4byte sSwabluPose38
+.4byte sSwabluPose39
+.4byte sSwabluPose40
+.4byte sSwabluPose41
+.4byte sSwabluPose42
+.4byte sSwabluPose43
+.4byte sSwabluPose44
+.4byte sSwabluPose45
+.4byte sSwabluPose46
+.4byte sSwabluPose47
+.4byte sSwabluPose48
+.4byte sSwabluPose49
+.4byte sSwabluPose50
+.4byte sSwabluPose51
+.4byte sSwabluPose52
+.4byte sSwabluPose53
+.4byte sSwabluPose54
+.4byte sSwabluPose55
+.4byte sSwabluPose56
+.4byte sSwabluPose57
+.4byte sSwabluPose58
+.4byte sSwabluPose59
+.4byte sSwabluPose60
+.4byte sSwabluPose61
+.4byte sSwabluPose62
+.4byte sSwabluPose63
+.4byte sSwabluPose64
+.4byte sSwabluPose65
+.4byte sSwabluPose66
+.4byte sSwabluPose67
+.4byte sSwabluPose68
+.4byte sSwabluPose69
+.4byte sSwabluPose70
+.4byte sSwabluPose71
+.4byte sSwabluPose72
+.4byte sSwabluPose73
+.4byte sSwabluPose74
+.4byte sSwabluPose75
+.4byte sSwabluPose76
+.4byte sSwabluPose77
+.4byte sSwabluPose78
+.4byte sSwabluPose79
+.4byte sSwabluPose80
+.4byte sSwabluPose81
+.4byte sSwabluPose82
+.4byte sSwabluPose83
+.4byte sSwabluPose84
+.4byte sSwabluPose85
+.4byte sSwabluPose86
+.4byte sSwabluPose87
+.4byte sSwabluPose88
+.4byte sSwabluPose89
+.4byte sSwabluPose90
+.4byte sSwabluPose91
+.4byte sSwabluPose92
+.4byte sSwabluPose93
+.4byte sSwabluPose94
+.4byte sSwabluPose95
+.4byte sSwabluPose96
+.4byte sSwabluPose97
+.4byte sSwabluPose98
+.4byte sSwabluPose99
+.4byte sSwabluPose100
+.4byte sSwabluPose101
+.4byte sSwabluPose102
+.4byte sSwabluPose103
+.4byte sSwabluPose104
+.4byte sSwabluPose105
+.4byte sSwabluPose106
+.4byte sSwabluPose107
+.4byte sSwabluPose108
+.4byte sSwabluPose109
+.4byte sSwabluPose110
+.4byte sSwabluPose111
+.4byte sSwabluPose112
+.4byte sSwabluPose113
+.4byte sSwabluPose114
+.4byte sSwabluPose115
+.4byte sSwabluPose116
+.4byte sSwabluPose117
+.4byte sSwabluPose118
+.4byte sSwabluPose119
+.4byte sSwabluPose120
+.4byte sSwabluPose121
+.4byte sSwabluPose122
+.4byte sSwabluPose123
+.4byte sSwabluPose124
+.4byte sSwabluPose125
+.4byte sSwabluPose126
+.4byte sSwabluPose127
+.4byte sSwabluPose128
+.4byte sSwabluPose129
+.4byte sSwabluPose130
+.4byte sSwabluPose131
+.4byte sSwabluPose132
+.4byte sSwabluPose133
+.4byte sSwabluPose134
+.4byte sSwabluPose135
+.4byte sSwabluPose136
+.4byte sSwabluPose137
+.4byte sSwabluPose138
+.4byte sSwabluPose139
+.4byte sSwabluPose140
+.4byte sSwabluPose141
+.4byte sSwabluPose142
+.4byte sSwabluPose143
+.4byte sSwabluPose144
+.4byte sSwabluPose145
+.4byte sSwabluPose146
+.4byte sSwabluPose147
+.4byte sSwabluPose148
+.4byte sSwabluPose149
+.4byte sSwabluPose150
+.4byte sSwabluPose151
+.4byte sSwabluPose152
+.4byte sSwabluPose153
+.4byte sSwabluPose154
+.4byte sSwabluPose155
+.4byte sSwabluPose156
+.4byte sSwabluPose157
+.4byte sSwabluPose158
+.4byte sSwabluPose159
+.4byte sSwabluPose160
+.4byte sSwabluPose161
+.4byte sSwabluPose162
+.4byte sSwabluPose163
+.4byte sSwabluPose164
+.4byte sSwabluPose165
+.4byte sSwabluPose166
+.4byte sSwabluPose167
+.4byte sSwabluPose168
+.4byte sSwabluPose169
+.4byte sSwabluPose170
+.4byte sSwabluPose171
+.4byte sSwabluPose172
+.4byte sSwabluPose173
+.4byte sSwabluPose174
+.4byte sSwabluPose175
+.4byte sSwabluPose176
+.4byte sSwabluPose177
+.4byte sSwabluPose178
+.4byte sSwabluPose179
+.4byte sSwabluPose180
+.4byte sSwabluPose181
+.4byte sSwabluPose182
+.4byte sSwabluPose183
+.4byte sSwabluPose184
+.4byte sSwabluPose185
+.4byte sSwabluPose186
+.4byte sSwabluPose187
+.4byte sSwabluPose188
+.4byte sSwabluPose189
+.4byte sSwabluPose190
+.4byte sSwabluPose191
+.4byte sSwabluPose192
+.4byte sSwabluPose193
+.4byte sSwabluPose194
+.4byte sSwabluPose195
+.4byte sSwabluPose196
+.4byte sSwabluPose197
+.4byte sSwabluPose198
+.4byte sSwabluPose199
+.4byte sSwabluPose200
+.4byte sSwabluPose201
+.4byte sSwabluPose202
+.4byte sSwabluPose203
+.4byte sSwabluPose204
+.4byte sSwabluPose205
+.4byte sSwabluPose206
+.4byte sSwabluPose207
+.4byte sSwabluPose208
+.4byte sSwabluPose209
+.4byte sSwabluPose210
+.4byte sSwabluPose211
+.4byte sSwabluPose212
+.4byte sSwabluPose213
+.4byte sSwabluPose214
+.4byte sSwabluPose215
+.4byte sSwabluPose216
+.4byte sSwabluPose217
+.4byte sSwabluPose218
+.4byte sSwabluPose219
+.4byte sSwabluPose220
+.4byte sSwabluPose221
+.4byte sSwabluPose222
+.4byte sSwabluPose223
+.4byte sSwabluPose224
+.4byte sSwabluPose225
+.4byte sSwabluPose226
+.4byte sSwabluPose227
+.4byte sSwabluPose228
+.4byte sSwabluPose229
+.4byte sSwabluPose230
+.4byte sSwabluPose231
+.4byte sSwabluPose232
+.4byte sSwabluPose233
+.4byte sSwabluPose234
+sAxPositionsSwablu:
+.2byte   -1,   -5, 	 -13,  -11, 	  11,  -11, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  11,   -3, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -14, 	  -1,   -9
+.2byte    3,   -5, 	   5,  -17, 	 -13,   -6, 	   0,   -9
+.2byte    3,   -5, 	   9,  -11, 	  -8,    0, 	   0,   -9
+.2byte    3,   -5, 	   3,  -18, 	 -13,  -10, 	  -1,   -9
+.2byte    5,   -7, 	  -2,  -17, 	  -8,   -2, 	  -1,   -9
+.2byte    5,   -7, 	   0,  -14, 	  -4,    4, 	  -2,   -9
+.2byte    5,   -7, 	  -1,  -18, 	  -6,   -5, 	  -1,   -9
+.2byte    3,  -11, 	 -10,  -14, 	   7,   -2, 	  -2,   -9
+.2byte    3,  -11, 	  -9,  -13, 	   5,   -1, 	  -2,   -9
+.2byte    3,  -11, 	 -11,  -16, 	   7,   -6, 	  -2,   -9
+.2byte   -1,  -10, 	  11,   -9, 	 -13,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	  11,  -12, 	 -13,  -12, 	  -1,   -8
+.2byte   -5,  -11, 	   8,  -14, 	  -9,   -2, 	   0,   -9
+.2byte   -5,  -11, 	   7,  -13, 	  -7,   -1, 	   0,   -9
+.2byte   -5,  -11, 	   9,  -16, 	  -9,   -6, 	   0,   -9
+.2byte   -7,   -7, 	   0,  -17, 	   6,   -2, 	  -1,   -9
+.2byte   -7,   -7, 	  -2,  -14, 	   2,    4, 	   0,   -9
+.2byte   -7,   -7, 	  -1,  -18, 	   4,   -5, 	  -1,   -9
+.2byte   -5,   -5, 	  -7,  -17, 	  11,   -6, 	  -2,   -9
+.2byte   -5,   -5, 	 -11,  -11, 	   6,    0, 	  -2,   -9
+.2byte   -5,   -5, 	  -5,  -18, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -5, 	 -13,  -11, 	  11,  -11, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  11,   -3, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -14, 	  -1,   -9
+.2byte    3,   -5, 	   5,  -17, 	 -13,   -6, 	   0,   -9
+.2byte    3,   -5, 	   9,  -11, 	  -8,    0, 	   0,   -9
+.2byte    3,   -5, 	   3,  -18, 	 -13,  -10, 	  -1,   -9
+.2byte    5,   -7, 	  -2,  -17, 	  -8,   -2, 	  -1,   -9
+.2byte    5,   -7, 	   0,  -14, 	  -4,    4, 	  -2,   -9
+.2byte    5,   -7, 	  -1,  -18, 	  -6,   -5, 	  -1,   -9
+.2byte    3,  -11, 	 -10,  -14, 	   7,   -2, 	  -2,   -9
+.2byte    3,  -11, 	  -9,  -13, 	   5,   -1, 	  -2,   -9
+.2byte    3,  -11, 	 -11,  -16, 	   7,   -6, 	  -2,   -9
+.2byte   -1,  -10, 	  11,   -9, 	 -13,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	  11,  -12, 	 -13,  -12, 	  -1,   -8
+.2byte   -5,  -11, 	   8,  -14, 	  -9,   -2, 	   0,   -9
+.2byte   -5,  -11, 	   7,  -13, 	  -7,   -1, 	   0,   -9
+.2byte   -5,  -11, 	   9,  -16, 	  -9,   -6, 	   0,   -9
+.2byte   -7,   -7, 	   0,  -17, 	   6,   -2, 	  -1,   -9
+.2byte   -7,   -7, 	  -2,  -14, 	   2,    4, 	   0,   -9
+.2byte   -7,   -7, 	  -1,  -18, 	   4,   -5, 	  -1,   -9
+.2byte   -5,   -5, 	  -7,  -17, 	  11,   -6, 	  -2,   -9
+.2byte   -5,   -5, 	 -11,  -11, 	   6,    0, 	  -2,   -9
+.2byte   -5,   -5, 	  -5,  -18, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -5, 	 -13,  -11, 	  11,  -11, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  11,   -3, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -14, 	  -1,   -9
+.2byte    3,   -5, 	   5,  -17, 	 -13,   -6, 	   0,   -9
+.2byte    3,   -5, 	   9,  -11, 	  -8,    0, 	   0,   -9
+.2byte    3,   -5, 	   3,  -18, 	 -13,  -10, 	  -1,   -9
+.2byte    5,   -7, 	  -2,  -17, 	  -8,   -2, 	  -1,   -9
+.2byte    5,   -7, 	   0,  -14, 	  -4,    4, 	  -2,   -9
+.2byte    5,   -7, 	  -1,  -18, 	  -6,   -5, 	  -1,   -9
+.2byte    3,  -11, 	 -10,  -14, 	   7,   -2, 	  -2,   -9
+.2byte    3,  -11, 	  -9,  -13, 	   5,   -1, 	  -2,   -9
+.2byte    3,  -11, 	 -11,  -16, 	   7,   -6, 	  -2,   -9
+.2byte   -1,  -10, 	  11,   -9, 	 -13,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	  11,  -12, 	 -13,  -12, 	  -1,   -8
+.2byte   -5,  -11, 	   8,  -14, 	  -9,   -2, 	   0,   -9
+.2byte   -5,  -11, 	   7,  -13, 	  -7,   -1, 	   0,   -9
+.2byte   -5,  -11, 	   9,  -16, 	  -9,   -6, 	   0,   -9
+.2byte   -7,   -7, 	   0,  -17, 	   6,   -2, 	  -1,   -9
+.2byte   -7,   -7, 	  -2,  -14, 	   2,    4, 	   0,   -9
+.2byte   -7,   -7, 	  -1,  -18, 	   4,   -5, 	  -1,   -9
+.2byte   -5,   -5, 	  -7,  -17, 	  11,   -6, 	  -2,   -9
+.2byte   -5,   -5, 	 -11,  -11, 	   6,    0, 	  -2,   -9
+.2byte   -5,   -5, 	  -5,  -18, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -5, 	 -13,  -11, 	  11,  -11, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  11,   -3, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -14, 	  -1,   -9
+.2byte   -1,   -5, 	 -13,  -12, 	  11,  -12, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  10,   -2, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -13, 	  -1,   -9
+.2byte    3,   -5, 	   5,  -17, 	 -13,   -6, 	   0,   -9
+.2byte    3,   -5, 	   9,  -11, 	  -8,    0, 	   0,   -9
+.2byte    3,   -5, 	   3,  -18, 	 -13,  -10, 	  -1,   -9
+.2byte    2,   -6, 	   5,  -17, 	 -13,   -6, 	  -1,   -9
+.2byte    2,   -6, 	   9,  -11, 	  -8,    0, 	  -1,   -9
+.2byte    2,   -6, 	   3,  -18, 	 -13,   -9, 	  -2,   -9
+.2byte    5,   -7, 	  -2,  -17, 	  -8,   -2, 	  -1,   -9
+.2byte    5,   -7, 	   0,  -14, 	  -4,    4, 	  -2,   -9
+.2byte    5,   -7, 	  -1,  -18, 	  -6,   -5, 	  -1,   -9
+.2byte    4,   -6, 	  -2,  -17, 	  -7,   -2, 	  -1,   -8
+.2byte    4,   -6, 	   0,  -14, 	  -5,    4, 	  -1,   -8
+.2byte    4,   -6, 	  -1,  -18, 	  -7,   -5, 	  -2,   -8
+.2byte    3,  -11, 	 -10,  -14, 	   7,   -2, 	  -2,   -9
+.2byte    3,  -11, 	  -9,  -13, 	   5,   -1, 	  -2,   -9
+.2byte    3,  -11, 	 -11,  -16, 	   7,   -6, 	  -2,   -9
+.2byte    4,  -11, 	 -10,  -14, 	   6,   -2, 	  -2,   -9
+.2byte    4,  -11, 	  -9,  -13, 	   5,   -2, 	  -2,   -9
+.2byte    4,  -11, 	 -11,  -16, 	   7,   -4, 	  -3,  -10
+.2byte   -1,  -10, 	  11,   -9, 	 -13,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	  11,  -12, 	 -13,  -12, 	  -1,   -8
+.2byte   -1,  -15, 	  11,   -9, 	 -13,   -9, 	  -1,   -8
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -7
+.2byte   -1,  -15, 	  11,  -12, 	 -13,  -12, 	  -1,   -9
+.2byte   -5,  -11, 	   8,  -14, 	  -9,   -2, 	   0,   -9
+.2byte   -5,  -11, 	   7,  -13, 	  -7,   -1, 	   0,   -9
+.2byte   -5,  -11, 	   9,  -16, 	  -9,   -6, 	   0,   -9
+.2byte   -6,  -11, 	   8,  -14, 	  -8,   -2, 	   0,   -9
+.2byte   -6,  -11, 	   7,  -13, 	  -7,   -2, 	   0,   -9
+.2byte   -6,  -11, 	   9,  -16, 	  -9,   -4, 	   1,  -10
+.2byte   -7,   -7, 	   0,  -17, 	   6,   -2, 	  -1,   -9
+.2byte   -7,   -7, 	  -2,  -14, 	   2,    4, 	   0,   -9
+.2byte   -7,   -7, 	  -1,  -18, 	   4,   -5, 	  -1,   -9
+.2byte   -6,   -6, 	   0,  -17, 	   5,   -2, 	  -1,   -8
+.2byte   -6,   -6, 	  -2,  -14, 	   3,    4, 	  -1,   -8
+.2byte   -6,   -6, 	  -1,  -18, 	   5,   -5, 	   0,   -8
+.2byte   -5,   -5, 	  -7,  -17, 	  11,   -6, 	  -2,   -9
+.2byte   -5,   -5, 	 -11,  -11, 	   6,    0, 	  -2,   -9
+.2byte   -5,   -5, 	  -5,  -18, 	  11,  -10, 	  -1,   -9
+.2byte   -4,   -6, 	  -7,  -17, 	  11,   -6, 	  -1,   -9
+.2byte   -4,   -6, 	 -11,  -11, 	   6,    0, 	  -1,   -9
+.2byte   -4,   -6, 	  -5,  -18, 	  11,   -9, 	   0,   -9
+.2byte   -1,   -5, 	 -13,  -11, 	  11,  -11, 	  -1,   -9
+.2byte   -1,   -6, 	 -12,   -3, 	  11,   -4, 	  -1,  -10
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -14, 	  -1,   -9
+.2byte    3,   -5, 	   5,  -17, 	 -13,   -6, 	   0,   -9
+.2byte    3,   -6, 	   9,  -12, 	  -8,   -1, 	   0,  -10
+.2byte    3,   -5, 	   3,  -18, 	 -13,  -10, 	  -1,   -9
+.2byte    5,   -7, 	  -2,  -17, 	  -8,   -2, 	  -1,   -9
+.2byte    5,   -8, 	   0,  -15, 	  -4,    3, 	  -2,  -10
+.2byte    5,   -7, 	  -1,  -18, 	  -6,   -5, 	  -1,   -9
+.2byte    3,  -11, 	 -10,  -14, 	   7,   -2, 	  -2,   -9
+.2byte    3,  -12, 	  -9,  -14, 	   5,   -2, 	  -2,  -10
+.2byte    3,  -11, 	 -11,  -16, 	   7,   -6, 	  -2,   -9
+.2byte   -1,  -10, 	  11,   -9, 	 -13,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   9,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	  11,  -12, 	 -13,  -12, 	  -1,   -8
+.2byte   -5,  -11, 	   8,  -14, 	  -9,   -2, 	   0,   -9
+.2byte   -5,  -12, 	   7,  -14, 	  -7,   -2, 	   0,  -10
+.2byte   -5,  -11, 	   9,  -16, 	  -9,   -6, 	   0,   -9
+.2byte   -7,   -7, 	   0,  -17, 	   6,   -2, 	  -1,   -9
+.2byte   -7,   -8, 	  -2,  -15, 	   2,    3, 	   0,  -10
+.2byte   -7,   -7, 	  -1,  -18, 	   4,   -5, 	  -1,   -9
+.2byte   -5,   -5, 	  -7,  -17, 	  11,   -6, 	  -2,   -9
+.2byte   -5,   -6, 	 -11,  -12, 	   6,   -1, 	  -2,  -10
+.2byte   -5,   -5, 	  -5,  -18, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -4
+.2byte   -1,   -1, 	  -7,   -7, 	   6,   -7, 	  -1,   -4
+.2byte   -1,  -15, 	 -10,   -8, 	   8,   -8, 	  -1,  -12
+.2byte    1,  -15, 	   9,  -12, 	  -6,   -3, 	  -1,  -12
+.2byte    2,  -18, 	   8,  -12, 	   4,   -7, 	  -1,  -12
+.2byte    1,  -18, 	   1,  -21, 	   8,  -11, 	  -2,  -12
+.2byte   -1,  -21, 	   9,  -18, 	 -11,  -18, 	  -1,  -14
+.2byte   -3,  -18, 	  -3,  -21, 	 -10,  -11, 	   0,  -12
+.2byte   -3,  -18, 	  -9,  -12, 	  -5,   -7, 	   0,  -12
+.2byte   -2,  -15, 	 -10,  -12, 	   5,   -3, 	   0,  -12
+.2byte   -1,   -5, 	 -13,  -11, 	  11,  -11, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  11,   -3, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -14, 	  -1,   -9
+.2byte    3,   -5, 	   5,  -17, 	 -13,   -6, 	   0,   -9
+.2byte    3,   -5, 	   9,  -11, 	  -8,    0, 	   0,   -9
+.2byte    3,   -5, 	   3,  -18, 	 -13,  -10, 	  -1,   -9
+.2byte    5,   -7, 	  -2,  -17, 	  -8,   -2, 	  -1,   -9
+.2byte    5,   -7, 	   0,  -14, 	  -4,    4, 	  -2,   -9
+.2byte    5,   -7, 	  -1,  -18, 	  -6,   -5, 	  -1,   -9
+.2byte    3,  -11, 	 -10,  -14, 	   7,   -2, 	  -2,   -9
+.2byte    3,  -11, 	  -9,  -13, 	   5,   -1, 	  -2,   -9
+.2byte    3,  -11, 	 -11,  -16, 	   7,   -6, 	  -2,   -9
+.2byte   -1,  -10, 	  11,   -9, 	 -13,   -8, 	  -1,   -8
+.2byte   -1,  -10, 	   9,   -6, 	 -11,   -6, 	  -1,   -8
+.2byte   -1,  -11, 	  11,  -12, 	 -13,  -12, 	  -1,   -8
+.2byte   -5,  -11, 	   8,  -14, 	  -9,   -2, 	   0,   -9
+.2byte   -5,  -11, 	   7,  -13, 	  -7,   -1, 	   0,   -9
+.2byte   -5,  -11, 	   9,  -16, 	  -9,   -6, 	   0,   -9
+.2byte   -7,   -7, 	   0,  -17, 	   6,   -2, 	  -1,   -9
+.2byte   -7,   -7, 	  -2,  -14, 	   2,    4, 	   0,   -9
+.2byte   -7,   -7, 	  -1,  -18, 	   4,   -5, 	  -1,   -9
+.2byte   -5,   -5, 	  -7,  -17, 	  11,   -6, 	  -2,   -9
+.2byte   -5,   -5, 	 -11,  -11, 	   6,    0, 	  -2,   -9
+.2byte   -5,   -5, 	  -5,  -18, 	  11,  -10, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -13, 	  -1,   -9
+.2byte   -4,   -6, 	  -5,  -18, 	  11,   -9, 	   0,   -9
+.2byte   -6,   -6, 	  -1,  -18, 	   5,   -5, 	   0,   -8
+.2byte   -6,  -11, 	   9,  -16, 	  -9,   -4, 	   1,  -10
+.2byte   -1,  -16, 	  11,  -13, 	 -13,  -13, 	  -1,  -10
+.2byte    5,  -11, 	 -10,  -16, 	   8,   -4, 	  -2,  -10
+.2byte    4,   -6, 	  -1,  -18, 	  -7,   -5, 	  -2,   -8
+.2byte    2,   -6, 	   3,  -18, 	 -13,   -9, 	  -2,   -9
+.2byte   -1,   -5, 	 -13,  -12, 	  11,  -12, 	  -1,   -9
+.2byte    2,   -6, 	   5,  -17, 	 -13,   -6, 	  -1,   -9
+.2byte    4,   -6, 	  -2,  -17, 	  -7,   -2, 	  -1,   -8
+.2byte    4,  -11, 	 -10,  -14, 	   6,   -2, 	  -2,   -9
+.2byte   -1,  -15, 	  11,   -9, 	 -13,   -9, 	  -1,   -8
+.2byte   -6,  -11, 	   8,  -14, 	  -8,   -2, 	   0,   -9
+.2byte   -6,   -6, 	   0,  -17, 	   5,   -2, 	  -1,   -8
+.2byte   -4,   -6, 	  -7,  -17, 	  11,   -6, 	  -1,   -9
+.2byte   -1,   -5, 	 -13,  -12, 	  11,  -12, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  10,   -2, 	  -1,   -9
+.2byte   -1,   -5, 	 -12,  -14, 	  10,  -13, 	  -1,   -9
+.2byte    2,   -6, 	   5,  -17, 	 -13,   -6, 	  -1,   -9
+.2byte    2,   -6, 	   9,  -11, 	  -8,    0, 	  -1,   -9
+.2byte    2,   -6, 	   3,  -18, 	 -13,   -9, 	  -2,   -9
+.2byte    4,   -6, 	  -2,  -17, 	  -7,   -2, 	  -1,   -8
+.2byte    4,   -6, 	   0,  -14, 	  -5,    4, 	  -1,   -8
+.2byte    4,   -6, 	  -1,  -18, 	  -7,   -5, 	  -2,   -8
+.2byte    4,  -11, 	 -10,  -14, 	   6,   -2, 	  -2,   -9
+.2byte    4,  -11, 	  -9,  -13, 	   5,   -2, 	  -2,   -9
+.2byte    4,  -11, 	 -11,  -16, 	   7,   -4, 	  -3,  -10
+.2byte   -1,  -15, 	  11,   -9, 	 -13,   -9, 	  -1,   -8
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -7
+.2byte   -1,  -15, 	  11,  -12, 	 -13,  -12, 	  -1,   -9
+.2byte   -6,  -11, 	   8,  -14, 	  -8,   -2, 	   0,   -9
+.2byte   -6,  -11, 	   7,  -13, 	  -7,   -2, 	   0,   -9
+.2byte   -6,  -11, 	   9,  -16, 	  -9,   -4, 	   1,  -10
+.2byte   -6,   -6, 	   0,  -17, 	   5,   -2, 	  -1,   -8
+.2byte   -6,   -6, 	  -2,  -14, 	   3,    4, 	  -1,   -8
+.2byte   -6,   -6, 	  -1,  -18, 	   5,   -5, 	   0,   -8
+.2byte   -4,   -6, 	  -7,  -17, 	  11,   -6, 	  -1,   -9
+.2byte   -4,   -6, 	 -11,  -11, 	   6,    0, 	  -1,   -9
+.2byte   -4,   -6, 	  -5,  -18, 	  11,   -9, 	   0,   -9
+.2byte   -1,   -5, 	 -12,   -2, 	  10,   -2, 	  -1,   -9
+.2byte   -4,   -6, 	 -11,  -11, 	   6,    0, 	  -1,   -9
+.2byte   -6,   -6, 	  -2,  -14, 	   3,    4, 	  -1,   -8
+.2byte   -7,  -11, 	   6,  -13, 	  -8,   -2, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -6, 	 -11,   -6, 	  -1,   -7
+.2byte    5,  -11, 	  -8,  -13, 	   6,   -2, 	  -1,   -9
+.2byte    5,   -6, 	   1,  -14, 	  -4,    4, 	   0,   -8
+.2byte    3,   -6, 	  10,  -11, 	  -7,    0, 	   0,   -9
+.2byte   -1,   -5, 	 -13,  -11, 	  11,  -11, 	  -1,   -9
+.2byte   -5,   -5, 	  -7,  -17, 	  11,   -6, 	  -2,   -9
+.2byte   -7,   -7, 	   0,  -17, 	   6,   -2, 	  -1,   -9
+.2byte   -5,  -11, 	   8,  -14, 	  -9,   -2, 	   0,   -9
+.2byte   -1,  -10, 	  11,   -9, 	 -13,   -8, 	  -1,   -8
+.2byte    3,  -11, 	 -10,  -14, 	   7,   -2, 	  -2,   -9
+.2byte    5,   -7, 	  -2,  -17, 	  -8,   -2, 	  -1,   -9
+.2byte    3,   -5, 	   5,  -17, 	 -13,   -6, 	   0,   -9
+sSwabluAnimTable1:
+.4byte sSwabluAnims_1_1
+.4byte sSwabluAnims_1_2
+.4byte sSwabluAnims_1_3
+.4byte sSwabluAnims_1_4
+.4byte sSwabluAnims_1_5
+.4byte sSwabluAnims_1_6
+.4byte sSwabluAnims_1_7
+.4byte sSwabluAnims_1_8
+sSwabluAnimTable2:
+.4byte sSwabluAnims_2_1
+.4byte sSwabluAnims_2_2
+.4byte sSwabluAnims_2_3
+.4byte sSwabluAnims_2_4
+.4byte sSwabluAnims_2_5
+.4byte sSwabluAnims_2_6
+.4byte sSwabluAnims_2_7
+.4byte sSwabluAnims_2_8
+sSwabluAnimTable3:
+.4byte sSwabluAnims_3_1
+.4byte sSwabluAnims_3_2
+.4byte sSwabluAnims_3_3
+.4byte sSwabluAnims_3_4
+.4byte sSwabluAnims_3_5
+.4byte sSwabluAnims_3_6
+.4byte sSwabluAnims_3_7
+.4byte sSwabluAnims_3_8
+sSwabluAnimTable4:
+.4byte sSwabluAnims_4_1
+.4byte sSwabluAnims_4_2
+.4byte sSwabluAnims_4_3
+.4byte sSwabluAnims_4_4
+.4byte sSwabluAnims_4_5
+.4byte sSwabluAnims_4_6
+.4byte sSwabluAnims_4_7
+.4byte sSwabluAnims_4_8
+sSwabluAnimTable5:
+.4byte sSwabluAnims_5_1
+.4byte sSwabluAnims_5_2
+.4byte sSwabluAnims_5_3
+.4byte sSwabluAnims_5_4
+.4byte sSwabluAnims_5_5
+.4byte sSwabluAnims_5_6
+.4byte sSwabluAnims_5_7
+.4byte sSwabluAnims_5_8
+sSwabluAnimTable6:
+.4byte sSwabluAnims_6_1
+.4byte sSwabluAnims_6_1
+.4byte sSwabluAnims_6_1
+.4byte sSwabluAnims_6_1
+.4byte sSwabluAnims_6_1
+.4byte sSwabluAnims_6_1
+.4byte sSwabluAnims_6_1
+.4byte sSwabluAnims_6_1
+sSwabluAnimTable7:
+.4byte sSwabluAnims_7_1
+.4byte sSwabluAnims_7_2
+.4byte sSwabluAnims_7_3
+.4byte sSwabluAnims_7_4
+.4byte sSwabluAnims_7_5
+.4byte sSwabluAnims_7_6
+.4byte sSwabluAnims_7_7
+.4byte sSwabluAnims_7_8
+sSwabluAnimTable8:
+.4byte sSwabluAnims_8_1
+.4byte sSwabluAnims_8_2
+.4byte sSwabluAnims_8_3
+.4byte sSwabluAnims_8_4
+.4byte sSwabluAnims_8_5
+.4byte sSwabluAnims_8_6
+.4byte sSwabluAnims_8_7
+.4byte sSwabluAnims_8_8
+sSwabluAnimTable9:
+.4byte sSwabluAnims_9_1
+.4byte sSwabluAnims_9_2
+.4byte sSwabluAnims_9_3
+.4byte sSwabluAnims_9_4
+.4byte sSwabluAnims_9_5
+.4byte sSwabluAnims_9_6
+.4byte sSwabluAnims_9_7
+.4byte sSwabluAnims_9_8
+sSwabluAnimTable10:
+.4byte sSwabluAnims_10_1
+.4byte sSwabluAnims_10_2
+.4byte sSwabluAnims_10_3
+.4byte sSwabluAnims_10_4
+.4byte sSwabluAnims_10_5
+.4byte sSwabluAnims_10_6
+.4byte sSwabluAnims_10_7
+.4byte sSwabluAnims_10_8
+sSwabluAnimTable11:
+.4byte sSwabluAnims_11_1
+.4byte sSwabluAnims_11_2
+.4byte sSwabluAnims_11_3
+.4byte sSwabluAnims_11_4
+.4byte sSwabluAnims_11_5
+.4byte sSwabluAnims_11_6
+.4byte sSwabluAnims_11_7
+.4byte sSwabluAnims_11_8
+sSwabluAnimTable12:
+.4byte sSwabluAnims_12_1
+.4byte sSwabluAnims_12_2
+.4byte sSwabluAnims_12_3
+.4byte sSwabluAnims_12_4
+.4byte sSwabluAnims_12_5
+.4byte sSwabluAnims_12_6
+.4byte sSwabluAnims_12_7
+.4byte sSwabluAnims_12_8
+sSwabluAnimTable13:
+.4byte sSwabluAnims_13_1
+.4byte sSwabluAnims_13_2
+.4byte sSwabluAnims_13_3
+.4byte sSwabluAnims_13_4
+.4byte sSwabluAnims_13_5
+.4byte sSwabluAnims_13_6
+.4byte sSwabluAnims_13_7
+.4byte sSwabluAnims_13_8
+sAxAnimationsSwablu:
+.4byte sSwabluAnimTable1
+.4byte sSwabluAnimTable2
+.4byte sSwabluAnimTable3
+.4byte sSwabluAnimTable4
+.4byte sSwabluAnimTable5
+.4byte sSwabluAnimTable6
+.4byte sSwabluAnimTable7
+.4byte sSwabluAnimTable8
+.4byte sSwabluAnimTable9
+.4byte sSwabluAnimTable10
+.4byte sSwabluAnimTable11
+.4byte sSwabluAnimTable12
+.4byte sSwabluAnimTable13
+sAxSpritesSwablu:
+.4byte sSwabluSprites1
+.4byte sSwabluSprites2
+.4byte sSwabluSprites3
+.4byte sSwabluSprites4
+.4byte sSwabluSprites5
+.4byte sSwabluSprites6
+.4byte sSwabluSprites7
+.4byte sSwabluSprites8
+.4byte sSwabluSprites9
+.4byte sSwabluSprites10
+.4byte sSwabluSprites11
+.4byte sSwabluSprites12
+.4byte sSwabluSprites13
+.4byte sSwabluSprites14
+.4byte sSwabluSprites15
+.4byte sSwabluSprites16
+.4byte sSwabluSprites17
+.4byte sSwabluSprites18
+.4byte sSwabluSprites19
+.4byte sSwabluSprites20
+.4byte sSwabluSprites21
+.4byte sSwabluSprites22
+.4byte sSwabluSprites23
+.4byte sSwabluSprites24
+.4byte sSwabluSprites25
+.4byte sSwabluSprites26
+.4byte sSwabluSprites27
+.4byte sSwabluSprites28
+.4byte sSwabluSprites29
+.4byte sSwabluSprites30
+.4byte sSwabluSprites31
+.4byte sSwabluSprites32
+.4byte sSwabluSprites33
+.4byte sSwabluSprites34
+.4byte sSwabluSprites35
+.4byte sSwabluSprites36
+.4byte sSwabluSprites37
+.4byte sSwabluSprites38
+.4byte sSwabluSprites39
+.4byte sSwabluSprites40
+.4byte sSwabluSprites41
+.4byte sSwabluSprites42
+.4byte sSwabluSprites43
+.4byte sSwabluSprites44
+.4byte sSwabluSprites45
+.4byte sSwabluSprites46
+.4byte sSwabluSprites47
+.4byte sSwabluSprites48
+.4byte sSwabluSprites49
+.4byte sSwabluSprites50
+sAxMainSwablu:
+ax_main sAxPosesSwablu, sAxAnimationsSwablu, 13, sAxSpritesSwablu, sAxPositionsSwablu

--- a/data/ax/swalot.inc
+++ b/data/ax/swalot.inc
@@ -1,0 +1,2910 @@
+.global gAxSwalot
+gAxSwalot:
+ax_siro sAxMainSwalot
+sSwalotPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose4:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose5:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose6:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose8:
+ax_pose 7, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose9:
+ax_pose 8, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose10:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose11:
+ax_pose 10, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose12:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose16:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose17:
+ax_pose 10, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose18:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose19:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose21:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose24:
+ax_pose 5, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose28:
+ax_pose 15, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwalotPose29:
+ax_pose 16, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwalotPose30:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose31:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose32:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose33:
+ax_pose 17, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose34:
+ax_pose 18, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose35:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose36:
+ax_pose 7, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose37:
+ax_pose 8, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose38:
+ax_pose 19, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose39:
+ax_pose 20, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose40:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose41:
+ax_pose 10, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose42:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose43:
+ax_pose 21, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose44:
+ax_pose 22, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose45:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose46:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose47:
+ax_pose 14, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose48:
+ax_pose 23, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose49:
+ax_pose 24, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose50:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose51:
+ax_pose 10, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose52:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose53:
+ax_pose 21, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose54:
+ax_pose 22, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose55:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose56:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose57:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose58:
+ax_pose 19, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose59:
+ax_pose 20, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose60:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose61:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose62:
+ax_pose 5, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose63:
+ax_pose 17, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose64:
+ax_pose 18, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose65:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose66:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose67:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose68:
+ax_pose 15, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwalotPose69:
+ax_pose 16, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwalotPose70:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose71:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose72:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose73:
+ax_pose 17, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose74:
+ax_pose 18, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose75:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose76:
+ax_pose 7, 0x01eb, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose77:
+ax_pose 8, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose78:
+ax_pose 19, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose79:
+ax_pose 20, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose80:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose81:
+ax_pose 10, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose82:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose83:
+ax_pose 21, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose84:
+ax_pose 22, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose85:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose86:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose87:
+ax_pose 14, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose88:
+ax_pose 23, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose89:
+ax_pose 24, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose90:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose91:
+ax_pose 10, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose92:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose93:
+ax_pose 21, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose94:
+ax_pose 22, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose95:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose96:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose97:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose98:
+ax_pose 19, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose99:
+ax_pose 20, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose100:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose101:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose102:
+ax_pose 5, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose103:
+ax_pose 17, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose104:
+ax_pose 18, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose105:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose106:
+ax_pose 25, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose107:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose108:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose109:
+ax_pose 27, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose110:
+ax_pose 28, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sSwalotPose111:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose112:
+ax_pose 29, 0x01e8, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose113:
+ax_pose 30, 0x01e8, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose114:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose115:
+ax_pose 31, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose116:
+ax_pose 32, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose117:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose118:
+ax_pose 33, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose119:
+ax_pose 34, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose120:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose121:
+ax_pose 31, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose122:
+ax_pose 32, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose123:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose124:
+ax_pose 29, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose125:
+ax_pose 30, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose126:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose127:
+ax_pose 27, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose128:
+ax_pose 28, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose129:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose130:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose131:
+ax_pose 35, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose132:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose133:
+ax_pose 28, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sSwalotPose134:
+ax_pose 36, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose135:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose136:
+ax_pose 30, 0x01e8, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose137:
+ax_pose 37, 0x01e8, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwalotPose138:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose139:
+ax_pose 32, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose140:
+ax_pose 38, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose141:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose142:
+ax_pose 34, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose143:
+ax_pose 39, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose144:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose145:
+ax_pose 32, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose146:
+ax_pose 38, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose147:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose148:
+ax_pose 30, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose149:
+ax_pose 37, 0x01e8, 0x80ee, 0x2c00
+ax_pose_terminator
+sSwalotPose150:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose151:
+ax_pose 28, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose152:
+ax_pose 36, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose153:
+ax_pose 40, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose154:
+ax_pose 41, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose155:
+ax_pose 42, 0x01e1, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose156:
+ax_pose 43, 0x81e2, 0x50f5, 0x2c00
+ax_pose 44, 0x01da, 0x10f5, 0x2c04
+ax_pose 45, 0x01da, 0x10fd, 0x2c05
+ax_pose 46, 0x81e2, 0x10ed, 0x2c06
+ax_pose 47, 0x81e2, 0x90fd, 0x2c08
+ax_pose_terminator
+sSwalotPose157:
+ax_pose 48, 0x81e2, 0x50f5, 0x2c00
+ax_pose 49, 0x01da, 0x10ed, 0x2c04
+ax_pose 50, 0x01da, 0x10f5, 0x2c05
+ax_pose 51, 0x81e2, 0x10ed, 0x2c06
+ax_pose 52, 0x81e2, 0x90fd, 0x2c08
+ax_pose_terminator
+sSwalotPose158:
+ax_pose 53, 0x81e3, 0x10ed, 0x2c00
+ax_pose 54, 0x01db, 0x10ed, 0x2c02
+ax_pose 55, 0x01db, 0x10f5, 0x2c03
+ax_pose 56, 0x81e3, 0x50f5, 0x2c04
+ax_pose 57, 0x81e3, 0x90fd, 0x2c08
+ax_pose_terminator
+sSwalotPose159:
+ax_pose 58, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose160:
+ax_pose 53, 0x81e3, 0x010b, 0x2c00
+ax_pose 54, 0x01db, 0x010b, 0x2c02
+ax_pose 55, 0x01db, 0x0103, 0x2c03
+ax_pose 56, 0x81e3, 0x4103, 0x2c04
+ax_pose 57, 0x81e3, 0x80f3, 0x2c08
+ax_pose_terminator
+sSwalotPose161:
+ax_pose 48, 0x81e2, 0x4103, 0x2c00
+ax_pose 49, 0x01da, 0x010b, 0x2c04
+ax_pose 50, 0x01da, 0x0103, 0x2c05
+ax_pose 51, 0x81e2, 0x010b, 0x2c06
+ax_pose 52, 0x81e2, 0x80f3, 0x2c08
+ax_pose_terminator
+sSwalotPose162:
+ax_pose 43, 0x81e2, 0x4103, 0x2c00
+ax_pose 44, 0x01da, 0x0103, 0x2c04
+ax_pose 45, 0x01da, 0x00fb, 0x2c05
+ax_pose 46, 0x81e2, 0x010b, 0x2c06
+ax_pose 47, 0x81e2, 0x80f3, 0x2c08
+ax_pose_terminator
+sSwalotPose163:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose164:
+ax_pose 2, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose165:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose166:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose167:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose168:
+ax_pose 8, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose169:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose170:
+ax_pose 11, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose171:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose172:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose173:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose174:
+ax_pose 11, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose175:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose176:
+ax_pose 8, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose177:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose178:
+ax_pose 5, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose179:
+ax_pose 16, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwalotPose180:
+ax_pose 18, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose181:
+ax_pose 20, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose182:
+ax_pose 22, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose183:
+ax_pose 24, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose184:
+ax_pose 22, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose185:
+ax_pose 20, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose186:
+ax_pose 18, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose187:
+ax_pose 1, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose188:
+ax_pose 4, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose189:
+ax_pose 7, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose190:
+ax_pose 10, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose191:
+ax_pose 13, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose192:
+ax_pose 10, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose193:
+ax_pose 7, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose194:
+ax_pose 4, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose195:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose196:
+ax_pose 25, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose197:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose198:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose199:
+ax_pose 27, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose200:
+ax_pose 28, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sSwalotPose201:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose202:
+ax_pose 29, 0x01e8, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose203:
+ax_pose 30, 0x01e8, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwalotPose204:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose205:
+ax_pose 31, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose206:
+ax_pose 32, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose207:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose208:
+ax_pose 33, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose209:
+ax_pose 34, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose210:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose211:
+ax_pose 31, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose212:
+ax_pose 32, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose213:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose214:
+ax_pose 29, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose215:
+ax_pose 30, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwalotPose216:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose217:
+ax_pose 27, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose218:
+ax_pose 28, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose219:
+ax_pose 26, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose220:
+ax_pose 28, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwalotPose221:
+ax_pose 30, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose222:
+ax_pose 32, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose223:
+ax_pose 34, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sSwalotPose224:
+ax_pose 32, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose225:
+ax_pose 30, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sSwalotPose226:
+ax_pose 28, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwalotPose227:
+ax_pose 0, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose228:
+ax_pose 3, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose229:
+ax_pose 6, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwalotPose230:
+ax_pose 9, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose231:
+ax_pose 12, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwalotPose232:
+ax_pose 9, 0x01e7, 0x90ec, 0x2c00
+ax_pose_terminator
+sSwalotPose233:
+ax_pose 6, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwalotPose234:
+ax_pose 3, 0x01eb, 0x90ec, 0x2c00
+ax_pose_terminator
+.align 2
+sSwalotAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 2, 0, 2, 0, 2,
+ax_anim 8, 0, 2, 0, 1, 0, 1,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 10, 0, 4, 2, 2, 2, 2,
+ax_anim 8, 0, 5, 2, 2, 2, 2,
+ax_anim 8, 0, 5, 1, 1, 1, 1,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, -1, 0, 1, 0,
+ax_anim 10, 0, 7, 1, 0, 2, 0,
+ax_anim 8, 0, 8, 2, 0, 3, 0,
+ax_anim 8, 0, 8, 1, 0, 2, 0,
+ax_anim 8, 0, 8, 0, 0, 1, 0,
+ax_anim_terminator
+sSwalotAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 11, 2, -2, 2, -2,
+ax_anim 8, 0, 11, 1, -1, 1, -1,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, -1,
+ax_anim 10, 0, 13, 0, -1, 0, -2,
+ax_anim 8, 0, 14, 0, -2, 0, -3,
+ax_anim 8, 0, 14, 0, -1, 0, -2,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 17, -2, -2, -2, -2,
+ax_anim 8, 0, 17, -1, -1, -1, -1,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 1, 0, -1, 0,
+ax_anim 10, 0, 19, -1, 0, -2, 0,
+ax_anim 8, 0, 20, -2, 0, -3, 0,
+ax_anim 8, 0, 20, -1, 0, -2, 0,
+ax_anim 8, 0, 20, 0, 0, -1, 0,
+ax_anim_terminator
+sSwalotAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 23, -2, 2, -2, 2,
+ax_anim 8, 0, 23, -1, 1, -1, 1,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwalotAnims_2_1:
+ax_anim 2, 0, 42, 0, -1, 0, -1,
+ax_anim 4, 0, 42, 0, -2, 0, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSwalotAnims_2_2:
+ax_anim 2, 0, 57, -1, -1, -1, -1,
+ax_anim 4, 0, 57, -2, -2, -2, -2,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 33, 18, 19, 18, 19,
+ax_anim 2, 1, 33, 19, 18, 19, 18,
+ax_anim 2, 0, 33, 18, 19, 18, 19,
+ax_anim 2, 0, 33, 19, 18, 19, 18,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sSwalotAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, 1, 18, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sSwalotAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 42, 0, -1, 0, -1,
+ax_anim 1, 2, 40, 7, -6, 7, -6,
+ax_anim 1, 0, 40, 13, -12, 13, -12,
+ax_anim 2, 0, 43, 19, -18, 19, -18,
+ax_anim 2, 1, 43, 20, -17, 20, -17,
+ax_anim 2, 0, 43, 19, -18, 19, -18,
+ax_anim 2, 0, 43, 20, -17, 20, -17,
+ax_anim 2, 0, 39, 7, -6, 7, -6,
+ax_anim_terminator
+sSwalotAnims_2_5:
+ax_anim 2, 0, 52, 0, 1, 0, 1,
+ax_anim 4, 0, 52, 0, 2, 0, 2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, -4,
+ax_anim 1, 0, 45, 0, -11, 0, -11,
+ax_anim 2, 0, 48, 0, -17, 0, -17,
+ax_anim 2, 1, 48, 1, -17, 1, -17,
+ax_anim 2, 0, 48, 0, -17, 0, -17,
+ax_anim 2, 0, 48, 1, -17, 1, -17,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sSwalotAnims_2_6:
+ax_anim 2, 0, 57, 1, 1, 1, 1,
+ax_anim 4, 0, 57, 2, 2, 2, 2,
+ax_anim 1, 0, 52, 0, -1, 0, -1,
+ax_anim 1, 2, 50, -7, -6, -7, -6,
+ax_anim 1, 0, 50, -13, -12, -13, -12,
+ax_anim 2, 0, 53, -19, -18, -19, -18,
+ax_anim 2, 1, 53, -20, -17, -20, -17,
+ax_anim 2, 0, 53, -19, -18, -19, -18,
+ax_anim 2, 0, 53, -20, -17, -20, -17,
+ax_anim 2, 0, 49, -7, -6, -7, -6,
+ax_anim_terminator
+sSwalotAnims_2_7:
+ax_anim 2, 0, 62, 1, 0, 1, 0,
+ax_anim 4, 0, 62, 2, 0, 2, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 0, -4, 0,
+ax_anim 1, 0, 55, -10, 0, -10, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, 1, -18, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sSwalotAnims_2_8:
+ax_anim 2, 0, 37, 1, -1, 1, -1,
+ax_anim 4, 0, 37, 2, -2, 2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 60, -10, 10, -10, 10,
+ax_anim 2, 0, 63, -18, 19, -18, 19,
+ax_anim 2, 1, 63, -19, 18, -19, 18,
+ax_anim 2, 0, 63, -18, 19, -18, 19,
+ax_anim 2, 0, 63, -19, 18, -19, 18,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSwalotAnims_3_1:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 4, 0, 82, 0, -2, 0, -2,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 65, 0, 10, 0, 10,
+ax_anim 2, 0, 68, 0, 18, 0, 18,
+ax_anim 2, 1, 68, 1, 18, 1, 18,
+ax_anim 2, 0, 68, 0, 18, 0, 18,
+ax_anim 2, 0, 68, 1, 18, 1, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sSwalotAnims_3_2:
+ax_anim 2, 0, 97, -1, -1, -1, -1,
+ax_anim 4, 0, 97, -2, -2, -2, -2,
+ax_anim 1, 0, 72, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, 4, 4, 4,
+ax_anim 1, 0, 70, 10, 10, 10, 10,
+ax_anim 2, 0, 73, 18, 19, 18, 19,
+ax_anim 2, 1, 73, 19, 18, 19, 18,
+ax_anim 2, 0, 73, 18, 19, 18, 19,
+ax_anim 2, 0, 73, 19, 18, 19, 18,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sSwalotAnims_3_3:
+ax_anim 2, 0, 72, -1, 0, -1, 0,
+ax_anim 4, 0, 72, -2, 0, -2, 0,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 4, 0, 4, 0,
+ax_anim 1, 0, 75, 10, 0, 10, 0,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 1, 78, 18, 1, 18, 1,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 78, 18, 1, 18, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sSwalotAnims_3_4:
+ax_anim 2, 0, 77, -1, 1, -1, 1,
+ax_anim 4, 0, 77, -2, 2, -2, 2,
+ax_anim 1, 0, 82, 0, -1, 0, -1,
+ax_anim 1, 2, 80, 7, -6, 7, -6,
+ax_anim 1, 0, 80, 13, -12, 13, -12,
+ax_anim 2, 0, 83, 19, -18, 19, -18,
+ax_anim 2, 1, 83, 20, -17, 20, -17,
+ax_anim 2, 0, 83, 19, -18, 19, -18,
+ax_anim 2, 0, 83, 20, -17, 20, -17,
+ax_anim 2, 0, 79, 7, -6, 7, -6,
+ax_anim_terminator
+sSwalotAnims_3_5:
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 4, 0, 92, 0, 2, 0, 2,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 2, 85, 0, -4, 0, -4,
+ax_anim 1, 0, 85, 0, -11, 0, -11,
+ax_anim 2, 0, 88, 0, -17, 0, -17,
+ax_anim 2, 1, 88, 1, -17, 1, -17,
+ax_anim 2, 0, 88, 0, -17, 0, -17,
+ax_anim 2, 0, 88, 1, -17, 1, -17,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sSwalotAnims_3_6:
+ax_anim 2, 0, 97, 1, 1, 1, 1,
+ax_anim 4, 0, 97, 2, 2, 2, 2,
+ax_anim 1, 0, 92, 0, -1, 0, -1,
+ax_anim 1, 2, 90, -7, -6, -7, -6,
+ax_anim 1, 0, 90, -13, -12, -13, -12,
+ax_anim 2, 0, 93, -19, -18, -19, -18,
+ax_anim 2, 1, 93, -20, -17, -20, -17,
+ax_anim 2, 0, 93, -19, -18, -19, -18,
+ax_anim 2, 0, 93, -20, -17, -20, -17,
+ax_anim 2, 0, 89, -7, -6, -7, -6,
+ax_anim_terminator
+sSwalotAnims_3_7:
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 4, 0, 102, 2, 0, 2, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 2, 95, -4, 0, -4, 0,
+ax_anim 1, 0, 95, -10, 0, -10, 0,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 1, 98, -18, 1, -18, 1,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 0, 98, -18, 1, -18, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sSwalotAnims_3_8:
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim 4, 0, 77, 2, -2, 2, -2,
+ax_anim 1, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 2, 100, -4, 4, -4, 4,
+ax_anim 1, 0, 100, -10, 10, -10, 10,
+ax_anim 2, 0, 103, -18, 19, -18, 19,
+ax_anim 2, 1, 103, -19, 18, -19, 18,
+ax_anim 2, 0, 103, -18, 19, -18, 19,
+ax_anim 2, 0, 103, -19, 18, -19, 18,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSwalotAnims_4_1:
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 5, 0, 105, 0, -4, 0, -4,
+ax_anim 3, 2, 105, 0, -4, 0, -4,
+ax_anim 1, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 1, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, -1, 3, -1, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sSwalotAnims_4_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 108, -3, -3, -3, -3,
+ax_anim 5, 0, 108, -4, -4, -4, -4,
+ax_anim 3, 2, 108, -4, -4, -4, -4,
+ax_anim 1, 0, 109, -3, -3, -3, -3,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 1, 109, 2, 4, 2, 4,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 2, 4, 2, 4,
+ax_anim 2, 0, 109, 3, 3, 3, 3,
+ax_anim 2, 0, 109, 2, 4, 2, 4,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sSwalotAnims_4_3:
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 5, 0, 111, -4, 0, -4, 0,
+ax_anim 3, 2, 111, -4, 0, -4, 0,
+ax_anim 1, 0, 112, -3, 0, -3, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 1, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 112, 3, 0, 3, 0,
+ax_anim 2, 0, 112, 3, 1, 3, 1,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sSwalotAnims_4_4:
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 114, -3, 3, -3, 3,
+ax_anim 5, 0, 114, -4, 4, -4, 4,
+ax_anim 3, 1, 114, -4, 4, -4, 4,
+ax_anim 1, 0, 115, -3, 3, -3, 3,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 1, 115, 2, -4, 2, -4,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 2, -4, 2, -4,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 2, 0, 115, 2, -4, 2, -4,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sSwalotAnims_4_5:
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim 2, 0, 117, 0, 3, 0, 3,
+ax_anim 5, 0, 117, 0, 4, 0, 4,
+ax_anim 3, 2, 117, 0, 4, 0, 4,
+ax_anim 1, 0, 118, 0, 3, 0, 3,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 1, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, -1, -3, -1, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sSwalotAnims_4_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 2, 0, 120, 3, 3, 3, 3,
+ax_anim 5, 0, 120, 4, 4, 4, 4,
+ax_anim 3, 2, 120, 4, 4, 4, 4,
+ax_anim 1, 0, 121, 3, 3, 3, 3,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 1, 121, -2, -4, -2, -4,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -2, -4, -2, -4,
+ax_anim 2, 0, 121, -3, -3, -3, -3,
+ax_anim 2, 0, 121, -2, -4, -2, -4,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sSwalotAnims_4_7:
+ax_anim 2, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 3, 0, 3, 0,
+ax_anim 5, 0, 123, 4, 0, 4, 0,
+ax_anim 3, 2, 123, 4, 0, 4, 0,
+ax_anim 1, 0, 124, 3, 0, 3, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 1, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 124, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 122, -1, 0, -1, 0,
+ax_anim_terminator
+sSwalotAnims_4_8:
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 3, -3, 3, -3,
+ax_anim 5, 0, 126, 4, -4, 4, -4,
+ax_anim 3, 2, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 127, 3, -3, 3, -3,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 1, 127, -2, 4, -2, 4,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -2, 4, -2, 4,
+ax_anim 2, 0, 127, -3, 3, -3, 3,
+ax_anim 2, 0, 127, -2, 4, -2, 4,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSwalotAnims_5_1:
+ax_anim 2, 0, 128, 0, -2, 0, -2,
+ax_anim 6, 0, 128, 0, -3, 0, -3,
+ax_anim 2, 0, 129, 0, -1, 0, -1,
+ax_anim 2, 0, 129, 0, 3, 0, 3,
+ax_anim 2, 0, 130, 0, 3, 0, 3,
+ax_anim 2, 2, 130, 1, 3, 1, 3,
+ax_anim 2, 0, 130, 0, 3, 0, 3,
+ax_anim 2, 0, 130, 1, 3, 1, 3,
+ax_anim 2, 0, 130, 0, 3, 0, 3,
+ax_anim 2, 0, 130, 1, 3, 1, 3,
+ax_anim 2, 0, 128, 0, 1, 0, 1,
+ax_anim_terminator
+sSwalotAnims_5_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 6, 0, 131, -3, -3, -3, -3,
+ax_anim 2, 0, 132, -1, -1, -1, -1,
+ax_anim 2, 0, 132, 3, 3, 3, 3,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 2, 2, 133, 4, 2, 4, 2,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 2, 0, 133, 4, 2, 4, 2,
+ax_anim 2, 0, 133, 3, 3, 3, 3,
+ax_anim 2, 0, 133, 4, 2, 4, 2,
+ax_anim 2, 0, 131, 1, 1, 1, 1,
+ax_anim_terminator
+sSwalotAnims_5_3:
+ax_anim 2, 0, 134, -2, 0, -2, 0,
+ax_anim 6, 0, 134, -3, 0, -3, 0,
+ax_anim 2, 0, 135, -1, 0, -1, 0,
+ax_anim 2, 0, 135, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 2, 2, 136, 3, 1, 3, 1,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 3, 1, 3, 1,
+ax_anim 2, 0, 136, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 3, 1, 3, 1,
+ax_anim 2, 0, 134, 1, 0, 1, 0,
+ax_anim_terminator
+sSwalotAnims_5_4:
+ax_anim 2, 0, 137, -2, 2, -2, 2,
+ax_anim 6, 0, 137, -3, 3, -3, 3,
+ax_anim 2, 0, 138, -1, 1, -1, 1,
+ax_anim 2, 0, 138, 3, -3, 3, -3,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 2, 2, 139, 4, -2, 4, -2,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 2, 0, 139, 4, -2, 4, -2,
+ax_anim 2, 0, 139, 3, -3, 3, -3,
+ax_anim 2, 0, 139, 4, -2, 4, -2,
+ax_anim 2, 0, 137, 1, -1, 1, -1,
+ax_anim_terminator
+sSwalotAnims_5_5:
+ax_anim 2, 0, 140, 0, 2, 0, 2,
+ax_anim 6, 0, 140, 0, 3, 0, 3,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 2, 0, 141, 0, -3, 0, -3,
+ax_anim 2, 0, 142, 0, -3, 0, -3,
+ax_anim 2, 2, 142, 1, -3, 1, -3,
+ax_anim 2, 0, 142, 0, -3, 0, -3,
+ax_anim 2, 0, 142, 1, -3, 1, -3,
+ax_anim 2, 0, 142, 0, -3, 0, -3,
+ax_anim 2, 0, 142, 1, -3, 1, -3,
+ax_anim 2, 0, 140, 0, -1, 0, -1,
+ax_anim_terminator
+sSwalotAnims_5_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 6, 0, 143, 3, 3, 3, 3,
+ax_anim 2, 0, 144, 1, 1, 1, 1,
+ax_anim 2, 0, 144, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 2, 145, -4, -2, -4, -2,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -4, -2, -4, -2,
+ax_anim 2, 0, 145, -3, -3, -3, -3,
+ax_anim 2, 0, 145, -4, -2, -4, -2,
+ax_anim 2, 0, 143, -1, -1, -1, -1,
+ax_anim_terminator
+sSwalotAnims_5_7:
+ax_anim 2, 0, 146, 2, 0, 2, 0,
+ax_anim 6, 0, 146, 3, 0, 3, 0,
+ax_anim 2, 0, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, -3, 0, -3, 0,
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim 2, 2, 148, -3, 1, -3, 1,
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim 2, 0, 148, -3, 1, -3, 1,
+ax_anim 2, 0, 148, -3, 0, -3, 0,
+ax_anim 2, 0, 148, -3, 1, -3, 1,
+ax_anim 2, 0, 146, -1, 0, -1, 0,
+ax_anim_terminator
+sSwalotAnims_5_8:
+ax_anim 2, 0, 149, 2, -2, 2, -2,
+ax_anim 6, 0, 149, 3, -3, 3, -3,
+ax_anim 2, 0, 150, 1, -1, 1, -1,
+ax_anim 2, 0, 150, -3, 3, -3, 3,
+ax_anim 2, 0, 151, -3, 3, -3, 3,
+ax_anim 2, 2, 151, -4, 2, -4, 2,
+ax_anim 2, 0, 151, -3, 3, -3, 3,
+ax_anim 2, 0, 151, -4, 2, -4, 2,
+ax_anim 2, 0, 151, -3, 3, -3, 3,
+ax_anim 2, 0, 151, -4, 2, -4, 2,
+ax_anim 2, 0, 149, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSwalotAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwalotAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sSwalotAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sSwalotAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sSwalotAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sSwalotAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sSwalotAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sSwalotAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sSwalotAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSwalotAnims_8_1:
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim 16, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_8_2:
+ax_anim 16, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 165, -1, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_8_3:
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim 16, 0, 167, -2, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_8_4:
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim 16, 0, 169, -1, 1, 0, 0,
+ax_anim_terminator
+sSwalotAnims_8_5:
+ax_anim 16, 0, 170, 0, 0, 0, 0,
+ax_anim 16, 0, 171, 0, 1, 0, 0,
+ax_anim_terminator
+sSwalotAnims_8_6:
+ax_anim 16, 0, 172, 0, 0, 0, 0,
+ax_anim 16, 0, 173, 1, 1, 0, 0,
+ax_anim_terminator
+sSwalotAnims_8_7:
+ax_anim 16, 0, 174, 0, 0, 0, 0,
+ax_anim 16, 0, 175, 2, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_8_8:
+ax_anim 16, 0, 176, 0, 0, 0, 0,
+ax_anim 16, 0, 177, 1, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwalotAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 9, 3, 9, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 14, 7, 14,
+ax_anim 3, 0, 182, 0, 18, 0, 18,
+ax_anim 2, 3, 183, -7, 14, -7, 14,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -9, 3, -9, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 9, -1, 9, -1,
+ax_anim 2, 0, 179, 18, 3, 18, 3,
+ax_anim 2, 0, 180, 20, 10, 20, 10,
+ax_anim 3, 0, 181, 19, 18, 18, 16,
+ax_anim 2, 3, 182, 11, 18, 11, 18,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 4, -3, 4, -3,
+ax_anim 2, 0, 178, 11, -5, 11, -5,
+ax_anim 2, 0, 179, 17, -5, 17, -5,
+ax_anim 3, 0, 180, 19, -2, 19, -2,
+ax_anim 2, 3, 181, 16, 4, 16, 4,
+ax_anim 2, 0, 182, 12, 6, 12, 6,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 1, -8, 1, -8,
+ax_anim 2, 0, 185, 4, -14, 4, -14,
+ax_anim 2, 0, 178, 11, -19, 11, -19,
+ax_anim 3, 0, 179, 18, -20, 18, -20,
+ax_anim 2, 3, 180, 20, -15, 20, -15,
+ax_anim 2, 0, 181, 17, -4, 17, -4,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -10, -9, -10,
+ax_anim 2, 0, 185, -7, -16, -7, -16,
+ax_anim 3, 0, 178, 0, -19, 0, -19,
+ax_anim 2, 3, 179, 7, -16, 7, -16,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -8, 1, -8,
+ax_anim 2, 0, 179, -4, -14, -4, -14,
+ax_anim 2, 0, 178, -11, -19, -11, -19,
+ax_anim 3, 0, 185, -18, -20, -18, -20,
+ax_anim 2, 3, 184, -20, -15, -20, -15,
+ax_anim 2, 0, 183, -17, -4, -17, -4,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -4, -3, -4, -3,
+ax_anim 2, 0, 178, -11, -5, -11, -5,
+ax_anim 2, 0, 185, -17, -5, -17, -5,
+ax_anim 3, 0, 184, -19, -2, -19, -2,
+ax_anim 2, 3, 183, -16, 4, -16, 4,
+ax_anim 2, 0, 182, -12, 6, -12, 6,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -9, -1, -9, -1,
+ax_anim 2, 0, 185, -18, 3, -18, 3,
+ax_anim 2, 0, 184, -20, 10, -20, 10,
+ax_anim 3, 0, 183, -19, 18, -19, 18,
+ax_anim 2, 3, 182, -11, 18, -11, 18,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwalotAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwalotAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -24, 0, 0,
+ax_anim 3, 0, 196, 0, -24, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -19, 0, 0,
+ax_anim 4, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -24, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 1, 0, 199, 0, -8, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -19, 0, 0,
+ax_anim 4, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -24, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -19, 0, 0,
+ax_anim 4, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -19, 0, 0,
+ax_anim 4, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -24, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -19, 0, 0,
+ax_anim 4, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -19, 0, 0,
+ax_anim 4, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -24, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -19, 0, 0,
+ax_anim 4, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -24, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 1, 0, 217, 0, -8, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwalotAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwalotAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sSwalotGfx1:
+.incbin "baserom.gba", 0x12EA638, 0x200
+sSwalotSprites1:
+ax_sprite sSwalotGfx1, 0x200
+ax_sprite_terminator
+sSwalotGfx2:
+.incbin "baserom.gba", 0x12EA848, 0x200
+sSwalotSprites2:
+ax_sprite sSwalotGfx2, 0x200
+ax_sprite_terminator
+sSwalotGfx3:
+.incbin "baserom.gba", 0x12EAA58, 0x200
+sSwalotSprites3:
+ax_sprite sSwalotGfx3, 0x200
+ax_sprite_terminator
+sSwalotGfx4:
+.incbin "baserom.gba", 0x12EAC68, 0x200
+sSwalotSprites4:
+ax_sprite sSwalotGfx4, 0x200
+ax_sprite_terminator
+sSwalotGfx5:
+.incbin "baserom.gba", 0x12EAE78, 0x200
+sSwalotSprites5:
+ax_sprite sSwalotGfx5, 0x200
+ax_sprite_terminator
+sSwalotGfx6:
+.incbin "baserom.gba", 0x12EB088, 0x200
+sSwalotSprites6:
+ax_sprite sSwalotGfx6, 0x200
+ax_sprite_terminator
+sSwalotGfx7:
+.incbin "baserom.gba", 0x12EB298, 0x200
+sSwalotSprites7:
+ax_sprite sSwalotGfx7, 0x200
+ax_sprite_terminator
+sSwalotGfx8:
+.incbin "baserom.gba", 0x12EB4A8, 0x200
+sSwalotSprites8:
+ax_sprite sSwalotGfx8, 0x200
+ax_sprite_terminator
+sSwalotGfx9:
+.incbin "baserom.gba", 0x12EB6B8, 0x200
+sSwalotSprites9:
+ax_sprite sSwalotGfx9, 0x200
+ax_sprite_terminator
+sSwalotGfx10:
+.incbin "baserom.gba", 0x12EB8C8, 0x200
+sSwalotSprites10:
+ax_sprite sSwalotGfx10, 0x200
+ax_sprite_terminator
+sSwalotGfx11:
+.incbin "baserom.gba", 0x12EBAD8, 0x200
+sSwalotSprites11:
+ax_sprite sSwalotGfx11, 0x200
+ax_sprite_terminator
+sSwalotGfx12:
+.incbin "baserom.gba", 0x12EBCE8, 0x200
+sSwalotSprites12:
+ax_sprite sSwalotGfx12, 0x200
+ax_sprite_terminator
+sSwalotGfx13:
+.incbin "baserom.gba", 0x12EBEF8, 0x200
+sSwalotSprites13:
+ax_sprite sSwalotGfx13, 0x200
+ax_sprite_terminator
+sSwalotGfx14:
+.incbin "baserom.gba", 0x12EC108, 0x200
+sSwalotSprites14:
+ax_sprite sSwalotGfx14, 0x200
+ax_sprite_terminator
+sSwalotGfx15:
+.incbin "baserom.gba", 0x12EC318, 0x200
+sSwalotSprites15:
+ax_sprite sSwalotGfx15, 0x200
+ax_sprite_terminator
+sSwalotGfx16:
+.incbin "baserom.gba", 0x12EC528, 0x160
+sSwalotSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx16, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSwalotGfx17:
+.incbin "baserom.gba", 0x12EC6A8, 0x1E0
+sSwalotSprites17:
+ax_sprite sSwalotGfx17, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx18:
+.incbin "baserom.gba", 0x12EC8A0, 0x60
+sSwalotGfx18_1:
+.incbin "baserom.gba", 0x12EC900, 0x60
+sSwalotGfx18_2:
+.incbin "baserom.gba", 0x12EC960, 0x60
+sSwalotSprites18:
+ax_sprite sSwalotGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSwalotGfx19:
+.incbin "baserom.gba", 0x12EC9F8, 0x60
+sSwalotGfx19_1:
+.incbin "baserom.gba", 0x12ECA58, 0x160
+sSwalotSprites19:
+ax_sprite sSwalotGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx20:
+.incbin "baserom.gba", 0x12ECBE0, 0x60
+sSwalotGfx20_1:
+.incbin "baserom.gba", 0x12ECC40, 0x100
+sSwalotSprites20:
+ax_sprite sSwalotGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sSwalotGfx21:
+.incbin "baserom.gba", 0x12ECD68, 0x60
+sSwalotGfx21_1:
+.incbin "baserom.gba", 0x12ECDC8, 0x60
+sSwalotGfx21_2:
+.incbin "baserom.gba", 0x12ECE28, 0xE0
+sSwalotSprites21:
+ax_sprite sSwalotGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx21_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx22:
+.incbin "baserom.gba", 0x12ECF40, 0x60
+sSwalotGfx22_1:
+.incbin "baserom.gba", 0x12ECFA0, 0x60
+sSwalotGfx22_2:
+.incbin "baserom.gba", 0x12ED000, 0xE0
+sSwalotSprites22:
+ax_sprite sSwalotGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx22_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx23:
+.incbin "baserom.gba", 0x12ED118, 0x60
+sSwalotGfx23_1:
+.incbin "baserom.gba", 0x12ED178, 0x60
+sSwalotGfx23_2:
+.incbin "baserom.gba", 0x12ED1D8, 0x100
+sSwalotSprites23:
+ax_sprite sSwalotGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx23_2, 0x100
+ax_sprite_terminator
+sSwalotGfx24:
+.incbin "baserom.gba", 0x12ED308, 0x40
+sSwalotGfx24_1:
+.incbin "baserom.gba", 0x12ED348, 0x60
+sSwalotGfx24_2:
+.incbin "baserom.gba", 0x12ED3A8, 0x100
+sSwalotSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx24_2, 0x100
+ax_sprite_terminator
+sSwalotGfx25:
+.incbin "baserom.gba", 0x12ED4E0, 0x60
+sSwalotGfx25_1:
+.incbin "baserom.gba", 0x12ED540, 0x180
+sSwalotSprites25:
+ax_sprite sSwalotGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx25_1, 0x180
+ax_sprite_terminator
+sSwalotGfx26:
+.incbin "baserom.gba", 0x12ED6E0, 0x60
+sSwalotGfx26_1:
+.incbin "baserom.gba", 0x12ED740, 0x160
+sSwalotSprites26:
+ax_sprite sSwalotGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx26_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx27:
+.incbin "baserom.gba", 0x12ED8C8, 0x60
+sSwalotGfx27_1:
+.incbin "baserom.gba", 0x12ED928, 0x160
+sSwalotSprites27:
+ax_sprite sSwalotGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx28:
+.incbin "baserom.gba", 0x12EDAB0, 0x1E0
+sSwalotSprites28:
+ax_sprite sSwalotGfx28, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx29:
+.incbin "baserom.gba", 0x12EDCA8, 0x60
+sSwalotGfx29_1:
+.incbin "baserom.gba", 0x12EDD08, 0x60
+sSwalotGfx29_2:
+.incbin "baserom.gba", 0x12EDD68, 0x80
+sSwalotGfx29_3:
+.incbin "baserom.gba", 0x12EDDE8, 0x20
+sSwalotSprites29:
+ax_sprite sSwalotGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx29_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sSwalotGfx30:
+.incbin "baserom.gba", 0x12EDE50, 0x60
+sSwalotGfx30_1:
+.incbin "baserom.gba", 0x12EDEB0, 0x160
+sSwalotSprites30:
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx30_1, 0x160
+ax_sprite_terminator
+sSwalotGfx31:
+.incbin "baserom.gba", 0x12EE038, 0x60
+sSwalotGfx31_1:
+.incbin "baserom.gba", 0x12EE098, 0x60
+sSwalotGfx31_2:
+.incbin "baserom.gba", 0x12EE0F8, 0x100
+sSwalotSprites31:
+ax_sprite sSwalotGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx31_2, 0x100
+ax_sprite_terminator
+sSwalotGfx32:
+.incbin "baserom.gba", 0x12EE228, 0x1E0
+sSwalotSprites32:
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx32, 0x1e0
+ax_sprite_terminator
+sSwalotGfx33:
+.incbin "baserom.gba", 0x12EE420, 0x60
+sSwalotGfx33_1:
+.incbin "baserom.gba", 0x12EE480, 0x60
+sSwalotGfx33_2:
+.incbin "baserom.gba", 0x12EE4E0, 0x100
+sSwalotSprites33:
+ax_sprite sSwalotGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx33_2, 0x100
+ax_sprite_terminator
+sSwalotGfx34:
+.incbin "baserom.gba", 0x12EE610, 0x60
+sSwalotGfx34_1:
+.incbin "baserom.gba", 0x12EE670, 0x180
+sSwalotSprites34:
+ax_sprite sSwalotGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx34_1, 0x180
+ax_sprite_terminator
+sSwalotGfx35:
+.incbin "baserom.gba", 0x12EE810, 0x60
+sSwalotGfx35_1:
+.incbin "baserom.gba", 0x12EE870, 0x180
+sSwalotSprites35:
+ax_sprite sSwalotGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx35_1, 0x180
+ax_sprite_terminator
+sSwalotGfx36:
+.incbin "baserom.gba", 0x12EEA10, 0x60
+sSwalotGfx36_1:
+.incbin "baserom.gba", 0x12EEA70, 0x160
+sSwalotSprites36:
+ax_sprite sSwalotGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx36_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx37:
+.incbin "baserom.gba", 0x12EEBF8, 0x60
+sSwalotGfx37_1:
+.incbin "baserom.gba", 0x12EEC58, 0x60
+sSwalotGfx37_2:
+.incbin "baserom.gba", 0x12EECB8, 0xE0
+sSwalotSprites37:
+ax_sprite sSwalotGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx37_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwalotGfx38:
+.incbin "baserom.gba", 0x12EEDD0, 0x60
+sSwalotGfx38_1:
+.incbin "baserom.gba", 0x12EEE30, 0xE0
+sSwalotGfx38_2:
+.incbin "baserom.gba", 0x12EEF10, 0x60
+sSwalotSprites38:
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx38_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx38_2, 0x60
+ax_sprite_terminator
+sSwalotGfx39:
+.incbin "baserom.gba", 0x12EEFA8, 0x60
+sSwalotGfx39_1:
+.incbin "baserom.gba", 0x12EF008, 0x60
+sSwalotGfx39_2:
+.incbin "baserom.gba", 0x12EF068, 0x100
+sSwalotSprites39:
+ax_sprite sSwalotGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx39_2, 0x100
+ax_sprite_terminator
+sSwalotGfx40:
+.incbin "baserom.gba", 0x12EF198, 0x60
+sSwalotGfx40_1:
+.incbin "baserom.gba", 0x12EF1F8, 0x180
+sSwalotSprites40:
+ax_sprite sSwalotGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwalotGfx40_1, 0x180
+ax_sprite_terminator
+sSwalotGfx41:
+.incbin "baserom.gba", 0x12EF398, 0x200
+sSwalotSprites41:
+ax_sprite sSwalotGfx41, 0x200
+ax_sprite_terminator
+sSwalotGfx42:
+.incbin "baserom.gba", 0x12EF5A8, 0x200
+sSwalotSprites42:
+ax_sprite sSwalotGfx42, 0x200
+ax_sprite_terminator
+sSwalotGfx43:
+.incbin "baserom.gba", 0x12EF7B8, 0x200
+sSwalotSprites43:
+ax_sprite sSwalotGfx43, 0x200
+ax_sprite_terminator
+sSwalotGfx44:
+.incbin "baserom.gba", 0x12EF9C8, 0x80
+sSwalotSprites44:
+ax_sprite sSwalotGfx44, 0x80
+ax_sprite_terminator
+sSwalotGfx45:
+.incbin "baserom.gba", 0x12EFA58, 0x20
+sSwalotSprites45:
+ax_sprite sSwalotGfx45, 0x20
+ax_sprite_terminator
+sSwalotGfx46:
+.incbin "baserom.gba", 0x12EFA88, 0x20
+sSwalotSprites46:
+ax_sprite sSwalotGfx46, 0x20
+ax_sprite_terminator
+sSwalotGfx47:
+.incbin "baserom.gba", 0x12EFAB8, 0x40
+sSwalotSprites47:
+ax_sprite sSwalotGfx47, 0x40
+ax_sprite_terminator
+sSwalotGfx48:
+.incbin "baserom.gba", 0x12EFB08, 0x100
+sSwalotSprites48:
+ax_sprite sSwalotGfx48, 0x100
+ax_sprite_terminator
+sSwalotGfx49:
+.incbin "baserom.gba", 0x12EFC18, 0x80
+sSwalotSprites49:
+ax_sprite sSwalotGfx49, 0x80
+ax_sprite_terminator
+sSwalotGfx50:
+.incbin "baserom.gba", 0x12EFCA8, 0x20
+sSwalotSprites50:
+ax_sprite sSwalotGfx50, 0x20
+ax_sprite_terminator
+sSwalotGfx51:
+.incbin "baserom.gba", 0x12EFCD8, 0x20
+sSwalotSprites51:
+ax_sprite sSwalotGfx51, 0x20
+ax_sprite_terminator
+sSwalotGfx52:
+.incbin "baserom.gba", 0x12EFD08, 0x40
+sSwalotSprites52:
+ax_sprite sSwalotGfx52, 0x40
+ax_sprite_terminator
+sSwalotGfx53:
+.incbin "baserom.gba", 0x12EFD58, 0x100
+sSwalotSprites53:
+ax_sprite sSwalotGfx53, 0x100
+ax_sprite_terminator
+sSwalotGfx54:
+.incbin "baserom.gba", 0x12EFE68, 0x40
+sSwalotSprites54:
+ax_sprite sSwalotGfx54, 0x40
+ax_sprite_terminator
+sSwalotGfx55:
+.incbin "baserom.gba", 0x12EFEB8, 0x20
+sSwalotSprites55:
+ax_sprite sSwalotGfx55, 0x20
+ax_sprite_terminator
+sSwalotGfx56:
+.incbin "baserom.gba", 0x12EFEE8, 0x20
+sSwalotSprites56:
+ax_sprite sSwalotGfx56, 0x20
+ax_sprite_terminator
+sSwalotGfx57:
+.incbin "baserom.gba", 0x12EFF18, 0x80
+sSwalotSprites57:
+ax_sprite sSwalotGfx57, 0x80
+ax_sprite_terminator
+sSwalotGfx58:
+.incbin "baserom.gba", 0x12EFFA8, 0x100
+sSwalotSprites58:
+ax_sprite sSwalotGfx58, 0x100
+ax_sprite_terminator
+sSwalotGfx59:
+.incbin "baserom.gba", 0x12F00B8, 0x200
+sSwalotSprites59:
+ax_sprite sSwalotGfx59, 0x200
+ax_sprite_terminator
+sAxPosesSwalot:
+.4byte sSwalotPose1
+.4byte sSwalotPose2
+.4byte sSwalotPose3
+.4byte sSwalotPose4
+.4byte sSwalotPose5
+.4byte sSwalotPose6
+.4byte sSwalotPose7
+.4byte sSwalotPose8
+.4byte sSwalotPose9
+.4byte sSwalotPose10
+.4byte sSwalotPose11
+.4byte sSwalotPose12
+.4byte sSwalotPose13
+.4byte sSwalotPose14
+.4byte sSwalotPose15
+.4byte sSwalotPose16
+.4byte sSwalotPose17
+.4byte sSwalotPose18
+.4byte sSwalotPose19
+.4byte sSwalotPose20
+.4byte sSwalotPose21
+.4byte sSwalotPose22
+.4byte sSwalotPose23
+.4byte sSwalotPose24
+.4byte sSwalotPose25
+.4byte sSwalotPose26
+.4byte sSwalotPose27
+.4byte sSwalotPose28
+.4byte sSwalotPose29
+.4byte sSwalotPose30
+.4byte sSwalotPose31
+.4byte sSwalotPose32
+.4byte sSwalotPose33
+.4byte sSwalotPose34
+.4byte sSwalotPose35
+.4byte sSwalotPose36
+.4byte sSwalotPose37
+.4byte sSwalotPose38
+.4byte sSwalotPose39
+.4byte sSwalotPose40
+.4byte sSwalotPose41
+.4byte sSwalotPose42
+.4byte sSwalotPose43
+.4byte sSwalotPose44
+.4byte sSwalotPose45
+.4byte sSwalotPose46
+.4byte sSwalotPose47
+.4byte sSwalotPose48
+.4byte sSwalotPose49
+.4byte sSwalotPose50
+.4byte sSwalotPose51
+.4byte sSwalotPose52
+.4byte sSwalotPose53
+.4byte sSwalotPose54
+.4byte sSwalotPose55
+.4byte sSwalotPose56
+.4byte sSwalotPose57
+.4byte sSwalotPose58
+.4byte sSwalotPose59
+.4byte sSwalotPose60
+.4byte sSwalotPose61
+.4byte sSwalotPose62
+.4byte sSwalotPose63
+.4byte sSwalotPose64
+.4byte sSwalotPose65
+.4byte sSwalotPose66
+.4byte sSwalotPose67
+.4byte sSwalotPose68
+.4byte sSwalotPose69
+.4byte sSwalotPose70
+.4byte sSwalotPose71
+.4byte sSwalotPose72
+.4byte sSwalotPose73
+.4byte sSwalotPose74
+.4byte sSwalotPose75
+.4byte sSwalotPose76
+.4byte sSwalotPose77
+.4byte sSwalotPose78
+.4byte sSwalotPose79
+.4byte sSwalotPose80
+.4byte sSwalotPose81
+.4byte sSwalotPose82
+.4byte sSwalotPose83
+.4byte sSwalotPose84
+.4byte sSwalotPose85
+.4byte sSwalotPose86
+.4byte sSwalotPose87
+.4byte sSwalotPose88
+.4byte sSwalotPose89
+.4byte sSwalotPose90
+.4byte sSwalotPose91
+.4byte sSwalotPose92
+.4byte sSwalotPose93
+.4byte sSwalotPose94
+.4byte sSwalotPose95
+.4byte sSwalotPose96
+.4byte sSwalotPose97
+.4byte sSwalotPose98
+.4byte sSwalotPose99
+.4byte sSwalotPose100
+.4byte sSwalotPose101
+.4byte sSwalotPose102
+.4byte sSwalotPose103
+.4byte sSwalotPose104
+.4byte sSwalotPose105
+.4byte sSwalotPose106
+.4byte sSwalotPose107
+.4byte sSwalotPose108
+.4byte sSwalotPose109
+.4byte sSwalotPose110
+.4byte sSwalotPose111
+.4byte sSwalotPose112
+.4byte sSwalotPose113
+.4byte sSwalotPose114
+.4byte sSwalotPose115
+.4byte sSwalotPose116
+.4byte sSwalotPose117
+.4byte sSwalotPose118
+.4byte sSwalotPose119
+.4byte sSwalotPose120
+.4byte sSwalotPose121
+.4byte sSwalotPose122
+.4byte sSwalotPose123
+.4byte sSwalotPose124
+.4byte sSwalotPose125
+.4byte sSwalotPose126
+.4byte sSwalotPose127
+.4byte sSwalotPose128
+.4byte sSwalotPose129
+.4byte sSwalotPose130
+.4byte sSwalotPose131
+.4byte sSwalotPose132
+.4byte sSwalotPose133
+.4byte sSwalotPose134
+.4byte sSwalotPose135
+.4byte sSwalotPose136
+.4byte sSwalotPose137
+.4byte sSwalotPose138
+.4byte sSwalotPose139
+.4byte sSwalotPose140
+.4byte sSwalotPose141
+.4byte sSwalotPose142
+.4byte sSwalotPose143
+.4byte sSwalotPose144
+.4byte sSwalotPose145
+.4byte sSwalotPose146
+.4byte sSwalotPose147
+.4byte sSwalotPose148
+.4byte sSwalotPose149
+.4byte sSwalotPose150
+.4byte sSwalotPose151
+.4byte sSwalotPose152
+.4byte sSwalotPose153
+.4byte sSwalotPose154
+.4byte sSwalotPose155
+.4byte sSwalotPose156
+.4byte sSwalotPose157
+.4byte sSwalotPose158
+.4byte sSwalotPose159
+.4byte sSwalotPose160
+.4byte sSwalotPose161
+.4byte sSwalotPose162
+.4byte sSwalotPose163
+.4byte sSwalotPose164
+.4byte sSwalotPose165
+.4byte sSwalotPose166
+.4byte sSwalotPose167
+.4byte sSwalotPose168
+.4byte sSwalotPose169
+.4byte sSwalotPose170
+.4byte sSwalotPose171
+.4byte sSwalotPose172
+.4byte sSwalotPose173
+.4byte sSwalotPose174
+.4byte sSwalotPose175
+.4byte sSwalotPose176
+.4byte sSwalotPose177
+.4byte sSwalotPose178
+.4byte sSwalotPose179
+.4byte sSwalotPose180
+.4byte sSwalotPose181
+.4byte sSwalotPose182
+.4byte sSwalotPose183
+.4byte sSwalotPose184
+.4byte sSwalotPose185
+.4byte sSwalotPose186
+.4byte sSwalotPose187
+.4byte sSwalotPose188
+.4byte sSwalotPose189
+.4byte sSwalotPose190
+.4byte sSwalotPose191
+.4byte sSwalotPose192
+.4byte sSwalotPose193
+.4byte sSwalotPose194
+.4byte sSwalotPose195
+.4byte sSwalotPose196
+.4byte sSwalotPose197
+.4byte sSwalotPose198
+.4byte sSwalotPose199
+.4byte sSwalotPose200
+.4byte sSwalotPose201
+.4byte sSwalotPose202
+.4byte sSwalotPose203
+.4byte sSwalotPose204
+.4byte sSwalotPose205
+.4byte sSwalotPose206
+.4byte sSwalotPose207
+.4byte sSwalotPose208
+.4byte sSwalotPose209
+.4byte sSwalotPose210
+.4byte sSwalotPose211
+.4byte sSwalotPose212
+.4byte sSwalotPose213
+.4byte sSwalotPose214
+.4byte sSwalotPose215
+.4byte sSwalotPose216
+.4byte sSwalotPose217
+.4byte sSwalotPose218
+.4byte sSwalotPose219
+.4byte sSwalotPose220
+.4byte sSwalotPose221
+.4byte sSwalotPose222
+.4byte sSwalotPose223
+.4byte sSwalotPose224
+.4byte sSwalotPose225
+.4byte sSwalotPose226
+.4byte sSwalotPose227
+.4byte sSwalotPose228
+.4byte sSwalotPose229
+.4byte sSwalotPose230
+.4byte sSwalotPose231
+.4byte sSwalotPose232
+.4byte sSwalotPose233
+.4byte sSwalotPose234
+sAxPositionsSwalot:
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte    0,  -13, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte   -1,   -9, 	  -9,   -6, 	   9,   -6, 	   0,   -6
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+.2byte    6,  -12, 	   5,   -9, 	  -8,   -6, 	  -1,   -8
+.2byte    6,  -11, 	   9,  -11, 	  -4,   -5, 	   1,   -8
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte   12,  -16, 	   2,   -9, 	   0,   -5, 	   3,   -7
+.2byte   10,  -12, 	   3,   -9, 	   4,   -5, 	   0,   -8
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte    6,  -15, 	  -8,  -11, 	   3,   -5, 	  -2,   -9
+.2byte    4,  -15, 	  -7,  -12, 	   8,   -7, 	  -3,  -10
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -12, 	   0,  -10
+.2byte    0,  -15, 	   8,  -12, 	  -9,  -12, 	   0,  -10
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte   -7,  -15, 	   7,  -11, 	  -4,   -5, 	   1,   -9
+.2byte   -5,  -15, 	   6,  -12, 	  -9,   -7, 	   2,  -10
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte  -13,  -16, 	  -3,   -9, 	  -1,   -5, 	  -4,   -7
+.2byte  -11,  -12, 	  -4,   -9, 	  -5,   -5, 	  -1,   -8
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -7,  -12, 	  -6,   -9, 	   7,   -6, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -11, 	   3,   -5, 	  -2,   -8
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte    0,  -13, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte   -1,   -9, 	  -9,   -6, 	   9,   -6, 	   0,   -6
+.2byte    8,   -9, 	  -7,   -6, 	  12,   -8, 	   3,   -7
+.2byte   -1,  -16, 	 -12,   -9, 	  12,   -9, 	   0,   -8
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+.2byte    6,  -12, 	   5,   -9, 	  -8,   -6, 	  -1,   -8
+.2byte    6,  -11, 	   9,  -11, 	  -4,   -5, 	   1,   -8
+.2byte   -5,   -7, 	   6,   -8, 	 -10,   -6, 	  -1,   -7
+.2byte    2,  -18, 	   2,  -15, 	 -11,   -7, 	  -1,  -10
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte   12,  -16, 	   2,   -9, 	   0,   -5, 	   3,   -7
+.2byte   10,  -12, 	   3,   -9, 	   4,   -5, 	   0,   -8
+.2byte    5,   -9, 	   9,   -8, 	  -4,   -2, 	  -2,   -8
+.2byte    4,  -20, 	  -4,  -12, 	  -5,   -6, 	   0,   -9
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte    6,  -15, 	  -8,  -11, 	   3,   -5, 	  -2,   -9
+.2byte    4,  -15, 	  -7,  -12, 	   8,   -7, 	  -3,  -10
+.2byte    6,   -9, 	  -7,  -10, 	   4,   -3, 	  -3,   -8
+.2byte    3,  -20, 	  -6,  -12, 	   2,   -8, 	  -2,  -10
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -12, 	   0,  -10
+.2byte    0,  -15, 	   8,  -12, 	  -9,  -12, 	   0,  -10
+.2byte   -8,  -12, 	   5,  -10, 	  -8,   -5, 	   1,   -7
+.2byte    0,  -22, 	  10,  -11, 	 -12,  -11, 	   0,   -8
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte   -7,  -15, 	   7,  -11, 	  -4,   -5, 	   1,   -9
+.2byte   -5,  -15, 	   6,  -12, 	  -9,   -7, 	   2,  -10
+.2byte   -7,   -9, 	   6,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -4,  -20, 	   5,  -12, 	  -3,   -8, 	   1,  -10
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte  -13,  -16, 	  -3,   -9, 	  -1,   -5, 	  -4,   -7
+.2byte  -11,  -12, 	  -4,   -9, 	  -5,   -5, 	  -1,   -8
+.2byte   -6,   -9, 	 -10,   -8, 	   3,   -2, 	   1,   -8
+.2byte   -5,  -20, 	   3,  -12, 	   4,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -7,  -12, 	  -6,   -9, 	   7,   -6, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -11, 	   3,   -5, 	  -2,   -8
+.2byte    4,   -7, 	  -7,   -8, 	   9,   -6, 	   0,   -7
+.2byte   -3,  -18, 	  -3,  -15, 	  10,   -7, 	   0,  -10
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte    0,  -13, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte   -1,   -9, 	  -9,   -6, 	   9,   -6, 	   0,   -6
+.2byte    8,   -9, 	  -7,   -6, 	  12,   -8, 	   3,   -7
+.2byte   -1,  -16, 	 -12,   -9, 	  12,   -9, 	   0,   -8
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+.2byte    6,  -12, 	   5,   -9, 	  -8,   -6, 	  -1,   -8
+.2byte    6,  -11, 	   9,  -11, 	  -4,   -5, 	   1,   -8
+.2byte   -5,   -7, 	   6,   -8, 	 -10,   -6, 	  -1,   -7
+.2byte    2,  -18, 	   2,  -15, 	 -11,   -7, 	  -1,  -10
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte   12,  -16, 	   2,   -9, 	   0,   -5, 	   3,   -7
+.2byte   10,  -12, 	   3,   -9, 	   4,   -5, 	   0,   -8
+.2byte    5,   -9, 	   9,   -8, 	  -4,   -2, 	  -2,   -8
+.2byte    4,  -20, 	  -4,  -12, 	  -5,   -6, 	   0,   -9
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte    6,  -15, 	  -8,  -11, 	   3,   -5, 	  -2,   -9
+.2byte    4,  -15, 	  -7,  -12, 	   8,   -7, 	  -3,  -10
+.2byte    6,   -9, 	  -7,  -10, 	   4,   -3, 	  -3,   -8
+.2byte    3,  -20, 	  -6,  -12, 	   2,   -8, 	  -2,  -10
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -12, 	   0,  -10
+.2byte    0,  -15, 	   8,  -12, 	  -9,  -12, 	   0,  -10
+.2byte   -8,  -12, 	   5,  -10, 	  -8,   -5, 	   1,   -7
+.2byte    0,  -22, 	  10,  -11, 	 -12,  -11, 	   0,   -8
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte   -7,  -15, 	   7,  -11, 	  -4,   -5, 	   1,   -9
+.2byte   -5,  -15, 	   6,  -12, 	  -9,   -7, 	   2,  -10
+.2byte   -7,   -9, 	   6,  -10, 	  -5,   -3, 	   2,   -8
+.2byte   -4,  -20, 	   5,  -12, 	  -3,   -8, 	   1,  -10
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte  -13,  -16, 	  -3,   -9, 	  -1,   -5, 	  -4,   -7
+.2byte  -11,  -12, 	  -4,   -9, 	  -5,   -5, 	  -1,   -8
+.2byte   -6,   -9, 	 -10,   -8, 	   3,   -2, 	   1,   -8
+.2byte   -5,  -20, 	   3,  -12, 	   4,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -7,  -12, 	  -6,   -9, 	   7,   -6, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -11, 	   3,   -5, 	  -2,   -8
+.2byte    4,   -7, 	  -7,   -8, 	   9,   -6, 	   0,   -7
+.2byte   -3,  -18, 	  -3,  -15, 	  10,   -7, 	   0,  -10
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte    0,  -19, 	  -9,   -8, 	   8,   -8, 	   0,   -9
+.2byte    0,   -3, 	 -11,  -11, 	  10,  -10, 	   0,   -6
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+.2byte    0,  -19, 	   7,  -12, 	  -4,   -7, 	  -1,  -10
+.2byte    5,   -5, 	  11,  -10, 	  -7,   -6, 	   1,   -7
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    0,  -21, 	   0,  -13, 	   2,   -7, 	  -4,   -9
+.2byte    8,   -8, 	   0,   -9, 	  -2,   -6, 	   1,   -7
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte   -1,  -20, 	 -10,  -11, 	   6,  -10, 	  -5,   -9
+.2byte    5,  -10, 	  -8,  -11, 	   0,   -5, 	  -3,   -9
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte    0,  -23, 	   8,  -11, 	  -9,  -11, 	   0,   -9
+.2byte   -1,  -15, 	  10,   -9, 	 -11,   -9, 	   0,   -6
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte    0,  -20, 	   9,  -11, 	  -7,  -10, 	   4,   -9
+.2byte   -6,  -10, 	   7,  -11, 	  -1,   -5, 	   2,   -9
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte   -1,  -21, 	  -1,  -13, 	  -3,   -7, 	   3,   -9
+.2byte   -9,   -8, 	  -1,   -9, 	   1,   -6, 	  -2,   -7
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -1,  -19, 	  -8,  -12, 	   3,   -7, 	   0,  -10
+.2byte   -6,   -5, 	 -12,  -10, 	   6,   -6, 	  -2,   -7
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte    0,   -3, 	 -11,  -11, 	  10,  -10, 	   0,   -6
+.2byte    0,  -13, 	  -9,   -6, 	   8,   -6, 	  -1,   -6
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+.2byte    5,   -5, 	  11,  -10, 	  -7,   -6, 	   1,   -7
+.2byte    1,  -13, 	   9,   -9, 	  -5,   -6, 	  -1,   -7
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    8,   -8, 	   0,   -9, 	  -2,   -6, 	   1,   -7
+.2byte    5,  -13, 	   1,   -9, 	   4,   -6, 	  -2,   -8
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte    5,  -10, 	  -8,  -11, 	   0,   -5, 	  -3,   -9
+.2byte    2,  -14, 	  -1,  -10, 	   8,   -6, 	  -4,   -8
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte   -1,  -15, 	  10,   -9, 	 -11,   -9, 	   0,   -6
+.2byte    0,  -23, 	   9,  -11, 	  -9,  -11, 	   0,   -9
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte   -6,  -10, 	   7,  -11, 	  -1,   -5, 	   2,   -9
+.2byte   -3,  -14, 	   0,  -10, 	  -9,   -6, 	   3,   -8
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte   -9,   -8, 	  -1,   -9, 	   1,   -6, 	  -2,   -7
+.2byte   -6,  -13, 	  -2,   -9, 	  -5,   -6, 	   1,   -8
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -6,   -5, 	 -12,  -10, 	   6,   -6, 	  -2,   -7
+.2byte   -2,  -13, 	 -10,   -9, 	   4,   -6, 	   0,   -7
+.2byte   -5,  -10, 	  -9,  -11, 	   6,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	  -9,  -10, 	   6,   -4, 	   0,   -7
+.2byte    0,  -19, 	 -11,  -15, 	  11,  -15, 	   0,  -12
+.2byte    4,  -19, 	   6,  -18, 	  -9,  -14, 	   0,  -11
+.2byte    4,  -22, 	   0,  -17, 	  -4,  -13, 	  -1,  -12
+.2byte    4,  -21, 	  -4,  -16, 	   5,  -12, 	  -2,  -11
+.2byte   -1,  -20, 	  10,  -14, 	 -11,  -14, 	   0,  -11
+.2byte   -5,  -21, 	   3,  -16, 	  -6,  -12, 	   1,  -11
+.2byte   -5,  -22, 	  -1,  -17, 	   3,  -13, 	   0,  -12
+.2byte   -5,  -19, 	  -7,  -18, 	   8,  -14, 	  -1,  -11
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte   -1,   -9, 	  -9,   -6, 	   9,   -6, 	   0,   -6
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+.2byte    6,  -11, 	   9,  -11, 	  -4,   -5, 	   1,   -8
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte   10,  -12, 	   3,   -9, 	   4,   -5, 	   0,   -8
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte    4,  -15, 	  -7,  -12, 	   8,   -7, 	  -3,  -10
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -12, 	   0,  -10
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte   -5,  -15, 	   6,  -12, 	  -9,   -7, 	   2,  -10
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte  -11,  -12, 	  -4,   -9, 	  -5,   -5, 	  -1,   -8
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -7,  -11, 	 -10,  -11, 	   3,   -5, 	  -2,   -8
+.2byte   -1,  -16, 	 -12,   -9, 	  12,   -9, 	   0,   -8
+.2byte   -3,  -17, 	  -3,  -14, 	  10,   -6, 	   0,   -9
+.2byte   -5,  -19, 	   3,  -11, 	   4,   -5, 	  -1,   -8
+.2byte   -4,  -19, 	   5,  -11, 	  -3,   -7, 	   1,   -9
+.2byte    0,  -21, 	  10,  -10, 	 -12,  -10, 	   0,   -7
+.2byte    3,  -19, 	  -6,  -11, 	   2,   -7, 	  -2,   -9
+.2byte    4,  -19, 	  -4,  -11, 	  -5,   -5, 	   0,   -8
+.2byte    2,  -17, 	   2,  -14, 	 -11,   -6, 	  -1,   -9
+.2byte    0,  -13, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte    6,  -12, 	   5,   -9, 	  -8,   -6, 	  -1,   -8
+.2byte    9,  -16, 	  -1,   -9, 	  -3,   -5, 	   0,   -7
+.2byte    5,  -15, 	  -9,  -11, 	   2,   -5, 	  -3,   -9
+.2byte    0,  -16, 	   8,  -11, 	  -9,  -12, 	   0,  -10
+.2byte   -6,  -15, 	   8,  -11, 	  -3,   -5, 	   2,   -9
+.2byte  -10,  -16, 	   0,   -9, 	   2,   -5, 	  -1,   -7
+.2byte   -7,  -12, 	  -6,   -9, 	   7,   -6, 	   0,   -8
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte    0,  -19, 	  -9,   -8, 	   8,   -8, 	   0,   -9
+.2byte    0,   -3, 	 -11,  -11, 	  10,  -10, 	   0,   -6
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+.2byte    0,  -19, 	   7,  -12, 	  -4,   -7, 	  -1,  -10
+.2byte    5,   -5, 	  11,  -10, 	  -7,   -6, 	   1,   -7
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    0,  -21, 	   0,  -13, 	   2,   -7, 	  -4,   -9
+.2byte    8,   -8, 	   0,   -9, 	  -2,   -6, 	   1,   -7
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte   -1,  -20, 	 -10,  -11, 	   6,  -10, 	  -5,   -9
+.2byte    5,  -10, 	  -8,  -11, 	   0,   -5, 	  -3,   -9
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte    0,  -23, 	   8,  -11, 	  -9,  -11, 	   0,   -9
+.2byte   -1,  -15, 	  10,   -9, 	 -11,   -9, 	   0,   -6
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte    0,  -20, 	   9,  -11, 	  -7,  -10, 	   4,   -9
+.2byte   -6,  -10, 	   7,  -11, 	  -1,   -5, 	   2,   -9
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte   -1,  -21, 	  -1,  -13, 	  -3,   -7, 	   3,   -9
+.2byte   -9,   -8, 	  -1,   -9, 	   1,   -6, 	  -2,   -7
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -1,  -19, 	  -8,  -12, 	   3,   -7, 	   0,  -10
+.2byte   -6,   -5, 	 -12,  -10, 	   6,   -6, 	  -2,   -7
+.2byte    0,   -3, 	 -11,  -11, 	  10,  -10, 	   0,   -6
+.2byte   -5,   -5, 	 -11,  -10, 	   7,   -6, 	  -1,   -7
+.2byte   -7,   -8, 	   1,   -9, 	   3,   -6, 	   0,   -7
+.2byte   -6,  -10, 	   7,  -11, 	  -1,   -5, 	   2,   -9
+.2byte   -1,  -15, 	  10,   -9, 	 -11,   -9, 	   0,   -6
+.2byte    5,  -10, 	  -8,  -11, 	   0,   -5, 	  -3,   -9
+.2byte    6,   -8, 	  -2,   -9, 	  -4,   -6, 	  -1,   -7
+.2byte    4,   -5, 	  10,  -10, 	  -8,   -6, 	   0,   -7
+.2byte    0,  -11, 	 -10,   -8, 	  10,   -8, 	   0,   -7
+.2byte   -5,  -12, 	  -9,  -11, 	   6,   -5, 	   0,   -8
+.2byte   -7,  -14, 	  -1,   -8, 	  -1,   -5, 	   1,   -9
+.2byte   -4,  -14, 	   6,  -10, 	  -7,   -6, 	   3,   -8
+.2byte   -1,  -14, 	   9,  -10, 	  -9,  -10, 	  -1,   -8
+.2byte    3,  -14, 	  -7,  -10, 	   6,   -6, 	  -4,   -8
+.2byte    6,  -14, 	   0,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    4,  -12, 	   8,  -11, 	  -7,   -5, 	  -1,   -8
+sSwalotAnimTable1:
+.4byte sSwalotAnims_1_1
+.4byte sSwalotAnims_1_2
+.4byte sSwalotAnims_1_3
+.4byte sSwalotAnims_1_4
+.4byte sSwalotAnims_1_5
+.4byte sSwalotAnims_1_6
+.4byte sSwalotAnims_1_7
+.4byte sSwalotAnims_1_8
+sSwalotAnimTable2:
+.4byte sSwalotAnims_2_1
+.4byte sSwalotAnims_2_2
+.4byte sSwalotAnims_2_3
+.4byte sSwalotAnims_2_4
+.4byte sSwalotAnims_2_5
+.4byte sSwalotAnims_2_6
+.4byte sSwalotAnims_2_7
+.4byte sSwalotAnims_2_8
+sSwalotAnimTable3:
+.4byte sSwalotAnims_3_1
+.4byte sSwalotAnims_3_2
+.4byte sSwalotAnims_3_3
+.4byte sSwalotAnims_3_4
+.4byte sSwalotAnims_3_5
+.4byte sSwalotAnims_3_6
+.4byte sSwalotAnims_3_7
+.4byte sSwalotAnims_3_8
+sSwalotAnimTable4:
+.4byte sSwalotAnims_4_1
+.4byte sSwalotAnims_4_2
+.4byte sSwalotAnims_4_3
+.4byte sSwalotAnims_4_4
+.4byte sSwalotAnims_4_5
+.4byte sSwalotAnims_4_6
+.4byte sSwalotAnims_4_7
+.4byte sSwalotAnims_4_8
+sSwalotAnimTable5:
+.4byte sSwalotAnims_5_1
+.4byte sSwalotAnims_5_2
+.4byte sSwalotAnims_5_3
+.4byte sSwalotAnims_5_4
+.4byte sSwalotAnims_5_5
+.4byte sSwalotAnims_5_6
+.4byte sSwalotAnims_5_7
+.4byte sSwalotAnims_5_8
+sSwalotAnimTable6:
+.4byte sSwalotAnims_6_1
+.4byte sSwalotAnims_6_1
+.4byte sSwalotAnims_6_1
+.4byte sSwalotAnims_6_1
+.4byte sSwalotAnims_6_1
+.4byte sSwalotAnims_6_1
+.4byte sSwalotAnims_6_1
+.4byte sSwalotAnims_6_1
+sSwalotAnimTable7:
+.4byte sSwalotAnims_7_1
+.4byte sSwalotAnims_7_2
+.4byte sSwalotAnims_7_3
+.4byte sSwalotAnims_7_4
+.4byte sSwalotAnims_7_5
+.4byte sSwalotAnims_7_6
+.4byte sSwalotAnims_7_7
+.4byte sSwalotAnims_7_8
+sSwalotAnimTable8:
+.4byte sSwalotAnims_8_1
+.4byte sSwalotAnims_8_2
+.4byte sSwalotAnims_8_3
+.4byte sSwalotAnims_8_4
+.4byte sSwalotAnims_8_5
+.4byte sSwalotAnims_8_6
+.4byte sSwalotAnims_8_7
+.4byte sSwalotAnims_8_8
+sSwalotAnimTable9:
+.4byte sSwalotAnims_9_1
+.4byte sSwalotAnims_9_2
+.4byte sSwalotAnims_9_3
+.4byte sSwalotAnims_9_4
+.4byte sSwalotAnims_9_5
+.4byte sSwalotAnims_9_6
+.4byte sSwalotAnims_9_7
+.4byte sSwalotAnims_9_8
+sSwalotAnimTable10:
+.4byte sSwalotAnims_10_1
+.4byte sSwalotAnims_10_2
+.4byte sSwalotAnims_10_3
+.4byte sSwalotAnims_10_4
+.4byte sSwalotAnims_10_5
+.4byte sSwalotAnims_10_6
+.4byte sSwalotAnims_10_7
+.4byte sSwalotAnims_10_8
+sSwalotAnimTable11:
+.4byte sSwalotAnims_11_1
+.4byte sSwalotAnims_11_2
+.4byte sSwalotAnims_11_3
+.4byte sSwalotAnims_11_4
+.4byte sSwalotAnims_11_5
+.4byte sSwalotAnims_11_6
+.4byte sSwalotAnims_11_7
+.4byte sSwalotAnims_11_8
+sSwalotAnimTable12:
+.4byte sSwalotAnims_12_1
+.4byte sSwalotAnims_12_2
+.4byte sSwalotAnims_12_3
+.4byte sSwalotAnims_12_4
+.4byte sSwalotAnims_12_5
+.4byte sSwalotAnims_12_6
+.4byte sSwalotAnims_12_7
+.4byte sSwalotAnims_12_8
+sSwalotAnimTable13:
+.4byte sSwalotAnims_13_1
+.4byte sSwalotAnims_13_2
+.4byte sSwalotAnims_13_3
+.4byte sSwalotAnims_13_4
+.4byte sSwalotAnims_13_5
+.4byte sSwalotAnims_13_6
+.4byte sSwalotAnims_13_7
+.4byte sSwalotAnims_13_8
+sAxAnimationsSwalot:
+.4byte sSwalotAnimTable1
+.4byte sSwalotAnimTable2
+.4byte sSwalotAnimTable3
+.4byte sSwalotAnimTable4
+.4byte sSwalotAnimTable5
+.4byte sSwalotAnimTable6
+.4byte sSwalotAnimTable7
+.4byte sSwalotAnimTable8
+.4byte sSwalotAnimTable9
+.4byte sSwalotAnimTable10
+.4byte sSwalotAnimTable11
+.4byte sSwalotAnimTable12
+.4byte sSwalotAnimTable13
+sAxSpritesSwalot:
+.4byte sSwalotSprites1
+.4byte sSwalotSprites2
+.4byte sSwalotSprites3
+.4byte sSwalotSprites4
+.4byte sSwalotSprites5
+.4byte sSwalotSprites6
+.4byte sSwalotSprites7
+.4byte sSwalotSprites8
+.4byte sSwalotSprites9
+.4byte sSwalotSprites10
+.4byte sSwalotSprites11
+.4byte sSwalotSprites12
+.4byte sSwalotSprites13
+.4byte sSwalotSprites14
+.4byte sSwalotSprites15
+.4byte sSwalotSprites16
+.4byte sSwalotSprites17
+.4byte sSwalotSprites18
+.4byte sSwalotSprites19
+.4byte sSwalotSprites20
+.4byte sSwalotSprites21
+.4byte sSwalotSprites22
+.4byte sSwalotSprites23
+.4byte sSwalotSprites24
+.4byte sSwalotSprites25
+.4byte sSwalotSprites26
+.4byte sSwalotSprites27
+.4byte sSwalotSprites28
+.4byte sSwalotSprites29
+.4byte sSwalotSprites30
+.4byte sSwalotSprites31
+.4byte sSwalotSprites32
+.4byte sSwalotSprites33
+.4byte sSwalotSprites34
+.4byte sSwalotSprites35
+.4byte sSwalotSprites36
+.4byte sSwalotSprites37
+.4byte sSwalotSprites38
+.4byte sSwalotSprites39
+.4byte sSwalotSprites40
+.4byte sSwalotSprites41
+.4byte sSwalotSprites42
+.4byte sSwalotSprites43
+.4byte sSwalotSprites44
+.4byte sSwalotSprites45
+.4byte sSwalotSprites46
+.4byte sSwalotSprites47
+.4byte sSwalotSprites48
+.4byte sSwalotSprites49
+.4byte sSwalotSprites50
+.4byte sSwalotSprites51
+.4byte sSwalotSprites52
+.4byte sSwalotSprites53
+.4byte sSwalotSprites54
+.4byte sSwalotSprites55
+.4byte sSwalotSprites56
+.4byte sSwalotSprites57
+.4byte sSwalotSprites58
+.4byte sSwalotSprites59
+sAxMainSwalot:
+ax_main sAxPosesSwalot, sAxAnimationsSwalot, 13, sAxSpritesSwalot, sAxPositionsSwalot

--- a/data/ax/swampert.inc
+++ b/data/ax/swampert.inc
@@ -1,0 +1,2695 @@
+.global gAxSwampert
+gAxSwampert:
+ax_siro sAxMainSwampert
+sSwampertPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose4:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose5:
+ax_pose 4, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose6:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose7:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose8:
+ax_pose 7, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose9:
+ax_pose 8, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose10:
+ax_pose 9, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose11:
+ax_pose 10, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose12:
+ax_pose 11, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose19:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose20:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose21:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose22:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose23:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose27:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose28:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose29:
+ax_pose 4, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose30:
+ax_pose 16, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sSwampertPose31:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose32:
+ax_pose 7, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose33:
+ax_pose 17, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose34:
+ax_pose 9, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose35:
+ax_pose 10, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose36:
+ax_pose 18, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose37:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose39:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose40:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose41:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose42:
+ax_pose 18, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose43:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose44:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose45:
+ax_pose 17, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose46:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose47:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose48:
+ax_pose 16, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sSwampertPose49:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose50:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose51:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose52:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose53:
+ax_pose 4, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose54:
+ax_pose 16, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sSwampertPose55:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose56:
+ax_pose 7, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose57:
+ax_pose 17, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose58:
+ax_pose 9, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose59:
+ax_pose 10, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose60:
+ax_pose 18, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose61:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose62:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose63:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose64:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose65:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose66:
+ax_pose 18, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose67:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose68:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose69:
+ax_pose 17, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose70:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose71:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose72:
+ax_pose 16, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sSwampertPose73:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose74:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose75:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose76:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose77:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose78:
+ax_pose 4, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose79:
+ax_pose 5, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose80:
+ax_pose 16, 0x01e5, 0x90f2, 0x5c00
+ax_pose_terminator
+sSwampertPose81:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose82:
+ax_pose 7, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose83:
+ax_pose 8, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose84:
+ax_pose 17, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose85:
+ax_pose 9, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose86:
+ax_pose 10, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose87:
+ax_pose 11, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose88:
+ax_pose 18, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose89:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose90:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose91:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose92:
+ax_pose 19, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose93:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose94:
+ax_pose 10, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose95:
+ax_pose 11, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose96:
+ax_pose 18, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose97:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose98:
+ax_pose 7, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose99:
+ax_pose 8, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose100:
+ax_pose 17, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose101:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose102:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose103:
+ax_pose 5, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose104:
+ax_pose 16, 0x01e5, 0x80ee, 0x5c00
+ax_pose_terminator
+sSwampertPose105:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose106:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose107:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose108:
+ax_pose 20, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose109:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose110:
+ax_pose 4, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose111:
+ax_pose 16, 0x01e7, 0x90f4, 0x5c00
+ax_pose_terminator
+sSwampertPose112:
+ax_pose 21, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose113:
+ax_pose 6, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sSwampertPose114:
+ax_pose 7, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose115:
+ax_pose 17, 0x01e4, 0x90f1, 0x5c00
+ax_pose_terminator
+sSwampertPose116:
+ax_pose 22, 0x81e3, 0x90ff, 0x5c00
+ax_pose 23, 0x81e3, 0x50f7, 0x5c08
+ax_pose 24, 0x01eb, 0x10ef, 0x5c0c
+ax_pose 25, 0x81f3, 0x10ef, 0x5c0d
+ax_pose 26, 0x01db, 0x10ff, 0x5c0f
+ax_pose_terminator
+sSwampertPose117:
+ax_pose 9, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose118:
+ax_pose 10, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose119:
+ax_pose 18, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sSwampertPose120:
+ax_pose 27, 0x81e4, 0x90ff, 0x5c00
+ax_pose 28, 0x81e4, 0x50f7, 0x5c08
+ax_pose 29, 0x81f4, 0x10ef, 0x5c0c
+ax_pose 30, 0x01dc, 0x10fb, 0x5c0e
+ax_pose_terminator
+sSwampertPose121:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose122:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose123:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose124:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose125:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose126:
+ax_pose 10, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose127:
+ax_pose 18, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose128:
+ax_pose 27, 0x81e4, 0x80f1, 0x5c00
+ax_pose 28, 0x81e4, 0x4101, 0x5c08
+ax_pose 29, 0x81f4, 0x0109, 0x5c0c
+ax_pose 30, 0x01dc, 0x00fd, 0x5c0e
+ax_pose_terminator
+sSwampertPose129:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose130:
+ax_pose 7, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose131:
+ax_pose 17, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sSwampertPose132:
+ax_pose 22, 0x81e3, 0x80f1, 0x5c00
+ax_pose 23, 0x81e3, 0x4101, 0x5c08
+ax_pose 24, 0x01eb, 0x0109, 0x5c0c
+ax_pose 25, 0x81f3, 0x0109, 0x5c0d
+ax_pose 26, 0x01db, 0x00f9, 0x5c0f
+ax_pose_terminator
+sSwampertPose133:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose134:
+ax_pose 4, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose135:
+ax_pose 16, 0x01e7, 0x80ec, 0x5c00
+ax_pose_terminator
+sSwampertPose136:
+ax_pose 21, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose137:
+ax_pose 32, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose138:
+ax_pose 33, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose139:
+ax_pose 34, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose140:
+ax_pose 35, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose141:
+ax_pose 36, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose142:
+ax_pose 37, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose143:
+ax_pose 38, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose144:
+ax_pose 37, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose145:
+ax_pose 36, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose146:
+ax_pose 35, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose147:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose148:
+ax_pose 20, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose149:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose150:
+ax_pose 21, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose151:
+ax_pose 6, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sSwampertPose152:
+ax_pose 22, 0x81e3, 0x90ff, 0x5c00
+ax_pose 23, 0x81e3, 0x50f7, 0x5c08
+ax_pose 24, 0x01eb, 0x10ef, 0x5c0c
+ax_pose 25, 0x81f3, 0x10ef, 0x5c0d
+ax_pose 26, 0x01db, 0x10ff, 0x5c0f
+ax_pose_terminator
+sSwampertPose153:
+ax_pose 9, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose154:
+ax_pose 27, 0x81e4, 0x90ff, 0x5c00
+ax_pose 28, 0x81e4, 0x50f7, 0x5c08
+ax_pose 29, 0x81f4, 0x10ef, 0x5c0c
+ax_pose 30, 0x01dc, 0x10fb, 0x5c0e
+ax_pose_terminator
+sSwampertPose155:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose156:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose157:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose158:
+ax_pose 27, 0x81e4, 0x80f1, 0x5c00
+ax_pose 28, 0x81e4, 0x4101, 0x5c08
+ax_pose 29, 0x81f4, 0x0109, 0x5c0c
+ax_pose 30, 0x01dc, 0x00fd, 0x5c0e
+ax_pose_terminator
+sSwampertPose159:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose160:
+ax_pose 22, 0x81e3, 0x80f1, 0x5c00
+ax_pose 23, 0x81e3, 0x4101, 0x5c08
+ax_pose 24, 0x01eb, 0x0109, 0x5c0c
+ax_pose 25, 0x81f3, 0x0109, 0x5c0d
+ax_pose 26, 0x01db, 0x00f9, 0x5c0f
+ax_pose_terminator
+sSwampertPose161:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose162:
+ax_pose 21, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose163:
+ax_pose 20, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose164:
+ax_pose 21, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose165:
+ax_pose 22, 0x81e4, 0x80f1, 0x5c00
+ax_pose 23, 0x81e4, 0x4101, 0x5c08
+ax_pose 24, 0x01ec, 0x0109, 0x5c0c
+ax_pose 25, 0x81f4, 0x0109, 0x5c0d
+ax_pose 26, 0x01dc, 0x00f9, 0x5c0f
+ax_pose_terminator
+sSwampertPose166:
+ax_pose 27, 0x81e4, 0x80f1, 0x5c00
+ax_pose 28, 0x81e4, 0x4101, 0x5c08
+ax_pose 29, 0x81f4, 0x0109, 0x5c0c
+ax_pose 30, 0x01dc, 0x00fd, 0x5c0e
+ax_pose_terminator
+sSwampertPose167:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose168:
+ax_pose 27, 0x81e4, 0x90ff, 0x5c00
+ax_pose 28, 0x81e4, 0x50f7, 0x5c08
+ax_pose 29, 0x81f4, 0x10ef, 0x5c0c
+ax_pose 30, 0x01dc, 0x10fb, 0x5c0e
+ax_pose_terminator
+sSwampertPose169:
+ax_pose 22, 0x81e4, 0x90ff, 0x5c00
+ax_pose 23, 0x81e4, 0x50f7, 0x5c08
+ax_pose 24, 0x01ec, 0x10ef, 0x5c0c
+ax_pose 25, 0x81f4, 0x10ef, 0x5c0d
+ax_pose 26, 0x01dc, 0x10ff, 0x5c0f
+ax_pose_terminator
+sSwampertPose170:
+ax_pose 21, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose171:
+ax_pose 20, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose172:
+ax_pose 21, 0x01e4, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose173:
+ax_pose 22, 0x81e4, 0x90ff, 0x5c00
+ax_pose 23, 0x81e4, 0x50f7, 0x5c08
+ax_pose 24, 0x01ec, 0x10ef, 0x5c0c
+ax_pose 25, 0x81f4, 0x10ef, 0x5c0d
+ax_pose 26, 0x01dc, 0x10ff, 0x5c0f
+ax_pose_terminator
+sSwampertPose174:
+ax_pose 27, 0x81e4, 0x90ff, 0x5c00
+ax_pose 28, 0x81e4, 0x50f7, 0x5c08
+ax_pose 29, 0x81f4, 0x10ef, 0x5c0c
+ax_pose 30, 0x01dc, 0x10fb, 0x5c0e
+ax_pose_terminator
+sSwampertPose175:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose176:
+ax_pose 27, 0x81e4, 0x80f1, 0x5c00
+ax_pose 28, 0x81e4, 0x4101, 0x5c08
+ax_pose 29, 0x81f4, 0x0109, 0x5c0c
+ax_pose 30, 0x01dc, 0x00fd, 0x5c0e
+ax_pose_terminator
+sSwampertPose177:
+ax_pose 22, 0x81e4, 0x80f1, 0x5c00
+ax_pose 23, 0x81e4, 0x4101, 0x5c08
+ax_pose 24, 0x01ec, 0x0109, 0x5c0c
+ax_pose 25, 0x81f4, 0x0109, 0x5c0d
+ax_pose 26, 0x01dc, 0x00f9, 0x5c0f
+ax_pose_terminator
+sSwampertPose178:
+ax_pose 21, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose179:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose180:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose181:
+ax_pose 20, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose182:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose183:
+ax_pose 16, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sSwampertPose184:
+ax_pose 21, 0x01e3, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose185:
+ax_pose 6, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sSwampertPose186:
+ax_pose 17, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose187:
+ax_pose 22, 0x81e3, 0x90ff, 0x5c00
+ax_pose 23, 0x81e3, 0x50f7, 0x5c08
+ax_pose 24, 0x01eb, 0x10ef, 0x5c0c
+ax_pose 25, 0x81f3, 0x10ef, 0x5c0d
+ax_pose 26, 0x01db, 0x10ff, 0x5c0f
+ax_pose_terminator
+sSwampertPose188:
+ax_pose 9, 0x01e5, 0x90ef, 0x5c00
+ax_pose_terminator
+sSwampertPose189:
+ax_pose 18, 0x01e7, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose190:
+ax_pose 27, 0x81e4, 0x90ff, 0x5c00
+ax_pose 28, 0x81e4, 0x50f7, 0x5c08
+ax_pose 29, 0x81f4, 0x10ef, 0x5c0c
+ax_pose 30, 0x01dc, 0x10fb, 0x5c0e
+ax_pose_terminator
+sSwampertPose191:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose192:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose193:
+ax_pose 31, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose194:
+ax_pose 9, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sSwampertPose195:
+ax_pose 18, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose196:
+ax_pose 27, 0x81e4, 0x80f1, 0x5c00
+ax_pose 28, 0x81e4, 0x4101, 0x5c08
+ax_pose 29, 0x81f4, 0x0109, 0x5c0c
+ax_pose 30, 0x01dc, 0x00fd, 0x5c0e
+ax_pose_terminator
+sSwampertPose197:
+ax_pose 6, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose198:
+ax_pose 17, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose199:
+ax_pose 22, 0x81e3, 0x80f1, 0x5c00
+ax_pose 23, 0x81e3, 0x4101, 0x5c08
+ax_pose 24, 0x01eb, 0x0109, 0x5c0c
+ax_pose 25, 0x81f3, 0x0109, 0x5c0d
+ax_pose 26, 0x01db, 0x00f9, 0x5c0f
+ax_pose_terminator
+sSwampertPose200:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose201:
+ax_pose 16, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sSwampertPose202:
+ax_pose 21, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose203:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose204:
+ax_pose 16, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sSwampertPose205:
+ax_pose 17, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose206:
+ax_pose 18, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sSwampertPose207:
+ax_pose 19, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose208:
+ax_pose 18, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sSwampertPose209:
+ax_pose 17, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sSwampertPose210:
+ax_pose 16, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sSwampertPose211:
+ax_pose 0, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose212:
+ax_pose 3, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose213:
+ax_pose 6, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose214:
+ax_pose 9, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose215:
+ax_pose 12, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sSwampertPose216:
+ax_pose 9, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose217:
+ax_pose 6, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+sSwampertPose218:
+ax_pose 3, 0x01e4, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sSwampertAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 1, 0, 1,
+ax_anim 2, 0, 26, -1, 1, -1, 1,
+ax_anim 2, 0, 26, 0, 1, 0, 1,
+ax_anim 2, 0, 26, -1, 1, -1, 1,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSwampertAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 2, -2, 2, -2,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 2, -2, 2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 16, 18, 16, 18,
+ax_anim 2, 1, 28, 17, 17, 17, 17,
+ax_anim 2, 0, 28, 16, 18, 16, 18,
+ax_anim 2, 0, 28, 17, 17, 17, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sSwampertAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim 2, 0, 32, 3, -1, 3, -1,
+ax_anim 2, 0, 32, 3, 0, 3, 0,
+ax_anim 2, 0, 32, 3, -1, 3, -1,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 15, 0, 15, 0,
+ax_anim 2, 1, 31, 15, 1, 15, 1,
+ax_anim 2, 0, 31, 15, 0, 15, 0,
+ax_anim 2, 0, 31, 15, 1, 15, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sSwampertAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 2, 0, 35, 3, -1, 3, -1,
+ax_anim 2, 0, 35, 2, -2, 2, -2,
+ax_anim 2, 0, 35, 3, -1, 3, -1,
+ax_anim 2, 0, 35, 2, -2, 2, -2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 34, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 15, -20, 15, -20,
+ax_anim 2, 1, 34, 16, -19, 16, -19,
+ax_anim 2, 0, 34, 15, -20, 15, -20,
+ax_anim 2, 0, 34, 16, -19, 16, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sSwampertAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 38, 0, -2, 0, -2,
+ax_anim 2, 0, 38, -1, -2, -1, -2,
+ax_anim 2, 0, 38, 0, -2, 0, -2,
+ax_anim 2, 0, 38, -1, -2, -1, -2,
+ax_anim 1, 0, 37, 0, -4, 0, -4,
+ax_anim 1, 2, 37, 0, -8, 0, -8,
+ax_anim 1, 0, 37, 0, -13, 0, -13,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 1, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 37, 0, -17, 0, -17,
+ax_anim 2, 0, 37, 1, -17, 1, -17,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sSwampertAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 2, 0, 41, -4, -1, -4, -1,
+ax_anim 2, 0, 41, -3, -2, -3, -2,
+ax_anim 2, 0, 41, -4, -1, -4, -1,
+ax_anim 2, 0, 41, -3, -2, -3, -2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 40, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -15, -20, -15, -20,
+ax_anim 2, 1, 40, -16, -19, -16, -19,
+ax_anim 2, 0, 40, -15, -20, -15, -20,
+ax_anim 2, 0, 40, -16, -19, -16, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sSwampertAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 2, 0, 44, -3, 0, -3, 0,
+ax_anim 2, 0, 44, -3, -1, -3, -1,
+ax_anim 2, 0, 44, -3, 0, -3, 0,
+ax_anim 2, 0, 44, -3, -1, -3, -1,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -15, 0, -15, 0,
+ax_anim 2, 1, 43, -15, 1, -15, 1,
+ax_anim 2, 0, 43, -15, 0, -15, 0,
+ax_anim 2, 0, 43, -15, 1, -15, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sSwampertAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 2, 0, 47, 0, -1, 0, -1,
+ax_anim 2, 0, 47, -1, -2, -1, -2,
+ax_anim 2, 0, 47, 0, -1, 0, -1,
+ax_anim 2, 0, 47, -1, -2, -1, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -16, 18, -16, 18,
+ax_anim 2, 1, 46, -17, 17, -17, 17,
+ax_anim 2, 0, 46, -16, 18, -16, 18,
+ax_anim 2, 0, 46, -17, 17, -17, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSwampertAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, 1, 0, 1,
+ax_anim 2, 0, 50, -1, 1, -1, 1,
+ax_anim 2, 0, 50, 0, 1, 0, 1,
+ax_anim 2, 0, 50, -1, 1, -1, 1,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sSwampertAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 16, 18, 16, 18,
+ax_anim 2, 1, 52, 17, 17, 17, 17,
+ax_anim 2, 0, 52, 16, 18, 16, 18,
+ax_anim 2, 0, 52, 17, 17, 17, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sSwampertAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim 2, 0, 56, 3, -1, 3, -1,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim 2, 0, 56, 3, -1, 3, -1,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 15, 0, 15, 0,
+ax_anim 2, 1, 55, 15, 1, 15, 1,
+ax_anim 2, 0, 55, 15, 0, 15, 0,
+ax_anim 2, 0, 55, 15, 1, 15, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sSwampertAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 2, 0, 59, 3, -1, 3, -1,
+ax_anim 2, 0, 59, 2, -2, 2, -2,
+ax_anim 2, 0, 59, 3, -1, 3, -1,
+ax_anim 2, 0, 59, 2, -2, 2, -2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 58, 10, -13, 10, -13,
+ax_anim 2, 0, 58, 15, -20, 15, -20,
+ax_anim 2, 1, 58, 16, -19, 16, -19,
+ax_anim 2, 0, 58, 15, -20, 15, -20,
+ax_anim 2, 0, 58, 16, -19, 16, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sSwampertAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 62, 0, -2, 0, -2,
+ax_anim 2, 0, 62, -1, -2, -1, -2,
+ax_anim 2, 0, 62, 0, -2, 0, -2,
+ax_anim 2, 0, 62, -1, -2, -1, -2,
+ax_anim 1, 0, 61, 0, -4, 0, -4,
+ax_anim 1, 2, 61, 0, -8, 0, -8,
+ax_anim 1, 0, 61, 0, -13, 0, -13,
+ax_anim 2, 0, 61, 0, -17, 0, -17,
+ax_anim 2, 1, 61, 1, -17, 1, -17,
+ax_anim 2, 0, 61, 0, -17, 0, -17,
+ax_anim 2, 0, 61, 1, -17, 1, -17,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sSwampertAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 2, 0, 65, -4, -1, -4, -1,
+ax_anim 2, 0, 65, -3, -2, -3, -2,
+ax_anim 2, 0, 65, -4, -1, -4, -1,
+ax_anim 2, 0, 65, -3, -2, -3, -2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 64, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -15, -20, -15, -20,
+ax_anim 2, 1, 64, -16, -19, -16, -19,
+ax_anim 2, 0, 64, -15, -20, -15, -20,
+ax_anim 2, 0, 64, -16, -19, -16, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sSwampertAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 2, 0, 68, -3, 0, -3, 0,
+ax_anim 2, 0, 68, -3, -1, -3, -1,
+ax_anim 2, 0, 68, -3, 0, -3, 0,
+ax_anim 2, 0, 68, -3, -1, -3, -1,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -15, 0, -15, 0,
+ax_anim 2, 1, 67, -15, 1, -15, 1,
+ax_anim 2, 0, 67, -15, 0, -15, 0,
+ax_anim 2, 0, 67, -15, 1, -15, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sSwampertAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 2, 0, 71, 0, -1, 0, -1,
+ax_anim 2, 0, 71, -1, -2, -1, -2,
+ax_anim 2, 0, 71, 0, -1, 0, -1,
+ax_anim 2, 0, 71, -1, -2, -1, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -16, 18, -16, 18,
+ax_anim 2, 1, 70, -17, 17, -17, 17,
+ax_anim 2, 0, 70, -16, 18, -16, 18,
+ax_anim 2, 0, 70, -17, 17, -17, 17,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSwampertAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 0, 72, 0, -3, 0, -3,
+ax_anim 4, 2, 72, 0, -4, 0, -4,
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 1, 75, -1, 3, -1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, -1, 3, -1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, -1, 3, -1, 3,
+ax_anim 2, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sSwampertAnims_4_2:
+ax_anim 2, 0, 76, -1, -1, -1, -1,
+ax_anim 2, 0, 76, -3, -3, -3, -3,
+ax_anim 4, 2, 76, -4, -4, -4, -4,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 1, 79, 2, 4, 2, 4,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 2, 4, 2, 4,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 2, 4, 2, 4,
+ax_anim 2, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim_terminator
+sSwampertAnims_4_3:
+ax_anim 2, 0, 80, -1, 0, -1, 0,
+ax_anim 2, 0, 80, -3, 0, -3, 0,
+ax_anim 4, 2, 80, -4, 0, -4, 0,
+ax_anim 2, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 1, 83, 5, -1, 5, -1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, -1, 5, -1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, -1, 5, -1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim_terminator
+sSwampertAnims_4_4:
+ax_anim 2, 0, 84, -1, 1, -1, 1,
+ax_anim 2, 0, 84, -3, 3, -3, 3,
+ax_anim 4, 2, 84, -4, 4, -3, 3,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 1, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 87, 3, -5, 3, -5,
+ax_anim 2, 0, 87, 4, -4, 4, -4,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim_terminator
+sSwampertAnims_4_5:
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim 4, 2, 88, 0, 4, 0, 4,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 1, 91, -1, -3, -1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, -1, -3, -1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, -1, -3, -1, -3,
+ax_anim 2, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sSwampertAnims_4_6:
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim 4, 2, 92, 4, 4, 3, 3,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 1, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 95, -3, -5, -3, -5,
+ax_anim 2, 0, 95, -4, -4, -4, -4,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim_terminator
+sSwampertAnims_4_7:
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 4, 2, 96, 4, 0, 4, 0,
+ax_anim 2, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 1, 99, -5, -1, -5, -1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, -1, -5, -1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, -1, -5, -1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sSwampertAnims_4_8:
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 4, 2, 100, 4, -4, 4, -4,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 1, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -2, 4, -2, 4,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSwampertAnims_5_1:
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 0, -1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 0, -1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 107, -1, 0, -1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_5_2:
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_5_3:
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim 2, 2, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, -1, -3, -1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 115, -3, -1, -3, -1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 1, 115, -3, -1, -3, -1,
+ax_anim 2, 0, 115, -3, 0, -3, 0,
+ax_anim 2, 0, 112, -3, 0, -3, 0,
+ax_anim_terminator
+sSwampertAnims_5_4:
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 116, -4, 2, -4, 2,
+ax_anim 2, 2, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -5, 1, -5, 1,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 119, -5, 1, -5, 1,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 1, 119, -5, 1, -5, 1,
+ax_anim 2, 0, 119, -4, 2, -4, 2,
+ax_anim 2, 0, 116, -4, 2, -4, 2,
+ax_anim_terminator
+sSwampertAnims_5_5:
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim 2, 2, 123, 0, 1, 0, 1,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim 2, 0, 123, 0, 1, 0, 1,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim 2, 0, 123, 0, 1, 0, 1,
+ax_anim 2, 1, 123, -1, 1, -1, 1,
+ax_anim 2, 0, 123, 0, 1, 0, 1,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sSwampertAnims_5_6:
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 4, 2, 4, 2,
+ax_anim 2, 2, 127, 4, 2, 4, 2,
+ax_anim 2, 0, 127, 5, 1, 5, 1,
+ax_anim 2, 0, 127, 4, 2, 4, 2,
+ax_anim 2, 0, 127, 5, 1, 5, 1,
+ax_anim 2, 0, 127, 4, 2, 4, 2,
+ax_anim 2, 1, 127, 5, 1, 5, 1,
+ax_anim 2, 0, 127, 4, 2, 4, 2,
+ax_anim 2, 0, 124, 4, 2, 4, 2,
+ax_anim_terminator
+sSwampertAnims_5_7:
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 2, 2, 131, 3, 0, 3, 0,
+ax_anim 2, 0, 131, 3, -1, 3, -1,
+ax_anim 2, 0, 131, 3, 0, 3, 0,
+ax_anim 2, 0, 131, 3, -1, 3, -1,
+ax_anim 2, 0, 131, 3, 0, 3, 0,
+ax_anim 2, 1, 131, 3, -1, 3, -1,
+ax_anim 2, 0, 131, 3, 0, 3, 0,
+ax_anim 2, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sSwampertAnims_5_8:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 1, 135, 1, 1, 1, 1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sSwampertAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sSwampertAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sSwampertAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sSwampertAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sSwampertAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sSwampertAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sSwampertAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSwampertAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -1, 0, 0,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 4, 0, 147, 0, -4, 0, 0,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_8_2:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -1, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_8_3:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -1, 0, 0,
+ax_anim 2, 0, 151, 0, -3, 0, 0,
+ax_anim 4, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 151, 0, -3, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_8_4:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -1, 0, 0,
+ax_anim 2, 0, 153, 0, -3, 0, 0,
+ax_anim 4, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -3, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_8_5:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -1, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 4, 0, 155, 0, -4, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_8_6:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -1, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 157, 0, -4, 0, 0,
+ax_anim 2, 0, 157, 0, -3, 0, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_8_7:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -1, 0, 0,
+ax_anim 2, 0, 159, 0, -3, 0, 0,
+ax_anim 4, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -3, 0, 0,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_8_8:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -1, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 4, 0, 161, 0, -4, 0, 0,
+ax_anim 2, 0, 161, 0, -3, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 15, 7, 15,
+ax_anim 3, 0, 166, 0, 18, 0, 18,
+ax_anim 2, 3, 167, -7, 15, -7, 15,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 19, 10, 19, 10,
+ax_anim 3, 0, 165, 20, 19, 20, 19,
+ax_anim 2, 3, 166, 12, 19, 12, 19,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 18, -2, 18, -2,
+ax_anim 2, 3, 165, 16, 4, 16, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -20, 12, -20,
+ax_anim 3, 0, 163, 19, -18, 19, -18,
+ax_anim 2, 3, 164, 20, -13, 20, -13,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -10, -9, -10,
+ax_anim 2, 0, 169, -7, -16, -7, -16,
+ax_anim 3, 0, 162, 0, -19, 0, -19,
+ax_anim 2, 3, 163, 7, -16, 7, -16,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -20, -12, -20,
+ax_anim 3, 0, 169, -19, -18, -19, -18,
+ax_anim 2, 3, 168, -20, -13, -20, -13,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -18, -2, -18, -2,
+ax_anim 2, 3, 167, -16, 4, -16, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -19, 10, -19, 10,
+ax_anim 3, 0, 167, -20, 19, -20, 19,
+ax_anim 2, 3, 166, -12, 19, -12, 19,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 179, 0, -22, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -17, 0, 0,
+ax_anim 1, 0, 188, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -23, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -17, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 197, 0, -22, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwampertAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSwampertGfx1:
+.incbin "baserom.gba", 0x10B1C88, 0x200
+sSwampertSprites1:
+ax_sprite sSwampertGfx1, 0x200
+ax_sprite_terminator
+sSwampertGfx2:
+.incbin "baserom.gba", 0x10B1E98, 0x200
+sSwampertSprites2:
+ax_sprite sSwampertGfx2, 0x200
+ax_sprite_terminator
+sSwampertGfx3:
+.incbin "baserom.gba", 0x10B20A8, 0x200
+sSwampertSprites3:
+ax_sprite sSwampertGfx3, 0x200
+ax_sprite_terminator
+sSwampertGfx4:
+.incbin "baserom.gba", 0x10B22B8, 0x200
+sSwampertSprites4:
+ax_sprite sSwampertGfx4, 0x200
+ax_sprite_terminator
+sSwampertGfx5:
+.incbin "baserom.gba", 0x10B24C8, 0x200
+sSwampertSprites5:
+ax_sprite sSwampertGfx5, 0x200
+ax_sprite_terminator
+sSwampertGfx6:
+.incbin "baserom.gba", 0x10B26D8, 0x200
+sSwampertSprites6:
+ax_sprite sSwampertGfx6, 0x200
+ax_sprite_terminator
+sSwampertGfx7:
+.incbin "baserom.gba", 0x10B28E8, 0x200
+sSwampertSprites7:
+ax_sprite sSwampertGfx7, 0x200
+ax_sprite_terminator
+sSwampertGfx8:
+.incbin "baserom.gba", 0x10B2AF8, 0x200
+sSwampertSprites8:
+ax_sprite sSwampertGfx8, 0x200
+ax_sprite_terminator
+sSwampertGfx9:
+.incbin "baserom.gba", 0x10B2D08, 0x200
+sSwampertSprites9:
+ax_sprite sSwampertGfx9, 0x200
+ax_sprite_terminator
+sSwampertGfx10:
+.incbin "baserom.gba", 0x10B2F18, 0x200
+sSwampertSprites10:
+ax_sprite sSwampertGfx10, 0x200
+ax_sprite_terminator
+sSwampertGfx11:
+.incbin "baserom.gba", 0x10B3128, 0x200
+sSwampertSprites11:
+ax_sprite sSwampertGfx11, 0x200
+ax_sprite_terminator
+sSwampertGfx12:
+.incbin "baserom.gba", 0x10B3338, 0x200
+sSwampertSprites12:
+ax_sprite sSwampertGfx12, 0x200
+ax_sprite_terminator
+sSwampertGfx13:
+.incbin "baserom.gba", 0x10B3548, 0x200
+sSwampertSprites13:
+ax_sprite sSwampertGfx13, 0x200
+ax_sprite_terminator
+sSwampertGfx14:
+.incbin "baserom.gba", 0x10B3758, 0x200
+sSwampertSprites14:
+ax_sprite sSwampertGfx14, 0x200
+ax_sprite_terminator
+sSwampertGfx15:
+.incbin "baserom.gba", 0x10B3968, 0x200
+sSwampertSprites15:
+ax_sprite sSwampertGfx15, 0x200
+ax_sprite_terminator
+sSwampertGfx16:
+.incbin "baserom.gba", 0x10B3B78, 0x40
+sSwampertGfx16_1:
+.incbin "baserom.gba", 0x10B3BB8, 0x40
+sSwampertGfx16_2:
+.incbin "baserom.gba", 0x10B3BF8, 0x100
+sSwampertSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSwampertGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx16_2, 0x100
+ax_sprite_terminator
+sSwampertGfx17:
+.incbin "baserom.gba", 0x10B3D30, 0x1C0
+sSwampertSprites17:
+ax_sprite 0, 0x40
+ax_sprite sSwampertGfx17, 0x1c0
+ax_sprite_terminator
+sSwampertGfx18:
+.incbin "baserom.gba", 0x10B3F08, 0x20
+sSwampertGfx18_1:
+.incbin "baserom.gba", 0x10B3F28, 0x180
+sSwampertSprites18:
+ax_sprite 0, 0x40
+ax_sprite sSwampertGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx18_1, 0x180
+ax_sprite_terminator
+sSwampertGfx19:
+.incbin "baserom.gba", 0x10B40D0, 0x60
+sSwampertGfx19_1:
+.incbin "baserom.gba", 0x10B4130, 0x180
+sSwampertSprites19:
+ax_sprite sSwampertGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx19_1, 0x180
+ax_sprite_terminator
+sSwampertGfx20:
+.incbin "baserom.gba", 0x10B42D0, 0x40
+sSwampertGfx20_1:
+.incbin "baserom.gba", 0x10B4310, 0x180
+sSwampertSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx20_1, 0x180
+ax_sprite_terminator
+sSwampertGfx21:
+.incbin "baserom.gba", 0x10B44B8, 0x40
+sSwampertGfx21_1:
+.incbin "baserom.gba", 0x10B44F8, 0x180
+sSwampertSprites21:
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx21_1, 0x180
+ax_sprite_terminator
+sSwampertGfx22:
+.incbin "baserom.gba", 0x10B46A0, 0x60
+sSwampertGfx22_1:
+.incbin "baserom.gba", 0x10B4700, 0x180
+sSwampertSprites22:
+ax_sprite sSwampertGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx22_1, 0x180
+ax_sprite_terminator
+sSwampertGfx23:
+.incbin "baserom.gba", 0x10B48A0, 0xC0
+sSwampertGfx23_1:
+.incbin "baserom.gba", 0x10B4960, 0x20
+sSwampertSprites23:
+ax_sprite sSwampertGfx23, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx23_1, 0x20
+ax_sprite_terminator
+sSwampertGfx24:
+.incbin "baserom.gba", 0x10B49A0, 0x80
+sSwampertSprites24:
+ax_sprite sSwampertGfx24, 0x80
+ax_sprite_terminator
+sSwampertGfx25:
+.incbin "baserom.gba", 0x10B4A30, 0x20
+sSwampertSprites25:
+ax_sprite sSwampertGfx25, 0x20
+ax_sprite_terminator
+sSwampertGfx26:
+.incbin "baserom.gba", 0x10B4A60, 0x40
+sSwampertSprites26:
+ax_sprite sSwampertGfx26, 0x40
+ax_sprite_terminator
+sSwampertGfx27:
+.incbin "baserom.gba", 0x10B4AB0, 0x20
+sSwampertSprites27:
+ax_sprite sSwampertGfx27, 0x20
+ax_sprite_terminator
+sSwampertGfx28:
+.incbin "baserom.gba", 0x10B4AE0, 0xC0
+sSwampertGfx28_1:
+.incbin "baserom.gba", 0x10B4BA0, 0x20
+sSwampertSprites28:
+ax_sprite sSwampertGfx28, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sSwampertGfx28_1, 0x20
+ax_sprite_terminator
+sSwampertGfx29:
+.incbin "baserom.gba", 0x10B4BE0, 0x80
+sSwampertSprites29:
+ax_sprite sSwampertGfx29, 0x80
+ax_sprite_terminator
+sSwampertGfx30:
+.incbin "baserom.gba", 0x10B4C70, 0x40
+sSwampertSprites30:
+ax_sprite sSwampertGfx30, 0x40
+ax_sprite_terminator
+sSwampertGfx31:
+.incbin "baserom.gba", 0x10B4CC0, 0x20
+sSwampertSprites31:
+ax_sprite sSwampertGfx31, 0x20
+ax_sprite_terminator
+sSwampertGfx32:
+.incbin "baserom.gba", 0x10B4CF0, 0x200
+sSwampertSprites32:
+ax_sprite sSwampertGfx32, 0x200
+ax_sprite_terminator
+sSwampertGfx33:
+.incbin "baserom.gba", 0x10B4F00, 0x200
+sSwampertSprites33:
+ax_sprite sSwampertGfx33, 0x200
+ax_sprite_terminator
+sSwampertGfx34:
+.incbin "baserom.gba", 0x10B5110, 0x200
+sSwampertSprites34:
+ax_sprite sSwampertGfx34, 0x200
+ax_sprite_terminator
+sSwampertGfx35:
+.incbin "baserom.gba", 0x10B5320, 0x200
+sSwampertSprites35:
+ax_sprite sSwampertGfx35, 0x200
+ax_sprite_terminator
+sSwampertGfx36:
+.incbin "baserom.gba", 0x10B5530, 0x200
+sSwampertSprites36:
+ax_sprite sSwampertGfx36, 0x200
+ax_sprite_terminator
+sSwampertGfx37:
+.incbin "baserom.gba", 0x10B5740, 0x200
+sSwampertSprites37:
+ax_sprite sSwampertGfx37, 0x200
+ax_sprite_terminator
+sSwampertGfx38:
+.incbin "baserom.gba", 0x10B5950, 0x200
+sSwampertSprites38:
+ax_sprite sSwampertGfx38, 0x200
+ax_sprite_terminator
+sSwampertGfx39:
+.incbin "baserom.gba", 0x10B5B60, 0x200
+sSwampertSprites39:
+ax_sprite sSwampertGfx39, 0x200
+ax_sprite_terminator
+sAxPosesSwampert:
+.4byte sSwampertPose1
+.4byte sSwampertPose2
+.4byte sSwampertPose3
+.4byte sSwampertPose4
+.4byte sSwampertPose5
+.4byte sSwampertPose6
+.4byte sSwampertPose7
+.4byte sSwampertPose8
+.4byte sSwampertPose9
+.4byte sSwampertPose10
+.4byte sSwampertPose11
+.4byte sSwampertPose12
+.4byte sSwampertPose13
+.4byte sSwampertPose14
+.4byte sSwampertPose15
+.4byte sSwampertPose16
+.4byte sSwampertPose17
+.4byte sSwampertPose18
+.4byte sSwampertPose19
+.4byte sSwampertPose20
+.4byte sSwampertPose21
+.4byte sSwampertPose22
+.4byte sSwampertPose23
+.4byte sSwampertPose24
+.4byte sSwampertPose25
+.4byte sSwampertPose26
+.4byte sSwampertPose27
+.4byte sSwampertPose28
+.4byte sSwampertPose29
+.4byte sSwampertPose30
+.4byte sSwampertPose31
+.4byte sSwampertPose32
+.4byte sSwampertPose33
+.4byte sSwampertPose34
+.4byte sSwampertPose35
+.4byte sSwampertPose36
+.4byte sSwampertPose37
+.4byte sSwampertPose38
+.4byte sSwampertPose39
+.4byte sSwampertPose40
+.4byte sSwampertPose41
+.4byte sSwampertPose42
+.4byte sSwampertPose43
+.4byte sSwampertPose44
+.4byte sSwampertPose45
+.4byte sSwampertPose46
+.4byte sSwampertPose47
+.4byte sSwampertPose48
+.4byte sSwampertPose49
+.4byte sSwampertPose50
+.4byte sSwampertPose51
+.4byte sSwampertPose52
+.4byte sSwampertPose53
+.4byte sSwampertPose54
+.4byte sSwampertPose55
+.4byte sSwampertPose56
+.4byte sSwampertPose57
+.4byte sSwampertPose58
+.4byte sSwampertPose59
+.4byte sSwampertPose60
+.4byte sSwampertPose61
+.4byte sSwampertPose62
+.4byte sSwampertPose63
+.4byte sSwampertPose64
+.4byte sSwampertPose65
+.4byte sSwampertPose66
+.4byte sSwampertPose67
+.4byte sSwampertPose68
+.4byte sSwampertPose69
+.4byte sSwampertPose70
+.4byte sSwampertPose71
+.4byte sSwampertPose72
+.4byte sSwampertPose73
+.4byte sSwampertPose74
+.4byte sSwampertPose75
+.4byte sSwampertPose76
+.4byte sSwampertPose77
+.4byte sSwampertPose78
+.4byte sSwampertPose79
+.4byte sSwampertPose80
+.4byte sSwampertPose81
+.4byte sSwampertPose82
+.4byte sSwampertPose83
+.4byte sSwampertPose84
+.4byte sSwampertPose85
+.4byte sSwampertPose86
+.4byte sSwampertPose87
+.4byte sSwampertPose88
+.4byte sSwampertPose89
+.4byte sSwampertPose90
+.4byte sSwampertPose91
+.4byte sSwampertPose92
+.4byte sSwampertPose93
+.4byte sSwampertPose94
+.4byte sSwampertPose95
+.4byte sSwampertPose96
+.4byte sSwampertPose97
+.4byte sSwampertPose98
+.4byte sSwampertPose99
+.4byte sSwampertPose100
+.4byte sSwampertPose101
+.4byte sSwampertPose102
+.4byte sSwampertPose103
+.4byte sSwampertPose104
+.4byte sSwampertPose105
+.4byte sSwampertPose106
+.4byte sSwampertPose107
+.4byte sSwampertPose108
+.4byte sSwampertPose109
+.4byte sSwampertPose110
+.4byte sSwampertPose111
+.4byte sSwampertPose112
+.4byte sSwampertPose113
+.4byte sSwampertPose114
+.4byte sSwampertPose115
+.4byte sSwampertPose116
+.4byte sSwampertPose117
+.4byte sSwampertPose118
+.4byte sSwampertPose119
+.4byte sSwampertPose120
+.4byte sSwampertPose121
+.4byte sSwampertPose122
+.4byte sSwampertPose123
+.4byte sSwampertPose124
+.4byte sSwampertPose125
+.4byte sSwampertPose126
+.4byte sSwampertPose127
+.4byte sSwampertPose128
+.4byte sSwampertPose129
+.4byte sSwampertPose130
+.4byte sSwampertPose131
+.4byte sSwampertPose132
+.4byte sSwampertPose133
+.4byte sSwampertPose134
+.4byte sSwampertPose135
+.4byte sSwampertPose136
+.4byte sSwampertPose137
+.4byte sSwampertPose138
+.4byte sSwampertPose139
+.4byte sSwampertPose140
+.4byte sSwampertPose141
+.4byte sSwampertPose142
+.4byte sSwampertPose143
+.4byte sSwampertPose144
+.4byte sSwampertPose145
+.4byte sSwampertPose146
+.4byte sSwampertPose147
+.4byte sSwampertPose148
+.4byte sSwampertPose149
+.4byte sSwampertPose150
+.4byte sSwampertPose151
+.4byte sSwampertPose152
+.4byte sSwampertPose153
+.4byte sSwampertPose154
+.4byte sSwampertPose155
+.4byte sSwampertPose156
+.4byte sSwampertPose157
+.4byte sSwampertPose158
+.4byte sSwampertPose159
+.4byte sSwampertPose160
+.4byte sSwampertPose161
+.4byte sSwampertPose162
+.4byte sSwampertPose163
+.4byte sSwampertPose164
+.4byte sSwampertPose165
+.4byte sSwampertPose166
+.4byte sSwampertPose167
+.4byte sSwampertPose168
+.4byte sSwampertPose169
+.4byte sSwampertPose170
+.4byte sSwampertPose171
+.4byte sSwampertPose172
+.4byte sSwampertPose173
+.4byte sSwampertPose174
+.4byte sSwampertPose175
+.4byte sSwampertPose176
+.4byte sSwampertPose177
+.4byte sSwampertPose178
+.4byte sSwampertPose179
+.4byte sSwampertPose180
+.4byte sSwampertPose181
+.4byte sSwampertPose182
+.4byte sSwampertPose183
+.4byte sSwampertPose184
+.4byte sSwampertPose185
+.4byte sSwampertPose186
+.4byte sSwampertPose187
+.4byte sSwampertPose188
+.4byte sSwampertPose189
+.4byte sSwampertPose190
+.4byte sSwampertPose191
+.4byte sSwampertPose192
+.4byte sSwampertPose193
+.4byte sSwampertPose194
+.4byte sSwampertPose195
+.4byte sSwampertPose196
+.4byte sSwampertPose197
+.4byte sSwampertPose198
+.4byte sSwampertPose199
+.4byte sSwampertPose200
+.4byte sSwampertPose201
+.4byte sSwampertPose202
+.4byte sSwampertPose203
+.4byte sSwampertPose204
+.4byte sSwampertPose205
+.4byte sSwampertPose206
+.4byte sSwampertPose207
+.4byte sSwampertPose208
+.4byte sSwampertPose209
+.4byte sSwampertPose210
+.4byte sSwampertPose211
+.4byte sSwampertPose212
+.4byte sSwampertPose213
+.4byte sSwampertPose214
+.4byte sSwampertPose215
+.4byte sSwampertPose216
+.4byte sSwampertPose217
+.4byte sSwampertPose218
+sAxPositionsSwampert:
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -2,   -7, 	 -10,   -3, 	   5,    0, 	  -2,   -6
+.2byte    0,   -7, 	  -6,    0, 	   9,   -3, 	   1,   -6
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+.2byte    8,   -8, 	  11,   -6, 	   1,    2, 	   2,   -7
+.2byte    6,   -7, 	  10,   -1, 	  -4,   -1, 	   1,   -6
+.2byte   11,  -12, 	   8,   -7, 	   9,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,   -4, 	  11,    1, 	   0,   -6
+.2byte   12,   -9, 	  12,   -3, 	   7,    0, 	   0,   -6
+.2byte    5,  -15, 	  -5,   -9, 	  11,   -6, 	   1,   -9
+.2byte    4,  -12, 	  -4,   -6, 	  11,   -4, 	   0,   -7
+.2byte    6,  -13, 	   5,   -9, 	  10,   -3, 	   2,   -8
+.2byte   -1,  -16, 	   7,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    1,  -14, 	   8,   -7, 	  -8,   -9, 	   1,   -8
+.2byte   -2,  -14, 	   5,  -10, 	 -10,   -7, 	  -2,   -8
+.2byte   -6,  -15, 	   4,   -9, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,  -12, 	   3,   -6, 	 -12,   -4, 	  -1,   -7
+.2byte   -7,  -13, 	  -6,   -9, 	 -11,   -3, 	  -3,   -8
+.2byte  -12,  -12, 	  -9,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte  -13,  -10, 	  -3,   -4, 	 -12,    1, 	  -1,   -6
+.2byte  -13,   -9, 	 -13,   -3, 	  -8,    0, 	  -1,   -6
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte   -9,   -8, 	 -12,   -6, 	  -2,    2, 	  -3,   -7
+.2byte   -7,   -7, 	 -11,   -1, 	   3,   -1, 	  -2,   -6
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -2,   -7, 	 -10,   -3, 	   5,    0, 	  -2,   -6
+.2byte   -1,    0, 	 -10,    2, 	   9,    2, 	  -1,   -6
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+.2byte    8,   -8, 	  11,   -6, 	   1,    2, 	   2,   -7
+.2byte    7,    0, 	  13,   -1, 	   1,    4, 	  -3,   -5
+.2byte   11,  -12, 	   8,   -7, 	   9,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,   -4, 	  11,    1, 	   0,   -6
+.2byte   11,   -4, 	  11,   -3, 	   9,    0, 	   0,   -5
+.2byte    5,  -15, 	  -5,   -9, 	  11,   -6, 	   1,   -9
+.2byte    4,  -12, 	  -4,   -6, 	  11,   -4, 	   0,   -7
+.2byte    8,  -10, 	   0,  -10, 	  12,   -5, 	   1,   -6
+.2byte   -1,  -16, 	   7,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    1,  -14, 	   8,   -7, 	  -8,   -9, 	   1,   -8
+.2byte   -1,  -12, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte   -6,  -15, 	   4,   -9, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,  -12, 	   3,   -6, 	 -12,   -4, 	  -1,   -7
+.2byte   -8,  -10, 	   0,  -10, 	 -12,   -5, 	  -1,   -6
+.2byte  -12,  -12, 	  -9,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte  -13,  -10, 	  -3,   -4, 	 -12,    1, 	  -1,   -6
+.2byte  -11,   -4, 	 -11,   -3, 	  -9,    0, 	   0,   -5
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte   -9,   -8, 	 -12,   -6, 	  -2,    2, 	  -3,   -7
+.2byte   -8,   -1, 	 -14,   -2, 	  -2,    3, 	   2,   -6
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -2,   -7, 	 -10,   -3, 	   5,    0, 	  -2,   -6
+.2byte   -1,    0, 	 -10,    2, 	   9,    2, 	  -1,   -6
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+.2byte    8,   -8, 	  11,   -6, 	   1,    2, 	   2,   -7
+.2byte    7,    0, 	  13,   -1, 	   1,    4, 	  -3,   -5
+.2byte   11,  -12, 	   8,   -7, 	   9,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,   -4, 	  11,    1, 	   0,   -6
+.2byte   11,   -4, 	  11,   -3, 	   9,    0, 	   0,   -5
+.2byte    5,  -15, 	  -5,   -9, 	  11,   -6, 	   1,   -9
+.2byte    4,  -12, 	  -4,   -6, 	  11,   -4, 	   0,   -7
+.2byte    8,  -10, 	   0,  -10, 	  12,   -5, 	   1,   -6
+.2byte   -1,  -16, 	   7,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    1,  -14, 	   8,   -7, 	  -8,   -9, 	   1,   -8
+.2byte   -1,  -12, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte   -6,  -15, 	   4,   -9, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,  -12, 	   3,   -6, 	 -12,   -4, 	  -1,   -7
+.2byte   -8,  -10, 	   0,  -10, 	 -12,   -5, 	  -1,   -6
+.2byte  -12,  -12, 	  -9,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte  -13,  -10, 	  -3,   -4, 	 -12,    1, 	  -1,   -6
+.2byte  -11,   -4, 	 -11,   -3, 	  -9,    0, 	   0,   -5
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte   -9,   -8, 	 -12,   -6, 	  -2,    2, 	  -3,   -7
+.2byte   -8,   -1, 	 -14,   -2, 	  -2,    3, 	   2,   -6
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -2,   -7, 	 -10,   -3, 	   5,    0, 	  -2,   -6
+.2byte    0,   -7, 	  -6,    0, 	   9,   -3, 	   1,   -6
+.2byte   -1,    0, 	 -10,    2, 	   9,    2, 	  -1,   -6
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+.2byte    8,   -8, 	  11,   -6, 	   1,    2, 	   2,   -7
+.2byte    6,   -7, 	  10,   -1, 	  -4,   -1, 	   1,   -6
+.2byte    7,   -2, 	  13,   -3, 	   1,    2, 	  -3,   -7
+.2byte   11,  -12, 	   8,   -7, 	   9,   -3, 	   1,   -7
+.2byte   12,  -10, 	   2,   -4, 	  11,    1, 	   0,   -6
+.2byte   12,   -9, 	  12,   -3, 	   7,    0, 	   0,   -6
+.2byte   11,   -4, 	  11,   -3, 	   9,    0, 	   0,   -5
+.2byte    5,  -15, 	  -5,   -9, 	  11,   -6, 	   1,   -9
+.2byte    4,  -12, 	  -4,   -6, 	  11,   -4, 	   0,   -7
+.2byte    6,  -13, 	   5,   -9, 	  10,   -3, 	   2,   -8
+.2byte    8,   -9, 	   0,   -9, 	  12,   -4, 	   1,   -5
+.2byte   -1,  -16, 	   7,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    1,  -14, 	   8,   -7, 	  -8,   -9, 	   1,   -8
+.2byte   -2,  -14, 	   5,  -10, 	 -10,   -7, 	  -2,   -8
+.2byte   -1,  -15, 	  10,  -11, 	 -11,  -11, 	   0,  -10
+.2byte   -6,  -15, 	   4,   -9, 	 -12,   -6, 	  -2,   -9
+.2byte   -5,  -12, 	   3,   -6, 	 -12,   -4, 	  -1,   -7
+.2byte   -7,  -13, 	  -6,   -9, 	 -11,   -3, 	  -3,   -8
+.2byte   -9,   -9, 	  -1,   -9, 	 -13,   -4, 	  -2,   -5
+.2byte  -12,  -12, 	  -9,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte  -13,  -10, 	  -3,   -4, 	 -12,    1, 	  -1,   -6
+.2byte  -13,   -9, 	 -13,   -3, 	  -8,    0, 	  -1,   -6
+.2byte  -12,   -4, 	 -12,   -3, 	 -10,    0, 	  -1,   -5
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte   -9,   -8, 	 -12,   -6, 	  -2,    2, 	  -3,   -7
+.2byte   -7,   -7, 	 -11,   -1, 	   3,   -1, 	  -2,   -6
+.2byte   -8,   -2, 	 -14,   -3, 	  -2,    2, 	   2,   -7
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -2,   -7, 	 -10,   -3, 	   5,    0, 	  -2,   -6
+.2byte   -1,    0, 	 -10,    2, 	   9,    2, 	  -1,   -6
+.2byte   -1,  -13, 	 -12,  -12, 	  11,  -12, 	  -1,  -10
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+.2byte    8,   -8, 	  11,   -6, 	   1,    2, 	   2,   -7
+.2byte    9,    0, 	  15,   -1, 	   3,    4, 	  -1,   -5
+.2byte    6,  -14, 	  12,  -16, 	  -2,  -11, 	   0,  -10
+.2byte    9,  -12, 	   6,   -7, 	   7,   -3, 	  -1,   -7
+.2byte   12,  -11, 	   2,   -5, 	  11,    0, 	   0,   -7
+.2byte   12,   -4, 	  12,   -3, 	  10,    0, 	   1,   -5
+.2byte    7,  -17, 	   9,  -20, 	   8,  -12, 	  -1,  -10
+.2byte    4,  -14, 	  -6,   -8, 	  10,   -5, 	   0,   -8
+.2byte    3,  -13, 	  -5,   -7, 	  10,   -5, 	  -1,   -8
+.2byte    7,   -9, 	  -1,   -9, 	  11,   -4, 	   0,   -5
+.2byte    6,  -18, 	  -2,  -18, 	  12,  -13, 	   0,  -12
+.2byte   -1,  -14, 	   7,   -8, 	  -8,   -8, 	   0,   -7
+.2byte    1,  -14, 	   8,   -7, 	  -8,   -9, 	   1,   -8
+.2byte   -1,  -12, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte   -1,  -18, 	  11,  -15, 	 -12,  -15, 	   0,  -11
+.2byte   -5,  -14, 	   5,   -8, 	 -11,   -5, 	  -1,   -8
+.2byte   -4,  -13, 	   4,   -7, 	 -11,   -5, 	   0,   -8
+.2byte   -8,   -9, 	   0,   -9, 	 -12,   -4, 	  -1,   -5
+.2byte   -7,  -18, 	   1,  -18, 	 -13,  -13, 	  -1,  -12
+.2byte  -10,  -12, 	  -7,   -7, 	  -8,   -3, 	   0,   -7
+.2byte  -13,  -11, 	  -3,   -5, 	 -12,    0, 	  -1,   -7
+.2byte  -13,   -4, 	 -13,   -3, 	 -11,    0, 	  -2,   -5
+.2byte   -8,  -17, 	 -10,  -20, 	  -9,  -12, 	   0,  -10
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte   -9,   -8, 	 -12,   -6, 	  -2,    2, 	  -3,   -7
+.2byte  -10,    0, 	 -16,   -1, 	  -4,    4, 	   0,   -5
+.2byte   -7,  -14, 	 -13,  -16, 	   1,  -11, 	  -1,  -10
+.2byte   -8,    0, 	 -11,    0, 	  -3,    3, 	   2,   -5
+.2byte   -8,    1, 	 -11,    0, 	  -3,    3, 	   2,   -5
+.2byte   -1,    1, 	 -12,  -12, 	  10,  -15, 	  -1,   -8
+.2byte    7,    1, 	  10,  -19, 	  -7,  -15, 	  -1,   -8
+.2byte   10,    1, 	   4,  -15, 	   0,   -6, 	  -3,   -5
+.2byte   10,   -9, 	  -4,  -18, 	  10,  -11, 	  -1,   -5
+.2byte   -1,   -9, 	  10,  -11, 	 -11,  -11, 	  -1,   -6
+.2byte   -9,   -9, 	   5,  -18, 	  -9,  -11, 	   2,   -5
+.2byte  -11,    1, 	  -5,  -15, 	  -1,   -6, 	   2,   -5
+.2byte   -8,    1, 	 -11,  -19, 	   6,  -15, 	   0,   -8
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	 -12,  -12, 	  11,  -12, 	  -1,  -10
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+.2byte    6,  -14, 	  12,  -16, 	  -2,  -11, 	   0,  -10
+.2byte    9,  -12, 	   6,   -7, 	   7,   -3, 	  -1,   -7
+.2byte    7,  -17, 	   9,  -20, 	   8,  -12, 	  -1,  -10
+.2byte    4,  -14, 	  -6,   -8, 	  10,   -5, 	   0,   -8
+.2byte    6,  -18, 	  -2,  -18, 	  12,  -13, 	   0,  -12
+.2byte   -1,  -14, 	   7,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -1,  -18, 	  11,  -15, 	 -12,  -15, 	   0,  -11
+.2byte   -5,  -14, 	   5,   -8, 	 -11,   -5, 	  -1,   -8
+.2byte   -7,  -18, 	   1,  -18, 	 -13,  -13, 	  -1,  -12
+.2byte  -10,  -12, 	  -7,   -7, 	  -8,   -3, 	   0,   -7
+.2byte   -8,  -17, 	 -10,  -20, 	  -9,  -12, 	   0,  -10
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte   -7,  -14, 	 -13,  -16, 	   1,  -11, 	  -1,  -10
+.2byte   -1,  -13, 	 -12,  -12, 	  11,  -12, 	  -1,  -10
+.2byte   -6,  -13, 	 -12,  -15, 	   2,  -10, 	   0,   -9
+.2byte   -8,  -16, 	 -10,  -19, 	  -9,  -11, 	   0,   -9
+.2byte   -7,  -18, 	   1,  -18, 	 -13,  -13, 	  -1,  -12
+.2byte   -1,  -18, 	  11,  -15, 	 -12,  -15, 	   0,  -11
+.2byte    6,  -18, 	  -2,  -18, 	  12,  -13, 	   0,  -12
+.2byte    7,  -16, 	   9,  -19, 	   8,  -11, 	  -1,   -9
+.2byte    5,  -13, 	  11,  -15, 	  -3,  -10, 	  -1,   -9
+.2byte   -1,  -13, 	 -12,  -12, 	  11,  -12, 	  -1,  -10
+.2byte    5,  -13, 	  11,  -15, 	  -3,  -10, 	  -1,   -9
+.2byte    7,  -16, 	   9,  -19, 	   8,  -11, 	  -1,   -9
+.2byte    6,  -18, 	  -2,  -18, 	  12,  -13, 	   0,  -12
+.2byte   -1,  -18, 	  11,  -15, 	 -12,  -15, 	   0,  -11
+.2byte   -7,  -18, 	   1,  -18, 	 -13,  -13, 	  -1,  -12
+.2byte   -8,  -16, 	 -10,  -19, 	  -9,  -11, 	   0,   -9
+.2byte   -6,  -13, 	 -12,  -15, 	   2,  -10, 	   0,   -9
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -1,    0, 	 -10,    2, 	   9,    2, 	  -1,   -6
+.2byte   -1,  -13, 	 -12,  -12, 	  11,  -12, 	  -1,  -10
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+.2byte    7,    0, 	  13,   -1, 	   1,    4, 	  -3,   -5
+.2byte    6,  -14, 	  12,  -16, 	  -2,  -11, 	   0,  -10
+.2byte    9,  -12, 	   6,   -7, 	   7,   -3, 	  -1,   -7
+.2byte   11,   -4, 	  11,   -3, 	   9,    0, 	   0,   -5
+.2byte    7,  -17, 	   9,  -20, 	   8,  -12, 	  -1,  -10
+.2byte    4,  -14, 	  -6,   -8, 	  10,   -5, 	   0,   -8
+.2byte    9,   -9, 	   1,   -9, 	  13,   -4, 	   2,   -5
+.2byte    6,  -18, 	  -2,  -18, 	  12,  -13, 	   0,  -12
+.2byte   -1,  -14, 	   7,   -8, 	  -8,   -8, 	   0,   -7
+.2byte   -1,  -12, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte   -1,  -18, 	  11,  -15, 	 -12,  -15, 	   0,  -11
+.2byte   -5,  -14, 	   5,   -8, 	 -11,   -5, 	  -1,   -8
+.2byte  -10,   -9, 	  -2,   -9, 	 -14,   -4, 	  -3,   -5
+.2byte   -7,  -18, 	   1,  -18, 	 -13,  -13, 	  -1,  -12
+.2byte  -10,  -12, 	  -7,   -7, 	  -8,   -3, 	   0,   -7
+.2byte  -12,   -4, 	 -12,   -3, 	 -10,    0, 	  -1,   -5
+.2byte   -8,  -17, 	 -10,  -20, 	  -9,  -12, 	   0,  -10
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte   -8,    0, 	 -14,   -1, 	  -2,    4, 	   2,   -5
+.2byte   -7,  -14, 	 -13,  -16, 	   1,  -11, 	  -1,  -10
+.2byte   -1,    0, 	 -10,    2, 	   9,    2, 	  -1,   -6
+.2byte   -7,    0, 	 -13,   -1, 	  -1,    4, 	   3,   -5
+.2byte  -10,   -4, 	 -10,   -3, 	  -8,    0, 	   1,   -5
+.2byte   -8,   -9, 	   0,   -9, 	 -12,   -4, 	  -1,   -5
+.2byte   -1,  -12, 	  10,   -8, 	 -11,   -8, 	   0,   -7
+.2byte    7,   -9, 	  -1,   -9, 	  11,   -4, 	   0,   -5
+.2byte    9,   -4, 	   9,   -3, 	   7,    0, 	  -2,   -5
+.2byte    6,    0, 	  12,   -1, 	   0,    4, 	  -4,   -5
+.2byte   -1,   -9, 	  -9,   -3, 	   8,   -3, 	  -1,   -8
+.2byte   -8,   -9, 	 -11,   -4, 	  -1,   -1, 	  -3,   -8
+.2byte  -12,  -12, 	  -9,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte   -6,  -15, 	   4,   -9, 	 -12,   -6, 	  -2,   -9
+.2byte   -1,  -16, 	   7,  -10, 	  -8,  -10, 	   0,   -9
+.2byte    5,  -15, 	  -5,   -9, 	  11,   -6, 	   1,   -9
+.2byte   11,  -12, 	   8,   -7, 	   9,   -3, 	   1,   -7
+.2byte    7,   -9, 	  10,   -4, 	   0,   -1, 	   2,   -8
+sSwampertAnimTable1:
+.4byte sSwampertAnims_1_1
+.4byte sSwampertAnims_1_2
+.4byte sSwampertAnims_1_3
+.4byte sSwampertAnims_1_4
+.4byte sSwampertAnims_1_5
+.4byte sSwampertAnims_1_6
+.4byte sSwampertAnims_1_7
+.4byte sSwampertAnims_1_8
+sSwampertAnimTable2:
+.4byte sSwampertAnims_2_1
+.4byte sSwampertAnims_2_2
+.4byte sSwampertAnims_2_3
+.4byte sSwampertAnims_2_4
+.4byte sSwampertAnims_2_5
+.4byte sSwampertAnims_2_6
+.4byte sSwampertAnims_2_7
+.4byte sSwampertAnims_2_8
+sSwampertAnimTable3:
+.4byte sSwampertAnims_3_1
+.4byte sSwampertAnims_3_2
+.4byte sSwampertAnims_3_3
+.4byte sSwampertAnims_3_4
+.4byte sSwampertAnims_3_5
+.4byte sSwampertAnims_3_6
+.4byte sSwampertAnims_3_7
+.4byte sSwampertAnims_3_8
+sSwampertAnimTable4:
+.4byte sSwampertAnims_4_1
+.4byte sSwampertAnims_4_2
+.4byte sSwampertAnims_4_3
+.4byte sSwampertAnims_4_4
+.4byte sSwampertAnims_4_5
+.4byte sSwampertAnims_4_6
+.4byte sSwampertAnims_4_7
+.4byte sSwampertAnims_4_8
+sSwampertAnimTable5:
+.4byte sSwampertAnims_5_1
+.4byte sSwampertAnims_5_2
+.4byte sSwampertAnims_5_3
+.4byte sSwampertAnims_5_4
+.4byte sSwampertAnims_5_5
+.4byte sSwampertAnims_5_6
+.4byte sSwampertAnims_5_7
+.4byte sSwampertAnims_5_8
+sSwampertAnimTable6:
+.4byte sSwampertAnims_6_1
+.4byte sSwampertAnims_6_1
+.4byte sSwampertAnims_6_1
+.4byte sSwampertAnims_6_1
+.4byte sSwampertAnims_6_1
+.4byte sSwampertAnims_6_1
+.4byte sSwampertAnims_6_1
+.4byte sSwampertAnims_6_1
+sSwampertAnimTable7:
+.4byte sSwampertAnims_7_1
+.4byte sSwampertAnims_7_2
+.4byte sSwampertAnims_7_3
+.4byte sSwampertAnims_7_4
+.4byte sSwampertAnims_7_5
+.4byte sSwampertAnims_7_6
+.4byte sSwampertAnims_7_7
+.4byte sSwampertAnims_7_8
+sSwampertAnimTable8:
+.4byte sSwampertAnims_8_1
+.4byte sSwampertAnims_8_2
+.4byte sSwampertAnims_8_3
+.4byte sSwampertAnims_8_4
+.4byte sSwampertAnims_8_5
+.4byte sSwampertAnims_8_6
+.4byte sSwampertAnims_8_7
+.4byte sSwampertAnims_8_8
+sSwampertAnimTable9:
+.4byte sSwampertAnims_9_1
+.4byte sSwampertAnims_9_2
+.4byte sSwampertAnims_9_3
+.4byte sSwampertAnims_9_4
+.4byte sSwampertAnims_9_5
+.4byte sSwampertAnims_9_6
+.4byte sSwampertAnims_9_7
+.4byte sSwampertAnims_9_8
+sSwampertAnimTable10:
+.4byte sSwampertAnims_10_1
+.4byte sSwampertAnims_10_2
+.4byte sSwampertAnims_10_3
+.4byte sSwampertAnims_10_4
+.4byte sSwampertAnims_10_5
+.4byte sSwampertAnims_10_6
+.4byte sSwampertAnims_10_7
+.4byte sSwampertAnims_10_8
+sSwampertAnimTable11:
+.4byte sSwampertAnims_11_1
+.4byte sSwampertAnims_11_2
+.4byte sSwampertAnims_11_3
+.4byte sSwampertAnims_11_4
+.4byte sSwampertAnims_11_5
+.4byte sSwampertAnims_11_6
+.4byte sSwampertAnims_11_7
+.4byte sSwampertAnims_11_8
+sSwampertAnimTable12:
+.4byte sSwampertAnims_12_1
+.4byte sSwampertAnims_12_2
+.4byte sSwampertAnims_12_3
+.4byte sSwampertAnims_12_4
+.4byte sSwampertAnims_12_5
+.4byte sSwampertAnims_12_6
+.4byte sSwampertAnims_12_7
+.4byte sSwampertAnims_12_8
+sSwampertAnimTable13:
+.4byte sSwampertAnims_13_1
+.4byte sSwampertAnims_13_2
+.4byte sSwampertAnims_13_3
+.4byte sSwampertAnims_13_4
+.4byte sSwampertAnims_13_5
+.4byte sSwampertAnims_13_6
+.4byte sSwampertAnims_13_7
+.4byte sSwampertAnims_13_8
+sAxAnimationsSwampert:
+.4byte sSwampertAnimTable1
+.4byte sSwampertAnimTable2
+.4byte sSwampertAnimTable3
+.4byte sSwampertAnimTable4
+.4byte sSwampertAnimTable5
+.4byte sSwampertAnimTable6
+.4byte sSwampertAnimTable7
+.4byte sSwampertAnimTable8
+.4byte sSwampertAnimTable9
+.4byte sSwampertAnimTable10
+.4byte sSwampertAnimTable11
+.4byte sSwampertAnimTable12
+.4byte sSwampertAnimTable13
+sAxSpritesSwampert:
+.4byte sSwampertSprites1
+.4byte sSwampertSprites2
+.4byte sSwampertSprites3
+.4byte sSwampertSprites4
+.4byte sSwampertSprites5
+.4byte sSwampertSprites6
+.4byte sSwampertSprites7
+.4byte sSwampertSprites8
+.4byte sSwampertSprites9
+.4byte sSwampertSprites10
+.4byte sSwampertSprites11
+.4byte sSwampertSprites12
+.4byte sSwampertSprites13
+.4byte sSwampertSprites14
+.4byte sSwampertSprites15
+.4byte sSwampertSprites16
+.4byte sSwampertSprites17
+.4byte sSwampertSprites18
+.4byte sSwampertSprites19
+.4byte sSwampertSprites20
+.4byte sSwampertSprites21
+.4byte sSwampertSprites22
+.4byte sSwampertSprites23
+.4byte sSwampertSprites24
+.4byte sSwampertSprites25
+.4byte sSwampertSprites26
+.4byte sSwampertSprites27
+.4byte sSwampertSprites28
+.4byte sSwampertSprites29
+.4byte sSwampertSprites30
+.4byte sSwampertSprites31
+.4byte sSwampertSprites32
+.4byte sSwampertSprites33
+.4byte sSwampertSprites34
+.4byte sSwampertSprites35
+.4byte sSwampertSprites36
+.4byte sSwampertSprites37
+.4byte sSwampertSprites38
+.4byte sSwampertSprites39
+sAxMainSwampert:
+ax_main sAxPosesSwampert, sAxAnimationsSwampert, 13, sAxSpritesSwampert, sAxPositionsSwampert

--- a/data/ax/swellow.inc
+++ b/data/ax/swellow.inc
@@ -1,0 +1,3357 @@
+.global gAxSwellow
+gAxSwellow:
+ax_siro sAxMainSwellow
+sSwellowPose1:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose4:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose5:
+ax_pose 4, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose6:
+ax_pose 5, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose7:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose8:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose9:
+ax_pose 8, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose10:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose11:
+ax_pose 10, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose12:
+ax_pose 11, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose16:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose17:
+ax_pose 10, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose18:
+ax_pose 11, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose19:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose20:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose21:
+ax_pose 8, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose22:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose23:
+ax_pose 4, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose24:
+ax_pose 5, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose25:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose26:
+ax_pose 15, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose27:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose28:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose29:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose30:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose31:
+ax_pose 19, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose32:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose33:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose34:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose35:
+ax_pose 22, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose36:
+ax_pose 23, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose37:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose38:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose39:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose40:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose42:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose43:
+ax_pose 28, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose44:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose45:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose46:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose47:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose48:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose49:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose50:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose51:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose52:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose53:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose54:
+ax_pose 18, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSwellowPose55:
+ax_pose 19, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose56:
+ax_pose 20, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose57:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose58:
+ax_pose 15, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose59:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose60:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose61:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose62:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose63:
+ax_pose 19, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose64:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose65:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose66:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose67:
+ax_pose 22, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose68:
+ax_pose 23, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose69:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose70:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose71:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose72:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose74:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose75:
+ax_pose 28, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose76:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose77:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose78:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose79:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose80:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose81:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose82:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose83:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose84:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose85:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose86:
+ax_pose 18, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSwellowPose87:
+ax_pose 19, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose88:
+ax_pose 20, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose89:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose90:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose91:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose92:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose93:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose94:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose95:
+ax_pose 4, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose96:
+ax_pose 5, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose97:
+ax_pose 19, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose98:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose99:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose100:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose101:
+ax_pose 8, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose102:
+ax_pose 22, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sSwellowPose103:
+ax_pose 23, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sSwellowPose104:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose105:
+ax_pose 10, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose106:
+ax_pose 11, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose107:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose108:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose109:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose110:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose111:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose112:
+ax_pose 28, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose113:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose114:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose115:
+ax_pose 10, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose116:
+ax_pose 11, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose117:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose118:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose119:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose120:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose121:
+ax_pose 8, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose122:
+ax_pose 22, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose123:
+ax_pose 23, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose124:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose125:
+ax_pose 4, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose126:
+ax_pose 5, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose127:
+ax_pose 19, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose128:
+ax_pose 20, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose129:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose130:
+ax_pose 1, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose131:
+ax_pose 2, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose132:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose133:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose134:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose135:
+ax_pose 4, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose136:
+ax_pose 5, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose137:
+ax_pose 19, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose138:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose139:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose140:
+ax_pose 7, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose141:
+ax_pose 8, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose142:
+ax_pose 22, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sSwellowPose143:
+ax_pose 23, 0x01e7, 0x90f1, 0x2c00
+ax_pose_terminator
+sSwellowPose144:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose145:
+ax_pose 10, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose146:
+ax_pose 11, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose147:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose148:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose149:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose150:
+ax_pose 13, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose151:
+ax_pose 14, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose152:
+ax_pose 28, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose153:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose154:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose155:
+ax_pose 10, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose156:
+ax_pose 11, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose157:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose158:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose159:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose160:
+ax_pose 7, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose161:
+ax_pose 8, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose162:
+ax_pose 22, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose163:
+ax_pose 23, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose164:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose165:
+ax_pose 4, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose166:
+ax_pose 5, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose167:
+ax_pose 19, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose168:
+ax_pose 20, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose169:
+ax_pose 30, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose170:
+ax_pose 31, 0x01ed, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose171:
+ax_pose 32, 0x01e0, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose172:
+ax_pose 33, 0x01e4, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwellowPose173:
+ax_pose 34, 0x01e3, 0x90eb, 0x2c00
+ax_pose_terminator
+sSwellowPose174:
+ax_pose 35, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sSwellowPose175:
+ax_pose 36, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose176:
+ax_pose 35, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sSwellowPose177:
+ax_pose 34, 0x01e3, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwellowPose178:
+ax_pose 33, 0x01e4, 0x80f5, 0x2c00
+ax_pose_terminator
+sSwellowPose179:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose180:
+ax_pose 15, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose181:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose182:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose183:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose184:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose185:
+ax_pose 19, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose186:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose187:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose188:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose189:
+ax_pose 22, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose190:
+ax_pose 23, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose191:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose192:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose193:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose194:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose195:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose196:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose197:
+ax_pose 28, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose198:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose199:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose200:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose201:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose202:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose203:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose204:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose205:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose206:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose207:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose208:
+ax_pose 18, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSwellowPose209:
+ax_pose 19, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose210:
+ax_pose 20, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose211:
+ax_pose 15, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose212:
+ax_pose 18, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSwellowPose213:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose214:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose215:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose216:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose217:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose218:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose219:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose220:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose221:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose222:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose223:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose224:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose225:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose226:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose227:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose228:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose229:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose230:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose231:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose232:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose233:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose234:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose235:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose236:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose237:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose238:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose239:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose240:
+ax_pose 18, 0x01e7, 0x80ee, 0x2c00
+ax_pose_terminator
+sSwellowPose241:
+ax_pose 21, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose242:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose243:
+ax_pose 27, 0x01e7, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose244:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose245:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose246:
+ax_pose 18, 0x01e7, 0x90f2, 0x2c00
+ax_pose_terminator
+sSwellowPose247:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose248:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose249:
+ax_pose 23, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose250:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose251:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose252:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose253:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose254:
+ax_pose 20, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose255:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose256:
+ax_pose 16, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose257:
+ax_pose 17, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose258:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose259:
+ax_pose 19, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose260:
+ax_pose 20, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sSwellowPose261:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose262:
+ax_pose 22, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose263:
+ax_pose 23, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose264:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose265:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose266:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose267:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose268:
+ax_pose 28, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose269:
+ax_pose 29, 0x01e8, 0x80ef, 0x2c00
+ax_pose_terminator
+sSwellowPose270:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose271:
+ax_pose 25, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose272:
+ax_pose 26, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose273:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose274:
+ax_pose 22, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose275:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose276:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose277:
+ax_pose 19, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose278:
+ax_pose 20, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sSwellowPose279:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose280:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose281:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose282:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose283:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose284:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose285:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose286:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose287:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose288:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose289:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose290:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose291:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose292:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose293:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose294:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose295:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose296:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose297:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose298:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose299:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose300:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose301:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose302:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose303:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose304:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose305:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose306:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose307:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose308:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose309:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose310:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose311:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose312:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose313:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose314:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose315:
+ax_pose 0, 0x81ed, 0x80f7, 0x2c00
+ax_pose_terminator
+sSwellowPose316:
+ax_pose 3, 0x01ed, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose317:
+ax_pose 6, 0x01ed, 0x80f0, 0x2c00
+ax_pose_terminator
+sSwellowPose318:
+ax_pose 9, 0x01ec, 0x80f6, 0x2c00
+ax_pose_terminator
+sSwellowPose319:
+ax_pose 12, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sSwellowPose320:
+ax_pose 9, 0x01ec, 0x90ea, 0x2c00
+ax_pose_terminator
+sSwellowPose321:
+ax_pose 6, 0x01ed, 0x90f0, 0x2c00
+ax_pose_terminator
+sSwellowPose322:
+ax_pose 3, 0x01ed, 0x90ea, 0x2c00
+ax_pose_terminator
+.align 2
+sSwellowAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, 0,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 4, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 6, 0, 10,
+ax_anim 2, 0, 27, 0, 1, 0, 5,
+ax_anim_terminator
+sSwellowAnims_2_2:
+ax_anim 2, 0, 30, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 4, 0, 31, 0, -5, 0, 0,
+ax_anim 1, 2, 29, 2, -3, 2, 2,
+ax_anim 1, 0, 29, 10, 8, 10, 10,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 1, 29, 20, 18, 20, 18,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 29, 20, 18, 20, 18,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 29, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 12, 8, 12, 12,
+ax_anim 2, 0, 31, 5, 1, 5, 5,
+ax_anim_terminator
+sSwellowAnims_2_3:
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 4, 0, 35, 0, -5, 0, 0,
+ax_anim 1, 2, 33, 2, -7, 2, 2,
+ax_anim 1, 0, 33, 10, -3, 10, 0,
+ax_anim 2, 0, 33, 17, 1, 17, 0,
+ax_anim 2, 1, 33, 17, 0, 17, -1,
+ax_anim 2, 0, 33, 17, 1, 17, 0,
+ax_anim 2, 0, 33, 17, 0, 17, -1,
+ax_anim 2, 0, 33, 17, 1, 17, 0,
+ax_anim 2, 0, 33, 17, 0, 17, -1,
+ax_anim 2, 0, 35, 12, 0, 12, 0,
+ax_anim 2, 0, 35, 5, -2, 5, 0,
+ax_anim_terminator
+sSwellowAnims_2_4:
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 2, 0, 39, 0, -4, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 4, 0, 39, 0, -5, 0, 0,
+ax_anim 1, 2, 37, 2, -6, 2, -2,
+ax_anim 1, 0, 37, 10, -14, 10, -12,
+ax_anim 2, 0, 37, 18, -22, 18, -22,
+ax_anim 2, 1, 37, 17, -23, 17, -23,
+ax_anim 2, 0, 37, 18, -22, 18, -22,
+ax_anim 2, 0, 37, 17, -23, 17, -23,
+ax_anim 2, 0, 37, 18, -22, 18, -22,
+ax_anim 2, 0, 37, 17, -23, 17, -23,
+ax_anim 2, 0, 39, 11, -15, 11, -14,
+ax_anim 2, 0, 39, 5, -11, 5, -7,
+ax_anim_terminator
+sSwellowAnims_2_5:
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 4, 0, 43, 0, -5, 0, 0,
+ax_anim 1, 2, 41, 0, -8, 0, -2,
+ax_anim 1, 0, 41, 0, -12, 0, -8,
+ax_anim 2, 0, 41, 0, -21, 0, -21,
+ax_anim 2, 1, 41, 1, -21, 1, -21,
+ax_anim 2, 0, 41, 0, -21, 0, -21,
+ax_anim 2, 0, 41, 1, -21, 1, -21,
+ax_anim 2, 0, 41, 0, -21, 0, -21,
+ax_anim 2, 0, 41, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -14, 0, -12,
+ax_anim 2, 0, 43, 0, -9, 0, -5,
+ax_anim_terminator
+sSwellowAnims_2_6:
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 4, 0, 47, 0, -5, 0, 0,
+ax_anim 1, 2, 45, -2, -6, -2, -2,
+ax_anim 1, 0, 45, -10, -14, -10, -12,
+ax_anim 2, 0, 45, -18, -22, -18, -22,
+ax_anim 2, 1, 45, -17, -23, -17, -23,
+ax_anim 2, 0, 45, -18, -22, -18, -22,
+ax_anim 2, 0, 45, -17, -23, -17, -23,
+ax_anim 2, 0, 45, -18, -22, -18, -22,
+ax_anim 2, 0, 45, -17, -23, -17, -23,
+ax_anim 2, 0, 47, -11, -15, -11, -14,
+ax_anim 2, 0, 47, -5, -11, -5, -7,
+ax_anim_terminator
+sSwellowAnims_2_7:
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 49, -2, -7, -2, 2,
+ax_anim 1, 0, 49, -10, -3, -10, 0,
+ax_anim 2, 0, 49, -17, 1, -17, 0,
+ax_anim 2, 1, 49, -17, 0, -17, -1,
+ax_anim 2, 0, 49, -17, 1, -17, 0,
+ax_anim 2, 0, 49, -17, 0, -17, -1,
+ax_anim 2, 0, 49, -17, 1, -17, 0,
+ax_anim 2, 0, 49, -17, 0, -17, -1,
+ax_anim 2, 0, 51, -12, 0, -12, 0,
+ax_anim 2, 0, 51, -5, -2, -5, 0,
+ax_anim_terminator
+sSwellowAnims_2_8:
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 4, 0, 55, 0, -5, 0, 0,
+ax_anim 1, 2, 53, -2, -3, -2, 2,
+ax_anim 1, 0, 53, -10, 8, -10, 10,
+ax_anim 2, 0, 53, -19, 19, -19, 19,
+ax_anim 2, 1, 53, -20, 18, -20, 18,
+ax_anim 2, 0, 53, -19, 19, -19, 19,
+ax_anim 2, 0, 53, -20, 18, -20, 18,
+ax_anim 2, 0, 53, -19, 19, -19, 19,
+ax_anim 2, 0, 53, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -12, 8, -12, 12,
+ax_anim 2, 0, 55, -5, 1, -5, 5,
+ax_anim_terminator
+.align 2
+sSwellowAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 4, 0, 59, 0, -5, 0, 0,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 57, 0, 18, 0, 18,
+ax_anim 2, 0, 57, 0, 35, 0, 35,
+ax_anim 2, 1, 57, 1, 43, 1, 43,
+ax_anim 2, 0, 57, 0, 43, 0, 43,
+ax_anim 2, 0, 57, 1, 43, 1, 43,
+ax_anim 2, 0, 57, 0, 43, 0, 43,
+ax_anim 2, 0, 57, 1, 43, 1, 43,
+ax_anim 2, 0, 59, 0, 6, 0, 10,
+ax_anim 2, 0, 59, 0, 1, 0, 5,
+ax_anim_terminator
+sSwellowAnims_3_2:
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 63, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -5, 0, 0,
+ax_anim 4, 0, 63, 0, -5, 0, 0,
+ax_anim 1, 2, 61, 2, -3, 2, 2,
+ax_anim 1, 0, 61, 18, 16, 18, 18,
+ax_anim 2, 0, 61, 35, 35, 35, 35,
+ax_anim 2, 1, 61, 44, 42, 44, 42,
+ax_anim 2, 0, 61, 43, 43, 43, 43,
+ax_anim 2, 0, 61, 44, 42, 44, 42,
+ax_anim 2, 0, 61, 43, 43, 43, 43,
+ax_anim 2, 0, 61, 44, 42, 44, 42,
+ax_anim 2, 0, 63, 12, 8, 12, 12,
+ax_anim 2, 0, 63, 5, 1, 5, 5,
+ax_anim_terminator
+sSwellowAnims_3_3:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 4, 0, 67, 0, -5, 0, 0,
+ax_anim 1, 2, 65, 2, -7, 2, 2,
+ax_anim 1, 0, 65, 18, -3, 18, 0,
+ax_anim 2, 0, 65, 33, 1, 33, 0,
+ax_anim 2, 1, 65, 41, 0, 41, -1,
+ax_anim 2, 0, 65, 41, 1, 41, 0,
+ax_anim 2, 0, 65, 41, 0, 41, -1,
+ax_anim 2, 0, 65, 41, 1, 41, 0,
+ax_anim 2, 0, 65, 41, 0, 41, -1,
+ax_anim 2, 0, 67, 12, 0, 12, 0,
+ax_anim 2, 0, 67, 5, -2, 5, 0,
+ax_anim_terminator
+sSwellowAnims_3_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 4, 0, 71, 0, -5, 0, 0,
+ax_anim 1, 2, 69, 2, -6, 2, -2,
+ax_anim 1, 0, 69, 18, -22, 18, -20,
+ax_anim 2, 0, 69, 34, -38, 34, -38,
+ax_anim 2, 1, 69, 41, -47, 41, -47,
+ax_anim 2, 0, 69, 42, -46, 42, -46,
+ax_anim 2, 0, 69, 41, -47, 41, -47,
+ax_anim 2, 0, 69, 42, -46, 42, -46,
+ax_anim 2, 0, 69, 41, -47, 41, -47,
+ax_anim 2, 0, 71, 11, -15, 11, -14,
+ax_anim 2, 0, 71, 5, -11, 5, -7,
+ax_anim_terminator
+sSwellowAnims_3_5:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 4, 0, 75, 0, -5, 0, 0,
+ax_anim 1, 2, 73, 0, -8, 0, -2,
+ax_anim 1, 0, 73, 0, -20, 0, -16,
+ax_anim 2, 0, 73, 0, -37, 0, -37,
+ax_anim 2, 1, 73, 1, -45, 1, -45,
+ax_anim 2, 0, 73, 0, -45, 0, -45,
+ax_anim 2, 0, 73, 1, -45, 1, -45,
+ax_anim 2, 0, 73, 0, -45, 0, -45,
+ax_anim 2, 0, 73, 1, -45, 1, -45,
+ax_anim 2, 0, 75, 0, -14, 0, -12,
+ax_anim 2, 0, 75, 0, -9, 0, -5,
+ax_anim_terminator
+sSwellowAnims_3_6:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 4, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 2, 77, -2, -6, -2, -2,
+ax_anim 1, 0, 77, -18, -22, -18, -20,
+ax_anim 2, 0, 77, -34, -38, -34, -38,
+ax_anim 2, 1, 77, -41, -47, -41, -47,
+ax_anim 2, 0, 77, -42, -46, -42, -46,
+ax_anim 2, 0, 77, -41, -47, -41, -47,
+ax_anim 2, 0, 77, -42, -46, -42, -46,
+ax_anim 2, 0, 77, -41, -47, -41, -47,
+ax_anim 2, 0, 79, -11, -15, -11, -14,
+ax_anim 2, 0, 79, -5, -11, -5, -7,
+ax_anim_terminator
+sSwellowAnims_3_7:
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 0, 83, 0, -5, 0, 0,
+ax_anim 1, 2, 81, -2, -7, -2, 2,
+ax_anim 1, 0, 81, -18, -3, -18, 0,
+ax_anim 2, 0, 81, -33, 1, -33, 0,
+ax_anim 2, 1, 81, -41, 0, -41, -1,
+ax_anim 2, 0, 81, -41, 1, -41, 0,
+ax_anim 2, 0, 81, -41, 0, -41, -1,
+ax_anim 2, 0, 81, -41, 1, -41, 0,
+ax_anim 2, 0, 81, -41, 0, -41, -1,
+ax_anim 2, 0, 83, -12, 0, -12, 0,
+ax_anim 2, 0, 83, -5, -2, -5, 0,
+ax_anim_terminator
+sSwellowAnims_3_8:
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 4, 0, 87, 0, -5, 0, 0,
+ax_anim 1, 2, 85, -2, -3, -2, 2,
+ax_anim 1, 0, 85, -18, 16, -18, 18,
+ax_anim 2, 0, 85, -35, 35, -35, 35,
+ax_anim 2, 1, 85, -44, 42, -44, 42,
+ax_anim 2, 0, 85, -43, 43, -43, 43,
+ax_anim 2, 0, 85, -44, 42, -44, 42,
+ax_anim 2, 0, 85, -43, 43, -43, 43,
+ax_anim 2, 0, 85, -44, 42, -44, 42,
+ax_anim 2, 0, 87, -12, 8, -12, 12,
+ax_anim 2, 0, 87, -5, 1, -5, 5,
+ax_anim_terminator
+.align 2
+sSwellowAnims_4_1:
+ax_anim 2, 0, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -6, 0, 0,
+ax_anim 3, 0, 92, 0, -7, 0, 0,
+ax_anim 3, 0, 91, 0, -8, 0, 0,
+ax_anim 3, 2, 92, 0, -8, 0, 0,
+ax_anim 3, 0, 91, 0, -8, 0, 0,
+ax_anim 3, 0, 92, 0, -8, 0, 0,
+ax_anim 3, 1, 91, 0, -8, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_4_2:
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -6, 0, 0,
+ax_anim 3, 0, 97, 0, -7, 0, 0,
+ax_anim 3, 0, 96, 0, -8, 0, 0,
+ax_anim 3, 2, 97, 0, -8, 0, 0,
+ax_anim 3, 0, 96, 0, -8, 0, 0,
+ax_anim 3, 0, 97, 0, -8, 0, 0,
+ax_anim 3, 1, 96, 0, -8, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_4_3:
+ax_anim 2, 0, 99, 0, -1, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 3, 0, 102, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 3, 2, 102, 0, -8, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 3, 0, 102, 0, -8, 0, 0,
+ax_anim 3, 1, 101, 0, -8, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_4_4:
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 106, 0, -8, 0, 0,
+ax_anim 3, 2, 107, 0, -8, 0, 0,
+ax_anim 3, 0, 106, 0, -8, 0, 0,
+ax_anim 3, 0, 107, 0, -8, 0, 0,
+ax_anim 3, 1, 106, 0, -8, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_4_5:
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 112, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 2, 112, 0, -8, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 0, 112, 0, -8, 0, 0,
+ax_anim 3, 1, 111, 0, -8, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_4_6:
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, 0,
+ax_anim 3, 0, 117, 0, -7, 0, 0,
+ax_anim 3, 0, 116, 0, -8, 0, 0,
+ax_anim 3, 2, 117, 0, -8, 0, 0,
+ax_anim 3, 0, 116, 0, -8, 0, 0,
+ax_anim 3, 0, 117, 0, -8, 0, 0,
+ax_anim 3, 1, 116, 0, -8, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_4_7:
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -6, 0, 0,
+ax_anim 3, 0, 122, 0, -7, 0, 0,
+ax_anim 3, 0, 121, 0, -8, 0, 0,
+ax_anim 3, 2, 122, 0, -8, 0, 0,
+ax_anim 3, 0, 121, 0, -8, 0, 0,
+ax_anim 3, 0, 122, 0, -8, 0, 0,
+ax_anim 3, 1, 121, 0, -8, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_4_8:
+ax_anim 2, 0, 124, 0, -1, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, 0,
+ax_anim 3, 0, 127, 0, -7, 0, 0,
+ax_anim 3, 0, 126, 0, -8, 0, 0,
+ax_anim 3, 2, 127, 0, -8, 0, 0,
+ax_anim 3, 0, 126, 0, -8, 0, 0,
+ax_anim 3, 0, 127, 0, -8, 0, 0,
+ax_anim 3, 1, 126, 0, -8, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_5_1:
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 2, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim_terminator
+sSwellowAnims_5_2:
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 2, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim_terminator
+sSwellowAnims_5_3:
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 2, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim_terminator
+sSwellowAnims_5_4:
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 2, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim_terminator
+sSwellowAnims_5_5:
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 2, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim_terminator
+sSwellowAnims_5_6:
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 2, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim_terminator
+sSwellowAnims_5_7:
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 2, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim_terminator
+sSwellowAnims_5_8:
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 2, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_7_1:
+ax_anim 2, 0, 170, 0, -4, 0, -4,
+ax_anim 8, 0, 170, 0, -5, 0, -5,
+ax_anim_terminator
+sSwellowAnims_7_2:
+ax_anim 2, 0, 171, -4, -4, -4, -4,
+ax_anim 8, 0, 171, -5, -5, -5, -5,
+ax_anim_terminator
+sSwellowAnims_7_3:
+ax_anim 2, 0, 172, -4, 0, -4, 0,
+ax_anim 8, 0, 172, -5, 0, -5, 0,
+ax_anim_terminator
+sSwellowAnims_7_4:
+ax_anim 2, 0, 173, -4, 4, -4, 4,
+ax_anim 8, 0, 173, -5, 5, -5, 5,
+ax_anim_terminator
+sSwellowAnims_7_5:
+ax_anim 2, 0, 174, 0, 4, 0, 4,
+ax_anim 8, 0, 174, 0, 5, 0, 5,
+ax_anim_terminator
+sSwellowAnims_7_6:
+ax_anim 2, 0, 175, 4, 4, 4, 4,
+ax_anim 8, 0, 175, 5, 5, 5, 5,
+ax_anim_terminator
+sSwellowAnims_7_7:
+ax_anim 2, 0, 176, 4, 0, 4, 0,
+ax_anim 8, 0, 176, 5, 0, 5, 0,
+ax_anim_terminator
+sSwellowAnims_7_8:
+ax_anim 2, 0, 177, 4, -4, 4, -4,
+ax_anim 8, 0, 177, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sSwellowAnims_8_1:
+ax_anim 40, 0, 178, 0, 0, 0, 0,
+ax_anim 3, 0, 181, 0, 3, 0, 0,
+ax_anim 3, 0, 180, 0, 1, 0, 0,
+ax_anim 3, 0, 181, 0, -3, 0, 0,
+ax_anim 3, 0, 180, 0, -5, 0, 0,
+ax_anim 3, 0, 181, 0, -7, 0, 0,
+ax_anim 3, 0, 180, 0, -5, 0, 0,
+ax_anim 3, 0, 181, 0, -7, 0, 0,
+ax_anim 3, 0, 180, 0, -8, 0, 0,
+ax_anim 3, 0, 181, 0, -9, 0, 0,
+ax_anim 3, 0, 181, 0, -9, 0, 0,
+ax_anim 3, 0, 181, 0, -8, 0, 0,
+ax_anim 3, 0, 181, 0, -6, 0, 0,
+ax_anim 3, 0, 181, 0, -4, 0, 0,
+ax_anim_terminator
+sSwellowAnims_8_2:
+ax_anim 40, 0, 182, 0, 0, 0, 0,
+ax_anim 3, 0, 185, 0, 3, 0, 0,
+ax_anim 3, 0, 184, 0, 1, 0, 0,
+ax_anim 3, 0, 185, 0, -3, 0, 0,
+ax_anim 3, 0, 184, 0, -5, 0, 0,
+ax_anim 3, 0, 185, 0, -7, 0, 0,
+ax_anim 3, 0, 184, 0, -5, 0, 0,
+ax_anim 3, 0, 185, 0, -7, 0, 0,
+ax_anim 3, 0, 184, 0, -8, 0, 0,
+ax_anim 3, 0, 185, 0, -9, 0, 0,
+ax_anim 3, 0, 185, 0, -9, 0, 0,
+ax_anim 3, 0, 185, 0, -8, 0, 0,
+ax_anim 2, 0, 185, 0, -6, 0, 0,
+ax_anim 2, 0, 185, 0, -4, 0, 0,
+ax_anim_terminator
+sSwellowAnims_8_3:
+ax_anim 40, 0, 186, 0, 0, 0, 0,
+ax_anim 3, 0, 189, 0, 3, 0, 0,
+ax_anim 3, 0, 188, 0, 1, 0, 0,
+ax_anim 3, 0, 189, 0, -3, 0, 0,
+ax_anim 3, 0, 188, 0, -5, 0, 0,
+ax_anim 3, 0, 189, 0, -7, 0, 0,
+ax_anim 3, 0, 188, 0, -5, 0, 0,
+ax_anim 3, 0, 189, 0, -7, 0, 0,
+ax_anim 3, 0, 188, 0, -8, 0, 0,
+ax_anim 3, 0, 189, 0, -9, 0, 0,
+ax_anim 3, 0, 189, 0, -9, 0, 0,
+ax_anim 3, 0, 189, 0, -8, 0, 0,
+ax_anim 2, 0, 189, 0, -6, 0, 0,
+ax_anim 2, 0, 189, 0, -4, 0, 0,
+ax_anim_terminator
+sSwellowAnims_8_4:
+ax_anim 40, 0, 190, 0, 0, 0, 0,
+ax_anim 3, 0, 193, 0, 3, 0, 0,
+ax_anim 3, 0, 192, 0, 1, 0, 0,
+ax_anim 3, 0, 193, 0, -3, 0, 0,
+ax_anim 3, 0, 192, 0, -5, 0, 0,
+ax_anim 3, 0, 193, 0, -7, 0, 0,
+ax_anim 3, 0, 192, 0, -5, 0, 0,
+ax_anim 3, 0, 193, 0, -7, 0, 0,
+ax_anim 3, 0, 192, 0, -8, 0, 0,
+ax_anim 3, 0, 193, 0, -9, 0, 0,
+ax_anim 3, 0, 193, 0, -9, 0, 0,
+ax_anim 3, 0, 193, 0, -8, 0, 0,
+ax_anim 2, 0, 193, 0, -6, 0, 0,
+ax_anim 2, 0, 193, 0, -4, 0, 0,
+ax_anim_terminator
+sSwellowAnims_8_5:
+ax_anim 40, 0, 194, 0, 0, 0, 0,
+ax_anim 3, 0, 197, 0, 3, 0, 0,
+ax_anim 3, 0, 196, 0, 1, 0, 0,
+ax_anim 3, 0, 197, 0, -3, 0, 0,
+ax_anim 3, 0, 196, 0, -5, 0, 0,
+ax_anim 3, 0, 197, 0, -7, 0, 0,
+ax_anim 3, 0, 196, 0, -5, 0, 0,
+ax_anim 3, 0, 197, 0, -7, 0, 0,
+ax_anim 3, 0, 196, 0, -8, 0, 0,
+ax_anim 3, 0, 197, 0, -9, 0, 0,
+ax_anim 3, 0, 197, 0, -9, 0, 0,
+ax_anim 3, 0, 197, 0, -8, 0, 0,
+ax_anim 2, 0, 197, 0, -6, 0, 0,
+ax_anim 2, 0, 197, 0, -4, 0, 0,
+ax_anim_terminator
+sSwellowAnims_8_6:
+ax_anim 40, 0, 198, 0, 0, 0, 0,
+ax_anim 3, 0, 201, 0, 3, 0, 0,
+ax_anim 3, 0, 200, 0, 1, 0, 0,
+ax_anim 3, 0, 201, 0, -3, 0, 0,
+ax_anim 3, 0, 200, 0, -5, 0, 0,
+ax_anim 3, 0, 201, 0, -7, 0, 0,
+ax_anim 3, 0, 200, 0, -5, 0, 0,
+ax_anim 3, 0, 201, 0, -7, 0, 0,
+ax_anim 3, 0, 200, 0, -8, 0, 0,
+ax_anim 3, 0, 201, 0, -9, 0, 0,
+ax_anim 3, 0, 201, 0, -9, 0, 0,
+ax_anim 3, 0, 201, 0, -8, 0, 0,
+ax_anim 2, 0, 201, 0, -6, 0, 0,
+ax_anim 2, 0, 201, 0, -4, 0, 0,
+ax_anim_terminator
+sSwellowAnims_8_7:
+ax_anim 40, 0, 202, 0, 0, 0, 0,
+ax_anim 3, 0, 205, 0, 3, 0, 0,
+ax_anim 3, 0, 204, 0, 1, 0, 0,
+ax_anim 3, 0, 205, 0, -3, 0, 0,
+ax_anim 3, 0, 204, 0, -5, 0, 0,
+ax_anim 3, 0, 205, 0, -7, 0, 0,
+ax_anim 3, 0, 204, 0, -5, 0, 0,
+ax_anim 3, 0, 205, 0, -7, 0, 0,
+ax_anim 3, 0, 204, 0, -8, 0, 0,
+ax_anim 3, 0, 205, 0, -9, 0, 0,
+ax_anim 3, 0, 205, 0, -9, 0, 0,
+ax_anim 3, 0, 205, 0, -8, 0, 0,
+ax_anim 2, 0, 205, 0, -6, 0, 0,
+ax_anim 2, 0, 205, 0, -4, 0, 0,
+ax_anim_terminator
+sSwellowAnims_8_8:
+ax_anim 40, 0, 206, 0, 0, 0, 0,
+ax_anim 3, 0, 209, 0, 3, 0, 0,
+ax_anim 3, 0, 208, 0, 1, 0, 0,
+ax_anim 3, 0, 209, 0, -3, 0, 0,
+ax_anim 3, 0, 208, 0, -5, 0, 0,
+ax_anim 3, 0, 209, 0, -7, 0, 0,
+ax_anim 3, 0, 208, 0, -5, 0, 0,
+ax_anim 3, 0, 209, 0, -7, 0, 0,
+ax_anim 3, 0, 208, 0, -8, 0, 0,
+ax_anim 3, 0, 209, 0, -9, 0, 0,
+ax_anim 3, 0, 209, 0, -9, 0, 0,
+ax_anim 3, 0, 209, 0, -8, 0, 0,
+ax_anim 2, 0, 209, 0, -6, 0, 0,
+ax_anim 2, 0, 209, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_9_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 6, 3, 6, 3,
+ax_anim 2, 0, 212, 10, 9, 10, 11,
+ax_anim 2, 0, 213, 9, 16, 9, 18,
+ax_anim 3, 0, 214, 0, 20, 0, 20,
+ax_anim 2, 3, 215, -9, 16, -9, 18,
+ax_anim 2, 0, 216, -10, 9, -10, 11,
+ax_anim 1, 0, 217, -6, 3, -6, 3,
+ax_anim 1, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_9_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 8, 0, 8, 0,
+ax_anim 2, 0, 211, 17, 6, 17, 6,
+ax_anim 2, 0, 212, 21, 12, 21, 12,
+ax_anim 3, 0, 213, 20, 20, 20, 20,
+ax_anim 2, 3, 214, 13, 21, 13, 21,
+ax_anim 2, 0, 215, 5, 17, 5, 17,
+ax_anim 1, 0, 216, 2, 7, 2, 7,
+ax_anim 1, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_9_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 3, -5, 3, -5,
+ax_anim 2, 0, 210, 11, -6, 11, -6,
+ax_anim 2, 0, 211, 16, -4, 16, -4,
+ax_anim 3, 0, 212, 19, 0, 19, 0,
+ax_anim 2, 3, 213, 16, 5, 16, 5,
+ax_anim 2, 0, 214, 12, 8, 12, 8,
+ax_anim 1, 0, 215, 5, 4, 5, 4,
+ax_anim 1, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_9_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, -1, -8, -1, -8,
+ax_anim 2, 0, 217, 3, -17, 3, -17,
+ax_anim 2, 0, 210, 11, -22, 11, -22,
+ax_anim 3, 0, 211, 19, -22, 19, -22,
+ax_anim 2, 3, 212, 22, -14, 22, -14,
+ax_anim 2, 0, 213, 17, -4, 17, -4,
+ax_anim 1, 0, 214, 9, -1, 9, -1,
+ax_anim 1, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_9_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, -8, -4, -8, -4,
+ax_anim 2, 0, 216, -9, -12, -9, -12,
+ax_anim 2, 0, 217, -8, -17, -8, -17,
+ax_anim 3, 0, 210, 0, -20, 0, -20,
+ax_anim 2, 3, 211, 8, -17, 8, -17,
+ax_anim 2, 0, 212, 9, -10, 9, -10,
+ax_anim 1, 0, 213, 8, -4, 8, -4,
+ax_anim 1, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_9_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 1, -8, 1, -8,
+ax_anim 2, 0, 211, -3, -17, -3, -17,
+ax_anim 2, 0, 210, -11, -22, -11, -22,
+ax_anim 3, 0, 217, -19, -22, -19, -22,
+ax_anim 2, 3, 216, -22, -14, -22, -14,
+ax_anim 2, 0, 215, -17, -4, -17, -4,
+ax_anim 1, 0, 214, -9, -1, -9, -1,
+ax_anim 1, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_9_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 211, -3, -5, -3, -5,
+ax_anim 2, 0, 210, -11, -6, -11, -6,
+ax_anim 2, 0, 217, -16, -4, -16, -4,
+ax_anim 3, 0, 216, -19, 0, -19, 0,
+ax_anim 2, 3, 215, -16, 5, -16, 5,
+ax_anim 2, 0, 214, -12, 8, -12, 8,
+ax_anim 1, 0, 213, -5, 4, -5, 4,
+ax_anim 1, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_9_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 210, -8, 0, -8, 0,
+ax_anim 2, 0, 217, -17, 6, -17, 6,
+ax_anim 2, 0, 216, -21, 12, -21, 12,
+ax_anim 3, 0, 215, -20, 20, -20, 20,
+ax_anim 2, 3, 214, -13, 21, -13, 21,
+ax_anim 2, 0, 213, -5, 17, -5, 17,
+ax_anim 1, 0, 212, -2, 7, -2, 7,
+ax_anim 1, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_10_1:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 3, 0, 246, 13, 0, 13, 0,
+ax_anim 3, 0, 246, -13, 0, -13, 0,
+ax_anim 2, 0, 246, 12, 0, 12, 0,
+ax_anim 3, 0, 246, -12, 0, -12, 0,
+ax_anim 2, 0, 246, 10, 0, 10, 0,
+ax_anim 2, 0, 246, -10, 0, -10, 0,
+ax_anim 2, 0, 246, 6, 0, 6, 0,
+ax_anim 2, 0, 246, -6, 0, -6, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_10_2:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 3, 0, 247, 13, -13, 13, -13,
+ax_anim 3, 0, 247, -13, 13, -13, 13,
+ax_anim 2, 0, 247, 12, -12, 12, -12,
+ax_anim 3, 0, 247, -12, 12, -12, 12,
+ax_anim 2, 0, 247, 10, -10, 10, -10,
+ax_anim 2, 0, 247, -10, 10, -10, 10,
+ax_anim 2, 0, 247, 6, -6, 6, -6,
+ax_anim 2, 0, 247, -6, 6, -6, 6,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_10_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 3, 0, 248, 0, -13, 0, -13,
+ax_anim 3, 0, 248, 0, 13, 0, 13,
+ax_anim 2, 0, 248, 0, -12, 0, -12,
+ax_anim 3, 0, 248, 0, 12, 0, 12,
+ax_anim 2, 0, 248, 0, -10, 0, -10,
+ax_anim 2, 0, 248, 0, 10, 0, 10,
+ax_anim 2, 0, 248, 0, -6, 0, -6,
+ax_anim 2, 0, 248, 0, 6, 0, 6,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_10_4:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 3, 0, 249, -13, -13, -13, -13,
+ax_anim 3, 0, 249, 13, 13, 13, 13,
+ax_anim 2, 0, 249, -12, -12, -12, -12,
+ax_anim 3, 0, 249, 12, 12, 12, 12,
+ax_anim 2, 0, 249, -10, -10, -10, -10,
+ax_anim 2, 0, 249, 10, 10, 10, 10,
+ax_anim 2, 0, 249, -6, -6, -6, -6,
+ax_anim 2, 0, 249, 6, 6, 6, 6,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_10_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 3, 0, 250, 13, 0, 13, 0,
+ax_anim 3, 0, 250, -13, 0, -13, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_10_6:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 3, 0, 251, 13, -13, 13, -13,
+ax_anim 3, 0, 251, -13, 13, -13, 13,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_10_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 3, 0, 252, 0, -13, 0, -13,
+ax_anim 3, 0, 252, 0, 13, 0, 13,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_10_8:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 3, 0, 253, -13, -13, -13, -13,
+ax_anim 3, 0, 253, 13, 13, 13, 13,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_11_1:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 1, 0, 254, 0, -10, 0, 0,
+ax_anim 2, 0, 254, 0, -16, 0, 0,
+ax_anim 3, 0, 254, 0, -20, 0, 0,
+ax_anim 4, 0, 254, 0, -21, 0, 0,
+ax_anim 4, 0, 256, 0, -23, 0, 0,
+ax_anim 3, 0, 256, 0, -22, 0, 0,
+ax_anim 2, 0, 256, 0, -18, 0, 0,
+ax_anim 1, 0, 256, 0, -12, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_11_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 1, 0, 257, 0, -10, 0, 0,
+ax_anim 2, 0, 257, 0, -16, 0, 0,
+ax_anim 3, 0, 257, 0, -20, 0, 0,
+ax_anim 4, 0, 257, 0, -21, 0, 0,
+ax_anim 4, 0, 259, 0, -23, 0, 0,
+ax_anim 3, 0, 259, 0, -22, 0, 0,
+ax_anim 2, 0, 259, 0, -18, 0, 0,
+ax_anim 1, 0, 259, 0, -12, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_11_3:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 1, 0, 260, 0, -10, 0, 0,
+ax_anim 2, 0, 260, 0, -16, 0, 0,
+ax_anim 3, 0, 260, 0, -20, 0, 0,
+ax_anim 4, 0, 260, 0, -21, 0, 0,
+ax_anim 4, 0, 262, 0, -23, 0, 0,
+ax_anim 3, 0, 262, 0, -22, 0, 0,
+ax_anim 2, 0, 262, 0, -18, 0, 0,
+ax_anim 1, 0, 262, 0, -12, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_11_4:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 0, -10, 0, 0,
+ax_anim 2, 0, 263, 0, -16, 0, 0,
+ax_anim 3, 0, 263, 0, -20, 0, 0,
+ax_anim 4, 0, 263, 0, -21, 0, 0,
+ax_anim 4, 0, 265, 0, -22, 0, 0,
+ax_anim 3, 0, 265, 0, -21, 0, 0,
+ax_anim 2, 0, 265, 0, -17, 0, 0,
+ax_anim 1, 0, 265, 0, -11, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_11_5:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 0, -10, 0, 0,
+ax_anim 2, 0, 266, 0, -16, 0, 0,
+ax_anim 3, 0, 266, 0, -20, 0, 0,
+ax_anim 4, 0, 266, 0, -21, 0, 0,
+ax_anim 4, 0, 268, 0, -23, 0, 0,
+ax_anim 3, 0, 268, 0, -22, 0, 0,
+ax_anim 2, 0, 268, 0, -18, 0, 0,
+ax_anim 1, 0, 268, 0, -12, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_11_6:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 1, 0, 269, 0, -10, 0, 0,
+ax_anim 2, 0, 269, 0, -16, 0, 0,
+ax_anim 3, 0, 269, 0, -20, 0, 0,
+ax_anim 4, 0, 269, 0, -21, 0, 0,
+ax_anim 4, 0, 271, 0, -22, 0, 0,
+ax_anim 3, 0, 271, 0, -21, 0, 0,
+ax_anim 2, 0, 271, 0, -17, 0, 0,
+ax_anim 1, 0, 271, 0, -11, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_11_7:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 1, 0, 272, 0, -10, 0, 0,
+ax_anim 2, 0, 272, 0, -16, 0, 0,
+ax_anim 3, 0, 272, 0, -20, 0, 0,
+ax_anim 4, 0, 272, 0, -21, 0, 0,
+ax_anim 4, 0, 274, 0, -23, 0, 0,
+ax_anim 3, 0, 274, 0, -22, 0, 0,
+ax_anim 2, 0, 274, 0, -18, 0, 0,
+ax_anim 1, 0, 274, 0, -12, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_11_8:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 1, 0, 275, 0, -10, 0, 0,
+ax_anim 2, 0, 275, 0, -16, 0, 0,
+ax_anim 3, 0, 275, 0, -20, 0, 0,
+ax_anim 4, 0, 275, 0, -21, 0, 0,
+ax_anim 4, 0, 277, 0, -23, 0, 0,
+ax_anim 3, 0, 277, 0, -22, 0, 0,
+ax_anim 2, 0, 277, 0, -18, 0, 0,
+ax_anim 1, 0, 277, 0, -12, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_12_1:
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 2, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 1, 0, 1, 0,
+ax_anim 2, 1, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_12_2:
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 1, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_12_3:
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 1, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_12_4:
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 1, 283, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_12_5:
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 1, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_12_6:
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 2, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, 1, -1, 1, -1,
+ax_anim 2, 1, 281, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_12_7:
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 2, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -1, 0, -1,
+ax_anim 2, 1, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_12_8:
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, -1, -1, -1, -1,
+ax_anim 2, 1, 279, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwellowAnims_13_1:
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 2, 314, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_13_2:
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 2, 321, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_13_3:
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 2, 320, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_13_4:
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 2, 319, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_13_5:
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 2, 318, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_13_6:
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 2, 317, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_13_7:
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 2, 316, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowAnims_13_8:
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, 0, 0, 0,
+ax_anim 2, 2, 315, 0, 0, 0, 0,
+ax_anim_terminator
+sSwellowGfx1:
+.incbin "baserom.gba", 0x1153A1C, 0x100
+sSwellowSprites1:
+ax_sprite sSwellowGfx1, 0x100
+ax_sprite_terminator
+sSwellowGfx2:
+.incbin "baserom.gba", 0x1153B2C, 0x200
+sSwellowSprites2:
+ax_sprite sSwellowGfx2, 0x200
+ax_sprite_terminator
+sSwellowGfx3:
+.incbin "baserom.gba", 0x1153D3C, 0x200
+sSwellowSprites3:
+ax_sprite sSwellowGfx3, 0x200
+ax_sprite_terminator
+sSwellowGfx4:
+.incbin "baserom.gba", 0x1153F4C, 0x200
+sSwellowSprites4:
+ax_sprite sSwellowGfx4, 0x200
+ax_sprite_terminator
+sSwellowGfx5:
+.incbin "baserom.gba", 0x115415C, 0x200
+sSwellowSprites5:
+ax_sprite sSwellowGfx5, 0x200
+ax_sprite_terminator
+sSwellowGfx6:
+.incbin "baserom.gba", 0x115436C, 0x200
+sSwellowSprites6:
+ax_sprite sSwellowGfx6, 0x200
+ax_sprite_terminator
+sSwellowGfx7:
+.incbin "baserom.gba", 0x115457C, 0x200
+sSwellowSprites7:
+ax_sprite sSwellowGfx7, 0x200
+ax_sprite_terminator
+sSwellowGfx8:
+.incbin "baserom.gba", 0x115478C, 0x200
+sSwellowSprites8:
+ax_sprite sSwellowGfx8, 0x200
+ax_sprite_terminator
+sSwellowGfx9:
+.incbin "baserom.gba", 0x115499C, 0x200
+sSwellowSprites9:
+ax_sprite sSwellowGfx9, 0x200
+ax_sprite_terminator
+sSwellowGfx10:
+.incbin "baserom.gba", 0x1154BAC, 0x200
+sSwellowSprites10:
+ax_sprite sSwellowGfx10, 0x200
+ax_sprite_terminator
+sSwellowGfx11:
+.incbin "baserom.gba", 0x1154DBC, 0x200
+sSwellowSprites11:
+ax_sprite sSwellowGfx11, 0x200
+ax_sprite_terminator
+sSwellowGfx12:
+.incbin "baserom.gba", 0x1154FCC, 0x200
+sSwellowSprites12:
+ax_sprite sSwellowGfx12, 0x200
+ax_sprite_terminator
+sSwellowGfx13:
+.incbin "baserom.gba", 0x11551DC, 0x200
+sSwellowSprites13:
+ax_sprite sSwellowGfx13, 0x200
+ax_sprite_terminator
+sSwellowGfx14:
+.incbin "baserom.gba", 0x11553EC, 0x200
+sSwellowSprites14:
+ax_sprite sSwellowGfx14, 0x200
+ax_sprite_terminator
+sSwellowGfx15:
+.incbin "baserom.gba", 0x11555FC, 0x200
+sSwellowSprites15:
+ax_sprite sSwellowGfx15, 0x200
+ax_sprite_terminator
+sSwellowGfx16:
+.incbin "baserom.gba", 0x115580C, 0x40
+sSwellowGfx16_1:
+.incbin "baserom.gba", 0x115584C, 0x100
+sSwellowGfx16_2:
+.incbin "baserom.gba", 0x115594C, 0x40
+sSwellowSprites16:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwellowGfx17:
+.incbin "baserom.gba", 0x11559CC, 0x40
+sSwellowGfx17_1:
+.incbin "baserom.gba", 0x1155A0C, 0x40
+sSwellowGfx17_2:
+.incbin "baserom.gba", 0x1155A4C, 0x100
+sSwellowSprites17:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSwellowGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx17_2, 0x100
+ax_sprite_terminator
+sSwellowGfx18:
+.incbin "baserom.gba", 0x1155B84, 0x180
+sSwellowGfx18_1:
+.incbin "baserom.gba", 0x1155D04, 0x40
+sSwellowSprites18:
+ax_sprite sSwellowGfx18, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwellowGfx19:
+.incbin "baserom.gba", 0x1155D6C, 0x100
+sSwellowGfx19_1:
+.incbin "baserom.gba", 0x1155E6C, 0x60
+sSwellowSprites19:
+ax_sprite 0, 0x80
+ax_sprite sSwellowGfx19, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx19_1, 0x60
+ax_sprite_terminator
+sSwellowGfx20:
+.incbin "baserom.gba", 0x1155EF4, 0x20
+sSwellowGfx20_1:
+.incbin "baserom.gba", 0x1155F14, 0x60
+sSwellowGfx20_2:
+.incbin "baserom.gba", 0x1155F74, 0x100
+sSwellowSprites20:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx20, 0x20
+ax_sprite 0, 0x40
+ax_sprite sSwellowGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx20_2, 0x100
+ax_sprite_terminator
+sSwellowGfx21:
+.incbin "baserom.gba", 0x11560AC, 0x40
+sSwellowGfx21_1:
+.incbin "baserom.gba", 0x11560EC, 0xA0
+sSwellowGfx21_2:
+.incbin "baserom.gba", 0x115618C, 0x60
+sSwellowGfx21_3:
+.incbin "baserom.gba", 0x11561EC, 0x40
+sSwellowSprites21:
+ax_sprite sSwellowGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx21_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwellowGfx22:
+.incbin "baserom.gba", 0x1156274, 0x100
+sSwellowGfx22_1:
+.incbin "baserom.gba", 0x1156374, 0x40
+sSwellowSprites22:
+ax_sprite 0, 0x80
+ax_sprite sSwellowGfx22, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwellowGfx23:
+.incbin "baserom.gba", 0x11563E4, 0x40
+sSwellowGfx23_1:
+.incbin "baserom.gba", 0x1156424, 0x60
+sSwellowGfx23_2:
+.incbin "baserom.gba", 0x1156484, 0x60
+sSwellowGfx23_3:
+.incbin "baserom.gba", 0x11564E4, 0x60
+sSwellowSprites23:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSwellowGfx23_3, 0x60
+ax_sprite_terminator
+sSwellowGfx24:
+.incbin "baserom.gba", 0x115658C, 0xE0
+sSwellowGfx24_1:
+.incbin "baserom.gba", 0x115666C, 0x60
+sSwellowGfx24_2:
+.incbin "baserom.gba", 0x11566CC, 0x20
+sSwellowGfx24_3:
+.incbin "baserom.gba", 0x11566EC, 0x20
+sSwellowSprites24:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx24, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx24_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx24_3, 0x20
+ax_sprite_terminator
+sSwellowGfx25:
+.incbin "baserom.gba", 0x1156754, 0x180
+sSwellowSprites25:
+ax_sprite 0, 0x80
+ax_sprite sSwellowGfx25, 0x180
+ax_sprite_terminator
+sSwellowGfx26:
+.incbin "baserom.gba", 0x11568EC, 0x40
+sSwellowGfx26_1:
+.incbin "baserom.gba", 0x115692C, 0x40
+sSwellowGfx26_2:
+.incbin "baserom.gba", 0x115696C, 0x100
+sSwellowSprites26:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSwellowGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx26_2, 0x100
+ax_sprite_terminator
+sSwellowGfx27:
+.incbin "baserom.gba", 0x1156AA4, 0x180
+sSwellowGfx27_1:
+.incbin "baserom.gba", 0x1156C24, 0x60
+sSwellowSprites27:
+ax_sprite sSwellowGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx27_1, 0x60
+ax_sprite_terminator
+sSwellowGfx28:
+.incbin "baserom.gba", 0x1156CA4, 0x40
+sSwellowGfx28_1:
+.incbin "baserom.gba", 0x1156CE4, 0x100
+sSwellowGfx28_2:
+.incbin "baserom.gba", 0x1156DE4, 0x40
+sSwellowSprites28:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx28_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwellowGfx29:
+.incbin "baserom.gba", 0x1156E64, 0x40
+sSwellowGfx29_1:
+.incbin "baserom.gba", 0x1156EA4, 0x40
+sSwellowGfx29_2:
+.incbin "baserom.gba", 0x1156EE4, 0x100
+sSwellowSprites29:
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSwellowGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx29_2, 0x100
+ax_sprite_terminator
+sSwellowGfx30:
+.incbin "baserom.gba", 0x115701C, 0x180
+sSwellowGfx30_1:
+.incbin "baserom.gba", 0x115719C, 0x40
+sSwellowSprites30:
+ax_sprite sSwellowGfx30, 0x180
+ax_sprite 0, 0x20
+ax_sprite sSwellowGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwellowGfx31:
+.incbin "baserom.gba", 0x1157204, 0x200
+sSwellowSprites31:
+ax_sprite sSwellowGfx31, 0x200
+ax_sprite_terminator
+sSwellowGfx32:
+.incbin "baserom.gba", 0x1157414, 0x200
+sSwellowSprites32:
+ax_sprite sSwellowGfx32, 0x200
+ax_sprite_terminator
+sSwellowGfx33:
+.incbin "baserom.gba", 0x1157624, 0x200
+sSwellowSprites33:
+ax_sprite sSwellowGfx33, 0x200
+ax_sprite_terminator
+sSwellowGfx34:
+.incbin "baserom.gba", 0x1157834, 0x200
+sSwellowSprites34:
+ax_sprite sSwellowGfx34, 0x200
+ax_sprite_terminator
+sSwellowGfx35:
+.incbin "baserom.gba", 0x1157A44, 0x200
+sSwellowSprites35:
+ax_sprite sSwellowGfx35, 0x200
+ax_sprite_terminator
+sSwellowGfx36:
+.incbin "baserom.gba", 0x1157C54, 0x200
+sSwellowSprites36:
+ax_sprite sSwellowGfx36, 0x200
+ax_sprite_terminator
+sSwellowGfx37:
+.incbin "baserom.gba", 0x1157E64, 0x200
+sSwellowSprites37:
+ax_sprite sSwellowGfx37, 0x200
+ax_sprite_terminator
+sAxPosesSwellow:
+.4byte sSwellowPose1
+.4byte sSwellowPose2
+.4byte sSwellowPose3
+.4byte sSwellowPose4
+.4byte sSwellowPose5
+.4byte sSwellowPose6
+.4byte sSwellowPose7
+.4byte sSwellowPose8
+.4byte sSwellowPose9
+.4byte sSwellowPose10
+.4byte sSwellowPose11
+.4byte sSwellowPose12
+.4byte sSwellowPose13
+.4byte sSwellowPose14
+.4byte sSwellowPose15
+.4byte sSwellowPose16
+.4byte sSwellowPose17
+.4byte sSwellowPose18
+.4byte sSwellowPose19
+.4byte sSwellowPose20
+.4byte sSwellowPose21
+.4byte sSwellowPose22
+.4byte sSwellowPose23
+.4byte sSwellowPose24
+.4byte sSwellowPose25
+.4byte sSwellowPose26
+.4byte sSwellowPose27
+.4byte sSwellowPose28
+.4byte sSwellowPose29
+.4byte sSwellowPose30
+.4byte sSwellowPose31
+.4byte sSwellowPose32
+.4byte sSwellowPose33
+.4byte sSwellowPose34
+.4byte sSwellowPose35
+.4byte sSwellowPose36
+.4byte sSwellowPose37
+.4byte sSwellowPose38
+.4byte sSwellowPose39
+.4byte sSwellowPose40
+.4byte sSwellowPose41
+.4byte sSwellowPose42
+.4byte sSwellowPose43
+.4byte sSwellowPose44
+.4byte sSwellowPose45
+.4byte sSwellowPose46
+.4byte sSwellowPose47
+.4byte sSwellowPose48
+.4byte sSwellowPose49
+.4byte sSwellowPose50
+.4byte sSwellowPose51
+.4byte sSwellowPose52
+.4byte sSwellowPose53
+.4byte sSwellowPose54
+.4byte sSwellowPose55
+.4byte sSwellowPose56
+.4byte sSwellowPose57
+.4byte sSwellowPose58
+.4byte sSwellowPose59
+.4byte sSwellowPose60
+.4byte sSwellowPose61
+.4byte sSwellowPose62
+.4byte sSwellowPose63
+.4byte sSwellowPose64
+.4byte sSwellowPose65
+.4byte sSwellowPose66
+.4byte sSwellowPose67
+.4byte sSwellowPose68
+.4byte sSwellowPose69
+.4byte sSwellowPose70
+.4byte sSwellowPose71
+.4byte sSwellowPose72
+.4byte sSwellowPose73
+.4byte sSwellowPose74
+.4byte sSwellowPose75
+.4byte sSwellowPose76
+.4byte sSwellowPose77
+.4byte sSwellowPose78
+.4byte sSwellowPose79
+.4byte sSwellowPose80
+.4byte sSwellowPose81
+.4byte sSwellowPose82
+.4byte sSwellowPose83
+.4byte sSwellowPose84
+.4byte sSwellowPose85
+.4byte sSwellowPose86
+.4byte sSwellowPose87
+.4byte sSwellowPose88
+.4byte sSwellowPose89
+.4byte sSwellowPose90
+.4byte sSwellowPose91
+.4byte sSwellowPose92
+.4byte sSwellowPose93
+.4byte sSwellowPose94
+.4byte sSwellowPose95
+.4byte sSwellowPose96
+.4byte sSwellowPose97
+.4byte sSwellowPose98
+.4byte sSwellowPose99
+.4byte sSwellowPose100
+.4byte sSwellowPose101
+.4byte sSwellowPose102
+.4byte sSwellowPose103
+.4byte sSwellowPose104
+.4byte sSwellowPose105
+.4byte sSwellowPose106
+.4byte sSwellowPose107
+.4byte sSwellowPose108
+.4byte sSwellowPose109
+.4byte sSwellowPose110
+.4byte sSwellowPose111
+.4byte sSwellowPose112
+.4byte sSwellowPose113
+.4byte sSwellowPose114
+.4byte sSwellowPose115
+.4byte sSwellowPose116
+.4byte sSwellowPose117
+.4byte sSwellowPose118
+.4byte sSwellowPose119
+.4byte sSwellowPose120
+.4byte sSwellowPose121
+.4byte sSwellowPose122
+.4byte sSwellowPose123
+.4byte sSwellowPose124
+.4byte sSwellowPose125
+.4byte sSwellowPose126
+.4byte sSwellowPose127
+.4byte sSwellowPose128
+.4byte sSwellowPose129
+.4byte sSwellowPose130
+.4byte sSwellowPose131
+.4byte sSwellowPose132
+.4byte sSwellowPose133
+.4byte sSwellowPose134
+.4byte sSwellowPose135
+.4byte sSwellowPose136
+.4byte sSwellowPose137
+.4byte sSwellowPose138
+.4byte sSwellowPose139
+.4byte sSwellowPose140
+.4byte sSwellowPose141
+.4byte sSwellowPose142
+.4byte sSwellowPose143
+.4byte sSwellowPose144
+.4byte sSwellowPose145
+.4byte sSwellowPose146
+.4byte sSwellowPose147
+.4byte sSwellowPose148
+.4byte sSwellowPose149
+.4byte sSwellowPose150
+.4byte sSwellowPose151
+.4byte sSwellowPose152
+.4byte sSwellowPose153
+.4byte sSwellowPose154
+.4byte sSwellowPose155
+.4byte sSwellowPose156
+.4byte sSwellowPose157
+.4byte sSwellowPose158
+.4byte sSwellowPose159
+.4byte sSwellowPose160
+.4byte sSwellowPose161
+.4byte sSwellowPose162
+.4byte sSwellowPose163
+.4byte sSwellowPose164
+.4byte sSwellowPose165
+.4byte sSwellowPose166
+.4byte sSwellowPose167
+.4byte sSwellowPose168
+.4byte sSwellowPose169
+.4byte sSwellowPose170
+.4byte sSwellowPose171
+.4byte sSwellowPose172
+.4byte sSwellowPose173
+.4byte sSwellowPose174
+.4byte sSwellowPose175
+.4byte sSwellowPose176
+.4byte sSwellowPose177
+.4byte sSwellowPose178
+.4byte sSwellowPose179
+.4byte sSwellowPose180
+.4byte sSwellowPose181
+.4byte sSwellowPose182
+.4byte sSwellowPose183
+.4byte sSwellowPose184
+.4byte sSwellowPose185
+.4byte sSwellowPose186
+.4byte sSwellowPose187
+.4byte sSwellowPose188
+.4byte sSwellowPose189
+.4byte sSwellowPose190
+.4byte sSwellowPose191
+.4byte sSwellowPose192
+.4byte sSwellowPose193
+.4byte sSwellowPose194
+.4byte sSwellowPose195
+.4byte sSwellowPose196
+.4byte sSwellowPose197
+.4byte sSwellowPose198
+.4byte sSwellowPose199
+.4byte sSwellowPose200
+.4byte sSwellowPose201
+.4byte sSwellowPose202
+.4byte sSwellowPose203
+.4byte sSwellowPose204
+.4byte sSwellowPose205
+.4byte sSwellowPose206
+.4byte sSwellowPose207
+.4byte sSwellowPose208
+.4byte sSwellowPose209
+.4byte sSwellowPose210
+.4byte sSwellowPose211
+.4byte sSwellowPose212
+.4byte sSwellowPose213
+.4byte sSwellowPose214
+.4byte sSwellowPose215
+.4byte sSwellowPose216
+.4byte sSwellowPose217
+.4byte sSwellowPose218
+.4byte sSwellowPose219
+.4byte sSwellowPose220
+.4byte sSwellowPose221
+.4byte sSwellowPose222
+.4byte sSwellowPose223
+.4byte sSwellowPose224
+.4byte sSwellowPose225
+.4byte sSwellowPose226
+.4byte sSwellowPose227
+.4byte sSwellowPose228
+.4byte sSwellowPose229
+.4byte sSwellowPose230
+.4byte sSwellowPose231
+.4byte sSwellowPose232
+.4byte sSwellowPose233
+.4byte sSwellowPose234
+.4byte sSwellowPose235
+.4byte sSwellowPose236
+.4byte sSwellowPose237
+.4byte sSwellowPose238
+.4byte sSwellowPose239
+.4byte sSwellowPose240
+.4byte sSwellowPose241
+.4byte sSwellowPose242
+.4byte sSwellowPose243
+.4byte sSwellowPose244
+.4byte sSwellowPose245
+.4byte sSwellowPose246
+.4byte sSwellowPose247
+.4byte sSwellowPose248
+.4byte sSwellowPose249
+.4byte sSwellowPose250
+.4byte sSwellowPose251
+.4byte sSwellowPose252
+.4byte sSwellowPose253
+.4byte sSwellowPose254
+.4byte sSwellowPose255
+.4byte sSwellowPose256
+.4byte sSwellowPose257
+.4byte sSwellowPose258
+.4byte sSwellowPose259
+.4byte sSwellowPose260
+.4byte sSwellowPose261
+.4byte sSwellowPose262
+.4byte sSwellowPose263
+.4byte sSwellowPose264
+.4byte sSwellowPose265
+.4byte sSwellowPose266
+.4byte sSwellowPose267
+.4byte sSwellowPose268
+.4byte sSwellowPose269
+.4byte sSwellowPose270
+.4byte sSwellowPose271
+.4byte sSwellowPose272
+.4byte sSwellowPose273
+.4byte sSwellowPose274
+.4byte sSwellowPose275
+.4byte sSwellowPose276
+.4byte sSwellowPose277
+.4byte sSwellowPose278
+.4byte sSwellowPose279
+.4byte sSwellowPose280
+.4byte sSwellowPose281
+.4byte sSwellowPose282
+.4byte sSwellowPose283
+.4byte sSwellowPose284
+.4byte sSwellowPose285
+.4byte sSwellowPose286
+.4byte sSwellowPose287
+.4byte sSwellowPose288
+.4byte sSwellowPose289
+.4byte sSwellowPose290
+.4byte sSwellowPose291
+.4byte sSwellowPose292
+.4byte sSwellowPose293
+.4byte sSwellowPose294
+.4byte sSwellowPose295
+.4byte sSwellowPose296
+.4byte sSwellowPose297
+.4byte sSwellowPose298
+.4byte sSwellowPose299
+.4byte sSwellowPose300
+.4byte sSwellowPose301
+.4byte sSwellowPose302
+.4byte sSwellowPose303
+.4byte sSwellowPose304
+.4byte sSwellowPose305
+.4byte sSwellowPose306
+.4byte sSwellowPose307
+.4byte sSwellowPose308
+.4byte sSwellowPose309
+.4byte sSwellowPose310
+.4byte sSwellowPose311
+.4byte sSwellowPose312
+.4byte sSwellowPose313
+.4byte sSwellowPose314
+.4byte sSwellowPose315
+.4byte sSwellowPose316
+.4byte sSwellowPose317
+.4byte sSwellowPose318
+.4byte sSwellowPose319
+.4byte sSwellowPose320
+.4byte sSwellowPose321
+.4byte sSwellowPose322
+sAxPositionsSwellow:
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	  -6,   -6, 	   4,   -8, 	  -1,   -6
+.2byte   -1,   -9, 	  -6,   -8, 	   4,   -6, 	  -1,   -6
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    6,   -9, 	   0,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    6,   -9, 	  -6,   -7, 	  -7,   -4, 	   1,   -7
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    8,  -12, 	  -3,   -7, 	  -7,   -3, 	   2,   -8
+.2byte    8,  -12, 	  -7,   -5, 	  -5,   -2, 	   2,   -8
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -7,   -4, 	  -2,   -1, 	   3,   -9
+.2byte    7,  -13, 	  -5,   -3, 	   1,    0, 	   2,   -9
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   5,   -5, 	  -4,   -2, 	  -1,   -9
+.2byte   -1,  -14, 	   2,   -2, 	  -7,   -5, 	  -1,   -9
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -8,  -13, 	   6,   -4, 	   1,   -1, 	  -4,   -9
+.2byte   -8,  -13, 	   4,   -3, 	  -2,    0, 	  -3,   -9
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -9,  -12, 	   2,   -7, 	   6,   -3, 	  -3,   -8
+.2byte   -9,  -12, 	   6,   -5, 	   4,   -2, 	  -3,   -8
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -7,   -9, 	  -1,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -7,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,    0, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte   -1,  -12, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	 -13,  -19, 	  11,  -19, 	  -1,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte    4,  -12, 	   8,   -4, 	  -1,   -1, 	   1,   -8
+.2byte    4,  -12, 	   6,  -20, 	 -12,  -17, 	  -1,   -9
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    6,  -14, 	   6,   -6, 	   5,   -1, 	   0,   -9
+.2byte    6,  -14, 	  -2,  -20, 	  -7,  -15, 	   1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte    5,  -15, 	  -5,   -6, 	   6,   -2, 	  -1,  -11
+.2byte    5,  -15, 	  -8,  -20, 	   8,  -15, 	  -1,  -11
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   6,   -3, 	  -8,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   9,  -17, 	 -11,  -17, 	  -1,  -10
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -8,  -11, 	   9,  -11, 	 -10,   -1, 	  -1,   -7
+.2byte   -6,  -15, 	   4,   -6, 	  -7,   -2, 	   0,  -11
+.2byte   -6,  -15, 	   7,  -20, 	  -9,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte  -11,   -7, 	   2,  -14, 	   1,    3, 	   0,   -7
+.2byte   -7,  -14, 	  -7,   -6, 	  -6,   -1, 	  -1,   -9
+.2byte   -7,  -14, 	   1,  -20, 	   6,  -15, 	  -2,  -10
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -8,   -2, 	  -7,  -14, 	   9,   -1, 	   1,   -7
+.2byte   -5,  -12, 	  -9,   -4, 	   0,   -1, 	  -2,   -8
+.2byte   -5,  -12, 	  -7,  -20, 	  11,  -17, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,    0, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte   -1,  -12, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	 -13,  -19, 	  11,  -19, 	  -1,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte    4,  -12, 	   8,   -4, 	  -1,   -1, 	   1,   -8
+.2byte    4,  -12, 	   6,  -20, 	 -12,  -17, 	  -1,   -9
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    6,  -14, 	   6,   -6, 	   5,   -1, 	   0,   -9
+.2byte    6,  -14, 	  -2,  -20, 	  -7,  -15, 	   1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte    5,  -15, 	  -5,   -6, 	   6,   -2, 	  -1,  -11
+.2byte    5,  -15, 	  -8,  -20, 	   8,  -15, 	  -1,  -11
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   6,   -3, 	  -8,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   9,  -17, 	 -11,  -17, 	  -1,  -10
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -8,  -11, 	   9,  -11, 	 -10,   -1, 	  -1,   -7
+.2byte   -6,  -15, 	   4,   -6, 	  -7,   -2, 	   0,  -11
+.2byte   -6,  -15, 	   7,  -20, 	  -9,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte  -11,   -7, 	   2,  -14, 	   1,    3, 	   0,   -7
+.2byte   -7,  -14, 	  -7,   -6, 	  -6,   -1, 	  -1,   -9
+.2byte   -7,  -14, 	   1,  -20, 	   6,  -15, 	  -2,  -10
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -8,   -2, 	  -7,  -14, 	   9,   -1, 	   1,   -7
+.2byte   -5,  -12, 	  -9,   -4, 	   0,   -1, 	  -2,   -8
+.2byte   -5,  -12, 	  -7,  -20, 	  11,  -17, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	  -6,   -6, 	   4,   -8, 	  -1,   -6
+.2byte   -1,   -9, 	  -6,   -8, 	   4,   -6, 	  -1,   -6
+.2byte   -1,  -12, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	 -13,  -19, 	  11,  -19, 	  -1,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    6,   -9, 	   0,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    6,   -9, 	  -6,   -7, 	  -7,   -4, 	   1,   -7
+.2byte    4,  -12, 	   8,   -4, 	  -1,   -1, 	   1,   -8
+.2byte    4,  -12, 	   6,  -20, 	 -12,  -17, 	  -1,   -9
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    8,  -12, 	  -3,   -7, 	  -7,   -3, 	   2,   -8
+.2byte    8,  -12, 	  -7,   -5, 	  -5,   -2, 	   2,   -8
+.2byte    7,  -14, 	   7,   -6, 	   6,   -1, 	   1,   -9
+.2byte    7,  -14, 	  -1,  -20, 	  -6,  -15, 	   2,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -7,   -4, 	  -2,   -1, 	   3,   -9
+.2byte    7,  -13, 	  -5,   -3, 	   1,    0, 	   2,   -9
+.2byte    5,  -15, 	  -5,   -6, 	   6,   -2, 	  -1,  -11
+.2byte    5,  -15, 	  -8,  -20, 	   8,  -15, 	  -1,  -11
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   5,   -5, 	  -4,   -2, 	  -1,   -9
+.2byte   -1,  -14, 	   2,   -2, 	  -7,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   6,   -3, 	  -8,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   9,  -17, 	 -11,  -17, 	  -1,  -10
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -8,  -13, 	   6,   -4, 	   1,   -1, 	  -4,   -9
+.2byte   -8,  -13, 	   4,   -3, 	  -2,    0, 	  -3,   -9
+.2byte   -6,  -15, 	   4,   -6, 	  -7,   -2, 	   0,  -11
+.2byte   -6,  -15, 	   7,  -20, 	  -9,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -9,  -12, 	   2,   -7, 	   6,   -3, 	  -3,   -8
+.2byte   -9,  -12, 	   6,   -5, 	   4,   -2, 	  -3,   -8
+.2byte   -8,  -14, 	  -8,   -6, 	  -7,   -1, 	  -2,   -9
+.2byte   -8,  -14, 	   0,  -20, 	   5,  -15, 	  -3,  -10
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -7,   -9, 	  -1,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -7,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte   -5,  -12, 	  -9,   -4, 	   0,   -1, 	  -2,   -8
+.2byte   -5,  -12, 	  -7,  -20, 	  11,  -17, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,   -9, 	  -6,   -6, 	   4,   -8, 	  -1,   -6
+.2byte   -1,   -9, 	  -6,   -8, 	   4,   -6, 	  -1,   -6
+.2byte   -1,  -12, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	 -13,  -19, 	  11,  -19, 	  -1,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    6,   -9, 	   0,   -6, 	  -8,   -6, 	   0,   -7
+.2byte    6,   -9, 	  -6,   -7, 	  -7,   -4, 	   1,   -7
+.2byte    4,  -12, 	   8,   -4, 	  -1,   -1, 	   1,   -8
+.2byte    4,  -12, 	   6,  -20, 	 -12,  -17, 	  -1,   -9
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    8,  -12, 	  -3,   -7, 	  -7,   -3, 	   2,   -8
+.2byte    8,  -12, 	  -7,   -5, 	  -5,   -2, 	   2,   -8
+.2byte    7,  -14, 	   7,   -6, 	   6,   -1, 	   1,   -9
+.2byte    7,  -14, 	  -1,  -20, 	  -6,  -15, 	   2,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -7,   -4, 	  -2,   -1, 	   3,   -9
+.2byte    7,  -13, 	  -5,   -3, 	   1,    0, 	   2,   -9
+.2byte    5,  -15, 	  -5,   -6, 	   6,   -2, 	  -1,  -11
+.2byte    5,  -15, 	  -8,  -20, 	   8,  -15, 	  -1,  -11
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   5,   -5, 	  -4,   -2, 	  -1,   -9
+.2byte   -1,  -14, 	   2,   -2, 	  -7,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	   6,   -3, 	  -8,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   9,  -17, 	 -11,  -17, 	  -1,  -10
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -8,  -13, 	   6,   -4, 	   1,   -1, 	  -4,   -9
+.2byte   -8,  -13, 	   4,   -3, 	  -2,    0, 	  -3,   -9
+.2byte   -6,  -15, 	   4,   -6, 	  -7,   -2, 	   0,  -11
+.2byte   -6,  -15, 	   7,  -20, 	  -9,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -9,  -12, 	   2,   -7, 	   6,   -3, 	  -3,   -8
+.2byte   -9,  -12, 	   6,   -5, 	   4,   -2, 	  -3,   -8
+.2byte   -8,  -14, 	  -8,   -6, 	  -7,   -1, 	  -2,   -9
+.2byte   -8,  -14, 	   0,  -20, 	   5,  -15, 	  -3,  -10
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -7,   -9, 	  -1,   -6, 	   7,   -6, 	  -1,   -7
+.2byte   -7,   -9, 	   5,   -7, 	   6,   -4, 	  -2,   -7
+.2byte   -5,  -12, 	  -9,   -4, 	   0,   -1, 	  -2,   -8
+.2byte   -5,  -12, 	  -7,  -20, 	  11,  -17, 	   0,   -9
+.2byte   -9,   -9, 	   3,   -3, 	   2,    0, 	  -2,   -4
+.2byte  -10,   -7, 	   3,   -3, 	   6,    0, 	  -3,   -4
+.2byte    0,  -13, 	 -10,  -19, 	  10,  -19, 	   0,  -10
+.2byte    2,  -14, 	   0,  -21, 	 -14,  -13, 	   0,   -9
+.2byte    2,  -15, 	  -7,  -18, 	 -12,  -12, 	  -1,   -9
+.2byte    2,  -12, 	 -12,  -16, 	   2,  -13, 	  -1,   -8
+.2byte    0,  -15, 	  11,  -13, 	 -11,  -13, 	   0,   -9
+.2byte   -3,  -12, 	  11,  -16, 	  -3,  -13, 	   0,   -8
+.2byte   -3,  -15, 	   6,  -18, 	  11,  -12, 	   0,   -9
+.2byte   -3,  -14, 	  -1,  -21, 	  13,  -13, 	  -1,   -9
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,    0, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte   -1,  -12, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	 -13,  -19, 	  11,  -19, 	  -1,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte    4,  -12, 	   8,   -4, 	  -1,   -1, 	   1,   -8
+.2byte    4,  -12, 	   6,  -20, 	 -12,  -17, 	  -1,   -9
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    6,  -14, 	   6,   -6, 	   5,   -1, 	   0,   -9
+.2byte    6,  -14, 	  -2,  -20, 	  -7,  -15, 	   1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte    5,  -15, 	  -5,   -6, 	   6,   -2, 	  -1,  -11
+.2byte    5,  -15, 	  -8,  -20, 	   8,  -15, 	  -1,  -11
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   6,   -3, 	  -8,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   9,  -17, 	 -11,  -17, 	  -1,  -10
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -8,  -11, 	   9,  -11, 	 -10,   -1, 	  -1,   -7
+.2byte   -6,  -15, 	   4,   -6, 	  -7,   -2, 	   0,  -11
+.2byte   -6,  -15, 	   7,  -20, 	  -9,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte  -11,   -7, 	   2,  -14, 	   1,    3, 	   0,   -7
+.2byte   -7,  -14, 	  -7,   -6, 	  -6,   -1, 	  -1,   -9
+.2byte   -7,  -14, 	   1,  -20, 	   6,  -15, 	  -2,  -10
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -8,   -2, 	  -7,  -14, 	   9,   -1, 	   1,   -7
+.2byte   -5,  -12, 	  -9,   -4, 	   0,   -1, 	  -2,   -8
+.2byte   -5,  -12, 	  -7,  -20, 	  11,  -17, 	   0,   -9
+.2byte   -1,    0, 	 -12,  -10, 	  10,  -10, 	  -1,   -7
+.2byte   -8,   -2, 	  -7,  -14, 	   9,   -1, 	   1,   -7
+.2byte  -11,   -7, 	   2,  -14, 	   1,    3, 	   0,   -7
+.2byte   -8,  -11, 	   9,  -11, 	 -10,   -1, 	  -1,   -7
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte   -8,  -11, 	   9,  -11, 	 -10,   -1, 	  -1,   -7
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte  -11,   -7, 	   2,  -14, 	   1,    3, 	   0,   -7
+.2byte   -8,  -11, 	   9,  -11, 	 -10,   -1, 	  -1,   -7
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte   -8,   -2, 	  -7,  -14, 	   9,   -1, 	   1,   -7
+.2byte  -11,   -7, 	   2,  -14, 	   1,    3, 	   0,   -7
+.2byte   -8,  -11, 	   9,  -11, 	 -10,   -1, 	  -1,   -7
+.2byte   -1,  -12, 	  12,   -5, 	 -14,   -5, 	  -1,   -8
+.2byte    7,  -11, 	 -10,  -11, 	   9,   -1, 	   0,   -7
+.2byte   10,   -7, 	  -3,  -14, 	  -2,    3, 	  -1,   -7
+.2byte    7,   -2, 	   6,  -14, 	 -10,   -1, 	  -2,   -7
+.2byte   -1,  -12, 	 -13,  -19, 	  11,  -19, 	  -1,   -9
+.2byte    4,  -12, 	   6,  -20, 	 -12,  -17, 	  -1,   -9
+.2byte    6,  -14, 	  -2,  -20, 	  -7,  -15, 	   1,  -10
+.2byte    5,  -15, 	  -8,  -20, 	   8,  -15, 	  -1,  -11
+.2byte   -1,  -14, 	   9,  -17, 	 -11,  -17, 	  -1,  -10
+.2byte   -6,  -15, 	   7,  -20, 	  -9,  -15, 	   0,  -11
+.2byte   -7,  -14, 	   1,  -20, 	   6,  -15, 	  -2,  -10
+.2byte   -5,  -12, 	  -7,  -20, 	  11,  -17, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	  -9,   -2, 	   7,   -2, 	  -1,   -9
+.2byte   -1,  -12, 	 -13,  -19, 	  11,  -19, 	  -1,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    4,  -12, 	   8,   -4, 	  -1,   -1, 	   1,   -8
+.2byte    4,  -12, 	   6,  -20, 	 -12,  -17, 	  -1,   -9
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    6,  -14, 	   6,   -6, 	   5,   -1, 	   0,   -9
+.2byte    6,  -14, 	  -2,  -20, 	  -7,  -15, 	   1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    5,  -15, 	  -5,   -6, 	   6,   -2, 	  -1,  -11
+.2byte    5,  -15, 	  -8,  -20, 	   8,  -15, 	  -1,  -11
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   6,   -3, 	  -8,   -3, 	  -1,  -10
+.2byte   -1,  -14, 	   9,  -17, 	 -11,  -17, 	  -1,  -10
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -6,  -15, 	   4,   -6, 	  -7,   -2, 	   0,  -11
+.2byte   -6,  -15, 	   7,  -20, 	  -9,  -15, 	   0,  -11
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -7,  -14, 	  -7,   -6, 	  -6,   -1, 	  -1,   -9
+.2byte   -7,  -14, 	   1,  -20, 	   6,  -15, 	  -2,  -10
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -5,  -12, 	  -9,   -4, 	   0,   -1, 	  -2,   -8
+.2byte   -5,  -12, 	  -7,  -20, 	  11,  -17, 	   0,   -9
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+.2byte   -1,  -10, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -6,  -10, 	   1,   -6, 	   7,   -5, 	  -1,   -8
+.2byte   -8,  -13, 	   5,   -6, 	   5,   -2, 	  -3,   -9
+.2byte   -7,  -14, 	   5,   -5, 	   0,   -1, 	  -3,  -10
+.2byte   -1,  -15, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte    6,  -14, 	  -6,   -5, 	  -1,   -1, 	   2,  -10
+.2byte    7,  -13, 	  -6,   -6, 	  -6,   -2, 	   2,   -9
+.2byte    5,  -10, 	  -2,   -6, 	  -8,   -5, 	   0,   -8
+sSwellowAnimTable1:
+.4byte sSwellowAnims_1_1
+.4byte sSwellowAnims_1_2
+.4byte sSwellowAnims_1_3
+.4byte sSwellowAnims_1_4
+.4byte sSwellowAnims_1_5
+.4byte sSwellowAnims_1_6
+.4byte sSwellowAnims_1_7
+.4byte sSwellowAnims_1_8
+sSwellowAnimTable2:
+.4byte sSwellowAnims_2_1
+.4byte sSwellowAnims_2_2
+.4byte sSwellowAnims_2_3
+.4byte sSwellowAnims_2_4
+.4byte sSwellowAnims_2_5
+.4byte sSwellowAnims_2_6
+.4byte sSwellowAnims_2_7
+.4byte sSwellowAnims_2_8
+sSwellowAnimTable3:
+.4byte sSwellowAnims_3_1
+.4byte sSwellowAnims_3_2
+.4byte sSwellowAnims_3_3
+.4byte sSwellowAnims_3_4
+.4byte sSwellowAnims_3_5
+.4byte sSwellowAnims_3_6
+.4byte sSwellowAnims_3_7
+.4byte sSwellowAnims_3_8
+sSwellowAnimTable4:
+.4byte sSwellowAnims_4_1
+.4byte sSwellowAnims_4_2
+.4byte sSwellowAnims_4_3
+.4byte sSwellowAnims_4_4
+.4byte sSwellowAnims_4_5
+.4byte sSwellowAnims_4_6
+.4byte sSwellowAnims_4_7
+.4byte sSwellowAnims_4_8
+sSwellowAnimTable5:
+.4byte sSwellowAnims_5_1
+.4byte sSwellowAnims_5_2
+.4byte sSwellowAnims_5_3
+.4byte sSwellowAnims_5_4
+.4byte sSwellowAnims_5_5
+.4byte sSwellowAnims_5_6
+.4byte sSwellowAnims_5_7
+.4byte sSwellowAnims_5_8
+sSwellowAnimTable6:
+.4byte sSwellowAnims_6_1
+.4byte sSwellowAnims_6_1
+.4byte sSwellowAnims_6_1
+.4byte sSwellowAnims_6_1
+.4byte sSwellowAnims_6_1
+.4byte sSwellowAnims_6_1
+.4byte sSwellowAnims_6_1
+.4byte sSwellowAnims_6_1
+sSwellowAnimTable7:
+.4byte sSwellowAnims_7_1
+.4byte sSwellowAnims_7_2
+.4byte sSwellowAnims_7_3
+.4byte sSwellowAnims_7_4
+.4byte sSwellowAnims_7_5
+.4byte sSwellowAnims_7_6
+.4byte sSwellowAnims_7_7
+.4byte sSwellowAnims_7_8
+sSwellowAnimTable8:
+.4byte sSwellowAnims_8_1
+.4byte sSwellowAnims_8_2
+.4byte sSwellowAnims_8_3
+.4byte sSwellowAnims_8_4
+.4byte sSwellowAnims_8_5
+.4byte sSwellowAnims_8_6
+.4byte sSwellowAnims_8_7
+.4byte sSwellowAnims_8_8
+sSwellowAnimTable9:
+.4byte sSwellowAnims_9_1
+.4byte sSwellowAnims_9_2
+.4byte sSwellowAnims_9_3
+.4byte sSwellowAnims_9_4
+.4byte sSwellowAnims_9_5
+.4byte sSwellowAnims_9_6
+.4byte sSwellowAnims_9_7
+.4byte sSwellowAnims_9_8
+sSwellowAnimTable10:
+.4byte sSwellowAnims_10_1
+.4byte sSwellowAnims_10_2
+.4byte sSwellowAnims_10_3
+.4byte sSwellowAnims_10_4
+.4byte sSwellowAnims_10_5
+.4byte sSwellowAnims_10_6
+.4byte sSwellowAnims_10_7
+.4byte sSwellowAnims_10_8
+sSwellowAnimTable11:
+.4byte sSwellowAnims_11_1
+.4byte sSwellowAnims_11_2
+.4byte sSwellowAnims_11_3
+.4byte sSwellowAnims_11_4
+.4byte sSwellowAnims_11_5
+.4byte sSwellowAnims_11_6
+.4byte sSwellowAnims_11_7
+.4byte sSwellowAnims_11_8
+sSwellowAnimTable12:
+.4byte sSwellowAnims_12_1
+.4byte sSwellowAnims_12_2
+.4byte sSwellowAnims_12_3
+.4byte sSwellowAnims_12_4
+.4byte sSwellowAnims_12_5
+.4byte sSwellowAnims_12_6
+.4byte sSwellowAnims_12_7
+.4byte sSwellowAnims_12_8
+sSwellowAnimTable13:
+.4byte sSwellowAnims_13_1
+.4byte sSwellowAnims_13_2
+.4byte sSwellowAnims_13_3
+.4byte sSwellowAnims_13_4
+.4byte sSwellowAnims_13_5
+.4byte sSwellowAnims_13_6
+.4byte sSwellowAnims_13_7
+.4byte sSwellowAnims_13_8
+sAxAnimationsSwellow:
+.4byte sSwellowAnimTable1
+.4byte sSwellowAnimTable2
+.4byte sSwellowAnimTable3
+.4byte sSwellowAnimTable4
+.4byte sSwellowAnimTable5
+.4byte sSwellowAnimTable6
+.4byte sSwellowAnimTable7
+.4byte sSwellowAnimTable8
+.4byte sSwellowAnimTable9
+.4byte sSwellowAnimTable10
+.4byte sSwellowAnimTable11
+.4byte sSwellowAnimTable12
+.4byte sSwellowAnimTable13
+sAxSpritesSwellow:
+.4byte sSwellowSprites1
+.4byte sSwellowSprites2
+.4byte sSwellowSprites3
+.4byte sSwellowSprites4
+.4byte sSwellowSprites5
+.4byte sSwellowSprites6
+.4byte sSwellowSprites7
+.4byte sSwellowSprites8
+.4byte sSwellowSprites9
+.4byte sSwellowSprites10
+.4byte sSwellowSprites11
+.4byte sSwellowSprites12
+.4byte sSwellowSprites13
+.4byte sSwellowSprites14
+.4byte sSwellowSprites15
+.4byte sSwellowSprites16
+.4byte sSwellowSprites17
+.4byte sSwellowSprites18
+.4byte sSwellowSprites19
+.4byte sSwellowSprites20
+.4byte sSwellowSprites21
+.4byte sSwellowSprites22
+.4byte sSwellowSprites23
+.4byte sSwellowSprites24
+.4byte sSwellowSprites25
+.4byte sSwellowSprites26
+.4byte sSwellowSprites27
+.4byte sSwellowSprites28
+.4byte sSwellowSprites29
+.4byte sSwellowSprites30
+.4byte sSwellowSprites31
+.4byte sSwellowSprites32
+.4byte sSwellowSprites33
+.4byte sSwellowSprites34
+.4byte sSwellowSprites35
+.4byte sSwellowSprites36
+.4byte sSwellowSprites37
+sAxMainSwellow:
+ax_main sAxPosesSwellow, sAxAnimationsSwellow, 13, sAxSpritesSwellow, sAxPositionsSwellow

--- a/data/ax/swinub.inc
+++ b/data/ax/swinub.inc
@@ -1,0 +1,2729 @@
+.global gAxSwinub
+gAxSwinub:
+ax_siro sAxMainSwinub
+sSwinubPose1:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose2:
+ax_pose 1, 0x41f2, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose3:
+ax_pose 2, 0x41f4, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose4:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose5:
+ax_pose 4, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose6:
+ax_pose 5, 0x41f3, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose7:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose8:
+ax_pose 7, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose9:
+ax_pose 8, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose10:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose11:
+ax_pose 10, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose12:
+ax_pose 11, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose13:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose15:
+ax_pose 14, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose16:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose17:
+ax_pose 10, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose18:
+ax_pose 11, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose19:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose20:
+ax_pose 7, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose21:
+ax_pose 8, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose22:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose23:
+ax_pose 4, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose24:
+ax_pose 5, 0x41f3, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose25:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose26:
+ax_pose 1, 0x41f2, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose27:
+ax_pose 2, 0x41f4, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose28:
+ax_pose 15, 0x01f2, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose29:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose30:
+ax_pose 4, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose31:
+ax_pose 5, 0x41f3, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose32:
+ax_pose 16, 0x01f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose33:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose34:
+ax_pose 7, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose35:
+ax_pose 8, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose36:
+ax_pose 17, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose37:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose38:
+ax_pose 10, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose39:
+ax_pose 11, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose40:
+ax_pose 18, 0x01f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose41:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose42:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose43:
+ax_pose 14, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose44:
+ax_pose 19, 0x01f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose45:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose46:
+ax_pose 10, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose47:
+ax_pose 11, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose48:
+ax_pose 18, 0x01f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose49:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose50:
+ax_pose 7, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose51:
+ax_pose 8, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose52:
+ax_pose 17, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose53:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose54:
+ax_pose 4, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose55:
+ax_pose 5, 0x41f3, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose56:
+ax_pose 16, 0x01f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose57:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose58:
+ax_pose 1, 0x41f2, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose59:
+ax_pose 2, 0x41f4, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose60:
+ax_pose 15, 0x01f2, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose61:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose62:
+ax_pose 4, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose63:
+ax_pose 5, 0x41f3, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose64:
+ax_pose 16, 0x01f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose65:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose66:
+ax_pose 7, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose67:
+ax_pose 8, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose68:
+ax_pose 17, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose69:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose70:
+ax_pose 10, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose71:
+ax_pose 11, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose72:
+ax_pose 18, 0x01f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose73:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose74:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose75:
+ax_pose 14, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose76:
+ax_pose 19, 0x01f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose77:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose78:
+ax_pose 10, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose79:
+ax_pose 11, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose80:
+ax_pose 18, 0x01f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose81:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose82:
+ax_pose 7, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose83:
+ax_pose 8, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose84:
+ax_pose 17, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose85:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose86:
+ax_pose 4, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose87:
+ax_pose 5, 0x41f3, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose88:
+ax_pose 16, 0x01f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose89:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose90:
+ax_pose 20, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose91:
+ax_pose 21, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose92:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose93:
+ax_pose 22, 0x41f3, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose94:
+ax_pose 23, 0x41f3, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose95:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose96:
+ax_pose 24, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose97:
+ax_pose 25, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose98:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose99:
+ax_pose 26, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose100:
+ax_pose 18, 0x01f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose101:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose102:
+ax_pose 27, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose103:
+ax_pose 28, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose104:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose105:
+ax_pose 26, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose106:
+ax_pose 18, 0x01f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose107:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose108:
+ax_pose 24, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose109:
+ax_pose 25, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose110:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose111:
+ax_pose 22, 0x41f3, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose112:
+ax_pose 23, 0x41f3, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose113:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose114:
+ax_pose 29, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose115:
+ax_pose 30, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose116:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose117:
+ax_pose 31, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose118:
+ax_pose 32, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose119:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose120:
+ax_pose 33, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose121:
+ax_pose 34, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose122:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose123:
+ax_pose 35, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose124:
+ax_pose 36, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose125:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose126:
+ax_pose 37, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose127:
+ax_pose 38, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose128:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose129:
+ax_pose 35, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose130:
+ax_pose 36, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose131:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose132:
+ax_pose 33, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose133:
+ax_pose 34, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose134:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose135:
+ax_pose 31, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose136:
+ax_pose 32, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose137:
+ax_pose 39, 0x41f4, 0x80f3, 0x1c00
+ax_pose_terminator
+sSwinubPose138:
+ax_pose 40, 0x41f5, 0x80f3, 0x1c00
+ax_pose_terminator
+sSwinubPose139:
+ax_pose 41, 0x01e1, 0x80f1, 0x1c00
+ax_pose_terminator
+sSwinubPose140:
+ax_pose 42, 0x01e2, 0x90ec, 0x1c00
+ax_pose_terminator
+sSwinubPose141:
+ax_pose 43, 0x01e4, 0x90ec, 0x1c00
+ax_pose_terminator
+sSwinubPose142:
+ax_pose 44, 0x01e6, 0x90ea, 0x1c00
+ax_pose_terminator
+sSwinubPose143:
+ax_pose 45, 0x01e6, 0x80f0, 0x1c00
+ax_pose_terminator
+sSwinubPose144:
+ax_pose 44, 0x01e6, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose145:
+ax_pose 43, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose146:
+ax_pose 42, 0x01e2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose147:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose148:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose149:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose150:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose151:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose152:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose153:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose154:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose155:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose156:
+ax_pose 3, 0x41f1, 0x80f7, 0x1c00
+ax_pose_terminator
+sSwinubPose157:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose158:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose159:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose160:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose161:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose162:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose163:
+ax_pose 15, 0x01f2, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose164:
+ax_pose 16, 0x01f4, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose165:
+ax_pose 17, 0x41f3, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose166:
+ax_pose 18, 0x01f3, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose167:
+ax_pose 19, 0x01f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose168:
+ax_pose 18, 0x01f3, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose169:
+ax_pose 17, 0x41f3, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose170:
+ax_pose 16, 0x01f4, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose171:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose172:
+ax_pose 1, 0x41f2, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose173:
+ax_pose 2, 0x41f4, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose174:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose175:
+ax_pose 4, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose176:
+ax_pose 5, 0x41f3, 0x90ea, 0x1c00
+ax_pose_terminator
+sSwinubPose177:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose178:
+ax_pose 7, 0x41f1, 0x90ee, 0x1c00
+ax_pose_terminator
+sSwinubPose179:
+ax_pose 8, 0x41f1, 0x90ec, 0x1c00
+ax_pose_terminator
+sSwinubPose180:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose181:
+ax_pose 10, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose182:
+ax_pose 11, 0x41f1, 0x90ec, 0x1c00
+ax_pose_terminator
+sSwinubPose183:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose184:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose185:
+ax_pose 14, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose186:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose187:
+ax_pose 10, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose188:
+ax_pose 11, 0x41f1, 0x80f5, 0x1c00
+ax_pose_terminator
+sSwinubPose189:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose190:
+ax_pose 7, 0x41f1, 0x80f3, 0x1c00
+ax_pose_terminator
+sSwinubPose191:
+ax_pose 8, 0x41f1, 0x80f5, 0x1c00
+ax_pose_terminator
+sSwinubPose192:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose193:
+ax_pose 4, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose194:
+ax_pose 5, 0x41f3, 0x80f7, 0x1c00
+ax_pose_terminator
+sSwinubPose195:
+ax_pose 30, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose196:
+ax_pose 32, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose197:
+ax_pose 34, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose198:
+ax_pose 36, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose199:
+ax_pose 38, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose200:
+ax_pose 36, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose201:
+ax_pose 34, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose202:
+ax_pose 31, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose203:
+ax_pose 29, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose204:
+ax_pose 31, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose205:
+ax_pose 33, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose206:
+ax_pose 35, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose207:
+ax_pose 37, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose208:
+ax_pose 35, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose209:
+ax_pose 33, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose210:
+ax_pose 32, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+sSwinubPose211:
+ax_pose 0, 0x41f3, 0x80f8, 0x1c00
+ax_pose_terminator
+sSwinubPose212:
+ax_pose 3, 0x41f2, 0x80f6, 0x1c00
+ax_pose_terminator
+sSwinubPose213:
+ax_pose 6, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose214:
+ax_pose 9, 0x41f1, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose215:
+ax_pose 12, 0x41f2, 0x80f4, 0x1c00
+ax_pose_terminator
+sSwinubPose216:
+ax_pose 9, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose217:
+ax_pose 6, 0x41f1, 0x90ed, 0x1c00
+ax_pose_terminator
+sSwinubPose218:
+ax_pose 3, 0x41f2, 0x90eb, 0x1c00
+ax_pose_terminator
+.align 2
+sSwinubAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 1, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 1, -1, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 16, -1, -1, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 19, -1, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwinubAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 1, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sSwinubAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 4, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 1, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sSwinubAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 33, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 0, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sSwinubAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -6, 4, -6,
+ax_anim 1, 0, 39, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 20, -23, 18, -23,
+ax_anim 2, 1, 39, 21, -22, 19, -22,
+ax_anim 2, 0, 39, 20, -23, 18, -23,
+ax_anim 2, 0, 39, 21, -22, 19, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sSwinubAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 41, 0, 4, 0, 4,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -4, 0, -4,
+ax_anim 1, 0, 43, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -25, 0, -25,
+ax_anim 2, 1, 43, 1, -25, 1, -25,
+ax_anim 2, 0, 43, 0, -25, 0, -25,
+ax_anim 2, 0, 43, 1, -25, 1, -25,
+ax_anim 2, 0, 40, 0, -8, 0, -8,
+ax_anim_terminator
+sSwinubAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 45, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -6, -4, -6,
+ax_anim 1, 0, 47, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -20, -23, -18, -23,
+ax_anim 2, 1, 47, -21, -22, -19, -22,
+ax_anim 2, 0, 47, -20, -23, -18, -23,
+ax_anim 2, 0, 47, -21, -22, -19, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sSwinubAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 49, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sSwinubAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 53, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -4, 4, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 1, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSwinubAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 6, 0, 57, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 1, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sSwinubAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 6, 0, 61, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 1, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 63, 19, 19, 19, 19,
+ax_anim 2, 0, 63, 20, 18, 20, 18,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sSwinubAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 6, 0, 65, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 0, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 1, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 0, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sSwinubAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 6, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 71, 4, -6, 4, -6,
+ax_anim 1, 0, 71, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 20, -23, 18, -23,
+ax_anim 2, 1, 71, 21, -22, 19, -22,
+ax_anim 2, 0, 71, 20, -23, 18, -23,
+ax_anim 2, 0, 71, 21, -22, 19, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sSwinubAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 73, 0, 4, 0, 4,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -4, 0, -4,
+ax_anim 1, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -25, 0, -25,
+ax_anim 2, 1, 75, 1, -25, 1, -25,
+ax_anim 2, 0, 75, 0, -25, 0, -25,
+ax_anim 2, 0, 75, 1, -25, 1, -25,
+ax_anim 2, 0, 72, 0, -8, 0, -8,
+ax_anim_terminator
+sSwinubAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 6, 0, 77, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 79, -4, -6, -4, -6,
+ax_anim 1, 0, 79, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -20, -23, -18, -23,
+ax_anim 2, 1, 79, -21, -22, -19, -22,
+ax_anim 2, 0, 79, -20, -23, -18, -23,
+ax_anim 2, 0, 79, -21, -22, -19, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sSwinubAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 6, 0, 81, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 0, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 1, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 0, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sSwinubAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 6, 0, 85, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -4, 4, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 1, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sSwinubAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sSwinubAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sSwinubAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sSwinubAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sSwinubAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sSwinubAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sSwinubAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sSwinubAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sSwinubAnims_5_1:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_5_2:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_5_3:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 6, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_5_4:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 6, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_5_5:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 6, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_5_6:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 6, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_5_7:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 6, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 1, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_5_8:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 6, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwinubAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwinubAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sSwinubAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sSwinubAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sSwinubAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sSwinubAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sSwinubAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sSwinubAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sSwinubAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sSwinubAnims_8_1:
+ax_anim 36, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 1, 0, 1, 0,
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 1, 0, 1, 0,
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim 6, 0, 146, 1, 0, 1, 0,
+ax_anim_terminator
+sSwinubAnims_8_2:
+ax_anim 36, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 153, -1, 1, -1, 1,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 153, -1, 1, -1, 1,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 153, -1, 1, -1, 1,
+ax_anim_terminator
+sSwinubAnims_8_3:
+ax_anim 36, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, -1,
+ax_anim 6, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, -1,
+ax_anim 6, 0, 152, 0, 0, 0, 0,
+ax_anim 6, 0, 152, 0, -1, 0, -1,
+ax_anim_terminator
+sSwinubAnims_8_4:
+ax_anim 36, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 151, -1, -1, -1, -1,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 151, -1, -1, -1, -1,
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 151, -1, -1, -1, -1,
+ax_anim_terminator
+sSwinubAnims_8_5:
+ax_anim 36, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 150, -1, 0, -1, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 150, -1, 0, -1, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 150, -1, 0, -1, 0,
+ax_anim_terminator
+sSwinubAnims_8_6:
+ax_anim 36, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, -1, 1, -1, 1,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, -1, 1, -1, 1,
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 6, 0, 149, -1, 1, -1, 1,
+ax_anim_terminator
+sSwinubAnims_8_7:
+ax_anim 36, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 1, 0, 1,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 1, 0, 1,
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 148, 0, 1, 0, 1,
+ax_anim_terminator
+sSwinubAnims_8_8:
+ax_anim 36, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 1, 1, 1, 1,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 1, 1, 1, 1,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sSwinubAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 17, 7, 17,
+ax_anim 3, 0, 158, 0, 21, 0, 18,
+ax_anim 2, 3, 159, -7, 17, -7, 17,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 20, 13, 20, 13,
+ax_anim 3, 0, 157, 20, 21, 20, 21,
+ax_anim 2, 3, 158, 13, 21, 13, 21,
+ax_anim 2, 0, 159, 5, 17, 5, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -3, 16, -3,
+ax_anim 3, 0, 156, 20, 0, 20, 0,
+ax_anim 2, 3, 157, 16, 4, 16, 4,
+ax_anim 2, 0, 158, 12, 5, 12, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 3, -17, 3, -17,
+ax_anim 2, 0, 154, 12, -24, 12, -24,
+ax_anim 3, 0, 155, 20, -22, 20, -22,
+ax_anim 2, 3, 156, 21, -15, 21, -15,
+ax_anim 2, 0, 157, 17, -4, 17, -4,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -19, -7, -19,
+ax_anim 3, 0, 154, 0, -23, 0, -23,
+ax_anim 2, 3, 155, 7, -19, 7, -19,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -6,
+ax_anim 2, 0, 155, -3, -17, -4, -16,
+ax_anim 2, 0, 154, -12, -24, -12, -22,
+ax_anim 3, 0, 161, -20, -22, -18, -22,
+ax_anim 2, 3, 160, -21, -15, -20, -15,
+ax_anim 2, 0, 159, -17, -4, -17, -4,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -3, -16, -5,
+ax_anim 3, 0, 160, -20, 0, -18, -2,
+ax_anim 2, 3, 159, -16, 4, -16, 4,
+ax_anim 2, 0, 158, -12, 5, -12, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -20, 13, -19, 10,
+ax_anim 3, 0, 159, -20, 21, -17, 19,
+ax_anim 2, 3, 158, -13, 21, -11, 19,
+ax_anim 2, 0, 157, -5, 17, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwinubAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwinubAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwinubAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sSwinubAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sSwinubGfx1:
+.incbin "baserom.gba", 0xEEF4D0, 0x100
+sSwinubSprites1:
+ax_sprite sSwinubGfx1, 0x100
+ax_sprite_terminator
+sSwinubGfx2:
+.incbin "baserom.gba", 0xEEF5E0, 0x100
+sSwinubSprites2:
+ax_sprite sSwinubGfx2, 0x100
+ax_sprite_terminator
+sSwinubGfx3:
+.incbin "baserom.gba", 0xEEF6F0, 0x100
+sSwinubSprites3:
+ax_sprite sSwinubGfx3, 0x100
+ax_sprite_terminator
+sSwinubGfx4:
+.incbin "baserom.gba", 0xEEF800, 0x100
+sSwinubSprites4:
+ax_sprite sSwinubGfx4, 0x100
+ax_sprite_terminator
+sSwinubGfx5:
+.incbin "baserom.gba", 0xEEF910, 0x100
+sSwinubSprites5:
+ax_sprite sSwinubGfx5, 0x100
+ax_sprite_terminator
+sSwinubGfx6:
+.incbin "baserom.gba", 0xEEFA20, 0x100
+sSwinubSprites6:
+ax_sprite sSwinubGfx6, 0x100
+ax_sprite_terminator
+sSwinubGfx7:
+.incbin "baserom.gba", 0xEEFB30, 0x100
+sSwinubSprites7:
+ax_sprite sSwinubGfx7, 0x100
+ax_sprite_terminator
+sSwinubGfx8:
+.incbin "baserom.gba", 0xEEFC40, 0x100
+sSwinubSprites8:
+ax_sprite sSwinubGfx8, 0x100
+ax_sprite_terminator
+sSwinubGfx9:
+.incbin "baserom.gba", 0xEEFD50, 0x100
+sSwinubSprites9:
+ax_sprite sSwinubGfx9, 0x100
+ax_sprite_terminator
+sSwinubGfx10:
+.incbin "baserom.gba", 0xEEFE60, 0x100
+sSwinubSprites10:
+ax_sprite sSwinubGfx10, 0x100
+ax_sprite_terminator
+sSwinubGfx11:
+.incbin "baserom.gba", 0xEEFF70, 0x100
+sSwinubSprites11:
+ax_sprite sSwinubGfx11, 0x100
+ax_sprite_terminator
+sSwinubGfx12:
+.incbin "baserom.gba", 0xEF0080, 0x100
+sSwinubSprites12:
+ax_sprite sSwinubGfx12, 0x100
+ax_sprite_terminator
+sSwinubGfx13:
+.incbin "baserom.gba", 0xEF0190, 0x100
+sSwinubSprites13:
+ax_sprite sSwinubGfx13, 0x100
+ax_sprite_terminator
+sSwinubGfx14:
+.incbin "baserom.gba", 0xEF02A0, 0x200
+sSwinubSprites14:
+ax_sprite sSwinubGfx14, 0x200
+ax_sprite_terminator
+sSwinubGfx15:
+.incbin "baserom.gba", 0xEF04B0, 0x100
+sSwinubSprites15:
+ax_sprite sSwinubGfx15, 0x100
+ax_sprite_terminator
+sSwinubGfx16:
+.incbin "baserom.gba", 0xEF05C0, 0x40
+sSwinubGfx16_1:
+.incbin "baserom.gba", 0xEF0600, 0x60
+sSwinubGfx16_2:
+.incbin "baserom.gba", 0xEF0660, 0x40
+sSwinubSprites16:
+ax_sprite sSwinubGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sSwinubGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx16_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSwinubGfx17:
+.incbin "baserom.gba", 0xEF06D8, 0x60
+sSwinubGfx17_1:
+.incbin "baserom.gba", 0xEF0738, 0x60
+sSwinubGfx17_2:
+.incbin "baserom.gba", 0xEF0798, 0x40
+sSwinubSprites17:
+ax_sprite sSwinubGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx17_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sSwinubGfx18:
+.incbin "baserom.gba", 0xEF0810, 0x60
+sSwinubGfx18_1:
+.incbin "baserom.gba", 0xEF0870, 0x80
+sSwinubSprites18:
+ax_sprite sSwinubGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx18_1, 0x80
+ax_sprite_terminator
+sSwinubGfx19:
+.incbin "baserom.gba", 0xEF0910, 0x60
+sSwinubGfx19_1:
+.incbin "baserom.gba", 0xEF0970, 0x60
+sSwinubGfx19_2:
+.incbin "baserom.gba", 0xEF09D0, 0x40
+sSwinubSprites19:
+ax_sprite sSwinubGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sSwinubGfx19_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSwinubGfx20:
+.incbin "baserom.gba", 0xEF0A48, 0x60
+sSwinubGfx20_1:
+.incbin "baserom.gba", 0xEF0AA8, 0x60
+sSwinubGfx20_2:
+.incbin "baserom.gba", 0xEF0B08, 0x60
+sSwinubSprites20:
+ax_sprite sSwinubGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sSwinubGfx21:
+.incbin "baserom.gba", 0xEF0BA0, 0x60
+sSwinubGfx21_1:
+.incbin "baserom.gba", 0xEF0C00, 0x60
+sSwinubSprites21:
+ax_sprite sSwinubGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx22:
+.incbin "baserom.gba", 0xEF0C88, 0x60
+sSwinubGfx22_1:
+.incbin "baserom.gba", 0xEF0CE8, 0x60
+sSwinubSprites22:
+ax_sprite sSwinubGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx23:
+.incbin "baserom.gba", 0xEF0D70, 0x60
+sSwinubGfx23_1:
+.incbin "baserom.gba", 0xEF0DD0, 0x60
+sSwinubSprites23:
+ax_sprite sSwinubGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx24:
+.incbin "baserom.gba", 0xEF0E58, 0x60
+sSwinubGfx24_1:
+.incbin "baserom.gba", 0xEF0EB8, 0x60
+sSwinubSprites24:
+ax_sprite sSwinubGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx25:
+.incbin "baserom.gba", 0xEF0F40, 0x60
+sSwinubGfx25_1:
+.incbin "baserom.gba", 0xEF0FA0, 0x60
+sSwinubSprites25:
+ax_sprite sSwinubGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx26:
+.incbin "baserom.gba", 0xEF1028, 0x60
+sSwinubGfx26_1:
+.incbin "baserom.gba", 0xEF1088, 0x60
+sSwinubSprites26:
+ax_sprite sSwinubGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx27:
+.incbin "baserom.gba", 0xEF1110, 0x60
+sSwinubGfx27_1:
+.incbin "baserom.gba", 0xEF1170, 0x60
+sSwinubSprites27:
+ax_sprite sSwinubGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx28:
+.incbin "baserom.gba", 0xEF11F8, 0x60
+sSwinubGfx28_1:
+.incbin "baserom.gba", 0xEF1258, 0x60
+sSwinubSprites28:
+ax_sprite sSwinubGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx29:
+.incbin "baserom.gba", 0xEF12E0, 0x60
+sSwinubGfx29_1:
+.incbin "baserom.gba", 0xEF1340, 0x60
+sSwinubSprites29:
+ax_sprite sSwinubGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx30:
+.incbin "baserom.gba", 0xEF13C8, 0x60
+sSwinubGfx30_1:
+.incbin "baserom.gba", 0xEF1428, 0x60
+sSwinubSprites30:
+ax_sprite sSwinubGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx31:
+.incbin "baserom.gba", 0xEF14B0, 0x60
+sSwinubGfx31_1:
+.incbin "baserom.gba", 0xEF1510, 0x60
+sSwinubSprites31:
+ax_sprite sSwinubGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx32:
+.incbin "baserom.gba", 0xEF1598, 0x60
+sSwinubGfx32_1:
+.incbin "baserom.gba", 0xEF15F8, 0x60
+sSwinubSprites32:
+ax_sprite sSwinubGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx33:
+.incbin "baserom.gba", 0xEF1680, 0x60
+sSwinubGfx33_1:
+.incbin "baserom.gba", 0xEF16E0, 0x60
+sSwinubSprites33:
+ax_sprite sSwinubGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx34:
+.incbin "baserom.gba", 0xEF1768, 0x60
+sSwinubGfx34_1:
+.incbin "baserom.gba", 0xEF17C8, 0x60
+sSwinubSprites34:
+ax_sprite sSwinubGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx35:
+.incbin "baserom.gba", 0xEF1850, 0x60
+sSwinubGfx35_1:
+.incbin "baserom.gba", 0xEF18B0, 0x60
+sSwinubSprites35:
+ax_sprite sSwinubGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx36:
+.incbin "baserom.gba", 0xEF1938, 0x60
+sSwinubGfx36_1:
+.incbin "baserom.gba", 0xEF1998, 0x60
+sSwinubSprites36:
+ax_sprite sSwinubGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx37:
+.incbin "baserom.gba", 0xEF1A20, 0x60
+sSwinubGfx37_1:
+.incbin "baserom.gba", 0xEF1A80, 0x60
+sSwinubSprites37:
+ax_sprite sSwinubGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx38:
+.incbin "baserom.gba", 0xEF1B08, 0x60
+sSwinubGfx38_1:
+.incbin "baserom.gba", 0xEF1B68, 0x60
+sSwinubSprites38:
+ax_sprite sSwinubGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx39:
+.incbin "baserom.gba", 0xEF1BF0, 0x60
+sSwinubGfx39_1:
+.incbin "baserom.gba", 0xEF1C50, 0x60
+sSwinubSprites39:
+ax_sprite sSwinubGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sSwinubGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sSwinubGfx40:
+.incbin "baserom.gba", 0xEF1CD8, 0x100
+sSwinubSprites40:
+ax_sprite sSwinubGfx40, 0x100
+ax_sprite_terminator
+sSwinubGfx41:
+.incbin "baserom.gba", 0xEF1DE8, 0x100
+sSwinubSprites41:
+ax_sprite sSwinubGfx41, 0x100
+ax_sprite_terminator
+sSwinubGfx42:
+.incbin "baserom.gba", 0xEF1EF8, 0x200
+sSwinubSprites42:
+ax_sprite sSwinubGfx42, 0x200
+ax_sprite_terminator
+sSwinubGfx43:
+.incbin "baserom.gba", 0xEF2108, 0x200
+sSwinubSprites43:
+ax_sprite sSwinubGfx43, 0x200
+ax_sprite_terminator
+sSwinubGfx44:
+.incbin "baserom.gba", 0xEF2318, 0x200
+sSwinubSprites44:
+ax_sprite sSwinubGfx44, 0x200
+ax_sprite_terminator
+sSwinubGfx45:
+.incbin "baserom.gba", 0xEF2528, 0x200
+sSwinubSprites45:
+ax_sprite sSwinubGfx45, 0x200
+ax_sprite_terminator
+sSwinubGfx46:
+.incbin "baserom.gba", 0xEF2738, 0x200
+sSwinubSprites46:
+ax_sprite sSwinubGfx46, 0x200
+ax_sprite_terminator
+sAxPosesSwinub:
+.4byte sSwinubPose1
+.4byte sSwinubPose2
+.4byte sSwinubPose3
+.4byte sSwinubPose4
+.4byte sSwinubPose5
+.4byte sSwinubPose6
+.4byte sSwinubPose7
+.4byte sSwinubPose8
+.4byte sSwinubPose9
+.4byte sSwinubPose10
+.4byte sSwinubPose11
+.4byte sSwinubPose12
+.4byte sSwinubPose13
+.4byte sSwinubPose14
+.4byte sSwinubPose15
+.4byte sSwinubPose16
+.4byte sSwinubPose17
+.4byte sSwinubPose18
+.4byte sSwinubPose19
+.4byte sSwinubPose20
+.4byte sSwinubPose21
+.4byte sSwinubPose22
+.4byte sSwinubPose23
+.4byte sSwinubPose24
+.4byte sSwinubPose25
+.4byte sSwinubPose26
+.4byte sSwinubPose27
+.4byte sSwinubPose28
+.4byte sSwinubPose29
+.4byte sSwinubPose30
+.4byte sSwinubPose31
+.4byte sSwinubPose32
+.4byte sSwinubPose33
+.4byte sSwinubPose34
+.4byte sSwinubPose35
+.4byte sSwinubPose36
+.4byte sSwinubPose37
+.4byte sSwinubPose38
+.4byte sSwinubPose39
+.4byte sSwinubPose40
+.4byte sSwinubPose41
+.4byte sSwinubPose42
+.4byte sSwinubPose43
+.4byte sSwinubPose44
+.4byte sSwinubPose45
+.4byte sSwinubPose46
+.4byte sSwinubPose47
+.4byte sSwinubPose48
+.4byte sSwinubPose49
+.4byte sSwinubPose50
+.4byte sSwinubPose51
+.4byte sSwinubPose52
+.4byte sSwinubPose53
+.4byte sSwinubPose54
+.4byte sSwinubPose55
+.4byte sSwinubPose56
+.4byte sSwinubPose57
+.4byte sSwinubPose58
+.4byte sSwinubPose59
+.4byte sSwinubPose60
+.4byte sSwinubPose61
+.4byte sSwinubPose62
+.4byte sSwinubPose63
+.4byte sSwinubPose64
+.4byte sSwinubPose65
+.4byte sSwinubPose66
+.4byte sSwinubPose67
+.4byte sSwinubPose68
+.4byte sSwinubPose69
+.4byte sSwinubPose70
+.4byte sSwinubPose71
+.4byte sSwinubPose72
+.4byte sSwinubPose73
+.4byte sSwinubPose74
+.4byte sSwinubPose75
+.4byte sSwinubPose76
+.4byte sSwinubPose77
+.4byte sSwinubPose78
+.4byte sSwinubPose79
+.4byte sSwinubPose80
+.4byte sSwinubPose81
+.4byte sSwinubPose82
+.4byte sSwinubPose83
+.4byte sSwinubPose84
+.4byte sSwinubPose85
+.4byte sSwinubPose86
+.4byte sSwinubPose87
+.4byte sSwinubPose88
+.4byte sSwinubPose89
+.4byte sSwinubPose90
+.4byte sSwinubPose91
+.4byte sSwinubPose92
+.4byte sSwinubPose93
+.4byte sSwinubPose94
+.4byte sSwinubPose95
+.4byte sSwinubPose96
+.4byte sSwinubPose97
+.4byte sSwinubPose98
+.4byte sSwinubPose99
+.4byte sSwinubPose100
+.4byte sSwinubPose101
+.4byte sSwinubPose102
+.4byte sSwinubPose103
+.4byte sSwinubPose104
+.4byte sSwinubPose105
+.4byte sSwinubPose106
+.4byte sSwinubPose107
+.4byte sSwinubPose108
+.4byte sSwinubPose109
+.4byte sSwinubPose110
+.4byte sSwinubPose111
+.4byte sSwinubPose112
+.4byte sSwinubPose113
+.4byte sSwinubPose114
+.4byte sSwinubPose115
+.4byte sSwinubPose116
+.4byte sSwinubPose117
+.4byte sSwinubPose118
+.4byte sSwinubPose119
+.4byte sSwinubPose120
+.4byte sSwinubPose121
+.4byte sSwinubPose122
+.4byte sSwinubPose123
+.4byte sSwinubPose124
+.4byte sSwinubPose125
+.4byte sSwinubPose126
+.4byte sSwinubPose127
+.4byte sSwinubPose128
+.4byte sSwinubPose129
+.4byte sSwinubPose130
+.4byte sSwinubPose131
+.4byte sSwinubPose132
+.4byte sSwinubPose133
+.4byte sSwinubPose134
+.4byte sSwinubPose135
+.4byte sSwinubPose136
+.4byte sSwinubPose137
+.4byte sSwinubPose138
+.4byte sSwinubPose139
+.4byte sSwinubPose140
+.4byte sSwinubPose141
+.4byte sSwinubPose142
+.4byte sSwinubPose143
+.4byte sSwinubPose144
+.4byte sSwinubPose145
+.4byte sSwinubPose146
+.4byte sSwinubPose147
+.4byte sSwinubPose148
+.4byte sSwinubPose149
+.4byte sSwinubPose150
+.4byte sSwinubPose151
+.4byte sSwinubPose152
+.4byte sSwinubPose153
+.4byte sSwinubPose154
+.4byte sSwinubPose155
+.4byte sSwinubPose156
+.4byte sSwinubPose157
+.4byte sSwinubPose158
+.4byte sSwinubPose159
+.4byte sSwinubPose160
+.4byte sSwinubPose161
+.4byte sSwinubPose162
+.4byte sSwinubPose163
+.4byte sSwinubPose164
+.4byte sSwinubPose165
+.4byte sSwinubPose166
+.4byte sSwinubPose167
+.4byte sSwinubPose168
+.4byte sSwinubPose169
+.4byte sSwinubPose170
+.4byte sSwinubPose171
+.4byte sSwinubPose172
+.4byte sSwinubPose173
+.4byte sSwinubPose174
+.4byte sSwinubPose175
+.4byte sSwinubPose176
+.4byte sSwinubPose177
+.4byte sSwinubPose178
+.4byte sSwinubPose179
+.4byte sSwinubPose180
+.4byte sSwinubPose181
+.4byte sSwinubPose182
+.4byte sSwinubPose183
+.4byte sSwinubPose184
+.4byte sSwinubPose185
+.4byte sSwinubPose186
+.4byte sSwinubPose187
+.4byte sSwinubPose188
+.4byte sSwinubPose189
+.4byte sSwinubPose190
+.4byte sSwinubPose191
+.4byte sSwinubPose192
+.4byte sSwinubPose193
+.4byte sSwinubPose194
+.4byte sSwinubPose195
+.4byte sSwinubPose196
+.4byte sSwinubPose197
+.4byte sSwinubPose198
+.4byte sSwinubPose199
+.4byte sSwinubPose200
+.4byte sSwinubPose201
+.4byte sSwinubPose202
+.4byte sSwinubPose203
+.4byte sSwinubPose204
+.4byte sSwinubPose205
+.4byte sSwinubPose206
+.4byte sSwinubPose207
+.4byte sSwinubPose208
+.4byte sSwinubPose209
+.4byte sSwinubPose210
+.4byte sSwinubPose211
+.4byte sSwinubPose212
+.4byte sSwinubPose213
+.4byte sSwinubPose214
+.4byte sSwinubPose215
+.4byte sSwinubPose216
+.4byte sSwinubPose217
+.4byte sSwinubPose218
+sAxPositionsSwinub:
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,   -1, 	  -5,   -2, 	   6,   -2, 	   0,   -8
+.2byte    0,    2, 	  -6,   -1, 	   6,   -1, 	   0,   -6
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    6,   -3, 	   7,   -7, 	   0,   -1, 	   0,   -7
+.2byte    8,    0, 	   8,   -5, 	  -1,   -1, 	   2,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    8,   -5, 	   3,   -7, 	   2,   -2, 	  -2,   -7
+.2byte   10,   -2, 	   4,   -7, 	   4,   -1, 	   1,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    2,  -10, 	  -5,   -9, 	   5,   -5, 	  -1,   -7
+.2byte    5,   -8, 	  -3,   -7, 	   6,   -3, 	   1,   -6
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   7,   -8, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -7, 	   6,   -5, 	  -6,   -5, 	   0,   -6
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte   -2,  -10, 	   5,   -9, 	  -5,   -5, 	   1,   -7
+.2byte   -5,   -8, 	   3,   -7, 	  -6,   -3, 	  -1,   -6
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -8,   -5, 	  -3,   -7, 	  -2,   -2, 	   2,   -7
+.2byte  -10,   -2, 	  -4,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -6,   -3, 	  -7,   -7, 	   0,   -1, 	   0,   -7
+.2byte   -8,    0, 	  -8,   -5, 	   1,   -1, 	  -2,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,   -1, 	  -5,   -2, 	   6,   -2, 	   0,   -8
+.2byte    0,    2, 	  -6,   -1, 	   6,   -1, 	   0,   -6
+.2byte    0,    5, 	  -7,   -2, 	   7,   -2, 	   0,   -4
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    6,   -3, 	   7,   -7, 	   0,   -1, 	   0,   -7
+.2byte    8,    0, 	   8,   -5, 	  -1,   -1, 	   2,   -6
+.2byte    8,    0, 	   8,   -6, 	  -1,   -1, 	   1,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    8,   -5, 	   3,   -7, 	   2,   -2, 	  -2,   -7
+.2byte   10,   -2, 	   4,   -7, 	   4,   -1, 	   1,   -6
+.2byte   10,   -2, 	   4,   -7, 	   3,   -1, 	  -1,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    2,  -10, 	  -5,   -9, 	   5,   -5, 	  -1,   -7
+.2byte    5,   -8, 	  -3,   -7, 	   6,   -3, 	   1,   -6
+.2byte    4,  -10, 	  -4,   -9, 	   7,   -5, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   7,   -8, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -7, 	   6,   -5, 	  -6,   -5, 	   0,   -6
+.2byte    0,   -8, 	   7,   -4, 	  -7,   -4, 	   0,   -4
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte   -2,  -10, 	   5,   -9, 	  -5,   -5, 	   1,   -7
+.2byte   -5,   -8, 	   3,   -7, 	  -6,   -3, 	  -1,   -6
+.2byte   -4,  -10, 	   4,   -9, 	  -7,   -5, 	   0,   -7
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -8,   -5, 	  -3,   -7, 	  -2,   -2, 	   2,   -7
+.2byte  -10,   -2, 	  -4,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte  -10,   -2, 	  -4,   -7, 	  -3,   -1, 	   1,   -6
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -6,   -3, 	  -7,   -7, 	   0,   -1, 	   0,   -7
+.2byte   -8,    0, 	  -8,   -5, 	   1,   -1, 	  -2,   -6
+.2byte   -8,    0, 	  -8,   -6, 	   1,   -1, 	  -1,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,   -1, 	  -5,   -2, 	   6,   -2, 	   0,   -8
+.2byte    0,    2, 	  -6,   -1, 	   6,   -1, 	   0,   -6
+.2byte    0,    5, 	  -7,   -2, 	   7,   -2, 	   0,   -4
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    6,   -3, 	   7,   -7, 	   0,   -1, 	   0,   -7
+.2byte    8,    0, 	   8,   -5, 	  -1,   -1, 	   2,   -6
+.2byte    8,    0, 	   8,   -6, 	  -1,   -1, 	   1,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    8,   -5, 	   3,   -7, 	   2,   -2, 	  -2,   -7
+.2byte   10,   -2, 	   4,   -7, 	   4,   -1, 	   1,   -6
+.2byte   10,   -2, 	   4,   -7, 	   3,   -1, 	  -1,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    2,  -10, 	  -5,   -9, 	   5,   -5, 	  -1,   -7
+.2byte    5,   -8, 	  -3,   -7, 	   6,   -3, 	   1,   -6
+.2byte    4,  -10, 	  -4,   -9, 	   7,   -5, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   7,   -8, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -7, 	   6,   -5, 	  -6,   -5, 	   0,   -6
+.2byte    0,   -8, 	   7,   -4, 	  -7,   -4, 	   0,   -4
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte   -2,  -10, 	   5,   -9, 	  -5,   -5, 	   1,   -7
+.2byte   -5,   -8, 	   3,   -7, 	  -6,   -3, 	  -1,   -6
+.2byte   -4,  -10, 	   4,   -9, 	  -7,   -5, 	   0,   -7
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -8,   -5, 	  -3,   -7, 	  -2,   -2, 	   2,   -7
+.2byte  -10,   -2, 	  -4,   -7, 	  -4,   -1, 	  -1,   -6
+.2byte  -10,   -2, 	  -4,   -7, 	  -3,   -1, 	   1,   -6
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -6,   -3, 	  -7,   -7, 	   0,   -1, 	   0,   -7
+.2byte   -8,    0, 	  -8,   -5, 	   1,   -1, 	  -2,   -6
+.2byte   -8,    0, 	  -8,   -6, 	   1,   -1, 	  -1,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,    1, 	  -6,   -4, 	   6,   -4, 	   1,   -6
+.2byte    0,    0, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    6,    0, 	   8,   -5, 	  -2,   -1, 	   1,   -6
+.2byte    8,    0, 	   8,   -4, 	  -1,   -1, 	   1,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    6,   -2, 	   3,   -7, 	   0,   -1, 	  -1,   -6
+.2byte   10,   -4, 	   3,   -7, 	   3,   -1, 	   0,   -5
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    3,  -10, 	  -3,   -9, 	   5,   -5, 	  -1,   -7
+.2byte    4,  -10, 	  -4,   -9, 	   7,   -5, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   6,   -6, 	  -7,   -6, 	   0,   -6
+.2byte    0,   -7, 	   7,   -4, 	  -7,   -4, 	   0,   -5
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte   -3,  -10, 	   3,   -9, 	  -5,   -5, 	   1,   -7
+.2byte   -4,  -10, 	   4,   -9, 	  -7,   -5, 	   0,   -7
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -6,   -2, 	  -3,   -7, 	   0,   -1, 	   1,   -6
+.2byte  -10,   -4, 	  -3,   -7, 	  -3,   -1, 	   0,   -5
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -6,    0, 	  -8,   -5, 	   2,   -1, 	  -1,   -6
+.2byte   -8,    0, 	  -8,   -4, 	   1,   -1, 	  -1,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,    1, 	  -7,   -5, 	   7,   -4, 	   0,   -5
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    7,    0, 	   8,   -5, 	   0,   -1, 	   1,   -6
+.2byte    7,   -1, 	   7,   -7, 	  -2,   -1, 	   1,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    9,   -4, 	   4,   -7, 	   3,   -2, 	   0,   -6
+.2byte    9,   -2, 	   5,   -8, 	   3,   -1, 	   0,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    3,   -9, 	  -3,   -9, 	   6,   -5, 	   0,   -7
+.2byte    4,  -10, 	  -4,  -10, 	   6,   -6, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   7,   -5, 	  -7,   -5, 	   1,   -6
+.2byte    2,   -9, 	   7,   -5, 	  -6,   -6, 	   0,   -6
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte   -3,   -9, 	   3,   -9, 	  -6,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   4,  -10, 	  -6,   -6, 	   0,   -7
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -9,   -4, 	  -4,   -7, 	  -3,   -2, 	   0,   -6
+.2byte   -9,   -2, 	  -5,   -8, 	  -3,   -1, 	   0,   -6
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -7,    0, 	  -8,   -5, 	   0,   -1, 	  -1,   -6
+.2byte   -7,   -1, 	  -7,   -7, 	   2,   -1, 	  -1,   -6
+.2byte   -8,    1, 	  -8,   -5, 	   1,    0, 	  -2,   -4
+.2byte   -8,    2, 	  -8,   -3, 	   0,    2, 	  -2,   -3
+.2byte   -1,   -7, 	  -7,   -8, 	   5,   -8, 	  -1,  -12
+.2byte    5,   -6, 	   4,  -11, 	  -2,   -5, 	  -2,  -10
+.2byte    7,   -5, 	   1,  -10, 	   0,   -3, 	  -2,   -7
+.2byte    2,  -11, 	  -4,  -10, 	   3,   -7, 	  -3,   -8
+.2byte   -1,  -10, 	   6,   -8, 	  -8,   -8, 	  -1,   -7
+.2byte   -3,  -11, 	   3,  -10, 	  -4,   -7, 	   2,   -8
+.2byte   -8,   -5, 	  -2,  -10, 	  -1,   -3, 	   1,   -7
+.2byte   -6,   -6, 	  -5,  -11, 	   1,   -5, 	   1,  -10
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte   -6,   -2, 	  -6,   -7, 	   3,   -2, 	   0,   -7
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    0,    5, 	  -7,   -2, 	   7,   -2, 	   0,   -4
+.2byte    8,    2, 	   8,   -4, 	  -1,    1, 	   1,   -4
+.2byte   10,    0, 	   4,   -5, 	   3,    1, 	  -1,   -4
+.2byte    4,   -8, 	  -4,   -7, 	   7,   -3, 	   0,   -5
+.2byte    0,   -8, 	   7,   -4, 	  -7,   -4, 	   0,   -4
+.2byte   -4,   -8, 	   4,   -7, 	  -7,   -3, 	   0,   -5
+.2byte  -10,    0, 	  -4,   -5, 	  -3,    1, 	   1,   -4
+.2byte   -8,    2, 	  -8,   -4, 	   1,    1, 	  -1,   -4
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte    0,   -1, 	  -5,   -2, 	   6,   -2, 	   0,   -8
+.2byte    0,    2, 	  -6,   -1, 	   6,   -1, 	   0,   -6
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+.2byte    6,   -3, 	   7,   -7, 	   0,   -1, 	   0,   -7
+.2byte    7,    0, 	   7,   -5, 	  -2,   -1, 	   1,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    9,   -5, 	   4,   -7, 	   3,   -2, 	  -1,   -7
+.2byte    9,   -2, 	   3,   -7, 	   3,   -1, 	   0,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    2,  -10, 	  -5,   -9, 	   5,   -5, 	  -1,   -7
+.2byte    4,   -8, 	  -4,   -7, 	   5,   -3, 	   0,   -6
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    0,   -9, 	   7,   -8, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -7, 	   6,   -5, 	  -6,   -5, 	   0,   -6
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte   -2,  -10, 	   5,   -9, 	  -5,   -5, 	   1,   -7
+.2byte   -4,   -8, 	   4,   -7, 	  -5,   -3, 	   0,   -6
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -9,   -5, 	  -4,   -7, 	  -3,   -2, 	   1,   -7
+.2byte   -9,   -2, 	  -3,   -7, 	  -3,   -1, 	   0,   -6
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -6,   -3, 	  -7,   -7, 	   0,   -1, 	   0,   -7
+.2byte   -7,    0, 	  -7,   -5, 	   2,   -1, 	  -1,   -6
+.2byte    0,    1, 	  -7,   -5, 	   7,   -4, 	   0,   -5
+.2byte   -7,   -1, 	  -7,   -7, 	   2,   -1, 	  -1,   -6
+.2byte   -9,   -2, 	  -5,   -8, 	  -3,   -1, 	   0,   -6
+.2byte   -4,  -10, 	   4,  -10, 	  -6,   -6, 	   0,   -7
+.2byte    2,   -9, 	   7,   -5, 	  -6,   -6, 	   0,   -6
+.2byte    4,  -10, 	  -4,  -10, 	   6,   -6, 	   0,   -7
+.2byte    9,   -2, 	   5,   -8, 	   3,   -1, 	   0,   -6
+.2byte    7,    0, 	   8,   -5, 	   0,   -1, 	   1,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte   -7,    0, 	  -8,   -5, 	   0,   -1, 	  -1,   -6
+.2byte   -9,   -4, 	  -4,   -7, 	  -3,   -2, 	   0,   -6
+.2byte   -3,   -9, 	   3,   -9, 	  -6,   -5, 	   0,   -7
+.2byte    0,   -9, 	   7,   -5, 	  -7,   -5, 	   1,   -6
+.2byte    3,   -9, 	  -3,   -9, 	   6,   -5, 	   0,   -7
+.2byte    9,   -4, 	   4,   -7, 	   3,   -2, 	   0,   -6
+.2byte    7,   -1, 	   7,   -7, 	  -2,   -1, 	   1,   -6
+.2byte    0,    1, 	  -6,   -3, 	   6,   -3, 	   0,   -6
+.2byte   -7,   -1, 	  -7,   -6, 	   2,   -1, 	  -1,   -6
+.2byte   -9,   -3, 	  -4,   -7, 	  -2,   -1, 	   0,   -6
+.2byte   -3,   -9, 	   4,   -9, 	  -5,   -5, 	   0,   -6
+.2byte    0,   -8, 	   6,   -7, 	  -6,   -7, 	   0,   -6
+.2byte    3,   -9, 	  -4,   -9, 	   5,   -5, 	   0,   -6
+.2byte    9,   -3, 	   4,   -7, 	   2,   -1, 	   0,   -6
+.2byte    7,   -1, 	   7,   -6, 	  -2,   -1, 	   1,   -6
+sSwinubAnimTable1:
+.4byte sSwinubAnims_1_1
+.4byte sSwinubAnims_1_2
+.4byte sSwinubAnims_1_3
+.4byte sSwinubAnims_1_4
+.4byte sSwinubAnims_1_5
+.4byte sSwinubAnims_1_6
+.4byte sSwinubAnims_1_7
+.4byte sSwinubAnims_1_8
+sSwinubAnimTable2:
+.4byte sSwinubAnims_2_1
+.4byte sSwinubAnims_2_2
+.4byte sSwinubAnims_2_3
+.4byte sSwinubAnims_2_4
+.4byte sSwinubAnims_2_5
+.4byte sSwinubAnims_2_6
+.4byte sSwinubAnims_2_7
+.4byte sSwinubAnims_2_8
+sSwinubAnimTable3:
+.4byte sSwinubAnims_3_1
+.4byte sSwinubAnims_3_2
+.4byte sSwinubAnims_3_3
+.4byte sSwinubAnims_3_4
+.4byte sSwinubAnims_3_5
+.4byte sSwinubAnims_3_6
+.4byte sSwinubAnims_3_7
+.4byte sSwinubAnims_3_8
+sSwinubAnimTable4:
+.4byte sSwinubAnims_4_1
+.4byte sSwinubAnims_4_2
+.4byte sSwinubAnims_4_3
+.4byte sSwinubAnims_4_4
+.4byte sSwinubAnims_4_5
+.4byte sSwinubAnims_4_6
+.4byte sSwinubAnims_4_7
+.4byte sSwinubAnims_4_8
+sSwinubAnimTable5:
+.4byte sSwinubAnims_5_1
+.4byte sSwinubAnims_5_2
+.4byte sSwinubAnims_5_3
+.4byte sSwinubAnims_5_4
+.4byte sSwinubAnims_5_5
+.4byte sSwinubAnims_5_6
+.4byte sSwinubAnims_5_7
+.4byte sSwinubAnims_5_8
+sSwinubAnimTable6:
+.4byte sSwinubAnims_6_1
+.4byte sSwinubAnims_6_1
+.4byte sSwinubAnims_6_1
+.4byte sSwinubAnims_6_1
+.4byte sSwinubAnims_6_1
+.4byte sSwinubAnims_6_1
+.4byte sSwinubAnims_6_1
+.4byte sSwinubAnims_6_1
+sSwinubAnimTable7:
+.4byte sSwinubAnims_7_1
+.4byte sSwinubAnims_7_2
+.4byte sSwinubAnims_7_3
+.4byte sSwinubAnims_7_4
+.4byte sSwinubAnims_7_5
+.4byte sSwinubAnims_7_6
+.4byte sSwinubAnims_7_7
+.4byte sSwinubAnims_7_8
+sSwinubAnimTable8:
+.4byte sSwinubAnims_8_1
+.4byte sSwinubAnims_8_2
+.4byte sSwinubAnims_8_3
+.4byte sSwinubAnims_8_4
+.4byte sSwinubAnims_8_5
+.4byte sSwinubAnims_8_6
+.4byte sSwinubAnims_8_7
+.4byte sSwinubAnims_8_8
+sSwinubAnimTable9:
+.4byte sSwinubAnims_9_1
+.4byte sSwinubAnims_9_2
+.4byte sSwinubAnims_9_3
+.4byte sSwinubAnims_9_4
+.4byte sSwinubAnims_9_5
+.4byte sSwinubAnims_9_6
+.4byte sSwinubAnims_9_7
+.4byte sSwinubAnims_9_8
+sSwinubAnimTable10:
+.4byte sSwinubAnims_10_1
+.4byte sSwinubAnims_10_2
+.4byte sSwinubAnims_10_3
+.4byte sSwinubAnims_10_4
+.4byte sSwinubAnims_10_5
+.4byte sSwinubAnims_10_6
+.4byte sSwinubAnims_10_7
+.4byte sSwinubAnims_10_8
+sSwinubAnimTable11:
+.4byte sSwinubAnims_11_1
+.4byte sSwinubAnims_11_2
+.4byte sSwinubAnims_11_3
+.4byte sSwinubAnims_11_4
+.4byte sSwinubAnims_11_5
+.4byte sSwinubAnims_11_6
+.4byte sSwinubAnims_11_7
+.4byte sSwinubAnims_11_8
+sSwinubAnimTable12:
+.4byte sSwinubAnims_12_1
+.4byte sSwinubAnims_12_2
+.4byte sSwinubAnims_12_3
+.4byte sSwinubAnims_12_4
+.4byte sSwinubAnims_12_5
+.4byte sSwinubAnims_12_6
+.4byte sSwinubAnims_12_7
+.4byte sSwinubAnims_12_8
+sSwinubAnimTable13:
+.4byte sSwinubAnims_13_1
+.4byte sSwinubAnims_13_2
+.4byte sSwinubAnims_13_3
+.4byte sSwinubAnims_13_4
+.4byte sSwinubAnims_13_5
+.4byte sSwinubAnims_13_6
+.4byte sSwinubAnims_13_7
+.4byte sSwinubAnims_13_8
+sAxAnimationsSwinub:
+.4byte sSwinubAnimTable1
+.4byte sSwinubAnimTable2
+.4byte sSwinubAnimTable3
+.4byte sSwinubAnimTable4
+.4byte sSwinubAnimTable5
+.4byte sSwinubAnimTable6
+.4byte sSwinubAnimTable7
+.4byte sSwinubAnimTable8
+.4byte sSwinubAnimTable9
+.4byte sSwinubAnimTable10
+.4byte sSwinubAnimTable11
+.4byte sSwinubAnimTable12
+.4byte sSwinubAnimTable13
+sAxSpritesSwinub:
+.4byte sSwinubSprites1
+.4byte sSwinubSprites2
+.4byte sSwinubSprites3
+.4byte sSwinubSprites4
+.4byte sSwinubSprites5
+.4byte sSwinubSprites6
+.4byte sSwinubSprites7
+.4byte sSwinubSprites8
+.4byte sSwinubSprites9
+.4byte sSwinubSprites10
+.4byte sSwinubSprites11
+.4byte sSwinubSprites12
+.4byte sSwinubSprites13
+.4byte sSwinubSprites14
+.4byte sSwinubSprites15
+.4byte sSwinubSprites16
+.4byte sSwinubSprites17
+.4byte sSwinubSprites18
+.4byte sSwinubSprites19
+.4byte sSwinubSprites20
+.4byte sSwinubSprites21
+.4byte sSwinubSprites22
+.4byte sSwinubSprites23
+.4byte sSwinubSprites24
+.4byte sSwinubSprites25
+.4byte sSwinubSprites26
+.4byte sSwinubSprites27
+.4byte sSwinubSprites28
+.4byte sSwinubSprites29
+.4byte sSwinubSprites30
+.4byte sSwinubSprites31
+.4byte sSwinubSprites32
+.4byte sSwinubSprites33
+.4byte sSwinubSprites34
+.4byte sSwinubSprites35
+.4byte sSwinubSprites36
+.4byte sSwinubSprites37
+.4byte sSwinubSprites38
+.4byte sSwinubSprites39
+.4byte sSwinubSprites40
+.4byte sSwinubSprites41
+.4byte sSwinubSprites42
+.4byte sSwinubSprites43
+.4byte sSwinubSprites44
+.4byte sSwinubSprites45
+.4byte sSwinubSprites46
+sAxMainSwinub:
+ax_main sAxPosesSwinub, sAxAnimationsSwinub, 13, sAxSpritesSwinub, sAxPositionsSwinub

--- a/data/ax/taillow.inc
+++ b/data/ax/taillow.inc
@@ -1,0 +1,3008 @@
+.global gAxTaillow
+gAxTaillow:
+ax_siro sAxMainTaillow
+sTaillowPose1:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose2:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose3:
+ax_pose 2, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose4:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose5:
+ax_pose 4, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose6:
+ax_pose 5, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose7:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose8:
+ax_pose 7, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose9:
+ax_pose 8, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose10:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose12:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose13:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose14:
+ax_pose 13, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose15:
+ax_pose 14, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose19:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose20:
+ax_pose 7, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose21:
+ax_pose 8, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose25:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose26:
+ax_pose 15, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose27:
+ax_pose 16, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose28:
+ax_pose 17, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose29:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose30:
+ax_pose 18, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sTaillowPose31:
+ax_pose 19, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose32:
+ax_pose 20, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose33:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose34:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose35:
+ax_pose 22, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose36:
+ax_pose 23, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose37:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose38:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose39:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose40:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose41:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose42:
+ax_pose 27, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose43:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose44:
+ax_pose 29, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose45:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose46:
+ax_pose 24, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose47:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose48:
+ax_pose 26, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose49:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose50:
+ax_pose 21, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose51:
+ax_pose 22, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose52:
+ax_pose 23, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose53:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose54:
+ax_pose 18, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sTaillowPose55:
+ax_pose 19, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose56:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose57:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose58:
+ax_pose 15, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose59:
+ax_pose 16, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose60:
+ax_pose 17, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose61:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose62:
+ax_pose 18, 0x01e9, 0x90ef, 0x2c00
+ax_pose_terminator
+sTaillowPose63:
+ax_pose 19, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose64:
+ax_pose 20, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose65:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose66:
+ax_pose 21, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose67:
+ax_pose 22, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose68:
+ax_pose 23, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose69:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose70:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose71:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose72:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose73:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose74:
+ax_pose 27, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose75:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose76:
+ax_pose 29, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose77:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose78:
+ax_pose 24, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose79:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose80:
+ax_pose 26, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose81:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose82:
+ax_pose 21, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose83:
+ax_pose 22, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose84:
+ax_pose 23, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose85:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose86:
+ax_pose 18, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sTaillowPose87:
+ax_pose 19, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose88:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose89:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose90:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose91:
+ax_pose 2, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose92:
+ax_pose 16, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose93:
+ax_pose 17, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose94:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose95:
+ax_pose 4, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose96:
+ax_pose 5, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose97:
+ax_pose 19, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose98:
+ax_pose 20, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose99:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose100:
+ax_pose 7, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose101:
+ax_pose 8, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose102:
+ax_pose 22, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose103:
+ax_pose 23, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose104:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose105:
+ax_pose 10, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose106:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose107:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose108:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose109:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose110:
+ax_pose 13, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose111:
+ax_pose 14, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose112:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose113:
+ax_pose 29, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose114:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose115:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose116:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose117:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose118:
+ax_pose 26, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose119:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose120:
+ax_pose 7, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose121:
+ax_pose 8, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose122:
+ax_pose 22, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose123:
+ax_pose 23, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose124:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose125:
+ax_pose 4, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose126:
+ax_pose 5, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose127:
+ax_pose 19, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose128:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose129:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose130:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose131:
+ax_pose 2, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose132:
+ax_pose 16, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose133:
+ax_pose 17, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose134:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose135:
+ax_pose 4, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose136:
+ax_pose 5, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose137:
+ax_pose 19, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose138:
+ax_pose 20, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose139:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose140:
+ax_pose 7, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose141:
+ax_pose 8, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose142:
+ax_pose 22, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose143:
+ax_pose 23, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose144:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose145:
+ax_pose 10, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose146:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose147:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose148:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose149:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose150:
+ax_pose 13, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose151:
+ax_pose 14, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose152:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose153:
+ax_pose 29, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose154:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose155:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose156:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose157:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose158:
+ax_pose 26, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose159:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose160:
+ax_pose 7, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose161:
+ax_pose 8, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose162:
+ax_pose 22, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose163:
+ax_pose 23, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose164:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose165:
+ax_pose 4, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose166:
+ax_pose 5, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose167:
+ax_pose 19, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose168:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose169:
+ax_pose 30, 0x41f3, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose170:
+ax_pose 31, 0x41f3, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose171:
+ax_pose 32, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose172:
+ax_pose 33, 0x01e4, 0x90e7, 0x2c00
+ax_pose_terminator
+sTaillowPose173:
+ax_pose 34, 0x01e7, 0x90e8, 0x2c00
+ax_pose_terminator
+sTaillowPose174:
+ax_pose 35, 0x01e9, 0x90e7, 0x2c00
+ax_pose_terminator
+sTaillowPose175:
+ax_pose 36, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose176:
+ax_pose 35, 0x01e9, 0x80f9, 0x2c00
+ax_pose_terminator
+sTaillowPose177:
+ax_pose 34, 0x01e7, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose178:
+ax_pose 33, 0x01e4, 0x80f9, 0x2c00
+ax_pose_terminator
+sTaillowPose179:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose180:
+ax_pose 1, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose181:
+ax_pose 2, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose182:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose183:
+ax_pose 4, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose184:
+ax_pose 5, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose185:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose186:
+ax_pose 7, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose187:
+ax_pose 8, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose188:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose189:
+ax_pose 10, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose190:
+ax_pose 11, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose191:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose192:
+ax_pose 13, 0x81ea, 0x80f8, 0x2c00
+ax_pose_terminator
+sTaillowPose193:
+ax_pose 14, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose194:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose195:
+ax_pose 10, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose196:
+ax_pose 11, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose197:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose198:
+ax_pose 7, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose199:
+ax_pose 8, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose200:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose201:
+ax_pose 4, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose202:
+ax_pose 5, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose203:
+ax_pose 15, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose204:
+ax_pose 18, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sTaillowPose205:
+ax_pose 21, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose206:
+ax_pose 24, 0x01e5, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose207:
+ax_pose 27, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sTaillowPose208:
+ax_pose 24, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose209:
+ax_pose 21, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose210:
+ax_pose 18, 0x01e9, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose211:
+ax_pose 17, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose212:
+ax_pose 20, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose213:
+ax_pose 23, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose214:
+ax_pose 26, 0x01e6, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose215:
+ax_pose 29, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose216:
+ax_pose 26, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose217:
+ax_pose 23, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose218:
+ax_pose 20, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose219:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose220:
+ax_pose 16, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose221:
+ax_pose 17, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose222:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose223:
+ax_pose 19, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose224:
+ax_pose 20, 0x01e8, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose225:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose226:
+ax_pose 22, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose227:
+ax_pose 23, 0x01e7, 0x90ee, 0x2c00
+ax_pose_terminator
+sTaillowPose228:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose229:
+ax_pose 25, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose230:
+ax_pose 26, 0x01e7, 0x90f0, 0x2c00
+ax_pose_terminator
+sTaillowPose231:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose232:
+ax_pose 28, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose233:
+ax_pose 29, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose234:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose235:
+ax_pose 25, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose236:
+ax_pose 26, 0x01e7, 0x80f1, 0x2c00
+ax_pose_terminator
+sTaillowPose237:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose238:
+ax_pose 22, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose239:
+ax_pose 23, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose240:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose241:
+ax_pose 19, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose242:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sTaillowPose243:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose244:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose245:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose246:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose247:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose248:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose249:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose250:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose251:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose252:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose253:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose254:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose255:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose256:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose257:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose258:
+ax_pose 0, 0x01f3, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose259:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose260:
+ax_pose 6, 0x41f2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTaillowPose261:
+ax_pose 9, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTaillowPose262:
+ax_pose 12, 0x01f2, 0x40f8, 0x2c00
+ax_pose_terminator
+sTaillowPose263:
+ax_pose 9, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+sTaillowPose264:
+ax_pose 6, 0x41f2, 0x90ec, 0x2c00
+ax_pose_terminator
+sTaillowPose265:
+ax_pose 3, 0x01ec, 0x90ed, 0x2c00
+ax_pose_terminator
+.align 2
+sTaillowAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 1,
+ax_anim 4, 0, 1, 0, 1, 0, 2,
+ax_anim 4, 0, 2, 0, 1, 0, 1,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 1, 0, 1, 1,
+ax_anim 4, 0, 4, 2, -1, 2, 2,
+ax_anim 4, 0, 5, 1, 1, 2, 2,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 2, -2, 2, 0,
+ax_anim 4, 0, 8, 1, -1, 1, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, -1,
+ax_anim 4, 0, 10, 2, -2, 3, -3,
+ax_anim 4, 0, 11, 1, -1, 2, -1,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, -1,
+ax_anim 4, 0, 13, 0, -1, 0, -3,
+ax_anim 4, 0, 14, 0, -1, 0, -1,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, 0, 0, -1,
+ax_anim 4, 0, 16, -2, -2, -3, -3,
+ax_anim 4, 0, 17, -1, -1, -2, -1,
+ax_anim 4, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, -2, -2, -2, 0,
+ax_anim 4, 0, 20, -1, -1, -1, 0,
+ax_anim 4, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, -1, 0, -1, 1,
+ax_anim 4, 0, 22, -2, -1, -2, 2,
+ax_anim 4, 0, 23, -1, 1, -2, 2,
+ax_anim 4, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, 0,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 0, 26, 0, -5, 0, 0,
+ax_anim 4, 0, 27, 0, -5, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 5, 0, 5,
+ax_anim_terminator
+sTaillowAnims_2_2:
+ax_anim 2, 0, 30, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 0, -4, 0, 0,
+ax_anim 2, 0, 30, 0, -5, 0, 0,
+ax_anim 4, 0, 31, 0, -5, 0, 0,
+ax_anim 1, 2, 29, 5, -2, 5, 5,
+ax_anim 1, 0, 29, 10, 4, 10, 10,
+ax_anim 2, 0, 29, 19, 20, 19, 20,
+ax_anim 2, 1, 29, 20, 19, 20, 19,
+ax_anim 2, 0, 29, 19, 20, 19, 20,
+ax_anim 2, 0, 29, 20, 19, 20, 19,
+ax_anim 2, 0, 29, 19, 20, 19, 20,
+ax_anim 2, 0, 29, 20, 19, 20, 19,
+ax_anim 2, 0, 31, 12, 8, 12, 12,
+ax_anim 2, 0, 30, 5, 0, 5, 5,
+ax_anim_terminator
+sTaillowAnims_2_3:
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 0, -5, 0, 0,
+ax_anim 4, 0, 35, 0, -5, 0, 0,
+ax_anim 1, 2, 33, 5, -5, 5, 0,
+ax_anim 1, 0, 33, 10, -3, 10, 0,
+ax_anim 2, 0, 33, 17, 0, 17, 0,
+ax_anim 2, 1, 33, 17, -1, 17, -1,
+ax_anim 2, 0, 33, 17, 0, 17, 0,
+ax_anim 2, 0, 33, 17, -1, 17, -1,
+ax_anim 2, 0, 33, 17, 0, 17, 0,
+ax_anim 2, 0, 33, 17, -1, 17, -1,
+ax_anim 2, 0, 35, 12, -3, 12, 0,
+ax_anim 2, 0, 34, 5, -3, 5, 0,
+ax_anim_terminator
+sTaillowAnims_2_4:
+ax_anim 2, 0, 38, 0, -2, 0, 0,
+ax_anim 2, 0, 39, 0, -4, 0, 0,
+ax_anim 2, 0, 38, 0, -5, 0, 0,
+ax_anim 4, 0, 39, 0, -5, 0, 0,
+ax_anim 1, 2, 37, 5, -8, 5, -5,
+ax_anim 1, 0, 37, 10, -14, 10, -12,
+ax_anim 2, 0, 37, 18, -22, 18, -22,
+ax_anim 2, 1, 37, 17, -23, 17, -23,
+ax_anim 2, 0, 37, 18, -22, 18, -22,
+ax_anim 2, 0, 37, 17, -23, 17, -23,
+ax_anim 2, 0, 37, 18, -22, 18, -22,
+ax_anim 2, 0, 37, 17, -23, 17, -23,
+ax_anim 2, 0, 39, 11, -15, 11, -11,
+ax_anim 2, 0, 38, 5, -9, 5, -5,
+ax_anim_terminator
+sTaillowAnims_2_5:
+ax_anim 2, 0, 42, 0, -2, 0, 0,
+ax_anim 2, 0, 43, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -5, 0, 0,
+ax_anim 4, 0, 43, 0, -5, 0, 0,
+ax_anim 1, 2, 41, 0, -8, 0, -5,
+ax_anim 1, 0, 41, 0, -16, 0, -10,
+ax_anim 2, 0, 41, 0, -21, 0, -23,
+ax_anim 2, 1, 41, 1, -21, 1, -23,
+ax_anim 2, 0, 41, 0, -21, 0, -23,
+ax_anim 2, 0, 41, 1, -21, 1, -23,
+ax_anim 2, 0, 41, 0, -21, 0, -23,
+ax_anim 2, 0, 41, 1, -21, 1, -23,
+ax_anim 2, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 42, 0, -5, 0, -5,
+ax_anim_terminator
+sTaillowAnims_2_6:
+ax_anim 2, 0, 46, 0, -2, 0, 0,
+ax_anim 2, 0, 47, 0, -4, 0, 0,
+ax_anim 2, 0, 46, 0, -5, 0, 0,
+ax_anim 4, 0, 47, 0, -5, 0, 0,
+ax_anim 1, 2, 45, -5, -8, -5, -5,
+ax_anim 1, 0, 45, -10, -14, -10, -12,
+ax_anim 2, 0, 45, -18, -22, -18, -22,
+ax_anim 2, 1, 45, -17, -23, -17, -23,
+ax_anim 2, 0, 45, -18, -22, -18, -22,
+ax_anim 2, 0, 45, -17, -23, -17, -23,
+ax_anim 2, 0, 45, -18, -22, -18, -22,
+ax_anim 2, 0, 45, -17, -23, -17, -23,
+ax_anim 2, 0, 47, -11, -15, -11, -11,
+ax_anim 2, 0, 46, -5, -9, -5, -5,
+ax_anim_terminator
+sTaillowAnims_2_7:
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -5, 0, 0,
+ax_anim 4, 0, 51, 0, -5, 0, 0,
+ax_anim 1, 2, 49, -5, -5, -5, 0,
+ax_anim 1, 0, 49, -10, -3, -10, 0,
+ax_anim 2, 0, 49, -17, 0, -17, 0,
+ax_anim 2, 1, 49, -17, -1, -17, -1,
+ax_anim 2, 0, 49, -17, 0, -17, 0,
+ax_anim 2, 0, 49, -17, -1, -17, -1,
+ax_anim 2, 0, 49, -17, 0, -17, 0,
+ax_anim 2, 0, 49, -17, -1, -17, -1,
+ax_anim 2, 0, 51, -12, -3, -12, 0,
+ax_anim 2, 0, 50, -5, -3, -5, 0,
+ax_anim_terminator
+sTaillowAnims_2_8:
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 54, 0, -5, 0, 0,
+ax_anim 4, 0, 55, 0, -5, 0, 0,
+ax_anim 1, 2, 53, -5, -2, -5, 5,
+ax_anim 1, 0, 53, -10, 4, -10, 10,
+ax_anim 2, 0, 53, -19, 20, -19, 20,
+ax_anim 2, 1, 53, -20, 19, -20, 19,
+ax_anim 2, 0, 53, -19, 20, -19, 20,
+ax_anim 2, 0, 53, -20, 19, -20, 19,
+ax_anim 2, 0, 53, -19, 20, -19, 20,
+ax_anim 2, 0, 53, -20, 19, -20, 19,
+ax_anim 2, 0, 55, -12, 8, -12, 12,
+ax_anim 2, 0, 54, -5, 0, -5, 5,
+ax_anim_terminator
+.align 2
+sTaillowAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -5, 0, 0,
+ax_anim 4, 0, 59, 0, -5, 0, 0,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 57, 0, 18, 0, 18,
+ax_anim 2, 0, 57, 0, 35, 0, 35,
+ax_anim 2, 1, 57, 1, 43, 1, 43,
+ax_anim 2, 0, 57, 0, 43, 0, 43,
+ax_anim 2, 0, 57, 1, 43, 1, 43,
+ax_anim 2, 0, 57, 0, 43, 0, 43,
+ax_anim 2, 0, 57, 1, 43, 1, 43,
+ax_anim 2, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 58, 0, 5, 0, 5,
+ax_anim_terminator
+sTaillowAnims_3_2:
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 63, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -5, 0, 0,
+ax_anim 4, 0, 63, 0, -5, 0, 0,
+ax_anim 1, 2, 61, 5, -2, 5, 5,
+ax_anim 1, 0, 61, 18, 12, 18, 18,
+ax_anim 2, 0, 61, 35, 32, 35, 32,
+ax_anim 2, 1, 61, 44, 43, 44, 43,
+ax_anim 2, 0, 61, 43, 44, 43, 44,
+ax_anim 2, 0, 61, 44, 43, 44, 43,
+ax_anim 2, 0, 61, 43, 44, 43, 44,
+ax_anim 2, 0, 61, 44, 43, 44, 43,
+ax_anim 2, 0, 63, 12, 8, 12, 12,
+ax_anim 2, 0, 62, 5, 0, 5, 5,
+ax_anim_terminator
+sTaillowAnims_3_3:
+ax_anim 2, 0, 66, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 66, 0, -5, 0, 0,
+ax_anim 4, 0, 67, 0, -5, 0, 0,
+ax_anim 1, 2, 65, 5, -5, 5, 0,
+ax_anim 1, 0, 65, 18, -3, 18, 0,
+ax_anim 2, 0, 65, 33, 0, 33, 0,
+ax_anim 2, 1, 65, 41, -1, 41, -1,
+ax_anim 2, 0, 65, 41, 0, 41, 0,
+ax_anim 2, 0, 65, 41, -1, 41, -1,
+ax_anim 2, 0, 65, 41, 0, 41, 0,
+ax_anim 2, 0, 65, 41, -1, 41, -1,
+ax_anim 2, 0, 67, 12, -3, 12, 0,
+ax_anim 2, 0, 66, 5, -3, 5, 0,
+ax_anim_terminator
+sTaillowAnims_3_4:
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -5, 0, 0,
+ax_anim 4, 0, 71, 0, -5, 0, 0,
+ax_anim 1, 2, 69, 5, -8, 5, -5,
+ax_anim 1, 0, 69, 18, -22, 18, -20,
+ax_anim 2, 0, 69, 34, -38, 34, -38,
+ax_anim 2, 1, 69, 41, -47, 41, -47,
+ax_anim 2, 0, 69, 42, -46, 42, -46,
+ax_anim 2, 0, 69, 41, -47, 41, -47,
+ax_anim 2, 0, 69, 42, -46, 42, -46,
+ax_anim 2, 0, 69, 41, -47, 41, -47,
+ax_anim 2, 0, 71, 11, -15, 11, -11,
+ax_anim 2, 0, 70, 5, -9, 5, -5,
+ax_anim_terminator
+sTaillowAnims_3_5:
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -4, 0, 0,
+ax_anim 2, 0, 74, 0, -5, 0, 0,
+ax_anim 4, 0, 75, 0, -5, 0, 0,
+ax_anim 1, 2, 73, 0, -8, 0, -5,
+ax_anim 1, 0, 73, 0, -24, 0, -18,
+ax_anim 2, 0, 73, 0, -37, 0, -39,
+ax_anim 2, 1, 73, 1, -45, 1, -47,
+ax_anim 2, 0, 73, 0, -45, 0, -47,
+ax_anim 2, 0, 73, 1, -45, 1, -47,
+ax_anim 2, 0, 73, 0, -45, 0, -47,
+ax_anim 2, 0, 73, 1, -45, 1, -47,
+ax_anim 2, 0, 75, 0, -12, 0, -12,
+ax_anim 2, 0, 74, 0, -5, 0, -5,
+ax_anim_terminator
+sTaillowAnims_3_6:
+ax_anim 2, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -5, 0, 0,
+ax_anim 4, 0, 79, 0, -5, 0, 0,
+ax_anim 1, 2, 77, -5, -8, -5, -5,
+ax_anim 1, 0, 77, -18, -22, -18, -20,
+ax_anim 2, 0, 77, -34, -38, -34, -38,
+ax_anim 2, 1, 77, -41, -47, -41, -47,
+ax_anim 2, 0, 77, -42, -46, -42, -46,
+ax_anim 2, 0, 77, -41, -47, -41, -47,
+ax_anim 2, 0, 77, -42, -46, -42, -46,
+ax_anim 2, 0, 77, -41, -47, -41, -47,
+ax_anim 2, 0, 79, -11, -15, -11, -11,
+ax_anim 2, 0, 78, -5, -9, -5, -5,
+ax_anim_terminator
+sTaillowAnims_3_7:
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 82, 0, -5, 0, 0,
+ax_anim 4, 0, 83, 0, -5, 0, 0,
+ax_anim 1, 2, 81, -5, -5, -5, 0,
+ax_anim 1, 0, 81, -18, -3, -18, 0,
+ax_anim 2, 0, 81, -33, 0, -33, 0,
+ax_anim 2, 1, 81, -41, -1, -41, -1,
+ax_anim 2, 0, 81, -41, 0, -41, 0,
+ax_anim 2, 0, 81, -41, -1, -41, -1,
+ax_anim 2, 0, 81, -41, 0, -41, 0,
+ax_anim 2, 0, 81, -41, -1, -41, -1,
+ax_anim 2, 0, 83, -12, -3, -12, 0,
+ax_anim 2, 0, 82, -5, -3, -5, 0,
+ax_anim_terminator
+sTaillowAnims_3_8:
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -5, 0, 0,
+ax_anim 4, 0, 87, 0, -5, 0, 0,
+ax_anim 1, 2, 85, -5, -2, -5, 5,
+ax_anim 1, 0, 85, -18, 12, -18, 18,
+ax_anim 2, 0, 85, -35, 32, -35, 32,
+ax_anim 2, 1, 85, -44, 43, -44, 43,
+ax_anim 2, 0, 85, -43, 44, -43, 44,
+ax_anim 2, 0, 85, -44, 43, -44, 43,
+ax_anim 2, 0, 85, -43, 44, -43, 44,
+ax_anim 2, 0, 85, -44, 43, -44, 43,
+ax_anim 2, 0, 87, -12, 8, -12, 12,
+ax_anim 2, 0, 86, -5, 0, -5, 5,
+ax_anim_terminator
+.align 2
+sTaillowAnims_4_1:
+ax_anim 2, 0, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -6, 0, 0,
+ax_anim 3, 0, 92, 0, -7, 0, 0,
+ax_anim 3, 0, 91, 0, -8, 0, 0,
+ax_anim 3, 2, 92, 0, -8, 0, 0,
+ax_anim 3, 0, 91, 0, -8, 0, 0,
+ax_anim 3, 0, 92, 0, -8, 0, 0,
+ax_anim 3, 1, 91, 0, -8, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_4_2:
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -6, 0, 0,
+ax_anim 3, 0, 97, 0, -7, 0, 0,
+ax_anim 3, 0, 96, 0, -8, 0, 0,
+ax_anim 3, 2, 97, 0, -8, 0, 0,
+ax_anim 3, 0, 96, 0, -8, 0, 0,
+ax_anim 3, 0, 97, 0, -8, 0, 0,
+ax_anim 3, 1, 96, 0, -8, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_4_3:
+ax_anim 2, 0, 99, 0, -1, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -6, 0, 0,
+ax_anim 3, 0, 102, 0, -7, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 3, 2, 102, 0, -8, 0, 0,
+ax_anim 3, 0, 101, 0, -8, 0, 0,
+ax_anim 3, 0, 102, 0, -8, 0, 0,
+ax_anim 3, 1, 101, 0, -8, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_4_4:
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -6, 0, 0,
+ax_anim 3, 0, 107, 0, -7, 0, 0,
+ax_anim 3, 0, 106, 0, -8, 0, 0,
+ax_anim 3, 2, 107, 0, -8, 0, 0,
+ax_anim 3, 0, 106, 0, -8, 0, 0,
+ax_anim 3, 0, 107, 0, -8, 0, 0,
+ax_anim 3, 1, 106, 0, -8, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_4_5:
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 3, 0, 112, 0, -7, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 2, 112, 0, -8, 0, 0,
+ax_anim 3, 0, 111, 0, -8, 0, 0,
+ax_anim 3, 0, 112, 0, -8, 0, 0,
+ax_anim 3, 1, 111, 0, -8, 0, 0,
+ax_anim 2, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_4_6:
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, 0,
+ax_anim 3, 0, 117, 0, -7, 0, 0,
+ax_anim 3, 0, 116, 0, -8, 0, 0,
+ax_anim 3, 2, 117, 0, -8, 0, 0,
+ax_anim 3, 0, 116, 0, -8, 0, 0,
+ax_anim 3, 0, 117, 0, -8, 0, 0,
+ax_anim 3, 1, 116, 0, -8, 0, 0,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_4_7:
+ax_anim 2, 0, 119, 0, -1, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 0, -6, 0, 0,
+ax_anim 3, 0, 122, 0, -7, 0, 0,
+ax_anim 3, 0, 121, 0, -8, 0, 0,
+ax_anim 3, 2, 122, 0, -8, 0, 0,
+ax_anim 3, 0, 121, 0, -8, 0, 0,
+ax_anim 3, 0, 122, 0, -8, 0, 0,
+ax_anim 3, 1, 121, 0, -8, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_4_8:
+ax_anim 2, 0, 124, 0, -1, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, 0,
+ax_anim 3, 0, 127, 0, -7, 0, 0,
+ax_anim 3, 0, 126, 0, -8, 0, 0,
+ax_anim 3, 2, 127, 0, -8, 0, 0,
+ax_anim 3, 0, 126, 0, -8, 0, 0,
+ax_anim 3, 0, 127, 0, -8, 0, 0,
+ax_anim 3, 1, 126, 0, -8, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_5_1:
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 2, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim_terminator
+sTaillowAnims_5_2:
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 2, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim_terminator
+sTaillowAnims_5_3:
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 2, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim_terminator
+sTaillowAnims_5_4:
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 2, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim_terminator
+sTaillowAnims_5_5:
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 2, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim_terminator
+sTaillowAnims_5_6:
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 2, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim_terminator
+sTaillowAnims_5_7:
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 2, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 0, 162, 0, -8, 0, 0,
+ax_anim_terminator
+sTaillowAnims_5_8:
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim 2, 0, 131, 0, -8, 0, 0,
+ax_anim 2, 0, 132, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 146, 0, -8, 0, 0,
+ax_anim 2, 0, 147, 0, -8, 0, 0,
+ax_anim 2, 0, 151, 0, -8, 0, 0,
+ax_anim 2, 0, 152, 0, -8, 0, 0,
+ax_anim 2, 0, 156, 0, -8, 0, 0,
+ax_anim 2, 0, 157, 0, -8, 0, 0,
+ax_anim 2, 0, 161, 0, -8, 0, 0,
+ax_anim 2, 2, 162, 0, -8, 0, 0,
+ax_anim 2, 0, 166, 0, -8, 0, 0,
+ax_anim 2, 0, 167, 0, -8, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_7_1:
+ax_anim 2, 0, 170, 0, -2, 0, -2,
+ax_anim 8, 0, 170, 0, -3, 0, -3,
+ax_anim_terminator
+sTaillowAnims_7_2:
+ax_anim 2, 0, 171, -2, -2, -2, -2,
+ax_anim 8, 0, 171, -3, -3, -3, -3,
+ax_anim_terminator
+sTaillowAnims_7_3:
+ax_anim 2, 0, 172, -2, 0, -2, 0,
+ax_anim 8, 0, 172, -3, 0, -3, 0,
+ax_anim_terminator
+sTaillowAnims_7_4:
+ax_anim 2, 0, 173, -2, 2, -2, 2,
+ax_anim 8, 0, 173, -3, 3, -3, 3,
+ax_anim_terminator
+sTaillowAnims_7_5:
+ax_anim 2, 0, 174, 0, 2, 0, 2,
+ax_anim 8, 0, 174, 0, 3, 0, 3,
+ax_anim_terminator
+sTaillowAnims_7_6:
+ax_anim 2, 0, 175, 2, 2, 2, 2,
+ax_anim 8, 0, 175, 3, 3, 3, 3,
+ax_anim_terminator
+sTaillowAnims_7_7:
+ax_anim 2, 0, 176, 2, 0, 2, 0,
+ax_anim 8, 0, 176, 3, 0, 3, 0,
+ax_anim_terminator
+sTaillowAnims_7_8:
+ax_anim 2, 0, 177, 2, -2, 2, -2,
+ax_anim 8, 0, 177, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTaillowAnims_8_1:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 6, 0, 179, 0, -1, 0, 0,
+ax_anim 4, 0, 179, 0, 0, 0, 0,
+ax_anim 4, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_8_2:
+ax_anim 30, 0, 181, 0, 0, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 6, 0, 182, 0, -1, 0, 0,
+ax_anim 4, 0, 182, 0, 0, 0, 0,
+ax_anim 4, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_8_3:
+ax_anim 30, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 6, 0, 185, 0, -1, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 4, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_8_4:
+ax_anim 30, 0, 187, 0, 0, 0, 0,
+ax_anim 4, 0, 188, 0, 0, 0, 0,
+ax_anim 6, 0, 188, 0, -1, 0, 0,
+ax_anim 4, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_8_5:
+ax_anim 30, 0, 190, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, 0, 0, 0,
+ax_anim 6, 0, 191, 0, -1, 0, 0,
+ax_anim 4, 0, 191, 0, 0, 0, 0,
+ax_anim 4, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_8_6:
+ax_anim 30, 0, 193, 0, 0, 0, 0,
+ax_anim 4, 0, 194, 0, 0, 0, 0,
+ax_anim 6, 0, 194, 0, -1, 0, 0,
+ax_anim 4, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_8_7:
+ax_anim 30, 0, 196, 0, 0, 0, 0,
+ax_anim 4, 0, 197, 0, 0, 0, 0,
+ax_anim 6, 0, 197, 0, -1, 0, 0,
+ax_anim 4, 0, 197, 0, 0, 0, 0,
+ax_anim 4, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_8_8:
+ax_anim 30, 0, 199, 0, 0, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 6, 0, 200, 0, -1, 0, 0,
+ax_anim 4, 0, 200, 0, 0, 0, 0,
+ax_anim 4, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 1, 6, 1,
+ax_anim 2, 0, 204, 10, 10, 10, 10,
+ax_anim 2, 0, 205, 9, 19, 9, 19,
+ax_anim 3, 0, 206, 0, 21, 0, 21,
+ax_anim 2, 3, 207, -9, 19, -9, 19,
+ax_anim 2, 0, 208, -10, 10, -10, 10,
+ax_anim 1, 0, 209, -6, 1, -6, 1,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 19, 4, 19, 4,
+ax_anim 2, 0, 204, 21, 14, 21, 14,
+ax_anim 3, 0, 205, 21, 22, 21, 22,
+ax_anim 2, 3, 206, 12, 23, 12, 23,
+ax_anim 2, 0, 207, 6, 15, 6, 15,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -5, 3, -5,
+ax_anim 2, 0, 202, 11, -6, 11, -6,
+ax_anim 2, 0, 203, 18, -7, 18, -7,
+ax_anim 3, 0, 204, 21, 0, 21, 0,
+ax_anim 2, 3, 205, 17, 5, 17, 5,
+ax_anim 2, 0, 206, 12, 6, 12, 6,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 1, -8, 1, -8,
+ax_anim 2, 0, 209, 4, -16, 4, -16,
+ax_anim 2, 0, 202, 14, -25, 14, -25,
+ax_anim 3, 0, 203, 22, -26, 22, -26,
+ax_anim 2, 3, 204, 21, -15, 21, -15,
+ax_anim 2, 0, 205, 17, -7, 17, -7,
+ax_anim 1, 0, 206, 9, -1, 9, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -4, -8, -4,
+ax_anim 2, 0, 208, -11, -12, -11, -12,
+ax_anim 2, 0, 209, -7, -20, -7, -20,
+ax_anim 3, 0, 202, 0, -23, 0, -23,
+ax_anim 2, 3, 203, 7, -20, 7, -20,
+ax_anim 2, 0, 204, 11, -10, 11, -10,
+ax_anim 1, 0, 205, 8, -4, 8, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -8, 1, -8,
+ax_anim 2, 0, 203, -4, -16, -4, -16,
+ax_anim 2, 0, 202, -14, -25, -14, -25,
+ax_anim 3, 0, 209, -22, -26, -22, -26,
+ax_anim 2, 3, 208, -21, -15, -21, -15,
+ax_anim 2, 0, 207, -17, -7, -17, -7,
+ax_anim 1, 0, 206, -9, -1, -9, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -5, -3, -5,
+ax_anim 2, 0, 202, -11, -6, -11, -6,
+ax_anim 2, 0, 209, -18, -7, -18, -7,
+ax_anim 3, 0, 208, -21, 0, -21, 0,
+ax_anim 2, 3, 207, -17, 5, -17, 5,
+ax_anim 2, 0, 206, -12, 6, -12, 6,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -19, 4, -19, 4,
+ax_anim 2, 0, 208, -21, 14, -21, 14,
+ax_anim 3, 0, 207, -21, 22, -21, 22,
+ax_anim 2, 3, 206, -12, 23, -12, 23,
+ax_anim 2, 0, 205, -6, 15, -6, 15,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -22, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -22, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -22, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -21, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 230, 0, -10, 0, 0,
+ax_anim 2, 0, 230, 0, -16, 0, 0,
+ax_anim 3, 0, 230, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -21, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 236, 0, -10, 0, 0,
+ax_anim 2, 0, 236, 0, -16, 0, 0,
+ax_anim 3, 0, 236, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -22, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 239, 0, -10, 0, 0,
+ax_anim 2, 0, 239, 0, -16, 0, 0,
+ax_anim 3, 0, 239, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -22, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaillowAnims_13_1:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_13_2:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_13_3:
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 2, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_13_4:
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 2, 262, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_13_5:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_13_6:
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 2, 260, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_13_7:
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 2, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowAnims_13_8:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 2, 0, 259, 0, 0, 0, 0,
+ax_anim 2, 0, 260, 0, 0, 0, 0,
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sTaillowGfx1:
+.incbin "baserom.gba", 0x1149E08, 0x80
+sTaillowSprites1:
+ax_sprite sTaillowGfx1, 0x80
+ax_sprite_terminator
+sTaillowGfx2:
+.incbin "baserom.gba", 0x1149E98, 0x100
+sTaillowSprites2:
+ax_sprite sTaillowGfx2, 0x100
+ax_sprite_terminator
+sTaillowGfx3:
+.incbin "baserom.gba", 0x1149FA8, 0x80
+sTaillowSprites3:
+ax_sprite sTaillowGfx3, 0x80
+ax_sprite_terminator
+sTaillowGfx4:
+.incbin "baserom.gba", 0x114A038, 0x200
+sTaillowSprites4:
+ax_sprite sTaillowGfx4, 0x200
+ax_sprite_terminator
+sTaillowGfx5:
+.incbin "baserom.gba", 0x114A248, 0x200
+sTaillowSprites5:
+ax_sprite sTaillowGfx5, 0x200
+ax_sprite_terminator
+sTaillowGfx6:
+.incbin "baserom.gba", 0x114A458, 0x200
+sTaillowSprites6:
+ax_sprite sTaillowGfx6, 0x200
+ax_sprite_terminator
+sTaillowGfx7:
+.incbin "baserom.gba", 0x114A668, 0x100
+sTaillowSprites7:
+ax_sprite sTaillowGfx7, 0x100
+ax_sprite_terminator
+sTaillowGfx8:
+.incbin "baserom.gba", 0x114A778, 0x200
+sTaillowSprites8:
+ax_sprite sTaillowGfx8, 0x200
+ax_sprite_terminator
+sTaillowGfx9:
+.incbin "baserom.gba", 0x114A988, 0x100
+sTaillowSprites9:
+ax_sprite sTaillowGfx9, 0x100
+ax_sprite_terminator
+sTaillowGfx10:
+.incbin "baserom.gba", 0x114AA98, 0x200
+sTaillowSprites10:
+ax_sprite sTaillowGfx10, 0x200
+ax_sprite_terminator
+sTaillowGfx11:
+.incbin "baserom.gba", 0x114ACA8, 0x200
+sTaillowSprites11:
+ax_sprite sTaillowGfx11, 0x200
+ax_sprite_terminator
+sTaillowGfx12:
+.incbin "baserom.gba", 0x114AEB8, 0x200
+sTaillowSprites12:
+ax_sprite sTaillowGfx12, 0x200
+ax_sprite_terminator
+sTaillowGfx13:
+.incbin "baserom.gba", 0x114B0C8, 0x80
+sTaillowSprites13:
+ax_sprite sTaillowGfx13, 0x80
+ax_sprite_terminator
+sTaillowGfx14:
+.incbin "baserom.gba", 0x114B158, 0x100
+sTaillowSprites14:
+ax_sprite sTaillowGfx14, 0x100
+ax_sprite_terminator
+sTaillowGfx15:
+.incbin "baserom.gba", 0x114B268, 0x80
+sTaillowSprites15:
+ax_sprite sTaillowGfx15, 0x80
+ax_sprite_terminator
+sTaillowGfx16:
+.incbin "baserom.gba", 0x114B2F8, 0x100
+sTaillowGfx16_1:
+.incbin "baserom.gba", 0x114B3F8, 0x40
+sTaillowSprites16:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx17:
+.incbin "baserom.gba", 0x114B468, 0x40
+sTaillowGfx17_1:
+.incbin "baserom.gba", 0x114B4A8, 0x60
+sTaillowGfx17_2:
+.incbin "baserom.gba", 0x114B508, 0x60
+sTaillowSprites17:
+ax_sprite 0, 0xa0
+ax_sprite sTaillowGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx18:
+.incbin "baserom.gba", 0x114B5A8, 0x100
+sTaillowGfx18_1:
+.incbin "baserom.gba", 0x114B6A8, 0x40
+sTaillowSprites18:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx18, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx19:
+.incbin "baserom.gba", 0x114B718, 0x100
+sTaillowGfx19_1:
+.incbin "baserom.gba", 0x114B818, 0x20
+sTaillowSprites19:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx19, 0x100
+ax_sprite 0, 0x40
+ax_sprite sTaillowGfx19_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx20:
+.incbin "baserom.gba", 0x114B868, 0x60
+sTaillowGfx20_1:
+.incbin "baserom.gba", 0x114B8C8, 0x60
+sTaillowGfx20_2:
+.incbin "baserom.gba", 0x114B928, 0x40
+sTaillowSprites20:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTaillowGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx21:
+.incbin "baserom.gba", 0x114B9A8, 0x20
+sTaillowGfx21_1:
+.incbin "baserom.gba", 0x114B9C8, 0xE0
+sTaillowGfx21_2:
+.incbin "baserom.gba", 0x114BAA8, 0x40
+sTaillowSprites21:
+ax_sprite sTaillowGfx21, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTaillowGfx21_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sTaillowGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx22:
+.incbin "baserom.gba", 0x114BB20, 0x100
+sTaillowGfx22_1:
+.incbin "baserom.gba", 0x114BC20, 0x40
+sTaillowSprites22:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx22, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx23:
+.incbin "baserom.gba", 0x114BC90, 0x60
+sTaillowGfx23_1:
+.incbin "baserom.gba", 0x114BCF0, 0x60
+sTaillowGfx23_2:
+.incbin "baserom.gba", 0x114BD50, 0x60
+sTaillowSprites23:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx24:
+.incbin "baserom.gba", 0x114BDF0, 0x60
+sTaillowGfx24_1:
+.incbin "baserom.gba", 0x114BE50, 0x60
+sTaillowGfx24_2:
+.incbin "baserom.gba", 0x114BEB0, 0x40
+sTaillowSprites24:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTaillowGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx25:
+.incbin "baserom.gba", 0x114BF30, 0x160
+sTaillowSprites25:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx25, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx26:
+.incbin "baserom.gba", 0x114C0B0, 0x60
+sTaillowGfx26_1:
+.incbin "baserom.gba", 0x114C110, 0x60
+sTaillowGfx26_2:
+.incbin "baserom.gba", 0x114C170, 0x60
+sTaillowSprites26:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx27:
+.incbin "baserom.gba", 0x114C210, 0x60
+sTaillowGfx27_1:
+.incbin "baserom.gba", 0x114C270, 0x60
+sTaillowGfx27_2:
+.incbin "baserom.gba", 0x114C2D0, 0x40
+sTaillowSprites27:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTaillowGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx28:
+.incbin "baserom.gba", 0x114C350, 0x40
+sTaillowGfx28_1:
+.incbin "baserom.gba", 0x114C390, 0x80
+sTaillowGfx28_2:
+.incbin "baserom.gba", 0x114C410, 0x40
+sTaillowSprites28:
+ax_sprite 0, 0xa0
+ax_sprite sTaillowGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx28_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx28_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx29:
+.incbin "baserom.gba", 0x114C490, 0x40
+sTaillowGfx29_1:
+.incbin "baserom.gba", 0x114C4D0, 0x60
+sTaillowGfx29_2:
+.incbin "baserom.gba", 0x114C530, 0x40
+sTaillowSprites29:
+ax_sprite 0, 0xa0
+ax_sprite sTaillowGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTaillowGfx29_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx30:
+.incbin "baserom.gba", 0x114C5B0, 0x100
+sTaillowGfx30_1:
+.incbin "baserom.gba", 0x114C6B0, 0x40
+sTaillowSprites30:
+ax_sprite 0, 0x80
+ax_sprite sTaillowGfx30, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaillowGfx30_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaillowGfx31:
+.incbin "baserom.gba", 0x114C720, 0x100
+sTaillowSprites31:
+ax_sprite sTaillowGfx31, 0x100
+ax_sprite_terminator
+sTaillowGfx32:
+.incbin "baserom.gba", 0x114C830, 0x100
+sTaillowSprites32:
+ax_sprite sTaillowGfx32, 0x100
+ax_sprite_terminator
+sTaillowGfx33:
+.incbin "baserom.gba", 0x114C940, 0x200
+sTaillowSprites33:
+ax_sprite sTaillowGfx33, 0x200
+ax_sprite_terminator
+sTaillowGfx34:
+.incbin "baserom.gba", 0x114CB50, 0x200
+sTaillowSprites34:
+ax_sprite sTaillowGfx34, 0x200
+ax_sprite_terminator
+sTaillowGfx35:
+.incbin "baserom.gba", 0x114CD60, 0x200
+sTaillowSprites35:
+ax_sprite sTaillowGfx35, 0x200
+ax_sprite_terminator
+sTaillowGfx36:
+.incbin "baserom.gba", 0x114CF70, 0x200
+sTaillowSprites36:
+ax_sprite sTaillowGfx36, 0x200
+ax_sprite_terminator
+sTaillowGfx37:
+.incbin "baserom.gba", 0x114D180, 0x200
+sTaillowSprites37:
+ax_sprite sTaillowGfx37, 0x200
+ax_sprite_terminator
+sAxPosesTaillow:
+.4byte sTaillowPose1
+.4byte sTaillowPose2
+.4byte sTaillowPose3
+.4byte sTaillowPose4
+.4byte sTaillowPose5
+.4byte sTaillowPose6
+.4byte sTaillowPose7
+.4byte sTaillowPose8
+.4byte sTaillowPose9
+.4byte sTaillowPose10
+.4byte sTaillowPose11
+.4byte sTaillowPose12
+.4byte sTaillowPose13
+.4byte sTaillowPose14
+.4byte sTaillowPose15
+.4byte sTaillowPose16
+.4byte sTaillowPose17
+.4byte sTaillowPose18
+.4byte sTaillowPose19
+.4byte sTaillowPose20
+.4byte sTaillowPose21
+.4byte sTaillowPose22
+.4byte sTaillowPose23
+.4byte sTaillowPose24
+.4byte sTaillowPose25
+.4byte sTaillowPose26
+.4byte sTaillowPose27
+.4byte sTaillowPose28
+.4byte sTaillowPose29
+.4byte sTaillowPose30
+.4byte sTaillowPose31
+.4byte sTaillowPose32
+.4byte sTaillowPose33
+.4byte sTaillowPose34
+.4byte sTaillowPose35
+.4byte sTaillowPose36
+.4byte sTaillowPose37
+.4byte sTaillowPose38
+.4byte sTaillowPose39
+.4byte sTaillowPose40
+.4byte sTaillowPose41
+.4byte sTaillowPose42
+.4byte sTaillowPose43
+.4byte sTaillowPose44
+.4byte sTaillowPose45
+.4byte sTaillowPose46
+.4byte sTaillowPose47
+.4byte sTaillowPose48
+.4byte sTaillowPose49
+.4byte sTaillowPose50
+.4byte sTaillowPose51
+.4byte sTaillowPose52
+.4byte sTaillowPose53
+.4byte sTaillowPose54
+.4byte sTaillowPose55
+.4byte sTaillowPose56
+.4byte sTaillowPose57
+.4byte sTaillowPose58
+.4byte sTaillowPose59
+.4byte sTaillowPose60
+.4byte sTaillowPose61
+.4byte sTaillowPose62
+.4byte sTaillowPose63
+.4byte sTaillowPose64
+.4byte sTaillowPose65
+.4byte sTaillowPose66
+.4byte sTaillowPose67
+.4byte sTaillowPose68
+.4byte sTaillowPose69
+.4byte sTaillowPose70
+.4byte sTaillowPose71
+.4byte sTaillowPose72
+.4byte sTaillowPose73
+.4byte sTaillowPose74
+.4byte sTaillowPose75
+.4byte sTaillowPose76
+.4byte sTaillowPose77
+.4byte sTaillowPose78
+.4byte sTaillowPose79
+.4byte sTaillowPose80
+.4byte sTaillowPose81
+.4byte sTaillowPose82
+.4byte sTaillowPose83
+.4byte sTaillowPose84
+.4byte sTaillowPose85
+.4byte sTaillowPose86
+.4byte sTaillowPose87
+.4byte sTaillowPose88
+.4byte sTaillowPose89
+.4byte sTaillowPose90
+.4byte sTaillowPose91
+.4byte sTaillowPose92
+.4byte sTaillowPose93
+.4byte sTaillowPose94
+.4byte sTaillowPose95
+.4byte sTaillowPose96
+.4byte sTaillowPose97
+.4byte sTaillowPose98
+.4byte sTaillowPose99
+.4byte sTaillowPose100
+.4byte sTaillowPose101
+.4byte sTaillowPose102
+.4byte sTaillowPose103
+.4byte sTaillowPose104
+.4byte sTaillowPose105
+.4byte sTaillowPose106
+.4byte sTaillowPose107
+.4byte sTaillowPose108
+.4byte sTaillowPose109
+.4byte sTaillowPose110
+.4byte sTaillowPose111
+.4byte sTaillowPose112
+.4byte sTaillowPose113
+.4byte sTaillowPose114
+.4byte sTaillowPose115
+.4byte sTaillowPose116
+.4byte sTaillowPose117
+.4byte sTaillowPose118
+.4byte sTaillowPose119
+.4byte sTaillowPose120
+.4byte sTaillowPose121
+.4byte sTaillowPose122
+.4byte sTaillowPose123
+.4byte sTaillowPose124
+.4byte sTaillowPose125
+.4byte sTaillowPose126
+.4byte sTaillowPose127
+.4byte sTaillowPose128
+.4byte sTaillowPose129
+.4byte sTaillowPose130
+.4byte sTaillowPose131
+.4byte sTaillowPose132
+.4byte sTaillowPose133
+.4byte sTaillowPose134
+.4byte sTaillowPose135
+.4byte sTaillowPose136
+.4byte sTaillowPose137
+.4byte sTaillowPose138
+.4byte sTaillowPose139
+.4byte sTaillowPose140
+.4byte sTaillowPose141
+.4byte sTaillowPose142
+.4byte sTaillowPose143
+.4byte sTaillowPose144
+.4byte sTaillowPose145
+.4byte sTaillowPose146
+.4byte sTaillowPose147
+.4byte sTaillowPose148
+.4byte sTaillowPose149
+.4byte sTaillowPose150
+.4byte sTaillowPose151
+.4byte sTaillowPose152
+.4byte sTaillowPose153
+.4byte sTaillowPose154
+.4byte sTaillowPose155
+.4byte sTaillowPose156
+.4byte sTaillowPose157
+.4byte sTaillowPose158
+.4byte sTaillowPose159
+.4byte sTaillowPose160
+.4byte sTaillowPose161
+.4byte sTaillowPose162
+.4byte sTaillowPose163
+.4byte sTaillowPose164
+.4byte sTaillowPose165
+.4byte sTaillowPose166
+.4byte sTaillowPose167
+.4byte sTaillowPose168
+.4byte sTaillowPose169
+.4byte sTaillowPose170
+.4byte sTaillowPose171
+.4byte sTaillowPose172
+.4byte sTaillowPose173
+.4byte sTaillowPose174
+.4byte sTaillowPose175
+.4byte sTaillowPose176
+.4byte sTaillowPose177
+.4byte sTaillowPose178
+.4byte sTaillowPose179
+.4byte sTaillowPose180
+.4byte sTaillowPose181
+.4byte sTaillowPose182
+.4byte sTaillowPose183
+.4byte sTaillowPose184
+.4byte sTaillowPose185
+.4byte sTaillowPose186
+.4byte sTaillowPose187
+.4byte sTaillowPose188
+.4byte sTaillowPose189
+.4byte sTaillowPose190
+.4byte sTaillowPose191
+.4byte sTaillowPose192
+.4byte sTaillowPose193
+.4byte sTaillowPose194
+.4byte sTaillowPose195
+.4byte sTaillowPose196
+.4byte sTaillowPose197
+.4byte sTaillowPose198
+.4byte sTaillowPose199
+.4byte sTaillowPose200
+.4byte sTaillowPose201
+.4byte sTaillowPose202
+.4byte sTaillowPose203
+.4byte sTaillowPose204
+.4byte sTaillowPose205
+.4byte sTaillowPose206
+.4byte sTaillowPose207
+.4byte sTaillowPose208
+.4byte sTaillowPose209
+.4byte sTaillowPose210
+.4byte sTaillowPose211
+.4byte sTaillowPose212
+.4byte sTaillowPose213
+.4byte sTaillowPose214
+.4byte sTaillowPose215
+.4byte sTaillowPose216
+.4byte sTaillowPose217
+.4byte sTaillowPose218
+.4byte sTaillowPose219
+.4byte sTaillowPose220
+.4byte sTaillowPose221
+.4byte sTaillowPose222
+.4byte sTaillowPose223
+.4byte sTaillowPose224
+.4byte sTaillowPose225
+.4byte sTaillowPose226
+.4byte sTaillowPose227
+.4byte sTaillowPose228
+.4byte sTaillowPose229
+.4byte sTaillowPose230
+.4byte sTaillowPose231
+.4byte sTaillowPose232
+.4byte sTaillowPose233
+.4byte sTaillowPose234
+.4byte sTaillowPose235
+.4byte sTaillowPose236
+.4byte sTaillowPose237
+.4byte sTaillowPose238
+.4byte sTaillowPose239
+.4byte sTaillowPose240
+.4byte sTaillowPose241
+.4byte sTaillowPose242
+.4byte sTaillowPose243
+.4byte sTaillowPose244
+.4byte sTaillowPose245
+.4byte sTaillowPose246
+.4byte sTaillowPose247
+.4byte sTaillowPose248
+.4byte sTaillowPose249
+.4byte sTaillowPose250
+.4byte sTaillowPose251
+.4byte sTaillowPose252
+.4byte sTaillowPose253
+.4byte sTaillowPose254
+.4byte sTaillowPose255
+.4byte sTaillowPose256
+.4byte sTaillowPose257
+.4byte sTaillowPose258
+.4byte sTaillowPose259
+.4byte sTaillowPose260
+.4byte sTaillowPose261
+.4byte sTaillowPose262
+.4byte sTaillowPose263
+.4byte sTaillowPose264
+.4byte sTaillowPose265
+sAxPositionsTaillow:
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,   -8, 	   4,   -8, 	  -1,   -9
+.2byte   -1,   -4, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    5,   -9, 	  -2,   -9, 	  -5,   -7, 	   0,   -9
+.2byte    5,   -5, 	  -2,   -5, 	  -5,   -3, 	   0,   -5
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    7,  -10, 	  -5,   -8, 	  -4,   -5, 	   0,   -9
+.2byte    7,   -6, 	  -5,   -4, 	  -4,   -1, 	   0,   -5
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    7,  -12, 	  -5,   -7, 	  -1,   -5, 	   1,  -10
+.2byte    7,   -8, 	  -4,   -3, 	  -1,   -1, 	   1,   -6
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -9
+.2byte   -1,   -9, 	   2,   -2, 	  -4,   -2, 	  -1,   -6
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -7,  -12, 	   5,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -7,   -8, 	   4,   -3, 	   1,   -1, 	  -1,   -6
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -7,  -10, 	   5,   -8, 	   4,   -5, 	   0,   -9
+.2byte   -7,   -6, 	   5,   -4, 	   4,   -1, 	   0,   -5
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -5,   -9, 	   2,   -9, 	   5,   -7, 	   0,   -9
+.2byte   -5,   -5, 	   2,   -5, 	   5,   -3, 	   0,   -5
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -1,    0, 	 -11,   -9, 	   9,   -9, 	  -1,   -4
+.2byte   -1,   -6, 	  -8,    0, 	   6,    0, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,  -12, 	   9,  -12, 	  -1,   -7
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    5,   -1, 	   6,  -12, 	 -10,   -1, 	  -2,   -4
+.2byte    4,   -7, 	   8,   -3, 	  -1,   -1, 	   0,   -5
+.2byte    4,   -7, 	   6,  -15, 	 -10,  -11, 	  -1,   -6
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    9,   -5, 	  -2,  -15, 	  -4,    1, 	   1,   -7
+.2byte    6,   -9, 	   7,   -5, 	   5,   -1, 	   1,   -7
+.2byte    6,   -9, 	  -2,  -15, 	  -6,  -12, 	   0,   -8
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    8,   -8, 	  -9,  -10, 	   8,    1, 	   0,   -6
+.2byte    7,  -11, 	  -2,   -5, 	   8,   -3, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -15, 	   8,  -11, 	   0,   -9
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   9,   -4, 	 -11,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   8,  -15, 	 -10,  -15, 	  -1,   -9
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -8,   -8, 	   9,  -10, 	  -8,    1, 	   0,   -6
+.2byte   -7,  -11, 	   2,   -5, 	  -8,   -3, 	   0,   -8
+.2byte   -7,  -11, 	   6,  -15, 	  -8,  -11, 	   0,   -9
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -9,   -5, 	   2,  -15, 	   4,    1, 	  -1,   -7
+.2byte   -6,   -9, 	  -7,   -5, 	  -5,   -1, 	  -1,   -7
+.2byte   -6,   -9, 	   2,  -15, 	   6,  -12, 	   0,   -8
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -5,   -1, 	  -6,  -12, 	  10,   -1, 	   2,   -4
+.2byte   -4,   -7, 	  -8,   -3, 	   1,   -1, 	   0,   -5
+.2byte   -4,   -7, 	  -6,  -15, 	  10,  -11, 	   1,   -6
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -1,    0, 	 -11,   -9, 	   9,   -9, 	  -1,   -4
+.2byte   -1,   -6, 	  -8,    0, 	   6,    0, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,  -12, 	   9,  -12, 	  -1,   -7
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    5,   -1, 	   6,  -12, 	 -10,   -1, 	  -2,   -4
+.2byte    4,   -7, 	   8,   -3, 	  -1,   -1, 	   0,   -5
+.2byte    4,   -7, 	   6,  -15, 	 -10,  -11, 	  -1,   -6
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    9,   -5, 	  -2,  -15, 	  -4,    1, 	   1,   -7
+.2byte    6,   -9, 	   7,   -5, 	   5,   -1, 	   1,   -7
+.2byte    6,   -9, 	  -2,  -15, 	  -6,  -12, 	   0,   -8
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    8,   -8, 	  -9,  -10, 	   8,    1, 	   0,   -6
+.2byte    7,  -11, 	  -2,   -5, 	   8,   -3, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -15, 	   8,  -11, 	   0,   -9
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   9,   -4, 	 -11,   -4, 	  -1,   -8
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   8,  -15, 	 -10,  -15, 	  -1,   -9
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -8,   -8, 	   9,  -10, 	  -8,    1, 	   0,   -6
+.2byte   -7,  -11, 	   2,   -5, 	  -8,   -3, 	   0,   -8
+.2byte   -7,  -11, 	   6,  -15, 	  -8,  -11, 	   0,   -9
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -9,   -5, 	   2,  -15, 	   4,    1, 	  -1,   -7
+.2byte   -6,   -9, 	  -7,   -5, 	  -5,   -1, 	  -1,   -7
+.2byte   -6,   -9, 	   2,  -15, 	   6,  -12, 	   0,   -8
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -5,   -1, 	  -6,  -12, 	  10,   -1, 	   2,   -4
+.2byte   -4,   -7, 	  -8,   -3, 	   1,   -1, 	   0,   -5
+.2byte   -4,   -7, 	  -6,  -15, 	  10,  -11, 	   1,   -6
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,   -8, 	   4,   -8, 	  -1,   -9
+.2byte   -1,   -4, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -8,    0, 	   6,    0, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,  -12, 	   9,  -12, 	  -1,   -7
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    5,   -9, 	  -2,   -9, 	  -5,   -7, 	   0,   -9
+.2byte    5,   -5, 	  -2,   -5, 	  -5,   -3, 	   0,   -5
+.2byte    4,   -7, 	   8,   -3, 	  -1,   -1, 	   0,   -5
+.2byte    4,   -7, 	   6,  -15, 	 -10,  -11, 	  -1,   -6
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    7,  -10, 	  -5,   -8, 	  -4,   -5, 	   0,   -9
+.2byte    7,   -6, 	  -5,   -4, 	  -4,   -1, 	   0,   -5
+.2byte    6,   -9, 	   7,   -5, 	   5,   -1, 	   1,   -7
+.2byte    6,   -9, 	  -2,  -15, 	  -6,  -12, 	   0,   -8
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    7,  -12, 	  -5,   -7, 	  -1,   -5, 	   1,  -10
+.2byte    7,   -8, 	  -4,   -3, 	  -1,   -1, 	   1,   -6
+.2byte    7,  -11, 	  -2,   -5, 	   8,   -3, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -15, 	   8,  -11, 	   0,   -9
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -9
+.2byte   -1,   -9, 	   2,   -2, 	  -4,   -2, 	  -1,   -6
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   8,  -15, 	 -10,  -15, 	  -1,   -9
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -7,  -12, 	   5,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -7,   -8, 	   4,   -3, 	   1,   -1, 	  -1,   -6
+.2byte   -7,  -11, 	   2,   -5, 	  -8,   -3, 	   0,   -8
+.2byte   -7,  -11, 	   6,  -15, 	  -8,  -11, 	   0,   -9
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -7,  -10, 	   5,   -8, 	   4,   -5, 	   0,   -9
+.2byte   -7,   -6, 	   5,   -4, 	   4,   -1, 	   0,   -5
+.2byte   -6,   -9, 	  -7,   -5, 	  -5,   -1, 	  -1,   -7
+.2byte   -6,   -9, 	   2,  -15, 	   6,  -12, 	   0,   -8
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -5,   -9, 	   2,   -9, 	   5,   -7, 	   0,   -9
+.2byte   -5,   -5, 	   2,   -5, 	   5,   -3, 	   0,   -5
+.2byte   -4,   -7, 	  -8,   -3, 	   1,   -1, 	   0,   -5
+.2byte   -4,   -7, 	  -6,  -15, 	  10,  -11, 	   1,   -6
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,   -8, 	   4,   -8, 	  -1,   -9
+.2byte   -1,   -4, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -8,    0, 	   6,    0, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,  -12, 	   9,  -12, 	  -1,   -7
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    5,   -9, 	  -2,   -9, 	  -5,   -7, 	   0,   -9
+.2byte    5,   -5, 	  -2,   -5, 	  -5,   -3, 	   0,   -5
+.2byte    4,   -7, 	   8,   -3, 	  -1,   -1, 	   0,   -5
+.2byte    4,   -7, 	   6,  -15, 	 -10,  -11, 	  -1,   -6
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    7,  -10, 	  -5,   -8, 	  -4,   -5, 	   0,   -9
+.2byte    7,   -6, 	  -5,   -4, 	  -4,   -1, 	   0,   -5
+.2byte    6,   -9, 	   7,   -5, 	   5,   -1, 	   1,   -7
+.2byte    6,   -9, 	  -2,  -15, 	  -6,  -12, 	   0,   -8
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    7,  -12, 	  -5,   -7, 	  -1,   -5, 	   1,  -10
+.2byte    7,   -8, 	  -4,   -3, 	  -1,   -1, 	   1,   -6
+.2byte    7,  -11, 	  -2,   -5, 	   8,   -3, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -15, 	   8,  -11, 	   0,   -9
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -9
+.2byte   -1,   -9, 	   2,   -2, 	  -4,   -2, 	  -1,   -6
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   8,  -15, 	 -10,  -15, 	  -1,   -9
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -7,  -12, 	   5,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -7,   -8, 	   4,   -3, 	   1,   -1, 	  -1,   -6
+.2byte   -7,  -11, 	   2,   -5, 	  -8,   -3, 	   0,   -8
+.2byte   -7,  -11, 	   6,  -15, 	  -8,  -11, 	   0,   -9
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -7,  -10, 	   5,   -8, 	   4,   -5, 	   0,   -9
+.2byte   -7,   -6, 	   5,   -4, 	   4,   -1, 	   0,   -5
+.2byte   -6,   -9, 	  -7,   -5, 	  -5,   -1, 	  -1,   -7
+.2byte   -6,   -9, 	   2,  -15, 	   6,  -12, 	   0,   -8
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -5,   -9, 	   2,   -9, 	   5,   -7, 	   0,   -9
+.2byte   -5,   -5, 	   2,   -5, 	   5,   -3, 	   0,   -5
+.2byte   -4,   -7, 	  -8,   -3, 	   1,   -1, 	   0,   -5
+.2byte   -4,   -7, 	  -6,  -15, 	  10,  -11, 	   1,   -6
+.2byte   -5,   -4, 	   2,   -5, 	   5,   -3, 	  -1,   -4
+.2byte   -4,   -5, 	   3,   -5, 	   6,   -3, 	   0,   -5
+.2byte    0,   -7, 	  -4,  -15, 	   4,  -15, 	   0,   -8
+.2byte    2,   -7, 	   0,  -17, 	  -4,  -14, 	  -2,   -8
+.2byte    4,   -8, 	   3,  -15, 	   0,  -14, 	  -2,   -8
+.2byte    4,  -10, 	  -2,  -15, 	   4,  -14, 	  -1,   -8
+.2byte    0,  -10, 	   5,  -14, 	  -5,  -14, 	   0,   -9
+.2byte   -5,  -10, 	   1,  -15, 	  -5,  -14, 	   0,   -8
+.2byte   -5,   -8, 	  -4,  -15, 	  -1,  -14, 	   1,   -8
+.2byte   -3,   -7, 	  -1,  -17, 	   3,  -14, 	   1,   -8
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,   -8, 	   4,   -8, 	  -1,   -9
+.2byte   -1,   -4, 	  -6,   -4, 	   4,   -4, 	  -1,   -5
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    5,   -9, 	  -2,   -9, 	  -5,   -7, 	   0,   -9
+.2byte    5,   -5, 	  -2,   -5, 	  -5,   -3, 	   0,   -5
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    7,  -10, 	  -5,   -8, 	  -4,   -5, 	   0,   -9
+.2byte    7,   -6, 	  -5,   -4, 	  -4,   -1, 	   0,   -5
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    7,  -12, 	  -5,   -7, 	  -1,   -5, 	   1,  -10
+.2byte    7,   -8, 	  -4,   -3, 	  -1,   -1, 	   1,   -6
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -9
+.2byte   -1,   -9, 	   2,   -2, 	  -4,   -2, 	  -1,   -6
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -7,  -12, 	   5,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -7,   -8, 	   4,   -3, 	   1,   -1, 	  -1,   -6
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -7,  -10, 	   5,   -8, 	   4,   -5, 	   0,   -9
+.2byte   -7,   -6, 	   5,   -4, 	   4,   -1, 	   0,   -5
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -5,   -9, 	   2,   -9, 	   5,   -7, 	   0,   -9
+.2byte   -5,   -5, 	   2,   -5, 	   5,   -3, 	   0,   -5
+.2byte   -1,    0, 	 -11,   -9, 	   9,   -9, 	  -1,   -4
+.2byte   -7,    0, 	  -8,  -11, 	   8,    0, 	   0,   -3
+.2byte   -9,   -5, 	   2,  -15, 	   4,    1, 	  -1,   -7
+.2byte   -8,  -10, 	   9,  -12, 	  -8,   -1, 	   0,   -8
+.2byte    0,  -11, 	  10,   -5, 	 -10,   -5, 	   0,   -9
+.2byte    8,   -8, 	  -9,  -10, 	   8,    1, 	   0,   -6
+.2byte    9,   -3, 	  -2,  -13, 	  -4,    3, 	   1,   -5
+.2byte    6,   -1, 	   7,  -12, 	  -9,   -1, 	  -1,   -4
+.2byte   -1,   -7, 	 -11,  -13, 	   9,  -13, 	  -1,   -8
+.2byte    4,   -8, 	   6,  -16, 	 -10,  -12, 	  -1,   -7
+.2byte    6,  -10, 	  -2,  -16, 	  -6,  -13, 	   0,   -9
+.2byte    7,  -12, 	  -6,  -16, 	   8,  -12, 	   0,  -10
+.2byte   -1,  -12, 	   8,  -16, 	 -10,  -16, 	  -1,  -10
+.2byte   -7,  -12, 	   6,  -16, 	  -8,  -12, 	   0,  -10
+.2byte   -6,  -10, 	   2,  -16, 	   6,  -13, 	   0,   -9
+.2byte   -4,   -8, 	  -6,  -16, 	  10,  -12, 	   1,   -7
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -1,   -6, 	  -8,    0, 	   6,    0, 	  -1,   -7
+.2byte   -1,   -6, 	 -11,  -12, 	   9,  -12, 	  -1,   -7
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    4,   -7, 	   8,   -3, 	  -1,   -1, 	   0,   -5
+.2byte    4,   -7, 	   6,  -15, 	 -10,  -11, 	  -1,   -6
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    6,   -9, 	   7,   -5, 	   5,   -1, 	   1,   -7
+.2byte    6,   -9, 	  -2,  -15, 	  -6,  -12, 	   0,   -8
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    7,  -11, 	  -2,   -5, 	   8,   -3, 	   0,   -8
+.2byte    7,  -11, 	  -6,  -15, 	   8,  -11, 	   0,   -9
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -12, 	   6,   -4, 	  -8,   -4, 	  -1,   -9
+.2byte   -1,  -11, 	   8,  -15, 	 -10,  -15, 	  -1,   -9
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -7,  -11, 	   2,   -5, 	  -8,   -3, 	   0,   -8
+.2byte   -7,  -11, 	   6,  -15, 	  -8,  -11, 	   0,   -9
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -6,   -9, 	  -7,   -5, 	  -5,   -1, 	  -1,   -7
+.2byte   -6,   -9, 	   2,  -15, 	   6,  -12, 	   0,   -8
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -4,   -7, 	  -8,   -3, 	   1,   -1, 	   0,   -5
+.2byte   -4,   -7, 	  -6,  -15, 	  10,  -11, 	   1,   -6
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -1,   -5, 	  -6,   -5, 	   4,   -5, 	  -1,   -6
+.2byte   -5,   -6, 	   2,   -6, 	   5,   -4, 	   0,   -6
+.2byte   -7,   -7, 	   5,   -5, 	   4,   -2, 	   0,   -6
+.2byte   -7,   -9, 	   5,   -4, 	   1,   -2, 	  -1,   -7
+.2byte   -1,   -9, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte    7,   -9, 	  -5,   -4, 	  -1,   -2, 	   1,   -7
+.2byte    7,   -7, 	  -5,   -5, 	  -4,   -2, 	   0,   -6
+.2byte    5,   -6, 	  -2,   -6, 	  -5,   -4, 	   0,   -6
+sTaillowAnimTable1:
+.4byte sTaillowAnims_1_1
+.4byte sTaillowAnims_1_2
+.4byte sTaillowAnims_1_3
+.4byte sTaillowAnims_1_4
+.4byte sTaillowAnims_1_5
+.4byte sTaillowAnims_1_6
+.4byte sTaillowAnims_1_7
+.4byte sTaillowAnims_1_8
+sTaillowAnimTable2:
+.4byte sTaillowAnims_2_1
+.4byte sTaillowAnims_2_2
+.4byte sTaillowAnims_2_3
+.4byte sTaillowAnims_2_4
+.4byte sTaillowAnims_2_5
+.4byte sTaillowAnims_2_6
+.4byte sTaillowAnims_2_7
+.4byte sTaillowAnims_2_8
+sTaillowAnimTable3:
+.4byte sTaillowAnims_3_1
+.4byte sTaillowAnims_3_2
+.4byte sTaillowAnims_3_3
+.4byte sTaillowAnims_3_4
+.4byte sTaillowAnims_3_5
+.4byte sTaillowAnims_3_6
+.4byte sTaillowAnims_3_7
+.4byte sTaillowAnims_3_8
+sTaillowAnimTable4:
+.4byte sTaillowAnims_4_1
+.4byte sTaillowAnims_4_2
+.4byte sTaillowAnims_4_3
+.4byte sTaillowAnims_4_4
+.4byte sTaillowAnims_4_5
+.4byte sTaillowAnims_4_6
+.4byte sTaillowAnims_4_7
+.4byte sTaillowAnims_4_8
+sTaillowAnimTable5:
+.4byte sTaillowAnims_5_1
+.4byte sTaillowAnims_5_2
+.4byte sTaillowAnims_5_3
+.4byte sTaillowAnims_5_4
+.4byte sTaillowAnims_5_5
+.4byte sTaillowAnims_5_6
+.4byte sTaillowAnims_5_7
+.4byte sTaillowAnims_5_8
+sTaillowAnimTable6:
+.4byte sTaillowAnims_6_1
+.4byte sTaillowAnims_6_1
+.4byte sTaillowAnims_6_1
+.4byte sTaillowAnims_6_1
+.4byte sTaillowAnims_6_1
+.4byte sTaillowAnims_6_1
+.4byte sTaillowAnims_6_1
+.4byte sTaillowAnims_6_1
+sTaillowAnimTable7:
+.4byte sTaillowAnims_7_1
+.4byte sTaillowAnims_7_2
+.4byte sTaillowAnims_7_3
+.4byte sTaillowAnims_7_4
+.4byte sTaillowAnims_7_5
+.4byte sTaillowAnims_7_6
+.4byte sTaillowAnims_7_7
+.4byte sTaillowAnims_7_8
+sTaillowAnimTable8:
+.4byte sTaillowAnims_8_1
+.4byte sTaillowAnims_8_2
+.4byte sTaillowAnims_8_3
+.4byte sTaillowAnims_8_4
+.4byte sTaillowAnims_8_5
+.4byte sTaillowAnims_8_6
+.4byte sTaillowAnims_8_7
+.4byte sTaillowAnims_8_8
+sTaillowAnimTable9:
+.4byte sTaillowAnims_9_1
+.4byte sTaillowAnims_9_2
+.4byte sTaillowAnims_9_3
+.4byte sTaillowAnims_9_4
+.4byte sTaillowAnims_9_5
+.4byte sTaillowAnims_9_6
+.4byte sTaillowAnims_9_7
+.4byte sTaillowAnims_9_8
+sTaillowAnimTable10:
+.4byte sTaillowAnims_10_1
+.4byte sTaillowAnims_10_2
+.4byte sTaillowAnims_10_3
+.4byte sTaillowAnims_10_4
+.4byte sTaillowAnims_10_5
+.4byte sTaillowAnims_10_6
+.4byte sTaillowAnims_10_7
+.4byte sTaillowAnims_10_8
+sTaillowAnimTable11:
+.4byte sTaillowAnims_11_1
+.4byte sTaillowAnims_11_2
+.4byte sTaillowAnims_11_3
+.4byte sTaillowAnims_11_4
+.4byte sTaillowAnims_11_5
+.4byte sTaillowAnims_11_6
+.4byte sTaillowAnims_11_7
+.4byte sTaillowAnims_11_8
+sTaillowAnimTable12:
+.4byte sTaillowAnims_12_1
+.4byte sTaillowAnims_12_2
+.4byte sTaillowAnims_12_3
+.4byte sTaillowAnims_12_4
+.4byte sTaillowAnims_12_5
+.4byte sTaillowAnims_12_6
+.4byte sTaillowAnims_12_7
+.4byte sTaillowAnims_12_8
+sTaillowAnimTable13:
+.4byte sTaillowAnims_13_1
+.4byte sTaillowAnims_13_2
+.4byte sTaillowAnims_13_3
+.4byte sTaillowAnims_13_4
+.4byte sTaillowAnims_13_5
+.4byte sTaillowAnims_13_6
+.4byte sTaillowAnims_13_7
+.4byte sTaillowAnims_13_8
+sAxAnimationsTaillow:
+.4byte sTaillowAnimTable1
+.4byte sTaillowAnimTable2
+.4byte sTaillowAnimTable3
+.4byte sTaillowAnimTable4
+.4byte sTaillowAnimTable5
+.4byte sTaillowAnimTable6
+.4byte sTaillowAnimTable7
+.4byte sTaillowAnimTable8
+.4byte sTaillowAnimTable9
+.4byte sTaillowAnimTable10
+.4byte sTaillowAnimTable11
+.4byte sTaillowAnimTable12
+.4byte sTaillowAnimTable13
+sAxSpritesTaillow:
+.4byte sTaillowSprites1
+.4byte sTaillowSprites2
+.4byte sTaillowSprites3
+.4byte sTaillowSprites4
+.4byte sTaillowSprites5
+.4byte sTaillowSprites6
+.4byte sTaillowSprites7
+.4byte sTaillowSprites8
+.4byte sTaillowSprites9
+.4byte sTaillowSprites10
+.4byte sTaillowSprites11
+.4byte sTaillowSprites12
+.4byte sTaillowSprites13
+.4byte sTaillowSprites14
+.4byte sTaillowSprites15
+.4byte sTaillowSprites16
+.4byte sTaillowSprites17
+.4byte sTaillowSprites18
+.4byte sTaillowSprites19
+.4byte sTaillowSprites20
+.4byte sTaillowSprites21
+.4byte sTaillowSprites22
+.4byte sTaillowSprites23
+.4byte sTaillowSprites24
+.4byte sTaillowSprites25
+.4byte sTaillowSprites26
+.4byte sTaillowSprites27
+.4byte sTaillowSprites28
+.4byte sTaillowSprites29
+.4byte sTaillowSprites30
+.4byte sTaillowSprites31
+.4byte sTaillowSprites32
+.4byte sTaillowSprites33
+.4byte sTaillowSprites34
+.4byte sTaillowSprites35
+.4byte sTaillowSprites36
+.4byte sTaillowSprites37
+sAxMainTaillow:
+ax_main sAxPosesTaillow, sAxAnimationsTaillow, 13, sAxSpritesTaillow, sAxPositionsTaillow

--- a/data/ax/tangela.inc
+++ b/data/ax/tangela.inc
@@ -1,0 +1,2534 @@
+.global gAxTangela
+gAxTangela:
+ax_siro sAxMainTangela
+sTangelaPose1:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose4:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose5:
+ax_pose 4, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose6:
+ax_pose 5, 0x01ed, 0x90ee, 0xbc00
+ax_pose_terminator
+sTangelaPose7:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose8:
+ax_pose 7, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose9:
+ax_pose 8, 0x01ed, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose10:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose11:
+ax_pose 10, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose12:
+ax_pose 11, 0x01ed, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose15:
+ax_pose 14, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose18:
+ax_pose 11, 0x01ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose21:
+ax_pose 8, 0x01ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose24:
+ax_pose 5, 0x01ed, 0x80f1, 0xbc00
+ax_pose_terminator
+sTangelaPose25:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose26:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose27:
+ax_pose 15, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose28:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose29:
+ax_pose 4, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose30:
+ax_pose 16, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose31:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose32:
+ax_pose 7, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose33:
+ax_pose 17, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose34:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose35:
+ax_pose 10, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose36:
+ax_pose 18, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose37:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose38:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose39:
+ax_pose 19, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose40:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose41:
+ax_pose 10, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose42:
+ax_pose 18, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose43:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose44:
+ax_pose 7, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose45:
+ax_pose 17, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose46:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose47:
+ax_pose 4, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose48:
+ax_pose 16, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose49:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose50:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose51:
+ax_pose 15, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose52:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose53:
+ax_pose 4, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose54:
+ax_pose 16, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose55:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose56:
+ax_pose 7, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose57:
+ax_pose 17, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose58:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose59:
+ax_pose 10, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose60:
+ax_pose 18, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose61:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose62:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose63:
+ax_pose 19, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose64:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose65:
+ax_pose 10, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose66:
+ax_pose 18, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose67:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose68:
+ax_pose 7, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose69:
+ax_pose 17, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose70:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose71:
+ax_pose 4, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose72:
+ax_pose 16, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose73:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose74:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose75:
+ax_pose 15, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose76:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose77:
+ax_pose 4, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose78:
+ax_pose 16, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose79:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose80:
+ax_pose 7, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose81:
+ax_pose 17, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose82:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose83:
+ax_pose 10, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose84:
+ax_pose 18, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose85:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose86:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose87:
+ax_pose 19, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose88:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose89:
+ax_pose 10, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose90:
+ax_pose 18, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose91:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose92:
+ax_pose 7, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose93:
+ax_pose 17, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose94:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose95:
+ax_pose 4, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose96:
+ax_pose 16, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose97:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose98:
+ax_pose 20, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose99:
+ax_pose 15, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose100:
+ax_pose 21, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose101:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose102:
+ax_pose 22, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose103:
+ax_pose 16, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose104:
+ax_pose 23, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose105:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose106:
+ax_pose 24, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose107:
+ax_pose 17, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose108:
+ax_pose 25, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose109:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose110:
+ax_pose 26, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose111:
+ax_pose 18, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose112:
+ax_pose 27, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose113:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose114:
+ax_pose 28, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose115:
+ax_pose 19, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose116:
+ax_pose 29, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose117:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose118:
+ax_pose 26, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose119:
+ax_pose 18, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose120:
+ax_pose 27, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose121:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose122:
+ax_pose 24, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose123:
+ax_pose 17, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose124:
+ax_pose 25, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose125:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose126:
+ax_pose 22, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose127:
+ax_pose 16, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose128:
+ax_pose 23, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose129:
+ax_pose 30, 0x01eb, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose130:
+ax_pose 31, 0x01eb, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose131:
+ax_pose 32, 0x01e1, 0x80f2, 0xbc00
+ax_pose_terminator
+sTangelaPose132:
+ax_pose 33, 0x01e2, 0x90ec, 0xbc00
+ax_pose_terminator
+sTangelaPose133:
+ax_pose 34, 0x01e3, 0x90ed, 0xbc00
+ax_pose_terminator
+sTangelaPose134:
+ax_pose 35, 0x01e3, 0x90ed, 0xbc00
+ax_pose_terminator
+sTangelaPose135:
+ax_pose 36, 0x01e2, 0x80f2, 0xbc00
+ax_pose_terminator
+sTangelaPose136:
+ax_pose 35, 0x01e3, 0x80f3, 0xbc00
+ax_pose_terminator
+sTangelaPose137:
+ax_pose 34, 0x01e3, 0x80f3, 0xbc00
+ax_pose_terminator
+sTangelaPose138:
+ax_pose 33, 0x01e2, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose139:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose140:
+ax_pose 1, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose141:
+ax_pose 2, 0x01ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose142:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose143:
+ax_pose 4, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose144:
+ax_pose 5, 0x01ed, 0x90ee, 0xbc00
+ax_pose_terminator
+sTangelaPose145:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose146:
+ax_pose 7, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose147:
+ax_pose 8, 0x01ed, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose148:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose149:
+ax_pose 10, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose150:
+ax_pose 11, 0x01ed, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose151:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose152:
+ax_pose 13, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose153:
+ax_pose 14, 0x01e9, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose154:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose155:
+ax_pose 10, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose156:
+ax_pose 11, 0x01ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose157:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose158:
+ax_pose 7, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose159:
+ax_pose 8, 0x01ed, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose160:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose161:
+ax_pose 4, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose162:
+ax_pose 5, 0x01ed, 0x80f1, 0xbc00
+ax_pose_terminator
+sTangelaPose163:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose164:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose165:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose166:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose167:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose168:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose169:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose170:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose171:
+ax_pose 20, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose172:
+ax_pose 22, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose173:
+ax_pose 24, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose174:
+ax_pose 26, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose175:
+ax_pose 28, 0x01ea, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose176:
+ax_pose 26, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose177:
+ax_pose 24, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose178:
+ax_pose 22, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose179:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose180:
+ax_pose 1, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose181:
+ax_pose 2, 0x01eb, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose182:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose183:
+ax_pose 4, 0x01e8, 0x90e9, 0xbc00
+ax_pose_terminator
+sTangelaPose184:
+ax_pose 5, 0x01ec, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose185:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose186:
+ax_pose 7, 0x01e8, 0x90ed, 0xbc00
+ax_pose_terminator
+sTangelaPose187:
+ax_pose 8, 0x01eb, 0x90ec, 0xbc00
+ax_pose_terminator
+sTangelaPose188:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose189:
+ax_pose 10, 0x01e8, 0x90ec, 0xbc00
+ax_pose_terminator
+sTangelaPose190:
+ax_pose 11, 0x01eb, 0x90ec, 0xbc00
+ax_pose_terminator
+sTangelaPose191:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose192:
+ax_pose 13, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose193:
+ax_pose 14, 0x01e8, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose194:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose195:
+ax_pose 10, 0x01e8, 0x80f3, 0xbc00
+ax_pose_terminator
+sTangelaPose196:
+ax_pose 11, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sTangelaPose197:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose198:
+ax_pose 7, 0x01e8, 0x80f2, 0xbc00
+ax_pose_terminator
+sTangelaPose199:
+ax_pose 8, 0x01eb, 0x80f3, 0xbc00
+ax_pose_terminator
+sTangelaPose200:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose201:
+ax_pose 4, 0x01e8, 0x80f6, 0xbc00
+ax_pose_terminator
+sTangelaPose202:
+ax_pose 5, 0x01ec, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose203:
+ax_pose 21, 0x01e5, 0x80f0, 0xbc00
+ax_pose_terminator
+sTangelaPose204:
+ax_pose 23, 0x01e5, 0x80f1, 0xbc00
+ax_pose_terminator
+sTangelaPose205:
+ax_pose 25, 0x01e5, 0x80f2, 0xbc00
+ax_pose_terminator
+sTangelaPose206:
+ax_pose 27, 0x01e5, 0x80f1, 0xbc00
+ax_pose_terminator
+sTangelaPose207:
+ax_pose 29, 0x01ea, 0x80f1, 0xbc00
+ax_pose_terminator
+sTangelaPose208:
+ax_pose 27, 0x01e5, 0x90ef, 0xbc00
+ax_pose_terminator
+sTangelaPose209:
+ax_pose 25, 0x01e5, 0x90ee, 0xbc00
+ax_pose_terminator
+sTangelaPose210:
+ax_pose 23, 0x01e5, 0x90ee, 0xbc00
+ax_pose_terminator
+sTangelaPose211:
+ax_pose 0, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose212:
+ax_pose 3, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose213:
+ax_pose 6, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose214:
+ax_pose 9, 0x01e5, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose215:
+ax_pose 12, 0x01ea, 0x80f4, 0xbc00
+ax_pose_terminator
+sTangelaPose216:
+ax_pose 9, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose217:
+ax_pose 6, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+sTangelaPose218:
+ax_pose 3, 0x01e5, 0x90eb, 0xbc00
+ax_pose_terminator
+.align 2
+sTangelaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 1,
+ax_anim 6, 0, 1, 0, -1, 0, 2,
+ax_anim 6, 0, 2, 0, 0, 0, 2,
+ax_anim 6, 0, 2, 0, -1, 0, 1,
+ax_anim_terminator
+sTangelaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -1, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 1, 1,
+ax_anim 6, 0, 4, 1, -1, 2, 2,
+ax_anim 6, 0, 5, 0, 1, 2, 2,
+ax_anim 6, 0, 5, -1, 0, 1, 1,
+ax_anim_terminator
+sTangelaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -1, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 1, 0,
+ax_anim 6, 0, 7, 1, -1, 2, 0,
+ax_anim 6, 0, 8, 0, 0, 2, 0,
+ax_anim 6, 0, 8, -1, 0, 1, 0,
+ax_anim_terminator
+sTangelaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 1, -1,
+ax_anim 6, 0, 10, 1, -1, 2, -2,
+ax_anim 6, 0, 11, 0, -1, 2, -2,
+ax_anim 6, 0, 11, -1, 0, 1, -1,
+ax_anim_terminator
+sTangelaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, -1,
+ax_anim 6, 0, 13, 0, -1, 0, -2,
+ax_anim 6, 0, 14, 0, -1, 0, -2,
+ax_anim 6, 0, 14, 0, 1, 0, -1,
+ax_anim_terminator
+sTangelaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 1, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -2, -1, -1,
+ax_anim 6, 0, 16, -1, -1, -2, -2,
+ax_anim 6, 0, 17, 0, -1, -2, -2,
+ax_anim 6, 0, 17, 1, 0, -1, -1,
+ax_anim_terminator
+sTangelaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 1, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -2, -1, 0,
+ax_anim 6, 0, 19, -1, -1, -2, 0,
+ax_anim 6, 0, 20, 0, 0, -2, 0,
+ax_anim 6, 0, 20, 1, 0, -1, 0,
+ax_anim_terminator
+sTangelaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 1, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -2, -1, 1,
+ax_anim 6, 0, 22, -1, -1, -2, 2,
+ax_anim 6, 0, 23, 0, 1, -2, 2,
+ax_anim 6, 0, 23, 1, 0, -1, 1,
+ax_anim_terminator
+.align 2
+sTangelaAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTangelaAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 2, 4, 5,
+ax_anim 2, 2, 28, 10, 9, 10, 12,
+ax_anim 2, 0, 29, 17, 20, 17, 20,
+ax_anim 2, 1, 29, 18, 19, 18, 19,
+ax_anim 2, 0, 29, 17, 20, 17, 20,
+ax_anim 2, 0, 29, 18, 19, 18, 19,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sTangelaAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, -2, 0, 0,
+ax_anim 2, 0, 31, 4, -4, 4, 0,
+ax_anim 2, 2, 31, 10, -4, 10, 0,
+ax_anim 2, 0, 32, 18, -1, 18, 0,
+ax_anim 2, 1, 32, 18, 0, 18, 1,
+ax_anim 2, 0, 32, 18, -1, 18, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sTangelaAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -3, 0, -1,
+ax_anim 2, 0, 34, 4, -9, 4, -4,
+ax_anim 2, 2, 34, 10, -14, 10, -10,
+ax_anim 2, 0, 35, 17, -20, 17, -20,
+ax_anim 2, 1, 35, 18, -19, 18, -19,
+ax_anim 2, 0, 35, 17, -20, 17, -20,
+ax_anim 2, 0, 35, 18, -19, 18, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sTangelaAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 37, 0, -10, 0, -10,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 1, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 0, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sTangelaAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -3, 0, -1,
+ax_anim 2, 0, 40, -4, -9, -4, -4,
+ax_anim 2, 2, 40, -10, -14, -10, -10,
+ax_anim 2, 0, 41, -17, -20, -17, -20,
+ax_anim 2, 1, 41, -18, -19, -18, -19,
+ax_anim 2, 0, 41, -17, -20, -17, -20,
+ax_anim 2, 0, 41, -18, -19, -18, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sTangelaAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, -2, 0, 0,
+ax_anim 2, 0, 43, -4, -4, -4, 0,
+ax_anim 2, 2, 43, -10, -4, -10, 0,
+ax_anim 2, 0, 44, -18, -1, -18, 0,
+ax_anim 2, 1, 44, -18, 0, -18, 1,
+ax_anim 2, 0, 44, -18, -1, -18, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sTangelaAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 46, -4, 2, -4, 5,
+ax_anim 2, 2, 46, -10, 9, -10, 12,
+ax_anim 2, 0, 47, -17, 20, -17, 20,
+ax_anim 2, 1, 47, -18, 19, -18, 19,
+ax_anim 2, 0, 47, -17, 20, -17, 20,
+ax_anim 2, 0, 47, -18, 19, -18, 19,
+ax_anim 2, 0, 45, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sTangelaAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sTangelaAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 4, 2, 4, 5,
+ax_anim 2, 2, 52, 10, 9, 10, 12,
+ax_anim 2, 0, 53, 17, 20, 17, 20,
+ax_anim 2, 1, 53, 18, 19, 18, 19,
+ax_anim 2, 0, 53, 17, 20, 17, 20,
+ax_anim 2, 0, 53, 18, 19, 18, 19,
+ax_anim 2, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sTangelaAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 4, -4, 4, 0,
+ax_anim 2, 2, 55, 10, -4, 10, 0,
+ax_anim 2, 0, 56, 18, -1, 18, 0,
+ax_anim 2, 1, 56, 18, 0, 18, 1,
+ax_anim 2, 0, 56, 18, -1, 18, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sTangelaAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -3, 0, -1,
+ax_anim 2, 0, 58, 4, -9, 4, -4,
+ax_anim 2, 2, 58, 10, -14, 10, -10,
+ax_anim 2, 0, 59, 17, -20, 17, -20,
+ax_anim 2, 1, 59, 18, -19, 18, -19,
+ax_anim 2, 0, 59, 17, -20, 17, -20,
+ax_anim 2, 0, 59, 18, -19, 18, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sTangelaAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, -4,
+ax_anim 2, 2, 61, 0, -10, 0, -10,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 1, 62, 1, -18, 1, -18,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 0, 62, 1, -18, 1, -18,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sTangelaAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -3, 0, -1,
+ax_anim 2, 0, 64, -4, -9, -4, -4,
+ax_anim 2, 2, 64, -10, -14, -10, -10,
+ax_anim 2, 0, 65, -17, -20, -17, -20,
+ax_anim 2, 1, 65, -18, -19, -18, -19,
+ax_anim 2, 0, 65, -17, -20, -17, -20,
+ax_anim 2, 0, 65, -18, -19, -18, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sTangelaAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 67, -4, -4, -4, 0,
+ax_anim 2, 2, 67, -10, -4, -10, 0,
+ax_anim 2, 0, 68, -18, -1, -18, 0,
+ax_anim 2, 1, 68, -18, 0, -18, 1,
+ax_anim 2, 0, 68, -18, -1, -18, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sTangelaAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 70, -4, 2, -4, 5,
+ax_anim 2, 2, 70, -10, 9, -10, 12,
+ax_anim 2, 0, 71, -17, 20, -17, 20,
+ax_anim 2, 1, 71, -18, 19, -18, 19,
+ax_anim 2, 0, 71, -17, 20, -17, 20,
+ax_anim 2, 0, 71, -18, 19, -18, 19,
+ax_anim 2, 0, 69, -8, 8, -6, 6,
+ax_anim_terminator
+.align 2
+sTangelaAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 8, 2, 72, 0, 0, 0, 0,
+ax_anim 1, 1, 74, 0, -10, 0, -10,
+ax_anim 2, 0, 74, 0, -14, 0, -14,
+ax_anim 4, 0, 74, 0, -15, 0, -15,
+ax_anim 4, 0, 72, 0, -16, 0, -16,
+ax_anim_terminator
+sTangelaAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 8, 2, 75, 0, 0, 0, 0,
+ax_anim 1, 1, 77, -10, -10, -10, -10,
+ax_anim 2, 0, 77, -14, -14, -14, -14,
+ax_anim 4, 0, 77, -15, -15, -15, -15,
+ax_anim 4, 0, 75, -16, -16, -16, -16,
+ax_anim_terminator
+sTangelaAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 8, 2, 78, 0, 0, 0, 0,
+ax_anim 1, 1, 80, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -14, 0, -14, 0,
+ax_anim 4, 0, 80, -15, 0, -15, 0,
+ax_anim 4, 0, 78, -16, 0, -16, 0,
+ax_anim_terminator
+sTangelaAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 8, 2, 81, 0, 0, 0, 0,
+ax_anim 1, 1, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, -14, 14, -14, 14,
+ax_anim 4, 0, 83, -15, 15, -15, 15,
+ax_anim 4, 0, 81, -16, 16, -16, 16,
+ax_anim_terminator
+sTangelaAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 8, 2, 84, 0, 0, 0, 0,
+ax_anim 1, 1, 86, 0, 10, 0, 10,
+ax_anim 2, 0, 86, 0, 14, 0, 14,
+ax_anim 4, 0, 86, 0, 15, 0, 15,
+ax_anim 4, 0, 84, 0, 16, 0, 16,
+ax_anim_terminator
+sTangelaAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 8, 2, 87, 0, 0, 0, 0,
+ax_anim 1, 1, 89, 10, 10, 10, 10,
+ax_anim 2, 0, 89, 14, 14, 14, 14,
+ax_anim 4, 0, 89, 15, 15, 15, 15,
+ax_anim 4, 0, 87, 16, 16, 16, 16,
+ax_anim_terminator
+sTangelaAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 8, 2, 90, 0, 0, 0, 0,
+ax_anim 1, 1, 92, 10, 0, 10, 0,
+ax_anim 2, 0, 92, 14, 0, 14, 0,
+ax_anim 4, 0, 92, 15, 0, 15, 0,
+ax_anim 4, 0, 90, 16, 0, 16, 0,
+ax_anim_terminator
+sTangelaAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 8, 2, 93, 0, 0, 0, 0,
+ax_anim 1, 1, 95, 10, -10, 10, -10,
+ax_anim 2, 0, 95, 14, -14, 14, -14,
+ax_anim 4, 0, 95, 15, -15, 15, -15,
+ax_anim 4, 0, 93, 16, -16, 16, -16,
+ax_anim_terminator
+.align 2
+sTangelaAnims_5_1:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 2, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_5_2:
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 2, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_5_3:
+ax_anim 6, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 2, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_5_4:
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 2, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_5_5:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 2, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_5_6:
+ax_anim 6, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 2, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_5_7:
+ax_anim 6, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 2, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_5_8:
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 2, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTangelaAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTangelaAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sTangelaAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sTangelaAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sTangelaAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sTangelaAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sTangelaAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sTangelaAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sTangelaAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sTangelaAnims_8_1:
+ax_anim 34, 0, 138, 0, 0, 0, 0,
+ax_anim 6, 0, 139, 0, -1, 0, 0,
+ax_anim 6, 0, 139, 0, -2, 0, 0,
+ax_anim 6, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sTangelaAnims_8_2:
+ax_anim 34, 0, 141, 0, 0, 0, 0,
+ax_anim 6, 0, 142, 0, -1, 0, 0,
+ax_anim 6, 0, 142, 0, -2, 0, 0,
+ax_anim 6, 0, 143, -4, 1, 0, 0,
+ax_anim_terminator
+sTangelaAnims_8_3:
+ax_anim 34, 0, 144, 0, 0, 0, 0,
+ax_anim 6, 0, 145, 0, -1, 0, 0,
+ax_anim 6, 0, 145, 0, -2, 0, 0,
+ax_anim 6, 0, 146, -3, -1, 0, 0,
+ax_anim_terminator
+sTangelaAnims_8_4:
+ax_anim 34, 0, 147, 0, 0, 0, 0,
+ax_anim 6, 0, 148, -3, -1, 0, 0,
+ax_anim 6, 0, 148, -3, -2, 0, 0,
+ax_anim 6, 0, 149, -3, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_8_5:
+ax_anim 34, 0, 150, 0, 0, 0, 0,
+ax_anim 6, 0, 151, 0, -1, 0, 0,
+ax_anim 6, 0, 151, 0, -2, 0, 0,
+ax_anim 6, 0, 152, 0, 1, 0, 0,
+ax_anim_terminator
+sTangelaAnims_8_6:
+ax_anim 34, 0, 153, 0, 0, 0, 0,
+ax_anim 6, 0, 154, 3, -1, 0, 0,
+ax_anim 6, 0, 154, 3, -2, 0, 0,
+ax_anim 6, 0, 155, 3, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_8_7:
+ax_anim 34, 0, 156, 0, 0, 0, 0,
+ax_anim 6, 0, 157, 0, -1, 0, 0,
+ax_anim 6, 0, 157, 0, -2, 0, 0,
+ax_anim 6, 0, 158, 3, -1, 0, 0,
+ax_anim_terminator
+sTangelaAnims_8_8:
+ax_anim 34, 0, 159, 0, 0, 0, 0,
+ax_anim 6, 0, 160, 0, -1, 0, 0,
+ax_anim 6, 0, 160, 0, -2, 0, 0,
+ax_anim 6, 0, 161, 4, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sTangelaAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 5, 17, 5,
+ax_anim 2, 0, 164, 21, 14, 21, 14,
+ax_anim 3, 0, 165, 20, 19, 20, 19,
+ax_anim 2, 3, 166, 11, 20, 11, 20,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 16, -5, 16, -5,
+ax_anim 3, 0, 164, 20, -2, 20, -2,
+ax_anim 2, 3, 165, 16, 4, 16, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 19, -20, 19, -20,
+ax_anim 2, 3, 164, 20, -15, 20, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -17, -7, -17,
+ax_anim 3, 0, 162, 0, -20, 0, -20,
+ax_anim 2, 3, 163, 7, -17, 7, -17,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -19, -20, -19, -20,
+ax_anim 2, 3, 168, -20, -15, -20, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -16, -5, -16, -5,
+ax_anim 3, 0, 168, -20, -2, -20, -2,
+ax_anim 2, 3, 167, -16, 4, -16, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 5, -17, 5,
+ax_anim 2, 0, 168, -21, 14, -21, 14,
+ax_anim 3, 0, 167, -20, 19, -20, 19,
+ax_anim 2, 3, 166, -11, 20, -11, 20,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTangelaAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTangelaAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTangelaAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTangelaAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sTangelaGfx1:
+.incbin "baserom.gba", 0x9EC1A0, 0x200
+sTangelaSprites1:
+ax_sprite sTangelaGfx1, 0x200
+ax_sprite_terminator
+sTangelaGfx2:
+.incbin "baserom.gba", 0x9EC3B0, 0x200
+sTangelaSprites2:
+ax_sprite sTangelaGfx2, 0x200
+ax_sprite_terminator
+sTangelaGfx3:
+.incbin "baserom.gba", 0x9EC5C0, 0x200
+sTangelaSprites3:
+ax_sprite sTangelaGfx3, 0x200
+ax_sprite_terminator
+sTangelaGfx4:
+.incbin "baserom.gba", 0x9EC7D0, 0x200
+sTangelaSprites4:
+ax_sprite sTangelaGfx4, 0x200
+ax_sprite_terminator
+sTangelaGfx5:
+.incbin "baserom.gba", 0x9EC9E0, 0x200
+sTangelaSprites5:
+ax_sprite sTangelaGfx5, 0x200
+ax_sprite_terminator
+sTangelaGfx6:
+.incbin "baserom.gba", 0x9ECBF0, 0x200
+sTangelaSprites6:
+ax_sprite sTangelaGfx6, 0x200
+ax_sprite_terminator
+sTangelaGfx7:
+.incbin "baserom.gba", 0x9ECE00, 0x200
+sTangelaSprites7:
+ax_sprite sTangelaGfx7, 0x200
+ax_sprite_terminator
+sTangelaGfx8:
+.incbin "baserom.gba", 0x9ED010, 0x200
+sTangelaSprites8:
+ax_sprite sTangelaGfx8, 0x200
+ax_sprite_terminator
+sTangelaGfx9:
+.incbin "baserom.gba", 0x9ED220, 0x200
+sTangelaSprites9:
+ax_sprite sTangelaGfx9, 0x200
+ax_sprite_terminator
+sTangelaGfx10:
+.incbin "baserom.gba", 0x9ED430, 0x200
+sTangelaSprites10:
+ax_sprite sTangelaGfx10, 0x200
+ax_sprite_terminator
+sTangelaGfx11:
+.incbin "baserom.gba", 0x9ED640, 0x200
+sTangelaSprites11:
+ax_sprite sTangelaGfx11, 0x200
+ax_sprite_terminator
+sTangelaGfx12:
+.incbin "baserom.gba", 0x9ED850, 0x200
+sTangelaSprites12:
+ax_sprite sTangelaGfx12, 0x200
+ax_sprite_terminator
+sTangelaGfx13:
+.incbin "baserom.gba", 0x9EDA60, 0x200
+sTangelaSprites13:
+ax_sprite sTangelaGfx13, 0x200
+ax_sprite_terminator
+sTangelaGfx14:
+.incbin "baserom.gba", 0x9EDC70, 0x200
+sTangelaSprites14:
+ax_sprite sTangelaGfx14, 0x200
+ax_sprite_terminator
+sTangelaGfx15:
+.incbin "baserom.gba", 0x9EDE80, 0x200
+sTangelaSprites15:
+ax_sprite sTangelaGfx15, 0x200
+ax_sprite_terminator
+sTangelaGfx16:
+.incbin "baserom.gba", 0x9EE090, 0x160
+sTangelaSprites16:
+ax_sprite 0, 0x80
+ax_sprite sTangelaGfx16, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx17:
+.incbin "baserom.gba", 0x9EE210, 0x20
+sTangelaGfx17_1:
+.incbin "baserom.gba", 0x9EE230, 0x160
+sTangelaSprites17:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx17, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTangelaGfx17_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx18:
+.incbin "baserom.gba", 0x9EE3C0, 0x160
+sTangelaSprites18:
+ax_sprite 0, 0x80
+ax_sprite sTangelaGfx18, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx19:
+.incbin "baserom.gba", 0x9EE540, 0x40
+sTangelaGfx19_1:
+.incbin "baserom.gba", 0x9EE580, 0x160
+sTangelaSprites19:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx20:
+.incbin "baserom.gba", 0x9EE710, 0x180
+sTangelaSprites20:
+ax_sprite sTangelaGfx20, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTangelaGfx21:
+.incbin "baserom.gba", 0x9EE8A8, 0x40
+sTangelaGfx21_1:
+.incbin "baserom.gba", 0x9EE8E8, 0x160
+sTangelaSprites21:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx22:
+.incbin "baserom.gba", 0x9EEA78, 0x180
+sTangelaSprites22:
+ax_sprite 0, 0x80
+ax_sprite sTangelaGfx22, 0x180
+ax_sprite_terminator
+sTangelaGfx23:
+.incbin "baserom.gba", 0x9EEC10, 0x40
+sTangelaGfx23_1:
+.incbin "baserom.gba", 0x9EEC50, 0x160
+sTangelaSprites23:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx23_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx24:
+.incbin "baserom.gba", 0x9EEDE0, 0x20
+sTangelaGfx24_1:
+.incbin "baserom.gba", 0x9EEE00, 0x160
+sTangelaSprites24:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx24, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTangelaGfx24_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx25:
+.incbin "baserom.gba", 0x9EEF90, 0x40
+sTangelaGfx25_1:
+.incbin "baserom.gba", 0x9EEFD0, 0x100
+sTangelaGfx25_2:
+.incbin "baserom.gba", 0x9EF0D0, 0x40
+sTangelaSprites25:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx26:
+.incbin "baserom.gba", 0x9EF150, 0x160
+sTangelaSprites26:
+ax_sprite 0, 0x80
+ax_sprite sTangelaGfx26, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx27:
+.incbin "baserom.gba", 0x9EF2D0, 0x40
+sTangelaGfx27_1:
+.incbin "baserom.gba", 0x9EF310, 0x160
+sTangelaSprites27:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx27_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx28:
+.incbin "baserom.gba", 0x9EF4A0, 0x40
+sTangelaGfx28_1:
+.incbin "baserom.gba", 0x9EF4E0, 0x160
+sTangelaSprites28:
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx28_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTangelaGfx29:
+.incbin "baserom.gba", 0x9EF670, 0x180
+sTangelaSprites29:
+ax_sprite sTangelaGfx29, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTangelaGfx30:
+.incbin "baserom.gba", 0x9EF808, 0x60
+sTangelaGfx30_1:
+.incbin "baserom.gba", 0x9EF868, 0x100
+sTangelaSprites30:
+ax_sprite sTangelaGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTangelaGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTangelaGfx31:
+.incbin "baserom.gba", 0x9EF990, 0x200
+sTangelaSprites31:
+ax_sprite sTangelaGfx31, 0x200
+ax_sprite_terminator
+sTangelaGfx32:
+.incbin "baserom.gba", 0x9EFBA0, 0x200
+sTangelaSprites32:
+ax_sprite sTangelaGfx32, 0x200
+ax_sprite_terminator
+sTangelaGfx33:
+.incbin "baserom.gba", 0x9EFDB0, 0x200
+sTangelaSprites33:
+ax_sprite sTangelaGfx33, 0x200
+ax_sprite_terminator
+sTangelaGfx34:
+.incbin "baserom.gba", 0x9EFFC0, 0x200
+sTangelaSprites34:
+ax_sprite sTangelaGfx34, 0x200
+ax_sprite_terminator
+sTangelaGfx35:
+.incbin "baserom.gba", 0x9F01D0, 0x200
+sTangelaSprites35:
+ax_sprite sTangelaGfx35, 0x200
+ax_sprite_terminator
+sTangelaGfx36:
+.incbin "baserom.gba", 0x9F03E0, 0x200
+sTangelaSprites36:
+ax_sprite sTangelaGfx36, 0x200
+ax_sprite_terminator
+sTangelaGfx37:
+.incbin "baserom.gba", 0x9F05F0, 0x200
+sTangelaSprites37:
+ax_sprite sTangelaGfx37, 0x200
+ax_sprite_terminator
+sAxPosesTangela:
+.4byte sTangelaPose1
+.4byte sTangelaPose2
+.4byte sTangelaPose3
+.4byte sTangelaPose4
+.4byte sTangelaPose5
+.4byte sTangelaPose6
+.4byte sTangelaPose7
+.4byte sTangelaPose8
+.4byte sTangelaPose9
+.4byte sTangelaPose10
+.4byte sTangelaPose11
+.4byte sTangelaPose12
+.4byte sTangelaPose13
+.4byte sTangelaPose14
+.4byte sTangelaPose15
+.4byte sTangelaPose16
+.4byte sTangelaPose17
+.4byte sTangelaPose18
+.4byte sTangelaPose19
+.4byte sTangelaPose20
+.4byte sTangelaPose21
+.4byte sTangelaPose22
+.4byte sTangelaPose23
+.4byte sTangelaPose24
+.4byte sTangelaPose25
+.4byte sTangelaPose26
+.4byte sTangelaPose27
+.4byte sTangelaPose28
+.4byte sTangelaPose29
+.4byte sTangelaPose30
+.4byte sTangelaPose31
+.4byte sTangelaPose32
+.4byte sTangelaPose33
+.4byte sTangelaPose34
+.4byte sTangelaPose35
+.4byte sTangelaPose36
+.4byte sTangelaPose37
+.4byte sTangelaPose38
+.4byte sTangelaPose39
+.4byte sTangelaPose40
+.4byte sTangelaPose41
+.4byte sTangelaPose42
+.4byte sTangelaPose43
+.4byte sTangelaPose44
+.4byte sTangelaPose45
+.4byte sTangelaPose46
+.4byte sTangelaPose47
+.4byte sTangelaPose48
+.4byte sTangelaPose49
+.4byte sTangelaPose50
+.4byte sTangelaPose51
+.4byte sTangelaPose52
+.4byte sTangelaPose53
+.4byte sTangelaPose54
+.4byte sTangelaPose55
+.4byte sTangelaPose56
+.4byte sTangelaPose57
+.4byte sTangelaPose58
+.4byte sTangelaPose59
+.4byte sTangelaPose60
+.4byte sTangelaPose61
+.4byte sTangelaPose62
+.4byte sTangelaPose63
+.4byte sTangelaPose64
+.4byte sTangelaPose65
+.4byte sTangelaPose66
+.4byte sTangelaPose67
+.4byte sTangelaPose68
+.4byte sTangelaPose69
+.4byte sTangelaPose70
+.4byte sTangelaPose71
+.4byte sTangelaPose72
+.4byte sTangelaPose73
+.4byte sTangelaPose74
+.4byte sTangelaPose75
+.4byte sTangelaPose76
+.4byte sTangelaPose77
+.4byte sTangelaPose78
+.4byte sTangelaPose79
+.4byte sTangelaPose80
+.4byte sTangelaPose81
+.4byte sTangelaPose82
+.4byte sTangelaPose83
+.4byte sTangelaPose84
+.4byte sTangelaPose85
+.4byte sTangelaPose86
+.4byte sTangelaPose87
+.4byte sTangelaPose88
+.4byte sTangelaPose89
+.4byte sTangelaPose90
+.4byte sTangelaPose91
+.4byte sTangelaPose92
+.4byte sTangelaPose93
+.4byte sTangelaPose94
+.4byte sTangelaPose95
+.4byte sTangelaPose96
+.4byte sTangelaPose97
+.4byte sTangelaPose98
+.4byte sTangelaPose99
+.4byte sTangelaPose100
+.4byte sTangelaPose101
+.4byte sTangelaPose102
+.4byte sTangelaPose103
+.4byte sTangelaPose104
+.4byte sTangelaPose105
+.4byte sTangelaPose106
+.4byte sTangelaPose107
+.4byte sTangelaPose108
+.4byte sTangelaPose109
+.4byte sTangelaPose110
+.4byte sTangelaPose111
+.4byte sTangelaPose112
+.4byte sTangelaPose113
+.4byte sTangelaPose114
+.4byte sTangelaPose115
+.4byte sTangelaPose116
+.4byte sTangelaPose117
+.4byte sTangelaPose118
+.4byte sTangelaPose119
+.4byte sTangelaPose120
+.4byte sTangelaPose121
+.4byte sTangelaPose122
+.4byte sTangelaPose123
+.4byte sTangelaPose124
+.4byte sTangelaPose125
+.4byte sTangelaPose126
+.4byte sTangelaPose127
+.4byte sTangelaPose128
+.4byte sTangelaPose129
+.4byte sTangelaPose130
+.4byte sTangelaPose131
+.4byte sTangelaPose132
+.4byte sTangelaPose133
+.4byte sTangelaPose134
+.4byte sTangelaPose135
+.4byte sTangelaPose136
+.4byte sTangelaPose137
+.4byte sTangelaPose138
+.4byte sTangelaPose139
+.4byte sTangelaPose140
+.4byte sTangelaPose141
+.4byte sTangelaPose142
+.4byte sTangelaPose143
+.4byte sTangelaPose144
+.4byte sTangelaPose145
+.4byte sTangelaPose146
+.4byte sTangelaPose147
+.4byte sTangelaPose148
+.4byte sTangelaPose149
+.4byte sTangelaPose150
+.4byte sTangelaPose151
+.4byte sTangelaPose152
+.4byte sTangelaPose153
+.4byte sTangelaPose154
+.4byte sTangelaPose155
+.4byte sTangelaPose156
+.4byte sTangelaPose157
+.4byte sTangelaPose158
+.4byte sTangelaPose159
+.4byte sTangelaPose160
+.4byte sTangelaPose161
+.4byte sTangelaPose162
+.4byte sTangelaPose163
+.4byte sTangelaPose164
+.4byte sTangelaPose165
+.4byte sTangelaPose166
+.4byte sTangelaPose167
+.4byte sTangelaPose168
+.4byte sTangelaPose169
+.4byte sTangelaPose170
+.4byte sTangelaPose171
+.4byte sTangelaPose172
+.4byte sTangelaPose173
+.4byte sTangelaPose174
+.4byte sTangelaPose175
+.4byte sTangelaPose176
+.4byte sTangelaPose177
+.4byte sTangelaPose178
+.4byte sTangelaPose179
+.4byte sTangelaPose180
+.4byte sTangelaPose181
+.4byte sTangelaPose182
+.4byte sTangelaPose183
+.4byte sTangelaPose184
+.4byte sTangelaPose185
+.4byte sTangelaPose186
+.4byte sTangelaPose187
+.4byte sTangelaPose188
+.4byte sTangelaPose189
+.4byte sTangelaPose190
+.4byte sTangelaPose191
+.4byte sTangelaPose192
+.4byte sTangelaPose193
+.4byte sTangelaPose194
+.4byte sTangelaPose195
+.4byte sTangelaPose196
+.4byte sTangelaPose197
+.4byte sTangelaPose198
+.4byte sTangelaPose199
+.4byte sTangelaPose200
+.4byte sTangelaPose201
+.4byte sTangelaPose202
+.4byte sTangelaPose203
+.4byte sTangelaPose204
+.4byte sTangelaPose205
+.4byte sTangelaPose206
+.4byte sTangelaPose207
+.4byte sTangelaPose208
+.4byte sTangelaPose209
+.4byte sTangelaPose210
+.4byte sTangelaPose211
+.4byte sTangelaPose212
+.4byte sTangelaPose213
+.4byte sTangelaPose214
+.4byte sTangelaPose215
+.4byte sTangelaPose216
+.4byte sTangelaPose217
+.4byte sTangelaPose218
+sAxPositionsTangela:
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -13, 	   8,  -13, 	   0,  -14
+.2byte   -1,   -2, 	 -10,   -6, 	   7,   -6, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    6,  -11, 	   7,  -18, 	  -4,  -10, 	   0,  -13
+.2byte    7,   -4, 	   8,  -11, 	  -1,   -4, 	   2,   -8
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    8,  -12, 	   5,  -17, 	   3,  -11, 	  -1,  -13
+.2byte    9,   -4, 	   7,   -9, 	   5,   -3, 	   0,   -7
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    6,  -17, 	  -1,  -19, 	   8,  -15, 	   1,  -13
+.2byte    6,   -8, 	  -2,  -12, 	   7,   -6, 	   1,   -8
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    0,  -17, 	   8,  -16, 	  -7,  -16, 	   0,  -14
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte   -8,  -17, 	  -1,  -19, 	 -10,  -15, 	  -3,  -13
+.2byte   -8,   -8, 	   0,  -12, 	  -9,   -6, 	  -3,   -8
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte  -10,  -12, 	  -7,  -17, 	  -5,  -11, 	  -1,  -13
+.2byte  -11,   -4, 	  -9,   -9, 	  -7,   -3, 	  -2,   -7
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,  -18, 	   2,  -10, 	  -2,  -13
+.2byte   -9,   -4, 	 -10,  -11, 	  -1,   -4, 	  -4,   -8
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -13, 	   8,  -13, 	   0,  -14
+.2byte   -2,   -3, 	 -10,  -10, 	   6,   -9, 	  -1,  -10
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    6,  -11, 	   7,  -18, 	  -4,  -10, 	   0,  -13
+.2byte    7,   -5, 	   7,  -13, 	   0,   -5, 	   0,   -9
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    8,  -12, 	   5,  -17, 	   3,  -11, 	  -1,  -13
+.2byte    8,   -6, 	   7,  -15, 	   7,   -8, 	   0,   -9
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    6,  -17, 	  -1,  -19, 	   8,  -15, 	   1,  -13
+.2byte    4,   -8, 	  -5,  -15, 	   6,  -10, 	  -1,   -9
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    0,  -17, 	   8,  -16, 	  -7,  -16, 	   0,  -14
+.2byte   -1,  -10, 	   7,  -11, 	  -9,   -9, 	  -1,   -9
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte   -8,  -17, 	  -1,  -19, 	 -10,  -15, 	  -3,  -13
+.2byte   -6,   -8, 	   3,  -15, 	  -8,  -10, 	  -1,   -9
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte  -10,  -12, 	  -7,  -17, 	  -5,  -11, 	  -1,  -13
+.2byte  -10,   -6, 	  -9,  -15, 	  -9,   -8, 	  -2,   -9
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,  -18, 	   2,  -10, 	  -2,  -13
+.2byte   -9,   -5, 	  -9,  -13, 	  -2,   -5, 	  -2,   -9
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -13, 	   8,  -13, 	   0,  -14
+.2byte   -2,   -3, 	 -10,  -10, 	   6,   -9, 	  -1,  -10
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    6,  -11, 	   7,  -18, 	  -4,  -10, 	   0,  -13
+.2byte    7,   -5, 	   7,  -13, 	   0,   -5, 	   0,   -9
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    8,  -12, 	   5,  -17, 	   3,  -11, 	  -1,  -13
+.2byte    8,   -6, 	   7,  -15, 	   7,   -8, 	   0,   -9
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    6,  -17, 	  -1,  -19, 	   8,  -15, 	   1,  -13
+.2byte    4,   -8, 	  -5,  -15, 	   6,  -10, 	  -1,   -9
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    0,  -17, 	   8,  -16, 	  -7,  -16, 	   0,  -14
+.2byte   -1,  -10, 	   7,  -11, 	  -9,   -9, 	  -1,   -9
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte   -8,  -17, 	  -1,  -19, 	 -10,  -15, 	  -3,  -13
+.2byte   -6,   -8, 	   3,  -15, 	  -8,  -10, 	  -1,   -9
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte  -10,  -12, 	  -7,  -17, 	  -5,  -11, 	  -1,  -13
+.2byte  -10,   -6, 	  -9,  -15, 	  -9,   -8, 	  -2,   -9
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,  -18, 	   2,  -10, 	  -2,  -13
+.2byte   -9,   -5, 	  -9,  -13, 	  -2,   -5, 	  -2,   -9
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -13, 	   8,  -13, 	   0,  -14
+.2byte   -2,   -3, 	 -10,  -10, 	   6,   -9, 	  -1,  -10
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    6,  -11, 	   7,  -18, 	  -4,  -10, 	   0,  -13
+.2byte    7,   -5, 	   7,  -13, 	   0,   -5, 	   0,   -9
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    8,  -12, 	   5,  -17, 	   3,  -11, 	  -1,  -13
+.2byte    8,   -6, 	   7,  -15, 	   7,   -8, 	   0,   -9
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    6,  -17, 	  -1,  -19, 	   8,  -15, 	   1,  -13
+.2byte    4,   -8, 	  -5,  -15, 	   6,  -10, 	  -1,   -9
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    0,  -17, 	   8,  -16, 	  -7,  -16, 	   0,  -14
+.2byte   -1,  -10, 	   7,  -11, 	  -9,   -9, 	  -1,   -9
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte   -8,  -17, 	  -1,  -19, 	 -10,  -15, 	  -3,  -13
+.2byte   -6,   -8, 	   3,  -15, 	  -8,  -10, 	  -1,   -9
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte  -10,  -12, 	  -7,  -17, 	  -5,  -11, 	  -1,  -13
+.2byte  -10,   -6, 	  -9,  -15, 	  -9,   -8, 	  -2,   -9
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,  -18, 	   2,  -10, 	  -2,  -13
+.2byte   -9,   -5, 	  -9,  -13, 	  -2,   -5, 	  -2,   -9
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte    2,  -11, 	  -5,  -14, 	   8,  -10, 	   0,  -10
+.2byte   -2,   -3, 	 -10,  -10, 	   6,   -9, 	  -1,  -10
+.2byte    0,   -3, 	  -9,   -7, 	   8,  -10, 	  -1,   -9
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    0,  -11, 	   5,  -17, 	  -7,   -8, 	  -2,  -12
+.2byte    7,   -5, 	   7,  -13, 	   0,   -5, 	   0,   -9
+.2byte    5,   -4, 	   8,  -12, 	   0,   -4, 	  -2,   -9
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    5,  -12, 	   3,  -18, 	  -4,   -7, 	  -3,  -12
+.2byte    8,   -6, 	   7,  -15, 	   7,   -8, 	   0,   -9
+.2byte    7,   -5, 	   5,  -14, 	   5,   -7, 	   0,  -10
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    5,  -14, 	   3,  -18, 	   5,   -8, 	  -1,  -11
+.2byte    4,   -8, 	  -5,  -15, 	   6,  -10, 	  -1,   -9
+.2byte    4,   -7, 	  -2,  -17, 	   7,  -13, 	  -2,  -10
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte   -2,  -14, 	   8,  -11, 	  -8,  -13, 	   1,  -11
+.2byte   -1,  -10, 	   7,  -11, 	  -9,   -9, 	  -1,   -9
+.2byte   -1,   -9, 	   7,   -8, 	  -9,   -9, 	  -1,   -8
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte   -7,  -14, 	  -5,  -18, 	  -7,   -8, 	  -1,  -11
+.2byte   -6,   -8, 	   3,  -15, 	  -8,  -10, 	  -1,   -9
+.2byte   -6,   -7, 	   0,  -17, 	  -9,  -13, 	   0,  -10
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte   -7,  -12, 	  -5,  -18, 	   2,   -7, 	   1,  -12
+.2byte  -10,   -6, 	  -9,  -15, 	  -9,   -8, 	  -2,   -9
+.2byte   -9,   -5, 	  -7,  -14, 	  -7,   -7, 	  -2,  -10
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -2,  -11, 	  -7,  -17, 	   5,   -8, 	   0,  -12
+.2byte   -9,   -5, 	  -9,  -13, 	  -2,   -5, 	  -2,   -9
+.2byte   -7,   -4, 	 -10,  -12, 	  -2,   -4, 	   0,   -9
+.2byte   -1,   -2, 	 -10,   -8, 	   8,   -8, 	   0,   -9
+.2byte   -1,   -1, 	 -10,   -7, 	   8,   -7, 	  -1,   -8
+.2byte    0,   -5, 	  -9,  -10, 	   8,   -9, 	   0,   -9
+.2byte    3,   -7, 	   4,  -13, 	  -4,   -7, 	  -2,  -12
+.2byte    7,   -8, 	   3,  -11, 	   2,   -7, 	  -1,   -9
+.2byte    4,  -10, 	  -5,  -14, 	   7,   -9, 	  -1,  -10
+.2byte    0,   -8, 	   7,   -8, 	  -8,   -8, 	   0,   -9
+.2byte   -5,  -10, 	   4,  -14, 	  -8,   -9, 	   0,  -10
+.2byte   -8,   -8, 	  -4,  -11, 	  -3,   -7, 	   0,   -9
+.2byte   -4,   -7, 	  -5,  -13, 	   3,   -7, 	   1,  -12
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -13, 	   8,  -13, 	   0,  -14
+.2byte   -1,   -2, 	 -10,   -6, 	   7,   -6, 	  -1,   -7
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    6,  -11, 	   7,  -18, 	  -4,  -10, 	   0,  -13
+.2byte    7,   -4, 	   8,  -11, 	  -1,   -4, 	   2,   -8
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    8,  -12, 	   5,  -17, 	   3,  -11, 	  -1,  -13
+.2byte    9,   -4, 	   7,   -9, 	   5,   -3, 	   0,   -7
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    6,  -17, 	  -1,  -19, 	   8,  -15, 	   1,  -13
+.2byte    6,   -8, 	  -2,  -12, 	   7,   -6, 	   1,   -8
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    0,  -17, 	   8,  -16, 	  -7,  -16, 	   0,  -14
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -12, 	   0,   -9
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte   -8,  -17, 	  -1,  -19, 	 -10,  -15, 	  -3,  -13
+.2byte   -8,   -8, 	   0,  -12, 	  -9,   -6, 	  -3,   -8
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte  -10,  -12, 	  -7,  -17, 	  -5,  -11, 	  -1,  -13
+.2byte  -11,   -4, 	  -9,   -9, 	  -7,   -3, 	  -2,   -7
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -8,  -11, 	  -9,  -18, 	   2,  -10, 	  -2,  -13
+.2byte   -9,   -4, 	 -10,  -11, 	  -1,   -4, 	  -4,   -8
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    2,  -11, 	  -5,  -14, 	   8,  -10, 	   0,  -10
+.2byte    0,  -11, 	   5,  -17, 	  -7,   -8, 	  -2,  -12
+.2byte    5,  -12, 	   3,  -18, 	  -4,   -7, 	  -3,  -12
+.2byte    5,  -14, 	   3,  -18, 	   5,   -8, 	  -1,  -11
+.2byte   -2,  -14, 	   8,  -11, 	  -8,  -13, 	   1,  -11
+.2byte   -7,  -14, 	  -5,  -18, 	  -7,   -8, 	  -1,  -11
+.2byte   -7,  -12, 	  -5,  -18, 	   2,   -7, 	   1,  -12
+.2byte   -2,  -11, 	  -7,  -17, 	   5,   -8, 	   0,  -12
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -1,   -6, 	  -9,  -10, 	   8,  -10, 	   0,  -11
+.2byte   -1,   -4, 	 -10,   -8, 	   7,   -8, 	  -1,   -9
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+.2byte    4,   -8, 	   5,  -15, 	  -6,   -7, 	  -2,  -10
+.2byte    4,   -5, 	   5,  -12, 	  -4,   -5, 	  -1,   -9
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    6,   -9, 	   3,  -14, 	   1,   -8, 	  -3,  -10
+.2byte    6,   -6, 	   4,  -11, 	   2,   -5, 	  -3,   -9
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    3,  -14, 	  -4,  -16, 	   5,  -12, 	  -2,  -10
+.2byte    3,  -10, 	  -5,  -14, 	   4,   -8, 	  -2,  -10
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    0,  -14, 	   8,  -13, 	  -7,  -13, 	   0,  -11
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -13, 	   0,  -10
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte   -5,  -14, 	   2,  -16, 	  -7,  -12, 	   0,  -10
+.2byte   -5,  -10, 	   3,  -14, 	  -6,   -8, 	   0,  -10
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte   -8,   -9, 	  -5,  -14, 	  -3,   -8, 	   1,  -10
+.2byte   -8,   -6, 	  -6,  -11, 	  -4,   -5, 	   1,   -9
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -6,   -8, 	  -7,  -15, 	   4,   -7, 	   0,  -10
+.2byte   -6,   -5, 	  -7,  -12, 	   2,   -5, 	  -1,   -9
+.2byte    0,   -3, 	  -9,   -7, 	   8,  -10, 	  -1,   -9
+.2byte   -6,   -4, 	  -9,  -12, 	  -1,   -4, 	   1,   -9
+.2byte   -7,   -5, 	  -5,  -14, 	  -5,   -7, 	   0,  -10
+.2byte   -5,   -7, 	   1,  -17, 	  -8,  -13, 	   1,  -10
+.2byte    0,   -9, 	   8,   -8, 	  -8,   -9, 	   0,   -8
+.2byte    4,   -7, 	  -2,  -17, 	   7,  -13, 	  -2,  -10
+.2byte    6,   -5, 	   4,  -14, 	   4,   -7, 	  -1,  -10
+.2byte    4,   -4, 	   7,  -12, 	  -1,   -4, 	  -3,   -9
+.2byte   -1,   -5, 	 -10,   -9, 	   8,   -9, 	  -1,  -11
+.2byte   -6,   -7, 	  -8,  -15, 	   3,   -6, 	  -1,  -10
+.2byte   -8,   -8, 	  -5,  -15, 	  -3,   -8, 	  -1,  -11
+.2byte   -5,  -13, 	   2,  -16, 	  -7,  -11, 	   0,  -11
+.2byte    0,  -11, 	   8,  -12, 	  -8,  -12, 	   0,  -10
+.2byte    3,  -13, 	  -4,  -16, 	   5,  -11, 	  -2,  -11
+.2byte    6,   -8, 	   3,  -15, 	   1,   -8, 	  -1,  -11
+.2byte    4,   -7, 	   6,  -15, 	  -5,   -6, 	  -1,  -10
+sTangelaAnimTable1:
+.4byte sTangelaAnims_1_1
+.4byte sTangelaAnims_1_2
+.4byte sTangelaAnims_1_3
+.4byte sTangelaAnims_1_4
+.4byte sTangelaAnims_1_5
+.4byte sTangelaAnims_1_6
+.4byte sTangelaAnims_1_7
+.4byte sTangelaAnims_1_8
+sTangelaAnimTable2:
+.4byte sTangelaAnims_2_1
+.4byte sTangelaAnims_2_2
+.4byte sTangelaAnims_2_3
+.4byte sTangelaAnims_2_4
+.4byte sTangelaAnims_2_5
+.4byte sTangelaAnims_2_6
+.4byte sTangelaAnims_2_7
+.4byte sTangelaAnims_2_8
+sTangelaAnimTable3:
+.4byte sTangelaAnims_3_1
+.4byte sTangelaAnims_3_2
+.4byte sTangelaAnims_3_3
+.4byte sTangelaAnims_3_4
+.4byte sTangelaAnims_3_5
+.4byte sTangelaAnims_3_6
+.4byte sTangelaAnims_3_7
+.4byte sTangelaAnims_3_8
+sTangelaAnimTable4:
+.4byte sTangelaAnims_4_1
+.4byte sTangelaAnims_4_2
+.4byte sTangelaAnims_4_3
+.4byte sTangelaAnims_4_4
+.4byte sTangelaAnims_4_5
+.4byte sTangelaAnims_4_6
+.4byte sTangelaAnims_4_7
+.4byte sTangelaAnims_4_8
+sTangelaAnimTable5:
+.4byte sTangelaAnims_5_1
+.4byte sTangelaAnims_5_2
+.4byte sTangelaAnims_5_3
+.4byte sTangelaAnims_5_4
+.4byte sTangelaAnims_5_5
+.4byte sTangelaAnims_5_6
+.4byte sTangelaAnims_5_7
+.4byte sTangelaAnims_5_8
+sTangelaAnimTable6:
+.4byte sTangelaAnims_6_1
+.4byte sTangelaAnims_6_1
+.4byte sTangelaAnims_6_1
+.4byte sTangelaAnims_6_1
+.4byte sTangelaAnims_6_1
+.4byte sTangelaAnims_6_1
+.4byte sTangelaAnims_6_1
+.4byte sTangelaAnims_6_1
+sTangelaAnimTable7:
+.4byte sTangelaAnims_7_1
+.4byte sTangelaAnims_7_2
+.4byte sTangelaAnims_7_3
+.4byte sTangelaAnims_7_4
+.4byte sTangelaAnims_7_5
+.4byte sTangelaAnims_7_6
+.4byte sTangelaAnims_7_7
+.4byte sTangelaAnims_7_8
+sTangelaAnimTable8:
+.4byte sTangelaAnims_8_1
+.4byte sTangelaAnims_8_2
+.4byte sTangelaAnims_8_3
+.4byte sTangelaAnims_8_4
+.4byte sTangelaAnims_8_5
+.4byte sTangelaAnims_8_6
+.4byte sTangelaAnims_8_7
+.4byte sTangelaAnims_8_8
+sTangelaAnimTable9:
+.4byte sTangelaAnims_9_1
+.4byte sTangelaAnims_9_2
+.4byte sTangelaAnims_9_3
+.4byte sTangelaAnims_9_4
+.4byte sTangelaAnims_9_5
+.4byte sTangelaAnims_9_6
+.4byte sTangelaAnims_9_7
+.4byte sTangelaAnims_9_8
+sTangelaAnimTable10:
+.4byte sTangelaAnims_10_1
+.4byte sTangelaAnims_10_2
+.4byte sTangelaAnims_10_3
+.4byte sTangelaAnims_10_4
+.4byte sTangelaAnims_10_5
+.4byte sTangelaAnims_10_6
+.4byte sTangelaAnims_10_7
+.4byte sTangelaAnims_10_8
+sTangelaAnimTable11:
+.4byte sTangelaAnims_11_1
+.4byte sTangelaAnims_11_2
+.4byte sTangelaAnims_11_3
+.4byte sTangelaAnims_11_4
+.4byte sTangelaAnims_11_5
+.4byte sTangelaAnims_11_6
+.4byte sTangelaAnims_11_7
+.4byte sTangelaAnims_11_8
+sTangelaAnimTable12:
+.4byte sTangelaAnims_12_1
+.4byte sTangelaAnims_12_2
+.4byte sTangelaAnims_12_3
+.4byte sTangelaAnims_12_4
+.4byte sTangelaAnims_12_5
+.4byte sTangelaAnims_12_6
+.4byte sTangelaAnims_12_7
+.4byte sTangelaAnims_12_8
+sTangelaAnimTable13:
+.4byte sTangelaAnims_13_1
+.4byte sTangelaAnims_13_2
+.4byte sTangelaAnims_13_3
+.4byte sTangelaAnims_13_4
+.4byte sTangelaAnims_13_5
+.4byte sTangelaAnims_13_6
+.4byte sTangelaAnims_13_7
+.4byte sTangelaAnims_13_8
+sAxAnimationsTangela:
+.4byte sTangelaAnimTable1
+.4byte sTangelaAnimTable2
+.4byte sTangelaAnimTable3
+.4byte sTangelaAnimTable4
+.4byte sTangelaAnimTable5
+.4byte sTangelaAnimTable6
+.4byte sTangelaAnimTable7
+.4byte sTangelaAnimTable8
+.4byte sTangelaAnimTable9
+.4byte sTangelaAnimTable10
+.4byte sTangelaAnimTable11
+.4byte sTangelaAnimTable12
+.4byte sTangelaAnimTable13
+sAxSpritesTangela:
+.4byte sTangelaSprites1
+.4byte sTangelaSprites2
+.4byte sTangelaSprites3
+.4byte sTangelaSprites4
+.4byte sTangelaSprites5
+.4byte sTangelaSprites6
+.4byte sTangelaSprites7
+.4byte sTangelaSprites8
+.4byte sTangelaSprites9
+.4byte sTangelaSprites10
+.4byte sTangelaSprites11
+.4byte sTangelaSprites12
+.4byte sTangelaSprites13
+.4byte sTangelaSprites14
+.4byte sTangelaSprites15
+.4byte sTangelaSprites16
+.4byte sTangelaSprites17
+.4byte sTangelaSprites18
+.4byte sTangelaSprites19
+.4byte sTangelaSprites20
+.4byte sTangelaSprites21
+.4byte sTangelaSprites22
+.4byte sTangelaSprites23
+.4byte sTangelaSprites24
+.4byte sTangelaSprites25
+.4byte sTangelaSprites26
+.4byte sTangelaSprites27
+.4byte sTangelaSprites28
+.4byte sTangelaSprites29
+.4byte sTangelaSprites30
+.4byte sTangelaSprites31
+.4byte sTangelaSprites32
+.4byte sTangelaSprites33
+.4byte sTangelaSprites34
+.4byte sTangelaSprites35
+.4byte sTangelaSprites36
+.4byte sTangelaSprites37
+sAxMainTangela:
+ax_main sAxPosesTangela, sAxAnimationsTangela, 13, sAxSpritesTangela, sAxPositionsTangela

--- a/data/ax/tauros.inc
+++ b/data/ax/tauros.inc
@@ -1,0 +1,2676 @@
+.global gAxTauros
+gAxTauros:
+ax_siro sAxMainTauros
+sTaurosPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose4:
+ax_pose 3, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose5:
+ax_pose 4, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose6:
+ax_pose 5, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose8:
+ax_pose 7, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose9:
+ax_pose 8, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose10:
+ax_pose 9, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sTaurosPose11:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sTaurosPose12:
+ax_pose 11, 0x01e8, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose15:
+ax_pose 14, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose16:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose17:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose18:
+ax_pose 11, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose21:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose23:
+ax_pose 4, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose24:
+ax_pose 5, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose25:
+ax_pose 15, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose26:
+ax_pose 16, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose27:
+ax_pose 17, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose28:
+ax_pose 18, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose29:
+ax_pose 19, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose30:
+ax_pose 20, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sTaurosPose31:
+ax_pose 21, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose32:
+ax_pose 22, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose33:
+ax_pose 23, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose34:
+ax_pose 24, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose35:
+ax_pose 25, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose36:
+ax_pose 26, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose37:
+ax_pose 27, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose38:
+ax_pose 28, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose39:
+ax_pose 29, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose40:
+ax_pose 24, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose41:
+ax_pose 25, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose42:
+ax_pose 26, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose43:
+ax_pose 21, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose44:
+ax_pose 22, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose45:
+ax_pose 23, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose46:
+ax_pose 18, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sTaurosPose47:
+ax_pose 19, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sTaurosPose48:
+ax_pose 20, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose49:
+ax_pose 0, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose50:
+ax_pose 1, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose51:
+ax_pose 2, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose52:
+ax_pose 30, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose53:
+ax_pose 31, 0x01e2, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose54:
+ax_pose 3, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose55:
+ax_pose 4, 0x01eb, 0x90f1, 0x6c00
+ax_pose_terminator
+sTaurosPose56:
+ax_pose 5, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose57:
+ax_pose 32, 0x01e0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTaurosPose58:
+ax_pose 33, 0x01e0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTaurosPose59:
+ax_pose 6, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose60:
+ax_pose 7, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sTaurosPose61:
+ax_pose 8, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose62:
+ax_pose 34, 0x01e2, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose63:
+ax_pose 35, 0x01e2, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose64:
+ax_pose 9, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sTaurosPose65:
+ax_pose 10, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sTaurosPose66:
+ax_pose 11, 0x01e8, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose67:
+ax_pose 36, 0x01e3, 0x90ec, 0x6c00
+ax_pose_terminator
+sTaurosPose68:
+ax_pose 37, 0x01e3, 0x90ec, 0x6c00
+ax_pose_terminator
+sTaurosPose69:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose70:
+ax_pose 13, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose71:
+ax_pose 14, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose72:
+ax_pose 38, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose73:
+ax_pose 39, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose74:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose75:
+ax_pose 10, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sTaurosPose76:
+ax_pose 11, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose77:
+ax_pose 36, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose78:
+ax_pose 37, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose79:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose80:
+ax_pose 7, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sTaurosPose81:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose82:
+ax_pose 34, 0x01e2, 0x80f2, 0x6c00
+ax_pose_terminator
+sTaurosPose83:
+ax_pose 35, 0x01e2, 0x80f2, 0x6c00
+ax_pose_terminator
+sTaurosPose84:
+ax_pose 3, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose85:
+ax_pose 4, 0x01eb, 0x80ee, 0x6c00
+ax_pose_terminator
+sTaurosPose86:
+ax_pose 5, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose87:
+ax_pose 32, 0x01e0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose88:
+ax_pose 33, 0x01e0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose89:
+ax_pose 30, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose90:
+ax_pose 32, 0x01e2, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose91:
+ax_pose 34, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose92:
+ax_pose 36, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose93:
+ax_pose 38, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose94:
+ax_pose 36, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose95:
+ax_pose 34, 0x01e3, 0x90ee, 0x6c00
+ax_pose_terminator
+sTaurosPose96:
+ax_pose 32, 0x01e2, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose97:
+ax_pose 0, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose98:
+ax_pose 3, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose99:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose100:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose101:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose102:
+ax_pose 9, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sTaurosPose103:
+ax_pose 6, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose104:
+ax_pose 3, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose105:
+ax_pose 40, 0x01ed, 0x80f1, 0x6c00
+ax_pose_terminator
+sTaurosPose106:
+ax_pose 41, 0x01ed, 0x80f1, 0x6c00
+ax_pose_terminator
+sTaurosPose107:
+ax_pose 42, 0x01e1, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose108:
+ax_pose 43, 0x01e2, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose109:
+ax_pose 44, 0x01e3, 0x90ee, 0x6c00
+ax_pose_terminator
+sTaurosPose110:
+ax_pose 45, 0x01e3, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose111:
+ax_pose 46, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sTaurosPose112:
+ax_pose 45, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sTaurosPose113:
+ax_pose 44, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sTaurosPose114:
+ax_pose 43, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose115:
+ax_pose 0, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose116:
+ax_pose 1, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose117:
+ax_pose 2, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose118:
+ax_pose 3, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose119:
+ax_pose 4, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose120:
+ax_pose 5, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose121:
+ax_pose 6, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose122:
+ax_pose 7, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose123:
+ax_pose 8, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose124:
+ax_pose 9, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sTaurosPose125:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sTaurosPose126:
+ax_pose 11, 0x01e8, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose127:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose128:
+ax_pose 13, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose129:
+ax_pose 14, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose130:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose131:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose132:
+ax_pose 11, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose133:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose134:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose135:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose136:
+ax_pose 3, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose137:
+ax_pose 4, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose138:
+ax_pose 5, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose139:
+ax_pose 2, 0x01e8, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose140:
+ax_pose 5, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose141:
+ax_pose 8, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose142:
+ax_pose 11, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose143:
+ax_pose 14, 0x01ec, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose144:
+ax_pose 11, 0x01e9, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose145:
+ax_pose 8, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose146:
+ax_pose 5, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sTaurosPose147:
+ax_pose 31, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose148:
+ax_pose 33, 0x01e2, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose149:
+ax_pose 35, 0x01e2, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose150:
+ax_pose 37, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose151:
+ax_pose 39, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose152:
+ax_pose 37, 0x01e3, 0x80f2, 0x6c00
+ax_pose_terminator
+sTaurosPose153:
+ax_pose 35, 0x01e2, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose154:
+ax_pose 33, 0x01e2, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose155:
+ax_pose 0, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose156:
+ax_pose 1, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose157:
+ax_pose 2, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose158:
+ax_pose 3, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose159:
+ax_pose 4, 0x01e9, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose160:
+ax_pose 5, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sTaurosPose161:
+ax_pose 6, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose162:
+ax_pose 7, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose163:
+ax_pose 8, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose164:
+ax_pose 9, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sTaurosPose165:
+ax_pose 10, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sTaurosPose166:
+ax_pose 11, 0x01e8, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose167:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose168:
+ax_pose 13, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose169:
+ax_pose 14, 0x01e9, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose170:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose171:
+ax_pose 10, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose172:
+ax_pose 11, 0x01e8, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose173:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose174:
+ax_pose 7, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose175:
+ax_pose 8, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose176:
+ax_pose 3, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose177:
+ax_pose 4, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose178:
+ax_pose 5, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sTaurosPose179:
+ax_pose 30, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose180:
+ax_pose 32, 0x01e2, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose181:
+ax_pose 34, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose182:
+ax_pose 36, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sTaurosPose183:
+ax_pose 38, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose184:
+ax_pose 36, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose185:
+ax_pose 34, 0x01e3, 0x90ee, 0x6c00
+ax_pose_terminator
+sTaurosPose186:
+ax_pose 32, 0x01e2, 0x90ed, 0x6c00
+ax_pose_terminator
+sTaurosPose187:
+ax_pose 0, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose188:
+ax_pose 3, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose189:
+ax_pose 6, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose190:
+ax_pose 9, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sTaurosPose191:
+ax_pose 12, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sTaurosPose192:
+ax_pose 9, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sTaurosPose193:
+ax_pose 6, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sTaurosPose194:
+ax_pose 3, 0x01e6, 0x90ef, 0x6c00
+ax_pose_terminator
+.align 2
+sTaurosAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 1,
+ax_anim 6, 0, 1, 0, -1, 0, 2,
+ax_anim 6, 0, 2, 0, -2, 0, 3,
+ax_anim 6, 0, 2, 0, 2, 0, 5,
+ax_anim 6, 0, 0, 0, 3, 0, 3,
+ax_anim 6, 0, 0, 0, 1, 0, 2,
+ax_anim_terminator
+sTaurosAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, 1, 1, 1,
+ax_anim 6, 0, 4, 2, 0, 2, 2,
+ax_anim 6, 0, 5, 2, 0, 3, 3,
+ax_anim 6, 0, 5, 3, 3, 4, 4,
+ax_anim 6, 0, 3, 4, 4, 4, 4,
+ax_anim 6, 0, 3, 2, 2, 2, 2,
+ax_anim_terminator
+sTaurosAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, 0, 1, 0,
+ax_anim 6, 0, 7, 2, -1, 3, 0,
+ax_anim 6, 0, 8, 4, -2, 5, 0,
+ax_anim 6, 0, 8, 5, 0, 6, 0,
+ax_anim 6, 0, 6, 6, 0, 6, 0,
+ax_anim 6, 0, 6, 2, 0, 3, 0,
+ax_anim_terminator
+sTaurosAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 1, -3, 2, -2,
+ax_anim 6, 0, 10, 2, -6, 4, -4,
+ax_anim 6, 0, 11, 2, -7, 5, -5,
+ax_anim 6, 0, 11, 3, -5, 6, -6,
+ax_anim 6, 0, 9, 4, -4, 3, -3,
+ax_anim 6, 0, 9, 2, -2, 2, -2,
+ax_anim_terminator
+sTaurosAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, -1,
+ax_anim 6, 0, 13, 0, -4, 0, -4,
+ax_anim 6, 0, 14, 0, -8, 0, -6,
+ax_anim 6, 0, 14, 0, -5, 0, -4,
+ax_anim 6, 0, 12, 0, -3, 0, -3,
+ax_anim 6, 0, 12, 0, -2, 0, -2,
+ax_anim_terminator
+sTaurosAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -3, -2, -2,
+ax_anim 6, 0, 16, -2, -6, -4, -4,
+ax_anim 6, 0, 17, -2, -7, -5, -5,
+ax_anim 6, 0, 17, -3, -5, -6, -6,
+ax_anim 6, 0, 15, -4, -4, -3, -3,
+ax_anim 6, 0, 15, -2, -2, -2, -2,
+ax_anim_terminator
+sTaurosAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, 0, -1, 0,
+ax_anim 6, 0, 19, -2, -1, -3, 0,
+ax_anim 6, 0, 20, -4, -2, -5, 0,
+ax_anim 6, 0, 20, -5, 0, -6, 0,
+ax_anim 6, 0, 18, -6, 0, -6, 0,
+ax_anim 6, 0, 18, -2, 0, -3, 0,
+ax_anim_terminator
+sTaurosAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -1, 1, -1, 1,
+ax_anim 6, 0, 22, -2, 0, -2, 2,
+ax_anim 6, 0, 23, -2, 0, -3, 3,
+ax_anim 6, 0, 23, -3, 3, -4, 4,
+ax_anim 6, 0, 21, -4, 4, -4, 4,
+ax_anim 6, 0, 21, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sTaurosAnims_2_1:
+ax_anim 1, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -4, 0, -4,
+ax_anim 4, 0, 24, 0, -5, 0, -5,
+ax_anim 1, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 2, 26, 0, 0, 0, 8,
+ax_anim 2, 0, 26, 0, 5, 0, 12,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 1, 26, 1, 16, 1, 16,
+ax_anim 2, 0, 26, 0, 16, 0, 16,
+ax_anim 2, 0, 26, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 8, 0, 8,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sTaurosAnims_2_2:
+ax_anim 1, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 27, -4, -4, -4, -4,
+ax_anim 4, 0, 27, -5, -5, -5, -5,
+ax_anim 1, 0, 28, 0, -1, 0, 0,
+ax_anim 1, 2, 29, 7, 1, 7, 7,
+ax_anim 2, 0, 29, 12, 7, 12, 12,
+ax_anim 2, 0, 29, 16, 16, 16, 16,
+ax_anim 2, 1, 29, 15, 17, 15, 17,
+ax_anim 2, 0, 29, 16, 16, 16, 16,
+ax_anim 2, 0, 29, 15, 17, 15, 17,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim 2, 0, 27, 4, 4, 4, 4,
+ax_anim_terminator
+sTaurosAnims_2_3:
+ax_anim 1, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 30, -4, 0, -4, 0,
+ax_anim 4, 0, 30, -5, 0, -5, 0,
+ax_anim 1, 0, 31, 0, -2, 0, 0,
+ax_anim 1, 2, 32, 5, -5, 5, 0,
+ax_anim 2, 0, 32, 11, -2, 11, 0,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 1, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 16, 1, 16, 1,
+ax_anim 2, 0, 30, 8, 0, 8, 0,
+ax_anim 2, 0, 30, 4, 0, 4, 0,
+ax_anim_terminator
+sTaurosAnims_2_4:
+ax_anim 1, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 33, -4, 4, -4, 4,
+ax_anim 4, 0, 33, -5, 5, -5, 5,
+ax_anim 1, 0, 34, 0, -4, 0, -1,
+ax_anim 1, 2, 35, 5, -11, 5, -6,
+ax_anim 2, 0, 35, 11, -15, 11, -13,
+ax_anim 2, 0, 35, 16, -18, 16, -18,
+ax_anim 2, 1, 35, 17, -17, 17, -17,
+ax_anim 2, 0, 35, 16, -18, 16, -18,
+ax_anim 2, 0, 35, 17, -17, 17, -17,
+ax_anim 2, 0, 33, 8, -8, 8, -8,
+ax_anim 2, 0, 33, 4, -4, 4, -4,
+ax_anim_terminator
+sTaurosAnims_2_5:
+ax_anim 1, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 36, 0, 4, 0, 4,
+ax_anim 4, 0, 36, 0, 5, 0, 5,
+ax_anim 1, 0, 37, 0, -2, 0, -4,
+ax_anim 1, 2, 38, 0, -11, 0, -9,
+ax_anim 2, 0, 38, 0, -15, 0, -14,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 1, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 0, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -8, 0, -8,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim_terminator
+sTaurosAnims_2_6:
+ax_anim 1, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 39, 4, 4, 4, 4,
+ax_anim 4, 0, 39, 5, 5, 5, 5,
+ax_anim 1, 0, 40, 0, -4, 0, -1,
+ax_anim 1, 2, 41, -5, -11, -5, -6,
+ax_anim 2, 0, 41, -11, -15, -11, -13,
+ax_anim 2, 0, 41, -16, -18, -16, -18,
+ax_anim 2, 1, 41, -17, -17, -17, -17,
+ax_anim 2, 0, 41, -16, -18, -16, -18,
+ax_anim 2, 0, 41, -17, -17, -17, -17,
+ax_anim 2, 0, 39, -8, -8, -8, -8,
+ax_anim 2, 0, 39, -4, -4, -4, -4,
+ax_anim_terminator
+sTaurosAnims_2_7:
+ax_anim 1, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 42, 4, 0, 4, 0,
+ax_anim 4, 0, 42, 5, 0, 5, 0,
+ax_anim 1, 0, 43, 0, -2, 0, 0,
+ax_anim 1, 2, 44, -5, -5, -5, 0,
+ax_anim 2, 0, 44, -11, -2, -11, 0,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 1, 44, -16, 1, -16, 1,
+ax_anim 2, 0, 44, -16, 0, -16, 0,
+ax_anim 2, 0, 44, -16, 1, -16, 1,
+ax_anim 2, 0, 42, -8, 0, -8, 0,
+ax_anim 2, 0, 42, -4, 0, -4, 0,
+ax_anim_terminator
+sTaurosAnims_2_8:
+ax_anim 1, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 45, 4, -4, 4, -4,
+ax_anim 4, 0, 45, 5, -5, 5, -5,
+ax_anim 1, 0, 46, 0, -1, 0, 0,
+ax_anim 1, 2, 47, -7, 1, -7, 7,
+ax_anim 2, 0, 47, -12, 7, -12, 12,
+ax_anim 2, 0, 47, -16, 16, -16, 16,
+ax_anim 2, 1, 47, -15, 17, -15, 17,
+ax_anim 2, 0, 47, -16, 16, -16, 16,
+ax_anim 2, 0, 47, -15, 17, -15, 17,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim 2, 0, 45, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sTaurosAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 3, 0, 51, 0, -2, 0, -2,
+ax_anim 3, 2, 52, 0, -3, 0, -3,
+ax_anim 3, 0, 51, 0, -3, 0, -3,
+ax_anim 4, 0, 52, 0, -3, 0, -3,
+ax_anim 1, 0, 52, 0, 3, 0, 3,
+ax_anim 1, 0, 49, 0, 11, 0, 11,
+ax_anim 2, 0, 48, 0, 19, 0, 19,
+ax_anim 2, 1, 48, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 19, 0, 19,
+ax_anim 2, 0, 48, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 9, 0, 9,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sTaurosAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 3, 0, 56, -2, -2, -2, -2,
+ax_anim 3, 2, 57, -3, -3, -3, -3,
+ax_anim 3, 0, 56, -3, -3, -3, -3,
+ax_anim 4, 0, 57, -3, -3, -3, -3,
+ax_anim 1, 0, 57, 3, 3, 3, 3,
+ax_anim 1, 0, 54, 11, 11, 11, 11,
+ax_anim 2, 0, 53, 19, 19, 19, 19,
+ax_anim 2, 1, 53, 20, 18, 20, 18,
+ax_anim 2, 0, 53, 19, 19, 19, 19,
+ax_anim 2, 0, 53, 20, 18, 20, 18,
+ax_anim 2, 0, 53, 9, 9, 9, 9,
+ax_anim 2, 0, 53, 3, 3, 3, 3,
+ax_anim_terminator
+sTaurosAnims_3_3:
+ax_anim 2, 0, 58, -1, 0, -1, 0,
+ax_anim 3, 0, 61, -2, 0, -2, 0,
+ax_anim 3, 2, 62, -3, 0, -3, 0,
+ax_anim 3, 0, 61, -3, 0, -3, 0,
+ax_anim 4, 0, 62, -3, 0, -3, 0,
+ax_anim 1, 0, 62, 3, 0, 3, 0,
+ax_anim 1, 0, 59, 11, 0, 11, 0,
+ax_anim 2, 0, 58, 17, 0, 17, 0,
+ax_anim 2, 1, 58, 17, 1, 17, 1,
+ax_anim 2, 0, 58, 17, 0, 17, 0,
+ax_anim 2, 0, 58, 17, 1, 17, 1,
+ax_anim 2, 0, 58, 9, 0, 9, 0,
+ax_anim 2, 0, 58, 3, 0, 3, 0,
+ax_anim_terminator
+sTaurosAnims_3_4:
+ax_anim 2, 0, 63, -1, 1, -1, 1,
+ax_anim 3, 0, 66, -2, 2, -2, 2,
+ax_anim 3, 2, 67, -3, 3, -3, 3,
+ax_anim 3, 0, 66, -3, 3, -3, 3,
+ax_anim 4, 0, 67, -3, 3, -3, 3,
+ax_anim 1, 0, 67, 3, -3, 3, -3,
+ax_anim 1, 0, 64, 11, -11, 11, -11,
+ax_anim 2, 0, 63, 19, -17, 19, -17,
+ax_anim 2, 1, 63, 20, -16, 20, -16,
+ax_anim 2, 0, 63, 19, -17, 19, -17,
+ax_anim 2, 0, 63, 20, -16, 20, -16,
+ax_anim 2, 0, 63, 9, -9, 9, -9,
+ax_anim 2, 0, 63, 3, -3, 3, -3,
+ax_anim_terminator
+sTaurosAnims_3_5:
+ax_anim 2, 0, 68, 0, 1, 0, 1,
+ax_anim 3, 0, 71, 0, 2, 0, 2,
+ax_anim 3, 2, 72, 0, 3, 0, 3,
+ax_anim 3, 0, 71, 0, 3, 0, 3,
+ax_anim 4, 0, 72, 0, 3, 0, 3,
+ax_anim 1, 0, 72, 0, -3, 0, -3,
+ax_anim 1, 0, 69, 0, -11, 0, -11,
+ax_anim 2, 0, 68, 0, -17, 0, -17,
+ax_anim 2, 1, 68, 1, -17, 1, -17,
+ax_anim 2, 0, 68, 0, -17, 0, -17,
+ax_anim 2, 0, 68, 1, -17, 1, -17,
+ax_anim 2, 0, 68, 0, -9, 0, -9,
+ax_anim 2, 0, 68, 0, -3, 0, -3,
+ax_anim_terminator
+sTaurosAnims_3_6:
+ax_anim 2, 0, 73, 1, 1, 1, 1,
+ax_anim 3, 0, 76, 2, 2, 2, 2,
+ax_anim 3, 2, 77, 3, 3, 3, 3,
+ax_anim 3, 0, 76, 3, 3, 3, 3,
+ax_anim 4, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 0, 77, -3, -3, -3, -3,
+ax_anim 1, 0, 74, -11, -11, -11, -11,
+ax_anim 2, 0, 73, -19, -17, -19, -17,
+ax_anim 2, 1, 73, -20, -16, -20, -16,
+ax_anim 2, 0, 73, -19, -17, -19, -17,
+ax_anim 2, 0, 73, -20, -16, -20, -16,
+ax_anim 2, 0, 73, -9, -9, -9, -9,
+ax_anim 2, 0, 73, -3, -3, -3, -3,
+ax_anim_terminator
+sTaurosAnims_3_7:
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim 3, 0, 81, 2, 0, 2, 0,
+ax_anim 3, 2, 82, 3, 0, 3, 0,
+ax_anim 3, 0, 81, 3, 0, 3, 0,
+ax_anim 4, 0, 82, 3, 0, 3, 0,
+ax_anim 1, 0, 82, -3, 0, -3, 0,
+ax_anim 1, 0, 79, -11, 0, -11, 0,
+ax_anim 2, 0, 78, -17, 0, -17, 0,
+ax_anim 2, 1, 78, -17, 1, -17, 1,
+ax_anim 2, 0, 78, -17, 0, -17, 0,
+ax_anim 2, 0, 78, -17, 1, -17, 1,
+ax_anim 2, 0, 78, -9, 0, -9, 0,
+ax_anim 2, 0, 78, -3, 0, -3, 0,
+ax_anim_terminator
+sTaurosAnims_3_8:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 3, 0, 86, 2, -2, 2, -2,
+ax_anim 3, 2, 87, 3, -3, 3, -3,
+ax_anim 3, 0, 86, 3, -3, 3, -3,
+ax_anim 4, 0, 87, 3, -3, 3, -3,
+ax_anim 1, 0, 87, -3, 3, -3, 3,
+ax_anim 1, 0, 84, -11, 11, -11, 11,
+ax_anim 2, 0, 83, -19, 19, -19, 19,
+ax_anim 2, 1, 83, -20, 18, -20, 18,
+ax_anim 2, 0, 83, -19, 19, -19, 19,
+ax_anim 2, 0, 83, -20, 18, -20, 18,
+ax_anim 2, 0, 83, -9, 9, -9, 9,
+ax_anim 2, 0, 83, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sTaurosAnims_4_1:
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_4_2:
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, -1, 1, -1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_4_3:
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 1, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_4_4:
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_4_5:
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_4_6:
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_4_7:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_4_8:
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, -1, -1, -1,
+ax_anim 2, 1, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_7_1:
+ax_anim 2, 0, 106, 0, -4, 0, -4,
+ax_anim 8, 0, 106, 0, -5, 0, -5,
+ax_anim_terminator
+sTaurosAnims_7_2:
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 8, 0, 107, -5, -5, -5, -5,
+ax_anim_terminator
+sTaurosAnims_7_3:
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim 8, 0, 108, -5, 0, -5, 0,
+ax_anim_terminator
+sTaurosAnims_7_4:
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim 8, 0, 109, -5, 5, -5, 5,
+ax_anim_terminator
+sTaurosAnims_7_5:
+ax_anim 2, 0, 110, 0, 4, 0, 4,
+ax_anim 8, 0, 110, 0, 5, 0, 5,
+ax_anim_terminator
+sTaurosAnims_7_6:
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 8, 0, 111, 5, 5, 5, 5,
+ax_anim_terminator
+sTaurosAnims_7_7:
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 8, 0, 112, 5, 0, 5, 0,
+ax_anim_terminator
+sTaurosAnims_7_8:
+ax_anim 2, 0, 113, 4, -4, 4, -4,
+ax_anim 8, 0, 113, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sTaurosAnims_8_1:
+ax_anim 40, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 115, 0, -1, 0, 0,
+ax_anim 6, 0, 115, 0, -2, 0, 0,
+ax_anim 3, 0, 115, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_8_2:
+ax_anim 40, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 118, 0, -2, 0, 0,
+ax_anim 6, 0, 118, 0, -3, 0, 0,
+ax_anim 3, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim_terminator
+sTaurosAnims_8_3:
+ax_anim 40, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, -3, 0, 0,
+ax_anim 6, 0, 121, 0, -4, 0, 0,
+ax_anim 3, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -2, 0, 0,
+ax_anim_terminator
+sTaurosAnims_8_4:
+ax_anim 40, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, -4, 0, 0,
+ax_anim 6, 0, 124, 0, -6, 0, 0,
+ax_anim 3, 0, 124, 0, -4, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim_terminator
+sTaurosAnims_8_5:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, -4, 0, 0,
+ax_anim 6, 0, 127, 0, -6, 0, 0,
+ax_anim 3, 0, 127, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim_terminator
+sTaurosAnims_8_6:
+ax_anim 40, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, -4, 0, 0,
+ax_anim 6, 0, 130, 0, -6, 0, 0,
+ax_anim 3, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim_terminator
+sTaurosAnims_8_7:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, -3, 0, 0,
+ax_anim 6, 0, 133, 0, -4, 0, 0,
+ax_anim 3, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim_terminator
+sTaurosAnims_8_8:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, -2, 0, 0,
+ax_anim 6, 0, 136, 0, -3, 0, 0,
+ax_anim 3, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 5, 4, 5, 4,
+ax_anim 2, 0, 140, 10, 11, 10, 11,
+ax_anim 2, 0, 141, 7, 19, 7, 19,
+ax_anim 3, 0, 142, 0, 21, 0, 21,
+ax_anim 2, 3, 143, -7, 19, -7, 19,
+ax_anim 2, 0, 144, -10, 11, -10, 11,
+ax_anim 1, 0, 145, -5, 4, -5, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 12, -1, 12, -1,
+ax_anim 2, 0, 139, 16, 7, 16, 7,
+ax_anim 2, 0, 140, 18, 14, 18, 14,
+ax_anim 3, 0, 141, 15, 21, 15, 21,
+ax_anim 2, 3, 142, 10, 22, 10, 22,
+ax_anim 2, 0, 143, 3, 15, 3, 15,
+ax_anim 1, 0, 144, 0, 7, 0, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 5, -4, 5, -4,
+ax_anim 2, 0, 138, 11, -8, 11, -8,
+ax_anim 2, 0, 139, 16, -2, 16, -2,
+ax_anim 3, 0, 140, 18, 1, 18, 1,
+ax_anim 2, 3, 141, 17, 7, 17, 7,
+ax_anim 2, 0, 142, 12, 8, 12, 8,
+ax_anim 1, 0, 143, 4, 7, 4, 7,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 3, -8, 3, -8,
+ax_anim 2, 0, 145, 9, -15, 9, -15,
+ax_anim 2, 0, 138, 13, -21, 13, -21,
+ax_anim 3, 0, 139, 16, -17, 16, -17,
+ax_anim 2, 3, 140, 17, -10, 17, -10,
+ax_anim 2, 0, 141, 15, -3, 15, -3,
+ax_anim 1, 0, 142, 10, 1, 10, 1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -8, -2, -8, -2,
+ax_anim 2, 0, 144, -8, -8, -8, -8,
+ax_anim 2, 0, 145, -5, -15, -5, -15,
+ax_anim 3, 0, 138, 0, -20, 0, -20,
+ax_anim 2, 3, 139, 5, -15, 5, -15,
+ax_anim 2, 0, 140, 8, -8, 8, -8,
+ax_anim 1, 0, 141, 8, -2, 8, -2,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -3, -8, -4, -8,
+ax_anim 2, 0, 139, -9, -15, -9, -15,
+ax_anim 2, 0, 138, -13, -21, -13, -19,
+ax_anim 3, 0, 145, -16, -17, -16, -17,
+ax_anim 2, 3, 144, -17, -10, -17, -10,
+ax_anim 2, 0, 143, -15, -3, -15, -3,
+ax_anim 1, 0, 142, -10, -1, -9, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -5, -4, -5, -4,
+ax_anim 2, 0, 138, -11, -8, -11, -8,
+ax_anim 2, 0, 145, -16, -2, -16, -2,
+ax_anim 3, 0, 144, -18, -1, -18, -1,
+ax_anim 2, 3, 143, -17, 7, -17, 7,
+ax_anim 2, 0, 142, -12, 8, -12, 8,
+ax_anim 1, 0, 141, -4, 7, -4, 7,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -12, -1, -12, -1,
+ax_anim 2, 0, 145, -16, 7, -16, 7,
+ax_anim 2, 0, 144, -18, 14, -18, 14,
+ax_anim 3, 0, 143, -15, 21, -15, 21,
+ax_anim 2, 3, 142, -10, 22, -10, 22,
+ax_anim 2, 0, 141, -3, 15, -3, 15,
+ax_anim 1, 0, 140, 0, 7, 0, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -24, 0, 0,
+ax_anim 3, 0, 156, 0, -23, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -24, 0, 0,
+ax_anim 3, 0, 159, 0, -23, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 162, 0, -21, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -22, 0, 0,
+ax_anim 3, 0, 168, 0, -21, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTaurosAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sTaurosGfx1:
+.incbin "baserom.gba", 0xA7E7F0, 0x200
+sTaurosSprites1:
+ax_sprite sTaurosGfx1, 0x200
+ax_sprite_terminator
+sTaurosGfx2:
+.incbin "baserom.gba", 0xA7EA00, 0x200
+sTaurosSprites2:
+ax_sprite sTaurosGfx2, 0x200
+ax_sprite_terminator
+sTaurosGfx3:
+.incbin "baserom.gba", 0xA7EC10, 0x200
+sTaurosSprites3:
+ax_sprite sTaurosGfx3, 0x200
+ax_sprite_terminator
+sTaurosGfx4:
+.incbin "baserom.gba", 0xA7EE20, 0x200
+sTaurosSprites4:
+ax_sprite sTaurosGfx4, 0x200
+ax_sprite_terminator
+sTaurosGfx5:
+.incbin "baserom.gba", 0xA7F030, 0x200
+sTaurosSprites5:
+ax_sprite sTaurosGfx5, 0x200
+ax_sprite_terminator
+sTaurosGfx6:
+.incbin "baserom.gba", 0xA7F240, 0x200
+sTaurosSprites6:
+ax_sprite sTaurosGfx6, 0x200
+ax_sprite_terminator
+sTaurosGfx7:
+.incbin "baserom.gba", 0xA7F450, 0x200
+sTaurosSprites7:
+ax_sprite sTaurosGfx7, 0x200
+ax_sprite_terminator
+sTaurosGfx8:
+.incbin "baserom.gba", 0xA7F660, 0x200
+sTaurosSprites8:
+ax_sprite sTaurosGfx8, 0x200
+ax_sprite_terminator
+sTaurosGfx9:
+.incbin "baserom.gba", 0xA7F870, 0x200
+sTaurosSprites9:
+ax_sprite sTaurosGfx9, 0x200
+ax_sprite_terminator
+sTaurosGfx10:
+.incbin "baserom.gba", 0xA7FA80, 0x200
+sTaurosSprites10:
+ax_sprite sTaurosGfx10, 0x200
+ax_sprite_terminator
+sTaurosGfx11:
+.incbin "baserom.gba", 0xA7FC90, 0x200
+sTaurosSprites11:
+ax_sprite sTaurosGfx11, 0x200
+ax_sprite_terminator
+sTaurosGfx12:
+.incbin "baserom.gba", 0xA7FEA0, 0x200
+sTaurosSprites12:
+ax_sprite sTaurosGfx12, 0x200
+ax_sprite_terminator
+sTaurosGfx13:
+.incbin "baserom.gba", 0xA800B0, 0x200
+sTaurosSprites13:
+ax_sprite sTaurosGfx13, 0x200
+ax_sprite_terminator
+sTaurosGfx14:
+.incbin "baserom.gba", 0xA802C0, 0x200
+sTaurosSprites14:
+ax_sprite sTaurosGfx14, 0x200
+ax_sprite_terminator
+sTaurosGfx15:
+.incbin "baserom.gba", 0xA804D0, 0x200
+sTaurosSprites15:
+ax_sprite sTaurosGfx15, 0x200
+ax_sprite_terminator
+sTaurosGfx16:
+.incbin "baserom.gba", 0xA806E0, 0x40
+sTaurosGfx16_1:
+.incbin "baserom.gba", 0xA80720, 0x100
+sTaurosGfx16_2:
+.incbin "baserom.gba", 0xA80820, 0x40
+sTaurosSprites16:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx17:
+.incbin "baserom.gba", 0xA808A0, 0x40
+sTaurosGfx17_1:
+.incbin "baserom.gba", 0xA808E0, 0x80
+sTaurosGfx17_2:
+.incbin "baserom.gba", 0xA80960, 0x40
+sTaurosSprites17:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx17_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTaurosGfx18:
+.incbin "baserom.gba", 0xA809E0, 0x40
+sTaurosGfx18_1:
+.incbin "baserom.gba", 0xA80A20, 0x40
+sTaurosGfx18_2:
+.incbin "baserom.gba", 0xA80A60, 0xE0
+sTaurosSprites18:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx18_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx18_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx19:
+.incbin "baserom.gba", 0xA80B80, 0x1E0
+sTaurosSprites19:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx19, 0x1e0
+ax_sprite_terminator
+sTaurosGfx20:
+.incbin "baserom.gba", 0xA80D78, 0x180
+sTaurosGfx20_1:
+.incbin "baserom.gba", 0xA80EF8, 0x20
+sTaurosSprites20:
+ax_sprite sTaurosGfx20, 0x180
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx20_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx21:
+.incbin "baserom.gba", 0xA80F40, 0x1A0
+sTaurosSprites21:
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx21, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx22:
+.incbin "baserom.gba", 0xA81100, 0x1E0
+sTaurosSprites22:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx22, 0x1e0
+ax_sprite_terminator
+sTaurosGfx23:
+.incbin "baserom.gba", 0xA812F8, 0x180
+sTaurosGfx23_1:
+.incbin "baserom.gba", 0xA81478, 0x60
+sTaurosSprites23:
+ax_sprite sTaurosGfx23, 0x180
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx23_1, 0x60
+ax_sprite_terminator
+sTaurosGfx24:
+.incbin "baserom.gba", 0xA814F8, 0x1A0
+sTaurosSprites24:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx24, 0x1a0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTaurosGfx25:
+.incbin "baserom.gba", 0xA816B8, 0x60
+sTaurosGfx25_1:
+.incbin "baserom.gba", 0xA81718, 0x100
+sTaurosGfx25_2:
+.incbin "baserom.gba", 0xA81818, 0x60
+sTaurosSprites25:
+ax_sprite sTaurosGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx25_2, 0x60
+ax_sprite_terminator
+sTaurosGfx26:
+.incbin "baserom.gba", 0xA818A8, 0x60
+sTaurosGfx26_1:
+.incbin "baserom.gba", 0xA81908, 0x100
+sTaurosGfx26_2:
+.incbin "baserom.gba", 0xA81A08, 0x40
+sTaurosSprites26:
+ax_sprite sTaurosGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx26_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx26_2, 0x40
+ax_sprite_terminator
+sTaurosGfx27:
+.incbin "baserom.gba", 0xA81A78, 0x180
+sTaurosGfx27_1:
+.incbin "baserom.gba", 0xA81BF8, 0x40
+sTaurosSprites27:
+ax_sprite sTaurosGfx27, 0x180
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx27_1, 0x40
+ax_sprite_terminator
+sTaurosGfx28:
+.incbin "baserom.gba", 0xA81C58, 0x40
+sTaurosGfx28_1:
+.incbin "baserom.gba", 0xA81C98, 0x60
+sTaurosGfx28_2:
+.incbin "baserom.gba", 0xA81CF8, 0x40
+sTaurosGfx28_3:
+.incbin "baserom.gba", 0xA81D38, 0x40
+sTaurosSprites28:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx28_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx29:
+.incbin "baserom.gba", 0xA81DC8, 0x40
+sTaurosGfx29_1:
+.incbin "baserom.gba", 0xA81E08, 0x60
+sTaurosGfx29_2:
+.incbin "baserom.gba", 0xA81E68, 0x60
+sTaurosGfx29_3:
+.incbin "baserom.gba", 0xA81EC8, 0x40
+sTaurosSprites29:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx30:
+.incbin "baserom.gba", 0xA81F58, 0x40
+sTaurosGfx30_1:
+.incbin "baserom.gba", 0xA81F98, 0x100
+sTaurosGfx30_2:
+.incbin "baserom.gba", 0xA82098, 0x20
+sTaurosSprites30:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx30_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTaurosGfx31:
+.incbin "baserom.gba", 0xA820F8, 0x180
+sTaurosGfx31_1:
+.incbin "baserom.gba", 0xA82278, 0x40
+sTaurosSprites31:
+ax_sprite sTaurosGfx31, 0x180
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx31_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx32:
+.incbin "baserom.gba", 0xA822E0, 0x160
+sTaurosGfx32_1:
+.incbin "baserom.gba", 0xA82440, 0x40
+sTaurosSprites32:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx32, 0x160
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx32_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx33:
+.incbin "baserom.gba", 0xA824B0, 0x60
+sTaurosGfx33_1:
+.incbin "baserom.gba", 0xA82510, 0x100
+sTaurosGfx33_2:
+.incbin "baserom.gba", 0xA82610, 0x60
+sTaurosSprites33:
+ax_sprite sTaurosGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx33_2, 0x60
+ax_sprite_terminator
+sTaurosGfx34:
+.incbin "baserom.gba", 0xA826A0, 0x60
+sTaurosGfx34_1:
+.incbin "baserom.gba", 0xA82700, 0x100
+sTaurosGfx34_2:
+.incbin "baserom.gba", 0xA82800, 0x60
+sTaurosSprites34:
+ax_sprite sTaurosGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx34_2, 0x60
+ax_sprite_terminator
+sTaurosGfx35:
+.incbin "baserom.gba", 0xA82890, 0x60
+sTaurosGfx35_1:
+.incbin "baserom.gba", 0xA828F0, 0x100
+sTaurosGfx35_2:
+.incbin "baserom.gba", 0xA829F0, 0x60
+sTaurosSprites35:
+ax_sprite sTaurosGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx35_2, 0x60
+ax_sprite_terminator
+sTaurosGfx36:
+.incbin "baserom.gba", 0xA82A80, 0x60
+sTaurosGfx36_1:
+.incbin "baserom.gba", 0xA82AE0, 0x180
+sTaurosSprites36:
+ax_sprite sTaurosGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx36_1, 0x180
+ax_sprite_terminator
+sTaurosGfx37:
+.incbin "baserom.gba", 0xA82C80, 0x60
+sTaurosGfx37_1:
+.incbin "baserom.gba", 0xA82CE0, 0x60
+sTaurosGfx37_2:
+.incbin "baserom.gba", 0xA82D40, 0x80
+sTaurosGfx37_3:
+.incbin "baserom.gba", 0xA82DC0, 0x60
+sTaurosSprites37:
+ax_sprite sTaurosGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx37_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx37_3, 0x60
+ax_sprite_terminator
+sTaurosGfx38:
+.incbin "baserom.gba", 0xA82E60, 0x60
+sTaurosGfx38_1:
+.incbin "baserom.gba", 0xA82EC0, 0x60
+sTaurosGfx38_2:
+.incbin "baserom.gba", 0xA82F20, 0x80
+sTaurosGfx38_3:
+.incbin "baserom.gba", 0xA82FA0, 0x60
+sTaurosSprites38:
+ax_sprite sTaurosGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx38_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx38_3, 0x60
+ax_sprite_terminator
+sTaurosGfx39:
+.incbin "baserom.gba", 0xA83040, 0xE0
+sTaurosGfx39_1:
+.incbin "baserom.gba", 0xA83120, 0x60
+sTaurosGfx39_2:
+.incbin "baserom.gba", 0xA83180, 0x60
+sTaurosSprites39:
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx39, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTaurosGfx39_2, 0x60
+ax_sprite_terminator
+sTaurosGfx40:
+.incbin "baserom.gba", 0xA83218, 0x160
+sTaurosGfx40_1:
+.incbin "baserom.gba", 0xA83378, 0x40
+sTaurosSprites40:
+ax_sprite sTaurosGfx40, 0x160
+ax_sprite 0, 0x40
+ax_sprite sTaurosGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTaurosGfx41:
+.incbin "baserom.gba", 0xA833E0, 0x200
+sTaurosSprites41:
+ax_sprite sTaurosGfx41, 0x200
+ax_sprite_terminator
+sTaurosGfx42:
+.incbin "baserom.gba", 0xA835F0, 0x200
+sTaurosSprites42:
+ax_sprite sTaurosGfx42, 0x200
+ax_sprite_terminator
+sTaurosGfx43:
+.incbin "baserom.gba", 0xA83800, 0x200
+sTaurosSprites43:
+ax_sprite sTaurosGfx43, 0x200
+ax_sprite_terminator
+sTaurosGfx44:
+.incbin "baserom.gba", 0xA83A10, 0x200
+sTaurosSprites44:
+ax_sprite sTaurosGfx44, 0x200
+ax_sprite_terminator
+sTaurosGfx45:
+.incbin "baserom.gba", 0xA83C20, 0x200
+sTaurosSprites45:
+ax_sprite sTaurosGfx45, 0x200
+ax_sprite_terminator
+sTaurosGfx46:
+.incbin "baserom.gba", 0xA83E30, 0x200
+sTaurosSprites46:
+ax_sprite sTaurosGfx46, 0x200
+ax_sprite_terminator
+sTaurosGfx47:
+.incbin "baserom.gba", 0xA84040, 0x200
+sTaurosSprites47:
+ax_sprite sTaurosGfx47, 0x200
+ax_sprite_terminator
+sAxPosesTauros:
+.4byte sTaurosPose1
+.4byte sTaurosPose2
+.4byte sTaurosPose3
+.4byte sTaurosPose4
+.4byte sTaurosPose5
+.4byte sTaurosPose6
+.4byte sTaurosPose7
+.4byte sTaurosPose8
+.4byte sTaurosPose9
+.4byte sTaurosPose10
+.4byte sTaurosPose11
+.4byte sTaurosPose12
+.4byte sTaurosPose13
+.4byte sTaurosPose14
+.4byte sTaurosPose15
+.4byte sTaurosPose16
+.4byte sTaurosPose17
+.4byte sTaurosPose18
+.4byte sTaurosPose19
+.4byte sTaurosPose20
+.4byte sTaurosPose21
+.4byte sTaurosPose22
+.4byte sTaurosPose23
+.4byte sTaurosPose24
+.4byte sTaurosPose25
+.4byte sTaurosPose26
+.4byte sTaurosPose27
+.4byte sTaurosPose28
+.4byte sTaurosPose29
+.4byte sTaurosPose30
+.4byte sTaurosPose31
+.4byte sTaurosPose32
+.4byte sTaurosPose33
+.4byte sTaurosPose34
+.4byte sTaurosPose35
+.4byte sTaurosPose36
+.4byte sTaurosPose37
+.4byte sTaurosPose38
+.4byte sTaurosPose39
+.4byte sTaurosPose40
+.4byte sTaurosPose41
+.4byte sTaurosPose42
+.4byte sTaurosPose43
+.4byte sTaurosPose44
+.4byte sTaurosPose45
+.4byte sTaurosPose46
+.4byte sTaurosPose47
+.4byte sTaurosPose48
+.4byte sTaurosPose49
+.4byte sTaurosPose50
+.4byte sTaurosPose51
+.4byte sTaurosPose52
+.4byte sTaurosPose53
+.4byte sTaurosPose54
+.4byte sTaurosPose55
+.4byte sTaurosPose56
+.4byte sTaurosPose57
+.4byte sTaurosPose58
+.4byte sTaurosPose59
+.4byte sTaurosPose60
+.4byte sTaurosPose61
+.4byte sTaurosPose62
+.4byte sTaurosPose63
+.4byte sTaurosPose64
+.4byte sTaurosPose65
+.4byte sTaurosPose66
+.4byte sTaurosPose67
+.4byte sTaurosPose68
+.4byte sTaurosPose69
+.4byte sTaurosPose70
+.4byte sTaurosPose71
+.4byte sTaurosPose72
+.4byte sTaurosPose73
+.4byte sTaurosPose74
+.4byte sTaurosPose75
+.4byte sTaurosPose76
+.4byte sTaurosPose77
+.4byte sTaurosPose78
+.4byte sTaurosPose79
+.4byte sTaurosPose80
+.4byte sTaurosPose81
+.4byte sTaurosPose82
+.4byte sTaurosPose83
+.4byte sTaurosPose84
+.4byte sTaurosPose85
+.4byte sTaurosPose86
+.4byte sTaurosPose87
+.4byte sTaurosPose88
+.4byte sTaurosPose89
+.4byte sTaurosPose90
+.4byte sTaurosPose91
+.4byte sTaurosPose92
+.4byte sTaurosPose93
+.4byte sTaurosPose94
+.4byte sTaurosPose95
+.4byte sTaurosPose96
+.4byte sTaurosPose97
+.4byte sTaurosPose98
+.4byte sTaurosPose99
+.4byte sTaurosPose100
+.4byte sTaurosPose101
+.4byte sTaurosPose102
+.4byte sTaurosPose103
+.4byte sTaurosPose104
+.4byte sTaurosPose105
+.4byte sTaurosPose106
+.4byte sTaurosPose107
+.4byte sTaurosPose108
+.4byte sTaurosPose109
+.4byte sTaurosPose110
+.4byte sTaurosPose111
+.4byte sTaurosPose112
+.4byte sTaurosPose113
+.4byte sTaurosPose114
+.4byte sTaurosPose115
+.4byte sTaurosPose116
+.4byte sTaurosPose117
+.4byte sTaurosPose118
+.4byte sTaurosPose119
+.4byte sTaurosPose120
+.4byte sTaurosPose121
+.4byte sTaurosPose122
+.4byte sTaurosPose123
+.4byte sTaurosPose124
+.4byte sTaurosPose125
+.4byte sTaurosPose126
+.4byte sTaurosPose127
+.4byte sTaurosPose128
+.4byte sTaurosPose129
+.4byte sTaurosPose130
+.4byte sTaurosPose131
+.4byte sTaurosPose132
+.4byte sTaurosPose133
+.4byte sTaurosPose134
+.4byte sTaurosPose135
+.4byte sTaurosPose136
+.4byte sTaurosPose137
+.4byte sTaurosPose138
+.4byte sTaurosPose139
+.4byte sTaurosPose140
+.4byte sTaurosPose141
+.4byte sTaurosPose142
+.4byte sTaurosPose143
+.4byte sTaurosPose144
+.4byte sTaurosPose145
+.4byte sTaurosPose146
+.4byte sTaurosPose147
+.4byte sTaurosPose148
+.4byte sTaurosPose149
+.4byte sTaurosPose150
+.4byte sTaurosPose151
+.4byte sTaurosPose152
+.4byte sTaurosPose153
+.4byte sTaurosPose154
+.4byte sTaurosPose155
+.4byte sTaurosPose156
+.4byte sTaurosPose157
+.4byte sTaurosPose158
+.4byte sTaurosPose159
+.4byte sTaurosPose160
+.4byte sTaurosPose161
+.4byte sTaurosPose162
+.4byte sTaurosPose163
+.4byte sTaurosPose164
+.4byte sTaurosPose165
+.4byte sTaurosPose166
+.4byte sTaurosPose167
+.4byte sTaurosPose168
+.4byte sTaurosPose169
+.4byte sTaurosPose170
+.4byte sTaurosPose171
+.4byte sTaurosPose172
+.4byte sTaurosPose173
+.4byte sTaurosPose174
+.4byte sTaurosPose175
+.4byte sTaurosPose176
+.4byte sTaurosPose177
+.4byte sTaurosPose178
+.4byte sTaurosPose179
+.4byte sTaurosPose180
+.4byte sTaurosPose181
+.4byte sTaurosPose182
+.4byte sTaurosPose183
+.4byte sTaurosPose184
+.4byte sTaurosPose185
+.4byte sTaurosPose186
+.4byte sTaurosPose187
+.4byte sTaurosPose188
+.4byte sTaurosPose189
+.4byte sTaurosPose190
+.4byte sTaurosPose191
+.4byte sTaurosPose192
+.4byte sTaurosPose193
+.4byte sTaurosPose194
+sAxPositionsTauros:
+.2byte   -1,   -2, 	  -6,    2, 	   4,    2, 	  -1,  -11
+.2byte   -1,   -7, 	  -6,   -3, 	   4,   -3, 	  -1,  -15
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,  -11
+.2byte    5,   -2, 	   7,   -1, 	   0,    2, 	  -3,  -12
+.2byte    7,   -5, 	   5,   -4, 	  -3,   -2, 	  -2,  -13
+.2byte    6,    0, 	  14,   -3, 	   3,    2, 	  -2,  -12
+.2byte    8,   -4, 	   6,   -3, 	   2,    1, 	  -3,  -11
+.2byte    9,   -6, 	   7,   -5, 	   2,   -2, 	   0,  -12
+.2byte    9,   -2, 	  12,   -5, 	   6,    1, 	  -1,  -12
+.2byte    5,  -11, 	  -4,  -10, 	   4,   -3, 	  -1,  -14
+.2byte    7,  -15, 	  -3,  -13, 	   6,   -7, 	  -2,  -13
+.2byte    8,  -11, 	   1,  -13, 	  10,   -6, 	  -1,  -14
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte   -1,  -18, 	   6,   -9, 	  -8,   -9, 	  -1,  -15
+.2byte   -1,  -14, 	   7,   -8, 	 -10,   -9, 	  -1,  -16
+.2byte   -7,  -11, 	   2,  -10, 	  -6,   -3, 	  -1,  -14
+.2byte   -9,  -15, 	   1,  -13, 	  -8,   -7, 	   0,  -13
+.2byte  -10,  -11, 	  -3,  -13, 	 -12,   -6, 	  -1,  -14
+.2byte  -10,   -4, 	  -8,   -3, 	  -4,    1, 	   1,  -11
+.2byte  -11,   -6, 	  -9,   -5, 	  -4,   -2, 	  -2,  -12
+.2byte  -11,   -2, 	 -14,   -5, 	  -8,    1, 	  -1,  -12
+.2byte   -7,   -2, 	  -9,   -1, 	  -2,    2, 	   1,  -12
+.2byte   -9,   -5, 	  -7,   -4, 	   1,   -2, 	   0,  -13
+.2byte   -7,    0, 	 -15,   -3, 	  -4,    2, 	   1,  -12
+.2byte   -1,   -2, 	  -6,    1, 	   4,    1, 	  -1,  -14
+.2byte   -1,   -6, 	  -6,   -4, 	   4,   -4, 	  -1,  -15
+.2byte   -1,    2, 	  -7,    4, 	   5,    4, 	  -1,  -11
+.2byte    3,   -1, 	   8,   -1, 	   1,    2, 	  -1,  -13
+.2byte    5,   -4, 	   3,   -6, 	  -2,   -2, 	   0,  -16
+.2byte    5,    0, 	  15,   -4, 	   4,    2, 	  -1,  -13
+.2byte    5,   -3, 	   4,   -5, 	   2,    1, 	  -2,  -12
+.2byte    6,   -5, 	   3,   -6, 	   1,   -2, 	  -1,  -14
+.2byte    5,   -2, 	  11,   -5, 	   5,    1, 	   0,  -12
+.2byte    5,   -9, 	  -6,   -8, 	   4,   -3, 	  -1,  -14
+.2byte    7,  -14, 	  -3,  -11, 	   5,   -7, 	  -1,  -14
+.2byte    8,  -11, 	   1,   -8, 	  10,   -5, 	  -1,  -14
+.2byte   -1,  -11, 	   5,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte   -1,  -17, 	   6,   -8, 	  -8,   -8, 	  -1,  -15
+.2byte   -1,  -14, 	   8,   -9, 	 -10,   -9, 	  -1,  -15
+.2byte   -7,   -9, 	   4,   -8, 	  -6,   -3, 	  -1,  -14
+.2byte   -9,  -14, 	   1,  -11, 	  -7,   -7, 	  -1,  -14
+.2byte  -10,  -11, 	  -3,   -8, 	 -12,   -5, 	  -1,  -14
+.2byte   -7,   -3, 	  -6,   -5, 	  -4,    1, 	   0,  -12
+.2byte   -8,   -5, 	  -5,   -6, 	  -3,   -2, 	  -1,  -14
+.2byte   -7,   -2, 	 -13,   -5, 	  -7,    1, 	  -2,  -12
+.2byte   -5,   -1, 	 -10,   -1, 	  -3,    2, 	  -1,  -13
+.2byte   -7,   -4, 	  -5,   -6, 	   0,   -2, 	  -2,  -16
+.2byte   -5,    0, 	 -15,   -4, 	  -4,    2, 	   1,  -13
+.2byte   -1,   -2, 	  -6,    2, 	   4,    2, 	  -1,  -11
+.2byte   -1,   -7, 	  -6,   -3, 	   4,   -3, 	  -1,  -15
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,  -11
+.2byte   -3,  -24, 	  -9,  -12, 	  11,  -15, 	   0,  -15
+.2byte   -1,  -23, 	 -10,  -13, 	  10,  -12, 	   0,  -17
+.2byte    5,   -2, 	   7,   -1, 	   0,    2, 	  -3,  -12
+.2byte    9,   -3, 	   7,   -2, 	  -1,    0, 	   0,  -11
+.2byte    5,    0, 	  13,   -3, 	   2,    2, 	  -3,  -12
+.2byte    4,  -24, 	   8,  -11, 	  -1,  -12, 	  -2,  -17
+.2byte    4,  -23, 	  10,  -13, 	  -3,   -8, 	  -2,  -16
+.2byte    8,   -4, 	   6,   -3, 	   2,    1, 	  -3,  -11
+.2byte   12,   -6, 	  10,   -5, 	   5,   -2, 	   3,  -12
+.2byte    9,   -2, 	  12,   -5, 	   6,    1, 	  -1,  -12
+.2byte    6,  -23, 	   4,   -9, 	  10,  -11, 	  -3,  -14
+.2byte    5,  -21, 	  10,  -10, 	   9,   -5, 	  -2,  -12
+.2byte    5,  -11, 	  -4,  -10, 	   4,   -3, 	  -1,  -14
+.2byte    9,  -17, 	  -1,  -15, 	   8,   -9, 	   0,  -15
+.2byte    8,  -11, 	   1,  -13, 	  10,   -6, 	  -1,  -14
+.2byte    3,  -25, 	  -1,  -14, 	   9,  -12, 	  -4,  -14
+.2byte    4,  -22, 	  -3,  -13, 	   7,   -8, 	  -4,  -14
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte   -1,  -19, 	   6,  -10, 	  -8,  -10, 	  -1,  -16
+.2byte   -1,  -14, 	   7,   -8, 	 -10,   -9, 	  -1,  -16
+.2byte    0,  -22, 	   9,  -12, 	  -9,  -14, 	   0,  -11
+.2byte    0,  -21, 	   9,  -14, 	  -9,  -10, 	   0,  -10
+.2byte   -7,  -11, 	   2,  -10, 	  -6,   -3, 	  -1,  -14
+.2byte  -11,  -17, 	  -1,  -15, 	 -10,   -9, 	  -2,  -15
+.2byte  -10,  -11, 	  -3,  -13, 	 -12,   -6, 	  -1,  -14
+.2byte   -5,  -25, 	  -1,  -14, 	 -11,  -12, 	   2,  -14
+.2byte   -6,  -22, 	   1,  -13, 	  -9,   -8, 	   2,  -14
+.2byte  -10,   -4, 	  -8,   -3, 	  -4,    1, 	   1,  -11
+.2byte  -14,   -6, 	 -12,   -5, 	  -7,   -2, 	  -5,  -12
+.2byte  -11,   -2, 	 -14,   -5, 	  -8,    1, 	  -1,  -12
+.2byte   -8,  -23, 	  -6,   -9, 	 -12,  -11, 	   1,  -14
+.2byte   -7,  -21, 	 -12,  -10, 	 -11,   -5, 	   0,  -12
+.2byte   -7,   -2, 	  -9,   -1, 	  -2,    2, 	   1,  -12
+.2byte  -11,   -3, 	  -9,   -2, 	  -1,    0, 	  -2,  -11
+.2byte   -7,    0, 	 -15,   -3, 	  -4,    2, 	   1,  -12
+.2byte   -6,  -24, 	 -10,  -11, 	  -1,  -12, 	   0,  -17
+.2byte   -6,  -23, 	 -12,  -13, 	   1,   -8, 	   0,  -16
+.2byte   -3,  -22, 	  -9,  -10, 	  11,  -13, 	   0,  -13
+.2byte   -6,  -22, 	 -10,   -9, 	  -1,  -10, 	   0,  -15
+.2byte   -7,  -22, 	  -5,   -8, 	 -11,  -10, 	   2,  -13
+.2byte   -5,  -25, 	  -1,  -14, 	 -11,  -12, 	   2,  -14
+.2byte    0,  -23, 	   9,  -13, 	  -9,  -15, 	   0,  -12
+.2byte    4,  -25, 	   0,  -14, 	  10,  -12, 	  -3,  -14
+.2byte    7,  -22, 	   5,   -8, 	  11,  -10, 	  -2,  -13
+.2byte    5,  -22, 	   9,   -9, 	   0,  -10, 	  -1,  -15
+.2byte   -1,   -2, 	  -6,    2, 	   4,    2, 	  -1,  -11
+.2byte   -7,   -2, 	  -9,   -1, 	  -2,    2, 	   1,  -12
+.2byte  -10,   -4, 	  -8,   -3, 	  -4,    1, 	   1,  -11
+.2byte   -7,  -11, 	   2,  -10, 	  -6,   -3, 	  -1,  -14
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte    5,  -11, 	  -4,  -10, 	   4,   -3, 	  -1,  -14
+.2byte    8,   -4, 	   6,   -3, 	   2,    1, 	  -3,  -11
+.2byte    5,   -2, 	   7,   -1, 	   0,    2, 	  -3,  -12
+.2byte   -9,    0, 	 -11,   -1, 	  -8,    2, 	  -1,   -7
+.2byte   -9,    0, 	 -11,   -1, 	  -8,    2, 	   0,   -7
+.2byte   -1,  -22, 	  -6,  -12, 	   5,  -10, 	  -1,  -13
+.2byte    8,  -21, 	  13,  -14, 	   5,   -9, 	  -1,  -15
+.2byte    8,  -19, 	  11,  -11, 	   6,   -6, 	  -1,  -14
+.2byte    6,  -22, 	  -2,  -15, 	   7,  -11, 	  -2,  -14
+.2byte    0,  -24, 	   5,  -14, 	  -8,  -13, 	   0,  -13
+.2byte   -7,  -22, 	   1,  -15, 	  -8,  -11, 	   1,  -14
+.2byte   -9,  -19, 	 -12,  -11, 	  -7,   -6, 	   0,  -14
+.2byte   -9,  -20, 	 -14,  -13, 	  -6,   -8, 	   0,  -14
+.2byte   -1,   -2, 	  -6,    2, 	   4,    2, 	  -1,  -11
+.2byte   -1,   -7, 	  -6,   -3, 	   4,   -3, 	  -1,  -15
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,  -11
+.2byte    5,   -2, 	   7,   -1, 	   0,    2, 	  -3,  -12
+.2byte    7,   -5, 	   5,   -4, 	  -3,   -2, 	  -2,  -13
+.2byte    6,    0, 	  14,   -3, 	   3,    2, 	  -2,  -12
+.2byte    8,   -4, 	   6,   -3, 	   2,    1, 	  -3,  -11
+.2byte    9,   -6, 	   7,   -5, 	   2,   -2, 	   0,  -12
+.2byte    9,   -2, 	  12,   -5, 	   6,    1, 	  -1,  -12
+.2byte    5,  -11, 	  -4,  -10, 	   4,   -3, 	  -1,  -14
+.2byte    7,  -15, 	  -3,  -13, 	   6,   -7, 	  -2,  -13
+.2byte    8,  -11, 	   1,  -13, 	  10,   -6, 	  -1,  -14
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte   -1,  -18, 	   6,   -9, 	  -8,   -9, 	  -1,  -15
+.2byte   -1,  -14, 	   7,   -8, 	 -10,   -9, 	  -1,  -16
+.2byte   -7,  -11, 	   2,  -10, 	  -6,   -3, 	  -1,  -14
+.2byte   -9,  -15, 	   1,  -13, 	  -8,   -7, 	   0,  -13
+.2byte  -10,  -11, 	  -3,  -13, 	 -12,   -6, 	  -1,  -14
+.2byte  -10,   -4, 	  -8,   -3, 	  -4,    1, 	   1,  -11
+.2byte  -11,   -6, 	  -9,   -5, 	  -4,   -2, 	  -2,  -12
+.2byte  -11,   -2, 	 -14,   -5, 	  -8,    1, 	  -1,  -12
+.2byte   -7,   -2, 	  -9,   -1, 	  -2,    2, 	   1,  -12
+.2byte   -9,   -5, 	  -7,   -4, 	   1,   -2, 	   0,  -13
+.2byte   -7,    0, 	 -15,   -3, 	  -4,    2, 	   1,  -12
+.2byte   -1,    2, 	  -7,    5, 	   5,    5, 	  -1,  -10
+.2byte   -7,    1, 	 -15,   -2, 	  -4,    3, 	   1,  -11
+.2byte  -11,   -1, 	 -14,   -4, 	  -8,    2, 	  -1,  -11
+.2byte  -10,  -10, 	  -3,  -12, 	 -12,   -5, 	  -1,  -13
+.2byte   -1,  -11, 	   7,   -5, 	 -10,   -6, 	  -1,  -13
+.2byte    9,  -10, 	   2,  -12, 	  11,   -5, 	   0,  -13
+.2byte   10,   -1, 	  13,   -4, 	   7,    2, 	   0,  -11
+.2byte    6,    1, 	  14,   -2, 	   3,    3, 	  -2,  -11
+.2byte   -1,  -21, 	 -10,  -11, 	  10,  -10, 	   0,  -15
+.2byte    5,  -21, 	  11,  -11, 	  -2,   -6, 	  -1,  -14
+.2byte    5,  -21, 	  10,  -10, 	   9,   -5, 	  -2,  -12
+.2byte    5,  -22, 	  -2,  -13, 	   8,   -8, 	  -3,  -14
+.2byte    0,  -23, 	   9,  -16, 	  -9,  -12, 	   0,  -12
+.2byte   -7,  -22, 	   0,  -13, 	 -10,   -8, 	   1,  -14
+.2byte   -6,  -21, 	 -11,  -10, 	 -10,   -5, 	   1,  -12
+.2byte   -6,  -21, 	 -12,  -11, 	   1,   -6, 	   0,  -14
+.2byte   -1,   -2, 	  -6,    2, 	   4,    2, 	  -1,  -11
+.2byte   -1,   -7, 	  -6,   -3, 	   4,   -3, 	  -1,  -15
+.2byte   -1,    1, 	  -7,    4, 	   5,    4, 	  -1,  -11
+.2byte    5,   -2, 	   7,   -1, 	   0,    2, 	  -3,  -12
+.2byte    7,   -5, 	   5,   -4, 	  -3,   -2, 	  -2,  -13
+.2byte    7,    0, 	  15,   -3, 	   4,    2, 	  -1,  -12
+.2byte    8,   -4, 	   6,   -3, 	   2,    1, 	  -3,  -11
+.2byte    9,   -6, 	   7,   -5, 	   2,   -2, 	   0,  -12
+.2byte    9,   -2, 	  12,   -5, 	   6,    1, 	  -1,  -12
+.2byte    5,  -11, 	  -4,  -10, 	   4,   -3, 	  -1,  -14
+.2byte    7,  -15, 	  -3,  -13, 	   6,   -7, 	  -2,  -13
+.2byte    8,  -11, 	   1,  -13, 	  10,   -6, 	  -1,  -14
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte   -1,  -18, 	   6,   -9, 	  -8,   -9, 	  -1,  -15
+.2byte   -1,  -14, 	   7,   -8, 	 -10,   -9, 	  -1,  -16
+.2byte   -7,  -11, 	   2,  -10, 	  -6,   -3, 	  -1,  -14
+.2byte   -9,  -15, 	   1,  -13, 	  -8,   -7, 	   0,  -13
+.2byte  -10,  -11, 	  -3,  -13, 	 -12,   -6, 	  -1,  -14
+.2byte  -10,   -4, 	  -8,   -3, 	  -4,    1, 	   1,  -11
+.2byte  -11,   -6, 	  -9,   -5, 	  -4,   -2, 	  -2,  -12
+.2byte  -11,   -2, 	 -14,   -5, 	  -8,    1, 	  -1,  -12
+.2byte   -7,   -2, 	  -9,   -1, 	  -2,    2, 	   1,  -12
+.2byte   -9,   -5, 	  -7,   -4, 	   1,   -2, 	   0,  -13
+.2byte   -8,    0, 	 -16,   -3, 	  -5,    2, 	   0,  -12
+.2byte   -3,  -22, 	  -9,  -10, 	  11,  -13, 	   0,  -13
+.2byte   -6,  -22, 	 -10,   -9, 	  -1,  -10, 	   0,  -15
+.2byte   -7,  -22, 	  -5,   -8, 	 -11,  -10, 	   2,  -13
+.2byte   -5,  -25, 	  -1,  -14, 	 -11,  -12, 	   2,  -14
+.2byte    0,  -23, 	   9,  -13, 	  -9,  -15, 	   0,  -12
+.2byte    4,  -25, 	   0,  -14, 	  10,  -12, 	  -3,  -14
+.2byte    7,  -22, 	   5,   -8, 	  11,  -10, 	  -2,  -13
+.2byte    5,  -22, 	   9,   -9, 	   0,  -10, 	  -1,  -15
+.2byte   -1,   -2, 	  -6,    2, 	   4,    2, 	  -1,  -11
+.2byte   -7,   -2, 	  -9,   -1, 	  -2,    2, 	   1,  -12
+.2byte  -10,   -4, 	  -8,   -3, 	  -4,    1, 	   1,  -11
+.2byte   -7,  -11, 	   2,  -10, 	  -6,   -3, 	  -1,  -14
+.2byte   -1,  -13, 	   5,   -7, 	  -7,   -7, 	  -1,  -14
+.2byte    5,  -11, 	  -4,  -10, 	   4,   -3, 	  -1,  -14
+.2byte    8,   -4, 	   6,   -3, 	   2,    1, 	  -3,  -11
+.2byte    5,   -2, 	   7,   -1, 	   0,    2, 	  -3,  -12
+sTaurosAnimTable1:
+.4byte sTaurosAnims_1_1
+.4byte sTaurosAnims_1_2
+.4byte sTaurosAnims_1_3
+.4byte sTaurosAnims_1_4
+.4byte sTaurosAnims_1_5
+.4byte sTaurosAnims_1_6
+.4byte sTaurosAnims_1_7
+.4byte sTaurosAnims_1_8
+sTaurosAnimTable2:
+.4byte sTaurosAnims_2_1
+.4byte sTaurosAnims_2_2
+.4byte sTaurosAnims_2_3
+.4byte sTaurosAnims_2_4
+.4byte sTaurosAnims_2_5
+.4byte sTaurosAnims_2_6
+.4byte sTaurosAnims_2_7
+.4byte sTaurosAnims_2_8
+sTaurosAnimTable3:
+.4byte sTaurosAnims_3_1
+.4byte sTaurosAnims_3_2
+.4byte sTaurosAnims_3_3
+.4byte sTaurosAnims_3_4
+.4byte sTaurosAnims_3_5
+.4byte sTaurosAnims_3_6
+.4byte sTaurosAnims_3_7
+.4byte sTaurosAnims_3_8
+sTaurosAnimTable4:
+.4byte sTaurosAnims_4_1
+.4byte sTaurosAnims_4_2
+.4byte sTaurosAnims_4_3
+.4byte sTaurosAnims_4_4
+.4byte sTaurosAnims_4_5
+.4byte sTaurosAnims_4_6
+.4byte sTaurosAnims_4_7
+.4byte sTaurosAnims_4_8
+sTaurosAnimTable5:
+.4byte sTaurosAnims_5_1
+.4byte sTaurosAnims_5_2
+.4byte sTaurosAnims_5_3
+.4byte sTaurosAnims_5_4
+.4byte sTaurosAnims_5_5
+.4byte sTaurosAnims_5_6
+.4byte sTaurosAnims_5_7
+.4byte sTaurosAnims_5_8
+sTaurosAnimTable6:
+.4byte sTaurosAnims_6_1
+.4byte sTaurosAnims_6_1
+.4byte sTaurosAnims_6_1
+.4byte sTaurosAnims_6_1
+.4byte sTaurosAnims_6_1
+.4byte sTaurosAnims_6_1
+.4byte sTaurosAnims_6_1
+.4byte sTaurosAnims_6_1
+sTaurosAnimTable7:
+.4byte sTaurosAnims_7_1
+.4byte sTaurosAnims_7_2
+.4byte sTaurosAnims_7_3
+.4byte sTaurosAnims_7_4
+.4byte sTaurosAnims_7_5
+.4byte sTaurosAnims_7_6
+.4byte sTaurosAnims_7_7
+.4byte sTaurosAnims_7_8
+sTaurosAnimTable8:
+.4byte sTaurosAnims_8_1
+.4byte sTaurosAnims_8_2
+.4byte sTaurosAnims_8_3
+.4byte sTaurosAnims_8_4
+.4byte sTaurosAnims_8_5
+.4byte sTaurosAnims_8_6
+.4byte sTaurosAnims_8_7
+.4byte sTaurosAnims_8_8
+sTaurosAnimTable9:
+.4byte sTaurosAnims_9_1
+.4byte sTaurosAnims_9_2
+.4byte sTaurosAnims_9_3
+.4byte sTaurosAnims_9_4
+.4byte sTaurosAnims_9_5
+.4byte sTaurosAnims_9_6
+.4byte sTaurosAnims_9_7
+.4byte sTaurosAnims_9_8
+sTaurosAnimTable10:
+.4byte sTaurosAnims_10_1
+.4byte sTaurosAnims_10_2
+.4byte sTaurosAnims_10_3
+.4byte sTaurosAnims_10_4
+.4byte sTaurosAnims_10_5
+.4byte sTaurosAnims_10_6
+.4byte sTaurosAnims_10_7
+.4byte sTaurosAnims_10_8
+sTaurosAnimTable11:
+.4byte sTaurosAnims_11_1
+.4byte sTaurosAnims_11_2
+.4byte sTaurosAnims_11_3
+.4byte sTaurosAnims_11_4
+.4byte sTaurosAnims_11_5
+.4byte sTaurosAnims_11_6
+.4byte sTaurosAnims_11_7
+.4byte sTaurosAnims_11_8
+sTaurosAnimTable12:
+.4byte sTaurosAnims_12_1
+.4byte sTaurosAnims_12_2
+.4byte sTaurosAnims_12_3
+.4byte sTaurosAnims_12_4
+.4byte sTaurosAnims_12_5
+.4byte sTaurosAnims_12_6
+.4byte sTaurosAnims_12_7
+.4byte sTaurosAnims_12_8
+sTaurosAnimTable13:
+.4byte sTaurosAnims_13_1
+.4byte sTaurosAnims_13_2
+.4byte sTaurosAnims_13_3
+.4byte sTaurosAnims_13_4
+.4byte sTaurosAnims_13_5
+.4byte sTaurosAnims_13_6
+.4byte sTaurosAnims_13_7
+.4byte sTaurosAnims_13_8
+sAxAnimationsTauros:
+.4byte sTaurosAnimTable1
+.4byte sTaurosAnimTable2
+.4byte sTaurosAnimTable3
+.4byte sTaurosAnimTable4
+.4byte sTaurosAnimTable5
+.4byte sTaurosAnimTable6
+.4byte sTaurosAnimTable7
+.4byte sTaurosAnimTable8
+.4byte sTaurosAnimTable9
+.4byte sTaurosAnimTable10
+.4byte sTaurosAnimTable11
+.4byte sTaurosAnimTable12
+.4byte sTaurosAnimTable13
+sAxSpritesTauros:
+.4byte sTaurosSprites1
+.4byte sTaurosSprites2
+.4byte sTaurosSprites3
+.4byte sTaurosSprites4
+.4byte sTaurosSprites5
+.4byte sTaurosSprites6
+.4byte sTaurosSprites7
+.4byte sTaurosSprites8
+.4byte sTaurosSprites9
+.4byte sTaurosSprites10
+.4byte sTaurosSprites11
+.4byte sTaurosSprites12
+.4byte sTaurosSprites13
+.4byte sTaurosSprites14
+.4byte sTaurosSprites15
+.4byte sTaurosSprites16
+.4byte sTaurosSprites17
+.4byte sTaurosSprites18
+.4byte sTaurosSprites19
+.4byte sTaurosSprites20
+.4byte sTaurosSprites21
+.4byte sTaurosSprites22
+.4byte sTaurosSprites23
+.4byte sTaurosSprites24
+.4byte sTaurosSprites25
+.4byte sTaurosSprites26
+.4byte sTaurosSprites27
+.4byte sTaurosSprites28
+.4byte sTaurosSprites29
+.4byte sTaurosSprites30
+.4byte sTaurosSprites31
+.4byte sTaurosSprites32
+.4byte sTaurosSprites33
+.4byte sTaurosSprites34
+.4byte sTaurosSprites35
+.4byte sTaurosSprites36
+.4byte sTaurosSprites37
+.4byte sTaurosSprites38
+.4byte sTaurosSprites39
+.4byte sTaurosSprites40
+.4byte sTaurosSprites41
+.4byte sTaurosSprites42
+.4byte sTaurosSprites43
+.4byte sTaurosSprites44
+.4byte sTaurosSprites45
+.4byte sTaurosSprites46
+.4byte sTaurosSprites47
+sAxMainTauros:
+ax_main sAxPosesTauros, sAxAnimationsTauros, 13, sAxSpritesTauros, sAxPositionsTauros

--- a/data/ax/teddiursa.inc
+++ b/data/ax/teddiursa.inc
@@ -1,0 +1,3225 @@
+.global gAxTeddiursa
+gAxTeddiursa:
+ax_siro sAxMainTeddiursa
+sTeddiursaPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose4:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose5:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose6:
+ax_pose 5, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose7:
+ax_pose 6, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose8:
+ax_pose 7, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose9:
+ax_pose 8, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose10:
+ax_pose 9, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose11:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose12:
+ax_pose 11, 0x81ed, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose16:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose17:
+ax_pose 16, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose18:
+ax_pose 17, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose19:
+ax_pose 18, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose20:
+ax_pose 19, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose21:
+ax_pose 20, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose22:
+ax_pose 21, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose23:
+ax_pose 22, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose24:
+ax_pose 23, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose28:
+ax_pose 24, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose29:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose30:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose31:
+ax_pose 5, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose32:
+ax_pose 25, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose33:
+ax_pose 6, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose34:
+ax_pose 7, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose35:
+ax_pose 8, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose36:
+ax_pose 26, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose37:
+ax_pose 9, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose38:
+ax_pose 10, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose39:
+ax_pose 11, 0x81ed, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose40:
+ax_pose 27, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose42:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose43:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose44:
+ax_pose 28, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose45:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose46:
+ax_pose 16, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose47:
+ax_pose 17, 0x01ed, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose48:
+ax_pose 29, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose49:
+ax_pose 18, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose50:
+ax_pose 19, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose51:
+ax_pose 20, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose52:
+ax_pose 30, 0x01e6, 0x80f2, 0x4c00
+ax_pose_terminator
+sTeddiursaPose53:
+ax_pose 21, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose54:
+ax_pose 22, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose55:
+ax_pose 23, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose56:
+ax_pose 31, 0x01e7, 0x80f1, 0x4c00
+ax_pose_terminator
+sTeddiursaPose57:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose58:
+ax_pose 1, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose59:
+ax_pose 2, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose60:
+ax_pose 32, 0x01e7, 0x90f0, 0x4c00
+ax_pose 24, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sTeddiursaPose61:
+ax_pose 24, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose62:
+ax_pose 32, 0x01e7, 0x80f0, 0x4c00
+ax_pose 33, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sTeddiursaPose63:
+ax_pose 33, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose64:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose65:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose66:
+ax_pose 5, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose67:
+ax_pose 34, 0x01e7, 0x90ef, 0x4c00
+ax_pose 25, 0x01e7, 0x80ef, 0x4c10
+ax_pose_terminator
+sTeddiursaPose68:
+ax_pose 25, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose69:
+ax_pose 35, 0x01e7, 0x90ef, 0x4c00
+ax_pose 36, 0x01e7, 0x80ef, 0x4c10
+ax_pose_terminator
+sTeddiursaPose70:
+ax_pose 36, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose71:
+ax_pose 6, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose72:
+ax_pose 7, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose73:
+ax_pose 8, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose74:
+ax_pose 37, 0x01e6, 0x90ef, 0x4c00
+ax_pose 26, 0x01e6, 0x80ef, 0x4c10
+ax_pose_terminator
+sTeddiursaPose75:
+ax_pose 26, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose76:
+ax_pose 38, 0x41f6, 0x90ef, 0x4c00
+ax_pose 39, 0x01e6, 0x90ef, 0x4c08
+ax_pose_terminator
+sTeddiursaPose77:
+ax_pose 39, 0x01e6, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose78:
+ax_pose 9, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose79:
+ax_pose 10, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose80:
+ax_pose 11, 0x81ec, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose81:
+ax_pose 40, 0x41ee, 0x90ef, 0x4c00
+ax_pose 27, 0x01e6, 0x80ef, 0x4c08
+ax_pose_terminator
+sTeddiursaPose82:
+ax_pose 27, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose83:
+ax_pose 41, 0x01e7, 0x90f0, 0x4c00
+ax_pose 29, 0x01e7, 0x90f0, 0x4c10
+ax_pose_terminator
+sTeddiursaPose84:
+ax_pose 29, 0x01e7, 0x90f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose85:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose86:
+ax_pose 13, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose87:
+ax_pose 14, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose88:
+ax_pose 42, 0x81e7, 0x9100, 0x4c00
+ax_pose 43, 0x01e7, 0x80f0, 0x4c08
+ax_pose_terminator
+sTeddiursaPose89:
+ax_pose 43, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose90:
+ax_pose 42, 0x81e7, 0x80f0, 0x4c00
+ax_pose 28, 0x01e7, 0x80f0, 0x4c08
+ax_pose_terminator
+sTeddiursaPose91:
+ax_pose 28, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose92:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose93:
+ax_pose 16, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose94:
+ax_pose 17, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sTeddiursaPose95:
+ax_pose 40, 0x41ee, 0x80f0, 0x4c00
+ax_pose 44, 0x01e6, 0x80f0, 0x4c08
+ax_pose_terminator
+sTeddiursaPose96:
+ax_pose 44, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose97:
+ax_pose 41, 0x01e6, 0x80f0, 0x4c00
+ax_pose 29, 0x01e6, 0x80f0, 0x4c10
+ax_pose_terminator
+sTeddiursaPose98:
+ax_pose 29, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose99:
+ax_pose 18, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose100:
+ax_pose 19, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose101:
+ax_pose 20, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose102:
+ax_pose 37, 0x01e7, 0x80f0, 0x4c00
+ax_pose 30, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sTeddiursaPose103:
+ax_pose 30, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose104:
+ax_pose 38, 0x41f7, 0x80f0, 0x4c00
+ax_pose 39, 0x01e7, 0x80f0, 0x4c08
+ax_pose_terminator
+sTeddiursaPose105:
+ax_pose 39, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose106:
+ax_pose 21, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose107:
+ax_pose 22, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose108:
+ax_pose 23, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose109:
+ax_pose 34, 0x01e7, 0x80f0, 0x4c00
+ax_pose 31, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sTeddiursaPose110:
+ax_pose 31, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose111:
+ax_pose 35, 0x01e7, 0x80f0, 0x4c00
+ax_pose 45, 0x01e7, 0x80f0, 0x4c10
+ax_pose_terminator
+sTeddiursaPose112:
+ax_pose 45, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose113:
+ax_pose 46, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose114:
+ax_pose 47, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose115:
+ax_pose 48, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose116:
+ax_pose 49, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose117:
+ax_pose 50, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose118:
+ax_pose 49, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose119:
+ax_pose 51, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose120:
+ax_pose 52, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose121:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose122:
+ax_pose 53, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose123:
+ax_pose 46, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose124:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose125:
+ax_pose 54, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose126:
+ax_pose 52, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose127:
+ax_pose 6, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose128:
+ax_pose 55, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose129:
+ax_pose 51, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose130:
+ax_pose 9, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose131:
+ax_pose 56, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose132:
+ax_pose 49, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose133:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose134:
+ax_pose 57, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose135:
+ax_pose 50, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose136:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose137:
+ax_pose 56, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose138:
+ax_pose 49, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose139:
+ax_pose 18, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose140:
+ax_pose 58, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose141:
+ax_pose 48, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose142:
+ax_pose 21, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose143:
+ax_pose 59, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose144:
+ax_pose 47, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose145:
+ax_pose 60, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose146:
+ax_pose 61, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose147:
+ax_pose 62, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose148:
+ax_pose 63, 0x01e6, 0x80e9, 0x4c00
+ax_pose_terminator
+sTeddiursaPose149:
+ax_pose 64, 0x01e4, 0x80e8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose150:
+ax_pose 65, 0x01e5, 0x90e9, 0x4c00
+ax_pose_terminator
+sTeddiursaPose151:
+ax_pose 66, 0x01e7, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose152:
+ax_pose 65, 0x01e5, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose153:
+ax_pose 67, 0x01e4, 0x80f9, 0x4c00
+ax_pose_terminator
+sTeddiursaPose154:
+ax_pose 68, 0x01e5, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose155:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose156:
+ax_pose 53, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose157:
+ax_pose 46, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose158:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose159:
+ax_pose 54, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose160:
+ax_pose 52, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose161:
+ax_pose 6, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose162:
+ax_pose 55, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose163:
+ax_pose 51, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose164:
+ax_pose 9, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose165:
+ax_pose 56, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose166:
+ax_pose 49, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose167:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose168:
+ax_pose 57, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose169:
+ax_pose 50, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose170:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose171:
+ax_pose 56, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose172:
+ax_pose 49, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose173:
+ax_pose 18, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose174:
+ax_pose 58, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose175:
+ax_pose 48, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose176:
+ax_pose 21, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose177:
+ax_pose 59, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose178:
+ax_pose 47, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose179:
+ax_pose 1, 0x01e9, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose180:
+ax_pose 22, 0x01ea, 0x80f6, 0x4c00
+ax_pose_terminator
+sTeddiursaPose181:
+ax_pose 19, 0x81ea, 0x80f9, 0x4c00
+ax_pose_terminator
+sTeddiursaPose182:
+ax_pose 16, 0x81ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose183:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose184:
+ax_pose 10, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sTeddiursaPose185:
+ax_pose 7, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose186:
+ax_pose 4, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose187:
+ax_pose 53, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose188:
+ax_pose 54, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose189:
+ax_pose 55, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose190:
+ax_pose 56, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose191:
+ax_pose 57, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose192:
+ax_pose 56, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose193:
+ax_pose 58, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose194:
+ax_pose 59, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose195:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose196:
+ax_pose 1, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sTeddiursaPose197:
+ax_pose 2, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sTeddiursaPose198:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose199:
+ax_pose 4, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sTeddiursaPose200:
+ax_pose 5, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sTeddiursaPose201:
+ax_pose 6, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose202:
+ax_pose 7, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose203:
+ax_pose 8, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose204:
+ax_pose 9, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose205:
+ax_pose 11, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose206:
+ax_pose 10, 0x01ec, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose207:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose208:
+ax_pose 13, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sTeddiursaPose209:
+ax_pose 14, 0x01ec, 0x80f5, 0x4c00
+ax_pose_terminator
+sTeddiursaPose210:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose211:
+ax_pose 16, 0x81ea, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose212:
+ax_pose 17, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sTeddiursaPose213:
+ax_pose 18, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose214:
+ax_pose 20, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose215:
+ax_pose 19, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose216:
+ax_pose 21, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose217:
+ax_pose 23, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sTeddiursaPose218:
+ax_pose 22, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sTeddiursaPose219:
+ax_pose 46, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose220:
+ax_pose 47, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose221:
+ax_pose 48, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose222:
+ax_pose 49, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose223:
+ax_pose 50, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTeddiursaPose224:
+ax_pose 49, 0x01e7, 0x90ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose225:
+ax_pose 51, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose226:
+ax_pose 52, 0x01e7, 0x80ef, 0x4c00
+ax_pose_terminator
+sTeddiursaPose227:
+ax_pose 0, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose228:
+ax_pose 21, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose229:
+ax_pose 18, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose230:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTeddiursaPose231:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTeddiursaPose232:
+ax_pose 9, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose233:
+ax_pose 6, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTeddiursaPose234:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+.align 2
+sTeddiursaAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_2_1:
+ax_anim 2, 0, 52, 0, -1, 0, -1,
+ax_anim 6, 0, 52, 1, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTeddiursaAnims_2_2:
+ax_anim 2, 0, 32, -1, -1, -1, -1,
+ax_anim 6, 0, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 1, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 0, 31, 21, 19, 21, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sTeddiursaAnims_2_3:
+ax_anim 2, 0, 36, -1, 0, -1, 0,
+ax_anim 6, 0, 36, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 1, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 21, 1, 21, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sTeddiursaAnims_2_4:
+ax_anim 2, 0, 40, -1, 1, -1, 1,
+ax_anim 6, 0, 40, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 11, -11, 11, -11,
+ax_anim 2, 0, 39, 21, -23, 21, -23,
+ax_anim 2, 1, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 39, 21, -23, 21, -23,
+ax_anim 2, 0, 39, 22, -22, 22, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sTeddiursaAnims_2_5:
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 6, 0, 44, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 1, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 1, -21, 1, -21,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sTeddiursaAnims_2_6:
+ax_anim 2, 0, 48, 1, 1, 1, 1,
+ax_anim 6, 0, 48, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -6, -6, -4, -6,
+ax_anim 1, 0, 46, -11, -11, -11, -11,
+ax_anim 2, 0, 47, -21, -23, -21, -23,
+ax_anim 2, 1, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 47, -21, -23, -21, -23,
+ax_anim 2, 0, 47, -22, -22, -22, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sTeddiursaAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 1, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -21, 1, -21, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sTeddiursaAnims_2_8:
+ax_anim 2, 0, 48, 1, -1, 1, -1,
+ax_anim 6, 0, 48, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 1, 55, -21, 19, -21, 19,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 0, 55, -21, 19, -21, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 56, 0, -4, 0, -4,
+ax_anim 4, 0, 56, 0, -6, 0, -6,
+ax_anim 1, 0, 106, 0, -3, 0, -3,
+ax_anim 1, 2, 107, 0, 3, 0, 3,
+ax_anim 2, 0, 59, 0, 19, 0, 19,
+ax_anim 2, 1, 60, 1, 20, 1, 20,
+ax_anim 2, 0, 63, 1, 16, 1, 16,
+ax_anim 2, 0, 63, 2, 14, 2, 14,
+ax_anim 2, 0, 61, 0, 19, 0, 19,
+ax_anim 2, 0, 62, -1, 20, -1, 20,
+ax_anim 2, 0, 58, -1, 16, -1, 16,
+ax_anim 2, 0, 57, 0, 11, 0, 11,
+ax_anim 2, 0, 58, 0, 3, 0, 3,
+ax_anim_terminator
+sTeddiursaAnims_3_2:
+ax_anim 2, 0, 63, -2, -2, -2, -2,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim 1, 0, 71, -3, -3, -3, -3,
+ax_anim 1, 2, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 66, 19, 19, 19, 19,
+ax_anim 2, 1, 67, 19, 21, 19, 21,
+ax_anim 2, 0, 56, 15, 17, 15, 17,
+ax_anim 2, 0, 56, 12, 14, 12, 14,
+ax_anim 2, 0, 68, 19, 19, 19, 19,
+ax_anim 2, 0, 69, 21, 19, 21, 19,
+ax_anim 2, 0, 65, 20, 15, 20, 15,
+ax_anim 2, 0, 64, 11, 11, 11, 11,
+ax_anim 2, 0, 65, 3, 3, 3, 3,
+ax_anim_terminator
+sTeddiursaAnims_3_3:
+ax_anim 2, 0, 70, -2, 0, -2, 0,
+ax_anim 2, 0, 70, -4, 0, -4, 0,
+ax_anim 4, 0, 70, -6, 0, -6, 0,
+ax_anim 1, 0, 78, -3, -1, -3, 0,
+ax_anim 1, 2, 79, 6, -1, 6, 0,
+ax_anim 2, 0, 73, 16, -1, 16, 0,
+ax_anim 2, 1, 74, 18, 1, 18, 1,
+ax_anim 2, 0, 63, 15, 2, 15, 2,
+ax_anim 2, 0, 63, 12, 2, 12, 2,
+ax_anim 2, 0, 75, 16, 0, 16, 0,
+ax_anim 2, 0, 76, 17, 0, 17, 0,
+ax_anim 2, 0, 72, 10, 0, 10, -2,
+ax_anim 2, 0, 71, 6, 0, 6, -1,
+ax_anim 2, 0, 72, 3, 0, 3, 0,
+ax_anim_terminator
+sTeddiursaAnims_3_4:
+ax_anim 2, 0, 77, -2, 2, -2, 2,
+ax_anim 2, 0, 77, -4, 4, -4, 4,
+ax_anim 4, 0, 77, -6, 6, -6, 6,
+ax_anim 1, 0, 85, 0, -2, 0, -2,
+ax_anim 1, 2, 85, 9, -13, 9, -13,
+ax_anim 2, 0, 80, 17, -22, 17, -22,
+ax_anim 2, 1, 81, 19, -22, 19, -22,
+ax_anim 2, 0, 70, 19, -18, 19, -18,
+ax_anim 2, 0, 70, 15, -14, 15, -14,
+ax_anim 2, 0, 82, 21, -22, 21, -22,
+ax_anim 2, 0, 83, 22, -24, 22, -24,
+ax_anim 2, 0, 79, 17, -17, 17, -17,
+ax_anim 2, 0, 78, 8, -8, 8, -8,
+ax_anim 2, 0, 79, 3, -3, 3, -3,
+ax_anim_terminator
+sTeddiursaAnims_3_5:
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 2, 0, 84, 0, 4, 0, 4,
+ax_anim 4, 0, 84, 0, 6, 0, 6,
+ax_anim 1, 0, 78, 1, 3, 0, 3,
+ax_anim 1, 2, 79, 2, -6, 0, -6,
+ax_anim 2, 0, 87, 0, -20, 0, -20,
+ax_anim 2, 1, 88, -1, -21, -1, -21,
+ax_anim 2, 0, 91, -1, -17, -1, -17,
+ax_anim 2, 0, 91, -1, -13, 0, -13,
+ax_anim 2, 0, 89, 0, -20, 0, -20,
+ax_anim 2, 0, 90, 1, -21, 1, -21,
+ax_anim 2, 0, 86, 1, -13, 1, -10,
+ax_anim 2, 0, 85, 0, -8, 0, -5,
+ax_anim 2, 0, 86, 0, -4, 0, -1,
+ax_anim_terminator
+sTeddiursaAnims_3_6:
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 4, 4, 4, 4,
+ax_anim 4, 0, 91, 6, 6, 6, 6,
+ax_anim 1, 0, 85, 3, -1, 3, -1,
+ax_anim 1, 2, 86, -4, -11, -4, -11,
+ax_anim 2, 0, 94, -17, -22, -17, -22,
+ax_anim 2, 1, 95, -19, -22, -19, -22,
+ax_anim 2, 0, 98, -20, -18, -20, -18,
+ax_anim 2, 0, 98, -15, -15, -15, -15,
+ax_anim 2, 0, 96, -21, -22, -21, -22,
+ax_anim 2, 0, 97, -22, -24, -22, -24,
+ax_anim 2, 0, 93, -17, -20, -17, -20,
+ax_anim 2, 0, 92, -11, -10, -11, -10,
+ax_anim 2, 0, 93, -6, -6, -6, -6,
+ax_anim_terminator
+sTeddiursaAnims_3_7:
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 2, 0, 98, 4, 0, 4, 0,
+ax_anim 4, 0, 98, 6, 0, 6, 0,
+ax_anim 1, 0, 92, 3, -1, 3, -1,
+ax_anim 1, 2, 93, -6, -1, -6, -1,
+ax_anim 2, 0, 101, -16, -1, -16, -1,
+ax_anim 2, 1, 102, -18, 1, -18, 1,
+ax_anim 2, 0, 105, -15, 2, -15, 2,
+ax_anim 2, 0, 105, -12, 2, -12, 2,
+ax_anim 2, 0, 103, -16, 0, -16, 0,
+ax_anim 2, 0, 104, -17, -1, -17, -1,
+ax_anim 2, 0, 100, -12, 0, -12, 0,
+ax_anim 2, 0, 99, -6, 0, -6, 0,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sTeddiursaAnims_3_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 2, 0, 105, 4, -4, 4, -4,
+ax_anim 4, 0, 105, 6, -6, 6, -6,
+ax_anim 1, 0, 99, 1, -3, 1, -3,
+ax_anim 1, 2, 100, -8, 6, -8, 6,
+ax_anim 2, 0, 108, -19, 19, -19, 19,
+ax_anim 2, 1, 109, -19, 21, -19, 21,
+ax_anim 2, 0, 56, -15, 17, -15, 17,
+ax_anim 2, 0, 56, -12, 14, -12, 14,
+ax_anim 2, 0, 110, -19, 19, -19, 19,
+ax_anim 2, 0, 111, -21, 19, -21, 19,
+ax_anim 2, 0, 107, -20, 15, -20, 15,
+ax_anim 2, 0, 106, -9, 8, -9, 8,
+ax_anim 2, 0, 107, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_4_1:
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 2, 1, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_4_2:
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_4_3:
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_4_4:
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -1, -1, -1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_4_5:
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 1, 0, 1, 0,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_4_6:
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_4_7:
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, -1,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_4_8:
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, -1, -1, -1, -1,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_5_1:
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 2, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_5_2:
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 6, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 2, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_5_3:
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 2, 128, 0, 0, 0, 0,
+ax_anim 3, 0, 127, 0, 0, 0, 0,
+ax_anim 3, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_5_4:
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 2, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_5_5:
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 2, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_5_6:
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 2, 137, 0, 0, 0, 0,
+ax_anim 3, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_5_7:
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 2, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_5_8:
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 2, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_7_1:
+ax_anim 2, 0, 146, 0, -4, 0, -4,
+ax_anim 8, 0, 146, 0, -5, 0, -5,
+ax_anim_terminator
+sTeddiursaAnims_7_2:
+ax_anim 2, 0, 147, -4, -4, -4, -4,
+ax_anim 8, 0, 147, -5, -5, -5, -5,
+ax_anim_terminator
+sTeddiursaAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sTeddiursaAnims_7_4:
+ax_anim 2, 0, 149, -4, 4, -4, 4,
+ax_anim 8, 0, 149, -5, 5, -5, 5,
+ax_anim_terminator
+sTeddiursaAnims_7_5:
+ax_anim 2, 0, 150, 0, 4, 0, 4,
+ax_anim 8, 0, 150, 0, 5, 0, 5,
+ax_anim_terminator
+sTeddiursaAnims_7_6:
+ax_anim 2, 0, 151, 4, 4, 4, 4,
+ax_anim 8, 0, 151, 5, 5, 5, 5,
+ax_anim_terminator
+sTeddiursaAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sTeddiursaAnims_7_8:
+ax_anim 2, 0, 153, 4, -4, 4, -4,
+ax_anim 8, 0, 153, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, 0, 0, 0,
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, 0, 0, 0,
+ax_anim 20, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 162, 0, 0, 0, 0,
+ax_anim 20, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 8, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 8, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 12, 0, 170, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 12, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 12, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 9, 9, 9, 9,
+ax_anim 2, 0, 181, 7, 17, 7, 17,
+ax_anim 3, 0, 182, 0, 20, 0, 20,
+ax_anim 2, 3, 183, -7, 17, -7, 17,
+ax_anim 2, 0, 184, -9, 9, -9, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 17, 3, 17, 3,
+ax_anim 2, 0, 180, 21, 11, 21, 11,
+ax_anim 3, 0, 181, 23, 20, 23, 20,
+ax_anim 2, 3, 182, 13, 21, 13, 21,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 5, -5, 5, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -5, 17, -5,
+ax_anim 3, 0, 180, 22, 0, 22, 0,
+ax_anim 2, 3, 181, 19, 5, 19, 5,
+ax_anim 2, 0, 182, 12, 7, 12, 7,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -8, -1, -8,
+ax_anim 2, 0, 185, 5, -17, 5, -17,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 21, -23, 21, -23,
+ax_anim 2, 3, 180, 23, -14, 23, -14,
+ax_anim 2, 0, 181, 20, -4, 20, -4,
+ax_anim 1, 0, 182, 10, 0, 10, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -11, -9, -11,
+ax_anim 2, 0, 185, -7, -20, -7, -20,
+ax_anim 3, 0, 178, 0, -24, 0, -24,
+ax_anim 2, 3, 179, 7, -20, 7, -20,
+ax_anim 2, 0, 180, 9, -11, 9, -11,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -8, 1, -8,
+ax_anim 2, 0, 179, -5, -17, -5, -17,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -21, -23, -21, -23,
+ax_anim 2, 3, 184, -23, -14, -23, -14,
+ax_anim 2, 0, 183, -20, -4, -20, -4,
+ax_anim 1, 0, 182, -10, 0, -10, 0,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -5, -5, -5, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -5, -17, -5,
+ax_anim 3, 0, 184, -22, 0, -22, 0,
+ax_anim 2, 3, 183, -19, 5, -19, 5,
+ax_anim 2, 0, 182, -12, 7, -12, 7,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -17, 3, -17, 3,
+ax_anim 2, 0, 184, -21, 11, -21, 11,
+ax_anim 3, 0, 183, -23, 20, -23, 20,
+ax_anim 2, 3, 182, -13, 21, -13, 21,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 3, 0, 217, 0, -21, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTeddiursaAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTeddiursaGfx1:
+.incbin "baserom.gba", 0xEC17CC, 0x200
+sTeddiursaSprites1:
+ax_sprite sTeddiursaGfx1, 0x200
+ax_sprite_terminator
+sTeddiursaGfx2:
+.incbin "baserom.gba", 0xEC19DC, 0x200
+sTeddiursaSprites2:
+ax_sprite sTeddiursaGfx2, 0x200
+ax_sprite_terminator
+sTeddiursaGfx3:
+.incbin "baserom.gba", 0xEC1BEC, 0x200
+sTeddiursaSprites3:
+ax_sprite sTeddiursaGfx3, 0x200
+ax_sprite_terminator
+sTeddiursaGfx4:
+.incbin "baserom.gba", 0xEC1DFC, 0x200
+sTeddiursaSprites4:
+ax_sprite sTeddiursaGfx4, 0x200
+ax_sprite_terminator
+sTeddiursaGfx5:
+.incbin "baserom.gba", 0xEC200C, 0x200
+sTeddiursaSprites5:
+ax_sprite sTeddiursaGfx5, 0x200
+ax_sprite_terminator
+sTeddiursaGfx6:
+.incbin "baserom.gba", 0xEC221C, 0x200
+sTeddiursaSprites6:
+ax_sprite sTeddiursaGfx6, 0x200
+ax_sprite_terminator
+sTeddiursaGfx7:
+.incbin "baserom.gba", 0xEC242C, 0x100
+sTeddiursaSprites7:
+ax_sprite sTeddiursaGfx7, 0x100
+ax_sprite_terminator
+sTeddiursaGfx8:
+.incbin "baserom.gba", 0xEC253C, 0x100
+sTeddiursaSprites8:
+ax_sprite sTeddiursaGfx8, 0x100
+ax_sprite_terminator
+sTeddiursaGfx9:
+.incbin "baserom.gba", 0xEC264C, 0x100
+sTeddiursaSprites9:
+ax_sprite sTeddiursaGfx9, 0x100
+ax_sprite_terminator
+sTeddiursaGfx10:
+.incbin "baserom.gba", 0xEC275C, 0x100
+sTeddiursaSprites10:
+ax_sprite sTeddiursaGfx10, 0x100
+ax_sprite_terminator
+sTeddiursaGfx11:
+.incbin "baserom.gba", 0xEC286C, 0x200
+sTeddiursaSprites11:
+ax_sprite sTeddiursaGfx11, 0x200
+ax_sprite_terminator
+sTeddiursaGfx12:
+.incbin "baserom.gba", 0xEC2A7C, 0x100
+sTeddiursaSprites12:
+ax_sprite sTeddiursaGfx12, 0x100
+ax_sprite_terminator
+sTeddiursaGfx13:
+.incbin "baserom.gba", 0xEC2B8C, 0x200
+sTeddiursaSprites13:
+ax_sprite sTeddiursaGfx13, 0x200
+ax_sprite_terminator
+sTeddiursaGfx14:
+.incbin "baserom.gba", 0xEC2D9C, 0x200
+sTeddiursaSprites14:
+ax_sprite sTeddiursaGfx14, 0x200
+ax_sprite_terminator
+sTeddiursaGfx15:
+.incbin "baserom.gba", 0xEC2FAC, 0x200
+sTeddiursaSprites15:
+ax_sprite sTeddiursaGfx15, 0x200
+ax_sprite_terminator
+sTeddiursaGfx16:
+.incbin "baserom.gba", 0xEC31BC, 0x100
+sTeddiursaSprites16:
+ax_sprite sTeddiursaGfx16, 0x100
+ax_sprite_terminator
+sTeddiursaGfx17:
+.incbin "baserom.gba", 0xEC32CC, 0x100
+sTeddiursaSprites17:
+ax_sprite sTeddiursaGfx17, 0x100
+ax_sprite_terminator
+sTeddiursaGfx18:
+.incbin "baserom.gba", 0xEC33DC, 0x200
+sTeddiursaSprites18:
+ax_sprite sTeddiursaGfx18, 0x200
+ax_sprite_terminator
+sTeddiursaGfx19:
+.incbin "baserom.gba", 0xEC35EC, 0x100
+sTeddiursaSprites19:
+ax_sprite sTeddiursaGfx19, 0x100
+ax_sprite_terminator
+sTeddiursaGfx20:
+.incbin "baserom.gba", 0xEC36FC, 0x100
+sTeddiursaSprites20:
+ax_sprite sTeddiursaGfx20, 0x100
+ax_sprite_terminator
+sTeddiursaGfx21:
+.incbin "baserom.gba", 0xEC380C, 0x100
+sTeddiursaSprites21:
+ax_sprite sTeddiursaGfx21, 0x100
+ax_sprite_terminator
+sTeddiursaGfx22:
+.incbin "baserom.gba", 0xEC391C, 0x200
+sTeddiursaSprites22:
+ax_sprite sTeddiursaGfx22, 0x200
+ax_sprite_terminator
+sTeddiursaGfx23:
+.incbin "baserom.gba", 0xEC3B2C, 0x200
+sTeddiursaSprites23:
+ax_sprite sTeddiursaGfx23, 0x200
+ax_sprite_terminator
+sTeddiursaGfx24:
+.incbin "baserom.gba", 0xEC3D3C, 0x200
+sTeddiursaSprites24:
+ax_sprite sTeddiursaGfx24, 0x200
+ax_sprite_terminator
+sTeddiursaGfx25:
+.incbin "baserom.gba", 0xEC3F4C, 0x20
+sTeddiursaGfx25_1:
+.incbin "baserom.gba", 0xEC3F6C, 0x60
+sTeddiursaGfx25_2:
+.incbin "baserom.gba", 0xEC3FCC, 0x80
+sTeddiursaGfx25_3:
+.incbin "baserom.gba", 0xEC404C, 0x40
+sTeddiursaSprites25:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx25, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx25_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx25_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx26:
+.incbin "baserom.gba", 0xEC40DC, 0x20
+sTeddiursaGfx26_1:
+.incbin "baserom.gba", 0xEC40FC, 0x60
+sTeddiursaGfx26_2:
+.incbin "baserom.gba", 0xEC415C, 0x60
+sTeddiursaGfx26_3:
+.incbin "baserom.gba", 0xEC41BC, 0x40
+sTeddiursaSprites26:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTeddiursaGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx27:
+.incbin "baserom.gba", 0xEC424C, 0x20
+sTeddiursaGfx27_1:
+.incbin "baserom.gba", 0xEC426C, 0x60
+sTeddiursaGfx27_2:
+.incbin "baserom.gba", 0xEC42CC, 0x60
+sTeddiursaGfx27_3:
+.incbin "baserom.gba", 0xEC432C, 0x40
+sTeddiursaSprites27:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx28:
+.incbin "baserom.gba", 0xEC43BC, 0x40
+sTeddiursaGfx28_1:
+.incbin "baserom.gba", 0xEC43FC, 0x60
+sTeddiursaGfx28_2:
+.incbin "baserom.gba", 0xEC445C, 0x60
+sTeddiursaGfx28_3:
+.incbin "baserom.gba", 0xEC44BC, 0x40
+sTeddiursaSprites28:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx29:
+.incbin "baserom.gba", 0xEC454C, 0x60
+sTeddiursaGfx29_1:
+.incbin "baserom.gba", 0xEC45AC, 0x60
+sTeddiursaGfx29_2:
+.incbin "baserom.gba", 0xEC460C, 0x60
+sTeddiursaSprites29:
+ax_sprite 0, 0x80
+ax_sprite sTeddiursaGfx29, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx29_2, 0x60
+ax_sprite_terminator
+sTeddiursaGfx30:
+.incbin "baserom.gba", 0xEC46A4, 0x20
+sTeddiursaGfx30_1:
+.incbin "baserom.gba", 0xEC46C4, 0x100
+sTeddiursaGfx30_2:
+.incbin "baserom.gba", 0xEC47C4, 0x40
+sTeddiursaSprites30:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx30, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx30_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx31:
+.incbin "baserom.gba", 0xEC4844, 0x20
+sTeddiursaGfx31_1:
+.incbin "baserom.gba", 0xEC4864, 0x60
+sTeddiursaGfx31_2:
+.incbin "baserom.gba", 0xEC48C4, 0x60
+sTeddiursaGfx31_3:
+.incbin "baserom.gba", 0xEC4924, 0x40
+sTeddiursaSprites31:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx31, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx31_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx32:
+.incbin "baserom.gba", 0xEC49B4, 0x20
+sTeddiursaGfx32_1:
+.incbin "baserom.gba", 0xEC49D4, 0x60
+sTeddiursaGfx32_2:
+.incbin "baserom.gba", 0xEC4A34, 0x60
+sTeddiursaGfx32_3:
+.incbin "baserom.gba", 0xEC4A94, 0x40
+sTeddiursaSprites32:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx32, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx33:
+.incbin "baserom.gba", 0xEC4B24, 0x20
+sTeddiursaGfx33_1:
+.incbin "baserom.gba", 0xEC4B44, 0x60
+sTeddiursaGfx33_2:
+.incbin "baserom.gba", 0xEC4BA4, 0x40
+sTeddiursaSprites33:
+ax_sprite 0, 0xe0
+ax_sprite sTeddiursaGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx34:
+.incbin "baserom.gba", 0xEC4C24, 0x20
+sTeddiursaGfx34_1:
+.incbin "baserom.gba", 0xEC4C44, 0xE0
+sTeddiursaGfx34_2:
+.incbin "baserom.gba", 0xEC4D24, 0x40
+sTeddiursaSprites34:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx34, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTeddiursaGfx34_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx35:
+.incbin "baserom.gba", 0xEC4DA4, 0x20
+sTeddiursaGfx35_1:
+.incbin "baserom.gba", 0xEC4DC4, 0x40
+sTeddiursaGfx35_2:
+.incbin "baserom.gba", 0xEC4E04, 0x40
+sTeddiursaGfx35_3:
+.incbin "baserom.gba", 0xEC4E44, 0x20
+sTeddiursaSprites35:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx35, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx35_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx35_3, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sTeddiursaGfx36:
+.incbin "baserom.gba", 0xEC4EB4, 0x20
+sTeddiursaGfx36_1:
+.incbin "baserom.gba", 0xEC4ED4, 0x60
+sTeddiursaGfx36_2:
+.incbin "baserom.gba", 0xEC4F34, 0x40
+sTeddiursaSprites36:
+ax_sprite 0, 0xe0
+ax_sprite sTeddiursaGfx36, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx37:
+.incbin "baserom.gba", 0xEC4FB4, 0x40
+sTeddiursaGfx37_1:
+.incbin "baserom.gba", 0xEC4FF4, 0x40
+sTeddiursaGfx37_2:
+.incbin "baserom.gba", 0xEC5034, 0x40
+sTeddiursaGfx37_3:
+.incbin "baserom.gba", 0xEC5074, 0x40
+sTeddiursaSprites37:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx37_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx37_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx37_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx38:
+.incbin "baserom.gba", 0xEC5104, 0x60
+sTeddiursaGfx38_1:
+.incbin "baserom.gba", 0xEC5164, 0x20
+sTeddiursaSprites38:
+ax_sprite 0, 0x80
+ax_sprite sTeddiursaGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx38_1, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sTeddiursaGfx39:
+.incbin "baserom.gba", 0xEC51B4, 0xC0
+sTeddiursaSprites39:
+ax_sprite sTeddiursaGfx39, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTeddiursaGfx40:
+.incbin "baserom.gba", 0xEC528C, 0x20
+sTeddiursaGfx40_1:
+.incbin "baserom.gba", 0xEC52AC, 0x40
+sTeddiursaGfx40_2:
+.incbin "baserom.gba", 0xEC52EC, 0x60
+sTeddiursaGfx40_3:
+.incbin "baserom.gba", 0xEC534C, 0x40
+sTeddiursaSprites40:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx40, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx40_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx40_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx41:
+.incbin "baserom.gba", 0xEC53DC, 0x40
+sTeddiursaGfx41_1:
+.incbin "baserom.gba", 0xEC541C, 0x20
+sTeddiursaGfx41_2:
+.incbin "baserom.gba", 0xEC543C, 0x20
+sTeddiursaSprites41:
+ax_sprite sTeddiursaGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx41_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx41_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx42:
+.incbin "baserom.gba", 0xEC5494, 0x40
+sTeddiursaGfx42_1:
+.incbin "baserom.gba", 0xEC54D4, 0x60
+sTeddiursaSprites42:
+ax_sprite 0, 0x100
+ax_sprite sTeddiursaGfx42, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx43:
+.incbin "baserom.gba", 0xEC5564, 0xA0
+sTeddiursaSprites43:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx43, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx44:
+.incbin "baserom.gba", 0xEC5624, 0xC0
+sTeddiursaGfx44_1:
+.incbin "baserom.gba", 0xEC56E4, 0x60
+sTeddiursaSprites44:
+ax_sprite 0, 0xa0
+ax_sprite sTeddiursaGfx44, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx45:
+.incbin "baserom.gba", 0xEC5774, 0x40
+sTeddiursaGfx45_1:
+.incbin "baserom.gba", 0xEC57B4, 0x60
+sTeddiursaGfx45_2:
+.incbin "baserom.gba", 0xEC5814, 0x60
+sTeddiursaGfx45_3:
+.incbin "baserom.gba", 0xEC5874, 0x40
+sTeddiursaSprites45:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx45_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx45_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx46:
+.incbin "baserom.gba", 0xEC5904, 0x40
+sTeddiursaGfx46_1:
+.incbin "baserom.gba", 0xEC5944, 0x40
+sTeddiursaGfx46_2:
+.incbin "baserom.gba", 0xEC5984, 0x40
+sTeddiursaGfx46_3:
+.incbin "baserom.gba", 0xEC59C4, 0x40
+sTeddiursaSprites46:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx46_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx46_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx46_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx47:
+.incbin "baserom.gba", 0xEC5A54, 0x60
+sTeddiursaGfx47_1:
+.incbin "baserom.gba", 0xEC5AB4, 0x40
+sTeddiursaGfx47_2:
+.incbin "baserom.gba", 0xEC5AF4, 0x40
+sTeddiursaSprites47:
+ax_sprite 0, 0x80
+ax_sprite sTeddiursaGfx47, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx47_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx47_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx48:
+.incbin "baserom.gba", 0xEC5B74, 0x20
+sTeddiursaGfx48_1:
+.incbin "baserom.gba", 0xEC5B94, 0x40
+sTeddiursaGfx48_2:
+.incbin "baserom.gba", 0xEC5BD4, 0x40
+sTeddiursaGfx48_3:
+.incbin "baserom.gba", 0xEC5C14, 0x40
+sTeddiursaSprites48:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx48, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTeddiursaGfx48_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx48_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx48_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx49:
+.incbin "baserom.gba", 0xEC5CA4, 0x40
+sTeddiursaGfx49_1:
+.incbin "baserom.gba", 0xEC5CE4, 0x40
+sTeddiursaGfx49_2:
+.incbin "baserom.gba", 0xEC5D24, 0x40
+sTeddiursaGfx49_3:
+.incbin "baserom.gba", 0xEC5D64, 0x40
+sTeddiursaSprites49:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx49, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx49_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx49_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx49_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx50:
+.incbin "baserom.gba", 0xEC5DF4, 0x20
+sTeddiursaGfx50_1:
+.incbin "baserom.gba", 0xEC5E14, 0x40
+sTeddiursaGfx50_2:
+.incbin "baserom.gba", 0xEC5E54, 0x40
+sTeddiursaGfx50_3:
+.incbin "baserom.gba", 0xEC5E94, 0x40
+sTeddiursaSprites50:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx50, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx50_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx50_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx50_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx51:
+.incbin "baserom.gba", 0xEC5F24, 0x60
+sTeddiursaGfx51_1:
+.incbin "baserom.gba", 0xEC5F84, 0x40
+sTeddiursaGfx51_2:
+.incbin "baserom.gba", 0xEC5FC4, 0x40
+sTeddiursaSprites51:
+ax_sprite 0, 0x80
+ax_sprite sTeddiursaGfx51, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx51_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx51_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx52:
+.incbin "baserom.gba", 0xEC6044, 0x40
+sTeddiursaGfx52_1:
+.incbin "baserom.gba", 0xEC6084, 0x40
+sTeddiursaGfx52_2:
+.incbin "baserom.gba", 0xEC60C4, 0x40
+sTeddiursaGfx52_3:
+.incbin "baserom.gba", 0xEC6104, 0x40
+sTeddiursaSprites52:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx52, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx52_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx52_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx52_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx53:
+.incbin "baserom.gba", 0xEC6194, 0x20
+sTeddiursaGfx53_1:
+.incbin "baserom.gba", 0xEC61B4, 0x40
+sTeddiursaGfx53_2:
+.incbin "baserom.gba", 0xEC61F4, 0x40
+sTeddiursaGfx53_3:
+.incbin "baserom.gba", 0xEC6234, 0x40
+sTeddiursaSprites53:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx53, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx53_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx53_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx53_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx54:
+.incbin "baserom.gba", 0xEC62C4, 0x80
+sTeddiursaGfx54_1:
+.incbin "baserom.gba", 0xEC6344, 0x40
+sTeddiursaGfx54_2:
+.incbin "baserom.gba", 0xEC6384, 0x40
+sTeddiursaSprites54:
+ax_sprite 0, 0x80
+ax_sprite sTeddiursaGfx54, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx54_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx54_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx55:
+.incbin "baserom.gba", 0xEC6404, 0x20
+sTeddiursaGfx55_1:
+.incbin "baserom.gba", 0xEC6424, 0x60
+sTeddiursaGfx55_2:
+.incbin "baserom.gba", 0xEC6484, 0x40
+sTeddiursaGfx55_3:
+.incbin "baserom.gba", 0xEC64C4, 0x40
+sTeddiursaSprites55:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx55, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx55_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx55_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx55_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx56:
+.incbin "baserom.gba", 0xEC6554, 0x40
+sTeddiursaGfx56_1:
+.incbin "baserom.gba", 0xEC6594, 0x40
+sTeddiursaGfx56_2:
+.incbin "baserom.gba", 0xEC65D4, 0x40
+sTeddiursaGfx56_3:
+.incbin "baserom.gba", 0xEC6614, 0x40
+sTeddiursaSprites56:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx56, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx56_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx56_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx56_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx57:
+.incbin "baserom.gba", 0xEC66A4, 0x20
+sTeddiursaGfx57_1:
+.incbin "baserom.gba", 0xEC66C4, 0x60
+sTeddiursaGfx57_2:
+.incbin "baserom.gba", 0xEC6724, 0x40
+sTeddiursaGfx57_3:
+.incbin "baserom.gba", 0xEC6764, 0x40
+sTeddiursaSprites57:
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx57, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx57_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx57_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx57_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx58:
+.incbin "baserom.gba", 0xEC67F4, 0x80
+sTeddiursaGfx58_1:
+.incbin "baserom.gba", 0xEC6874, 0x40
+sTeddiursaGfx58_2:
+.incbin "baserom.gba", 0xEC68B4, 0x40
+sTeddiursaSprites58:
+ax_sprite 0, 0x80
+ax_sprite sTeddiursaGfx58, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx58_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx58_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx59:
+.incbin "baserom.gba", 0xEC6934, 0x40
+sTeddiursaGfx59_1:
+.incbin "baserom.gba", 0xEC6974, 0x40
+sTeddiursaGfx59_2:
+.incbin "baserom.gba", 0xEC69B4, 0x40
+sTeddiursaGfx59_3:
+.incbin "baserom.gba", 0xEC69F4, 0x40
+sTeddiursaSprites59:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx59, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx59_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx59_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx59_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx60:
+.incbin "baserom.gba", 0xEC6A84, 0x20
+sTeddiursaGfx60_1:
+.incbin "baserom.gba", 0xEC6AA4, 0x60
+sTeddiursaGfx60_2:
+.incbin "baserom.gba", 0xEC6B04, 0x40
+sTeddiursaGfx60_3:
+.incbin "baserom.gba", 0xEC6B44, 0x40
+sTeddiursaSprites60:
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx60, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTeddiursaGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTeddiursaGfx60_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTeddiursaGfx60_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTeddiursaGfx61:
+.incbin "baserom.gba", 0xEC6BD4, 0x200
+sTeddiursaSprites61:
+ax_sprite sTeddiursaGfx61, 0x200
+ax_sprite_terminator
+sTeddiursaGfx62:
+.incbin "baserom.gba", 0xEC6DE4, 0x200
+sTeddiursaSprites62:
+ax_sprite sTeddiursaGfx62, 0x200
+ax_sprite_terminator
+sTeddiursaGfx63:
+.incbin "baserom.gba", 0xEC6FF4, 0x200
+sTeddiursaSprites63:
+ax_sprite sTeddiursaGfx63, 0x200
+ax_sprite_terminator
+sTeddiursaGfx64:
+.incbin "baserom.gba", 0xEC7204, 0x200
+sTeddiursaSprites64:
+ax_sprite sTeddiursaGfx64, 0x200
+ax_sprite_terminator
+sTeddiursaGfx65:
+.incbin "baserom.gba", 0xEC7414, 0x200
+sTeddiursaSprites65:
+ax_sprite sTeddiursaGfx65, 0x200
+ax_sprite_terminator
+sTeddiursaGfx66:
+.incbin "baserom.gba", 0xEC7624, 0x200
+sTeddiursaSprites66:
+ax_sprite sTeddiursaGfx66, 0x200
+ax_sprite_terminator
+sTeddiursaGfx67:
+.incbin "baserom.gba", 0xEC7834, 0x200
+sTeddiursaSprites67:
+ax_sprite sTeddiursaGfx67, 0x200
+ax_sprite_terminator
+sTeddiursaGfx68:
+.incbin "baserom.gba", 0xEC7A44, 0x200
+sTeddiursaSprites68:
+ax_sprite sTeddiursaGfx68, 0x200
+ax_sprite_terminator
+sTeddiursaGfx69:
+.incbin "baserom.gba", 0xEC7C54, 0x200
+sTeddiursaSprites69:
+ax_sprite sTeddiursaGfx69, 0x200
+ax_sprite_terminator
+sAxPosesTeddiursa:
+.4byte sTeddiursaPose1
+.4byte sTeddiursaPose2
+.4byte sTeddiursaPose3
+.4byte sTeddiursaPose4
+.4byte sTeddiursaPose5
+.4byte sTeddiursaPose6
+.4byte sTeddiursaPose7
+.4byte sTeddiursaPose8
+.4byte sTeddiursaPose9
+.4byte sTeddiursaPose10
+.4byte sTeddiursaPose11
+.4byte sTeddiursaPose12
+.4byte sTeddiursaPose13
+.4byte sTeddiursaPose14
+.4byte sTeddiursaPose15
+.4byte sTeddiursaPose16
+.4byte sTeddiursaPose17
+.4byte sTeddiursaPose18
+.4byte sTeddiursaPose19
+.4byte sTeddiursaPose20
+.4byte sTeddiursaPose21
+.4byte sTeddiursaPose22
+.4byte sTeddiursaPose23
+.4byte sTeddiursaPose24
+.4byte sTeddiursaPose25
+.4byte sTeddiursaPose26
+.4byte sTeddiursaPose27
+.4byte sTeddiursaPose28
+.4byte sTeddiursaPose29
+.4byte sTeddiursaPose30
+.4byte sTeddiursaPose31
+.4byte sTeddiursaPose32
+.4byte sTeddiursaPose33
+.4byte sTeddiursaPose34
+.4byte sTeddiursaPose35
+.4byte sTeddiursaPose36
+.4byte sTeddiursaPose37
+.4byte sTeddiursaPose38
+.4byte sTeddiursaPose39
+.4byte sTeddiursaPose40
+.4byte sTeddiursaPose41
+.4byte sTeddiursaPose42
+.4byte sTeddiursaPose43
+.4byte sTeddiursaPose44
+.4byte sTeddiursaPose45
+.4byte sTeddiursaPose46
+.4byte sTeddiursaPose47
+.4byte sTeddiursaPose48
+.4byte sTeddiursaPose49
+.4byte sTeddiursaPose50
+.4byte sTeddiursaPose51
+.4byte sTeddiursaPose52
+.4byte sTeddiursaPose53
+.4byte sTeddiursaPose54
+.4byte sTeddiursaPose55
+.4byte sTeddiursaPose56
+.4byte sTeddiursaPose57
+.4byte sTeddiursaPose58
+.4byte sTeddiursaPose59
+.4byte sTeddiursaPose60
+.4byte sTeddiursaPose61
+.4byte sTeddiursaPose62
+.4byte sTeddiursaPose63
+.4byte sTeddiursaPose64
+.4byte sTeddiursaPose65
+.4byte sTeddiursaPose66
+.4byte sTeddiursaPose67
+.4byte sTeddiursaPose68
+.4byte sTeddiursaPose69
+.4byte sTeddiursaPose70
+.4byte sTeddiursaPose71
+.4byte sTeddiursaPose72
+.4byte sTeddiursaPose73
+.4byte sTeddiursaPose74
+.4byte sTeddiursaPose75
+.4byte sTeddiursaPose76
+.4byte sTeddiursaPose77
+.4byte sTeddiursaPose78
+.4byte sTeddiursaPose79
+.4byte sTeddiursaPose80
+.4byte sTeddiursaPose81
+.4byte sTeddiursaPose82
+.4byte sTeddiursaPose83
+.4byte sTeddiursaPose84
+.4byte sTeddiursaPose85
+.4byte sTeddiursaPose86
+.4byte sTeddiursaPose87
+.4byte sTeddiursaPose88
+.4byte sTeddiursaPose89
+.4byte sTeddiursaPose90
+.4byte sTeddiursaPose91
+.4byte sTeddiursaPose92
+.4byte sTeddiursaPose93
+.4byte sTeddiursaPose94
+.4byte sTeddiursaPose95
+.4byte sTeddiursaPose96
+.4byte sTeddiursaPose97
+.4byte sTeddiursaPose98
+.4byte sTeddiursaPose99
+.4byte sTeddiursaPose100
+.4byte sTeddiursaPose101
+.4byte sTeddiursaPose102
+.4byte sTeddiursaPose103
+.4byte sTeddiursaPose104
+.4byte sTeddiursaPose105
+.4byte sTeddiursaPose106
+.4byte sTeddiursaPose107
+.4byte sTeddiursaPose108
+.4byte sTeddiursaPose109
+.4byte sTeddiursaPose110
+.4byte sTeddiursaPose111
+.4byte sTeddiursaPose112
+.4byte sTeddiursaPose113
+.4byte sTeddiursaPose114
+.4byte sTeddiursaPose115
+.4byte sTeddiursaPose116
+.4byte sTeddiursaPose117
+.4byte sTeddiursaPose118
+.4byte sTeddiursaPose119
+.4byte sTeddiursaPose120
+.4byte sTeddiursaPose121
+.4byte sTeddiursaPose122
+.4byte sTeddiursaPose123
+.4byte sTeddiursaPose124
+.4byte sTeddiursaPose125
+.4byte sTeddiursaPose126
+.4byte sTeddiursaPose127
+.4byte sTeddiursaPose128
+.4byte sTeddiursaPose129
+.4byte sTeddiursaPose130
+.4byte sTeddiursaPose131
+.4byte sTeddiursaPose132
+.4byte sTeddiursaPose133
+.4byte sTeddiursaPose134
+.4byte sTeddiursaPose135
+.4byte sTeddiursaPose136
+.4byte sTeddiursaPose137
+.4byte sTeddiursaPose138
+.4byte sTeddiursaPose139
+.4byte sTeddiursaPose140
+.4byte sTeddiursaPose141
+.4byte sTeddiursaPose142
+.4byte sTeddiursaPose143
+.4byte sTeddiursaPose144
+.4byte sTeddiursaPose145
+.4byte sTeddiursaPose146
+.4byte sTeddiursaPose147
+.4byte sTeddiursaPose148
+.4byte sTeddiursaPose149
+.4byte sTeddiursaPose150
+.4byte sTeddiursaPose151
+.4byte sTeddiursaPose152
+.4byte sTeddiursaPose153
+.4byte sTeddiursaPose154
+.4byte sTeddiursaPose155
+.4byte sTeddiursaPose156
+.4byte sTeddiursaPose157
+.4byte sTeddiursaPose158
+.4byte sTeddiursaPose159
+.4byte sTeddiursaPose160
+.4byte sTeddiursaPose161
+.4byte sTeddiursaPose162
+.4byte sTeddiursaPose163
+.4byte sTeddiursaPose164
+.4byte sTeddiursaPose165
+.4byte sTeddiursaPose166
+.4byte sTeddiursaPose167
+.4byte sTeddiursaPose168
+.4byte sTeddiursaPose169
+.4byte sTeddiursaPose170
+.4byte sTeddiursaPose171
+.4byte sTeddiursaPose172
+.4byte sTeddiursaPose173
+.4byte sTeddiursaPose174
+.4byte sTeddiursaPose175
+.4byte sTeddiursaPose176
+.4byte sTeddiursaPose177
+.4byte sTeddiursaPose178
+.4byte sTeddiursaPose179
+.4byte sTeddiursaPose180
+.4byte sTeddiursaPose181
+.4byte sTeddiursaPose182
+.4byte sTeddiursaPose183
+.4byte sTeddiursaPose184
+.4byte sTeddiursaPose185
+.4byte sTeddiursaPose186
+.4byte sTeddiursaPose187
+.4byte sTeddiursaPose188
+.4byte sTeddiursaPose189
+.4byte sTeddiursaPose190
+.4byte sTeddiursaPose191
+.4byte sTeddiursaPose192
+.4byte sTeddiursaPose193
+.4byte sTeddiursaPose194
+.4byte sTeddiursaPose195
+.4byte sTeddiursaPose196
+.4byte sTeddiursaPose197
+.4byte sTeddiursaPose198
+.4byte sTeddiursaPose199
+.4byte sTeddiursaPose200
+.4byte sTeddiursaPose201
+.4byte sTeddiursaPose202
+.4byte sTeddiursaPose203
+.4byte sTeddiursaPose204
+.4byte sTeddiursaPose205
+.4byte sTeddiursaPose206
+.4byte sTeddiursaPose207
+.4byte sTeddiursaPose208
+.4byte sTeddiursaPose209
+.4byte sTeddiursaPose210
+.4byte sTeddiursaPose211
+.4byte sTeddiursaPose212
+.4byte sTeddiursaPose213
+.4byte sTeddiursaPose214
+.4byte sTeddiursaPose215
+.4byte sTeddiursaPose216
+.4byte sTeddiursaPose217
+.4byte sTeddiursaPose218
+.4byte sTeddiursaPose219
+.4byte sTeddiursaPose220
+.4byte sTeddiursaPose221
+.4byte sTeddiursaPose222
+.4byte sTeddiursaPose223
+.4byte sTeddiursaPose224
+.4byte sTeddiursaPose225
+.4byte sTeddiursaPose226
+.4byte sTeddiursaPose227
+.4byte sTeddiursaPose228
+.4byte sTeddiursaPose229
+.4byte sTeddiursaPose230
+.4byte sTeddiursaPose231
+.4byte sTeddiursaPose232
+.4byte sTeddiursaPose233
+.4byte sTeddiursaPose234
+sAxPositionsTeddiursa:
+.2byte   -1,   -5, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte    0,   -4, 	  -6,   -1, 	   6,   -3, 	   0,   -3
+.2byte   -2,   -4, 	  -8,   -3, 	   4,   -1, 	  -1,   -3
+.2byte    4,   -6, 	  -6,   -1, 	   5,   -5, 	   0,   -5
+.2byte    2,   -5, 	  -3,    0, 	   0,   -5, 	  -1,   -4
+.2byte    5,   -5, 	  -7,   -2, 	   7,   -3, 	   0,   -4
+.2byte    4,   -7, 	   1,   -1, 	   1,   -4, 	   0,   -5
+.2byte    3,   -6, 	   2,   -2, 	  -4,   -4, 	  -2,   -5
+.2byte    5,   -6, 	  -2,   -1, 	   4,   -3, 	   0,   -5
+.2byte    0,   -8, 	   4,   -2, 	  -3,   -4, 	  -1,   -6
+.2byte    2,   -7, 	   5,   -3, 	  -6,   -4, 	  -1,   -4
+.2byte   -1,   -7, 	   3,    0, 	  -4,   -3, 	  -2,   -4
+.2byte   -1,   -8, 	   5,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte    0,   -7, 	   6,   -1, 	  -7,   -6, 	   0,   -4
+.2byte   -2,   -7, 	   5,   -6, 	  -8,   -1, 	  -2,   -4
+.2byte   -2,   -8, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte   -1,   -7, 	   1,   -6, 	  -5,    0, 	   1,   -5
+.2byte   -2,   -6, 	   4,   -3, 	  -7,   -2, 	   0,   -4
+.2byte   -5,   -6, 	  -3,   -5, 	  -3,   -1, 	   0,   -7
+.2byte   -6,   -5, 	  -7,   -6, 	   0,   -1, 	  -1,   -6
+.2byte   -4,   -5, 	  -1,   -6, 	  -4,   -2, 	   1,   -6
+.2byte   -4,   -5, 	  -7,   -5, 	   4,   -1, 	  -1,   -7
+.2byte   -5,   -4, 	  -9,   -3, 	   5,   -2, 	  -1,   -5
+.2byte   -3,   -4, 	  -4,   -6, 	   1,    0, 	  -1,   -5
+.2byte   -1,   -5, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte    0,   -4, 	  -6,   -1, 	   6,   -3, 	   0,   -3
+.2byte   -2,   -4, 	  -8,   -3, 	   4,   -1, 	  -1,   -3
+.2byte    2,   -6, 	  -1,   -3, 	   2,   -5, 	   0,   -6
+.2byte    4,   -6, 	  -6,   -1, 	   5,   -5, 	   0,   -5
+.2byte    2,   -5, 	  -3,    0, 	   0,   -5, 	  -1,   -4
+.2byte    5,   -5, 	  -7,   -2, 	   7,   -3, 	   0,   -4
+.2byte    0,   -6, 	  -6,   -6, 	   8,   -4, 	   0,   -5
+.2byte    4,   -7, 	   1,   -1, 	   1,   -4, 	   0,   -5
+.2byte    3,   -6, 	   2,   -2, 	  -4,   -4, 	  -2,   -5
+.2byte    5,   -6, 	  -2,   -1, 	   4,   -3, 	   0,   -5
+.2byte    3,   -6, 	  -6,   -3, 	  10,   -8, 	   1,   -6
+.2byte    0,   -8, 	   4,   -2, 	  -3,   -4, 	  -1,   -6
+.2byte    2,   -7, 	   5,   -3, 	  -6,   -4, 	  -1,   -4
+.2byte   -1,   -7, 	   3,    0, 	  -4,   -3, 	  -2,   -4
+.2byte    4,   -7, 	  -3,   -3, 	   8,   -9, 	   0,   -6
+.2byte   -1,   -8, 	   5,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte    0,   -7, 	   6,   -1, 	  -7,   -6, 	   0,   -4
+.2byte   -2,   -7, 	   5,   -6, 	  -8,   -1, 	  -2,   -4
+.2byte    1,   -9, 	   6,   -5, 	  -1,   -7, 	   0,   -6
+.2byte   -2,   -8, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte   -1,   -7, 	   1,   -6, 	  -5,    0, 	   1,   -5
+.2byte   -2,   -6, 	   4,   -3, 	  -7,   -2, 	   0,   -4
+.2byte   -1,   -9, 	   7,   -8, 	  -8,   -6, 	   1,   -6
+.2byte   -5,   -6, 	  -3,   -5, 	  -3,   -1, 	   0,   -7
+.2byte   -6,   -5, 	  -7,   -6, 	   0,   -1, 	  -1,   -6
+.2byte   -4,   -5, 	  -1,   -6, 	  -4,   -2, 	   1,   -6
+.2byte   -2,   -6, 	 -10,   -8, 	   5,   -3, 	   0,   -6
+.2byte   -4,   -5, 	  -7,   -5, 	   4,   -1, 	  -1,   -7
+.2byte   -5,   -4, 	  -9,   -3, 	   5,   -2, 	  -1,   -5
+.2byte   -3,   -4, 	  -4,   -6, 	   1,    0, 	  -1,   -5
+.2byte    0,   -6, 	  -8,   -4, 	   6,   -6, 	   1,   -6
+.2byte   -1,   -5, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte    0,   -4, 	  -6,   -1, 	   6,   -3, 	   0,   -3
+.2byte   -2,   -4, 	  -8,   -3, 	   4,   -1, 	  -1,   -3
+.2byte    2,   -5, 	  -1,   -2, 	   2,   -4, 	   0,   -5
+.2byte    2,   -5, 	  -1,   -2, 	   2,   -4, 	   0,   -5
+.2byte   -3,   -5, 	  -2,   -7, 	   0,   -2, 	   0,   -5
+.2byte   -3,   -5, 	  -2,   -7, 	   0,   -2, 	   0,   -5
+.2byte    4,   -6, 	  -6,   -1, 	   5,   -5, 	   0,   -5
+.2byte    2,   -5, 	  -3,    0, 	   0,   -5, 	  -1,   -4
+.2byte    5,   -5, 	  -7,   -2, 	   7,   -3, 	   0,   -4
+.2byte   -1,   -6, 	  -7,   -6, 	   7,   -4, 	  -1,   -5
+.2byte   -1,   -6, 	  -7,   -6, 	   7,   -4, 	  -1,   -5
+.2byte    4,   -6, 	   4,   -1, 	   4,   -4, 	  -1,   -5
+.2byte    4,   -6, 	   4,   -1, 	   4,   -4, 	  -1,   -5
+.2byte    4,   -7, 	   1,   -1, 	   1,   -4, 	   0,   -5
+.2byte    3,   -6, 	   2,   -2, 	  -4,   -4, 	  -2,   -5
+.2byte    5,   -6, 	  -2,   -1, 	   4,   -3, 	   0,   -5
+.2byte    3,   -6, 	  -6,   -3, 	  10,   -8, 	   1,   -6
+.2byte    3,   -6, 	  -6,   -3, 	  10,   -8, 	   1,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   6,   -5, 	  -2,   -6
+.2byte    0,   -8, 	  -5,   -5, 	   6,   -5, 	  -2,   -6
+.2byte    0,   -8, 	   4,   -2, 	  -3,   -4, 	  -1,   -6
+.2byte    2,   -8, 	   5,   -4, 	  -6,   -5, 	  -1,   -5
+.2byte   -1,   -8, 	   3,   -1, 	  -4,   -4, 	  -2,   -5
+.2byte    4,   -7, 	  -3,   -3, 	   8,   -9, 	   0,   -6
+.2byte    4,   -7, 	  -3,   -3, 	   8,   -9, 	   0,   -6
+.2byte    0,   -9, 	  -8,   -8, 	   7,   -6, 	  -2,   -6
+.2byte    0,   -9, 	  -8,   -8, 	   7,   -6, 	  -2,   -6
+.2byte   -1,   -8, 	   5,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte    0,   -7, 	   6,   -1, 	  -7,   -6, 	   0,   -4
+.2byte   -2,   -7, 	   5,   -6, 	  -8,   -1, 	  -2,   -4
+.2byte   -3,   -9, 	   1,   -7, 	  -8,   -5, 	  -2,   -5
+.2byte   -3,   -9, 	   1,   -7, 	  -8,   -5, 	  -2,   -5
+.2byte    2,   -8, 	   7,   -4, 	   0,   -6, 	   1,   -5
+.2byte    2,   -8, 	   7,   -4, 	   0,   -6, 	   1,   -5
+.2byte   -2,   -8, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte   -1,   -8, 	   1,   -7, 	  -5,   -1, 	   1,   -6
+.2byte   -1,   -8, 	   5,   -5, 	  -6,   -4, 	   1,   -6
+.2byte   -6,   -7, 	 -10,   -9, 	   1,   -3, 	  -1,   -6
+.2byte   -6,   -7, 	 -10,   -9, 	   1,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   7,   -9, 	  -8,   -7, 	   1,   -7
+.2byte   -1,  -10, 	   7,   -9, 	  -8,   -7, 	   1,   -7
+.2byte   -5,   -6, 	  -3,   -5, 	  -3,   -1, 	   0,   -7
+.2byte   -6,   -5, 	  -7,   -6, 	   0,   -1, 	  -1,   -6
+.2byte   -4,   -5, 	  -1,   -6, 	  -4,   -2, 	   1,   -6
+.2byte   -4,   -5, 	 -12,   -7, 	   3,   -2, 	  -2,   -5
+.2byte   -4,   -5, 	 -12,   -7, 	   3,   -2, 	  -2,   -5
+.2byte   -2,   -7, 	   3,   -4, 	  -8,   -4, 	   0,   -5
+.2byte   -2,   -7, 	   3,   -4, 	  -8,   -4, 	   0,   -5
+.2byte   -4,   -5, 	  -7,   -5, 	   4,   -1, 	  -1,   -7
+.2byte   -5,   -4, 	  -9,   -3, 	   5,   -2, 	  -1,   -5
+.2byte   -3,   -4, 	  -4,   -6, 	   1,    0, 	  -1,   -5
+.2byte   -1,   -6, 	  -9,   -4, 	   5,   -6, 	   0,   -6
+.2byte   -1,   -6, 	  -9,   -4, 	   5,   -6, 	   0,   -6
+.2byte   -6,   -6, 	  -7,   -4, 	  -5,   -1, 	  -1,   -4
+.2byte   -6,   -6, 	  -7,   -4, 	  -5,   -1, 	  -1,   -4
+.2byte   -1,   -5, 	  -2,   -4, 	   4,   -2, 	  -1,   -6
+.2byte   -4,   -5, 	  -6,   -6, 	   2,   -1, 	  -1,   -5
+.2byte   -6,   -7, 	  -7,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte   -3,   -8, 	  -1,   -8, 	  -5,   -2, 	   0,   -5
+.2byte   -1,   -8, 	  -1,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte    1,   -8, 	  -1,   -8, 	   3,   -2, 	  -2,   -5
+.2byte    4,   -7, 	   0,   -1, 	   5,   -6, 	   0,   -5
+.2byte    3,   -5, 	  -4,   -1, 	   4,   -6, 	   0,   -5
+.2byte   -1,   -5, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -5, 	  -2,   -4, 	   4,   -2, 	  -1,   -6
+.2byte   -1,   -5, 	  -2,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    4,   -6, 	  -6,   -1, 	   5,   -5, 	   0,   -5
+.2byte    3,   -5, 	  -4,   -1, 	   4,   -6, 	   0,   -4
+.2byte    3,   -5, 	  -4,   -1, 	   4,   -6, 	   0,   -5
+.2byte    4,   -7, 	   1,   -1, 	   1,   -4, 	   0,   -5
+.2byte    4,   -7, 	   0,   -1, 	   5,   -6, 	   0,   -5
+.2byte    4,   -7, 	   0,   -1, 	   5,   -6, 	   0,   -5
+.2byte    0,   -8, 	   4,   -2, 	  -3,   -4, 	  -1,   -6
+.2byte    0,   -8, 	  -1,   -8, 	   3,   -2, 	  -2,   -5
+.2byte    1,   -8, 	  -1,   -8, 	   3,   -2, 	  -2,   -5
+.2byte   -1,   -8, 	   5,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,   -8, 	   0,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -1,   -8, 	  -1,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -2,   -8, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte   -2,   -8, 	  -1,   -8, 	  -5,   -2, 	   0,   -5
+.2byte   -3,   -8, 	  -1,   -8, 	  -5,   -2, 	   0,   -5
+.2byte   -5,   -6, 	  -3,   -5, 	  -3,   -1, 	   0,   -7
+.2byte   -6,   -7, 	  -7,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte   -6,   -7, 	  -7,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte   -4,   -5, 	  -7,   -5, 	   4,   -1, 	  -1,   -7
+.2byte   -4,   -5, 	  -6,   -6, 	   2,   -1, 	  -1,   -5
+.2byte   -4,   -5, 	  -6,   -6, 	   2,   -1, 	  -1,   -5
+.2byte   -4,   -4, 	  -8,   -3, 	   4,    0, 	   0,   -4
+.2byte   -3,   -3, 	  -8,   -3, 	   4,    0, 	  -1,   -4
+.2byte   -1,   -5, 	  -8,   -3, 	   6,   -3, 	  -1,   -4
+.2byte    3,   -7, 	  -3,    0, 	   5,   -6, 	  -1,   -4
+.2byte    5,   -8, 	   2,   -2, 	   3,   -7, 	   0,   -5
+.2byte   -1,   -8, 	  -2,   -8, 	   6,   -3, 	  -2,   -7
+.2byte   -1,   -8, 	   6,   -3, 	  -8,   -3, 	  -1,   -4
+.2byte    0,   -8, 	   1,   -8, 	  -7,   -3, 	   1,   -7
+.2byte   -4,   -7, 	  -3,   -7, 	  -2,   -2, 	   0,   -5
+.2byte   -3,   -7, 	  -6,   -7, 	   2,   -1, 	   0,   -6
+.2byte   -1,   -5, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -5, 	  -2,   -4, 	   4,   -2, 	  -1,   -6
+.2byte   -1,   -5, 	  -2,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    4,   -6, 	  -6,   -1, 	   5,   -5, 	   0,   -5
+.2byte    3,   -5, 	  -4,   -1, 	   4,   -6, 	   0,   -4
+.2byte    3,   -5, 	  -4,   -1, 	   4,   -6, 	   0,   -5
+.2byte    4,   -7, 	   1,   -1, 	   1,   -4, 	   0,   -5
+.2byte    4,   -7, 	   0,   -1, 	   5,   -6, 	   0,   -5
+.2byte    4,   -7, 	   0,   -1, 	   5,   -6, 	   0,   -5
+.2byte    0,   -8, 	   4,   -2, 	  -3,   -4, 	  -1,   -6
+.2byte    0,   -8, 	  -1,   -8, 	   3,   -2, 	  -2,   -5
+.2byte    1,   -8, 	  -1,   -8, 	   3,   -2, 	  -2,   -5
+.2byte   -1,   -8, 	   5,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,   -8, 	   0,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -1,   -8, 	  -1,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -2,   -8, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte   -2,   -8, 	  -1,   -8, 	  -5,   -2, 	   0,   -5
+.2byte   -3,   -8, 	  -1,   -8, 	  -5,   -2, 	   0,   -5
+.2byte   -5,   -6, 	  -3,   -5, 	  -3,   -1, 	   0,   -7
+.2byte   -6,   -7, 	  -7,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte   -6,   -7, 	  -7,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte   -4,   -5, 	  -7,   -5, 	   4,   -1, 	  -1,   -7
+.2byte   -4,   -5, 	  -6,   -6, 	   2,   -1, 	  -1,   -5
+.2byte   -4,   -5, 	  -6,   -6, 	   2,   -1, 	  -1,   -5
+.2byte    0,   -6, 	  -6,   -3, 	   6,   -5, 	   0,   -5
+.2byte   -3,   -5, 	  -7,   -4, 	   7,   -3, 	   1,   -6
+.2byte   -4,   -6, 	  -5,   -7, 	   2,   -2, 	   1,   -7
+.2byte   -2,   -8, 	   0,   -7, 	  -6,   -1, 	   0,   -6
+.2byte    0,   -8, 	   6,   -2, 	  -7,   -7, 	   0,   -5
+.2byte    3,   -8, 	   6,   -4, 	  -5,   -5, 	   0,   -5
+.2byte    4,   -7, 	   3,   -3, 	  -3,   -5, 	  -1,   -6
+.2byte    2,   -6, 	  -3,   -1, 	   0,   -6, 	  -1,   -5
+.2byte   -1,   -5, 	  -2,   -4, 	   4,   -2, 	  -1,   -6
+.2byte    3,   -5, 	  -4,   -1, 	   4,   -6, 	   0,   -4
+.2byte    4,   -7, 	   0,   -1, 	   5,   -6, 	   0,   -5
+.2byte    0,   -8, 	  -1,   -8, 	   3,   -2, 	  -2,   -5
+.2byte   -1,   -8, 	   0,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte   -2,   -8, 	  -1,   -8, 	  -5,   -2, 	   0,   -5
+.2byte   -6,   -7, 	  -7,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte   -4,   -5, 	  -6,   -6, 	   2,   -1, 	  -1,   -5
+.2byte   -1,   -5, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -1,   -4, 	  -7,   -1, 	   5,   -3, 	  -1,   -3
+.2byte   -1,   -4, 	  -7,   -3, 	   5,   -1, 	   0,   -3
+.2byte    4,   -6, 	  -6,   -1, 	   5,   -5, 	   0,   -5
+.2byte    3,   -5, 	  -2,    0, 	   1,   -5, 	   0,   -4
+.2byte    4,   -5, 	  -8,   -2, 	   6,   -3, 	  -1,   -4
+.2byte    4,   -7, 	   1,   -1, 	   1,   -4, 	   0,   -5
+.2byte    4,   -6, 	   3,   -2, 	  -3,   -4, 	  -1,   -5
+.2byte    4,   -6, 	  -3,   -1, 	   3,   -3, 	  -1,   -5
+.2byte    0,   -8, 	   4,   -2, 	  -3,   -4, 	  -1,   -6
+.2byte    0,   -8, 	   4,   -1, 	  -3,   -4, 	  -1,   -5
+.2byte    1,   -8, 	   4,   -4, 	  -7,   -5, 	  -2,   -5
+.2byte   -1,   -8, 	   5,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	   5,   -1, 	  -8,   -6, 	  -1,   -4
+.2byte   -1,   -7, 	   6,   -6, 	  -7,   -1, 	  -1,   -4
+.2byte   -2,   -8, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte   -2,   -8, 	   0,   -7, 	  -6,   -1, 	   0,   -6
+.2byte   -1,   -7, 	   5,   -4, 	  -6,   -3, 	   1,   -5
+.2byte   -5,   -6, 	  -3,   -5, 	  -3,   -1, 	   0,   -7
+.2byte   -5,   -5, 	  -2,   -6, 	  -5,   -2, 	   0,   -6
+.2byte   -5,   -5, 	  -6,   -6, 	   1,   -1, 	   0,   -6
+.2byte   -4,   -5, 	  -7,   -5, 	   4,   -1, 	  -1,   -7
+.2byte   -4,   -4, 	  -5,   -6, 	   0,    0, 	  -2,   -5
+.2byte   -4,   -4, 	  -8,   -3, 	   6,   -2, 	   0,   -5
+.2byte   -1,   -5, 	  -2,   -4, 	   4,   -2, 	  -1,   -6
+.2byte   -4,   -5, 	  -6,   -6, 	   2,   -1, 	  -1,   -5
+.2byte   -6,   -7, 	  -7,   -6, 	  -2,   -1, 	  -1,   -5
+.2byte   -3,   -8, 	  -1,   -8, 	  -5,   -2, 	   0,   -5
+.2byte   -1,   -8, 	  -1,   -6, 	  -6,   -3, 	  -1,   -5
+.2byte    1,   -8, 	  -1,   -8, 	   3,   -2, 	  -2,   -5
+.2byte    4,   -7, 	   0,   -1, 	   5,   -6, 	   0,   -5
+.2byte    3,   -5, 	  -4,   -1, 	   4,   -6, 	   0,   -5
+.2byte   -1,   -5, 	  -7,   -2, 	   5,   -2, 	  -1,   -4
+.2byte   -4,   -5, 	  -7,   -5, 	   4,   -1, 	  -1,   -7
+.2byte   -5,   -6, 	  -3,   -5, 	  -3,   -1, 	   0,   -7
+.2byte   -2,   -8, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte   -1,   -8, 	   5,   -3, 	  -7,   -3, 	  -1,   -5
+.2byte    0,   -8, 	   4,   -2, 	  -3,   -4, 	  -1,   -6
+.2byte    4,   -7, 	   1,   -1, 	   1,   -4, 	   0,   -5
+.2byte    4,   -6, 	  -6,   -1, 	   5,   -5, 	   0,   -5
+sTeddiursaAnimTable1:
+.4byte sTeddiursaAnims_1_1
+.4byte sTeddiursaAnims_1_2
+.4byte sTeddiursaAnims_1_3
+.4byte sTeddiursaAnims_1_4
+.4byte sTeddiursaAnims_1_5
+.4byte sTeddiursaAnims_1_6
+.4byte sTeddiursaAnims_1_7
+.4byte sTeddiursaAnims_1_8
+sTeddiursaAnimTable2:
+.4byte sTeddiursaAnims_2_1
+.4byte sTeddiursaAnims_2_2
+.4byte sTeddiursaAnims_2_3
+.4byte sTeddiursaAnims_2_4
+.4byte sTeddiursaAnims_2_5
+.4byte sTeddiursaAnims_2_6
+.4byte sTeddiursaAnims_2_7
+.4byte sTeddiursaAnims_2_8
+sTeddiursaAnimTable3:
+.4byte sTeddiursaAnims_3_1
+.4byte sTeddiursaAnims_3_2
+.4byte sTeddiursaAnims_3_3
+.4byte sTeddiursaAnims_3_4
+.4byte sTeddiursaAnims_3_5
+.4byte sTeddiursaAnims_3_6
+.4byte sTeddiursaAnims_3_7
+.4byte sTeddiursaAnims_3_8
+sTeddiursaAnimTable4:
+.4byte sTeddiursaAnims_4_1
+.4byte sTeddiursaAnims_4_2
+.4byte sTeddiursaAnims_4_3
+.4byte sTeddiursaAnims_4_4
+.4byte sTeddiursaAnims_4_5
+.4byte sTeddiursaAnims_4_6
+.4byte sTeddiursaAnims_4_7
+.4byte sTeddiursaAnims_4_8
+sTeddiursaAnimTable5:
+.4byte sTeddiursaAnims_5_1
+.4byte sTeddiursaAnims_5_2
+.4byte sTeddiursaAnims_5_3
+.4byte sTeddiursaAnims_5_4
+.4byte sTeddiursaAnims_5_5
+.4byte sTeddiursaAnims_5_6
+.4byte sTeddiursaAnims_5_7
+.4byte sTeddiursaAnims_5_8
+sTeddiursaAnimTable6:
+.4byte sTeddiursaAnims_6_1
+.4byte sTeddiursaAnims_6_1
+.4byte sTeddiursaAnims_6_1
+.4byte sTeddiursaAnims_6_1
+.4byte sTeddiursaAnims_6_1
+.4byte sTeddiursaAnims_6_1
+.4byte sTeddiursaAnims_6_1
+.4byte sTeddiursaAnims_6_1
+sTeddiursaAnimTable7:
+.4byte sTeddiursaAnims_7_1
+.4byte sTeddiursaAnims_7_2
+.4byte sTeddiursaAnims_7_3
+.4byte sTeddiursaAnims_7_4
+.4byte sTeddiursaAnims_7_5
+.4byte sTeddiursaAnims_7_6
+.4byte sTeddiursaAnims_7_7
+.4byte sTeddiursaAnims_7_8
+sTeddiursaAnimTable8:
+.4byte sTeddiursaAnims_8_1
+.4byte sTeddiursaAnims_8_2
+.4byte sTeddiursaAnims_8_3
+.4byte sTeddiursaAnims_8_4
+.4byte sTeddiursaAnims_8_5
+.4byte sTeddiursaAnims_8_6
+.4byte sTeddiursaAnims_8_7
+.4byte sTeddiursaAnims_8_8
+sTeddiursaAnimTable9:
+.4byte sTeddiursaAnims_9_1
+.4byte sTeddiursaAnims_9_2
+.4byte sTeddiursaAnims_9_3
+.4byte sTeddiursaAnims_9_4
+.4byte sTeddiursaAnims_9_5
+.4byte sTeddiursaAnims_9_6
+.4byte sTeddiursaAnims_9_7
+.4byte sTeddiursaAnims_9_8
+sTeddiursaAnimTable10:
+.4byte sTeddiursaAnims_10_1
+.4byte sTeddiursaAnims_10_2
+.4byte sTeddiursaAnims_10_3
+.4byte sTeddiursaAnims_10_4
+.4byte sTeddiursaAnims_10_5
+.4byte sTeddiursaAnims_10_6
+.4byte sTeddiursaAnims_10_7
+.4byte sTeddiursaAnims_10_8
+sTeddiursaAnimTable11:
+.4byte sTeddiursaAnims_11_1
+.4byte sTeddiursaAnims_11_2
+.4byte sTeddiursaAnims_11_3
+.4byte sTeddiursaAnims_11_4
+.4byte sTeddiursaAnims_11_5
+.4byte sTeddiursaAnims_11_6
+.4byte sTeddiursaAnims_11_7
+.4byte sTeddiursaAnims_11_8
+sTeddiursaAnimTable12:
+.4byte sTeddiursaAnims_12_1
+.4byte sTeddiursaAnims_12_2
+.4byte sTeddiursaAnims_12_3
+.4byte sTeddiursaAnims_12_4
+.4byte sTeddiursaAnims_12_5
+.4byte sTeddiursaAnims_12_6
+.4byte sTeddiursaAnims_12_7
+.4byte sTeddiursaAnims_12_8
+sTeddiursaAnimTable13:
+.4byte sTeddiursaAnims_13_1
+.4byte sTeddiursaAnims_13_2
+.4byte sTeddiursaAnims_13_3
+.4byte sTeddiursaAnims_13_4
+.4byte sTeddiursaAnims_13_5
+.4byte sTeddiursaAnims_13_6
+.4byte sTeddiursaAnims_13_7
+.4byte sTeddiursaAnims_13_8
+sAxAnimationsTeddiursa:
+.4byte sTeddiursaAnimTable1
+.4byte sTeddiursaAnimTable2
+.4byte sTeddiursaAnimTable3
+.4byte sTeddiursaAnimTable4
+.4byte sTeddiursaAnimTable5
+.4byte sTeddiursaAnimTable6
+.4byte sTeddiursaAnimTable7
+.4byte sTeddiursaAnimTable8
+.4byte sTeddiursaAnimTable9
+.4byte sTeddiursaAnimTable10
+.4byte sTeddiursaAnimTable11
+.4byte sTeddiursaAnimTable12
+.4byte sTeddiursaAnimTable13
+sAxSpritesTeddiursa:
+.4byte sTeddiursaSprites1
+.4byte sTeddiursaSprites2
+.4byte sTeddiursaSprites3
+.4byte sTeddiursaSprites4
+.4byte sTeddiursaSprites5
+.4byte sTeddiursaSprites6
+.4byte sTeddiursaSprites7
+.4byte sTeddiursaSprites8
+.4byte sTeddiursaSprites9
+.4byte sTeddiursaSprites10
+.4byte sTeddiursaSprites11
+.4byte sTeddiursaSprites12
+.4byte sTeddiursaSprites13
+.4byte sTeddiursaSprites14
+.4byte sTeddiursaSprites15
+.4byte sTeddiursaSprites16
+.4byte sTeddiursaSprites17
+.4byte sTeddiursaSprites18
+.4byte sTeddiursaSprites19
+.4byte sTeddiursaSprites20
+.4byte sTeddiursaSprites21
+.4byte sTeddiursaSprites22
+.4byte sTeddiursaSprites23
+.4byte sTeddiursaSprites24
+.4byte sTeddiursaSprites25
+.4byte sTeddiursaSprites26
+.4byte sTeddiursaSprites27
+.4byte sTeddiursaSprites28
+.4byte sTeddiursaSprites29
+.4byte sTeddiursaSprites30
+.4byte sTeddiursaSprites31
+.4byte sTeddiursaSprites32
+.4byte sTeddiursaSprites33
+.4byte sTeddiursaSprites34
+.4byte sTeddiursaSprites35
+.4byte sTeddiursaSprites36
+.4byte sTeddiursaSprites37
+.4byte sTeddiursaSprites38
+.4byte sTeddiursaSprites39
+.4byte sTeddiursaSprites40
+.4byte sTeddiursaSprites41
+.4byte sTeddiursaSprites42
+.4byte sTeddiursaSprites43
+.4byte sTeddiursaSprites44
+.4byte sTeddiursaSprites45
+.4byte sTeddiursaSprites46
+.4byte sTeddiursaSprites47
+.4byte sTeddiursaSprites48
+.4byte sTeddiursaSprites49
+.4byte sTeddiursaSprites50
+.4byte sTeddiursaSprites51
+.4byte sTeddiursaSprites52
+.4byte sTeddiursaSprites53
+.4byte sTeddiursaSprites54
+.4byte sTeddiursaSprites55
+.4byte sTeddiursaSprites56
+.4byte sTeddiursaSprites57
+.4byte sTeddiursaSprites58
+.4byte sTeddiursaSprites59
+.4byte sTeddiursaSprites60
+.4byte sTeddiursaSprites61
+.4byte sTeddiursaSprites62
+.4byte sTeddiursaSprites63
+.4byte sTeddiursaSprites64
+.4byte sTeddiursaSprites65
+.4byte sTeddiursaSprites66
+.4byte sTeddiursaSprites67
+.4byte sTeddiursaSprites68
+.4byte sTeddiursaSprites69
+sAxMainTeddiursa:
+ax_main sAxPosesTeddiursa, sAxAnimationsTeddiursa, 13, sAxSpritesTeddiursa, sAxPositionsTeddiursa

--- a/data/ax/tentacool.inc
+++ b/data/ax/tentacool.inc
@@ -1,0 +1,2932 @@
+.global gAxTentacool
+gAxTentacool:
+ax_siro sAxMainTentacool
+sTentacoolPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose4:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose5:
+ax_pose 4, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose6:
+ax_pose 5, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose7:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose8:
+ax_pose 7, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose9:
+ax_pose 8, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose10:
+ax_pose 9, 0x81e6, 0x90f8, 0x1c00
+ax_pose_terminator
+sTentacoolPose11:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose12:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose16:
+ax_pose 9, 0x81e6, 0x80f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose18:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose21:
+ax_pose 8, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose23:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose24:
+ax_pose 5, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose28:
+ax_pose 15, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose29:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose30:
+ax_pose 4, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose31:
+ax_pose 5, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose32:
+ax_pose 16, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose33:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose34:
+ax_pose 7, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose35:
+ax_pose 8, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose36:
+ax_pose 17, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose37:
+ax_pose 9, 0x81e6, 0x90f8, 0x1c00
+ax_pose_terminator
+sTentacoolPose38:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose39:
+ax_pose 11, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose40:
+ax_pose 18, 0x01e5, 0x90f0, 0x1c00
+ax_pose_terminator
+sTentacoolPose41:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose42:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose43:
+ax_pose 14, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose44:
+ax_pose 19, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose45:
+ax_pose 9, 0x81e6, 0x80f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose46:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose47:
+ax_pose 11, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose48:
+ax_pose 18, 0x01e5, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacoolPose49:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose50:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose51:
+ax_pose 8, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose52:
+ax_pose 17, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sTentacoolPose53:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose54:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose55:
+ax_pose 5, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose56:
+ax_pose 16, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose57:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose58:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose59:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose60:
+ax_pose 20, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose61:
+ax_pose 21, 0x01ea, 0x80f2, 0x1c00
+ax_pose 22, 0x01ea, 0x80f4, 0x1c10
+ax_pose_terminator
+sTentacoolPose62:
+ax_pose 22, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose63:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose64:
+ax_pose 4, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose65:
+ax_pose 5, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose66:
+ax_pose 23, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose67:
+ax_pose 24, 0x01ea, 0x90f1, 0x1c00
+ax_pose 25, 0x01eb, 0x90ed, 0x1c10
+ax_pose_terminator
+sTentacoolPose68:
+ax_pose 25, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose69:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose70:
+ax_pose 7, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose71:
+ax_pose 8, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose72:
+ax_pose 26, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose73:
+ax_pose 27, 0x01e5, 0x90f4, 0x1c00
+ax_pose 28, 0x01e5, 0x90ed, 0x1c10
+ax_pose_terminator
+sTentacoolPose74:
+ax_pose 28, 0x01e5, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose75:
+ax_pose 9, 0x81e6, 0x90f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose76:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose77:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose78:
+ax_pose 29, 0x01e5, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacoolPose79:
+ax_pose 30, 0x01e5, 0x90f4, 0x1c00
+ax_pose 31, 0x01e5, 0x90ee, 0x1c10
+ax_pose_terminator
+sTentacoolPose80:
+ax_pose 31, 0x01e5, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacoolPose81:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose82:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose83:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose84:
+ax_pose 32, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose85:
+ax_pose 33, 0x01e6, 0x80f2, 0x1c00
+ax_pose 34, 0x01ea, 0x80f4, 0x1c10
+ax_pose_terminator
+sTentacoolPose86:
+ax_pose 34, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose87:
+ax_pose 9, 0x81e6, 0x80fa, 0x1c00
+ax_pose_terminator
+sTentacoolPose88:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose89:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose90:
+ax_pose 29, 0x01e5, 0x80f5, 0x1c00
+ax_pose_terminator
+sTentacoolPose91:
+ax_pose 30, 0x01e5, 0x80ef, 0x1c00
+ax_pose 31, 0x01e5, 0x80f5, 0x1c10
+ax_pose_terminator
+sTentacoolPose92:
+ax_pose 31, 0x01e5, 0x80f5, 0x1c00
+ax_pose_terminator
+sTentacoolPose93:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose94:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose95:
+ax_pose 8, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose96:
+ax_pose 26, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose97:
+ax_pose 27, 0x01e5, 0x80ed, 0x1c00
+ax_pose 28, 0x01e5, 0x80f4, 0x1c10
+ax_pose_terminator
+sTentacoolPose98:
+ax_pose 28, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose99:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose100:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose101:
+ax_pose 5, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose102:
+ax_pose 23, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose103:
+ax_pose 24, 0x01ea, 0x80f0, 0x1c00
+ax_pose 25, 0x01eb, 0x80f4, 0x1c10
+ax_pose_terminator
+sTentacoolPose104:
+ax_pose 25, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose105:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose106:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose107:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose108:
+ax_pose 20, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose109:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose110:
+ax_pose 4, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose111:
+ax_pose 5, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose112:
+ax_pose 23, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose113:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose114:
+ax_pose 7, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose115:
+ax_pose 8, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose116:
+ax_pose 26, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose117:
+ax_pose 9, 0x81e6, 0x90f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose118:
+ax_pose 10, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose119:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose120:
+ax_pose 29, 0x01e5, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacoolPose121:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose122:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose123:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose124:
+ax_pose 32, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose125:
+ax_pose 9, 0x81e6, 0x80fa, 0x1c00
+ax_pose_terminator
+sTentacoolPose126:
+ax_pose 10, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose127:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose128:
+ax_pose 29, 0x01e5, 0x80f5, 0x1c00
+ax_pose_terminator
+sTentacoolPose129:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose130:
+ax_pose 7, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose131:
+ax_pose 8, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose132:
+ax_pose 26, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose133:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose134:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose135:
+ax_pose 5, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose136:
+ax_pose 23, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose137:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose138:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose139:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose140:
+ax_pose 9, 0x81e6, 0x80f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose141:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose142:
+ax_pose 9, 0x81e6, 0x90f8, 0x1c00
+ax_pose_terminator
+sTentacoolPose143:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose144:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose145:
+ax_pose 35, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose146:
+ax_pose 36, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose147:
+ax_pose 37, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose148:
+ax_pose 38, 0x01e6, 0x80f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose149:
+ax_pose 39, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose150:
+ax_pose 38, 0x01e6, 0x90ea, 0x1c00
+ax_pose_terminator
+sTentacoolPose151:
+ax_pose 37, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose152:
+ax_pose 36, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose153:
+ax_pose 40, 0x01f0, 0x80f2, 0x1c00
+ax_pose_terminator
+sTentacoolPose154:
+ax_pose 41, 0x01f0, 0x80f2, 0x1c00
+ax_pose_terminator
+sTentacoolPose155:
+ax_pose 42, 0x01de, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacoolPose156:
+ax_pose 43, 0x01dd, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose157:
+ax_pose 44, 0x01e3, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose158:
+ax_pose 45, 0x01e4, 0x90ec, 0x1c00
+ax_pose_terminator
+sTentacoolPose159:
+ax_pose 46, 0x01df, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacoolPose160:
+ax_pose 45, 0x01e4, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose161:
+ax_pose 44, 0x01e3, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacoolPose162:
+ax_pose 43, 0x01dd, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacoolPose163:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose164:
+ax_pose 1, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose165:
+ax_pose 2, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose166:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose167:
+ax_pose 4, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose168:
+ax_pose 5, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose169:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose170:
+ax_pose 7, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose171:
+ax_pose 8, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose172:
+ax_pose 9, 0x81e6, 0x90f8, 0x1c00
+ax_pose_terminator
+sTentacoolPose173:
+ax_pose 10, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose174:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose175:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose176:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose177:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose178:
+ax_pose 9, 0x81e6, 0x80f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose179:
+ax_pose 10, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose180:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose181:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose182:
+ax_pose 7, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose183:
+ax_pose 8, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose184:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose185:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose186:
+ax_pose 5, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose187:
+ax_pose 15, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose188:
+ax_pose 16, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose189:
+ax_pose 17, 0x01e6, 0x80f1, 0x1c00
+ax_pose_terminator
+sTentacoolPose190:
+ax_pose 18, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose191:
+ax_pose 19, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose192:
+ax_pose 18, 0x01e5, 0x90ec, 0x1c00
+ax_pose_terminator
+sTentacoolPose193:
+ax_pose 17, 0x01e6, 0x90ef, 0x1c00
+ax_pose_terminator
+sTentacoolPose194:
+ax_pose 16, 0x01e9, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacoolPose195:
+ax_pose 20, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose196:
+ax_pose 23, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose197:
+ax_pose 26, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose198:
+ax_pose 29, 0x01e5, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose199:
+ax_pose 32, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose200:
+ax_pose 29, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose201:
+ax_pose 26, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose202:
+ax_pose 23, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose203:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose204:
+ax_pose 20, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose205:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose206:
+ax_pose 23, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose207:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose208:
+ax_pose 26, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose209:
+ax_pose 9, 0x81e6, 0x90f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose210:
+ax_pose 29, 0x01e5, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacoolPose211:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose212:
+ax_pose 32, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose213:
+ax_pose 9, 0x81e6, 0x80fa, 0x1c00
+ax_pose_terminator
+sTentacoolPose214:
+ax_pose 29, 0x01e5, 0x80f5, 0x1c00
+ax_pose_terminator
+sTentacoolPose215:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose216:
+ax_pose 26, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose217:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose218:
+ax_pose 23, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose219:
+ax_pose 22, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose220:
+ax_pose 25, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose221:
+ax_pose 28, 0x01e5, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose222:
+ax_pose 31, 0x01e5, 0x80f5, 0x1c00
+ax_pose_terminator
+sTentacoolPose223:
+ax_pose 34, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose224:
+ax_pose 31, 0x01e5, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacoolPose225:
+ax_pose 28, 0x01e5, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose226:
+ax_pose 25, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose227:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose228:
+ax_pose 3, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose229:
+ax_pose 6, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose230:
+ax_pose 9, 0x81e6, 0x80f9, 0x1c00
+ax_pose_terminator
+sTentacoolPose231:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacoolPose232:
+ax_pose 9, 0x81e6, 0x90f8, 0x1c00
+ax_pose_terminator
+sTentacoolPose233:
+ax_pose 6, 0x01e6, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacoolPose234:
+ax_pose 3, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+.align 2
+sTentacoolAnims_1_1:
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 10, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 10, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_1_2:
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 10, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_1_3:
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_1_4:
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 10, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_1_5:
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_1_6:
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 10, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_1_7:
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 10, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_1_8:
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 10, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 4, 0, 26, 0, -3, 0, -3,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 5, 0, 5,
+ax_anim 1, 0, 27, 0, 12, 0, 12,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 1, 27, -1, 21, -1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 27, -1, 21, -1, 21,
+ax_anim 2, 0, 27, 0, 21, 0, 21,
+ax_anim 2, 0, 24, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sTentacoolAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 28, -3, -3, -3, -3,
+ax_anim 4, 0, 30, -4, -3, -4, -4,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 5, 5, 5, 5,
+ax_anim 1, 0, 31, 12, 12, 12, 12,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 1, 31, 17, 20, 17, 20,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 31, 17, 20, 17, 20,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 28, 12, 12, 12, 12,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sTentacoolAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 2, 0, 33, -2, 0, -2, 0,
+ax_anim 2, 0, 32, -3, 0, -3, 0,
+ax_anim 4, 0, 34, -4, 0, -4, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 5, 0, 5, 0,
+ax_anim 1, 0, 35, 10, 1, 10, 0,
+ax_anim 2, 0, 35, 16, 2, 16, 0,
+ax_anim 2, 1, 35, 16, 3, 16, 1,
+ax_anim 2, 0, 35, 16, 2, 16, 0,
+ax_anim 2, 0, 35, 16, 3, 16, 1,
+ax_anim 2, 0, 35, 16, 2, 16, 0,
+ax_anim 2, 0, 32, 12, 1, 12, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sTentacoolAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 2, 0, 37, -2, 2, -2, 2,
+ax_anim 2, 0, 36, -3, 3, -3, 3,
+ax_anim 4, 0, 38, -4, 3, -4, 3,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 5, -6, 5, -6,
+ax_anim 1, 0, 39, 11, -14, 11, -14,
+ax_anim 2, 0, 39, 14, -18, 14, -18,
+ax_anim 2, 1, 39, 13, -19, 13, -19,
+ax_anim 2, 0, 39, 14, -18, 14, -18,
+ax_anim 2, 0, 39, 13, -19, 13, -19,
+ax_anim 2, 0, 39, 14, -18, 14, -18,
+ax_anim 2, 0, 36, 10, -13, 10, -13,
+ax_anim 2, 0, 36, 3, -5, 3, -5,
+ax_anim_terminator
+sTentacoolAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 2, 0, 41, 0, 2, 0, 2,
+ax_anim 2, 0, 40, 0, 4, 0, 3,
+ax_anim 4, 0, 42, 0, 4, 0, 4,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -5, 0, -5,
+ax_anim 1, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 1, 43, -1, -19, -1, -19,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 0, 43, -1, -19, -1, -19,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 0, 40, 0, -12, 0, -12,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sTentacoolAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 2, 0, 45, 2, 2, 2, 2,
+ax_anim 2, 0, 44, 3, 3, 3, 3,
+ax_anim 4, 0, 46, 4, 3, 4, 3,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -5, -6, -5, -6,
+ax_anim 1, 0, 47, -11, -14, -11, -14,
+ax_anim 2, 0, 47, -14, -18, -14, -18,
+ax_anim 2, 1, 47, -13, -19, -13, -19,
+ax_anim 2, 0, 47, -14, -18, -14, -18,
+ax_anim 2, 0, 47, -13, -19, -13, -19,
+ax_anim 2, 0, 47, -14, -18, -14, -18,
+ax_anim 2, 0, 44, -10, -13, -10, -13,
+ax_anim 2, 0, 44, -3, -5, -3, -5,
+ax_anim_terminator
+sTentacoolAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 2, 0, 49, 2, 0, 2, 0,
+ax_anim 2, 0, 48, 3, 0, 3, 0,
+ax_anim 4, 0, 50, 4, 0, 4, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -5, 0, -5, 0,
+ax_anim 1, 0, 51, -10, 1, -10, 0,
+ax_anim 2, 0, 51, -16, 2, -16, 0,
+ax_anim 2, 1, 51, -16, 3, -16, 1,
+ax_anim 2, 0, 51, -16, 2, -16, 0,
+ax_anim 2, 0, 51, -16, 3, -16, 1,
+ax_anim 2, 0, 51, -16, 2, -16, 0,
+ax_anim 2, 0, 48, -12, 1, -12, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sTentacoolAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 0, 52, 3, -3, 3, -3,
+ax_anim 4, 0, 54, 4, -3, 4, -4,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -5, 5, -5, 5,
+ax_anim 1, 0, 55, -12, 12, -12, 12,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 1, 55, -17, 20, -17, 20,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 0, 55, -17, 20, -17, 20,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 0, 52, -12, 12, -12, 12,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 56, 0, -4, 0, -4,
+ax_anim 4, 0, 59, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 0, 4, 0, 4,
+ax_anim 2, 0, 60, 0, 13, 0, 13,
+ax_anim 2, 1, 61, -1, 13, -1, 13,
+ax_anim 2, 0, 61, 0, 13, 0, 13,
+ax_anim 2, 0, 61, -1, 13, -1, 13,
+ax_anim 2, 0, 61, 0, 13, 0, 13,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sTentacoolAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 62, -4, -4, -4, -4,
+ax_anim 4, 0, 65, -4, -4, -4, -4,
+ax_anim 1, 2, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 65, 4, 4, 4, 4,
+ax_anim 2, 0, 66, 14, 14, 14, 14,
+ax_anim 2, 1, 67, 13, 15, 13, 15,
+ax_anim 2, 0, 67, 14, 14, 14, 14,
+ax_anim 2, 0, 67, 13, 15, 13, 15,
+ax_anim 2, 0, 67, 14, 14, 14, 14,
+ax_anim 2, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 62, 4, 4, 4, 4,
+ax_anim_terminator
+sTentacoolAnims_3_3:
+ax_anim 2, 0, 68, -2, 0, -2, 0,
+ax_anim 2, 0, 68, -4, 0, -4, 0,
+ax_anim 4, 0, 71, -4, 0, -4, 0,
+ax_anim 1, 2, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 71, 4, 0, 4, 0,
+ax_anim 2, 0, 72, 12, 0, 12, 0,
+ax_anim 2, 1, 73, 12, -1, 12, -1,
+ax_anim 2, 0, 73, 12, 0, 12, 0,
+ax_anim 2, 0, 73, 12, -1, 12, -1,
+ax_anim 2, 0, 73, 12, 0, 12, 0,
+ax_anim 2, 0, 68, 10, 0, 10, 0,
+ax_anim 2, 0, 68, 4, 0, 4, 0,
+ax_anim_terminator
+sTentacoolAnims_3_4:
+ax_anim 2, 0, 74, -2, 2, -2, 2,
+ax_anim 2, 0, 74, -4, 4, -4, 4,
+ax_anim 4, 0, 77, -4, 4, -4, 4,
+ax_anim 1, 2, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 4, -6, 4, -6,
+ax_anim 2, 0, 78, 11, -16, 11, -16,
+ax_anim 2, 1, 79, 10, -16, 10, -16,
+ax_anim 2, 0, 79, 11, -15, 11, -15,
+ax_anim 2, 0, 79, 10, -16, 10, -16,
+ax_anim 2, 0, 79, 11, -15, 11, -15,
+ax_anim 2, 0, 74, 8, -12, 8, -12,
+ax_anim 2, 0, 74, 3, -5, 3, -5,
+ax_anim_terminator
+sTentacoolAnims_3_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 2, 0, 80, 0, 4, 0, 4,
+ax_anim 4, 0, 83, 0, 4, 0, 4,
+ax_anim 1, 2, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 0, -13, 0, -13,
+ax_anim 2, 1, 85, -1, -13, -1, -13,
+ax_anim 2, 0, 85, 0, -13, 0, -13,
+ax_anim 2, 0, 85, -1, -13, -1, -13,
+ax_anim 2, 0, 85, 0, -13, 0, -13,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sTentacoolAnims_3_6:
+ax_anim 2, 0, 86, 2, 2, 2, 2,
+ax_anim 2, 0, 86, 4, 4, 4, 4,
+ax_anim 4, 0, 89, 4, 4, 4, 4,
+ax_anim 1, 2, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, -4, -6, -4, -6,
+ax_anim 2, 0, 90, -11, -16, -11, -16,
+ax_anim 2, 1, 91, -10, -16, -10, -16,
+ax_anim 2, 0, 91, -11, -15, -11, -15,
+ax_anim 2, 0, 91, -10, -16, -10, -16,
+ax_anim 2, 0, 91, -11, -15, -11, -15,
+ax_anim 2, 0, 86, -8, -12, -8, -12,
+ax_anim 2, 0, 86, -3, -5, -3, -5,
+ax_anim_terminator
+sTentacoolAnims_3_7:
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 0, 92, 4, 0, 4, 0,
+ax_anim 4, 0, 95, 4, 0, 4, 0,
+ax_anim 1, 2, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -4, 0, -4, 0,
+ax_anim 2, 0, 96, -12, 0, -12, 0,
+ax_anim 2, 1, 97, -12, -1, -12, -1,
+ax_anim 2, 0, 97, -12, 0, -12, 0,
+ax_anim 2, 0, 97, -12, -1, -12, -1,
+ax_anim 2, 0, 97, -12, 0, -12, 0,
+ax_anim 2, 0, 92, -10, 0, -10, 0,
+ax_anim 2, 0, 92, -4, 0, -4, 0,
+ax_anim_terminator
+sTentacoolAnims_3_8:
+ax_anim 2, 0, 98, 2, -2, 2, -2,
+ax_anim 2, 0, 98, 4, -4, 4, -4,
+ax_anim 4, 0, 101, 4, -4, 4, -4,
+ax_anim 1, 2, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, -4, 4, -4, 4,
+ax_anim 2, 0, 102, -14, 14, -14, 14,
+ax_anim 2, 1, 103, -13, 15, -13, 15,
+ax_anim 2, 0, 103, -14, 14, -14, 14,
+ax_anim 2, 0, 103, -13, 15, -13, 15,
+ax_anim 2, 0, 103, -14, 14, -14, 14,
+ax_anim 2, 0, 98, -10, 10, -10, 10,
+ax_anim 2, 0, 98, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_4_1:
+ax_anim 8, 2, 104, 0, 0, 0, 0,
+ax_anim 1, 1, 107, 0, -7, 0, -7,
+ax_anim 2, 0, 107, 0, -9, 0, -9,
+ax_anim 6, 0, 107, 0, -10, 0, -10,
+ax_anim 2, 0, 105, 0, -11, 0, -10,
+ax_anim 2, 0, 105, 0, -6, 0, -6,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sTentacoolAnims_4_2:
+ax_anim 8, 2, 108, 0, 0, 0, 0,
+ax_anim 1, 1, 111, -7, -7, -7, -7,
+ax_anim 2, 0, 111, -9, -9, -9, -9,
+ax_anim 6, 0, 111, -10, -10, -10, -10,
+ax_anim 2, 0, 109, -10, -11, -10, -11,
+ax_anim 2, 0, 109, -6, -6, -6, -6,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sTentacoolAnims_4_3:
+ax_anim 8, 2, 112, 0, 0, 0, 0,
+ax_anim 1, 1, 115, -7, 0, -7, 0,
+ax_anim 2, 0, 115, -9, 0, -9, 0,
+ax_anim 6, 0, 115, -11, 0, -11, 0,
+ax_anim 2, 0, 113, -10, 0, -10, 0,
+ax_anim 2, 0, 113, -6, 0, -6, 0,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sTentacoolAnims_4_4:
+ax_anim 8, 2, 116, 0, 0, 0, 0,
+ax_anim 1, 1, 119, -7, 7, -7, 7,
+ax_anim 2, 0, 119, -9, 9, -9, 9,
+ax_anim 6, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 117, -10, 10, -10, 10,
+ax_anim 2, 0, 117, -6, 6, -6, 6,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+sTentacoolAnims_4_5:
+ax_anim 8, 2, 120, 0, 0, 0, 0,
+ax_anim 1, 1, 123, 0, 7, 0, 7,
+ax_anim 2, 0, 123, 0, 9, 0, 9,
+ax_anim 6, 0, 123, 0, 10, 0, 10,
+ax_anim 2, 0, 121, 0, 10, 0, 10,
+ax_anim 2, 0, 121, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, 2, 0, 2,
+ax_anim_terminator
+sTentacoolAnims_4_6:
+ax_anim 8, 2, 124, 0, 0, 0, 0,
+ax_anim 1, 1, 127, 7, 7, 7, 7,
+ax_anim 2, 0, 127, 9, 9, 9, 9,
+ax_anim 6, 0, 127, 10, 10, 10, 10,
+ax_anim 2, 0, 125, 10, 10, 10, 10,
+ax_anim 2, 0, 125, 6, 6, 6, 6,
+ax_anim 2, 0, 124, 2, 2, 2, 2,
+ax_anim_terminator
+sTentacoolAnims_4_7:
+ax_anim 8, 2, 128, 0, 0, 0, 0,
+ax_anim 1, 1, 131, 7, 0, 7, 0,
+ax_anim 2, 0, 131, 9, 0, 9, 0,
+ax_anim 6, 0, 131, 11, 0, 11, 0,
+ax_anim 2, 0, 129, 10, 0, 10, 0,
+ax_anim 2, 0, 129, 6, 0, 6, 0,
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim_terminator
+sTentacoolAnims_4_8:
+ax_anim 8, 2, 132, 0, 0, 0, 0,
+ax_anim 1, 1, 135, 7, -7, 7, -7,
+ax_anim 2, 0, 135, 9, -9, 9, -9,
+ax_anim 6, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 133, 10, -11, 10, -11,
+ax_anim 2, 0, 133, 6, -6, 6, -6,
+ax_anim 2, 0, 132, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_5_1:
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 2, 0, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 0, 140, 0, -9, 0, 0,
+ax_anim 2, 2, 139, 0, -8, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_5_2:
+ax_anim 6, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 138, 0, -9, 0, 0,
+ax_anim 2, 0, 139, 0, -9, 0, 0,
+ax_anim 2, 2, 140, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_5_3:
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 138, 0, -9, 0, 0,
+ax_anim 2, 2, 139, 0, -8, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_5_4:
+ax_anim 6, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -9, 0, 0,
+ax_anim 2, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 2, 138, 0, -8, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_5_5:
+ax_anim 6, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -8, 0, 0,
+ax_anim 2, 0, 137, 0, -9, 0, 0,
+ax_anim 2, 0, 136, 0, -9, 0, 0,
+ax_anim 2, 2, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_5_6:
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -5, 0, 0,
+ax_anim 2, 0, 137, 0, -8, 0, 0,
+ax_anim 2, 0, 136, 0, -9, 0, 0,
+ax_anim 2, 0, 143, 0, -9, 0, 0,
+ax_anim 2, 2, 142, 0, -8, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_5_7:
+ax_anim 6, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 0, -8, 0, 0,
+ax_anim 2, 0, 143, 0, -9, 0, 0,
+ax_anim 2, 0, 142, 0, -9, 0, 0,
+ax_anim 2, 2, 141, 0, -8, 0, 0,
+ax_anim 2, 0, 140, 0, -5, 0, 0,
+ax_anim 2, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_5_8:
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 143, 0, -8, 0, 0,
+ax_anim 2, 0, 142, 0, -9, 0, 0,
+ax_anim 2, 0, 141, 0, -9, 0, 0,
+ax_anim 2, 2, 140, 0, -8, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_7_1:
+ax_anim 2, 0, 154, 0, -3, 0, -3,
+ax_anim 8, 0, 154, 0, -4, 0, -4,
+ax_anim_terminator
+sTentacoolAnims_7_2:
+ax_anim 2, 0, 155, -3, -3, -3, -3,
+ax_anim 8, 0, 155, -4, -4, -4, -4,
+ax_anim_terminator
+sTentacoolAnims_7_3:
+ax_anim 2, 0, 156, -3, 0, -3, 0,
+ax_anim 8, 0, 156, -4, 0, -4, 0,
+ax_anim_terminator
+sTentacoolAnims_7_4:
+ax_anim 2, 0, 157, -3, 3, -3, 3,
+ax_anim 8, 0, 157, -4, 4, -4, 4,
+ax_anim_terminator
+sTentacoolAnims_7_5:
+ax_anim 2, 0, 158, 0, 3, 0, 3,
+ax_anim 8, 0, 158, 0, 4, 0, 4,
+ax_anim_terminator
+sTentacoolAnims_7_6:
+ax_anim 2, 0, 159, 3, 3, 3, 3,
+ax_anim 8, 0, 159, 4, 4, 4, 4,
+ax_anim_terminator
+sTentacoolAnims_7_7:
+ax_anim 2, 0, 160, 3, 0, 3, 0,
+ax_anim 8, 0, 160, 4, 0, 4, 0,
+ax_anim_terminator
+sTentacoolAnims_7_8:
+ax_anim 2, 0, 161, 3, -3, 3, -3,
+ax_anim 8, 0, 161, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_8_1:
+ax_anim 4, 0, 162, 0, -2, 0, 0,
+ax_anim 8, 0, 164, 0, -2, 0, 0,
+ax_anim 8, 0, 164, 0, -3, 0, 0,
+ax_anim 4, 0, 162, 0, -5, 0, 0,
+ax_anim 8, 0, 163, 0, -6, 0, 0,
+ax_anim 8, 0, 163, 0, -5, 0, 0,
+ax_anim 8, 0, 163, 0, -4, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_8_2:
+ax_anim 4, 0, 165, 0, -2, 0, 0,
+ax_anim 8, 0, 167, 0, -2, 0, 0,
+ax_anim 8, 0, 167, 0, -3, 0, 0,
+ax_anim 4, 0, 165, 0, -5, 0, 0,
+ax_anim 8, 0, 166, 0, -6, 0, 0,
+ax_anim 8, 0, 166, 0, -5, 0, 0,
+ax_anim 8, 0, 166, 0, -4, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_8_3:
+ax_anim 4, 0, 168, 0, -2, 0, 0,
+ax_anim 8, 0, 170, 0, -2, 0, 0,
+ax_anim 8, 0, 170, 0, -3, 0, 0,
+ax_anim 4, 0, 168, 0, -5, 0, 0,
+ax_anim 8, 0, 169, 0, -6, 0, 0,
+ax_anim 8, 0, 169, 0, -5, 0, 0,
+ax_anim 8, 0, 169, 0, -4, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_8_4:
+ax_anim 4, 0, 171, 0, -2, 0, 0,
+ax_anim 8, 0, 173, 0, -2, 0, 0,
+ax_anim 8, 0, 173, 0, -3, 0, 0,
+ax_anim 4, 0, 171, 0, -5, 0, 0,
+ax_anim 8, 0, 172, 0, -6, 0, 0,
+ax_anim 8, 0, 172, 0, -5, 0, 0,
+ax_anim 8, 0, 172, 0, -4, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_8_5:
+ax_anim 4, 0, 174, 0, -2, 0, 0,
+ax_anim 8, 0, 176, 0, -2, 0, 0,
+ax_anim 8, 0, 176, 0, -3, 0, 0,
+ax_anim 4, 0, 174, 0, -5, 0, 0,
+ax_anim 8, 0, 175, 0, -6, 0, 0,
+ax_anim 8, 0, 175, 0, -5, 0, 0,
+ax_anim 8, 0, 175, 0, -4, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_8_6:
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim 8, 0, 179, 0, -2, 0, 0,
+ax_anim 8, 0, 179, 0, -3, 0, 0,
+ax_anim 4, 0, 177, 0, -5, 0, 0,
+ax_anim 8, 0, 178, 0, -6, 0, 0,
+ax_anim 8, 0, 178, 0, -5, 0, 0,
+ax_anim 8, 0, 178, 0, -4, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_8_7:
+ax_anim 4, 0, 180, 0, -2, 0, 0,
+ax_anim 8, 0, 182, 0, -2, 0, 0,
+ax_anim 8, 0, 182, 0, -3, 0, 0,
+ax_anim 4, 0, 180, 0, -5, 0, 0,
+ax_anim 8, 0, 181, 0, -6, 0, 0,
+ax_anim 8, 0, 181, 0, -5, 0, 0,
+ax_anim 8, 0, 181, 0, -4, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_8_8:
+ax_anim 4, 0, 183, 0, -2, 0, 0,
+ax_anim 8, 0, 185, 0, -2, 0, 0,
+ax_anim 8, 0, 185, 0, -3, 0, 0,
+ax_anim 4, 0, 183, 0, -5, 0, 0,
+ax_anim 8, 0, 184, 0, -6, 0, 0,
+ax_anim 8, 0, 184, 0, -5, 0, 0,
+ax_anim 8, 0, 184, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 15, 7, 15,
+ax_anim 3, 0, 190, 0, 18, 0, 18,
+ax_anim 2, 3, 191, -7, 15, -7, 15,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 3, 18, 3,
+ax_anim 2, 0, 188, 19, 10, 21, 10,
+ax_anim 3, 0, 189, 17, 19, 19, 20,
+ax_anim 2, 3, 190, 11, 19, 11, 19,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 11, -6, 11, -6,
+ax_anim 2, 0, 187, 16, -5, 16, -5,
+ax_anim 3, 0, 188, 18, 1, 18, 1,
+ax_anim 2, 3, 189, 16, 6, 16, 6,
+ax_anim 2, 0, 190, 9, 5, 9, 5,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 4, -16, 4, -16,
+ax_anim 2, 0, 186, 12, -19, 12, -19,
+ax_anim 3, 0, 187, 18, -18, 18, -18,
+ax_anim 2, 3, 188, 20, -12, 20, -12,
+ax_anim 2, 0, 189, 17, -4, 17, -4,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -8, -4, -8, -4,
+ax_anim 2, 0, 192, -9, -12, -9, -12,
+ax_anim 2, 0, 193, -7, -18, -7, -18,
+ax_anim 3, 0, 186, 0, -20, 0, -20,
+ax_anim 2, 3, 187, 7, -18, 7, -18,
+ax_anim 2, 0, 188, 9, -10, 9, -10,
+ax_anim 1, 0, 189, 8, -4, 8, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -4, -16, -4, -16,
+ax_anim 2, 0, 186, -12, -19, -12, -19,
+ax_anim 3, 0, 193, -18, -19, -18, -19,
+ax_anim 2, 3, 192, -20, -12, -20, -12,
+ax_anim 2, 0, 191, -17, -4, -17, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -11, -6, -11, -6,
+ax_anim 2, 0, 193, -16, -5, -16, -5,
+ax_anim 3, 0, 192, -18, -1, -18, -1,
+ax_anim 2, 3, 191, -16, 6, -16, 6,
+ax_anim 2, 0, 190, -8, 5, -8, 5,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 3, -17, 3,
+ax_anim 2, 0, 192, -19, 10, -19, 10,
+ax_anim 3, 0, 191, -17, 19, -17, 19,
+ax_anim 2, 3, 190, -11, 19, -11, 19,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -24, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_11_2:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_11_3:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_11_4:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -17, 0, 0,
+ax_anim 1, 0, 208, 0, -11, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_11_5:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -23, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_11_6:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -21, 0, 0,
+ax_anim 2, 0, 212, 0, -17, 0, 0,
+ax_anim 1, 0, 212, 0, -11, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_11_7:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_11_8:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 217, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacoolAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacoolGfx1:
+.incbin "baserom.gba", 0x8219B0, 0x200
+sTentacoolSprites1:
+ax_sprite sTentacoolGfx1, 0x200
+ax_sprite_terminator
+sTentacoolGfx2:
+.incbin "baserom.gba", 0x821BC0, 0x200
+sTentacoolSprites2:
+ax_sprite sTentacoolGfx2, 0x200
+ax_sprite_terminator
+sTentacoolGfx3:
+.incbin "baserom.gba", 0x821DD0, 0x200
+sTentacoolSprites3:
+ax_sprite sTentacoolGfx3, 0x200
+ax_sprite_terminator
+sTentacoolGfx4:
+.incbin "baserom.gba", 0x821FE0, 0x200
+sTentacoolSprites4:
+ax_sprite sTentacoolGfx4, 0x200
+ax_sprite_terminator
+sTentacoolGfx5:
+.incbin "baserom.gba", 0x8221F0, 0x200
+sTentacoolSprites5:
+ax_sprite sTentacoolGfx5, 0x200
+ax_sprite_terminator
+sTentacoolGfx6:
+.incbin "baserom.gba", 0x822400, 0x200
+sTentacoolSprites6:
+ax_sprite sTentacoolGfx6, 0x200
+ax_sprite_terminator
+sTentacoolGfx7:
+.incbin "baserom.gba", 0x822610, 0x200
+sTentacoolSprites7:
+ax_sprite sTentacoolGfx7, 0x200
+ax_sprite_terminator
+sTentacoolGfx8:
+.incbin "baserom.gba", 0x822820, 0x200
+sTentacoolSprites8:
+ax_sprite sTentacoolGfx8, 0x200
+ax_sprite_terminator
+sTentacoolGfx9:
+.incbin "baserom.gba", 0x822A30, 0x200
+sTentacoolSprites9:
+ax_sprite sTentacoolGfx9, 0x200
+ax_sprite_terminator
+sTentacoolGfx10:
+.incbin "baserom.gba", 0x822C40, 0x100
+sTentacoolSprites10:
+ax_sprite sTentacoolGfx10, 0x100
+ax_sprite_terminator
+sTentacoolGfx11:
+.incbin "baserom.gba", 0x822D50, 0x200
+sTentacoolSprites11:
+ax_sprite sTentacoolGfx11, 0x200
+ax_sprite_terminator
+sTentacoolGfx12:
+.incbin "baserom.gba", 0x822F60, 0x200
+sTentacoolSprites12:
+ax_sprite sTentacoolGfx12, 0x200
+ax_sprite_terminator
+sTentacoolGfx13:
+.incbin "baserom.gba", 0x823170, 0x200
+sTentacoolSprites13:
+ax_sprite sTentacoolGfx13, 0x200
+ax_sprite_terminator
+sTentacoolGfx14:
+.incbin "baserom.gba", 0x823380, 0x200
+sTentacoolSprites14:
+ax_sprite sTentacoolGfx14, 0x200
+ax_sprite_terminator
+sTentacoolGfx15:
+.incbin "baserom.gba", 0x823590, 0x200
+sTentacoolSprites15:
+ax_sprite sTentacoolGfx15, 0x200
+ax_sprite_terminator
+sTentacoolGfx16:
+.incbin "baserom.gba", 0x8237A0, 0x60
+sTentacoolGfx16_1:
+.incbin "baserom.gba", 0x823800, 0x60
+sTentacoolGfx16_2:
+.incbin "baserom.gba", 0x823860, 0x60
+sTentacoolSprites16:
+ax_sprite sTentacoolGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx17:
+.incbin "baserom.gba", 0x8238F8, 0x40
+sTentacoolGfx17_1:
+.incbin "baserom.gba", 0x823938, 0x60
+sTentacoolGfx17_2:
+.incbin "baserom.gba", 0x823998, 0x60
+sTentacoolSprites17:
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx18:
+.incbin "baserom.gba", 0x823A38, 0x100
+sTentacoolSprites18:
+ax_sprite 0, 0x80
+ax_sprite sTentacoolGfx18, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTentacoolGfx19:
+.incbin "baserom.gba", 0x823B58, 0x40
+sTentacoolGfx19_1:
+.incbin "baserom.gba", 0x823B98, 0x60
+sTentacoolGfx19_2:
+.incbin "baserom.gba", 0x823BF8, 0x80
+sTentacoolGfx19_3:
+.incbin "baserom.gba", 0x823C78, 0x60
+sTentacoolSprites19:
+ax_sprite sTentacoolGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx19_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx19_3, 0x60
+ax_sprite_terminator
+sTentacoolGfx20:
+.incbin "baserom.gba", 0x823D18, 0x60
+sTentacoolGfx20_1:
+.incbin "baserom.gba", 0x823D78, 0x60
+sTentacoolGfx20_2:
+.incbin "baserom.gba", 0x823DD8, 0x60
+sTentacoolGfx20_3:
+.incbin "baserom.gba", 0x823E38, 0x20
+sTentacoolGfx20_4:
+.incbin "baserom.gba", 0x823E58, 0x20
+sTentacoolSprites20:
+ax_sprite sTentacoolGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx20_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx20_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacoolGfx21:
+.incbin "baserom.gba", 0x823ED0, 0x60
+sTentacoolGfx21_1:
+.incbin "baserom.gba", 0x823F30, 0x60
+sTentacoolSprites21:
+ax_sprite sTentacoolGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx21_1, 0x60
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sTentacoolGfx22:
+.incbin "baserom.gba", 0x823FB8, 0x20
+sTentacoolGfx22_1:
+.incbin "baserom.gba", 0x823FD8, 0x60
+sTentacoolGfx22_2:
+.incbin "baserom.gba", 0x824038, 0x40
+sTentacoolGfx22_3:
+.incbin "baserom.gba", 0x824078, 0xA0
+sTentacoolSprites22:
+ax_sprite sTentacoolGfx22, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx22_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx22_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx22_3, 0xa0
+ax_sprite_terminator
+sTentacoolGfx23:
+.incbin "baserom.gba", 0x824158, 0x60
+sTentacoolGfx23_1:
+.incbin "baserom.gba", 0x8241B8, 0x60
+sTentacoolGfx23_2:
+.incbin "baserom.gba", 0x824218, 0x60
+sTentacoolGfx23_3:
+.incbin "baserom.gba", 0x824278, 0x60
+sTentacoolSprites23:
+ax_sprite sTentacoolGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacoolGfx24:
+.incbin "baserom.gba", 0x824320, 0x60
+sTentacoolGfx24_1:
+.incbin "baserom.gba", 0x824380, 0x60
+sTentacoolGfx24_2:
+.incbin "baserom.gba", 0x8243E0, 0x40
+sTentacoolSprites24:
+ax_sprite sTentacoolGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx25:
+.incbin "baserom.gba", 0x824458, 0x40
+sTentacoolGfx25_1:
+.incbin "baserom.gba", 0x824498, 0x40
+sTentacoolGfx25_2:
+.incbin "baserom.gba", 0x8244D8, 0xA0
+sTentacoolGfx25_3:
+.incbin "baserom.gba", 0x824578, 0x60
+sTentacoolSprites25:
+ax_sprite sTentacoolGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx25_2, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacoolGfx26:
+.incbin "baserom.gba", 0x824620, 0x60
+sTentacoolGfx26_1:
+.incbin "baserom.gba", 0x824680, 0x60
+sTentacoolGfx26_2:
+.incbin "baserom.gba", 0x8246E0, 0x60
+sTentacoolGfx26_3:
+.incbin "baserom.gba", 0x824740, 0x40
+sTentacoolSprites26:
+ax_sprite sTentacoolGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx26_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacoolGfx27:
+.incbin "baserom.gba", 0x8247C8, 0x40
+sTentacoolGfx27_1:
+.incbin "baserom.gba", 0x824808, 0x60
+sTentacoolGfx27_2:
+.incbin "baserom.gba", 0x824868, 0x60
+sTentacoolSprites27:
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx28:
+.incbin "baserom.gba", 0x824908, 0x20
+sTentacoolGfx28_1:
+.incbin "baserom.gba", 0x824928, 0xC0
+sTentacoolGfx28_2:
+.incbin "baserom.gba", 0x8249E8, 0x40
+sTentacoolSprites28:
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx28_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx28_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacoolGfx29:
+.incbin "baserom.gba", 0x824A68, 0x40
+sTentacoolGfx29_1:
+.incbin "baserom.gba", 0x824AA8, 0x60
+sTentacoolGfx29_2:
+.incbin "baserom.gba", 0x824B08, 0x60
+sTentacoolGfx29_3:
+.incbin "baserom.gba", 0x824B68, 0x40
+sTentacoolSprites29:
+ax_sprite sTentacoolGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx29_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacoolGfx30:
+.incbin "baserom.gba", 0x824BF0, 0x40
+sTentacoolGfx30_1:
+.incbin "baserom.gba", 0x824C30, 0xE0
+sTentacoolSprites30:
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx30_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx31:
+.incbin "baserom.gba", 0x824D40, 0x60
+sTentacoolGfx31_1:
+.incbin "baserom.gba", 0x824DA0, 0xE0
+sTentacoolGfx31_2:
+.incbin "baserom.gba", 0x824E80, 0x60
+sTentacoolSprites31:
+ax_sprite sTentacoolGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx31_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacoolGfx32:
+.incbin "baserom.gba", 0x824F18, 0x40
+sTentacoolGfx32_1:
+.incbin "baserom.gba", 0x824F58, 0x60
+sTentacoolGfx32_2:
+.incbin "baserom.gba", 0x824FB8, 0x60
+sTentacoolGfx32_3:
+.incbin "baserom.gba", 0x825018, 0x40
+sTentacoolSprites32:
+ax_sprite sTentacoolGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx32_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacoolGfx33:
+.incbin "baserom.gba", 0x8250A0, 0x60
+sTentacoolGfx33_1:
+.incbin "baserom.gba", 0x825100, 0xE0
+sTentacoolSprites33:
+ax_sprite sTentacoolGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx33_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx34:
+.incbin "baserom.gba", 0x825208, 0xA0
+sTentacoolGfx34_1:
+.incbin "baserom.gba", 0x8252A8, 0x140
+sTentacoolSprites34:
+ax_sprite sTentacoolGfx34, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx34_1, 0x140
+ax_sprite_terminator
+sTentacoolGfx35:
+.incbin "baserom.gba", 0x825408, 0x60
+sTentacoolGfx35_1:
+.incbin "baserom.gba", 0x825468, 0x60
+sTentacoolGfx35_2:
+.incbin "baserom.gba", 0x8254C8, 0x60
+sTentacoolSprites35:
+ax_sprite sTentacoolGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx36:
+.incbin "baserom.gba", 0x825560, 0x60
+sTentacoolGfx36_1:
+.incbin "baserom.gba", 0x8255C0, 0x60
+sTentacoolGfx36_2:
+.incbin "baserom.gba", 0x825620, 0x60
+sTentacoolSprites36:
+ax_sprite sTentacoolGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx37:
+.incbin "baserom.gba", 0x8256B8, 0x60
+sTentacoolGfx37_1:
+.incbin "baserom.gba", 0x825718, 0x60
+sTentacoolGfx37_2:
+.incbin "baserom.gba", 0x825778, 0x60
+sTentacoolSprites37:
+ax_sprite sTentacoolGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx37_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx38:
+.incbin "baserom.gba", 0x825810, 0x40
+sTentacoolGfx38_1:
+.incbin "baserom.gba", 0x825850, 0x60
+sTentacoolGfx38_2:
+.incbin "baserom.gba", 0x8258B0, 0x80
+sTentacoolSprites38:
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx38_2, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTentacoolGfx39:
+.incbin "baserom.gba", 0x825970, 0x40
+sTentacoolGfx39_1:
+.incbin "baserom.gba", 0x8259B0, 0x40
+sTentacoolGfx39_2:
+.incbin "baserom.gba", 0x8259F0, 0x60
+sTentacoolSprites39:
+ax_sprite sTentacoolGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx39_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx39_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacoolGfx40:
+.incbin "baserom.gba", 0x825A88, 0x60
+sTentacoolGfx40_1:
+.incbin "baserom.gba", 0x825AE8, 0x60
+sTentacoolGfx40_2:
+.incbin "baserom.gba", 0x825B48, 0x40
+sTentacoolGfx40_3:
+.incbin "baserom.gba", 0x825B88, 0x20
+sTentacoolSprites40:
+ax_sprite sTentacoolGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacoolGfx40_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTentacoolGfx40_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sTentacoolGfx40_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacoolGfx41:
+.incbin "baserom.gba", 0x825BF0, 0x200
+sTentacoolSprites41:
+ax_sprite sTentacoolGfx41, 0x200
+ax_sprite_terminator
+sTentacoolGfx42:
+.incbin "baserom.gba", 0x825E00, 0x200
+sTentacoolSprites42:
+ax_sprite sTentacoolGfx42, 0x200
+ax_sprite_terminator
+sTentacoolGfx43:
+.incbin "baserom.gba", 0x826010, 0x200
+sTentacoolSprites43:
+ax_sprite sTentacoolGfx43, 0x200
+ax_sprite_terminator
+sTentacoolGfx44:
+.incbin "baserom.gba", 0x826220, 0x200
+sTentacoolSprites44:
+ax_sprite sTentacoolGfx44, 0x200
+ax_sprite_terminator
+sTentacoolGfx45:
+.incbin "baserom.gba", 0x826430, 0x200
+sTentacoolSprites45:
+ax_sprite sTentacoolGfx45, 0x200
+ax_sprite_terminator
+sTentacoolGfx46:
+.incbin "baserom.gba", 0x826640, 0x200
+sTentacoolSprites46:
+ax_sprite sTentacoolGfx46, 0x200
+ax_sprite_terminator
+sTentacoolGfx47:
+.incbin "baserom.gba", 0x826850, 0x200
+sTentacoolSprites47:
+ax_sprite sTentacoolGfx47, 0x200
+ax_sprite_terminator
+sAxPosesTentacool:
+.4byte sTentacoolPose1
+.4byte sTentacoolPose2
+.4byte sTentacoolPose3
+.4byte sTentacoolPose4
+.4byte sTentacoolPose5
+.4byte sTentacoolPose6
+.4byte sTentacoolPose7
+.4byte sTentacoolPose8
+.4byte sTentacoolPose9
+.4byte sTentacoolPose10
+.4byte sTentacoolPose11
+.4byte sTentacoolPose12
+.4byte sTentacoolPose13
+.4byte sTentacoolPose14
+.4byte sTentacoolPose15
+.4byte sTentacoolPose16
+.4byte sTentacoolPose17
+.4byte sTentacoolPose18
+.4byte sTentacoolPose19
+.4byte sTentacoolPose20
+.4byte sTentacoolPose21
+.4byte sTentacoolPose22
+.4byte sTentacoolPose23
+.4byte sTentacoolPose24
+.4byte sTentacoolPose25
+.4byte sTentacoolPose26
+.4byte sTentacoolPose27
+.4byte sTentacoolPose28
+.4byte sTentacoolPose29
+.4byte sTentacoolPose30
+.4byte sTentacoolPose31
+.4byte sTentacoolPose32
+.4byte sTentacoolPose33
+.4byte sTentacoolPose34
+.4byte sTentacoolPose35
+.4byte sTentacoolPose36
+.4byte sTentacoolPose37
+.4byte sTentacoolPose38
+.4byte sTentacoolPose39
+.4byte sTentacoolPose40
+.4byte sTentacoolPose41
+.4byte sTentacoolPose42
+.4byte sTentacoolPose43
+.4byte sTentacoolPose44
+.4byte sTentacoolPose45
+.4byte sTentacoolPose46
+.4byte sTentacoolPose47
+.4byte sTentacoolPose48
+.4byte sTentacoolPose49
+.4byte sTentacoolPose50
+.4byte sTentacoolPose51
+.4byte sTentacoolPose52
+.4byte sTentacoolPose53
+.4byte sTentacoolPose54
+.4byte sTentacoolPose55
+.4byte sTentacoolPose56
+.4byte sTentacoolPose57
+.4byte sTentacoolPose58
+.4byte sTentacoolPose59
+.4byte sTentacoolPose60
+.4byte sTentacoolPose61
+.4byte sTentacoolPose62
+.4byte sTentacoolPose63
+.4byte sTentacoolPose64
+.4byte sTentacoolPose65
+.4byte sTentacoolPose66
+.4byte sTentacoolPose67
+.4byte sTentacoolPose68
+.4byte sTentacoolPose69
+.4byte sTentacoolPose70
+.4byte sTentacoolPose71
+.4byte sTentacoolPose72
+.4byte sTentacoolPose73
+.4byte sTentacoolPose74
+.4byte sTentacoolPose75
+.4byte sTentacoolPose76
+.4byte sTentacoolPose77
+.4byte sTentacoolPose78
+.4byte sTentacoolPose79
+.4byte sTentacoolPose80
+.4byte sTentacoolPose81
+.4byte sTentacoolPose82
+.4byte sTentacoolPose83
+.4byte sTentacoolPose84
+.4byte sTentacoolPose85
+.4byte sTentacoolPose86
+.4byte sTentacoolPose87
+.4byte sTentacoolPose88
+.4byte sTentacoolPose89
+.4byte sTentacoolPose90
+.4byte sTentacoolPose91
+.4byte sTentacoolPose92
+.4byte sTentacoolPose93
+.4byte sTentacoolPose94
+.4byte sTentacoolPose95
+.4byte sTentacoolPose96
+.4byte sTentacoolPose97
+.4byte sTentacoolPose98
+.4byte sTentacoolPose99
+.4byte sTentacoolPose100
+.4byte sTentacoolPose101
+.4byte sTentacoolPose102
+.4byte sTentacoolPose103
+.4byte sTentacoolPose104
+.4byte sTentacoolPose105
+.4byte sTentacoolPose106
+.4byte sTentacoolPose107
+.4byte sTentacoolPose108
+.4byte sTentacoolPose109
+.4byte sTentacoolPose110
+.4byte sTentacoolPose111
+.4byte sTentacoolPose112
+.4byte sTentacoolPose113
+.4byte sTentacoolPose114
+.4byte sTentacoolPose115
+.4byte sTentacoolPose116
+.4byte sTentacoolPose117
+.4byte sTentacoolPose118
+.4byte sTentacoolPose119
+.4byte sTentacoolPose120
+.4byte sTentacoolPose121
+.4byte sTentacoolPose122
+.4byte sTentacoolPose123
+.4byte sTentacoolPose124
+.4byte sTentacoolPose125
+.4byte sTentacoolPose126
+.4byte sTentacoolPose127
+.4byte sTentacoolPose128
+.4byte sTentacoolPose129
+.4byte sTentacoolPose130
+.4byte sTentacoolPose131
+.4byte sTentacoolPose132
+.4byte sTentacoolPose133
+.4byte sTentacoolPose134
+.4byte sTentacoolPose135
+.4byte sTentacoolPose136
+.4byte sTentacoolPose137
+.4byte sTentacoolPose138
+.4byte sTentacoolPose139
+.4byte sTentacoolPose140
+.4byte sTentacoolPose141
+.4byte sTentacoolPose142
+.4byte sTentacoolPose143
+.4byte sTentacoolPose144
+.4byte sTentacoolPose145
+.4byte sTentacoolPose146
+.4byte sTentacoolPose147
+.4byte sTentacoolPose148
+.4byte sTentacoolPose149
+.4byte sTentacoolPose150
+.4byte sTentacoolPose151
+.4byte sTentacoolPose152
+.4byte sTentacoolPose153
+.4byte sTentacoolPose154
+.4byte sTentacoolPose155
+.4byte sTentacoolPose156
+.4byte sTentacoolPose157
+.4byte sTentacoolPose158
+.4byte sTentacoolPose159
+.4byte sTentacoolPose160
+.4byte sTentacoolPose161
+.4byte sTentacoolPose162
+.4byte sTentacoolPose163
+.4byte sTentacoolPose164
+.4byte sTentacoolPose165
+.4byte sTentacoolPose166
+.4byte sTentacoolPose167
+.4byte sTentacoolPose168
+.4byte sTentacoolPose169
+.4byte sTentacoolPose170
+.4byte sTentacoolPose171
+.4byte sTentacoolPose172
+.4byte sTentacoolPose173
+.4byte sTentacoolPose174
+.4byte sTentacoolPose175
+.4byte sTentacoolPose176
+.4byte sTentacoolPose177
+.4byte sTentacoolPose178
+.4byte sTentacoolPose179
+.4byte sTentacoolPose180
+.4byte sTentacoolPose181
+.4byte sTentacoolPose182
+.4byte sTentacoolPose183
+.4byte sTentacoolPose184
+.4byte sTentacoolPose185
+.4byte sTentacoolPose186
+.4byte sTentacoolPose187
+.4byte sTentacoolPose188
+.4byte sTentacoolPose189
+.4byte sTentacoolPose190
+.4byte sTentacoolPose191
+.4byte sTentacoolPose192
+.4byte sTentacoolPose193
+.4byte sTentacoolPose194
+.4byte sTentacoolPose195
+.4byte sTentacoolPose196
+.4byte sTentacoolPose197
+.4byte sTentacoolPose198
+.4byte sTentacoolPose199
+.4byte sTentacoolPose200
+.4byte sTentacoolPose201
+.4byte sTentacoolPose202
+.4byte sTentacoolPose203
+.4byte sTentacoolPose204
+.4byte sTentacoolPose205
+.4byte sTentacoolPose206
+.4byte sTentacoolPose207
+.4byte sTentacoolPose208
+.4byte sTentacoolPose209
+.4byte sTentacoolPose210
+.4byte sTentacoolPose211
+.4byte sTentacoolPose212
+.4byte sTentacoolPose213
+.4byte sTentacoolPose214
+.4byte sTentacoolPose215
+.4byte sTentacoolPose216
+.4byte sTentacoolPose217
+.4byte sTentacoolPose218
+.4byte sTentacoolPose219
+.4byte sTentacoolPose220
+.4byte sTentacoolPose221
+.4byte sTentacoolPose222
+.4byte sTentacoolPose223
+.4byte sTentacoolPose224
+.4byte sTentacoolPose225
+.4byte sTentacoolPose226
+.4byte sTentacoolPose227
+.4byte sTentacoolPose228
+.4byte sTentacoolPose229
+.4byte sTentacoolPose230
+.4byte sTentacoolPose231
+.4byte sTentacoolPose232
+.4byte sTentacoolPose233
+.4byte sTentacoolPose234
+sAxPositionsTentacool:
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -1, 	   3,   -1, 	   0,  -12
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+.2byte    4,   -5, 	   2,   -5, 	  -6,   -1, 	   1,  -11
+.2byte    4,   -7, 	   1,   -6, 	  -4,   -2, 	   1,  -13
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    7,   -8, 	   1,   -4, 	  -2,    1, 	   0,  -10
+.2byte    7,  -10, 	   0,   -4, 	  -3,   -1, 	   0,  -12
+.2byte    4,  -10, 	  -4,   -1, 	   1,    2, 	   0,  -12
+.2byte    3,   -9, 	  -7,   -5, 	   2,    0, 	  -1,  -11
+.2byte    3,  -11, 	  -3,   -3, 	   0,   -1, 	  -1,  -13
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    0,   -8, 	   6,   -2, 	  -6,   -2, 	   0,  -11
+.2byte    0,  -10, 	   3,   -2, 	  -3,   -2, 	   0,  -13
+.2byte   -4,  -10, 	   4,   -1, 	  -1,    2, 	   0,  -12
+.2byte   -3,   -9, 	   7,   -5, 	  -2,    0, 	   1,  -11
+.2byte   -3,  -11, 	   3,   -3, 	   0,   -1, 	   1,  -13
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -7,   -8, 	  -1,   -4, 	   2,    1, 	   0,  -10
+.2byte   -7,  -10, 	   0,   -4, 	   3,   -1, 	   0,  -12
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -4,   -5, 	  -2,   -5, 	   6,   -1, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	   4,   -2, 	  -1,  -13
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -1, 	   3,   -1, 	   0,  -12
+.2byte    0,   -5, 	  -6,  -20, 	   6,  -20, 	   0,   -8
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+.2byte    4,   -5, 	   2,   -5, 	  -6,   -1, 	   1,  -11
+.2byte    4,   -7, 	   1,   -6, 	  -4,   -2, 	   1,  -13
+.2byte    0,   -4, 	  -2,  -17, 	 -10,  -14, 	   2,   -7
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    7,   -8, 	   1,   -4, 	  -2,    1, 	   0,  -10
+.2byte    7,   -8, 	   0,   -2, 	  -3,    1, 	   0,  -10
+.2byte   -1,   -5, 	 -16,  -13, 	 -17,   -8, 	   0,  -11
+.2byte    4,  -10, 	  -4,   -1, 	   1,    2, 	   0,  -12
+.2byte    3,   -9, 	  -7,   -5, 	   2,    0, 	  -1,  -11
+.2byte    3,   -9, 	  -3,   -1, 	   0,    1, 	  -1,  -11
+.2byte    3,   -7, 	  -8,   -5, 	   1,    1, 	   6,  -13
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    0,   -8, 	   6,   -2, 	  -6,   -2, 	   0,  -11
+.2byte    0,   -8, 	   3,    0, 	  -3,    0, 	   0,  -11
+.2byte    0,   -5, 	   8,    3, 	  -8,    3, 	   0,  -10
+.2byte   -4,  -10, 	   4,   -1, 	  -1,    2, 	   0,  -12
+.2byte   -3,   -9, 	   7,   -5, 	  -2,    0, 	   1,  -11
+.2byte   -3,   -9, 	   3,   -1, 	   0,    1, 	   1,  -11
+.2byte   -1,   -7, 	  10,   -5, 	   1,    1, 	  -4,  -13
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -7,   -8, 	  -1,   -4, 	   2,    1, 	   0,  -10
+.2byte   -7,   -8, 	   0,   -2, 	   3,    1, 	   0,  -10
+.2byte   -2,   -5, 	  13,  -13, 	  14,   -8, 	  -3,  -11
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -4,   -5, 	  -2,   -5, 	   6,   -1, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	   4,   -2, 	  -1,  -13
+.2byte    0,   -4, 	   2,  -17, 	  10,  -14, 	  -2,   -7
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -1, 	   3,   -1, 	   0,  -12
+.2byte    0,   -7, 	  -9,  -15, 	   9,  -15, 	   0,  -14
+.2byte    0,   -3, 	  -4,    4, 	   4,    4, 	   0,  -10
+.2byte    0,   -3, 	  -4,    4, 	   4,    4, 	   0,  -10
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+.2byte    4,   -5, 	   2,   -5, 	  -6,   -1, 	   1,  -11
+.2byte    4,   -7, 	   1,   -6, 	  -4,   -2, 	   1,  -13
+.2byte    4,   -8, 	   7,  -17, 	  -9,  -12, 	   0,  -14
+.2byte    3,   -4, 	   8,    2, 	   2,    4, 	   0,   -9
+.2byte    3,   -4, 	   8,    2, 	   2,    4, 	   0,   -9
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    7,   -8, 	   1,   -4, 	  -2,    1, 	   0,  -10
+.2byte    7,  -10, 	   0,   -4, 	  -3,   -1, 	   0,  -12
+.2byte    7,  -11, 	  -7,  -17, 	  -8,   -9, 	   0,  -14
+.2byte    5,   -7, 	   9,   -1, 	   7,    2, 	   1,  -12
+.2byte    5,   -7, 	   9,   -1, 	   7,    2, 	   1,  -12
+.2byte    5,  -10, 	  -3,   -1, 	   2,    2, 	   1,  -12
+.2byte    3,   -9, 	  -7,   -5, 	   2,    0, 	  -1,  -11
+.2byte    3,  -11, 	  -3,   -3, 	   0,   -1, 	  -1,  -13
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -8, 	   0,  -13
+.2byte    3,   -8, 	   4,   -4, 	  11,   -2, 	   2,  -13
+.2byte    3,   -8, 	   4,   -4, 	  11,   -2, 	   2,  -13
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    0,   -8, 	   6,   -2, 	  -6,   -2, 	   0,  -11
+.2byte    0,  -10, 	   3,   -2, 	  -3,   -2, 	   0,  -13
+.2byte    0,  -12, 	  10,  -10, 	 -10,  -10, 	   0,  -11
+.2byte    0,   -9, 	   6,   -4, 	  -6,   -4, 	   0,  -14
+.2byte    0,   -9, 	   6,   -4, 	  -6,   -4, 	   0,  -14
+.2byte   -3,  -10, 	   5,   -1, 	   0,    2, 	   1,  -12
+.2byte   -3,   -9, 	   7,   -5, 	  -2,    0, 	   1,  -11
+.2byte   -3,  -11, 	   3,   -3, 	   0,   -1, 	   1,  -13
+.2byte   -3,  -12, 	  11,  -14, 	  -1,   -8, 	   2,  -13
+.2byte   -1,   -8, 	  -2,   -4, 	  -9,   -2, 	   0,  -13
+.2byte   -1,   -8, 	  -2,   -4, 	  -9,   -2, 	   0,  -13
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -7,   -8, 	  -1,   -4, 	   2,    1, 	   0,  -10
+.2byte   -7,  -10, 	   0,   -4, 	   3,   -1, 	   0,  -12
+.2byte   -7,  -11, 	   7,  -17, 	   8,   -9, 	   0,  -14
+.2byte   -5,   -7, 	  -9,   -1, 	  -7,    2, 	  -1,  -12
+.2byte   -5,   -7, 	  -9,   -1, 	  -7,    2, 	  -1,  -12
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -4,   -5, 	  -2,   -5, 	   6,   -1, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	   4,   -2, 	  -1,  -13
+.2byte   -4,   -8, 	  -7,  -17, 	   9,  -12, 	   0,  -14
+.2byte   -3,   -4, 	  -8,    2, 	  -2,    4, 	   0,   -9
+.2byte   -3,   -4, 	  -8,    2, 	  -2,    4, 	   0,   -9
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -1, 	   3,   -1, 	   0,  -12
+.2byte    0,   -7, 	  -9,  -15, 	   9,  -15, 	   0,  -14
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+.2byte    4,   -5, 	   2,   -5, 	  -6,   -1, 	   1,  -11
+.2byte    4,   -7, 	   1,   -6, 	  -4,   -2, 	   1,  -13
+.2byte    4,   -8, 	   7,  -17, 	  -9,  -12, 	   0,  -14
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    7,  -10, 	   1,   -6, 	  -2,   -1, 	   0,  -12
+.2byte    7,  -10, 	   0,   -4, 	  -3,   -1, 	   0,  -12
+.2byte    7,  -11, 	  -7,  -17, 	  -8,   -9, 	   0,  -14
+.2byte    5,  -10, 	  -3,   -1, 	   2,    2, 	   1,  -12
+.2byte    3,  -11, 	  -7,   -7, 	   2,   -2, 	  -1,  -13
+.2byte    3,  -11, 	  -3,   -3, 	   0,   -1, 	  -1,  -13
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -8, 	   0,  -13
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    0,   -8, 	   6,   -2, 	  -6,   -2, 	   0,  -11
+.2byte    0,  -10, 	   3,   -2, 	  -3,   -2, 	   0,  -13
+.2byte    0,  -12, 	  10,  -10, 	 -10,  -10, 	   0,  -11
+.2byte   -3,  -10, 	   5,   -1, 	   0,    2, 	   1,  -12
+.2byte   -3,  -11, 	   7,   -7, 	  -2,   -2, 	   1,  -13
+.2byte   -3,  -11, 	   3,   -3, 	   0,   -1, 	   1,  -13
+.2byte   -3,  -12, 	  11,  -14, 	  -1,   -8, 	   2,  -13
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -7,  -10, 	  -1,   -6, 	   2,   -1, 	   0,  -12
+.2byte   -7,  -10, 	   0,   -4, 	   3,   -1, 	   0,  -12
+.2byte   -7,  -11, 	   7,  -17, 	   8,   -9, 	   0,  -14
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -4,   -5, 	  -2,   -5, 	   6,   -1, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	   4,   -2, 	  -1,  -13
+.2byte   -4,   -8, 	  -7,  -17, 	   9,  -12, 	   0,  -14
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -4,  -10, 	   4,   -1, 	  -1,    2, 	   0,  -12
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    4,  -10, 	  -4,   -1, 	   1,    2, 	   0,  -12
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+.2byte   -2,   -5, 	  -7,  -12, 	  -5,   -5, 	   1,  -11
+.2byte   -4,   -8, 	   2,  -10, 	  -7,   -6, 	   0,  -11
+.2byte   -3,   -9, 	  11,   -7, 	  -5,   -9, 	   1,  -13
+.2byte    1,  -10, 	  14,   -5, 	   1,  -14, 	   2,  -13
+.2byte    5,   -9, 	   8,    1, 	   9,   -9, 	   0,  -12
+.2byte    1,  -10, 	 -12,   -5, 	   1,  -14, 	   0,  -13
+.2byte    3,   -9, 	 -11,   -7, 	   5,   -9, 	  -1,  -13
+.2byte    4,   -8, 	  -2,  -10, 	   7,   -6, 	   0,  -11
+.2byte   -4,    1, 	 -10,   -6, 	  12,    2, 	   0,   -6
+.2byte   -4,    2, 	 -11,   -6, 	  12,    3, 	   0,   -4
+.2byte   -1,  -11, 	   5,  -19, 	  -8,  -20, 	  -1,  -16
+.2byte    3,  -10, 	  -6,  -20, 	   7,  -22, 	  -1,  -15
+.2byte    6,  -12, 	   1,  -16, 	   6,  -21, 	  -1,  -14
+.2byte    4,  -14, 	   7,  -21, 	  -4,  -24, 	  -1,  -13
+.2byte   -1,  -11, 	  -8,  -22, 	   6,  -23, 	  -1,  -12
+.2byte   -5,  -14, 	  -8,  -21, 	   3,  -24, 	   0,  -13
+.2byte   -7,  -12, 	  -2,  -16, 	  -7,  -21, 	   0,  -14
+.2byte   -4,  -10, 	   5,  -20, 	  -8,  -22, 	   0,  -15
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -4, 	  -7,    0, 	   7,    0, 	   0,  -10
+.2byte    0,   -6, 	  -3,   -1, 	   3,   -1, 	   0,  -12
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+.2byte    4,   -5, 	   2,   -5, 	  -6,   -1, 	   1,  -11
+.2byte    4,   -7, 	   1,   -6, 	  -4,   -2, 	   1,  -13
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    7,   -8, 	   1,   -4, 	  -2,    1, 	   0,  -10
+.2byte    7,  -10, 	   0,   -4, 	  -3,   -1, 	   0,  -12
+.2byte    4,  -10, 	  -4,   -1, 	   1,    2, 	   0,  -12
+.2byte    3,   -9, 	  -7,   -5, 	   2,    0, 	  -1,  -11
+.2byte    3,  -11, 	  -3,   -3, 	   0,   -1, 	  -1,  -13
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    0,   -8, 	   6,   -2, 	  -6,   -2, 	   0,  -11
+.2byte    0,  -10, 	   3,   -2, 	  -3,   -2, 	   0,  -13
+.2byte   -4,  -10, 	   4,   -1, 	  -1,    2, 	   0,  -12
+.2byte   -3,   -9, 	   7,   -5, 	  -2,    0, 	   1,  -11
+.2byte   -3,  -11, 	   3,   -3, 	   0,   -1, 	   1,  -13
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -7,   -8, 	  -1,   -4, 	   2,    1, 	   0,  -10
+.2byte   -7,  -10, 	   0,   -4, 	   3,   -1, 	   0,  -12
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -4,   -5, 	  -2,   -5, 	   6,   -1, 	  -1,  -11
+.2byte   -4,   -7, 	  -1,   -6, 	   4,   -2, 	  -1,  -13
+.2byte    0,   -5, 	  -6,  -20, 	   6,  -20, 	   0,   -8
+.2byte    0,   -6, 	   2,  -19, 	  10,  -16, 	  -2,   -9
+.2byte   -2,   -5, 	  13,  -13, 	  14,   -8, 	  -3,  -11
+.2byte    0,   -7, 	  11,   -5, 	   2,    1, 	  -3,  -13
+.2byte    0,   -6, 	   8,    2, 	  -8,    2, 	   0,  -11
+.2byte   -1,   -7, 	 -12,   -5, 	  -3,    1, 	   2,  -13
+.2byte    1,   -5, 	 -14,  -13, 	 -15,   -8, 	   2,  -11
+.2byte    1,   -6, 	  -1,  -19, 	  -9,  -16, 	   3,   -9
+.2byte    0,   -7, 	  -9,  -15, 	   9,  -15, 	   0,  -14
+.2byte    4,   -9, 	   7,  -18, 	  -9,  -13, 	   0,  -15
+.2byte    7,  -11, 	  -7,  -17, 	  -8,   -9, 	   0,  -14
+.2byte    4,  -12, 	 -10,  -14, 	   2,   -8, 	  -1,  -13
+.2byte    0,  -13, 	  10,  -11, 	 -10,  -11, 	   0,  -12
+.2byte   -4,  -12, 	  10,  -14, 	  -2,   -8, 	   1,  -13
+.2byte   -7,  -11, 	   7,  -17, 	   8,   -9, 	   0,  -14
+.2byte   -4,   -9, 	  -7,  -18, 	   9,  -13, 	   0,  -15
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte    0,   -7, 	  -9,  -15, 	   9,  -15, 	   0,  -14
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+.2byte    4,   -8, 	   7,  -17, 	  -9,  -12, 	   0,  -14
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    7,  -11, 	  -7,  -17, 	  -8,   -9, 	   0,  -14
+.2byte    5,  -10, 	  -3,   -1, 	   2,    2, 	   1,  -12
+.2byte    5,  -12, 	  -9,  -14, 	   3,   -8, 	   0,  -13
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    0,  -13, 	  10,  -11, 	 -10,  -11, 	   0,  -12
+.2byte   -3,  -10, 	   5,   -1, 	   0,    2, 	   1,  -12
+.2byte   -3,  -12, 	  11,  -14, 	  -1,   -8, 	   2,  -13
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -7,  -11, 	   7,  -17, 	   8,   -9, 	   0,  -14
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -4,   -8, 	  -7,  -17, 	   9,  -12, 	   0,  -14
+.2byte    0,   -3, 	  -4,    4, 	   4,    4, 	   0,  -10
+.2byte   -3,   -4, 	  -8,    2, 	  -2,    4, 	   0,   -9
+.2byte   -5,   -7, 	  -9,   -1, 	  -7,    2, 	  -1,  -12
+.2byte   -1,   -8, 	  -2,   -4, 	  -9,   -2, 	   0,  -13
+.2byte    0,   -9, 	   6,   -4, 	  -6,   -4, 	   0,  -14
+.2byte    3,   -8, 	   4,   -4, 	  11,   -2, 	   2,  -13
+.2byte    5,   -7, 	   9,   -1, 	   7,    2, 	   1,  -12
+.2byte    3,   -4, 	   8,    2, 	   2,    4, 	   0,   -9
+.2byte    0,   -5, 	  -5,    0, 	   5,    0, 	   0,  -11
+.2byte   -4,   -6, 	  -2,   -3, 	   5,    1, 	  -1,  -12
+.2byte   -7,   -9, 	   0,   -3, 	   3,    2, 	   0,  -11
+.2byte   -4,  -10, 	   4,   -1, 	  -1,    2, 	   0,  -12
+.2byte    0,   -9, 	   5,   -1, 	  -5,   -1, 	   0,  -12
+.2byte    4,  -10, 	  -4,   -1, 	   1,    2, 	   0,  -12
+.2byte    7,   -9, 	   0,   -3, 	  -3,    2, 	   0,  -11
+.2byte    4,   -6, 	   2,   -3, 	  -5,    1, 	   1,  -12
+sTentacoolAnimTable1:
+.4byte sTentacoolAnims_1_1
+.4byte sTentacoolAnims_1_2
+.4byte sTentacoolAnims_1_3
+.4byte sTentacoolAnims_1_4
+.4byte sTentacoolAnims_1_5
+.4byte sTentacoolAnims_1_6
+.4byte sTentacoolAnims_1_7
+.4byte sTentacoolAnims_1_8
+sTentacoolAnimTable2:
+.4byte sTentacoolAnims_2_1
+.4byte sTentacoolAnims_2_2
+.4byte sTentacoolAnims_2_3
+.4byte sTentacoolAnims_2_4
+.4byte sTentacoolAnims_2_5
+.4byte sTentacoolAnims_2_6
+.4byte sTentacoolAnims_2_7
+.4byte sTentacoolAnims_2_8
+sTentacoolAnimTable3:
+.4byte sTentacoolAnims_3_1
+.4byte sTentacoolAnims_3_2
+.4byte sTentacoolAnims_3_3
+.4byte sTentacoolAnims_3_4
+.4byte sTentacoolAnims_3_5
+.4byte sTentacoolAnims_3_6
+.4byte sTentacoolAnims_3_7
+.4byte sTentacoolAnims_3_8
+sTentacoolAnimTable4:
+.4byte sTentacoolAnims_4_1
+.4byte sTentacoolAnims_4_2
+.4byte sTentacoolAnims_4_3
+.4byte sTentacoolAnims_4_4
+.4byte sTentacoolAnims_4_5
+.4byte sTentacoolAnims_4_6
+.4byte sTentacoolAnims_4_7
+.4byte sTentacoolAnims_4_8
+sTentacoolAnimTable5:
+.4byte sTentacoolAnims_5_1
+.4byte sTentacoolAnims_5_2
+.4byte sTentacoolAnims_5_3
+.4byte sTentacoolAnims_5_4
+.4byte sTentacoolAnims_5_5
+.4byte sTentacoolAnims_5_6
+.4byte sTentacoolAnims_5_7
+.4byte sTentacoolAnims_5_8
+sTentacoolAnimTable6:
+.4byte sTentacoolAnims_6_1
+.4byte sTentacoolAnims_6_1
+.4byte sTentacoolAnims_6_1
+.4byte sTentacoolAnims_6_1
+.4byte sTentacoolAnims_6_1
+.4byte sTentacoolAnims_6_1
+.4byte sTentacoolAnims_6_1
+.4byte sTentacoolAnims_6_1
+sTentacoolAnimTable7:
+.4byte sTentacoolAnims_7_1
+.4byte sTentacoolAnims_7_2
+.4byte sTentacoolAnims_7_3
+.4byte sTentacoolAnims_7_4
+.4byte sTentacoolAnims_7_5
+.4byte sTentacoolAnims_7_6
+.4byte sTentacoolAnims_7_7
+.4byte sTentacoolAnims_7_8
+sTentacoolAnimTable8:
+.4byte sTentacoolAnims_8_1
+.4byte sTentacoolAnims_8_2
+.4byte sTentacoolAnims_8_3
+.4byte sTentacoolAnims_8_4
+.4byte sTentacoolAnims_8_5
+.4byte sTentacoolAnims_8_6
+.4byte sTentacoolAnims_8_7
+.4byte sTentacoolAnims_8_8
+sTentacoolAnimTable9:
+.4byte sTentacoolAnims_9_1
+.4byte sTentacoolAnims_9_2
+.4byte sTentacoolAnims_9_3
+.4byte sTentacoolAnims_9_4
+.4byte sTentacoolAnims_9_5
+.4byte sTentacoolAnims_9_6
+.4byte sTentacoolAnims_9_7
+.4byte sTentacoolAnims_9_8
+sTentacoolAnimTable10:
+.4byte sTentacoolAnims_10_1
+.4byte sTentacoolAnims_10_2
+.4byte sTentacoolAnims_10_3
+.4byte sTentacoolAnims_10_4
+.4byte sTentacoolAnims_10_5
+.4byte sTentacoolAnims_10_6
+.4byte sTentacoolAnims_10_7
+.4byte sTentacoolAnims_10_8
+sTentacoolAnimTable11:
+.4byte sTentacoolAnims_11_1
+.4byte sTentacoolAnims_11_2
+.4byte sTentacoolAnims_11_3
+.4byte sTentacoolAnims_11_4
+.4byte sTentacoolAnims_11_5
+.4byte sTentacoolAnims_11_6
+.4byte sTentacoolAnims_11_7
+.4byte sTentacoolAnims_11_8
+sTentacoolAnimTable12:
+.4byte sTentacoolAnims_12_1
+.4byte sTentacoolAnims_12_2
+.4byte sTentacoolAnims_12_3
+.4byte sTentacoolAnims_12_4
+.4byte sTentacoolAnims_12_5
+.4byte sTentacoolAnims_12_6
+.4byte sTentacoolAnims_12_7
+.4byte sTentacoolAnims_12_8
+sTentacoolAnimTable13:
+.4byte sTentacoolAnims_13_1
+.4byte sTentacoolAnims_13_2
+.4byte sTentacoolAnims_13_3
+.4byte sTentacoolAnims_13_4
+.4byte sTentacoolAnims_13_5
+.4byte sTentacoolAnims_13_6
+.4byte sTentacoolAnims_13_7
+.4byte sTentacoolAnims_13_8
+sAxAnimationsTentacool:
+.4byte sTentacoolAnimTable1
+.4byte sTentacoolAnimTable2
+.4byte sTentacoolAnimTable3
+.4byte sTentacoolAnimTable4
+.4byte sTentacoolAnimTable5
+.4byte sTentacoolAnimTable6
+.4byte sTentacoolAnimTable7
+.4byte sTentacoolAnimTable8
+.4byte sTentacoolAnimTable9
+.4byte sTentacoolAnimTable10
+.4byte sTentacoolAnimTable11
+.4byte sTentacoolAnimTable12
+.4byte sTentacoolAnimTable13
+sAxSpritesTentacool:
+.4byte sTentacoolSprites1
+.4byte sTentacoolSprites2
+.4byte sTentacoolSprites3
+.4byte sTentacoolSprites4
+.4byte sTentacoolSprites5
+.4byte sTentacoolSprites6
+.4byte sTentacoolSprites7
+.4byte sTentacoolSprites8
+.4byte sTentacoolSprites9
+.4byte sTentacoolSprites10
+.4byte sTentacoolSprites11
+.4byte sTentacoolSprites12
+.4byte sTentacoolSprites13
+.4byte sTentacoolSprites14
+.4byte sTentacoolSprites15
+.4byte sTentacoolSprites16
+.4byte sTentacoolSprites17
+.4byte sTentacoolSprites18
+.4byte sTentacoolSprites19
+.4byte sTentacoolSprites20
+.4byte sTentacoolSprites21
+.4byte sTentacoolSprites22
+.4byte sTentacoolSprites23
+.4byte sTentacoolSprites24
+.4byte sTentacoolSprites25
+.4byte sTentacoolSprites26
+.4byte sTentacoolSprites27
+.4byte sTentacoolSprites28
+.4byte sTentacoolSprites29
+.4byte sTentacoolSprites30
+.4byte sTentacoolSprites31
+.4byte sTentacoolSprites32
+.4byte sTentacoolSprites33
+.4byte sTentacoolSprites34
+.4byte sTentacoolSprites35
+.4byte sTentacoolSprites36
+.4byte sTentacoolSprites37
+.4byte sTentacoolSprites38
+.4byte sTentacoolSprites39
+.4byte sTentacoolSprites40
+.4byte sTentacoolSprites41
+.4byte sTentacoolSprites42
+.4byte sTentacoolSprites43
+.4byte sTentacoolSprites44
+.4byte sTentacoolSprites45
+.4byte sTentacoolSprites46
+.4byte sTentacoolSprites47
+sAxMainTentacool:
+ax_main sAxPosesTentacool, sAxAnimationsTentacool, 13, sAxSpritesTentacool, sAxPositionsTentacool

--- a/data/ax/tentacruel.inc
+++ b/data/ax/tentacruel.inc
@@ -1,0 +1,2791 @@
+.global gAxTentacruel
+gAxTentacruel:
+ax_siro sAxMainTentacruel
+sTentacruelPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose4:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose5:
+ax_pose 4, 0x01ec, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose6:
+ax_pose 5, 0x01ea, 0x90f1, 0x1c00
+ax_pose_terminator
+sTentacruelPose7:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose8:
+ax_pose 7, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose9:
+ax_pose 8, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose10:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose11:
+ax_pose 10, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose12:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacruelPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose16:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose17:
+ax_pose 10, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose18:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose19:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose20:
+ax_pose 7, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose21:
+ax_pose 8, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose22:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose23:
+ax_pose 4, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose24:
+ax_pose 5, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sTentacruelPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose28:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose29:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose30:
+ax_pose 4, 0x01ec, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose31:
+ax_pose 5, 0x01ea, 0x90f1, 0x1c00
+ax_pose_terminator
+sTentacruelPose32:
+ax_pose 16, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose33:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose34:
+ax_pose 7, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose35:
+ax_pose 8, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose36:
+ax_pose 17, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose37:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose38:
+ax_pose 10, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose39:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacruelPose40:
+ax_pose 18, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose41:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose42:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose43:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose44:
+ax_pose 19, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose45:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose46:
+ax_pose 10, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose47:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose48:
+ax_pose 18, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose49:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose50:
+ax_pose 7, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose51:
+ax_pose 8, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose52:
+ax_pose 17, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose53:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose54:
+ax_pose 4, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose55:
+ax_pose 5, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sTentacruelPose56:
+ax_pose 16, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose57:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose58:
+ax_pose 1, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose59:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose60:
+ax_pose 20, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose61:
+ax_pose 21, 0x01eb, 0x80f2, 0x1c00
+ax_pose 22, 0x01eb, 0x80f3, 0x1c10
+ax_pose_terminator
+sTentacruelPose62:
+ax_pose 22, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose63:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose64:
+ax_pose 4, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose65:
+ax_pose 5, 0x01ea, 0x90f1, 0x1c00
+ax_pose_terminator
+sTentacruelPose66:
+ax_pose 23, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose67:
+ax_pose 24, 0x01e9, 0x90f2, 0x1c00
+ax_pose 25, 0x01ea, 0x90ee, 0x1c10
+ax_pose_terminator
+sTentacruelPose68:
+ax_pose 25, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose69:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose70:
+ax_pose 7, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose71:
+ax_pose 8, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose72:
+ax_pose 26, 0x01e9, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose73:
+ax_pose 27, 0x01ea, 0x90f4, 0x1c00
+ax_pose 28, 0x01ea, 0x90ee, 0x1c10
+ax_pose_terminator
+sTentacruelPose74:
+ax_pose 28, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose75:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose76:
+ax_pose 10, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose77:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacruelPose78:
+ax_pose 29, 0x01e8, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose79:
+ax_pose 30, 0x01e6, 0x90f0, 0x1c00
+ax_pose 31, 0x01e8, 0x90ee, 0x1c10
+ax_pose_terminator
+sTentacruelPose80:
+ax_pose 31, 0x01e8, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose81:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose82:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose83:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose84:
+ax_pose 32, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose85:
+ax_pose 33, 0x01e8, 0x80f3, 0x1c00
+ax_pose 34, 0x01ea, 0x80f4, 0x1c10
+ax_pose_terminator
+sTentacruelPose86:
+ax_pose 34, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose87:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose88:
+ax_pose 10, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose89:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose90:
+ax_pose 29, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose91:
+ax_pose 30, 0x01e6, 0x80f1, 0x1c00
+ax_pose 31, 0x01e8, 0x80f3, 0x1c10
+ax_pose_terminator
+sTentacruelPose92:
+ax_pose 31, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose93:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose94:
+ax_pose 7, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose95:
+ax_pose 8, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose96:
+ax_pose 26, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose97:
+ax_pose 27, 0x01ea, 0x80ed, 0x1c00
+ax_pose 28, 0x01ea, 0x80f3, 0x1c10
+ax_pose_terminator
+sTentacruelPose98:
+ax_pose 28, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose99:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose100:
+ax_pose 4, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose101:
+ax_pose 5, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sTentacruelPose102:
+ax_pose 23, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose103:
+ax_pose 24, 0x01e9, 0x80ef, 0x1c00
+ax_pose 25, 0x01ea, 0x80f3, 0x1c10
+ax_pose_terminator
+sTentacruelPose104:
+ax_pose 25, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose105:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose106:
+ax_pose 20, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose107:
+ax_pose 22, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose108:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose109:
+ax_pose 23, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose110:
+ax_pose 25, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose111:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose112:
+ax_pose 26, 0x01e9, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose113:
+ax_pose 28, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose114:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose115:
+ax_pose 29, 0x01e8, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose116:
+ax_pose 31, 0x01e8, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose117:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose118:
+ax_pose 32, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose119:
+ax_pose 34, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose120:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose121:
+ax_pose 29, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose122:
+ax_pose 31, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose123:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose124:
+ax_pose 26, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose125:
+ax_pose 28, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose126:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose127:
+ax_pose 23, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose128:
+ax_pose 25, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose129:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose130:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose131:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose132:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose133:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose134:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose135:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose136:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose137:
+ax_pose 35, 0x01ed, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose138:
+ax_pose 36, 0x01ed, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose139:
+ax_pose 37, 0x01de, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose140:
+ax_pose 38, 0x01df, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacruelPose141:
+ax_pose 39, 0x01de, 0x90ec, 0x1c00
+ax_pose_terminator
+sTentacruelPose142:
+ax_pose 40, 0x01e2, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose143:
+ax_pose 41, 0x01df, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose144:
+ax_pose 40, 0x01e2, 0x80f2, 0x1c00
+ax_pose_terminator
+sTentacruelPose145:
+ax_pose 39, 0x01de, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose146:
+ax_pose 38, 0x01df, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose147:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose148:
+ax_pose 1, 0x01ec, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose149:
+ax_pose 2, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose150:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose151:
+ax_pose 4, 0x01ec, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose152:
+ax_pose 5, 0x01ea, 0x90f1, 0x1c00
+ax_pose_terminator
+sTentacruelPose153:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose154:
+ax_pose 7, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose155:
+ax_pose 8, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose156:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose157:
+ax_pose 10, 0x01eb, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose158:
+ax_pose 11, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacruelPose159:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose160:
+ax_pose 13, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose161:
+ax_pose 14, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose162:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose163:
+ax_pose 10, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose164:
+ax_pose 11, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose165:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose166:
+ax_pose 7, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose167:
+ax_pose 8, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose168:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose169:
+ax_pose 4, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose170:
+ax_pose 5, 0x01ea, 0x80f0, 0x1c00
+ax_pose_terminator
+sTentacruelPose171:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose172:
+ax_pose 16, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose173:
+ax_pose 17, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose174:
+ax_pose 18, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose175:
+ax_pose 19, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose176:
+ax_pose 18, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose177:
+ax_pose 17, 0x01e8, 0x90ec, 0x1c00
+ax_pose_terminator
+sTentacruelPose178:
+ax_pose 16, 0x01ec, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose179:
+ax_pose 20, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose180:
+ax_pose 23, 0x01ea, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacruelPose181:
+ax_pose 26, 0x01e7, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose182:
+ax_pose 29, 0x01e7, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose183:
+ax_pose 32, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose184:
+ax_pose 29, 0x01e7, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose185:
+ax_pose 26, 0x01e7, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose186:
+ax_pose 23, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose187:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose188:
+ax_pose 20, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose189:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose190:
+ax_pose 23, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose191:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose192:
+ax_pose 26, 0x01e9, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose193:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose194:
+ax_pose 29, 0x01e8, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose195:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose196:
+ax_pose 32, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose197:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose198:
+ax_pose 29, 0x01e8, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose199:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose200:
+ax_pose 26, 0x01e9, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose201:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose202:
+ax_pose 23, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose203:
+ax_pose 22, 0x01eb, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose204:
+ax_pose 25, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose205:
+ax_pose 28, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose206:
+ax_pose 31, 0x01e8, 0x80f2, 0x1c00
+ax_pose_terminator
+sTentacruelPose207:
+ax_pose 34, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose208:
+ax_pose 31, 0x01e8, 0x90ef, 0x1c00
+ax_pose_terminator
+sTentacruelPose209:
+ax_pose 28, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose210:
+ax_pose 25, 0x01eb, 0x90ed, 0x1c00
+ax_pose_terminator
+sTentacruelPose211:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose212:
+ax_pose 3, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose213:
+ax_pose 6, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose214:
+ax_pose 9, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sTentacruelPose215:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sTentacruelPose216:
+ax_pose 9, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose217:
+ax_pose 6, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+sTentacruelPose218:
+ax_pose 3, 0x01ea, 0x90ee, 0x1c00
+ax_pose_terminator
+.align 2
+sTentacruelAnims_1_1:
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 10, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 10, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_1_2:
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 10, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_1_3:
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_1_4:
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 10, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_1_5:
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_1_6:
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 10, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_1_7:
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 10, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_1_8:
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 10, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 4, 0, 26, 0, -3, 0, -3,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 5, 0, 5,
+ax_anim 1, 0, 27, 0, 12, 0, 12,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, -1, 20, -1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, -1, 20, -1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 0, 12, 0, 12,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sTentacruelAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 28, -3, -3, -3, -3,
+ax_anim 4, 0, 30, -4, -3, -4, -4,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 5, 5, 5, 5,
+ax_anim 1, 0, 31, 11, 13, 11, 13,
+ax_anim 2, 0, 31, 18, 22, 18, 22,
+ax_anim 2, 1, 31, 17, 23, 17, 23,
+ax_anim 2, 0, 31, 18, 22, 18, 22,
+ax_anim 2, 0, 31, 17, 23, 17, 23,
+ax_anim 2, 0, 31, 18, 22, 18, 22,
+ax_anim 2, 0, 28, 11, 13, 11, 13,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim_terminator
+sTentacruelAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 2, 0, 33, -2, 0, -2, 0,
+ax_anim 2, 0, 32, -3, 0, -3, 0,
+ax_anim 4, 0, 34, -4, 0, -4, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 5, 0, 5, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 32, 12, 0, 12, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sTentacruelAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 2, 0, 37, -2, 2, -2, 2,
+ax_anim 2, 0, 36, -3, 3, -3, 3,
+ax_anim 4, 0, 38, -4, 3, -3, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 39, 5, -6, 5, -6,
+ax_anim 1, 0, 39, 13, -14, 13, -14,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 1, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 36, 12, -13, 12, -13,
+ax_anim 2, 0, 36, 4, -5, 4, -5,
+ax_anim_terminator
+sTentacruelAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 2, 0, 41, 0, 2, 0, 2,
+ax_anim 2, 0, 40, 0, 4, 0, 3,
+ax_anim 4, 0, 42, 0, 4, 0, 3,
+ax_anim 1, 0, 40, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -5, 0, -5,
+ax_anim 1, 0, 43, 0, -12, 0, -12,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 1, 43, -1, -20, -1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 43, -1, -20, -1, -20,
+ax_anim 2, 0, 43, 0, -20, 0, -20,
+ax_anim 2, 0, 40, 0, -12, 0, -12,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim_terminator
+sTentacruelAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 2, 0, 45, 2, 2, 2, 2,
+ax_anim 2, 0, 44, 3, 3, 3, 3,
+ax_anim 4, 0, 46, 4, 3, 3, 3,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -5, -6, -5, -6,
+ax_anim 1, 0, 47, -13, -14, -13, -14,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 1, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 44, -12, -13, -12, -13,
+ax_anim 2, 0, 44, -4, -5, -4, -5,
+ax_anim_terminator
+sTentacruelAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 2, 0, 49, 2, 0, 2, 0,
+ax_anim 2, 0, 48, 3, 0, 3, 0,
+ax_anim 4, 0, 50, 4, 0, 4, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -5, 0, -5, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 48, -12, 0, -12, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sTentacruelAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 0, 52, 3, -3, 3, -3,
+ax_anim 4, 0, 54, 4, -3, 4, -4,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -5, 5, -5, 5,
+ax_anim 1, 0, 55, -11, 13, -11, 13,
+ax_anim 2, 0, 55, -18, 22, -18, 22,
+ax_anim 2, 1, 55, -17, 23, -17, 23,
+ax_anim 2, 0, 55, -18, 22, -18, 22,
+ax_anim 2, 0, 55, -17, 23, -17, 23,
+ax_anim 2, 0, 55, -18, 22, -18, 22,
+ax_anim 2, 0, 52, -11, 13, -11, 13,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_3_1:
+ax_anim 2, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 57, 0, -4, 0, -4,
+ax_anim 4, 0, 59, 0, -4, 0, -4,
+ax_anim 1, 2, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 59, 0, 4, 0, 4,
+ax_anim 2, 0, 60, 0, 15, 0, 15,
+ax_anim 2, 1, 61, -1, 15, -1, 15,
+ax_anim 2, 0, 61, 0, 15, 0, 15,
+ax_anim 2, 0, 61, -1, 15, -1, 15,
+ax_anim 2, 0, 61, 0, 15, 0, 15,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sTentacruelAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim 4, 0, 65, -4, -4, -4, -4,
+ax_anim 1, 2, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 65, 4, 5, 4, 5,
+ax_anim 2, 0, 66, 14, 18, 14, 18,
+ax_anim 2, 1, 67, 13, 19, 13, 19,
+ax_anim 2, 0, 67, 14, 18, 14, 18,
+ax_anim 2, 0, 67, 13, 19, 13, 19,
+ax_anim 2, 0, 67, 14, 18, 14, 18,
+ax_anim 2, 0, 62, 9, 11, 9, 11,
+ax_anim 2, 0, 62, 3, 4, 3, 4,
+ax_anim_terminator
+sTentacruelAnims_3_3:
+ax_anim 2, 0, 68, -2, 0, -2, 0,
+ax_anim 2, 0, 69, -4, 0, -4, 0,
+ax_anim 4, 0, 71, -4, 0, -4, 0,
+ax_anim 1, 2, 71, 0, 0, 0, 0,
+ax_anim 1, 0, 71, 4, 0, 4, 0,
+ax_anim 2, 0, 72, 10, 0, 10, 0,
+ax_anim 2, 1, 73, 10, -1, 10, -1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 73, 10, -1, 10, -1,
+ax_anim 2, 0, 73, 10, 0, 10, 0,
+ax_anim 2, 0, 68, 6, 0, 6, 0,
+ax_anim 2, 0, 68, 2, 0, 2, 0,
+ax_anim_terminator
+sTentacruelAnims_3_4:
+ax_anim 2, 0, 74, -2, 2, -2, 2,
+ax_anim 2, 0, 75, -4, 4, -4, 4,
+ax_anim 4, 0, 77, -4, 4, -4, 4,
+ax_anim 1, 2, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 6, -7, 6, -7,
+ax_anim 2, 0, 78, 14, -16, 14, -16,
+ax_anim 2, 1, 79, 13, -16, 13, -16,
+ax_anim 2, 0, 79, 14, -15, 14, -15,
+ax_anim 2, 0, 79, 13, -16, 13, -16,
+ax_anim 2, 0, 79, 14, -15, 14, -15,
+ax_anim 2, 0, 74, 9, -11, 9, -11,
+ax_anim 2, 0, 74, 4, -5, 4, -5,
+ax_anim_terminator
+sTentacruelAnims_3_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 2, 0, 81, 0, 4, 0, 4,
+ax_anim 4, 0, 83, 0, 4, 0, 4,
+ax_anim 1, 2, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, -4, 0, -4,
+ax_anim 2, 0, 84, 0, -16, 0, -16,
+ax_anim 2, 1, 85, -1, -16, -1, -16,
+ax_anim 2, 0, 85, 0, -16, 0, -16,
+ax_anim 2, 0, 85, -1, -16, -1, -16,
+ax_anim 2, 0, 85, 0, -16, 0, -16,
+ax_anim 2, 0, 80, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim_terminator
+sTentacruelAnims_3_6:
+ax_anim 2, 0, 86, 2, 2, 2, 2,
+ax_anim 2, 0, 87, 4, 4, 4, 4,
+ax_anim 4, 0, 89, 4, 4, 4, 4,
+ax_anim 1, 2, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 89, -6, -7, -6, -7,
+ax_anim 2, 0, 90, -14, -16, -14, -16,
+ax_anim 2, 1, 91, -13, -16, -13, -16,
+ax_anim 2, 0, 91, -14, -15, -14, -15,
+ax_anim 2, 0, 91, -13, -16, -13, -16,
+ax_anim 2, 0, 91, -14, -15, -14, -15,
+ax_anim 2, 0, 86, -9, -11, -9, -11,
+ax_anim 2, 0, 86, -4, -5, -4, -5,
+ax_anim_terminator
+sTentacruelAnims_3_7:
+ax_anim 2, 0, 92, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 4, 0, 4, 0,
+ax_anim 4, 0, 95, 4, 0, 4, 0,
+ax_anim 1, 2, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -4, 0, -4, 0,
+ax_anim 2, 0, 96, -10, 0, -10, 0,
+ax_anim 2, 1, 97, -10, -1, -10, -1,
+ax_anim 2, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -10, -1, -10, -1,
+ax_anim 2, 0, 97, -10, 0, -10, 0,
+ax_anim 2, 0, 92, -6, 0, -6, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim_terminator
+sTentacruelAnims_3_8:
+ax_anim 2, 0, 98, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 4, 0, 101, 4, -4, 4, -4,
+ax_anim 1, 2, 101, 0, 0, 0, 0,
+ax_anim 1, 0, 101, -4, 5, -4, 5,
+ax_anim 2, 0, 102, -14, 18, -14, 18,
+ax_anim 2, 1, 103, -13, 19, -13, 19,
+ax_anim 2, 0, 103, -14, 18, -14, 18,
+ax_anim 2, 0, 103, -13, 19, -13, 19,
+ax_anim 2, 0, 103, -14, 18, -14, 18,
+ax_anim 2, 0, 98, -9, 11, -9, 11,
+ax_anim 2, 0, 98, -3, 4, -3, 4,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_4_1:
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -4, 0, -4,
+ax_anim 4, 0, 104, 0, -5, 0, -5,
+ax_anim 1, 2, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 4, 0, 4,
+ax_anim 2, 0, 106, 0, 4, 0, 4,
+ax_anim 2, 1, 105, 0, 4, 0, 4,
+ax_anim 2, 0, 106, 0, 4, 0, 4,
+ax_anim 2, 0, 105, 0, 4, 0, 4,
+ax_anim 2, 0, 106, 0, 4, 0, 4,
+ax_anim 2, 0, 105, 0, 4, 0, 4,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sTentacruelAnims_4_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 4, 0, 107, -5, -5, -5, -5,
+ax_anim 1, 2, 108, -2, -2, -2, -2,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 4, 4, 4, 4,
+ax_anim 2, 0, 109, 4, 4, 4, 4,
+ax_anim 2, 1, 108, 4, 4, 4, 4,
+ax_anim 2, 0, 109, 4, 4, 4, 4,
+ax_anim 2, 0, 108, 4, 4, 4, 4,
+ax_anim 2, 0, 109, 4, 4, 4, 4,
+ax_anim 2, 0, 108, 4, 4, 4, 4,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim_terminator
+sTentacruelAnims_4_3:
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 2, 0, 110, -4, 0, -4, 0,
+ax_anim 4, 0, 110, -5, 0, -5, 0,
+ax_anim 1, 2, 111, -2, 0, -2, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 4, 0, 4, 0,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 2, 1, 111, 4, 0, 4, 0,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 2, 0, 111, 4, 0, 4, 0,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 2, 0, 111, 4, 0, 4, 0,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sTentacruelAnims_4_4:
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 2, 0, 113, -4, 4, -4, 4,
+ax_anim 4, 0, 113, -5, 5, -5, 5,
+ax_anim 1, 2, 114, -2, 2, -2, 2,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 4, -4, 4, -4,
+ax_anim 2, 0, 115, 4, -4, 4, -4,
+ax_anim 2, 1, 114, 4, -4, 4, -4,
+ax_anim 2, 0, 115, 4, -4, 4, -4,
+ax_anim 2, 0, 114, 4, -4, 4, -4,
+ax_anim 2, 0, 115, 4, -4, 4, -4,
+ax_anim 2, 0, 114, 4, -4, 4, -4,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim_terminator
+sTentacruelAnims_4_5:
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim 2, 0, 116, 0, 4, 0, 4,
+ax_anim 4, 0, 116, 0, 5, 0, 5,
+ax_anim 1, 2, 117, 0, 2, 0, 2,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, -4,
+ax_anim 2, 0, 118, 0, -4, 0, -4,
+ax_anim 2, 1, 117, 0, -4, 0, -4,
+ax_anim 2, 0, 118, 0, -4, 0, -4,
+ax_anim 2, 0, 117, 0, -4, 0, -4,
+ax_anim 2, 0, 118, 0, -4, 0, -4,
+ax_anim 2, 0, 117, 0, -4, 0, -4,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sTentacruelAnims_4_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 4, 0, 119, 5, 5, 5, 5,
+ax_anim 1, 2, 120, 2, 2, 2, 2,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, -4, -4, -4, -4,
+ax_anim 2, 0, 121, -4, -4, -4, -4,
+ax_anim 2, 1, 120, -4, -4, -4, -4,
+ax_anim 2, 0, 121, -4, -4, -4, -4,
+ax_anim 2, 0, 120, -4, -4, -4, -4,
+ax_anim 2, 0, 121, -4, -4, -4, -4,
+ax_anim 2, 0, 120, -4, -4, -4, -4,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim_terminator
+sTentacruelAnims_4_7:
+ax_anim 2, 0, 122, 2, 0, 2, 0,
+ax_anim 2, 0, 122, 4, 0, 4, 0,
+ax_anim 4, 0, 122, 5, 0, 5, 0,
+ax_anim 1, 2, 123, 2, 0, 2, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -4, 0, -4, 0,
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 2, 1, 123, -4, 0, -4, 0,
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 2, 0, 123, -4, 0, -4, 0,
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 2, 0, 123, -4, 0, -4, 0,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sTentacruelAnims_4_8:
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 2, 0, 125, 4, -4, 4, -4,
+ax_anim 4, 0, 125, 5, -5, 5, -5,
+ax_anim 1, 2, 126, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -4, 4, -4, 4,
+ax_anim 2, 0, 127, -4, 4, -4, 4,
+ax_anim 2, 1, 126, -4, 4, -4, 4,
+ax_anim 2, 0, 127, -4, 4, -4, 4,
+ax_anim 2, 0, 126, -4, 4, -4, 4,
+ax_anim 2, 0, 127, -4, 4, -4, 4,
+ax_anim 2, 0, 126, -4, 4, -4, 4,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_7_1:
+ax_anim 2, 0, 138, 0, -3, 0, -3,
+ax_anim 8, 0, 138, 0, -4, 0, -4,
+ax_anim_terminator
+sTentacruelAnims_7_2:
+ax_anim 2, 0, 139, -3, -3, -3, -3,
+ax_anim 8, 0, 139, -4, -4, -4, -4,
+ax_anim_terminator
+sTentacruelAnims_7_3:
+ax_anim 2, 0, 140, -3, 0, -3, 0,
+ax_anim 8, 0, 140, -4, 0, -4, 0,
+ax_anim_terminator
+sTentacruelAnims_7_4:
+ax_anim 2, 0, 141, -3, 3, -3, 3,
+ax_anim 8, 0, 141, -4, 4, -4, 4,
+ax_anim_terminator
+sTentacruelAnims_7_5:
+ax_anim 2, 0, 142, 0, 3, 0, 3,
+ax_anim 8, 0, 142, 0, 4, 0, 4,
+ax_anim_terminator
+sTentacruelAnims_7_6:
+ax_anim 2, 0, 143, 3, 3, 3, 3,
+ax_anim 8, 0, 143, 4, 4, 4, 4,
+ax_anim_terminator
+sTentacruelAnims_7_7:
+ax_anim 2, 0, 144, 3, 0, 3, 0,
+ax_anim 8, 0, 144, 4, 0, 4, 0,
+ax_anim_terminator
+sTentacruelAnims_7_8:
+ax_anim 2, 0, 145, 3, -3, 3, -3,
+ax_anim 8, 0, 145, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_8_1:
+ax_anim 6, 0, 146, 0, -2, 0, 0,
+ax_anim 10, 0, 147, 0, -4, 0, 0,
+ax_anim 10, 0, 147, 0, -5, 0, 0,
+ax_anim 6, 0, 146, 0, -5, 0, 0,
+ax_anim 10, 0, 148, 0, -4, 0, 0,
+ax_anim 10, 0, 148, 0, -3, 0, 0,
+ax_anim 10, 0, 148, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_8_2:
+ax_anim 6, 0, 149, 0, -2, 0, 0,
+ax_anim 10, 0, 150, 0, -4, 0, 0,
+ax_anim 10, 0, 150, 0, -5, 0, 0,
+ax_anim 6, 0, 149, 0, -5, 0, 0,
+ax_anim 10, 0, 151, 0, -4, 0, 0,
+ax_anim 10, 0, 151, 0, -3, 0, 0,
+ax_anim 10, 0, 151, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_8_3:
+ax_anim 6, 0, 152, 0, -2, 0, 0,
+ax_anim 10, 0, 153, 0, -4, 0, 0,
+ax_anim 10, 0, 153, 0, -5, 0, 0,
+ax_anim 6, 0, 152, 0, -5, 0, 0,
+ax_anim 10, 0, 154, 0, -4, 0, 0,
+ax_anim 10, 0, 154, 0, -3, 0, 0,
+ax_anim 10, 0, 154, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_8_4:
+ax_anim 6, 0, 155, 0, -2, 0, 0,
+ax_anim 10, 0, 156, 0, -4, 0, 0,
+ax_anim 10, 0, 156, 0, -5, 0, 0,
+ax_anim 6, 0, 155, 0, -5, 0, 0,
+ax_anim 10, 0, 157, 0, -4, 0, 0,
+ax_anim 10, 0, 157, 0, -3, 0, 0,
+ax_anim 10, 0, 157, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_8_5:
+ax_anim 6, 0, 158, 0, -2, 0, 0,
+ax_anim 10, 0, 159, 0, -4, 0, 0,
+ax_anim 10, 0, 159, 0, -5, 0, 0,
+ax_anim 6, 0, 158, 0, -5, 0, 0,
+ax_anim 10, 0, 160, 0, -4, 0, 0,
+ax_anim 10, 0, 160, 0, -3, 0, 0,
+ax_anim 10, 0, 160, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_8_6:
+ax_anim 6, 0, 161, 0, -2, 0, 0,
+ax_anim 10, 0, 162, 0, -4, 0, 0,
+ax_anim 10, 0, 162, 0, -5, 0, 0,
+ax_anim 6, 0, 161, 0, -5, 0, 0,
+ax_anim 10, 0, 163, 0, -4, 0, 0,
+ax_anim 10, 0, 163, 0, -3, 0, 0,
+ax_anim 10, 0, 163, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_8_7:
+ax_anim 6, 0, 164, 0, -2, 0, 0,
+ax_anim 10, 0, 165, 0, -4, 0, 0,
+ax_anim 10, 0, 165, 0, -5, 0, 0,
+ax_anim 6, 0, 164, 0, -5, 0, 0,
+ax_anim 10, 0, 166, 0, -4, 0, 0,
+ax_anim 10, 0, 166, 0, -3, 0, 0,
+ax_anim 10, 0, 166, 0, -2, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_8_8:
+ax_anim 6, 0, 167, 0, -2, 0, 0,
+ax_anim 10, 0, 168, 0, -4, 0, 0,
+ax_anim 10, 0, 168, 0, -5, 0, 0,
+ax_anim 6, 0, 167, 0, -5, 0, 0,
+ax_anim 10, 0, 169, 0, -4, 0, 0,
+ax_anim 10, 0, 169, 0, -3, 0, 0,
+ax_anim 10, 0, 169, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 17, 7, 17,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 17, -7, 17,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 21, 10, 21, 10,
+ax_anim 3, 0, 173, 19, 19, 19, 19,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 20, -2, 20, -2,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -20, 12, -20,
+ax_anim 3, 0, 171, 20, -20, 20, -20,
+ax_anim 2, 3, 172, 20, -11, 20, -11,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 9, 1, 9, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -16, -7, -16,
+ax_anim 3, 0, 170, 0, -20, 0, -20,
+ax_anim 2, 3, 171, 7, -16, 7, -16,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -20, -12, -20,
+ax_anim 3, 0, 177, -20, -20, -20, -20,
+ax_anim 2, 3, 176, -20, -11, -20, -11,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -8, 1, -8, 1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -20, -2, -20, -2,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -21, 10, -21, 10,
+ax_anim 3, 0, 175, -19, 19, -19, 19,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -17, 0, 0,
+ax_anim 1, 0, 186, 0, -11, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_11_2:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_11_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_11_4:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -21, 0, 0,
+ax_anim 2, 0, 192, 0, -17, 0, 0,
+ax_anim 1, 0, 192, 0, -11, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_11_6:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_11_7:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTentacruelAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sTentacruelGfx1:
+.incbin "baserom.gba", 0x82C078, 0x200
+sTentacruelSprites1:
+ax_sprite sTentacruelGfx1, 0x200
+ax_sprite_terminator
+sTentacruelGfx2:
+.incbin "baserom.gba", 0x82C288, 0x200
+sTentacruelSprites2:
+ax_sprite sTentacruelGfx2, 0x200
+ax_sprite_terminator
+sTentacruelGfx3:
+.incbin "baserom.gba", 0x82C498, 0x200
+sTentacruelSprites3:
+ax_sprite sTentacruelGfx3, 0x200
+ax_sprite_terminator
+sTentacruelGfx4:
+.incbin "baserom.gba", 0x82C6A8, 0x200
+sTentacruelSprites4:
+ax_sprite sTentacruelGfx4, 0x200
+ax_sprite_terminator
+sTentacruelGfx5:
+.incbin "baserom.gba", 0x82C8B8, 0x200
+sTentacruelSprites5:
+ax_sprite sTentacruelGfx5, 0x200
+ax_sprite_terminator
+sTentacruelGfx6:
+.incbin "baserom.gba", 0x82CAC8, 0x200
+sTentacruelSprites6:
+ax_sprite sTentacruelGfx6, 0x200
+ax_sprite_terminator
+sTentacruelGfx7:
+.incbin "baserom.gba", 0x82CCD8, 0x200
+sTentacruelSprites7:
+ax_sprite sTentacruelGfx7, 0x200
+ax_sprite_terminator
+sTentacruelGfx8:
+.incbin "baserom.gba", 0x82CEE8, 0x200
+sTentacruelSprites8:
+ax_sprite sTentacruelGfx8, 0x200
+ax_sprite_terminator
+sTentacruelGfx9:
+.incbin "baserom.gba", 0x82D0F8, 0x200
+sTentacruelSprites9:
+ax_sprite sTentacruelGfx9, 0x200
+ax_sprite_terminator
+sTentacruelGfx10:
+.incbin "baserom.gba", 0x82D308, 0x200
+sTentacruelSprites10:
+ax_sprite sTentacruelGfx10, 0x200
+ax_sprite_terminator
+sTentacruelGfx11:
+.incbin "baserom.gba", 0x82D518, 0x200
+sTentacruelSprites11:
+ax_sprite sTentacruelGfx11, 0x200
+ax_sprite_terminator
+sTentacruelGfx12:
+.incbin "baserom.gba", 0x82D728, 0x200
+sTentacruelSprites12:
+ax_sprite sTentacruelGfx12, 0x200
+ax_sprite_terminator
+sTentacruelGfx13:
+.incbin "baserom.gba", 0x82D938, 0x200
+sTentacruelSprites13:
+ax_sprite sTentacruelGfx13, 0x200
+ax_sprite_terminator
+sTentacruelGfx14:
+.incbin "baserom.gba", 0x82DB48, 0x200
+sTentacruelSprites14:
+ax_sprite sTentacruelGfx14, 0x200
+ax_sprite_terminator
+sTentacruelGfx15:
+.incbin "baserom.gba", 0x82DD58, 0x200
+sTentacruelSprites15:
+ax_sprite sTentacruelGfx15, 0x200
+ax_sprite_terminator
+sTentacruelGfx16:
+.incbin "baserom.gba", 0x82DF68, 0x60
+sTentacruelGfx16_1:
+.incbin "baserom.gba", 0x82DFC8, 0x60
+sTentacruelGfx16_2:
+.incbin "baserom.gba", 0x82E028, 0x60
+sTentacruelSprites16:
+ax_sprite sTentacruelGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx17:
+.incbin "baserom.gba", 0x82E0C0, 0x60
+sTentacruelGfx17_1:
+.incbin "baserom.gba", 0x82E120, 0x60
+sTentacruelGfx17_2:
+.incbin "baserom.gba", 0x82E180, 0x60
+sTentacruelSprites17:
+ax_sprite sTentacruelGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx18:
+.incbin "baserom.gba", 0x82E218, 0x40
+sTentacruelGfx18_1:
+.incbin "baserom.gba", 0x82E258, 0x60
+sTentacruelGfx18_2:
+.incbin "baserom.gba", 0x82E2B8, 0x60
+sTentacruelGfx18_3:
+.incbin "baserom.gba", 0x82E318, 0x20
+sTentacruelSprites18:
+ax_sprite sTentacruelGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacruelGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTentacruelGfx18_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacruelGfx19:
+.incbin "baserom.gba", 0x82E380, 0x60
+sTentacruelGfx19_1:
+.incbin "baserom.gba", 0x82E3E0, 0x60
+sTentacruelGfx19_2:
+.incbin "baserom.gba", 0x82E440, 0x60
+sTentacruelGfx19_3:
+.incbin "baserom.gba", 0x82E4A0, 0x20
+sTentacruelSprites19:
+ax_sprite sTentacruelGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTentacruelGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacruelGfx20:
+.incbin "baserom.gba", 0x82E508, 0x60
+sTentacruelGfx20_1:
+.incbin "baserom.gba", 0x82E568, 0x60
+sTentacruelGfx20_2:
+.incbin "baserom.gba", 0x82E5C8, 0x60
+sTentacruelGfx20_3:
+.incbin "baserom.gba", 0x82E628, 0x20
+sTentacruelGfx20_4:
+.incbin "baserom.gba", 0x82E648, 0x20
+sTentacruelSprites20:
+ax_sprite sTentacruelGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx20_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx20_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacruelGfx21:
+.incbin "baserom.gba", 0x82E6C0, 0x160
+sTentacruelSprites21:
+ax_sprite sTentacruelGfx21, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx22:
+.incbin "baserom.gba", 0x82E838, 0x20
+sTentacruelGfx22_1:
+.incbin "baserom.gba", 0x82E858, 0x40
+sTentacruelGfx22_2:
+.incbin "baserom.gba", 0x82E898, 0x120
+sTentacruelSprites22:
+ax_sprite sTentacruelGfx22, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTentacruelGfx22_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTentacruelGfx22_2, 0x120
+ax_sprite_terminator
+sTentacruelGfx23:
+.incbin "baserom.gba", 0x82E9E8, 0x60
+sTentacruelGfx23_1:
+.incbin "baserom.gba", 0x82EA48, 0xE0
+sTentacruelSprites23:
+ax_sprite sTentacruelGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx23_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx24:
+.incbin "baserom.gba", 0x82EB50, 0x60
+sTentacruelGfx24_1:
+.incbin "baserom.gba", 0x82EBB0, 0x60
+sTentacruelGfx24_2:
+.incbin "baserom.gba", 0x82EC10, 0x60
+sTentacruelSprites24:
+ax_sprite sTentacruelGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx25:
+.incbin "baserom.gba", 0x82ECA8, 0xE0
+sTentacruelGfx25_1:
+.incbin "baserom.gba", 0x82ED88, 0x60
+sTentacruelGfx25_2:
+.incbin "baserom.gba", 0x82EDE8, 0x40
+sTentacruelSprites25:
+ax_sprite sTentacruelGfx25, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx25_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacruelGfx26:
+.incbin "baserom.gba", 0x82EE60, 0x60
+sTentacruelGfx26_1:
+.incbin "baserom.gba", 0x82EEC0, 0x60
+sTentacruelGfx26_2:
+.incbin "baserom.gba", 0x82EF20, 0x60
+sTentacruelSprites26:
+ax_sprite sTentacruelGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx27:
+.incbin "baserom.gba", 0x82EFB8, 0x60
+sTentacruelGfx27_1:
+.incbin "baserom.gba", 0x82F018, 0x100
+sTentacruelGfx27_2:
+.incbin "baserom.gba", 0x82F118, 0x40
+sTentacruelSprites27:
+ax_sprite sTentacruelGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx27_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacruelGfx28:
+.incbin "baserom.gba", 0x82F190, 0xE0
+sTentacruelGfx28_1:
+.incbin "baserom.gba", 0x82F270, 0x40
+sTentacruelGfx28_2:
+.incbin "baserom.gba", 0x82F2B0, 0x20
+sTentacruelSprites28:
+ax_sprite sTentacruelGfx28, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx28_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sTentacruelGfx28_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacruelGfx29:
+.incbin "baserom.gba", 0x82F308, 0x40
+sTentacruelGfx29_1:
+.incbin "baserom.gba", 0x82F348, 0x140
+sTentacruelSprites29:
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx29_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacruelGfx30:
+.incbin "baserom.gba", 0x82F4B8, 0x60
+sTentacruelGfx30_1:
+.incbin "baserom.gba", 0x82F518, 0x100
+sTentacruelGfx30_2:
+.incbin "baserom.gba", 0x82F618, 0x20
+sTentacruelSprites30:
+ax_sprite sTentacruelGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx30_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx30_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacruelGfx31:
+.incbin "baserom.gba", 0x82F670, 0x160
+sTentacruelGfx31_1:
+.incbin "baserom.gba", 0x82F7D0, 0x40
+sTentacruelSprites31:
+ax_sprite sTentacruelGfx31, 0x160
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTentacruelGfx32:
+.incbin "baserom.gba", 0x82F838, 0x40
+sTentacruelGfx32_1:
+.incbin "baserom.gba", 0x82F878, 0x100
+sTentacruelGfx32_2:
+.incbin "baserom.gba", 0x82F978, 0x20
+sTentacruelSprites32:
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx32_1, 0x100
+ax_sprite 0, 0x40
+ax_sprite sTentacruelGfx32_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTentacruelGfx33:
+.incbin "baserom.gba", 0x82F9D8, 0xE0
+sTentacruelGfx33_1:
+.incbin "baserom.gba", 0x82FAB8, 0x60
+sTentacruelSprites33:
+ax_sprite sTentacruelGfx33, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx33_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx34:
+.incbin "baserom.gba", 0x82FB40, 0xA0
+sTentacruelGfx34_1:
+.incbin "baserom.gba", 0x82FBE0, 0x60
+sTentacruelGfx34_2:
+.incbin "baserom.gba", 0x82FC40, 0x20
+sTentacruelSprites34:
+ax_sprite sTentacruelGfx34, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTentacruelGfx34_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTentacruelGfx35:
+.incbin "baserom.gba", 0x82FC98, 0x60
+sTentacruelGfx35_1:
+.incbin "baserom.gba", 0x82FCF8, 0x60
+sTentacruelGfx35_2:
+.incbin "baserom.gba", 0x82FD58, 0x60
+sTentacruelSprites35:
+ax_sprite sTentacruelGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTentacruelGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTentacruelGfx36:
+.incbin "baserom.gba", 0x82FDF0, 0x200
+sTentacruelSprites36:
+ax_sprite sTentacruelGfx36, 0x200
+ax_sprite_terminator
+sTentacruelGfx37:
+.incbin "baserom.gba", 0x830000, 0x200
+sTentacruelSprites37:
+ax_sprite sTentacruelGfx37, 0x200
+ax_sprite_terminator
+sTentacruelGfx38:
+.incbin "baserom.gba", 0x830210, 0x200
+sTentacruelSprites38:
+ax_sprite sTentacruelGfx38, 0x200
+ax_sprite_terminator
+sTentacruelGfx39:
+.incbin "baserom.gba", 0x830420, 0x200
+sTentacruelSprites39:
+ax_sprite sTentacruelGfx39, 0x200
+ax_sprite_terminator
+sTentacruelGfx40:
+.incbin "baserom.gba", 0x830630, 0x200
+sTentacruelSprites40:
+ax_sprite sTentacruelGfx40, 0x200
+ax_sprite_terminator
+sTentacruelGfx41:
+.incbin "baserom.gba", 0x830840, 0x200
+sTentacruelSprites41:
+ax_sprite sTentacruelGfx41, 0x200
+ax_sprite_terminator
+sTentacruelGfx42:
+.incbin "baserom.gba", 0x830A50, 0x200
+sTentacruelSprites42:
+ax_sprite sTentacruelGfx42, 0x200
+ax_sprite_terminator
+sAxPosesTentacruel:
+.4byte sTentacruelPose1
+.4byte sTentacruelPose2
+.4byte sTentacruelPose3
+.4byte sTentacruelPose4
+.4byte sTentacruelPose5
+.4byte sTentacruelPose6
+.4byte sTentacruelPose7
+.4byte sTentacruelPose8
+.4byte sTentacruelPose9
+.4byte sTentacruelPose10
+.4byte sTentacruelPose11
+.4byte sTentacruelPose12
+.4byte sTentacruelPose13
+.4byte sTentacruelPose14
+.4byte sTentacruelPose15
+.4byte sTentacruelPose16
+.4byte sTentacruelPose17
+.4byte sTentacruelPose18
+.4byte sTentacruelPose19
+.4byte sTentacruelPose20
+.4byte sTentacruelPose21
+.4byte sTentacruelPose22
+.4byte sTentacruelPose23
+.4byte sTentacruelPose24
+.4byte sTentacruelPose25
+.4byte sTentacruelPose26
+.4byte sTentacruelPose27
+.4byte sTentacruelPose28
+.4byte sTentacruelPose29
+.4byte sTentacruelPose30
+.4byte sTentacruelPose31
+.4byte sTentacruelPose32
+.4byte sTentacruelPose33
+.4byte sTentacruelPose34
+.4byte sTentacruelPose35
+.4byte sTentacruelPose36
+.4byte sTentacruelPose37
+.4byte sTentacruelPose38
+.4byte sTentacruelPose39
+.4byte sTentacruelPose40
+.4byte sTentacruelPose41
+.4byte sTentacruelPose42
+.4byte sTentacruelPose43
+.4byte sTentacruelPose44
+.4byte sTentacruelPose45
+.4byte sTentacruelPose46
+.4byte sTentacruelPose47
+.4byte sTentacruelPose48
+.4byte sTentacruelPose49
+.4byte sTentacruelPose50
+.4byte sTentacruelPose51
+.4byte sTentacruelPose52
+.4byte sTentacruelPose53
+.4byte sTentacruelPose54
+.4byte sTentacruelPose55
+.4byte sTentacruelPose56
+.4byte sTentacruelPose57
+.4byte sTentacruelPose58
+.4byte sTentacruelPose59
+.4byte sTentacruelPose60
+.4byte sTentacruelPose61
+.4byte sTentacruelPose62
+.4byte sTentacruelPose63
+.4byte sTentacruelPose64
+.4byte sTentacruelPose65
+.4byte sTentacruelPose66
+.4byte sTentacruelPose67
+.4byte sTentacruelPose68
+.4byte sTentacruelPose69
+.4byte sTentacruelPose70
+.4byte sTentacruelPose71
+.4byte sTentacruelPose72
+.4byte sTentacruelPose73
+.4byte sTentacruelPose74
+.4byte sTentacruelPose75
+.4byte sTentacruelPose76
+.4byte sTentacruelPose77
+.4byte sTentacruelPose78
+.4byte sTentacruelPose79
+.4byte sTentacruelPose80
+.4byte sTentacruelPose81
+.4byte sTentacruelPose82
+.4byte sTentacruelPose83
+.4byte sTentacruelPose84
+.4byte sTentacruelPose85
+.4byte sTentacruelPose86
+.4byte sTentacruelPose87
+.4byte sTentacruelPose88
+.4byte sTentacruelPose89
+.4byte sTentacruelPose90
+.4byte sTentacruelPose91
+.4byte sTentacruelPose92
+.4byte sTentacruelPose93
+.4byte sTentacruelPose94
+.4byte sTentacruelPose95
+.4byte sTentacruelPose96
+.4byte sTentacruelPose97
+.4byte sTentacruelPose98
+.4byte sTentacruelPose99
+.4byte sTentacruelPose100
+.4byte sTentacruelPose101
+.4byte sTentacruelPose102
+.4byte sTentacruelPose103
+.4byte sTentacruelPose104
+.4byte sTentacruelPose105
+.4byte sTentacruelPose106
+.4byte sTentacruelPose107
+.4byte sTentacruelPose108
+.4byte sTentacruelPose109
+.4byte sTentacruelPose110
+.4byte sTentacruelPose111
+.4byte sTentacruelPose112
+.4byte sTentacruelPose113
+.4byte sTentacruelPose114
+.4byte sTentacruelPose115
+.4byte sTentacruelPose116
+.4byte sTentacruelPose117
+.4byte sTentacruelPose118
+.4byte sTentacruelPose119
+.4byte sTentacruelPose120
+.4byte sTentacruelPose121
+.4byte sTentacruelPose122
+.4byte sTentacruelPose123
+.4byte sTentacruelPose124
+.4byte sTentacruelPose125
+.4byte sTentacruelPose126
+.4byte sTentacruelPose127
+.4byte sTentacruelPose128
+.4byte sTentacruelPose129
+.4byte sTentacruelPose130
+.4byte sTentacruelPose131
+.4byte sTentacruelPose132
+.4byte sTentacruelPose133
+.4byte sTentacruelPose134
+.4byte sTentacruelPose135
+.4byte sTentacruelPose136
+.4byte sTentacruelPose137
+.4byte sTentacruelPose138
+.4byte sTentacruelPose139
+.4byte sTentacruelPose140
+.4byte sTentacruelPose141
+.4byte sTentacruelPose142
+.4byte sTentacruelPose143
+.4byte sTentacruelPose144
+.4byte sTentacruelPose145
+.4byte sTentacruelPose146
+.4byte sTentacruelPose147
+.4byte sTentacruelPose148
+.4byte sTentacruelPose149
+.4byte sTentacruelPose150
+.4byte sTentacruelPose151
+.4byte sTentacruelPose152
+.4byte sTentacruelPose153
+.4byte sTentacruelPose154
+.4byte sTentacruelPose155
+.4byte sTentacruelPose156
+.4byte sTentacruelPose157
+.4byte sTentacruelPose158
+.4byte sTentacruelPose159
+.4byte sTentacruelPose160
+.4byte sTentacruelPose161
+.4byte sTentacruelPose162
+.4byte sTentacruelPose163
+.4byte sTentacruelPose164
+.4byte sTentacruelPose165
+.4byte sTentacruelPose166
+.4byte sTentacruelPose167
+.4byte sTentacruelPose168
+.4byte sTentacruelPose169
+.4byte sTentacruelPose170
+.4byte sTentacruelPose171
+.4byte sTentacruelPose172
+.4byte sTentacruelPose173
+.4byte sTentacruelPose174
+.4byte sTentacruelPose175
+.4byte sTentacruelPose176
+.4byte sTentacruelPose177
+.4byte sTentacruelPose178
+.4byte sTentacruelPose179
+.4byte sTentacruelPose180
+.4byte sTentacruelPose181
+.4byte sTentacruelPose182
+.4byte sTentacruelPose183
+.4byte sTentacruelPose184
+.4byte sTentacruelPose185
+.4byte sTentacruelPose186
+.4byte sTentacruelPose187
+.4byte sTentacruelPose188
+.4byte sTentacruelPose189
+.4byte sTentacruelPose190
+.4byte sTentacruelPose191
+.4byte sTentacruelPose192
+.4byte sTentacruelPose193
+.4byte sTentacruelPose194
+.4byte sTentacruelPose195
+.4byte sTentacruelPose196
+.4byte sTentacruelPose197
+.4byte sTentacruelPose198
+.4byte sTentacruelPose199
+.4byte sTentacruelPose200
+.4byte sTentacruelPose201
+.4byte sTentacruelPose202
+.4byte sTentacruelPose203
+.4byte sTentacruelPose204
+.4byte sTentacruelPose205
+.4byte sTentacruelPose206
+.4byte sTentacruelPose207
+.4byte sTentacruelPose208
+.4byte sTentacruelPose209
+.4byte sTentacruelPose210
+.4byte sTentacruelPose211
+.4byte sTentacruelPose212
+.4byte sTentacruelPose213
+.4byte sTentacruelPose214
+.4byte sTentacruelPose215
+.4byte sTentacruelPose216
+.4byte sTentacruelPose217
+.4byte sTentacruelPose218
+sAxPositionsTentacruel:
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -5, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte    0,   -7, 	  -9,   -6, 	   9,   -6, 	   0,  -10
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+.2byte    0,   -5, 	  10,   -6, 	   4,   -2, 	   0,   -8
+.2byte    0,   -7, 	  12,  -12, 	   0,   -3, 	   0,  -10
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte   -1,   -6, 	  10,  -10, 	  10,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	   8,  -16, 	   8,   -5, 	  -1,  -11
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte   -1,   -7, 	   6,  -13, 	   9,  -11, 	  -1,  -10
+.2byte   -1,   -9, 	   1,  -11, 	   9,   -8, 	  -1,  -12
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte    0,   -8, 	   6,  -14, 	  -6,  -14, 	   0,  -10
+.2byte    0,   -9, 	  10,  -12, 	 -10,  -12, 	   0,  -11
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    1,   -7, 	  -6,  -13, 	  -9,  -11, 	   1,  -10
+.2byte    1,   -9, 	  -1,  -11, 	  -9,   -8, 	   1,  -12
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte    1,   -6, 	 -10,  -10, 	 -10,   -7, 	   1,   -9
+.2byte    1,   -8, 	  -8,  -16, 	  -8,   -5, 	   1,  -11
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte    0,   -5, 	 -10,   -6, 	  -4,   -2, 	   0,   -8
+.2byte    0,   -7, 	 -12,  -12, 	   0,   -3, 	   0,  -10
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -5, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte    0,   -7, 	  -9,   -6, 	   9,   -6, 	   0,  -10
+.2byte    0,   -9, 	  -6,  -13, 	   6,  -13, 	   0,   -7
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+.2byte    0,   -5, 	  10,   -6, 	   4,   -2, 	   0,   -8
+.2byte    0,   -7, 	  12,  -12, 	   0,   -3, 	   0,  -10
+.2byte    1,  -11, 	   3,  -13, 	  -6,  -10, 	   2,   -9
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte   -1,   -6, 	  10,  -10, 	  10,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	   8,  -16, 	   8,   -5, 	  -1,  -11
+.2byte    1,   -6, 	  -6,   -7, 	  -7,   -1, 	   3,   -7
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte   -1,   -7, 	   6,  -13, 	   9,  -11, 	  -1,  -10
+.2byte   -1,   -9, 	   1,  -11, 	   9,   -8, 	  -1,  -12
+.2byte    0,   -8, 	  -7,   -3, 	  -1,    0, 	   1,  -10
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte    0,   -8, 	   6,  -14, 	  -6,  -14, 	   0,  -10
+.2byte    0,   -9, 	  10,  -12, 	 -10,  -12, 	   0,  -11
+.2byte    0,   -7, 	   5,    0, 	  -6,    0, 	   0,   -9
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    1,   -7, 	  -6,  -13, 	  -9,  -11, 	   1,  -10
+.2byte    1,   -9, 	  -1,  -11, 	  -9,   -8, 	   1,  -12
+.2byte    0,   -8, 	   7,   -3, 	   1,    0, 	  -1,  -10
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte    1,   -6, 	 -10,  -10, 	 -10,   -7, 	   1,   -9
+.2byte    1,   -8, 	  -8,  -16, 	  -8,   -5, 	   1,  -11
+.2byte   -1,   -6, 	   6,   -7, 	   7,   -1, 	  -3,   -7
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte    0,   -5, 	 -10,   -6, 	  -4,   -2, 	   0,   -8
+.2byte    0,   -7, 	 -12,  -12, 	   0,   -3, 	   0,  -10
+.2byte   -1,  -11, 	  -3,  -13, 	   6,  -10, 	  -2,   -9
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -6, 	  -5,   -3, 	   5,   -3, 	   0,   -9
+.2byte    0,   -7, 	  -9,   -6, 	   9,   -6, 	   0,  -10
+.2byte    0,   -7, 	  -9,  -18, 	   9,  -18, 	   0,  -10
+.2byte    0,   -7, 	  -5,   -2, 	   5,   -2, 	   0,   -9
+.2byte    0,   -7, 	  -5,   -2, 	   5,   -2, 	   0,   -9
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+.2byte    0,   -6, 	  10,   -7, 	   4,   -3, 	   0,   -9
+.2byte    0,   -7, 	  12,  -12, 	   0,   -3, 	   0,  -10
+.2byte    2,   -8, 	   9,  -19, 	  -6,  -15, 	   0,  -10
+.2byte    3,   -7, 	  10,   -3, 	   4,   -1, 	   1,   -9
+.2byte    3,   -7, 	  10,   -3, 	   4,   -1, 	   1,   -9
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte   -1,   -7, 	  10,  -11, 	  10,   -8, 	  -1,  -10
+.2byte   -1,   -8, 	   8,  -16, 	   8,   -5, 	  -1,  -11
+.2byte    3,   -7, 	   5,  -21, 	   3,  -10, 	  -2,   -9
+.2byte    2,   -6, 	  11,   -5, 	   9,    0, 	  -1,   -8
+.2byte    2,   -6, 	  11,   -5, 	   9,    0, 	  -1,   -8
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	   6,  -14, 	   9,  -12, 	  -1,  -11
+.2byte   -1,   -9, 	   1,  -11, 	   9,   -8, 	  -1,  -12
+.2byte    0,   -9, 	  -6,  -22, 	   8,  -16, 	  -4,   -9
+.2byte   -1,   -8, 	   2,   -6, 	   8,   -3, 	  -3,  -10
+.2byte   -1,   -8, 	   2,   -6, 	   8,   -3, 	  -3,  -10
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte    0,   -9, 	   6,  -15, 	  -6,  -15, 	   0,  -11
+.2byte    0,   -9, 	  10,  -12, 	 -10,  -12, 	   0,  -11
+.2byte    0,  -10, 	  10,  -17, 	 -10,  -17, 	   0,   -8
+.2byte    0,  -10, 	   4,  -13, 	  -4,  -13, 	   0,   -9
+.2byte    0,  -10, 	   4,  -13, 	  -4,  -13, 	   0,   -9
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    1,   -8, 	  -6,  -14, 	  -9,  -12, 	   1,  -11
+.2byte    1,   -9, 	  -1,  -11, 	  -9,   -8, 	   1,  -12
+.2byte    0,   -9, 	   6,  -22, 	  -8,  -16, 	   4,   -9
+.2byte    1,   -8, 	  -2,   -6, 	  -8,   -3, 	   3,  -10
+.2byte    1,   -8, 	  -2,   -6, 	  -8,   -3, 	   3,  -10
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte    1,   -7, 	 -10,  -11, 	 -10,   -8, 	   1,  -10
+.2byte    1,   -8, 	  -8,  -16, 	  -8,   -5, 	   1,  -11
+.2byte   -3,   -7, 	  -5,  -21, 	  -3,  -10, 	   2,   -9
+.2byte   -2,   -6, 	 -11,   -5, 	  -9,    0, 	   1,   -8
+.2byte   -2,   -6, 	 -11,   -5, 	  -9,    0, 	   1,   -8
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte    0,   -6, 	 -10,   -7, 	  -4,   -3, 	   0,   -9
+.2byte    0,   -7, 	 -12,  -12, 	   0,   -3, 	   0,  -10
+.2byte   -2,   -8, 	  -9,  -19, 	   6,  -15, 	   0,  -10
+.2byte   -3,   -7, 	 -10,   -3, 	  -4,   -1, 	  -1,   -9
+.2byte   -3,   -7, 	 -10,   -3, 	  -4,   -1, 	  -1,   -9
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -7, 	  -9,  -18, 	   9,  -18, 	   0,  -10
+.2byte    0,   -7, 	  -5,   -2, 	   5,   -2, 	   0,   -9
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+.2byte    2,   -8, 	   9,  -19, 	  -6,  -15, 	   0,  -10
+.2byte    3,   -7, 	  10,   -3, 	   4,   -1, 	   1,   -9
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte    3,   -7, 	   5,  -21, 	   3,  -10, 	  -2,   -9
+.2byte    2,   -6, 	  11,   -5, 	   9,    0, 	  -1,   -8
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte    0,   -9, 	  -6,  -22, 	   8,  -16, 	  -4,   -9
+.2byte   -1,   -8, 	   2,   -6, 	   8,   -3, 	  -3,  -10
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte    0,  -10, 	  10,  -17, 	 -10,  -17, 	   0,   -8
+.2byte    0,  -10, 	   4,  -13, 	  -4,  -13, 	   0,   -9
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    0,   -9, 	   6,  -22, 	  -8,  -16, 	   4,   -9
+.2byte    1,   -8, 	  -2,   -6, 	  -8,   -3, 	   3,  -10
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte   -3,   -7, 	  -5,  -21, 	  -3,  -10, 	   2,   -9
+.2byte   -2,   -6, 	 -11,   -5, 	  -9,    0, 	   1,   -8
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte   -2,   -8, 	  -9,  -19, 	   6,  -15, 	   0,  -10
+.2byte   -3,   -7, 	 -10,   -3, 	  -4,   -1, 	  -1,   -9
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+.2byte    0,   -4, 	 -10,   -5, 	  -2,    1, 	   0,   -7
+.2byte    0,   -5, 	 -10,   -4, 	  -2,    2, 	   0,   -8
+.2byte   -1,  -11, 	 -10,  -20, 	   8,  -20, 	  -1,  -14
+.2byte    1,  -12, 	   9,  -24, 	  -4,  -19, 	  -1,  -15
+.2byte   -1,  -12, 	   6,  -24, 	   1,  -19, 	  -2,  -15
+.2byte   -1,  -11, 	  -4,  -24, 	  10,  -19, 	  -2,  -14
+.2byte   -1,  -15, 	   9,  -22, 	 -11,  -22, 	  -1,  -14
+.2byte    0,  -11, 	   3,  -24, 	 -11,  -19, 	   1,  -14
+.2byte   -1,  -12, 	  -8,  -24, 	  -3,  -19, 	   0,  -15
+.2byte   -2,  -12, 	 -10,  -24, 	   3,  -19, 	   0,  -15
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -5, 	  -5,   -2, 	   5,   -2, 	   0,   -8
+.2byte    0,   -7, 	  -9,   -6, 	   9,   -6, 	   0,  -10
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+.2byte    0,   -5, 	  10,   -6, 	   4,   -2, 	   0,   -8
+.2byte    0,   -7, 	  12,  -12, 	   0,   -3, 	   0,  -10
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte   -1,   -6, 	  10,  -10, 	  10,   -7, 	  -1,   -9
+.2byte   -1,   -8, 	   8,  -16, 	   8,   -5, 	  -1,  -11
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte   -1,   -7, 	   6,  -13, 	   9,  -11, 	  -1,  -10
+.2byte   -1,   -9, 	   1,  -11, 	   9,   -8, 	  -1,  -12
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte    0,   -8, 	   6,  -14, 	  -6,  -14, 	   0,  -10
+.2byte    0,   -9, 	  10,  -12, 	 -10,  -12, 	   0,  -11
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    1,   -7, 	  -6,  -13, 	  -9,  -11, 	   1,  -10
+.2byte    1,   -9, 	  -1,  -11, 	  -9,   -8, 	   1,  -12
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte    1,   -6, 	 -10,  -10, 	 -10,   -7, 	   1,   -9
+.2byte    1,   -8, 	  -8,  -16, 	  -8,   -5, 	   1,  -11
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte    0,   -5, 	 -10,   -6, 	  -4,   -2, 	   0,   -8
+.2byte    0,   -7, 	 -12,  -12, 	   0,   -3, 	   0,  -10
+.2byte    0,   -9, 	  -6,  -13, 	   6,  -13, 	   0,   -7
+.2byte   -1,   -9, 	  -3,  -11, 	   6,   -8, 	  -2,   -7
+.2byte    0,   -8, 	   7,   -9, 	   8,   -3, 	  -2,   -9
+.2byte    0,   -8, 	   7,   -3, 	   1,    0, 	  -1,  -10
+.2byte    0,   -8, 	   5,   -1, 	  -6,   -1, 	   0,  -10
+.2byte    0,   -8, 	  -7,   -3, 	  -1,    0, 	   1,  -10
+.2byte   -1,   -8, 	  -8,   -9, 	  -9,   -3, 	   1,   -9
+.2byte    1,   -9, 	   3,  -11, 	  -6,   -8, 	   2,   -7
+.2byte    0,   -8, 	  -9,  -19, 	   9,  -19, 	   0,  -11
+.2byte    1,   -8, 	   8,  -19, 	  -7,  -15, 	  -1,  -10
+.2byte    3,   -9, 	   5,  -23, 	   3,  -12, 	  -2,  -11
+.2byte    0,  -10, 	  -6,  -23, 	   8,  -17, 	  -4,  -10
+.2byte    0,  -11, 	  10,  -18, 	 -10,  -18, 	   0,   -9
+.2byte    0,  -10, 	   6,  -23, 	  -8,  -17, 	   4,  -10
+.2byte   -3,   -9, 	  -5,  -23, 	  -3,  -12, 	   2,  -11
+.2byte   -1,   -9, 	  -8,  -20, 	   7,  -16, 	   1,  -11
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -7, 	  -9,  -18, 	   9,  -18, 	   0,  -10
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+.2byte    2,   -8, 	   9,  -19, 	  -6,  -15, 	   0,  -10
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte    3,   -7, 	   5,  -21, 	   3,  -10, 	  -2,   -9
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte    0,   -9, 	  -6,  -22, 	   8,  -16, 	  -4,   -9
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte    0,  -12, 	  10,  -19, 	 -10,  -19, 	   0,  -10
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    0,   -9, 	   6,  -22, 	  -8,  -16, 	   4,   -9
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte   -3,   -7, 	  -5,  -21, 	  -3,  -10, 	   2,   -9
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte   -2,   -8, 	  -9,  -19, 	   6,  -15, 	   0,  -10
+.2byte    0,   -7, 	  -5,   -2, 	   5,   -2, 	   0,   -9
+.2byte   -2,   -6, 	  -9,   -2, 	  -3,    0, 	   0,   -8
+.2byte   -2,   -6, 	 -11,   -5, 	  -9,    0, 	   1,   -8
+.2byte    0,   -8, 	  -3,   -6, 	  -9,   -3, 	   2,  -10
+.2byte    0,  -10, 	   4,  -13, 	  -4,  -13, 	   0,   -9
+.2byte    0,   -8, 	   3,   -6, 	   9,   -3, 	  -2,  -10
+.2byte    2,   -6, 	  11,   -5, 	   9,    0, 	  -1,   -8
+.2byte    2,   -6, 	   9,   -2, 	   3,    0, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -6, 	 -11,   -8, 	  -3,   -2, 	   0,   -9
+.2byte    1,   -7, 	 -10,  -12, 	 -11,   -6, 	   1,  -10
+.2byte    1,   -8, 	  -7,  -15, 	 -10,  -12, 	   1,  -11
+.2byte    0,   -9, 	   9,  -15, 	  -9,  -15, 	   0,  -11
+.2byte   -1,   -8, 	   7,  -15, 	  10,  -12, 	  -1,  -11
+.2byte   -1,   -7, 	  10,  -12, 	  11,   -6, 	  -1,  -10
+.2byte    0,   -6, 	  11,   -8, 	   3,   -2, 	   0,   -9
+sTentacruelAnimTable1:
+.4byte sTentacruelAnims_1_1
+.4byte sTentacruelAnims_1_2
+.4byte sTentacruelAnims_1_3
+.4byte sTentacruelAnims_1_4
+.4byte sTentacruelAnims_1_5
+.4byte sTentacruelAnims_1_6
+.4byte sTentacruelAnims_1_7
+.4byte sTentacruelAnims_1_8
+sTentacruelAnimTable2:
+.4byte sTentacruelAnims_2_1
+.4byte sTentacruelAnims_2_2
+.4byte sTentacruelAnims_2_3
+.4byte sTentacruelAnims_2_4
+.4byte sTentacruelAnims_2_5
+.4byte sTentacruelAnims_2_6
+.4byte sTentacruelAnims_2_7
+.4byte sTentacruelAnims_2_8
+sTentacruelAnimTable3:
+.4byte sTentacruelAnims_3_1
+.4byte sTentacruelAnims_3_2
+.4byte sTentacruelAnims_3_3
+.4byte sTentacruelAnims_3_4
+.4byte sTentacruelAnims_3_5
+.4byte sTentacruelAnims_3_6
+.4byte sTentacruelAnims_3_7
+.4byte sTentacruelAnims_3_8
+sTentacruelAnimTable4:
+.4byte sTentacruelAnims_4_1
+.4byte sTentacruelAnims_4_2
+.4byte sTentacruelAnims_4_3
+.4byte sTentacruelAnims_4_4
+.4byte sTentacruelAnims_4_5
+.4byte sTentacruelAnims_4_6
+.4byte sTentacruelAnims_4_7
+.4byte sTentacruelAnims_4_8
+sTentacruelAnimTable5:
+.4byte sTentacruelAnims_5_1
+.4byte sTentacruelAnims_5_2
+.4byte sTentacruelAnims_5_3
+.4byte sTentacruelAnims_5_4
+.4byte sTentacruelAnims_5_5
+.4byte sTentacruelAnims_5_6
+.4byte sTentacruelAnims_5_7
+.4byte sTentacruelAnims_5_8
+sTentacruelAnimTable6:
+.4byte sTentacruelAnims_6_1
+.4byte sTentacruelAnims_6_1
+.4byte sTentacruelAnims_6_1
+.4byte sTentacruelAnims_6_1
+.4byte sTentacruelAnims_6_1
+.4byte sTentacruelAnims_6_1
+.4byte sTentacruelAnims_6_1
+.4byte sTentacruelAnims_6_1
+sTentacruelAnimTable7:
+.4byte sTentacruelAnims_7_1
+.4byte sTentacruelAnims_7_2
+.4byte sTentacruelAnims_7_3
+.4byte sTentacruelAnims_7_4
+.4byte sTentacruelAnims_7_5
+.4byte sTentacruelAnims_7_6
+.4byte sTentacruelAnims_7_7
+.4byte sTentacruelAnims_7_8
+sTentacruelAnimTable8:
+.4byte sTentacruelAnims_8_1
+.4byte sTentacruelAnims_8_2
+.4byte sTentacruelAnims_8_3
+.4byte sTentacruelAnims_8_4
+.4byte sTentacruelAnims_8_5
+.4byte sTentacruelAnims_8_6
+.4byte sTentacruelAnims_8_7
+.4byte sTentacruelAnims_8_8
+sTentacruelAnimTable9:
+.4byte sTentacruelAnims_9_1
+.4byte sTentacruelAnims_9_2
+.4byte sTentacruelAnims_9_3
+.4byte sTentacruelAnims_9_4
+.4byte sTentacruelAnims_9_5
+.4byte sTentacruelAnims_9_6
+.4byte sTentacruelAnims_9_7
+.4byte sTentacruelAnims_9_8
+sTentacruelAnimTable10:
+.4byte sTentacruelAnims_10_1
+.4byte sTentacruelAnims_10_2
+.4byte sTentacruelAnims_10_3
+.4byte sTentacruelAnims_10_4
+.4byte sTentacruelAnims_10_5
+.4byte sTentacruelAnims_10_6
+.4byte sTentacruelAnims_10_7
+.4byte sTentacruelAnims_10_8
+sTentacruelAnimTable11:
+.4byte sTentacruelAnims_11_1
+.4byte sTentacruelAnims_11_2
+.4byte sTentacruelAnims_11_3
+.4byte sTentacruelAnims_11_4
+.4byte sTentacruelAnims_11_5
+.4byte sTentacruelAnims_11_6
+.4byte sTentacruelAnims_11_7
+.4byte sTentacruelAnims_11_8
+sTentacruelAnimTable12:
+.4byte sTentacruelAnims_12_1
+.4byte sTentacruelAnims_12_2
+.4byte sTentacruelAnims_12_3
+.4byte sTentacruelAnims_12_4
+.4byte sTentacruelAnims_12_5
+.4byte sTentacruelAnims_12_6
+.4byte sTentacruelAnims_12_7
+.4byte sTentacruelAnims_12_8
+sTentacruelAnimTable13:
+.4byte sTentacruelAnims_13_1
+.4byte sTentacruelAnims_13_2
+.4byte sTentacruelAnims_13_3
+.4byte sTentacruelAnims_13_4
+.4byte sTentacruelAnims_13_5
+.4byte sTentacruelAnims_13_6
+.4byte sTentacruelAnims_13_7
+.4byte sTentacruelAnims_13_8
+sAxAnimationsTentacruel:
+.4byte sTentacruelAnimTable1
+.4byte sTentacruelAnimTable2
+.4byte sTentacruelAnimTable3
+.4byte sTentacruelAnimTable4
+.4byte sTentacruelAnimTable5
+.4byte sTentacruelAnimTable6
+.4byte sTentacruelAnimTable7
+.4byte sTentacruelAnimTable8
+.4byte sTentacruelAnimTable9
+.4byte sTentacruelAnimTable10
+.4byte sTentacruelAnimTable11
+.4byte sTentacruelAnimTable12
+.4byte sTentacruelAnimTable13
+sAxSpritesTentacruel:
+.4byte sTentacruelSprites1
+.4byte sTentacruelSprites2
+.4byte sTentacruelSprites3
+.4byte sTentacruelSprites4
+.4byte sTentacruelSprites5
+.4byte sTentacruelSprites6
+.4byte sTentacruelSprites7
+.4byte sTentacruelSprites8
+.4byte sTentacruelSprites9
+.4byte sTentacruelSprites10
+.4byte sTentacruelSprites11
+.4byte sTentacruelSprites12
+.4byte sTentacruelSprites13
+.4byte sTentacruelSprites14
+.4byte sTentacruelSprites15
+.4byte sTentacruelSprites16
+.4byte sTentacruelSprites17
+.4byte sTentacruelSprites18
+.4byte sTentacruelSprites19
+.4byte sTentacruelSprites20
+.4byte sTentacruelSprites21
+.4byte sTentacruelSprites22
+.4byte sTentacruelSprites23
+.4byte sTentacruelSprites24
+.4byte sTentacruelSprites25
+.4byte sTentacruelSprites26
+.4byte sTentacruelSprites27
+.4byte sTentacruelSprites28
+.4byte sTentacruelSprites29
+.4byte sTentacruelSprites30
+.4byte sTentacruelSprites31
+.4byte sTentacruelSprites32
+.4byte sTentacruelSprites33
+.4byte sTentacruelSprites34
+.4byte sTentacruelSprites35
+.4byte sTentacruelSprites36
+.4byte sTentacruelSprites37
+.4byte sTentacruelSprites38
+.4byte sTentacruelSprites39
+.4byte sTentacruelSprites40
+.4byte sTentacruelSprites41
+.4byte sTentacruelSprites42
+sAxMainTentacruel:
+ax_main sAxPosesTentacruel, sAxAnimationsTentacruel, 13, sAxSpritesTentacruel, sAxPositionsTentacruel

--- a/data/ax/togepi.inc
+++ b/data/ax/togepi.inc
@@ -1,0 +1,2559 @@
+.global gAxTogepi
+gAxTogepi:
+ax_siro sAxMainTogepi
+sTogepiPose1:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose2:
+ax_pose 1, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose3:
+ax_pose 2, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose4:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose5:
+ax_pose 4, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose6:
+ax_pose 5, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose7:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose8:
+ax_pose 7, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose9:
+ax_pose 8, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose10:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose11:
+ax_pose 10, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose12:
+ax_pose 11, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose13:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose14:
+ax_pose 13, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose15:
+ax_pose 14, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose16:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose17:
+ax_pose 10, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose18:
+ax_pose 11, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose19:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose20:
+ax_pose 7, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose21:
+ax_pose 8, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose22:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose23:
+ax_pose 4, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose24:
+ax_pose 5, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose25:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose26:
+ax_pose 1, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose27:
+ax_pose 2, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose28:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose29:
+ax_pose 4, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose30:
+ax_pose 5, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose31:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose32:
+ax_pose 7, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose33:
+ax_pose 8, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose34:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose35:
+ax_pose 10, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose36:
+ax_pose 11, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose37:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose38:
+ax_pose 13, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose39:
+ax_pose 14, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose40:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose41:
+ax_pose 10, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose42:
+ax_pose 11, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose43:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose44:
+ax_pose 7, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose45:
+ax_pose 8, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose46:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose47:
+ax_pose 4, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose48:
+ax_pose 5, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose49:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose50:
+ax_pose 1, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose51:
+ax_pose 2, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose52:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose53:
+ax_pose 4, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose54:
+ax_pose 5, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose55:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose56:
+ax_pose 7, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose57:
+ax_pose 8, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose58:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose59:
+ax_pose 10, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose60:
+ax_pose 11, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose61:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose62:
+ax_pose 13, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose63:
+ax_pose 14, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose64:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose65:
+ax_pose 10, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose66:
+ax_pose 11, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose67:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose68:
+ax_pose 7, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose69:
+ax_pose 8, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose70:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose71:
+ax_pose 4, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose72:
+ax_pose 5, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose73:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose74:
+ax_pose 15, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose75:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose76:
+ax_pose 16, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose77:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose78:
+ax_pose 17, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose79:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose80:
+ax_pose 18, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose81:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose82:
+ax_pose 19, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose83:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose84:
+ax_pose 18, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose85:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose86:
+ax_pose 17, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose87:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose88:
+ax_pose 16, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose89:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose90:
+ax_pose 20, 0x81ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogepiPose91:
+ax_pose 21, 0x81ed, 0x80f9, 0x5c00
+ax_pose_terminator
+sTogepiPose92:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose93:
+ax_pose 22, 0x81ed, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogepiPose94:
+ax_pose 23, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose95:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose96:
+ax_pose 24, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose97:
+ax_pose 25, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose98:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose99:
+ax_pose 26, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose100:
+ax_pose 27, 0x81ed, 0x90fa, 0x5c00
+ax_pose_terminator
+sTogepiPose101:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose102:
+ax_pose 28, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose103:
+ax_pose 29, 0x81ed, 0x80f6, 0x5c00
+ax_pose 30, 0x01f5, 0x0106, 0x5c08
+ax_pose_terminator
+sTogepiPose104:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose105:
+ax_pose 26, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose106:
+ax_pose 27, 0x81ed, 0x80f6, 0x5c00
+ax_pose_terminator
+sTogepiPose107:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose108:
+ax_pose 24, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose109:
+ax_pose 25, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose110:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose111:
+ax_pose 22, 0x81ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogepiPose112:
+ax_pose 23, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose113:
+ax_pose 31, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose114:
+ax_pose 32, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose115:
+ax_pose 33, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sTogepiPose116:
+ax_pose 34, 0x01ea, 0x90ea, 0x5c00
+ax_pose_terminator
+sTogepiPose117:
+ax_pose 35, 0x01ea, 0x90e7, 0x5c00
+ax_pose_terminator
+sTogepiPose118:
+ax_pose 36, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sTogepiPose119:
+ax_pose 37, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sTogepiPose120:
+ax_pose 36, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose121:
+ax_pose 35, 0x01ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sTogepiPose122:
+ax_pose 34, 0x01ea, 0x80f6, 0x5c00
+ax_pose_terminator
+sTogepiPose123:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose124:
+ax_pose 15, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose125:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose126:
+ax_pose 16, 0x81ef, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose127:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose128:
+ax_pose 17, 0x81ef, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogepiPose129:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose130:
+ax_pose 18, 0x81ef, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogepiPose131:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose132:
+ax_pose 19, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose133:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose134:
+ax_pose 18, 0x81ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogepiPose135:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose136:
+ax_pose 17, 0x81ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogepiPose137:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose138:
+ax_pose 16, 0x81ef, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose139:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose140:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose141:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose142:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose143:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose144:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose145:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose146:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose147:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose148:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose149:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose150:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose151:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose152:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose153:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose154:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose155:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose156:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose157:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose158:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose159:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose160:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose161:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose162:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose163:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose164:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose165:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose166:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose167:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose168:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose169:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose170:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose171:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose172:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose173:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose174:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose175:
+ax_pose 15, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose176:
+ax_pose 16, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose177:
+ax_pose 17, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose178:
+ax_pose 18, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose179:
+ax_pose 19, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose180:
+ax_pose 18, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose181:
+ax_pose 17, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose182:
+ax_pose 16, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose183:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose184:
+ax_pose 15, 0x81f0, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose185:
+ax_pose 1, 0x81f0, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose186:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose187:
+ax_pose 16, 0x81f0, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose188:
+ax_pose 4, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose189:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose190:
+ax_pose 17, 0x81f0, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose191:
+ax_pose 7, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose192:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose193:
+ax_pose 18, 0x81f0, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose194:
+ax_pose 10, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose195:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose196:
+ax_pose 19, 0x81f0, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose197:
+ax_pose 13, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose198:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose199:
+ax_pose 18, 0x81f0, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose200:
+ax_pose 10, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose201:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose202:
+ax_pose 17, 0x81f0, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose203:
+ax_pose 7, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose204:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose205:
+ax_pose 16, 0x81f0, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose206:
+ax_pose 4, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose207:
+ax_pose 21, 0x81ed, 0x80f9, 0x5c00
+ax_pose_terminator
+sTogepiPose208:
+ax_pose 22, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose209:
+ax_pose 24, 0x81ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose210:
+ax_pose 26, 0x81ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogepiPose211:
+ax_pose 29, 0x81ed, 0x80f7, 0x5c00
+ax_pose 30, 0x01f5, 0x0107, 0x5c08
+ax_pose_terminator
+sTogepiPose212:
+ax_pose 26, 0x81ed, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogepiPose213:
+ax_pose 24, 0x81ee, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose214:
+ax_pose 22, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose215:
+ax_pose 0, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose216:
+ax_pose 3, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose217:
+ax_pose 6, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose218:
+ax_pose 9, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose219:
+ax_pose 12, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogepiPose220:
+ax_pose 9, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose221:
+ax_pose 6, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogepiPose222:
+ax_pose 3, 0x81ed, 0x90f8, 0x5c00
+ax_pose_terminator
+.align 2
+sTogepiAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 1, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 20, 0, 20,
+ax_anim 2, 0, 25, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTogepiAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 11, 9, 11, 9,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 1, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 0, 28, 23, 19, 23, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sTogepiAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 1, 31, 22, 1, 22, 1,
+ax_anim 2, 0, 31, 22, 0, 22, 0,
+ax_anim 2, 0, 31, 22, 1, 22, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sTogepiAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 21, -21, 21, -21,
+ax_anim 2, 1, 34, 22, -20, 22, -20,
+ax_anim 2, 0, 34, 21, -21, 21, -21,
+ax_anim 2, 0, 34, 22, -20, 22, -20,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sTogepiAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sTogepiAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sTogepiAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 1, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 43, -22, 0, -22, 0,
+ax_anim 2, 0, 43, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sTogepiAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -11, 9, -11, 9,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 1, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 46, -22, 20, -22, 20,
+ax_anim 2, 0, 46, -23, 19, -23, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTogepiAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 1, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 49, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sTogepiAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 11, 9, 11, 9,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 1, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 52, 22, 20, 22, 20,
+ax_anim 2, 0, 52, 23, 19, 23, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sTogepiAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 1, 55, 22, 1, 22, 1,
+ax_anim 2, 0, 55, 22, 0, 22, 0,
+ax_anim 2, 0, 55, 22, 1, 22, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sTogepiAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 58, 21, -21, 21, -21,
+ax_anim 2, 1, 58, 22, -20, 22, -20,
+ax_anim 2, 0, 58, 21, -21, 21, -21,
+ax_anim 2, 0, 58, 22, -20, 22, -20,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sTogepiAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 1, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 61, 0, -21, 0, -21,
+ax_anim 2, 0, 61, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sTogepiAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -13, -10, -13,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 1, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 64, -18, -23, -18, -23,
+ax_anim 2, 0, 64, -19, -22, -19, -22,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sTogepiAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 1, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 67, -22, 0, -22, 0,
+ax_anim 2, 0, 67, -22, 1, -22, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sTogepiAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -11, 9, -11, 9,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 1, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 70, -22, 20, -22, 20,
+ax_anim 2, 0, 70, -23, 19, -23, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTogepiAnims_4_1:
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 3, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 3, 0, 72, 0, 1, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 3, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 3, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 3, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 3, 1, 72, 0, 1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_4_2:
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 3, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 3, 0, 74, 0, 1, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 3, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 3, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 3, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 0, 75, 0, -1, 0, 0,
+ax_anim 3, 1, 74, 0, 1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_4_3:
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 3, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 3, 0, 76, 0, 1, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 3, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 3, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 3, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 3, 1, 76, 0, 1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_4_4:
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 3, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 3, 0, 78, 0, 1, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 3, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 3, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 3, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 3, 1, 78, 0, 1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_4_5:
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 3, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 3, 0, 80, 0, 1, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 3, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 3, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 3, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -1, 0, 0,
+ax_anim 3, 1, 80, 0, 1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_4_6:
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 0, 82, 0, 1, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 3, 1, 82, 0, 1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_4_7:
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 0, 84, 0, 1, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 3, 1, 84, 0, 1, 0, 0,
+ax_anim_terminator
+sTogepiAnims_4_8:
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 0, 86, 0, 1, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, 0,
+ax_anim 3, 1, 86, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_5_1:
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_5_2:
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_5_3:
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_5_4:
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_5_5:
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_5_6:
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_5_7:
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_5_8:
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sTogepiAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sTogepiAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sTogepiAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sTogepiAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sTogepiAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sTogepiAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sTogepiAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sTogepiAnims_8_1:
+ax_anim 30, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 10, 0, 122, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_8_2:
+ax_anim 30, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim 10, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_8_3:
+ax_anim 30, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 10, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_8_4:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 10, 0, 128, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_8_5:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_8_6:
+ax_anim 30, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_8_7:
+ax_anim 30, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_8_8:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 3, 6, 3,
+ax_anim 2, 0, 140, 9, 11, 9, 11,
+ax_anim 2, 0, 141, 7, 18, 7, 18,
+ax_anim 3, 0, 142, 0, 21, 0, 21,
+ax_anim 2, 3, 143, -7, 18, -7, 18,
+ax_anim 2, 0, 144, -9, 11, -9, 11,
+ax_anim 1, 0, 145, -6, 3, -6, 3,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 9, 2, 9, 2,
+ax_anim 2, 0, 139, 19, 7, 19, 7,
+ax_anim 2, 0, 140, 24, 15, 24, 15,
+ax_anim 3, 0, 141, 23, 21, 23, 21,
+ax_anim 2, 3, 142, 13, 21, 13, 21,
+ax_anim 2, 0, 143, 6, 15, 6, 15,
+ax_anim 1, 0, 144, 1, 8, 1, 8,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 4, -5, 4, -5,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 20, -5, 20, -5,
+ax_anim 3, 0, 140, 23, 0, 23, 0,
+ax_anim 2, 3, 141, 20, 5, 20, 5,
+ax_anim 2, 0, 142, 12, 6, 12, 6,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 1, -8, 1, -8,
+ax_anim 2, 0, 145, 5, -19, 5, -19,
+ax_anim 2, 0, 138, 14, -24, 14, -24,
+ax_anim 3, 0, 139, 23, -24, 23, -24,
+ax_anim 2, 3, 140, 22, -15, 22, -15,
+ax_anim 2, 0, 141, 16, -6, 16, -6,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -6, -4, -6, -4,
+ax_anim 2, 0, 144, -10, -12, -10, -12,
+ax_anim 2, 0, 145, -7, -21, -7, -21,
+ax_anim 3, 0, 138, 0, -24, 0, -24,
+ax_anim 2, 3, 139, 7, -21, 7, -21,
+ax_anim 2, 0, 140, 10, -12, 10, -12,
+ax_anim 1, 0, 141, 6, -4, 6, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -8, 1, -8,
+ax_anim 2, 0, 139, -5, -19, -5, -19,
+ax_anim 2, 0, 138, -14, -24, -14, -24,
+ax_anim 3, 0, 145, -23, -24, -23, -24,
+ax_anim 2, 3, 144, -22, -15, -22, -15,
+ax_anim 2, 0, 143, -16, -6, -16, -6,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -4, -5, -4, -5,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -20, -5, -20, -5,
+ax_anim 3, 0, 144, -23, 0, -23, 0,
+ax_anim 2, 3, 143, -20, 5, -20, 5,
+ax_anim 2, 0, 142, -12, 6, -12, 6,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -9, 2, -9, 2,
+ax_anim 2, 0, 145, -19, 7, -19, 7,
+ax_anim 2, 0, 144, -24, 15, -24, 15,
+ax_anim 3, 0, 143, -23, 21, -23, 21,
+ax_anim 2, 3, 142, -13, 21, -13, 21,
+ax_anim 2, 0, 141, -6, 15, -6, 15,
+ax_anim 1, 0, 140, -1, 8, -1, 8,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_10_1:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_10_2:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_10_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_10_4:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_10_5:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_10_6:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_10_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_10_8:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_11_1:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 182, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_11_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -17, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_11_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -17, 0, 0,
+ax_anim 1, 0, 188, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_11_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_11_5:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -17, 0, 0,
+ax_anim 1, 0, 194, 0, -11, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_11_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_11_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -17, 0, 0,
+ax_anim 1, 0, 200, 0, -11, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_11_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_12_1:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_12_2:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_12_3:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_12_4:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_12_5:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_12_6:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_12_7:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_12_8:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogepiAnims_13_1:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_13_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_13_3:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_13_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_13_5:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_13_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_13_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiAnims_13_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTogepiGfx1:
+.incbin "baserom.gba", 0xC9DC74, 0x100
+sTogepiSprites1:
+ax_sprite sTogepiGfx1, 0x100
+ax_sprite_terminator
+sTogepiGfx2:
+.incbin "baserom.gba", 0xC9DD84, 0x100
+sTogepiSprites2:
+ax_sprite sTogepiGfx2, 0x100
+ax_sprite_terminator
+sTogepiGfx3:
+.incbin "baserom.gba", 0xC9DE94, 0x100
+sTogepiSprites3:
+ax_sprite sTogepiGfx3, 0x100
+ax_sprite_terminator
+sTogepiGfx4:
+.incbin "baserom.gba", 0xC9DFA4, 0x100
+sTogepiSprites4:
+ax_sprite sTogepiGfx4, 0x100
+ax_sprite_terminator
+sTogepiGfx5:
+.incbin "baserom.gba", 0xC9E0B4, 0x100
+sTogepiSprites5:
+ax_sprite sTogepiGfx5, 0x100
+ax_sprite_terminator
+sTogepiGfx6:
+.incbin "baserom.gba", 0xC9E1C4, 0x100
+sTogepiSprites6:
+ax_sprite sTogepiGfx6, 0x100
+ax_sprite_terminator
+sTogepiGfx7:
+.incbin "baserom.gba", 0xC9E2D4, 0x100
+sTogepiSprites7:
+ax_sprite sTogepiGfx7, 0x100
+ax_sprite_terminator
+sTogepiGfx8:
+.incbin "baserom.gba", 0xC9E3E4, 0x100
+sTogepiSprites8:
+ax_sprite sTogepiGfx8, 0x100
+ax_sprite_terminator
+sTogepiGfx9:
+.incbin "baserom.gba", 0xC9E4F4, 0x100
+sTogepiSprites9:
+ax_sprite sTogepiGfx9, 0x100
+ax_sprite_terminator
+sTogepiGfx10:
+.incbin "baserom.gba", 0xC9E604, 0x100
+sTogepiSprites10:
+ax_sprite sTogepiGfx10, 0x100
+ax_sprite_terminator
+sTogepiGfx11:
+.incbin "baserom.gba", 0xC9E714, 0x100
+sTogepiSprites11:
+ax_sprite sTogepiGfx11, 0x100
+ax_sprite_terminator
+sTogepiGfx12:
+.incbin "baserom.gba", 0xC9E824, 0x100
+sTogepiSprites12:
+ax_sprite sTogepiGfx12, 0x100
+ax_sprite_terminator
+sTogepiGfx13:
+.incbin "baserom.gba", 0xC9E934, 0x100
+sTogepiSprites13:
+ax_sprite sTogepiGfx13, 0x100
+ax_sprite_terminator
+sTogepiGfx14:
+.incbin "baserom.gba", 0xC9EA44, 0x100
+sTogepiSprites14:
+ax_sprite sTogepiGfx14, 0x100
+ax_sprite_terminator
+sTogepiGfx15:
+.incbin "baserom.gba", 0xC9EB54, 0x100
+sTogepiSprites15:
+ax_sprite sTogepiGfx15, 0x100
+ax_sprite_terminator
+sTogepiGfx16:
+.incbin "baserom.gba", 0xC9EC64, 0xC0
+sTogepiSprites16:
+ax_sprite sTogepiGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx17:
+.incbin "baserom.gba", 0xC9ED3C, 0xC0
+sTogepiSprites17:
+ax_sprite sTogepiGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx18:
+.incbin "baserom.gba", 0xC9EE14, 0xC0
+sTogepiSprites18:
+ax_sprite sTogepiGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx19:
+.incbin "baserom.gba", 0xC9EEEC, 0xC0
+sTogepiSprites19:
+ax_sprite sTogepiGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx20:
+.incbin "baserom.gba", 0xC9EFC4, 0xC0
+sTogepiSprites20:
+ax_sprite sTogepiGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx21:
+.incbin "baserom.gba", 0xC9F09C, 0xC0
+sTogepiSprites21:
+ax_sprite sTogepiGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx22:
+.incbin "baserom.gba", 0xC9F174, 0xC0
+sTogepiSprites22:
+ax_sprite sTogepiGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx23:
+.incbin "baserom.gba", 0xC9F24C, 0xC0
+sTogepiSprites23:
+ax_sprite sTogepiGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx24:
+.incbin "baserom.gba", 0xC9F324, 0xC0
+sTogepiSprites24:
+ax_sprite sTogepiGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx25:
+.incbin "baserom.gba", 0xC9F3FC, 0xC0
+sTogepiSprites25:
+ax_sprite sTogepiGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx26:
+.incbin "baserom.gba", 0xC9F4D4, 0xC0
+sTogepiSprites26:
+ax_sprite sTogepiGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx27:
+.incbin "baserom.gba", 0xC9F5AC, 0xC0
+sTogepiSprites27:
+ax_sprite sTogepiGfx27, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx28:
+.incbin "baserom.gba", 0xC9F684, 0xC0
+sTogepiSprites28:
+ax_sprite sTogepiGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx29:
+.incbin "baserom.gba", 0xC9F75C, 0xC0
+sTogepiSprites29:
+ax_sprite sTogepiGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx30:
+.incbin "baserom.gba", 0xC9F834, 0xC0
+sTogepiSprites30:
+ax_sprite sTogepiGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogepiGfx31:
+.incbin "baserom.gba", 0xC9F90C, 0x20
+sTogepiSprites31:
+ax_sprite sTogepiGfx31, 0x20
+ax_sprite_terminator
+sTogepiGfx32:
+.incbin "baserom.gba", 0xC9F93C, 0x100
+sTogepiSprites32:
+ax_sprite sTogepiGfx32, 0x100
+ax_sprite_terminator
+sTogepiGfx33:
+.incbin "baserom.gba", 0xC9FA4C, 0x100
+sTogepiSprites33:
+ax_sprite sTogepiGfx33, 0x100
+ax_sprite_terminator
+sTogepiGfx34:
+.incbin "baserom.gba", 0xC9FB5C, 0x200
+sTogepiSprites34:
+ax_sprite sTogepiGfx34, 0x200
+ax_sprite_terminator
+sTogepiGfx35:
+.incbin "baserom.gba", 0xC9FD6C, 0x200
+sTogepiSprites35:
+ax_sprite sTogepiGfx35, 0x200
+ax_sprite_terminator
+sTogepiGfx36:
+.incbin "baserom.gba", 0xC9FF7C, 0x200
+sTogepiSprites36:
+ax_sprite sTogepiGfx36, 0x200
+ax_sprite_terminator
+sTogepiGfx37:
+.incbin "baserom.gba", 0xCA018C, 0x200
+sTogepiSprites37:
+ax_sprite sTogepiGfx37, 0x200
+ax_sprite_terminator
+sTogepiGfx38:
+.incbin "baserom.gba", 0xCA039C, 0x200
+sTogepiSprites38:
+ax_sprite sTogepiGfx38, 0x200
+ax_sprite_terminator
+sAxPosesTogepi:
+.4byte sTogepiPose1
+.4byte sTogepiPose2
+.4byte sTogepiPose3
+.4byte sTogepiPose4
+.4byte sTogepiPose5
+.4byte sTogepiPose6
+.4byte sTogepiPose7
+.4byte sTogepiPose8
+.4byte sTogepiPose9
+.4byte sTogepiPose10
+.4byte sTogepiPose11
+.4byte sTogepiPose12
+.4byte sTogepiPose13
+.4byte sTogepiPose14
+.4byte sTogepiPose15
+.4byte sTogepiPose16
+.4byte sTogepiPose17
+.4byte sTogepiPose18
+.4byte sTogepiPose19
+.4byte sTogepiPose20
+.4byte sTogepiPose21
+.4byte sTogepiPose22
+.4byte sTogepiPose23
+.4byte sTogepiPose24
+.4byte sTogepiPose25
+.4byte sTogepiPose26
+.4byte sTogepiPose27
+.4byte sTogepiPose28
+.4byte sTogepiPose29
+.4byte sTogepiPose30
+.4byte sTogepiPose31
+.4byte sTogepiPose32
+.4byte sTogepiPose33
+.4byte sTogepiPose34
+.4byte sTogepiPose35
+.4byte sTogepiPose36
+.4byte sTogepiPose37
+.4byte sTogepiPose38
+.4byte sTogepiPose39
+.4byte sTogepiPose40
+.4byte sTogepiPose41
+.4byte sTogepiPose42
+.4byte sTogepiPose43
+.4byte sTogepiPose44
+.4byte sTogepiPose45
+.4byte sTogepiPose46
+.4byte sTogepiPose47
+.4byte sTogepiPose48
+.4byte sTogepiPose49
+.4byte sTogepiPose50
+.4byte sTogepiPose51
+.4byte sTogepiPose52
+.4byte sTogepiPose53
+.4byte sTogepiPose54
+.4byte sTogepiPose55
+.4byte sTogepiPose56
+.4byte sTogepiPose57
+.4byte sTogepiPose58
+.4byte sTogepiPose59
+.4byte sTogepiPose60
+.4byte sTogepiPose61
+.4byte sTogepiPose62
+.4byte sTogepiPose63
+.4byte sTogepiPose64
+.4byte sTogepiPose65
+.4byte sTogepiPose66
+.4byte sTogepiPose67
+.4byte sTogepiPose68
+.4byte sTogepiPose69
+.4byte sTogepiPose70
+.4byte sTogepiPose71
+.4byte sTogepiPose72
+.4byte sTogepiPose73
+.4byte sTogepiPose74
+.4byte sTogepiPose75
+.4byte sTogepiPose76
+.4byte sTogepiPose77
+.4byte sTogepiPose78
+.4byte sTogepiPose79
+.4byte sTogepiPose80
+.4byte sTogepiPose81
+.4byte sTogepiPose82
+.4byte sTogepiPose83
+.4byte sTogepiPose84
+.4byte sTogepiPose85
+.4byte sTogepiPose86
+.4byte sTogepiPose87
+.4byte sTogepiPose88
+.4byte sTogepiPose89
+.4byte sTogepiPose90
+.4byte sTogepiPose91
+.4byte sTogepiPose92
+.4byte sTogepiPose93
+.4byte sTogepiPose94
+.4byte sTogepiPose95
+.4byte sTogepiPose96
+.4byte sTogepiPose97
+.4byte sTogepiPose98
+.4byte sTogepiPose99
+.4byte sTogepiPose100
+.4byte sTogepiPose101
+.4byte sTogepiPose102
+.4byte sTogepiPose103
+.4byte sTogepiPose104
+.4byte sTogepiPose105
+.4byte sTogepiPose106
+.4byte sTogepiPose107
+.4byte sTogepiPose108
+.4byte sTogepiPose109
+.4byte sTogepiPose110
+.4byte sTogepiPose111
+.4byte sTogepiPose112
+.4byte sTogepiPose113
+.4byte sTogepiPose114
+.4byte sTogepiPose115
+.4byte sTogepiPose116
+.4byte sTogepiPose117
+.4byte sTogepiPose118
+.4byte sTogepiPose119
+.4byte sTogepiPose120
+.4byte sTogepiPose121
+.4byte sTogepiPose122
+.4byte sTogepiPose123
+.4byte sTogepiPose124
+.4byte sTogepiPose125
+.4byte sTogepiPose126
+.4byte sTogepiPose127
+.4byte sTogepiPose128
+.4byte sTogepiPose129
+.4byte sTogepiPose130
+.4byte sTogepiPose131
+.4byte sTogepiPose132
+.4byte sTogepiPose133
+.4byte sTogepiPose134
+.4byte sTogepiPose135
+.4byte sTogepiPose136
+.4byte sTogepiPose137
+.4byte sTogepiPose138
+.4byte sTogepiPose139
+.4byte sTogepiPose140
+.4byte sTogepiPose141
+.4byte sTogepiPose142
+.4byte sTogepiPose143
+.4byte sTogepiPose144
+.4byte sTogepiPose145
+.4byte sTogepiPose146
+.4byte sTogepiPose147
+.4byte sTogepiPose148
+.4byte sTogepiPose149
+.4byte sTogepiPose150
+.4byte sTogepiPose151
+.4byte sTogepiPose152
+.4byte sTogepiPose153
+.4byte sTogepiPose154
+.4byte sTogepiPose155
+.4byte sTogepiPose156
+.4byte sTogepiPose157
+.4byte sTogepiPose158
+.4byte sTogepiPose159
+.4byte sTogepiPose160
+.4byte sTogepiPose161
+.4byte sTogepiPose162
+.4byte sTogepiPose163
+.4byte sTogepiPose164
+.4byte sTogepiPose165
+.4byte sTogepiPose166
+.4byte sTogepiPose167
+.4byte sTogepiPose168
+.4byte sTogepiPose169
+.4byte sTogepiPose170
+.4byte sTogepiPose171
+.4byte sTogepiPose172
+.4byte sTogepiPose173
+.4byte sTogepiPose174
+.4byte sTogepiPose175
+.4byte sTogepiPose176
+.4byte sTogepiPose177
+.4byte sTogepiPose178
+.4byte sTogepiPose179
+.4byte sTogepiPose180
+.4byte sTogepiPose181
+.4byte sTogepiPose182
+.4byte sTogepiPose183
+.4byte sTogepiPose184
+.4byte sTogepiPose185
+.4byte sTogepiPose186
+.4byte sTogepiPose187
+.4byte sTogepiPose188
+.4byte sTogepiPose189
+.4byte sTogepiPose190
+.4byte sTogepiPose191
+.4byte sTogepiPose192
+.4byte sTogepiPose193
+.4byte sTogepiPose194
+.4byte sTogepiPose195
+.4byte sTogepiPose196
+.4byte sTogepiPose197
+.4byte sTogepiPose198
+.4byte sTogepiPose199
+.4byte sTogepiPose200
+.4byte sTogepiPose201
+.4byte sTogepiPose202
+.4byte sTogepiPose203
+.4byte sTogepiPose204
+.4byte sTogepiPose205
+.4byte sTogepiPose206
+.4byte sTogepiPose207
+.4byte sTogepiPose208
+.4byte sTogepiPose209
+.4byte sTogepiPose210
+.4byte sTogepiPose211
+.4byte sTogepiPose212
+.4byte sTogepiPose213
+.4byte sTogepiPose214
+.4byte sTogepiPose215
+.4byte sTogepiPose216
+.4byte sTogepiPose217
+.4byte sTogepiPose218
+.4byte sTogepiPose219
+.4byte sTogepiPose220
+.4byte sTogepiPose221
+.4byte sTogepiPose222
+sAxPositionsTogepi:
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte    0,   -8, 	  -6,   -7, 	   6,   -8, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -8, 	   5,   -7, 	   0,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -8, 	   6,   -8, 	  -5,   -6, 	   0,   -7
+.2byte    2,   -8, 	   6,   -9, 	  -3,   -6, 	   0,   -8
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    5,   -9, 	   0,   -9, 	   0,   -6, 	  -1,   -8
+.2byte    3,  -10, 	  -1,  -10, 	   2,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    0,  -10, 	  -4,   -9, 	   6,   -7, 	  -1,   -7
+.2byte    1,  -10, 	  -7,   -8, 	   6,   -7, 	  -1,   -8
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -9, 	   6,   -9, 	  -7,   -8, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -8, 	  -7,   -9, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -1,  -10, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -2,  -10, 	   6,   -8, 	  -7,   -7, 	   0,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -6,   -9, 	  -1,   -9, 	  -1,   -6, 	   0,   -8
+.2byte   -4,  -10, 	   0,  -10, 	  -3,   -6, 	   0,   -8
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -7,   -8, 	   4,   -6, 	  -1,   -7
+.2byte   -3,   -8, 	  -7,   -9, 	   2,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte    0,   -8, 	  -6,   -7, 	   6,   -8, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -8, 	   5,   -7, 	   0,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -8, 	   6,   -8, 	  -5,   -6, 	   0,   -7
+.2byte    2,   -8, 	   6,   -9, 	  -3,   -6, 	   0,   -8
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    5,   -9, 	   0,   -9, 	   0,   -6, 	  -1,   -8
+.2byte    3,  -10, 	  -1,  -10, 	   2,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    0,  -10, 	  -4,   -9, 	   6,   -7, 	  -1,   -7
+.2byte    1,  -10, 	  -7,   -8, 	   6,   -7, 	  -1,   -8
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -9, 	   6,   -9, 	  -7,   -8, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -8, 	  -7,   -9, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -1,  -10, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -2,  -10, 	   6,   -8, 	  -7,   -7, 	   0,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -6,   -9, 	  -1,   -9, 	  -1,   -6, 	   0,   -8
+.2byte   -4,  -10, 	   0,  -10, 	  -3,   -6, 	   0,   -8
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -7,   -8, 	   4,   -6, 	  -1,   -7
+.2byte   -3,   -8, 	  -7,   -9, 	   2,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte    0,   -8, 	  -6,   -7, 	   6,   -8, 	   0,   -7
+.2byte   -2,   -8, 	  -7,   -8, 	   5,   -7, 	   0,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -8, 	   6,   -8, 	  -5,   -6, 	   0,   -7
+.2byte    2,   -8, 	   6,   -9, 	  -3,   -6, 	   0,   -8
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    5,   -9, 	   0,   -9, 	   0,   -6, 	  -1,   -8
+.2byte    3,  -10, 	  -1,  -10, 	   2,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    0,  -10, 	  -4,   -9, 	   6,   -7, 	  -1,   -7
+.2byte    1,  -10, 	  -7,   -8, 	   6,   -7, 	  -1,   -8
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -9, 	   6,   -9, 	  -7,   -8, 	  -1,   -7
+.2byte   -1,   -9, 	   6,   -8, 	  -7,   -9, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -1,  -10, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -2,  -10, 	   6,   -8, 	  -7,   -7, 	   0,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -6,   -9, 	  -1,   -9, 	  -1,   -6, 	   0,   -8
+.2byte   -4,  -10, 	   0,  -10, 	  -3,   -6, 	   0,   -8
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -7,   -8, 	   4,   -6, 	  -1,   -7
+.2byte   -3,   -8, 	  -7,   -9, 	   2,   -6, 	  -1,   -8
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -1,  -10, 	  -6,  -11, 	   5,  -11, 	  -1,   -9
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    1,  -10, 	   6,  -12, 	  -4,  -10, 	   0,   -9
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    5,  -11, 	   0,  -12, 	   1,   -9, 	  -1,   -9
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    1,  -12, 	  -4,  -13, 	   6,  -11, 	  -1,  -10
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    0,  -12, 	   6,  -12, 	  -7,  -12, 	   0,   -9
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -2,  -12, 	   3,  -13, 	  -7,  -11, 	   0,  -10
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -6,  -11, 	  -1,  -12, 	  -2,   -9, 	   0,   -9
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -2,  -10, 	  -7,  -12, 	   3,  -10, 	  -1,   -9
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -2,   -7, 	  -8,   -6, 	   4,   -7, 	  -2,   -5
+.2byte    0,   -7, 	  -6,   -6, 	   8,   -7, 	   0,   -5
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    2,   -6, 	   7,   -7, 	  -2,   -6, 	   1,   -6
+.2byte    0,   -7, 	   5,   -7, 	  -6,   -6, 	  -2,   -6
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    5,   -9, 	   1,  -10, 	   2,   -7, 	   0,   -7
+.2byte    5,   -7, 	  -1,   -8, 	   0,   -4, 	  -1,   -5
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    0,   -9, 	  -5,  -10, 	   5,   -7, 	  -2,   -6
+.2byte    2,   -9, 	  -3,  -10, 	   8,   -7, 	   0,   -6
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -9, 	   7,   -7, 	  -6,   -8, 	   1,   -6
+.2byte   -2,   -9, 	   5,   -7, 	  -9,   -8, 	  -1,   -6
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -1,   -9, 	   4,  -10, 	  -6,   -7, 	   1,   -6
+.2byte   -3,   -9, 	   2,  -10, 	  -9,   -7, 	  -1,   -6
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -6,   -9, 	  -2,  -10, 	  -3,   -7, 	  -1,   -7
+.2byte   -6,   -7, 	   0,   -8, 	  -1,   -4, 	   0,   -5
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -3,   -6, 	  -8,   -7, 	   1,   -6, 	  -2,   -6
+.2byte   -1,   -7, 	  -6,   -7, 	   5,   -6, 	   1,   -6
+.2byte   -1,   -6, 	  -5,   -4, 	   4,   -3, 	   0,   -5
+.2byte   -2,   -5, 	  -5,   -4, 	   5,   -2, 	   0,   -4
+.2byte   -1,   -8, 	  -5,   -7, 	   4,   -7, 	   0,   -6
+.2byte    2,   -7, 	   6,   -8, 	  -2,   -6, 	   0,   -6
+.2byte    4,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,   -6
+.2byte    1,   -8, 	  -4,  -10, 	   6,   -7, 	  -1,   -5
+.2byte   -1,   -7, 	   3,   -6, 	  -4,   -6, 	   0,   -5
+.2byte   -2,   -8, 	   3,  -10, 	  -7,   -7, 	   0,   -5
+.2byte   -5,   -8, 	   0,   -9, 	  -2,   -7, 	   0,   -6
+.2byte   -3,   -7, 	  -7,   -8, 	   1,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,   -9, 	   5,   -9, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    1,   -8, 	   6,  -10, 	  -4,   -8, 	   0,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    6,   -9, 	   1,  -10, 	   2,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    2,  -10, 	  -3,  -11, 	   7,   -9, 	   0,   -8
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    0,  -10, 	   6,  -10, 	  -7,  -10, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -3,  -10, 	   2,  -11, 	  -8,   -9, 	  -1,   -8
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -7,   -9, 	  -2,  -10, 	  -3,   -7, 	  -1,   -7
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -2,   -8, 	  -7,  -10, 	   3,   -8, 	  -1,   -7
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte   -1,  -10, 	  -6,  -11, 	   5,  -11, 	  -1,   -9
+.2byte    1,  -10, 	   6,  -12, 	  -4,  -10, 	   0,   -9
+.2byte    5,  -11, 	   0,  -12, 	   1,   -9, 	  -1,   -9
+.2byte    1,  -12, 	  -4,  -13, 	   6,  -11, 	  -1,  -10
+.2byte    0,  -12, 	   6,  -12, 	  -7,  -12, 	   0,   -9
+.2byte   -2,  -12, 	   3,  -13, 	  -7,  -11, 	   0,  -10
+.2byte   -6,  -11, 	  -1,  -12, 	  -2,   -9, 	   0,   -9
+.2byte   -2,  -10, 	  -7,  -12, 	   3,  -10, 	  -1,   -9
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -8, 	   5,   -8, 	  -1,   -6
+.2byte    0,   -5, 	  -6,   -4, 	   6,   -5, 	   0,   -4
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+.2byte    1,   -7, 	   6,   -9, 	  -4,   -7, 	   0,   -6
+.2byte    0,   -8, 	   6,   -8, 	  -5,   -6, 	   0,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -9, 	   1,   -6, 	  -1,   -6
+.2byte    5,   -9, 	   0,   -9, 	   0,   -6, 	  -1,   -8
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    1,   -9, 	  -4,  -10, 	   6,   -8, 	  -1,   -7
+.2byte    0,  -10, 	  -4,   -9, 	   6,   -7, 	  -1,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    0,   -9, 	   6,   -9, 	  -7,   -9, 	   0,   -6
+.2byte    0,   -9, 	   6,   -9, 	  -7,   -8, 	  -1,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte   -2,   -9, 	   3,  -10, 	  -7,   -8, 	   0,   -7
+.2byte   -1,  -10, 	   3,   -9, 	  -7,   -7, 	   0,   -7
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -6,   -8, 	  -1,   -9, 	  -2,   -6, 	   0,   -6
+.2byte   -6,   -9, 	  -1,   -9, 	  -1,   -6, 	   0,   -8
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -2,   -7, 	  -7,   -9, 	   3,   -7, 	  -1,   -6
+.2byte   -1,   -8, 	  -7,   -8, 	   4,   -6, 	  -1,   -7
+.2byte    0,   -7, 	  -6,   -6, 	   8,   -7, 	   0,   -5
+.2byte   -2,   -6, 	  -7,   -7, 	   2,   -6, 	  -1,   -6
+.2byte   -6,   -8, 	  -2,   -9, 	  -3,   -6, 	  -1,   -6
+.2byte   -2,   -9, 	   3,  -10, 	  -7,   -7, 	   0,   -6
+.2byte   -1,   -9, 	   6,   -7, 	  -8,   -8, 	   0,   -6
+.2byte    1,   -9, 	  -4,  -10, 	   6,   -7, 	  -1,   -6
+.2byte    5,   -8, 	   1,   -9, 	   2,   -6, 	   0,   -6
+.2byte    1,   -6, 	   6,   -7, 	  -3,   -6, 	   0,   -6
+.2byte   -1,   -7, 	  -7,   -6, 	   6,   -6, 	  -1,   -6
+.2byte   -2,   -7, 	  -7,   -7, 	   3,   -5, 	  -1,   -6
+.2byte   -6,   -8, 	  -1,   -8, 	  -2,   -5, 	   0,   -7
+.2byte   -2,   -9, 	   3,   -8, 	  -7,   -6, 	   0,   -7
+.2byte    0,   -8, 	   6,   -7, 	  -7,   -7, 	   0,   -7
+.2byte    1,   -9, 	  -4,   -8, 	   6,   -6, 	  -1,   -7
+.2byte    5,   -8, 	   0,   -8, 	   1,   -5, 	  -1,   -7
+.2byte    1,   -7, 	   6,   -7, 	  -4,   -5, 	   0,   -6
+sTogepiAnimTable1:
+.4byte sTogepiAnims_1_1
+.4byte sTogepiAnims_1_2
+.4byte sTogepiAnims_1_3
+.4byte sTogepiAnims_1_4
+.4byte sTogepiAnims_1_5
+.4byte sTogepiAnims_1_6
+.4byte sTogepiAnims_1_7
+.4byte sTogepiAnims_1_8
+sTogepiAnimTable2:
+.4byte sTogepiAnims_2_1
+.4byte sTogepiAnims_2_2
+.4byte sTogepiAnims_2_3
+.4byte sTogepiAnims_2_4
+.4byte sTogepiAnims_2_5
+.4byte sTogepiAnims_2_6
+.4byte sTogepiAnims_2_7
+.4byte sTogepiAnims_2_8
+sTogepiAnimTable3:
+.4byte sTogepiAnims_3_1
+.4byte sTogepiAnims_3_2
+.4byte sTogepiAnims_3_3
+.4byte sTogepiAnims_3_4
+.4byte sTogepiAnims_3_5
+.4byte sTogepiAnims_3_6
+.4byte sTogepiAnims_3_7
+.4byte sTogepiAnims_3_8
+sTogepiAnimTable4:
+.4byte sTogepiAnims_4_1
+.4byte sTogepiAnims_4_2
+.4byte sTogepiAnims_4_3
+.4byte sTogepiAnims_4_4
+.4byte sTogepiAnims_4_5
+.4byte sTogepiAnims_4_6
+.4byte sTogepiAnims_4_7
+.4byte sTogepiAnims_4_8
+sTogepiAnimTable5:
+.4byte sTogepiAnims_5_1
+.4byte sTogepiAnims_5_2
+.4byte sTogepiAnims_5_3
+.4byte sTogepiAnims_5_4
+.4byte sTogepiAnims_5_5
+.4byte sTogepiAnims_5_6
+.4byte sTogepiAnims_5_7
+.4byte sTogepiAnims_5_8
+sTogepiAnimTable6:
+.4byte sTogepiAnims_6_1
+.4byte sTogepiAnims_6_1
+.4byte sTogepiAnims_6_1
+.4byte sTogepiAnims_6_1
+.4byte sTogepiAnims_6_1
+.4byte sTogepiAnims_6_1
+.4byte sTogepiAnims_6_1
+.4byte sTogepiAnims_6_1
+sTogepiAnimTable7:
+.4byte sTogepiAnims_7_1
+.4byte sTogepiAnims_7_2
+.4byte sTogepiAnims_7_3
+.4byte sTogepiAnims_7_4
+.4byte sTogepiAnims_7_5
+.4byte sTogepiAnims_7_6
+.4byte sTogepiAnims_7_7
+.4byte sTogepiAnims_7_8
+sTogepiAnimTable8:
+.4byte sTogepiAnims_8_1
+.4byte sTogepiAnims_8_2
+.4byte sTogepiAnims_8_3
+.4byte sTogepiAnims_8_4
+.4byte sTogepiAnims_8_5
+.4byte sTogepiAnims_8_6
+.4byte sTogepiAnims_8_7
+.4byte sTogepiAnims_8_8
+sTogepiAnimTable9:
+.4byte sTogepiAnims_9_1
+.4byte sTogepiAnims_9_2
+.4byte sTogepiAnims_9_3
+.4byte sTogepiAnims_9_4
+.4byte sTogepiAnims_9_5
+.4byte sTogepiAnims_9_6
+.4byte sTogepiAnims_9_7
+.4byte sTogepiAnims_9_8
+sTogepiAnimTable10:
+.4byte sTogepiAnims_10_1
+.4byte sTogepiAnims_10_2
+.4byte sTogepiAnims_10_3
+.4byte sTogepiAnims_10_4
+.4byte sTogepiAnims_10_5
+.4byte sTogepiAnims_10_6
+.4byte sTogepiAnims_10_7
+.4byte sTogepiAnims_10_8
+sTogepiAnimTable11:
+.4byte sTogepiAnims_11_1
+.4byte sTogepiAnims_11_2
+.4byte sTogepiAnims_11_3
+.4byte sTogepiAnims_11_4
+.4byte sTogepiAnims_11_5
+.4byte sTogepiAnims_11_6
+.4byte sTogepiAnims_11_7
+.4byte sTogepiAnims_11_8
+sTogepiAnimTable12:
+.4byte sTogepiAnims_12_1
+.4byte sTogepiAnims_12_2
+.4byte sTogepiAnims_12_3
+.4byte sTogepiAnims_12_4
+.4byte sTogepiAnims_12_5
+.4byte sTogepiAnims_12_6
+.4byte sTogepiAnims_12_7
+.4byte sTogepiAnims_12_8
+sTogepiAnimTable13:
+.4byte sTogepiAnims_13_1
+.4byte sTogepiAnims_13_2
+.4byte sTogepiAnims_13_3
+.4byte sTogepiAnims_13_4
+.4byte sTogepiAnims_13_5
+.4byte sTogepiAnims_13_6
+.4byte sTogepiAnims_13_7
+.4byte sTogepiAnims_13_8
+sAxAnimationsTogepi:
+.4byte sTogepiAnimTable1
+.4byte sTogepiAnimTable2
+.4byte sTogepiAnimTable3
+.4byte sTogepiAnimTable4
+.4byte sTogepiAnimTable5
+.4byte sTogepiAnimTable6
+.4byte sTogepiAnimTable7
+.4byte sTogepiAnimTable8
+.4byte sTogepiAnimTable9
+.4byte sTogepiAnimTable10
+.4byte sTogepiAnimTable11
+.4byte sTogepiAnimTable12
+.4byte sTogepiAnimTable13
+sAxSpritesTogepi:
+.4byte sTogepiSprites1
+.4byte sTogepiSprites2
+.4byte sTogepiSprites3
+.4byte sTogepiSprites4
+.4byte sTogepiSprites5
+.4byte sTogepiSprites6
+.4byte sTogepiSprites7
+.4byte sTogepiSprites8
+.4byte sTogepiSprites9
+.4byte sTogepiSprites10
+.4byte sTogepiSprites11
+.4byte sTogepiSprites12
+.4byte sTogepiSprites13
+.4byte sTogepiSprites14
+.4byte sTogepiSprites15
+.4byte sTogepiSprites16
+.4byte sTogepiSprites17
+.4byte sTogepiSprites18
+.4byte sTogepiSprites19
+.4byte sTogepiSprites20
+.4byte sTogepiSprites21
+.4byte sTogepiSprites22
+.4byte sTogepiSprites23
+.4byte sTogepiSprites24
+.4byte sTogepiSprites25
+.4byte sTogepiSprites26
+.4byte sTogepiSprites27
+.4byte sTogepiSprites28
+.4byte sTogepiSprites29
+.4byte sTogepiSprites30
+.4byte sTogepiSprites31
+.4byte sTogepiSprites32
+.4byte sTogepiSprites33
+.4byte sTogepiSprites34
+.4byte sTogepiSprites35
+.4byte sTogepiSprites36
+.4byte sTogepiSprites37
+.4byte sTogepiSprites38
+sAxMainTogepi:
+ax_main sAxPosesTogepi, sAxAnimationsTogepi, 13, sAxSpritesTogepi, sAxPositionsTogepi

--- a/data/ax/togetic.inc
+++ b/data/ax/togetic.inc
@@ -1,0 +1,2832 @@
+.global gAxTogetic
+gAxTogetic:
+ax_siro sAxMainTogetic
+sTogeticPose1:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose2:
+ax_pose 1, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose3:
+ax_pose 2, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose4:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose5:
+ax_pose 4, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose6:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose7:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose8:
+ax_pose 8, 0x81eb, 0x10f1, 0x5c00
+ax_pose 9, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose9:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose10:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose11:
+ax_pose 13, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose12:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose13:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose14:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose15:
+ax_pose 17, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose16:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose17:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose18:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose19:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose20:
+ax_pose 8, 0x81eb, 0x0107, 0x5c00
+ax_pose 9, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose21:
+ax_pose 10, 0x81eb, 0x0107, 0x5c00
+ax_pose 11, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose22:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose23:
+ax_pose 4, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose24:
+ax_pose 5, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose25:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose26:
+ax_pose 1, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose27:
+ax_pose 2, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose28:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose29:
+ax_pose 4, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose30:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose31:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose32:
+ax_pose 8, 0x81eb, 0x10f1, 0x5c00
+ax_pose 9, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose33:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose34:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose35:
+ax_pose 13, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose36:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose37:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose38:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose39:
+ax_pose 17, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose40:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose41:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose42:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose43:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose44:
+ax_pose 8, 0x81eb, 0x0107, 0x5c00
+ax_pose 9, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose45:
+ax_pose 10, 0x81eb, 0x0107, 0x5c00
+ax_pose 11, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose46:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose47:
+ax_pose 4, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose48:
+ax_pose 5, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose49:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose50:
+ax_pose 1, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose51:
+ax_pose 2, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose52:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose53:
+ax_pose 4, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose54:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose55:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose56:
+ax_pose 8, 0x81eb, 0x10f1, 0x5c00
+ax_pose 9, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose57:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose58:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose59:
+ax_pose 13, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose60:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose61:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose62:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose63:
+ax_pose 17, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose64:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose65:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose66:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose67:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose68:
+ax_pose 8, 0x81eb, 0x0107, 0x5c00
+ax_pose 9, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose69:
+ax_pose 10, 0x81eb, 0x0107, 0x5c00
+ax_pose 11, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose70:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose71:
+ax_pose 4, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose72:
+ax_pose 5, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose73:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose74:
+ax_pose 18, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose75:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose 20, 0x01f2, 0x00f0, 0x5c08
+ax_pose_terminator
+sTogeticPose76:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose77:
+ax_pose 21, 0x81ea, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose78:
+ax_pose 22, 0x01f2, 0x10f0, 0x5c00
+ax_pose 23, 0x81ea, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose79:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose80:
+ax_pose 24, 0x81ea, 0x10f1, 0x5c00
+ax_pose 25, 0x81ea, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose81:
+ax_pose 26, 0x01f2, 0x10f1, 0x5c00
+ax_pose 27, 0x81ea, 0x90f9, 0x5c01
+ax_pose_terminator
+sTogeticPose82:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose83:
+ax_pose 28, 0x81ea, 0x10f1, 0x5c00
+ax_pose 29, 0x81ea, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose84:
+ax_pose 30, 0x01f2, 0x10f1, 0x5c00
+ax_pose 31, 0x81ea, 0x90f9, 0x5c01
+ax_pose_terminator
+sTogeticPose85:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose86:
+ax_pose 32, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose87:
+ax_pose 33, 0x81ea, 0x80f8, 0x5c00
+ax_pose 20, 0x01f5, 0x00f0, 0x5c08
+ax_pose_terminator
+sTogeticPose88:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose89:
+ax_pose 28, 0x81ea, 0x0107, 0x5c00
+ax_pose 29, 0x81ea, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose90:
+ax_pose 30, 0x01f2, 0x0107, 0x5c00
+ax_pose 31, 0x81ea, 0x80f7, 0x5c01
+ax_pose_terminator
+sTogeticPose91:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose92:
+ax_pose 24, 0x81ea, 0x0108, 0x5c00
+ax_pose 25, 0x81ea, 0x80f8, 0x5c02
+ax_pose_terminator
+sTogeticPose93:
+ax_pose 26, 0x01f2, 0x0108, 0x5c00
+ax_pose 27, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose94:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose95:
+ax_pose 21, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose96:
+ax_pose 22, 0x01f2, 0x0108, 0x5c00
+ax_pose 23, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose97:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose98:
+ax_pose 34, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sTogeticPose99:
+ax_pose 35, 0x81ea, 0x80f6, 0x5c00
+ax_pose_terminator
+sTogeticPose100:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose101:
+ax_pose 36, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose102:
+ax_pose 37, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose103:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose104:
+ax_pose 38, 0x01eb, 0x90e8, 0x5c00
+ax_pose_terminator
+sTogeticPose105:
+ax_pose 39, 0x01ea, 0x90e9, 0x5c00
+ax_pose_terminator
+sTogeticPose106:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose107:
+ax_pose 40, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose108:
+ax_pose 41, 0x81eb, 0x90f8, 0x5c00
+ax_pose 42, 0x01f3, 0x10f0, 0x5c08
+ax_pose_terminator
+sTogeticPose109:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose110:
+ax_pose 43, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose111:
+ax_pose 44, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose112:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose113:
+ax_pose 40, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose114:
+ax_pose 41, 0x81eb, 0x80f8, 0x5c00
+ax_pose 42, 0x01f3, 0x0108, 0x5c08
+ax_pose_terminator
+sTogeticPose115:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose116:
+ax_pose 38, 0x01eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose117:
+ax_pose 39, 0x01ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose118:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose119:
+ax_pose 36, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose120:
+ax_pose 37, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose121:
+ax_pose 45, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sTogeticPose122:
+ax_pose 46, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sTogeticPose123:
+ax_pose 47, 0x01e2, 0x80f4, 0x5c00
+ax_pose_terminator
+sTogeticPose124:
+ax_pose 48, 0x01e2, 0x90ea, 0x5c00
+ax_pose_terminator
+sTogeticPose125:
+ax_pose 49, 0x01e5, 0x90e8, 0x5c00
+ax_pose_terminator
+sTogeticPose126:
+ax_pose 50, 0x01ea, 0x90e8, 0x5c00
+ax_pose_terminator
+sTogeticPose127:
+ax_pose 51, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sTogeticPose128:
+ax_pose 50, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose129:
+ax_pose 49, 0x01e5, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose130:
+ax_pose 48, 0x01e2, 0x80f6, 0x5c00
+ax_pose_terminator
+sTogeticPose131:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose132:
+ax_pose 1, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose133:
+ax_pose 2, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose134:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose135:
+ax_pose 4, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose136:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose137:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose138:
+ax_pose 8, 0x81eb, 0x10f1, 0x5c00
+ax_pose 9, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose139:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose140:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose141:
+ax_pose 13, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose142:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose143:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose144:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose145:
+ax_pose 17, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose146:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose147:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose148:
+ax_pose 14, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose149:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose150:
+ax_pose 8, 0x81eb, 0x0107, 0x5c00
+ax_pose 9, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose151:
+ax_pose 10, 0x81eb, 0x0107, 0x5c00
+ax_pose 11, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose152:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose153:
+ax_pose 4, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose154:
+ax_pose 5, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose155:
+ax_pose 20, 0x01f2, 0x00f0, 0x5c00
+ax_pose 19, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose156:
+ax_pose 22, 0x01f2, 0x0108, 0x5c00
+ax_pose 23, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose157:
+ax_pose 26, 0x01f2, 0x0107, 0x5c00
+ax_pose 27, 0x81ea, 0x80f7, 0x5c01
+ax_pose_terminator
+sTogeticPose158:
+ax_pose 30, 0x01f3, 0x0108, 0x5c00
+ax_pose 31, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose159:
+ax_pose 20, 0x01f5, 0x00f0, 0x5c00
+ax_pose 33, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose160:
+ax_pose 30, 0x01f3, 0x10f0, 0x5c00
+ax_pose 31, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose161:
+ax_pose 26, 0x01f2, 0x10f1, 0x5c00
+ax_pose 27, 0x81ea, 0x90f9, 0x5c01
+ax_pose_terminator
+sTogeticPose162:
+ax_pose 22, 0x01f2, 0x10f0, 0x5c00
+ax_pose 23, 0x81ea, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose163:
+ax_pose 19, 0x81ea, 0x80f8, 0x5c00
+ax_pose 20, 0x01f2, 0x00f0, 0x5c08
+ax_pose_terminator
+sTogeticPose164:
+ax_pose 22, 0x01f2, 0x10f0, 0x5c00
+ax_pose 23, 0x81ea, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose165:
+ax_pose 26, 0x01f2, 0x10f1, 0x5c00
+ax_pose 27, 0x81ea, 0x90f9, 0x5c01
+ax_pose_terminator
+sTogeticPose166:
+ax_pose 30, 0x01f2, 0x10f0, 0x5c00
+ax_pose 31, 0x81ea, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose167:
+ax_pose 33, 0x81ea, 0x80f8, 0x5c00
+ax_pose 20, 0x01f5, 0x00f0, 0x5c08
+ax_pose_terminator
+sTogeticPose168:
+ax_pose 30, 0x01f2, 0x0108, 0x5c00
+ax_pose 31, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose169:
+ax_pose 26, 0x01f2, 0x0108, 0x5c00
+ax_pose 27, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose170:
+ax_pose 22, 0x01f2, 0x0108, 0x5c00
+ax_pose 23, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose171:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose172:
+ax_pose 20, 0x01f2, 0x00f0, 0x5c00
+ax_pose 19, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose173:
+ax_pose 1, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose174:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose175:
+ax_pose 22, 0x01f2, 0x10ef, 0x5c00
+ax_pose 23, 0x81ea, 0x90f7, 0x5c01
+ax_pose_terminator
+sTogeticPose176:
+ax_pose 4, 0x81ea, 0x90f7, 0x5c00
+ax_pose_terminator
+sTogeticPose177:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose178:
+ax_pose 26, 0x01f2, 0x10f0, 0x5c00
+ax_pose 27, 0x81ea, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose179:
+ax_pose 8, 0x81ea, 0x10f0, 0x5c00
+ax_pose 9, 0x81ea, 0x90f8, 0x5c02
+ax_pose_terminator
+sTogeticPose180:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose181:
+ax_pose 30, 0x01f2, 0x10f1, 0x5c00
+ax_pose 31, 0x81ea, 0x90f9, 0x5c01
+ax_pose_terminator
+sTogeticPose182:
+ax_pose 13, 0x81ea, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose183:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose184:
+ax_pose 20, 0x01f5, 0x00f0, 0x5c00
+ax_pose 33, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose185:
+ax_pose 16, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose186:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose187:
+ax_pose 30, 0x01f2, 0x0107, 0x5c00
+ax_pose 31, 0x81ea, 0x80f7, 0x5c01
+ax_pose_terminator
+sTogeticPose188:
+ax_pose 13, 0x81ea, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose189:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose190:
+ax_pose 26, 0x01f2, 0x0108, 0x5c00
+ax_pose 27, 0x81ea, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose191:
+ax_pose 8, 0x81ea, 0x0108, 0x5c00
+ax_pose 9, 0x81ea, 0x80f8, 0x5c02
+ax_pose_terminator
+sTogeticPose192:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose193:
+ax_pose 22, 0x01f2, 0x0109, 0x5c00
+ax_pose 23, 0x81ea, 0x80f9, 0x5c01
+ax_pose_terminator
+sTogeticPose194:
+ax_pose 4, 0x81ea, 0x80f9, 0x5c00
+ax_pose_terminator
+sTogeticPose195:
+ax_pose 1, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose196:
+ax_pose 4, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose197:
+ax_pose 8, 0x81eb, 0x0107, 0x5c00
+ax_pose 9, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose198:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose199:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose200:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose201:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose202:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose203:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose204:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose205:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose206:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose207:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose208:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose209:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose210:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose211:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose212:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose213:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose214:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose215:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose216:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose217:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose218:
+ax_pose 8, 0x81eb, 0x0107, 0x5c00
+ax_pose 9, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose219:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose220:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose221:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose222:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose223:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose224:
+ax_pose 4, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose225:
+ax_pose 8, 0x81eb, 0x0107, 0x5c00
+ax_pose 9, 0x81eb, 0x80f7, 0x5c02
+ax_pose_terminator
+sTogeticPose226:
+ax_pose 13, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sTogeticPose227:
+ax_pose 16, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose228:
+ax_pose 14, 0x81eb, 0x90f9, 0x5c00
+ax_pose_terminator
+sTogeticPose229:
+ax_pose 10, 0x81eb, 0x10f1, 0x5c00
+ax_pose 11, 0x81eb, 0x90f9, 0x5c02
+ax_pose_terminator
+sTogeticPose230:
+ax_pose 5, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose231:
+ax_pose 0, 0x81ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose232:
+ax_pose 3, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose233:
+ax_pose 6, 0x01f3, 0x0108, 0x5c00
+ax_pose 7, 0x81eb, 0x80f8, 0x5c01
+ax_pose_terminator
+sTogeticPose234:
+ax_pose 12, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose235:
+ax_pose 15, 0x81eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sTogeticPose236:
+ax_pose 12, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+sTogeticPose237:
+ax_pose 6, 0x01f3, 0x10f0, 0x5c00
+ax_pose 7, 0x81eb, 0x90f8, 0x5c01
+ax_pose_terminator
+sTogeticPose238:
+ax_pose 3, 0x81eb, 0x90f8, 0x5c00
+ax_pose_terminator
+.align 2
+sTogeticAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTogeticAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 21, 20, 21, 20,
+ax_anim 2, 1, 28, 22, 19, 22, 19,
+ax_anim 2, 0, 28, 21, 20, 21, 20,
+ax_anim 2, 0, 28, 22, 19, 22, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sTogeticAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 1, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 31, 21, 0, 21, 0,
+ax_anim 2, 0, 31, 21, 1, 21, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sTogeticAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 20, -20, 20, -20,
+ax_anim 2, 1, 34, 21, -19, 21, -19,
+ax_anim 2, 0, 34, 20, -20, 20, -20,
+ax_anim 2, 0, 34, 21, -19, 21, -19,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sTogeticAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 1, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 0, 37, 1, -20, 1, -20,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sTogeticAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -20, -20, -20, -20,
+ax_anim 2, 1, 40, -21, -19, -21, -19,
+ax_anim 2, 0, 40, -20, -20, -20, -20,
+ax_anim 2, 0, 40, -21, -19, -21, -19,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sTogeticAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 1, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 43, -21, 0, -21, 0,
+ax_anim 2, 0, 43, -21, 1, -21, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sTogeticAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -21, 20, -21, 20,
+ax_anim 2, 1, 46, -22, 19, -22, 19,
+ax_anim 2, 0, 46, -21, 20, -21, 20,
+ax_anim 2, 0, 46, -22, 19, -22, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTogeticAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 1, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 0, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sTogeticAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 21, 20, 21, 20,
+ax_anim 2, 1, 52, 22, 19, 22, 19,
+ax_anim 2, 0, 52, 21, 20, 21, 20,
+ax_anim 2, 0, 52, 22, 19, 22, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sTogeticAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 21, 0, 21, 0,
+ax_anim 2, 1, 55, 21, 1, 21, 1,
+ax_anim 2, 0, 55, 21, 0, 21, 0,
+ax_anim 2, 0, 55, 21, 1, 21, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sTogeticAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 58, 20, -20, 20, -20,
+ax_anim 2, 1, 58, 21, -19, 21, -19,
+ax_anim 2, 0, 58, 20, -20, 20, -20,
+ax_anim 2, 0, 58, 21, -19, 21, -19,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sTogeticAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 1, 61, 1, -20, 1, -20,
+ax_anim 2, 0, 61, 0, -20, 0, -20,
+ax_anim 2, 0, 61, 1, -20, 1, -20,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sTogeticAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -10, -10, -10, -10,
+ax_anim 2, 0, 64, -20, -20, -20, -20,
+ax_anim 2, 1, 64, -21, -19, -21, -19,
+ax_anim 2, 0, 64, -20, -20, -20, -20,
+ax_anim 2, 0, 64, -21, -19, -21, -19,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sTogeticAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -21, 0, -21, 0,
+ax_anim 2, 1, 67, -21, 1, -21, 1,
+ax_anim 2, 0, 67, -21, 0, -21, 0,
+ax_anim 2, 0, 67, -21, 1, -21, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sTogeticAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -21, 20, -21, 20,
+ax_anim 2, 1, 70, -22, 19, -22, 19,
+ax_anim 2, 0, 70, -21, 20, -21, 20,
+ax_anim 2, 0, 70, -22, 19, -22, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTogeticAnims_4_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 2, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 1, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_4_2:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, -1, 0, 0,
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 2, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 1, 76, 0, -3, 0, 0,
+ax_anim 2, 0, 77, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_4_3:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, -1, 0, 0,
+ax_anim 2, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 2, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 1, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -3, 0, 0,
+ax_anim 2, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_4_4:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 2, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 2, 1, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 83, 0, -3, 0, 0,
+ax_anim 2, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_4_5:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 2, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 1, 85, 0, -3, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_4_6:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -1, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 2, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 1, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -2, 0, 0,
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -1, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_4_7:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, -1, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 2, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 1, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -2, 0, 0,
+ax_anim 2, 0, 92, 0, -2, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_4_8:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, -1, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 2, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 1, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_5_1:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 2, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_5_2:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 2, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_5_3:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 2, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_5_4:
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 2, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 6, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_5_5:
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 2, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 6, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_5_6:
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 2, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_5_7:
+ax_anim 6, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 2, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_5_8:
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 2, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 6, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sTogeticAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sTogeticAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sTogeticAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sTogeticAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sTogeticAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sTogeticAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sTogeticAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sTogeticAnims_8_1:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim 3, 0, 131, 0, -4, 0, 0,
+ax_anim 3, 0, 130, 0, -4, 0, 0,
+ax_anim 3, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -3, 0, 0,
+ax_anim_terminator
+sTogeticAnims_8_2:
+ax_anim 30, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim 3, 0, 134, 0, -4, 0, 0,
+ax_anim 3, 0, 133, 0, -4, 0, 0,
+ax_anim 3, 0, 135, 0, -4, 0, 0,
+ax_anim 4, 0, 135, 0, -3, 0, 0,
+ax_anim_terminator
+sTogeticAnims_8_3:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim 3, 0, 137, 0, -4, 0, 0,
+ax_anim 3, 0, 136, 0, -4, 0, 0,
+ax_anim 3, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 138, 0, -3, 0, 0,
+ax_anim_terminator
+sTogeticAnims_8_4:
+ax_anim 30, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 3, 0, 140, 0, -4, 0, 0,
+ax_anim 3, 0, 139, 0, -4, 0, 0,
+ax_anim 3, 0, 141, 0, -4, 0, 0,
+ax_anim 4, 0, 141, 0, -3, 0, 0,
+ax_anim_terminator
+sTogeticAnims_8_5:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 3, 0, 143, 0, -4, 0, 0,
+ax_anim 3, 0, 142, 0, -4, 0, 0,
+ax_anim 3, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 144, 0, -3, 0, 0,
+ax_anim_terminator
+sTogeticAnims_8_6:
+ax_anim 30, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 3, 0, 146, 0, -4, 0, 0,
+ax_anim 3, 0, 145, 0, -4, 0, 0,
+ax_anim 3, 0, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 147, 0, -3, 0, 0,
+ax_anim_terminator
+sTogeticAnims_8_7:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim 3, 0, 149, 0, -4, 0, 0,
+ax_anim 3, 0, 148, 0, -4, 0, 0,
+ax_anim 3, 0, 150, 0, -4, 0, 0,
+ax_anim 4, 0, 150, 0, -3, 0, 0,
+ax_anim_terminator
+sTogeticAnims_8_8:
+ax_anim 30, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 3, 0, 152, 0, -4, 0, 0,
+ax_anim 3, 0, 151, 0, -4, 0, 0,
+ax_anim 3, 0, 153, 0, -4, 0, 0,
+ax_anim 4, 0, 153, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 5, 6, 5,
+ax_anim 2, 0, 156, 9, 13, 9, 13,
+ax_anim 2, 0, 157, 8, 22, 8, 22,
+ax_anim 3, 0, 158, 0, 24, 0, 24,
+ax_anim 2, 3, 159, -8, 22, -8, 22,
+ax_anim 2, 0, 160, -9, 13, -9, 13,
+ax_anim 1, 0, 161, -6, 5, -6, 5,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 10, 1, 10, 1,
+ax_anim 2, 0, 155, 20, 9, 20, 9,
+ax_anim 2, 0, 156, 24, 18, 24, 18,
+ax_anim 3, 0, 157, 22, 24, 22, 24,
+ax_anim 2, 3, 158, 14, 24, 14, 24,
+ax_anim 2, 0, 159, 6, 18, 6, 18,
+ax_anim 1, 0, 160, 2, 11, 2, 11,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 4, -4, 4, -4,
+ax_anim 2, 0, 154, 12, -6, 12, -6,
+ax_anim 2, 0, 155, 20, -3, 20, -3,
+ax_anim 3, 0, 156, 22, 2, 22, 2,
+ax_anim 2, 3, 157, 19, 6, 19, 6,
+ax_anim 2, 0, 158, 12, 8, 12, 8,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -8, -1, -8,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 15, -22, 15, -22,
+ax_anim 3, 0, 155, 23, -20, 23, -20,
+ax_anim 2, 3, 156, 22, -10, 22, -10,
+ax_anim 2, 0, 157, 17, -5, 17, -5,
+ax_anim 1, 0, 158, 9, -1, 9, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -6, -4, -6, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -8, -19, -8, -19,
+ax_anim 3, 0, 154, 0, -21, 0, -21,
+ax_anim 2, 3, 155, 8, -19, 8, -19,
+ax_anim 2, 0, 156, 9, -12, 9, -12,
+ax_anim 1, 0, 157, 6, -4, 6, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -8, 1, -8,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -15, -22, -15, -22,
+ax_anim 3, 0, 161, -23, -20, -23, -20,
+ax_anim 2, 3, 160, -22, -10, -22, -10,
+ax_anim 2, 0, 159, -17, -5, -17, -5,
+ax_anim 1, 0, 158, -9, -1, -9, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -4, -4, -4, -4,
+ax_anim 2, 0, 154, -12, -6, -12, -6,
+ax_anim 2, 0, 161, -20, -3, -20, -3,
+ax_anim 3, 0, 160, -22, 2, -22, 2,
+ax_anim 2, 3, 159, -19, 6, -19, 6,
+ax_anim 2, 0, 158, -12, 8, -12, 8,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -10, 1, -10, 1,
+ax_anim 2, 0, 161, -20, 9, -20, 9,
+ax_anim 2, 0, 160, -24, 18, -24, 18,
+ax_anim 3, 0, 159, -22, 24, -22, 24,
+ax_anim 2, 3, 158, -14, 24, -14, 24,
+ax_anim 2, 0, 157, -6, 18, -6, 18,
+ax_anim 1, 0, 156, -2, 11, -2, 11,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -21, 0, 0,
+ax_anim 2, 0, 172, 0, -17, 0, 0,
+ax_anim 1, 0, 172, 0, -11, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -9, 0, 0,
+ax_anim 2, 0, 174, 0, -15, 0, 0,
+ax_anim 3, 0, 174, 0, -19, 0, 0,
+ax_anim 4, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -9, 0, 0,
+ax_anim 2, 0, 177, 0, -15, 0, 0,
+ax_anim 3, 0, 177, 0, -19, 0, 0,
+ax_anim 4, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -21, 0, 0,
+ax_anim 2, 0, 178, 0, -17, 0, 0,
+ax_anim 1, 0, 178, 0, -11, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -8, 0, 0,
+ax_anim 2, 0, 180, 0, -14, 0, 0,
+ax_anim 3, 0, 180, 0, -18, 0, 0,
+ax_anim 4, 0, 180, 0, -19, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -9, 0, 0,
+ax_anim 2, 0, 186, 0, -15, 0, 0,
+ax_anim 3, 0, 186, 0, -19, 0, 0,
+ax_anim 4, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -17, 0, 0,
+ax_anim 1, 0, 190, 0, -11, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -9, 0, 0,
+ax_anim 2, 0, 192, 0, -15, 0, 0,
+ax_anim 3, 0, 192, 0, -19, 0, 0,
+ax_anim 4, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 193, 0, -11, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTogeticAnims_13_1:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_13_2:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_13_3:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_13_4:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_13_5:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_13_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_13_7:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticAnims_13_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTogeticGfx1:
+.incbin "baserom.gba", 0xCA5C84, 0x100
+sTogeticSprites1:
+ax_sprite sTogeticGfx1, 0x100
+ax_sprite_terminator
+sTogeticGfx2:
+.incbin "baserom.gba", 0xCA5D94, 0x100
+sTogeticSprites2:
+ax_sprite sTogeticGfx2, 0x100
+ax_sprite_terminator
+sTogeticGfx3:
+.incbin "baserom.gba", 0xCA5EA4, 0x100
+sTogeticSprites3:
+ax_sprite sTogeticGfx3, 0x100
+ax_sprite_terminator
+sTogeticGfx4:
+.incbin "baserom.gba", 0xCA5FB4, 0x100
+sTogeticSprites4:
+ax_sprite sTogeticGfx4, 0x100
+ax_sprite_terminator
+sTogeticGfx5:
+.incbin "baserom.gba", 0xCA60C4, 0x100
+sTogeticSprites5:
+ax_sprite sTogeticGfx5, 0x100
+ax_sprite_terminator
+sTogeticGfx6:
+.incbin "baserom.gba", 0xCA61D4, 0x100
+sTogeticSprites6:
+ax_sprite sTogeticGfx6, 0x100
+ax_sprite_terminator
+sTogeticGfx7:
+.incbin "baserom.gba", 0xCA62E4, 0x20
+sTogeticSprites7:
+ax_sprite sTogeticGfx7, 0x20
+ax_sprite_terminator
+sTogeticGfx8:
+.incbin "baserom.gba", 0xCA6314, 0x100
+sTogeticSprites8:
+ax_sprite sTogeticGfx8, 0x100
+ax_sprite_terminator
+sTogeticGfx9:
+.incbin "baserom.gba", 0xCA6424, 0x40
+sTogeticSprites9:
+ax_sprite sTogeticGfx9, 0x40
+ax_sprite_terminator
+sTogeticGfx10:
+.incbin "baserom.gba", 0xCA6474, 0x100
+sTogeticSprites10:
+ax_sprite sTogeticGfx10, 0x100
+ax_sprite_terminator
+sTogeticGfx11:
+.incbin "baserom.gba", 0xCA6584, 0x40
+sTogeticSprites11:
+ax_sprite sTogeticGfx11, 0x40
+ax_sprite_terminator
+sTogeticGfx12:
+.incbin "baserom.gba", 0xCA65D4, 0x100
+sTogeticSprites12:
+ax_sprite sTogeticGfx12, 0x100
+ax_sprite_terminator
+sTogeticGfx13:
+.incbin "baserom.gba", 0xCA66E4, 0x100
+sTogeticSprites13:
+ax_sprite sTogeticGfx13, 0x100
+ax_sprite_terminator
+sTogeticGfx14:
+.incbin "baserom.gba", 0xCA67F4, 0x100
+sTogeticSprites14:
+ax_sprite sTogeticGfx14, 0x100
+ax_sprite_terminator
+sTogeticGfx15:
+.incbin "baserom.gba", 0xCA6904, 0x100
+sTogeticSprites15:
+ax_sprite sTogeticGfx15, 0x100
+ax_sprite_terminator
+sTogeticGfx16:
+.incbin "baserom.gba", 0xCA6A14, 0x100
+sTogeticSprites16:
+ax_sprite sTogeticGfx16, 0x100
+ax_sprite_terminator
+sTogeticGfx17:
+.incbin "baserom.gba", 0xCA6B24, 0x100
+sTogeticSprites17:
+ax_sprite sTogeticGfx17, 0x100
+ax_sprite_terminator
+sTogeticGfx18:
+.incbin "baserom.gba", 0xCA6C34, 0x100
+sTogeticSprites18:
+ax_sprite sTogeticGfx18, 0x100
+ax_sprite_terminator
+sTogeticGfx19:
+.incbin "baserom.gba", 0xCA6D44, 0xC0
+sTogeticSprites19:
+ax_sprite sTogeticGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx20:
+.incbin "baserom.gba", 0xCA6E1C, 0xC0
+sTogeticSprites20:
+ax_sprite sTogeticGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx21:
+.incbin "baserom.gba", 0xCA6EF4, 0x20
+sTogeticSprites21:
+ax_sprite sTogeticGfx21, 0x20
+ax_sprite_terminator
+sTogeticGfx22:
+.incbin "baserom.gba", 0xCA6F24, 0xC0
+sTogeticSprites22:
+ax_sprite sTogeticGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx23:
+.incbin "baserom.gba", 0xCA6FFC, 0x20
+sTogeticSprites23:
+ax_sprite sTogeticGfx23, 0x20
+ax_sprite_terminator
+sTogeticGfx24:
+.incbin "baserom.gba", 0xCA702C, 0xC0
+sTogeticSprites24:
+ax_sprite sTogeticGfx24, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx25:
+.incbin "baserom.gba", 0xCA7104, 0x40
+sTogeticSprites25:
+ax_sprite sTogeticGfx25, 0x40
+ax_sprite_terminator
+sTogeticGfx26:
+.incbin "baserom.gba", 0xCA7154, 0xC0
+sTogeticSprites26:
+ax_sprite sTogeticGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx27:
+.incbin "baserom.gba", 0xCA722C, 0x20
+sTogeticSprites27:
+ax_sprite sTogeticGfx27, 0x20
+ax_sprite_terminator
+sTogeticGfx28:
+.incbin "baserom.gba", 0xCA725C, 0xC0
+sTogeticSprites28:
+ax_sprite sTogeticGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx29:
+.incbin "baserom.gba", 0xCA7334, 0x40
+sTogeticSprites29:
+ax_sprite sTogeticGfx29, 0x40
+ax_sprite_terminator
+sTogeticGfx30:
+.incbin "baserom.gba", 0xCA7384, 0xC0
+sTogeticSprites30:
+ax_sprite sTogeticGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx31:
+.incbin "baserom.gba", 0xCA745C, 0x20
+sTogeticSprites31:
+ax_sprite sTogeticGfx31, 0x20
+ax_sprite_terminator
+sTogeticGfx32:
+.incbin "baserom.gba", 0xCA748C, 0xC0
+sTogeticSprites32:
+ax_sprite sTogeticGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx33:
+.incbin "baserom.gba", 0xCA7564, 0xC0
+sTogeticSprites33:
+ax_sprite sTogeticGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx34:
+.incbin "baserom.gba", 0xCA763C, 0xC0
+sTogeticSprites34:
+ax_sprite sTogeticGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx35:
+.incbin "baserom.gba", 0xCA7714, 0xC0
+sTogeticSprites35:
+ax_sprite sTogeticGfx35, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx36:
+.incbin "baserom.gba", 0xCA77EC, 0xC0
+sTogeticSprites36:
+ax_sprite sTogeticGfx36, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx37:
+.incbin "baserom.gba", 0xCA78C4, 0xC0
+sTogeticSprites37:
+ax_sprite sTogeticGfx37, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx38:
+.incbin "baserom.gba", 0xCA799C, 0xC0
+sTogeticSprites38:
+ax_sprite sTogeticGfx38, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx39:
+.incbin "baserom.gba", 0xCA7A74, 0x40
+sTogeticGfx39_1:
+.incbin "baserom.gba", 0xCA7AB4, 0x60
+sTogeticGfx39_2:
+.incbin "baserom.gba", 0xCA7B14, 0x40
+sTogeticSprites39:
+ax_sprite sTogeticGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTogeticGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTogeticGfx39_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sTogeticGfx40:
+.incbin "baserom.gba", 0xCA7B8C, 0x40
+sTogeticGfx40_1:
+.incbin "baserom.gba", 0xCA7BCC, 0x60
+sTogeticGfx40_2:
+.incbin "baserom.gba", 0xCA7C2C, 0x40
+sTogeticSprites40:
+ax_sprite sTogeticGfx40, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTogeticGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTogeticGfx40_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sTogeticGfx41:
+.incbin "baserom.gba", 0xCA7CA4, 0xC0
+sTogeticSprites41:
+ax_sprite sTogeticGfx41, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx42:
+.incbin "baserom.gba", 0xCA7D7C, 0xC0
+sTogeticSprites42:
+ax_sprite sTogeticGfx42, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx43:
+.incbin "baserom.gba", 0xCA7E54, 0x20
+sTogeticSprites43:
+ax_sprite sTogeticGfx43, 0x20
+ax_sprite_terminator
+sTogeticGfx44:
+.incbin "baserom.gba", 0xCA7E84, 0xC0
+sTogeticSprites44:
+ax_sprite sTogeticGfx44, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx45:
+.incbin "baserom.gba", 0xCA7F5C, 0xC0
+sTogeticSprites45:
+ax_sprite sTogeticGfx45, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTogeticGfx46:
+.incbin "baserom.gba", 0xCA8034, 0x200
+sTogeticSprites46:
+ax_sprite sTogeticGfx46, 0x200
+ax_sprite_terminator
+sTogeticGfx47:
+.incbin "baserom.gba", 0xCA8244, 0x200
+sTogeticSprites47:
+ax_sprite sTogeticGfx47, 0x200
+ax_sprite_terminator
+sTogeticGfx48:
+.incbin "baserom.gba", 0xCA8454, 0x200
+sTogeticSprites48:
+ax_sprite sTogeticGfx48, 0x200
+ax_sprite_terminator
+sTogeticGfx49:
+.incbin "baserom.gba", 0xCA8664, 0x200
+sTogeticSprites49:
+ax_sprite sTogeticGfx49, 0x200
+ax_sprite_terminator
+sTogeticGfx50:
+.incbin "baserom.gba", 0xCA8874, 0x200
+sTogeticSprites50:
+ax_sprite sTogeticGfx50, 0x200
+ax_sprite_terminator
+sTogeticGfx51:
+.incbin "baserom.gba", 0xCA8A84, 0x200
+sTogeticSprites51:
+ax_sprite sTogeticGfx51, 0x200
+ax_sprite_terminator
+sTogeticGfx52:
+.incbin "baserom.gba", 0xCA8C94, 0x200
+sTogeticSprites52:
+ax_sprite sTogeticGfx52, 0x200
+ax_sprite_terminator
+sAxPosesTogetic:
+.4byte sTogeticPose1
+.4byte sTogeticPose2
+.4byte sTogeticPose3
+.4byte sTogeticPose4
+.4byte sTogeticPose5
+.4byte sTogeticPose6
+.4byte sTogeticPose7
+.4byte sTogeticPose8
+.4byte sTogeticPose9
+.4byte sTogeticPose10
+.4byte sTogeticPose11
+.4byte sTogeticPose12
+.4byte sTogeticPose13
+.4byte sTogeticPose14
+.4byte sTogeticPose15
+.4byte sTogeticPose16
+.4byte sTogeticPose17
+.4byte sTogeticPose18
+.4byte sTogeticPose19
+.4byte sTogeticPose20
+.4byte sTogeticPose21
+.4byte sTogeticPose22
+.4byte sTogeticPose23
+.4byte sTogeticPose24
+.4byte sTogeticPose25
+.4byte sTogeticPose26
+.4byte sTogeticPose27
+.4byte sTogeticPose28
+.4byte sTogeticPose29
+.4byte sTogeticPose30
+.4byte sTogeticPose31
+.4byte sTogeticPose32
+.4byte sTogeticPose33
+.4byte sTogeticPose34
+.4byte sTogeticPose35
+.4byte sTogeticPose36
+.4byte sTogeticPose37
+.4byte sTogeticPose38
+.4byte sTogeticPose39
+.4byte sTogeticPose40
+.4byte sTogeticPose41
+.4byte sTogeticPose42
+.4byte sTogeticPose43
+.4byte sTogeticPose44
+.4byte sTogeticPose45
+.4byte sTogeticPose46
+.4byte sTogeticPose47
+.4byte sTogeticPose48
+.4byte sTogeticPose49
+.4byte sTogeticPose50
+.4byte sTogeticPose51
+.4byte sTogeticPose52
+.4byte sTogeticPose53
+.4byte sTogeticPose54
+.4byte sTogeticPose55
+.4byte sTogeticPose56
+.4byte sTogeticPose57
+.4byte sTogeticPose58
+.4byte sTogeticPose59
+.4byte sTogeticPose60
+.4byte sTogeticPose61
+.4byte sTogeticPose62
+.4byte sTogeticPose63
+.4byte sTogeticPose64
+.4byte sTogeticPose65
+.4byte sTogeticPose66
+.4byte sTogeticPose67
+.4byte sTogeticPose68
+.4byte sTogeticPose69
+.4byte sTogeticPose70
+.4byte sTogeticPose71
+.4byte sTogeticPose72
+.4byte sTogeticPose73
+.4byte sTogeticPose74
+.4byte sTogeticPose75
+.4byte sTogeticPose76
+.4byte sTogeticPose77
+.4byte sTogeticPose78
+.4byte sTogeticPose79
+.4byte sTogeticPose80
+.4byte sTogeticPose81
+.4byte sTogeticPose82
+.4byte sTogeticPose83
+.4byte sTogeticPose84
+.4byte sTogeticPose85
+.4byte sTogeticPose86
+.4byte sTogeticPose87
+.4byte sTogeticPose88
+.4byte sTogeticPose89
+.4byte sTogeticPose90
+.4byte sTogeticPose91
+.4byte sTogeticPose92
+.4byte sTogeticPose93
+.4byte sTogeticPose94
+.4byte sTogeticPose95
+.4byte sTogeticPose96
+.4byte sTogeticPose97
+.4byte sTogeticPose98
+.4byte sTogeticPose99
+.4byte sTogeticPose100
+.4byte sTogeticPose101
+.4byte sTogeticPose102
+.4byte sTogeticPose103
+.4byte sTogeticPose104
+.4byte sTogeticPose105
+.4byte sTogeticPose106
+.4byte sTogeticPose107
+.4byte sTogeticPose108
+.4byte sTogeticPose109
+.4byte sTogeticPose110
+.4byte sTogeticPose111
+.4byte sTogeticPose112
+.4byte sTogeticPose113
+.4byte sTogeticPose114
+.4byte sTogeticPose115
+.4byte sTogeticPose116
+.4byte sTogeticPose117
+.4byte sTogeticPose118
+.4byte sTogeticPose119
+.4byte sTogeticPose120
+.4byte sTogeticPose121
+.4byte sTogeticPose122
+.4byte sTogeticPose123
+.4byte sTogeticPose124
+.4byte sTogeticPose125
+.4byte sTogeticPose126
+.4byte sTogeticPose127
+.4byte sTogeticPose128
+.4byte sTogeticPose129
+.4byte sTogeticPose130
+.4byte sTogeticPose131
+.4byte sTogeticPose132
+.4byte sTogeticPose133
+.4byte sTogeticPose134
+.4byte sTogeticPose135
+.4byte sTogeticPose136
+.4byte sTogeticPose137
+.4byte sTogeticPose138
+.4byte sTogeticPose139
+.4byte sTogeticPose140
+.4byte sTogeticPose141
+.4byte sTogeticPose142
+.4byte sTogeticPose143
+.4byte sTogeticPose144
+.4byte sTogeticPose145
+.4byte sTogeticPose146
+.4byte sTogeticPose147
+.4byte sTogeticPose148
+.4byte sTogeticPose149
+.4byte sTogeticPose150
+.4byte sTogeticPose151
+.4byte sTogeticPose152
+.4byte sTogeticPose153
+.4byte sTogeticPose154
+.4byte sTogeticPose155
+.4byte sTogeticPose156
+.4byte sTogeticPose157
+.4byte sTogeticPose158
+.4byte sTogeticPose159
+.4byte sTogeticPose160
+.4byte sTogeticPose161
+.4byte sTogeticPose162
+.4byte sTogeticPose163
+.4byte sTogeticPose164
+.4byte sTogeticPose165
+.4byte sTogeticPose166
+.4byte sTogeticPose167
+.4byte sTogeticPose168
+.4byte sTogeticPose169
+.4byte sTogeticPose170
+.4byte sTogeticPose171
+.4byte sTogeticPose172
+.4byte sTogeticPose173
+.4byte sTogeticPose174
+.4byte sTogeticPose175
+.4byte sTogeticPose176
+.4byte sTogeticPose177
+.4byte sTogeticPose178
+.4byte sTogeticPose179
+.4byte sTogeticPose180
+.4byte sTogeticPose181
+.4byte sTogeticPose182
+.4byte sTogeticPose183
+.4byte sTogeticPose184
+.4byte sTogeticPose185
+.4byte sTogeticPose186
+.4byte sTogeticPose187
+.4byte sTogeticPose188
+.4byte sTogeticPose189
+.4byte sTogeticPose190
+.4byte sTogeticPose191
+.4byte sTogeticPose192
+.4byte sTogeticPose193
+.4byte sTogeticPose194
+.4byte sTogeticPose195
+.4byte sTogeticPose196
+.4byte sTogeticPose197
+.4byte sTogeticPose198
+.4byte sTogeticPose199
+.4byte sTogeticPose200
+.4byte sTogeticPose201
+.4byte sTogeticPose202
+.4byte sTogeticPose203
+.4byte sTogeticPose204
+.4byte sTogeticPose205
+.4byte sTogeticPose206
+.4byte sTogeticPose207
+.4byte sTogeticPose208
+.4byte sTogeticPose209
+.4byte sTogeticPose210
+.4byte sTogeticPose211
+.4byte sTogeticPose212
+.4byte sTogeticPose213
+.4byte sTogeticPose214
+.4byte sTogeticPose215
+.4byte sTogeticPose216
+.4byte sTogeticPose217
+.4byte sTogeticPose218
+.4byte sTogeticPose219
+.4byte sTogeticPose220
+.4byte sTogeticPose221
+.4byte sTogeticPose222
+.4byte sTogeticPose223
+.4byte sTogeticPose224
+.4byte sTogeticPose225
+.4byte sTogeticPose226
+.4byte sTogeticPose227
+.4byte sTogeticPose228
+.4byte sTogeticPose229
+.4byte sTogeticPose230
+.4byte sTogeticPose231
+.4byte sTogeticPose232
+.4byte sTogeticPose233
+.4byte sTogeticPose234
+.4byte sTogeticPose235
+.4byte sTogeticPose236
+.4byte sTogeticPose237
+.4byte sTogeticPose238
+sAxPositionsTogetic:
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -5,   -6, 	   2,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,   -5, 	   3,   -6, 	  -1,   -6
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   3,   -6, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    6,  -11, 	   4,   -5, 	   3,   -4, 	   0,   -6
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -12, 	   0,   -7, 	   4,   -5, 	   0,   -6
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   4,   -7, 	  -5,   -4, 	  -1,   -5
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	   2,   -6, 	  -3,   -4, 	   0,   -7
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -5,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -3,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	  -4,   -6, 	   0,   -4, 	   0,   -6
+.2byte   -5,  -10, 	  -4,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -5,   -6, 	   2,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,   -5, 	   3,   -6, 	  -1,   -6
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   3,   -6, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    6,  -11, 	   4,   -5, 	   3,   -4, 	   0,   -6
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -12, 	   0,   -7, 	   4,   -5, 	   0,   -6
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   4,   -7, 	  -5,   -4, 	  -1,   -5
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	   2,   -6, 	  -3,   -4, 	   0,   -7
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -5,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -3,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	  -4,   -6, 	   0,   -4, 	   0,   -6
+.2byte   -5,  -10, 	  -4,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -5,   -6, 	   2,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,   -5, 	   3,   -6, 	  -1,   -6
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   3,   -6, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    6,  -11, 	   4,   -5, 	   3,   -4, 	   0,   -6
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -12, 	   0,   -7, 	   4,   -5, 	   0,   -6
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   4,   -7, 	  -5,   -4, 	  -1,   -5
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	   2,   -6, 	  -3,   -4, 	   0,   -7
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -5,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -3,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	  -4,   -6, 	   0,   -4, 	   0,   -6
+.2byte   -5,  -10, 	  -4,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -12, 	  -3,   -7, 	   1,   -7, 	  -1,   -7
+.2byte   -1,  -12, 	  -3,   -7, 	   1,   -7, 	  -1,   -7
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    4,  -12, 	   3,   -8, 	   1,   -7, 	   0,   -9
+.2byte    4,  -12, 	   3,   -8, 	   1,   -7, 	   0,   -9
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    6,  -13, 	   4,   -9, 	   4,   -8, 	   0,   -8
+.2byte    6,  -13, 	   4,   -9, 	   4,   -8, 	   0,   -8
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -14, 	   0,  -11, 	   3,   -9, 	  -1,   -8
+.2byte    5,  -14, 	  -1,  -11, 	   3,   -9, 	  -1,   -8
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,  -14, 	   3,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte   -1,  -14, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -6,  -14, 	  -1,  -11, 	  -4,   -9, 	   0,   -8
+.2byte   -6,  -14, 	   0,  -11, 	  -4,   -9, 	   0,   -8
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -6,  -13, 	  -4,   -9, 	  -4,   -8, 	   0,   -8
+.2byte   -6,  -13, 	  -4,   -9, 	  -4,   -8, 	   0,   -8
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -5,  -12, 	  -4,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte   -5,  -12, 	  -4,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte    1,  -10, 	  -5,   -7, 	   1,   -5, 	   0,   -6
+.2byte   -3,  -10, 	  -4,   -5, 	   3,   -7, 	  -2,   -6
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    2,   -9, 	   4,   -6, 	   0,   -5, 	   0,   -6
+.2byte    4,  -10, 	   2,   -6, 	  -3,   -6, 	   1,   -6
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    5,  -10, 	   4,   -7, 	   4,   -5, 	   0,   -6
+.2byte    6,  -13, 	   4,   -7, 	   0,   -7, 	   0,   -8
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -11, 	  -2,   -9, 	   3,   -6, 	   0,   -6
+.2byte    3,  -13, 	  -1,   -8, 	   3,   -6, 	  -2,   -7
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -3,  -13, 	   3,   -7, 	  -4,   -7, 	  -2,   -6
+.2byte    1,  -13, 	   2,   -7, 	  -5,   -7, 	   0,   -6
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -6,  -11, 	   1,   -9, 	  -4,   -6, 	  -1,   -6
+.2byte   -4,  -13, 	   0,   -8, 	  -4,   -6, 	   1,   -7
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -6,  -10, 	  -5,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -7,  -13, 	  -5,   -7, 	  -1,   -7, 	  -1,   -8
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -3,   -9, 	  -5,   -6, 	  -1,   -5, 	  -1,   -6
+.2byte   -5,  -10, 	  -3,   -6, 	   2,   -6, 	  -2,   -6
+.2byte   -3,   -9, 	  -3,   -3, 	   3,   -2, 	   1,   -4
+.2byte   -4,   -8, 	  -3,   -3, 	   3,   -2, 	   1,   -4
+.2byte    0,   -9, 	  -3,   -7, 	   3,   -7, 	   0,   -6
+.2byte   -1,  -10, 	   2,   -9, 	  -2,   -7, 	  -1,   -6
+.2byte   -2,   -9, 	   0,  -10, 	  -1,   -8, 	   0,   -5
+.2byte   -1,   -9, 	  -3,   -9, 	   2,   -8, 	   0,   -3
+.2byte    0,   -7, 	   3,   -5, 	  -3,   -5, 	   0,   -3
+.2byte    0,   -9, 	   2,   -9, 	  -3,   -8, 	  -1,   -3
+.2byte    1,   -9, 	  -1,  -10, 	   0,   -8, 	  -1,   -5
+.2byte    0,  -10, 	  -3,   -9, 	   1,   -7, 	   0,   -6
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -5,   -6, 	   2,   -5, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,   -5, 	   3,   -6, 	  -1,   -6
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    4,  -10, 	   3,   -6, 	  -1,   -4, 	  -1,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    6,  -11, 	   4,   -5, 	   3,   -4, 	   0,   -6
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -12, 	   0,   -7, 	   4,   -5, 	   0,   -6
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte   -1,  -12, 	   4,   -7, 	  -5,   -4, 	  -1,   -5
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -6,  -12, 	   2,   -6, 	  -3,   -4, 	   0,   -7
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -5,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -7,  -11, 	  -3,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	  -4,   -6, 	   0,   -4, 	   0,   -6
+.2byte   -5,  -10, 	  -4,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -1,  -12, 	  -3,   -7, 	   1,   -7, 	  -1,   -7
+.2byte   -5,  -12, 	  -4,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte   -7,  -13, 	  -5,   -9, 	  -5,   -8, 	  -1,   -8
+.2byte   -5,  -13, 	   1,  -10, 	  -3,   -8, 	   1,   -7
+.2byte   -1,  -14, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    4,  -13, 	  -2,  -10, 	   2,   -8, 	  -2,   -7
+.2byte    6,  -13, 	   4,   -9, 	   4,   -8, 	   0,   -8
+.2byte    4,  -12, 	   3,   -8, 	   1,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -3,   -7, 	   1,   -7, 	  -1,   -7
+.2byte    4,  -12, 	   3,   -8, 	   1,   -7, 	   0,   -9
+.2byte    6,  -13, 	   4,   -9, 	   4,   -8, 	   0,   -8
+.2byte    4,  -14, 	  -2,  -11, 	   2,   -9, 	  -2,   -8
+.2byte   -1,  -14, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte   -5,  -14, 	   1,  -11, 	  -3,   -9, 	   1,   -8
+.2byte   -6,  -13, 	  -4,   -9, 	  -4,   -8, 	   0,   -8
+.2byte   -5,  -12, 	  -4,   -8, 	  -2,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -1,  -12, 	  -3,   -7, 	   1,   -7, 	  -1,   -7
+.2byte   -1,  -12, 	  -5,   -8, 	   2,   -7, 	  -1,   -8
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+.2byte    3,  -12, 	   2,   -8, 	   0,   -7, 	  -1,   -9
+.2byte    3,  -11, 	   2,   -7, 	  -2,   -5, 	  -2,   -7
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    5,  -13, 	   3,   -9, 	   3,   -8, 	  -1,   -8
+.2byte    5,  -12, 	   3,   -6, 	   2,   -5, 	  -1,   -7
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -14, 	  -1,  -11, 	   3,   -9, 	  -1,   -8
+.2byte    5,  -13, 	   0,   -8, 	   4,   -6, 	   0,   -7
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -1,  -14, 	   2,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte   -1,  -13, 	   3,   -5, 	  -6,   -8, 	  -1,   -6
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -6,  -14, 	   0,  -11, 	  -4,   -9, 	   0,   -8
+.2byte   -6,  -13, 	  -1,   -8, 	  -5,   -6, 	  -1,   -7
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -6,  -13, 	  -4,   -9, 	  -4,   -8, 	   0,   -8
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -5, 	   0,   -7
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -4,  -12, 	  -3,   -8, 	  -1,   -7, 	   0,   -9
+.2byte   -4,  -11, 	  -3,   -7, 	   1,   -5, 	   1,   -7
+.2byte   -1,  -10, 	  -5,   -6, 	   2,   -5, 	  -1,   -6
+.2byte   -5,  -10, 	  -4,   -6, 	   0,   -4, 	   0,   -6
+.2byte   -7,  -11, 	  -5,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte   -7,  -11, 	  -5,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte   -5,  -10, 	  -4,   -6, 	   0,   -4, 	   0,   -6
+.2byte   -7,  -11, 	  -5,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -6,  -12, 	  -1,   -7, 	  -5,   -5, 	  -1,   -6
+.2byte   -1,  -12, 	   3,   -4, 	  -6,   -7, 	  -1,   -5
+.2byte    5,  -12, 	  -3,   -6, 	   2,   -4, 	  -1,   -7
+.2byte    6,  -11, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte    4,  -10, 	   3,   -5, 	  -3,   -4, 	   0,   -6
+.2byte   -1,  -11, 	  -5,   -5, 	   3,   -5, 	  -1,   -6
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -4, 	  -1,   -7
+.2byte   -6,  -12, 	  -4,   -6, 	  -3,   -4, 	  -1,   -6
+.2byte   -6,  -14, 	   0,   -7, 	  -4,   -5, 	  -1,   -6
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte    5,  -14, 	  -1,   -7, 	   3,   -5, 	   0,   -6
+.2byte    5,  -12, 	   3,   -6, 	   2,   -4, 	   0,   -6
+.2byte    3,  -11, 	   3,   -6, 	  -2,   -4, 	   0,   -7
+sTogeticAnimTable1:
+.4byte sTogeticAnims_1_1
+.4byte sTogeticAnims_1_2
+.4byte sTogeticAnims_1_3
+.4byte sTogeticAnims_1_4
+.4byte sTogeticAnims_1_5
+.4byte sTogeticAnims_1_6
+.4byte sTogeticAnims_1_7
+.4byte sTogeticAnims_1_8
+sTogeticAnimTable2:
+.4byte sTogeticAnims_2_1
+.4byte sTogeticAnims_2_2
+.4byte sTogeticAnims_2_3
+.4byte sTogeticAnims_2_4
+.4byte sTogeticAnims_2_5
+.4byte sTogeticAnims_2_6
+.4byte sTogeticAnims_2_7
+.4byte sTogeticAnims_2_8
+sTogeticAnimTable3:
+.4byte sTogeticAnims_3_1
+.4byte sTogeticAnims_3_2
+.4byte sTogeticAnims_3_3
+.4byte sTogeticAnims_3_4
+.4byte sTogeticAnims_3_5
+.4byte sTogeticAnims_3_6
+.4byte sTogeticAnims_3_7
+.4byte sTogeticAnims_3_8
+sTogeticAnimTable4:
+.4byte sTogeticAnims_4_1
+.4byte sTogeticAnims_4_2
+.4byte sTogeticAnims_4_3
+.4byte sTogeticAnims_4_4
+.4byte sTogeticAnims_4_5
+.4byte sTogeticAnims_4_6
+.4byte sTogeticAnims_4_7
+.4byte sTogeticAnims_4_8
+sTogeticAnimTable5:
+.4byte sTogeticAnims_5_1
+.4byte sTogeticAnims_5_2
+.4byte sTogeticAnims_5_3
+.4byte sTogeticAnims_5_4
+.4byte sTogeticAnims_5_5
+.4byte sTogeticAnims_5_6
+.4byte sTogeticAnims_5_7
+.4byte sTogeticAnims_5_8
+sTogeticAnimTable6:
+.4byte sTogeticAnims_6_1
+.4byte sTogeticAnims_6_1
+.4byte sTogeticAnims_6_1
+.4byte sTogeticAnims_6_1
+.4byte sTogeticAnims_6_1
+.4byte sTogeticAnims_6_1
+.4byte sTogeticAnims_6_1
+.4byte sTogeticAnims_6_1
+sTogeticAnimTable7:
+.4byte sTogeticAnims_7_1
+.4byte sTogeticAnims_7_2
+.4byte sTogeticAnims_7_3
+.4byte sTogeticAnims_7_4
+.4byte sTogeticAnims_7_5
+.4byte sTogeticAnims_7_6
+.4byte sTogeticAnims_7_7
+.4byte sTogeticAnims_7_8
+sTogeticAnimTable8:
+.4byte sTogeticAnims_8_1
+.4byte sTogeticAnims_8_2
+.4byte sTogeticAnims_8_3
+.4byte sTogeticAnims_8_4
+.4byte sTogeticAnims_8_5
+.4byte sTogeticAnims_8_6
+.4byte sTogeticAnims_8_7
+.4byte sTogeticAnims_8_8
+sTogeticAnimTable9:
+.4byte sTogeticAnims_9_1
+.4byte sTogeticAnims_9_2
+.4byte sTogeticAnims_9_3
+.4byte sTogeticAnims_9_4
+.4byte sTogeticAnims_9_5
+.4byte sTogeticAnims_9_6
+.4byte sTogeticAnims_9_7
+.4byte sTogeticAnims_9_8
+sTogeticAnimTable10:
+.4byte sTogeticAnims_10_1
+.4byte sTogeticAnims_10_2
+.4byte sTogeticAnims_10_3
+.4byte sTogeticAnims_10_4
+.4byte sTogeticAnims_10_5
+.4byte sTogeticAnims_10_6
+.4byte sTogeticAnims_10_7
+.4byte sTogeticAnims_10_8
+sTogeticAnimTable11:
+.4byte sTogeticAnims_11_1
+.4byte sTogeticAnims_11_2
+.4byte sTogeticAnims_11_3
+.4byte sTogeticAnims_11_4
+.4byte sTogeticAnims_11_5
+.4byte sTogeticAnims_11_6
+.4byte sTogeticAnims_11_7
+.4byte sTogeticAnims_11_8
+sTogeticAnimTable12:
+.4byte sTogeticAnims_12_1
+.4byte sTogeticAnims_12_2
+.4byte sTogeticAnims_12_3
+.4byte sTogeticAnims_12_4
+.4byte sTogeticAnims_12_5
+.4byte sTogeticAnims_12_6
+.4byte sTogeticAnims_12_7
+.4byte sTogeticAnims_12_8
+sTogeticAnimTable13:
+.4byte sTogeticAnims_13_1
+.4byte sTogeticAnims_13_2
+.4byte sTogeticAnims_13_3
+.4byte sTogeticAnims_13_4
+.4byte sTogeticAnims_13_5
+.4byte sTogeticAnims_13_6
+.4byte sTogeticAnims_13_7
+.4byte sTogeticAnims_13_8
+sAxAnimationsTogetic:
+.4byte sTogeticAnimTable1
+.4byte sTogeticAnimTable2
+.4byte sTogeticAnimTable3
+.4byte sTogeticAnimTable4
+.4byte sTogeticAnimTable5
+.4byte sTogeticAnimTable6
+.4byte sTogeticAnimTable7
+.4byte sTogeticAnimTable8
+.4byte sTogeticAnimTable9
+.4byte sTogeticAnimTable10
+.4byte sTogeticAnimTable11
+.4byte sTogeticAnimTable12
+.4byte sTogeticAnimTable13
+sAxSpritesTogetic:
+.4byte sTogeticSprites1
+.4byte sTogeticSprites2
+.4byte sTogeticSprites3
+.4byte sTogeticSprites4
+.4byte sTogeticSprites5
+.4byte sTogeticSprites6
+.4byte sTogeticSprites7
+.4byte sTogeticSprites8
+.4byte sTogeticSprites9
+.4byte sTogeticSprites10
+.4byte sTogeticSprites11
+.4byte sTogeticSprites12
+.4byte sTogeticSprites13
+.4byte sTogeticSprites14
+.4byte sTogeticSprites15
+.4byte sTogeticSprites16
+.4byte sTogeticSprites17
+.4byte sTogeticSprites18
+.4byte sTogeticSprites19
+.4byte sTogeticSprites20
+.4byte sTogeticSprites21
+.4byte sTogeticSprites22
+.4byte sTogeticSprites23
+.4byte sTogeticSprites24
+.4byte sTogeticSprites25
+.4byte sTogeticSprites26
+.4byte sTogeticSprites27
+.4byte sTogeticSprites28
+.4byte sTogeticSprites29
+.4byte sTogeticSprites30
+.4byte sTogeticSprites31
+.4byte sTogeticSprites32
+.4byte sTogeticSprites33
+.4byte sTogeticSprites34
+.4byte sTogeticSprites35
+.4byte sTogeticSprites36
+.4byte sTogeticSprites37
+.4byte sTogeticSprites38
+.4byte sTogeticSprites39
+.4byte sTogeticSprites40
+.4byte sTogeticSprites41
+.4byte sTogeticSprites42
+.4byte sTogeticSprites43
+.4byte sTogeticSprites44
+.4byte sTogeticSprites45
+.4byte sTogeticSprites46
+.4byte sTogeticSprites47
+.4byte sTogeticSprites48
+.4byte sTogeticSprites49
+.4byte sTogeticSprites50
+.4byte sTogeticSprites51
+.4byte sTogeticSprites52
+sAxMainTogetic:
+ax_main sAxPosesTogetic, sAxAnimationsTogetic, 13, sAxSpritesTogetic, sAxPositionsTogetic

--- a/data/ax/torchic.inc
+++ b/data/ax/torchic.inc
@@ -1,0 +1,3933 @@
+.global gAxTorchic
+gAxTorchic:
+ax_siro sAxMainTorchic
+sTorchicPose1:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose2:
+ax_pose 1, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose3:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose4:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose5:
+ax_pose 4, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose6:
+ax_pose 5, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose7:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose8:
+ax_pose 7, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose9:
+ax_pose 8, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose10:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose11:
+ax_pose 10, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose12:
+ax_pose 11, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose13:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose14:
+ax_pose 13, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose15:
+ax_pose 14, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose16:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose17:
+ax_pose 10, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose18:
+ax_pose 11, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose19:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose20:
+ax_pose 7, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose21:
+ax_pose 8, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose25:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose26:
+ax_pose 1, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose27:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose28:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose29:
+ax_pose 4, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose30:
+ax_pose 5, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose31:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose32:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose33:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose34:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose35:
+ax_pose 10, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose36:
+ax_pose 11, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose37:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose38:
+ax_pose 13, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose39:
+ax_pose 14, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose40:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose41:
+ax_pose 10, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose42:
+ax_pose 11, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose43:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose44:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose45:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose47:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose48:
+ax_pose 5, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose49:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose50:
+ax_pose 1, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose51:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose52:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose53:
+ax_pose 4, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose54:
+ax_pose 5, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose55:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose56:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose57:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose58:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose59:
+ax_pose 10, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose60:
+ax_pose 11, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose61:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose62:
+ax_pose 13, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose63:
+ax_pose 14, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose64:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose65:
+ax_pose 10, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose66:
+ax_pose 11, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose67:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose68:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose69:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose71:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose72:
+ax_pose 5, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose73:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose74:
+ax_pose 1, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose75:
+ax_pose 2, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose76:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose77:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose78:
+ax_pose 4, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose79:
+ax_pose 5, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose80:
+ax_pose 16, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sTorchicPose81:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose82:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose83:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose84:
+ax_pose 17, 0x81eb, 0x90fb, 0x4c00
+ax_pose_terminator
+sTorchicPose85:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose86:
+ax_pose 10, 0x81ec, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose87:
+ax_pose 11, 0x81ec, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose88:
+ax_pose 18, 0x81eb, 0x90f9, 0x4c00
+ax_pose_terminator
+sTorchicPose89:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose90:
+ax_pose 13, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose91:
+ax_pose 14, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose92:
+ax_pose 19, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose93:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose94:
+ax_pose 10, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose95:
+ax_pose 11, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose96:
+ax_pose 18, 0x81eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose97:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose98:
+ax_pose 7, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose99:
+ax_pose 8, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose100:
+ax_pose 17, 0x81eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose101:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose102:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose103:
+ax_pose 5, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose104:
+ax_pose 16, 0x81ec, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose105:
+ax_pose 20, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose106:
+ax_pose 21, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose107:
+ax_pose 22, 0x81eb, 0x90f7, 0x4c00
+ax_pose 23, 0x01f3, 0x10ef, 0x4c08
+ax_pose_terminator
+sTorchicPose108:
+ax_pose 24, 0x81eb, 0x90f7, 0x4c00
+ax_pose_terminator
+sTorchicPose109:
+ax_pose 25, 0x81eb, 0x90f8, 0x4c00
+ax_pose 26, 0x01eb, 0x10f0, 0x4c08
+ax_pose_terminator
+sTorchicPose110:
+ax_pose 27, 0x81eb, 0x90f8, 0x4c00
+ax_pose_terminator
+sTorchicPose111:
+ax_pose 28, 0x81ed, 0x90f7, 0x4c00
+ax_pose 29, 0x81ed, 0x10ef, 0x4c08
+ax_pose_terminator
+sTorchicPose112:
+ax_pose 30, 0x81ed, 0x90f7, 0x4c00
+ax_pose_terminator
+sTorchicPose113:
+ax_pose 31, 0x01f2, 0x40f8, 0x4c00
+ax_pose_terminator
+sTorchicPose114:
+ax_pose 32, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose115:
+ax_pose 28, 0x81ed, 0x80f8, 0x4c00
+ax_pose 29, 0x81ed, 0x0108, 0x4c08
+ax_pose_terminator
+sTorchicPose116:
+ax_pose 30, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose117:
+ax_pose 25, 0x81eb, 0x80f7, 0x4c00
+ax_pose 26, 0x01eb, 0x0107, 0x4c08
+ax_pose_terminator
+sTorchicPose118:
+ax_pose 27, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose119:
+ax_pose 22, 0x81eb, 0x80f8, 0x4c00
+ax_pose 23, 0x01f3, 0x0108, 0x4c08
+ax_pose_terminator
+sTorchicPose120:
+ax_pose 24, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose121:
+ax_pose 33, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose122:
+ax_pose 34, 0x01eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose123:
+ax_pose 35, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose124:
+ax_pose 36, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sTorchicPose125:
+ax_pose 37, 0x01e5, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose126:
+ax_pose 38, 0x01e3, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose127:
+ax_pose 39, 0x01e6, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose128:
+ax_pose 38, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose129:
+ax_pose 37, 0x01e5, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose130:
+ax_pose 36, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sTorchicPose131:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose132:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose133:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose134:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose135:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose136:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose137:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose138:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose139:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose140:
+ax_pose 21, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose141:
+ax_pose 20, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose142:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose143:
+ax_pose 24, 0x81eb, 0x90f7, 0x4c00
+ax_pose_terminator
+sTorchicPose144:
+ax_pose 22, 0x81eb, 0x90f7, 0x4c00
+ax_pose 23, 0x01f3, 0x10ef, 0x4c08
+ax_pose_terminator
+sTorchicPose145:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose146:
+ax_pose 27, 0x81eb, 0x90f8, 0x4c00
+ax_pose_terminator
+sTorchicPose147:
+ax_pose 25, 0x81eb, 0x90f8, 0x4c00
+ax_pose 26, 0x01eb, 0x10f0, 0x4c08
+ax_pose_terminator
+sTorchicPose148:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose149:
+ax_pose 30, 0x81ed, 0x90f7, 0x4c00
+ax_pose_terminator
+sTorchicPose150:
+ax_pose 28, 0x81ed, 0x90f7, 0x4c00
+ax_pose 29, 0x81ed, 0x10ef, 0x4c08
+ax_pose_terminator
+sTorchicPose151:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose152:
+ax_pose 32, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose153:
+ax_pose 31, 0x01f2, 0x40f8, 0x4c00
+ax_pose_terminator
+sTorchicPose154:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose155:
+ax_pose 30, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose156:
+ax_pose 28, 0x81ed, 0x80f8, 0x4c00
+ax_pose 29, 0x81ed, 0x0108, 0x4c08
+ax_pose_terminator
+sTorchicPose157:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose158:
+ax_pose 27, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose159:
+ax_pose 25, 0x81eb, 0x80f7, 0x4c00
+ax_pose 26, 0x01eb, 0x0107, 0x4c08
+ax_pose_terminator
+sTorchicPose160:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose161:
+ax_pose 24, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose162:
+ax_pose 22, 0x81eb, 0x80f8, 0x4c00
+ax_pose 23, 0x01f3, 0x0108, 0x4c08
+ax_pose_terminator
+sTorchicPose163:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose164:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose165:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose166:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose167:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose168:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose169:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose170:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose171:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose172:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose173:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose174:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose175:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose176:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose177:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose178:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose179:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose180:
+ax_pose 21, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose181:
+ax_pose 20, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose182:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose183:
+ax_pose 24, 0x81eb, 0x90f7, 0x4c00
+ax_pose_terminator
+sTorchicPose184:
+ax_pose 22, 0x81eb, 0x90f7, 0x4c00
+ax_pose 23, 0x01f3, 0x10ef, 0x4c08
+ax_pose_terminator
+sTorchicPose185:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose186:
+ax_pose 27, 0x81eb, 0x90f8, 0x4c00
+ax_pose_terminator
+sTorchicPose187:
+ax_pose 25, 0x81eb, 0x90f8, 0x4c00
+ax_pose 26, 0x01eb, 0x10f0, 0x4c08
+ax_pose_terminator
+sTorchicPose188:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose189:
+ax_pose 30, 0x81ed, 0x90f7, 0x4c00
+ax_pose_terminator
+sTorchicPose190:
+ax_pose 28, 0x81ed, 0x90f7, 0x4c00
+ax_pose 29, 0x81ed, 0x10ef, 0x4c08
+ax_pose_terminator
+sTorchicPose191:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose192:
+ax_pose 32, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose193:
+ax_pose 31, 0x01f2, 0x40f8, 0x4c00
+ax_pose_terminator
+sTorchicPose194:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose195:
+ax_pose 30, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose196:
+ax_pose 28, 0x81ed, 0x80f8, 0x4c00
+ax_pose 29, 0x81ed, 0x0108, 0x4c08
+ax_pose_terminator
+sTorchicPose197:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose198:
+ax_pose 27, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose199:
+ax_pose 25, 0x81eb, 0x80f7, 0x4c00
+ax_pose 26, 0x01eb, 0x0107, 0x4c08
+ax_pose_terminator
+sTorchicPose200:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose201:
+ax_pose 24, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose202:
+ax_pose 22, 0x81eb, 0x80f8, 0x4c00
+ax_pose 23, 0x01f3, 0x0108, 0x4c08
+ax_pose_terminator
+sTorchicPose203:
+ax_pose 15, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose204:
+ax_pose 16, 0x81ec, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose205:
+ax_pose 17, 0x81eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose206:
+ax_pose 18, 0x81eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose207:
+ax_pose 19, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sTorchicPose208:
+ax_pose 18, 0x81eb, 0x90f9, 0x4c00
+ax_pose_terminator
+sTorchicPose209:
+ax_pose 17, 0x81eb, 0x90fb, 0x4c00
+ax_pose_terminator
+sTorchicPose210:
+ax_pose 16, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sTorchicPose211:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose212:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose213:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose214:
+ax_pose 9, 0x81ed, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose215:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose216:
+ax_pose 9, 0x81ed, 0x90f6, 0x4c00
+ax_pose_terminator
+sTorchicPose217:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose218:
+ax_pose 3, 0x01ec, 0x90eb, 0x4c00
+ax_pose_terminator
+sTorchicPose219:
+ax_pose 40, 0x41f3, 0x80ec, 0x4c00
+ax_pose_terminator
+sTorchicPose220:
+ax_pose 41, 0x41f3, 0x80ec, 0x4c00
+ax_pose_terminator
+sTorchicPose221:
+ax_pose 40, 0x41f3, 0x90f4, 0x4c00
+ax_pose_terminator
+sTorchicPose222:
+ax_pose 41, 0x41f3, 0x90f4, 0x4c00
+ax_pose_terminator
+sTorchicPose223:
+ax_pose 40, 0x41f3, 0x80ec, 0x4c00
+ax_pose_terminator
+sTorchicPose224:
+ax_pose 42, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sTorchicPose225:
+ax_pose 43, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sTorchicPose226:
+ax_pose 44, 0x01e7, 0x80f3, 0x4c00
+ax_pose_terminator
+sTorchicPose227:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose228:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose229:
+ax_pose 45, 0x81ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose230:
+ax_pose 46, 0x81ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose231:
+ax_pose 47, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose232:
+ax_pose 48, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose233:
+ax_pose 49, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose234:
+ax_pose 50, 0x81e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose235:
+ax_pose 51, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose236:
+ax_pose 52, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose237:
+ax_pose 53, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose238:
+ax_pose 54, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose239:
+ax_pose 55, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose240:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose241:
+ax_pose 56, 0x01eb, 0x80f9, 0x4c00
+ax_pose_terminator
+sTorchicPose242:
+ax_pose 57, 0x01ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose243:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose244:
+ax_pose 58, 0x81e8, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose245:
+ax_pose 59, 0x81e8, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose246:
+ax_pose 0, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose247:
+ax_pose 48, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose248:
+ax_pose 60, 0x81e8, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose249:
+ax_pose 6, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTorchicPose250:
+ax_pose 61, 0x81e7, 0x80f5, 0x4c00
+ax_pose_terminator
+sTorchicPose251:
+ax_pose 6, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sTorchicPose252:
+ax_pose 61, 0x81e7, 0x90fa, 0x4c00
+ax_pose_terminator
+sTorchicPose253:
+ax_pose 12, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sTorchicPose254:
+ax_pose 62, 0x81eb, 0x80f6, 0x4c00
+ax_pose_terminator
+sTorchicPose255:
+ax_pose 63, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sTorchicPose256:
+ax_pose 64, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sTorchicPose257:
+ax_pose 65, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sTorchicPose258:
+ax_pose 66, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sTorchicPose259:
+ax_pose 67, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sTorchicPose260:
+ax_pose 63, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sTorchicPose261:
+ax_pose 64, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sTorchicPose262:
+ax_pose 65, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sTorchicPose263:
+ax_pose 66, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sTorchicPose264:
+ax_pose 67, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sTorchicPose265:
+ax_pose 68, 0x81eb, 0x90f8, 0x4c00
+ax_pose_terminator
+sTorchicPose266:
+ax_pose 40, 0x41f3, 0x80ec, 0x4c00
+ax_pose_terminator
+sTorchicPose267:
+ax_pose 41, 0x41f3, 0x80ec, 0x4c00
+ax_pose_terminator
+sTorchicPose268:
+ax_pose 40, 0x41f3, 0x90f4, 0x4c00
+ax_pose_terminator
+sTorchicPose269:
+ax_pose 41, 0x41f3, 0x90f4, 0x4c00
+ax_pose_terminator
+sTorchicPose270:
+ax_pose 40, 0x41f3, 0x80ec, 0x4c00
+ax_pose_terminator
+sTorchicPose271:
+ax_pose 41, 0x41f3, 0x80ec, 0x4c00
+ax_pose_terminator
+sTorchicPose272:
+ax_pose 40, 0x41f3, 0x90f4, 0x4c00
+ax_pose_terminator
+sTorchicPose273:
+ax_pose 41, 0x41f3, 0x90f4, 0x4c00
+ax_pose_terminator
+.align 2
+sTorchicAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -2, 0, -1,
+ax_anim 4, 0, 25, 0, -3, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim 2, 2, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTorchicAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -2, -2, -1, -1,
+ax_anim 4, 0, 29, -3, -3, -2, -2,
+ax_anim 2, 0, 28, 0, -1, 0, 0,
+ax_anim 2, 0, 27, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 0, 29, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sTorchicAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -2, 0, -1, 0,
+ax_anim 4, 0, 32, -3, 0, -2, 0,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 1, 32, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sTorchicAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -2, 2, -1, 1,
+ax_anim 4, 0, 35, -3, 3, -2, 2,
+ax_anim 2, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 0, 33, 4, -4, 4, -4,
+ax_anim 2, 2, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 1, 35, 19, -17, 19, -17,
+ax_anim 2, 0, 35, 18, -18, 18, -18,
+ax_anim 2, 0, 35, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sTorchicAnims_2_5:
+ax_anim 4, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 38, 0, 2, 0, 2,
+ax_anim 4, 0, 38, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, -4, 0, -4,
+ax_anim 2, 2, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 1, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 0, 38, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sTorchicAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 2, 2, 2, 2,
+ax_anim 4, 0, 41, 3, 3, 3, 3,
+ax_anim 2, 0, 40, 0, 0, 0, -1,
+ax_anim 2, 0, 39, -4, -4, -4, -4,
+ax_anim 2, 2, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 1, 41, -19, -17, -19, -17,
+ax_anim 2, 0, 41, -18, -18, -18, -18,
+ax_anim 2, 0, 41, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sTorchicAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 2, 0, 1, 0,
+ax_anim 4, 0, 44, 3, 0, 2, 0,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 42, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 1, 44, -18, 1, -18, 1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sTorchicAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 2, -2, 1, -1,
+ax_anim 4, 0, 47, 3, -3, 2, -2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 45, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 2, 1, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTorchicAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, -1,
+ax_anim 4, 0, 49, 0, -3, 0, -2,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim 2, 2, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sTorchicAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 53, -2, -2, -1, -1,
+ax_anim 4, 0, 53, -3, -3, -2, -2,
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 51, 4, 4, 4, 4,
+ax_anim 2, 2, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 53, 18, 18, 18, 18,
+ax_anim 2, 1, 53, 19, 17, 19, 17,
+ax_anim 2, 0, 53, 18, 18, 18, 18,
+ax_anim 2, 0, 53, 19, 17, 19, 17,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sTorchicAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 56, -2, 0, -1, 0,
+ax_anim 4, 0, 56, -3, 0, -2, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 1, 56, 18, 1, 18, 1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, 1, 18, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sTorchicAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 59, -2, 2, -1, 1,
+ax_anim 4, 0, 59, -3, 3, -2, 2,
+ax_anim 2, 0, 58, 0, -1, 0, -1,
+ax_anim 2, 0, 57, 4, -4, 4, -4,
+ax_anim 2, 2, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 59, 18, -18, 18, -18,
+ax_anim 2, 1, 59, 19, -17, 19, -17,
+ax_anim 2, 0, 59, 18, -18, 18, -18,
+ax_anim 2, 0, 59, 19, -17, 19, -17,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sTorchicAnims_3_5:
+ax_anim 4, 0, 60, 0, 1, 0, 1,
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 4, 0, 62, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim 2, 2, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 1, 62, 1, -18, 1, -18,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 0, 62, 1, -18, 1, -18,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sTorchicAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 2, 2, 2, 2,
+ax_anim 4, 0, 65, 3, 3, 3, 3,
+ax_anim 2, 0, 64, 0, 0, 0, -1,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim 2, 2, 65, -10, -10, -10, -10,
+ax_anim 2, 0, 65, -18, -18, -18, -18,
+ax_anim 2, 1, 65, -19, -17, -19, -17,
+ax_anim 2, 0, 65, -18, -18, -18, -18,
+ax_anim 2, 0, 65, -19, -17, -19, -17,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sTorchicAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 2, 0, 1, 0,
+ax_anim 4, 0, 68, 3, 0, 2, 0,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 66, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 1, 68, -18, 1, -18, 1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, 1, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sTorchicAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 2, -2, 1, -1,
+ax_anim 4, 0, 71, 3, -3, 2, -2,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -4, 4, -4, 4,
+ax_anim 2, 2, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 2, 1, 71, -18, 18, -18, 18,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTorchicAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 0, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 75, 0, -1, 0, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_4_2:
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 77, -2, -2, -2, -2,
+ax_anim 6, 0, 77, -3, -3, -3, -3,
+ax_anim 2, 0, 79, -1, -1, -1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_4_3:
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, -2, 0, -2, 0,
+ax_anim 6, 0, 81, -3, 0, -3, 0,
+ax_anim 2, 0, 83, -1, 0, -1, 0,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim_terminator
+sTorchicAnims_4_4:
+ax_anim 2, 0, 84, 1, 1, 1, 1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 1, 1, 1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, -2, 2, -2, 2,
+ax_anim 6, 0, 85, -3, 3, -3, 3,
+ax_anim 2, 0, 87, -1, 1, -1, 1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim_terminator
+sTorchicAnims_4_5:
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 4, 0, 89, 0, 2, 0, 2,
+ax_anim 6, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 91, 0, 1, 0, 1,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 1, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, -1, 0, -1,
+ax_anim_terminator
+sTorchicAnims_4_6:
+ax_anim 2, 0, 92, -1, 1, -1, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, -1, 1, -1, 1,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 2, 2, 2, 2,
+ax_anim 6, 0, 93, 3, 3, 3, 3,
+ax_anim 2, 0, 95, 1, 1, 1, 1,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 1, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -1, -1, -1, -1,
+ax_anim_terminator
+sTorchicAnims_4_7:
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 2, 0, 2, 0,
+ax_anim 6, 0, 97, 3, 0, 3, 0,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_4_8:
+ax_anim 2, 0, 100, -1, -1, -1, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, -1, -1, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 2, -2, 2, -2,
+ax_anim 6, 0, 101, 3, -3, 3, -3,
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 2, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 1, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sTorchicAnims_5_1:
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 2, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_5_2:
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 2, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_5_3:
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 2, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_5_4:
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 2, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_5_5:
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 2, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 112, 0, 0, 0, 0,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_5_6:
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 2, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 114, 0, 0, 0, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_5_7:
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 2, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 116, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_5_8:
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 2, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 118, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sTorchicAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sTorchicAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sTorchicAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sTorchicAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sTorchicAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sTorchicAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sTorchicAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTorchicAnims_8_1:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 3, 0, 139, 0, -1, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_8_2:
+ax_anim 30, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 3, 0, 142, 0, -1, 0, 0,
+ax_anim 3, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_8_3:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 3, 0, 145, 0, -1, 0, 0,
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_8_4:
+ax_anim 30, 0, 147, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 0, 148, 0, -3, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_8_5:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 0, 151, 0, -3, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim 3, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_8_6:
+ax_anim 30, 0, 153, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 3, 0, 154, 0, -1, 0, 0,
+ax_anim 3, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_8_7:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 3, 0, 157, 0, -1, 0, 0,
+ax_anim 3, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_8_8:
+ax_anim 30, 0, 159, 0, 0, 0, 0,
+ax_anim 3, 0, 160, 0, -2, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -1, 0, 0,
+ax_anim 3, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 13, 7, 13,
+ax_anim 3, 0, 166, 1, 16, 1, 16,
+ax_anim 2, 3, 167, -6, 14, -6, 14,
+ax_anim 2, 0, 168, -7, 8, -7, 8,
+ax_anim 1, 0, 169, -5, 4, -5, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 24, 10, 24, 10,
+ax_anim 3, 0, 165, 23, 18, 23, 18,
+ax_anim 2, 3, 166, 11, 18, 11, 18,
+ax_anim 2, 0, 167, 4, 12, 4, 12,
+ax_anim 1, 0, 168, 1, 7, 1, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 20, 1, 20, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 1, -6, 1, -6,
+ax_anim 2, 0, 169, 5, -14, 5, -14,
+ax_anim 2, 0, 162, 11, -18, 11, -18,
+ax_anim 3, 0, 163, 18, -17, 18, -17,
+ax_anim 2, 3, 164, 18, -11, 18, -11,
+ax_anim 2, 0, 165, 15, -5, 15, -5,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -9, -8, -9,
+ax_anim 2, 0, 169, -7, -15, -7, -13,
+ax_anim 3, 0, 162, -1, -19, -1, -16,
+ax_anim 2, 3, 163, 7, -16, 7, -14,
+ax_anim 2, 0, 164, 8, -8, 8, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, -1, -6, -1, -6,
+ax_anim 2, 0, 163, -5, -14, -5, -14,
+ax_anim 2, 0, 162, -11, -18, -11, -18,
+ax_anim 3, 0, 169, -18, -17, -18, -17,
+ax_anim 2, 3, 168, -18, -11, -18, -11,
+ax_anim 2, 0, 167, -15, -5, -15, -5,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -20, 1, -20, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -24, 10, -24, 10,
+ax_anim 3, 0, 167, -23, 18, -23, 18,
+ax_anim 2, 3, 166, -11, 18, -11, 18,
+ax_anim 2, 0, 165, -4, 12, -4, 12,
+ax_anim 1, 0, 164, -1, 7, -1, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -23, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_14_1:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_14_2:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_14_3:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_14_4:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_14_5:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_14_6:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_14_7:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_14_8:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 35, 0, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_15_1:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_15_2:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_15_3:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_15_4:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_15_5:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_15_6:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_15_7:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_15_8:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 14, 0, 224, 0, 0, 0, 0,
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 10, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_16_1:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_16_2:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_16_3:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_16_4:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_16_5:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_16_6:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_16_7:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_16_8:
+ax_anim 8, 0, 227, 0, 0, 0, 0,
+ax_anim 3, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_17_1:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_17_2:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_17_3:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_17_4:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_17_5:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_17_6:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_17_7:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+sTorchicAnims_17_8:
+ax_anim 12, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_18_1:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_18_2:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_18_3:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_18_4:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_18_5:
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 1, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 1, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 1, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_18_6:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_18_7:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_18_8:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 1, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_19_1:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_19_2:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_19_3:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_19_4:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_19_5:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_19_6:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_19_7:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_19_8:
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 237, 0, 0, 0, 0,
+ax_anim 8, 0, 236, 0, 0, 0, 0,
+ax_anim 10, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_20_1:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 1, 0, 0,
+ax_anim 2, 0, 241, 1, 1, 1, 0,
+ax_anim 2, 0, 241, 0, 1, 0, 0,
+ax_anim 2, 0, 241, 1, 1, 1, 0,
+ax_anim 2, 0, 241, 0, 1, 0, 0,
+ax_anim 2, 0, 241, 1, 1, 1, 0,
+ax_anim_terminator
+sTorchicAnims_20_2:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim_terminator
+sTorchicAnims_20_3:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim_terminator
+sTorchicAnims_20_4:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim_terminator
+sTorchicAnims_20_5:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim_terminator
+sTorchicAnims_20_6:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim_terminator
+sTorchicAnims_20_7:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim_terminator
+sTorchicAnims_20_8:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -2, 0, 0,
+ax_anim 1, 0, 240, 0, -4, 0, 0,
+ax_anim 2, 0, 241, 0, -4, 0, 0,
+ax_anim 1, 0, 241, 0, -2, 0, 0,
+ax_anim 4, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_21_1:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_21_2:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_21_3:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_21_4:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_21_5:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_21_6:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_21_7:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_21_8:
+ax_anim 8, 0, 242, 0, 0, 0, 0,
+ax_anim 8, 0, 243, 0, 0, 0, 0,
+ax_anim 8, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_22_1:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_22_2:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_22_3:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_22_4:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_22_5:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_22_6:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_22_7:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_22_8:
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 30, 0, 246, 0, 0, 0, 0,
+ax_anim 34, 0, 247, 0, 0, 0, 0,
+ax_anim 4, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_23_1:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_23_2:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_23_3:
+ax_anim 10, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 250, 0, 0, 0, 0,
+ax_anim 8, 0, 251, 0, 0, 0, 0,
+ax_anim 4, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_23_4:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_23_5:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_23_6:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_23_7:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_23_8:
+ax_anim 10, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 8, 0, 249, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_24_1:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_24_2:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_24_3:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_24_4:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_24_5:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_24_6:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_24_7:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_24_8:
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_25_1:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_25_2:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_25_3:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_25_4:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_25_5:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_25_6:
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 10, 0, 259, 0, 0, 0, 0,
+ax_anim 8, 0, 262, 0, 0, 0, 0,
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_25_7:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 257, 0, 0, 0, 0,
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_25_8:
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 255, 0, 0, 0, 0,
+ax_anim 12, 0, 256, 0, 0, 0, 0,
+ax_anim 10, 0, 254, 0, 0, 0, 0,
+ax_anim 8, 0, 257, 0, 0, 0, 0,
+ax_anim 12, 0, 258, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_26_1:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_26_2:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_26_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_26_4:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_26_5:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_26_6:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_26_7:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+sTorchicAnims_26_8:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 2, 0, 264, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sTorchicAnims_27_1:
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim 16, 0, 265, -1, 0, 0, 0,
+ax_anim 12, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 265, 1, 0, 0, 0,
+ax_anim 16, 0, 265, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorchicAnims_28_1:
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_28_2:
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_28_3:
+ax_anim 12, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_28_4:
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_28_5:
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_28_6:
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_28_7:
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicAnims_28_8:
+ax_anim 12, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sTorchicGfx1:
+.incbin "baserom.gba", 0x1076AA0, 0x100
+sTorchicSprites1:
+ax_sprite sTorchicGfx1, 0x100
+ax_sprite_terminator
+sTorchicGfx2:
+.incbin "baserom.gba", 0x1076BB0, 0x100
+sTorchicSprites2:
+ax_sprite sTorchicGfx2, 0x100
+ax_sprite_terminator
+sTorchicGfx3:
+.incbin "baserom.gba", 0x1076CC0, 0x100
+sTorchicSprites3:
+ax_sprite sTorchicGfx3, 0x100
+ax_sprite_terminator
+sTorchicGfx4:
+.incbin "baserom.gba", 0x1076DD0, 0x200
+sTorchicSprites4:
+ax_sprite sTorchicGfx4, 0x200
+ax_sprite_terminator
+sTorchicGfx5:
+.incbin "baserom.gba", 0x1076FE0, 0x200
+sTorchicSprites5:
+ax_sprite sTorchicGfx5, 0x200
+ax_sprite_terminator
+sTorchicGfx6:
+.incbin "baserom.gba", 0x10771F0, 0x200
+sTorchicSprites6:
+ax_sprite sTorchicGfx6, 0x200
+ax_sprite_terminator
+sTorchicGfx7:
+.incbin "baserom.gba", 0x1077400, 0x200
+sTorchicSprites7:
+ax_sprite sTorchicGfx7, 0x200
+ax_sprite_terminator
+sTorchicGfx8:
+.incbin "baserom.gba", 0x1077610, 0x200
+sTorchicSprites8:
+ax_sprite sTorchicGfx8, 0x200
+ax_sprite_terminator
+sTorchicGfx9:
+.incbin "baserom.gba", 0x1077820, 0x200
+sTorchicSprites9:
+ax_sprite sTorchicGfx9, 0x200
+ax_sprite_terminator
+sTorchicGfx10:
+.incbin "baserom.gba", 0x1077A30, 0x100
+sTorchicSprites10:
+ax_sprite sTorchicGfx10, 0x100
+ax_sprite_terminator
+sTorchicGfx11:
+.incbin "baserom.gba", 0x1077B40, 0x100
+sTorchicSprites11:
+ax_sprite sTorchicGfx11, 0x100
+ax_sprite_terminator
+sTorchicGfx12:
+.incbin "baserom.gba", 0x1077C50, 0x100
+sTorchicSprites12:
+ax_sprite sTorchicGfx12, 0x100
+ax_sprite_terminator
+sTorchicGfx13:
+.incbin "baserom.gba", 0x1077D60, 0x100
+sTorchicSprites13:
+ax_sprite sTorchicGfx13, 0x100
+ax_sprite_terminator
+sTorchicGfx14:
+.incbin "baserom.gba", 0x1077E70, 0x100
+sTorchicSprites14:
+ax_sprite sTorchicGfx14, 0x100
+ax_sprite_terminator
+sTorchicGfx15:
+.incbin "baserom.gba", 0x1077F80, 0x100
+sTorchicSprites15:
+ax_sprite sTorchicGfx15, 0x100
+ax_sprite_terminator
+sTorchicGfx16:
+.incbin "baserom.gba", 0x1078090, 0xC0
+sTorchicSprites16:
+ax_sprite sTorchicGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx17:
+.incbin "baserom.gba", 0x1078168, 0xC0
+sTorchicSprites17:
+ax_sprite sTorchicGfx17, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx18:
+.incbin "baserom.gba", 0x1078240, 0xC0
+sTorchicSprites18:
+ax_sprite sTorchicGfx18, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx19:
+.incbin "baserom.gba", 0x1078318, 0xC0
+sTorchicSprites19:
+ax_sprite sTorchicGfx19, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx20:
+.incbin "baserom.gba", 0x10783F0, 0xC0
+sTorchicSprites20:
+ax_sprite sTorchicGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx21:
+.incbin "baserom.gba", 0x10784C8, 0xC0
+sTorchicSprites21:
+ax_sprite sTorchicGfx21, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx22:
+.incbin "baserom.gba", 0x10785A0, 0xC0
+sTorchicSprites22:
+ax_sprite sTorchicGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx23:
+.incbin "baserom.gba", 0x1078678, 0xC0
+sTorchicSprites23:
+ax_sprite sTorchicGfx23, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx24:
+.incbin "baserom.gba", 0x1078750, 0x20
+sTorchicSprites24:
+ax_sprite sTorchicGfx24, 0x20
+ax_sprite_terminator
+sTorchicGfx25:
+.incbin "baserom.gba", 0x1078780, 0xC0
+sTorchicSprites25:
+ax_sprite sTorchicGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx26:
+.incbin "baserom.gba", 0x1078858, 0xA0
+sTorchicSprites26:
+ax_sprite 0, 0x20
+ax_sprite sTorchicGfx26, 0xa0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx27:
+.incbin "baserom.gba", 0x1078918, 0x20
+sTorchicSprites27:
+ax_sprite sTorchicGfx27, 0x20
+ax_sprite_terminator
+sTorchicGfx28:
+.incbin "baserom.gba", 0x1078948, 0xC0
+sTorchicSprites28:
+ax_sprite sTorchicGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx29:
+.incbin "baserom.gba", 0x1078A20, 0xC0
+sTorchicSprites29:
+ax_sprite sTorchicGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx30:
+.incbin "baserom.gba", 0x1078AF8, 0x40
+sTorchicSprites30:
+ax_sprite sTorchicGfx30, 0x40
+ax_sprite_terminator
+sTorchicGfx31:
+.incbin "baserom.gba", 0x1078B48, 0xC0
+sTorchicSprites31:
+ax_sprite sTorchicGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx32:
+.incbin "baserom.gba", 0x1078C20, 0x80
+sTorchicSprites32:
+ax_sprite sTorchicGfx32, 0x80
+ax_sprite_terminator
+sTorchicGfx33:
+.incbin "baserom.gba", 0x1078CB0, 0xC0
+sTorchicSprites33:
+ax_sprite sTorchicGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTorchicGfx34:
+.incbin "baserom.gba", 0x1078D88, 0x200
+sTorchicSprites34:
+ax_sprite sTorchicGfx34, 0x200
+ax_sprite_terminator
+sTorchicGfx35:
+.incbin "baserom.gba", 0x1078F98, 0x200
+sTorchicSprites35:
+ax_sprite sTorchicGfx35, 0x200
+ax_sprite_terminator
+sTorchicGfx36:
+.incbin "baserom.gba", 0x10791A8, 0x200
+sTorchicSprites36:
+ax_sprite sTorchicGfx36, 0x200
+ax_sprite_terminator
+sTorchicGfx37:
+.incbin "baserom.gba", 0x10793B8, 0x200
+sTorchicSprites37:
+ax_sprite sTorchicGfx37, 0x200
+ax_sprite_terminator
+sTorchicGfx38:
+.incbin "baserom.gba", 0x10795C8, 0x200
+sTorchicSprites38:
+ax_sprite sTorchicGfx38, 0x200
+ax_sprite_terminator
+sTorchicGfx39:
+.incbin "baserom.gba", 0x10797D8, 0x200
+sTorchicSprites39:
+ax_sprite sTorchicGfx39, 0x200
+ax_sprite_terminator
+sTorchicGfx40:
+.incbin "baserom.gba", 0x10799E8, 0x200
+sTorchicSprites40:
+ax_sprite sTorchicGfx40, 0x200
+ax_sprite_terminator
+sTorchicGfx41:
+.incbin "baserom.gba", 0x1079BF8, 0x100
+sTorchicSprites41:
+ax_sprite sTorchicGfx41, 0x100
+ax_sprite_terminator
+sTorchicGfx42:
+.incbin "baserom.gba", 0x1079D08, 0x100
+sTorchicSprites42:
+ax_sprite sTorchicGfx42, 0x100
+ax_sprite_terminator
+sTorchicGfx43:
+.incbin "baserom.gba", 0x1079E18, 0x200
+sTorchicSprites43:
+ax_sprite sTorchicGfx43, 0x200
+ax_sprite_terminator
+sTorchicGfx44:
+.incbin "baserom.gba", 0x107A028, 0x200
+sTorchicSprites44:
+ax_sprite sTorchicGfx44, 0x200
+ax_sprite_terminator
+sTorchicGfx45:
+.incbin "baserom.gba", 0x107A238, 0x200
+sTorchicSprites45:
+ax_sprite sTorchicGfx45, 0x200
+ax_sprite_terminator
+sTorchicGfx46:
+.incbin "baserom.gba", 0x107A448, 0x100
+sTorchicSprites46:
+ax_sprite sTorchicGfx46, 0x100
+ax_sprite_terminator
+sTorchicGfx47:
+.incbin "baserom.gba", 0x107A558, 0x100
+sTorchicSprites47:
+ax_sprite sTorchicGfx47, 0x100
+ax_sprite_terminator
+sTorchicGfx48:
+.incbin "baserom.gba", 0x107A668, 0x100
+sTorchicSprites48:
+ax_sprite sTorchicGfx48, 0x100
+ax_sprite_terminator
+sTorchicGfx49:
+.incbin "baserom.gba", 0x107A778, 0x100
+sTorchicSprites49:
+ax_sprite sTorchicGfx49, 0x100
+ax_sprite_terminator
+sTorchicGfx50:
+.incbin "baserom.gba", 0x107A888, 0x100
+sTorchicSprites50:
+ax_sprite sTorchicGfx50, 0x100
+ax_sprite_terminator
+sTorchicGfx51:
+.incbin "baserom.gba", 0x107A998, 0x100
+sTorchicSprites51:
+ax_sprite sTorchicGfx51, 0x100
+ax_sprite_terminator
+sTorchicGfx52:
+.incbin "baserom.gba", 0x107AAA8, 0x100
+sTorchicSprites52:
+ax_sprite sTorchicGfx52, 0x100
+ax_sprite_terminator
+sTorchicGfx53:
+.incbin "baserom.gba", 0x107ABB8, 0x100
+sTorchicSprites53:
+ax_sprite sTorchicGfx53, 0x100
+ax_sprite_terminator
+sTorchicGfx54:
+.incbin "baserom.gba", 0x107ACC8, 0x200
+sTorchicSprites54:
+ax_sprite sTorchicGfx54, 0x200
+ax_sprite_terminator
+sTorchicGfx55:
+.incbin "baserom.gba", 0x107AED8, 0x100
+sTorchicSprites55:
+ax_sprite sTorchicGfx55, 0x100
+ax_sprite_terminator
+sTorchicGfx56:
+.incbin "baserom.gba", 0x107AFE8, 0x100
+sTorchicSprites56:
+ax_sprite sTorchicGfx56, 0x100
+ax_sprite_terminator
+sTorchicGfx57:
+.incbin "baserom.gba", 0x107B0F8, 0x200
+sTorchicSprites57:
+ax_sprite sTorchicGfx57, 0x200
+ax_sprite_terminator
+sTorchicGfx58:
+.incbin "baserom.gba", 0x107B308, 0x200
+sTorchicSprites58:
+ax_sprite sTorchicGfx58, 0x200
+ax_sprite_terminator
+sTorchicGfx59:
+.incbin "baserom.gba", 0x107B518, 0x100
+sTorchicSprites59:
+ax_sprite sTorchicGfx59, 0x100
+ax_sprite_terminator
+sTorchicGfx60:
+.incbin "baserom.gba", 0x107B628, 0x100
+sTorchicSprites60:
+ax_sprite sTorchicGfx60, 0x100
+ax_sprite_terminator
+sTorchicGfx61:
+.incbin "baserom.gba", 0x107B738, 0x100
+sTorchicSprites61:
+ax_sprite sTorchicGfx61, 0x100
+ax_sprite_terminator
+sTorchicGfx62:
+.incbin "baserom.gba", 0x107B848, 0x100
+sTorchicSprites62:
+ax_sprite sTorchicGfx62, 0x100
+ax_sprite_terminator
+sTorchicGfx63:
+.incbin "baserom.gba", 0x107B958, 0x100
+sTorchicSprites63:
+ax_sprite sTorchicGfx63, 0x100
+ax_sprite_terminator
+sTorchicGfx64:
+.incbin "baserom.gba", 0x107BA68, 0x200
+sTorchicSprites64:
+ax_sprite sTorchicGfx64, 0x200
+ax_sprite_terminator
+sTorchicGfx65:
+.incbin "baserom.gba", 0x107BC78, 0x200
+sTorchicSprites65:
+ax_sprite sTorchicGfx65, 0x200
+ax_sprite_terminator
+sTorchicGfx66:
+.incbin "baserom.gba", 0x107BE88, 0x200
+sTorchicSprites66:
+ax_sprite sTorchicGfx66, 0x200
+ax_sprite_terminator
+sTorchicGfx67:
+.incbin "baserom.gba", 0x107C098, 0x200
+sTorchicSprites67:
+ax_sprite sTorchicGfx67, 0x200
+ax_sprite_terminator
+sTorchicGfx68:
+.incbin "baserom.gba", 0x107C2A8, 0x200
+sTorchicSprites68:
+ax_sprite sTorchicGfx68, 0x200
+ax_sprite_terminator
+sTorchicGfx69:
+.incbin "baserom.gba", 0x107C4B8, 0x100
+sTorchicSprites69:
+ax_sprite sTorchicGfx69, 0x100
+ax_sprite_terminator
+sAxPosesTorchic:
+.4byte sTorchicPose1
+.4byte sTorchicPose2
+.4byte sTorchicPose3
+.4byte sTorchicPose4
+.4byte sTorchicPose5
+.4byte sTorchicPose6
+.4byte sTorchicPose7
+.4byte sTorchicPose8
+.4byte sTorchicPose9
+.4byte sTorchicPose10
+.4byte sTorchicPose11
+.4byte sTorchicPose12
+.4byte sTorchicPose13
+.4byte sTorchicPose14
+.4byte sTorchicPose15
+.4byte sTorchicPose16
+.4byte sTorchicPose17
+.4byte sTorchicPose18
+.4byte sTorchicPose19
+.4byte sTorchicPose20
+.4byte sTorchicPose21
+.4byte sTorchicPose22
+.4byte sTorchicPose23
+.4byte sTorchicPose24
+.4byte sTorchicPose25
+.4byte sTorchicPose26
+.4byte sTorchicPose27
+.4byte sTorchicPose28
+.4byte sTorchicPose29
+.4byte sTorchicPose30
+.4byte sTorchicPose31
+.4byte sTorchicPose32
+.4byte sTorchicPose33
+.4byte sTorchicPose34
+.4byte sTorchicPose35
+.4byte sTorchicPose36
+.4byte sTorchicPose37
+.4byte sTorchicPose38
+.4byte sTorchicPose39
+.4byte sTorchicPose40
+.4byte sTorchicPose41
+.4byte sTorchicPose42
+.4byte sTorchicPose43
+.4byte sTorchicPose44
+.4byte sTorchicPose45
+.4byte sTorchicPose46
+.4byte sTorchicPose47
+.4byte sTorchicPose48
+.4byte sTorchicPose49
+.4byte sTorchicPose50
+.4byte sTorchicPose51
+.4byte sTorchicPose52
+.4byte sTorchicPose53
+.4byte sTorchicPose54
+.4byte sTorchicPose55
+.4byte sTorchicPose56
+.4byte sTorchicPose57
+.4byte sTorchicPose58
+.4byte sTorchicPose59
+.4byte sTorchicPose60
+.4byte sTorchicPose61
+.4byte sTorchicPose62
+.4byte sTorchicPose63
+.4byte sTorchicPose64
+.4byte sTorchicPose65
+.4byte sTorchicPose66
+.4byte sTorchicPose67
+.4byte sTorchicPose68
+.4byte sTorchicPose69
+.4byte sTorchicPose70
+.4byte sTorchicPose71
+.4byte sTorchicPose72
+.4byte sTorchicPose73
+.4byte sTorchicPose74
+.4byte sTorchicPose75
+.4byte sTorchicPose76
+.4byte sTorchicPose77
+.4byte sTorchicPose78
+.4byte sTorchicPose79
+.4byte sTorchicPose80
+.4byte sTorchicPose81
+.4byte sTorchicPose82
+.4byte sTorchicPose83
+.4byte sTorchicPose84
+.4byte sTorchicPose85
+.4byte sTorchicPose86
+.4byte sTorchicPose87
+.4byte sTorchicPose88
+.4byte sTorchicPose89
+.4byte sTorchicPose90
+.4byte sTorchicPose91
+.4byte sTorchicPose92
+.4byte sTorchicPose93
+.4byte sTorchicPose94
+.4byte sTorchicPose95
+.4byte sTorchicPose96
+.4byte sTorchicPose97
+.4byte sTorchicPose98
+.4byte sTorchicPose99
+.4byte sTorchicPose100
+.4byte sTorchicPose101
+.4byte sTorchicPose102
+.4byte sTorchicPose103
+.4byte sTorchicPose104
+.4byte sTorchicPose105
+.4byte sTorchicPose106
+.4byte sTorchicPose107
+.4byte sTorchicPose108
+.4byte sTorchicPose109
+.4byte sTorchicPose110
+.4byte sTorchicPose111
+.4byte sTorchicPose112
+.4byte sTorchicPose113
+.4byte sTorchicPose114
+.4byte sTorchicPose115
+.4byte sTorchicPose116
+.4byte sTorchicPose117
+.4byte sTorchicPose118
+.4byte sTorchicPose119
+.4byte sTorchicPose120
+.4byte sTorchicPose121
+.4byte sTorchicPose122
+.4byte sTorchicPose123
+.4byte sTorchicPose124
+.4byte sTorchicPose125
+.4byte sTorchicPose126
+.4byte sTorchicPose127
+.4byte sTorchicPose128
+.4byte sTorchicPose129
+.4byte sTorchicPose130
+.4byte sTorchicPose131
+.4byte sTorchicPose132
+.4byte sTorchicPose133
+.4byte sTorchicPose134
+.4byte sTorchicPose135
+.4byte sTorchicPose136
+.4byte sTorchicPose137
+.4byte sTorchicPose138
+.4byte sTorchicPose139
+.4byte sTorchicPose140
+.4byte sTorchicPose141
+.4byte sTorchicPose142
+.4byte sTorchicPose143
+.4byte sTorchicPose144
+.4byte sTorchicPose145
+.4byte sTorchicPose146
+.4byte sTorchicPose147
+.4byte sTorchicPose148
+.4byte sTorchicPose149
+.4byte sTorchicPose150
+.4byte sTorchicPose151
+.4byte sTorchicPose152
+.4byte sTorchicPose153
+.4byte sTorchicPose154
+.4byte sTorchicPose155
+.4byte sTorchicPose156
+.4byte sTorchicPose157
+.4byte sTorchicPose158
+.4byte sTorchicPose159
+.4byte sTorchicPose160
+.4byte sTorchicPose161
+.4byte sTorchicPose162
+.4byte sTorchicPose163
+.4byte sTorchicPose164
+.4byte sTorchicPose165
+.4byte sTorchicPose166
+.4byte sTorchicPose167
+.4byte sTorchicPose168
+.4byte sTorchicPose169
+.4byte sTorchicPose170
+.4byte sTorchicPose171
+.4byte sTorchicPose172
+.4byte sTorchicPose173
+.4byte sTorchicPose174
+.4byte sTorchicPose175
+.4byte sTorchicPose176
+.4byte sTorchicPose177
+.4byte sTorchicPose178
+.4byte sTorchicPose179
+.4byte sTorchicPose180
+.4byte sTorchicPose181
+.4byte sTorchicPose182
+.4byte sTorchicPose183
+.4byte sTorchicPose184
+.4byte sTorchicPose185
+.4byte sTorchicPose186
+.4byte sTorchicPose187
+.4byte sTorchicPose188
+.4byte sTorchicPose189
+.4byte sTorchicPose190
+.4byte sTorchicPose191
+.4byte sTorchicPose192
+.4byte sTorchicPose193
+.4byte sTorchicPose194
+.4byte sTorchicPose195
+.4byte sTorchicPose196
+.4byte sTorchicPose197
+.4byte sTorchicPose198
+.4byte sTorchicPose199
+.4byte sTorchicPose200
+.4byte sTorchicPose201
+.4byte sTorchicPose202
+.4byte sTorchicPose203
+.4byte sTorchicPose204
+.4byte sTorchicPose205
+.4byte sTorchicPose206
+.4byte sTorchicPose207
+.4byte sTorchicPose208
+.4byte sTorchicPose209
+.4byte sTorchicPose210
+.4byte sTorchicPose211
+.4byte sTorchicPose212
+.4byte sTorchicPose213
+.4byte sTorchicPose214
+.4byte sTorchicPose215
+.4byte sTorchicPose216
+.4byte sTorchicPose217
+.4byte sTorchicPose218
+.4byte sTorchicPose219
+.4byte sTorchicPose220
+.4byte sTorchicPose221
+.4byte sTorchicPose222
+.4byte sTorchicPose223
+.4byte sTorchicPose224
+.4byte sTorchicPose225
+.4byte sTorchicPose226
+.4byte sTorchicPose227
+.4byte sTorchicPose228
+.4byte sTorchicPose229
+.4byte sTorchicPose230
+.4byte sTorchicPose231
+.4byte sTorchicPose232
+.4byte sTorchicPose233
+.4byte sTorchicPose234
+.4byte sTorchicPose235
+.4byte sTorchicPose236
+.4byte sTorchicPose237
+.4byte sTorchicPose238
+.4byte sTorchicPose239
+.4byte sTorchicPose240
+.4byte sTorchicPose241
+.4byte sTorchicPose242
+.4byte sTorchicPose243
+.4byte sTorchicPose244
+.4byte sTorchicPose245
+.4byte sTorchicPose246
+.4byte sTorchicPose247
+.4byte sTorchicPose248
+.4byte sTorchicPose249
+.4byte sTorchicPose250
+.4byte sTorchicPose251
+.4byte sTorchicPose252
+.4byte sTorchicPose253
+.4byte sTorchicPose254
+.4byte sTorchicPose255
+.4byte sTorchicPose256
+.4byte sTorchicPose257
+.4byte sTorchicPose258
+.4byte sTorchicPose259
+.4byte sTorchicPose260
+.4byte sTorchicPose261
+.4byte sTorchicPose262
+.4byte sTorchicPose263
+.4byte sTorchicPose264
+.4byte sTorchicPose265
+.4byte sTorchicPose266
+.4byte sTorchicPose267
+.4byte sTorchicPose268
+.4byte sTorchicPose269
+.4byte sTorchicPose270
+.4byte sTorchicPose271
+.4byte sTorchicPose272
+.4byte sTorchicPose273
+sAxPositionsTorchic:
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -6
+.2byte   -1,   -5, 	  -7,   -4, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte    4,   -5, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte    4,   -5, 	   1,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    6,   -6, 	  -2,   -4, 	  -5,   -3, 	  -2,   -5
+.2byte    6,   -6, 	  -2,   -4, 	  -4,   -3, 	  -2,   -5
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    2,  -10, 	  -6,   -3, 	  -4,   -2, 	  -2,   -4
+.2byte    2,  -11, 	  -6,   -2, 	  -3,   -2, 	  -2,   -4
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -11, 	   2,   -1, 	  -1,   -1, 	  -1,   -5
+.2byte   -1,  -11, 	   1,   -1, 	  -3,   -1, 	  -1,   -5
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -4,  -10, 	   4,   -3, 	   2,   -2, 	   0,   -4
+.2byte   -4,  -11, 	   4,   -2, 	   1,   -2, 	   0,   -4
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -8,   -6, 	   0,   -4, 	   3,   -3, 	   0,   -5
+.2byte   -8,   -6, 	   0,   -4, 	   2,   -3, 	   0,   -5
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -6,   -5, 	  -3,   -5, 	   4,   -2, 	  -2,   -6
+.2byte   -6,   -5, 	  -3,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -6
+.2byte   -1,   -5, 	  -7,   -4, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte    4,   -5, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte    4,   -5, 	   1,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    6,   -7, 	  -2,   -5, 	  -5,   -4, 	  -2,   -6
+.2byte    6,   -7, 	  -2,   -5, 	  -4,   -4, 	  -2,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    2,  -10, 	  -6,   -3, 	  -4,   -2, 	  -2,   -4
+.2byte    2,  -11, 	  -6,   -2, 	  -3,   -2, 	  -2,   -4
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -11, 	   2,   -1, 	  -1,   -1, 	  -1,   -5
+.2byte   -1,  -11, 	   1,   -1, 	  -3,   -1, 	  -1,   -5
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -4,  -10, 	   4,   -3, 	   2,   -2, 	   0,   -4
+.2byte   -4,  -11, 	   4,   -2, 	   1,   -2, 	   0,   -4
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -8,   -7, 	   0,   -5, 	   3,   -4, 	   0,   -6
+.2byte   -8,   -7, 	   0,   -5, 	   2,   -4, 	   0,   -6
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -6,   -5, 	  -3,   -5, 	   4,   -2, 	  -2,   -6
+.2byte   -6,   -5, 	  -3,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -6
+.2byte   -1,   -5, 	  -7,   -4, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte    4,   -5, 	   1,   -5, 	  -6,   -2, 	   0,   -6
+.2byte    4,   -5, 	   1,   -6, 	  -5,   -3, 	   0,   -6
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    6,   -7, 	  -2,   -5, 	  -5,   -4, 	  -2,   -6
+.2byte    6,   -7, 	  -2,   -5, 	  -4,   -4, 	  -2,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    2,  -10, 	  -6,   -3, 	  -4,   -2, 	  -2,   -4
+.2byte    2,  -11, 	  -6,   -2, 	  -3,   -2, 	  -2,   -4
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -11, 	   2,   -1, 	  -1,   -1, 	  -1,   -5
+.2byte   -1,  -11, 	   1,   -1, 	  -3,   -1, 	  -1,   -5
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -4,  -10, 	   4,   -3, 	   2,   -2, 	   0,   -4
+.2byte   -4,  -11, 	   4,   -2, 	   1,   -2, 	   0,   -4
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -8,   -7, 	   0,   -5, 	   3,   -4, 	   0,   -6
+.2byte   -8,   -7, 	   0,   -5, 	   2,   -4, 	   0,   -6
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -6,   -5, 	  -3,   -5, 	   4,   -2, 	  -2,   -6
+.2byte   -6,   -5, 	  -3,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,   -4, 	   5,   -4, 	  -1,   -6
+.2byte   -1,   -5, 	  -7,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -1,   -4, 	  -7,   -5, 	   5,   -5, 	  -1,   -5
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -3, 	   0,   -7
+.2byte    4,   -6, 	   1,   -7, 	  -5,   -4, 	   0,   -7
+.2byte    6,   -4, 	   3,   -6, 	  -5,   -5, 	   1,   -5
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    6,   -7, 	  -2,   -5, 	  -5,   -4, 	  -2,   -6
+.2byte    6,   -7, 	  -2,   -5, 	  -4,   -4, 	  -2,   -6
+.2byte    9,   -8, 	  -2,   -7, 	  -4,   -6, 	   1,   -7
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -2,   -5
+.2byte    2,  -12, 	  -6,   -3, 	  -3,   -3, 	  -2,   -5
+.2byte    7,  -10, 	  -4,   -6, 	  -3,   -5, 	   1,   -7
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -12, 	   2,   -2, 	  -1,   -2, 	  -1,   -6
+.2byte   -1,  -12, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -14, 	   1,   -4, 	  -3,   -4, 	  -1,   -7
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -4,  -10, 	   4,   -3, 	   2,   -2, 	   0,   -4
+.2byte   -4,  -11, 	   4,   -2, 	   1,   -2, 	   0,   -4
+.2byte   -9,  -10, 	   2,   -6, 	   1,   -5, 	  -3,   -7
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -8,   -6, 	   0,   -4, 	   3,   -3, 	   0,   -5
+.2byte   -8,   -6, 	   0,   -4, 	   2,   -3, 	   0,   -5
+.2byte  -11,   -8, 	   0,   -7, 	   2,   -6, 	  -3,   -7
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -6,   -5, 	  -3,   -5, 	   4,   -2, 	  -2,   -6
+.2byte   -6,   -5, 	  -3,   -6, 	   3,   -3, 	  -2,   -6
+.2byte   -7,   -4, 	  -4,   -6, 	   4,   -5, 	  -2,   -5
+.2byte   -1,   -5, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -1,   -7, 	  -6,   -6, 	   4,   -6, 	  -1,   -8
+.2byte    4,   -5, 	   0,   -5, 	  -6,   -3, 	   0,   -7
+.2byte    4,   -7, 	   1,   -9, 	  -6,   -6, 	  -1,   -8
+.2byte    6,   -6, 	  -3,   -4, 	  -4,   -3, 	  -2,   -6
+.2byte    6,   -8, 	  -4,   -7, 	  -4,   -5, 	  -2,   -7
+.2byte    3,  -10, 	  -6,   -3, 	  -4,   -2, 	  -2,   -5
+.2byte    4,  -11, 	  -6,   -5, 	  -4,   -4, 	  -2,   -7
+.2byte   -1,  -12, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte   -1,  -14, 	   1,   -4, 	  -3,   -4, 	  -1,   -7
+.2byte   -5,  -10, 	   4,   -3, 	   2,   -2, 	   0,   -5
+.2byte   -6,  -11, 	   4,   -5, 	   2,   -4, 	   0,   -7
+.2byte   -8,   -6, 	   1,   -4, 	   2,   -3, 	   0,   -6
+.2byte   -8,   -8, 	   2,   -7, 	   2,   -5, 	   0,   -7
+.2byte   -6,   -5, 	  -2,   -5, 	   4,   -3, 	  -2,   -7
+.2byte   -6,   -7, 	  -3,   -9, 	   4,   -6, 	  -1,   -8
+.2byte   -4,   -6, 	   0,   -6, 	   6,   -4, 	   0,   -7
+.2byte   -4,   -5, 	   0,   -5, 	   6,   -4, 	   0,   -6
+.2byte   -1,   -7, 	  -7,   -3, 	   5,   -3, 	  -1,   -8
+.2byte    4,   -9, 	  -1,   -5, 	  -7,   -2, 	   0,   -8
+.2byte    4,   -9, 	  -3,   -3, 	  -6,   -3, 	  -3,   -6
+.2byte    1,  -13, 	  -7,   -3, 	  -4,   -3, 	  -3,   -6
+.2byte   -1,  -13, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -3,  -13, 	   5,   -3, 	   2,   -3, 	   1,   -6
+.2byte   -6,   -9, 	   1,   -3, 	   4,   -3, 	   1,   -6
+.2byte   -6,   -9, 	  -1,   -5, 	   5,   -2, 	  -2,   -8
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -6,   -6, 	   4,   -6, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte    4,   -7, 	   1,   -9, 	  -6,   -6, 	  -1,   -8
+.2byte    4,   -5, 	   0,   -5, 	  -6,   -3, 	   0,   -7
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    6,   -8, 	  -4,   -7, 	  -4,   -5, 	  -2,   -7
+.2byte    6,   -6, 	  -3,   -4, 	  -4,   -3, 	  -2,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    4,  -11, 	  -6,   -5, 	  -4,   -4, 	  -2,   -7
+.2byte    3,  -10, 	  -6,   -3, 	  -4,   -2, 	  -2,   -5
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -14, 	   1,   -4, 	  -3,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -6,  -11, 	   4,   -5, 	   2,   -4, 	   0,   -7
+.2byte   -5,  -10, 	   4,   -3, 	   2,   -2, 	   0,   -5
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -8,   -8, 	   2,   -7, 	   2,   -5, 	   0,   -7
+.2byte   -8,   -6, 	   1,   -4, 	   2,   -3, 	   0,   -6
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -6,   -7, 	  -3,   -9, 	   4,   -6, 	  -1,   -8
+.2byte   -6,   -5, 	  -2,   -5, 	   4,   -3, 	  -2,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -6,   -6, 	   4,   -6, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte    4,   -7, 	   1,   -9, 	  -6,   -6, 	  -1,   -8
+.2byte    4,   -5, 	   0,   -5, 	  -6,   -3, 	   0,   -7
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    6,   -8, 	  -4,   -7, 	  -4,   -5, 	  -2,   -7
+.2byte    6,   -6, 	  -3,   -4, 	  -4,   -3, 	  -2,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    4,  -11, 	  -6,   -5, 	  -4,   -4, 	  -2,   -7
+.2byte    3,  -10, 	  -6,   -3, 	  -4,   -2, 	  -2,   -5
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -14, 	   1,   -4, 	  -3,   -4, 	  -1,   -7
+.2byte   -1,  -12, 	   1,   -2, 	  -3,   -2, 	  -1,   -4
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -6,  -11, 	   4,   -5, 	   2,   -4, 	   0,   -7
+.2byte   -5,  -10, 	   4,   -3, 	   2,   -2, 	   0,   -5
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -8,   -8, 	   2,   -7, 	   2,   -5, 	   0,   -7
+.2byte   -8,   -6, 	   1,   -4, 	   2,   -3, 	   0,   -6
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -6,   -7, 	  -3,   -9, 	   4,   -6, 	  -1,   -8
+.2byte   -6,   -5, 	  -2,   -5, 	   4,   -3, 	  -2,   -7
+.2byte   -1,   -4, 	  -7,   -5, 	   5,   -5, 	  -1,   -5
+.2byte   -7,   -4, 	  -4,   -6, 	   4,   -5, 	  -2,   -5
+.2byte  -11,   -8, 	   0,   -7, 	   2,   -6, 	  -3,   -7
+.2byte   -9,  -10, 	   2,   -6, 	   1,   -5, 	  -3,   -7
+.2byte   -1,  -14, 	   1,   -4, 	  -3,   -4, 	  -1,   -7
+.2byte    7,  -10, 	  -4,   -6, 	  -3,   -5, 	   1,   -7
+.2byte    9,   -8, 	  -2,   -7, 	  -4,   -6, 	   1,   -7
+.2byte    6,   -4, 	   3,   -6, 	  -5,   -5, 	   1,   -5
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -6,   -6, 	  -3,   -6, 	   4,   -4, 	  -2,   -7
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -4,  -11, 	   4,   -4, 	   2,   -3, 	  -1,   -5
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte    2,  -11, 	  -6,   -4, 	  -4,   -3, 	  -1,   -5
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    4,   -6, 	   1,   -6, 	  -6,   -4, 	   0,   -7
+.2byte   -2,  -11, 	   2,   -3, 	   0,   -3, 	  -1,   -3
+.2byte   -2,  -10, 	   2,   -3, 	   0,   -3, 	  -1,   -4
+.2byte    1,  -11, 	  -3,   -3, 	  -1,   -3, 	   0,   -3
+.2byte    1,  -10, 	  -3,   -3, 	  -1,   -3, 	   0,   -4
+.2byte   -2,  -11, 	   2,   -3, 	   0,   -3, 	  -1,   -3
+.2byte    4,   -8, 	  -3,   -1, 	  -3,   -3, 	  -1,   -4
+.2byte    7,   -4, 	  -4,   -2, 	  -4,   -4, 	  -1,   -4
+.2byte    7,   -5, 	  -4,   -3, 	  -4,   -5, 	  -1,   -5
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -13, 	   2,   -3, 	  -4,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   2,   -4, 	  -4,   -4, 	  -1,   -7
+.2byte   -1,   -5, 	  -7,   -5, 	   5,   -5, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -7, 	  -6,   -7, 	   4,   -7, 	  -1,   -8
+.2byte   -1,  -11, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -12, 	   1,   -4, 	  -3,   -4, 	  -1,   -6
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -5, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -1,   -5, 	  -6,   -4, 	   4,   -4, 	  -1,   -6
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -5,  -10, 	   2,   -6, 	   3,   -4, 	   1,   -7
+.2byte   -1,  -11, 	   2,   -4, 	   3,   -2, 	   2,   -6
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -1,  -10, 	   1,   -1, 	  -3,   -1, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,   -8, 	  -6,   -6, 	   4,   -6, 	  -1,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -5
+.2byte   -8,   -7, 	  -1,   -5, 	   2,   -4, 	  -1,   -6
+.2byte   -6,   -1, 	   2,   -6, 	   0,   -6, 	  -2,   -5
+.2byte    6,   -7, 	  -1,   -5, 	  -4,   -4, 	  -1,   -6
+.2byte    4,   -1, 	  -4,   -6, 	  -2,   -6, 	   0,   -5
+.2byte   -1,  -12, 	   1,   -3, 	  -3,   -3, 	  -1,   -6
+.2byte   -1,  -11, 	   1,   -2, 	  -3,   -2, 	  -1,   -6
+.2byte   -9,   -6, 	   1,   -7, 	   2,   -4, 	   0,   -6
+.2byte   -7,   -7, 	   3,   -7, 	   4,   -5, 	   1,   -7
+.2byte  -10,   -6, 	   0,   -6, 	   1,   -4, 	  -2,   -6
+.2byte   -7,   -7, 	   3,   -7, 	   4,   -5, 	   1,   -7
+.2byte  -10,   -6, 	   0,   -6, 	   1,   -4, 	  -2,   -6
+.2byte    8,   -6, 	  -2,   -7, 	  -3,   -4, 	  -1,   -6
+.2byte    6,   -7, 	  -4,   -7, 	  -5,   -5, 	  -2,   -7
+.2byte    9,   -6, 	  -1,   -6, 	  -2,   -4, 	   1,   -6
+.2byte    6,   -7, 	  -4,   -7, 	  -5,   -5, 	  -2,   -7
+.2byte    9,   -6, 	  -1,   -6, 	  -2,   -4, 	   1,   -6
+.2byte    2,   -9, 	  -6,   -3, 	  -3,   -1, 	  -2,   -5
+.2byte   -2,  -11, 	   2,   -3, 	   0,   -3, 	  -1,   -3
+.2byte   -2,  -10, 	   2,   -3, 	   0,   -3, 	  -1,   -4
+.2byte    1,  -11, 	  -3,   -3, 	  -1,   -3, 	   0,   -3
+.2byte    1,  -10, 	  -3,   -3, 	  -1,   -3, 	   0,   -4
+.2byte   -2,  -11, 	   2,   -3, 	   0,   -3, 	  -1,   -3
+.2byte   -2,  -10, 	   2,   -3, 	   0,   -3, 	  -1,   -4
+.2byte    1,  -11, 	  -3,   -3, 	  -1,   -3, 	   0,   -3
+.2byte    1,  -10, 	  -3,   -3, 	  -1,   -3, 	   0,   -4
+sTorchicAnimTable1:
+.4byte sTorchicAnims_1_1
+.4byte sTorchicAnims_1_2
+.4byte sTorchicAnims_1_3
+.4byte sTorchicAnims_1_4
+.4byte sTorchicAnims_1_5
+.4byte sTorchicAnims_1_6
+.4byte sTorchicAnims_1_7
+.4byte sTorchicAnims_1_8
+sTorchicAnimTable2:
+.4byte sTorchicAnims_2_1
+.4byte sTorchicAnims_2_2
+.4byte sTorchicAnims_2_3
+.4byte sTorchicAnims_2_4
+.4byte sTorchicAnims_2_5
+.4byte sTorchicAnims_2_6
+.4byte sTorchicAnims_2_7
+.4byte sTorchicAnims_2_8
+sTorchicAnimTable3:
+.4byte sTorchicAnims_3_1
+.4byte sTorchicAnims_3_2
+.4byte sTorchicAnims_3_3
+.4byte sTorchicAnims_3_4
+.4byte sTorchicAnims_3_5
+.4byte sTorchicAnims_3_6
+.4byte sTorchicAnims_3_7
+.4byte sTorchicAnims_3_8
+sTorchicAnimTable4:
+.4byte sTorchicAnims_4_1
+.4byte sTorchicAnims_4_2
+.4byte sTorchicAnims_4_3
+.4byte sTorchicAnims_4_4
+.4byte sTorchicAnims_4_5
+.4byte sTorchicAnims_4_6
+.4byte sTorchicAnims_4_7
+.4byte sTorchicAnims_4_8
+sTorchicAnimTable5:
+.4byte sTorchicAnims_5_1
+.4byte sTorchicAnims_5_2
+.4byte sTorchicAnims_5_3
+.4byte sTorchicAnims_5_4
+.4byte sTorchicAnims_5_5
+.4byte sTorchicAnims_5_6
+.4byte sTorchicAnims_5_7
+.4byte sTorchicAnims_5_8
+sTorchicAnimTable6:
+.4byte sTorchicAnims_6_1
+.4byte sTorchicAnims_6_1
+.4byte sTorchicAnims_6_1
+.4byte sTorchicAnims_6_1
+.4byte sTorchicAnims_6_1
+.4byte sTorchicAnims_6_1
+.4byte sTorchicAnims_6_1
+.4byte sTorchicAnims_6_1
+sTorchicAnimTable7:
+.4byte sTorchicAnims_7_1
+.4byte sTorchicAnims_7_2
+.4byte sTorchicAnims_7_3
+.4byte sTorchicAnims_7_4
+.4byte sTorchicAnims_7_5
+.4byte sTorchicAnims_7_6
+.4byte sTorchicAnims_7_7
+.4byte sTorchicAnims_7_8
+sTorchicAnimTable8:
+.4byte sTorchicAnims_8_1
+.4byte sTorchicAnims_8_2
+.4byte sTorchicAnims_8_3
+.4byte sTorchicAnims_8_4
+.4byte sTorchicAnims_8_5
+.4byte sTorchicAnims_8_6
+.4byte sTorchicAnims_8_7
+.4byte sTorchicAnims_8_8
+sTorchicAnimTable9:
+.4byte sTorchicAnims_9_1
+.4byte sTorchicAnims_9_2
+.4byte sTorchicAnims_9_3
+.4byte sTorchicAnims_9_4
+.4byte sTorchicAnims_9_5
+.4byte sTorchicAnims_9_6
+.4byte sTorchicAnims_9_7
+.4byte sTorchicAnims_9_8
+sTorchicAnimTable10:
+.4byte sTorchicAnims_10_1
+.4byte sTorchicAnims_10_2
+.4byte sTorchicAnims_10_3
+.4byte sTorchicAnims_10_4
+.4byte sTorchicAnims_10_5
+.4byte sTorchicAnims_10_6
+.4byte sTorchicAnims_10_7
+.4byte sTorchicAnims_10_8
+sTorchicAnimTable11:
+.4byte sTorchicAnims_11_1
+.4byte sTorchicAnims_11_2
+.4byte sTorchicAnims_11_3
+.4byte sTorchicAnims_11_4
+.4byte sTorchicAnims_11_5
+.4byte sTorchicAnims_11_6
+.4byte sTorchicAnims_11_7
+.4byte sTorchicAnims_11_8
+sTorchicAnimTable12:
+.4byte sTorchicAnims_12_1
+.4byte sTorchicAnims_12_2
+.4byte sTorchicAnims_12_3
+.4byte sTorchicAnims_12_4
+.4byte sTorchicAnims_12_5
+.4byte sTorchicAnims_12_6
+.4byte sTorchicAnims_12_7
+.4byte sTorchicAnims_12_8
+sTorchicAnimTable13:
+.4byte sTorchicAnims_13_1
+.4byte sTorchicAnims_13_2
+.4byte sTorchicAnims_13_3
+.4byte sTorchicAnims_13_4
+.4byte sTorchicAnims_13_5
+.4byte sTorchicAnims_13_6
+.4byte sTorchicAnims_13_7
+.4byte sTorchicAnims_13_8
+sTorchicAnimTable14:
+.4byte sTorchicAnims_14_1
+.4byte sTorchicAnims_14_2
+.4byte sTorchicAnims_14_3
+.4byte sTorchicAnims_14_4
+.4byte sTorchicAnims_14_5
+.4byte sTorchicAnims_14_6
+.4byte sTorchicAnims_14_7
+.4byte sTorchicAnims_14_8
+sTorchicAnimTable15:
+.4byte sTorchicAnims_15_1
+.4byte sTorchicAnims_15_2
+.4byte sTorchicAnims_15_3
+.4byte sTorchicAnims_15_4
+.4byte sTorchicAnims_15_5
+.4byte sTorchicAnims_15_6
+.4byte sTorchicAnims_15_7
+.4byte sTorchicAnims_15_8
+sTorchicAnimTable16:
+.4byte sTorchicAnims_16_1
+.4byte sTorchicAnims_16_2
+.4byte sTorchicAnims_16_3
+.4byte sTorchicAnims_16_4
+.4byte sTorchicAnims_16_5
+.4byte sTorchicAnims_16_6
+.4byte sTorchicAnims_16_7
+.4byte sTorchicAnims_16_8
+sTorchicAnimTable17:
+.4byte sTorchicAnims_17_1
+.4byte sTorchicAnims_17_2
+.4byte sTorchicAnims_17_3
+.4byte sTorchicAnims_17_4
+.4byte sTorchicAnims_17_5
+.4byte sTorchicAnims_17_6
+.4byte sTorchicAnims_17_7
+.4byte sTorchicAnims_17_8
+sTorchicAnimTable18:
+.4byte sTorchicAnims_18_1
+.4byte sTorchicAnims_18_2
+.4byte sTorchicAnims_18_3
+.4byte sTorchicAnims_18_4
+.4byte sTorchicAnims_18_5
+.4byte sTorchicAnims_18_6
+.4byte sTorchicAnims_18_7
+.4byte sTorchicAnims_18_8
+sTorchicAnimTable19:
+.4byte sTorchicAnims_19_1
+.4byte sTorchicAnims_19_2
+.4byte sTorchicAnims_19_3
+.4byte sTorchicAnims_19_4
+.4byte sTorchicAnims_19_5
+.4byte sTorchicAnims_19_6
+.4byte sTorchicAnims_19_7
+.4byte sTorchicAnims_19_8
+sTorchicAnimTable20:
+.4byte sTorchicAnims_20_1
+.4byte sTorchicAnims_20_2
+.4byte sTorchicAnims_20_3
+.4byte sTorchicAnims_20_4
+.4byte sTorchicAnims_20_5
+.4byte sTorchicAnims_20_6
+.4byte sTorchicAnims_20_7
+.4byte sTorchicAnims_20_8
+sTorchicAnimTable21:
+.4byte sTorchicAnims_21_1
+.4byte sTorchicAnims_21_2
+.4byte sTorchicAnims_21_3
+.4byte sTorchicAnims_21_4
+.4byte sTorchicAnims_21_5
+.4byte sTorchicAnims_21_6
+.4byte sTorchicAnims_21_7
+.4byte sTorchicAnims_21_8
+sTorchicAnimTable22:
+.4byte sTorchicAnims_22_1
+.4byte sTorchicAnims_22_2
+.4byte sTorchicAnims_22_3
+.4byte sTorchicAnims_22_4
+.4byte sTorchicAnims_22_5
+.4byte sTorchicAnims_22_6
+.4byte sTorchicAnims_22_7
+.4byte sTorchicAnims_22_8
+sTorchicAnimTable23:
+.4byte sTorchicAnims_23_1
+.4byte sTorchicAnims_23_2
+.4byte sTorchicAnims_23_3
+.4byte sTorchicAnims_23_4
+.4byte sTorchicAnims_23_5
+.4byte sTorchicAnims_23_6
+.4byte sTorchicAnims_23_7
+.4byte sTorchicAnims_23_8
+sTorchicAnimTable24:
+.4byte sTorchicAnims_24_1
+.4byte sTorchicAnims_24_2
+.4byte sTorchicAnims_24_3
+.4byte sTorchicAnims_24_4
+.4byte sTorchicAnims_24_5
+.4byte sTorchicAnims_24_6
+.4byte sTorchicAnims_24_7
+.4byte sTorchicAnims_24_8
+sTorchicAnimTable25:
+.4byte sTorchicAnims_25_1
+.4byte sTorchicAnims_25_2
+.4byte sTorchicAnims_25_3
+.4byte sTorchicAnims_25_4
+.4byte sTorchicAnims_25_5
+.4byte sTorchicAnims_25_6
+.4byte sTorchicAnims_25_7
+.4byte sTorchicAnims_25_8
+sTorchicAnimTable26:
+.4byte sTorchicAnims_26_1
+.4byte sTorchicAnims_26_2
+.4byte sTorchicAnims_26_3
+.4byte sTorchicAnims_26_4
+.4byte sTorchicAnims_26_5
+.4byte sTorchicAnims_26_6
+.4byte sTorchicAnims_26_7
+.4byte sTorchicAnims_26_8
+sTorchicAnimTable27:
+.4byte sTorchicAnims_27_1
+.4byte sTorchicAnims_27_1
+.4byte sTorchicAnims_27_1
+.4byte sTorchicAnims_27_1
+.4byte sTorchicAnims_27_1
+.4byte sTorchicAnims_27_1
+.4byte sTorchicAnims_27_1
+.4byte sTorchicAnims_27_1
+sTorchicAnimTable28:
+.4byte sTorchicAnims_28_1
+.4byte sTorchicAnims_28_2
+.4byte sTorchicAnims_28_3
+.4byte sTorchicAnims_28_4
+.4byte sTorchicAnims_28_5
+.4byte sTorchicAnims_28_6
+.4byte sTorchicAnims_28_7
+.4byte sTorchicAnims_28_8
+sAxAnimationsTorchic:
+.4byte sTorchicAnimTable1
+.4byte sTorchicAnimTable2
+.4byte sTorchicAnimTable3
+.4byte sTorchicAnimTable4
+.4byte sTorchicAnimTable5
+.4byte sTorchicAnimTable6
+.4byte sTorchicAnimTable7
+.4byte sTorchicAnimTable8
+.4byte sTorchicAnimTable9
+.4byte sTorchicAnimTable10
+.4byte sTorchicAnimTable11
+.4byte sTorchicAnimTable12
+.4byte sTorchicAnimTable13
+.4byte sTorchicAnimTable14
+.4byte sTorchicAnimTable15
+.4byte sTorchicAnimTable16
+.4byte sTorchicAnimTable17
+.4byte sTorchicAnimTable18
+.4byte sTorchicAnimTable19
+.4byte sTorchicAnimTable20
+.4byte sTorchicAnimTable21
+.4byte sTorchicAnimTable22
+.4byte sTorchicAnimTable23
+.4byte sTorchicAnimTable24
+.4byte sTorchicAnimTable25
+.4byte sTorchicAnimTable26
+.4byte sTorchicAnimTable27
+.4byte sTorchicAnimTable28
+sAxSpritesTorchic:
+.4byte sTorchicSprites1
+.4byte sTorchicSprites2
+.4byte sTorchicSprites3
+.4byte sTorchicSprites4
+.4byte sTorchicSprites5
+.4byte sTorchicSprites6
+.4byte sTorchicSprites7
+.4byte sTorchicSprites8
+.4byte sTorchicSprites9
+.4byte sTorchicSprites10
+.4byte sTorchicSprites11
+.4byte sTorchicSprites12
+.4byte sTorchicSprites13
+.4byte sTorchicSprites14
+.4byte sTorchicSprites15
+.4byte sTorchicSprites16
+.4byte sTorchicSprites17
+.4byte sTorchicSprites18
+.4byte sTorchicSprites19
+.4byte sTorchicSprites20
+.4byte sTorchicSprites21
+.4byte sTorchicSprites22
+.4byte sTorchicSprites23
+.4byte sTorchicSprites24
+.4byte sTorchicSprites25
+.4byte sTorchicSprites26
+.4byte sTorchicSprites27
+.4byte sTorchicSprites28
+.4byte sTorchicSprites29
+.4byte sTorchicSprites30
+.4byte sTorchicSprites31
+.4byte sTorchicSprites32
+.4byte sTorchicSprites33
+.4byte sTorchicSprites34
+.4byte sTorchicSprites35
+.4byte sTorchicSprites36
+.4byte sTorchicSprites37
+.4byte sTorchicSprites38
+.4byte sTorchicSprites39
+.4byte sTorchicSprites40
+.4byte sTorchicSprites41
+.4byte sTorchicSprites42
+.4byte sTorchicSprites43
+.4byte sTorchicSprites44
+.4byte sTorchicSprites45
+.4byte sTorchicSprites46
+.4byte sTorchicSprites47
+.4byte sTorchicSprites48
+.4byte sTorchicSprites49
+.4byte sTorchicSprites50
+.4byte sTorchicSprites51
+.4byte sTorchicSprites52
+.4byte sTorchicSprites53
+.4byte sTorchicSprites54
+.4byte sTorchicSprites55
+.4byte sTorchicSprites56
+.4byte sTorchicSprites57
+.4byte sTorchicSprites58
+.4byte sTorchicSprites59
+.4byte sTorchicSprites60
+.4byte sTorchicSprites61
+.4byte sTorchicSprites62
+.4byte sTorchicSprites63
+.4byte sTorchicSprites64
+.4byte sTorchicSprites65
+.4byte sTorchicSprites66
+.4byte sTorchicSprites67
+.4byte sTorchicSprites68
+.4byte sTorchicSprites69
+sAxMainTorchic:
+ax_main sAxPosesTorchic, sAxAnimationsTorchic, 28, sAxSpritesTorchic, sAxPositionsTorchic

--- a/data/ax/torkoal.inc
+++ b/data/ax/torkoal.inc
@@ -1,0 +1,3096 @@
+.global gAxTorkoal
+gAxTorkoal:
+ax_siro sAxMainTorkoal
+sTorkoalPose1:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose2:
+ax_pose 1, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose3:
+ax_pose 2, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose4:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose5:
+ax_pose 4, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose6:
+ax_pose 5, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose7:
+ax_pose 6, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose8:
+ax_pose 7, 0x01ef, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose9:
+ax_pose 8, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose10:
+ax_pose 9, 0x01ed, 0x90eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose11:
+ax_pose 10, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose12:
+ax_pose 11, 0x01ed, 0x90eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose13:
+ax_pose 12, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose14:
+ax_pose 13, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose15:
+ax_pose 14, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose16:
+ax_pose 9, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose17:
+ax_pose 10, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose19:
+ax_pose 6, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose20:
+ax_pose 7, 0x01ef, 0x80ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose21:
+ax_pose 8, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose22:
+ax_pose 3, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose23:
+ax_pose 4, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose24:
+ax_pose 5, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose25:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose26:
+ax_pose 3, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose27:
+ax_pose 6, 0x01ef, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose28:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sTorkoalPose29:
+ax_pose 12, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose30:
+ax_pose 9, 0x01ee, 0x90ea, 0x6c00
+ax_pose_terminator
+sTorkoalPose31:
+ax_pose 6, 0x01ef, 0x90ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose32:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose33:
+ax_pose 15, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose34:
+ax_pose 16, 0x0200, 0x00fa, 0x6c00
+ax_pose 17, 0x41f0, 0x80f2, 0x6c01
+ax_pose_terminator
+sTorkoalPose35:
+ax_pose 18, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose36:
+ax_pose 19, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose37:
+ax_pose 20, 0x01ec, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose38:
+ax_pose 19, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose39:
+ax_pose 18, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose40:
+ax_pose 16, 0x0200, 0x10fd, 0x6c00
+ax_pose 17, 0x41f0, 0x90ed, 0x6c01
+ax_pose_terminator
+sTorkoalPose41:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose42:
+ax_pose 3, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose43:
+ax_pose 6, 0x01ef, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose44:
+ax_pose 9, 0x01ee, 0x80f5, 0x6c00
+ax_pose_terminator
+sTorkoalPose45:
+ax_pose 12, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose46:
+ax_pose 9, 0x01ee, 0x90ea, 0x6c00
+ax_pose_terminator
+sTorkoalPose47:
+ax_pose 6, 0x01ef, 0x90ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose48:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose49:
+ax_pose 15, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose50:
+ax_pose 16, 0x0200, 0x00fa, 0x6c00
+ax_pose 17, 0x41f0, 0x80f2, 0x6c01
+ax_pose_terminator
+sTorkoalPose51:
+ax_pose 18, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose52:
+ax_pose 19, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose53:
+ax_pose 20, 0x01ec, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose54:
+ax_pose 19, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose55:
+ax_pose 18, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose56:
+ax_pose 16, 0x0200, 0x10fd, 0x6c00
+ax_pose 17, 0x41f0, 0x90ed, 0x6c01
+ax_pose_terminator
+sTorkoalPose57:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose58:
+ax_pose 21, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose59:
+ax_pose 22, 0x01fc, 0x40f4, 0x6c00
+ax_pose -1, 0x01fc, 0x40fc, 0x6c00
+ax_pose -1, 0x01e9, 0x40f8, 0x6c00
+ax_pose 23, 0x01ec, 0x80f0, 0x6c04
+ax_pose_terminator
+sTorkoalPose60:
+ax_pose 22, 0x01fd, 0x40f3, 0x6c00
+ax_pose -1, 0x01fd, 0x40fd, 0x6c00
+ax_pose -1, 0x01e7, 0x40f8, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 23, 0x01ec, 0x80f0, 0x6c05
+ax_pose_terminator
+sTorkoalPose61:
+ax_pose 25, 0x01fe, 0x40f1, 0x6c00
+ax_pose -1, 0x01fe, 0x40ff, 0x6c00
+ax_pose -1, 0x01e4, 0x40f8, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 23, 0x01ec, 0x80f0, 0x6c05
+ax_pose_terminator
+sTorkoalPose62:
+ax_pose 26, 0x01ff, 0x40ef, 0x6c00
+ax_pose -1, 0x01ff, 0x4101, 0x6c00
+ax_pose -1, 0x01e2, 0x40f8, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 23, 0x01ec, 0x80f0, 0x6c05
+ax_pose_terminator
+sTorkoalPose63:
+ax_pose 27, 0x0200, 0x40ed, 0x6c00
+ax_pose -1, 0x0200, 0x4103, 0x6c00
+ax_pose -1, 0x01e2, 0x40f8, 0x6c00
+ax_pose 23, 0x01ec, 0x80f0, 0x6c04
+ax_pose_terminator
+sTorkoalPose64:
+ax_pose 28, 0x0201, 0x40eb, 0x6c00
+ax_pose -1, 0x0201, 0x4105, 0x6c00
+ax_pose -1, 0x01e0, 0x40f8, 0x6c00
+ax_pose 23, 0x01ec, 0x80f0, 0x6c04
+ax_pose_terminator
+sTorkoalPose65:
+ax_pose 29, 0x0202, 0x40e9, 0x6c00
+ax_pose -1, 0x0202, 0x4107, 0x6c00
+ax_pose -1, 0x01de, 0x40f8, 0x6c00
+ax_pose 23, 0x01ec, 0x80f0, 0x6c04
+ax_pose_terminator
+sTorkoalPose66:
+ax_pose 23, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose67:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose68:
+ax_pose 30, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose69:
+ax_pose 22, 0x01f9, 0x4101, 0x6c00
+ax_pose -1, 0x01f6, 0x4109, 0x6c00
+ax_pose -1, 0x01e9, 0x40f8, 0x6c00
+ax_pose 31, 0x01ec, 0x90f1, 0x6c04
+ax_pose_terminator
+sTorkoalPose70:
+ax_pose 22, 0x01fa, 0x4101, 0x6c00
+ax_pose -1, 0x01f7, 0x4109, 0x6c00
+ax_pose -1, 0x01e6, 0x40f8, 0x6c00
+ax_pose 24, 0x01ed, 0x00fc, 0x6c04
+ax_pose 31, 0x01ec, 0x90f1, 0x6c05
+ax_pose_terminator
+sTorkoalPose71:
+ax_pose 25, 0x01fc, 0x4100, 0x6c00
+ax_pose -1, 0x01f7, 0x410a, 0x6c00
+ax_pose -1, 0x01e3, 0x40f8, 0x6c00
+ax_pose 24, 0x01ed, 0x00fc, 0x6c04
+ax_pose 31, 0x01ec, 0x90f1, 0x6c05
+ax_pose_terminator
+sTorkoalPose72:
+ax_pose 26, 0x01fd, 0x40ff, 0x6c00
+ax_pose -1, 0x01f7, 0x410c, 0x6c00
+ax_pose -1, 0x01e1, 0x40f8, 0x6c00
+ax_pose 24, 0x01ed, 0x00fc, 0x6c04
+ax_pose 31, 0x01ec, 0x90f1, 0x6c05
+ax_pose_terminator
+sTorkoalPose73:
+ax_pose 27, 0x01fe, 0x40fe, 0x6c00
+ax_pose -1, 0x01f8, 0x410e, 0x6c00
+ax_pose -1, 0x01e1, 0x40f8, 0x6c00
+ax_pose 31, 0x01ec, 0x90f1, 0x6c04
+ax_pose_terminator
+sTorkoalPose74:
+ax_pose 28, 0x01ff, 0x40fc, 0x6c00
+ax_pose -1, 0x01f9, 0x4110, 0x6c00
+ax_pose -1, 0x01e0, 0x40f8, 0x6c00
+ax_pose 31, 0x01ec, 0x90f1, 0x6c04
+ax_pose_terminator
+sTorkoalPose75:
+ax_pose 29, 0x01ff, 0x40fb, 0x6c00
+ax_pose -1, 0x01fa, 0x4112, 0x6c00
+ax_pose -1, 0x01de, 0x40f8, 0x6c00
+ax_pose 31, 0x01ec, 0x90f1, 0x6c04
+ax_pose_terminator
+sTorkoalPose76:
+ax_pose 31, 0x01ec, 0x90f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose77:
+ax_pose 6, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose78:
+ax_pose 32, 0x01ec, 0x90f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose79:
+ax_pose 33, 0x01ec, 0x90f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose80:
+ax_pose 22, 0x01f7, 0x4107, 0x6c00
+ax_pose -1, 0x01e9, 0x40f8, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 33, 0x01ec, 0x90f4, 0x6c05
+ax_pose -1, 0x01f5, 0x4109, 0x6c00
+ax_pose_terminator
+sTorkoalPose81:
+ax_pose 22, 0x01f8, 0x4108, 0x6c00
+ax_pose -1, 0x01e6, 0x40f8, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 33, 0x01ec, 0x90f4, 0x6c05
+ax_pose -1, 0x01f6, 0x410a, 0x6c00
+ax_pose_terminator
+sTorkoalPose82:
+ax_pose 25, 0x01fa, 0x4109, 0x6c00
+ax_pose -1, 0x01e4, 0x40f8, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 33, 0x01ec, 0x90f4, 0x6c05
+ax_pose -1, 0x01f6, 0x410c, 0x6c00
+ax_pose_terminator
+sTorkoalPose83:
+ax_pose 26, 0x01fb, 0x4108, 0x6c00
+ax_pose -1, 0x01e2, 0x40f8, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 33, 0x01ec, 0x90f4, 0x6c05
+ax_pose -1, 0x01f6, 0x410d, 0x6c00
+ax_pose_terminator
+sTorkoalPose84:
+ax_pose 27, 0x01fc, 0x4109, 0x6c00
+ax_pose -1, 0x01e1, 0x40f8, 0x6c00
+ax_pose 33, 0x01ec, 0x90f4, 0x6c04
+ax_pose -1, 0x01f7, 0x4111, 0x6c00
+ax_pose_terminator
+sTorkoalPose85:
+ax_pose 28, 0x01fd, 0x4108, 0x6c00
+ax_pose -1, 0x01e0, 0x40f8, 0x6c00
+ax_pose 33, 0x01ec, 0x90f4, 0x6c04
+ax_pose -1, 0x01f8, 0x4113, 0x6c00
+ax_pose_terminator
+sTorkoalPose86:
+ax_pose 29, 0x01fd, 0x410a, 0x6c00
+ax_pose -1, 0x01de, 0x40f8, 0x6c00
+ax_pose 33, 0x01ec, 0x90f4, 0x6c04
+ax_pose -1, 0x01f9, 0x4115, 0x6c00
+ax_pose_terminator
+sTorkoalPose87:
+ax_pose 33, 0x01ec, 0x90f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose88:
+ax_pose 9, 0x01ed, 0x90eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose89:
+ax_pose 34, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose90:
+ax_pose 22, 0x01ea, 0x40f7, 0x6c00
+ax_pose 35, 0x01ea, 0x90f0, 0x6c04
+ax_pose -1, 0x01eb, 0x4108, 0x6c00
+ax_pose -1, 0x01e7, 0x4102, 0x6c00
+ax_pose_terminator
+sTorkoalPose91:
+ax_pose 22, 0x01e9, 0x40f7, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 35, 0x01ea, 0x90f0, 0x6c05
+ax_pose -1, 0x01eb, 0x4109, 0x6c00
+ax_pose -1, 0x01e8, 0x4102, 0x6c00
+ax_pose_terminator
+sTorkoalPose92:
+ax_pose 25, 0x01e5, 0x40f7, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 35, 0x01ea, 0x90f0, 0x6c05
+ax_pose -1, 0x01ec, 0x410a, 0x6c00
+ax_pose -1, 0x01e8, 0x4102, 0x6c00
+ax_pose_terminator
+sTorkoalPose93:
+ax_pose 26, 0x01e2, 0x40f7, 0x6c00
+ax_pose 24, 0x01ee, 0x00fc, 0x6c04
+ax_pose 35, 0x01ea, 0x90f0, 0x6c05
+ax_pose -1, 0x01ec, 0x410b, 0x6c00
+ax_pose -1, 0x01e7, 0x4104, 0x6c00
+ax_pose_terminator
+sTorkoalPose94:
+ax_pose 27, 0x01e2, 0x40f7, 0x6c00
+ax_pose 35, 0x01ea, 0x90f0, 0x6c04
+ax_pose -1, 0x01ed, 0x410d, 0x6c00
+ax_pose -1, 0x01e8, 0x4104, 0x6c00
+ax_pose_terminator
+sTorkoalPose95:
+ax_pose 28, 0x01e1, 0x40f7, 0x6c00
+ax_pose 35, 0x01ea, 0x90f0, 0x6c04
+ax_pose -1, 0x01ef, 0x410f, 0x6c00
+ax_pose -1, 0x01e9, 0x4105, 0x6c00
+ax_pose_terminator
+sTorkoalPose96:
+ax_pose 29, 0x01df, 0x40f7, 0x6c00
+ax_pose 35, 0x01ea, 0x90f0, 0x6c04
+ax_pose -1, 0x01ef, 0x410f, 0x6c00
+ax_pose -1, 0x01ea, 0x4104, 0x6c00
+ax_pose_terminator
+sTorkoalPose97:
+ax_pose 35, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose98:
+ax_pose 12, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose99:
+ax_pose 36, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose100:
+ax_pose 22, 0x01e7, 0x40f8, 0x6c00
+ax_pose 37, 0x01e9, 0x80f1, 0x6c04
+ax_pose -1, 0x01ea, 0x40f4, 0x6c00
+ax_pose -1, 0x01ea, 0x40fc, 0x6c00
+ax_pose_terminator
+sTorkoalPose101:
+ax_pose 22, 0x01e6, 0x40f8, 0x6c00
+ax_pose 24, 0x01eb, 0x00fc, 0x6c04
+ax_pose 37, 0x01e9, 0x80f1, 0x6c05
+ax_pose -1, 0x01eb, 0x40f3, 0x6c00
+ax_pose -1, 0x01eb, 0x40fd, 0x6c00
+ax_pose_terminator
+sTorkoalPose102:
+ax_pose 25, 0x01e2, 0x40f8, 0x6c00
+ax_pose 24, 0x01eb, 0x00fc, 0x6c04
+ax_pose 37, 0x01e9, 0x80f1, 0x6c05
+ax_pose -1, 0x01ec, 0x40f1, 0x6c00
+ax_pose -1, 0x01ec, 0x40ff, 0x6c00
+ax_pose_terminator
+sTorkoalPose103:
+ax_pose 26, 0x01df, 0x40f8, 0x6c00
+ax_pose 24, 0x01eb, 0x00fc, 0x6c04
+ax_pose 37, 0x01e9, 0x80f1, 0x6c05
+ax_pose -1, 0x01ec, 0x40ef, 0x6c00
+ax_pose -1, 0x01ec, 0x4101, 0x6c00
+ax_pose_terminator
+sTorkoalPose104:
+ax_pose 27, 0x01df, 0x40f8, 0x6c00
+ax_pose 37, 0x01e9, 0x80f1, 0x6c04
+ax_pose -1, 0x01ec, 0x40ed, 0x6c00
+ax_pose -1, 0x01ec, 0x4103, 0x6c00
+ax_pose_terminator
+sTorkoalPose105:
+ax_pose 28, 0x01de, 0x40f8, 0x6c00
+ax_pose 37, 0x01e9, 0x80f1, 0x6c04
+ax_pose -1, 0x01ec, 0x40eb, 0x6c00
+ax_pose -1, 0x01ec, 0x4105, 0x6c00
+ax_pose_terminator
+sTorkoalPose106:
+ax_pose 29, 0x01dc, 0x40f8, 0x6c00
+ax_pose 37, 0x01e9, 0x80f1, 0x6c04
+ax_pose -1, 0x01ec, 0x40e9, 0x6c00
+ax_pose -1, 0x01ec, 0x4107, 0x6c00
+ax_pose_terminator
+sTorkoalPose107:
+ax_pose 37, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose108:
+ax_pose 9, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sTorkoalPose109:
+ax_pose 34, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose110:
+ax_pose 22, 0x01ea, 0x50f9, 0x6c00
+ax_pose 35, 0x01ea, 0x80f0, 0x6c04
+ax_pose -1, 0x01eb, 0x50e8, 0x6c00
+ax_pose -1, 0x01e7, 0x50ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose111:
+ax_pose 22, 0x01e9, 0x50f9, 0x6c00
+ax_pose 24, 0x01ee, 0x10fc, 0x6c04
+ax_pose 35, 0x01ea, 0x80f0, 0x6c05
+ax_pose -1, 0x01eb, 0x50e7, 0x6c00
+ax_pose -1, 0x01e8, 0x50ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose112:
+ax_pose 25, 0x01e5, 0x50f9, 0x6c00
+ax_pose 24, 0x01ee, 0x10fc, 0x6c04
+ax_pose 35, 0x01ea, 0x80f0, 0x6c05
+ax_pose -1, 0x01ec, 0x50e6, 0x6c00
+ax_pose -1, 0x01e8, 0x50ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose113:
+ax_pose 26, 0x01e2, 0x50f9, 0x6c00
+ax_pose 24, 0x01ee, 0x10fc, 0x6c04
+ax_pose 35, 0x01ea, 0x80f0, 0x6c05
+ax_pose -1, 0x01ec, 0x50e5, 0x6c00
+ax_pose -1, 0x01e7, 0x50ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose114:
+ax_pose 27, 0x01e2, 0x50f9, 0x6c00
+ax_pose 35, 0x01ea, 0x80f0, 0x6c04
+ax_pose -1, 0x01ed, 0x50e3, 0x6c00
+ax_pose -1, 0x01e8, 0x50ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose115:
+ax_pose 28, 0x01e1, 0x50f9, 0x6c00
+ax_pose 35, 0x01ea, 0x80f0, 0x6c04
+ax_pose -1, 0x01ef, 0x50e1, 0x6c00
+ax_pose -1, 0x01e9, 0x50eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose116:
+ax_pose 29, 0x01df, 0x50f9, 0x6c00
+ax_pose 35, 0x01ea, 0x80f0, 0x6c04
+ax_pose -1, 0x01ef, 0x50e1, 0x6c00
+ax_pose -1, 0x01ea, 0x50ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose117:
+ax_pose 35, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose118:
+ax_pose 6, 0x01ef, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose119:
+ax_pose 32, 0x01ec, 0x80ed, 0x6c00
+ax_pose_terminator
+sTorkoalPose120:
+ax_pose 33, 0x01ec, 0x80ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose121:
+ax_pose 22, 0x01f7, 0x50e9, 0x6c00
+ax_pose -1, 0x01e9, 0x50f8, 0x6c00
+ax_pose 24, 0x01ee, 0x10fc, 0x6c04
+ax_pose 33, 0x01ec, 0x80ec, 0x6c05
+ax_pose -1, 0x01f5, 0x50e7, 0x6c00
+ax_pose_terminator
+sTorkoalPose122:
+ax_pose 22, 0x01f8, 0x50e8, 0x6c00
+ax_pose -1, 0x01e6, 0x50f8, 0x6c00
+ax_pose 24, 0x01ee, 0x10fc, 0x6c04
+ax_pose 33, 0x01ec, 0x80ec, 0x6c05
+ax_pose -1, 0x01f6, 0x50e6, 0x6c00
+ax_pose_terminator
+sTorkoalPose123:
+ax_pose 25, 0x01fa, 0x50e7, 0x6c00
+ax_pose -1, 0x01e4, 0x50f8, 0x6c00
+ax_pose 24, 0x01ee, 0x10fc, 0x6c04
+ax_pose 33, 0x01ec, 0x80ec, 0x6c05
+ax_pose -1, 0x01f6, 0x50e4, 0x6c00
+ax_pose_terminator
+sTorkoalPose124:
+ax_pose 26, 0x01fb, 0x50e8, 0x6c00
+ax_pose -1, 0x01e2, 0x50f8, 0x6c00
+ax_pose 24, 0x01ee, 0x10fc, 0x6c04
+ax_pose 33, 0x01ec, 0x80ec, 0x6c05
+ax_pose -1, 0x01f6, 0x50e3, 0x6c00
+ax_pose_terminator
+sTorkoalPose125:
+ax_pose 27, 0x01fc, 0x50e7, 0x6c00
+ax_pose -1, 0x01e1, 0x50f8, 0x6c00
+ax_pose 33, 0x01ec, 0x80ec, 0x6c04
+ax_pose -1, 0x01f7, 0x50df, 0x6c00
+ax_pose_terminator
+sTorkoalPose126:
+ax_pose 28, 0x01fd, 0x50e8, 0x6c00
+ax_pose -1, 0x01e0, 0x50f8, 0x6c00
+ax_pose 33, 0x01ec, 0x80ec, 0x6c04
+ax_pose -1, 0x01f8, 0x50dd, 0x6c00
+ax_pose_terminator
+sTorkoalPose127:
+ax_pose 29, 0x01fd, 0x50e6, 0x6c00
+ax_pose -1, 0x01de, 0x50f8, 0x6c00
+ax_pose 33, 0x01ec, 0x80ec, 0x6c04
+ax_pose -1, 0x01f9, 0x50db, 0x6c00
+ax_pose_terminator
+sTorkoalPose128:
+ax_pose 33, 0x01ec, 0x80ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose129:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose130:
+ax_pose 30, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose131:
+ax_pose 22, 0x01f9, 0x50ef, 0x6c00
+ax_pose -1, 0x01f6, 0x50e7, 0x6c00
+ax_pose -1, 0x01e9, 0x50f8, 0x6c00
+ax_pose 31, 0x01ec, 0x80ef, 0x6c04
+ax_pose_terminator
+sTorkoalPose132:
+ax_pose 22, 0x01fa, 0x50ef, 0x6c00
+ax_pose -1, 0x01f7, 0x50e7, 0x6c00
+ax_pose -1, 0x01e6, 0x50f8, 0x6c00
+ax_pose 24, 0x01ed, 0x10fc, 0x6c04
+ax_pose 31, 0x01ec, 0x80ef, 0x6c05
+ax_pose_terminator
+sTorkoalPose133:
+ax_pose 25, 0x01fc, 0x50f0, 0x6c00
+ax_pose -1, 0x01f7, 0x50e6, 0x6c00
+ax_pose -1, 0x01e3, 0x50f8, 0x6c00
+ax_pose 24, 0x01ed, 0x10fc, 0x6c04
+ax_pose 31, 0x01ec, 0x80ef, 0x6c05
+ax_pose_terminator
+sTorkoalPose134:
+ax_pose 26, 0x01fd, 0x50f1, 0x6c00
+ax_pose -1, 0x01f7, 0x50e4, 0x6c00
+ax_pose -1, 0x01e1, 0x50f8, 0x6c00
+ax_pose 24, 0x01ed, 0x10fc, 0x6c04
+ax_pose 31, 0x01ec, 0x80ef, 0x6c05
+ax_pose_terminator
+sTorkoalPose135:
+ax_pose 27, 0x01fe, 0x50f2, 0x6c00
+ax_pose -1, 0x01f8, 0x50e2, 0x6c00
+ax_pose -1, 0x01e1, 0x50f8, 0x6c00
+ax_pose 31, 0x01ec, 0x80ef, 0x6c04
+ax_pose_terminator
+sTorkoalPose136:
+ax_pose 28, 0x01ff, 0x50f4, 0x6c00
+ax_pose -1, 0x01f9, 0x50e0, 0x6c00
+ax_pose -1, 0x01e0, 0x50f8, 0x6c00
+ax_pose 31, 0x01ec, 0x80ef, 0x6c04
+ax_pose_terminator
+sTorkoalPose137:
+ax_pose 29, 0x01ff, 0x50f5, 0x6c00
+ax_pose -1, 0x01fa, 0x50de, 0x6c00
+ax_pose -1, 0x01de, 0x50f8, 0x6c00
+ax_pose 31, 0x01ec, 0x80ef, 0x6c04
+ax_pose_terminator
+sTorkoalPose138:
+ax_pose 31, 0x01ec, 0x80ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose139:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose140:
+ax_pose 3, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose141:
+ax_pose 6, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose142:
+ax_pose 9, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose143:
+ax_pose 12, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose144:
+ax_pose 9, 0x01ed, 0x90eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose145:
+ax_pose 6, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose146:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose147:
+ax_pose 15, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose148:
+ax_pose 16, 0x0200, 0x00fa, 0x6c00
+ax_pose 17, 0x41f0, 0x80f2, 0x6c01
+ax_pose_terminator
+sTorkoalPose149:
+ax_pose 18, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose150:
+ax_pose 19, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose151:
+ax_pose 20, 0x01ec, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose152:
+ax_pose 19, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose153:
+ax_pose 18, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose154:
+ax_pose 16, 0x0200, 0x10fd, 0x6c00
+ax_pose 17, 0x41f0, 0x90ed, 0x6c01
+ax_pose_terminator
+sTorkoalPose155:
+ax_pose 38, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose156:
+ax_pose 39, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose157:
+ax_pose 40, 0x01e5, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose158:
+ax_pose 41, 0x01e8, 0x90ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose159:
+ax_pose 42, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sTorkoalPose160:
+ax_pose 43, 0x01e9, 0x90ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose161:
+ax_pose 44, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose162:
+ax_pose 43, 0x01e9, 0x80f2, 0x6c00
+ax_pose_terminator
+sTorkoalPose163:
+ax_pose 42, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose164:
+ax_pose 41, 0x01e8, 0x80f2, 0x6c00
+ax_pose_terminator
+sTorkoalPose165:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose166:
+ax_pose 21, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose167:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose168:
+ax_pose 30, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose169:
+ax_pose 6, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose170:
+ax_pose 32, 0x01ec, 0x90f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose171:
+ax_pose 9, 0x01ed, 0x90eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose172:
+ax_pose 34, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose173:
+ax_pose 12, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose174:
+ax_pose 36, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose175:
+ax_pose 9, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sTorkoalPose176:
+ax_pose 34, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose177:
+ax_pose 6, 0x01ef, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose178:
+ax_pose 32, 0x01ec, 0x80ed, 0x6c00
+ax_pose_terminator
+sTorkoalPose179:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose180:
+ax_pose 30, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose181:
+ax_pose 15, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose182:
+ax_pose 16, 0x0200, 0x00fa, 0x6c00
+ax_pose 17, 0x41f0, 0x80f2, 0x6c01
+ax_pose_terminator
+sTorkoalPose183:
+ax_pose 18, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose184:
+ax_pose 19, 0x41f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose185:
+ax_pose 20, 0x01ec, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose186:
+ax_pose 19, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose187:
+ax_pose 18, 0x41f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose188:
+ax_pose 16, 0x0200, 0x10fd, 0x6c00
+ax_pose 17, 0x41f0, 0x90ed, 0x6c01
+ax_pose_terminator
+sTorkoalPose189:
+ax_pose 23, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose190:
+ax_pose 31, 0x01ec, 0x90f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose191:
+ax_pose 33, 0x01eb, 0x90f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose192:
+ax_pose 35, 0x01e9, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose193:
+ax_pose 37, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose194:
+ax_pose 35, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose195:
+ax_pose 33, 0x01eb, 0x80eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose196:
+ax_pose 31, 0x01ec, 0x80ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose197:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose198:
+ax_pose 21, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose199:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+sTorkoalPose200:
+ax_pose 30, 0x01ec, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose201:
+ax_pose 6, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose202:
+ax_pose 32, 0x01ec, 0x90f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose203:
+ax_pose 9, 0x01ed, 0x90eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose204:
+ax_pose 34, 0x01ea, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose205:
+ax_pose 12, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose206:
+ax_pose 36, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose207:
+ax_pose 9, 0x01ed, 0x80f5, 0x6c00
+ax_pose_terminator
+sTorkoalPose208:
+ax_pose 34, 0x01ea, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose209:
+ax_pose 6, 0x01ef, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose210:
+ax_pose 32, 0x01ec, 0x80ed, 0x6c00
+ax_pose_terminator
+sTorkoalPose211:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose212:
+ax_pose 30, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose213:
+ax_pose 23, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose214:
+ax_pose 31, 0x01ec, 0x90f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose215:
+ax_pose 33, 0x01eb, 0x90f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose216:
+ax_pose 35, 0x01e9, 0x90f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose217:
+ax_pose 37, 0x01e9, 0x80f1, 0x6c00
+ax_pose_terminator
+sTorkoalPose218:
+ax_pose 35, 0x01e9, 0x80ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose219:
+ax_pose 33, 0x01eb, 0x80eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose220:
+ax_pose 31, 0x01ec, 0x80ee, 0x6c00
+ax_pose_terminator
+sTorkoalPose221:
+ax_pose 0, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose222:
+ax_pose 3, 0x01ef, 0x80f3, 0x6c00
+ax_pose_terminator
+sTorkoalPose223:
+ax_pose 6, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sTorkoalPose224:
+ax_pose 9, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose225:
+ax_pose 12, 0x01ed, 0x80f4, 0x6c00
+ax_pose_terminator
+sTorkoalPose226:
+ax_pose 9, 0x01ed, 0x90eb, 0x6c00
+ax_pose_terminator
+sTorkoalPose227:
+ax_pose 6, 0x01ef, 0x90ef, 0x6c00
+ax_pose_terminator
+sTorkoalPose228:
+ax_pose 3, 0x01ef, 0x90ec, 0x6c00
+ax_pose_terminator
+.align 2
+sTorkoalAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, 0,
+ax_anim 2, 0, 25, 0, -3, 0, 0,
+ax_anim 2, 0, 34, 0, -2, 0, 0,
+ax_anim 1, 0, 35, 0, -2, 0, 0,
+ax_anim 1, 0, 36, 0, -2, 0, 0,
+ax_anim 1, 2, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 8, 0, 8,
+ax_anim 2, 0, 39, 0, 20, 0, 20,
+ax_anim 2, 1, 32, 0, 20, 0, 20,
+ax_anim 2, 0, 33, 0, 20, 0, 20,
+ax_anim 2, 0, 34, 0, 20, 0, 20,
+ax_anim 1, 0, 35, 0, 10, 0, 10,
+ax_anim 1, 0, 36, 0, 4, 0, 4,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_2_2:
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 2, 0, 32, 0, -3, 0, 0,
+ax_anim 2, 0, 33, 0, -2, 0, 0,
+ax_anim 1, 0, 34, 0, -2, 0, 0,
+ax_anim 1, 0, 35, 0, -2, 0, 0,
+ax_anim 1, 2, 36, 2, 2, 2, 2,
+ax_anim 1, 0, 37, 8, 8, 8, 8,
+ax_anim 2, 0, 38, 20, 20, 20, 20,
+ax_anim 2, 1, 39, 20, 20, 20, 20,
+ax_anim 2, 0, 32, 20, 20, 20, 20,
+ax_anim 2, 0, 33, 20, 20, 20, 20,
+ax_anim 1, 0, 34, 10, 10, 10, 10,
+ax_anim 1, 0, 35, 4, 4, 4, 4,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_2_3:
+ax_anim 2, 0, 30, 0, -1, 0, 0,
+ax_anim 2, 0, 31, 0, -3, 0, 0,
+ax_anim 2, 0, 32, 0, -2, 0, 0,
+ax_anim 1, 0, 33, 0, -2, 0, 0,
+ax_anim 1, 0, 34, 0, -2, 0, 0,
+ax_anim 1, 2, 35, 2, 0, 2, 0,
+ax_anim 1, 0, 36, 8, 0, 8, 0,
+ax_anim 2, 0, 37, 20, 0, 20, 0,
+ax_anim 2, 1, 38, 20, 0, 20, 0,
+ax_anim 2, 0, 39, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 1, 0, 33, 10, 0, 10, 0,
+ax_anim 1, 0, 34, 4, 0, 4, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 3, 0, 3,
+ax_anim_terminator
+sTorkoalAnims_2_4:
+ax_anim 2, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 0, 30, 0, -3, 0, 0,
+ax_anim 2, 0, 39, 0, -2, 0, 0,
+ax_anim 1, 0, 32, 0, -2, 0, 0,
+ax_anim 1, 0, 33, 0, -2, 0, 0,
+ax_anim 1, 2, 34, 2, -2, 2, -2,
+ax_anim 1, 0, 35, 8, -8, 8, -8,
+ax_anim 2, 0, 36, 20, -20, 20, -20,
+ax_anim 2, 1, 37, 20, -20, 20, -20,
+ax_anim 2, 0, 38, 20, -20, 20, -20,
+ax_anim 2, 0, 39, 20, -20, 20, -20,
+ax_anim 1, 0, 32, 10, -10, 10, -10,
+ax_anim 1, 0, 33, 4, -4, 4, -4,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_2_5:
+ax_anim 2, 0, 28, 0, -1, 0, -1,
+ax_anim 2, 0, 29, 0, -3, 0, -3,
+ax_anim 2, 0, 38, 0, -2, 0, -2,
+ax_anim 1, 0, 39, 0, -2, 0, -2,
+ax_anim 1, 0, 32, 0, -2, 0, -2,
+ax_anim 1, 2, 33, 0, -2, 0, -2,
+ax_anim 1, 0, 34, 0, -8, 0, -8,
+ax_anim 2, 0, 35, 0, -20, 0, -20,
+ax_anim 2, 1, 36, 0, -20, 0, -20,
+ax_anim 2, 0, 37, 0, -20, 0, -20,
+ax_anim 2, 0, 38, 0, -20, 0, -20,
+ax_anim 1, 0, 39, 0, -10, 0, -10,
+ax_anim 1, 0, 32, 0, -4, 0, -4,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 3, 0, 3,
+ax_anim_terminator
+sTorkoalAnims_2_6:
+ax_anim 2, 0, 27, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 0, -3, 0, 0,
+ax_anim 2, 0, 37, 0, -2, 0, 0,
+ax_anim 1, 0, 38, 0, -2, 0, 0,
+ax_anim 1, 0, 39, 0, -2, 0, 0,
+ax_anim 1, 2, 32, -2, -2, -2, -2,
+ax_anim 1, 0, 33, -8, -8, -8, -8,
+ax_anim 2, 0, 34, -20, -20, -20, -20,
+ax_anim 2, 1, 35, -20, -20, -20, -20,
+ax_anim 2, 0, 36, -20, -20, -20, -20,
+ax_anim 2, 0, 37, -20, -20, -20, -20,
+ax_anim 1, 0, 38, -10, -10, -10, -10,
+ax_anim 1, 0, 39, -4, -4, -4, -4,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_2_7:
+ax_anim 2, 0, 26, 0, -1, 0, 0,
+ax_anim 2, 0, 27, 0, -3, 0, 0,
+ax_anim 2, 0, 36, 0, -2, 0, 0,
+ax_anim 1, 0, 37, 0, -2, 0, 0,
+ax_anim 1, 0, 38, 0, -2, 0, 0,
+ax_anim 1, 2, 39, -2, 0, -2, 0,
+ax_anim 1, 0, 32, -8, 0, -8, 0,
+ax_anim 2, 0, 33, -20, 0, -20, 0,
+ax_anim 2, 1, 34, -20, 0, -20, 0,
+ax_anim 2, 0, 35, -20, 0, -20, 0,
+ax_anim 2, 0, 36, -20, 0, -20, 0,
+ax_anim 1, 0, 37, -10, 0, -10, 0,
+ax_anim 1, 0, 38, -4, 0, -4, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 3, 0, 3,
+ax_anim_terminator
+sTorkoalAnims_2_8:
+ax_anim 2, 0, 25, 0, -1, 0, 0,
+ax_anim 2, 0, 26, 0, -3, 0, 0,
+ax_anim 2, 0, 35, 0, -2, 0, 0,
+ax_anim 1, 0, 36, 0, -2, 0, 0,
+ax_anim 1, 0, 37, 0, -2, 0, 0,
+ax_anim 1, 2, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 39, -8, 8, -8, 8,
+ax_anim 2, 0, 32, -20, 20, -20, 20,
+ax_anim 2, 1, 33, -20, 20, -20, 20,
+ax_anim 2, 0, 34, -20, 20, -20, 20,
+ax_anim 2, 0, 35, -20, 20, -20, 20,
+ax_anim 1, 0, 36, -10, 10, -10, 10,
+ax_anim 1, 0, 37, -4, 4, -4, 4,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_3_1:
+ax_anim 2, 0, 40, 0, -1, 0, 0,
+ax_anim 2, 0, 41, 0, -3, 0, 0,
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 1, 0, 51, 0, -2, 0, 0,
+ax_anim 1, 0, 52, 0, -2, 0, 0,
+ax_anim 1, 2, 53, 0, 2, 0, 2,
+ax_anim 1, 0, 54, 0, 8, 0, 8,
+ax_anim 2, 0, 55, 0, 20, 0, 20,
+ax_anim 2, 1, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 49, 0, 20, 0, 20,
+ax_anim 2, 0, 50, 0, 20, 0, 20,
+ax_anim 1, 0, 51, 0, 10, 0, 10,
+ax_anim 1, 0, 52, 0, 4, 0, 4,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_3_2:
+ax_anim 2, 0, 47, 0, -1, 0, 0,
+ax_anim 2, 0, 48, 0, -3, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, 0,
+ax_anim 1, 0, 50, 0, -2, 0, 0,
+ax_anim 1, 0, 51, 0, -2, 0, 0,
+ax_anim 1, 2, 52, 2, 2, 2, 2,
+ax_anim 1, 0, 53, 8, 8, 8, 8,
+ax_anim 2, 0, 54, 20, 20, 20, 20,
+ax_anim 2, 1, 55, 20, 20, 20, 20,
+ax_anim 2, 0, 48, 20, 20, 20, 20,
+ax_anim 2, 0, 49, 20, 20, 20, 20,
+ax_anim 1, 0, 50, 10, 10, 10, 10,
+ax_anim 1, 0, 51, 4, 4, 4, 4,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_3_3:
+ax_anim 2, 0, 46, 0, -1, 0, 0,
+ax_anim 2, 0, 47, 0, -3, 0, 0,
+ax_anim 2, 0, 48, 0, -2, 0, 0,
+ax_anim 1, 0, 49, 0, -2, 0, 0,
+ax_anim 1, 0, 50, 0, -2, 0, 0,
+ax_anim 1, 2, 51, 2, 0, 2, 0,
+ax_anim 1, 0, 52, 8, 0, 8, 0,
+ax_anim 2, 0, 53, 20, 0, 20, 0,
+ax_anim 2, 1, 54, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 48, 20, 0, 20, 0,
+ax_anim 1, 0, 49, 10, 0, 10, 0,
+ax_anim 1, 0, 50, 4, 0, 4, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, 0, 3, 0, 3,
+ax_anim_terminator
+sTorkoalAnims_3_4:
+ax_anim 2, 0, 45, 0, -1, 0, 0,
+ax_anim 2, 0, 46, 0, -3, 0, 0,
+ax_anim 2, 0, 55, 0, -2, 0, 0,
+ax_anim 1, 0, 48, 0, -2, 0, 0,
+ax_anim 1, 0, 49, 0, -2, 0, 0,
+ax_anim 1, 2, 50, 2, -2, 2, -2,
+ax_anim 1, 0, 51, 8, -8, 8, -8,
+ax_anim 2, 0, 52, 20, -20, 20, -20,
+ax_anim 2, 1, 53, 20, -20, 20, -20,
+ax_anim 2, 0, 54, 20, -20, 20, -20,
+ax_anim 2, 0, 55, 20, -20, 20, -20,
+ax_anim 1, 0, 48, 10, -10, 10, -10,
+ax_anim 1, 0, 49, 4, -4, 4, -4,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_3_5:
+ax_anim 2, 0, 44, 0, -1, 0, 0,
+ax_anim 2, 0, 45, 0, -3, 0, 0,
+ax_anim 2, 0, 54, 0, -2, 0, 0,
+ax_anim 1, 0, 55, 0, -2, 0, 0,
+ax_anim 1, 0, 48, 0, -2, 0, 0,
+ax_anim 1, 2, 49, 0, -2, 2, -2,
+ax_anim 1, 0, 50, 0, -8, 8, -8,
+ax_anim 2, 0, 51, 0, -20, 0, -20,
+ax_anim 2, 1, 52, 0, -20, 0, -20,
+ax_anim 2, 0, 53, 0, -20, 0, -20,
+ax_anim 2, 0, 54, 0, -20, 0, -20,
+ax_anim 1, 0, 55, 0, -10, 0, -10,
+ax_anim 1, 0, 48, 0, -4, 0, -4,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_3_6:
+ax_anim 2, 0, 43, 0, -1, 0, 0,
+ax_anim 2, 0, 44, 0, -3, 0, 0,
+ax_anim 2, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 0, 54, 0, -2, 0, 0,
+ax_anim 1, 0, 55, 0, -2, 0, 0,
+ax_anim 1, 2, 48, -2, -2, -2, -2,
+ax_anim 1, 0, 49, -8, -8, -8, -8,
+ax_anim 2, 0, 50, -20, -20, -20, -20,
+ax_anim 2, 1, 51, -20, -20, -20, -20,
+ax_anim 2, 0, 52, -20, -20, -20, -20,
+ax_anim 2, 0, 53, -20, -20, -20, -20,
+ax_anim 1, 0, 54, -10, -10, -10, -10,
+ax_anim 1, 0, 55, -4, -4, -4, -4,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_3_7:
+ax_anim 2, 0, 42, 0, -1, 0, 0,
+ax_anim 2, 0, 43, 0, -3, 0, 0,
+ax_anim 2, 0, 52, 0, -2, 0, 0,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 0, 54, 0, -2, 0, 0,
+ax_anim 1, 2, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 48, -8, 0, -8, 0,
+ax_anim 2, 0, 49, -20, 0, -20, 0,
+ax_anim 2, 1, 50, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 52, -20, 0, -20, 0,
+ax_anim 1, 0, 53, -10, 0, -10, 0,
+ax_anim 1, 0, 54, -4, 0, -4, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, 3, 0, 3,
+ax_anim_terminator
+sTorkoalAnims_3_8:
+ax_anim 2, 0, 41, 0, -1, 0, 0,
+ax_anim 2, 0, 42, 0, -3, 0, 0,
+ax_anim 2, 0, 51, 0, -2, 0, 0,
+ax_anim 1, 0, 52, 0, -2, 0, 0,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 2, 54, -2, 2, -2, 2,
+ax_anim 1, 0, 55, -8, 8, -8, 8,
+ax_anim 2, 0, 48, -20, 20, -20, 20,
+ax_anim 2, 1, 49, -20, 20, -20, 20,
+ax_anim 2, 0, 50, -20, 20, -20, 20,
+ax_anim 2, 0, 51, -20, 20, -20, 20,
+ax_anim 1, 0, 52, -10, 10, -10, 10,
+ax_anim 1, 0, 53, -4, 4, -4, 4,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_4_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 6, 2, 57, 0, -3, 0, -3,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 2, 1, 58, 0, 3, 0, 3,
+ax_anim 2, 0, 59, 1, 3, 1, 3,
+ax_anim 2, 0, 60, 0, 3, 0, 3,
+ax_anim 2, 0, 61, 1, 3, 1, 3,
+ax_anim 2, 0, 62, 0, 3, 0, 3,
+ax_anim 2, 0, 63, 1, 3, 1, 3,
+ax_anim 2, 0, 64, 0, 3, 0, 3,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 2, 0, 56, 0, 1, 0, 1,
+ax_anim_terminator
+sTorkoalAnims_4_2:
+ax_anim 2, 0, 67, -2, -2, -2, -2,
+ax_anim 6, 2, 67, -3, -3, -3, -3,
+ax_anim 2, 0, 66, -1, -1, -1, -1,
+ax_anim 2, 1, 68, 2, 2, 2, 2,
+ax_anim 2, 0, 69, 3, 1, 3, 1,
+ax_anim 2, 0, 70, 2, 2, 2, 2,
+ax_anim 2, 0, 71, 3, 1, 3, 1,
+ax_anim 2, 0, 72, 2, 2, 2, 2,
+ax_anim 2, 0, 73, 3, 1, 3, 1,
+ax_anim 2, 0, 74, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 2, 2, 2, 2,
+ax_anim 2, 0, 66, 1, 1, 1, 1,
+ax_anim_terminator
+sTorkoalAnims_4_3:
+ax_anim 2, 0, 77, -2, 0, -2, 0,
+ax_anim 6, 2, 77, -3, 0, -3, 0,
+ax_anim 2, 0, 76, -1, 0, -1, 0,
+ax_anim 2, 1, 78, 3, 0, 3, 0,
+ax_anim 2, 0, 79, 3, 1, 3, 1,
+ax_anim 2, 0, 80, 3, 0, 3, 0,
+ax_anim 2, 0, 81, 3, 1, 3, 1,
+ax_anim 2, 0, 82, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 3, 1, 3, 1,
+ax_anim 2, 0, 84, 3, 0, 3, 0,
+ax_anim 2, 0, 85, 3, 0, 3, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim_terminator
+sTorkoalAnims_4_4:
+ax_anim 2, 0, 88, -2, 2, -2, 2,
+ax_anim 6, 2, 88, -3, 3, -3, 3,
+ax_anim 2, 0, 87, -1, 1, -1, 1,
+ax_anim 2, 1, 89, 2, -2, 2, -2,
+ax_anim 2, 0, 90, 3, -1, 3, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 92, 3, -1, 3, -1,
+ax_anim 2, 0, 93, 2, -2, 2, -2,
+ax_anim 2, 0, 94, 3, -1, 3, -1,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim 2, 0, 96, 2, -2, 2, -2,
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim_terminator
+sTorkoalAnims_4_5:
+ax_anim 2, 0, 98, 0, 2, 0, 2,
+ax_anim 6, 2, 98, 0, 3, 0, 3,
+ax_anim 2, 0, 97, 0, 1, 0, 1,
+ax_anim 2, 1, 99, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 1, -3, 1, -3,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 103, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 1, -3, 1, -3,
+ax_anim 2, 0, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 0, -3, 0, -3,
+ax_anim 2, 0, 97, 0, -1, 0, -1,
+ax_anim_terminator
+sTorkoalAnims_4_6:
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim 6, 2, 108, 3, 3, 3, 3,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 1, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 110, -3, -1, -3, -1,
+ax_anim 2, 0, 111, -2, -2, -2, -2,
+ax_anim 2, 0, 112, -3, -1, -3, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 114, -3, -1, -3, -1,
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim_terminator
+sTorkoalAnims_4_7:
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 6, 2, 118, 3, 0, 3, 0,
+ax_anim 2, 0, 117, 1, 0, 1, 0,
+ax_anim 2, 1, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 120, -3, 1, -3, 1,
+ax_anim 2, 0, 121, -3, 0, -3, 0,
+ax_anim 2, 0, 122, -3, 1, -3, 1,
+ax_anim 2, 0, 123, -3, 0, -3, 0,
+ax_anim 2, 0, 124, -3, 1, -3, 1,
+ax_anim 2, 0, 125, -3, 0, -3, 0,
+ax_anim 2, 0, 126, -3, 0, -3, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim_terminator
+sTorkoalAnims_4_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 6, 2, 129, 3, -3, 3, -3,
+ax_anim 2, 0, 128, 1, -1, 1, -1,
+ax_anim 2, 1, 130, -2, 2, -2, 2,
+ax_anim 2, 0, 131, -3, 1, -3, 1,
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim 2, 0, 133, -3, 1, -3, 1,
+ax_anim 2, 0, 134, -2, 2, -2, 2,
+ax_anim 2, 0, 135, -3, 1, -3, 1,
+ax_anim 2, 0, 136, -2, 2, -2, 2,
+ax_anim 2, 0, 137, -2, 2, -2, 2,
+ax_anim 2, 0, 128, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_5_1:
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 1, 0, 0,
+ax_anim 2, 0, 151, 0, 1, 0, 0,
+ax_anim 1, 0, 152, 0, 2, 0, 0,
+ax_anim 1, 0, 153, 0, 3, 0, 0,
+ax_anim 1, 0, 146, 0, 3, 0, 0,
+ax_anim 1, 0, 147, 0, 3, 0, 0,
+ax_anim 1, 0, 148, 0, 3, 0, 0,
+ax_anim 1, 2, 149, 0, 3, 0, 0,
+ax_anim 2, 0, 150, 0, 3, 0, 0,
+ax_anim 2, 0, 151, 0, 3, 0, 0,
+ax_anim 2, 0, 152, 0, 3, 0, 0,
+ax_anim 3, 0, 153, 0, 3, 0, 0,
+ax_anim 3, 0, 146, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_5_2:
+ax_anim 3, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 1, 0, 0,
+ax_anim 2, 0, 150, 0, 1, 0, 0,
+ax_anim 1, 0, 151, 0, 2, 0, 0,
+ax_anim 1, 0, 152, 0, 3, 0, 0,
+ax_anim 1, 0, 153, 0, 3, 0, 0,
+ax_anim 1, 0, 146, 0, 3, 0, 0,
+ax_anim 1, 0, 147, 0, 3, 0, 0,
+ax_anim 1, 2, 148, 0, 3, 0, 0,
+ax_anim 2, 0, 149, 0, 3, 0, 0,
+ax_anim 2, 0, 150, 0, 3, 0, 0,
+ax_anim 2, 0, 151, 0, 3, 0, 0,
+ax_anim 3, 0, 152, 0, 3, 0, 0,
+ax_anim 3, 0, 153, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_5_3:
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 1, 0, 0,
+ax_anim 2, 0, 149, 0, 1, 0, 0,
+ax_anim 1, 0, 150, 0, 2, 0, 0,
+ax_anim 1, 0, 151, 0, 3, 0, 0,
+ax_anim 1, 0, 152, 0, 3, 0, 0,
+ax_anim 1, 0, 153, 0, 3, 0, 0,
+ax_anim 1, 0, 146, 0, 3, 0, 0,
+ax_anim 1, 2, 147, 0, 3, 0, 0,
+ax_anim 2, 0, 148, 0, 3, 0, 0,
+ax_anim 2, 0, 149, 0, 3, 0, 0,
+ax_anim 2, 0, 150, 0, 3, 0, 0,
+ax_anim 3, 0, 151, 0, 3, 0, 0,
+ax_anim 3, 0, 152, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_5_4:
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim 3, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 1, 0, 0,
+ax_anim 2, 0, 148, 0, 1, 0, 0,
+ax_anim 1, 0, 149, 0, 2, 0, 0,
+ax_anim 1, 0, 150, 0, 3, 0, 0,
+ax_anim 1, 0, 151, 0, 3, 0, 0,
+ax_anim 1, 0, 152, 0, 3, 0, 0,
+ax_anim 1, 0, 153, 0, 3, 0, 0,
+ax_anim 1, 2, 146, 0, 3, 0, 0,
+ax_anim 2, 0, 147, 0, 3, 0, 0,
+ax_anim 2, 0, 148, 0, 3, 0, 0,
+ax_anim 2, 0, 149, 0, 3, 0, 0,
+ax_anim 3, 0, 150, 0, 3, 0, 0,
+ax_anim 3, 0, 151, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_5_5:
+ax_anim 3, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 1, 0, 0,
+ax_anim 2, 0, 147, 0, 1, 0, 0,
+ax_anim 1, 0, 148, 0, 2, 0, 0,
+ax_anim 1, 0, 149, 0, 3, 0, 0,
+ax_anim 1, 0, 150, 0, 3, 0, 0,
+ax_anim 1, 0, 151, 0, 3, 0, 0,
+ax_anim 1, 0, 152, 0, 3, 0, 0,
+ax_anim 1, 2, 153, 0, 3, 0, 0,
+ax_anim 2, 0, 146, 0, 3, 0, 0,
+ax_anim 2, 0, 147, 0, 3, 0, 0,
+ax_anim 2, 0, 148, 0, 3, 0, 0,
+ax_anim 3, 0, 149, 0, 3, 0, 0,
+ax_anim 3, 0, 150, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_5_6:
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 1, 0, 0,
+ax_anim 2, 0, 146, 0, 1, 0, 0,
+ax_anim 1, 0, 147, 0, 2, 0, 0,
+ax_anim 1, 0, 148, 0, 3, 0, 0,
+ax_anim 1, 0, 149, 0, 3, 0, 0,
+ax_anim 1, 0, 150, 0, 3, 0, 0,
+ax_anim 1, 0, 151, 0, 3, 0, 0,
+ax_anim 1, 2, 152, 0, 3, 0, 0,
+ax_anim 2, 0, 153, 0, 3, 0, 0,
+ax_anim 2, 0, 146, 0, 3, 0, 0,
+ax_anim 2, 0, 147, 0, 3, 0, 0,
+ax_anim 3, 0, 148, 0, 3, 0, 0,
+ax_anim 3, 0, 149, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_5_7:
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 1, 0, 0,
+ax_anim 2, 0, 153, 0, 1, 0, 0,
+ax_anim 1, 0, 146, 0, 2, 0, 0,
+ax_anim 1, 0, 147, 0, 3, 0, 0,
+ax_anim 1, 0, 148, 0, 3, 0, 0,
+ax_anim 1, 0, 149, 0, 3, 0, 0,
+ax_anim 1, 0, 150, 0, 3, 0, 0,
+ax_anim 1, 2, 151, 0, 3, 0, 0,
+ax_anim 2, 0, 152, 0, 3, 0, 0,
+ax_anim 2, 0, 153, 0, 3, 0, 0,
+ax_anim 2, 0, 146, 0, 3, 0, 0,
+ax_anim 3, 0, 147, 0, 3, 0, 0,
+ax_anim 3, 0, 148, 0, 3, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_5_8:
+ax_anim 3, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 1, 0, 0,
+ax_anim 2, 0, 152, 0, 1, 0, 0,
+ax_anim 1, 0, 153, 0, 2, 0, 0,
+ax_anim 1, 0, 146, 0, 3, 0, 0,
+ax_anim 1, 0, 147, 0, 3, 0, 0,
+ax_anim 1, 0, 148, 0, 3, 0, 0,
+ax_anim 1, 0, 149, 0, 3, 0, 0,
+ax_anim 1, 2, 150, 0, 3, 0, 0,
+ax_anim 2, 0, 151, 0, 3, 0, 0,
+ax_anim 2, 0, 152, 0, 3, 0, 0,
+ax_anim 2, 0, 153, 0, 3, 0, 0,
+ax_anim 3, 0, 146, 0, 3, 0, 0,
+ax_anim 3, 0, 147, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_6_1:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 35, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_7_1:
+ax_anim 2, 0, 156, 0, -2, 0, -2,
+ax_anim 8, 0, 156, 0, -3, 0, -3,
+ax_anim_terminator
+sTorkoalAnims_7_2:
+ax_anim 2, 0, 157, -2, -2, -2, -2,
+ax_anim 8, 0, 157, -3, -3, -3, -3,
+ax_anim_terminator
+sTorkoalAnims_7_3:
+ax_anim 2, 0, 158, -2, 0, -2, 0,
+ax_anim 8, 0, 158, -3, 0, -3, 0,
+ax_anim_terminator
+sTorkoalAnims_7_4:
+ax_anim 2, 0, 159, -2, 2, -2, 2,
+ax_anim 8, 0, 159, -3, 3, -3, 3,
+ax_anim_terminator
+sTorkoalAnims_7_5:
+ax_anim 2, 0, 160, 0, 2, 0, 2,
+ax_anim 8, 0, 160, 0, 3, 0, 3,
+ax_anim_terminator
+sTorkoalAnims_7_6:
+ax_anim 2, 0, 161, 2, 2, 2, 2,
+ax_anim 8, 0, 161, 3, 3, 3, 3,
+ax_anim_terminator
+sTorkoalAnims_7_7:
+ax_anim 2, 0, 162, 2, 0, 2, 0,
+ax_anim 8, 0, 162, 3, 0, 3, 0,
+ax_anim_terminator
+sTorkoalAnims_7_8:
+ax_anim 2, 0, 163, 2, -2, 2, -2,
+ax_anim 8, 0, 163, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_8_1:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 20, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim 20, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_8_2:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 20, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_8_3:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 20, 0, 168, 0, 0, 0, 0,
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_8_4:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 20, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 170, 0, 0, 0, 0,
+ax_anim 20, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_8_5:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 20, 0, 173, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 0, 0, 0, 0,
+ax_anim 20, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_8_6:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim 20, 0, 174, 0, 0, 0, 0,
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_8_7:
+ax_anim 40, 0, 176, 0, 0, 0, 0,
+ax_anim 20, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 176, 0, 0, 0, 0,
+ax_anim 20, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_8_8:
+ax_anim 40, 0, 178, 0, 0, 0, 0,
+ax_anim 20, 0, 179, 0, 0, 0, 0,
+ax_anim 20, 0, 178, 0, 0, 0, 0,
+ax_anim 20, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_9_1:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 6, 4, 6, 4,
+ax_anim 2, 0, 182, 10, 11, 10, 11,
+ax_anim 2, 0, 183, 8, 18, 8, 18,
+ax_anim 3, 0, 184, 0, 21, 0, 21,
+ax_anim 2, 3, 185, -8, 18, -8, 18,
+ax_anim 2, 0, 186, -10, 11, -10, 11,
+ax_anim 1, 0, 187, -6, 4, -6, 4,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_9_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 8, 1, 8, 1,
+ax_anim 2, 0, 181, 18, 7, 18, 7,
+ax_anim 2, 0, 182, 24, 17, 24, 17,
+ax_anim 3, 0, 183, 21, 23, 21, 23,
+ax_anim 2, 3, 184, 13, 23, 13, 23,
+ax_anim 2, 0, 185, 5, 16, 5, 16,
+ax_anim 1, 0, 186, -1, 7, -1, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_9_3:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 3, -3, 3, -3,
+ax_anim 2, 0, 180, 10, -4, 10, -4,
+ax_anim 2, 0, 181, 16, -2, 16, -2,
+ax_anim 3, 0, 182, 20, 2, 20, 2,
+ax_anim 2, 3, 183, 16, 8, 16, 8,
+ax_anim 2, 0, 184, 10, 9, 10, 9,
+ax_anim 1, 0, 185, 3, 6, 3, 6,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_9_4:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -1, -8, -1, -8,
+ax_anim 2, 0, 187, 4, -17, 4, -17,
+ax_anim 2, 0, 180, 12, -22, 12, -22,
+ax_anim 3, 0, 181, 21, -21, 21, -21,
+ax_anim 2, 3, 182, 25, -13, 25, -13,
+ax_anim 2, 0, 183, 19, -5, 19, -5,
+ax_anim 1, 0, 184, 9, -1, 9, -1,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_9_5:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, -7, -4, -7, -4,
+ax_anim 2, 0, 186, -10, -12, -10, -12,
+ax_anim 2, 0, 187, -8, -19, -8, -19,
+ax_anim 3, 0, 180, 0, -22, 0, -22,
+ax_anim 2, 3, 181, 8, -19, 8, -19,
+ax_anim 2, 0, 182, 10, -12, 10, -12,
+ax_anim 1, 0, 183, 7, -4, 7, -4,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_9_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 1, -8, 1, -8,
+ax_anim 2, 0, 181, -4, -17, -4, -17,
+ax_anim 2, 0, 180, -12, -22, -12, -22,
+ax_anim 3, 0, 187, -21, -21, -21, -21,
+ax_anim 2, 3, 186, -25, -13, -25, -13,
+ax_anim 2, 0, 185, -19, -5, -19, -5,
+ax_anim 1, 0, 184, -9, -1, -9, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_9_7:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 181, -3, -3, -3, -3,
+ax_anim 2, 0, 180, -10, -4, -10, -4,
+ax_anim 2, 0, 187, -16, -2, -16, -2,
+ax_anim 3, 0, 186, -20, 2, -20, 2,
+ax_anim 2, 3, 185, -16, 8, -16, 8,
+ax_anim 2, 0, 184, -10, 9, -10, 9,
+ax_anim 1, 0, 183, -3, 6, -3, 6,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_9_8:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -8, 1, -8, 1,
+ax_anim 2, 0, 187, -18, 7, -18, 7,
+ax_anim 2, 0, 186, -24, 17, -24, 17,
+ax_anim 3, 0, 185, -21, 23, -21, 23,
+ax_anim 2, 3, 184, -13, 23, -13, 23,
+ax_anim 2, 0, 183, -5, 16, -5, 16,
+ax_anim 1, 0, 182, 1, 7, 1, 7,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_10_1:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 6, 0, 6, 0,
+ax_anim 2, 0, 188, -6, 0, -6, 0,
+ax_anim 2, 0, 188, 10, 0, 10, 0,
+ax_anim 2, 0, 188, -10, 0, -10, 0,
+ax_anim 2, 0, 188, 12, 0, 12, 0,
+ax_anim 3, 0, 188, -12, 0, -12, 0,
+ax_anim 3, 0, 188, 13, 0, 13, 0,
+ax_anim 3, 0, 188, -13, 0, -13, 0,
+ax_anim 2, 0, 188, 12, 0, 12, 0,
+ax_anim 3, 0, 188, -12, 0, -12, 0,
+ax_anim 2, 0, 188, 10, 0, 10, 0,
+ax_anim 2, 0, 188, -10, 0, -10, 0,
+ax_anim 2, 0, 188, 6, 0, 6, 0,
+ax_anim 2, 0, 188, -6, 0, -6, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_10_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 6, -6, 6, -6,
+ax_anim 2, 0, 189, -6, 6, -6, 6,
+ax_anim 2, 0, 189, 10, -10, 10, -10,
+ax_anim 2, 0, 189, -10, 10, -10, 10,
+ax_anim 2, 0, 189, 12, -12, 12, -12,
+ax_anim 3, 0, 189, -12, 12, -12, 12,
+ax_anim 3, 0, 189, 13, -13, 13, -13,
+ax_anim 3, 0, 189, -13, 13, -13, 13,
+ax_anim 2, 0, 189, 12, -12, 12, -12,
+ax_anim 3, 0, 189, -12, 12, -12, 12,
+ax_anim 2, 0, 189, 10, -10, 10, -10,
+ax_anim 2, 0, 189, -10, 10, -10, 10,
+ax_anim 2, 0, 189, 6, -6, 6, -6,
+ax_anim 2, 0, 189, -6, 6, -6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_10_3:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, -6, 0, -6,
+ax_anim 2, 0, 190, 0, 6, 0, 6,
+ax_anim 2, 0, 190, 0, -10, 0, -10,
+ax_anim 2, 0, 190, 0, 10, 0, 10,
+ax_anim 2, 0, 190, 0, -12, 0, -12,
+ax_anim 3, 0, 190, 0, 12, 0, 12,
+ax_anim 3, 0, 190, 0, -13, 0, -13,
+ax_anim 3, 0, 190, 0, 13, 0, 13,
+ax_anim 2, 0, 190, 0, -12, 0, -12,
+ax_anim 3, 0, 190, 0, 12, 0, 12,
+ax_anim 2, 0, 190, 0, -10, 0, -10,
+ax_anim 2, 0, 190, 0, 10, 0, 10,
+ax_anim 2, 0, 190, 0, -6, 0, -6,
+ax_anim 2, 0, 190, 0, 6, 0, 6,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_10_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -6, -6, -6, -6,
+ax_anim 2, 0, 191, 6, 6, 6, 6,
+ax_anim 2, 0, 191, -10, -10, -10, -10,
+ax_anim 2, 0, 191, 10, 10, 10, 10,
+ax_anim 2, 0, 191, -12, -12, -12, -12,
+ax_anim 3, 0, 191, 12, 12, 12, 12,
+ax_anim 3, 0, 191, -13, -13, -13, -13,
+ax_anim 3, 0, 191, 13, 13, 13, 13,
+ax_anim 2, 0, 191, -12, -12, -12, -12,
+ax_anim 3, 0, 191, 12, 12, 12, 12,
+ax_anim 2, 0, 191, -10, -10, -10, -10,
+ax_anim 2, 0, 191, 10, 10, 10, 10,
+ax_anim 2, 0, 191, -6, -6, -6, -6,
+ax_anim 2, 0, 191, 6, 6, 6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_10_5:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 6, 0, 6, 0,
+ax_anim 2, 0, 192, -6, 0, -6, 0,
+ax_anim 2, 0, 192, 10, 0, 10, 0,
+ax_anim 2, 0, 192, -10, 0, -10, 0,
+ax_anim 2, 0, 192, 12, 0, 12, 0,
+ax_anim 3, 0, 192, -12, 0, -12, 0,
+ax_anim 3, 0, 192, 13, 0, 13, 0,
+ax_anim 3, 0, 192, -13, 0, -13, 0,
+ax_anim 2, 0, 192, 12, 0, 12, 0,
+ax_anim 3, 0, 192, -12, 0, -12, 0,
+ax_anim 2, 0, 192, 10, 0, 10, 0,
+ax_anim 2, 0, 192, -10, 0, -10, 0,
+ax_anim 2, 0, 192, 6, 0, 6, 0,
+ax_anim 2, 0, 192, -6, 0, -6, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_10_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 6, -6, 6, -6,
+ax_anim 2, 0, 193, -6, 6, -6, 6,
+ax_anim 2, 0, 193, 10, -10, 10, -10,
+ax_anim 2, 0, 193, -10, 10, -10, 10,
+ax_anim 2, 0, 193, 12, -12, 12, -12,
+ax_anim 3, 0, 193, -12, 12, -12, 12,
+ax_anim 3, 0, 193, 13, -13, 13, -13,
+ax_anim 3, 0, 193, -13, 13, -13, 13,
+ax_anim 2, 0, 193, 12, -12, 12, -12,
+ax_anim 3, 0, 193, -12, 12, -12, 12,
+ax_anim 2, 0, 193, 10, -10, 10, -10,
+ax_anim 2, 0, 193, -10, 10, -10, 10,
+ax_anim 2, 0, 193, 6, -6, 6, -6,
+ax_anim 2, 0, 193, -6, 6, -6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_10_7:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, -6, 0, -6,
+ax_anim 2, 0, 194, 0, 6, 0, 6,
+ax_anim 2, 0, 194, 0, -10, 0, -10,
+ax_anim 2, 0, 194, 0, 10, 0, 10,
+ax_anim 2, 0, 194, 0, -12, 0, -12,
+ax_anim 3, 0, 194, 0, 12, 0, 12,
+ax_anim 3, 0, 194, 0, -13, 0, -13,
+ax_anim 3, 0, 194, 0, 13, 0, 13,
+ax_anim 2, 0, 194, 0, -12, 0, -12,
+ax_anim 3, 0, 194, 0, 12, 0, 12,
+ax_anim 2, 0, 194, 0, -10, 0, -10,
+ax_anim 2, 0, 194, 0, 10, 0, 10,
+ax_anim 2, 0, 194, 0, -6, 0, -6,
+ax_anim 2, 0, 194, 0, 6, 0, 6,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_10_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -6, -6, -6, -6,
+ax_anim 2, 0, 195, 6, 6, 6, 6,
+ax_anim 2, 0, 195, -10, -10, -10, -10,
+ax_anim 2, 0, 195, 10, 10, 10, 10,
+ax_anim 2, 0, 195, -12, -12, -12, -12,
+ax_anim 3, 0, 195, 12, 12, 12, 12,
+ax_anim 3, 0, 195, -13, -13, -13, -13,
+ax_anim 3, 0, 195, 13, 13, 13, 13,
+ax_anim 2, 0, 195, -12, -12, -12, -12,
+ax_anim 3, 0, 195, 12, 12, 12, 12,
+ax_anim 2, 0, 195, -10, -10, -10, -10,
+ax_anim 2, 0, 195, 10, 10, 10, 10,
+ax_anim 2, 0, 195, -6, -6, -6, -6,
+ax_anim 2, 0, 195, 6, 6, 6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_11_1:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_11_2:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -22, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -17, 0, 0,
+ax_anim 1, 0, 198, 0, -11, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -17, 0, 0,
+ax_anim 1, 0, 200, 0, -11, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_11_4:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_11_5:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 204, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_11_6:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -22, 0, 0,
+ax_anim 3, 0, 206, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -17, 0, 0,
+ax_anim 1, 0, 206, 0, -11, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_11_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 208, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -17, 0, 0,
+ax_anim 1, 0, 208, 0, -11, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_11_8:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 211, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 3, 0, 210, 0, -21, 0, 0,
+ax_anim 2, 0, 210, 0, -17, 0, 0,
+ax_anim 1, 0, 210, 0, -11, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_12_1:
+ax_anim 2, 0, 212, 1, 0, 1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 1, 0, 1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 1, 0, 1, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 1, 0, 1, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 1, 0, 1, 0,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_12_2:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_12_3:
+ax_anim 2, 0, 214, 0, -1, 0, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, -1, 0, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, -1, 0, -1,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, -1, 0, -1,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, -1, 0, -1,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_12_5:
+ax_anim 2, 0, 216, 1, 0, 1, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 1, 0, 1, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 1, 0, 1, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 1, 0, 1, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 1, 0, 1, 0,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_12_6:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_12_7:
+ax_anim 2, 0, 218, 0, -1, 0, -1,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, -1, 0, -1,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, -1, 0, -1,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, -1, 0, -1,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, -1, 0, -1,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTorkoalAnims_13_1:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_13_2:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_13_3:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_13_4:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_13_5:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_13_6:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_13_7:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalAnims_13_8:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sTorkoalGfx1:
+.incbin "baserom.gba", 0x133A190, 0x200
+sTorkoalSprites1:
+ax_sprite sTorkoalGfx1, 0x200
+ax_sprite_terminator
+sTorkoalGfx2:
+.incbin "baserom.gba", 0x133A3A0, 0x200
+sTorkoalSprites2:
+ax_sprite sTorkoalGfx2, 0x200
+ax_sprite_terminator
+sTorkoalGfx3:
+.incbin "baserom.gba", 0x133A5B0, 0x200
+sTorkoalSprites3:
+ax_sprite sTorkoalGfx3, 0x200
+ax_sprite_terminator
+sTorkoalGfx4:
+.incbin "baserom.gba", 0x133A7C0, 0x200
+sTorkoalSprites4:
+ax_sprite sTorkoalGfx4, 0x200
+ax_sprite_terminator
+sTorkoalGfx5:
+.incbin "baserom.gba", 0x133A9D0, 0x200
+sTorkoalSprites5:
+ax_sprite sTorkoalGfx5, 0x200
+ax_sprite_terminator
+sTorkoalGfx6:
+.incbin "baserom.gba", 0x133ABE0, 0x200
+sTorkoalSprites6:
+ax_sprite sTorkoalGfx6, 0x200
+ax_sprite_terminator
+sTorkoalGfx7:
+.incbin "baserom.gba", 0x133ADF0, 0x200
+sTorkoalSprites7:
+ax_sprite sTorkoalGfx7, 0x200
+ax_sprite_terminator
+sTorkoalGfx8:
+.incbin "baserom.gba", 0x133B000, 0x200
+sTorkoalSprites8:
+ax_sprite sTorkoalGfx8, 0x200
+ax_sprite_terminator
+sTorkoalGfx9:
+.incbin "baserom.gba", 0x133B210, 0x200
+sTorkoalSprites9:
+ax_sprite sTorkoalGfx9, 0x200
+ax_sprite_terminator
+sTorkoalGfx10:
+.incbin "baserom.gba", 0x133B420, 0x200
+sTorkoalSprites10:
+ax_sprite sTorkoalGfx10, 0x200
+ax_sprite_terminator
+sTorkoalGfx11:
+.incbin "baserom.gba", 0x133B630, 0x200
+sTorkoalSprites11:
+ax_sprite sTorkoalGfx11, 0x200
+ax_sprite_terminator
+sTorkoalGfx12:
+.incbin "baserom.gba", 0x133B840, 0x200
+sTorkoalSprites12:
+ax_sprite sTorkoalGfx12, 0x200
+ax_sprite_terminator
+sTorkoalGfx13:
+.incbin "baserom.gba", 0x133BA50, 0x200
+sTorkoalSprites13:
+ax_sprite sTorkoalGfx13, 0x200
+ax_sprite_terminator
+sTorkoalGfx14:
+.incbin "baserom.gba", 0x133BC60, 0x200
+sTorkoalSprites14:
+ax_sprite sTorkoalGfx14, 0x200
+ax_sprite_terminator
+sTorkoalGfx15:
+.incbin "baserom.gba", 0x133BE70, 0x200
+sTorkoalSprites15:
+ax_sprite sTorkoalGfx15, 0x200
+ax_sprite_terminator
+sTorkoalGfx16:
+.incbin "baserom.gba", 0x133C080, 0x60
+sTorkoalGfx16_1:
+.incbin "baserom.gba", 0x133C0E0, 0x60
+sTorkoalGfx16_2:
+.incbin "baserom.gba", 0x133C140, 0x60
+sTorkoalSprites16:
+ax_sprite sTorkoalGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTorkoalGfx17:
+.incbin "baserom.gba", 0x133C1D8, 0x20
+sTorkoalSprites17:
+ax_sprite sTorkoalGfx17, 0x20
+ax_sprite_terminator
+sTorkoalGfx18:
+.incbin "baserom.gba", 0x133C208, 0x60
+sTorkoalGfx18_1:
+.incbin "baserom.gba", 0x133C268, 0x60
+sTorkoalSprites18:
+ax_sprite sTorkoalGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx19:
+.incbin "baserom.gba", 0x133C2F0, 0x60
+sTorkoalGfx19_1:
+.incbin "baserom.gba", 0x133C350, 0x60
+sTorkoalSprites19:
+ax_sprite sTorkoalGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx20:
+.incbin "baserom.gba", 0x133C3D8, 0x60
+sTorkoalGfx20_1:
+.incbin "baserom.gba", 0x133C438, 0x60
+sTorkoalSprites20:
+ax_sprite sTorkoalGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx21:
+.incbin "baserom.gba", 0x133C4C0, 0x60
+sTorkoalGfx21_1:
+.incbin "baserom.gba", 0x133C520, 0x60
+sTorkoalGfx21_2:
+.incbin "baserom.gba", 0x133C580, 0x60
+sTorkoalSprites21:
+ax_sprite sTorkoalGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTorkoalGfx22:
+.incbin "baserom.gba", 0x133C618, 0x40
+sTorkoalGfx22_1:
+.incbin "baserom.gba", 0x133C658, 0x100
+sTorkoalSprites22:
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx22_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTorkoalGfx23:
+.incbin "baserom.gba", 0x133C788, 0x80
+sTorkoalSprites23:
+ax_sprite sTorkoalGfx23, 0x80
+ax_sprite_terminator
+sTorkoalGfx24:
+.incbin "baserom.gba", 0x133C818, 0x40
+sTorkoalGfx24_1:
+.incbin "baserom.gba", 0x133C858, 0x100
+sTorkoalGfx24_2:
+.incbin "baserom.gba", 0x133C958, 0x40
+sTorkoalSprites24:
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx24_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx25:
+.incbin "baserom.gba", 0x133C9D8, 0x20
+sTorkoalSprites25:
+ax_sprite sTorkoalGfx25, 0x20
+ax_sprite_terminator
+sTorkoalGfx26:
+.incbin "baserom.gba", 0x133CA08, 0x80
+sTorkoalSprites26:
+ax_sprite sTorkoalGfx26, 0x80
+ax_sprite_terminator
+sTorkoalGfx27:
+.incbin "baserom.gba", 0x133CA98, 0x80
+sTorkoalSprites27:
+ax_sprite sTorkoalGfx27, 0x80
+ax_sprite_terminator
+sTorkoalGfx28:
+.incbin "baserom.gba", 0x133CB28, 0x80
+sTorkoalSprites28:
+ax_sprite sTorkoalGfx28, 0x80
+ax_sprite_terminator
+sTorkoalGfx29:
+.incbin "baserom.gba", 0x133CBB8, 0x80
+sTorkoalSprites29:
+ax_sprite sTorkoalGfx29, 0x80
+ax_sprite_terminator
+sTorkoalGfx30:
+.incbin "baserom.gba", 0x133CC48, 0x80
+sTorkoalSprites30:
+ax_sprite sTorkoalGfx30, 0x80
+ax_sprite_terminator
+sTorkoalGfx31:
+.incbin "baserom.gba", 0x133CCD8, 0x60
+sTorkoalGfx31_1:
+.incbin "baserom.gba", 0x133CD38, 0x100
+sTorkoalSprites31:
+ax_sprite sTorkoalGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx31_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTorkoalGfx32:
+.incbin "baserom.gba", 0x133CE60, 0x40
+sTorkoalGfx32_1:
+.incbin "baserom.gba", 0x133CEA0, 0x120
+sTorkoalGfx32_2:
+.incbin "baserom.gba", 0x133CFC0, 0x20
+sTorkoalSprites32:
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx32_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx32_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx33:
+.incbin "baserom.gba", 0x133D020, 0x100
+sTorkoalGfx33_1:
+.incbin "baserom.gba", 0x133D120, 0x60
+sTorkoalSprites33:
+ax_sprite sTorkoalGfx33, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx33_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTorkoalGfx34:
+.incbin "baserom.gba", 0x133D1A8, 0x20
+sTorkoalGfx34_1:
+.incbin "baserom.gba", 0x133D1C8, 0x100
+sTorkoalGfx34_2:
+.incbin "baserom.gba", 0x133D2C8, 0x40
+sTorkoalSprites34:
+ax_sprite 0, 0x40
+ax_sprite sTorkoalGfx34, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx34_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx35:
+.incbin "baserom.gba", 0x133D348, 0x40
+sTorkoalGfx35_1:
+.incbin "baserom.gba", 0x133D388, 0x100
+sTorkoalGfx35_2:
+.incbin "baserom.gba", 0x133D488, 0x60
+sTorkoalSprites35:
+ax_sprite sTorkoalGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTorkoalGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx35_2, 0x60
+ax_sprite_terminator
+sTorkoalGfx36:
+.incbin "baserom.gba", 0x133D518, 0x40
+sTorkoalGfx36_1:
+.incbin "baserom.gba", 0x133D558, 0x100
+sTorkoalGfx36_2:
+.incbin "baserom.gba", 0x133D658, 0x40
+sTorkoalSprites36:
+ax_sprite sTorkoalGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTorkoalGfx36_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx37:
+.incbin "baserom.gba", 0x133D6D0, 0x40
+sTorkoalGfx37_1:
+.incbin "baserom.gba", 0x133D710, 0x60
+sTorkoalGfx37_2:
+.incbin "baserom.gba", 0x133D770, 0xE0
+sTorkoalSprites37:
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx37_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx38:
+.incbin "baserom.gba", 0x133D890, 0x40
+sTorkoalGfx38_1:
+.incbin "baserom.gba", 0x133D8D0, 0x160
+sTorkoalSprites38:
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx38, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTorkoalGfx38_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTorkoalGfx39:
+.incbin "baserom.gba", 0x133DA60, 0x200
+sTorkoalSprites39:
+ax_sprite sTorkoalGfx39, 0x200
+ax_sprite_terminator
+sTorkoalGfx40:
+.incbin "baserom.gba", 0x133DC70, 0x200
+sTorkoalSprites40:
+ax_sprite sTorkoalGfx40, 0x200
+ax_sprite_terminator
+sTorkoalGfx41:
+.incbin "baserom.gba", 0x133DE80, 0x200
+sTorkoalSprites41:
+ax_sprite sTorkoalGfx41, 0x200
+ax_sprite_terminator
+sTorkoalGfx42:
+.incbin "baserom.gba", 0x133E090, 0x200
+sTorkoalSprites42:
+ax_sprite sTorkoalGfx42, 0x200
+ax_sprite_terminator
+sTorkoalGfx43:
+.incbin "baserom.gba", 0x133E2A0, 0x200
+sTorkoalSprites43:
+ax_sprite sTorkoalGfx43, 0x200
+ax_sprite_terminator
+sTorkoalGfx44:
+.incbin "baserom.gba", 0x133E4B0, 0x200
+sTorkoalSprites44:
+ax_sprite sTorkoalGfx44, 0x200
+ax_sprite_terminator
+sTorkoalGfx45:
+.incbin "baserom.gba", 0x133E6C0, 0x200
+sTorkoalSprites45:
+ax_sprite sTorkoalGfx45, 0x200
+ax_sprite_terminator
+sAxPosesTorkoal:
+.4byte sTorkoalPose1
+.4byte sTorkoalPose2
+.4byte sTorkoalPose3
+.4byte sTorkoalPose4
+.4byte sTorkoalPose5
+.4byte sTorkoalPose6
+.4byte sTorkoalPose7
+.4byte sTorkoalPose8
+.4byte sTorkoalPose9
+.4byte sTorkoalPose10
+.4byte sTorkoalPose11
+.4byte sTorkoalPose12
+.4byte sTorkoalPose13
+.4byte sTorkoalPose14
+.4byte sTorkoalPose15
+.4byte sTorkoalPose16
+.4byte sTorkoalPose17
+.4byte sTorkoalPose18
+.4byte sTorkoalPose19
+.4byte sTorkoalPose20
+.4byte sTorkoalPose21
+.4byte sTorkoalPose22
+.4byte sTorkoalPose23
+.4byte sTorkoalPose24
+.4byte sTorkoalPose25
+.4byte sTorkoalPose26
+.4byte sTorkoalPose27
+.4byte sTorkoalPose28
+.4byte sTorkoalPose29
+.4byte sTorkoalPose30
+.4byte sTorkoalPose31
+.4byte sTorkoalPose32
+.4byte sTorkoalPose33
+.4byte sTorkoalPose34
+.4byte sTorkoalPose35
+.4byte sTorkoalPose36
+.4byte sTorkoalPose37
+.4byte sTorkoalPose38
+.4byte sTorkoalPose39
+.4byte sTorkoalPose40
+.4byte sTorkoalPose41
+.4byte sTorkoalPose42
+.4byte sTorkoalPose43
+.4byte sTorkoalPose44
+.4byte sTorkoalPose45
+.4byte sTorkoalPose46
+.4byte sTorkoalPose47
+.4byte sTorkoalPose48
+.4byte sTorkoalPose49
+.4byte sTorkoalPose50
+.4byte sTorkoalPose51
+.4byte sTorkoalPose52
+.4byte sTorkoalPose53
+.4byte sTorkoalPose54
+.4byte sTorkoalPose55
+.4byte sTorkoalPose56
+.4byte sTorkoalPose57
+.4byte sTorkoalPose58
+.4byte sTorkoalPose59
+.4byte sTorkoalPose60
+.4byte sTorkoalPose61
+.4byte sTorkoalPose62
+.4byte sTorkoalPose63
+.4byte sTorkoalPose64
+.4byte sTorkoalPose65
+.4byte sTorkoalPose66
+.4byte sTorkoalPose67
+.4byte sTorkoalPose68
+.4byte sTorkoalPose69
+.4byte sTorkoalPose70
+.4byte sTorkoalPose71
+.4byte sTorkoalPose72
+.4byte sTorkoalPose73
+.4byte sTorkoalPose74
+.4byte sTorkoalPose75
+.4byte sTorkoalPose76
+.4byte sTorkoalPose77
+.4byte sTorkoalPose78
+.4byte sTorkoalPose79
+.4byte sTorkoalPose80
+.4byte sTorkoalPose81
+.4byte sTorkoalPose82
+.4byte sTorkoalPose83
+.4byte sTorkoalPose84
+.4byte sTorkoalPose85
+.4byte sTorkoalPose86
+.4byte sTorkoalPose87
+.4byte sTorkoalPose88
+.4byte sTorkoalPose89
+.4byte sTorkoalPose90
+.4byte sTorkoalPose91
+.4byte sTorkoalPose92
+.4byte sTorkoalPose93
+.4byte sTorkoalPose94
+.4byte sTorkoalPose95
+.4byte sTorkoalPose96
+.4byte sTorkoalPose97
+.4byte sTorkoalPose98
+.4byte sTorkoalPose99
+.4byte sTorkoalPose100
+.4byte sTorkoalPose101
+.4byte sTorkoalPose102
+.4byte sTorkoalPose103
+.4byte sTorkoalPose104
+.4byte sTorkoalPose105
+.4byte sTorkoalPose106
+.4byte sTorkoalPose107
+.4byte sTorkoalPose108
+.4byte sTorkoalPose109
+.4byte sTorkoalPose110
+.4byte sTorkoalPose111
+.4byte sTorkoalPose112
+.4byte sTorkoalPose113
+.4byte sTorkoalPose114
+.4byte sTorkoalPose115
+.4byte sTorkoalPose116
+.4byte sTorkoalPose117
+.4byte sTorkoalPose118
+.4byte sTorkoalPose119
+.4byte sTorkoalPose120
+.4byte sTorkoalPose121
+.4byte sTorkoalPose122
+.4byte sTorkoalPose123
+.4byte sTorkoalPose124
+.4byte sTorkoalPose125
+.4byte sTorkoalPose126
+.4byte sTorkoalPose127
+.4byte sTorkoalPose128
+.4byte sTorkoalPose129
+.4byte sTorkoalPose130
+.4byte sTorkoalPose131
+.4byte sTorkoalPose132
+.4byte sTorkoalPose133
+.4byte sTorkoalPose134
+.4byte sTorkoalPose135
+.4byte sTorkoalPose136
+.4byte sTorkoalPose137
+.4byte sTorkoalPose138
+.4byte sTorkoalPose139
+.4byte sTorkoalPose140
+.4byte sTorkoalPose141
+.4byte sTorkoalPose142
+.4byte sTorkoalPose143
+.4byte sTorkoalPose144
+.4byte sTorkoalPose145
+.4byte sTorkoalPose146
+.4byte sTorkoalPose147
+.4byte sTorkoalPose148
+.4byte sTorkoalPose149
+.4byte sTorkoalPose150
+.4byte sTorkoalPose151
+.4byte sTorkoalPose152
+.4byte sTorkoalPose153
+.4byte sTorkoalPose154
+.4byte sTorkoalPose155
+.4byte sTorkoalPose156
+.4byte sTorkoalPose157
+.4byte sTorkoalPose158
+.4byte sTorkoalPose159
+.4byte sTorkoalPose160
+.4byte sTorkoalPose161
+.4byte sTorkoalPose162
+.4byte sTorkoalPose163
+.4byte sTorkoalPose164
+.4byte sTorkoalPose165
+.4byte sTorkoalPose166
+.4byte sTorkoalPose167
+.4byte sTorkoalPose168
+.4byte sTorkoalPose169
+.4byte sTorkoalPose170
+.4byte sTorkoalPose171
+.4byte sTorkoalPose172
+.4byte sTorkoalPose173
+.4byte sTorkoalPose174
+.4byte sTorkoalPose175
+.4byte sTorkoalPose176
+.4byte sTorkoalPose177
+.4byte sTorkoalPose178
+.4byte sTorkoalPose179
+.4byte sTorkoalPose180
+.4byte sTorkoalPose181
+.4byte sTorkoalPose182
+.4byte sTorkoalPose183
+.4byte sTorkoalPose184
+.4byte sTorkoalPose185
+.4byte sTorkoalPose186
+.4byte sTorkoalPose187
+.4byte sTorkoalPose188
+.4byte sTorkoalPose189
+.4byte sTorkoalPose190
+.4byte sTorkoalPose191
+.4byte sTorkoalPose192
+.4byte sTorkoalPose193
+.4byte sTorkoalPose194
+.4byte sTorkoalPose195
+.4byte sTorkoalPose196
+.4byte sTorkoalPose197
+.4byte sTorkoalPose198
+.4byte sTorkoalPose199
+.4byte sTorkoalPose200
+.4byte sTorkoalPose201
+.4byte sTorkoalPose202
+.4byte sTorkoalPose203
+.4byte sTorkoalPose204
+.4byte sTorkoalPose205
+.4byte sTorkoalPose206
+.4byte sTorkoalPose207
+.4byte sTorkoalPose208
+.4byte sTorkoalPose209
+.4byte sTorkoalPose210
+.4byte sTorkoalPose211
+.4byte sTorkoalPose212
+.4byte sTorkoalPose213
+.4byte sTorkoalPose214
+.4byte sTorkoalPose215
+.4byte sTorkoalPose216
+.4byte sTorkoalPose217
+.4byte sTorkoalPose218
+.4byte sTorkoalPose219
+.4byte sTorkoalPose220
+.4byte sTorkoalPose221
+.4byte sTorkoalPose222
+.4byte sTorkoalPose223
+.4byte sTorkoalPose224
+.4byte sTorkoalPose225
+.4byte sTorkoalPose226
+.4byte sTorkoalPose227
+.4byte sTorkoalPose228
+sAxPositionsTorkoal:
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte   -2,   -3, 	  -7,    3, 	   5,    0, 	  -1,   -7
+.2byte    0,   -3, 	  -7,    0, 	   5,    3, 	  -1,   -7
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+.2byte    9,   -5, 	   9,    1, 	  -4,    2, 	  -2,   -7
+.2byte    7,   -4, 	   6,   -1, 	   0,    4, 	  -2,   -7
+.2byte   11,   -8, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte   11,   -6, 	   2,   -1, 	   6,    1, 	  -4,   -6
+.2byte   10,   -6, 	   8,   -1, 	   0,    1, 	  -3,   -6
+.2byte    9,  -12, 	   0,   -4, 	   6,   -1, 	  -2,   -7
+.2byte   10,  -10, 	   0,   -4, 	   8,   -2, 	  -2,   -6
+.2byte    8,  -11, 	   0,   -6, 	   5,    0, 	  -2,   -6
+.2byte   -1,  -16, 	   7,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte   -2,  -15, 	   4,   -7, 	  -7,   -4, 	  -1,   -8
+.2byte    0,  -15, 	   7,   -4, 	  -6,   -7, 	  -1,   -8
+.2byte  -11,  -12, 	  -2,   -4, 	  -8,   -1, 	   0,   -7
+.2byte  -12,  -10, 	  -2,   -4, 	 -10,   -2, 	   0,   -6
+.2byte  -10,  -11, 	  -2,   -6, 	  -7,    0, 	   0,   -6
+.2byte  -13,   -8, 	  -8,   -2, 	  -5,    1, 	   1,   -7
+.2byte  -13,   -6, 	  -4,   -1, 	  -8,    1, 	   2,   -6
+.2byte  -12,   -6, 	 -10,   -1, 	  -2,    1, 	   1,   -6
+.2byte  -10,   -6, 	 -10,   -1, 	   0,    2, 	  -1,   -8
+.2byte  -11,   -5, 	 -11,    1, 	   2,    2, 	   0,   -7
+.2byte   -9,   -4, 	  -8,   -1, 	  -2,    4, 	   0,   -7
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte  -10,   -6, 	 -10,   -1, 	   0,    2, 	  -1,   -8
+.2byte  -12,   -8, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte  -10,  -11, 	  -1,   -3, 	  -7,    0, 	   1,   -6
+.2byte   -1,  -15, 	   7,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte    8,  -11, 	  -1,   -3, 	   5,    0, 	  -3,   -6
+.2byte   10,   -8, 	   5,   -2, 	   2,    1, 	  -4,   -7
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+.2byte   -1,    0, 	  -7,   -3, 	   5,   -3, 	  -1,  -10
+.2byte   -8,   -3, 	  -7,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte  -10,   -4, 	  -5,   -7, 	  -4,   -2, 	  -1,  -10
+.2byte   -5,   -9, 	   0,  -10, 	  -5,   -3, 	   0,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    3,   -9, 	  -2,  -10, 	   3,   -3, 	  -2,   -9
+.2byte    8,   -4, 	   3,   -7, 	   2,   -2, 	  -1,  -10
+.2byte    6,   -3, 	   5,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte  -10,   -6, 	 -10,   -1, 	   0,    2, 	  -1,   -8
+.2byte  -12,   -8, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte  -10,  -11, 	  -1,   -3, 	  -7,    0, 	   1,   -6
+.2byte   -1,  -15, 	   7,   -2, 	  -9,   -2, 	  -1,   -8
+.2byte    8,  -11, 	  -1,   -3, 	   5,    0, 	  -3,   -6
+.2byte   10,   -8, 	   5,   -2, 	   2,    1, 	  -4,   -7
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+.2byte   -1,    0, 	  -7,   -3, 	   5,   -3, 	  -1,  -10
+.2byte   -8,   -3, 	  -7,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte  -10,   -4, 	  -5,   -7, 	  -4,   -2, 	  -1,  -10
+.2byte   -5,   -9, 	   0,  -10, 	  -5,   -3, 	   0,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    3,   -9, 	  -2,  -10, 	   3,   -3, 	  -2,   -9
+.2byte    8,   -4, 	   3,   -7, 	   2,   -2, 	  -1,  -10
+.2byte    6,   -3, 	   5,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -8,    1, 	   6,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+.2byte    9,   -8, 	   8,   -1, 	  -2,    2, 	  -2,   -7
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   11,   -8, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte   11,  -10, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte   15,   -2, 	   5,   -3, 	   4,    4, 	  -1,   -6
+.2byte    9,  -12, 	   0,   -4, 	   6,   -1, 	  -2,   -7
+.2byte    9,  -14, 	  -2,   -8, 	   7,   -1, 	  -3,   -7
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   11,  -11, 	  -1,   -7, 	   8,    0, 	  -2,   -8
+.2byte   -1,  -16, 	   7,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte   -1,  -18, 	   8,   -3, 	 -10,   -3, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte  -10,  -12, 	  -1,   -4, 	  -7,   -1, 	   1,   -7
+.2byte  -10,  -14, 	   1,   -8, 	  -8,   -1, 	   2,   -7
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,  -11, 	   0,   -7, 	  -9,    0, 	   1,   -8
+.2byte  -12,   -8, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte  -16,   -2, 	  -6,   -3, 	  -5,    4, 	   0,   -6
+.2byte   -9,   -6, 	  -9,   -1, 	   1,    2, 	   0,   -8
+.2byte  -10,   -8, 	  -9,   -1, 	   1,    2, 	   1,   -7
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte  -12,    2, 	  -7,   -1, 	   2,    3, 	   0,   -6
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte  -10,   -6, 	 -10,   -1, 	   0,    2, 	  -1,   -8
+.2byte  -13,   -8, 	  -8,   -2, 	  -5,    1, 	   1,   -7
+.2byte  -11,  -12, 	  -2,   -4, 	  -8,   -1, 	   0,   -7
+.2byte   -1,  -16, 	   7,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte    9,  -12, 	   0,   -4, 	   6,   -1, 	  -2,   -7
+.2byte   11,   -8, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+.2byte   -1,    0, 	  -7,   -3, 	   5,   -3, 	  -1,  -10
+.2byte   -8,   -3, 	  -7,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte  -10,   -4, 	  -5,   -7, 	  -4,   -2, 	  -1,  -10
+.2byte   -5,   -9, 	   0,  -10, 	  -5,   -3, 	   0,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    3,   -9, 	  -2,  -10, 	   3,   -3, 	  -2,   -9
+.2byte    8,   -4, 	   3,   -7, 	   2,   -2, 	  -1,  -10
+.2byte    6,   -3, 	   5,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte   -9,    2, 	  -8,   -2, 	   1,    2, 	   0,   -8
+.2byte   -9,    1, 	  -8,   -3, 	   1,    2, 	   1,   -8
+.2byte    0,    1, 	  -9,    0, 	   9,    0, 	   0,   -7
+.2byte    7,    1, 	  10,   -4, 	  -4,    2, 	  -1,   -7
+.2byte    9,    0, 	   3,   -2, 	   3,    1, 	  -1,   -6
+.2byte    3,   -5, 	  -4,   -7, 	  11,   -1, 	   0,   -5
+.2byte    0,   -5, 	  10,   -3, 	  -9,   -3, 	   0,   -4
+.2byte   -4,   -5, 	   3,   -7, 	 -12,   -1, 	  -1,   -5
+.2byte  -10,    0, 	  -4,   -2, 	  -4,    1, 	   0,   -6
+.2byte   -8,    1, 	 -11,   -4, 	   3,    2, 	   0,   -7
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -8,    1, 	   6,    1, 	  -1,   -4
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+.2byte    9,   -8, 	   8,   -1, 	  -2,    2, 	  -2,   -7
+.2byte   11,   -8, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte   11,  -10, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte    9,  -12, 	   0,   -4, 	   6,   -1, 	  -2,   -7
+.2byte    9,  -14, 	  -2,   -8, 	   7,   -1, 	  -3,   -7
+.2byte   -1,  -16, 	   7,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte   -1,  -18, 	   8,   -3, 	 -10,   -3, 	  -1,   -9
+.2byte  -10,  -12, 	  -1,   -4, 	  -7,   -1, 	   1,   -7
+.2byte  -10,  -14, 	   1,   -8, 	  -8,   -1, 	   2,   -7
+.2byte  -12,   -8, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte   -9,   -6, 	  -9,   -1, 	   1,    2, 	   0,   -8
+.2byte  -10,   -8, 	  -9,   -1, 	   1,    2, 	   1,   -7
+.2byte   -1,    0, 	  -7,   -3, 	   5,   -3, 	  -1,  -10
+.2byte   -8,   -3, 	  -7,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte  -10,   -4, 	  -5,   -7, 	  -4,   -2, 	  -1,  -10
+.2byte   -5,   -9, 	   0,  -10, 	  -5,   -3, 	   0,   -9
+.2byte   -1,  -11, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    3,   -9, 	  -2,  -10, 	   3,   -3, 	  -2,   -9
+.2byte    8,   -4, 	   3,   -7, 	   2,   -2, 	  -1,  -10
+.2byte    6,   -3, 	   5,   -6, 	  -1,   -1, 	  -1,   -9
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   15,   -3, 	   5,   -4, 	   4,    3, 	  -1,   -7
+.2byte   11,  -12, 	  -1,   -8, 	   8,   -1, 	  -2,   -9
+.2byte   -1,  -16, 	   8,   -4, 	 -11,   -3, 	  -1,   -8
+.2byte  -13,  -12, 	  -1,   -8, 	 -10,   -1, 	   0,   -9
+.2byte  -17,   -3, 	  -7,   -4, 	  -6,    3, 	  -1,   -7
+.2byte  -13,    2, 	  -8,   -1, 	   1,    3, 	  -1,   -6
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte   -1,   -6, 	  -8,    1, 	   6,    1, 	  -1,   -4
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+.2byte    9,   -8, 	   8,   -1, 	  -2,    2, 	  -2,   -7
+.2byte   11,   -8, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte   11,  -10, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte    9,  -12, 	   0,   -4, 	   6,   -1, 	  -2,   -7
+.2byte    9,  -14, 	  -2,   -8, 	   7,   -1, 	  -3,   -7
+.2byte   -1,  -16, 	   7,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte   -1,  -18, 	   8,   -3, 	 -10,   -3, 	  -1,   -9
+.2byte  -10,  -12, 	  -1,   -4, 	  -7,   -1, 	   1,   -7
+.2byte  -10,  -14, 	   1,   -8, 	  -8,   -1, 	   2,   -7
+.2byte  -12,   -8, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte  -12,  -10, 	  -7,   -2, 	  -4,    1, 	   2,   -7
+.2byte   -9,   -6, 	  -9,   -1, 	   1,    2, 	   0,   -8
+.2byte  -10,   -8, 	  -9,   -1, 	   1,    2, 	   1,   -7
+.2byte   -1,    4, 	 -10,    1, 	   8,    1, 	  -1,   -4
+.2byte   11,    2, 	   6,   -1, 	  -3,    3, 	  -1,   -6
+.2byte   15,   -3, 	   5,   -4, 	   4,    3, 	  -1,   -7
+.2byte   11,  -12, 	  -1,   -8, 	   8,   -1, 	  -2,   -9
+.2byte   -1,  -17, 	   8,   -5, 	 -11,   -4, 	  -1,   -9
+.2byte  -13,  -12, 	  -1,   -8, 	 -10,   -1, 	   0,   -9
+.2byte  -17,   -3, 	  -7,   -4, 	  -6,    3, 	  -1,   -7
+.2byte  -13,    2, 	  -8,   -1, 	   1,    3, 	  -1,   -6
+.2byte   -1,   -4, 	  -8,    1, 	   6,    1, 	  -1,   -7
+.2byte  -10,   -6, 	 -10,   -1, 	   0,    2, 	  -1,   -8
+.2byte  -13,   -8, 	  -8,   -2, 	  -5,    1, 	   1,   -7
+.2byte  -11,  -12, 	  -2,   -4, 	  -8,   -1, 	   0,   -7
+.2byte   -1,  -16, 	   7,   -3, 	  -9,   -3, 	  -1,   -9
+.2byte    9,  -12, 	   0,   -4, 	   6,   -1, 	  -2,   -7
+.2byte   11,   -8, 	   6,   -2, 	   3,    1, 	  -3,   -7
+.2byte    8,   -6, 	   8,   -1, 	  -2,    2, 	  -1,   -8
+sTorkoalAnimTable1:
+.4byte sTorkoalAnims_1_1
+.4byte sTorkoalAnims_1_2
+.4byte sTorkoalAnims_1_3
+.4byte sTorkoalAnims_1_4
+.4byte sTorkoalAnims_1_5
+.4byte sTorkoalAnims_1_6
+.4byte sTorkoalAnims_1_7
+.4byte sTorkoalAnims_1_8
+sTorkoalAnimTable2:
+.4byte sTorkoalAnims_2_1
+.4byte sTorkoalAnims_2_2
+.4byte sTorkoalAnims_2_3
+.4byte sTorkoalAnims_2_4
+.4byte sTorkoalAnims_2_5
+.4byte sTorkoalAnims_2_6
+.4byte sTorkoalAnims_2_7
+.4byte sTorkoalAnims_2_8
+sTorkoalAnimTable3:
+.4byte sTorkoalAnims_3_1
+.4byte sTorkoalAnims_3_2
+.4byte sTorkoalAnims_3_3
+.4byte sTorkoalAnims_3_4
+.4byte sTorkoalAnims_3_5
+.4byte sTorkoalAnims_3_6
+.4byte sTorkoalAnims_3_7
+.4byte sTorkoalAnims_3_8
+sTorkoalAnimTable4:
+.4byte sTorkoalAnims_4_1
+.4byte sTorkoalAnims_4_2
+.4byte sTorkoalAnims_4_3
+.4byte sTorkoalAnims_4_4
+.4byte sTorkoalAnims_4_5
+.4byte sTorkoalAnims_4_6
+.4byte sTorkoalAnims_4_7
+.4byte sTorkoalAnims_4_8
+sTorkoalAnimTable5:
+.4byte sTorkoalAnims_5_1
+.4byte sTorkoalAnims_5_2
+.4byte sTorkoalAnims_5_3
+.4byte sTorkoalAnims_5_4
+.4byte sTorkoalAnims_5_5
+.4byte sTorkoalAnims_5_6
+.4byte sTorkoalAnims_5_7
+.4byte sTorkoalAnims_5_8
+sTorkoalAnimTable6:
+.4byte sTorkoalAnims_6_1
+.4byte sTorkoalAnims_6_1
+.4byte sTorkoalAnims_6_1
+.4byte sTorkoalAnims_6_1
+.4byte sTorkoalAnims_6_1
+.4byte sTorkoalAnims_6_1
+.4byte sTorkoalAnims_6_1
+.4byte sTorkoalAnims_6_1
+sTorkoalAnimTable7:
+.4byte sTorkoalAnims_7_1
+.4byte sTorkoalAnims_7_2
+.4byte sTorkoalAnims_7_3
+.4byte sTorkoalAnims_7_4
+.4byte sTorkoalAnims_7_5
+.4byte sTorkoalAnims_7_6
+.4byte sTorkoalAnims_7_7
+.4byte sTorkoalAnims_7_8
+sTorkoalAnimTable8:
+.4byte sTorkoalAnims_8_1
+.4byte sTorkoalAnims_8_2
+.4byte sTorkoalAnims_8_3
+.4byte sTorkoalAnims_8_4
+.4byte sTorkoalAnims_8_5
+.4byte sTorkoalAnims_8_6
+.4byte sTorkoalAnims_8_7
+.4byte sTorkoalAnims_8_8
+sTorkoalAnimTable9:
+.4byte sTorkoalAnims_9_1
+.4byte sTorkoalAnims_9_2
+.4byte sTorkoalAnims_9_3
+.4byte sTorkoalAnims_9_4
+.4byte sTorkoalAnims_9_5
+.4byte sTorkoalAnims_9_6
+.4byte sTorkoalAnims_9_7
+.4byte sTorkoalAnims_9_8
+sTorkoalAnimTable10:
+.4byte sTorkoalAnims_10_1
+.4byte sTorkoalAnims_10_2
+.4byte sTorkoalAnims_10_3
+.4byte sTorkoalAnims_10_4
+.4byte sTorkoalAnims_10_5
+.4byte sTorkoalAnims_10_6
+.4byte sTorkoalAnims_10_7
+.4byte sTorkoalAnims_10_8
+sTorkoalAnimTable11:
+.4byte sTorkoalAnims_11_1
+.4byte sTorkoalAnims_11_2
+.4byte sTorkoalAnims_11_3
+.4byte sTorkoalAnims_11_4
+.4byte sTorkoalAnims_11_5
+.4byte sTorkoalAnims_11_6
+.4byte sTorkoalAnims_11_7
+.4byte sTorkoalAnims_11_8
+sTorkoalAnimTable12:
+.4byte sTorkoalAnims_12_1
+.4byte sTorkoalAnims_12_2
+.4byte sTorkoalAnims_12_3
+.4byte sTorkoalAnims_12_4
+.4byte sTorkoalAnims_12_5
+.4byte sTorkoalAnims_12_6
+.4byte sTorkoalAnims_12_7
+.4byte sTorkoalAnims_12_8
+sTorkoalAnimTable13:
+.4byte sTorkoalAnims_13_1
+.4byte sTorkoalAnims_13_2
+.4byte sTorkoalAnims_13_3
+.4byte sTorkoalAnims_13_4
+.4byte sTorkoalAnims_13_5
+.4byte sTorkoalAnims_13_6
+.4byte sTorkoalAnims_13_7
+.4byte sTorkoalAnims_13_8
+sAxAnimationsTorkoal:
+.4byte sTorkoalAnimTable1
+.4byte sTorkoalAnimTable2
+.4byte sTorkoalAnimTable3
+.4byte sTorkoalAnimTable4
+.4byte sTorkoalAnimTable5
+.4byte sTorkoalAnimTable6
+.4byte sTorkoalAnimTable7
+.4byte sTorkoalAnimTable8
+.4byte sTorkoalAnimTable9
+.4byte sTorkoalAnimTable10
+.4byte sTorkoalAnimTable11
+.4byte sTorkoalAnimTable12
+.4byte sTorkoalAnimTable13
+sAxSpritesTorkoal:
+.4byte sTorkoalSprites1
+.4byte sTorkoalSprites2
+.4byte sTorkoalSprites3
+.4byte sTorkoalSprites4
+.4byte sTorkoalSprites5
+.4byte sTorkoalSprites6
+.4byte sTorkoalSprites7
+.4byte sTorkoalSprites8
+.4byte sTorkoalSprites9
+.4byte sTorkoalSprites10
+.4byte sTorkoalSprites11
+.4byte sTorkoalSprites12
+.4byte sTorkoalSprites13
+.4byte sTorkoalSprites14
+.4byte sTorkoalSprites15
+.4byte sTorkoalSprites16
+.4byte sTorkoalSprites17
+.4byte sTorkoalSprites18
+.4byte sTorkoalSprites19
+.4byte sTorkoalSprites20
+.4byte sTorkoalSprites21
+.4byte sTorkoalSprites22
+.4byte sTorkoalSprites23
+.4byte sTorkoalSprites24
+.4byte sTorkoalSprites25
+.4byte sTorkoalSprites26
+.4byte sTorkoalSprites27
+.4byte sTorkoalSprites28
+.4byte sTorkoalSprites29
+.4byte sTorkoalSprites30
+.4byte sTorkoalSprites31
+.4byte sTorkoalSprites32
+.4byte sTorkoalSprites33
+.4byte sTorkoalSprites34
+.4byte sTorkoalSprites35
+.4byte sTorkoalSprites36
+.4byte sTorkoalSprites37
+.4byte sTorkoalSprites38
+.4byte sTorkoalSprites39
+.4byte sTorkoalSprites40
+.4byte sTorkoalSprites41
+.4byte sTorkoalSprites42
+.4byte sTorkoalSprites43
+.4byte sTorkoalSprites44
+.4byte sTorkoalSprites45
+sAxMainTorkoal:
+ax_main sAxPosesTorkoal, sAxAnimationsTorkoal, 13, sAxSpritesTorkoal, sAxPositionsTorkoal

--- a/data/ax/totodile.inc
+++ b/data/ax/totodile.inc
@@ -1,0 +1,4249 @@
+.global gAxTotodile
+gAxTotodile:
+ax_siro sAxMainTotodile
+sTotodilePose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose5:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose6:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose7:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose8:
+ax_pose 7, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose9:
+ax_pose 8, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose10:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose11:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose12:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose17:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose19:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose20:
+ax_pose 7, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose21:
+ax_pose 8, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose23:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose24:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose28:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose29:
+ax_pose 4, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose30:
+ax_pose 5, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose31:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose32:
+ax_pose 7, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose33:
+ax_pose 8, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose34:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose35:
+ax_pose 10, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose36:
+ax_pose 11, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose37:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose41:
+ax_pose 10, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose43:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose44:
+ax_pose 7, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose45:
+ax_pose 8, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose47:
+ax_pose 4, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose48:
+ax_pose 5, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose50:
+ax_pose 15, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose51:
+ax_pose 16, 0x81ec, 0x80f2, 0x0c00
+ax_pose 17, 0x01ec, 0x80f2, 0x0c08
+ax_pose_terminator
+sTotodilePose52:
+ax_pose 17, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose53:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose54:
+ax_pose 18, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose55:
+ax_pose 19, 0x81ec, 0x90fc, 0x0c00
+ax_pose 20, 0x01ec, 0x90ec, 0x0c08
+ax_pose_terminator
+sTotodilePose56:
+ax_pose 20, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose57:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose58:
+ax_pose 21, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sTotodilePose59:
+ax_pose 22, 0x01ec, 0x90f0, 0x0c00
+ax_pose 23, 0x01ec, 0x90ec, 0x0c10
+ax_pose_terminator
+sTotodilePose60:
+ax_pose 23, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose61:
+ax_pose 24, 0x01ec, 0x90eb, 0x0c00
+ax_pose_terminator
+sTotodilePose62:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose63:
+ax_pose 25, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sTotodilePose64:
+ax_pose 26, 0x41eb, 0x90ec, 0x0c00
+ax_pose 27, 0x01ec, 0x90ec, 0x0c08
+ax_pose_terminator
+sTotodilePose65:
+ax_pose 27, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose66:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose67:
+ax_pose 24, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose68:
+ax_pose 28, 0x81eb, 0x80fd, 0x0c00
+ax_pose 29, 0x01ec, 0x80f5, 0x0c08
+ax_pose_terminator
+sTotodilePose69:
+ax_pose 29, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose70:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose71:
+ax_pose 25, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sTotodilePose72:
+ax_pose 26, 0x41eb, 0x80f4, 0x0c00
+ax_pose 27, 0x01ec, 0x80f4, 0x0c08
+ax_pose_terminator
+sTotodilePose73:
+ax_pose 27, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose74:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose75:
+ax_pose 21, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sTotodilePose76:
+ax_pose 22, 0x01ec, 0x80f0, 0x0c00
+ax_pose 23, 0x01ec, 0x80f4, 0x0c10
+ax_pose_terminator
+sTotodilePose77:
+ax_pose 23, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose78:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose79:
+ax_pose 18, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose80:
+ax_pose 19, 0x81ec, 0x80f4, 0x0c00
+ax_pose 20, 0x01ec, 0x80f4, 0x0c08
+ax_pose_terminator
+sTotodilePose81:
+ax_pose 20, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose82:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose83:
+ax_pose 30, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose84:
+ax_pose 31, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose85:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose86:
+ax_pose 32, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose87:
+ax_pose 33, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose88:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose89:
+ax_pose 34, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose90:
+ax_pose 35, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose91:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose92:
+ax_pose 36, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose93:
+ax_pose 37, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose94:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose95:
+ax_pose 38, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose96:
+ax_pose 39, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose97:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose98:
+ax_pose 36, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose99:
+ax_pose 37, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose100:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose101:
+ax_pose 34, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose102:
+ax_pose 35, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose103:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose104:
+ax_pose 32, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose105:
+ax_pose 33, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose106:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose107:
+ax_pose 30, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose108:
+ax_pose 31, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose109:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose110:
+ax_pose 32, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose111:
+ax_pose 33, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose112:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose113:
+ax_pose 34, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose114:
+ax_pose 35, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose115:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose116:
+ax_pose 36, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose117:
+ax_pose 37, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose118:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose119:
+ax_pose 38, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose120:
+ax_pose 39, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose121:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose122:
+ax_pose 36, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose123:
+ax_pose 37, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose124:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose125:
+ax_pose 34, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose126:
+ax_pose 35, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose127:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose128:
+ax_pose 32, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose129:
+ax_pose 33, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose130:
+ax_pose 40, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose131:
+ax_pose 41, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose132:
+ax_pose 42, 0x01e3, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose133:
+ax_pose 43, 0x01e5, 0x90ea, 0x0c00
+ax_pose_terminator
+sTotodilePose134:
+ax_pose 44, 0x01e6, 0x90e9, 0x0c00
+ax_pose_terminator
+sTotodilePose135:
+ax_pose 45, 0x01e5, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose136:
+ax_pose 46, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose137:
+ax_pose 45, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose138:
+ax_pose 44, 0x01e6, 0x80f7, 0x0c00
+ax_pose_terminator
+sTotodilePose139:
+ax_pose 43, 0x01e5, 0x80f6, 0x0c00
+ax_pose_terminator
+sTotodilePose140:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose141:
+ax_pose 30, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose142:
+ax_pose 31, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose143:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose144:
+ax_pose 32, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose145:
+ax_pose 33, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose146:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose147:
+ax_pose 34, 0x01e9, 0x90ef, 0x0c00
+ax_pose_terminator
+sTotodilePose148:
+ax_pose 35, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose149:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose150:
+ax_pose 36, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose151:
+ax_pose 37, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose152:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose153:
+ax_pose 38, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose154:
+ax_pose 39, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose155:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose156:
+ax_pose 36, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose157:
+ax_pose 37, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose158:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose159:
+ax_pose 34, 0x01e9, 0x80f1, 0x0c00
+ax_pose_terminator
+sTotodilePose160:
+ax_pose 35, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose161:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose162:
+ax_pose 32, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose163:
+ax_pose 33, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose164:
+ax_pose 31, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose165:
+ax_pose 33, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose166:
+ax_pose 35, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose167:
+ax_pose 37, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sTotodilePose168:
+ax_pose 39, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose169:
+ax_pose 37, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sTotodilePose170:
+ax_pose 35, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose171:
+ax_pose 33, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose172:
+ax_pose 30, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose173:
+ax_pose 32, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sTotodilePose174:
+ax_pose 34, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose175:
+ax_pose 36, 0x01eb, 0x90ef, 0x0c00
+ax_pose_terminator
+sTotodilePose176:
+ax_pose 38, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose177:
+ax_pose 36, 0x01eb, 0x80f1, 0x0c00
+ax_pose_terminator
+sTotodilePose178:
+ax_pose 34, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose179:
+ax_pose 32, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose180:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose181:
+ax_pose 30, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose182:
+ax_pose 31, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose183:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose184:
+ax_pose 32, 0x01ea, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose185:
+ax_pose 33, 0x01ea, 0x90eb, 0x0c00
+ax_pose_terminator
+sTotodilePose186:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose187:
+ax_pose 34, 0x01e9, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose188:
+ax_pose 35, 0x01e9, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose189:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose190:
+ax_pose 36, 0x01eb, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose191:
+ax_pose 37, 0x01eb, 0x90ed, 0x0c00
+ax_pose_terminator
+sTotodilePose192:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose193:
+ax_pose 38, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose194:
+ax_pose 39, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose195:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose196:
+ax_pose 36, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose197:
+ax_pose 37, 0x01eb, 0x80f3, 0x0c00
+ax_pose_terminator
+sTotodilePose198:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose199:
+ax_pose 34, 0x01e9, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose200:
+ax_pose 35, 0x01e9, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose201:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose202:
+ax_pose 32, 0x01ea, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose203:
+ax_pose 33, 0x01ea, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose204:
+ax_pose 15, 0x01eb, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose205:
+ax_pose 18, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose206:
+ax_pose 21, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sTotodilePose207:
+ax_pose 25, 0x01ec, 0x80f1, 0x0c00
+ax_pose_terminator
+sTotodilePose208:
+ax_pose 24, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose209:
+ax_pose 25, 0x01ec, 0x90ef, 0x0c00
+ax_pose_terminator
+sTotodilePose210:
+ax_pose 21, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sTotodilePose211:
+ax_pose 18, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose212:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose213:
+ax_pose 3, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose214:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose215:
+ax_pose 9, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose216:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose217:
+ax_pose 9, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose218:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose219:
+ax_pose 3, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose220:
+ax_pose 47, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose221:
+ax_pose 48, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose222:
+ax_pose 47, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose223:
+ax_pose 48, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose224:
+ax_pose 47, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose225:
+ax_pose 49, 0x01ed, 0x80f1, 0x0c00
+ax_pose_terminator
+sTotodilePose226:
+ax_pose 50, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose227:
+ax_pose 51, 0x01ed, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose228:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose229:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose230:
+ax_pose 52, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose231:
+ax_pose 53, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose232:
+ax_pose 54, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose233:
+ax_pose 55, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose234:
+ax_pose 56, 0x01ec, 0x80f5, 0x0c00
+ax_pose_terminator
+sTotodilePose235:
+ax_pose 57, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose236:
+ax_pose 58, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose237:
+ax_pose 59, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose238:
+ax_pose 60, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose239:
+ax_pose 60, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose240:
+ax_pose 61, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose241:
+ax_pose 62, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose242:
+ax_pose 63, 0x01e7, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose243:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose244:
+ax_pose 64, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose245:
+ax_pose 65, 0x01eb, 0x80f6, 0x0c00
+ax_pose_terminator
+sTotodilePose246:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose247:
+ax_pose 66, 0x01ee, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose248:
+ax_pose 67, 0x01ef, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose249:
+ax_pose 0, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose250:
+ax_pose 55, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose251:
+ax_pose 68, 0x01eb, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose252:
+ax_pose 6, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose253:
+ax_pose 69, 0x01ec, 0x80f0, 0x0c00
+ax_pose_terminator
+sTotodilePose254:
+ax_pose 6, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose255:
+ax_pose 69, 0x01ec, 0x90f0, 0x0c00
+ax_pose_terminator
+sTotodilePose256:
+ax_pose 12, 0x01ec, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose257:
+ax_pose 70, 0x01ed, 0x80f4, 0x0c00
+ax_pose_terminator
+sTotodilePose258:
+ax_pose 71, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose259:
+ax_pose 72, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose260:
+ax_pose 73, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose261:
+ax_pose 74, 0x01ec, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose262:
+ax_pose 75, 0x01ec, 0x80f3, 0x0c00
+ax_pose_terminator
+sTotodilePose263:
+ax_pose 71, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose264:
+ax_pose 72, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose265:
+ax_pose 73, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose266:
+ax_pose 74, 0x01ec, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose267:
+ax_pose 75, 0x01ec, 0x90ed, 0x0c00
+ax_pose_terminator
+sTotodilePose268:
+ax_pose 76, 0x01ec, 0x90ec, 0x0c00
+ax_pose_terminator
+sTotodilePose269:
+ax_pose 47, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose270:
+ax_pose 48, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose271:
+ax_pose 47, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose272:
+ax_pose 48, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose273:
+ax_pose 47, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose274:
+ax_pose 48, 0x01ef, 0x80f2, 0x0c00
+ax_pose_terminator
+sTotodilePose275:
+ax_pose 47, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+sTotodilePose276:
+ax_pose 48, 0x01ef, 0x90ee, 0x0c00
+ax_pose_terminator
+.align 2
+sTotodileAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTotodileAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sTotodileAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sTotodileAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sTotodileAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sTotodileAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sTotodileAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sTotodileAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTotodileAnims_3_1:
+ax_anim 2, 0, 49, 0, -2, 0, -2,
+ax_anim 6, 0, 74, 3, -3, 3, -3,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 49, 0, 4, 0, 4,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 1, 51, 1, 16, 1, 16,
+ax_anim 2, 0, 51, 0, 16, 0, 16,
+ax_anim 2, 0, 51, 1, 16, 1, 16,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sTotodileAnims_3_2:
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 6, 0, 62, -6, -1, -6, -1,
+ax_anim 2, 0, 57, -1, -1, -1, -1,
+ax_anim 2, 2, 53, 4, 4, 4, 4,
+ax_anim 2, 0, 54, 16, 16, 16, 16,
+ax_anim 2, 1, 55, 15, 17, 15, 17,
+ax_anim 2, 0, 55, 16, 16, 16, 16,
+ax_anim 2, 0, 55, 15, 17, 15, 17,
+ax_anim 4, 0, 52, 6, 6, 6, 6,
+ax_anim_terminator
+sTotodileAnims_3_3:
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 6, 0, 60, -5, 1, -5, 1,
+ax_anim 2, 0, 62, -2, 0, -2, 0,
+ax_anim 2, 2, 57, 4, 0, 4, 0,
+ax_anim 2, 0, 58, 14, 0, 14, 0,
+ax_anim 2, 1, 59, 14, 1, 14, 1,
+ax_anim 2, 0, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 59, 14, 1, 14, 1,
+ax_anim 4, 0, 56, 6, 0, 6, 0,
+ax_anim_terminator
+sTotodileAnims_3_4:
+ax_anim 2, 0, 62, -2, 2, -2, 2,
+ax_anim 6, 0, 60, -3, 4, -3, 4,
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 2, 62, 5, -5, 5, -5,
+ax_anim 2, 0, 63, 16, -18, 16, -18,
+ax_anim 2, 1, 64, 17, -17, 17, -17,
+ax_anim 2, 0, 64, 16, -18, 16, -18,
+ax_anim 2, 0, 64, 17, -17, 17, -17,
+ax_anim 4, 0, 61, 6, -6, 6, -6,
+ax_anim_terminator
+sTotodileAnims_3_5:
+ax_anim 2, 0, 66, 0, 2, 0, 2,
+ax_anim 6, 0, 57, 0, 3, 0, 3,
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 2, 2, 66, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, -19, 0, -19,
+ax_anim 2, 1, 68, 1, -19, 1, -19,
+ax_anim 2, 0, 68, 0, -19, 0, -19,
+ax_anim 2, 0, 68, 1, -19, 1, -19,
+ax_anim 4, 0, 65, 0, -6, 0, -6,
+ax_anim_terminator
+sTotodileAnims_3_6:
+ax_anim 2, 0, 70, 2, 2, 2, 2,
+ax_anim 6, 0, 66, 5, 5, 5, 5,
+ax_anim 2, 0, 66, 1, 1, 1, 1,
+ax_anim 2, 2, 70, -4, -5, -4, -5,
+ax_anim 2, 0, 71, -16, -18, -16, -18,
+ax_anim 2, 1, 72, -17, -17, -17, -17,
+ax_anim 2, 0, 72, -16, -18, -16, -18,
+ax_anim 2, 0, 72, -17, -17, -17, -17,
+ax_anim 4, 0, 69, -6, -6, -6, -6,
+ax_anim_terminator
+sTotodileAnims_3_7:
+ax_anim 2, 0, 74, 2, 0, 2, 0,
+ax_anim 6, 0, 66, 5, 0, 5, 0,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 2, 74, -4, 0, -4, 0,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 1, 76, -14, 1, -14, 1,
+ax_anim 2, 0, 76, -14, 0, -14, 0,
+ax_anim 2, 0, 76, -14, 1, -14, 1,
+ax_anim 4, 0, 73, -6, 0, -6, 0,
+ax_anim_terminator
+sTotodileAnims_3_8:
+ax_anim 2, 0, 78, 2, -2, 2, -2,
+ax_anim 6, 0, 70, 7, -2, 7, -2,
+ax_anim 2, 0, 74, 3, -1, 3, -1,
+ax_anim 2, 2, 78, -4, 4, -4, 4,
+ax_anim 2, 0, 79, -16, 16, -16, 16,
+ax_anim 2, 1, 80, -17, 15, -17, 15,
+ax_anim 2, 0, 80, -16, 16, -16, 16,
+ax_anim 2, 0, 80, -17, 15, -17, 15,
+ax_anim 4, 0, 77, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTotodileAnims_4_1:
+ax_anim 2, 0, 81, 0, -2, 0, -2,
+ax_anim 3, 0, 82, 0, -4, 0, -4,
+ax_anim 2, 0, 82, 0, -5, 0, -5,
+ax_anim 2, 0, 82, 1, -5, 1, -5,
+ax_anim 2, 2, 82, 0, -5, 0, -5,
+ax_anim 2, 0, 82, 1, -5, 1, -5,
+ax_anim 2, 0, 81, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 1, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 83, 0, 4, 0, 4,
+ax_anim 2, 0, 83, 1, 4, 1, 4,
+ax_anim 2, 0, 81, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_4_2:
+ax_anim 2, 0, 84, -2, -2, -2, -2,
+ax_anim 3, 0, 85, -4, -4, -4, -4,
+ax_anim 2, 0, 85, -5, -5, -5, -5,
+ax_anim 2, 0, 85, -4, -6, -5, -5,
+ax_anim 2, 2, 85, -5, -5, -5, -5,
+ax_anim 2, 0, 85, -4, -6, -5, -5,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 86, 4, 4, 6, 6,
+ax_anim 2, 1, 86, 5, 3, 7, 5,
+ax_anim 2, 0, 86, 4, 4, 6, 6,
+ax_anim 2, 0, 86, 5, 3, 7, 5,
+ax_anim 2, 0, 86, 4, 4, 6, 6,
+ax_anim 2, 0, 86, 5, 3, 7, 5,
+ax_anim 2, 0, 84, 2, 2, 2, 2,
+ax_anim_terminator
+sTotodileAnims_4_3:
+ax_anim 2, 0, 87, -2, 0, -2, 0,
+ax_anim 3, 0, 88, -4, 0, -4, 0,
+ax_anim 2, 0, 88, -5, 0, -5, 0,
+ax_anim 2, 0, 88, -5, -1, -5, -1,
+ax_anim 2, 2, 88, -5, 0, -5, 0,
+ax_anim 2, 0, 88, -5, -1, -5, -1,
+ax_anim 2, 0, 87, -1, 0, -1, 0,
+ax_anim 2, 0, 89, 4, 0, 4, 0,
+ax_anim 2, 1, 89, 5, 0, 5, 0,
+ax_anim 2, 0, 89, 4, 0, 4, 0,
+ax_anim 2, 0, 89, 5, 0, 5, 0,
+ax_anim 2, 0, 89, 4, 0, 4, 0,
+ax_anim 2, 0, 89, 5, 0, 5, 0,
+ax_anim 2, 0, 87, 2, 0, 2, 0,
+ax_anim_terminator
+sTotodileAnims_4_4:
+ax_anim 2, 0, 90, -2, 2, -2, 2,
+ax_anim 3, 0, 91, -4, 4, -4, 4,
+ax_anim 2, 0, 91, -5, 5, -5, 5,
+ax_anim 2, 0, 91, -4, 6, -4, 6,
+ax_anim 2, 2, 91, -5, 5, -5, 5,
+ax_anim 2, 0, 91, -4, 6, -4, 6,
+ax_anim 2, 0, 90, -1, 1, -1, 1,
+ax_anim 2, 0, 92, 4, -4, 4, -4,
+ax_anim 2, 1, 92, 5, -3, 5, -3,
+ax_anim 2, 0, 92, 4, -4, 4, -4,
+ax_anim 2, 0, 92, 5, -3, 5, -3,
+ax_anim 2, 0, 92, 4, -4, 4, -4,
+ax_anim 2, 0, 92, 5, -3, 5, -3,
+ax_anim 2, 0, 90, 2, -2, 2, -2,
+ax_anim_terminator
+sTotodileAnims_4_5:
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 3, 0, 94, 0, 4, 0, 4,
+ax_anim 2, 0, 94, 0, 5, 0, 5,
+ax_anim 2, 0, 94, 1, 5, 1, 5,
+ax_anim 2, 2, 94, 0, 5, 0, 5,
+ax_anim 2, 0, 94, 1, 5, 1, 5,
+ax_anim 2, 0, 93, 0, 1, 0, 1,
+ax_anim 2, 0, 95, 0, -4, 0, -4,
+ax_anim 2, 1, 95, 1, -4, 1, -4,
+ax_anim 2, 0, 95, 0, -4, 0, -4,
+ax_anim 2, 0, 95, 1, -4, 1, -4,
+ax_anim 2, 0, 95, 0, -4, 0, -4,
+ax_anim 2, 0, 95, 1, -4, 1, -4,
+ax_anim 2, 0, 93, 0, -2, 0, -2,
+ax_anim_terminator
+sTotodileAnims_4_6:
+ax_anim 2, 0, 96, 2, 2, 2, 2,
+ax_anim 3, 0, 97, 4, 4, 4, 4,
+ax_anim 2, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 4, 6, 4, 6,
+ax_anim 2, 2, 97, 5, 5, 5, 5,
+ax_anim 2, 0, 97, 4, 6, 4, 6,
+ax_anim 2, 0, 96, 1, 1, 1, 1,
+ax_anim 2, 0, 98, -4, -4, -4, -4,
+ax_anim 2, 1, 98, -5, -3, -5, -3,
+ax_anim 2, 0, 98, -4, -4, -4, -4,
+ax_anim 2, 0, 98, -5, -3, -5, -3,
+ax_anim 2, 0, 98, -4, -4, -4, -4,
+ax_anim 2, 0, 98, -5, -3, -5, -3,
+ax_anim 2, 0, 96, -2, -2, -2, -2,
+ax_anim_terminator
+sTotodileAnims_4_7:
+ax_anim 2, 0, 99, 2, 0, 2, 0,
+ax_anim 3, 0, 100, 4, 0, 4, 0,
+ax_anim 2, 0, 100, 5, 0, 5, 0,
+ax_anim 2, 0, 100, 5, -1, 5, -1,
+ax_anim 2, 2, 100, 5, 0, 5, 0,
+ax_anim 2, 0, 100, 5, -1, 5, -1,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 0, 101, -4, 0, -4, 0,
+ax_anim 2, 1, 101, -5, 0, -5, 0,
+ax_anim 2, 0, 101, -4, 0, -4, 0,
+ax_anim 2, 0, 101, -5, 0, -5, 0,
+ax_anim 2, 0, 101, -4, 0, -4, 0,
+ax_anim 2, 0, 101, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -2, 0, -2, 0,
+ax_anim_terminator
+sTotodileAnims_4_8:
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim 3, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 4, -6, 5, -5,
+ax_anim 2, 2, 103, 5, -5, 5, -5,
+ax_anim 2, 0, 103, 4, -6, 5, -5,
+ax_anim 2, 0, 102, 1, -1, 1, -1,
+ax_anim 2, 0, 104, -4, 4, -6, 6,
+ax_anim 2, 1, 104, -5, 3, -7, 5,
+ax_anim 2, 0, 104, -4, 4, -6, 6,
+ax_anim 2, 0, 104, -5, 3, -7, 5,
+ax_anim 2, 0, 104, -4, 4, -6, 6,
+ax_anim 2, 0, 104, -5, 3, -7, 5,
+ax_anim 2, 0, 102, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sTotodileAnims_5_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 3, 0, 106, 0, -4, 0, -4,
+ax_anim 2, 0, 106, 0, -5, 0, -5,
+ax_anim 2, 0, 106, 1, -5, 1, -5,
+ax_anim 2, 2, 106, 0, -5, 0, -5,
+ax_anim 2, 0, 106, 1, -5, 1, -5,
+ax_anim 2, 0, 105, 0, -1, 0, -1,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 1, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 105, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_5_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 3, 0, 109, -4, -4, -4, -4,
+ax_anim 2, 0, 109, -5, -5, -5, -5,
+ax_anim 2, 0, 109, -4, -6, -5, -5,
+ax_anim 2, 2, 109, -5, -5, -5, -5,
+ax_anim 2, 0, 109, -4, -6, -5, -5,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 110, 4, 4, 6, 6,
+ax_anim 2, 1, 110, 5, 3, 7, 5,
+ax_anim 2, 0, 110, 4, 4, 6, 6,
+ax_anim 2, 0, 110, 5, 3, 7, 5,
+ax_anim 2, 0, 110, 4, 4, 6, 6,
+ax_anim 2, 0, 110, 5, 3, 7, 5,
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim_terminator
+sTotodileAnims_5_3:
+ax_anim 2, 0, 111, -2, 0, -2, 0,
+ax_anim 3, 0, 112, -4, 0, -4, 0,
+ax_anim 2, 0, 112, -5, 0, -5, 0,
+ax_anim 2, 0, 112, -5, -1, -5, -1,
+ax_anim 2, 2, 112, -5, 0, -5, 0,
+ax_anim 2, 0, 112, -5, -1, -5, -1,
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim 2, 0, 113, 4, 0, 4, 0,
+ax_anim 2, 1, 113, 5, 0, 5, 0,
+ax_anim 2, 0, 113, 4, 0, 4, 0,
+ax_anim 2, 0, 113, 5, 0, 5, 0,
+ax_anim 2, 0, 113, 4, 0, 4, 0,
+ax_anim 2, 0, 113, 5, 0, 5, 0,
+ax_anim 2, 0, 111, 2, 0, 2, 0,
+ax_anim_terminator
+sTotodileAnims_5_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 3, 0, 115, -4, 4, -4, 4,
+ax_anim 2, 0, 115, -5, 5, -5, 5,
+ax_anim 2, 0, 115, -4, 6, -4, 6,
+ax_anim 2, 2, 115, -5, 5, -5, 5,
+ax_anim 2, 0, 115, -4, 6, -4, 6,
+ax_anim 2, 0, 114, -1, 1, -1, 1,
+ax_anim 2, 0, 116, 4, -4, 4, -4,
+ax_anim 2, 1, 116, 5, -3, 5, -3,
+ax_anim 2, 0, 116, 4, -4, 4, -4,
+ax_anim 2, 0, 116, 5, -3, 5, -3,
+ax_anim 2, 0, 116, 4, -4, 4, -4,
+ax_anim 2, 0, 116, 5, -3, 5, -3,
+ax_anim 2, 0, 114, 2, -2, 2, -2,
+ax_anim_terminator
+sTotodileAnims_5_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 3, 0, 118, 0, 4, 0, 4,
+ax_anim 2, 0, 118, 0, 5, 0, 5,
+ax_anim 2, 0, 118, 1, 5, 1, 5,
+ax_anim 2, 2, 118, 0, 5, 0, 5,
+ax_anim 2, 0, 118, 1, 5, 1, 5,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 0, 119, 0, -4, 0, -4,
+ax_anim 2, 1, 119, 1, -4, 1, -4,
+ax_anim 2, 0, 119, 0, -4, 0, -4,
+ax_anim 2, 0, 119, 1, -4, 1, -4,
+ax_anim 2, 0, 119, 0, -4, 0, -4,
+ax_anim 2, 0, 119, 1, -4, 1, -4,
+ax_anim 2, 0, 117, 0, -2, 0, -2,
+ax_anim_terminator
+sTotodileAnims_5_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 3, 0, 121, 4, 4, 4, 4,
+ax_anim 2, 0, 121, 5, 5, 5, 5,
+ax_anim 2, 0, 121, 4, 6, 4, 6,
+ax_anim 2, 2, 121, 5, 5, 5, 5,
+ax_anim 2, 0, 121, 4, 6, 4, 6,
+ax_anim 2, 0, 120, 1, 1, 1, 1,
+ax_anim 2, 0, 122, -4, -4, -4, -4,
+ax_anim 2, 1, 122, -5, -3, -5, -3,
+ax_anim 2, 0, 122, -4, -4, -4, -4,
+ax_anim 2, 0, 122, -5, -3, -5, -3,
+ax_anim 2, 0, 122, -4, -4, -4, -4,
+ax_anim 2, 0, 122, -5, -3, -5, -3,
+ax_anim 2, 0, 120, -2, -2, -2, -2,
+ax_anim_terminator
+sTotodileAnims_5_7:
+ax_anim 2, 0, 123, 2, 0, 2, 0,
+ax_anim 3, 0, 124, 4, 0, 4, 0,
+ax_anim 2, 0, 124, 5, 0, 5, 0,
+ax_anim 2, 0, 124, 5, -1, 5, -1,
+ax_anim 2, 2, 124, 5, 0, 5, 0,
+ax_anim 2, 0, 124, 5, -1, 5, -1,
+ax_anim 2, 0, 123, 1, 0, 1, 0,
+ax_anim 2, 0, 125, -4, 0, -4, 0,
+ax_anim 2, 1, 125, -5, 0, -5, 0,
+ax_anim 2, 0, 125, -4, 0, -4, 0,
+ax_anim 2, 0, 125, -5, 0, -5, 0,
+ax_anim 2, 0, 125, -4, 0, -4, 0,
+ax_anim 2, 0, 125, -5, 0, -5, 0,
+ax_anim 2, 0, 123, -2, 0, -2, 0,
+ax_anim_terminator
+sTotodileAnims_5_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 3, 0, 127, 4, -4, 4, -4,
+ax_anim 2, 0, 127, 5, -5, 5, -5,
+ax_anim 2, 0, 127, 4, -6, 5, -5,
+ax_anim 2, 2, 127, 5, -5, 5, -5,
+ax_anim 2, 0, 127, 4, -6, 5, -5,
+ax_anim 2, 0, 126, 1, -1, 1, -1,
+ax_anim 2, 0, 128, -4, 4, -6, 6,
+ax_anim 2, 1, 128, -5, 3, -7, 5,
+ax_anim 2, 0, 128, -4, 4, -6, 6,
+ax_anim 2, 0, 128, -5, 3, -7, 5,
+ax_anim 2, 0, 128, -4, 4, -6, 6,
+ax_anim 2, 0, 128, -5, 3, -7, 5,
+ax_anim 2, 0, 126, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sTotodileAnims_6_1:
+ax_anim 30, 0, 129, 0, 0, 0, 0,
+ax_anim 35, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_7_1:
+ax_anim 2, 0, 131, 0, -2, 0, -2,
+ax_anim 8, 0, 131, 0, -3, 0, -3,
+ax_anim_terminator
+sTotodileAnims_7_2:
+ax_anim 2, 0, 132, -2, -2, -2, -2,
+ax_anim 8, 0, 132, -3, -3, -3, -3,
+ax_anim_terminator
+sTotodileAnims_7_3:
+ax_anim 2, 0, 133, -2, 0, -2, 0,
+ax_anim 8, 0, 133, -3, 0, -3, 0,
+ax_anim_terminator
+sTotodileAnims_7_4:
+ax_anim 2, 0, 134, -2, 2, -2, 2,
+ax_anim 8, 0, 134, -3, 3, -3, 3,
+ax_anim_terminator
+sTotodileAnims_7_5:
+ax_anim 2, 0, 135, 0, 2, 0, 2,
+ax_anim 8, 0, 135, 0, 3, 0, 3,
+ax_anim_terminator
+sTotodileAnims_7_6:
+ax_anim 2, 0, 136, 2, 2, 2, 2,
+ax_anim 8, 0, 136, 3, 3, 3, 3,
+ax_anim_terminator
+sTotodileAnims_7_7:
+ax_anim 2, 0, 137, 2, 0, 2, 0,
+ax_anim 8, 0, 137, 3, 0, 3, 0,
+ax_anim_terminator
+sTotodileAnims_7_8:
+ax_anim 2, 0, 138, 2, -2, 2, -2,
+ax_anim 8, 0, 138, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTotodileAnims_8_1:
+ax_anim 30, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 6, 0, 140, 0, -5, 0, 0,
+ax_anim 3, 0, 140, 0, -3, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_8_2:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 6, 0, 143, 0, -5, 0, 0,
+ax_anim 3, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_8_3:
+ax_anim 30, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 6, 0, 146, 0, -5, 0, 0,
+ax_anim 3, 0, 146, 0, -3, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_8_4:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, -3, 0, 0,
+ax_anim 6, 0, 149, 0, -5, 0, 0,
+ax_anim 3, 0, 149, 0, -3, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_8_5:
+ax_anim 30, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 6, 0, 152, 0, -5, 0, 0,
+ax_anim 3, 0, 152, 0, -3, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_8_6:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -3, 0, 0,
+ax_anim 6, 0, 155, 0, -5, 0, 0,
+ax_anim 3, 0, 155, 0, -3, 0, 0,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_8_7:
+ax_anim 30, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim 6, 0, 158, 0, -5, 0, 0,
+ax_anim 3, 0, 158, 0, -3, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_8_8:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -2, 0, 0,
+ax_anim 6, 0, 161, 0, -5, 0, 0,
+ax_anim 3, 0, 161, 0, -3, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_9_1:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 6, 4, 6, 4,
+ax_anim 2, 0, 165, 8, 9, 8, 9,
+ax_anim 2, 0, 166, 7, 19, 7, 19,
+ax_anim 3, 0, 167, 0, 21, 0, 21,
+ax_anim 2, 3, 168, -7, 19, -7, 19,
+ax_anim 2, 0, 169, -8, 9, -8, 9,
+ax_anim 1, 0, 170, -6, 4, -6, 4,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_9_2:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 0, 6, 0,
+ax_anim 2, 0, 164, 17, 3, 17, 3,
+ax_anim 2, 0, 165, 22, 9, 22, 9,
+ax_anim 3, 0, 166, 19, 20, 19, 20,
+ax_anim 2, 3, 167, 11, 21, 11, 21,
+ax_anim 2, 0, 168, 2, 16, 2, 16,
+ax_anim 1, 0, 169, -2, 7, -2, 7,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_9_3:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 3, -4, 3, -4,
+ax_anim 2, 0, 163, 11, -6, 11, -6,
+ax_anim 2, 0, 164, 17, -4, 17, -4,
+ax_anim 3, 0, 165, 20, 1, 20, 1,
+ax_anim 2, 3, 166, 17, 5, 17, 5,
+ax_anim 2, 0, 167, 12, 7, 12, 7,
+ax_anim 1, 0, 168, 4, 5, 4, 5,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_9_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, -2, -6, -2, -6,
+ax_anim 2, 0, 170, 4, -18, 4, -18,
+ax_anim 2, 0, 163, 10, -23, 10, -23,
+ax_anim 3, 0, 164, 18, -24, 18, -24,
+ax_anim 2, 3, 165, 21, -12, 21, -12,
+ax_anim 2, 0, 166, 16, -4, 16, -4,
+ax_anim 1, 0, 167, 8, 1, 8, 1,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_9_5:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -6, -4, -6, -4,
+ax_anim 2, 0, 169, -8, -10, -8, -10,
+ax_anim 2, 0, 170, -7, -18, -7, -18,
+ax_anim 3, 0, 163, 0, -24, 0, -24,
+ax_anim 2, 3, 164, 7, -18, 7, -18,
+ax_anim 2, 0, 165, 8, -8, 8, -8,
+ax_anim 1, 0, 166, 6, -4, 6, -4,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_9_6:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 2, -6, 2, -6,
+ax_anim 2, 0, 164, -4, -18, -4, -18,
+ax_anim 2, 0, 163, -10, -23, -10, -23,
+ax_anim 3, 0, 170, -18, -24, -18, -24,
+ax_anim 2, 3, 169, -21, -12, -21, -12,
+ax_anim 2, 0, 168, -16, -4, -16, -4,
+ax_anim 1, 0, 167, -8, -1, -8, -1,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_9_7:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, -3, -4, -3, -4,
+ax_anim 2, 0, 163, -11, -6, -11, -6,
+ax_anim 2, 0, 170, -17, -4, -17, -4,
+ax_anim 3, 0, 169, -20, 1, -20, 1,
+ax_anim 2, 3, 168, -17, 5, -17, 5,
+ax_anim 2, 0, 167, -12, 7, -12, 7,
+ax_anim 1, 0, 166, -4, 5, -4, 5,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_9_8:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -6, 0, -6, 0,
+ax_anim 2, 0, 170, -17, 3, -17, 3,
+ax_anim 2, 0, 169, -22, 9, -22, 9,
+ax_anim 3, 0, 168, -19, 20, -19, 20,
+ax_anim 2, 3, 167, -11, 21, -11, 21,
+ax_anim 2, 0, 166, -2, 16, -2, 16,
+ax_anim 1, 0, 165, 2, 7, 2, 7,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_10_1:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, 0, 6, 0,
+ax_anim 2, 0, 171, -6, 0, -6, 0,
+ax_anim 2, 0, 171, 10, 0, 10, 0,
+ax_anim 2, 0, 171, -10, 0, -10, 0,
+ax_anim 2, 0, 171, 12, 0, 12, 0,
+ax_anim 3, 0, 171, -12, 0, -12, 0,
+ax_anim 3, 0, 171, 13, 0, 13, 0,
+ax_anim 3, 0, 171, -13, 0, -13, 0,
+ax_anim 2, 0, 171, 12, 0, 12, 0,
+ax_anim 3, 0, 171, -12, 0, -12, 0,
+ax_anim 2, 0, 171, 10, 0, 10, 0,
+ax_anim 2, 0, 171, -10, 0, -10, 0,
+ax_anim 2, 0, 171, 6, 0, 6, 0,
+ax_anim 2, 0, 171, -6, 0, -6, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_10_2:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 6, -6, 6, -6,
+ax_anim 2, 0, 172, -6, 6, -6, 6,
+ax_anim 2, 0, 172, 10, -10, 10, -10,
+ax_anim 2, 0, 172, -10, 10, -10, 10,
+ax_anim 2, 0, 172, 12, -12, 12, -12,
+ax_anim 3, 0, 172, -12, 12, -12, 12,
+ax_anim 3, 0, 172, 13, -13, 13, -13,
+ax_anim 3, 0, 172, -13, 13, -13, 13,
+ax_anim 2, 0, 172, 12, -12, 12, -12,
+ax_anim 3, 0, 172, -12, 12, -12, 12,
+ax_anim 2, 0, 172, 10, -10, 10, -10,
+ax_anim 2, 0, 172, -10, 10, -10, 10,
+ax_anim 2, 0, 172, 6, -6, 6, -6,
+ax_anim 2, 0, 172, -6, 6, -6, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_10_3:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 3, 0, 173, 0, -13, 0, -13,
+ax_anim 3, 0, 173, 0, 13, 0, 13,
+ax_anim 2, 0, 173, 0, -12, 0, -12,
+ax_anim 3, 0, 173, 0, 12, 0, 12,
+ax_anim 2, 0, 173, 0, -10, 0, -10,
+ax_anim 2, 0, 173, 0, 10, 0, 10,
+ax_anim 2, 0, 173, 0, -6, 0, -6,
+ax_anim 2, 0, 173, 0, 6, 0, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_10_4:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, -6, -6, -6, -6,
+ax_anim 2, 0, 174, 6, 6, 6, 6,
+ax_anim 2, 0, 174, -10, -10, -10, -10,
+ax_anim 2, 0, 174, 10, 10, 10, 10,
+ax_anim 2, 0, 174, -12, -12, -12, -12,
+ax_anim 3, 0, 174, 12, 12, 12, 12,
+ax_anim 3, 0, 174, -13, -13, -13, -13,
+ax_anim 3, 0, 174, 13, 13, 13, 13,
+ax_anim 2, 0, 174, -12, -12, -12, -12,
+ax_anim 3, 0, 174, 12, 12, 12, 12,
+ax_anim 2, 0, 174, -10, -10, -10, -10,
+ax_anim 2, 0, 174, 10, 10, 10, 10,
+ax_anim 2, 0, 174, -6, -6, -6, -6,
+ax_anim 2, 0, 174, 6, 6, 6, 6,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_10_5:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, 0, 6, 0,
+ax_anim 2, 0, 175, -6, 0, -6, 0,
+ax_anim 2, 0, 175, 10, 0, 10, 0,
+ax_anim 2, 0, 175, -10, 0, -10, 0,
+ax_anim 2, 0, 175, 12, 0, 12, 0,
+ax_anim 3, 0, 175, -12, 0, -12, 0,
+ax_anim 3, 0, 175, 13, 0, 13, 0,
+ax_anim 3, 0, 175, -13, 0, -13, 0,
+ax_anim 2, 0, 175, 12, 0, 12, 0,
+ax_anim 3, 0, 175, -12, 0, -12, 0,
+ax_anim 2, 0, 175, 10, 0, 10, 0,
+ax_anim 2, 0, 175, -10, 0, -10, 0,
+ax_anim 2, 0, 175, 6, 0, 6, 0,
+ax_anim 2, 0, 175, -6, 0, -6, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_10_6:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 6, -6, 6, -6,
+ax_anim 2, 0, 176, -6, 6, -6, 6,
+ax_anim 2, 0, 176, 10, -10, 10, -10,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 2, 0, 176, 12, -12, 12, -12,
+ax_anim 3, 0, 176, -12, 12, -12, 12,
+ax_anim 3, 0, 176, 13, -13, 13, -13,
+ax_anim 3, 0, 176, -13, 13, -13, 13,
+ax_anim 2, 0, 176, 12, -12, 12, -12,
+ax_anim 3, 0, 176, -12, 12, -12, 12,
+ax_anim 2, 0, 176, 10, -10, 10, -10,
+ax_anim 2, 0, 176, -10, 10, -10, 10,
+ax_anim 2, 0, 176, 6, -6, 6, -6,
+ax_anim 2, 0, 176, -6, 6, -6, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_10_7:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, -6, 0, -6,
+ax_anim 2, 0, 177, 0, 6, 0, 6,
+ax_anim 2, 0, 177, 0, -10, 0, -10,
+ax_anim 2, 0, 177, 0, 10, 0, 10,
+ax_anim 2, 0, 177, 0, -12, 0, -12,
+ax_anim 3, 0, 177, 0, 12, 0, 12,
+ax_anim 3, 0, 177, 0, -13, 0, -13,
+ax_anim 3, 0, 177, 0, 13, 0, 13,
+ax_anim 2, 0, 177, 0, -12, 0, -12,
+ax_anim 3, 0, 177, 0, 12, 0, 12,
+ax_anim 2, 0, 177, 0, -10, 0, -10,
+ax_anim 2, 0, 177, 0, 10, 0, 10,
+ax_anim 2, 0, 177, 0, -6, 0, -6,
+ax_anim 2, 0, 177, 0, 6, 0, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_10_8:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, -6, -6, -6, -6,
+ax_anim 2, 0, 178, 6, 6, 6, 6,
+ax_anim 2, 0, 178, -10, -10, -10, -10,
+ax_anim 2, 0, 178, 10, 10, 10, 10,
+ax_anim 2, 0, 178, -12, -12, -12, -12,
+ax_anim 3, 0, 178, 12, 12, 12, 12,
+ax_anim 3, 0, 178, -13, -13, -13, -13,
+ax_anim 3, 0, 178, 13, 13, 13, 13,
+ax_anim 2, 0, 178, -12, -12, -12, -12,
+ax_anim 3, 0, 178, 12, 12, 12, 12,
+ax_anim 2, 0, 178, -10, -10, -10, -10,
+ax_anim 2, 0, 178, 10, 10, 10, 10,
+ax_anim 2, 0, 178, -6, -6, -6, -6,
+ax_anim 2, 0, 178, 6, 6, 6, 6,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_11_1:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 181, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_11_2:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_11_3:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -23, 0, 0,
+ax_anim 3, 0, 187, 0, -22, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_11_4:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -17, 0, 0,
+ax_anim 1, 0, 190, 0, -11, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_11_5:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_11_6:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_11_7:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -23, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_12_1:
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_12_2:
+ax_anim 2, 0, 210, 1, -1, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, -1, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_12_3:
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_12_4:
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, -1, -1, -1, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_12_5:
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 1, 0, 1, 0,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_12_6:
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, -1,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_12_7:
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -1, 0, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_12_8:
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -1, -1, -1, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_13_1:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_13_2:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_13_3:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_13_4:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_13_5:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_13_6:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_13_7:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_13_8:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_14_1:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_14_2:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_14_3:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_14_4:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_14_5:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_14_6:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_14_7:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_14_8:
+ax_anim 30, 0, 219, 0, 0, 0, 0,
+ax_anim 35, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_15_1:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_15_2:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_15_3:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_15_4:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_15_5:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_15_6:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_15_7:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_15_8:
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 6, 0, 224, 0, 0, 0, 0,
+ax_anim 14, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 226, 0, 0, 0, 0,
+ax_anim 10, 0, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_16_1:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_16_2:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_16_3:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_16_4:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_16_5:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_16_6:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_16_7:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_16_8:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 3, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_17_1:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+sTotodileAnims_17_2:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+sTotodileAnims_17_3:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+sTotodileAnims_17_4:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+sTotodileAnims_17_5:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+sTotodileAnims_17_6:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+sTotodileAnims_17_7:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+sTotodileAnims_17_8:
+ax_anim 12, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_18_1:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 2, 0, 2,
+ax_anim 8, 0, 235, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_18_2:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 2, 0, 2,
+ax_anim 8, 0, 235, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_18_3:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 2, 0, 2,
+ax_anim 8, 0, 235, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_18_4:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 2, 0, 2,
+ax_anim 8, 0, 235, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_18_5:
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 2, 0, 2,
+ax_anim 8, 0, 238, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_18_6:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 2, 0, 2,
+ax_anim 8, 0, 235, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_18_7:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 2, 0, 2,
+ax_anim 8, 0, 235, 0, 2, 0, 2,
+ax_anim_terminator
+sTotodileAnims_18_8:
+ax_anim 12, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 2, 0, 2,
+ax_anim 8, 0, 235, 0, 2, 0, 2,
+ax_anim_terminator
+.align 2
+sTotodileAnims_19_1:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_19_2:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_19_3:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_19_4:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_19_5:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_19_6:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_19_7:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_19_8:
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 240, 0, 0, 0, 0,
+ax_anim 8, 0, 239, 0, 0, 0, 0,
+ax_anim 10, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_20_1:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 1, 0, 0,
+ax_anim 2, 0, 244, 1, 1, 1, 0,
+ax_anim 2, 0, 244, 0, 1, 0, 0,
+ax_anim 2, 0, 244, 1, 1, 1, 0,
+ax_anim 2, 0, 244, 0, 1, 0, 0,
+ax_anim 2, 0, 244, 1, 1, 1, 0,
+ax_anim_terminator
+sTotodileAnims_20_2:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim_terminator
+sTotodileAnims_20_3:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim_terminator
+sTotodileAnims_20_4:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim_terminator
+sTotodileAnims_20_5:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim_terminator
+sTotodileAnims_20_6:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim_terminator
+sTotodileAnims_20_7:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim_terminator
+sTotodileAnims_20_8:
+ax_anim 4, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 0, -2, 0, 0,
+ax_anim 1, 0, 243, 0, -4, 0, 0,
+ax_anim 2, 0, 244, 0, -4, 0, 0,
+ax_anim 1, 0, 244, 0, -2, 0, 0,
+ax_anim 4, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_21_1:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_21_2:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_21_3:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_21_4:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_21_5:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_21_6:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_21_7:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_21_8:
+ax_anim 8, 0, 245, 0, 0, 0, 0,
+ax_anim 8, 0, 246, 0, 0, 0, 0,
+ax_anim 8, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_22_1:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_22_2:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_22_3:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_22_4:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_22_5:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_22_6:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_22_7:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_22_8:
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 30, 0, 249, 0, 0, 0, 0,
+ax_anim 34, 0, 250, 0, 0, 0, 0,
+ax_anim 4, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_23_1:
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_23_2:
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_23_3:
+ax_anim 10, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 253, 0, 0, 0, 0,
+ax_anim 8, 0, 254, 0, 0, 0, 0,
+ax_anim 4, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_23_4:
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_23_5:
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_23_6:
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_23_7:
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_23_8:
+ax_anim 10, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 8, 0, 252, 0, 0, 0, 0,
+ax_anim 4, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_24_1:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_24_2:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_24_3:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_24_4:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_24_5:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_24_6:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_24_7:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_24_8:
+ax_anim 4, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_25_1:
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_25_2:
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_25_3:
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_25_4:
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_25_5:
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_25_6:
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 263, 0, 0, 0, 0,
+ax_anim 12, 0, 264, 0, 0, 0, 0,
+ax_anim 10, 0, 262, 0, 0, 0, 0,
+ax_anim 8, 0, 265, 0, 0, 0, 0,
+ax_anim 12, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_25_7:
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_25_8:
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 258, 0, 0, 0, 0,
+ax_anim 12, 0, 259, 0, 0, 0, 0,
+ax_anim 10, 0, 257, 0, 0, 0, 0,
+ax_anim 8, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_26_1:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+sTotodileAnims_26_2:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+sTotodileAnims_26_3:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+sTotodileAnims_26_4:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+sTotodileAnims_26_5:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+sTotodileAnims_26_6:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+sTotodileAnims_26_7:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+sTotodileAnims_26_8:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 2, 0, 267, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sTotodileAnims_27_1:
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 16, 0, 268, -1, 0, 0, 0,
+ax_anim 12, 0, 268, 0, 0, 0, 0,
+ax_anim 12, 0, 268, 1, 0, 0, 0,
+ax_anim 16, 0, 268, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTotodileAnims_28_1:
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_28_2:
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_28_3:
+ax_anim 12, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_28_4:
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_28_5:
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_28_6:
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_28_7:
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileAnims_28_8:
+ax_anim 12, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sTotodileGfx1:
+.incbin "baserom.gba", 0xBEE578, 0x200
+sTotodileSprites1:
+ax_sprite sTotodileGfx1, 0x200
+ax_sprite_terminator
+sTotodileGfx2:
+.incbin "baserom.gba", 0xBEE788, 0x200
+sTotodileSprites2:
+ax_sprite sTotodileGfx2, 0x200
+ax_sprite_terminator
+sTotodileGfx3:
+.incbin "baserom.gba", 0xBEE998, 0x200
+sTotodileSprites3:
+ax_sprite sTotodileGfx3, 0x200
+ax_sprite_terminator
+sTotodileGfx4:
+.incbin "baserom.gba", 0xBEEBA8, 0x200
+sTotodileSprites4:
+ax_sprite sTotodileGfx4, 0x200
+ax_sprite_terminator
+sTotodileGfx5:
+.incbin "baserom.gba", 0xBEEDB8, 0x200
+sTotodileSprites5:
+ax_sprite sTotodileGfx5, 0x200
+ax_sprite_terminator
+sTotodileGfx6:
+.incbin "baserom.gba", 0xBEEFC8, 0x200
+sTotodileSprites6:
+ax_sprite sTotodileGfx6, 0x200
+ax_sprite_terminator
+sTotodileGfx7:
+.incbin "baserom.gba", 0xBEF1D8, 0x200
+sTotodileSprites7:
+ax_sprite sTotodileGfx7, 0x200
+ax_sprite_terminator
+sTotodileGfx8:
+.incbin "baserom.gba", 0xBEF3E8, 0x200
+sTotodileSprites8:
+ax_sprite sTotodileGfx8, 0x200
+ax_sprite_terminator
+sTotodileGfx9:
+.incbin "baserom.gba", 0xBEF5F8, 0x200
+sTotodileSprites9:
+ax_sprite sTotodileGfx9, 0x200
+ax_sprite_terminator
+sTotodileGfx10:
+.incbin "baserom.gba", 0xBEF808, 0x200
+sTotodileSprites10:
+ax_sprite sTotodileGfx10, 0x200
+ax_sprite_terminator
+sTotodileGfx11:
+.incbin "baserom.gba", 0xBEFA18, 0x200
+sTotodileSprites11:
+ax_sprite sTotodileGfx11, 0x200
+ax_sprite_terminator
+sTotodileGfx12:
+.incbin "baserom.gba", 0xBEFC28, 0x200
+sTotodileSprites12:
+ax_sprite sTotodileGfx12, 0x200
+ax_sprite_terminator
+sTotodileGfx13:
+.incbin "baserom.gba", 0xBEFE38, 0x200
+sTotodileSprites13:
+ax_sprite sTotodileGfx13, 0x200
+ax_sprite_terminator
+sTotodileGfx14:
+.incbin "baserom.gba", 0xBF0048, 0x200
+sTotodileSprites14:
+ax_sprite sTotodileGfx14, 0x200
+ax_sprite_terminator
+sTotodileGfx15:
+.incbin "baserom.gba", 0xBF0258, 0x200
+sTotodileSprites15:
+ax_sprite sTotodileGfx15, 0x200
+ax_sprite_terminator
+sTotodileGfx16:
+.incbin "baserom.gba", 0xBF0468, 0x40
+sTotodileGfx16_1:
+.incbin "baserom.gba", 0xBF04A8, 0x60
+sTotodileGfx16_2:
+.incbin "baserom.gba", 0xBF0508, 0x60
+sTotodileSprites16:
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx17:
+.incbin "baserom.gba", 0xBF05A8, 0x20
+sTotodileGfx17_1:
+.incbin "baserom.gba", 0xBF05C8, 0x20
+sTotodileGfx17_2:
+.incbin "baserom.gba", 0xBF05E8, 0x80
+sTotodileSprites17:
+ax_sprite sTotodileGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx17_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx17_2, 0x80
+ax_sprite_terminator
+sTotodileGfx18:
+.incbin "baserom.gba", 0xBF0698, 0x40
+sTotodileGfx18_1:
+.incbin "baserom.gba", 0xBF06D8, 0x60
+sTotodileGfx18_2:
+.incbin "baserom.gba", 0xBF0738, 0x60
+sTotodileSprites18:
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx19:
+.incbin "baserom.gba", 0xBF07D8, 0x60
+sTotodileGfx19_1:
+.incbin "baserom.gba", 0xBF0838, 0x60
+sTotodileGfx19_2:
+.incbin "baserom.gba", 0xBF0898, 0x60
+sTotodileSprites19:
+ax_sprite sTotodileGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx20:
+.incbin "baserom.gba", 0xBF0930, 0x60
+sTotodileGfx20_1:
+.incbin "baserom.gba", 0xBF0990, 0x40
+sTotodileSprites20:
+ax_sprite sTotodileGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx20_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTotodileGfx21:
+.incbin "baserom.gba", 0xBF09F8, 0x20
+sTotodileGfx21_1:
+.incbin "baserom.gba", 0xBF0A18, 0x60
+sTotodileGfx21_2:
+.incbin "baserom.gba", 0xBF0A78, 0x60
+sTotodileSprites21:
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx22:
+.incbin "baserom.gba", 0xBF0B18, 0x60
+sTotodileGfx22_1:
+.incbin "baserom.gba", 0xBF0B78, 0x60
+sTotodileGfx22_2:
+.incbin "baserom.gba", 0xBF0BD8, 0x60
+sTotodileSprites22:
+ax_sprite sTotodileGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx23:
+.incbin "baserom.gba", 0xBF0C70, 0x60
+sTotodileGfx23_1:
+.incbin "baserom.gba", 0xBF0CD0, 0x20
+sTotodileGfx23_2:
+.incbin "baserom.gba", 0xBF0CF0, 0x20
+sTotodileSprites23:
+ax_sprite sTotodileGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx23_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTotodileGfx23_2, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sTotodileGfx24:
+.incbin "baserom.gba", 0xBF0D48, 0x40
+sTotodileGfx24_1:
+.incbin "baserom.gba", 0xBF0D88, 0x60
+sTotodileGfx24_2:
+.incbin "baserom.gba", 0xBF0DE8, 0x60
+sTotodileSprites24:
+ax_sprite sTotodileGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx25:
+.incbin "baserom.gba", 0xBF0E80, 0x40
+sTotodileGfx25_1:
+.incbin "baserom.gba", 0xBF0EC0, 0x60
+sTotodileGfx25_2:
+.incbin "baserom.gba", 0xBF0F20, 0x60
+sTotodileSprites25:
+ax_sprite sTotodileGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx26:
+.incbin "baserom.gba", 0xBF0FB8, 0x40
+sTotodileGfx26_1:
+.incbin "baserom.gba", 0xBF0FF8, 0x60
+sTotodileGfx26_2:
+.incbin "baserom.gba", 0xBF1058, 0x60
+sTotodileGfx26_3:
+.incbin "baserom.gba", 0xBF10B8, 0x20
+sTotodileSprites26:
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx26_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sTotodileGfx26_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTotodileGfx27:
+.incbin "baserom.gba", 0xBF1128, 0x60
+sTotodileGfx27_1:
+.incbin "baserom.gba", 0xBF1188, 0x20
+sTotodileGfx27_2:
+.incbin "baserom.gba", 0xBF11A8, 0x20
+sTotodileSprites27:
+ax_sprite sTotodileGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx27_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx27_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTotodileGfx28:
+.incbin "baserom.gba", 0xBF1200, 0x40
+sTotodileGfx28_1:
+.incbin "baserom.gba", 0xBF1240, 0x60
+sTotodileGfx28_2:
+.incbin "baserom.gba", 0xBF12A0, 0x60
+sTotodileSprites28:
+ax_sprite sTotodileGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx29:
+.incbin "baserom.gba", 0xBF1338, 0x40
+sTotodileGfx29_1:
+.incbin "baserom.gba", 0xBF1378, 0x20
+sTotodileGfx29_2:
+.incbin "baserom.gba", 0xBF1398, 0x20
+sTotodileSprites29:
+ax_sprite sTotodileGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx29_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx29_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTotodileGfx30:
+.incbin "baserom.gba", 0xBF13F0, 0x40
+sTotodileGfx30_1:
+.incbin "baserom.gba", 0xBF1430, 0x60
+sTotodileGfx30_2:
+.incbin "baserom.gba", 0xBF1490, 0x60
+sTotodileSprites30:
+ax_sprite sTotodileGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx31:
+.incbin "baserom.gba", 0xBF1528, 0x60
+sTotodileGfx31_1:
+.incbin "baserom.gba", 0xBF1588, 0x60
+sTotodileGfx31_2:
+.incbin "baserom.gba", 0xBF15E8, 0x60
+sTotodileSprites31:
+ax_sprite sTotodileGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx32:
+.incbin "baserom.gba", 0xBF1680, 0x60
+sTotodileGfx32_1:
+.incbin "baserom.gba", 0xBF16E0, 0x60
+sTotodileGfx32_2:
+.incbin "baserom.gba", 0xBF1740, 0x60
+sTotodileSprites32:
+ax_sprite sTotodileGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx33:
+.incbin "baserom.gba", 0xBF17D8, 0x60
+sTotodileGfx33_1:
+.incbin "baserom.gba", 0xBF1838, 0x60
+sTotodileGfx33_2:
+.incbin "baserom.gba", 0xBF1898, 0x60
+sTotodileGfx33_3:
+.incbin "baserom.gba", 0xBF18F8, 0x40
+sTotodileSprites33:
+ax_sprite sTotodileGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTotodileGfx34:
+.incbin "baserom.gba", 0xBF1980, 0x40
+sTotodileGfx34_1:
+.incbin "baserom.gba", 0xBF19C0, 0x60
+sTotodileGfx34_2:
+.incbin "baserom.gba", 0xBF1A20, 0x60
+sTotodileGfx34_3:
+.incbin "baserom.gba", 0xBF1A80, 0x40
+sTotodileSprites34:
+ax_sprite sTotodileGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx34_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTotodileGfx35:
+.incbin "baserom.gba", 0xBF1B08, 0x40
+sTotodileGfx35_1:
+.incbin "baserom.gba", 0xBF1B48, 0x40
+sTotodileGfx35_2:
+.incbin "baserom.gba", 0xBF1B88, 0x60
+sTotodileGfx35_3:
+.incbin "baserom.gba", 0xBF1BE8, 0x40
+sTotodileSprites35:
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTotodileGfx36:
+.incbin "baserom.gba", 0xBF1C78, 0x40
+sTotodileGfx36_1:
+.incbin "baserom.gba", 0xBF1CB8, 0x60
+sTotodileGfx36_2:
+.incbin "baserom.gba", 0xBF1D18, 0x80
+sTotodileGfx36_3:
+.incbin "baserom.gba", 0xBF1D98, 0x20
+sTotodileSprites36:
+ax_sprite sTotodileGfx36, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx36_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx36_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTotodileGfx37:
+.incbin "baserom.gba", 0xBF1E00, 0x40
+sTotodileGfx37_1:
+.incbin "baserom.gba", 0xBF1E40, 0x40
+sTotodileGfx37_2:
+.incbin "baserom.gba", 0xBF1E80, 0x60
+sTotodileGfx37_3:
+.incbin "baserom.gba", 0xBF1EE0, 0x20
+sTotodileSprites37:
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx37_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sTotodileGfx37_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTotodileGfx38:
+.incbin "baserom.gba", 0xBF1F50, 0x60
+sTotodileGfx38_1:
+.incbin "baserom.gba", 0xBF1FB0, 0x60
+sTotodileGfx38_2:
+.incbin "baserom.gba", 0xBF2010, 0x60
+sTotodileSprites38:
+ax_sprite sTotodileGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx39:
+.incbin "baserom.gba", 0xBF20A8, 0x60
+sTotodileGfx39_1:
+.incbin "baserom.gba", 0xBF2108, 0x60
+sTotodileGfx39_2:
+.incbin "baserom.gba", 0xBF2168, 0x60
+sTotodileGfx39_3:
+.incbin "baserom.gba", 0xBF21C8, 0x20
+sTotodileSprites39:
+ax_sprite sTotodileGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx39_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTotodileGfx39_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTotodileGfx40:
+.incbin "baserom.gba", 0xBF2230, 0x60
+sTotodileGfx40_1:
+.incbin "baserom.gba", 0xBF2290, 0x60
+sTotodileGfx40_2:
+.incbin "baserom.gba", 0xBF22F0, 0x60
+sTotodileSprites40:
+ax_sprite sTotodileGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTotodileGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTotodileGfx41:
+.incbin "baserom.gba", 0xBF2388, 0x200
+sTotodileSprites41:
+ax_sprite sTotodileGfx41, 0x200
+ax_sprite_terminator
+sTotodileGfx42:
+.incbin "baserom.gba", 0xBF2598, 0x200
+sTotodileSprites42:
+ax_sprite sTotodileGfx42, 0x200
+ax_sprite_terminator
+sTotodileGfx43:
+.incbin "baserom.gba", 0xBF27A8, 0x200
+sTotodileSprites43:
+ax_sprite sTotodileGfx43, 0x200
+ax_sprite_terminator
+sTotodileGfx44:
+.incbin "baserom.gba", 0xBF29B8, 0x200
+sTotodileSprites44:
+ax_sprite sTotodileGfx44, 0x200
+ax_sprite_terminator
+sTotodileGfx45:
+.incbin "baserom.gba", 0xBF2BC8, 0x200
+sTotodileSprites45:
+ax_sprite sTotodileGfx45, 0x200
+ax_sprite_terminator
+sTotodileGfx46:
+.incbin "baserom.gba", 0xBF2DD8, 0x200
+sTotodileSprites46:
+ax_sprite sTotodileGfx46, 0x200
+ax_sprite_terminator
+sTotodileGfx47:
+.incbin "baserom.gba", 0xBF2FE8, 0x200
+sTotodileSprites47:
+ax_sprite sTotodileGfx47, 0x200
+ax_sprite_terminator
+sTotodileGfx48:
+.incbin "baserom.gba", 0xBF31F8, 0x200
+sTotodileSprites48:
+ax_sprite sTotodileGfx48, 0x200
+ax_sprite_terminator
+sTotodileGfx49:
+.incbin "baserom.gba", 0xBF3408, 0x200
+sTotodileSprites49:
+ax_sprite sTotodileGfx49, 0x200
+ax_sprite_terminator
+sTotodileGfx50:
+.incbin "baserom.gba", 0xBF3618, 0x200
+sTotodileSprites50:
+ax_sprite sTotodileGfx50, 0x200
+ax_sprite_terminator
+sTotodileGfx51:
+.incbin "baserom.gba", 0xBF3828, 0x200
+sTotodileSprites51:
+ax_sprite sTotodileGfx51, 0x200
+ax_sprite_terminator
+sTotodileGfx52:
+.incbin "baserom.gba", 0xBF3A38, 0x200
+sTotodileSprites52:
+ax_sprite sTotodileGfx52, 0x200
+ax_sprite_terminator
+sTotodileGfx53:
+.incbin "baserom.gba", 0xBF3C48, 0x200
+sTotodileSprites53:
+ax_sprite sTotodileGfx53, 0x200
+ax_sprite_terminator
+sTotodileGfx54:
+.incbin "baserom.gba", 0xBF3E58, 0x200
+sTotodileSprites54:
+ax_sprite sTotodileGfx54, 0x200
+ax_sprite_terminator
+sTotodileGfx55:
+.incbin "baserom.gba", 0xBF4068, 0x200
+sTotodileSprites55:
+ax_sprite sTotodileGfx55, 0x200
+ax_sprite_terminator
+sTotodileGfx56:
+.incbin "baserom.gba", 0xBF4278, 0x200
+sTotodileSprites56:
+ax_sprite sTotodileGfx56, 0x200
+ax_sprite_terminator
+sTotodileGfx57:
+.incbin "baserom.gba", 0xBF4488, 0x200
+sTotodileSprites57:
+ax_sprite sTotodileGfx57, 0x200
+ax_sprite_terminator
+sTotodileGfx58:
+.incbin "baserom.gba", 0xBF4698, 0x200
+sTotodileSprites58:
+ax_sprite sTotodileGfx58, 0x200
+ax_sprite_terminator
+sTotodileGfx59:
+.incbin "baserom.gba", 0xBF48A8, 0x200
+sTotodileSprites59:
+ax_sprite sTotodileGfx59, 0x200
+ax_sprite_terminator
+sTotodileGfx60:
+.incbin "baserom.gba", 0xBF4AB8, 0x200
+sTotodileSprites60:
+ax_sprite sTotodileGfx60, 0x200
+ax_sprite_terminator
+sTotodileGfx61:
+.incbin "baserom.gba", 0xBF4CC8, 0x200
+sTotodileSprites61:
+ax_sprite sTotodileGfx61, 0x200
+ax_sprite_terminator
+sTotodileGfx62:
+.incbin "baserom.gba", 0xBF4ED8, 0x200
+sTotodileSprites62:
+ax_sprite sTotodileGfx62, 0x200
+ax_sprite_terminator
+sTotodileGfx63:
+.incbin "baserom.gba", 0xBF50E8, 0x200
+sTotodileSprites63:
+ax_sprite sTotodileGfx63, 0x200
+ax_sprite_terminator
+sTotodileGfx64:
+.incbin "baserom.gba", 0xBF52F8, 0x200
+sTotodileSprites64:
+ax_sprite sTotodileGfx64, 0x200
+ax_sprite_terminator
+sTotodileGfx65:
+.incbin "baserom.gba", 0xBF5508, 0x200
+sTotodileSprites65:
+ax_sprite sTotodileGfx65, 0x200
+ax_sprite_terminator
+sTotodileGfx66:
+.incbin "baserom.gba", 0xBF5718, 0x200
+sTotodileSprites66:
+ax_sprite sTotodileGfx66, 0x200
+ax_sprite_terminator
+sTotodileGfx67:
+.incbin "baserom.gba", 0xBF5928, 0x200
+sTotodileSprites67:
+ax_sprite sTotodileGfx67, 0x200
+ax_sprite_terminator
+sTotodileGfx68:
+.incbin "baserom.gba", 0xBF5B38, 0x200
+sTotodileSprites68:
+ax_sprite sTotodileGfx68, 0x200
+ax_sprite_terminator
+sTotodileGfx69:
+.incbin "baserom.gba", 0xBF5D48, 0x200
+sTotodileSprites69:
+ax_sprite sTotodileGfx69, 0x200
+ax_sprite_terminator
+sTotodileGfx70:
+.incbin "baserom.gba", 0xBF5F58, 0x200
+sTotodileSprites70:
+ax_sprite sTotodileGfx70, 0x200
+ax_sprite_terminator
+sTotodileGfx71:
+.incbin "baserom.gba", 0xBF6168, 0x200
+sTotodileSprites71:
+ax_sprite sTotodileGfx71, 0x200
+ax_sprite_terminator
+sTotodileGfx72:
+.incbin "baserom.gba", 0xBF6378, 0x200
+sTotodileSprites72:
+ax_sprite sTotodileGfx72, 0x200
+ax_sprite_terminator
+sTotodileGfx73:
+.incbin "baserom.gba", 0xBF6588, 0x200
+sTotodileSprites73:
+ax_sprite sTotodileGfx73, 0x200
+ax_sprite_terminator
+sTotodileGfx74:
+.incbin "baserom.gba", 0xBF6798, 0x200
+sTotodileSprites74:
+ax_sprite sTotodileGfx74, 0x200
+ax_sprite_terminator
+sTotodileGfx75:
+.incbin "baserom.gba", 0xBF69A8, 0x200
+sTotodileSprites75:
+ax_sprite sTotodileGfx75, 0x200
+ax_sprite_terminator
+sTotodileGfx76:
+.incbin "baserom.gba", 0xBF6BB8, 0x200
+sTotodileSprites76:
+ax_sprite sTotodileGfx76, 0x200
+ax_sprite_terminator
+sTotodileGfx77:
+.incbin "baserom.gba", 0xBF6DC8, 0x200
+sTotodileSprites77:
+ax_sprite sTotodileGfx77, 0x200
+ax_sprite_terminator
+sAxPosesTotodile:
+.4byte sTotodilePose1
+.4byte sTotodilePose2
+.4byte sTotodilePose3
+.4byte sTotodilePose4
+.4byte sTotodilePose5
+.4byte sTotodilePose6
+.4byte sTotodilePose7
+.4byte sTotodilePose8
+.4byte sTotodilePose9
+.4byte sTotodilePose10
+.4byte sTotodilePose11
+.4byte sTotodilePose12
+.4byte sTotodilePose13
+.4byte sTotodilePose14
+.4byte sTotodilePose15
+.4byte sTotodilePose16
+.4byte sTotodilePose17
+.4byte sTotodilePose18
+.4byte sTotodilePose19
+.4byte sTotodilePose20
+.4byte sTotodilePose21
+.4byte sTotodilePose22
+.4byte sTotodilePose23
+.4byte sTotodilePose24
+.4byte sTotodilePose25
+.4byte sTotodilePose26
+.4byte sTotodilePose27
+.4byte sTotodilePose28
+.4byte sTotodilePose29
+.4byte sTotodilePose30
+.4byte sTotodilePose31
+.4byte sTotodilePose32
+.4byte sTotodilePose33
+.4byte sTotodilePose34
+.4byte sTotodilePose35
+.4byte sTotodilePose36
+.4byte sTotodilePose37
+.4byte sTotodilePose38
+.4byte sTotodilePose39
+.4byte sTotodilePose40
+.4byte sTotodilePose41
+.4byte sTotodilePose42
+.4byte sTotodilePose43
+.4byte sTotodilePose44
+.4byte sTotodilePose45
+.4byte sTotodilePose46
+.4byte sTotodilePose47
+.4byte sTotodilePose48
+.4byte sTotodilePose49
+.4byte sTotodilePose50
+.4byte sTotodilePose51
+.4byte sTotodilePose52
+.4byte sTotodilePose53
+.4byte sTotodilePose54
+.4byte sTotodilePose55
+.4byte sTotodilePose56
+.4byte sTotodilePose57
+.4byte sTotodilePose58
+.4byte sTotodilePose59
+.4byte sTotodilePose60
+.4byte sTotodilePose61
+.4byte sTotodilePose62
+.4byte sTotodilePose63
+.4byte sTotodilePose64
+.4byte sTotodilePose65
+.4byte sTotodilePose66
+.4byte sTotodilePose67
+.4byte sTotodilePose68
+.4byte sTotodilePose69
+.4byte sTotodilePose70
+.4byte sTotodilePose71
+.4byte sTotodilePose72
+.4byte sTotodilePose73
+.4byte sTotodilePose74
+.4byte sTotodilePose75
+.4byte sTotodilePose76
+.4byte sTotodilePose77
+.4byte sTotodilePose78
+.4byte sTotodilePose79
+.4byte sTotodilePose80
+.4byte sTotodilePose81
+.4byte sTotodilePose82
+.4byte sTotodilePose83
+.4byte sTotodilePose84
+.4byte sTotodilePose85
+.4byte sTotodilePose86
+.4byte sTotodilePose87
+.4byte sTotodilePose88
+.4byte sTotodilePose89
+.4byte sTotodilePose90
+.4byte sTotodilePose91
+.4byte sTotodilePose92
+.4byte sTotodilePose93
+.4byte sTotodilePose94
+.4byte sTotodilePose95
+.4byte sTotodilePose96
+.4byte sTotodilePose97
+.4byte sTotodilePose98
+.4byte sTotodilePose99
+.4byte sTotodilePose100
+.4byte sTotodilePose101
+.4byte sTotodilePose102
+.4byte sTotodilePose103
+.4byte sTotodilePose104
+.4byte sTotodilePose105
+.4byte sTotodilePose106
+.4byte sTotodilePose107
+.4byte sTotodilePose108
+.4byte sTotodilePose109
+.4byte sTotodilePose110
+.4byte sTotodilePose111
+.4byte sTotodilePose112
+.4byte sTotodilePose113
+.4byte sTotodilePose114
+.4byte sTotodilePose115
+.4byte sTotodilePose116
+.4byte sTotodilePose117
+.4byte sTotodilePose118
+.4byte sTotodilePose119
+.4byte sTotodilePose120
+.4byte sTotodilePose121
+.4byte sTotodilePose122
+.4byte sTotodilePose123
+.4byte sTotodilePose124
+.4byte sTotodilePose125
+.4byte sTotodilePose126
+.4byte sTotodilePose127
+.4byte sTotodilePose128
+.4byte sTotodilePose129
+.4byte sTotodilePose130
+.4byte sTotodilePose131
+.4byte sTotodilePose132
+.4byte sTotodilePose133
+.4byte sTotodilePose134
+.4byte sTotodilePose135
+.4byte sTotodilePose136
+.4byte sTotodilePose137
+.4byte sTotodilePose138
+.4byte sTotodilePose139
+.4byte sTotodilePose140
+.4byte sTotodilePose141
+.4byte sTotodilePose142
+.4byte sTotodilePose143
+.4byte sTotodilePose144
+.4byte sTotodilePose145
+.4byte sTotodilePose146
+.4byte sTotodilePose147
+.4byte sTotodilePose148
+.4byte sTotodilePose149
+.4byte sTotodilePose150
+.4byte sTotodilePose151
+.4byte sTotodilePose152
+.4byte sTotodilePose153
+.4byte sTotodilePose154
+.4byte sTotodilePose155
+.4byte sTotodilePose156
+.4byte sTotodilePose157
+.4byte sTotodilePose158
+.4byte sTotodilePose159
+.4byte sTotodilePose160
+.4byte sTotodilePose161
+.4byte sTotodilePose162
+.4byte sTotodilePose163
+.4byte sTotodilePose164
+.4byte sTotodilePose165
+.4byte sTotodilePose166
+.4byte sTotodilePose167
+.4byte sTotodilePose168
+.4byte sTotodilePose169
+.4byte sTotodilePose170
+.4byte sTotodilePose171
+.4byte sTotodilePose172
+.4byte sTotodilePose173
+.4byte sTotodilePose174
+.4byte sTotodilePose175
+.4byte sTotodilePose176
+.4byte sTotodilePose177
+.4byte sTotodilePose178
+.4byte sTotodilePose179
+.4byte sTotodilePose180
+.4byte sTotodilePose181
+.4byte sTotodilePose182
+.4byte sTotodilePose183
+.4byte sTotodilePose184
+.4byte sTotodilePose185
+.4byte sTotodilePose186
+.4byte sTotodilePose187
+.4byte sTotodilePose188
+.4byte sTotodilePose189
+.4byte sTotodilePose190
+.4byte sTotodilePose191
+.4byte sTotodilePose192
+.4byte sTotodilePose193
+.4byte sTotodilePose194
+.4byte sTotodilePose195
+.4byte sTotodilePose196
+.4byte sTotodilePose197
+.4byte sTotodilePose198
+.4byte sTotodilePose199
+.4byte sTotodilePose200
+.4byte sTotodilePose201
+.4byte sTotodilePose202
+.4byte sTotodilePose203
+.4byte sTotodilePose204
+.4byte sTotodilePose205
+.4byte sTotodilePose206
+.4byte sTotodilePose207
+.4byte sTotodilePose208
+.4byte sTotodilePose209
+.4byte sTotodilePose210
+.4byte sTotodilePose211
+.4byte sTotodilePose212
+.4byte sTotodilePose213
+.4byte sTotodilePose214
+.4byte sTotodilePose215
+.4byte sTotodilePose216
+.4byte sTotodilePose217
+.4byte sTotodilePose218
+.4byte sTotodilePose219
+.4byte sTotodilePose220
+.4byte sTotodilePose221
+.4byte sTotodilePose222
+.4byte sTotodilePose223
+.4byte sTotodilePose224
+.4byte sTotodilePose225
+.4byte sTotodilePose226
+.4byte sTotodilePose227
+.4byte sTotodilePose228
+.4byte sTotodilePose229
+.4byte sTotodilePose230
+.4byte sTotodilePose231
+.4byte sTotodilePose232
+.4byte sTotodilePose233
+.4byte sTotodilePose234
+.4byte sTotodilePose235
+.4byte sTotodilePose236
+.4byte sTotodilePose237
+.4byte sTotodilePose238
+.4byte sTotodilePose239
+.4byte sTotodilePose240
+.4byte sTotodilePose241
+.4byte sTotodilePose242
+.4byte sTotodilePose243
+.4byte sTotodilePose244
+.4byte sTotodilePose245
+.4byte sTotodilePose246
+.4byte sTotodilePose247
+.4byte sTotodilePose248
+.4byte sTotodilePose249
+.4byte sTotodilePose250
+.4byte sTotodilePose251
+.4byte sTotodilePose252
+.4byte sTotodilePose253
+.4byte sTotodilePose254
+.4byte sTotodilePose255
+.4byte sTotodilePose256
+.4byte sTotodilePose257
+.4byte sTotodilePose258
+.4byte sTotodilePose259
+.4byte sTotodilePose260
+.4byte sTotodilePose261
+.4byte sTotodilePose262
+.4byte sTotodilePose263
+.4byte sTotodilePose264
+.4byte sTotodilePose265
+.4byte sTotodilePose266
+.4byte sTotodilePose267
+.4byte sTotodilePose268
+.4byte sTotodilePose269
+.4byte sTotodilePose270
+.4byte sTotodilePose271
+.4byte sTotodilePose272
+.4byte sTotodilePose273
+.4byte sTotodilePose274
+.4byte sTotodilePose275
+.4byte sTotodilePose276
+sAxPositionsTotodile:
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -9, 	   7,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -7,   -5, 	   8,   -9, 	  -1,   -7
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    4,   -5, 	   5,   -7, 	  -1,   -4, 	  -1,   -8
+.2byte    5,   -7, 	   8,   -6, 	  -6,   -7, 	   0,   -8
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    6,   -8, 	  -2,   -5, 	   3,   -6, 	   0,   -8
+.2byte    7,   -8, 	   4,   -5, 	  -2,   -4, 	  -1,   -8
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    3,   -9, 	  -7,   -8, 	   6,   -9, 	  -1,   -7
+.2byte    4,  -10, 	  -3,  -10, 	   4,   -4, 	  -1,   -6
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte    0,  -13, 	   7,   -7, 	  -7,  -10, 	  -1,   -7
+.2byte    0,  -13, 	   6,  -10, 	  -8,   -7, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte   -4,   -9, 	   6,   -8, 	  -7,   -9, 	   0,   -7
+.2byte   -5,  -10, 	   2,  -10, 	  -5,   -4, 	   0,   -6
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -7,   -8, 	   1,   -5, 	  -4,   -6, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,   -5, 	   1,   -4, 	   0,   -8
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -5,   -5, 	  -6,   -7, 	   0,   -4, 	   0,   -8
+.2byte   -6,   -7, 	  -9,   -6, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -9, 	   7,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -7,   -5, 	   8,   -9, 	  -1,   -7
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    4,   -5, 	   5,   -7, 	  -1,   -4, 	  -1,   -8
+.2byte    5,   -7, 	   8,   -6, 	  -6,   -7, 	   0,   -8
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    6,   -8, 	  -2,   -5, 	   3,   -6, 	   0,   -8
+.2byte    7,   -8, 	   4,   -5, 	  -2,   -4, 	  -1,   -8
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    3,   -9, 	  -7,   -8, 	   6,   -9, 	  -1,   -7
+.2byte    4,  -10, 	  -3,  -10, 	   4,   -4, 	  -1,   -6
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte    0,  -13, 	   7,   -7, 	  -7,  -10, 	  -1,   -7
+.2byte    0,  -13, 	   6,  -10, 	  -8,   -7, 	   0,   -7
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte   -4,   -9, 	   6,   -8, 	  -7,   -9, 	   0,   -7
+.2byte   -5,  -10, 	   2,  -10, 	  -5,   -4, 	   0,   -6
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -7,   -8, 	   1,   -5, 	  -4,   -6, 	  -1,   -8
+.2byte   -8,   -8, 	  -5,   -5, 	   1,   -4, 	   0,   -8
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -5,   -5, 	  -6,   -7, 	   0,   -4, 	   0,   -8
+.2byte   -6,   -7, 	  -9,   -6, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte   -1,   -8, 	  -8,  -12, 	   4,   -7, 	   0,   -8
+.2byte    3,   -2, 	  -2,   -1, 	   1,   -3, 	   0,   -7
+.2byte    3,   -2, 	  -2,   -1, 	   1,   -3, 	   0,   -7
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    4,   -8, 	   1,  -12, 	  -2,   -6, 	  -2,   -9
+.2byte   -2,   -1, 	   6,   -1, 	  -9,   -6, 	  -1,   -6
+.2byte   -2,   -1, 	   6,   -1, 	  -9,   -6, 	  -1,   -6
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -3,  -13, 	   4,   -7, 	  -2,   -8
+.2byte    5,   -2, 	   5,   -8, 	  -3,   -4, 	   0,   -7
+.2byte    5,   -2, 	   5,   -8, 	  -3,   -4, 	   0,   -7
+.2byte    0,  -11, 	  -8,   -7, 	   5,  -11, 	   1,   -7
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    1,  -10, 	 -10,   -7, 	   4,   -8, 	  -2,   -6
+.2byte    7,   -7, 	   4,  -10, 	   0,   -6, 	   1,   -8
+.2byte    7,   -7, 	   4,  -10, 	   0,   -6, 	   1,   -8
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -7, 	  -6,  -11, 	  -2,   -7
+.2byte   -6,  -10, 	  -3,   -9, 	  -6,   -4, 	  -1,   -8
+.2byte   -6,  -10, 	  -3,   -9, 	  -6,   -4, 	  -1,   -8
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte   -2,  -10, 	   9,   -7, 	  -5,   -8, 	   1,   -6
+.2byte   -8,   -7, 	  -5,  -10, 	  -1,   -6, 	  -2,   -8
+.2byte   -8,   -7, 	  -5,  -10, 	  -1,   -6, 	  -2,   -8
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -4,  -10, 	   2,  -13, 	  -5,   -7, 	   1,   -8
+.2byte   -6,   -2, 	  -6,   -8, 	   2,   -4, 	  -1,   -7
+.2byte   -6,   -2, 	  -6,   -8, 	   2,   -4, 	  -1,   -7
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -5,   -8, 	  -2,  -12, 	   1,   -6, 	   1,   -9
+.2byte    1,   -1, 	  -7,   -1, 	   8,   -6, 	   0,   -6
+.2byte    1,   -1, 	  -7,   -1, 	   8,   -6, 	   0,   -6
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte   -1,  -21, 	  -9,  -12, 	   8,  -12, 	  -1,   -9
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    2,  -19, 	   7,  -13, 	  -6,  -10, 	  -1,   -9
+.2byte    5,   -5, 	   2,  -11, 	  -6,   -7, 	   0,   -8
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    2,  -19, 	  -4,  -12, 	  -3,   -9, 	  -4,  -10
+.2byte    8,   -7, 	  -2,  -10, 	  -2,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    0,  -16, 	  -2,  -10, 	   4,  -10, 	  -3,   -8
+.2byte    5,  -10, 	  -6,   -9, 	   6,   -5, 	   0,   -8
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -16, 	   7,  -11, 	  -8,  -11, 	  -1,   -5
+.2byte   -1,  -14, 	   7,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -16, 	   1,  -10, 	  -5,  -10, 	   2,   -8
+.2byte   -6,  -10, 	   5,   -9, 	  -7,   -5, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -3,  -19, 	   3,  -12, 	   2,   -9, 	   3,  -10
+.2byte   -9,   -7, 	   1,  -10, 	   1,   -5, 	  -1,   -8
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -3,  -19, 	  -8,  -13, 	   5,  -10, 	   0,   -9
+.2byte   -6,   -5, 	  -3,  -11, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte   -1,  -21, 	  -9,  -12, 	   8,  -12, 	  -1,   -9
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    2,  -19, 	   7,  -13, 	  -6,  -10, 	  -1,   -9
+.2byte    5,   -5, 	   2,  -11, 	  -6,   -7, 	   0,   -8
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    2,  -19, 	  -4,  -12, 	  -3,   -9, 	  -4,  -10
+.2byte    8,   -7, 	  -2,  -10, 	  -2,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    0,  -16, 	  -2,  -10, 	   4,  -10, 	  -3,   -8
+.2byte    5,  -10, 	  -6,   -9, 	   6,   -5, 	   0,   -8
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -16, 	   7,  -11, 	  -8,  -11, 	  -1,   -5
+.2byte   -1,  -14, 	   7,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -16, 	   1,  -10, 	  -5,  -10, 	   2,   -8
+.2byte   -6,  -10, 	   5,   -9, 	  -7,   -5, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -3,  -19, 	   3,  -12, 	   2,   -9, 	   3,  -10
+.2byte   -9,   -7, 	   1,  -10, 	   1,   -5, 	  -1,   -8
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -3,  -19, 	  -8,  -13, 	   5,  -10, 	   0,   -9
+.2byte   -6,   -5, 	  -3,  -11, 	   5,   -7, 	  -1,   -8
+.2byte   -4,   -6, 	  -6,   -4, 	   5,   -3, 	   0,   -8
+.2byte   -5,   -5, 	  -6,   -3, 	   5,   -2, 	  -1,   -7
+.2byte    0,   -6, 	  -5,  -11, 	   4,  -11, 	   0,   -9
+.2byte    2,   -7, 	   4,  -11, 	  -2,  -10, 	  -3,   -9
+.2byte    1,   -8, 	   0,  -12, 	   2,  -11, 	  -3,   -8
+.2byte    2,  -10, 	  -2,  -12, 	   4,  -12, 	  -1,   -6
+.2byte    0,  -11, 	   3,  -13, 	  -4,  -13, 	   0,   -6
+.2byte   -3,   -9, 	   1,  -11, 	  -5,  -11, 	   0,   -5
+.2byte   -2,   -8, 	  -1,  -12, 	  -3,  -11, 	   2,   -8
+.2byte   -3,   -7, 	  -5,  -11, 	   1,  -10, 	   2,   -9
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte   -1,  -21, 	  -9,  -12, 	   8,  -12, 	  -1,   -9
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    2,  -19, 	   7,  -13, 	  -6,  -10, 	  -1,   -9
+.2byte    5,   -5, 	   2,  -11, 	  -6,   -7, 	   0,   -8
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    3,  -19, 	  -3,  -12, 	  -2,   -9, 	  -3,  -10
+.2byte    8,   -7, 	  -2,  -10, 	  -2,   -5, 	   0,   -8
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    0,  -16, 	  -2,  -10, 	   4,  -10, 	  -3,   -8
+.2byte    5,  -10, 	  -6,   -9, 	   6,   -5, 	   0,   -8
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -16, 	   7,  -11, 	  -8,  -11, 	  -1,   -5
+.2byte   -1,  -14, 	   7,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -16, 	   1,  -10, 	  -5,  -10, 	   2,   -8
+.2byte   -6,  -10, 	   5,   -9, 	  -7,   -5, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -4,  -19, 	   2,  -12, 	   1,   -9, 	   2,  -10
+.2byte   -9,   -7, 	   1,  -10, 	   1,   -5, 	  -1,   -8
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -3,  -19, 	  -8,  -13, 	   5,  -10, 	   0,   -9
+.2byte   -6,   -5, 	  -3,  -11, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte   -6,   -5, 	  -3,  -11, 	   5,   -7, 	  -1,   -8
+.2byte   -9,   -7, 	   1,  -10, 	   1,   -5, 	  -1,   -8
+.2byte   -5,  -10, 	   6,   -9, 	  -6,   -5, 	   0,   -8
+.2byte   -1,  -14, 	   7,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte    4,  -10, 	  -7,   -9, 	   5,   -5, 	  -1,   -8
+.2byte    8,   -7, 	  -2,  -10, 	  -2,   -5, 	   0,   -8
+.2byte    5,   -5, 	   2,  -11, 	  -6,   -7, 	   0,   -8
+.2byte   -1,  -21, 	  -9,  -12, 	   8,  -12, 	  -1,   -9
+.2byte    1,  -19, 	   6,  -13, 	  -7,  -10, 	  -2,   -9
+.2byte    2,  -19, 	  -4,  -12, 	  -3,   -9, 	  -4,  -10
+.2byte    1,  -16, 	  -1,  -10, 	   5,  -10, 	  -2,   -8
+.2byte   -1,  -16, 	   7,  -11, 	  -8,  -11, 	  -1,   -5
+.2byte   -2,  -16, 	   0,  -10, 	  -6,  -10, 	   1,   -8
+.2byte   -3,  -19, 	   3,  -12, 	   2,   -9, 	   3,  -10
+.2byte   -2,  -19, 	  -7,  -13, 	   6,  -10, 	   1,   -9
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte   -1,  -21, 	  -9,  -12, 	   8,  -12, 	  -1,   -9
+.2byte    0,   -4, 	  -9,   -9, 	   8,   -9, 	   0,   -8
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte    2,  -19, 	   7,  -13, 	  -6,  -10, 	  -1,   -9
+.2byte    4,   -5, 	   1,  -11, 	  -7,   -7, 	  -1,   -8
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    2,  -19, 	  -4,  -12, 	  -3,   -9, 	  -4,  -10
+.2byte    6,   -7, 	  -4,  -10, 	  -4,   -5, 	  -2,   -8
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    0,  -16, 	  -2,  -10, 	   4,  -10, 	  -3,   -8
+.2byte    4,  -10, 	  -7,   -9, 	   5,   -5, 	  -1,   -8
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -16, 	   7,  -11, 	  -8,  -11, 	  -1,   -5
+.2byte   -1,  -14, 	   7,   -7, 	  -8,   -7, 	  -1,   -8
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte   -1,  -16, 	   1,  -10, 	  -5,  -10, 	   2,   -8
+.2byte   -5,  -10, 	   6,   -9, 	  -6,   -5, 	   0,   -8
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -3,  -19, 	   3,  -12, 	   2,   -9, 	   3,  -10
+.2byte   -7,   -7, 	   3,  -10, 	   3,   -5, 	   1,   -8
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -3,  -19, 	  -8,  -13, 	   5,  -10, 	   0,   -9
+.2byte   -5,   -5, 	  -2,  -11, 	   6,   -7, 	   0,   -8
+.2byte   -1,   -8, 	  -8,  -12, 	   4,   -7, 	   0,   -8
+.2byte   -5,   -8, 	  -2,  -12, 	   1,   -6, 	   1,   -9
+.2byte   -4,  -10, 	   2,  -13, 	  -5,   -7, 	   1,   -8
+.2byte   -4,  -10, 	   7,   -7, 	  -7,   -8, 	  -1,   -6
+.2byte   -1,  -11, 	   7,   -7, 	  -6,  -11, 	  -2,   -7
+.2byte    3,  -10, 	  -8,   -7, 	   6,   -8, 	   0,   -6
+.2byte    3,  -10, 	  -3,  -13, 	   4,   -7, 	  -2,   -8
+.2byte    4,   -8, 	   1,  -12, 	  -2,   -6, 	  -2,   -9
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte   -5,   -6, 	  -8,   -7, 	   3,   -5, 	  -1,   -8
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -4,  -10, 	   5,   -8, 	  -7,   -7, 	  -1,   -7
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte    3,  -10, 	  -6,   -8, 	   6,   -7, 	   0,   -7
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    4,   -6, 	   7,   -7, 	  -4,   -5, 	   0,   -8
+.2byte   -1,  -11, 	  -4,   -1, 	   6,  -10, 	  -1,   -5
+.2byte   -1,  -10, 	  -4,   -1, 	   6,  -10, 	   0,   -5
+.2byte    0,  -11, 	   3,   -1, 	  -7,  -10, 	   0,   -5
+.2byte    0,  -10, 	   3,   -1, 	  -7,  -10, 	  -1,   -5
+.2byte   -1,  -11, 	  -4,   -1, 	   6,  -10, 	  -1,   -5
+.2byte    1,   -9, 	  -1,   -7, 	   5,  -10, 	   0,   -5
+.2byte   11,   -6, 	   6,   -3, 	   7,   -8, 	   1,   -7
+.2byte    9,   -8, 	   3,   -5, 	   3,  -11, 	  -1,   -8
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -13, 	   7,  -10, 	  -8,  -10, 	  -1,   -8
+.2byte    0,  -11, 	   7,  -12, 	  -8,  -12, 	   0,   -8
+.2byte    0,   -5, 	  -9,   -8, 	   8,   -8, 	   0,   -7
+.2byte    0,  -11, 	  -9,  -12, 	   8,  -12, 	   0,   -6
+.2byte   -5,   -7, 	  -8,  -10, 	   7,   -5, 	   1,   -6
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -9, 	  -8,  -13, 	   8,   -9, 	   0,   -5
+.2byte    7,  -11, 	   7,   -7, 	  -7,  -10, 	   1,   -6
+.2byte    0,  -14, 	   7,  -15, 	  -8,   -7, 	   0,   -6
+.2byte    0,  -14, 	   7,  -15, 	  -8,   -7, 	   0,   -6
+.2byte   -1,   -7, 	  -7,   -7, 	   6,   -7, 	   0,   -5
+.2byte   -1,   -6, 	  -7,   -6, 	   6,   -6, 	   0,   -4
+.2byte    0,   -6, 	  -7,   -6, 	   6,   -6, 	   0,   -4
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -4,  -15, 	  -8,  -10, 	  -2,   -6, 	  -1,   -6
+.2byte   -1,  -15, 	  -5,  -12, 	   8,   -5, 	  -1,   -7
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -11, 	   6,   -7, 	  -7,   -7, 	  -1,   -5
+.2byte    0,   -8, 	   5,   -3, 	  -6,   -3, 	   0,   -4
+.2byte    0,   -6, 	  -9,   -7, 	   8,   -7, 	   0,   -8
+.2byte    0,  -11, 	  -9,  -12, 	   8,  -12, 	   0,   -6
+.2byte   -1,   -5, 	  -5,   -4, 	   4,   -4, 	   0,   -5
+.2byte   -7,   -9, 	  -5,   -7, 	  -2,   -5, 	  -1,   -8
+.2byte   -7,   -6, 	   0,  -14, 	   0,   -5, 	   1,   -7
+.2byte    6,   -9, 	   4,   -7, 	   1,   -5, 	   0,   -8
+.2byte    6,   -6, 	  -1,  -14, 	  -1,   -5, 	  -2,   -7
+.2byte    0,  -14, 	   7,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   -1,  -12, 	   7,  -10, 	  -8,  -10, 	  -1,   -4
+.2byte   -7,   -7, 	  -1,  -12, 	   1,   -6, 	   0,   -6
+.2byte   -4,   -8, 	  -2,  -12, 	   5,   -6, 	   0,   -7
+.2byte   -9,   -6, 	  -5,   -9, 	   1,   -5, 	  -2,   -7
+.2byte   -6,   -8, 	   2,  -12, 	   4,   -6, 	   1,   -7
+.2byte   -8,   -8, 	   3,  -10, 	   0,   -5, 	   1,   -7
+.2byte    6,   -7, 	   0,  -12, 	  -2,   -6, 	  -1,   -6
+.2byte    3,   -8, 	   1,  -12, 	  -6,   -6, 	  -1,   -7
+.2byte    8,   -6, 	   4,   -9, 	  -2,   -5, 	   1,   -7
+.2byte    5,   -8, 	  -3,  -12, 	  -5,   -6, 	  -2,   -7
+.2byte    7,   -8, 	  -4,  -10, 	  -1,   -5, 	  -2,   -7
+.2byte    4,   -9, 	   0,  -11, 	   4,   -7, 	  -1,   -5
+.2byte   -1,  -11, 	  -4,   -1, 	   6,  -10, 	  -1,   -5
+.2byte   -1,  -10, 	  -4,   -1, 	   6,  -10, 	   0,   -5
+.2byte    0,  -11, 	   3,   -1, 	  -7,  -10, 	   0,   -5
+.2byte    0,  -10, 	   3,   -1, 	  -7,  -10, 	  -1,   -5
+.2byte   -1,  -11, 	  -4,   -1, 	   6,  -10, 	  -1,   -5
+.2byte   -1,  -10, 	  -4,   -1, 	   6,  -10, 	   0,   -5
+.2byte    0,  -11, 	   3,   -1, 	  -7,  -10, 	   0,   -5
+.2byte    0,  -10, 	   3,   -1, 	  -7,  -10, 	  -1,   -5
+sTotodileAnimTable1:
+.4byte sTotodileAnims_1_1
+.4byte sTotodileAnims_1_2
+.4byte sTotodileAnims_1_3
+.4byte sTotodileAnims_1_4
+.4byte sTotodileAnims_1_5
+.4byte sTotodileAnims_1_6
+.4byte sTotodileAnims_1_7
+.4byte sTotodileAnims_1_8
+sTotodileAnimTable2:
+.4byte sTotodileAnims_2_1
+.4byte sTotodileAnims_2_2
+.4byte sTotodileAnims_2_3
+.4byte sTotodileAnims_2_4
+.4byte sTotodileAnims_2_5
+.4byte sTotodileAnims_2_6
+.4byte sTotodileAnims_2_7
+.4byte sTotodileAnims_2_8
+sTotodileAnimTable3:
+.4byte sTotodileAnims_3_1
+.4byte sTotodileAnims_3_2
+.4byte sTotodileAnims_3_3
+.4byte sTotodileAnims_3_4
+.4byte sTotodileAnims_3_5
+.4byte sTotodileAnims_3_6
+.4byte sTotodileAnims_3_7
+.4byte sTotodileAnims_3_8
+sTotodileAnimTable4:
+.4byte sTotodileAnims_4_1
+.4byte sTotodileAnims_4_2
+.4byte sTotodileAnims_4_3
+.4byte sTotodileAnims_4_4
+.4byte sTotodileAnims_4_5
+.4byte sTotodileAnims_4_6
+.4byte sTotodileAnims_4_7
+.4byte sTotodileAnims_4_8
+sTotodileAnimTable5:
+.4byte sTotodileAnims_5_1
+.4byte sTotodileAnims_5_2
+.4byte sTotodileAnims_5_3
+.4byte sTotodileAnims_5_4
+.4byte sTotodileAnims_5_5
+.4byte sTotodileAnims_5_6
+.4byte sTotodileAnims_5_7
+.4byte sTotodileAnims_5_8
+sTotodileAnimTable6:
+.4byte sTotodileAnims_6_1
+.4byte sTotodileAnims_6_1
+.4byte sTotodileAnims_6_1
+.4byte sTotodileAnims_6_1
+.4byte sTotodileAnims_6_1
+.4byte sTotodileAnims_6_1
+.4byte sTotodileAnims_6_1
+.4byte sTotodileAnims_6_1
+sTotodileAnimTable7:
+.4byte sTotodileAnims_7_1
+.4byte sTotodileAnims_7_2
+.4byte sTotodileAnims_7_3
+.4byte sTotodileAnims_7_4
+.4byte sTotodileAnims_7_5
+.4byte sTotodileAnims_7_6
+.4byte sTotodileAnims_7_7
+.4byte sTotodileAnims_7_8
+sTotodileAnimTable8:
+.4byte sTotodileAnims_8_1
+.4byte sTotodileAnims_8_2
+.4byte sTotodileAnims_8_3
+.4byte sTotodileAnims_8_4
+.4byte sTotodileAnims_8_5
+.4byte sTotodileAnims_8_6
+.4byte sTotodileAnims_8_7
+.4byte sTotodileAnims_8_8
+sTotodileAnimTable9:
+.4byte sTotodileAnims_9_1
+.4byte sTotodileAnims_9_2
+.4byte sTotodileAnims_9_3
+.4byte sTotodileAnims_9_4
+.4byte sTotodileAnims_9_5
+.4byte sTotodileAnims_9_6
+.4byte sTotodileAnims_9_7
+.4byte sTotodileAnims_9_8
+sTotodileAnimTable10:
+.4byte sTotodileAnims_10_1
+.4byte sTotodileAnims_10_2
+.4byte sTotodileAnims_10_3
+.4byte sTotodileAnims_10_4
+.4byte sTotodileAnims_10_5
+.4byte sTotodileAnims_10_6
+.4byte sTotodileAnims_10_7
+.4byte sTotodileAnims_10_8
+sTotodileAnimTable11:
+.4byte sTotodileAnims_11_1
+.4byte sTotodileAnims_11_2
+.4byte sTotodileAnims_11_3
+.4byte sTotodileAnims_11_4
+.4byte sTotodileAnims_11_5
+.4byte sTotodileAnims_11_6
+.4byte sTotodileAnims_11_7
+.4byte sTotodileAnims_11_8
+sTotodileAnimTable12:
+.4byte sTotodileAnims_12_1
+.4byte sTotodileAnims_12_2
+.4byte sTotodileAnims_12_3
+.4byte sTotodileAnims_12_4
+.4byte sTotodileAnims_12_5
+.4byte sTotodileAnims_12_6
+.4byte sTotodileAnims_12_7
+.4byte sTotodileAnims_12_8
+sTotodileAnimTable13:
+.4byte sTotodileAnims_13_1
+.4byte sTotodileAnims_13_2
+.4byte sTotodileAnims_13_3
+.4byte sTotodileAnims_13_4
+.4byte sTotodileAnims_13_5
+.4byte sTotodileAnims_13_6
+.4byte sTotodileAnims_13_7
+.4byte sTotodileAnims_13_8
+sTotodileAnimTable14:
+.4byte sTotodileAnims_14_1
+.4byte sTotodileAnims_14_2
+.4byte sTotodileAnims_14_3
+.4byte sTotodileAnims_14_4
+.4byte sTotodileAnims_14_5
+.4byte sTotodileAnims_14_6
+.4byte sTotodileAnims_14_7
+.4byte sTotodileAnims_14_8
+sTotodileAnimTable15:
+.4byte sTotodileAnims_15_1
+.4byte sTotodileAnims_15_2
+.4byte sTotodileAnims_15_3
+.4byte sTotodileAnims_15_4
+.4byte sTotodileAnims_15_5
+.4byte sTotodileAnims_15_6
+.4byte sTotodileAnims_15_7
+.4byte sTotodileAnims_15_8
+sTotodileAnimTable16:
+.4byte sTotodileAnims_16_1
+.4byte sTotodileAnims_16_2
+.4byte sTotodileAnims_16_3
+.4byte sTotodileAnims_16_4
+.4byte sTotodileAnims_16_5
+.4byte sTotodileAnims_16_6
+.4byte sTotodileAnims_16_7
+.4byte sTotodileAnims_16_8
+sTotodileAnimTable17:
+.4byte sTotodileAnims_17_1
+.4byte sTotodileAnims_17_2
+.4byte sTotodileAnims_17_3
+.4byte sTotodileAnims_17_4
+.4byte sTotodileAnims_17_5
+.4byte sTotodileAnims_17_6
+.4byte sTotodileAnims_17_7
+.4byte sTotodileAnims_17_8
+sTotodileAnimTable18:
+.4byte sTotodileAnims_18_1
+.4byte sTotodileAnims_18_2
+.4byte sTotodileAnims_18_3
+.4byte sTotodileAnims_18_4
+.4byte sTotodileAnims_18_5
+.4byte sTotodileAnims_18_6
+.4byte sTotodileAnims_18_7
+.4byte sTotodileAnims_18_8
+sTotodileAnimTable19:
+.4byte sTotodileAnims_19_1
+.4byte sTotodileAnims_19_2
+.4byte sTotodileAnims_19_3
+.4byte sTotodileAnims_19_4
+.4byte sTotodileAnims_19_5
+.4byte sTotodileAnims_19_6
+.4byte sTotodileAnims_19_7
+.4byte sTotodileAnims_19_8
+sTotodileAnimTable20:
+.4byte sTotodileAnims_20_1
+.4byte sTotodileAnims_20_2
+.4byte sTotodileAnims_20_3
+.4byte sTotodileAnims_20_4
+.4byte sTotodileAnims_20_5
+.4byte sTotodileAnims_20_6
+.4byte sTotodileAnims_20_7
+.4byte sTotodileAnims_20_8
+sTotodileAnimTable21:
+.4byte sTotodileAnims_21_1
+.4byte sTotodileAnims_21_2
+.4byte sTotodileAnims_21_3
+.4byte sTotodileAnims_21_4
+.4byte sTotodileAnims_21_5
+.4byte sTotodileAnims_21_6
+.4byte sTotodileAnims_21_7
+.4byte sTotodileAnims_21_8
+sTotodileAnimTable22:
+.4byte sTotodileAnims_22_1
+.4byte sTotodileAnims_22_2
+.4byte sTotodileAnims_22_3
+.4byte sTotodileAnims_22_4
+.4byte sTotodileAnims_22_5
+.4byte sTotodileAnims_22_6
+.4byte sTotodileAnims_22_7
+.4byte sTotodileAnims_22_8
+sTotodileAnimTable23:
+.4byte sTotodileAnims_23_1
+.4byte sTotodileAnims_23_2
+.4byte sTotodileAnims_23_3
+.4byte sTotodileAnims_23_4
+.4byte sTotodileAnims_23_5
+.4byte sTotodileAnims_23_6
+.4byte sTotodileAnims_23_7
+.4byte sTotodileAnims_23_8
+sTotodileAnimTable24:
+.4byte sTotodileAnims_24_1
+.4byte sTotodileAnims_24_2
+.4byte sTotodileAnims_24_3
+.4byte sTotodileAnims_24_4
+.4byte sTotodileAnims_24_5
+.4byte sTotodileAnims_24_6
+.4byte sTotodileAnims_24_7
+.4byte sTotodileAnims_24_8
+sTotodileAnimTable25:
+.4byte sTotodileAnims_25_1
+.4byte sTotodileAnims_25_2
+.4byte sTotodileAnims_25_3
+.4byte sTotodileAnims_25_4
+.4byte sTotodileAnims_25_5
+.4byte sTotodileAnims_25_6
+.4byte sTotodileAnims_25_7
+.4byte sTotodileAnims_25_8
+sTotodileAnimTable26:
+.4byte sTotodileAnims_26_1
+.4byte sTotodileAnims_26_2
+.4byte sTotodileAnims_26_3
+.4byte sTotodileAnims_26_4
+.4byte sTotodileAnims_26_5
+.4byte sTotodileAnims_26_6
+.4byte sTotodileAnims_26_7
+.4byte sTotodileAnims_26_8
+sTotodileAnimTable27:
+.4byte sTotodileAnims_27_1
+.4byte sTotodileAnims_27_1
+.4byte sTotodileAnims_27_1
+.4byte sTotodileAnims_27_1
+.4byte sTotodileAnims_27_1
+.4byte sTotodileAnims_27_1
+.4byte sTotodileAnims_27_1
+.4byte sTotodileAnims_27_1
+sTotodileAnimTable28:
+.4byte sTotodileAnims_28_1
+.4byte sTotodileAnims_28_2
+.4byte sTotodileAnims_28_3
+.4byte sTotodileAnims_28_4
+.4byte sTotodileAnims_28_5
+.4byte sTotodileAnims_28_6
+.4byte sTotodileAnims_28_7
+.4byte sTotodileAnims_28_8
+sAxAnimationsTotodile:
+.4byte sTotodileAnimTable1
+.4byte sTotodileAnimTable2
+.4byte sTotodileAnimTable3
+.4byte sTotodileAnimTable4
+.4byte sTotodileAnimTable5
+.4byte sTotodileAnimTable6
+.4byte sTotodileAnimTable7
+.4byte sTotodileAnimTable8
+.4byte sTotodileAnimTable9
+.4byte sTotodileAnimTable10
+.4byte sTotodileAnimTable11
+.4byte sTotodileAnimTable12
+.4byte sTotodileAnimTable13
+.4byte sTotodileAnimTable14
+.4byte sTotodileAnimTable15
+.4byte sTotodileAnimTable16
+.4byte sTotodileAnimTable17
+.4byte sTotodileAnimTable18
+.4byte sTotodileAnimTable19
+.4byte sTotodileAnimTable20
+.4byte sTotodileAnimTable21
+.4byte sTotodileAnimTable22
+.4byte sTotodileAnimTable23
+.4byte sTotodileAnimTable24
+.4byte sTotodileAnimTable25
+.4byte sTotodileAnimTable26
+.4byte sTotodileAnimTable27
+.4byte sTotodileAnimTable28
+sAxSpritesTotodile:
+.4byte sTotodileSprites1
+.4byte sTotodileSprites2
+.4byte sTotodileSprites3
+.4byte sTotodileSprites4
+.4byte sTotodileSprites5
+.4byte sTotodileSprites6
+.4byte sTotodileSprites7
+.4byte sTotodileSprites8
+.4byte sTotodileSprites9
+.4byte sTotodileSprites10
+.4byte sTotodileSprites11
+.4byte sTotodileSprites12
+.4byte sTotodileSprites13
+.4byte sTotodileSprites14
+.4byte sTotodileSprites15
+.4byte sTotodileSprites16
+.4byte sTotodileSprites17
+.4byte sTotodileSprites18
+.4byte sTotodileSprites19
+.4byte sTotodileSprites20
+.4byte sTotodileSprites21
+.4byte sTotodileSprites22
+.4byte sTotodileSprites23
+.4byte sTotodileSprites24
+.4byte sTotodileSprites25
+.4byte sTotodileSprites26
+.4byte sTotodileSprites27
+.4byte sTotodileSprites28
+.4byte sTotodileSprites29
+.4byte sTotodileSprites30
+.4byte sTotodileSprites31
+.4byte sTotodileSprites32
+.4byte sTotodileSprites33
+.4byte sTotodileSprites34
+.4byte sTotodileSprites35
+.4byte sTotodileSprites36
+.4byte sTotodileSprites37
+.4byte sTotodileSprites38
+.4byte sTotodileSprites39
+.4byte sTotodileSprites40
+.4byte sTotodileSprites41
+.4byte sTotodileSprites42
+.4byte sTotodileSprites43
+.4byte sTotodileSprites44
+.4byte sTotodileSprites45
+.4byte sTotodileSprites46
+.4byte sTotodileSprites47
+.4byte sTotodileSprites48
+.4byte sTotodileSprites49
+.4byte sTotodileSprites50
+.4byte sTotodileSprites51
+.4byte sTotodileSprites52
+.4byte sTotodileSprites53
+.4byte sTotodileSprites54
+.4byte sTotodileSprites55
+.4byte sTotodileSprites56
+.4byte sTotodileSprites57
+.4byte sTotodileSprites58
+.4byte sTotodileSprites59
+.4byte sTotodileSprites60
+.4byte sTotodileSprites61
+.4byte sTotodileSprites62
+.4byte sTotodileSprites63
+.4byte sTotodileSprites64
+.4byte sTotodileSprites65
+.4byte sTotodileSprites66
+.4byte sTotodileSprites67
+.4byte sTotodileSprites68
+.4byte sTotodileSprites69
+.4byte sTotodileSprites70
+.4byte sTotodileSprites71
+.4byte sTotodileSprites72
+.4byte sTotodileSprites73
+.4byte sTotodileSprites74
+.4byte sTotodileSprites75
+.4byte sTotodileSprites76
+.4byte sTotodileSprites77
+sAxMainTotodile:
+ax_main sAxPosesTotodile, sAxAnimationsTotodile, 28, sAxSpritesTotodile, sAxPositionsTotodile

--- a/data/ax/trapinch.inc
+++ b/data/ax/trapinch.inc
@@ -1,0 +1,2665 @@
+.global gAxTrapinch
+gAxTrapinch:
+ax_siro sAxMainTrapinch
+sTrapinchPose1:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose2:
+ax_pose 1, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose3:
+ax_pose 2, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose4:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose5:
+ax_pose 4, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose6:
+ax_pose 5, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose8:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose9:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose10:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose11:
+ax_pose 10, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose12:
+ax_pose 11, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose13:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose14:
+ax_pose 13, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose15:
+ax_pose 14, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose16:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose17:
+ax_pose 10, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose18:
+ax_pose 11, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose22:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose23:
+ax_pose 4, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose24:
+ax_pose 5, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose25:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose26:
+ax_pose 1, 0x01ee, 0x80f5, 0x4c00
+ax_pose_terminator
+sTrapinchPose27:
+ax_pose 2, 0x01ee, 0x80f3, 0x4c00
+ax_pose_terminator
+sTrapinchPose28:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose29:
+ax_pose 4, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose30:
+ax_pose 5, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose31:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose32:
+ax_pose 7, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose33:
+ax_pose 8, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose34:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose35:
+ax_pose 10, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose36:
+ax_pose 11, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose37:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose38:
+ax_pose 13, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose39:
+ax_pose 14, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose40:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose41:
+ax_pose 10, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose42:
+ax_pose 11, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose43:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose44:
+ax_pose 7, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose45:
+ax_pose 8, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose46:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose47:
+ax_pose 4, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose48:
+ax_pose 5, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose49:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose50:
+ax_pose 1, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose51:
+ax_pose 2, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose52:
+ax_pose 15, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose53:
+ax_pose 16, 0x01e7, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose54:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose55:
+ax_pose 4, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose56:
+ax_pose 5, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose57:
+ax_pose 17, 0x01e6, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose58:
+ax_pose 18, 0x01e6, 0x90f2, 0x4c00
+ax_pose_terminator
+sTrapinchPose59:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose60:
+ax_pose 7, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose61:
+ax_pose 8, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose62:
+ax_pose 19, 0x01e4, 0x90f6, 0x4c00
+ax_pose_terminator
+sTrapinchPose63:
+ax_pose 20, 0x01e4, 0x90f2, 0x4c00
+ax_pose_terminator
+sTrapinchPose64:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose65:
+ax_pose 10, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose66:
+ax_pose 11, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose67:
+ax_pose 21, 0x01e5, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose68:
+ax_pose 22, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sTrapinchPose69:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose70:
+ax_pose 13, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose71:
+ax_pose 14, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose72:
+ax_pose 23, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose73:
+ax_pose 24, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose74:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose75:
+ax_pose 10, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose76:
+ax_pose 11, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose77:
+ax_pose 21, 0x01e5, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose78:
+ax_pose 22, 0x01e6, 0x80ee, 0x4c00
+ax_pose_terminator
+sTrapinchPose79:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose80:
+ax_pose 7, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose81:
+ax_pose 8, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose82:
+ax_pose 19, 0x01e4, 0x80e9, 0x4c00
+ax_pose_terminator
+sTrapinchPose83:
+ax_pose 20, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sTrapinchPose84:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose85:
+ax_pose 4, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose86:
+ax_pose 5, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose87:
+ax_pose 17, 0x01e6, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose88:
+ax_pose 18, 0x01e6, 0x80ed, 0x4c00
+ax_pose_terminator
+sTrapinchPose89:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose90:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose91:
+ax_pose 26, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose92:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose93:
+ax_pose 27, 0x01e6, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose94:
+ax_pose 28, 0x01e6, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose95:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose96:
+ax_pose 29, 0x01e4, 0x90f6, 0x4c00
+ax_pose_terminator
+sTrapinchPose97:
+ax_pose 30, 0x01e4, 0x90f6, 0x4c00
+ax_pose_terminator
+sTrapinchPose98:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose99:
+ax_pose 31, 0x01e5, 0x90f5, 0x4c00
+ax_pose_terminator
+sTrapinchPose100:
+ax_pose 32, 0x01e5, 0x90f5, 0x4c00
+ax_pose_terminator
+sTrapinchPose101:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose102:
+ax_pose 33, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose103:
+ax_pose 34, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose104:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose105:
+ax_pose 31, 0x01e5, 0x80ea, 0x4c00
+ax_pose_terminator
+sTrapinchPose106:
+ax_pose 32, 0x01e5, 0x80ea, 0x4c00
+ax_pose_terminator
+sTrapinchPose107:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose108:
+ax_pose 29, 0x01e4, 0x80e9, 0x4c00
+ax_pose_terminator
+sTrapinchPose109:
+ax_pose 30, 0x01e4, 0x80e9, 0x4c00
+ax_pose_terminator
+sTrapinchPose110:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose111:
+ax_pose 27, 0x01e6, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose112:
+ax_pose 28, 0x01e6, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose113:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose114:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose115:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose116:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose117:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose118:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose119:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose120:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose121:
+ax_pose 35, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose122:
+ax_pose 36, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose123:
+ax_pose 37, 0x01e2, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose124:
+ax_pose 38, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sTrapinchPose125:
+ax_pose 39, 0x01e4, 0x90ee, 0x4c00
+ax_pose_terminator
+sTrapinchPose126:
+ax_pose 40, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sTrapinchPose127:
+ax_pose 41, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sTrapinchPose128:
+ax_pose 40, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sTrapinchPose129:
+ax_pose 39, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sTrapinchPose130:
+ax_pose 38, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose131:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose132:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose133:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose134:
+ax_pose 27, 0x01e6, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose135:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose136:
+ax_pose 29, 0x01e4, 0x90f6, 0x4c00
+ax_pose_terminator
+sTrapinchPose137:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose138:
+ax_pose 31, 0x01e5, 0x90f5, 0x4c00
+ax_pose_terminator
+sTrapinchPose139:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose140:
+ax_pose 33, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose141:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose142:
+ax_pose 31, 0x01e5, 0x80ea, 0x4c00
+ax_pose_terminator
+sTrapinchPose143:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose144:
+ax_pose 29, 0x01e4, 0x80e9, 0x4c00
+ax_pose_terminator
+sTrapinchPose145:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose146:
+ax_pose 27, 0x01e6, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose147:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose148:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose149:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose150:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose151:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose152:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose153:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose154:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose155:
+ax_pose 26, 0x01e8, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose156:
+ax_pose 28, 0x01e6, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose157:
+ax_pose 30, 0x01e4, 0x90f6, 0x4c00
+ax_pose_terminator
+sTrapinchPose158:
+ax_pose 32, 0x01e5, 0x90f5, 0x4c00
+ax_pose_terminator
+sTrapinchPose159:
+ax_pose 34, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose160:
+ax_pose 32, 0x01e5, 0x80ea, 0x4c00
+ax_pose_terminator
+sTrapinchPose161:
+ax_pose 30, 0x01e4, 0x80e9, 0x4c00
+ax_pose_terminator
+sTrapinchPose162:
+ax_pose 28, 0x01e6, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose163:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose164:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose165:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose166:
+ax_pose 27, 0x01e6, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose167:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose168:
+ax_pose 29, 0x01e4, 0x90f6, 0x4c00
+ax_pose_terminator
+sTrapinchPose169:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose170:
+ax_pose 31, 0x01e5, 0x90f5, 0x4c00
+ax_pose_terminator
+sTrapinchPose171:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose172:
+ax_pose 33, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose173:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose174:
+ax_pose 31, 0x01e5, 0x80ea, 0x4c00
+ax_pose_terminator
+sTrapinchPose175:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose176:
+ax_pose 29, 0x01e4, 0x80e9, 0x4c00
+ax_pose_terminator
+sTrapinchPose177:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose178:
+ax_pose 27, 0x01e6, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose179:
+ax_pose 25, 0x01e9, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose180:
+ax_pose 27, 0x01e6, 0x80eb, 0x4c00
+ax_pose_terminator
+sTrapinchPose181:
+ax_pose 29, 0x01e4, 0x80e9, 0x4c00
+ax_pose_terminator
+sTrapinchPose182:
+ax_pose 31, 0x01e5, 0x80ea, 0x4c00
+ax_pose_terminator
+sTrapinchPose183:
+ax_pose 33, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose184:
+ax_pose 31, 0x01e5, 0x90f5, 0x4c00
+ax_pose_terminator
+sTrapinchPose185:
+ax_pose 29, 0x01e4, 0x90f6, 0x4c00
+ax_pose_terminator
+sTrapinchPose186:
+ax_pose 27, 0x01e6, 0x90f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose187:
+ax_pose 0, 0x41f2, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose188:
+ax_pose 3, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose189:
+ax_pose 6, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose190:
+ax_pose 9, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sTrapinchPose191:
+ax_pose 12, 0x01ef, 0x80f4, 0x4c00
+ax_pose_terminator
+sTrapinchPose192:
+ax_pose 9, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose193:
+ax_pose 6, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sTrapinchPose194:
+ax_pose 3, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+.align 2
+sTrapinchAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 1, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 20, 0, 20,
+ax_anim 2, 0, 24, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTrapinchAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 20, 21, 20, 21,
+ax_anim 2, 1, 27, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 20, 21, 20, 21,
+ax_anim 2, 0, 27, 21, 20, 21, 20,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sTrapinchAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 6, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 1, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sTrapinchAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 6, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 33, 19, -22, 19, -22,
+ax_anim 2, 1, 33, 20, -21, 20, -21,
+ax_anim 2, 0, 33, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 20, -21, 20, -21,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sTrapinchAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 6, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -22, 0, -22,
+ax_anim 2, 1, 36, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -22, 0, -22,
+ax_anim 2, 0, 36, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sTrapinchAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 6, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 39, -19, -22, -19, -22,
+ax_anim 2, 1, 39, -20, -21, -20, -21,
+ax_anim 2, 0, 39, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -20, -21, -20, -21,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sTrapinchAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 6, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 1, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sTrapinchAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 6, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -20, 21, -20, 21,
+ax_anim 2, 1, 45, -21, 20, -21, 20,
+ax_anim 2, 0, 45, -20, 21, -20, 21,
+ax_anim 2, 0, 45, -21, 20, -21, 20,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_3_1:
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 51, 0, -3, 0, -3,
+ax_anim 6, 0, 51, 0, -4, 0, -4,
+ax_anim 1, 2, 52, 0, -7, 0, -1,
+ax_anim 2, 0, 52, 0, 3, 0, 9,
+ax_anim 2, 0, 52, 0, 14, 0, 18,
+ax_anim 2, 1, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 1, 20, 1, 20,
+ax_anim 2, 0, 48, 0, 20, 0, 20,
+ax_anim 2, 0, 48, 0, 12, 0, 12,
+ax_anim 2, 0, 48, 0, 4, 0, 4,
+ax_anim_terminator
+sTrapinchAnims_3_2:
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 2, 0, 56, -3, -3, -3, -3,
+ax_anim 6, 0, 56, -4, -4, -4, -4,
+ax_anim 1, 2, 57, 1, -5, 1, 1,
+ax_anim 2, 0, 57, 8, -1, 8, 8,
+ax_anim 2, 0, 57, 15, 10, 15, 16,
+ax_anim 2, 1, 53, 19, 20, 19, 20,
+ax_anim 2, 0, 53, 20, 19, 20, 19,
+ax_anim 2, 0, 53, 19, 20, 19, 20,
+ax_anim 2, 0, 53, 20, 19, 20, 19,
+ax_anim 2, 0, 53, 19, 20, 19, 20,
+ax_anim 2, 0, 53, 12, 12, 12, 12,
+ax_anim 2, 0, 53, 4, 4, 4, 4,
+ax_anim_terminator
+sTrapinchAnims_3_3:
+ax_anim 2, 0, 58, -2, 0, -2, 0,
+ax_anim 2, 0, 61, -3, 0, -3, 0,
+ax_anim 6, 0, 61, -4, 0, -4, 0,
+ax_anim 1, 2, 62, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 7, -6, 7, 0,
+ax_anim 2, 0, 62, 14, -3, 14, 0,
+ax_anim 2, 1, 58, 17, 0, 17, 0,
+ax_anim 2, 0, 58, 17, 1, 17, 1,
+ax_anim 2, 0, 58, 17, 0, 17, 0,
+ax_anim 2, 0, 58, 17, 1, 17, 1,
+ax_anim 2, 0, 58, 17, 0, 17, 0,
+ax_anim 2, 0, 58, 12, 0, 12, 0,
+ax_anim 2, 0, 58, 4, 0, 4, 0,
+ax_anim_terminator
+sTrapinchAnims_3_4:
+ax_anim 2, 0, 63, -2, 2, -2, 2,
+ax_anim 2, 0, 66, -3, 3, -3, 3,
+ax_anim 6, 0, 66, -4, 4, -4, 4,
+ax_anim 1, 2, 67, -1, -5, -1, 0,
+ax_anim 2, 0, 67, 4, -15, 4, -5,
+ax_anim 2, 0, 67, 12, -20, 12, -14,
+ax_anim 2, 1, 63, 20, -21, 20, -21,
+ax_anim 2, 0, 63, 21, -20, 21, -20,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 0, 63, 21, -20, 21, -20,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 0, 63, 12, -12, 12, -12,
+ax_anim 2, 0, 63, 4, -4, 4, -4,
+ax_anim_terminator
+sTrapinchAnims_3_5:
+ax_anim 2, 0, 68, 0, 2, 0, 2,
+ax_anim 2, 0, 71, 0, 3, 0, 3,
+ax_anim 6, 0, 71, 0, 4, 0, 4,
+ax_anim 1, 2, 72, 0, -5, 0, -1,
+ax_anim 2, 0, 72, 0, -15, 0, -8,
+ax_anim 2, 0, 72, 0, -20, 0, -16,
+ax_anim 2, 1, 68, 0, -21, 0, -21,
+ax_anim 2, 0, 68, 1, -21, 1, -21,
+ax_anim 2, 0, 68, 0, -21, 0, -21,
+ax_anim 2, 0, 68, 1, -21, 1, -21,
+ax_anim 2, 0, 68, 0, -21, 0, -21,
+ax_anim 2, 0, 68, 0, -12, 0, -12,
+ax_anim 2, 0, 68, 0, -4, 0, -4,
+ax_anim_terminator
+sTrapinchAnims_3_6:
+ax_anim 2, 0, 73, 2, 2, 2, 2,
+ax_anim 2, 0, 76, 3, 3, 3, 3,
+ax_anim 6, 0, 76, 4, 4, 4, 4,
+ax_anim 1, 2, 77, 1, -5, 1, 0,
+ax_anim 2, 0, 77, -4, -15, -4, -5,
+ax_anim 2, 0, 77, -12, -20, -12, -14,
+ax_anim 2, 1, 73, -20, -21, -20, -21,
+ax_anim 2, 0, 73, -21, -20, -21, -20,
+ax_anim 2, 0, 73, -20, -21, -20, -21,
+ax_anim 2, 0, 73, -21, -20, -21, -20,
+ax_anim 2, 0, 73, -20, -21, -20, -21,
+ax_anim 2, 0, 73, -12, -12, -12, -12,
+ax_anim 2, 0, 73, -4, -4, -4, -4,
+ax_anim_terminator
+sTrapinchAnims_3_7:
+ax_anim 2, 0, 78, 2, 0, 2, 0,
+ax_anim 2, 0, 81, 3, 0, 3, 0,
+ax_anim 6, 0, 81, 4, 0, 4, 0,
+ax_anim 1, 2, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 82, -7, -6, -7, 0,
+ax_anim 2, 0, 82, -14, -3, -14, 0,
+ax_anim 2, 1, 78, -17, 0, -17, 0,
+ax_anim 2, 0, 78, -17, 1, -17, 1,
+ax_anim 2, 0, 78, -17, 0, -17, 0,
+ax_anim 2, 0, 78, -17, 1, -17, 1,
+ax_anim 2, 0, 78, -17, 0, -17, 0,
+ax_anim 2, 0, 78, -12, 0, -12, 0,
+ax_anim 2, 0, 78, -4, 0, -4, 0,
+ax_anim_terminator
+sTrapinchAnims_3_8:
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 86, 3, -3, 3, -3,
+ax_anim 6, 0, 86, 4, -4, 4, -4,
+ax_anim 1, 2, 87, -1, -5, -1, 1,
+ax_anim 2, 0, 87, -8, -1, -8, 8,
+ax_anim 2, 0, 87, -15, 10, -15, 16,
+ax_anim 2, 1, 83, -19, 20, -19, 20,
+ax_anim 2, 0, 83, -20, 19, -20, 19,
+ax_anim 2, 0, 83, -19, 20, -19, 20,
+ax_anim 2, 0, 83, -20, 19, -20, 19,
+ax_anim 2, 0, 83, -19, 20, -19, 20,
+ax_anim 2, 0, 83, -12, 12, -12, 12,
+ax_anim 2, 0, 83, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_4_1:
+ax_anim 1, 0, 88, 1, 0, 1, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 1, -1, 1, -1,
+ax_anim 2, 0, 89, 0, -1, 0, -1,
+ax_anim 1, 0, 89, 1, -2, 1, -2,
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 1, 0, 89, 1, -2, 1, -2,
+ax_anim 6, 2, 89, 0, -2, 0, -2,
+ax_anim 1, 0, 90, 0, 2, 0, 2,
+ax_anim 1, 0, 90, 0, 6, 0, 6,
+ax_anim 2, 1, 90, 0, 8, 0, 8,
+ax_anim 2, 0, 90, 1, 8, 1, 8,
+ax_anim 2, 0, 90, 0, 8, 0, 8,
+ax_anim 2, 0, 90, 1, 8, 1, 8,
+ax_anim 2, 0, 90, 0, 8, 0, 8,
+ax_anim 2, 0, 88, 0, 4, 0, 4,
+ax_anim_terminator
+sTrapinchAnims_4_2:
+ax_anim 1, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -2, 0, -2,
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 1, 0, 92, -1, -3, -1, -3,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 1, 0, 92, -1, -3, -1, -3,
+ax_anim 6, 2, 92, -2, -2, -2, -2,
+ax_anim 1, 0, 93, 2, 2, 2, 2,
+ax_anim 1, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 1, 93, 8, 8, 8, 8,
+ax_anim 2, 0, 93, 9, 7, 9, 7,
+ax_anim 2, 0, 93, 8, 8, 8, 8,
+ax_anim 2, 0, 93, 9, 7, 9, 7,
+ax_anim 2, 0, 93, 8, 8, 8, 8,
+ax_anim 2, 0, 91, 4, 4, 4, 4,
+ax_anim_terminator
+sTrapinchAnims_4_3:
+ax_anim 1, 0, 94, 0, 1, 0, 1,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, -1, 1, -1, 1,
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 1, 0, 95, -2, 1, -2, 1,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 1, 0, 95, -2, 1, -2, 1,
+ax_anim 6, 2, 95, -2, 0, -2, 0,
+ax_anim 1, 0, 96, 2, 0, 2, 0,
+ax_anim 1, 0, 96, 6, 0, 6, 0,
+ax_anim 2, 1, 96, 8, 0, 8, 0,
+ax_anim 2, 0, 96, 8, 1, 8, 1,
+ax_anim 2, 0, 96, 8, 0, 8, 0,
+ax_anim 2, 0, 96, 8, 1, 8, 1,
+ax_anim 2, 0, 96, 8, 0, 8, 0,
+ax_anim 2, 0, 94, 4, 0, 4, 0,
+ax_anim_terminator
+sTrapinchAnims_4_4:
+ax_anim 1, 0, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 0, 2, 0, 2,
+ax_anim 2, 0, 98, -1, 1, -1, 1,
+ax_anim 1, 0, 98, -1, 3, -1, 3,
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 1, 0, 98, -1, 3, -1, 3,
+ax_anim 6, 2, 98, -2, 2, -2, 2,
+ax_anim 1, 0, 99, 2, -2, 2, -2,
+ax_anim 1, 0, 99, 6, -6, 6, -6,
+ax_anim 2, 1, 99, 8, -8, 8, -8,
+ax_anim 2, 0, 99, 9, -7, 9, -7,
+ax_anim 2, 0, 99, 8, -8, 8, -8,
+ax_anim 2, 0, 99, 9, -7, 9, -7,
+ax_anim 2, 0, 99, 8, -8, 8, -8,
+ax_anim 2, 0, 97, 4, -4, 4, -4,
+ax_anim_terminator
+sTrapinchAnims_4_5:
+ax_anim 1, 0, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 101, 1, 1, 1, 1,
+ax_anim 2, 0, 101, 0, 1, 0, 1,
+ax_anim 1, 0, 101, 1, 2, 1, 2,
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 1, 0, 101, 1, 2, 1, 2,
+ax_anim 6, 2, 101, 0, 2, 0, 2,
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 1, 0, 102, 0, -6, 0, -6,
+ax_anim 2, 1, 102, 0, -8, 0, -8,
+ax_anim 2, 0, 102, 1, -8, 1, -8,
+ax_anim 2, 0, 102, 0, -8, 0, -8,
+ax_anim 2, 0, 102, 1, -8, 1, -8,
+ax_anim 2, 0, 102, 0, -8, 0, -8,
+ax_anim 2, 0, 100, 0, -4, 0, -4,
+ax_anim_terminator
+sTrapinchAnims_4_6:
+ax_anim 1, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 104, 0, 2, 0, 2,
+ax_anim 2, 0, 104, 1, 1, 1, 1,
+ax_anim 1, 0, 104, 1, 3, 1, 3,
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 1, 0, 104, 1, 3, 1, 3,
+ax_anim 6, 2, 104, 2, 2, 2, 2,
+ax_anim 1, 0, 105, -2, -2, -2, -2,
+ax_anim 1, 0, 105, -6, -6, -6, -6,
+ax_anim 2, 1, 105, -8, -8, -8, -8,
+ax_anim 2, 0, 105, -9, -7, -9, -7,
+ax_anim 2, 0, 105, -8, -8, -8, -8,
+ax_anim 2, 0, 105, -9, -7, -9, -7,
+ax_anim 2, 0, 105, -8, -8, -8, -8,
+ax_anim 2, 0, 103, -4, -4, -4, -4,
+ax_anim_terminator
+sTrapinchAnims_4_7:
+ax_anim 1, 0, 106, 0, 1, 0, 1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 1, 1, 1, 1,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 1, 0, 107, 2, 1, 2, 1,
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 1, 0, 107, 2, 1, 2, 1,
+ax_anim 6, 2, 107, 2, 0, 2, 0,
+ax_anim 1, 0, 108, -2, 0, -2, 0,
+ax_anim 1, 0, 108, -6, 0, -6, 0,
+ax_anim 2, 1, 108, -8, 0, -8, 0,
+ax_anim 2, 0, 108, -8, 1, -8, 1,
+ax_anim 2, 0, 108, -8, 0, -8, 0,
+ax_anim 2, 0, 108, -8, 1, -8, 1,
+ax_anim 2, 0, 108, -8, 0, -8, 0,
+ax_anim 2, 0, 106, -4, 0, -4, 0,
+ax_anim_terminator
+sTrapinchAnims_4_8:
+ax_anim 1, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, -2,
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 1, 0, 110, 1, -3, 1, -3,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 1, 0, 110, 1, -3, 1, -3,
+ax_anim 6, 2, 110, 2, -2, 2, -2,
+ax_anim 1, 0, 111, -2, 2, -2, 2,
+ax_anim 1, 0, 111, -6, 6, -6, 6,
+ax_anim 2, 1, 111, -8, 8, -8, 8,
+ax_anim 2, 0, 111, -9, 7, -9, 7,
+ax_anim 2, 0, 111, -8, 8, -8, 8,
+ax_anim 2, 0, 111, -9, 7, -9, 7,
+ax_anim 2, 0, 111, -8, 8, -8, 8,
+ax_anim 2, 0, 109, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sTrapinchAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sTrapinchAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sTrapinchAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sTrapinchAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sTrapinchAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sTrapinchAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sTrapinchAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_8_2:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 10, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_8_3:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 10, 0, 134, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_8_4:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_8_5:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 10, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_8_6:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_8_7:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_8_8:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 7, 5, 7, 5,
+ax_anim 2, 0, 148, 8, 12, 8, 12,
+ax_anim 2, 0, 149, 7, 18, 7, 18,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 18, -7, 18,
+ax_anim 2, 0, 152, -8, 12, -8, 12,
+ax_anim 1, 0, 153, -7, 5, -7, 5,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 10, 1, 10, 1,
+ax_anim 2, 0, 147, 21, 7, 21, 7,
+ax_anim 2, 0, 148, 25, 14, 25, 14,
+ax_anim 3, 0, 149, 22, 19, 22, 19,
+ax_anim 2, 3, 150, 14, 20, 14, 20,
+ax_anim 2, 0, 151, 6, 16, 6, 16,
+ax_anim 1, 0, 152, 0, 8, 0, 8,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -3, 3, -3,
+ax_anim 2, 0, 146, 10, -5, 10, -5,
+ax_anim 2, 0, 147, 20, -4, 20, -4,
+ax_anim 3, 0, 148, 24, 0, 24, 0,
+ax_anim 2, 3, 149, 21, 4, 21, 4,
+ax_anim 2, 0, 150, 10, 6, 10, 6,
+ax_anim 1, 0, 151, 3, 5, 3, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 13, -24, 13, -24,
+ax_anim 3, 0, 147, 24, -23, 24, -23,
+ax_anim 2, 3, 148, 26, -15, 26, -15,
+ax_anim 2, 0, 149, 22, -6, 22, -6,
+ax_anim 1, 0, 150, 10, -1, 10, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -12, -12, -12, -12,
+ax_anim 2, 0, 153, -9, -21, -9, -21,
+ax_anim 3, 0, 146, 0, -25, 0, -25,
+ax_anim 2, 3, 147, 9, -21, 9, -21,
+ax_anim 2, 0, 148, 12, -12, 12, -12,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -13, -24, -13, -24,
+ax_anim 3, 0, 153, -24, -23, -24, -23,
+ax_anim 2, 3, 152, -26, -15, -26, -15,
+ax_anim 2, 0, 151, -22, -6, -22, -6,
+ax_anim 1, 0, 150, -10, -1, -10, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -3, -3, -3,
+ax_anim 2, 0, 146, -10, -5, -10, -5,
+ax_anim 2, 0, 153, -20, -4, -20, -4,
+ax_anim 3, 0, 152, -24, 0, -24, 0,
+ax_anim 2, 3, 151, -21, 4, -21, 4,
+ax_anim 2, 0, 150, -10, 6, -10, 6,
+ax_anim 1, 0, 149, -3, 5, -3, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -10, 1, -10, 1,
+ax_anim 2, 0, 153, -21, 7, -21, 7,
+ax_anim 2, 0, 152, -25, 14, -25, 14,
+ax_anim 3, 0, 151, -22, 19, -22, 19,
+ax_anim 2, 3, 150, -14, 20, -14, 20,
+ax_anim 2, 0, 149, -6, 16, -6, 16,
+ax_anim 1, 0, 148, 0, 8, 0, 8,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -18, 0, 0,
+ax_anim 4, 0, 163, 0, -19, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_11_2:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_11_3:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -18, 0, 0,
+ax_anim 4, 0, 167, 0, -19, 0, 0,
+ax_anim 4, 0, 166, 0, -23, 0, 0,
+ax_anim 3, 0, 166, 0, -22, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_11_4:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -18, 0, 0,
+ax_anim 4, 0, 169, 0, -19, 0, 0,
+ax_anim 4, 0, 168, 0, -22, 0, 0,
+ax_anim 3, 0, 168, 0, -21, 0, 0,
+ax_anim 2, 0, 168, 0, -17, 0, 0,
+ax_anim 1, 0, 168, 0, -11, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_11_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -19, 0, 0,
+ax_anim 4, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_11_6:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -18, 0, 0,
+ax_anim 4, 0, 173, 0, -19, 0, 0,
+ax_anim 4, 0, 172, 0, -22, 0, 0,
+ax_anim 3, 0, 172, 0, -21, 0, 0,
+ax_anim 2, 0, 172, 0, -17, 0, 0,
+ax_anim 1, 0, 172, 0, -11, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_11_7:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -18, 0, 0,
+ax_anim 4, 0, 175, 0, -19, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_11_8:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, -1,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTrapinchAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sTrapinchGfx1:
+.incbin "baserom.gba", 0x1364094, 0x100
+sTrapinchSprites1:
+ax_sprite sTrapinchGfx1, 0x100
+ax_sprite_terminator
+sTrapinchGfx2:
+.incbin "baserom.gba", 0x13641A4, 0x200
+sTrapinchSprites2:
+ax_sprite sTrapinchGfx2, 0x200
+ax_sprite_terminator
+sTrapinchGfx3:
+.incbin "baserom.gba", 0x13643B4, 0x200
+sTrapinchSprites3:
+ax_sprite sTrapinchGfx3, 0x200
+ax_sprite_terminator
+sTrapinchGfx4:
+.incbin "baserom.gba", 0x13645C4, 0x200
+sTrapinchSprites4:
+ax_sprite sTrapinchGfx4, 0x200
+ax_sprite_terminator
+sTrapinchGfx5:
+.incbin "baserom.gba", 0x13647D4, 0x200
+sTrapinchSprites5:
+ax_sprite sTrapinchGfx5, 0x200
+ax_sprite_terminator
+sTrapinchGfx6:
+.incbin "baserom.gba", 0x13649E4, 0x200
+sTrapinchSprites6:
+ax_sprite sTrapinchGfx6, 0x200
+ax_sprite_terminator
+sTrapinchGfx7:
+.incbin "baserom.gba", 0x1364BF4, 0x200
+sTrapinchSprites7:
+ax_sprite sTrapinchGfx7, 0x200
+ax_sprite_terminator
+sTrapinchGfx8:
+.incbin "baserom.gba", 0x1364E04, 0x200
+sTrapinchSprites8:
+ax_sprite sTrapinchGfx8, 0x200
+ax_sprite_terminator
+sTrapinchGfx9:
+.incbin "baserom.gba", 0x1365014, 0x200
+sTrapinchSprites9:
+ax_sprite sTrapinchGfx9, 0x200
+ax_sprite_terminator
+sTrapinchGfx10:
+.incbin "baserom.gba", 0x1365224, 0x200
+sTrapinchSprites10:
+ax_sprite sTrapinchGfx10, 0x200
+ax_sprite_terminator
+sTrapinchGfx11:
+.incbin "baserom.gba", 0x1365434, 0x200
+sTrapinchSprites11:
+ax_sprite sTrapinchGfx11, 0x200
+ax_sprite_terminator
+sTrapinchGfx12:
+.incbin "baserom.gba", 0x1365644, 0x200
+sTrapinchSprites12:
+ax_sprite sTrapinchGfx12, 0x200
+ax_sprite_terminator
+sTrapinchGfx13:
+.incbin "baserom.gba", 0x1365854, 0x200
+sTrapinchSprites13:
+ax_sprite sTrapinchGfx13, 0x200
+ax_sprite_terminator
+sTrapinchGfx14:
+.incbin "baserom.gba", 0x1365A64, 0x200
+sTrapinchSprites14:
+ax_sprite sTrapinchGfx14, 0x200
+ax_sprite_terminator
+sTrapinchGfx15:
+.incbin "baserom.gba", 0x1365C74, 0x200
+sTrapinchSprites15:
+ax_sprite sTrapinchGfx15, 0x200
+ax_sprite_terminator
+sTrapinchGfx16:
+.incbin "baserom.gba", 0x1365E84, 0x40
+sTrapinchGfx16_1:
+.incbin "baserom.gba", 0x1365EC4, 0x40
+sTrapinchGfx16_2:
+.incbin "baserom.gba", 0x1365F04, 0x40
+sTrapinchSprites16:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx16_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx16_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTrapinchGfx17:
+.incbin "baserom.gba", 0x1365F84, 0x60
+sTrapinchGfx17_1:
+.incbin "baserom.gba", 0x1365FE4, 0x160
+sTrapinchSprites17:
+ax_sprite sTrapinchGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx17_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTrapinchGfx18:
+.incbin "baserom.gba", 0x136616C, 0x40
+sTrapinchGfx18_1:
+.incbin "baserom.gba", 0x13661AC, 0x60
+sTrapinchGfx18_2:
+.incbin "baserom.gba", 0x136620C, 0x60
+sTrapinchGfx18_3:
+.incbin "baserom.gba", 0x136626C, 0x60
+sTrapinchSprites18:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx18_3, 0x60
+ax_sprite_terminator
+sTrapinchGfx19:
+.incbin "baserom.gba", 0x1366314, 0x60
+sTrapinchGfx19_1:
+.incbin "baserom.gba", 0x1366374, 0x60
+sTrapinchGfx19_2:
+.incbin "baserom.gba", 0x13663D4, 0x100
+sTrapinchSprites19:
+ax_sprite sTrapinchGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx19_2, 0x100
+ax_sprite_terminator
+sTrapinchGfx20:
+.incbin "baserom.gba", 0x1366504, 0x40
+sTrapinchGfx20_1:
+.incbin "baserom.gba", 0x1366544, 0x80
+sTrapinchGfx20_2:
+.incbin "baserom.gba", 0x13665C4, 0x60
+sTrapinchGfx20_3:
+.incbin "baserom.gba", 0x1366624, 0x60
+sTrapinchSprites20:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx20_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx20_3, 0x60
+ax_sprite_terminator
+sTrapinchGfx21:
+.incbin "baserom.gba", 0x13666CC, 0x60
+sTrapinchGfx21_1:
+.incbin "baserom.gba", 0x136672C, 0x60
+sTrapinchGfx21_2:
+.incbin "baserom.gba", 0x136678C, 0x100
+sTrapinchSprites21:
+ax_sprite sTrapinchGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx21_2, 0x100
+ax_sprite_terminator
+sTrapinchGfx22:
+.incbin "baserom.gba", 0x13668BC, 0x40
+sTrapinchGfx22_1:
+.incbin "baserom.gba", 0x13668FC, 0x60
+sTrapinchGfx22_2:
+.incbin "baserom.gba", 0x136695C, 0x60
+sTrapinchGfx22_3:
+.incbin "baserom.gba", 0x13669BC, 0x60
+sTrapinchSprites22:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx22_3, 0x60
+ax_sprite_terminator
+sTrapinchGfx23:
+.incbin "baserom.gba", 0x1366A64, 0x60
+sTrapinchGfx23_1:
+.incbin "baserom.gba", 0x1366AC4, 0x180
+sTrapinchSprites23:
+ax_sprite sTrapinchGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx23_1, 0x180
+ax_sprite_terminator
+sTrapinchGfx24:
+.incbin "baserom.gba", 0x1366C64, 0x40
+sTrapinchGfx24_1:
+.incbin "baserom.gba", 0x1366CA4, 0x60
+sTrapinchGfx24_2:
+.incbin "baserom.gba", 0x1366D04, 0x60
+sTrapinchGfx24_3:
+.incbin "baserom.gba", 0x1366D64, 0x40
+sTrapinchSprites24:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTrapinchGfx25:
+.incbin "baserom.gba", 0x1366DF4, 0x180
+sTrapinchGfx25_1:
+.incbin "baserom.gba", 0x1366F74, 0x40
+sTrapinchSprites25:
+ax_sprite sTrapinchGfx25, 0x180
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx25_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTrapinchGfx26:
+.incbin "baserom.gba", 0x1366FDC, 0x40
+sTrapinchGfx26_1:
+.incbin "baserom.gba", 0x136701C, 0x60
+sTrapinchGfx26_2:
+.incbin "baserom.gba", 0x136707C, 0x40
+sTrapinchGfx26_3:
+.incbin "baserom.gba", 0x13670BC, 0x40
+sTrapinchSprites26:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx26_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTrapinchGfx27:
+.incbin "baserom.gba", 0x136714C, 0x40
+sTrapinchGfx27_1:
+.incbin "baserom.gba", 0x136718C, 0x60
+sTrapinchGfx27_2:
+.incbin "baserom.gba", 0x13671EC, 0x40
+sTrapinchSprites27:
+ax_sprite 0, 0xa0
+ax_sprite sTrapinchGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx27_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTrapinchGfx28:
+.incbin "baserom.gba", 0x136726C, 0x40
+sTrapinchGfx28_1:
+.incbin "baserom.gba", 0x13672AC, 0x60
+sTrapinchGfx28_2:
+.incbin "baserom.gba", 0x136730C, 0x60
+sTrapinchGfx28_3:
+.incbin "baserom.gba", 0x136736C, 0x60
+sTrapinchSprites28:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx28_3, 0x60
+ax_sprite_terminator
+sTrapinchGfx29:
+.incbin "baserom.gba", 0x1367414, 0x60
+sTrapinchGfx29_1:
+.incbin "baserom.gba", 0x1367474, 0x100
+sTrapinchSprites29:
+ax_sprite 0, 0x80
+ax_sprite sTrapinchGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx29_1, 0x100
+ax_sprite_terminator
+sTrapinchGfx30:
+.incbin "baserom.gba", 0x136759C, 0x60
+sTrapinchGfx30_1:
+.incbin "baserom.gba", 0x13675FC, 0x60
+sTrapinchGfx30_2:
+.incbin "baserom.gba", 0x136765C, 0x40
+sTrapinchSprites30:
+ax_sprite 0, 0xa0
+ax_sprite sTrapinchGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx30_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx30_2, 0x40
+ax_sprite_terminator
+sTrapinchGfx31:
+.incbin "baserom.gba", 0x13676D4, 0x60
+sTrapinchGfx31_1:
+.incbin "baserom.gba", 0x1367734, 0x100
+sTrapinchSprites31:
+ax_sprite 0, 0x80
+ax_sprite sTrapinchGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx31_1, 0x100
+ax_sprite_terminator
+sTrapinchGfx32:
+.incbin "baserom.gba", 0x136785C, 0x40
+sTrapinchGfx32_1:
+.incbin "baserom.gba", 0x136789C, 0x60
+sTrapinchGfx32_2:
+.incbin "baserom.gba", 0x13678FC, 0x60
+sTrapinchGfx32_3:
+.incbin "baserom.gba", 0x136795C, 0x40
+sTrapinchSprites32:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx32_3, 0x40
+ax_sprite_terminator
+sTrapinchGfx33:
+.incbin "baserom.gba", 0x13679E4, 0x40
+sTrapinchGfx33_1:
+.incbin "baserom.gba", 0x1367A24, 0x60
+sTrapinchGfx33_2:
+.incbin "baserom.gba", 0x1367A84, 0x60
+sTrapinchGfx33_3:
+.incbin "baserom.gba", 0x1367AE4, 0x60
+sTrapinchSprites33:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx33_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx33_3, 0x60
+ax_sprite_terminator
+sTrapinchGfx34:
+.incbin "baserom.gba", 0x1367B8C, 0x60
+sTrapinchGfx34_1:
+.incbin "baserom.gba", 0x1367BEC, 0x60
+sTrapinchGfx34_2:
+.incbin "baserom.gba", 0x1367C4C, 0x40
+sTrapinchSprites34:
+ax_sprite 0, 0x80
+ax_sprite sTrapinchGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx34_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTrapinchGfx35:
+.incbin "baserom.gba", 0x1367CCC, 0x40
+sTrapinchGfx35_1:
+.incbin "baserom.gba", 0x1367D0C, 0x60
+sTrapinchGfx35_2:
+.incbin "baserom.gba", 0x1367D6C, 0x60
+sTrapinchGfx35_3:
+.incbin "baserom.gba", 0x1367DCC, 0x40
+sTrapinchSprites35:
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx35, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTrapinchGfx35_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTrapinchGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTrapinchGfx36:
+.incbin "baserom.gba", 0x1367E5C, 0x200
+sTrapinchSprites36:
+ax_sprite sTrapinchGfx36, 0x200
+ax_sprite_terminator
+sTrapinchGfx37:
+.incbin "baserom.gba", 0x136806C, 0x200
+sTrapinchSprites37:
+ax_sprite sTrapinchGfx37, 0x200
+ax_sprite_terminator
+sTrapinchGfx38:
+.incbin "baserom.gba", 0x136827C, 0x200
+sTrapinchSprites38:
+ax_sprite sTrapinchGfx38, 0x200
+ax_sprite_terminator
+sTrapinchGfx39:
+.incbin "baserom.gba", 0x136848C, 0x200
+sTrapinchSprites39:
+ax_sprite sTrapinchGfx39, 0x200
+ax_sprite_terminator
+sTrapinchGfx40:
+.incbin "baserom.gba", 0x136869C, 0x200
+sTrapinchSprites40:
+ax_sprite sTrapinchGfx40, 0x200
+ax_sprite_terminator
+sTrapinchGfx41:
+.incbin "baserom.gba", 0x13688AC, 0x200
+sTrapinchSprites41:
+ax_sprite sTrapinchGfx41, 0x200
+ax_sprite_terminator
+sTrapinchGfx42:
+.incbin "baserom.gba", 0x1368ABC, 0x200
+sTrapinchSprites42:
+ax_sprite sTrapinchGfx42, 0x200
+ax_sprite_terminator
+sAxPosesTrapinch:
+.4byte sTrapinchPose1
+.4byte sTrapinchPose2
+.4byte sTrapinchPose3
+.4byte sTrapinchPose4
+.4byte sTrapinchPose5
+.4byte sTrapinchPose6
+.4byte sTrapinchPose7
+.4byte sTrapinchPose8
+.4byte sTrapinchPose9
+.4byte sTrapinchPose10
+.4byte sTrapinchPose11
+.4byte sTrapinchPose12
+.4byte sTrapinchPose13
+.4byte sTrapinchPose14
+.4byte sTrapinchPose15
+.4byte sTrapinchPose16
+.4byte sTrapinchPose17
+.4byte sTrapinchPose18
+.4byte sTrapinchPose19
+.4byte sTrapinchPose20
+.4byte sTrapinchPose21
+.4byte sTrapinchPose22
+.4byte sTrapinchPose23
+.4byte sTrapinchPose24
+.4byte sTrapinchPose25
+.4byte sTrapinchPose26
+.4byte sTrapinchPose27
+.4byte sTrapinchPose28
+.4byte sTrapinchPose29
+.4byte sTrapinchPose30
+.4byte sTrapinchPose31
+.4byte sTrapinchPose32
+.4byte sTrapinchPose33
+.4byte sTrapinchPose34
+.4byte sTrapinchPose35
+.4byte sTrapinchPose36
+.4byte sTrapinchPose37
+.4byte sTrapinchPose38
+.4byte sTrapinchPose39
+.4byte sTrapinchPose40
+.4byte sTrapinchPose41
+.4byte sTrapinchPose42
+.4byte sTrapinchPose43
+.4byte sTrapinchPose44
+.4byte sTrapinchPose45
+.4byte sTrapinchPose46
+.4byte sTrapinchPose47
+.4byte sTrapinchPose48
+.4byte sTrapinchPose49
+.4byte sTrapinchPose50
+.4byte sTrapinchPose51
+.4byte sTrapinchPose52
+.4byte sTrapinchPose53
+.4byte sTrapinchPose54
+.4byte sTrapinchPose55
+.4byte sTrapinchPose56
+.4byte sTrapinchPose57
+.4byte sTrapinchPose58
+.4byte sTrapinchPose59
+.4byte sTrapinchPose60
+.4byte sTrapinchPose61
+.4byte sTrapinchPose62
+.4byte sTrapinchPose63
+.4byte sTrapinchPose64
+.4byte sTrapinchPose65
+.4byte sTrapinchPose66
+.4byte sTrapinchPose67
+.4byte sTrapinchPose68
+.4byte sTrapinchPose69
+.4byte sTrapinchPose70
+.4byte sTrapinchPose71
+.4byte sTrapinchPose72
+.4byte sTrapinchPose73
+.4byte sTrapinchPose74
+.4byte sTrapinchPose75
+.4byte sTrapinchPose76
+.4byte sTrapinchPose77
+.4byte sTrapinchPose78
+.4byte sTrapinchPose79
+.4byte sTrapinchPose80
+.4byte sTrapinchPose81
+.4byte sTrapinchPose82
+.4byte sTrapinchPose83
+.4byte sTrapinchPose84
+.4byte sTrapinchPose85
+.4byte sTrapinchPose86
+.4byte sTrapinchPose87
+.4byte sTrapinchPose88
+.4byte sTrapinchPose89
+.4byte sTrapinchPose90
+.4byte sTrapinchPose91
+.4byte sTrapinchPose92
+.4byte sTrapinchPose93
+.4byte sTrapinchPose94
+.4byte sTrapinchPose95
+.4byte sTrapinchPose96
+.4byte sTrapinchPose97
+.4byte sTrapinchPose98
+.4byte sTrapinchPose99
+.4byte sTrapinchPose100
+.4byte sTrapinchPose101
+.4byte sTrapinchPose102
+.4byte sTrapinchPose103
+.4byte sTrapinchPose104
+.4byte sTrapinchPose105
+.4byte sTrapinchPose106
+.4byte sTrapinchPose107
+.4byte sTrapinchPose108
+.4byte sTrapinchPose109
+.4byte sTrapinchPose110
+.4byte sTrapinchPose111
+.4byte sTrapinchPose112
+.4byte sTrapinchPose113
+.4byte sTrapinchPose114
+.4byte sTrapinchPose115
+.4byte sTrapinchPose116
+.4byte sTrapinchPose117
+.4byte sTrapinchPose118
+.4byte sTrapinchPose119
+.4byte sTrapinchPose120
+.4byte sTrapinchPose121
+.4byte sTrapinchPose122
+.4byte sTrapinchPose123
+.4byte sTrapinchPose124
+.4byte sTrapinchPose125
+.4byte sTrapinchPose126
+.4byte sTrapinchPose127
+.4byte sTrapinchPose128
+.4byte sTrapinchPose129
+.4byte sTrapinchPose130
+.4byte sTrapinchPose131
+.4byte sTrapinchPose132
+.4byte sTrapinchPose133
+.4byte sTrapinchPose134
+.4byte sTrapinchPose135
+.4byte sTrapinchPose136
+.4byte sTrapinchPose137
+.4byte sTrapinchPose138
+.4byte sTrapinchPose139
+.4byte sTrapinchPose140
+.4byte sTrapinchPose141
+.4byte sTrapinchPose142
+.4byte sTrapinchPose143
+.4byte sTrapinchPose144
+.4byte sTrapinchPose145
+.4byte sTrapinchPose146
+.4byte sTrapinchPose147
+.4byte sTrapinchPose148
+.4byte sTrapinchPose149
+.4byte sTrapinchPose150
+.4byte sTrapinchPose151
+.4byte sTrapinchPose152
+.4byte sTrapinchPose153
+.4byte sTrapinchPose154
+.4byte sTrapinchPose155
+.4byte sTrapinchPose156
+.4byte sTrapinchPose157
+.4byte sTrapinchPose158
+.4byte sTrapinchPose159
+.4byte sTrapinchPose160
+.4byte sTrapinchPose161
+.4byte sTrapinchPose162
+.4byte sTrapinchPose163
+.4byte sTrapinchPose164
+.4byte sTrapinchPose165
+.4byte sTrapinchPose166
+.4byte sTrapinchPose167
+.4byte sTrapinchPose168
+.4byte sTrapinchPose169
+.4byte sTrapinchPose170
+.4byte sTrapinchPose171
+.4byte sTrapinchPose172
+.4byte sTrapinchPose173
+.4byte sTrapinchPose174
+.4byte sTrapinchPose175
+.4byte sTrapinchPose176
+.4byte sTrapinchPose177
+.4byte sTrapinchPose178
+.4byte sTrapinchPose179
+.4byte sTrapinchPose180
+.4byte sTrapinchPose181
+.4byte sTrapinchPose182
+.4byte sTrapinchPose183
+.4byte sTrapinchPose184
+.4byte sTrapinchPose185
+.4byte sTrapinchPose186
+.4byte sTrapinchPose187
+.4byte sTrapinchPose188
+.4byte sTrapinchPose189
+.4byte sTrapinchPose190
+.4byte sTrapinchPose191
+.4byte sTrapinchPose192
+.4byte sTrapinchPose193
+.4byte sTrapinchPose194
+sAxPositionsTrapinch:
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte   -2,   -3, 	  -5,    2, 	   1,    1, 	  -2,   -2
+.2byte    0,   -4, 	  -3,    0, 	   3,    2, 	   0,   -2
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte    8,   -3, 	   5,    1, 	  -2,    1, 	   0,   -4
+.2byte    7,   -5, 	   2,   -1, 	   0,    2, 	  -1,   -4
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte   10,   -6, 	   0,   -1, 	  -1,    1, 	  -1,   -3
+.2byte   12,   -7, 	  -1,   -1, 	   2,    1, 	  -2,   -3
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte    7,   -8, 	  -3,   -3, 	   2,    1, 	  -1,   -3
+.2byte    8,   -7, 	  -2,   -2, 	   4,    0, 	  -1,   -3
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,   -9, 	   4,   -3, 	  -6,   -1, 	  -1,   -4
+.2byte   -2,   -9, 	   4,   -1, 	  -6,   -3, 	  -1,   -4
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte   -9,   -8, 	   1,   -3, 	  -4,    1, 	  -1,   -3
+.2byte  -10,   -7, 	   0,   -2, 	  -6,    0, 	  -1,   -3
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte  -12,   -6, 	  -2,   -1, 	  -1,    1, 	  -1,   -3
+.2byte  -14,   -7, 	  -1,   -1, 	  -4,    1, 	   0,   -3
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -10,   -3, 	  -7,    1, 	   0,    1, 	  -2,   -4
+.2byte   -9,   -5, 	  -4,   -1, 	  -2,    2, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte   -1,   -4, 	  -4,    1, 	   2,    0, 	  -1,   -3
+.2byte   -1,   -5, 	  -4,   -1, 	   2,    1, 	  -1,   -3
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte    8,   -4, 	   5,    0, 	  -2,    0, 	   0,   -5
+.2byte    7,   -6, 	   2,   -2, 	   0,    1, 	  -1,   -5
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte   10,   -7, 	   0,   -2, 	  -1,    0, 	  -1,   -4
+.2byte   12,   -8, 	  -1,   -2, 	   2,    0, 	  -2,   -4
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte    7,   -9, 	  -3,   -4, 	   2,    0, 	  -1,   -4
+.2byte    8,   -8, 	  -2,   -3, 	   4,   -1, 	  -1,   -4
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,  -10, 	   4,   -4, 	  -6,   -2, 	  -1,   -5
+.2byte   -2,  -10, 	   4,   -2, 	  -6,   -4, 	  -1,   -5
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte   -9,   -9, 	   1,   -4, 	  -4,    0, 	  -1,   -4
+.2byte  -10,   -8, 	   0,   -3, 	  -6,   -1, 	  -1,   -4
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte  -12,   -7, 	  -2,   -2, 	  -1,    0, 	  -1,   -4
+.2byte  -14,   -8, 	  -1,   -2, 	  -4,    0, 	   0,   -4
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -10,   -4, 	  -7,    0, 	   0,    0, 	  -2,   -5
+.2byte   -9,   -6, 	  -4,   -2, 	  -2,    1, 	  -1,   -5
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte   -2,   -3, 	  -5,    2, 	   1,    1, 	  -2,   -2
+.2byte    0,   -4, 	  -3,    0, 	   3,    2, 	   0,   -2
+.2byte   -1,   -7, 	  -4,   -4, 	   2,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -5,   -4, 	   4,   -4, 	  -1,   -5
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte    8,   -3, 	   5,    1, 	  -2,    1, 	   0,   -4
+.2byte    7,   -5, 	   2,   -1, 	   0,    2, 	  -1,   -4
+.2byte    4,   -8, 	   2,   -3, 	  -1,    0, 	  -1,   -6
+.2byte    6,   -8, 	   2,   -2, 	  -6,    1, 	   1,   -5
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte   10,   -6, 	   0,   -1, 	  -1,    1, 	  -1,   -3
+.2byte   12,   -7, 	  -1,   -1, 	   2,    1, 	  -2,   -3
+.2byte    7,   -7, 	  -1,   -1, 	   0,    0, 	  -2,   -5
+.2byte    6,   -9, 	  -2,   -1, 	  -4,    0, 	  -3,   -5
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte    7,   -8, 	  -3,   -3, 	   2,    1, 	  -1,   -3
+.2byte    8,   -7, 	  -2,   -2, 	   4,    0, 	  -1,   -3
+.2byte    5,   -8, 	  -4,   -3, 	   3,    0, 	  -2,   -3
+.2byte    5,   -8, 	  -6,   -1, 	   0,    2, 	  -3,   -3
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    0,   -9, 	   4,   -3, 	  -6,   -1, 	  -1,   -4
+.2byte   -2,   -9, 	   4,   -1, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -11, 	   4,   -3, 	  -6,   -3, 	  -1,   -6
+.2byte   -1,  -10, 	   4,   -1, 	  -6,   -1, 	  -1,   -5
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte   -9,   -8, 	   1,   -3, 	  -4,    1, 	  -1,   -3
+.2byte  -10,   -7, 	   0,   -2, 	  -6,    0, 	  -1,   -3
+.2byte   -7,   -8, 	   2,   -3, 	  -5,    0, 	   0,   -3
+.2byte   -7,   -8, 	   4,   -1, 	  -2,    2, 	   1,   -3
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte  -12,   -6, 	  -2,   -1, 	  -1,    1, 	  -1,   -3
+.2byte  -14,   -7, 	  -1,   -1, 	  -4,    1, 	   0,   -3
+.2byte   -9,   -7, 	  -1,   -1, 	  -2,    0, 	   0,   -5
+.2byte   -8,   -9, 	   0,   -1, 	   2,    0, 	   1,   -5
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -10,   -3, 	  -7,    1, 	   0,    1, 	  -2,   -4
+.2byte   -9,   -5, 	  -4,   -1, 	  -2,    2, 	  -1,   -4
+.2byte   -6,   -8, 	  -4,   -3, 	  -1,    0, 	  -1,   -6
+.2byte   -8,   -8, 	  -4,   -2, 	   4,    1, 	  -3,   -5
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte   -1,   -8, 	  -5,    0, 	   3,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte    5,  -10, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte    8,   -1, 	   4,   -1, 	  -2,    0, 	   2,   -4
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte   10,  -14, 	   2,   -2, 	   0,    0, 	  -3,   -4
+.2byte   12,   -5, 	   2,   -2, 	   0,    0, 	  -1,   -5
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte    9,  -13, 	  -2,   -3, 	   3,    0, 	  -2,   -4
+.2byte   10,   -9, 	  -2,   -3, 	   3,    0, 	   0,   -5
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,  -11, 	   4,   -1, 	  -6,   -1, 	  -1,   -6
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte  -11,  -13, 	   0,   -3, 	  -5,    0, 	   0,   -4
+.2byte  -12,   -9, 	   0,   -3, 	  -5,    0, 	  -2,   -5
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte  -12,  -14, 	  -4,   -2, 	  -2,    0, 	   1,   -4
+.2byte  -14,   -5, 	  -4,   -2, 	  -2,    0, 	  -1,   -5
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -7,  -10, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -10,   -1, 	  -6,   -1, 	   0,    0, 	  -4,   -4
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -9,   -2, 	  -5,   -1, 	  -1,    1, 	  -1,   -4
+.2byte   -9,   -3, 	  -6,   -2, 	  -1,    1, 	   0,   -5
+.2byte    0,   -9, 	  -6,   -6, 	   6,   -6, 	   0,   -7
+.2byte    1,   -8, 	   4,   -5, 	  -3,   -5, 	  -1,   -5
+.2byte    8,  -11, 	  -1,   -6, 	   0,   -4, 	  -3,   -6
+.2byte    5,  -12, 	  -2,   -7, 	   2,   -4, 	  -3,   -5
+.2byte    0,  -11, 	   5,   -5, 	  -5,   -5, 	   0,   -5
+.2byte   -6,  -12, 	   1,   -7, 	  -3,   -4, 	   2,   -5
+.2byte   -9,  -11, 	   0,   -6, 	  -1,   -4, 	   2,   -6
+.2byte   -2,   -8, 	  -5,   -5, 	   2,   -5, 	   0,   -5
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte   -1,   -8, 	  -5,    0, 	   3,    0, 	  -1,   -5
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte    5,  -10, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte   10,  -14, 	   2,   -2, 	   0,    0, 	  -3,   -4
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte    9,  -13, 	  -2,   -3, 	   3,    0, 	  -2,   -4
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte  -11,  -13, 	   0,   -3, 	  -5,    0, 	   0,   -4
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte  -12,  -14, 	  -4,   -2, 	  -2,    0, 	   1,   -4
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -7,  -10, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte    8,   -1, 	   4,   -1, 	  -2,    0, 	   2,   -4
+.2byte   12,   -5, 	   2,   -2, 	   0,    0, 	  -1,   -5
+.2byte   10,   -9, 	  -2,   -3, 	   3,    0, 	   0,   -5
+.2byte   -1,  -11, 	   4,   -1, 	  -6,   -1, 	  -1,   -6
+.2byte  -12,   -9, 	   0,   -3, 	  -5,    0, 	  -2,   -5
+.2byte  -14,   -5, 	  -4,   -2, 	  -2,    0, 	  -1,   -5
+.2byte  -10,   -1, 	  -6,   -1, 	   0,    0, 	  -4,   -4
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte   -1,   -8, 	  -5,    0, 	   3,    0, 	  -1,   -5
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte    5,  -10, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte   10,  -14, 	   2,   -2, 	   0,    0, 	  -3,   -4
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte    9,  -13, 	  -2,   -3, 	   3,    0, 	  -2,   -4
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte  -11,  -13, 	   0,   -3, 	  -5,    0, 	   0,   -4
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte  -12,  -14, 	  -4,   -2, 	  -2,    0, 	   1,   -4
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -7,  -10, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -1,   -8, 	  -5,    0, 	   3,    0, 	  -1,   -5
+.2byte   -7,  -10, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -12,  -14, 	  -4,   -2, 	  -2,    0, 	   1,   -4
+.2byte  -11,  -13, 	   0,   -3, 	  -5,    0, 	   0,   -4
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    9,  -13, 	  -2,   -3, 	   3,    0, 	  -2,   -4
+.2byte   10,  -14, 	   2,   -2, 	   0,    0, 	  -3,   -4
+.2byte    5,  -10, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+.2byte   -1,   -5, 	  -5,    0, 	   3,    0, 	  -1,   -3
+.2byte  -10,   -6, 	  -6,   -1, 	  -1,    0, 	  -1,   -5
+.2byte  -14,   -8, 	  -4,   -2, 	  -2,    0, 	  -1,   -4
+.2byte   -9,  -10, 	   2,   -4, 	  -5,    0, 	  -1,   -4
+.2byte   -1,  -10, 	   4,   -2, 	  -6,   -2, 	  -1,   -5
+.2byte    7,  -10, 	  -4,   -4, 	   3,    0, 	  -1,   -4
+.2byte   12,   -8, 	   2,   -2, 	   0,    0, 	  -1,   -4
+.2byte    8,   -6, 	   4,   -1, 	  -1,    0, 	  -1,   -5
+sTrapinchAnimTable1:
+.4byte sTrapinchAnims_1_1
+.4byte sTrapinchAnims_1_2
+.4byte sTrapinchAnims_1_3
+.4byte sTrapinchAnims_1_4
+.4byte sTrapinchAnims_1_5
+.4byte sTrapinchAnims_1_6
+.4byte sTrapinchAnims_1_7
+.4byte sTrapinchAnims_1_8
+sTrapinchAnimTable2:
+.4byte sTrapinchAnims_2_1
+.4byte sTrapinchAnims_2_2
+.4byte sTrapinchAnims_2_3
+.4byte sTrapinchAnims_2_4
+.4byte sTrapinchAnims_2_5
+.4byte sTrapinchAnims_2_6
+.4byte sTrapinchAnims_2_7
+.4byte sTrapinchAnims_2_8
+sTrapinchAnimTable3:
+.4byte sTrapinchAnims_3_1
+.4byte sTrapinchAnims_3_2
+.4byte sTrapinchAnims_3_3
+.4byte sTrapinchAnims_3_4
+.4byte sTrapinchAnims_3_5
+.4byte sTrapinchAnims_3_6
+.4byte sTrapinchAnims_3_7
+.4byte sTrapinchAnims_3_8
+sTrapinchAnimTable4:
+.4byte sTrapinchAnims_4_1
+.4byte sTrapinchAnims_4_2
+.4byte sTrapinchAnims_4_3
+.4byte sTrapinchAnims_4_4
+.4byte sTrapinchAnims_4_5
+.4byte sTrapinchAnims_4_6
+.4byte sTrapinchAnims_4_7
+.4byte sTrapinchAnims_4_8
+sTrapinchAnimTable5:
+.4byte sTrapinchAnims_5_1
+.4byte sTrapinchAnims_5_2
+.4byte sTrapinchAnims_5_3
+.4byte sTrapinchAnims_5_4
+.4byte sTrapinchAnims_5_5
+.4byte sTrapinchAnims_5_6
+.4byte sTrapinchAnims_5_7
+.4byte sTrapinchAnims_5_8
+sTrapinchAnimTable6:
+.4byte sTrapinchAnims_6_1
+.4byte sTrapinchAnims_6_1
+.4byte sTrapinchAnims_6_1
+.4byte sTrapinchAnims_6_1
+.4byte sTrapinchAnims_6_1
+.4byte sTrapinchAnims_6_1
+.4byte sTrapinchAnims_6_1
+.4byte sTrapinchAnims_6_1
+sTrapinchAnimTable7:
+.4byte sTrapinchAnims_7_1
+.4byte sTrapinchAnims_7_2
+.4byte sTrapinchAnims_7_3
+.4byte sTrapinchAnims_7_4
+.4byte sTrapinchAnims_7_5
+.4byte sTrapinchAnims_7_6
+.4byte sTrapinchAnims_7_7
+.4byte sTrapinchAnims_7_8
+sTrapinchAnimTable8:
+.4byte sTrapinchAnims_8_1
+.4byte sTrapinchAnims_8_2
+.4byte sTrapinchAnims_8_3
+.4byte sTrapinchAnims_8_4
+.4byte sTrapinchAnims_8_5
+.4byte sTrapinchAnims_8_6
+.4byte sTrapinchAnims_8_7
+.4byte sTrapinchAnims_8_8
+sTrapinchAnimTable9:
+.4byte sTrapinchAnims_9_1
+.4byte sTrapinchAnims_9_2
+.4byte sTrapinchAnims_9_3
+.4byte sTrapinchAnims_9_4
+.4byte sTrapinchAnims_9_5
+.4byte sTrapinchAnims_9_6
+.4byte sTrapinchAnims_9_7
+.4byte sTrapinchAnims_9_8
+sTrapinchAnimTable10:
+.4byte sTrapinchAnims_10_1
+.4byte sTrapinchAnims_10_2
+.4byte sTrapinchAnims_10_3
+.4byte sTrapinchAnims_10_4
+.4byte sTrapinchAnims_10_5
+.4byte sTrapinchAnims_10_6
+.4byte sTrapinchAnims_10_7
+.4byte sTrapinchAnims_10_8
+sTrapinchAnimTable11:
+.4byte sTrapinchAnims_11_1
+.4byte sTrapinchAnims_11_2
+.4byte sTrapinchAnims_11_3
+.4byte sTrapinchAnims_11_4
+.4byte sTrapinchAnims_11_5
+.4byte sTrapinchAnims_11_6
+.4byte sTrapinchAnims_11_7
+.4byte sTrapinchAnims_11_8
+sTrapinchAnimTable12:
+.4byte sTrapinchAnims_12_1
+.4byte sTrapinchAnims_12_2
+.4byte sTrapinchAnims_12_3
+.4byte sTrapinchAnims_12_4
+.4byte sTrapinchAnims_12_5
+.4byte sTrapinchAnims_12_6
+.4byte sTrapinchAnims_12_7
+.4byte sTrapinchAnims_12_8
+sTrapinchAnimTable13:
+.4byte sTrapinchAnims_13_1
+.4byte sTrapinchAnims_13_2
+.4byte sTrapinchAnims_13_3
+.4byte sTrapinchAnims_13_4
+.4byte sTrapinchAnims_13_5
+.4byte sTrapinchAnims_13_6
+.4byte sTrapinchAnims_13_7
+.4byte sTrapinchAnims_13_8
+sAxAnimationsTrapinch:
+.4byte sTrapinchAnimTable1
+.4byte sTrapinchAnimTable2
+.4byte sTrapinchAnimTable3
+.4byte sTrapinchAnimTable4
+.4byte sTrapinchAnimTable5
+.4byte sTrapinchAnimTable6
+.4byte sTrapinchAnimTable7
+.4byte sTrapinchAnimTable8
+.4byte sTrapinchAnimTable9
+.4byte sTrapinchAnimTable10
+.4byte sTrapinchAnimTable11
+.4byte sTrapinchAnimTable12
+.4byte sTrapinchAnimTable13
+sAxSpritesTrapinch:
+.4byte sTrapinchSprites1
+.4byte sTrapinchSprites2
+.4byte sTrapinchSprites3
+.4byte sTrapinchSprites4
+.4byte sTrapinchSprites5
+.4byte sTrapinchSprites6
+.4byte sTrapinchSprites7
+.4byte sTrapinchSprites8
+.4byte sTrapinchSprites9
+.4byte sTrapinchSprites10
+.4byte sTrapinchSprites11
+.4byte sTrapinchSprites12
+.4byte sTrapinchSprites13
+.4byte sTrapinchSprites14
+.4byte sTrapinchSprites15
+.4byte sTrapinchSprites16
+.4byte sTrapinchSprites17
+.4byte sTrapinchSprites18
+.4byte sTrapinchSprites19
+.4byte sTrapinchSprites20
+.4byte sTrapinchSprites21
+.4byte sTrapinchSprites22
+.4byte sTrapinchSprites23
+.4byte sTrapinchSprites24
+.4byte sTrapinchSprites25
+.4byte sTrapinchSprites26
+.4byte sTrapinchSprites27
+.4byte sTrapinchSprites28
+.4byte sTrapinchSprites29
+.4byte sTrapinchSprites30
+.4byte sTrapinchSprites31
+.4byte sTrapinchSprites32
+.4byte sTrapinchSprites33
+.4byte sTrapinchSprites34
+.4byte sTrapinchSprites35
+.4byte sTrapinchSprites36
+.4byte sTrapinchSprites37
+.4byte sTrapinchSprites38
+.4byte sTrapinchSprites39
+.4byte sTrapinchSprites40
+.4byte sTrapinchSprites41
+.4byte sTrapinchSprites42
+sAxMainTrapinch:
+ax_main sAxPosesTrapinch, sAxAnimationsTrapinch, 13, sAxSpritesTrapinch, sAxPositionsTrapinch

--- a/data/ax/treecko.inc
+++ b/data/ax/treecko.inc
@@ -1,0 +1,4154 @@
+.global gAxTreecko
+gAxTreecko:
+ax_siro sAxMainTreecko
+sTreeckoPose1:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose2:
+ax_pose 1, 0x81ee, 0x80f7, 0x3c00
+ax_pose_terminator
+sTreeckoPose3:
+ax_pose 2, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose4:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose5:
+ax_pose 4, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose6:
+ax_pose 5, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose7:
+ax_pose 6, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sTreeckoPose8:
+ax_pose 7, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sTreeckoPose9:
+ax_pose 8, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sTreeckoPose10:
+ax_pose 9, 0x01ee, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose11:
+ax_pose 10, 0x01ee, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose12:
+ax_pose 11, 0x01ee, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose13:
+ax_pose 12, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose14:
+ax_pose 13, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose15:
+ax_pose 14, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose16:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose17:
+ax_pose 10, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose18:
+ax_pose 11, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose19:
+ax_pose 6, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose20:
+ax_pose 7, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose21:
+ax_pose 8, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose22:
+ax_pose 3, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose23:
+ax_pose 4, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose24:
+ax_pose 5, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose25:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose26:
+ax_pose 1, 0x81ee, 0x80f7, 0x3c00
+ax_pose_terminator
+sTreeckoPose27:
+ax_pose 2, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose28:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose29:
+ax_pose 4, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose30:
+ax_pose 5, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose31:
+ax_pose 6, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sTreeckoPose32:
+ax_pose 7, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sTreeckoPose33:
+ax_pose 8, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sTreeckoPose34:
+ax_pose 9, 0x01ee, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose35:
+ax_pose 10, 0x01ee, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose36:
+ax_pose 11, 0x01ee, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose37:
+ax_pose 12, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose38:
+ax_pose 13, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose39:
+ax_pose 14, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose40:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose41:
+ax_pose 10, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose42:
+ax_pose 11, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose43:
+ax_pose 6, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose44:
+ax_pose 7, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose45:
+ax_pose 8, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose46:
+ax_pose 3, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose47:
+ax_pose 4, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose48:
+ax_pose 5, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose49:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose50:
+ax_pose 16, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose51:
+ax_pose 17, 0x81eb, 0x80f4, 0x3c00
+ax_pose 18, 0x01eb, 0x80f4, 0x3c08
+ax_pose_terminator
+sTreeckoPose52:
+ax_pose 18, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose53:
+ax_pose 19, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose54:
+ax_pose 20, 0x01eb, 0x90e8, 0x3c00
+ax_pose_terminator
+sTreeckoPose55:
+ax_pose 21, 0x81eb, 0x5103, 0x3c00
+ax_pose 22, 0x01eb, 0x90eb, 0x3c04
+ax_pose_terminator
+sTreeckoPose56:
+ax_pose 22, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose57:
+ax_pose 23, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose58:
+ax_pose 24, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose59:
+ax_pose 25, 0x01eb, 0x90eb, 0x3c00
+ax_pose 26, 0x01eb, 0x90eb, 0x3c10
+ax_pose_terminator
+sTreeckoPose60:
+ax_pose 26, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose61:
+ax_pose 27, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose62:
+ax_pose 28, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose63:
+ax_pose 29, 0x01ec, 0x90eb, 0x3c00
+ax_pose 30, 0x01eb, 0x90ee, 0x3c10
+ax_pose_terminator
+sTreeckoPose64:
+ax_pose 29, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose65:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose66:
+ax_pose 32, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose67:
+ax_pose 33, 0x01ec, 0x80f4, 0x3c00
+ax_pose 34, 0x01e9, 0x40fc, 0x3c10
+ax_pose_terminator
+sTreeckoPose68:
+ax_pose 33, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose69:
+ax_pose 27, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose70:
+ax_pose 28, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose71:
+ax_pose 29, 0x01ec, 0x80f4, 0x3c00
+ax_pose 30, 0x01ea, 0x80f0, 0x3c10
+ax_pose_terminator
+sTreeckoPose72:
+ax_pose 29, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose73:
+ax_pose 23, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose74:
+ax_pose 24, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose75:
+ax_pose 25, 0x01eb, 0x80f4, 0x3c00
+ax_pose 26, 0x01eb, 0x80f4, 0x3c10
+ax_pose_terminator
+sTreeckoPose76:
+ax_pose 26, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose77:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose78:
+ax_pose 20, 0x01eb, 0x80f7, 0x3c00
+ax_pose_terminator
+sTreeckoPose79:
+ax_pose 21, 0x81eb, 0x40f4, 0x3c00
+ax_pose 22, 0x01eb, 0x80f4, 0x3c04
+ax_pose_terminator
+sTreeckoPose80:
+ax_pose 22, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose81:
+ax_pose 35, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose82:
+ax_pose 36, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose83:
+ax_pose 37, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose84:
+ax_pose 38, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose85:
+ax_pose 39, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose86:
+ax_pose 38, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose87:
+ax_pose 37, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose88:
+ax_pose 36, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose89:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose90:
+ax_pose 16, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose91:
+ax_pose 35, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose92:
+ax_pose 40, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose93:
+ax_pose 19, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose94:
+ax_pose 20, 0x01eb, 0x90e8, 0x3c00
+ax_pose_terminator
+sTreeckoPose95:
+ax_pose 36, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose96:
+ax_pose 41, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose97:
+ax_pose 23, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose98:
+ax_pose 24, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose99:
+ax_pose 37, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose100:
+ax_pose 42, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose101:
+ax_pose 27, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose102:
+ax_pose 28, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose103:
+ax_pose 38, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose104:
+ax_pose 43, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose105:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose106:
+ax_pose 32, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose107:
+ax_pose 39, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose108:
+ax_pose 44, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose109:
+ax_pose 27, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose110:
+ax_pose 28, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose111:
+ax_pose 38, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose112:
+ax_pose 43, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose113:
+ax_pose 23, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose114:
+ax_pose 24, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose115:
+ax_pose 37, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose116:
+ax_pose 42, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose117:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose118:
+ax_pose 20, 0x01eb, 0x80f7, 0x3c00
+ax_pose_terminator
+sTreeckoPose119:
+ax_pose 36, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose120:
+ax_pose 41, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose121:
+ax_pose 45, 0x01ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sTreeckoPose122:
+ax_pose 46, 0x01ec, 0x80f7, 0x3c00
+ax_pose_terminator
+sTreeckoPose123:
+ax_pose 47, 0x01e0, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose124:
+ax_pose 48, 0x01e0, 0x90ed, 0x3c00
+ax_pose_terminator
+sTreeckoPose125:
+ax_pose 49, 0x01e2, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose126:
+ax_pose 50, 0x01e3, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose127:
+ax_pose 51, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sTreeckoPose128:
+ax_pose 50, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose129:
+ax_pose 49, 0x01e2, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose130:
+ax_pose 48, 0x01e0, 0x80f2, 0x3c00
+ax_pose_terminator
+sTreeckoPose131:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose132:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose133:
+ax_pose 23, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose134:
+ax_pose 27, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose135:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose136:
+ax_pose 27, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose137:
+ax_pose 23, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose138:
+ax_pose 19, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose139:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose140:
+ax_pose 3, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose141:
+ax_pose 6, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose142:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose143:
+ax_pose 12, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose144:
+ax_pose 9, 0x01ee, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose145:
+ax_pose 6, 0x01ef, 0x90ec, 0x3c00
+ax_pose_terminator
+sTreeckoPose146:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose147:
+ax_pose 35, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose148:
+ax_pose 36, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose149:
+ax_pose 37, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose150:
+ax_pose 38, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose151:
+ax_pose 39, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose152:
+ax_pose 38, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose153:
+ax_pose 37, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose154:
+ax_pose 36, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose155:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose156:
+ax_pose 35, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose157:
+ax_pose 40, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose158:
+ax_pose 0, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose159:
+ax_pose 19, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose160:
+ax_pose 36, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose161:
+ax_pose 41, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose162:
+ax_pose 3, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose163:
+ax_pose 23, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose164:
+ax_pose 37, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose165:
+ax_pose 42, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose166:
+ax_pose 6, 0x01f0, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose167:
+ax_pose 27, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose168:
+ax_pose 38, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose169:
+ax_pose 43, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose170:
+ax_pose 9, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose171:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose172:
+ax_pose 39, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose173:
+ax_pose 44, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose174:
+ax_pose 12, 0x81ef, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose175:
+ax_pose 27, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose176:
+ax_pose 38, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose177:
+ax_pose 43, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose178:
+ax_pose 9, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose179:
+ax_pose 23, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose180:
+ax_pose 37, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose181:
+ax_pose 42, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose182:
+ax_pose 6, 0x01f0, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose183:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose184:
+ax_pose 36, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose185:
+ax_pose 41, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose186:
+ax_pose 3, 0x01ee, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose187:
+ax_pose 35, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose188:
+ax_pose 36, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose189:
+ax_pose 37, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose190:
+ax_pose 38, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose191:
+ax_pose 39, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose192:
+ax_pose 38, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose193:
+ax_pose 37, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose194:
+ax_pose 36, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose195:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose196:
+ax_pose 19, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose197:
+ax_pose 23, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose198:
+ax_pose 27, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose199:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose200:
+ax_pose 27, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose201:
+ax_pose 23, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose202:
+ax_pose 19, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose203:
+ax_pose 52, 0x41f3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose204:
+ax_pose 53, 0x41f3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose205:
+ax_pose 52, 0x41f3, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose206:
+ax_pose 53, 0x41f3, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose207:
+ax_pose 52, 0x41f3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose208:
+ax_pose 54, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sTreeckoPose209:
+ax_pose 55, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sTreeckoPose210:
+ax_pose 56, 0x01ed, 0x80f1, 0x3c00
+ax_pose_terminator
+sTreeckoPose211:
+ax_pose 23, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose212:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose213:
+ax_pose 57, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose214:
+ax_pose 58, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose215:
+ax_pose 59, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sTreeckoPose216:
+ax_pose 60, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sTreeckoPose217:
+ax_pose 61, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sTreeckoPose218:
+ax_pose 62, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sTreeckoPose219:
+ax_pose 63, 0x01ec, 0x80f3, 0x3c00
+ax_pose_terminator
+sTreeckoPose220:
+ax_pose 64, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sTreeckoPose221:
+ax_pose 65, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sTreeckoPose222:
+ax_pose 65, 0x01eb, 0x80f2, 0x3c00
+ax_pose_terminator
+sTreeckoPose223:
+ax_pose 66, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose224:
+ax_pose 67, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose225:
+ax_pose 68, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose226:
+ax_pose 23, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose227:
+ax_pose 69, 0x01ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sTreeckoPose228:
+ax_pose 70, 0x41f3, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose229:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose230:
+ax_pose 71, 0x81ee, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose231:
+ax_pose 72, 0x01ee, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose232:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose233:
+ax_pose 60, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sTreeckoPose234:
+ax_pose 73, 0x81eb, 0x80f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose235:
+ax_pose 23, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose236:
+ax_pose 74, 0x01eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sTreeckoPose237:
+ax_pose 23, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sTreeckoPose238:
+ax_pose 74, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sTreeckoPose239:
+ax_pose 31, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sTreeckoPose240:
+ax_pose 75, 0x01ed, 0x80f3, 0x3c00
+ax_pose_terminator
+sTreeckoPose241:
+ax_pose 76, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose242:
+ax_pose 77, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose243:
+ax_pose 78, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose244:
+ax_pose 79, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose245:
+ax_pose 80, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose246:
+ax_pose 76, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose247:
+ax_pose 77, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose248:
+ax_pose 78, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose249:
+ax_pose 79, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose250:
+ax_pose 80, 0x01ed, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose251:
+ax_pose 81, 0x81ed, 0x90f8, 0x3c00
+ax_pose_terminator
+sTreeckoPose252:
+ax_pose 52, 0x41f3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose253:
+ax_pose 53, 0x41f3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose254:
+ax_pose 52, 0x41f3, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose255:
+ax_pose 53, 0x41f3, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose256:
+ax_pose 52, 0x41f3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose257:
+ax_pose 53, 0x41f3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose258:
+ax_pose 52, 0x41f3, 0x90f0, 0x3c00
+ax_pose_terminator
+sTreeckoPose259:
+ax_pose 53, 0x41f3, 0x90f0, 0x3c00
+ax_pose_terminator
+.align 2
+sTreeckoAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 0, 25, 0, 4, 0, 4,
+ax_anim 1, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTreeckoAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, -1, 0, 0,
+ax_anim 1, 0, 28, 4, 4, 4, 4,
+ax_anim 1, 2, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sTreeckoAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 0, 31, 4, 0, 4, 0,
+ax_anim 1, 2, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sTreeckoAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 0, 34, 4, -6, 4, -6,
+ax_anim 1, 2, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 1, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 34, 18, -23, 18, -23,
+ax_anim 2, 0, 34, 19, -22, 19, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sTreeckoAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 0, -4, 0, -4,
+ax_anim 1, 2, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 1, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 37, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sTreeckoAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 0, 40, -4, -6, -4, -6,
+ax_anim 1, 2, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 1, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 40, -18, -23, -18, -23,
+ax_anim 2, 0, 40, -19, -22, -19, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sTreeckoAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 0, 43, -4, 0, -4, 0,
+ax_anim 1, 2, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sTreeckoAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 0, 47, -4, 4, -4, 4,
+ax_anim 1, 2, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_3_1:
+ax_anim 3, 0, 49, 0, -3, 0, -3,
+ax_anim 6, 0, 49, 0, -4, 0, -4,
+ax_anim 2, 0, 49, -1, -2, -1, -2,
+ax_anim 2, 2, 49, -1, 5, -1, 5,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 1, 51, 1, 16, 1, 16,
+ax_anim 2, 0, 51, 0, 16, 0, 16,
+ax_anim 2, 0, 51, 1, 16, 1, 16,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sTreeckoAnims_3_2:
+ax_anim 3, 0, 53, -3, -3, -3, -3,
+ax_anim 6, 0, 53, -4, -4, -4, -4,
+ax_anim 2, 0, 53, -2, -2, -2, -2,
+ax_anim 2, 2, 53, 5, 3, 5, 3,
+ax_anim 2, 0, 54, 18, 18, 18, 18,
+ax_anim 2, 1, 55, 17, 19, 17, 19,
+ax_anim 2, 0, 55, 18, 18, 18, 18,
+ax_anim 2, 0, 55, 17, 19, 17, 19,
+ax_anim 2, 0, 52, 6, 6, 6, 6,
+ax_anim_terminator
+sTreeckoAnims_3_3:
+ax_anim 3, 0, 57, -3, 0, -3, 0,
+ax_anim 6, 0, 57, -4, 0, -4, 0,
+ax_anim 2, 0, 57, -2, 0, -2, 0,
+ax_anim 2, 2, 57, 5, 0, 5, 0,
+ax_anim 2, 0, 58, 14, 0, 14, 0,
+ax_anim 2, 1, 59, 14, 1, 14, 1,
+ax_anim 2, 0, 59, 14, 0, 14, 0,
+ax_anim 2, 0, 59, 14, 1, 14, 1,
+ax_anim 2, 0, 56, 6, 0, 6, 0,
+ax_anim_terminator
+sTreeckoAnims_3_4:
+ax_anim 3, 0, 61, -3, 3, -3, 3,
+ax_anim 6, 0, 61, -4, 4, -4, 4,
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 2, 2, 61, 5, -9, 5, -9,
+ax_anim 2, 0, 62, 20, -20, 20, -20,
+ax_anim 2, 1, 63, 21, -19, 21, -19,
+ax_anim 2, 0, 63, 20, -20, 20, -20,
+ax_anim 2, 0, 63, 21, -19, 21, -19,
+ax_anim 2, 0, 60, 6, -6, 6, -6,
+ax_anim_terminator
+sTreeckoAnims_3_5:
+ax_anim 3, 0, 65, 0, 3, 0, 3,
+ax_anim 6, 0, 65, 0, 4, 0, 4,
+ax_anim 2, 0, 65, 1, 0, 0, 0,
+ax_anim 2, 2, 65, 1, -7, 0, -7,
+ax_anim 2, 0, 66, 0, -18, 0, -22,
+ax_anim 2, 1, 67, -1, -18, -1, -22,
+ax_anim 2, 0, 67, 0, -18, 0, -22,
+ax_anim 2, 0, 67, -1, -18, -1, -22,
+ax_anim 2, 0, 64, 0, -6, 0, -6,
+ax_anim_terminator
+sTreeckoAnims_3_6:
+ax_anim 3, 0, 69, 3, 3, 3, 3,
+ax_anim 6, 0, 69, 4, 4, 4, 4,
+ax_anim 2, 0, 69, 2, 2, 2, 2,
+ax_anim 2, 2, 69, -5, -9, -5, -9,
+ax_anim 2, 0, 70, -20, -20, -20, -20,
+ax_anim 2, 1, 71, -21, -19, -21, -19,
+ax_anim 2, 0, 71, -20, -20, -20, -20,
+ax_anim 2, 0, 71, -21, -19, -21, -19,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim_terminator
+sTreeckoAnims_3_7:
+ax_anim 3, 0, 73, 3, 0, 3, 0,
+ax_anim 6, 0, 73, 4, 0, 4, 0,
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim 2, 2, 73, -5, 0, -5, 0,
+ax_anim 2, 0, 74, -14, 0, -14, 0,
+ax_anim 2, 1, 75, -14, 1, -14, 1,
+ax_anim 2, 0, 75, -14, 0, -14, 0,
+ax_anim 2, 0, 75, -14, 1, -14, 1,
+ax_anim 2, 0, 72, -6, 0, -6, 0,
+ax_anim_terminator
+sTreeckoAnims_3_8:
+ax_anim 3, 0, 77, 3, -3, 3, -3,
+ax_anim 6, 0, 77, 4, -4, 4, -4,
+ax_anim 2, 0, 77, 2, -2, 2, -2,
+ax_anim 2, 2, 77, -5, 3, -5, 3,
+ax_anim 2, 0, 78, -18, 18, -18, 18,
+ax_anim 2, 1, 79, -17, 19, -17, 19,
+ax_anim 2, 0, 79, -18, 18, -18, 18,
+ax_anim 2, 0, 79, -17, 19, -17, 19,
+ax_anim 2, 0, 76, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_4_1:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 2, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_4_2:
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, -1, 1, 0,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_4_3:
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, -1, 0, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_4_4:
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, -1, -1, -1,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_4_5:
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, 0, 1, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_4_6:
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 1, -1, 1, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_4_7:
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_4_8:
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, -1, -1, -1, -1,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_5_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 3, 0, 89, 0, -3, 0, -3,
+ax_anim 4, 0, 89, 0, -4, 0, -4,
+ax_anim 1, 0, 89, 0, -2, 0, -2,
+ax_anim 1, 0, 88, 0, 1, 0, 1,
+ax_anim 4, 0, 90, 0, 4, 0, 4,
+ax_anim 3, 2, 91, 0, 4, 0, 4,
+ax_anim 3, 0, 90, 0, 4, 0, 4,
+ax_anim 3, 0, 91, 0, 4, 0, 4,
+ax_anim 3, 0, 90, 0, 4, 0, 4,
+ax_anim 3, 0, 91, 0, 4, 0, 4,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_5_2:
+ax_anim 2, 0, 92, -1, -1, -1, -1,
+ax_anim 3, 0, 93, -3, -3, -3, -3,
+ax_anim 4, 0, 93, -4, -4, -4, -4,
+ax_anim 1, 0, 93, -2, -2, -2, -2,
+ax_anim 1, 0, 92, 1, 1, 1, 1,
+ax_anim 4, 0, 94, 4, 4, 4, 4,
+ax_anim 3, 2, 95, 4, 4, 4, 4,
+ax_anim 3, 0, 94, 4, 4, 4, 4,
+ax_anim 3, 0, 95, 4, 4, 4, 4,
+ax_anim 3, 0, 94, 4, 4, 4, 4,
+ax_anim 3, 0, 95, 4, 4, 4, 4,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_5_3:
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 3, 0, 97, -3, 0, -3, 0,
+ax_anim 4, 0, 97, -4, 0, -4, 0,
+ax_anim 1, 0, 97, -2, 0, -2, 0,
+ax_anim 1, 0, 96, 1, 0, 1, 0,
+ax_anim 4, 0, 98, 4, 0, 4, 0,
+ax_anim 3, 2, 99, 4, 0, 4, 0,
+ax_anim 3, 0, 98, 4, 0, 4, 0,
+ax_anim 3, 0, 99, 4, 0, 4, 0,
+ax_anim 3, 0, 98, 4, 0, 4, 0,
+ax_anim 3, 0, 99, 4, 0, 4, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_5_4:
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim 3, 0, 101, -3, 3, -3, 3,
+ax_anim 4, 0, 101, -4, 4, -4, 4,
+ax_anim 1, 0, 101, -2, 2, -2, 2,
+ax_anim 1, 0, 100, 1, -1, 1, -1,
+ax_anim 4, 0, 102, 4, -4, 4, -4,
+ax_anim 3, 2, 103, 4, -4, 4, -4,
+ax_anim 3, 0, 102, 4, -4, 4, -4,
+ax_anim 3, 0, 103, 4, -4, 4, -4,
+ax_anim 3, 0, 102, 4, -4, 4, -4,
+ax_anim 3, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim_terminator
+sTreeckoAnims_5_5:
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 3, 0, 105, 0, 3, 0, 3,
+ax_anim 4, 0, 105, 0, 4, 0, 4,
+ax_anim 1, 0, 105, 0, 2, 0, 2,
+ax_anim 1, 0, 104, 0, -1, 0, -1,
+ax_anim 4, 0, 106, 0, -4, 0, -4,
+ax_anim 3, 2, 107, 0, -4, 0, -4,
+ax_anim 3, 0, 106, 0, -4, 0, -4,
+ax_anim 3, 0, 107, 0, -4, 0, -4,
+ax_anim 3, 0, 106, 0, -4, 0, -4,
+ax_anim 3, 0, 107, 0, -4, 0, -4,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim_terminator
+sTreeckoAnims_5_6:
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 3, 0, 109, 3, 3, 3, 3,
+ax_anim 4, 0, 109, 4, 4, 4, 4,
+ax_anim 1, 0, 109, 2, 2, 2, 2,
+ax_anim 1, 0, 108, -1, -1, -1, -1,
+ax_anim 4, 0, 110, -4, -4, -4, -4,
+ax_anim 3, 2, 111, -4, -4, -4, -4,
+ax_anim 3, 0, 110, -4, -4, -4, -4,
+ax_anim 3, 0, 111, -4, -4, -4, -4,
+ax_anim 3, 0, 110, -4, -4, -4, -4,
+ax_anim 3, 0, 111, -4, -4, -4, -4,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim_terminator
+sTreeckoAnims_5_7:
+ax_anim 2, 0, 112, 1, 0, 1, 0,
+ax_anim 3, 0, 113, 3, 0, 3, 0,
+ax_anim 4, 0, 113, 4, 0, 4, 0,
+ax_anim 1, 0, 113, 2, 0, 2, 0,
+ax_anim 1, 0, 112, -1, 0, -1, 0,
+ax_anim 4, 0, 114, -4, 0, -4, 0,
+ax_anim 3, 2, 115, -4, 0, -4, 0,
+ax_anim 3, 0, 114, -4, 0, -4, 0,
+ax_anim 3, 0, 115, -4, 0, -4, 0,
+ax_anim 3, 0, 114, -4, 0, -4, 0,
+ax_anim 3, 0, 115, -4, 0, -4, 0,
+ax_anim 2, 0, 112, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_5_8:
+ax_anim 2, 0, 116, 1, -1, 1, -1,
+ax_anim 3, 0, 117, 3, -3, 3, -3,
+ax_anim 4, 0, 117, 4, -4, 4, -4,
+ax_anim 1, 0, 117, 2, -2, 2, -2,
+ax_anim 1, 0, 116, -1, 1, -1, 1,
+ax_anim 4, 0, 118, -4, 4, -4, 4,
+ax_anim 3, 2, 119, -4, 4, -4, 4,
+ax_anim 3, 0, 118, -4, 4, -4, 4,
+ax_anim 3, 0, 119, -4, 4, -4, 4,
+ax_anim 3, 0, 118, -4, 4, -4, 4,
+ax_anim 3, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 116, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sTreeckoAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sTreeckoAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sTreeckoAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sTreeckoAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sTreeckoAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sTreeckoAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sTreeckoAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 130, 0, -3, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_8_2:
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, -3, 0, 0,
+ax_anim 2, 0, 136, 0, -3, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_8_4:
+ax_anim 40, 0, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_8_5:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_8_6:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_8_7:
+ax_anim 40, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_8_8:
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 4, 6, 4,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 17, 7, 17,
+ax_anim 3, 0, 142, 0, 20, 0, 20,
+ax_anim 2, 3, 143, -7, 17, -7, 17,
+ax_anim 2, 0, 144, -8, 9, -8, 9,
+ax_anim 1, 0, 145, -6, 4, -6, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 22, 9, 22, 9,
+ax_anim 3, 0, 141, 20, 19, 20, 19,
+ax_anim 2, 3, 142, 11, 21, 11, 21,
+ax_anim 2, 0, 143, 2, 12, 2, 12,
+ax_anim 1, 0, 144, -2, 7, -2, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 17, -4, 17, -4,
+ax_anim 3, 0, 140, 23, 1, 23, 1,
+ax_anim 2, 3, 141, 19, 5, 19, 5,
+ax_anim 2, 0, 142, 12, 7, 12, 7,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, -1, -6, -1, -6,
+ax_anim 2, 0, 145, 2, -16, 2, -16,
+ax_anim 2, 0, 138, 12, -23, 12, -23,
+ax_anim 3, 0, 139, 17, -22, 17, -22,
+ax_anim 2, 3, 140, 20, -12, 20, -12,
+ax_anim 2, 0, 141, 17, -5, 17, -5,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -6, -4, -6, -4,
+ax_anim 2, 0, 144, -9, -10, -9, -10,
+ax_anim 2, 0, 145, -7, -20, -7, -20,
+ax_anim 3, 0, 138, 0, -26, 0, -26,
+ax_anim 2, 3, 139, 7, -20, 7, -20,
+ax_anim 2, 0, 140, 9, -8, 9, -8,
+ax_anim 1, 0, 141, 6, -4, 6, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 1, -6, 1, -6,
+ax_anim 2, 0, 139, -2, -16, -2, -16,
+ax_anim 2, 0, 138, -12, -23, -12, -23,
+ax_anim 3, 0, 145, -17, -22, -17, -22,
+ax_anim 2, 3, 144, -20, -12, -20, -12,
+ax_anim 2, 0, 143, -17, -5, -17, -5,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -17, -4, -17, -4,
+ax_anim 3, 0, 144, -23, 1, -23, 1,
+ax_anim 2, 3, 143, -19, 5, -19, 5,
+ax_anim 2, 0, 142, -12, 7, -12, 7,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -22, 9, -22, 9,
+ax_anim 3, 0, 143, -20, 19, -20, 19,
+ax_anim 2, 3, 142, -11, 21, -11, 21,
+ax_anim 2, 0, 141, -2, 12, -2, 12,
+ax_anim 1, 0, 140, 2, 7, 2, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 157, 0, -18, 0, 0,
+ax_anim 1, 0, 157, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_11_2:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -20, 0, 0,
+ax_anim 4, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 160, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_11_3:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 165, 0, -18, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_11_4:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -21, 0, 0,
+ax_anim 2, 0, 169, 0, -15, 0, 0,
+ax_anim 1, 0, 169, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_11_5:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 1, 0, 173, 0, -12, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_11_6:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -21, 0, 0,
+ax_anim 2, 0, 177, 0, -15, 0, 0,
+ax_anim 1, 0, 177, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_11_7:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 181, 0, -18, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_11_8:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -23, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_14_1:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_14_2:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_14_3:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_14_4:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_14_5:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_14_6:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_14_7:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_14_8:
+ax_anim 30, 0, 202, 0, 0, 0, 0,
+ax_anim 35, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_15_1:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_15_2:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_15_3:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_15_4:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_15_5:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_15_6:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_15_7:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_15_8:
+ax_anim 8, 0, 206, 0, 0, 0, 0,
+ax_anim 6, 0, 207, 0, 0, 0, 0,
+ax_anim 14, 0, 208, 0, 0, 0, 0,
+ax_anim 6, 0, 209, 0, 0, 0, 0,
+ax_anim 10, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_16_1:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_16_2:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_16_3:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_16_4:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_16_5:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_16_6:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_16_7:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_16_8:
+ax_anim 8, 0, 211, 0, 0, 0, 0,
+ax_anim 3, 0, 212, 0, 0, 0, 0,
+ax_anim 8, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_17_1:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_17_2:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_17_3:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_17_4:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_17_5:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_17_6:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_17_7:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+sTreeckoAnims_17_8:
+ax_anim 12, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_18_1:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 1, 0, 1,
+ax_anim 8, 0, 218, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_18_2:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 1, 0, 1,
+ax_anim 8, 0, 218, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_18_3:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 1, 0, 1,
+ax_anim 8, 0, 218, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_18_4:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 1, 0, 1,
+ax_anim 8, 0, 218, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_18_5:
+ax_anim 12, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 1, 0, 1,
+ax_anim 8, 0, 221, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_18_6:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 1, 0, 1,
+ax_anim 8, 0, 218, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_18_7:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 1, 0, 1,
+ax_anim 8, 0, 218, 0, 1, 0, 1,
+ax_anim_terminator
+sTreeckoAnims_18_8:
+ax_anim 12, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 1, 0, 1,
+ax_anim 8, 0, 218, 0, 1, 0, 1,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_19_1:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_19_2:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_19_3:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_19_4:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_19_5:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_19_6:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_19_7:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_19_8:
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 223, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 10, 0, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_20_1:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 2, 0, 227, 0, -2, 0, 0,
+ax_anim 1, 0, 227, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 1, 0, 0,
+ax_anim 2, 0, 227, 1, 1, 1, 0,
+ax_anim 2, 0, 227, 0, 1, 0, 0,
+ax_anim 2, 0, 227, 1, 1, 1, 0,
+ax_anim 2, 0, 227, 0, 1, 0, 0,
+ax_anim 2, 0, 227, 1, 1, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_20_2:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_20_3:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_20_4:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_20_5:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_20_6:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_20_7:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+sTreeckoAnims_20_8:
+ax_anim 4, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -2, 0, 0,
+ax_anim 1, 0, 226, 0, -4, 0, 0,
+ax_anim 2, 0, 227, 0, -4, 0, 0,
+ax_anim 1, 0, 227, 0, -2, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_21_1:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_21_2:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_21_3:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_21_4:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_21_5:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_21_6:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_21_7:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_21_8:
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 8, 0, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_22_1:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_22_2:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_22_3:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_22_4:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_22_5:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_22_6:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_22_7:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_22_8:
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 30, 0, 232, 0, 0, 0, 0,
+ax_anim 34, 0, 233, 0, 0, 0, 0,
+ax_anim 4, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_23_1:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_23_2:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_23_3:
+ax_anim 10, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 12, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_23_4:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_23_5:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_23_6:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_23_7:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_23_8:
+ax_anim 10, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 12, 0, 234, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 234, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_24_1:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_24_2:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_24_3:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_24_4:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_24_5:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_24_6:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_24_7:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_24_8:
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_25_1:
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_25_2:
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_25_3:
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_25_4:
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_25_5:
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_25_6:
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, 0, 0, 0,
+ax_anim 12, 0, 247, 0, 0, 0, 0,
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_25_7:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_25_8:
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 12, 0, 241, 0, 0, 0, 0,
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 240, 0, 0, 0, 0,
+ax_anim 12, 0, 243, 0, 0, 0, 0,
+ax_anim 12, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_26_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_26_2:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_26_3:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_26_4:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_26_5:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_26_6:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_26_7:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+sTreeckoAnims_26_8:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 1, 1, 1, 1,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_27_1:
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 16, 0, 251, -1, 0, 0, 0,
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 251, 1, 0, 0, 0,
+ax_anim 16, 0, 251, 2, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTreeckoAnims_28_1:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_28_2:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_28_3:
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_28_4:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_28_5:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_28_6:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_28_7:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoAnims_28_8:
+ax_anim 12, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTreeckoGfx1:
+.incbin "baserom.gba", 0x1051D18, 0x100
+sTreeckoSprites1:
+ax_sprite sTreeckoGfx1, 0x100
+ax_sprite_terminator
+sTreeckoGfx2:
+.incbin "baserom.gba", 0x1051E28, 0x100
+sTreeckoSprites2:
+ax_sprite sTreeckoGfx2, 0x100
+ax_sprite_terminator
+sTreeckoGfx3:
+.incbin "baserom.gba", 0x1051F38, 0x100
+sTreeckoSprites3:
+ax_sprite sTreeckoGfx3, 0x100
+ax_sprite_terminator
+sTreeckoGfx4:
+.incbin "baserom.gba", 0x1052048, 0x200
+sTreeckoSprites4:
+ax_sprite sTreeckoGfx4, 0x200
+ax_sprite_terminator
+sTreeckoGfx5:
+.incbin "baserom.gba", 0x1052258, 0x200
+sTreeckoSprites5:
+ax_sprite sTreeckoGfx5, 0x200
+ax_sprite_terminator
+sTreeckoGfx6:
+.incbin "baserom.gba", 0x1052468, 0x200
+sTreeckoSprites6:
+ax_sprite sTreeckoGfx6, 0x200
+ax_sprite_terminator
+sTreeckoGfx7:
+.incbin "baserom.gba", 0x1052678, 0x200
+sTreeckoSprites7:
+ax_sprite sTreeckoGfx7, 0x200
+ax_sprite_terminator
+sTreeckoGfx8:
+.incbin "baserom.gba", 0x1052888, 0x200
+sTreeckoSprites8:
+ax_sprite sTreeckoGfx8, 0x200
+ax_sprite_terminator
+sTreeckoGfx9:
+.incbin "baserom.gba", 0x1052A98, 0x200
+sTreeckoSprites9:
+ax_sprite sTreeckoGfx9, 0x200
+ax_sprite_terminator
+sTreeckoGfx10:
+.incbin "baserom.gba", 0x1052CA8, 0x200
+sTreeckoSprites10:
+ax_sprite sTreeckoGfx10, 0x200
+ax_sprite_terminator
+sTreeckoGfx11:
+.incbin "baserom.gba", 0x1052EB8, 0x200
+sTreeckoSprites11:
+ax_sprite sTreeckoGfx11, 0x200
+ax_sprite_terminator
+sTreeckoGfx12:
+.incbin "baserom.gba", 0x10530C8, 0x200
+sTreeckoSprites12:
+ax_sprite sTreeckoGfx12, 0x200
+ax_sprite_terminator
+sTreeckoGfx13:
+.incbin "baserom.gba", 0x10532D8, 0x100
+sTreeckoSprites13:
+ax_sprite sTreeckoGfx13, 0x100
+ax_sprite_terminator
+sTreeckoGfx14:
+.incbin "baserom.gba", 0x10533E8, 0x100
+sTreeckoSprites14:
+ax_sprite sTreeckoGfx14, 0x100
+ax_sprite_terminator
+sTreeckoGfx15:
+.incbin "baserom.gba", 0x10534F8, 0x100
+sTreeckoSprites15:
+ax_sprite sTreeckoGfx15, 0x100
+ax_sprite_terminator
+sTreeckoGfx16:
+.incbin "baserom.gba", 0x1053608, 0x60
+sTreeckoGfx16_1:
+.incbin "baserom.gba", 0x1053668, 0x60
+sTreeckoGfx16_2:
+.incbin "baserom.gba", 0x10536C8, 0x60
+sTreeckoSprites16:
+ax_sprite sTreeckoGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx17:
+.incbin "baserom.gba", 0x1053760, 0x60
+sTreeckoGfx17_1:
+.incbin "baserom.gba", 0x10537C0, 0x60
+sTreeckoGfx17_2:
+.incbin "baserom.gba", 0x1053820, 0x60
+sTreeckoSprites17:
+ax_sprite sTreeckoGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx18:
+.incbin "baserom.gba", 0x10538B8, 0x20
+sTreeckoGfx18_1:
+.incbin "baserom.gba", 0x10538D8, 0x20
+sTreeckoGfx18_2:
+.incbin "baserom.gba", 0x10538F8, 0x40
+sTreeckoSprites18:
+ax_sprite sTreeckoGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx18_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx18_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx19:
+.incbin "baserom.gba", 0x1053970, 0x20
+sTreeckoGfx19_1:
+.incbin "baserom.gba", 0x1053990, 0x60
+sTreeckoGfx19_2:
+.incbin "baserom.gba", 0x10539F0, 0x60
+sTreeckoGfx19_3:
+.incbin "baserom.gba", 0x1053A50, 0x40
+sTreeckoSprites19:
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTreeckoGfx20:
+.incbin "baserom.gba", 0x1053AE0, 0x60
+sTreeckoGfx20_1:
+.incbin "baserom.gba", 0x1053B40, 0x60
+sTreeckoGfx20_2:
+.incbin "baserom.gba", 0x1053BA0, 0x60
+sTreeckoSprites20:
+ax_sprite sTreeckoGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx21:
+.incbin "baserom.gba", 0x1053C38, 0x40
+sTreeckoGfx21_1:
+.incbin "baserom.gba", 0x1053C78, 0x60
+sTreeckoGfx21_2:
+.incbin "baserom.gba", 0x1053CD8, 0x60
+sTreeckoSprites21:
+ax_sprite sTreeckoGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx22:
+.incbin "baserom.gba", 0x1053D70, 0x40
+sTreeckoSprites22:
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTreeckoGfx23:
+.incbin "baserom.gba", 0x1053DD0, 0x40
+sTreeckoGfx23_1:
+.incbin "baserom.gba", 0x1053E10, 0x60
+sTreeckoGfx23_2:
+.incbin "baserom.gba", 0x1053E70, 0x40
+sTreeckoGfx23_3:
+.incbin "baserom.gba", 0x1053EB0, 0x20
+sTreeckoSprites23:
+ax_sprite sTreeckoGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx23_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sTreeckoGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx24:
+.incbin "baserom.gba", 0x1053F18, 0x40
+sTreeckoGfx24_1:
+.incbin "baserom.gba", 0x1053F58, 0x60
+sTreeckoGfx24_2:
+.incbin "baserom.gba", 0x1053FB8, 0x60
+sTreeckoSprites24:
+ax_sprite sTreeckoGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx25:
+.incbin "baserom.gba", 0x1054050, 0x60
+sTreeckoGfx25_1:
+.incbin "baserom.gba", 0x10540B0, 0x60
+sTreeckoGfx25_2:
+.incbin "baserom.gba", 0x1054110, 0x60
+sTreeckoSprites25:
+ax_sprite sTreeckoGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx26:
+.incbin "baserom.gba", 0x10541A8, 0x60
+sTreeckoGfx26_1:
+.incbin "baserom.gba", 0x1054208, 0x20
+sTreeckoSprites26:
+ax_sprite 0, 0x80
+ax_sprite sTreeckoGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx26_1, 0x20
+ax_sprite 0, 0xe0
+ax_sprite_terminator
+sTreeckoGfx27:
+.incbin "baserom.gba", 0x1054258, 0x40
+sTreeckoGfx27_1:
+.incbin "baserom.gba", 0x1054298, 0xE0
+sTreeckoSprites27:
+ax_sprite sTreeckoGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx27_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx28:
+.incbin "baserom.gba", 0x10543A0, 0x60
+sTreeckoGfx28_1:
+.incbin "baserom.gba", 0x1054400, 0x60
+sTreeckoGfx28_2:
+.incbin "baserom.gba", 0x1054460, 0x60
+sTreeckoSprites28:
+ax_sprite sTreeckoGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx29:
+.incbin "baserom.gba", 0x10544F8, 0x60
+sTreeckoGfx29_1:
+.incbin "baserom.gba", 0x1054558, 0x60
+sTreeckoGfx29_2:
+.incbin "baserom.gba", 0x10545B8, 0x60
+sTreeckoGfx29_3:
+.incbin "baserom.gba", 0x1054618, 0x20
+sTreeckoSprites29:
+ax_sprite sTreeckoGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx30:
+.incbin "baserom.gba", 0x1054680, 0x40
+sTreeckoGfx30_1:
+.incbin "baserom.gba", 0x10546C0, 0x60
+sTreeckoGfx30_2:
+.incbin "baserom.gba", 0x1054720, 0x60
+sTreeckoSprites30:
+ax_sprite sTreeckoGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx31:
+.incbin "baserom.gba", 0x10547B8, 0xC0
+sTreeckoSprites31:
+ax_sprite 0, 0x80
+ax_sprite sTreeckoGfx31, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sTreeckoGfx32:
+.incbin "baserom.gba", 0x1054898, 0x60
+sTreeckoGfx32_1:
+.incbin "baserom.gba", 0x10548F8, 0x60
+sTreeckoGfx32_2:
+.incbin "baserom.gba", 0x1054958, 0x60
+sTreeckoSprites32:
+ax_sprite sTreeckoGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx33:
+.incbin "baserom.gba", 0x10549F0, 0x40
+sTreeckoGfx33_1:
+.incbin "baserom.gba", 0x1054A30, 0x60
+sTreeckoGfx33_2:
+.incbin "baserom.gba", 0x1054A90, 0x40
+sTreeckoSprites33:
+ax_sprite sTreeckoGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx33_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sTreeckoGfx34:
+.incbin "baserom.gba", 0x1054B08, 0x60
+sTreeckoGfx34_1:
+.incbin "baserom.gba", 0x1054B68, 0x60
+sTreeckoGfx34_2:
+.incbin "baserom.gba", 0x1054BC8, 0x60
+sTreeckoSprites34:
+ax_sprite sTreeckoGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTreeckoGfx35:
+.incbin "baserom.gba", 0x1054C60, 0x60
+sTreeckoSprites35:
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx35, 0x60
+ax_sprite_terminator
+sTreeckoGfx36:
+.incbin "baserom.gba", 0x1054CD8, 0x60
+sTreeckoGfx36_1:
+.incbin "baserom.gba", 0x1054D38, 0x60
+sTreeckoGfx36_2:
+.incbin "baserom.gba", 0x1054D98, 0x60
+sTreeckoGfx36_3:
+.incbin "baserom.gba", 0x1054DF8, 0x20
+sTreeckoSprites36:
+ax_sprite sTreeckoGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx36_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx37:
+.incbin "baserom.gba", 0x1054E60, 0x40
+sTreeckoGfx37_1:
+.incbin "baserom.gba", 0x1054EA0, 0x60
+sTreeckoGfx37_2:
+.incbin "baserom.gba", 0x1054F00, 0x60
+sTreeckoGfx37_3:
+.incbin "baserom.gba", 0x1054F60, 0x20
+sTreeckoSprites37:
+ax_sprite sTreeckoGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx37_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx37_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx38:
+.incbin "baserom.gba", 0x1054FC8, 0x40
+sTreeckoGfx38_1:
+.incbin "baserom.gba", 0x1055008, 0x60
+sTreeckoGfx38_2:
+.incbin "baserom.gba", 0x1055068, 0x60
+sTreeckoGfx38_3:
+.incbin "baserom.gba", 0x10550C8, 0x20
+sTreeckoSprites38:
+ax_sprite sTreeckoGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx38_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sTreeckoGfx38_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTreeckoGfx39:
+.incbin "baserom.gba", 0x1055130, 0x60
+sTreeckoGfx39_1:
+.incbin "baserom.gba", 0x1055190, 0x60
+sTreeckoGfx39_2:
+.incbin "baserom.gba", 0x10551F0, 0x60
+sTreeckoGfx39_3:
+.incbin "baserom.gba", 0x1055250, 0x20
+sTreeckoSprites39:
+ax_sprite sTreeckoGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx39_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx39_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx40:
+.incbin "baserom.gba", 0x10552B8, 0x60
+sTreeckoGfx40_1:
+.incbin "baserom.gba", 0x1055318, 0x60
+sTreeckoGfx40_2:
+.incbin "baserom.gba", 0x1055378, 0x60
+sTreeckoGfx40_3:
+.incbin "baserom.gba", 0x10553D8, 0x40
+sTreeckoSprites40:
+ax_sprite sTreeckoGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx40_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx41:
+.incbin "baserom.gba", 0x1055460, 0x40
+sTreeckoGfx41_1:
+.incbin "baserom.gba", 0x10554A0, 0x60
+sTreeckoGfx41_2:
+.incbin "baserom.gba", 0x1055500, 0x60
+sTreeckoGfx41_3:
+.incbin "baserom.gba", 0x1055560, 0x20
+sTreeckoSprites41:
+ax_sprite sTreeckoGfx41, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx41_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx41_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx42:
+.incbin "baserom.gba", 0x10555C8, 0x40
+sTreeckoGfx42_1:
+.incbin "baserom.gba", 0x1055608, 0x60
+sTreeckoGfx42_2:
+.incbin "baserom.gba", 0x1055668, 0x60
+sTreeckoGfx42_3:
+.incbin "baserom.gba", 0x10556C8, 0x20
+sTreeckoSprites42:
+ax_sprite sTreeckoGfx42, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx42_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx42_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx43:
+.incbin "baserom.gba", 0x1055730, 0x40
+sTreeckoGfx43_1:
+.incbin "baserom.gba", 0x1055770, 0x40
+sTreeckoGfx43_2:
+.incbin "baserom.gba", 0x10557B0, 0x60
+sTreeckoGfx43_3:
+.incbin "baserom.gba", 0x1055810, 0x20
+sTreeckoSprites43:
+ax_sprite sTreeckoGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx43_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx43_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sTreeckoGfx43_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTreeckoGfx44:
+.incbin "baserom.gba", 0x1055878, 0x60
+sTreeckoGfx44_1:
+.incbin "baserom.gba", 0x10558D8, 0x60
+sTreeckoGfx44_2:
+.incbin "baserom.gba", 0x1055938, 0x60
+sTreeckoGfx44_3:
+.incbin "baserom.gba", 0x1055998, 0x20
+sTreeckoSprites44:
+ax_sprite sTreeckoGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx44_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTreeckoGfx44_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx45:
+.incbin "baserom.gba", 0x1055A00, 0x60
+sTreeckoGfx45_1:
+.incbin "baserom.gba", 0x1055A60, 0x60
+sTreeckoGfx45_2:
+.incbin "baserom.gba", 0x1055AC0, 0x60
+sTreeckoGfx45_3:
+.incbin "baserom.gba", 0x1055B20, 0x40
+sTreeckoSprites45:
+ax_sprite sTreeckoGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTreeckoGfx45_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTreeckoGfx46:
+.incbin "baserom.gba", 0x1055BA8, 0x200
+sTreeckoSprites46:
+ax_sprite sTreeckoGfx46, 0x200
+ax_sprite_terminator
+sTreeckoGfx47:
+.incbin "baserom.gba", 0x1055DB8, 0x200
+sTreeckoSprites47:
+ax_sprite sTreeckoGfx47, 0x200
+ax_sprite_terminator
+sTreeckoGfx48:
+.incbin "baserom.gba", 0x1055FC8, 0x200
+sTreeckoSprites48:
+ax_sprite sTreeckoGfx48, 0x200
+ax_sprite_terminator
+sTreeckoGfx49:
+.incbin "baserom.gba", 0x10561D8, 0x200
+sTreeckoSprites49:
+ax_sprite sTreeckoGfx49, 0x200
+ax_sprite_terminator
+sTreeckoGfx50:
+.incbin "baserom.gba", 0x10563E8, 0x200
+sTreeckoSprites50:
+ax_sprite sTreeckoGfx50, 0x200
+ax_sprite_terminator
+sTreeckoGfx51:
+.incbin "baserom.gba", 0x10565F8, 0x200
+sTreeckoSprites51:
+ax_sprite sTreeckoGfx51, 0x200
+ax_sprite_terminator
+sTreeckoGfx52:
+.incbin "baserom.gba", 0x1056808, 0x200
+sTreeckoSprites52:
+ax_sprite sTreeckoGfx52, 0x200
+ax_sprite_terminator
+sTreeckoGfx53:
+.incbin "baserom.gba", 0x1056A18, 0x100
+sTreeckoSprites53:
+ax_sprite sTreeckoGfx53, 0x100
+ax_sprite_terminator
+sTreeckoGfx54:
+.incbin "baserom.gba", 0x1056B28, 0x100
+sTreeckoSprites54:
+ax_sprite sTreeckoGfx54, 0x100
+ax_sprite_terminator
+sTreeckoGfx55:
+.incbin "baserom.gba", 0x1056C38, 0x200
+sTreeckoSprites55:
+ax_sprite sTreeckoGfx55, 0x200
+ax_sprite_terminator
+sTreeckoGfx56:
+.incbin "baserom.gba", 0x1056E48, 0x200
+sTreeckoSprites56:
+ax_sprite sTreeckoGfx56, 0x200
+ax_sprite_terminator
+sTreeckoGfx57:
+.incbin "baserom.gba", 0x1057058, 0x200
+sTreeckoSprites57:
+ax_sprite sTreeckoGfx57, 0x200
+ax_sprite_terminator
+sTreeckoGfx58:
+.incbin "baserom.gba", 0x1057268, 0x200
+sTreeckoSprites58:
+ax_sprite sTreeckoGfx58, 0x200
+ax_sprite_terminator
+sTreeckoGfx59:
+.incbin "baserom.gba", 0x1057478, 0x200
+sTreeckoSprites59:
+ax_sprite sTreeckoGfx59, 0x200
+ax_sprite_terminator
+sTreeckoGfx60:
+.incbin "baserom.gba", 0x1057688, 0x200
+sTreeckoSprites60:
+ax_sprite sTreeckoGfx60, 0x200
+ax_sprite_terminator
+sTreeckoGfx61:
+.incbin "baserom.gba", 0x1057898, 0x200
+sTreeckoSprites61:
+ax_sprite sTreeckoGfx61, 0x200
+ax_sprite_terminator
+sTreeckoGfx62:
+.incbin "baserom.gba", 0x1057AA8, 0x200
+sTreeckoSprites62:
+ax_sprite sTreeckoGfx62, 0x200
+ax_sprite_terminator
+sTreeckoGfx63:
+.incbin "baserom.gba", 0x1057CB8, 0x200
+sTreeckoSprites63:
+ax_sprite sTreeckoGfx63, 0x200
+ax_sprite_terminator
+sTreeckoGfx64:
+.incbin "baserom.gba", 0x1057EC8, 0x200
+sTreeckoSprites64:
+ax_sprite sTreeckoGfx64, 0x200
+ax_sprite_terminator
+sTreeckoGfx65:
+.incbin "baserom.gba", 0x10580D8, 0x200
+sTreeckoSprites65:
+ax_sprite sTreeckoGfx65, 0x200
+ax_sprite_terminator
+sTreeckoGfx66:
+.incbin "baserom.gba", 0x10582E8, 0x200
+sTreeckoSprites66:
+ax_sprite sTreeckoGfx66, 0x200
+ax_sprite_terminator
+sTreeckoGfx67:
+.incbin "baserom.gba", 0x10584F8, 0x200
+sTreeckoSprites67:
+ax_sprite sTreeckoGfx67, 0x200
+ax_sprite_terminator
+sTreeckoGfx68:
+.incbin "baserom.gba", 0x1058708, 0x200
+sTreeckoSprites68:
+ax_sprite sTreeckoGfx68, 0x200
+ax_sprite_terminator
+sTreeckoGfx69:
+.incbin "baserom.gba", 0x1058918, 0x200
+sTreeckoSprites69:
+ax_sprite sTreeckoGfx69, 0x200
+ax_sprite_terminator
+sTreeckoGfx70:
+.incbin "baserom.gba", 0x1058B28, 0x200
+sTreeckoSprites70:
+ax_sprite sTreeckoGfx70, 0x200
+ax_sprite_terminator
+sTreeckoGfx71:
+.incbin "baserom.gba", 0x1058D38, 0x100
+sTreeckoSprites71:
+ax_sprite sTreeckoGfx71, 0x100
+ax_sprite_terminator
+sTreeckoGfx72:
+.incbin "baserom.gba", 0x1058E48, 0x100
+sTreeckoSprites72:
+ax_sprite sTreeckoGfx72, 0x100
+ax_sprite_terminator
+sTreeckoGfx73:
+.incbin "baserom.gba", 0x1058F58, 0x200
+sTreeckoSprites73:
+ax_sprite sTreeckoGfx73, 0x200
+ax_sprite_terminator
+sTreeckoGfx74:
+.incbin "baserom.gba", 0x1059168, 0x100
+sTreeckoSprites74:
+ax_sprite sTreeckoGfx74, 0x100
+ax_sprite_terminator
+sTreeckoGfx75:
+.incbin "baserom.gba", 0x1059278, 0x200
+sTreeckoSprites75:
+ax_sprite sTreeckoGfx75, 0x200
+ax_sprite_terminator
+sTreeckoGfx76:
+.incbin "baserom.gba", 0x1059488, 0x200
+sTreeckoSprites76:
+ax_sprite sTreeckoGfx76, 0x200
+ax_sprite_terminator
+sTreeckoGfx77:
+.incbin "baserom.gba", 0x1059698, 0x200
+sTreeckoSprites77:
+ax_sprite sTreeckoGfx77, 0x200
+ax_sprite_terminator
+sTreeckoGfx78:
+.incbin "baserom.gba", 0x10598A8, 0x200
+sTreeckoSprites78:
+ax_sprite sTreeckoGfx78, 0x200
+ax_sprite_terminator
+sTreeckoGfx79:
+.incbin "baserom.gba", 0x1059AB8, 0x200
+sTreeckoSprites79:
+ax_sprite sTreeckoGfx79, 0x200
+ax_sprite_terminator
+sTreeckoGfx80:
+.incbin "baserom.gba", 0x1059CC8, 0x200
+sTreeckoSprites80:
+ax_sprite sTreeckoGfx80, 0x200
+ax_sprite_terminator
+sTreeckoGfx81:
+.incbin "baserom.gba", 0x1059ED8, 0x200
+sTreeckoSprites81:
+ax_sprite sTreeckoGfx81, 0x200
+ax_sprite_terminator
+sTreeckoGfx82:
+.incbin "baserom.gba", 0x105A0E8, 0x100
+sTreeckoSprites82:
+ax_sprite sTreeckoGfx82, 0x100
+ax_sprite_terminator
+sAxPosesTreecko:
+.4byte sTreeckoPose1
+.4byte sTreeckoPose2
+.4byte sTreeckoPose3
+.4byte sTreeckoPose4
+.4byte sTreeckoPose5
+.4byte sTreeckoPose6
+.4byte sTreeckoPose7
+.4byte sTreeckoPose8
+.4byte sTreeckoPose9
+.4byte sTreeckoPose10
+.4byte sTreeckoPose11
+.4byte sTreeckoPose12
+.4byte sTreeckoPose13
+.4byte sTreeckoPose14
+.4byte sTreeckoPose15
+.4byte sTreeckoPose16
+.4byte sTreeckoPose17
+.4byte sTreeckoPose18
+.4byte sTreeckoPose19
+.4byte sTreeckoPose20
+.4byte sTreeckoPose21
+.4byte sTreeckoPose22
+.4byte sTreeckoPose23
+.4byte sTreeckoPose24
+.4byte sTreeckoPose25
+.4byte sTreeckoPose26
+.4byte sTreeckoPose27
+.4byte sTreeckoPose28
+.4byte sTreeckoPose29
+.4byte sTreeckoPose30
+.4byte sTreeckoPose31
+.4byte sTreeckoPose32
+.4byte sTreeckoPose33
+.4byte sTreeckoPose34
+.4byte sTreeckoPose35
+.4byte sTreeckoPose36
+.4byte sTreeckoPose37
+.4byte sTreeckoPose38
+.4byte sTreeckoPose39
+.4byte sTreeckoPose40
+.4byte sTreeckoPose41
+.4byte sTreeckoPose42
+.4byte sTreeckoPose43
+.4byte sTreeckoPose44
+.4byte sTreeckoPose45
+.4byte sTreeckoPose46
+.4byte sTreeckoPose47
+.4byte sTreeckoPose48
+.4byte sTreeckoPose49
+.4byte sTreeckoPose50
+.4byte sTreeckoPose51
+.4byte sTreeckoPose52
+.4byte sTreeckoPose53
+.4byte sTreeckoPose54
+.4byte sTreeckoPose55
+.4byte sTreeckoPose56
+.4byte sTreeckoPose57
+.4byte sTreeckoPose58
+.4byte sTreeckoPose59
+.4byte sTreeckoPose60
+.4byte sTreeckoPose61
+.4byte sTreeckoPose62
+.4byte sTreeckoPose63
+.4byte sTreeckoPose64
+.4byte sTreeckoPose65
+.4byte sTreeckoPose66
+.4byte sTreeckoPose67
+.4byte sTreeckoPose68
+.4byte sTreeckoPose69
+.4byte sTreeckoPose70
+.4byte sTreeckoPose71
+.4byte sTreeckoPose72
+.4byte sTreeckoPose73
+.4byte sTreeckoPose74
+.4byte sTreeckoPose75
+.4byte sTreeckoPose76
+.4byte sTreeckoPose77
+.4byte sTreeckoPose78
+.4byte sTreeckoPose79
+.4byte sTreeckoPose80
+.4byte sTreeckoPose81
+.4byte sTreeckoPose82
+.4byte sTreeckoPose83
+.4byte sTreeckoPose84
+.4byte sTreeckoPose85
+.4byte sTreeckoPose86
+.4byte sTreeckoPose87
+.4byte sTreeckoPose88
+.4byte sTreeckoPose89
+.4byte sTreeckoPose90
+.4byte sTreeckoPose91
+.4byte sTreeckoPose92
+.4byte sTreeckoPose93
+.4byte sTreeckoPose94
+.4byte sTreeckoPose95
+.4byte sTreeckoPose96
+.4byte sTreeckoPose97
+.4byte sTreeckoPose98
+.4byte sTreeckoPose99
+.4byte sTreeckoPose100
+.4byte sTreeckoPose101
+.4byte sTreeckoPose102
+.4byte sTreeckoPose103
+.4byte sTreeckoPose104
+.4byte sTreeckoPose105
+.4byte sTreeckoPose106
+.4byte sTreeckoPose107
+.4byte sTreeckoPose108
+.4byte sTreeckoPose109
+.4byte sTreeckoPose110
+.4byte sTreeckoPose111
+.4byte sTreeckoPose112
+.4byte sTreeckoPose113
+.4byte sTreeckoPose114
+.4byte sTreeckoPose115
+.4byte sTreeckoPose116
+.4byte sTreeckoPose117
+.4byte sTreeckoPose118
+.4byte sTreeckoPose119
+.4byte sTreeckoPose120
+.4byte sTreeckoPose121
+.4byte sTreeckoPose122
+.4byte sTreeckoPose123
+.4byte sTreeckoPose124
+.4byte sTreeckoPose125
+.4byte sTreeckoPose126
+.4byte sTreeckoPose127
+.4byte sTreeckoPose128
+.4byte sTreeckoPose129
+.4byte sTreeckoPose130
+.4byte sTreeckoPose131
+.4byte sTreeckoPose132
+.4byte sTreeckoPose133
+.4byte sTreeckoPose134
+.4byte sTreeckoPose135
+.4byte sTreeckoPose136
+.4byte sTreeckoPose137
+.4byte sTreeckoPose138
+.4byte sTreeckoPose139
+.4byte sTreeckoPose140
+.4byte sTreeckoPose141
+.4byte sTreeckoPose142
+.4byte sTreeckoPose143
+.4byte sTreeckoPose144
+.4byte sTreeckoPose145
+.4byte sTreeckoPose146
+.4byte sTreeckoPose147
+.4byte sTreeckoPose148
+.4byte sTreeckoPose149
+.4byte sTreeckoPose150
+.4byte sTreeckoPose151
+.4byte sTreeckoPose152
+.4byte sTreeckoPose153
+.4byte sTreeckoPose154
+.4byte sTreeckoPose155
+.4byte sTreeckoPose156
+.4byte sTreeckoPose157
+.4byte sTreeckoPose158
+.4byte sTreeckoPose159
+.4byte sTreeckoPose160
+.4byte sTreeckoPose161
+.4byte sTreeckoPose162
+.4byte sTreeckoPose163
+.4byte sTreeckoPose164
+.4byte sTreeckoPose165
+.4byte sTreeckoPose166
+.4byte sTreeckoPose167
+.4byte sTreeckoPose168
+.4byte sTreeckoPose169
+.4byte sTreeckoPose170
+.4byte sTreeckoPose171
+.4byte sTreeckoPose172
+.4byte sTreeckoPose173
+.4byte sTreeckoPose174
+.4byte sTreeckoPose175
+.4byte sTreeckoPose176
+.4byte sTreeckoPose177
+.4byte sTreeckoPose178
+.4byte sTreeckoPose179
+.4byte sTreeckoPose180
+.4byte sTreeckoPose181
+.4byte sTreeckoPose182
+.4byte sTreeckoPose183
+.4byte sTreeckoPose184
+.4byte sTreeckoPose185
+.4byte sTreeckoPose186
+.4byte sTreeckoPose187
+.4byte sTreeckoPose188
+.4byte sTreeckoPose189
+.4byte sTreeckoPose190
+.4byte sTreeckoPose191
+.4byte sTreeckoPose192
+.4byte sTreeckoPose193
+.4byte sTreeckoPose194
+.4byte sTreeckoPose195
+.4byte sTreeckoPose196
+.4byte sTreeckoPose197
+.4byte sTreeckoPose198
+.4byte sTreeckoPose199
+.4byte sTreeckoPose200
+.4byte sTreeckoPose201
+.4byte sTreeckoPose202
+.4byte sTreeckoPose203
+.4byte sTreeckoPose204
+.4byte sTreeckoPose205
+.4byte sTreeckoPose206
+.4byte sTreeckoPose207
+.4byte sTreeckoPose208
+.4byte sTreeckoPose209
+.4byte sTreeckoPose210
+.4byte sTreeckoPose211
+.4byte sTreeckoPose212
+.4byte sTreeckoPose213
+.4byte sTreeckoPose214
+.4byte sTreeckoPose215
+.4byte sTreeckoPose216
+.4byte sTreeckoPose217
+.4byte sTreeckoPose218
+.4byte sTreeckoPose219
+.4byte sTreeckoPose220
+.4byte sTreeckoPose221
+.4byte sTreeckoPose222
+.4byte sTreeckoPose223
+.4byte sTreeckoPose224
+.4byte sTreeckoPose225
+.4byte sTreeckoPose226
+.4byte sTreeckoPose227
+.4byte sTreeckoPose228
+.4byte sTreeckoPose229
+.4byte sTreeckoPose230
+.4byte sTreeckoPose231
+.4byte sTreeckoPose232
+.4byte sTreeckoPose233
+.4byte sTreeckoPose234
+.4byte sTreeckoPose235
+.4byte sTreeckoPose236
+.4byte sTreeckoPose237
+.4byte sTreeckoPose238
+.4byte sTreeckoPose239
+.4byte sTreeckoPose240
+.4byte sTreeckoPose241
+.4byte sTreeckoPose242
+.4byte sTreeckoPose243
+.4byte sTreeckoPose244
+.4byte sTreeckoPose245
+.4byte sTreeckoPose246
+.4byte sTreeckoPose247
+.4byte sTreeckoPose248
+.4byte sTreeckoPose249
+.4byte sTreeckoPose250
+.4byte sTreeckoPose251
+.4byte sTreeckoPose252
+.4byte sTreeckoPose253
+.4byte sTreeckoPose254
+.4byte sTreeckoPose255
+.4byte sTreeckoPose256
+.4byte sTreeckoPose257
+.4byte sTreeckoPose258
+.4byte sTreeckoPose259
+sAxPositionsTreecko:
+.2byte   -1,   -1, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -1,    0, 	  -5,    0, 	   3,    3, 	  -1,   -4
+.2byte   -1,    0, 	  -5,    3, 	   3,    0, 	  -1,   -4
+.2byte    7,   -3, 	   6,   -1, 	   1,    2, 	   0,   -6
+.2byte    7,   -2, 	   7,   -3, 	   3,    3, 	   0,   -5
+.2byte    7,   -2, 	   7,    1, 	   0,    1, 	   0,   -5
+.2byte   10,   -7, 	   2,   -2, 	   4,    0, 	   0,   -6
+.2byte   10,   -6, 	   2,   -2, 	   5,    0, 	   0,   -5
+.2byte   10,   -6, 	   5,   -2, 	   2,    0, 	   0,   -5
+.2byte    8,   -9, 	  -2,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    8,   -8, 	  -2,   -4, 	   6,   -2, 	  -1,   -5
+.2byte    8,   -8, 	   0,   -7, 	   3,   -1, 	  -1,   -5
+.2byte   -1,  -11, 	   5,   -3, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	   3,   -8, 	  -7,   -4, 	   0,   -8
+.2byte   -1,  -11, 	   5,   -4, 	  -5,   -8, 	  -1,   -6
+.2byte  -10,   -9, 	   0,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -2, 	  -1,   -5
+.2byte  -10,   -8, 	  -2,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte  -11,   -7, 	  -3,   -2, 	  -5,    0, 	  -1,   -6
+.2byte  -11,   -6, 	  -3,   -2, 	  -6,    0, 	  -1,   -5
+.2byte  -11,   -6, 	  -6,   -2, 	  -3,    0, 	  -1,   -5
+.2byte   -8,   -3, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -8,   -2, 	  -8,   -3, 	  -4,    3, 	  -1,   -5
+.2byte   -8,   -2, 	  -8,    1, 	  -1,    1, 	  -1,   -5
+.2byte   -1,   -1, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -1,    0, 	  -5,    0, 	   3,    3, 	  -1,   -4
+.2byte   -1,    0, 	  -5,    3, 	   3,    0, 	  -1,   -4
+.2byte    7,   -3, 	   6,   -1, 	   1,    2, 	   0,   -6
+.2byte    7,   -2, 	   7,   -3, 	   3,    3, 	   0,   -5
+.2byte    7,   -2, 	   7,    1, 	   0,    1, 	   0,   -5
+.2byte   10,   -7, 	   2,   -2, 	   4,    0, 	   0,   -6
+.2byte   10,   -6, 	   2,   -2, 	   5,    0, 	   0,   -5
+.2byte   10,   -6, 	   5,   -2, 	   2,    0, 	   0,   -5
+.2byte    8,   -9, 	  -2,   -5, 	   5,   -2, 	  -1,   -6
+.2byte    8,   -8, 	  -2,   -4, 	   6,   -2, 	  -1,   -5
+.2byte    8,   -8, 	   0,   -7, 	   3,   -1, 	  -1,   -5
+.2byte   -1,  -11, 	   5,   -3, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -10, 	   3,   -8, 	  -7,   -4, 	   0,   -8
+.2byte   -1,  -11, 	   5,   -4, 	  -5,   -8, 	  -1,   -6
+.2byte  -10,   -9, 	   0,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte  -10,   -8, 	   0,   -4, 	  -8,   -2, 	  -1,   -5
+.2byte  -10,   -8, 	  -2,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte  -11,   -7, 	  -3,   -2, 	  -5,    0, 	  -1,   -6
+.2byte  -11,   -6, 	  -3,   -2, 	  -6,    0, 	  -1,   -5
+.2byte  -11,   -6, 	  -6,   -2, 	  -3,    0, 	  -1,   -5
+.2byte   -8,   -3, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -8,   -2, 	  -8,   -3, 	  -4,    3, 	  -1,   -5
+.2byte   -8,   -2, 	  -8,    1, 	  -1,    1, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -9, 	   7,   -9, 	  -1,   -9
+.2byte   -3,  -10, 	  -9,  -13, 	   4,   -6, 	  -1,   -8
+.2byte    0,   -2, 	   1,    1, 	   7,  -12, 	   0,   -4
+.2byte    0,   -2, 	   1,    1, 	   7,  -12, 	   0,   -4
+.2byte    2,   -9, 	   4,  -12, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	   0,  -11, 	  -4,   -5, 	  -3,   -9
+.2byte    1,   -5, 	   4,    0, 	  -6,  -12, 	   0,   -8
+.2byte    1,   -5, 	   4,    0, 	  -6,  -12, 	   0,   -8
+.2byte    4,  -10, 	   0,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte    3,  -11, 	  -7,  -11, 	   0,   -5, 	  -2,   -8
+.2byte    7,   -8, 	   6,   -3, 	  -5,   -8, 	   0,   -6
+.2byte    7,   -8, 	   6,   -3, 	  -5,   -8, 	   0,   -6
+.2byte    4,  -13, 	  -8,  -11, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -11, 	  -9,   -9, 	   5,   -5, 	  -2,   -7
+.2byte    8,  -10, 	   1,   -4, 	   3,   -5, 	   0,   -8
+.2byte    8,  -10, 	   1,   -4, 	   3,   -5, 	   0,   -8
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -2,  -13, 	   3,  -12, 	  -8,   -7, 	  -2,   -8
+.2byte   -1,  -10, 	   2,   -4, 	  -7,  -10, 	  -1,   -8
+.2byte   -1,  -10, 	   2,   -4, 	  -7,  -10, 	  -1,   -8
+.2byte   -6,  -13, 	   6,  -11, 	  -8,   -5, 	  -1,   -8
+.2byte   -6,  -11, 	   7,   -9, 	  -7,   -5, 	   0,   -7
+.2byte  -10,  -10, 	  -3,   -4, 	  -5,   -5, 	  -2,   -8
+.2byte  -10,  -10, 	  -3,   -4, 	  -5,   -5, 	  -2,   -8
+.2byte   -6,  -10, 	  -2,   -4, 	   1,   -3, 	  -1,   -9
+.2byte   -5,  -11, 	   5,  -11, 	  -2,   -5, 	   0,   -8
+.2byte   -9,   -8, 	  -8,   -3, 	   3,   -8, 	  -2,   -6
+.2byte   -9,   -8, 	  -8,   -3, 	   3,   -8, 	  -2,   -6
+.2byte   -4,   -9, 	  -6,  -12, 	   5,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	  -2,  -11, 	   2,   -5, 	   1,   -9
+.2byte   -3,   -5, 	  -6,    0, 	   4,  -12, 	  -2,   -8
+.2byte   -3,   -5, 	  -6,    0, 	   4,  -12, 	  -2,   -8
+.2byte   -1,   -6, 	  -9,  -12, 	   7,  -12, 	  -1,   -8
+.2byte   -4,   -7, 	  -7,  -15, 	   4,   -9, 	   0,   -6
+.2byte   -7,   -9, 	   2,  -11, 	   3,   -8, 	   0,   -7
+.2byte   -6,  -11, 	   5,  -13, 	  -7,   -8, 	   0,   -7
+.2byte   -1,  -12, 	   6,  -13, 	  -9,  -12, 	  -1,   -7
+.2byte    4,  -11, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    5,   -9, 	  -4,  -11, 	  -5,   -8, 	  -2,   -7
+.2byte    2,   -7, 	   5,  -15, 	  -6,   -9, 	  -2,   -6
+.2byte   -1,   -8, 	  -9,   -9, 	   7,   -9, 	  -1,   -9
+.2byte   -3,  -10, 	  -9,  -13, 	   4,   -6, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,  -12, 	   7,  -12, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -3, 	   6,   -3, 	  -1,   -7
+.2byte    2,   -9, 	   4,  -12, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	   0,  -11, 	  -4,   -5, 	  -3,   -9
+.2byte    2,   -7, 	   5,  -15, 	  -6,   -9, 	  -2,   -6
+.2byte    2,   -6, 	   6,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte    4,  -10, 	   0,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte    3,  -11, 	  -7,  -11, 	   0,   -5, 	  -2,   -8
+.2byte    5,   -9, 	  -4,  -11, 	  -5,   -8, 	  -2,   -7
+.2byte    5,   -8, 	  -1,   -2, 	  -2,    1, 	  -1,   -7
+.2byte    4,  -13, 	  -8,  -11, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -11, 	  -9,   -9, 	   5,   -5, 	  -2,   -7
+.2byte    4,  -11, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    4,   -9, 	  -6,   -5, 	   2,    0, 	  -2,   -6
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -2,  -13, 	   3,  -12, 	  -8,   -7, 	  -2,   -8
+.2byte   -1,  -12, 	   6,  -13, 	  -9,  -12, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -4, 	  -9,   -4, 	  -1,   -6
+.2byte   -6,  -13, 	   6,  -11, 	  -8,   -5, 	  -1,   -8
+.2byte   -6,  -11, 	   7,   -9, 	  -7,   -5, 	   0,   -7
+.2byte   -6,  -11, 	   5,  -13, 	  -7,   -8, 	   0,   -7
+.2byte   -6,   -9, 	   4,   -5, 	  -4,    0, 	   0,   -6
+.2byte   -6,  -10, 	  -2,   -4, 	   1,   -3, 	  -1,   -9
+.2byte   -5,  -11, 	   5,  -11, 	  -2,   -5, 	   0,   -8
+.2byte   -7,   -9, 	   2,  -11, 	   3,   -8, 	   0,   -7
+.2byte   -7,   -8, 	  -1,   -2, 	   0,    1, 	  -1,   -7
+.2byte   -4,   -9, 	  -6,  -12, 	   5,   -4, 	  -1,   -9
+.2byte   -1,  -10, 	  -2,  -11, 	   2,   -5, 	   1,   -9
+.2byte   -4,   -7, 	  -7,  -15, 	   4,   -9, 	   0,   -6
+.2byte   -4,   -6, 	  -8,   -7, 	   3,   -1, 	  -1,   -5
+.2byte   -1,   -7, 	  -5,   -3, 	   5,   -1, 	   1,   -7
+.2byte   -2,   -6, 	  -5,   -2, 	   5,    0, 	   1,   -6
+.2byte    0,  -13, 	  -8,  -18, 	   8,  -18, 	   0,  -12
+.2byte    1,  -13, 	   3,  -19, 	  -7,  -13, 	  -2,  -12
+.2byte    2,  -14, 	  -5,  -17, 	  -7,  -13, 	  -2,  -11
+.2byte    1,  -16, 	 -10,  -17, 	  -5,  -14, 	  -2,  -13
+.2byte   -1,  -14, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -3,  -16, 	   8,  -17, 	   3,  -14, 	   0,  -13
+.2byte   -4,  -14, 	   3,  -17, 	   5,  -13, 	   0,  -11
+.2byte   -3,  -13, 	  -5,  -19, 	   5,  -13, 	   0,  -12
+.2byte   -1,   -8, 	  -9,   -9, 	   7,   -9, 	  -1,   -9
+.2byte   -4,   -9, 	  -6,  -12, 	   5,   -4, 	  -1,   -9
+.2byte   -6,  -10, 	  -2,   -4, 	   1,   -3, 	  -1,   -9
+.2byte   -6,  -13, 	   6,  -11, 	  -8,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte    4,  -13, 	  -8,  -11, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -10, 	   0,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte    2,   -9, 	   4,  -12, 	  -7,   -4, 	  -1,   -9
+.2byte   -1,   -1, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte   -8,   -3, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte  -11,   -7, 	  -3,   -2, 	  -5,    0, 	  -1,   -6
+.2byte  -10,   -9, 	   0,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -1,  -11, 	   5,   -3, 	  -7,   -3, 	  -1,   -9
+.2byte    8,   -9, 	  -2,   -5, 	   5,   -2, 	  -1,   -6
+.2byte   10,   -7, 	   2,   -2, 	   4,    0, 	   0,   -6
+.2byte    7,   -3, 	   6,   -1, 	   1,    2, 	   0,   -6
+.2byte   -1,   -6, 	  -9,  -12, 	   7,  -12, 	  -1,   -8
+.2byte    2,   -7, 	   5,  -15, 	  -6,   -9, 	  -2,   -6
+.2byte    5,   -9, 	  -4,  -11, 	  -5,   -8, 	  -2,   -7
+.2byte    4,  -11, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte   -1,  -12, 	   6,  -13, 	  -9,  -12, 	  -1,   -7
+.2byte   -6,  -11, 	   5,  -13, 	  -7,   -8, 	   0,   -7
+.2byte   -7,   -9, 	   2,  -11, 	   3,   -8, 	   0,   -7
+.2byte   -4,   -7, 	  -7,  -15, 	   4,   -9, 	   0,   -6
+.2byte   -1,   -8, 	  -9,   -9, 	   7,   -9, 	  -1,   -9
+.2byte   -1,   -6, 	  -9,  -12, 	   7,  -12, 	  -1,   -8
+.2byte   -1,   -5, 	  -6,   -3, 	   6,   -3, 	  -1,   -7
+.2byte   -1,   -1, 	  -5,    1, 	   3,    1, 	  -1,   -5
+.2byte    2,   -9, 	   4,  -12, 	  -7,   -4, 	  -1,   -9
+.2byte    2,   -7, 	   5,  -15, 	  -6,   -9, 	  -2,   -6
+.2byte    2,   -6, 	   6,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte    7,   -3, 	   6,   -1, 	   1,    2, 	   0,   -6
+.2byte    4,  -10, 	   0,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte    5,   -9, 	  -4,  -11, 	  -5,   -8, 	  -2,   -7
+.2byte    5,   -8, 	  -1,   -2, 	  -2,    1, 	  -1,   -7
+.2byte    9,   -6, 	   1,   -1, 	   3,    1, 	  -1,   -5
+.2byte    4,  -13, 	  -8,  -11, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -11, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    4,   -9, 	  -6,   -5, 	   2,    0, 	  -2,   -6
+.2byte    9,   -9, 	  -1,   -5, 	   6,   -2, 	   0,   -6
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,  -12, 	   6,  -13, 	  -9,  -12, 	  -1,   -7
+.2byte   -1,  -11, 	   7,   -4, 	  -9,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	   5,   -3, 	  -7,   -3, 	  -1,   -9
+.2byte   -6,  -13, 	   6,  -11, 	  -8,   -5, 	  -1,   -8
+.2byte   -6,  -11, 	   5,  -13, 	  -7,   -8, 	   0,   -7
+.2byte   -6,   -9, 	   4,   -5, 	  -4,    0, 	   0,   -6
+.2byte  -10,   -9, 	   0,   -5, 	  -7,   -2, 	  -1,   -6
+.2byte   -6,  -10, 	  -2,   -4, 	   1,   -3, 	  -1,   -9
+.2byte   -7,   -9, 	   2,  -11, 	   3,   -8, 	   0,   -7
+.2byte   -7,   -8, 	  -1,   -2, 	   0,    1, 	  -1,   -7
+.2byte  -10,   -6, 	  -2,   -1, 	  -4,    1, 	   0,   -5
+.2byte   -4,   -9, 	  -6,  -12, 	   5,   -4, 	  -1,   -9
+.2byte   -4,   -7, 	  -7,  -15, 	   4,   -9, 	   0,   -6
+.2byte   -4,   -6, 	  -8,   -7, 	   3,   -1, 	  -1,   -5
+.2byte   -8,   -3, 	  -7,   -1, 	  -2,    2, 	  -1,   -6
+.2byte   -1,   -6, 	  -9,  -12, 	   7,  -12, 	  -1,   -8
+.2byte   -4,   -7, 	  -7,  -15, 	   4,   -9, 	   0,   -6
+.2byte   -7,   -9, 	   2,  -11, 	   3,   -8, 	   0,   -7
+.2byte   -6,  -11, 	   5,  -13, 	  -7,   -8, 	   0,   -7
+.2byte   -1,  -12, 	   6,  -13, 	  -9,  -12, 	  -1,   -7
+.2byte    4,  -11, 	  -7,  -13, 	   5,   -8, 	  -2,   -7
+.2byte    5,   -9, 	  -4,  -11, 	  -5,   -8, 	  -2,   -7
+.2byte    2,   -7, 	   5,  -15, 	  -6,   -9, 	  -2,   -6
+.2byte   -1,   -8, 	  -9,   -9, 	   7,   -9, 	  -1,   -9
+.2byte   -4,   -9, 	  -6,  -12, 	   5,   -4, 	  -1,   -9
+.2byte   -6,  -10, 	  -2,   -4, 	   1,   -3, 	  -1,   -9
+.2byte   -6,  -13, 	   6,  -11, 	  -8,   -5, 	  -1,   -8
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte    4,  -13, 	  -8,  -11, 	   6,   -5, 	  -1,   -8
+.2byte    4,  -10, 	   0,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte    2,   -9, 	   4,  -12, 	  -7,   -4, 	  -1,   -9
+.2byte   -3,   -1, 	  -7,    1, 	   2,    0, 	   1,   -4
+.2byte   -4,   -1, 	  -7,    1, 	   2,    0, 	   1,   -5
+.2byte    2,   -1, 	   6,    1, 	  -3,    0, 	  -2,   -4
+.2byte    3,   -1, 	   6,    1, 	  -3,    0, 	  -2,   -5
+.2byte   -3,   -1, 	  -7,    1, 	   2,    0, 	   1,   -4
+.2byte   -1,   -2, 	  -8,    1, 	   0,    0, 	   0,   -5
+.2byte    2,   -4, 	  -7,    0, 	   0,    0, 	  -2,   -5
+.2byte    5,   -8, 	  -4,   -2, 	   2,   -4, 	   0,   -6
+.2byte    4,  -10, 	   0,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,  -14, 	   8,   -5, 	 -10,   -5, 	  -1,   -8
+.2byte   -1,  -11, 	   8,   -5, 	 -10,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	  -6,   -5, 	   4,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte   -2,   -7, 	  -6,   -6, 	   4,   -5, 	   0,   -7
+.2byte    0,    0, 	   0,    0, 	   0,    0, 	   0,    0
+.2byte    0,   -9, 	  -7,  -15, 	   6,   -8, 	   0,   -8
+.2byte   -1,  -14, 	   5,   -9, 	  -7,   -8, 	  -1,   -9
+.2byte   -2,  -15, 	   5,  -18, 	  -7,   -7, 	  -1,  -10
+.2byte   -2,  -15, 	   5,  -18, 	  -7,   -7, 	  -1,  -10
+.2byte   -1,   -7, 	  -6,   -3, 	   4,   -3, 	  -1,   -6
+.2byte   -1,   -8, 	  -6,   -4, 	   4,   -4, 	  -1,   -7
+.2byte   -1,   -8, 	  -6,   -4, 	   4,   -4, 	  -1,   -7
+.2byte   -6,  -10, 	  -2,   -4, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -12, 	   3,   -9, 	   2,   -5, 	   1,   -6
+.2byte    1,  -12, 	   8,   -6, 	   3,   -3, 	  -1,   -6
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,  -12, 	   4,   -2, 	  -6,   -2, 	  -1,   -6
+.2byte   -1,   -9, 	   5,    1, 	  -7,    1, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -9, 	   7,   -9, 	  -1,   -9
+.2byte   -1,  -12, 	  -9,   -6, 	   7,   -6, 	  -1,   -9
+.2byte   -1,   -6, 	  -2,   -1, 	  -1,   -2, 	  -1,   -7
+.2byte   -6,  -10, 	  -2,   -4, 	   1,   -3, 	  -1,   -9
+.2byte   -4,   -6, 	   1,   -5, 	   1,   -3, 	  -2,   -7
+.2byte    4,  -10, 	   0,   -4, 	  -3,   -3, 	  -1,   -9
+.2byte    2,   -6, 	  -3,   -5, 	  -3,   -3, 	   0,   -7
+.2byte   -1,  -13, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte   -1,   -9, 	   6,  -11, 	  -8,  -11, 	  -1,   -6
+.2byte  -11,   -6, 	  -4,   -3, 	  -5,    1, 	  -2,   -5
+.2byte  -11,   -7, 	  -1,   -3, 	  -5,   -3, 	  -3,   -6
+.2byte  -11,   -5, 	   0,   -1, 	  -7,    1, 	  -2,   -4
+.2byte  -11,   -7, 	  -7,   -5, 	  -4,    1, 	  -2,   -6
+.2byte  -11,   -5, 	  -9,   -2, 	  -4,    1, 	  -2,   -5
+.2byte   10,   -6, 	   3,   -3, 	   4,    1, 	   1,   -5
+.2byte   10,   -7, 	   0,   -3, 	   4,   -3, 	   2,   -6
+.2byte   10,   -5, 	  -1,   -1, 	   6,    1, 	   1,   -4
+.2byte   10,   -7, 	   6,   -5, 	   3,    1, 	   1,   -6
+.2byte   10,   -5, 	   8,   -2, 	   3,    1, 	   1,   -5
+.2byte    2,   -9, 	  -3,  -12, 	   4,   -9, 	  -3,   -6
+.2byte   -3,   -1, 	  -7,    1, 	   2,    0, 	   1,   -4
+.2byte   -4,   -1, 	  -7,    1, 	   2,    0, 	   1,   -5
+.2byte    2,   -1, 	   6,    1, 	  -3,    0, 	  -2,   -4
+.2byte    3,   -1, 	   6,    1, 	  -3,    0, 	  -2,   -5
+.2byte   -3,   -1, 	  -7,    1, 	   2,    0, 	   1,   -4
+.2byte   -4,   -1, 	  -7,    1, 	   2,    0, 	   1,   -5
+.2byte    2,   -1, 	   6,    1, 	  -3,    0, 	  -2,   -4
+.2byte    3,   -1, 	   6,    1, 	  -3,    0, 	  -2,   -5
+sTreeckoAnimTable1:
+.4byte sTreeckoAnims_1_1
+.4byte sTreeckoAnims_1_2
+.4byte sTreeckoAnims_1_3
+.4byte sTreeckoAnims_1_4
+.4byte sTreeckoAnims_1_5
+.4byte sTreeckoAnims_1_6
+.4byte sTreeckoAnims_1_7
+.4byte sTreeckoAnims_1_8
+sTreeckoAnimTable2:
+.4byte sTreeckoAnims_2_1
+.4byte sTreeckoAnims_2_2
+.4byte sTreeckoAnims_2_3
+.4byte sTreeckoAnims_2_4
+.4byte sTreeckoAnims_2_5
+.4byte sTreeckoAnims_2_6
+.4byte sTreeckoAnims_2_7
+.4byte sTreeckoAnims_2_8
+sTreeckoAnimTable3:
+.4byte sTreeckoAnims_3_1
+.4byte sTreeckoAnims_3_2
+.4byte sTreeckoAnims_3_3
+.4byte sTreeckoAnims_3_4
+.4byte sTreeckoAnims_3_5
+.4byte sTreeckoAnims_3_6
+.4byte sTreeckoAnims_3_7
+.4byte sTreeckoAnims_3_8
+sTreeckoAnimTable4:
+.4byte sTreeckoAnims_4_1
+.4byte sTreeckoAnims_4_2
+.4byte sTreeckoAnims_4_3
+.4byte sTreeckoAnims_4_4
+.4byte sTreeckoAnims_4_5
+.4byte sTreeckoAnims_4_6
+.4byte sTreeckoAnims_4_7
+.4byte sTreeckoAnims_4_8
+sTreeckoAnimTable5:
+.4byte sTreeckoAnims_5_1
+.4byte sTreeckoAnims_5_2
+.4byte sTreeckoAnims_5_3
+.4byte sTreeckoAnims_5_4
+.4byte sTreeckoAnims_5_5
+.4byte sTreeckoAnims_5_6
+.4byte sTreeckoAnims_5_7
+.4byte sTreeckoAnims_5_8
+sTreeckoAnimTable6:
+.4byte sTreeckoAnims_6_1
+.4byte sTreeckoAnims_6_1
+.4byte sTreeckoAnims_6_1
+.4byte sTreeckoAnims_6_1
+.4byte sTreeckoAnims_6_1
+.4byte sTreeckoAnims_6_1
+.4byte sTreeckoAnims_6_1
+.4byte sTreeckoAnims_6_1
+sTreeckoAnimTable7:
+.4byte sTreeckoAnims_7_1
+.4byte sTreeckoAnims_7_2
+.4byte sTreeckoAnims_7_3
+.4byte sTreeckoAnims_7_4
+.4byte sTreeckoAnims_7_5
+.4byte sTreeckoAnims_7_6
+.4byte sTreeckoAnims_7_7
+.4byte sTreeckoAnims_7_8
+sTreeckoAnimTable8:
+.4byte sTreeckoAnims_8_1
+.4byte sTreeckoAnims_8_2
+.4byte sTreeckoAnims_8_3
+.4byte sTreeckoAnims_8_4
+.4byte sTreeckoAnims_8_5
+.4byte sTreeckoAnims_8_6
+.4byte sTreeckoAnims_8_7
+.4byte sTreeckoAnims_8_8
+sTreeckoAnimTable9:
+.4byte sTreeckoAnims_9_1
+.4byte sTreeckoAnims_9_2
+.4byte sTreeckoAnims_9_3
+.4byte sTreeckoAnims_9_4
+.4byte sTreeckoAnims_9_5
+.4byte sTreeckoAnims_9_6
+.4byte sTreeckoAnims_9_7
+.4byte sTreeckoAnims_9_8
+sTreeckoAnimTable10:
+.4byte sTreeckoAnims_10_1
+.4byte sTreeckoAnims_10_2
+.4byte sTreeckoAnims_10_3
+.4byte sTreeckoAnims_10_4
+.4byte sTreeckoAnims_10_5
+.4byte sTreeckoAnims_10_6
+.4byte sTreeckoAnims_10_7
+.4byte sTreeckoAnims_10_8
+sTreeckoAnimTable11:
+.4byte sTreeckoAnims_11_1
+.4byte sTreeckoAnims_11_2
+.4byte sTreeckoAnims_11_3
+.4byte sTreeckoAnims_11_4
+.4byte sTreeckoAnims_11_5
+.4byte sTreeckoAnims_11_6
+.4byte sTreeckoAnims_11_7
+.4byte sTreeckoAnims_11_8
+sTreeckoAnimTable12:
+.4byte sTreeckoAnims_12_1
+.4byte sTreeckoAnims_12_2
+.4byte sTreeckoAnims_12_3
+.4byte sTreeckoAnims_12_4
+.4byte sTreeckoAnims_12_5
+.4byte sTreeckoAnims_12_6
+.4byte sTreeckoAnims_12_7
+.4byte sTreeckoAnims_12_8
+sTreeckoAnimTable13:
+.4byte sTreeckoAnims_13_1
+.4byte sTreeckoAnims_13_2
+.4byte sTreeckoAnims_13_3
+.4byte sTreeckoAnims_13_4
+.4byte sTreeckoAnims_13_5
+.4byte sTreeckoAnims_13_6
+.4byte sTreeckoAnims_13_7
+.4byte sTreeckoAnims_13_8
+sTreeckoAnimTable14:
+.4byte sTreeckoAnims_14_1
+.4byte sTreeckoAnims_14_2
+.4byte sTreeckoAnims_14_3
+.4byte sTreeckoAnims_14_4
+.4byte sTreeckoAnims_14_5
+.4byte sTreeckoAnims_14_6
+.4byte sTreeckoAnims_14_7
+.4byte sTreeckoAnims_14_8
+sTreeckoAnimTable15:
+.4byte sTreeckoAnims_15_1
+.4byte sTreeckoAnims_15_2
+.4byte sTreeckoAnims_15_3
+.4byte sTreeckoAnims_15_4
+.4byte sTreeckoAnims_15_5
+.4byte sTreeckoAnims_15_6
+.4byte sTreeckoAnims_15_7
+.4byte sTreeckoAnims_15_8
+sTreeckoAnimTable16:
+.4byte sTreeckoAnims_16_1
+.4byte sTreeckoAnims_16_2
+.4byte sTreeckoAnims_16_3
+.4byte sTreeckoAnims_16_4
+.4byte sTreeckoAnims_16_5
+.4byte sTreeckoAnims_16_6
+.4byte sTreeckoAnims_16_7
+.4byte sTreeckoAnims_16_8
+sTreeckoAnimTable17:
+.4byte sTreeckoAnims_17_1
+.4byte sTreeckoAnims_17_2
+.4byte sTreeckoAnims_17_3
+.4byte sTreeckoAnims_17_4
+.4byte sTreeckoAnims_17_5
+.4byte sTreeckoAnims_17_6
+.4byte sTreeckoAnims_17_7
+.4byte sTreeckoAnims_17_8
+sTreeckoAnimTable18:
+.4byte sTreeckoAnims_18_1
+.4byte sTreeckoAnims_18_2
+.4byte sTreeckoAnims_18_3
+.4byte sTreeckoAnims_18_4
+.4byte sTreeckoAnims_18_5
+.4byte sTreeckoAnims_18_6
+.4byte sTreeckoAnims_18_7
+.4byte sTreeckoAnims_18_8
+sTreeckoAnimTable19:
+.4byte sTreeckoAnims_19_1
+.4byte sTreeckoAnims_19_2
+.4byte sTreeckoAnims_19_3
+.4byte sTreeckoAnims_19_4
+.4byte sTreeckoAnims_19_5
+.4byte sTreeckoAnims_19_6
+.4byte sTreeckoAnims_19_7
+.4byte sTreeckoAnims_19_8
+sTreeckoAnimTable20:
+.4byte sTreeckoAnims_20_1
+.4byte sTreeckoAnims_20_2
+.4byte sTreeckoAnims_20_3
+.4byte sTreeckoAnims_20_4
+.4byte sTreeckoAnims_20_5
+.4byte sTreeckoAnims_20_6
+.4byte sTreeckoAnims_20_7
+.4byte sTreeckoAnims_20_8
+sTreeckoAnimTable21:
+.4byte sTreeckoAnims_21_1
+.4byte sTreeckoAnims_21_2
+.4byte sTreeckoAnims_21_3
+.4byte sTreeckoAnims_21_4
+.4byte sTreeckoAnims_21_5
+.4byte sTreeckoAnims_21_6
+.4byte sTreeckoAnims_21_7
+.4byte sTreeckoAnims_21_8
+sTreeckoAnimTable22:
+.4byte sTreeckoAnims_22_1
+.4byte sTreeckoAnims_22_2
+.4byte sTreeckoAnims_22_3
+.4byte sTreeckoAnims_22_4
+.4byte sTreeckoAnims_22_5
+.4byte sTreeckoAnims_22_6
+.4byte sTreeckoAnims_22_7
+.4byte sTreeckoAnims_22_8
+sTreeckoAnimTable23:
+.4byte sTreeckoAnims_23_1
+.4byte sTreeckoAnims_23_2
+.4byte sTreeckoAnims_23_3
+.4byte sTreeckoAnims_23_4
+.4byte sTreeckoAnims_23_5
+.4byte sTreeckoAnims_23_6
+.4byte sTreeckoAnims_23_7
+.4byte sTreeckoAnims_23_8
+sTreeckoAnimTable24:
+.4byte sTreeckoAnims_24_1
+.4byte sTreeckoAnims_24_2
+.4byte sTreeckoAnims_24_3
+.4byte sTreeckoAnims_24_4
+.4byte sTreeckoAnims_24_5
+.4byte sTreeckoAnims_24_6
+.4byte sTreeckoAnims_24_7
+.4byte sTreeckoAnims_24_8
+sTreeckoAnimTable25:
+.4byte sTreeckoAnims_25_1
+.4byte sTreeckoAnims_25_2
+.4byte sTreeckoAnims_25_3
+.4byte sTreeckoAnims_25_4
+.4byte sTreeckoAnims_25_5
+.4byte sTreeckoAnims_25_6
+.4byte sTreeckoAnims_25_7
+.4byte sTreeckoAnims_25_8
+sTreeckoAnimTable26:
+.4byte sTreeckoAnims_26_1
+.4byte sTreeckoAnims_26_2
+.4byte sTreeckoAnims_26_3
+.4byte sTreeckoAnims_26_4
+.4byte sTreeckoAnims_26_5
+.4byte sTreeckoAnims_26_6
+.4byte sTreeckoAnims_26_7
+.4byte sTreeckoAnims_26_8
+sTreeckoAnimTable27:
+.4byte sTreeckoAnims_27_1
+.4byte sTreeckoAnims_27_1
+.4byte sTreeckoAnims_27_1
+.4byte sTreeckoAnims_27_1
+.4byte sTreeckoAnims_27_1
+.4byte sTreeckoAnims_27_1
+.4byte sTreeckoAnims_27_1
+.4byte sTreeckoAnims_27_1
+sTreeckoAnimTable28:
+.4byte sTreeckoAnims_28_1
+.4byte sTreeckoAnims_28_2
+.4byte sTreeckoAnims_28_3
+.4byte sTreeckoAnims_28_4
+.4byte sTreeckoAnims_28_5
+.4byte sTreeckoAnims_28_6
+.4byte sTreeckoAnims_28_7
+.4byte sTreeckoAnims_28_8
+sAxAnimationsTreecko:
+.4byte sTreeckoAnimTable1
+.4byte sTreeckoAnimTable2
+.4byte sTreeckoAnimTable3
+.4byte sTreeckoAnimTable4
+.4byte sTreeckoAnimTable5
+.4byte sTreeckoAnimTable6
+.4byte sTreeckoAnimTable7
+.4byte sTreeckoAnimTable8
+.4byte sTreeckoAnimTable9
+.4byte sTreeckoAnimTable10
+.4byte sTreeckoAnimTable11
+.4byte sTreeckoAnimTable12
+.4byte sTreeckoAnimTable13
+.4byte sTreeckoAnimTable14
+.4byte sTreeckoAnimTable15
+.4byte sTreeckoAnimTable16
+.4byte sTreeckoAnimTable17
+.4byte sTreeckoAnimTable18
+.4byte sTreeckoAnimTable19
+.4byte sTreeckoAnimTable20
+.4byte sTreeckoAnimTable21
+.4byte sTreeckoAnimTable22
+.4byte sTreeckoAnimTable23
+.4byte sTreeckoAnimTable24
+.4byte sTreeckoAnimTable25
+.4byte sTreeckoAnimTable26
+.4byte sTreeckoAnimTable27
+.4byte sTreeckoAnimTable28
+sAxSpritesTreecko:
+.4byte sTreeckoSprites1
+.4byte sTreeckoSprites2
+.4byte sTreeckoSprites3
+.4byte sTreeckoSprites4
+.4byte sTreeckoSprites5
+.4byte sTreeckoSprites6
+.4byte sTreeckoSprites7
+.4byte sTreeckoSprites8
+.4byte sTreeckoSprites9
+.4byte sTreeckoSprites10
+.4byte sTreeckoSprites11
+.4byte sTreeckoSprites12
+.4byte sTreeckoSprites13
+.4byte sTreeckoSprites14
+.4byte sTreeckoSprites15
+.4byte sTreeckoSprites16
+.4byte sTreeckoSprites17
+.4byte sTreeckoSprites18
+.4byte sTreeckoSprites19
+.4byte sTreeckoSprites20
+.4byte sTreeckoSprites21
+.4byte sTreeckoSprites22
+.4byte sTreeckoSprites23
+.4byte sTreeckoSprites24
+.4byte sTreeckoSprites25
+.4byte sTreeckoSprites26
+.4byte sTreeckoSprites27
+.4byte sTreeckoSprites28
+.4byte sTreeckoSprites29
+.4byte sTreeckoSprites30
+.4byte sTreeckoSprites31
+.4byte sTreeckoSprites32
+.4byte sTreeckoSprites33
+.4byte sTreeckoSprites34
+.4byte sTreeckoSprites35
+.4byte sTreeckoSprites36
+.4byte sTreeckoSprites37
+.4byte sTreeckoSprites38
+.4byte sTreeckoSprites39
+.4byte sTreeckoSprites40
+.4byte sTreeckoSprites41
+.4byte sTreeckoSprites42
+.4byte sTreeckoSprites43
+.4byte sTreeckoSprites44
+.4byte sTreeckoSprites45
+.4byte sTreeckoSprites46
+.4byte sTreeckoSprites47
+.4byte sTreeckoSprites48
+.4byte sTreeckoSprites49
+.4byte sTreeckoSprites50
+.4byte sTreeckoSprites51
+.4byte sTreeckoSprites52
+.4byte sTreeckoSprites53
+.4byte sTreeckoSprites54
+.4byte sTreeckoSprites55
+.4byte sTreeckoSprites56
+.4byte sTreeckoSprites57
+.4byte sTreeckoSprites58
+.4byte sTreeckoSprites59
+.4byte sTreeckoSprites60
+.4byte sTreeckoSprites61
+.4byte sTreeckoSprites62
+.4byte sTreeckoSprites63
+.4byte sTreeckoSprites64
+.4byte sTreeckoSprites65
+.4byte sTreeckoSprites66
+.4byte sTreeckoSprites67
+.4byte sTreeckoSprites68
+.4byte sTreeckoSprites69
+.4byte sTreeckoSprites70
+.4byte sTreeckoSprites71
+.4byte sTreeckoSprites72
+.4byte sTreeckoSprites73
+.4byte sTreeckoSprites74
+.4byte sTreeckoSprites75
+.4byte sTreeckoSprites76
+.4byte sTreeckoSprites77
+.4byte sTreeckoSprites78
+.4byte sTreeckoSprites79
+.4byte sTreeckoSprites80
+.4byte sTreeckoSprites81
+.4byte sTreeckoSprites82
+sAxMainTreecko:
+ax_main sAxPosesTreecko, sAxAnimationsTreecko, 28, sAxSpritesTreecko, sAxPositionsTreecko

--- a/data/ax/tropius.inc
+++ b/data/ax/tropius.inc
@@ -1,0 +1,3979 @@
+.global gAxTropius
+gAxTropius:
+ax_siro sAxMainTropius
+sTropiusPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose2:
+ax_pose 1, 0x41ef, 0x80ef, 0x8c00
+ax_pose 2, 0x41ff, 0x00f7, 0x8c08
+ax_pose 3, 0x01ef, 0x010f, 0x8c0a
+ax_pose_terminator
+sTropiusPose3:
+ax_pose 4, 0x41ee, 0x80ef, 0x8c00
+ax_pose 5, 0x41fe, 0x40ef, 0x8c08
+ax_pose 6, 0x01ee, 0x010f, 0x8c0c
+ax_pose_terminator
+sTropiusPose4:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose5:
+ax_pose 8, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose6:
+ax_pose 9, 0x81e3, 0x9100, 0x8c00
+ax_pose 10, 0x01f3, 0x50f0, 0x8c08
+ax_pose 11, 0x01f0, 0x1110, 0x8c0c
+ax_pose_terminator
+sTropiusPose7:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose8:
+ax_pose 13, 0x81e6, 0x90f2, 0x8c00
+ax_pose 14, 0x81e6, 0x5102, 0x8c08
+ax_pose 15, 0x81e6, 0x110a, 0x8c0c
+ax_pose 16, 0x01eb, 0x1112, 0x8c0e
+ax_pose_terminator
+sTropiusPose9:
+ax_pose 17, 0x81e7, 0x90f3, 0x8c00
+ax_pose 18, 0x81e7, 0x5103, 0x8c08
+ax_pose 19, 0x81e7, 0x110b, 0x8c0c
+ax_pose 20, 0x01ed, 0x1113, 0x8c0e
+ax_pose_terminator
+sTropiusPose10:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose11:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose12:
+ax_pose 23, 0x81e6, 0x90ef, 0x8c00
+ax_pose 24, 0x81e6, 0x50ff, 0x8c08
+ax_pose 25, 0x81e6, 0x1107, 0x8c0c
+ax_pose 26, 0x01f6, 0x1107, 0x8c0e
+ax_pose 27, 0x01de, 0x1103, 0x8c0f
+ax_pose_terminator
+sTropiusPose13:
+ax_pose 28, 0x41e2, 0x00f8, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c02
+ax_pose 30, 0x41f2, 0x80f0, 0x8c06
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose14:
+ax_pose 33, 0x41e5, 0x00f8, 0x8c00
+ax_pose 34, 0x41ed, 0x40f0, 0x8c02
+ax_pose 35, 0x41f5, 0x80f0, 0x8c06
+ax_pose 31, 0x01f2, 0x00e8, 0x8c0e
+ax_pose 32, 0x01f2, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose15:
+ax_pose 36, 0x41e5, 0x00f8, 0x8c00
+ax_pose 37, 0x41ed, 0x40f0, 0x8c02
+ax_pose 38, 0x41f5, 0x80f0, 0x8c06
+ax_pose 31, 0x01f3, 0x00e8, 0x8c0e
+ax_pose 32, 0x01f3, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose16:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose17:
+ax_pose 22, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose18:
+ax_pose 23, 0x81e6, 0x8100, 0x8c00
+ax_pose 24, 0x81e6, 0x40f8, 0x8c08
+ax_pose 25, 0x81e6, 0x00f0, 0x8c0c
+ax_pose 26, 0x01f6, 0x00f0, 0x8c0e
+ax_pose 27, 0x01de, 0x00f4, 0x8c0f
+ax_pose_terminator
+sTropiusPose19:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose20:
+ax_pose 13, 0x81e6, 0x80fd, 0x8c00
+ax_pose 14, 0x81e6, 0x40f5, 0x8c08
+ax_pose 15, 0x81e6, 0x00ed, 0x8c0c
+ax_pose 16, 0x01eb, 0x00e5, 0x8c0e
+ax_pose_terminator
+sTropiusPose21:
+ax_pose 17, 0x81e7, 0x80fc, 0x8c00
+ax_pose 18, 0x81e7, 0x40f4, 0x8c08
+ax_pose 19, 0x81e7, 0x00ec, 0x8c0c
+ax_pose 20, 0x01ed, 0x00e4, 0x8c0e
+ax_pose_terminator
+sTropiusPose22:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose23:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose24:
+ax_pose 9, 0x81e3, 0x80f0, 0x8c00
+ax_pose 10, 0x01f3, 0x4100, 0x8c08
+ax_pose 11, 0x01f0, 0x00e8, 0x8c0c
+ax_pose_terminator
+sTropiusPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose26:
+ax_pose 1, 0x41ef, 0x80ef, 0x8c00
+ax_pose 2, 0x41ff, 0x00f7, 0x8c08
+ax_pose 3, 0x01ef, 0x010f, 0x8c0a
+ax_pose_terminator
+sTropiusPose27:
+ax_pose 4, 0x41ee, 0x80ef, 0x8c00
+ax_pose 5, 0x41fe, 0x40ef, 0x8c08
+ax_pose 6, 0x01ee, 0x010f, 0x8c0c
+ax_pose_terminator
+sTropiusPose28:
+ax_pose 39, 0x01ed, 0x80f1, 0x8c00
+ax_pose_terminator
+sTropiusPose29:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose30:
+ax_pose 8, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose31:
+ax_pose 9, 0x81e3, 0x9100, 0x8c00
+ax_pose 10, 0x01f3, 0x50f0, 0x8c08
+ax_pose 11, 0x01f0, 0x1110, 0x8c0c
+ax_pose_terminator
+sTropiusPose32:
+ax_pose 40, 0x81e8, 0x90f6, 0x8c00
+ax_pose 41, 0x81e8, 0x5106, 0x8c08
+ax_pose 42, 0x81f8, 0x110e, 0x8c0c
+ax_pose 43, 0x01f0, 0x110e, 0x8c0e
+ax_pose 44, 0x01f0, 0x10ee, 0x8c0f
+ax_pose_terminator
+sTropiusPose33:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose34:
+ax_pose 13, 0x81e6, 0x90f2, 0x8c00
+ax_pose 14, 0x81e6, 0x5102, 0x8c08
+ax_pose 15, 0x81e6, 0x110a, 0x8c0c
+ax_pose 16, 0x01eb, 0x1112, 0x8c0e
+ax_pose_terminator
+sTropiusPose35:
+ax_pose 17, 0x81e7, 0x90f3, 0x8c00
+ax_pose 18, 0x81e7, 0x5103, 0x8c08
+ax_pose 19, 0x81e7, 0x110b, 0x8c0c
+ax_pose 20, 0x01ed, 0x1113, 0x8c0e
+ax_pose_terminator
+sTropiusPose36:
+ax_pose 45, 0x41ee, 0x90fb, 0x8c00
+ax_pose 46, 0x41fe, 0x50fb, 0x8c08
+ax_pose 47, 0x01ee, 0x10f3, 0x8c0c
+ax_pose 48, 0x01f6, 0x10f3, 0x8c0d
+ax_pose 49, 0x01fe, 0x10f3, 0x8c0e
+ax_pose_terminator
+sTropiusPose37:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose38:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose39:
+ax_pose 23, 0x81e6, 0x90ef, 0x8c00
+ax_pose 24, 0x81e6, 0x50ff, 0x8c08
+ax_pose 25, 0x81e6, 0x1107, 0x8c0c
+ax_pose 26, 0x01f6, 0x1107, 0x8c0e
+ax_pose 27, 0x01de, 0x1103, 0x8c0f
+ax_pose_terminator
+sTropiusPose40:
+ax_pose 50, 0x81e6, 0x9101, 0x8c00
+ax_pose 51, 0x81e6, 0x50f9, 0x8c08
+ax_pose 52, 0x81f6, 0x10f1, 0x8c0c
+ax_pose 53, 0x01f6, 0x10e9, 0x8c0e
+ax_pose_terminator
+sTropiusPose41:
+ax_pose 28, 0x41e2, 0x00f8, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c02
+ax_pose 30, 0x41f2, 0x80f0, 0x8c06
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose42:
+ax_pose 33, 0x41e5, 0x00f8, 0x8c00
+ax_pose 34, 0x41ed, 0x40f0, 0x8c02
+ax_pose 35, 0x41f5, 0x80f0, 0x8c06
+ax_pose 31, 0x01f2, 0x00e8, 0x8c0e
+ax_pose 32, 0x01f2, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose43:
+ax_pose 36, 0x41e5, 0x00f8, 0x8c00
+ax_pose 37, 0x41ed, 0x40f0, 0x8c02
+ax_pose 38, 0x41f5, 0x80f0, 0x8c06
+ax_pose 31, 0x01f3, 0x00e8, 0x8c0e
+ax_pose 32, 0x01f3, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose44:
+ax_pose 54, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sTropiusPose45:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose46:
+ax_pose 22, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose47:
+ax_pose 23, 0x81e6, 0x8100, 0x8c00
+ax_pose 24, 0x81e6, 0x40f8, 0x8c08
+ax_pose 25, 0x81e6, 0x00f0, 0x8c0c
+ax_pose 26, 0x01f6, 0x00f0, 0x8c0e
+ax_pose 27, 0x01de, 0x00f4, 0x8c0f
+ax_pose_terminator
+sTropiusPose48:
+ax_pose 50, 0x81e6, 0x80ee, 0x8c00
+ax_pose 51, 0x81e6, 0x40fe, 0x8c08
+ax_pose 52, 0x81f6, 0x0106, 0x8c0c
+ax_pose 53, 0x01f6, 0x010e, 0x8c0e
+ax_pose_terminator
+sTropiusPose49:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose50:
+ax_pose 13, 0x81e6, 0x80fd, 0x8c00
+ax_pose 14, 0x81e6, 0x40f5, 0x8c08
+ax_pose 15, 0x81e6, 0x00ed, 0x8c0c
+ax_pose 16, 0x01eb, 0x00e5, 0x8c0e
+ax_pose_terminator
+sTropiusPose51:
+ax_pose 17, 0x81e7, 0x80fc, 0x8c00
+ax_pose 18, 0x81e7, 0x40f4, 0x8c08
+ax_pose 19, 0x81e7, 0x00ec, 0x8c0c
+ax_pose 20, 0x01ed, 0x00e4, 0x8c0e
+ax_pose_terminator
+sTropiusPose52:
+ax_pose 45, 0x41ee, 0x80e4, 0x8c00
+ax_pose 46, 0x41fe, 0x40e4, 0x8c08
+ax_pose 47, 0x01ee, 0x0104, 0x8c0c
+ax_pose 48, 0x01f6, 0x0104, 0x8c0d
+ax_pose 49, 0x01fe, 0x0104, 0x8c0e
+ax_pose_terminator
+sTropiusPose53:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose54:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose55:
+ax_pose 9, 0x81e3, 0x80f0, 0x8c00
+ax_pose 10, 0x01f3, 0x4100, 0x8c08
+ax_pose 11, 0x01f0, 0x00e8, 0x8c0c
+ax_pose_terminator
+sTropiusPose56:
+ax_pose 40, 0x81e8, 0x80fa, 0x8c00
+ax_pose 41, 0x81e8, 0x40f2, 0x8c08
+ax_pose 42, 0x81f8, 0x00ea, 0x8c0c
+ax_pose 43, 0x01f0, 0x00ea, 0x8c0e
+ax_pose 44, 0x01f0, 0x010a, 0x8c0f
+ax_pose_terminator
+sTropiusPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose58:
+ax_pose 1, 0x41ef, 0x80ef, 0x8c00
+ax_pose 2, 0x41ff, 0x00f7, 0x8c08
+ax_pose 3, 0x01ef, 0x010f, 0x8c0a
+ax_pose_terminator
+sTropiusPose59:
+ax_pose 4, 0x41ee, 0x80ef, 0x8c00
+ax_pose 5, 0x41fe, 0x40ef, 0x8c08
+ax_pose 6, 0x01ee, 0x010f, 0x8c0c
+ax_pose_terminator
+sTropiusPose60:
+ax_pose 39, 0x01ed, 0x80f1, 0x8c00
+ax_pose_terminator
+sTropiusPose61:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose62:
+ax_pose 8, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose63:
+ax_pose 9, 0x81e3, 0x9100, 0x8c00
+ax_pose 10, 0x01f3, 0x50f0, 0x8c08
+ax_pose 11, 0x01f0, 0x1110, 0x8c0c
+ax_pose_terminator
+sTropiusPose64:
+ax_pose 40, 0x81e8, 0x90f6, 0x8c00
+ax_pose 41, 0x81e8, 0x5106, 0x8c08
+ax_pose 42, 0x81f8, 0x110e, 0x8c0c
+ax_pose 43, 0x01f0, 0x110e, 0x8c0e
+ax_pose 44, 0x01f0, 0x10ee, 0x8c0f
+ax_pose_terminator
+sTropiusPose65:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose66:
+ax_pose 13, 0x81e6, 0x90f2, 0x8c00
+ax_pose 14, 0x81e6, 0x5102, 0x8c08
+ax_pose 15, 0x81e6, 0x110a, 0x8c0c
+ax_pose 16, 0x01eb, 0x1112, 0x8c0e
+ax_pose_terminator
+sTropiusPose67:
+ax_pose 17, 0x81e7, 0x90f3, 0x8c00
+ax_pose 18, 0x81e7, 0x5103, 0x8c08
+ax_pose 19, 0x81e7, 0x110b, 0x8c0c
+ax_pose 20, 0x01ed, 0x1113, 0x8c0e
+ax_pose_terminator
+sTropiusPose68:
+ax_pose 45, 0x41ee, 0x90fb, 0x8c00
+ax_pose 46, 0x41fe, 0x50fb, 0x8c08
+ax_pose 47, 0x01ee, 0x10f3, 0x8c0c
+ax_pose 48, 0x01f6, 0x10f3, 0x8c0d
+ax_pose 49, 0x01fe, 0x10f3, 0x8c0e
+ax_pose_terminator
+sTropiusPose69:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose70:
+ax_pose 22, 0x01e6, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose71:
+ax_pose 23, 0x81e6, 0x90ef, 0x8c00
+ax_pose 24, 0x81e6, 0x50ff, 0x8c08
+ax_pose 25, 0x81e6, 0x1107, 0x8c0c
+ax_pose 26, 0x01f6, 0x1107, 0x8c0e
+ax_pose 27, 0x01de, 0x1103, 0x8c0f
+ax_pose_terminator
+sTropiusPose72:
+ax_pose 50, 0x81e6, 0x9101, 0x8c00
+ax_pose 51, 0x81e6, 0x50f9, 0x8c08
+ax_pose 52, 0x81f6, 0x10f1, 0x8c0c
+ax_pose 53, 0x01f6, 0x10e9, 0x8c0e
+ax_pose_terminator
+sTropiusPose73:
+ax_pose 28, 0x41e2, 0x00f8, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c02
+ax_pose 30, 0x41f2, 0x80f0, 0x8c06
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose74:
+ax_pose 33, 0x41e5, 0x00f8, 0x8c00
+ax_pose 34, 0x41ed, 0x40f0, 0x8c02
+ax_pose 35, 0x41f5, 0x80f0, 0x8c06
+ax_pose 31, 0x01f2, 0x00e8, 0x8c0e
+ax_pose 32, 0x01f2, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose75:
+ax_pose 36, 0x41e5, 0x00f8, 0x8c00
+ax_pose 37, 0x41ed, 0x40f0, 0x8c02
+ax_pose 38, 0x41f5, 0x80f0, 0x8c06
+ax_pose 31, 0x01f3, 0x00e8, 0x8c0e
+ax_pose 32, 0x01f3, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose76:
+ax_pose 54, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sTropiusPose77:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose78:
+ax_pose 22, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose79:
+ax_pose 23, 0x81e6, 0x8100, 0x8c00
+ax_pose 24, 0x81e6, 0x40f8, 0x8c08
+ax_pose 25, 0x81e6, 0x00f0, 0x8c0c
+ax_pose 26, 0x01f6, 0x00f0, 0x8c0e
+ax_pose 27, 0x01de, 0x00f4, 0x8c0f
+ax_pose_terminator
+sTropiusPose80:
+ax_pose 50, 0x81e6, 0x80ee, 0x8c00
+ax_pose 51, 0x81e6, 0x40fe, 0x8c08
+ax_pose 52, 0x81f6, 0x0106, 0x8c0c
+ax_pose 53, 0x01f6, 0x010e, 0x8c0e
+ax_pose_terminator
+sTropiusPose81:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose82:
+ax_pose 13, 0x81e6, 0x80fd, 0x8c00
+ax_pose 14, 0x81e6, 0x40f5, 0x8c08
+ax_pose 15, 0x81e6, 0x00ed, 0x8c0c
+ax_pose 16, 0x01eb, 0x00e5, 0x8c0e
+ax_pose_terminator
+sTropiusPose83:
+ax_pose 17, 0x81e7, 0x80fc, 0x8c00
+ax_pose 18, 0x81e7, 0x40f4, 0x8c08
+ax_pose 19, 0x81e7, 0x00ec, 0x8c0c
+ax_pose 20, 0x01ed, 0x00e4, 0x8c0e
+ax_pose_terminator
+sTropiusPose84:
+ax_pose 45, 0x41ee, 0x80e4, 0x8c00
+ax_pose 46, 0x41fe, 0x40e4, 0x8c08
+ax_pose 47, 0x01ee, 0x0104, 0x8c0c
+ax_pose 48, 0x01f6, 0x0104, 0x8c0d
+ax_pose 49, 0x01fe, 0x0104, 0x8c0e
+ax_pose_terminator
+sTropiusPose85:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose86:
+ax_pose 8, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose87:
+ax_pose 9, 0x81e3, 0x80f0, 0x8c00
+ax_pose 10, 0x01f3, 0x4100, 0x8c08
+ax_pose 11, 0x01f0, 0x00e8, 0x8c0c
+ax_pose_terminator
+sTropiusPose88:
+ax_pose 40, 0x81e8, 0x80fa, 0x8c00
+ax_pose 41, 0x81e8, 0x40f2, 0x8c08
+ax_pose 42, 0x81f8, 0x00ea, 0x8c0c
+ax_pose 43, 0x01f0, 0x00ea, 0x8c0e
+ax_pose 44, 0x01f0, 0x010a, 0x8c0f
+ax_pose_terminator
+sTropiusPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose90:
+ax_pose 55, 0x81e3, 0x80ef, 0x8c00
+ax_pose 56, 0x81e3, 0x40ff, 0x8c08
+ax_pose 57, 0x81f3, 0x0107, 0x8c0c
+ax_pose 58, 0x01f3, 0x010f, 0x8c0e
+ax_pose_terminator
+sTropiusPose91:
+ax_pose 39, 0x01ed, 0x80f1, 0x8c00
+ax_pose_terminator
+sTropiusPose92:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose93:
+ax_pose 59, 0x01e3, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose94:
+ax_pose 40, 0x81e8, 0x90f6, 0x8c00
+ax_pose 41, 0x81e8, 0x5106, 0x8c08
+ax_pose 42, 0x81f8, 0x110e, 0x8c0c
+ax_pose 43, 0x01f0, 0x110e, 0x8c0e
+ax_pose 44, 0x01f0, 0x10ee, 0x8c0f
+ax_pose_terminator
+sTropiusPose95:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose96:
+ax_pose 60, 0x81e2, 0x90fc, 0x8c00
+ax_pose 61, 0x81e2, 0x50f4, 0x8c08
+ax_pose 62, 0x01da, 0x10fc, 0x8c0c
+ax_pose 63, 0x01fa, 0x10ec, 0x8c0d
+ax_pose_terminator
+sTropiusPose97:
+ax_pose 45, 0x41ee, 0x90fb, 0x8c00
+ax_pose 46, 0x41fe, 0x50fb, 0x8c08
+ax_pose 47, 0x01ee, 0x10f3, 0x8c0c
+ax_pose 48, 0x01f6, 0x10f3, 0x8c0d
+ax_pose 49, 0x01fe, 0x10f3, 0x8c0e
+ax_pose_terminator
+sTropiusPose98:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose99:
+ax_pose 64, 0x81e3, 0x9100, 0x8c00
+ax_pose 65, 0x81e3, 0x50f8, 0x8c08
+ax_pose 66, 0x81f3, 0x10f0, 0x8c0c
+ax_pose 67, 0x01db, 0x1100, 0x8c0e
+ax_pose 68, 0x01db, 0x10f8, 0x8c0f
+ax_pose_terminator
+sTropiusPose100:
+ax_pose 50, 0x81e4, 0x9103, 0x8c00
+ax_pose 51, 0x81e4, 0x50fb, 0x8c08
+ax_pose 52, 0x81f4, 0x10f3, 0x8c0c
+ax_pose 53, 0x01f4, 0x10eb, 0x8c0e
+ax_pose_terminator
+sTropiusPose101:
+ax_pose 28, 0x41e2, 0x00f8, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c02
+ax_pose 30, 0x41f2, 0x80f0, 0x8c06
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose102:
+ax_pose 69, 0x01e9, 0x00f0, 0x8c00
+ax_pose 70, 0x81e2, 0x80f8, 0x8c01
+ax_pose 71, 0x81f1, 0x00f0, 0x8c09
+ax_pose 72, 0x01e9, 0x0108, 0x8c0b
+ax_pose 73, 0x81f1, 0x0108, 0x8c0c
+ax_pose 74, 0x01da, 0x00f8, 0x8c0e
+ax_pose 75, 0x01da, 0x0100, 0x8c0f
+ax_pose_terminator
+sTropiusPose103:
+ax_pose 54, 0x01e4, 0x80f2, 0x8c00
+ax_pose_terminator
+sTropiusPose104:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose105:
+ax_pose 64, 0x81e3, 0x80ef, 0x8c00
+ax_pose 65, 0x81e3, 0x40ff, 0x8c08
+ax_pose 66, 0x81f3, 0x0107, 0x8c0c
+ax_pose 67, 0x01db, 0x00f7, 0x8c0e
+ax_pose 68, 0x01db, 0x00ff, 0x8c0f
+ax_pose_terminator
+sTropiusPose106:
+ax_pose 50, 0x81e4, 0x80ec, 0x8c00
+ax_pose 51, 0x81e4, 0x40fc, 0x8c08
+ax_pose 52, 0x81f4, 0x0104, 0x8c0c
+ax_pose 53, 0x01f4, 0x010c, 0x8c0e
+ax_pose_terminator
+sTropiusPose107:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose108:
+ax_pose 60, 0x81e2, 0x80f3, 0x8c00
+ax_pose 61, 0x81e2, 0x4103, 0x8c08
+ax_pose 62, 0x01da, 0x00fb, 0x8c0c
+ax_pose 63, 0x01fa, 0x010b, 0x8c0d
+ax_pose_terminator
+sTropiusPose109:
+ax_pose 45, 0x41ee, 0x80e4, 0x8c00
+ax_pose 46, 0x41fe, 0x40e4, 0x8c08
+ax_pose 47, 0x01ee, 0x0104, 0x8c0c
+ax_pose 48, 0x01f6, 0x0104, 0x8c0d
+ax_pose 49, 0x01fe, 0x0104, 0x8c0e
+ax_pose_terminator
+sTropiusPose110:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose111:
+ax_pose 59, 0x01e3, 0x80ef, 0x8c00
+ax_pose_terminator
+sTropiusPose112:
+ax_pose 40, 0x81e8, 0x80fa, 0x8c00
+ax_pose 41, 0x81e8, 0x40f2, 0x8c08
+ax_pose 42, 0x81f8, 0x00ea, 0x8c0c
+ax_pose 43, 0x01f0, 0x00ea, 0x8c0e
+ax_pose 44, 0x01f0, 0x010a, 0x8c0f
+ax_pose_terminator
+sTropiusPose113:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose114:
+ax_pose 76, 0x81e3, 0x80f4, 0x8c00
+ax_pose 77, 0x81e3, 0x4104, 0x8c08
+ax_pose 78, 0x01db, 0x00f4, 0x8c0c
+ax_pose 79, 0x01db, 0x0104, 0x8c0d
+ax_pose_terminator
+sTropiusPose115:
+ax_pose 80, 0x41f2, 0x80ee, 0x8c00
+ax_pose 81, 0x41ea, 0x00f6, 0x8c08
+ax_pose 82, 0x01fa, 0x010e, 0x8c0a
+ax_pose_terminator
+sTropiusPose116:
+ax_pose 83, 0x81e5, 0x80f8, 0x8c00
+ax_pose 84, 0x01ed, 0x4103, 0x8c08
+ax_pose -1, 0x01ed, 0x50ec, 0x8c08
+ax_pose_terminator
+sTropiusPose117:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose118:
+ax_pose 85, 0x01df, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose119:
+ax_pose 86, 0x01e8, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose120:
+ax_pose 87, 0x01e3, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose121:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose122:
+ax_pose 88, 0x81e1, 0x90f3, 0x8c00
+ax_pose 89, 0x81e1, 0x5103, 0x8c08
+ax_pose 90, 0x81e7, 0x110b, 0x8c0c
+ax_pose 91, 0x01d9, 0x10f3, 0x8c0e
+ax_pose 92, 0x01e9, 0x1113, 0x8c0f
+ax_pose_terminator
+sTropiusPose123:
+ax_pose 93, 0x81e7, 0x90f2, 0x8c00
+ax_pose 94, 0x81e7, 0x5102, 0x8c08
+ax_pose 95, 0x81e7, 0x110a, 0x8c0c
+ax_pose 96, 0x01e7, 0x1112, 0x8c0e
+ax_pose_terminator
+sTropiusPose124:
+ax_pose 97, 0x01e5, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose125:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose126:
+ax_pose 98, 0x81e2, 0x90fe, 0x8c00
+ax_pose 99, 0x81e2, 0x50f6, 0x8c08
+ax_pose 100, 0x01f8, 0x10ee, 0x8c0c
+ax_pose 101, 0x0202, 0x10fe, 0x8c0d
+ax_pose 102, 0x01da, 0x10f6, 0x8c0e
+ax_pose 103, 0x01e0, 0x10ee, 0x8c0f
+ax_pose_terminator
+sTropiusPose127:
+ax_pose 104, 0x01e1, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose128:
+ax_pose 105, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose129:
+ax_pose 28, 0x41e2, 0x00f8, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c02
+ax_pose 30, 0x41f2, 0x80f0, 0x8c06
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose130:
+ax_pose 106, 0x81e1, 0x80f3, 0x8c00
+ax_pose 107, 0x81e1, 0x4103, 0x8c08
+ax_pose 108, 0x01e1, 0x010b, 0x8c0c
+ax_pose 109, 0x01f9, 0x010b, 0x8c0d
+ax_pose 110, 0x01d9, 0x00fb, 0x8c0e
+ax_pose_terminator
+sTropiusPose131:
+ax_pose 111, 0x81e1, 0x80fd, 0x8c00
+ax_pose 112, 0x81e1, 0x40f5, 0x8c08
+ax_pose 113, 0x81f1, 0x00ed, 0x8c0c
+ax_pose 114, 0x81f1, 0x010d, 0x8c0e
+ax_pose_terminator
+sTropiusPose132:
+ax_pose 115, 0x01ed, 0x0110, 0x8c00
+ax_pose 116, 0x01ed, 0x00e8, 0x8c01
+ax_pose 117, 0x41e1, 0x00f8, 0x8c02
+ax_pose 118, 0x41e9, 0x40f0, 0x8c04
+ax_pose 119, 0x41f1, 0x80f0, 0x8c08
+ax_pose_terminator
+sTropiusPose133:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose134:
+ax_pose 98, 0x81e2, 0x80f1, 0x8c00
+ax_pose 99, 0x81e2, 0x4101, 0x8c08
+ax_pose 100, 0x01f8, 0x0109, 0x8c0c
+ax_pose 101, 0x0202, 0x00f9, 0x8c0d
+ax_pose 102, 0x01da, 0x0101, 0x8c0e
+ax_pose 103, 0x01e0, 0x0109, 0x8c0f
+ax_pose_terminator
+sTropiusPose135:
+ax_pose 104, 0x01e1, 0x80ee, 0x8c00
+ax_pose_terminator
+sTropiusPose136:
+ax_pose 105, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose137:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose138:
+ax_pose 88, 0x81e1, 0x80fc, 0x8c00
+ax_pose 89, 0x81e1, 0x40f4, 0x8c08
+ax_pose 90, 0x81e7, 0x00ec, 0x8c0c
+ax_pose 91, 0x01d9, 0x0104, 0x8c0e
+ax_pose 92, 0x01e9, 0x00e4, 0x8c0f
+ax_pose_terminator
+sTropiusPose139:
+ax_pose 93, 0x81e7, 0x80fd, 0x8c00
+ax_pose 94, 0x81e7, 0x40f5, 0x8c08
+ax_pose 95, 0x81e7, 0x00ed, 0x8c0c
+ax_pose 96, 0x01e7, 0x00e5, 0x8c0e
+ax_pose_terminator
+sTropiusPose140:
+ax_pose 97, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose141:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose142:
+ax_pose 85, 0x01df, 0x80ef, 0x8c00
+ax_pose_terminator
+sTropiusPose143:
+ax_pose 86, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose144:
+ax_pose 87, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose145:
+ax_pose 120, 0x0204, 0x00ed, 0x8c00
+ax_pose 121, 0x01fc, 0x010d, 0x8c01
+ax_pose 122, 0x41f4, 0x80ed, 0x8c02
+ax_pose_terminator
+sTropiusPose146:
+ax_pose 123, 0x4204, 0x00ed, 0x8c00
+ax_pose 124, 0x01fc, 0x010d, 0x8c02
+ax_pose 125, 0x41f4, 0x80ed, 0x8c03
+ax_pose_terminator
+sTropiusPose147:
+ax_pose 126, 0x41e1, 0x00f9, 0x8c00
+ax_pose 127, 0x41e9, 0x80f1, 0x8c02
+ax_pose 128, 0x01e9, 0x00e9, 0x8c0a
+ax_pose 129, 0x41f9, 0x00f9, 0x8c0b
+ax_pose 130, 0x41d9, 0x00f8, 0x8c0d
+ax_pose_terminator
+sTropiusPose148:
+ax_pose 131, 0x81df, 0x90fa, 0x8c00
+ax_pose 132, 0x81df, 0x50f2, 0x8c08
+ax_pose 133, 0x01ff, 0x10fb, 0x8c0c
+ax_pose 134, 0x81eb, 0x10ea, 0x8c0d
+ax_pose_terminator
+sTropiusPose149:
+ax_pose 135, 0x81e3, 0x90f9, 0x8c00
+ax_pose 136, 0x81e3, 0x50f1, 0x8c08
+ax_pose 137, 0x01e3, 0x10e9, 0x8c0c
+ax_pose 138, 0x01db, 0x1101, 0x8c0d
+ax_pose 139, 0x01db, 0x10f9, 0x8c0e
+ax_pose 140, 0x01db, 0x10f1, 0x8c0f
+ax_pose_terminator
+sTropiusPose150:
+ax_pose 141, 0x81e5, 0x90f7, 0x8c00
+ax_pose 142, 0x81e5, 0x10ef, 0x8c08
+ax_pose 143, 0x81e5, 0x10e7, 0x8c0a
+ax_pose 144, 0x01dd, 0x10ef, 0x8c0c
+ax_pose 145, 0x01dd, 0x10f7, 0x8c0d
+ax_pose 146, 0x01f5, 0x10ef, 0x8c0e
+ax_pose 147, 0x01dd, 0x10ff, 0x8c0f
+ax_pose_terminator
+sTropiusPose151:
+ax_pose 148, 0x41e7, 0x00f9, 0x8c00
+ax_pose 149, 0x41df, 0x00f9, 0x8c02
+ax_pose 150, 0x41ef, 0x40f1, 0x8c04
+ax_pose 151, 0x41f7, 0x80f1, 0x8c08
+ax_pose_terminator
+sTropiusPose152:
+ax_pose 141, 0x81e5, 0x80f9, 0x8c00
+ax_pose 142, 0x81e5, 0x0109, 0x8c08
+ax_pose 143, 0x81e5, 0x0111, 0x8c0a
+ax_pose 144, 0x01dd, 0x0109, 0x8c0c
+ax_pose 145, 0x01dd, 0x0101, 0x8c0d
+ax_pose 146, 0x01f5, 0x0109, 0x8c0e
+ax_pose 147, 0x01dd, 0x00f9, 0x8c0f
+ax_pose_terminator
+sTropiusPose153:
+ax_pose 135, 0x81e3, 0x80f7, 0x8c00
+ax_pose 136, 0x81e3, 0x4107, 0x8c08
+ax_pose 137, 0x01e3, 0x010f, 0x8c0c
+ax_pose 138, 0x01db, 0x00f7, 0x8c0d
+ax_pose 139, 0x01db, 0x00ff, 0x8c0e
+ax_pose 140, 0x01db, 0x0107, 0x8c0f
+ax_pose_terminator
+sTropiusPose154:
+ax_pose 131, 0x81df, 0x80f6, 0x8c00
+ax_pose 132, 0x81df, 0x4106, 0x8c08
+ax_pose 133, 0x01ff, 0x00fd, 0x8c0c
+ax_pose 134, 0x81eb, 0x010e, 0x8c0d
+ax_pose_terminator
+sTropiusPose155:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose156:
+ax_pose 76, 0x81e3, 0x80f4, 0x8c00
+ax_pose 77, 0x81e3, 0x4104, 0x8c08
+ax_pose 78, 0x01db, 0x00f4, 0x8c0c
+ax_pose 79, 0x01db, 0x0104, 0x8c0d
+ax_pose_terminator
+sTropiusPose157:
+ax_pose 80, 0x41f2, 0x80ee, 0x8c00
+ax_pose 81, 0x41ea, 0x00f6, 0x8c08
+ax_pose 82, 0x01fa, 0x010e, 0x8c0a
+ax_pose_terminator
+sTropiusPose158:
+ax_pose 83, 0x81e5, 0x80f8, 0x8c00
+ax_pose 84, 0x01ed, 0x4103, 0x8c08
+ax_pose -1, 0x01ed, 0x50ec, 0x8c08
+ax_pose_terminator
+sTropiusPose159:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose160:
+ax_pose 85, 0x01df, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose161:
+ax_pose 86, 0x01e8, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose162:
+ax_pose 87, 0x01e3, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose163:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose164:
+ax_pose 88, 0x81e1, 0x90f3, 0x8c00
+ax_pose 89, 0x81e1, 0x5103, 0x8c08
+ax_pose 90, 0x81e7, 0x110b, 0x8c0c
+ax_pose 91, 0x01d9, 0x10f3, 0x8c0e
+ax_pose 92, 0x01e9, 0x1113, 0x8c0f
+ax_pose_terminator
+sTropiusPose165:
+ax_pose 93, 0x81e7, 0x90f2, 0x8c00
+ax_pose 94, 0x81e7, 0x5102, 0x8c08
+ax_pose 95, 0x81e7, 0x110a, 0x8c0c
+ax_pose 96, 0x01e7, 0x1112, 0x8c0e
+ax_pose_terminator
+sTropiusPose166:
+ax_pose 97, 0x01e5, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose167:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose168:
+ax_pose 98, 0x81e2, 0x90fe, 0x8c00
+ax_pose 99, 0x81e2, 0x50f6, 0x8c08
+ax_pose 100, 0x01f8, 0x10ee, 0x8c0c
+ax_pose 101, 0x0202, 0x10fe, 0x8c0d
+ax_pose 102, 0x01da, 0x10f6, 0x8c0e
+ax_pose 103, 0x01e0, 0x10ee, 0x8c0f
+ax_pose_terminator
+sTropiusPose169:
+ax_pose 104, 0x01e1, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose170:
+ax_pose 105, 0x01e2, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose171:
+ax_pose 28, 0x41e2, 0x00f8, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c02
+ax_pose 30, 0x41f2, 0x80f0, 0x8c06
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose172:
+ax_pose 106, 0x81e1, 0x80f3, 0x8c00
+ax_pose 107, 0x81e1, 0x4103, 0x8c08
+ax_pose 108, 0x01e1, 0x010b, 0x8c0c
+ax_pose 109, 0x01f9, 0x010b, 0x8c0d
+ax_pose 110, 0x01d9, 0x00fb, 0x8c0e
+ax_pose_terminator
+sTropiusPose173:
+ax_pose 111, 0x81e1, 0x80fd, 0x8c00
+ax_pose 112, 0x81e1, 0x40f5, 0x8c08
+ax_pose 113, 0x81f1, 0x00ed, 0x8c0c
+ax_pose 114, 0x81f1, 0x010d, 0x8c0e
+ax_pose_terminator
+sTropiusPose174:
+ax_pose 115, 0x01ed, 0x0110, 0x8c00
+ax_pose 116, 0x01ed, 0x00e8, 0x8c01
+ax_pose 117, 0x41e1, 0x00f8, 0x8c02
+ax_pose 118, 0x41e9, 0x40f0, 0x8c04
+ax_pose 119, 0x41f1, 0x80f0, 0x8c08
+ax_pose_terminator
+sTropiusPose175:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose176:
+ax_pose 98, 0x81e2, 0x80f1, 0x8c00
+ax_pose 99, 0x81e2, 0x4101, 0x8c08
+ax_pose 100, 0x01f8, 0x0109, 0x8c0c
+ax_pose 101, 0x0202, 0x00f9, 0x8c0d
+ax_pose 102, 0x01da, 0x0101, 0x8c0e
+ax_pose 103, 0x01e0, 0x0109, 0x8c0f
+ax_pose_terminator
+sTropiusPose177:
+ax_pose 104, 0x01e1, 0x80ee, 0x8c00
+ax_pose_terminator
+sTropiusPose178:
+ax_pose 105, 0x01e2, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose179:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose180:
+ax_pose 88, 0x81e1, 0x80fc, 0x8c00
+ax_pose 89, 0x81e1, 0x40f4, 0x8c08
+ax_pose 90, 0x81e7, 0x00ec, 0x8c0c
+ax_pose 91, 0x01d9, 0x0104, 0x8c0e
+ax_pose 92, 0x01e9, 0x00e4, 0x8c0f
+ax_pose_terminator
+sTropiusPose181:
+ax_pose 93, 0x81e7, 0x80fd, 0x8c00
+ax_pose 94, 0x81e7, 0x40f5, 0x8c08
+ax_pose 95, 0x81e7, 0x00ed, 0x8c0c
+ax_pose 96, 0x01e7, 0x00e5, 0x8c0e
+ax_pose_terminator
+sTropiusPose182:
+ax_pose 97, 0x01e5, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose183:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose184:
+ax_pose 85, 0x01df, 0x80ef, 0x8c00
+ax_pose_terminator
+sTropiusPose185:
+ax_pose 86, 0x01e8, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose186:
+ax_pose 87, 0x01e3, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose187:
+ax_pose 39, 0x01ea, 0x80f1, 0x8c00
+ax_pose_terminator
+sTropiusPose188:
+ax_pose 40, 0x81e8, 0x80fd, 0x8c00
+ax_pose 41, 0x81e8, 0x40f5, 0x8c08
+ax_pose 42, 0x81f8, 0x00ed, 0x8c0c
+ax_pose 43, 0x01f0, 0x00ed, 0x8c0e
+ax_pose 44, 0x01f0, 0x010d, 0x8c0f
+ax_pose_terminator
+sTropiusPose189:
+ax_pose 45, 0x41ef, 0x80e9, 0x8c00
+ax_pose 46, 0x41ff, 0x40e9, 0x8c08
+ax_pose 47, 0x01ef, 0x0109, 0x8c0c
+ax_pose 48, 0x01f7, 0x0109, 0x8c0d
+ax_pose 49, 0x01ff, 0x0109, 0x8c0e
+ax_pose_terminator
+sTropiusPose190:
+ax_pose 50, 0x81e6, 0x80ef, 0x8c00
+ax_pose 51, 0x81e6, 0x40ff, 0x8c08
+ax_pose 52, 0x81f6, 0x0107, 0x8c0c
+ax_pose 53, 0x01f6, 0x010f, 0x8c0e
+ax_pose_terminator
+sTropiusPose191:
+ax_pose 54, 0x01e8, 0x80f2, 0x8c00
+ax_pose_terminator
+sTropiusPose192:
+ax_pose 50, 0x81e6, 0x9101, 0x8c00
+ax_pose 51, 0x81e6, 0x50f9, 0x8c08
+ax_pose 52, 0x81f6, 0x10f1, 0x8c0c
+ax_pose 53, 0x01f6, 0x10e9, 0x8c0e
+ax_pose_terminator
+sTropiusPose193:
+ax_pose 45, 0x41ef, 0x90f7, 0x8c00
+ax_pose 46, 0x41ff, 0x50f7, 0x8c08
+ax_pose 47, 0x01ef, 0x10ef, 0x8c0c
+ax_pose 48, 0x01f7, 0x10ef, 0x8c0d
+ax_pose 49, 0x01ff, 0x10ef, 0x8c0e
+ax_pose_terminator
+sTropiusPose194:
+ax_pose 40, 0x81e8, 0x90f4, 0x8c00
+ax_pose 41, 0x81e8, 0x5104, 0x8c08
+ax_pose 42, 0x81f8, 0x110c, 0x8c0c
+ax_pose 43, 0x01f0, 0x110c, 0x8c0e
+ax_pose 44, 0x01f0, 0x10ec, 0x8c0f
+ax_pose_terminator
+sTropiusPose195:
+ax_pose 76, 0x81e2, 0x80f4, 0x8c00
+ax_pose 77, 0x81e2, 0x4104, 0x8c08
+ax_pose 78, 0x01da, 0x00f4, 0x8c0c
+ax_pose 79, 0x01da, 0x0104, 0x8c0d
+ax_pose_terminator
+sTropiusPose196:
+ax_pose 85, 0x01e1, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose197:
+ax_pose 88, 0x81e2, 0x90f3, 0x8c00
+ax_pose 89, 0x81e2, 0x5103, 0x8c08
+ax_pose 90, 0x81e8, 0x110b, 0x8c0c
+ax_pose 91, 0x01da, 0x10f3, 0x8c0e
+ax_pose 92, 0x01ea, 0x1113, 0x8c0f
+ax_pose_terminator
+sTropiusPose198:
+ax_pose 98, 0x81e5, 0x90fe, 0x8c00
+ax_pose 99, 0x81e5, 0x50f6, 0x8c08
+ax_pose 100, 0x01fb, 0x10ee, 0x8c0c
+ax_pose 101, 0x0205, 0x10fe, 0x8c0d
+ax_pose 102, 0x01dd, 0x10f6, 0x8c0e
+ax_pose 103, 0x01e3, 0x10ee, 0x8c0f
+ax_pose_terminator
+sTropiusPose199:
+ax_pose 106, 0x81e4, 0x80f3, 0x8c00
+ax_pose 107, 0x81e4, 0x4103, 0x8c08
+ax_pose 108, 0x01e4, 0x010b, 0x8c0c
+ax_pose 109, 0x01fc, 0x010b, 0x8c0d
+ax_pose 110, 0x01dc, 0x00fb, 0x8c0e
+ax_pose_terminator
+sTropiusPose200:
+ax_pose 98, 0x81e5, 0x80f1, 0x8c00
+ax_pose 99, 0x81e5, 0x4101, 0x8c08
+ax_pose 100, 0x01fb, 0x0109, 0x8c0c
+ax_pose 101, 0x0205, 0x00f9, 0x8c0d
+ax_pose 102, 0x01dd, 0x0101, 0x8c0e
+ax_pose 103, 0x01e3, 0x0109, 0x8c0f
+ax_pose_terminator
+sTropiusPose201:
+ax_pose 88, 0x81e3, 0x80fc, 0x8c00
+ax_pose 89, 0x81e3, 0x40f4, 0x8c08
+ax_pose 90, 0x81e9, 0x00ec, 0x8c0c
+ax_pose 91, 0x01db, 0x0104, 0x8c0e
+ax_pose 92, 0x01eb, 0x00e4, 0x8c0f
+ax_pose_terminator
+sTropiusPose202:
+ax_pose 85, 0x01e1, 0x80ef, 0x8c00
+ax_pose_terminator
+sTropiusPose203:
+ax_pose 0, 0x01e7, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose204:
+ax_pose 76, 0x81e3, 0x80f4, 0x8c00
+ax_pose 77, 0x81e3, 0x4104, 0x8c08
+ax_pose 78, 0x01db, 0x00f4, 0x8c0c
+ax_pose 79, 0x01db, 0x0104, 0x8c0d
+ax_pose_terminator
+sTropiusPose205:
+ax_pose 55, 0x81e3, 0x80ef, 0x8c00
+ax_pose 56, 0x81e3, 0x40ff, 0x8c08
+ax_pose 57, 0x81f3, 0x0107, 0x8c0c
+ax_pose 58, 0x01f3, 0x010f, 0x8c0e
+ax_pose_terminator
+sTropiusPose206:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+sTropiusPose207:
+ax_pose 85, 0x01df, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose208:
+ax_pose 59, 0x01e3, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose209:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose210:
+ax_pose 88, 0x81e1, 0x90f3, 0x8c00
+ax_pose 89, 0x81e1, 0x5103, 0x8c08
+ax_pose 90, 0x81e7, 0x110b, 0x8c0c
+ax_pose 91, 0x01d9, 0x10f3, 0x8c0e
+ax_pose 92, 0x01e9, 0x1113, 0x8c0f
+ax_pose_terminator
+sTropiusPose211:
+ax_pose 60, 0x81e2, 0x90fc, 0x8c00
+ax_pose 61, 0x81e2, 0x50f4, 0x8c08
+ax_pose 62, 0x01da, 0x10fc, 0x8c0c
+ax_pose 63, 0x01fa, 0x10ec, 0x8c0d
+ax_pose_terminator
+sTropiusPose212:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose213:
+ax_pose 98, 0x81e2, 0x90fe, 0x8c00
+ax_pose 99, 0x81e2, 0x50f6, 0x8c08
+ax_pose 100, 0x01f8, 0x10ee, 0x8c0c
+ax_pose 101, 0x0202, 0x10fe, 0x8c0d
+ax_pose 102, 0x01da, 0x10f6, 0x8c0e
+ax_pose 103, 0x01e0, 0x10ee, 0x8c0f
+ax_pose_terminator
+sTropiusPose214:
+ax_pose 64, 0x81e3, 0x9100, 0x8c00
+ax_pose 65, 0x81e3, 0x50f8, 0x8c08
+ax_pose 66, 0x81f3, 0x10f0, 0x8c0c
+ax_pose 67, 0x01db, 0x1100, 0x8c0e
+ax_pose 68, 0x01db, 0x10f8, 0x8c0f
+ax_pose_terminator
+sTropiusPose215:
+ax_pose 28, 0x41e2, 0x00f8, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c02
+ax_pose 30, 0x41f2, 0x80f0, 0x8c06
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose216:
+ax_pose 106, 0x81e1, 0x80f3, 0x8c00
+ax_pose 107, 0x81e1, 0x4103, 0x8c08
+ax_pose 108, 0x01e1, 0x010b, 0x8c0c
+ax_pose 109, 0x01f9, 0x010b, 0x8c0d
+ax_pose 110, 0x01d9, 0x00fb, 0x8c0e
+ax_pose_terminator
+sTropiusPose217:
+ax_pose 69, 0x01e9, 0x00f0, 0x8c00
+ax_pose 70, 0x81e2, 0x80f8, 0x8c01
+ax_pose 71, 0x81f1, 0x00f0, 0x8c09
+ax_pose 72, 0x01e9, 0x0108, 0x8c0b
+ax_pose 73, 0x81f1, 0x0108, 0x8c0c
+ax_pose 74, 0x01da, 0x00f8, 0x8c0e
+ax_pose 75, 0x01da, 0x0100, 0x8c0f
+ax_pose_terminator
+sTropiusPose218:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose219:
+ax_pose 98, 0x81e2, 0x80f1, 0x8c00
+ax_pose 99, 0x81e2, 0x4101, 0x8c08
+ax_pose 100, 0x01f8, 0x0109, 0x8c0c
+ax_pose 101, 0x0202, 0x00f9, 0x8c0d
+ax_pose 102, 0x01da, 0x0101, 0x8c0e
+ax_pose 103, 0x01e0, 0x0109, 0x8c0f
+ax_pose_terminator
+sTropiusPose220:
+ax_pose 64, 0x81e3, 0x80ef, 0x8c00
+ax_pose 65, 0x81e3, 0x40ff, 0x8c08
+ax_pose 66, 0x81f3, 0x0107, 0x8c0c
+ax_pose 67, 0x01db, 0x00f7, 0x8c0e
+ax_pose 68, 0x01db, 0x00ff, 0x8c0f
+ax_pose_terminator
+sTropiusPose221:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose222:
+ax_pose 88, 0x81e1, 0x80fc, 0x8c00
+ax_pose 89, 0x81e1, 0x40f4, 0x8c08
+ax_pose 90, 0x81e7, 0x00ec, 0x8c0c
+ax_pose 91, 0x01d9, 0x0104, 0x8c0e
+ax_pose 92, 0x01e9, 0x00e4, 0x8c0f
+ax_pose_terminator
+sTropiusPose223:
+ax_pose 60, 0x81e2, 0x80f3, 0x8c00
+ax_pose 61, 0x81e2, 0x4103, 0x8c08
+ax_pose 62, 0x01da, 0x00fb, 0x8c0c
+ax_pose 63, 0x01fa, 0x010b, 0x8c0d
+ax_pose_terminator
+sTropiusPose224:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose225:
+ax_pose 85, 0x01df, 0x80ef, 0x8c00
+ax_pose_terminator
+sTropiusPose226:
+ax_pose 59, 0x01e3, 0x80ef, 0x8c00
+ax_pose_terminator
+sTropiusPose227:
+ax_pose 55, 0x81e3, 0x80ef, 0x8c00
+ax_pose 56, 0x81e3, 0x40ff, 0x8c08
+ax_pose 57, 0x81f3, 0x0107, 0x8c0c
+ax_pose 58, 0x01f3, 0x010f, 0x8c0e
+ax_pose_terminator
+sTropiusPose228:
+ax_pose 59, 0x01e3, 0x90f1, 0x8c00
+ax_pose_terminator
+sTropiusPose229:
+ax_pose 60, 0x81e2, 0x90fc, 0x8c00
+ax_pose 61, 0x81e2, 0x50f4, 0x8c08
+ax_pose 62, 0x01da, 0x10fc, 0x8c0c
+ax_pose 63, 0x01fa, 0x10ec, 0x8c0d
+ax_pose_terminator
+sTropiusPose230:
+ax_pose 64, 0x81e3, 0x9100, 0x8c00
+ax_pose 65, 0x81e3, 0x50f8, 0x8c08
+ax_pose 66, 0x81f3, 0x10f0, 0x8c0c
+ax_pose 67, 0x01db, 0x1100, 0x8c0e
+ax_pose 68, 0x01db, 0x10f8, 0x8c0f
+ax_pose_terminator
+sTropiusPose231:
+ax_pose 69, 0x01e9, 0x00f0, 0x8c00
+ax_pose 70, 0x81e2, 0x80f8, 0x8c01
+ax_pose 71, 0x81f1, 0x00f0, 0x8c09
+ax_pose 72, 0x01e9, 0x0108, 0x8c0b
+ax_pose 73, 0x81f1, 0x0108, 0x8c0c
+ax_pose 74, 0x01da, 0x00f8, 0x8c0e
+ax_pose 75, 0x01da, 0x0100, 0x8c0f
+ax_pose_terminator
+sTropiusPose232:
+ax_pose 64, 0x81e3, 0x80ef, 0x8c00
+ax_pose 65, 0x81e3, 0x40ff, 0x8c08
+ax_pose 66, 0x81f3, 0x0107, 0x8c0c
+ax_pose 67, 0x01db, 0x00f7, 0x8c0e
+ax_pose 68, 0x01db, 0x00ff, 0x8c0f
+ax_pose_terminator
+sTropiusPose233:
+ax_pose 60, 0x81e2, 0x80f3, 0x8c00
+ax_pose 61, 0x81e2, 0x4103, 0x8c08
+ax_pose 62, 0x01da, 0x00fb, 0x8c0c
+ax_pose 63, 0x01fa, 0x010b, 0x8c0d
+ax_pose_terminator
+sTropiusPose234:
+ax_pose 59, 0x01e3, 0x80ef, 0x8c00
+ax_pose_terminator
+sTropiusPose235:
+ax_pose 0, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose236:
+ax_pose 7, 0x01e6, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose237:
+ax_pose 12, 0x01e6, 0x80ec, 0x8c00
+ax_pose_terminator
+sTropiusPose238:
+ax_pose 21, 0x01e4, 0x80f0, 0x8c00
+ax_pose_terminator
+sTropiusPose239:
+ax_pose 30, 0x41f2, 0x80f0, 0x8c00
+ax_pose 29, 0x41ea, 0x40f0, 0x8c08
+ax_pose 28, 0x41e2, 0x00f8, 0x8c0c
+ax_pose 31, 0x01ee, 0x00e8, 0x8c0e
+ax_pose 32, 0x01ee, 0x0110, 0x8c0f
+ax_pose_terminator
+sTropiusPose240:
+ax_pose 21, 0x01e4, 0x90ef, 0x8c00
+ax_pose_terminator
+sTropiusPose241:
+ax_pose 12, 0x01e6, 0x90f3, 0x8c00
+ax_pose_terminator
+sTropiusPose242:
+ax_pose 7, 0x01e6, 0x90f0, 0x8c00
+ax_pose_terminator
+.align 2
+sTropiusAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 14, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 14, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 14, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 14, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 14, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 14, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 14, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 14, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 2, 0, 2,
+ax_anim 1, 0, 26, 0, 8, 0, 8,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 1, 27, 1, 15, 1, 15,
+ax_anim 2, 0, 27, 0, 15, 0, 15,
+ax_anim 2, 0, 27, 1, 15, 1, 15,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sTropiusAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 3, 5, 3, 5,
+ax_anim 1, 0, 30, 7, 11, 7, 11,
+ax_anim 2, 0, 31, 11, 18, 11, 18,
+ax_anim 2, 1, 31, 12, 17, 12, 17,
+ax_anim 2, 0, 31, 11, 18, 11, 18,
+ax_anim 2, 0, 31, 12, 17, 12, 17,
+ax_anim 2, 0, 28, 5, 7, 5, 7,
+ax_anim_terminator
+sTropiusAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 3, 0, 3, 0,
+ax_anim 1, 0, 34, 7, 0, 7, 0,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 1, 35, 11, 1, 11, 1,
+ax_anim 2, 0, 35, 11, 0, 11, 0,
+ax_anim 2, 0, 35, 11, 1, 11, 1,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim_terminator
+sTropiusAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 16, -18, 17, -19,
+ax_anim 2, 1, 39, 17, -17, 18, -18,
+ax_anim 2, 0, 39, 16, -18, 17, -19,
+ax_anim 2, 0, 39, 17, -17, 18, -18,
+ax_anim 2, 0, 36, 6, -7, 6, -7,
+ax_anim_terminator
+sTropiusAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -2, 0, -2,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 1, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sTropiusAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -16, -18, -17, -19,
+ax_anim 2, 1, 47, -17, -17, -18, -18,
+ax_anim 2, 0, 47, -16, -18, -17, -19,
+ax_anim 2, 0, 47, -17, -17, -18, -18,
+ax_anim 2, 0, 44, -6, -7, -6, -7,
+ax_anim_terminator
+sTropiusAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -3, 0, -3, 0,
+ax_anim 1, 0, 50, -7, 0, -7, 0,
+ax_anim 2, 0, 51, -11, 0, -11, 0,
+ax_anim 2, 1, 51, -11, 1, -11, 1,
+ax_anim 2, 0, 51, -11, 0, -11, 0,
+ax_anim 2, 0, 51, -11, 1, -11, 1,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim_terminator
+sTropiusAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -3, 5, -3, 5,
+ax_anim 1, 0, 54, -7, 11, -7, 11,
+ax_anim 2, 0, 55, -11, 18, -11, 18,
+ax_anim 2, 1, 55, -12, 17, -12, 17,
+ax_anim 2, 0, 55, -11, 18, -11, 18,
+ax_anim 2, 0, 55, -12, 17, -12, 17,
+ax_anim 2, 0, 52, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sTropiusAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 6, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 2, 0, 2,
+ax_anim 1, 0, 58, 0, 8, 0, 8,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 1, 59, 1, 15, 1, 15,
+ax_anim 2, 0, 59, 0, 15, 0, 15,
+ax_anim 2, 0, 59, 1, 15, 1, 15,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sTropiusAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 6, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 3, 5, 3, 5,
+ax_anim 1, 0, 62, 7, 11, 7, 11,
+ax_anim 2, 0, 63, 11, 18, 11, 18,
+ax_anim 2, 1, 63, 12, 17, 12, 17,
+ax_anim 2, 0, 63, 11, 18, 11, 18,
+ax_anim 2, 0, 63, 12, 17, 12, 17,
+ax_anim 2, 0, 60, 5, 7, 5, 7,
+ax_anim_terminator
+sTropiusAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 6, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 3, 0, 3, 0,
+ax_anim 1, 0, 66, 7, 0, 7, 0,
+ax_anim 2, 0, 67, 11, 0, 11, 0,
+ax_anim 2, 1, 67, 11, 1, 11, 1,
+ax_anim 2, 0, 67, 11, 0, 11, 0,
+ax_anim 2, 0, 67, 11, 1, 11, 1,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sTropiusAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 6, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 5, -6, 5, -6,
+ax_anim 1, 0, 70, 11, -13, 11, -13,
+ax_anim 2, 0, 71, 16, -18, 17, -19,
+ax_anim 2, 1, 71, 17, -17, 18, -18,
+ax_anim 2, 0, 71, 16, -18, 17, -19,
+ax_anim 2, 0, 71, 17, -17, 18, -18,
+ax_anim 2, 0, 68, 6, -7, 6, -7,
+ax_anim_terminator
+sTropiusAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -2, 0, -2,
+ax_anim 1, 0, 74, 0, -9, 0, -9,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 1, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 0, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sTropiusAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 6, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -5, -6, -5, -6,
+ax_anim 1, 0, 78, -11, -13, -11, -13,
+ax_anim 2, 0, 79, -16, -18, -17, -19,
+ax_anim 2, 1, 79, -17, -17, -18, -18,
+ax_anim 2, 0, 79, -16, -18, -17, -19,
+ax_anim 2, 0, 79, -17, -17, -18, -18,
+ax_anim 2, 0, 76, -6, -7, -6, -7,
+ax_anim_terminator
+sTropiusAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 6, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -3, 0, -3, 0,
+ax_anim 1, 0, 82, -7, 0, -7, 0,
+ax_anim 2, 0, 83, -11, 0, -11, 0,
+ax_anim 2, 1, 83, -11, 1, -11, 1,
+ax_anim 2, 0, 83, -11, 0, -11, 0,
+ax_anim 2, 0, 83, -11, 1, -11, 1,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sTropiusAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 6, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -3, 5, -3, 5,
+ax_anim 1, 0, 86, -7, 11, -7, 11,
+ax_anim 2, 0, 87, -11, 18, -11, 18,
+ax_anim 2, 1, 87, -12, 17, -12, 17,
+ax_anim 2, 0, 87, -11, 18, -11, 18,
+ax_anim 2, 0, 87, -12, 17, -12, 17,
+ax_anim 2, 0, 84, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sTropiusAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 1, 3, 1, 3,
+ax_anim 2, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sTropiusAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 3, 1, 3, 1,
+ax_anim 2, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sTropiusAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sTropiusAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 3, -1, 3, -1,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sTropiusAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 102, 1, -3, 1, -3,
+ax_anim 2, 0, 102, 0, -3, 0, -3,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sTropiusAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 105, -3, -1, -3, -1,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sTropiusAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sTropiusAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, -3, 1, -3, 1,
+ax_anim 2, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sTropiusAnims_5_1:
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 113, 0, -2, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 3, 0, 114, 0, -6, 0, 0,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim 3, 2, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 114, 0, -6, 0, 0,
+ax_anim 3, 0, 113, 0, -6, 0, 0,
+ax_anim 3, 0, 115, 0, -6, 0, 0,
+ax_anim 2, 0, 114, 0, -6, 0, 0,
+ax_anim 3, 0, 113, 0, -6, 0, 0,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_5_2:
+ax_anim 3, 0, 118, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 3, 0, 118, 0, -6, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, 0,
+ax_anim 3, 2, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 118, 0, -6, 0, 0,
+ax_anim 3, 0, 117, 0, -6, 0, 0,
+ax_anim 3, 0, 119, 0, -6, 0, 0,
+ax_anim 2, 0, 118, 0, -6, 0, 0,
+ax_anim 3, 0, 117, 0, -6, 0, 0,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_5_3:
+ax_anim 3, 0, 122, 0, 0, 0, 0,
+ax_anim 3, 0, 121, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 3, 0, 122, 0, -6, 0, 0,
+ax_anim 2, 0, 121, 0, -6, 0, 0,
+ax_anim 3, 2, 123, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -6, 0, 0,
+ax_anim 3, 0, 121, 0, -6, 0, 0,
+ax_anim 3, 0, 123, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -6, 0, 0,
+ax_anim 3, 0, 121, 0, -6, 0, 0,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 2, 0, 123, 0, -2, 0, 0,
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_5_4:
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 125, 0, -2, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 3, 0, 126, 0, -6, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, 0,
+ax_anim 3, 2, 127, 0, -6, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, 0,
+ax_anim 3, 0, 125, 0, -6, 0, 0,
+ax_anim 3, 0, 127, 0, -6, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, 0,
+ax_anim 3, 0, 125, 0, -6, 0, 0,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_5_5:
+ax_anim 3, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 3, 0, 130, 0, -6, 0, 0,
+ax_anim 2, 0, 129, 0, -6, 0, 0,
+ax_anim 3, 2, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 3, 0, 129, 0, -6, 0, 0,
+ax_anim 3, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 130, 0, -6, 0, 0,
+ax_anim 3, 0, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_5_6:
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 3, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 3, 0, 134, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -6, 0, 0,
+ax_anim 3, 2, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 134, 0, -6, 0, 0,
+ax_anim 3, 0, 133, 0, -6, 0, 0,
+ax_anim 3, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 134, 0, -6, 0, 0,
+ax_anim 3, 0, 133, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_5_7:
+ax_anim 3, 0, 138, 0, 0, 0, 0,
+ax_anim 3, 0, 137, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 3, 0, 138, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -6, 0, 0,
+ax_anim 3, 2, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 138, 0, -6, 0, 0,
+ax_anim 3, 0, 137, 0, -6, 0, 0,
+ax_anim 3, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 138, 0, -6, 0, 0,
+ax_anim 3, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 2, 0, 138, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_5_8:
+ax_anim 3, 0, 142, 0, 0, 0, 0,
+ax_anim 3, 0, 141, 0, -2, 0, 0,
+ax_anim 2, 0, 143, 0, -4, 0, 0,
+ax_anim 3, 0, 142, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, 0,
+ax_anim 3, 2, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, 0,
+ax_anim 3, 0, 141, 0, -6, 0, 0,
+ax_anim 3, 0, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, 0,
+ax_anim 3, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_6_1:
+ax_anim 30, 0, 144, 2, 0, 0, 0,
+ax_anim 35, 0, 145, 2, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sTropiusAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sTropiusAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sTropiusAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sTropiusAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sTropiusAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sTropiusAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sTropiusAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTropiusAnims_8_1:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, 0, 0, 0,
+ax_anim 5, 0, 155, 0, -2, 0, 0,
+ax_anim 4, 0, 157, 0, -4, 0, 0,
+ax_anim 5, 0, 156, 0, -6, 0, 0,
+ax_anim 4, 0, 155, 0, -6, 0, 0,
+ax_anim 5, 2, 157, 0, -6, 0, 0,
+ax_anim 4, 0, 156, 0, -6, 0, 0,
+ax_anim 5, 0, 155, 0, -6, 0, 0,
+ax_anim 4, 0, 157, 0, -5, 0, 0,
+ax_anim 4, 0, 156, 0, -4, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim_terminator
+sTropiusAnims_8_2:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 160, 0, 0, 0, 0,
+ax_anim 5, 0, 159, 0, -2, 0, 0,
+ax_anim 4, 0, 161, 0, -4, 0, 0,
+ax_anim 5, 0, 160, 0, -6, 0, 0,
+ax_anim 4, 0, 159, 0, -6, 0, 0,
+ax_anim 5, 2, 161, 0, -6, 0, 0,
+ax_anim 4, 0, 160, 0, -6, 0, 0,
+ax_anim 5, 0, 159, 0, -6, 0, 0,
+ax_anim 4, 0, 161, 0, -5, 0, 0,
+ax_anim 4, 0, 160, 0, -4, 0, 0,
+ax_anim 4, 0, 161, 0, -2, 0, 0,
+ax_anim_terminator
+sTropiusAnims_8_3:
+ax_anim 30, 0, 162, 0, 0, 0, 0,
+ax_anim 3, 0, 164, 0, 0, 0, 0,
+ax_anim 5, 0, 163, 0, -2, 0, 0,
+ax_anim 4, 0, 165, 0, -4, 0, 0,
+ax_anim 5, 0, 164, 0, -6, 0, 0,
+ax_anim 4, 0, 163, 0, -6, 0, 0,
+ax_anim 5, 2, 165, 0, -6, 0, 0,
+ax_anim 4, 0, 164, 0, -6, 0, 0,
+ax_anim 5, 0, 163, 0, -6, 0, 0,
+ax_anim 4, 0, 165, 0, -5, 0, 0,
+ax_anim 4, 0, 164, 0, -4, 0, 0,
+ax_anim 4, 0, 165, 0, -2, 0, 0,
+ax_anim_terminator
+sTropiusAnims_8_4:
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim 3, 0, 168, 0, 0, 0, 0,
+ax_anim 5, 0, 167, 0, -2, 0, 0,
+ax_anim 4, 0, 169, 0, -4, 0, 0,
+ax_anim 5, 0, 168, 0, -6, 0, 0,
+ax_anim 4, 0, 167, 0, -6, 0, 0,
+ax_anim 5, 2, 169, 0, -6, 0, 0,
+ax_anim 4, 0, 168, 0, -6, 0, 0,
+ax_anim 5, 0, 167, 0, -6, 0, 0,
+ax_anim 4, 0, 169, 0, -5, 0, 0,
+ax_anim 4, 0, 168, 0, -4, 0, 0,
+ax_anim 4, 0, 169, 0, -2, 0, 0,
+ax_anim_terminator
+sTropiusAnims_8_5:
+ax_anim 30, 0, 170, 0, 0, 0, 0,
+ax_anim 3, 0, 172, 0, 0, 0, 0,
+ax_anim 5, 0, 171, 0, -2, 0, 0,
+ax_anim 4, 0, 173, 0, -4, 0, 0,
+ax_anim 5, 0, 172, 0, -6, 0, 0,
+ax_anim 4, 0, 171, 0, -6, 0, 0,
+ax_anim 5, 2, 173, 0, -6, 0, 0,
+ax_anim 4, 0, 172, 0, -6, 0, 0,
+ax_anim 5, 0, 171, 0, -6, 0, 0,
+ax_anim 4, 0, 173, 0, -5, 0, 0,
+ax_anim 4, 0, 172, 0, -4, 0, 0,
+ax_anim 4, 0, 173, 0, -2, 0, 0,
+ax_anim_terminator
+sTropiusAnims_8_6:
+ax_anim 30, 0, 174, 0, 0, 0, 0,
+ax_anim 3, 0, 176, 0, 0, 0, 0,
+ax_anim 5, 0, 175, 0, -2, 0, 0,
+ax_anim 4, 0, 177, 0, -4, 0, 0,
+ax_anim 5, 0, 176, 0, -6, 0, 0,
+ax_anim 4, 0, 175, 0, -6, 0, 0,
+ax_anim 5, 2, 177, 0, -6, 0, 0,
+ax_anim 4, 0, 176, 0, -6, 0, 0,
+ax_anim 5, 0, 175, 0, -6, 0, 0,
+ax_anim 4, 0, 177, 0, -5, 0, 0,
+ax_anim 4, 0, 176, 0, -4, 0, 0,
+ax_anim 4, 0, 177, 0, -2, 0, 0,
+ax_anim_terminator
+sTropiusAnims_8_7:
+ax_anim 30, 0, 178, 0, 0, 0, 0,
+ax_anim 3, 0, 180, 0, 0, 0, 0,
+ax_anim 5, 0, 179, 0, -2, 0, 0,
+ax_anim 4, 0, 181, 0, -4, 0, 0,
+ax_anim 5, 0, 180, 0, -6, 0, 0,
+ax_anim 4, 0, 179, 0, -6, 0, 0,
+ax_anim 5, 2, 181, 0, -6, 0, 0,
+ax_anim 4, 0, 180, 0, -6, 0, 0,
+ax_anim 5, 0, 179, 0, -6, 0, 0,
+ax_anim 4, 0, 181, 0, -5, 0, 0,
+ax_anim 4, 0, 180, 0, -4, 0, 0,
+ax_anim 4, 0, 181, 0, -2, 0, 0,
+ax_anim_terminator
+sTropiusAnims_8_8:
+ax_anim 30, 0, 182, 0, 0, 0, 0,
+ax_anim 3, 0, 184, 0, 0, 0, 0,
+ax_anim 5, 0, 183, 0, -2, 0, 0,
+ax_anim 4, 0, 185, 0, -4, 0, 0,
+ax_anim 5, 0, 184, 0, -6, 0, 0,
+ax_anim 4, 0, 183, 0, -6, 0, 0,
+ax_anim 5, 2, 185, 0, -6, 0, 0,
+ax_anim 4, 0, 184, 0, -6, 0, 0,
+ax_anim 5, 0, 183, 0, -6, 0, 0,
+ax_anim 4, 0, 185, 0, -5, 0, 0,
+ax_anim 4, 0, 184, 0, -4, 0, 0,
+ax_anim 4, 0, 185, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 7, 15, 7, 15,
+ax_anim 3, 0, 190, 0, 17, 0, 17,
+ax_anim 2, 3, 191, -7, 15, -7, 15,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 8, 0, 8, 0,
+ax_anim 2, 0, 187, 17, 4, 17, 4,
+ax_anim 2, 0, 188, 19, 10, 19, 10,
+ax_anim 3, 0, 189, 19, 16, 19, 16,
+ax_anim 2, 3, 190, 11, 18, 11, 18,
+ax_anim 2, 0, 191, 3, 15, 3, 15,
+ax_anim 1, 0, 192, 0, 7, 0, 7,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 3, -5, 3, -5,
+ax_anim 2, 0, 186, 10, -4, 10, -4,
+ax_anim 2, 0, 187, 14, -4, 14, -4,
+ax_anim 3, 0, 188, 16, 0, 16, 0,
+ax_anim 2, 3, 189, 15, 4, 15, 4,
+ax_anim 2, 0, 190, 12, 5, 12, 5,
+ax_anim 1, 0, 191, 4, 5, 4, 5,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, -1, -8, -1, -8,
+ax_anim 2, 0, 193, 3, -13, 3, -13,
+ax_anim 2, 0, 186, 10, -17, 10, -17,
+ax_anim 3, 0, 187, 19, -19, 19, -19,
+ax_anim 2, 3, 188, 18, -11, 18, -11,
+ax_anim 2, 0, 189, 16, -4, 16, -4,
+ax_anim 1, 0, 190, 7, -1, 7, -1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -5, -4, -5, -4,
+ax_anim 2, 0, 192, -5, -8, -5, -8,
+ax_anim 2, 0, 193, -5, -17, -5, -17,
+ax_anim 3, 0, 186, 0, -18, 0, -18,
+ax_anim 2, 3, 187, 5, -17, 5, -17,
+ax_anim 2, 0, 188, 5, -8, 5, -8,
+ax_anim 1, 0, 189, 5, -4, 5, -4,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 1, -8, 1, -8,
+ax_anim 2, 0, 187, -3, -13, -3, -13,
+ax_anim 2, 0, 186, -10, -17, -10, -17,
+ax_anim 3, 0, 193, -19, -19, -19, -19,
+ax_anim 2, 3, 192, -18, -11, -18, -11,
+ax_anim 2, 0, 191, -16, -4, -16, -4,
+ax_anim 1, 0, 190, -7, -1, -7, -1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -3, -5, -3, -5,
+ax_anim 2, 0, 186, -10, -4, -10, -4,
+ax_anim 2, 0, 193, -14, -4, -14, -4,
+ax_anim 3, 0, 192, -16, 0, -16, 0,
+ax_anim 2, 3, 191, -15, 4, -15, 4,
+ax_anim 2, 0, 190, -12, 5, -12, 5,
+ax_anim 1, 0, 189, -4, 5, -4, 5,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -8, 0, -8, 0,
+ax_anim 2, 0, 193, -17, 4, -17, 4,
+ax_anim 2, 0, 192, -19, 10, -19, 10,
+ax_anim 3, 0, 191, -19, 16, -19, 16,
+ax_anim 2, 3, 190, -11, 18, -11, 18,
+ax_anim 2, 0, 189, -3, 15, -3, 15,
+ax_anim 1, 0, 188, 0, 7, 0, 7,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -17, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -17, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 1, 0, 203, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -17, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -17, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 212, 0, -19, 0, 0,
+ax_anim 2, 0, 212, 0, -17, 0, 0,
+ax_anim 1, 0, 212, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -17, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -19, 0, 0,
+ax_anim 2, 0, 215, 0, -17, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -22, 0, 0,
+ax_anim 3, 0, 218, 0, -19, 0, 0,
+ax_anim 2, 0, 218, 0, -17, 0, 0,
+ax_anim 1, 0, 218, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -17, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -23, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 2, 0, 221, 0, -18, 0, 0,
+ax_anim 1, 0, 221, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -17, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_12_2:
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 1, -1, 1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_12_3:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_12_4:
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, -1, -1, -1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_12_6:
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 1, -1, 1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_12_7:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_12_8:
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, -1, -1, -1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTropiusAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sTropiusGfx1:
+.incbin "baserom.gba", 0x14C0FB8, 0x200
+sTropiusSprites1:
+ax_sprite sTropiusGfx1, 0x200
+ax_sprite_terminator
+sTropiusGfx2:
+.incbin "baserom.gba", 0x14C11C8, 0x100
+sTropiusSprites2:
+ax_sprite sTropiusGfx2, 0x100
+ax_sprite_terminator
+sTropiusGfx3:
+.incbin "baserom.gba", 0x14C12D8, 0x40
+sTropiusSprites3:
+ax_sprite sTropiusGfx3, 0x40
+ax_sprite_terminator
+sTropiusGfx4:
+.incbin "baserom.gba", 0x14C1328, 0x20
+sTropiusSprites4:
+ax_sprite sTropiusGfx4, 0x20
+ax_sprite_terminator
+sTropiusGfx5:
+.incbin "baserom.gba", 0x14C1358, 0x100
+sTropiusSprites5:
+ax_sprite sTropiusGfx5, 0x100
+ax_sprite_terminator
+sTropiusGfx6:
+.incbin "baserom.gba", 0x14C1468, 0x80
+sTropiusSprites6:
+ax_sprite sTropiusGfx6, 0x80
+ax_sprite_terminator
+sTropiusGfx7:
+.incbin "baserom.gba", 0x14C14F8, 0x20
+sTropiusSprites7:
+ax_sprite sTropiusGfx7, 0x20
+ax_sprite_terminator
+sTropiusGfx8:
+.incbin "baserom.gba", 0x14C1528, 0x200
+sTropiusSprites8:
+ax_sprite sTropiusGfx8, 0x200
+ax_sprite_terminator
+sTropiusGfx9:
+.incbin "baserom.gba", 0x14C1738, 0x200
+sTropiusSprites9:
+ax_sprite sTropiusGfx9, 0x200
+ax_sprite_terminator
+sTropiusGfx10:
+.incbin "baserom.gba", 0x14C1948, 0x100
+sTropiusSprites10:
+ax_sprite sTropiusGfx10, 0x100
+ax_sprite_terminator
+sTropiusGfx11:
+.incbin "baserom.gba", 0x14C1A58, 0x80
+sTropiusSprites11:
+ax_sprite sTropiusGfx11, 0x80
+ax_sprite_terminator
+sTropiusGfx12:
+.incbin "baserom.gba", 0x14C1AE8, 0x20
+sTropiusSprites12:
+ax_sprite sTropiusGfx12, 0x20
+ax_sprite_terminator
+sTropiusGfx13:
+.incbin "baserom.gba", 0x14C1B18, 0x200
+sTropiusSprites13:
+ax_sprite sTropiusGfx13, 0x200
+ax_sprite_terminator
+sTropiusGfx14:
+.incbin "baserom.gba", 0x14C1D28, 0x100
+sTropiusSprites14:
+ax_sprite sTropiusGfx14, 0x100
+ax_sprite_terminator
+sTropiusGfx15:
+.incbin "baserom.gba", 0x14C1E38, 0x80
+sTropiusSprites15:
+ax_sprite sTropiusGfx15, 0x80
+ax_sprite_terminator
+sTropiusGfx16:
+.incbin "baserom.gba", 0x14C1EC8, 0x40
+sTropiusSprites16:
+ax_sprite sTropiusGfx16, 0x40
+ax_sprite_terminator
+sTropiusGfx17:
+.incbin "baserom.gba", 0x14C1F18, 0x20
+sTropiusSprites17:
+ax_sprite sTropiusGfx17, 0x20
+ax_sprite_terminator
+sTropiusGfx18:
+.incbin "baserom.gba", 0x14C1F48, 0x100
+sTropiusSprites18:
+ax_sprite sTropiusGfx18, 0x100
+ax_sprite_terminator
+sTropiusGfx19:
+.incbin "baserom.gba", 0x14C2058, 0x80
+sTropiusSprites19:
+ax_sprite sTropiusGfx19, 0x80
+ax_sprite_terminator
+sTropiusGfx20:
+.incbin "baserom.gba", 0x14C20E8, 0x40
+sTropiusSprites20:
+ax_sprite sTropiusGfx20, 0x40
+ax_sprite_terminator
+sTropiusGfx21:
+.incbin "baserom.gba", 0x14C2138, 0x20
+sTropiusSprites21:
+ax_sprite sTropiusGfx21, 0x20
+ax_sprite_terminator
+sTropiusGfx22:
+.incbin "baserom.gba", 0x14C2168, 0x200
+sTropiusSprites22:
+ax_sprite sTropiusGfx22, 0x200
+ax_sprite_terminator
+sTropiusGfx23:
+.incbin "baserom.gba", 0x14C2378, 0x200
+sTropiusSprites23:
+ax_sprite sTropiusGfx23, 0x200
+ax_sprite_terminator
+sTropiusGfx24:
+.incbin "baserom.gba", 0x14C2588, 0x100
+sTropiusSprites24:
+ax_sprite sTropiusGfx24, 0x100
+ax_sprite_terminator
+sTropiusGfx25:
+.incbin "baserom.gba", 0x14C2698, 0x80
+sTropiusSprites25:
+ax_sprite sTropiusGfx25, 0x80
+ax_sprite_terminator
+sTropiusGfx26:
+.incbin "baserom.gba", 0x14C2728, 0x40
+sTropiusSprites26:
+ax_sprite sTropiusGfx26, 0x40
+ax_sprite_terminator
+sTropiusGfx27:
+.incbin "baserom.gba", 0x14C2778, 0x20
+sTropiusSprites27:
+ax_sprite sTropiusGfx27, 0x20
+ax_sprite_terminator
+sTropiusGfx28:
+.incbin "baserom.gba", 0x14C27A8, 0x20
+sTropiusSprites28:
+ax_sprite sTropiusGfx28, 0x20
+ax_sprite_terminator
+sTropiusGfx29:
+.incbin "baserom.gba", 0x14C27D8, 0x40
+sTropiusSprites29:
+ax_sprite sTropiusGfx29, 0x40
+ax_sprite_terminator
+sTropiusGfx30:
+.incbin "baserom.gba", 0x14C2828, 0x80
+sTropiusSprites30:
+ax_sprite sTropiusGfx30, 0x80
+ax_sprite_terminator
+sTropiusGfx31:
+.incbin "baserom.gba", 0x14C28B8, 0x100
+sTropiusSprites31:
+ax_sprite sTropiusGfx31, 0x100
+ax_sprite_terminator
+sTropiusGfx32:
+.incbin "baserom.gba", 0x14C29C8, 0x20
+sTropiusSprites32:
+ax_sprite sTropiusGfx32, 0x20
+ax_sprite_terminator
+sTropiusGfx33:
+.incbin "baserom.gba", 0x14C29F8, 0x20
+sTropiusSprites33:
+ax_sprite sTropiusGfx33, 0x20
+ax_sprite_terminator
+sTropiusGfx34:
+.incbin "baserom.gba", 0x14C2A28, 0x40
+sTropiusSprites34:
+ax_sprite sTropiusGfx34, 0x40
+ax_sprite_terminator
+sTropiusGfx35:
+.incbin "baserom.gba", 0x14C2A78, 0x80
+sTropiusSprites35:
+ax_sprite sTropiusGfx35, 0x80
+ax_sprite_terminator
+sTropiusGfx36:
+.incbin "baserom.gba", 0x14C2B08, 0x100
+sTropiusSprites36:
+ax_sprite sTropiusGfx36, 0x100
+ax_sprite_terminator
+sTropiusGfx37:
+.incbin "baserom.gba", 0x14C2C18, 0x40
+sTropiusSprites37:
+ax_sprite sTropiusGfx37, 0x40
+ax_sprite_terminator
+sTropiusGfx38:
+.incbin "baserom.gba", 0x14C2C68, 0x80
+sTropiusSprites38:
+ax_sprite sTropiusGfx38, 0x80
+ax_sprite_terminator
+sTropiusGfx39:
+.incbin "baserom.gba", 0x14C2CF8, 0x100
+sTropiusSprites39:
+ax_sprite sTropiusGfx39, 0x100
+ax_sprite_terminator
+sTropiusGfx40:
+.incbin "baserom.gba", 0x14C2E08, 0x180
+sTropiusGfx40_1:
+.incbin "baserom.gba", 0x14C2F88, 0x40
+sTropiusSprites40:
+ax_sprite sTropiusGfx40, 0x180
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTropiusGfx41:
+.incbin "baserom.gba", 0x14C2FF0, 0xE0
+sTropiusSprites41:
+ax_sprite sTropiusGfx41, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTropiusGfx42:
+.incbin "baserom.gba", 0x14C30E8, 0x60
+sTropiusSprites42:
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx42, 0x60
+ax_sprite_terminator
+sTropiusGfx43:
+.incbin "baserom.gba", 0x14C3160, 0x40
+sTropiusSprites43:
+ax_sprite sTropiusGfx43, 0x40
+ax_sprite_terminator
+sTropiusGfx44:
+.incbin "baserom.gba", 0x14C31B0, 0x20
+sTropiusSprites44:
+ax_sprite sTropiusGfx44, 0x20
+ax_sprite_terminator
+sTropiusGfx45:
+.incbin "baserom.gba", 0x14C31E0, 0x20
+sTropiusSprites45:
+ax_sprite sTropiusGfx45, 0x20
+ax_sprite_terminator
+sTropiusGfx46:
+.incbin "baserom.gba", 0x14C3210, 0x100
+sTropiusSprites46:
+ax_sprite sTropiusGfx46, 0x100
+ax_sprite_terminator
+sTropiusGfx47:
+.incbin "baserom.gba", 0x14C3320, 0x60
+sTropiusSprites47:
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx47, 0x60
+ax_sprite_terminator
+sTropiusGfx48:
+.incbin "baserom.gba", 0x14C3398, 0x20
+sTropiusSprites48:
+ax_sprite sTropiusGfx48, 0x20
+ax_sprite_terminator
+sTropiusGfx49:
+.incbin "baserom.gba", 0x14C33C8, 0x20
+sTropiusSprites49:
+ax_sprite sTropiusGfx49, 0x20
+ax_sprite_terminator
+sTropiusGfx50:
+.incbin "baserom.gba", 0x14C33F8, 0x20
+sTropiusSprites50:
+ax_sprite sTropiusGfx50, 0x20
+ax_sprite_terminator
+sTropiusGfx51:
+.incbin "baserom.gba", 0x14C3428, 0xC0
+sTropiusGfx51_1:
+.incbin "baserom.gba", 0x14C34E8, 0x20
+sTropiusSprites51:
+ax_sprite sTropiusGfx51, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx51_1, 0x20
+ax_sprite_terminator
+sTropiusGfx52:
+.incbin "baserom.gba", 0x14C3528, 0x80
+sTropiusSprites52:
+ax_sprite sTropiusGfx52, 0x80
+ax_sprite_terminator
+sTropiusGfx53:
+.incbin "baserom.gba", 0x14C35B8, 0x40
+sTropiusSprites53:
+ax_sprite sTropiusGfx53, 0x40
+ax_sprite_terminator
+sTropiusGfx54:
+.incbin "baserom.gba", 0x14C3608, 0x20
+sTropiusSprites54:
+ax_sprite sTropiusGfx54, 0x20
+ax_sprite_terminator
+sTropiusGfx55:
+.incbin "baserom.gba", 0x14C3638, 0x40
+sTropiusGfx55_1:
+.incbin "baserom.gba", 0x14C3678, 0x160
+sTropiusSprites55:
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx55, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx55_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTropiusGfx56:
+.incbin "baserom.gba", 0x14C3808, 0x20
+sTropiusGfx56_1:
+.incbin "baserom.gba", 0x14C3828, 0xA0
+sTropiusSprites56:
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx56, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx56_1, 0xa0
+ax_sprite_terminator
+sTropiusGfx57:
+.incbin "baserom.gba", 0x14C38F0, 0x80
+sTropiusSprites57:
+ax_sprite sTropiusGfx57, 0x80
+ax_sprite_terminator
+sTropiusGfx58:
+.incbin "baserom.gba", 0x14C3980, 0x40
+sTropiusSprites58:
+ax_sprite sTropiusGfx58, 0x40
+ax_sprite_terminator
+sTropiusGfx59:
+.incbin "baserom.gba", 0x14C39D0, 0x20
+sTropiusSprites59:
+ax_sprite sTropiusGfx59, 0x20
+ax_sprite_terminator
+sTropiusGfx60:
+.incbin "baserom.gba", 0x14C3A00, 0x40
+sTropiusGfx60_1:
+.incbin "baserom.gba", 0x14C3A40, 0x60
+sTropiusGfx60_2:
+.incbin "baserom.gba", 0x14C3AA0, 0x80
+sTropiusGfx60_3:
+.incbin "baserom.gba", 0x14C3B20, 0x60
+sTropiusSprites60:
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx60, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx60_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx60_3, 0x60
+ax_sprite_terminator
+sTropiusGfx61:
+.incbin "baserom.gba", 0x14C3BC8, 0x100
+sTropiusSprites61:
+ax_sprite sTropiusGfx61, 0x100
+ax_sprite_terminator
+sTropiusGfx62:
+.incbin "baserom.gba", 0x14C3CD8, 0x20
+sTropiusGfx62_1:
+.incbin "baserom.gba", 0x14C3CF8, 0x40
+sTropiusSprites62:
+ax_sprite sTropiusGfx62, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx62_1, 0x40
+ax_sprite_terminator
+sTropiusGfx63:
+.incbin "baserom.gba", 0x14C3D58, 0x20
+sTropiusSprites63:
+ax_sprite sTropiusGfx63, 0x20
+ax_sprite_terminator
+sTropiusGfx64:
+.incbin "baserom.gba", 0x14C3D88, 0x20
+sTropiusSprites64:
+ax_sprite sTropiusGfx64, 0x20
+ax_sprite_terminator
+sTropiusGfx65:
+.incbin "baserom.gba", 0x14C3DB8, 0xA0
+sTropiusGfx65_1:
+.incbin "baserom.gba", 0x14C3E58, 0x20
+sTropiusSprites65:
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx65, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx65_1, 0x20
+ax_sprite_terminator
+sTropiusGfx66:
+.incbin "baserom.gba", 0x14C3EA0, 0x80
+sTropiusSprites66:
+ax_sprite sTropiusGfx66, 0x80
+ax_sprite_terminator
+sTropiusGfx67:
+.incbin "baserom.gba", 0x14C3F30, 0x40
+sTropiusSprites67:
+ax_sprite sTropiusGfx67, 0x40
+ax_sprite_terminator
+sTropiusGfx68:
+.incbin "baserom.gba", 0x14C3F80, 0x20
+sTropiusSprites68:
+ax_sprite sTropiusGfx68, 0x20
+ax_sprite_terminator
+sTropiusGfx69:
+.incbin "baserom.gba", 0x14C3FB0, 0x20
+sTropiusSprites69:
+ax_sprite sTropiusGfx69, 0x20
+ax_sprite_terminator
+sTropiusGfx70:
+.incbin "baserom.gba", 0x14C3FE0, 0x20
+sTropiusSprites70:
+ax_sprite sTropiusGfx70, 0x20
+ax_sprite_terminator
+sTropiusGfx71:
+.incbin "baserom.gba", 0x14C4010, 0x100
+sTropiusSprites71:
+ax_sprite sTropiusGfx71, 0x100
+ax_sprite_terminator
+sTropiusGfx72:
+.incbin "baserom.gba", 0x14C4120, 0x40
+sTropiusSprites72:
+ax_sprite sTropiusGfx72, 0x40
+ax_sprite_terminator
+sTropiusGfx73:
+.incbin "baserom.gba", 0x14C4170, 0x20
+sTropiusSprites73:
+ax_sprite sTropiusGfx73, 0x20
+ax_sprite_terminator
+sTropiusGfx74:
+.incbin "baserom.gba", 0x14C41A0, 0x40
+sTropiusSprites74:
+ax_sprite sTropiusGfx74, 0x40
+ax_sprite_terminator
+sTropiusGfx75:
+.incbin "baserom.gba", 0x14C41F0, 0x20
+sTropiusSprites75:
+ax_sprite sTropiusGfx75, 0x20
+ax_sprite_terminator
+sTropiusGfx76:
+.incbin "baserom.gba", 0x14C4220, 0x20
+sTropiusSprites76:
+ax_sprite sTropiusGfx76, 0x20
+ax_sprite_terminator
+sTropiusGfx77:
+.incbin "baserom.gba", 0x14C4250, 0x100
+sTropiusSprites77:
+ax_sprite sTropiusGfx77, 0x100
+ax_sprite_terminator
+sTropiusGfx78:
+.incbin "baserom.gba", 0x14C4360, 0x80
+sTropiusSprites78:
+ax_sprite sTropiusGfx78, 0x80
+ax_sprite_terminator
+sTropiusGfx79:
+.incbin "baserom.gba", 0x14C43F0, 0x20
+sTropiusSprites79:
+ax_sprite sTropiusGfx79, 0x20
+ax_sprite_terminator
+sTropiusGfx80:
+.incbin "baserom.gba", 0x14C4420, 0x20
+sTropiusSprites80:
+ax_sprite sTropiusGfx80, 0x20
+ax_sprite_terminator
+sTropiusGfx81:
+.incbin "baserom.gba", 0x14C4450, 0x100
+sTropiusSprites81:
+ax_sprite sTropiusGfx81, 0x100
+ax_sprite_terminator
+sTropiusGfx82:
+.incbin "baserom.gba", 0x14C4560, 0x40
+sTropiusSprites82:
+ax_sprite sTropiusGfx82, 0x40
+ax_sprite_terminator
+sTropiusGfx83:
+.incbin "baserom.gba", 0x14C45B0, 0x20
+sTropiusSprites83:
+ax_sprite sTropiusGfx83, 0x20
+ax_sprite_terminator
+sTropiusGfx84:
+.incbin "baserom.gba", 0x14C45E0, 0x100
+sTropiusSprites84:
+ax_sprite sTropiusGfx84, 0x100
+ax_sprite_terminator
+sTropiusGfx85:
+.incbin "baserom.gba", 0x14C46F0, 0x80
+sTropiusSprites85:
+ax_sprite sTropiusGfx85, 0x80
+ax_sprite_terminator
+sTropiusGfx86:
+.incbin "baserom.gba", 0x14C4780, 0x160
+sTropiusGfx86_1:
+.incbin "baserom.gba", 0x14C48E0, 0x60
+sTropiusSprites86:
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx86, 0x160
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx86_1, 0x60
+ax_sprite_terminator
+sTropiusGfx87:
+.incbin "baserom.gba", 0x14C4968, 0x40
+sTropiusGfx87_1:
+.incbin "baserom.gba", 0x14C49A8, 0x60
+sTropiusGfx87_2:
+.incbin "baserom.gba", 0x14C4A08, 0x80
+sTropiusGfx87_3:
+.incbin "baserom.gba", 0x14C4A88, 0x40
+sTropiusSprites87:
+ax_sprite sTropiusGfx87, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTropiusGfx87_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx87_2, 0x80
+ax_sprite 0, 0x40
+ax_sprite sTropiusGfx87_3, 0x40
+ax_sprite_terminator
+sTropiusGfx88:
+.incbin "baserom.gba", 0x14C4B08, 0x40
+sTropiusGfx88_1:
+.incbin "baserom.gba", 0x14C4B48, 0x100
+sTropiusGfx88_2:
+.incbin "baserom.gba", 0x14C4C48, 0x60
+sTropiusSprites88:
+ax_sprite sTropiusGfx88, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTropiusGfx88_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx88_2, 0x60
+ax_sprite_terminator
+sTropiusGfx89:
+.incbin "baserom.gba", 0x14C4CD8, 0x100
+sTropiusSprites89:
+ax_sprite sTropiusGfx89, 0x100
+ax_sprite_terminator
+sTropiusGfx90:
+.incbin "baserom.gba", 0x14C4DE8, 0x80
+sTropiusSprites90:
+ax_sprite sTropiusGfx90, 0x80
+ax_sprite_terminator
+sTropiusGfx91:
+.incbin "baserom.gba", 0x14C4E78, 0x40
+sTropiusSprites91:
+ax_sprite sTropiusGfx91, 0x40
+ax_sprite_terminator
+sTropiusGfx92:
+.incbin "baserom.gba", 0x14C4EC8, 0x20
+sTropiusSprites92:
+ax_sprite sTropiusGfx92, 0x20
+ax_sprite_terminator
+sTropiusGfx93:
+.incbin "baserom.gba", 0x14C4EF8, 0x20
+sTropiusSprites93:
+ax_sprite sTropiusGfx93, 0x20
+ax_sprite_terminator
+sTropiusGfx94:
+.incbin "baserom.gba", 0x14C4F28, 0xC0
+sTropiusSprites94:
+ax_sprite 0, 0x40
+ax_sprite sTropiusGfx94, 0xc0
+ax_sprite_terminator
+sTropiusGfx95:
+.incbin "baserom.gba", 0x14C5000, 0x80
+sTropiusSprites95:
+ax_sprite sTropiusGfx95, 0x80
+ax_sprite_terminator
+sTropiusGfx96:
+.incbin "baserom.gba", 0x14C5090, 0x40
+sTropiusSprites96:
+ax_sprite sTropiusGfx96, 0x40
+ax_sprite_terminator
+sTropiusGfx97:
+.incbin "baserom.gba", 0x14C50E0, 0x20
+sTropiusSprites97:
+ax_sprite sTropiusGfx97, 0x20
+ax_sprite_terminator
+sTropiusGfx98:
+.incbin "baserom.gba", 0x14C5110, 0x100
+sTropiusGfx98_1:
+.incbin "baserom.gba", 0x14C5210, 0x60
+sTropiusGfx98_2:
+.incbin "baserom.gba", 0x14C5270, 0x60
+sTropiusSprites98:
+ax_sprite sTropiusGfx98, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx98_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx98_2, 0x60
+ax_sprite_terminator
+sTropiusGfx99:
+.incbin "baserom.gba", 0x14C5300, 0x100
+sTropiusSprites99:
+ax_sprite sTropiusGfx99, 0x100
+ax_sprite_terminator
+sTropiusGfx100:
+.incbin "baserom.gba", 0x14C5410, 0x80
+sTropiusSprites100:
+ax_sprite sTropiusGfx100, 0x80
+ax_sprite_terminator
+sTropiusGfx101:
+.incbin "baserom.gba", 0x14C54A0, 0x20
+sTropiusSprites101:
+ax_sprite sTropiusGfx101, 0x20
+ax_sprite_terminator
+sTropiusGfx102:
+.incbin "baserom.gba", 0x14C54D0, 0x20
+sTropiusSprites102:
+ax_sprite sTropiusGfx102, 0x20
+ax_sprite_terminator
+sTropiusGfx103:
+.incbin "baserom.gba", 0x14C5500, 0x20
+sTropiusSprites103:
+ax_sprite sTropiusGfx103, 0x20
+ax_sprite_terminator
+sTropiusGfx104:
+.incbin "baserom.gba", 0x14C5530, 0x20
+sTropiusSprites104:
+ax_sprite sTropiusGfx104, 0x20
+ax_sprite_terminator
+sTropiusGfx105:
+.incbin "baserom.gba", 0x14C5560, 0x40
+sTropiusGfx105_1:
+.incbin "baserom.gba", 0x14C55A0, 0x60
+sTropiusGfx105_2:
+.incbin "baserom.gba", 0x14C5600, 0x100
+sTropiusSprites105:
+ax_sprite sTropiusGfx105, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTropiusGfx105_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx105_2, 0x100
+ax_sprite_terminator
+sTropiusGfx106:
+.incbin "baserom.gba", 0x14C5730, 0x200
+sTropiusSprites106:
+ax_sprite sTropiusGfx106, 0x200
+ax_sprite_terminator
+sTropiusGfx107:
+.incbin "baserom.gba", 0x14C5940, 0x100
+sTropiusSprites107:
+ax_sprite sTropiusGfx107, 0x100
+ax_sprite_terminator
+sTropiusGfx108:
+.incbin "baserom.gba", 0x14C5A50, 0x80
+sTropiusSprites108:
+ax_sprite sTropiusGfx108, 0x80
+ax_sprite_terminator
+sTropiusGfx109:
+.incbin "baserom.gba", 0x14C5AE0, 0x20
+sTropiusSprites109:
+ax_sprite sTropiusGfx109, 0x20
+ax_sprite_terminator
+sTropiusGfx110:
+.incbin "baserom.gba", 0x14C5B10, 0x20
+sTropiusSprites110:
+ax_sprite sTropiusGfx110, 0x20
+ax_sprite_terminator
+sTropiusGfx111:
+.incbin "baserom.gba", 0x14C5B40, 0x20
+sTropiusSprites111:
+ax_sprite sTropiusGfx111, 0x20
+ax_sprite_terminator
+sTropiusGfx112:
+.incbin "baserom.gba", 0x14C5B70, 0x20
+sTropiusGfx112_1:
+.incbin "baserom.gba", 0x14C5B90, 0x20
+sTropiusGfx112_2:
+.incbin "baserom.gba", 0x14C5BB0, 0x80
+sTropiusSprites112:
+ax_sprite sTropiusGfx112, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx112_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTropiusGfx112_2, 0x80
+ax_sprite_terminator
+sTropiusGfx113:
+.incbin "baserom.gba", 0x14C5C60, 0x80
+sTropiusSprites113:
+ax_sprite sTropiusGfx113, 0x80
+ax_sprite_terminator
+sTropiusGfx114:
+.incbin "baserom.gba", 0x14C5CF0, 0x40
+sTropiusSprites114:
+ax_sprite sTropiusGfx114, 0x40
+ax_sprite_terminator
+sTropiusGfx115:
+.incbin "baserom.gba", 0x14C5D40, 0x40
+sTropiusSprites115:
+ax_sprite sTropiusGfx115, 0x40
+ax_sprite_terminator
+sTropiusGfx116:
+.incbin "baserom.gba", 0x14C5D90, 0x20
+sTropiusSprites116:
+ax_sprite sTropiusGfx116, 0x20
+ax_sprite_terminator
+sTropiusGfx117:
+.incbin "baserom.gba", 0x14C5DC0, 0x20
+sTropiusSprites117:
+ax_sprite sTropiusGfx117, 0x20
+ax_sprite_terminator
+sTropiusGfx118:
+.incbin "baserom.gba", 0x14C5DF0, 0x40
+sTropiusSprites118:
+ax_sprite sTropiusGfx118, 0x40
+ax_sprite_terminator
+sTropiusGfx119:
+.incbin "baserom.gba", 0x14C5E40, 0x80
+sTropiusSprites119:
+ax_sprite sTropiusGfx119, 0x80
+ax_sprite_terminator
+sTropiusGfx120:
+.incbin "baserom.gba", 0x14C5ED0, 0x100
+sTropiusSprites120:
+ax_sprite sTropiusGfx120, 0x100
+ax_sprite_terminator
+sTropiusGfx121:
+.incbin "baserom.gba", 0x14C5FE0, 0x20
+sTropiusSprites121:
+ax_sprite sTropiusGfx121, 0x20
+ax_sprite_terminator
+sTropiusGfx122:
+.incbin "baserom.gba", 0x14C6010, 0x20
+sTropiusSprites122:
+ax_sprite sTropiusGfx122, 0x20
+ax_sprite_terminator
+sTropiusGfx123:
+.incbin "baserom.gba", 0x14C6040, 0x100
+sTropiusSprites123:
+ax_sprite sTropiusGfx123, 0x100
+ax_sprite_terminator
+sTropiusGfx124:
+.incbin "baserom.gba", 0x14C6150, 0x40
+sTropiusSprites124:
+ax_sprite sTropiusGfx124, 0x40
+ax_sprite_terminator
+sTropiusGfx125:
+.incbin "baserom.gba", 0x14C61A0, 0x20
+sTropiusSprites125:
+ax_sprite sTropiusGfx125, 0x20
+ax_sprite_terminator
+sTropiusGfx126:
+.incbin "baserom.gba", 0x14C61D0, 0x100
+sTropiusSprites126:
+ax_sprite sTropiusGfx126, 0x100
+ax_sprite_terminator
+sTropiusGfx127:
+.incbin "baserom.gba", 0x14C62E0, 0x40
+sTropiusSprites127:
+ax_sprite sTropiusGfx127, 0x40
+ax_sprite_terminator
+sTropiusGfx128:
+.incbin "baserom.gba", 0x14C6330, 0x100
+sTropiusSprites128:
+ax_sprite sTropiusGfx128, 0x100
+ax_sprite_terminator
+sTropiusGfx129:
+.incbin "baserom.gba", 0x14C6440, 0x20
+sTropiusSprites129:
+ax_sprite sTropiusGfx129, 0x20
+ax_sprite_terminator
+sTropiusGfx130:
+.incbin "baserom.gba", 0x14C6470, 0x40
+sTropiusSprites130:
+ax_sprite sTropiusGfx130, 0x40
+ax_sprite_terminator
+sTropiusGfx131:
+.incbin "baserom.gba", 0x14C64C0, 0x40
+sTropiusSprites131:
+ax_sprite sTropiusGfx131, 0x40
+ax_sprite_terminator
+sTropiusGfx132:
+.incbin "baserom.gba", 0x14C6510, 0x100
+sTropiusSprites132:
+ax_sprite sTropiusGfx132, 0x100
+ax_sprite_terminator
+sTropiusGfx133:
+.incbin "baserom.gba", 0x14C6620, 0x80
+sTropiusSprites133:
+ax_sprite sTropiusGfx133, 0x80
+ax_sprite_terminator
+sTropiusGfx134:
+.incbin "baserom.gba", 0x14C66B0, 0x20
+sTropiusSprites134:
+ax_sprite sTropiusGfx134, 0x20
+ax_sprite_terminator
+sTropiusGfx135:
+.incbin "baserom.gba", 0x14C66E0, 0x40
+sTropiusSprites135:
+ax_sprite sTropiusGfx135, 0x40
+ax_sprite_terminator
+sTropiusGfx136:
+.incbin "baserom.gba", 0x14C6730, 0x100
+sTropiusSprites136:
+ax_sprite sTropiusGfx136, 0x100
+ax_sprite_terminator
+sTropiusGfx137:
+.incbin "baserom.gba", 0x14C6840, 0x80
+sTropiusSprites137:
+ax_sprite sTropiusGfx137, 0x80
+ax_sprite_terminator
+sTropiusGfx138:
+.incbin "baserom.gba", 0x14C68D0, 0x20
+sTropiusSprites138:
+ax_sprite sTropiusGfx138, 0x20
+ax_sprite_terminator
+sTropiusGfx139:
+.incbin "baserom.gba", 0x14C6900, 0x20
+sTropiusSprites139:
+ax_sprite sTropiusGfx139, 0x20
+ax_sprite_terminator
+sTropiusGfx140:
+.incbin "baserom.gba", 0x14C6930, 0x20
+sTropiusSprites140:
+ax_sprite sTropiusGfx140, 0x20
+ax_sprite_terminator
+sTropiusGfx141:
+.incbin "baserom.gba", 0x14C6960, 0x20
+sTropiusSprites141:
+ax_sprite sTropiusGfx141, 0x20
+ax_sprite_terminator
+sTropiusGfx142:
+.incbin "baserom.gba", 0x14C6990, 0x100
+sTropiusSprites142:
+ax_sprite sTropiusGfx142, 0x100
+ax_sprite_terminator
+sTropiusGfx143:
+.incbin "baserom.gba", 0x14C6AA0, 0x40
+sTropiusSprites143:
+ax_sprite sTropiusGfx143, 0x40
+ax_sprite_terminator
+sTropiusGfx144:
+.incbin "baserom.gba", 0x14C6AF0, 0x40
+sTropiusSprites144:
+ax_sprite sTropiusGfx144, 0x40
+ax_sprite_terminator
+sTropiusGfx145:
+.incbin "baserom.gba", 0x14C6B40, 0x20
+sTropiusSprites145:
+ax_sprite sTropiusGfx145, 0x20
+ax_sprite_terminator
+sTropiusGfx146:
+.incbin "baserom.gba", 0x14C6B70, 0x20
+sTropiusSprites146:
+ax_sprite sTropiusGfx146, 0x20
+ax_sprite_terminator
+sTropiusGfx147:
+.incbin "baserom.gba", 0x14C6BA0, 0x20
+sTropiusSprites147:
+ax_sprite sTropiusGfx147, 0x20
+ax_sprite_terminator
+sTropiusGfx148:
+.incbin "baserom.gba", 0x14C6BD0, 0x20
+sTropiusSprites148:
+ax_sprite sTropiusGfx148, 0x20
+ax_sprite_terminator
+sTropiusGfx149:
+.incbin "baserom.gba", 0x14C6C00, 0x40
+sTropiusSprites149:
+ax_sprite sTropiusGfx149, 0x40
+ax_sprite_terminator
+sTropiusGfx150:
+.incbin "baserom.gba", 0x14C6C50, 0x40
+sTropiusSprites150:
+ax_sprite sTropiusGfx150, 0x40
+ax_sprite_terminator
+sTropiusGfx151:
+.incbin "baserom.gba", 0x14C6CA0, 0x80
+sTropiusSprites151:
+ax_sprite sTropiusGfx151, 0x80
+ax_sprite_terminator
+sTropiusGfx152:
+.incbin "baserom.gba", 0x14C6D30, 0x100
+sTropiusSprites152:
+ax_sprite sTropiusGfx152, 0x100
+ax_sprite_terminator
+sAxPosesTropius:
+.4byte sTropiusPose1
+.4byte sTropiusPose2
+.4byte sTropiusPose3
+.4byte sTropiusPose4
+.4byte sTropiusPose5
+.4byte sTropiusPose6
+.4byte sTropiusPose7
+.4byte sTropiusPose8
+.4byte sTropiusPose9
+.4byte sTropiusPose10
+.4byte sTropiusPose11
+.4byte sTropiusPose12
+.4byte sTropiusPose13
+.4byte sTropiusPose14
+.4byte sTropiusPose15
+.4byte sTropiusPose16
+.4byte sTropiusPose17
+.4byte sTropiusPose18
+.4byte sTropiusPose19
+.4byte sTropiusPose20
+.4byte sTropiusPose21
+.4byte sTropiusPose22
+.4byte sTropiusPose23
+.4byte sTropiusPose24
+.4byte sTropiusPose25
+.4byte sTropiusPose26
+.4byte sTropiusPose27
+.4byte sTropiusPose28
+.4byte sTropiusPose29
+.4byte sTropiusPose30
+.4byte sTropiusPose31
+.4byte sTropiusPose32
+.4byte sTropiusPose33
+.4byte sTropiusPose34
+.4byte sTropiusPose35
+.4byte sTropiusPose36
+.4byte sTropiusPose37
+.4byte sTropiusPose38
+.4byte sTropiusPose39
+.4byte sTropiusPose40
+.4byte sTropiusPose41
+.4byte sTropiusPose42
+.4byte sTropiusPose43
+.4byte sTropiusPose44
+.4byte sTropiusPose45
+.4byte sTropiusPose46
+.4byte sTropiusPose47
+.4byte sTropiusPose48
+.4byte sTropiusPose49
+.4byte sTropiusPose50
+.4byte sTropiusPose51
+.4byte sTropiusPose52
+.4byte sTropiusPose53
+.4byte sTropiusPose54
+.4byte sTropiusPose55
+.4byte sTropiusPose56
+.4byte sTropiusPose57
+.4byte sTropiusPose58
+.4byte sTropiusPose59
+.4byte sTropiusPose60
+.4byte sTropiusPose61
+.4byte sTropiusPose62
+.4byte sTropiusPose63
+.4byte sTropiusPose64
+.4byte sTropiusPose65
+.4byte sTropiusPose66
+.4byte sTropiusPose67
+.4byte sTropiusPose68
+.4byte sTropiusPose69
+.4byte sTropiusPose70
+.4byte sTropiusPose71
+.4byte sTropiusPose72
+.4byte sTropiusPose73
+.4byte sTropiusPose74
+.4byte sTropiusPose75
+.4byte sTropiusPose76
+.4byte sTropiusPose77
+.4byte sTropiusPose78
+.4byte sTropiusPose79
+.4byte sTropiusPose80
+.4byte sTropiusPose81
+.4byte sTropiusPose82
+.4byte sTropiusPose83
+.4byte sTropiusPose84
+.4byte sTropiusPose85
+.4byte sTropiusPose86
+.4byte sTropiusPose87
+.4byte sTropiusPose88
+.4byte sTropiusPose89
+.4byte sTropiusPose90
+.4byte sTropiusPose91
+.4byte sTropiusPose92
+.4byte sTropiusPose93
+.4byte sTropiusPose94
+.4byte sTropiusPose95
+.4byte sTropiusPose96
+.4byte sTropiusPose97
+.4byte sTropiusPose98
+.4byte sTropiusPose99
+.4byte sTropiusPose100
+.4byte sTropiusPose101
+.4byte sTropiusPose102
+.4byte sTropiusPose103
+.4byte sTropiusPose104
+.4byte sTropiusPose105
+.4byte sTropiusPose106
+.4byte sTropiusPose107
+.4byte sTropiusPose108
+.4byte sTropiusPose109
+.4byte sTropiusPose110
+.4byte sTropiusPose111
+.4byte sTropiusPose112
+.4byte sTropiusPose113
+.4byte sTropiusPose114
+.4byte sTropiusPose115
+.4byte sTropiusPose116
+.4byte sTropiusPose117
+.4byte sTropiusPose118
+.4byte sTropiusPose119
+.4byte sTropiusPose120
+.4byte sTropiusPose121
+.4byte sTropiusPose122
+.4byte sTropiusPose123
+.4byte sTropiusPose124
+.4byte sTropiusPose125
+.4byte sTropiusPose126
+.4byte sTropiusPose127
+.4byte sTropiusPose128
+.4byte sTropiusPose129
+.4byte sTropiusPose130
+.4byte sTropiusPose131
+.4byte sTropiusPose132
+.4byte sTropiusPose133
+.4byte sTropiusPose134
+.4byte sTropiusPose135
+.4byte sTropiusPose136
+.4byte sTropiusPose137
+.4byte sTropiusPose138
+.4byte sTropiusPose139
+.4byte sTropiusPose140
+.4byte sTropiusPose141
+.4byte sTropiusPose142
+.4byte sTropiusPose143
+.4byte sTropiusPose144
+.4byte sTropiusPose145
+.4byte sTropiusPose146
+.4byte sTropiusPose147
+.4byte sTropiusPose148
+.4byte sTropiusPose149
+.4byte sTropiusPose150
+.4byte sTropiusPose151
+.4byte sTropiusPose152
+.4byte sTropiusPose153
+.4byte sTropiusPose154
+.4byte sTropiusPose155
+.4byte sTropiusPose156
+.4byte sTropiusPose157
+.4byte sTropiusPose158
+.4byte sTropiusPose159
+.4byte sTropiusPose160
+.4byte sTropiusPose161
+.4byte sTropiusPose162
+.4byte sTropiusPose163
+.4byte sTropiusPose164
+.4byte sTropiusPose165
+.4byte sTropiusPose166
+.4byte sTropiusPose167
+.4byte sTropiusPose168
+.4byte sTropiusPose169
+.4byte sTropiusPose170
+.4byte sTropiusPose171
+.4byte sTropiusPose172
+.4byte sTropiusPose173
+.4byte sTropiusPose174
+.4byte sTropiusPose175
+.4byte sTropiusPose176
+.4byte sTropiusPose177
+.4byte sTropiusPose178
+.4byte sTropiusPose179
+.4byte sTropiusPose180
+.4byte sTropiusPose181
+.4byte sTropiusPose182
+.4byte sTropiusPose183
+.4byte sTropiusPose184
+.4byte sTropiusPose185
+.4byte sTropiusPose186
+.4byte sTropiusPose187
+.4byte sTropiusPose188
+.4byte sTropiusPose189
+.4byte sTropiusPose190
+.4byte sTropiusPose191
+.4byte sTropiusPose192
+.4byte sTropiusPose193
+.4byte sTropiusPose194
+.4byte sTropiusPose195
+.4byte sTropiusPose196
+.4byte sTropiusPose197
+.4byte sTropiusPose198
+.4byte sTropiusPose199
+.4byte sTropiusPose200
+.4byte sTropiusPose201
+.4byte sTropiusPose202
+.4byte sTropiusPose203
+.4byte sTropiusPose204
+.4byte sTropiusPose205
+.4byte sTropiusPose206
+.4byte sTropiusPose207
+.4byte sTropiusPose208
+.4byte sTropiusPose209
+.4byte sTropiusPose210
+.4byte sTropiusPose211
+.4byte sTropiusPose212
+.4byte sTropiusPose213
+.4byte sTropiusPose214
+.4byte sTropiusPose215
+.4byte sTropiusPose216
+.4byte sTropiusPose217
+.4byte sTropiusPose218
+.4byte sTropiusPose219
+.4byte sTropiusPose220
+.4byte sTropiusPose221
+.4byte sTropiusPose222
+.4byte sTropiusPose223
+.4byte sTropiusPose224
+.4byte sTropiusPose225
+.4byte sTropiusPose226
+.4byte sTropiusPose227
+.4byte sTropiusPose228
+.4byte sTropiusPose229
+.4byte sTropiusPose230
+.4byte sTropiusPose231
+.4byte sTropiusPose232
+.4byte sTropiusPose233
+.4byte sTropiusPose234
+.4byte sTropiusPose235
+.4byte sTropiusPose236
+.4byte sTropiusPose237
+.4byte sTropiusPose238
+.4byte sTropiusPose239
+.4byte sTropiusPose240
+.4byte sTropiusPose241
+.4byte sTropiusPose242
+sAxPositionsTropius:
+.2byte   -1,  -10, 	  -4,    1, 	   2,    1, 	  -1,   -6
+.2byte    0,   -8, 	  -4,    1, 	   2,    3, 	  -1,   -4
+.2byte   -2,   -8, 	  -4,    3, 	   3,    1, 	  -1,   -4
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+.2byte   11,   -9, 	   4,   -1, 	   1,    3, 	   1,   -5
+.2byte   13,   -9, 	   7,    1, 	  -1,    1, 	   2,   -5
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte   17,  -15, 	   1,   -1, 	   5,    0, 	  -1,   -7
+.2byte   17,  -15, 	   7,   -2, 	   0,    0, 	  -1,   -7
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte   11,  -19, 	   0,   -5, 	   6,   -4, 	  -3,   -9
+.2byte    9,  -20, 	   0,   -7, 	   3,   -3, 	  -2,   -9
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -2,  -22, 	   3,   -5, 	  -3,   -5, 	  -1,   -7
+.2byte    0,  -22, 	   2,   -3, 	  -4,   -4, 	  -1,   -7
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte  -13,  -19, 	  -2,   -5, 	  -8,   -4, 	   1,   -9
+.2byte  -11,  -20, 	  -2,   -7, 	  -5,   -3, 	   0,   -9
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte  -19,  -15, 	  -3,   -1, 	  -7,    0, 	  -1,   -7
+.2byte  -19,  -15, 	  -9,   -2, 	  -2,    0, 	  -1,   -7
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte  -12,   -9, 	  -5,   -1, 	  -2,    3, 	  -2,   -5
+.2byte  -14,   -9, 	  -8,    1, 	   0,    1, 	  -3,   -5
+.2byte   -1,  -10, 	  -4,    1, 	   2,    1, 	  -1,   -6
+.2byte    0,   -8, 	  -4,    1, 	   2,    3, 	  -1,   -4
+.2byte   -2,   -8, 	  -4,    3, 	   3,    1, 	  -1,   -4
+.2byte   -1,    5, 	  -3,   -1, 	   2,   -1, 	  -1,   -5
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+.2byte   11,   -9, 	   4,   -1, 	   1,    3, 	   1,   -5
+.2byte   13,   -9, 	   7,    1, 	  -1,    1, 	   2,   -5
+.2byte   17,    1, 	   6,   -2, 	   2,    2, 	   1,   -6
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte   17,  -15, 	   1,   -1, 	   5,    0, 	  -1,   -7
+.2byte   17,  -15, 	   7,   -2, 	   0,    0, 	  -1,   -7
+.2byte   22,   -8, 	   4,   -2, 	   5,    0, 	   2,   -7
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte   11,  -19, 	   0,   -5, 	   6,   -4, 	  -3,   -9
+.2byte    9,  -20, 	   0,   -7, 	   3,   -3, 	  -2,   -9
+.2byte   14,  -15, 	  -2,   -5, 	   4,   -2, 	  -1,   -9
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -2,  -22, 	   3,   -5, 	  -3,   -5, 	  -1,   -7
+.2byte    0,  -22, 	   2,   -3, 	  -4,   -4, 	  -1,   -7
+.2byte   -1,  -21, 	   3,   -4, 	  -4,   -4, 	  -1,   -9
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte  -13,  -19, 	  -2,   -5, 	  -8,   -4, 	   1,   -9
+.2byte  -11,  -20, 	  -2,   -7, 	  -5,   -3, 	   0,   -9
+.2byte  -16,  -15, 	   0,   -5, 	  -6,   -2, 	  -1,   -9
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte  -19,  -15, 	  -3,   -1, 	  -7,    0, 	  -1,   -7
+.2byte  -19,  -15, 	  -9,   -2, 	  -2,    0, 	  -1,   -7
+.2byte  -24,   -8, 	  -6,   -2, 	  -7,    0, 	  -4,   -7
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte  -12,   -9, 	  -5,   -1, 	  -2,    3, 	  -2,   -5
+.2byte  -14,   -9, 	  -8,    1, 	   0,    1, 	  -3,   -5
+.2byte  -18,    1, 	  -7,   -2, 	  -3,    2, 	  -2,   -6
+.2byte   -1,  -10, 	  -4,    1, 	   2,    1, 	  -1,   -6
+.2byte    0,   -8, 	  -4,    1, 	   2,    3, 	  -1,   -4
+.2byte   -2,   -8, 	  -4,    3, 	   3,    1, 	  -1,   -4
+.2byte   -1,    5, 	  -3,   -1, 	   2,   -1, 	  -1,   -5
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+.2byte   11,   -9, 	   4,   -1, 	   1,    3, 	   1,   -5
+.2byte   13,   -9, 	   7,    1, 	  -1,    1, 	   2,   -5
+.2byte   17,    1, 	   6,   -2, 	   2,    2, 	   1,   -6
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte   17,  -15, 	   1,   -1, 	   5,    0, 	  -1,   -7
+.2byte   17,  -15, 	   7,   -2, 	   0,    0, 	  -1,   -7
+.2byte   22,   -8, 	   4,   -2, 	   5,    0, 	   2,   -7
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte   11,  -19, 	   0,   -5, 	   6,   -4, 	  -3,   -9
+.2byte    9,  -20, 	   0,   -7, 	   3,   -3, 	  -2,   -9
+.2byte   14,  -15, 	  -2,   -5, 	   4,   -2, 	  -1,   -9
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -2,  -22, 	   3,   -5, 	  -3,   -5, 	  -1,   -7
+.2byte    0,  -22, 	   2,   -3, 	  -4,   -4, 	  -1,   -7
+.2byte   -1,  -21, 	   3,   -4, 	  -4,   -4, 	  -1,   -9
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte  -13,  -19, 	  -2,   -5, 	  -8,   -4, 	   1,   -9
+.2byte  -11,  -20, 	  -2,   -7, 	  -5,   -3, 	   0,   -9
+.2byte  -16,  -15, 	   0,   -5, 	  -6,   -2, 	  -1,   -9
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte  -19,  -15, 	  -3,   -1, 	  -7,    0, 	  -1,   -7
+.2byte  -19,  -15, 	  -9,   -2, 	  -2,    0, 	  -1,   -7
+.2byte  -24,   -8, 	  -6,   -2, 	  -7,    0, 	  -4,   -7
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte  -12,   -9, 	  -5,   -1, 	  -2,    3, 	  -2,   -5
+.2byte  -14,   -9, 	  -8,    1, 	   0,    1, 	  -3,   -5
+.2byte  -18,    1, 	  -7,   -2, 	  -3,    2, 	  -2,   -6
+.2byte   -1,  -10, 	  -4,    1, 	   2,    1, 	  -1,   -6
+.2byte   -1,  -24, 	  -4,    1, 	   2,    1, 	  -1,   -7
+.2byte   -1,    5, 	  -3,   -1, 	   2,   -1, 	  -1,   -5
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+.2byte    0,  -27, 	   4,   -1, 	   0,    1, 	   0,   -7
+.2byte   17,    1, 	   6,   -2, 	   2,    2, 	   1,   -6
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte    2,  -30, 	   2,   -4, 	   3,    0, 	  -1,   -8
+.2byte   22,   -8, 	   4,   -2, 	   5,    0, 	   2,   -7
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte    1,  -30, 	  -1,   -7, 	   4,   -3, 	  -1,  -12
+.2byte   16,  -17, 	   0,   -7, 	   6,   -4, 	   1,  -11
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -1,  -27, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -1,  -21, 	   3,   -4, 	  -4,   -4, 	  -1,   -9
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte   -3,  -30, 	  -1,   -7, 	  -6,   -3, 	  -1,  -12
+.2byte  -18,  -17, 	  -2,   -7, 	  -8,   -4, 	  -3,  -11
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte   -4,  -30, 	  -4,   -4, 	  -5,    0, 	  -1,   -8
+.2byte  -24,   -8, 	  -6,   -2, 	  -7,    0, 	  -4,   -7
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte   -1,  -27, 	  -5,   -1, 	  -1,    1, 	  -1,   -7
+.2byte  -18,    1, 	  -7,   -2, 	  -3,    2, 	  -2,   -6
+.2byte   -1,  -10, 	  -4,    1, 	   2,    1, 	  -1,   -6
+.2byte   -1,  -12, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,  -13, 	  -4,   -3, 	   2,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	  -4,   -3, 	   2,   -3, 	  -1,   -8
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+.2byte   13,  -13, 	   5,   -5, 	   1,   -3, 	   0,  -10
+.2byte   12,  -14, 	   5,   -6, 	   1,   -4, 	   0,  -10
+.2byte   12,  -14, 	   5,   -6, 	   1,   -4, 	   0,  -10
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte   16,  -18, 	   3,   -7, 	   4,   -3, 	  -1,  -11
+.2byte   15,  -18, 	   3,   -6, 	   4,   -4, 	  -1,  -11
+.2byte   15,  -18, 	   4,   -6, 	   4,   -4, 	  -1,   -8
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte   11,  -23, 	   0,   -9, 	   5,   -6, 	  -1,  -12
+.2byte   10,  -23, 	  -2,   -9, 	   2,   -8, 	  -2,  -12
+.2byte    9,  -22, 	   0,  -11, 	   5,   -7, 	  -2,  -12
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -1,  -27, 	   3,   -5, 	  -4,   -5, 	  -1,  -10
+.2byte   -1,  -26, 	   3,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -25, 	   3,   -7, 	  -4,   -7, 	  -1,  -10
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte  -13,  -23, 	  -2,   -9, 	  -7,   -6, 	  -1,  -12
+.2byte  -12,  -23, 	   0,   -9, 	  -4,   -8, 	   0,  -12
+.2byte  -11,  -22, 	  -2,  -11, 	  -7,   -7, 	   0,  -12
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte  -18,  -18, 	  -5,   -7, 	  -6,   -3, 	  -1,  -11
+.2byte  -17,  -18, 	  -5,   -6, 	  -6,   -4, 	  -1,  -11
+.2byte  -17,  -18, 	  -6,   -6, 	  -6,   -4, 	  -1,   -8
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte  -14,  -13, 	  -6,   -5, 	  -2,   -3, 	  -1,  -10
+.2byte  -13,  -14, 	  -6,   -6, 	  -2,   -4, 	  -1,  -10
+.2byte  -13,  -14, 	  -6,   -6, 	  -2,   -4, 	  -1,  -10
+.2byte  -15,    2, 	  -6,   -1, 	  -1,    1, 	  -2,   -7
+.2byte  -14,    3, 	  -6,    0, 	  -1,    2, 	  -1,   -6
+.2byte    0,  -22, 	  -3,   -7, 	   3,   -7, 	   1,  -14
+.2byte    6,  -20, 	   7,   -8, 	   3,   -5, 	   0,   -9
+.2byte    7,  -24, 	   6,   -6, 	   4,   -3, 	  -4,   -9
+.2byte    2,  -24, 	  -1,  -10, 	   5,   -7, 	  -4,  -10
+.2byte    0,  -21, 	   4,   -3, 	  -2,   -3, 	   0,   -5
+.2byte   -3,  -24, 	   0,  -10, 	  -6,   -7, 	   3,  -10
+.2byte   -8,  -24, 	  -7,   -6, 	  -5,   -3, 	   3,   -9
+.2byte   -7,  -20, 	  -8,   -8, 	  -4,   -5, 	  -1,   -9
+.2byte   -1,  -10, 	  -4,    1, 	   2,    1, 	  -1,   -6
+.2byte   -1,  -12, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,  -13, 	  -4,   -3, 	   2,   -3, 	  -1,   -8
+.2byte   -1,  -13, 	  -4,   -3, 	   2,   -3, 	  -1,   -8
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+.2byte   13,  -13, 	   5,   -5, 	   1,   -3, 	   0,  -10
+.2byte   12,  -14, 	   5,   -6, 	   1,   -4, 	   0,  -10
+.2byte   12,  -14, 	   5,   -6, 	   1,   -4, 	   0,  -10
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte   16,  -18, 	   3,   -7, 	   4,   -3, 	  -1,  -11
+.2byte   15,  -18, 	   3,   -6, 	   4,   -4, 	  -1,  -11
+.2byte   15,  -18, 	   4,   -6, 	   4,   -4, 	  -1,   -8
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte   11,  -23, 	   0,   -9, 	   5,   -6, 	  -1,  -12
+.2byte   10,  -23, 	  -2,   -9, 	   2,   -8, 	  -2,  -12
+.2byte    9,  -22, 	   0,  -11, 	   5,   -7, 	  -2,  -12
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -1,  -27, 	   3,   -5, 	  -4,   -5, 	  -1,  -10
+.2byte   -1,  -26, 	   3,   -6, 	  -4,   -6, 	  -1,  -10
+.2byte   -1,  -25, 	   3,   -7, 	  -4,   -7, 	  -1,  -10
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte  -13,  -23, 	  -2,   -9, 	  -7,   -6, 	  -1,  -12
+.2byte  -12,  -23, 	   0,   -9, 	  -4,   -8, 	   0,  -12
+.2byte  -11,  -22, 	  -2,  -11, 	  -7,   -7, 	   0,  -12
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte  -18,  -18, 	  -5,   -7, 	  -6,   -3, 	  -1,  -11
+.2byte  -17,  -18, 	  -5,   -6, 	  -6,   -4, 	  -1,  -11
+.2byte  -17,  -18, 	  -6,   -6, 	  -6,   -4, 	  -1,   -8
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte  -14,  -13, 	  -6,   -5, 	  -2,   -3, 	  -1,  -10
+.2byte  -13,  -14, 	  -6,   -6, 	  -2,   -4, 	  -1,  -10
+.2byte  -13,  -14, 	  -6,   -6, 	  -2,   -4, 	  -1,  -10
+.2byte   -1,    2, 	  -3,   -4, 	   2,   -4, 	  -1,   -8
+.2byte  -15,    1, 	  -4,   -2, 	   0,    2, 	   1,   -6
+.2byte  -19,   -7, 	  -1,   -1, 	  -2,    1, 	   1,   -6
+.2byte  -15,  -15, 	   1,   -5, 	  -5,   -2, 	   0,   -9
+.2byte   -1,  -17, 	   3,    0, 	  -4,    0, 	  -1,   -5
+.2byte   14,  -15, 	  -2,   -5, 	   4,   -2, 	  -1,   -9
+.2byte   18,   -7, 	   0,   -1, 	   1,    1, 	  -2,   -6
+.2byte   15,    1, 	   4,   -2, 	   0,    2, 	  -1,   -6
+.2byte   -1,  -13, 	  -4,   -3, 	   2,   -3, 	  -1,   -9
+.2byte   13,  -11, 	   5,   -3, 	   1,   -1, 	   0,   -8
+.2byte   16,  -17, 	   3,   -6, 	   4,   -2, 	  -1,  -10
+.2byte   11,  -20, 	   0,   -6, 	   5,   -3, 	  -1,   -9
+.2byte   -1,  -24, 	   3,   -2, 	  -4,   -2, 	  -1,   -7
+.2byte  -13,  -20, 	  -2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte  -18,  -16, 	  -5,   -5, 	  -6,   -1, 	  -1,   -9
+.2byte  -14,  -11, 	  -6,   -3, 	  -2,   -1, 	  -1,   -8
+.2byte   -1,   -9, 	  -4,    2, 	   2,    2, 	  -1,   -5
+.2byte   -1,  -12, 	  -4,   -2, 	   2,   -2, 	  -1,   -8
+.2byte   -1,  -24, 	  -4,    1, 	   2,    1, 	  -1,   -7
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+.2byte   13,  -13, 	   5,   -5, 	   1,   -3, 	   0,  -10
+.2byte    0,  -27, 	   4,   -1, 	   0,    1, 	   0,   -7
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte   16,  -18, 	   3,   -7, 	   4,   -3, 	  -1,  -11
+.2byte    2,  -30, 	   2,   -4, 	   3,    0, 	  -1,   -8
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte   11,  -23, 	   0,   -9, 	   5,   -6, 	  -1,  -12
+.2byte    1,  -30, 	  -1,   -7, 	   4,   -3, 	  -1,  -12
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -1,  -27, 	   3,   -5, 	  -4,   -5, 	  -1,  -10
+.2byte   -1,  -27, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte  -13,  -23, 	  -2,   -9, 	  -7,   -6, 	  -1,  -12
+.2byte   -3,  -30, 	  -1,   -7, 	  -6,   -3, 	  -1,  -12
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte  -18,  -18, 	  -5,   -7, 	  -6,   -3, 	  -1,  -11
+.2byte   -4,  -30, 	  -4,   -4, 	  -5,    0, 	  -1,   -8
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte  -14,  -13, 	  -6,   -5, 	  -2,   -3, 	  -1,  -10
+.2byte   -1,  -27, 	  -5,   -1, 	  -1,    1, 	  -1,   -7
+.2byte   -1,  -24, 	  -4,    1, 	   2,    1, 	  -1,   -7
+.2byte    0,  -27, 	   4,   -1, 	   0,    1, 	   0,   -7
+.2byte    2,  -30, 	   2,   -4, 	   3,    0, 	  -1,   -8
+.2byte    1,  -30, 	  -1,   -7, 	   4,   -3, 	  -1,  -12
+.2byte   -1,  -27, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   -3,  -30, 	  -1,   -7, 	  -6,   -3, 	  -1,  -12
+.2byte   -4,  -30, 	  -4,   -4, 	  -5,    0, 	  -1,   -8
+.2byte   -1,  -27, 	  -5,   -1, 	  -1,    1, 	  -1,   -7
+.2byte   -1,  -10, 	  -4,    1, 	   2,    1, 	  -1,   -6
+.2byte  -13,  -11, 	  -5,   -1, 	  -1,    1, 	  -3,   -6
+.2byte  -18,  -17, 	  -5,   -2, 	  -5,    0, 	  -2,   -8
+.2byte  -12,  -21, 	  -2,   -6, 	  -6,   -3, 	   0,  -10
+.2byte   -1,  -25, 	   3,   -5, 	  -4,   -5, 	  -1,   -9
+.2byte   10,  -21, 	   0,   -6, 	   4,   -3, 	  -2,  -10
+.2byte   16,  -17, 	   3,   -2, 	   3,    0, 	   0,   -8
+.2byte   12,  -11, 	   4,   -1, 	   0,    1, 	   2,   -6
+sTropiusAnimTable1:
+.4byte sTropiusAnims_1_1
+.4byte sTropiusAnims_1_2
+.4byte sTropiusAnims_1_3
+.4byte sTropiusAnims_1_4
+.4byte sTropiusAnims_1_5
+.4byte sTropiusAnims_1_6
+.4byte sTropiusAnims_1_7
+.4byte sTropiusAnims_1_8
+sTropiusAnimTable2:
+.4byte sTropiusAnims_2_1
+.4byte sTropiusAnims_2_2
+.4byte sTropiusAnims_2_3
+.4byte sTropiusAnims_2_4
+.4byte sTropiusAnims_2_5
+.4byte sTropiusAnims_2_6
+.4byte sTropiusAnims_2_7
+.4byte sTropiusAnims_2_8
+sTropiusAnimTable3:
+.4byte sTropiusAnims_3_1
+.4byte sTropiusAnims_3_2
+.4byte sTropiusAnims_3_3
+.4byte sTropiusAnims_3_4
+.4byte sTropiusAnims_3_5
+.4byte sTropiusAnims_3_6
+.4byte sTropiusAnims_3_7
+.4byte sTropiusAnims_3_8
+sTropiusAnimTable4:
+.4byte sTropiusAnims_4_1
+.4byte sTropiusAnims_4_2
+.4byte sTropiusAnims_4_3
+.4byte sTropiusAnims_4_4
+.4byte sTropiusAnims_4_5
+.4byte sTropiusAnims_4_6
+.4byte sTropiusAnims_4_7
+.4byte sTropiusAnims_4_8
+sTropiusAnimTable5:
+.4byte sTropiusAnims_5_1
+.4byte sTropiusAnims_5_2
+.4byte sTropiusAnims_5_3
+.4byte sTropiusAnims_5_4
+.4byte sTropiusAnims_5_5
+.4byte sTropiusAnims_5_6
+.4byte sTropiusAnims_5_7
+.4byte sTropiusAnims_5_8
+sTropiusAnimTable6:
+.4byte sTropiusAnims_6_1
+.4byte sTropiusAnims_6_1
+.4byte sTropiusAnims_6_1
+.4byte sTropiusAnims_6_1
+.4byte sTropiusAnims_6_1
+.4byte sTropiusAnims_6_1
+.4byte sTropiusAnims_6_1
+.4byte sTropiusAnims_6_1
+sTropiusAnimTable7:
+.4byte sTropiusAnims_7_1
+.4byte sTropiusAnims_7_2
+.4byte sTropiusAnims_7_3
+.4byte sTropiusAnims_7_4
+.4byte sTropiusAnims_7_5
+.4byte sTropiusAnims_7_6
+.4byte sTropiusAnims_7_7
+.4byte sTropiusAnims_7_8
+sTropiusAnimTable8:
+.4byte sTropiusAnims_8_1
+.4byte sTropiusAnims_8_2
+.4byte sTropiusAnims_8_3
+.4byte sTropiusAnims_8_4
+.4byte sTropiusAnims_8_5
+.4byte sTropiusAnims_8_6
+.4byte sTropiusAnims_8_7
+.4byte sTropiusAnims_8_8
+sTropiusAnimTable9:
+.4byte sTropiusAnims_9_1
+.4byte sTropiusAnims_9_2
+.4byte sTropiusAnims_9_3
+.4byte sTropiusAnims_9_4
+.4byte sTropiusAnims_9_5
+.4byte sTropiusAnims_9_6
+.4byte sTropiusAnims_9_7
+.4byte sTropiusAnims_9_8
+sTropiusAnimTable10:
+.4byte sTropiusAnims_10_1
+.4byte sTropiusAnims_10_2
+.4byte sTropiusAnims_10_3
+.4byte sTropiusAnims_10_4
+.4byte sTropiusAnims_10_5
+.4byte sTropiusAnims_10_6
+.4byte sTropiusAnims_10_7
+.4byte sTropiusAnims_10_8
+sTropiusAnimTable11:
+.4byte sTropiusAnims_11_1
+.4byte sTropiusAnims_11_2
+.4byte sTropiusAnims_11_3
+.4byte sTropiusAnims_11_4
+.4byte sTropiusAnims_11_5
+.4byte sTropiusAnims_11_6
+.4byte sTropiusAnims_11_7
+.4byte sTropiusAnims_11_8
+sTropiusAnimTable12:
+.4byte sTropiusAnims_12_1
+.4byte sTropiusAnims_12_2
+.4byte sTropiusAnims_12_3
+.4byte sTropiusAnims_12_4
+.4byte sTropiusAnims_12_5
+.4byte sTropiusAnims_12_6
+.4byte sTropiusAnims_12_7
+.4byte sTropiusAnims_12_8
+sTropiusAnimTable13:
+.4byte sTropiusAnims_13_1
+.4byte sTropiusAnims_13_2
+.4byte sTropiusAnims_13_3
+.4byte sTropiusAnims_13_4
+.4byte sTropiusAnims_13_5
+.4byte sTropiusAnims_13_6
+.4byte sTropiusAnims_13_7
+.4byte sTropiusAnims_13_8
+sAxAnimationsTropius:
+.4byte sTropiusAnimTable1
+.4byte sTropiusAnimTable2
+.4byte sTropiusAnimTable3
+.4byte sTropiusAnimTable4
+.4byte sTropiusAnimTable5
+.4byte sTropiusAnimTable6
+.4byte sTropiusAnimTable7
+.4byte sTropiusAnimTable8
+.4byte sTropiusAnimTable9
+.4byte sTropiusAnimTable10
+.4byte sTropiusAnimTable11
+.4byte sTropiusAnimTable12
+.4byte sTropiusAnimTable13
+sAxSpritesTropius:
+.4byte sTropiusSprites1
+.4byte sTropiusSprites2
+.4byte sTropiusSprites3
+.4byte sTropiusSprites4
+.4byte sTropiusSprites5
+.4byte sTropiusSprites6
+.4byte sTropiusSprites7
+.4byte sTropiusSprites8
+.4byte sTropiusSprites9
+.4byte sTropiusSprites10
+.4byte sTropiusSprites11
+.4byte sTropiusSprites12
+.4byte sTropiusSprites13
+.4byte sTropiusSprites14
+.4byte sTropiusSprites15
+.4byte sTropiusSprites16
+.4byte sTropiusSprites17
+.4byte sTropiusSprites18
+.4byte sTropiusSprites19
+.4byte sTropiusSprites20
+.4byte sTropiusSprites21
+.4byte sTropiusSprites22
+.4byte sTropiusSprites23
+.4byte sTropiusSprites24
+.4byte sTropiusSprites25
+.4byte sTropiusSprites26
+.4byte sTropiusSprites27
+.4byte sTropiusSprites28
+.4byte sTropiusSprites29
+.4byte sTropiusSprites30
+.4byte sTropiusSprites31
+.4byte sTropiusSprites32
+.4byte sTropiusSprites33
+.4byte sTropiusSprites34
+.4byte sTropiusSprites35
+.4byte sTropiusSprites36
+.4byte sTropiusSprites37
+.4byte sTropiusSprites38
+.4byte sTropiusSprites39
+.4byte sTropiusSprites40
+.4byte sTropiusSprites41
+.4byte sTropiusSprites42
+.4byte sTropiusSprites43
+.4byte sTropiusSprites44
+.4byte sTropiusSprites45
+.4byte sTropiusSprites46
+.4byte sTropiusSprites47
+.4byte sTropiusSprites48
+.4byte sTropiusSprites49
+.4byte sTropiusSprites50
+.4byte sTropiusSprites51
+.4byte sTropiusSprites52
+.4byte sTropiusSprites53
+.4byte sTropiusSprites54
+.4byte sTropiusSprites55
+.4byte sTropiusSprites56
+.4byte sTropiusSprites57
+.4byte sTropiusSprites58
+.4byte sTropiusSprites59
+.4byte sTropiusSprites60
+.4byte sTropiusSprites61
+.4byte sTropiusSprites62
+.4byte sTropiusSprites63
+.4byte sTropiusSprites64
+.4byte sTropiusSprites65
+.4byte sTropiusSprites66
+.4byte sTropiusSprites67
+.4byte sTropiusSprites68
+.4byte sTropiusSprites69
+.4byte sTropiusSprites70
+.4byte sTropiusSprites71
+.4byte sTropiusSprites72
+.4byte sTropiusSprites73
+.4byte sTropiusSprites74
+.4byte sTropiusSprites75
+.4byte sTropiusSprites76
+.4byte sTropiusSprites77
+.4byte sTropiusSprites78
+.4byte sTropiusSprites79
+.4byte sTropiusSprites80
+.4byte sTropiusSprites81
+.4byte sTropiusSprites82
+.4byte sTropiusSprites83
+.4byte sTropiusSprites84
+.4byte sTropiusSprites85
+.4byte sTropiusSprites86
+.4byte sTropiusSprites87
+.4byte sTropiusSprites88
+.4byte sTropiusSprites89
+.4byte sTropiusSprites90
+.4byte sTropiusSprites91
+.4byte sTropiusSprites92
+.4byte sTropiusSprites93
+.4byte sTropiusSprites94
+.4byte sTropiusSprites95
+.4byte sTropiusSprites96
+.4byte sTropiusSprites97
+.4byte sTropiusSprites98
+.4byte sTropiusSprites99
+.4byte sTropiusSprites100
+.4byte sTropiusSprites101
+.4byte sTropiusSprites102
+.4byte sTropiusSprites103
+.4byte sTropiusSprites104
+.4byte sTropiusSprites105
+.4byte sTropiusSprites106
+.4byte sTropiusSprites107
+.4byte sTropiusSprites108
+.4byte sTropiusSprites109
+.4byte sTropiusSprites110
+.4byte sTropiusSprites111
+.4byte sTropiusSprites112
+.4byte sTropiusSprites113
+.4byte sTropiusSprites114
+.4byte sTropiusSprites115
+.4byte sTropiusSprites116
+.4byte sTropiusSprites117
+.4byte sTropiusSprites118
+.4byte sTropiusSprites119
+.4byte sTropiusSprites120
+.4byte sTropiusSprites121
+.4byte sTropiusSprites122
+.4byte sTropiusSprites123
+.4byte sTropiusSprites124
+.4byte sTropiusSprites125
+.4byte sTropiusSprites126
+.4byte sTropiusSprites127
+.4byte sTropiusSprites128
+.4byte sTropiusSprites129
+.4byte sTropiusSprites130
+.4byte sTropiusSprites131
+.4byte sTropiusSprites132
+.4byte sTropiusSprites133
+.4byte sTropiusSprites134
+.4byte sTropiusSprites135
+.4byte sTropiusSprites136
+.4byte sTropiusSprites137
+.4byte sTropiusSprites138
+.4byte sTropiusSprites139
+.4byte sTropiusSprites140
+.4byte sTropiusSprites141
+.4byte sTropiusSprites142
+.4byte sTropiusSprites143
+.4byte sTropiusSprites144
+.4byte sTropiusSprites145
+.4byte sTropiusSprites146
+.4byte sTropiusSprites147
+.4byte sTropiusSprites148
+.4byte sTropiusSprites149
+.4byte sTropiusSprites150
+.4byte sTropiusSprites151
+.4byte sTropiusSprites152
+sAxMainTropius:
+ax_main sAxPosesTropius, sAxAnimationsTropius, 13, sAxSpritesTropius, sAxPositionsTropius

--- a/data/ax/typhlosion.inc
+++ b/data/ax/typhlosion.inc
@@ -1,0 +1,3373 @@
+.global gAxTyphlosion
+gAxTyphlosion:
+ax_siro sAxMainTyphlosion
+sTyphlosionPose1:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose2:
+ax_pose 1, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose3:
+ax_pose 2, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose4:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose5:
+ax_pose 4, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose6:
+ax_pose 5, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose7:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose8:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose9:
+ax_pose 8, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose10:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose11:
+ax_pose 10, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose12:
+ax_pose 11, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose13:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose14:
+ax_pose 13, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose15:
+ax_pose 14, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose16:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose17:
+ax_pose 10, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose18:
+ax_pose 11, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose19:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose20:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose21:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose22:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose23:
+ax_pose 4, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose24:
+ax_pose 5, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose25:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose26:
+ax_pose 1, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose27:
+ax_pose 2, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose28:
+ax_pose 15, 0x01e3, 0x80f4, 0x2c00
+ax_pose 16, 0x01ec, 0x80f4, 0x2c10
+ax_pose_terminator
+sTyphlosionPose29:
+ax_pose 17, 0x01e3, 0x80f4, 0x2c00
+ax_pose 16, 0x01ec, 0x80f4, 0x2c10
+ax_pose_terminator
+sTyphlosionPose30:
+ax_pose 16, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose31:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose32:
+ax_pose 4, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose33:
+ax_pose 5, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose34:
+ax_pose 18, 0x01e5, 0x90f0, 0x2c00
+ax_pose 19, 0x01ee, 0x90f0, 0x2c10
+ax_pose_terminator
+sTyphlosionPose35:
+ax_pose 20, 0x01e5, 0x90f0, 0x2c00
+ax_pose 19, 0x01ee, 0x90f0, 0x2c10
+ax_pose_terminator
+sTyphlosionPose36:
+ax_pose 19, 0x01ee, 0x90f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose37:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose38:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose39:
+ax_pose 8, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose40:
+ax_pose 21, 0x81e4, 0x90fc, 0x2c00
+ax_pose 22, 0x41f2, 0x90f2, 0x2c08
+ax_pose_terminator
+sTyphlosionPose41:
+ax_pose 23, 0x81e5, 0x90fc, 0x2c00
+ax_pose 22, 0x41f2, 0x90f2, 0x2c08
+ax_pose_terminator
+sTyphlosionPose42:
+ax_pose 22, 0x41f2, 0x90f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose43:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose44:
+ax_pose 10, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose45:
+ax_pose 11, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose46:
+ax_pose 24, 0x01e6, 0x90ee, 0x2c00
+ax_pose 25, 0x01f0, 0x90ee, 0x2c10
+ax_pose_terminator
+sTyphlosionPose47:
+ax_pose 26, 0x01e7, 0x90ee, 0x2c00
+ax_pose 25, 0x01f0, 0x90ee, 0x2c10
+ax_pose_terminator
+sTyphlosionPose48:
+ax_pose 25, 0x01f0, 0x90ee, 0x2c00
+ax_pose_terminator
+sTyphlosionPose49:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose50:
+ax_pose 13, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose51:
+ax_pose 14, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose52:
+ax_pose 27, 0x01e2, 0x80f2, 0x2c00
+ax_pose 28, 0x01eb, 0x80f2, 0x2c10
+ax_pose_terminator
+sTyphlosionPose53:
+ax_pose 29, 0x01e2, 0x80f2, 0x2c00
+ax_pose 28, 0x01eb, 0x80f2, 0x2c10
+ax_pose_terminator
+sTyphlosionPose54:
+ax_pose 28, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose55:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose56:
+ax_pose 10, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose57:
+ax_pose 11, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose58:
+ax_pose 24, 0x01e6, 0x80f2, 0x2c00
+ax_pose 25, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sTyphlosionPose59:
+ax_pose 26, 0x01e7, 0x80f2, 0x2c00
+ax_pose 25, 0x01f0, 0x80f2, 0x2c10
+ax_pose_terminator
+sTyphlosionPose60:
+ax_pose 25, 0x01f0, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose61:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose62:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose63:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose64:
+ax_pose 21, 0x81e4, 0x80f4, 0x2c00
+ax_pose 22, 0x41f2, 0x80ee, 0x2c08
+ax_pose_terminator
+sTyphlosionPose65:
+ax_pose 23, 0x81e5, 0x80f4, 0x2c00
+ax_pose 22, 0x41f2, 0x80ee, 0x2c08
+ax_pose_terminator
+sTyphlosionPose66:
+ax_pose 22, 0x41f2, 0x80ee, 0x2c00
+ax_pose_terminator
+sTyphlosionPose67:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose68:
+ax_pose 4, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose69:
+ax_pose 5, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose70:
+ax_pose 18, 0x01e5, 0x80f0, 0x2c00
+ax_pose 19, 0x01ee, 0x80f0, 0x2c10
+ax_pose_terminator
+sTyphlosionPose71:
+ax_pose 20, 0x01e5, 0x80f0, 0x2c00
+ax_pose 19, 0x01ee, 0x80f0, 0x2c10
+ax_pose_terminator
+sTyphlosionPose72:
+ax_pose 19, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose73:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose74:
+ax_pose 1, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose75:
+ax_pose 2, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose76:
+ax_pose 30, 0x81e4, 0x4104, 0x2c00
+ax_pose 31, 0x81e4, 0x80f4, 0x2c04
+ax_pose_terminator
+sTyphlosionPose77:
+ax_pose 32, 0x81e4, 0x80fd, 0x2c00
+ax_pose 33, 0x81e4, 0x4104, 0x2c08
+ax_pose 34, 0x81e4, 0x80f4, 0x2c0c
+ax_pose_terminator
+sTyphlosionPose78:
+ax_pose 33, 0x81e4, 0x4104, 0x2c00
+ax_pose 34, 0x81e4, 0x80f4, 0x2c04
+ax_pose_terminator
+sTyphlosionPose79:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose80:
+ax_pose 4, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose81:
+ax_pose 5, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose82:
+ax_pose 35, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyphlosionPose83:
+ax_pose 36, 0x01e5, 0x90ec, 0x2c00
+ax_pose 37, 0x01e5, 0x90ec, 0x2c10
+ax_pose_terminator
+sTyphlosionPose84:
+ax_pose 37, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyphlosionPose85:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose86:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose87:
+ax_pose 8, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose88:
+ax_pose 38, 0x01e6, 0x90f1, 0x2c00
+ax_pose_terminator
+sTyphlosionPose89:
+ax_pose 39, 0x41ee, 0x90f0, 0x2c00
+ax_pose 40, 0x01e6, 0x90ef, 0x2c08
+ax_pose_terminator
+sTyphlosionPose90:
+ax_pose 40, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sTyphlosionPose91:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose92:
+ax_pose 10, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose93:
+ax_pose 11, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose94:
+ax_pose 41, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose95:
+ax_pose 42, 0x01e7, 0x90f2, 0x2c00
+ax_pose 43, 0x01e7, 0x90eb, 0x2c10
+ax_pose_terminator
+sTyphlosionPose96:
+ax_pose 43, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose97:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose98:
+ax_pose 13, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose99:
+ax_pose 14, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose100:
+ax_pose 44, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose101:
+ax_pose 45, 0x81e6, 0x80f0, 0x2c00
+ax_pose 46, 0x01e7, 0x80f2, 0x2c08
+ax_pose_terminator
+sTyphlosionPose102:
+ax_pose 46, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose103:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose104:
+ax_pose 10, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose105:
+ax_pose 11, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose106:
+ax_pose 41, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose107:
+ax_pose 42, 0x01e7, 0x80ee, 0x2c00
+ax_pose 43, 0x01e7, 0x80f5, 0x2c10
+ax_pose_terminator
+sTyphlosionPose108:
+ax_pose 43, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose109:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose110:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose111:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose112:
+ax_pose 38, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sTyphlosionPose113:
+ax_pose 39, 0x41ee, 0x80f0, 0x2c00
+ax_pose 40, 0x01e6, 0x80f1, 0x2c08
+ax_pose_terminator
+sTyphlosionPose114:
+ax_pose 40, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sTyphlosionPose115:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose116:
+ax_pose 4, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose117:
+ax_pose 5, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose118:
+ax_pose 35, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose119:
+ax_pose 36, 0x01e5, 0x80f4, 0x2c00
+ax_pose 37, 0x01e5, 0x80f4, 0x2c10
+ax_pose_terminator
+sTyphlosionPose120:
+ax_pose 37, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose121:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose122:
+ax_pose 1, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose123:
+ax_pose 2, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose124:
+ax_pose 47, 0x01d3, 0x80f4, 0x2c00
+ax_pose 48, 0x01e3, 0x80f4, 0x2c10
+ax_pose_terminator
+sTyphlosionPose125:
+ax_pose 49, 0x01d3, 0x80f4, 0x2c00
+ax_pose 48, 0x01e3, 0x80f4, 0x2c10
+ax_pose_terminator
+sTyphlosionPose126:
+ax_pose 48, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose127:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose128:
+ax_pose 4, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose129:
+ax_pose 5, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose130:
+ax_pose 50, 0x01d6, 0x90ea, 0x2c00
+ax_pose 51, 0x01e5, 0x90ea, 0x2c10
+ax_pose_terminator
+sTyphlosionPose131:
+ax_pose 52, 0x01d6, 0x90ea, 0x2c00
+ax_pose 51, 0x01e5, 0x90ea, 0x2c10
+ax_pose_terminator
+sTyphlosionPose132:
+ax_pose 51, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose133:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose134:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose135:
+ax_pose 8, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose136:
+ax_pose 53, 0x81d8, 0x90f5, 0x2c00
+ax_pose 54, 0x01e6, 0x90ed, 0x2c08
+ax_pose_terminator
+sTyphlosionPose137:
+ax_pose 55, 0x81d8, 0x90f5, 0x2c00
+ax_pose 54, 0x01e6, 0x90ed, 0x2c08
+ax_pose_terminator
+sTyphlosionPose138:
+ax_pose 54, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose139:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose140:
+ax_pose 10, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose141:
+ax_pose 11, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose142:
+ax_pose 56, 0x01d6, 0x90ed, 0x2c00
+ax_pose 57, 0x81e7, 0x90fb, 0x2c10
+ax_pose 58, 0x81e7, 0x50f3, 0x2c18
+ax_pose_terminator
+sTyphlosionPose143:
+ax_pose 59, 0x01d6, 0x90ed, 0x2c00
+ax_pose 57, 0x81e7, 0x90fb, 0x2c10
+ax_pose 58, 0x81e7, 0x50f3, 0x2c18
+ax_pose_terminator
+sTyphlosionPose144:
+ax_pose 57, 0x81e7, 0x90fb, 0x2c00
+ax_pose 58, 0x81e7, 0x50f3, 0x2c08
+ax_pose_terminator
+sTyphlosionPose145:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose146:
+ax_pose 13, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose147:
+ax_pose 14, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose148:
+ax_pose 60, 0x01d7, 0x80f2, 0x2c00
+ax_pose 61, 0x01e7, 0x80f2, 0x2c10
+ax_pose_terminator
+sTyphlosionPose149:
+ax_pose 62, 0x01d7, 0x80f2, 0x2c00
+ax_pose 61, 0x01e7, 0x80f2, 0x2c10
+ax_pose_terminator
+sTyphlosionPose150:
+ax_pose 61, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose151:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose152:
+ax_pose 10, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose153:
+ax_pose 11, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose154:
+ax_pose 56, 0x01d6, 0x80f3, 0x2c00
+ax_pose 57, 0x81e7, 0x80f5, 0x2c10
+ax_pose 58, 0x81e7, 0x4105, 0x2c18
+ax_pose_terminator
+sTyphlosionPose155:
+ax_pose 59, 0x01d6, 0x80f3, 0x2c00
+ax_pose 57, 0x81e7, 0x80f5, 0x2c10
+ax_pose 58, 0x81e7, 0x4105, 0x2c18
+ax_pose_terminator
+sTyphlosionPose156:
+ax_pose 57, 0x81e7, 0x80f5, 0x2c00
+ax_pose 58, 0x81e7, 0x4105, 0x2c08
+ax_pose_terminator
+sTyphlosionPose157:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose158:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose159:
+ax_pose 8, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose160:
+ax_pose 53, 0x81d8, 0x80fb, 0x2c00
+ax_pose 54, 0x01e6, 0x80f3, 0x2c08
+ax_pose_terminator
+sTyphlosionPose161:
+ax_pose 55, 0x81d8, 0x80fb, 0x2c00
+ax_pose 54, 0x01e6, 0x80f3, 0x2c08
+ax_pose_terminator
+sTyphlosionPose162:
+ax_pose 54, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose163:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose164:
+ax_pose 4, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose165:
+ax_pose 5, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose166:
+ax_pose 50, 0x01d6, 0x80f6, 0x2c00
+ax_pose 51, 0x01e5, 0x80f6, 0x2c10
+ax_pose_terminator
+sTyphlosionPose167:
+ax_pose 52, 0x01d6, 0x80f6, 0x2c00
+ax_pose 51, 0x01e5, 0x80f6, 0x2c10
+ax_pose_terminator
+sTyphlosionPose168:
+ax_pose 51, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose169:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose170:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose171:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose172:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose173:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose174:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose175:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose176:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose177:
+ax_pose 63, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose178:
+ax_pose 64, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose179:
+ax_pose 65, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose180:
+ax_pose 66, 0x01e2, 0x90ef, 0x2c00
+ax_pose_terminator
+sTyphlosionPose181:
+ax_pose 67, 0x01e2, 0x90f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose182:
+ax_pose 68, 0x01e3, 0x90ee, 0x2c00
+ax_pose_terminator
+sTyphlosionPose183:
+ax_pose 69, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose184:
+ax_pose 68, 0x01e3, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose185:
+ax_pose 67, 0x01e2, 0x80f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose186:
+ax_pose 66, 0x01e2, 0x80f1, 0x2c00
+ax_pose_terminator
+sTyphlosionPose187:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose188:
+ax_pose 30, 0x81e4, 0x4105, 0x2c00
+ax_pose 31, 0x81e4, 0x80f5, 0x2c04
+ax_pose_terminator
+sTyphlosionPose189:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose190:
+ax_pose 35, 0x01e5, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose191:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose192:
+ax_pose 38, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sTyphlosionPose193:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose194:
+ax_pose 41, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose195:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose196:
+ax_pose 44, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose197:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose198:
+ax_pose 41, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose199:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose200:
+ax_pose 38, 0x01e4, 0x80f1, 0x2c00
+ax_pose_terminator
+sTyphlosionPose201:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose202:
+ax_pose 35, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose203:
+ax_pose 16, 0x01ef, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose204:
+ax_pose 19, 0x01ee, 0x80f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose205:
+ax_pose 22, 0x41f3, 0x80ef, 0x2c00
+ax_pose_terminator
+sTyphlosionPose206:
+ax_pose 25, 0x01f1, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose207:
+ax_pose 28, 0x01ee, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose208:
+ax_pose 25, 0x01f1, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose209:
+ax_pose 22, 0x41f3, 0x90f1, 0x2c00
+ax_pose_terminator
+sTyphlosionPose210:
+ax_pose 19, 0x01ee, 0x90f0, 0x2c00
+ax_pose_terminator
+sTyphlosionPose211:
+ax_pose 48, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose212:
+ax_pose 51, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose213:
+ax_pose 54, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose214:
+ax_pose 57, 0x81e7, 0x90fb, 0x2c00
+ax_pose 58, 0x81e7, 0x50f3, 0x2c08
+ax_pose_terminator
+sTyphlosionPose215:
+ax_pose 61, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose216:
+ax_pose 57, 0x81e7, 0x80f5, 0x2c00
+ax_pose 58, 0x81e7, 0x4105, 0x2c08
+ax_pose_terminator
+sTyphlosionPose217:
+ax_pose 54, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose218:
+ax_pose 51, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose219:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose220:
+ax_pose 31, 0x81e4, 0x80f4, 0x2c00
+ax_pose 30, 0x81e4, 0x4104, 0x2c08
+ax_pose_terminator
+sTyphlosionPose221:
+ax_pose 48, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose222:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyphlosionPose223:
+ax_pose 35, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyphlosionPose224:
+ax_pose 51, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sTyphlosionPose225:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose226:
+ax_pose 38, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sTyphlosionPose227:
+ax_pose 54, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyphlosionPose228:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose229:
+ax_pose 41, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose230:
+ax_pose 57, 0x81e7, 0x90fa, 0x2c00
+ax_pose 58, 0x81e7, 0x50f2, 0x2c08
+ax_pose_terminator
+sTyphlosionPose231:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose232:
+ax_pose 44, 0x01e7, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose233:
+ax_pose 61, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose234:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose235:
+ax_pose 41, 0x01e7, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose236:
+ax_pose 57, 0x81e7, 0x80f6, 0x2c00
+ax_pose 58, 0x81e7, 0x4106, 0x2c08
+ax_pose_terminator
+sTyphlosionPose237:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose238:
+ax_pose 38, 0x01e6, 0x80f1, 0x2c00
+ax_pose_terminator
+sTyphlosionPose239:
+ax_pose 54, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose240:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose241:
+ax_pose 35, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose242:
+ax_pose 51, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyphlosionPose243:
+ax_pose 48, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose244:
+ax_pose 51, 0x01e5, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose245:
+ax_pose 54, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose246:
+ax_pose 57, 0x81e7, 0x80f4, 0x2c00
+ax_pose 58, 0x81e7, 0x4104, 0x2c08
+ax_pose_terminator
+sTyphlosionPose247:
+ax_pose 61, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose248:
+ax_pose 57, 0x81e7, 0x90fc, 0x2c00
+ax_pose 58, 0x81e7, 0x50f4, 0x2c08
+ax_pose_terminator
+sTyphlosionPose249:
+ax_pose 54, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sTyphlosionPose250:
+ax_pose 51, 0x01e5, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose251:
+ax_pose 0, 0x01e4, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyphlosionPose252:
+ax_pose 3, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyphlosionPose253:
+ax_pose 6, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyphlosionPose254:
+ax_pose 9, 0x01e7, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyphlosionPose255:
+ax_pose 12, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sTyphlosionPose256:
+ax_pose 9, 0x01e7, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyphlosionPose257:
+ax_pose 6, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyphlosionPose258:
+ax_pose 3, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+.align 2
+sTyphlosionAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 12, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 12, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 12, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 12, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 12, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 12, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 12, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 12, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_2_1:
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 26, 0, -5, 0, -5,
+ax_anim 6, 0, 24, 0, -6, 0, -6,
+ax_anim 1, 0, 27, 0, -6, 0, -6,
+ax_anim 1, 0, 29, 0, -2, 0, -2,
+ax_anim 1, 2, 28, 0, 4, 0, 4,
+ax_anim 1, 0, 29, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 1, 28, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 28, 1, 17, 1, 17,
+ax_anim 2, 0, 27, 0, 17, 0, 17,
+ax_anim 2, 0, 29, 0, 9, 0, 9,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sTyphlosionAnims_2_2:
+ax_anim 2, 0, 31, -3, -3, -3, -3,
+ax_anim 2, 0, 32, -5, -5, -5, -5,
+ax_anim 6, 0, 30, -6, -6, -6, -6,
+ax_anim 1, 0, 33, -4, -8, -4, -4,
+ax_anim 1, 0, 35, -1, -7, -1, -1,
+ax_anim 1, 2, 34, 5, -1, 5, 6,
+ax_anim 1, 0, 35, 12, 9, 12, 14,
+ax_anim 2, 0, 33, 15, 18, 15, 18,
+ax_anim 2, 1, 34, 16, 17, 16, 17,
+ax_anim 2, 0, 33, 15, 18, 15, 18,
+ax_anim 2, 0, 34, 16, 17, 16, 17,
+ax_anim 2, 0, 33, 15, 18, 15, 18,
+ax_anim 2, 0, 35, 8, 7, 8, 10,
+ax_anim 2, 0, 30, 3, 5, 3, 5,
+ax_anim_terminator
+sTyphlosionAnims_2_3:
+ax_anim 2, 0, 37, -3, 0, -3, 0,
+ax_anim 2, 0, 38, -5, 0, -5, 0,
+ax_anim 6, 0, 36, -6, 0, -6, 0,
+ax_anim 1, 0, 39, -4, -3, -4, 0,
+ax_anim 1, 0, 41, -1, -5, -1, 0,
+ax_anim 1, 2, 40, 5, -5, 5, 0,
+ax_anim 1, 0, 41, 12, -3, 12, 0,
+ax_anim 2, 0, 39, 14, 0, 14, 0,
+ax_anim 2, 1, 40, 14, 1, 14, 1,
+ax_anim 2, 0, 39, 14, 0, 14, 0,
+ax_anim 2, 0, 40, 14, 1, 14, 1,
+ax_anim 2, 0, 39, 14, 0, 14, 0,
+ax_anim 2, 0, 41, 10, -2, 10, 0,
+ax_anim 2, 0, 36, 3, 0, 3, 0,
+ax_anim_terminator
+sTyphlosionAnims_2_4:
+ax_anim 2, 0, 43, -3, 3, -3, 3,
+ax_anim 2, 0, 44, -5, 5, -5, 5,
+ax_anim 6, 0, 42, -6, 6, -6, 6,
+ax_anim 1, 0, 45, -2, -4, -2, 2,
+ax_anim 1, 0, 47, 3, -11, 3, -4,
+ax_anim 1, 2, 46, 4, -15, 4, -6,
+ax_anim 1, 0, 47, 10, -20, 10, -14,
+ax_anim 2, 0, 45, 16, -21, 16, -21,
+ax_anim 2, 1, 46, 17, -20, 17, -20,
+ax_anim 2, 0, 45, 16, -21, 16, -21,
+ax_anim 2, 0, 46, 17, -20, 17, -20,
+ax_anim 2, 0, 45, 16, -21, 16, -21,
+ax_anim 2, 0, 47, 8, -15, 8, -11,
+ax_anim 2, 0, 42, 3, -3, 3, -3,
+ax_anim_terminator
+sTyphlosionAnims_2_5:
+ax_anim 2, 0, 49, 0, 3, 0, 3,
+ax_anim 2, 0, 50, 0, 5, 0, 5,
+ax_anim 6, 0, 48, 0, 6, 0, 6,
+ax_anim 1, 0, 51, 0, 0, 0, 2,
+ax_anim 1, 0, 53, 0, -3, 0, -1,
+ax_anim 1, 2, 52, 0, -9, 0, -7,
+ax_anim 1, 0, 53, 0, -13, 0, -11,
+ax_anim 2, 0, 51, 0, -17, 0, -17,
+ax_anim 2, 1, 52, 1, -17, 1, -17,
+ax_anim 2, 0, 51, 0, -17, 0, -17,
+ax_anim 2, 0, 52, 1, -17, 1, -17,
+ax_anim 2, 0, 51, 0, -17, 0, -17,
+ax_anim 2, 0, 53, 0, -9, 0, -7,
+ax_anim 2, 0, 48, 0, -4, 0, -4,
+ax_anim_terminator
+sTyphlosionAnims_2_6:
+ax_anim 2, 0, 55, 3, 3, 3, 3,
+ax_anim 2, 0, 56, 5, 5, 5, 5,
+ax_anim 6, 0, 54, 6, 6, 6, 6,
+ax_anim 1, 0, 57, 2, -4, 2, 2,
+ax_anim 1, 0, 59, -3, -11, -3, -4,
+ax_anim 1, 2, 58, -4, -15, -4, -6,
+ax_anim 1, 0, 59, -10, -20, -10, -14,
+ax_anim 2, 0, 57, -16, -21, -16, -21,
+ax_anim 2, 1, 58, -17, -20, -17, -20,
+ax_anim 2, 0, 57, -16, -21, -16, -21,
+ax_anim 2, 0, 58, -17, -20, -17, -20,
+ax_anim 2, 0, 57, -16, -21, -16, -21,
+ax_anim 2, 0, 59, -8, -15, -8, -11,
+ax_anim 2, 0, 54, -3, -3, -3, -3,
+ax_anim_terminator
+sTyphlosionAnims_2_7:
+ax_anim 2, 0, 61, 3, 0, 3, 0,
+ax_anim 2, 0, 62, 5, 0, 5, 0,
+ax_anim 6, 0, 60, 6, 0, 6, 0,
+ax_anim 1, 0, 63, 4, -3, 4, 0,
+ax_anim 1, 0, 65, 1, -5, 1, 0,
+ax_anim 1, 2, 64, -5, -5, -5, 0,
+ax_anim 1, 0, 65, -12, -3, -12, 0,
+ax_anim 2, 0, 63, -14, 0, -14, 0,
+ax_anim 2, 1, 64, -14, 1, -14, 1,
+ax_anim 2, 0, 63, -14, 0, -14, 0,
+ax_anim 2, 0, 64, -14, 1, -14, 1,
+ax_anim 2, 0, 63, -14, 0, -14, 0,
+ax_anim 2, 0, 65, -10, -2, -10, 0,
+ax_anim 2, 0, 60, -3, 0, -3, 0,
+ax_anim_terminator
+sTyphlosionAnims_2_8:
+ax_anim 2, 0, 67, 3, -3, 3, -3,
+ax_anim 2, 0, 68, 5, -5, 5, -5,
+ax_anim 6, 0, 66, 6, -6, 6, -6,
+ax_anim 1, 0, 69, 4, -8, 4, -4,
+ax_anim 1, 0, 71, 1, -7, 1, -1,
+ax_anim 1, 2, 70, -5, -1, -5, 6,
+ax_anim 1, 0, 71, -12, 9, -12, 14,
+ax_anim 2, 0, 69, -15, 18, -15, 18,
+ax_anim 2, 1, 70, -16, 17, -16, 17,
+ax_anim 2, 0, 69, -15, 18, -15, 18,
+ax_anim 2, 0, 70, -16, 17, -16, 17,
+ax_anim 2, 0, 69, -15, 18, -15, 18,
+ax_anim 2, 0, 71, -8, 7, -8, 10,
+ax_anim 2, 0, 66, -3, 5, -3, 5,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_3_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 0, 75, 0, -3, 0, -3,
+ax_anim 6, 0, 75, 0, -4, 0, -4,
+ax_anim 1, 2, 75, 0, 4, 0, 4,
+ax_anim 1, 0, 75, 0, 12, 0, 12,
+ax_anim 2, 0, 76, 0, 20, 0, 20,
+ax_anim 2, 1, 118, -2, 22, -2, 22,
+ax_anim 2, 0, 119, -1, 22, -1, 22,
+ax_anim 2, 0, 119, -2, 22, -2, 22,
+ax_anim 2, 0, 119, -1, 22, -1, 22,
+ax_anim 2, 0, 77, -2, 22, -2, 22,
+ax_anim 2, 0, 74, 0, 13, 0, 13,
+ax_anim 2, 0, 72, 0, 6, 0, 6,
+ax_anim_terminator
+sTyphlosionAnims_3_2:
+ax_anim 2, 0, 80, -2, -2, -2, -2,
+ax_anim 2, 0, 81, -3, -3, -3, -3,
+ax_anim 6, 0, 81, -4, -4, -4, -4,
+ax_anim 1, 2, 81, 4, 4, 4, 4,
+ax_anim 1, 0, 81, 12, 12, 12, 12,
+ax_anim 2, 0, 82, 22, 20, 22, 20,
+ax_anim 2, 1, 89, 22, 20, 22, 20,
+ax_anim 2, 0, 89, 23, 19, 23, 19,
+ax_anim 2, 0, 89, 22, 20, 22, 20,
+ax_anim 2, 0, 89, 23, 19, 23, 19,
+ax_anim 2, 0, 83, 21, 20, 21, 20,
+ax_anim 2, 0, 80, 14, 13, 14, 13,
+ax_anim 2, 0, 78, 6, 6, 6, 6,
+ax_anim_terminator
+sTyphlosionAnims_3_3:
+ax_anim 2, 0, 86, -2, 0, -2, 0,
+ax_anim 2, 0, 87, -3, 0, -3, 0,
+ax_anim 6, 0, 87, -4, 0, -4, 0,
+ax_anim 1, 2, 87, 2, 0, 2, 0,
+ax_anim 1, 0, 87, 10, 0, 10, 0,
+ax_anim 2, 0, 88, 15, 0, 15, 0,
+ax_anim 2, 1, 95, 16, 0, 16, 0,
+ax_anim 2, 0, 95, 17, -1, 17, -1,
+ax_anim 2, 0, 95, 16, 0, 16, 0,
+ax_anim 2, 0, 95, 17, -1, 17, -1,
+ax_anim 2, 0, 89, 16, 0, 16, 0,
+ax_anim 2, 0, 86, 10, 0, 10, 0,
+ax_anim 2, 0, 84, 4, 0, 4, 0,
+ax_anim_terminator
+sTyphlosionAnims_3_4:
+ax_anim 2, 0, 92, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -3, 3, -3, 3,
+ax_anim 6, 0, 93, -4, 4, -4, 4,
+ax_anim 1, 2, 93, 4, -4, 4, -4,
+ax_anim 1, 0, 94, 10, -10, 10, -10,
+ax_anim 2, 0, 94, 14, -15, 14, -15,
+ax_anim 2, 1, 95, 13, -15, 13, -15,
+ax_anim 2, 0, 95, 14, -15, 14, -15,
+ax_anim 2, 0, 95, 13, -15, 13, -15,
+ax_anim 2, 0, 95, 14, -15, 14, -15,
+ax_anim 2, 0, 95, 13, -15, 13, -15,
+ax_anim 2, 0, 91, 8, -9, 8, -9,
+ax_anim 2, 0, 90, 4, -4, 4, -4,
+ax_anim_terminator
+sTyphlosionAnims_3_5:
+ax_anim 2, 0, 97, 0, 2, 0, 2,
+ax_anim 2, 0, 99, 0, 3, 0, 3,
+ax_anim 6, 0, 99, 0, 4, 0, 4,
+ax_anim 1, 2, 99, 0, -4, 0, -4,
+ax_anim 1, 0, 99, 0, -9, 0, -9,
+ax_anim 2, 0, 100, 0, -14, 0, -14,
+ax_anim 2, 1, 101, 1, -14, 1, -14,
+ax_anim 2, 0, 101, 0, -14, 0, -14,
+ax_anim 2, 0, 101, 1, -14, 1, -14,
+ax_anim 2, 0, 101, 0, -14, 0, -14,
+ax_anim 2, 0, 101, 1, -14, 1, -14,
+ax_anim 2, 0, 98, 0, -10, 0, -10,
+ax_anim 2, 0, 96, 0, -4, 0, -4,
+ax_anim_terminator
+sTyphlosionAnims_3_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 2, 0, 105, 3, 3, 3, 3,
+ax_anim 6, 0, 105, 4, 4, 4, 4,
+ax_anim 1, 2, 105, -4, -4, -4, -4,
+ax_anim 1, 0, 105, -10, -10, -10, -10,
+ax_anim 2, 0, 106, -14, -15, -14, -15,
+ax_anim 2, 1, 101, -13, -17, -13, -17,
+ax_anim 2, 0, 101, -14, -18, -14, -18,
+ax_anim 2, 0, 101, -13, -17, -13, -17,
+ax_anim 2, 0, 101, -14, -18, -14, -18,
+ax_anim 2, 0, 107, -13, -15, -13, -15,
+ax_anim 2, 0, 103, -8, -9, -8, -9,
+ax_anim 2, 0, 102, -4, -4, -4, -4,
+ax_anim_terminator
+sTyphlosionAnims_3_7:
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim 2, 0, 111, 3, 0, 3, 0,
+ax_anim 6, 0, 111, 4, 0, 4, 0,
+ax_anim 1, 2, 111, -2, 0, -2, 0,
+ax_anim 1, 0, 111, -10, 0, -10, 0,
+ax_anim 2, 0, 112, -15, 0, -15, 0,
+ax_anim 2, 1, 107, -15, -1, -15, -1,
+ax_anim 2, 0, 107, -15, -2, -15, -2,
+ax_anim 2, 0, 107, -15, -1, -15, -1,
+ax_anim 2, 0, 107, -15, -2, -15, -2,
+ax_anim 2, 0, 113, -15, 1, -15, 1,
+ax_anim 2, 0, 110, -10, 0, -10, 0,
+ax_anim 2, 0, 108, -4, 0, -4, 0,
+ax_anim_terminator
+sTyphlosionAnims_3_8:
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim 2, 0, 117, 3, -3, 3, -3,
+ax_anim 6, 0, 117, 4, -4, 4, -4,
+ax_anim 1, 2, 117, -4, 4, -4, 4,
+ax_anim 1, 0, 117, -12, 12, -12, 12,
+ax_anim 2, 0, 118, -19, 20, -19, 20,
+ax_anim 2, 1, 113, -20, 20, -20, 20,
+ax_anim 2, 0, 113, -21, 19, -21, 19,
+ax_anim 2, 0, 113, -20, 20, -20, 20,
+ax_anim 2, 0, 113, -21, 19, -21, 19,
+ax_anim 2, 0, 119, -18, 20, -18, 20,
+ax_anim 2, 0, 116, -12, 13, -12, 13,
+ax_anim 2, 0, 114, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_4_1:
+ax_anim 3, 0, 122, 0, -2, 0, -2,
+ax_anim 6, 2, 122, 0, -3, 0, -3,
+ax_anim 2, 0, 123, 0, 3, 0, 3,
+ax_anim 2, 1, 124, 1, 3, 1, 3,
+ax_anim 2, 0, 123, 0, 3, 0, 3,
+ax_anim 2, 0, 124, 1, 3, 1, 3,
+ax_anim 2, 0, 123, 0, 3, 0, 3,
+ax_anim 2, 0, 124, 1, 3, 1, 3,
+ax_anim 2, 0, 125, 0, 3, 0, 3,
+ax_anim 2, 0, 120, 0, 1, 0, 1,
+ax_anim_terminator
+sTyphlosionAnims_4_2:
+ax_anim 3, 0, 128, -2, -2, -2, -2,
+ax_anim 6, 2, 128, -3, -3, -3, -3,
+ax_anim 2, 0, 129, 3, 3, 3, 3,
+ax_anim 2, 1, 130, 2, 4, 2, 4,
+ax_anim 2, 0, 129, 3, 3, 3, 3,
+ax_anim 2, 0, 130, 2, 4, 2, 4,
+ax_anim 2, 0, 129, 3, 3, 3, 3,
+ax_anim 2, 0, 130, 2, 4, 2, 4,
+ax_anim 2, 0, 131, 3, 3, 3, 3,
+ax_anim 2, 0, 126, 1, 1, 1, 1,
+ax_anim_terminator
+sTyphlosionAnims_4_3:
+ax_anim 3, 0, 134, -2, 0, -2, 0,
+ax_anim 6, 2, 134, -3, 0, -3, 0,
+ax_anim 2, 0, 135, 3, 0, 3, 0,
+ax_anim 2, 1, 136, 3, -1, 3, -1,
+ax_anim 2, 0, 135, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 3, -1, 3, -1,
+ax_anim 2, 0, 135, 3, 0, 3, 0,
+ax_anim 2, 0, 136, 3, -1, 3, -1,
+ax_anim 2, 0, 137, 3, 0, 3, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim_terminator
+sTyphlosionAnims_4_4:
+ax_anim 3, 0, 140, -2, 2, -2, 2,
+ax_anim 6, 2, 140, -3, 3, -3, 3,
+ax_anim 2, 0, 141, 3, -3, 3, -3,
+ax_anim 2, 1, 142, 2, -4, 2, -4,
+ax_anim 2, 0, 141, 3, -3, 3, -3,
+ax_anim 2, 0, 142, 2, -4, 2, -4,
+ax_anim 2, 0, 141, 3, -3, 3, -3,
+ax_anim 2, 0, 142, 2, -4, 2, -4,
+ax_anim 2, 0, 143, 3, -3, 3, -3,
+ax_anim 2, 0, 138, 1, -1, 1, -1,
+ax_anim_terminator
+sTyphlosionAnims_4_5:
+ax_anim 3, 0, 146, 0, 2, 0, 2,
+ax_anim 6, 2, 146, 0, 3, 0, 3,
+ax_anim 2, 0, 147, 0, -3, 0, -3,
+ax_anim 2, 1, 148, 1, -3, 1, -3,
+ax_anim 2, 0, 147, 0, -3, 0, -3,
+ax_anim 2, 0, 148, 1, -3, 1, -3,
+ax_anim 2, 0, 147, 0, -3, 0, -3,
+ax_anim 2, 0, 148, 1, -3, 1, -3,
+ax_anim 2, 0, 149, 0, -3, 0, -3,
+ax_anim 2, 0, 144, 0, -1, 0, -1,
+ax_anim_terminator
+sTyphlosionAnims_4_6:
+ax_anim 3, 0, 152, 2, 2, 2, 2,
+ax_anim 6, 2, 152, 3, 3, 3, 3,
+ax_anim 2, 0, 153, -3, -3, -3, -3,
+ax_anim 2, 1, 154, -2, -4, -2, -4,
+ax_anim 2, 0, 153, -3, -3, -3, -3,
+ax_anim 2, 0, 154, -2, -4, -2, -4,
+ax_anim 2, 0, 153, -3, -3, -3, -3,
+ax_anim 2, 0, 154, -2, -4, -2, -4,
+ax_anim 2, 0, 155, -3, -3, -3, -3,
+ax_anim 2, 0, 150, -1, -1, -1, -1,
+ax_anim_terminator
+sTyphlosionAnims_4_7:
+ax_anim 3, 0, 158, 2, 0, 2, 0,
+ax_anim 6, 2, 158, 3, 0, 3, 0,
+ax_anim 2, 0, 159, -3, 0, -3, 0,
+ax_anim 2, 1, 160, -3, -1, -3, -1,
+ax_anim 2, 0, 159, -3, 0, -3, 0,
+ax_anim 2, 0, 160, -3, -1, -3, -1,
+ax_anim 2, 0, 159, -3, 0, -3, 0,
+ax_anim 2, 0, 160, -3, -1, -3, -1,
+ax_anim 2, 0, 161, -3, 0, -3, 0,
+ax_anim 2, 0, 156, -1, 0, -1, 0,
+ax_anim_terminator
+sTyphlosionAnims_4_8:
+ax_anim 3, 0, 164, 2, -2, 2, -2,
+ax_anim 6, 0, 164, 3, -3, 3, -3,
+ax_anim 2, 0, 165, -3, 3, -3, 3,
+ax_anim 2, 2, 166, -2, 4, -2, 4,
+ax_anim 2, 0, 165, -3, 3, -3, 3,
+ax_anim 2, 0, 166, -2, 4, -2, 4,
+ax_anim 2, 0, 165, -3, 3, -3, 3,
+ax_anim 2, 0, 166, -2, 4, -2, 4,
+ax_anim 2, 0, 167, -3, 3, -3, 3,
+ax_anim 2, 0, 162, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_5_1:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_5_2:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_5_3:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_5_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_5_5:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_5_6:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_5_7:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_5_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_7_1:
+ax_anim 2, 0, 178, 0, -2, 0, -2,
+ax_anim 8, 0, 178, 0, -3, 0, -3,
+ax_anim_terminator
+sTyphlosionAnims_7_2:
+ax_anim 2, 0, 179, -2, -2, -2, -2,
+ax_anim 8, 0, 179, -3, -3, -3, -3,
+ax_anim_terminator
+sTyphlosionAnims_7_3:
+ax_anim 2, 0, 180, -2, 0, -2, 0,
+ax_anim 8, 0, 180, -3, 0, -3, 0,
+ax_anim_terminator
+sTyphlosionAnims_7_4:
+ax_anim 2, 0, 181, -2, 2, -2, 2,
+ax_anim 8, 0, 181, -3, 3, -3, 3,
+ax_anim_terminator
+sTyphlosionAnims_7_5:
+ax_anim 2, 0, 182, 0, 2, 0, 2,
+ax_anim 8, 0, 182, 0, 3, 0, 3,
+ax_anim_terminator
+sTyphlosionAnims_7_6:
+ax_anim 2, 0, 183, 2, 2, 2, 2,
+ax_anim 8, 0, 183, 3, 3, 3, 3,
+ax_anim_terminator
+sTyphlosionAnims_7_7:
+ax_anim 2, 0, 184, 2, 0, 2, 0,
+ax_anim 8, 0, 184, 3, 0, 3, 0,
+ax_anim_terminator
+sTyphlosionAnims_7_8:
+ax_anim 2, 0, 185, 2, -2, 2, -2,
+ax_anim 8, 0, 185, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_8_1:
+ax_anim 30, 0, 186, 0, 0, 0, 0,
+ax_anim 4, 0, 187, 0, -2, 0, 0,
+ax_anim 4, 0, 187, 0, -3, 0, 0,
+ax_anim 4, 0, 187, 0, -2, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_8_2:
+ax_anim 30, 0, 188, 0, 0, 0, 0,
+ax_anim 4, 0, 189, 0, -2, 0, 0,
+ax_anim 4, 0, 189, 0, -3, 0, 0,
+ax_anim 4, 0, 189, 0, -2, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_8_3:
+ax_anim 30, 0, 190, 0, 0, 0, 0,
+ax_anim 4, 0, 191, 0, -2, 0, 0,
+ax_anim 4, 0, 191, 0, -3, 0, 0,
+ax_anim 4, 0, 191, 0, -2, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_8_4:
+ax_anim 30, 0, 192, 0, 0, 0, 0,
+ax_anim 4, 0, 193, 0, -2, 0, 0,
+ax_anim 4, 0, 193, 0, -3, 0, 0,
+ax_anim 4, 0, 193, 0, -2, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_8_5:
+ax_anim 30, 0, 194, 0, 0, 0, 0,
+ax_anim 4, 0, 195, 0, -2, 0, 0,
+ax_anim 4, 0, 195, 0, -3, 0, 0,
+ax_anim 4, 0, 195, 0, -2, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_8_6:
+ax_anim 30, 0, 196, 0, 0, 0, 0,
+ax_anim 4, 0, 197, 0, -2, 0, 0,
+ax_anim 4, 0, 197, 0, -3, 0, 0,
+ax_anim 4, 0, 197, 0, -2, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_8_7:
+ax_anim 30, 0, 198, 0, 0, 0, 0,
+ax_anim 4, 0, 199, 0, -2, 0, 0,
+ax_anim 4, 0, 199, 0, -3, 0, 0,
+ax_anim 4, 0, 199, 0, -2, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_8_8:
+ax_anim 30, 0, 200, 0, 0, 0, 0,
+ax_anim 4, 0, 201, 0, -2, 0, 0,
+ax_anim 4, 0, 201, 0, -3, 0, 0,
+ax_anim 4, 0, 201, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 8, 5, 8, 5,
+ax_anim 2, 0, 204, 10, 8, 10, 8,
+ax_anim 2, 0, 205, 7, 12, 7, 12,
+ax_anim 3, 0, 206, 0, 16, 0, 16,
+ax_anim 2, 3, 207, -7, 12, -7, 12,
+ax_anim 2, 0, 208, -10, 8, -10, 8,
+ax_anim 1, 0, 209, -8, 5, -8, 5,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 10, -2, 10, -2,
+ax_anim 2, 0, 203, 20, 6, 20, 6,
+ax_anim 2, 0, 204, 20, 12, 20, 12,
+ax_anim 3, 0, 205, 14, 17, 14, 17,
+ax_anim 2, 3, 206, 8, 18, 8, 18,
+ax_anim 2, 0, 207, 2, 13, 2, 13,
+ax_anim 1, 0, 208, -2, 7, -2, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -3, 0, -3,
+ax_anim 2, 0, 202, 9, -7, 9, -7,
+ax_anim 2, 0, 203, 14, -3, 14, -3,
+ax_anim 3, 0, 204, 16, 0, 16, 0,
+ax_anim 2, 3, 205, 11, 5, 11, 5,
+ax_anim 2, 0, 206, 10, 7, 10, 7,
+ax_anim 1, 0, 207, 4, 4, 4, 4,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -3, -8, -3, -8,
+ax_anim 2, 0, 209, 0, -17, 0, -17,
+ax_anim 2, 0, 202, 12, -25, 12, -25,
+ax_anim 3, 0, 203, 20, -22, 20, -22,
+ax_anim 2, 3, 204, 21, -13, 21, -13,
+ax_anim 2, 0, 205, 17, -3, 17, -3,
+ax_anim 1, 0, 206, 9, 2, 9, 2,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -3, -8, -3,
+ax_anim 2, 0, 208, -11, -8, -11, -8,
+ax_anim 2, 0, 209, -10, -16, -10, -16,
+ax_anim 3, 0, 202, 0, -24, 0, -24,
+ax_anim 2, 3, 203, 10, -16, 10, -16,
+ax_anim 2, 0, 204, 11, -8, 11, -8,
+ax_anim 1, 0, 205, 8, -3, 8, -3,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, -3, -8, -3, -8,
+ax_anim 2, 0, 203, 0, -17, 0, -17,
+ax_anim 2, 0, 202, -12, -25, -12, -25,
+ax_anim 3, 0, 209, -20, -22, -20, -22,
+ax_anim 2, 3, 208, -21, -13, -21, -13,
+ax_anim 2, 0, 207, -17, -3, -17, -3,
+ax_anim 1, 0, 206, -9, 2, -9, 2,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -3, 0, -3,
+ax_anim 2, 0, 202, -9, -7, -9, -7,
+ax_anim 2, 0, 209, -14, -3, -14, -3,
+ax_anim 3, 0, 208, -16, 0, -16, 0,
+ax_anim 2, 3, 207, -11, 5, -11, 5,
+ax_anim 2, 0, 206, -10, 7, -10, 7,
+ax_anim 1, 0, 205, -4, 4, -4, 4,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -10, -2, -10, -2,
+ax_anim 2, 0, 209, -20, 6, -20, 6,
+ax_anim 2, 0, 208, -20, 12, -20, 12,
+ax_anim 3, 0, 207, -14, 17, -14, 17,
+ax_anim 2, 3, 206, -8, 18, -8, 18,
+ax_anim 2, 0, 205, -2, 13, -2, 13,
+ax_anim 1, 0, 204, 2, 7, 2, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -8, 0, 0,
+ax_anim 2, 0, 219, 0, -14, 0, 0,
+ax_anim 3, 0, 219, 0, -18, 0, 0,
+ax_anim 4, 0, 219, 0, -19, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -9, 0, 0,
+ax_anim 2, 0, 222, 0, -15, 0, 0,
+ax_anim 3, 0, 222, 0, -19, 0, 0,
+ax_anim 4, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 223, 0, -21, 0, 0,
+ax_anim 2, 0, 223, 0, -17, 0, 0,
+ax_anim 1, 0, 223, 0, -11, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -8, 0, 0,
+ax_anim 2, 0, 225, 0, -14, 0, 0,
+ax_anim 3, 0, 225, 0, -18, 0, 0,
+ax_anim 4, 0, 225, 0, -19, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 226, 0, -21, 0, 0,
+ax_anim 2, 0, 226, 0, -17, 0, 0,
+ax_anim 1, 0, 226, 0, -11, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -9, 0, 0,
+ax_anim 2, 0, 228, 0, -15, 0, 0,
+ax_anim 3, 0, 228, 0, -19, 0, 0,
+ax_anim 4, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 2, 0, 229, 0, -15, 0, 0,
+ax_anim 1, 0, 229, 0, -9, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -9, 0, 0,
+ax_anim 2, 0, 231, 0, -15, 0, 0,
+ax_anim 3, 0, 231, 0, -19, 0, 0,
+ax_anim 4, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 230, 0, -21, 0, 0,
+ax_anim 3, 0, 232, 0, -21, 0, 0,
+ax_anim 2, 0, 232, 0, -17, 0, 0,
+ax_anim 1, 0, 232, 0, -11, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -9, 0, 0,
+ax_anim 2, 0, 234, 0, -15, 0, 0,
+ax_anim 3, 0, 234, 0, -19, 0, 0,
+ax_anim 4, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -22, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 2, 0, 235, 0, -15, 0, 0,
+ax_anim 1, 0, 235, 0, -9, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -8, 0, 0,
+ax_anim 2, 0, 237, 0, -14, 0, 0,
+ax_anim 3, 0, 237, 0, -18, 0, 0,
+ax_anim 4, 0, 237, 0, -19, 0, 0,
+ax_anim 4, 0, 236, 0, -23, 0, 0,
+ax_anim 3, 0, 238, 0, -21, 0, 0,
+ax_anim 2, 0, 238, 0, -17, 0, 0,
+ax_anim 1, 0, 238, 0, -11, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -9, 0, 0,
+ax_anim 2, 0, 240, 0, -15, 0, 0,
+ax_anim 3, 0, 240, 0, -19, 0, 0,
+ax_anim 4, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 241, 0, -21, 0, 0,
+ax_anim 2, 0, 241, 0, -17, 0, 0,
+ax_anim 1, 0, 241, 0, -11, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyphlosionAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sTyphlosionGfx1:
+.incbin "baserom.gba", 0xBE0018, 0x200
+sTyphlosionSprites1:
+ax_sprite sTyphlosionGfx1, 0x200
+ax_sprite_terminator
+sTyphlosionGfx2:
+.incbin "baserom.gba", 0xBE0228, 0x200
+sTyphlosionSprites2:
+ax_sprite sTyphlosionGfx2, 0x200
+ax_sprite_terminator
+sTyphlosionGfx3:
+.incbin "baserom.gba", 0xBE0438, 0x200
+sTyphlosionSprites3:
+ax_sprite sTyphlosionGfx3, 0x200
+ax_sprite_terminator
+sTyphlosionGfx4:
+.incbin "baserom.gba", 0xBE0648, 0x200
+sTyphlosionSprites4:
+ax_sprite sTyphlosionGfx4, 0x200
+ax_sprite_terminator
+sTyphlosionGfx5:
+.incbin "baserom.gba", 0xBE0858, 0x200
+sTyphlosionSprites5:
+ax_sprite sTyphlosionGfx5, 0x200
+ax_sprite_terminator
+sTyphlosionGfx6:
+.incbin "baserom.gba", 0xBE0A68, 0x200
+sTyphlosionSprites6:
+ax_sprite sTyphlosionGfx6, 0x200
+ax_sprite_terminator
+sTyphlosionGfx7:
+.incbin "baserom.gba", 0xBE0C78, 0x200
+sTyphlosionSprites7:
+ax_sprite sTyphlosionGfx7, 0x200
+ax_sprite_terminator
+sTyphlosionGfx8:
+.incbin "baserom.gba", 0xBE0E88, 0x200
+sTyphlosionSprites8:
+ax_sprite sTyphlosionGfx8, 0x200
+ax_sprite_terminator
+sTyphlosionGfx9:
+.incbin "baserom.gba", 0xBE1098, 0x200
+sTyphlosionSprites9:
+ax_sprite sTyphlosionGfx9, 0x200
+ax_sprite_terminator
+sTyphlosionGfx10:
+.incbin "baserom.gba", 0xBE12A8, 0x200
+sTyphlosionSprites10:
+ax_sprite sTyphlosionGfx10, 0x200
+ax_sprite_terminator
+sTyphlosionGfx11:
+.incbin "baserom.gba", 0xBE14B8, 0x200
+sTyphlosionSprites11:
+ax_sprite sTyphlosionGfx11, 0x200
+ax_sprite_terminator
+sTyphlosionGfx12:
+.incbin "baserom.gba", 0xBE16C8, 0x200
+sTyphlosionSprites12:
+ax_sprite sTyphlosionGfx12, 0x200
+ax_sprite_terminator
+sTyphlosionGfx13:
+.incbin "baserom.gba", 0xBE18D8, 0x200
+sTyphlosionSprites13:
+ax_sprite sTyphlosionGfx13, 0x200
+ax_sprite_terminator
+sTyphlosionGfx14:
+.incbin "baserom.gba", 0xBE1AE8, 0x200
+sTyphlosionSprites14:
+ax_sprite sTyphlosionGfx14, 0x200
+ax_sprite_terminator
+sTyphlosionGfx15:
+.incbin "baserom.gba", 0xBE1CF8, 0x200
+sTyphlosionSprites15:
+ax_sprite sTyphlosionGfx15, 0x200
+ax_sprite_terminator
+sTyphlosionGfx16:
+.incbin "baserom.gba", 0xBE1F08, 0x60
+sTyphlosionGfx16_1:
+.incbin "baserom.gba", 0xBE1F68, 0x60
+sTyphlosionGfx16_2:
+.incbin "baserom.gba", 0xBE1FC8, 0x60
+sTyphlosionGfx16_3:
+.incbin "baserom.gba", 0xBE2028, 0x20
+sTyphlosionGfx16_4:
+.incbin "baserom.gba", 0xBE2048, 0x20
+sTyphlosionSprites16:
+ax_sprite sTyphlosionGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx16_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx16_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx16_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx17:
+.incbin "baserom.gba", 0xBE20C0, 0x60
+sTyphlosionGfx17_1:
+.incbin "baserom.gba", 0xBE2120, 0x60
+sTyphlosionGfx17_2:
+.incbin "baserom.gba", 0xBE2180, 0x60
+sTyphlosionGfx17_3:
+.incbin "baserom.gba", 0xBE21E0, 0x20
+sTyphlosionSprites17:
+ax_sprite sTyphlosionGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx17_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyphlosionGfx18:
+.incbin "baserom.gba", 0xBE2248, 0x20
+sTyphlosionGfx18_1:
+.incbin "baserom.gba", 0xBE2268, 0x60
+sTyphlosionGfx18_2:
+.incbin "baserom.gba", 0xBE22C8, 0x60
+sTyphlosionSprites18:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTyphlosionGfx19:
+.incbin "baserom.gba", 0xBE2368, 0x60
+sTyphlosionGfx19_1:
+.incbin "baserom.gba", 0xBE23C8, 0x60
+sTyphlosionGfx19_2:
+.incbin "baserom.gba", 0xBE2428, 0x60
+sTyphlosionGfx19_3:
+.incbin "baserom.gba", 0xBE2488, 0x40
+sTyphlosionSprites19:
+ax_sprite sTyphlosionGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx20:
+.incbin "baserom.gba", 0xBE2510, 0x160
+sTyphlosionSprites20:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx20, 0x160
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTyphlosionGfx21:
+.incbin "baserom.gba", 0xBE2690, 0x60
+sTyphlosionGfx21_1:
+.incbin "baserom.gba", 0xBE26F0, 0x60
+sTyphlosionGfx21_2:
+.incbin "baserom.gba", 0xBE2750, 0x40
+sTyphlosionGfx21_3:
+.incbin "baserom.gba", 0xBE2790, 0x40
+sTyphlosionSprites21:
+ax_sprite sTyphlosionGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx21_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx22:
+.incbin "baserom.gba", 0xBE2818, 0xC0
+sTyphlosionSprites22:
+ax_sprite sTyphlosionGfx22, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyphlosionGfx23:
+.incbin "baserom.gba", 0xBE28F0, 0x100
+sTyphlosionSprites23:
+ax_sprite sTyphlosionGfx23, 0x100
+ax_sprite_terminator
+sTyphlosionGfx24:
+.incbin "baserom.gba", 0xBE2A00, 0x100
+sTyphlosionSprites24:
+ax_sprite sTyphlosionGfx24, 0x100
+ax_sprite_terminator
+sTyphlosionGfx25:
+.incbin "baserom.gba", 0xBE2B10, 0x60
+sTyphlosionGfx25_1:
+.incbin "baserom.gba", 0xBE2B70, 0x60
+sTyphlosionGfx25_2:
+.incbin "baserom.gba", 0xBE2BD0, 0x40
+sTyphlosionSprites25:
+ax_sprite sTyphlosionGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx25_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sTyphlosionGfx26:
+.incbin "baserom.gba", 0xBE2C48, 0x100
+sTyphlosionGfx26_1:
+.incbin "baserom.gba", 0xBE2D48, 0x60
+sTyphlosionSprites26:
+ax_sprite sTyphlosionGfx26, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx26_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTyphlosionGfx27:
+.incbin "baserom.gba", 0xBE2DD0, 0x60
+sTyphlosionGfx27_1:
+.incbin "baserom.gba", 0xBE2E30, 0x60
+sTyphlosionGfx27_2:
+.incbin "baserom.gba", 0xBE2E90, 0x40
+sTyphlosionSprites27:
+ax_sprite sTyphlosionGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx27_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sTyphlosionGfx28:
+.incbin "baserom.gba", 0xBE2F08, 0x60
+sTyphlosionGfx28_1:
+.incbin "baserom.gba", 0xBE2F68, 0x60
+sTyphlosionGfx28_2:
+.incbin "baserom.gba", 0xBE2FC8, 0x60
+sTyphlosionSprites28:
+ax_sprite sTyphlosionGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTyphlosionGfx29:
+.incbin "baserom.gba", 0xBE3060, 0x40
+sTyphlosionGfx29_1:
+.incbin "baserom.gba", 0xBE30A0, 0x60
+sTyphlosionGfx29_2:
+.incbin "baserom.gba", 0xBE3100, 0x60
+sTyphlosionGfx29_3:
+.incbin "baserom.gba", 0xBE3160, 0x60
+sTyphlosionSprites29:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx29_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx30:
+.incbin "baserom.gba", 0xBE3210, 0x60
+sTyphlosionGfx30_1:
+.incbin "baserom.gba", 0xBE3270, 0x100
+sTyphlosionSprites30:
+ax_sprite sTyphlosionGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sTyphlosionGfx31:
+.incbin "baserom.gba", 0xBE3398, 0x80
+sTyphlosionSprites31:
+ax_sprite sTyphlosionGfx31, 0x80
+ax_sprite_terminator
+sTyphlosionGfx32:
+.incbin "baserom.gba", 0xBE3428, 0x100
+sTyphlosionSprites32:
+ax_sprite sTyphlosionGfx32, 0x100
+ax_sprite_terminator
+sTyphlosionGfx33:
+.incbin "baserom.gba", 0xBE3538, 0x20
+sTyphlosionGfx33_1:
+.incbin "baserom.gba", 0xBE3558, 0xA0
+sTyphlosionSprites33:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx33, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx33_1, 0xa0
+ax_sprite_terminator
+sTyphlosionGfx34:
+.incbin "baserom.gba", 0xBE3620, 0x60
+sTyphlosionSprites34:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx34, 0x60
+ax_sprite_terminator
+sTyphlosionGfx35:
+.incbin "baserom.gba", 0xBE3698, 0xC0
+sTyphlosionSprites35:
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx35, 0xc0
+ax_sprite_terminator
+sTyphlosionGfx36:
+.incbin "baserom.gba", 0xBE3770, 0x60
+sTyphlosionGfx36_1:
+.incbin "baserom.gba", 0xBE37D0, 0x60
+sTyphlosionGfx36_2:
+.incbin "baserom.gba", 0xBE3830, 0x60
+sTyphlosionGfx36_3:
+.incbin "baserom.gba", 0xBE3890, 0x40
+sTyphlosionSprites36:
+ax_sprite sTyphlosionGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx37:
+.incbin "baserom.gba", 0xBE3918, 0x40
+sTyphlosionGfx37_1:
+.incbin "baserom.gba", 0xBE3958, 0x120
+sTyphlosionSprites37:
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx37_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx38:
+.incbin "baserom.gba", 0xBE3AA8, 0x60
+sTyphlosionGfx38_1:
+.incbin "baserom.gba", 0xBE3B08, 0x60
+sTyphlosionGfx38_2:
+.incbin "baserom.gba", 0xBE3B68, 0x60
+sTyphlosionSprites38:
+ax_sprite 0, 0x80
+ax_sprite sTyphlosionGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx38_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx39:
+.incbin "baserom.gba", 0xBE3C08, 0x60
+sTyphlosionGfx39_1:
+.incbin "baserom.gba", 0xBE3C68, 0x60
+sTyphlosionGfx39_2:
+.incbin "baserom.gba", 0xBE3CC8, 0x80
+sTyphlosionGfx39_3:
+.incbin "baserom.gba", 0xBE3D48, 0x40
+sTyphlosionSprites39:
+ax_sprite sTyphlosionGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx39_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx39_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx40:
+.incbin "baserom.gba", 0xBE3DD0, 0xC0
+sTyphlosionSprites40:
+ax_sprite sTyphlosionGfx40, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyphlosionGfx41:
+.incbin "baserom.gba", 0xBE3EA8, 0x100
+sTyphlosionGfx41_1:
+.incbin "baserom.gba", 0xBE3FA8, 0x40
+sTyphlosionSprites41:
+ax_sprite 0, 0x80
+ax_sprite sTyphlosionGfx41, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx41_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx42:
+.incbin "baserom.gba", 0xBE4018, 0x60
+sTyphlosionGfx42_1:
+.incbin "baserom.gba", 0xBE4078, 0x60
+sTyphlosionGfx42_2:
+.incbin "baserom.gba", 0xBE40D8, 0x60
+sTyphlosionGfx42_3:
+.incbin "baserom.gba", 0xBE4138, 0x40
+sTyphlosionSprites42:
+ax_sprite sTyphlosionGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx42_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx42_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx43:
+.incbin "baserom.gba", 0xBE41C0, 0x60
+sTyphlosionGfx43_1:
+.incbin "baserom.gba", 0xBE4220, 0x60
+sTyphlosionGfx43_2:
+.incbin "baserom.gba", 0xBE4280, 0x60
+sTyphlosionSprites43:
+ax_sprite sTyphlosionGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx43_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx43_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTyphlosionGfx44:
+.incbin "baserom.gba", 0xBE4318, 0x60
+sTyphlosionGfx44_1:
+.incbin "baserom.gba", 0xBE4378, 0x60
+sTyphlosionGfx44_2:
+.incbin "baserom.gba", 0xBE43D8, 0x60
+sTyphlosionGfx44_3:
+.incbin "baserom.gba", 0xBE4438, 0x20
+sTyphlosionSprites44:
+ax_sprite sTyphlosionGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx44_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx44_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyphlosionGfx45:
+.incbin "baserom.gba", 0xBE44A0, 0x60
+sTyphlosionGfx45_1:
+.incbin "baserom.gba", 0xBE4500, 0x60
+sTyphlosionGfx45_2:
+.incbin "baserom.gba", 0xBE4560, 0x60
+sTyphlosionGfx45_3:
+.incbin "baserom.gba", 0xBE45C0, 0x60
+sTyphlosionSprites45:
+ax_sprite sTyphlosionGfx45, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx45_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx46:
+.incbin "baserom.gba", 0xBE4668, 0xC0
+sTyphlosionSprites46:
+ax_sprite sTyphlosionGfx46, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyphlosionGfx47:
+.incbin "baserom.gba", 0xBE4740, 0x40
+sTyphlosionGfx47_1:
+.incbin "baserom.gba", 0xBE4780, 0x60
+sTyphlosionGfx47_2:
+.incbin "baserom.gba", 0xBE47E0, 0x60
+sTyphlosionGfx47_3:
+.incbin "baserom.gba", 0xBE4840, 0x40
+sTyphlosionSprites47:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx47, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx47_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx47_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx47_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyphlosionGfx48:
+.incbin "baserom.gba", 0xBE48D0, 0x60
+sTyphlosionGfx48_1:
+.incbin "baserom.gba", 0xBE4930, 0x60
+sTyphlosionGfx48_2:
+.incbin "baserom.gba", 0xBE4990, 0x60
+sTyphlosionSprites48:
+ax_sprite 0, 0x80
+ax_sprite sTyphlosionGfx48, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx48_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx49:
+.incbin "baserom.gba", 0xBE4A30, 0x20
+sTyphlosionGfx49_1:
+.incbin "baserom.gba", 0xBE4A50, 0x60
+sTyphlosionGfx49_2:
+.incbin "baserom.gba", 0xBE4AB0, 0x60
+sTyphlosionGfx49_3:
+.incbin "baserom.gba", 0xBE4B10, 0x60
+sTyphlosionSprites49:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx49, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx49_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx49_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx50:
+.incbin "baserom.gba", 0xBE4BC0, 0x60
+sTyphlosionGfx50_1:
+.incbin "baserom.gba", 0xBE4C20, 0x60
+sTyphlosionGfx50_2:
+.incbin "baserom.gba", 0xBE4C80, 0x60
+sTyphlosionSprites50:
+ax_sprite 0, 0x80
+ax_sprite sTyphlosionGfx50, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx51:
+.incbin "baserom.gba", 0xBE4D20, 0x40
+sTyphlosionGfx51_1:
+.incbin "baserom.gba", 0xBE4D60, 0x60
+sTyphlosionGfx51_2:
+.incbin "baserom.gba", 0xBE4DC0, 0x60
+sTyphlosionGfx51_3:
+.incbin "baserom.gba", 0xBE4E20, 0x40
+sTyphlosionSprites51:
+ax_sprite sTyphlosionGfx51, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx51_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx51_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx51_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx52:
+.incbin "baserom.gba", 0xBE4EA8, 0x40
+sTyphlosionGfx52_1:
+.incbin "baserom.gba", 0xBE4EE8, 0x60
+sTyphlosionGfx52_2:
+.incbin "baserom.gba", 0xBE4F48, 0x60
+sTyphlosionGfx52_3:
+.incbin "baserom.gba", 0xBE4FA8, 0x60
+sTyphlosionSprites52:
+ax_sprite sTyphlosionGfx52, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx52_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx52_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx52_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx53:
+.incbin "baserom.gba", 0xBE5050, 0x20
+sTyphlosionGfx53_1:
+.incbin "baserom.gba", 0xBE5070, 0x60
+sTyphlosionGfx53_2:
+.incbin "baserom.gba", 0xBE50D0, 0x60
+sTyphlosionGfx53_3:
+.incbin "baserom.gba", 0xBE5130, 0x40
+sTyphlosionSprites53:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx53, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx53_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx53_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx53_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx54:
+.incbin "baserom.gba", 0xBE51C0, 0xE0
+sTyphlosionSprites54:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx54, 0xe0
+ax_sprite_terminator
+sTyphlosionGfx55:
+.incbin "baserom.gba", 0xBE52B8, 0x60
+sTyphlosionGfx55_1:
+.incbin "baserom.gba", 0xBE5318, 0x60
+sTyphlosionGfx55_2:
+.incbin "baserom.gba", 0xBE5378, 0x60
+sTyphlosionGfx55_3:
+.incbin "baserom.gba", 0xBE53D8, 0x40
+sTyphlosionSprites55:
+ax_sprite sTyphlosionGfx55, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx55_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyphlosionGfx55_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx55_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx56:
+.incbin "baserom.gba", 0xBE5460, 0xE0
+sTyphlosionSprites56:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx56, 0xe0
+ax_sprite_terminator
+sTyphlosionGfx57:
+.incbin "baserom.gba", 0xBE5558, 0x60
+sTyphlosionGfx57_1:
+.incbin "baserom.gba", 0xBE55B8, 0x60
+sTyphlosionGfx57_2:
+.incbin "baserom.gba", 0xBE5618, 0x60
+sTyphlosionSprites57:
+ax_sprite 0, 0x80
+ax_sprite sTyphlosionGfx57, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx57_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx57_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx58:
+.incbin "baserom.gba", 0xBE56B8, 0x100
+sTyphlosionSprites58:
+ax_sprite sTyphlosionGfx58, 0x100
+ax_sprite_terminator
+sTyphlosionGfx59:
+.incbin "baserom.gba", 0xBE57C8, 0x60
+sTyphlosionSprites59:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx59, 0x60
+ax_sprite_terminator
+sTyphlosionGfx60:
+.incbin "baserom.gba", 0xBE5840, 0x40
+sTyphlosionGfx60_1:
+.incbin "baserom.gba", 0xBE5880, 0x60
+sTyphlosionGfx60_2:
+.incbin "baserom.gba", 0xBE58E0, 0x60
+sTyphlosionSprites60:
+ax_sprite 0, 0xa0
+ax_sprite sTyphlosionGfx60, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx60_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx60_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx61:
+.incbin "baserom.gba", 0xBE5980, 0x60
+sTyphlosionGfx61_1:
+.incbin "baserom.gba", 0xBE59E0, 0x60
+sTyphlosionGfx61_2:
+.incbin "baserom.gba", 0xBE5A40, 0x60
+sTyphlosionSprites61:
+ax_sprite 0, 0x80
+ax_sprite sTyphlosionGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx61_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx61_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx62:
+.incbin "baserom.gba", 0xBE5AE0, 0x40
+sTyphlosionGfx62_1:
+.incbin "baserom.gba", 0xBE5B20, 0x60
+sTyphlosionGfx62_2:
+.incbin "baserom.gba", 0xBE5B80, 0x60
+sTyphlosionGfx62_3:
+.incbin "baserom.gba", 0xBE5BE0, 0x60
+sTyphlosionSprites62:
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx62, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx62_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx62_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx62_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyphlosionGfx63:
+.incbin "baserom.gba", 0xBE5C90, 0x60
+sTyphlosionGfx63_1:
+.incbin "baserom.gba", 0xBE5CF0, 0x100
+sTyphlosionSprites63:
+ax_sprite 0, 0x80
+ax_sprite sTyphlosionGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyphlosionGfx63_1, 0x100
+ax_sprite_terminator
+sTyphlosionGfx64:
+.incbin "baserom.gba", 0xBE5E18, 0x200
+sTyphlosionSprites64:
+ax_sprite sTyphlosionGfx64, 0x200
+ax_sprite_terminator
+sTyphlosionGfx65:
+.incbin "baserom.gba", 0xBE6028, 0x200
+sTyphlosionSprites65:
+ax_sprite sTyphlosionGfx65, 0x200
+ax_sprite_terminator
+sTyphlosionGfx66:
+.incbin "baserom.gba", 0xBE6238, 0x200
+sTyphlosionSprites66:
+ax_sprite sTyphlosionGfx66, 0x200
+ax_sprite_terminator
+sTyphlosionGfx67:
+.incbin "baserom.gba", 0xBE6448, 0x200
+sTyphlosionSprites67:
+ax_sprite sTyphlosionGfx67, 0x200
+ax_sprite_terminator
+sTyphlosionGfx68:
+.incbin "baserom.gba", 0xBE6658, 0x200
+sTyphlosionSprites68:
+ax_sprite sTyphlosionGfx68, 0x200
+ax_sprite_terminator
+sTyphlosionGfx69:
+.incbin "baserom.gba", 0xBE6868, 0x200
+sTyphlosionSprites69:
+ax_sprite sTyphlosionGfx69, 0x200
+ax_sprite_terminator
+sTyphlosionGfx70:
+.incbin "baserom.gba", 0xBE6A78, 0x200
+sTyphlosionSprites70:
+ax_sprite sTyphlosionGfx70, 0x200
+ax_sprite_terminator
+sAxPosesTyphlosion:
+.4byte sTyphlosionPose1
+.4byte sTyphlosionPose2
+.4byte sTyphlosionPose3
+.4byte sTyphlosionPose4
+.4byte sTyphlosionPose5
+.4byte sTyphlosionPose6
+.4byte sTyphlosionPose7
+.4byte sTyphlosionPose8
+.4byte sTyphlosionPose9
+.4byte sTyphlosionPose10
+.4byte sTyphlosionPose11
+.4byte sTyphlosionPose12
+.4byte sTyphlosionPose13
+.4byte sTyphlosionPose14
+.4byte sTyphlosionPose15
+.4byte sTyphlosionPose16
+.4byte sTyphlosionPose17
+.4byte sTyphlosionPose18
+.4byte sTyphlosionPose19
+.4byte sTyphlosionPose20
+.4byte sTyphlosionPose21
+.4byte sTyphlosionPose22
+.4byte sTyphlosionPose23
+.4byte sTyphlosionPose24
+.4byte sTyphlosionPose25
+.4byte sTyphlosionPose26
+.4byte sTyphlosionPose27
+.4byte sTyphlosionPose28
+.4byte sTyphlosionPose29
+.4byte sTyphlosionPose30
+.4byte sTyphlosionPose31
+.4byte sTyphlosionPose32
+.4byte sTyphlosionPose33
+.4byte sTyphlosionPose34
+.4byte sTyphlosionPose35
+.4byte sTyphlosionPose36
+.4byte sTyphlosionPose37
+.4byte sTyphlosionPose38
+.4byte sTyphlosionPose39
+.4byte sTyphlosionPose40
+.4byte sTyphlosionPose41
+.4byte sTyphlosionPose42
+.4byte sTyphlosionPose43
+.4byte sTyphlosionPose44
+.4byte sTyphlosionPose45
+.4byte sTyphlosionPose46
+.4byte sTyphlosionPose47
+.4byte sTyphlosionPose48
+.4byte sTyphlosionPose49
+.4byte sTyphlosionPose50
+.4byte sTyphlosionPose51
+.4byte sTyphlosionPose52
+.4byte sTyphlosionPose53
+.4byte sTyphlosionPose54
+.4byte sTyphlosionPose55
+.4byte sTyphlosionPose56
+.4byte sTyphlosionPose57
+.4byte sTyphlosionPose58
+.4byte sTyphlosionPose59
+.4byte sTyphlosionPose60
+.4byte sTyphlosionPose61
+.4byte sTyphlosionPose62
+.4byte sTyphlosionPose63
+.4byte sTyphlosionPose64
+.4byte sTyphlosionPose65
+.4byte sTyphlosionPose66
+.4byte sTyphlosionPose67
+.4byte sTyphlosionPose68
+.4byte sTyphlosionPose69
+.4byte sTyphlosionPose70
+.4byte sTyphlosionPose71
+.4byte sTyphlosionPose72
+.4byte sTyphlosionPose73
+.4byte sTyphlosionPose74
+.4byte sTyphlosionPose75
+.4byte sTyphlosionPose76
+.4byte sTyphlosionPose77
+.4byte sTyphlosionPose78
+.4byte sTyphlosionPose79
+.4byte sTyphlosionPose80
+.4byte sTyphlosionPose81
+.4byte sTyphlosionPose82
+.4byte sTyphlosionPose83
+.4byte sTyphlosionPose84
+.4byte sTyphlosionPose85
+.4byte sTyphlosionPose86
+.4byte sTyphlosionPose87
+.4byte sTyphlosionPose88
+.4byte sTyphlosionPose89
+.4byte sTyphlosionPose90
+.4byte sTyphlosionPose91
+.4byte sTyphlosionPose92
+.4byte sTyphlosionPose93
+.4byte sTyphlosionPose94
+.4byte sTyphlosionPose95
+.4byte sTyphlosionPose96
+.4byte sTyphlosionPose97
+.4byte sTyphlosionPose98
+.4byte sTyphlosionPose99
+.4byte sTyphlosionPose100
+.4byte sTyphlosionPose101
+.4byte sTyphlosionPose102
+.4byte sTyphlosionPose103
+.4byte sTyphlosionPose104
+.4byte sTyphlosionPose105
+.4byte sTyphlosionPose106
+.4byte sTyphlosionPose107
+.4byte sTyphlosionPose108
+.4byte sTyphlosionPose109
+.4byte sTyphlosionPose110
+.4byte sTyphlosionPose111
+.4byte sTyphlosionPose112
+.4byte sTyphlosionPose113
+.4byte sTyphlosionPose114
+.4byte sTyphlosionPose115
+.4byte sTyphlosionPose116
+.4byte sTyphlosionPose117
+.4byte sTyphlosionPose118
+.4byte sTyphlosionPose119
+.4byte sTyphlosionPose120
+.4byte sTyphlosionPose121
+.4byte sTyphlosionPose122
+.4byte sTyphlosionPose123
+.4byte sTyphlosionPose124
+.4byte sTyphlosionPose125
+.4byte sTyphlosionPose126
+.4byte sTyphlosionPose127
+.4byte sTyphlosionPose128
+.4byte sTyphlosionPose129
+.4byte sTyphlosionPose130
+.4byte sTyphlosionPose131
+.4byte sTyphlosionPose132
+.4byte sTyphlosionPose133
+.4byte sTyphlosionPose134
+.4byte sTyphlosionPose135
+.4byte sTyphlosionPose136
+.4byte sTyphlosionPose137
+.4byte sTyphlosionPose138
+.4byte sTyphlosionPose139
+.4byte sTyphlosionPose140
+.4byte sTyphlosionPose141
+.4byte sTyphlosionPose142
+.4byte sTyphlosionPose143
+.4byte sTyphlosionPose144
+.4byte sTyphlosionPose145
+.4byte sTyphlosionPose146
+.4byte sTyphlosionPose147
+.4byte sTyphlosionPose148
+.4byte sTyphlosionPose149
+.4byte sTyphlosionPose150
+.4byte sTyphlosionPose151
+.4byte sTyphlosionPose152
+.4byte sTyphlosionPose153
+.4byte sTyphlosionPose154
+.4byte sTyphlosionPose155
+.4byte sTyphlosionPose156
+.4byte sTyphlosionPose157
+.4byte sTyphlosionPose158
+.4byte sTyphlosionPose159
+.4byte sTyphlosionPose160
+.4byte sTyphlosionPose161
+.4byte sTyphlosionPose162
+.4byte sTyphlosionPose163
+.4byte sTyphlosionPose164
+.4byte sTyphlosionPose165
+.4byte sTyphlosionPose166
+.4byte sTyphlosionPose167
+.4byte sTyphlosionPose168
+.4byte sTyphlosionPose169
+.4byte sTyphlosionPose170
+.4byte sTyphlosionPose171
+.4byte sTyphlosionPose172
+.4byte sTyphlosionPose173
+.4byte sTyphlosionPose174
+.4byte sTyphlosionPose175
+.4byte sTyphlosionPose176
+.4byte sTyphlosionPose177
+.4byte sTyphlosionPose178
+.4byte sTyphlosionPose179
+.4byte sTyphlosionPose180
+.4byte sTyphlosionPose181
+.4byte sTyphlosionPose182
+.4byte sTyphlosionPose183
+.4byte sTyphlosionPose184
+.4byte sTyphlosionPose185
+.4byte sTyphlosionPose186
+.4byte sTyphlosionPose187
+.4byte sTyphlosionPose188
+.4byte sTyphlosionPose189
+.4byte sTyphlosionPose190
+.4byte sTyphlosionPose191
+.4byte sTyphlosionPose192
+.4byte sTyphlosionPose193
+.4byte sTyphlosionPose194
+.4byte sTyphlosionPose195
+.4byte sTyphlosionPose196
+.4byte sTyphlosionPose197
+.4byte sTyphlosionPose198
+.4byte sTyphlosionPose199
+.4byte sTyphlosionPose200
+.4byte sTyphlosionPose201
+.4byte sTyphlosionPose202
+.4byte sTyphlosionPose203
+.4byte sTyphlosionPose204
+.4byte sTyphlosionPose205
+.4byte sTyphlosionPose206
+.4byte sTyphlosionPose207
+.4byte sTyphlosionPose208
+.4byte sTyphlosionPose209
+.4byte sTyphlosionPose210
+.4byte sTyphlosionPose211
+.4byte sTyphlosionPose212
+.4byte sTyphlosionPose213
+.4byte sTyphlosionPose214
+.4byte sTyphlosionPose215
+.4byte sTyphlosionPose216
+.4byte sTyphlosionPose217
+.4byte sTyphlosionPose218
+.4byte sTyphlosionPose219
+.4byte sTyphlosionPose220
+.4byte sTyphlosionPose221
+.4byte sTyphlosionPose222
+.4byte sTyphlosionPose223
+.4byte sTyphlosionPose224
+.4byte sTyphlosionPose225
+.4byte sTyphlosionPose226
+.4byte sTyphlosionPose227
+.4byte sTyphlosionPose228
+.4byte sTyphlosionPose229
+.4byte sTyphlosionPose230
+.4byte sTyphlosionPose231
+.4byte sTyphlosionPose232
+.4byte sTyphlosionPose233
+.4byte sTyphlosionPose234
+.4byte sTyphlosionPose235
+.4byte sTyphlosionPose236
+.4byte sTyphlosionPose237
+.4byte sTyphlosionPose238
+.4byte sTyphlosionPose239
+.4byte sTyphlosionPose240
+.4byte sTyphlosionPose241
+.4byte sTyphlosionPose242
+.4byte sTyphlosionPose243
+.4byte sTyphlosionPose244
+.4byte sTyphlosionPose245
+.4byte sTyphlosionPose246
+.4byte sTyphlosionPose247
+.4byte sTyphlosionPose248
+.4byte sTyphlosionPose249
+.4byte sTyphlosionPose250
+.4byte sTyphlosionPose251
+.4byte sTyphlosionPose252
+.4byte sTyphlosionPose253
+.4byte sTyphlosionPose254
+.4byte sTyphlosionPose255
+.4byte sTyphlosionPose256
+.4byte sTyphlosionPose257
+.4byte sTyphlosionPose258
+sAxPositionsTyphlosion:
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte   -2,  -11, 	 -10,  -10, 	   4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	  -6,   -8, 	   8,  -10, 	  -1,   -9
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte    4,  -13, 	   3,   -9, 	  -3,   -8, 	  -2,  -10
+.2byte    2,  -12, 	   5,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    7,  -13, 	   1,  -12, 	   2,   -9, 	  -3,   -9
+.2byte    6,  -12, 	   3,  -11, 	  -2,   -7, 	  -3,  -10
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    4,  -15, 	  -7,  -11, 	   6,  -10, 	  -4,   -9
+.2byte    6,  -15, 	   0,  -12, 	   3,   -7, 	  -3,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    0,  -16, 	   6,   -6, 	  -6,  -11, 	   0,   -9
+.2byte   -2,  -16, 	   4,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -5,  -15, 	   6,  -11, 	  -7,  -10, 	   3,   -9
+.2byte   -7,  -15, 	  -1,  -12, 	  -4,   -7, 	   2,  -10
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -8,  -13, 	  -2,  -12, 	  -3,   -9, 	   2,   -9
+.2byte   -7,  -12, 	  -4,  -11, 	   1,   -7, 	   2,  -10
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -5,  -13, 	  -4,   -9, 	   2,   -8, 	   1,  -10
+.2byte   -3,  -12, 	  -6,   -9, 	   5,   -8, 	   1,   -9
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte   -2,  -11, 	 -10,  -10, 	   4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	  -6,   -8, 	   8,  -10, 	  -1,   -9
+.2byte   -1,    3, 	  -7,    1, 	   5,    1, 	  -1,  -10
+.2byte   -1,    3, 	  -7,    1, 	   5,    1, 	  -1,  -10
+.2byte   -1,    3, 	  -7,    1, 	   5,    1, 	  -1,  -10
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte    4,  -13, 	   3,   -9, 	  -3,   -8, 	  -2,  -10
+.2byte    2,  -12, 	   5,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte   10,    0, 	   8,    0, 	   5,    2, 	  -1,   -7
+.2byte   10,    0, 	   8,    0, 	   5,    2, 	  -1,   -7
+.2byte   10,    0, 	   8,    0, 	   5,    2, 	  -1,   -7
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    7,  -13, 	   1,  -12, 	   2,   -9, 	  -3,   -9
+.2byte    6,  -12, 	   3,  -11, 	  -2,   -7, 	  -3,  -10
+.2byte   14,   -5, 	  10,   -4, 	   7,   -1, 	   0,   -8
+.2byte   14,   -5, 	  10,   -4, 	   7,   -1, 	   0,   -8
+.2byte   14,   -5, 	  10,   -4, 	   7,   -1, 	   0,   -8
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    4,  -15, 	  -7,  -11, 	   6,  -10, 	  -4,   -9
+.2byte    6,  -15, 	   0,  -12, 	   3,   -7, 	  -3,  -10
+.2byte   11,   -7, 	   3,   -9, 	   9,   -4, 	   0,   -8
+.2byte   11,   -7, 	   3,   -9, 	   9,   -4, 	   0,   -8
+.2byte   11,   -7, 	   3,   -9, 	   9,   -4, 	   0,   -8
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    0,  -16, 	   6,   -6, 	  -6,  -11, 	   0,   -9
+.2byte   -2,  -16, 	   4,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -10
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -5,  -15, 	   6,  -11, 	  -7,  -10, 	   3,   -9
+.2byte   -7,  -15, 	  -1,  -12, 	  -4,   -7, 	   2,  -10
+.2byte  -12,   -7, 	  -4,   -9, 	 -10,   -4, 	  -1,   -8
+.2byte  -12,   -7, 	  -4,   -9, 	 -10,   -4, 	  -1,   -8
+.2byte  -12,   -7, 	  -4,   -9, 	 -10,   -4, 	  -1,   -8
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -8,  -13, 	  -2,  -12, 	  -3,   -9, 	   2,   -9
+.2byte   -7,  -12, 	  -4,  -11, 	   1,   -7, 	   2,  -10
+.2byte  -15,   -5, 	 -11,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte  -15,   -5, 	 -11,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte  -15,   -5, 	 -11,   -4, 	  -8,   -1, 	  -1,   -8
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -5,  -13, 	  -4,   -9, 	   2,   -8, 	   1,  -10
+.2byte   -3,  -12, 	  -6,   -9, 	   5,   -8, 	   1,   -9
+.2byte  -11,    0, 	  -9,    0, 	  -6,    2, 	   0,   -7
+.2byte  -11,    0, 	  -9,    0, 	  -6,    2, 	   0,   -7
+.2byte  -11,    0, 	  -9,    0, 	  -6,    2, 	   0,   -7
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte   -2,  -11, 	 -10,  -10, 	   4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	  -6,   -8, 	   8,  -10, 	  -1,   -9
+.2byte    2,  -16, 	  -4,  -11, 	   7,  -14, 	   0,  -12
+.2byte   -3,   -6, 	 -10,  -12, 	   0,   -3, 	  -1,  -12
+.2byte   -3,   -6, 	 -10,  -12, 	   0,   -3, 	  -1,  -12
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte    4,  -13, 	   3,   -9, 	  -3,   -8, 	  -2,  -10
+.2byte    2,  -12, 	   5,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte    2,  -15, 	   2,  -11, 	  -4,  -15, 	  -1,  -11
+.2byte    7,   -6, 	   6,  -14, 	   2,   -4, 	   0,  -11
+.2byte    7,   -6, 	   6,  -14, 	   2,   -4, 	   0,  -11
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    7,  -13, 	   1,  -12, 	   2,   -9, 	  -3,   -9
+.2byte    6,  -12, 	   3,  -11, 	  -2,   -7, 	  -3,  -10
+.2byte    5,  -17, 	   5,  -13, 	  -2,  -16, 	   0,  -12
+.2byte   11,   -7, 	   5,  -16, 	   6,   -5, 	  -1,  -11
+.2byte   11,   -7, 	   5,  -16, 	   6,   -5, 	  -1,  -11
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    4,  -15, 	  -7,  -11, 	   6,  -10, 	  -4,   -9
+.2byte    6,  -15, 	   0,  -12, 	   3,   -7, 	  -3,  -10
+.2byte    4,  -15, 	  -1,  -13, 	  -2,  -15, 	  -4,  -10
+.2byte    7,  -13, 	  -8,  -20, 	   4,   -8, 	  -2,  -13
+.2byte    7,  -13, 	  -8,  -20, 	   4,   -8, 	  -2,  -13
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    0,  -16, 	   6,   -6, 	  -6,  -11, 	   0,   -9
+.2byte   -2,  -16, 	   4,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte   -6,  -16, 	   1,  -15, 	 -10,  -13, 	  -1,  -11
+.2byte   -1,  -16, 	   7,  -15, 	  -4,  -10, 	  -1,  -13
+.2byte   -1,  -16, 	   7,  -15, 	  -4,  -10, 	  -1,  -13
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -5,  -15, 	   6,  -11, 	  -7,  -10, 	   3,   -9
+.2byte   -7,  -15, 	  -1,  -12, 	  -4,   -7, 	   2,  -10
+.2byte   -5,  -15, 	   0,  -13, 	   1,  -15, 	   3,  -10
+.2byte   -8,  -13, 	   7,  -20, 	  -5,   -8, 	   1,  -13
+.2byte   -8,  -13, 	   7,  -20, 	  -5,   -8, 	   1,  -13
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -8,  -13, 	  -2,  -12, 	  -3,   -9, 	   2,   -9
+.2byte   -7,  -12, 	  -4,  -11, 	   1,   -7, 	   2,  -10
+.2byte   -4,  -17, 	  -4,  -13, 	   3,  -16, 	   1,  -12
+.2byte  -12,   -7, 	  -6,  -16, 	  -7,   -5, 	   0,  -11
+.2byte  -12,   -7, 	  -6,  -16, 	  -7,   -5, 	   0,  -11
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -5,  -13, 	  -4,   -9, 	   2,   -8, 	   1,  -10
+.2byte   -3,  -12, 	  -6,   -9, 	   5,   -8, 	   1,   -9
+.2byte   -3,  -15, 	  -3,  -11, 	   3,  -15, 	   0,  -11
+.2byte   -8,   -6, 	  -7,  -14, 	  -3,   -4, 	  -1,  -11
+.2byte   -8,   -6, 	  -7,  -14, 	  -3,   -4, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte   -2,  -11, 	 -10,  -10, 	   4,   -8, 	  -1,   -9
+.2byte    0,  -11, 	  -6,   -8, 	   8,  -10, 	  -1,   -9
+.2byte   -1,  -12, 	 -10,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	 -10,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	 -10,  -12, 	   9,  -12, 	  -1,  -10
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte    4,  -13, 	   3,   -9, 	  -3,   -8, 	  -2,  -10
+.2byte    2,  -12, 	   5,   -9, 	  -6,   -8, 	  -2,   -9
+.2byte    5,  -13, 	   4,  -11, 	  -6,  -11, 	   0,  -10
+.2byte    5,  -13, 	   4,  -11, 	  -6,  -11, 	   0,  -10
+.2byte    5,  -13, 	   4,  -11, 	  -6,  -11, 	   0,  -10
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    7,  -13, 	   1,  -12, 	   2,   -9, 	  -3,   -9
+.2byte    6,  -12, 	   3,  -11, 	  -2,   -7, 	  -3,  -10
+.2byte    8,  -14, 	  -1,  -12, 	  -3,   -9, 	  -4,  -12
+.2byte    8,  -14, 	  -1,  -12, 	  -3,   -9, 	  -4,  -12
+.2byte    8,  -14, 	  -1,  -12, 	  -3,   -9, 	  -4,  -12
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    4,  -15, 	  -7,  -11, 	   6,  -10, 	  -4,   -9
+.2byte    6,  -15, 	   0,  -12, 	   3,   -7, 	  -3,  -10
+.2byte    7,  -15, 	  -7,  -14, 	  -1,   -9, 	  -4,  -10
+.2byte    7,  -15, 	  -7,  -14, 	  -1,   -9, 	  -4,  -10
+.2byte    7,  -15, 	  -7,  -14, 	  -1,   -9, 	  -4,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    0,  -16, 	   6,   -6, 	  -6,  -11, 	   0,   -9
+.2byte   -2,  -16, 	   4,  -11, 	  -8,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   8,  -10, 	 -10,  -10, 	  -1,  -13
+.2byte   -1,  -19, 	   8,  -10, 	 -10,  -10, 	  -1,  -13
+.2byte   -1,  -19, 	   8,  -10, 	 -10,  -10, 	  -1,  -13
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -5,  -15, 	   6,  -11, 	  -7,  -10, 	   3,   -9
+.2byte   -7,  -15, 	  -1,  -12, 	  -4,   -7, 	   2,  -10
+.2byte   -8,  -15, 	   6,  -14, 	   0,   -9, 	   3,  -10
+.2byte   -8,  -15, 	   6,  -14, 	   0,   -9, 	   3,  -10
+.2byte   -8,  -15, 	   6,  -14, 	   0,   -9, 	   3,  -10
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -8,  -13, 	  -2,  -12, 	  -3,   -9, 	   2,   -9
+.2byte   -7,  -12, 	  -4,  -11, 	   1,   -7, 	   2,  -10
+.2byte   -9,  -14, 	   0,  -12, 	   2,   -9, 	   3,  -12
+.2byte   -9,  -14, 	   0,  -12, 	   2,   -9, 	   3,  -12
+.2byte   -9,  -14, 	   0,  -12, 	   2,   -9, 	   3,  -12
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -5,  -13, 	  -4,   -9, 	   2,   -8, 	   1,  -10
+.2byte   -3,  -12, 	  -6,   -9, 	   5,   -8, 	   1,   -9
+.2byte   -6,  -13, 	  -5,  -11, 	   5,  -11, 	  -1,  -10
+.2byte   -6,  -13, 	  -5,  -11, 	   5,  -11, 	  -1,  -10
+.2byte   -6,  -13, 	  -5,  -11, 	   5,  -11, 	  -1,  -10
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte   -5,  -10, 	  -5,   -7, 	   3,   -5, 	   0,   -8
+.2byte   -5,   -9, 	  -5,   -6, 	   3,   -3, 	   0,   -8
+.2byte    0,  -25, 	  -9,  -13, 	   9,  -13, 	   0,  -15
+.2byte    0,  -25, 	   6,  -18, 	  -8,  -12, 	  -3,  -13
+.2byte    2,  -23, 	   2,  -14, 	  -4,   -9, 	  -3,  -11
+.2byte    1,  -24, 	  -7,  -12, 	   6,  -11, 	  -2,  -10
+.2byte    0,  -26, 	  10,  -13, 	 -10,  -13, 	   0,  -11
+.2byte   -2,  -24, 	   6,  -12, 	  -7,  -11, 	   1,  -10
+.2byte   -3,  -23, 	  -3,  -14, 	   3,   -9, 	   2,  -11
+.2byte   -1,  -25, 	  -7,  -18, 	   7,  -12, 	   2,  -13
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte    3,  -16, 	  -3,  -11, 	   8,  -14, 	   1,  -12
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte    1,  -15, 	   1,  -11, 	  -5,  -15, 	  -2,  -11
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    3,  -17, 	   3,  -13, 	  -4,  -16, 	  -2,  -12
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    6,  -15, 	   1,  -13, 	   0,  -15, 	  -2,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte   -4,  -17, 	   3,  -16, 	  -8,  -14, 	   1,  -12
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -7,  -15, 	  -2,  -13, 	  -1,  -15, 	   1,  -10
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -4,  -19, 	  -4,  -15, 	   3,  -18, 	   1,  -14
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -2,  -15, 	  -2,  -11, 	   4,  -15, 	   1,  -11
+.2byte   -1,    6, 	  -7,    4, 	   5,    4, 	  -1,   -7
+.2byte  -11,    0, 	  -9,    0, 	  -6,    2, 	   0,   -7
+.2byte  -14,   -4, 	 -10,   -3, 	  -7,    0, 	   0,   -7
+.2byte  -11,   -6, 	  -3,   -8, 	  -9,   -3, 	   0,   -7
+.2byte   -1,  -10, 	   6,   -9, 	  -8,   -9, 	  -1,   -7
+.2byte   10,   -6, 	   2,   -8, 	   8,   -3, 	  -1,   -7
+.2byte   13,   -4, 	   9,   -3, 	   6,    0, 	  -1,   -7
+.2byte   10,    0, 	   8,    0, 	   5,    2, 	  -1,   -7
+.2byte   -1,  -12, 	 -10,  -12, 	   9,  -12, 	  -1,  -10
+.2byte    5,  -13, 	   4,  -11, 	  -6,  -11, 	   0,  -10
+.2byte    8,  -14, 	  -1,  -12, 	  -3,   -9, 	  -4,  -12
+.2byte    7,  -15, 	  -7,  -14, 	  -1,   -9, 	  -4,  -10
+.2byte   -1,  -19, 	   8,  -10, 	 -10,  -10, 	  -1,  -13
+.2byte   -8,  -15, 	   6,  -14, 	   0,   -9, 	   3,  -10
+.2byte   -9,  -14, 	   0,  -12, 	   2,   -9, 	   3,  -12
+.2byte   -6,  -13, 	  -5,  -11, 	   5,  -11, 	  -1,  -10
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte    2,  -16, 	  -4,  -11, 	   7,  -14, 	   0,  -12
+.2byte   -1,  -12, 	 -10,  -12, 	   9,  -12, 	  -1,  -10
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte    2,  -15, 	   2,  -11, 	  -4,  -15, 	  -1,  -11
+.2byte    4,  -13, 	   3,  -11, 	  -7,  -11, 	  -1,  -10
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    3,  -17, 	   3,  -13, 	  -4,  -16, 	  -2,  -12
+.2byte    7,  -14, 	  -2,  -12, 	  -4,   -9, 	  -5,  -12
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    6,  -15, 	   1,  -13, 	   0,  -15, 	  -2,  -10
+.2byte    6,  -15, 	  -8,  -14, 	  -2,   -9, 	  -5,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte   -4,  -16, 	   3,  -15, 	  -8,  -13, 	   1,  -11
+.2byte   -1,  -19, 	   8,  -10, 	 -10,  -10, 	  -1,  -13
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -7,  -15, 	  -2,  -13, 	  -1,  -15, 	   1,  -10
+.2byte   -7,  -15, 	   7,  -14, 	   1,   -9, 	   4,  -10
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -4,  -17, 	  -4,  -13, 	   3,  -16, 	   1,  -12
+.2byte   -8,  -14, 	   1,  -12, 	   3,   -9, 	   4,  -12
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -3,  -15, 	  -3,  -11, 	   3,  -15, 	   0,  -11
+.2byte   -5,  -13, 	  -4,  -11, 	   6,  -11, 	   0,  -10
+.2byte   -1,  -12, 	 -10,  -12, 	   9,  -12, 	  -1,  -10
+.2byte   -7,  -13, 	  -6,  -11, 	   4,  -11, 	  -2,  -10
+.2byte  -10,  -14, 	  -1,  -12, 	   1,   -9, 	   2,  -12
+.2byte   -9,  -15, 	   5,  -14, 	  -1,   -9, 	   2,  -10
+.2byte   -1,  -19, 	   8,  -10, 	 -10,  -10, 	  -1,  -13
+.2byte    8,  -15, 	  -6,  -14, 	   0,   -9, 	  -3,  -10
+.2byte    9,  -14, 	   0,  -12, 	  -2,   -9, 	  -3,  -12
+.2byte    6,  -13, 	   5,  -11, 	  -5,  -11, 	   1,  -10
+.2byte   -1,  -12, 	  -9,   -9, 	   7,   -9, 	  -1,  -10
+.2byte   -4,  -14, 	  -5,  -10, 	   4,   -8, 	   1,  -10
+.2byte   -7,  -14, 	  -3,  -13, 	  -1,   -9, 	   4,  -10
+.2byte   -6,  -16, 	   5,  -11, 	  -5,   -8, 	   2,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    5,  -16, 	  -6,  -11, 	   4,   -8, 	  -3,  -10
+.2byte    6,  -14, 	   2,  -13, 	   0,   -9, 	  -5,  -10
+.2byte    3,  -14, 	   4,  -10, 	  -5,   -8, 	  -2,  -10
+sTyphlosionAnimTable1:
+.4byte sTyphlosionAnims_1_1
+.4byte sTyphlosionAnims_1_2
+.4byte sTyphlosionAnims_1_3
+.4byte sTyphlosionAnims_1_4
+.4byte sTyphlosionAnims_1_5
+.4byte sTyphlosionAnims_1_6
+.4byte sTyphlosionAnims_1_7
+.4byte sTyphlosionAnims_1_8
+sTyphlosionAnimTable2:
+.4byte sTyphlosionAnims_2_1
+.4byte sTyphlosionAnims_2_2
+.4byte sTyphlosionAnims_2_3
+.4byte sTyphlosionAnims_2_4
+.4byte sTyphlosionAnims_2_5
+.4byte sTyphlosionAnims_2_6
+.4byte sTyphlosionAnims_2_7
+.4byte sTyphlosionAnims_2_8
+sTyphlosionAnimTable3:
+.4byte sTyphlosionAnims_3_1
+.4byte sTyphlosionAnims_3_2
+.4byte sTyphlosionAnims_3_3
+.4byte sTyphlosionAnims_3_4
+.4byte sTyphlosionAnims_3_5
+.4byte sTyphlosionAnims_3_6
+.4byte sTyphlosionAnims_3_7
+.4byte sTyphlosionAnims_3_8
+sTyphlosionAnimTable4:
+.4byte sTyphlosionAnims_4_1
+.4byte sTyphlosionAnims_4_2
+.4byte sTyphlosionAnims_4_3
+.4byte sTyphlosionAnims_4_4
+.4byte sTyphlosionAnims_4_5
+.4byte sTyphlosionAnims_4_6
+.4byte sTyphlosionAnims_4_7
+.4byte sTyphlosionAnims_4_8
+sTyphlosionAnimTable5:
+.4byte sTyphlosionAnims_5_1
+.4byte sTyphlosionAnims_5_2
+.4byte sTyphlosionAnims_5_3
+.4byte sTyphlosionAnims_5_4
+.4byte sTyphlosionAnims_5_5
+.4byte sTyphlosionAnims_5_6
+.4byte sTyphlosionAnims_5_7
+.4byte sTyphlosionAnims_5_8
+sTyphlosionAnimTable6:
+.4byte sTyphlosionAnims_6_1
+.4byte sTyphlosionAnims_6_1
+.4byte sTyphlosionAnims_6_1
+.4byte sTyphlosionAnims_6_1
+.4byte sTyphlosionAnims_6_1
+.4byte sTyphlosionAnims_6_1
+.4byte sTyphlosionAnims_6_1
+.4byte sTyphlosionAnims_6_1
+sTyphlosionAnimTable7:
+.4byte sTyphlosionAnims_7_1
+.4byte sTyphlosionAnims_7_2
+.4byte sTyphlosionAnims_7_3
+.4byte sTyphlosionAnims_7_4
+.4byte sTyphlosionAnims_7_5
+.4byte sTyphlosionAnims_7_6
+.4byte sTyphlosionAnims_7_7
+.4byte sTyphlosionAnims_7_8
+sTyphlosionAnimTable8:
+.4byte sTyphlosionAnims_8_1
+.4byte sTyphlosionAnims_8_2
+.4byte sTyphlosionAnims_8_3
+.4byte sTyphlosionAnims_8_4
+.4byte sTyphlosionAnims_8_5
+.4byte sTyphlosionAnims_8_6
+.4byte sTyphlosionAnims_8_7
+.4byte sTyphlosionAnims_8_8
+sTyphlosionAnimTable9:
+.4byte sTyphlosionAnims_9_1
+.4byte sTyphlosionAnims_9_2
+.4byte sTyphlosionAnims_9_3
+.4byte sTyphlosionAnims_9_4
+.4byte sTyphlosionAnims_9_5
+.4byte sTyphlosionAnims_9_6
+.4byte sTyphlosionAnims_9_7
+.4byte sTyphlosionAnims_9_8
+sTyphlosionAnimTable10:
+.4byte sTyphlosionAnims_10_1
+.4byte sTyphlosionAnims_10_2
+.4byte sTyphlosionAnims_10_3
+.4byte sTyphlosionAnims_10_4
+.4byte sTyphlosionAnims_10_5
+.4byte sTyphlosionAnims_10_6
+.4byte sTyphlosionAnims_10_7
+.4byte sTyphlosionAnims_10_8
+sTyphlosionAnimTable11:
+.4byte sTyphlosionAnims_11_1
+.4byte sTyphlosionAnims_11_2
+.4byte sTyphlosionAnims_11_3
+.4byte sTyphlosionAnims_11_4
+.4byte sTyphlosionAnims_11_5
+.4byte sTyphlosionAnims_11_6
+.4byte sTyphlosionAnims_11_7
+.4byte sTyphlosionAnims_11_8
+sTyphlosionAnimTable12:
+.4byte sTyphlosionAnims_12_1
+.4byte sTyphlosionAnims_12_2
+.4byte sTyphlosionAnims_12_3
+.4byte sTyphlosionAnims_12_4
+.4byte sTyphlosionAnims_12_5
+.4byte sTyphlosionAnims_12_6
+.4byte sTyphlosionAnims_12_7
+.4byte sTyphlosionAnims_12_8
+sTyphlosionAnimTable13:
+.4byte sTyphlosionAnims_13_1
+.4byte sTyphlosionAnims_13_2
+.4byte sTyphlosionAnims_13_3
+.4byte sTyphlosionAnims_13_4
+.4byte sTyphlosionAnims_13_5
+.4byte sTyphlosionAnims_13_6
+.4byte sTyphlosionAnims_13_7
+.4byte sTyphlosionAnims_13_8
+sAxAnimationsTyphlosion:
+.4byte sTyphlosionAnimTable1
+.4byte sTyphlosionAnimTable2
+.4byte sTyphlosionAnimTable3
+.4byte sTyphlosionAnimTable4
+.4byte sTyphlosionAnimTable5
+.4byte sTyphlosionAnimTable6
+.4byte sTyphlosionAnimTable7
+.4byte sTyphlosionAnimTable8
+.4byte sTyphlosionAnimTable9
+.4byte sTyphlosionAnimTable10
+.4byte sTyphlosionAnimTable11
+.4byte sTyphlosionAnimTable12
+.4byte sTyphlosionAnimTable13
+sAxSpritesTyphlosion:
+.4byte sTyphlosionSprites1
+.4byte sTyphlosionSprites2
+.4byte sTyphlosionSprites3
+.4byte sTyphlosionSprites4
+.4byte sTyphlosionSprites5
+.4byte sTyphlosionSprites6
+.4byte sTyphlosionSprites7
+.4byte sTyphlosionSprites8
+.4byte sTyphlosionSprites9
+.4byte sTyphlosionSprites10
+.4byte sTyphlosionSprites11
+.4byte sTyphlosionSprites12
+.4byte sTyphlosionSprites13
+.4byte sTyphlosionSprites14
+.4byte sTyphlosionSprites15
+.4byte sTyphlosionSprites16
+.4byte sTyphlosionSprites17
+.4byte sTyphlosionSprites18
+.4byte sTyphlosionSprites19
+.4byte sTyphlosionSprites20
+.4byte sTyphlosionSprites21
+.4byte sTyphlosionSprites22
+.4byte sTyphlosionSprites23
+.4byte sTyphlosionSprites24
+.4byte sTyphlosionSprites25
+.4byte sTyphlosionSprites26
+.4byte sTyphlosionSprites27
+.4byte sTyphlosionSprites28
+.4byte sTyphlosionSprites29
+.4byte sTyphlosionSprites30
+.4byte sTyphlosionSprites31
+.4byte sTyphlosionSprites32
+.4byte sTyphlosionSprites33
+.4byte sTyphlosionSprites34
+.4byte sTyphlosionSprites35
+.4byte sTyphlosionSprites36
+.4byte sTyphlosionSprites37
+.4byte sTyphlosionSprites38
+.4byte sTyphlosionSprites39
+.4byte sTyphlosionSprites40
+.4byte sTyphlosionSprites41
+.4byte sTyphlosionSprites42
+.4byte sTyphlosionSprites43
+.4byte sTyphlosionSprites44
+.4byte sTyphlosionSprites45
+.4byte sTyphlosionSprites46
+.4byte sTyphlosionSprites47
+.4byte sTyphlosionSprites48
+.4byte sTyphlosionSprites49
+.4byte sTyphlosionSprites50
+.4byte sTyphlosionSprites51
+.4byte sTyphlosionSprites52
+.4byte sTyphlosionSprites53
+.4byte sTyphlosionSprites54
+.4byte sTyphlosionSprites55
+.4byte sTyphlosionSprites56
+.4byte sTyphlosionSprites57
+.4byte sTyphlosionSprites58
+.4byte sTyphlosionSprites59
+.4byte sTyphlosionSprites60
+.4byte sTyphlosionSprites61
+.4byte sTyphlosionSprites62
+.4byte sTyphlosionSprites63
+.4byte sTyphlosionSprites64
+.4byte sTyphlosionSprites65
+.4byte sTyphlosionSprites66
+.4byte sTyphlosionSprites67
+.4byte sTyphlosionSprites68
+.4byte sTyphlosionSprites69
+.4byte sTyphlosionSprites70
+sAxMainTyphlosion:
+ax_main sAxPosesTyphlosion, sAxAnimationsTyphlosion, 13, sAxSpritesTyphlosion, sAxPositionsTyphlosion

--- a/data/ax/tyranitar.inc
+++ b/data/ax/tyranitar.inc
@@ -1,0 +1,2890 @@
+.global gAxTyranitar
+gAxTyranitar:
+ax_siro sAxMainTyranitar
+sTyranitarPose1:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose2:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose3:
+ax_pose 2, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose4:
+ax_pose 3, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose5:
+ax_pose 4, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose6:
+ax_pose 5, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose7:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose8:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose9:
+ax_pose 8, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose10:
+ax_pose 9, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose11:
+ax_pose 10, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose12:
+ax_pose 11, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose16:
+ax_pose 9, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose17:
+ax_pose 10, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose18:
+ax_pose 11, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose19:
+ax_pose 6, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose20:
+ax_pose 7, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose21:
+ax_pose 8, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose25:
+ax_pose 15, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose26:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose27:
+ax_pose 2, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose28:
+ax_pose 16, 0x01e4, 0x90ee, 0x3c00
+ax_pose_terminator
+sTyranitarPose29:
+ax_pose 4, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose30:
+ax_pose 5, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose31:
+ax_pose 17, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose32:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose33:
+ax_pose 8, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose34:
+ax_pose 18, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose35:
+ax_pose 10, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose36:
+ax_pose 11, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose37:
+ax_pose 19, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose39:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose40:
+ax_pose 18, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose41:
+ax_pose 10, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose42:
+ax_pose 11, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose43:
+ax_pose 17, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose44:
+ax_pose 7, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose45:
+ax_pose 8, 0x01e5, 0x80ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose46:
+ax_pose 16, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sTyranitarPose47:
+ax_pose 4, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose48:
+ax_pose 5, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose49:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose50:
+ax_pose 20, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose51:
+ax_pose 21, 0x01e8, 0x80ef, 0x3c00
+ax_pose 15, 0x01e5, 0x80f0, 0x3c10
+ax_pose_terminator
+sTyranitarPose52:
+ax_pose 15, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose53:
+ax_pose 3, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose54:
+ax_pose 22, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose55:
+ax_pose 23, 0x01e7, 0x90f4, 0x3c00
+ax_pose 16, 0x01e5, 0x90ef, 0x3c10
+ax_pose_terminator
+sTyranitarPose56:
+ax_pose 16, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose57:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose58:
+ax_pose 24, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose59:
+ax_pose 25, 0x01e6, 0x90f0, 0x3c00
+ax_pose 17, 0x01e5, 0x90ec, 0x3c10
+ax_pose_terminator
+sTyranitarPose60:
+ax_pose 17, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose61:
+ax_pose 9, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose62:
+ax_pose 26, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose63:
+ax_pose 27, 0x01df, 0x90f2, 0x3c00
+ax_pose 18, 0x01e5, 0x90ef, 0x3c10
+ax_pose_terminator
+sTyranitarPose64:
+ax_pose 18, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose65:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose66:
+ax_pose 28, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose67:
+ax_pose 29, 0x81e2, 0x80f2, 0x3c00
+ax_pose 19, 0x01e5, 0x80f0, 0x3c08
+ax_pose_terminator
+sTyranitarPose68:
+ax_pose 19, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose69:
+ax_pose 9, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose70:
+ax_pose 26, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose71:
+ax_pose 27, 0x01e5, 0x80f0, 0x3c00
+ax_pose 18, 0x01e5, 0x80f0, 0x3c10
+ax_pose_terminator
+sTyranitarPose72:
+ax_pose 18, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose73:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sTyranitarPose74:
+ax_pose 24, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sTyranitarPose75:
+ax_pose 25, 0x01e6, 0x80f0, 0x3c00
+ax_pose 17, 0x01e5, 0x80f4, 0x3c10
+ax_pose_terminator
+sTyranitarPose76:
+ax_pose 17, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sTyranitarPose77:
+ax_pose 3, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose78:
+ax_pose 22, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose79:
+ax_pose 23, 0x01e7, 0x80ec, 0x3c00
+ax_pose 16, 0x01e5, 0x80f1, 0x3c10
+ax_pose_terminator
+sTyranitarPose80:
+ax_pose 16, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose81:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose82:
+ax_pose 30, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose83:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose84:
+ax_pose 3, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose85:
+ax_pose 32, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose86:
+ax_pose 33, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose87:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose88:
+ax_pose 34, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose89:
+ax_pose 35, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose90:
+ax_pose 9, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose91:
+ax_pose 36, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose92:
+ax_pose 37, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose93:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose94:
+ax_pose 38, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose95:
+ax_pose 39, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose96:
+ax_pose 9, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose97:
+ax_pose 36, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose98:
+ax_pose 37, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose99:
+ax_pose 6, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose100:
+ax_pose 34, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose101:
+ax_pose 35, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose102:
+ax_pose 3, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose103:
+ax_pose 32, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose104:
+ax_pose 33, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose105:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose106:
+ax_pose 3, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose107:
+ax_pose 6, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose108:
+ax_pose 9, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose109:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose110:
+ax_pose 9, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose111:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose112:
+ax_pose 3, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose113:
+ax_pose 40, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose114:
+ax_pose 41, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sTyranitarPose115:
+ax_pose 42, 0x01e2, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose116:
+ax_pose 43, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose117:
+ax_pose 44, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose118:
+ax_pose 45, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sTyranitarPose119:
+ax_pose 46, 0x81e6, 0x4104, 0x3c00
+ax_pose 47, 0x0206, 0x00fc, 0x3c04
+ax_pose 48, 0x01ee, 0x010c, 0x3c05
+ax_pose 49, 0x81e6, 0x80f4, 0x3c06
+ax_pose_terminator
+sTyranitarPose120:
+ax_pose 45, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sTyranitarPose121:
+ax_pose 44, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sTyranitarPose122:
+ax_pose 43, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose123:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose124:
+ax_pose 1, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose125:
+ax_pose 2, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose126:
+ax_pose 3, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose127:
+ax_pose 4, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose128:
+ax_pose 5, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose129:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose130:
+ax_pose 7, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose131:
+ax_pose 8, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose132:
+ax_pose 9, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose133:
+ax_pose 10, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose134:
+ax_pose 11, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose135:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose136:
+ax_pose 13, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose137:
+ax_pose 14, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose138:
+ax_pose 9, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose139:
+ax_pose 10, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose140:
+ax_pose 11, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose141:
+ax_pose 6, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose142:
+ax_pose 7, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose143:
+ax_pose 8, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose144:
+ax_pose 3, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose145:
+ax_pose 4, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose146:
+ax_pose 5, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose147:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose148:
+ax_pose 33, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose149:
+ax_pose 35, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sTyranitarPose150:
+ax_pose 37, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose151:
+ax_pose 39, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose152:
+ax_pose 37, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose153:
+ax_pose 35, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose154:
+ax_pose 33, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose155:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose156:
+ax_pose 33, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose157:
+ax_pose 35, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose158:
+ax_pose 37, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose159:
+ax_pose 39, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose160:
+ax_pose 37, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose161:
+ax_pose 35, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sTyranitarPose162:
+ax_pose 33, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose163:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose164:
+ax_pose 30, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose165:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose166:
+ax_pose 3, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose167:
+ax_pose 32, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose168:
+ax_pose 33, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose169:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose170:
+ax_pose 34, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose171:
+ax_pose 35, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose172:
+ax_pose 9, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose173:
+ax_pose 36, 0x01e4, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose174:
+ax_pose 37, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose175:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose176:
+ax_pose 38, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose177:
+ax_pose 39, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose178:
+ax_pose 9, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose179:
+ax_pose 36, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose180:
+ax_pose 37, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose181:
+ax_pose 6, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose182:
+ax_pose 34, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose183:
+ax_pose 35, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose184:
+ax_pose 3, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose185:
+ax_pose 32, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose186:
+ax_pose 33, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sTyranitarPose187:
+ax_pose 31, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose188:
+ax_pose 33, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose189:
+ax_pose 35, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sTyranitarPose190:
+ax_pose 37, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose191:
+ax_pose 39, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose192:
+ax_pose 37, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose193:
+ax_pose 35, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose194:
+ax_pose 33, 0x01e5, 0x90ed, 0x3c00
+ax_pose_terminator
+sTyranitarPose195:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose196:
+ax_pose 3, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose197:
+ax_pose 6, 0x01e5, 0x80f3, 0x3c00
+ax_pose_terminator
+sTyranitarPose198:
+ax_pose 9, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose199:
+ax_pose 12, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose200:
+ax_pose 9, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose201:
+ax_pose 6, 0x01e5, 0x90ec, 0x3c00
+ax_pose_terminator
+sTyranitarPose202:
+ax_pose 3, 0x01e5, 0x90ef, 0x3c00
+ax_pose_terminator
+sTyranitarPose203:
+ax_pose 0, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose204:
+ax_pose 50, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose205:
+ax_pose 51, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose206:
+ax_pose 52, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sTyranitarPose207:
+ax_pose 53, 0x81eb, 0x80f0, 0x3c00
+ax_pose 54, 0x81eb, 0x4100, 0x3c08
+ax_pose 55, 0x81fb, 0x0108, 0x3c0c
+ax_pose 56, 0x0203, 0x0110, 0x3c0e
+ax_pose_terminator
+sTyranitarPose208:
+ax_pose 53, 0x81eb, 0x9100, 0x3c00
+ax_pose 54, 0x81eb, 0x50f8, 0x3c08
+ax_pose 55, 0x81fb, 0x10f0, 0x3c0c
+ax_pose 56, 0x0203, 0x10e8, 0x3c0e
+ax_pose_terminator
+.align 2
+sTyranitarAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 16, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 16, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 16, 0, 4, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 16, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 16, 0, 7, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 16, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 16, 0, 10, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 16, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 16, 0, 13, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 16, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 16, 0, 16, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 16, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 16, 0, 19, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 16, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 16, 0, 22, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 16, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 25, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -5, 0, -5,
+ax_anim 6, 0, 24, -1, -2, -1, -2,
+ax_anim 2, 2, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 19, 0, 19,
+ax_anim 2, 1, 24, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 19, 0, 19,
+ax_anim 2, 0, 24, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim 2, 0, 25, 0, 3, 0, 3,
+ax_anim_terminator
+sTyranitarAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 2, 0, 28, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -6, -5, -6, -5,
+ax_anim 6, 0, 27, -5, -5, -5, -5,
+ax_anim 2, 2, 27, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 19, 19, 19, 19,
+ax_anim 2, 1, 27, 20, 18, 20, 18,
+ax_anim 2, 0, 27, 19, 19, 19, 19,
+ax_anim 2, 0, 27, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim 2, 0, 28, 3, 3, 3, 3,
+ax_anim_terminator
+sTyranitarAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 2, 0, 31, -2, 0, -2, 0,
+ax_anim 2, 0, 32, -7, 0, -7, 0,
+ax_anim 6, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 2, 30, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 19, 0, 19, 0,
+ax_anim 2, 1, 30, 20, 0, 20, 0,
+ax_anim 2, 0, 30, 19, 0, 19, 0,
+ax_anim 2, 0, 30, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 6, 0, 6, 0,
+ax_anim 2, 0, 31, 3, 0, 3, 0,
+ax_anim_terminator
+sTyranitarAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 2, 0, 34, -2, 2, -2, 2,
+ax_anim 2, 0, 35, -6, 5, -6, 5,
+ax_anim 6, 0, 33, -6, 6, -6, 6,
+ax_anim 2, 2, 33, 10, -10, 10, -10,
+ax_anim 2, 0, 33, 19, -19, 19, -19,
+ax_anim 2, 1, 33, 20, -18, 20, -18,
+ax_anim 2, 0, 33, 19, -19, 19, -19,
+ax_anim 2, 0, 33, 20, -18, 20, -18,
+ax_anim 2, 0, 34, 6, -6, 6, -6,
+ax_anim 2, 0, 34, 3, -3, 3, -3,
+ax_anim_terminator
+sTyranitarAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 5, 0, 5,
+ax_anim 6, 0, 36, 2, 6, 2, 6,
+ax_anim 2, 2, 36, 1, -10, 1, -10,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 1, 36, 1, -19, 1, -19,
+ax_anim 2, 0, 36, 0, -19, 0, -19,
+ax_anim 2, 0, 36, 1, -19, 1, -19,
+ax_anim 2, 0, 37, 0, -6, 0, -6,
+ax_anim 2, 0, 37, 0, -3, 0, -3,
+ax_anim_terminator
+sTyranitarAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 2, 0, 40, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 6, 5, 6, 5,
+ax_anim 6, 0, 39, 6, 6, 6, 6,
+ax_anim 2, 2, 39, -10, -10, -10, -10,
+ax_anim 2, 0, 39, -19, -19, -19, -19,
+ax_anim 2, 1, 39, -20, -18, -20, -18,
+ax_anim 2, 0, 39, -19, -19, -19, -19,
+ax_anim 2, 0, 39, -20, -18, -20, -18,
+ax_anim 2, 0, 40, -6, -6, -6, -6,
+ax_anim 2, 0, 40, -3, -3, -3, -3,
+ax_anim_terminator
+sTyranitarAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 2, 0, 43, 2, 0, 2, 0,
+ax_anim 2, 0, 44, 7, 0, 7, 0,
+ax_anim 6, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 2, 42, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -19, 0, -19, 0,
+ax_anim 2, 1, 42, -20, 0, -20, 0,
+ax_anim 2, 0, 42, -19, 0, -19, 0,
+ax_anim 2, 0, 42, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -6, 0, -6, 0,
+ax_anim 2, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sTyranitarAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 2, 0, 46, 2, -2, 2, -2,
+ax_anim 2, 0, 47, 6, -5, 6, -5,
+ax_anim 6, 0, 45, 5, -5, 5, -5,
+ax_anim 2, 2, 45, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -19, 19, -19, 19,
+ax_anim 2, 1, 45, -20, 18, -20, 18,
+ax_anim 2, 0, 45, -19, 19, -19, 19,
+ax_anim 2, 0, 45, -20, 18, -20, 18,
+ax_anim 2, 0, 46, -6, 6, -6, 6,
+ax_anim 2, 0, 46, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -3, 0, -3,
+ax_anim 4, 0, 49, 0, -4, 0, -4,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 2, 49, 0, 5, 0, 5,
+ax_anim 2, 0, 50, 0, 16, 0, 16,
+ax_anim 2, 1, 51, -1, 16, -1, 16,
+ax_anim 2, 0, 51, 0, 16, 0, 16,
+ax_anim 2, 0, 51, -1, 16, -1, 16,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sTyranitarAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -3, -3, -3, -3,
+ax_anim 4, 0, 53, -4, -4, -4, -4,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 2, 53, 5, 5, 5, 5,
+ax_anim 2, 0, 54, 18, 17, 18, 17,
+ax_anim 2, 1, 55, 19, 16, 19, 16,
+ax_anim 2, 0, 55, 18, 17, 18, 17,
+ax_anim 2, 0, 55, 19, 16, 19, 16,
+ax_anim 2, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 3, 3, 3, 3,
+ax_anim_terminator
+sTyranitarAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 2, 0, 57, -3, 0, -3, 0,
+ax_anim 4, 0, 57, -4, 0, -4, 0,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 2, 57, 5, 0, 5, 0,
+ax_anim 2, 0, 58, 18, 0, 18, 0,
+ax_anim 2, 1, 59, 18, -1, 18, -1,
+ax_anim 2, 0, 59, 18, 0, 18, 0,
+ax_anim 2, 0, 59, 18, -1, 18, -1,
+ax_anim 2, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim_terminator
+sTyranitarAnims_3_4:
+ax_anim 2, 0, 60, -1, 1, -1, 1,
+ax_anim 2, 0, 61, -3, 3, -3, 3,
+ax_anim 4, 0, 61, -4, 4, -4, 4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 2, 61, 5, -5, 5, -5,
+ax_anim 2, 0, 62, 16, -18, 16, -18,
+ax_anim 2, 1, 63, 15, -19, 15, -19,
+ax_anim 2, 0, 63, 16, -18, 16, -18,
+ax_anim 2, 0, 63, 15, -19, 15, -19,
+ax_anim 2, 0, 60, 10, -11, 10, -11,
+ax_anim 2, 0, 60, 3, -4, 3, -4,
+ax_anim_terminator
+sTyranitarAnims_3_5:
+ax_anim 2, 0, 64, 0, 1, 0, 1,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 4, 0, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 2, 65, 0, -5, 0, -5,
+ax_anim 2, 0, 66, 0, -14, 0, -14,
+ax_anim 2, 1, 67, 1, -14, 1, -14,
+ax_anim 2, 0, 67, 0, -14, 0, -14,
+ax_anim 2, 0, 67, 1, -14, 1, -14,
+ax_anim 2, 0, 64, 0, -9, 0, -9,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sTyranitarAnims_3_6:
+ax_anim 2, 0, 68, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 3, 3, 3, 3,
+ax_anim 4, 0, 69, 4, 4, 4, 4,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 2, 69, -5, -5, -5, -5,
+ax_anim 2, 0, 70, -16, -18, -16, -18,
+ax_anim 2, 1, 71, -15, -19, -15, -19,
+ax_anim 2, 0, 71, -16, -18, -16, -18,
+ax_anim 2, 0, 71, -15, -19, -15, -19,
+ax_anim 2, 0, 68, -10, -11, -10, -11,
+ax_anim 2, 0, 68, -3, -4, -3, -4,
+ax_anim_terminator
+sTyranitarAnims_3_7:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 3, 0, 3, 0,
+ax_anim 4, 0, 73, 4, 0, 4, 0,
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 73, -5, 0, -5, 0,
+ax_anim 2, 0, 74, -18, 0, -18, 0,
+ax_anim 2, 1, 75, -18, -1, -18, -1,
+ax_anim 2, 0, 75, -18, 0, -18, 0,
+ax_anim 2, 0, 75, -18, -1, -18, -1,
+ax_anim 2, 0, 72, -10, 0, -10, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sTyranitarAnims_3_8:
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 2, 0, 77, 3, -3, 3, -3,
+ax_anim 4, 0, 77, 4, -4, 4, -4,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 77, -5, 5, -5, 5,
+ax_anim 2, 0, 78, -18, 17, -18, 17,
+ax_anim 2, 1, 79, -19, 16, -19, 16,
+ax_anim 2, 0, 79, -18, 17, -18, 17,
+ax_anim 2, 0, 79, -19, 16, -19, 16,
+ax_anim 2, 0, 76, -10, 10, -10, 10,
+ax_anim 2, 0, 76, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_4_1:
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim 3, 0, 81, 0, -3, 0, -3,
+ax_anim 6, 0, 81, 0, -4, 0, -4,
+ax_anim 1, 2, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 82, 0, 2, 0, 2,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 1, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim 2, 0, 82, 0, 3, 0, 3,
+ax_anim 2, 0, 82, 1, 3, 1, 3,
+ax_anim_terminator
+sTyranitarAnims_4_2:
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 3, 0, 84, -3, -3, -3, -3,
+ax_anim 6, 0, 84, -4, -4, -4, -4,
+ax_anim 1, 2, 85, -1, -1, -1, -1,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim 2, 0, 85, 3, 3, 3, 3,
+ax_anim 2, 0, 85, 4, 2, 4, 2,
+ax_anim 2, 0, 85, 3, 3, 3, 3,
+ax_anim 2, 1, 85, 4, 2, 4, 2,
+ax_anim 2, 0, 85, 3, 3, 3, 3,
+ax_anim 2, 0, 85, 4, 2, 4, 2,
+ax_anim 2, 0, 85, 3, 3, 3, 3,
+ax_anim 2, 0, 85, 4, 2, 4, 2,
+ax_anim_terminator
+sTyranitarAnims_4_3:
+ax_anim 2, 0, 86, -2, 0, -2, 0,
+ax_anim 3, 0, 87, -3, 0, -3, 0,
+ax_anim 6, 0, 87, -4, 0, -4, 0,
+ax_anim 1, 2, 88, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, -1, 3, -1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 1, 88, 3, -1, 3, -1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, -1, 3, -1,
+ax_anim 2, 0, 88, 3, 0, 3, 0,
+ax_anim 2, 0, 88, 3, -1, 3, -1,
+ax_anim_terminator
+sTyranitarAnims_4_4:
+ax_anim 2, 0, 89, -2, 2, -2, 2,
+ax_anim 3, 0, 90, -3, 3, -3, 3,
+ax_anim 6, 0, 90, -4, 4, -4, 4,
+ax_anim 1, 2, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 91, 2, -2, 2, -2,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 2, -4, 2, -4,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 1, 91, 2, -4, 2, -4,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 2, -4, 2, -4,
+ax_anim 2, 0, 91, 3, -3, 3, -3,
+ax_anim 2, 0, 91, 2, -4, 2, -4,
+ax_anim_terminator
+sTyranitarAnims_4_5:
+ax_anim 2, 0, 92, 0, 2, 0, 2,
+ax_anim 3, 0, 93, 0, 3, 0, 3,
+ax_anim 6, 0, 93, 0, 4, 0, 4,
+ax_anim 1, 2, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 94, 0, -3, 0, -3,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, 1, -5, 1, -5,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 1, 94, 1, -5, 1, -5,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, 1, -5, 1, -5,
+ax_anim 2, 0, 94, 0, -5, 0, -5,
+ax_anim 2, 0, 94, 1, -5, 1, -5,
+ax_anim_terminator
+sTyranitarAnims_4_6:
+ax_anim 2, 0, 95, 2, 2, 2, 2,
+ax_anim 3, 0, 96, 3, 3, 3, 3,
+ax_anim 6, 0, 96, 4, 4, 4, 4,
+ax_anim 1, 2, 97, 1, -1, 1, -1,
+ax_anim 2, 0, 97, -2, -2, -2, -2,
+ax_anim 2, 0, 97, -3, -3, -3, -3,
+ax_anim 2, 0, 97, -2, -4, -2, -4,
+ax_anim 2, 0, 97, -3, -3, -3, -3,
+ax_anim 2, 1, 97, -2, -4, -2, -4,
+ax_anim 2, 0, 97, -3, -3, -3, -3,
+ax_anim 2, 0, 97, -2, -4, -2, -4,
+ax_anim 2, 0, 97, -3, -3, -3, -3,
+ax_anim 2, 0, 97, -2, -4, -2, -4,
+ax_anim_terminator
+sTyranitarAnims_4_7:
+ax_anim 2, 0, 98, 2, 0, 2, 0,
+ax_anim 3, 0, 99, 3, 0, 3, 0,
+ax_anim 6, 0, 99, 4, 0, 4, 0,
+ax_anim 1, 2, 100, 1, 0, 1, 0,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, -1, -3, -1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 1, 100, -3, -1, -3, -1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, -1, -3, -1,
+ax_anim 2, 0, 100, -3, 0, -3, 0,
+ax_anim 2, 0, 100, -3, -1, -3, -1,
+ax_anim_terminator
+sTyranitarAnims_4_8:
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 3, 0, 102, 3, -3, 3, -3,
+ax_anim 6, 0, 102, 4, -4, 4, -4,
+ax_anim 1, 2, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 1, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim 2, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -4, 2, -4, 2,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_5_1:
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_5_2:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_5_3:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 2, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_5_4:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_5_6:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_5_7:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_5_8:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sTyranitarAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sTyranitarAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sTyranitarAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sTyranitarAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sTyranitarAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sTyranitarAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sTyranitarAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_8_1:
+ax_anim 14, 0, 122, 0, 0, 0, 0,
+ax_anim 24, 0, 123, 0, 0, 0, 0,
+ax_anim 14, 0, 122, 0, 0, 0, 0,
+ax_anim 24, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_8_2:
+ax_anim 14, 0, 125, 0, 0, 0, 0,
+ax_anim 24, 0, 126, 0, 0, 0, 0,
+ax_anim 14, 0, 125, 0, 0, 0, 0,
+ax_anim 24, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_8_3:
+ax_anim 14, 0, 128, 0, 0, 0, 0,
+ax_anim 24, 0, 129, 0, 0, 0, 0,
+ax_anim 14, 0, 128, 0, 0, 0, 0,
+ax_anim 24, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_8_4:
+ax_anim 14, 0, 131, 0, 0, 0, 0,
+ax_anim 24, 0, 132, 0, 0, 0, 0,
+ax_anim 14, 0, 131, 0, 0, 0, 0,
+ax_anim 24, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_8_5:
+ax_anim 14, 0, 134, 0, 0, 0, 0,
+ax_anim 24, 0, 135, 0, 0, 0, 0,
+ax_anim 14, 0, 134, 0, 0, 0, 0,
+ax_anim 24, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_8_6:
+ax_anim 14, 0, 137, 0, 0, 0, 0,
+ax_anim 24, 0, 138, 0, 0, 0, 0,
+ax_anim 14, 0, 137, 0, 0, 0, 0,
+ax_anim 24, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_8_7:
+ax_anim 14, 0, 140, 0, 0, 0, 0,
+ax_anim 24, 0, 141, 0, 0, 0, 0,
+ax_anim 14, 0, 140, 0, 0, 0, 0,
+ax_anim 24, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_8_8:
+ax_anim 14, 0, 143, 0, 0, 0, 0,
+ax_anim 24, 0, 144, 0, 0, 0, 0,
+ax_anim 14, 0, 143, 0, 0, 0, 0,
+ax_anim 24, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 4, 6, 4,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 17, 7, 17,
+ax_anim 3, 0, 150, 0, 21, 0, 21,
+ax_anim 2, 3, 151, -7, 17, -7, 17,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 4, -6, 4,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 24, 9, 24, 9,
+ax_anim 3, 0, 149, 20, 19, 20, 19,
+ax_anim 2, 3, 150, 11, 21, 11, 21,
+ax_anim 2, 0, 151, 0, 13, 0, 13,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -4, 3, -4,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 17, -4, 17, -4,
+ax_anim 3, 0, 148, 19, 1, 19, 1,
+ax_anim 2, 3, 149, 17, 5, 17, 5,
+ax_anim 2, 0, 150, 12, 7, 12, 7,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 11, -20, 11, -20,
+ax_anim 3, 0, 147, 16, -20, 16, -20,
+ax_anim 2, 3, 148, 18, -12, 18, -12,
+ax_anim 2, 0, 149, 16, -6, 16, -6,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -6, -4, -6, -4,
+ax_anim 2, 0, 152, -8, -10, -8, -10,
+ax_anim 2, 0, 153, -7, -18, -7, -18,
+ax_anim 3, 0, 146, 0, -22, 0, -22,
+ax_anim 2, 3, 147, 7, -18, 7, -18,
+ax_anim 2, 0, 148, 8, -8, 8, -8,
+ax_anim 1, 0, 149, 6, -4, 6, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -11, -20, -11, -20,
+ax_anim 3, 0, 153, -16, -20, -16, -20,
+ax_anim 2, 3, 152, -18, -12, -18, -12,
+ax_anim 2, 0, 151, -16, -6, -16, -6,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -4, -3, -4,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -17, -4, -17, -4,
+ax_anim 3, 0, 152, -19, 1, -19, 1,
+ax_anim 2, 3, 151, -17, 5, -17, 5,
+ax_anim 2, 0, 150, -12, 7, -12, 7,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -24, 9, -24, 9,
+ax_anim 3, 0, 151, -20, 19, -20, 19,
+ax_anim 2, 3, 150, -11, 21, -11, 21,
+ax_anim 2, 0, 149, 0, 13, 0, 13,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -23, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -23, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, 0,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_14_1:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_14_2:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_14_3:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_14_4:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_14_5:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_14_6:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_14_7:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_14_8:
+ax_anim 12, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 8, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyranitarAnims_15_1:
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_15_2:
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_15_3:
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_15_4:
+ax_anim 10, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_15_5:
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_15_6:
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_15_7:
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarAnims_15_8:
+ax_anim 10, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyranitarGfx1:
+.incbin "baserom.gba", 0x10136D4, 0x200
+sTyranitarSprites1:
+ax_sprite sTyranitarGfx1, 0x200
+ax_sprite_terminator
+sTyranitarGfx2:
+.incbin "baserom.gba", 0x10138E4, 0x200
+sTyranitarSprites2:
+ax_sprite sTyranitarGfx2, 0x200
+ax_sprite_terminator
+sTyranitarGfx3:
+.incbin "baserom.gba", 0x1013AF4, 0x200
+sTyranitarSprites3:
+ax_sprite sTyranitarGfx3, 0x200
+ax_sprite_terminator
+sTyranitarGfx4:
+.incbin "baserom.gba", 0x1013D04, 0x200
+sTyranitarSprites4:
+ax_sprite sTyranitarGfx4, 0x200
+ax_sprite_terminator
+sTyranitarGfx5:
+.incbin "baserom.gba", 0x1013F14, 0x200
+sTyranitarSprites5:
+ax_sprite sTyranitarGfx5, 0x200
+ax_sprite_terminator
+sTyranitarGfx6:
+.incbin "baserom.gba", 0x1014124, 0x200
+sTyranitarSprites6:
+ax_sprite sTyranitarGfx6, 0x200
+ax_sprite_terminator
+sTyranitarGfx7:
+.incbin "baserom.gba", 0x1014334, 0x200
+sTyranitarSprites7:
+ax_sprite sTyranitarGfx7, 0x200
+ax_sprite_terminator
+sTyranitarGfx8:
+.incbin "baserom.gba", 0x1014544, 0x200
+sTyranitarSprites8:
+ax_sprite sTyranitarGfx8, 0x200
+ax_sprite_terminator
+sTyranitarGfx9:
+.incbin "baserom.gba", 0x1014754, 0x200
+sTyranitarSprites9:
+ax_sprite sTyranitarGfx9, 0x200
+ax_sprite_terminator
+sTyranitarGfx10:
+.incbin "baserom.gba", 0x1014964, 0x200
+sTyranitarSprites10:
+ax_sprite sTyranitarGfx10, 0x200
+ax_sprite_terminator
+sTyranitarGfx11:
+.incbin "baserom.gba", 0x1014B74, 0x200
+sTyranitarSprites11:
+ax_sprite sTyranitarGfx11, 0x200
+ax_sprite_terminator
+sTyranitarGfx12:
+.incbin "baserom.gba", 0x1014D84, 0x200
+sTyranitarSprites12:
+ax_sprite sTyranitarGfx12, 0x200
+ax_sprite_terminator
+sTyranitarGfx13:
+.incbin "baserom.gba", 0x1014F94, 0x200
+sTyranitarSprites13:
+ax_sprite sTyranitarGfx13, 0x200
+ax_sprite_terminator
+sTyranitarGfx14:
+.incbin "baserom.gba", 0x10151A4, 0x200
+sTyranitarSprites14:
+ax_sprite sTyranitarGfx14, 0x200
+ax_sprite_terminator
+sTyranitarGfx15:
+.incbin "baserom.gba", 0x10153B4, 0x200
+sTyranitarSprites15:
+ax_sprite sTyranitarGfx15, 0x200
+ax_sprite_terminator
+sTyranitarGfx16:
+.incbin "baserom.gba", 0x10155C4, 0x60
+sTyranitarGfx16_1:
+.incbin "baserom.gba", 0x1015624, 0x100
+sTyranitarSprites16:
+ax_sprite 0, 0x80
+ax_sprite sTyranitarGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx16_1, 0x100
+ax_sprite_terminator
+sTyranitarGfx17:
+.incbin "baserom.gba", 0x101574C, 0x60
+sTyranitarGfx17_1:
+.incbin "baserom.gba", 0x10157AC, 0xE0
+sTyranitarSprites17:
+ax_sprite 0, 0x80
+ax_sprite sTyranitarGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx17_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx18:
+.incbin "baserom.gba", 0x10158BC, 0x40
+sTyranitarGfx18_1:
+.incbin "baserom.gba", 0x10158FC, 0x60
+sTyranitarGfx18_2:
+.incbin "baserom.gba", 0x101595C, 0xE0
+sTyranitarSprites18:
+ax_sprite sTyranitarGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx18_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx19:
+.incbin "baserom.gba", 0x1015A74, 0x60
+sTyranitarGfx19_1:
+.incbin "baserom.gba", 0x1015AD4, 0x60
+sTyranitarGfx19_2:
+.incbin "baserom.gba", 0x1015B34, 0xE0
+sTyranitarSprites19:
+ax_sprite sTyranitarGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx19_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx20:
+.incbin "baserom.gba", 0x1015C4C, 0x40
+sTyranitarGfx20_1:
+.incbin "baserom.gba", 0x1015C8C, 0x60
+sTyranitarGfx20_2:
+.incbin "baserom.gba", 0x1015CEC, 0x100
+sTyranitarSprites20:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx20_2, 0x100
+ax_sprite_terminator
+sTyranitarGfx21:
+.incbin "baserom.gba", 0x1015E24, 0x40
+sTyranitarGfx21_1:
+.incbin "baserom.gba", 0x1015E64, 0xE0
+sTyranitarGfx21_2:
+.incbin "baserom.gba", 0x1015F44, 0x80
+sTyranitarSprites21:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx21_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx21_2, 0x80
+ax_sprite_terminator
+sTyranitarGfx22:
+.incbin "baserom.gba", 0x1015FFC, 0x40
+sTyranitarGfx22_1:
+.incbin "baserom.gba", 0x101603C, 0x40
+sTyranitarGfx22_2:
+.incbin "baserom.gba", 0x101607C, 0x40
+sTyranitarGfx22_3:
+.incbin "baserom.gba", 0x10160BC, 0x60
+sTyranitarSprites22:
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx22, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx22_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx22_3, 0x60
+ax_sprite_terminator
+sTyranitarGfx23:
+.incbin "baserom.gba", 0x1016164, 0x40
+sTyranitarGfx23_1:
+.incbin "baserom.gba", 0x10161A4, 0x180
+sTyranitarSprites23:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx23_1, 0x180
+ax_sprite_terminator
+sTyranitarGfx24:
+.incbin "baserom.gba", 0x101634C, 0x20
+sTyranitarGfx24_1:
+.incbin "baserom.gba", 0x101636C, 0x40
+sTyranitarGfx24_2:
+.incbin "baserom.gba", 0x10163AC, 0xC0
+sTyranitarSprites24:
+ax_sprite 0, 0x60
+ax_sprite sTyranitarGfx24, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx24_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx25:
+.incbin "baserom.gba", 0x10164AC, 0x40
+sTyranitarGfx25_1:
+.incbin "baserom.gba", 0x10164EC, 0x60
+sTyranitarGfx25_2:
+.incbin "baserom.gba", 0x101654C, 0xE0
+sTyranitarSprites25:
+ax_sprite sTyranitarGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx25_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx26:
+.incbin "baserom.gba", 0x1016664, 0xC0
+sTyranitarGfx26_1:
+.incbin "baserom.gba", 0x1016724, 0x40
+sTyranitarSprites26:
+ax_sprite 0, 0x80
+ax_sprite sTyranitarGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx26_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyranitarGfx27:
+.incbin "baserom.gba", 0x1016794, 0x40
+sTyranitarGfx27_1:
+.incbin "baserom.gba", 0x10167D4, 0x60
+sTyranitarGfx27_2:
+.incbin "baserom.gba", 0x1016834, 0x80
+sTyranitarGfx27_3:
+.incbin "baserom.gba", 0x10168B4, 0x60
+sTyranitarSprites27:
+ax_sprite sTyranitarGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx27_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx27_3, 0x60
+ax_sprite_terminator
+sTyranitarGfx28:
+.incbin "baserom.gba", 0x1016954, 0x20
+sTyranitarGfx28_1:
+.incbin "baserom.gba", 0x1016974, 0x40
+sTyranitarGfx28_2:
+.incbin "baserom.gba", 0x10169B4, 0x60
+sTyranitarSprites28:
+ax_sprite sTyranitarGfx28, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTyranitarGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTyranitarGfx29:
+.incbin "baserom.gba", 0x1016A4C, 0x40
+sTyranitarGfx29_1:
+.incbin "baserom.gba", 0x1016A8C, 0x60
+sTyranitarGfx29_2:
+.incbin "baserom.gba", 0x1016AEC, 0x60
+sTyranitarGfx29_3:
+.incbin "baserom.gba", 0x1016B4C, 0x80
+sTyranitarSprites29:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx29_3, 0x80
+ax_sprite_terminator
+sTyranitarGfx30:
+.incbin "baserom.gba", 0x1016C14, 0xA0
+sTyranitarGfx30_1:
+.incbin "baserom.gba", 0x1016CB4, 0x20
+sTyranitarSprites30:
+ax_sprite sTyranitarGfx30, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx30_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx31:
+.incbin "baserom.gba", 0x1016CFC, 0x40
+sTyranitarGfx31_1:
+.incbin "baserom.gba", 0x1016D3C, 0x60
+sTyranitarGfx31_2:
+.incbin "baserom.gba", 0x1016D9C, 0x100
+sTyranitarSprites31:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx31_2, 0x100
+ax_sprite_terminator
+sTyranitarGfx32:
+.incbin "baserom.gba", 0x1016ED4, 0x40
+sTyranitarGfx32_1:
+.incbin "baserom.gba", 0x1016F14, 0x180
+sTyranitarSprites32:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx32_1, 0x180
+ax_sprite_terminator
+sTyranitarGfx33:
+.incbin "baserom.gba", 0x10170BC, 0x40
+sTyranitarGfx33_1:
+.incbin "baserom.gba", 0x10170FC, 0x160
+sTyranitarSprites33:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx33_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx34:
+.incbin "baserom.gba", 0x101728C, 0x20
+sTyranitarGfx34_1:
+.incbin "baserom.gba", 0x10172AC, 0x180
+sTyranitarSprites34:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx34, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx34_1, 0x180
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx35:
+.incbin "baserom.gba", 0x101745C, 0x100
+sTyranitarGfx35_1:
+.incbin "baserom.gba", 0x101755C, 0x60
+sTyranitarGfx35_2:
+.incbin "baserom.gba", 0x10175BC, 0x40
+sTyranitarSprites35:
+ax_sprite sTyranitarGfx35, 0x100
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx35_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx36:
+.incbin "baserom.gba", 0x1017634, 0x160
+sTyranitarSprites36:
+ax_sprite 0, 0x80
+ax_sprite sTyranitarGfx36, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx37:
+.incbin "baserom.gba", 0x10177B4, 0x40
+sTyranitarGfx37_1:
+.incbin "baserom.gba", 0x10177F4, 0x60
+sTyranitarGfx37_2:
+.incbin "baserom.gba", 0x1017854, 0x100
+sTyranitarSprites37:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx37_2, 0x100
+ax_sprite_terminator
+sTyranitarGfx38:
+.incbin "baserom.gba", 0x101798C, 0x40
+sTyranitarGfx38_1:
+.incbin "baserom.gba", 0x10179CC, 0x160
+sTyranitarSprites38:
+ax_sprite sTyranitarGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyranitarGfx38_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyranitarGfx39:
+.incbin "baserom.gba", 0x1017B54, 0x60
+sTyranitarGfx39_1:
+.incbin "baserom.gba", 0x1017BB4, 0x60
+sTyranitarGfx39_2:
+.incbin "baserom.gba", 0x1017C14, 0x100
+sTyranitarSprites39:
+ax_sprite sTyranitarGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx39_2, 0x100
+ax_sprite_terminator
+sTyranitarGfx40:
+.incbin "baserom.gba", 0x1017D44, 0x40
+sTyranitarGfx40_1:
+.incbin "baserom.gba", 0x1017D84, 0x180
+sTyranitarSprites40:
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyranitarGfx40_1, 0x180
+ax_sprite_terminator
+sTyranitarGfx41:
+.incbin "baserom.gba", 0x1017F2C, 0x200
+sTyranitarSprites41:
+ax_sprite sTyranitarGfx41, 0x200
+ax_sprite_terminator
+sTyranitarGfx42:
+.incbin "baserom.gba", 0x101813C, 0x200
+sTyranitarSprites42:
+ax_sprite sTyranitarGfx42, 0x200
+ax_sprite_terminator
+sTyranitarGfx43:
+.incbin "baserom.gba", 0x101834C, 0x200
+sTyranitarSprites43:
+ax_sprite sTyranitarGfx43, 0x200
+ax_sprite_terminator
+sTyranitarGfx44:
+.incbin "baserom.gba", 0x101855C, 0x200
+sTyranitarSprites44:
+ax_sprite sTyranitarGfx44, 0x200
+ax_sprite_terminator
+sTyranitarGfx45:
+.incbin "baserom.gba", 0x101876C, 0x200
+sTyranitarSprites45:
+ax_sprite sTyranitarGfx45, 0x200
+ax_sprite_terminator
+sTyranitarGfx46:
+.incbin "baserom.gba", 0x101897C, 0x200
+sTyranitarSprites46:
+ax_sprite sTyranitarGfx46, 0x200
+ax_sprite_terminator
+sTyranitarGfx47:
+.incbin "baserom.gba", 0x1018B8C, 0x80
+sTyranitarSprites47:
+ax_sprite sTyranitarGfx47, 0x80
+ax_sprite_terminator
+sTyranitarGfx48:
+.incbin "baserom.gba", 0x1018C1C, 0x20
+sTyranitarSprites48:
+ax_sprite sTyranitarGfx48, 0x20
+ax_sprite_terminator
+sTyranitarGfx49:
+.incbin "baserom.gba", 0x1018C4C, 0x20
+sTyranitarSprites49:
+ax_sprite sTyranitarGfx49, 0x20
+ax_sprite_terminator
+sTyranitarGfx50:
+.incbin "baserom.gba", 0x1018C7C, 0x100
+sTyranitarSprites50:
+ax_sprite sTyranitarGfx50, 0x100
+ax_sprite_terminator
+sTyranitarGfx51:
+.incbin "baserom.gba", 0x1018D8C, 0x200
+sTyranitarSprites51:
+ax_sprite sTyranitarGfx51, 0x200
+ax_sprite_terminator
+sTyranitarGfx52:
+.incbin "baserom.gba", 0x1018F9C, 0x200
+sTyranitarSprites52:
+ax_sprite sTyranitarGfx52, 0x200
+ax_sprite_terminator
+sTyranitarGfx53:
+.incbin "baserom.gba", 0x10191AC, 0x200
+sTyranitarSprites53:
+ax_sprite sTyranitarGfx53, 0x200
+ax_sprite_terminator
+sTyranitarGfx54:
+.incbin "baserom.gba", 0x10193BC, 0x100
+sTyranitarSprites54:
+ax_sprite sTyranitarGfx54, 0x100
+ax_sprite_terminator
+sTyranitarGfx55:
+.incbin "baserom.gba", 0x10194CC, 0x80
+sTyranitarSprites55:
+ax_sprite sTyranitarGfx55, 0x80
+ax_sprite_terminator
+sTyranitarGfx56:
+.incbin "baserom.gba", 0x101955C, 0x40
+sTyranitarSprites56:
+ax_sprite sTyranitarGfx56, 0x40
+ax_sprite_terminator
+sTyranitarGfx57:
+.incbin "baserom.gba", 0x10195AC, 0x20
+sTyranitarSprites57:
+ax_sprite sTyranitarGfx57, 0x20
+ax_sprite_terminator
+sAxPosesTyranitar:
+.4byte sTyranitarPose1
+.4byte sTyranitarPose2
+.4byte sTyranitarPose3
+.4byte sTyranitarPose4
+.4byte sTyranitarPose5
+.4byte sTyranitarPose6
+.4byte sTyranitarPose7
+.4byte sTyranitarPose8
+.4byte sTyranitarPose9
+.4byte sTyranitarPose10
+.4byte sTyranitarPose11
+.4byte sTyranitarPose12
+.4byte sTyranitarPose13
+.4byte sTyranitarPose14
+.4byte sTyranitarPose15
+.4byte sTyranitarPose16
+.4byte sTyranitarPose17
+.4byte sTyranitarPose18
+.4byte sTyranitarPose19
+.4byte sTyranitarPose20
+.4byte sTyranitarPose21
+.4byte sTyranitarPose22
+.4byte sTyranitarPose23
+.4byte sTyranitarPose24
+.4byte sTyranitarPose25
+.4byte sTyranitarPose26
+.4byte sTyranitarPose27
+.4byte sTyranitarPose28
+.4byte sTyranitarPose29
+.4byte sTyranitarPose30
+.4byte sTyranitarPose31
+.4byte sTyranitarPose32
+.4byte sTyranitarPose33
+.4byte sTyranitarPose34
+.4byte sTyranitarPose35
+.4byte sTyranitarPose36
+.4byte sTyranitarPose37
+.4byte sTyranitarPose38
+.4byte sTyranitarPose39
+.4byte sTyranitarPose40
+.4byte sTyranitarPose41
+.4byte sTyranitarPose42
+.4byte sTyranitarPose43
+.4byte sTyranitarPose44
+.4byte sTyranitarPose45
+.4byte sTyranitarPose46
+.4byte sTyranitarPose47
+.4byte sTyranitarPose48
+.4byte sTyranitarPose49
+.4byte sTyranitarPose50
+.4byte sTyranitarPose51
+.4byte sTyranitarPose52
+.4byte sTyranitarPose53
+.4byte sTyranitarPose54
+.4byte sTyranitarPose55
+.4byte sTyranitarPose56
+.4byte sTyranitarPose57
+.4byte sTyranitarPose58
+.4byte sTyranitarPose59
+.4byte sTyranitarPose60
+.4byte sTyranitarPose61
+.4byte sTyranitarPose62
+.4byte sTyranitarPose63
+.4byte sTyranitarPose64
+.4byte sTyranitarPose65
+.4byte sTyranitarPose66
+.4byte sTyranitarPose67
+.4byte sTyranitarPose68
+.4byte sTyranitarPose69
+.4byte sTyranitarPose70
+.4byte sTyranitarPose71
+.4byte sTyranitarPose72
+.4byte sTyranitarPose73
+.4byte sTyranitarPose74
+.4byte sTyranitarPose75
+.4byte sTyranitarPose76
+.4byte sTyranitarPose77
+.4byte sTyranitarPose78
+.4byte sTyranitarPose79
+.4byte sTyranitarPose80
+.4byte sTyranitarPose81
+.4byte sTyranitarPose82
+.4byte sTyranitarPose83
+.4byte sTyranitarPose84
+.4byte sTyranitarPose85
+.4byte sTyranitarPose86
+.4byte sTyranitarPose87
+.4byte sTyranitarPose88
+.4byte sTyranitarPose89
+.4byte sTyranitarPose90
+.4byte sTyranitarPose91
+.4byte sTyranitarPose92
+.4byte sTyranitarPose93
+.4byte sTyranitarPose94
+.4byte sTyranitarPose95
+.4byte sTyranitarPose96
+.4byte sTyranitarPose97
+.4byte sTyranitarPose98
+.4byte sTyranitarPose99
+.4byte sTyranitarPose100
+.4byte sTyranitarPose101
+.4byte sTyranitarPose102
+.4byte sTyranitarPose103
+.4byte sTyranitarPose104
+.4byte sTyranitarPose105
+.4byte sTyranitarPose106
+.4byte sTyranitarPose107
+.4byte sTyranitarPose108
+.4byte sTyranitarPose109
+.4byte sTyranitarPose110
+.4byte sTyranitarPose111
+.4byte sTyranitarPose112
+.4byte sTyranitarPose113
+.4byte sTyranitarPose114
+.4byte sTyranitarPose115
+.4byte sTyranitarPose116
+.4byte sTyranitarPose117
+.4byte sTyranitarPose118
+.4byte sTyranitarPose119
+.4byte sTyranitarPose120
+.4byte sTyranitarPose121
+.4byte sTyranitarPose122
+.4byte sTyranitarPose123
+.4byte sTyranitarPose124
+.4byte sTyranitarPose125
+.4byte sTyranitarPose126
+.4byte sTyranitarPose127
+.4byte sTyranitarPose128
+.4byte sTyranitarPose129
+.4byte sTyranitarPose130
+.4byte sTyranitarPose131
+.4byte sTyranitarPose132
+.4byte sTyranitarPose133
+.4byte sTyranitarPose134
+.4byte sTyranitarPose135
+.4byte sTyranitarPose136
+.4byte sTyranitarPose137
+.4byte sTyranitarPose138
+.4byte sTyranitarPose139
+.4byte sTyranitarPose140
+.4byte sTyranitarPose141
+.4byte sTyranitarPose142
+.4byte sTyranitarPose143
+.4byte sTyranitarPose144
+.4byte sTyranitarPose145
+.4byte sTyranitarPose146
+.4byte sTyranitarPose147
+.4byte sTyranitarPose148
+.4byte sTyranitarPose149
+.4byte sTyranitarPose150
+.4byte sTyranitarPose151
+.4byte sTyranitarPose152
+.4byte sTyranitarPose153
+.4byte sTyranitarPose154
+.4byte sTyranitarPose155
+.4byte sTyranitarPose156
+.4byte sTyranitarPose157
+.4byte sTyranitarPose158
+.4byte sTyranitarPose159
+.4byte sTyranitarPose160
+.4byte sTyranitarPose161
+.4byte sTyranitarPose162
+.4byte sTyranitarPose163
+.4byte sTyranitarPose164
+.4byte sTyranitarPose165
+.4byte sTyranitarPose166
+.4byte sTyranitarPose167
+.4byte sTyranitarPose168
+.4byte sTyranitarPose169
+.4byte sTyranitarPose170
+.4byte sTyranitarPose171
+.4byte sTyranitarPose172
+.4byte sTyranitarPose173
+.4byte sTyranitarPose174
+.4byte sTyranitarPose175
+.4byte sTyranitarPose176
+.4byte sTyranitarPose177
+.4byte sTyranitarPose178
+.4byte sTyranitarPose179
+.4byte sTyranitarPose180
+.4byte sTyranitarPose181
+.4byte sTyranitarPose182
+.4byte sTyranitarPose183
+.4byte sTyranitarPose184
+.4byte sTyranitarPose185
+.4byte sTyranitarPose186
+.4byte sTyranitarPose187
+.4byte sTyranitarPose188
+.4byte sTyranitarPose189
+.4byte sTyranitarPose190
+.4byte sTyranitarPose191
+.4byte sTyranitarPose192
+.4byte sTyranitarPose193
+.4byte sTyranitarPose194
+.4byte sTyranitarPose195
+.4byte sTyranitarPose196
+.4byte sTyranitarPose197
+.4byte sTyranitarPose198
+.4byte sTyranitarPose199
+.4byte sTyranitarPose200
+.4byte sTyranitarPose201
+.4byte sTyranitarPose202
+.4byte sTyranitarPose203
+.4byte sTyranitarPose204
+.4byte sTyranitarPose205
+.4byte sTyranitarPose206
+.4byte sTyranitarPose207
+.4byte sTyranitarPose208
+sAxPositionsTyranitar:
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -15, 	 -10,   -9, 	   7,   -8, 	  -1,   -9
+.2byte   -1,  -15, 	  -9,   -8, 	   8,   -9, 	  -1,   -9
+.2byte    3,  -16, 	   8,  -12, 	  -6,   -8, 	   1,  -10
+.2byte    3,  -15, 	   7,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte    3,  -15, 	   9,  -10, 	  -7,   -8, 	   0,   -9
+.2byte    5,  -16, 	   2,   -9, 	   0,   -7, 	  -1,  -10
+.2byte    5,  -15, 	  -2,   -7, 	   3,   -8, 	  -2,  -11
+.2byte    5,  -15, 	   2,   -8, 	  -2,   -7, 	  -2,  -10
+.2byte    5,  -18, 	  -5,  -11, 	   9,   -9, 	  -1,  -11
+.2byte    5,  -17, 	  -4,  -11, 	   9,  -10, 	   0,  -11
+.2byte    5,  -17, 	  -3,  -11, 	   7,   -8, 	  -4,  -11
+.2byte   -1,  -20, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte    0,  -19, 	   8,   -9, 	 -11,  -12, 	  -2,  -11
+.2byte   -2,  -18, 	   9,  -12, 	 -10,   -9, 	   0,  -10
+.2byte   -7,  -18, 	   3,  -11, 	 -11,   -9, 	  -1,  -11
+.2byte   -7,  -17, 	   2,  -11, 	 -11,  -10, 	  -2,  -11
+.2byte   -7,  -17, 	   1,  -11, 	  -9,   -8, 	   2,  -11
+.2byte   -7,  -16, 	  -4,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte   -7,  -15, 	   0,   -7, 	  -5,   -8, 	   0,  -11
+.2byte   -7,  -15, 	  -4,   -8, 	   0,   -7, 	   0,  -10
+.2byte   -5,  -16, 	 -10,  -12, 	   4,   -8, 	  -3,  -10
+.2byte   -5,  -15, 	  -9,  -11, 	   1,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	 -11,  -10, 	   5,   -8, 	  -2,   -9
+.2byte   -6,   -7, 	  -4,  -18, 	  -2,    1, 	   0,   -7
+.2byte   -1,  -15, 	 -10,   -9, 	   7,   -8, 	  -1,   -9
+.2byte   -1,  -15, 	  -9,   -8, 	   8,   -9, 	  -1,   -9
+.2byte    7,   -6, 	   5,  -14, 	   4,    1, 	  -1,   -6
+.2byte    3,  -15, 	   7,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte    3,  -15, 	   9,  -10, 	  -7,   -8, 	   0,   -9
+.2byte    9,  -10, 	   0,  -17, 	   6,   -3, 	  -3,   -8
+.2byte    5,  -15, 	  -2,   -7, 	   3,   -8, 	  -2,  -11
+.2byte    5,  -15, 	   2,   -8, 	  -2,   -7, 	  -2,  -10
+.2byte    2,  -18, 	  -9,  -10, 	   3,   -8, 	   0,  -12
+.2byte    5,  -17, 	  -4,  -11, 	   9,  -10, 	   0,  -11
+.2byte    5,  -17, 	  -3,  -11, 	   7,   -8, 	  -4,  -11
+.2byte    5,  -15, 	   6,   -6, 	  -5,   -8, 	  -1,  -11
+.2byte    0,  -19, 	   8,   -9, 	 -11,  -12, 	  -2,  -11
+.2byte   -2,  -18, 	   9,  -12, 	 -10,   -9, 	   0,  -10
+.2byte   -3,  -18, 	   8,  -10, 	  -4,   -8, 	  -1,  -12
+.2byte   -6,  -17, 	   3,  -11, 	 -10,  -10, 	  -1,  -11
+.2byte   -6,  -17, 	   2,  -11, 	  -8,   -8, 	   3,  -11
+.2byte  -18,  -10, 	  -9,  -17, 	 -15,   -3, 	  -6,   -8
+.2byte  -14,  -15, 	  -7,   -7, 	 -12,   -8, 	  -7,  -11
+.2byte  -14,  -15, 	 -11,   -8, 	  -7,   -7, 	  -7,  -10
+.2byte   -8,   -6, 	  -6,  -14, 	  -5,    1, 	   0,   -6
+.2byte   -4,  -15, 	  -8,  -11, 	   2,   -7, 	   0,   -9
+.2byte   -4,  -15, 	 -10,  -10, 	   6,   -8, 	  -1,   -9
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    5,  -16, 	  -6,   -3, 	   7,  -17, 	  -2,  -10
+.2byte   -6,   -5, 	  -4,  -16, 	  -2,    3, 	   0,   -5
+.2byte   -6,   -5, 	  -4,  -16, 	  -2,    3, 	   0,   -5
+.2byte    3,  -16, 	   8,  -12, 	  -6,   -8, 	   1,  -10
+.2byte   -3,  -18, 	   8,   -6, 	  -7,  -18, 	   0,  -11
+.2byte    8,   -5, 	   6,  -13, 	   5,    2, 	   0,   -5
+.2byte    8,   -5, 	   6,  -13, 	   5,    2, 	   0,   -5
+.2byte    5,  -16, 	   2,   -9, 	   0,   -7, 	  -1,  -10
+.2byte    7,  -17, 	   9,   -8, 	  -5,  -16, 	   2,   -8
+.2byte    9,  -10, 	   0,  -17, 	   6,   -3, 	  -3,   -8
+.2byte    9,  -10, 	   0,  -17, 	   6,   -3, 	  -3,   -8
+.2byte    5,  -18, 	  -5,  -11, 	   9,   -9, 	  -1,  -11
+.2byte    8,  -19, 	  -1,   -8, 	   1,  -15, 	   1,   -9
+.2byte    2,  -18, 	  -9,  -10, 	   3,   -8, 	   0,  -12
+.2byte    2,  -18, 	  -9,  -10, 	   3,   -8, 	   0,  -12
+.2byte   -1,  -20, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -7,  -18, 	   0,   -8, 	  -8,  -14, 	  -1,  -11
+.2byte    5,  -16, 	   6,   -7, 	  -5,   -9, 	  -1,  -12
+.2byte    5,  -16, 	   6,   -7, 	  -5,   -9, 	  -1,  -12
+.2byte   -7,  -18, 	   3,  -11, 	 -11,   -9, 	  -1,  -11
+.2byte  -10,  -19, 	  -1,   -8, 	  -3,  -15, 	  -3,   -9
+.2byte   -4,  -18, 	   7,  -10, 	  -5,   -8, 	  -2,  -12
+.2byte   -4,  -18, 	   7,  -10, 	  -5,   -8, 	  -2,  -12
+.2byte   -6,  -16, 	  -3,   -9, 	  -1,   -7, 	   0,  -10
+.2byte   -8,  -17, 	 -10,   -8, 	   4,  -16, 	  -3,   -8
+.2byte  -10,  -10, 	  -1,  -17, 	  -7,   -3, 	   2,   -8
+.2byte  -10,  -10, 	  -1,  -17, 	  -7,   -3, 	   2,   -8
+.2byte   -4,  -16, 	  -9,  -12, 	   5,   -8, 	  -2,  -10
+.2byte    2,  -18, 	  -9,   -6, 	   6,  -18, 	  -1,  -11
+.2byte   -9,   -5, 	  -7,  -13, 	  -6,    2, 	  -1,   -5
+.2byte   -9,   -5, 	  -7,  -13, 	  -6,    2, 	  -1,   -5
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    4,  -20, 	 -10,  -17, 	   7,  -10, 	  -1,  -11
+.2byte   -1,   -6, 	 -10,   -5, 	   8,   -5, 	   0,   -8
+.2byte    3,  -16, 	   8,  -12, 	  -6,   -8, 	   1,  -10
+.2byte   -6,  -20, 	   8,  -18, 	 -10,   -9, 	  -1,  -12
+.2byte    6,   -9, 	  10,   -7, 	  -4,   -4, 	   2,   -8
+.2byte    5,  -16, 	   2,   -9, 	   0,   -7, 	  -1,  -10
+.2byte   -5,  -17, 	   6,  -20, 	  -4,   -5, 	  -1,  -11
+.2byte   10,   -9, 	   6,   -6, 	   5,   -3, 	   1,   -6
+.2byte    5,  -18, 	  -5,  -11, 	   9,   -9, 	  -1,  -11
+.2byte    6,  -16, 	  -5,  -20, 	   8,   -4, 	   0,  -10
+.2byte   10,  -16, 	   4,  -12, 	  10,   -6, 	   2,  -11
+.2byte   -1,  -20, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -7,  -16, 	   6,  -14, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	   9,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte   -7,  -18, 	   3,  -11, 	 -11,   -9, 	  -1,  -11
+.2byte   -8,  -16, 	   3,  -20, 	 -10,   -4, 	  -2,  -10
+.2byte  -12,  -16, 	  -6,  -12, 	 -12,   -6, 	  -4,  -11
+.2byte   -7,  -16, 	  -4,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte    3,  -17, 	  -8,  -20, 	   2,   -5, 	  -1,  -11
+.2byte  -12,   -9, 	  -8,   -6, 	  -7,   -3, 	  -3,   -6
+.2byte   -5,  -16, 	 -10,  -12, 	   4,   -8, 	  -3,  -10
+.2byte    4,  -20, 	 -10,  -18, 	   8,   -9, 	  -1,  -12
+.2byte   -8,   -9, 	 -12,   -7, 	   2,   -4, 	  -4,   -8
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -5,  -16, 	 -10,  -12, 	   4,   -8, 	  -3,  -10
+.2byte   -7,  -16, 	  -4,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte   -7,  -18, 	   3,  -11, 	 -11,   -9, 	  -1,  -11
+.2byte   -1,  -20, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte    5,  -18, 	  -5,  -11, 	   9,   -9, 	  -1,  -11
+.2byte    5,  -16, 	   2,   -9, 	   0,   -7, 	  -1,  -10
+.2byte    3,  -16, 	   8,  -12, 	  -6,   -8, 	   1,  -10
+.2byte   -4,  -13, 	  -9,   -8, 	   4,   -6, 	  -1,   -9
+.2byte   -5,  -12, 	  -9,   -7, 	   3,   -5, 	  -2,   -9
+.2byte    0,  -19, 	 -10,  -14, 	  10,  -14, 	   0,  -13
+.2byte    0,  -17, 	   5,  -18, 	 -11,  -11, 	  -2,  -12
+.2byte    1,  -17, 	   2,  -14, 	  -3,   -8, 	  -2,  -11
+.2byte    3,  -20, 	  -4,  -18, 	   8,  -14, 	  -3,  -10
+.2byte    0,  -20, 	  10,  -12, 	 -10,  -12, 	   0,   -9
+.2byte   -4,  -20, 	   3,  -18, 	  -9,  -14, 	   2,  -10
+.2byte   -2,  -17, 	  -3,  -14, 	   2,   -8, 	   1,  -11
+.2byte   -1,  -17, 	  -6,  -18, 	  10,  -11, 	   1,  -12
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -1,  -15, 	 -10,   -9, 	   7,   -8, 	  -1,   -9
+.2byte   -1,  -15, 	  -9,   -8, 	   8,   -9, 	  -1,   -9
+.2byte    3,  -16, 	   8,  -12, 	  -6,   -8, 	   1,  -10
+.2byte    3,  -15, 	   7,  -11, 	  -3,   -7, 	  -1,   -9
+.2byte    3,  -15, 	   9,  -10, 	  -7,   -8, 	   0,   -9
+.2byte    5,  -16, 	   2,   -9, 	   0,   -7, 	  -1,  -10
+.2byte    5,  -15, 	  -2,   -7, 	   3,   -8, 	  -2,  -11
+.2byte    5,  -15, 	   2,   -8, 	  -2,   -7, 	  -2,  -10
+.2byte    5,  -18, 	  -5,  -11, 	   9,   -9, 	  -1,  -11
+.2byte    5,  -17, 	  -4,  -11, 	   9,  -10, 	   0,  -11
+.2byte    5,  -17, 	  -3,  -11, 	   7,   -8, 	  -4,  -11
+.2byte   -1,  -20, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte    0,  -19, 	   8,   -9, 	 -11,  -12, 	  -2,  -11
+.2byte   -2,  -18, 	   9,  -12, 	 -10,   -9, 	   0,  -10
+.2byte   -7,  -18, 	   3,  -11, 	 -11,   -9, 	  -1,  -11
+.2byte   -7,  -17, 	   2,  -11, 	 -11,  -10, 	  -2,  -11
+.2byte   -7,  -17, 	   1,  -11, 	  -9,   -8, 	   2,  -11
+.2byte   -7,  -16, 	  -4,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte   -7,  -15, 	   0,   -7, 	  -5,   -8, 	   0,  -11
+.2byte   -7,  -15, 	  -4,   -8, 	   0,   -7, 	   0,  -10
+.2byte   -5,  -16, 	 -10,  -12, 	   4,   -8, 	  -3,  -10
+.2byte   -5,  -15, 	  -9,  -11, 	   1,   -7, 	  -1,   -9
+.2byte   -5,  -15, 	 -11,  -10, 	   5,   -8, 	  -2,   -9
+.2byte   -1,   -6, 	 -10,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -5,   -9, 	  -9,   -7, 	   5,   -4, 	  -1,   -8
+.2byte   -8,   -9, 	  -4,   -6, 	  -3,   -3, 	   1,   -6
+.2byte   -9,  -14, 	  -3,  -10, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   9,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte    8,  -14, 	   2,  -10, 	   8,   -4, 	   0,   -9
+.2byte    7,   -9, 	   3,   -6, 	   2,   -3, 	  -2,   -6
+.2byte    4,   -9, 	   8,   -7, 	  -6,   -4, 	   0,   -8
+.2byte   -1,   -6, 	 -10,   -5, 	   8,   -5, 	   0,   -8
+.2byte    4,   -9, 	   8,   -7, 	  -6,   -4, 	   0,   -8
+.2byte    7,   -9, 	   3,   -6, 	   2,   -3, 	  -2,   -6
+.2byte    8,  -14, 	   2,  -10, 	   8,   -4, 	   0,   -9
+.2byte   -1,  -17, 	   9,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte   -9,  -14, 	  -3,  -10, 	  -9,   -4, 	  -1,   -9
+.2byte   -8,   -9, 	  -4,   -6, 	  -3,   -3, 	   1,   -6
+.2byte   -5,   -9, 	  -9,   -7, 	   5,   -4, 	  -1,   -8
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte    4,  -20, 	 -10,  -17, 	   7,  -10, 	  -1,  -11
+.2byte   -1,   -6, 	 -10,   -5, 	   8,   -5, 	   0,   -8
+.2byte    3,  -16, 	   8,  -12, 	  -6,   -8, 	   1,  -10
+.2byte   -6,  -20, 	   8,  -18, 	 -10,   -9, 	  -1,  -12
+.2byte    4,   -9, 	   8,   -7, 	  -6,   -4, 	   0,   -8
+.2byte    5,  -16, 	   2,   -9, 	   0,   -7, 	  -1,  -10
+.2byte   -5,  -17, 	   6,  -20, 	  -4,   -5, 	  -1,  -11
+.2byte    8,   -9, 	   4,   -6, 	   3,   -3, 	  -1,   -6
+.2byte    5,  -18, 	  -5,  -11, 	   9,   -9, 	  -1,  -11
+.2byte    6,  -17, 	  -5,  -21, 	   8,   -5, 	   0,  -11
+.2byte    7,  -17, 	   1,  -13, 	   7,   -7, 	  -1,  -12
+.2byte   -1,  -20, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte   -7,  -16, 	   6,  -14, 	 -10,   -8, 	  -1,  -10
+.2byte   -1,  -17, 	   9,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte   -7,  -18, 	   3,  -11, 	 -11,   -9, 	  -1,  -11
+.2byte   -8,  -17, 	   3,  -21, 	 -10,   -5, 	  -2,  -11
+.2byte   -9,  -17, 	  -3,  -13, 	  -9,   -7, 	  -1,  -12
+.2byte   -7,  -16, 	  -4,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte    3,  -17, 	  -8,  -20, 	   2,   -5, 	  -1,  -11
+.2byte   -9,   -9, 	  -5,   -6, 	  -4,   -3, 	   0,   -6
+.2byte   -5,  -16, 	 -10,  -12, 	   4,   -8, 	  -3,  -10
+.2byte    4,  -20, 	 -10,  -18, 	   8,   -9, 	  -1,  -12
+.2byte   -6,   -9, 	 -10,   -7, 	   4,   -4, 	  -2,   -8
+.2byte   -1,   -6, 	 -10,   -5, 	   8,   -5, 	   0,   -8
+.2byte   -5,   -9, 	  -9,   -7, 	   5,   -4, 	  -1,   -8
+.2byte   -8,   -9, 	  -4,   -6, 	  -3,   -3, 	   1,   -6
+.2byte   -9,  -14, 	  -3,  -10, 	  -9,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   9,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte    8,  -14, 	   2,  -10, 	   8,   -4, 	   0,   -9
+.2byte    7,   -9, 	   3,   -6, 	   2,   -3, 	  -2,   -6
+.2byte    4,   -9, 	   8,   -7, 	  -6,   -4, 	   0,   -8
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -5,  -16, 	 -10,  -12, 	   4,   -8, 	  -3,  -10
+.2byte   -7,  -16, 	  -4,   -9, 	  -2,   -7, 	  -1,  -10
+.2byte   -7,  -18, 	   3,  -11, 	 -11,   -9, 	  -1,  -11
+.2byte   -1,  -20, 	   9,  -11, 	 -11,  -11, 	  -1,  -11
+.2byte    5,  -18, 	  -5,  -11, 	   9,   -9, 	  -1,  -11
+.2byte    5,  -16, 	   2,   -9, 	   0,   -7, 	  -1,  -10
+.2byte    3,  -16, 	   8,  -12, 	  -6,   -8, 	   1,  -10
+.2byte   -1,  -16, 	 -11,   -9, 	   9,   -9, 	  -1,  -10
+.2byte   -2,  -15, 	  -7,  -10, 	   5,   -8, 	  -2,  -10
+.2byte    0,  -18, 	  -9,  -19, 	  10,   -9, 	   0,  -11
+.2byte    0,  -18, 	  -8,  -21, 	  10,   -9, 	   0,  -11
+.2byte  -12,   -5, 	   4,   -8, 	 -13,   -2, 	  -1,   -4
+.2byte   11,   -5, 	  -5,   -8, 	  12,   -2, 	   0,   -4
+sTyranitarAnimTable1:
+.4byte sTyranitarAnims_1_1
+.4byte sTyranitarAnims_1_2
+.4byte sTyranitarAnims_1_3
+.4byte sTyranitarAnims_1_4
+.4byte sTyranitarAnims_1_5
+.4byte sTyranitarAnims_1_6
+.4byte sTyranitarAnims_1_7
+.4byte sTyranitarAnims_1_8
+sTyranitarAnimTable2:
+.4byte sTyranitarAnims_2_1
+.4byte sTyranitarAnims_2_2
+.4byte sTyranitarAnims_2_3
+.4byte sTyranitarAnims_2_4
+.4byte sTyranitarAnims_2_5
+.4byte sTyranitarAnims_2_6
+.4byte sTyranitarAnims_2_7
+.4byte sTyranitarAnims_2_8
+sTyranitarAnimTable3:
+.4byte sTyranitarAnims_3_1
+.4byte sTyranitarAnims_3_2
+.4byte sTyranitarAnims_3_3
+.4byte sTyranitarAnims_3_4
+.4byte sTyranitarAnims_3_5
+.4byte sTyranitarAnims_3_6
+.4byte sTyranitarAnims_3_7
+.4byte sTyranitarAnims_3_8
+sTyranitarAnimTable4:
+.4byte sTyranitarAnims_4_1
+.4byte sTyranitarAnims_4_2
+.4byte sTyranitarAnims_4_3
+.4byte sTyranitarAnims_4_4
+.4byte sTyranitarAnims_4_5
+.4byte sTyranitarAnims_4_6
+.4byte sTyranitarAnims_4_7
+.4byte sTyranitarAnims_4_8
+sTyranitarAnimTable5:
+.4byte sTyranitarAnims_5_1
+.4byte sTyranitarAnims_5_2
+.4byte sTyranitarAnims_5_3
+.4byte sTyranitarAnims_5_4
+.4byte sTyranitarAnims_5_5
+.4byte sTyranitarAnims_5_6
+.4byte sTyranitarAnims_5_7
+.4byte sTyranitarAnims_5_8
+sTyranitarAnimTable6:
+.4byte sTyranitarAnims_6_1
+.4byte sTyranitarAnims_6_1
+.4byte sTyranitarAnims_6_1
+.4byte sTyranitarAnims_6_1
+.4byte sTyranitarAnims_6_1
+.4byte sTyranitarAnims_6_1
+.4byte sTyranitarAnims_6_1
+.4byte sTyranitarAnims_6_1
+sTyranitarAnimTable7:
+.4byte sTyranitarAnims_7_1
+.4byte sTyranitarAnims_7_2
+.4byte sTyranitarAnims_7_3
+.4byte sTyranitarAnims_7_4
+.4byte sTyranitarAnims_7_5
+.4byte sTyranitarAnims_7_6
+.4byte sTyranitarAnims_7_7
+.4byte sTyranitarAnims_7_8
+sTyranitarAnimTable8:
+.4byte sTyranitarAnims_8_1
+.4byte sTyranitarAnims_8_2
+.4byte sTyranitarAnims_8_3
+.4byte sTyranitarAnims_8_4
+.4byte sTyranitarAnims_8_5
+.4byte sTyranitarAnims_8_6
+.4byte sTyranitarAnims_8_7
+.4byte sTyranitarAnims_8_8
+sTyranitarAnimTable9:
+.4byte sTyranitarAnims_9_1
+.4byte sTyranitarAnims_9_2
+.4byte sTyranitarAnims_9_3
+.4byte sTyranitarAnims_9_4
+.4byte sTyranitarAnims_9_5
+.4byte sTyranitarAnims_9_6
+.4byte sTyranitarAnims_9_7
+.4byte sTyranitarAnims_9_8
+sTyranitarAnimTable10:
+.4byte sTyranitarAnims_10_1
+.4byte sTyranitarAnims_10_2
+.4byte sTyranitarAnims_10_3
+.4byte sTyranitarAnims_10_4
+.4byte sTyranitarAnims_10_5
+.4byte sTyranitarAnims_10_6
+.4byte sTyranitarAnims_10_7
+.4byte sTyranitarAnims_10_8
+sTyranitarAnimTable11:
+.4byte sTyranitarAnims_11_1
+.4byte sTyranitarAnims_11_2
+.4byte sTyranitarAnims_11_3
+.4byte sTyranitarAnims_11_4
+.4byte sTyranitarAnims_11_5
+.4byte sTyranitarAnims_11_6
+.4byte sTyranitarAnims_11_7
+.4byte sTyranitarAnims_11_8
+sTyranitarAnimTable12:
+.4byte sTyranitarAnims_12_1
+.4byte sTyranitarAnims_12_2
+.4byte sTyranitarAnims_12_3
+.4byte sTyranitarAnims_12_4
+.4byte sTyranitarAnims_12_5
+.4byte sTyranitarAnims_12_6
+.4byte sTyranitarAnims_12_7
+.4byte sTyranitarAnims_12_8
+sTyranitarAnimTable13:
+.4byte sTyranitarAnims_13_1
+.4byte sTyranitarAnims_13_2
+.4byte sTyranitarAnims_13_3
+.4byte sTyranitarAnims_13_4
+.4byte sTyranitarAnims_13_5
+.4byte sTyranitarAnims_13_6
+.4byte sTyranitarAnims_13_7
+.4byte sTyranitarAnims_13_8
+sTyranitarAnimTable14:
+.4byte sTyranitarAnims_14_1
+.4byte sTyranitarAnims_14_2
+.4byte sTyranitarAnims_14_3
+.4byte sTyranitarAnims_14_4
+.4byte sTyranitarAnims_14_5
+.4byte sTyranitarAnims_14_6
+.4byte sTyranitarAnims_14_7
+.4byte sTyranitarAnims_14_8
+sTyranitarAnimTable15:
+.4byte sTyranitarAnims_15_1
+.4byte sTyranitarAnims_15_2
+.4byte sTyranitarAnims_15_3
+.4byte sTyranitarAnims_15_4
+.4byte sTyranitarAnims_15_5
+.4byte sTyranitarAnims_15_6
+.4byte sTyranitarAnims_15_7
+.4byte sTyranitarAnims_15_8
+sAxAnimationsTyranitar:
+.4byte sTyranitarAnimTable1
+.4byte sTyranitarAnimTable2
+.4byte sTyranitarAnimTable3
+.4byte sTyranitarAnimTable4
+.4byte sTyranitarAnimTable5
+.4byte sTyranitarAnimTable6
+.4byte sTyranitarAnimTable7
+.4byte sTyranitarAnimTable8
+.4byte sTyranitarAnimTable9
+.4byte sTyranitarAnimTable10
+.4byte sTyranitarAnimTable11
+.4byte sTyranitarAnimTable12
+.4byte sTyranitarAnimTable13
+.4byte sTyranitarAnimTable14
+.4byte sTyranitarAnimTable15
+sAxSpritesTyranitar:
+.4byte sTyranitarSprites1
+.4byte sTyranitarSprites2
+.4byte sTyranitarSprites3
+.4byte sTyranitarSprites4
+.4byte sTyranitarSprites5
+.4byte sTyranitarSprites6
+.4byte sTyranitarSprites7
+.4byte sTyranitarSprites8
+.4byte sTyranitarSprites9
+.4byte sTyranitarSprites10
+.4byte sTyranitarSprites11
+.4byte sTyranitarSprites12
+.4byte sTyranitarSprites13
+.4byte sTyranitarSprites14
+.4byte sTyranitarSprites15
+.4byte sTyranitarSprites16
+.4byte sTyranitarSprites17
+.4byte sTyranitarSprites18
+.4byte sTyranitarSprites19
+.4byte sTyranitarSprites20
+.4byte sTyranitarSprites21
+.4byte sTyranitarSprites22
+.4byte sTyranitarSprites23
+.4byte sTyranitarSprites24
+.4byte sTyranitarSprites25
+.4byte sTyranitarSprites26
+.4byte sTyranitarSprites27
+.4byte sTyranitarSprites28
+.4byte sTyranitarSprites29
+.4byte sTyranitarSprites30
+.4byte sTyranitarSprites31
+.4byte sTyranitarSprites32
+.4byte sTyranitarSprites33
+.4byte sTyranitarSprites34
+.4byte sTyranitarSprites35
+.4byte sTyranitarSprites36
+.4byte sTyranitarSprites37
+.4byte sTyranitarSprites38
+.4byte sTyranitarSprites39
+.4byte sTyranitarSprites40
+.4byte sTyranitarSprites41
+.4byte sTyranitarSprites42
+.4byte sTyranitarSprites43
+.4byte sTyranitarSprites44
+.4byte sTyranitarSprites45
+.4byte sTyranitarSprites46
+.4byte sTyranitarSprites47
+.4byte sTyranitarSprites48
+.4byte sTyranitarSprites49
+.4byte sTyranitarSprites50
+.4byte sTyranitarSprites51
+.4byte sTyranitarSprites52
+.4byte sTyranitarSprites53
+.4byte sTyranitarSprites54
+.4byte sTyranitarSprites55
+.4byte sTyranitarSprites56
+.4byte sTyranitarSprites57
+sAxMainTyranitar:
+ax_main sAxPosesTyranitar, sAxAnimationsTyranitar, 15, sAxSpritesTyranitar, sAxPositionsTyranitar

--- a/data/ax/tyrogue.inc
+++ b/data/ax/tyrogue.inc
@@ -1,0 +1,2752 @@
+.global gAxTyrogue
+gAxTyrogue:
+ax_siro sAxMainTyrogue
+sTyroguePose1:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose4:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose5:
+ax_pose 4, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose6:
+ax_pose 5, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose7:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose8:
+ax_pose 7, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose9:
+ax_pose 8, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose10:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose11:
+ax_pose 10, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose12:
+ax_pose 11, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose13:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose14:
+ax_pose 13, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose15:
+ax_pose 14, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose16:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose17:
+ax_pose 10, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose18:
+ax_pose 11, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose19:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose20:
+ax_pose 7, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose21:
+ax_pose 8, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose22:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose23:
+ax_pose 4, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose24:
+ax_pose 5, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose25:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose26:
+ax_pose 1, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose27:
+ax_pose 2, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose28:
+ax_pose 15, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose29:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose30:
+ax_pose 4, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose31:
+ax_pose 5, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose32:
+ax_pose 16, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose33:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose34:
+ax_pose 7, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose35:
+ax_pose 8, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose36:
+ax_pose 17, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose37:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose38:
+ax_pose 10, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose39:
+ax_pose 11, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose40:
+ax_pose 18, 0x81e5, 0x90fa, 0x2c00
+ax_pose_terminator
+sTyroguePose41:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose42:
+ax_pose 13, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose43:
+ax_pose 14, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose44:
+ax_pose 19, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose45:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose46:
+ax_pose 10, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose47:
+ax_pose 11, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose48:
+ax_pose 18, 0x81e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyroguePose49:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose50:
+ax_pose 7, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose51:
+ax_pose 8, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose52:
+ax_pose 17, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose53:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose54:
+ax_pose 4, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose55:
+ax_pose 5, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose56:
+ax_pose 16, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose57:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose58:
+ax_pose 20, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose59:
+ax_pose 21, 0x81e5, 0x80f6, 0x2c00
+ax_pose 22, 0x81e5, 0x80f8, 0x2c08
+ax_pose_terminator
+sTyroguePose60:
+ax_pose 22, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose61:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose62:
+ax_pose 23, 0x01e6, 0x90e7, 0x2c00
+ax_pose_terminator
+sTyroguePose63:
+ax_pose 24, 0x01e5, 0x90ec, 0x2c00
+ax_pose 25, 0x01e5, 0x90ea, 0x2c10
+ax_pose_terminator
+sTyroguePose64:
+ax_pose 25, 0x01e5, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyroguePose65:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose66:
+ax_pose 26, 0x01e5, 0x90e8, 0x2c00
+ax_pose_terminator
+sTyroguePose67:
+ax_pose 27, 0x41f2, 0x90ef, 0x2c00
+ax_pose 28, 0x01e5, 0x90ed, 0x2c08
+ax_pose_terminator
+sTyroguePose68:
+ax_pose 28, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyroguePose69:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose70:
+ax_pose 29, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose71:
+ax_pose 30, 0x01e8, 0x90ed, 0x2c00
+ax_pose 31, 0x01e8, 0x90eb, 0x2c10
+ax_pose_terminator
+sTyroguePose72:
+ax_pose 31, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyroguePose73:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose74:
+ax_pose 32, 0x81e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose75:
+ax_pose 33, 0x81e9, 0x8102, 0x2c00
+ax_pose 34, 0x81e9, 0x80f7, 0x2c08
+ax_pose_terminator
+sTyroguePose76:
+ax_pose 34, 0x81e9, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose77:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose78:
+ax_pose 29, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose79:
+ax_pose 30, 0x01e8, 0x80f3, 0x2c00
+ax_pose 31, 0x01e8, 0x80f5, 0x2c10
+ax_pose_terminator
+sTyroguePose80:
+ax_pose 31, 0x01e8, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyroguePose81:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose82:
+ax_pose 26, 0x01e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose83:
+ax_pose 27, 0x41f2, 0x80f1, 0x2c00
+ax_pose 28, 0x01e6, 0x80f4, 0x2c08
+ax_pose_terminator
+sTyroguePose84:
+ax_pose 28, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose85:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose86:
+ax_pose 23, 0x01e6, 0x80f9, 0x2c00
+ax_pose_terminator
+sTyroguePose87:
+ax_pose 24, 0x01e5, 0x80f4, 0x2c00
+ax_pose 25, 0x01e5, 0x80f6, 0x2c10
+ax_pose_terminator
+sTyroguePose88:
+ax_pose 25, 0x01e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyroguePose89:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose90:
+ax_pose 15, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose91:
+ax_pose 35, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose92:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose93:
+ax_pose 16, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose94:
+ax_pose 36, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sTyroguePose95:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose96:
+ax_pose 17, 0x81e5, 0x90f9, 0x2c00
+ax_pose_terminator
+sTyroguePose97:
+ax_pose 37, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose98:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose99:
+ax_pose 18, 0x81e5, 0x90fa, 0x2c00
+ax_pose_terminator
+sTyroguePose100:
+ax_pose 38, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sTyroguePose101:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose102:
+ax_pose 19, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose103:
+ax_pose 39, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose104:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose105:
+ax_pose 18, 0x81e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyroguePose106:
+ax_pose 38, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose107:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose108:
+ax_pose 17, 0x81e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose109:
+ax_pose 37, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose110:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose111:
+ax_pose 16, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose112:
+ax_pose 36, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose113:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose114:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose115:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose116:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose117:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose118:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose119:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose120:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose121:
+ax_pose 40, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose122:
+ax_pose 41, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose123:
+ax_pose 42, 0x01e3, 0x80f0, 0x2c00
+ax_pose_terminator
+sTyroguePose124:
+ax_pose 43, 0x01e1, 0x90ed, 0x2c00
+ax_pose_terminator
+sTyroguePose125:
+ax_pose 44, 0x01e2, 0x90eb, 0x2c00
+ax_pose_terminator
+sTyroguePose126:
+ax_pose 45, 0x01e1, 0x90ea, 0x2c00
+ax_pose_terminator
+sTyroguePose127:
+ax_pose 46, 0x01e3, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose128:
+ax_pose 45, 0x01e1, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyroguePose129:
+ax_pose 44, 0x01e2, 0x80f5, 0x2c00
+ax_pose_terminator
+sTyroguePose130:
+ax_pose 43, 0x01e1, 0x80f3, 0x2c00
+ax_pose_terminator
+sTyroguePose131:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose132:
+ax_pose 1, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose133:
+ax_pose 2, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose134:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose135:
+ax_pose 4, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose136:
+ax_pose 5, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose137:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose138:
+ax_pose 7, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose139:
+ax_pose 8, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose140:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose141:
+ax_pose 10, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose142:
+ax_pose 11, 0x01e5, 0x90ec, 0x2c00
+ax_pose_terminator
+sTyroguePose143:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose144:
+ax_pose 13, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose145:
+ax_pose 14, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose146:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose147:
+ax_pose 10, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose148:
+ax_pose 11, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose149:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose150:
+ax_pose 7, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose151:
+ax_pose 8, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose152:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose153:
+ax_pose 4, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose154:
+ax_pose 5, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose155:
+ax_pose 15, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose156:
+ax_pose 16, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose157:
+ax_pose 17, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose158:
+ax_pose 18, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose159:
+ax_pose 19, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose160:
+ax_pose 18, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose161:
+ax_pose 17, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose162:
+ax_pose 16, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose163:
+ax_pose 35, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose164:
+ax_pose 36, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sTyroguePose165:
+ax_pose 37, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose166:
+ax_pose 38, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sTyroguePose167:
+ax_pose 39, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose168:
+ax_pose 38, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose169:
+ax_pose 37, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose170:
+ax_pose 36, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose171:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose172:
+ax_pose 35, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose173:
+ax_pose 15, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose174:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose175:
+ax_pose 36, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sTyroguePose176:
+ax_pose 16, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose177:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose178:
+ax_pose 37, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose179:
+ax_pose 17, 0x81e5, 0x90f9, 0x2c00
+ax_pose_terminator
+sTyroguePose180:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose181:
+ax_pose 38, 0x01e5, 0x90e9, 0x2c00
+ax_pose_terminator
+sTyroguePose182:
+ax_pose 18, 0x81e5, 0x90fa, 0x2c00
+ax_pose_terminator
+sTyroguePose183:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose184:
+ax_pose 39, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose185:
+ax_pose 19, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose186:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose187:
+ax_pose 38, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose188:
+ax_pose 18, 0x81e5, 0x80f6, 0x2c00
+ax_pose_terminator
+sTyroguePose189:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose190:
+ax_pose 37, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose191:
+ax_pose 17, 0x81e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose192:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose193:
+ax_pose 36, 0x01e5, 0x80f7, 0x2c00
+ax_pose_terminator
+sTyroguePose194:
+ax_pose 16, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose195:
+ax_pose 15, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose196:
+ax_pose 16, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose197:
+ax_pose 17, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose198:
+ax_pose 18, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose199:
+ax_pose 19, 0x81e4, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose200:
+ax_pose 18, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose201:
+ax_pose 17, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose202:
+ax_pose 16, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose203:
+ax_pose 0, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose204:
+ax_pose 3, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose205:
+ax_pose 6, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose206:
+ax_pose 9, 0x81e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sTyroguePose207:
+ax_pose 12, 0x01e5, 0x80f4, 0x2c00
+ax_pose_terminator
+sTyroguePose208:
+ax_pose 9, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose209:
+ax_pose 6, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+sTyroguePose210:
+ax_pose 3, 0x81e5, 0x90f8, 0x2c00
+ax_pose_terminator
+.align 2
+sTyrogueAnims_1_1:
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 30, 0, 10, 0, 10,
+ax_anim 2, 0, 35, 0, 20, 0, 20,
+ax_anim 2, 1, 35, 1, 20, 1, 20,
+ax_anim 2, 0, 35, 0, 20, 0, 20,
+ax_anim 2, 0, 35, 1, 20, 1, 20,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sTyrogueAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 34, 11, 11, 11, 11,
+ax_anim 2, 0, 39, 20, 20, 20, 20,
+ax_anim 2, 1, 39, 21, 19, 21, 19,
+ax_anim 2, 0, 39, 20, 20, 20, 20,
+ax_anim 2, 0, 39, 21, 19, 21, 19,
+ax_anim 2, 0, 29, 8, 8, 8, 8,
+ax_anim_terminator
+sTyrogueAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 25, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 38, 10, 0, 10, 0,
+ax_anim 2, 0, 43, 22, 0, 22, 0,
+ax_anim 2, 1, 43, 22, 1, 22, 1,
+ax_anim 2, 0, 43, 22, 0, 22, 0,
+ax_anim 2, 0, 43, 22, 1, 22, 1,
+ax_anim 2, 0, 33, 6, 0, 6, 0,
+ax_anim_terminator
+sTyrogueAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 29, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 42, 12, -13, 12, -13,
+ax_anim 2, 0, 47, 22, -22, 22, -22,
+ax_anim 2, 1, 47, 23, -21, 23, -21,
+ax_anim 2, 0, 47, 22, -22, 22, -22,
+ax_anim 2, 0, 47, 23, -21, 23, -21,
+ax_anim 2, 0, 37, 6, -6, 6, -6,
+ax_anim_terminator
+sTyrogueAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 33, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 46, 0, -11, 0, -11,
+ax_anim 2, 0, 47, 0, -21, 0, -21,
+ax_anim 2, 1, 47, 1, -21, 1, -21,
+ax_anim 2, 0, 47, 0, -21, 0, -21,
+ax_anim 2, 0, 47, 1, -21, 1, -21,
+ax_anim 2, 0, 41, 0, -6, 0, -6,
+ax_anim_terminator
+sTyrogueAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 37, 2, 2, 2, 2,
+ax_anim 1, 0, 42, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 50, -12, -13, -12, -13,
+ax_anim 2, 0, 55, -22, -22, -22, -22,
+ax_anim 2, 1, 55, -23, -21, -23, -21,
+ax_anim 2, 0, 55, -22, -22, -22, -22,
+ax_anim 2, 0, 55, -23, -21, -23, -21,
+ax_anim 2, 0, 45, -6, -6, -6, -6,
+ax_anim_terminator
+sTyrogueAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 41, 2, 0, 2, 0,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 54, -10, 0, -10, 0,
+ax_anim 2, 0, 27, -22, 0, -22, 0,
+ax_anim 2, 1, 27, -22, 1, -22, 1,
+ax_anim 2, 0, 27, -22, 0, -22, 0,
+ax_anim 2, 0, 27, -22, 1, -22, 1,
+ax_anim 2, 0, 49, -6, 0, -6, 0,
+ax_anim_terminator
+sTyrogueAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 26, -11, 11, -11, 11,
+ax_anim 2, 0, 31, -22, 20, -22, 20,
+ax_anim 2, 1, 31, -23, 19, -23, 19,
+ax_anim 2, 0, 31, -22, 20, -22, 20,
+ax_anim 2, 0, 31, -23, 19, -23, 19,
+ax_anim 2, 0, 53, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 6, 0, 85, 0, -3, 0, -3,
+ax_anim 1, 2, 85, 0, 1, 0, 1,
+ax_anim 1, 0, 57, 0, 8, 0, 8,
+ax_anim 2, 0, 58, 0, 16, 0, 16,
+ax_anim 2, 1, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 59, 0, 16, 0, 16,
+ax_anim 2, 0, 59, 1, 16, 1, 16,
+ax_anim 2, 0, 56, 0, 10, 0, 10,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sTyrogueAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 6, 0, 65, -3, -3, -3, -3,
+ax_anim 1, 2, 65, 1, 1, 1, 1,
+ax_anim 1, 0, 61, 8, 8, 8, 8,
+ax_anim 2, 0, 62, 18, 17, 18, 17,
+ax_anim 2, 1, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 63, 18, 17, 18, 17,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 60, 10, 10, 10, 10,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim_terminator
+sTyrogueAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 2, 0, 65, -2, 0, -2, 0,
+ax_anim 6, 0, 69, -5, -1, -3, 0,
+ax_anim 1, 2, 69, 1, 0, 1, 0,
+ax_anim 1, 0, 65, 8, 0, 8, 0,
+ax_anim 2, 0, 66, 15, 0, 15, 0,
+ax_anim 2, 1, 67, 15, -1, 15, -1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 67, 15, -1, 15, -1,
+ax_anim 2, 0, 67, 15, 0, 15, 0,
+ax_anim 2, 0, 67, 15, -1, 15, -1,
+ax_anim 2, 0, 64, 10, 0, 10, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim_terminator
+sTyrogueAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 2, 0, 69, -2, 2, -2, 2,
+ax_anim 6, 0, 73, -3, 3, -3, 3,
+ax_anim 1, 2, 73, 1, -1, 1, -1,
+ax_anim 1, 0, 69, 8, -8, 8, -8,
+ax_anim 2, 0, 70, 16, -17, 16, -17,
+ax_anim 2, 1, 71, 17, -17, 17, -17,
+ax_anim 2, 0, 71, 16, -17, 16, -17,
+ax_anim 2, 0, 71, 17, -17, 17, -17,
+ax_anim 2, 0, 71, 16, -17, 16, -17,
+ax_anim 2, 0, 71, 17, -17, 17, -17,
+ax_anim 2, 0, 68, 10, -10, 10, -10,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim_terminator
+sTyrogueAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 6, 0, 69, 1, 3, 1, 3,
+ax_anim 1, 2, 69, 0, -1, 0, -1,
+ax_anim 1, 0, 73, 0, -8, 0, -8,
+ax_anim 2, 0, 74, 0, -16, 0, -16,
+ax_anim 2, 1, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 0, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 0, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 72, 0, -10, 0, -10,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim_terminator
+sTyrogueAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 6, 0, 73, 3, 3, 3, 3,
+ax_anim 1, 2, 73, -1, -1, -1, -1,
+ax_anim 1, 0, 77, -8, -8, -8, -8,
+ax_anim 2, 0, 78, -16, -17, -16, -17,
+ax_anim 2, 1, 79, -17, -17, -17, -17,
+ax_anim 2, 0, 79, -16, -17, -16, -17,
+ax_anim 2, 0, 79, -17, -17, -17, -17,
+ax_anim 2, 0, 79, -16, -17, -16, -17,
+ax_anim 2, 0, 79, -17, -17, -17, -17,
+ax_anim 2, 0, 76, -10, -10, -10, -10,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim_terminator
+sTyrogueAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 2, 0, 2, 0,
+ax_anim 6, 0, 77, 4, -2, 3, 0,
+ax_anim 1, 2, 77, -1, 0, -1, 0,
+ax_anim 1, 0, 81, -8, 0, -8, 0,
+ax_anim 2, 0, 82, -15, 0, -15, 0,
+ax_anim 2, 1, 83, -15, -1, -15, -1,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 83, -15, -1, -15, -1,
+ax_anim 2, 0, 83, -15, 0, -15, 0,
+ax_anim 2, 0, 83, -15, -1, -15, -1,
+ax_anim 2, 0, 80, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim_terminator
+sTyrogueAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 6, 0, 81, 3, -3, 3, -3,
+ax_anim 1, 2, 81, -1, 1, -1, 1,
+ax_anim 1, 0, 85, -8, 8, -8, 8,
+ax_anim 2, 0, 86, -18, 17, -18, 17,
+ax_anim 2, 1, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -18, 17, -18, 17,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 84, -10, 10, -10, 10,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_4_1:
+ax_anim 4, 0, 88, 0, -2, 0, 0,
+ax_anim 8, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 2, 90, 0, -1, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim_terminator
+sTyrogueAnims_4_2:
+ax_anim 4, 0, 91, 0, -2, 0, 0,
+ax_anim 8, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 2, 93, 0, -1, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 93, 1, -1, 1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim_terminator
+sTyrogueAnims_4_3:
+ax_anim 4, 0, 94, 0, -2, 0, 0,
+ax_anim 8, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 2, 96, 0, -1, 0, 0,
+ax_anim 1, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 1, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim_terminator
+sTyrogueAnims_4_4:
+ax_anim 4, 0, 97, 0, -2, 0, 0,
+ax_anim 8, 0, 98, 0, 0, 0, 0,
+ax_anim 1, 2, 99, 0, -1, 0, 0,
+ax_anim 1, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 0, 99, 0, -3, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 1, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, -1, -1, -1,
+ax_anim_terminator
+sTyrogueAnims_4_5:
+ax_anim 4, 0, 100, 0, -2, 0, 0,
+ax_anim 8, 0, 101, 0, 0, 0, 0,
+ax_anim 1, 2, 102, 0, -1, 0, 0,
+ax_anim 1, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 1, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim_terminator
+sTyrogueAnims_4_6:
+ax_anim 4, 0, 103, 0, -2, 0, 0,
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim 1, 2, 105, 0, -1, 0, 0,
+ax_anim 1, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, -4, 0, 0,
+ax_anim 2, 0, 105, 0, -3, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 105, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, -1, 1, -1,
+ax_anim_terminator
+sTyrogueAnims_4_7:
+ax_anim 4, 0, 106, 0, -2, 0, 0,
+ax_anim 8, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 2, 108, 0, -1, 0, 0,
+ax_anim 1, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -3, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 1, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim_terminator
+sTyrogueAnims_4_8:
+ax_anim 4, 0, 109, 0, -2, 0, 0,
+ax_anim 8, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 2, 111, 0, -1, 0, 0,
+ax_anim 1, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sTyrogueAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sTyrogueAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sTyrogueAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sTyrogueAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sTyrogueAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sTyrogueAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sTyrogueAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_8_1:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_8_2:
+ax_anim 30, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -1, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim 4, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -1, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_8_3:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -1, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 138, 0, -3, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim 1, 0, 138, 0, -1, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_8_4:
+ax_anim 30, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 140, 0, -2, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim 1, 0, 141, 0, -1, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_8_5:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -1, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 1, 0, 144, 0, -1, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_8_6:
+ax_anim 30, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 0, -1, 0, 0,
+ax_anim 2, 0, 146, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 4, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 1, 0, 147, 0, -1, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_8_7:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -1, 0, 0,
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim 4, 0, 150, 0, -3, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim 1, 0, 150, 0, -1, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_8_8:
+ax_anim 30, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, 0, -1, 0, 0,
+ax_anim 2, 0, 152, 0, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 4, 0, 153, 0, -3, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim 1, 0, 153, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 4, 6, 4,
+ax_anim 2, 0, 156, 8, 10, 8, 10,
+ax_anim 2, 0, 157, 7, 18, 7, 18,
+ax_anim 3, 0, 158, 0, 21, 0, 21,
+ax_anim 2, 3, 159, -7, 18, -7, 18,
+ax_anim 2, 0, 160, -8, 10, -8, 10,
+ax_anim 1, 0, 161, -6, 4, -6, 4,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 17, 3, 17, 3,
+ax_anim 2, 0, 156, 22, 12, 22, 12,
+ax_anim 3, 0, 157, 23, 21, 23, 21,
+ax_anim 2, 3, 158, 11, 21, 11, 21,
+ax_anim 2, 0, 159, 3, 15, 3, 15,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 5, -5, 5, -5,
+ax_anim 2, 0, 154, 13, -6, 13, -6,
+ax_anim 2, 0, 155, 19, -5, 19, -5,
+ax_anim 3, 0, 156, 23, 0, 23, 0,
+ax_anim 2, 3, 157, 18, 4, 18, 4,
+ax_anim 2, 0, 158, 13, 5, 13, 5,
+ax_anim 1, 0, 159, 4, 5, 4, 5,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -8, 0, -8,
+ax_anim 2, 0, 161, 3, -17, 3, -17,
+ax_anim 2, 0, 154, 12, -22, 12, -22,
+ax_anim 3, 0, 155, 23, -22, 23, -22,
+ax_anim 2, 3, 156, 22, -15, 22, -15,
+ax_anim 2, 0, 157, 19, -6, 19, -6,
+ax_anim 1, 0, 158, 9, -1, 9, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -18, -7, -18,
+ax_anim 3, 0, 154, 0, -22, 0, -22,
+ax_anim 2, 3, 155, 7, -18, 7, -18,
+ax_anim 2, 0, 156, 9, -12, 9, -12,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -8, 0, -8,
+ax_anim 2, 0, 155, -3, -17, -3, -17,
+ax_anim 2, 0, 155, -12, -22, -12, -22,
+ax_anim 3, 0, 161, -23, -22, -23, -22,
+ax_anim 2, 3, 160, -22, -15, -22, -15,
+ax_anim 2, 0, 159, -19, -6, -19, -6,
+ax_anim 1, 0, 158, -9, -1, -9, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -5, -5, -5, -5,
+ax_anim 2, 0, 154, -13, -6, -13, -6,
+ax_anim 2, 0, 161, -19, -5, -19, -5,
+ax_anim 3, 0, 160, -23, 0, -23, 0,
+ax_anim 2, 3, 159, -18, 4, -18, 4,
+ax_anim 2, 0, 158, -13, 5, -13, 5,
+ax_anim 1, 0, 157, -4, 5, -4, 5,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -17, 3, -17, 3,
+ax_anim 2, 0, 160, -22, 12, -22, 12,
+ax_anim 3, 0, 159, -23, 21, -23, 21,
+ax_anim 2, 3, 158, -11, 21, -11, 21,
+ax_anim 2, 0, 157, -3, 15, -3, 15,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -8, 0, 0,
+ax_anim 2, 0, 171, 0, -14, 0, 0,
+ax_anim 3, 0, 171, 0, -18, 0, 0,
+ax_anim 4, 0, 171, 0, -19, 0, 0,
+ax_anim 4, 0, 170, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -25, 0, 0,
+ax_anim 2, 0, 172, 0, -20, 0, 0,
+ax_anim 1, 0, 172, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -8, 0, 0,
+ax_anim 2, 0, 174, 0, -14, 0, 0,
+ax_anim 3, 0, 174, 0, -18, 0, 0,
+ax_anim 4, 0, 174, 0, -19, 0, 0,
+ax_anim 4, 0, 173, 0, -22, 0, 0,
+ax_anim 3, 0, 175, 0, -23, 0, 0,
+ax_anim 2, 0, 175, 0, -20, 0, 0,
+ax_anim 1, 0, 175, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -8, 0, 0,
+ax_anim 2, 0, 177, 0, -14, 0, 0,
+ax_anim 3, 0, 177, 0, -18, 0, 0,
+ax_anim 4, 0, 177, 0, -19, 0, 0,
+ax_anim 4, 0, 176, 0, -22, 0, 0,
+ax_anim 3, 0, 178, 0, -23, 0, 0,
+ax_anim 2, 0, 178, 0, -20, 0, 0,
+ax_anim 1, 0, 178, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -8, 0, 0,
+ax_anim 2, 0, 180, 0, -14, 0, 0,
+ax_anim 3, 0, 180, 0, -18, 0, 0,
+ax_anim 4, 0, 180, 0, -19, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 3, 0, 181, 0, -23, 0, 0,
+ax_anim 2, 0, 181, 0, -19, 0, 0,
+ax_anim 1, 0, 181, 0, -11, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -8, 0, 0,
+ax_anim 2, 0, 183, 0, -14, 0, 0,
+ax_anim 3, 0, 183, 0, -18, 0, 0,
+ax_anim 4, 0, 183, 0, -19, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 3, 0, 184, 0, -22, 0, 0,
+ax_anim 2, 0, 184, 0, -18, 0, 0,
+ax_anim 1, 0, 184, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -8, 0, 0,
+ax_anim 2, 0, 186, 0, -14, 0, 0,
+ax_anim 3, 0, 186, 0, -18, 0, 0,
+ax_anim 4, 0, 186, 0, -19, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 3, 0, 187, 0, -23, 0, 0,
+ax_anim 2, 0, 187, 0, -19, 0, 0,
+ax_anim 1, 0, 187, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -8, 0, 0,
+ax_anim 2, 0, 189, 0, -14, 0, 0,
+ax_anim 3, 0, 189, 0, -18, 0, 0,
+ax_anim 4, 0, 189, 0, -19, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 3, 0, 190, 0, -23, 0, 0,
+ax_anim 2, 0, 190, 0, -20, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -8, 0, 0,
+ax_anim 2, 0, 192, 0, -14, 0, 0,
+ax_anim 3, 0, 192, 0, -18, 0, 0,
+ax_anim 4, 0, 192, 0, -19, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 3, 0, 193, 0, -24, 0, 0,
+ax_anim 2, 0, 193, 0, -20, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sTyrogueAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sTyrogueGfx1:
+.incbin "baserom.gba", 0xF93FFC, 0x200
+sTyrogueSprites1:
+ax_sprite sTyrogueGfx1, 0x200
+ax_sprite_terminator
+sTyrogueGfx2:
+.incbin "baserom.gba", 0xF9420C, 0x200
+sTyrogueSprites2:
+ax_sprite sTyrogueGfx2, 0x200
+ax_sprite_terminator
+sTyrogueGfx3:
+.incbin "baserom.gba", 0xF9441C, 0x200
+sTyrogueSprites3:
+ax_sprite sTyrogueGfx3, 0x200
+ax_sprite_terminator
+sTyrogueGfx4:
+.incbin "baserom.gba", 0xF9462C, 0x100
+sTyrogueSprites4:
+ax_sprite sTyrogueGfx4, 0x100
+ax_sprite_terminator
+sTyrogueGfx5:
+.incbin "baserom.gba", 0xF9473C, 0x200
+sTyrogueSprites5:
+ax_sprite sTyrogueGfx5, 0x200
+ax_sprite_terminator
+sTyrogueGfx6:
+.incbin "baserom.gba", 0xF9494C, 0x200
+sTyrogueSprites6:
+ax_sprite sTyrogueGfx6, 0x200
+ax_sprite_terminator
+sTyrogueGfx7:
+.incbin "baserom.gba", 0xF94B5C, 0x100
+sTyrogueSprites7:
+ax_sprite sTyrogueGfx7, 0x100
+ax_sprite_terminator
+sTyrogueGfx8:
+.incbin "baserom.gba", 0xF94C6C, 0x200
+sTyrogueSprites8:
+ax_sprite sTyrogueGfx8, 0x200
+ax_sprite_terminator
+sTyrogueGfx9:
+.incbin "baserom.gba", 0xF94E7C, 0x200
+sTyrogueSprites9:
+ax_sprite sTyrogueGfx9, 0x200
+ax_sprite_terminator
+sTyrogueGfx10:
+.incbin "baserom.gba", 0xF9508C, 0x100
+sTyrogueSprites10:
+ax_sprite sTyrogueGfx10, 0x100
+ax_sprite_terminator
+sTyrogueGfx11:
+.incbin "baserom.gba", 0xF9519C, 0x200
+sTyrogueSprites11:
+ax_sprite sTyrogueGfx11, 0x200
+ax_sprite_terminator
+sTyrogueGfx12:
+.incbin "baserom.gba", 0xF953AC, 0x200
+sTyrogueSprites12:
+ax_sprite sTyrogueGfx12, 0x200
+ax_sprite_terminator
+sTyrogueGfx13:
+.incbin "baserom.gba", 0xF955BC, 0x200
+sTyrogueSprites13:
+ax_sprite sTyrogueGfx13, 0x200
+ax_sprite_terminator
+sTyrogueGfx14:
+.incbin "baserom.gba", 0xF957CC, 0x200
+sTyrogueSprites14:
+ax_sprite sTyrogueGfx14, 0x200
+ax_sprite_terminator
+sTyrogueGfx15:
+.incbin "baserom.gba", 0xF959DC, 0x200
+sTyrogueSprites15:
+ax_sprite sTyrogueGfx15, 0x200
+ax_sprite_terminator
+sTyrogueGfx16:
+.incbin "baserom.gba", 0xF95BEC, 0x100
+sTyrogueSprites16:
+ax_sprite sTyrogueGfx16, 0x100
+ax_sprite_terminator
+sTyrogueGfx17:
+.incbin "baserom.gba", 0xF95CFC, 0x100
+sTyrogueSprites17:
+ax_sprite sTyrogueGfx17, 0x100
+ax_sprite_terminator
+sTyrogueGfx18:
+.incbin "baserom.gba", 0xF95E0C, 0xE0
+sTyrogueSprites18:
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx18, 0xe0
+ax_sprite_terminator
+sTyrogueGfx19:
+.incbin "baserom.gba", 0xF95F04, 0x100
+sTyrogueSprites19:
+ax_sprite sTyrogueGfx19, 0x100
+ax_sprite_terminator
+sTyrogueGfx20:
+.incbin "baserom.gba", 0xF96014, 0x100
+sTyrogueSprites20:
+ax_sprite sTyrogueGfx20, 0x100
+ax_sprite_terminator
+sTyrogueGfx21:
+.incbin "baserom.gba", 0xF96124, 0x40
+sTyrogueGfx21_1:
+.incbin "baserom.gba", 0xF96164, 0x60
+sTyrogueGfx21_2:
+.incbin "baserom.gba", 0xF961C4, 0x60
+sTyrogueGfx21_3:
+.incbin "baserom.gba", 0xF96224, 0x20
+sTyrogueSprites21:
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx21_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyrogueGfx22:
+.incbin "baserom.gba", 0xF96294, 0x60
+sTyrogueGfx22_1:
+.incbin "baserom.gba", 0xF962F4, 0x20
+sTyrogueGfx22_2:
+.incbin "baserom.gba", 0xF96314, 0x40
+sTyrogueSprites22:
+ax_sprite sTyrogueGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx22_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx22_2, 0x40
+ax_sprite_terminator
+sTyrogueGfx23:
+.incbin "baserom.gba", 0xF96384, 0xC0
+sTyrogueSprites23:
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx23, 0xc0
+ax_sprite_terminator
+sTyrogueGfx24:
+.incbin "baserom.gba", 0xF9645C, 0x40
+sTyrogueGfx24_1:
+.incbin "baserom.gba", 0xF9649C, 0x60
+sTyrogueGfx24_2:
+.incbin "baserom.gba", 0xF964FC, 0x60
+sTyrogueGfx24_3:
+.incbin "baserom.gba", 0xF9655C, 0x40
+sTyrogueSprites24:
+ax_sprite sTyrogueGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx24_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyrogueGfx25:
+.incbin "baserom.gba", 0xF965E4, 0x40
+sTyrogueGfx25_1:
+.incbin "baserom.gba", 0xF96624, 0x20
+sTyrogueGfx25_2:
+.incbin "baserom.gba", 0xF96644, 0x20
+sTyrogueSprites25:
+ax_sprite 0, 0xa0
+ax_sprite sTyrogueGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx25_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTyrogueGfx25_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sTyrogueGfx26:
+.incbin "baserom.gba", 0xF966A4, 0x40
+sTyrogueGfx26_1:
+.incbin "baserom.gba", 0xF966E4, 0x60
+sTyrogueGfx26_2:
+.incbin "baserom.gba", 0xF96744, 0x40
+sTyrogueSprites26:
+ax_sprite 0, 0x80
+ax_sprite sTyrogueGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx26_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyrogueGfx27:
+.incbin "baserom.gba", 0xF967C4, 0x40
+sTyrogueGfx27_1:
+.incbin "baserom.gba", 0xF96804, 0x60
+sTyrogueGfx27_2:
+.incbin "baserom.gba", 0xF96864, 0x60
+sTyrogueGfx27_3:
+.incbin "baserom.gba", 0xF968C4, 0x40
+sTyrogueSprites27:
+ax_sprite sTyrogueGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx27_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyrogueGfx28:
+.incbin "baserom.gba", 0xF9694C, 0x20
+sTyrogueGfx28_1:
+.incbin "baserom.gba", 0xF9696C, 0x60
+sTyrogueSprites28:
+ax_sprite sTyrogueGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx28_1, 0x60
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sTyrogueGfx29:
+.incbin "baserom.gba", 0xF969F4, 0x20
+sTyrogueGfx29_1:
+.incbin "baserom.gba", 0xF96A14, 0x60
+sTyrogueGfx29_2:
+.incbin "baserom.gba", 0xF96A74, 0x60
+sTyrogueGfx29_3:
+.incbin "baserom.gba", 0xF96AD4, 0x40
+sTyrogueSprites29:
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx29, 0x20
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx29_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyrogueGfx30:
+.incbin "baserom.gba", 0xF96B64, 0x100
+sTyrogueSprites30:
+ax_sprite sTyrogueGfx30, 0x100
+ax_sprite_terminator
+sTyrogueGfx31:
+.incbin "baserom.gba", 0xF96C74, 0x40
+sTyrogueGfx31_1:
+.incbin "baserom.gba", 0xF96CB4, 0x20
+sTyrogueGfx31_2:
+.incbin "baserom.gba", 0xF96CD4, 0x20
+sTyrogueGfx31_3:
+.incbin "baserom.gba", 0xF96CF4, 0x20
+sTyrogueSprites31:
+ax_sprite sTyrogueGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx31_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx31_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sTyrogueGfx31_3, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sTyrogueGfx32:
+.incbin "baserom.gba", 0xF96D5C, 0x40
+sTyrogueGfx32_1:
+.incbin "baserom.gba", 0xF96D9C, 0x40
+sTyrogueGfx32_2:
+.incbin "baserom.gba", 0xF96DDC, 0x60
+sTyrogueGfx32_3:
+.incbin "baserom.gba", 0xF96E3C, 0x40
+sTyrogueSprites32:
+ax_sprite sTyrogueGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx32_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyrogueGfx33:
+.incbin "baserom.gba", 0xF96EC4, 0x100
+sTyrogueSprites33:
+ax_sprite sTyrogueGfx33, 0x100
+ax_sprite_terminator
+sTyrogueGfx34:
+.incbin "baserom.gba", 0xF96FD4, 0x20
+sTyrogueGfx34_1:
+.incbin "baserom.gba", 0xF96FF4, 0x20
+sTyrogueGfx34_2:
+.incbin "baserom.gba", 0xF97014, 0x20
+sTyrogueSprites34:
+ax_sprite sTyrogueGfx34, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx34_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx34_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sTyrogueGfx35:
+.incbin "baserom.gba", 0xF9706C, 0x100
+sTyrogueSprites35:
+ax_sprite sTyrogueGfx35, 0x100
+ax_sprite_terminator
+sTyrogueGfx36:
+.incbin "baserom.gba", 0xF9717C, 0x60
+sTyrogueGfx36_1:
+.incbin "baserom.gba", 0xF971DC, 0x60
+sTyrogueGfx36_2:
+.incbin "baserom.gba", 0xF9723C, 0x60
+sTyrogueGfx36_3:
+.incbin "baserom.gba", 0xF9729C, 0x60
+sTyrogueSprites36:
+ax_sprite sTyrogueGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx36_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx36_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyrogueGfx37:
+.incbin "baserom.gba", 0xF97344, 0x40
+sTyrogueGfx37_1:
+.incbin "baserom.gba", 0xF97384, 0x60
+sTyrogueGfx37_2:
+.incbin "baserom.gba", 0xF973E4, 0x60
+sTyrogueGfx37_3:
+.incbin "baserom.gba", 0xF97444, 0x40
+sTyrogueSprites37:
+ax_sprite sTyrogueGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx37_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyrogueGfx38:
+.incbin "baserom.gba", 0xF974CC, 0x100
+sTyrogueSprites38:
+ax_sprite sTyrogueGfx38, 0x100
+ax_sprite_terminator
+sTyrogueGfx39:
+.incbin "baserom.gba", 0xF975DC, 0x40
+sTyrogueGfx39_1:
+.incbin "baserom.gba", 0xF9761C, 0x60
+sTyrogueGfx39_2:
+.incbin "baserom.gba", 0xF9767C, 0x60
+sTyrogueGfx39_3:
+.incbin "baserom.gba", 0xF976DC, 0x40
+sTyrogueSprites39:
+ax_sprite sTyrogueGfx39, 0x40
+ax_sprite 0, 0x40
+ax_sprite sTyrogueGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx39_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sTyrogueGfx40:
+.incbin "baserom.gba", 0xF97764, 0x60
+sTyrogueGfx40_1:
+.incbin "baserom.gba", 0xF977C4, 0x60
+sTyrogueGfx40_2:
+.incbin "baserom.gba", 0xF97824, 0x60
+sTyrogueGfx40_3:
+.incbin "baserom.gba", 0xF97884, 0x60
+sTyrogueSprites40:
+ax_sprite sTyrogueGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx40_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sTyrogueGfx40_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sTyrogueGfx41:
+.incbin "baserom.gba", 0xF9792C, 0x200
+sTyrogueSprites41:
+ax_sprite sTyrogueGfx41, 0x200
+ax_sprite_terminator
+sTyrogueGfx42:
+.incbin "baserom.gba", 0xF97B3C, 0x200
+sTyrogueSprites42:
+ax_sprite sTyrogueGfx42, 0x200
+ax_sprite_terminator
+sTyrogueGfx43:
+.incbin "baserom.gba", 0xF97D4C, 0x200
+sTyrogueSprites43:
+ax_sprite sTyrogueGfx43, 0x200
+ax_sprite_terminator
+sTyrogueGfx44:
+.incbin "baserom.gba", 0xF97F5C, 0x200
+sTyrogueSprites44:
+ax_sprite sTyrogueGfx44, 0x200
+ax_sprite_terminator
+sTyrogueGfx45:
+.incbin "baserom.gba", 0xF9816C, 0x200
+sTyrogueSprites45:
+ax_sprite sTyrogueGfx45, 0x200
+ax_sprite_terminator
+sTyrogueGfx46:
+.incbin "baserom.gba", 0xF9837C, 0x200
+sTyrogueSprites46:
+ax_sprite sTyrogueGfx46, 0x200
+ax_sprite_terminator
+sTyrogueGfx47:
+.incbin "baserom.gba", 0xF9858C, 0x200
+sTyrogueSprites47:
+ax_sprite sTyrogueGfx47, 0x200
+ax_sprite_terminator
+sAxPosesTyrogue:
+.4byte sTyroguePose1
+.4byte sTyroguePose2
+.4byte sTyroguePose3
+.4byte sTyroguePose4
+.4byte sTyroguePose5
+.4byte sTyroguePose6
+.4byte sTyroguePose7
+.4byte sTyroguePose8
+.4byte sTyroguePose9
+.4byte sTyroguePose10
+.4byte sTyroguePose11
+.4byte sTyroguePose12
+.4byte sTyroguePose13
+.4byte sTyroguePose14
+.4byte sTyroguePose15
+.4byte sTyroguePose16
+.4byte sTyroguePose17
+.4byte sTyroguePose18
+.4byte sTyroguePose19
+.4byte sTyroguePose20
+.4byte sTyroguePose21
+.4byte sTyroguePose22
+.4byte sTyroguePose23
+.4byte sTyroguePose24
+.4byte sTyroguePose25
+.4byte sTyroguePose26
+.4byte sTyroguePose27
+.4byte sTyroguePose28
+.4byte sTyroguePose29
+.4byte sTyroguePose30
+.4byte sTyroguePose31
+.4byte sTyroguePose32
+.4byte sTyroguePose33
+.4byte sTyroguePose34
+.4byte sTyroguePose35
+.4byte sTyroguePose36
+.4byte sTyroguePose37
+.4byte sTyroguePose38
+.4byte sTyroguePose39
+.4byte sTyroguePose40
+.4byte sTyroguePose41
+.4byte sTyroguePose42
+.4byte sTyroguePose43
+.4byte sTyroguePose44
+.4byte sTyroguePose45
+.4byte sTyroguePose46
+.4byte sTyroguePose47
+.4byte sTyroguePose48
+.4byte sTyroguePose49
+.4byte sTyroguePose50
+.4byte sTyroguePose51
+.4byte sTyroguePose52
+.4byte sTyroguePose53
+.4byte sTyroguePose54
+.4byte sTyroguePose55
+.4byte sTyroguePose56
+.4byte sTyroguePose57
+.4byte sTyroguePose58
+.4byte sTyroguePose59
+.4byte sTyroguePose60
+.4byte sTyroguePose61
+.4byte sTyroguePose62
+.4byte sTyroguePose63
+.4byte sTyroguePose64
+.4byte sTyroguePose65
+.4byte sTyroguePose66
+.4byte sTyroguePose67
+.4byte sTyroguePose68
+.4byte sTyroguePose69
+.4byte sTyroguePose70
+.4byte sTyroguePose71
+.4byte sTyroguePose72
+.4byte sTyroguePose73
+.4byte sTyroguePose74
+.4byte sTyroguePose75
+.4byte sTyroguePose76
+.4byte sTyroguePose77
+.4byte sTyroguePose78
+.4byte sTyroguePose79
+.4byte sTyroguePose80
+.4byte sTyroguePose81
+.4byte sTyroguePose82
+.4byte sTyroguePose83
+.4byte sTyroguePose84
+.4byte sTyroguePose85
+.4byte sTyroguePose86
+.4byte sTyroguePose87
+.4byte sTyroguePose88
+.4byte sTyroguePose89
+.4byte sTyroguePose90
+.4byte sTyroguePose91
+.4byte sTyroguePose92
+.4byte sTyroguePose93
+.4byte sTyroguePose94
+.4byte sTyroguePose95
+.4byte sTyroguePose96
+.4byte sTyroguePose97
+.4byte sTyroguePose98
+.4byte sTyroguePose99
+.4byte sTyroguePose100
+.4byte sTyroguePose101
+.4byte sTyroguePose102
+.4byte sTyroguePose103
+.4byte sTyroguePose104
+.4byte sTyroguePose105
+.4byte sTyroguePose106
+.4byte sTyroguePose107
+.4byte sTyroguePose108
+.4byte sTyroguePose109
+.4byte sTyroguePose110
+.4byte sTyroguePose111
+.4byte sTyroguePose112
+.4byte sTyroguePose113
+.4byte sTyroguePose114
+.4byte sTyroguePose115
+.4byte sTyroguePose116
+.4byte sTyroguePose117
+.4byte sTyroguePose118
+.4byte sTyroguePose119
+.4byte sTyroguePose120
+.4byte sTyroguePose121
+.4byte sTyroguePose122
+.4byte sTyroguePose123
+.4byte sTyroguePose124
+.4byte sTyroguePose125
+.4byte sTyroguePose126
+.4byte sTyroguePose127
+.4byte sTyroguePose128
+.4byte sTyroguePose129
+.4byte sTyroguePose130
+.4byte sTyroguePose131
+.4byte sTyroguePose132
+.4byte sTyroguePose133
+.4byte sTyroguePose134
+.4byte sTyroguePose135
+.4byte sTyroguePose136
+.4byte sTyroguePose137
+.4byte sTyroguePose138
+.4byte sTyroguePose139
+.4byte sTyroguePose140
+.4byte sTyroguePose141
+.4byte sTyroguePose142
+.4byte sTyroguePose143
+.4byte sTyroguePose144
+.4byte sTyroguePose145
+.4byte sTyroguePose146
+.4byte sTyroguePose147
+.4byte sTyroguePose148
+.4byte sTyroguePose149
+.4byte sTyroguePose150
+.4byte sTyroguePose151
+.4byte sTyroguePose152
+.4byte sTyroguePose153
+.4byte sTyroguePose154
+.4byte sTyroguePose155
+.4byte sTyroguePose156
+.4byte sTyroguePose157
+.4byte sTyroguePose158
+.4byte sTyroguePose159
+.4byte sTyroguePose160
+.4byte sTyroguePose161
+.4byte sTyroguePose162
+.4byte sTyroguePose163
+.4byte sTyroguePose164
+.4byte sTyroguePose165
+.4byte sTyroguePose166
+.4byte sTyroguePose167
+.4byte sTyroguePose168
+.4byte sTyroguePose169
+.4byte sTyroguePose170
+.4byte sTyroguePose171
+.4byte sTyroguePose172
+.4byte sTyroguePose173
+.4byte sTyroguePose174
+.4byte sTyroguePose175
+.4byte sTyroguePose176
+.4byte sTyroguePose177
+.4byte sTyroguePose178
+.4byte sTyroguePose179
+.4byte sTyroguePose180
+.4byte sTyroguePose181
+.4byte sTyroguePose182
+.4byte sTyroguePose183
+.4byte sTyroguePose184
+.4byte sTyroguePose185
+.4byte sTyroguePose186
+.4byte sTyroguePose187
+.4byte sTyroguePose188
+.4byte sTyroguePose189
+.4byte sTyroguePose190
+.4byte sTyroguePose191
+.4byte sTyroguePose192
+.4byte sTyroguePose193
+.4byte sTyroguePose194
+.4byte sTyroguePose195
+.4byte sTyroguePose196
+.4byte sTyroguePose197
+.4byte sTyroguePose198
+.4byte sTyroguePose199
+.4byte sTyroguePose200
+.4byte sTyroguePose201
+.4byte sTyroguePose202
+.4byte sTyroguePose203
+.4byte sTyroguePose204
+.4byte sTyroguePose205
+.4byte sTyroguePose206
+.4byte sTyroguePose207
+.4byte sTyroguePose208
+.4byte sTyroguePose209
+.4byte sTyroguePose210
+sAxPositionsTyrogue:
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    0,  -12, 	  -5,   -8, 	   6,  -11, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -11, 	   4,   -8, 	  -1,   -9
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte    2,  -12, 	   8,  -10, 	  -8,   -7, 	  -1,  -10
+.2byte    3,  -12, 	   3,  -11, 	   2,   -6, 	  -1,  -10
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    2,  -12, 	  -6,   -7, 	   5,   -8, 	  -2,   -9
+.2byte    3,  -12, 	   6,   -8, 	  -8,   -6, 	   0,   -9
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    1,  -14, 	   4,   -9, 	  -4,   -4, 	  -1,   -9
+.2byte    1,  -14, 	  -8,   -7, 	   7,   -9, 	   0,   -9
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte   -1,  -14, 	   5,  -11, 	  -8,   -5, 	   0,  -11
+.2byte    0,  -14, 	   7,   -5, 	  -5,  -11, 	   0,  -11
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte   -2,  -14, 	  -5,   -9, 	   3,   -4, 	   0,   -9
+.2byte   -2,  -14, 	   7,   -7, 	  -8,   -9, 	  -1,   -9
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -3,  -12, 	   5,   -7, 	  -6,   -8, 	   1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	   7,   -6, 	  -1,   -9
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -3,  -12, 	  -9,  -10, 	   7,   -7, 	   0,  -10
+.2byte   -4,  -12, 	  -4,  -11, 	  -3,   -6, 	   0,  -10
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    0,  -12, 	  -5,   -8, 	   6,  -11, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -11, 	   4,   -8, 	  -1,   -9
+.2byte   -1,   -8, 	   2,   -6, 	  -4,   -6, 	   0,   -8
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte    2,  -12, 	   8,  -10, 	  -8,   -7, 	  -1,  -10
+.2byte    3,  -12, 	   3,  -11, 	   2,   -6, 	  -1,  -10
+.2byte    1,   -8, 	   0,   -5, 	   3,   -7, 	  -1,   -6
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    2,  -12, 	  -6,   -7, 	   5,   -8, 	  -2,   -9
+.2byte    3,  -12, 	   6,   -8, 	  -8,   -6, 	   0,   -9
+.2byte    2,   -9, 	   1,   -5, 	   4,   -8, 	  -3,   -7
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    1,  -14, 	   4,   -9, 	  -4,   -4, 	  -1,   -9
+.2byte    1,  -14, 	  -8,   -7, 	   7,   -9, 	   0,   -9
+.2byte    4,  -11, 	   5,   -7, 	   0,  -10, 	   0,   -8
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte   -1,  -14, 	   5,  -11, 	  -8,   -5, 	   0,  -11
+.2byte    0,  -14, 	   7,   -5, 	  -5,  -11, 	   0,  -11
+.2byte    0,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -8
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte   -2,  -14, 	  -5,   -9, 	   3,   -4, 	   0,   -9
+.2byte   -2,  -14, 	   7,   -7, 	  -8,   -9, 	  -1,   -9
+.2byte   -5,  -11, 	  -6,   -7, 	  -1,  -10, 	  -1,   -8
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -3,  -12, 	   5,   -7, 	  -6,   -8, 	   1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	   7,   -6, 	  -1,   -9
+.2byte   -3,   -9, 	  -2,   -5, 	  -5,   -8, 	   2,   -7
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -3,  -12, 	  -9,  -10, 	   7,   -7, 	   0,  -10
+.2byte   -4,  -12, 	  -4,  -11, 	  -3,   -6, 	   0,  -10
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -7, 	   0,   -6
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    0,  -12, 	  -2,  -16, 	  -4,   -9, 	   1,   -9
+.2byte   -1,   -4, 	  -4,    2, 	   5,   -5, 	   0,   -5
+.2byte   -1,   -4, 	  -4,    2, 	   5,   -5, 	   0,   -5
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte    0,  -11, 	  -9,  -12, 	   3,   -9, 	  -2,   -9
+.2byte    2,   -6, 	   7,   -1, 	  -4,   -5, 	   0,   -5
+.2byte    2,   -6, 	   7,   -1, 	  -4,   -5, 	   0,   -5
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    0,  -11, 	 -10,   -9, 	   4,  -11, 	  -4,   -9
+.2byte    4,   -9, 	  11,   -7, 	  -2,   -7, 	  -1,   -8
+.2byte    4,   -9, 	  11,   -7, 	  -2,   -7, 	  -1,   -8
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    1,  -12, 	  -6,   -5, 	   5,  -11, 	   0,   -8
+.2byte    2,  -11, 	   8,  -15, 	   3,   -7, 	  -1,   -7
+.2byte    2,  -11, 	   8,  -15, 	   3,   -7, 	  -1,   -7
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte   -1,  -12, 	   0,   -3, 	   3,   -9, 	  -2,   -8
+.2byte   -2,  -14, 	   3,  -20, 	  -7,  -10, 	  -2,   -9
+.2byte   -2,  -14, 	   3,  -20, 	  -7,  -10, 	  -2,   -9
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte   -2,  -12, 	   5,   -5, 	  -6,  -11, 	  -1,   -8
+.2byte   -3,  -11, 	  -9,  -15, 	  -4,   -7, 	   0,   -7
+.2byte   -3,  -11, 	  -9,  -15, 	  -4,   -7, 	   0,   -7
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -1,  -11, 	   9,   -9, 	  -5,  -11, 	   3,   -9
+.2byte   -4,   -8, 	 -11,   -6, 	   2,   -6, 	   1,   -7
+.2byte   -4,   -8, 	 -11,   -6, 	   2,   -6, 	   1,   -7
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -1,  -11, 	   8,  -12, 	  -4,   -9, 	   1,   -9
+.2byte   -3,   -6, 	  -8,   -1, 	   3,   -5, 	  -1,   -5
+.2byte   -3,   -6, 	  -8,   -1, 	   3,   -5, 	  -1,   -5
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -1,   -8, 	   2,   -6, 	  -4,   -6, 	   0,   -8
+.2byte   -1,  -14, 	  -9,  -12, 	   8,  -12, 	  -1,  -11
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte    1,   -8, 	   0,   -5, 	   3,   -7, 	  -1,   -6
+.2byte    3,  -13, 	   6,  -13, 	  -8,  -10, 	   1,   -9
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    3,   -9, 	   2,   -5, 	   5,   -8, 	  -2,   -7
+.2byte    2,  -13, 	   4,  -20, 	  -6,  -10, 	   1,   -9
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    4,  -11, 	   5,   -7, 	   0,  -10, 	   0,   -8
+.2byte    0,  -13, 	  -8,  -12, 	   6,   -8, 	  -1,   -9
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte    0,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -8
+.2byte   -1,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -9
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte   -5,  -11, 	  -6,   -7, 	  -1,  -10, 	  -1,   -8
+.2byte   -1,  -13, 	   7,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -4,   -9, 	  -3,   -5, 	  -6,   -8, 	   1,   -7
+.2byte   -3,  -13, 	  -5,  -20, 	   5,  -10, 	  -2,   -9
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -7, 	   0,   -6
+.2byte   -4,  -13, 	  -7,  -13, 	   7,  -10, 	  -2,   -9
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -3,   -7, 	  -5,   -4, 	   5,   -1, 	   0,   -5
+.2byte   -3,   -8, 	  -4,   -5, 	   5,   -2, 	   0,   -6
+.2byte    0,  -12, 	  -9,  -13, 	   8,  -13, 	   0,   -9
+.2byte    1,  -12, 	   2,  -14, 	 -10,  -13, 	  -2,   -9
+.2byte    1,  -11, 	  -2,  -16, 	  -8,  -12, 	  -2,   -7
+.2byte   -3,  -11, 	  -5,  -15, 	   1,  -13, 	  -2,   -6
+.2byte    0,  -13, 	   8,  -11, 	  -9,  -11, 	  -1,   -9
+.2byte    2,  -11, 	   4,  -15, 	  -2,  -13, 	   1,   -6
+.2byte   -2,  -11, 	   1,  -16, 	   7,  -12, 	   1,   -7
+.2byte   -2,  -12, 	  -3,  -14, 	   9,  -13, 	   1,   -9
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte    0,  -12, 	  -5,   -8, 	   6,  -11, 	   0,   -9
+.2byte    0,  -12, 	  -7,  -11, 	   4,   -8, 	  -1,   -9
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte    2,  -12, 	   8,  -10, 	  -8,   -7, 	  -1,  -10
+.2byte    3,  -12, 	   3,  -11, 	   2,   -6, 	  -1,  -10
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    2,  -12, 	  -6,   -7, 	   5,   -8, 	  -2,   -9
+.2byte    3,  -12, 	   6,   -8, 	  -8,   -6, 	   0,   -9
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    1,  -14, 	   4,   -9, 	  -4,   -4, 	  -1,   -9
+.2byte    1,  -14, 	  -8,   -7, 	   7,   -9, 	   0,   -9
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte   -1,  -14, 	   5,  -11, 	  -8,   -5, 	   0,  -11
+.2byte    0,  -14, 	   7,   -5, 	  -5,  -11, 	   0,  -11
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte   -2,  -14, 	  -5,   -9, 	   3,   -4, 	   0,   -9
+.2byte   -2,  -14, 	   7,   -7, 	  -8,   -9, 	  -1,   -9
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -3,  -12, 	   5,   -7, 	  -6,   -8, 	   1,   -9
+.2byte   -4,  -12, 	  -7,   -8, 	   7,   -6, 	  -1,   -9
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -3,  -12, 	  -9,  -10, 	   7,   -7, 	   0,  -10
+.2byte   -4,  -12, 	  -4,  -11, 	  -3,   -6, 	   0,  -10
+.2byte   -1,   -8, 	   2,   -6, 	  -4,   -6, 	   0,   -8
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -7, 	   0,   -6
+.2byte   -3,   -9, 	  -2,   -5, 	  -5,   -8, 	   2,   -7
+.2byte   -3,  -11, 	  -4,   -7, 	   1,  -10, 	   1,   -8
+.2byte    0,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -8
+.2byte    2,  -11, 	   3,   -7, 	  -2,  -10, 	  -2,   -8
+.2byte    2,   -9, 	   1,   -5, 	   4,   -8, 	  -3,   -7
+.2byte    1,   -8, 	   0,   -5, 	   3,   -7, 	  -1,   -6
+.2byte   -1,  -14, 	  -9,  -12, 	   8,  -12, 	  -1,  -11
+.2byte    3,  -13, 	   6,  -13, 	  -8,  -10, 	   1,   -9
+.2byte    2,  -13, 	   4,  -20, 	  -6,  -10, 	   1,   -9
+.2byte    0,  -13, 	  -8,  -12, 	   6,   -8, 	  -1,   -9
+.2byte   -1,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -9
+.2byte   -1,  -13, 	   7,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -3,  -13, 	  -5,  -20, 	   5,  -10, 	  -2,   -9
+.2byte   -4,  -13, 	  -7,  -13, 	   7,  -10, 	  -2,   -9
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -1,  -14, 	  -9,  -12, 	   8,  -12, 	  -1,  -11
+.2byte   -1,   -8, 	   2,   -6, 	  -4,   -6, 	   0,   -8
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte    3,  -13, 	   6,  -13, 	  -8,  -10, 	   1,   -9
+.2byte    1,   -8, 	   0,   -5, 	   3,   -7, 	  -1,   -6
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    2,  -13, 	   4,  -20, 	  -6,  -10, 	   1,   -9
+.2byte    3,   -9, 	   2,   -5, 	   5,   -8, 	  -2,   -7
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    0,  -13, 	  -8,  -12, 	   6,   -8, 	  -1,   -9
+.2byte    4,  -11, 	   5,   -7, 	   0,  -10, 	   0,   -8
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte   -1,  -15, 	   8,  -11, 	  -9,  -11, 	   0,   -9
+.2byte    0,  -12, 	  -4,   -9, 	   3,   -9, 	   0,   -8
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte   -1,  -13, 	   7,  -12, 	  -7,   -8, 	   0,   -9
+.2byte   -5,  -11, 	  -6,   -7, 	  -1,  -10, 	  -1,   -8
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -3,  -13, 	  -5,  -20, 	   5,  -10, 	  -2,   -9
+.2byte   -4,   -9, 	  -3,   -5, 	  -6,   -8, 	   1,   -7
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -4,  -13, 	  -7,  -13, 	   7,  -10, 	  -2,   -9
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -7, 	   0,   -6
+.2byte   -1,   -8, 	   2,   -6, 	  -4,   -6, 	   0,   -8
+.2byte   -2,   -8, 	  -1,   -5, 	  -4,   -7, 	   0,   -6
+.2byte   -3,   -9, 	  -2,   -5, 	  -5,   -8, 	   2,   -7
+.2byte   -3,  -11, 	  -4,   -7, 	   1,  -10, 	   1,   -8
+.2byte    0,  -13, 	  -4,  -10, 	   3,  -10, 	   0,   -9
+.2byte    2,  -11, 	   3,   -7, 	  -2,  -10, 	  -2,   -8
+.2byte    2,   -9, 	   1,   -5, 	   4,   -8, 	  -3,   -7
+.2byte    1,   -8, 	   0,   -5, 	   3,   -7, 	  -1,   -6
+.2byte   -1,  -11, 	  -7,   -7, 	   6,   -7, 	   0,   -8
+.2byte   -4,  -11, 	  -6,   -7, 	   4,   -5, 	   0,   -9
+.2byte   -4,  -11, 	  -1,   -6, 	   0,   -4, 	   0,   -9
+.2byte   -3,  -12, 	   4,   -7, 	  -5,   -4, 	   0,   -8
+.2byte    0,  -13, 	   6,   -6, 	  -7,   -6, 	  -1,  -10
+.2byte    2,  -12, 	  -5,   -7, 	   4,   -4, 	  -1,   -8
+.2byte    3,  -11, 	   0,   -6, 	  -1,   -4, 	  -1,   -9
+.2byte    3,  -11, 	   5,   -7, 	  -5,   -5, 	  -1,   -9
+sTyrogueAnimTable1:
+.4byte sTyrogueAnims_1_1
+.4byte sTyrogueAnims_1_2
+.4byte sTyrogueAnims_1_3
+.4byte sTyrogueAnims_1_4
+.4byte sTyrogueAnims_1_5
+.4byte sTyrogueAnims_1_6
+.4byte sTyrogueAnims_1_7
+.4byte sTyrogueAnims_1_8
+sTyrogueAnimTable2:
+.4byte sTyrogueAnims_2_1
+.4byte sTyrogueAnims_2_2
+.4byte sTyrogueAnims_2_3
+.4byte sTyrogueAnims_2_4
+.4byte sTyrogueAnims_2_5
+.4byte sTyrogueAnims_2_6
+.4byte sTyrogueAnims_2_7
+.4byte sTyrogueAnims_2_8
+sTyrogueAnimTable3:
+.4byte sTyrogueAnims_3_1
+.4byte sTyrogueAnims_3_2
+.4byte sTyrogueAnims_3_3
+.4byte sTyrogueAnims_3_4
+.4byte sTyrogueAnims_3_5
+.4byte sTyrogueAnims_3_6
+.4byte sTyrogueAnims_3_7
+.4byte sTyrogueAnims_3_8
+sTyrogueAnimTable4:
+.4byte sTyrogueAnims_4_1
+.4byte sTyrogueAnims_4_2
+.4byte sTyrogueAnims_4_3
+.4byte sTyrogueAnims_4_4
+.4byte sTyrogueAnims_4_5
+.4byte sTyrogueAnims_4_6
+.4byte sTyrogueAnims_4_7
+.4byte sTyrogueAnims_4_8
+sTyrogueAnimTable5:
+.4byte sTyrogueAnims_5_1
+.4byte sTyrogueAnims_5_2
+.4byte sTyrogueAnims_5_3
+.4byte sTyrogueAnims_5_4
+.4byte sTyrogueAnims_5_5
+.4byte sTyrogueAnims_5_6
+.4byte sTyrogueAnims_5_7
+.4byte sTyrogueAnims_5_8
+sTyrogueAnimTable6:
+.4byte sTyrogueAnims_6_1
+.4byte sTyrogueAnims_6_1
+.4byte sTyrogueAnims_6_1
+.4byte sTyrogueAnims_6_1
+.4byte sTyrogueAnims_6_1
+.4byte sTyrogueAnims_6_1
+.4byte sTyrogueAnims_6_1
+.4byte sTyrogueAnims_6_1
+sTyrogueAnimTable7:
+.4byte sTyrogueAnims_7_1
+.4byte sTyrogueAnims_7_2
+.4byte sTyrogueAnims_7_3
+.4byte sTyrogueAnims_7_4
+.4byte sTyrogueAnims_7_5
+.4byte sTyrogueAnims_7_6
+.4byte sTyrogueAnims_7_7
+.4byte sTyrogueAnims_7_8
+sTyrogueAnimTable8:
+.4byte sTyrogueAnims_8_1
+.4byte sTyrogueAnims_8_2
+.4byte sTyrogueAnims_8_3
+.4byte sTyrogueAnims_8_4
+.4byte sTyrogueAnims_8_5
+.4byte sTyrogueAnims_8_6
+.4byte sTyrogueAnims_8_7
+.4byte sTyrogueAnims_8_8
+sTyrogueAnimTable9:
+.4byte sTyrogueAnims_9_1
+.4byte sTyrogueAnims_9_2
+.4byte sTyrogueAnims_9_3
+.4byte sTyrogueAnims_9_4
+.4byte sTyrogueAnims_9_5
+.4byte sTyrogueAnims_9_6
+.4byte sTyrogueAnims_9_7
+.4byte sTyrogueAnims_9_8
+sTyrogueAnimTable10:
+.4byte sTyrogueAnims_10_1
+.4byte sTyrogueAnims_10_2
+.4byte sTyrogueAnims_10_3
+.4byte sTyrogueAnims_10_4
+.4byte sTyrogueAnims_10_5
+.4byte sTyrogueAnims_10_6
+.4byte sTyrogueAnims_10_7
+.4byte sTyrogueAnims_10_8
+sTyrogueAnimTable11:
+.4byte sTyrogueAnims_11_1
+.4byte sTyrogueAnims_11_2
+.4byte sTyrogueAnims_11_3
+.4byte sTyrogueAnims_11_4
+.4byte sTyrogueAnims_11_5
+.4byte sTyrogueAnims_11_6
+.4byte sTyrogueAnims_11_7
+.4byte sTyrogueAnims_11_8
+sTyrogueAnimTable12:
+.4byte sTyrogueAnims_12_1
+.4byte sTyrogueAnims_12_2
+.4byte sTyrogueAnims_12_3
+.4byte sTyrogueAnims_12_4
+.4byte sTyrogueAnims_12_5
+.4byte sTyrogueAnims_12_6
+.4byte sTyrogueAnims_12_7
+.4byte sTyrogueAnims_12_8
+sTyrogueAnimTable13:
+.4byte sTyrogueAnims_13_1
+.4byte sTyrogueAnims_13_2
+.4byte sTyrogueAnims_13_3
+.4byte sTyrogueAnims_13_4
+.4byte sTyrogueAnims_13_5
+.4byte sTyrogueAnims_13_6
+.4byte sTyrogueAnims_13_7
+.4byte sTyrogueAnims_13_8
+sAxAnimationsTyrogue:
+.4byte sTyrogueAnimTable1
+.4byte sTyrogueAnimTable2
+.4byte sTyrogueAnimTable3
+.4byte sTyrogueAnimTable4
+.4byte sTyrogueAnimTable5
+.4byte sTyrogueAnimTable6
+.4byte sTyrogueAnimTable7
+.4byte sTyrogueAnimTable8
+.4byte sTyrogueAnimTable9
+.4byte sTyrogueAnimTable10
+.4byte sTyrogueAnimTable11
+.4byte sTyrogueAnimTable12
+.4byte sTyrogueAnimTable13
+sAxSpritesTyrogue:
+.4byte sTyrogueSprites1
+.4byte sTyrogueSprites2
+.4byte sTyrogueSprites3
+.4byte sTyrogueSprites4
+.4byte sTyrogueSprites5
+.4byte sTyrogueSprites6
+.4byte sTyrogueSprites7
+.4byte sTyrogueSprites8
+.4byte sTyrogueSprites9
+.4byte sTyrogueSprites10
+.4byte sTyrogueSprites11
+.4byte sTyrogueSprites12
+.4byte sTyrogueSprites13
+.4byte sTyrogueSprites14
+.4byte sTyrogueSprites15
+.4byte sTyrogueSprites16
+.4byte sTyrogueSprites17
+.4byte sTyrogueSprites18
+.4byte sTyrogueSprites19
+.4byte sTyrogueSprites20
+.4byte sTyrogueSprites21
+.4byte sTyrogueSprites22
+.4byte sTyrogueSprites23
+.4byte sTyrogueSprites24
+.4byte sTyrogueSprites25
+.4byte sTyrogueSprites26
+.4byte sTyrogueSprites27
+.4byte sTyrogueSprites28
+.4byte sTyrogueSprites29
+.4byte sTyrogueSprites30
+.4byte sTyrogueSprites31
+.4byte sTyrogueSprites32
+.4byte sTyrogueSprites33
+.4byte sTyrogueSprites34
+.4byte sTyrogueSprites35
+.4byte sTyrogueSprites36
+.4byte sTyrogueSprites37
+.4byte sTyrogueSprites38
+.4byte sTyrogueSprites39
+.4byte sTyrogueSprites40
+.4byte sTyrogueSprites41
+.4byte sTyrogueSprites42
+.4byte sTyrogueSprites43
+.4byte sTyrogueSprites44
+.4byte sTyrogueSprites45
+.4byte sTyrogueSprites46
+.4byte sTyrogueSprites47
+sAxMainTyrogue:
+ax_main sAxPosesTyrogue, sAxAnimationsTyrogue, 13, sAxSpritesTyrogue, sAxPositionsTyrogue

--- a/data/ax/umbreon.inc
+++ b/data/ax/umbreon.inc
@@ -1,0 +1,2649 @@
+.global gAxUmbreon
+gAxUmbreon:
+ax_siro sAxMainUmbreon
+sUmbreonPose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose2:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose3:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose4:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose5:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose7:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose8:
+ax_pose 7, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose9:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose10:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose11:
+ax_pose 10, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose12:
+ax_pose 11, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose16:
+ax_pose 9, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose17:
+ax_pose 10, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose18:
+ax_pose 11, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose22:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose23:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose26:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose27:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose28:
+ax_pose 15, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose29:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose30:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose31:
+ax_pose 5, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose32:
+ax_pose 16, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose33:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose34:
+ax_pose 7, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose35:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose36:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose37:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose38:
+ax_pose 10, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose39:
+ax_pose 11, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose40:
+ax_pose 18, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUmbreonPose41:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose42:
+ax_pose 13, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose43:
+ax_pose 14, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose44:
+ax_pose 19, 0x81e7, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose45:
+ax_pose 9, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose46:
+ax_pose 10, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose47:
+ax_pose 11, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose48:
+ax_pose 18, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose49:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose50:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose51:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose52:
+ax_pose 17, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose53:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose54:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose55:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose56:
+ax_pose 16, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose57:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose58:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose59:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose60:
+ax_pose 15, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose61:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose62:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose63:
+ax_pose 5, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose64:
+ax_pose 16, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose65:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose66:
+ax_pose 7, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose67:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose68:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose69:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose70:
+ax_pose 10, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose71:
+ax_pose 11, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose72:
+ax_pose 18, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUmbreonPose73:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose74:
+ax_pose 13, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose75:
+ax_pose 14, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose76:
+ax_pose 19, 0x81e7, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose77:
+ax_pose 9, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose78:
+ax_pose 10, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose79:
+ax_pose 11, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose80:
+ax_pose 18, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose81:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose82:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose83:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose84:
+ax_pose 17, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose85:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose86:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose87:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose88:
+ax_pose 16, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose89:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose90:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose91:
+ax_pose 15, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose92:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose93:
+ax_pose 21, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose94:
+ax_pose 16, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose95:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose96:
+ax_pose 22, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose97:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose98:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose99:
+ax_pose 23, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sUmbreonPose100:
+ax_pose 18, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose101:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose102:
+ax_pose 24, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose103:
+ax_pose 19, 0x81e7, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose104:
+ax_pose 9, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose105:
+ax_pose 23, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose106:
+ax_pose 18, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose107:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose108:
+ax_pose 22, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose109:
+ax_pose 17, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose110:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose111:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose112:
+ax_pose 16, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose113:
+ax_pose 15, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose114:
+ax_pose 16, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose115:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose116:
+ax_pose 18, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose117:
+ax_pose 19, 0x81e6, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose118:
+ax_pose 18, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose119:
+ax_pose 17, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose120:
+ax_pose 16, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose121:
+ax_pose 25, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sUmbreonPose122:
+ax_pose 26, 0x01ec, 0x80f2, 0x5c00
+ax_pose_terminator
+sUmbreonPose123:
+ax_pose 27, 0x01e2, 0x80f1, 0x5c00
+ax_pose_terminator
+sUmbreonPose124:
+ax_pose 28, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose125:
+ax_pose 29, 0x01e3, 0x90ea, 0x5c00
+ax_pose_terminator
+sUmbreonPose126:
+ax_pose 30, 0x01e5, 0x90e9, 0x5c00
+ax_pose_terminator
+sUmbreonPose127:
+ax_pose 31, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sUmbreonPose128:
+ax_pose 30, 0x01e5, 0x80f7, 0x5c00
+ax_pose_terminator
+sUmbreonPose129:
+ax_pose 29, 0x01e3, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose130:
+ax_pose 28, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose131:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose132:
+ax_pose 1, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose133:
+ax_pose 2, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose134:
+ax_pose 15, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose135:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose136:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose137:
+ax_pose 5, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose138:
+ax_pose 16, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose139:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose140:
+ax_pose 7, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose141:
+ax_pose 8, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose142:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose143:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose144:
+ax_pose 10, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose145:
+ax_pose 11, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose146:
+ax_pose 18, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUmbreonPose147:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose148:
+ax_pose 13, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose149:
+ax_pose 14, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose150:
+ax_pose 19, 0x81e7, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose151:
+ax_pose 9, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose152:
+ax_pose 10, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose153:
+ax_pose 11, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose154:
+ax_pose 18, 0x01e7, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose155:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose156:
+ax_pose 7, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose157:
+ax_pose 8, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose158:
+ax_pose 17, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose159:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose160:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose161:
+ax_pose 5, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose162:
+ax_pose 16, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose163:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose164:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose165:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose166:
+ax_pose 9, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose167:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose168:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose169:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose170:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose171:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose172:
+ax_pose 21, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sUmbreonPose173:
+ax_pose 22, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose174:
+ax_pose 23, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose175:
+ax_pose 24, 0x81e7, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose176:
+ax_pose 23, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose177:
+ax_pose 22, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose178:
+ax_pose 21, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose179:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose180:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose181:
+ax_pose 15, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose182:
+ax_pose 3, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose183:
+ax_pose 21, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose184:
+ax_pose 16, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sUmbreonPose185:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose186:
+ax_pose 22, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose187:
+ax_pose 17, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose188:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose189:
+ax_pose 23, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sUmbreonPose190:
+ax_pose 18, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose191:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose192:
+ax_pose 24, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose193:
+ax_pose 19, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose194:
+ax_pose 9, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose195:
+ax_pose 23, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose196:
+ax_pose 18, 0x01e6, 0x80f6, 0x5c00
+ax_pose_terminator
+sUmbreonPose197:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose198:
+ax_pose 22, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose199:
+ax_pose 17, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose200:
+ax_pose 3, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose201:
+ax_pose 21, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose202:
+ax_pose 16, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sUmbreonPose203:
+ax_pose 20, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose204:
+ax_pose 21, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose205:
+ax_pose 22, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose206:
+ax_pose 23, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose207:
+ax_pose 24, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sUmbreonPose208:
+ax_pose 23, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUmbreonPose209:
+ax_pose 22, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose210:
+ax_pose 21, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose211:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose212:
+ax_pose 3, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sUmbreonPose213:
+ax_pose 6, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose214:
+ax_pose 9, 0x01e7, 0x80f5, 0x5c00
+ax_pose_terminator
+sUmbreonPose215:
+ax_pose 12, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUmbreonPose216:
+ax_pose 9, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUmbreonPose217:
+ax_pose 6, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUmbreonPose218:
+ax_pose 3, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+.align 2
+sUmbreonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 1, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim 4, 0, 24, 0, 1, 0, 1,
+ax_anim_terminator
+sUmbreonAnims_2_2:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 6, 0, 31, -2, -2, -2, -2,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 1, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 0, 29, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 4, 0, 28, 1, 1, 1, 1,
+ax_anim_terminator
+sUmbreonAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 6, 0, 35, -2, 0, -2, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 33, 10, 0, 10, 0,
+ax_anim 1, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 1, 33, 19, 0, 19, 0,
+ax_anim 2, 0, 33, 18, 0, 18, 0,
+ax_anim 2, 0, 33, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 4, 0, 4, 0,
+ax_anim 4, 0, 32, 1, 0, 1, 0,
+ax_anim_terminator
+sUmbreonAnims_2_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 2, 37, 4, -4, 4, -4,
+ax_anim 1, 0, 37, 10, -10, 10, -10,
+ax_anim 1, 0, 37, 18, -18, 18, -18,
+ax_anim 2, 1, 37, 19, -17, 19, -17,
+ax_anim 2, 0, 37, 18, -18, 18, -18,
+ax_anim 2, 0, 37, 19, -17, 19, -17,
+ax_anim 2, 0, 36, 4, -4, 4, -4,
+ax_anim 4, 0, 36, 1, -1, 1, -1,
+ax_anim_terminator
+sUmbreonAnims_2_5:
+ax_anim 2, 0, 43, 0, 1, 0, 1,
+ax_anim 6, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 41, 0, -10, 0, -10,
+ax_anim 1, 0, 41, 0, -18, 0, -18,
+ax_anim 2, 1, 41, 1, -18, 1, -18,
+ax_anim 2, 0, 41, 0, -18, 0, -18,
+ax_anim 2, 0, 41, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -4, 0, -4,
+ax_anim 4, 0, 40, 0, -1, 0, -1,
+ax_anim_terminator
+sUmbreonAnims_2_6:
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 6, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 2, 45, -4, -4, -4, -4,
+ax_anim 1, 0, 45, -10, -10, -10, -10,
+ax_anim 1, 0, 45, -18, -18, -18, -18,
+ax_anim 2, 1, 45, -19, -17, -19, -17,
+ax_anim 2, 0, 45, -18, -18, -18, -18,
+ax_anim 2, 0, 45, -19, -17, -19, -17,
+ax_anim 2, 0, 44, -4, -4, -4, -4,
+ax_anim 4, 0, 44, -1, -1, -1, -1,
+ax_anim_terminator
+sUmbreonAnims_2_7:
+ax_anim 2, 0, 51, 1, 0, 1, 0,
+ax_anim 6, 0, 51, 2, 0, 2, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 49, -10, 0, -10, 0,
+ax_anim 1, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 1, 49, -19, 0, -19, 0,
+ax_anim 2, 0, 49, -18, 0, -18, 0,
+ax_anim 2, 0, 49, -19, 0, -19, 0,
+ax_anim 2, 0, 48, -4, 0, -4, 0,
+ax_anim 4, 0, 48, -1, 0, -1, 0,
+ax_anim_terminator
+sUmbreonAnims_2_8:
+ax_anim 2, 0, 55, 1, -1, 1, -1,
+ax_anim 6, 0, 55, 2, -2, 2, -2,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 53, -10, 10, -10, 10,
+ax_anim 1, 0, 53, -18, 18, -18, 18,
+ax_anim 2, 1, 53, -19, 17, -19, 17,
+ax_anim 2, 0, 53, -18, 18, -18, 18,
+ax_anim 2, 0, 53, -19, 17, -19, 17,
+ax_anim 2, 0, 52, -4, 4, -4, 4,
+ax_anim 4, 0, 52, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_3_1:
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 6, 0, 59, 0, -2, 0, -2,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 57, 0, 10, 0, 10,
+ax_anim 1, 0, 57, 0, 18, 0, 18,
+ax_anim 2, 1, 57, 1, 18, 1, 18,
+ax_anim 2, 0, 57, 0, 18, 0, 18,
+ax_anim 2, 0, 57, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim 4, 0, 56, 0, 1, 0, 1,
+ax_anim_terminator
+sUmbreonAnims_3_2:
+ax_anim 2, 0, 63, -1, -1, -1, -1,
+ax_anim 6, 0, 63, -2, -2, -2, -2,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 61, 10, 10, 10, 10,
+ax_anim 1, 0, 61, 18, 18, 18, 18,
+ax_anim 2, 1, 61, 19, 17, 19, 17,
+ax_anim 2, 0, 61, 18, 18, 18, 18,
+ax_anim 2, 0, 61, 19, 17, 19, 17,
+ax_anim 2, 0, 60, 4, 4, 4, 4,
+ax_anim 4, 0, 60, 1, 1, 1, 1,
+ax_anim_terminator
+sUmbreonAnims_3_3:
+ax_anim 2, 0, 67, -1, 0, -1, 0,
+ax_anim 6, 0, 67, -2, 0, -2, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 65, 10, 0, 10, 0,
+ax_anim 1, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 1, 65, 19, 0, 19, 0,
+ax_anim 2, 0, 65, 18, 0, 18, 0,
+ax_anim 2, 0, 65, 19, 0, 19, 0,
+ax_anim 2, 0, 64, 4, 0, 4, 0,
+ax_anim 4, 0, 64, 1, 0, 1, 0,
+ax_anim_terminator
+sUmbreonAnims_3_4:
+ax_anim 2, 0, 71, -1, 1, -1, 1,
+ax_anim 6, 0, 71, -2, 2, -2, 2,
+ax_anim 1, 2, 69, 4, -4, 4, -4,
+ax_anim 1, 0, 69, 10, -10, 10, -10,
+ax_anim 1, 0, 69, 18, -18, 18, -18,
+ax_anim 2, 1, 69, 19, -17, 19, -17,
+ax_anim 2, 0, 69, 18, -18, 18, -18,
+ax_anim 2, 0, 69, 19, -17, 19, -17,
+ax_anim 2, 0, 68, 4, -4, 4, -4,
+ax_anim 4, 0, 68, 1, -1, 1, -1,
+ax_anim_terminator
+sUmbreonAnims_3_5:
+ax_anim 2, 0, 75, 0, 1, 0, 1,
+ax_anim 6, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 73, 0, -10, 0, -10,
+ax_anim 1, 0, 73, 0, -18, 0, -18,
+ax_anim 2, 1, 73, 1, -18, 1, -18,
+ax_anim 2, 0, 73, 0, -18, 0, -18,
+ax_anim 2, 0, 73, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -4, 0, -4,
+ax_anim 4, 0, 72, 0, -1, 0, -1,
+ax_anim_terminator
+sUmbreonAnims_3_6:
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 6, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 2, 77, -4, -4, -4, -4,
+ax_anim 1, 0, 77, -10, -10, -10, -10,
+ax_anim 1, 0, 77, -18, -18, -18, -18,
+ax_anim 2, 1, 77, -19, -17, -19, -17,
+ax_anim 2, 0, 77, -18, -18, -18, -18,
+ax_anim 2, 0, 77, -19, -17, -19, -17,
+ax_anim 2, 0, 76, -4, -4, -4, -4,
+ax_anim 4, 0, 76, -1, -1, -1, -1,
+ax_anim_terminator
+sUmbreonAnims_3_7:
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 6, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 81, -10, 0, -10, 0,
+ax_anim 1, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 1, 81, -19, 0, -19, 0,
+ax_anim 2, 0, 81, -18, 0, -18, 0,
+ax_anim 2, 0, 81, -19, 0, -19, 0,
+ax_anim 2, 0, 80, -4, 0, -4, 0,
+ax_anim 4, 0, 80, -1, 0, -1, 0,
+ax_anim_terminator
+sUmbreonAnims_3_8:
+ax_anim 2, 0, 87, 1, -1, 1, -1,
+ax_anim 6, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 85, -10, 10, -10, 10,
+ax_anim 1, 0, 85, -18, 18, -18, 18,
+ax_anim 2, 1, 85, -19, 17, -19, 17,
+ax_anim 2, 0, 85, -18, 18, -18, 18,
+ax_anim 2, 0, 85, -19, 17, -19, 17,
+ax_anim 2, 0, 84, -4, 4, -4, 4,
+ax_anim 4, 0, 84, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_4_1:
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 6, 0, 90, 0, -2, 0, -2,
+ax_anim 4, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 2, 89, -1, 2, -1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, -1, 2, -1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 1, 89, -1, 2, -1, 2,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 0, 89, -1, 2, -1, 2,
+ax_anim_terminator
+sUmbreonAnims_4_2:
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, -1, -1, -1,
+ax_anim 6, 0, 93, -2, -2, -2, -2,
+ax_anim 4, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 2, 92, 2, -1, 2, -1,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 2, -1, 2, -1,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 1, 92, 2, -1, 2, -1,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 2, -1, 2, -1,
+ax_anim_terminator
+sUmbreonAnims_4_3:
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 6, 0, 96, -2, 0, -2, 0,
+ax_anim 4, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 2, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 2, 1, 2, 1,
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 2, 1, 2, 1,
+ax_anim 2, 1, 95, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 2, 1, 2, 1,
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim_terminator
+sUmbreonAnims_4_4:
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 99, -1, 1, -1, 1,
+ax_anim 6, 0, 99, -2, 2, -2, 2,
+ax_anim 4, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 2, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 1, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim_terminator
+sUmbreonAnims_4_5:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 1, 0, 1,
+ax_anim 6, 0, 102, 0, 2, 0, 2,
+ax_anim 4, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 2, 101, -1, -2, -1, -2,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, -1, -2, -1, -2,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 1, 101, -1, -2, -1, -2,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, -1, -2, -1, -2,
+ax_anim_terminator
+sUmbreonAnims_4_6:
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 1, 1, 1,
+ax_anim 6, 0, 105, 2, 2, 2, 2,
+ax_anim 4, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 2, 104, -1, 0, -1, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 104, -1, 0, -1, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 104, -1, 0, -1, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 104, -1, 0, -1, 0,
+ax_anim_terminator
+sUmbreonAnims_4_7:
+ax_anim 6, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 6, 0, 108, 2, 0, 2, 0,
+ax_anim 4, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 2, 107, -2, 0, -2, 0,
+ax_anim 2, 0, 107, -2, 1, -2, 1,
+ax_anim 2, 0, 107, -2, 0, -2, 0,
+ax_anim 2, 0, 107, -2, 1, -2, 1,
+ax_anim 2, 1, 107, -2, 0, -2, 0,
+ax_anim 2, 0, 107, -2, 1, -2, 1,
+ax_anim 2, 0, 107, -2, 0, -2, 0,
+ax_anim_terminator
+sUmbreonAnims_4_8:
+ax_anim 6, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 6, 0, 111, 2, -2, 2, -2,
+ax_anim 4, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 2, 110, -2, -1, -2, -1,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 110, -2, -1, -2, -1,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 110, -2, -1, -2, -1,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 110, -2, -1, -2, -1,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_5_1:
+ax_anim 4, 0, 112, 0, -1, 0, -1,
+ax_anim 6, 0, 112, 0, -2, 0, -2,
+ax_anim 2, 2, 112, 1, -2, 1, -2,
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim 2, 0, 112, 1, -2, 1, -2,
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim 2, 0, 112, 1, -2, 1, -2,
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim_terminator
+sUmbreonAnims_5_2:
+ax_anim 4, 0, 113, -1, -1, -1, -1,
+ax_anim 6, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 2, 113, -1, -3, -1, -3,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -1, -3, -1, -3,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim 2, 0, 113, -1, -3, -1, -3,
+ax_anim 2, 0, 113, -2, -2, -2, -2,
+ax_anim_terminator
+sUmbreonAnims_5_3:
+ax_anim 4, 0, 114, -1, 0, -1, 0,
+ax_anim 6, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 2, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, -1, -2, -1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, -1, -2, -1,
+ax_anim 2, 0, 114, -2, 0, -2, 0,
+ax_anim 2, 0, 114, -2, -1, -2, -1,
+ax_anim_terminator
+sUmbreonAnims_5_4:
+ax_anim 4, 0, 115, -1, 1, -1, 1,
+ax_anim 6, 0, 115, -2, 2, -2, 2,
+ax_anim 2, 2, 115, -1, 3, -1, 3,
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim 2, 0, 115, -1, 3, -1, 3,
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim 2, 0, 115, -1, 3, -1, 3,
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim_terminator
+sUmbreonAnims_5_5:
+ax_anim 4, 0, 116, 0, 1, 0, 1,
+ax_anim 6, 0, 116, 0, 2, 0, 2,
+ax_anim 2, 2, 116, 1, 2, 1, 2,
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim 2, 0, 116, 1, 2, 1, 2,
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim 2, 0, 116, 1, 2, 1, 2,
+ax_anim 2, 0, 116, 0, 2, 0, 2,
+ax_anim_terminator
+sUmbreonAnims_5_6:
+ax_anim 4, 0, 117, 1, 1, 1, 1,
+ax_anim 6, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 2, 117, 1, 3, 1, 3,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 1, 3, 1, 3,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 117, 1, 3, 1, 3,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim_terminator
+sUmbreonAnims_5_7:
+ax_anim 4, 0, 118, 1, 0, 1, 0,
+ax_anim 6, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 2, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 2, -1, 2, -1,
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 2, -1, 2, -1,
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 118, 2, -1, 2, -1,
+ax_anim_terminator
+sUmbreonAnims_5_8:
+ax_anim 4, 0, 119, 1, -1, 1, -1,
+ax_anim 6, 0, 119, 2, -2, 2, -2,
+ax_anim 2, 2, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sUmbreonAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sUmbreonAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sUmbreonAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sUmbreonAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sUmbreonAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sUmbreonAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sUmbreonAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_8_1:
+ax_anim 60, 0, 130, 0, 0, 0, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -1, 0, -1, 0,
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_8_2:
+ax_anim 60, 0, 134, 0, 0, 0, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -1, 0, -1, 0,
+ax_anim 10, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_8_3:
+ax_anim 60, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -1, 0, -1, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_8_4:
+ax_anim 60, 0, 142, 0, 0, 0, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -1, 0, -1, 0,
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_8_5:
+ax_anim 60, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -1, 0, -1, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_8_6:
+ax_anim 60, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 0, -1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 0, -1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 0, -1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 0, -1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 0, -1, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -1, 0, -1, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_8_7:
+ax_anim 60, 0, 154, 0, 0, 0, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, 0, -1, 0,
+ax_anim 10, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_8_8:
+ax_anim 60, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, 0, -1, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 10, 10, 10, 10,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 1, 19, 1, 19,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -10, 10, -10, 10,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 11, 22, 11,
+ax_anim 3, 0, 165, 22, 20, 22, 20,
+ax_anim 2, 3, 166, 15, 19, 15, 19,
+ax_anim 2, 0, 167, 4, 16, 4, 16,
+ax_anim 1, 0, 168, 1, 8, 1, 8,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 20, 1, 20, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 11, -20, 11, -20,
+ax_anim 3, 0, 163, 16, -20, 16, -20,
+ax_anim 2, 3, 164, 18, -13, 18, -13,
+ax_anim 2, 0, 165, 14, -6, 14, -6,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -11, -8, -11,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, -1, -21, -1, -21,
+ax_anim 2, 3, 163, 7, -16, 7, -16,
+ax_anim 2, 0, 164, 8, -11, 8, -11,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -11, -20, -11, -20,
+ax_anim 3, 0, 169, -16, -20, -16, -20,
+ax_anim 2, 3, 168, -18, -13, -18, -13,
+ax_anim 2, 0, 167, -14, -6, -14, -6,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -20, 1, -20, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 11, -22, 11,
+ax_anim 3, 0, 167, -22, 20, -22, 20,
+ax_anim 2, 3, 166, -15, 19, -15, 19,
+ax_anim 2, 0, 165, -4, 16, -4, 16,
+ax_anim 1, 0, 164, -1, 8, -1, 8,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_11_1:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_11_2:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_11_3:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_11_4:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_11_5:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_11_6:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_11_7:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_11_8:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUmbreonAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sUmbreonGfx1:
+.incbin "baserom.gba", 0xD6FCDC, 0x200
+sUmbreonSprites1:
+ax_sprite sUmbreonGfx1, 0x200
+ax_sprite_terminator
+sUmbreonGfx2:
+.incbin "baserom.gba", 0xD6FEEC, 0x200
+sUmbreonSprites2:
+ax_sprite sUmbreonGfx2, 0x200
+ax_sprite_terminator
+sUmbreonGfx3:
+.incbin "baserom.gba", 0xD700FC, 0x200
+sUmbreonSprites3:
+ax_sprite sUmbreonGfx3, 0x200
+ax_sprite_terminator
+sUmbreonGfx4:
+.incbin "baserom.gba", 0xD7030C, 0x200
+sUmbreonSprites4:
+ax_sprite sUmbreonGfx4, 0x200
+ax_sprite_terminator
+sUmbreonGfx5:
+.incbin "baserom.gba", 0xD7051C, 0x200
+sUmbreonSprites5:
+ax_sprite sUmbreonGfx5, 0x200
+ax_sprite_terminator
+sUmbreonGfx6:
+.incbin "baserom.gba", 0xD7072C, 0x200
+sUmbreonSprites6:
+ax_sprite sUmbreonGfx6, 0x200
+ax_sprite_terminator
+sUmbreonGfx7:
+.incbin "baserom.gba", 0xD7093C, 0x200
+sUmbreonSprites7:
+ax_sprite sUmbreonGfx7, 0x200
+ax_sprite_terminator
+sUmbreonGfx8:
+.incbin "baserom.gba", 0xD70B4C, 0x200
+sUmbreonSprites8:
+ax_sprite sUmbreonGfx8, 0x200
+ax_sprite_terminator
+sUmbreonGfx9:
+.incbin "baserom.gba", 0xD70D5C, 0x200
+sUmbreonSprites9:
+ax_sprite sUmbreonGfx9, 0x200
+ax_sprite_terminator
+sUmbreonGfx10:
+.incbin "baserom.gba", 0xD70F6C, 0x200
+sUmbreonSprites10:
+ax_sprite sUmbreonGfx10, 0x200
+ax_sprite_terminator
+sUmbreonGfx11:
+.incbin "baserom.gba", 0xD7117C, 0x200
+sUmbreonSprites11:
+ax_sprite sUmbreonGfx11, 0x200
+ax_sprite_terminator
+sUmbreonGfx12:
+.incbin "baserom.gba", 0xD7138C, 0x200
+sUmbreonSprites12:
+ax_sprite sUmbreonGfx12, 0x200
+ax_sprite_terminator
+sUmbreonGfx13:
+.incbin "baserom.gba", 0xD7159C, 0x200
+sUmbreonSprites13:
+ax_sprite sUmbreonGfx13, 0x200
+ax_sprite_terminator
+sUmbreonGfx14:
+.incbin "baserom.gba", 0xD717AC, 0x200
+sUmbreonSprites14:
+ax_sprite sUmbreonGfx14, 0x200
+ax_sprite_terminator
+sUmbreonGfx15:
+.incbin "baserom.gba", 0xD719BC, 0x200
+sUmbreonSprites15:
+ax_sprite sUmbreonGfx15, 0x200
+ax_sprite_terminator
+sUmbreonGfx16:
+.incbin "baserom.gba", 0xD71BCC, 0x20
+sUmbreonGfx16_1:
+.incbin "baserom.gba", 0xD71BEC, 0x60
+sUmbreonGfx16_2:
+.incbin "baserom.gba", 0xD71C4C, 0x60
+sUmbreonGfx16_3:
+.incbin "baserom.gba", 0xD71CAC, 0x40
+sUmbreonSprites16:
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx16_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx17:
+.incbin "baserom.gba", 0xD71D3C, 0x20
+sUmbreonGfx17_1:
+.incbin "baserom.gba", 0xD71D5C, 0x60
+sUmbreonGfx17_2:
+.incbin "baserom.gba", 0xD71DBC, 0x60
+sUmbreonGfx17_3:
+.incbin "baserom.gba", 0xD71E1C, 0x60
+sUmbreonSprites17:
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx18:
+.incbin "baserom.gba", 0xD71ECC, 0x20
+sUmbreonGfx18_1:
+.incbin "baserom.gba", 0xD71EEC, 0x60
+sUmbreonGfx18_2:
+.incbin "baserom.gba", 0xD71F4C, 0x60
+sUmbreonGfx18_3:
+.incbin "baserom.gba", 0xD71FAC, 0x60
+sUmbreonSprites18:
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx18, 0x20
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx18_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx19:
+.incbin "baserom.gba", 0xD7205C, 0x40
+sUmbreonGfx19_1:
+.incbin "baserom.gba", 0xD7209C, 0x60
+sUmbreonGfx19_2:
+.incbin "baserom.gba", 0xD720FC, 0x60
+sUmbreonGfx19_3:
+.incbin "baserom.gba", 0xD7215C, 0x60
+sUmbreonSprites19:
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx19_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx20:
+.incbin "baserom.gba", 0xD7220C, 0xC0
+sUmbreonSprites20:
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx20, 0xc0
+ax_sprite_terminator
+sUmbreonGfx21:
+.incbin "baserom.gba", 0xD722E4, 0x20
+sUmbreonGfx21_1:
+.incbin "baserom.gba", 0xD72304, 0x60
+sUmbreonGfx21_2:
+.incbin "baserom.gba", 0xD72364, 0x60
+sUmbreonGfx21_3:
+.incbin "baserom.gba", 0xD723C4, 0x40
+sUmbreonSprites21:
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx22:
+.incbin "baserom.gba", 0xD72454, 0x40
+sUmbreonGfx22_1:
+.incbin "baserom.gba", 0xD72494, 0x60
+sUmbreonGfx22_2:
+.incbin "baserom.gba", 0xD724F4, 0x60
+sUmbreonGfx22_3:
+.incbin "baserom.gba", 0xD72554, 0x60
+sUmbreonSprites22:
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx22_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx22_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx23:
+.incbin "baserom.gba", 0xD72604, 0x20
+sUmbreonGfx23_1:
+.incbin "baserom.gba", 0xD72624, 0x20
+sUmbreonGfx23_2:
+.incbin "baserom.gba", 0xD72644, 0x60
+sUmbreonGfx23_3:
+.incbin "baserom.gba", 0xD726A4, 0x60
+sUmbreonGfx23_4:
+.incbin "baserom.gba", 0xD72704, 0x60
+sUmbreonSprites23:
+ax_sprite sUmbreonGfx23, 0x20
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx23_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx23_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx24:
+.incbin "baserom.gba", 0xD727BC, 0x40
+sUmbreonGfx24_1:
+.incbin "baserom.gba", 0xD727FC, 0x60
+sUmbreonGfx24_2:
+.incbin "baserom.gba", 0xD7285C, 0x60
+sUmbreonGfx24_3:
+.incbin "baserom.gba", 0xD728BC, 0x40
+sUmbreonSprites24:
+ax_sprite sUmbreonGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUmbreonGfx24_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sUmbreonGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUmbreonGfx25:
+.incbin "baserom.gba", 0xD72944, 0x100
+sUmbreonSprites25:
+ax_sprite sUmbreonGfx25, 0x100
+ax_sprite_terminator
+sUmbreonGfx26:
+.incbin "baserom.gba", 0xD72A54, 0x200
+sUmbreonSprites26:
+ax_sprite sUmbreonGfx26, 0x200
+ax_sprite_terminator
+sUmbreonGfx27:
+.incbin "baserom.gba", 0xD72C64, 0x200
+sUmbreonSprites27:
+ax_sprite sUmbreonGfx27, 0x200
+ax_sprite_terminator
+sUmbreonGfx28:
+.incbin "baserom.gba", 0xD72E74, 0x200
+sUmbreonSprites28:
+ax_sprite sUmbreonGfx28, 0x200
+ax_sprite_terminator
+sUmbreonGfx29:
+.incbin "baserom.gba", 0xD73084, 0x200
+sUmbreonSprites29:
+ax_sprite sUmbreonGfx29, 0x200
+ax_sprite_terminator
+sUmbreonGfx30:
+.incbin "baserom.gba", 0xD73294, 0x200
+sUmbreonSprites30:
+ax_sprite sUmbreonGfx30, 0x200
+ax_sprite_terminator
+sUmbreonGfx31:
+.incbin "baserom.gba", 0xD734A4, 0x200
+sUmbreonSprites31:
+ax_sprite sUmbreonGfx31, 0x200
+ax_sprite_terminator
+sUmbreonGfx32:
+.incbin "baserom.gba", 0xD736B4, 0x200
+sUmbreonSprites32:
+ax_sprite sUmbreonGfx32, 0x200
+ax_sprite_terminator
+sAxPosesUmbreon:
+.4byte sUmbreonPose1
+.4byte sUmbreonPose2
+.4byte sUmbreonPose3
+.4byte sUmbreonPose4
+.4byte sUmbreonPose5
+.4byte sUmbreonPose6
+.4byte sUmbreonPose7
+.4byte sUmbreonPose8
+.4byte sUmbreonPose9
+.4byte sUmbreonPose10
+.4byte sUmbreonPose11
+.4byte sUmbreonPose12
+.4byte sUmbreonPose13
+.4byte sUmbreonPose14
+.4byte sUmbreonPose15
+.4byte sUmbreonPose16
+.4byte sUmbreonPose17
+.4byte sUmbreonPose18
+.4byte sUmbreonPose19
+.4byte sUmbreonPose20
+.4byte sUmbreonPose21
+.4byte sUmbreonPose22
+.4byte sUmbreonPose23
+.4byte sUmbreonPose24
+.4byte sUmbreonPose25
+.4byte sUmbreonPose26
+.4byte sUmbreonPose27
+.4byte sUmbreonPose28
+.4byte sUmbreonPose29
+.4byte sUmbreonPose30
+.4byte sUmbreonPose31
+.4byte sUmbreonPose32
+.4byte sUmbreonPose33
+.4byte sUmbreonPose34
+.4byte sUmbreonPose35
+.4byte sUmbreonPose36
+.4byte sUmbreonPose37
+.4byte sUmbreonPose38
+.4byte sUmbreonPose39
+.4byte sUmbreonPose40
+.4byte sUmbreonPose41
+.4byte sUmbreonPose42
+.4byte sUmbreonPose43
+.4byte sUmbreonPose44
+.4byte sUmbreonPose45
+.4byte sUmbreonPose46
+.4byte sUmbreonPose47
+.4byte sUmbreonPose48
+.4byte sUmbreonPose49
+.4byte sUmbreonPose50
+.4byte sUmbreonPose51
+.4byte sUmbreonPose52
+.4byte sUmbreonPose53
+.4byte sUmbreonPose54
+.4byte sUmbreonPose55
+.4byte sUmbreonPose56
+.4byte sUmbreonPose57
+.4byte sUmbreonPose58
+.4byte sUmbreonPose59
+.4byte sUmbreonPose60
+.4byte sUmbreonPose61
+.4byte sUmbreonPose62
+.4byte sUmbreonPose63
+.4byte sUmbreonPose64
+.4byte sUmbreonPose65
+.4byte sUmbreonPose66
+.4byte sUmbreonPose67
+.4byte sUmbreonPose68
+.4byte sUmbreonPose69
+.4byte sUmbreonPose70
+.4byte sUmbreonPose71
+.4byte sUmbreonPose72
+.4byte sUmbreonPose73
+.4byte sUmbreonPose74
+.4byte sUmbreonPose75
+.4byte sUmbreonPose76
+.4byte sUmbreonPose77
+.4byte sUmbreonPose78
+.4byte sUmbreonPose79
+.4byte sUmbreonPose80
+.4byte sUmbreonPose81
+.4byte sUmbreonPose82
+.4byte sUmbreonPose83
+.4byte sUmbreonPose84
+.4byte sUmbreonPose85
+.4byte sUmbreonPose86
+.4byte sUmbreonPose87
+.4byte sUmbreonPose88
+.4byte sUmbreonPose89
+.4byte sUmbreonPose90
+.4byte sUmbreonPose91
+.4byte sUmbreonPose92
+.4byte sUmbreonPose93
+.4byte sUmbreonPose94
+.4byte sUmbreonPose95
+.4byte sUmbreonPose96
+.4byte sUmbreonPose97
+.4byte sUmbreonPose98
+.4byte sUmbreonPose99
+.4byte sUmbreonPose100
+.4byte sUmbreonPose101
+.4byte sUmbreonPose102
+.4byte sUmbreonPose103
+.4byte sUmbreonPose104
+.4byte sUmbreonPose105
+.4byte sUmbreonPose106
+.4byte sUmbreonPose107
+.4byte sUmbreonPose108
+.4byte sUmbreonPose109
+.4byte sUmbreonPose110
+.4byte sUmbreonPose111
+.4byte sUmbreonPose112
+.4byte sUmbreonPose113
+.4byte sUmbreonPose114
+.4byte sUmbreonPose115
+.4byte sUmbreonPose116
+.4byte sUmbreonPose117
+.4byte sUmbreonPose118
+.4byte sUmbreonPose119
+.4byte sUmbreonPose120
+.4byte sUmbreonPose121
+.4byte sUmbreonPose122
+.4byte sUmbreonPose123
+.4byte sUmbreonPose124
+.4byte sUmbreonPose125
+.4byte sUmbreonPose126
+.4byte sUmbreonPose127
+.4byte sUmbreonPose128
+.4byte sUmbreonPose129
+.4byte sUmbreonPose130
+.4byte sUmbreonPose131
+.4byte sUmbreonPose132
+.4byte sUmbreonPose133
+.4byte sUmbreonPose134
+.4byte sUmbreonPose135
+.4byte sUmbreonPose136
+.4byte sUmbreonPose137
+.4byte sUmbreonPose138
+.4byte sUmbreonPose139
+.4byte sUmbreonPose140
+.4byte sUmbreonPose141
+.4byte sUmbreonPose142
+.4byte sUmbreonPose143
+.4byte sUmbreonPose144
+.4byte sUmbreonPose145
+.4byte sUmbreonPose146
+.4byte sUmbreonPose147
+.4byte sUmbreonPose148
+.4byte sUmbreonPose149
+.4byte sUmbreonPose150
+.4byte sUmbreonPose151
+.4byte sUmbreonPose152
+.4byte sUmbreonPose153
+.4byte sUmbreonPose154
+.4byte sUmbreonPose155
+.4byte sUmbreonPose156
+.4byte sUmbreonPose157
+.4byte sUmbreonPose158
+.4byte sUmbreonPose159
+.4byte sUmbreonPose160
+.4byte sUmbreonPose161
+.4byte sUmbreonPose162
+.4byte sUmbreonPose163
+.4byte sUmbreonPose164
+.4byte sUmbreonPose165
+.4byte sUmbreonPose166
+.4byte sUmbreonPose167
+.4byte sUmbreonPose168
+.4byte sUmbreonPose169
+.4byte sUmbreonPose170
+.4byte sUmbreonPose171
+.4byte sUmbreonPose172
+.4byte sUmbreonPose173
+.4byte sUmbreonPose174
+.4byte sUmbreonPose175
+.4byte sUmbreonPose176
+.4byte sUmbreonPose177
+.4byte sUmbreonPose178
+.4byte sUmbreonPose179
+.4byte sUmbreonPose180
+.4byte sUmbreonPose181
+.4byte sUmbreonPose182
+.4byte sUmbreonPose183
+.4byte sUmbreonPose184
+.4byte sUmbreonPose185
+.4byte sUmbreonPose186
+.4byte sUmbreonPose187
+.4byte sUmbreonPose188
+.4byte sUmbreonPose189
+.4byte sUmbreonPose190
+.4byte sUmbreonPose191
+.4byte sUmbreonPose192
+.4byte sUmbreonPose193
+.4byte sUmbreonPose194
+.4byte sUmbreonPose195
+.4byte sUmbreonPose196
+.4byte sUmbreonPose197
+.4byte sUmbreonPose198
+.4byte sUmbreonPose199
+.4byte sUmbreonPose200
+.4byte sUmbreonPose201
+.4byte sUmbreonPose202
+.4byte sUmbreonPose203
+.4byte sUmbreonPose204
+.4byte sUmbreonPose205
+.4byte sUmbreonPose206
+.4byte sUmbreonPose207
+.4byte sUmbreonPose208
+.4byte sUmbreonPose209
+.4byte sUmbreonPose210
+.4byte sUmbreonPose211
+.4byte sUmbreonPose212
+.4byte sUmbreonPose213
+.4byte sUmbreonPose214
+.4byte sUmbreonPose215
+.4byte sUmbreonPose216
+.4byte sUmbreonPose217
+.4byte sUmbreonPose218
+sAxPositionsUmbreon:
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte    0,   -4, 	  -3,    4, 	   3,    1, 	   0,   -5
+.2byte    0,   -4, 	  -3,    1, 	   2,    4, 	   0,   -5
+.2byte    5,   -6, 	   3,    1, 	   0,    2, 	   0,   -6
+.2byte    5,   -5, 	   6,    3, 	  -2,    1, 	   0,   -5
+.2byte    5,   -5, 	   0,   -1, 	   4,    3, 	  -1,   -6
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    9,   -7, 	   1,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -7, 	   7,   -1, 	   0,    0, 	   0,   -6
+.2byte    6,  -11, 	   0,   -4, 	   5,   -2, 	   1,   -9
+.2byte    6,   -9, 	   3,   -4, 	   2,   -1, 	   1,   -8
+.2byte    6,   -9, 	   0,   -3, 	   7,   -4, 	   1,   -8
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   2,   -2, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   3,    0, 	  -2,   -2, 	   0,   -6
+.2byte   -5,  -11, 	   1,   -4, 	  -4,   -2, 	   0,   -9
+.2byte   -5,   -9, 	  -2,   -4, 	  -1,   -1, 	   0,   -8
+.2byte   -5,   -9, 	   1,   -3, 	  -6,   -4, 	   0,   -8
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte  -10,   -7, 	  -2,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -7, 	  -8,   -1, 	  -1,    0, 	  -1,   -6
+.2byte   -6,   -6, 	  -4,    1, 	  -1,    2, 	  -1,   -6
+.2byte   -6,   -5, 	  -7,    3, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -5, 	  -1,   -1, 	  -5,    3, 	   0,   -6
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte    0,   -4, 	  -3,    4, 	   3,    1, 	   0,   -5
+.2byte    0,   -4, 	  -3,    1, 	   2,    4, 	   0,   -5
+.2byte    0,   -3, 	  -2,    2, 	   2,    2, 	   0,  -11
+.2byte    5,   -6, 	   3,    1, 	   0,    2, 	   0,   -6
+.2byte    5,   -5, 	   6,    3, 	  -2,    1, 	   0,   -5
+.2byte    5,   -5, 	   0,   -1, 	   4,    3, 	  -1,   -6
+.2byte    3,   -3, 	   4,    1, 	   1,    3, 	  -2,   -6
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    9,   -7, 	   1,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -7, 	   7,   -1, 	   0,    0, 	   0,   -6
+.2byte    7,   -5, 	   5,   -1, 	   3,    0, 	  -2,   -7
+.2byte    6,  -11, 	   0,   -4, 	   5,   -2, 	   1,   -9
+.2byte    6,   -9, 	   3,   -4, 	   2,   -1, 	   1,   -8
+.2byte    6,   -9, 	   0,   -3, 	   7,   -4, 	   1,   -8
+.2byte    5,   -7, 	   2,   -3, 	   4,   -2, 	   0,   -8
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   2,   -2, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   3,    0, 	  -2,   -2, 	   0,   -6
+.2byte    0,   -8, 	   2,   -1, 	  -2,   -1, 	   0,   -7
+.2byte   -6,  -11, 	   0,   -4, 	  -5,   -2, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,   -4, 	  -2,   -1, 	  -1,   -8
+.2byte   -6,   -9, 	   0,   -3, 	  -7,   -4, 	  -1,   -8
+.2byte   -5,   -7, 	  -2,   -3, 	  -4,   -2, 	   0,   -8
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte  -10,   -7, 	  -2,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -7, 	  -8,   -1, 	  -1,    0, 	  -1,   -6
+.2byte   -8,   -5, 	  -6,   -1, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -6, 	  -4,    1, 	  -1,    2, 	  -1,   -6
+.2byte   -6,   -5, 	  -7,    3, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -5, 	  -1,   -1, 	  -5,    3, 	   0,   -6
+.2byte   -4,   -3, 	  -5,    1, 	  -2,    3, 	   1,   -6
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte    0,   -4, 	  -3,    4, 	   3,    1, 	   0,   -5
+.2byte    0,   -4, 	  -3,    1, 	   2,    4, 	   0,   -5
+.2byte    0,   -3, 	  -2,    2, 	   2,    2, 	   0,  -11
+.2byte    5,   -6, 	   3,    1, 	   0,    2, 	   0,   -6
+.2byte    5,   -5, 	   6,    3, 	  -2,    1, 	   0,   -5
+.2byte    5,   -5, 	   0,   -1, 	   4,    3, 	  -1,   -6
+.2byte    3,   -3, 	   4,    1, 	   1,    3, 	  -2,   -6
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    9,   -7, 	   1,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -7, 	   7,   -1, 	   0,    0, 	   0,   -6
+.2byte    7,   -5, 	   5,   -1, 	   3,    0, 	  -2,   -7
+.2byte    6,  -11, 	   0,   -4, 	   5,   -2, 	   1,   -9
+.2byte    6,   -9, 	   3,   -4, 	   2,   -1, 	   1,   -8
+.2byte    6,   -9, 	   0,   -3, 	   7,   -4, 	   1,   -8
+.2byte    5,   -7, 	   2,   -3, 	   4,   -2, 	   0,   -8
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   2,   -2, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   3,    0, 	  -2,   -2, 	   0,   -6
+.2byte    0,   -8, 	   2,   -1, 	  -2,   -1, 	   0,   -7
+.2byte   -6,  -11, 	   0,   -4, 	  -5,   -2, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,   -4, 	  -2,   -1, 	  -1,   -8
+.2byte   -6,   -9, 	   0,   -3, 	  -7,   -4, 	  -1,   -8
+.2byte   -5,   -7, 	  -2,   -3, 	  -4,   -2, 	   0,   -8
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte  -10,   -7, 	  -2,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -7, 	  -8,   -1, 	  -1,    0, 	  -1,   -6
+.2byte   -8,   -5, 	  -6,   -1, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -6, 	  -4,    1, 	  -1,    2, 	  -1,   -6
+.2byte   -6,   -5, 	  -7,    3, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -5, 	  -1,   -1, 	  -5,    3, 	   0,   -6
+.2byte   -4,   -3, 	  -5,    1, 	  -2,    3, 	   1,   -6
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte    0,   -4, 	  -3,    4, 	   4,    0, 	   0,  -10
+.2byte    0,   -2, 	  -2,    3, 	   2,    3, 	   0,  -10
+.2byte    5,   -6, 	   3,    1, 	   0,    2, 	   0,   -6
+.2byte    6,   -3, 	   8,    3, 	  -2,    2, 	   0,   -5
+.2byte    3,   -3, 	   4,    1, 	   1,    3, 	  -2,   -6
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    8,   -7, 	   8,   -2, 	   0,    0, 	  -1,   -7
+.2byte    7,   -5, 	   5,   -1, 	   3,    0, 	  -2,   -7
+.2byte    6,  -11, 	   0,   -4, 	   5,   -2, 	   1,   -9
+.2byte    6,   -8, 	   5,   -4, 	   3,   -1, 	   2,   -9
+.2byte    6,   -8, 	   3,   -4, 	   5,   -3, 	   1,   -9
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    0,  -10, 	   2,   -1, 	  -3,   -2, 	   0,   -8
+.2byte    0,   -8, 	   2,   -1, 	  -2,   -1, 	   0,   -7
+.2byte   -5,  -11, 	   1,   -4, 	  -4,   -2, 	   0,   -9
+.2byte   -5,   -8, 	  -4,   -4, 	  -2,   -1, 	  -1,   -9
+.2byte   -5,   -8, 	  -2,   -4, 	  -4,   -3, 	   0,   -9
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte   -9,   -7, 	  -9,   -2, 	  -1,    0, 	   0,   -7
+.2byte   -8,   -5, 	  -6,   -1, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -6, 	  -4,    1, 	  -1,    2, 	  -1,   -6
+.2byte   -7,   -3, 	  -9,    3, 	   1,    2, 	  -1,   -5
+.2byte   -4,   -3, 	  -5,    1, 	  -2,    3, 	   1,   -6
+.2byte    0,   -2, 	  -2,    3, 	   2,    3, 	   0,  -10
+.2byte    3,   -3, 	   4,    1, 	   1,    3, 	  -2,   -6
+.2byte    7,   -5, 	   5,   -1, 	   3,    0, 	  -2,   -7
+.2byte    6,   -8, 	   3,   -4, 	   5,   -3, 	   1,   -9
+.2byte    0,   -9, 	   2,   -2, 	  -2,   -2, 	   0,   -8
+.2byte   -6,   -8, 	  -3,   -4, 	  -5,   -3, 	  -1,   -9
+.2byte   -8,   -5, 	  -6,   -1, 	  -4,    0, 	   1,   -7
+.2byte   -4,   -3, 	  -5,    1, 	  -2,    3, 	   1,   -6
+.2byte   -7,   -3, 	  -7,   -1, 	  -5,    0, 	   0,   -5
+.2byte   -6,   -2, 	  -7,    0, 	  -5,    0, 	  -1,   -5
+.2byte    0,  -12, 	  -6,  -12, 	   6,  -15, 	   0,   -9
+.2byte    3,  -12, 	   8,  -12, 	  -1,  -13, 	  -3,   -8
+.2byte    3,  -15, 	   6,  -16, 	   3,  -14, 	  -3,   -9
+.2byte    3,  -15, 	   0,  -18, 	   5,  -14, 	  -2,   -9
+.2byte    0,  -14, 	   5,  -12, 	  -5,  -14, 	   0,  -10
+.2byte   -4,  -15, 	  -1,  -18, 	  -6,  -14, 	   1,   -9
+.2byte   -4,  -15, 	  -7,  -16, 	  -4,  -14, 	   2,   -9
+.2byte   -4,  -12, 	  -9,  -12, 	   0,  -13, 	   2,   -8
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte    0,   -4, 	  -3,    4, 	   3,    1, 	   0,   -5
+.2byte    0,   -4, 	  -3,    1, 	   2,    4, 	   0,   -5
+.2byte    0,   -3, 	  -2,    2, 	   2,    2, 	   0,  -11
+.2byte    5,   -6, 	   3,    1, 	   0,    2, 	   0,   -6
+.2byte    5,   -5, 	   6,    3, 	  -2,    1, 	   0,   -5
+.2byte    5,   -5, 	   0,   -1, 	   4,    3, 	  -1,   -6
+.2byte    3,   -3, 	   4,    1, 	   1,    3, 	  -2,   -6
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    9,   -7, 	   1,   -1, 	   7,    0, 	   0,   -6
+.2byte    9,   -7, 	   7,   -1, 	   0,    0, 	   0,   -6
+.2byte    7,   -5, 	   5,   -1, 	   3,    0, 	  -2,   -7
+.2byte    6,  -11, 	   0,   -4, 	   5,   -2, 	   1,   -9
+.2byte    6,   -9, 	   3,   -4, 	   2,   -1, 	   1,   -8
+.2byte    6,   -9, 	   0,   -3, 	   7,   -4, 	   1,   -8
+.2byte    5,   -7, 	   2,   -3, 	   4,   -2, 	   0,   -8
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   2,   -2, 	  -2,   -1, 	   0,   -6
+.2byte    0,   -9, 	   3,    0, 	  -2,   -2, 	   0,   -6
+.2byte    0,   -8, 	   2,   -1, 	  -2,   -1, 	   0,   -7
+.2byte   -6,  -11, 	   0,   -4, 	  -5,   -2, 	  -1,   -9
+.2byte   -6,   -9, 	  -3,   -4, 	  -2,   -1, 	  -1,   -8
+.2byte   -6,   -9, 	   0,   -3, 	  -7,   -4, 	  -1,   -8
+.2byte   -5,   -7, 	  -2,   -3, 	  -4,   -2, 	   0,   -8
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte  -10,   -7, 	  -2,   -1, 	  -8,    0, 	  -1,   -6
+.2byte  -10,   -7, 	  -8,   -1, 	  -1,    0, 	  -1,   -6
+.2byte   -8,   -5, 	  -6,   -1, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -6, 	  -4,    1, 	  -1,    2, 	  -1,   -6
+.2byte   -6,   -5, 	  -7,    3, 	   1,    1, 	  -1,   -5
+.2byte   -6,   -5, 	  -1,   -1, 	  -5,    3, 	   0,   -6
+.2byte   -4,   -3, 	  -5,    1, 	  -2,    3, 	   1,   -6
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte   -6,   -6, 	  -4,    1, 	  -1,    2, 	  -1,   -6
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte   -5,  -11, 	   1,   -4, 	  -4,   -2, 	   0,   -9
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    6,  -11, 	   0,   -4, 	   5,   -2, 	   1,   -9
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    5,   -6, 	   3,    1, 	   0,    2, 	   0,   -6
+.2byte    0,   -4, 	  -3,    4, 	   4,    0, 	   0,  -10
+.2byte    5,   -5, 	   7,    1, 	  -3,    0, 	  -1,   -7
+.2byte    8,   -7, 	   8,   -2, 	   0,    0, 	  -1,   -7
+.2byte    5,   -8, 	   4,   -4, 	   2,   -1, 	   1,   -9
+.2byte    0,  -11, 	   2,   -2, 	  -3,   -3, 	   0,   -9
+.2byte   -6,   -8, 	  -5,   -4, 	  -3,   -1, 	  -2,   -9
+.2byte   -9,   -7, 	  -9,   -2, 	  -1,    0, 	   0,   -7
+.2byte   -6,   -4, 	  -8,    2, 	   2,    1, 	   0,   -6
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte    0,   -4, 	  -3,    4, 	   4,    0, 	   0,  -10
+.2byte    0,   -2, 	  -2,    3, 	   2,    3, 	   0,  -10
+.2byte    5,   -6, 	   3,    1, 	   0,    2, 	   0,   -6
+.2byte    6,   -3, 	   8,    3, 	  -2,    2, 	   0,   -5
+.2byte    5,   -3, 	   6,    1, 	   3,    3, 	   0,   -6
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    8,   -7, 	   8,   -2, 	   0,    0, 	  -1,   -7
+.2byte    7,   -5, 	   5,   -1, 	   3,    0, 	  -2,   -7
+.2byte    6,  -11, 	   0,   -4, 	   5,   -2, 	   1,   -9
+.2byte    6,   -8, 	   5,   -4, 	   3,   -1, 	   2,   -9
+.2byte    6,   -8, 	   3,   -4, 	   5,   -3, 	   1,   -9
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    0,  -10, 	   2,   -1, 	  -3,   -2, 	   0,   -8
+.2byte    0,   -7, 	   2,    0, 	  -2,    0, 	   0,   -6
+.2byte   -5,  -11, 	   1,   -4, 	  -4,   -2, 	   0,   -9
+.2byte   -5,   -8, 	  -4,   -4, 	  -2,   -1, 	  -1,   -9
+.2byte   -5,   -8, 	  -2,   -4, 	  -4,   -3, 	   0,   -9
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte   -9,   -7, 	  -9,   -2, 	  -1,    0, 	   0,   -7
+.2byte   -8,   -5, 	  -6,   -1, 	  -4,    0, 	   1,   -7
+.2byte   -6,   -6, 	  -4,    1, 	  -1,    2, 	  -1,   -6
+.2byte   -7,   -3, 	  -9,    3, 	   1,    2, 	  -1,   -5
+.2byte   -6,   -3, 	  -7,    1, 	  -4,    3, 	  -1,   -6
+.2byte    0,   -4, 	  -3,    4, 	   4,    0, 	   0,  -10
+.2byte   -7,   -5, 	  -9,    1, 	   1,    0, 	  -1,   -7
+.2byte   -9,   -7, 	  -9,   -2, 	  -1,    0, 	   0,   -7
+.2byte   -5,   -8, 	  -4,   -4, 	  -2,   -1, 	  -1,   -9
+.2byte    0,  -10, 	   2,   -1, 	  -3,   -2, 	   0,   -8
+.2byte    4,   -8, 	   3,   -4, 	   1,   -1, 	   0,   -9
+.2byte    8,   -7, 	   8,   -2, 	   0,    0, 	  -1,   -7
+.2byte    6,   -5, 	   8,    1, 	  -2,    0, 	   0,   -7
+.2byte    0,   -5, 	  -3,    2, 	   3,    2, 	   0,   -4
+.2byte   -7,   -6, 	  -5,    1, 	  -2,    2, 	  -2,   -6
+.2byte  -10,   -8, 	  -6,   -1, 	  -4,    0, 	   0,   -8
+.2byte   -6,  -10, 	   0,   -3, 	  -5,   -1, 	  -1,   -8
+.2byte    0,  -10, 	   2,   -1, 	  -2,   -1, 	   0,   -6
+.2byte    5,  -10, 	  -1,   -3, 	   4,   -1, 	   0,   -8
+.2byte    9,   -8, 	   5,   -1, 	   3,    0, 	  -1,   -8
+.2byte    6,   -6, 	   4,    1, 	   1,    2, 	   1,   -6
+sUmbreonAnimTable1:
+.4byte sUmbreonAnims_1_1
+.4byte sUmbreonAnims_1_2
+.4byte sUmbreonAnims_1_3
+.4byte sUmbreonAnims_1_4
+.4byte sUmbreonAnims_1_5
+.4byte sUmbreonAnims_1_6
+.4byte sUmbreonAnims_1_7
+.4byte sUmbreonAnims_1_8
+sUmbreonAnimTable2:
+.4byte sUmbreonAnims_2_1
+.4byte sUmbreonAnims_2_2
+.4byte sUmbreonAnims_2_3
+.4byte sUmbreonAnims_2_4
+.4byte sUmbreonAnims_2_5
+.4byte sUmbreonAnims_2_6
+.4byte sUmbreonAnims_2_7
+.4byte sUmbreonAnims_2_8
+sUmbreonAnimTable3:
+.4byte sUmbreonAnims_3_1
+.4byte sUmbreonAnims_3_2
+.4byte sUmbreonAnims_3_3
+.4byte sUmbreonAnims_3_4
+.4byte sUmbreonAnims_3_5
+.4byte sUmbreonAnims_3_6
+.4byte sUmbreonAnims_3_7
+.4byte sUmbreonAnims_3_8
+sUmbreonAnimTable4:
+.4byte sUmbreonAnims_4_1
+.4byte sUmbreonAnims_4_2
+.4byte sUmbreonAnims_4_3
+.4byte sUmbreonAnims_4_4
+.4byte sUmbreonAnims_4_5
+.4byte sUmbreonAnims_4_6
+.4byte sUmbreonAnims_4_7
+.4byte sUmbreonAnims_4_8
+sUmbreonAnimTable5:
+.4byte sUmbreonAnims_5_1
+.4byte sUmbreonAnims_5_2
+.4byte sUmbreonAnims_5_3
+.4byte sUmbreonAnims_5_4
+.4byte sUmbreonAnims_5_5
+.4byte sUmbreonAnims_5_6
+.4byte sUmbreonAnims_5_7
+.4byte sUmbreonAnims_5_8
+sUmbreonAnimTable6:
+.4byte sUmbreonAnims_6_1
+.4byte sUmbreonAnims_6_1
+.4byte sUmbreonAnims_6_1
+.4byte sUmbreonAnims_6_1
+.4byte sUmbreonAnims_6_1
+.4byte sUmbreonAnims_6_1
+.4byte sUmbreonAnims_6_1
+.4byte sUmbreonAnims_6_1
+sUmbreonAnimTable7:
+.4byte sUmbreonAnims_7_1
+.4byte sUmbreonAnims_7_2
+.4byte sUmbreonAnims_7_3
+.4byte sUmbreonAnims_7_4
+.4byte sUmbreonAnims_7_5
+.4byte sUmbreonAnims_7_6
+.4byte sUmbreonAnims_7_7
+.4byte sUmbreonAnims_7_8
+sUmbreonAnimTable8:
+.4byte sUmbreonAnims_8_1
+.4byte sUmbreonAnims_8_2
+.4byte sUmbreonAnims_8_3
+.4byte sUmbreonAnims_8_4
+.4byte sUmbreonAnims_8_5
+.4byte sUmbreonAnims_8_6
+.4byte sUmbreonAnims_8_7
+.4byte sUmbreonAnims_8_8
+sUmbreonAnimTable9:
+.4byte sUmbreonAnims_9_1
+.4byte sUmbreonAnims_9_2
+.4byte sUmbreonAnims_9_3
+.4byte sUmbreonAnims_9_4
+.4byte sUmbreonAnims_9_5
+.4byte sUmbreonAnims_9_6
+.4byte sUmbreonAnims_9_7
+.4byte sUmbreonAnims_9_8
+sUmbreonAnimTable10:
+.4byte sUmbreonAnims_10_1
+.4byte sUmbreonAnims_10_2
+.4byte sUmbreonAnims_10_3
+.4byte sUmbreonAnims_10_4
+.4byte sUmbreonAnims_10_5
+.4byte sUmbreonAnims_10_6
+.4byte sUmbreonAnims_10_7
+.4byte sUmbreonAnims_10_8
+sUmbreonAnimTable11:
+.4byte sUmbreonAnims_11_1
+.4byte sUmbreonAnims_11_2
+.4byte sUmbreonAnims_11_3
+.4byte sUmbreonAnims_11_4
+.4byte sUmbreonAnims_11_5
+.4byte sUmbreonAnims_11_6
+.4byte sUmbreonAnims_11_7
+.4byte sUmbreonAnims_11_8
+sUmbreonAnimTable12:
+.4byte sUmbreonAnims_12_1
+.4byte sUmbreonAnims_12_2
+.4byte sUmbreonAnims_12_3
+.4byte sUmbreonAnims_12_4
+.4byte sUmbreonAnims_12_5
+.4byte sUmbreonAnims_12_6
+.4byte sUmbreonAnims_12_7
+.4byte sUmbreonAnims_12_8
+sUmbreonAnimTable13:
+.4byte sUmbreonAnims_13_1
+.4byte sUmbreonAnims_13_2
+.4byte sUmbreonAnims_13_3
+.4byte sUmbreonAnims_13_4
+.4byte sUmbreonAnims_13_5
+.4byte sUmbreonAnims_13_6
+.4byte sUmbreonAnims_13_7
+.4byte sUmbreonAnims_13_8
+sAxAnimationsUmbreon:
+.4byte sUmbreonAnimTable1
+.4byte sUmbreonAnimTable2
+.4byte sUmbreonAnimTable3
+.4byte sUmbreonAnimTable4
+.4byte sUmbreonAnimTable5
+.4byte sUmbreonAnimTable6
+.4byte sUmbreonAnimTable7
+.4byte sUmbreonAnimTable8
+.4byte sUmbreonAnimTable9
+.4byte sUmbreonAnimTable10
+.4byte sUmbreonAnimTable11
+.4byte sUmbreonAnimTable12
+.4byte sUmbreonAnimTable13
+sAxSpritesUmbreon:
+.4byte sUmbreonSprites1
+.4byte sUmbreonSprites2
+.4byte sUmbreonSprites3
+.4byte sUmbreonSprites4
+.4byte sUmbreonSprites5
+.4byte sUmbreonSprites6
+.4byte sUmbreonSprites7
+.4byte sUmbreonSprites8
+.4byte sUmbreonSprites9
+.4byte sUmbreonSprites10
+.4byte sUmbreonSprites11
+.4byte sUmbreonSprites12
+.4byte sUmbreonSprites13
+.4byte sUmbreonSprites14
+.4byte sUmbreonSprites15
+.4byte sUmbreonSprites16
+.4byte sUmbreonSprites17
+.4byte sUmbreonSprites18
+.4byte sUmbreonSprites19
+.4byte sUmbreonSprites20
+.4byte sUmbreonSprites21
+.4byte sUmbreonSprites22
+.4byte sUmbreonSprites23
+.4byte sUmbreonSprites24
+.4byte sUmbreonSprites25
+.4byte sUmbreonSprites26
+.4byte sUmbreonSprites27
+.4byte sUmbreonSprites28
+.4byte sUmbreonSprites29
+.4byte sUmbreonSprites30
+.4byte sUmbreonSprites31
+.4byte sUmbreonSprites32
+sAxMainUmbreon:
+ax_main sAxPosesUmbreon, sAxAnimationsUmbreon, 13, sAxSpritesUmbreon, sAxPositionsUmbreon

--- a/data/ax/unowna.inc
+++ b/data/ax/unowna.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownA
+gAxUnownA:
+ax_siro sAxMainUnownA
+sUnownAPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose2:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose3:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose4:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose6:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose7:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose8:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose10:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose11:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose12:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose14:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose15:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose16:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose18:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose19:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose20:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose22:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose23:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose24:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose26:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose27:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose28:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose30:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose31:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose32:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose34:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose35:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose36:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose38:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose39:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose40:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose42:
+ax_pose 6, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose43:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownAPose44:
+ax_pose 8, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose45:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose47:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose48:
+ax_pose 8, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose49:
+ax_pose 7, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownAPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose51:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose52:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose53:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose55:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose56:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose57:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose59:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose60:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose61:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose63:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose64:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose65:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose67:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose68:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose69:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose71:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose72:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose73:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose75:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose76:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose77:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose79:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose80:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose81:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose83:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose84:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose85:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose87:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose88:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose89:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose91:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose92:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose93:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownAPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose95:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose96:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownAPose97:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownAAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownAAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownAAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownAAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownAAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownAAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownAAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownAAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownAAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownAAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownAAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownAAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownAAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownAAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownAAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownAAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownAAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownAAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownAAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownAAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownAAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownAAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownAAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownAAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownAAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownAAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownAAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownAAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownAAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownAAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownAAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownAAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownAAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownAAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownAAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownAAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownAAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownAAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownAAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownAAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownAAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownAAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownAAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownAAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownAAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownAAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownAAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownAAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownAAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownAAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownAGfx1:
+.incbin "baserom.gba", 0xD93870, 0x200
+sUnownASprites1:
+ax_sprite sUnownAGfx1, 0x200
+ax_sprite_terminator
+sUnownAGfx2:
+.incbin "baserom.gba", 0xD93A80, 0x200
+sUnownASprites2:
+ax_sprite sUnownAGfx2, 0x200
+ax_sprite_terminator
+sUnownAGfx3:
+.incbin "baserom.gba", 0xD93C90, 0x200
+sUnownASprites3:
+ax_sprite sUnownAGfx3, 0x200
+ax_sprite_terminator
+sUnownAGfx4:
+.incbin "baserom.gba", 0xD93EA0, 0x200
+sUnownASprites4:
+ax_sprite sUnownAGfx4, 0x200
+ax_sprite_terminator
+sUnownAGfx5:
+.incbin "baserom.gba", 0xD940B0, 0x200
+sUnownASprites5:
+ax_sprite sUnownAGfx5, 0x200
+ax_sprite_terminator
+sUnownAGfx6:
+.incbin "baserom.gba", 0xD942C0, 0x200
+sUnownASprites6:
+ax_sprite sUnownAGfx6, 0x200
+ax_sprite_terminator
+sUnownAGfx7:
+.incbin "baserom.gba", 0xD944D0, 0x200
+sUnownASprites7:
+ax_sprite sUnownAGfx7, 0x200
+ax_sprite_terminator
+sUnownAGfx8:
+.incbin "baserom.gba", 0xD946E0, 0x200
+sUnownASprites8:
+ax_sprite sUnownAGfx8, 0x200
+ax_sprite_terminator
+sUnownAGfx9:
+.incbin "baserom.gba", 0xD948F0, 0x200
+sUnownASprites9:
+ax_sprite sUnownAGfx9, 0x200
+ax_sprite_terminator
+sUnownAGfx10:
+.incbin "baserom.gba", 0xD94B00, 0x200
+sUnownASprites10:
+ax_sprite sUnownAGfx10, 0x200
+ax_sprite_terminator
+sUnownAGfx11:
+.incbin "baserom.gba", 0xD94D10, 0x200
+sUnownASprites11:
+ax_sprite sUnownAGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownA:
+.4byte sUnownAPose1
+.4byte sUnownAPose2
+.4byte sUnownAPose3
+.4byte sUnownAPose4
+.4byte sUnownAPose5
+.4byte sUnownAPose6
+.4byte sUnownAPose7
+.4byte sUnownAPose8
+.4byte sUnownAPose9
+.4byte sUnownAPose10
+.4byte sUnownAPose11
+.4byte sUnownAPose12
+.4byte sUnownAPose13
+.4byte sUnownAPose14
+.4byte sUnownAPose15
+.4byte sUnownAPose16
+.4byte sUnownAPose17
+.4byte sUnownAPose18
+.4byte sUnownAPose19
+.4byte sUnownAPose20
+.4byte sUnownAPose21
+.4byte sUnownAPose22
+.4byte sUnownAPose23
+.4byte sUnownAPose24
+.4byte sUnownAPose25
+.4byte sUnownAPose26
+.4byte sUnownAPose27
+.4byte sUnownAPose28
+.4byte sUnownAPose29
+.4byte sUnownAPose30
+.4byte sUnownAPose31
+.4byte sUnownAPose32
+.4byte sUnownAPose33
+.4byte sUnownAPose34
+.4byte sUnownAPose35
+.4byte sUnownAPose36
+.4byte sUnownAPose37
+.4byte sUnownAPose38
+.4byte sUnownAPose39
+.4byte sUnownAPose40
+.4byte sUnownAPose41
+.4byte sUnownAPose42
+.4byte sUnownAPose43
+.4byte sUnownAPose44
+.4byte sUnownAPose45
+.4byte sUnownAPose46
+.4byte sUnownAPose47
+.4byte sUnownAPose48
+.4byte sUnownAPose49
+.4byte sUnownAPose50
+.4byte sUnownAPose51
+.4byte sUnownAPose52
+.4byte sUnownAPose53
+.4byte sUnownAPose54
+.4byte sUnownAPose55
+.4byte sUnownAPose56
+.4byte sUnownAPose57
+.4byte sUnownAPose58
+.4byte sUnownAPose59
+.4byte sUnownAPose60
+.4byte sUnownAPose61
+.4byte sUnownAPose62
+.4byte sUnownAPose63
+.4byte sUnownAPose64
+.4byte sUnownAPose65
+.4byte sUnownAPose66
+.4byte sUnownAPose67
+.4byte sUnownAPose68
+.4byte sUnownAPose69
+.4byte sUnownAPose70
+.4byte sUnownAPose71
+.4byte sUnownAPose72
+.4byte sUnownAPose73
+.4byte sUnownAPose74
+.4byte sUnownAPose75
+.4byte sUnownAPose76
+.4byte sUnownAPose77
+.4byte sUnownAPose78
+.4byte sUnownAPose79
+.4byte sUnownAPose80
+.4byte sUnownAPose81
+.4byte sUnownAPose82
+.4byte sUnownAPose83
+.4byte sUnownAPose84
+.4byte sUnownAPose85
+.4byte sUnownAPose86
+.4byte sUnownAPose87
+.4byte sUnownAPose88
+.4byte sUnownAPose89
+.4byte sUnownAPose90
+.4byte sUnownAPose91
+.4byte sUnownAPose92
+.4byte sUnownAPose93
+.4byte sUnownAPose94
+.4byte sUnownAPose95
+.4byte sUnownAPose96
+.4byte sUnownAPose97
+sAxPositionsUnownA:
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -5,   -5, 	   3,   -5, 	  -1,  -10
+.2byte    1,  -17, 	   4,  -10, 	  -3,   -8, 	   0,  -14
+.2byte    0,  -14, 	   1,   -8, 	  -3,   -7, 	  -1,  -12
+.2byte   -1,  -19, 	  -5,  -13, 	   3,  -10, 	  -2,  -15
+.2byte   -1,  -18, 	   3,  -12, 	  -5,  -12, 	  -1,  -16
+.2byte   -1,  -19, 	   3,  -13, 	  -5,  -10, 	   0,  -15
+.2byte   -2,  -14, 	  -3,   -8, 	   1,   -7, 	  -1,  -12
+.2byte   -3,  -17, 	  -6,  -10, 	   1,   -8, 	  -2,  -14
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -6, 	   3,   -6, 	  -1,  -11
+.2byte    0,  -14, 	   2,   -8, 	  -5,   -5, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -8, 	  -3,   -7, 	  -1,  -11
+.2byte    0,  -14, 	  -5,   -9, 	   3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	   3,   -9, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   3,   -5, 	  -1,  -11
+sUnownAAnimTable1:
+.4byte sUnownAAnims_1_1
+.4byte sUnownAAnims_1_2
+.4byte sUnownAAnims_1_3
+.4byte sUnownAAnims_1_4
+.4byte sUnownAAnims_1_5
+.4byte sUnownAAnims_1_6
+.4byte sUnownAAnims_1_7
+.4byte sUnownAAnims_1_8
+sUnownAAnimTable2:
+.4byte sUnownAAnims_2_1
+.4byte sUnownAAnims_2_2
+.4byte sUnownAAnims_2_3
+.4byte sUnownAAnims_2_4
+.4byte sUnownAAnims_2_5
+.4byte sUnownAAnims_2_6
+.4byte sUnownAAnims_2_7
+.4byte sUnownAAnims_2_8
+sUnownAAnimTable3:
+.4byte sUnownAAnims_3_1
+.4byte sUnownAAnims_3_2
+.4byte sUnownAAnims_3_3
+.4byte sUnownAAnims_3_4
+.4byte sUnownAAnims_3_5
+.4byte sUnownAAnims_3_6
+.4byte sUnownAAnims_3_7
+.4byte sUnownAAnims_3_8
+sUnownAAnimTable4:
+.4byte sUnownAAnims_4_1
+.4byte sUnownAAnims_4_2
+.4byte sUnownAAnims_4_3
+.4byte sUnownAAnims_4_4
+.4byte sUnownAAnims_4_5
+.4byte sUnownAAnims_4_6
+.4byte sUnownAAnims_4_7
+.4byte sUnownAAnims_4_8
+sUnownAAnimTable5:
+.4byte sUnownAAnims_5_1
+.4byte sUnownAAnims_5_2
+.4byte sUnownAAnims_5_3
+.4byte sUnownAAnims_5_4
+.4byte sUnownAAnims_5_5
+.4byte sUnownAAnims_5_6
+.4byte sUnownAAnims_5_7
+.4byte sUnownAAnims_5_8
+sUnownAAnimTable6:
+.4byte sUnownAAnims_6_1
+.4byte sUnownAAnims_6_1
+.4byte sUnownAAnims_6_1
+.4byte sUnownAAnims_6_1
+.4byte sUnownAAnims_6_1
+.4byte sUnownAAnims_6_1
+.4byte sUnownAAnims_6_1
+.4byte sUnownAAnims_6_1
+sUnownAAnimTable7:
+.4byte sUnownAAnims_7_1
+.4byte sUnownAAnims_7_2
+.4byte sUnownAAnims_7_3
+.4byte sUnownAAnims_7_4
+.4byte sUnownAAnims_7_5
+.4byte sUnownAAnims_7_6
+.4byte sUnownAAnims_7_7
+.4byte sUnownAAnims_7_8
+sUnownAAnimTable8:
+.4byte sUnownAAnims_8_1
+.4byte sUnownAAnims_8_2
+.4byte sUnownAAnims_8_3
+.4byte sUnownAAnims_8_4
+.4byte sUnownAAnims_8_5
+.4byte sUnownAAnims_8_6
+.4byte sUnownAAnims_8_7
+.4byte sUnownAAnims_8_8
+sUnownAAnimTable9:
+.4byte sUnownAAnims_9_1
+.4byte sUnownAAnims_9_2
+.4byte sUnownAAnims_9_3
+.4byte sUnownAAnims_9_4
+.4byte sUnownAAnims_9_5
+.4byte sUnownAAnims_9_6
+.4byte sUnownAAnims_9_7
+.4byte sUnownAAnims_9_8
+sUnownAAnimTable10:
+.4byte sUnownAAnims_10_1
+.4byte sUnownAAnims_10_2
+.4byte sUnownAAnims_10_3
+.4byte sUnownAAnims_10_4
+.4byte sUnownAAnims_10_5
+.4byte sUnownAAnims_10_6
+.4byte sUnownAAnims_10_7
+.4byte sUnownAAnims_10_8
+sUnownAAnimTable11:
+.4byte sUnownAAnims_11_1
+.4byte sUnownAAnims_11_2
+.4byte sUnownAAnims_11_3
+.4byte sUnownAAnims_11_4
+.4byte sUnownAAnims_11_5
+.4byte sUnownAAnims_11_6
+.4byte sUnownAAnims_11_7
+.4byte sUnownAAnims_11_8
+sUnownAAnimTable12:
+.4byte sUnownAAnims_12_1
+.4byte sUnownAAnims_12_2
+.4byte sUnownAAnims_12_3
+.4byte sUnownAAnims_12_4
+.4byte sUnownAAnims_12_5
+.4byte sUnownAAnims_12_6
+.4byte sUnownAAnims_12_7
+.4byte sUnownAAnims_12_8
+sUnownAAnimTable13:
+.4byte sUnownAAnims_13_1
+.4byte sUnownAAnims_13_2
+.4byte sUnownAAnims_13_3
+.4byte sUnownAAnims_13_4
+.4byte sUnownAAnims_13_5
+.4byte sUnownAAnims_13_6
+.4byte sUnownAAnims_13_7
+.4byte sUnownAAnims_13_8
+sAxAnimationsUnownA:
+.4byte sUnownAAnimTable1
+.4byte sUnownAAnimTable2
+.4byte sUnownAAnimTable3
+.4byte sUnownAAnimTable4
+.4byte sUnownAAnimTable5
+.4byte sUnownAAnimTable6
+.4byte sUnownAAnimTable7
+.4byte sUnownAAnimTable8
+.4byte sUnownAAnimTable9
+.4byte sUnownAAnimTable10
+.4byte sUnownAAnimTable11
+.4byte sUnownAAnimTable12
+.4byte sUnownAAnimTable13
+sAxSpritesUnownA:
+.4byte sUnownASprites1
+.4byte sUnownASprites2
+.4byte sUnownASprites3
+.4byte sUnownASprites4
+.4byte sUnownASprites5
+.4byte sUnownASprites6
+.4byte sUnownASprites7
+.4byte sUnownASprites8
+.4byte sUnownASprites9
+.4byte sUnownASprites10
+.4byte sUnownASprites11
+sAxMainUnownA:
+ax_main sAxPosesUnownA, sAxAnimationsUnownA, 13, sAxSpritesUnownA, sAxPositionsUnownA

--- a/data/ax/unownb.inc
+++ b/data/ax/unownb.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownB
+gAxUnownB:
+ax_siro sAxMainUnownB
+sUnownBPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose4:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose6:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose12:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose14:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose20:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose22:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose28:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose30:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose36:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose38:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose43:
+ax_pose 10, 0x01e6, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownBPose44:
+ax_pose 11, 0x01e6, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownBPose45:
+ax_pose 12, 0x01e5, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownBPose46:
+ax_pose 13, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose47:
+ax_pose 14, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose48:
+ax_pose 15, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose49:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose53:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose55:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose61:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose63:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose69:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose71:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose77:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose79:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose85:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose87:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose93:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownBPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose95:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownBPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownBAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownBAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownBAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownBAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownBAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownBAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownBAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownBAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownBAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownBAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownBAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownBAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownBAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownBAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownBAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownBAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownBAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownBAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownBAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownBAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownBAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownBAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownBAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownBAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownBAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownBAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownBAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownBAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownBAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownBAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownBAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownBAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownBAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownBAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownBAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownBAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownBAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownBAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownBAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownBAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownBAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownBAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownBAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownBAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownBAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownBAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownBAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownBAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownBAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownBAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownBGfx1:
+.incbin "baserom.gba", 0xD98E08, 0x200
+sUnownBSprites1:
+ax_sprite sUnownBGfx1, 0x200
+ax_sprite_terminator
+sUnownBGfx2:
+.incbin "baserom.gba", 0xD99018, 0x200
+sUnownBSprites2:
+ax_sprite sUnownBGfx2, 0x200
+ax_sprite_terminator
+sUnownBGfx3:
+.incbin "baserom.gba", 0xD99228, 0x200
+sUnownBSprites3:
+ax_sprite sUnownBGfx3, 0x200
+ax_sprite_terminator
+sUnownBGfx4:
+.incbin "baserom.gba", 0xD99438, 0x200
+sUnownBSprites4:
+ax_sprite sUnownBGfx4, 0x200
+ax_sprite_terminator
+sUnownBGfx5:
+.incbin "baserom.gba", 0xD99648, 0x200
+sUnownBSprites5:
+ax_sprite sUnownBGfx5, 0x200
+ax_sprite_terminator
+sUnownBGfx6:
+.incbin "baserom.gba", 0xD99858, 0x200
+sUnownBSprites6:
+ax_sprite sUnownBGfx6, 0x200
+ax_sprite_terminator
+sUnownBGfx7:
+.incbin "baserom.gba", 0xD99A68, 0x200
+sUnownBSprites7:
+ax_sprite sUnownBGfx7, 0x200
+ax_sprite_terminator
+sUnownBGfx8:
+.incbin "baserom.gba", 0xD99C78, 0x200
+sUnownBSprites8:
+ax_sprite sUnownBGfx8, 0x200
+ax_sprite_terminator
+sUnownBGfx9:
+.incbin "baserom.gba", 0xD99E88, 0x200
+sUnownBSprites9:
+ax_sprite sUnownBGfx9, 0x200
+ax_sprite_terminator
+sUnownBGfx10:
+.incbin "baserom.gba", 0xD9A098, 0x200
+sUnownBSprites10:
+ax_sprite sUnownBGfx10, 0x200
+ax_sprite_terminator
+sUnownBGfx11:
+.incbin "baserom.gba", 0xD9A2A8, 0x200
+sUnownBSprites11:
+ax_sprite sUnownBGfx11, 0x200
+ax_sprite_terminator
+sUnownBGfx12:
+.incbin "baserom.gba", 0xD9A4B8, 0x200
+sUnownBSprites12:
+ax_sprite sUnownBGfx12, 0x200
+ax_sprite_terminator
+sUnownBGfx13:
+.incbin "baserom.gba", 0xD9A6C8, 0x200
+sUnownBSprites13:
+ax_sprite sUnownBGfx13, 0x200
+ax_sprite_terminator
+sUnownBGfx14:
+.incbin "baserom.gba", 0xD9A8D8, 0x200
+sUnownBSprites14:
+ax_sprite sUnownBGfx14, 0x200
+ax_sprite_terminator
+sUnownBGfx15:
+.incbin "baserom.gba", 0xD9AAE8, 0x200
+sUnownBSprites15:
+ax_sprite sUnownBGfx15, 0x200
+ax_sprite_terminator
+sUnownBGfx16:
+.incbin "baserom.gba", 0xD9ACF8, 0x200
+sUnownBSprites16:
+ax_sprite sUnownBGfx16, 0x200
+ax_sprite_terminator
+sUnownBGfx17:
+.incbin "baserom.gba", 0xD9AF08, 0x200
+sUnownBSprites17:
+ax_sprite sUnownBGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownB:
+.4byte sUnownBPose1
+.4byte sUnownBPose2
+.4byte sUnownBPose3
+.4byte sUnownBPose4
+.4byte sUnownBPose5
+.4byte sUnownBPose6
+.4byte sUnownBPose7
+.4byte sUnownBPose8
+.4byte sUnownBPose9
+.4byte sUnownBPose10
+.4byte sUnownBPose11
+.4byte sUnownBPose12
+.4byte sUnownBPose13
+.4byte sUnownBPose14
+.4byte sUnownBPose15
+.4byte sUnownBPose16
+.4byte sUnownBPose17
+.4byte sUnownBPose18
+.4byte sUnownBPose19
+.4byte sUnownBPose20
+.4byte sUnownBPose21
+.4byte sUnownBPose22
+.4byte sUnownBPose23
+.4byte sUnownBPose24
+.4byte sUnownBPose25
+.4byte sUnownBPose26
+.4byte sUnownBPose27
+.4byte sUnownBPose28
+.4byte sUnownBPose29
+.4byte sUnownBPose30
+.4byte sUnownBPose31
+.4byte sUnownBPose32
+.4byte sUnownBPose33
+.4byte sUnownBPose34
+.4byte sUnownBPose35
+.4byte sUnownBPose36
+.4byte sUnownBPose37
+.4byte sUnownBPose38
+.4byte sUnownBPose39
+.4byte sUnownBPose40
+.4byte sUnownBPose41
+.4byte sUnownBPose42
+.4byte sUnownBPose43
+.4byte sUnownBPose44
+.4byte sUnownBPose45
+.4byte sUnownBPose46
+.4byte sUnownBPose47
+.4byte sUnownBPose48
+.4byte sUnownBPose49
+.4byte sUnownBPose50
+.4byte sUnownBPose51
+.4byte sUnownBPose52
+.4byte sUnownBPose53
+.4byte sUnownBPose54
+.4byte sUnownBPose55
+.4byte sUnownBPose56
+.4byte sUnownBPose57
+.4byte sUnownBPose58
+.4byte sUnownBPose59
+.4byte sUnownBPose60
+.4byte sUnownBPose61
+.4byte sUnownBPose62
+.4byte sUnownBPose63
+.4byte sUnownBPose64
+.4byte sUnownBPose65
+.4byte sUnownBPose66
+.4byte sUnownBPose67
+.4byte sUnownBPose68
+.4byte sUnownBPose69
+.4byte sUnownBPose70
+.4byte sUnownBPose71
+.4byte sUnownBPose72
+.4byte sUnownBPose73
+.4byte sUnownBPose74
+.4byte sUnownBPose75
+.4byte sUnownBPose76
+.4byte sUnownBPose77
+.4byte sUnownBPose78
+.4byte sUnownBPose79
+.4byte sUnownBPose80
+.4byte sUnownBPose81
+.4byte sUnownBPose82
+.4byte sUnownBPose83
+.4byte sUnownBPose84
+.4byte sUnownBPose85
+.4byte sUnownBPose86
+.4byte sUnownBPose87
+.4byte sUnownBPose88
+.4byte sUnownBPose89
+.4byte sUnownBPose90
+.4byte sUnownBPose91
+.4byte sUnownBPose92
+.4byte sUnownBPose93
+.4byte sUnownBPose94
+.4byte sUnownBPose95
+.4byte sUnownBPose96
+.4byte sUnownBPose97
+sAxPositionsUnownB:
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte   -3,  -16, 	  -4,   -6, 	   0,  -16, 	  -2,  -12
+.2byte   -2,  -16, 	  -3,   -6, 	  -4,  -17, 	  -2,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -6,  -14, 	  -3,  -11
+.2byte   -1,  -13, 	   3,   -7, 	  -4,  -13, 	  -1,  -10
+.2byte   -1,  -15, 	   3,   -7, 	  -4,  -13, 	   0,  -10
+.2byte   -1,  -16, 	  -2,   -8, 	   2,  -14, 	   0,  -12
+.2byte    0,  -16, 	  -4,   -9, 	   5,  -14, 	   1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+.2byte   -1,  -16, 	  -6,   -8, 	   4,  -16, 	  -1,  -12
+.2byte    0,  -15, 	  -4,   -6, 	   4,  -16, 	  -1,  -12
+.2byte    1,  -15, 	  -2,   -6, 	   0,  -16, 	   0,  -11
+.2byte    1,  -16, 	   2,   -6, 	  -5,  -16, 	  -1,  -12
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -15, 	  -1,  -12
+.2byte   -2,  -16, 	   3,   -8, 	  -5,  -14, 	  -1,  -11
+.2byte   -3,  -15, 	  -3,   -8, 	   1,  -14, 	  -1,  -11
+.2byte   -2,  -15, 	  -5,   -8, 	   2,  -14, 	  -1,  -11
+sUnownBAnimTable1:
+.4byte sUnownBAnims_1_1
+.4byte sUnownBAnims_1_2
+.4byte sUnownBAnims_1_3
+.4byte sUnownBAnims_1_4
+.4byte sUnownBAnims_1_5
+.4byte sUnownBAnims_1_6
+.4byte sUnownBAnims_1_7
+.4byte sUnownBAnims_1_8
+sUnownBAnimTable2:
+.4byte sUnownBAnims_2_1
+.4byte sUnownBAnims_2_2
+.4byte sUnownBAnims_2_3
+.4byte sUnownBAnims_2_4
+.4byte sUnownBAnims_2_5
+.4byte sUnownBAnims_2_6
+.4byte sUnownBAnims_2_7
+.4byte sUnownBAnims_2_8
+sUnownBAnimTable3:
+.4byte sUnownBAnims_3_1
+.4byte sUnownBAnims_3_2
+.4byte sUnownBAnims_3_3
+.4byte sUnownBAnims_3_4
+.4byte sUnownBAnims_3_5
+.4byte sUnownBAnims_3_6
+.4byte sUnownBAnims_3_7
+.4byte sUnownBAnims_3_8
+sUnownBAnimTable4:
+.4byte sUnownBAnims_4_1
+.4byte sUnownBAnims_4_2
+.4byte sUnownBAnims_4_3
+.4byte sUnownBAnims_4_4
+.4byte sUnownBAnims_4_5
+.4byte sUnownBAnims_4_6
+.4byte sUnownBAnims_4_7
+.4byte sUnownBAnims_4_8
+sUnownBAnimTable5:
+.4byte sUnownBAnims_5_1
+.4byte sUnownBAnims_5_2
+.4byte sUnownBAnims_5_3
+.4byte sUnownBAnims_5_4
+.4byte sUnownBAnims_5_5
+.4byte sUnownBAnims_5_6
+.4byte sUnownBAnims_5_7
+.4byte sUnownBAnims_5_8
+sUnownBAnimTable6:
+.4byte sUnownBAnims_6_1
+.4byte sUnownBAnims_6_1
+.4byte sUnownBAnims_6_1
+.4byte sUnownBAnims_6_1
+.4byte sUnownBAnims_6_1
+.4byte sUnownBAnims_6_1
+.4byte sUnownBAnims_6_1
+.4byte sUnownBAnims_6_1
+sUnownBAnimTable7:
+.4byte sUnownBAnims_7_1
+.4byte sUnownBAnims_7_2
+.4byte sUnownBAnims_7_3
+.4byte sUnownBAnims_7_4
+.4byte sUnownBAnims_7_5
+.4byte sUnownBAnims_7_6
+.4byte sUnownBAnims_7_7
+.4byte sUnownBAnims_7_8
+sUnownBAnimTable8:
+.4byte sUnownBAnims_8_1
+.4byte sUnownBAnims_8_2
+.4byte sUnownBAnims_8_3
+.4byte sUnownBAnims_8_4
+.4byte sUnownBAnims_8_5
+.4byte sUnownBAnims_8_6
+.4byte sUnownBAnims_8_7
+.4byte sUnownBAnims_8_8
+sUnownBAnimTable9:
+.4byte sUnownBAnims_9_1
+.4byte sUnownBAnims_9_2
+.4byte sUnownBAnims_9_3
+.4byte sUnownBAnims_9_4
+.4byte sUnownBAnims_9_5
+.4byte sUnownBAnims_9_6
+.4byte sUnownBAnims_9_7
+.4byte sUnownBAnims_9_8
+sUnownBAnimTable10:
+.4byte sUnownBAnims_10_1
+.4byte sUnownBAnims_10_2
+.4byte sUnownBAnims_10_3
+.4byte sUnownBAnims_10_4
+.4byte sUnownBAnims_10_5
+.4byte sUnownBAnims_10_6
+.4byte sUnownBAnims_10_7
+.4byte sUnownBAnims_10_8
+sUnownBAnimTable11:
+.4byte sUnownBAnims_11_1
+.4byte sUnownBAnims_11_2
+.4byte sUnownBAnims_11_3
+.4byte sUnownBAnims_11_4
+.4byte sUnownBAnims_11_5
+.4byte sUnownBAnims_11_6
+.4byte sUnownBAnims_11_7
+.4byte sUnownBAnims_11_8
+sUnownBAnimTable12:
+.4byte sUnownBAnims_12_1
+.4byte sUnownBAnims_12_2
+.4byte sUnownBAnims_12_3
+.4byte sUnownBAnims_12_4
+.4byte sUnownBAnims_12_5
+.4byte sUnownBAnims_12_6
+.4byte sUnownBAnims_12_7
+.4byte sUnownBAnims_12_8
+sUnownBAnimTable13:
+.4byte sUnownBAnims_13_1
+.4byte sUnownBAnims_13_2
+.4byte sUnownBAnims_13_3
+.4byte sUnownBAnims_13_4
+.4byte sUnownBAnims_13_5
+.4byte sUnownBAnims_13_6
+.4byte sUnownBAnims_13_7
+.4byte sUnownBAnims_13_8
+sAxAnimationsUnownB:
+.4byte sUnownBAnimTable1
+.4byte sUnownBAnimTable2
+.4byte sUnownBAnimTable3
+.4byte sUnownBAnimTable4
+.4byte sUnownBAnimTable5
+.4byte sUnownBAnimTable6
+.4byte sUnownBAnimTable7
+.4byte sUnownBAnimTable8
+.4byte sUnownBAnimTable9
+.4byte sUnownBAnimTable10
+.4byte sUnownBAnimTable11
+.4byte sUnownBAnimTable12
+.4byte sUnownBAnimTable13
+sAxSpritesUnownB:
+.4byte sUnownBSprites1
+.4byte sUnownBSprites2
+.4byte sUnownBSprites3
+.4byte sUnownBSprites4
+.4byte sUnownBSprites5
+.4byte sUnownBSprites6
+.4byte sUnownBSprites7
+.4byte sUnownBSprites8
+.4byte sUnownBSprites9
+.4byte sUnownBSprites10
+.4byte sUnownBSprites11
+.4byte sUnownBSprites12
+.4byte sUnownBSprites13
+.4byte sUnownBSprites14
+.4byte sUnownBSprites15
+.4byte sUnownBSprites16
+.4byte sUnownBSprites17
+sAxMainUnownB:
+ax_main sAxPosesUnownB, sAxAnimationsUnownB, 13, sAxSpritesUnownB, sAxPositionsUnownB

--- a/data/ax/unownc.inc
+++ b/data/ax/unownc.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownC
+gAxUnownC:
+ax_siro sAxMainUnownC
+sUnownCPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose4:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose6:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose12:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose14:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose20:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose22:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose28:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose30:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose36:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose38:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose43:
+ax_pose 10, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownCPose44:
+ax_pose 11, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownCPose45:
+ax_pose 12, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownCPose46:
+ax_pose 13, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose47:
+ax_pose 14, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose48:
+ax_pose 15, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sUnownCPose49:
+ax_pose 16, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownCPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose53:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose55:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose61:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose63:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose69:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose71:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose77:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose79:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose85:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose87:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose93:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownCPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose95:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownCPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownCAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownCAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownCAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownCAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownCAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownCAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownCAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownCAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownCAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownCAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownCAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownCAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownCAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownCAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownCAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownCAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownCAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownCAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownCAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownCAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownCAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownCAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownCAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownCAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownCAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownCAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownCAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownCAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownCAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownCAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownCAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownCAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownCAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownCAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownCAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownCAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownCAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownCAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownCAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownCAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownCAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownCAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownCAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownCAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownCAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownCAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownCAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownCAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownCAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownCAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownCGfx1:
+.incbin "baserom.gba", 0xD9F018, 0x200
+sUnownCSprites1:
+ax_sprite sUnownCGfx1, 0x200
+ax_sprite_terminator
+sUnownCGfx2:
+.incbin "baserom.gba", 0xD9F228, 0x200
+sUnownCSprites2:
+ax_sprite sUnownCGfx2, 0x200
+ax_sprite_terminator
+sUnownCGfx3:
+.incbin "baserom.gba", 0xD9F438, 0x200
+sUnownCSprites3:
+ax_sprite sUnownCGfx3, 0x200
+ax_sprite_terminator
+sUnownCGfx4:
+.incbin "baserom.gba", 0xD9F648, 0x200
+sUnownCSprites4:
+ax_sprite sUnownCGfx4, 0x200
+ax_sprite_terminator
+sUnownCGfx5:
+.incbin "baserom.gba", 0xD9F858, 0x200
+sUnownCSprites5:
+ax_sprite sUnownCGfx5, 0x200
+ax_sprite_terminator
+sUnownCGfx6:
+.incbin "baserom.gba", 0xD9FA68, 0x200
+sUnownCSprites6:
+ax_sprite sUnownCGfx6, 0x200
+ax_sprite_terminator
+sUnownCGfx7:
+.incbin "baserom.gba", 0xD9FC78, 0x200
+sUnownCSprites7:
+ax_sprite sUnownCGfx7, 0x200
+ax_sprite_terminator
+sUnownCGfx8:
+.incbin "baserom.gba", 0xD9FE88, 0x200
+sUnownCSprites8:
+ax_sprite sUnownCGfx8, 0x200
+ax_sprite_terminator
+sUnownCGfx9:
+.incbin "baserom.gba", 0xDA0098, 0x200
+sUnownCSprites9:
+ax_sprite sUnownCGfx9, 0x200
+ax_sprite_terminator
+sUnownCGfx10:
+.incbin "baserom.gba", 0xDA02A8, 0x200
+sUnownCSprites10:
+ax_sprite sUnownCGfx10, 0x200
+ax_sprite_terminator
+sUnownCGfx11:
+.incbin "baserom.gba", 0xDA04B8, 0x200
+sUnownCSprites11:
+ax_sprite sUnownCGfx11, 0x200
+ax_sprite_terminator
+sUnownCGfx12:
+.incbin "baserom.gba", 0xDA06C8, 0x200
+sUnownCSprites12:
+ax_sprite sUnownCGfx12, 0x200
+ax_sprite_terminator
+sUnownCGfx13:
+.incbin "baserom.gba", 0xDA08D8, 0x200
+sUnownCSprites13:
+ax_sprite sUnownCGfx13, 0x200
+ax_sprite_terminator
+sUnownCGfx14:
+.incbin "baserom.gba", 0xDA0AE8, 0x200
+sUnownCSprites14:
+ax_sprite sUnownCGfx14, 0x200
+ax_sprite_terminator
+sUnownCGfx15:
+.incbin "baserom.gba", 0xDA0CF8, 0x200
+sUnownCSprites15:
+ax_sprite sUnownCGfx15, 0x200
+ax_sprite_terminator
+sUnownCGfx16:
+.incbin "baserom.gba", 0xDA0F08, 0x200
+sUnownCSprites16:
+ax_sprite sUnownCGfx16, 0x200
+ax_sprite_terminator
+sUnownCGfx17:
+.incbin "baserom.gba", 0xDA1118, 0x200
+sUnownCSprites17:
+ax_sprite sUnownCGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownC:
+.4byte sUnownCPose1
+.4byte sUnownCPose2
+.4byte sUnownCPose3
+.4byte sUnownCPose4
+.4byte sUnownCPose5
+.4byte sUnownCPose6
+.4byte sUnownCPose7
+.4byte sUnownCPose8
+.4byte sUnownCPose9
+.4byte sUnownCPose10
+.4byte sUnownCPose11
+.4byte sUnownCPose12
+.4byte sUnownCPose13
+.4byte sUnownCPose14
+.4byte sUnownCPose15
+.4byte sUnownCPose16
+.4byte sUnownCPose17
+.4byte sUnownCPose18
+.4byte sUnownCPose19
+.4byte sUnownCPose20
+.4byte sUnownCPose21
+.4byte sUnownCPose22
+.4byte sUnownCPose23
+.4byte sUnownCPose24
+.4byte sUnownCPose25
+.4byte sUnownCPose26
+.4byte sUnownCPose27
+.4byte sUnownCPose28
+.4byte sUnownCPose29
+.4byte sUnownCPose30
+.4byte sUnownCPose31
+.4byte sUnownCPose32
+.4byte sUnownCPose33
+.4byte sUnownCPose34
+.4byte sUnownCPose35
+.4byte sUnownCPose36
+.4byte sUnownCPose37
+.4byte sUnownCPose38
+.4byte sUnownCPose39
+.4byte sUnownCPose40
+.4byte sUnownCPose41
+.4byte sUnownCPose42
+.4byte sUnownCPose43
+.4byte sUnownCPose44
+.4byte sUnownCPose45
+.4byte sUnownCPose46
+.4byte sUnownCPose47
+.4byte sUnownCPose48
+.4byte sUnownCPose49
+.4byte sUnownCPose50
+.4byte sUnownCPose51
+.4byte sUnownCPose52
+.4byte sUnownCPose53
+.4byte sUnownCPose54
+.4byte sUnownCPose55
+.4byte sUnownCPose56
+.4byte sUnownCPose57
+.4byte sUnownCPose58
+.4byte sUnownCPose59
+.4byte sUnownCPose60
+.4byte sUnownCPose61
+.4byte sUnownCPose62
+.4byte sUnownCPose63
+.4byte sUnownCPose64
+.4byte sUnownCPose65
+.4byte sUnownCPose66
+.4byte sUnownCPose67
+.4byte sUnownCPose68
+.4byte sUnownCPose69
+.4byte sUnownCPose70
+.4byte sUnownCPose71
+.4byte sUnownCPose72
+.4byte sUnownCPose73
+.4byte sUnownCPose74
+.4byte sUnownCPose75
+.4byte sUnownCPose76
+.4byte sUnownCPose77
+.4byte sUnownCPose78
+.4byte sUnownCPose79
+.4byte sUnownCPose80
+.4byte sUnownCPose81
+.4byte sUnownCPose82
+.4byte sUnownCPose83
+.4byte sUnownCPose84
+.4byte sUnownCPose85
+.4byte sUnownCPose86
+.4byte sUnownCPose87
+.4byte sUnownCPose88
+.4byte sUnownCPose89
+.4byte sUnownCPose90
+.4byte sUnownCPose91
+.4byte sUnownCPose92
+.4byte sUnownCPose93
+.4byte sUnownCPose94
+.4byte sUnownCPose95
+.4byte sUnownCPose96
+.4byte sUnownCPose97
+sAxPositionsUnownC:
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   0,   -6, 	   4,  -13, 	  -1,  -13
+.2byte    1,  -14, 	  -1,   -6, 	   0,  -17, 	  -2,  -13
+.2byte    0,  -15, 	   0,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -14, 	  -1,   -7, 	  -8,  -13, 	  -1,  -12
+.2byte   -2,  -14, 	  -2,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -14, 	  -2,   -6, 	   2,  -11, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -6, 	   5,  -11, 	   0,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,   -5, 	   6,  -13, 	  -1,  -12
+.2byte    0,  -13, 	  -1,   -6, 	   4,  -14, 	  -2,  -12
+.2byte    2,  -13, 	  -1,   -6, 	   2,  -16, 	   0,  -12
+.2byte    0,  -15, 	  -1,   -6, 	  -6,  -15, 	  -1,  -13
+.2byte   -1,  -13, 	  -1,   -6, 	  -8,  -14, 	  -1,  -12
+.2byte   -2,  -14, 	  -1,   -6, 	  -6,  -11, 	   0,  -12
+.2byte   -4,  -13, 	  -1,   -6, 	   2,  -11, 	  -2,  -12
+.2byte   -2,  -13, 	  -1,   -6, 	   5,  -11, 	  -1,  -12
+sUnownCAnimTable1:
+.4byte sUnownCAnims_1_1
+.4byte sUnownCAnims_1_2
+.4byte sUnownCAnims_1_3
+.4byte sUnownCAnims_1_4
+.4byte sUnownCAnims_1_5
+.4byte sUnownCAnims_1_6
+.4byte sUnownCAnims_1_7
+.4byte sUnownCAnims_1_8
+sUnownCAnimTable2:
+.4byte sUnownCAnims_2_1
+.4byte sUnownCAnims_2_2
+.4byte sUnownCAnims_2_3
+.4byte sUnownCAnims_2_4
+.4byte sUnownCAnims_2_5
+.4byte sUnownCAnims_2_6
+.4byte sUnownCAnims_2_7
+.4byte sUnownCAnims_2_8
+sUnownCAnimTable3:
+.4byte sUnownCAnims_3_1
+.4byte sUnownCAnims_3_2
+.4byte sUnownCAnims_3_3
+.4byte sUnownCAnims_3_4
+.4byte sUnownCAnims_3_5
+.4byte sUnownCAnims_3_6
+.4byte sUnownCAnims_3_7
+.4byte sUnownCAnims_3_8
+sUnownCAnimTable4:
+.4byte sUnownCAnims_4_1
+.4byte sUnownCAnims_4_2
+.4byte sUnownCAnims_4_3
+.4byte sUnownCAnims_4_4
+.4byte sUnownCAnims_4_5
+.4byte sUnownCAnims_4_6
+.4byte sUnownCAnims_4_7
+.4byte sUnownCAnims_4_8
+sUnownCAnimTable5:
+.4byte sUnownCAnims_5_1
+.4byte sUnownCAnims_5_2
+.4byte sUnownCAnims_5_3
+.4byte sUnownCAnims_5_4
+.4byte sUnownCAnims_5_5
+.4byte sUnownCAnims_5_6
+.4byte sUnownCAnims_5_7
+.4byte sUnownCAnims_5_8
+sUnownCAnimTable6:
+.4byte sUnownCAnims_6_1
+.4byte sUnownCAnims_6_1
+.4byte sUnownCAnims_6_1
+.4byte sUnownCAnims_6_1
+.4byte sUnownCAnims_6_1
+.4byte sUnownCAnims_6_1
+.4byte sUnownCAnims_6_1
+.4byte sUnownCAnims_6_1
+sUnownCAnimTable7:
+.4byte sUnownCAnims_7_1
+.4byte sUnownCAnims_7_2
+.4byte sUnownCAnims_7_3
+.4byte sUnownCAnims_7_4
+.4byte sUnownCAnims_7_5
+.4byte sUnownCAnims_7_6
+.4byte sUnownCAnims_7_7
+.4byte sUnownCAnims_7_8
+sUnownCAnimTable8:
+.4byte sUnownCAnims_8_1
+.4byte sUnownCAnims_8_2
+.4byte sUnownCAnims_8_3
+.4byte sUnownCAnims_8_4
+.4byte sUnownCAnims_8_5
+.4byte sUnownCAnims_8_6
+.4byte sUnownCAnims_8_7
+.4byte sUnownCAnims_8_8
+sUnownCAnimTable9:
+.4byte sUnownCAnims_9_1
+.4byte sUnownCAnims_9_2
+.4byte sUnownCAnims_9_3
+.4byte sUnownCAnims_9_4
+.4byte sUnownCAnims_9_5
+.4byte sUnownCAnims_9_6
+.4byte sUnownCAnims_9_7
+.4byte sUnownCAnims_9_8
+sUnownCAnimTable10:
+.4byte sUnownCAnims_10_1
+.4byte sUnownCAnims_10_2
+.4byte sUnownCAnims_10_3
+.4byte sUnownCAnims_10_4
+.4byte sUnownCAnims_10_5
+.4byte sUnownCAnims_10_6
+.4byte sUnownCAnims_10_7
+.4byte sUnownCAnims_10_8
+sUnownCAnimTable11:
+.4byte sUnownCAnims_11_1
+.4byte sUnownCAnims_11_2
+.4byte sUnownCAnims_11_3
+.4byte sUnownCAnims_11_4
+.4byte sUnownCAnims_11_5
+.4byte sUnownCAnims_11_6
+.4byte sUnownCAnims_11_7
+.4byte sUnownCAnims_11_8
+sUnownCAnimTable12:
+.4byte sUnownCAnims_12_1
+.4byte sUnownCAnims_12_2
+.4byte sUnownCAnims_12_3
+.4byte sUnownCAnims_12_4
+.4byte sUnownCAnims_12_5
+.4byte sUnownCAnims_12_6
+.4byte sUnownCAnims_12_7
+.4byte sUnownCAnims_12_8
+sUnownCAnimTable13:
+.4byte sUnownCAnims_13_1
+.4byte sUnownCAnims_13_2
+.4byte sUnownCAnims_13_3
+.4byte sUnownCAnims_13_4
+.4byte sUnownCAnims_13_5
+.4byte sUnownCAnims_13_6
+.4byte sUnownCAnims_13_7
+.4byte sUnownCAnims_13_8
+sAxAnimationsUnownC:
+.4byte sUnownCAnimTable1
+.4byte sUnownCAnimTable2
+.4byte sUnownCAnimTable3
+.4byte sUnownCAnimTable4
+.4byte sUnownCAnimTable5
+.4byte sUnownCAnimTable6
+.4byte sUnownCAnimTable7
+.4byte sUnownCAnimTable8
+.4byte sUnownCAnimTable9
+.4byte sUnownCAnimTable10
+.4byte sUnownCAnimTable11
+.4byte sUnownCAnimTable12
+.4byte sUnownCAnimTable13
+sAxSpritesUnownC:
+.4byte sUnownCSprites1
+.4byte sUnownCSprites2
+.4byte sUnownCSprites3
+.4byte sUnownCSprites4
+.4byte sUnownCSprites5
+.4byte sUnownCSprites6
+.4byte sUnownCSprites7
+.4byte sUnownCSprites8
+.4byte sUnownCSprites9
+.4byte sUnownCSprites10
+.4byte sUnownCSprites11
+.4byte sUnownCSprites12
+.4byte sUnownCSprites13
+.4byte sUnownCSprites14
+.4byte sUnownCSprites15
+.4byte sUnownCSprites16
+.4byte sUnownCSprites17
+sAxMainUnownC:
+ax_main sAxPosesUnownC, sAxAnimationsUnownC, 13, sAxSpritesUnownC, sAxPositionsUnownC

--- a/data/ax/unownd.inc
+++ b/data/ax/unownd.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownD
+gAxUnownD:
+ax_siro sAxMainUnownD
+sUnownDPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose4:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose6:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose12:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose14:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose20:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose22:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose28:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose30:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose36:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose38:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose43:
+ax_pose 10, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownDPose44:
+ax_pose 11, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownDPose45:
+ax_pose 12, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownDPose46:
+ax_pose 13, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose47:
+ax_pose 14, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownDPose48:
+ax_pose 15, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownDPose49:
+ax_pose 16, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownDPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose53:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose55:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose61:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose63:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose69:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose71:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose77:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose79:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose85:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose87:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose93:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownDPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose95:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownDPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownDAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownDAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownDAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownDAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownDAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownDAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownDAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownDAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownDAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownDAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownDAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownDAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownDAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownDAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownDAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownDAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownDAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownDAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownDAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownDAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownDAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownDAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownDAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownDAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownDAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownDAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownDAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownDAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownDAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownDAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownDAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownDAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownDAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownDAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownDAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownDAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownDAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownDAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownDAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownDAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownDAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownDAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownDAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownDAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownDAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownDAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownDAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownDAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownDAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownDAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownDGfx1:
+.incbin "baserom.gba", 0xDA5228, 0x200
+sUnownDSprites1:
+ax_sprite sUnownDGfx1, 0x200
+ax_sprite_terminator
+sUnownDGfx2:
+.incbin "baserom.gba", 0xDA5438, 0x200
+sUnownDSprites2:
+ax_sprite sUnownDGfx2, 0x200
+ax_sprite_terminator
+sUnownDGfx3:
+.incbin "baserom.gba", 0xDA5648, 0x200
+sUnownDSprites3:
+ax_sprite sUnownDGfx3, 0x200
+ax_sprite_terminator
+sUnownDGfx4:
+.incbin "baserom.gba", 0xDA5858, 0x200
+sUnownDSprites4:
+ax_sprite sUnownDGfx4, 0x200
+ax_sprite_terminator
+sUnownDGfx5:
+.incbin "baserom.gba", 0xDA5A68, 0x200
+sUnownDSprites5:
+ax_sprite sUnownDGfx5, 0x200
+ax_sprite_terminator
+sUnownDGfx6:
+.incbin "baserom.gba", 0xDA5C78, 0x200
+sUnownDSprites6:
+ax_sprite sUnownDGfx6, 0x200
+ax_sprite_terminator
+sUnownDGfx7:
+.incbin "baserom.gba", 0xDA5E88, 0x200
+sUnownDSprites7:
+ax_sprite sUnownDGfx7, 0x200
+ax_sprite_terminator
+sUnownDGfx8:
+.incbin "baserom.gba", 0xDA6098, 0x200
+sUnownDSprites8:
+ax_sprite sUnownDGfx8, 0x200
+ax_sprite_terminator
+sUnownDGfx9:
+.incbin "baserom.gba", 0xDA62A8, 0x200
+sUnownDSprites9:
+ax_sprite sUnownDGfx9, 0x200
+ax_sprite_terminator
+sUnownDGfx10:
+.incbin "baserom.gba", 0xDA64B8, 0x200
+sUnownDSprites10:
+ax_sprite sUnownDGfx10, 0x200
+ax_sprite_terminator
+sUnownDGfx11:
+.incbin "baserom.gba", 0xDA66C8, 0x200
+sUnownDSprites11:
+ax_sprite sUnownDGfx11, 0x200
+ax_sprite_terminator
+sUnownDGfx12:
+.incbin "baserom.gba", 0xDA68D8, 0x200
+sUnownDSprites12:
+ax_sprite sUnownDGfx12, 0x200
+ax_sprite_terminator
+sUnownDGfx13:
+.incbin "baserom.gba", 0xDA6AE8, 0x200
+sUnownDSprites13:
+ax_sprite sUnownDGfx13, 0x200
+ax_sprite_terminator
+sUnownDGfx14:
+.incbin "baserom.gba", 0xDA6CF8, 0x200
+sUnownDSprites14:
+ax_sprite sUnownDGfx14, 0x200
+ax_sprite_terminator
+sUnownDGfx15:
+.incbin "baserom.gba", 0xDA6F08, 0x200
+sUnownDSprites15:
+ax_sprite sUnownDGfx15, 0x200
+ax_sprite_terminator
+sUnownDGfx16:
+.incbin "baserom.gba", 0xDA7118, 0x200
+sUnownDSprites16:
+ax_sprite sUnownDGfx16, 0x200
+ax_sprite_terminator
+sUnownDGfx17:
+.incbin "baserom.gba", 0xDA7328, 0x200
+sUnownDSprites17:
+ax_sprite sUnownDGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownD:
+.4byte sUnownDPose1
+.4byte sUnownDPose2
+.4byte sUnownDPose3
+.4byte sUnownDPose4
+.4byte sUnownDPose5
+.4byte sUnownDPose6
+.4byte sUnownDPose7
+.4byte sUnownDPose8
+.4byte sUnownDPose9
+.4byte sUnownDPose10
+.4byte sUnownDPose11
+.4byte sUnownDPose12
+.4byte sUnownDPose13
+.4byte sUnownDPose14
+.4byte sUnownDPose15
+.4byte sUnownDPose16
+.4byte sUnownDPose17
+.4byte sUnownDPose18
+.4byte sUnownDPose19
+.4byte sUnownDPose20
+.4byte sUnownDPose21
+.4byte sUnownDPose22
+.4byte sUnownDPose23
+.4byte sUnownDPose24
+.4byte sUnownDPose25
+.4byte sUnownDPose26
+.4byte sUnownDPose27
+.4byte sUnownDPose28
+.4byte sUnownDPose29
+.4byte sUnownDPose30
+.4byte sUnownDPose31
+.4byte sUnownDPose32
+.4byte sUnownDPose33
+.4byte sUnownDPose34
+.4byte sUnownDPose35
+.4byte sUnownDPose36
+.4byte sUnownDPose37
+.4byte sUnownDPose38
+.4byte sUnownDPose39
+.4byte sUnownDPose40
+.4byte sUnownDPose41
+.4byte sUnownDPose42
+.4byte sUnownDPose43
+.4byte sUnownDPose44
+.4byte sUnownDPose45
+.4byte sUnownDPose46
+.4byte sUnownDPose47
+.4byte sUnownDPose48
+.4byte sUnownDPose49
+.4byte sUnownDPose50
+.4byte sUnownDPose51
+.4byte sUnownDPose52
+.4byte sUnownDPose53
+.4byte sUnownDPose54
+.4byte sUnownDPose55
+.4byte sUnownDPose56
+.4byte sUnownDPose57
+.4byte sUnownDPose58
+.4byte sUnownDPose59
+.4byte sUnownDPose60
+.4byte sUnownDPose61
+.4byte sUnownDPose62
+.4byte sUnownDPose63
+.4byte sUnownDPose64
+.4byte sUnownDPose65
+.4byte sUnownDPose66
+.4byte sUnownDPose67
+.4byte sUnownDPose68
+.4byte sUnownDPose69
+.4byte sUnownDPose70
+.4byte sUnownDPose71
+.4byte sUnownDPose72
+.4byte sUnownDPose73
+.4byte sUnownDPose74
+.4byte sUnownDPose75
+.4byte sUnownDPose76
+.4byte sUnownDPose77
+.4byte sUnownDPose78
+.4byte sUnownDPose79
+.4byte sUnownDPose80
+.4byte sUnownDPose81
+.4byte sUnownDPose82
+.4byte sUnownDPose83
+.4byte sUnownDPose84
+.4byte sUnownDPose85
+.4byte sUnownDPose86
+.4byte sUnownDPose87
+.4byte sUnownDPose88
+.4byte sUnownDPose89
+.4byte sUnownDPose90
+.4byte sUnownDPose91
+.4byte sUnownDPose92
+.4byte sUnownDPose93
+.4byte sUnownDPose94
+.4byte sUnownDPose95
+.4byte sUnownDPose96
+.4byte sUnownDPose97
+sAxPositionsUnownD:
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	   0,  -12
+.2byte    0,  -13, 	  -3,  -19, 	   1,   -5, 	  -1,  -13
+.2byte    0,  -12, 	  -3,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -18, 	  -1,   -6, 	  -2,  -12
+.2byte   -1,  -14, 	   0,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -13, 	   0,  -19, 	  -3,   -5, 	  -1,  -12
+.2byte   -4,  -13, 	   0,  -19, 	  -3,   -5, 	  -1,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+.2byte   -2,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte    0,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte    0,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -1,  -13, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -2,  -14, 	  -1,  -19, 	  -1,   -5, 	  -2,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -1,  -12
+.2byte   -4,  -12, 	  -2,  -19, 	  -2,   -5, 	  -2,  -12
+sUnownDAnimTable1:
+.4byte sUnownDAnims_1_1
+.4byte sUnownDAnims_1_2
+.4byte sUnownDAnims_1_3
+.4byte sUnownDAnims_1_4
+.4byte sUnownDAnims_1_5
+.4byte sUnownDAnims_1_6
+.4byte sUnownDAnims_1_7
+.4byte sUnownDAnims_1_8
+sUnownDAnimTable2:
+.4byte sUnownDAnims_2_1
+.4byte sUnownDAnims_2_2
+.4byte sUnownDAnims_2_3
+.4byte sUnownDAnims_2_4
+.4byte sUnownDAnims_2_5
+.4byte sUnownDAnims_2_6
+.4byte sUnownDAnims_2_7
+.4byte sUnownDAnims_2_8
+sUnownDAnimTable3:
+.4byte sUnownDAnims_3_1
+.4byte sUnownDAnims_3_2
+.4byte sUnownDAnims_3_3
+.4byte sUnownDAnims_3_4
+.4byte sUnownDAnims_3_5
+.4byte sUnownDAnims_3_6
+.4byte sUnownDAnims_3_7
+.4byte sUnownDAnims_3_8
+sUnownDAnimTable4:
+.4byte sUnownDAnims_4_1
+.4byte sUnownDAnims_4_2
+.4byte sUnownDAnims_4_3
+.4byte sUnownDAnims_4_4
+.4byte sUnownDAnims_4_5
+.4byte sUnownDAnims_4_6
+.4byte sUnownDAnims_4_7
+.4byte sUnownDAnims_4_8
+sUnownDAnimTable5:
+.4byte sUnownDAnims_5_1
+.4byte sUnownDAnims_5_2
+.4byte sUnownDAnims_5_3
+.4byte sUnownDAnims_5_4
+.4byte sUnownDAnims_5_5
+.4byte sUnownDAnims_5_6
+.4byte sUnownDAnims_5_7
+.4byte sUnownDAnims_5_8
+sUnownDAnimTable6:
+.4byte sUnownDAnims_6_1
+.4byte sUnownDAnims_6_1
+.4byte sUnownDAnims_6_1
+.4byte sUnownDAnims_6_1
+.4byte sUnownDAnims_6_1
+.4byte sUnownDAnims_6_1
+.4byte sUnownDAnims_6_1
+.4byte sUnownDAnims_6_1
+sUnownDAnimTable7:
+.4byte sUnownDAnims_7_1
+.4byte sUnownDAnims_7_2
+.4byte sUnownDAnims_7_3
+.4byte sUnownDAnims_7_4
+.4byte sUnownDAnims_7_5
+.4byte sUnownDAnims_7_6
+.4byte sUnownDAnims_7_7
+.4byte sUnownDAnims_7_8
+sUnownDAnimTable8:
+.4byte sUnownDAnims_8_1
+.4byte sUnownDAnims_8_2
+.4byte sUnownDAnims_8_3
+.4byte sUnownDAnims_8_4
+.4byte sUnownDAnims_8_5
+.4byte sUnownDAnims_8_6
+.4byte sUnownDAnims_8_7
+.4byte sUnownDAnims_8_8
+sUnownDAnimTable9:
+.4byte sUnownDAnims_9_1
+.4byte sUnownDAnims_9_2
+.4byte sUnownDAnims_9_3
+.4byte sUnownDAnims_9_4
+.4byte sUnownDAnims_9_5
+.4byte sUnownDAnims_9_6
+.4byte sUnownDAnims_9_7
+.4byte sUnownDAnims_9_8
+sUnownDAnimTable10:
+.4byte sUnownDAnims_10_1
+.4byte sUnownDAnims_10_2
+.4byte sUnownDAnims_10_3
+.4byte sUnownDAnims_10_4
+.4byte sUnownDAnims_10_5
+.4byte sUnownDAnims_10_6
+.4byte sUnownDAnims_10_7
+.4byte sUnownDAnims_10_8
+sUnownDAnimTable11:
+.4byte sUnownDAnims_11_1
+.4byte sUnownDAnims_11_2
+.4byte sUnownDAnims_11_3
+.4byte sUnownDAnims_11_4
+.4byte sUnownDAnims_11_5
+.4byte sUnownDAnims_11_6
+.4byte sUnownDAnims_11_7
+.4byte sUnownDAnims_11_8
+sUnownDAnimTable12:
+.4byte sUnownDAnims_12_1
+.4byte sUnownDAnims_12_2
+.4byte sUnownDAnims_12_3
+.4byte sUnownDAnims_12_4
+.4byte sUnownDAnims_12_5
+.4byte sUnownDAnims_12_6
+.4byte sUnownDAnims_12_7
+.4byte sUnownDAnims_12_8
+sUnownDAnimTable13:
+.4byte sUnownDAnims_13_1
+.4byte sUnownDAnims_13_2
+.4byte sUnownDAnims_13_3
+.4byte sUnownDAnims_13_4
+.4byte sUnownDAnims_13_5
+.4byte sUnownDAnims_13_6
+.4byte sUnownDAnims_13_7
+.4byte sUnownDAnims_13_8
+sAxAnimationsUnownD:
+.4byte sUnownDAnimTable1
+.4byte sUnownDAnimTable2
+.4byte sUnownDAnimTable3
+.4byte sUnownDAnimTable4
+.4byte sUnownDAnimTable5
+.4byte sUnownDAnimTable6
+.4byte sUnownDAnimTable7
+.4byte sUnownDAnimTable8
+.4byte sUnownDAnimTable9
+.4byte sUnownDAnimTable10
+.4byte sUnownDAnimTable11
+.4byte sUnownDAnimTable12
+.4byte sUnownDAnimTable13
+sAxSpritesUnownD:
+.4byte sUnownDSprites1
+.4byte sUnownDSprites2
+.4byte sUnownDSprites3
+.4byte sUnownDSprites4
+.4byte sUnownDSprites5
+.4byte sUnownDSprites6
+.4byte sUnownDSprites7
+.4byte sUnownDSprites8
+.4byte sUnownDSprites9
+.4byte sUnownDSprites10
+.4byte sUnownDSprites11
+.4byte sUnownDSprites12
+.4byte sUnownDSprites13
+.4byte sUnownDSprites14
+.4byte sUnownDSprites15
+.4byte sUnownDSprites16
+.4byte sUnownDSprites17
+sAxMainUnownD:
+ax_main sAxPosesUnownD, sAxAnimationsUnownD, 13, sAxSpritesUnownD, sAxPositionsUnownD

--- a/data/ax/unowne.inc
+++ b/data/ax/unowne.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownE
+gAxUnownE:
+ax_siro sAxMainUnownE
+sUnownEPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose2:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose3:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose4:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose7:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose8:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose9:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose10:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose11:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose12:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose15:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose16:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose17:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose18:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose19:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose20:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose23:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose24:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose26:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose27:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose28:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose31:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose32:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose33:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose34:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose35:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose36:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose39:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose40:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEPose42:
+ax_pose 9, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose43:
+ax_pose 10, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownEPose44:
+ax_pose 11, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownEPose45:
+ax_pose 12, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownEPose46:
+ax_pose 13, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose48:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEPose50:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose51:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose52:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose53:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose56:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose57:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose58:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose59:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose60:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose61:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose64:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose65:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose66:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose67:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose68:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose69:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose72:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose73:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose74:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose75:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose76:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose77:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose80:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose81:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose82:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose83:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose84:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose85:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose88:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose89:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose90:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose91:
+ax_pose 1, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose92:
+ax_pose 2, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose93:
+ax_pose 3, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sUnownEPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose96:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownEPose97:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownEAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownEAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownEAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownEAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownEAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownEAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownEAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownEAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownEAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownEAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownEAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownEAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownEAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownEAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownEAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownEAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownEAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownEAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownEAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownEAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownEAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownEAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownEAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownEAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownEAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownEAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownEAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownEAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownEAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownEAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownEAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownEAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownEAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownEAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownEAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEGfx1:
+.incbin "baserom.gba", 0xDAB438, 0x200
+sUnownESprites1:
+ax_sprite sUnownEGfx1, 0x200
+ax_sprite_terminator
+sUnownEGfx2:
+.incbin "baserom.gba", 0xDAB648, 0x200
+sUnownESprites2:
+ax_sprite sUnownEGfx2, 0x200
+ax_sprite_terminator
+sUnownEGfx3:
+.incbin "baserom.gba", 0xDAB858, 0x200
+sUnownESprites3:
+ax_sprite sUnownEGfx3, 0x200
+ax_sprite_terminator
+sUnownEGfx4:
+.incbin "baserom.gba", 0xDABA68, 0x200
+sUnownESprites4:
+ax_sprite sUnownEGfx4, 0x200
+ax_sprite_terminator
+sUnownEGfx5:
+.incbin "baserom.gba", 0xDABC78, 0x200
+sUnownESprites5:
+ax_sprite sUnownEGfx5, 0x200
+ax_sprite_terminator
+sUnownEGfx6:
+.incbin "baserom.gba", 0xDABE88, 0x200
+sUnownESprites6:
+ax_sprite sUnownEGfx6, 0x200
+ax_sprite_terminator
+sUnownEGfx7:
+.incbin "baserom.gba", 0xDAC098, 0x200
+sUnownESprites7:
+ax_sprite sUnownEGfx7, 0x200
+ax_sprite_terminator
+sUnownEGfx8:
+.incbin "baserom.gba", 0xDAC2A8, 0x200
+sUnownESprites8:
+ax_sprite sUnownEGfx8, 0x200
+ax_sprite_terminator
+sUnownEGfx9:
+.incbin "baserom.gba", 0xDAC4B8, 0x200
+sUnownESprites9:
+ax_sprite sUnownEGfx9, 0x200
+ax_sprite_terminator
+sUnownEGfx10:
+.incbin "baserom.gba", 0xDAC6C8, 0x200
+sUnownESprites10:
+ax_sprite sUnownEGfx10, 0x200
+ax_sprite_terminator
+sUnownEGfx11:
+.incbin "baserom.gba", 0xDAC8D8, 0x200
+sUnownESprites11:
+ax_sprite sUnownEGfx11, 0x200
+ax_sprite_terminator
+sUnownEGfx12:
+.incbin "baserom.gba", 0xDACAE8, 0x200
+sUnownESprites12:
+ax_sprite sUnownEGfx12, 0x200
+ax_sprite_terminator
+sUnownEGfx13:
+.incbin "baserom.gba", 0xDACCF8, 0x200
+sUnownESprites13:
+ax_sprite sUnownEGfx13, 0x200
+ax_sprite_terminator
+sUnownEGfx14:
+.incbin "baserom.gba", 0xDACF08, 0x200
+sUnownESprites14:
+ax_sprite sUnownEGfx14, 0x200
+ax_sprite_terminator
+sUnownEGfx15:
+.incbin "baserom.gba", 0xDAD118, 0x200
+sUnownESprites15:
+ax_sprite sUnownEGfx15, 0x200
+ax_sprite_terminator
+sUnownEGfx16:
+.incbin "baserom.gba", 0xDAD328, 0x200
+sUnownESprites16:
+ax_sprite sUnownEGfx16, 0x200
+ax_sprite_terminator
+sUnownEGfx17:
+.incbin "baserom.gba", 0xDAD538, 0x200
+sUnownESprites17:
+ax_sprite sUnownEGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownE:
+.4byte sUnownEPose1
+.4byte sUnownEPose2
+.4byte sUnownEPose3
+.4byte sUnownEPose4
+.4byte sUnownEPose5
+.4byte sUnownEPose6
+.4byte sUnownEPose7
+.4byte sUnownEPose8
+.4byte sUnownEPose9
+.4byte sUnownEPose10
+.4byte sUnownEPose11
+.4byte sUnownEPose12
+.4byte sUnownEPose13
+.4byte sUnownEPose14
+.4byte sUnownEPose15
+.4byte sUnownEPose16
+.4byte sUnownEPose17
+.4byte sUnownEPose18
+.4byte sUnownEPose19
+.4byte sUnownEPose20
+.4byte sUnownEPose21
+.4byte sUnownEPose22
+.4byte sUnownEPose23
+.4byte sUnownEPose24
+.4byte sUnownEPose25
+.4byte sUnownEPose26
+.4byte sUnownEPose27
+.4byte sUnownEPose28
+.4byte sUnownEPose29
+.4byte sUnownEPose30
+.4byte sUnownEPose31
+.4byte sUnownEPose32
+.4byte sUnownEPose33
+.4byte sUnownEPose34
+.4byte sUnownEPose35
+.4byte sUnownEPose36
+.4byte sUnownEPose37
+.4byte sUnownEPose38
+.4byte sUnownEPose39
+.4byte sUnownEPose40
+.4byte sUnownEPose41
+.4byte sUnownEPose42
+.4byte sUnownEPose43
+.4byte sUnownEPose44
+.4byte sUnownEPose45
+.4byte sUnownEPose46
+.4byte sUnownEPose47
+.4byte sUnownEPose48
+.4byte sUnownEPose49
+.4byte sUnownEPose50
+.4byte sUnownEPose51
+.4byte sUnownEPose52
+.4byte sUnownEPose53
+.4byte sUnownEPose54
+.4byte sUnownEPose55
+.4byte sUnownEPose56
+.4byte sUnownEPose57
+.4byte sUnownEPose58
+.4byte sUnownEPose59
+.4byte sUnownEPose60
+.4byte sUnownEPose61
+.4byte sUnownEPose62
+.4byte sUnownEPose63
+.4byte sUnownEPose64
+.4byte sUnownEPose65
+.4byte sUnownEPose66
+.4byte sUnownEPose67
+.4byte sUnownEPose68
+.4byte sUnownEPose69
+.4byte sUnownEPose70
+.4byte sUnownEPose71
+.4byte sUnownEPose72
+.4byte sUnownEPose73
+.4byte sUnownEPose74
+.4byte sUnownEPose75
+.4byte sUnownEPose76
+.4byte sUnownEPose77
+.4byte sUnownEPose78
+.4byte sUnownEPose79
+.4byte sUnownEPose80
+.4byte sUnownEPose81
+.4byte sUnownEPose82
+.4byte sUnownEPose83
+.4byte sUnownEPose84
+.4byte sUnownEPose85
+.4byte sUnownEPose86
+.4byte sUnownEPose87
+.4byte sUnownEPose88
+.4byte sUnownEPose89
+.4byte sUnownEPose90
+.4byte sUnownEPose91
+.4byte sUnownEPose92
+.4byte sUnownEPose93
+.4byte sUnownEPose94
+.4byte sUnownEPose95
+.4byte sUnownEPose96
+.4byte sUnownEPose97
+sAxPositionsUnownE:
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,  -12, 	   3,  -12, 	  -2,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -13, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -13, 	  -4,  -10, 	   1,  -11, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -14, 	   4,  -11, 	  -6,  -11, 	  -1,  -11
+.2byte   -2,  -13, 	   3,  -13, 	  -5,  -11, 	   0,  -11
+.2byte   -4,  -13, 	  -2,  -14, 	   1,  -10, 	  -1,  -11
+.2byte   -3,  -13, 	  -5,  -13, 	   2,  -11, 	   0,  -12
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -12, 	   4,  -12, 	  -1,  -11
+.2byte    1,  -12, 	  -5,  -11, 	   3,  -13, 	  -1,  -11
+.2byte    2,  -12, 	  -3,  -10, 	   1,  -13, 	  -1,  -12
+.2byte    0,  -14, 	   3,  -11, 	  -5,  -13, 	  -1,  -12
+.2byte   -1,  -15, 	   4,  -12, 	  -6,  -12, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -13, 	  -5,  -11, 	  -1,  -11
+.2byte   -4,  -12, 	  -3,  -13, 	   2,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -5,  -13, 	   3,  -11, 	  -1,  -11
+sUnownEAnimTable1:
+.4byte sUnownEAnims_1_1
+.4byte sUnownEAnims_1_2
+.4byte sUnownEAnims_1_3
+.4byte sUnownEAnims_1_4
+.4byte sUnownEAnims_1_5
+.4byte sUnownEAnims_1_6
+.4byte sUnownEAnims_1_7
+.4byte sUnownEAnims_1_8
+sUnownEAnimTable2:
+.4byte sUnownEAnims_2_1
+.4byte sUnownEAnims_2_2
+.4byte sUnownEAnims_2_3
+.4byte sUnownEAnims_2_4
+.4byte sUnownEAnims_2_5
+.4byte sUnownEAnims_2_6
+.4byte sUnownEAnims_2_7
+.4byte sUnownEAnims_2_8
+sUnownEAnimTable3:
+.4byte sUnownEAnims_3_1
+.4byte sUnownEAnims_3_2
+.4byte sUnownEAnims_3_3
+.4byte sUnownEAnims_3_4
+.4byte sUnownEAnims_3_5
+.4byte sUnownEAnims_3_6
+.4byte sUnownEAnims_3_7
+.4byte sUnownEAnims_3_8
+sUnownEAnimTable4:
+.4byte sUnownEAnims_4_1
+.4byte sUnownEAnims_4_2
+.4byte sUnownEAnims_4_3
+.4byte sUnownEAnims_4_4
+.4byte sUnownEAnims_4_5
+.4byte sUnownEAnims_4_6
+.4byte sUnownEAnims_4_7
+.4byte sUnownEAnims_4_8
+sUnownEAnimTable5:
+.4byte sUnownEAnims_5_1
+.4byte sUnownEAnims_5_2
+.4byte sUnownEAnims_5_3
+.4byte sUnownEAnims_5_4
+.4byte sUnownEAnims_5_5
+.4byte sUnownEAnims_5_6
+.4byte sUnownEAnims_5_7
+.4byte sUnownEAnims_5_8
+sUnownEAnimTable6:
+.4byte sUnownEAnims_6_1
+.4byte sUnownEAnims_6_1
+.4byte sUnownEAnims_6_1
+.4byte sUnownEAnims_6_1
+.4byte sUnownEAnims_6_1
+.4byte sUnownEAnims_6_1
+.4byte sUnownEAnims_6_1
+.4byte sUnownEAnims_6_1
+sUnownEAnimTable7:
+.4byte sUnownEAnims_7_1
+.4byte sUnownEAnims_7_2
+.4byte sUnownEAnims_7_3
+.4byte sUnownEAnims_7_4
+.4byte sUnownEAnims_7_5
+.4byte sUnownEAnims_7_6
+.4byte sUnownEAnims_7_7
+.4byte sUnownEAnims_7_8
+sUnownEAnimTable8:
+.4byte sUnownEAnims_8_1
+.4byte sUnownEAnims_8_2
+.4byte sUnownEAnims_8_3
+.4byte sUnownEAnims_8_4
+.4byte sUnownEAnims_8_5
+.4byte sUnownEAnims_8_6
+.4byte sUnownEAnims_8_7
+.4byte sUnownEAnims_8_8
+sUnownEAnimTable9:
+.4byte sUnownEAnims_9_1
+.4byte sUnownEAnims_9_2
+.4byte sUnownEAnims_9_3
+.4byte sUnownEAnims_9_4
+.4byte sUnownEAnims_9_5
+.4byte sUnownEAnims_9_6
+.4byte sUnownEAnims_9_7
+.4byte sUnownEAnims_9_8
+sUnownEAnimTable10:
+.4byte sUnownEAnims_10_1
+.4byte sUnownEAnims_10_2
+.4byte sUnownEAnims_10_3
+.4byte sUnownEAnims_10_4
+.4byte sUnownEAnims_10_5
+.4byte sUnownEAnims_10_6
+.4byte sUnownEAnims_10_7
+.4byte sUnownEAnims_10_8
+sUnownEAnimTable11:
+.4byte sUnownEAnims_11_1
+.4byte sUnownEAnims_11_2
+.4byte sUnownEAnims_11_3
+.4byte sUnownEAnims_11_4
+.4byte sUnownEAnims_11_5
+.4byte sUnownEAnims_11_6
+.4byte sUnownEAnims_11_7
+.4byte sUnownEAnims_11_8
+sUnownEAnimTable12:
+.4byte sUnownEAnims_12_1
+.4byte sUnownEAnims_12_2
+.4byte sUnownEAnims_12_3
+.4byte sUnownEAnims_12_4
+.4byte sUnownEAnims_12_5
+.4byte sUnownEAnims_12_6
+.4byte sUnownEAnims_12_7
+.4byte sUnownEAnims_12_8
+sUnownEAnimTable13:
+.4byte sUnownEAnims_13_1
+.4byte sUnownEAnims_13_2
+.4byte sUnownEAnims_13_3
+.4byte sUnownEAnims_13_4
+.4byte sUnownEAnims_13_5
+.4byte sUnownEAnims_13_6
+.4byte sUnownEAnims_13_7
+.4byte sUnownEAnims_13_8
+sAxAnimationsUnownE:
+.4byte sUnownEAnimTable1
+.4byte sUnownEAnimTable2
+.4byte sUnownEAnimTable3
+.4byte sUnownEAnimTable4
+.4byte sUnownEAnimTable5
+.4byte sUnownEAnimTable6
+.4byte sUnownEAnimTable7
+.4byte sUnownEAnimTable8
+.4byte sUnownEAnimTable9
+.4byte sUnownEAnimTable10
+.4byte sUnownEAnimTable11
+.4byte sUnownEAnimTable12
+.4byte sUnownEAnimTable13
+sAxSpritesUnownE:
+.4byte sUnownESprites1
+.4byte sUnownESprites2
+.4byte sUnownESprites3
+.4byte sUnownESprites4
+.4byte sUnownESprites5
+.4byte sUnownESprites6
+.4byte sUnownESprites7
+.4byte sUnownESprites8
+.4byte sUnownESprites9
+.4byte sUnownESprites10
+.4byte sUnownESprites11
+.4byte sUnownESprites12
+.4byte sUnownESprites13
+.4byte sUnownESprites14
+.4byte sUnownESprites15
+.4byte sUnownESprites16
+.4byte sUnownESprites17
+sAxMainUnownE:
+ax_main sAxPosesUnownE, sAxAnimationsUnownE, 13, sAxSpritesUnownE, sAxPositionsUnownE

--- a/data/ax/unownemark.inc
+++ b/data/ax/unownemark.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownEmark
+gAxUnownEmark:
+ax_siro sAxMainUnownEmark
+sUnownEmarkPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose2:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose3:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose4:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose6:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose7:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose8:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose10:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose11:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose12:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose14:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose15:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose16:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose18:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose19:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose20:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose22:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose23:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose24:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose26:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose27:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose28:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose30:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose31:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose32:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose34:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose35:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose36:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose38:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose39:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose40:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose42:
+ax_pose 6, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose43:
+ax_pose 7, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose44:
+ax_pose 8, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose45:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose46:
+ax_pose 10, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose47:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose48:
+ax_pose 8, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose49:
+ax_pose 7, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose51:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose52:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose53:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose55:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose56:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose57:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose59:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose60:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose61:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose63:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose64:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose65:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose67:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose68:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose69:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose71:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose72:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose73:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose75:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose76:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose77:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose79:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose80:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose81:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose83:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose84:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose85:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose87:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose88:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose89:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose91:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose92:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose93:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose95:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose96:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownEmarkPose97:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownEmarkAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownEmarkAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownEmarkAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownEmarkAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownEmarkAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownEmarkAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownEmarkAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownEmarkAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownEmarkAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownEmarkAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownEmarkAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownEmarkAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownEmarkAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownEmarkAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownEmarkAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownEmarkAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownEmarkAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownEmarkAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownEmarkAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownEmarkAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownEmarkAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownEmarkAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownEmarkAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownEmarkAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownEmarkAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownEmarkAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownEmarkAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownEmarkAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownEmarkAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownEmarkAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownEmarkAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownEmarkAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownEmarkGfx1:
+.incbin "baserom.gba", 0x161A2AC, 0x200
+sUnownEmarkSprites1:
+ax_sprite sUnownEmarkGfx1, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx2:
+.incbin "baserom.gba", 0x161A4BC, 0x200
+sUnownEmarkSprites2:
+ax_sprite sUnownEmarkGfx2, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx3:
+.incbin "baserom.gba", 0x161A6CC, 0x200
+sUnownEmarkSprites3:
+ax_sprite sUnownEmarkGfx3, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx4:
+.incbin "baserom.gba", 0x161A8DC, 0x200
+sUnownEmarkSprites4:
+ax_sprite sUnownEmarkGfx4, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx5:
+.incbin "baserom.gba", 0x161AAEC, 0x200
+sUnownEmarkSprites5:
+ax_sprite sUnownEmarkGfx5, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx6:
+.incbin "baserom.gba", 0x161ACFC, 0x200
+sUnownEmarkSprites6:
+ax_sprite sUnownEmarkGfx6, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx7:
+.incbin "baserom.gba", 0x161AF0C, 0x200
+sUnownEmarkSprites7:
+ax_sprite sUnownEmarkGfx7, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx8:
+.incbin "baserom.gba", 0x161B11C, 0x200
+sUnownEmarkSprites8:
+ax_sprite sUnownEmarkGfx8, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx9:
+.incbin "baserom.gba", 0x161B32C, 0x200
+sUnownEmarkSprites9:
+ax_sprite sUnownEmarkGfx9, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx10:
+.incbin "baserom.gba", 0x161B53C, 0x200
+sUnownEmarkSprites10:
+ax_sprite sUnownEmarkGfx10, 0x200
+ax_sprite_terminator
+sUnownEmarkGfx11:
+.incbin "baserom.gba", 0x161B74C, 0x200
+sUnownEmarkSprites11:
+ax_sprite sUnownEmarkGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownEmark:
+.4byte sUnownEmarkPose1
+.4byte sUnownEmarkPose2
+.4byte sUnownEmarkPose3
+.4byte sUnownEmarkPose4
+.4byte sUnownEmarkPose5
+.4byte sUnownEmarkPose6
+.4byte sUnownEmarkPose7
+.4byte sUnownEmarkPose8
+.4byte sUnownEmarkPose9
+.4byte sUnownEmarkPose10
+.4byte sUnownEmarkPose11
+.4byte sUnownEmarkPose12
+.4byte sUnownEmarkPose13
+.4byte sUnownEmarkPose14
+.4byte sUnownEmarkPose15
+.4byte sUnownEmarkPose16
+.4byte sUnownEmarkPose17
+.4byte sUnownEmarkPose18
+.4byte sUnownEmarkPose19
+.4byte sUnownEmarkPose20
+.4byte sUnownEmarkPose21
+.4byte sUnownEmarkPose22
+.4byte sUnownEmarkPose23
+.4byte sUnownEmarkPose24
+.4byte sUnownEmarkPose25
+.4byte sUnownEmarkPose26
+.4byte sUnownEmarkPose27
+.4byte sUnownEmarkPose28
+.4byte sUnownEmarkPose29
+.4byte sUnownEmarkPose30
+.4byte sUnownEmarkPose31
+.4byte sUnownEmarkPose32
+.4byte sUnownEmarkPose33
+.4byte sUnownEmarkPose34
+.4byte sUnownEmarkPose35
+.4byte sUnownEmarkPose36
+.4byte sUnownEmarkPose37
+.4byte sUnownEmarkPose38
+.4byte sUnownEmarkPose39
+.4byte sUnownEmarkPose40
+.4byte sUnownEmarkPose41
+.4byte sUnownEmarkPose42
+.4byte sUnownEmarkPose43
+.4byte sUnownEmarkPose44
+.4byte sUnownEmarkPose45
+.4byte sUnownEmarkPose46
+.4byte sUnownEmarkPose47
+.4byte sUnownEmarkPose48
+.4byte sUnownEmarkPose49
+.4byte sUnownEmarkPose50
+.4byte sUnownEmarkPose51
+.4byte sUnownEmarkPose52
+.4byte sUnownEmarkPose53
+.4byte sUnownEmarkPose54
+.4byte sUnownEmarkPose55
+.4byte sUnownEmarkPose56
+.4byte sUnownEmarkPose57
+.4byte sUnownEmarkPose58
+.4byte sUnownEmarkPose59
+.4byte sUnownEmarkPose60
+.4byte sUnownEmarkPose61
+.4byte sUnownEmarkPose62
+.4byte sUnownEmarkPose63
+.4byte sUnownEmarkPose64
+.4byte sUnownEmarkPose65
+.4byte sUnownEmarkPose66
+.4byte sUnownEmarkPose67
+.4byte sUnownEmarkPose68
+.4byte sUnownEmarkPose69
+.4byte sUnownEmarkPose70
+.4byte sUnownEmarkPose71
+.4byte sUnownEmarkPose72
+.4byte sUnownEmarkPose73
+.4byte sUnownEmarkPose74
+.4byte sUnownEmarkPose75
+.4byte sUnownEmarkPose76
+.4byte sUnownEmarkPose77
+.4byte sUnownEmarkPose78
+.4byte sUnownEmarkPose79
+.4byte sUnownEmarkPose80
+.4byte sUnownEmarkPose81
+.4byte sUnownEmarkPose82
+.4byte sUnownEmarkPose83
+.4byte sUnownEmarkPose84
+.4byte sUnownEmarkPose85
+.4byte sUnownEmarkPose86
+.4byte sUnownEmarkPose87
+.4byte sUnownEmarkPose88
+.4byte sUnownEmarkPose89
+.4byte sUnownEmarkPose90
+.4byte sUnownEmarkPose91
+.4byte sUnownEmarkPose92
+.4byte sUnownEmarkPose93
+.4byte sUnownEmarkPose94
+.4byte sUnownEmarkPose95
+.4byte sUnownEmarkPose96
+.4byte sUnownEmarkPose97
+sAxPositionsUnownEmark:
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,   -8
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -9, 	   2,   -9, 	  -4,   -7, 	  -2,  -11
+.2byte    1,   -9, 	   0,   -9, 	  -2,   -7, 	  -2,  -11
+.2byte    1,  -10, 	  -4,   -8, 	   1,   -8, 	  -2,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   2,   -8, 	  -3,   -8, 	   0,  -10
+.2byte   -3,   -9, 	  -2,   -9, 	   0,   -7, 	   0,  -11
+.2byte   -3,   -9, 	  -4,   -9, 	   2,   -7, 	   0,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    1,   -8, 	   2,   -9, 	  -4,   -7, 	  -1,  -10
+.2byte    1,   -8, 	  -1,   -9, 	  -3,   -7, 	  -1,  -11
+.2byte    1,  -10, 	  -3,   -8, 	   1,   -7, 	  -1,  -10
+.2byte   -1,   -9, 	   2,   -8, 	  -4,   -8, 	  -1,  -10
+.2byte   -3,  -10, 	   1,   -8, 	  -3,   -7, 	  -1,  -10
+.2byte   -3,   -8, 	  -1,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -3,   -8, 	  -4,   -9, 	   2,   -7, 	  -1,  -10
+sUnownEmarkAnimTable1:
+.4byte sUnownEmarkAnims_1_1
+.4byte sUnownEmarkAnims_1_2
+.4byte sUnownEmarkAnims_1_3
+.4byte sUnownEmarkAnims_1_4
+.4byte sUnownEmarkAnims_1_5
+.4byte sUnownEmarkAnims_1_6
+.4byte sUnownEmarkAnims_1_7
+.4byte sUnownEmarkAnims_1_8
+sUnownEmarkAnimTable2:
+.4byte sUnownEmarkAnims_2_1
+.4byte sUnownEmarkAnims_2_2
+.4byte sUnownEmarkAnims_2_3
+.4byte sUnownEmarkAnims_2_4
+.4byte sUnownEmarkAnims_2_5
+.4byte sUnownEmarkAnims_2_6
+.4byte sUnownEmarkAnims_2_7
+.4byte sUnownEmarkAnims_2_8
+sUnownEmarkAnimTable3:
+.4byte sUnownEmarkAnims_3_1
+.4byte sUnownEmarkAnims_3_2
+.4byte sUnownEmarkAnims_3_3
+.4byte sUnownEmarkAnims_3_4
+.4byte sUnownEmarkAnims_3_5
+.4byte sUnownEmarkAnims_3_6
+.4byte sUnownEmarkAnims_3_7
+.4byte sUnownEmarkAnims_3_8
+sUnownEmarkAnimTable4:
+.4byte sUnownEmarkAnims_4_1
+.4byte sUnownEmarkAnims_4_2
+.4byte sUnownEmarkAnims_4_3
+.4byte sUnownEmarkAnims_4_4
+.4byte sUnownEmarkAnims_4_5
+.4byte sUnownEmarkAnims_4_6
+.4byte sUnownEmarkAnims_4_7
+.4byte sUnownEmarkAnims_4_8
+sUnownEmarkAnimTable5:
+.4byte sUnownEmarkAnims_5_1
+.4byte sUnownEmarkAnims_5_2
+.4byte sUnownEmarkAnims_5_3
+.4byte sUnownEmarkAnims_5_4
+.4byte sUnownEmarkAnims_5_5
+.4byte sUnownEmarkAnims_5_6
+.4byte sUnownEmarkAnims_5_7
+.4byte sUnownEmarkAnims_5_8
+sUnownEmarkAnimTable6:
+.4byte sUnownEmarkAnims_6_1
+.4byte sUnownEmarkAnims_6_1
+.4byte sUnownEmarkAnims_6_1
+.4byte sUnownEmarkAnims_6_1
+.4byte sUnownEmarkAnims_6_1
+.4byte sUnownEmarkAnims_6_1
+.4byte sUnownEmarkAnims_6_1
+.4byte sUnownEmarkAnims_6_1
+sUnownEmarkAnimTable7:
+.4byte sUnownEmarkAnims_7_1
+.4byte sUnownEmarkAnims_7_2
+.4byte sUnownEmarkAnims_7_3
+.4byte sUnownEmarkAnims_7_4
+.4byte sUnownEmarkAnims_7_5
+.4byte sUnownEmarkAnims_7_6
+.4byte sUnownEmarkAnims_7_7
+.4byte sUnownEmarkAnims_7_8
+sUnownEmarkAnimTable8:
+.4byte sUnownEmarkAnims_8_1
+.4byte sUnownEmarkAnims_8_2
+.4byte sUnownEmarkAnims_8_3
+.4byte sUnownEmarkAnims_8_4
+.4byte sUnownEmarkAnims_8_5
+.4byte sUnownEmarkAnims_8_6
+.4byte sUnownEmarkAnims_8_7
+.4byte sUnownEmarkAnims_8_8
+sUnownEmarkAnimTable9:
+.4byte sUnownEmarkAnims_9_1
+.4byte sUnownEmarkAnims_9_2
+.4byte sUnownEmarkAnims_9_3
+.4byte sUnownEmarkAnims_9_4
+.4byte sUnownEmarkAnims_9_5
+.4byte sUnownEmarkAnims_9_6
+.4byte sUnownEmarkAnims_9_7
+.4byte sUnownEmarkAnims_9_8
+sUnownEmarkAnimTable10:
+.4byte sUnownEmarkAnims_10_1
+.4byte sUnownEmarkAnims_10_2
+.4byte sUnownEmarkAnims_10_3
+.4byte sUnownEmarkAnims_10_4
+.4byte sUnownEmarkAnims_10_5
+.4byte sUnownEmarkAnims_10_6
+.4byte sUnownEmarkAnims_10_7
+.4byte sUnownEmarkAnims_10_8
+sUnownEmarkAnimTable11:
+.4byte sUnownEmarkAnims_11_1
+.4byte sUnownEmarkAnims_11_2
+.4byte sUnownEmarkAnims_11_3
+.4byte sUnownEmarkAnims_11_4
+.4byte sUnownEmarkAnims_11_5
+.4byte sUnownEmarkAnims_11_6
+.4byte sUnownEmarkAnims_11_7
+.4byte sUnownEmarkAnims_11_8
+sUnownEmarkAnimTable12:
+.4byte sUnownEmarkAnims_12_1
+.4byte sUnownEmarkAnims_12_2
+.4byte sUnownEmarkAnims_12_3
+.4byte sUnownEmarkAnims_12_4
+.4byte sUnownEmarkAnims_12_5
+.4byte sUnownEmarkAnims_12_6
+.4byte sUnownEmarkAnims_12_7
+.4byte sUnownEmarkAnims_12_8
+sUnownEmarkAnimTable13:
+.4byte sUnownEmarkAnims_13_1
+.4byte sUnownEmarkAnims_13_2
+.4byte sUnownEmarkAnims_13_3
+.4byte sUnownEmarkAnims_13_4
+.4byte sUnownEmarkAnims_13_5
+.4byte sUnownEmarkAnims_13_6
+.4byte sUnownEmarkAnims_13_7
+.4byte sUnownEmarkAnims_13_8
+sAxAnimationsUnownEmark:
+.4byte sUnownEmarkAnimTable1
+.4byte sUnownEmarkAnimTable2
+.4byte sUnownEmarkAnimTable3
+.4byte sUnownEmarkAnimTable4
+.4byte sUnownEmarkAnimTable5
+.4byte sUnownEmarkAnimTable6
+.4byte sUnownEmarkAnimTable7
+.4byte sUnownEmarkAnimTable8
+.4byte sUnownEmarkAnimTable9
+.4byte sUnownEmarkAnimTable10
+.4byte sUnownEmarkAnimTable11
+.4byte sUnownEmarkAnimTable12
+.4byte sUnownEmarkAnimTable13
+sAxSpritesUnownEmark:
+.4byte sUnownEmarkSprites1
+.4byte sUnownEmarkSprites2
+.4byte sUnownEmarkSprites3
+.4byte sUnownEmarkSprites4
+.4byte sUnownEmarkSprites5
+.4byte sUnownEmarkSprites6
+.4byte sUnownEmarkSprites7
+.4byte sUnownEmarkSprites8
+.4byte sUnownEmarkSprites9
+.4byte sUnownEmarkSprites10
+.4byte sUnownEmarkSprites11
+sAxMainUnownEmark:
+ax_main sAxPosesUnownEmark, sAxAnimationsUnownEmark, 13, sAxSpritesUnownEmark, sAxPositionsUnownEmark

--- a/data/ax/unownf.inc
+++ b/data/ax/unownf.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownF
+gAxUnownF:
+ax_siro sAxMainUnownF
+sUnownFPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose43:
+ax_pose 10, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownFPose44:
+ax_pose 11, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sUnownFPose45:
+ax_pose 12, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownFPose46:
+ax_pose 13, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose47:
+ax_pose 14, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose48:
+ax_pose 15, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownFPose49:
+ax_pose 16, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownFPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownFPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownFPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownFAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownFAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownFAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownFAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownFAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownFAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownFAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownFAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownFAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownFAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownFAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownFAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownFAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownFAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownFAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownFAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownFAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownFAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownFAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownFAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownFAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownFAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownFAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownFAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownFAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownFAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownFAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownFAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownFAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownFAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownFAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownFAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownFAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownFAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownFAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownFAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownFAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownFAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownFAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownFAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownFAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownFAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownFAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownFAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownFAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownFAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownFAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownFAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownFAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownFAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownFGfx1:
+.incbin "baserom.gba", 0xDB1648, 0x200
+sUnownFSprites1:
+ax_sprite sUnownFGfx1, 0x200
+ax_sprite_terminator
+sUnownFGfx2:
+.incbin "baserom.gba", 0xDB1858, 0x200
+sUnownFSprites2:
+ax_sprite sUnownFGfx2, 0x200
+ax_sprite_terminator
+sUnownFGfx3:
+.incbin "baserom.gba", 0xDB1A68, 0x200
+sUnownFSprites3:
+ax_sprite sUnownFGfx3, 0x200
+ax_sprite_terminator
+sUnownFGfx4:
+.incbin "baserom.gba", 0xDB1C78, 0x200
+sUnownFSprites4:
+ax_sprite sUnownFGfx4, 0x200
+ax_sprite_terminator
+sUnownFGfx5:
+.incbin "baserom.gba", 0xDB1E88, 0x200
+sUnownFSprites5:
+ax_sprite sUnownFGfx5, 0x200
+ax_sprite_terminator
+sUnownFGfx6:
+.incbin "baserom.gba", 0xDB2098, 0x200
+sUnownFSprites6:
+ax_sprite sUnownFGfx6, 0x200
+ax_sprite_terminator
+sUnownFGfx7:
+.incbin "baserom.gba", 0xDB22A8, 0x200
+sUnownFSprites7:
+ax_sprite sUnownFGfx7, 0x200
+ax_sprite_terminator
+sUnownFGfx8:
+.incbin "baserom.gba", 0xDB24B8, 0x200
+sUnownFSprites8:
+ax_sprite sUnownFGfx8, 0x200
+ax_sprite_terminator
+sUnownFGfx9:
+.incbin "baserom.gba", 0xDB26C8, 0x200
+sUnownFSprites9:
+ax_sprite sUnownFGfx9, 0x200
+ax_sprite_terminator
+sUnownFGfx10:
+.incbin "baserom.gba", 0xDB28D8, 0x200
+sUnownFSprites10:
+ax_sprite sUnownFGfx10, 0x200
+ax_sprite_terminator
+sUnownFGfx11:
+.incbin "baserom.gba", 0xDB2AE8, 0x200
+sUnownFSprites11:
+ax_sprite sUnownFGfx11, 0x200
+ax_sprite_terminator
+sUnownFGfx12:
+.incbin "baserom.gba", 0xDB2CF8, 0x200
+sUnownFSprites12:
+ax_sprite sUnownFGfx12, 0x200
+ax_sprite_terminator
+sUnownFGfx13:
+.incbin "baserom.gba", 0xDB2F08, 0x200
+sUnownFSprites13:
+ax_sprite sUnownFGfx13, 0x200
+ax_sprite_terminator
+sUnownFGfx14:
+.incbin "baserom.gba", 0xDB3118, 0x200
+sUnownFSprites14:
+ax_sprite sUnownFGfx14, 0x200
+ax_sprite_terminator
+sUnownFGfx15:
+.incbin "baserom.gba", 0xDB3328, 0x200
+sUnownFSprites15:
+ax_sprite sUnownFGfx15, 0x200
+ax_sprite_terminator
+sUnownFGfx16:
+.incbin "baserom.gba", 0xDB3538, 0x200
+sUnownFSprites16:
+ax_sprite sUnownFGfx16, 0x200
+ax_sprite_terminator
+sUnownFGfx17:
+.incbin "baserom.gba", 0xDB3748, 0x200
+sUnownFSprites17:
+ax_sprite sUnownFGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownF:
+.4byte sUnownFPose1
+.4byte sUnownFPose2
+.4byte sUnownFPose3
+.4byte sUnownFPose4
+.4byte sUnownFPose5
+.4byte sUnownFPose6
+.4byte sUnownFPose7
+.4byte sUnownFPose8
+.4byte sUnownFPose9
+.4byte sUnownFPose10
+.4byte sUnownFPose11
+.4byte sUnownFPose12
+.4byte sUnownFPose13
+.4byte sUnownFPose14
+.4byte sUnownFPose15
+.4byte sUnownFPose16
+.4byte sUnownFPose17
+.4byte sUnownFPose18
+.4byte sUnownFPose19
+.4byte sUnownFPose20
+.4byte sUnownFPose21
+.4byte sUnownFPose22
+.4byte sUnownFPose23
+.4byte sUnownFPose24
+.4byte sUnownFPose25
+.4byte sUnownFPose26
+.4byte sUnownFPose27
+.4byte sUnownFPose28
+.4byte sUnownFPose29
+.4byte sUnownFPose30
+.4byte sUnownFPose31
+.4byte sUnownFPose32
+.4byte sUnownFPose33
+.4byte sUnownFPose34
+.4byte sUnownFPose35
+.4byte sUnownFPose36
+.4byte sUnownFPose37
+.4byte sUnownFPose38
+.4byte sUnownFPose39
+.4byte sUnownFPose40
+.4byte sUnownFPose41
+.4byte sUnownFPose42
+.4byte sUnownFPose43
+.4byte sUnownFPose44
+.4byte sUnownFPose45
+.4byte sUnownFPose46
+.4byte sUnownFPose47
+.4byte sUnownFPose48
+.4byte sUnownFPose49
+.4byte sUnownFPose50
+.4byte sUnownFPose51
+.4byte sUnownFPose52
+.4byte sUnownFPose53
+.4byte sUnownFPose54
+.4byte sUnownFPose55
+.4byte sUnownFPose56
+.4byte sUnownFPose57
+.4byte sUnownFPose58
+.4byte sUnownFPose59
+.4byte sUnownFPose60
+.4byte sUnownFPose61
+.4byte sUnownFPose62
+.4byte sUnownFPose63
+.4byte sUnownFPose64
+.4byte sUnownFPose65
+.4byte sUnownFPose66
+.4byte sUnownFPose67
+.4byte sUnownFPose68
+.4byte sUnownFPose69
+.4byte sUnownFPose70
+.4byte sUnownFPose71
+.4byte sUnownFPose72
+.4byte sUnownFPose73
+.4byte sUnownFPose74
+.4byte sUnownFPose75
+.4byte sUnownFPose76
+.4byte sUnownFPose77
+.4byte sUnownFPose78
+.4byte sUnownFPose79
+.4byte sUnownFPose80
+.4byte sUnownFPose81
+.4byte sUnownFPose82
+.4byte sUnownFPose83
+.4byte sUnownFPose84
+.4byte sUnownFPose85
+.4byte sUnownFPose86
+.4byte sUnownFPose87
+.4byte sUnownFPose88
+.4byte sUnownFPose89
+.4byte sUnownFPose90
+.4byte sUnownFPose91
+.4byte sUnownFPose92
+.4byte sUnownFPose93
+.4byte sUnownFPose94
+.4byte sUnownFPose95
+.4byte sUnownFPose96
+.4byte sUnownFPose97
+sAxPositionsUnownF:
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -11
+.2byte   -1,  -16, 	  -2,   -5, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -16, 	  -1,   -5, 	   1,   -7, 	  -1,  -11
+.2byte    0,  -16, 	   2,   -5, 	  -2,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   1,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -1,  -17, 	   1,   -6, 	  -4,   -5, 	  -1,  -11
+.2byte    0,  -16, 	  -3,   -7, 	  -1,   -5, 	   0,  -11
+.2byte   -1,  -16, 	  -4,   -6, 	   0,   -5, 	   0,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -15, 	  -3,   -5, 	   1,   -5, 	  -1,  -12
+.2byte    0,  -15, 	  -3,   -5, 	   1,   -6, 	  -1,  -11
+.2byte    0,  -15, 	  -2,   -5, 	   0,   -7, 	  -1,  -11
+.2byte    1,  -15, 	   1,   -5, 	  -3,   -6, 	  -1,  -11
+.2byte   -1,  -14, 	   2,   -5, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -16, 	   1,   -6, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -15, 	  -2,   -7, 	   0,   -5, 	  -1,  -12
+.2byte   -2,  -15, 	  -3,   -6, 	   1,   -5, 	  -1,  -12
+sUnownFAnimTable1:
+.4byte sUnownFAnims_1_1
+.4byte sUnownFAnims_1_2
+.4byte sUnownFAnims_1_3
+.4byte sUnownFAnims_1_4
+.4byte sUnownFAnims_1_5
+.4byte sUnownFAnims_1_6
+.4byte sUnownFAnims_1_7
+.4byte sUnownFAnims_1_8
+sUnownFAnimTable2:
+.4byte sUnownFAnims_2_1
+.4byte sUnownFAnims_2_2
+.4byte sUnownFAnims_2_3
+.4byte sUnownFAnims_2_4
+.4byte sUnownFAnims_2_5
+.4byte sUnownFAnims_2_6
+.4byte sUnownFAnims_2_7
+.4byte sUnownFAnims_2_8
+sUnownFAnimTable3:
+.4byte sUnownFAnims_3_1
+.4byte sUnownFAnims_3_2
+.4byte sUnownFAnims_3_3
+.4byte sUnownFAnims_3_4
+.4byte sUnownFAnims_3_5
+.4byte sUnownFAnims_3_6
+.4byte sUnownFAnims_3_7
+.4byte sUnownFAnims_3_8
+sUnownFAnimTable4:
+.4byte sUnownFAnims_4_1
+.4byte sUnownFAnims_4_2
+.4byte sUnownFAnims_4_3
+.4byte sUnownFAnims_4_4
+.4byte sUnownFAnims_4_5
+.4byte sUnownFAnims_4_6
+.4byte sUnownFAnims_4_7
+.4byte sUnownFAnims_4_8
+sUnownFAnimTable5:
+.4byte sUnownFAnims_5_1
+.4byte sUnownFAnims_5_2
+.4byte sUnownFAnims_5_3
+.4byte sUnownFAnims_5_4
+.4byte sUnownFAnims_5_5
+.4byte sUnownFAnims_5_6
+.4byte sUnownFAnims_5_7
+.4byte sUnownFAnims_5_8
+sUnownFAnimTable6:
+.4byte sUnownFAnims_6_1
+.4byte sUnownFAnims_6_1
+.4byte sUnownFAnims_6_1
+.4byte sUnownFAnims_6_1
+.4byte sUnownFAnims_6_1
+.4byte sUnownFAnims_6_1
+.4byte sUnownFAnims_6_1
+.4byte sUnownFAnims_6_1
+sUnownFAnimTable7:
+.4byte sUnownFAnims_7_1
+.4byte sUnownFAnims_7_2
+.4byte sUnownFAnims_7_3
+.4byte sUnownFAnims_7_4
+.4byte sUnownFAnims_7_5
+.4byte sUnownFAnims_7_6
+.4byte sUnownFAnims_7_7
+.4byte sUnownFAnims_7_8
+sUnownFAnimTable8:
+.4byte sUnownFAnims_8_1
+.4byte sUnownFAnims_8_2
+.4byte sUnownFAnims_8_3
+.4byte sUnownFAnims_8_4
+.4byte sUnownFAnims_8_5
+.4byte sUnownFAnims_8_6
+.4byte sUnownFAnims_8_7
+.4byte sUnownFAnims_8_8
+sUnownFAnimTable9:
+.4byte sUnownFAnims_9_1
+.4byte sUnownFAnims_9_2
+.4byte sUnownFAnims_9_3
+.4byte sUnownFAnims_9_4
+.4byte sUnownFAnims_9_5
+.4byte sUnownFAnims_9_6
+.4byte sUnownFAnims_9_7
+.4byte sUnownFAnims_9_8
+sUnownFAnimTable10:
+.4byte sUnownFAnims_10_1
+.4byte sUnownFAnims_10_2
+.4byte sUnownFAnims_10_3
+.4byte sUnownFAnims_10_4
+.4byte sUnownFAnims_10_5
+.4byte sUnownFAnims_10_6
+.4byte sUnownFAnims_10_7
+.4byte sUnownFAnims_10_8
+sUnownFAnimTable11:
+.4byte sUnownFAnims_11_1
+.4byte sUnownFAnims_11_2
+.4byte sUnownFAnims_11_3
+.4byte sUnownFAnims_11_4
+.4byte sUnownFAnims_11_5
+.4byte sUnownFAnims_11_6
+.4byte sUnownFAnims_11_7
+.4byte sUnownFAnims_11_8
+sUnownFAnimTable12:
+.4byte sUnownFAnims_12_1
+.4byte sUnownFAnims_12_2
+.4byte sUnownFAnims_12_3
+.4byte sUnownFAnims_12_4
+.4byte sUnownFAnims_12_5
+.4byte sUnownFAnims_12_6
+.4byte sUnownFAnims_12_7
+.4byte sUnownFAnims_12_8
+sUnownFAnimTable13:
+.4byte sUnownFAnims_13_1
+.4byte sUnownFAnims_13_2
+.4byte sUnownFAnims_13_3
+.4byte sUnownFAnims_13_4
+.4byte sUnownFAnims_13_5
+.4byte sUnownFAnims_13_6
+.4byte sUnownFAnims_13_7
+.4byte sUnownFAnims_13_8
+sAxAnimationsUnownF:
+.4byte sUnownFAnimTable1
+.4byte sUnownFAnimTable2
+.4byte sUnownFAnimTable3
+.4byte sUnownFAnimTable4
+.4byte sUnownFAnimTable5
+.4byte sUnownFAnimTable6
+.4byte sUnownFAnimTable7
+.4byte sUnownFAnimTable8
+.4byte sUnownFAnimTable9
+.4byte sUnownFAnimTable10
+.4byte sUnownFAnimTable11
+.4byte sUnownFAnimTable12
+.4byte sUnownFAnimTable13
+sAxSpritesUnownF:
+.4byte sUnownFSprites1
+.4byte sUnownFSprites2
+.4byte sUnownFSprites3
+.4byte sUnownFSprites4
+.4byte sUnownFSprites5
+.4byte sUnownFSprites6
+.4byte sUnownFSprites7
+.4byte sUnownFSprites8
+.4byte sUnownFSprites9
+.4byte sUnownFSprites10
+.4byte sUnownFSprites11
+.4byte sUnownFSprites12
+.4byte sUnownFSprites13
+.4byte sUnownFSprites14
+.4byte sUnownFSprites15
+.4byte sUnownFSprites16
+.4byte sUnownFSprites17
+sAxMainUnownF:
+ax_main sAxPosesUnownF, sAxAnimationsUnownF, 13, sAxSpritesUnownF, sAxPositionsUnownF

--- a/data/ax/unowng.inc
+++ b/data/ax/unowng.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownG
+gAxUnownG:
+ax_siro sAxMainUnownG
+sUnownGPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownGPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownGPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownGPose46:
+ax_pose 13, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownGPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownGPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownGAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownGAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownGAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownGAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownGAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownGAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownGAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownGAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownGAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownGAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownGAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownGAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownGAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownGAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownGAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownGAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownGAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownGAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownGAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownGAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownGAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownGAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownGAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownGAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownGAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownGAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownGAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownGAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownGAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownGAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownGAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownGAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownGAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownGAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownGAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownGAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownGAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownGAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownGAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownGAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownGAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownGAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownGAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownGAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownGAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownGAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownGAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownGAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownGAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownGAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownGGfx1:
+.incbin "baserom.gba", 0xDB7858, 0x200
+sUnownGSprites1:
+ax_sprite sUnownGGfx1, 0x200
+ax_sprite_terminator
+sUnownGGfx2:
+.incbin "baserom.gba", 0xDB7A68, 0x200
+sUnownGSprites2:
+ax_sprite sUnownGGfx2, 0x200
+ax_sprite_terminator
+sUnownGGfx3:
+.incbin "baserom.gba", 0xDB7C78, 0x200
+sUnownGSprites3:
+ax_sprite sUnownGGfx3, 0x200
+ax_sprite_terminator
+sUnownGGfx4:
+.incbin "baserom.gba", 0xDB7E88, 0x200
+sUnownGSprites4:
+ax_sprite sUnownGGfx4, 0x200
+ax_sprite_terminator
+sUnownGGfx5:
+.incbin "baserom.gba", 0xDB8098, 0x200
+sUnownGSprites5:
+ax_sprite sUnownGGfx5, 0x200
+ax_sprite_terminator
+sUnownGGfx6:
+.incbin "baserom.gba", 0xDB82A8, 0x200
+sUnownGSprites6:
+ax_sprite sUnownGGfx6, 0x200
+ax_sprite_terminator
+sUnownGGfx7:
+.incbin "baserom.gba", 0xDB84B8, 0x200
+sUnownGSprites7:
+ax_sprite sUnownGGfx7, 0x200
+ax_sprite_terminator
+sUnownGGfx8:
+.incbin "baserom.gba", 0xDB86C8, 0x200
+sUnownGSprites8:
+ax_sprite sUnownGGfx8, 0x200
+ax_sprite_terminator
+sUnownGGfx9:
+.incbin "baserom.gba", 0xDB88D8, 0x200
+sUnownGSprites9:
+ax_sprite sUnownGGfx9, 0x200
+ax_sprite_terminator
+sUnownGGfx10:
+.incbin "baserom.gba", 0xDB8AE8, 0x200
+sUnownGSprites10:
+ax_sprite sUnownGGfx10, 0x200
+ax_sprite_terminator
+sUnownGGfx11:
+.incbin "baserom.gba", 0xDB8CF8, 0x200
+sUnownGSprites11:
+ax_sprite sUnownGGfx11, 0x200
+ax_sprite_terminator
+sUnownGGfx12:
+.incbin "baserom.gba", 0xDB8F08, 0x200
+sUnownGSprites12:
+ax_sprite sUnownGGfx12, 0x200
+ax_sprite_terminator
+sUnownGGfx13:
+.incbin "baserom.gba", 0xDB9118, 0x200
+sUnownGSprites13:
+ax_sprite sUnownGGfx13, 0x200
+ax_sprite_terminator
+sUnownGGfx14:
+.incbin "baserom.gba", 0xDB9328, 0x200
+sUnownGSprites14:
+ax_sprite sUnownGGfx14, 0x200
+ax_sprite_terminator
+sUnownGGfx15:
+.incbin "baserom.gba", 0xDB9538, 0x200
+sUnownGSprites15:
+ax_sprite sUnownGGfx15, 0x200
+ax_sprite_terminator
+sUnownGGfx16:
+.incbin "baserom.gba", 0xDB9748, 0x200
+sUnownGSprites16:
+ax_sprite sUnownGGfx16, 0x200
+ax_sprite_terminator
+sUnownGGfx17:
+.incbin "baserom.gba", 0xDB9958, 0x200
+sUnownGSprites17:
+ax_sprite sUnownGGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownG:
+.4byte sUnownGPose1
+.4byte sUnownGPose2
+.4byte sUnownGPose3
+.4byte sUnownGPose4
+.4byte sUnownGPose5
+.4byte sUnownGPose6
+.4byte sUnownGPose7
+.4byte sUnownGPose8
+.4byte sUnownGPose9
+.4byte sUnownGPose10
+.4byte sUnownGPose11
+.4byte sUnownGPose12
+.4byte sUnownGPose13
+.4byte sUnownGPose14
+.4byte sUnownGPose15
+.4byte sUnownGPose16
+.4byte sUnownGPose17
+.4byte sUnownGPose18
+.4byte sUnownGPose19
+.4byte sUnownGPose20
+.4byte sUnownGPose21
+.4byte sUnownGPose22
+.4byte sUnownGPose23
+.4byte sUnownGPose24
+.4byte sUnownGPose25
+.4byte sUnownGPose26
+.4byte sUnownGPose27
+.4byte sUnownGPose28
+.4byte sUnownGPose29
+.4byte sUnownGPose30
+.4byte sUnownGPose31
+.4byte sUnownGPose32
+.4byte sUnownGPose33
+.4byte sUnownGPose34
+.4byte sUnownGPose35
+.4byte sUnownGPose36
+.4byte sUnownGPose37
+.4byte sUnownGPose38
+.4byte sUnownGPose39
+.4byte sUnownGPose40
+.4byte sUnownGPose41
+.4byte sUnownGPose42
+.4byte sUnownGPose43
+.4byte sUnownGPose44
+.4byte sUnownGPose45
+.4byte sUnownGPose46
+.4byte sUnownGPose47
+.4byte sUnownGPose48
+.4byte sUnownGPose49
+.4byte sUnownGPose50
+.4byte sUnownGPose51
+.4byte sUnownGPose52
+.4byte sUnownGPose53
+.4byte sUnownGPose54
+.4byte sUnownGPose55
+.4byte sUnownGPose56
+.4byte sUnownGPose57
+.4byte sUnownGPose58
+.4byte sUnownGPose59
+.4byte sUnownGPose60
+.4byte sUnownGPose61
+.4byte sUnownGPose62
+.4byte sUnownGPose63
+.4byte sUnownGPose64
+.4byte sUnownGPose65
+.4byte sUnownGPose66
+.4byte sUnownGPose67
+.4byte sUnownGPose68
+.4byte sUnownGPose69
+.4byte sUnownGPose70
+.4byte sUnownGPose71
+.4byte sUnownGPose72
+.4byte sUnownGPose73
+.4byte sUnownGPose74
+.4byte sUnownGPose75
+.4byte sUnownGPose76
+.4byte sUnownGPose77
+.4byte sUnownGPose78
+.4byte sUnownGPose79
+.4byte sUnownGPose80
+.4byte sUnownGPose81
+.4byte sUnownGPose82
+.4byte sUnownGPose83
+.4byte sUnownGPose84
+.4byte sUnownGPose85
+.4byte sUnownGPose86
+.4byte sUnownGPose87
+.4byte sUnownGPose88
+.4byte sUnownGPose89
+.4byte sUnownGPose90
+.4byte sUnownGPose91
+.4byte sUnownGPose92
+.4byte sUnownGPose93
+.4byte sUnownGPose94
+.4byte sUnownGPose95
+.4byte sUnownGPose96
+.4byte sUnownGPose97
+sAxPositionsUnownG:
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -14, 	  -2,   -7, 	   2,   -5, 	  -1,  -10
+.2byte    1,  -14, 	   0,   -6, 	   1,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -2,   -5, 	  -1,  -10
+.2byte   -1,  -12, 	   2,   -6, 	  -3,   -4, 	  -1,  -10
+.2byte   -2,  -14, 	   0,   -7, 	  -2,   -4, 	   0,  -10
+.2byte   -4,  -14, 	  -4,   -7, 	  -2,   -4, 	  -3,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	  -1,   -4, 	  -1,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+.2byte   -1,  -13, 	  -4,   -7, 	   1,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -3,   -7, 	   1,   -5, 	   0,  -10
+.2byte    1,  -13, 	  -1,   -6, 	   0,   -4, 	   0,  -11
+.2byte    0,  -14, 	   1,   -7, 	  -3,   -5, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -7, 	  -3,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	   1,   -7, 	  -2,   -4, 	  -1,  -10
+.2byte   -4,  -13, 	  -3,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte   -3,  -13, 	  -3,   -7, 	   0,   -4, 	  -2,  -10
+sUnownGAnimTable1:
+.4byte sUnownGAnims_1_1
+.4byte sUnownGAnims_1_2
+.4byte sUnownGAnims_1_3
+.4byte sUnownGAnims_1_4
+.4byte sUnownGAnims_1_5
+.4byte sUnownGAnims_1_6
+.4byte sUnownGAnims_1_7
+.4byte sUnownGAnims_1_8
+sUnownGAnimTable2:
+.4byte sUnownGAnims_2_1
+.4byte sUnownGAnims_2_2
+.4byte sUnownGAnims_2_3
+.4byte sUnownGAnims_2_4
+.4byte sUnownGAnims_2_5
+.4byte sUnownGAnims_2_6
+.4byte sUnownGAnims_2_7
+.4byte sUnownGAnims_2_8
+sUnownGAnimTable3:
+.4byte sUnownGAnims_3_1
+.4byte sUnownGAnims_3_2
+.4byte sUnownGAnims_3_3
+.4byte sUnownGAnims_3_4
+.4byte sUnownGAnims_3_5
+.4byte sUnownGAnims_3_6
+.4byte sUnownGAnims_3_7
+.4byte sUnownGAnims_3_8
+sUnownGAnimTable4:
+.4byte sUnownGAnims_4_1
+.4byte sUnownGAnims_4_2
+.4byte sUnownGAnims_4_3
+.4byte sUnownGAnims_4_4
+.4byte sUnownGAnims_4_5
+.4byte sUnownGAnims_4_6
+.4byte sUnownGAnims_4_7
+.4byte sUnownGAnims_4_8
+sUnownGAnimTable5:
+.4byte sUnownGAnims_5_1
+.4byte sUnownGAnims_5_2
+.4byte sUnownGAnims_5_3
+.4byte sUnownGAnims_5_4
+.4byte sUnownGAnims_5_5
+.4byte sUnownGAnims_5_6
+.4byte sUnownGAnims_5_7
+.4byte sUnownGAnims_5_8
+sUnownGAnimTable6:
+.4byte sUnownGAnims_6_1
+.4byte sUnownGAnims_6_1
+.4byte sUnownGAnims_6_1
+.4byte sUnownGAnims_6_1
+.4byte sUnownGAnims_6_1
+.4byte sUnownGAnims_6_1
+.4byte sUnownGAnims_6_1
+.4byte sUnownGAnims_6_1
+sUnownGAnimTable7:
+.4byte sUnownGAnims_7_1
+.4byte sUnownGAnims_7_2
+.4byte sUnownGAnims_7_3
+.4byte sUnownGAnims_7_4
+.4byte sUnownGAnims_7_5
+.4byte sUnownGAnims_7_6
+.4byte sUnownGAnims_7_7
+.4byte sUnownGAnims_7_8
+sUnownGAnimTable8:
+.4byte sUnownGAnims_8_1
+.4byte sUnownGAnims_8_2
+.4byte sUnownGAnims_8_3
+.4byte sUnownGAnims_8_4
+.4byte sUnownGAnims_8_5
+.4byte sUnownGAnims_8_6
+.4byte sUnownGAnims_8_7
+.4byte sUnownGAnims_8_8
+sUnownGAnimTable9:
+.4byte sUnownGAnims_9_1
+.4byte sUnownGAnims_9_2
+.4byte sUnownGAnims_9_3
+.4byte sUnownGAnims_9_4
+.4byte sUnownGAnims_9_5
+.4byte sUnownGAnims_9_6
+.4byte sUnownGAnims_9_7
+.4byte sUnownGAnims_9_8
+sUnownGAnimTable10:
+.4byte sUnownGAnims_10_1
+.4byte sUnownGAnims_10_2
+.4byte sUnownGAnims_10_3
+.4byte sUnownGAnims_10_4
+.4byte sUnownGAnims_10_5
+.4byte sUnownGAnims_10_6
+.4byte sUnownGAnims_10_7
+.4byte sUnownGAnims_10_8
+sUnownGAnimTable11:
+.4byte sUnownGAnims_11_1
+.4byte sUnownGAnims_11_2
+.4byte sUnownGAnims_11_3
+.4byte sUnownGAnims_11_4
+.4byte sUnownGAnims_11_5
+.4byte sUnownGAnims_11_6
+.4byte sUnownGAnims_11_7
+.4byte sUnownGAnims_11_8
+sUnownGAnimTable12:
+.4byte sUnownGAnims_12_1
+.4byte sUnownGAnims_12_2
+.4byte sUnownGAnims_12_3
+.4byte sUnownGAnims_12_4
+.4byte sUnownGAnims_12_5
+.4byte sUnownGAnims_12_6
+.4byte sUnownGAnims_12_7
+.4byte sUnownGAnims_12_8
+sUnownGAnimTable13:
+.4byte sUnownGAnims_13_1
+.4byte sUnownGAnims_13_2
+.4byte sUnownGAnims_13_3
+.4byte sUnownGAnims_13_4
+.4byte sUnownGAnims_13_5
+.4byte sUnownGAnims_13_6
+.4byte sUnownGAnims_13_7
+.4byte sUnownGAnims_13_8
+sAxAnimationsUnownG:
+.4byte sUnownGAnimTable1
+.4byte sUnownGAnimTable2
+.4byte sUnownGAnimTable3
+.4byte sUnownGAnimTable4
+.4byte sUnownGAnimTable5
+.4byte sUnownGAnimTable6
+.4byte sUnownGAnimTable7
+.4byte sUnownGAnimTable8
+.4byte sUnownGAnimTable9
+.4byte sUnownGAnimTable10
+.4byte sUnownGAnimTable11
+.4byte sUnownGAnimTable12
+.4byte sUnownGAnimTable13
+sAxSpritesUnownG:
+.4byte sUnownGSprites1
+.4byte sUnownGSprites2
+.4byte sUnownGSprites3
+.4byte sUnownGSprites4
+.4byte sUnownGSprites5
+.4byte sUnownGSprites6
+.4byte sUnownGSprites7
+.4byte sUnownGSprites8
+.4byte sUnownGSprites9
+.4byte sUnownGSprites10
+.4byte sUnownGSprites11
+.4byte sUnownGSprites12
+.4byte sUnownGSprites13
+.4byte sUnownGSprites14
+.4byte sUnownGSprites15
+.4byte sUnownGSprites16
+.4byte sUnownGSprites17
+sAxMainUnownG:
+ax_main sAxPosesUnownG, sAxAnimationsUnownG, 13, sAxSpritesUnownG, sAxPositionsUnownG

--- a/data/ax/unownh.inc
+++ b/data/ax/unownh.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownH
+gAxUnownH:
+ax_siro sAxMainUnownH
+sUnownHPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownHPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownHPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownHPose46:
+ax_pose 13, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownHPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownHPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownHAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownHAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownHAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownHAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownHAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownHAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownHAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownHAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownHAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownHAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownHAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownHAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownHAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownHAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownHAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownHAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownHAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownHAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownHAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownHAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownHAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownHAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownHAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownHAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownHAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownHAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownHAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownHAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownHAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownHAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownHAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownHAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownHAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownHAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownHAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownHAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownHAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownHAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownHAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownHAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownHAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownHAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownHAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownHAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownHAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownHAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownHAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownHAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownHAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownHAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownHGfx1:
+.incbin "baserom.gba", 0xDBDA68, 0x200
+sUnownHSprites1:
+ax_sprite sUnownHGfx1, 0x200
+ax_sprite_terminator
+sUnownHGfx2:
+.incbin "baserom.gba", 0xDBDC78, 0x200
+sUnownHSprites2:
+ax_sprite sUnownHGfx2, 0x200
+ax_sprite_terminator
+sUnownHGfx3:
+.incbin "baserom.gba", 0xDBDE88, 0x200
+sUnownHSprites3:
+ax_sprite sUnownHGfx3, 0x200
+ax_sprite_terminator
+sUnownHGfx4:
+.incbin "baserom.gba", 0xDBE098, 0x200
+sUnownHSprites4:
+ax_sprite sUnownHGfx4, 0x200
+ax_sprite_terminator
+sUnownHGfx5:
+.incbin "baserom.gba", 0xDBE2A8, 0x200
+sUnownHSprites5:
+ax_sprite sUnownHGfx5, 0x200
+ax_sprite_terminator
+sUnownHGfx6:
+.incbin "baserom.gba", 0xDBE4B8, 0x200
+sUnownHSprites6:
+ax_sprite sUnownHGfx6, 0x200
+ax_sprite_terminator
+sUnownHGfx7:
+.incbin "baserom.gba", 0xDBE6C8, 0x200
+sUnownHSprites7:
+ax_sprite sUnownHGfx7, 0x200
+ax_sprite_terminator
+sUnownHGfx8:
+.incbin "baserom.gba", 0xDBE8D8, 0x200
+sUnownHSprites8:
+ax_sprite sUnownHGfx8, 0x200
+ax_sprite_terminator
+sUnownHGfx9:
+.incbin "baserom.gba", 0xDBEAE8, 0x200
+sUnownHSprites9:
+ax_sprite sUnownHGfx9, 0x200
+ax_sprite_terminator
+sUnownHGfx10:
+.incbin "baserom.gba", 0xDBECF8, 0x200
+sUnownHSprites10:
+ax_sprite sUnownHGfx10, 0x200
+ax_sprite_terminator
+sUnownHGfx11:
+.incbin "baserom.gba", 0xDBEF08, 0x200
+sUnownHSprites11:
+ax_sprite sUnownHGfx11, 0x200
+ax_sprite_terminator
+sUnownHGfx12:
+.incbin "baserom.gba", 0xDBF118, 0x200
+sUnownHSprites12:
+ax_sprite sUnownHGfx12, 0x200
+ax_sprite_terminator
+sUnownHGfx13:
+.incbin "baserom.gba", 0xDBF328, 0x200
+sUnownHSprites13:
+ax_sprite sUnownHGfx13, 0x200
+ax_sprite_terminator
+sUnownHGfx14:
+.incbin "baserom.gba", 0xDBF538, 0x200
+sUnownHSprites14:
+ax_sprite sUnownHGfx14, 0x200
+ax_sprite_terminator
+sUnownHGfx15:
+.incbin "baserom.gba", 0xDBF748, 0x200
+sUnownHSprites15:
+ax_sprite sUnownHGfx15, 0x200
+ax_sprite_terminator
+sUnownHGfx16:
+.incbin "baserom.gba", 0xDBF958, 0x200
+sUnownHSprites16:
+ax_sprite sUnownHGfx16, 0x200
+ax_sprite_terminator
+sUnownHGfx17:
+.incbin "baserom.gba", 0xDBFB68, 0x200
+sUnownHSprites17:
+ax_sprite sUnownHGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownH:
+.4byte sUnownHPose1
+.4byte sUnownHPose2
+.4byte sUnownHPose3
+.4byte sUnownHPose4
+.4byte sUnownHPose5
+.4byte sUnownHPose6
+.4byte sUnownHPose7
+.4byte sUnownHPose8
+.4byte sUnownHPose9
+.4byte sUnownHPose10
+.4byte sUnownHPose11
+.4byte sUnownHPose12
+.4byte sUnownHPose13
+.4byte sUnownHPose14
+.4byte sUnownHPose15
+.4byte sUnownHPose16
+.4byte sUnownHPose17
+.4byte sUnownHPose18
+.4byte sUnownHPose19
+.4byte sUnownHPose20
+.4byte sUnownHPose21
+.4byte sUnownHPose22
+.4byte sUnownHPose23
+.4byte sUnownHPose24
+.4byte sUnownHPose25
+.4byte sUnownHPose26
+.4byte sUnownHPose27
+.4byte sUnownHPose28
+.4byte sUnownHPose29
+.4byte sUnownHPose30
+.4byte sUnownHPose31
+.4byte sUnownHPose32
+.4byte sUnownHPose33
+.4byte sUnownHPose34
+.4byte sUnownHPose35
+.4byte sUnownHPose36
+.4byte sUnownHPose37
+.4byte sUnownHPose38
+.4byte sUnownHPose39
+.4byte sUnownHPose40
+.4byte sUnownHPose41
+.4byte sUnownHPose42
+.4byte sUnownHPose43
+.4byte sUnownHPose44
+.4byte sUnownHPose45
+.4byte sUnownHPose46
+.4byte sUnownHPose47
+.4byte sUnownHPose48
+.4byte sUnownHPose49
+.4byte sUnownHPose50
+.4byte sUnownHPose51
+.4byte sUnownHPose52
+.4byte sUnownHPose53
+.4byte sUnownHPose54
+.4byte sUnownHPose55
+.4byte sUnownHPose56
+.4byte sUnownHPose57
+.4byte sUnownHPose58
+.4byte sUnownHPose59
+.4byte sUnownHPose60
+.4byte sUnownHPose61
+.4byte sUnownHPose62
+.4byte sUnownHPose63
+.4byte sUnownHPose64
+.4byte sUnownHPose65
+.4byte sUnownHPose66
+.4byte sUnownHPose67
+.4byte sUnownHPose68
+.4byte sUnownHPose69
+.4byte sUnownHPose70
+.4byte sUnownHPose71
+.4byte sUnownHPose72
+.4byte sUnownHPose73
+.4byte sUnownHPose74
+.4byte sUnownHPose75
+.4byte sUnownHPose76
+.4byte sUnownHPose77
+.4byte sUnownHPose78
+.4byte sUnownHPose79
+.4byte sUnownHPose80
+.4byte sUnownHPose81
+.4byte sUnownHPose82
+.4byte sUnownHPose83
+.4byte sUnownHPose84
+.4byte sUnownHPose85
+.4byte sUnownHPose86
+.4byte sUnownHPose87
+.4byte sUnownHPose88
+.4byte sUnownHPose89
+.4byte sUnownHPose90
+.4byte sUnownHPose91
+.4byte sUnownHPose92
+.4byte sUnownHPose93
+.4byte sUnownHPose94
+.4byte sUnownHPose95
+.4byte sUnownHPose96
+.4byte sUnownHPose97
+sAxPositionsUnownH:
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -13, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -13, 	  -4,  -11, 	   1,  -12, 	  -1,  -11
+.2byte    0,  -14, 	   4,  -10, 	  -6,  -13, 	  -2,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -11
+.2byte   -2,  -14, 	   3,  -13, 	  -7,  -10, 	  -1,  -11
+.2byte   -4,  -13, 	  -2,  -13, 	   1,  -10, 	  -1,  -11
+.2byte   -3,  -13, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	  -7,  -11, 	   3,  -12, 	  -2,  -11
+.2byte    1,  -12, 	  -4,  -11, 	   1,  -13, 	  -2,  -10
+.2byte    0,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	   5,  -12, 	  -9,  -12, 	  -2,  -12
+.2byte   -3,  -13, 	   3,  -12, 	  -7,  -10, 	  -2,  -11
+.2byte   -4,  -12, 	  -3,  -12, 	   1,   -9, 	  -1,  -11
+.2byte   -3,  -12, 	  -6,  -13, 	   4,  -11, 	  -1,  -11
+sUnownHAnimTable1:
+.4byte sUnownHAnims_1_1
+.4byte sUnownHAnims_1_2
+.4byte sUnownHAnims_1_3
+.4byte sUnownHAnims_1_4
+.4byte sUnownHAnims_1_5
+.4byte sUnownHAnims_1_6
+.4byte sUnownHAnims_1_7
+.4byte sUnownHAnims_1_8
+sUnownHAnimTable2:
+.4byte sUnownHAnims_2_1
+.4byte sUnownHAnims_2_2
+.4byte sUnownHAnims_2_3
+.4byte sUnownHAnims_2_4
+.4byte sUnownHAnims_2_5
+.4byte sUnownHAnims_2_6
+.4byte sUnownHAnims_2_7
+.4byte sUnownHAnims_2_8
+sUnownHAnimTable3:
+.4byte sUnownHAnims_3_1
+.4byte sUnownHAnims_3_2
+.4byte sUnownHAnims_3_3
+.4byte sUnownHAnims_3_4
+.4byte sUnownHAnims_3_5
+.4byte sUnownHAnims_3_6
+.4byte sUnownHAnims_3_7
+.4byte sUnownHAnims_3_8
+sUnownHAnimTable4:
+.4byte sUnownHAnims_4_1
+.4byte sUnownHAnims_4_2
+.4byte sUnownHAnims_4_3
+.4byte sUnownHAnims_4_4
+.4byte sUnownHAnims_4_5
+.4byte sUnownHAnims_4_6
+.4byte sUnownHAnims_4_7
+.4byte sUnownHAnims_4_8
+sUnownHAnimTable5:
+.4byte sUnownHAnims_5_1
+.4byte sUnownHAnims_5_2
+.4byte sUnownHAnims_5_3
+.4byte sUnownHAnims_5_4
+.4byte sUnownHAnims_5_5
+.4byte sUnownHAnims_5_6
+.4byte sUnownHAnims_5_7
+.4byte sUnownHAnims_5_8
+sUnownHAnimTable6:
+.4byte sUnownHAnims_6_1
+.4byte sUnownHAnims_6_1
+.4byte sUnownHAnims_6_1
+.4byte sUnownHAnims_6_1
+.4byte sUnownHAnims_6_1
+.4byte sUnownHAnims_6_1
+.4byte sUnownHAnims_6_1
+.4byte sUnownHAnims_6_1
+sUnownHAnimTable7:
+.4byte sUnownHAnims_7_1
+.4byte sUnownHAnims_7_2
+.4byte sUnownHAnims_7_3
+.4byte sUnownHAnims_7_4
+.4byte sUnownHAnims_7_5
+.4byte sUnownHAnims_7_6
+.4byte sUnownHAnims_7_7
+.4byte sUnownHAnims_7_8
+sUnownHAnimTable8:
+.4byte sUnownHAnims_8_1
+.4byte sUnownHAnims_8_2
+.4byte sUnownHAnims_8_3
+.4byte sUnownHAnims_8_4
+.4byte sUnownHAnims_8_5
+.4byte sUnownHAnims_8_6
+.4byte sUnownHAnims_8_7
+.4byte sUnownHAnims_8_8
+sUnownHAnimTable9:
+.4byte sUnownHAnims_9_1
+.4byte sUnownHAnims_9_2
+.4byte sUnownHAnims_9_3
+.4byte sUnownHAnims_9_4
+.4byte sUnownHAnims_9_5
+.4byte sUnownHAnims_9_6
+.4byte sUnownHAnims_9_7
+.4byte sUnownHAnims_9_8
+sUnownHAnimTable10:
+.4byte sUnownHAnims_10_1
+.4byte sUnownHAnims_10_2
+.4byte sUnownHAnims_10_3
+.4byte sUnownHAnims_10_4
+.4byte sUnownHAnims_10_5
+.4byte sUnownHAnims_10_6
+.4byte sUnownHAnims_10_7
+.4byte sUnownHAnims_10_8
+sUnownHAnimTable11:
+.4byte sUnownHAnims_11_1
+.4byte sUnownHAnims_11_2
+.4byte sUnownHAnims_11_3
+.4byte sUnownHAnims_11_4
+.4byte sUnownHAnims_11_5
+.4byte sUnownHAnims_11_6
+.4byte sUnownHAnims_11_7
+.4byte sUnownHAnims_11_8
+sUnownHAnimTable12:
+.4byte sUnownHAnims_12_1
+.4byte sUnownHAnims_12_2
+.4byte sUnownHAnims_12_3
+.4byte sUnownHAnims_12_4
+.4byte sUnownHAnims_12_5
+.4byte sUnownHAnims_12_6
+.4byte sUnownHAnims_12_7
+.4byte sUnownHAnims_12_8
+sUnownHAnimTable13:
+.4byte sUnownHAnims_13_1
+.4byte sUnownHAnims_13_2
+.4byte sUnownHAnims_13_3
+.4byte sUnownHAnims_13_4
+.4byte sUnownHAnims_13_5
+.4byte sUnownHAnims_13_6
+.4byte sUnownHAnims_13_7
+.4byte sUnownHAnims_13_8
+sAxAnimationsUnownH:
+.4byte sUnownHAnimTable1
+.4byte sUnownHAnimTable2
+.4byte sUnownHAnimTable3
+.4byte sUnownHAnimTable4
+.4byte sUnownHAnimTable5
+.4byte sUnownHAnimTable6
+.4byte sUnownHAnimTable7
+.4byte sUnownHAnimTable8
+.4byte sUnownHAnimTable9
+.4byte sUnownHAnimTable10
+.4byte sUnownHAnimTable11
+.4byte sUnownHAnimTable12
+.4byte sUnownHAnimTable13
+sAxSpritesUnownH:
+.4byte sUnownHSprites1
+.4byte sUnownHSprites2
+.4byte sUnownHSprites3
+.4byte sUnownHSprites4
+.4byte sUnownHSprites5
+.4byte sUnownHSprites6
+.4byte sUnownHSprites7
+.4byte sUnownHSprites8
+.4byte sUnownHSprites9
+.4byte sUnownHSprites10
+.4byte sUnownHSprites11
+.4byte sUnownHSprites12
+.4byte sUnownHSprites13
+.4byte sUnownHSprites14
+.4byte sUnownHSprites15
+.4byte sUnownHSprites16
+.4byte sUnownHSprites17
+sAxMainUnownH:
+ax_main sAxPosesUnownH, sAxAnimationsUnownH, 13, sAxSpritesUnownH, sAxPositionsUnownH

--- a/data/ax/unowni.inc
+++ b/data/ax/unowni.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownI
+gAxUnownI:
+ax_siro sAxMainUnownI
+sUnownIPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose2:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose3:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose4:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose6:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose7:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose8:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose10:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose11:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose12:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose14:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose15:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose16:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose18:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose19:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose20:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose22:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose23:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose24:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose26:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose27:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose28:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose30:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose31:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose32:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose34:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose35:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose36:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose38:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose39:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose40:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose42:
+ax_pose 6, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose43:
+ax_pose 7, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose44:
+ax_pose 8, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose45:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose47:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose48:
+ax_pose 8, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose49:
+ax_pose 7, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose51:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose52:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose53:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose55:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose56:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose57:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose59:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose60:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose61:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose63:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose64:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose65:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose67:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose68:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose69:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose71:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose72:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose73:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose75:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose76:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose77:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose79:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose80:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose81:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose83:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose84:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose85:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose87:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose88:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose89:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose91:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose92:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose93:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownIPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose95:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose96:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownIPose97:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownIAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownIAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownIAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownIAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownIAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownIAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownIAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownIAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownIAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownIAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownIAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownIAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownIAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownIAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownIAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownIAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownIAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownIAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownIAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownIAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownIAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownIAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownIAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownIAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownIAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownIAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownIAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownIAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownIAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownIAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownIAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownIAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownIAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownIAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownIAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownIAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownIAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownIAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownIAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownIAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownIAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownIAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownIAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownIAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownIAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownIAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownIAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownIAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownIAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownIAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownIGfx1:
+.incbin "baserom.gba", 0xDC3C78, 0x200
+sUnownISprites1:
+ax_sprite sUnownIGfx1, 0x200
+ax_sprite_terminator
+sUnownIGfx2:
+.incbin "baserom.gba", 0xDC3E88, 0x200
+sUnownISprites2:
+ax_sprite sUnownIGfx2, 0x200
+ax_sprite_terminator
+sUnownIGfx3:
+.incbin "baserom.gba", 0xDC4098, 0x200
+sUnownISprites3:
+ax_sprite sUnownIGfx3, 0x200
+ax_sprite_terminator
+sUnownIGfx4:
+.incbin "baserom.gba", 0xDC42A8, 0x200
+sUnownISprites4:
+ax_sprite sUnownIGfx4, 0x200
+ax_sprite_terminator
+sUnownIGfx5:
+.incbin "baserom.gba", 0xDC44B8, 0x200
+sUnownISprites5:
+ax_sprite sUnownIGfx5, 0x200
+ax_sprite_terminator
+sUnownIGfx6:
+.incbin "baserom.gba", 0xDC46C8, 0x200
+sUnownISprites6:
+ax_sprite sUnownIGfx6, 0x200
+ax_sprite_terminator
+sUnownIGfx7:
+.incbin "baserom.gba", 0xDC48D8, 0x200
+sUnownISprites7:
+ax_sprite sUnownIGfx7, 0x200
+ax_sprite_terminator
+sUnownIGfx8:
+.incbin "baserom.gba", 0xDC4AE8, 0x200
+sUnownISprites8:
+ax_sprite sUnownIGfx8, 0x200
+ax_sprite_terminator
+sUnownIGfx9:
+.incbin "baserom.gba", 0xDC4CF8, 0x200
+sUnownISprites9:
+ax_sprite sUnownIGfx9, 0x200
+ax_sprite_terminator
+sUnownIGfx10:
+.incbin "baserom.gba", 0xDC4F08, 0x200
+sUnownISprites10:
+ax_sprite sUnownIGfx10, 0x200
+ax_sprite_terminator
+sUnownIGfx11:
+.incbin "baserom.gba", 0xDC5118, 0x200
+sUnownISprites11:
+ax_sprite sUnownIGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownI:
+.4byte sUnownIPose1
+.4byte sUnownIPose2
+.4byte sUnownIPose3
+.4byte sUnownIPose4
+.4byte sUnownIPose5
+.4byte sUnownIPose6
+.4byte sUnownIPose7
+.4byte sUnownIPose8
+.4byte sUnownIPose9
+.4byte sUnownIPose10
+.4byte sUnownIPose11
+.4byte sUnownIPose12
+.4byte sUnownIPose13
+.4byte sUnownIPose14
+.4byte sUnownIPose15
+.4byte sUnownIPose16
+.4byte sUnownIPose17
+.4byte sUnownIPose18
+.4byte sUnownIPose19
+.4byte sUnownIPose20
+.4byte sUnownIPose21
+.4byte sUnownIPose22
+.4byte sUnownIPose23
+.4byte sUnownIPose24
+.4byte sUnownIPose25
+.4byte sUnownIPose26
+.4byte sUnownIPose27
+.4byte sUnownIPose28
+.4byte sUnownIPose29
+.4byte sUnownIPose30
+.4byte sUnownIPose31
+.4byte sUnownIPose32
+.4byte sUnownIPose33
+.4byte sUnownIPose34
+.4byte sUnownIPose35
+.4byte sUnownIPose36
+.4byte sUnownIPose37
+.4byte sUnownIPose38
+.4byte sUnownIPose39
+.4byte sUnownIPose40
+.4byte sUnownIPose41
+.4byte sUnownIPose42
+.4byte sUnownIPose43
+.4byte sUnownIPose44
+.4byte sUnownIPose45
+.4byte sUnownIPose46
+.4byte sUnownIPose47
+.4byte sUnownIPose48
+.4byte sUnownIPose49
+.4byte sUnownIPose50
+.4byte sUnownIPose51
+.4byte sUnownIPose52
+.4byte sUnownIPose53
+.4byte sUnownIPose54
+.4byte sUnownIPose55
+.4byte sUnownIPose56
+.4byte sUnownIPose57
+.4byte sUnownIPose58
+.4byte sUnownIPose59
+.4byte sUnownIPose60
+.4byte sUnownIPose61
+.4byte sUnownIPose62
+.4byte sUnownIPose63
+.4byte sUnownIPose64
+.4byte sUnownIPose65
+.4byte sUnownIPose66
+.4byte sUnownIPose67
+.4byte sUnownIPose68
+.4byte sUnownIPose69
+.4byte sUnownIPose70
+.4byte sUnownIPose71
+.4byte sUnownIPose72
+.4byte sUnownIPose73
+.4byte sUnownIPose74
+.4byte sUnownIPose75
+.4byte sUnownIPose76
+.4byte sUnownIPose77
+.4byte sUnownIPose78
+.4byte sUnownIPose79
+.4byte sUnownIPose80
+.4byte sUnownIPose81
+.4byte sUnownIPose82
+.4byte sUnownIPose83
+.4byte sUnownIPose84
+.4byte sUnownIPose85
+.4byte sUnownIPose86
+.4byte sUnownIPose87
+.4byte sUnownIPose88
+.4byte sUnownIPose89
+.4byte sUnownIPose90
+.4byte sUnownIPose91
+.4byte sUnownIPose92
+.4byte sUnownIPose93
+.4byte sUnownIPose94
+.4byte sUnownIPose95
+.4byte sUnownIPose96
+.4byte sUnownIPose97
+sAxPositionsUnownI:
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -13, 	   1,  -13, 	  -3,  -12, 	  -1,  -11
+.2byte    1,  -13, 	  -1,  -13, 	  -2,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -13, 	  -1,  -13, 	   0,  -10, 	  -1,  -11
+.2byte   -2,  -13, 	  -3,  -13, 	   1,  -12, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	  -4,  -12, 	   2,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   0,  -13, 	  -2,  -11, 	  -1,  -11
+.2byte    0,  -13, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -12, 	  -4,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -12, 	  -3,  -11, 	  -1,  -11
+.2byte   -3,  -12, 	  -2,  -13, 	   0,  -11, 	  -1,  -11
+.2byte   -2,  -12, 	  -3,  -12, 	   1,  -11, 	  -1,  -11
+sUnownIAnimTable1:
+.4byte sUnownIAnims_1_1
+.4byte sUnownIAnims_1_2
+.4byte sUnownIAnims_1_3
+.4byte sUnownIAnims_1_4
+.4byte sUnownIAnims_1_5
+.4byte sUnownIAnims_1_6
+.4byte sUnownIAnims_1_7
+.4byte sUnownIAnims_1_8
+sUnownIAnimTable2:
+.4byte sUnownIAnims_2_1
+.4byte sUnownIAnims_2_2
+.4byte sUnownIAnims_2_3
+.4byte sUnownIAnims_2_4
+.4byte sUnownIAnims_2_5
+.4byte sUnownIAnims_2_6
+.4byte sUnownIAnims_2_7
+.4byte sUnownIAnims_2_8
+sUnownIAnimTable3:
+.4byte sUnownIAnims_3_1
+.4byte sUnownIAnims_3_2
+.4byte sUnownIAnims_3_3
+.4byte sUnownIAnims_3_4
+.4byte sUnownIAnims_3_5
+.4byte sUnownIAnims_3_6
+.4byte sUnownIAnims_3_7
+.4byte sUnownIAnims_3_8
+sUnownIAnimTable4:
+.4byte sUnownIAnims_4_1
+.4byte sUnownIAnims_4_2
+.4byte sUnownIAnims_4_3
+.4byte sUnownIAnims_4_4
+.4byte sUnownIAnims_4_5
+.4byte sUnownIAnims_4_6
+.4byte sUnownIAnims_4_7
+.4byte sUnownIAnims_4_8
+sUnownIAnimTable5:
+.4byte sUnownIAnims_5_1
+.4byte sUnownIAnims_5_2
+.4byte sUnownIAnims_5_3
+.4byte sUnownIAnims_5_4
+.4byte sUnownIAnims_5_5
+.4byte sUnownIAnims_5_6
+.4byte sUnownIAnims_5_7
+.4byte sUnownIAnims_5_8
+sUnownIAnimTable6:
+.4byte sUnownIAnims_6_1
+.4byte sUnownIAnims_6_1
+.4byte sUnownIAnims_6_1
+.4byte sUnownIAnims_6_1
+.4byte sUnownIAnims_6_1
+.4byte sUnownIAnims_6_1
+.4byte sUnownIAnims_6_1
+.4byte sUnownIAnims_6_1
+sUnownIAnimTable7:
+.4byte sUnownIAnims_7_1
+.4byte sUnownIAnims_7_2
+.4byte sUnownIAnims_7_3
+.4byte sUnownIAnims_7_4
+.4byte sUnownIAnims_7_5
+.4byte sUnownIAnims_7_6
+.4byte sUnownIAnims_7_7
+.4byte sUnownIAnims_7_8
+sUnownIAnimTable8:
+.4byte sUnownIAnims_8_1
+.4byte sUnownIAnims_8_2
+.4byte sUnownIAnims_8_3
+.4byte sUnownIAnims_8_4
+.4byte sUnownIAnims_8_5
+.4byte sUnownIAnims_8_6
+.4byte sUnownIAnims_8_7
+.4byte sUnownIAnims_8_8
+sUnownIAnimTable9:
+.4byte sUnownIAnims_9_1
+.4byte sUnownIAnims_9_2
+.4byte sUnownIAnims_9_3
+.4byte sUnownIAnims_9_4
+.4byte sUnownIAnims_9_5
+.4byte sUnownIAnims_9_6
+.4byte sUnownIAnims_9_7
+.4byte sUnownIAnims_9_8
+sUnownIAnimTable10:
+.4byte sUnownIAnims_10_1
+.4byte sUnownIAnims_10_2
+.4byte sUnownIAnims_10_3
+.4byte sUnownIAnims_10_4
+.4byte sUnownIAnims_10_5
+.4byte sUnownIAnims_10_6
+.4byte sUnownIAnims_10_7
+.4byte sUnownIAnims_10_8
+sUnownIAnimTable11:
+.4byte sUnownIAnims_11_1
+.4byte sUnownIAnims_11_2
+.4byte sUnownIAnims_11_3
+.4byte sUnownIAnims_11_4
+.4byte sUnownIAnims_11_5
+.4byte sUnownIAnims_11_6
+.4byte sUnownIAnims_11_7
+.4byte sUnownIAnims_11_8
+sUnownIAnimTable12:
+.4byte sUnownIAnims_12_1
+.4byte sUnownIAnims_12_2
+.4byte sUnownIAnims_12_3
+.4byte sUnownIAnims_12_4
+.4byte sUnownIAnims_12_5
+.4byte sUnownIAnims_12_6
+.4byte sUnownIAnims_12_7
+.4byte sUnownIAnims_12_8
+sUnownIAnimTable13:
+.4byte sUnownIAnims_13_1
+.4byte sUnownIAnims_13_2
+.4byte sUnownIAnims_13_3
+.4byte sUnownIAnims_13_4
+.4byte sUnownIAnims_13_5
+.4byte sUnownIAnims_13_6
+.4byte sUnownIAnims_13_7
+.4byte sUnownIAnims_13_8
+sAxAnimationsUnownI:
+.4byte sUnownIAnimTable1
+.4byte sUnownIAnimTable2
+.4byte sUnownIAnimTable3
+.4byte sUnownIAnimTable4
+.4byte sUnownIAnimTable5
+.4byte sUnownIAnimTable6
+.4byte sUnownIAnimTable7
+.4byte sUnownIAnimTable8
+.4byte sUnownIAnimTable9
+.4byte sUnownIAnimTable10
+.4byte sUnownIAnimTable11
+.4byte sUnownIAnimTable12
+.4byte sUnownIAnimTable13
+sAxSpritesUnownI:
+.4byte sUnownISprites1
+.4byte sUnownISprites2
+.4byte sUnownISprites3
+.4byte sUnownISprites4
+.4byte sUnownISprites5
+.4byte sUnownISprites6
+.4byte sUnownISprites7
+.4byte sUnownISprites8
+.4byte sUnownISprites9
+.4byte sUnownISprites10
+.4byte sUnownISprites11
+sAxMainUnownI:
+ax_main sAxPosesUnownI, sAxAnimationsUnownI, 13, sAxSpritesUnownI, sAxPositionsUnownI

--- a/data/ax/unownj.inc
+++ b/data/ax/unownj.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownJ
+gAxUnownJ:
+ax_siro sAxMainUnownJ
+sUnownJPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownJPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownJPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownJPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose49:
+ax_pose 16, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownJPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownJPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownJPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownJAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownJAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownJAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownJAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownJAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownJAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownJAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownJAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownJAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownJAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownJAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownJAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownJAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownJAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownJAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownJAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownJAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownJAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownJAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownJAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownJAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownJAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownJAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownJAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownJAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownJAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownJAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownJAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownJAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownJAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownJAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownJAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownJAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownJAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownJAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownJAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownJAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownJAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownJAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownJAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownJAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownJAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownJAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownJAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownJAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownJAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownJAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownJAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownJAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownJAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownJGfx1:
+.incbin "baserom.gba", 0xDC9210, 0x200
+sUnownJSprites1:
+ax_sprite sUnownJGfx1, 0x200
+ax_sprite_terminator
+sUnownJGfx2:
+.incbin "baserom.gba", 0xDC9420, 0x200
+sUnownJSprites2:
+ax_sprite sUnownJGfx2, 0x200
+ax_sprite_terminator
+sUnownJGfx3:
+.incbin "baserom.gba", 0xDC9630, 0x200
+sUnownJSprites3:
+ax_sprite sUnownJGfx3, 0x200
+ax_sprite_terminator
+sUnownJGfx4:
+.incbin "baserom.gba", 0xDC9840, 0x200
+sUnownJSprites4:
+ax_sprite sUnownJGfx4, 0x200
+ax_sprite_terminator
+sUnownJGfx5:
+.incbin "baserom.gba", 0xDC9A50, 0x200
+sUnownJSprites5:
+ax_sprite sUnownJGfx5, 0x200
+ax_sprite_terminator
+sUnownJGfx6:
+.incbin "baserom.gba", 0xDC9C60, 0x200
+sUnownJSprites6:
+ax_sprite sUnownJGfx6, 0x200
+ax_sprite_terminator
+sUnownJGfx7:
+.incbin "baserom.gba", 0xDC9E70, 0x200
+sUnownJSprites7:
+ax_sprite sUnownJGfx7, 0x200
+ax_sprite_terminator
+sUnownJGfx8:
+.incbin "baserom.gba", 0xDCA080, 0x200
+sUnownJSprites8:
+ax_sprite sUnownJGfx8, 0x200
+ax_sprite_terminator
+sUnownJGfx9:
+.incbin "baserom.gba", 0xDCA290, 0x200
+sUnownJSprites9:
+ax_sprite sUnownJGfx9, 0x200
+ax_sprite_terminator
+sUnownJGfx10:
+.incbin "baserom.gba", 0xDCA4A0, 0x200
+sUnownJSprites10:
+ax_sprite sUnownJGfx10, 0x200
+ax_sprite_terminator
+sUnownJGfx11:
+.incbin "baserom.gba", 0xDCA6B0, 0x200
+sUnownJSprites11:
+ax_sprite sUnownJGfx11, 0x200
+ax_sprite_terminator
+sUnownJGfx12:
+.incbin "baserom.gba", 0xDCA8C0, 0x200
+sUnownJSprites12:
+ax_sprite sUnownJGfx12, 0x200
+ax_sprite_terminator
+sUnownJGfx13:
+.incbin "baserom.gba", 0xDCAAD0, 0x200
+sUnownJSprites13:
+ax_sprite sUnownJGfx13, 0x200
+ax_sprite_terminator
+sUnownJGfx14:
+.incbin "baserom.gba", 0xDCACE0, 0x200
+sUnownJSprites14:
+ax_sprite sUnownJGfx14, 0x200
+ax_sprite_terminator
+sUnownJGfx15:
+.incbin "baserom.gba", 0xDCAEF0, 0x200
+sUnownJSprites15:
+ax_sprite sUnownJGfx15, 0x200
+ax_sprite_terminator
+sUnownJGfx16:
+.incbin "baserom.gba", 0xDCB100, 0x200
+sUnownJSprites16:
+ax_sprite sUnownJGfx16, 0x200
+ax_sprite_terminator
+sUnownJGfx17:
+.incbin "baserom.gba", 0xDCB310, 0x200
+sUnownJSprites17:
+ax_sprite sUnownJGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownJ:
+.4byte sUnownJPose1
+.4byte sUnownJPose2
+.4byte sUnownJPose3
+.4byte sUnownJPose4
+.4byte sUnownJPose5
+.4byte sUnownJPose6
+.4byte sUnownJPose7
+.4byte sUnownJPose8
+.4byte sUnownJPose9
+.4byte sUnownJPose10
+.4byte sUnownJPose11
+.4byte sUnownJPose12
+.4byte sUnownJPose13
+.4byte sUnownJPose14
+.4byte sUnownJPose15
+.4byte sUnownJPose16
+.4byte sUnownJPose17
+.4byte sUnownJPose18
+.4byte sUnownJPose19
+.4byte sUnownJPose20
+.4byte sUnownJPose21
+.4byte sUnownJPose22
+.4byte sUnownJPose23
+.4byte sUnownJPose24
+.4byte sUnownJPose25
+.4byte sUnownJPose26
+.4byte sUnownJPose27
+.4byte sUnownJPose28
+.4byte sUnownJPose29
+.4byte sUnownJPose30
+.4byte sUnownJPose31
+.4byte sUnownJPose32
+.4byte sUnownJPose33
+.4byte sUnownJPose34
+.4byte sUnownJPose35
+.4byte sUnownJPose36
+.4byte sUnownJPose37
+.4byte sUnownJPose38
+.4byte sUnownJPose39
+.4byte sUnownJPose40
+.4byte sUnownJPose41
+.4byte sUnownJPose42
+.4byte sUnownJPose43
+.4byte sUnownJPose44
+.4byte sUnownJPose45
+.4byte sUnownJPose46
+.4byte sUnownJPose47
+.4byte sUnownJPose48
+.4byte sUnownJPose49
+.4byte sUnownJPose50
+.4byte sUnownJPose51
+.4byte sUnownJPose52
+.4byte sUnownJPose53
+.4byte sUnownJPose54
+.4byte sUnownJPose55
+.4byte sUnownJPose56
+.4byte sUnownJPose57
+.4byte sUnownJPose58
+.4byte sUnownJPose59
+.4byte sUnownJPose60
+.4byte sUnownJPose61
+.4byte sUnownJPose62
+.4byte sUnownJPose63
+.4byte sUnownJPose64
+.4byte sUnownJPose65
+.4byte sUnownJPose66
+.4byte sUnownJPose67
+.4byte sUnownJPose68
+.4byte sUnownJPose69
+.4byte sUnownJPose70
+.4byte sUnownJPose71
+.4byte sUnownJPose72
+.4byte sUnownJPose73
+.4byte sUnownJPose74
+.4byte sUnownJPose75
+.4byte sUnownJPose76
+.4byte sUnownJPose77
+.4byte sUnownJPose78
+.4byte sUnownJPose79
+.4byte sUnownJPose80
+.4byte sUnownJPose81
+.4byte sUnownJPose82
+.4byte sUnownJPose83
+.4byte sUnownJPose84
+.4byte sUnownJPose85
+.4byte sUnownJPose86
+.4byte sUnownJPose87
+.4byte sUnownJPose88
+.4byte sUnownJPose89
+.4byte sUnownJPose90
+.4byte sUnownJPose91
+.4byte sUnownJPose92
+.4byte sUnownJPose93
+.4byte sUnownJPose94
+.4byte sUnownJPose95
+.4byte sUnownJPose96
+.4byte sUnownJPose97
+sAxPositionsUnownJ:
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte   -1,  -15, 	  -3,   -7, 	   1,  -19, 	  -2,  -10
+.2byte    0,  -15, 	  -3,   -7, 	  -2,  -19, 	  -1,  -10
+.2byte   -1,  -15, 	   3,   -7, 	  -5,  -19, 	  -2,  -10
+.2byte   -1,  -15, 	   3,   -8, 	  -6,  -17, 	  -1,  -11
+.2byte   -1,  -15, 	   1,   -8, 	  -4,  -17, 	   0,  -11
+.2byte   -2,  -15, 	  -4,   -8, 	   4,  -16, 	   0,  -11
+.2byte   -2,  -15, 	  -4,   -8, 	   4,  -17, 	  -1,  -10
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,   -7, 	   4,  -18, 	  -1,  -11
+.2byte    0,  -14, 	  -4,   -7, 	   2,  -19, 	  -1,  -10
+.2byte    1,  -14, 	  -3,   -7, 	  -1,  -19, 	  -1,  -10
+.2byte    0,  -15, 	   2,   -7, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	   3,   -7, 	  -6,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   2,   -8, 	  -5,  -17, 	  -1,  -10
+.2byte   -3,  -14, 	  -3,   -7, 	   3,  -16, 	  -1,  -11
+.2byte   -2,  -14, 	  -4,   -8, 	   4,  -17, 	  -1,  -11
+sUnownJAnimTable1:
+.4byte sUnownJAnims_1_1
+.4byte sUnownJAnims_1_2
+.4byte sUnownJAnims_1_3
+.4byte sUnownJAnims_1_4
+.4byte sUnownJAnims_1_5
+.4byte sUnownJAnims_1_6
+.4byte sUnownJAnims_1_7
+.4byte sUnownJAnims_1_8
+sUnownJAnimTable2:
+.4byte sUnownJAnims_2_1
+.4byte sUnownJAnims_2_2
+.4byte sUnownJAnims_2_3
+.4byte sUnownJAnims_2_4
+.4byte sUnownJAnims_2_5
+.4byte sUnownJAnims_2_6
+.4byte sUnownJAnims_2_7
+.4byte sUnownJAnims_2_8
+sUnownJAnimTable3:
+.4byte sUnownJAnims_3_1
+.4byte sUnownJAnims_3_2
+.4byte sUnownJAnims_3_3
+.4byte sUnownJAnims_3_4
+.4byte sUnownJAnims_3_5
+.4byte sUnownJAnims_3_6
+.4byte sUnownJAnims_3_7
+.4byte sUnownJAnims_3_8
+sUnownJAnimTable4:
+.4byte sUnownJAnims_4_1
+.4byte sUnownJAnims_4_2
+.4byte sUnownJAnims_4_3
+.4byte sUnownJAnims_4_4
+.4byte sUnownJAnims_4_5
+.4byte sUnownJAnims_4_6
+.4byte sUnownJAnims_4_7
+.4byte sUnownJAnims_4_8
+sUnownJAnimTable5:
+.4byte sUnownJAnims_5_1
+.4byte sUnownJAnims_5_2
+.4byte sUnownJAnims_5_3
+.4byte sUnownJAnims_5_4
+.4byte sUnownJAnims_5_5
+.4byte sUnownJAnims_5_6
+.4byte sUnownJAnims_5_7
+.4byte sUnownJAnims_5_8
+sUnownJAnimTable6:
+.4byte sUnownJAnims_6_1
+.4byte sUnownJAnims_6_1
+.4byte sUnownJAnims_6_1
+.4byte sUnownJAnims_6_1
+.4byte sUnownJAnims_6_1
+.4byte sUnownJAnims_6_1
+.4byte sUnownJAnims_6_1
+.4byte sUnownJAnims_6_1
+sUnownJAnimTable7:
+.4byte sUnownJAnims_7_1
+.4byte sUnownJAnims_7_2
+.4byte sUnownJAnims_7_3
+.4byte sUnownJAnims_7_4
+.4byte sUnownJAnims_7_5
+.4byte sUnownJAnims_7_6
+.4byte sUnownJAnims_7_7
+.4byte sUnownJAnims_7_8
+sUnownJAnimTable8:
+.4byte sUnownJAnims_8_1
+.4byte sUnownJAnims_8_2
+.4byte sUnownJAnims_8_3
+.4byte sUnownJAnims_8_4
+.4byte sUnownJAnims_8_5
+.4byte sUnownJAnims_8_6
+.4byte sUnownJAnims_8_7
+.4byte sUnownJAnims_8_8
+sUnownJAnimTable9:
+.4byte sUnownJAnims_9_1
+.4byte sUnownJAnims_9_2
+.4byte sUnownJAnims_9_3
+.4byte sUnownJAnims_9_4
+.4byte sUnownJAnims_9_5
+.4byte sUnownJAnims_9_6
+.4byte sUnownJAnims_9_7
+.4byte sUnownJAnims_9_8
+sUnownJAnimTable10:
+.4byte sUnownJAnims_10_1
+.4byte sUnownJAnims_10_2
+.4byte sUnownJAnims_10_3
+.4byte sUnownJAnims_10_4
+.4byte sUnownJAnims_10_5
+.4byte sUnownJAnims_10_6
+.4byte sUnownJAnims_10_7
+.4byte sUnownJAnims_10_8
+sUnownJAnimTable11:
+.4byte sUnownJAnims_11_1
+.4byte sUnownJAnims_11_2
+.4byte sUnownJAnims_11_3
+.4byte sUnownJAnims_11_4
+.4byte sUnownJAnims_11_5
+.4byte sUnownJAnims_11_6
+.4byte sUnownJAnims_11_7
+.4byte sUnownJAnims_11_8
+sUnownJAnimTable12:
+.4byte sUnownJAnims_12_1
+.4byte sUnownJAnims_12_2
+.4byte sUnownJAnims_12_3
+.4byte sUnownJAnims_12_4
+.4byte sUnownJAnims_12_5
+.4byte sUnownJAnims_12_6
+.4byte sUnownJAnims_12_7
+.4byte sUnownJAnims_12_8
+sUnownJAnimTable13:
+.4byte sUnownJAnims_13_1
+.4byte sUnownJAnims_13_2
+.4byte sUnownJAnims_13_3
+.4byte sUnownJAnims_13_4
+.4byte sUnownJAnims_13_5
+.4byte sUnownJAnims_13_6
+.4byte sUnownJAnims_13_7
+.4byte sUnownJAnims_13_8
+sAxAnimationsUnownJ:
+.4byte sUnownJAnimTable1
+.4byte sUnownJAnimTable2
+.4byte sUnownJAnimTable3
+.4byte sUnownJAnimTable4
+.4byte sUnownJAnimTable5
+.4byte sUnownJAnimTable6
+.4byte sUnownJAnimTable7
+.4byte sUnownJAnimTable8
+.4byte sUnownJAnimTable9
+.4byte sUnownJAnimTable10
+.4byte sUnownJAnimTable11
+.4byte sUnownJAnimTable12
+.4byte sUnownJAnimTable13
+sAxSpritesUnownJ:
+.4byte sUnownJSprites1
+.4byte sUnownJSprites2
+.4byte sUnownJSprites3
+.4byte sUnownJSprites4
+.4byte sUnownJSprites5
+.4byte sUnownJSprites6
+.4byte sUnownJSprites7
+.4byte sUnownJSprites8
+.4byte sUnownJSprites9
+.4byte sUnownJSprites10
+.4byte sUnownJSprites11
+.4byte sUnownJSprites12
+.4byte sUnownJSprites13
+.4byte sUnownJSprites14
+.4byte sUnownJSprites15
+.4byte sUnownJSprites16
+.4byte sUnownJSprites17
+sAxMainUnownJ:
+ax_main sAxPosesUnownJ, sAxAnimationsUnownJ, 13, sAxSpritesUnownJ, sAxPositionsUnownJ

--- a/data/ax/unownk.inc
+++ b/data/ax/unownk.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownK
+gAxUnownK:
+ax_siro sAxMainUnownK
+sUnownKPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose4:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose6:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose12:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose14:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose20:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose22:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose28:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose30:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose36:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose38:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownKPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownKPose45:
+ax_pose 12, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownKPose46:
+ax_pose 13, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose47:
+ax_pose 14, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose53:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose55:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose61:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose63:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose69:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose71:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose77:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose79:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose85:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose87:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose93:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownKPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose95:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownKPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownKAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownKAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownKAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownKAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownKAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownKAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownKAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownKAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownKAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownKAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownKAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownKAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownKAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownKAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownKAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownKAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownKAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownKAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownKAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownKAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownKAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownKAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownKAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownKAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownKAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownKAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownKAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownKAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownKAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownKAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownKAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownKAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownKAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownKAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownKAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownKAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownKAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownKAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownKAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownKAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownKAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownKAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownKAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownKAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownKAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownKAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownKAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownKAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownKAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownKAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownKGfx1:
+.incbin "baserom.gba", 0xDCF428, 0x200
+sUnownKSprites1:
+ax_sprite sUnownKGfx1, 0x200
+ax_sprite_terminator
+sUnownKGfx2:
+.incbin "baserom.gba", 0xDCF638, 0x200
+sUnownKSprites2:
+ax_sprite sUnownKGfx2, 0x200
+ax_sprite_terminator
+sUnownKGfx3:
+.incbin "baserom.gba", 0xDCF848, 0x200
+sUnownKSprites3:
+ax_sprite sUnownKGfx3, 0x200
+ax_sprite_terminator
+sUnownKGfx4:
+.incbin "baserom.gba", 0xDCFA58, 0x200
+sUnownKSprites4:
+ax_sprite sUnownKGfx4, 0x200
+ax_sprite_terminator
+sUnownKGfx5:
+.incbin "baserom.gba", 0xDCFC68, 0x200
+sUnownKSprites5:
+ax_sprite sUnownKGfx5, 0x200
+ax_sprite_terminator
+sUnownKGfx6:
+.incbin "baserom.gba", 0xDCFE78, 0x200
+sUnownKSprites6:
+ax_sprite sUnownKGfx6, 0x200
+ax_sprite_terminator
+sUnownKGfx7:
+.incbin "baserom.gba", 0xDD0088, 0x200
+sUnownKSprites7:
+ax_sprite sUnownKGfx7, 0x200
+ax_sprite_terminator
+sUnownKGfx8:
+.incbin "baserom.gba", 0xDD0298, 0x200
+sUnownKSprites8:
+ax_sprite sUnownKGfx8, 0x200
+ax_sprite_terminator
+sUnownKGfx9:
+.incbin "baserom.gba", 0xDD04A8, 0x200
+sUnownKSprites9:
+ax_sprite sUnownKGfx9, 0x200
+ax_sprite_terminator
+sUnownKGfx10:
+.incbin "baserom.gba", 0xDD06B8, 0x200
+sUnownKSprites10:
+ax_sprite sUnownKGfx10, 0x200
+ax_sprite_terminator
+sUnownKGfx11:
+.incbin "baserom.gba", 0xDD08C8, 0x200
+sUnownKSprites11:
+ax_sprite sUnownKGfx11, 0x200
+ax_sprite_terminator
+sUnownKGfx12:
+.incbin "baserom.gba", 0xDD0AD8, 0x200
+sUnownKSprites12:
+ax_sprite sUnownKGfx12, 0x200
+ax_sprite_terminator
+sUnownKGfx13:
+.incbin "baserom.gba", 0xDD0CE8, 0x200
+sUnownKSprites13:
+ax_sprite sUnownKGfx13, 0x200
+ax_sprite_terminator
+sUnownKGfx14:
+.incbin "baserom.gba", 0xDD0EF8, 0x200
+sUnownKSprites14:
+ax_sprite sUnownKGfx14, 0x200
+ax_sprite_terminator
+sUnownKGfx15:
+.incbin "baserom.gba", 0xDD1108, 0x200
+sUnownKSprites15:
+ax_sprite sUnownKGfx15, 0x200
+ax_sprite_terminator
+sUnownKGfx16:
+.incbin "baserom.gba", 0xDD1318, 0x200
+sUnownKSprites16:
+ax_sprite sUnownKGfx16, 0x200
+ax_sprite_terminator
+sUnownKGfx17:
+.incbin "baserom.gba", 0xDD1528, 0x200
+sUnownKSprites17:
+ax_sprite sUnownKGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownK:
+.4byte sUnownKPose1
+.4byte sUnownKPose2
+.4byte sUnownKPose3
+.4byte sUnownKPose4
+.4byte sUnownKPose5
+.4byte sUnownKPose6
+.4byte sUnownKPose7
+.4byte sUnownKPose8
+.4byte sUnownKPose9
+.4byte sUnownKPose10
+.4byte sUnownKPose11
+.4byte sUnownKPose12
+.4byte sUnownKPose13
+.4byte sUnownKPose14
+.4byte sUnownKPose15
+.4byte sUnownKPose16
+.4byte sUnownKPose17
+.4byte sUnownKPose18
+.4byte sUnownKPose19
+.4byte sUnownKPose20
+.4byte sUnownKPose21
+.4byte sUnownKPose22
+.4byte sUnownKPose23
+.4byte sUnownKPose24
+.4byte sUnownKPose25
+.4byte sUnownKPose26
+.4byte sUnownKPose27
+.4byte sUnownKPose28
+.4byte sUnownKPose29
+.4byte sUnownKPose30
+.4byte sUnownKPose31
+.4byte sUnownKPose32
+.4byte sUnownKPose33
+.4byte sUnownKPose34
+.4byte sUnownKPose35
+.4byte sUnownKPose36
+.4byte sUnownKPose37
+.4byte sUnownKPose38
+.4byte sUnownKPose39
+.4byte sUnownKPose40
+.4byte sUnownKPose41
+.4byte sUnownKPose42
+.4byte sUnownKPose43
+.4byte sUnownKPose44
+.4byte sUnownKPose45
+.4byte sUnownKPose46
+.4byte sUnownKPose47
+.4byte sUnownKPose48
+.4byte sUnownKPose49
+.4byte sUnownKPose50
+.4byte sUnownKPose51
+.4byte sUnownKPose52
+.4byte sUnownKPose53
+.4byte sUnownKPose54
+.4byte sUnownKPose55
+.4byte sUnownKPose56
+.4byte sUnownKPose57
+.4byte sUnownKPose58
+.4byte sUnownKPose59
+.4byte sUnownKPose60
+.4byte sUnownKPose61
+.4byte sUnownKPose62
+.4byte sUnownKPose63
+.4byte sUnownKPose64
+.4byte sUnownKPose65
+.4byte sUnownKPose66
+.4byte sUnownKPose67
+.4byte sUnownKPose68
+.4byte sUnownKPose69
+.4byte sUnownKPose70
+.4byte sUnownKPose71
+.4byte sUnownKPose72
+.4byte sUnownKPose73
+.4byte sUnownKPose74
+.4byte sUnownKPose75
+.4byte sUnownKPose76
+.4byte sUnownKPose77
+.4byte sUnownKPose78
+.4byte sUnownKPose79
+.4byte sUnownKPose80
+.4byte sUnownKPose81
+.4byte sUnownKPose82
+.4byte sUnownKPose83
+.4byte sUnownKPose84
+.4byte sUnownKPose85
+.4byte sUnownKPose86
+.4byte sUnownKPose87
+.4byte sUnownKPose88
+.4byte sUnownKPose89
+.4byte sUnownKPose90
+.4byte sUnownKPose91
+.4byte sUnownKPose92
+.4byte sUnownKPose93
+.4byte sUnownKPose94
+.4byte sUnownKPose95
+.4byte sUnownKPose96
+.4byte sUnownKPose97
+sAxPositionsUnownK:
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    1,  -13, 	  -3,  -19, 	   0,  -17, 	  -1,  -10
+.2byte    0,  -14, 	  -2,  -19, 	  -6,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -18, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	   0,  -18, 	  -6,  -14, 	  -1,  -11
+.2byte   -3,  -13, 	   1,  -19, 	   3,  -12, 	  -1,  -11
+.2byte   -3,  -13, 	   0,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+.2byte   -1,  -12, 	  -1,  -19, 	   5,  -15, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   3,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -1,  -19, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -13, 	  -1,  -19, 	  -5,  -16, 	  -1,  -11
+.2byte   -1,  -13, 	  -1,  -19, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -14, 	  -1,  -19, 	  -7,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   2,  -13, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -19, 	   3,  -14, 	  -1,  -11
+sUnownKAnimTable1:
+.4byte sUnownKAnims_1_1
+.4byte sUnownKAnims_1_2
+.4byte sUnownKAnims_1_3
+.4byte sUnownKAnims_1_4
+.4byte sUnownKAnims_1_5
+.4byte sUnownKAnims_1_6
+.4byte sUnownKAnims_1_7
+.4byte sUnownKAnims_1_8
+sUnownKAnimTable2:
+.4byte sUnownKAnims_2_1
+.4byte sUnownKAnims_2_2
+.4byte sUnownKAnims_2_3
+.4byte sUnownKAnims_2_4
+.4byte sUnownKAnims_2_5
+.4byte sUnownKAnims_2_6
+.4byte sUnownKAnims_2_7
+.4byte sUnownKAnims_2_8
+sUnownKAnimTable3:
+.4byte sUnownKAnims_3_1
+.4byte sUnownKAnims_3_2
+.4byte sUnownKAnims_3_3
+.4byte sUnownKAnims_3_4
+.4byte sUnownKAnims_3_5
+.4byte sUnownKAnims_3_6
+.4byte sUnownKAnims_3_7
+.4byte sUnownKAnims_3_8
+sUnownKAnimTable4:
+.4byte sUnownKAnims_4_1
+.4byte sUnownKAnims_4_2
+.4byte sUnownKAnims_4_3
+.4byte sUnownKAnims_4_4
+.4byte sUnownKAnims_4_5
+.4byte sUnownKAnims_4_6
+.4byte sUnownKAnims_4_7
+.4byte sUnownKAnims_4_8
+sUnownKAnimTable5:
+.4byte sUnownKAnims_5_1
+.4byte sUnownKAnims_5_2
+.4byte sUnownKAnims_5_3
+.4byte sUnownKAnims_5_4
+.4byte sUnownKAnims_5_5
+.4byte sUnownKAnims_5_6
+.4byte sUnownKAnims_5_7
+.4byte sUnownKAnims_5_8
+sUnownKAnimTable6:
+.4byte sUnownKAnims_6_1
+.4byte sUnownKAnims_6_1
+.4byte sUnownKAnims_6_1
+.4byte sUnownKAnims_6_1
+.4byte sUnownKAnims_6_1
+.4byte sUnownKAnims_6_1
+.4byte sUnownKAnims_6_1
+.4byte sUnownKAnims_6_1
+sUnownKAnimTable7:
+.4byte sUnownKAnims_7_1
+.4byte sUnownKAnims_7_2
+.4byte sUnownKAnims_7_3
+.4byte sUnownKAnims_7_4
+.4byte sUnownKAnims_7_5
+.4byte sUnownKAnims_7_6
+.4byte sUnownKAnims_7_7
+.4byte sUnownKAnims_7_8
+sUnownKAnimTable8:
+.4byte sUnownKAnims_8_1
+.4byte sUnownKAnims_8_2
+.4byte sUnownKAnims_8_3
+.4byte sUnownKAnims_8_4
+.4byte sUnownKAnims_8_5
+.4byte sUnownKAnims_8_6
+.4byte sUnownKAnims_8_7
+.4byte sUnownKAnims_8_8
+sUnownKAnimTable9:
+.4byte sUnownKAnims_9_1
+.4byte sUnownKAnims_9_2
+.4byte sUnownKAnims_9_3
+.4byte sUnownKAnims_9_4
+.4byte sUnownKAnims_9_5
+.4byte sUnownKAnims_9_6
+.4byte sUnownKAnims_9_7
+.4byte sUnownKAnims_9_8
+sUnownKAnimTable10:
+.4byte sUnownKAnims_10_1
+.4byte sUnownKAnims_10_2
+.4byte sUnownKAnims_10_3
+.4byte sUnownKAnims_10_4
+.4byte sUnownKAnims_10_5
+.4byte sUnownKAnims_10_6
+.4byte sUnownKAnims_10_7
+.4byte sUnownKAnims_10_8
+sUnownKAnimTable11:
+.4byte sUnownKAnims_11_1
+.4byte sUnownKAnims_11_2
+.4byte sUnownKAnims_11_3
+.4byte sUnownKAnims_11_4
+.4byte sUnownKAnims_11_5
+.4byte sUnownKAnims_11_6
+.4byte sUnownKAnims_11_7
+.4byte sUnownKAnims_11_8
+sUnownKAnimTable12:
+.4byte sUnownKAnims_12_1
+.4byte sUnownKAnims_12_2
+.4byte sUnownKAnims_12_3
+.4byte sUnownKAnims_12_4
+.4byte sUnownKAnims_12_5
+.4byte sUnownKAnims_12_6
+.4byte sUnownKAnims_12_7
+.4byte sUnownKAnims_12_8
+sUnownKAnimTable13:
+.4byte sUnownKAnims_13_1
+.4byte sUnownKAnims_13_2
+.4byte sUnownKAnims_13_3
+.4byte sUnownKAnims_13_4
+.4byte sUnownKAnims_13_5
+.4byte sUnownKAnims_13_6
+.4byte sUnownKAnims_13_7
+.4byte sUnownKAnims_13_8
+sAxAnimationsUnownK:
+.4byte sUnownKAnimTable1
+.4byte sUnownKAnimTable2
+.4byte sUnownKAnimTable3
+.4byte sUnownKAnimTable4
+.4byte sUnownKAnimTable5
+.4byte sUnownKAnimTable6
+.4byte sUnownKAnimTable7
+.4byte sUnownKAnimTable8
+.4byte sUnownKAnimTable9
+.4byte sUnownKAnimTable10
+.4byte sUnownKAnimTable11
+.4byte sUnownKAnimTable12
+.4byte sUnownKAnimTable13
+sAxSpritesUnownK:
+.4byte sUnownKSprites1
+.4byte sUnownKSprites2
+.4byte sUnownKSprites3
+.4byte sUnownKSprites4
+.4byte sUnownKSprites5
+.4byte sUnownKSprites6
+.4byte sUnownKSprites7
+.4byte sUnownKSprites8
+.4byte sUnownKSprites9
+.4byte sUnownKSprites10
+.4byte sUnownKSprites11
+.4byte sUnownKSprites12
+.4byte sUnownKSprites13
+.4byte sUnownKSprites14
+.4byte sUnownKSprites15
+.4byte sUnownKSprites16
+.4byte sUnownKSprites17
+sAxMainUnownK:
+ax_main sAxPosesUnownK, sAxAnimationsUnownK, 13, sAxSpritesUnownK, sAxPositionsUnownK

--- a/data/ax/unownl.inc
+++ b/data/ax/unownl.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownL
+gAxUnownL:
+ax_siro sAxMainUnownL
+sUnownLPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownLPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownLPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownLPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownLPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownLPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownLAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownLAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownLAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownLAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownLAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownLAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownLAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownLAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownLAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownLAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownLAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownLAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownLAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownLAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownLAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownLAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownLAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownLAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownLAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownLAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownLAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownLAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownLAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownLAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownLAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownLAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownLAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownLAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownLAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownLAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownLAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownLAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownLAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownLAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownLAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownLAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownLAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownLAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownLAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownLAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownLAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownLAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownLAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownLAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownLAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownLAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownLAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownLAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownLAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownLAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownLGfx1:
+.incbin "baserom.gba", 0xDD5638, 0x200
+sUnownLSprites1:
+ax_sprite sUnownLGfx1, 0x200
+ax_sprite_terminator
+sUnownLGfx2:
+.incbin "baserom.gba", 0xDD5848, 0x200
+sUnownLSprites2:
+ax_sprite sUnownLGfx2, 0x200
+ax_sprite_terminator
+sUnownLGfx3:
+.incbin "baserom.gba", 0xDD5A58, 0x200
+sUnownLSprites3:
+ax_sprite sUnownLGfx3, 0x200
+ax_sprite_terminator
+sUnownLGfx4:
+.incbin "baserom.gba", 0xDD5C68, 0x200
+sUnownLSprites4:
+ax_sprite sUnownLGfx4, 0x200
+ax_sprite_terminator
+sUnownLGfx5:
+.incbin "baserom.gba", 0xDD5E78, 0x200
+sUnownLSprites5:
+ax_sprite sUnownLGfx5, 0x200
+ax_sprite_terminator
+sUnownLGfx6:
+.incbin "baserom.gba", 0xDD6088, 0x200
+sUnownLSprites6:
+ax_sprite sUnownLGfx6, 0x200
+ax_sprite_terminator
+sUnownLGfx7:
+.incbin "baserom.gba", 0xDD6298, 0x200
+sUnownLSprites7:
+ax_sprite sUnownLGfx7, 0x200
+ax_sprite_terminator
+sUnownLGfx8:
+.incbin "baserom.gba", 0xDD64A8, 0x200
+sUnownLSprites8:
+ax_sprite sUnownLGfx8, 0x200
+ax_sprite_terminator
+sUnownLGfx9:
+.incbin "baserom.gba", 0xDD66B8, 0x200
+sUnownLSprites9:
+ax_sprite sUnownLGfx9, 0x200
+ax_sprite_terminator
+sUnownLGfx10:
+.incbin "baserom.gba", 0xDD68C8, 0x200
+sUnownLSprites10:
+ax_sprite sUnownLGfx10, 0x200
+ax_sprite_terminator
+sUnownLGfx11:
+.incbin "baserom.gba", 0xDD6AD8, 0x200
+sUnownLSprites11:
+ax_sprite sUnownLGfx11, 0x200
+ax_sprite_terminator
+sUnownLGfx12:
+.incbin "baserom.gba", 0xDD6CE8, 0x200
+sUnownLSprites12:
+ax_sprite sUnownLGfx12, 0x200
+ax_sprite_terminator
+sUnownLGfx13:
+.incbin "baserom.gba", 0xDD6EF8, 0x200
+sUnownLSprites13:
+ax_sprite sUnownLGfx13, 0x200
+ax_sprite_terminator
+sUnownLGfx14:
+.incbin "baserom.gba", 0xDD7108, 0x200
+sUnownLSprites14:
+ax_sprite sUnownLGfx14, 0x200
+ax_sprite_terminator
+sUnownLGfx15:
+.incbin "baserom.gba", 0xDD7318, 0x200
+sUnownLSprites15:
+ax_sprite sUnownLGfx15, 0x200
+ax_sprite_terminator
+sUnownLGfx16:
+.incbin "baserom.gba", 0xDD7528, 0x200
+sUnownLSprites16:
+ax_sprite sUnownLGfx16, 0x200
+ax_sprite_terminator
+sUnownLGfx17:
+.incbin "baserom.gba", 0xDD7738, 0x200
+sUnownLSprites17:
+ax_sprite sUnownLGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownL:
+.4byte sUnownLPose1
+.4byte sUnownLPose2
+.4byte sUnownLPose3
+.4byte sUnownLPose4
+.4byte sUnownLPose5
+.4byte sUnownLPose6
+.4byte sUnownLPose7
+.4byte sUnownLPose8
+.4byte sUnownLPose9
+.4byte sUnownLPose10
+.4byte sUnownLPose11
+.4byte sUnownLPose12
+.4byte sUnownLPose13
+.4byte sUnownLPose14
+.4byte sUnownLPose15
+.4byte sUnownLPose16
+.4byte sUnownLPose17
+.4byte sUnownLPose18
+.4byte sUnownLPose19
+.4byte sUnownLPose20
+.4byte sUnownLPose21
+.4byte sUnownLPose22
+.4byte sUnownLPose23
+.4byte sUnownLPose24
+.4byte sUnownLPose25
+.4byte sUnownLPose26
+.4byte sUnownLPose27
+.4byte sUnownLPose28
+.4byte sUnownLPose29
+.4byte sUnownLPose30
+.4byte sUnownLPose31
+.4byte sUnownLPose32
+.4byte sUnownLPose33
+.4byte sUnownLPose34
+.4byte sUnownLPose35
+.4byte sUnownLPose36
+.4byte sUnownLPose37
+.4byte sUnownLPose38
+.4byte sUnownLPose39
+.4byte sUnownLPose40
+.4byte sUnownLPose41
+.4byte sUnownLPose42
+.4byte sUnownLPose43
+.4byte sUnownLPose44
+.4byte sUnownLPose45
+.4byte sUnownLPose46
+.4byte sUnownLPose47
+.4byte sUnownLPose48
+.4byte sUnownLPose49
+.4byte sUnownLPose50
+.4byte sUnownLPose51
+.4byte sUnownLPose52
+.4byte sUnownLPose53
+.4byte sUnownLPose54
+.4byte sUnownLPose55
+.4byte sUnownLPose56
+.4byte sUnownLPose57
+.4byte sUnownLPose58
+.4byte sUnownLPose59
+.4byte sUnownLPose60
+.4byte sUnownLPose61
+.4byte sUnownLPose62
+.4byte sUnownLPose63
+.4byte sUnownLPose64
+.4byte sUnownLPose65
+.4byte sUnownLPose66
+.4byte sUnownLPose67
+.4byte sUnownLPose68
+.4byte sUnownLPose69
+.4byte sUnownLPose70
+.4byte sUnownLPose71
+.4byte sUnownLPose72
+.4byte sUnownLPose73
+.4byte sUnownLPose74
+.4byte sUnownLPose75
+.4byte sUnownLPose76
+.4byte sUnownLPose77
+.4byte sUnownLPose78
+.4byte sUnownLPose79
+.4byte sUnownLPose80
+.4byte sUnownLPose81
+.4byte sUnownLPose82
+.4byte sUnownLPose83
+.4byte sUnownLPose84
+.4byte sUnownLPose85
+.4byte sUnownLPose86
+.4byte sUnownLPose87
+.4byte sUnownLPose88
+.4byte sUnownLPose89
+.4byte sUnownLPose90
+.4byte sUnownLPose91
+.4byte sUnownLPose92
+.4byte sUnownLPose93
+.4byte sUnownLPose94
+.4byte sUnownLPose95
+.4byte sUnownLPose96
+.4byte sUnownLPose97
+sAxPositionsUnownL:
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte   -1,  -15, 	  -6,  -17, 	   3,   -7, 	  -2,  -10
+.2byte    0,  -15, 	  -5,  -16, 	   2,   -8, 	  -1,  -10
+.2byte   -1,  -15, 	   2,  -17, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -14, 	   4,  -17, 	  -5,   -6, 	  -1,  -10
+.2byte   -1,  -15, 	   3,  -19, 	  -6,   -4, 	  -1,  -10
+.2byte   -2,  -15, 	   0,  -19, 	   0,   -3, 	  -1,  -10
+.2byte   -1,  -15, 	  -3,  -19, 	   2,   -4, 	   0,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+.2byte   -1,  -14, 	  -6,  -18, 	   3,   -5, 	  -1,  -11
+.2byte    0,  -14, 	  -5,  -17, 	   3,   -7, 	  -1,  -10
+.2byte    1,  -14, 	  -4,  -16, 	   1,   -7, 	  -1,   -9
+.2byte    1,  -15, 	   3,  -17, 	  -4,   -7, 	  -1,  -10
+.2byte   -1,  -15, 	   4,  -18, 	  -5,   -5, 	  -1,  -10
+.2byte   -2,  -15, 	   2,  -19, 	  -5,   -4, 	  -1,   -9
+.2byte   -3,  -14, 	  -1,  -19, 	   1,   -3, 	  -1,   -9
+.2byte   -2,  -14, 	  -4,  -19, 	   3,   -4, 	  -1,  -10
+sUnownLAnimTable1:
+.4byte sUnownLAnims_1_1
+.4byte sUnownLAnims_1_2
+.4byte sUnownLAnims_1_3
+.4byte sUnownLAnims_1_4
+.4byte sUnownLAnims_1_5
+.4byte sUnownLAnims_1_6
+.4byte sUnownLAnims_1_7
+.4byte sUnownLAnims_1_8
+sUnownLAnimTable2:
+.4byte sUnownLAnims_2_1
+.4byte sUnownLAnims_2_2
+.4byte sUnownLAnims_2_3
+.4byte sUnownLAnims_2_4
+.4byte sUnownLAnims_2_5
+.4byte sUnownLAnims_2_6
+.4byte sUnownLAnims_2_7
+.4byte sUnownLAnims_2_8
+sUnownLAnimTable3:
+.4byte sUnownLAnims_3_1
+.4byte sUnownLAnims_3_2
+.4byte sUnownLAnims_3_3
+.4byte sUnownLAnims_3_4
+.4byte sUnownLAnims_3_5
+.4byte sUnownLAnims_3_6
+.4byte sUnownLAnims_3_7
+.4byte sUnownLAnims_3_8
+sUnownLAnimTable4:
+.4byte sUnownLAnims_4_1
+.4byte sUnownLAnims_4_2
+.4byte sUnownLAnims_4_3
+.4byte sUnownLAnims_4_4
+.4byte sUnownLAnims_4_5
+.4byte sUnownLAnims_4_6
+.4byte sUnownLAnims_4_7
+.4byte sUnownLAnims_4_8
+sUnownLAnimTable5:
+.4byte sUnownLAnims_5_1
+.4byte sUnownLAnims_5_2
+.4byte sUnownLAnims_5_3
+.4byte sUnownLAnims_5_4
+.4byte sUnownLAnims_5_5
+.4byte sUnownLAnims_5_6
+.4byte sUnownLAnims_5_7
+.4byte sUnownLAnims_5_8
+sUnownLAnimTable6:
+.4byte sUnownLAnims_6_1
+.4byte sUnownLAnims_6_1
+.4byte sUnownLAnims_6_1
+.4byte sUnownLAnims_6_1
+.4byte sUnownLAnims_6_1
+.4byte sUnownLAnims_6_1
+.4byte sUnownLAnims_6_1
+.4byte sUnownLAnims_6_1
+sUnownLAnimTable7:
+.4byte sUnownLAnims_7_1
+.4byte sUnownLAnims_7_2
+.4byte sUnownLAnims_7_3
+.4byte sUnownLAnims_7_4
+.4byte sUnownLAnims_7_5
+.4byte sUnownLAnims_7_6
+.4byte sUnownLAnims_7_7
+.4byte sUnownLAnims_7_8
+sUnownLAnimTable8:
+.4byte sUnownLAnims_8_1
+.4byte sUnownLAnims_8_2
+.4byte sUnownLAnims_8_3
+.4byte sUnownLAnims_8_4
+.4byte sUnownLAnims_8_5
+.4byte sUnownLAnims_8_6
+.4byte sUnownLAnims_8_7
+.4byte sUnownLAnims_8_8
+sUnownLAnimTable9:
+.4byte sUnownLAnims_9_1
+.4byte sUnownLAnims_9_2
+.4byte sUnownLAnims_9_3
+.4byte sUnownLAnims_9_4
+.4byte sUnownLAnims_9_5
+.4byte sUnownLAnims_9_6
+.4byte sUnownLAnims_9_7
+.4byte sUnownLAnims_9_8
+sUnownLAnimTable10:
+.4byte sUnownLAnims_10_1
+.4byte sUnownLAnims_10_2
+.4byte sUnownLAnims_10_3
+.4byte sUnownLAnims_10_4
+.4byte sUnownLAnims_10_5
+.4byte sUnownLAnims_10_6
+.4byte sUnownLAnims_10_7
+.4byte sUnownLAnims_10_8
+sUnownLAnimTable11:
+.4byte sUnownLAnims_11_1
+.4byte sUnownLAnims_11_2
+.4byte sUnownLAnims_11_3
+.4byte sUnownLAnims_11_4
+.4byte sUnownLAnims_11_5
+.4byte sUnownLAnims_11_6
+.4byte sUnownLAnims_11_7
+.4byte sUnownLAnims_11_8
+sUnownLAnimTable12:
+.4byte sUnownLAnims_12_1
+.4byte sUnownLAnims_12_2
+.4byte sUnownLAnims_12_3
+.4byte sUnownLAnims_12_4
+.4byte sUnownLAnims_12_5
+.4byte sUnownLAnims_12_6
+.4byte sUnownLAnims_12_7
+.4byte sUnownLAnims_12_8
+sUnownLAnimTable13:
+.4byte sUnownLAnims_13_1
+.4byte sUnownLAnims_13_2
+.4byte sUnownLAnims_13_3
+.4byte sUnownLAnims_13_4
+.4byte sUnownLAnims_13_5
+.4byte sUnownLAnims_13_6
+.4byte sUnownLAnims_13_7
+.4byte sUnownLAnims_13_8
+sAxAnimationsUnownL:
+.4byte sUnownLAnimTable1
+.4byte sUnownLAnimTable2
+.4byte sUnownLAnimTable3
+.4byte sUnownLAnimTable4
+.4byte sUnownLAnimTable5
+.4byte sUnownLAnimTable6
+.4byte sUnownLAnimTable7
+.4byte sUnownLAnimTable8
+.4byte sUnownLAnimTable9
+.4byte sUnownLAnimTable10
+.4byte sUnownLAnimTable11
+.4byte sUnownLAnimTable12
+.4byte sUnownLAnimTable13
+sAxSpritesUnownL:
+.4byte sUnownLSprites1
+.4byte sUnownLSprites2
+.4byte sUnownLSprites3
+.4byte sUnownLSprites4
+.4byte sUnownLSprites5
+.4byte sUnownLSprites6
+.4byte sUnownLSprites7
+.4byte sUnownLSprites8
+.4byte sUnownLSprites9
+.4byte sUnownLSprites10
+.4byte sUnownLSprites11
+.4byte sUnownLSprites12
+.4byte sUnownLSprites13
+.4byte sUnownLSprites14
+.4byte sUnownLSprites15
+.4byte sUnownLSprites16
+.4byte sUnownLSprites17
+sAxMainUnownL:
+ax_main sAxPosesUnownL, sAxAnimationsUnownL, 13, sAxSpritesUnownL, sAxPositionsUnownL

--- a/data/ax/unownm.inc
+++ b/data/ax/unownm.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownM
+gAxUnownM:
+ax_siro sAxMainUnownM
+sUnownMPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose2:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose3:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose4:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose6:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose7:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose8:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose10:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose11:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose12:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose14:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose15:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose16:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose18:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose19:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose20:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose22:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose23:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose24:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose26:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose27:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose28:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose30:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose31:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose32:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose34:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose35:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose36:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose38:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose39:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose40:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose42:
+ax_pose 6, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose43:
+ax_pose 7, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose44:
+ax_pose 8, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose45:
+ax_pose 9, 0x01e6, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose47:
+ax_pose 9, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose48:
+ax_pose 8, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose49:
+ax_pose 7, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose51:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose52:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose53:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose55:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose56:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose57:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose59:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose60:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose61:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose63:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose64:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose65:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose67:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose68:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose69:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose71:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose72:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose73:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose75:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose76:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose77:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose79:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose80:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose81:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose83:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose84:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose85:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose87:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose88:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose89:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose91:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownMPose92:
+ax_pose 2, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownMPose93:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownMPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownMPose95:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownMPose96:
+ax_pose 2, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownMPose97:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownMAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownMAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownMAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownMAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownMAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownMAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownMAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownMAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownMAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownMAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownMAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownMAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownMAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownMAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownMAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownMAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownMAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownMAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownMAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownMAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownMAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownMAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownMAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownMAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownMAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownMAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownMAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownMAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownMAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownMAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownMAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownMAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownMAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownMAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownMAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownMAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownMAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownMAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownMAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownMAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownMAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownMAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownMAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownMAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownMAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownMAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownMAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownMAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownMAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownMAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownMGfx1:
+.incbin "baserom.gba", 0xDDB848, 0x200
+sUnownMSprites1:
+ax_sprite sUnownMGfx1, 0x200
+ax_sprite_terminator
+sUnownMGfx2:
+.incbin "baserom.gba", 0xDDBA58, 0x200
+sUnownMSprites2:
+ax_sprite sUnownMGfx2, 0x200
+ax_sprite_terminator
+sUnownMGfx3:
+.incbin "baserom.gba", 0xDDBC68, 0x200
+sUnownMSprites3:
+ax_sprite sUnownMGfx3, 0x200
+ax_sprite_terminator
+sUnownMGfx4:
+.incbin "baserom.gba", 0xDDBE78, 0x200
+sUnownMSprites4:
+ax_sprite sUnownMGfx4, 0x200
+ax_sprite_terminator
+sUnownMGfx5:
+.incbin "baserom.gba", 0xDDC088, 0x200
+sUnownMSprites5:
+ax_sprite sUnownMGfx5, 0x200
+ax_sprite_terminator
+sUnownMGfx6:
+.incbin "baserom.gba", 0xDDC298, 0x200
+sUnownMSprites6:
+ax_sprite sUnownMGfx6, 0x200
+ax_sprite_terminator
+sUnownMGfx7:
+.incbin "baserom.gba", 0xDDC4A8, 0x200
+sUnownMSprites7:
+ax_sprite sUnownMGfx7, 0x200
+ax_sprite_terminator
+sUnownMGfx8:
+.incbin "baserom.gba", 0xDDC6B8, 0x200
+sUnownMSprites8:
+ax_sprite sUnownMGfx8, 0x200
+ax_sprite_terminator
+sUnownMGfx9:
+.incbin "baserom.gba", 0xDDC8C8, 0x200
+sUnownMSprites9:
+ax_sprite sUnownMGfx9, 0x200
+ax_sprite_terminator
+sUnownMGfx10:
+.incbin "baserom.gba", 0xDDCAD8, 0x200
+sUnownMSprites10:
+ax_sprite sUnownMGfx10, 0x200
+ax_sprite_terminator
+sUnownMGfx11:
+.incbin "baserom.gba", 0xDDCCE8, 0x200
+sUnownMSprites11:
+ax_sprite sUnownMGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownM:
+.4byte sUnownMPose1
+.4byte sUnownMPose2
+.4byte sUnownMPose3
+.4byte sUnownMPose4
+.4byte sUnownMPose5
+.4byte sUnownMPose6
+.4byte sUnownMPose7
+.4byte sUnownMPose8
+.4byte sUnownMPose9
+.4byte sUnownMPose10
+.4byte sUnownMPose11
+.4byte sUnownMPose12
+.4byte sUnownMPose13
+.4byte sUnownMPose14
+.4byte sUnownMPose15
+.4byte sUnownMPose16
+.4byte sUnownMPose17
+.4byte sUnownMPose18
+.4byte sUnownMPose19
+.4byte sUnownMPose20
+.4byte sUnownMPose21
+.4byte sUnownMPose22
+.4byte sUnownMPose23
+.4byte sUnownMPose24
+.4byte sUnownMPose25
+.4byte sUnownMPose26
+.4byte sUnownMPose27
+.4byte sUnownMPose28
+.4byte sUnownMPose29
+.4byte sUnownMPose30
+.4byte sUnownMPose31
+.4byte sUnownMPose32
+.4byte sUnownMPose33
+.4byte sUnownMPose34
+.4byte sUnownMPose35
+.4byte sUnownMPose36
+.4byte sUnownMPose37
+.4byte sUnownMPose38
+.4byte sUnownMPose39
+.4byte sUnownMPose40
+.4byte sUnownMPose41
+.4byte sUnownMPose42
+.4byte sUnownMPose43
+.4byte sUnownMPose44
+.4byte sUnownMPose45
+.4byte sUnownMPose46
+.4byte sUnownMPose47
+.4byte sUnownMPose48
+.4byte sUnownMPose49
+.4byte sUnownMPose50
+.4byte sUnownMPose51
+.4byte sUnownMPose52
+.4byte sUnownMPose53
+.4byte sUnownMPose54
+.4byte sUnownMPose55
+.4byte sUnownMPose56
+.4byte sUnownMPose57
+.4byte sUnownMPose58
+.4byte sUnownMPose59
+.4byte sUnownMPose60
+.4byte sUnownMPose61
+.4byte sUnownMPose62
+.4byte sUnownMPose63
+.4byte sUnownMPose64
+.4byte sUnownMPose65
+.4byte sUnownMPose66
+.4byte sUnownMPose67
+.4byte sUnownMPose68
+.4byte sUnownMPose69
+.4byte sUnownMPose70
+.4byte sUnownMPose71
+.4byte sUnownMPose72
+.4byte sUnownMPose73
+.4byte sUnownMPose74
+.4byte sUnownMPose75
+.4byte sUnownMPose76
+.4byte sUnownMPose77
+.4byte sUnownMPose78
+.4byte sUnownMPose79
+.4byte sUnownMPose80
+.4byte sUnownMPose81
+.4byte sUnownMPose82
+.4byte sUnownMPose83
+.4byte sUnownMPose84
+.4byte sUnownMPose85
+.4byte sUnownMPose86
+.4byte sUnownMPose87
+.4byte sUnownMPose88
+.4byte sUnownMPose89
+.4byte sUnownMPose90
+.4byte sUnownMPose91
+.4byte sUnownMPose92
+.4byte sUnownMPose93
+.4byte sUnownMPose94
+.4byte sUnownMPose95
+.4byte sUnownMPose96
+.4byte sUnownMPose97
+sAxPositionsUnownM:
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -11, 	   3,  -17, 	  -7,  -16, 	  -1,  -12
+.2byte    1,  -11, 	   1,  -17, 	  -6,  -16, 	  -2,  -12
+.2byte    1,  -12, 	  -6,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -1,  -12, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	   4,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte   -3,  -11, 	  -3,  -17, 	   4,  -16, 	   0,  -12
+.2byte   -3,  -11, 	  -5,  -17, 	   5,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -10, 	  -7,  -16, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -10, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte    1,  -10, 	   2,  -17, 	  -5,  -16, 	  -1,  -12
+.2byte    0,  -12, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+.2byte   -1,  -11, 	   5,  -16, 	  -7,  -16, 	  -1,  -12
+.2byte   -2,  -12, 	   3,  -17, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -4,  -17, 	   3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -5,  -17, 	   4,  -16, 	  -1,  -12
+sUnownMAnimTable1:
+.4byte sUnownMAnims_1_1
+.4byte sUnownMAnims_1_2
+.4byte sUnownMAnims_1_3
+.4byte sUnownMAnims_1_4
+.4byte sUnownMAnims_1_5
+.4byte sUnownMAnims_1_6
+.4byte sUnownMAnims_1_7
+.4byte sUnownMAnims_1_8
+sUnownMAnimTable2:
+.4byte sUnownMAnims_2_1
+.4byte sUnownMAnims_2_2
+.4byte sUnownMAnims_2_3
+.4byte sUnownMAnims_2_4
+.4byte sUnownMAnims_2_5
+.4byte sUnownMAnims_2_6
+.4byte sUnownMAnims_2_7
+.4byte sUnownMAnims_2_8
+sUnownMAnimTable3:
+.4byte sUnownMAnims_3_1
+.4byte sUnownMAnims_3_2
+.4byte sUnownMAnims_3_3
+.4byte sUnownMAnims_3_4
+.4byte sUnownMAnims_3_5
+.4byte sUnownMAnims_3_6
+.4byte sUnownMAnims_3_7
+.4byte sUnownMAnims_3_8
+sUnownMAnimTable4:
+.4byte sUnownMAnims_4_1
+.4byte sUnownMAnims_4_2
+.4byte sUnownMAnims_4_3
+.4byte sUnownMAnims_4_4
+.4byte sUnownMAnims_4_5
+.4byte sUnownMAnims_4_6
+.4byte sUnownMAnims_4_7
+.4byte sUnownMAnims_4_8
+sUnownMAnimTable5:
+.4byte sUnownMAnims_5_1
+.4byte sUnownMAnims_5_2
+.4byte sUnownMAnims_5_3
+.4byte sUnownMAnims_5_4
+.4byte sUnownMAnims_5_5
+.4byte sUnownMAnims_5_6
+.4byte sUnownMAnims_5_7
+.4byte sUnownMAnims_5_8
+sUnownMAnimTable6:
+.4byte sUnownMAnims_6_1
+.4byte sUnownMAnims_6_1
+.4byte sUnownMAnims_6_1
+.4byte sUnownMAnims_6_1
+.4byte sUnownMAnims_6_1
+.4byte sUnownMAnims_6_1
+.4byte sUnownMAnims_6_1
+.4byte sUnownMAnims_6_1
+sUnownMAnimTable7:
+.4byte sUnownMAnims_7_1
+.4byte sUnownMAnims_7_2
+.4byte sUnownMAnims_7_3
+.4byte sUnownMAnims_7_4
+.4byte sUnownMAnims_7_5
+.4byte sUnownMAnims_7_6
+.4byte sUnownMAnims_7_7
+.4byte sUnownMAnims_7_8
+sUnownMAnimTable8:
+.4byte sUnownMAnims_8_1
+.4byte sUnownMAnims_8_2
+.4byte sUnownMAnims_8_3
+.4byte sUnownMAnims_8_4
+.4byte sUnownMAnims_8_5
+.4byte sUnownMAnims_8_6
+.4byte sUnownMAnims_8_7
+.4byte sUnownMAnims_8_8
+sUnownMAnimTable9:
+.4byte sUnownMAnims_9_1
+.4byte sUnownMAnims_9_2
+.4byte sUnownMAnims_9_3
+.4byte sUnownMAnims_9_4
+.4byte sUnownMAnims_9_5
+.4byte sUnownMAnims_9_6
+.4byte sUnownMAnims_9_7
+.4byte sUnownMAnims_9_8
+sUnownMAnimTable10:
+.4byte sUnownMAnims_10_1
+.4byte sUnownMAnims_10_2
+.4byte sUnownMAnims_10_3
+.4byte sUnownMAnims_10_4
+.4byte sUnownMAnims_10_5
+.4byte sUnownMAnims_10_6
+.4byte sUnownMAnims_10_7
+.4byte sUnownMAnims_10_8
+sUnownMAnimTable11:
+.4byte sUnownMAnims_11_1
+.4byte sUnownMAnims_11_2
+.4byte sUnownMAnims_11_3
+.4byte sUnownMAnims_11_4
+.4byte sUnownMAnims_11_5
+.4byte sUnownMAnims_11_6
+.4byte sUnownMAnims_11_7
+.4byte sUnownMAnims_11_8
+sUnownMAnimTable12:
+.4byte sUnownMAnims_12_1
+.4byte sUnownMAnims_12_2
+.4byte sUnownMAnims_12_3
+.4byte sUnownMAnims_12_4
+.4byte sUnownMAnims_12_5
+.4byte sUnownMAnims_12_6
+.4byte sUnownMAnims_12_7
+.4byte sUnownMAnims_12_8
+sUnownMAnimTable13:
+.4byte sUnownMAnims_13_1
+.4byte sUnownMAnims_13_2
+.4byte sUnownMAnims_13_3
+.4byte sUnownMAnims_13_4
+.4byte sUnownMAnims_13_5
+.4byte sUnownMAnims_13_6
+.4byte sUnownMAnims_13_7
+.4byte sUnownMAnims_13_8
+sAxAnimationsUnownM:
+.4byte sUnownMAnimTable1
+.4byte sUnownMAnimTable2
+.4byte sUnownMAnimTable3
+.4byte sUnownMAnimTable4
+.4byte sUnownMAnimTable5
+.4byte sUnownMAnimTable6
+.4byte sUnownMAnimTable7
+.4byte sUnownMAnimTable8
+.4byte sUnownMAnimTable9
+.4byte sUnownMAnimTable10
+.4byte sUnownMAnimTable11
+.4byte sUnownMAnimTable12
+.4byte sUnownMAnimTable13
+sAxSpritesUnownM:
+.4byte sUnownMSprites1
+.4byte sUnownMSprites2
+.4byte sUnownMSprites3
+.4byte sUnownMSprites4
+.4byte sUnownMSprites5
+.4byte sUnownMSprites6
+.4byte sUnownMSprites7
+.4byte sUnownMSprites8
+.4byte sUnownMSprites9
+.4byte sUnownMSprites10
+.4byte sUnownMSprites11
+sAxMainUnownM:
+ax_main sAxPosesUnownM, sAxAnimationsUnownM, 13, sAxSpritesUnownM, sAxPositionsUnownM

--- a/data/ax/unownn.inc
+++ b/data/ax/unownn.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownN
+gAxUnownN:
+ax_siro sAxMainUnownN
+sUnownNPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose3:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose4:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose10:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose11:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose12:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose18:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose19:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose20:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose26:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose27:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose28:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose34:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose35:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose36:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose43:
+ax_pose 10, 0x01e5, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownNPose44:
+ax_pose 11, 0x01e5, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownNPose45:
+ax_pose 12, 0x01e5, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownNPose46:
+ax_pose 13, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose51:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose52:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose53:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose59:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose60:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose61:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose67:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose68:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose69:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose75:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose76:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose77:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose83:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose84:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose85:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose91:
+ax_pose 1, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose92:
+ax_pose 2, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose93:
+ax_pose 3, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownNPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownNPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownNAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownNAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownNAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownNAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownNAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownNAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownNAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownNAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownNAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownNAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownNAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownNAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownNAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownNAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownNAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownNAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownNAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownNAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownNAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownNAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownNAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownNAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownNAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownNAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownNAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownNAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownNAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownNAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownNAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownNAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownNAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownNAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownNAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownNAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownNAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownNAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownNAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownNAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownNAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownNAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownNAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownNAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownNAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownNAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownNAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownNAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownNAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownNAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownNAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownNAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownNGfx1:
+.incbin "baserom.gba", 0xDE0DE0, 0x200
+sUnownNSprites1:
+ax_sprite sUnownNGfx1, 0x200
+ax_sprite_terminator
+sUnownNGfx2:
+.incbin "baserom.gba", 0xDE0FF0, 0x200
+sUnownNSprites2:
+ax_sprite sUnownNGfx2, 0x200
+ax_sprite_terminator
+sUnownNGfx3:
+.incbin "baserom.gba", 0xDE1200, 0x200
+sUnownNSprites3:
+ax_sprite sUnownNGfx3, 0x200
+ax_sprite_terminator
+sUnownNGfx4:
+.incbin "baserom.gba", 0xDE1410, 0x200
+sUnownNSprites4:
+ax_sprite sUnownNGfx4, 0x200
+ax_sprite_terminator
+sUnownNGfx5:
+.incbin "baserom.gba", 0xDE1620, 0x200
+sUnownNSprites5:
+ax_sprite sUnownNGfx5, 0x200
+ax_sprite_terminator
+sUnownNGfx6:
+.incbin "baserom.gba", 0xDE1830, 0x200
+sUnownNSprites6:
+ax_sprite sUnownNGfx6, 0x200
+ax_sprite_terminator
+sUnownNGfx7:
+.incbin "baserom.gba", 0xDE1A40, 0x200
+sUnownNSprites7:
+ax_sprite sUnownNGfx7, 0x200
+ax_sprite_terminator
+sUnownNGfx8:
+.incbin "baserom.gba", 0xDE1C50, 0x200
+sUnownNSprites8:
+ax_sprite sUnownNGfx8, 0x200
+ax_sprite_terminator
+sUnownNGfx9:
+.incbin "baserom.gba", 0xDE1E60, 0x200
+sUnownNSprites9:
+ax_sprite sUnownNGfx9, 0x200
+ax_sprite_terminator
+sUnownNGfx10:
+.incbin "baserom.gba", 0xDE2070, 0x200
+sUnownNSprites10:
+ax_sprite sUnownNGfx10, 0x200
+ax_sprite_terminator
+sUnownNGfx11:
+.incbin "baserom.gba", 0xDE2280, 0x200
+sUnownNSprites11:
+ax_sprite sUnownNGfx11, 0x200
+ax_sprite_terminator
+sUnownNGfx12:
+.incbin "baserom.gba", 0xDE2490, 0x200
+sUnownNSprites12:
+ax_sprite sUnownNGfx12, 0x200
+ax_sprite_terminator
+sUnownNGfx13:
+.incbin "baserom.gba", 0xDE26A0, 0x200
+sUnownNSprites13:
+ax_sprite sUnownNGfx13, 0x200
+ax_sprite_terminator
+sUnownNGfx14:
+.incbin "baserom.gba", 0xDE28B0, 0x200
+sUnownNSprites14:
+ax_sprite sUnownNGfx14, 0x200
+ax_sprite_terminator
+sUnownNGfx15:
+.incbin "baserom.gba", 0xDE2AC0, 0x200
+sUnownNSprites15:
+ax_sprite sUnownNGfx15, 0x200
+ax_sprite_terminator
+sUnownNGfx16:
+.incbin "baserom.gba", 0xDE2CD0, 0x200
+sUnownNSprites16:
+ax_sprite sUnownNGfx16, 0x200
+ax_sprite_terminator
+sUnownNGfx17:
+.incbin "baserom.gba", 0xDE2EE0, 0x200
+sUnownNSprites17:
+ax_sprite sUnownNGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownN:
+.4byte sUnownNPose1
+.4byte sUnownNPose2
+.4byte sUnownNPose3
+.4byte sUnownNPose4
+.4byte sUnownNPose5
+.4byte sUnownNPose6
+.4byte sUnownNPose7
+.4byte sUnownNPose8
+.4byte sUnownNPose9
+.4byte sUnownNPose10
+.4byte sUnownNPose11
+.4byte sUnownNPose12
+.4byte sUnownNPose13
+.4byte sUnownNPose14
+.4byte sUnownNPose15
+.4byte sUnownNPose16
+.4byte sUnownNPose17
+.4byte sUnownNPose18
+.4byte sUnownNPose19
+.4byte sUnownNPose20
+.4byte sUnownNPose21
+.4byte sUnownNPose22
+.4byte sUnownNPose23
+.4byte sUnownNPose24
+.4byte sUnownNPose25
+.4byte sUnownNPose26
+.4byte sUnownNPose27
+.4byte sUnownNPose28
+.4byte sUnownNPose29
+.4byte sUnownNPose30
+.4byte sUnownNPose31
+.4byte sUnownNPose32
+.4byte sUnownNPose33
+.4byte sUnownNPose34
+.4byte sUnownNPose35
+.4byte sUnownNPose36
+.4byte sUnownNPose37
+.4byte sUnownNPose38
+.4byte sUnownNPose39
+.4byte sUnownNPose40
+.4byte sUnownNPose41
+.4byte sUnownNPose42
+.4byte sUnownNPose43
+.4byte sUnownNPose44
+.4byte sUnownNPose45
+.4byte sUnownNPose46
+.4byte sUnownNPose47
+.4byte sUnownNPose48
+.4byte sUnownNPose49
+.4byte sUnownNPose50
+.4byte sUnownNPose51
+.4byte sUnownNPose52
+.4byte sUnownNPose53
+.4byte sUnownNPose54
+.4byte sUnownNPose55
+.4byte sUnownNPose56
+.4byte sUnownNPose57
+.4byte sUnownNPose58
+.4byte sUnownNPose59
+.4byte sUnownNPose60
+.4byte sUnownNPose61
+.4byte sUnownNPose62
+.4byte sUnownNPose63
+.4byte sUnownNPose64
+.4byte sUnownNPose65
+.4byte sUnownNPose66
+.4byte sUnownNPose67
+.4byte sUnownNPose68
+.4byte sUnownNPose69
+.4byte sUnownNPose70
+.4byte sUnownNPose71
+.4byte sUnownNPose72
+.4byte sUnownNPose73
+.4byte sUnownNPose74
+.4byte sUnownNPose75
+.4byte sUnownNPose76
+.4byte sUnownNPose77
+.4byte sUnownNPose78
+.4byte sUnownNPose79
+.4byte sUnownNPose80
+.4byte sUnownNPose81
+.4byte sUnownNPose82
+.4byte sUnownNPose83
+.4byte sUnownNPose84
+.4byte sUnownNPose85
+.4byte sUnownNPose86
+.4byte sUnownNPose87
+.4byte sUnownNPose88
+.4byte sUnownNPose89
+.4byte sUnownNPose90
+.4byte sUnownNPose91
+.4byte sUnownNPose92
+.4byte sUnownNPose93
+.4byte sUnownNPose94
+.4byte sUnownNPose95
+.4byte sUnownNPose96
+.4byte sUnownNPose97
+sAxPositionsUnownN:
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -13, 	  -6,   -6, 	   3,  -17, 	  -1,  -11
+.2byte    1,  -13, 	  -4,   -5, 	   1,  -17, 	  -1,  -11
+.2byte    0,  -14, 	   6,   -6, 	  -8,  -17, 	  -1,  -11
+.2byte   -2,  -13, 	   6,   -9, 	 -10,  -17, 	  -2,  -11
+.2byte   -2,  -14, 	   4,   -9, 	  -6,  -16, 	   0,  -12
+.2byte   -3,  -13, 	  -5,   -9, 	   4,  -15, 	   0,  -11
+.2byte   -2,  -13, 	  -8,   -9, 	   6,  -17, 	   0,  -12
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -9,   -7, 	   7,  -18, 	  -1,  -11
+.2byte    0,  -12, 	  -7,   -6, 	   5,  -16, 	  -1,  -11
+.2byte    1,  -12, 	  -5,   -5, 	   2,  -18, 	  -1,  -11
+.2byte    0,  -13, 	   5,   -7, 	  -7,  -17, 	   0,  -11
+.2byte   -2,  -13, 	   6,   -8, 	 -10,  -17, 	  -2,  -12
+.2byte   -2,  -13, 	   5,   -9, 	  -7,  -17, 	  -1,  -11
+.2byte   -3,  -12, 	  -3,   -9, 	   3,  -15, 	  -1,  -11
+.2byte   -2,  -12, 	  -7,   -9, 	   5,  -16, 	  -1,  -11
+sUnownNAnimTable1:
+.4byte sUnownNAnims_1_1
+.4byte sUnownNAnims_1_2
+.4byte sUnownNAnims_1_3
+.4byte sUnownNAnims_1_4
+.4byte sUnownNAnims_1_5
+.4byte sUnownNAnims_1_6
+.4byte sUnownNAnims_1_7
+.4byte sUnownNAnims_1_8
+sUnownNAnimTable2:
+.4byte sUnownNAnims_2_1
+.4byte sUnownNAnims_2_2
+.4byte sUnownNAnims_2_3
+.4byte sUnownNAnims_2_4
+.4byte sUnownNAnims_2_5
+.4byte sUnownNAnims_2_6
+.4byte sUnownNAnims_2_7
+.4byte sUnownNAnims_2_8
+sUnownNAnimTable3:
+.4byte sUnownNAnims_3_1
+.4byte sUnownNAnims_3_2
+.4byte sUnownNAnims_3_3
+.4byte sUnownNAnims_3_4
+.4byte sUnownNAnims_3_5
+.4byte sUnownNAnims_3_6
+.4byte sUnownNAnims_3_7
+.4byte sUnownNAnims_3_8
+sUnownNAnimTable4:
+.4byte sUnownNAnims_4_1
+.4byte sUnownNAnims_4_2
+.4byte sUnownNAnims_4_3
+.4byte sUnownNAnims_4_4
+.4byte sUnownNAnims_4_5
+.4byte sUnownNAnims_4_6
+.4byte sUnownNAnims_4_7
+.4byte sUnownNAnims_4_8
+sUnownNAnimTable5:
+.4byte sUnownNAnims_5_1
+.4byte sUnownNAnims_5_2
+.4byte sUnownNAnims_5_3
+.4byte sUnownNAnims_5_4
+.4byte sUnownNAnims_5_5
+.4byte sUnownNAnims_5_6
+.4byte sUnownNAnims_5_7
+.4byte sUnownNAnims_5_8
+sUnownNAnimTable6:
+.4byte sUnownNAnims_6_1
+.4byte sUnownNAnims_6_1
+.4byte sUnownNAnims_6_1
+.4byte sUnownNAnims_6_1
+.4byte sUnownNAnims_6_1
+.4byte sUnownNAnims_6_1
+.4byte sUnownNAnims_6_1
+.4byte sUnownNAnims_6_1
+sUnownNAnimTable7:
+.4byte sUnownNAnims_7_1
+.4byte sUnownNAnims_7_2
+.4byte sUnownNAnims_7_3
+.4byte sUnownNAnims_7_4
+.4byte sUnownNAnims_7_5
+.4byte sUnownNAnims_7_6
+.4byte sUnownNAnims_7_7
+.4byte sUnownNAnims_7_8
+sUnownNAnimTable8:
+.4byte sUnownNAnims_8_1
+.4byte sUnownNAnims_8_2
+.4byte sUnownNAnims_8_3
+.4byte sUnownNAnims_8_4
+.4byte sUnownNAnims_8_5
+.4byte sUnownNAnims_8_6
+.4byte sUnownNAnims_8_7
+.4byte sUnownNAnims_8_8
+sUnownNAnimTable9:
+.4byte sUnownNAnims_9_1
+.4byte sUnownNAnims_9_2
+.4byte sUnownNAnims_9_3
+.4byte sUnownNAnims_9_4
+.4byte sUnownNAnims_9_5
+.4byte sUnownNAnims_9_6
+.4byte sUnownNAnims_9_7
+.4byte sUnownNAnims_9_8
+sUnownNAnimTable10:
+.4byte sUnownNAnims_10_1
+.4byte sUnownNAnims_10_2
+.4byte sUnownNAnims_10_3
+.4byte sUnownNAnims_10_4
+.4byte sUnownNAnims_10_5
+.4byte sUnownNAnims_10_6
+.4byte sUnownNAnims_10_7
+.4byte sUnownNAnims_10_8
+sUnownNAnimTable11:
+.4byte sUnownNAnims_11_1
+.4byte sUnownNAnims_11_2
+.4byte sUnownNAnims_11_3
+.4byte sUnownNAnims_11_4
+.4byte sUnownNAnims_11_5
+.4byte sUnownNAnims_11_6
+.4byte sUnownNAnims_11_7
+.4byte sUnownNAnims_11_8
+sUnownNAnimTable12:
+.4byte sUnownNAnims_12_1
+.4byte sUnownNAnims_12_2
+.4byte sUnownNAnims_12_3
+.4byte sUnownNAnims_12_4
+.4byte sUnownNAnims_12_5
+.4byte sUnownNAnims_12_6
+.4byte sUnownNAnims_12_7
+.4byte sUnownNAnims_12_8
+sUnownNAnimTable13:
+.4byte sUnownNAnims_13_1
+.4byte sUnownNAnims_13_2
+.4byte sUnownNAnims_13_3
+.4byte sUnownNAnims_13_4
+.4byte sUnownNAnims_13_5
+.4byte sUnownNAnims_13_6
+.4byte sUnownNAnims_13_7
+.4byte sUnownNAnims_13_8
+sAxAnimationsUnownN:
+.4byte sUnownNAnimTable1
+.4byte sUnownNAnimTable2
+.4byte sUnownNAnimTable3
+.4byte sUnownNAnimTable4
+.4byte sUnownNAnimTable5
+.4byte sUnownNAnimTable6
+.4byte sUnownNAnimTable7
+.4byte sUnownNAnimTable8
+.4byte sUnownNAnimTable9
+.4byte sUnownNAnimTable10
+.4byte sUnownNAnimTable11
+.4byte sUnownNAnimTable12
+.4byte sUnownNAnimTable13
+sAxSpritesUnownN:
+.4byte sUnownNSprites1
+.4byte sUnownNSprites2
+.4byte sUnownNSprites3
+.4byte sUnownNSprites4
+.4byte sUnownNSprites5
+.4byte sUnownNSprites6
+.4byte sUnownNSprites7
+.4byte sUnownNSprites8
+.4byte sUnownNSprites9
+.4byte sUnownNSprites10
+.4byte sUnownNSprites11
+.4byte sUnownNSprites12
+.4byte sUnownNSprites13
+.4byte sUnownNSprites14
+.4byte sUnownNSprites15
+.4byte sUnownNSprites16
+.4byte sUnownNSprites17
+sAxMainUnownN:
+ax_main sAxPosesUnownN, sAxAnimationsUnownN, 13, sAxSpritesUnownN, sAxPositionsUnownN

--- a/data/ax/unowno.inc
+++ b/data/ax/unowno.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownO
+gAxUnownO:
+ax_siro sAxMainUnownO
+sUnownOPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose2:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose3:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose4:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose6:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose7:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose8:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose10:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose11:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose12:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose14:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose15:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose16:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose18:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose19:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose20:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose22:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose23:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose24:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose26:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose27:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose28:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose30:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose31:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose32:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose34:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose35:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose36:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose38:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose39:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose40:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose42:
+ax_pose 6, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose43:
+ax_pose 7, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose44:
+ax_pose 8, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose45:
+ax_pose 9, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose47:
+ax_pose 9, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose48:
+ax_pose 8, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose49:
+ax_pose 7, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose51:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose52:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose53:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose55:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose56:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose57:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose59:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose60:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose61:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose63:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose64:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose65:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose67:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose68:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose69:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose71:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose72:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose73:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose75:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose76:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose77:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose79:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose80:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose81:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose83:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose84:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose85:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose87:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose88:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose89:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose91:
+ax_pose 1, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose92:
+ax_pose 2, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose93:
+ax_pose 3, 0x01e7, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownOPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownOPose95:
+ax_pose 3, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose96:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownOPose97:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownOAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownOAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownOAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownOAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownOAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownOAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownOAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownOAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownOAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownOAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownOAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownOAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownOAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownOAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownOAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownOAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownOAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownOAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownOAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownOAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownOAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownOAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownOAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownOAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownOAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownOAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownOAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownOAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownOAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownOAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownOAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownOAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownOAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownOAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownOAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownOAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownOAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownOAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownOAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownOAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownOAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownOAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownOAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownOAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownOAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownOAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownOAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownOAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownOAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownOAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownOGfx1:
+.incbin "baserom.gba", 0xDE6FF0, 0x200
+sUnownOSprites1:
+ax_sprite sUnownOGfx1, 0x200
+ax_sprite_terminator
+sUnownOGfx2:
+.incbin "baserom.gba", 0xDE7200, 0x200
+sUnownOSprites2:
+ax_sprite sUnownOGfx2, 0x200
+ax_sprite_terminator
+sUnownOGfx3:
+.incbin "baserom.gba", 0xDE7410, 0x200
+sUnownOSprites3:
+ax_sprite sUnownOGfx3, 0x200
+ax_sprite_terminator
+sUnownOGfx4:
+.incbin "baserom.gba", 0xDE7620, 0x200
+sUnownOSprites4:
+ax_sprite sUnownOGfx4, 0x200
+ax_sprite_terminator
+sUnownOGfx5:
+.incbin "baserom.gba", 0xDE7830, 0x200
+sUnownOSprites5:
+ax_sprite sUnownOGfx5, 0x200
+ax_sprite_terminator
+sUnownOGfx6:
+.incbin "baserom.gba", 0xDE7A40, 0x200
+sUnownOSprites6:
+ax_sprite sUnownOGfx6, 0x200
+ax_sprite_terminator
+sUnownOGfx7:
+.incbin "baserom.gba", 0xDE7C50, 0x200
+sUnownOSprites7:
+ax_sprite sUnownOGfx7, 0x200
+ax_sprite_terminator
+sUnownOGfx8:
+.incbin "baserom.gba", 0xDE7E60, 0x200
+sUnownOSprites8:
+ax_sprite sUnownOGfx8, 0x200
+ax_sprite_terminator
+sUnownOGfx9:
+.incbin "baserom.gba", 0xDE8070, 0x200
+sUnownOSprites9:
+ax_sprite sUnownOGfx9, 0x200
+ax_sprite_terminator
+sUnownOGfx10:
+.incbin "baserom.gba", 0xDE8280, 0x200
+sUnownOSprites10:
+ax_sprite sUnownOGfx10, 0x200
+ax_sprite_terminator
+sUnownOGfx11:
+.incbin "baserom.gba", 0xDE8490, 0x200
+sUnownOSprites11:
+ax_sprite sUnownOGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownO:
+.4byte sUnownOPose1
+.4byte sUnownOPose2
+.4byte sUnownOPose3
+.4byte sUnownOPose4
+.4byte sUnownOPose5
+.4byte sUnownOPose6
+.4byte sUnownOPose7
+.4byte sUnownOPose8
+.4byte sUnownOPose9
+.4byte sUnownOPose10
+.4byte sUnownOPose11
+.4byte sUnownOPose12
+.4byte sUnownOPose13
+.4byte sUnownOPose14
+.4byte sUnownOPose15
+.4byte sUnownOPose16
+.4byte sUnownOPose17
+.4byte sUnownOPose18
+.4byte sUnownOPose19
+.4byte sUnownOPose20
+.4byte sUnownOPose21
+.4byte sUnownOPose22
+.4byte sUnownOPose23
+.4byte sUnownOPose24
+.4byte sUnownOPose25
+.4byte sUnownOPose26
+.4byte sUnownOPose27
+.4byte sUnownOPose28
+.4byte sUnownOPose29
+.4byte sUnownOPose30
+.4byte sUnownOPose31
+.4byte sUnownOPose32
+.4byte sUnownOPose33
+.4byte sUnownOPose34
+.4byte sUnownOPose35
+.4byte sUnownOPose36
+.4byte sUnownOPose37
+.4byte sUnownOPose38
+.4byte sUnownOPose39
+.4byte sUnownOPose40
+.4byte sUnownOPose41
+.4byte sUnownOPose42
+.4byte sUnownOPose43
+.4byte sUnownOPose44
+.4byte sUnownOPose45
+.4byte sUnownOPose46
+.4byte sUnownOPose47
+.4byte sUnownOPose48
+.4byte sUnownOPose49
+.4byte sUnownOPose50
+.4byte sUnownOPose51
+.4byte sUnownOPose52
+.4byte sUnownOPose53
+.4byte sUnownOPose54
+.4byte sUnownOPose55
+.4byte sUnownOPose56
+.4byte sUnownOPose57
+.4byte sUnownOPose58
+.4byte sUnownOPose59
+.4byte sUnownOPose60
+.4byte sUnownOPose61
+.4byte sUnownOPose62
+.4byte sUnownOPose63
+.4byte sUnownOPose64
+.4byte sUnownOPose65
+.4byte sUnownOPose66
+.4byte sUnownOPose67
+.4byte sUnownOPose68
+.4byte sUnownOPose69
+.4byte sUnownOPose70
+.4byte sUnownOPose71
+.4byte sUnownOPose72
+.4byte sUnownOPose73
+.4byte sUnownOPose74
+.4byte sUnownOPose75
+.4byte sUnownOPose76
+.4byte sUnownOPose77
+.4byte sUnownOPose78
+.4byte sUnownOPose79
+.4byte sUnownOPose80
+.4byte sUnownOPose81
+.4byte sUnownOPose82
+.4byte sUnownOPose83
+.4byte sUnownOPose84
+.4byte sUnownOPose85
+.4byte sUnownOPose86
+.4byte sUnownOPose87
+.4byte sUnownOPose88
+.4byte sUnownOPose89
+.4byte sUnownOPose90
+.4byte sUnownOPose91
+.4byte sUnownOPose92
+.4byte sUnownOPose93
+.4byte sUnownOPose94
+.4byte sUnownOPose95
+.4byte sUnownOPose96
+.4byte sUnownOPose97
+sAxPositionsUnownO:
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -10, 	  -1,  -11
+.2byte    0,  -13, 	   1,  -14, 	  -5,  -11, 	  -2,  -11
+.2byte    0,  -13, 	  -6,  -11, 	   4,  -13, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -11, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -11, 	  -6,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	  -3,  -14, 	   3,  -11, 	   0,  -11
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+.2byte   -1,  -12, 	  -8,  -12, 	   6,  -12, 	  -1,  -11
+.2byte    0,  -12, 	   4,  -14, 	  -6,  -11, 	  -1,  -12
+.2byte    1,  -12, 	   2,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -13, 	  -6,  -13, 	   4,  -10, 	  -1,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -8,  -12, 	  -1,  -11
+.2byte   -2,  -13, 	   4,  -13, 	  -6,  -10, 	  -1,  -11
+.2byte   -3,  -12, 	  -4,  -14, 	   3,  -10, 	  -1,  -11
+.2byte   -2,  -12, 	  -6,  -14, 	   4,  -11, 	  -1,  -12
+sUnownOAnimTable1:
+.4byte sUnownOAnims_1_1
+.4byte sUnownOAnims_1_2
+.4byte sUnownOAnims_1_3
+.4byte sUnownOAnims_1_4
+.4byte sUnownOAnims_1_5
+.4byte sUnownOAnims_1_6
+.4byte sUnownOAnims_1_7
+.4byte sUnownOAnims_1_8
+sUnownOAnimTable2:
+.4byte sUnownOAnims_2_1
+.4byte sUnownOAnims_2_2
+.4byte sUnownOAnims_2_3
+.4byte sUnownOAnims_2_4
+.4byte sUnownOAnims_2_5
+.4byte sUnownOAnims_2_6
+.4byte sUnownOAnims_2_7
+.4byte sUnownOAnims_2_8
+sUnownOAnimTable3:
+.4byte sUnownOAnims_3_1
+.4byte sUnownOAnims_3_2
+.4byte sUnownOAnims_3_3
+.4byte sUnownOAnims_3_4
+.4byte sUnownOAnims_3_5
+.4byte sUnownOAnims_3_6
+.4byte sUnownOAnims_3_7
+.4byte sUnownOAnims_3_8
+sUnownOAnimTable4:
+.4byte sUnownOAnims_4_1
+.4byte sUnownOAnims_4_2
+.4byte sUnownOAnims_4_3
+.4byte sUnownOAnims_4_4
+.4byte sUnownOAnims_4_5
+.4byte sUnownOAnims_4_6
+.4byte sUnownOAnims_4_7
+.4byte sUnownOAnims_4_8
+sUnownOAnimTable5:
+.4byte sUnownOAnims_5_1
+.4byte sUnownOAnims_5_2
+.4byte sUnownOAnims_5_3
+.4byte sUnownOAnims_5_4
+.4byte sUnownOAnims_5_5
+.4byte sUnownOAnims_5_6
+.4byte sUnownOAnims_5_7
+.4byte sUnownOAnims_5_8
+sUnownOAnimTable6:
+.4byte sUnownOAnims_6_1
+.4byte sUnownOAnims_6_1
+.4byte sUnownOAnims_6_1
+.4byte sUnownOAnims_6_1
+.4byte sUnownOAnims_6_1
+.4byte sUnownOAnims_6_1
+.4byte sUnownOAnims_6_1
+.4byte sUnownOAnims_6_1
+sUnownOAnimTable7:
+.4byte sUnownOAnims_7_1
+.4byte sUnownOAnims_7_2
+.4byte sUnownOAnims_7_3
+.4byte sUnownOAnims_7_4
+.4byte sUnownOAnims_7_5
+.4byte sUnownOAnims_7_6
+.4byte sUnownOAnims_7_7
+.4byte sUnownOAnims_7_8
+sUnownOAnimTable8:
+.4byte sUnownOAnims_8_1
+.4byte sUnownOAnims_8_2
+.4byte sUnownOAnims_8_3
+.4byte sUnownOAnims_8_4
+.4byte sUnownOAnims_8_5
+.4byte sUnownOAnims_8_6
+.4byte sUnownOAnims_8_7
+.4byte sUnownOAnims_8_8
+sUnownOAnimTable9:
+.4byte sUnownOAnims_9_1
+.4byte sUnownOAnims_9_2
+.4byte sUnownOAnims_9_3
+.4byte sUnownOAnims_9_4
+.4byte sUnownOAnims_9_5
+.4byte sUnownOAnims_9_6
+.4byte sUnownOAnims_9_7
+.4byte sUnownOAnims_9_8
+sUnownOAnimTable10:
+.4byte sUnownOAnims_10_1
+.4byte sUnownOAnims_10_2
+.4byte sUnownOAnims_10_3
+.4byte sUnownOAnims_10_4
+.4byte sUnownOAnims_10_5
+.4byte sUnownOAnims_10_6
+.4byte sUnownOAnims_10_7
+.4byte sUnownOAnims_10_8
+sUnownOAnimTable11:
+.4byte sUnownOAnims_11_1
+.4byte sUnownOAnims_11_2
+.4byte sUnownOAnims_11_3
+.4byte sUnownOAnims_11_4
+.4byte sUnownOAnims_11_5
+.4byte sUnownOAnims_11_6
+.4byte sUnownOAnims_11_7
+.4byte sUnownOAnims_11_8
+sUnownOAnimTable12:
+.4byte sUnownOAnims_12_1
+.4byte sUnownOAnims_12_2
+.4byte sUnownOAnims_12_3
+.4byte sUnownOAnims_12_4
+.4byte sUnownOAnims_12_5
+.4byte sUnownOAnims_12_6
+.4byte sUnownOAnims_12_7
+.4byte sUnownOAnims_12_8
+sUnownOAnimTable13:
+.4byte sUnownOAnims_13_1
+.4byte sUnownOAnims_13_2
+.4byte sUnownOAnims_13_3
+.4byte sUnownOAnims_13_4
+.4byte sUnownOAnims_13_5
+.4byte sUnownOAnims_13_6
+.4byte sUnownOAnims_13_7
+.4byte sUnownOAnims_13_8
+sAxAnimationsUnownO:
+.4byte sUnownOAnimTable1
+.4byte sUnownOAnimTable2
+.4byte sUnownOAnimTable3
+.4byte sUnownOAnimTable4
+.4byte sUnownOAnimTable5
+.4byte sUnownOAnimTable6
+.4byte sUnownOAnimTable7
+.4byte sUnownOAnimTable8
+.4byte sUnownOAnimTable9
+.4byte sUnownOAnimTable10
+.4byte sUnownOAnimTable11
+.4byte sUnownOAnimTable12
+.4byte sUnownOAnimTable13
+sAxSpritesUnownO:
+.4byte sUnownOSprites1
+.4byte sUnownOSprites2
+.4byte sUnownOSprites3
+.4byte sUnownOSprites4
+.4byte sUnownOSprites5
+.4byte sUnownOSprites6
+.4byte sUnownOSprites7
+.4byte sUnownOSprites8
+.4byte sUnownOSprites9
+.4byte sUnownOSprites10
+.4byte sUnownOSprites11
+sAxMainUnownO:
+ax_main sAxPosesUnownO, sAxAnimationsUnownO, 13, sAxSpritesUnownO, sAxPositionsUnownO

--- a/data/ax/unownp.inc
+++ b/data/ax/unownp.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownP
+gAxUnownP:
+ax_siro sAxMainUnownP
+sUnownPPose1:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose9:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose17:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose25:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose33:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose42:
+ax_pose 9, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownPPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownPPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownPPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose50:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose58:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose66:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose74:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose82:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose90:
+ax_pose 0, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownPPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownPPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownPPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownPAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownPAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownPAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownPAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownPAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownPAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownPAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownPAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownPAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownPAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownPAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownPAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownPAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownPAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownPAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownPAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownPAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownPAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownPAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownPAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownPAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownPAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownPAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownPAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownPAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownPAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownPAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownPAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownPAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownPAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownPAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownPAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownPAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownPAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownPAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownPAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownPAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownPAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownPAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownPAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownPAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownPAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownPAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownPAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownPAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownPAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownPAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownPAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownPAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownPAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownPGfx1:
+.incbin "baserom.gba", 0xDEC588, 0x200
+sUnownPSprites1:
+ax_sprite sUnownPGfx1, 0x200
+ax_sprite_terminator
+sUnownPGfx2:
+.incbin "baserom.gba", 0xDEC798, 0x200
+sUnownPSprites2:
+ax_sprite sUnownPGfx2, 0x200
+ax_sprite_terminator
+sUnownPGfx3:
+.incbin "baserom.gba", 0xDEC9A8, 0x200
+sUnownPSprites3:
+ax_sprite sUnownPGfx3, 0x200
+ax_sprite_terminator
+sUnownPGfx4:
+.incbin "baserom.gba", 0xDECBB8, 0x200
+sUnownPSprites4:
+ax_sprite sUnownPGfx4, 0x200
+ax_sprite_terminator
+sUnownPGfx5:
+.incbin "baserom.gba", 0xDECDC8, 0x200
+sUnownPSprites5:
+ax_sprite sUnownPGfx5, 0x200
+ax_sprite_terminator
+sUnownPGfx6:
+.incbin "baserom.gba", 0xDECFD8, 0x200
+sUnownPSprites6:
+ax_sprite sUnownPGfx6, 0x200
+ax_sprite_terminator
+sUnownPGfx7:
+.incbin "baserom.gba", 0xDED1E8, 0x200
+sUnownPSprites7:
+ax_sprite sUnownPGfx7, 0x200
+ax_sprite_terminator
+sUnownPGfx8:
+.incbin "baserom.gba", 0xDED3F8, 0x200
+sUnownPSprites8:
+ax_sprite sUnownPGfx8, 0x200
+ax_sprite_terminator
+sUnownPGfx9:
+.incbin "baserom.gba", 0xDED608, 0x200
+sUnownPSprites9:
+ax_sprite sUnownPGfx9, 0x200
+ax_sprite_terminator
+sUnownPGfx10:
+.incbin "baserom.gba", 0xDED818, 0x200
+sUnownPSprites10:
+ax_sprite sUnownPGfx10, 0x200
+ax_sprite_terminator
+sUnownPGfx11:
+.incbin "baserom.gba", 0xDEDA28, 0x200
+sUnownPSprites11:
+ax_sprite sUnownPGfx11, 0x200
+ax_sprite_terminator
+sUnownPGfx12:
+.incbin "baserom.gba", 0xDEDC38, 0x200
+sUnownPSprites12:
+ax_sprite sUnownPGfx12, 0x200
+ax_sprite_terminator
+sUnownPGfx13:
+.incbin "baserom.gba", 0xDEDE48, 0x200
+sUnownPSprites13:
+ax_sprite sUnownPGfx13, 0x200
+ax_sprite_terminator
+sUnownPGfx14:
+.incbin "baserom.gba", 0xDEE058, 0x200
+sUnownPSprites14:
+ax_sprite sUnownPGfx14, 0x200
+ax_sprite_terminator
+sUnownPGfx15:
+.incbin "baserom.gba", 0xDEE268, 0x200
+sUnownPSprites15:
+ax_sprite sUnownPGfx15, 0x200
+ax_sprite_terminator
+sUnownPGfx16:
+.incbin "baserom.gba", 0xDEE478, 0x200
+sUnownPSprites16:
+ax_sprite sUnownPGfx16, 0x200
+ax_sprite_terminator
+sUnownPGfx17:
+.incbin "baserom.gba", 0xDEE688, 0x200
+sUnownPSprites17:
+ax_sprite sUnownPGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownP:
+.4byte sUnownPPose1
+.4byte sUnownPPose2
+.4byte sUnownPPose3
+.4byte sUnownPPose4
+.4byte sUnownPPose5
+.4byte sUnownPPose6
+.4byte sUnownPPose7
+.4byte sUnownPPose8
+.4byte sUnownPPose9
+.4byte sUnownPPose10
+.4byte sUnownPPose11
+.4byte sUnownPPose12
+.4byte sUnownPPose13
+.4byte sUnownPPose14
+.4byte sUnownPPose15
+.4byte sUnownPPose16
+.4byte sUnownPPose17
+.4byte sUnownPPose18
+.4byte sUnownPPose19
+.4byte sUnownPPose20
+.4byte sUnownPPose21
+.4byte sUnownPPose22
+.4byte sUnownPPose23
+.4byte sUnownPPose24
+.4byte sUnownPPose25
+.4byte sUnownPPose26
+.4byte sUnownPPose27
+.4byte sUnownPPose28
+.4byte sUnownPPose29
+.4byte sUnownPPose30
+.4byte sUnownPPose31
+.4byte sUnownPPose32
+.4byte sUnownPPose33
+.4byte sUnownPPose34
+.4byte sUnownPPose35
+.4byte sUnownPPose36
+.4byte sUnownPPose37
+.4byte sUnownPPose38
+.4byte sUnownPPose39
+.4byte sUnownPPose40
+.4byte sUnownPPose41
+.4byte sUnownPPose42
+.4byte sUnownPPose43
+.4byte sUnownPPose44
+.4byte sUnownPPose45
+.4byte sUnownPPose46
+.4byte sUnownPPose47
+.4byte sUnownPPose48
+.4byte sUnownPPose49
+.4byte sUnownPPose50
+.4byte sUnownPPose51
+.4byte sUnownPPose52
+.4byte sUnownPPose53
+.4byte sUnownPPose54
+.4byte sUnownPPose55
+.4byte sUnownPPose56
+.4byte sUnownPPose57
+.4byte sUnownPPose58
+.4byte sUnownPPose59
+.4byte sUnownPPose60
+.4byte sUnownPPose61
+.4byte sUnownPPose62
+.4byte sUnownPPose63
+.4byte sUnownPPose64
+.4byte sUnownPPose65
+.4byte sUnownPPose66
+.4byte sUnownPPose67
+.4byte sUnownPPose68
+.4byte sUnownPPose69
+.4byte sUnownPPose70
+.4byte sUnownPPose71
+.4byte sUnownPPose72
+.4byte sUnownPPose73
+.4byte sUnownPPose74
+.4byte sUnownPPose75
+.4byte sUnownPPose76
+.4byte sUnownPPose77
+.4byte sUnownPPose78
+.4byte sUnownPPose79
+.4byte sUnownPPose80
+.4byte sUnownPPose81
+.4byte sUnownPPose82
+.4byte sUnownPPose83
+.4byte sUnownPPose84
+.4byte sUnownPPose85
+.4byte sUnownPPose86
+.4byte sUnownPPose87
+.4byte sUnownPPose88
+.4byte sUnownPPose89
+.4byte sUnownPPose90
+.4byte sUnownPPose91
+.4byte sUnownPPose92
+.4byte sUnownPPose93
+.4byte sUnownPPose94
+.4byte sUnownPPose95
+.4byte sUnownPPose96
+.4byte sUnownPPose97
+sAxPositionsUnownP:
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte    0,  -14, 	  -5,  -18, 	  -3,   -6, 	   1,  -13
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte   -1,  -14, 	  -7,  -17, 	   0,   -5, 	  -2,  -12
+.2byte    0,  -15, 	  -5,  -16, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -15, 	   2,  -17, 	   0,   -6, 	  -2,  -12
+.2byte   -1,  -15, 	   4,  -17, 	   2,   -7, 	   0,  -13
+.2byte   -1,  -15, 	   3,  -19, 	   0,   -7, 	   1,  -13
+.2byte   -2,  -15, 	   1,  -19, 	  -2,   -7, 	   0,  -13
+.2byte   -1,  -14, 	  -3,  -18, 	  -4,   -7, 	  -1,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+.2byte   -1,  -14, 	  -6,  -18, 	  -4,   -6, 	  -1,  -13
+.2byte    0,  -14, 	  -5,  -17, 	  -3,   -5, 	  -1,  -13
+.2byte    1,  -14, 	  -4,  -16, 	  -1,   -5, 	  -1,  -13
+.2byte    0,  -15, 	   3,  -17, 	   0,   -5, 	   0,  -13
+.2byte   -1,  -16, 	   4,  -18, 	   2,   -6, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -19, 	   1,   -7, 	   0,  -13
+.2byte   -3,  -14, 	  -1,  -19, 	  -1,   -7, 	  -1,  -12
+.2byte   -2,  -14, 	  -4,  -19, 	  -3,   -7, 	  -2,  -12
+sUnownPAnimTable1:
+.4byte sUnownPAnims_1_1
+.4byte sUnownPAnims_1_2
+.4byte sUnownPAnims_1_3
+.4byte sUnownPAnims_1_4
+.4byte sUnownPAnims_1_5
+.4byte sUnownPAnims_1_6
+.4byte sUnownPAnims_1_7
+.4byte sUnownPAnims_1_8
+sUnownPAnimTable2:
+.4byte sUnownPAnims_2_1
+.4byte sUnownPAnims_2_2
+.4byte sUnownPAnims_2_3
+.4byte sUnownPAnims_2_4
+.4byte sUnownPAnims_2_5
+.4byte sUnownPAnims_2_6
+.4byte sUnownPAnims_2_7
+.4byte sUnownPAnims_2_8
+sUnownPAnimTable3:
+.4byte sUnownPAnims_3_1
+.4byte sUnownPAnims_3_2
+.4byte sUnownPAnims_3_3
+.4byte sUnownPAnims_3_4
+.4byte sUnownPAnims_3_5
+.4byte sUnownPAnims_3_6
+.4byte sUnownPAnims_3_7
+.4byte sUnownPAnims_3_8
+sUnownPAnimTable4:
+.4byte sUnownPAnims_4_1
+.4byte sUnownPAnims_4_2
+.4byte sUnownPAnims_4_3
+.4byte sUnownPAnims_4_4
+.4byte sUnownPAnims_4_5
+.4byte sUnownPAnims_4_6
+.4byte sUnownPAnims_4_7
+.4byte sUnownPAnims_4_8
+sUnownPAnimTable5:
+.4byte sUnownPAnims_5_1
+.4byte sUnownPAnims_5_2
+.4byte sUnownPAnims_5_3
+.4byte sUnownPAnims_5_4
+.4byte sUnownPAnims_5_5
+.4byte sUnownPAnims_5_6
+.4byte sUnownPAnims_5_7
+.4byte sUnownPAnims_5_8
+sUnownPAnimTable6:
+.4byte sUnownPAnims_6_1
+.4byte sUnownPAnims_6_1
+.4byte sUnownPAnims_6_1
+.4byte sUnownPAnims_6_1
+.4byte sUnownPAnims_6_1
+.4byte sUnownPAnims_6_1
+.4byte sUnownPAnims_6_1
+.4byte sUnownPAnims_6_1
+sUnownPAnimTable7:
+.4byte sUnownPAnims_7_1
+.4byte sUnownPAnims_7_2
+.4byte sUnownPAnims_7_3
+.4byte sUnownPAnims_7_4
+.4byte sUnownPAnims_7_5
+.4byte sUnownPAnims_7_6
+.4byte sUnownPAnims_7_7
+.4byte sUnownPAnims_7_8
+sUnownPAnimTable8:
+.4byte sUnownPAnims_8_1
+.4byte sUnownPAnims_8_2
+.4byte sUnownPAnims_8_3
+.4byte sUnownPAnims_8_4
+.4byte sUnownPAnims_8_5
+.4byte sUnownPAnims_8_6
+.4byte sUnownPAnims_8_7
+.4byte sUnownPAnims_8_8
+sUnownPAnimTable9:
+.4byte sUnownPAnims_9_1
+.4byte sUnownPAnims_9_2
+.4byte sUnownPAnims_9_3
+.4byte sUnownPAnims_9_4
+.4byte sUnownPAnims_9_5
+.4byte sUnownPAnims_9_6
+.4byte sUnownPAnims_9_7
+.4byte sUnownPAnims_9_8
+sUnownPAnimTable10:
+.4byte sUnownPAnims_10_1
+.4byte sUnownPAnims_10_2
+.4byte sUnownPAnims_10_3
+.4byte sUnownPAnims_10_4
+.4byte sUnownPAnims_10_5
+.4byte sUnownPAnims_10_6
+.4byte sUnownPAnims_10_7
+.4byte sUnownPAnims_10_8
+sUnownPAnimTable11:
+.4byte sUnownPAnims_11_1
+.4byte sUnownPAnims_11_2
+.4byte sUnownPAnims_11_3
+.4byte sUnownPAnims_11_4
+.4byte sUnownPAnims_11_5
+.4byte sUnownPAnims_11_6
+.4byte sUnownPAnims_11_7
+.4byte sUnownPAnims_11_8
+sUnownPAnimTable12:
+.4byte sUnownPAnims_12_1
+.4byte sUnownPAnims_12_2
+.4byte sUnownPAnims_12_3
+.4byte sUnownPAnims_12_4
+.4byte sUnownPAnims_12_5
+.4byte sUnownPAnims_12_6
+.4byte sUnownPAnims_12_7
+.4byte sUnownPAnims_12_8
+sUnownPAnimTable13:
+.4byte sUnownPAnims_13_1
+.4byte sUnownPAnims_13_2
+.4byte sUnownPAnims_13_3
+.4byte sUnownPAnims_13_4
+.4byte sUnownPAnims_13_5
+.4byte sUnownPAnims_13_6
+.4byte sUnownPAnims_13_7
+.4byte sUnownPAnims_13_8
+sAxAnimationsUnownP:
+.4byte sUnownPAnimTable1
+.4byte sUnownPAnimTable2
+.4byte sUnownPAnimTable3
+.4byte sUnownPAnimTable4
+.4byte sUnownPAnimTable5
+.4byte sUnownPAnimTable6
+.4byte sUnownPAnimTable7
+.4byte sUnownPAnimTable8
+.4byte sUnownPAnimTable9
+.4byte sUnownPAnimTable10
+.4byte sUnownPAnimTable11
+.4byte sUnownPAnimTable12
+.4byte sUnownPAnimTable13
+sAxSpritesUnownP:
+.4byte sUnownPSprites1
+.4byte sUnownPSprites2
+.4byte sUnownPSprites3
+.4byte sUnownPSprites4
+.4byte sUnownPSprites5
+.4byte sUnownPSprites6
+.4byte sUnownPSprites7
+.4byte sUnownPSprites8
+.4byte sUnownPSprites9
+.4byte sUnownPSprites10
+.4byte sUnownPSprites11
+.4byte sUnownPSprites12
+.4byte sUnownPSprites13
+.4byte sUnownPSprites14
+.4byte sUnownPSprites15
+.4byte sUnownPSprites16
+.4byte sUnownPSprites17
+sAxMainUnownP:
+ax_main sAxPosesUnownP, sAxAnimationsUnownP, 13, sAxSpritesUnownP, sAxPositionsUnownP

--- a/data/ax/unownq.inc
+++ b/data/ax/unownq.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownQ
+gAxUnownQ:
+ax_siro sAxMainUnownQ
+sUnownQPose1:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose2:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose3:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose4:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose6:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose7:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose8:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose9:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose10:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose11:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose12:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose14:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose15:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose16:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose17:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose18:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose19:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose20:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose22:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose23:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose24:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose25:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose26:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose27:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose28:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose30:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose31:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose32:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose33:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose34:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose35:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose36:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose38:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose39:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose40:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose42:
+ax_pose 9, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose43:
+ax_pose 10, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownQPose44:
+ax_pose 11, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownQPose45:
+ax_pose 12, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownQPose46:
+ax_pose 13, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose47:
+ax_pose 14, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose48:
+ax_pose 15, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose49:
+ax_pose 16, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose50:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose51:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose52:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose53:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose55:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose56:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose57:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose58:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose59:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose60:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose61:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose63:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose64:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose65:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose66:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose67:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose68:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose69:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose71:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose72:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose73:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose74:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose75:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose76:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose77:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose79:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose80:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose81:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose82:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose83:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose84:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose85:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose87:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose88:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose89:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose90:
+ax_pose 0, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose91:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose92:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose93:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose95:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQPose96:
+ax_pose 6, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQPose97:
+ax_pose 7, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownQAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownQAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownQAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownQAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownQAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownQAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownQAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownQAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownQAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownQAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownQAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownQAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownQAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownQAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownQAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownQAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownQAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownQAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownQAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownQAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownQAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownQAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownQAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownQAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownQAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownQAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownQAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownQAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownQAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownQAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownQAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownQAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownQAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownQAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownQAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQGfx1:
+.incbin "baserom.gba", 0xDF2798, 0x200
+sUnownQSprites1:
+ax_sprite sUnownQGfx1, 0x200
+ax_sprite_terminator
+sUnownQGfx2:
+.incbin "baserom.gba", 0xDF29A8, 0x200
+sUnownQSprites2:
+ax_sprite sUnownQGfx2, 0x200
+ax_sprite_terminator
+sUnownQGfx3:
+.incbin "baserom.gba", 0xDF2BB8, 0x200
+sUnownQSprites3:
+ax_sprite sUnownQGfx3, 0x200
+ax_sprite_terminator
+sUnownQGfx4:
+.incbin "baserom.gba", 0xDF2DC8, 0x200
+sUnownQSprites4:
+ax_sprite sUnownQGfx4, 0x200
+ax_sprite_terminator
+sUnownQGfx5:
+.incbin "baserom.gba", 0xDF2FD8, 0x200
+sUnownQSprites5:
+ax_sprite sUnownQGfx5, 0x200
+ax_sprite_terminator
+sUnownQGfx6:
+.incbin "baserom.gba", 0xDF31E8, 0x200
+sUnownQSprites6:
+ax_sprite sUnownQGfx6, 0x200
+ax_sprite_terminator
+sUnownQGfx7:
+.incbin "baserom.gba", 0xDF33F8, 0x200
+sUnownQSprites7:
+ax_sprite sUnownQGfx7, 0x200
+ax_sprite_terminator
+sUnownQGfx8:
+.incbin "baserom.gba", 0xDF3608, 0x200
+sUnownQSprites8:
+ax_sprite sUnownQGfx8, 0x200
+ax_sprite_terminator
+sUnownQGfx9:
+.incbin "baserom.gba", 0xDF3818, 0x200
+sUnownQSprites9:
+ax_sprite sUnownQGfx9, 0x200
+ax_sprite_terminator
+sUnownQGfx10:
+.incbin "baserom.gba", 0xDF3A28, 0x200
+sUnownQSprites10:
+ax_sprite sUnownQGfx10, 0x200
+ax_sprite_terminator
+sUnownQGfx11:
+.incbin "baserom.gba", 0xDF3C38, 0x200
+sUnownQSprites11:
+ax_sprite sUnownQGfx11, 0x200
+ax_sprite_terminator
+sUnownQGfx12:
+.incbin "baserom.gba", 0xDF3E48, 0x200
+sUnownQSprites12:
+ax_sprite sUnownQGfx12, 0x200
+ax_sprite_terminator
+sUnownQGfx13:
+.incbin "baserom.gba", 0xDF4058, 0x200
+sUnownQSprites13:
+ax_sprite sUnownQGfx13, 0x200
+ax_sprite_terminator
+sUnownQGfx14:
+.incbin "baserom.gba", 0xDF4268, 0x200
+sUnownQSprites14:
+ax_sprite sUnownQGfx14, 0x200
+ax_sprite_terminator
+sUnownQGfx15:
+.incbin "baserom.gba", 0xDF4478, 0x200
+sUnownQSprites15:
+ax_sprite sUnownQGfx15, 0x200
+ax_sprite_terminator
+sUnownQGfx16:
+.incbin "baserom.gba", 0xDF4688, 0x200
+sUnownQSprites16:
+ax_sprite sUnownQGfx16, 0x200
+ax_sprite_terminator
+sUnownQGfx17:
+.incbin "baserom.gba", 0xDF4898, 0x200
+sUnownQSprites17:
+ax_sprite sUnownQGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownQ:
+.4byte sUnownQPose1
+.4byte sUnownQPose2
+.4byte sUnownQPose3
+.4byte sUnownQPose4
+.4byte sUnownQPose5
+.4byte sUnownQPose6
+.4byte sUnownQPose7
+.4byte sUnownQPose8
+.4byte sUnownQPose9
+.4byte sUnownQPose10
+.4byte sUnownQPose11
+.4byte sUnownQPose12
+.4byte sUnownQPose13
+.4byte sUnownQPose14
+.4byte sUnownQPose15
+.4byte sUnownQPose16
+.4byte sUnownQPose17
+.4byte sUnownQPose18
+.4byte sUnownQPose19
+.4byte sUnownQPose20
+.4byte sUnownQPose21
+.4byte sUnownQPose22
+.4byte sUnownQPose23
+.4byte sUnownQPose24
+.4byte sUnownQPose25
+.4byte sUnownQPose26
+.4byte sUnownQPose27
+.4byte sUnownQPose28
+.4byte sUnownQPose29
+.4byte sUnownQPose30
+.4byte sUnownQPose31
+.4byte sUnownQPose32
+.4byte sUnownQPose33
+.4byte sUnownQPose34
+.4byte sUnownQPose35
+.4byte sUnownQPose36
+.4byte sUnownQPose37
+.4byte sUnownQPose38
+.4byte sUnownQPose39
+.4byte sUnownQPose40
+.4byte sUnownQPose41
+.4byte sUnownQPose42
+.4byte sUnownQPose43
+.4byte sUnownQPose44
+.4byte sUnownQPose45
+.4byte sUnownQPose46
+.4byte sUnownQPose47
+.4byte sUnownQPose48
+.4byte sUnownQPose49
+.4byte sUnownQPose50
+.4byte sUnownQPose51
+.4byte sUnownQPose52
+.4byte sUnownQPose53
+.4byte sUnownQPose54
+.4byte sUnownQPose55
+.4byte sUnownQPose56
+.4byte sUnownQPose57
+.4byte sUnownQPose58
+.4byte sUnownQPose59
+.4byte sUnownQPose60
+.4byte sUnownQPose61
+.4byte sUnownQPose62
+.4byte sUnownQPose63
+.4byte sUnownQPose64
+.4byte sUnownQPose65
+.4byte sUnownQPose66
+.4byte sUnownQPose67
+.4byte sUnownQPose68
+.4byte sUnownQPose69
+.4byte sUnownQPose70
+.4byte sUnownQPose71
+.4byte sUnownQPose72
+.4byte sUnownQPose73
+.4byte sUnownQPose74
+.4byte sUnownQPose75
+.4byte sUnownQPose76
+.4byte sUnownQPose77
+.4byte sUnownQPose78
+.4byte sUnownQPose79
+.4byte sUnownQPose80
+.4byte sUnownQPose81
+.4byte sUnownQPose82
+.4byte sUnownQPose83
+.4byte sUnownQPose84
+.4byte sUnownQPose85
+.4byte sUnownQPose86
+.4byte sUnownQPose87
+.4byte sUnownQPose88
+.4byte sUnownQPose89
+.4byte sUnownQPose90
+.4byte sUnownQPose91
+.4byte sUnownQPose92
+.4byte sUnownQPose93
+.4byte sUnownQPose94
+.4byte sUnownQPose95
+.4byte sUnownQPose96
+.4byte sUnownQPose97
+sAxPositionsUnownQ:
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -2,  -13, 	  -5,  -13, 	   4,   -8, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -14, 	  -2,  -12, 	   3,   -7, 	   1,  -10
+.2byte    1,  -14, 	  -2,  -12, 	   1,   -7, 	   0,  -10
+.2byte    1,  -14, 	   1,  -12, 	  -2,   -7, 	  -1,  -10
+.2byte   -1,  -14, 	   2,  -12, 	  -6,   -6, 	  -2,  -11
+.2byte   -1,  -14, 	   1,  -12, 	  -5,   -6, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -13, 	   0,   -6, 	  -1,  -11
+.2byte   -2,  -14, 	  -3,  -15, 	   2,   -6, 	   0,  -10
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+.2byte   -1,  -13, 	  -4,  -13, 	   5,   -8, 	   0,  -11
+.2byte    0,  -13, 	  -3,  -13, 	   2,   -7, 	   0,  -10
+.2byte    1,  -13, 	  -3,  -12, 	   0,   -7, 	  -1,  -10
+.2byte    0,  -14, 	   1,  -12, 	  -3,   -7, 	  -1,  -10
+.2byte   -1,  -13, 	   2,  -11, 	  -6,   -7, 	  -3,  -11
+.2byte   -2,  -14, 	   1,  -13, 	  -5,   -6, 	  -1,  -10
+.2byte   -3,  -13, 	  -2,  -13, 	   1,   -6, 	   0,  -10
+.2byte   -2,  -13, 	  -3,  -14, 	   2,   -6, 	  -1,  -11
+sUnownQAnimTable1:
+.4byte sUnownQAnims_1_1
+.4byte sUnownQAnims_1_2
+.4byte sUnownQAnims_1_3
+.4byte sUnownQAnims_1_4
+.4byte sUnownQAnims_1_5
+.4byte sUnownQAnims_1_6
+.4byte sUnownQAnims_1_7
+.4byte sUnownQAnims_1_8
+sUnownQAnimTable2:
+.4byte sUnownQAnims_2_1
+.4byte sUnownQAnims_2_2
+.4byte sUnownQAnims_2_3
+.4byte sUnownQAnims_2_4
+.4byte sUnownQAnims_2_5
+.4byte sUnownQAnims_2_6
+.4byte sUnownQAnims_2_7
+.4byte sUnownQAnims_2_8
+sUnownQAnimTable3:
+.4byte sUnownQAnims_3_1
+.4byte sUnownQAnims_3_2
+.4byte sUnownQAnims_3_3
+.4byte sUnownQAnims_3_4
+.4byte sUnownQAnims_3_5
+.4byte sUnownQAnims_3_6
+.4byte sUnownQAnims_3_7
+.4byte sUnownQAnims_3_8
+sUnownQAnimTable4:
+.4byte sUnownQAnims_4_1
+.4byte sUnownQAnims_4_2
+.4byte sUnownQAnims_4_3
+.4byte sUnownQAnims_4_4
+.4byte sUnownQAnims_4_5
+.4byte sUnownQAnims_4_6
+.4byte sUnownQAnims_4_7
+.4byte sUnownQAnims_4_8
+sUnownQAnimTable5:
+.4byte sUnownQAnims_5_1
+.4byte sUnownQAnims_5_2
+.4byte sUnownQAnims_5_3
+.4byte sUnownQAnims_5_4
+.4byte sUnownQAnims_5_5
+.4byte sUnownQAnims_5_6
+.4byte sUnownQAnims_5_7
+.4byte sUnownQAnims_5_8
+sUnownQAnimTable6:
+.4byte sUnownQAnims_6_1
+.4byte sUnownQAnims_6_1
+.4byte sUnownQAnims_6_1
+.4byte sUnownQAnims_6_1
+.4byte sUnownQAnims_6_1
+.4byte sUnownQAnims_6_1
+.4byte sUnownQAnims_6_1
+.4byte sUnownQAnims_6_1
+sUnownQAnimTable7:
+.4byte sUnownQAnims_7_1
+.4byte sUnownQAnims_7_2
+.4byte sUnownQAnims_7_3
+.4byte sUnownQAnims_7_4
+.4byte sUnownQAnims_7_5
+.4byte sUnownQAnims_7_6
+.4byte sUnownQAnims_7_7
+.4byte sUnownQAnims_7_8
+sUnownQAnimTable8:
+.4byte sUnownQAnims_8_1
+.4byte sUnownQAnims_8_2
+.4byte sUnownQAnims_8_3
+.4byte sUnownQAnims_8_4
+.4byte sUnownQAnims_8_5
+.4byte sUnownQAnims_8_6
+.4byte sUnownQAnims_8_7
+.4byte sUnownQAnims_8_8
+sUnownQAnimTable9:
+.4byte sUnownQAnims_9_1
+.4byte sUnownQAnims_9_2
+.4byte sUnownQAnims_9_3
+.4byte sUnownQAnims_9_4
+.4byte sUnownQAnims_9_5
+.4byte sUnownQAnims_9_6
+.4byte sUnownQAnims_9_7
+.4byte sUnownQAnims_9_8
+sUnownQAnimTable10:
+.4byte sUnownQAnims_10_1
+.4byte sUnownQAnims_10_2
+.4byte sUnownQAnims_10_3
+.4byte sUnownQAnims_10_4
+.4byte sUnownQAnims_10_5
+.4byte sUnownQAnims_10_6
+.4byte sUnownQAnims_10_7
+.4byte sUnownQAnims_10_8
+sUnownQAnimTable11:
+.4byte sUnownQAnims_11_1
+.4byte sUnownQAnims_11_2
+.4byte sUnownQAnims_11_3
+.4byte sUnownQAnims_11_4
+.4byte sUnownQAnims_11_5
+.4byte sUnownQAnims_11_6
+.4byte sUnownQAnims_11_7
+.4byte sUnownQAnims_11_8
+sUnownQAnimTable12:
+.4byte sUnownQAnims_12_1
+.4byte sUnownQAnims_12_2
+.4byte sUnownQAnims_12_3
+.4byte sUnownQAnims_12_4
+.4byte sUnownQAnims_12_5
+.4byte sUnownQAnims_12_6
+.4byte sUnownQAnims_12_7
+.4byte sUnownQAnims_12_8
+sUnownQAnimTable13:
+.4byte sUnownQAnims_13_1
+.4byte sUnownQAnims_13_2
+.4byte sUnownQAnims_13_3
+.4byte sUnownQAnims_13_4
+.4byte sUnownQAnims_13_5
+.4byte sUnownQAnims_13_6
+.4byte sUnownQAnims_13_7
+.4byte sUnownQAnims_13_8
+sAxAnimationsUnownQ:
+.4byte sUnownQAnimTable1
+.4byte sUnownQAnimTable2
+.4byte sUnownQAnimTable3
+.4byte sUnownQAnimTable4
+.4byte sUnownQAnimTable5
+.4byte sUnownQAnimTable6
+.4byte sUnownQAnimTable7
+.4byte sUnownQAnimTable8
+.4byte sUnownQAnimTable9
+.4byte sUnownQAnimTable10
+.4byte sUnownQAnimTable11
+.4byte sUnownQAnimTable12
+.4byte sUnownQAnimTable13
+sAxSpritesUnownQ:
+.4byte sUnownQSprites1
+.4byte sUnownQSprites2
+.4byte sUnownQSprites3
+.4byte sUnownQSprites4
+.4byte sUnownQSprites5
+.4byte sUnownQSprites6
+.4byte sUnownQSprites7
+.4byte sUnownQSprites8
+.4byte sUnownQSprites9
+.4byte sUnownQSprites10
+.4byte sUnownQSprites11
+.4byte sUnownQSprites12
+.4byte sUnownQSprites13
+.4byte sUnownQSprites14
+.4byte sUnownQSprites15
+.4byte sUnownQSprites16
+.4byte sUnownQSprites17
+sAxMainUnownQ:
+ax_main sAxPosesUnownQ, sAxAnimationsUnownQ, 13, sAxSpritesUnownQ, sAxPositionsUnownQ

--- a/data/ax/unownqmark.inc
+++ b/data/ax/unownqmark.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownQmark
+gAxUnownQmark:
+ax_siro sAxMainUnownQmark
+sUnownQmarkPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose46:
+ax_pose 13, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownQmarkPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownQmarkAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownQmarkAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownQmarkAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownQmarkAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownQmarkAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownQmarkAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownQmarkAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownQmarkAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownQmarkAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownQmarkAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownQmarkAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownQmarkAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownQmarkAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownQmarkAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownQmarkAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownQmarkAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownQmarkAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownQmarkAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownQmarkAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownQmarkAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownQmarkAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownQmarkAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownQmarkAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownQmarkAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownQmarkAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownQmarkAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownQmarkAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownQmarkAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownQmarkAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownQmarkAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownQmarkAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownQmarkAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownQmarkGfx1:
+.incbin "baserom.gba", 0x161F844, 0x200
+sUnownQmarkSprites1:
+ax_sprite sUnownQmarkGfx1, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx2:
+.incbin "baserom.gba", 0x161FA54, 0x200
+sUnownQmarkSprites2:
+ax_sprite sUnownQmarkGfx2, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx3:
+.incbin "baserom.gba", 0x161FC64, 0x200
+sUnownQmarkSprites3:
+ax_sprite sUnownQmarkGfx3, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx4:
+.incbin "baserom.gba", 0x161FE74, 0x200
+sUnownQmarkSprites4:
+ax_sprite sUnownQmarkGfx4, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx5:
+.incbin "baserom.gba", 0x1620084, 0x200
+sUnownQmarkSprites5:
+ax_sprite sUnownQmarkGfx5, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx6:
+.incbin "baserom.gba", 0x1620294, 0x200
+sUnownQmarkSprites6:
+ax_sprite sUnownQmarkGfx6, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx7:
+.incbin "baserom.gba", 0x16204A4, 0x200
+sUnownQmarkSprites7:
+ax_sprite sUnownQmarkGfx7, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx8:
+.incbin "baserom.gba", 0x16206B4, 0x200
+sUnownQmarkSprites8:
+ax_sprite sUnownQmarkGfx8, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx9:
+.incbin "baserom.gba", 0x16208C4, 0x200
+sUnownQmarkSprites9:
+ax_sprite sUnownQmarkGfx9, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx10:
+.incbin "baserom.gba", 0x1620AD4, 0x200
+sUnownQmarkSprites10:
+ax_sprite sUnownQmarkGfx10, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx11:
+.incbin "baserom.gba", 0x1620CE4, 0x200
+sUnownQmarkSprites11:
+ax_sprite sUnownQmarkGfx11, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx12:
+.incbin "baserom.gba", 0x1620EF4, 0x200
+sUnownQmarkSprites12:
+ax_sprite sUnownQmarkGfx12, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx13:
+.incbin "baserom.gba", 0x1621104, 0x200
+sUnownQmarkSprites13:
+ax_sprite sUnownQmarkGfx13, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx14:
+.incbin "baserom.gba", 0x1621314, 0x200
+sUnownQmarkSprites14:
+ax_sprite sUnownQmarkGfx14, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx15:
+.incbin "baserom.gba", 0x1621524, 0x200
+sUnownQmarkSprites15:
+ax_sprite sUnownQmarkGfx15, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx16:
+.incbin "baserom.gba", 0x1621734, 0x200
+sUnownQmarkSprites16:
+ax_sprite sUnownQmarkGfx16, 0x200
+ax_sprite_terminator
+sUnownQmarkGfx17:
+.incbin "baserom.gba", 0x1621944, 0x200
+sUnownQmarkSprites17:
+ax_sprite sUnownQmarkGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownQmark:
+.4byte sUnownQmarkPose1
+.4byte sUnownQmarkPose2
+.4byte sUnownQmarkPose3
+.4byte sUnownQmarkPose4
+.4byte sUnownQmarkPose5
+.4byte sUnownQmarkPose6
+.4byte sUnownQmarkPose7
+.4byte sUnownQmarkPose8
+.4byte sUnownQmarkPose9
+.4byte sUnownQmarkPose10
+.4byte sUnownQmarkPose11
+.4byte sUnownQmarkPose12
+.4byte sUnownQmarkPose13
+.4byte sUnownQmarkPose14
+.4byte sUnownQmarkPose15
+.4byte sUnownQmarkPose16
+.4byte sUnownQmarkPose17
+.4byte sUnownQmarkPose18
+.4byte sUnownQmarkPose19
+.4byte sUnownQmarkPose20
+.4byte sUnownQmarkPose21
+.4byte sUnownQmarkPose22
+.4byte sUnownQmarkPose23
+.4byte sUnownQmarkPose24
+.4byte sUnownQmarkPose25
+.4byte sUnownQmarkPose26
+.4byte sUnownQmarkPose27
+.4byte sUnownQmarkPose28
+.4byte sUnownQmarkPose29
+.4byte sUnownQmarkPose30
+.4byte sUnownQmarkPose31
+.4byte sUnownQmarkPose32
+.4byte sUnownQmarkPose33
+.4byte sUnownQmarkPose34
+.4byte sUnownQmarkPose35
+.4byte sUnownQmarkPose36
+.4byte sUnownQmarkPose37
+.4byte sUnownQmarkPose38
+.4byte sUnownQmarkPose39
+.4byte sUnownQmarkPose40
+.4byte sUnownQmarkPose41
+.4byte sUnownQmarkPose42
+.4byte sUnownQmarkPose43
+.4byte sUnownQmarkPose44
+.4byte sUnownQmarkPose45
+.4byte sUnownQmarkPose46
+.4byte sUnownQmarkPose47
+.4byte sUnownQmarkPose48
+.4byte sUnownQmarkPose49
+.4byte sUnownQmarkPose50
+.4byte sUnownQmarkPose51
+.4byte sUnownQmarkPose52
+.4byte sUnownQmarkPose53
+.4byte sUnownQmarkPose54
+.4byte sUnownQmarkPose55
+.4byte sUnownQmarkPose56
+.4byte sUnownQmarkPose57
+.4byte sUnownQmarkPose58
+.4byte sUnownQmarkPose59
+.4byte sUnownQmarkPose60
+.4byte sUnownQmarkPose61
+.4byte sUnownQmarkPose62
+.4byte sUnownQmarkPose63
+.4byte sUnownQmarkPose64
+.4byte sUnownQmarkPose65
+.4byte sUnownQmarkPose66
+.4byte sUnownQmarkPose67
+.4byte sUnownQmarkPose68
+.4byte sUnownQmarkPose69
+.4byte sUnownQmarkPose70
+.4byte sUnownQmarkPose71
+.4byte sUnownQmarkPose72
+.4byte sUnownQmarkPose73
+.4byte sUnownQmarkPose74
+.4byte sUnownQmarkPose75
+.4byte sUnownQmarkPose76
+.4byte sUnownQmarkPose77
+.4byte sUnownQmarkPose78
+.4byte sUnownQmarkPose79
+.4byte sUnownQmarkPose80
+.4byte sUnownQmarkPose81
+.4byte sUnownQmarkPose82
+.4byte sUnownQmarkPose83
+.4byte sUnownQmarkPose84
+.4byte sUnownQmarkPose85
+.4byte sUnownQmarkPose86
+.4byte sUnownQmarkPose87
+.4byte sUnownQmarkPose88
+.4byte sUnownQmarkPose89
+.4byte sUnownQmarkPose90
+.4byte sUnownQmarkPose91
+.4byte sUnownQmarkPose92
+.4byte sUnownQmarkPose93
+.4byte sUnownQmarkPose94
+.4byte sUnownQmarkPose95
+.4byte sUnownQmarkPose96
+.4byte sUnownQmarkPose97
+sAxPositionsUnownQmark:
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -7, 	  -4,   -8, 	   2,   -8, 	  -1,   -8
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -9, 	  -3,   -8, 	   1,  -10, 	  -2,  -12
+.2byte    1,   -9, 	  -2,   -7, 	   1,   -8, 	  -1,  -12
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -7, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -2,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -9, 	  -1,   -8, 	   1,   -7, 	   0,  -11
+.2byte   -2,   -9, 	  -3,  -10, 	   1,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+.2byte   -1,   -8, 	  -4,   -8, 	   2,   -8, 	  -1,   -9
+.2byte    0,   -8, 	  -3,   -8, 	   2,   -9, 	  -1,  -12
+.2byte    1,   -8, 	  -3,   -7, 	   1,   -9, 	  -1,  -11
+.2byte    1,   -8, 	   1,   -9, 	  -3,   -8, 	  -1,  -12
+.2byte   -1,   -8, 	   2,   -8, 	  -4,   -8, 	  -1,  -11
+.2byte   -1,   -9, 	   1,   -8, 	  -3,   -6, 	  -1,  -11
+.2byte   -3,   -8, 	  -1,   -8, 	   1,   -7, 	  -1,  -11
+.2byte   -2,   -8, 	  -3,   -9, 	   1,   -7, 	  -1,  -11
+sUnownQmarkAnimTable1:
+.4byte sUnownQmarkAnims_1_1
+.4byte sUnownQmarkAnims_1_2
+.4byte sUnownQmarkAnims_1_3
+.4byte sUnownQmarkAnims_1_4
+.4byte sUnownQmarkAnims_1_5
+.4byte sUnownQmarkAnims_1_6
+.4byte sUnownQmarkAnims_1_7
+.4byte sUnownQmarkAnims_1_8
+sUnownQmarkAnimTable2:
+.4byte sUnownQmarkAnims_2_1
+.4byte sUnownQmarkAnims_2_2
+.4byte sUnownQmarkAnims_2_3
+.4byte sUnownQmarkAnims_2_4
+.4byte sUnownQmarkAnims_2_5
+.4byte sUnownQmarkAnims_2_6
+.4byte sUnownQmarkAnims_2_7
+.4byte sUnownQmarkAnims_2_8
+sUnownQmarkAnimTable3:
+.4byte sUnownQmarkAnims_3_1
+.4byte sUnownQmarkAnims_3_2
+.4byte sUnownQmarkAnims_3_3
+.4byte sUnownQmarkAnims_3_4
+.4byte sUnownQmarkAnims_3_5
+.4byte sUnownQmarkAnims_3_6
+.4byte sUnownQmarkAnims_3_7
+.4byte sUnownQmarkAnims_3_8
+sUnownQmarkAnimTable4:
+.4byte sUnownQmarkAnims_4_1
+.4byte sUnownQmarkAnims_4_2
+.4byte sUnownQmarkAnims_4_3
+.4byte sUnownQmarkAnims_4_4
+.4byte sUnownQmarkAnims_4_5
+.4byte sUnownQmarkAnims_4_6
+.4byte sUnownQmarkAnims_4_7
+.4byte sUnownQmarkAnims_4_8
+sUnownQmarkAnimTable5:
+.4byte sUnownQmarkAnims_5_1
+.4byte sUnownQmarkAnims_5_2
+.4byte sUnownQmarkAnims_5_3
+.4byte sUnownQmarkAnims_5_4
+.4byte sUnownQmarkAnims_5_5
+.4byte sUnownQmarkAnims_5_6
+.4byte sUnownQmarkAnims_5_7
+.4byte sUnownQmarkAnims_5_8
+sUnownQmarkAnimTable6:
+.4byte sUnownQmarkAnims_6_1
+.4byte sUnownQmarkAnims_6_1
+.4byte sUnownQmarkAnims_6_1
+.4byte sUnownQmarkAnims_6_1
+.4byte sUnownQmarkAnims_6_1
+.4byte sUnownQmarkAnims_6_1
+.4byte sUnownQmarkAnims_6_1
+.4byte sUnownQmarkAnims_6_1
+sUnownQmarkAnimTable7:
+.4byte sUnownQmarkAnims_7_1
+.4byte sUnownQmarkAnims_7_2
+.4byte sUnownQmarkAnims_7_3
+.4byte sUnownQmarkAnims_7_4
+.4byte sUnownQmarkAnims_7_5
+.4byte sUnownQmarkAnims_7_6
+.4byte sUnownQmarkAnims_7_7
+.4byte sUnownQmarkAnims_7_8
+sUnownQmarkAnimTable8:
+.4byte sUnownQmarkAnims_8_1
+.4byte sUnownQmarkAnims_8_2
+.4byte sUnownQmarkAnims_8_3
+.4byte sUnownQmarkAnims_8_4
+.4byte sUnownQmarkAnims_8_5
+.4byte sUnownQmarkAnims_8_6
+.4byte sUnownQmarkAnims_8_7
+.4byte sUnownQmarkAnims_8_8
+sUnownQmarkAnimTable9:
+.4byte sUnownQmarkAnims_9_1
+.4byte sUnownQmarkAnims_9_2
+.4byte sUnownQmarkAnims_9_3
+.4byte sUnownQmarkAnims_9_4
+.4byte sUnownQmarkAnims_9_5
+.4byte sUnownQmarkAnims_9_6
+.4byte sUnownQmarkAnims_9_7
+.4byte sUnownQmarkAnims_9_8
+sUnownQmarkAnimTable10:
+.4byte sUnownQmarkAnims_10_1
+.4byte sUnownQmarkAnims_10_2
+.4byte sUnownQmarkAnims_10_3
+.4byte sUnownQmarkAnims_10_4
+.4byte sUnownQmarkAnims_10_5
+.4byte sUnownQmarkAnims_10_6
+.4byte sUnownQmarkAnims_10_7
+.4byte sUnownQmarkAnims_10_8
+sUnownQmarkAnimTable11:
+.4byte sUnownQmarkAnims_11_1
+.4byte sUnownQmarkAnims_11_2
+.4byte sUnownQmarkAnims_11_3
+.4byte sUnownQmarkAnims_11_4
+.4byte sUnownQmarkAnims_11_5
+.4byte sUnownQmarkAnims_11_6
+.4byte sUnownQmarkAnims_11_7
+.4byte sUnownQmarkAnims_11_8
+sUnownQmarkAnimTable12:
+.4byte sUnownQmarkAnims_12_1
+.4byte sUnownQmarkAnims_12_2
+.4byte sUnownQmarkAnims_12_3
+.4byte sUnownQmarkAnims_12_4
+.4byte sUnownQmarkAnims_12_5
+.4byte sUnownQmarkAnims_12_6
+.4byte sUnownQmarkAnims_12_7
+.4byte sUnownQmarkAnims_12_8
+sUnownQmarkAnimTable13:
+.4byte sUnownQmarkAnims_13_1
+.4byte sUnownQmarkAnims_13_2
+.4byte sUnownQmarkAnims_13_3
+.4byte sUnownQmarkAnims_13_4
+.4byte sUnownQmarkAnims_13_5
+.4byte sUnownQmarkAnims_13_6
+.4byte sUnownQmarkAnims_13_7
+.4byte sUnownQmarkAnims_13_8
+sAxAnimationsUnownQmark:
+.4byte sUnownQmarkAnimTable1
+.4byte sUnownQmarkAnimTable2
+.4byte sUnownQmarkAnimTable3
+.4byte sUnownQmarkAnimTable4
+.4byte sUnownQmarkAnimTable5
+.4byte sUnownQmarkAnimTable6
+.4byte sUnownQmarkAnimTable7
+.4byte sUnownQmarkAnimTable8
+.4byte sUnownQmarkAnimTable9
+.4byte sUnownQmarkAnimTable10
+.4byte sUnownQmarkAnimTable11
+.4byte sUnownQmarkAnimTable12
+.4byte sUnownQmarkAnimTable13
+sAxSpritesUnownQmark:
+.4byte sUnownQmarkSprites1
+.4byte sUnownQmarkSprites2
+.4byte sUnownQmarkSprites3
+.4byte sUnownQmarkSprites4
+.4byte sUnownQmarkSprites5
+.4byte sUnownQmarkSprites6
+.4byte sUnownQmarkSprites7
+.4byte sUnownQmarkSprites8
+.4byte sUnownQmarkSprites9
+.4byte sUnownQmarkSprites10
+.4byte sUnownQmarkSprites11
+.4byte sUnownQmarkSprites12
+.4byte sUnownQmarkSprites13
+.4byte sUnownQmarkSprites14
+.4byte sUnownQmarkSprites15
+.4byte sUnownQmarkSprites16
+.4byte sUnownQmarkSprites17
+sAxMainUnownQmark:
+ax_main sAxPosesUnownQmark, sAxAnimationsUnownQmark, 13, sAxSpritesUnownQmark, sAxPositionsUnownQmark

--- a/data/ax/unownr.inc
+++ b/data/ax/unownr.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownR
+gAxUnownR:
+ax_siro sAxMainUnownR
+sUnownRPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose42:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownRPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownRPose45:
+ax_pose 12, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownRPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose47:
+ax_pose 14, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownRPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownRPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownRAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownRAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownRAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownRAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownRAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownRAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownRAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownRAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownRAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownRAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownRAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownRAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownRAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownRAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownRAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownRAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownRAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownRAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownRAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownRAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownRAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownRAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownRAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownRAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownRAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownRAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownRAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownRAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownRAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownRAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownRAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownRAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownRAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownRAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownRAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownRAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownRAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownRAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownRAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownRAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownRAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownRAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownRAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownRAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownRAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownRAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownRAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownRAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownRAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownRAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownRGfx1:
+.incbin "baserom.gba", 0xDF89A8, 0x200
+sUnownRSprites1:
+ax_sprite sUnownRGfx1, 0x200
+ax_sprite_terminator
+sUnownRGfx2:
+.incbin "baserom.gba", 0xDF8BB8, 0x200
+sUnownRSprites2:
+ax_sprite sUnownRGfx2, 0x200
+ax_sprite_terminator
+sUnownRGfx3:
+.incbin "baserom.gba", 0xDF8DC8, 0x200
+sUnownRSprites3:
+ax_sprite sUnownRGfx3, 0x200
+ax_sprite_terminator
+sUnownRGfx4:
+.incbin "baserom.gba", 0xDF8FD8, 0x200
+sUnownRSprites4:
+ax_sprite sUnownRGfx4, 0x200
+ax_sprite_terminator
+sUnownRGfx5:
+.incbin "baserom.gba", 0xDF91E8, 0x200
+sUnownRSprites5:
+ax_sprite sUnownRGfx5, 0x200
+ax_sprite_terminator
+sUnownRGfx6:
+.incbin "baserom.gba", 0xDF93F8, 0x200
+sUnownRSprites6:
+ax_sprite sUnownRGfx6, 0x200
+ax_sprite_terminator
+sUnownRGfx7:
+.incbin "baserom.gba", 0xDF9608, 0x200
+sUnownRSprites7:
+ax_sprite sUnownRGfx7, 0x200
+ax_sprite_terminator
+sUnownRGfx8:
+.incbin "baserom.gba", 0xDF9818, 0x200
+sUnownRSprites8:
+ax_sprite sUnownRGfx8, 0x200
+ax_sprite_terminator
+sUnownRGfx9:
+.incbin "baserom.gba", 0xDF9A28, 0x200
+sUnownRSprites9:
+ax_sprite sUnownRGfx9, 0x200
+ax_sprite_terminator
+sUnownRGfx10:
+.incbin "baserom.gba", 0xDF9C38, 0x200
+sUnownRSprites10:
+ax_sprite sUnownRGfx10, 0x200
+ax_sprite_terminator
+sUnownRGfx11:
+.incbin "baserom.gba", 0xDF9E48, 0x200
+sUnownRSprites11:
+ax_sprite sUnownRGfx11, 0x200
+ax_sprite_terminator
+sUnownRGfx12:
+.incbin "baserom.gba", 0xDFA058, 0x200
+sUnownRSprites12:
+ax_sprite sUnownRGfx12, 0x200
+ax_sprite_terminator
+sUnownRGfx13:
+.incbin "baserom.gba", 0xDFA268, 0x200
+sUnownRSprites13:
+ax_sprite sUnownRGfx13, 0x200
+ax_sprite_terminator
+sUnownRGfx14:
+.incbin "baserom.gba", 0xDFA478, 0x200
+sUnownRSprites14:
+ax_sprite sUnownRGfx14, 0x200
+ax_sprite_terminator
+sUnownRGfx15:
+.incbin "baserom.gba", 0xDFA688, 0x200
+sUnownRSprites15:
+ax_sprite sUnownRGfx15, 0x200
+ax_sprite_terminator
+sUnownRGfx16:
+.incbin "baserom.gba", 0xDFA898, 0x200
+sUnownRSprites16:
+ax_sprite sUnownRGfx16, 0x200
+ax_sprite_terminator
+sUnownRGfx17:
+.incbin "baserom.gba", 0xDFAAA8, 0x200
+sUnownRSprites17:
+ax_sprite sUnownRGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownR:
+.4byte sUnownRPose1
+.4byte sUnownRPose2
+.4byte sUnownRPose3
+.4byte sUnownRPose4
+.4byte sUnownRPose5
+.4byte sUnownRPose6
+.4byte sUnownRPose7
+.4byte sUnownRPose8
+.4byte sUnownRPose9
+.4byte sUnownRPose10
+.4byte sUnownRPose11
+.4byte sUnownRPose12
+.4byte sUnownRPose13
+.4byte sUnownRPose14
+.4byte sUnownRPose15
+.4byte sUnownRPose16
+.4byte sUnownRPose17
+.4byte sUnownRPose18
+.4byte sUnownRPose19
+.4byte sUnownRPose20
+.4byte sUnownRPose21
+.4byte sUnownRPose22
+.4byte sUnownRPose23
+.4byte sUnownRPose24
+.4byte sUnownRPose25
+.4byte sUnownRPose26
+.4byte sUnownRPose27
+.4byte sUnownRPose28
+.4byte sUnownRPose29
+.4byte sUnownRPose30
+.4byte sUnownRPose31
+.4byte sUnownRPose32
+.4byte sUnownRPose33
+.4byte sUnownRPose34
+.4byte sUnownRPose35
+.4byte sUnownRPose36
+.4byte sUnownRPose37
+.4byte sUnownRPose38
+.4byte sUnownRPose39
+.4byte sUnownRPose40
+.4byte sUnownRPose41
+.4byte sUnownRPose42
+.4byte sUnownRPose43
+.4byte sUnownRPose44
+.4byte sUnownRPose45
+.4byte sUnownRPose46
+.4byte sUnownRPose47
+.4byte sUnownRPose48
+.4byte sUnownRPose49
+.4byte sUnownRPose50
+.4byte sUnownRPose51
+.4byte sUnownRPose52
+.4byte sUnownRPose53
+.4byte sUnownRPose54
+.4byte sUnownRPose55
+.4byte sUnownRPose56
+.4byte sUnownRPose57
+.4byte sUnownRPose58
+.4byte sUnownRPose59
+.4byte sUnownRPose60
+.4byte sUnownRPose61
+.4byte sUnownRPose62
+.4byte sUnownRPose63
+.4byte sUnownRPose64
+.4byte sUnownRPose65
+.4byte sUnownRPose66
+.4byte sUnownRPose67
+.4byte sUnownRPose68
+.4byte sUnownRPose69
+.4byte sUnownRPose70
+.4byte sUnownRPose71
+.4byte sUnownRPose72
+.4byte sUnownRPose73
+.4byte sUnownRPose74
+.4byte sUnownRPose75
+.4byte sUnownRPose76
+.4byte sUnownRPose77
+.4byte sUnownRPose78
+.4byte sUnownRPose79
+.4byte sUnownRPose80
+.4byte sUnownRPose81
+.4byte sUnownRPose82
+.4byte sUnownRPose83
+.4byte sUnownRPose84
+.4byte sUnownRPose85
+.4byte sUnownRPose86
+.4byte sUnownRPose87
+.4byte sUnownRPose88
+.4byte sUnownRPose89
+.4byte sUnownRPose90
+.4byte sUnownRPose91
+.4byte sUnownRPose92
+.4byte sUnownRPose93
+.4byte sUnownRPose94
+.4byte sUnownRPose95
+.4byte sUnownRPose96
+.4byte sUnownRPose97
+sAxPositionsUnownR:
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte   -1,  -15, 	   0,   -5, 	   3,  -10, 	  -2,  -11
+.2byte    0,  -15, 	   0,   -5, 	   1,  -10, 	  -1,  -11
+.2byte    0,  -15, 	   1,   -6, 	  -3,   -8, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -7, 	  -6,  -10, 	   0,  -13
+.2byte   -2,  -15, 	  -1,   -6, 	  -4,   -9, 	  -1,  -13
+.2byte   -2,  -15, 	  -2,   -6, 	   1,   -8, 	   0,  -12
+.2byte   -2,  -15, 	  -4,   -7, 	   2,   -9, 	  -1,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+.2byte   -1,  -14, 	  -4,   -6, 	   3,   -9, 	  -1,  -12
+.2byte    0,  -14, 	  -3,   -5, 	   1,   -8, 	  -2,  -11
+.2byte    1,  -14, 	  -1,   -5, 	   1,   -9, 	  -1,  -10
+.2byte    0,  -15, 	   0,   -5, 	  -3,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	   2,   -6, 	  -5,   -9, 	   0,  -13
+.2byte   -2,  -15, 	   1,   -7, 	  -4,   -8, 	  -1,  -13
+.2byte   -3,  -14, 	  -1,   -7, 	   1,   -8, 	  -1,  -12
+.2byte   -2,  -14, 	  -3,   -7, 	   2,   -8, 	  -2,  -12
+sUnownRAnimTable1:
+.4byte sUnownRAnims_1_1
+.4byte sUnownRAnims_1_2
+.4byte sUnownRAnims_1_3
+.4byte sUnownRAnims_1_4
+.4byte sUnownRAnims_1_5
+.4byte sUnownRAnims_1_6
+.4byte sUnownRAnims_1_7
+.4byte sUnownRAnims_1_8
+sUnownRAnimTable2:
+.4byte sUnownRAnims_2_1
+.4byte sUnownRAnims_2_2
+.4byte sUnownRAnims_2_3
+.4byte sUnownRAnims_2_4
+.4byte sUnownRAnims_2_5
+.4byte sUnownRAnims_2_6
+.4byte sUnownRAnims_2_7
+.4byte sUnownRAnims_2_8
+sUnownRAnimTable3:
+.4byte sUnownRAnims_3_1
+.4byte sUnownRAnims_3_2
+.4byte sUnownRAnims_3_3
+.4byte sUnownRAnims_3_4
+.4byte sUnownRAnims_3_5
+.4byte sUnownRAnims_3_6
+.4byte sUnownRAnims_3_7
+.4byte sUnownRAnims_3_8
+sUnownRAnimTable4:
+.4byte sUnownRAnims_4_1
+.4byte sUnownRAnims_4_2
+.4byte sUnownRAnims_4_3
+.4byte sUnownRAnims_4_4
+.4byte sUnownRAnims_4_5
+.4byte sUnownRAnims_4_6
+.4byte sUnownRAnims_4_7
+.4byte sUnownRAnims_4_8
+sUnownRAnimTable5:
+.4byte sUnownRAnims_5_1
+.4byte sUnownRAnims_5_2
+.4byte sUnownRAnims_5_3
+.4byte sUnownRAnims_5_4
+.4byte sUnownRAnims_5_5
+.4byte sUnownRAnims_5_6
+.4byte sUnownRAnims_5_7
+.4byte sUnownRAnims_5_8
+sUnownRAnimTable6:
+.4byte sUnownRAnims_6_1
+.4byte sUnownRAnims_6_1
+.4byte sUnownRAnims_6_1
+.4byte sUnownRAnims_6_1
+.4byte sUnownRAnims_6_1
+.4byte sUnownRAnims_6_1
+.4byte sUnownRAnims_6_1
+.4byte sUnownRAnims_6_1
+sUnownRAnimTable7:
+.4byte sUnownRAnims_7_1
+.4byte sUnownRAnims_7_2
+.4byte sUnownRAnims_7_3
+.4byte sUnownRAnims_7_4
+.4byte sUnownRAnims_7_5
+.4byte sUnownRAnims_7_6
+.4byte sUnownRAnims_7_7
+.4byte sUnownRAnims_7_8
+sUnownRAnimTable8:
+.4byte sUnownRAnims_8_1
+.4byte sUnownRAnims_8_2
+.4byte sUnownRAnims_8_3
+.4byte sUnownRAnims_8_4
+.4byte sUnownRAnims_8_5
+.4byte sUnownRAnims_8_6
+.4byte sUnownRAnims_8_7
+.4byte sUnownRAnims_8_8
+sUnownRAnimTable9:
+.4byte sUnownRAnims_9_1
+.4byte sUnownRAnims_9_2
+.4byte sUnownRAnims_9_3
+.4byte sUnownRAnims_9_4
+.4byte sUnownRAnims_9_5
+.4byte sUnownRAnims_9_6
+.4byte sUnownRAnims_9_7
+.4byte sUnownRAnims_9_8
+sUnownRAnimTable10:
+.4byte sUnownRAnims_10_1
+.4byte sUnownRAnims_10_2
+.4byte sUnownRAnims_10_3
+.4byte sUnownRAnims_10_4
+.4byte sUnownRAnims_10_5
+.4byte sUnownRAnims_10_6
+.4byte sUnownRAnims_10_7
+.4byte sUnownRAnims_10_8
+sUnownRAnimTable11:
+.4byte sUnownRAnims_11_1
+.4byte sUnownRAnims_11_2
+.4byte sUnownRAnims_11_3
+.4byte sUnownRAnims_11_4
+.4byte sUnownRAnims_11_5
+.4byte sUnownRAnims_11_6
+.4byte sUnownRAnims_11_7
+.4byte sUnownRAnims_11_8
+sUnownRAnimTable12:
+.4byte sUnownRAnims_12_1
+.4byte sUnownRAnims_12_2
+.4byte sUnownRAnims_12_3
+.4byte sUnownRAnims_12_4
+.4byte sUnownRAnims_12_5
+.4byte sUnownRAnims_12_6
+.4byte sUnownRAnims_12_7
+.4byte sUnownRAnims_12_8
+sUnownRAnimTable13:
+.4byte sUnownRAnims_13_1
+.4byte sUnownRAnims_13_2
+.4byte sUnownRAnims_13_3
+.4byte sUnownRAnims_13_4
+.4byte sUnownRAnims_13_5
+.4byte sUnownRAnims_13_6
+.4byte sUnownRAnims_13_7
+.4byte sUnownRAnims_13_8
+sAxAnimationsUnownR:
+.4byte sUnownRAnimTable1
+.4byte sUnownRAnimTable2
+.4byte sUnownRAnimTable3
+.4byte sUnownRAnimTable4
+.4byte sUnownRAnimTable5
+.4byte sUnownRAnimTable6
+.4byte sUnownRAnimTable7
+.4byte sUnownRAnimTable8
+.4byte sUnownRAnimTable9
+.4byte sUnownRAnimTable10
+.4byte sUnownRAnimTable11
+.4byte sUnownRAnimTable12
+.4byte sUnownRAnimTable13
+sAxSpritesUnownR:
+.4byte sUnownRSprites1
+.4byte sUnownRSprites2
+.4byte sUnownRSprites3
+.4byte sUnownRSprites4
+.4byte sUnownRSprites5
+.4byte sUnownRSprites6
+.4byte sUnownRSprites7
+.4byte sUnownRSprites8
+.4byte sUnownRSprites9
+.4byte sUnownRSprites10
+.4byte sUnownRSprites11
+.4byte sUnownRSprites12
+.4byte sUnownRSprites13
+.4byte sUnownRSprites14
+.4byte sUnownRSprites15
+.4byte sUnownRSprites16
+.4byte sUnownRSprites17
+sAxMainUnownR:
+ax_main sAxPosesUnownR, sAxAnimationsUnownR, 13, sAxSpritesUnownR, sAxPositionsUnownR

--- a/data/ax/unowns.inc
+++ b/data/ax/unowns.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownS
+gAxUnownS:
+ax_siro sAxMainUnownS
+sUnownSPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownSPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownSPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownSPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownSPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownSPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownSAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownSAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownSAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownSAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownSAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownSAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownSAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownSAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownSAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownSAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownSAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownSAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownSAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownSAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownSAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownSAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownSAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownSAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownSAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownSAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownSAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownSAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownSAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownSAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownSAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownSAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownSAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownSAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownSAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownSAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownSAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownSAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownSAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownSAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownSAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownSAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownSAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownSAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownSAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownSAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownSAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownSAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownSAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownSAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownSAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownSAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownSAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownSAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownSAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownSAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownSGfx1:
+.incbin "baserom.gba", 0xDFEBB8, 0x200
+sUnownSSprites1:
+ax_sprite sUnownSGfx1, 0x200
+ax_sprite_terminator
+sUnownSGfx2:
+.incbin "baserom.gba", 0xDFEDC8, 0x200
+sUnownSSprites2:
+ax_sprite sUnownSGfx2, 0x200
+ax_sprite_terminator
+sUnownSGfx3:
+.incbin "baserom.gba", 0xDFEFD8, 0x200
+sUnownSSprites3:
+ax_sprite sUnownSGfx3, 0x200
+ax_sprite_terminator
+sUnownSGfx4:
+.incbin "baserom.gba", 0xDFF1E8, 0x200
+sUnownSSprites4:
+ax_sprite sUnownSGfx4, 0x200
+ax_sprite_terminator
+sUnownSGfx5:
+.incbin "baserom.gba", 0xDFF3F8, 0x200
+sUnownSSprites5:
+ax_sprite sUnownSGfx5, 0x200
+ax_sprite_terminator
+sUnownSGfx6:
+.incbin "baserom.gba", 0xDFF608, 0x200
+sUnownSSprites6:
+ax_sprite sUnownSGfx6, 0x200
+ax_sprite_terminator
+sUnownSGfx7:
+.incbin "baserom.gba", 0xDFF818, 0x200
+sUnownSSprites7:
+ax_sprite sUnownSGfx7, 0x200
+ax_sprite_terminator
+sUnownSGfx8:
+.incbin "baserom.gba", 0xDFFA28, 0x200
+sUnownSSprites8:
+ax_sprite sUnownSGfx8, 0x200
+ax_sprite_terminator
+sUnownSGfx9:
+.incbin "baserom.gba", 0xDFFC38, 0x200
+sUnownSSprites9:
+ax_sprite sUnownSGfx9, 0x200
+ax_sprite_terminator
+sUnownSGfx10:
+.incbin "baserom.gba", 0xDFFE48, 0x200
+sUnownSSprites10:
+ax_sprite sUnownSGfx10, 0x200
+ax_sprite_terminator
+sUnownSGfx11:
+.incbin "baserom.gba", 0xE00058, 0x200
+sUnownSSprites11:
+ax_sprite sUnownSGfx11, 0x200
+ax_sprite_terminator
+sUnownSGfx12:
+.incbin "baserom.gba", 0xE00268, 0x200
+sUnownSSprites12:
+ax_sprite sUnownSGfx12, 0x200
+ax_sprite_terminator
+sUnownSGfx13:
+.incbin "baserom.gba", 0xE00478, 0x200
+sUnownSSprites13:
+ax_sprite sUnownSGfx13, 0x200
+ax_sprite_terminator
+sUnownSGfx14:
+.incbin "baserom.gba", 0xE00688, 0x200
+sUnownSSprites14:
+ax_sprite sUnownSGfx14, 0x200
+ax_sprite_terminator
+sUnownSGfx15:
+.incbin "baserom.gba", 0xE00898, 0x200
+sUnownSSprites15:
+ax_sprite sUnownSGfx15, 0x200
+ax_sprite_terminator
+sUnownSGfx16:
+.incbin "baserom.gba", 0xE00AA8, 0x200
+sUnownSSprites16:
+ax_sprite sUnownSGfx16, 0x200
+ax_sprite_terminator
+sUnownSGfx17:
+.incbin "baserom.gba", 0xE00CB8, 0x200
+sUnownSSprites17:
+ax_sprite sUnownSGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownS:
+.4byte sUnownSPose1
+.4byte sUnownSPose2
+.4byte sUnownSPose3
+.4byte sUnownSPose4
+.4byte sUnownSPose5
+.4byte sUnownSPose6
+.4byte sUnownSPose7
+.4byte sUnownSPose8
+.4byte sUnownSPose9
+.4byte sUnownSPose10
+.4byte sUnownSPose11
+.4byte sUnownSPose12
+.4byte sUnownSPose13
+.4byte sUnownSPose14
+.4byte sUnownSPose15
+.4byte sUnownSPose16
+.4byte sUnownSPose17
+.4byte sUnownSPose18
+.4byte sUnownSPose19
+.4byte sUnownSPose20
+.4byte sUnownSPose21
+.4byte sUnownSPose22
+.4byte sUnownSPose23
+.4byte sUnownSPose24
+.4byte sUnownSPose25
+.4byte sUnownSPose26
+.4byte sUnownSPose27
+.4byte sUnownSPose28
+.4byte sUnownSPose29
+.4byte sUnownSPose30
+.4byte sUnownSPose31
+.4byte sUnownSPose32
+.4byte sUnownSPose33
+.4byte sUnownSPose34
+.4byte sUnownSPose35
+.4byte sUnownSPose36
+.4byte sUnownSPose37
+.4byte sUnownSPose38
+.4byte sUnownSPose39
+.4byte sUnownSPose40
+.4byte sUnownSPose41
+.4byte sUnownSPose42
+.4byte sUnownSPose43
+.4byte sUnownSPose44
+.4byte sUnownSPose45
+.4byte sUnownSPose46
+.4byte sUnownSPose47
+.4byte sUnownSPose48
+.4byte sUnownSPose49
+.4byte sUnownSPose50
+.4byte sUnownSPose51
+.4byte sUnownSPose52
+.4byte sUnownSPose53
+.4byte sUnownSPose54
+.4byte sUnownSPose55
+.4byte sUnownSPose56
+.4byte sUnownSPose57
+.4byte sUnownSPose58
+.4byte sUnownSPose59
+.4byte sUnownSPose60
+.4byte sUnownSPose61
+.4byte sUnownSPose62
+.4byte sUnownSPose63
+.4byte sUnownSPose64
+.4byte sUnownSPose65
+.4byte sUnownSPose66
+.4byte sUnownSPose67
+.4byte sUnownSPose68
+.4byte sUnownSPose69
+.4byte sUnownSPose70
+.4byte sUnownSPose71
+.4byte sUnownSPose72
+.4byte sUnownSPose73
+.4byte sUnownSPose74
+.4byte sUnownSPose75
+.4byte sUnownSPose76
+.4byte sUnownSPose77
+.4byte sUnownSPose78
+.4byte sUnownSPose79
+.4byte sUnownSPose80
+.4byte sUnownSPose81
+.4byte sUnownSPose82
+.4byte sUnownSPose83
+.4byte sUnownSPose84
+.4byte sUnownSPose85
+.4byte sUnownSPose86
+.4byte sUnownSPose87
+.4byte sUnownSPose88
+.4byte sUnownSPose89
+.4byte sUnownSPose90
+.4byte sUnownSPose91
+.4byte sUnownSPose92
+.4byte sUnownSPose93
+.4byte sUnownSPose94
+.4byte sUnownSPose95
+.4byte sUnownSPose96
+.4byte sUnownSPose97
+sAxPositionsUnownS:
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	  -1,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    1,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   1,   -5, 	  -1,  -12
+.2byte   -1,  -13, 	  -1,  -18, 	  -1,   -6, 	  -1,  -11
+.2byte   -2,  -13, 	  -1,  -19, 	  -1,   -5, 	  -1,  -12
+.2byte   -3,  -13, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte   -2,  -13, 	   1,  -19, 	  -3,   -5, 	   0,  -10
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+.2byte   -1,  -12, 	  -2,  -19, 	   0,   -5, 	  -1,  -11
+.2byte    0,  -12, 	   0,  -19, 	  -2,   -5, 	  -1,  -11
+.2byte    1,  -12, 	  -2,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte    0,  -13, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -1,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,  -19, 	   0,   -5, 	  -1,  -12
+.2byte   -3,  -12, 	  -1,  -19, 	  -1,   -5, 	  -1,  -11
+.2byte   -2,  -12, 	  -1,  -19, 	  -2,   -5, 	   0,  -11
+sUnownSAnimTable1:
+.4byte sUnownSAnims_1_1
+.4byte sUnownSAnims_1_2
+.4byte sUnownSAnims_1_3
+.4byte sUnownSAnims_1_4
+.4byte sUnownSAnims_1_5
+.4byte sUnownSAnims_1_6
+.4byte sUnownSAnims_1_7
+.4byte sUnownSAnims_1_8
+sUnownSAnimTable2:
+.4byte sUnownSAnims_2_1
+.4byte sUnownSAnims_2_2
+.4byte sUnownSAnims_2_3
+.4byte sUnownSAnims_2_4
+.4byte sUnownSAnims_2_5
+.4byte sUnownSAnims_2_6
+.4byte sUnownSAnims_2_7
+.4byte sUnownSAnims_2_8
+sUnownSAnimTable3:
+.4byte sUnownSAnims_3_1
+.4byte sUnownSAnims_3_2
+.4byte sUnownSAnims_3_3
+.4byte sUnownSAnims_3_4
+.4byte sUnownSAnims_3_5
+.4byte sUnownSAnims_3_6
+.4byte sUnownSAnims_3_7
+.4byte sUnownSAnims_3_8
+sUnownSAnimTable4:
+.4byte sUnownSAnims_4_1
+.4byte sUnownSAnims_4_2
+.4byte sUnownSAnims_4_3
+.4byte sUnownSAnims_4_4
+.4byte sUnownSAnims_4_5
+.4byte sUnownSAnims_4_6
+.4byte sUnownSAnims_4_7
+.4byte sUnownSAnims_4_8
+sUnownSAnimTable5:
+.4byte sUnownSAnims_5_1
+.4byte sUnownSAnims_5_2
+.4byte sUnownSAnims_5_3
+.4byte sUnownSAnims_5_4
+.4byte sUnownSAnims_5_5
+.4byte sUnownSAnims_5_6
+.4byte sUnownSAnims_5_7
+.4byte sUnownSAnims_5_8
+sUnownSAnimTable6:
+.4byte sUnownSAnims_6_1
+.4byte sUnownSAnims_6_1
+.4byte sUnownSAnims_6_1
+.4byte sUnownSAnims_6_1
+.4byte sUnownSAnims_6_1
+.4byte sUnownSAnims_6_1
+.4byte sUnownSAnims_6_1
+.4byte sUnownSAnims_6_1
+sUnownSAnimTable7:
+.4byte sUnownSAnims_7_1
+.4byte sUnownSAnims_7_2
+.4byte sUnownSAnims_7_3
+.4byte sUnownSAnims_7_4
+.4byte sUnownSAnims_7_5
+.4byte sUnownSAnims_7_6
+.4byte sUnownSAnims_7_7
+.4byte sUnownSAnims_7_8
+sUnownSAnimTable8:
+.4byte sUnownSAnims_8_1
+.4byte sUnownSAnims_8_2
+.4byte sUnownSAnims_8_3
+.4byte sUnownSAnims_8_4
+.4byte sUnownSAnims_8_5
+.4byte sUnownSAnims_8_6
+.4byte sUnownSAnims_8_7
+.4byte sUnownSAnims_8_8
+sUnownSAnimTable9:
+.4byte sUnownSAnims_9_1
+.4byte sUnownSAnims_9_2
+.4byte sUnownSAnims_9_3
+.4byte sUnownSAnims_9_4
+.4byte sUnownSAnims_9_5
+.4byte sUnownSAnims_9_6
+.4byte sUnownSAnims_9_7
+.4byte sUnownSAnims_9_8
+sUnownSAnimTable10:
+.4byte sUnownSAnims_10_1
+.4byte sUnownSAnims_10_2
+.4byte sUnownSAnims_10_3
+.4byte sUnownSAnims_10_4
+.4byte sUnownSAnims_10_5
+.4byte sUnownSAnims_10_6
+.4byte sUnownSAnims_10_7
+.4byte sUnownSAnims_10_8
+sUnownSAnimTable11:
+.4byte sUnownSAnims_11_1
+.4byte sUnownSAnims_11_2
+.4byte sUnownSAnims_11_3
+.4byte sUnownSAnims_11_4
+.4byte sUnownSAnims_11_5
+.4byte sUnownSAnims_11_6
+.4byte sUnownSAnims_11_7
+.4byte sUnownSAnims_11_8
+sUnownSAnimTable12:
+.4byte sUnownSAnims_12_1
+.4byte sUnownSAnims_12_2
+.4byte sUnownSAnims_12_3
+.4byte sUnownSAnims_12_4
+.4byte sUnownSAnims_12_5
+.4byte sUnownSAnims_12_6
+.4byte sUnownSAnims_12_7
+.4byte sUnownSAnims_12_8
+sUnownSAnimTable13:
+.4byte sUnownSAnims_13_1
+.4byte sUnownSAnims_13_2
+.4byte sUnownSAnims_13_3
+.4byte sUnownSAnims_13_4
+.4byte sUnownSAnims_13_5
+.4byte sUnownSAnims_13_6
+.4byte sUnownSAnims_13_7
+.4byte sUnownSAnims_13_8
+sAxAnimationsUnownS:
+.4byte sUnownSAnimTable1
+.4byte sUnownSAnimTable2
+.4byte sUnownSAnimTable3
+.4byte sUnownSAnimTable4
+.4byte sUnownSAnimTable5
+.4byte sUnownSAnimTable6
+.4byte sUnownSAnimTable7
+.4byte sUnownSAnimTable8
+.4byte sUnownSAnimTable9
+.4byte sUnownSAnimTable10
+.4byte sUnownSAnimTable11
+.4byte sUnownSAnimTable12
+.4byte sUnownSAnimTable13
+sAxSpritesUnownS:
+.4byte sUnownSSprites1
+.4byte sUnownSSprites2
+.4byte sUnownSSprites3
+.4byte sUnownSSprites4
+.4byte sUnownSSprites5
+.4byte sUnownSSprites6
+.4byte sUnownSSprites7
+.4byte sUnownSSprites8
+.4byte sUnownSSprites9
+.4byte sUnownSSprites10
+.4byte sUnownSSprites11
+.4byte sUnownSSprites12
+.4byte sUnownSSprites13
+.4byte sUnownSSprites14
+.4byte sUnownSSprites15
+.4byte sUnownSSprites16
+.4byte sUnownSSprites17
+sAxMainUnownS:
+ax_main sAxPosesUnownS, sAxAnimationsUnownS, 13, sAxSpritesUnownS, sAxPositionsUnownS

--- a/data/ax/unownt.inc
+++ b/data/ax/unownt.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownT
+gAxUnownT:
+ax_siro sAxMainUnownT
+sUnownTPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose2:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose3:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose4:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose6:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose7:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose8:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose10:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose11:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose12:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose14:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose15:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose16:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose18:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose19:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose20:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose22:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose23:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose24:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose26:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose27:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose28:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose30:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose31:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose32:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose34:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose35:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose36:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose38:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose39:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose40:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose42:
+ax_pose 6, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose43:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownTPose44:
+ax_pose 8, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose45:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose47:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose48:
+ax_pose 8, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose49:
+ax_pose 7, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownTPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose51:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose52:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose53:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose55:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose56:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose57:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose59:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose60:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose61:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose63:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose64:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose65:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose67:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose68:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose69:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose71:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose72:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose73:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose75:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose76:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose77:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose79:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose80:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose81:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose83:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose84:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose85:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose87:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose88:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose89:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose91:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose92:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose93:
+ax_pose 3, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownTPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose95:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose96:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownTPose97:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownTAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownTAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownTAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownTAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownTAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownTAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownTAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownTAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownTAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownTAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownTAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownTAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownTAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownTAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownTAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownTAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownTAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownTAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownTAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownTAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownTAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownTAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownTAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownTAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownTAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownTAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownTAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownTAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownTAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownTAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownTAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownTAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownTAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownTAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownTAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownTAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownTAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownTAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownTAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownTAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownTAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownTAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownTAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownTAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownTAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownTAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownTAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownTAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownTAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownTAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownTGfx1:
+.incbin "baserom.gba", 0xE04DC8, 0x200
+sUnownTSprites1:
+ax_sprite sUnownTGfx1, 0x200
+ax_sprite_terminator
+sUnownTGfx2:
+.incbin "baserom.gba", 0xE04FD8, 0x200
+sUnownTSprites2:
+ax_sprite sUnownTGfx2, 0x200
+ax_sprite_terminator
+sUnownTGfx3:
+.incbin "baserom.gba", 0xE051E8, 0x200
+sUnownTSprites3:
+ax_sprite sUnownTGfx3, 0x200
+ax_sprite_terminator
+sUnownTGfx4:
+.incbin "baserom.gba", 0xE053F8, 0x200
+sUnownTSprites4:
+ax_sprite sUnownTGfx4, 0x200
+ax_sprite_terminator
+sUnownTGfx5:
+.incbin "baserom.gba", 0xE05608, 0x200
+sUnownTSprites5:
+ax_sprite sUnownTGfx5, 0x200
+ax_sprite_terminator
+sUnownTGfx6:
+.incbin "baserom.gba", 0xE05818, 0x200
+sUnownTSprites6:
+ax_sprite sUnownTGfx6, 0x200
+ax_sprite_terminator
+sUnownTGfx7:
+.incbin "baserom.gba", 0xE05A28, 0x200
+sUnownTSprites7:
+ax_sprite sUnownTGfx7, 0x200
+ax_sprite_terminator
+sUnownTGfx8:
+.incbin "baserom.gba", 0xE05C38, 0x200
+sUnownTSprites8:
+ax_sprite sUnownTGfx8, 0x200
+ax_sprite_terminator
+sUnownTGfx9:
+.incbin "baserom.gba", 0xE05E48, 0x200
+sUnownTSprites9:
+ax_sprite sUnownTGfx9, 0x200
+ax_sprite_terminator
+sUnownTGfx10:
+.incbin "baserom.gba", 0xE06058, 0x200
+sUnownTSprites10:
+ax_sprite sUnownTGfx10, 0x200
+ax_sprite_terminator
+sUnownTGfx11:
+.incbin "baserom.gba", 0xE06268, 0x200
+sUnownTSprites11:
+ax_sprite sUnownTGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownT:
+.4byte sUnownTPose1
+.4byte sUnownTPose2
+.4byte sUnownTPose3
+.4byte sUnownTPose4
+.4byte sUnownTPose5
+.4byte sUnownTPose6
+.4byte sUnownTPose7
+.4byte sUnownTPose8
+.4byte sUnownTPose9
+.4byte sUnownTPose10
+.4byte sUnownTPose11
+.4byte sUnownTPose12
+.4byte sUnownTPose13
+.4byte sUnownTPose14
+.4byte sUnownTPose15
+.4byte sUnownTPose16
+.4byte sUnownTPose17
+.4byte sUnownTPose18
+.4byte sUnownTPose19
+.4byte sUnownTPose20
+.4byte sUnownTPose21
+.4byte sUnownTPose22
+.4byte sUnownTPose23
+.4byte sUnownTPose24
+.4byte sUnownTPose25
+.4byte sUnownTPose26
+.4byte sUnownTPose27
+.4byte sUnownTPose28
+.4byte sUnownTPose29
+.4byte sUnownTPose30
+.4byte sUnownTPose31
+.4byte sUnownTPose32
+.4byte sUnownTPose33
+.4byte sUnownTPose34
+.4byte sUnownTPose35
+.4byte sUnownTPose36
+.4byte sUnownTPose37
+.4byte sUnownTPose38
+.4byte sUnownTPose39
+.4byte sUnownTPose40
+.4byte sUnownTPose41
+.4byte sUnownTPose42
+.4byte sUnownTPose43
+.4byte sUnownTPose44
+.4byte sUnownTPose45
+.4byte sUnownTPose46
+.4byte sUnownTPose47
+.4byte sUnownTPose48
+.4byte sUnownTPose49
+.4byte sUnownTPose50
+.4byte sUnownTPose51
+.4byte sUnownTPose52
+.4byte sUnownTPose53
+.4byte sUnownTPose54
+.4byte sUnownTPose55
+.4byte sUnownTPose56
+.4byte sUnownTPose57
+.4byte sUnownTPose58
+.4byte sUnownTPose59
+.4byte sUnownTPose60
+.4byte sUnownTPose61
+.4byte sUnownTPose62
+.4byte sUnownTPose63
+.4byte sUnownTPose64
+.4byte sUnownTPose65
+.4byte sUnownTPose66
+.4byte sUnownTPose67
+.4byte sUnownTPose68
+.4byte sUnownTPose69
+.4byte sUnownTPose70
+.4byte sUnownTPose71
+.4byte sUnownTPose72
+.4byte sUnownTPose73
+.4byte sUnownTPose74
+.4byte sUnownTPose75
+.4byte sUnownTPose76
+.4byte sUnownTPose77
+.4byte sUnownTPose78
+.4byte sUnownTPose79
+.4byte sUnownTPose80
+.4byte sUnownTPose81
+.4byte sUnownTPose82
+.4byte sUnownTPose83
+.4byte sUnownTPose84
+.4byte sUnownTPose85
+.4byte sUnownTPose86
+.4byte sUnownTPose87
+.4byte sUnownTPose88
+.4byte sUnownTPose89
+.4byte sUnownTPose90
+.4byte sUnownTPose91
+.4byte sUnownTPose92
+.4byte sUnownTPose93
+.4byte sUnownTPose94
+.4byte sUnownTPose95
+.4byte sUnownTPose96
+.4byte sUnownTPose97
+sAxPositionsUnownT:
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -12
+.2byte    0,  -10, 	   1,  -18, 	  -5,  -16, 	  -1,  -12
+.2byte    1,  -10, 	  -1,  -19, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -5,  -18, 	   1,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	   3,  -16, 	  -5,  -16, 	  -1,  -11
+.2byte   -2,  -10, 	   3,  -18, 	  -3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	  -1,  -19, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -10, 	  -3,  -18, 	   3,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   3,  -17, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -18, 	  -4,  -16, 	  -1,  -12
+.2byte    1,   -9, 	   0,  -19, 	  -2,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	   3,  -17, 	  -5,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	  -1,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   0,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -12
+sUnownTAnimTable1:
+.4byte sUnownTAnims_1_1
+.4byte sUnownTAnims_1_2
+.4byte sUnownTAnims_1_3
+.4byte sUnownTAnims_1_4
+.4byte sUnownTAnims_1_5
+.4byte sUnownTAnims_1_6
+.4byte sUnownTAnims_1_7
+.4byte sUnownTAnims_1_8
+sUnownTAnimTable2:
+.4byte sUnownTAnims_2_1
+.4byte sUnownTAnims_2_2
+.4byte sUnownTAnims_2_3
+.4byte sUnownTAnims_2_4
+.4byte sUnownTAnims_2_5
+.4byte sUnownTAnims_2_6
+.4byte sUnownTAnims_2_7
+.4byte sUnownTAnims_2_8
+sUnownTAnimTable3:
+.4byte sUnownTAnims_3_1
+.4byte sUnownTAnims_3_2
+.4byte sUnownTAnims_3_3
+.4byte sUnownTAnims_3_4
+.4byte sUnownTAnims_3_5
+.4byte sUnownTAnims_3_6
+.4byte sUnownTAnims_3_7
+.4byte sUnownTAnims_3_8
+sUnownTAnimTable4:
+.4byte sUnownTAnims_4_1
+.4byte sUnownTAnims_4_2
+.4byte sUnownTAnims_4_3
+.4byte sUnownTAnims_4_4
+.4byte sUnownTAnims_4_5
+.4byte sUnownTAnims_4_6
+.4byte sUnownTAnims_4_7
+.4byte sUnownTAnims_4_8
+sUnownTAnimTable5:
+.4byte sUnownTAnims_5_1
+.4byte sUnownTAnims_5_2
+.4byte sUnownTAnims_5_3
+.4byte sUnownTAnims_5_4
+.4byte sUnownTAnims_5_5
+.4byte sUnownTAnims_5_6
+.4byte sUnownTAnims_5_7
+.4byte sUnownTAnims_5_8
+sUnownTAnimTable6:
+.4byte sUnownTAnims_6_1
+.4byte sUnownTAnims_6_1
+.4byte sUnownTAnims_6_1
+.4byte sUnownTAnims_6_1
+.4byte sUnownTAnims_6_1
+.4byte sUnownTAnims_6_1
+.4byte sUnownTAnims_6_1
+.4byte sUnownTAnims_6_1
+sUnownTAnimTable7:
+.4byte sUnownTAnims_7_1
+.4byte sUnownTAnims_7_2
+.4byte sUnownTAnims_7_3
+.4byte sUnownTAnims_7_4
+.4byte sUnownTAnims_7_5
+.4byte sUnownTAnims_7_6
+.4byte sUnownTAnims_7_7
+.4byte sUnownTAnims_7_8
+sUnownTAnimTable8:
+.4byte sUnownTAnims_8_1
+.4byte sUnownTAnims_8_2
+.4byte sUnownTAnims_8_3
+.4byte sUnownTAnims_8_4
+.4byte sUnownTAnims_8_5
+.4byte sUnownTAnims_8_6
+.4byte sUnownTAnims_8_7
+.4byte sUnownTAnims_8_8
+sUnownTAnimTable9:
+.4byte sUnownTAnims_9_1
+.4byte sUnownTAnims_9_2
+.4byte sUnownTAnims_9_3
+.4byte sUnownTAnims_9_4
+.4byte sUnownTAnims_9_5
+.4byte sUnownTAnims_9_6
+.4byte sUnownTAnims_9_7
+.4byte sUnownTAnims_9_8
+sUnownTAnimTable10:
+.4byte sUnownTAnims_10_1
+.4byte sUnownTAnims_10_2
+.4byte sUnownTAnims_10_3
+.4byte sUnownTAnims_10_4
+.4byte sUnownTAnims_10_5
+.4byte sUnownTAnims_10_6
+.4byte sUnownTAnims_10_7
+.4byte sUnownTAnims_10_8
+sUnownTAnimTable11:
+.4byte sUnownTAnims_11_1
+.4byte sUnownTAnims_11_2
+.4byte sUnownTAnims_11_3
+.4byte sUnownTAnims_11_4
+.4byte sUnownTAnims_11_5
+.4byte sUnownTAnims_11_6
+.4byte sUnownTAnims_11_7
+.4byte sUnownTAnims_11_8
+sUnownTAnimTable12:
+.4byte sUnownTAnims_12_1
+.4byte sUnownTAnims_12_2
+.4byte sUnownTAnims_12_3
+.4byte sUnownTAnims_12_4
+.4byte sUnownTAnims_12_5
+.4byte sUnownTAnims_12_6
+.4byte sUnownTAnims_12_7
+.4byte sUnownTAnims_12_8
+sUnownTAnimTable13:
+.4byte sUnownTAnims_13_1
+.4byte sUnownTAnims_13_2
+.4byte sUnownTAnims_13_3
+.4byte sUnownTAnims_13_4
+.4byte sUnownTAnims_13_5
+.4byte sUnownTAnims_13_6
+.4byte sUnownTAnims_13_7
+.4byte sUnownTAnims_13_8
+sAxAnimationsUnownT:
+.4byte sUnownTAnimTable1
+.4byte sUnownTAnimTable2
+.4byte sUnownTAnimTable3
+.4byte sUnownTAnimTable4
+.4byte sUnownTAnimTable5
+.4byte sUnownTAnimTable6
+.4byte sUnownTAnimTable7
+.4byte sUnownTAnimTable8
+.4byte sUnownTAnimTable9
+.4byte sUnownTAnimTable10
+.4byte sUnownTAnimTable11
+.4byte sUnownTAnimTable12
+.4byte sUnownTAnimTable13
+sAxSpritesUnownT:
+.4byte sUnownTSprites1
+.4byte sUnownTSprites2
+.4byte sUnownTSprites3
+.4byte sUnownTSprites4
+.4byte sUnownTSprites5
+.4byte sUnownTSprites6
+.4byte sUnownTSprites7
+.4byte sUnownTSprites8
+.4byte sUnownTSprites9
+.4byte sUnownTSprites10
+.4byte sUnownTSprites11
+sAxMainUnownT:
+ax_main sAxPosesUnownT, sAxAnimationsUnownT, 13, sAxSpritesUnownT, sAxPositionsUnownT

--- a/data/ax/unownu.inc
+++ b/data/ax/unownu.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownU
+gAxUnownU:
+ax_siro sAxMainUnownU
+sUnownUPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose2:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose3:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose4:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose6:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose7:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose8:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose10:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose11:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose12:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose14:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose15:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose16:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose18:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose19:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose20:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose22:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose23:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose24:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose26:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose27:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose28:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose30:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose31:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose32:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose34:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose35:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose36:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose38:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose39:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose40:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose42:
+ax_pose 6, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose43:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownUPose44:
+ax_pose 8, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownUPose45:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose47:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose48:
+ax_pose 8, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownUPose49:
+ax_pose 7, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownUPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose51:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose52:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose53:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose55:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose56:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose57:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose59:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose60:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose61:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose63:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose64:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose65:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose67:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose68:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose69:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose71:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose72:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose73:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose75:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose76:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose77:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose79:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose80:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose81:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose83:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose84:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose85:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose87:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose88:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose89:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose91:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose92:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownUPose93:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownUPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose95:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownUPose96:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownUPose97:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownUAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownUAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownUAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownUAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownUAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownUAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownUAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownUAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownUAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownUAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownUAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownUAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownUAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownUAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownUAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownUAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownUAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownUAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownUAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownUAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownUAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownUAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownUAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownUAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownUAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownUAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownUAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownUAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownUAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownUAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownUAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownUAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownUAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownUAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownUAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownUAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownUAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownUAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownUAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownUAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownUAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownUAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownUAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownUAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownUAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownUAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownUAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownUAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownUAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownUAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownUGfx1:
+.incbin "baserom.gba", 0xE0A368, 0x200
+sUnownUSprites1:
+ax_sprite sUnownUGfx1, 0x200
+ax_sprite_terminator
+sUnownUGfx2:
+.incbin "baserom.gba", 0xE0A578, 0x200
+sUnownUSprites2:
+ax_sprite sUnownUGfx2, 0x200
+ax_sprite_terminator
+sUnownUGfx3:
+.incbin "baserom.gba", 0xE0A788, 0x200
+sUnownUSprites3:
+ax_sprite sUnownUGfx3, 0x200
+ax_sprite_terminator
+sUnownUGfx4:
+.incbin "baserom.gba", 0xE0A998, 0x200
+sUnownUSprites4:
+ax_sprite sUnownUGfx4, 0x200
+ax_sprite_terminator
+sUnownUGfx5:
+.incbin "baserom.gba", 0xE0ABA8, 0x200
+sUnownUSprites5:
+ax_sprite sUnownUGfx5, 0x200
+ax_sprite_terminator
+sUnownUGfx6:
+.incbin "baserom.gba", 0xE0ADB8, 0x200
+sUnownUSprites6:
+ax_sprite sUnownUGfx6, 0x200
+ax_sprite_terminator
+sUnownUGfx7:
+.incbin "baserom.gba", 0xE0AFC8, 0x200
+sUnownUSprites7:
+ax_sprite sUnownUGfx7, 0x200
+ax_sprite_terminator
+sUnownUGfx8:
+.incbin "baserom.gba", 0xE0B1D8, 0x200
+sUnownUSprites8:
+ax_sprite sUnownUGfx8, 0x200
+ax_sprite_terminator
+sUnownUGfx9:
+.incbin "baserom.gba", 0xE0B3E8, 0x200
+sUnownUSprites9:
+ax_sprite sUnownUGfx9, 0x200
+ax_sprite_terminator
+sUnownUGfx10:
+.incbin "baserom.gba", 0xE0B5F8, 0x200
+sUnownUSprites10:
+ax_sprite sUnownUGfx10, 0x200
+ax_sprite_terminator
+sUnownUGfx11:
+.incbin "baserom.gba", 0xE0B808, 0x200
+sUnownUSprites11:
+ax_sprite sUnownUGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownU:
+.4byte sUnownUPose1
+.4byte sUnownUPose2
+.4byte sUnownUPose3
+.4byte sUnownUPose4
+.4byte sUnownUPose5
+.4byte sUnownUPose6
+.4byte sUnownUPose7
+.4byte sUnownUPose8
+.4byte sUnownUPose9
+.4byte sUnownUPose10
+.4byte sUnownUPose11
+.4byte sUnownUPose12
+.4byte sUnownUPose13
+.4byte sUnownUPose14
+.4byte sUnownUPose15
+.4byte sUnownUPose16
+.4byte sUnownUPose17
+.4byte sUnownUPose18
+.4byte sUnownUPose19
+.4byte sUnownUPose20
+.4byte sUnownUPose21
+.4byte sUnownUPose22
+.4byte sUnownUPose23
+.4byte sUnownUPose24
+.4byte sUnownUPose25
+.4byte sUnownUPose26
+.4byte sUnownUPose27
+.4byte sUnownUPose28
+.4byte sUnownUPose29
+.4byte sUnownUPose30
+.4byte sUnownUPose31
+.4byte sUnownUPose32
+.4byte sUnownUPose33
+.4byte sUnownUPose34
+.4byte sUnownUPose35
+.4byte sUnownUPose36
+.4byte sUnownUPose37
+.4byte sUnownUPose38
+.4byte sUnownUPose39
+.4byte sUnownUPose40
+.4byte sUnownUPose41
+.4byte sUnownUPose42
+.4byte sUnownUPose43
+.4byte sUnownUPose44
+.4byte sUnownUPose45
+.4byte sUnownUPose46
+.4byte sUnownUPose47
+.4byte sUnownUPose48
+.4byte sUnownUPose49
+.4byte sUnownUPose50
+.4byte sUnownUPose51
+.4byte sUnownUPose52
+.4byte sUnownUPose53
+.4byte sUnownUPose54
+.4byte sUnownUPose55
+.4byte sUnownUPose56
+.4byte sUnownUPose57
+.4byte sUnownUPose58
+.4byte sUnownUPose59
+.4byte sUnownUPose60
+.4byte sUnownUPose61
+.4byte sUnownUPose62
+.4byte sUnownUPose63
+.4byte sUnownUPose64
+.4byte sUnownUPose65
+.4byte sUnownUPose66
+.4byte sUnownUPose67
+.4byte sUnownUPose68
+.4byte sUnownUPose69
+.4byte sUnownUPose70
+.4byte sUnownUPose71
+.4byte sUnownUPose72
+.4byte sUnownUPose73
+.4byte sUnownUPose74
+.4byte sUnownUPose75
+.4byte sUnownUPose76
+.4byte sUnownUPose77
+.4byte sUnownUPose78
+.4byte sUnownUPose79
+.4byte sUnownUPose80
+.4byte sUnownUPose81
+.4byte sUnownUPose82
+.4byte sUnownUPose83
+.4byte sUnownUPose84
+.4byte sUnownUPose85
+.4byte sUnownUPose86
+.4byte sUnownUPose87
+.4byte sUnownUPose88
+.4byte sUnownUPose89
+.4byte sUnownUPose90
+.4byte sUnownUPose91
+.4byte sUnownUPose92
+.4byte sUnownUPose93
+.4byte sUnownUPose94
+.4byte sUnownUPose95
+.4byte sUnownUPose96
+.4byte sUnownUPose97
+sAxPositionsUnownU:
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -14, 	   3,  -14, 	  -6,  -12, 	  -1,  -10
+.2byte    1,  -14, 	   2,  -15, 	  -4,  -11, 	   0,  -10
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -12, 	   0,  -10
+.2byte   -1,  -13, 	   6,  -13, 	  -8,  -13, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -12, 	  -2,  -10
+.2byte   -3,  -14, 	  -4,  -15, 	   2,  -11, 	  -2,  -10
+.2byte   -2,  -14, 	  -5,  -14, 	   4,  -12, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+.2byte   -1,  -13, 	  -8,  -13, 	   6,  -13, 	  -1,  -11
+.2byte    0,  -13, 	   4,  -14, 	  -6,  -13, 	  -1,  -10
+.2byte    1,  -13, 	   3,  -15, 	  -4,  -12, 	  -1,   -9
+.2byte    0,  -14, 	  -6,  -14, 	   4,  -13, 	  -1,   -9
+.2byte   -1,  -13, 	   6,  -14, 	  -8,  -14, 	  -1,  -10
+.2byte   -2,  -14, 	   4,  -14, 	  -6,  -13, 	  -1,   -9
+.2byte   -3,  -13, 	  -5,  -15, 	   2,  -12, 	  -1,   -9
+.2byte   -2,  -13, 	  -6,  -14, 	   4,  -13, 	  -1,  -10
+sUnownUAnimTable1:
+.4byte sUnownUAnims_1_1
+.4byte sUnownUAnims_1_2
+.4byte sUnownUAnims_1_3
+.4byte sUnownUAnims_1_4
+.4byte sUnownUAnims_1_5
+.4byte sUnownUAnims_1_6
+.4byte sUnownUAnims_1_7
+.4byte sUnownUAnims_1_8
+sUnownUAnimTable2:
+.4byte sUnownUAnims_2_1
+.4byte sUnownUAnims_2_2
+.4byte sUnownUAnims_2_3
+.4byte sUnownUAnims_2_4
+.4byte sUnownUAnims_2_5
+.4byte sUnownUAnims_2_6
+.4byte sUnownUAnims_2_7
+.4byte sUnownUAnims_2_8
+sUnownUAnimTable3:
+.4byte sUnownUAnims_3_1
+.4byte sUnownUAnims_3_2
+.4byte sUnownUAnims_3_3
+.4byte sUnownUAnims_3_4
+.4byte sUnownUAnims_3_5
+.4byte sUnownUAnims_3_6
+.4byte sUnownUAnims_3_7
+.4byte sUnownUAnims_3_8
+sUnownUAnimTable4:
+.4byte sUnownUAnims_4_1
+.4byte sUnownUAnims_4_2
+.4byte sUnownUAnims_4_3
+.4byte sUnownUAnims_4_4
+.4byte sUnownUAnims_4_5
+.4byte sUnownUAnims_4_6
+.4byte sUnownUAnims_4_7
+.4byte sUnownUAnims_4_8
+sUnownUAnimTable5:
+.4byte sUnownUAnims_5_1
+.4byte sUnownUAnims_5_2
+.4byte sUnownUAnims_5_3
+.4byte sUnownUAnims_5_4
+.4byte sUnownUAnims_5_5
+.4byte sUnownUAnims_5_6
+.4byte sUnownUAnims_5_7
+.4byte sUnownUAnims_5_8
+sUnownUAnimTable6:
+.4byte sUnownUAnims_6_1
+.4byte sUnownUAnims_6_1
+.4byte sUnownUAnims_6_1
+.4byte sUnownUAnims_6_1
+.4byte sUnownUAnims_6_1
+.4byte sUnownUAnims_6_1
+.4byte sUnownUAnims_6_1
+.4byte sUnownUAnims_6_1
+sUnownUAnimTable7:
+.4byte sUnownUAnims_7_1
+.4byte sUnownUAnims_7_2
+.4byte sUnownUAnims_7_3
+.4byte sUnownUAnims_7_4
+.4byte sUnownUAnims_7_5
+.4byte sUnownUAnims_7_6
+.4byte sUnownUAnims_7_7
+.4byte sUnownUAnims_7_8
+sUnownUAnimTable8:
+.4byte sUnownUAnims_8_1
+.4byte sUnownUAnims_8_2
+.4byte sUnownUAnims_8_3
+.4byte sUnownUAnims_8_4
+.4byte sUnownUAnims_8_5
+.4byte sUnownUAnims_8_6
+.4byte sUnownUAnims_8_7
+.4byte sUnownUAnims_8_8
+sUnownUAnimTable9:
+.4byte sUnownUAnims_9_1
+.4byte sUnownUAnims_9_2
+.4byte sUnownUAnims_9_3
+.4byte sUnownUAnims_9_4
+.4byte sUnownUAnims_9_5
+.4byte sUnownUAnims_9_6
+.4byte sUnownUAnims_9_7
+.4byte sUnownUAnims_9_8
+sUnownUAnimTable10:
+.4byte sUnownUAnims_10_1
+.4byte sUnownUAnims_10_2
+.4byte sUnownUAnims_10_3
+.4byte sUnownUAnims_10_4
+.4byte sUnownUAnims_10_5
+.4byte sUnownUAnims_10_6
+.4byte sUnownUAnims_10_7
+.4byte sUnownUAnims_10_8
+sUnownUAnimTable11:
+.4byte sUnownUAnims_11_1
+.4byte sUnownUAnims_11_2
+.4byte sUnownUAnims_11_3
+.4byte sUnownUAnims_11_4
+.4byte sUnownUAnims_11_5
+.4byte sUnownUAnims_11_6
+.4byte sUnownUAnims_11_7
+.4byte sUnownUAnims_11_8
+sUnownUAnimTable12:
+.4byte sUnownUAnims_12_1
+.4byte sUnownUAnims_12_2
+.4byte sUnownUAnims_12_3
+.4byte sUnownUAnims_12_4
+.4byte sUnownUAnims_12_5
+.4byte sUnownUAnims_12_6
+.4byte sUnownUAnims_12_7
+.4byte sUnownUAnims_12_8
+sUnownUAnimTable13:
+.4byte sUnownUAnims_13_1
+.4byte sUnownUAnims_13_2
+.4byte sUnownUAnims_13_3
+.4byte sUnownUAnims_13_4
+.4byte sUnownUAnims_13_5
+.4byte sUnownUAnims_13_6
+.4byte sUnownUAnims_13_7
+.4byte sUnownUAnims_13_8
+sAxAnimationsUnownU:
+.4byte sUnownUAnimTable1
+.4byte sUnownUAnimTable2
+.4byte sUnownUAnimTable3
+.4byte sUnownUAnimTable4
+.4byte sUnownUAnimTable5
+.4byte sUnownUAnimTable6
+.4byte sUnownUAnimTable7
+.4byte sUnownUAnimTable8
+.4byte sUnownUAnimTable9
+.4byte sUnownUAnimTable10
+.4byte sUnownUAnimTable11
+.4byte sUnownUAnimTable12
+.4byte sUnownUAnimTable13
+sAxSpritesUnownU:
+.4byte sUnownUSprites1
+.4byte sUnownUSprites2
+.4byte sUnownUSprites3
+.4byte sUnownUSprites4
+.4byte sUnownUSprites5
+.4byte sUnownUSprites6
+.4byte sUnownUSprites7
+.4byte sUnownUSprites8
+.4byte sUnownUSprites9
+.4byte sUnownUSprites10
+.4byte sUnownUSprites11
+sAxMainUnownU:
+ax_main sAxPosesUnownU, sAxAnimationsUnownU, 13, sAxSpritesUnownU, sAxPositionsUnownU

--- a/data/ax/unownv.inc
+++ b/data/ax/unownv.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownV
+gAxUnownV:
+ax_siro sAxMainUnownV
+sUnownVPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose42:
+ax_pose 9, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownVPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownVPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownVPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownVPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownVPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownVAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownVAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownVAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownVAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownVAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownVAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownVAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownVAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownVAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownVAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownVAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownVAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownVAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownVAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownVAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownVAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownVAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownVAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownVAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownVAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownVAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownVAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownVAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownVAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownVAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownVAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownVAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownVAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownVAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownVAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownVAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownVAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownVAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownVAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownVAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownVAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownVAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownVAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownVAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownVAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownVAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownVAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownVAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownVAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownVAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownVAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownVAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownVAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownVAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownVAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownVGfx1:
+.incbin "baserom.gba", 0xE0F900, 0x200
+sUnownVSprites1:
+ax_sprite sUnownVGfx1, 0x200
+ax_sprite_terminator
+sUnownVGfx2:
+.incbin "baserom.gba", 0xE0FB10, 0x200
+sUnownVSprites2:
+ax_sprite sUnownVGfx2, 0x200
+ax_sprite_terminator
+sUnownVGfx3:
+.incbin "baserom.gba", 0xE0FD20, 0x200
+sUnownVSprites3:
+ax_sprite sUnownVGfx3, 0x200
+ax_sprite_terminator
+sUnownVGfx4:
+.incbin "baserom.gba", 0xE0FF30, 0x200
+sUnownVSprites4:
+ax_sprite sUnownVGfx4, 0x200
+ax_sprite_terminator
+sUnownVGfx5:
+.incbin "baserom.gba", 0xE10140, 0x200
+sUnownVSprites5:
+ax_sprite sUnownVGfx5, 0x200
+ax_sprite_terminator
+sUnownVGfx6:
+.incbin "baserom.gba", 0xE10350, 0x200
+sUnownVSprites6:
+ax_sprite sUnownVGfx6, 0x200
+ax_sprite_terminator
+sUnownVGfx7:
+.incbin "baserom.gba", 0xE10560, 0x200
+sUnownVSprites7:
+ax_sprite sUnownVGfx7, 0x200
+ax_sprite_terminator
+sUnownVGfx8:
+.incbin "baserom.gba", 0xE10770, 0x200
+sUnownVSprites8:
+ax_sprite sUnownVGfx8, 0x200
+ax_sprite_terminator
+sUnownVGfx9:
+.incbin "baserom.gba", 0xE10980, 0x200
+sUnownVSprites9:
+ax_sprite sUnownVGfx9, 0x200
+ax_sprite_terminator
+sUnownVGfx10:
+.incbin "baserom.gba", 0xE10B90, 0x200
+sUnownVSprites10:
+ax_sprite sUnownVGfx10, 0x200
+ax_sprite_terminator
+sUnownVGfx11:
+.incbin "baserom.gba", 0xE10DA0, 0x200
+sUnownVSprites11:
+ax_sprite sUnownVGfx11, 0x200
+ax_sprite_terminator
+sUnownVGfx12:
+.incbin "baserom.gba", 0xE10FB0, 0x200
+sUnownVSprites12:
+ax_sprite sUnownVGfx12, 0x200
+ax_sprite_terminator
+sUnownVGfx13:
+.incbin "baserom.gba", 0xE111C0, 0x200
+sUnownVSprites13:
+ax_sprite sUnownVGfx13, 0x200
+ax_sprite_terminator
+sUnownVGfx14:
+.incbin "baserom.gba", 0xE113D0, 0x200
+sUnownVSprites14:
+ax_sprite sUnownVGfx14, 0x200
+ax_sprite_terminator
+sUnownVGfx15:
+.incbin "baserom.gba", 0xE115E0, 0x200
+sUnownVSprites15:
+ax_sprite sUnownVGfx15, 0x200
+ax_sprite_terminator
+sUnownVGfx16:
+.incbin "baserom.gba", 0xE117F0, 0x200
+sUnownVSprites16:
+ax_sprite sUnownVGfx16, 0x200
+ax_sprite_terminator
+sUnownVGfx17:
+.incbin "baserom.gba", 0xE11A00, 0x200
+sUnownVSprites17:
+ax_sprite sUnownVGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownV:
+.4byte sUnownVPose1
+.4byte sUnownVPose2
+.4byte sUnownVPose3
+.4byte sUnownVPose4
+.4byte sUnownVPose5
+.4byte sUnownVPose6
+.4byte sUnownVPose7
+.4byte sUnownVPose8
+.4byte sUnownVPose9
+.4byte sUnownVPose10
+.4byte sUnownVPose11
+.4byte sUnownVPose12
+.4byte sUnownVPose13
+.4byte sUnownVPose14
+.4byte sUnownVPose15
+.4byte sUnownVPose16
+.4byte sUnownVPose17
+.4byte sUnownVPose18
+.4byte sUnownVPose19
+.4byte sUnownVPose20
+.4byte sUnownVPose21
+.4byte sUnownVPose22
+.4byte sUnownVPose23
+.4byte sUnownVPose24
+.4byte sUnownVPose25
+.4byte sUnownVPose26
+.4byte sUnownVPose27
+.4byte sUnownVPose28
+.4byte sUnownVPose29
+.4byte sUnownVPose30
+.4byte sUnownVPose31
+.4byte sUnownVPose32
+.4byte sUnownVPose33
+.4byte sUnownVPose34
+.4byte sUnownVPose35
+.4byte sUnownVPose36
+.4byte sUnownVPose37
+.4byte sUnownVPose38
+.4byte sUnownVPose39
+.4byte sUnownVPose40
+.4byte sUnownVPose41
+.4byte sUnownVPose42
+.4byte sUnownVPose43
+.4byte sUnownVPose44
+.4byte sUnownVPose45
+.4byte sUnownVPose46
+.4byte sUnownVPose47
+.4byte sUnownVPose48
+.4byte sUnownVPose49
+.4byte sUnownVPose50
+.4byte sUnownVPose51
+.4byte sUnownVPose52
+.4byte sUnownVPose53
+.4byte sUnownVPose54
+.4byte sUnownVPose55
+.4byte sUnownVPose56
+.4byte sUnownVPose57
+.4byte sUnownVPose58
+.4byte sUnownVPose59
+.4byte sUnownVPose60
+.4byte sUnownVPose61
+.4byte sUnownVPose62
+.4byte sUnownVPose63
+.4byte sUnownVPose64
+.4byte sUnownVPose65
+.4byte sUnownVPose66
+.4byte sUnownVPose67
+.4byte sUnownVPose68
+.4byte sUnownVPose69
+.4byte sUnownVPose70
+.4byte sUnownVPose71
+.4byte sUnownVPose72
+.4byte sUnownVPose73
+.4byte sUnownVPose74
+.4byte sUnownVPose75
+.4byte sUnownVPose76
+.4byte sUnownVPose77
+.4byte sUnownVPose78
+.4byte sUnownVPose79
+.4byte sUnownVPose80
+.4byte sUnownVPose81
+.4byte sUnownVPose82
+.4byte sUnownVPose83
+.4byte sUnownVPose84
+.4byte sUnownVPose85
+.4byte sUnownVPose86
+.4byte sUnownVPose87
+.4byte sUnownVPose88
+.4byte sUnownVPose89
+.4byte sUnownVPose90
+.4byte sUnownVPose91
+.4byte sUnownVPose92
+.4byte sUnownVPose93
+.4byte sUnownVPose94
+.4byte sUnownVPose95
+.4byte sUnownVPose96
+.4byte sUnownVPose97
+sAxPositionsUnownV:
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,  -10, 	  -5,  -16, 	  -1,  -19, 	  -1,  -12
+.2byte    1,  -10, 	  -4,  -15, 	  -3,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   0,  -16, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -11, 	   3,  -16, 	  -5,  -16, 	  -1,  -12
+.2byte   -3,  -11, 	   4,  -18, 	  -3,  -16, 	  -1,  -12
+.2byte   -3,  -10, 	   0,  -19, 	   2,  -15, 	   0,  -11
+.2byte   -2,  -10, 	  -1,  -19, 	   4,  -16, 	   0,  -12
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+.2byte   -1,   -9, 	  -5,  -17, 	   4,  -18, 	  -1,  -10
+.2byte    0,   -9, 	  -4,  -15, 	   1,  -19, 	  -1,  -12
+.2byte    1,   -9, 	  -3,  -15, 	  -1,  -19, 	  -1,  -11
+.2byte    0,   -9, 	   2,  -16, 	  -4,  -19, 	  -1,  -11
+.2byte   -1,  -10, 	   3,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -2,  -10, 	   2,  -18, 	  -4,  -16, 	   0,  -11
+.2byte   -3,   -9, 	  -2,  -19, 	   1,  -15, 	   0,  -11
+.2byte   -2,   -9, 	  -4,  -18, 	   2,  -16, 	  -1,  -11
+sUnownVAnimTable1:
+.4byte sUnownVAnims_1_1
+.4byte sUnownVAnims_1_2
+.4byte sUnownVAnims_1_3
+.4byte sUnownVAnims_1_4
+.4byte sUnownVAnims_1_5
+.4byte sUnownVAnims_1_6
+.4byte sUnownVAnims_1_7
+.4byte sUnownVAnims_1_8
+sUnownVAnimTable2:
+.4byte sUnownVAnims_2_1
+.4byte sUnownVAnims_2_2
+.4byte sUnownVAnims_2_3
+.4byte sUnownVAnims_2_4
+.4byte sUnownVAnims_2_5
+.4byte sUnownVAnims_2_6
+.4byte sUnownVAnims_2_7
+.4byte sUnownVAnims_2_8
+sUnownVAnimTable3:
+.4byte sUnownVAnims_3_1
+.4byte sUnownVAnims_3_2
+.4byte sUnownVAnims_3_3
+.4byte sUnownVAnims_3_4
+.4byte sUnownVAnims_3_5
+.4byte sUnownVAnims_3_6
+.4byte sUnownVAnims_3_7
+.4byte sUnownVAnims_3_8
+sUnownVAnimTable4:
+.4byte sUnownVAnims_4_1
+.4byte sUnownVAnims_4_2
+.4byte sUnownVAnims_4_3
+.4byte sUnownVAnims_4_4
+.4byte sUnownVAnims_4_5
+.4byte sUnownVAnims_4_6
+.4byte sUnownVAnims_4_7
+.4byte sUnownVAnims_4_8
+sUnownVAnimTable5:
+.4byte sUnownVAnims_5_1
+.4byte sUnownVAnims_5_2
+.4byte sUnownVAnims_5_3
+.4byte sUnownVAnims_5_4
+.4byte sUnownVAnims_5_5
+.4byte sUnownVAnims_5_6
+.4byte sUnownVAnims_5_7
+.4byte sUnownVAnims_5_8
+sUnownVAnimTable6:
+.4byte sUnownVAnims_6_1
+.4byte sUnownVAnims_6_1
+.4byte sUnownVAnims_6_1
+.4byte sUnownVAnims_6_1
+.4byte sUnownVAnims_6_1
+.4byte sUnownVAnims_6_1
+.4byte sUnownVAnims_6_1
+.4byte sUnownVAnims_6_1
+sUnownVAnimTable7:
+.4byte sUnownVAnims_7_1
+.4byte sUnownVAnims_7_2
+.4byte sUnownVAnims_7_3
+.4byte sUnownVAnims_7_4
+.4byte sUnownVAnims_7_5
+.4byte sUnownVAnims_7_6
+.4byte sUnownVAnims_7_7
+.4byte sUnownVAnims_7_8
+sUnownVAnimTable8:
+.4byte sUnownVAnims_8_1
+.4byte sUnownVAnims_8_2
+.4byte sUnownVAnims_8_3
+.4byte sUnownVAnims_8_4
+.4byte sUnownVAnims_8_5
+.4byte sUnownVAnims_8_6
+.4byte sUnownVAnims_8_7
+.4byte sUnownVAnims_8_8
+sUnownVAnimTable9:
+.4byte sUnownVAnims_9_1
+.4byte sUnownVAnims_9_2
+.4byte sUnownVAnims_9_3
+.4byte sUnownVAnims_9_4
+.4byte sUnownVAnims_9_5
+.4byte sUnownVAnims_9_6
+.4byte sUnownVAnims_9_7
+.4byte sUnownVAnims_9_8
+sUnownVAnimTable10:
+.4byte sUnownVAnims_10_1
+.4byte sUnownVAnims_10_2
+.4byte sUnownVAnims_10_3
+.4byte sUnownVAnims_10_4
+.4byte sUnownVAnims_10_5
+.4byte sUnownVAnims_10_6
+.4byte sUnownVAnims_10_7
+.4byte sUnownVAnims_10_8
+sUnownVAnimTable11:
+.4byte sUnownVAnims_11_1
+.4byte sUnownVAnims_11_2
+.4byte sUnownVAnims_11_3
+.4byte sUnownVAnims_11_4
+.4byte sUnownVAnims_11_5
+.4byte sUnownVAnims_11_6
+.4byte sUnownVAnims_11_7
+.4byte sUnownVAnims_11_8
+sUnownVAnimTable12:
+.4byte sUnownVAnims_12_1
+.4byte sUnownVAnims_12_2
+.4byte sUnownVAnims_12_3
+.4byte sUnownVAnims_12_4
+.4byte sUnownVAnims_12_5
+.4byte sUnownVAnims_12_6
+.4byte sUnownVAnims_12_7
+.4byte sUnownVAnims_12_8
+sUnownVAnimTable13:
+.4byte sUnownVAnims_13_1
+.4byte sUnownVAnims_13_2
+.4byte sUnownVAnims_13_3
+.4byte sUnownVAnims_13_4
+.4byte sUnownVAnims_13_5
+.4byte sUnownVAnims_13_6
+.4byte sUnownVAnims_13_7
+.4byte sUnownVAnims_13_8
+sAxAnimationsUnownV:
+.4byte sUnownVAnimTable1
+.4byte sUnownVAnimTable2
+.4byte sUnownVAnimTable3
+.4byte sUnownVAnimTable4
+.4byte sUnownVAnimTable5
+.4byte sUnownVAnimTable6
+.4byte sUnownVAnimTable7
+.4byte sUnownVAnimTable8
+.4byte sUnownVAnimTable9
+.4byte sUnownVAnimTable10
+.4byte sUnownVAnimTable11
+.4byte sUnownVAnimTable12
+.4byte sUnownVAnimTable13
+sAxSpritesUnownV:
+.4byte sUnownVSprites1
+.4byte sUnownVSprites2
+.4byte sUnownVSprites3
+.4byte sUnownVSprites4
+.4byte sUnownVSprites5
+.4byte sUnownVSprites6
+.4byte sUnownVSprites7
+.4byte sUnownVSprites8
+.4byte sUnownVSprites9
+.4byte sUnownVSprites10
+.4byte sUnownVSprites11
+.4byte sUnownVSprites12
+.4byte sUnownVSprites13
+.4byte sUnownVSprites14
+.4byte sUnownVSprites15
+.4byte sUnownVSprites16
+.4byte sUnownVSprites17
+sAxMainUnownV:
+ax_main sAxPosesUnownV, sAxAnimationsUnownV, 13, sAxSpritesUnownV, sAxPositionsUnownV

--- a/data/ax/unownw.inc
+++ b/data/ax/unownw.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownW
+gAxUnownW:
+ax_siro sAxMainUnownW
+sUnownWPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose2:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose3:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose4:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose6:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose7:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose8:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose10:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose11:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose12:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose14:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose15:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose16:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose18:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose19:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose20:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose22:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose23:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose24:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose26:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose27:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose28:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose30:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose31:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose32:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose34:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose35:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose36:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose38:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose39:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose40:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose42:
+ax_pose 6, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose43:
+ax_pose 7, 0x01e4, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownWPose44:
+ax_pose 8, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose45:
+ax_pose 9, 0x01e4, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose46:
+ax_pose 10, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose47:
+ax_pose 9, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose48:
+ax_pose 8, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose49:
+ax_pose 7, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose51:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose52:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose53:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose55:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose56:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose57:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose59:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose60:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose61:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose63:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose64:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose65:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose67:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose68:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose69:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose71:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose72:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose73:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose75:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose76:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose77:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose79:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose80:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose81:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose83:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose84:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose85:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose87:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose88:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose89:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose91:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose92:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownWPose93:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownWPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose95:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownWPose96:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownWPose97:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownWAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownWAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownWAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownWAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownWAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownWAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownWAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownWAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownWAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownWAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownWAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownWAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownWAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownWAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownWAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownWAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownWAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownWAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownWAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownWAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownWAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownWAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownWAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownWAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownWAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownWAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownWAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownWAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownWAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownWAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownWAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownWAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownWAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownWAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownWAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownWAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownWAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownWAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownWAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownWAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownWAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownWAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownWAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownWAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownWAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownWAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownWAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownWAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownWAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownWAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownWGfx1:
+.incbin "baserom.gba", 0xE15B10, 0x200
+sUnownWSprites1:
+ax_sprite sUnownWGfx1, 0x200
+ax_sprite_terminator
+sUnownWGfx2:
+.incbin "baserom.gba", 0xE15D20, 0x200
+sUnownWSprites2:
+ax_sprite sUnownWGfx2, 0x200
+ax_sprite_terminator
+sUnownWGfx3:
+.incbin "baserom.gba", 0xE15F30, 0x200
+sUnownWSprites3:
+ax_sprite sUnownWGfx3, 0x200
+ax_sprite_terminator
+sUnownWGfx4:
+.incbin "baserom.gba", 0xE16140, 0x200
+sUnownWSprites4:
+ax_sprite sUnownWGfx4, 0x200
+ax_sprite_terminator
+sUnownWGfx5:
+.incbin "baserom.gba", 0xE16350, 0x200
+sUnownWSprites5:
+ax_sprite sUnownWGfx5, 0x200
+ax_sprite_terminator
+sUnownWGfx6:
+.incbin "baserom.gba", 0xE16560, 0x200
+sUnownWSprites6:
+ax_sprite sUnownWGfx6, 0x200
+ax_sprite_terminator
+sUnownWGfx7:
+.incbin "baserom.gba", 0xE16770, 0x200
+sUnownWSprites7:
+ax_sprite sUnownWGfx7, 0x200
+ax_sprite_terminator
+sUnownWGfx8:
+.incbin "baserom.gba", 0xE16980, 0x200
+sUnownWSprites8:
+ax_sprite sUnownWGfx8, 0x200
+ax_sprite_terminator
+sUnownWGfx9:
+.incbin "baserom.gba", 0xE16B90, 0x200
+sUnownWSprites9:
+ax_sprite sUnownWGfx9, 0x200
+ax_sprite_terminator
+sUnownWGfx10:
+.incbin "baserom.gba", 0xE16DA0, 0x200
+sUnownWSprites10:
+ax_sprite sUnownWGfx10, 0x200
+ax_sprite_terminator
+sUnownWGfx11:
+.incbin "baserom.gba", 0xE16FB0, 0x200
+sUnownWSprites11:
+ax_sprite sUnownWGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownW:
+.4byte sUnownWPose1
+.4byte sUnownWPose2
+.4byte sUnownWPose3
+.4byte sUnownWPose4
+.4byte sUnownWPose5
+.4byte sUnownWPose6
+.4byte sUnownWPose7
+.4byte sUnownWPose8
+.4byte sUnownWPose9
+.4byte sUnownWPose10
+.4byte sUnownWPose11
+.4byte sUnownWPose12
+.4byte sUnownWPose13
+.4byte sUnownWPose14
+.4byte sUnownWPose15
+.4byte sUnownWPose16
+.4byte sUnownWPose17
+.4byte sUnownWPose18
+.4byte sUnownWPose19
+.4byte sUnownWPose20
+.4byte sUnownWPose21
+.4byte sUnownWPose22
+.4byte sUnownWPose23
+.4byte sUnownWPose24
+.4byte sUnownWPose25
+.4byte sUnownWPose26
+.4byte sUnownWPose27
+.4byte sUnownWPose28
+.4byte sUnownWPose29
+.4byte sUnownWPose30
+.4byte sUnownWPose31
+.4byte sUnownWPose32
+.4byte sUnownWPose33
+.4byte sUnownWPose34
+.4byte sUnownWPose35
+.4byte sUnownWPose36
+.4byte sUnownWPose37
+.4byte sUnownWPose38
+.4byte sUnownWPose39
+.4byte sUnownWPose40
+.4byte sUnownWPose41
+.4byte sUnownWPose42
+.4byte sUnownWPose43
+.4byte sUnownWPose44
+.4byte sUnownWPose45
+.4byte sUnownWPose46
+.4byte sUnownWPose47
+.4byte sUnownWPose48
+.4byte sUnownWPose49
+.4byte sUnownWPose50
+.4byte sUnownWPose51
+.4byte sUnownWPose52
+.4byte sUnownWPose53
+.4byte sUnownWPose54
+.4byte sUnownWPose55
+.4byte sUnownWPose56
+.4byte sUnownWPose57
+.4byte sUnownWPose58
+.4byte sUnownWPose59
+.4byte sUnownWPose60
+.4byte sUnownWPose61
+.4byte sUnownWPose62
+.4byte sUnownWPose63
+.4byte sUnownWPose64
+.4byte sUnownWPose65
+.4byte sUnownWPose66
+.4byte sUnownWPose67
+.4byte sUnownWPose68
+.4byte sUnownWPose69
+.4byte sUnownWPose70
+.4byte sUnownWPose71
+.4byte sUnownWPose72
+.4byte sUnownWPose73
+.4byte sUnownWPose74
+.4byte sUnownWPose75
+.4byte sUnownWPose76
+.4byte sUnownWPose77
+.4byte sUnownWPose78
+.4byte sUnownWPose79
+.4byte sUnownWPose80
+.4byte sUnownWPose81
+.4byte sUnownWPose82
+.4byte sUnownWPose83
+.4byte sUnownWPose84
+.4byte sUnownWPose85
+.4byte sUnownWPose86
+.4byte sUnownWPose87
+.4byte sUnownWPose88
+.4byte sUnownWPose89
+.4byte sUnownWPose90
+.4byte sUnownWPose91
+.4byte sUnownWPose92
+.4byte sUnownWPose93
+.4byte sUnownWPose94
+.4byte sUnownWPose95
+.4byte sUnownWPose96
+.4byte sUnownWPose97
+sAxPositionsUnownW:
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    1,  -10, 	   3,  -15, 	  -6,  -14, 	  -1,  -11
+.2byte    1,  -10, 	   0,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -8,  -15, 	   2,  -14, 	  -2,  -12
+.2byte   -1,  -10, 	   5,  -14, 	  -7,  -14, 	  -1,  -11
+.2byte   -2,  -10, 	   6,  -15, 	  -4,  -14, 	   0,  -12
+.2byte   -3,  -10, 	  -2,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -2,  -10, 	  -4,  -15, 	   5,  -14, 	   0,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+.2byte   -1,   -9, 	  -7,  -15, 	   5,  -15, 	  -1,  -10
+.2byte    0,   -9, 	   4,  -16, 	  -6,  -14, 	  -1,  -11
+.2byte    1,   -9, 	   2,  -16, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -10, 	  -6,  -16, 	   3,  -14, 	  -1,  -12
+.2byte   -1,   -9, 	   5,  -15, 	  -7,  -15, 	  -1,  -11
+.2byte   -2,  -10, 	   4,  -16, 	  -5,  -14, 	  -1,  -12
+.2byte   -3,   -9, 	  -4,  -16, 	   2,  -14, 	  -1,  -11
+.2byte   -2,   -9, 	  -6,  -16, 	   4,  -14, 	  -1,  -11
+sUnownWAnimTable1:
+.4byte sUnownWAnims_1_1
+.4byte sUnownWAnims_1_2
+.4byte sUnownWAnims_1_3
+.4byte sUnownWAnims_1_4
+.4byte sUnownWAnims_1_5
+.4byte sUnownWAnims_1_6
+.4byte sUnownWAnims_1_7
+.4byte sUnownWAnims_1_8
+sUnownWAnimTable2:
+.4byte sUnownWAnims_2_1
+.4byte sUnownWAnims_2_2
+.4byte sUnownWAnims_2_3
+.4byte sUnownWAnims_2_4
+.4byte sUnownWAnims_2_5
+.4byte sUnownWAnims_2_6
+.4byte sUnownWAnims_2_7
+.4byte sUnownWAnims_2_8
+sUnownWAnimTable3:
+.4byte sUnownWAnims_3_1
+.4byte sUnownWAnims_3_2
+.4byte sUnownWAnims_3_3
+.4byte sUnownWAnims_3_4
+.4byte sUnownWAnims_3_5
+.4byte sUnownWAnims_3_6
+.4byte sUnownWAnims_3_7
+.4byte sUnownWAnims_3_8
+sUnownWAnimTable4:
+.4byte sUnownWAnims_4_1
+.4byte sUnownWAnims_4_2
+.4byte sUnownWAnims_4_3
+.4byte sUnownWAnims_4_4
+.4byte sUnownWAnims_4_5
+.4byte sUnownWAnims_4_6
+.4byte sUnownWAnims_4_7
+.4byte sUnownWAnims_4_8
+sUnownWAnimTable5:
+.4byte sUnownWAnims_5_1
+.4byte sUnownWAnims_5_2
+.4byte sUnownWAnims_5_3
+.4byte sUnownWAnims_5_4
+.4byte sUnownWAnims_5_5
+.4byte sUnownWAnims_5_6
+.4byte sUnownWAnims_5_7
+.4byte sUnownWAnims_5_8
+sUnownWAnimTable6:
+.4byte sUnownWAnims_6_1
+.4byte sUnownWAnims_6_1
+.4byte sUnownWAnims_6_1
+.4byte sUnownWAnims_6_1
+.4byte sUnownWAnims_6_1
+.4byte sUnownWAnims_6_1
+.4byte sUnownWAnims_6_1
+.4byte sUnownWAnims_6_1
+sUnownWAnimTable7:
+.4byte sUnownWAnims_7_1
+.4byte sUnownWAnims_7_2
+.4byte sUnownWAnims_7_3
+.4byte sUnownWAnims_7_4
+.4byte sUnownWAnims_7_5
+.4byte sUnownWAnims_7_6
+.4byte sUnownWAnims_7_7
+.4byte sUnownWAnims_7_8
+sUnownWAnimTable8:
+.4byte sUnownWAnims_8_1
+.4byte sUnownWAnims_8_2
+.4byte sUnownWAnims_8_3
+.4byte sUnownWAnims_8_4
+.4byte sUnownWAnims_8_5
+.4byte sUnownWAnims_8_6
+.4byte sUnownWAnims_8_7
+.4byte sUnownWAnims_8_8
+sUnownWAnimTable9:
+.4byte sUnownWAnims_9_1
+.4byte sUnownWAnims_9_2
+.4byte sUnownWAnims_9_3
+.4byte sUnownWAnims_9_4
+.4byte sUnownWAnims_9_5
+.4byte sUnownWAnims_9_6
+.4byte sUnownWAnims_9_7
+.4byte sUnownWAnims_9_8
+sUnownWAnimTable10:
+.4byte sUnownWAnims_10_1
+.4byte sUnownWAnims_10_2
+.4byte sUnownWAnims_10_3
+.4byte sUnownWAnims_10_4
+.4byte sUnownWAnims_10_5
+.4byte sUnownWAnims_10_6
+.4byte sUnownWAnims_10_7
+.4byte sUnownWAnims_10_8
+sUnownWAnimTable11:
+.4byte sUnownWAnims_11_1
+.4byte sUnownWAnims_11_2
+.4byte sUnownWAnims_11_3
+.4byte sUnownWAnims_11_4
+.4byte sUnownWAnims_11_5
+.4byte sUnownWAnims_11_6
+.4byte sUnownWAnims_11_7
+.4byte sUnownWAnims_11_8
+sUnownWAnimTable12:
+.4byte sUnownWAnims_12_1
+.4byte sUnownWAnims_12_2
+.4byte sUnownWAnims_12_3
+.4byte sUnownWAnims_12_4
+.4byte sUnownWAnims_12_5
+.4byte sUnownWAnims_12_6
+.4byte sUnownWAnims_12_7
+.4byte sUnownWAnims_12_8
+sUnownWAnimTable13:
+.4byte sUnownWAnims_13_1
+.4byte sUnownWAnims_13_2
+.4byte sUnownWAnims_13_3
+.4byte sUnownWAnims_13_4
+.4byte sUnownWAnims_13_5
+.4byte sUnownWAnims_13_6
+.4byte sUnownWAnims_13_7
+.4byte sUnownWAnims_13_8
+sAxAnimationsUnownW:
+.4byte sUnownWAnimTable1
+.4byte sUnownWAnimTable2
+.4byte sUnownWAnimTable3
+.4byte sUnownWAnimTable4
+.4byte sUnownWAnimTable5
+.4byte sUnownWAnimTable6
+.4byte sUnownWAnimTable7
+.4byte sUnownWAnimTable8
+.4byte sUnownWAnimTable9
+.4byte sUnownWAnimTable10
+.4byte sUnownWAnimTable11
+.4byte sUnownWAnimTable12
+.4byte sUnownWAnimTable13
+sAxSpritesUnownW:
+.4byte sUnownWSprites1
+.4byte sUnownWSprites2
+.4byte sUnownWSprites3
+.4byte sUnownWSprites4
+.4byte sUnownWSprites5
+.4byte sUnownWSprites6
+.4byte sUnownWSprites7
+.4byte sUnownWSprites8
+.4byte sUnownWSprites9
+.4byte sUnownWSprites10
+.4byte sUnownWSprites11
+sAxMainUnownW:
+ax_main sAxPosesUnownW, sAxAnimationsUnownW, 13, sAxSpritesUnownW, sAxPositionsUnownW

--- a/data/ax/unownx.inc
+++ b/data/ax/unownx.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownX
+gAxUnownX:
+ax_siro sAxMainUnownX
+sUnownXPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose2:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose3:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose4:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose6:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose7:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose8:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose10:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose11:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose12:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose14:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose15:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose16:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose18:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose19:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose20:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose22:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose23:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose24:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose26:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose27:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose28:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose30:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose31:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose32:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose34:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose35:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose36:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose38:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose39:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose40:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose42:
+ax_pose 6, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose43:
+ax_pose 7, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownXPose44:
+ax_pose 8, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sUnownXPose45:
+ax_pose 9, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose46:
+ax_pose 10, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose47:
+ax_pose 9, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownXPose48:
+ax_pose 8, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownXPose49:
+ax_pose 7, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sUnownXPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose51:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose52:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose53:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose55:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose56:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose57:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose59:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose60:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose61:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose63:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose64:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose65:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose67:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose68:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose69:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose71:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose72:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose73:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose75:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose76:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose77:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose79:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose80:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose81:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose83:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose84:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose85:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose87:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose88:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose89:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose91:
+ax_pose 1, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose92:
+ax_pose 2, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownXPose93:
+ax_pose 3, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownXPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose95:
+ax_pose 3, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownXPose96:
+ax_pose 2, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownXPose97:
+ax_pose 1, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownXAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownXAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownXAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownXAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownXAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownXAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownXAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownXAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownXAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownXAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownXAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownXAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownXAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownXAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownXAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownXAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownXAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownXAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownXAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownXAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownXAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownXAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownXAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownXAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownXAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownXAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownXAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownXAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownXAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownXAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownXAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownXAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownXAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownXAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownXAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownXAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownXAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownXAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownXAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownXAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownXAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownXAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownXAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownXAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownXAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownXAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownXAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownXAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownXAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownXAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownXGfx1:
+.incbin "baserom.gba", 0xE1B0A8, 0x200
+sUnownXSprites1:
+ax_sprite sUnownXGfx1, 0x200
+ax_sprite_terminator
+sUnownXGfx2:
+.incbin "baserom.gba", 0xE1B2B8, 0x200
+sUnownXSprites2:
+ax_sprite sUnownXGfx2, 0x200
+ax_sprite_terminator
+sUnownXGfx3:
+.incbin "baserom.gba", 0xE1B4C8, 0x200
+sUnownXSprites3:
+ax_sprite sUnownXGfx3, 0x200
+ax_sprite_terminator
+sUnownXGfx4:
+.incbin "baserom.gba", 0xE1B6D8, 0x200
+sUnownXSprites4:
+ax_sprite sUnownXGfx4, 0x200
+ax_sprite_terminator
+sUnownXGfx5:
+.incbin "baserom.gba", 0xE1B8E8, 0x200
+sUnownXSprites5:
+ax_sprite sUnownXGfx5, 0x200
+ax_sprite_terminator
+sUnownXGfx6:
+.incbin "baserom.gba", 0xE1BAF8, 0x200
+sUnownXSprites6:
+ax_sprite sUnownXGfx6, 0x200
+ax_sprite_terminator
+sUnownXGfx7:
+.incbin "baserom.gba", 0xE1BD08, 0x200
+sUnownXSprites7:
+ax_sprite sUnownXGfx7, 0x200
+ax_sprite_terminator
+sUnownXGfx8:
+.incbin "baserom.gba", 0xE1BF18, 0x200
+sUnownXSprites8:
+ax_sprite sUnownXGfx8, 0x200
+ax_sprite_terminator
+sUnownXGfx9:
+.incbin "baserom.gba", 0xE1C128, 0x200
+sUnownXSprites9:
+ax_sprite sUnownXGfx9, 0x200
+ax_sprite_terminator
+sUnownXGfx10:
+.incbin "baserom.gba", 0xE1C338, 0x200
+sUnownXSprites10:
+ax_sprite sUnownXGfx10, 0x200
+ax_sprite_terminator
+sUnownXGfx11:
+.incbin "baserom.gba", 0xE1C548, 0x200
+sUnownXSprites11:
+ax_sprite sUnownXGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownX:
+.4byte sUnownXPose1
+.4byte sUnownXPose2
+.4byte sUnownXPose3
+.4byte sUnownXPose4
+.4byte sUnownXPose5
+.4byte sUnownXPose6
+.4byte sUnownXPose7
+.4byte sUnownXPose8
+.4byte sUnownXPose9
+.4byte sUnownXPose10
+.4byte sUnownXPose11
+.4byte sUnownXPose12
+.4byte sUnownXPose13
+.4byte sUnownXPose14
+.4byte sUnownXPose15
+.4byte sUnownXPose16
+.4byte sUnownXPose17
+.4byte sUnownXPose18
+.4byte sUnownXPose19
+.4byte sUnownXPose20
+.4byte sUnownXPose21
+.4byte sUnownXPose22
+.4byte sUnownXPose23
+.4byte sUnownXPose24
+.4byte sUnownXPose25
+.4byte sUnownXPose26
+.4byte sUnownXPose27
+.4byte sUnownXPose28
+.4byte sUnownXPose29
+.4byte sUnownXPose30
+.4byte sUnownXPose31
+.4byte sUnownXPose32
+.4byte sUnownXPose33
+.4byte sUnownXPose34
+.4byte sUnownXPose35
+.4byte sUnownXPose36
+.4byte sUnownXPose37
+.4byte sUnownXPose38
+.4byte sUnownXPose39
+.4byte sUnownXPose40
+.4byte sUnownXPose41
+.4byte sUnownXPose42
+.4byte sUnownXPose43
+.4byte sUnownXPose44
+.4byte sUnownXPose45
+.4byte sUnownXPose46
+.4byte sUnownXPose47
+.4byte sUnownXPose48
+.4byte sUnownXPose49
+.4byte sUnownXPose50
+.4byte sUnownXPose51
+.4byte sUnownXPose52
+.4byte sUnownXPose53
+.4byte sUnownXPose54
+.4byte sUnownXPose55
+.4byte sUnownXPose56
+.4byte sUnownXPose57
+.4byte sUnownXPose58
+.4byte sUnownXPose59
+.4byte sUnownXPose60
+.4byte sUnownXPose61
+.4byte sUnownXPose62
+.4byte sUnownXPose63
+.4byte sUnownXPose64
+.4byte sUnownXPose65
+.4byte sUnownXPose66
+.4byte sUnownXPose67
+.4byte sUnownXPose68
+.4byte sUnownXPose69
+.4byte sUnownXPose70
+.4byte sUnownXPose71
+.4byte sUnownXPose72
+.4byte sUnownXPose73
+.4byte sUnownXPose74
+.4byte sUnownXPose75
+.4byte sUnownXPose76
+.4byte sUnownXPose77
+.4byte sUnownXPose78
+.4byte sUnownXPose79
+.4byte sUnownXPose80
+.4byte sUnownXPose81
+.4byte sUnownXPose82
+.4byte sUnownXPose83
+.4byte sUnownXPose84
+.4byte sUnownXPose85
+.4byte sUnownXPose86
+.4byte sUnownXPose87
+.4byte sUnownXPose88
+.4byte sUnownXPose89
+.4byte sUnownXPose90
+.4byte sUnownXPose91
+.4byte sUnownXPose92
+.4byte sUnownXPose93
+.4byte sUnownXPose94
+.4byte sUnownXPose95
+.4byte sUnownXPose96
+.4byte sUnownXPose97
+sAxPositionsUnownX:
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -13, 	   1,  -17, 	  -5,  -14, 	  -1,  -12
+.2byte    1,  -13, 	  -2,  -17, 	  -5,  -13, 	  -1,  -11
+.2byte   -1,  -14, 	  -5,  -17, 	   2,  -16, 	  -1,  -12
+.2byte   -1,  -14, 	   4,  -15, 	  -6,  -16, 	  -1,  -11
+.2byte   -2,  -15, 	   2,  -18, 	  -5,  -17, 	  -2,  -13
+.2byte   -3,  -13, 	   0,  -17, 	   3,  -13, 	  -1,  -11
+.2byte   -2,  -13, 	  -3,  -17, 	   3,  -14, 	  -1,  -12
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -12, 	  -6,  -16, 	   4,  -16, 	  -1,  -11
+.2byte    0,  -12, 	   2,  -17, 	  -5,  -15, 	  -2,  -11
+.2byte    1,  -12, 	  -1,  -17, 	  -4,  -14, 	  -1,  -11
+.2byte    0,  -13, 	  -4,  -17, 	   2,  -15, 	  -1,  -11
+.2byte   -1,  -13, 	   4,  -16, 	  -6,  -16, 	  -1,  -12
+.2byte   -2,  -13, 	   2,  -17, 	  -4,  -15, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,  -17, 	   2,  -14, 	  -1,  -11
+.2byte   -2,  -12, 	  -4,  -17, 	   3,  -15, 	   0,  -11
+sUnownXAnimTable1:
+.4byte sUnownXAnims_1_1
+.4byte sUnownXAnims_1_2
+.4byte sUnownXAnims_1_3
+.4byte sUnownXAnims_1_4
+.4byte sUnownXAnims_1_5
+.4byte sUnownXAnims_1_6
+.4byte sUnownXAnims_1_7
+.4byte sUnownXAnims_1_8
+sUnownXAnimTable2:
+.4byte sUnownXAnims_2_1
+.4byte sUnownXAnims_2_2
+.4byte sUnownXAnims_2_3
+.4byte sUnownXAnims_2_4
+.4byte sUnownXAnims_2_5
+.4byte sUnownXAnims_2_6
+.4byte sUnownXAnims_2_7
+.4byte sUnownXAnims_2_8
+sUnownXAnimTable3:
+.4byte sUnownXAnims_3_1
+.4byte sUnownXAnims_3_2
+.4byte sUnownXAnims_3_3
+.4byte sUnownXAnims_3_4
+.4byte sUnownXAnims_3_5
+.4byte sUnownXAnims_3_6
+.4byte sUnownXAnims_3_7
+.4byte sUnownXAnims_3_8
+sUnownXAnimTable4:
+.4byte sUnownXAnims_4_1
+.4byte sUnownXAnims_4_2
+.4byte sUnownXAnims_4_3
+.4byte sUnownXAnims_4_4
+.4byte sUnownXAnims_4_5
+.4byte sUnownXAnims_4_6
+.4byte sUnownXAnims_4_7
+.4byte sUnownXAnims_4_8
+sUnownXAnimTable5:
+.4byte sUnownXAnims_5_1
+.4byte sUnownXAnims_5_2
+.4byte sUnownXAnims_5_3
+.4byte sUnownXAnims_5_4
+.4byte sUnownXAnims_5_5
+.4byte sUnownXAnims_5_6
+.4byte sUnownXAnims_5_7
+.4byte sUnownXAnims_5_8
+sUnownXAnimTable6:
+.4byte sUnownXAnims_6_1
+.4byte sUnownXAnims_6_1
+.4byte sUnownXAnims_6_1
+.4byte sUnownXAnims_6_1
+.4byte sUnownXAnims_6_1
+.4byte sUnownXAnims_6_1
+.4byte sUnownXAnims_6_1
+.4byte sUnownXAnims_6_1
+sUnownXAnimTable7:
+.4byte sUnownXAnims_7_1
+.4byte sUnownXAnims_7_2
+.4byte sUnownXAnims_7_3
+.4byte sUnownXAnims_7_4
+.4byte sUnownXAnims_7_5
+.4byte sUnownXAnims_7_6
+.4byte sUnownXAnims_7_7
+.4byte sUnownXAnims_7_8
+sUnownXAnimTable8:
+.4byte sUnownXAnims_8_1
+.4byte sUnownXAnims_8_2
+.4byte sUnownXAnims_8_3
+.4byte sUnownXAnims_8_4
+.4byte sUnownXAnims_8_5
+.4byte sUnownXAnims_8_6
+.4byte sUnownXAnims_8_7
+.4byte sUnownXAnims_8_8
+sUnownXAnimTable9:
+.4byte sUnownXAnims_9_1
+.4byte sUnownXAnims_9_2
+.4byte sUnownXAnims_9_3
+.4byte sUnownXAnims_9_4
+.4byte sUnownXAnims_9_5
+.4byte sUnownXAnims_9_6
+.4byte sUnownXAnims_9_7
+.4byte sUnownXAnims_9_8
+sUnownXAnimTable10:
+.4byte sUnownXAnims_10_1
+.4byte sUnownXAnims_10_2
+.4byte sUnownXAnims_10_3
+.4byte sUnownXAnims_10_4
+.4byte sUnownXAnims_10_5
+.4byte sUnownXAnims_10_6
+.4byte sUnownXAnims_10_7
+.4byte sUnownXAnims_10_8
+sUnownXAnimTable11:
+.4byte sUnownXAnims_11_1
+.4byte sUnownXAnims_11_2
+.4byte sUnownXAnims_11_3
+.4byte sUnownXAnims_11_4
+.4byte sUnownXAnims_11_5
+.4byte sUnownXAnims_11_6
+.4byte sUnownXAnims_11_7
+.4byte sUnownXAnims_11_8
+sUnownXAnimTable12:
+.4byte sUnownXAnims_12_1
+.4byte sUnownXAnims_12_2
+.4byte sUnownXAnims_12_3
+.4byte sUnownXAnims_12_4
+.4byte sUnownXAnims_12_5
+.4byte sUnownXAnims_12_6
+.4byte sUnownXAnims_12_7
+.4byte sUnownXAnims_12_8
+sUnownXAnimTable13:
+.4byte sUnownXAnims_13_1
+.4byte sUnownXAnims_13_2
+.4byte sUnownXAnims_13_3
+.4byte sUnownXAnims_13_4
+.4byte sUnownXAnims_13_5
+.4byte sUnownXAnims_13_6
+.4byte sUnownXAnims_13_7
+.4byte sUnownXAnims_13_8
+sAxAnimationsUnownX:
+.4byte sUnownXAnimTable1
+.4byte sUnownXAnimTable2
+.4byte sUnownXAnimTable3
+.4byte sUnownXAnimTable4
+.4byte sUnownXAnimTable5
+.4byte sUnownXAnimTable6
+.4byte sUnownXAnimTable7
+.4byte sUnownXAnimTable8
+.4byte sUnownXAnimTable9
+.4byte sUnownXAnimTable10
+.4byte sUnownXAnimTable11
+.4byte sUnownXAnimTable12
+.4byte sUnownXAnimTable13
+sAxSpritesUnownX:
+.4byte sUnownXSprites1
+.4byte sUnownXSprites2
+.4byte sUnownXSprites3
+.4byte sUnownXSprites4
+.4byte sUnownXSprites5
+.4byte sUnownXSprites6
+.4byte sUnownXSprites7
+.4byte sUnownXSprites8
+.4byte sUnownXSprites9
+.4byte sUnownXSprites10
+.4byte sUnownXSprites11
+sAxMainUnownX:
+ax_main sAxPosesUnownX, sAxAnimationsUnownX, 13, sAxSpritesUnownX, sAxPositionsUnownX

--- a/data/ax/unowny.inc
+++ b/data/ax/unowny.inc
@@ -1,0 +1,1773 @@
+.global gAxUnownY
+gAxUnownY:
+ax_siro sAxMainUnownY
+sUnownYPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose2:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose3:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose4:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose5:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose6:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose7:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose8:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose10:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose11:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose12:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose13:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose14:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose15:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose16:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose18:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose19:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose20:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose21:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose22:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose23:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose24:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose26:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose27:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose28:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose29:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose30:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose31:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose32:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose34:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose35:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose36:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose37:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose38:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose39:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose40:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose41:
+ax_pose 5, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose42:
+ax_pose 6, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose43:
+ax_pose 7, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose44:
+ax_pose 8, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose45:
+ax_pose 9, 0x01e4, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose46:
+ax_pose 10, 0x01e3, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose47:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose48:
+ax_pose 8, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose49:
+ax_pose 7, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose51:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose52:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose53:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose54:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose55:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose56:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose57:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose59:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose60:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose61:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose62:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose63:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose64:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose65:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose67:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose68:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose69:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose70:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose71:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose72:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose73:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose75:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose76:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose77:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose78:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose79:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose80:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose81:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose83:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose84:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose85:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose86:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose87:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose88:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose89:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose91:
+ax_pose 1, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose92:
+ax_pose 2, 0x01e8, 0x90ec, 0x5c00
+ax_pose_terminator
+sUnownYPose93:
+ax_pose 3, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sUnownYPose94:
+ax_pose 4, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose95:
+ax_pose 3, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownYPose96:
+ax_pose 2, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownYPose97:
+ax_pose 1, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownYAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownYAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownYAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownYAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownYAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownYAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownYAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownYAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownYAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownYAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownYAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownYAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownYAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownYAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownYAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownYAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownYAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownYAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownYAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownYAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownYAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownYAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownYAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownYAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownYAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownYAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownYAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownYAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownYAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownYAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownYAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownYAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownYAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownYAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownYAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownYAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownYAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownYAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownYAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownYAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownYAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownYAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownYAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownYAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownYAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownYAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownYAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownYAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownYAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownYAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownYGfx1:
+.incbin "baserom.gba", 0xE20640, 0x200
+sUnownYSprites1:
+ax_sprite sUnownYGfx1, 0x200
+ax_sprite_terminator
+sUnownYGfx2:
+.incbin "baserom.gba", 0xE20850, 0x200
+sUnownYSprites2:
+ax_sprite sUnownYGfx2, 0x200
+ax_sprite_terminator
+sUnownYGfx3:
+.incbin "baserom.gba", 0xE20A60, 0x200
+sUnownYSprites3:
+ax_sprite sUnownYGfx3, 0x200
+ax_sprite_terminator
+sUnownYGfx4:
+.incbin "baserom.gba", 0xE20C70, 0x200
+sUnownYSprites4:
+ax_sprite sUnownYGfx4, 0x200
+ax_sprite_terminator
+sUnownYGfx5:
+.incbin "baserom.gba", 0xE20E80, 0x200
+sUnownYSprites5:
+ax_sprite sUnownYGfx5, 0x200
+ax_sprite_terminator
+sUnownYGfx6:
+.incbin "baserom.gba", 0xE21090, 0x200
+sUnownYSprites6:
+ax_sprite sUnownYGfx6, 0x200
+ax_sprite_terminator
+sUnownYGfx7:
+.incbin "baserom.gba", 0xE212A0, 0x200
+sUnownYSprites7:
+ax_sprite sUnownYGfx7, 0x200
+ax_sprite_terminator
+sUnownYGfx8:
+.incbin "baserom.gba", 0xE214B0, 0x200
+sUnownYSprites8:
+ax_sprite sUnownYGfx8, 0x200
+ax_sprite_terminator
+sUnownYGfx9:
+.incbin "baserom.gba", 0xE216C0, 0x200
+sUnownYSprites9:
+ax_sprite sUnownYGfx9, 0x200
+ax_sprite_terminator
+sUnownYGfx10:
+.incbin "baserom.gba", 0xE218D0, 0x200
+sUnownYSprites10:
+ax_sprite sUnownYGfx10, 0x200
+ax_sprite_terminator
+sUnownYGfx11:
+.incbin "baserom.gba", 0xE21AE0, 0x200
+sUnownYSprites11:
+ax_sprite sUnownYGfx11, 0x200
+ax_sprite_terminator
+sAxPosesUnownY:
+.4byte sUnownYPose1
+.4byte sUnownYPose2
+.4byte sUnownYPose3
+.4byte sUnownYPose4
+.4byte sUnownYPose5
+.4byte sUnownYPose6
+.4byte sUnownYPose7
+.4byte sUnownYPose8
+.4byte sUnownYPose9
+.4byte sUnownYPose10
+.4byte sUnownYPose11
+.4byte sUnownYPose12
+.4byte sUnownYPose13
+.4byte sUnownYPose14
+.4byte sUnownYPose15
+.4byte sUnownYPose16
+.4byte sUnownYPose17
+.4byte sUnownYPose18
+.4byte sUnownYPose19
+.4byte sUnownYPose20
+.4byte sUnownYPose21
+.4byte sUnownYPose22
+.4byte sUnownYPose23
+.4byte sUnownYPose24
+.4byte sUnownYPose25
+.4byte sUnownYPose26
+.4byte sUnownYPose27
+.4byte sUnownYPose28
+.4byte sUnownYPose29
+.4byte sUnownYPose30
+.4byte sUnownYPose31
+.4byte sUnownYPose32
+.4byte sUnownYPose33
+.4byte sUnownYPose34
+.4byte sUnownYPose35
+.4byte sUnownYPose36
+.4byte sUnownYPose37
+.4byte sUnownYPose38
+.4byte sUnownYPose39
+.4byte sUnownYPose40
+.4byte sUnownYPose41
+.4byte sUnownYPose42
+.4byte sUnownYPose43
+.4byte sUnownYPose44
+.4byte sUnownYPose45
+.4byte sUnownYPose46
+.4byte sUnownYPose47
+.4byte sUnownYPose48
+.4byte sUnownYPose49
+.4byte sUnownYPose50
+.4byte sUnownYPose51
+.4byte sUnownYPose52
+.4byte sUnownYPose53
+.4byte sUnownYPose54
+.4byte sUnownYPose55
+.4byte sUnownYPose56
+.4byte sUnownYPose57
+.4byte sUnownYPose58
+.4byte sUnownYPose59
+.4byte sUnownYPose60
+.4byte sUnownYPose61
+.4byte sUnownYPose62
+.4byte sUnownYPose63
+.4byte sUnownYPose64
+.4byte sUnownYPose65
+.4byte sUnownYPose66
+.4byte sUnownYPose67
+.4byte sUnownYPose68
+.4byte sUnownYPose69
+.4byte sUnownYPose70
+.4byte sUnownYPose71
+.4byte sUnownYPose72
+.4byte sUnownYPose73
+.4byte sUnownYPose74
+.4byte sUnownYPose75
+.4byte sUnownYPose76
+.4byte sUnownYPose77
+.4byte sUnownYPose78
+.4byte sUnownYPose79
+.4byte sUnownYPose80
+.4byte sUnownYPose81
+.4byte sUnownYPose82
+.4byte sUnownYPose83
+.4byte sUnownYPose84
+.4byte sUnownYPose85
+.4byte sUnownYPose86
+.4byte sUnownYPose87
+.4byte sUnownYPose88
+.4byte sUnownYPose89
+.4byte sUnownYPose90
+.4byte sUnownYPose91
+.4byte sUnownYPose92
+.4byte sUnownYPose93
+.4byte sUnownYPose94
+.4byte sUnownYPose95
+.4byte sUnownYPose96
+.4byte sUnownYPose97
+sAxPositionsUnownY:
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte   -1,  -13, 	  -7,  -18, 	   4,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   0,  -18, 	  -6,  -15, 	  -1,  -11
+.2byte    0,  -15, 	  -3,  -19, 	  -5,  -15, 	  -2,  -11
+.2byte   -1,  -15, 	  -5,  -19, 	   2,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -17, 	  -6,  -17, 	  -1,  -11
+.2byte   -1,  -15, 	   3,  -19, 	  -4,  -18, 	  -1,  -11
+.2byte   -2,  -15, 	   1,  -19, 	   3,  -15, 	   0,  -11
+.2byte   -1,  -14, 	  -2,  -18, 	   4,  -15, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	  -6,  -18, 	   4,  -18, 	  -1,  -12
+.2byte    0,  -14, 	   2,  -19, 	  -4,  -17, 	  -1,  -11
+.2byte    1,  -14, 	  -1,  -19, 	  -4,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	  -4,  -19, 	   3,  -17, 	  -1,  -11
+.2byte   -1,  -14, 	   4,  -18, 	  -6,  -18, 	  -1,  -11
+.2byte   -1,  -14, 	   2,  -19, 	  -5,  -17, 	  -1,  -11
+.2byte   -3,  -14, 	  -1,  -19, 	   2,  -16, 	  -1,  -10
+.2byte   -2,  -14, 	  -4,  -19, 	   2,  -17, 	  -1,  -11
+sUnownYAnimTable1:
+.4byte sUnownYAnims_1_1
+.4byte sUnownYAnims_1_2
+.4byte sUnownYAnims_1_3
+.4byte sUnownYAnims_1_4
+.4byte sUnownYAnims_1_5
+.4byte sUnownYAnims_1_6
+.4byte sUnownYAnims_1_7
+.4byte sUnownYAnims_1_8
+sUnownYAnimTable2:
+.4byte sUnownYAnims_2_1
+.4byte sUnownYAnims_2_2
+.4byte sUnownYAnims_2_3
+.4byte sUnownYAnims_2_4
+.4byte sUnownYAnims_2_5
+.4byte sUnownYAnims_2_6
+.4byte sUnownYAnims_2_7
+.4byte sUnownYAnims_2_8
+sUnownYAnimTable3:
+.4byte sUnownYAnims_3_1
+.4byte sUnownYAnims_3_2
+.4byte sUnownYAnims_3_3
+.4byte sUnownYAnims_3_4
+.4byte sUnownYAnims_3_5
+.4byte sUnownYAnims_3_6
+.4byte sUnownYAnims_3_7
+.4byte sUnownYAnims_3_8
+sUnownYAnimTable4:
+.4byte sUnownYAnims_4_1
+.4byte sUnownYAnims_4_2
+.4byte sUnownYAnims_4_3
+.4byte sUnownYAnims_4_4
+.4byte sUnownYAnims_4_5
+.4byte sUnownYAnims_4_6
+.4byte sUnownYAnims_4_7
+.4byte sUnownYAnims_4_8
+sUnownYAnimTable5:
+.4byte sUnownYAnims_5_1
+.4byte sUnownYAnims_5_2
+.4byte sUnownYAnims_5_3
+.4byte sUnownYAnims_5_4
+.4byte sUnownYAnims_5_5
+.4byte sUnownYAnims_5_6
+.4byte sUnownYAnims_5_7
+.4byte sUnownYAnims_5_8
+sUnownYAnimTable6:
+.4byte sUnownYAnims_6_1
+.4byte sUnownYAnims_6_1
+.4byte sUnownYAnims_6_1
+.4byte sUnownYAnims_6_1
+.4byte sUnownYAnims_6_1
+.4byte sUnownYAnims_6_1
+.4byte sUnownYAnims_6_1
+.4byte sUnownYAnims_6_1
+sUnownYAnimTable7:
+.4byte sUnownYAnims_7_1
+.4byte sUnownYAnims_7_2
+.4byte sUnownYAnims_7_3
+.4byte sUnownYAnims_7_4
+.4byte sUnownYAnims_7_5
+.4byte sUnownYAnims_7_6
+.4byte sUnownYAnims_7_7
+.4byte sUnownYAnims_7_8
+sUnownYAnimTable8:
+.4byte sUnownYAnims_8_1
+.4byte sUnownYAnims_8_2
+.4byte sUnownYAnims_8_3
+.4byte sUnownYAnims_8_4
+.4byte sUnownYAnims_8_5
+.4byte sUnownYAnims_8_6
+.4byte sUnownYAnims_8_7
+.4byte sUnownYAnims_8_8
+sUnownYAnimTable9:
+.4byte sUnownYAnims_9_1
+.4byte sUnownYAnims_9_2
+.4byte sUnownYAnims_9_3
+.4byte sUnownYAnims_9_4
+.4byte sUnownYAnims_9_5
+.4byte sUnownYAnims_9_6
+.4byte sUnownYAnims_9_7
+.4byte sUnownYAnims_9_8
+sUnownYAnimTable10:
+.4byte sUnownYAnims_10_1
+.4byte sUnownYAnims_10_2
+.4byte sUnownYAnims_10_3
+.4byte sUnownYAnims_10_4
+.4byte sUnownYAnims_10_5
+.4byte sUnownYAnims_10_6
+.4byte sUnownYAnims_10_7
+.4byte sUnownYAnims_10_8
+sUnownYAnimTable11:
+.4byte sUnownYAnims_11_1
+.4byte sUnownYAnims_11_2
+.4byte sUnownYAnims_11_3
+.4byte sUnownYAnims_11_4
+.4byte sUnownYAnims_11_5
+.4byte sUnownYAnims_11_6
+.4byte sUnownYAnims_11_7
+.4byte sUnownYAnims_11_8
+sUnownYAnimTable12:
+.4byte sUnownYAnims_12_1
+.4byte sUnownYAnims_12_2
+.4byte sUnownYAnims_12_3
+.4byte sUnownYAnims_12_4
+.4byte sUnownYAnims_12_5
+.4byte sUnownYAnims_12_6
+.4byte sUnownYAnims_12_7
+.4byte sUnownYAnims_12_8
+sUnownYAnimTable13:
+.4byte sUnownYAnims_13_1
+.4byte sUnownYAnims_13_2
+.4byte sUnownYAnims_13_3
+.4byte sUnownYAnims_13_4
+.4byte sUnownYAnims_13_5
+.4byte sUnownYAnims_13_6
+.4byte sUnownYAnims_13_7
+.4byte sUnownYAnims_13_8
+sAxAnimationsUnownY:
+.4byte sUnownYAnimTable1
+.4byte sUnownYAnimTable2
+.4byte sUnownYAnimTable3
+.4byte sUnownYAnimTable4
+.4byte sUnownYAnimTable5
+.4byte sUnownYAnimTable6
+.4byte sUnownYAnimTable7
+.4byte sUnownYAnimTable8
+.4byte sUnownYAnimTable9
+.4byte sUnownYAnimTable10
+.4byte sUnownYAnimTable11
+.4byte sUnownYAnimTable12
+.4byte sUnownYAnimTable13
+sAxSpritesUnownY:
+.4byte sUnownYSprites1
+.4byte sUnownYSprites2
+.4byte sUnownYSprites3
+.4byte sUnownYSprites4
+.4byte sUnownYSprites5
+.4byte sUnownYSprites6
+.4byte sUnownYSprites7
+.4byte sUnownYSprites8
+.4byte sUnownYSprites9
+.4byte sUnownYSprites10
+.4byte sUnownYSprites11
+sAxMainUnownY:
+ax_main sAxPosesUnownY, sAxAnimationsUnownY, 13, sAxSpritesUnownY, sAxPositionsUnownY

--- a/data/ax/unownz.inc
+++ b/data/ax/unownz.inc
@@ -1,0 +1,1809 @@
+.global gAxUnownZ
+gAxUnownZ:
+ax_siro sAxMainUnownZ
+sUnownZPose1:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose3:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose4:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose5:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose6:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose7:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose8:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose9:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose10:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose11:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose12:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose13:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose14:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose15:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose16:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose17:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose18:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose19:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose20:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose21:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose22:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose23:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose24:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose25:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose26:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose27:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose28:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose29:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose30:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose31:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose32:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose33:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose34:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose35:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose36:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose37:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose38:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose39:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose40:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose41:
+ax_pose 8, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose42:
+ax_pose 9, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose43:
+ax_pose 10, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownZPose44:
+ax_pose 11, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sUnownZPose45:
+ax_pose 12, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sUnownZPose46:
+ax_pose 13, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose47:
+ax_pose 14, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose48:
+ax_pose 15, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose49:
+ax_pose 16, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose50:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose51:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose52:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose53:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose54:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose55:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose56:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose57:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose58:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose59:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose60:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose61:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose62:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose63:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose64:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose65:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose66:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose67:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose68:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose69:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose70:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose71:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose72:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose73:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose74:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose75:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose76:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose77:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose78:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose79:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose80:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose81:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose82:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose83:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose84:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose85:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose86:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose87:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose88:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose89:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose90:
+ax_pose 0, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose91:
+ax_pose 1, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose92:
+ax_pose 2, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose93:
+ax_pose 3, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose94:
+ax_pose 4, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose95:
+ax_pose 5, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sUnownZPose96:
+ax_pose 6, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sUnownZPose97:
+ax_pose 7, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+.align 2
+sUnownZAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 2, -1, 2, 0,
+ax_anim 5, 0, 0, 3, -2, 3, 0,
+ax_anim 5, 0, 0, 3, -3, 3, 0,
+ax_anim 6, 0, 0, 2, -4, 2, 0,
+ax_anim 6, 0, 0, 0, -5, 0, 0,
+ax_anim 6, 0, 0, -2, -4, -2, 0,
+ax_anim 5, 0, 0, -3, -3, -3, 0,
+ax_anim 5, 0, 0, -3, -2, -3, 0,
+ax_anim 6, 0, 0, -2, -1, -2, 0,
+ax_anim_terminator
+sUnownZAnims_1_2:
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 1, -2, 0, -1, 1,
+ax_anim 5, 0, 1, -3, -1, -2, 2,
+ax_anim 5, 0, 1, -3, -2, -2, 2,
+ax_anim 6, 0, 1, -2, -3, -1, 1,
+ax_anim 6, 0, 1, 0, -5, 0, 0,
+ax_anim 6, 0, 1, 2, -5, 1, -1,
+ax_anim 5, 0, 1, 3, -4, 2, -2,
+ax_anim 5, 0, 1, 3, -3, 2, -2,
+ax_anim 6, 0, 1, 2, -2, 1, -1,
+ax_anim_terminator
+sUnownZAnims_1_3:
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 1, -1, 1, 1,
+ax_anim 5, 0, 2, 2, -2, 2, 1,
+ax_anim 5, 0, 2, 2, -3, 2, 1,
+ax_anim 6, 0, 2, 1, -4, 1, 1,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, -1, -4, -1, -1,
+ax_anim 5, 0, 2, -2, -3, -2, -1,
+ax_anim 5, 0, 2, -2, -2, -2, -1,
+ax_anim 6, 0, 2, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownZAnims_1_4:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 3, -1, -1, -1, -1,
+ax_anim 5, 0, 3, -2, -2, -2, -2,
+ax_anim 5, 0, 3, -3, -3, -2, -2,
+ax_anim 6, 0, 3, -2, -4, -1, -1,
+ax_anim 6, 0, 3, 0, -5, 0, 0,
+ax_anim 6, 0, 3, 1, -4, 1, 1,
+ax_anim 5, 0, 3, 2, -3, 2, 2,
+ax_anim 5, 0, 3, 3, -2, 2, 2,
+ax_anim 6, 0, 3, 2, -1, 1, 1,
+ax_anim_terminator
+sUnownZAnims_1_5:
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -2, -1, -2, 0,
+ax_anim 5, 0, 4, -3, -2, -3, 0,
+ax_anim 5, 0, 4, -3, -3, -3, 0,
+ax_anim 6, 0, 4, -2, -4, -2, 0,
+ax_anim 6, 0, 4, 0, -5, 0, 0,
+ax_anim 6, 0, 4, 2, -4, 2, 0,
+ax_anim 5, 0, 4, 3, -3, 3, 0,
+ax_anim 5, 0, 4, 3, -2, 3, 0,
+ax_anim 6, 0, 4, 2, -1, 2, 0,
+ax_anim_terminator
+sUnownZAnims_1_6:
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 1, -1, 1, -1,
+ax_anim 5, 0, 5, 2, -2, 2, -2,
+ax_anim 5, 0, 5, 3, -3, 2, -2,
+ax_anim 6, 0, 5, 2, -4, 1, -1,
+ax_anim 6, 0, 5, 0, -5, 0, 0,
+ax_anim 6, 0, 5, -1, -4, -1, 1,
+ax_anim 5, 0, 5, -2, -3, -2, 2,
+ax_anim 5, 0, 5, -3, -2, -2, 2,
+ax_anim 6, 0, 5, -2, -1, -1, 1,
+ax_anim_terminator
+sUnownZAnims_1_7:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 1, -1, 1, 1,
+ax_anim 5, 0, 6, 2, -2, 2, 1,
+ax_anim 5, 0, 6, 2, -3, 2, 1,
+ax_anim 6, 0, 6, 1, -4, 1, 1,
+ax_anim 6, 0, 6, 0, -5, 0, 0,
+ax_anim 6, 0, 6, -1, -4, -1, -1,
+ax_anim 5, 0, 6, -2, -3, -2, -1,
+ax_anim 5, 0, 6, -2, -2, -2, -1,
+ax_anim 6, 0, 6, -1, -1, -1, -1,
+ax_anim_terminator
+sUnownZAnims_1_8:
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 2, 0, 1, 1,
+ax_anim 5, 0, 7, 3, -1, 2, 2,
+ax_anim 5, 0, 7, 3, -2, 2, 2,
+ax_anim 6, 0, 7, 2, -3, 1, 1,
+ax_anim 6, 0, 7, 0, -5, 0, 0,
+ax_anim 6, 0, 7, -2, -5, -1, -1,
+ax_anim 5, 0, 7, -3, -4, -2, -2,
+ax_anim 5, 0, 7, -3, -3, -2, -2,
+ax_anim 6, 0, 7, -2, -2, -1, -1,
+ax_anim_terminator
+.align 2
+sUnownZAnims_2_1:
+ax_anim 2, 0, 8, 0, -1, 0, -1,
+ax_anim 4, 0, 8, 0, -2, 0, -2,
+ax_anim 1, 0, 8, 0, 0, 0, 0,
+ax_anim 1, 2, 8, 0, 4, 0, 4,
+ax_anim 1, 0, 8, 0, 10, 0, 8,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 1, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 24, 0, 21,
+ax_anim 2, 0, 8, 1, 24, 1, 21,
+ax_anim 2, 0, 8, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownZAnims_2_2:
+ax_anim 2, 0, 9, -1, -1, -1, -1,
+ax_anim 4, 0, 9, -2, -2, -2, -2,
+ax_anim 1, 0, 9, 0, 0, 0, 0,
+ax_anim 1, 2, 9, 4, 4, 4, 4,
+ax_anim 1, 0, 9, 10, 10, 10, 9,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 1, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 23, 24, 23, 21,
+ax_anim 2, 0, 9, 24, 23, 24, 20,
+ax_anim 2, 0, 9, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownZAnims_2_3:
+ax_anim 2, 0, 10, -1, 0, -1, 0,
+ax_anim 4, 0, 10, -2, 0, -2, 0,
+ax_anim 1, 0, 10, 0, 0, 0, 0,
+ax_anim 1, 2, 10, 4, 0, 4, 0,
+ax_anim 1, 0, 10, 10, 1, 10, 0,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 1, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 23, 2, 23, 0,
+ax_anim 2, 0, 10, 23, 1, 23, -1,
+ax_anim 2, 0, 10, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownZAnims_2_4:
+ax_anim 2, 0, 11, -1, 1, -1, 1,
+ax_anim 4, 0, 11, -2, 2, -2, 2,
+ax_anim 1, 0, 11, 0, 0, 0, 0,
+ax_anim 1, 2, 11, 6, -5, 6, -5,
+ax_anim 1, 0, 11, 14, -11, 14, -13,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 1, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 23, -17, 23, -20,
+ax_anim 2, 0, 11, 22, -18, 22, -21,
+ax_anim 2, 0, 11, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownZAnims_2_5:
+ax_anim 2, 0, 12, 0, 1, 0, 1,
+ax_anim 4, 0, 12, 0, 2, 0, 2,
+ax_anim 1, 0, 12, 0, 0, 0, 0,
+ax_anim 1, 2, 12, 0, -4, 0, -4,
+ax_anim 1, 0, 12, 0, -11, 0, -12,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 1, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -17, 0, -20,
+ax_anim 2, 0, 12, 1, -17, 1, -20,
+ax_anim 2, 0, 12, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownZAnims_2_6:
+ax_anim 2, 0, 13, 1, 1, 1, 1,
+ax_anim 4, 0, 13, 2, 2, 2, 2,
+ax_anim 1, 0, 13, 0, 0, 0, 0,
+ax_anim 1, 2, 13, -6, -5, -6, -5,
+ax_anim 1, 0, 13, -14, -11, -14, -13,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 1, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -23, -17, -23, -20,
+ax_anim 2, 0, 13, -24, -16, -24, -19,
+ax_anim 2, 0, 13, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownZAnims_2_7:
+ax_anim 2, 0, 14, 1, 0, 1, 0,
+ax_anim 4, 0, 14, 2, 0, 2, 0,
+ax_anim 1, 0, 14, 0, 0, 0, 0,
+ax_anim 1, 2, 14, -4, 0, -4, 0,
+ax_anim 1, 0, 14, -10, 1, -10, 0,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 1, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -23, 2, -23, 0,
+ax_anim 2, 0, 14, -23, 1, -23, -1,
+ax_anim 2, 0, 14, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownZAnims_2_8:
+ax_anim 2, 0, 15, 1, -1, 1, -1,
+ax_anim 4, 0, 15, 2, -2, 2, -2,
+ax_anim 1, 0, 15, 0, 0, 0, 0,
+ax_anim 1, 2, 15, -4, 4, -4, 4,
+ax_anim 1, 0, 15, -10, 10, -10, 9,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 1, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -23, 24, -23, 21,
+ax_anim 2, 0, 15, -24, 23, -24, 20,
+ax_anim 2, 0, 15, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownZAnims_3_1:
+ax_anim 2, 0, 16, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 16, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 16, 0, 10, 0, 8,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 1, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 24, 0, 21,
+ax_anim 2, 0, 16, 1, 24, 1, 21,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sUnownZAnims_3_2:
+ax_anim 2, 0, 17, -1, -1, -1, -1,
+ax_anim 4, 0, 17, -2, -2, -2, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 17, 4, 4, 4, 4,
+ax_anim 1, 0, 17, 10, 10, 10, 9,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 1, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 23, 24, 23, 21,
+ax_anim 2, 0, 17, 24, 23, 24, 20,
+ax_anim 2, 0, 17, 6, 6, 6, 6,
+ax_anim_terminator
+sUnownZAnims_3_3:
+ax_anim 2, 0, 18, -1, 0, -1, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim 1, 0, 18, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 4, 0, 4, 0,
+ax_anim 1, 0, 18, 10, 1, 10, 0,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 1, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 23, 2, 23, 0,
+ax_anim 2, 0, 18, 23, 1, 23, -1,
+ax_anim 2, 0, 18, 6, 0, 6, 0,
+ax_anim_terminator
+sUnownZAnims_3_4:
+ax_anim 2, 0, 19, -1, 1, -1, 1,
+ax_anim 4, 0, 19, -2, 2, -2, 2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 19, 6, -5, 6, -5,
+ax_anim 1, 0, 19, 14, -11, 14, -13,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 1, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 23, -17, 23, -20,
+ax_anim 2, 0, 19, 22, -18, 22, -21,
+ax_anim 2, 0, 19, 7, -5, 7, -6,
+ax_anim_terminator
+sUnownZAnims_3_5:
+ax_anim 2, 0, 20, 0, 1, 0, 1,
+ax_anim 4, 0, 20, 0, 2, 0, 2,
+ax_anim 1, 0, 20, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 0, -4, 0, -4,
+ax_anim 1, 0, 20, 0, -11, 0, -12,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 1, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -17, 0, -20,
+ax_anim 2, 0, 20, 1, -17, 1, -20,
+ax_anim 2, 0, 20, 0, -6, 0, -6,
+ax_anim_terminator
+sUnownZAnims_3_6:
+ax_anim 2, 0, 21, 1, 1, 1, 1,
+ax_anim 4, 0, 21, 2, 2, 2, 2,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 21, -6, -5, -6, -5,
+ax_anim 1, 0, 21, -14, -11, -14, -13,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 1, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -23, -17, -23, -20,
+ax_anim 2, 0, 21, -24, -16, -24, -19,
+ax_anim 2, 0, 21, -7, -5, -7, -6,
+ax_anim_terminator
+sUnownZAnims_3_7:
+ax_anim 2, 0, 22, 1, 0, 1, 0,
+ax_anim 4, 0, 22, 2, 0, 2, 0,
+ax_anim 1, 0, 22, 0, 0, 0, 0,
+ax_anim 1, 2, 22, -4, 0, -4, 0,
+ax_anim 1, 0, 22, -10, 1, -10, 0,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 1, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -23, 2, -23, 0,
+ax_anim 2, 0, 22, -23, 1, -23, -1,
+ax_anim 2, 0, 22, -6, 0, -6, 0,
+ax_anim_terminator
+sUnownZAnims_3_8:
+ax_anim 2, 0, 23, 1, -1, 1, -1,
+ax_anim 4, 0, 23, 2, -2, 2, -2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 23, -4, 4, -4, 4,
+ax_anim 1, 0, 23, -10, 10, -10, 9,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 1, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -23, 24, -23, 21,
+ax_anim 2, 0, 23, -24, 23, -24, 20,
+ax_anim 2, 0, 23, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUnownZAnims_4_1:
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 2, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 1, 0, 1, 0,
+ax_anim 2, 1, 24, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_4_2:
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 2, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 1, -1, 1, -1,
+ax_anim 2, 1, 25, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_4_3:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 2, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 2, 1, 26, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_4_4:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 2, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 2, 1, 27, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_4_5:
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 2, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, 1, 0, 1, 0,
+ax_anim 2, 1, 28, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_4_6:
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 2, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, 1, -1, 1, -1,
+ax_anim 2, 1, 29, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_4_7:
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 2, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, 0, -1, 0, -1,
+ax_anim 2, 1, 30, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_4_8:
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 2, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, -1, -1, -1, -1,
+ax_anim 2, 1, 31, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_5_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 2, 32, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_5_2:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_5_3:
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 2, 34, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_5_4:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 2, 35, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_5_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 2, 36, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_5_6:
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 2, 37, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_5_7:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 2, 38, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_5_8:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 2, 39, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_6_1:
+ax_anim 30, 0, 40, 0, 0, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim 35, 0, 40, 0, 2, 0, 0,
+ax_anim 4, 0, 40, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_7_1:
+ax_anim 2, 0, 41, 0, -2, 0, -2,
+ax_anim 8, 0, 41, 0, -3, 0, -3,
+ax_anim_terminator
+sUnownZAnims_7_2:
+ax_anim 2, 0, 42, -2, -2, -2, -2,
+ax_anim 8, 0, 42, -3, -3, -3, -3,
+ax_anim_terminator
+sUnownZAnims_7_3:
+ax_anim 2, 0, 43, -2, 0, -2, 0,
+ax_anim 8, 0, 43, -3, 0, -3, 0,
+ax_anim_terminator
+sUnownZAnims_7_4:
+ax_anim 2, 0, 44, -2, 2, -2, 2,
+ax_anim 8, 0, 44, -3, 3, -3, 3,
+ax_anim_terminator
+sUnownZAnims_7_5:
+ax_anim 2, 0, 45, 0, 2, 0, 2,
+ax_anim 8, 0, 45, 0, 3, 0, 3,
+ax_anim_terminator
+sUnownZAnims_7_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 8, 0, 46, 3, 3, 3, 3,
+ax_anim_terminator
+sUnownZAnims_7_7:
+ax_anim 2, 0, 47, 2, 0, 2, 0,
+ax_anim 8, 0, 47, 3, 0, 3, 0,
+ax_anim_terminator
+sUnownZAnims_7_8:
+ax_anim 2, 0, 48, 2, -2, 2, -2,
+ax_anim 8, 0, 48, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUnownZAnims_8_1:
+ax_anim 20, 0, 49, 0, 0, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim 20, 0, 49, 0, -2, 0, 0,
+ax_anim 8, 0, 49, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownZAnims_8_2:
+ax_anim 20, 0, 50, 0, 0, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim 20, 0, 50, 0, -2, 0, 0,
+ax_anim 8, 0, 50, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownZAnims_8_3:
+ax_anim 20, 0, 51, 0, 0, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim 20, 0, 51, 0, -2, 0, 0,
+ax_anim 8, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownZAnims_8_4:
+ax_anim 20, 0, 52, 0, 0, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim 20, 0, 52, 0, -2, 0, 0,
+ax_anim 8, 0, 52, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownZAnims_8_5:
+ax_anim 20, 0, 53, 0, 0, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim 20, 0, 53, 0, -2, 0, 0,
+ax_anim 8, 0, 53, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownZAnims_8_6:
+ax_anim 20, 0, 54, 0, 0, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim 20, 0, 54, 0, -2, 0, 0,
+ax_anim 8, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownZAnims_8_7:
+ax_anim 20, 0, 55, 0, 0, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim 20, 0, 55, 0, -2, 0, 0,
+ax_anim 8, 0, 55, 0, -1, 0, 0,
+ax_anim_terminator
+sUnownZAnims_8_8:
+ax_anim 20, 0, 56, 0, 0, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim 20, 0, 56, 0, -2, 0, 0,
+ax_anim 8, 0, 56, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_9_1:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 0, 64, 6, 3, 6, 3,
+ax_anim 2, 0, 63, 8, 9, 8, 9,
+ax_anim 2, 0, 62, 7, 18, 7, 18,
+ax_anim 3, 0, 61, 0, 22, 0, 22,
+ax_anim 2, 3, 60, -7, 18, -7, 18,
+ax_anim 2, 0, 59, -8, 9, -8, 9,
+ax_anim 1, 0, 58, -6, 3, -6, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_9_2:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 0, 57, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 21, 3, 21, 3,
+ax_anim 2, 0, 63, 26, 10, 26, 10,
+ax_anim 3, 0, 62, 20, 18, 20, 18,
+ax_anim 2, 3, 61, 11, 19, 11, 19,
+ax_anim 2, 0, 60, 3, 15, 3, 15,
+ax_anim 1, 0, 59, 0, 7, 0, 7,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_9_3:
+ax_anim 2, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 0, 58, 5, -5, 5, -5,
+ax_anim 2, 0, 57, 13, -6, 13, -6,
+ax_anim 2, 0, 64, 20, -5, 20, -5,
+ax_anim 3, 0, 63, 23, 0, 23, 0,
+ax_anim 2, 3, 62, 20, 4, 20, 4,
+ax_anim 2, 0, 61, 14, 7, 14, 7,
+ax_anim 1, 0, 60, 6, 5, 6, 5,
+ax_anim 1, 0, 59, 2, 0, 2, 0,
+ax_anim_terminator
+sUnownZAnims_9_4:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 0, 59, -1, -6, -1, -6,
+ax_anim 2, 0, 58, 4, -17, 4, -17,
+ax_anim 2, 0, 57, 15, -22, 15, -22,
+ax_anim 3, 0, 64, 21, -21, 21, -21,
+ax_anim 2, 3, 63, 24, -13, 24, -13,
+ax_anim 2, 0, 62, 19, -4, 19, -4,
+ax_anim 1, 0, 61, 9, 0, 9, 0,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_9_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 0, 60, -8, -4, -8, -4,
+ax_anim 2, 0, 59, -9, -12, -9, -12,
+ax_anim 2, 0, 58, -7, -20, -7, -20,
+ax_anim 3, 0, 57, 0, -22, 0, -22,
+ax_anim 2, 3, 64, 7, -20, 7, -20,
+ax_anim 2, 0, 63, 9, -10, 9, -10,
+ax_anim 1, 0, 62, 8, -4, 8, -4,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_9_6:
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 0, 63, 1, -6, 1, -6,
+ax_anim 2, 0, 64, -4, -17, -4, -17,
+ax_anim 2, 0, 57, -15, -22, -15, -22,
+ax_anim 3, 0, 58, -21, -21, -21, -21,
+ax_anim 2, 3, 59, -24, -13, -24, -13,
+ax_anim 2, 0, 60, -19, -4, -19, -4,
+ax_anim 1, 0, 61, -9, 0, -9, 0,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_9_7:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 0, 64, -5, -5, -5, -5,
+ax_anim 2, 0, 57, -13, -6, -13, -6,
+ax_anim 2, 0, 58, -20, -5, -20, -5,
+ax_anim 3, 0, 59, -23, 0, -23, 0,
+ax_anim 2, 3, 60, -20, 4, -20, 4,
+ax_anim 2, 0, 61, -14, 7, -14, 7,
+ax_anim 1, 0, 62, -6, 5, -6, 5,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sUnownZAnims_9_8:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 0, 57, -11, 0, -11, 0,
+ax_anim 2, 0, 58, -21, 3, -21, 3,
+ax_anim 2, 0, 59, -26, 10, -26, 10,
+ax_anim 3, 0, 60, -20, 18, -20, 18,
+ax_anim 2, 3, 61, -11, 19, -11, 19,
+ax_anim 2, 0, 62, -3, 15, -3, 15,
+ax_anim 1, 0, 63, 0, 7, 0, 7,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_10_1:
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 3, 0, 65, 13, 0, 13, 0,
+ax_anim 3, 0, 65, -13, 0, -13, 0,
+ax_anim 2, 0, 65, 12, 0, 12, 0,
+ax_anim 3, 0, 65, -12, 0, -12, 0,
+ax_anim 2, 0, 65, 10, 0, 10, 0,
+ax_anim 2, 0, 65, -10, 0, -10, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim 2, 0, 65, -6, 0, -6, 0,
+ax_anim 2, 0, 65, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_10_2:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 3, 0, 66, 13, -13, 13, -13,
+ax_anim 3, 0, 66, -13, 13, -13, 13,
+ax_anim 2, 0, 66, 12, -12, 12, -12,
+ax_anim 3, 0, 66, -12, 12, -12, 12,
+ax_anim 2, 0, 66, 10, -10, 10, -10,
+ax_anim 2, 0, 66, -10, 10, -10, 10,
+ax_anim 2, 0, 66, 6, -6, 6, -6,
+ax_anim 2, 0, 66, -6, 6, -6, 6,
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_10_3:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 3, 0, 67, 0, -13, 0, -13,
+ax_anim 3, 0, 67, 0, 13, 0, 13,
+ax_anim 2, 0, 67, 0, -12, 0, -12,
+ax_anim 3, 0, 67, 0, 12, 0, 12,
+ax_anim 2, 0, 67, 0, -10, 0, -10,
+ax_anim 2, 0, 67, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, -6, 0, -6,
+ax_anim 2, 0, 67, 0, 6, 0, 6,
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_10_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 3, 0, 68, -13, -13, -13, -13,
+ax_anim 3, 0, 68, 13, 13, 13, 13,
+ax_anim 2, 0, 68, -12, -12, -12, -12,
+ax_anim 3, 0, 68, 12, 12, 12, 12,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, 10, 10, 10, 10,
+ax_anim 2, 0, 68, -6, -6, -6, -6,
+ax_anim 2, 0, 68, 6, 6, 6, 6,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_10_5:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 3, 0, 69, 13, 0, 13, 0,
+ax_anim 3, 0, 69, -13, 0, -13, 0,
+ax_anim 2, 0, 69, 12, 0, 12, 0,
+ax_anim 3, 0, 69, -12, 0, -12, 0,
+ax_anim 2, 0, 69, 10, 0, 10, 0,
+ax_anim 2, 0, 69, -10, 0, -10, 0,
+ax_anim 2, 0, 69, 6, 0, 6, 0,
+ax_anim 2, 0, 69, -6, 0, -6, 0,
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_10_6:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 3, 0, 70, 13, -13, 13, -13,
+ax_anim 3, 0, 70, -13, 13, -13, 13,
+ax_anim 2, 0, 70, 12, -12, 12, -12,
+ax_anim 3, 0, 70, -12, 12, -12, 12,
+ax_anim 2, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 70, -10, 10, -10, 10,
+ax_anim 2, 0, 70, 6, -6, 6, -6,
+ax_anim 2, 0, 70, -6, 6, -6, 6,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_10_7:
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 3, 0, 71, 0, -13, 0, -13,
+ax_anim 3, 0, 71, 0, 13, 0, 13,
+ax_anim 2, 0, 71, 0, -12, 0, -12,
+ax_anim 3, 0, 71, 0, 12, 0, 12,
+ax_anim 2, 0, 71, 0, -10, 0, -10,
+ax_anim 2, 0, 71, 0, 10, 0, 10,
+ax_anim 2, 0, 71, 0, -6, 0, -6,
+ax_anim 2, 0, 71, 0, 6, 0, 6,
+ax_anim 2, 0, 71, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_10_8:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 3, 0, 72, -13, -13, -13, -13,
+ax_anim 3, 0, 72, 13, 13, 13, 13,
+ax_anim 2, 0, 72, -12, -12, -12, -12,
+ax_anim 3, 0, 72, 12, 12, 12, 12,
+ax_anim 2, 0, 72, -10, -10, -10, -10,
+ax_anim 2, 0, 72, 10, 10, 10, 10,
+ax_anim 2, 0, 72, -6, -6, -6, -6,
+ax_anim 2, 0, 72, 6, 6, 6, 6,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_11_1:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -10, 0, 0,
+ax_anim 2, 0, 73, 0, -16, 0, 0,
+ax_anim 3, 0, 73, 0, -20, 0, 0,
+ax_anim 4, 0, 73, 0, -21, 0, 0,
+ax_anim 4, 0, 73, 0, -22, 0, 0,
+ax_anim 3, 0, 73, 0, -21, 0, 0,
+ax_anim 2, 0, 73, 0, -18, 0, 0,
+ax_anim 1, 0, 73, 0, -12, 0, 0,
+ax_anim 2, 2, 73, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownZAnims_11_2:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 0, -10, 0, 0,
+ax_anim 2, 0, 74, 0, -16, 0, 0,
+ax_anim 3, 0, 74, 0, -20, 0, 0,
+ax_anim 4, 0, 74, 0, -21, 0, 0,
+ax_anim 4, 0, 74, 0, -22, 0, 0,
+ax_anim 3, 0, 74, 0, -21, 0, 0,
+ax_anim 2, 0, 74, 0, -18, 0, 0,
+ax_anim 1, 0, 74, 0, -12, 0, 0,
+ax_anim 2, 2, 74, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownZAnims_11_3:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -10, 0, 0,
+ax_anim 2, 0, 75, 0, -16, 0, 0,
+ax_anim 3, 0, 75, 0, -20, 0, 0,
+ax_anim 4, 0, 75, 0, -21, 0, 0,
+ax_anim 4, 0, 75, 0, -22, 0, 0,
+ax_anim 3, 0, 75, 0, -21, 0, 0,
+ax_anim 2, 0, 75, 0, -18, 0, 0,
+ax_anim 1, 0, 75, 0, -12, 0, 0,
+ax_anim 2, 2, 75, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownZAnims_11_4:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 0, -10, 0, 0,
+ax_anim 2, 0, 76, 0, -16, 0, 0,
+ax_anim 3, 0, 76, 0, -20, 0, 0,
+ax_anim 4, 0, 76, 0, -21, 0, 0,
+ax_anim 4, 0, 76, 0, -22, 0, 0,
+ax_anim 3, 0, 76, 0, -21, 0, 0,
+ax_anim 2, 0, 76, 0, -18, 0, 0,
+ax_anim 1, 0, 76, 0, -12, 0, 0,
+ax_anim 2, 2, 76, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownZAnims_11_5:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -10, 0, 0,
+ax_anim 2, 0, 77, 0, -16, 0, 0,
+ax_anim 3, 0, 77, 0, -20, 0, 0,
+ax_anim 4, 0, 77, 0, -21, 0, 0,
+ax_anim 4, 0, 77, 0, -22, 0, 0,
+ax_anim 3, 0, 77, 0, -21, 0, 0,
+ax_anim 2, 0, 77, 0, -18, 0, 0,
+ax_anim 1, 0, 77, 0, -12, 0, 0,
+ax_anim 2, 2, 77, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownZAnims_11_6:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 78, 0, -10, 0, 0,
+ax_anim 2, 0, 78, 0, -16, 0, 0,
+ax_anim 3, 0, 78, 0, -20, 0, 0,
+ax_anim 4, 0, 78, 0, -21, 0, 0,
+ax_anim 4, 0, 78, 0, -22, 0, 0,
+ax_anim 3, 0, 78, 0, -21, 0, 0,
+ax_anim 2, 0, 78, 0, -18, 0, 0,
+ax_anim 1, 0, 78, 0, -12, 0, 0,
+ax_anim 2, 2, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownZAnims_11_7:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -10, 0, 0,
+ax_anim 2, 0, 79, 0, -16, 0, 0,
+ax_anim 3, 0, 79, 0, -20, 0, 0,
+ax_anim 4, 0, 79, 0, -21, 0, 0,
+ax_anim 4, 0, 79, 0, -22, 0, 0,
+ax_anim 3, 0, 79, 0, -21, 0, 0,
+ax_anim 2, 0, 79, 0, -18, 0, 0,
+ax_anim 1, 0, 79, 0, -12, 0, 0,
+ax_anim 2, 2, 79, 0, 4, 0, 0,
+ax_anim_terminator
+sUnownZAnims_11_8:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 80, 0, -10, 0, 0,
+ax_anim 2, 0, 80, 0, -16, 0, 0,
+ax_anim 3, 0, 80, 0, -20, 0, 0,
+ax_anim 4, 0, 80, 0, -21, 0, 0,
+ax_anim 4, 0, 80, 0, -22, 0, 0,
+ax_anim 3, 0, 80, 0, -21, 0, 0,
+ax_anim 2, 0, 80, 0, -18, 0, 0,
+ax_anim 1, 0, 80, 0, -12, 0, 0,
+ax_anim 2, 2, 80, 0, 4, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_12_1:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 2, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 1, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_12_2:
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 2, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, -1, 1, -1,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_12_3:
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 2, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 0, -1, 0, -1,
+ax_anim 2, 1, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_12_4:
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_12_5:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 2, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 1, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_12_6:
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 2, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 1, -1, 1, -1,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_12_7:
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 2, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 0, -1, 0, -1,
+ax_anim 2, 1, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_12_8:
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, -1, -1, -1, -1,
+ax_anim 2, 1, 88, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUnownZAnims_13_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_13_2:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_13_3:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_13_4:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_13_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_13_6:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_13_7:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZAnims_13_8:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sUnownZGfx1:
+.incbin "baserom.gba", 0xE25BD8, 0x200
+sUnownZSprites1:
+ax_sprite sUnownZGfx1, 0x200
+ax_sprite_terminator
+sUnownZGfx2:
+.incbin "baserom.gba", 0xE25DE8, 0x200
+sUnownZSprites2:
+ax_sprite sUnownZGfx2, 0x200
+ax_sprite_terminator
+sUnownZGfx3:
+.incbin "baserom.gba", 0xE25FF8, 0x200
+sUnownZSprites3:
+ax_sprite sUnownZGfx3, 0x200
+ax_sprite_terminator
+sUnownZGfx4:
+.incbin "baserom.gba", 0xE26208, 0x200
+sUnownZSprites4:
+ax_sprite sUnownZGfx4, 0x200
+ax_sprite_terminator
+sUnownZGfx5:
+.incbin "baserom.gba", 0xE26418, 0x200
+sUnownZSprites5:
+ax_sprite sUnownZGfx5, 0x200
+ax_sprite_terminator
+sUnownZGfx6:
+.incbin "baserom.gba", 0xE26628, 0x200
+sUnownZSprites6:
+ax_sprite sUnownZGfx6, 0x200
+ax_sprite_terminator
+sUnownZGfx7:
+.incbin "baserom.gba", 0xE26838, 0x200
+sUnownZSprites7:
+ax_sprite sUnownZGfx7, 0x200
+ax_sprite_terminator
+sUnownZGfx8:
+.incbin "baserom.gba", 0xE26A48, 0x200
+sUnownZSprites8:
+ax_sprite sUnownZGfx8, 0x200
+ax_sprite_terminator
+sUnownZGfx9:
+.incbin "baserom.gba", 0xE26C58, 0x200
+sUnownZSprites9:
+ax_sprite sUnownZGfx9, 0x200
+ax_sprite_terminator
+sUnownZGfx10:
+.incbin "baserom.gba", 0xE26E68, 0x200
+sUnownZSprites10:
+ax_sprite sUnownZGfx10, 0x200
+ax_sprite_terminator
+sUnownZGfx11:
+.incbin "baserom.gba", 0xE27078, 0x200
+sUnownZSprites11:
+ax_sprite sUnownZGfx11, 0x200
+ax_sprite_terminator
+sUnownZGfx12:
+.incbin "baserom.gba", 0xE27288, 0x200
+sUnownZSprites12:
+ax_sprite sUnownZGfx12, 0x200
+ax_sprite_terminator
+sUnownZGfx13:
+.incbin "baserom.gba", 0xE27498, 0x200
+sUnownZSprites13:
+ax_sprite sUnownZGfx13, 0x200
+ax_sprite_terminator
+sUnownZGfx14:
+.incbin "baserom.gba", 0xE276A8, 0x200
+sUnownZSprites14:
+ax_sprite sUnownZGfx14, 0x200
+ax_sprite_terminator
+sUnownZGfx15:
+.incbin "baserom.gba", 0xE278B8, 0x200
+sUnownZSprites15:
+ax_sprite sUnownZGfx15, 0x200
+ax_sprite_terminator
+sUnownZGfx16:
+.incbin "baserom.gba", 0xE27AC8, 0x200
+sUnownZSprites16:
+ax_sprite sUnownZGfx16, 0x200
+ax_sprite_terminator
+sUnownZGfx17:
+.incbin "baserom.gba", 0xE27CD8, 0x200
+sUnownZSprites17:
+ax_sprite sUnownZGfx17, 0x200
+ax_sprite_terminator
+sAxPosesUnownZ:
+.4byte sUnownZPose1
+.4byte sUnownZPose2
+.4byte sUnownZPose3
+.4byte sUnownZPose4
+.4byte sUnownZPose5
+.4byte sUnownZPose6
+.4byte sUnownZPose7
+.4byte sUnownZPose8
+.4byte sUnownZPose9
+.4byte sUnownZPose10
+.4byte sUnownZPose11
+.4byte sUnownZPose12
+.4byte sUnownZPose13
+.4byte sUnownZPose14
+.4byte sUnownZPose15
+.4byte sUnownZPose16
+.4byte sUnownZPose17
+.4byte sUnownZPose18
+.4byte sUnownZPose19
+.4byte sUnownZPose20
+.4byte sUnownZPose21
+.4byte sUnownZPose22
+.4byte sUnownZPose23
+.4byte sUnownZPose24
+.4byte sUnownZPose25
+.4byte sUnownZPose26
+.4byte sUnownZPose27
+.4byte sUnownZPose28
+.4byte sUnownZPose29
+.4byte sUnownZPose30
+.4byte sUnownZPose31
+.4byte sUnownZPose32
+.4byte sUnownZPose33
+.4byte sUnownZPose34
+.4byte sUnownZPose35
+.4byte sUnownZPose36
+.4byte sUnownZPose37
+.4byte sUnownZPose38
+.4byte sUnownZPose39
+.4byte sUnownZPose40
+.4byte sUnownZPose41
+.4byte sUnownZPose42
+.4byte sUnownZPose43
+.4byte sUnownZPose44
+.4byte sUnownZPose45
+.4byte sUnownZPose46
+.4byte sUnownZPose47
+.4byte sUnownZPose48
+.4byte sUnownZPose49
+.4byte sUnownZPose50
+.4byte sUnownZPose51
+.4byte sUnownZPose52
+.4byte sUnownZPose53
+.4byte sUnownZPose54
+.4byte sUnownZPose55
+.4byte sUnownZPose56
+.4byte sUnownZPose57
+.4byte sUnownZPose58
+.4byte sUnownZPose59
+.4byte sUnownZPose60
+.4byte sUnownZPose61
+.4byte sUnownZPose62
+.4byte sUnownZPose63
+.4byte sUnownZPose64
+.4byte sUnownZPose65
+.4byte sUnownZPose66
+.4byte sUnownZPose67
+.4byte sUnownZPose68
+.4byte sUnownZPose69
+.4byte sUnownZPose70
+.4byte sUnownZPose71
+.4byte sUnownZPose72
+.4byte sUnownZPose73
+.4byte sUnownZPose74
+.4byte sUnownZPose75
+.4byte sUnownZPose76
+.4byte sUnownZPose77
+.4byte sUnownZPose78
+.4byte sUnownZPose79
+.4byte sUnownZPose80
+.4byte sUnownZPose81
+.4byte sUnownZPose82
+.4byte sUnownZPose83
+.4byte sUnownZPose84
+.4byte sUnownZPose85
+.4byte sUnownZPose86
+.4byte sUnownZPose87
+.4byte sUnownZPose88
+.4byte sUnownZPose89
+.4byte sUnownZPose90
+.4byte sUnownZPose91
+.4byte sUnownZPose92
+.4byte sUnownZPose93
+.4byte sUnownZPose94
+.4byte sUnownZPose95
+.4byte sUnownZPose96
+.4byte sUnownZPose97
+sAxPositionsUnownZ:
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -13, 	   0,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    1,  -13, 	   0,   -5, 	  -2,  -19, 	  -1,  -12
+.2byte    0,  -14, 	   1,   -5, 	  -2,  -19, 	   0,  -11
+.2byte   -1,  -13, 	  -2,   -6, 	   0,  -17, 	  -1,  -11
+.2byte   -2,  -14, 	  -2,   -5, 	   2,  -19, 	   0,  -12
+.2byte   -3,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -2,  -13, 	  -1,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+.2byte   -1,  -12, 	   1,   -5, 	  -3,  -19, 	  -1,  -11
+.2byte    0,  -12, 	  -1,   -5, 	  -2,  -19, 	  -1,  -11
+.2byte    1,  -12, 	  -1,   -4, 	  -1,  -19, 	  -1,  -11
+.2byte    0,  -14, 	  -1,   -5, 	   0,  -19, 	  -1,  -12
+.2byte   -1,  -13, 	  -2,   -5, 	   0,  -19, 	  -1,  -11
+.2byte   -1,  -14, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -3,  -12, 	  -1,   -5, 	  -1,  -19, 	  -1,  -11
+.2byte   -2,  -12, 	   0,   -5, 	  -1,  -20, 	  -2,  -11
+sUnownZAnimTable1:
+.4byte sUnownZAnims_1_1
+.4byte sUnownZAnims_1_2
+.4byte sUnownZAnims_1_3
+.4byte sUnownZAnims_1_4
+.4byte sUnownZAnims_1_5
+.4byte sUnownZAnims_1_6
+.4byte sUnownZAnims_1_7
+.4byte sUnownZAnims_1_8
+sUnownZAnimTable2:
+.4byte sUnownZAnims_2_1
+.4byte sUnownZAnims_2_2
+.4byte sUnownZAnims_2_3
+.4byte sUnownZAnims_2_4
+.4byte sUnownZAnims_2_5
+.4byte sUnownZAnims_2_6
+.4byte sUnownZAnims_2_7
+.4byte sUnownZAnims_2_8
+sUnownZAnimTable3:
+.4byte sUnownZAnims_3_1
+.4byte sUnownZAnims_3_2
+.4byte sUnownZAnims_3_3
+.4byte sUnownZAnims_3_4
+.4byte sUnownZAnims_3_5
+.4byte sUnownZAnims_3_6
+.4byte sUnownZAnims_3_7
+.4byte sUnownZAnims_3_8
+sUnownZAnimTable4:
+.4byte sUnownZAnims_4_1
+.4byte sUnownZAnims_4_2
+.4byte sUnownZAnims_4_3
+.4byte sUnownZAnims_4_4
+.4byte sUnownZAnims_4_5
+.4byte sUnownZAnims_4_6
+.4byte sUnownZAnims_4_7
+.4byte sUnownZAnims_4_8
+sUnownZAnimTable5:
+.4byte sUnownZAnims_5_1
+.4byte sUnownZAnims_5_2
+.4byte sUnownZAnims_5_3
+.4byte sUnownZAnims_5_4
+.4byte sUnownZAnims_5_5
+.4byte sUnownZAnims_5_6
+.4byte sUnownZAnims_5_7
+.4byte sUnownZAnims_5_8
+sUnownZAnimTable6:
+.4byte sUnownZAnims_6_1
+.4byte sUnownZAnims_6_1
+.4byte sUnownZAnims_6_1
+.4byte sUnownZAnims_6_1
+.4byte sUnownZAnims_6_1
+.4byte sUnownZAnims_6_1
+.4byte sUnownZAnims_6_1
+.4byte sUnownZAnims_6_1
+sUnownZAnimTable7:
+.4byte sUnownZAnims_7_1
+.4byte sUnownZAnims_7_2
+.4byte sUnownZAnims_7_3
+.4byte sUnownZAnims_7_4
+.4byte sUnownZAnims_7_5
+.4byte sUnownZAnims_7_6
+.4byte sUnownZAnims_7_7
+.4byte sUnownZAnims_7_8
+sUnownZAnimTable8:
+.4byte sUnownZAnims_8_1
+.4byte sUnownZAnims_8_2
+.4byte sUnownZAnims_8_3
+.4byte sUnownZAnims_8_4
+.4byte sUnownZAnims_8_5
+.4byte sUnownZAnims_8_6
+.4byte sUnownZAnims_8_7
+.4byte sUnownZAnims_8_8
+sUnownZAnimTable9:
+.4byte sUnownZAnims_9_1
+.4byte sUnownZAnims_9_2
+.4byte sUnownZAnims_9_3
+.4byte sUnownZAnims_9_4
+.4byte sUnownZAnims_9_5
+.4byte sUnownZAnims_9_6
+.4byte sUnownZAnims_9_7
+.4byte sUnownZAnims_9_8
+sUnownZAnimTable10:
+.4byte sUnownZAnims_10_1
+.4byte sUnownZAnims_10_2
+.4byte sUnownZAnims_10_3
+.4byte sUnownZAnims_10_4
+.4byte sUnownZAnims_10_5
+.4byte sUnownZAnims_10_6
+.4byte sUnownZAnims_10_7
+.4byte sUnownZAnims_10_8
+sUnownZAnimTable11:
+.4byte sUnownZAnims_11_1
+.4byte sUnownZAnims_11_2
+.4byte sUnownZAnims_11_3
+.4byte sUnownZAnims_11_4
+.4byte sUnownZAnims_11_5
+.4byte sUnownZAnims_11_6
+.4byte sUnownZAnims_11_7
+.4byte sUnownZAnims_11_8
+sUnownZAnimTable12:
+.4byte sUnownZAnims_12_1
+.4byte sUnownZAnims_12_2
+.4byte sUnownZAnims_12_3
+.4byte sUnownZAnims_12_4
+.4byte sUnownZAnims_12_5
+.4byte sUnownZAnims_12_6
+.4byte sUnownZAnims_12_7
+.4byte sUnownZAnims_12_8
+sUnownZAnimTable13:
+.4byte sUnownZAnims_13_1
+.4byte sUnownZAnims_13_2
+.4byte sUnownZAnims_13_3
+.4byte sUnownZAnims_13_4
+.4byte sUnownZAnims_13_5
+.4byte sUnownZAnims_13_6
+.4byte sUnownZAnims_13_7
+.4byte sUnownZAnims_13_8
+sAxAnimationsUnownZ:
+.4byte sUnownZAnimTable1
+.4byte sUnownZAnimTable2
+.4byte sUnownZAnimTable3
+.4byte sUnownZAnimTable4
+.4byte sUnownZAnimTable5
+.4byte sUnownZAnimTable6
+.4byte sUnownZAnimTable7
+.4byte sUnownZAnimTable8
+.4byte sUnownZAnimTable9
+.4byte sUnownZAnimTable10
+.4byte sUnownZAnimTable11
+.4byte sUnownZAnimTable12
+.4byte sUnownZAnimTable13
+sAxSpritesUnownZ:
+.4byte sUnownZSprites1
+.4byte sUnownZSprites2
+.4byte sUnownZSprites3
+.4byte sUnownZSprites4
+.4byte sUnownZSprites5
+.4byte sUnownZSprites6
+.4byte sUnownZSprites7
+.4byte sUnownZSprites8
+.4byte sUnownZSprites9
+.4byte sUnownZSprites10
+.4byte sUnownZSprites11
+.4byte sUnownZSprites12
+.4byte sUnownZSprites13
+.4byte sUnownZSprites14
+.4byte sUnownZSprites15
+.4byte sUnownZSprites16
+.4byte sUnownZSprites17
+sAxMainUnownZ:
+ax_main sAxPosesUnownZ, sAxAnimationsUnownZ, 13, sAxSpritesUnownZ, sAxPositionsUnownZ

--- a/data/ax/ursaring.inc
+++ b/data/ax/ursaring.inc
@@ -1,0 +1,3324 @@
+.global gAxUrsaring
+gAxUrsaring:
+ax_siro sAxMainUrsaring
+sUrsaringPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose4:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose5:
+ax_pose 4, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose6:
+ax_pose 5, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose7:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose8:
+ax_pose 7, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose9:
+ax_pose 8, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose10:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose11:
+ax_pose 10, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose12:
+ax_pose 11, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose14:
+ax_pose 13, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sUrsaringPose15:
+ax_pose 14, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose16:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose17:
+ax_pose 10, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose19:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose20:
+ax_pose 7, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose21:
+ax_pose 8, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose22:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose23:
+ax_pose 4, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose24:
+ax_pose 5, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose28:
+ax_pose 15, 0x81e4, 0x80f1, 0x4c00
+ax_pose 16, 0x81e4, 0x4101, 0x4c08
+ax_pose 17, 0x01ec, 0x0109, 0x4c0c
+ax_pose 18, 0x01ec, 0x00e9, 0x4c0d
+ax_pose_terminator
+sUrsaringPose29:
+ax_pose 19, 0x81e5, 0x80f2, 0x4c00
+ax_pose 20, 0x81e5, 0x4102, 0x4c08
+ax_pose 21, 0x81e5, 0x010a, 0x4c0c
+ax_pose 22, 0x01ed, 0x00ea, 0x4c0e
+ax_pose_terminator
+sUrsaringPose30:
+ax_pose 23, 0x01e5, 0x80ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose31:
+ax_pose 24, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose32:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose33:
+ax_pose 4, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose34:
+ax_pose 5, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose35:
+ax_pose 25, 0x81e3, 0x90fb, 0x4c00
+ax_pose 26, 0x81e3, 0x50f3, 0x4c08
+ax_pose 27, 0x0203, 0x10f7, 0x4c0c
+ax_pose 28, 0x81eb, 0x10eb, 0x4c0d
+ax_pose_terminator
+sUrsaringPose36:
+ax_pose 29, 0x01e4, 0x90f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose37:
+ax_pose 30, 0x01e3, 0x90f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose38:
+ax_pose 31, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose39:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose40:
+ax_pose 7, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose41:
+ax_pose 8, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose42:
+ax_pose 32, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose43:
+ax_pose 33, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose44:
+ax_pose 34, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose45:
+ax_pose 35, 0x81e5, 0x90ff, 0x4c00
+ax_pose 36, 0x81e5, 0x50f7, 0x4c08
+ax_pose 37, 0x01ed, 0x110f, 0x4c0c
+ax_pose 38, 0x81ed, 0x10ef, 0x4c0d
+ax_pose 39, 0x01fd, 0x10ef, 0x4c0f
+ax_pose_terminator
+sUrsaringPose46:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose47:
+ax_pose 10, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose48:
+ax_pose 11, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose49:
+ax_pose 40, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose50:
+ax_pose 41, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose51:
+ax_pose 42, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose52:
+ax_pose 43, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sUrsaringPose53:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose54:
+ax_pose 13, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sUrsaringPose55:
+ax_pose 14, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose56:
+ax_pose 44, 0x81e2, 0x80ef, 0x4c00
+ax_pose 45, 0x81e2, 0x40ff, 0x4c08
+ax_pose 46, 0x01ea, 0x010f, 0x4c0c
+ax_pose 47, 0x01ea, 0x0107, 0x4c0d
+ax_pose 48, 0x81f2, 0x0107, 0x4c0e
+ax_pose_terminator
+sUrsaringPose57:
+ax_pose 49, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose58:
+ax_pose 50, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose59:
+ax_pose 51, 0x01e7, 0x80ee, 0x4c00
+ax_pose_terminator
+sUrsaringPose60:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose61:
+ax_pose 10, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose62:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose63:
+ax_pose 40, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose64:
+ax_pose 41, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose65:
+ax_pose 42, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose66:
+ax_pose 43, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose67:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose68:
+ax_pose 7, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose69:
+ax_pose 8, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose70:
+ax_pose 32, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose71:
+ax_pose 33, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose72:
+ax_pose 34, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose73:
+ax_pose 35, 0x81e5, 0x80f0, 0x4c00
+ax_pose 36, 0x81e5, 0x4100, 0x4c08
+ax_pose 37, 0x01ed, 0x00e8, 0x4c0c
+ax_pose 38, 0x81ed, 0x0108, 0x4c0d
+ax_pose 39, 0x01fd, 0x0108, 0x4c0f
+ax_pose_terminator
+sUrsaringPose74:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose75:
+ax_pose 4, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose76:
+ax_pose 5, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose77:
+ax_pose 25, 0x81e3, 0x80f4, 0x4c00
+ax_pose 26, 0x81e3, 0x4104, 0x4c08
+ax_pose 27, 0x0203, 0x0100, 0x4c0c
+ax_pose 28, 0x81eb, 0x010c, 0x4c0d
+ax_pose_terminator
+sUrsaringPose78:
+ax_pose 29, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose79:
+ax_pose 30, 0x01e3, 0x80ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose80:
+ax_pose 31, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose81:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose82:
+ax_pose 1, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose83:
+ax_pose 2, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose84:
+ax_pose 52, 0x01de, 0x80f5, 0x4c00
+ax_pose 23, 0x01e5, 0x80ef, 0x4c10
+ax_pose_terminator
+sUrsaringPose85:
+ax_pose 23, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose86:
+ax_pose 53, 0x01de, 0x80ee, 0x4c00
+ax_pose 24, 0x01e5, 0x80f1, 0x4c10
+ax_pose_terminator
+sUrsaringPose87:
+ax_pose 24, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose88:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose89:
+ax_pose 4, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose90:
+ax_pose 5, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose91:
+ax_pose 54, 0x41ea, 0x90f6, 0x4c00
+ax_pose 55, 0x81e4, 0x10ee, 0x4c08
+ax_pose 30, 0x01e3, 0x90f2, 0x4c0a
+ax_pose_terminator
+sUrsaringPose92:
+ax_pose 30, 0x01e3, 0x90f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose93:
+ax_pose 56, 0x01dd, 0x90f7, 0x4c00
+ax_pose 31, 0x01e4, 0x90ef, 0x4c10
+ax_pose_terminator
+sUrsaringPose94:
+ax_pose 31, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose95:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose96:
+ax_pose 7, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose97:
+ax_pose 8, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose98:
+ax_pose 57, 0x41ea, 0x90f6, 0x4c00
+ax_pose 58, 0x01ee, 0x10ee, 0x4c08
+ax_pose 34, 0x01e5, 0x90f0, 0x4c09
+ax_pose_terminator
+sUrsaringPose99:
+ax_pose 34, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose100:
+ax_pose 59, 0x41f2, 0x1106, 0x4c00
+ax_pose 35, 0x81e5, 0x90ff, 0x4c02
+ax_pose 36, 0x81e5, 0x50f7, 0x4c0a
+ax_pose 38, 0x81ed, 0x10ef, 0x4c0e
+ax_pose 39, 0x01fd, 0x10ef, 0x4c10
+ax_pose 60, 0x41e2, 0x90f6, 0x4c11
+ax_pose 61, 0x01ea, 0x10ee, 0x4c19
+ax_pose_terminator
+sUrsaringPose101:
+ax_pose 35, 0x81e5, 0x90ff, 0x4c00
+ax_pose 36, 0x81e5, 0x50f7, 0x4c08
+ax_pose 37, 0x01f1, 0x110f, 0x4c0c
+ax_pose 38, 0x81ed, 0x10ef, 0x4c0d
+ax_pose 39, 0x01fd, 0x10ef, 0x4c0f
+ax_pose_terminator
+sUrsaringPose102:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose103:
+ax_pose 10, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose104:
+ax_pose 11, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose105:
+ax_pose 62, 0x01e4, 0x90f7, 0x4c00
+ax_pose 42, 0x01e5, 0x90ec, 0x4c10
+ax_pose_terminator
+sUrsaringPose106:
+ax_pose 42, 0x01e5, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose107:
+ax_pose 63, 0x41e1, 0x90f6, 0x4c00
+ax_pose 64, 0x81e9, 0x10ee, 0x4c08
+ax_pose 43, 0x01e5, 0x90ee, 0x4c0a
+ax_pose_terminator
+sUrsaringPose108:
+ax_pose 43, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sUrsaringPose109:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose110:
+ax_pose 13, 0x01e4, 0x80f4, 0x4c00
+ax_pose_terminator
+sUrsaringPose111:
+ax_pose 14, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose112:
+ax_pose 50, 0x01e7, 0x80f2, 0x4c00
+ax_pose 65, 0x01de, 0x80e9, 0x4c10
+ax_pose_terminator
+sUrsaringPose113:
+ax_pose 50, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose114:
+ax_pose 50, 0x01e7, 0x90ee, 0x4c00
+ax_pose 65, 0x01de, 0x90f7, 0x4c10
+ax_pose_terminator
+sUrsaringPose115:
+ax_pose 51, 0x01e7, 0x80ee, 0x4c00
+ax_pose_terminator
+sUrsaringPose116:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose117:
+ax_pose 10, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose118:
+ax_pose 11, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose119:
+ax_pose 62, 0x01e5, 0x80e8, 0x4c00
+ax_pose 42, 0x01e5, 0x80f3, 0x4c10
+ax_pose_terminator
+sUrsaringPose120:
+ax_pose 42, 0x01e5, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose121:
+ax_pose 63, 0x41e3, 0x80ea, 0x4c00
+ax_pose 64, 0x81eb, 0x010a, 0x4c08
+ax_pose 43, 0x01e5, 0x80f1, 0x4c0a
+ax_pose_terminator
+sUrsaringPose122:
+ax_pose 43, 0x01e5, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose123:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose124:
+ax_pose 7, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose125:
+ax_pose 8, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose126:
+ax_pose 57, 0x41ea, 0x80e9, 0x4c00
+ax_pose 58, 0x01ee, 0x0109, 0x4c08
+ax_pose 34, 0x01e5, 0x80ef, 0x4c09
+ax_pose_terminator
+sUrsaringPose127:
+ax_pose 34, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose128:
+ax_pose 59, 0x41f2, 0x00e9, 0x4c00
+ax_pose 61, 0x01ea, 0x0109, 0x4c02
+ax_pose 35, 0x81e5, 0x80f0, 0x4c03
+ax_pose 36, 0x81e5, 0x4100, 0x4c0b
+ax_pose 38, 0x81ed, 0x0108, 0x4c0f
+ax_pose 39, 0x01fd, 0x0108, 0x4c11
+ax_pose 60, 0x41e2, 0x80e9, 0x4c12
+ax_pose_terminator
+sUrsaringPose129:
+ax_pose 35, 0x81e5, 0x80f0, 0x4c00
+ax_pose 36, 0x81e5, 0x4100, 0x4c08
+ax_pose 37, 0x01f1, 0x00e8, 0x4c0c
+ax_pose 38, 0x81ed, 0x0108, 0x4c0d
+ax_pose 39, 0x01fd, 0x0108, 0x4c0f
+ax_pose_terminator
+sUrsaringPose130:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose131:
+ax_pose 4, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose132:
+ax_pose 5, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose133:
+ax_pose 54, 0x41ea, 0x80e9, 0x4c00
+ax_pose 55, 0x81e4, 0x0109, 0x4c08
+ax_pose 30, 0x01e3, 0x80ed, 0x4c0a
+ax_pose_terminator
+sUrsaringPose134:
+ax_pose 30, 0x01e3, 0x80ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose135:
+ax_pose 56, 0x01de, 0x80ee, 0x4c00
+ax_pose 31, 0x01e4, 0x80f2, 0x4c10
+ax_pose_terminator
+sUrsaringPose136:
+ax_pose 31, 0x01e4, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose137:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose138:
+ax_pose 15, 0x81e4, 0x80f1, 0x4c00
+ax_pose 16, 0x81e4, 0x4101, 0x4c08
+ax_pose 17, 0x01ec, 0x0109, 0x4c0c
+ax_pose 18, 0x01ec, 0x00e9, 0x4c0d
+ax_pose_terminator
+sUrsaringPose139:
+ax_pose 19, 0x81e5, 0x80f2, 0x4c00
+ax_pose 20, 0x81e5, 0x4102, 0x4c08
+ax_pose 21, 0x81e5, 0x010a, 0x4c0c
+ax_pose 22, 0x01ed, 0x00ea, 0x4c0e
+ax_pose_terminator
+sUrsaringPose140:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose141:
+ax_pose 25, 0x81e3, 0x90fb, 0x4c00
+ax_pose 26, 0x81e3, 0x50f3, 0x4c08
+ax_pose 27, 0x0203, 0x10f7, 0x4c0c
+ax_pose 28, 0x81eb, 0x10eb, 0x4c0d
+ax_pose_terminator
+sUrsaringPose142:
+ax_pose 29, 0x01e4, 0x90f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose143:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose144:
+ax_pose 32, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose145:
+ax_pose 33, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose146:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose147:
+ax_pose 40, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose148:
+ax_pose 41, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose149:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose150:
+ax_pose 44, 0x81e2, 0x80ef, 0x4c00
+ax_pose 45, 0x81e2, 0x40ff, 0x4c08
+ax_pose 46, 0x01ea, 0x010f, 0x4c0c
+ax_pose 47, 0x01ea, 0x0107, 0x4c0d
+ax_pose 48, 0x81f2, 0x0107, 0x4c0e
+ax_pose_terminator
+sUrsaringPose151:
+ax_pose 49, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose152:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose153:
+ax_pose 40, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose154:
+ax_pose 41, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose155:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose156:
+ax_pose 32, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose157:
+ax_pose 33, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose158:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose159:
+ax_pose 25, 0x81e3, 0x80f4, 0x4c00
+ax_pose 26, 0x81e3, 0x4104, 0x4c08
+ax_pose 27, 0x0203, 0x0100, 0x4c0c
+ax_pose 28, 0x81eb, 0x010c, 0x4c0d
+ax_pose_terminator
+sUrsaringPose160:
+ax_pose 29, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose161:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose162:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose163:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose164:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose165:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose166:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose167:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose168:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose169:
+ax_pose 66, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose170:
+ax_pose 67, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose171:
+ax_pose 68, 0x01e1, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose172:
+ax_pose 69, 0x01e3, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose173:
+ax_pose 70, 0x01e2, 0x90eb, 0x4c00
+ax_pose_terminator
+sUrsaringPose174:
+ax_pose 71, 0x01e2, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose175:
+ax_pose 72, 0x01e2, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose176:
+ax_pose 71, 0x01e2, 0x80f4, 0x4c00
+ax_pose_terminator
+sUrsaringPose177:
+ax_pose 70, 0x01e2, 0x80f5, 0x4c00
+ax_pose_terminator
+sUrsaringPose178:
+ax_pose 69, 0x01e3, 0x80f4, 0x4c00
+ax_pose_terminator
+sUrsaringPose179:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose180:
+ax_pose 15, 0x81e3, 0x80f1, 0x4c00
+ax_pose 16, 0x81e3, 0x4101, 0x4c08
+ax_pose 17, 0x01eb, 0x0109, 0x4c0c
+ax_pose 18, 0x01eb, 0x00e9, 0x4c0d
+ax_pose_terminator
+sUrsaringPose181:
+ax_pose 19, 0x81e5, 0x80f2, 0x4c00
+ax_pose 20, 0x81e5, 0x4102, 0x4c08
+ax_pose 21, 0x81e5, 0x010a, 0x4c0c
+ax_pose 22, 0x01ed, 0x00ea, 0x4c0e
+ax_pose_terminator
+sUrsaringPose182:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose183:
+ax_pose 25, 0x81e3, 0x90fb, 0x4c00
+ax_pose 26, 0x81e3, 0x50f3, 0x4c08
+ax_pose 27, 0x0203, 0x10f7, 0x4c0c
+ax_pose 28, 0x81eb, 0x10eb, 0x4c0d
+ax_pose_terminator
+sUrsaringPose184:
+ax_pose 29, 0x01e4, 0x90f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose185:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose186:
+ax_pose 32, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose187:
+ax_pose 33, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose188:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose189:
+ax_pose 40, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose190:
+ax_pose 41, 0x01e5, 0x90ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose191:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose192:
+ax_pose 44, 0x81e2, 0x80ef, 0x4c00
+ax_pose 45, 0x81e2, 0x40ff, 0x4c08
+ax_pose 46, 0x01ea, 0x010f, 0x4c0c
+ax_pose 47, 0x01ea, 0x0107, 0x4c0d
+ax_pose 48, 0x81f2, 0x0107, 0x4c0e
+ax_pose_terminator
+sUrsaringPose193:
+ax_pose 49, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose194:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose195:
+ax_pose 40, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose196:
+ax_pose 41, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose197:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose198:
+ax_pose 32, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose199:
+ax_pose 33, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose200:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose201:
+ax_pose 25, 0x81e3, 0x80f4, 0x4c00
+ax_pose 26, 0x81e3, 0x4104, 0x4c08
+ax_pose 27, 0x0203, 0x0100, 0x4c0c
+ax_pose 28, 0x81eb, 0x010c, 0x4c0d
+ax_pose_terminator
+sUrsaringPose202:
+ax_pose 29, 0x01e4, 0x80ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose203:
+ax_pose 19, 0x81e5, 0x80f2, 0x4c00
+ax_pose 20, 0x81e5, 0x4102, 0x4c08
+ax_pose 21, 0x81e5, 0x010a, 0x4c0c
+ax_pose 22, 0x01ed, 0x00ea, 0x4c0e
+ax_pose_terminator
+sUrsaringPose204:
+ax_pose 29, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose205:
+ax_pose 33, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose206:
+ax_pose 41, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose207:
+ax_pose 49, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose208:
+ax_pose 41, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose209:
+ax_pose 33, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sUrsaringPose210:
+ax_pose 29, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose211:
+ax_pose 19, 0x81e5, 0x80f2, 0x4c00
+ax_pose 20, 0x81e5, 0x4102, 0x4c08
+ax_pose 21, 0x81e5, 0x010a, 0x4c0c
+ax_pose 22, 0x01ed, 0x00ea, 0x4c0e
+ax_pose_terminator
+sUrsaringPose212:
+ax_pose 29, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose213:
+ax_pose 33, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sUrsaringPose214:
+ax_pose 41, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose215:
+ax_pose 49, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose216:
+ax_pose 41, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose217:
+ax_pose 33, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose218:
+ax_pose 29, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose219:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose220:
+ax_pose 15, 0x81e4, 0x80f1, 0x4c00
+ax_pose 16, 0x81e4, 0x4101, 0x4c08
+ax_pose 17, 0x01ec, 0x0109, 0x4c0c
+ax_pose 18, 0x01ec, 0x00e9, 0x4c0d
+ax_pose_terminator
+sUrsaringPose221:
+ax_pose 19, 0x81e3, 0x80f2, 0x4c00
+ax_pose 20, 0x81e3, 0x4102, 0x4c08
+ax_pose 21, 0x81e3, 0x010a, 0x4c0c
+ax_pose 22, 0x01eb, 0x00ea, 0x4c0e
+ax_pose_terminator
+sUrsaringPose222:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose223:
+ax_pose 25, 0x81e3, 0x90fb, 0x4c00
+ax_pose 26, 0x81e3, 0x50f3, 0x4c08
+ax_pose 27, 0x0203, 0x10f7, 0x4c0c
+ax_pose 28, 0x81eb, 0x10eb, 0x4c0d
+ax_pose_terminator
+sUrsaringPose224:
+ax_pose 29, 0x01e4, 0x90f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose225:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose226:
+ax_pose 32, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose227:
+ax_pose 33, 0x01e5, 0x90ed, 0x4c00
+ax_pose_terminator
+sUrsaringPose228:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose229:
+ax_pose 40, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose230:
+ax_pose 41, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose231:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose232:
+ax_pose 44, 0x81e2, 0x80ef, 0x4c00
+ax_pose 45, 0x81e2, 0x40ff, 0x4c08
+ax_pose 46, 0x01ea, 0x010f, 0x4c0c
+ax_pose 47, 0x01ea, 0x0107, 0x4c0d
+ax_pose 48, 0x81f2, 0x0107, 0x4c0e
+ax_pose_terminator
+sUrsaringPose233:
+ax_pose 49, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose234:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose235:
+ax_pose 40, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose236:
+ax_pose 41, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose237:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose238:
+ax_pose 32, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose239:
+ax_pose 33, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose240:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose241:
+ax_pose 25, 0x81e3, 0x80f4, 0x4c00
+ax_pose 26, 0x81e3, 0x4104, 0x4c08
+ax_pose 27, 0x0203, 0x0100, 0x4c0c
+ax_pose 28, 0x81eb, 0x010c, 0x4c0d
+ax_pose_terminator
+sUrsaringPose242:
+ax_pose 29, 0x01e4, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose243:
+ax_pose 19, 0x81e5, 0x80f2, 0x4c00
+ax_pose 20, 0x81e5, 0x4102, 0x4c08
+ax_pose 21, 0x81e5, 0x010a, 0x4c0c
+ax_pose 22, 0x01ed, 0x00ea, 0x4c0e
+ax_pose_terminator
+sUrsaringPose244:
+ax_pose 29, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose245:
+ax_pose 33, 0x01e5, 0x80f2, 0x4c00
+ax_pose_terminator
+sUrsaringPose246:
+ax_pose 41, 0x01e6, 0x80ef, 0x4c00
+ax_pose_terminator
+sUrsaringPose247:
+ax_pose 49, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose248:
+ax_pose 41, 0x01e6, 0x90f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose249:
+ax_pose 33, 0x01e5, 0x90ee, 0x4c00
+ax_pose_terminator
+sUrsaringPose250:
+ax_pose 29, 0x01e5, 0x90f1, 0x4c00
+ax_pose_terminator
+sUrsaringPose251:
+ax_pose 0, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose252:
+ax_pose 3, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose253:
+ax_pose 6, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose254:
+ax_pose 9, 0x01e4, 0x80f3, 0x4c00
+ax_pose_terminator
+sUrsaringPose255:
+ax_pose 12, 0x01e4, 0x80f0, 0x4c00
+ax_pose_terminator
+sUrsaringPose256:
+ax_pose 9, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose257:
+ax_pose 6, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+sUrsaringPose258:
+ax_pose 3, 0x01e4, 0x90ec, 0x4c00
+ax_pose_terminator
+.align 2
+sUrsaringAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_2_1:
+ax_anim 2, 0, 27, 0, -1, 0, -1,
+ax_anim 4, 0, 27, 0, -2, 0, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 0, 4, 0, 4,
+ax_anim 1, 0, 28, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 1, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 28, 0, 18, 0, 18,
+ax_anim 2, 0, 28, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sUrsaringAnims_2_2:
+ax_anim 2, 0, 34, -1, -1, -1, -1,
+ax_anim 4, 0, 34, -2, -2, -2, -2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 4, 4, 4,
+ax_anim 1, 0, 35, 10, 11, 10, 11,
+ax_anim 2, 0, 35, 18, 20, 18, 20,
+ax_anim 2, 1, 35, 19, 19, 19, 19,
+ax_anim 2, 0, 35, 18, 20, 18, 20,
+ax_anim 2, 0, 35, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 6, 6, 6, 6,
+ax_anim_terminator
+sUrsaringAnims_2_3:
+ax_anim 2, 0, 41, -1, 0, -1, 0,
+ax_anim 4, 0, 41, -2, 0, -2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 4, 0, 4, 0,
+ax_anim 1, 0, 42, 10, 0, 10, 0,
+ax_anim 2, 0, 42, 18, 0, 18, 0,
+ax_anim 2, 1, 42, 18, 1, 18, 1,
+ax_anim 2, 0, 42, 18, 0, 18, 0,
+ax_anim 2, 0, 42, 18, 1, 18, 1,
+ax_anim 2, 0, 38, 6, 0, 6, 0,
+ax_anim_terminator
+sUrsaringAnims_2_4:
+ax_anim 2, 0, 48, -1, 1, -1, 1,
+ax_anim 4, 0, 48, -2, 2, -2, 2,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 2, 49, 5, -5, 5, -5,
+ax_anim 1, 0, 49, 12, -10, 12, -10,
+ax_anim 2, 0, 49, 21, -16, 21, -16,
+ax_anim 2, 1, 49, 22, -15, 22, -15,
+ax_anim 2, 0, 49, 21, -16, 21, -16,
+ax_anim 2, 0, 49, 22, -15, 22, -15,
+ax_anim 2, 0, 45, 7, -6, 7, -6,
+ax_anim_terminator
+sUrsaringAnims_2_5:
+ax_anim 2, 0, 55, 0, 1, 0, 1,
+ax_anim 4, 0, 55, 0, 2, 0, 2,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 0, -3, 0, -3,
+ax_anim 1, 0, 56, 0, -9, 0, -9,
+ax_anim 2, 0, 56, 0, -17, 0, -17,
+ax_anim 2, 1, 56, 1, -17, 1, -17,
+ax_anim 2, 0, 56, 0, -17, 0, -17,
+ax_anim 2, 0, 56, 1, -17, 1, -17,
+ax_anim 2, 0, 52, 0, -6, 0, -6,
+ax_anim_terminator
+sUrsaringAnims_2_6:
+ax_anim 2, 0, 62, 1, 1, 1, 1,
+ax_anim 4, 0, 62, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -5, -5, -5, -5,
+ax_anim 1, 0, 63, -12, -10, -12, -10,
+ax_anim 2, 0, 63, -21, -16, -21, -16,
+ax_anim 2, 1, 63, -22, -15, -22, -15,
+ax_anim 2, 0, 63, -21, -16, -21, -16,
+ax_anim 2, 0, 63, -22, -15, -22, -15,
+ax_anim 2, 0, 59, -7, -6, -7, -6,
+ax_anim_terminator
+sUrsaringAnims_2_7:
+ax_anim 2, 0, 69, 1, 0, 1, 0,
+ax_anim 4, 0, 69, 2, 0, 2, 0,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 0, -4, 0,
+ax_anim 1, 0, 70, -10, 0, -10, 0,
+ax_anim 2, 0, 70, -18, 0, -18, 0,
+ax_anim 2, 1, 70, -18, 1, -18, 1,
+ax_anim 2, 0, 70, -18, 0, -18, 0,
+ax_anim 2, 0, 70, -18, 1, -18, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sUrsaringAnims_2_8:
+ax_anim 2, 0, 76, 1, -1, 1, -1,
+ax_anim 4, 0, 76, 2, -2, 2, -2,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 2, 77, -4, 4, -4, 4,
+ax_anim 1, 0, 77, -10, 11, -10, 11,
+ax_anim 2, 0, 77, -18, 20, -18, 20,
+ax_anim 2, 1, 77, -19, 19, -19, 19,
+ax_anim 2, 0, 77, -18, 20, -18, 20,
+ax_anim 2, 0, 77, -19, 19, -19, 19,
+ax_anim 2, 0, 73, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_3_1:
+ax_anim 2, 0, 86, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 6, 0, 91, 0, -5, 0, -5,
+ax_anim 1, 2, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 86, 0, 8, 0, 8,
+ax_anim 2, 0, 83, 0, 17, 0, 17,
+ax_anim 2, 1, 133, 0, 19, 0, 19,
+ax_anim 4, 0, 133, 0, 16, 0, 16,
+ax_anim 2, 0, 84, 0, 15, 0, 15,
+ax_anim 2, 0, 85, 0, 17, 0, 17,
+ax_anim 4, 0, 91, 4, 19, 4, 19,
+ax_anim 2, 0, 86, 2, 12, 2, 12,
+ax_anim 2, 0, 81, 0, 4, 0, 4,
+ax_anim_terminator
+sUrsaringAnims_3_2:
+ax_anim 2, 0, 91, -2, -2, -2, -2,
+ax_anim 2, 0, 98, -4, -4, -4, -4,
+ax_anim 6, 0, 98, -5, -5, -5, -5,
+ax_anim 1, 2, 98, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 8, 10, 8, 10,
+ax_anim 2, 0, 92, 13, 18, 13, 18,
+ax_anim 2, 1, 84, 15, 20, 15, 20,
+ax_anim 4, 0, 84, 12, 17, 12, 17,
+ax_anim 2, 0, 93, 13, 18, 13, 18,
+ax_anim 2, 0, 90, 19, 20, 19, 20,
+ax_anim 4, 0, 98, 21, 18, 21, 18,
+ax_anim 2, 0, 91, 9, 12, 9, 12,
+ax_anim 2, 0, 88, 3, 5, 3, 5,
+ax_anim_terminator
+sUrsaringAnims_3_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 2, 0, 105, -4, 0, -4, 0,
+ax_anim 6, 0, 105, -5, 0, -5, 0,
+ax_anim 1, 2, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 98, 8, 0, 8, 0,
+ax_anim 2, 0, 99, 13, 0, 13, 0,
+ax_anim 2, 1, 93, 15, 0, 15, 0,
+ax_anim 4, 0, 93, 12, 0, 12, 0,
+ax_anim 2, 0, 93, 8, 0, 8, 0,
+ax_anim 2, 0, 97, 13, 0, 13, 0,
+ax_anim 4, 0, 105, 15, 0, 15, 0,
+ax_anim 2, 0, 98, 9, 0, 9, 0,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim_terminator
+sUrsaringAnims_3_4:
+ax_anim 2, 0, 105, -2, 2, -2, 2,
+ax_anim 2, 0, 114, -4, 4, -4, 4,
+ax_anim 6, 0, 114, -5, 5, -5, 5,
+ax_anim 1, 2, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 105, 11, -8, 11, -8,
+ax_anim 2, 0, 106, 15, -11, 15, -11,
+ax_anim 2, 1, 100, 18, -13, 18, -13,
+ax_anim 4, 0, 100, 14, -10, 14, -10,
+ax_anim 2, 0, 100, 9, -6, 9, -6,
+ax_anim 2, 0, 104, 15, -11, 15, -11,
+ax_anim 4, 0, 114, 17, -16, 17, -16,
+ax_anim 2, 0, 105, 12, -9, 12, -9,
+ax_anim 2, 0, 102, 5, -5, 5, -5,
+ax_anim_terminator
+sUrsaringAnims_3_5:
+ax_anim 2, 0, 114, 0, 2, 0, 2,
+ax_anim 2, 0, 121, 0, 4, 0, 4,
+ax_anim 6, 0, 121, 0, 5, 0, 5,
+ax_anim 1, 2, 121, 0, 0, 0, 0,
+ax_anim 1, 0, 114, 0, -5, 0, -5,
+ax_anim 2, 0, 111, 0, -13, 0, -13,
+ax_anim 2, 1, 107, 0, -15, 0, -15,
+ax_anim 4, 0, 107, 0, -12, 0, -12,
+ax_anim 2, 0, 107, 0, -8, 0, -8,
+ax_anim 2, 0, 113, 0, -13, 0, -13,
+ax_anim 4, 0, 121, 0, -15, 0, -15,
+ax_anim 2, 0, 114, 0, -8, 0, -8,
+ax_anim 2, 0, 109, 0, -3, 0, -3,
+ax_anim_terminator
+sUrsaringAnims_3_6:
+ax_anim 2, 0, 121, 2, 2, 2, 2,
+ax_anim 2, 0, 128, 4, 4, 4, 4,
+ax_anim 6, 0, 128, 5, 5, 5, 5,
+ax_anim 1, 2, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 121, -11, -8, -11, -8,
+ax_anim 2, 0, 118, -15, -11, -15, -11,
+ax_anim 2, 1, 112, -13, -14, -13, -14,
+ax_anim 4, 0, 112, -12, -12, -12, -12,
+ax_anim 2, 0, 112, -11, -8, -11, -8,
+ax_anim 2, 0, 120, -15, -11, -15, -11,
+ax_anim 4, 0, 128, -18, -11, -18, -11,
+ax_anim 2, 0, 121, -12, -9, -12, -9,
+ax_anim 2, 0, 116, -5, -5, -5, -5,
+ax_anim_terminator
+sUrsaringAnims_3_7:
+ax_anim 2, 0, 119, 1, 0, 1, 0,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 6, 0, 112, 5, 0, 5, 0,
+ax_anim 1, 2, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 126, -8, 0, -8, 0,
+ax_anim 2, 0, 127, -13, 0, -13, 0,
+ax_anim 2, 1, 135, -15, 1, -15, 1,
+ax_anim 4, 0, 135, -13, 1, -13, 1,
+ax_anim 2, 0, 135, -12, 1, -12, 1,
+ax_anim 2, 0, 132, -11, 1, -11, 1,
+ax_anim 4, 0, 119, -18, -1, -18, -1,
+ax_anim 2, 0, 126, -9, 0, -9, 0,
+ax_anim 2, 0, 123, -3, 0, -3, 0,
+ax_anim_terminator
+sUrsaringAnims_3_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 4, -4, 4, -4,
+ax_anim 6, 0, 126, 5, -5, 5, -5,
+ax_anim 1, 2, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 126, -8, 10, -8, 10,
+ax_anim 2, 0, 134, -13, 18, -13, 18,
+ax_anim 2, 1, 86, -15, 20, -15, 20,
+ax_anim 4, 0, 86, -12, 17, -12, 17,
+ax_anim 2, 0, 86, -8, 13, -8, 13,
+ax_anim 2, 0, 132, -13, 18, -13, 18,
+ax_anim 4, 0, 126, -16, 16, -16, 16,
+ax_anim 2, 0, 133, -9, 12, -9, 12,
+ax_anim 2, 0, 130, -3, 5, -3, 5,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_4_1:
+ax_anim 2, 0, 137, 0, -2, 0, -2,
+ax_anim 2, 0, 137, 0, -4, 0, -4,
+ax_anim 2, 0, 137, 0, -5, 0, -5,
+ax_anim 6, 2, 137, 0, -5, 0, -5,
+ax_anim 2, 0, 138, 0, -1, 0, -1,
+ax_anim 2, 1, 138, 0, 3, 0, 3,
+ax_anim 2, 0, 138, 1, 3, 1, 3,
+ax_anim 2, 0, 138, 0, 3, 0, 3,
+ax_anim 2, 0, 138, 1, 3, 1, 3,
+ax_anim 2, 0, 138, 0, 3, 0, 3,
+ax_anim 2, 0, 138, 1, 3, 1, 3,
+ax_anim 2, 0, 138, 0, 3, 0, 3,
+ax_anim 2, 0, 136, 0, 1, 0, 1,
+ax_anim_terminator
+sUrsaringAnims_4_2:
+ax_anim 2, 0, 140, -2, -2, -2, -2,
+ax_anim 2, 0, 140, -4, -4, -4, -4,
+ax_anim 2, 0, 140, -5, -5, -5, -5,
+ax_anim 6, 2, 140, -5, -5, -5, -5,
+ax_anim 2, 0, 139, -1, -1, -1, -1,
+ax_anim 2, 1, 141, 2, 2, 2, 2,
+ax_anim 2, 0, 141, 3, 1, 3, 1,
+ax_anim 2, 0, 141, 2, 2, 2, 2,
+ax_anim 2, 0, 141, 3, 1, 3, 1,
+ax_anim 2, 0, 141, 2, 2, 2, 2,
+ax_anim 2, 0, 141, 3, 1, 3, 1,
+ax_anim 2, 0, 141, 2, 2, 2, 2,
+ax_anim 2, 0, 139, 1, 1, 1, 1,
+ax_anim_terminator
+sUrsaringAnims_4_3:
+ax_anim 2, 0, 143, -2, 0, -2, 0,
+ax_anim 2, 0, 143, -4, 0, -4, 0,
+ax_anim 2, 0, 143, -5, 0, -5, 0,
+ax_anim 6, 2, 143, -5, 0, -5, 0,
+ax_anim 2, 0, 142, -1, 0, -1, 0,
+ax_anim 2, 1, 144, 6, 0, 6, 0,
+ax_anim 2, 0, 144, 6, 1, 6, 1,
+ax_anim 2, 0, 144, 6, 0, 6, 0,
+ax_anim 2, 0, 144, 6, 1, 6, 1,
+ax_anim 2, 0, 144, 6, 0, 6, 0,
+ax_anim 2, 0, 144, 6, 1, 6, 1,
+ax_anim 2, 0, 144, 6, 0, 6, 0,
+ax_anim 2, 0, 142, 3, 0, 3, 0,
+ax_anim_terminator
+sUrsaringAnims_4_4:
+ax_anim 2, 0, 146, -2, 2, -2, 2,
+ax_anim 2, 0, 146, -4, 4, -4, 4,
+ax_anim 2, 0, 146, -5, 5, -5, 5,
+ax_anim 6, 2, 146, -5, 5, -5, 5,
+ax_anim 2, 0, 145, -1, 1, -1, 1,
+ax_anim 2, 1, 147, 2, -2, 2, -2,
+ax_anim 2, 0, 147, 3, -1, 3, -1,
+ax_anim 2, 0, 147, 2, -2, 2, -2,
+ax_anim 2, 0, 147, 3, -1, 3, -1,
+ax_anim 2, 0, 147, 2, -2, 2, -2,
+ax_anim 2, 0, 147, 3, -1, 3, -1,
+ax_anim 2, 0, 147, 2, -2, 2, -2,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim_terminator
+sUrsaringAnims_4_5:
+ax_anim 2, 0, 149, 0, 2, 0, 2,
+ax_anim 2, 0, 149, 0, 4, 0, 4,
+ax_anim 2, 0, 149, 0, 5, 0, 5,
+ax_anim 6, 2, 149, 0, 5, 0, 5,
+ax_anim 2, 0, 148, 0, 1, 0, 1,
+ax_anim 2, 1, 150, 0, -3, 0, -3,
+ax_anim 2, 0, 150, 1, -3, 1, -3,
+ax_anim 2, 0, 150, 0, -3, 0, -3,
+ax_anim 2, 0, 150, 1, -3, 1, -3,
+ax_anim 2, 0, 150, 0, -3, 0, -3,
+ax_anim 2, 0, 150, 1, -3, 1, -3,
+ax_anim 2, 0, 150, 0, -3, 0, -3,
+ax_anim 2, 0, 148, 0, -1, 0, -1,
+ax_anim_terminator
+sUrsaringAnims_4_6:
+ax_anim 2, 0, 152, 2, 2, 2, 2,
+ax_anim 2, 0, 152, 4, 4, 4, 4,
+ax_anim 2, 0, 152, 5, 5, 5, 5,
+ax_anim 6, 2, 152, 5, 5, 5, 5,
+ax_anim 2, 0, 151, 1, 1, 1, 1,
+ax_anim 2, 1, 153, -2, -2, -2, -2,
+ax_anim 2, 0, 153, -3, -1, -3, -1,
+ax_anim 2, 0, 153, -2, -2, -2, -2,
+ax_anim 2, 0, 153, -3, -1, -3, -1,
+ax_anim 2, 0, 153, -2, -2, -2, -2,
+ax_anim 2, 0, 153, -3, -1, -3, -1,
+ax_anim 2, 0, 153, -2, -2, -2, -2,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim_terminator
+sUrsaringAnims_4_7:
+ax_anim 2, 0, 155, 2, 0, 2, 0,
+ax_anim 2, 0, 155, 4, 0, 4, 0,
+ax_anim 2, 0, 155, 5, 0, 5, 0,
+ax_anim 6, 2, 155, 5, 0, 5, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 1, 156, -6, 0, -6, 0,
+ax_anim 2, 0, 156, -6, 1, -6, 1,
+ax_anim 2, 0, 156, -6, 0, -6, 0,
+ax_anim 2, 0, 156, -6, 1, -6, 1,
+ax_anim 2, 0, 156, -6, 0, -6, 0,
+ax_anim 2, 0, 156, -6, 1, -6, 1,
+ax_anim 2, 0, 156, -6, 0, -6, 0,
+ax_anim 2, 0, 154, -3, 0, -3, 0,
+ax_anim_terminator
+sUrsaringAnims_4_8:
+ax_anim 2, 0, 158, 2, -2, 2, -2,
+ax_anim 2, 0, 158, 4, -4, 4, -4,
+ax_anim 2, 0, 158, 5, -5, 5, -5,
+ax_anim 6, 2, 158, 5, -5, 5, -5,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 1, 159, -2, 2, -2, 2,
+ax_anim 2, 0, 159, -3, 1, -3, 1,
+ax_anim 2, 0, 159, -2, 2, -2, 2,
+ax_anim 2, 0, 159, -3, 1, -3, 1,
+ax_anim 2, 0, 159, -2, 2, -2, 2,
+ax_anim 2, 0, 159, -3, 1, -3, 1,
+ax_anim 2, 0, 159, -2, 2, -2, 2,
+ax_anim 2, 0, 157, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_5_1:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_5_2:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_5_3:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_5_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_5_5:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_5_6:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_5_7:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_5_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_7_1:
+ax_anim 2, 0, 170, 0, -2, 0, -2,
+ax_anim 8, 0, 170, 0, -3, 0, -3,
+ax_anim_terminator
+sUrsaringAnims_7_2:
+ax_anim 2, 0, 171, -2, -2, -2, -2,
+ax_anim 8, 0, 171, -3, -3, -3, -3,
+ax_anim_terminator
+sUrsaringAnims_7_3:
+ax_anim 2, 0, 172, -2, 0, -2, 0,
+ax_anim 8, 0, 172, -3, 0, -3, 0,
+ax_anim_terminator
+sUrsaringAnims_7_4:
+ax_anim 2, 0, 173, -2, 2, -2, 2,
+ax_anim 8, 0, 173, -3, 3, -3, 3,
+ax_anim_terminator
+sUrsaringAnims_7_5:
+ax_anim 2, 0, 174, 0, 2, 0, 2,
+ax_anim 8, 0, 174, 0, 3, 0, 3,
+ax_anim_terminator
+sUrsaringAnims_7_6:
+ax_anim 2, 0, 175, 2, 2, 2, 2,
+ax_anim 8, 0, 175, 3, 3, 3, 3,
+ax_anim_terminator
+sUrsaringAnims_7_7:
+ax_anim 2, 0, 176, 2, 0, 2, 0,
+ax_anim 8, 0, 176, 3, 0, 3, 0,
+ax_anim_terminator
+sUrsaringAnims_7_8:
+ax_anim 2, 0, 177, 2, -2, 2, -2,
+ax_anim 8, 0, 177, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_8_1:
+ax_anim 60, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, 0, -1, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_8_2:
+ax_anim 60, 0, 181, 0, 0, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, -1, 0, -1, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_8_3:
+ax_anim 60, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -1, 0, -1, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_8_4:
+ax_anim 60, 0, 187, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, -1, 0, -1, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_8_5:
+ax_anim 60, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, 0, -1, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_8_6:
+ax_anim 60, 0, 193, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, -1, 0, -1, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_8_7:
+ax_anim 60, 0, 196, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 0, -1, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_8_8:
+ax_anim 60, 0, 199, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -1, 0, -1, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 3, 6, 3,
+ax_anim 2, 0, 204, 10, 9, 10, 9,
+ax_anim 2, 0, 205, 9, 15, 9, 15,
+ax_anim 3, 0, 206, 0, 19, 0, 19,
+ax_anim 2, 3, 207, -9, 15, -9, 15,
+ax_anim 2, 0, 208, -10, 9, -10, 9,
+ax_anim 1, 0, 209, -6, 3, -6, 3,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 17, 3, 17, 3,
+ax_anim 2, 0, 204, 20, 10, 20, 10,
+ax_anim 3, 0, 205, 20, 18, 20, 18,
+ax_anim 2, 3, 206, 11, 19, 11, 19,
+ax_anim 2, 0, 207, 3, 15, 3, 15,
+ax_anim 1, 0, 208, 0, 7, 0, 7,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -5, 3, -5,
+ax_anim 2, 0, 202, 11, -7, 11, -7,
+ax_anim 2, 0, 203, 16, -5, 16, -5,
+ax_anim 3, 0, 204, 21, 0, 21, 0,
+ax_anim 2, 3, 205, 19, 5, 19, 5,
+ax_anim 2, 0, 206, 12, 6, 12, 6,
+ax_anim 1, 0, 207, 4, 5, 4, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -8, -1, -8,
+ax_anim 2, 0, 209, 4, -15, 4, -15,
+ax_anim 2, 0, 202, 12, -21, 12, -21,
+ax_anim 3, 0, 203, 19, -19, 19, -19,
+ax_anim 2, 3, 204, 21, -14, 21, -14,
+ax_anim 2, 0, 205, 19, -6, 19, -6,
+ax_anim 1, 0, 206, 9, -1, 9, -1,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -4, -8, -4,
+ax_anim 2, 0, 208, -10, -12, -10, -12,
+ax_anim 2, 0, 209, -8, -17, -8, -17,
+ax_anim 3, 0, 202, 0, -21, 0, -21,
+ax_anim 2, 3, 203, 8, -17, 8, -17,
+ax_anim 2, 0, 204, 10, -12, 10, -12,
+ax_anim 1, 0, 205, 8, -4, 8, -4,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -8, 1, -8,
+ax_anim 2, 0, 203, -4, -15, -4, -15,
+ax_anim 2, 0, 202, -12, -21, -12, -21,
+ax_anim 3, 0, 209, -19, -19, -19, -19,
+ax_anim 2, 3, 208, -21, -14, -21, -14,
+ax_anim 2, 0, 207, -19, -6, -19, -6,
+ax_anim 1, 0, 206, -9, -1, -9, -1,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -5, -3, -5,
+ax_anim 2, 0, 202, -11, -7, -11, -7,
+ax_anim 2, 0, 209, -16, -5, -16, -5,
+ax_anim 3, 0, 208, -21, 0, -21, 0,
+ax_anim 2, 3, 207, -19, 5, -19, 5,
+ax_anim 2, 0, 206, -12, 6, -12, 6,
+ax_anim 1, 0, 205, -4, 5, -4, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -17, 3, -17, 3,
+ax_anim 2, 0, 208, -20, 10, -20, 10,
+ax_anim 3, 0, 207, -20, 18, -20, 18,
+ax_anim 2, 3, 206, -11, 19, -11, 19,
+ax_anim 2, 0, 205, -3, 15, -3, 15,
+ax_anim 1, 0, 204, 0, 7, 0, 7,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 219, 0, -16, 0, 0,
+ax_anim 3, 0, 219, 0, -20, 0, 0,
+ax_anim 4, 0, 219, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -24, 0, 0,
+ax_anim 3, 0, 220, 0, -23, 0, 0,
+ax_anim 2, 0, 220, 0, -18, 0, 0,
+ax_anim 1, 0, 220, 0, -12, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 222, 0, -16, 0, 0,
+ax_anim 3, 0, 222, 0, -20, 0, 0,
+ax_anim 4, 0, 222, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -25, 0, 0,
+ax_anim 3, 0, 223, 0, -24, 0, 0,
+ax_anim 2, 0, 223, 0, -18, 0, 0,
+ax_anim 1, 0, 223, 0, -12, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -24, 0, 0,
+ax_anim 3, 0, 226, 0, -23, 0, 0,
+ax_anim 2, 0, 226, 0, -18, 0, 0,
+ax_anim 1, 0, 226, 0, -12, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 228, 0, -16, 0, 0,
+ax_anim 3, 0, 228, 0, -20, 0, 0,
+ax_anim 4, 0, 228, 0, -21, 0, 0,
+ax_anim 4, 0, 229, 0, -23, 0, 0,
+ax_anim 3, 0, 229, 0, -22, 0, 0,
+ax_anim 2, 0, 229, 0, -17, 0, 0,
+ax_anim 1, 0, 229, 0, -11, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 231, 0, -16, 0, 0,
+ax_anim 3, 0, 231, 0, -20, 0, 0,
+ax_anim 4, 0, 231, 0, -21, 0, 0,
+ax_anim 4, 0, 232, 0, -23, 0, 0,
+ax_anim 3, 0, 232, 0, -22, 0, 0,
+ax_anim 2, 0, 232, 0, -18, 0, 0,
+ax_anim 1, 0, 232, 0, -12, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 234, 0, -10, 0, 0,
+ax_anim 2, 0, 234, 0, -16, 0, 0,
+ax_anim 3, 0, 234, 0, -20, 0, 0,
+ax_anim 4, 0, 234, 0, -21, 0, 0,
+ax_anim 4, 0, 235, 0, -23, 0, 0,
+ax_anim 3, 0, 235, 0, -22, 0, 0,
+ax_anim 2, 0, 235, 0, -17, 0, 0,
+ax_anim 1, 0, 235, 0, -11, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 237, 0, -10, 0, 0,
+ax_anim 2, 0, 237, 0, -16, 0, 0,
+ax_anim 3, 0, 237, 0, -20, 0, 0,
+ax_anim 4, 0, 237, 0, -21, 0, 0,
+ax_anim 4, 0, 238, 0, -24, 0, 0,
+ax_anim 3, 0, 238, 0, -23, 0, 0,
+ax_anim 2, 0, 238, 0, -18, 0, 0,
+ax_anim 1, 0, 238, 0, -12, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 240, 0, -10, 0, 0,
+ax_anim 2, 0, 240, 0, -16, 0, 0,
+ax_anim 3, 0, 240, 0, -20, 0, 0,
+ax_anim 4, 0, 240, 0, -21, 0, 0,
+ax_anim 4, 0, 241, 0, -25, 0, 0,
+ax_anim 3, 0, 241, 0, -24, 0, 0,
+ax_anim 2, 0, 241, 0, -18, 0, 0,
+ax_anim 1, 0, 241, 0, -12, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sUrsaringAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sUrsaringGfx1:
+.incbin "baserom.gba", 0xECDDE0, 0x200
+sUrsaringSprites1:
+ax_sprite sUrsaringGfx1, 0x200
+ax_sprite_terminator
+sUrsaringGfx2:
+.incbin "baserom.gba", 0xECDFF0, 0x200
+sUrsaringSprites2:
+ax_sprite sUrsaringGfx2, 0x200
+ax_sprite_terminator
+sUrsaringGfx3:
+.incbin "baserom.gba", 0xECE200, 0x200
+sUrsaringSprites3:
+ax_sprite sUrsaringGfx3, 0x200
+ax_sprite_terminator
+sUrsaringGfx4:
+.incbin "baserom.gba", 0xECE410, 0x200
+sUrsaringSprites4:
+ax_sprite sUrsaringGfx4, 0x200
+ax_sprite_terminator
+sUrsaringGfx5:
+.incbin "baserom.gba", 0xECE620, 0x200
+sUrsaringSprites5:
+ax_sprite sUrsaringGfx5, 0x200
+ax_sprite_terminator
+sUrsaringGfx6:
+.incbin "baserom.gba", 0xECE830, 0x200
+sUrsaringSprites6:
+ax_sprite sUrsaringGfx6, 0x200
+ax_sprite_terminator
+sUrsaringGfx7:
+.incbin "baserom.gba", 0xECEA40, 0x200
+sUrsaringSprites7:
+ax_sprite sUrsaringGfx7, 0x200
+ax_sprite_terminator
+sUrsaringGfx8:
+.incbin "baserom.gba", 0xECEC50, 0x200
+sUrsaringSprites8:
+ax_sprite sUrsaringGfx8, 0x200
+ax_sprite_terminator
+sUrsaringGfx9:
+.incbin "baserom.gba", 0xECEE60, 0x200
+sUrsaringSprites9:
+ax_sprite sUrsaringGfx9, 0x200
+ax_sprite_terminator
+sUrsaringGfx10:
+.incbin "baserom.gba", 0xECF070, 0x200
+sUrsaringSprites10:
+ax_sprite sUrsaringGfx10, 0x200
+ax_sprite_terminator
+sUrsaringGfx11:
+.incbin "baserom.gba", 0xECF280, 0x200
+sUrsaringSprites11:
+ax_sprite sUrsaringGfx11, 0x200
+ax_sprite_terminator
+sUrsaringGfx12:
+.incbin "baserom.gba", 0xECF490, 0x200
+sUrsaringSprites12:
+ax_sprite sUrsaringGfx12, 0x200
+ax_sprite_terminator
+sUrsaringGfx13:
+.incbin "baserom.gba", 0xECF6A0, 0x200
+sUrsaringSprites13:
+ax_sprite sUrsaringGfx13, 0x200
+ax_sprite_terminator
+sUrsaringGfx14:
+.incbin "baserom.gba", 0xECF8B0, 0x200
+sUrsaringSprites14:
+ax_sprite sUrsaringGfx14, 0x200
+ax_sprite_terminator
+sUrsaringGfx15:
+.incbin "baserom.gba", 0xECFAC0, 0x200
+sUrsaringSprites15:
+ax_sprite sUrsaringGfx15, 0x200
+ax_sprite_terminator
+sUrsaringGfx16:
+.incbin "baserom.gba", 0xECFCD0, 0x100
+sUrsaringSprites16:
+ax_sprite sUrsaringGfx16, 0x100
+ax_sprite_terminator
+sUrsaringGfx17:
+.incbin "baserom.gba", 0xECFDE0, 0x80
+sUrsaringSprites17:
+ax_sprite sUrsaringGfx17, 0x80
+ax_sprite_terminator
+sUrsaringGfx18:
+.incbin "baserom.gba", 0xECFE70, 0x20
+sUrsaringSprites18:
+ax_sprite sUrsaringGfx18, 0x20
+ax_sprite_terminator
+sUrsaringGfx19:
+.incbin "baserom.gba", 0xECFEA0, 0x20
+sUrsaringSprites19:
+ax_sprite sUrsaringGfx19, 0x20
+ax_sprite_terminator
+sUrsaringGfx20:
+.incbin "baserom.gba", 0xECFED0, 0x100
+sUrsaringSprites20:
+ax_sprite sUrsaringGfx20, 0x100
+ax_sprite_terminator
+sUrsaringGfx21:
+.incbin "baserom.gba", 0xECFFE0, 0x80
+sUrsaringSprites21:
+ax_sprite sUrsaringGfx21, 0x80
+ax_sprite_terminator
+sUrsaringGfx22:
+.incbin "baserom.gba", 0xED0070, 0x40
+sUrsaringSprites22:
+ax_sprite sUrsaringGfx22, 0x40
+ax_sprite_terminator
+sUrsaringGfx23:
+.incbin "baserom.gba", 0xED00C0, 0x20
+sUrsaringSprites23:
+ax_sprite sUrsaringGfx23, 0x20
+ax_sprite_terminator
+sUrsaringGfx24:
+.incbin "baserom.gba", 0xED00F0, 0x60
+sUrsaringGfx24_1:
+.incbin "baserom.gba", 0xED0150, 0x80
+sUrsaringGfx24_2:
+.incbin "baserom.gba", 0xED01D0, 0x60
+sUrsaringGfx24_3:
+.incbin "baserom.gba", 0xED0230, 0x60
+sUrsaringSprites24:
+ax_sprite sUrsaringGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx24_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx24_3, 0x60
+ax_sprite_terminator
+sUrsaringGfx25:
+.incbin "baserom.gba", 0xED02D0, 0x140
+sUrsaringGfx25_1:
+.incbin "baserom.gba", 0xED0410, 0x60
+sUrsaringSprites25:
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx25, 0x140
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx26:
+.incbin "baserom.gba", 0xED04A0, 0x100
+sUrsaringSprites26:
+ax_sprite sUrsaringGfx26, 0x100
+ax_sprite_terminator
+sUrsaringGfx27:
+.incbin "baserom.gba", 0xED05B0, 0x80
+sUrsaringSprites27:
+ax_sprite sUrsaringGfx27, 0x80
+ax_sprite_terminator
+sUrsaringGfx28:
+.incbin "baserom.gba", 0xED0640, 0x20
+sUrsaringSprites28:
+ax_sprite sUrsaringGfx28, 0x20
+ax_sprite_terminator
+sUrsaringGfx29:
+.incbin "baserom.gba", 0xED0670, 0x40
+sUrsaringSprites29:
+ax_sprite sUrsaringGfx29, 0x40
+ax_sprite_terminator
+sUrsaringGfx30:
+.incbin "baserom.gba", 0xED06C0, 0x60
+sUrsaringGfx30_1:
+.incbin "baserom.gba", 0xED0720, 0x180
+sUrsaringSprites30:
+ax_sprite sUrsaringGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx30_1, 0x180
+ax_sprite_terminator
+sUrsaringGfx31:
+.incbin "baserom.gba", 0xED08C0, 0x60
+sUrsaringGfx31_1:
+.incbin "baserom.gba", 0xED0920, 0x100
+sUrsaringGfx31_2:
+.incbin "baserom.gba", 0xED0A20, 0x60
+sUrsaringSprites31:
+ax_sprite sUrsaringGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx31_2, 0x60
+ax_sprite_terminator
+sUrsaringGfx32:
+.incbin "baserom.gba", 0xED0AB0, 0x60
+sUrsaringGfx32_1:
+.incbin "baserom.gba", 0xED0B10, 0x160
+sUrsaringSprites32:
+ax_sprite sUrsaringGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx32_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx33:
+.incbin "baserom.gba", 0xED0C98, 0x40
+sUrsaringGfx33_1:
+.incbin "baserom.gba", 0xED0CD8, 0x60
+sUrsaringGfx33_2:
+.incbin "baserom.gba", 0xED0D38, 0x60
+sUrsaringGfx33_3:
+.incbin "baserom.gba", 0xED0D98, 0x40
+sUrsaringSprites33:
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sUrsaringGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx34:
+.incbin "baserom.gba", 0xED0E28, 0x60
+sUrsaringGfx34_1:
+.incbin "baserom.gba", 0xED0E88, 0x60
+sUrsaringGfx34_2:
+.incbin "baserom.gba", 0xED0EE8, 0x100
+sUrsaringSprites34:
+ax_sprite sUrsaringGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx34_2, 0x100
+ax_sprite_terminator
+sUrsaringGfx35:
+.incbin "baserom.gba", 0xED1018, 0x60
+sUrsaringGfx35_1:
+.incbin "baserom.gba", 0xED1078, 0x100
+sUrsaringGfx35_2:
+.incbin "baserom.gba", 0xED1178, 0x60
+sUrsaringSprites35:
+ax_sprite sUrsaringGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx35_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx35_2, 0x60
+ax_sprite_terminator
+sUrsaringGfx36:
+.incbin "baserom.gba", 0xED1208, 0xC0
+sUrsaringGfx36_1:
+.incbin "baserom.gba", 0xED12C8, 0x20
+sUrsaringSprites36:
+ax_sprite sUrsaringGfx36, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx36_1, 0x20
+ax_sprite_terminator
+sUrsaringGfx37:
+.incbin "baserom.gba", 0xED1308, 0x80
+sUrsaringSprites37:
+ax_sprite sUrsaringGfx37, 0x80
+ax_sprite_terminator
+sUrsaringGfx38:
+.incbin "baserom.gba", 0xED1398, 0x20
+sUrsaringSprites38:
+ax_sprite sUrsaringGfx38, 0x20
+ax_sprite_terminator
+sUrsaringGfx39:
+.incbin "baserom.gba", 0xED13C8, 0x40
+sUrsaringSprites39:
+ax_sprite sUrsaringGfx39, 0x40
+ax_sprite_terminator
+sUrsaringGfx40:
+.incbin "baserom.gba", 0xED1418, 0x20
+sUrsaringSprites40:
+ax_sprite sUrsaringGfx40, 0x20
+ax_sprite_terminator
+sUrsaringGfx41:
+.incbin "baserom.gba", 0xED1448, 0x140
+sUrsaringGfx41_1:
+.incbin "baserom.gba", 0xED1588, 0x60
+sUrsaringSprites41:
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx41, 0x140
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx42:
+.incbin "baserom.gba", 0xED1618, 0x180
+sUrsaringGfx42_1:
+.incbin "baserom.gba", 0xED1798, 0x60
+sUrsaringSprites42:
+ax_sprite sUrsaringGfx42, 0x180
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx42_1, 0x60
+ax_sprite_terminator
+sUrsaringGfx43:
+.incbin "baserom.gba", 0xED1818, 0x60
+sUrsaringGfx43_1:
+.incbin "baserom.gba", 0xED1878, 0xE0
+sUrsaringGfx43_2:
+.incbin "baserom.gba", 0xED1958, 0x60
+sUrsaringSprites43:
+ax_sprite sUrsaringGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx43_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx43_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx44:
+.incbin "baserom.gba", 0xED19F0, 0x60
+sUrsaringGfx44_1:
+.incbin "baserom.gba", 0xED1A50, 0x60
+sUrsaringGfx44_2:
+.incbin "baserom.gba", 0xED1AB0, 0x80
+sUrsaringGfx44_3:
+.incbin "baserom.gba", 0xED1B30, 0x60
+sUrsaringSprites44:
+ax_sprite sUrsaringGfx44, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx44_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx44_3, 0x60
+ax_sprite_terminator
+sUrsaringGfx45:
+.incbin "baserom.gba", 0xED1BD0, 0xE0
+sUrsaringSprites45:
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx45, 0xe0
+ax_sprite_terminator
+sUrsaringGfx46:
+.incbin "baserom.gba", 0xED1CC8, 0x80
+sUrsaringSprites46:
+ax_sprite sUrsaringGfx46, 0x80
+ax_sprite_terminator
+sUrsaringGfx47:
+.incbin "baserom.gba", 0xED1D58, 0x20
+sUrsaringSprites47:
+ax_sprite sUrsaringGfx47, 0x20
+ax_sprite_terminator
+sUrsaringGfx48:
+.incbin "baserom.gba", 0xED1D88, 0x20
+sUrsaringSprites48:
+ax_sprite sUrsaringGfx48, 0x20
+ax_sprite_terminator
+sUrsaringGfx49:
+.incbin "baserom.gba", 0xED1DB8, 0x40
+sUrsaringSprites49:
+ax_sprite sUrsaringGfx49, 0x40
+ax_sprite_terminator
+sUrsaringGfx50:
+.incbin "baserom.gba", 0xED1E08, 0x160
+sUrsaringGfx50_1:
+.incbin "baserom.gba", 0xED1F68, 0x60
+sUrsaringSprites50:
+ax_sprite sUrsaringGfx50, 0x160
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx50_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx51:
+.incbin "baserom.gba", 0xED1FF0, 0x1E0
+sUrsaringSprites51:
+ax_sprite sUrsaringGfx51, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx52:
+.incbin "baserom.gba", 0xED21E8, 0x180
+sUrsaringGfx52_1:
+.incbin "baserom.gba", 0xED2368, 0x60
+sUrsaringSprites52:
+ax_sprite sUrsaringGfx52, 0x180
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx52_1, 0x60
+ax_sprite_terminator
+sUrsaringGfx53:
+.incbin "baserom.gba", 0xED23E8, 0x40
+sUrsaringGfx53_1:
+.incbin "baserom.gba", 0xED2428, 0x120
+sUrsaringSprites53:
+ax_sprite 0, 0x40
+ax_sprite sUrsaringGfx53, 0x40
+ax_sprite 0, 0x60
+ax_sprite sUrsaringGfx53_1, 0x120
+ax_sprite_terminator
+sUrsaringGfx54:
+.incbin "baserom.gba", 0xED2570, 0x20
+sUrsaringGfx54_1:
+.incbin "baserom.gba", 0xED2590, 0x20
+sUrsaringGfx54_2:
+.incbin "baserom.gba", 0xED25B0, 0x100
+sUrsaringSprites54:
+ax_sprite sUrsaringGfx54, 0x20
+ax_sprite 0, 0x60
+ax_sprite sUrsaringGfx54_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sUrsaringGfx54_2, 0x100
+ax_sprite_terminator
+sUrsaringGfx55:
+.incbin "baserom.gba", 0xED26E0, 0x40
+sUrsaringGfx55_1:
+.incbin "baserom.gba", 0xED2720, 0xA0
+sUrsaringSprites55:
+ax_sprite sUrsaringGfx55, 0x40
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx55_1, 0xa0
+ax_sprite_terminator
+sUrsaringGfx56:
+.incbin "baserom.gba", 0xED27E0, 0x40
+sUrsaringSprites56:
+ax_sprite sUrsaringGfx56, 0x40
+ax_sprite_terminator
+sUrsaringGfx57:
+.incbin "baserom.gba", 0xED2830, 0x60
+sUrsaringGfx57_1:
+.incbin "baserom.gba", 0xED2890, 0x40
+sUrsaringGfx57_2:
+.incbin "baserom.gba", 0xED28D0, 0x40
+sUrsaringGfx57_3:
+.incbin "baserom.gba", 0xED2910, 0x40
+sUrsaringSprites57:
+ax_sprite sUrsaringGfx57, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx57_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sUrsaringGfx57_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sUrsaringGfx57_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sUrsaringGfx58:
+.incbin "baserom.gba", 0xED2998, 0x40
+sUrsaringGfx58_1:
+.incbin "baserom.gba", 0xED29D8, 0x80
+sUrsaringSprites58:
+ax_sprite sUrsaringGfx58, 0x40
+ax_sprite 0, 0x40
+ax_sprite sUrsaringGfx58_1, 0x80
+ax_sprite_terminator
+sUrsaringGfx59:
+.incbin "baserom.gba", 0xED2A78, 0x20
+sUrsaringSprites59:
+ax_sprite sUrsaringGfx59, 0x20
+ax_sprite_terminator
+sUrsaringGfx60:
+.incbin "baserom.gba", 0xED2AA8, 0x40
+sUrsaringSprites60:
+ax_sprite sUrsaringGfx60, 0x40
+ax_sprite_terminator
+sUrsaringGfx61:
+.incbin "baserom.gba", 0xED2AF8, 0xC0
+sUrsaringGfx61_1:
+.incbin "baserom.gba", 0xED2BB8, 0x20
+sUrsaringSprites61:
+ax_sprite sUrsaringGfx61, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx61_1, 0x20
+ax_sprite_terminator
+sUrsaringGfx62:
+.incbin "baserom.gba", 0xED2BF8, 0x20
+sUrsaringSprites62:
+ax_sprite sUrsaringGfx62, 0x20
+ax_sprite_terminator
+sUrsaringGfx63:
+.incbin "baserom.gba", 0xED2C28, 0x60
+sUrsaringGfx63_1:
+.incbin "baserom.gba", 0xED2C88, 0x60
+sUrsaringGfx63_2:
+.incbin "baserom.gba", 0xED2CE8, 0x40
+sUrsaringGfx63_3:
+.incbin "baserom.gba", 0xED2D28, 0x40
+sUrsaringSprites63:
+ax_sprite sUrsaringGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx63_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx63_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sUrsaringGfx63_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sUrsaringGfx64:
+.incbin "baserom.gba", 0xED2DB0, 0xC0
+sUrsaringGfx64_1:
+.incbin "baserom.gba", 0xED2E70, 0x20
+sUrsaringSprites64:
+ax_sprite sUrsaringGfx64, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx64_1, 0x20
+ax_sprite_terminator
+sUrsaringGfx65:
+.incbin "baserom.gba", 0xED2EB0, 0x40
+sUrsaringSprites65:
+ax_sprite sUrsaringGfx65, 0x40
+ax_sprite_terminator
+sUrsaringGfx66:
+.incbin "baserom.gba", 0xED2F00, 0x60
+sUrsaringGfx66_1:
+.incbin "baserom.gba", 0xED2F60, 0xC0
+sUrsaringGfx66_2:
+.incbin "baserom.gba", 0xED3020, 0x20
+sUrsaringSprites66:
+ax_sprite sUrsaringGfx66, 0x60
+ax_sprite 0, 0x20
+ax_sprite sUrsaringGfx66_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sUrsaringGfx66_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sUrsaringGfx67:
+.incbin "baserom.gba", 0xED3078, 0x200
+sUrsaringSprites67:
+ax_sprite sUrsaringGfx67, 0x200
+ax_sprite_terminator
+sUrsaringGfx68:
+.incbin "baserom.gba", 0xED3288, 0x200
+sUrsaringSprites68:
+ax_sprite sUrsaringGfx68, 0x200
+ax_sprite_terminator
+sUrsaringGfx69:
+.incbin "baserom.gba", 0xED3498, 0x200
+sUrsaringSprites69:
+ax_sprite sUrsaringGfx69, 0x200
+ax_sprite_terminator
+sUrsaringGfx70:
+.incbin "baserom.gba", 0xED36A8, 0x200
+sUrsaringSprites70:
+ax_sprite sUrsaringGfx70, 0x200
+ax_sprite_terminator
+sUrsaringGfx71:
+.incbin "baserom.gba", 0xED38B8, 0x200
+sUrsaringSprites71:
+ax_sprite sUrsaringGfx71, 0x200
+ax_sprite_terminator
+sUrsaringGfx72:
+.incbin "baserom.gba", 0xED3AC8, 0x200
+sUrsaringSprites72:
+ax_sprite sUrsaringGfx72, 0x200
+ax_sprite_terminator
+sUrsaringGfx73:
+.incbin "baserom.gba", 0xED3CD8, 0x200
+sUrsaringSprites73:
+ax_sprite sUrsaringGfx73, 0x200
+ax_sprite_terminator
+sAxPosesUrsaring:
+.4byte sUrsaringPose1
+.4byte sUrsaringPose2
+.4byte sUrsaringPose3
+.4byte sUrsaringPose4
+.4byte sUrsaringPose5
+.4byte sUrsaringPose6
+.4byte sUrsaringPose7
+.4byte sUrsaringPose8
+.4byte sUrsaringPose9
+.4byte sUrsaringPose10
+.4byte sUrsaringPose11
+.4byte sUrsaringPose12
+.4byte sUrsaringPose13
+.4byte sUrsaringPose14
+.4byte sUrsaringPose15
+.4byte sUrsaringPose16
+.4byte sUrsaringPose17
+.4byte sUrsaringPose18
+.4byte sUrsaringPose19
+.4byte sUrsaringPose20
+.4byte sUrsaringPose21
+.4byte sUrsaringPose22
+.4byte sUrsaringPose23
+.4byte sUrsaringPose24
+.4byte sUrsaringPose25
+.4byte sUrsaringPose26
+.4byte sUrsaringPose27
+.4byte sUrsaringPose28
+.4byte sUrsaringPose29
+.4byte sUrsaringPose30
+.4byte sUrsaringPose31
+.4byte sUrsaringPose32
+.4byte sUrsaringPose33
+.4byte sUrsaringPose34
+.4byte sUrsaringPose35
+.4byte sUrsaringPose36
+.4byte sUrsaringPose37
+.4byte sUrsaringPose38
+.4byte sUrsaringPose39
+.4byte sUrsaringPose40
+.4byte sUrsaringPose41
+.4byte sUrsaringPose42
+.4byte sUrsaringPose43
+.4byte sUrsaringPose44
+.4byte sUrsaringPose45
+.4byte sUrsaringPose46
+.4byte sUrsaringPose47
+.4byte sUrsaringPose48
+.4byte sUrsaringPose49
+.4byte sUrsaringPose50
+.4byte sUrsaringPose51
+.4byte sUrsaringPose52
+.4byte sUrsaringPose53
+.4byte sUrsaringPose54
+.4byte sUrsaringPose55
+.4byte sUrsaringPose56
+.4byte sUrsaringPose57
+.4byte sUrsaringPose58
+.4byte sUrsaringPose59
+.4byte sUrsaringPose60
+.4byte sUrsaringPose61
+.4byte sUrsaringPose62
+.4byte sUrsaringPose63
+.4byte sUrsaringPose64
+.4byte sUrsaringPose65
+.4byte sUrsaringPose66
+.4byte sUrsaringPose67
+.4byte sUrsaringPose68
+.4byte sUrsaringPose69
+.4byte sUrsaringPose70
+.4byte sUrsaringPose71
+.4byte sUrsaringPose72
+.4byte sUrsaringPose73
+.4byte sUrsaringPose74
+.4byte sUrsaringPose75
+.4byte sUrsaringPose76
+.4byte sUrsaringPose77
+.4byte sUrsaringPose78
+.4byte sUrsaringPose79
+.4byte sUrsaringPose80
+.4byte sUrsaringPose81
+.4byte sUrsaringPose82
+.4byte sUrsaringPose83
+.4byte sUrsaringPose84
+.4byte sUrsaringPose85
+.4byte sUrsaringPose86
+.4byte sUrsaringPose87
+.4byte sUrsaringPose88
+.4byte sUrsaringPose89
+.4byte sUrsaringPose90
+.4byte sUrsaringPose91
+.4byte sUrsaringPose92
+.4byte sUrsaringPose93
+.4byte sUrsaringPose94
+.4byte sUrsaringPose95
+.4byte sUrsaringPose96
+.4byte sUrsaringPose97
+.4byte sUrsaringPose98
+.4byte sUrsaringPose99
+.4byte sUrsaringPose100
+.4byte sUrsaringPose101
+.4byte sUrsaringPose102
+.4byte sUrsaringPose103
+.4byte sUrsaringPose104
+.4byte sUrsaringPose105
+.4byte sUrsaringPose106
+.4byte sUrsaringPose107
+.4byte sUrsaringPose108
+.4byte sUrsaringPose109
+.4byte sUrsaringPose110
+.4byte sUrsaringPose111
+.4byte sUrsaringPose112
+.4byte sUrsaringPose113
+.4byte sUrsaringPose114
+.4byte sUrsaringPose115
+.4byte sUrsaringPose116
+.4byte sUrsaringPose117
+.4byte sUrsaringPose118
+.4byte sUrsaringPose119
+.4byte sUrsaringPose120
+.4byte sUrsaringPose121
+.4byte sUrsaringPose122
+.4byte sUrsaringPose123
+.4byte sUrsaringPose124
+.4byte sUrsaringPose125
+.4byte sUrsaringPose126
+.4byte sUrsaringPose127
+.4byte sUrsaringPose128
+.4byte sUrsaringPose129
+.4byte sUrsaringPose130
+.4byte sUrsaringPose131
+.4byte sUrsaringPose132
+.4byte sUrsaringPose133
+.4byte sUrsaringPose134
+.4byte sUrsaringPose135
+.4byte sUrsaringPose136
+.4byte sUrsaringPose137
+.4byte sUrsaringPose138
+.4byte sUrsaringPose139
+.4byte sUrsaringPose140
+.4byte sUrsaringPose141
+.4byte sUrsaringPose142
+.4byte sUrsaringPose143
+.4byte sUrsaringPose144
+.4byte sUrsaringPose145
+.4byte sUrsaringPose146
+.4byte sUrsaringPose147
+.4byte sUrsaringPose148
+.4byte sUrsaringPose149
+.4byte sUrsaringPose150
+.4byte sUrsaringPose151
+.4byte sUrsaringPose152
+.4byte sUrsaringPose153
+.4byte sUrsaringPose154
+.4byte sUrsaringPose155
+.4byte sUrsaringPose156
+.4byte sUrsaringPose157
+.4byte sUrsaringPose158
+.4byte sUrsaringPose159
+.4byte sUrsaringPose160
+.4byte sUrsaringPose161
+.4byte sUrsaringPose162
+.4byte sUrsaringPose163
+.4byte sUrsaringPose164
+.4byte sUrsaringPose165
+.4byte sUrsaringPose166
+.4byte sUrsaringPose167
+.4byte sUrsaringPose168
+.4byte sUrsaringPose169
+.4byte sUrsaringPose170
+.4byte sUrsaringPose171
+.4byte sUrsaringPose172
+.4byte sUrsaringPose173
+.4byte sUrsaringPose174
+.4byte sUrsaringPose175
+.4byte sUrsaringPose176
+.4byte sUrsaringPose177
+.4byte sUrsaringPose178
+.4byte sUrsaringPose179
+.4byte sUrsaringPose180
+.4byte sUrsaringPose181
+.4byte sUrsaringPose182
+.4byte sUrsaringPose183
+.4byte sUrsaringPose184
+.4byte sUrsaringPose185
+.4byte sUrsaringPose186
+.4byte sUrsaringPose187
+.4byte sUrsaringPose188
+.4byte sUrsaringPose189
+.4byte sUrsaringPose190
+.4byte sUrsaringPose191
+.4byte sUrsaringPose192
+.4byte sUrsaringPose193
+.4byte sUrsaringPose194
+.4byte sUrsaringPose195
+.4byte sUrsaringPose196
+.4byte sUrsaringPose197
+.4byte sUrsaringPose198
+.4byte sUrsaringPose199
+.4byte sUrsaringPose200
+.4byte sUrsaringPose201
+.4byte sUrsaringPose202
+.4byte sUrsaringPose203
+.4byte sUrsaringPose204
+.4byte sUrsaringPose205
+.4byte sUrsaringPose206
+.4byte sUrsaringPose207
+.4byte sUrsaringPose208
+.4byte sUrsaringPose209
+.4byte sUrsaringPose210
+.4byte sUrsaringPose211
+.4byte sUrsaringPose212
+.4byte sUrsaringPose213
+.4byte sUrsaringPose214
+.4byte sUrsaringPose215
+.4byte sUrsaringPose216
+.4byte sUrsaringPose217
+.4byte sUrsaringPose218
+.4byte sUrsaringPose219
+.4byte sUrsaringPose220
+.4byte sUrsaringPose221
+.4byte sUrsaringPose222
+.4byte sUrsaringPose223
+.4byte sUrsaringPose224
+.4byte sUrsaringPose225
+.4byte sUrsaringPose226
+.4byte sUrsaringPose227
+.4byte sUrsaringPose228
+.4byte sUrsaringPose229
+.4byte sUrsaringPose230
+.4byte sUrsaringPose231
+.4byte sUrsaringPose232
+.4byte sUrsaringPose233
+.4byte sUrsaringPose234
+.4byte sUrsaringPose235
+.4byte sUrsaringPose236
+.4byte sUrsaringPose237
+.4byte sUrsaringPose238
+.4byte sUrsaringPose239
+.4byte sUrsaringPose240
+.4byte sUrsaringPose241
+.4byte sUrsaringPose242
+.4byte sUrsaringPose243
+.4byte sUrsaringPose244
+.4byte sUrsaringPose245
+.4byte sUrsaringPose246
+.4byte sUrsaringPose247
+.4byte sUrsaringPose248
+.4byte sUrsaringPose249
+.4byte sUrsaringPose250
+.4byte sUrsaringPose251
+.4byte sUrsaringPose252
+.4byte sUrsaringPose253
+.4byte sUrsaringPose254
+.4byte sUrsaringPose255
+.4byte sUrsaringPose256
+.4byte sUrsaringPose257
+.4byte sUrsaringPose258
+sAxPositionsUrsaring:
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -2,  -15, 	  -8,   -6, 	  10,  -10, 	  -1,   -9
+.2byte    0,  -15, 	 -12,  -11, 	   6,   -6, 	  -1,   -9
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+.2byte    4,  -16, 	   9,   -9, 	  -9,   -7, 	  -1,  -10
+.2byte    2,  -16, 	   5,  -12, 	  -4,   -4, 	  -1,  -10
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    5,  -16, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    4,  -15, 	   0,   -9, 	   4,   -5, 	  -2,   -7
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte    2,  -19, 	  -8,  -10, 	   3,   -5, 	  -3,  -10
+.2byte    5,  -19, 	 -12,  -11, 	  10,   -7, 	  -1,  -13
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte   -2,  -19, 	   8,  -12, 	 -10,   -9, 	  -1,  -12
+.2byte    0,  -20, 	   7,   -9, 	 -10,  -12, 	  -1,  -13
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte   -4,  -19, 	   6,  -10, 	  -5,   -5, 	   1,  -10
+.2byte   -7,  -19, 	  10,  -11, 	 -12,   -7, 	  -1,  -13
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -7,  -16, 	  -4,   -7, 	   1,   -5, 	  -1,   -8
+.2byte   -6,  -15, 	  -2,   -9, 	  -6,   -5, 	   0,   -7
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte   -6,  -16, 	 -11,   -9, 	   7,   -7, 	  -1,  -10
+.2byte   -4,  -16, 	  -7,  -12, 	   2,   -4, 	  -1,  -10
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -2,  -15, 	  -8,   -6, 	  10,  -10, 	  -1,   -9
+.2byte    0,  -15, 	 -12,  -11, 	   6,   -6, 	  -1,   -9
+.2byte   -1,  -26, 	 -14,  -16, 	  12,  -16, 	  -1,  -10
+.2byte   -1,  -12, 	 -14,  -17, 	  11,  -16, 	   0,   -8
+.2byte   -8,  -12, 	 -17,  -17, 	  -6,  -10, 	  -2,   -7
+.2byte    8,  -13, 	   6,  -10, 	  16,  -17, 	   2,   -6
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+.2byte    4,  -16, 	   9,   -9, 	  -9,   -7, 	  -1,  -10
+.2byte    2,  -16, 	   5,  -12, 	  -4,   -4, 	  -1,  -10
+.2byte   -2,  -27, 	   7,  -20, 	 -14,  -13, 	  -2,  -12
+.2byte    6,  -15, 	  13,  -20, 	  -4,  -13, 	   0,  -10
+.2byte   11,  -16, 	   0,  -23, 	  14,  -14, 	  -1,  -10
+.2byte    5,  -14, 	   8,   -9, 	 -15,  -14, 	   1,  -10
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    5,  -16, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    4,  -15, 	   0,   -9, 	   4,   -5, 	  -2,   -7
+.2byte   -3,  -23, 	  -1,  -21, 	  -5,  -12, 	  -2,  -10
+.2byte    6,  -16, 	   5,  -23, 	   8,  -10, 	  -2,   -7
+.2byte    6,  -18, 	 -10,  -17, 	  13,  -17, 	  -1,   -8
+.2byte    8,  -14, 	  13,  -10, 	 -12,   -7, 	  -2,   -6
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte    2,  -19, 	  -8,  -10, 	   3,   -5, 	  -3,  -10
+.2byte    5,  -19, 	 -12,  -11, 	  10,   -7, 	  -1,  -13
+.2byte   -3,  -25, 	 -12,  -20, 	   8,  -12, 	  -2,  -12
+.2byte    4,  -20, 	  -6,  -25, 	  11,  -16, 	  -3,  -12
+.2byte   -2,  -21, 	 -17,  -16, 	   4,  -21, 	  -1,  -12
+.2byte    8,  -15, 	   9,  -16, 	   2,   -4, 	  -3,   -9
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte   -2,  -19, 	   8,  -12, 	 -10,   -9, 	  -1,  -12
+.2byte    0,  -20, 	   7,   -9, 	 -10,  -12, 	  -1,  -13
+.2byte   -1,  -22, 	  14,  -18, 	 -15,  -19, 	  -1,  -13
+.2byte   -1,  -21, 	  12,  -21, 	 -13,  -21, 	  -1,  -13
+.2byte    1,  -17, 	  12,  -11, 	  -2,  -15, 	   0,  -12
+.2byte    1,  -17, 	   0,  -16, 	 -14,  -11, 	   1,  -12
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte   -4,  -19, 	   6,  -10, 	  -5,   -5, 	   1,  -10
+.2byte   -7,  -19, 	  10,  -11, 	 -12,   -7, 	  -1,  -13
+.2byte    1,  -25, 	  10,  -20, 	 -10,  -12, 	   0,  -12
+.2byte   -6,  -20, 	   4,  -25, 	 -13,  -16, 	   1,  -12
+.2byte    0,  -21, 	  15,  -16, 	  -6,  -21, 	  -1,  -12
+.2byte  -10,  -15, 	 -11,  -16, 	  -4,   -4, 	   1,   -9
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -7,  -16, 	  -4,   -7, 	   1,   -5, 	  -1,   -8
+.2byte   -6,  -15, 	  -2,   -9, 	  -6,   -5, 	   0,   -7
+.2byte    1,  -23, 	  -1,  -21, 	   3,  -12, 	   0,  -10
+.2byte   -8,  -16, 	  -7,  -23, 	 -10,  -10, 	   0,   -7
+.2byte   -8,  -18, 	   8,  -17, 	 -15,  -17, 	  -1,   -8
+.2byte  -10,  -14, 	 -15,  -10, 	  10,   -7, 	   0,   -6
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte   -6,  -16, 	 -11,   -9, 	   7,   -7, 	  -1,  -10
+.2byte   -4,  -16, 	  -7,  -12, 	   2,   -4, 	  -1,  -10
+.2byte    0,  -27, 	  -9,  -20, 	  12,  -13, 	   0,  -12
+.2byte   -8,  -15, 	 -15,  -20, 	   2,  -13, 	  -2,  -10
+.2byte  -13,  -16, 	  -2,  -23, 	 -16,  -14, 	  -1,  -10
+.2byte   -5,  -14, 	  -8,   -9, 	  15,  -14, 	  -1,  -10
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -2,  -15, 	  -8,   -6, 	  10,  -10, 	  -1,   -9
+.2byte    0,  -15, 	 -12,  -11, 	   6,   -6, 	  -1,   -9
+.2byte   -6,  -12, 	 -15,  -17, 	  -4,  -10, 	   0,   -7
+.2byte   -6,  -12, 	 -15,  -17, 	  -4,  -10, 	   0,   -7
+.2byte    6,  -13, 	   4,  -10, 	  14,  -17, 	   0,   -6
+.2byte    6,  -13, 	   4,  -10, 	  14,  -17, 	   0,   -6
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+.2byte    4,  -16, 	   9,   -9, 	  -9,   -7, 	  -1,  -10
+.2byte    2,  -16, 	   5,  -12, 	  -4,   -4, 	  -1,  -10
+.2byte   11,  -16, 	   0,  -23, 	  14,  -14, 	  -1,  -10
+.2byte   11,  -16, 	   0,  -23, 	  14,  -14, 	  -1,  -10
+.2byte    5,  -14, 	   8,   -9, 	 -15,  -14, 	   1,  -10
+.2byte    5,  -14, 	   8,   -9, 	 -15,  -14, 	   1,  -10
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    5,  -16, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    4,  -15, 	   0,   -9, 	   4,   -5, 	  -2,   -7
+.2byte    6,  -18, 	 -10,  -17, 	  13,  -17, 	  -1,   -8
+.2byte    6,  -18, 	 -10,  -17, 	  13,  -17, 	  -1,   -8
+.2byte    8,  -14, 	  13,  -10, 	 -12,   -7, 	  -2,   -6
+.2byte    8,  -14, 	  13,  -10, 	 -12,   -7, 	  -2,   -6
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte    2,  -19, 	  -8,  -10, 	   3,   -5, 	  -3,  -10
+.2byte    5,  -19, 	 -12,  -11, 	  10,   -7, 	  -1,  -13
+.2byte   -2,  -21, 	 -17,  -16, 	   4,  -21, 	  -1,  -12
+.2byte   -2,  -21, 	 -17,  -16, 	   4,  -21, 	  -1,  -12
+.2byte    8,  -15, 	   9,  -16, 	   2,   -4, 	  -3,   -9
+.2byte    8,  -15, 	   9,  -16, 	   2,   -4, 	  -3,   -9
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte   -2,  -19, 	   8,  -12, 	 -10,   -9, 	  -1,  -12
+.2byte    0,  -20, 	   7,   -9, 	 -10,  -12, 	  -1,  -13
+.2byte    1,  -17, 	  12,  -11, 	  -2,  -15, 	   0,  -12
+.2byte    1,  -17, 	  12,  -11, 	  -2,  -15, 	   0,  -12
+.2byte   -2,  -17, 	 -13,  -11, 	   1,  -15, 	  -1,  -12
+.2byte    1,  -17, 	   0,  -16, 	 -14,  -11, 	   1,  -12
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte   -4,  -19, 	   6,  -10, 	  -5,   -5, 	   1,  -10
+.2byte   -7,  -19, 	  10,  -11, 	 -12,   -7, 	  -1,  -13
+.2byte    0,  -21, 	  15,  -16, 	  -6,  -21, 	  -1,  -12
+.2byte    0,  -21, 	  15,  -16, 	  -6,  -21, 	  -1,  -12
+.2byte  -10,  -15, 	 -11,  -16, 	  -4,   -4, 	   1,   -9
+.2byte  -10,  -15, 	 -11,  -16, 	  -4,   -4, 	   1,   -9
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -7,  -16, 	  -4,   -7, 	   1,   -5, 	  -1,   -8
+.2byte   -6,  -15, 	  -2,   -9, 	  -6,   -5, 	   0,   -7
+.2byte   -8,  -18, 	   8,  -17, 	 -15,  -17, 	  -1,   -8
+.2byte   -8,  -18, 	   8,  -17, 	 -15,  -17, 	  -1,   -8
+.2byte  -10,  -14, 	 -15,  -10, 	  10,   -7, 	   0,   -6
+.2byte  -10,  -14, 	 -15,  -10, 	  10,   -7, 	   0,   -6
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte   -6,  -16, 	 -11,   -9, 	   7,   -7, 	  -1,  -10
+.2byte   -4,  -16, 	  -7,  -12, 	   2,   -4, 	  -1,  -10
+.2byte  -13,  -16, 	  -2,  -23, 	 -16,  -14, 	  -1,  -10
+.2byte  -13,  -16, 	  -2,  -23, 	 -16,  -14, 	  -1,  -10
+.2byte   -5,  -14, 	  -8,   -9, 	  15,  -14, 	  -1,  -10
+.2byte   -5,  -14, 	  -8,   -9, 	  15,  -14, 	  -1,  -10
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -1,  -26, 	 -14,  -16, 	  12,  -16, 	  -1,  -10
+.2byte   -1,  -12, 	 -14,  -17, 	  11,  -16, 	   0,   -8
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+.2byte   -2,  -27, 	   7,  -20, 	 -14,  -13, 	  -2,  -12
+.2byte    6,  -15, 	  13,  -20, 	  -4,  -13, 	   0,  -10
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte   -3,  -23, 	  -1,  -21, 	  -5,  -12, 	  -2,  -10
+.2byte    6,  -16, 	   5,  -23, 	   8,  -10, 	  -2,   -7
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte   -3,  -25, 	 -12,  -20, 	   8,  -12, 	  -2,  -12
+.2byte    4,  -20, 	  -6,  -25, 	  11,  -16, 	  -3,  -12
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte   -1,  -22, 	  14,  -18, 	 -15,  -19, 	  -1,  -13
+.2byte   -1,  -21, 	  12,  -21, 	 -13,  -21, 	  -1,  -13
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte    1,  -25, 	  10,  -20, 	 -10,  -12, 	   0,  -12
+.2byte   -6,  -20, 	   4,  -25, 	 -13,  -16, 	   1,  -12
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte    1,  -23, 	  -1,  -21, 	   3,  -12, 	   0,  -10
+.2byte   -8,  -16, 	  -7,  -23, 	 -10,  -10, 	   0,   -7
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte    0,  -27, 	  -9,  -20, 	  12,  -13, 	   0,  -12
+.2byte   -8,  -15, 	 -15,  -20, 	   2,  -13, 	  -2,  -10
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+.2byte   -3,  -15, 	   1,  -11, 	  -5,  -11, 	  -1,   -9
+.2byte   -4,  -13, 	  -4,  -11, 	   1,  -10, 	  -1,   -9
+.2byte    0,  -15, 	 -11,  -11, 	  11,  -11, 	   0,  -10
+.2byte    2,  -15, 	   7,  -16, 	  -9,   -9, 	  -2,  -10
+.2byte    4,  -17, 	   5,  -12, 	   2,   -9, 	  -3,   -9
+.2byte    2,  -19, 	  -5,  -14, 	   7,  -10, 	  -1,  -11
+.2byte    0,  -19, 	  10,  -10, 	 -10,  -10, 	   0,  -12
+.2byte   -3,  -19, 	   4,  -14, 	  -8,  -10, 	   0,  -11
+.2byte   -5,  -17, 	  -6,  -12, 	  -3,   -9, 	   2,   -9
+.2byte   -3,  -15, 	  -8,  -16, 	   8,   -9, 	   1,  -10
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -1,  -27, 	 -14,  -17, 	  12,  -17, 	  -1,  -11
+.2byte   -1,  -12, 	 -14,  -17, 	  11,  -16, 	   0,   -8
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+.2byte   -2,  -27, 	   7,  -20, 	 -14,  -13, 	  -2,  -12
+.2byte    6,  -15, 	  13,  -20, 	  -4,  -13, 	   0,  -10
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte   -3,  -23, 	  -1,  -21, 	  -5,  -12, 	  -2,  -10
+.2byte    6,  -16, 	   5,  -23, 	   8,  -10, 	  -2,   -7
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte   -3,  -25, 	 -12,  -20, 	   8,  -12, 	  -2,  -12
+.2byte    4,  -20, 	  -6,  -25, 	  11,  -16, 	  -3,  -12
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte   -1,  -22, 	  14,  -18, 	 -15,  -19, 	  -1,  -13
+.2byte   -1,  -21, 	  12,  -21, 	 -13,  -21, 	  -1,  -13
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte    1,  -25, 	  10,  -20, 	 -10,  -12, 	   0,  -12
+.2byte   -6,  -20, 	   4,  -25, 	 -13,  -16, 	   1,  -12
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte    1,  -23, 	  -1,  -21, 	   3,  -12, 	   0,  -10
+.2byte   -8,  -16, 	  -7,  -23, 	 -10,  -10, 	   0,   -7
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte    0,  -27, 	  -9,  -20, 	  12,  -13, 	   0,  -12
+.2byte   -8,  -15, 	 -15,  -20, 	   2,  -13, 	  -2,  -10
+.2byte   -1,  -12, 	 -14,  -17, 	  11,  -16, 	   0,   -8
+.2byte   -6,  -14, 	 -13,  -19, 	   4,  -12, 	   0,   -9
+.2byte   -8,  -16, 	  -7,  -23, 	 -10,  -10, 	   0,   -7
+.2byte   -7,  -19, 	   3,  -24, 	 -14,  -15, 	   0,  -11
+.2byte    0,  -20, 	  13,  -20, 	 -12,  -20, 	   0,  -12
+.2byte    6,  -19, 	  -4,  -24, 	  13,  -15, 	  -1,  -11
+.2byte    7,  -16, 	   6,  -23, 	   9,  -10, 	  -1,   -7
+.2byte    5,  -14, 	  12,  -19, 	  -5,  -12, 	  -1,   -9
+.2byte   -1,  -12, 	 -14,  -17, 	  11,  -16, 	   0,   -8
+.2byte    5,  -14, 	  12,  -19, 	  -5,  -12, 	  -1,   -9
+.2byte    7,  -16, 	   6,  -23, 	   9,  -10, 	  -1,   -7
+.2byte    6,  -19, 	  -4,  -24, 	  13,  -15, 	  -1,  -11
+.2byte    0,  -20, 	  13,  -20, 	 -12,  -20, 	   0,  -12
+.2byte   -7,  -19, 	   3,  -24, 	 -14,  -15, 	   0,  -11
+.2byte   -8,  -16, 	  -7,  -23, 	 -10,  -10, 	   0,   -7
+.2byte   -6,  -14, 	 -13,  -19, 	   4,  -12, 	   0,   -9
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -1,  -26, 	 -14,  -16, 	  12,  -16, 	  -1,  -10
+.2byte   -1,  -14, 	 -14,  -19, 	  11,  -18, 	   0,  -10
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+.2byte   -2,  -27, 	   7,  -20, 	 -14,  -13, 	  -2,  -12
+.2byte    4,  -15, 	  11,  -20, 	  -6,  -13, 	  -2,  -10
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte   -3,  -23, 	  -1,  -21, 	  -5,  -12, 	  -2,  -10
+.2byte    6,  -16, 	   5,  -23, 	   8,  -10, 	  -2,   -7
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte   -3,  -25, 	 -12,  -20, 	   8,  -12, 	  -2,  -12
+.2byte    5,  -20, 	  -5,  -25, 	  12,  -16, 	  -2,  -12
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte   -1,  -22, 	  14,  -18, 	 -15,  -19, 	  -1,  -13
+.2byte   -1,  -21, 	  12,  -21, 	 -13,  -21, 	  -1,  -13
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte    1,  -25, 	  10,  -20, 	 -10,  -12, 	   0,  -12
+.2byte   -7,  -20, 	   3,  -25, 	 -14,  -16, 	   0,  -12
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte    1,  -23, 	  -1,  -21, 	   3,  -12, 	   0,  -10
+.2byte   -8,  -16, 	  -7,  -23, 	 -10,  -10, 	   0,   -7
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte    0,  -27, 	  -9,  -20, 	  12,  -13, 	   0,  -12
+.2byte   -6,  -15, 	 -13,  -20, 	   4,  -13, 	   0,  -10
+.2byte   -1,  -12, 	 -14,  -17, 	  11,  -16, 	   0,   -8
+.2byte   -6,  -14, 	 -13,  -19, 	   4,  -12, 	   0,   -9
+.2byte   -8,  -16, 	  -7,  -23, 	 -10,  -10, 	   0,   -7
+.2byte   -7,  -19, 	   3,  -24, 	 -14,  -15, 	   0,  -11
+.2byte    0,  -20, 	  13,  -20, 	 -12,  -20, 	   0,  -12
+.2byte    6,  -19, 	  -4,  -24, 	  13,  -15, 	  -1,  -11
+.2byte    7,  -16, 	   6,  -23, 	   9,  -10, 	  -1,   -7
+.2byte    5,  -14, 	  12,  -19, 	  -5,  -12, 	  -1,   -9
+.2byte   -1,  -16, 	 -12,   -7, 	  10,   -7, 	   0,   -9
+.2byte   -5,  -17, 	  -9,  -12, 	   5,   -4, 	  -2,  -10
+.2byte   -6,  -17, 	  -5,   -8, 	  -2,   -5, 	   0,   -9
+.2byte   -6,  -21, 	   7,  -12, 	  -9,   -6, 	   0,  -12
+.2byte   -1,  -20, 	  10,   -9, 	 -12,   -8, 	  -1,  -13
+.2byte    4,  -21, 	  -9,  -12, 	   7,   -6, 	  -2,  -12
+.2byte    4,  -17, 	   3,   -8, 	   0,   -5, 	  -2,   -9
+.2byte    3,  -17, 	   7,  -12, 	  -7,   -4, 	   0,  -10
+sUrsaringAnimTable1:
+.4byte sUrsaringAnims_1_1
+.4byte sUrsaringAnims_1_2
+.4byte sUrsaringAnims_1_3
+.4byte sUrsaringAnims_1_4
+.4byte sUrsaringAnims_1_5
+.4byte sUrsaringAnims_1_6
+.4byte sUrsaringAnims_1_7
+.4byte sUrsaringAnims_1_8
+sUrsaringAnimTable2:
+.4byte sUrsaringAnims_2_1
+.4byte sUrsaringAnims_2_2
+.4byte sUrsaringAnims_2_3
+.4byte sUrsaringAnims_2_4
+.4byte sUrsaringAnims_2_5
+.4byte sUrsaringAnims_2_6
+.4byte sUrsaringAnims_2_7
+.4byte sUrsaringAnims_2_8
+sUrsaringAnimTable3:
+.4byte sUrsaringAnims_3_1
+.4byte sUrsaringAnims_3_2
+.4byte sUrsaringAnims_3_3
+.4byte sUrsaringAnims_3_4
+.4byte sUrsaringAnims_3_5
+.4byte sUrsaringAnims_3_6
+.4byte sUrsaringAnims_3_7
+.4byte sUrsaringAnims_3_8
+sUrsaringAnimTable4:
+.4byte sUrsaringAnims_4_1
+.4byte sUrsaringAnims_4_2
+.4byte sUrsaringAnims_4_3
+.4byte sUrsaringAnims_4_4
+.4byte sUrsaringAnims_4_5
+.4byte sUrsaringAnims_4_6
+.4byte sUrsaringAnims_4_7
+.4byte sUrsaringAnims_4_8
+sUrsaringAnimTable5:
+.4byte sUrsaringAnims_5_1
+.4byte sUrsaringAnims_5_2
+.4byte sUrsaringAnims_5_3
+.4byte sUrsaringAnims_5_4
+.4byte sUrsaringAnims_5_5
+.4byte sUrsaringAnims_5_6
+.4byte sUrsaringAnims_5_7
+.4byte sUrsaringAnims_5_8
+sUrsaringAnimTable6:
+.4byte sUrsaringAnims_6_1
+.4byte sUrsaringAnims_6_1
+.4byte sUrsaringAnims_6_1
+.4byte sUrsaringAnims_6_1
+.4byte sUrsaringAnims_6_1
+.4byte sUrsaringAnims_6_1
+.4byte sUrsaringAnims_6_1
+.4byte sUrsaringAnims_6_1
+sUrsaringAnimTable7:
+.4byte sUrsaringAnims_7_1
+.4byte sUrsaringAnims_7_2
+.4byte sUrsaringAnims_7_3
+.4byte sUrsaringAnims_7_4
+.4byte sUrsaringAnims_7_5
+.4byte sUrsaringAnims_7_6
+.4byte sUrsaringAnims_7_7
+.4byte sUrsaringAnims_7_8
+sUrsaringAnimTable8:
+.4byte sUrsaringAnims_8_1
+.4byte sUrsaringAnims_8_2
+.4byte sUrsaringAnims_8_3
+.4byte sUrsaringAnims_8_4
+.4byte sUrsaringAnims_8_5
+.4byte sUrsaringAnims_8_6
+.4byte sUrsaringAnims_8_7
+.4byte sUrsaringAnims_8_8
+sUrsaringAnimTable9:
+.4byte sUrsaringAnims_9_1
+.4byte sUrsaringAnims_9_2
+.4byte sUrsaringAnims_9_3
+.4byte sUrsaringAnims_9_4
+.4byte sUrsaringAnims_9_5
+.4byte sUrsaringAnims_9_6
+.4byte sUrsaringAnims_9_7
+.4byte sUrsaringAnims_9_8
+sUrsaringAnimTable10:
+.4byte sUrsaringAnims_10_1
+.4byte sUrsaringAnims_10_2
+.4byte sUrsaringAnims_10_3
+.4byte sUrsaringAnims_10_4
+.4byte sUrsaringAnims_10_5
+.4byte sUrsaringAnims_10_6
+.4byte sUrsaringAnims_10_7
+.4byte sUrsaringAnims_10_8
+sUrsaringAnimTable11:
+.4byte sUrsaringAnims_11_1
+.4byte sUrsaringAnims_11_2
+.4byte sUrsaringAnims_11_3
+.4byte sUrsaringAnims_11_4
+.4byte sUrsaringAnims_11_5
+.4byte sUrsaringAnims_11_6
+.4byte sUrsaringAnims_11_7
+.4byte sUrsaringAnims_11_8
+sUrsaringAnimTable12:
+.4byte sUrsaringAnims_12_1
+.4byte sUrsaringAnims_12_2
+.4byte sUrsaringAnims_12_3
+.4byte sUrsaringAnims_12_4
+.4byte sUrsaringAnims_12_5
+.4byte sUrsaringAnims_12_6
+.4byte sUrsaringAnims_12_7
+.4byte sUrsaringAnims_12_8
+sUrsaringAnimTable13:
+.4byte sUrsaringAnims_13_1
+.4byte sUrsaringAnims_13_2
+.4byte sUrsaringAnims_13_3
+.4byte sUrsaringAnims_13_4
+.4byte sUrsaringAnims_13_5
+.4byte sUrsaringAnims_13_6
+.4byte sUrsaringAnims_13_7
+.4byte sUrsaringAnims_13_8
+sAxAnimationsUrsaring:
+.4byte sUrsaringAnimTable1
+.4byte sUrsaringAnimTable2
+.4byte sUrsaringAnimTable3
+.4byte sUrsaringAnimTable4
+.4byte sUrsaringAnimTable5
+.4byte sUrsaringAnimTable6
+.4byte sUrsaringAnimTable7
+.4byte sUrsaringAnimTable8
+.4byte sUrsaringAnimTable9
+.4byte sUrsaringAnimTable10
+.4byte sUrsaringAnimTable11
+.4byte sUrsaringAnimTable12
+.4byte sUrsaringAnimTable13
+sAxSpritesUrsaring:
+.4byte sUrsaringSprites1
+.4byte sUrsaringSprites2
+.4byte sUrsaringSprites3
+.4byte sUrsaringSprites4
+.4byte sUrsaringSprites5
+.4byte sUrsaringSprites6
+.4byte sUrsaringSprites7
+.4byte sUrsaringSprites8
+.4byte sUrsaringSprites9
+.4byte sUrsaringSprites10
+.4byte sUrsaringSprites11
+.4byte sUrsaringSprites12
+.4byte sUrsaringSprites13
+.4byte sUrsaringSprites14
+.4byte sUrsaringSprites15
+.4byte sUrsaringSprites16
+.4byte sUrsaringSprites17
+.4byte sUrsaringSprites18
+.4byte sUrsaringSprites19
+.4byte sUrsaringSprites20
+.4byte sUrsaringSprites21
+.4byte sUrsaringSprites22
+.4byte sUrsaringSprites23
+.4byte sUrsaringSprites24
+.4byte sUrsaringSprites25
+.4byte sUrsaringSprites26
+.4byte sUrsaringSprites27
+.4byte sUrsaringSprites28
+.4byte sUrsaringSprites29
+.4byte sUrsaringSprites30
+.4byte sUrsaringSprites31
+.4byte sUrsaringSprites32
+.4byte sUrsaringSprites33
+.4byte sUrsaringSprites34
+.4byte sUrsaringSprites35
+.4byte sUrsaringSprites36
+.4byte sUrsaringSprites37
+.4byte sUrsaringSprites38
+.4byte sUrsaringSprites39
+.4byte sUrsaringSprites40
+.4byte sUrsaringSprites41
+.4byte sUrsaringSprites42
+.4byte sUrsaringSprites43
+.4byte sUrsaringSprites44
+.4byte sUrsaringSprites45
+.4byte sUrsaringSprites46
+.4byte sUrsaringSprites47
+.4byte sUrsaringSprites48
+.4byte sUrsaringSprites49
+.4byte sUrsaringSprites50
+.4byte sUrsaringSprites51
+.4byte sUrsaringSprites52
+.4byte sUrsaringSprites53
+.4byte sUrsaringSprites54
+.4byte sUrsaringSprites55
+.4byte sUrsaringSprites56
+.4byte sUrsaringSprites57
+.4byte sUrsaringSprites58
+.4byte sUrsaringSprites59
+.4byte sUrsaringSprites60
+.4byte sUrsaringSprites61
+.4byte sUrsaringSprites62
+.4byte sUrsaringSprites63
+.4byte sUrsaringSprites64
+.4byte sUrsaringSprites65
+.4byte sUrsaringSprites66
+.4byte sUrsaringSprites67
+.4byte sUrsaringSprites68
+.4byte sUrsaringSprites69
+.4byte sUrsaringSprites70
+.4byte sUrsaringSprites71
+.4byte sUrsaringSprites72
+.4byte sUrsaringSprites73
+sAxMainUrsaring:
+ax_main sAxPosesUrsaring, sAxAnimationsUrsaring, 13, sAxSpritesUrsaring, sAxPositionsUrsaring

--- a/data/ax/vaporeon.inc
+++ b/data/ax/vaporeon.inc
@@ -1,0 +1,2855 @@
+.global gAxVaporeon
+gAxVaporeon:
+ax_siro sAxMainVaporeon
+sVaporeonPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose4:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose5:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose6:
+ax_pose 5, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose7:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose8:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose9:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose10:
+ax_pose 9, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose11:
+ax_pose 10, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose12:
+ax_pose 11, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose13:
+ax_pose 12, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose16:
+ax_pose 9, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose17:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose18:
+ax_pose 11, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose19:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose20:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose21:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose22:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose23:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose24:
+ax_pose 5, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose28:
+ax_pose 15, 0x41dc, 0x00f4, 0x0c00
+ax_pose 16, 0x41e4, 0x00fc, 0x0c02
+ax_pose 17, 0x41ec, 0x80ed, 0x0c04
+ax_pose 18, 0x41fc, 0x40ed, 0x0c0c
+ax_pose_terminator
+sVaporeonPose29:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose30:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose31:
+ax_pose 5, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose32:
+ax_pose 19, 0x01dc, 0x10ed, 0x0c00
+ax_pose 20, 0x41e4, 0x10ec, 0x0c01
+ax_pose 21, 0x41ec, 0x90ec, 0x0c03
+ax_pose 22, 0x41fc, 0x50ec, 0x0c0b
+ax_pose_terminator
+sVaporeonPose33:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose34:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose35:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose36:
+ax_pose 23, 0x01e2, 0x10ec, 0x0c00
+ax_pose 24, 0x01e9, 0x10e4, 0x0c01
+ax_pose 25, 0x41f2, 0x90ec, 0x0c02
+ax_pose 26, 0x41ea, 0x50ec, 0x0c0a
+ax_pose_terminator
+sVaporeonPose37:
+ax_pose 9, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose38:
+ax_pose 10, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose39:
+ax_pose 11, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose40:
+ax_pose 27, 0x41f4, 0x90f1, 0x0c00
+ax_pose 28, 0x41ec, 0x50f1, 0x0c08
+ax_pose 29, 0x01f3, 0x10e9, 0x0c0c
+ax_pose 30, 0x41e4, 0x1101, 0x0c0d
+ax_pose_terminator
+sVaporeonPose41:
+ax_pose 12, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose42:
+ax_pose 13, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose43:
+ax_pose 14, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose44:
+ax_pose 31, 0x01e9, 0x80ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose45:
+ax_pose 9, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose46:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose47:
+ax_pose 11, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose48:
+ax_pose 32, 0x41ec, 0x80f0, 0x0c00
+ax_pose 33, 0x41fc, 0x40f0, 0x0c08
+ax_pose 30, 0x41e4, 0x00f0, 0x0c0c
+ax_pose 29, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sVaporeonPose49:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose50:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose51:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose52:
+ax_pose 25, 0x41f2, 0x80f4, 0x0c00
+ax_pose 26, 0x41ea, 0x40f4, 0x0c08
+ax_pose 23, 0x01e2, 0x010c, 0x0c0c
+ax_pose 24, 0x01e8, 0x0114, 0x0c0d
+ax_pose_terminator
+sVaporeonPose53:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose54:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose55:
+ax_pose 5, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose56:
+ax_pose 21, 0x41ec, 0x80f4, 0x0c00
+ax_pose 22, 0x41fc, 0x40f4, 0x0c08
+ax_pose 19, 0x01dc, 0x010b, 0x0c0c
+ax_pose 20, 0x41e4, 0x0104, 0x0c0d
+ax_pose_terminator
+sVaporeonPose57:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose58:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose59:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose60:
+ax_pose 15, 0x41dc, 0x00f4, 0x0c00
+ax_pose 16, 0x41e4, 0x00fc, 0x0c02
+ax_pose 17, 0x41ec, 0x80ed, 0x0c04
+ax_pose 18, 0x41fc, 0x40ed, 0x0c0c
+ax_pose_terminator
+sVaporeonPose61:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose62:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose63:
+ax_pose 5, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose64:
+ax_pose 19, 0x01dc, 0x10ed, 0x0c00
+ax_pose 20, 0x41e4, 0x10ec, 0x0c01
+ax_pose 21, 0x41ec, 0x90ec, 0x0c03
+ax_pose 22, 0x41fc, 0x50ec, 0x0c0b
+ax_pose_terminator
+sVaporeonPose65:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose66:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose67:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose68:
+ax_pose 23, 0x01e2, 0x10ec, 0x0c00
+ax_pose 24, 0x01e9, 0x10e4, 0x0c01
+ax_pose 25, 0x41f2, 0x90ec, 0x0c02
+ax_pose 26, 0x41ea, 0x50ec, 0x0c0a
+ax_pose_terminator
+sVaporeonPose69:
+ax_pose 9, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose70:
+ax_pose 10, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose71:
+ax_pose 11, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose72:
+ax_pose 27, 0x41f4, 0x90f1, 0x0c00
+ax_pose 28, 0x41ec, 0x50f1, 0x0c08
+ax_pose 29, 0x01f3, 0x10e9, 0x0c0c
+ax_pose 30, 0x41e4, 0x1101, 0x0c0d
+ax_pose_terminator
+sVaporeonPose73:
+ax_pose 12, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose74:
+ax_pose 13, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose75:
+ax_pose 14, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose76:
+ax_pose 31, 0x01e9, 0x80ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose77:
+ax_pose 9, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose78:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose79:
+ax_pose 11, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose80:
+ax_pose 32, 0x41ec, 0x80f0, 0x0c00
+ax_pose 33, 0x41fc, 0x40f0, 0x0c08
+ax_pose 30, 0x41e4, 0x00f0, 0x0c0c
+ax_pose 29, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sVaporeonPose81:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose82:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose83:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose84:
+ax_pose 25, 0x41f2, 0x80f4, 0x0c00
+ax_pose 26, 0x41ea, 0x40f4, 0x0c08
+ax_pose 23, 0x01e2, 0x010c, 0x0c0c
+ax_pose 24, 0x01e8, 0x0114, 0x0c0d
+ax_pose_terminator
+sVaporeonPose85:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose86:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose87:
+ax_pose 5, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose88:
+ax_pose 21, 0x41ec, 0x80f4, 0x0c00
+ax_pose 22, 0x41fc, 0x40f4, 0x0c08
+ax_pose 19, 0x01dc, 0x010b, 0x0c0c
+ax_pose 20, 0x41e4, 0x0104, 0x0c0d
+ax_pose_terminator
+sVaporeonPose89:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose90:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose91:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose92:
+ax_pose 15, 0x41dc, 0x00f4, 0x0c00
+ax_pose 16, 0x41e4, 0x00fc, 0x0c02
+ax_pose 17, 0x41ec, 0x80ed, 0x0c04
+ax_pose 18, 0x41fc, 0x40ed, 0x0c0c
+ax_pose_terminator
+sVaporeonPose93:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose94:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose95:
+ax_pose 5, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose96:
+ax_pose 19, 0x01dc, 0x10ed, 0x0c00
+ax_pose 20, 0x41e4, 0x10ec, 0x0c01
+ax_pose 21, 0x41ec, 0x90ec, 0x0c03
+ax_pose 22, 0x41fc, 0x50ec, 0x0c0b
+ax_pose_terminator
+sVaporeonPose97:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose98:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose99:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose100:
+ax_pose 23, 0x01e2, 0x10ee, 0x0c00
+ax_pose 24, 0x01e9, 0x10e6, 0x0c01
+ax_pose 25, 0x41f2, 0x90ee, 0x0c02
+ax_pose 26, 0x41ea, 0x50ee, 0x0c0a
+ax_pose_terminator
+sVaporeonPose101:
+ax_pose 9, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose102:
+ax_pose 10, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose103:
+ax_pose 11, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose104:
+ax_pose 27, 0x41f4, 0x90f1, 0x0c00
+ax_pose 28, 0x41ec, 0x50f1, 0x0c08
+ax_pose 29, 0x01f3, 0x10e9, 0x0c0c
+ax_pose 30, 0x41e4, 0x1101, 0x0c0d
+ax_pose_terminator
+sVaporeonPose105:
+ax_pose 12, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose106:
+ax_pose 13, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose107:
+ax_pose 14, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose108:
+ax_pose 31, 0x01e9, 0x80ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose109:
+ax_pose 9, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose110:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose111:
+ax_pose 11, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose112:
+ax_pose 32, 0x41ec, 0x80f0, 0x0c00
+ax_pose 33, 0x41fc, 0x40f0, 0x0c08
+ax_pose 30, 0x41e4, 0x00f0, 0x0c0c
+ax_pose 29, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sVaporeonPose113:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose114:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose115:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose116:
+ax_pose 25, 0x41f2, 0x80f2, 0x0c00
+ax_pose 26, 0x41ea, 0x40f2, 0x0c08
+ax_pose 23, 0x01e2, 0x010a, 0x0c0c
+ax_pose 24, 0x01e8, 0x0112, 0x0c0d
+ax_pose_terminator
+sVaporeonPose117:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose118:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose119:
+ax_pose 5, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose120:
+ax_pose 21, 0x41ec, 0x80f4, 0x0c00
+ax_pose 22, 0x41fc, 0x40f4, 0x0c08
+ax_pose 19, 0x01dc, 0x010b, 0x0c0c
+ax_pose 20, 0x41e4, 0x0104, 0x0c0d
+ax_pose_terminator
+sVaporeonPose121:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose122:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose123:
+ax_pose 2, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose124:
+ax_pose 34, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose125:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose126:
+ax_pose 4, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose127:
+ax_pose 5, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose128:
+ax_pose 35, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose129:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose130:
+ax_pose 7, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose131:
+ax_pose 8, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose132:
+ax_pose 36, 0x01e2, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose133:
+ax_pose 9, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose134:
+ax_pose 10, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose135:
+ax_pose 11, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose136:
+ax_pose 37, 0x41f6, 0x90ef, 0x0c00
+ax_pose 38, 0x01e6, 0x50ff, 0x0c08
+ax_pose 39, 0x81e6, 0x10f7, 0x0c0c
+ax_pose 40, 0x0206, 0x10f4, 0x0c0e
+ax_pose 41, 0x01de, 0x1100, 0x0c0f
+ax_pose_terminator
+sVaporeonPose137:
+ax_pose 12, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose138:
+ax_pose 13, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose139:
+ax_pose 14, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose140:
+ax_pose 42, 0x41e6, 0x80f0, 0x0c00
+ax_pose 43, 0x41f6, 0x00f8, 0x0c08
+ax_pose 44, 0x01de, 0x00f8, 0x0c0a
+ax_pose 45, 0x01de, 0x0100, 0x0c0b
+ax_pose 46, 0x41fe, 0x00f8, 0x0c0c
+ax_pose_terminator
+sVaporeonPose141:
+ax_pose 9, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose142:
+ax_pose 10, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose143:
+ax_pose 11, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose144:
+ax_pose 37, 0x41f6, 0x80f1, 0x0c00
+ax_pose 41, 0x01de, 0x00f8, 0x0c08
+ax_pose 40, 0x0206, 0x0104, 0x0c09
+ax_pose 38, 0x01e6, 0x40f1, 0x0c0a
+ax_pose 39, 0x81e6, 0x0101, 0x0c0e
+ax_pose_terminator
+sVaporeonPose145:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose146:
+ax_pose 7, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose147:
+ax_pose 8, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose148:
+ax_pose 36, 0x01e2, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose149:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose150:
+ax_pose 4, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose151:
+ax_pose 5, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose152:
+ax_pose 35, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose153:
+ax_pose 47, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose154:
+ax_pose 48, 0x01eb, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose155:
+ax_pose 49, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sVaporeonPose156:
+ax_pose 50, 0x01e6, 0x90ee, 0x2c00
+ax_pose_terminator
+sVaporeonPose157:
+ax_pose 51, 0x01e4, 0x90ee, 0x2c00
+ax_pose_terminator
+sVaporeonPose158:
+ax_pose 52, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sVaporeonPose159:
+ax_pose 53, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVaporeonPose160:
+ax_pose 52, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sVaporeonPose161:
+ax_pose 51, 0x01e4, 0x80f2, 0x2c00
+ax_pose_terminator
+sVaporeonPose162:
+ax_pose 50, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sVaporeonPose163:
+ax_pose 54, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose164:
+ax_pose 55, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose165:
+ax_pose 56, 0x01e2, 0x90ee, 0x0c00
+ax_pose_terminator
+sVaporeonPose166:
+ax_pose 37, 0x41f6, 0x90ee, 0x0c00
+ax_pose 38, 0x01e6, 0x50fe, 0x0c08
+ax_pose 39, 0x81e6, 0x10f6, 0x0c0c
+ax_pose 40, 0x0206, 0x10f3, 0x0c0e
+ax_pose 41, 0x01de, 0x10ff, 0x0c0f
+ax_pose_terminator
+sVaporeonPose167:
+ax_pose 42, 0x41e7, 0x80f0, 0x0c00
+ax_pose 43, 0x41f7, 0x00f8, 0x0c08
+ax_pose 44, 0x01df, 0x00f8, 0x0c0a
+ax_pose 45, 0x01df, 0x0100, 0x0c0b
+ax_pose 46, 0x41ff, 0x00f8, 0x0c0c
+ax_pose_terminator
+sVaporeonPose168:
+ax_pose 37, 0x41f6, 0x80f1, 0x0c00
+ax_pose 41, 0x01de, 0x00f8, 0x0c08
+ax_pose 40, 0x0206, 0x0104, 0x0c09
+ax_pose 38, 0x01e6, 0x40f1, 0x0c0a
+ax_pose 39, 0x81e6, 0x0101, 0x0c0e
+ax_pose_terminator
+sVaporeonPose169:
+ax_pose 56, 0x01e2, 0x80f2, 0x0c00
+ax_pose_terminator
+sVaporeonPose170:
+ax_pose 55, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose171:
+ax_pose 15, 0x41dc, 0x00f4, 0x0c00
+ax_pose 16, 0x41e4, 0x00fc, 0x0c02
+ax_pose 17, 0x41ec, 0x80ed, 0x0c04
+ax_pose 18, 0x41fc, 0x40ed, 0x0c0c
+ax_pose_terminator
+sVaporeonPose172:
+ax_pose 21, 0x41ec, 0x80f1, 0x0c00
+ax_pose 22, 0x41fc, 0x40f1, 0x0c08
+ax_pose 19, 0x01dc, 0x0108, 0x0c0c
+ax_pose 20, 0x41e4, 0x0101, 0x0c0d
+ax_pose_terminator
+sVaporeonPose173:
+ax_pose 25, 0x41f2, 0x80f2, 0x0c00
+ax_pose 26, 0x41ea, 0x40f2, 0x0c08
+ax_pose 23, 0x01e2, 0x010a, 0x0c0c
+ax_pose 24, 0x01e8, 0x0112, 0x0c0d
+ax_pose_terminator
+sVaporeonPose174:
+ax_pose 32, 0x41ec, 0x80f0, 0x0c00
+ax_pose 33, 0x41fc, 0x40f0, 0x0c08
+ax_pose 30, 0x41e4, 0x00f0, 0x0c0c
+ax_pose 29, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sVaporeonPose175:
+ax_pose 31, 0x01e7, 0x80ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose176:
+ax_pose 27, 0x41f4, 0x90f1, 0x0c00
+ax_pose 28, 0x41ec, 0x50f1, 0x0c08
+ax_pose 29, 0x01f3, 0x10e9, 0x0c0c
+ax_pose 30, 0x41e4, 0x1101, 0x0c0d
+ax_pose_terminator
+sVaporeonPose177:
+ax_pose 23, 0x01e2, 0x10ee, 0x0c00
+ax_pose 24, 0x01e8, 0x10e6, 0x0c01
+ax_pose 25, 0x41f2, 0x90ee, 0x0c02
+ax_pose 26, 0x41ea, 0x50ee, 0x0c0a
+ax_pose_terminator
+sVaporeonPose178:
+ax_pose 19, 0x01dc, 0x10f0, 0x0c00
+ax_pose 20, 0x41e4, 0x10ef, 0x0c01
+ax_pose 21, 0x41ec, 0x90ef, 0x0c03
+ax_pose 22, 0x41fc, 0x50ef, 0x0c0b
+ax_pose_terminator
+sVaporeonPose179:
+ax_pose 34, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose180:
+ax_pose 35, 0x01e4, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose181:
+ax_pose 36, 0x01e2, 0x90ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose182:
+ax_pose 37, 0x41f6, 0x90ec, 0x0c00
+ax_pose 38, 0x01e6, 0x50fc, 0x0c08
+ax_pose 39, 0x81e6, 0x10f4, 0x0c0c
+ax_pose 40, 0x0206, 0x10f1, 0x0c0e
+ax_pose 41, 0x01de, 0x10fd, 0x0c0f
+ax_pose_terminator
+sVaporeonPose183:
+ax_pose 42, 0x41e7, 0x80f0, 0x0c00
+ax_pose 43, 0x41f7, 0x00f8, 0x0c08
+ax_pose 44, 0x01df, 0x00f8, 0x0c0a
+ax_pose 45, 0x01df, 0x0100, 0x0c0b
+ax_pose 46, 0x41ff, 0x00f8, 0x0c0c
+ax_pose_terminator
+sVaporeonPose184:
+ax_pose 37, 0x41f6, 0x80f4, 0x0c00
+ax_pose 41, 0x01de, 0x00fb, 0x0c08
+ax_pose 40, 0x0206, 0x0107, 0x0c09
+ax_pose 38, 0x01e6, 0x40f4, 0x0c0a
+ax_pose 39, 0x81e6, 0x0104, 0x0c0e
+ax_pose_terminator
+sVaporeonPose185:
+ax_pose 36, 0x01e2, 0x80f3, 0x0c00
+ax_pose_terminator
+sVaporeonPose186:
+ax_pose 35, 0x01e4, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose187:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose188:
+ax_pose 1, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose189:
+ax_pose 15, 0x41dc, 0x00f4, 0x0c00
+ax_pose 16, 0x41e4, 0x00fc, 0x0c02
+ax_pose 17, 0x41ec, 0x80ed, 0x0c04
+ax_pose 18, 0x41fc, 0x40ed, 0x0c0c
+ax_pose_terminator
+sVaporeonPose190:
+ax_pose 3, 0x01e5, 0x90ef, 0x0c00
+ax_pose_terminator
+sVaporeonPose191:
+ax_pose 4, 0x01e4, 0x90ef, 0x0c00
+ax_pose_terminator
+sVaporeonPose192:
+ax_pose 19, 0x01dc, 0x10ef, 0x0c00
+ax_pose 20, 0x41e4, 0x10ee, 0x0c01
+ax_pose 21, 0x41ec, 0x90ee, 0x0c03
+ax_pose 22, 0x41fc, 0x50ee, 0x0c0b
+ax_pose_terminator
+sVaporeonPose193:
+ax_pose 6, 0x01e5, 0x90ee, 0x0c00
+ax_pose_terminator
+sVaporeonPose194:
+ax_pose 7, 0x01e5, 0x90ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose195:
+ax_pose 23, 0x01e3, 0x10ed, 0x0c00
+ax_pose 24, 0x01ea, 0x10e5, 0x0c01
+ax_pose 25, 0x41f3, 0x90ed, 0x0c02
+ax_pose 26, 0x41eb, 0x50ed, 0x0c0a
+ax_pose_terminator
+sVaporeonPose196:
+ax_pose 9, 0x01e6, 0x90ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose197:
+ax_pose 10, 0x01e6, 0x90ec, 0x0c00
+ax_pose_terminator
+sVaporeonPose198:
+ax_pose 27, 0x41f4, 0x90ef, 0x0c00
+ax_pose 28, 0x41ec, 0x50ef, 0x0c08
+ax_pose 29, 0x01f3, 0x10e7, 0x0c0c
+ax_pose 30, 0x41e4, 0x10ff, 0x0c0d
+ax_pose_terminator
+sVaporeonPose199:
+ax_pose 12, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose200:
+ax_pose 13, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose201:
+ax_pose 31, 0x01e8, 0x80ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose202:
+ax_pose 9, 0x01e6, 0x80f3, 0x0c00
+ax_pose_terminator
+sVaporeonPose203:
+ax_pose 10, 0x01e6, 0x80f4, 0x0c00
+ax_pose_terminator
+sVaporeonPose204:
+ax_pose 32, 0x41ec, 0x80f1, 0x0c00
+ax_pose 33, 0x41fc, 0x40f1, 0x0c08
+ax_pose 30, 0x41e4, 0x00f1, 0x0c0c
+ax_pose 29, 0x01f3, 0x0111, 0x0c0e
+ax_pose_terminator
+sVaporeonPose205:
+ax_pose 6, 0x01e5, 0x80f2, 0x0c00
+ax_pose_terminator
+sVaporeonPose206:
+ax_pose 7, 0x01e5, 0x80f3, 0x0c00
+ax_pose_terminator
+sVaporeonPose207:
+ax_pose 25, 0x41f3, 0x80f3, 0x0c00
+ax_pose 26, 0x41eb, 0x40f3, 0x0c08
+ax_pose 23, 0x01e3, 0x010b, 0x0c0c
+ax_pose 24, 0x01e9, 0x0113, 0x0c0d
+ax_pose_terminator
+sVaporeonPose208:
+ax_pose 3, 0x01e5, 0x80f1, 0x0c00
+ax_pose_terminator
+sVaporeonPose209:
+ax_pose 4, 0x01e4, 0x80f2, 0x0c00
+ax_pose_terminator
+sVaporeonPose210:
+ax_pose 21, 0x41ec, 0x80f2, 0x0c00
+ax_pose 22, 0x41fc, 0x40f2, 0x0c08
+ax_pose 19, 0x01dc, 0x0109, 0x0c0c
+ax_pose 20, 0x41e4, 0x0102, 0x0c0d
+ax_pose_terminator
+sVaporeonPose211:
+ax_pose 15, 0x41dc, 0x00f4, 0x0c00
+ax_pose 16, 0x41e4, 0x00fc, 0x0c02
+ax_pose 17, 0x41ec, 0x80ed, 0x0c04
+ax_pose 18, 0x41fc, 0x40ed, 0x0c0c
+ax_pose_terminator
+sVaporeonPose212:
+ax_pose 21, 0x41ec, 0x80f1, 0x0c00
+ax_pose 22, 0x41fc, 0x40f1, 0x0c08
+ax_pose 19, 0x01dc, 0x0108, 0x0c0c
+ax_pose 20, 0x41e4, 0x0101, 0x0c0d
+ax_pose_terminator
+sVaporeonPose213:
+ax_pose 25, 0x41f2, 0x80f2, 0x0c00
+ax_pose 26, 0x41ea, 0x40f2, 0x0c08
+ax_pose 23, 0x01e2, 0x010a, 0x0c0c
+ax_pose 24, 0x01e8, 0x0112, 0x0c0d
+ax_pose_terminator
+sVaporeonPose214:
+ax_pose 32, 0x41ec, 0x80f0, 0x0c00
+ax_pose 33, 0x41fc, 0x40f0, 0x0c08
+ax_pose 30, 0x41e4, 0x00f0, 0x0c0c
+ax_pose 29, 0x01f3, 0x0110, 0x0c0e
+ax_pose_terminator
+sVaporeonPose215:
+ax_pose 31, 0x01e9, 0x80ed, 0x0c00
+ax_pose_terminator
+sVaporeonPose216:
+ax_pose 27, 0x41f4, 0x90f1, 0x0c00
+ax_pose 28, 0x41ec, 0x50f1, 0x0c08
+ax_pose 29, 0x01f3, 0x10e9, 0x0c0c
+ax_pose 30, 0x41e4, 0x1101, 0x0c0d
+ax_pose_terminator
+sVaporeonPose217:
+ax_pose 23, 0x01e2, 0x10ee, 0x0c00
+ax_pose 24, 0x01e8, 0x10e6, 0x0c01
+ax_pose 25, 0x41f2, 0x90ee, 0x0c02
+ax_pose 26, 0x41ea, 0x50ee, 0x0c0a
+ax_pose_terminator
+sVaporeonPose218:
+ax_pose 19, 0x01dc, 0x10f0, 0x0c00
+ax_pose 20, 0x41e4, 0x10ef, 0x0c01
+ax_pose 21, 0x41ec, 0x90ef, 0x0c03
+ax_pose 22, 0x41fc, 0x50ef, 0x0c0b
+ax_pose_terminator
+sVaporeonPose219:
+ax_pose 0, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose220:
+ax_pose 3, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose221:
+ax_pose 6, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose222:
+ax_pose 9, 0x01e6, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose223:
+ax_pose 12, 0x01e5, 0x80f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose224:
+ax_pose 9, 0x01e6, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose225:
+ax_pose 6, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+sVaporeonPose226:
+ax_pose 3, 0x01e5, 0x90f0, 0x0c00
+ax_pose_terminator
+.align 2
+sVaporeonAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sVaporeonAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 1, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 31, 18, 18, 18, 18,
+ax_anim 2, 0, 31, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sVaporeonAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 1, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 35, 18, 0, 18, 0,
+ax_anim 2, 0, 35, 18, 1, 18, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sVaporeonAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -6, 4, -6,
+ax_anim 1, 0, 38, 10, -13, 10, -13,
+ax_anim 2, 0, 39, 15, -19, 15, -19,
+ax_anim 2, 1, 39, 16, -18, 16, -18,
+ax_anim 2, 0, 39, 15, -19, 15, -19,
+ax_anim 2, 0, 39, 16, -18, 16, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sVaporeonAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sVaporeonAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -6, -4, -6,
+ax_anim 1, 0, 46, -10, -13, -10, -13,
+ax_anim 2, 0, 47, -15, -19, -15, -19,
+ax_anim 2, 1, 47, -16, -18, -16, -18,
+ax_anim 2, 0, 47, -15, -19, -15, -19,
+ax_anim 2, 0, 47, -16, -18, -16, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sVaporeonAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 1, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 51, -18, 0, -18, 0,
+ax_anim 2, 0, 51, -18, 1, -18, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sVaporeonAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 1, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 55, -18, 18, -18, 18,
+ax_anim 2, 0, 55, -19, 17, -19, 17,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 1, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 18, 0, 18,
+ax_anim 2, 0, 59, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sVaporeonAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 1, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 63, 18, 18, 18, 18,
+ax_anim 2, 0, 63, 19, 17, 19, 17,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sVaporeonAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 1, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 67, 18, 0, 18, 0,
+ax_anim 2, 0, 67, 18, 1, 18, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sVaporeonAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -6, 4, -6,
+ax_anim 1, 0, 70, 10, -13, 10, -13,
+ax_anim 2, 0, 71, 15, -19, 15, -19,
+ax_anim 2, 1, 71, 16, -18, 16, -18,
+ax_anim 2, 0, 71, 15, -19, 15, -19,
+ax_anim 2, 0, 71, 16, -18, 16, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sVaporeonAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -15, 0, -15,
+ax_anim 2, 1, 75, 1, -15, 1, -15,
+ax_anim 2, 0, 75, 0, -15, 0, -15,
+ax_anim 2, 0, 75, 1, -15, 1, -15,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sVaporeonAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -6, -4, -6,
+ax_anim 1, 0, 78, -10, -13, -10, -13,
+ax_anim 2, 0, 79, -15, -19, -15, -19,
+ax_anim 2, 1, 79, -16, -18, -16, -18,
+ax_anim 2, 0, 79, -15, -19, -15, -19,
+ax_anim 2, 0, 79, -16, -18, -16, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sVaporeonAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 1, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 83, -18, 0, -18, 0,
+ax_anim 2, 0, 83, -18, 1, -18, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sVaporeonAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 1, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 87, -18, 18, -18, 18,
+ax_anim 2, 0, 87, -19, 17, -19, 17,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_4_1:
+ax_anim 2, 0, 90, 0, -1, 0, -1,
+ax_anim 2, 0, 90, 0, -3, 0, -3,
+ax_anim 6, 2, 90, 0, -4, 0, -4,
+ax_anim 1, 0, 91, 0, -1, 0, -1,
+ax_anim 2, 0, 91, 0, 4, 0, 4,
+ax_anim 2, 1, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 91, 0, 5, 0, 5,
+ax_anim 2, 0, 91, 1, 5, 1, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sVaporeonAnims_4_2:
+ax_anim 2, 0, 94, -1, -1, -1, -1,
+ax_anim 2, 0, 94, -3, -3, -3, -3,
+ax_anim 6, 2, 94, -4, -4, -4, -4,
+ax_anim 1, 0, 95, -1, -1, -1, -1,
+ax_anim 2, 0, 95, 4, 4, 4, 4,
+ax_anim 2, 1, 95, 6, 6, 6, 6,
+ax_anim 2, 0, 95, 7, 5, 7, 5,
+ax_anim 2, 0, 95, 6, 6, 6, 6,
+ax_anim 2, 0, 95, 7, 5, 7, 5,
+ax_anim 2, 0, 95, 6, 6, 6, 6,
+ax_anim 2, 0, 95, 7, 5, 7, 5,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim_terminator
+sVaporeonAnims_4_3:
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 98, -3, 0, -3, 0,
+ax_anim 6, 2, 98, -4, 0, -4, 0,
+ax_anim 1, 0, 99, -1, 0, -1, 0,
+ax_anim 2, 0, 99, 4, 0, 4, 0,
+ax_anim 2, 1, 99, 6, 0, 6, 0,
+ax_anim 2, 0, 99, 6, 1, 6, 1,
+ax_anim 2, 0, 99, 6, 0, 6, 0,
+ax_anim 2, 0, 99, 6, 1, 6, 1,
+ax_anim 2, 0, 99, 6, 0, 6, 0,
+ax_anim 2, 0, 99, 6, 1, 6, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim_terminator
+sVaporeonAnims_4_4:
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim 2, 0, 102, -3, 3, -3, 3,
+ax_anim 6, 2, 102, -4, 4, -4, 4,
+ax_anim 1, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 1, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 103, 7, -5, 7, -5,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 103, 7, -5, 7, -5,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 103, 7, -5, 7, -5,
+ax_anim 2, 0, 100, 2, -2, 2, -2,
+ax_anim_terminator
+sVaporeonAnims_4_5:
+ax_anim 2, 0, 106, 0, 1, 0, 1,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 6, 2, 106, 0, 4, 0, 4,
+ax_anim 1, 0, 107, 0, 1, 0, 1,
+ax_anim 2, 0, 107, 0, -4, 0, -4,
+ax_anim 2, 1, 107, 0, -6, 0, -5,
+ax_anim 2, 0, 107, 1, -6, 1, -5,
+ax_anim 2, 0, 107, 0, -6, 0, -5,
+ax_anim 2, 0, 107, 1, -6, 1, -5,
+ax_anim 2, 0, 107, 0, -6, 0, -5,
+ax_anim 2, 0, 107, 1, -6, 1, -5,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sVaporeonAnims_4_6:
+ax_anim 2, 0, 110, 1, 1, 1, 1,
+ax_anim 2, 0, 110, 3, 3, 3, 3,
+ax_anim 6, 2, 110, 4, 4, 4, 4,
+ax_anim 1, 0, 111, 1, 1, 1, 1,
+ax_anim 2, 0, 111, -4, -4, -4, -4,
+ax_anim 2, 1, 111, -6, -6, -6, -6,
+ax_anim 2, 0, 111, -7, -5, -7, -5,
+ax_anim 2, 0, 111, -6, -6, -6, -6,
+ax_anim 2, 0, 111, -7, -5, -7, -5,
+ax_anim 2, 0, 111, -6, -6, -6, -6,
+ax_anim 2, 0, 111, -7, -5, -7, -5,
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim_terminator
+sVaporeonAnims_4_7:
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 3, 0, 3, 0,
+ax_anim 6, 2, 114, 4, 0, 4, 0,
+ax_anim 1, 0, 115, 1, 0, 1, 0,
+ax_anim 2, 0, 115, -4, 0, -4, 0,
+ax_anim 2, 1, 115, -6, 0, -6, 0,
+ax_anim 2, 0, 115, -6, 1, -6, 1,
+ax_anim 2, 0, 115, -6, 0, -6, 0,
+ax_anim 2, 0, 115, -6, 1, -6, 1,
+ax_anim 2, 0, 115, -6, 0, -6, 0,
+ax_anim 2, 0, 115, -6, 1, -6, 1,
+ax_anim 2, 0, 112, -2, 0, -2, 0,
+ax_anim_terminator
+sVaporeonAnims_4_8:
+ax_anim 2, 0, 118, 1, -1, 1, -1,
+ax_anim 2, 0, 118, 3, -3, 3, -3,
+ax_anim 6, 2, 118, 4, -4, 4, -4,
+ax_anim 1, 0, 119, 1, -1, 1, -1,
+ax_anim 2, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 1, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, -7, 5, -7, 5,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, -7, 5, -7, 5,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, -7, 5, -7, 5,
+ax_anim 2, 0, 116, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_5_1:
+ax_anim 10, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_5_2:
+ax_anim 10, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 1, -1, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, -1, -1, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_5_3:
+ax_anim 10, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -1, 0, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_5_4:
+ax_anim 10, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 135, -1, -1, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_5_5:
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, -1, 0, -1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_5_6:
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, -1, 1, -1,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_5_7:
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, -1,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_5_8:
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, -1, -1, -1, -1,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sVaporeonAnims_7_2:
+ax_anim 2, 0, 155, -2, -2, -2, -2,
+ax_anim 8, 0, 155, -3, -3, -3, -3,
+ax_anim_terminator
+sVaporeonAnims_7_3:
+ax_anim 2, 0, 156, -2, 0, -2, 0,
+ax_anim 8, 0, 156, -3, 0, -3, 0,
+ax_anim_terminator
+sVaporeonAnims_7_4:
+ax_anim 2, 0, 157, -2, 2, -2, 2,
+ax_anim 8, 0, 157, -3, 3, -3, 3,
+ax_anim_terminator
+sVaporeonAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sVaporeonAnims_7_6:
+ax_anim 2, 0, 159, 2, 2, 2, 2,
+ax_anim 8, 0, 159, 3, 3, 3, 3,
+ax_anim_terminator
+sVaporeonAnims_7_7:
+ax_anim 2, 0, 160, 2, 0, 2, 0,
+ax_anim 8, 0, 160, 3, 0, 3, 0,
+ax_anim_terminator
+sVaporeonAnims_7_8:
+ax_anim 2, 0, 161, 2, -2, 2, -2,
+ax_anim 8, 0, 161, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_8_1:
+ax_anim 30, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_8_2:
+ax_anim 30, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_8_3:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_8_4:
+ax_anim 30, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_8_5:
+ax_anim 30, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_8_6:
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_8_7:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_8_8:
+ax_anim 30, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 10, 3, 10, 3,
+ax_anim 2, 0, 172, 14, 9, 14, 9,
+ax_anim 2, 0, 173, 11, 17, 11, 17,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -11, 17, -11, 17,
+ax_anim 2, 0, 176, -14, 9, -14, 9,
+ax_anim 1, 0, 177, -10, 3, -10, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 12, 0, 12, 0,
+ax_anim 2, 0, 171, 21, 3, 21, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 21, 19, 21, 19,
+ax_anim 2, 3, 174, 13, 21, 13, 21,
+ax_anim 2, 0, 175, 1, 15, 1, 15,
+ax_anim 1, 0, 176, 0, 8, 0, 8,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 12, -6, 12, -6,
+ax_anim 2, 0, 171, 21, -5, 21, -5,
+ax_anim 3, 0, 172, 22, 0, 22, 0,
+ax_anim 2, 3, 173, 18, 6, 18, 6,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 3, 6, 3, 6,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 1, -15, 1, -15,
+ax_anim 2, 0, 170, 12, -19, 12, -19,
+ax_anim 3, 0, 171, 23, -20, 23, -20,
+ax_anim 2, 3, 172, 26, -12, 26, -12,
+ax_anim 2, 0, 173, 22, -4, 22, -4,
+ax_anim 1, 0, 174, 12, 1, 12, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -11, -3, -11, -3,
+ax_anim 2, 0, 176, -13, -12, -13, -12,
+ax_anim 2, 0, 177, -11, -18, -11, -18,
+ax_anim 3, 0, 170, 0, -20, 0, -20,
+ax_anim 2, 3, 171, 12, -17, 12, -17,
+ax_anim 2, 0, 172, 13, -12, 13, -12,
+ax_anim 1, 0, 173, 11, -3, 11, -3,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -1, -15, -1, -15,
+ax_anim 2, 0, 170, -12, -19, -12, -19,
+ax_anim 3, 0, 177, -23, -20, -23, -20,
+ax_anim 2, 3, 176, -26, -12, -26, -12,
+ax_anim 2, 0, 175, -22, -4, -22, -4,
+ax_anim 1, 0, 174, -12, -1, -12, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -12, -6, -12, -6,
+ax_anim 2, 0, 177, -21, -5, -21, -5,
+ax_anim 3, 0, 176, -22, 0, -22, 0,
+ax_anim 2, 3, 175, -18, 6, -18, 6,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -3, 6, -3, 6,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 177, -21, 3, -21, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -21, 19, -21, 19,
+ax_anim 2, 3, 174, -13, 21, -13, 21,
+ax_anim 2, 0, 173, -1, 15, -1, 15,
+ax_anim 1, 0, 172, 0, 8, 0, 8,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -7, 0, 0,
+ax_anim 2, 0, 187, 0, -13, 0, 0,
+ax_anim 3, 0, 187, 0, -17, 0, 0,
+ax_anim 4, 0, 187, 0, -18, 0, 0,
+ax_anim 4, 0, 186, 0, -18, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -9, 0, 0,
+ax_anim 2, 0, 193, 0, -15, 0, 0,
+ax_anim 3, 0, 193, 0, -19, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 4, 0, 192, 0, -25, 0, 0,
+ax_anim 3, 0, 194, 0, -24, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -24, 0, 0,
+ax_anim 3, 0, 197, 0, -23, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 4, 0, 198, 0, -25, 0, 0,
+ax_anim 3, 0, 200, 0, -23, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -24, 0, 0,
+ax_anim 3, 0, 203, 0, -23, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -9, 0, 0,
+ax_anim 2, 0, 205, 0, -15, 0, 0,
+ax_anim 3, 0, 205, 0, -19, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 4, 0, 204, 0, -25, 0, 0,
+ax_anim 3, 0, 206, 0, -24, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -22, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVaporeonAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sVaporeonGfx1:
+.incbin "baserom.gba", 0xACFE30, 0x200
+sVaporeonSprites1:
+ax_sprite sVaporeonGfx1, 0x200
+ax_sprite_terminator
+sVaporeonGfx2:
+.incbin "baserom.gba", 0xAD0040, 0x200
+sVaporeonSprites2:
+ax_sprite sVaporeonGfx2, 0x200
+ax_sprite_terminator
+sVaporeonGfx3:
+.incbin "baserom.gba", 0xAD0250, 0x200
+sVaporeonSprites3:
+ax_sprite sVaporeonGfx3, 0x200
+ax_sprite_terminator
+sVaporeonGfx4:
+.incbin "baserom.gba", 0xAD0460, 0x200
+sVaporeonSprites4:
+ax_sprite sVaporeonGfx4, 0x200
+ax_sprite_terminator
+sVaporeonGfx5:
+.incbin "baserom.gba", 0xAD0670, 0x200
+sVaporeonSprites5:
+ax_sprite sVaporeonGfx5, 0x200
+ax_sprite_terminator
+sVaporeonGfx6:
+.incbin "baserom.gba", 0xAD0880, 0x200
+sVaporeonSprites6:
+ax_sprite sVaporeonGfx6, 0x200
+ax_sprite_terminator
+sVaporeonGfx7:
+.incbin "baserom.gba", 0xAD0A90, 0x200
+sVaporeonSprites7:
+ax_sprite sVaporeonGfx7, 0x200
+ax_sprite_terminator
+sVaporeonGfx8:
+.incbin "baserom.gba", 0xAD0CA0, 0x200
+sVaporeonSprites8:
+ax_sprite sVaporeonGfx8, 0x200
+ax_sprite_terminator
+sVaporeonGfx9:
+.incbin "baserom.gba", 0xAD0EB0, 0x200
+sVaporeonSprites9:
+ax_sprite sVaporeonGfx9, 0x200
+ax_sprite_terminator
+sVaporeonGfx10:
+.incbin "baserom.gba", 0xAD10C0, 0x200
+sVaporeonSprites10:
+ax_sprite sVaporeonGfx10, 0x200
+ax_sprite_terminator
+sVaporeonGfx11:
+.incbin "baserom.gba", 0xAD12D0, 0x200
+sVaporeonSprites11:
+ax_sprite sVaporeonGfx11, 0x200
+ax_sprite_terminator
+sVaporeonGfx12:
+.incbin "baserom.gba", 0xAD14E0, 0x200
+sVaporeonSprites12:
+ax_sprite sVaporeonGfx12, 0x200
+ax_sprite_terminator
+sVaporeonGfx13:
+.incbin "baserom.gba", 0xAD16F0, 0x200
+sVaporeonSprites13:
+ax_sprite sVaporeonGfx13, 0x200
+ax_sprite_terminator
+sVaporeonGfx14:
+.incbin "baserom.gba", 0xAD1900, 0x200
+sVaporeonSprites14:
+ax_sprite sVaporeonGfx14, 0x200
+ax_sprite_terminator
+sVaporeonGfx15:
+.incbin "baserom.gba", 0xAD1B10, 0x200
+sVaporeonSprites15:
+ax_sprite sVaporeonGfx15, 0x200
+ax_sprite_terminator
+sVaporeonGfx16:
+.incbin "baserom.gba", 0xAD1D20, 0x40
+sVaporeonSprites16:
+ax_sprite sVaporeonGfx16, 0x40
+ax_sprite_terminator
+sVaporeonGfx17:
+.incbin "baserom.gba", 0xAD1D70, 0x20
+sVaporeonSprites17:
+ax_sprite sVaporeonGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVaporeonGfx18:
+.incbin "baserom.gba", 0xAD1DA8, 0xE0
+sVaporeonSprites18:
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx18, 0xe0
+ax_sprite_terminator
+sVaporeonGfx19:
+.incbin "baserom.gba", 0xAD1EA0, 0x60
+sVaporeonSprites19:
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx19, 0x60
+ax_sprite_terminator
+sVaporeonGfx20:
+.incbin "baserom.gba", 0xAD1F18, 0x20
+sVaporeonSprites20:
+ax_sprite sVaporeonGfx20, 0x20
+ax_sprite_terminator
+sVaporeonGfx21:
+.incbin "baserom.gba", 0xAD1F48, 0x40
+sVaporeonSprites21:
+ax_sprite sVaporeonGfx21, 0x40
+ax_sprite_terminator
+sVaporeonGfx22:
+.incbin "baserom.gba", 0xAD1F98, 0x100
+sVaporeonSprites22:
+ax_sprite sVaporeonGfx22, 0x100
+ax_sprite_terminator
+sVaporeonGfx23:
+.incbin "baserom.gba", 0xAD20A8, 0x60
+sVaporeonSprites23:
+ax_sprite sVaporeonGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVaporeonGfx24:
+.incbin "baserom.gba", 0xAD2120, 0x20
+sVaporeonSprites24:
+ax_sprite sVaporeonGfx24, 0x20
+ax_sprite_terminator
+sVaporeonGfx25:
+.incbin "baserom.gba", 0xAD2150, 0x20
+sVaporeonSprites25:
+ax_sprite sVaporeonGfx25, 0x20
+ax_sprite_terminator
+sVaporeonGfx26:
+.incbin "baserom.gba", 0xAD2180, 0x100
+sVaporeonSprites26:
+ax_sprite sVaporeonGfx26, 0x100
+ax_sprite_terminator
+sVaporeonGfx27:
+.incbin "baserom.gba", 0xAD2290, 0x40
+sVaporeonGfx27_1:
+.incbin "baserom.gba", 0xAD22D0, 0x20
+sVaporeonSprites27:
+ax_sprite sVaporeonGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx27_1, 0x20
+ax_sprite_terminator
+sVaporeonGfx28:
+.incbin "baserom.gba", 0xAD2310, 0x80
+sVaporeonGfx28_1:
+.incbin "baserom.gba", 0xAD2390, 0x60
+sVaporeonSprites28:
+ax_sprite sVaporeonGfx28, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx28_1, 0x60
+ax_sprite_terminator
+sVaporeonGfx29:
+.incbin "baserom.gba", 0xAD2410, 0x60
+sVaporeonSprites29:
+ax_sprite sVaporeonGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVaporeonGfx30:
+.incbin "baserom.gba", 0xAD2488, 0x20
+sVaporeonSprites30:
+ax_sprite sVaporeonGfx30, 0x20
+ax_sprite_terminator
+sVaporeonGfx31:
+.incbin "baserom.gba", 0xAD24B8, 0x20
+sVaporeonSprites31:
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx31, 0x20
+ax_sprite_terminator
+sVaporeonGfx32:
+.incbin "baserom.gba", 0xAD24F0, 0x100
+sVaporeonGfx32_1:
+.incbin "baserom.gba", 0xAD25F0, 0x60
+sVaporeonGfx32_2:
+.incbin "baserom.gba", 0xAD2650, 0x60
+sVaporeonSprites32:
+ax_sprite sVaporeonGfx32, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx32_2, 0x60
+ax_sprite_terminator
+sVaporeonGfx33:
+.incbin "baserom.gba", 0xAD26E0, 0x60
+sVaporeonGfx33_1:
+.incbin "baserom.gba", 0xAD2740, 0x80
+sVaporeonSprites33:
+ax_sprite sVaporeonGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx33_1, 0x80
+ax_sprite_terminator
+sVaporeonGfx34:
+.incbin "baserom.gba", 0xAD27E0, 0x60
+sVaporeonSprites34:
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx34, 0x60
+ax_sprite_terminator
+sVaporeonGfx35:
+.incbin "baserom.gba", 0xAD2858, 0x160
+sVaporeonGfx35_1:
+.incbin "baserom.gba", 0xAD29B8, 0x40
+sVaporeonSprites35:
+ax_sprite sVaporeonGfx35, 0x160
+ax_sprite 0, 0x40
+ax_sprite sVaporeonGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVaporeonGfx36:
+.incbin "baserom.gba", 0xAD2A20, 0x180
+sVaporeonGfx36_1:
+.incbin "baserom.gba", 0xAD2BA0, 0x60
+sVaporeonSprites36:
+ax_sprite sVaporeonGfx36, 0x180
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx36_1, 0x60
+ax_sprite_terminator
+sVaporeonGfx37:
+.incbin "baserom.gba", 0xAD2C20, 0x20
+sVaporeonGfx37_1:
+.incbin "baserom.gba", 0xAD2C40, 0x180
+sVaporeonSprites37:
+ax_sprite 0, 0x20
+ax_sprite sVaporeonGfx37, 0x20
+ax_sprite 0, 0x40
+ax_sprite sVaporeonGfx37_1, 0x180
+ax_sprite_terminator
+sVaporeonGfx38:
+.incbin "baserom.gba", 0xAD2DE8, 0x100
+sVaporeonSprites38:
+ax_sprite sVaporeonGfx38, 0x100
+ax_sprite_terminator
+sVaporeonGfx39:
+.incbin "baserom.gba", 0xAD2EF8, 0x80
+sVaporeonSprites39:
+ax_sprite sVaporeonGfx39, 0x80
+ax_sprite_terminator
+sVaporeonGfx40:
+.incbin "baserom.gba", 0xAD2F88, 0x40
+sVaporeonSprites40:
+ax_sprite sVaporeonGfx40, 0x40
+ax_sprite_terminator
+sVaporeonGfx41:
+.incbin "baserom.gba", 0xAD2FD8, 0x20
+sVaporeonSprites41:
+ax_sprite sVaporeonGfx41, 0x20
+ax_sprite_terminator
+sVaporeonGfx42:
+.incbin "baserom.gba", 0xAD3008, 0x20
+sVaporeonSprites42:
+ax_sprite sVaporeonGfx42, 0x20
+ax_sprite_terminator
+sVaporeonGfx43:
+.incbin "baserom.gba", 0xAD3038, 0x100
+sVaporeonSprites43:
+ax_sprite sVaporeonGfx43, 0x100
+ax_sprite_terminator
+sVaporeonGfx44:
+.incbin "baserom.gba", 0xAD3148, 0x40
+sVaporeonSprites44:
+ax_sprite sVaporeonGfx44, 0x40
+ax_sprite_terminator
+sVaporeonGfx45:
+.incbin "baserom.gba", 0xAD3198, 0x20
+sVaporeonSprites45:
+ax_sprite sVaporeonGfx45, 0x20
+ax_sprite_terminator
+sVaporeonGfx46:
+.incbin "baserom.gba", 0xAD31C8, 0x20
+sVaporeonSprites46:
+ax_sprite sVaporeonGfx46, 0x20
+ax_sprite_terminator
+sVaporeonGfx47:
+.incbin "baserom.gba", 0xAD31F8, 0x40
+sVaporeonSprites47:
+ax_sprite sVaporeonGfx47, 0x40
+ax_sprite_terminator
+sVaporeonGfx48:
+.incbin "baserom.gba", 0xAD3248, 0x200
+sVaporeonSprites48:
+ax_sprite sVaporeonGfx48, 0x200
+ax_sprite_terminator
+sVaporeonGfx49:
+.incbin "baserom.gba", 0xAD3458, 0x200
+sVaporeonSprites49:
+ax_sprite sVaporeonGfx49, 0x200
+ax_sprite_terminator
+sVaporeonGfx50:
+.incbin "baserom.gba", 0xAD3668, 0x200
+sVaporeonSprites50:
+ax_sprite sVaporeonGfx50, 0x200
+ax_sprite_terminator
+sVaporeonGfx51:
+.incbin "baserom.gba", 0xAD3878, 0x200
+sVaporeonSprites51:
+ax_sprite sVaporeonGfx51, 0x200
+ax_sprite_terminator
+sVaporeonGfx52:
+.incbin "baserom.gba", 0xAD3A88, 0x200
+sVaporeonSprites52:
+ax_sprite sVaporeonGfx52, 0x200
+ax_sprite_terminator
+sVaporeonGfx53:
+.incbin "baserom.gba", 0xAD3C98, 0x200
+sVaporeonSprites53:
+ax_sprite sVaporeonGfx53, 0x200
+ax_sprite_terminator
+sVaporeonGfx54:
+.incbin "baserom.gba", 0xAD3EA8, 0x200
+sVaporeonSprites54:
+ax_sprite sVaporeonGfx54, 0x200
+ax_sprite_terminator
+sVaporeonGfx55:
+.incbin "baserom.gba", 0xAD40B8, 0x200
+sVaporeonSprites55:
+ax_sprite sVaporeonGfx55, 0x200
+ax_sprite_terminator
+sVaporeonGfx56:
+.incbin "baserom.gba", 0xAD42C8, 0x200
+sVaporeonSprites56:
+ax_sprite sVaporeonGfx56, 0x200
+ax_sprite_terminator
+sVaporeonGfx57:
+.incbin "baserom.gba", 0xAD44D8, 0x200
+sVaporeonSprites57:
+ax_sprite sVaporeonGfx57, 0x200
+ax_sprite_terminator
+sAxPosesVaporeon:
+.4byte sVaporeonPose1
+.4byte sVaporeonPose2
+.4byte sVaporeonPose3
+.4byte sVaporeonPose4
+.4byte sVaporeonPose5
+.4byte sVaporeonPose6
+.4byte sVaporeonPose7
+.4byte sVaporeonPose8
+.4byte sVaporeonPose9
+.4byte sVaporeonPose10
+.4byte sVaporeonPose11
+.4byte sVaporeonPose12
+.4byte sVaporeonPose13
+.4byte sVaporeonPose14
+.4byte sVaporeonPose15
+.4byte sVaporeonPose16
+.4byte sVaporeonPose17
+.4byte sVaporeonPose18
+.4byte sVaporeonPose19
+.4byte sVaporeonPose20
+.4byte sVaporeonPose21
+.4byte sVaporeonPose22
+.4byte sVaporeonPose23
+.4byte sVaporeonPose24
+.4byte sVaporeonPose25
+.4byte sVaporeonPose26
+.4byte sVaporeonPose27
+.4byte sVaporeonPose28
+.4byte sVaporeonPose29
+.4byte sVaporeonPose30
+.4byte sVaporeonPose31
+.4byte sVaporeonPose32
+.4byte sVaporeonPose33
+.4byte sVaporeonPose34
+.4byte sVaporeonPose35
+.4byte sVaporeonPose36
+.4byte sVaporeonPose37
+.4byte sVaporeonPose38
+.4byte sVaporeonPose39
+.4byte sVaporeonPose40
+.4byte sVaporeonPose41
+.4byte sVaporeonPose42
+.4byte sVaporeonPose43
+.4byte sVaporeonPose44
+.4byte sVaporeonPose45
+.4byte sVaporeonPose46
+.4byte sVaporeonPose47
+.4byte sVaporeonPose48
+.4byte sVaporeonPose49
+.4byte sVaporeonPose50
+.4byte sVaporeonPose51
+.4byte sVaporeonPose52
+.4byte sVaporeonPose53
+.4byte sVaporeonPose54
+.4byte sVaporeonPose55
+.4byte sVaporeonPose56
+.4byte sVaporeonPose57
+.4byte sVaporeonPose58
+.4byte sVaporeonPose59
+.4byte sVaporeonPose60
+.4byte sVaporeonPose61
+.4byte sVaporeonPose62
+.4byte sVaporeonPose63
+.4byte sVaporeonPose64
+.4byte sVaporeonPose65
+.4byte sVaporeonPose66
+.4byte sVaporeonPose67
+.4byte sVaporeonPose68
+.4byte sVaporeonPose69
+.4byte sVaporeonPose70
+.4byte sVaporeonPose71
+.4byte sVaporeonPose72
+.4byte sVaporeonPose73
+.4byte sVaporeonPose74
+.4byte sVaporeonPose75
+.4byte sVaporeonPose76
+.4byte sVaporeonPose77
+.4byte sVaporeonPose78
+.4byte sVaporeonPose79
+.4byte sVaporeonPose80
+.4byte sVaporeonPose81
+.4byte sVaporeonPose82
+.4byte sVaporeonPose83
+.4byte sVaporeonPose84
+.4byte sVaporeonPose85
+.4byte sVaporeonPose86
+.4byte sVaporeonPose87
+.4byte sVaporeonPose88
+.4byte sVaporeonPose89
+.4byte sVaporeonPose90
+.4byte sVaporeonPose91
+.4byte sVaporeonPose92
+.4byte sVaporeonPose93
+.4byte sVaporeonPose94
+.4byte sVaporeonPose95
+.4byte sVaporeonPose96
+.4byte sVaporeonPose97
+.4byte sVaporeonPose98
+.4byte sVaporeonPose99
+.4byte sVaporeonPose100
+.4byte sVaporeonPose101
+.4byte sVaporeonPose102
+.4byte sVaporeonPose103
+.4byte sVaporeonPose104
+.4byte sVaporeonPose105
+.4byte sVaporeonPose106
+.4byte sVaporeonPose107
+.4byte sVaporeonPose108
+.4byte sVaporeonPose109
+.4byte sVaporeonPose110
+.4byte sVaporeonPose111
+.4byte sVaporeonPose112
+.4byte sVaporeonPose113
+.4byte sVaporeonPose114
+.4byte sVaporeonPose115
+.4byte sVaporeonPose116
+.4byte sVaporeonPose117
+.4byte sVaporeonPose118
+.4byte sVaporeonPose119
+.4byte sVaporeonPose120
+.4byte sVaporeonPose121
+.4byte sVaporeonPose122
+.4byte sVaporeonPose123
+.4byte sVaporeonPose124
+.4byte sVaporeonPose125
+.4byte sVaporeonPose126
+.4byte sVaporeonPose127
+.4byte sVaporeonPose128
+.4byte sVaporeonPose129
+.4byte sVaporeonPose130
+.4byte sVaporeonPose131
+.4byte sVaporeonPose132
+.4byte sVaporeonPose133
+.4byte sVaporeonPose134
+.4byte sVaporeonPose135
+.4byte sVaporeonPose136
+.4byte sVaporeonPose137
+.4byte sVaporeonPose138
+.4byte sVaporeonPose139
+.4byte sVaporeonPose140
+.4byte sVaporeonPose141
+.4byte sVaporeonPose142
+.4byte sVaporeonPose143
+.4byte sVaporeonPose144
+.4byte sVaporeonPose145
+.4byte sVaporeonPose146
+.4byte sVaporeonPose147
+.4byte sVaporeonPose148
+.4byte sVaporeonPose149
+.4byte sVaporeonPose150
+.4byte sVaporeonPose151
+.4byte sVaporeonPose152
+.4byte sVaporeonPose153
+.4byte sVaporeonPose154
+.4byte sVaporeonPose155
+.4byte sVaporeonPose156
+.4byte sVaporeonPose157
+.4byte sVaporeonPose158
+.4byte sVaporeonPose159
+.4byte sVaporeonPose160
+.4byte sVaporeonPose161
+.4byte sVaporeonPose162
+.4byte sVaporeonPose163
+.4byte sVaporeonPose164
+.4byte sVaporeonPose165
+.4byte sVaporeonPose166
+.4byte sVaporeonPose167
+.4byte sVaporeonPose168
+.4byte sVaporeonPose169
+.4byte sVaporeonPose170
+.4byte sVaporeonPose171
+.4byte sVaporeonPose172
+.4byte sVaporeonPose173
+.4byte sVaporeonPose174
+.4byte sVaporeonPose175
+.4byte sVaporeonPose176
+.4byte sVaporeonPose177
+.4byte sVaporeonPose178
+.4byte sVaporeonPose179
+.4byte sVaporeonPose180
+.4byte sVaporeonPose181
+.4byte sVaporeonPose182
+.4byte sVaporeonPose183
+.4byte sVaporeonPose184
+.4byte sVaporeonPose185
+.4byte sVaporeonPose186
+.4byte sVaporeonPose187
+.4byte sVaporeonPose188
+.4byte sVaporeonPose189
+.4byte sVaporeonPose190
+.4byte sVaporeonPose191
+.4byte sVaporeonPose192
+.4byte sVaporeonPose193
+.4byte sVaporeonPose194
+.4byte sVaporeonPose195
+.4byte sVaporeonPose196
+.4byte sVaporeonPose197
+.4byte sVaporeonPose198
+.4byte sVaporeonPose199
+.4byte sVaporeonPose200
+.4byte sVaporeonPose201
+.4byte sVaporeonPose202
+.4byte sVaporeonPose203
+.4byte sVaporeonPose204
+.4byte sVaporeonPose205
+.4byte sVaporeonPose206
+.4byte sVaporeonPose207
+.4byte sVaporeonPose208
+.4byte sVaporeonPose209
+.4byte sVaporeonPose210
+.4byte sVaporeonPose211
+.4byte sVaporeonPose212
+.4byte sVaporeonPose213
+.4byte sVaporeonPose214
+.4byte sVaporeonPose215
+.4byte sVaporeonPose216
+.4byte sVaporeonPose217
+.4byte sVaporeonPose218
+.4byte sVaporeonPose219
+.4byte sVaporeonPose220
+.4byte sVaporeonPose221
+.4byte sVaporeonPose222
+.4byte sVaporeonPose223
+.4byte sVaporeonPose224
+.4byte sVaporeonPose225
+.4byte sVaporeonPose226
+sAxPositionsVaporeon:
+.2byte   -1,   -6, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    4, 	   2,    1, 	  -1,   -9
+.2byte   -1,   -5, 	  -4,    1, 	   2,    4, 	  -1,   -9
+.2byte    9,   -7, 	   7,    0, 	   3,    2, 	   1,   -8
+.2byte    9,   -6, 	   0,   -2, 	   6,    3, 	   1,   -6
+.2byte    9,   -6, 	   9,    2, 	   1,    1, 	   1,   -6
+.2byte   13,  -11, 	   9,   -2, 	   8,    0, 	   2,   -7
+.2byte   13,  -10, 	   5,   -1, 	  11,    0, 	   1,   -7
+.2byte   13,  -10, 	  11,   -1, 	   4,    0, 	   2,   -7
+.2byte    7,  -13, 	   2,   -4, 	   7,   -2, 	   1,   -8
+.2byte    8,  -13, 	   3,  -10, 	   5,   -1, 	   1,   -7
+.2byte    7,  -12, 	   0,   -7, 	   9,   -3, 	   1,   -7
+.2byte   -1,  -13, 	   3,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -3, 	  -5,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -8,  -13, 	  -3,   -4, 	  -8,   -2, 	  -2,   -8
+.2byte   -9,  -13, 	  -4,  -10, 	  -6,   -1, 	  -2,   -7
+.2byte   -8,  -12, 	  -1,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte  -14,  -11, 	 -10,   -2, 	  -9,    0, 	  -3,   -7
+.2byte  -14,  -10, 	  -6,   -1, 	 -12,    0, 	  -2,   -7
+.2byte  -14,  -10, 	 -12,   -1, 	  -5,    0, 	  -3,   -7
+.2byte  -10,   -7, 	  -8,    0, 	  -4,    2, 	  -2,   -8
+.2byte  -10,   -6, 	  -1,   -2, 	  -7,    3, 	  -2,   -6
+.2byte  -10,   -6, 	 -10,    2, 	  -2,    1, 	  -2,   -6
+.2byte   -1,   -6, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    4, 	   2,    1, 	  -1,   -9
+.2byte   -1,   -5, 	  -4,    1, 	   2,    4, 	  -1,   -9
+.2byte   -1,   -2, 	  -4,    2, 	   2,    2, 	  -1,  -11
+.2byte    9,   -7, 	   7,    0, 	   3,    2, 	   1,   -8
+.2byte    9,   -6, 	   0,   -2, 	   6,    3, 	   1,   -6
+.2byte    9,   -6, 	   9,    2, 	   1,    1, 	   1,   -6
+.2byte    5,   -3, 	   5,    1, 	   2,    2, 	  -2,   -8
+.2byte   13,  -11, 	   9,   -2, 	   8,    0, 	   2,   -7
+.2byte   13,  -10, 	   5,   -1, 	  11,    0, 	   1,   -7
+.2byte   13,  -10, 	  11,   -1, 	   4,    0, 	   2,   -7
+.2byte    7,   -3, 	   7,   -1, 	   5,    0, 	  -2,   -8
+.2byte    7,  -13, 	   2,   -4, 	   7,   -2, 	   1,   -8
+.2byte    8,  -13, 	   3,  -10, 	   5,   -1, 	   1,   -7
+.2byte    7,  -12, 	   0,   -7, 	   9,   -3, 	   1,   -7
+.2byte    6,   -7, 	   2,   -6, 	   7,   -3, 	   1,   -9
+.2byte   -1,  -13, 	   3,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -3, 	  -5,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -8,  -13, 	  -3,   -4, 	  -8,   -2, 	  -2,   -8
+.2byte   -9,  -13, 	  -4,  -10, 	  -6,   -1, 	  -2,   -7
+.2byte   -8,  -12, 	  -1,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte   -6,   -7, 	  -2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte  -14,  -11, 	 -10,   -2, 	  -9,    0, 	  -3,   -7
+.2byte  -14,  -10, 	  -6,   -1, 	 -12,    0, 	  -2,   -7
+.2byte  -14,  -10, 	 -12,   -1, 	  -5,    0, 	  -3,   -7
+.2byte   -8,   -3, 	  -8,   -1, 	  -6,    0, 	   1,   -8
+.2byte  -10,   -7, 	  -8,    0, 	  -4,    2, 	  -2,   -8
+.2byte  -10,   -6, 	  -1,   -2, 	  -7,    3, 	  -2,   -6
+.2byte  -10,   -6, 	 -10,    2, 	  -2,    1, 	  -2,   -6
+.2byte   -6,   -3, 	  -6,    1, 	  -3,    2, 	   1,   -8
+.2byte   -1,   -6, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    4, 	   2,    1, 	  -1,   -9
+.2byte   -1,   -5, 	  -4,    1, 	   2,    4, 	  -1,   -9
+.2byte   -1,   -2, 	  -4,    2, 	   2,    2, 	  -1,  -11
+.2byte    9,   -7, 	   7,    0, 	   3,    2, 	   1,   -8
+.2byte    9,   -6, 	   0,   -2, 	   6,    3, 	   1,   -6
+.2byte    9,   -6, 	   9,    2, 	   1,    1, 	   1,   -6
+.2byte    5,   -3, 	   5,    1, 	   2,    2, 	  -2,   -8
+.2byte   13,  -11, 	   9,   -2, 	   8,    0, 	   2,   -7
+.2byte   13,  -10, 	   5,   -1, 	  11,    0, 	   1,   -7
+.2byte   13,  -10, 	  11,   -1, 	   4,    0, 	   2,   -7
+.2byte    7,   -3, 	   7,   -1, 	   5,    0, 	  -2,   -8
+.2byte    7,  -13, 	   2,   -4, 	   7,   -2, 	   1,   -8
+.2byte    8,  -13, 	   3,  -10, 	   5,   -1, 	   1,   -7
+.2byte    7,  -12, 	   0,   -7, 	   9,   -3, 	   1,   -7
+.2byte    6,   -7, 	   2,   -6, 	   7,   -3, 	   1,   -9
+.2byte   -1,  -13, 	   3,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -3, 	  -5,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -8,  -13, 	  -3,   -4, 	  -8,   -2, 	  -2,   -8
+.2byte   -9,  -13, 	  -4,  -10, 	  -6,   -1, 	  -2,   -7
+.2byte   -8,  -12, 	  -1,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte   -6,   -7, 	  -2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte  -14,  -11, 	 -10,   -2, 	  -9,    0, 	  -3,   -7
+.2byte  -14,  -10, 	  -6,   -1, 	 -12,    0, 	  -2,   -7
+.2byte  -14,  -10, 	 -12,   -1, 	  -5,    0, 	  -3,   -7
+.2byte   -8,   -3, 	  -8,   -1, 	  -6,    0, 	   1,   -8
+.2byte  -10,   -7, 	  -8,    0, 	  -4,    2, 	  -2,   -8
+.2byte  -10,   -6, 	  -1,   -2, 	  -7,    3, 	  -2,   -6
+.2byte  -10,   -6, 	 -10,    2, 	  -2,    1, 	  -2,   -6
+.2byte   -6,   -3, 	  -6,    1, 	  -3,    2, 	   1,   -8
+.2byte   -1,   -6, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    4, 	   2,    1, 	  -1,   -9
+.2byte   -1,   -5, 	  -4,    1, 	   2,    4, 	  -1,   -9
+.2byte   -1,   -2, 	  -4,    2, 	   2,    2, 	  -1,  -11
+.2byte    9,   -7, 	   7,    0, 	   3,    2, 	   1,   -8
+.2byte    9,   -6, 	   0,   -2, 	   6,    3, 	   1,   -6
+.2byte    9,   -6, 	   9,    2, 	   1,    1, 	   1,   -6
+.2byte    5,   -3, 	   5,    1, 	   2,    2, 	  -2,   -8
+.2byte   13,  -11, 	   9,   -2, 	   8,    0, 	   2,   -7
+.2byte   13,  -10, 	   5,   -1, 	  11,    0, 	   1,   -7
+.2byte   13,  -10, 	  11,   -1, 	   4,    0, 	   2,   -7
+.2byte    9,   -3, 	   9,   -1, 	   7,    0, 	   0,   -8
+.2byte    7,  -13, 	   2,   -4, 	   7,   -2, 	   1,   -8
+.2byte    8,  -13, 	   3,  -10, 	   5,   -1, 	   1,   -7
+.2byte    7,  -12, 	   0,   -7, 	   9,   -3, 	   1,   -7
+.2byte    6,   -7, 	   2,   -6, 	   7,   -3, 	   1,   -9
+.2byte   -1,  -13, 	   3,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -3, 	  -5,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte   -8,  -13, 	  -3,   -4, 	  -8,   -2, 	  -2,   -8
+.2byte   -9,  -13, 	  -4,  -10, 	  -6,   -1, 	  -2,   -7
+.2byte   -8,  -12, 	  -1,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte   -6,   -7, 	  -2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte  -14,  -11, 	 -10,   -2, 	  -9,    0, 	  -3,   -7
+.2byte  -14,  -10, 	  -6,   -1, 	 -12,    0, 	  -2,   -7
+.2byte  -14,  -10, 	 -12,   -1, 	  -5,    0, 	  -3,   -7
+.2byte  -10,   -3, 	 -10,   -1, 	  -8,    0, 	  -1,   -8
+.2byte  -10,   -7, 	  -8,    0, 	  -4,    2, 	  -2,   -8
+.2byte  -10,   -6, 	  -1,   -2, 	  -7,    3, 	  -2,   -6
+.2byte  -10,   -6, 	 -10,    2, 	  -2,    1, 	  -2,   -6
+.2byte   -6,   -3, 	  -6,    1, 	  -3,    2, 	   1,   -8
+.2byte   -1,   -6, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    4, 	   2,    1, 	  -1,   -9
+.2byte   -1,   -5, 	  -4,    1, 	   2,    4, 	  -1,   -9
+.2byte   -1,  -10, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte    9,   -7, 	   7,    0, 	   3,    2, 	   1,   -8
+.2byte    9,   -6, 	   0,   -2, 	   6,    3, 	   1,   -6
+.2byte    9,   -6, 	   9,    2, 	   1,    1, 	   1,   -6
+.2byte    8,  -13, 	   6,   -1, 	   3,    1, 	  -2,   -6
+.2byte   13,  -11, 	   9,   -2, 	   8,    0, 	   2,   -7
+.2byte   13,  -10, 	   5,   -1, 	  11,    0, 	   1,   -7
+.2byte   13,  -10, 	  11,   -1, 	   4,    0, 	   2,   -7
+.2byte   13,  -16, 	   9,   -1, 	   8,    0, 	   1,   -7
+.2byte    7,  -13, 	   2,   -4, 	   7,   -2, 	   1,   -8
+.2byte    8,  -13, 	   3,  -10, 	   5,   -1, 	   1,   -7
+.2byte    7,  -12, 	   0,   -7, 	   9,   -3, 	   1,   -7
+.2byte    4,  -14, 	   0,   -4, 	   7,   -2, 	  -1,   -6
+.2byte   -1,  -13, 	   3,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -3, 	  -5,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -4, 	  -5,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   4,   -4, 	  -6,   -4, 	  -1,  -11
+.2byte   -8,  -13, 	  -3,   -4, 	  -8,   -2, 	  -2,   -8
+.2byte   -9,  -13, 	  -4,  -10, 	  -6,   -1, 	  -2,   -7
+.2byte   -8,  -12, 	  -1,   -7, 	 -10,   -3, 	  -2,   -7
+.2byte   -5,  -14, 	  -1,   -4, 	  -8,   -2, 	   0,   -6
+.2byte  -14,  -11, 	 -10,   -2, 	  -9,    0, 	  -3,   -7
+.2byte  -14,  -10, 	  -6,   -1, 	 -12,    0, 	  -2,   -7
+.2byte  -14,  -10, 	 -12,   -1, 	  -5,    0, 	  -3,   -7
+.2byte  -14,  -16, 	 -10,   -1, 	  -9,    0, 	  -2,   -7
+.2byte  -10,   -7, 	  -8,    0, 	  -4,    2, 	  -2,   -8
+.2byte  -10,   -6, 	  -1,   -2, 	  -7,    3, 	  -2,   -6
+.2byte  -10,   -6, 	 -10,    2, 	  -2,    1, 	  -2,   -6
+.2byte   -9,  -13, 	  -7,   -1, 	  -4,    1, 	   1,   -6
+.2byte  -11,   -6, 	 -11,    0, 	  -9,    0, 	  -3,   -7
+.2byte  -11,   -5, 	 -11,    0, 	  -9,    0, 	  -3,   -6
+.2byte   -1,   -3, 	  -6,    3, 	   4,    3, 	  -1,   -8
+.2byte    8,   -3, 	  12,    0, 	   5,    3, 	  -2,   -6
+.2byte   12,   -7, 	  10,   -1, 	  11,    0, 	   0,   -5
+.2byte    5,   -3, 	   1,   -6, 	   8,   -1, 	  -1,   -5
+.2byte   -1,   -8, 	   3,   -3, 	  -5,   -3, 	  -1,   -9
+.2byte   -6,   -3, 	  -2,   -6, 	  -9,   -1, 	   0,   -5
+.2byte  -13,   -7, 	 -11,   -1, 	 -12,    0, 	  -1,   -5
+.2byte   -9,   -3, 	 -13,    0, 	  -6,    3, 	   1,   -6
+.2byte   -1,   -9, 	  -4,    2, 	   2,    2, 	  -1,   -7
+.2byte    8,  -12, 	   6,    0, 	   3,    1, 	  -1,   -7
+.2byte    9,  -14, 	   7,   -1, 	   6,    0, 	  -1,   -7
+.2byte    3,  -14, 	  -1,   -4, 	   6,   -2, 	  -2,   -6
+.2byte   -1,  -16, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -5,  -14, 	  -1,   -4, 	  -8,   -2, 	   0,   -6
+.2byte  -10,  -14, 	  -8,   -1, 	  -7,    0, 	   0,   -7
+.2byte   -9,  -12, 	  -7,    0, 	  -4,    1, 	   0,   -7
+.2byte   -1,   -2, 	  -4,    2, 	   2,    2, 	  -1,  -11
+.2byte   -9,   -3, 	  -9,    1, 	  -6,    2, 	  -2,   -8
+.2byte  -10,   -3, 	 -10,   -1, 	  -8,    0, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -14, 	   3,   -7, 	  -5,   -7, 	  -1,  -12
+.2byte    6,   -7, 	   2,   -6, 	   7,   -3, 	   1,   -9
+.2byte    9,   -3, 	   9,   -1, 	   7,    0, 	   0,   -8
+.2byte    8,   -3, 	   8,    1, 	   5,    2, 	   1,   -8
+.2byte   -1,  -10, 	  -4,    2, 	   2,    2, 	  -1,   -8
+.2byte    8,  -13, 	   6,   -1, 	   3,    1, 	  -2,   -6
+.2byte   10,  -16, 	   6,   -1, 	   5,    0, 	  -2,   -7
+.2byte    1,  -14, 	  -3,   -4, 	   4,   -2, 	  -4,   -6
+.2byte   -1,  -16, 	   4,   -3, 	  -6,   -3, 	  -1,  -10
+.2byte   -2,  -14, 	   2,   -4, 	  -5,   -2, 	   3,   -6
+.2byte  -11,  -16, 	  -7,   -1, 	  -6,    0, 	   1,   -7
+.2byte   -9,  -13, 	  -7,   -1, 	  -4,    1, 	   1,   -6
+.2byte   -1,   -6, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte   -1,   -5, 	  -4,    4, 	   2,    1, 	  -1,   -9
+.2byte   -1,   -2, 	  -4,    2, 	   2,    2, 	  -1,  -11
+.2byte    8,   -7, 	   6,    0, 	   2,    2, 	   0,   -8
+.2byte    8,   -7, 	  -1,   -3, 	   5,    2, 	   0,   -7
+.2byte    7,   -3, 	   7,    1, 	   4,    2, 	   0,   -8
+.2byte   11,  -11, 	   7,   -2, 	   6,    0, 	   0,   -7
+.2byte   10,  -10, 	   2,   -1, 	   8,    0, 	  -2,   -7
+.2byte    8,   -2, 	   8,    0, 	   6,    1, 	  -1,   -7
+.2byte    4,  -13, 	  -1,   -4, 	   4,   -2, 	  -2,   -8
+.2byte    4,  -13, 	  -1,  -10, 	   1,   -1, 	  -3,   -7
+.2byte    4,   -7, 	   0,   -6, 	   5,   -3, 	  -1,   -9
+.2byte   -1,  -13, 	   3,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -3, 	  -5,   -3, 	  -1,   -9
+.2byte   -1,  -13, 	   3,   -6, 	  -5,   -6, 	  -1,  -11
+.2byte   -5,  -13, 	   0,   -4, 	  -5,   -2, 	   1,   -8
+.2byte   -5,  -13, 	   0,  -10, 	  -2,   -1, 	   2,   -7
+.2byte   -5,   -7, 	  -1,   -6, 	  -6,   -3, 	   0,   -9
+.2byte  -12,  -11, 	  -8,   -2, 	  -7,    0, 	  -1,   -7
+.2byte  -11,  -10, 	  -3,   -1, 	  -9,    0, 	   1,   -7
+.2byte   -9,   -2, 	  -9,    0, 	  -7,    1, 	   0,   -7
+.2byte   -9,   -7, 	  -7,    0, 	  -3,    2, 	  -1,   -8
+.2byte   -8,   -7, 	   1,   -3, 	  -5,    2, 	   0,   -7
+.2byte   -8,   -3, 	  -8,    1, 	  -5,    2, 	  -1,   -8
+.2byte   -1,   -2, 	  -4,    2, 	   2,    2, 	  -1,  -11
+.2byte   -9,   -3, 	  -9,    1, 	  -6,    2, 	  -2,   -8
+.2byte  -10,   -3, 	 -10,   -1, 	  -8,    0, 	  -1,   -8
+.2byte   -6,   -7, 	  -2,   -6, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	   3,   -5, 	  -5,   -5, 	  -1,  -10
+.2byte    6,   -7, 	   2,   -6, 	   7,   -3, 	   1,   -9
+.2byte    9,   -3, 	   9,   -1, 	   7,    0, 	   0,   -8
+.2byte    8,   -3, 	   8,    1, 	   5,    2, 	   1,   -8
+.2byte   -1,   -6, 	  -5,    2, 	   3,    2, 	  -1,  -10
+.2byte  -10,   -7, 	  -8,    0, 	  -4,    2, 	  -2,   -8
+.2byte  -14,  -11, 	 -10,   -2, 	  -9,    0, 	  -3,   -7
+.2byte   -8,  -13, 	  -3,   -4, 	  -8,   -2, 	  -2,   -8
+.2byte   -1,  -13, 	   3,   -4, 	  -5,   -4, 	  -1,  -10
+.2byte    7,  -13, 	   2,   -4, 	   7,   -2, 	   1,   -8
+.2byte   13,  -11, 	   9,   -2, 	   8,    0, 	   2,   -7
+.2byte    9,   -7, 	   7,    0, 	   3,    2, 	   1,   -8
+sVaporeonAnimTable1:
+.4byte sVaporeonAnims_1_1
+.4byte sVaporeonAnims_1_2
+.4byte sVaporeonAnims_1_3
+.4byte sVaporeonAnims_1_4
+.4byte sVaporeonAnims_1_5
+.4byte sVaporeonAnims_1_6
+.4byte sVaporeonAnims_1_7
+.4byte sVaporeonAnims_1_8
+sVaporeonAnimTable2:
+.4byte sVaporeonAnims_2_1
+.4byte sVaporeonAnims_2_2
+.4byte sVaporeonAnims_2_3
+.4byte sVaporeonAnims_2_4
+.4byte sVaporeonAnims_2_5
+.4byte sVaporeonAnims_2_6
+.4byte sVaporeonAnims_2_7
+.4byte sVaporeonAnims_2_8
+sVaporeonAnimTable3:
+.4byte sVaporeonAnims_3_1
+.4byte sVaporeonAnims_3_2
+.4byte sVaporeonAnims_3_3
+.4byte sVaporeonAnims_3_4
+.4byte sVaporeonAnims_3_5
+.4byte sVaporeonAnims_3_6
+.4byte sVaporeonAnims_3_7
+.4byte sVaporeonAnims_3_8
+sVaporeonAnimTable4:
+.4byte sVaporeonAnims_4_1
+.4byte sVaporeonAnims_4_2
+.4byte sVaporeonAnims_4_3
+.4byte sVaporeonAnims_4_4
+.4byte sVaporeonAnims_4_5
+.4byte sVaporeonAnims_4_6
+.4byte sVaporeonAnims_4_7
+.4byte sVaporeonAnims_4_8
+sVaporeonAnimTable5:
+.4byte sVaporeonAnims_5_1
+.4byte sVaporeonAnims_5_2
+.4byte sVaporeonAnims_5_3
+.4byte sVaporeonAnims_5_4
+.4byte sVaporeonAnims_5_5
+.4byte sVaporeonAnims_5_6
+.4byte sVaporeonAnims_5_7
+.4byte sVaporeonAnims_5_8
+sVaporeonAnimTable6:
+.4byte sVaporeonAnims_6_1
+.4byte sVaporeonAnims_6_1
+.4byte sVaporeonAnims_6_1
+.4byte sVaporeonAnims_6_1
+.4byte sVaporeonAnims_6_1
+.4byte sVaporeonAnims_6_1
+.4byte sVaporeonAnims_6_1
+.4byte sVaporeonAnims_6_1
+sVaporeonAnimTable7:
+.4byte sVaporeonAnims_7_1
+.4byte sVaporeonAnims_7_2
+.4byte sVaporeonAnims_7_3
+.4byte sVaporeonAnims_7_4
+.4byte sVaporeonAnims_7_5
+.4byte sVaporeonAnims_7_6
+.4byte sVaporeonAnims_7_7
+.4byte sVaporeonAnims_7_8
+sVaporeonAnimTable8:
+.4byte sVaporeonAnims_8_1
+.4byte sVaporeonAnims_8_2
+.4byte sVaporeonAnims_8_3
+.4byte sVaporeonAnims_8_4
+.4byte sVaporeonAnims_8_5
+.4byte sVaporeonAnims_8_6
+.4byte sVaporeonAnims_8_7
+.4byte sVaporeonAnims_8_8
+sVaporeonAnimTable9:
+.4byte sVaporeonAnims_9_1
+.4byte sVaporeonAnims_9_2
+.4byte sVaporeonAnims_9_3
+.4byte sVaporeonAnims_9_4
+.4byte sVaporeonAnims_9_5
+.4byte sVaporeonAnims_9_6
+.4byte sVaporeonAnims_9_7
+.4byte sVaporeonAnims_9_8
+sVaporeonAnimTable10:
+.4byte sVaporeonAnims_10_1
+.4byte sVaporeonAnims_10_2
+.4byte sVaporeonAnims_10_3
+.4byte sVaporeonAnims_10_4
+.4byte sVaporeonAnims_10_5
+.4byte sVaporeonAnims_10_6
+.4byte sVaporeonAnims_10_7
+.4byte sVaporeonAnims_10_8
+sVaporeonAnimTable11:
+.4byte sVaporeonAnims_11_1
+.4byte sVaporeonAnims_11_2
+.4byte sVaporeonAnims_11_3
+.4byte sVaporeonAnims_11_4
+.4byte sVaporeonAnims_11_5
+.4byte sVaporeonAnims_11_6
+.4byte sVaporeonAnims_11_7
+.4byte sVaporeonAnims_11_8
+sVaporeonAnimTable12:
+.4byte sVaporeonAnims_12_1
+.4byte sVaporeonAnims_12_2
+.4byte sVaporeonAnims_12_3
+.4byte sVaporeonAnims_12_4
+.4byte sVaporeonAnims_12_5
+.4byte sVaporeonAnims_12_6
+.4byte sVaporeonAnims_12_7
+.4byte sVaporeonAnims_12_8
+sVaporeonAnimTable13:
+.4byte sVaporeonAnims_13_1
+.4byte sVaporeonAnims_13_2
+.4byte sVaporeonAnims_13_3
+.4byte sVaporeonAnims_13_4
+.4byte sVaporeonAnims_13_5
+.4byte sVaporeonAnims_13_6
+.4byte sVaporeonAnims_13_7
+.4byte sVaporeonAnims_13_8
+sAxAnimationsVaporeon:
+.4byte sVaporeonAnimTable1
+.4byte sVaporeonAnimTable2
+.4byte sVaporeonAnimTable3
+.4byte sVaporeonAnimTable4
+.4byte sVaporeonAnimTable5
+.4byte sVaporeonAnimTable6
+.4byte sVaporeonAnimTable7
+.4byte sVaporeonAnimTable8
+.4byte sVaporeonAnimTable9
+.4byte sVaporeonAnimTable10
+.4byte sVaporeonAnimTable11
+.4byte sVaporeonAnimTable12
+.4byte sVaporeonAnimTable13
+sAxSpritesVaporeon:
+.4byte sVaporeonSprites1
+.4byte sVaporeonSprites2
+.4byte sVaporeonSprites3
+.4byte sVaporeonSprites4
+.4byte sVaporeonSprites5
+.4byte sVaporeonSprites6
+.4byte sVaporeonSprites7
+.4byte sVaporeonSprites8
+.4byte sVaporeonSprites9
+.4byte sVaporeonSprites10
+.4byte sVaporeonSprites11
+.4byte sVaporeonSprites12
+.4byte sVaporeonSprites13
+.4byte sVaporeonSprites14
+.4byte sVaporeonSprites15
+.4byte sVaporeonSprites16
+.4byte sVaporeonSprites17
+.4byte sVaporeonSprites18
+.4byte sVaporeonSprites19
+.4byte sVaporeonSprites20
+.4byte sVaporeonSprites21
+.4byte sVaporeonSprites22
+.4byte sVaporeonSprites23
+.4byte sVaporeonSprites24
+.4byte sVaporeonSprites25
+.4byte sVaporeonSprites26
+.4byte sVaporeonSprites27
+.4byte sVaporeonSprites28
+.4byte sVaporeonSprites29
+.4byte sVaporeonSprites30
+.4byte sVaporeonSprites31
+.4byte sVaporeonSprites32
+.4byte sVaporeonSprites33
+.4byte sVaporeonSprites34
+.4byte sVaporeonSprites35
+.4byte sVaporeonSprites36
+.4byte sVaporeonSprites37
+.4byte sVaporeonSprites38
+.4byte sVaporeonSprites39
+.4byte sVaporeonSprites40
+.4byte sVaporeonSprites41
+.4byte sVaporeonSprites42
+.4byte sVaporeonSprites43
+.4byte sVaporeonSprites44
+.4byte sVaporeonSprites45
+.4byte sVaporeonSprites46
+.4byte sVaporeonSprites47
+.4byte sVaporeonSprites48
+.4byte sVaporeonSprites49
+.4byte sVaporeonSprites50
+.4byte sVaporeonSprites51
+.4byte sVaporeonSprites52
+.4byte sVaporeonSprites53
+.4byte sVaporeonSprites54
+.4byte sVaporeonSprites55
+.4byte sVaporeonSprites56
+.4byte sVaporeonSprites57
+sAxMainVaporeon:
+ax_main sAxPosesVaporeon, sAxAnimationsVaporeon, 13, sAxSpritesVaporeon, sAxPositionsVaporeon

--- a/data/ax/venomoth.inc
+++ b/data/ax/venomoth.inc
@@ -1,0 +1,2813 @@
+.global gAxVenomoth
+gAxVenomoth:
+ax_siro sAxMainVenomoth
+sVenomothPose1:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose2:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose3:
+ax_pose 2, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose4:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose5:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose6:
+ax_pose 5, 0x01e6, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose7:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose8:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose9:
+ax_pose 8, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose10:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose11:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose12:
+ax_pose 11, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose13:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose14:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose15:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose16:
+ax_pose 9, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose17:
+ax_pose 10, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose18:
+ax_pose 11, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose19:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose20:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose21:
+ax_pose 8, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose22:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose23:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose24:
+ax_pose 5, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose25:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose26:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose27:
+ax_pose 2, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose28:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose29:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose30:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose31:
+ax_pose 5, 0x01e6, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose32:
+ax_pose 16, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose33:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose34:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose35:
+ax_pose 8, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose36:
+ax_pose 17, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose37:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose38:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose39:
+ax_pose 11, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose40:
+ax_pose 18, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sVenomothPose41:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose42:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose43:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose44:
+ax_pose 19, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose45:
+ax_pose 9, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose46:
+ax_pose 10, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose47:
+ax_pose 11, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose48:
+ax_pose 18, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose49:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose50:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose51:
+ax_pose 8, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose52:
+ax_pose 17, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose53:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose54:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose55:
+ax_pose 5, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose56:
+ax_pose 16, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose57:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose58:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose59:
+ax_pose 2, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose60:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose61:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose62:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose63:
+ax_pose 5, 0x01e6, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose64:
+ax_pose 16, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose65:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose66:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose67:
+ax_pose 8, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose68:
+ax_pose 17, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose69:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose70:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose71:
+ax_pose 11, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose72:
+ax_pose 18, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sVenomothPose73:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose74:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose75:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose76:
+ax_pose 19, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose77:
+ax_pose 9, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose78:
+ax_pose 10, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose79:
+ax_pose 11, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose80:
+ax_pose 18, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose81:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose82:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose83:
+ax_pose 8, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose84:
+ax_pose 17, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose85:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose86:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose87:
+ax_pose 5, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose88:
+ax_pose 16, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose89:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose90:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose91:
+ax_pose 2, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose92:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose93:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose94:
+ax_pose 5, 0x01e6, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose95:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose96:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose97:
+ax_pose 8, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose98:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose99:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose100:
+ax_pose 11, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose101:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose102:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose103:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose104:
+ax_pose 9, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose105:
+ax_pose 10, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose106:
+ax_pose 11, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose107:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose108:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose109:
+ax_pose 8, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose110:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose111:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose112:
+ax_pose 5, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose113:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose114:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose115:
+ax_pose 2, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose116:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose117:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose118:
+ax_pose 5, 0x01e6, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose119:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose120:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose121:
+ax_pose 8, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose122:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose123:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose124:
+ax_pose 11, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose125:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose126:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose127:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose128:
+ax_pose 9, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose129:
+ax_pose 10, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose130:
+ax_pose 11, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose131:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose132:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose133:
+ax_pose 8, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose134:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose135:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose136:
+ax_pose 5, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose137:
+ax_pose 20, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sVenomothPose138:
+ax_pose 21, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sVenomothPose139:
+ax_pose 22, 0x01e1, 0x80ef, 0x7c00
+ax_pose_terminator
+sVenomothPose140:
+ax_pose 23, 0x01e0, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose141:
+ax_pose 24, 0x01e2, 0x90ec, 0x7c00
+ax_pose_terminator
+sVenomothPose142:
+ax_pose 25, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose143:
+ax_pose 26, 0x01e5, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose144:
+ax_pose 25, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose145:
+ax_pose 24, 0x01e2, 0x80f4, 0x7c00
+ax_pose_terminator
+sVenomothPose146:
+ax_pose 23, 0x01e0, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose147:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose148:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose149:
+ax_pose 2, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose150:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose151:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose152:
+ax_pose 5, 0x01e6, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose153:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose154:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose155:
+ax_pose 8, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose156:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose157:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose158:
+ax_pose 11, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose159:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose160:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose161:
+ax_pose 14, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose162:
+ax_pose 9, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sVenomothPose163:
+ax_pose 10, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sVenomothPose164:
+ax_pose 11, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sVenomothPose165:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose166:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose167:
+ax_pose 8, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose168:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose169:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose170:
+ax_pose 5, 0x01e6, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose171:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose172:
+ax_pose 16, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose173:
+ax_pose 17, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose174:
+ax_pose 18, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose175:
+ax_pose 19, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose176:
+ax_pose 18, 0x01e5, 0x90ed, 0x7c00
+ax_pose_terminator
+sVenomothPose177:
+ax_pose 17, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose178:
+ax_pose 16, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose179:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose180:
+ax_pose 16, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose181:
+ax_pose 17, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose182:
+ax_pose 18, 0x01e5, 0x90ed, 0x7c00
+ax_pose_terminator
+sVenomothPose183:
+ax_pose 19, 0x01e9, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose184:
+ax_pose 18, 0x01e5, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose185:
+ax_pose 17, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose186:
+ax_pose 16, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose187:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose188:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose189:
+ax_pose 15, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose190:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose191:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose192:
+ax_pose 16, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose193:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose194:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose195:
+ax_pose 17, 0x01e4, 0x90e9, 0x7c00
+ax_pose_terminator
+sVenomothPose196:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose197:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose198:
+ax_pose 18, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sVenomothPose199:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose200:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose201:
+ax_pose 19, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose202:
+ax_pose 9, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose203:
+ax_pose 10, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose204:
+ax_pose 18, 0x01e4, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose205:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose206:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose207:
+ax_pose 17, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose208:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose209:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose210:
+ax_pose 16, 0x01e4, 0x80f7, 0x7c00
+ax_pose_terminator
+sVenomothPose211:
+ax_pose 1, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose212:
+ax_pose 4, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose213:
+ax_pose 7, 0x81e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose214:
+ax_pose 10, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose215:
+ax_pose 13, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sVenomothPose216:
+ax_pose 10, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose217:
+ax_pose 7, 0x81e4, 0x90f8, 0x7c00
+ax_pose_terminator
+sVenomothPose218:
+ax_pose 4, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose219:
+ax_pose 0, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose220:
+ax_pose 3, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose221:
+ax_pose 6, 0x01e4, 0x80f8, 0x7c00
+ax_pose_terminator
+sVenomothPose222:
+ax_pose 9, 0x01e4, 0x80f5, 0x7c00
+ax_pose_terminator
+sVenomothPose223:
+ax_pose 12, 0x01e7, 0x80f3, 0x7c00
+ax_pose_terminator
+sVenomothPose224:
+ax_pose 9, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+sVenomothPose225:
+ax_pose 6, 0x01e4, 0x90e8, 0x7c00
+ax_pose_terminator
+sVenomothPose226:
+ax_pose 3, 0x01e4, 0x90eb, 0x7c00
+ax_pose_terminator
+.align 2
+sVenomothAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 1, 1, 1, 0,
+ax_anim 8, 0, 0, 1, 2, 1, 0,
+ax_anim 8, 0, 2, 0, 2, 0, 0,
+ax_anim 8, 0, 0, 0, 1, 0, 0,
+ax_anim 8, 0, 1, -1, 0, -1, 0,
+ax_anim 8, 0, 0, -1, -1, -1, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 0, -1, 1, -1, 0,
+ax_anim 8, 0, 2, -1, 0, -1, 0,
+ax_anim_terminator
+sVenomothAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 1, 1, 1, 1,
+ax_anim 8, 0, 3, 1, 2, 1, 2,
+ax_anim 8, 0, 5, 0, 2, 0, 2,
+ax_anim 8, 0, 3, 0, 1, 0, 1,
+ax_anim 8, 0, 4, 1, 0, 1, 0,
+ax_anim 8, 0, 3, 1, -1, 1, -1,
+ax_anim 8, 0, 5, 1, -1, 1, -1,
+ax_anim 8, 0, 3, 1, 0, 1, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 1,
+ax_anim 8, 0, 3, -1, 1, -1, 1,
+ax_anim 8, 0, 5, -1, 0, -1, 0,
+ax_anim_terminator
+sVenomothAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 1, 1, 1, 0,
+ax_anim 8, 0, 6, 1, 2, 1, 0,
+ax_anim 8, 0, 8, 0, 2, 0, 0,
+ax_anim 8, 0, 6, 0, 1, 0, 0,
+ax_anim 8, 0, 7, 1, 0, 1, 0,
+ax_anim 8, 0, 6, 1, -1, 1, 0,
+ax_anim 8, 0, 8, 1, -1, 1, 0,
+ax_anim 8, 0, 6, 1, 0, 1, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 6, -1, 1, -1, 0,
+ax_anim 8, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sVenomothAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 1, -1, 1, -1,
+ax_anim 8, 0, 9, 1, -2, 1, -2,
+ax_anim 8, 0, 11, 0, -2, 0, -2,
+ax_anim 8, 0, 9, 0, -1, 0, -1,
+ax_anim 8, 0, 10, 1, 0, 1, 0,
+ax_anim 8, 0, 9, 1, 1, 1, 1,
+ax_anim 8, 0, 11, 1, 1, 1, 1,
+ax_anim 8, 0, 9, 1, 0, 1, 0,
+ax_anim 8, 0, 10, 0, -1, 0, -1,
+ax_anim 8, 0, 9, -1, -1, -1, -1,
+ax_anim 8, 0, 11, -1, 0, -1, 0,
+ax_anim_terminator
+sVenomothAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 1, 1, 1, 0,
+ax_anim 8, 0, 12, 1, 2, 1, 0,
+ax_anim 8, 0, 14, 0, 2, 0, 0,
+ax_anim 8, 0, 12, 0, 1, 0, 0,
+ax_anim 8, 0, 13, -1, 0, -1, 0,
+ax_anim 8, 0, 12, -1, -1, -1, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 12, -1, 1, -1, 0,
+ax_anim 8, 0, 14, -1, 0, -1, 0,
+ax_anim_terminator
+sVenomothAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, -1, -1, -1, -1,
+ax_anim 8, 0, 15, -1, -2, -1, -2,
+ax_anim 8, 0, 17, 0, -2, 0, -2,
+ax_anim 8, 0, 15, 0, -1, 0, -1,
+ax_anim 8, 0, 16, -1, 0, -1, 0,
+ax_anim 8, 0, 15, -1, 1, -1, 1,
+ax_anim 8, 0, 17, -1, 1, -1, 1,
+ax_anim 8, 0, 15, -1, 0, -1, 0,
+ax_anim 8, 0, 16, 0, -1, 0, -1,
+ax_anim 8, 0, 15, 1, -1, 1, -1,
+ax_anim 8, 0, 17, 1, 0, 1, 0,
+ax_anim_terminator
+sVenomothAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, -1, 1, -1, 0,
+ax_anim 8, 0, 18, -1, 2, -1, 0,
+ax_anim 8, 0, 20, 0, 2, 0, 0,
+ax_anim 8, 0, 18, 0, 1, 0, 0,
+ax_anim 8, 0, 19, -1, 0, -1, 0,
+ax_anim 8, 0, 18, -1, -1, -1, 0,
+ax_anim 8, 0, 20, -1, -1, -1, 0,
+ax_anim 8, 0, 18, -1, 0, -1, 0,
+ax_anim 8, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 18, 1, 1, 1, 0,
+ax_anim 8, 0, 20, 1, 0, 1, 0,
+ax_anim_terminator
+sVenomothAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, -1, 1, -1, 1,
+ax_anim 8, 0, 21, -1, 2, -1, 2,
+ax_anim 8, 0, 23, 0, 2, 0, 2,
+ax_anim 8, 0, 21, 0, 1, 0, 1,
+ax_anim 8, 0, 22, -1, 0, -1, 0,
+ax_anim 8, 0, 21, -1, -1, -1, -1,
+ax_anim 8, 0, 23, -1, -1, -1, -1,
+ax_anim 8, 0, 21, -1, 0, -1, 0,
+ax_anim 8, 0, 22, 0, 1, 0, 1,
+ax_anim 8, 0, 21, 1, 1, 1, 1,
+ax_anim 8, 0, 23, 1, 0, 1, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -5, 0, -2,
+ax_anim 2, 0, 26, 0, -6, 0, -3,
+ax_anim 2, 0, 25, 0, -6, 0, -3,
+ax_anim 2, 0, 26, 0, -6, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 4,
+ax_anim 1, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 25, 0, 22,
+ax_anim 2, 1, 27, 1, 25, 1, 22,
+ax_anim 2, 0, 27, 0, 25, 0, 22,
+ax_anim 2, 0, 27, 1, 25, 1, 22,
+ax_anim 2, 0, 25, 0, 14, 0, 14,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim_terminator
+sVenomothAnims_2_2:
+ax_anim 2, 0, 29, -1, -2, -1, -1,
+ax_anim 2, 0, 28, -5, -6, -5, -5,
+ax_anim 2, 0, 30, -6, -8, -6, -6,
+ax_anim 2, 0, 29, -6, -8, -6, -6,
+ax_anim 2, 0, 30, -6, -8, -6, -6,
+ax_anim 1, 0, 30, 0, -2, 0, 0,
+ax_anim 1, 2, 31, 4, 3, 4, 4,
+ax_anim 1, 0, 31, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 22, 23, 22, 23,
+ax_anim 2, 1, 31, 23, 23, 23, 23,
+ax_anim 2, 0, 31, 22, 23, 22, 23,
+ax_anim 2, 0, 31, 23, 23, 23, 23,
+ax_anim 2, 0, 29, 14, 14, 14, 14,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sVenomothAnims_2_3:
+ax_anim 2, 0, 33, -1, -1, -1, 0,
+ax_anim 2, 0, 32, -5, -2, -5, 0,
+ax_anim 2, 0, 34, -6, -3, -6, 0,
+ax_anim 2, 0, 33, -6, -3, -6, 0,
+ax_anim 2, 0, 34, -6, -3, -6, 0,
+ax_anim 1, 0, 34, 0, -2, 0, 0,
+ax_anim 1, 2, 35, 4, -1, 4, 0,
+ax_anim 1, 0, 35, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 1, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 35, 20, 0, 20, 0,
+ax_anim 2, 0, 35, 21, 0, 21, 0,
+ax_anim 2, 0, 33, 14, 0, 14, 0,
+ax_anim 2, 0, 33, 6, 0, 6, 0,
+ax_anim_terminator
+sVenomothAnims_2_4:
+ax_anim 2, 0, 37, -1, 0, -1, 1,
+ax_anim 2, 0, 36, -5, -1, -2, 2,
+ax_anim 2, 0, 38, -6, -2, -3, 3,
+ax_anim 2, 0, 37, -6, -2, -3, 3,
+ax_anim 2, 0, 38, -6, -2, -3, 3,
+ax_anim 1, 0, 38, 0, -5, 0, 0,
+ax_anim 1, 2, 39, 4, -8, 4, -4,
+ax_anim 1, 0, 39, 10, -11, 10, -10,
+ax_anim 2, 0, 39, 19, -16, 19, -16,
+ax_anim 2, 1, 39, 20, -16, 20, -16,
+ax_anim 2, 0, 39, 19, -16, 19, -16,
+ax_anim 2, 0, 39, 20, -16, 20, -16,
+ax_anim 2, 0, 37, 14, -14, 14, -14,
+ax_anim 2, 0, 37, 6, -6, 6, -6,
+ax_anim_terminator
+sVenomothAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 2, 0, 40, 0, 2, 0, 2,
+ax_anim 2, 0, 42, 0, 2, 0, 2,
+ax_anim 2, 0, 41, 0, 2, 0, 2,
+ax_anim 2, 0, 42, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, 0, -2, 0, -2,
+ax_anim 1, 0, 43, 0, -6, 0, -6,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 1, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 43, 0, -16, 0, -16,
+ax_anim 2, 0, 43, 1, -16, 1, -16,
+ax_anim 2, 0, 41, 0, -8, 0, -8,
+ax_anim 2, 0, 41, 0, -4, 0, -4,
+ax_anim_terminator
+sVenomothAnims_2_6:
+ax_anim 2, 0, 45, 1, 0, 1, 1,
+ax_anim 2, 0, 44, 5, -1, 2, 2,
+ax_anim 2, 0, 46, 6, -2, 3, 3,
+ax_anim 2, 0, 45, 6, -2, 3, 3,
+ax_anim 2, 0, 46, 6, -2, 3, 3,
+ax_anim 1, 0, 46, 0, -5, 0, 0,
+ax_anim 1, 2, 47, -4, -8, -4, -4,
+ax_anim 1, 0, 47, -10, -11, -10, -10,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 1, 47, -20, -16, -20, -16,
+ax_anim 2, 0, 47, -19, -16, -19, -16,
+ax_anim 2, 0, 47, -20, -16, -20, -16,
+ax_anim 2, 0, 45, -14, -14, -14, -14,
+ax_anim 2, 0, 45, -6, -6, -6, -6,
+ax_anim_terminator
+sVenomothAnims_2_7:
+ax_anim 2, 0, 49, 1, -1, 1, 0,
+ax_anim 2, 0, 48, 5, -2, 5, 0,
+ax_anim 2, 0, 50, 6, -3, 6, 0,
+ax_anim 2, 0, 49, 6, -3, 6, 0,
+ax_anim 2, 0, 50, 6, -3, 6, 0,
+ax_anim 1, 0, 50, 0, -2, 0, 0,
+ax_anim 1, 2, 51, -4, -1, -4, 0,
+ax_anim 1, 0, 51, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 1, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 51, -20, 0, -20, 0,
+ax_anim 2, 0, 51, -21, 0, -21, 0,
+ax_anim 2, 0, 49, -14, 0, -14, 0,
+ax_anim 2, 0, 49, -6, 0, -6, 0,
+ax_anim_terminator
+sVenomothAnims_2_8:
+ax_anim 2, 0, 53, 1, -2, 1, -1,
+ax_anim 2, 0, 52, 5, -6, 5, -5,
+ax_anim 2, 0, 54, 6, -8, 6, -6,
+ax_anim 2, 0, 53, 6, -8, 6, -6,
+ax_anim 2, 0, 54, 6, -8, 6, -6,
+ax_anim 1, 0, 54, 0, -2, 0, 0,
+ax_anim 1, 2, 55, -4, 3, -4, 4,
+ax_anim 1, 0, 55, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -22, 23, -22, 23,
+ax_anim 2, 1, 55, -23, 23, -23, 23,
+ax_anim 2, 0, 55, -22, 23, -22, 23,
+ax_anim 2, 0, 55, -23, 23, -23, 23,
+ax_anim 2, 0, 53, -14, 14, -14, 14,
+ax_anim 2, 0, 53, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVenomothAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 2, 0, 56, 0, -5, 0, -2,
+ax_anim 2, 0, 58, 0, -6, 0, -3,
+ax_anim 2, 0, 57, 0, -6, 0, -3,
+ax_anim 2, 0, 58, 0, -6, 0, -3,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 4,
+ax_anim 1, 0, 59, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 25, 0, 22,
+ax_anim 2, 1, 59, 1, 25, 1, 22,
+ax_anim 2, 0, 59, 0, 25, 0, 22,
+ax_anim 2, 0, 59, 1, 25, 1, 22,
+ax_anim 2, 0, 57, 0, 14, 0, 14,
+ax_anim 2, 0, 57, 0, 6, 0, 6,
+ax_anim_terminator
+sVenomothAnims_3_2:
+ax_anim 2, 0, 61, -1, -2, -1, -1,
+ax_anim 2, 0, 60, -5, -6, -5, -5,
+ax_anim 2, 0, 62, -6, -8, -6, -6,
+ax_anim 2, 0, 61, -6, -8, -6, -6,
+ax_anim 2, 0, 62, -6, -8, -6, -6,
+ax_anim 1, 0, 62, 0, -2, 0, 0,
+ax_anim 1, 2, 63, 4, 3, 4, 4,
+ax_anim 1, 0, 63, 10, 10, 10, 10,
+ax_anim 2, 0, 63, 22, 23, 22, 23,
+ax_anim 2, 1, 63, 23, 23, 23, 23,
+ax_anim 2, 0, 63, 22, 23, 22, 23,
+ax_anim 2, 0, 63, 23, 23, 23, 23,
+ax_anim 2, 0, 61, 14, 14, 14, 14,
+ax_anim 2, 0, 61, 6, 6, 6, 6,
+ax_anim_terminator
+sVenomothAnims_3_3:
+ax_anim 2, 0, 65, -1, -1, -1, 0,
+ax_anim 2, 0, 64, -5, -2, -5, 0,
+ax_anim 2, 0, 66, -6, -3, -6, 0,
+ax_anim 2, 0, 65, -6, -3, -6, 0,
+ax_anim 2, 0, 66, -6, -3, -6, 0,
+ax_anim 1, 0, 66, 0, -2, 0, 0,
+ax_anim 1, 2, 67, 4, -1, 4, 0,
+ax_anim 1, 0, 67, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 20, 0, 20, 0,
+ax_anim 2, 1, 67, 21, 0, 21, 0,
+ax_anim 2, 0, 67, 20, 0, 20, 0,
+ax_anim 2, 0, 67, 21, 0, 21, 0,
+ax_anim 2, 0, 65, 14, 0, 14, 0,
+ax_anim 2, 0, 65, 6, 0, 6, 0,
+ax_anim_terminator
+sVenomothAnims_3_4:
+ax_anim 2, 0, 69, -1, 0, -1, 1,
+ax_anim 2, 0, 68, -5, -1, -2, 2,
+ax_anim 2, 0, 70, -6, -2, -3, 3,
+ax_anim 2, 0, 69, -6, -2, -3, 3,
+ax_anim 2, 0, 70, -6, -2, -3, 3,
+ax_anim 1, 0, 70, 0, -5, 0, 0,
+ax_anim 1, 2, 71, 4, -8, 4, -4,
+ax_anim 1, 0, 71, 10, -11, 10, -10,
+ax_anim 2, 0, 71, 19, -16, 19, -16,
+ax_anim 2, 1, 71, 20, -16, 20, -16,
+ax_anim 2, 0, 71, 19, -16, 19, -16,
+ax_anim 2, 0, 71, 20, -16, 20, -16,
+ax_anim 2, 0, 69, 14, -14, 14, -14,
+ax_anim 2, 0, 69, 6, -6, 6, -6,
+ax_anim_terminator
+sVenomothAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 73, 0, 2, 0, 2,
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 75, 0, -2, 0, -2,
+ax_anim 1, 0, 75, 0, -6, 0, -6,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 1, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 75, 0, -16, 0, -16,
+ax_anim 2, 0, 75, 1, -16, 1, -16,
+ax_anim 2, 0, 73, 0, -8, 0, -8,
+ax_anim 2, 0, 73, 0, -4, 0, -4,
+ax_anim_terminator
+sVenomothAnims_3_6:
+ax_anim 2, 0, 77, 1, 0, 1, 1,
+ax_anim 2, 0, 76, 5, -1, 2, 2,
+ax_anim 2, 0, 78, 6, -2, 3, 3,
+ax_anim 2, 0, 77, 6, -2, 3, 3,
+ax_anim 2, 0, 78, 6, -2, 3, 3,
+ax_anim 1, 0, 78, 0, -5, 0, 0,
+ax_anim 1, 2, 79, -4, -8, -4, -4,
+ax_anim 1, 0, 79, -10, -11, -10, -10,
+ax_anim 2, 0, 79, -19, -16, -19, -16,
+ax_anim 2, 1, 79, -20, -16, -20, -16,
+ax_anim 2, 0, 79, -19, -16, -19, -16,
+ax_anim 2, 0, 79, -20, -16, -20, -16,
+ax_anim 2, 0, 77, -14, -14, -14, -14,
+ax_anim 2, 0, 77, -6, -6, -6, -6,
+ax_anim_terminator
+sVenomothAnims_3_7:
+ax_anim 2, 0, 81, 1, -1, 1, 0,
+ax_anim 2, 0, 80, 5, -2, 5, 0,
+ax_anim 2, 0, 82, 6, -3, 6, 0,
+ax_anim 2, 0, 81, 6, -3, 6, 0,
+ax_anim 2, 0, 82, 6, -3, 6, 0,
+ax_anim 1, 0, 82, 0, -2, 0, 0,
+ax_anim 1, 2, 83, -4, -1, -4, 0,
+ax_anim 1, 0, 83, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 1, 83, -21, 0, -21, 0,
+ax_anim 2, 0, 83, -20, 0, -20, 0,
+ax_anim 2, 0, 83, -21, 0, -21, 0,
+ax_anim 2, 0, 81, -14, 0, -14, 0,
+ax_anim 2, 0, 81, -6, 0, -6, 0,
+ax_anim_terminator
+sVenomothAnims_3_8:
+ax_anim 2, 0, 85, 1, -2, 1, -1,
+ax_anim 2, 0, 84, 5, -6, 5, -5,
+ax_anim 2, 0, 86, 6, -8, 6, -6,
+ax_anim 2, 0, 85, 6, -8, 6, -6,
+ax_anim 2, 0, 86, 6, -8, 6, -6,
+ax_anim 1, 0, 86, 0, -2, 0, 0,
+ax_anim 1, 2, 87, -4, 3, -4, 4,
+ax_anim 1, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -22, 23, -22, 23,
+ax_anim 2, 1, 87, -23, 23, -23, 23,
+ax_anim 2, 0, 87, -22, 23, -22, 23,
+ax_anim 2, 0, 87, -23, 23, -23, 23,
+ax_anim 2, 0, 85, -14, 14, -14, 14,
+ax_anim 2, 0, 85, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVenomothAnims_4_1:
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 1, 1, 0,
+ax_anim 1, 0, 88, 1, 2, 1, 0,
+ax_anim 2, 0, 90, 0, 2, 0, 0,
+ax_anim 1, 2, 88, 0, 1, 0, 0,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim 1, 0, 88, -1, -1, -1, 0,
+ax_anim 2, 0, 90, 0, -1, 0, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 1, 0, 0,
+ax_anim 1, 1, 88, -1, 1, -1, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim 1, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 1, 1, 1, 0,
+ax_anim 1, 0, 88, 1, 2, 1, 0,
+ax_anim 2, 0, 90, 0, 2, 0, 0,
+ax_anim 1, 0, 88, 0, 1, 0, 0,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim 1, 0, 88, -1, -1, -1, 0,
+ax_anim 2, 0, 90, 0, -1, 0, 0,
+ax_anim_terminator
+sVenomothAnims_4_2:
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 1, 0, 91, 1, 2, 1, 2,
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 1, 2, 91, 0, 1, 0, 1,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 1, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 1, 0, 91, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 1, 0, 1,
+ax_anim 1, 1, 91, -1, 1, -1, 1,
+ax_anim 2, 0, 93, -1, 0, -1, 0,
+ax_anim 1, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, 1, 1, 1,
+ax_anim 1, 0, 91, 1, 2, 1, 2,
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 1, 0, 91, 0, 1, 0, 1,
+ax_anim 2, 0, 92, 1, 0, 1, 0,
+ax_anim 1, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim_terminator
+sVenomothAnims_4_3:
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 0,
+ax_anim 1, 0, 94, 1, 2, 1, 0,
+ax_anim 2, 0, 96, 0, 2, 0, 0,
+ax_anim 1, 2, 94, 0, 1, 0, 0,
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 1, 0, 94, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 1, -1, 1, 0,
+ax_anim 1, 0, 94, 1, 0, 1, 0,
+ax_anim 2, 0, 95, 0, 1, 0, 0,
+ax_anim 1, 1, 94, -1, 1, -1, 0,
+ax_anim 2, 0, 96, -1, 0, -1, 0,
+ax_anim 1, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 1, 1, 1, 0,
+ax_anim 1, 0, 94, 1, 2, 1, 0,
+ax_anim 2, 0, 96, 0, 2, 0, 0,
+ax_anim 1, 0, 94, 0, 1, 0, 0,
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 1, 0, 94, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 1, -1, 1, 0,
+ax_anim_terminator
+sVenomothAnims_4_4:
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim 1, 0, 97, 1, -2, 1, -2,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 1, 2, 97, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 1, 0, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim 1, 0, 97, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, -1, 0, -1,
+ax_anim 1, 1, 97, -1, -1, -1, -1,
+ax_anim 2, 0, 99, -1, 0, -1, 0,
+ax_anim 1, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim 1, 0, 97, 1, -2, 1, -2,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 1, 0, 97, 0, -1, 0, -1,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 1, 0, 97, 1, 1, 1, 1,
+ax_anim 2, 0, 99, 1, 1, 1, 1,
+ax_anim_terminator
+sVenomothAnims_4_5:
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, 1, 1, 0,
+ax_anim 1, 0, 100, 1, 2, 1, 0,
+ax_anim 2, 0, 102, 0, 2, 0, 0,
+ax_anim 1, 2, 100, 0, 1, 0, 0,
+ax_anim 2, 0, 101, -1, 0, -1, 0,
+ax_anim 1, 0, 100, -1, -1, -1, 0,
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 1, 0, 0,
+ax_anim 1, 1, 100, -1, 1, -1, 0,
+ax_anim 2, 0, 102, -1, 0, -1, 0,
+ax_anim 1, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 1, 1, 1, 0,
+ax_anim 1, 0, 100, 1, 2, 1, 0,
+ax_anim 2, 0, 102, 0, 2, 0, 0,
+ax_anim 1, 0, 100, 0, 1, 0, 0,
+ax_anim 2, 0, 101, -1, 0, -1, 0,
+ax_anim 1, 0, 100, -1, -1, -1, 0,
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim_terminator
+sVenomothAnims_4_6:
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, -1, -1, -1, -1,
+ax_anim 1, 0, 103, -1, -2, -1, -2,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 1, 2, 103, 0, -1, 0, -1,
+ax_anim 2, 0, 104, -1, 0, -1, 0,
+ax_anim 1, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim 1, 0, 103, -1, 0, -1, 0,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 1, 1, 103, 1, -1, 1, -1,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 1, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 104, -1, -1, -1, -1,
+ax_anim 1, 0, 103, -1, -2, -1, -2,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 1, 0, 103, 0, -1, 0, -1,
+ax_anim 2, 0, 104, -1, 0, -1, 0,
+ax_anim 1, 0, 103, -1, 1, -1, 1,
+ax_anim 2, 0, 105, -1, 1, -1, 1,
+ax_anim_terminator
+sVenomothAnims_4_7:
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 1, -1, 0,
+ax_anim 1, 0, 106, -1, 2, -1, 0,
+ax_anim 2, 0, 108, 0, 2, 0, 0,
+ax_anim 1, 2, 106, 0, 1, 0, 0,
+ax_anim 2, 0, 107, -1, 0, -1, 0,
+ax_anim 1, 0, 106, -1, -1, -1, 0,
+ax_anim 2, 0, 108, -1, -1, -1, 0,
+ax_anim 1, 0, 106, -1, 0, -1, 0,
+ax_anim 2, 0, 107, 0, 1, 0, 0,
+ax_anim 1, 1, 106, 1, 1, 1, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 107, -1, 1, -1, 0,
+ax_anim 1, 0, 106, -1, 2, -1, 0,
+ax_anim 2, 0, 108, 0, 2, 0, 0,
+ax_anim 1, 0, 106, 0, 1, 0, 0,
+ax_anim 2, 0, 107, -1, 0, -1, 0,
+ax_anim 1, 0, 106, -1, -1, -1, 0,
+ax_anim 2, 0, 108, -1, -1, -1, 0,
+ax_anim_terminator
+sVenomothAnims_4_8:
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -1, 1, -1, 1,
+ax_anim 1, 0, 109, -1, 2, -1, 2,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 1, 2, 109, 0, 1, 0, 1,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 1, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 1, 0, 109, -1, 0, -1, 0,
+ax_anim 2, 0, 110, 0, 1, 0, 1,
+ax_anim 1, 1, 109, 1, 1, 1, 1,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 110, -1, 1, -1, 1,
+ax_anim 1, 0, 109, -1, 2, -1, 2,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 1, 0, 109, 0, 1, 0, 1,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 1, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sVenomothAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_5_2:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_5_4:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_5_5:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_5_6:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_5_8:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_6_1:
+ax_anim 30, 0, 136, 3, 1, 0, 0,
+ax_anim 8, 0, 136, 3, 1, 0, 0,
+ax_anim 8, 0, 136, 3, 1, 0, 0,
+ax_anim 30, 0, 137, 3, 0, 0, 0,
+ax_anim 8, 0, 137, 3, 0, 0, 0,
+ax_anim 8, 0, 137, 3, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sVenomothAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sVenomothAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sVenomothAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sVenomothAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sVenomothAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sVenomothAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sVenomothAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVenomothAnims_8_1:
+ax_anim 12, 0, 146, 0, 0, 0, 0,
+ax_anim 12, 0, 147, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 148, 0, -2, 0, 0,
+ax_anim 12, 0, 146, 0, -2, 0, 0,
+ax_anim 12, 0, 147, 0, -1, 0, 0,
+ax_anim 12, 0, 146, 0, -1, 0, 0,
+ax_anim 12, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_8_2:
+ax_anim 12, 0, 149, 0, 0, 0, 0,
+ax_anim 12, 0, 150, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 151, 0, -2, 0, 0,
+ax_anim 12, 0, 149, 0, -2, 0, 0,
+ax_anim 12, 0, 150, 0, -1, 0, 0,
+ax_anim 12, 0, 149, 0, -1, 0, 0,
+ax_anim 12, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_8_3:
+ax_anim 12, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 153, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 154, 0, -2, 0, 0,
+ax_anim 12, 0, 152, 0, -2, 0, 0,
+ax_anim 12, 0, 153, 0, -1, 0, 0,
+ax_anim 12, 0, 152, 0, -1, 0, 0,
+ax_anim 12, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_8_4:
+ax_anim 12, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 156, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, -1, 0, 0,
+ax_anim 12, 0, 157, 0, -2, 0, 0,
+ax_anim 12, 0, 155, 0, -2, 0, 0,
+ax_anim 12, 0, 156, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, -1, 0, 0,
+ax_anim 12, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_8_5:
+ax_anim 12, 0, 158, 0, 0, 0, 0,
+ax_anim 12, 0, 159, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, -1, 0, 0,
+ax_anim 12, 0, 160, 0, -2, 0, 0,
+ax_anim 12, 0, 158, 0, -2, 0, 0,
+ax_anim 12, 0, 159, 0, -1, 0, 0,
+ax_anim 12, 0, 158, 0, -1, 0, 0,
+ax_anim 12, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_8_6:
+ax_anim 12, 0, 161, 0, 0, 0, 0,
+ax_anim 12, 0, 162, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 12, 0, 163, 0, -2, 0, 0,
+ax_anim 12, 0, 161, 0, -2, 0, 0,
+ax_anim 12, 0, 162, 0, -1, 0, 0,
+ax_anim 12, 0, 161, 0, -1, 0, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_8_7:
+ax_anim 12, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, -1, 0, 0,
+ax_anim 12, 0, 164, 0, -1, 0, 0,
+ax_anim 12, 0, 166, 0, -2, 0, 0,
+ax_anim 12, 0, 164, 0, -2, 0, 0,
+ax_anim 12, 0, 165, 0, -1, 0, 0,
+ax_anim 12, 0, 164, 0, -1, 0, 0,
+ax_anim 12, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_8_8:
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 12, 0, 168, 0, -1, 0, 0,
+ax_anim 12, 0, 167, 0, -1, 0, 0,
+ax_anim 12, 0, 169, 0, -2, 0, 0,
+ax_anim 12, 0, 167, 0, -2, 0, 0,
+ax_anim 12, 0, 168, 0, -1, 0, 0,
+ax_anim 12, 0, 167, 0, -1, 0, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 22, 0, 20,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 3, 19, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 19, 21, 19, 21,
+ax_anim 2, 3, 174, 11, 21, 11, 19,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 19, 1, 19, 1,
+ax_anim 2, 3, 173, 17, 4, 17, 4,
+ax_anim 2, 0, 174, 12, 7, 12, 7,
+ax_anim 1, 0, 175, 4, 3, 4, 3,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 18, -19, 18, -19,
+ax_anim 2, 3, 172, 22, -12, 22, -12,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, 1, 7, 1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -16, -7, -16,
+ax_anim 3, 0, 170, 0, -20, 0, -20,
+ax_anim 2, 3, 171, 7, -16, 7, -16,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -18, -19, -18, -19,
+ax_anim 2, 3, 176, -22, -12, -22, -12,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -19, -1, -19, -1,
+ax_anim 2, 3, 175, -17, 4, -17, 4,
+ax_anim 2, 0, 174, -12, 7, -12, 7,
+ax_anim 1, 0, 173, -4, 3, -4, 3,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 3, -19, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -19, 21, -19, 21,
+ax_anim 2, 3, 174, -11, 21, -11, 19,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -24, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 3, 0, 0,
+ax_anim_terminator
+sVenomothAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -24, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 3, 0, 0,
+ax_anim_terminator
+sVenomothAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 2, 0, 0,
+ax_anim_terminator
+sVenomothAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 3, 0, 0,
+ax_anim_terminator
+sVenomothAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 3, 0, 0,
+ax_anim_terminator
+sVenomothAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 3, 0, 0,
+ax_anim_terminator
+sVenomothAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 2, 0, 0,
+ax_anim_terminator
+sVenomothAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -24, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 3, 0, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenomothAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sVenomothGfx1:
+.incbin "baserom.gba", 0x711630, 0x200
+sVenomothSprites1:
+ax_sprite sVenomothGfx1, 0x200
+ax_sprite_terminator
+sVenomothGfx2:
+.incbin "baserom.gba", 0x711840, 0x200
+sVenomothSprites2:
+ax_sprite sVenomothGfx2, 0x200
+ax_sprite_terminator
+sVenomothGfx3:
+.incbin "baserom.gba", 0x711A50, 0x200
+sVenomothSprites3:
+ax_sprite sVenomothGfx3, 0x200
+ax_sprite_terminator
+sVenomothGfx4:
+.incbin "baserom.gba", 0x711C60, 0x200
+sVenomothSprites4:
+ax_sprite sVenomothGfx4, 0x200
+ax_sprite_terminator
+sVenomothGfx5:
+.incbin "baserom.gba", 0x711E70, 0x200
+sVenomothSprites5:
+ax_sprite sVenomothGfx5, 0x200
+ax_sprite_terminator
+sVenomothGfx6:
+.incbin "baserom.gba", 0x712080, 0x200
+sVenomothSprites6:
+ax_sprite sVenomothGfx6, 0x200
+ax_sprite_terminator
+sVenomothGfx7:
+.incbin "baserom.gba", 0x712290, 0x200
+sVenomothSprites7:
+ax_sprite sVenomothGfx7, 0x200
+ax_sprite_terminator
+sVenomothGfx8:
+.incbin "baserom.gba", 0x7124A0, 0x100
+sVenomothSprites8:
+ax_sprite sVenomothGfx8, 0x100
+ax_sprite_terminator
+sVenomothGfx9:
+.incbin "baserom.gba", 0x7125B0, 0x200
+sVenomothSprites9:
+ax_sprite sVenomothGfx9, 0x200
+ax_sprite_terminator
+sVenomothGfx10:
+.incbin "baserom.gba", 0x7127C0, 0x200
+sVenomothSprites10:
+ax_sprite sVenomothGfx10, 0x200
+ax_sprite_terminator
+sVenomothGfx11:
+.incbin "baserom.gba", 0x7129D0, 0x200
+sVenomothSprites11:
+ax_sprite sVenomothGfx11, 0x200
+ax_sprite_terminator
+sVenomothGfx12:
+.incbin "baserom.gba", 0x712BE0, 0x200
+sVenomothSprites12:
+ax_sprite sVenomothGfx12, 0x200
+ax_sprite_terminator
+sVenomothGfx13:
+.incbin "baserom.gba", 0x712DF0, 0x200
+sVenomothSprites13:
+ax_sprite sVenomothGfx13, 0x200
+ax_sprite_terminator
+sVenomothGfx14:
+.incbin "baserom.gba", 0x713000, 0x200
+sVenomothSprites14:
+ax_sprite sVenomothGfx14, 0x200
+ax_sprite_terminator
+sVenomothGfx15:
+.incbin "baserom.gba", 0x713210, 0x200
+sVenomothSprites15:
+ax_sprite sVenomothGfx15, 0x200
+ax_sprite_terminator
+sVenomothGfx16:
+.incbin "baserom.gba", 0x713420, 0x160
+sVenomothSprites16:
+ax_sprite sVenomothGfx16, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVenomothGfx17:
+.incbin "baserom.gba", 0x713598, 0x20
+sVenomothGfx17_1:
+.incbin "baserom.gba", 0x7135B8, 0x60
+sVenomothGfx17_2:
+.incbin "baserom.gba", 0x713618, 0x60
+sVenomothGfx17_3:
+.incbin "baserom.gba", 0x713678, 0x60
+sVenomothSprites17:
+ax_sprite sVenomothGfx17, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVenomothGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenomothGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenomothGfx17_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenomothGfx18:
+.incbin "baserom.gba", 0x713720, 0x40
+sVenomothGfx18_1:
+.incbin "baserom.gba", 0x713760, 0x40
+sVenomothGfx18_2:
+.incbin "baserom.gba", 0x7137A0, 0x60
+sVenomothGfx18_3:
+.incbin "baserom.gba", 0x713800, 0x40
+sVenomothSprites18:
+ax_sprite sVenomothGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVenomothGfx18_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVenomothGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVenomothGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenomothGfx19:
+.incbin "baserom.gba", 0x713888, 0x60
+sVenomothGfx19_1:
+.incbin "baserom.gba", 0x7138E8, 0x60
+sVenomothGfx19_2:
+.incbin "baserom.gba", 0x713948, 0x60
+sVenomothGfx19_3:
+.incbin "baserom.gba", 0x7139A8, 0x20
+sVenomothSprites19:
+ax_sprite sVenomothGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenomothGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenomothGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVenomothGfx19_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sVenomothGfx20:
+.incbin "baserom.gba", 0x713A10, 0x60
+sVenomothGfx20_1:
+.incbin "baserom.gba", 0x713A70, 0x60
+sVenomothGfx20_2:
+.incbin "baserom.gba", 0x713AD0, 0x60
+sVenomothSprites20:
+ax_sprite sVenomothGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenomothGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenomothGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVenomothGfx21:
+.incbin "baserom.gba", 0x713B68, 0x200
+sVenomothSprites21:
+ax_sprite sVenomothGfx21, 0x200
+ax_sprite_terminator
+sVenomothGfx22:
+.incbin "baserom.gba", 0x713D78, 0x200
+sVenomothSprites22:
+ax_sprite sVenomothGfx22, 0x200
+ax_sprite_terminator
+sVenomothGfx23:
+.incbin "baserom.gba", 0x713F88, 0x200
+sVenomothSprites23:
+ax_sprite sVenomothGfx23, 0x200
+ax_sprite_terminator
+sVenomothGfx24:
+.incbin "baserom.gba", 0x714198, 0x200
+sVenomothSprites24:
+ax_sprite sVenomothGfx24, 0x200
+ax_sprite_terminator
+sVenomothGfx25:
+.incbin "baserom.gba", 0x7143A8, 0x200
+sVenomothSprites25:
+ax_sprite sVenomothGfx25, 0x200
+ax_sprite_terminator
+sVenomothGfx26:
+.incbin "baserom.gba", 0x7145B8, 0x200
+sVenomothSprites26:
+ax_sprite sVenomothGfx26, 0x200
+ax_sprite_terminator
+sVenomothGfx27:
+.incbin "baserom.gba", 0x7147C8, 0x200
+sVenomothSprites27:
+ax_sprite sVenomothGfx27, 0x200
+ax_sprite_terminator
+sAxPosesVenomoth:
+.4byte sVenomothPose1
+.4byte sVenomothPose2
+.4byte sVenomothPose3
+.4byte sVenomothPose4
+.4byte sVenomothPose5
+.4byte sVenomothPose6
+.4byte sVenomothPose7
+.4byte sVenomothPose8
+.4byte sVenomothPose9
+.4byte sVenomothPose10
+.4byte sVenomothPose11
+.4byte sVenomothPose12
+.4byte sVenomothPose13
+.4byte sVenomothPose14
+.4byte sVenomothPose15
+.4byte sVenomothPose16
+.4byte sVenomothPose17
+.4byte sVenomothPose18
+.4byte sVenomothPose19
+.4byte sVenomothPose20
+.4byte sVenomothPose21
+.4byte sVenomothPose22
+.4byte sVenomothPose23
+.4byte sVenomothPose24
+.4byte sVenomothPose25
+.4byte sVenomothPose26
+.4byte sVenomothPose27
+.4byte sVenomothPose28
+.4byte sVenomothPose29
+.4byte sVenomothPose30
+.4byte sVenomothPose31
+.4byte sVenomothPose32
+.4byte sVenomothPose33
+.4byte sVenomothPose34
+.4byte sVenomothPose35
+.4byte sVenomothPose36
+.4byte sVenomothPose37
+.4byte sVenomothPose38
+.4byte sVenomothPose39
+.4byte sVenomothPose40
+.4byte sVenomothPose41
+.4byte sVenomothPose42
+.4byte sVenomothPose43
+.4byte sVenomothPose44
+.4byte sVenomothPose45
+.4byte sVenomothPose46
+.4byte sVenomothPose47
+.4byte sVenomothPose48
+.4byte sVenomothPose49
+.4byte sVenomothPose50
+.4byte sVenomothPose51
+.4byte sVenomothPose52
+.4byte sVenomothPose53
+.4byte sVenomothPose54
+.4byte sVenomothPose55
+.4byte sVenomothPose56
+.4byte sVenomothPose57
+.4byte sVenomothPose58
+.4byte sVenomothPose59
+.4byte sVenomothPose60
+.4byte sVenomothPose61
+.4byte sVenomothPose62
+.4byte sVenomothPose63
+.4byte sVenomothPose64
+.4byte sVenomothPose65
+.4byte sVenomothPose66
+.4byte sVenomothPose67
+.4byte sVenomothPose68
+.4byte sVenomothPose69
+.4byte sVenomothPose70
+.4byte sVenomothPose71
+.4byte sVenomothPose72
+.4byte sVenomothPose73
+.4byte sVenomothPose74
+.4byte sVenomothPose75
+.4byte sVenomothPose76
+.4byte sVenomothPose77
+.4byte sVenomothPose78
+.4byte sVenomothPose79
+.4byte sVenomothPose80
+.4byte sVenomothPose81
+.4byte sVenomothPose82
+.4byte sVenomothPose83
+.4byte sVenomothPose84
+.4byte sVenomothPose85
+.4byte sVenomothPose86
+.4byte sVenomothPose87
+.4byte sVenomothPose88
+.4byte sVenomothPose89
+.4byte sVenomothPose90
+.4byte sVenomothPose91
+.4byte sVenomothPose92
+.4byte sVenomothPose93
+.4byte sVenomothPose94
+.4byte sVenomothPose95
+.4byte sVenomothPose96
+.4byte sVenomothPose97
+.4byte sVenomothPose98
+.4byte sVenomothPose99
+.4byte sVenomothPose100
+.4byte sVenomothPose101
+.4byte sVenomothPose102
+.4byte sVenomothPose103
+.4byte sVenomothPose104
+.4byte sVenomothPose105
+.4byte sVenomothPose106
+.4byte sVenomothPose107
+.4byte sVenomothPose108
+.4byte sVenomothPose109
+.4byte sVenomothPose110
+.4byte sVenomothPose111
+.4byte sVenomothPose112
+.4byte sVenomothPose113
+.4byte sVenomothPose114
+.4byte sVenomothPose115
+.4byte sVenomothPose116
+.4byte sVenomothPose117
+.4byte sVenomothPose118
+.4byte sVenomothPose119
+.4byte sVenomothPose120
+.4byte sVenomothPose121
+.4byte sVenomothPose122
+.4byte sVenomothPose123
+.4byte sVenomothPose124
+.4byte sVenomothPose125
+.4byte sVenomothPose126
+.4byte sVenomothPose127
+.4byte sVenomothPose128
+.4byte sVenomothPose129
+.4byte sVenomothPose130
+.4byte sVenomothPose131
+.4byte sVenomothPose132
+.4byte sVenomothPose133
+.4byte sVenomothPose134
+.4byte sVenomothPose135
+.4byte sVenomothPose136
+.4byte sVenomothPose137
+.4byte sVenomothPose138
+.4byte sVenomothPose139
+.4byte sVenomothPose140
+.4byte sVenomothPose141
+.4byte sVenomothPose142
+.4byte sVenomothPose143
+.4byte sVenomothPose144
+.4byte sVenomothPose145
+.4byte sVenomothPose146
+.4byte sVenomothPose147
+.4byte sVenomothPose148
+.4byte sVenomothPose149
+.4byte sVenomothPose150
+.4byte sVenomothPose151
+.4byte sVenomothPose152
+.4byte sVenomothPose153
+.4byte sVenomothPose154
+.4byte sVenomothPose155
+.4byte sVenomothPose156
+.4byte sVenomothPose157
+.4byte sVenomothPose158
+.4byte sVenomothPose159
+.4byte sVenomothPose160
+.4byte sVenomothPose161
+.4byte sVenomothPose162
+.4byte sVenomothPose163
+.4byte sVenomothPose164
+.4byte sVenomothPose165
+.4byte sVenomothPose166
+.4byte sVenomothPose167
+.4byte sVenomothPose168
+.4byte sVenomothPose169
+.4byte sVenomothPose170
+.4byte sVenomothPose171
+.4byte sVenomothPose172
+.4byte sVenomothPose173
+.4byte sVenomothPose174
+.4byte sVenomothPose175
+.4byte sVenomothPose176
+.4byte sVenomothPose177
+.4byte sVenomothPose178
+.4byte sVenomothPose179
+.4byte sVenomothPose180
+.4byte sVenomothPose181
+.4byte sVenomothPose182
+.4byte sVenomothPose183
+.4byte sVenomothPose184
+.4byte sVenomothPose185
+.4byte sVenomothPose186
+.4byte sVenomothPose187
+.4byte sVenomothPose188
+.4byte sVenomothPose189
+.4byte sVenomothPose190
+.4byte sVenomothPose191
+.4byte sVenomothPose192
+.4byte sVenomothPose193
+.4byte sVenomothPose194
+.4byte sVenomothPose195
+.4byte sVenomothPose196
+.4byte sVenomothPose197
+.4byte sVenomothPose198
+.4byte sVenomothPose199
+.4byte sVenomothPose200
+.4byte sVenomothPose201
+.4byte sVenomothPose202
+.4byte sVenomothPose203
+.4byte sVenomothPose204
+.4byte sVenomothPose205
+.4byte sVenomothPose206
+.4byte sVenomothPose207
+.4byte sVenomothPose208
+.4byte sVenomothPose209
+.4byte sVenomothPose210
+.4byte sVenomothPose211
+.4byte sVenomothPose212
+.4byte sVenomothPose213
+.4byte sVenomothPose214
+.4byte sVenomothPose215
+.4byte sVenomothPose216
+.4byte sVenomothPose217
+.4byte sVenomothPose218
+.4byte sVenomothPose219
+.4byte sVenomothPose220
+.4byte sVenomothPose221
+.4byte sVenomothPose222
+.4byte sVenomothPose223
+.4byte sVenomothPose224
+.4byte sVenomothPose225
+.4byte sVenomothPose226
+sAxPositionsVenomoth:
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -23, 	   7,  -23, 	  -1,  -12
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte    2,  -10, 	   3,  -23, 	 -10,  -20, 	  -1,  -11
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    5,  -10, 	  -7,  -24, 	  -9,  -18, 	   1,   -9
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    6,  -14, 	  -9,  -21, 	   2,  -15, 	   0,  -12
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -16, 	   6,  -20, 	  -8,  -20, 	  -1,  -14
+.2byte   -5,  -15, 	   7,  -22, 	  -5,  -16, 	  -1,  -13
+.2byte   -5,  -15, 	   6,  -24, 	  -8,  -17, 	  -1,  -13
+.2byte   -7,  -14, 	   8,  -21, 	  -3,  -15, 	  -1,  -12
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -6,  -10, 	   6,  -24, 	   8,  -18, 	  -2,   -9
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -3,  -10, 	  -4,  -23, 	   9,  -20, 	   0,  -11
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -23, 	   7,  -23, 	  -1,  -12
+.2byte   -1,   -6, 	 -11,  -19, 	   9,  -19, 	  -1,   -9
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte    2,  -10, 	   3,  -23, 	 -10,  -20, 	  -1,  -11
+.2byte    2,   -6, 	   6,  -20, 	  -7,  -18, 	  -1,   -9
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    5,  -10, 	  -7,  -24, 	  -9,  -18, 	   1,   -9
+.2byte    4,   -8, 	   0,  -23, 	   0,  -17, 	   0,  -10
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    6,  -14, 	  -9,  -21, 	   2,  -15, 	   0,  -12
+.2byte    4,  -13, 	  -5,  -24, 	   9,  -16, 	   0,  -13
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -16, 	   6,  -20, 	  -8,  -20, 	  -1,  -14
+.2byte   -1,  -15, 	   8,  -22, 	 -10,  -22, 	  -1,  -14
+.2byte   -5,  -15, 	   7,  -22, 	  -5,  -16, 	  -1,  -13
+.2byte   -5,  -15, 	   6,  -24, 	  -8,  -17, 	  -1,  -13
+.2byte   -7,  -14, 	   8,  -21, 	  -3,  -15, 	  -1,  -12
+.2byte   -5,  -13, 	   4,  -24, 	 -10,  -16, 	  -1,  -13
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -6,  -10, 	   6,  -24, 	   8,  -18, 	  -2,   -9
+.2byte   -5,   -8, 	  -1,  -23, 	  -1,  -17, 	  -1,  -10
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -3,  -10, 	  -4,  -23, 	   9,  -20, 	   0,  -11
+.2byte   -3,   -6, 	  -7,  -20, 	   6,  -18, 	   0,   -9
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -23, 	   7,  -23, 	  -1,  -12
+.2byte   -1,   -6, 	 -11,  -19, 	   9,  -19, 	  -1,   -9
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte    2,  -10, 	   3,  -23, 	 -10,  -20, 	  -1,  -11
+.2byte    2,   -6, 	   6,  -20, 	  -7,  -18, 	  -1,   -9
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    5,  -10, 	  -7,  -24, 	  -9,  -18, 	   1,   -9
+.2byte    4,   -8, 	   0,  -23, 	   0,  -17, 	   0,  -10
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    6,  -14, 	  -9,  -21, 	   2,  -15, 	   0,  -12
+.2byte    4,  -13, 	  -5,  -24, 	   9,  -16, 	   0,  -13
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -16, 	   6,  -20, 	  -8,  -20, 	  -1,  -14
+.2byte   -1,  -15, 	   8,  -22, 	 -10,  -22, 	  -1,  -14
+.2byte   -5,  -15, 	   7,  -22, 	  -5,  -16, 	  -1,  -13
+.2byte   -5,  -15, 	   6,  -24, 	  -8,  -17, 	  -1,  -13
+.2byte   -7,  -14, 	   8,  -21, 	  -3,  -15, 	  -1,  -12
+.2byte   -5,  -13, 	   4,  -24, 	 -10,  -16, 	  -1,  -13
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -6,  -10, 	   6,  -24, 	   8,  -18, 	  -2,   -9
+.2byte   -5,   -8, 	  -1,  -23, 	  -1,  -17, 	  -1,  -10
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -3,  -10, 	  -4,  -23, 	   9,  -20, 	   0,  -11
+.2byte   -3,   -6, 	  -7,  -20, 	   6,  -18, 	   0,   -9
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -23, 	   7,  -23, 	  -1,  -12
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte    2,  -10, 	   3,  -23, 	 -10,  -20, 	  -1,  -11
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    5,  -10, 	  -7,  -24, 	  -9,  -18, 	   1,   -9
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    6,  -14, 	  -9,  -21, 	   2,  -15, 	   0,  -12
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -16, 	   6,  -20, 	  -8,  -20, 	  -1,  -14
+.2byte   -5,  -15, 	   7,  -22, 	  -5,  -16, 	  -1,  -13
+.2byte   -5,  -15, 	   6,  -24, 	  -8,  -17, 	  -1,  -13
+.2byte   -7,  -14, 	   8,  -21, 	  -3,  -15, 	  -1,  -12
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -6,  -10, 	   6,  -24, 	   8,  -18, 	  -2,   -9
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -3,  -10, 	  -4,  -23, 	   9,  -20, 	   0,  -11
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -23, 	   7,  -23, 	  -1,  -12
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte    2,  -10, 	   3,  -23, 	 -10,  -20, 	  -1,  -11
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    5,  -10, 	  -7,  -24, 	  -9,  -18, 	   1,   -9
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    6,  -14, 	  -9,  -21, 	   2,  -15, 	   0,  -12
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -16, 	   6,  -20, 	  -8,  -20, 	  -1,  -14
+.2byte   -5,  -15, 	   7,  -22, 	  -5,  -16, 	  -1,  -13
+.2byte   -5,  -15, 	   6,  -24, 	  -8,  -17, 	  -1,  -13
+.2byte   -7,  -14, 	   8,  -21, 	  -3,  -15, 	  -1,  -12
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -6,  -10, 	   6,  -24, 	   8,  -18, 	  -2,   -9
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -3,  -10, 	  -4,  -23, 	   9,  -20, 	   0,  -11
+.2byte   -6,   -7, 	  -5,  -23, 	   0,  -23, 	  -2,   -9
+.2byte   -6,   -5, 	 -12,  -19, 	   3,  -20, 	  -2,   -8
+.2byte   -1,   -9, 	  -9,  -19, 	   7,  -19, 	  -1,  -11
+.2byte    2,   -9, 	   0,  -24, 	 -12,  -20, 	  -2,  -11
+.2byte    5,  -11, 	  -7,  -21, 	 -10,  -17, 	   1,   -9
+.2byte    4,  -14, 	 -15,  -16, 	  -1,  -12, 	  -2,  -10
+.2byte    0,  -14, 	   7,  -17, 	  -7,  -17, 	   0,  -11
+.2byte   -5,  -14, 	  14,  -16, 	   0,  -12, 	   1,  -10
+.2byte   -6,  -11, 	   6,  -21, 	   9,  -17, 	  -2,   -9
+.2byte   -3,   -9, 	  -1,  -24, 	  11,  -20, 	   1,  -11
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -1,   -9, 	  -9,  -23, 	   7,  -23, 	  -1,  -12
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte    2,  -10, 	   3,  -23, 	 -10,  -20, 	  -1,  -11
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    5,  -10, 	  -7,  -24, 	  -9,  -18, 	   1,   -9
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    6,  -14, 	  -9,  -21, 	   2,  -15, 	   0,  -12
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -16, 	   6,  -20, 	  -8,  -20, 	  -1,  -14
+.2byte   -6,  -15, 	   6,  -22, 	  -6,  -16, 	  -2,  -13
+.2byte   -6,  -15, 	   5,  -24, 	  -9,  -17, 	  -2,  -13
+.2byte   -8,  -14, 	   7,  -21, 	  -4,  -15, 	  -2,  -12
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -6,  -10, 	   6,  -24, 	   8,  -18, 	  -2,   -9
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -3,  -10, 	  -4,  -23, 	   9,  -20, 	   0,  -11
+.2byte   -1,   -6, 	 -11,  -19, 	   9,  -19, 	  -1,   -9
+.2byte   -3,   -6, 	  -7,  -20, 	   6,  -18, 	   0,   -9
+.2byte   -5,   -8, 	  -1,  -23, 	  -1,  -17, 	  -1,  -10
+.2byte   -5,  -12, 	   4,  -23, 	 -10,  -15, 	  -1,  -12
+.2byte   -1,  -13, 	   8,  -20, 	 -10,  -20, 	  -1,  -12
+.2byte    4,  -12, 	  -5,  -23, 	   9,  -15, 	   0,  -12
+.2byte    4,   -8, 	   0,  -23, 	   0,  -17, 	   0,  -10
+.2byte    2,   -6, 	   6,  -20, 	  -7,  -18, 	  -1,   -9
+.2byte   -1,   -6, 	 -11,  -19, 	   9,  -19, 	  -1,   -9
+.2byte    2,   -6, 	   6,  -20, 	  -7,  -18, 	  -1,   -9
+.2byte    4,   -8, 	   0,  -23, 	   0,  -17, 	   0,  -10
+.2byte    4,  -12, 	  -5,  -23, 	   9,  -15, 	   0,  -12
+.2byte   -1,  -13, 	   8,  -20, 	 -10,  -20, 	  -1,  -12
+.2byte   -5,  -12, 	   4,  -23, 	 -10,  -15, 	  -1,  -12
+.2byte   -5,   -8, 	  -1,  -23, 	  -1,  -17, 	  -1,  -10
+.2byte   -3,   -6, 	  -7,  -20, 	   6,  -18, 	   0,   -9
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -1,   -6, 	 -11,  -19, 	   9,  -19, 	  -1,   -9
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte    2,   -6, 	   6,  -20, 	  -7,  -18, 	  -1,   -9
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    4,   -8, 	   0,  -23, 	   0,  -17, 	   0,  -10
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    4,  -13, 	  -5,  -24, 	   9,  -16, 	   0,  -13
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte   -1,  -15, 	   8,  -22, 	 -10,  -22, 	  -1,  -14
+.2byte   -5,  -15, 	   7,  -22, 	  -5,  -16, 	  -1,  -13
+.2byte   -5,  -15, 	   6,  -24, 	  -8,  -17, 	  -1,  -13
+.2byte   -5,  -13, 	   4,  -24, 	 -10,  -16, 	  -1,  -13
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -5,   -8, 	  -1,  -23, 	  -1,  -17, 	  -1,  -10
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -3,   -6, 	  -7,  -20, 	   6,  -18, 	   0,   -9
+.2byte   -1,   -9, 	 -12,  -19, 	  10,  -19, 	  -1,  -11
+.2byte   -3,  -10, 	  -8,  -22, 	   8,  -18, 	  -1,  -10
+.2byte   -6,  -10, 	   1,  -24, 	   4,  -16, 	  -2,   -9
+.2byte   -5,  -15, 	   6,  -24, 	  -8,  -17, 	  -1,  -13
+.2byte   -1,  -16, 	  11,  -22, 	 -13,  -22, 	  -1,  -14
+.2byte    4,  -15, 	  -7,  -24, 	   7,  -17, 	   0,  -13
+.2byte    5,  -10, 	  -2,  -24, 	  -5,  -16, 	   1,   -9
+.2byte    2,  -10, 	   7,  -22, 	  -9,  -18, 	   0,  -10
+.2byte   -1,   -9, 	 -10,  -20, 	   8,  -20, 	  -1,  -11
+.2byte   -3,  -10, 	  -6,  -23, 	   9,  -19, 	  -1,  -10
+.2byte   -6,  -10, 	   3,  -24, 	   5,  -17, 	  -2,  -10
+.2byte   -5,  -15, 	   7,  -22, 	  -5,  -16, 	  -1,  -13
+.2byte   -1,  -16, 	   7,  -21, 	  -9,  -21, 	  -1,  -14
+.2byte    4,  -15, 	  -8,  -22, 	   4,  -16, 	   0,  -13
+.2byte    5,  -10, 	  -4,  -24, 	  -6,  -17, 	   1,  -10
+.2byte    2,  -10, 	   5,  -23, 	 -10,  -19, 	   0,  -10
+sVenomothAnimTable1:
+.4byte sVenomothAnims_1_1
+.4byte sVenomothAnims_1_2
+.4byte sVenomothAnims_1_3
+.4byte sVenomothAnims_1_4
+.4byte sVenomothAnims_1_5
+.4byte sVenomothAnims_1_6
+.4byte sVenomothAnims_1_7
+.4byte sVenomothAnims_1_8
+sVenomothAnimTable2:
+.4byte sVenomothAnims_2_1
+.4byte sVenomothAnims_2_2
+.4byte sVenomothAnims_2_3
+.4byte sVenomothAnims_2_4
+.4byte sVenomothAnims_2_5
+.4byte sVenomothAnims_2_6
+.4byte sVenomothAnims_2_7
+.4byte sVenomothAnims_2_8
+sVenomothAnimTable3:
+.4byte sVenomothAnims_3_1
+.4byte sVenomothAnims_3_2
+.4byte sVenomothAnims_3_3
+.4byte sVenomothAnims_3_4
+.4byte sVenomothAnims_3_5
+.4byte sVenomothAnims_3_6
+.4byte sVenomothAnims_3_7
+.4byte sVenomothAnims_3_8
+sVenomothAnimTable4:
+.4byte sVenomothAnims_4_1
+.4byte sVenomothAnims_4_2
+.4byte sVenomothAnims_4_3
+.4byte sVenomothAnims_4_4
+.4byte sVenomothAnims_4_5
+.4byte sVenomothAnims_4_6
+.4byte sVenomothAnims_4_7
+.4byte sVenomothAnims_4_8
+sVenomothAnimTable5:
+.4byte sVenomothAnims_5_1
+.4byte sVenomothAnims_5_2
+.4byte sVenomothAnims_5_3
+.4byte sVenomothAnims_5_4
+.4byte sVenomothAnims_5_5
+.4byte sVenomothAnims_5_6
+.4byte sVenomothAnims_5_7
+.4byte sVenomothAnims_5_8
+sVenomothAnimTable6:
+.4byte sVenomothAnims_6_1
+.4byte sVenomothAnims_6_1
+.4byte sVenomothAnims_6_1
+.4byte sVenomothAnims_6_1
+.4byte sVenomothAnims_6_1
+.4byte sVenomothAnims_6_1
+.4byte sVenomothAnims_6_1
+.4byte sVenomothAnims_6_1
+sVenomothAnimTable7:
+.4byte sVenomothAnims_7_1
+.4byte sVenomothAnims_7_2
+.4byte sVenomothAnims_7_3
+.4byte sVenomothAnims_7_4
+.4byte sVenomothAnims_7_5
+.4byte sVenomothAnims_7_6
+.4byte sVenomothAnims_7_7
+.4byte sVenomothAnims_7_8
+sVenomothAnimTable8:
+.4byte sVenomothAnims_8_1
+.4byte sVenomothAnims_8_2
+.4byte sVenomothAnims_8_3
+.4byte sVenomothAnims_8_4
+.4byte sVenomothAnims_8_5
+.4byte sVenomothAnims_8_6
+.4byte sVenomothAnims_8_7
+.4byte sVenomothAnims_8_8
+sVenomothAnimTable9:
+.4byte sVenomothAnims_9_1
+.4byte sVenomothAnims_9_2
+.4byte sVenomothAnims_9_3
+.4byte sVenomothAnims_9_4
+.4byte sVenomothAnims_9_5
+.4byte sVenomothAnims_9_6
+.4byte sVenomothAnims_9_7
+.4byte sVenomothAnims_9_8
+sVenomothAnimTable10:
+.4byte sVenomothAnims_10_1
+.4byte sVenomothAnims_10_2
+.4byte sVenomothAnims_10_3
+.4byte sVenomothAnims_10_4
+.4byte sVenomothAnims_10_5
+.4byte sVenomothAnims_10_6
+.4byte sVenomothAnims_10_7
+.4byte sVenomothAnims_10_8
+sVenomothAnimTable11:
+.4byte sVenomothAnims_11_1
+.4byte sVenomothAnims_11_2
+.4byte sVenomothAnims_11_3
+.4byte sVenomothAnims_11_4
+.4byte sVenomothAnims_11_5
+.4byte sVenomothAnims_11_6
+.4byte sVenomothAnims_11_7
+.4byte sVenomothAnims_11_8
+sVenomothAnimTable12:
+.4byte sVenomothAnims_12_1
+.4byte sVenomothAnims_12_2
+.4byte sVenomothAnims_12_3
+.4byte sVenomothAnims_12_4
+.4byte sVenomothAnims_12_5
+.4byte sVenomothAnims_12_6
+.4byte sVenomothAnims_12_7
+.4byte sVenomothAnims_12_8
+sVenomothAnimTable13:
+.4byte sVenomothAnims_13_1
+.4byte sVenomothAnims_13_2
+.4byte sVenomothAnims_13_3
+.4byte sVenomothAnims_13_4
+.4byte sVenomothAnims_13_5
+.4byte sVenomothAnims_13_6
+.4byte sVenomothAnims_13_7
+.4byte sVenomothAnims_13_8
+sAxAnimationsVenomoth:
+.4byte sVenomothAnimTable1
+.4byte sVenomothAnimTable2
+.4byte sVenomothAnimTable3
+.4byte sVenomothAnimTable4
+.4byte sVenomothAnimTable5
+.4byte sVenomothAnimTable6
+.4byte sVenomothAnimTable7
+.4byte sVenomothAnimTable8
+.4byte sVenomothAnimTable9
+.4byte sVenomothAnimTable10
+.4byte sVenomothAnimTable11
+.4byte sVenomothAnimTable12
+.4byte sVenomothAnimTable13
+sAxSpritesVenomoth:
+.4byte sVenomothSprites1
+.4byte sVenomothSprites2
+.4byte sVenomothSprites3
+.4byte sVenomothSprites4
+.4byte sVenomothSprites5
+.4byte sVenomothSprites6
+.4byte sVenomothSprites7
+.4byte sVenomothSprites8
+.4byte sVenomothSprites9
+.4byte sVenomothSprites10
+.4byte sVenomothSprites11
+.4byte sVenomothSprites12
+.4byte sVenomothSprites13
+.4byte sVenomothSprites14
+.4byte sVenomothSprites15
+.4byte sVenomothSprites16
+.4byte sVenomothSprites17
+.4byte sVenomothSprites18
+.4byte sVenomothSprites19
+.4byte sVenomothSprites20
+.4byte sVenomothSprites21
+.4byte sVenomothSprites22
+.4byte sVenomothSprites23
+.4byte sVenomothSprites24
+.4byte sVenomothSprites25
+.4byte sVenomothSprites26
+.4byte sVenomothSprites27
+sAxMainVenomoth:
+ax_main sAxPosesVenomoth, sAxAnimationsVenomoth, 13, sAxSpritesVenomoth, sAxPositionsVenomoth

--- a/data/ax/venonat.inc
+++ b/data/ax/venonat.inc
@@ -1,0 +1,2459 @@
+.global gAxVenonat
+gAxVenonat:
+ax_siro sAxMainVenonat
+sVenonatPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose2:
+ax_pose 1, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose4:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose5:
+ax_pose 4, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose6:
+ax_pose 5, 0x01ec, 0x90ef, 0x2c00
+ax_pose_terminator
+sVenonatPose7:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose8:
+ax_pose 7, 0x01e6, 0x90ef, 0x2c00
+ax_pose_terminator
+sVenonatPose9:
+ax_pose 8, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sVenonatPose10:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose11:
+ax_pose 10, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose12:
+ax_pose 11, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose13:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose14:
+ax_pose 13, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose15:
+ax_pose 14, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose16:
+ax_pose 9, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose17:
+ax_pose 10, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose18:
+ax_pose 11, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose19:
+ax_pose 6, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose20:
+ax_pose 7, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sVenonatPose21:
+ax_pose 8, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sVenonatPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose23:
+ax_pose 4, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose24:
+ax_pose 5, 0x01ec, 0x80f0, 0x2c00
+ax_pose_terminator
+sVenonatPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose28:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose29:
+ax_pose 4, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sVenonatPose30:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose31:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose32:
+ax_pose 7, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose33:
+ax_pose 8, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose34:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose35:
+ax_pose 10, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose36:
+ax_pose 11, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose37:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose38:
+ax_pose 13, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose39:
+ax_pose 14, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose40:
+ax_pose 9, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose41:
+ax_pose 10, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sVenonatPose42:
+ax_pose 11, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sVenonatPose43:
+ax_pose 6, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose44:
+ax_pose 7, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose45:
+ax_pose 8, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose46:
+ax_pose 3, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sVenonatPose47:
+ax_pose 4, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sVenonatPose48:
+ax_pose 5, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose49:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose50:
+ax_pose 1, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose51:
+ax_pose 2, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose52:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose53:
+ax_pose 4, 0x01eb, 0x90e9, 0x2c00
+ax_pose_terminator
+sVenonatPose54:
+ax_pose 5, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose55:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose56:
+ax_pose 7, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose57:
+ax_pose 8, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose58:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose59:
+ax_pose 10, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose60:
+ax_pose 11, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose61:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose62:
+ax_pose 13, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose63:
+ax_pose 14, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose64:
+ax_pose 9, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose65:
+ax_pose 10, 0x01eb, 0x80f5, 0x2c00
+ax_pose_terminator
+sVenonatPose66:
+ax_pose 11, 0x01ea, 0x80f5, 0x2c00
+ax_pose_terminator
+sVenonatPose67:
+ax_pose 6, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose68:
+ax_pose 7, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose69:
+ax_pose 8, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose70:
+ax_pose 3, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sVenonatPose71:
+ax_pose 4, 0x01eb, 0x80f7, 0x2c00
+ax_pose_terminator
+sVenonatPose72:
+ax_pose 5, 0x01eb, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose73:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose74:
+ax_pose 1, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose75:
+ax_pose 2, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose76:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose77:
+ax_pose 4, 0x01e8, 0x90e8, 0x2c00
+ax_pose_terminator
+sVenonatPose78:
+ax_pose 5, 0x01ec, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose79:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose80:
+ax_pose 7, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose81:
+ax_pose 8, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose82:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose83:
+ax_pose 10, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose84:
+ax_pose 11, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose85:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose86:
+ax_pose 13, 0x01e6, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose87:
+ax_pose 14, 0x01ec, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose88:
+ax_pose 9, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose89:
+ax_pose 10, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose90:
+ax_pose 11, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose91:
+ax_pose 6, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose92:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose93:
+ax_pose 8, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose94:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose95:
+ax_pose 4, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sVenonatPose96:
+ax_pose 5, 0x01ec, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose97:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose98:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose99:
+ax_pose 6, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose100:
+ax_pose 9, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose101:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose102:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose103:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose104:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose105:
+ax_pose 15, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose106:
+ax_pose 16, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose107:
+ax_pose 17, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose108:
+ax_pose 18, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose109:
+ax_pose 19, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose110:
+ax_pose 18, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose111:
+ax_pose 17, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose112:
+ax_pose 16, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose113:
+ax_pose 1, 0x01e8, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose114:
+ax_pose 4, 0x01e8, 0x80f7, 0x2c00
+ax_pose_terminator
+sVenonatPose115:
+ax_pose 7, 0x01e6, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose116:
+ax_pose 10, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose117:
+ax_pose 13, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose118:
+ax_pose 10, 0x01e8, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose119:
+ax_pose 7, 0x01e6, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose120:
+ax_pose 4, 0x01e8, 0x90e9, 0x2c00
+ax_pose_terminator
+sVenonatPose121:
+ax_pose 20, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose122:
+ax_pose 21, 0x01ed, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose123:
+ax_pose 22, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sVenonatPose124:
+ax_pose 23, 0x01e3, 0x90ea, 0x2c00
+ax_pose_terminator
+sVenonatPose125:
+ax_pose 24, 0x01e5, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose126:
+ax_pose 25, 0x01e6, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose127:
+ax_pose 26, 0x01e6, 0x80f0, 0x2c00
+ax_pose_terminator
+sVenonatPose128:
+ax_pose 25, 0x01e6, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose129:
+ax_pose 24, 0x01e5, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose130:
+ax_pose 23, 0x01e3, 0x80f6, 0x2c00
+ax_pose_terminator
+sVenonatPose131:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose132:
+ax_pose 1, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose133:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose134:
+ax_pose 4, 0x01ea, 0x90ea, 0x2c00
+ax_pose_terminator
+sVenonatPose135:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose136:
+ax_pose 7, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sVenonatPose137:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose138:
+ax_pose 10, 0x01e9, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose139:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose140:
+ax_pose 13, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose141:
+ax_pose 9, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose142:
+ax_pose 10, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose143:
+ax_pose 6, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose144:
+ax_pose 7, 0x01e8, 0x80f1, 0x2c00
+ax_pose_terminator
+sVenonatPose145:
+ax_pose 3, 0x01ec, 0x80f5, 0x2c00
+ax_pose_terminator
+sVenonatPose146:
+ax_pose 4, 0x01ea, 0x80f6, 0x2c00
+ax_pose_terminator
+sVenonatPose147:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose148:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose149:
+ax_pose 6, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose150:
+ax_pose 9, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose151:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose152:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose153:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose154:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose155:
+ax_pose 1, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose156:
+ax_pose 4, 0x01e9, 0x90e9, 0x2c00
+ax_pose_terminator
+sVenonatPose157:
+ax_pose 7, 0x01e8, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose158:
+ax_pose 10, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose159:
+ax_pose 13, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose160:
+ax_pose 10, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose161:
+ax_pose 7, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose162:
+ax_pose 4, 0x01e9, 0x80f7, 0x2c00
+ax_pose_terminator
+sVenonatPose163:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose164:
+ax_pose 1, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose165:
+ax_pose 2, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose166:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose167:
+ax_pose 4, 0x01ea, 0x90e8, 0x2c00
+ax_pose_terminator
+sVenonatPose168:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose169:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose170:
+ax_pose 7, 0x01e7, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose171:
+ax_pose 8, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose172:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose173:
+ax_pose 10, 0x01eb, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose174:
+ax_pose 11, 0x01e9, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose175:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose176:
+ax_pose 13, 0x01e9, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose177:
+ax_pose 14, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose178:
+ax_pose 9, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose179:
+ax_pose 10, 0x01eb, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose180:
+ax_pose 11, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose181:
+ax_pose 6, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose182:
+ax_pose 7, 0x01e7, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose183:
+ax_pose 8, 0x01e9, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose184:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose185:
+ax_pose 4, 0x01ea, 0x80f7, 0x2c00
+ax_pose_terminator
+sVenonatPose186:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose187:
+ax_pose 2, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose188:
+ax_pose 5, 0x01ea, 0x80f3, 0x2c00
+ax_pose_terminator
+sVenonatPose189:
+ax_pose 8, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose190:
+ax_pose 11, 0x01e9, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose191:
+ax_pose 14, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose192:
+ax_pose 11, 0x01e9, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose193:
+ax_pose 8, 0x01ea, 0x90eb, 0x2c00
+ax_pose_terminator
+sVenonatPose194:
+ax_pose 5, 0x01ea, 0x90ec, 0x2c00
+ax_pose_terminator
+sVenonatPose195:
+ax_pose 0, 0x01ea, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose196:
+ax_pose 3, 0x01ec, 0x80f4, 0x2c00
+ax_pose_terminator
+sVenonatPose197:
+ax_pose 6, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose198:
+ax_pose 9, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose199:
+ax_pose 12, 0x01ea, 0x80f2, 0x2c00
+ax_pose_terminator
+sVenonatPose200:
+ax_pose 9, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose201:
+ax_pose 6, 0x01ea, 0x90ed, 0x2c00
+ax_pose_terminator
+sVenonatPose202:
+ax_pose 3, 0x01ec, 0x90eb, 0x2c00
+ax_pose_terminator
+.align 2
+sVenonatAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 1,
+ax_anim 6, 0, 1, 0, -2, 0, 2,
+ax_anim 8, 0, 2, 0, 0, 0, 1,
+ax_anim_terminator
+sVenonatAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, -1, -2, 1, 1,
+ax_anim 6, 0, 4, 0, -3, 2, 2,
+ax_anim 6, 0, 4, 1, -2, 3, 3,
+ax_anim 8, 0, 5, 0, 0, 2, 2,
+ax_anim_terminator
+sVenonatAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, -1, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 1, 0,
+ax_anim 6, 0, 7, 1, -2, 2, 0,
+ax_anim 8, 0, 8, 0, 0, 2, 0,
+ax_anim_terminator
+sVenonatAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 1, -1,
+ax_anim 6, 0, 10, 1, -2, 2, -2,
+ax_anim 8, 0, 11, 0, 0, 1, -1,
+ax_anim_terminator
+sVenonatAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, -1,
+ax_anim 6, 0, 13, 0, -2, 0, -2,
+ax_anim 8, 0, 14, 0, 0, 0, -1,
+ax_anim_terminator
+sVenonatAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 1, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -3, -1, -1,
+ax_anim 6, 0, 16, -1, -2, -2, -2,
+ax_anim 8, 0, 17, 0, 0, -1, -1,
+ax_anim_terminator
+sVenonatAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 1, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -3, -1, 0,
+ax_anim 6, 0, 19, -1, -2, -2, 0,
+ax_anim 8, 0, 20, 0, 0, -2, 0,
+ax_anim_terminator
+sVenonatAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 1, -2, -1, 1,
+ax_anim 6, 0, 22, 0, -3, -2, 2,
+ax_anim 6, 0, 22, -1, -2, -3, 3,
+ax_anim 8, 0, 23, 0, 0, -2, 2,
+ax_anim_terminator
+.align 2
+sVenonatAnims_2_1:
+ax_anim 1, 0, 25, 0, -1, 0, 2,
+ax_anim 1, 0, 25, 0, -2, 0, 4,
+ax_anim 2, 0, 25, 0, -3, 0, 6,
+ax_anim 3, 0, 25, 0, 0, 0, 8,
+ax_anim 2, 2, 25, 0, 4, 0, 10,
+ax_anim 1, 0, 25, 0, 10, 0, 12,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 0, 6, 0, 6,
+ax_anim 2, 0, 25, 0, 4, 0, 6,
+ax_anim 2, 0, 25, 0, 3, 0, 6,
+ax_anim_terminator
+sVenonatAnims_2_2:
+ax_anim 1, 0, 28, 2, -1, 2, 2,
+ax_anim 1, 0, 28, 4, -2, 4, 4,
+ax_anim 2, 0, 28, 6, -3, 6, 6,
+ax_anim 3, 0, 28, 8, -2, 8, 8,
+ax_anim 2, 2, 28, 10, 0, 10, 10,
+ax_anim 1, 0, 28, 12, 5, 12, 12,
+ax_anim 2, 0, 29, 19, 19, 18, 18,
+ax_anim 2, 1, 29, 20, 18, 20, 18,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 29, 20, 18, 20, 18,
+ax_anim 2, 0, 29, 19, 19, 19, 19,
+ax_anim 2, 0, 28, 10, 2, 2, 6,
+ax_anim 2, 0, 28, 6, 0, 0, 6,
+ax_anim 2, 0, 28, 2, 0, 0, 6,
+ax_anim_terminator
+sVenonatAnims_2_3:
+ax_anim 1, 0, 31, 2, -2, 2, 0,
+ax_anim 1, 0, 31, 4, -4, 4, 0,
+ax_anim 2, 0, 31, 6, -6, 6, 0,
+ax_anim 3, 0, 31, 9, -7, 9, 0,
+ax_anim 2, 2, 31, 12, -6, 12, 0,
+ax_anim 1, 0, 31, 15, -3, 15, 0,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 1, 32, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 32, 20, 0, 20, 0,
+ax_anim 2, 0, 32, 19, 0, 19, 0,
+ax_anim 2, 0, 31, 10, -4, 10, 0,
+ax_anim 2, 0, 31, 6, -3, 6, 0,
+ax_anim 2, 0, 31, 2, -2, 2, 0,
+ax_anim_terminator
+sVenonatAnims_2_4:
+ax_anim 1, 0, 34, 2, -4, 2, -2,
+ax_anim 1, 0, 34, 4, -8, 4, -4,
+ax_anim 2, 0, 34, 6, -12, 6, -6,
+ax_anim 3, 0, 34, 9, -18, 9, -9,
+ax_anim 2, 2, 34, 12, -21, 12, -12,
+ax_anim 1, 0, 34, 15, -22, 15, -15,
+ax_anim 2, 0, 35, 21, -21, 21, -21,
+ax_anim 2, 1, 35, 22, -20, 22, -20,
+ax_anim 2, 0, 35, 21, -21, 21, -21,
+ax_anim 2, 0, 35, 22, -20, 22, -20,
+ax_anim 2, 0, 35, 21, -21, 21, -21,
+ax_anim 2, 0, 34, 10, -13, 10, -10,
+ax_anim 2, 0, 34, 6, -9, 6, -6,
+ax_anim 2, 0, 34, 2, -4, 2, -2,
+ax_anim_terminator
+sVenonatAnims_2_5:
+ax_anim 1, 0, 37, 0, -4, 0, -2,
+ax_anim 1, 0, 37, 0, -8, 0, -4,
+ax_anim 2, 0, 37, 0, -12, 0, -6,
+ax_anim 3, 0, 37, 0, -18, 0, -9,
+ax_anim 2, 2, 37, 0, -21, 0, -12,
+ax_anim 1, 0, 37, 0, -22, 0, -15,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 1, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 0, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 0, 37, 0, -13, 0, -10,
+ax_anim 2, 0, 37, 0, -9, 0, -6,
+ax_anim 2, 0, 37, 0, -4, 0, -2,
+ax_anim_terminator
+sVenonatAnims_2_6:
+ax_anim 1, 0, 40, -2, -4, -2, -2,
+ax_anim 1, 0, 40, -4, -8, -4, -4,
+ax_anim 2, 0, 40, -6, -12, -6, -6,
+ax_anim 3, 0, 40, -9, -18, -9, -9,
+ax_anim 2, 2, 40, -12, -21, -12, -12,
+ax_anim 1, 0, 40, -15, -22, -15, -15,
+ax_anim 2, 0, 41, -21, -21, -21, -21,
+ax_anim 2, 1, 41, -22, -20, -22, -20,
+ax_anim 2, 0, 41, -21, -21, -21, -21,
+ax_anim 2, 0, 41, -22, -20, -22, -20,
+ax_anim 2, 0, 41, -21, -21, -21, -21,
+ax_anim 2, 0, 40, -10, -13, -10, -10,
+ax_anim 2, 0, 40, -6, -9, -6, -6,
+ax_anim 2, 0, 40, -2, -4, -2, -2,
+ax_anim_terminator
+sVenonatAnims_2_7:
+ax_anim 1, 0, 43, -2, -2, -2, 0,
+ax_anim 1, 0, 43, -4, -4, -4, 0,
+ax_anim 2, 0, 43, -6, -6, -6, 0,
+ax_anim 3, 0, 43, -9, -7, -9, 0,
+ax_anim 2, 2, 43, -12, -6, -12, 0,
+ax_anim 1, 0, 43, -15, -3, -15, 0,
+ax_anim 2, 0, 44, -19, 0, -19, 0,
+ax_anim 2, 1, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -19, 0, -19, 0,
+ax_anim 2, 0, 44, -20, 0, -20, 0,
+ax_anim 2, 0, 44, -19, 0, -19, 0,
+ax_anim 2, 0, 43, -10, -4, -10, 0,
+ax_anim 2, 0, 43, -6, -3, -6, 0,
+ax_anim 2, 0, 43, -2, -2, -2, 0,
+ax_anim_terminator
+sVenonatAnims_2_8:
+ax_anim 1, 0, 46, -2, -1, -2, 2,
+ax_anim 1, 0, 46, -4, -2, -4, 4,
+ax_anim 2, 0, 46, -6, -3, -6, 6,
+ax_anim 3, 0, 46, -8, -2, -8, 8,
+ax_anim 2, 2, 46, -10, 0, -10, 10,
+ax_anim 1, 0, 46, -12, 5, -12, 12,
+ax_anim 2, 0, 47, -19, 19, -18, 18,
+ax_anim 2, 1, 47, -20, 18, -20, 18,
+ax_anim 2, 0, 47, -19, 19, -19, 19,
+ax_anim 2, 0, 47, -20, 18, -20, 18,
+ax_anim 2, 0, 47, -19, 19, -19, 19,
+ax_anim 2, 0, 46, -10, 2, -2, 6,
+ax_anim 2, 0, 46, -6, 0, 0, 6,
+ax_anim 2, 0, 46, -2, 0, 0, 6,
+ax_anim_terminator
+.align 2
+sVenonatAnims_3_1:
+ax_anim 1, 0, 49, 0, -1, 0, 2,
+ax_anim 1, 0, 49, 0, -2, 0, 4,
+ax_anim 2, 0, 49, 0, -3, 0, 6,
+ax_anim 3, 0, 49, 0, 0, 0, 8,
+ax_anim 2, 2, 49, 0, 4, 0, 10,
+ax_anim 1, 0, 49, 0, 10, 0, 12,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 0, 6, 0, 6,
+ax_anim 2, 0, 49, 0, 4, 0, 6,
+ax_anim 2, 0, 49, 0, 3, 0, 6,
+ax_anim_terminator
+sVenonatAnims_3_2:
+ax_anim 1, 0, 52, 2, -1, 2, 2,
+ax_anim 1, 0, 52, 4, -2, 4, 4,
+ax_anim 2, 0, 52, 6, -3, 6, 6,
+ax_anim 3, 0, 52, 8, -2, 8, 8,
+ax_anim 2, 2, 52, 10, 0, 10, 10,
+ax_anim 1, 0, 52, 12, 5, 12, 12,
+ax_anim 2, 0, 53, 19, 19, 18, 18,
+ax_anim 2, 1, 53, 20, 18, 20, 18,
+ax_anim 2, 0, 53, 19, 19, 19, 19,
+ax_anim 2, 0, 53, 20, 18, 20, 18,
+ax_anim 2, 0, 53, 19, 19, 19, 19,
+ax_anim 2, 0, 52, 10, 2, 2, 6,
+ax_anim 2, 0, 52, 6, 0, 0, 6,
+ax_anim 2, 0, 52, 2, 0, 0, 6,
+ax_anim_terminator
+sVenonatAnims_3_3:
+ax_anim 1, 0, 55, 2, -2, 2, 0,
+ax_anim 1, 0, 55, 4, -4, 4, 0,
+ax_anim 2, 0, 55, 6, -6, 6, 0,
+ax_anim 3, 0, 55, 9, -7, 9, 0,
+ax_anim 2, 2, 55, 12, -6, 12, 0,
+ax_anim 1, 0, 55, 15, -3, 15, 0,
+ax_anim 2, 0, 56, 19, 0, 19, 0,
+ax_anim 2, 1, 56, 20, 0, 20, 0,
+ax_anim 2, 0, 56, 19, 0, 19, 0,
+ax_anim 2, 0, 56, 20, 0, 20, 0,
+ax_anim 2, 0, 56, 19, 0, 19, 0,
+ax_anim 2, 0, 55, 10, -4, 10, 0,
+ax_anim 2, 0, 55, 6, -3, 6, 0,
+ax_anim 2, 0, 55, 2, -2, 2, 0,
+ax_anim_terminator
+sVenonatAnims_3_4:
+ax_anim 1, 0, 58, 2, -4, 2, -2,
+ax_anim 1, 0, 58, 4, -8, 4, -4,
+ax_anim 2, 0, 58, 6, -12, 6, -6,
+ax_anim 3, 0, 58, 9, -18, 9, -9,
+ax_anim 2, 2, 58, 12, -21, 12, -12,
+ax_anim 1, 0, 58, 15, -22, 15, -15,
+ax_anim 2, 0, 59, 21, -21, 21, -21,
+ax_anim 2, 1, 59, 22, -20, 22, -20,
+ax_anim 2, 0, 59, 21, -21, 21, -21,
+ax_anim 2, 0, 59, 22, -20, 22, -20,
+ax_anim 2, 0, 59, 21, -21, 21, -21,
+ax_anim 2, 0, 58, 10, -13, 10, -10,
+ax_anim 2, 0, 58, 6, -9, 6, -6,
+ax_anim 2, 0, 58, 2, -4, 2, -2,
+ax_anim_terminator
+sVenonatAnims_3_5:
+ax_anim 1, 0, 61, 0, -4, 0, -2,
+ax_anim 1, 0, 61, 0, -8, 0, -4,
+ax_anim 2, 0, 61, 0, -12, 0, -6,
+ax_anim 3, 0, 61, 0, -18, 0, -9,
+ax_anim 2, 2, 61, 0, -21, 0, -12,
+ax_anim 1, 0, 61, 0, -22, 0, -15,
+ax_anim 2, 0, 62, 0, -21, 0, -21,
+ax_anim 2, 1, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 62, 0, -21, 0, -21,
+ax_anim 2, 0, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 62, 0, -21, 0, -21,
+ax_anim 2, 0, 61, 0, -13, 0, -10,
+ax_anim 2, 0, 61, 0, -9, 0, -6,
+ax_anim 2, 0, 61, 0, -4, 0, -2,
+ax_anim_terminator
+sVenonatAnims_3_6:
+ax_anim 1, 0, 64, -2, -4, -2, -2,
+ax_anim 1, 0, 64, -4, -8, -4, -4,
+ax_anim 2, 0, 64, -6, -12, -6, -6,
+ax_anim 3, 0, 64, -9, -18, -9, -9,
+ax_anim 2, 2, 64, -12, -21, -12, -12,
+ax_anim 1, 0, 64, -15, -22, -15, -15,
+ax_anim 2, 0, 65, -21, -21, -21, -21,
+ax_anim 2, 1, 65, -22, -20, -22, -20,
+ax_anim 2, 0, 65, -21, -21, -21, -21,
+ax_anim 2, 0, 65, -22, -20, -22, -20,
+ax_anim 2, 0, 65, -21, -21, -21, -21,
+ax_anim 2, 0, 64, -10, -13, -10, -10,
+ax_anim 2, 0, 64, -6, -9, -6, -6,
+ax_anim 2, 0, 64, -2, -4, -2, -2,
+ax_anim_terminator
+sVenonatAnims_3_7:
+ax_anim 1, 0, 67, -2, -2, -2, 0,
+ax_anim 1, 0, 67, -4, -4, -4, 0,
+ax_anim 2, 0, 67, -6, -6, -6, 0,
+ax_anim 3, 0, 67, -9, -7, -9, 0,
+ax_anim 2, 2, 67, -12, -6, -12, 0,
+ax_anim 1, 0, 67, -15, -3, -15, 0,
+ax_anim 2, 0, 68, -19, 0, -19, 0,
+ax_anim 2, 1, 68, -20, 0, -20, 0,
+ax_anim 2, 0, 68, -19, 0, -19, 0,
+ax_anim 2, 0, 68, -20, 0, -20, 0,
+ax_anim 2, 0, 68, -19, 0, -19, 0,
+ax_anim 2, 0, 67, -10, -4, -10, 0,
+ax_anim 2, 0, 67, -6, -3, -6, 0,
+ax_anim 2, 0, 67, -2, -2, -2, 0,
+ax_anim_terminator
+sVenonatAnims_3_8:
+ax_anim 1, 0, 70, -2, -1, -2, 2,
+ax_anim 1, 0, 70, -4, -2, -4, 4,
+ax_anim 2, 0, 70, -6, -3, -6, 6,
+ax_anim 3, 0, 70, -8, -2, -8, 8,
+ax_anim 2, 2, 70, -10, 0, -10, 10,
+ax_anim 1, 0, 70, -12, 5, -12, 12,
+ax_anim 2, 0, 71, -19, 19, -18, 18,
+ax_anim 2, 1, 71, -20, 18, -20, 18,
+ax_anim 2, 0, 71, -19, 19, -19, 19,
+ax_anim 2, 0, 71, -20, 18, -20, 18,
+ax_anim 2, 0, 71, -19, 19, -19, 19,
+ax_anim 2, 0, 70, -10, 2, -2, 6,
+ax_anim 2, 0, 70, -6, 0, 0, 6,
+ax_anim 2, 0, 70, -2, 0, 0, 6,
+ax_anim_terminator
+.align 2
+sVenonatAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 8, 2, 72, 0, 0, 0, 0,
+ax_anim 1, 1, 74, 0, -10, 0, -10,
+ax_anim 2, 0, 74, 0, -14, 0, -14,
+ax_anim 4, 0, 74, 0, -15, 0, -15,
+ax_anim 4, 0, 72, 0, -16, 0, -16,
+ax_anim_terminator
+sVenonatAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 8, 2, 75, 0, 0, 0, 0,
+ax_anim 1, 1, 77, -10, -10, -10, -10,
+ax_anim 2, 0, 77, -14, -14, -14, -14,
+ax_anim 4, 0, 77, -15, -15, -15, -15,
+ax_anim 4, 0, 75, -16, -16, -16, -16,
+ax_anim_terminator
+sVenonatAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 8, 2, 78, 0, 0, 0, 0,
+ax_anim 1, 1, 80, -10, 0, -10, 0,
+ax_anim 2, 0, 80, -14, 0, -14, 0,
+ax_anim 4, 0, 80, -15, 0, -15, 0,
+ax_anim 4, 0, 78, -16, 0, -16, 0,
+ax_anim_terminator
+sVenonatAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 8, 2, 81, 0, 0, 0, 0,
+ax_anim 1, 1, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, -14, 14, -14, 14,
+ax_anim 4, 0, 83, -15, 15, -15, 15,
+ax_anim 4, 0, 81, -16, 16, -16, 16,
+ax_anim_terminator
+sVenonatAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 8, 2, 84, 0, 0, 0, 0,
+ax_anim 1, 1, 86, 0, 10, 0, 10,
+ax_anim 2, 0, 86, 0, 14, 0, 14,
+ax_anim 4, 0, 86, 0, 15, 0, 15,
+ax_anim 4, 0, 84, 0, 16, 0, 16,
+ax_anim_terminator
+sVenonatAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 8, 2, 87, 0, 0, 0, 0,
+ax_anim 1, 1, 89, 10, 10, 10, 10,
+ax_anim 2, 0, 89, 14, 14, 14, 14,
+ax_anim 4, 0, 89, 15, 15, 15, 15,
+ax_anim 4, 0, 87, 16, 16, 16, 16,
+ax_anim_terminator
+sVenonatAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 8, 2, 90, 0, 0, 0, 0,
+ax_anim 1, 1, 92, 10, 0, 10, 0,
+ax_anim 2, 0, 92, 14, 0, 14, 0,
+ax_anim 4, 0, 92, 15, 0, 15, 0,
+ax_anim 4, 0, 90, 16, 0, 16, 0,
+ax_anim_terminator
+sVenonatAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 8, 2, 93, 0, 0, 0, 0,
+ax_anim 1, 1, 95, 10, -10, 10, -10,
+ax_anim 2, 0, 95, 14, -14, 14, -14,
+ax_anim 4, 0, 95, 15, -15, 15, -15,
+ax_anim 4, 0, 93, 16, -16, 16, -16,
+ax_anim_terminator
+.align 2
+sVenonatAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -7, 0, 0,
+ax_anim 2, 0, 99, 0, -8, 0, 0,
+ax_anim 2, 2, 100, 0, -8, 0, 0,
+ax_anim 2, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 1, 96, 0, -2, 0, 0,
+ax_anim 3, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_5_2:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 0, 100, 0, -8, 0, 0,
+ax_anim 2, 2, 99, 0, -8, 0, 0,
+ax_anim 2, 0, 98, 0, -7, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 1, 103, 0, -2, 0, 0,
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -7, 0, 0,
+ax_anim 2, 0, 99, 0, -8, 0, 0,
+ax_anim 2, 2, 98, 0, -8, 0, 0,
+ax_anim 2, 0, 97, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 103, 0, -4, 0, 0,
+ax_anim 2, 1, 102, 0, -2, 0, 0,
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_5_4:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 98, 0, -8, 0, 0,
+ax_anim 2, 2, 97, 0, -8, 0, 0,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim 2, 1, 101, 0, -2, 0, 0,
+ax_anim 3, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_5_5:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 103, 0, -8, 0, 0,
+ax_anim 2, 2, 96, 0, -8, 0, 0,
+ax_anim 2, 0, 97, 0, -7, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -4, 0, 0,
+ax_anim 2, 1, 100, 0, -2, 0, 0,
+ax_anim 3, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_5_6:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -5, 0, 0,
+ax_anim 2, 0, 101, 0, -7, 0, 0,
+ax_anim 2, 0, 102, 0, -8, 0, 0,
+ax_anim 2, 2, 103, 0, -8, 0, 0,
+ax_anim 2, 0, 96, 0, -7, 0, 0,
+ax_anim 2, 0, 97, 0, -5, 0, 0,
+ax_anim 2, 0, 98, 0, -4, 0, 0,
+ax_anim 2, 1, 99, 0, -2, 0, 0,
+ax_anim 3, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_5_7:
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 2, 0, 100, 0, -7, 0, 0,
+ax_anim 2, 0, 101, 0, -8, 0, 0,
+ax_anim 2, 2, 102, 0, -8, 0, 0,
+ax_anim 2, 0, 103, 0, -7, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 1, 98, 0, -2, 0, 0,
+ax_anim 3, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_5_8:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 2, 0, 99, 0, -7, 0, 0,
+ax_anim 2, 0, 100, 0, -8, 0, 0,
+ax_anim 2, 2, 101, 0, -8, 0, 0,
+ax_anim 2, 0, 102, 0, -7, 0, 0,
+ax_anim 2, 0, 103, 0, -5, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 1, 97, 0, -2, 0, 0,
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenonatAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenonatAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sVenonatAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sVenonatAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sVenonatAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sVenonatAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sVenonatAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sVenonatAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sVenonatAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVenonatAnims_8_1:
+ax_anim 16, 0, 130, 0, 0, 0, 0,
+ax_anim 16, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_8_2:
+ax_anim 16, 0, 132, 0, 0, 0, 0,
+ax_anim 16, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_8_3:
+ax_anim 16, 0, 134, 0, 0, 0, 0,
+ax_anim 16, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_8_4:
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 16, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_8_5:
+ax_anim 16, 0, 138, 0, 0, 0, 0,
+ax_anim 16, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_8_6:
+ax_anim 16, 0, 140, 0, 0, 0, 0,
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_8_7:
+ax_anim 16, 0, 142, 0, 0, 0, 0,
+ax_anim 16, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_8_8:
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 16, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenonatAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 9, 8, 9,
+ax_anim 2, 0, 149, 7, 16, 7, 16,
+ax_anim 3, 0, 150, 0, 20, 0, 20,
+ax_anim 2, 3, 151, -7, 16, -7, 16,
+ax_anim 2, 0, 152, -8, 9, -8, 9,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 19, 3, 19, 3,
+ax_anim 2, 0, 148, 23, 10, 23, 10,
+ax_anim 3, 0, 149, 22, 20, 22, 20,
+ax_anim 2, 3, 150, 11, 19, 11, 19,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 18, -5, 18, -5,
+ax_anim 3, 0, 148, 21, -2, 21, -2,
+ax_anim 2, 3, 149, 18, 4, 18, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -6, -1, -6,
+ax_anim 2, 0, 153, 4, -16, 4, -16,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 21, -25, 21, -25,
+ax_anim 2, 3, 148, 22, -15, 22, -15,
+ax_anim 2, 0, 149, 17, -4, 17, -4,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -7, -18, -7, -18,
+ax_anim 3, 0, 146, 0, -22, 0, -22,
+ax_anim 2, 3, 147, 7, -18, 7, -18,
+ax_anim 2, 0, 148, 9, -10, 9, -10,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -6, 1, -6,
+ax_anim 2, 0, 147, -4, -16, -4, -16,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -21, -25, -21, -25,
+ax_anim 2, 3, 152, -22, -15, -22, -15,
+ax_anim 2, 0, 151, -17, -4, -17, -4,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -18, -5, -18, -5,
+ax_anim 3, 0, 152, -21, -2, -21, -2,
+ax_anim 2, 3, 151, -18, 4, -18, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -19, 3, -19, 3,
+ax_anim 2, 0, 152, -23, 10, -23, 10,
+ax_anim 3, 0, 151, -22, 20, -22, 20,
+ax_anim 2, 3, 150, -11, 19, -11, 19,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenonatAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenonatAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -24, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -24, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 170, 0, -25, 0, 0,
+ax_anim 3, 0, 170, 0, -22, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 173, 0, -25, 0, 0,
+ax_anim 3, 0, 173, 0, -21, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 176, 0, -26, 0, 0,
+ax_anim 3, 0, 176, 0, -22, 0, 0,
+ax_anim 2, 0, 176, 0, -18, 0, 0,
+ax_anim 1, 0, 176, 0, -12, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -25, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -25, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenonatAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenonatAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sVenonatGfx1:
+.incbin "baserom.gba", 0x7084F0, 0x200
+sVenonatSprites1:
+ax_sprite sVenonatGfx1, 0x200
+ax_sprite_terminator
+sVenonatGfx2:
+.incbin "baserom.gba", 0x708700, 0x200
+sVenonatSprites2:
+ax_sprite sVenonatGfx2, 0x200
+ax_sprite_terminator
+sVenonatGfx3:
+.incbin "baserom.gba", 0x708910, 0x200
+sVenonatSprites3:
+ax_sprite sVenonatGfx3, 0x200
+ax_sprite_terminator
+sVenonatGfx4:
+.incbin "baserom.gba", 0x708B20, 0x200
+sVenonatSprites4:
+ax_sprite sVenonatGfx4, 0x200
+ax_sprite_terminator
+sVenonatGfx5:
+.incbin "baserom.gba", 0x708D30, 0x200
+sVenonatSprites5:
+ax_sprite sVenonatGfx5, 0x200
+ax_sprite_terminator
+sVenonatGfx6:
+.incbin "baserom.gba", 0x708F40, 0x200
+sVenonatSprites6:
+ax_sprite sVenonatGfx6, 0x200
+ax_sprite_terminator
+sVenonatGfx7:
+.incbin "baserom.gba", 0x709150, 0x200
+sVenonatSprites7:
+ax_sprite sVenonatGfx7, 0x200
+ax_sprite_terminator
+sVenonatGfx8:
+.incbin "baserom.gba", 0x709360, 0x200
+sVenonatSprites8:
+ax_sprite sVenonatGfx8, 0x200
+ax_sprite_terminator
+sVenonatGfx9:
+.incbin "baserom.gba", 0x709570, 0x200
+sVenonatSprites9:
+ax_sprite sVenonatGfx9, 0x200
+ax_sprite_terminator
+sVenonatGfx10:
+.incbin "baserom.gba", 0x709780, 0x200
+sVenonatSprites10:
+ax_sprite sVenonatGfx10, 0x200
+ax_sprite_terminator
+sVenonatGfx11:
+.incbin "baserom.gba", 0x709990, 0x200
+sVenonatSprites11:
+ax_sprite sVenonatGfx11, 0x200
+ax_sprite_terminator
+sVenonatGfx12:
+.incbin "baserom.gba", 0x709BA0, 0x200
+sVenonatSprites12:
+ax_sprite sVenonatGfx12, 0x200
+ax_sprite_terminator
+sVenonatGfx13:
+.incbin "baserom.gba", 0x709DB0, 0x200
+sVenonatSprites13:
+ax_sprite sVenonatGfx13, 0x200
+ax_sprite_terminator
+sVenonatGfx14:
+.incbin "baserom.gba", 0x709FC0, 0x200
+sVenonatSprites14:
+ax_sprite sVenonatGfx14, 0x200
+ax_sprite_terminator
+sVenonatGfx15:
+.incbin "baserom.gba", 0x70A1D0, 0x200
+sVenonatSprites15:
+ax_sprite sVenonatGfx15, 0x200
+ax_sprite_terminator
+sVenonatGfx16:
+.incbin "baserom.gba", 0x70A3E0, 0x60
+sVenonatGfx16_1:
+.incbin "baserom.gba", 0x70A440, 0x60
+sVenonatGfx16_2:
+.incbin "baserom.gba", 0x70A4A0, 0x60
+sVenonatSprites16:
+ax_sprite sVenonatGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVenonatGfx17:
+.incbin "baserom.gba", 0x70A538, 0x60
+sVenonatGfx17_1:
+.incbin "baserom.gba", 0x70A598, 0x60
+sVenonatGfx17_2:
+.incbin "baserom.gba", 0x70A5F8, 0x60
+sVenonatSprites17:
+ax_sprite sVenonatGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx17_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVenonatGfx18:
+.incbin "baserom.gba", 0x70A690, 0x60
+sVenonatGfx18_1:
+.incbin "baserom.gba", 0x70A6F0, 0x60
+sVenonatGfx18_2:
+.incbin "baserom.gba", 0x70A750, 0x60
+sVenonatSprites18:
+ax_sprite sVenonatGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVenonatGfx19:
+.incbin "baserom.gba", 0x70A7E8, 0x40
+sVenonatGfx19_1:
+.incbin "baserom.gba", 0x70A828, 0x60
+sVenonatGfx19_2:
+.incbin "baserom.gba", 0x70A888, 0x60
+sVenonatSprites19:
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVenonatGfx20:
+.incbin "baserom.gba", 0x70A928, 0x40
+sVenonatGfx20_1:
+.incbin "baserom.gba", 0x70A968, 0x60
+sVenonatGfx20_2:
+.incbin "baserom.gba", 0x70A9C8, 0x60
+sVenonatGfx20_3:
+.incbin "baserom.gba", 0x70AA28, 0x20
+sVenonatSprites20:
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenonatGfx20_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVenonatGfx20_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sVenonatGfx21:
+.incbin "baserom.gba", 0x70AA98, 0x200
+sVenonatSprites21:
+ax_sprite sVenonatGfx21, 0x200
+ax_sprite_terminator
+sVenonatGfx22:
+.incbin "baserom.gba", 0x70ACA8, 0x200
+sVenonatSprites22:
+ax_sprite sVenonatGfx22, 0x200
+ax_sprite_terminator
+sVenonatGfx23:
+.incbin "baserom.gba", 0x70AEB8, 0x200
+sVenonatSprites23:
+ax_sprite sVenonatGfx23, 0x200
+ax_sprite_terminator
+sVenonatGfx24:
+.incbin "baserom.gba", 0x70B0C8, 0x200
+sVenonatSprites24:
+ax_sprite sVenonatGfx24, 0x200
+ax_sprite_terminator
+sVenonatGfx25:
+.incbin "baserom.gba", 0x70B2D8, 0x200
+sVenonatSprites25:
+ax_sprite sVenonatGfx25, 0x200
+ax_sprite_terminator
+sVenonatGfx26:
+.incbin "baserom.gba", 0x70B4E8, 0x200
+sVenonatSprites26:
+ax_sprite sVenonatGfx26, 0x200
+ax_sprite_terminator
+sVenonatGfx27:
+.incbin "baserom.gba", 0x70B6F8, 0x200
+sVenonatSprites27:
+ax_sprite sVenonatGfx27, 0x200
+ax_sprite_terminator
+sAxPosesVenonat:
+.4byte sVenonatPose1
+.4byte sVenonatPose2
+.4byte sVenonatPose3
+.4byte sVenonatPose4
+.4byte sVenonatPose5
+.4byte sVenonatPose6
+.4byte sVenonatPose7
+.4byte sVenonatPose8
+.4byte sVenonatPose9
+.4byte sVenonatPose10
+.4byte sVenonatPose11
+.4byte sVenonatPose12
+.4byte sVenonatPose13
+.4byte sVenonatPose14
+.4byte sVenonatPose15
+.4byte sVenonatPose16
+.4byte sVenonatPose17
+.4byte sVenonatPose18
+.4byte sVenonatPose19
+.4byte sVenonatPose20
+.4byte sVenonatPose21
+.4byte sVenonatPose22
+.4byte sVenonatPose23
+.4byte sVenonatPose24
+.4byte sVenonatPose25
+.4byte sVenonatPose26
+.4byte sVenonatPose27
+.4byte sVenonatPose28
+.4byte sVenonatPose29
+.4byte sVenonatPose30
+.4byte sVenonatPose31
+.4byte sVenonatPose32
+.4byte sVenonatPose33
+.4byte sVenonatPose34
+.4byte sVenonatPose35
+.4byte sVenonatPose36
+.4byte sVenonatPose37
+.4byte sVenonatPose38
+.4byte sVenonatPose39
+.4byte sVenonatPose40
+.4byte sVenonatPose41
+.4byte sVenonatPose42
+.4byte sVenonatPose43
+.4byte sVenonatPose44
+.4byte sVenonatPose45
+.4byte sVenonatPose46
+.4byte sVenonatPose47
+.4byte sVenonatPose48
+.4byte sVenonatPose49
+.4byte sVenonatPose50
+.4byte sVenonatPose51
+.4byte sVenonatPose52
+.4byte sVenonatPose53
+.4byte sVenonatPose54
+.4byte sVenonatPose55
+.4byte sVenonatPose56
+.4byte sVenonatPose57
+.4byte sVenonatPose58
+.4byte sVenonatPose59
+.4byte sVenonatPose60
+.4byte sVenonatPose61
+.4byte sVenonatPose62
+.4byte sVenonatPose63
+.4byte sVenonatPose64
+.4byte sVenonatPose65
+.4byte sVenonatPose66
+.4byte sVenonatPose67
+.4byte sVenonatPose68
+.4byte sVenonatPose69
+.4byte sVenonatPose70
+.4byte sVenonatPose71
+.4byte sVenonatPose72
+.4byte sVenonatPose73
+.4byte sVenonatPose74
+.4byte sVenonatPose75
+.4byte sVenonatPose76
+.4byte sVenonatPose77
+.4byte sVenonatPose78
+.4byte sVenonatPose79
+.4byte sVenonatPose80
+.4byte sVenonatPose81
+.4byte sVenonatPose82
+.4byte sVenonatPose83
+.4byte sVenonatPose84
+.4byte sVenonatPose85
+.4byte sVenonatPose86
+.4byte sVenonatPose87
+.4byte sVenonatPose88
+.4byte sVenonatPose89
+.4byte sVenonatPose90
+.4byte sVenonatPose91
+.4byte sVenonatPose92
+.4byte sVenonatPose93
+.4byte sVenonatPose94
+.4byte sVenonatPose95
+.4byte sVenonatPose96
+.4byte sVenonatPose97
+.4byte sVenonatPose98
+.4byte sVenonatPose99
+.4byte sVenonatPose100
+.4byte sVenonatPose101
+.4byte sVenonatPose102
+.4byte sVenonatPose103
+.4byte sVenonatPose104
+.4byte sVenonatPose105
+.4byte sVenonatPose106
+.4byte sVenonatPose107
+.4byte sVenonatPose108
+.4byte sVenonatPose109
+.4byte sVenonatPose110
+.4byte sVenonatPose111
+.4byte sVenonatPose112
+.4byte sVenonatPose113
+.4byte sVenonatPose114
+.4byte sVenonatPose115
+.4byte sVenonatPose116
+.4byte sVenonatPose117
+.4byte sVenonatPose118
+.4byte sVenonatPose119
+.4byte sVenonatPose120
+.4byte sVenonatPose121
+.4byte sVenonatPose122
+.4byte sVenonatPose123
+.4byte sVenonatPose124
+.4byte sVenonatPose125
+.4byte sVenonatPose126
+.4byte sVenonatPose127
+.4byte sVenonatPose128
+.4byte sVenonatPose129
+.4byte sVenonatPose130
+.4byte sVenonatPose131
+.4byte sVenonatPose132
+.4byte sVenonatPose133
+.4byte sVenonatPose134
+.4byte sVenonatPose135
+.4byte sVenonatPose136
+.4byte sVenonatPose137
+.4byte sVenonatPose138
+.4byte sVenonatPose139
+.4byte sVenonatPose140
+.4byte sVenonatPose141
+.4byte sVenonatPose142
+.4byte sVenonatPose143
+.4byte sVenonatPose144
+.4byte sVenonatPose145
+.4byte sVenonatPose146
+.4byte sVenonatPose147
+.4byte sVenonatPose148
+.4byte sVenonatPose149
+.4byte sVenonatPose150
+.4byte sVenonatPose151
+.4byte sVenonatPose152
+.4byte sVenonatPose153
+.4byte sVenonatPose154
+.4byte sVenonatPose155
+.4byte sVenonatPose156
+.4byte sVenonatPose157
+.4byte sVenonatPose158
+.4byte sVenonatPose159
+.4byte sVenonatPose160
+.4byte sVenonatPose161
+.4byte sVenonatPose162
+.4byte sVenonatPose163
+.4byte sVenonatPose164
+.4byte sVenonatPose165
+.4byte sVenonatPose166
+.4byte sVenonatPose167
+.4byte sVenonatPose168
+.4byte sVenonatPose169
+.4byte sVenonatPose170
+.4byte sVenonatPose171
+.4byte sVenonatPose172
+.4byte sVenonatPose173
+.4byte sVenonatPose174
+.4byte sVenonatPose175
+.4byte sVenonatPose176
+.4byte sVenonatPose177
+.4byte sVenonatPose178
+.4byte sVenonatPose179
+.4byte sVenonatPose180
+.4byte sVenonatPose181
+.4byte sVenonatPose182
+.4byte sVenonatPose183
+.4byte sVenonatPose184
+.4byte sVenonatPose185
+.4byte sVenonatPose186
+.4byte sVenonatPose187
+.4byte sVenonatPose188
+.4byte sVenonatPose189
+.4byte sVenonatPose190
+.4byte sVenonatPose191
+.4byte sVenonatPose192
+.4byte sVenonatPose193
+.4byte sVenonatPose194
+.4byte sVenonatPose195
+.4byte sVenonatPose196
+.4byte sVenonatPose197
+.4byte sVenonatPose198
+.4byte sVenonatPose199
+.4byte sVenonatPose200
+.4byte sVenonatPose201
+.4byte sVenonatPose202
+sAxPositionsVenonat:
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -1,   -7, 	  -5,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -4
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte    5,  -10, 	   9,  -10, 	   2,   -6, 	   0,  -12
+.2byte    5,   -1, 	   9,   -2, 	   2,    2, 	   1,   -5
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    8,  -11, 	   8,  -12, 	   7,   -9, 	   1,  -13
+.2byte    8,   -3, 	   9,   -4, 	   8,   -2, 	   2,   -7
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    3,  -15, 	  -2,  -15, 	   6,  -13, 	   0,  -13
+.2byte    3,   -6, 	  -2,   -9, 	   6,   -5, 	   0,   -8
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -15, 	   3,  -12, 	  -5,  -12, 	  -1,  -13
+.2byte   -1,   -6, 	   4,   -7, 	  -5,   -7, 	  -1,   -7
+.2byte   -4,   -8, 	   2,  -10, 	  -7,   -7, 	   0,   -8
+.2byte   -5,  -15, 	   0,  -15, 	  -8,  -13, 	  -2,  -13
+.2byte   -5,   -6, 	   0,   -9, 	  -8,   -5, 	  -2,   -8
+.2byte   -7,   -5, 	  -7,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte  -10,  -11, 	 -10,  -12, 	  -9,   -9, 	  -3,  -13
+.2byte  -10,   -3, 	 -11,   -4, 	 -10,   -2, 	  -4,   -7
+.2byte   -4,   -5, 	  -8,   -5, 	  -1,   -1, 	   0,   -7
+.2byte   -7,  -10, 	 -11,  -10, 	  -4,   -6, 	  -2,  -12
+.2byte   -7,   -1, 	 -11,   -2, 	  -4,    2, 	  -3,   -5
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -5, 	   3,   -5, 	  -1,   -8
+.2byte   -1,   -1, 	  -5,   -1, 	   3,   -1, 	  -1,   -6
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte    3,   -7, 	   7,   -7, 	   0,   -3, 	  -2,   -9
+.2byte    3,   -2, 	   7,   -3, 	   0,    1, 	  -1,   -6
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    6,   -9, 	   6,  -10, 	   5,   -7, 	  -1,  -11
+.2byte    5,   -3, 	   6,   -4, 	   5,   -2, 	  -1,   -7
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    1,  -12, 	  -4,  -12, 	   4,  -10, 	  -2,  -10
+.2byte    1,   -4, 	  -4,   -7, 	   4,   -3, 	  -2,   -6
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	   3,   -9, 	  -5,   -9, 	  -1,  -10
+.2byte   -1,   -4, 	   4,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte   -3,   -8, 	   3,  -10, 	  -6,   -7, 	   1,   -8
+.2byte   -2,  -12, 	   3,  -12, 	  -5,  -10, 	   1,  -10
+.2byte   -2,   -4, 	   3,   -7, 	  -5,   -3, 	   1,   -6
+.2byte   -6,   -5, 	  -6,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -7,   -9, 	  -7,  -10, 	  -6,   -7, 	   0,  -11
+.2byte   -6,   -3, 	  -7,   -4, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -5, 	  -7,   -5, 	   0,   -1, 	   1,   -7
+.2byte   -4,   -7, 	  -8,   -7, 	  -1,   -3, 	   1,   -9
+.2byte   -4,   -2, 	  -8,   -3, 	  -1,    1, 	   0,   -6
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -5, 	   3,   -5, 	  -1,   -8
+.2byte   -1,   -1, 	  -5,   -1, 	   3,   -1, 	  -1,   -6
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte    3,   -7, 	   7,   -7, 	   0,   -3, 	  -2,   -9
+.2byte    3,   -2, 	   7,   -3, 	   0,    1, 	  -1,   -6
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    6,   -9, 	   6,  -10, 	   5,   -7, 	  -1,  -11
+.2byte    5,   -3, 	   6,   -4, 	   5,   -2, 	  -1,   -7
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    1,  -12, 	  -4,  -12, 	   4,  -10, 	  -2,  -10
+.2byte    1,   -4, 	  -4,   -7, 	   4,   -3, 	  -2,   -6
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	   3,   -9, 	  -5,   -9, 	  -1,  -10
+.2byte   -1,   -4, 	   4,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte   -3,   -8, 	   3,  -10, 	  -6,   -7, 	   1,   -8
+.2byte   -2,  -12, 	   3,  -12, 	  -5,  -10, 	   1,  -10
+.2byte   -2,   -4, 	   3,   -7, 	  -5,   -3, 	   1,   -6
+.2byte   -6,   -5, 	  -6,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -7,   -9, 	  -7,  -10, 	  -6,   -7, 	   0,  -11
+.2byte   -6,   -3, 	  -7,   -4, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -5, 	  -7,   -5, 	   0,   -1, 	   1,   -7
+.2byte   -4,   -7, 	  -8,   -7, 	  -1,   -3, 	   1,   -9
+.2byte   -4,   -2, 	  -8,   -3, 	  -1,    1, 	   0,   -6
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -1,   -7, 	  -5,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -1,   -1, 	  -5,   -1, 	   3,   -1, 	  -1,   -6
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte    2,  -10, 	   6,  -10, 	  -1,   -6, 	  -3,  -12
+.2byte    2,   -1, 	   6,   -2, 	  -1,    2, 	  -2,   -5
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    5,  -11, 	   5,  -12, 	   4,   -9, 	  -2,  -13
+.2byte    4,   -3, 	   5,   -4, 	   4,   -2, 	  -2,   -7
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    1,  -15, 	  -4,  -15, 	   4,  -13, 	  -2,  -13
+.2byte    1,   -6, 	  -4,   -9, 	   4,   -5, 	  -2,   -8
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -15, 	   3,  -12, 	  -5,  -12, 	  -1,  -13
+.2byte   -1,   -4, 	   4,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte   -4,   -8, 	   2,  -10, 	  -7,   -7, 	   0,   -8
+.2byte   -3,  -15, 	   2,  -15, 	  -6,  -13, 	   0,  -13
+.2byte   -3,   -6, 	   2,   -9, 	  -6,   -5, 	   0,   -8
+.2byte   -7,   -5, 	  -7,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte   -7,  -11, 	  -7,  -12, 	  -6,   -9, 	   0,  -13
+.2byte   -6,   -3, 	  -7,   -4, 	  -6,   -2, 	   0,   -7
+.2byte   -4,   -5, 	  -8,   -5, 	  -1,   -1, 	   0,   -7
+.2byte   -4,  -10, 	  -8,  -10, 	  -1,   -6, 	   1,  -12
+.2byte   -4,   -1, 	  -8,   -2, 	  -1,    2, 	   0,   -5
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -4,   -5, 	  -8,   -5, 	  -1,   -1, 	   0,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte   -4,   -8, 	   2,  -10, 	  -7,   -7, 	   0,   -8
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte    1,   -5, 	  -1,   -3, 	   5,   -6, 	  -2,   -8
+.2byte   -1,   -4, 	  -5,   -3, 	   3,   -3, 	  -1,   -8
+.2byte   -5,   -4, 	  -8,   -5, 	   0,   -4, 	  -1,   -8
+.2byte   -8,   -6, 	  -7,   -7, 	  -5,   -5, 	   0,   -8
+.2byte   -3,   -7, 	   3,   -9, 	  -7,   -5, 	   0,   -7
+.2byte    6,   -5, 	   5,   -6, 	   3,   -4, 	  -2,   -7
+.2byte    3,   -4, 	   6,   -5, 	  -2,   -4, 	  -1,   -8
+.2byte   -1,   -4, 	   3,   -3, 	  -5,   -3, 	  -1,   -8
+.2byte   -1,   -7, 	  -5,   -7, 	   3,   -7, 	  -1,  -10
+.2byte   -4,  -10, 	  -8,  -10, 	  -1,   -6, 	   1,  -12
+.2byte   -7,  -11, 	  -7,  -12, 	  -6,   -9, 	   0,  -13
+.2byte   -3,  -14, 	   2,  -14, 	  -6,  -12, 	   0,  -12
+.2byte   -1,  -14, 	   3,  -11, 	  -5,  -11, 	  -1,  -12
+.2byte    1,  -15, 	  -4,  -15, 	   4,  -13, 	  -2,  -13
+.2byte    6,  -11, 	   6,  -12, 	   5,   -9, 	  -1,  -13
+.2byte    3,  -10, 	   7,  -10, 	   0,   -6, 	  -2,  -12
+.2byte   -1,   -2, 	  -5,   -2, 	   3,   -2, 	  -1,   -7
+.2byte   -1,   -1, 	  -5,   -1, 	   3,   -1, 	  -1,   -6
+.2byte    0,  -10, 	  -5,  -11, 	   5,  -11, 	   0,   -8
+.2byte   -1,  -13, 	   3,  -15, 	  -1,  -10, 	  -2,   -9
+.2byte    2,  -14, 	   3,  -15, 	   2,  -12, 	   0,   -8
+.2byte   -1,  -13, 	  -2,  -15, 	   4,  -11, 	  -2,   -8
+.2byte    0,  -12, 	  -5,  -14, 	   5,  -14, 	   0,   -5
+.2byte    0,  -13, 	   1,  -15, 	  -5,  -11, 	   1,   -8
+.2byte   -3,  -14, 	  -4,  -15, 	  -3,  -12, 	  -1,   -8
+.2byte    0,  -13, 	  -4,  -15, 	   0,  -10, 	   1,   -9
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -9
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte    4,   -8, 	   8,   -8, 	   1,   -4, 	  -1,  -10
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    8,   -9, 	   8,  -10, 	   7,   -7, 	   1,  -11
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    3,  -14, 	  -2,  -14, 	   6,  -12, 	   0,  -12
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -14, 	   3,  -11, 	  -5,  -11, 	  -1,  -12
+.2byte   -3,   -8, 	   3,  -10, 	  -6,   -7, 	   1,   -8
+.2byte   -4,  -14, 	   1,  -14, 	  -7,  -12, 	  -1,  -12
+.2byte   -6,   -5, 	  -6,   -6, 	  -5,   -3, 	   0,   -8
+.2byte   -9,   -9, 	  -9,  -10, 	  -8,   -7, 	  -2,  -11
+.2byte   -3,   -5, 	  -7,   -5, 	   0,   -1, 	   1,   -7
+.2byte   -5,   -8, 	  -9,   -8, 	  -2,   -4, 	   0,  -10
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -4,   -5, 	  -8,   -5, 	  -1,   -1, 	   0,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte   -4,   -8, 	   2,  -10, 	  -7,   -7, 	   0,   -8
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -9
+.2byte    3,   -9, 	   7,   -9, 	   0,   -5, 	  -2,  -11
+.2byte    6,   -9, 	   6,  -10, 	   5,   -7, 	  -1,  -11
+.2byte    2,  -13, 	  -3,  -13, 	   5,  -11, 	  -1,  -11
+.2byte   -1,  -12, 	   3,   -9, 	  -5,   -9, 	  -1,  -10
+.2byte   -4,  -13, 	   1,  -13, 	  -7,  -11, 	  -1,  -11
+.2byte   -8,   -9, 	  -8,  -10, 	  -7,   -7, 	  -1,  -11
+.2byte   -4,   -9, 	  -8,   -9, 	  -1,   -5, 	   1,  -11
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -1,   -6, 	  -5,   -6, 	   3,   -6, 	  -1,   -9
+.2byte   -1,   -2, 	  -5,   -2, 	   3,   -2, 	  -1,   -7
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+.2byte    2,   -8, 	   6,   -8, 	  -1,   -4, 	  -3,  -10
+.2byte    2,   -3, 	   6,   -4, 	  -1,    0, 	  -2,   -7
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    6,  -10, 	   6,  -11, 	   5,   -8, 	  -1,  -12
+.2byte    5,   -4, 	   6,   -5, 	   5,   -3, 	  -1,   -8
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    1,  -12, 	  -4,  -12, 	   4,  -10, 	  -2,  -10
+.2byte    1,   -5, 	  -4,   -8, 	   4,   -4, 	  -2,   -7
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -12, 	   3,   -9, 	  -5,   -9, 	  -1,  -10
+.2byte   -1,   -5, 	   4,   -6, 	  -5,   -6, 	  -1,   -6
+.2byte   -4,   -8, 	   2,  -10, 	  -7,   -7, 	   0,   -8
+.2byte   -3,  -12, 	   2,  -12, 	  -6,  -10, 	   0,  -10
+.2byte   -3,   -5, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte   -8,  -10, 	  -8,  -11, 	  -7,   -8, 	  -1,  -12
+.2byte   -7,   -4, 	  -8,   -5, 	  -7,   -3, 	  -1,   -8
+.2byte   -4,   -5, 	  -8,   -5, 	  -1,   -1, 	   0,   -7
+.2byte   -4,   -8, 	  -8,   -8, 	  -1,   -4, 	   1,  -10
+.2byte   -4,   -3, 	  -8,   -4, 	  -1,    0, 	   0,   -7
+.2byte   -1,   -2, 	  -5,   -2, 	   3,   -2, 	  -1,   -7
+.2byte   -4,   -3, 	  -8,   -4, 	  -1,    0, 	   0,   -7
+.2byte   -6,   -3, 	  -7,   -4, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -5, 	   2,   -8, 	  -6,   -4, 	   0,   -7
+.2byte   -1,   -6, 	   4,   -7, 	  -5,   -7, 	  -1,   -7
+.2byte    2,   -5, 	  -3,   -8, 	   5,   -4, 	  -1,   -7
+.2byte    4,   -3, 	   5,   -4, 	   4,   -2, 	  -2,   -7
+.2byte    2,   -3, 	   6,   -4, 	  -1,    0, 	  -2,   -7
+.2byte   -1,   -3, 	  -5,   -3, 	   3,   -3, 	  -1,   -7
+.2byte   -4,   -5, 	  -8,   -5, 	  -1,   -1, 	   0,   -7
+.2byte   -7,   -5, 	  -7,   -6, 	  -6,   -3, 	  -1,   -8
+.2byte   -4,   -8, 	   2,  -10, 	  -7,   -7, 	   0,   -8
+.2byte   -1,   -9, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    2,   -8, 	  -4,  -10, 	   5,   -7, 	  -2,   -8
+.2byte    5,   -5, 	   5,   -6, 	   4,   -3, 	  -1,   -8
+.2byte    2,   -5, 	   6,   -5, 	  -1,   -1, 	  -2,   -7
+sVenonatAnimTable1:
+.4byte sVenonatAnims_1_1
+.4byte sVenonatAnims_1_2
+.4byte sVenonatAnims_1_3
+.4byte sVenonatAnims_1_4
+.4byte sVenonatAnims_1_5
+.4byte sVenonatAnims_1_6
+.4byte sVenonatAnims_1_7
+.4byte sVenonatAnims_1_8
+sVenonatAnimTable2:
+.4byte sVenonatAnims_2_1
+.4byte sVenonatAnims_2_2
+.4byte sVenonatAnims_2_3
+.4byte sVenonatAnims_2_4
+.4byte sVenonatAnims_2_5
+.4byte sVenonatAnims_2_6
+.4byte sVenonatAnims_2_7
+.4byte sVenonatAnims_2_8
+sVenonatAnimTable3:
+.4byte sVenonatAnims_3_1
+.4byte sVenonatAnims_3_2
+.4byte sVenonatAnims_3_3
+.4byte sVenonatAnims_3_4
+.4byte sVenonatAnims_3_5
+.4byte sVenonatAnims_3_6
+.4byte sVenonatAnims_3_7
+.4byte sVenonatAnims_3_8
+sVenonatAnimTable4:
+.4byte sVenonatAnims_4_1
+.4byte sVenonatAnims_4_2
+.4byte sVenonatAnims_4_3
+.4byte sVenonatAnims_4_4
+.4byte sVenonatAnims_4_5
+.4byte sVenonatAnims_4_6
+.4byte sVenonatAnims_4_7
+.4byte sVenonatAnims_4_8
+sVenonatAnimTable5:
+.4byte sVenonatAnims_5_1
+.4byte sVenonatAnims_5_2
+.4byte sVenonatAnims_5_3
+.4byte sVenonatAnims_5_4
+.4byte sVenonatAnims_5_5
+.4byte sVenonatAnims_5_6
+.4byte sVenonatAnims_5_7
+.4byte sVenonatAnims_5_8
+sVenonatAnimTable6:
+.4byte sVenonatAnims_6_1
+.4byte sVenonatAnims_6_1
+.4byte sVenonatAnims_6_1
+.4byte sVenonatAnims_6_1
+.4byte sVenonatAnims_6_1
+.4byte sVenonatAnims_6_1
+.4byte sVenonatAnims_6_1
+.4byte sVenonatAnims_6_1
+sVenonatAnimTable7:
+.4byte sVenonatAnims_7_1
+.4byte sVenonatAnims_7_2
+.4byte sVenonatAnims_7_3
+.4byte sVenonatAnims_7_4
+.4byte sVenonatAnims_7_5
+.4byte sVenonatAnims_7_6
+.4byte sVenonatAnims_7_7
+.4byte sVenonatAnims_7_8
+sVenonatAnimTable8:
+.4byte sVenonatAnims_8_1
+.4byte sVenonatAnims_8_2
+.4byte sVenonatAnims_8_3
+.4byte sVenonatAnims_8_4
+.4byte sVenonatAnims_8_5
+.4byte sVenonatAnims_8_6
+.4byte sVenonatAnims_8_7
+.4byte sVenonatAnims_8_8
+sVenonatAnimTable9:
+.4byte sVenonatAnims_9_1
+.4byte sVenonatAnims_9_2
+.4byte sVenonatAnims_9_3
+.4byte sVenonatAnims_9_4
+.4byte sVenonatAnims_9_5
+.4byte sVenonatAnims_9_6
+.4byte sVenonatAnims_9_7
+.4byte sVenonatAnims_9_8
+sVenonatAnimTable10:
+.4byte sVenonatAnims_10_1
+.4byte sVenonatAnims_10_2
+.4byte sVenonatAnims_10_3
+.4byte sVenonatAnims_10_4
+.4byte sVenonatAnims_10_5
+.4byte sVenonatAnims_10_6
+.4byte sVenonatAnims_10_7
+.4byte sVenonatAnims_10_8
+sVenonatAnimTable11:
+.4byte sVenonatAnims_11_1
+.4byte sVenonatAnims_11_2
+.4byte sVenonatAnims_11_3
+.4byte sVenonatAnims_11_4
+.4byte sVenonatAnims_11_5
+.4byte sVenonatAnims_11_6
+.4byte sVenonatAnims_11_7
+.4byte sVenonatAnims_11_8
+sVenonatAnimTable12:
+.4byte sVenonatAnims_12_1
+.4byte sVenonatAnims_12_2
+.4byte sVenonatAnims_12_3
+.4byte sVenonatAnims_12_4
+.4byte sVenonatAnims_12_5
+.4byte sVenonatAnims_12_6
+.4byte sVenonatAnims_12_7
+.4byte sVenonatAnims_12_8
+sVenonatAnimTable13:
+.4byte sVenonatAnims_13_1
+.4byte sVenonatAnims_13_2
+.4byte sVenonatAnims_13_3
+.4byte sVenonatAnims_13_4
+.4byte sVenonatAnims_13_5
+.4byte sVenonatAnims_13_6
+.4byte sVenonatAnims_13_7
+.4byte sVenonatAnims_13_8
+sAxAnimationsVenonat:
+.4byte sVenonatAnimTable1
+.4byte sVenonatAnimTable2
+.4byte sVenonatAnimTable3
+.4byte sVenonatAnimTable4
+.4byte sVenonatAnimTable5
+.4byte sVenonatAnimTable6
+.4byte sVenonatAnimTable7
+.4byte sVenonatAnimTable8
+.4byte sVenonatAnimTable9
+.4byte sVenonatAnimTable10
+.4byte sVenonatAnimTable11
+.4byte sVenonatAnimTable12
+.4byte sVenonatAnimTable13
+sAxSpritesVenonat:
+.4byte sVenonatSprites1
+.4byte sVenonatSprites2
+.4byte sVenonatSprites3
+.4byte sVenonatSprites4
+.4byte sVenonatSprites5
+.4byte sVenonatSprites6
+.4byte sVenonatSprites7
+.4byte sVenonatSprites8
+.4byte sVenonatSprites9
+.4byte sVenonatSprites10
+.4byte sVenonatSprites11
+.4byte sVenonatSprites12
+.4byte sVenonatSprites13
+.4byte sVenonatSprites14
+.4byte sVenonatSprites15
+.4byte sVenonatSprites16
+.4byte sVenonatSprites17
+.4byte sVenonatSprites18
+.4byte sVenonatSprites19
+.4byte sVenonatSprites20
+.4byte sVenonatSprites21
+.4byte sVenonatSprites22
+.4byte sVenonatSprites23
+.4byte sVenonatSprites24
+.4byte sVenonatSprites25
+.4byte sVenonatSprites26
+.4byte sVenonatSprites27
+sAxMainVenonat:
+ax_main sAxPosesVenonat, sAxAnimationsVenonat, 13, sAxSpritesVenonat, sAxPositionsVenonat

--- a/data/ax/venusaur.inc
+++ b/data/ax/venusaur.inc
@@ -1,0 +1,2426 @@
+.global gAxVenusaur
+gAxVenusaur:
+ax_siro sAxMainVenusaur
+sVenusaurPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose3:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose4:
+ax_pose 3, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose5:
+ax_pose 4, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose6:
+ax_pose 5, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose7:
+ax_pose 6, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose8:
+ax_pose 7, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose9:
+ax_pose 8, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose10:
+ax_pose 9, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose11:
+ax_pose 10, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose12:
+ax_pose 11, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose14:
+ax_pose 13, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose15:
+ax_pose 14, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose16:
+ax_pose 9, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose17:
+ax_pose 10, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose18:
+ax_pose 11, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose19:
+ax_pose 6, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose20:
+ax_pose 7, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose21:
+ax_pose 8, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose22:
+ax_pose 3, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose23:
+ax_pose 4, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose24:
+ax_pose 5, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose25:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose27:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose28:
+ax_pose 3, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose29:
+ax_pose 4, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose30:
+ax_pose 5, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose31:
+ax_pose 6, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose32:
+ax_pose 7, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose33:
+ax_pose 8, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose34:
+ax_pose 9, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose35:
+ax_pose 10, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose36:
+ax_pose 11, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose37:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose38:
+ax_pose 13, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose39:
+ax_pose 14, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose40:
+ax_pose 9, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose41:
+ax_pose 10, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose42:
+ax_pose 11, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose43:
+ax_pose 6, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose44:
+ax_pose 7, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose45:
+ax_pose 8, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose46:
+ax_pose 3, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose47:
+ax_pose 4, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose48:
+ax_pose 5, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose49:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose50:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose51:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose52:
+ax_pose 3, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose53:
+ax_pose 4, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose54:
+ax_pose 5, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose55:
+ax_pose 6, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose56:
+ax_pose 7, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose57:
+ax_pose 8, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose58:
+ax_pose 9, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose59:
+ax_pose 10, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose60:
+ax_pose 11, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose61:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose62:
+ax_pose 13, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose63:
+ax_pose 14, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose64:
+ax_pose 9, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose65:
+ax_pose 10, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose66:
+ax_pose 11, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose67:
+ax_pose 6, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose68:
+ax_pose 7, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose69:
+ax_pose 8, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose70:
+ax_pose 3, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose71:
+ax_pose 4, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose72:
+ax_pose 5, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose73:
+ax_pose 15, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose74:
+ax_pose 16, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose75:
+ax_pose 17, 0x01ef, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose76:
+ax_pose 18, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose77:
+ax_pose 19, 0x01ec, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose78:
+ax_pose 20, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose79:
+ax_pose 21, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose80:
+ax_pose 22, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose81:
+ax_pose 23, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose82:
+ax_pose 24, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose83:
+ax_pose 21, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose84:
+ax_pose 22, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose85:
+ax_pose 19, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose86:
+ax_pose 20, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose87:
+ax_pose 17, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose88:
+ax_pose 18, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose89:
+ax_pose 25, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose90:
+ax_pose 26, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose91:
+ax_pose 27, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose92:
+ax_pose 28, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose93:
+ax_pose 29, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose94:
+ax_pose 30, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose95:
+ax_pose 31, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose96:
+ax_pose 32, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose97:
+ax_pose 33, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose98:
+ax_pose 34, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose99:
+ax_pose 31, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose100:
+ax_pose 32, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose101:
+ax_pose 29, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose102:
+ax_pose 30, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose103:
+ax_pose 27, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose104:
+ax_pose 28, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose105:
+ax_pose 35, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose106:
+ax_pose 36, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose107:
+ax_pose 37, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose108:
+ax_pose 38, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sVenusaurPose109:
+ax_pose 39, 0x01e7, 0x90ef, 0x3c00
+ax_pose_terminator
+sVenusaurPose110:
+ax_pose 40, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sVenusaurPose111:
+ax_pose 41, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose112:
+ax_pose 40, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sVenusaurPose113:
+ax_pose 39, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose114:
+ax_pose 38, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose115:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose116:
+ax_pose 1, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose117:
+ax_pose 2, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose118:
+ax_pose 3, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose119:
+ax_pose 4, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose120:
+ax_pose 5, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose121:
+ax_pose 6, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose122:
+ax_pose 7, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose123:
+ax_pose 8, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose124:
+ax_pose 9, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose125:
+ax_pose 10, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose126:
+ax_pose 11, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose127:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose128:
+ax_pose 13, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose129:
+ax_pose 14, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose130:
+ax_pose 9, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose131:
+ax_pose 10, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose132:
+ax_pose 11, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose133:
+ax_pose 6, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose134:
+ax_pose 7, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose135:
+ax_pose 8, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose136:
+ax_pose 3, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose137:
+ax_pose 4, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose138:
+ax_pose 5, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose139:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose140:
+ax_pose 3, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose141:
+ax_pose 6, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose142:
+ax_pose 9, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose143:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose144:
+ax_pose 9, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose145:
+ax_pose 6, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose146:
+ax_pose 3, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose147:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose148:
+ax_pose 3, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose149:
+ax_pose 6, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose150:
+ax_pose 9, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose151:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose152:
+ax_pose 9, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose153:
+ax_pose 6, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose154:
+ax_pose 3, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose155:
+ax_pose 0, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose156:
+ax_pose 16, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose157:
+ax_pose 15, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose158:
+ax_pose 3, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose159:
+ax_pose 18, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose160:
+ax_pose 17, 0x01ef, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose161:
+ax_pose 6, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose162:
+ax_pose 20, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose163:
+ax_pose 19, 0x01ec, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose164:
+ax_pose 9, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose165:
+ax_pose 22, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose166:
+ax_pose 21, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose167:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose168:
+ax_pose 24, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose169:
+ax_pose 23, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose170:
+ax_pose 9, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose171:
+ax_pose 22, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose172:
+ax_pose 21, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose173:
+ax_pose 6, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose174:
+ax_pose 20, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose175:
+ax_pose 19, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose176:
+ax_pose 3, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose177:
+ax_pose 18, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose178:
+ax_pose 17, 0x01ef, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose179:
+ax_pose 16, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose180:
+ax_pose 18, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose181:
+ax_pose 20, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose182:
+ax_pose 22, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose183:
+ax_pose 24, 0x01e9, 0x80f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose184:
+ax_pose 22, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose185:
+ax_pose 20, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose186:
+ax_pose 18, 0x01e9, 0x90f1, 0x3c00
+ax_pose_terminator
+sVenusaurPose187:
+ax_pose 0, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sVenusaurPose188:
+ax_pose 3, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sVenusaurPose189:
+ax_pose 6, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sVenusaurPose190:
+ax_pose 9, 0x01e8, 0x80ef, 0x3c00
+ax_pose_terminator
+sVenusaurPose191:
+ax_pose 12, 0x01eb, 0x80ef, 0x3c00
+ax_pose_terminator
+sVenusaurPose192:
+ax_pose 9, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose193:
+ax_pose 6, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+sVenusaurPose194:
+ax_pose 3, 0x01e8, 0x90f0, 0x3c00
+ax_pose_terminator
+.align 2
+sVenusaurAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 16, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 16, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 16, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 16, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 16, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 16, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 16, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 16, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 16, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 16, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 16, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 16, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 16, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 16, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 16, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 16, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sVenusaurAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sVenusaurAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sVenusaurAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 35, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim 2, 2, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 1, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sVenusaurAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sVenusaurAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 0, 0, 0, -1,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim 2, 2, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 1, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sVenusaurAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sVenusaurAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_3_1:
+ax_anim 4, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 1, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 49, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 4, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sVenusaurAnims_3_2:
+ax_anim 4, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 4, 4, 4, 4,
+ax_anim 2, 2, 53, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 1, 52, 19, 17, 19, 17,
+ax_anim 2, 0, 52, 18, 18, 18, 18,
+ax_anim 2, 0, 52, 19, 17, 19, 17,
+ax_anim 4, 0, 51, 8, 8, 6, 6,
+ax_anim_terminator
+sVenusaurAnims_3_3:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 4, 0, 4, 0,
+ax_anim 2, 2, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 1, 55, 18, 1, 18, 1,
+ax_anim 2, 0, 55, 18, 0, 18, 0,
+ax_anim 2, 0, 55, 18, 1, 18, 1,
+ax_anim 4, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sVenusaurAnims_3_4:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 59, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 4, -4, 4, -4,
+ax_anim 2, 2, 59, 10, -10, 10, -10,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 1, 58, 19, -17, 19, -17,
+ax_anim 2, 0, 58, 18, -18, 18, -18,
+ax_anim 2, 0, 58, 19, -17, 19, -17,
+ax_anim 4, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sVenusaurAnims_3_5:
+ax_anim 4, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, -4,
+ax_anim 2, 2, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 1, 61, 1, -18, 1, -18,
+ax_anim 2, 0, 61, 0, -18, 0, -18,
+ax_anim 2, 0, 61, 1, -18, 1, -18,
+ax_anim 4, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sVenusaurAnims_3_6:
+ax_anim 4, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 65, 0, 0, 0, -1,
+ax_anim 2, 0, 64, -4, -4, -4, -4,
+ax_anim 2, 2, 65, -10, -10, -10, -10,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 1, 64, -19, -17, -19, -17,
+ax_anim 2, 0, 64, -18, -18, -18, -18,
+ax_anim 2, 0, 64, -19, -17, -19, -17,
+ax_anim 4, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sVenusaurAnims_3_7:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -4, 0, -4, 0,
+ax_anim 2, 2, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 1, 67, -18, 1, -18, 1,
+ax_anim 2, 0, 67, -18, 0, -18, 0,
+ax_anim 2, 0, 67, -18, 1, -18, 1,
+ax_anim 4, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sVenusaurAnims_3_8:
+ax_anim 4, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, -4, 4, -4, 4,
+ax_anim 2, 2, 71, -10, 10, -10, 10,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 1, 70, -18, 18, -18, 18,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 2, 0, 70, -17, 19, -17, 19,
+ax_anim 4, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_4_1:
+ax_anim 12, 0, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 4, 2, 72, 0, 0, 0, 0,
+ax_anim 4, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_4_2:
+ax_anim 12, 0, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 4, 2, 74, 0, 0, 0, 0,
+ax_anim 4, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_4_3:
+ax_anim 12, 0, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 4, 2, 76, 0, 0, 0, 0,
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_4_4:
+ax_anim 12, 0, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 4, 2, 78, 0, 0, 0, 0,
+ax_anim 4, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_4_5:
+ax_anim 12, 0, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 4, 2, 80, 0, 0, 0, 0,
+ax_anim 4, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_4_6:
+ax_anim 12, 0, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 4, 2, 82, 0, 0, 0, 0,
+ax_anim 4, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 1, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_4_7:
+ax_anim 12, 0, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 4, 2, 84, 0, 0, 0, 0,
+ax_anim 4, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_4_8:
+ax_anim 12, 0, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 4, 2, 86, 0, 0, 0, 0,
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_5_1:
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 2, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim 6, 0, 88, 0, 0, 0, 0,
+ax_anim 6, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_5_2:
+ax_anim 6, 0, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 2, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 6, 0, 90, 0, 0, 0, 0,
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_5_3:
+ax_anim 6, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 2, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim 6, 0, 92, 0, 0, 0, 0,
+ax_anim 6, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_5_4:
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 2, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim 6, 0, 94, 0, 0, 0, 0,
+ax_anim 6, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_5_5:
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 2, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim 6, 0, 96, 0, 0, 0, 0,
+ax_anim 6, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_5_6:
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 2, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim 6, 0, 98, 0, 0, 0, 0,
+ax_anim 6, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_5_7:
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 2, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim 6, 0, 100, 0, 0, 0, 0,
+ax_anim 6, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_5_8:
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 2, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 6, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_6_1:
+ax_anim 30, 0, 104, 0, 0, 0, 0,
+ax_anim 35, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_7_1:
+ax_anim 2, 0, 106, 0, -2, 0, -2,
+ax_anim 8, 0, 106, 0, -3, 0, -3,
+ax_anim_terminator
+sVenusaurAnims_7_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 8, 0, 107, -3, -3, -3, -3,
+ax_anim_terminator
+sVenusaurAnims_7_3:
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 8, 0, 108, -3, 0, -3, 0,
+ax_anim_terminator
+sVenusaurAnims_7_4:
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 8, 0, 109, -3, 3, -3, 3,
+ax_anim_terminator
+sVenusaurAnims_7_5:
+ax_anim 2, 0, 110, 0, 2, 0, 2,
+ax_anim 8, 0, 110, 0, 3, 0, 3,
+ax_anim_terminator
+sVenusaurAnims_7_6:
+ax_anim 2, 0, 111, 2, 2, 2, 2,
+ax_anim 8, 0, 111, 3, 3, 3, 3,
+ax_anim_terminator
+sVenusaurAnims_7_7:
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 8, 0, 112, 3, 0, 3, 0,
+ax_anim_terminator
+sVenusaurAnims_7_8:
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim 8, 0, 113, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_8_1:
+ax_anim 30, 0, 114, 0, 0, 0, 0,
+ax_anim 16, 0, 115, 0, 0, 0, 0,
+ax_anim 12, 0, 114, 0, 0, 0, 0,
+ax_anim 16, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_8_2:
+ax_anim 30, 0, 117, 0, 0, 0, 0,
+ax_anim 16, 0, 118, 0, 0, 0, 0,
+ax_anim 12, 0, 117, 0, 0, 0, 0,
+ax_anim 16, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_8_3:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 16, 0, 121, 0, 0, 0, 0,
+ax_anim 12, 0, 120, 0, 0, 0, 0,
+ax_anim 16, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_8_4:
+ax_anim 30, 0, 123, 0, 0, 0, 0,
+ax_anim 16, 0, 124, 0, 0, 0, 0,
+ax_anim 12, 0, 123, 0, 0, 0, 0,
+ax_anim 16, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_8_5:
+ax_anim 30, 0, 126, 0, 0, 0, 0,
+ax_anim 16, 0, 127, 0, 0, 0, 0,
+ax_anim 12, 0, 126, 0, 0, 0, 0,
+ax_anim 16, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_8_6:
+ax_anim 30, 0, 129, 0, 0, 0, 0,
+ax_anim 16, 0, 130, 0, 0, 0, 0,
+ax_anim 12, 0, 129, 0, 0, 0, 0,
+ax_anim 16, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_8_7:
+ax_anim 30, 0, 132, 0, 0, 0, 0,
+ax_anim 16, 0, 133, 0, 0, 0, 0,
+ax_anim 12, 0, 132, 0, 0, 0, 0,
+ax_anim 16, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_8_8:
+ax_anim 30, 0, 135, 0, 0, 0, 0,
+ax_anim 16, 0, 136, 0, 0, 0, 0,
+ax_anim 12, 0, 135, 0, 0, 0, 0,
+ax_anim 16, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_9_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 6, 4, 6, 4,
+ax_anim 2, 0, 140, 8, 9, 8, 9,
+ax_anim 2, 0, 141, 7, 13, 7, 13,
+ax_anim 3, 0, 142, 1, 16, 1, 16,
+ax_anim 2, 3, 143, -4, 14, -4, 14,
+ax_anim 2, 0, 144, -5, 8, -5, 8,
+ax_anim 1, 0, 145, -4, 4, -4, 4,
+ax_anim 1, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_9_2:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 139, 17, 3, 17, 3,
+ax_anim 2, 0, 140, 24, 9, 24, 9,
+ax_anim 3, 0, 141, 23, 16, 23, 16,
+ax_anim 2, 3, 142, 11, 16, 11, 16,
+ax_anim 2, 0, 143, 4, 12, 4, 12,
+ax_anim 1, 0, 144, 3, 7, 3, 7,
+ax_anim 1, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_9_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 3, -4, 3, -4,
+ax_anim 2, 0, 138, 11, -6, 11, -6,
+ax_anim 2, 0, 139, 17, -4, 17, -4,
+ax_anim 3, 0, 140, 20, 1, 20, 1,
+ax_anim 2, 3, 141, 17, 5, 17, 5,
+ax_anim 2, 0, 142, 12, 7, 12, 7,
+ax_anim 1, 0, 143, 4, 5, 4, 5,
+ax_anim 1, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_9_4:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 1, 0, 144, 1, -6, 1, -6,
+ax_anim 2, 0, 145, 4, -16, 4, -16,
+ax_anim 2, 0, 138, 11, -20, 11, -20,
+ax_anim 3, 0, 139, 16, -20, 16, -20,
+ax_anim 2, 3, 140, 16, -15, 16, -15,
+ax_anim 2, 0, 141, 14, -6, 14, -6,
+ax_anim 1, 0, 142, 7, -1, 7, -1,
+ax_anim 1, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_9_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, -6, -4, -6, -4,
+ax_anim 2, 0, 144, -8, -9, -8, -9,
+ax_anim 2, 0, 145, -7, -13, -7, -13,
+ax_anim 3, 0, 138, -1, -16, -1, -16,
+ax_anim 2, 3, 139, 4, -14, 4, -14,
+ax_anim 2, 0, 140, 5, -8, 5, -8,
+ax_anim 1, 0, 141, 4, -4, 4, -4,
+ax_anim 1, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_9_6:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 140, -1, -6, -1, -6,
+ax_anim 2, 0, 139, -4, -16, -4, -16,
+ax_anim 2, 0, 138, -11, -20, -11, -20,
+ax_anim 3, 0, 145, -16, -20, -16, -20,
+ax_anim 2, 3, 144, -16, -15, -16, -15,
+ax_anim 2, 0, 143, -14, -6, -14, -6,
+ax_anim 1, 0, 142, -7, -1, -7, -1,
+ax_anim 1, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_9_7:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 139, -3, -4, -3, -4,
+ax_anim 2, 0, 138, -11, -6, -11, -6,
+ax_anim 2, 0, 145, -17, -4, -17, -4,
+ax_anim 3, 0, 144, -20, 1, -20, 1,
+ax_anim 2, 3, 143, -17, 5, -17, 5,
+ax_anim 2, 0, 142, -12, 7, -12, 7,
+ax_anim 1, 0, 141, -4, 5, -4, 5,
+ax_anim 1, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_9_8:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 1, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 145, -17, 3, -17, 3,
+ax_anim 2, 0, 144, -24, 9, -24, 9,
+ax_anim 3, 0, 143, -23, 16, -23, 16,
+ax_anim 2, 3, 142, -11, 16, -11, 16,
+ax_anim 2, 0, 141, -4, 12, -4, 12,
+ax_anim 1, 0, 140, -3, 7, -3, 7,
+ax_anim 1, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_10_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 3, 0, 146, 13, 0, 13, 0,
+ax_anim 3, 0, 146, -13, 0, -13, 0,
+ax_anim 2, 0, 146, 12, 0, 12, 0,
+ax_anim 3, 0, 146, -12, 0, -12, 0,
+ax_anim 2, 0, 146, 10, 0, 10, 0,
+ax_anim 2, 0, 146, -10, 0, -10, 0,
+ax_anim 2, 0, 146, 6, 0, 6, 0,
+ax_anim 2, 0, 146, -6, 0, -6, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_10_2:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 3, 0, 147, 13, -13, 13, -13,
+ax_anim 3, 0, 147, -13, 13, -13, 13,
+ax_anim 2, 0, 147, 12, -12, 12, -12,
+ax_anim 3, 0, 147, -12, 12, -12, 12,
+ax_anim 2, 0, 147, 10, -10, 10, -10,
+ax_anim 2, 0, 147, -10, 10, -10, 10,
+ax_anim 2, 0, 147, 6, -6, 6, -6,
+ax_anim 2, 0, 147, -6, 6, -6, 6,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_10_3:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 3, 0, 148, 0, -13, 0, -13,
+ax_anim 3, 0, 148, 0, 13, 0, 13,
+ax_anim 2, 0, 148, 0, -12, 0, -12,
+ax_anim 3, 0, 148, 0, 12, 0, 12,
+ax_anim 2, 0, 148, 0, -10, 0, -10,
+ax_anim 2, 0, 148, 0, 10, 0, 10,
+ax_anim 2, 0, 148, 0, -6, 0, -6,
+ax_anim 2, 0, 148, 0, 6, 0, 6,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_10_4:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 3, 0, 149, -13, -13, -13, -13,
+ax_anim 3, 0, 149, 13, 13, 13, 13,
+ax_anim 2, 0, 149, -12, -12, -12, -12,
+ax_anim 3, 0, 149, 12, 12, 12, 12,
+ax_anim 2, 0, 149, -10, -10, -10, -10,
+ax_anim 2, 0, 149, 10, 10, 10, 10,
+ax_anim 2, 0, 149, -6, -6, -6, -6,
+ax_anim 2, 0, 149, 6, 6, 6, 6,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_10_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 3, 0, 150, 13, 0, 13, 0,
+ax_anim 3, 0, 150, -13, 0, -13, 0,
+ax_anim 2, 0, 150, 12, 0, 12, 0,
+ax_anim 3, 0, 150, -12, 0, -12, 0,
+ax_anim 2, 0, 150, 10, 0, 10, 0,
+ax_anim 2, 0, 150, -10, 0, -10, 0,
+ax_anim 2, 0, 150, 6, 0, 6, 0,
+ax_anim 2, 0, 150, -6, 0, -6, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_10_6:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 3, 0, 151, 13, -13, 13, -13,
+ax_anim 3, 0, 151, -13, 13, -13, 13,
+ax_anim 2, 0, 151, 12, -12, 12, -12,
+ax_anim 3, 0, 151, -12, 12, -12, 12,
+ax_anim 2, 0, 151, 10, -10, 10, -10,
+ax_anim 2, 0, 151, -10, 10, -10, 10,
+ax_anim 2, 0, 151, 6, -6, 6, -6,
+ax_anim 2, 0, 151, -6, 6, -6, 6,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_10_7:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 3, 0, 152, 0, -13, 0, -13,
+ax_anim 3, 0, 152, 0, 13, 0, 13,
+ax_anim 2, 0, 152, 0, -12, 0, -12,
+ax_anim 3, 0, 152, 0, 12, 0, 12,
+ax_anim 2, 0, 152, 0, -10, 0, -10,
+ax_anim 2, 0, 152, 0, 10, 0, 10,
+ax_anim 2, 0, 152, 0, -6, 0, -6,
+ax_anim 2, 0, 152, 0, 6, 0, 6,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_10_8:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 3, 0, 153, -13, -13, -13, -13,
+ax_anim 3, 0, 153, 13, 13, 13, 13,
+ax_anim 2, 0, 153, -12, -12, -12, -12,
+ax_anim 3, 0, 153, 12, 12, 12, 12,
+ax_anim 2, 0, 153, -10, -10, -10, -10,
+ax_anim 2, 0, 153, 10, 10, 10, 10,
+ax_anim 2, 0, 153, -6, -6, -6, -6,
+ax_anim 2, 0, 153, 6, 6, 6, 6,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_11_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 0, -10, 0, 0,
+ax_anim 2, 0, 155, 0, -16, 0, 0,
+ax_anim 3, 0, 155, 0, -20, 0, 0,
+ax_anim 4, 0, 155, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -23, 0, 0,
+ax_anim 3, 0, 156, 0, -22, 0, 0,
+ax_anim 2, 0, 156, 0, -18, 0, 0,
+ax_anim 1, 0, 156, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_11_2:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 158, 0, -10, 0, 0,
+ax_anim 2, 0, 158, 0, -16, 0, 0,
+ax_anim 3, 0, 158, 0, -20, 0, 0,
+ax_anim 4, 0, 158, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 159, 0, -22, 0, 0,
+ax_anim 2, 0, 159, 0, -18, 0, 0,
+ax_anim 1, 0, 159, 0, -12, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_11_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 0, -10, 0, 0,
+ax_anim 2, 0, 161, 0, -16, 0, 0,
+ax_anim 3, 0, 161, 0, -20, 0, 0,
+ax_anim 4, 0, 161, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -23, 0, 0,
+ax_anim 3, 0, 162, 0, -22, 0, 0,
+ax_anim 2, 0, 162, 0, -18, 0, 0,
+ax_anim 1, 0, 162, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_11_4:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -10, 0, 0,
+ax_anim 2, 0, 164, 0, -16, 0, 0,
+ax_anim 3, 0, 164, 0, -20, 0, 0,
+ax_anim 4, 0, 164, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -22, 0, 0,
+ax_anim 3, 0, 165, 0, -21, 0, 0,
+ax_anim 2, 0, 165, 0, -17, 0, 0,
+ax_anim 1, 0, 165, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_11_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, -10, 0, 0,
+ax_anim 2, 0, 167, 0, -16, 0, 0,
+ax_anim 3, 0, 167, 0, -20, 0, 0,
+ax_anim 4, 0, 167, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -23, 0, 0,
+ax_anim 3, 0, 168, 0, -22, 0, 0,
+ax_anim 2, 0, 168, 0, -18, 0, 0,
+ax_anim 1, 0, 168, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_11_6:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, -10, 0, 0,
+ax_anim 2, 0, 170, 0, -16, 0, 0,
+ax_anim 3, 0, 170, 0, -20, 0, 0,
+ax_anim 4, 0, 170, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 171, 0, -21, 0, 0,
+ax_anim 2, 0, 171, 0, -17, 0, 0,
+ax_anim 1, 0, 171, 0, -11, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_11_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 0, -10, 0, 0,
+ax_anim 2, 0, 173, 0, -16, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 4, 0, 173, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -23, 0, 0,
+ax_anim 3, 0, 174, 0, -22, 0, 0,
+ax_anim 2, 0, 174, 0, -18, 0, 0,
+ax_anim 1, 0, 174, 0, -12, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_11_8:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 4, 0, 176, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -23, 0, 0,
+ax_anim 3, 0, 177, 0, -22, 0, 0,
+ax_anim 2, 0, 177, 0, -18, 0, 0,
+ax_anim 1, 0, 177, 0, -12, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_12_1:
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 1, 0, 1, 0,
+ax_anim 2, 1, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_12_2:
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 1, -1, 1, 0,
+ax_anim 2, 1, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_12_3:
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -1, 0, -1,
+ax_anim 2, 1, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_12_4:
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, -1, -1, -1, -1,
+ax_anim 2, 1, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_12_5:
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 1, 0, 1, 0,
+ax_anim 2, 1, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_12_6:
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 1, -1, 1, -1,
+ax_anim 2, 1, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_12_7:
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -1, 0, -1,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_12_8:
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, -1, -1, -1, -1,
+ax_anim 2, 1, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVenusaurAnims_13_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_13_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_13_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_13_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_13_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_13_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_13_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurAnims_13_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sVenusaurGfx1:
+.incbin "baserom.gba", 0x52E1D0, 0x200
+sVenusaurSprites1:
+ax_sprite sVenusaurGfx1, 0x200
+ax_sprite_terminator
+sVenusaurGfx2:
+.incbin "baserom.gba", 0x52E3E0, 0x200
+sVenusaurSprites2:
+ax_sprite sVenusaurGfx2, 0x200
+ax_sprite_terminator
+sVenusaurGfx3:
+.incbin "baserom.gba", 0x52E5F0, 0x200
+sVenusaurSprites3:
+ax_sprite sVenusaurGfx3, 0x200
+ax_sprite_terminator
+sVenusaurGfx4:
+.incbin "baserom.gba", 0x52E800, 0x200
+sVenusaurSprites4:
+ax_sprite sVenusaurGfx4, 0x200
+ax_sprite_terminator
+sVenusaurGfx5:
+.incbin "baserom.gba", 0x52EA10, 0x200
+sVenusaurSprites5:
+ax_sprite sVenusaurGfx5, 0x200
+ax_sprite_terminator
+sVenusaurGfx6:
+.incbin "baserom.gba", 0x52EC20, 0x200
+sVenusaurSprites6:
+ax_sprite sVenusaurGfx6, 0x200
+ax_sprite_terminator
+sVenusaurGfx7:
+.incbin "baserom.gba", 0x52EE30, 0x200
+sVenusaurSprites7:
+ax_sprite sVenusaurGfx7, 0x200
+ax_sprite_terminator
+sVenusaurGfx8:
+.incbin "baserom.gba", 0x52F040, 0x200
+sVenusaurSprites8:
+ax_sprite sVenusaurGfx8, 0x200
+ax_sprite_terminator
+sVenusaurGfx9:
+.incbin "baserom.gba", 0x52F250, 0x200
+sVenusaurSprites9:
+ax_sprite sVenusaurGfx9, 0x200
+ax_sprite_terminator
+sVenusaurGfx10:
+.incbin "baserom.gba", 0x52F460, 0x200
+sVenusaurSprites10:
+ax_sprite sVenusaurGfx10, 0x200
+ax_sprite_terminator
+sVenusaurGfx11:
+.incbin "baserom.gba", 0x52F670, 0x200
+sVenusaurSprites11:
+ax_sprite sVenusaurGfx11, 0x200
+ax_sprite_terminator
+sVenusaurGfx12:
+.incbin "baserom.gba", 0x52F880, 0x200
+sVenusaurSprites12:
+ax_sprite sVenusaurGfx12, 0x200
+ax_sprite_terminator
+sVenusaurGfx13:
+.incbin "baserom.gba", 0x52FA90, 0x200
+sVenusaurSprites13:
+ax_sprite sVenusaurGfx13, 0x200
+ax_sprite_terminator
+sVenusaurGfx14:
+.incbin "baserom.gba", 0x52FCA0, 0x200
+sVenusaurSprites14:
+ax_sprite sVenusaurGfx14, 0x200
+ax_sprite_terminator
+sVenusaurGfx15:
+.incbin "baserom.gba", 0x52FEB0, 0x200
+sVenusaurSprites15:
+ax_sprite sVenusaurGfx15, 0x200
+ax_sprite_terminator
+sVenusaurGfx16:
+.incbin "baserom.gba", 0x5300C0, 0x180
+sVenusaurSprites16:
+ax_sprite sVenusaurGfx16, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVenusaurGfx17:
+.incbin "baserom.gba", 0x530258, 0x1E0
+sVenusaurSprites17:
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx17, 0x1e0
+ax_sprite_terminator
+sVenusaurGfx18:
+.incbin "baserom.gba", 0x530450, 0x60
+sVenusaurGfx18_1:
+.incbin "baserom.gba", 0x5304B0, 0x100
+sVenusaurSprites18:
+ax_sprite sVenusaurGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx18_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVenusaurGfx19:
+.incbin "baserom.gba", 0x5305D8, 0x60
+sVenusaurGfx19_1:
+.incbin "baserom.gba", 0x530638, 0x160
+sVenusaurSprites19:
+ax_sprite sVenusaurGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx20:
+.incbin "baserom.gba", 0x5307C0, 0x60
+sVenusaurGfx20_1:
+.incbin "baserom.gba", 0x530820, 0x100
+sVenusaurSprites20:
+ax_sprite sVenusaurGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVenusaurGfx21:
+.incbin "baserom.gba", 0x530948, 0x60
+sVenusaurGfx21_1:
+.incbin "baserom.gba", 0x5309A8, 0x100
+sVenusaurGfx21_2:
+.incbin "baserom.gba", 0x530AA8, 0x60
+sVenusaurSprites21:
+ax_sprite sVenusaurGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx21_2, 0x60
+ax_sprite_terminator
+sVenusaurGfx22:
+.incbin "baserom.gba", 0x530B38, 0x180
+sVenusaurGfx22_1:
+.incbin "baserom.gba", 0x530CB8, 0x40
+sVenusaurSprites22:
+ax_sprite sVenusaurGfx22, 0x180
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx22_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx23:
+.incbin "baserom.gba", 0x530D20, 0x180
+sVenusaurGfx23_1:
+.incbin "baserom.gba", 0x530EA0, 0x40
+sVenusaurSprites23:
+ax_sprite sVenusaurGfx23, 0x180
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx23_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx24:
+.incbin "baserom.gba", 0x530F08, 0x180
+sVenusaurSprites24:
+ax_sprite sVenusaurGfx24, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVenusaurGfx25:
+.incbin "baserom.gba", 0x5310A0, 0x180
+sVenusaurSprites25:
+ax_sprite sVenusaurGfx25, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVenusaurGfx26:
+.incbin "baserom.gba", 0x531238, 0x200
+sVenusaurSprites26:
+ax_sprite sVenusaurGfx26, 0x200
+ax_sprite_terminator
+sVenusaurGfx27:
+.incbin "baserom.gba", 0x531448, 0x1E0
+sVenusaurSprites27:
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx27, 0x1e0
+ax_sprite_terminator
+sVenusaurGfx28:
+.incbin "baserom.gba", 0x531640, 0x60
+sVenusaurGfx28_1:
+.incbin "baserom.gba", 0x5316A0, 0x160
+sVenusaurSprites28:
+ax_sprite sVenusaurGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx28_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx29:
+.incbin "baserom.gba", 0x531828, 0x1E0
+sVenusaurSprites29:
+ax_sprite sVenusaurGfx29, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx30:
+.incbin "baserom.gba", 0x531A20, 0x180
+sVenusaurGfx30_1:
+.incbin "baserom.gba", 0x531BA0, 0x60
+sVenusaurSprites30:
+ax_sprite sVenusaurGfx30, 0x180
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx30_1, 0x60
+ax_sprite_terminator
+sVenusaurGfx31:
+.incbin "baserom.gba", 0x531C20, 0x40
+sVenusaurGfx31_1:
+.incbin "baserom.gba", 0x531C60, 0x100
+sVenusaurGfx31_2:
+.incbin "baserom.gba", 0x531D60, 0x40
+sVenusaurSprites31:
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx31_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx32:
+.incbin "baserom.gba", 0x531DE0, 0x160
+sVenusaurGfx32_1:
+.incbin "baserom.gba", 0x531F40, 0x40
+sVenusaurSprites32:
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx32, 0x160
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx32_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx33:
+.incbin "baserom.gba", 0x531FB0, 0x160
+sVenusaurGfx33_1:
+.incbin "baserom.gba", 0x532110, 0x40
+sVenusaurSprites33:
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx33, 0x160
+ax_sprite 0, 0x20
+ax_sprite sVenusaurGfx33_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVenusaurGfx34:
+.incbin "baserom.gba", 0x532180, 0x180
+sVenusaurSprites34:
+ax_sprite sVenusaurGfx34, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVenusaurGfx35:
+.incbin "baserom.gba", 0x532318, 0x180
+sVenusaurSprites35:
+ax_sprite sVenusaurGfx35, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVenusaurGfx36:
+.incbin "baserom.gba", 0x5324B0, 0x200
+sVenusaurSprites36:
+ax_sprite sVenusaurGfx36, 0x200
+ax_sprite_terminator
+sVenusaurGfx37:
+.incbin "baserom.gba", 0x5326C0, 0x200
+sVenusaurSprites37:
+ax_sprite sVenusaurGfx37, 0x200
+ax_sprite_terminator
+sVenusaurGfx38:
+.incbin "baserom.gba", 0x5328D0, 0x200
+sVenusaurSprites38:
+ax_sprite sVenusaurGfx38, 0x200
+ax_sprite_terminator
+sVenusaurGfx39:
+.incbin "baserom.gba", 0x532AE0, 0x200
+sVenusaurSprites39:
+ax_sprite sVenusaurGfx39, 0x200
+ax_sprite_terminator
+sVenusaurGfx40:
+.incbin "baserom.gba", 0x532CF0, 0x200
+sVenusaurSprites40:
+ax_sprite sVenusaurGfx40, 0x200
+ax_sprite_terminator
+sVenusaurGfx41:
+.incbin "baserom.gba", 0x532F00, 0x200
+sVenusaurSprites41:
+ax_sprite sVenusaurGfx41, 0x200
+ax_sprite_terminator
+sVenusaurGfx42:
+.incbin "baserom.gba", 0x533110, 0x200
+sVenusaurSprites42:
+ax_sprite sVenusaurGfx42, 0x200
+ax_sprite_terminator
+sAxPosesVenusaur:
+.4byte sVenusaurPose1
+.4byte sVenusaurPose2
+.4byte sVenusaurPose3
+.4byte sVenusaurPose4
+.4byte sVenusaurPose5
+.4byte sVenusaurPose6
+.4byte sVenusaurPose7
+.4byte sVenusaurPose8
+.4byte sVenusaurPose9
+.4byte sVenusaurPose10
+.4byte sVenusaurPose11
+.4byte sVenusaurPose12
+.4byte sVenusaurPose13
+.4byte sVenusaurPose14
+.4byte sVenusaurPose15
+.4byte sVenusaurPose16
+.4byte sVenusaurPose17
+.4byte sVenusaurPose18
+.4byte sVenusaurPose19
+.4byte sVenusaurPose20
+.4byte sVenusaurPose21
+.4byte sVenusaurPose22
+.4byte sVenusaurPose23
+.4byte sVenusaurPose24
+.4byte sVenusaurPose25
+.4byte sVenusaurPose26
+.4byte sVenusaurPose27
+.4byte sVenusaurPose28
+.4byte sVenusaurPose29
+.4byte sVenusaurPose30
+.4byte sVenusaurPose31
+.4byte sVenusaurPose32
+.4byte sVenusaurPose33
+.4byte sVenusaurPose34
+.4byte sVenusaurPose35
+.4byte sVenusaurPose36
+.4byte sVenusaurPose37
+.4byte sVenusaurPose38
+.4byte sVenusaurPose39
+.4byte sVenusaurPose40
+.4byte sVenusaurPose41
+.4byte sVenusaurPose42
+.4byte sVenusaurPose43
+.4byte sVenusaurPose44
+.4byte sVenusaurPose45
+.4byte sVenusaurPose46
+.4byte sVenusaurPose47
+.4byte sVenusaurPose48
+.4byte sVenusaurPose49
+.4byte sVenusaurPose50
+.4byte sVenusaurPose51
+.4byte sVenusaurPose52
+.4byte sVenusaurPose53
+.4byte sVenusaurPose54
+.4byte sVenusaurPose55
+.4byte sVenusaurPose56
+.4byte sVenusaurPose57
+.4byte sVenusaurPose58
+.4byte sVenusaurPose59
+.4byte sVenusaurPose60
+.4byte sVenusaurPose61
+.4byte sVenusaurPose62
+.4byte sVenusaurPose63
+.4byte sVenusaurPose64
+.4byte sVenusaurPose65
+.4byte sVenusaurPose66
+.4byte sVenusaurPose67
+.4byte sVenusaurPose68
+.4byte sVenusaurPose69
+.4byte sVenusaurPose70
+.4byte sVenusaurPose71
+.4byte sVenusaurPose72
+.4byte sVenusaurPose73
+.4byte sVenusaurPose74
+.4byte sVenusaurPose75
+.4byte sVenusaurPose76
+.4byte sVenusaurPose77
+.4byte sVenusaurPose78
+.4byte sVenusaurPose79
+.4byte sVenusaurPose80
+.4byte sVenusaurPose81
+.4byte sVenusaurPose82
+.4byte sVenusaurPose83
+.4byte sVenusaurPose84
+.4byte sVenusaurPose85
+.4byte sVenusaurPose86
+.4byte sVenusaurPose87
+.4byte sVenusaurPose88
+.4byte sVenusaurPose89
+.4byte sVenusaurPose90
+.4byte sVenusaurPose91
+.4byte sVenusaurPose92
+.4byte sVenusaurPose93
+.4byte sVenusaurPose94
+.4byte sVenusaurPose95
+.4byte sVenusaurPose96
+.4byte sVenusaurPose97
+.4byte sVenusaurPose98
+.4byte sVenusaurPose99
+.4byte sVenusaurPose100
+.4byte sVenusaurPose101
+.4byte sVenusaurPose102
+.4byte sVenusaurPose103
+.4byte sVenusaurPose104
+.4byte sVenusaurPose105
+.4byte sVenusaurPose106
+.4byte sVenusaurPose107
+.4byte sVenusaurPose108
+.4byte sVenusaurPose109
+.4byte sVenusaurPose110
+.4byte sVenusaurPose111
+.4byte sVenusaurPose112
+.4byte sVenusaurPose113
+.4byte sVenusaurPose114
+.4byte sVenusaurPose115
+.4byte sVenusaurPose116
+.4byte sVenusaurPose117
+.4byte sVenusaurPose118
+.4byte sVenusaurPose119
+.4byte sVenusaurPose120
+.4byte sVenusaurPose121
+.4byte sVenusaurPose122
+.4byte sVenusaurPose123
+.4byte sVenusaurPose124
+.4byte sVenusaurPose125
+.4byte sVenusaurPose126
+.4byte sVenusaurPose127
+.4byte sVenusaurPose128
+.4byte sVenusaurPose129
+.4byte sVenusaurPose130
+.4byte sVenusaurPose131
+.4byte sVenusaurPose132
+.4byte sVenusaurPose133
+.4byte sVenusaurPose134
+.4byte sVenusaurPose135
+.4byte sVenusaurPose136
+.4byte sVenusaurPose137
+.4byte sVenusaurPose138
+.4byte sVenusaurPose139
+.4byte sVenusaurPose140
+.4byte sVenusaurPose141
+.4byte sVenusaurPose142
+.4byte sVenusaurPose143
+.4byte sVenusaurPose144
+.4byte sVenusaurPose145
+.4byte sVenusaurPose146
+.4byte sVenusaurPose147
+.4byte sVenusaurPose148
+.4byte sVenusaurPose149
+.4byte sVenusaurPose150
+.4byte sVenusaurPose151
+.4byte sVenusaurPose152
+.4byte sVenusaurPose153
+.4byte sVenusaurPose154
+.4byte sVenusaurPose155
+.4byte sVenusaurPose156
+.4byte sVenusaurPose157
+.4byte sVenusaurPose158
+.4byte sVenusaurPose159
+.4byte sVenusaurPose160
+.4byte sVenusaurPose161
+.4byte sVenusaurPose162
+.4byte sVenusaurPose163
+.4byte sVenusaurPose164
+.4byte sVenusaurPose165
+.4byte sVenusaurPose166
+.4byte sVenusaurPose167
+.4byte sVenusaurPose168
+.4byte sVenusaurPose169
+.4byte sVenusaurPose170
+.4byte sVenusaurPose171
+.4byte sVenusaurPose172
+.4byte sVenusaurPose173
+.4byte sVenusaurPose174
+.4byte sVenusaurPose175
+.4byte sVenusaurPose176
+.4byte sVenusaurPose177
+.4byte sVenusaurPose178
+.4byte sVenusaurPose179
+.4byte sVenusaurPose180
+.4byte sVenusaurPose181
+.4byte sVenusaurPose182
+.4byte sVenusaurPose183
+.4byte sVenusaurPose184
+.4byte sVenusaurPose185
+.4byte sVenusaurPose186
+.4byte sVenusaurPose187
+.4byte sVenusaurPose188
+.4byte sVenusaurPose189
+.4byte sVenusaurPose190
+.4byte sVenusaurPose191
+.4byte sVenusaurPose192
+.4byte sVenusaurPose193
+.4byte sVenusaurPose194
+sAxPositionsVenusaur:
+.2byte    0,    4, 	 -10,    0, 	  10,    0, 	   0,   -6
+.2byte    1,    5, 	  -9,    2, 	  10,    0, 	   1,   -5
+.2byte   -1,    5, 	 -10,    0, 	   9,    2, 	  -1,   -5
+.2byte    9,    2, 	  10,   -2, 	  -1,    3, 	   1,  -10
+.2byte    8,    3, 	  11,    0, 	  -3,    3, 	   0,   -9
+.2byte   10,    2, 	   8,   -3, 	   1,    4, 	   1,   -9
+.2byte   13,   -4, 	   7,   -4, 	   5,    1, 	   0,  -10
+.2byte   13,   -3, 	  10,   -3, 	   3,    1, 	   0,   -9
+.2byte   13,   -5, 	   2,   -5, 	   8,    1, 	   0,   -9
+.2byte    5,  -11, 	  -3,   -9, 	  10,   -3, 	   0,  -11
+.2byte    8,  -10, 	   1,  -10, 	   9,   -1, 	   0,  -10
+.2byte    5,  -10, 	  -4,   -7, 	  11,   -3, 	   0,  -11
+.2byte    0,   -8, 	   9,   -8, 	  -9,   -8, 	   0,   -7
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -5, 	   0,   -6
+.2byte    1,   -7, 	   9,   -6, 	  -7,   -8, 	   0,   -6
+.2byte   -5,  -11, 	   3,   -9, 	 -10,   -3, 	   0,  -11
+.2byte   -8,  -10, 	  -1,  -10, 	  -9,   -1, 	   0,  -10
+.2byte   -5,  -10, 	   4,   -7, 	 -11,   -3, 	   0,  -11
+.2byte  -13,   -4, 	  -7,   -4, 	  -5,    1, 	   0,  -10
+.2byte  -13,   -3, 	 -10,   -3, 	  -3,    1, 	   0,   -9
+.2byte  -13,   -5, 	  -2,   -5, 	  -8,    1, 	   0,   -9
+.2byte   -9,    2, 	 -10,   -2, 	   1,    3, 	  -1,  -10
+.2byte   -8,    3, 	 -11,    0, 	   3,    3, 	   0,   -9
+.2byte  -10,    2, 	  -8,   -3, 	  -1,    4, 	  -1,   -9
+.2byte    0,    4, 	 -10,    0, 	  10,    0, 	   0,   -6
+.2byte    1,    5, 	  -9,    2, 	  10,    0, 	   1,   -5
+.2byte   -1,    5, 	 -10,    0, 	   9,    2, 	  -1,   -5
+.2byte    9,    2, 	  10,   -2, 	  -1,    3, 	   1,  -10
+.2byte    8,    3, 	  11,    0, 	  -3,    3, 	   0,   -9
+.2byte   10,    2, 	   8,   -3, 	   1,    4, 	   1,   -9
+.2byte   13,   -4, 	   7,   -4, 	   5,    1, 	   0,  -10
+.2byte   13,   -3, 	  10,   -3, 	   3,    1, 	   0,   -9
+.2byte   13,   -5, 	   2,   -5, 	   8,    1, 	   0,   -9
+.2byte    5,  -11, 	  -3,   -9, 	  10,   -3, 	   0,  -11
+.2byte    8,  -10, 	   1,  -10, 	   9,   -1, 	   0,  -10
+.2byte    5,  -10, 	  -4,   -7, 	  11,   -3, 	   0,  -11
+.2byte    0,   -8, 	   9,   -8, 	  -9,   -8, 	   0,   -7
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -5, 	   0,   -6
+.2byte    1,   -7, 	   9,   -6, 	  -7,   -8, 	   0,   -6
+.2byte   -5,  -11, 	   3,   -9, 	 -10,   -3, 	   0,  -11
+.2byte   -8,  -10, 	  -1,  -10, 	  -9,   -1, 	   0,  -10
+.2byte   -5,  -10, 	   4,   -7, 	 -11,   -3, 	   0,  -11
+.2byte  -13,   -4, 	  -7,   -4, 	  -5,    1, 	   0,  -10
+.2byte  -13,   -3, 	 -10,   -3, 	  -3,    1, 	   0,   -9
+.2byte  -13,   -5, 	  -2,   -5, 	  -8,    1, 	   0,   -9
+.2byte   -9,    2, 	 -10,   -2, 	   1,    3, 	  -1,  -10
+.2byte   -8,    3, 	 -11,    0, 	   3,    3, 	   0,   -9
+.2byte  -10,    2, 	  -8,   -3, 	  -1,    4, 	  -1,   -9
+.2byte    0,    4, 	 -10,    0, 	  10,    0, 	   0,   -6
+.2byte    1,    5, 	  -9,    2, 	  10,    0, 	   1,   -5
+.2byte   -1,    5, 	 -10,    0, 	   9,    2, 	  -1,   -5
+.2byte    9,    2, 	  10,   -2, 	  -1,    3, 	   1,  -10
+.2byte    8,    3, 	  11,    0, 	  -3,    3, 	   0,   -9
+.2byte   10,    2, 	   8,   -3, 	   1,    4, 	   1,   -9
+.2byte   13,   -4, 	   7,   -4, 	   5,    1, 	   0,  -10
+.2byte   13,   -3, 	  10,   -3, 	   3,    1, 	   0,   -9
+.2byte   13,   -5, 	   2,   -5, 	   8,    1, 	   0,   -9
+.2byte    5,  -11, 	  -3,   -9, 	  10,   -3, 	   0,  -11
+.2byte    8,  -10, 	   1,  -10, 	   9,   -1, 	   0,  -10
+.2byte    5,  -10, 	  -4,   -7, 	  11,   -3, 	   0,  -11
+.2byte    0,   -8, 	   9,   -8, 	  -9,   -8, 	   0,   -7
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -5, 	   0,   -6
+.2byte    1,   -7, 	   9,   -6, 	  -7,   -8, 	   0,   -6
+.2byte   -5,  -11, 	   3,   -9, 	 -10,   -3, 	   0,  -11
+.2byte   -8,  -10, 	  -1,  -10, 	  -9,   -1, 	   0,  -10
+.2byte   -5,  -10, 	   4,   -7, 	 -11,   -3, 	   0,  -11
+.2byte  -13,   -4, 	  -7,   -4, 	  -5,    1, 	   0,  -10
+.2byte  -13,   -3, 	 -10,   -3, 	  -3,    1, 	   0,   -9
+.2byte  -13,   -5, 	  -2,   -5, 	  -8,    1, 	   0,   -9
+.2byte   -9,    2, 	 -10,   -2, 	   1,    3, 	  -1,  -10
+.2byte   -8,    3, 	 -11,    0, 	   3,    3, 	   0,   -9
+.2byte  -10,    2, 	  -8,   -3, 	  -1,    4, 	  -1,   -9
+.2byte    0,   -9, 	  -9,    0, 	   9,    0, 	   0,   -4
+.2byte    0,  -14, 	  -9,    0, 	   9,    0, 	   0,   -8
+.2byte    4,  -12, 	  11,   -2, 	  -1,    3, 	   3,   -6
+.2byte    1,  -15, 	  11,   -1, 	  -1,    3, 	   2,   -9
+.2byte    6,  -15, 	   8,   -2, 	   5,    1, 	   2,   -9
+.2byte    2,  -16, 	   7,   -2, 	   5,    1, 	   1,  -11
+.2byte    4,  -18, 	  -2,   -8, 	  10,   -3, 	   1,  -10
+.2byte    2,  -18, 	  -2,   -8, 	  10,   -3, 	  -1,  -11
+.2byte    0,  -18, 	   9,   -7, 	  -9,   -7, 	   0,   -9
+.2byte    0,  -16, 	   9,   -7, 	  -9,   -7, 	   0,   -8
+.2byte   -4,  -18, 	   2,   -8, 	 -10,   -3, 	  -1,  -10
+.2byte   -2,  -18, 	   2,   -8, 	 -10,   -3, 	   1,  -11
+.2byte   -6,  -15, 	  -8,   -2, 	  -5,    1, 	  -2,   -9
+.2byte   -2,  -16, 	  -7,   -2, 	  -5,    1, 	  -1,  -11
+.2byte   -4,  -12, 	 -11,   -2, 	   1,    3, 	  -3,   -6
+.2byte   -1,  -15, 	 -11,   -1, 	   1,    3, 	  -2,   -9
+.2byte   -1,  -16, 	  -9,    0, 	  10,    0, 	   0,   -8
+.2byte    1,  -16, 	 -10,    0, 	   9,    0, 	   0,   -8
+.2byte    2,  -16, 	  11,   -1, 	  -1,    3, 	   3,   -9
+.2byte    0,  -16, 	  12,   -1, 	  -1,    3, 	   0,   -9
+.2byte    1,  -16, 	   7,   -2, 	   5,    1, 	   0,  -10
+.2byte    1,  -13, 	   8,   -2, 	   5,    1, 	   1,   -9
+.2byte   -1,  -16, 	  -2,   -8, 	  10,   -3, 	  -1,  -11
+.2byte    1,  -16, 	  -2,   -8, 	  10,   -3, 	   1,  -10
+.2byte    1,  -16, 	   9,   -7, 	  -9,   -7, 	   0,   -7
+.2byte   -1,  -16, 	   9,   -7, 	  -9,   -7, 	  -1,   -7
+.2byte    1,  -16, 	   2,   -8, 	 -10,   -3, 	   1,  -11
+.2byte   -1,  -16, 	   2,   -8, 	 -10,   -3, 	  -1,  -10
+.2byte   -1,  -16, 	  -7,   -2, 	  -5,    1, 	   0,  -10
+.2byte   -1,  -13, 	  -8,   -2, 	  -5,    1, 	  -1,   -9
+.2byte   -2,  -16, 	 -11,   -1, 	   1,    3, 	  -3,   -9
+.2byte    0,  -16, 	 -12,   -1, 	   1,    3, 	   0,   -9
+.2byte    0,    5, 	  -9,    1, 	   9,    1, 	   0,   -8
+.2byte    0,    6, 	  -9,    1, 	   9,    1, 	   0,   -8
+.2byte    0,    3, 	 -12,   -1, 	  12,   -1, 	   0,   -9
+.2byte    8,    2, 	  11,   -2, 	  -8,    4, 	  -1,   -9
+.2byte   12,   -1, 	   3,   -1, 	   2,    4, 	  -1,   -9
+.2byte    6,   -8, 	  -4,   -9, 	  10,   -1, 	  -1,  -10
+.2byte    0,   -9, 	   9,   -5, 	  -9,   -5, 	   0,   -6
+.2byte   -7,   -8, 	   3,   -9, 	 -11,   -1, 	   0,  -10
+.2byte  -13,   -1, 	  -4,   -1, 	  -3,    4, 	   0,   -9
+.2byte   -9,    2, 	 -12,   -2, 	   7,    4, 	   0,   -9
+.2byte    0,    4, 	 -10,    0, 	  10,    0, 	   0,   -6
+.2byte    1,    5, 	  -9,    2, 	  10,    0, 	   1,   -5
+.2byte   -1,    5, 	 -10,    0, 	   9,    2, 	  -1,   -5
+.2byte    9,    2, 	  10,   -2, 	  -1,    3, 	   1,  -10
+.2byte    8,    3, 	  11,    0, 	  -3,    3, 	   0,   -9
+.2byte   10,    2, 	   8,   -3, 	   1,    4, 	   1,   -9
+.2byte   13,   -4, 	   7,   -4, 	   5,    1, 	   0,  -10
+.2byte   13,   -3, 	  10,   -3, 	   3,    1, 	   0,   -9
+.2byte   13,   -5, 	   2,   -5, 	   8,    1, 	   0,   -9
+.2byte    5,  -11, 	  -3,   -9, 	  10,   -3, 	   0,  -11
+.2byte    8,  -10, 	   1,  -10, 	   9,   -1, 	   0,  -10
+.2byte    5,  -10, 	  -4,   -7, 	  11,   -3, 	   0,  -11
+.2byte    0,   -8, 	   9,   -8, 	  -9,   -8, 	   0,   -7
+.2byte   -1,   -7, 	   8,   -7, 	  -9,   -5, 	   0,   -6
+.2byte    1,   -7, 	   9,   -6, 	  -7,   -8, 	   0,   -6
+.2byte   -5,  -11, 	   3,   -9, 	 -10,   -3, 	   0,  -11
+.2byte   -8,  -10, 	  -1,  -10, 	  -9,   -1, 	   0,  -10
+.2byte   -5,  -10, 	   4,   -7, 	 -11,   -3, 	   0,  -11
+.2byte  -13,   -4, 	  -7,   -4, 	  -5,    1, 	   0,  -10
+.2byte  -13,   -3, 	 -10,   -3, 	  -3,    1, 	   0,   -9
+.2byte  -13,   -5, 	  -2,   -5, 	  -8,    1, 	   0,   -9
+.2byte   -9,    2, 	 -10,   -2, 	   1,    3, 	  -1,  -10
+.2byte   -8,    3, 	 -11,    0, 	   3,    3, 	   0,   -9
+.2byte  -10,    2, 	  -8,   -3, 	  -1,    4, 	  -1,   -9
+.2byte    0,    4, 	 -10,    0, 	  10,    0, 	   0,   -6
+.2byte   -9,    2, 	 -10,   -2, 	   1,    3, 	  -1,  -10
+.2byte  -13,   -4, 	  -7,   -4, 	  -5,    1, 	   0,  -10
+.2byte   -5,  -11, 	   3,   -9, 	 -10,   -3, 	   0,  -11
+.2byte    0,   -8, 	   9,   -8, 	  -9,   -8, 	   0,   -7
+.2byte    5,  -11, 	  -3,   -9, 	  10,   -3, 	   0,  -11
+.2byte   13,   -4, 	   7,   -4, 	   5,    1, 	   0,  -10
+.2byte    9,    2, 	  10,   -2, 	  -1,    3, 	   1,  -10
+.2byte    0,    4, 	 -10,    0, 	  10,    0, 	   0,   -6
+.2byte    9,    2, 	  10,   -2, 	  -1,    3, 	   1,  -10
+.2byte   13,   -4, 	   7,   -4, 	   5,    1, 	   0,  -10
+.2byte    5,  -11, 	  -3,   -9, 	  10,   -3, 	   0,  -11
+.2byte    0,   -8, 	   9,   -8, 	  -9,   -8, 	   0,   -7
+.2byte   -5,  -11, 	   3,   -9, 	 -10,   -3, 	   0,  -11
+.2byte  -13,   -4, 	  -7,   -4, 	  -5,    1, 	   0,  -10
+.2byte   -9,    2, 	 -10,   -2, 	   1,    3, 	  -1,  -10
+.2byte    0,    4, 	 -10,    0, 	  10,    0, 	   0,   -6
+.2byte    0,  -14, 	  -9,    0, 	   9,    0, 	   0,   -8
+.2byte    0,   -9, 	  -9,    0, 	   9,    0, 	   0,   -4
+.2byte    9,    2, 	  10,   -2, 	  -1,    3, 	   1,  -10
+.2byte    1,  -15, 	  11,   -1, 	  -1,    3, 	   2,   -9
+.2byte    4,  -12, 	  11,   -2, 	  -1,    3, 	   3,   -6
+.2byte   13,   -4, 	   7,   -4, 	   5,    1, 	   0,  -10
+.2byte    2,  -16, 	   7,   -2, 	   5,    1, 	   1,  -11
+.2byte    6,  -15, 	   8,   -2, 	   5,    1, 	   2,   -9
+.2byte    5,  -11, 	  -3,   -9, 	  10,   -3, 	   0,  -11
+.2byte    2,  -18, 	  -2,   -8, 	  10,   -3, 	  -1,  -11
+.2byte    4,  -18, 	  -2,   -8, 	  10,   -3, 	   1,  -10
+.2byte    0,   -8, 	   9,   -8, 	  -9,   -8, 	   0,   -7
+.2byte    0,  -16, 	   9,   -7, 	  -9,   -7, 	   0,   -8
+.2byte    0,  -18, 	   9,   -7, 	  -9,   -7, 	   0,   -9
+.2byte   -5,  -11, 	   3,   -9, 	 -10,   -3, 	   0,  -11
+.2byte   -2,  -18, 	   2,   -8, 	 -10,   -3, 	   1,  -11
+.2byte   -4,  -18, 	   2,   -8, 	 -10,   -3, 	  -1,  -10
+.2byte  -13,   -4, 	  -7,   -4, 	  -5,    1, 	   0,  -10
+.2byte   -2,  -16, 	  -7,   -2, 	  -5,    1, 	  -1,  -11
+.2byte   -6,  -15, 	  -8,   -2, 	  -5,    1, 	  -2,   -9
+.2byte   -9,    2, 	 -10,   -2, 	   1,    3, 	  -1,  -10
+.2byte   -1,  -15, 	 -11,   -1, 	   1,    3, 	  -2,   -9
+.2byte   -4,  -12, 	 -11,   -2, 	   1,    3, 	  -3,   -6
+.2byte    0,  -14, 	  -9,    0, 	   9,    0, 	   0,   -8
+.2byte   -1,  -15, 	 -11,   -1, 	   1,    3, 	  -2,   -9
+.2byte   -2,  -16, 	  -7,   -2, 	  -5,    1, 	  -1,  -11
+.2byte   -2,  -18, 	   2,   -8, 	 -10,   -3, 	   1,  -11
+.2byte    0,  -18, 	   9,   -9, 	  -9,   -9, 	   0,  -10
+.2byte    2,  -18, 	  -2,   -8, 	  10,   -3, 	  -1,  -11
+.2byte    2,  -16, 	   7,   -2, 	   5,    1, 	   1,  -11
+.2byte    1,  -15, 	  11,   -1, 	  -1,    3, 	   2,   -9
+.2byte   -1,    3, 	 -11,   -1, 	   9,   -1, 	  -1,   -7
+.2byte  -10,    1, 	 -11,   -3, 	   0,    2, 	  -2,  -11
+.2byte  -14,   -5, 	  -8,   -5, 	  -6,    0, 	  -1,  -11
+.2byte   -6,  -12, 	   2,  -10, 	 -11,   -4, 	  -1,  -12
+.2byte   -1,   -9, 	   8,   -9, 	 -10,   -9, 	  -1,   -8
+.2byte    4,  -12, 	  -4,  -10, 	   9,   -4, 	  -1,  -12
+.2byte   12,   -5, 	   6,   -5, 	   4,    0, 	  -1,  -11
+.2byte    8,    1, 	   9,   -3, 	  -2,    2, 	   0,  -11
+sVenusaurAnimTable1:
+.4byte sVenusaurAnims_1_1
+.4byte sVenusaurAnims_1_2
+.4byte sVenusaurAnims_1_3
+.4byte sVenusaurAnims_1_4
+.4byte sVenusaurAnims_1_5
+.4byte sVenusaurAnims_1_6
+.4byte sVenusaurAnims_1_7
+.4byte sVenusaurAnims_1_8
+sVenusaurAnimTable2:
+.4byte sVenusaurAnims_2_1
+.4byte sVenusaurAnims_2_2
+.4byte sVenusaurAnims_2_3
+.4byte sVenusaurAnims_2_4
+.4byte sVenusaurAnims_2_5
+.4byte sVenusaurAnims_2_6
+.4byte sVenusaurAnims_2_7
+.4byte sVenusaurAnims_2_8
+sVenusaurAnimTable3:
+.4byte sVenusaurAnims_3_1
+.4byte sVenusaurAnims_3_2
+.4byte sVenusaurAnims_3_3
+.4byte sVenusaurAnims_3_4
+.4byte sVenusaurAnims_3_5
+.4byte sVenusaurAnims_3_6
+.4byte sVenusaurAnims_3_7
+.4byte sVenusaurAnims_3_8
+sVenusaurAnimTable4:
+.4byte sVenusaurAnims_4_1
+.4byte sVenusaurAnims_4_2
+.4byte sVenusaurAnims_4_3
+.4byte sVenusaurAnims_4_4
+.4byte sVenusaurAnims_4_5
+.4byte sVenusaurAnims_4_6
+.4byte sVenusaurAnims_4_7
+.4byte sVenusaurAnims_4_8
+sVenusaurAnimTable5:
+.4byte sVenusaurAnims_5_1
+.4byte sVenusaurAnims_5_2
+.4byte sVenusaurAnims_5_3
+.4byte sVenusaurAnims_5_4
+.4byte sVenusaurAnims_5_5
+.4byte sVenusaurAnims_5_6
+.4byte sVenusaurAnims_5_7
+.4byte sVenusaurAnims_5_8
+sVenusaurAnimTable6:
+.4byte sVenusaurAnims_6_1
+.4byte sVenusaurAnims_6_1
+.4byte sVenusaurAnims_6_1
+.4byte sVenusaurAnims_6_1
+.4byte sVenusaurAnims_6_1
+.4byte sVenusaurAnims_6_1
+.4byte sVenusaurAnims_6_1
+.4byte sVenusaurAnims_6_1
+sVenusaurAnimTable7:
+.4byte sVenusaurAnims_7_1
+.4byte sVenusaurAnims_7_2
+.4byte sVenusaurAnims_7_3
+.4byte sVenusaurAnims_7_4
+.4byte sVenusaurAnims_7_5
+.4byte sVenusaurAnims_7_6
+.4byte sVenusaurAnims_7_7
+.4byte sVenusaurAnims_7_8
+sVenusaurAnimTable8:
+.4byte sVenusaurAnims_8_1
+.4byte sVenusaurAnims_8_2
+.4byte sVenusaurAnims_8_3
+.4byte sVenusaurAnims_8_4
+.4byte sVenusaurAnims_8_5
+.4byte sVenusaurAnims_8_6
+.4byte sVenusaurAnims_8_7
+.4byte sVenusaurAnims_8_8
+sVenusaurAnimTable9:
+.4byte sVenusaurAnims_9_1
+.4byte sVenusaurAnims_9_2
+.4byte sVenusaurAnims_9_3
+.4byte sVenusaurAnims_9_4
+.4byte sVenusaurAnims_9_5
+.4byte sVenusaurAnims_9_6
+.4byte sVenusaurAnims_9_7
+.4byte sVenusaurAnims_9_8
+sVenusaurAnimTable10:
+.4byte sVenusaurAnims_10_1
+.4byte sVenusaurAnims_10_2
+.4byte sVenusaurAnims_10_3
+.4byte sVenusaurAnims_10_4
+.4byte sVenusaurAnims_10_5
+.4byte sVenusaurAnims_10_6
+.4byte sVenusaurAnims_10_7
+.4byte sVenusaurAnims_10_8
+sVenusaurAnimTable11:
+.4byte sVenusaurAnims_11_1
+.4byte sVenusaurAnims_11_2
+.4byte sVenusaurAnims_11_3
+.4byte sVenusaurAnims_11_4
+.4byte sVenusaurAnims_11_5
+.4byte sVenusaurAnims_11_6
+.4byte sVenusaurAnims_11_7
+.4byte sVenusaurAnims_11_8
+sVenusaurAnimTable12:
+.4byte sVenusaurAnims_12_1
+.4byte sVenusaurAnims_12_2
+.4byte sVenusaurAnims_12_3
+.4byte sVenusaurAnims_12_4
+.4byte sVenusaurAnims_12_5
+.4byte sVenusaurAnims_12_6
+.4byte sVenusaurAnims_12_7
+.4byte sVenusaurAnims_12_8
+sVenusaurAnimTable13:
+.4byte sVenusaurAnims_13_1
+.4byte sVenusaurAnims_13_2
+.4byte sVenusaurAnims_13_3
+.4byte sVenusaurAnims_13_4
+.4byte sVenusaurAnims_13_5
+.4byte sVenusaurAnims_13_6
+.4byte sVenusaurAnims_13_7
+.4byte sVenusaurAnims_13_8
+sAxAnimationsVenusaur:
+.4byte sVenusaurAnimTable1
+.4byte sVenusaurAnimTable2
+.4byte sVenusaurAnimTable3
+.4byte sVenusaurAnimTable4
+.4byte sVenusaurAnimTable5
+.4byte sVenusaurAnimTable6
+.4byte sVenusaurAnimTable7
+.4byte sVenusaurAnimTable8
+.4byte sVenusaurAnimTable9
+.4byte sVenusaurAnimTable10
+.4byte sVenusaurAnimTable11
+.4byte sVenusaurAnimTable12
+.4byte sVenusaurAnimTable13
+sAxSpritesVenusaur:
+.4byte sVenusaurSprites1
+.4byte sVenusaurSprites2
+.4byte sVenusaurSprites3
+.4byte sVenusaurSprites4
+.4byte sVenusaurSprites5
+.4byte sVenusaurSprites6
+.4byte sVenusaurSprites7
+.4byte sVenusaurSprites8
+.4byte sVenusaurSprites9
+.4byte sVenusaurSprites10
+.4byte sVenusaurSprites11
+.4byte sVenusaurSprites12
+.4byte sVenusaurSprites13
+.4byte sVenusaurSprites14
+.4byte sVenusaurSprites15
+.4byte sVenusaurSprites16
+.4byte sVenusaurSprites17
+.4byte sVenusaurSprites18
+.4byte sVenusaurSprites19
+.4byte sVenusaurSprites20
+.4byte sVenusaurSprites21
+.4byte sVenusaurSprites22
+.4byte sVenusaurSprites23
+.4byte sVenusaurSprites24
+.4byte sVenusaurSprites25
+.4byte sVenusaurSprites26
+.4byte sVenusaurSprites27
+.4byte sVenusaurSprites28
+.4byte sVenusaurSprites29
+.4byte sVenusaurSprites30
+.4byte sVenusaurSprites31
+.4byte sVenusaurSprites32
+.4byte sVenusaurSprites33
+.4byte sVenusaurSprites34
+.4byte sVenusaurSprites35
+.4byte sVenusaurSprites36
+.4byte sVenusaurSprites37
+.4byte sVenusaurSprites38
+.4byte sVenusaurSprites39
+.4byte sVenusaurSprites40
+.4byte sVenusaurSprites41
+.4byte sVenusaurSprites42
+sAxMainVenusaur:
+ax_main sAxPosesVenusaur, sAxAnimationsVenusaur, 13, sAxSpritesVenusaur, sAxPositionsVenusaur

--- a/data/ax/vibrava.inc
+++ b/data/ax/vibrava.inc
@@ -1,0 +1,2654 @@
+.global gAxVibrava
+gAxVibrava:
+ax_siro sAxMainVibrava
+sVibravaPose1:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose2:
+ax_pose 1, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose3:
+ax_pose 2, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose4:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose5:
+ax_pose 4, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose6:
+ax_pose 5, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose7:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose8:
+ax_pose 7, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose9:
+ax_pose 8, 0x01e8, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose10:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose11:
+ax_pose 10, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose12:
+ax_pose 11, 0x01ea, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose14:
+ax_pose 13, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose15:
+ax_pose 14, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose16:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose17:
+ax_pose 10, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose18:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose19:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose20:
+ax_pose 7, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose21:
+ax_pose 8, 0x01e8, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose22:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose23:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose24:
+ax_pose 5, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose25:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose26:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose27:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose28:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose29:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose30:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose31:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose32:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose33:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose34:
+ax_pose 1, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose35:
+ax_pose 2, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose36:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose37:
+ax_pose 4, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose38:
+ax_pose 5, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose39:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose40:
+ax_pose 7, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose41:
+ax_pose 8, 0x01e8, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose42:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose43:
+ax_pose 10, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose44:
+ax_pose 11, 0x01ea, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose45:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose46:
+ax_pose 13, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose47:
+ax_pose 14, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose48:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose49:
+ax_pose 10, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose50:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose51:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose52:
+ax_pose 7, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose53:
+ax_pose 8, 0x01e8, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose54:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose55:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose56:
+ax_pose 5, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose57:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose58:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose59:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose60:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose61:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose62:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose63:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose64:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose65:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose66:
+ax_pose 1, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose67:
+ax_pose 2, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose68:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose69:
+ax_pose 4, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose70:
+ax_pose 5, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose71:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose72:
+ax_pose 7, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose73:
+ax_pose 8, 0x01e8, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose74:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose75:
+ax_pose 10, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose76:
+ax_pose 11, 0x01ea, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose77:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose78:
+ax_pose 13, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose79:
+ax_pose 14, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose80:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose81:
+ax_pose 10, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose82:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose83:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose84:
+ax_pose 7, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose85:
+ax_pose 8, 0x01e8, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose86:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose87:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose88:
+ax_pose 5, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose89:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose90:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose91:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose92:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose93:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose94:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose95:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose96:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose97:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose98:
+ax_pose 15, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sVibravaPose99:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose100:
+ax_pose 16, 0x01eb, 0x90ee, 0xac00
+ax_pose_terminator
+sVibravaPose101:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose102:
+ax_pose 17, 0x01eb, 0x90f0, 0xac00
+ax_pose_terminator
+sVibravaPose103:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose104:
+ax_pose 18, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose105:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose106:
+ax_pose 19, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose107:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose108:
+ax_pose 18, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose109:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose110:
+ax_pose 17, 0x01eb, 0x80ef, 0xac00
+ax_pose_terminator
+sVibravaPose111:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose112:
+ax_pose 16, 0x01eb, 0x80f1, 0xac00
+ax_pose_terminator
+sVibravaPose113:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose114:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose115:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose116:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose117:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose118:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose119:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose120:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose121:
+ax_pose 20, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose122:
+ax_pose 21, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose123:
+ax_pose 22, 0x81e5, 0x4103, 0xac00
+ax_pose 23, 0x01dd, 0x00f8, 0xac04
+ax_pose 24, 0x01dd, 0x0103, 0xac05
+ax_pose 25, 0x01e5, 0x010b, 0xac06
+ax_pose 26, 0x81e5, 0x80f3, 0xac07
+ax_pose_terminator
+sVibravaPose124:
+ax_pose 27, 0x01e5, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose125:
+ax_pose 28, 0x01e6, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose126:
+ax_pose 29, 0x01e7, 0x90ee, 0xac00
+ax_pose_terminator
+sVibravaPose127:
+ax_pose 30, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose128:
+ax_pose 29, 0x01e7, 0x80f2, 0xac00
+ax_pose_terminator
+sVibravaPose129:
+ax_pose 28, 0x01e6, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose130:
+ax_pose 27, 0x01e5, 0x80f2, 0xac00
+ax_pose_terminator
+sVibravaPose131:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose132:
+ax_pose 1, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose133:
+ax_pose 2, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose134:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose135:
+ax_pose 4, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose136:
+ax_pose 5, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose137:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose138:
+ax_pose 7, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose139:
+ax_pose 8, 0x01e8, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose140:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose141:
+ax_pose 10, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose142:
+ax_pose 11, 0x01ea, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose143:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose144:
+ax_pose 13, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose145:
+ax_pose 14, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose146:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose147:
+ax_pose 10, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose148:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose149:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose150:
+ax_pose 7, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose151:
+ax_pose 8, 0x01e8, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose152:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose153:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose154:
+ax_pose 5, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose155:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose156:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose157:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose158:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose159:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose160:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose161:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose162:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose163:
+ax_pose 1, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose164:
+ax_pose 4, 0x01ed, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose165:
+ax_pose 7, 0x01ed, 0x80ee, 0xac00
+ax_pose_terminator
+sVibravaPose166:
+ax_pose 10, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose167:
+ax_pose 13, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose168:
+ax_pose 10, 0x01ea, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose169:
+ax_pose 7, 0x01ed, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose170:
+ax_pose 4, 0x01ed, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose171:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose172:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose173:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose174:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose175:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose176:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose177:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose178:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose179:
+ax_pose 15, 0x01ec, 0x80f2, 0xac00
+ax_pose_terminator
+sVibravaPose180:
+ax_pose 16, 0x01eb, 0x90ee, 0xac00
+ax_pose_terminator
+sVibravaPose181:
+ax_pose 17, 0x01eb, 0x90f0, 0xac00
+ax_pose_terminator
+sVibravaPose182:
+ax_pose 18, 0x01e9, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose183:
+ax_pose 19, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose184:
+ax_pose 18, 0x01e9, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose185:
+ax_pose 17, 0x01eb, 0x80ef, 0xac00
+ax_pose_terminator
+sVibravaPose186:
+ax_pose 16, 0x01eb, 0x80f1, 0xac00
+ax_pose_terminator
+sVibravaPose187:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose188:
+ax_pose 1, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose189:
+ax_pose 2, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose190:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose191:
+ax_pose 4, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose192:
+ax_pose 5, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose193:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose194:
+ax_pose 7, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose195:
+ax_pose 8, 0x01e8, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose196:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose197:
+ax_pose 10, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose198:
+ax_pose 11, 0x01ea, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose199:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose200:
+ax_pose 13, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose201:
+ax_pose 14, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose202:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose203:
+ax_pose 10, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose204:
+ax_pose 11, 0x01ea, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose205:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose206:
+ax_pose 7, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose207:
+ax_pose 8, 0x01e8, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose208:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose209:
+ax_pose 4, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose210:
+ax_pose 5, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose211:
+ax_pose 2, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose212:
+ax_pose 5, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose213:
+ax_pose 8, 0x01e9, 0x80ee, 0xac00
+ax_pose_terminator
+sVibravaPose214:
+ax_pose 11, 0x01ec, 0x80f1, 0xac00
+ax_pose_terminator
+sVibravaPose215:
+ax_pose 14, 0x01eb, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose216:
+ax_pose 11, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose217:
+ax_pose 8, 0x01e9, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose218:
+ax_pose 5, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose219:
+ax_pose 0, 0x01ec, 0x80f3, 0xac00
+ax_pose_terminator
+sVibravaPose220:
+ax_pose 3, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose221:
+ax_pose 6, 0x01ec, 0x80ed, 0xac00
+ax_pose_terminator
+sVibravaPose222:
+ax_pose 9, 0x01e8, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose223:
+ax_pose 12, 0x01ec, 0x80f0, 0xac00
+ax_pose_terminator
+sVibravaPose224:
+ax_pose 9, 0x01e8, 0x90ef, 0xac00
+ax_pose_terminator
+sVibravaPose225:
+ax_pose 6, 0x01ec, 0x90f2, 0xac00
+ax_pose_terminator
+sVibravaPose226:
+ax_pose 3, 0x01ec, 0x90ef, 0xac00
+ax_pose_terminator
+.align 2
+sVibravaAnims_1_1:
+ax_anim 4, 0, 0, 0, -4, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 6, 0, 1, 0, -4, 0, 0,
+ax_anim 4, 0, 0, 0, -6, 0, 0,
+ax_anim 6, 0, 2, 0, -5, 0, 0,
+ax_anim 6, 0, 2, 0, -4, 0, 0,
+ax_anim 6, 0, 2, 0, -3, 0, 0,
+ax_anim_terminator
+sVibravaAnims_1_2:
+ax_anim 4, 0, 3, 0, -4, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 4, 0, -4, 0, 0,
+ax_anim 4, 0, 3, 0, -6, 0, 0,
+ax_anim 6, 0, 5, 0, -4, 0, 0,
+ax_anim 6, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_1_3:
+ax_anim 4, 0, 6, 0, -4, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 7, 0, -4, 0, 0,
+ax_anim 4, 0, 6, 0, -6, 0, 0,
+ax_anim 6, 0, 8, 0, -4, 0, 0,
+ax_anim 6, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_1_4:
+ax_anim 4, 0, 9, 0, -4, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 6, 0, 10, 0, -4, 0, 0,
+ax_anim 4, 0, 9, 0, -6, 0, 0,
+ax_anim 6, 0, 11, 0, -4, 0, 0,
+ax_anim 6, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_1_5:
+ax_anim 4, 0, 12, 0, -4, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 6, 0, 13, 0, -4, 0, 0,
+ax_anim 4, 0, 12, 0, -7, 0, 0,
+ax_anim 6, 0, 14, 0, -4, 0, 0,
+ax_anim 6, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_1_6:
+ax_anim 4, 0, 15, 0, -4, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -3, 0, 0,
+ax_anim 6, 0, 16, 0, -4, 0, 0,
+ax_anim 4, 0, 15, 0, -6, 0, 0,
+ax_anim 6, 0, 17, 0, -4, 0, 0,
+ax_anim 6, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_1_7:
+ax_anim 4, 0, 18, 0, -4, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 6, 0, 19, 0, -4, 0, 0,
+ax_anim 4, 0, 18, 0, -6, 0, 0,
+ax_anim 6, 0, 20, 0, -4, 0, 0,
+ax_anim 6, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_1_8:
+ax_anim 4, 0, 21, 0, -4, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 22, 0, -3, 0, 0,
+ax_anim 6, 0, 22, 0, -4, 0, 0,
+ax_anim 4, 0, 21, 0, -6, 0, 0,
+ax_anim 6, 0, 23, 0, -4, 0, 0,
+ax_anim 6, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_2_1:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, 0, -1, 0, -1,
+ax_anim 4, 0, 32, 0, -2, 0, -2,
+ax_anim 2, 0, 33, 0, -6, 0, -6,
+ax_anim 2, 2, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 34, 0, 10, 0, 10,
+ax_anim 2, 0, 34, 0, 18, 0, 18,
+ax_anim 2, 1, 34, 1, 18, 1, 18,
+ax_anim 2, 0, 34, 0, 18, 0, 18,
+ax_anim 2, 0, 34, 1, 18, 1, 18,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sVibravaAnims_2_2:
+ax_anim 2, 0, 35, 0, 0, 0, 0,
+ax_anim 2, 0, 35, -1, -1, -1, -1,
+ax_anim 4, 0, 35, -2, -2, -2, -2,
+ax_anim 2, 0, 36, 3, -1, 3, 3,
+ax_anim 2, 2, 36, 9, 4, 9, 9,
+ax_anim 2, 0, 37, 16, 14, 16, 16,
+ax_anim 2, 0, 37, 19, 19, 19, 19,
+ax_anim 2, 1, 37, 20, 18, 20, 18,
+ax_anim 2, 0, 37, 19, 19, 19, 19,
+ax_anim 2, 0, 37, 20, 18, 20, 18,
+ax_anim 2, 0, 35, 8, 8, 8, 8,
+ax_anim_terminator
+sVibravaAnims_2_3:
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 4, 0, 38, -2, 0, -2, 0,
+ax_anim 2, 0, 39, 4, -3, 4, 0,
+ax_anim 2, 2, 39, 9, -5, 9, 0,
+ax_anim 2, 0, 40, 13, -4, 13, 0,
+ax_anim 2, 0, 40, 17, 0, 17, 0,
+ax_anim 2, 1, 40, 17, 1, 17, 1,
+ax_anim 2, 0, 40, 17, 0, 17, 0,
+ax_anim 2, 0, 40, 17, 1, 17, 1,
+ax_anim 2, 0, 38, 6, 0, 6, -1,
+ax_anim_terminator
+sVibravaAnims_2_4:
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, -1, 1, -1, 1,
+ax_anim 4, 0, 41, -2, 2, -2, 2,
+ax_anim 2, 0, 42, 3, -9, 3, -3,
+ax_anim 2, 2, 42, 8, -17, 8, -9,
+ax_anim 2, 0, 43, 16, -20, 16, -16,
+ax_anim 2, 0, 43, 19, -19, 19, -19,
+ax_anim 2, 1, 43, 20, -18, 20, -18,
+ax_anim 2, 0, 43, 19, -19, 19, -19,
+ax_anim 2, 0, 43, 20, -18, 20, -18,
+ax_anim 2, 0, 41, 6, -6, 6, -6,
+ax_anim_terminator
+sVibravaAnims_2_5:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 4, 0, 44, 0, 2, 0, 2,
+ax_anim 2, 0, 45, 0, -5, 0, -1,
+ax_anim 2, 2, 45, 0, -11, 0, -6,
+ax_anim 2, 0, 46, 0, -16, 0, -15,
+ax_anim 2, 0, 46, 0, -20, 0, -20,
+ax_anim 2, 1, 46, 1, -20, 1, -20,
+ax_anim 2, 0, 46, 0, -20, 0, -20,
+ax_anim 2, 0, 46, 1, -20, 1, -20,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sVibravaAnims_2_6:
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, 1, 1, 1,
+ax_anim 4, 0, 47, 2, 2, 2, 2,
+ax_anim 2, 0, 48, -3, -9, -3, -3,
+ax_anim 2, 2, 48, -8, -17, -8, -9,
+ax_anim 2, 0, 49, -16, -20, -16, -16,
+ax_anim 2, 0, 49, -19, -19, -19, -19,
+ax_anim 2, 1, 49, -20, -18, -20, -18,
+ax_anim 2, 0, 49, -19, -19, -19, -19,
+ax_anim 2, 0, 49, -20, -18, -20, -18,
+ax_anim 2, 0, 47, -6, -6, -6, -6,
+ax_anim_terminator
+sVibravaAnims_2_7:
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 1, 0, 1, 0,
+ax_anim 4, 0, 50, 2, 0, 2, 0,
+ax_anim 2, 0, 51, -4, -3, -4, 0,
+ax_anim 2, 2, 51, -9, -5, -9, 0,
+ax_anim 2, 0, 52, -13, -4, -13, 0,
+ax_anim 2, 0, 52, -17, 0, -17, 0,
+ax_anim 2, 1, 52, -17, 1, -17, 1,
+ax_anim 2, 0, 52, -17, 0, -17, 0,
+ax_anim 2, 0, 52, -17, 1, -17, 1,
+ax_anim 2, 0, 50, -6, 0, -6, -1,
+ax_anim_terminator
+sVibravaAnims_2_8:
+ax_anim 2, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 0, 54, -3, -1, -3, 3,
+ax_anim 2, 2, 54, -9, 4, -9, 9,
+ax_anim 2, 0, 55, -16, 14, -16, 16,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 1, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -20, 18, -20, 18,
+ax_anim 2, 0, 53, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sVibravaAnims_3_1:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 4, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 65, 0, -6, 0, -6,
+ax_anim 2, 2, 65, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 0, 10, 0, 10,
+ax_anim 2, 0, 66, 0, 18, 0, 18,
+ax_anim 2, 1, 66, 1, 18, 1, 18,
+ax_anim 2, 0, 66, 0, 18, 0, 18,
+ax_anim 2, 0, 66, 1, 18, 1, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sVibravaAnims_3_2:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -1, -1, -1, -1,
+ax_anim 4, 0, 67, -2, -2, -2, -2,
+ax_anim 2, 0, 68, 3, -1, 3, 3,
+ax_anim 2, 2, 68, 9, 4, 9, 9,
+ax_anim 2, 0, 69, 16, 14, 16, 16,
+ax_anim 2, 0, 69, 19, 19, 19, 19,
+ax_anim 2, 1, 69, 20, 18, 20, 18,
+ax_anim 2, 0, 69, 19, 19, 19, 19,
+ax_anim 2, 0, 69, 20, 18, 20, 18,
+ax_anim 2, 0, 67, 8, 8, 8, 8,
+ax_anim_terminator
+sVibravaAnims_3_3:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 70, -1, 0, -1, 0,
+ax_anim 4, 0, 70, -2, 0, -2, 0,
+ax_anim 2, 0, 71, 4, -3, 4, 0,
+ax_anim 2, 2, 71, 9, -5, 9, 0,
+ax_anim 2, 0, 72, 13, -4, 13, 0,
+ax_anim 2, 0, 72, 17, 0, 17, 0,
+ax_anim 2, 1, 72, 17, 1, 17, 1,
+ax_anim 2, 0, 72, 17, 0, 17, 0,
+ax_anim 2, 0, 72, 17, 1, 17, 1,
+ax_anim 2, 0, 70, 6, 0, 6, -1,
+ax_anim_terminator
+sVibravaAnims_3_4:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, 1, -1, 1,
+ax_anim 4, 0, 73, -2, 2, -2, 2,
+ax_anim 2, 0, 74, 3, -9, 3, -3,
+ax_anim 2, 2, 74, 8, -17, 8, -9,
+ax_anim 2, 0, 75, 16, -20, 16, -16,
+ax_anim 2, 0, 75, 19, -19, 19, -19,
+ax_anim 2, 1, 75, 20, -18, 20, -18,
+ax_anim 2, 0, 75, 19, -19, 19, -19,
+ax_anim 2, 0, 75, 20, -18, 20, -18,
+ax_anim 2, 0, 73, 6, -6, 6, -6,
+ax_anim_terminator
+sVibravaAnims_3_5:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 1, 0, 1,
+ax_anim 4, 0, 76, 0, 2, 0, 2,
+ax_anim 2, 0, 77, 0, -5, 0, -1,
+ax_anim 2, 2, 77, 0, -11, 0, -6,
+ax_anim 2, 0, 78, 0, -16, 0, -15,
+ax_anim 2, 0, 78, 0, -20, 0, -20,
+ax_anim 2, 1, 78, 1, -20, 1, -20,
+ax_anim 2, 0, 78, 0, -20, 0, -20,
+ax_anim 2, 0, 78, 1, -20, 1, -20,
+ax_anim 2, 0, 76, 0, -6, 0, -6,
+ax_anim_terminator
+sVibravaAnims_3_6:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 4, 0, 79, 2, 2, 2, 2,
+ax_anim 2, 0, 80, -3, -9, -3, -3,
+ax_anim 2, 2, 80, -8, -17, -8, -9,
+ax_anim 2, 0, 81, -16, -20, -16, -16,
+ax_anim 2, 0, 81, -19, -19, -19, -19,
+ax_anim 2, 1, 81, -20, -18, -20, -18,
+ax_anim 2, 0, 81, -19, -19, -19, -19,
+ax_anim 2, 0, 81, -20, -18, -20, -18,
+ax_anim 2, 0, 79, -6, -6, -6, -6,
+ax_anim_terminator
+sVibravaAnims_3_7:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, 0, 1, 0,
+ax_anim 4, 0, 82, 2, 0, 2, 0,
+ax_anim 2, 0, 83, -4, -3, -4, 0,
+ax_anim 2, 2, 83, -9, -5, -9, 0,
+ax_anim 2, 0, 84, -13, -4, -13, 0,
+ax_anim 2, 0, 84, -17, 0, -17, 0,
+ax_anim 2, 1, 84, -17, 1, -17, 1,
+ax_anim 2, 0, 84, -17, 0, -17, 0,
+ax_anim 2, 0, 84, -17, 1, -17, 1,
+ax_anim 2, 0, 82, -6, 0, -6, -1,
+ax_anim_terminator
+sVibravaAnims_3_8:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 4, 0, 85, 2, -2, 2, -2,
+ax_anim 2, 0, 86, -3, -1, -3, 3,
+ax_anim 2, 2, 86, -9, 4, -9, 9,
+ax_anim 2, 0, 87, -16, 14, -16, 16,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 1, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 87, -19, 19, -19, 19,
+ax_anim 2, 0, 87, -20, 18, -20, 18,
+ax_anim 2, 0, 85, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sVibravaAnims_4_1:
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 0, 96, 1, -1, 1, -1,
+ax_anim 2, 0, 96, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 1, -2, 1, -2,
+ax_anim 6, 2, 96, 0, -2, 0, -2,
+ax_anim 1, 0, 97, 0, 1, 0, 1,
+ax_anim 1, 0, 97, 0, 4, 0, 4,
+ax_anim 2, 1, 97, 1, 4, 1, 4,
+ax_anim 2, 0, 97, 0, 4, 0, 4,
+ax_anim 2, 0, 97, 1, 4, 1, 4,
+ax_anim 2, 0, 97, 0, 4, 0, 4,
+ax_anim 2, 0, 97, 1, 4, 1, 4,
+ax_anim 2, 0, 97, 0, 4, 0, 4,
+ax_anim 2, 0, 96, 0, 2, 0, 2,
+ax_anim_terminator
+sVibravaAnims_4_2:
+ax_anim 2, 0, 98, -1, -1, -1, -1,
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 2, 0, 98, -2, -2, -2, -2,
+ax_anim 2, 0, 98, -1, -3, -1, -3,
+ax_anim 6, 2, 98, -2, -2, -2, -2,
+ax_anim 1, 0, 99, 1, 1, 1, 1,
+ax_anim 1, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 1, 99, 5, 3, 5, 3,
+ax_anim 2, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 0, 99, 5, 3, 5, 3,
+ax_anim 2, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 0, 99, 5, 3, 5, 3,
+ax_anim 2, 0, 99, 4, 4, 4, 4,
+ax_anim 2, 0, 98, 2, 2, 2, 2,
+ax_anim_terminator
+sVibravaAnims_4_3:
+ax_anim 2, 0, 100, -1, 0, -1, 0,
+ax_anim 2, 0, 100, -1, 1, -1, 1,
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 2, 0, 100, -2, 1, -2, 1,
+ax_anim 6, 2, 100, -2, 0, -2, 0,
+ax_anim 1, 0, 101, 1, 0, 1, 0,
+ax_anim 1, 0, 101, 5, 0, 5, 0,
+ax_anim 2, 1, 101, 5, 1, 5, 1,
+ax_anim 2, 0, 101, 5, 0, 5, 0,
+ax_anim 2, 0, 101, 5, 1, 5, 1,
+ax_anim 2, 0, 101, 5, 0, 5, 0,
+ax_anim 2, 0, 101, 5, 1, 5, 1,
+ax_anim 2, 0, 101, 5, 0, 5, 0,
+ax_anim 2, 0, 100, 2, 0, 2, 0,
+ax_anim_terminator
+sVibravaAnims_4_4:
+ax_anim 2, 0, 102, -1, 1, -1, 1,
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 2, 0, 102, -2, 2, -2, 2,
+ax_anim 2, 0, 102, -1, 3, -1, 3,
+ax_anim 6, 2, 102, -2, 2, -2, 2,
+ax_anim 1, 0, 103, 1, -1, 1, -1,
+ax_anim 1, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 1, 103, 5, -3, 5, -3,
+ax_anim 2, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -3, 5, -3,
+ax_anim 2, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 103, 5, -3, 5, -3,
+ax_anim 2, 0, 103, 4, -4, 4, -4,
+ax_anim 2, 0, 102, 2, -2, 2, -2,
+ax_anim_terminator
+sVibravaAnims_4_5:
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim 2, 0, 104, 1, 1, 1, 1,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim 2, 0, 104, 1, 2, 1, 2,
+ax_anim 6, 2, 104, 0, 2, 0, 2,
+ax_anim 1, 0, 105, 0, -1, 0, -1,
+ax_anim 1, 0, 105, 0, -6, 0, -6,
+ax_anim 2, 1, 105, 1, -6, 1, -6,
+ax_anim 2, 0, 105, 0, -6, 0, -6,
+ax_anim 2, 0, 105, 1, -6, 1, -6,
+ax_anim 2, 0, 105, 0, -6, 0, -6,
+ax_anim 2, 0, 105, 1, -6, 1, -6,
+ax_anim 2, 0, 105, 0, -6, 0, -6,
+ax_anim 2, 0, 104, 0, -2, 0, -2,
+ax_anim_terminator
+sVibravaAnims_4_6:
+ax_anim 2, 0, 106, 1, 1, 1, 1,
+ax_anim 2, 0, 106, 0, 2, 0, 2,
+ax_anim 2, 0, 106, 2, 2, 2, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 6, 2, 106, 2, 2, 2, 2,
+ax_anim 1, 0, 107, -1, -1, -1, -1,
+ax_anim 1, 0, 107, -4, -4, -4, -4,
+ax_anim 2, 1, 107, -5, -3, -5, -3,
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 2, 0, 107, -5, -3, -5, -3,
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 2, 0, 107, -5, -3, -5, -3,
+ax_anim 2, 0, 107, -4, -4, -4, -4,
+ax_anim 2, 0, 106, -2, -2, -2, -2,
+ax_anim_terminator
+sVibravaAnims_4_7:
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 1, 1, 1, 1,
+ax_anim 2, 0, 108, 2, 0, 2, 0,
+ax_anim 2, 0, 108, 2, 1, 2, 1,
+ax_anim 6, 2, 108, 2, 0, 2, 0,
+ax_anim 1, 0, 109, -1, 0, -1, 0,
+ax_anim 1, 0, 109, -5, 0, -5, 0,
+ax_anim 2, 1, 109, -5, 1, -5, 1,
+ax_anim 2, 0, 109, -5, 0, -5, 0,
+ax_anim 2, 0, 109, -5, 1, -5, 1,
+ax_anim 2, 0, 109, -5, 0, -5, 0,
+ax_anim 2, 0, 109, -5, 1, -5, 1,
+ax_anim 2, 0, 109, -5, 0, -5, 0,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim_terminator
+sVibravaAnims_4_8:
+ax_anim 2, 0, 110, 1, -1, 1, -1,
+ax_anim 2, 0, 110, 0, -2, 0, -2,
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 2, 0, 110, 1, -3, 1, -3,
+ax_anim 6, 2, 110, 2, -2, 2, -2,
+ax_anim 1, 0, 111, -1, 1, -1, 1,
+ax_anim 1, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 1, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 111, -5, 3, -5, 3,
+ax_anim 2, 0, 111, -4, 4, -4, 4,
+ax_anim 2, 0, 110, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sVibravaAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sVibravaAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sVibravaAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sVibravaAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sVibravaAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sVibravaAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sVibravaAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sVibravaAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVibravaAnims_8_1:
+ax_anim 40, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, -1, 0, 0,
+ax_anim 4, 0, 131, 0, 1, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -5, 0, 0,
+ax_anim 4, 0, 131, 0, -4, 0, 0,
+ax_anim 4, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 4, 0, 131, 0, 1, 0, 0,
+ax_anim_terminator
+sVibravaAnims_8_2:
+ax_anim 40, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 1, 0, 0,
+ax_anim 4, 0, 134, 0, 1, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -5, 0, 0,
+ax_anim 4, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -3, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim 4, 0, 134, 0, 2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_8_3:
+ax_anim 40, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 1, 0, 0,
+ax_anim 4, 0, 137, 0, 1, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -5, 0, 0,
+ax_anim 4, 0, 137, 0, -4, 0, 0,
+ax_anim 4, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 137, 0, 0, 0, 0,
+ax_anim 4, 0, 137, 0, 2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_8_4:
+ax_anim 40, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 2, 0, 0,
+ax_anim 4, 0, 140, 0, 1, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -5, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim 4, 0, 140, 0, 2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_8_5:
+ax_anim 40, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 2, 0, 0,
+ax_anim 4, 0, 143, 0, -2, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -5, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 143, 0, 0, 0, 0,
+ax_anim 4, 0, 143, 0, 2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_8_6:
+ax_anim 40, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 2, 0, 0,
+ax_anim 4, 0, 146, 0, 1, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -5, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_8_7:
+ax_anim 40, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 150, 0, 1, 0, 0,
+ax_anim 4, 0, 149, 0, 1, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -5, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 2, 0, 0,
+ax_anim_terminator
+sVibravaAnims_8_8:
+ax_anim 40, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 1, 0, 0,
+ax_anim 4, 0, 152, 0, 1, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -5, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim 4, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 152, 0, 2, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 7, 4, 7, 4,
+ax_anim 2, 0, 164, 11, 10, 11, 10,
+ax_anim 2, 0, 165, 8, 16, 8, 16,
+ax_anim 3, 0, 166, 0, 18, 0, 18,
+ax_anim 2, 3, 167, -8, 16, -8, 16,
+ax_anim 2, 0, 168, -11, 10, -11, 10,
+ax_anim 1, 0, 169, -7, 4, -7, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 7, 0, 7, 0,
+ax_anim 2, 0, 163, 17, 5, 17, 5,
+ax_anim 2, 0, 164, 21, 13, 21, 13,
+ax_anim 3, 0, 165, 19, 18, 19, 18,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 1, 17, 1, 17,
+ax_anim 1, 0, 168, -2, 8, -2, 8,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 9, -6, 9, -6,
+ax_anim 2, 0, 163, 17, -2, 17, -2,
+ax_anim 3, 0, 164, 20, 3, 20, 3,
+ax_anim 2, 3, 165, 19, 5, 19, 5,
+ax_anim 2, 0, 166, 8, 7, 8, 7,
+ax_anim 1, 0, 167, 3, 5, 3, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -3, -10, -3, -10,
+ax_anim 2, 0, 169, 2, -17, 2, -17,
+ax_anim 2, 0, 162, 10, -24, 10, -24,
+ax_anim 3, 0, 163, 18, -21, 18, -21,
+ax_anim 2, 3, 164, 22, -15, 22, -15,
+ax_anim 2, 0, 165, 18, -5, 18, -5,
+ax_anim 1, 0, 166, 9, 0, 9, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -3, -8, -3,
+ax_anim 2, 0, 168, -12, -12, -12, -12,
+ax_anim 2, 0, 169, -8, -18, -8, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 8, -18, 8, -18,
+ax_anim 2, 0, 164, 12, -12, 12, -12,
+ax_anim 1, 0, 165, 8, -3, 8, -3,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 3, -10, 3, -10,
+ax_anim 2, 0, 163, -2, -17, -2, -17,
+ax_anim 2, 0, 162, -10, -24, -10, -24,
+ax_anim 3, 0, 169, -18, -21, -18, -21,
+ax_anim 2, 3, 168, -22, -15, -22, -15,
+ax_anim 2, 0, 167, -18, -5, -18, -5,
+ax_anim 1, 0, 166, -9, 0, -9, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -9, -6, -9, -6,
+ax_anim 2, 0, 169, -17, -2, -17, -2,
+ax_anim 3, 0, 168, -20, 3, -20, 3,
+ax_anim 2, 3, 167, -19, 5, -19, 5,
+ax_anim 2, 0, 166, -8, 7, -8, 7,
+ax_anim 1, 0, 165, -3, 5, -3, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -7, 0, -7, 0,
+ax_anim 2, 0, 169, -17, 5, -17, 5,
+ax_anim 2, 0, 168, -21, 13, -21, 13,
+ax_anim 3, 0, 167, -19, 18, -19, 18,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -1, 17, -1, 17,
+ax_anim 1, 0, 164, 2, 8, 2, 8,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -18, 0, 0,
+ax_anim 4, 0, 187, 0, -19, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -18, 0, 0,
+ax_anim 4, 0, 190, 0, -19, 0, 0,
+ax_anim 4, 0, 189, 0, -24, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -18, 0, 0,
+ax_anim 4, 0, 193, 0, -19, 0, 0,
+ax_anim 4, 0, 192, 0, -25, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -18, 0, 0,
+ax_anim 4, 0, 196, 0, -19, 0, 0,
+ax_anim 4, 0, 195, 0, -24, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -18, 0, 0,
+ax_anim 4, 0, 199, 0, -19, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -18, 0, 0,
+ax_anim 4, 0, 202, 0, -19, 0, 0,
+ax_anim 4, 0, 201, 0, -24, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -18, 0, 0,
+ax_anim 4, 0, 205, 0, -19, 0, 0,
+ax_anim 4, 0, 204, 0, -25, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -18, 0, 0,
+ax_anim 4, 0, 208, 0, -19, 0, 0,
+ax_anim 4, 0, 207, 0, -24, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVibravaAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sVibravaGfx1:
+.incbin "baserom.gba", 0x136E148, 0x200
+sVibravaSprites1:
+ax_sprite sVibravaGfx1, 0x200
+ax_sprite_terminator
+sVibravaGfx2:
+.incbin "baserom.gba", 0x136E358, 0x200
+sVibravaSprites2:
+ax_sprite sVibravaGfx2, 0x200
+ax_sprite_terminator
+sVibravaGfx3:
+.incbin "baserom.gba", 0x136E568, 0x200
+sVibravaSprites3:
+ax_sprite sVibravaGfx3, 0x200
+ax_sprite_terminator
+sVibravaGfx4:
+.incbin "baserom.gba", 0x136E778, 0x200
+sVibravaSprites4:
+ax_sprite sVibravaGfx4, 0x200
+ax_sprite_terminator
+sVibravaGfx5:
+.incbin "baserom.gba", 0x136E988, 0x200
+sVibravaSprites5:
+ax_sprite sVibravaGfx5, 0x200
+ax_sprite_terminator
+sVibravaGfx6:
+.incbin "baserom.gba", 0x136EB98, 0x200
+sVibravaSprites6:
+ax_sprite sVibravaGfx6, 0x200
+ax_sprite_terminator
+sVibravaGfx7:
+.incbin "baserom.gba", 0x136EDA8, 0x200
+sVibravaSprites7:
+ax_sprite sVibravaGfx7, 0x200
+ax_sprite_terminator
+sVibravaGfx8:
+.incbin "baserom.gba", 0x136EFB8, 0x200
+sVibravaSprites8:
+ax_sprite sVibravaGfx8, 0x200
+ax_sprite_terminator
+sVibravaGfx9:
+.incbin "baserom.gba", 0x136F1C8, 0x200
+sVibravaSprites9:
+ax_sprite sVibravaGfx9, 0x200
+ax_sprite_terminator
+sVibravaGfx10:
+.incbin "baserom.gba", 0x136F3D8, 0x200
+sVibravaSprites10:
+ax_sprite sVibravaGfx10, 0x200
+ax_sprite_terminator
+sVibravaGfx11:
+.incbin "baserom.gba", 0x136F5E8, 0x200
+sVibravaSprites11:
+ax_sprite sVibravaGfx11, 0x200
+ax_sprite_terminator
+sVibravaGfx12:
+.incbin "baserom.gba", 0x136F7F8, 0x200
+sVibravaSprites12:
+ax_sprite sVibravaGfx12, 0x200
+ax_sprite_terminator
+sVibravaGfx13:
+.incbin "baserom.gba", 0x136FA08, 0x200
+sVibravaSprites13:
+ax_sprite sVibravaGfx13, 0x200
+ax_sprite_terminator
+sVibravaGfx14:
+.incbin "baserom.gba", 0x136FC18, 0x200
+sVibravaSprites14:
+ax_sprite sVibravaGfx14, 0x200
+ax_sprite_terminator
+sVibravaGfx15:
+.incbin "baserom.gba", 0x136FE28, 0x200
+sVibravaSprites15:
+ax_sprite sVibravaGfx15, 0x200
+ax_sprite_terminator
+sVibravaGfx16:
+.incbin "baserom.gba", 0x1370038, 0x160
+sVibravaSprites16:
+ax_sprite sVibravaGfx16, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVibravaGfx17:
+.incbin "baserom.gba", 0x13701B0, 0x60
+sVibravaGfx17_1:
+.incbin "baserom.gba", 0x1370210, 0x100
+sVibravaSprites17:
+ax_sprite sVibravaGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx17_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVibravaGfx18:
+.incbin "baserom.gba", 0x1370338, 0x60
+sVibravaGfx18_1:
+.incbin "baserom.gba", 0x1370398, 0x80
+sVibravaGfx18_2:
+.incbin "baserom.gba", 0x1370418, 0x60
+sVibravaGfx18_3:
+.incbin "baserom.gba", 0x1370478, 0x40
+sVibravaSprites18:
+ax_sprite sVibravaGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx18_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVibravaGfx19:
+.incbin "baserom.gba", 0x1370500, 0x20
+sVibravaGfx19_1:
+.incbin "baserom.gba", 0x1370520, 0x60
+sVibravaGfx19_2:
+.incbin "baserom.gba", 0x1370580, 0x60
+sVibravaGfx19_3:
+.incbin "baserom.gba", 0x13705E0, 0x60
+sVibravaSprites19:
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx19, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVibravaGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx19_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx19_3, 0x60
+ax_sprite_terminator
+sVibravaGfx20:
+.incbin "baserom.gba", 0x1370688, 0x40
+sVibravaGfx20_1:
+.incbin "baserom.gba", 0x13706C8, 0x100
+sVibravaGfx20_2:
+.incbin "baserom.gba", 0x13707C8, 0x40
+sVibravaSprites20:
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVibravaGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVibravaGfx21:
+.incbin "baserom.gba", 0x1370848, 0x200
+sVibravaSprites21:
+ax_sprite sVibravaGfx21, 0x200
+ax_sprite_terminator
+sVibravaGfx22:
+.incbin "baserom.gba", 0x1370A58, 0x200
+sVibravaSprites22:
+ax_sprite sVibravaGfx22, 0x200
+ax_sprite_terminator
+sVibravaGfx23:
+.incbin "baserom.gba", 0x1370C68, 0x80
+sVibravaSprites23:
+ax_sprite sVibravaGfx23, 0x80
+ax_sprite_terminator
+sVibravaGfx24:
+.incbin "baserom.gba", 0x1370CF8, 0x20
+sVibravaSprites24:
+ax_sprite sVibravaGfx24, 0x20
+ax_sprite_terminator
+sVibravaGfx25:
+.incbin "baserom.gba", 0x1370D28, 0x20
+sVibravaSprites25:
+ax_sprite sVibravaGfx25, 0x20
+ax_sprite_terminator
+sVibravaGfx26:
+.incbin "baserom.gba", 0x1370D58, 0x20
+sVibravaSprites26:
+ax_sprite sVibravaGfx26, 0x20
+ax_sprite_terminator
+sVibravaGfx27:
+.incbin "baserom.gba", 0x1370D88, 0x100
+sVibravaSprites27:
+ax_sprite sVibravaGfx27, 0x100
+ax_sprite_terminator
+sVibravaGfx28:
+.incbin "baserom.gba", 0x1370E98, 0x200
+sVibravaSprites28:
+ax_sprite sVibravaGfx28, 0x200
+ax_sprite_terminator
+sVibravaGfx29:
+.incbin "baserom.gba", 0x13710A8, 0x200
+sVibravaSprites29:
+ax_sprite sVibravaGfx29, 0x200
+ax_sprite_terminator
+sVibravaGfx30:
+.incbin "baserom.gba", 0x13712B8, 0x200
+sVibravaSprites30:
+ax_sprite sVibravaGfx30, 0x200
+ax_sprite_terminator
+sVibravaGfx31:
+.incbin "baserom.gba", 0x13714C8, 0x200
+sVibravaSprites31:
+ax_sprite sVibravaGfx31, 0x200
+ax_sprite_terminator
+sAxPosesVibrava:
+.4byte sVibravaPose1
+.4byte sVibravaPose2
+.4byte sVibravaPose3
+.4byte sVibravaPose4
+.4byte sVibravaPose5
+.4byte sVibravaPose6
+.4byte sVibravaPose7
+.4byte sVibravaPose8
+.4byte sVibravaPose9
+.4byte sVibravaPose10
+.4byte sVibravaPose11
+.4byte sVibravaPose12
+.4byte sVibravaPose13
+.4byte sVibravaPose14
+.4byte sVibravaPose15
+.4byte sVibravaPose16
+.4byte sVibravaPose17
+.4byte sVibravaPose18
+.4byte sVibravaPose19
+.4byte sVibravaPose20
+.4byte sVibravaPose21
+.4byte sVibravaPose22
+.4byte sVibravaPose23
+.4byte sVibravaPose24
+.4byte sVibravaPose25
+.4byte sVibravaPose26
+.4byte sVibravaPose27
+.4byte sVibravaPose28
+.4byte sVibravaPose29
+.4byte sVibravaPose30
+.4byte sVibravaPose31
+.4byte sVibravaPose32
+.4byte sVibravaPose33
+.4byte sVibravaPose34
+.4byte sVibravaPose35
+.4byte sVibravaPose36
+.4byte sVibravaPose37
+.4byte sVibravaPose38
+.4byte sVibravaPose39
+.4byte sVibravaPose40
+.4byte sVibravaPose41
+.4byte sVibravaPose42
+.4byte sVibravaPose43
+.4byte sVibravaPose44
+.4byte sVibravaPose45
+.4byte sVibravaPose46
+.4byte sVibravaPose47
+.4byte sVibravaPose48
+.4byte sVibravaPose49
+.4byte sVibravaPose50
+.4byte sVibravaPose51
+.4byte sVibravaPose52
+.4byte sVibravaPose53
+.4byte sVibravaPose54
+.4byte sVibravaPose55
+.4byte sVibravaPose56
+.4byte sVibravaPose57
+.4byte sVibravaPose58
+.4byte sVibravaPose59
+.4byte sVibravaPose60
+.4byte sVibravaPose61
+.4byte sVibravaPose62
+.4byte sVibravaPose63
+.4byte sVibravaPose64
+.4byte sVibravaPose65
+.4byte sVibravaPose66
+.4byte sVibravaPose67
+.4byte sVibravaPose68
+.4byte sVibravaPose69
+.4byte sVibravaPose70
+.4byte sVibravaPose71
+.4byte sVibravaPose72
+.4byte sVibravaPose73
+.4byte sVibravaPose74
+.4byte sVibravaPose75
+.4byte sVibravaPose76
+.4byte sVibravaPose77
+.4byte sVibravaPose78
+.4byte sVibravaPose79
+.4byte sVibravaPose80
+.4byte sVibravaPose81
+.4byte sVibravaPose82
+.4byte sVibravaPose83
+.4byte sVibravaPose84
+.4byte sVibravaPose85
+.4byte sVibravaPose86
+.4byte sVibravaPose87
+.4byte sVibravaPose88
+.4byte sVibravaPose89
+.4byte sVibravaPose90
+.4byte sVibravaPose91
+.4byte sVibravaPose92
+.4byte sVibravaPose93
+.4byte sVibravaPose94
+.4byte sVibravaPose95
+.4byte sVibravaPose96
+.4byte sVibravaPose97
+.4byte sVibravaPose98
+.4byte sVibravaPose99
+.4byte sVibravaPose100
+.4byte sVibravaPose101
+.4byte sVibravaPose102
+.4byte sVibravaPose103
+.4byte sVibravaPose104
+.4byte sVibravaPose105
+.4byte sVibravaPose106
+.4byte sVibravaPose107
+.4byte sVibravaPose108
+.4byte sVibravaPose109
+.4byte sVibravaPose110
+.4byte sVibravaPose111
+.4byte sVibravaPose112
+.4byte sVibravaPose113
+.4byte sVibravaPose114
+.4byte sVibravaPose115
+.4byte sVibravaPose116
+.4byte sVibravaPose117
+.4byte sVibravaPose118
+.4byte sVibravaPose119
+.4byte sVibravaPose120
+.4byte sVibravaPose121
+.4byte sVibravaPose122
+.4byte sVibravaPose123
+.4byte sVibravaPose124
+.4byte sVibravaPose125
+.4byte sVibravaPose126
+.4byte sVibravaPose127
+.4byte sVibravaPose128
+.4byte sVibravaPose129
+.4byte sVibravaPose130
+.4byte sVibravaPose131
+.4byte sVibravaPose132
+.4byte sVibravaPose133
+.4byte sVibravaPose134
+.4byte sVibravaPose135
+.4byte sVibravaPose136
+.4byte sVibravaPose137
+.4byte sVibravaPose138
+.4byte sVibravaPose139
+.4byte sVibravaPose140
+.4byte sVibravaPose141
+.4byte sVibravaPose142
+.4byte sVibravaPose143
+.4byte sVibravaPose144
+.4byte sVibravaPose145
+.4byte sVibravaPose146
+.4byte sVibravaPose147
+.4byte sVibravaPose148
+.4byte sVibravaPose149
+.4byte sVibravaPose150
+.4byte sVibravaPose151
+.4byte sVibravaPose152
+.4byte sVibravaPose153
+.4byte sVibravaPose154
+.4byte sVibravaPose155
+.4byte sVibravaPose156
+.4byte sVibravaPose157
+.4byte sVibravaPose158
+.4byte sVibravaPose159
+.4byte sVibravaPose160
+.4byte sVibravaPose161
+.4byte sVibravaPose162
+.4byte sVibravaPose163
+.4byte sVibravaPose164
+.4byte sVibravaPose165
+.4byte sVibravaPose166
+.4byte sVibravaPose167
+.4byte sVibravaPose168
+.4byte sVibravaPose169
+.4byte sVibravaPose170
+.4byte sVibravaPose171
+.4byte sVibravaPose172
+.4byte sVibravaPose173
+.4byte sVibravaPose174
+.4byte sVibravaPose175
+.4byte sVibravaPose176
+.4byte sVibravaPose177
+.4byte sVibravaPose178
+.4byte sVibravaPose179
+.4byte sVibravaPose180
+.4byte sVibravaPose181
+.4byte sVibravaPose182
+.4byte sVibravaPose183
+.4byte sVibravaPose184
+.4byte sVibravaPose185
+.4byte sVibravaPose186
+.4byte sVibravaPose187
+.4byte sVibravaPose188
+.4byte sVibravaPose189
+.4byte sVibravaPose190
+.4byte sVibravaPose191
+.4byte sVibravaPose192
+.4byte sVibravaPose193
+.4byte sVibravaPose194
+.4byte sVibravaPose195
+.4byte sVibravaPose196
+.4byte sVibravaPose197
+.4byte sVibravaPose198
+.4byte sVibravaPose199
+.4byte sVibravaPose200
+.4byte sVibravaPose201
+.4byte sVibravaPose202
+.4byte sVibravaPose203
+.4byte sVibravaPose204
+.4byte sVibravaPose205
+.4byte sVibravaPose206
+.4byte sVibravaPose207
+.4byte sVibravaPose208
+.4byte sVibravaPose209
+.4byte sVibravaPose210
+.4byte sVibravaPose211
+.4byte sVibravaPose212
+.4byte sVibravaPose213
+.4byte sVibravaPose214
+.4byte sVibravaPose215
+.4byte sVibravaPose216
+.4byte sVibravaPose217
+.4byte sVibravaPose218
+.4byte sVibravaPose219
+.4byte sVibravaPose220
+.4byte sVibravaPose221
+.4byte sVibravaPose222
+.4byte sVibravaPose223
+.4byte sVibravaPose224
+.4byte sVibravaPose225
+.4byte sVibravaPose226
+sAxPositionsVibrava:
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -8,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -1,    2, 	  -8,    1, 	   6,    1, 	  -1,   -5
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte    6,   -4, 	   1,   -8, 	  -4,   -2, 	  -2,   -9
+.2byte    7,   -1, 	   6,   -6, 	  -1,    1, 	   0,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    5,   -6, 	   1,   -8, 	   1,   -1, 	  -1,   -9
+.2byte    6,   -4, 	   3,   -7, 	   3,    0, 	   1,   -7
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    4,  -11, 	  -5,  -11, 	   5,   -6, 	  -2,   -9
+.2byte    5,   -9, 	  -2,  -11, 	   6,   -6, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -15, 	   4,   -9, 	  -4,   -9, 	  -1,  -10
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -6,  -11, 	   3,  -11, 	  -7,   -6, 	   0,   -9
+.2byte   -7,   -9, 	   0,  -11, 	  -8,   -6, 	  -1,  -10
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	  -3,   -1, 	  -1,   -9
+.2byte   -8,   -4, 	  -5,   -7, 	  -5,    0, 	  -3,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,   -8, 	   2,   -2, 	   0,   -9
+.2byte   -9,   -1, 	  -8,   -6, 	  -1,    1, 	  -2,   -7
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -8,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -1,    2, 	  -8,    1, 	   6,    1, 	  -1,   -5
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte    6,   -4, 	   1,   -8, 	  -4,   -2, 	  -2,   -9
+.2byte    7,   -1, 	   6,   -6, 	  -1,    1, 	   0,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    5,   -6, 	   1,   -8, 	   1,   -1, 	  -1,   -9
+.2byte    6,   -4, 	   3,   -7, 	   3,    0, 	   1,   -7
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    4,  -11, 	  -5,  -11, 	   5,   -6, 	  -2,   -9
+.2byte    5,   -9, 	  -2,  -11, 	   6,   -6, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -15, 	   4,   -9, 	  -4,   -9, 	  -1,  -10
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -6,  -11, 	   3,  -11, 	  -7,   -6, 	   0,   -9
+.2byte   -7,   -9, 	   0,  -11, 	  -8,   -6, 	  -1,  -10
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	  -3,   -1, 	  -1,   -9
+.2byte   -8,   -4, 	  -5,   -7, 	  -5,    0, 	  -3,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,   -8, 	   2,   -2, 	   0,   -9
+.2byte   -9,   -1, 	  -8,   -6, 	  -1,    1, 	  -2,   -7
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -8,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -1,    2, 	  -8,    1, 	   6,    1, 	  -1,   -5
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte    6,   -4, 	   1,   -8, 	  -4,   -2, 	  -2,   -9
+.2byte    7,   -1, 	   6,   -6, 	  -1,    1, 	   0,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    5,   -6, 	   1,   -8, 	   1,   -1, 	  -1,   -9
+.2byte    6,   -4, 	   3,   -7, 	   3,    0, 	   1,   -7
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    4,  -11, 	  -5,  -11, 	   5,   -6, 	  -2,   -9
+.2byte    5,   -9, 	  -2,  -11, 	   6,   -6, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -15, 	   4,   -9, 	  -4,   -9, 	  -1,  -10
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -6,  -11, 	   3,  -11, 	  -7,   -6, 	   0,   -9
+.2byte   -7,   -9, 	   0,  -11, 	  -8,   -6, 	  -1,  -10
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	  -3,   -1, 	  -1,   -9
+.2byte   -8,   -4, 	  -5,   -7, 	  -5,    0, 	  -3,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,   -8, 	   2,   -2, 	   0,   -9
+.2byte   -9,   -1, 	  -8,   -6, 	  -1,    1, 	  -2,   -7
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -7,    0, 	   5,    0, 	  -1,   -7
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte    4,   -4, 	   4,   -2, 	  -3,    0, 	  -2,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    6,   -7, 	   1,   -6, 	   1,    0, 	  -2,   -7
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    4,  -10, 	  -5,   -9, 	   1,   -4, 	  -2,   -8
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -10, 	   4,   -5, 	  -5,   -5, 	  -1,   -5
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -6,  -10, 	   3,   -9, 	  -3,   -4, 	   0,   -8
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -8,   -7, 	  -3,   -6, 	  -3,    0, 	   0,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -6,   -4, 	  -6,   -2, 	   1,    0, 	   0,   -7
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte   -1,    3, 	  -8,    0, 	   6,    0, 	  -1,   -6
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -7
+.2byte   -1,    2, 	  -9,   -3, 	   7,   -3, 	  -1,   -6
+.2byte    8,    1, 	   7,   -5, 	   0,    0, 	   1,   -6
+.2byte    4,   -1, 	   3,   -3, 	   2,    0, 	   0,   -5
+.2byte    5,   -5, 	   0,  -10, 	   6,   -1, 	  -1,   -5
+.2byte   -1,   -8, 	   5,   -6, 	  -7,   -6, 	  -1,   -5
+.2byte   -6,   -5, 	  -1,  -10, 	  -7,   -1, 	   0,   -5
+.2byte   -3,   -1, 	  -2,   -3, 	  -1,    0, 	   1,   -5
+.2byte   -5,    1, 	  -4,   -5, 	   3,    0, 	   2,   -6
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -8,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -1,    2, 	  -8,    1, 	   6,    1, 	  -1,   -5
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte    6,   -4, 	   1,   -8, 	  -4,   -2, 	  -2,   -9
+.2byte    7,   -1, 	   6,   -6, 	  -1,    1, 	   0,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    5,   -6, 	   1,   -8, 	   1,   -1, 	  -1,   -9
+.2byte    6,   -4, 	   3,   -7, 	   3,    0, 	   1,   -7
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    4,  -11, 	  -5,  -11, 	   5,   -6, 	  -2,   -9
+.2byte    5,   -9, 	  -2,  -11, 	   6,   -6, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -15, 	   4,   -9, 	  -4,   -9, 	  -1,  -10
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -6,  -11, 	   3,  -11, 	  -7,   -6, 	   0,   -9
+.2byte   -7,   -9, 	   0,  -11, 	  -8,   -6, 	  -1,  -10
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	  -3,   -1, 	  -1,   -9
+.2byte   -8,   -4, 	  -5,   -7, 	  -5,    0, 	  -3,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,   -8, 	   2,   -2, 	   0,   -9
+.2byte   -9,   -1, 	  -8,   -6, 	  -1,    1, 	  -2,   -7
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte   -1,   -1, 	  -8,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -8,   -3, 	  -3,   -7, 	   2,   -1, 	   0,   -8
+.2byte   -6,   -5, 	  -2,   -7, 	  -2,    0, 	   0,   -8
+.2byte   -6,   -9, 	   3,   -9, 	  -7,   -4, 	   0,   -7
+.2byte   -1,  -13, 	   4,   -7, 	  -4,   -7, 	  -1,   -8
+.2byte    4,   -9, 	  -5,   -9, 	   5,   -4, 	  -2,   -7
+.2byte    5,   -5, 	   1,   -7, 	   1,    0, 	  -1,   -8
+.2byte    6,   -3, 	   1,   -7, 	  -4,   -1, 	  -2,   -8
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte   -1,   -1, 	  -7,    0, 	   5,    0, 	  -1,   -7
+.2byte    4,   -4, 	   4,   -2, 	  -3,    0, 	  -2,   -7
+.2byte    6,   -7, 	   1,   -6, 	   1,    0, 	  -2,   -7
+.2byte    4,   -9, 	  -5,   -8, 	   1,   -3, 	  -2,   -7
+.2byte   -1,  -12, 	   4,   -7, 	  -5,   -7, 	  -1,   -7
+.2byte   -6,   -9, 	   3,   -8, 	  -3,   -3, 	   0,   -7
+.2byte   -8,   -7, 	  -3,   -6, 	  -3,    0, 	   0,   -7
+.2byte   -6,   -4, 	  -6,   -2, 	   1,    0, 	   0,   -7
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -1,   -1, 	  -8,   -1, 	   6,   -1, 	  -1,   -7
+.2byte   -1,    2, 	  -8,    1, 	   6,    1, 	  -1,   -5
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+.2byte    6,   -4, 	   1,   -8, 	  -4,   -2, 	  -2,   -9
+.2byte    7,   -1, 	   6,   -6, 	  -1,    1, 	   0,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    5,   -6, 	   1,   -8, 	   1,   -1, 	  -1,   -9
+.2byte    6,   -4, 	   3,   -7, 	   3,    0, 	   1,   -7
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    4,  -11, 	  -5,  -11, 	   5,   -6, 	  -2,   -9
+.2byte    5,   -9, 	  -2,  -11, 	   6,   -6, 	  -1,  -10
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte   -1,  -15, 	   4,   -9, 	  -4,   -9, 	  -1,  -10
+.2byte   -1,  -14, 	   3,  -10, 	  -4,  -10, 	  -1,  -10
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -6,  -11, 	   3,  -11, 	  -7,   -6, 	   0,   -9
+.2byte   -7,   -9, 	   0,  -11, 	  -8,   -6, 	  -1,  -10
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -6, 	  -3,   -8, 	  -3,   -1, 	  -1,   -9
+.2byte   -8,   -4, 	  -5,   -7, 	  -5,    0, 	  -3,   -7
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -4, 	  -3,   -8, 	   2,   -2, 	   0,   -9
+.2byte   -9,   -1, 	  -8,   -6, 	  -1,    1, 	  -2,   -7
+.2byte   -1,    2, 	  -8,    1, 	   6,    1, 	  -1,   -5
+.2byte   -9,   -1, 	  -8,   -6, 	  -1,    1, 	  -2,   -7
+.2byte   -7,   -3, 	  -4,   -6, 	  -4,    1, 	  -2,   -6
+.2byte   -6,   -7, 	   1,   -9, 	  -7,   -4, 	   0,   -8
+.2byte   -1,  -11, 	   3,   -7, 	  -4,   -7, 	  -1,   -7
+.2byte    5,   -7, 	  -2,   -9, 	   6,   -4, 	  -1,   -8
+.2byte    6,   -3, 	   3,   -6, 	   3,    1, 	   1,   -6
+.2byte    7,   -1, 	   6,   -6, 	  -1,    1, 	   0,   -7
+.2byte   -1,    2, 	  -8,    0, 	   6,    0, 	  -1,   -5
+.2byte   -9,    0, 	  -8,   -5, 	   1,    0, 	  -1,   -6
+.2byte   -8,   -2, 	  -4,   -4, 	  -4,    1, 	  -2,   -6
+.2byte   -7,   -7, 	   1,   -9, 	  -7,   -3, 	  -1,   -7
+.2byte   -1,  -12, 	   3,   -7, 	  -5,   -7, 	  -1,   -8
+.2byte    5,   -7, 	  -3,   -9, 	   5,   -3, 	  -1,   -7
+.2byte    6,   -2, 	   2,   -4, 	   2,    1, 	   0,   -6
+.2byte    7,    0, 	   6,   -5, 	  -3,    0, 	  -1,   -6
+sVibravaAnimTable1:
+.4byte sVibravaAnims_1_1
+.4byte sVibravaAnims_1_2
+.4byte sVibravaAnims_1_3
+.4byte sVibravaAnims_1_4
+.4byte sVibravaAnims_1_5
+.4byte sVibravaAnims_1_6
+.4byte sVibravaAnims_1_7
+.4byte sVibravaAnims_1_8
+sVibravaAnimTable2:
+.4byte sVibravaAnims_2_1
+.4byte sVibravaAnims_2_2
+.4byte sVibravaAnims_2_3
+.4byte sVibravaAnims_2_4
+.4byte sVibravaAnims_2_5
+.4byte sVibravaAnims_2_6
+.4byte sVibravaAnims_2_7
+.4byte sVibravaAnims_2_8
+sVibravaAnimTable3:
+.4byte sVibravaAnims_3_1
+.4byte sVibravaAnims_3_2
+.4byte sVibravaAnims_3_3
+.4byte sVibravaAnims_3_4
+.4byte sVibravaAnims_3_5
+.4byte sVibravaAnims_3_6
+.4byte sVibravaAnims_3_7
+.4byte sVibravaAnims_3_8
+sVibravaAnimTable4:
+.4byte sVibravaAnims_4_1
+.4byte sVibravaAnims_4_2
+.4byte sVibravaAnims_4_3
+.4byte sVibravaAnims_4_4
+.4byte sVibravaAnims_4_5
+.4byte sVibravaAnims_4_6
+.4byte sVibravaAnims_4_7
+.4byte sVibravaAnims_4_8
+sVibravaAnimTable5:
+.4byte sVibravaAnims_5_1
+.4byte sVibravaAnims_5_2
+.4byte sVibravaAnims_5_3
+.4byte sVibravaAnims_5_4
+.4byte sVibravaAnims_5_5
+.4byte sVibravaAnims_5_6
+.4byte sVibravaAnims_5_7
+.4byte sVibravaAnims_5_8
+sVibravaAnimTable6:
+.4byte sVibravaAnims_6_1
+.4byte sVibravaAnims_6_1
+.4byte sVibravaAnims_6_1
+.4byte sVibravaAnims_6_1
+.4byte sVibravaAnims_6_1
+.4byte sVibravaAnims_6_1
+.4byte sVibravaAnims_6_1
+.4byte sVibravaAnims_6_1
+sVibravaAnimTable7:
+.4byte sVibravaAnims_7_1
+.4byte sVibravaAnims_7_2
+.4byte sVibravaAnims_7_3
+.4byte sVibravaAnims_7_4
+.4byte sVibravaAnims_7_5
+.4byte sVibravaAnims_7_6
+.4byte sVibravaAnims_7_7
+.4byte sVibravaAnims_7_8
+sVibravaAnimTable8:
+.4byte sVibravaAnims_8_1
+.4byte sVibravaAnims_8_2
+.4byte sVibravaAnims_8_3
+.4byte sVibravaAnims_8_4
+.4byte sVibravaAnims_8_5
+.4byte sVibravaAnims_8_6
+.4byte sVibravaAnims_8_7
+.4byte sVibravaAnims_8_8
+sVibravaAnimTable9:
+.4byte sVibravaAnims_9_1
+.4byte sVibravaAnims_9_2
+.4byte sVibravaAnims_9_3
+.4byte sVibravaAnims_9_4
+.4byte sVibravaAnims_9_5
+.4byte sVibravaAnims_9_6
+.4byte sVibravaAnims_9_7
+.4byte sVibravaAnims_9_8
+sVibravaAnimTable10:
+.4byte sVibravaAnims_10_1
+.4byte sVibravaAnims_10_2
+.4byte sVibravaAnims_10_3
+.4byte sVibravaAnims_10_4
+.4byte sVibravaAnims_10_5
+.4byte sVibravaAnims_10_6
+.4byte sVibravaAnims_10_7
+.4byte sVibravaAnims_10_8
+sVibravaAnimTable11:
+.4byte sVibravaAnims_11_1
+.4byte sVibravaAnims_11_2
+.4byte sVibravaAnims_11_3
+.4byte sVibravaAnims_11_4
+.4byte sVibravaAnims_11_5
+.4byte sVibravaAnims_11_6
+.4byte sVibravaAnims_11_7
+.4byte sVibravaAnims_11_8
+sVibravaAnimTable12:
+.4byte sVibravaAnims_12_1
+.4byte sVibravaAnims_12_2
+.4byte sVibravaAnims_12_3
+.4byte sVibravaAnims_12_4
+.4byte sVibravaAnims_12_5
+.4byte sVibravaAnims_12_6
+.4byte sVibravaAnims_12_7
+.4byte sVibravaAnims_12_8
+sVibravaAnimTable13:
+.4byte sVibravaAnims_13_1
+.4byte sVibravaAnims_13_2
+.4byte sVibravaAnims_13_3
+.4byte sVibravaAnims_13_4
+.4byte sVibravaAnims_13_5
+.4byte sVibravaAnims_13_6
+.4byte sVibravaAnims_13_7
+.4byte sVibravaAnims_13_8
+sAxAnimationsVibrava:
+.4byte sVibravaAnimTable1
+.4byte sVibravaAnimTable2
+.4byte sVibravaAnimTable3
+.4byte sVibravaAnimTable4
+.4byte sVibravaAnimTable5
+.4byte sVibravaAnimTable6
+.4byte sVibravaAnimTable7
+.4byte sVibravaAnimTable8
+.4byte sVibravaAnimTable9
+.4byte sVibravaAnimTable10
+.4byte sVibravaAnimTable11
+.4byte sVibravaAnimTable12
+.4byte sVibravaAnimTable13
+sAxSpritesVibrava:
+.4byte sVibravaSprites1
+.4byte sVibravaSprites2
+.4byte sVibravaSprites3
+.4byte sVibravaSprites4
+.4byte sVibravaSprites5
+.4byte sVibravaSprites6
+.4byte sVibravaSprites7
+.4byte sVibravaSprites8
+.4byte sVibravaSprites9
+.4byte sVibravaSprites10
+.4byte sVibravaSprites11
+.4byte sVibravaSprites12
+.4byte sVibravaSprites13
+.4byte sVibravaSprites14
+.4byte sVibravaSprites15
+.4byte sVibravaSprites16
+.4byte sVibravaSprites17
+.4byte sVibravaSprites18
+.4byte sVibravaSprites19
+.4byte sVibravaSprites20
+.4byte sVibravaSprites21
+.4byte sVibravaSprites22
+.4byte sVibravaSprites23
+.4byte sVibravaSprites24
+.4byte sVibravaSprites25
+.4byte sVibravaSprites26
+.4byte sVibravaSprites27
+.4byte sVibravaSprites28
+.4byte sVibravaSprites29
+.4byte sVibravaSprites30
+.4byte sVibravaSprites31
+sAxMainVibrava:
+ax_main sAxPosesVibrava, sAxAnimationsVibrava, 13, sAxSpritesVibrava, sAxPositionsVibrava

--- a/data/ax/victreebel.inc
+++ b/data/ax/victreebel.inc
@@ -1,0 +1,2942 @@
+.global gAxVictreebel
+gAxVictreebel:
+ax_siro sAxMainVictreebel
+sVictreebelPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose4:
+ax_pose 3, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose5:
+ax_pose 4, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose6:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose7:
+ax_pose 6, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose8:
+ax_pose 7, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose9:
+ax_pose 8, 0x81e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose10:
+ax_pose 9, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose11:
+ax_pose 10, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose12:
+ax_pose 11, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose16:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose17:
+ax_pose 16, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose18:
+ax_pose 17, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose19:
+ax_pose 18, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose20:
+ax_pose 19, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose21:
+ax_pose 20, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose22:
+ax_pose 21, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose23:
+ax_pose 22, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose24:
+ax_pose 23, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose28:
+ax_pose 3, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose29:
+ax_pose 4, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose30:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose31:
+ax_pose 6, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose32:
+ax_pose 7, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose33:
+ax_pose 8, 0x81e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose34:
+ax_pose 9, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose35:
+ax_pose 10, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose36:
+ax_pose 11, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose37:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose38:
+ax_pose 13, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose39:
+ax_pose 14, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose40:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose41:
+ax_pose 16, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose42:
+ax_pose 17, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose43:
+ax_pose 18, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose44:
+ax_pose 19, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose45:
+ax_pose 20, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose46:
+ax_pose 21, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose47:
+ax_pose 22, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose48:
+ax_pose 23, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose49:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose50:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose51:
+ax_pose 2, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose52:
+ax_pose 24, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sVictreebelPose53:
+ax_pose 25, 0x01e8, 0x80f0, 0x3c00
+ax_pose 26, 0x01e6, 0x80f0, 0x3c10
+ax_pose_terminator
+sVictreebelPose54:
+ax_pose 26, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose55:
+ax_pose 3, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose56:
+ax_pose 4, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose57:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose58:
+ax_pose 27, 0x01e6, 0x90f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose59:
+ax_pose 28, 0x81e6, 0x9100, 0x3c00
+ax_pose 29, 0x01e6, 0x90f0, 0x3c08
+ax_pose_terminator
+sVictreebelPose60:
+ax_pose 29, 0x01e6, 0x90f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose61:
+ax_pose 6, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose62:
+ax_pose 7, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose63:
+ax_pose 8, 0x81e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose64:
+ax_pose 30, 0x01e7, 0x90f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose65:
+ax_pose 31, 0x01e6, 0x90f1, 0x3c00
+ax_pose 32, 0x01e6, 0x90f0, 0x3c10
+ax_pose_terminator
+sVictreebelPose66:
+ax_pose 32, 0x01e6, 0x90f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose67:
+ax_pose 9, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose68:
+ax_pose 10, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose69:
+ax_pose 11, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose70:
+ax_pose 33, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sVictreebelPose71:
+ax_pose 34, 0x01e5, 0x90ef, 0x3c00
+ax_pose 35, 0x01e6, 0x90ef, 0x3c10
+ax_pose_terminator
+sVictreebelPose72:
+ax_pose 35, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sVictreebelPose73:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose74:
+ax_pose 13, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose75:
+ax_pose 14, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose76:
+ax_pose 36, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose77:
+ax_pose 37, 0x01e6, 0x80f0, 0x3c00
+ax_pose 38, 0x01e7, 0x80f0, 0x3c10
+ax_pose_terminator
+sVictreebelPose78:
+ax_pose 38, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose79:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose80:
+ax_pose 16, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose81:
+ax_pose 17, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose82:
+ax_pose 33, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sVictreebelPose83:
+ax_pose 34, 0x01e5, 0x80f1, 0x3c00
+ax_pose 35, 0x01e6, 0x80f1, 0x3c10
+ax_pose_terminator
+sVictreebelPose84:
+ax_pose 35, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sVictreebelPose85:
+ax_pose 18, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose86:
+ax_pose 19, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose87:
+ax_pose 20, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose88:
+ax_pose 30, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose89:
+ax_pose 31, 0x01e6, 0x80ef, 0x3c00
+ax_pose 32, 0x01e6, 0x80f0, 0x3c10
+ax_pose_terminator
+sVictreebelPose90:
+ax_pose 32, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose91:
+ax_pose 21, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose92:
+ax_pose 22, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose93:
+ax_pose 23, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose94:
+ax_pose 27, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose95:
+ax_pose 28, 0x81e6, 0x80f0, 0x3c00
+ax_pose 29, 0x01e6, 0x80f0, 0x3c08
+ax_pose_terminator
+sVictreebelPose96:
+ax_pose 29, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose97:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose98:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose99:
+ax_pose 2, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose100:
+ax_pose 39, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose101:
+ax_pose 3, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose102:
+ax_pose 4, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose103:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose104:
+ax_pose 40, 0x01e5, 0x90f1, 0x3c00
+ax_pose_terminator
+sVictreebelPose105:
+ax_pose 6, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose106:
+ax_pose 7, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose107:
+ax_pose 8, 0x81e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose108:
+ax_pose 41, 0x01e6, 0x90f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose109:
+ax_pose 9, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose110:
+ax_pose 10, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose111:
+ax_pose 11, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose112:
+ax_pose 42, 0x01e4, 0x90ee, 0x3c00
+ax_pose_terminator
+sVictreebelPose113:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose114:
+ax_pose 13, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose115:
+ax_pose 14, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose116:
+ax_pose 43, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose117:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose118:
+ax_pose 16, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose119:
+ax_pose 17, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose120:
+ax_pose 42, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose121:
+ax_pose 18, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose122:
+ax_pose 19, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose123:
+ax_pose 20, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose124:
+ax_pose 41, 0x01e6, 0x80ec, 0x3c00
+ax_pose_terminator
+sVictreebelPose125:
+ax_pose 21, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose126:
+ax_pose 22, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose127:
+ax_pose 23, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose128:
+ax_pose 40, 0x01e5, 0x80ef, 0x3c00
+ax_pose_terminator
+sVictreebelPose129:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose130:
+ax_pose 21, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sVictreebelPose131:
+ax_pose 18, 0x01e4, 0x80f7, 0x3c00
+ax_pose_terminator
+sVictreebelPose132:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose133:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose134:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sVictreebelPose135:
+ax_pose 44, 0x01e4, 0x80f9, 0x3c00
+ax_pose_terminator
+sVictreebelPose136:
+ax_pose 3, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sVictreebelPose137:
+ax_pose 45, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose138:
+ax_pose 46, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose139:
+ax_pose 47, 0x01df, 0x80f3, 0x3c00
+ax_pose_terminator
+sVictreebelPose140:
+ax_pose 48, 0x01df, 0x90ec, 0x3c00
+ax_pose_terminator
+sVictreebelPose141:
+ax_pose 49, 0x01df, 0x90ea, 0x3c00
+ax_pose_terminator
+sVictreebelPose142:
+ax_pose 50, 0x01e1, 0x90ed, 0x3c00
+ax_pose_terminator
+sVictreebelPose143:
+ax_pose 51, 0x01e1, 0x80ef, 0x3c00
+ax_pose_terminator
+sVictreebelPose144:
+ax_pose 50, 0x01e1, 0x80f3, 0x3c00
+ax_pose_terminator
+sVictreebelPose145:
+ax_pose 49, 0x01df, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose146:
+ax_pose 48, 0x01df, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose147:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose148:
+ax_pose 2, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose149:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose150:
+ax_pose 3, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose151:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose152:
+ax_pose 4, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose153:
+ax_pose 6, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose154:
+ax_pose 8, 0x81e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose155:
+ax_pose 7, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose156:
+ax_pose 9, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose157:
+ax_pose 11, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose158:
+ax_pose 10, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose159:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose160:
+ax_pose 14, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose161:
+ax_pose 13, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose162:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose163:
+ax_pose 17, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose164:
+ax_pose 16, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose165:
+ax_pose 18, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose166:
+ax_pose 20, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose167:
+ax_pose 19, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose168:
+ax_pose 21, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose169:
+ax_pose 23, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose170:
+ax_pose 22, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose171:
+ax_pose 39, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose172:
+ax_pose 40, 0x01e6, 0x80ef, 0x3c00
+ax_pose_terminator
+sVictreebelPose173:
+ax_pose 41, 0x01e6, 0x80ec, 0x3c00
+ax_pose_terminator
+sVictreebelPose174:
+ax_pose 42, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose175:
+ax_pose 43, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose176:
+ax_pose 42, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sVictreebelPose177:
+ax_pose 41, 0x01e6, 0x90f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose178:
+ax_pose 40, 0x01e6, 0x90f1, 0x3c00
+ax_pose_terminator
+sVictreebelPose179:
+ax_pose 39, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose180:
+ax_pose 40, 0x01e8, 0x90f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose181:
+ax_pose 41, 0x01e7, 0x90f3, 0x3c00
+ax_pose_terminator
+sVictreebelPose182:
+ax_pose 42, 0x01e7, 0x90ed, 0x3c00
+ax_pose_terminator
+sVictreebelPose183:
+ax_pose 43, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose184:
+ax_pose 42, 0x01e7, 0x80f3, 0x3c00
+ax_pose_terminator
+sVictreebelPose185:
+ax_pose 41, 0x01e7, 0x80ed, 0x3c00
+ax_pose_terminator
+sVictreebelPose186:
+ax_pose 40, 0x01e8, 0x80ee, 0x3c00
+ax_pose_terminator
+sVictreebelPose187:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose188:
+ax_pose 1, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose189:
+ax_pose 2, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose190:
+ax_pose 3, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose191:
+ax_pose 4, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose192:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose193:
+ax_pose 6, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose194:
+ax_pose 7, 0x81e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose195:
+ax_pose 8, 0x81e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose196:
+ax_pose 9, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose197:
+ax_pose 10, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose198:
+ax_pose 11, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose199:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose200:
+ax_pose 13, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose201:
+ax_pose 14, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose202:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose203:
+ax_pose 16, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose204:
+ax_pose 17, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose205:
+ax_pose 18, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose206:
+ax_pose 19, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose207:
+ax_pose 20, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose208:
+ax_pose 21, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose209:
+ax_pose 22, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose210:
+ax_pose 23, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose211:
+ax_pose 2, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose212:
+ax_pose 23, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose213:
+ax_pose 20, 0x01e4, 0x80f8, 0x3c00
+ax_pose_terminator
+sVictreebelPose214:
+ax_pose 17, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose215:
+ax_pose 14, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose216:
+ax_pose 11, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sVictreebelPose217:
+ax_pose 8, 0x81e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sVictreebelPose218:
+ax_pose 5, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose219:
+ax_pose 0, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose220:
+ax_pose 21, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sVictreebelPose221:
+ax_pose 18, 0x01e4, 0x80f7, 0x3c00
+ax_pose_terminator
+sVictreebelPose222:
+ax_pose 15, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sVictreebelPose223:
+ax_pose 12, 0x01e4, 0x80f0, 0x3c00
+ax_pose_terminator
+sVictreebelPose224:
+ax_pose 9, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sVictreebelPose225:
+ax_pose 44, 0x01e4, 0x80f9, 0x3c00
+ax_pose_terminator
+sVictreebelPose226:
+ax_pose 3, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+.align 2
+sVictreebelAnims_1_1:
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -3, 0, 0,
+ax_anim 6, 0, 0, 0, -4, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_1_2:
+ax_anim 6, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -3, 0, 0,
+ax_anim 6, 0, 3, 0, -4, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_1_3:
+ax_anim 6, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 6, 0, -4, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_1_4:
+ax_anim 6, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -3, 0, 0,
+ax_anim 6, 0, 9, 0, -4, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_1_5:
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -3, 0, 0,
+ax_anim 6, 0, 12, 0, -4, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_1_6:
+ax_anim 6, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -3, 0, 0,
+ax_anim 6, 0, 15, 0, -4, 0, 0,
+ax_anim 8, 0, 17, 0, -3, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_1_7:
+ax_anim 6, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -3, 0, 0,
+ax_anim 6, 0, 18, 0, -4, 0, 0,
+ax_anim 8, 0, 20, 0, -3, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_1_8:
+ax_anim 6, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -3, 0, 0,
+ax_anim 6, 0, 21, 0, -4, 0, 0,
+ax_anim 8, 0, 23, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 21, 0, 21,
+ax_anim 2, 1, 24, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 21, 0, 21,
+ax_anim 2, 0, 24, 1, 21, 1, 21,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sVictreebelAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 27, 21, 21, 21, 21,
+ax_anim 2, 1, 27, 22, 20, 22, 20,
+ax_anim 2, 0, 27, 21, 21, 21, 21,
+ax_anim 2, 0, 27, 22, 20, 22, 20,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sVictreebelAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 30, 22, 0, 22, 0,
+ax_anim 2, 1, 30, 22, 1, 22, 1,
+ax_anim 2, 0, 30, 22, 0, 22, 0,
+ax_anim 2, 0, 30, 22, 1, 22, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sVictreebelAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -4, 4, -4,
+ax_anim 1, 0, 35, 11, -10, 11, -10,
+ax_anim 2, 0, 33, 22, -19, 22, -19,
+ax_anim 2, 1, 33, 23, -18, 23, -18,
+ax_anim 2, 0, 33, 22, -19, 22, -19,
+ax_anim 2, 0, 33, 23, -18, 23, -18,
+ax_anim 2, 0, 33, 7, -6, 7, -6,
+ax_anim_terminator
+sVictreebelAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 36, 0, -18, 0, -18,
+ax_anim 2, 1, 36, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -18, 0, -18,
+ax_anim 2, 0, 36, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sVictreebelAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -4, -4, -4,
+ax_anim 1, 0, 41, -11, -10, -11, -10,
+ax_anim 2, 0, 39, -22, -19, -22, -19,
+ax_anim 2, 1, 39, -23, -18, -23, -18,
+ax_anim 2, 0, 39, -22, -19, -22, -19,
+ax_anim 2, 0, 39, -23, -18, -23, -18,
+ax_anim 2, 0, 39, -7, -6, -7, -6,
+ax_anim_terminator
+sVictreebelAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 42, -22, 0, -22, 0,
+ax_anim 2, 1, 42, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -22, 0, -22, 0,
+ax_anim 2, 0, 42, -22, 1, -22, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sVictreebelAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 45, -21, 21, -21, 21,
+ax_anim 2, 1, 45, -22, 20, -22, 20,
+ax_anim 2, 0, 45, -21, 21, -21, 21,
+ax_anim 2, 0, 45, -22, 20, -22, 20,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, -3, 0, -3,
+ax_anim 4, 0, 48, 0, -4, 0, -4,
+ax_anim 1, 0, 51, 0, -2, 0, -2,
+ax_anim 1, 2, 51, 0, 6, 0, 6,
+ax_anim 1, 0, 51, 0, 13, 0, 13,
+ax_anim 2, 0, 52, 1, 16, 1, 16,
+ax_anim 2, 1, 53, 2, 17, 2, 17,
+ax_anim 2, 0, 53, 3, 17, 3, 17,
+ax_anim 2, 0, 53, 2, 17, 2, 17,
+ax_anim 2, 0, 53, 3, 17, 3, 17,
+ax_anim 2, 0, 53, 2, 17, 2, 17,
+ax_anim 2, 0, 53, 2, 11, 2, 11,
+ax_anim 2, 0, 48, 1, 4, 1, 4,
+ax_anim_terminator
+sVictreebelAnims_3_2:
+ax_anim 2, 0, 55, -1, -1, -1, -1,
+ax_anim 2, 0, 56, -3, -3, -3, -3,
+ax_anim 4, 0, 54, -4, -4, -4, -4,
+ax_anim 1, 0, 57, -2, -2, -2, -2,
+ax_anim 1, 2, 57, 6, 6, 6, 6,
+ax_anim 1, 0, 57, 13, 13, 13, 13,
+ax_anim 2, 0, 58, 16, 18, 16, 18,
+ax_anim 2, 1, 59, 16, 19, 16, 19,
+ax_anim 2, 0, 59, 15, 20, 15, 20,
+ax_anim 2, 0, 59, 16, 19, 16, 19,
+ax_anim 2, 0, 59, 15, 20, 15, 20,
+ax_anim 2, 0, 59, 16, 19, 16, 19,
+ax_anim 2, 0, 59, 10, 18, 10, 18,
+ax_anim 2, 0, 54, 3, 8, 3, 8,
+ax_anim_terminator
+sVictreebelAnims_3_3:
+ax_anim 2, 0, 61, -1, 0, -1, 0,
+ax_anim 2, 0, 62, -3, 0, -3, 0,
+ax_anim 4, 0, 60, -4, 0, -4, 0,
+ax_anim 1, 0, 63, -2, 0, -2, 0,
+ax_anim 1, 2, 63, 6, 0, 6, 0,
+ax_anim 1, 0, 63, 11, 0, 11, 0,
+ax_anim 2, 0, 64, 14, 1, 14, 1,
+ax_anim 2, 1, 65, 15, 2, 15, 2,
+ax_anim 2, 0, 65, 15, 3, 15, 3,
+ax_anim 2, 0, 65, 15, 2, 15, 2,
+ax_anim 2, 0, 65, 15, 3, 15, 3,
+ax_anim 2, 0, 65, 15, 2, 15, 2,
+ax_anim 2, 0, 65, 10, 3, 10, 3,
+ax_anim 2, 0, 60, 3, 2, 3, 2,
+ax_anim_terminator
+sVictreebelAnims_3_4:
+ax_anim 2, 0, 67, -1, 1, -1, 1,
+ax_anim 2, 0, 68, -3, 3, -3, 3,
+ax_anim 4, 0, 66, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -2, 2, -2, 2,
+ax_anim 1, 2, 69, 8, -5, 8, -5,
+ax_anim 1, 0, 69, 12, -8, 12, -8,
+ax_anim 2, 0, 70, 17, -11, 17, -11,
+ax_anim 2, 1, 71, 18, -12, 18, -12,
+ax_anim 2, 0, 71, 17, -13, 17, -13,
+ax_anim 2, 0, 71, 18, -12, 18, -12,
+ax_anim 2, 0, 71, 17, -13, 17, -13,
+ax_anim 2, 0, 71, 18, -12, 18, -12,
+ax_anim 2, 0, 71, 13, -8, 13, -8,
+ax_anim 2, 0, 66, 8, -4, 8, -4,
+ax_anim_terminator
+sVictreebelAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 4, 0, 72, 0, 4, 0, 4,
+ax_anim 1, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 2, 75, 0, -6, 0, -6,
+ax_anim 1, 0, 75, 0, -11, 0, -11,
+ax_anim 2, 0, 76, -1, -14, -1, -14,
+ax_anim 2, 1, 77, -2, -15, -2, -15,
+ax_anim 2, 0, 77, -3, -15, -3, -15,
+ax_anim 2, 0, 77, -2, -15, -2, -15,
+ax_anim 2, 0, 77, -3, -15, -3, -15,
+ax_anim 2, 0, 77, -2, -15, -2, -15,
+ax_anim 2, 0, 77, -2, -11, -2, -11,
+ax_anim 2, 0, 72, -1, -4, -1, -4,
+ax_anim_terminator
+sVictreebelAnims_3_6:
+ax_anim 2, 0, 79, 1, 1, 1, 1,
+ax_anim 2, 0, 80, 3, 3, 3, 3,
+ax_anim 4, 0, 78, 4, 4, 4, 4,
+ax_anim 1, 0, 81, 2, 2, 2, 2,
+ax_anim 1, 2, 81, -8, -5, -8, -5,
+ax_anim 1, 0, 81, -12, -8, -12, -8,
+ax_anim 2, 0, 82, -17, -11, -17, -11,
+ax_anim 2, 1, 83, -18, -12, -18, -12,
+ax_anim 2, 0, 83, -17, -13, -17, -13,
+ax_anim 2, 0, 83, -18, -12, -18, -12,
+ax_anim 2, 0, 83, -17, -13, -17, -13,
+ax_anim 2, 0, 83, -18, -12, -18, -12,
+ax_anim 2, 0, 83, -13, -8, -13, -8,
+ax_anim 2, 0, 78, -8, -4, -8, -4,
+ax_anim_terminator
+sVictreebelAnims_3_7:
+ax_anim 2, 0, 85, 1, 0, 1, 0,
+ax_anim 2, 0, 86, 3, 0, 3, 0,
+ax_anim 4, 0, 84, 4, 0, 4, 0,
+ax_anim 1, 0, 87, 2, 0, 2, 0,
+ax_anim 1, 2, 87, -6, 0, -6, 0,
+ax_anim 1, 0, 87, -11, 0, -11, 0,
+ax_anim 2, 0, 88, -14, 1, -14, 1,
+ax_anim 2, 1, 89, -15, 2, -15, 2,
+ax_anim 2, 0, 89, -15, 3, -15, 3,
+ax_anim 2, 0, 89, -15, 2, -15, 2,
+ax_anim 2, 0, 89, -15, 3, -15, 3,
+ax_anim 2, 0, 89, -15, 2, -15, 2,
+ax_anim 2, 0, 89, -10, 3, -10, 3,
+ax_anim 2, 0, 84, -3, 2, -3, 2,
+ax_anim_terminator
+sVictreebelAnims_3_8:
+ax_anim 2, 0, 91, 1, -1, 1, -1,
+ax_anim 2, 0, 92, 3, -3, 3, -3,
+ax_anim 4, 0, 90, 4, -4, 4, -4,
+ax_anim 1, 0, 93, 2, -2, 2, -2,
+ax_anim 1, 2, 93, -6, 6, -6, 6,
+ax_anim 1, 0, 93, -13, 13, -13, 13,
+ax_anim 2, 0, 94, -16, 18, -16, 18,
+ax_anim 2, 1, 95, -16, 19, -16, 19,
+ax_anim 2, 0, 95, -15, 20, -15, 20,
+ax_anim 2, 0, 95, -16, 19, -16, 19,
+ax_anim 2, 0, 95, -15, 20, -15, 20,
+ax_anim 2, 0, 95, -16, 19, -16, 19,
+ax_anim 2, 0, 95, -10, 18, -10, 18,
+ax_anim 2, 0, 90, -3, 8, -3, 8,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_4_1:
+ax_anim 2, 0, 96, 0, -1, 0, -1,
+ax_anim 2, 0, 97, 0, -2, 0, -2,
+ax_anim 2, 0, 96, 0, -3, 0, -3,
+ax_anim 4, 2, 98, 0, -4, 0, -4,
+ax_anim 1, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 0, 1, 0, 1,
+ax_anim 2, 0, 99, 0, 6, 0, 6,
+ax_anim 2, 1, 99, 1, 6, 1, 6,
+ax_anim 2, 0, 99, 0, 6, 0, 6,
+ax_anim 2, 0, 99, 1, 6, 1, 6,
+ax_anim 2, 0, 99, 0, 6, 0, 6,
+ax_anim 2, 0, 99, 1, 6, 1, 6,
+ax_anim 2, 0, 99, 0, 6, 0, 6,
+ax_anim 2, 0, 96, 0, 2, 0, 2,
+ax_anim_terminator
+sVictreebelAnims_4_2:
+ax_anim 2, 0, 100, -1, -1, -1, -1,
+ax_anim 2, 0, 101, -2, -2, -2, -2,
+ax_anim 2, 0, 100, -3, -3, -3, -3,
+ax_anim 4, 2, 102, -4, -4, -4, -4,
+ax_anim 1, 0, 103, -2, -2, -2, -2,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 103, 6, 6, 6, 6,
+ax_anim 2, 1, 103, 7, 5, 7, 5,
+ax_anim 2, 0, 103, 6, 6, 6, 6,
+ax_anim 2, 0, 103, 7, 5, 7, 5,
+ax_anim 2, 0, 103, 6, 6, 6, 6,
+ax_anim 2, 0, 103, 7, 5, 7, 5,
+ax_anim 2, 0, 103, 6, 6, 6, 6,
+ax_anim 2, 0, 100, 2, 2, 2, 2,
+ax_anim_terminator
+sVictreebelAnims_4_3:
+ax_anim 2, 0, 104, -1, 0, -1, 0,
+ax_anim 2, 0, 105, -2, 0, -2, 0,
+ax_anim 2, 0, 104, -3, 0, -3, 0,
+ax_anim 4, 2, 106, -4, 0, -4, 0,
+ax_anim 1, 0, 107, -2, 0, -2, 0,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 6, 0, 6, 0,
+ax_anim 2, 1, 107, 6, 1, 6, 1,
+ax_anim 2, 0, 107, 6, 0, 6, 0,
+ax_anim 2, 0, 107, 6, 1, 6, 1,
+ax_anim 2, 0, 107, 6, 0, 6, 0,
+ax_anim 2, 0, 107, 6, 1, 6, 1,
+ax_anim 2, 0, 107, 6, 0, 6, 0,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim_terminator
+sVictreebelAnims_4_4:
+ax_anim 2, 0, 108, -1, 1, -1, 1,
+ax_anim 2, 0, 109, -2, 2, -2, 2,
+ax_anim 2, 0, 108, -3, 3, -3, 3,
+ax_anim 4, 2, 110, -4, 4, -4, 4,
+ax_anim 1, 0, 111, -2, 2, -2, 2,
+ax_anim 2, 0, 111, 1, -1, 1, -1,
+ax_anim 2, 0, 111, 6, -6, 6, -6,
+ax_anim 2, 1, 111, 7, -5, 7, -5,
+ax_anim 2, 0, 111, 6, -6, 6, -6,
+ax_anim 2, 0, 111, 7, -5, 7, -5,
+ax_anim 2, 0, 111, 6, -6, 6, -6,
+ax_anim 2, 0, 111, 7, -5, 7, -5,
+ax_anim 2, 0, 111, 6, -6, 6, -6,
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim_terminator
+sVictreebelAnims_4_5:
+ax_anim 2, 0, 112, 0, 1, 0, 1,
+ax_anim 2, 0, 113, 0, 2, 0, 2,
+ax_anim 2, 0, 112, 0, 3, 0, 3,
+ax_anim 4, 2, 114, 0, 4, 0, 4,
+ax_anim 1, 0, 115, 0, 2, 0, 2,
+ax_anim 2, 0, 115, 0, -1, 0, -1,
+ax_anim 2, 0, 115, 0, -6, 0, -6,
+ax_anim 2, 1, 115, 1, -6, 1, -6,
+ax_anim 2, 0, 115, 0, -6, 0, -6,
+ax_anim 2, 0, 115, 1, -6, 1, -6,
+ax_anim 2, 0, 115, 0, -6, 0, -6,
+ax_anim 2, 0, 115, 1, -6, 1, -6,
+ax_anim 2, 0, 115, 0, -6, 0, -6,
+ax_anim 2, 0, 112, 0, -2, 0, -2,
+ax_anim_terminator
+sVictreebelAnims_4_6:
+ax_anim 2, 0, 116, 1, 1, 1, 1,
+ax_anim 2, 0, 117, 2, 2, 2, 2,
+ax_anim 2, 0, 116, 3, 3, 3, 3,
+ax_anim 4, 2, 118, 4, 4, 4, 4,
+ax_anim 1, 0, 119, 2, 2, 2, 2,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, -6, -6, -6, -6,
+ax_anim 2, 1, 119, -7, -5, -7, -5,
+ax_anim 2, 0, 119, -6, -6, -6, -6,
+ax_anim 2, 0, 119, -7, -5, -7, -5,
+ax_anim 2, 0, 119, -6, -6, -6, -6,
+ax_anim 2, 0, 119, -7, -5, -7, -5,
+ax_anim 2, 0, 119, -6, -6, -6, -6,
+ax_anim 2, 0, 116, -2, -2, -2, -2,
+ax_anim_terminator
+sVictreebelAnims_4_7:
+ax_anim 2, 0, 120, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 2, 0, 2, 0,
+ax_anim 2, 0, 120, 3, 0, 3, 0,
+ax_anim 4, 2, 122, 4, 0, 4, 0,
+ax_anim 1, 0, 123, 2, 0, 2, 0,
+ax_anim 2, 0, 123, -1, 0, -1, 0,
+ax_anim 2, 0, 123, -6, 0, -6, 0,
+ax_anim 2, 1, 123, -6, 1, -6, 1,
+ax_anim 2, 0, 123, -6, 0, -6, 0,
+ax_anim 2, 0, 123, -6, 1, -6, 1,
+ax_anim 2, 0, 123, -6, 0, -6, 0,
+ax_anim 2, 0, 123, -6, 1, -6, 1,
+ax_anim 2, 0, 123, -6, 0, -6, 0,
+ax_anim 2, 0, 120, -2, 0, -2, 0,
+ax_anim_terminator
+sVictreebelAnims_4_8:
+ax_anim 2, 0, 124, 1, -1, 1, -1,
+ax_anim 2, 0, 125, 2, -2, 2, -2,
+ax_anim 2, 0, 124, 3, -3, 3, -3,
+ax_anim 4, 2, 126, 4, -4, 4, -4,
+ax_anim 1, 0, 127, 2, -2, 2, -2,
+ax_anim 2, 0, 127, -1, 1, -1, 1,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 1, 127, -7, 5, -7, 5,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, -7, 5, -7, 5,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 127, -7, 5, -7, 5,
+ax_anim 2, 0, 127, -6, 6, -6, 6,
+ax_anim 2, 0, 124, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_5_1:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_5_2:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 2, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_5_3:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_5_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_5_5:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 2, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_5_6:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_5_7:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_5_8:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sVictreebelAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sVictreebelAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sVictreebelAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sVictreebelAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sVictreebelAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sVictreebelAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sVictreebelAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_8_1:
+ax_anim 35, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, -1, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 5, 0, 147, 0, -4, 0, 0,
+ax_anim 5, 0, 146, 0, -4, 0, 0,
+ax_anim 5, 0, 148, 0, -4, 0, 0,
+ax_anim 3, 0, 148, 0, -3, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim 3, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_8_2:
+ax_anim 35, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, -1, 0, 0,
+ax_anim 3, 0, 150, 0, -3, 0, 0,
+ax_anim 5, 0, 150, 0, -4, 0, 0,
+ax_anim 5, 0, 149, 0, -4, 0, 0,
+ax_anim 5, 0, 151, 0, -4, 0, 0,
+ax_anim 3, 0, 151, 0, -3, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim 3, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_8_3:
+ax_anim 35, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, -1, 0, 0,
+ax_anim 3, 0, 153, 0, -3, 0, 0,
+ax_anim 5, 0, 153, 0, -4, 0, 0,
+ax_anim 5, 0, 152, 0, -4, 0, 0,
+ax_anim 5, 0, 154, 0, -4, 0, 0,
+ax_anim 3, 0, 154, 0, -3, 0, 0,
+ax_anim 3, 0, 154, 0, -1, 0, 0,
+ax_anim 3, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_8_4:
+ax_anim 35, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, -1, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 5, 0, 156, 0, -4, 0, 0,
+ax_anim 5, 0, 155, 0, -4, 0, 0,
+ax_anim 5, 0, 157, 0, -4, 0, 0,
+ax_anim 3, 0, 157, 0, -3, 0, 0,
+ax_anim 3, 0, 157, 0, -1, 0, 0,
+ax_anim 3, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_8_5:
+ax_anim 35, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 159, 0, -1, 0, 0,
+ax_anim 3, 0, 159, 0, -3, 0, 0,
+ax_anim 5, 0, 159, 0, -4, 0, 0,
+ax_anim 5, 0, 158, 0, -4, 0, 0,
+ax_anim 5, 0, 160, 0, -4, 0, 0,
+ax_anim 3, 0, 160, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -1, 0, 0,
+ax_anim 3, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_8_6:
+ax_anim 35, 0, 161, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, -1, 0, 0,
+ax_anim 3, 0, 162, 0, -3, 0, 0,
+ax_anim 5, 0, 162, 0, -4, 0, 0,
+ax_anim 5, 0, 161, 0, -4, 0, 0,
+ax_anim 5, 0, 163, 0, -4, 0, 0,
+ax_anim 3, 0, 163, 0, -3, 0, 0,
+ax_anim 3, 0, 163, 0, -1, 0, 0,
+ax_anim 3, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_8_7:
+ax_anim 35, 0, 164, 0, 0, 0, 0,
+ax_anim 3, 0, 165, 0, -1, 0, 0,
+ax_anim 3, 0, 165, 0, -3, 0, 0,
+ax_anim 5, 0, 165, 0, -4, 0, 0,
+ax_anim 5, 0, 164, 0, -4, 0, 0,
+ax_anim 5, 0, 166, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -3, 0, 0,
+ax_anim 3, 0, 166, 0, -1, 0, 0,
+ax_anim 3, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_8_8:
+ax_anim 35, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 168, 0, -1, 0, 0,
+ax_anim 3, 0, 168, 0, -3, 0, 0,
+ax_anim 5, 0, 168, 0, -4, 0, 0,
+ax_anim 5, 0, 167, 0, -4, 0, 0,
+ax_anim 5, 0, 169, 0, -4, 0, 0,
+ax_anim 3, 0, 169, 0, -3, 0, 0,
+ax_anim 3, 0, 169, 0, -1, 0, 0,
+ax_anim 3, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 15, 7, 15,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 15, -7, 15,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 17, 3, 17, 3,
+ax_anim 2, 0, 172, 21, 10, 21, 10,
+ax_anim 3, 0, 173, 19, 21, 19, 21,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 20, -2, 20, -2,
+ax_anim 2, 3, 173, 16, 4, 16, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 18, -21, 18, -21,
+ax_anim 2, 3, 172, 20, -15, 20, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -10, 9, -10,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -18, -21, -18, -21,
+ax_anim 2, 3, 176, -20, -15, -20, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -20, -2, -20, -2,
+ax_anim 2, 3, 175, -16, 4, -16, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -17, 3, -17, 3,
+ax_anim 2, 0, 176, -21, 10, -21, 10,
+ax_anim 3, 0, 175, -19, 21, -19, 21,
+ax_anim 2, 3, 174, -11, 21, -11, 21,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVictreebelAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sVictreebelGfx1:
+.incbin "baserom.gba", 0x816704, 0x200
+sVictreebelSprites1:
+ax_sprite sVictreebelGfx1, 0x200
+ax_sprite_terminator
+sVictreebelGfx2:
+.incbin "baserom.gba", 0x816914, 0x200
+sVictreebelSprites2:
+ax_sprite sVictreebelGfx2, 0x200
+ax_sprite_terminator
+sVictreebelGfx3:
+.incbin "baserom.gba", 0x816B24, 0x200
+sVictreebelSprites3:
+ax_sprite sVictreebelGfx3, 0x200
+ax_sprite_terminator
+sVictreebelGfx4:
+.incbin "baserom.gba", 0x816D34, 0x200
+sVictreebelSprites4:
+ax_sprite sVictreebelGfx4, 0x200
+ax_sprite_terminator
+sVictreebelGfx5:
+.incbin "baserom.gba", 0x816F44, 0x200
+sVictreebelSprites5:
+ax_sprite sVictreebelGfx5, 0x200
+ax_sprite_terminator
+sVictreebelGfx6:
+.incbin "baserom.gba", 0x817154, 0x200
+sVictreebelSprites6:
+ax_sprite sVictreebelGfx6, 0x200
+ax_sprite_terminator
+sVictreebelGfx7:
+.incbin "baserom.gba", 0x817364, 0x100
+sVictreebelSprites7:
+ax_sprite sVictreebelGfx7, 0x100
+ax_sprite_terminator
+sVictreebelGfx8:
+.incbin "baserom.gba", 0x817474, 0x100
+sVictreebelSprites8:
+ax_sprite sVictreebelGfx8, 0x100
+ax_sprite_terminator
+sVictreebelGfx9:
+.incbin "baserom.gba", 0x817584, 0x100
+sVictreebelSprites9:
+ax_sprite sVictreebelGfx9, 0x100
+ax_sprite_terminator
+sVictreebelGfx10:
+.incbin "baserom.gba", 0x817694, 0x200
+sVictreebelSprites10:
+ax_sprite sVictreebelGfx10, 0x200
+ax_sprite_terminator
+sVictreebelGfx11:
+.incbin "baserom.gba", 0x8178A4, 0x200
+sVictreebelSprites11:
+ax_sprite sVictreebelGfx11, 0x200
+ax_sprite_terminator
+sVictreebelGfx12:
+.incbin "baserom.gba", 0x817AB4, 0x200
+sVictreebelSprites12:
+ax_sprite sVictreebelGfx12, 0x200
+ax_sprite_terminator
+sVictreebelGfx13:
+.incbin "baserom.gba", 0x817CC4, 0x200
+sVictreebelSprites13:
+ax_sprite sVictreebelGfx13, 0x200
+ax_sprite_terminator
+sVictreebelGfx14:
+.incbin "baserom.gba", 0x817ED4, 0x200
+sVictreebelSprites14:
+ax_sprite sVictreebelGfx14, 0x200
+ax_sprite_terminator
+sVictreebelGfx15:
+.incbin "baserom.gba", 0x8180E4, 0x200
+sVictreebelSprites15:
+ax_sprite sVictreebelGfx15, 0x200
+ax_sprite_terminator
+sVictreebelGfx16:
+.incbin "baserom.gba", 0x8182F4, 0x200
+sVictreebelSprites16:
+ax_sprite sVictreebelGfx16, 0x200
+ax_sprite_terminator
+sVictreebelGfx17:
+.incbin "baserom.gba", 0x818504, 0x200
+sVictreebelSprites17:
+ax_sprite sVictreebelGfx17, 0x200
+ax_sprite_terminator
+sVictreebelGfx18:
+.incbin "baserom.gba", 0x818714, 0x200
+sVictreebelSprites18:
+ax_sprite sVictreebelGfx18, 0x200
+ax_sprite_terminator
+sVictreebelGfx19:
+.incbin "baserom.gba", 0x818924, 0x200
+sVictreebelSprites19:
+ax_sprite sVictreebelGfx19, 0x200
+ax_sprite_terminator
+sVictreebelGfx20:
+.incbin "baserom.gba", 0x818B34, 0x200
+sVictreebelSprites20:
+ax_sprite sVictreebelGfx20, 0x200
+ax_sprite_terminator
+sVictreebelGfx21:
+.incbin "baserom.gba", 0x818D44, 0x200
+sVictreebelSprites21:
+ax_sprite sVictreebelGfx21, 0x200
+ax_sprite_terminator
+sVictreebelGfx22:
+.incbin "baserom.gba", 0x818F54, 0x200
+sVictreebelSprites22:
+ax_sprite sVictreebelGfx22, 0x200
+ax_sprite_terminator
+sVictreebelGfx23:
+.incbin "baserom.gba", 0x819164, 0x200
+sVictreebelSprites23:
+ax_sprite sVictreebelGfx23, 0x200
+ax_sprite_terminator
+sVictreebelGfx24:
+.incbin "baserom.gba", 0x819374, 0x200
+sVictreebelSprites24:
+ax_sprite sVictreebelGfx24, 0x200
+ax_sprite_terminator
+sVictreebelGfx25:
+.incbin "baserom.gba", 0x819584, 0xE0
+sVictreebelGfx25_1:
+.incbin "baserom.gba", 0x819664, 0x60
+sVictreebelGfx25_2:
+.incbin "baserom.gba", 0x8196C4, 0x40
+sVictreebelSprites25:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx25, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx26:
+.incbin "baserom.gba", 0x819744, 0x20
+sVictreebelGfx26_1:
+.incbin "baserom.gba", 0x819764, 0x20
+sVictreebelGfx26_2:
+.incbin "baserom.gba", 0x819784, 0x20
+sVictreebelGfx26_3:
+.incbin "baserom.gba", 0x8197A4, 0x60
+sVictreebelSprites26:
+ax_sprite 0, 0x80
+ax_sprite sVictreebelGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVictreebelGfx26_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx26_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx26_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx27:
+.incbin "baserom.gba", 0x819854, 0x60
+sVictreebelGfx27_1:
+.incbin "baserom.gba", 0x8198B4, 0x60
+sVictreebelGfx27_2:
+.incbin "baserom.gba", 0x819914, 0x40
+sVictreebelGfx27_3:
+.incbin "baserom.gba", 0x819954, 0x40
+sVictreebelSprites27:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx27_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx28:
+.incbin "baserom.gba", 0x8199E4, 0x180
+sVictreebelGfx28_1:
+.incbin "baserom.gba", 0x819B64, 0x40
+sVictreebelSprites28:
+ax_sprite sVictreebelGfx28, 0x180
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx29:
+.incbin "baserom.gba", 0x819BCC, 0xC0
+sVictreebelSprites29:
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx29, 0xc0
+ax_sprite_terminator
+sVictreebelGfx30:
+.incbin "baserom.gba", 0x819CA4, 0x60
+sVictreebelGfx30_1:
+.incbin "baserom.gba", 0x819D04, 0x60
+sVictreebelGfx30_2:
+.incbin "baserom.gba", 0x819D64, 0xC0
+sVictreebelSprites30:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx30_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx31:
+.incbin "baserom.gba", 0x819E64, 0x60
+sVictreebelGfx31_1:
+.incbin "baserom.gba", 0x819EC4, 0x60
+sVictreebelGfx31_2:
+.incbin "baserom.gba", 0x819F24, 0x60
+sVictreebelGfx31_3:
+.incbin "baserom.gba", 0x819F84, 0x40
+sVictreebelSprites31:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx31_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx32:
+.incbin "baserom.gba", 0x81A014, 0x40
+sVictreebelGfx32_1:
+.incbin "baserom.gba", 0x81A054, 0x40
+sVictreebelGfx32_2:
+.incbin "baserom.gba", 0x81A094, 0x60
+sVictreebelGfx32_3:
+.incbin "baserom.gba", 0x81A0F4, 0x40
+sVictreebelSprites32:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx32_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx32_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sVictreebelGfx33:
+.incbin "baserom.gba", 0x81A184, 0x40
+sVictreebelGfx33_1:
+.incbin "baserom.gba", 0x81A1C4, 0x160
+sVictreebelSprites33:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx33_1, 0x160
+ax_sprite_terminator
+sVictreebelGfx34:
+.incbin "baserom.gba", 0x81A34C, 0x40
+sVictreebelGfx34_1:
+.incbin "baserom.gba", 0x81A38C, 0x60
+sVictreebelGfx34_2:
+.incbin "baserom.gba", 0x81A3EC, 0x60
+sVictreebelGfx34_3:
+.incbin "baserom.gba", 0x81A44C, 0x60
+sVictreebelSprites34:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx35:
+.incbin "baserom.gba", 0x81A4FC, 0x60
+sVictreebelGfx35_1:
+.incbin "baserom.gba", 0x81A55C, 0x80
+sVictreebelGfx35_2:
+.incbin "baserom.gba", 0x81A5DC, 0x20
+sVictreebelGfx35_3:
+.incbin "baserom.gba", 0x81A5FC, 0x20
+sVictreebelSprites35:
+ax_sprite sVictreebelGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx35_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sVictreebelGfx35_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVictreebelGfx35_3, 0x20
+ax_sprite_terminator
+sVictreebelGfx36:
+.incbin "baserom.gba", 0x81A65C, 0x60
+sVictreebelGfx36_1:
+.incbin "baserom.gba", 0x81A6BC, 0x60
+sVictreebelGfx36_2:
+.incbin "baserom.gba", 0x81A71C, 0x60
+sVictreebelGfx36_3:
+.incbin "baserom.gba", 0x81A77C, 0x40
+sVictreebelSprites36:
+ax_sprite sVictreebelGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx36_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx36_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx37:
+.incbin "baserom.gba", 0x81A804, 0x120
+sVictreebelGfx37_1:
+.incbin "baserom.gba", 0x81A924, 0x40
+sVictreebelSprites37:
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx37, 0x120
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx38:
+.incbin "baserom.gba", 0x81A994, 0x60
+sVictreebelGfx38_1:
+.incbin "baserom.gba", 0x81A9F4, 0x40
+sVictreebelGfx38_2:
+.incbin "baserom.gba", 0x81AA34, 0x20
+sVictreebelGfx38_3:
+.incbin "baserom.gba", 0x81AA54, 0x40
+sVictreebelSprites38:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx38, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx38_1, 0x40
+ax_sprite 0, 0x60
+ax_sprite sVictreebelGfx38_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx38_3, 0x40
+ax_sprite_terminator
+sVictreebelGfx39:
+.incbin "baserom.gba", 0x81AADC, 0x40
+sVictreebelGfx39_1:
+.incbin "baserom.gba", 0x81AB1C, 0x60
+sVictreebelGfx39_2:
+.incbin "baserom.gba", 0x81AB7C, 0x60
+sVictreebelGfx39_3:
+.incbin "baserom.gba", 0x81ABDC, 0x60
+sVictreebelSprites39:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx39, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx40:
+.incbin "baserom.gba", 0x81AC8C, 0x100
+sVictreebelGfx40_1:
+.incbin "baserom.gba", 0x81AD8C, 0x40
+sVictreebelSprites40:
+ax_sprite 0, 0x80
+ax_sprite sVictreebelGfx40, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx40_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx41:
+.incbin "baserom.gba", 0x81ADFC, 0x40
+sVictreebelGfx41_1:
+.incbin "baserom.gba", 0x81AE3C, 0x160
+sVictreebelSprites41:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx41_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx42:
+.incbin "baserom.gba", 0x81AFCC, 0x60
+sVictreebelGfx42_1:
+.incbin "baserom.gba", 0x81B02C, 0x80
+sVictreebelGfx42_2:
+.incbin "baserom.gba", 0x81B0AC, 0x60
+sVictreebelGfx42_3:
+.incbin "baserom.gba", 0x81B10C, 0x20
+sVictreebelSprites42:
+ax_sprite sVictreebelGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx42_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx42_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx42_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sVictreebelGfx43:
+.incbin "baserom.gba", 0x81B174, 0x60
+sVictreebelGfx43_1:
+.incbin "baserom.gba", 0x81B1D4, 0x100
+sVictreebelGfx43_2:
+.incbin "baserom.gba", 0x81B2D4, 0x40
+sVictreebelSprites43:
+ax_sprite sVictreebelGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx43_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx43_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx44:
+.incbin "baserom.gba", 0x81B34C, 0x40
+sVictreebelGfx44_1:
+.incbin "baserom.gba", 0x81B38C, 0x100
+sVictreebelGfx44_2:
+.incbin "baserom.gba", 0x81B48C, 0x40
+sVictreebelSprites44:
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx44_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVictreebelGfx44_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVictreebelGfx45:
+.incbin "baserom.gba", 0x81B50C, 0x40
+sVictreebelGfx45_1:
+.incbin "baserom.gba", 0x81B54C, 0x40
+sVictreebelGfx45_2:
+.incbin "baserom.gba", 0x81B58C, 0x40
+sVictreebelGfx45_3:
+.incbin "baserom.gba", 0x81B5CC, 0x40
+sVictreebelSprites45:
+ax_sprite sVictreebelGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx45_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx45_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVictreebelGfx45_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sVictreebelGfx46:
+.incbin "baserom.gba", 0x81B654, 0x200
+sVictreebelSprites46:
+ax_sprite sVictreebelGfx46, 0x200
+ax_sprite_terminator
+sVictreebelGfx47:
+.incbin "baserom.gba", 0x81B864, 0x200
+sVictreebelSprites47:
+ax_sprite sVictreebelGfx47, 0x200
+ax_sprite_terminator
+sVictreebelGfx48:
+.incbin "baserom.gba", 0x81BA74, 0x200
+sVictreebelSprites48:
+ax_sprite sVictreebelGfx48, 0x200
+ax_sprite_terminator
+sVictreebelGfx49:
+.incbin "baserom.gba", 0x81BC84, 0x200
+sVictreebelSprites49:
+ax_sprite sVictreebelGfx49, 0x200
+ax_sprite_terminator
+sVictreebelGfx50:
+.incbin "baserom.gba", 0x81BE94, 0x200
+sVictreebelSprites50:
+ax_sprite sVictreebelGfx50, 0x200
+ax_sprite_terminator
+sVictreebelGfx51:
+.incbin "baserom.gba", 0x81C0A4, 0x200
+sVictreebelSprites51:
+ax_sprite sVictreebelGfx51, 0x200
+ax_sprite_terminator
+sVictreebelGfx52:
+.incbin "baserom.gba", 0x81C2B4, 0x200
+sVictreebelSprites52:
+ax_sprite sVictreebelGfx52, 0x200
+ax_sprite_terminator
+sAxPosesVictreebel:
+.4byte sVictreebelPose1
+.4byte sVictreebelPose2
+.4byte sVictreebelPose3
+.4byte sVictreebelPose4
+.4byte sVictreebelPose5
+.4byte sVictreebelPose6
+.4byte sVictreebelPose7
+.4byte sVictreebelPose8
+.4byte sVictreebelPose9
+.4byte sVictreebelPose10
+.4byte sVictreebelPose11
+.4byte sVictreebelPose12
+.4byte sVictreebelPose13
+.4byte sVictreebelPose14
+.4byte sVictreebelPose15
+.4byte sVictreebelPose16
+.4byte sVictreebelPose17
+.4byte sVictreebelPose18
+.4byte sVictreebelPose19
+.4byte sVictreebelPose20
+.4byte sVictreebelPose21
+.4byte sVictreebelPose22
+.4byte sVictreebelPose23
+.4byte sVictreebelPose24
+.4byte sVictreebelPose25
+.4byte sVictreebelPose26
+.4byte sVictreebelPose27
+.4byte sVictreebelPose28
+.4byte sVictreebelPose29
+.4byte sVictreebelPose30
+.4byte sVictreebelPose31
+.4byte sVictreebelPose32
+.4byte sVictreebelPose33
+.4byte sVictreebelPose34
+.4byte sVictreebelPose35
+.4byte sVictreebelPose36
+.4byte sVictreebelPose37
+.4byte sVictreebelPose38
+.4byte sVictreebelPose39
+.4byte sVictreebelPose40
+.4byte sVictreebelPose41
+.4byte sVictreebelPose42
+.4byte sVictreebelPose43
+.4byte sVictreebelPose44
+.4byte sVictreebelPose45
+.4byte sVictreebelPose46
+.4byte sVictreebelPose47
+.4byte sVictreebelPose48
+.4byte sVictreebelPose49
+.4byte sVictreebelPose50
+.4byte sVictreebelPose51
+.4byte sVictreebelPose52
+.4byte sVictreebelPose53
+.4byte sVictreebelPose54
+.4byte sVictreebelPose55
+.4byte sVictreebelPose56
+.4byte sVictreebelPose57
+.4byte sVictreebelPose58
+.4byte sVictreebelPose59
+.4byte sVictreebelPose60
+.4byte sVictreebelPose61
+.4byte sVictreebelPose62
+.4byte sVictreebelPose63
+.4byte sVictreebelPose64
+.4byte sVictreebelPose65
+.4byte sVictreebelPose66
+.4byte sVictreebelPose67
+.4byte sVictreebelPose68
+.4byte sVictreebelPose69
+.4byte sVictreebelPose70
+.4byte sVictreebelPose71
+.4byte sVictreebelPose72
+.4byte sVictreebelPose73
+.4byte sVictreebelPose74
+.4byte sVictreebelPose75
+.4byte sVictreebelPose76
+.4byte sVictreebelPose77
+.4byte sVictreebelPose78
+.4byte sVictreebelPose79
+.4byte sVictreebelPose80
+.4byte sVictreebelPose81
+.4byte sVictreebelPose82
+.4byte sVictreebelPose83
+.4byte sVictreebelPose84
+.4byte sVictreebelPose85
+.4byte sVictreebelPose86
+.4byte sVictreebelPose87
+.4byte sVictreebelPose88
+.4byte sVictreebelPose89
+.4byte sVictreebelPose90
+.4byte sVictreebelPose91
+.4byte sVictreebelPose92
+.4byte sVictreebelPose93
+.4byte sVictreebelPose94
+.4byte sVictreebelPose95
+.4byte sVictreebelPose96
+.4byte sVictreebelPose97
+.4byte sVictreebelPose98
+.4byte sVictreebelPose99
+.4byte sVictreebelPose100
+.4byte sVictreebelPose101
+.4byte sVictreebelPose102
+.4byte sVictreebelPose103
+.4byte sVictreebelPose104
+.4byte sVictreebelPose105
+.4byte sVictreebelPose106
+.4byte sVictreebelPose107
+.4byte sVictreebelPose108
+.4byte sVictreebelPose109
+.4byte sVictreebelPose110
+.4byte sVictreebelPose111
+.4byte sVictreebelPose112
+.4byte sVictreebelPose113
+.4byte sVictreebelPose114
+.4byte sVictreebelPose115
+.4byte sVictreebelPose116
+.4byte sVictreebelPose117
+.4byte sVictreebelPose118
+.4byte sVictreebelPose119
+.4byte sVictreebelPose120
+.4byte sVictreebelPose121
+.4byte sVictreebelPose122
+.4byte sVictreebelPose123
+.4byte sVictreebelPose124
+.4byte sVictreebelPose125
+.4byte sVictreebelPose126
+.4byte sVictreebelPose127
+.4byte sVictreebelPose128
+.4byte sVictreebelPose129
+.4byte sVictreebelPose130
+.4byte sVictreebelPose131
+.4byte sVictreebelPose132
+.4byte sVictreebelPose133
+.4byte sVictreebelPose134
+.4byte sVictreebelPose135
+.4byte sVictreebelPose136
+.4byte sVictreebelPose137
+.4byte sVictreebelPose138
+.4byte sVictreebelPose139
+.4byte sVictreebelPose140
+.4byte sVictreebelPose141
+.4byte sVictreebelPose142
+.4byte sVictreebelPose143
+.4byte sVictreebelPose144
+.4byte sVictreebelPose145
+.4byte sVictreebelPose146
+.4byte sVictreebelPose147
+.4byte sVictreebelPose148
+.4byte sVictreebelPose149
+.4byte sVictreebelPose150
+.4byte sVictreebelPose151
+.4byte sVictreebelPose152
+.4byte sVictreebelPose153
+.4byte sVictreebelPose154
+.4byte sVictreebelPose155
+.4byte sVictreebelPose156
+.4byte sVictreebelPose157
+.4byte sVictreebelPose158
+.4byte sVictreebelPose159
+.4byte sVictreebelPose160
+.4byte sVictreebelPose161
+.4byte sVictreebelPose162
+.4byte sVictreebelPose163
+.4byte sVictreebelPose164
+.4byte sVictreebelPose165
+.4byte sVictreebelPose166
+.4byte sVictreebelPose167
+.4byte sVictreebelPose168
+.4byte sVictreebelPose169
+.4byte sVictreebelPose170
+.4byte sVictreebelPose171
+.4byte sVictreebelPose172
+.4byte sVictreebelPose173
+.4byte sVictreebelPose174
+.4byte sVictreebelPose175
+.4byte sVictreebelPose176
+.4byte sVictreebelPose177
+.4byte sVictreebelPose178
+.4byte sVictreebelPose179
+.4byte sVictreebelPose180
+.4byte sVictreebelPose181
+.4byte sVictreebelPose182
+.4byte sVictreebelPose183
+.4byte sVictreebelPose184
+.4byte sVictreebelPose185
+.4byte sVictreebelPose186
+.4byte sVictreebelPose187
+.4byte sVictreebelPose188
+.4byte sVictreebelPose189
+.4byte sVictreebelPose190
+.4byte sVictreebelPose191
+.4byte sVictreebelPose192
+.4byte sVictreebelPose193
+.4byte sVictreebelPose194
+.4byte sVictreebelPose195
+.4byte sVictreebelPose196
+.4byte sVictreebelPose197
+.4byte sVictreebelPose198
+.4byte sVictreebelPose199
+.4byte sVictreebelPose200
+.4byte sVictreebelPose201
+.4byte sVictreebelPose202
+.4byte sVictreebelPose203
+.4byte sVictreebelPose204
+.4byte sVictreebelPose205
+.4byte sVictreebelPose206
+.4byte sVictreebelPose207
+.4byte sVictreebelPose208
+.4byte sVictreebelPose209
+.4byte sVictreebelPose210
+.4byte sVictreebelPose211
+.4byte sVictreebelPose212
+.4byte sVictreebelPose213
+.4byte sVictreebelPose214
+.4byte sVictreebelPose215
+.4byte sVictreebelPose216
+.4byte sVictreebelPose217
+.4byte sVictreebelPose218
+.4byte sVictreebelPose219
+.4byte sVictreebelPose220
+.4byte sVictreebelPose221
+.4byte sVictreebelPose222
+.4byte sVictreebelPose223
+.4byte sVictreebelPose224
+.4byte sVictreebelPose225
+.4byte sVictreebelPose226
+sAxPositionsVictreebel:
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte    0,  -16, 	 -11,   -3, 	  10,   -3, 	   0,   -9
+.2byte    0,  -16, 	 -12,   -9, 	  11,   -9, 	   0,   -9
+.2byte    0,  -16, 	  -8,   -3, 	   7,   -9, 	  -1,   -9
+.2byte    0,  -16, 	  -8,   -2, 	   7,   -6, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,   -4, 	   6,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -2, 	   4,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -5,    0, 	   4,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -5, 	   3,  -11, 	  -1,   -9
+.2byte    0,  -16, 	   7,   -4, 	  -7,  -12, 	  -2,   -9
+.2byte    0,  -16, 	   7,   -2, 	  -8,   -8, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -7, 	  -7,  -12, 	  -1,   -9
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	  10,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -8,   -2, 	   0,  -10
+.2byte   -1,  -16, 	   7,  -12, 	  -9,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  -5,  -11, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -15, 	  -5,   -9, 	   4,    0, 	   1,  -11
+.2byte   -1,  -16, 	  -4,  -13, 	   4,   -6, 	   1,  -11
+.2byte    0,  -16, 	  -8,   -9, 	   7,   -3, 	   1,  -10
+.2byte    0,  -16, 	  -8,   -6, 	   7,   -2, 	   1,  -10
+.2byte    0,  -15, 	  -7,  -11, 	   8,   -4, 	   1,  -10
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte    0,  -16, 	 -11,   -3, 	  10,   -3, 	   0,   -9
+.2byte    0,  -16, 	 -12,   -9, 	  11,   -9, 	   0,   -9
+.2byte    0,  -16, 	  -8,   -3, 	   7,   -9, 	  -1,   -9
+.2byte    0,  -16, 	  -8,   -2, 	   7,   -6, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,   -4, 	   6,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -2, 	   4,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -5,    0, 	   4,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -5, 	   3,  -11, 	  -1,   -9
+.2byte    0,  -16, 	   7,   -4, 	  -7,  -12, 	  -2,   -9
+.2byte    0,  -16, 	   7,   -2, 	  -8,   -8, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -7, 	  -7,  -12, 	  -1,   -9
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	  10,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -8,   -2, 	   0,  -10
+.2byte   -1,  -16, 	   7,  -12, 	  -9,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  -5,  -11, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -15, 	  -5,   -9, 	   4,    0, 	   1,  -11
+.2byte   -1,  -16, 	  -4,  -13, 	   4,   -6, 	   1,  -11
+.2byte    0,  -16, 	  -8,   -9, 	   7,   -3, 	   1,  -10
+.2byte    0,  -16, 	  -8,   -6, 	   7,   -2, 	   1,  -10
+.2byte    0,  -15, 	  -7,  -11, 	   8,   -4, 	   1,  -10
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte    0,  -16, 	 -11,   -3, 	  10,   -3, 	   0,   -9
+.2byte    0,  -16, 	 -12,   -9, 	  11,   -9, 	   0,   -9
+.2byte   -3,  -13, 	  -8,  -12, 	   4,    0, 	  -1,   -7
+.2byte    1,  -14, 	   5,    1, 	   5,   -8, 	   0,   -8
+.2byte    1,  -14, 	   5,    1, 	   5,   -8, 	   0,   -8
+.2byte    0,  -16, 	  -8,   -3, 	   7,   -9, 	  -1,   -9
+.2byte    0,  -16, 	  -8,   -2, 	   7,   -6, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,   -4, 	   6,  -11, 	  -1,   -9
+.2byte    4,  -14, 	   0,  -14, 	   0,    0, 	   1,   -8
+.2byte    0,  -13, 	   8,    0, 	  -8,  -10, 	  -1,   -7
+.2byte    0,  -13, 	   8,    0, 	  -8,  -10, 	  -1,   -7
+.2byte    0,  -15, 	  -4,   -2, 	   4,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -5,    0, 	   4,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -5, 	   3,  -11, 	  -1,   -9
+.2byte    0,  -16, 	  -8,  -12, 	   4,   -1, 	  -2,  -10
+.2byte    0,  -14, 	  13,   -5, 	 -10,    2, 	  -1,   -7
+.2byte    0,  -14, 	  13,   -5, 	 -10,    2, 	  -1,   -7
+.2byte    0,  -16, 	   7,   -4, 	  -7,  -12, 	  -2,   -9
+.2byte    0,  -16, 	   7,   -2, 	  -8,   -8, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -7, 	  -7,  -12, 	  -1,   -9
+.2byte   -2,  -16, 	  -8,   -1, 	   8,  -11, 	  -1,  -10
+.2byte    2,  -14, 	  11,  -18, 	   1,    4, 	   0,   -9
+.2byte    2,  -14, 	  11,  -18, 	   1,    4, 	   0,   -9
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	  10,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte    4,  -13, 	   1,    5, 	  -5,  -12, 	   0,   -7
+.2byte    0,  -12, 	  -4,  -21, 	  -9,   -1, 	   0,   -8
+.2byte    0,  -12, 	  -4,  -21, 	  -9,   -1, 	   0,   -8
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -8,   -2, 	   0,  -10
+.2byte   -1,  -16, 	   7,  -12, 	  -9,   -7, 	   0,  -10
+.2byte    1,  -16, 	   7,   -1, 	  -9,  -11, 	   0,  -10
+.2byte   -3,  -14, 	 -12,  -18, 	  -2,    4, 	  -1,   -9
+.2byte   -3,  -14, 	 -12,  -18, 	  -2,    4, 	  -1,   -9
+.2byte   -1,  -15, 	  -5,  -11, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -15, 	  -5,   -9, 	   4,    0, 	   1,  -11
+.2byte   -1,  -16, 	  -4,  -13, 	   4,   -6, 	   1,  -11
+.2byte   -1,  -16, 	   7,  -12, 	  -5,   -1, 	   1,  -10
+.2byte   -1,  -14, 	 -14,   -5, 	   9,    2, 	   0,   -7
+.2byte   -1,  -14, 	 -14,   -5, 	   9,    2, 	   0,   -7
+.2byte    0,  -16, 	  -8,   -9, 	   7,   -3, 	   1,  -10
+.2byte    0,  -16, 	  -8,   -6, 	   7,   -2, 	   1,  -10
+.2byte    0,  -15, 	  -7,  -11, 	   8,   -4, 	   1,  -10
+.2byte   -5,  -14, 	  -1,  -14, 	  -1,    0, 	  -2,   -8
+.2byte   -1,  -13, 	  -9,    0, 	   7,  -10, 	   0,   -7
+.2byte   -1,  -13, 	  -9,    0, 	   7,  -10, 	   0,   -7
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte    0,  -16, 	 -11,   -3, 	  10,   -3, 	   0,   -9
+.2byte    0,  -16, 	 -12,   -9, 	  11,   -9, 	   0,   -9
+.2byte    0,   -3, 	  -9,  -17, 	   8,  -17, 	   0,   -9
+.2byte    0,  -16, 	  -8,   -3, 	   7,   -9, 	  -1,   -9
+.2byte    0,  -16, 	  -8,   -2, 	   7,   -6, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,   -4, 	   6,  -11, 	  -1,   -9
+.2byte    4,   -7, 	  -1,  -20, 	 -10,  -17, 	  -2,  -11
+.2byte    0,  -15, 	  -4,   -2, 	   4,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -5,    0, 	   4,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -5, 	   3,  -11, 	  -1,   -9
+.2byte    6,   -9, 	  -5,  -17, 	  -9,  -11, 	   0,   -9
+.2byte    0,  -16, 	   7,   -4, 	  -7,  -12, 	  -2,   -9
+.2byte    0,  -16, 	   7,   -2, 	  -8,   -8, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -7, 	  -7,  -12, 	  -1,   -9
+.2byte    3,  -13, 	 -11,  -13, 	  -2,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	  10,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte    0,  -14, 	   9,  -12, 	 -10,  -12, 	   0,   -8
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -8,   -2, 	   0,  -10
+.2byte   -1,  -16, 	   7,  -12, 	  -9,   -7, 	   0,  -10
+.2byte   -4,  -13, 	  10,  -13, 	   1,   -9, 	   0,  -11
+.2byte   -1,  -15, 	  -5,  -11, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -15, 	  -5,   -9, 	   4,    0, 	   1,  -11
+.2byte   -1,  -16, 	  -4,  -13, 	   4,   -6, 	   1,  -11
+.2byte   -7,   -9, 	   4,  -17, 	   8,  -11, 	  -1,   -9
+.2byte    0,  -16, 	  -8,   -9, 	   7,   -3, 	   1,  -10
+.2byte    0,  -16, 	  -8,   -6, 	   7,   -2, 	   1,  -10
+.2byte    0,  -15, 	  -7,  -11, 	   8,   -4, 	   1,  -10
+.2byte   -5,   -7, 	   0,  -20, 	   9,  -17, 	   1,  -11
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte   -1,  -16, 	  -9,   -9, 	   6,   -3, 	   0,  -10
+.2byte   -2,  -15, 	  -6,  -11, 	   2,   -2, 	   0,  -11
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte    1,  -16, 	   8,   -4, 	  -6,  -12, 	  -1,   -9
+.2byte    1,  -15, 	  -3,   -2, 	   5,  -11, 	   0,   -9
+.2byte    1,  -16, 	  -7,   -3, 	   8,   -9, 	   0,   -9
+.2byte   -1,  -16, 	  -8,   -9, 	   7,   -3, 	   0,   -9
+.2byte   -1,  -15, 	  -8,   -7, 	   7,   -1, 	   0,   -8
+.2byte    0,  -13, 	 -11,   -5, 	  12,  -10, 	   0,  -10
+.2byte    3,  -12, 	   6,   -5, 	 -12,   -8, 	  -1,  -10
+.2byte    2,  -16, 	   6,   -9, 	  -9,   -7, 	  -2,  -11
+.2byte    6,  -15, 	  -8,  -11, 	   5,   -4, 	   0,  -11
+.2byte   -1,  -14, 	   9,   -6, 	 -11,   -8, 	  -1,  -10
+.2byte   -7,  -15, 	   7,  -11, 	  -6,   -4, 	  -1,  -11
+.2byte   -3,  -16, 	  -7,   -9, 	   8,   -7, 	   1,  -11
+.2byte   -4,  -12, 	  -7,   -5, 	  11,   -8, 	   0,  -10
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte    0,  -16, 	 -12,   -9, 	  11,   -9, 	   0,   -9
+.2byte    0,  -16, 	 -11,   -3, 	  10,   -3, 	   0,   -9
+.2byte    0,  -16, 	  -8,   -3, 	   7,   -9, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,   -4, 	   6,  -11, 	  -1,   -9
+.2byte    0,  -16, 	  -8,   -2, 	   7,   -6, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -2, 	   4,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -5, 	   3,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -5,    0, 	   4,   -9, 	  -1,   -9
+.2byte    0,  -16, 	   7,   -4, 	  -7,  -12, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -7, 	  -7,  -12, 	  -1,   -9
+.2byte    0,  -16, 	   7,   -2, 	  -8,   -8, 	  -2,   -9
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -1,  -16, 	  10,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte   -1,  -15, 	   9,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -16, 	   7,  -12, 	  -9,   -7, 	   0,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -8,   -2, 	   0,  -10
+.2byte   -1,  -15, 	  -5,  -11, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -16, 	  -4,  -13, 	   4,   -6, 	   1,  -11
+.2byte   -1,  -15, 	  -5,   -9, 	   4,    0, 	   1,  -11
+.2byte    0,  -16, 	  -8,   -9, 	   7,   -3, 	   1,  -10
+.2byte    0,  -15, 	  -7,  -11, 	   8,   -4, 	   1,  -10
+.2byte    0,  -16, 	  -8,   -6, 	   7,   -2, 	   1,  -10
+.2byte    0,   -4, 	  -9,  -18, 	   8,  -18, 	   0,  -10
+.2byte   -5,   -6, 	   0,  -19, 	   9,  -16, 	   1,  -10
+.2byte   -7,   -9, 	   4,  -17, 	   8,  -11, 	  -1,   -9
+.2byte   -4,  -12, 	  10,  -12, 	   1,   -8, 	   0,  -10
+.2byte    0,  -14, 	   9,  -12, 	 -10,  -12, 	   0,   -8
+.2byte    3,  -12, 	 -11,  -12, 	  -2,   -8, 	  -1,  -10
+.2byte    6,   -9, 	  -5,  -17, 	  -9,  -11, 	   0,   -9
+.2byte    4,   -6, 	  -1,  -19, 	 -10,  -16, 	  -2,  -10
+.2byte    0,   -3, 	  -9,  -17, 	   8,  -17, 	   0,   -9
+.2byte    5,   -4, 	   0,  -17, 	  -9,  -14, 	  -1,   -8
+.2byte    5,   -8, 	  -6,  -16, 	 -10,  -10, 	  -1,   -8
+.2byte    2,  -10, 	 -12,  -10, 	  -3,   -6, 	  -2,   -8
+.2byte    0,  -13, 	   9,  -11, 	 -10,  -11, 	   0,   -7
+.2byte   -3,  -10, 	  11,  -10, 	   2,   -6, 	   1,   -8
+.2byte   -6,   -8, 	   5,  -16, 	   9,  -10, 	   0,   -8
+.2byte   -6,   -4, 	  -1,  -17, 	   8,  -14, 	   0,   -8
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte    0,  -16, 	 -11,   -3, 	  10,   -3, 	   0,   -9
+.2byte    0,  -16, 	 -12,   -9, 	  11,   -9, 	   0,   -9
+.2byte    0,  -16, 	  -8,   -3, 	   7,   -9, 	  -1,   -9
+.2byte    0,  -16, 	  -8,   -2, 	   7,   -6, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,   -4, 	   6,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -2, 	   4,  -11, 	  -1,   -9
+.2byte    0,  -15, 	  -5,    0, 	   4,   -9, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -5, 	   3,  -11, 	  -1,   -9
+.2byte    0,  -16, 	   7,   -4, 	  -7,  -12, 	  -2,   -9
+.2byte    0,  -16, 	   7,   -2, 	  -8,   -8, 	  -2,   -9
+.2byte    0,  -16, 	   8,   -7, 	  -7,  -12, 	  -1,   -9
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte   -1,  -15, 	   9,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -16, 	  10,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -17, 	   7,   -8, 	  -8,   -2, 	   0,  -10
+.2byte   -1,  -16, 	   7,  -12, 	  -9,   -7, 	   0,  -10
+.2byte   -1,  -15, 	  -5,  -11, 	   3,   -2, 	   1,  -11
+.2byte   -1,  -15, 	  -5,   -9, 	   4,    0, 	   1,  -11
+.2byte   -1,  -16, 	  -4,  -13, 	   4,   -6, 	   1,  -11
+.2byte    0,  -16, 	  -8,   -9, 	   7,   -3, 	   1,  -10
+.2byte    0,  -16, 	  -8,   -6, 	   7,   -2, 	   1,  -10
+.2byte    0,  -15, 	  -7,  -11, 	   8,   -4, 	   1,  -10
+.2byte    0,  -16, 	 -12,   -9, 	  11,   -9, 	   0,   -9
+.2byte    0,  -15, 	  -7,  -11, 	   8,   -4, 	   1,  -10
+.2byte   -1,  -16, 	  -4,  -13, 	   4,   -6, 	   1,  -11
+.2byte   -1,  -16, 	   7,  -12, 	  -9,   -7, 	   0,  -10
+.2byte   -1,  -16, 	  10,   -9, 	 -11,   -9, 	  -1,  -10
+.2byte    0,  -16, 	   8,   -7, 	  -7,  -12, 	  -1,   -9
+.2byte    0,  -15, 	  -4,   -5, 	   3,  -11, 	  -1,   -9
+.2byte   -1,  -16, 	  -9,   -4, 	   6,  -11, 	  -1,   -9
+.2byte    0,  -15, 	 -12,   -5, 	  11,   -5, 	   0,   -9
+.2byte   -1,  -16, 	  -9,   -9, 	   6,   -3, 	   0,  -10
+.2byte   -2,  -15, 	  -6,  -11, 	   2,   -2, 	   0,  -11
+.2byte   -1,  -17, 	   7,  -10, 	  -8,   -4, 	   0,  -10
+.2byte   -1,  -15, 	  10,   -7, 	 -11,   -7, 	  -1,   -9
+.2byte    1,  -16, 	   8,   -4, 	  -6,  -12, 	  -1,   -9
+.2byte    1,  -15, 	  -3,   -2, 	   5,  -11, 	   0,   -9
+.2byte    1,  -16, 	  -7,   -3, 	   8,   -9, 	   0,   -9
+sVictreebelAnimTable1:
+.4byte sVictreebelAnims_1_1
+.4byte sVictreebelAnims_1_2
+.4byte sVictreebelAnims_1_3
+.4byte sVictreebelAnims_1_4
+.4byte sVictreebelAnims_1_5
+.4byte sVictreebelAnims_1_6
+.4byte sVictreebelAnims_1_7
+.4byte sVictreebelAnims_1_8
+sVictreebelAnimTable2:
+.4byte sVictreebelAnims_2_1
+.4byte sVictreebelAnims_2_2
+.4byte sVictreebelAnims_2_3
+.4byte sVictreebelAnims_2_4
+.4byte sVictreebelAnims_2_5
+.4byte sVictreebelAnims_2_6
+.4byte sVictreebelAnims_2_7
+.4byte sVictreebelAnims_2_8
+sVictreebelAnimTable3:
+.4byte sVictreebelAnims_3_1
+.4byte sVictreebelAnims_3_2
+.4byte sVictreebelAnims_3_3
+.4byte sVictreebelAnims_3_4
+.4byte sVictreebelAnims_3_5
+.4byte sVictreebelAnims_3_6
+.4byte sVictreebelAnims_3_7
+.4byte sVictreebelAnims_3_8
+sVictreebelAnimTable4:
+.4byte sVictreebelAnims_4_1
+.4byte sVictreebelAnims_4_2
+.4byte sVictreebelAnims_4_3
+.4byte sVictreebelAnims_4_4
+.4byte sVictreebelAnims_4_5
+.4byte sVictreebelAnims_4_6
+.4byte sVictreebelAnims_4_7
+.4byte sVictreebelAnims_4_8
+sVictreebelAnimTable5:
+.4byte sVictreebelAnims_5_1
+.4byte sVictreebelAnims_5_2
+.4byte sVictreebelAnims_5_3
+.4byte sVictreebelAnims_5_4
+.4byte sVictreebelAnims_5_5
+.4byte sVictreebelAnims_5_6
+.4byte sVictreebelAnims_5_7
+.4byte sVictreebelAnims_5_8
+sVictreebelAnimTable6:
+.4byte sVictreebelAnims_6_1
+.4byte sVictreebelAnims_6_1
+.4byte sVictreebelAnims_6_1
+.4byte sVictreebelAnims_6_1
+.4byte sVictreebelAnims_6_1
+.4byte sVictreebelAnims_6_1
+.4byte sVictreebelAnims_6_1
+.4byte sVictreebelAnims_6_1
+sVictreebelAnimTable7:
+.4byte sVictreebelAnims_7_1
+.4byte sVictreebelAnims_7_2
+.4byte sVictreebelAnims_7_3
+.4byte sVictreebelAnims_7_4
+.4byte sVictreebelAnims_7_5
+.4byte sVictreebelAnims_7_6
+.4byte sVictreebelAnims_7_7
+.4byte sVictreebelAnims_7_8
+sVictreebelAnimTable8:
+.4byte sVictreebelAnims_8_1
+.4byte sVictreebelAnims_8_2
+.4byte sVictreebelAnims_8_3
+.4byte sVictreebelAnims_8_4
+.4byte sVictreebelAnims_8_5
+.4byte sVictreebelAnims_8_6
+.4byte sVictreebelAnims_8_7
+.4byte sVictreebelAnims_8_8
+sVictreebelAnimTable9:
+.4byte sVictreebelAnims_9_1
+.4byte sVictreebelAnims_9_2
+.4byte sVictreebelAnims_9_3
+.4byte sVictreebelAnims_9_4
+.4byte sVictreebelAnims_9_5
+.4byte sVictreebelAnims_9_6
+.4byte sVictreebelAnims_9_7
+.4byte sVictreebelAnims_9_8
+sVictreebelAnimTable10:
+.4byte sVictreebelAnims_10_1
+.4byte sVictreebelAnims_10_2
+.4byte sVictreebelAnims_10_3
+.4byte sVictreebelAnims_10_4
+.4byte sVictreebelAnims_10_5
+.4byte sVictreebelAnims_10_6
+.4byte sVictreebelAnims_10_7
+.4byte sVictreebelAnims_10_8
+sVictreebelAnimTable11:
+.4byte sVictreebelAnims_11_1
+.4byte sVictreebelAnims_11_2
+.4byte sVictreebelAnims_11_3
+.4byte sVictreebelAnims_11_4
+.4byte sVictreebelAnims_11_5
+.4byte sVictreebelAnims_11_6
+.4byte sVictreebelAnims_11_7
+.4byte sVictreebelAnims_11_8
+sVictreebelAnimTable12:
+.4byte sVictreebelAnims_12_1
+.4byte sVictreebelAnims_12_2
+.4byte sVictreebelAnims_12_3
+.4byte sVictreebelAnims_12_4
+.4byte sVictreebelAnims_12_5
+.4byte sVictreebelAnims_12_6
+.4byte sVictreebelAnims_12_7
+.4byte sVictreebelAnims_12_8
+sVictreebelAnimTable13:
+.4byte sVictreebelAnims_13_1
+.4byte sVictreebelAnims_13_2
+.4byte sVictreebelAnims_13_3
+.4byte sVictreebelAnims_13_4
+.4byte sVictreebelAnims_13_5
+.4byte sVictreebelAnims_13_6
+.4byte sVictreebelAnims_13_7
+.4byte sVictreebelAnims_13_8
+sAxAnimationsVictreebel:
+.4byte sVictreebelAnimTable1
+.4byte sVictreebelAnimTable2
+.4byte sVictreebelAnimTable3
+.4byte sVictreebelAnimTable4
+.4byte sVictreebelAnimTable5
+.4byte sVictreebelAnimTable6
+.4byte sVictreebelAnimTable7
+.4byte sVictreebelAnimTable8
+.4byte sVictreebelAnimTable9
+.4byte sVictreebelAnimTable10
+.4byte sVictreebelAnimTable11
+.4byte sVictreebelAnimTable12
+.4byte sVictreebelAnimTable13
+sAxSpritesVictreebel:
+.4byte sVictreebelSprites1
+.4byte sVictreebelSprites2
+.4byte sVictreebelSprites3
+.4byte sVictreebelSprites4
+.4byte sVictreebelSprites5
+.4byte sVictreebelSprites6
+.4byte sVictreebelSprites7
+.4byte sVictreebelSprites8
+.4byte sVictreebelSprites9
+.4byte sVictreebelSprites10
+.4byte sVictreebelSprites11
+.4byte sVictreebelSprites12
+.4byte sVictreebelSprites13
+.4byte sVictreebelSprites14
+.4byte sVictreebelSprites15
+.4byte sVictreebelSprites16
+.4byte sVictreebelSprites17
+.4byte sVictreebelSprites18
+.4byte sVictreebelSprites19
+.4byte sVictreebelSprites20
+.4byte sVictreebelSprites21
+.4byte sVictreebelSprites22
+.4byte sVictreebelSprites23
+.4byte sVictreebelSprites24
+.4byte sVictreebelSprites25
+.4byte sVictreebelSprites26
+.4byte sVictreebelSprites27
+.4byte sVictreebelSprites28
+.4byte sVictreebelSprites29
+.4byte sVictreebelSprites30
+.4byte sVictreebelSprites31
+.4byte sVictreebelSprites32
+.4byte sVictreebelSprites33
+.4byte sVictreebelSprites34
+.4byte sVictreebelSprites35
+.4byte sVictreebelSprites36
+.4byte sVictreebelSprites37
+.4byte sVictreebelSprites38
+.4byte sVictreebelSprites39
+.4byte sVictreebelSprites40
+.4byte sVictreebelSprites41
+.4byte sVictreebelSprites42
+.4byte sVictreebelSprites43
+.4byte sVictreebelSprites44
+.4byte sVictreebelSprites45
+.4byte sVictreebelSprites46
+.4byte sVictreebelSprites47
+.4byte sVictreebelSprites48
+.4byte sVictreebelSprites49
+.4byte sVictreebelSprites50
+.4byte sVictreebelSprites51
+.4byte sVictreebelSprites52
+sAxMainVictreebel:
+ax_main sAxPosesVictreebel, sAxAnimationsVictreebel, 13, sAxSpritesVictreebel, sAxPositionsVictreebel

--- a/data/ax/vigoroth.inc
+++ b/data/ax/vigoroth.inc
@@ -1,0 +1,2953 @@
+.global gAxVigoroth
+gAxVigoroth:
+ax_siro sAxMainVigoroth
+sVigorothPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose2:
+ax_pose 1, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose3:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose4:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose5:
+ax_pose 4, 0x01ed, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose6:
+ax_pose 5, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose7:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose8:
+ax_pose 7, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose9:
+ax_pose 8, 0x01eb, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose10:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose11:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose12:
+ax_pose 11, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose13:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose14:
+ax_pose 13, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose15:
+ax_pose 14, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose16:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose17:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose18:
+ax_pose 11, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose19:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose20:
+ax_pose 7, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose21:
+ax_pose 8, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose23:
+ax_pose 4, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose24:
+ax_pose 5, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose26:
+ax_pose 1, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose27:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose28:
+ax_pose 15, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose29:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose30:
+ax_pose 4, 0x01ed, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose31:
+ax_pose 5, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose32:
+ax_pose 16, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose33:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose34:
+ax_pose 7, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose35:
+ax_pose 8, 0x01eb, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose36:
+ax_pose 17, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose37:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose38:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose39:
+ax_pose 11, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose40:
+ax_pose 18, 0x01e3, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose41:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose42:
+ax_pose 13, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose43:
+ax_pose 14, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose44:
+ax_pose 19, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose45:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose46:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose47:
+ax_pose 11, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose48:
+ax_pose 18, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose49:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose50:
+ax_pose 7, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose51:
+ax_pose 8, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose52:
+ax_pose 17, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose53:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose54:
+ax_pose 4, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose55:
+ax_pose 5, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose56:
+ax_pose 16, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose57:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose58:
+ax_pose 1, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose59:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose60:
+ax_pose 20, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose61:
+ax_pose 21, 0x01e9, 0x80f0, 0x6c00
+ax_pose 22, 0x01e5, 0x80f0, 0x6c10
+ax_pose_terminator
+sVigorothPose62:
+ax_pose 22, 0x01e5, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose63:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose64:
+ax_pose 4, 0x01ed, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose65:
+ax_pose 5, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose66:
+ax_pose 23, 0x01e8, 0x90f1, 0x6c00
+ax_pose_terminator
+sVigorothPose67:
+ax_pose 24, 0x01e7, 0x90f2, 0x6c00
+ax_pose 25, 0x01e4, 0x90f0, 0x6c10
+ax_pose_terminator
+sVigorothPose68:
+ax_pose 25, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose69:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose70:
+ax_pose 7, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose71:
+ax_pose 8, 0x01eb, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose72:
+ax_pose 26, 0x01e4, 0x90f1, 0x6c00
+ax_pose_terminator
+sVigorothPose73:
+ax_pose 27, 0x01e4, 0x90f5, 0x6c00
+ax_pose 28, 0x01e6, 0x90ee, 0x6c10
+ax_pose_terminator
+sVigorothPose74:
+ax_pose 28, 0x01e6, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose75:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose76:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose77:
+ax_pose 11, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose78:
+ax_pose 29, 0x01e5, 0x90f2, 0x6c00
+ax_pose_terminator
+sVigorothPose79:
+ax_pose 30, 0x01e4, 0x90ee, 0x6c00
+ax_pose 31, 0x01e4, 0x90f0, 0x6c10
+ax_pose_terminator
+sVigorothPose80:
+ax_pose 30, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose81:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose82:
+ax_pose 13, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose83:
+ax_pose 14, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose84:
+ax_pose 32, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose85:
+ax_pose 33, 0x01e4, 0x80f2, 0x6c00
+ax_pose 34, 0x01e3, 0x80f2, 0x6c10
+ax_pose_terminator
+sVigorothPose86:
+ax_pose 33, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose87:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose88:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose89:
+ax_pose 11, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose90:
+ax_pose 29, 0x01e5, 0x80ee, 0x6c00
+ax_pose_terminator
+sVigorothPose91:
+ax_pose 30, 0x01e4, 0x80f2, 0x6c00
+ax_pose 31, 0x01e4, 0x80f0, 0x6c10
+ax_pose_terminator
+sVigorothPose92:
+ax_pose 30, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose93:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose94:
+ax_pose 7, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose95:
+ax_pose 8, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose96:
+ax_pose 26, 0x01e4, 0x80ef, 0x6c00
+ax_pose_terminator
+sVigorothPose97:
+ax_pose 27, 0x01e4, 0x80eb, 0x6c00
+ax_pose 28, 0x01e6, 0x80f2, 0x6c10
+ax_pose_terminator
+sVigorothPose98:
+ax_pose 28, 0x01e6, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose99:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose100:
+ax_pose 4, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose101:
+ax_pose 5, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose102:
+ax_pose 23, 0x01e8, 0x80ef, 0x6c00
+ax_pose_terminator
+sVigorothPose103:
+ax_pose 24, 0x01e7, 0x80ee, 0x6c00
+ax_pose 25, 0x01e4, 0x80f0, 0x6c10
+ax_pose_terminator
+sVigorothPose104:
+ax_pose 25, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose105:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose106:
+ax_pose 35, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose107:
+ax_pose 15, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose108:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose109:
+ax_pose 36, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose110:
+ax_pose 16, 0x01e7, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose111:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose112:
+ax_pose 37, 0x01e5, 0x90f6, 0x6c00
+ax_pose_terminator
+sVigorothPose113:
+ax_pose 17, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose114:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose115:
+ax_pose 38, 0x01e3, 0x90f4, 0x6c00
+ax_pose_terminator
+sVigorothPose116:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose117:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose118:
+ax_pose 39, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose119:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose120:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose121:
+ax_pose 38, 0x01e3, 0x80ec, 0x6c00
+ax_pose_terminator
+sVigorothPose122:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose123:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose124:
+ax_pose 37, 0x01e7, 0x80ea, 0x6c00
+ax_pose_terminator
+sVigorothPose125:
+ax_pose 17, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose126:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose127:
+ax_pose 36, 0x01e6, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose128:
+ax_pose 16, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose129:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose130:
+ax_pose 40, 0x01e4, 0x80f1, 0x6c00
+ax_pose_terminator
+sVigorothPose131:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose132:
+ax_pose 41, 0x01e1, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose133:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose134:
+ax_pose 42, 0x01e1, 0x90f2, 0x6c00
+ax_pose_terminator
+sVigorothPose135:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose136:
+ax_pose 43, 0x01e5, 0x90f3, 0x6c00
+ax_pose_terminator
+sVigorothPose137:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose138:
+ax_pose 44, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sVigorothPose139:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose140:
+ax_pose 43, 0x01e5, 0x80ed, 0x6c00
+ax_pose_terminator
+sVigorothPose141:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose142:
+ax_pose 42, 0x01e1, 0x80ee, 0x6c00
+ax_pose_terminator
+sVigorothPose143:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose144:
+ax_pose 41, 0x01e1, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose145:
+ax_pose 45, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sVigorothPose146:
+ax_pose 46, 0x01ee, 0x80ef, 0x6c00
+ax_pose_terminator
+sVigorothPose147:
+ax_pose 47, 0x01e3, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose148:
+ax_pose 48, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose149:
+ax_pose 49, 0x01e3, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose150:
+ax_pose 50, 0x01e4, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose151:
+ax_pose 51, 0x81e2, 0x4104, 0x6c00
+ax_pose 52, 0x0202, 0x00fc, 0x6c04
+ax_pose 53, 0x81e2, 0x80f4, 0x6c05
+ax_pose_terminator
+sVigorothPose152:
+ax_pose 50, 0x01e4, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose153:
+ax_pose 49, 0x01e3, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose154:
+ax_pose 48, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose155:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose156:
+ax_pose 1, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose157:
+ax_pose 2, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose158:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose159:
+ax_pose 4, 0x01ed, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose160:
+ax_pose 5, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose161:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose162:
+ax_pose 7, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose163:
+ax_pose 8, 0x01eb, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose164:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose165:
+ax_pose 10, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose166:
+ax_pose 11, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose167:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose168:
+ax_pose 13, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose169:
+ax_pose 14, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose170:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose171:
+ax_pose 10, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose172:
+ax_pose 11, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose173:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose174:
+ax_pose 7, 0x01eb, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose175:
+ax_pose 8, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose176:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose177:
+ax_pose 4, 0x01ed, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose178:
+ax_pose 5, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose179:
+ax_pose 15, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose180:
+ax_pose 16, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sVigorothPose181:
+ax_pose 17, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose182:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose183:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose184:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose185:
+ax_pose 17, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose186:
+ax_pose 16, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sVigorothPose187:
+ax_pose 15, 0x01e7, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose188:
+ax_pose 16, 0x01e7, 0x90ef, 0x6c00
+ax_pose_terminator
+sVigorothPose189:
+ax_pose 17, 0x01e7, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose190:
+ax_pose 18, 0x01e4, 0x90f0, 0x6c00
+ax_pose_terminator
+sVigorothPose191:
+ax_pose 19, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose192:
+ax_pose 18, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose193:
+ax_pose 17, 0x01e7, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose194:
+ax_pose 16, 0x01e7, 0x80f1, 0x6c00
+ax_pose_terminator
+sVigorothPose195:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose196:
+ax_pose 40, 0x01e4, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose197:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose198:
+ax_pose 41, 0x01e1, 0x90f1, 0x6c00
+ax_pose_terminator
+sVigorothPose199:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose200:
+ax_pose 42, 0x01e1, 0x90f2, 0x6c00
+ax_pose_terminator
+sVigorothPose201:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose202:
+ax_pose 43, 0x01e5, 0x90f3, 0x6c00
+ax_pose_terminator
+sVigorothPose203:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose204:
+ax_pose 44, 0x01e3, 0x80f1, 0x6c00
+ax_pose_terminator
+sVigorothPose205:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose206:
+ax_pose 43, 0x01e5, 0x80ed, 0x6c00
+ax_pose_terminator
+sVigorothPose207:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose208:
+ax_pose 42, 0x01e1, 0x80ee, 0x6c00
+ax_pose_terminator
+sVigorothPose209:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose210:
+ax_pose 41, 0x01e1, 0x80f0, 0x6c00
+ax_pose_terminator
+sVigorothPose211:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose212:
+ax_pose 3, 0x01eb, 0x80f6, 0x6c00
+ax_pose_terminator
+sVigorothPose213:
+ax_pose 6, 0x01ea, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose214:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose215:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose216:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose217:
+ax_pose 6, 0x01ea, 0x90ec, 0x6c00
+ax_pose_terminator
+sVigorothPose218:
+ax_pose 3, 0x01eb, 0x90ea, 0x6c00
+ax_pose_terminator
+sVigorothPose219:
+ax_pose 0, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose220:
+ax_pose 3, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose221:
+ax_pose 6, 0x01ea, 0x80f3, 0x6c00
+ax_pose_terminator
+sVigorothPose222:
+ax_pose 9, 0x01e7, 0x80f2, 0x6c00
+ax_pose_terminator
+sVigorothPose223:
+ax_pose 12, 0x01e7, 0x80f4, 0x6c00
+ax_pose_terminator
+sVigorothPose224:
+ax_pose 9, 0x01e7, 0x90ee, 0x6c00
+ax_pose_terminator
+sVigorothPose225:
+ax_pose 6, 0x01ea, 0x90ed, 0x6c00
+ax_pose_terminator
+sVigorothPose226:
+ax_pose 3, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+.align 2
+sVigorothAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 1, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 27, 0, 19, 0, 19,
+ax_anim 2, 0, 27, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sVigorothAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 20, 18, 20,
+ax_anim 2, 1, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 31, 18, 20, 18, 20,
+ax_anim 2, 0, 31, 19, 19, 19, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sVigorothAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 1, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 35, 15, 0, 15, 0,
+ax_anim 2, 0, 35, 15, 1, 15, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sVigorothAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -6, 5, -6,
+ax_anim 1, 0, 38, 11, -13, 11, -13,
+ax_anim 2, 0, 39, 17, -18, 17, -18,
+ax_anim 2, 1, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 39, 17, -18, 17, -18,
+ax_anim 2, 0, 39, 18, -17, 18, -17,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sVigorothAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -9, 0, -9,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 1, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 43, 0, -15, 0, -15,
+ax_anim 2, 0, 43, 1, -15, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sVigorothAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -6, -5, -6,
+ax_anim 1, 0, 46, -11, -13, -11, -13,
+ax_anim 2, 0, 47, -17, -18, -17, -18,
+ax_anim 2, 1, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 47, -17, -18, -17, -18,
+ax_anim 2, 0, 47, -18, -17, -18, -17,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sVigorothAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 1, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 51, -15, 0, -15, 0,
+ax_anim 2, 0, 51, -15, 1, -15, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sVigorothAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 20, -18, 20,
+ax_anim 2, 1, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 55, -18, 20, -18, 20,
+ax_anim 2, 0, 55, -19, 19, -19, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sVigorothAnims_3_1:
+ax_anim 2, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 57, 0, -4, 0, -4,
+ax_anim 6, 0, 56, 0, -5, 0, -5,
+ax_anim 1, 2, 59, 0, -3, 0, -3,
+ax_anim 1, 0, 59, 0, 6, 0, 6,
+ax_anim 2, 0, 60, 0, 14, 0, 14,
+ax_anim 2, 1, 61, 1, 14, 1, 14,
+ax_anim 2, 0, 61, 0, 14, 0, 14,
+ax_anim 2, 0, 61, 1, 14, 1, 14,
+ax_anim 2, 0, 61, 0, 14, 0, 14,
+ax_anim 2, 0, 56, 0, 8, 0, 8,
+ax_anim 2, 0, 56, 0, 4, 0, 4,
+ax_anim_terminator
+sVigorothAnims_3_2:
+ax_anim 2, 0, 63, -2, -2, -2, -2,
+ax_anim 2, 0, 63, -4, -4, -4, -4,
+ax_anim 6, 0, 62, -5, -5, -5, -5,
+ax_anim 1, 2, 65, -1, -1, -1, -1,
+ax_anim 1, 0, 65, 6, 6, 6, 6,
+ax_anim 2, 0, 66, 13, 15, 13, 15,
+ax_anim 2, 1, 67, 14, 14, 14, 14,
+ax_anim 2, 0, 67, 13, 15, 13, 15,
+ax_anim 2, 0, 67, 14, 14, 14, 14,
+ax_anim 2, 0, 67, 13, 15, 13, 15,
+ax_anim 2, 0, 62, 7, 8, 7, 8,
+ax_anim 2, 0, 62, 3, 3, 3, 3,
+ax_anim_terminator
+sVigorothAnims_3_3:
+ax_anim 2, 0, 69, -2, 0, -2, 0,
+ax_anim 2, 0, 69, -4, 0, -4, 0,
+ax_anim 6, 0, 68, -5, 0, -5, 0,
+ax_anim 1, 2, 71, -1, 0, -1, 0,
+ax_anim 1, 0, 71, 6, 0, 6, 0,
+ax_anim 2, 0, 72, 13, 0, 13, 0,
+ax_anim 2, 1, 73, 13, 1, 13, 1,
+ax_anim 2, 0, 73, 13, 0, 13, 0,
+ax_anim 2, 0, 73, 13, 1, 13, 1,
+ax_anim 2, 0, 73, 13, 0, 13, 0,
+ax_anim 2, 0, 68, 7, 0, 7, 0,
+ax_anim 2, 0, 68, 3, 0, 3, 0,
+ax_anim_terminator
+sVigorothAnims_3_4:
+ax_anim 2, 0, 75, -2, 2, -2, 2,
+ax_anim 2, 0, 75, -4, 4, -4, 4,
+ax_anim 6, 0, 74, -5, 5, -5, 5,
+ax_anim 1, 2, 77, -1, 1, -1, 1,
+ax_anim 1, 0, 77, 6, -6, 6, -6,
+ax_anim 2, 0, 78, 15, -15, 15, -15,
+ax_anim 2, 1, 79, 16, -14, 16, -14,
+ax_anim 2, 0, 79, 15, -15, 15, -15,
+ax_anim 2, 0, 79, 16, -14, 16, -14,
+ax_anim 2, 0, 79, 15, -15, 15, -15,
+ax_anim 2, 0, 74, 7, -7, 7, -7,
+ax_anim 2, 0, 74, 3, -3, 3, -3,
+ax_anim_terminator
+sVigorothAnims_3_5:
+ax_anim 2, 0, 81, 0, 2, 0, 2,
+ax_anim 2, 0, 81, 0, 4, 0, 4,
+ax_anim 6, 0, 80, 0, 5, 0, 5,
+ax_anim 1, 2, 83, 0, 3, 0, 3,
+ax_anim 1, 0, 83, 0, -2, 0, -2,
+ax_anim 2, 0, 84, 0, -12, 0, -12,
+ax_anim 2, 1, 85, 1, -12, 1, -12,
+ax_anim 2, 0, 85, 0, -12, 0, -12,
+ax_anim 2, 0, 85, 1, -12, 1, -12,
+ax_anim 2, 0, 85, 0, -12, 0, -12,
+ax_anim 2, 0, 80, 0, -7, 0, -7,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim_terminator
+sVigorothAnims_3_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 2, 0, 87, 4, 4, 4, 4,
+ax_anim 6, 0, 86, 5, 5, 5, 5,
+ax_anim 1, 2, 89, 1, 1, 1, 1,
+ax_anim 1, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 90, -15, -15, -15, -15,
+ax_anim 2, 1, 91, -16, -14, -16, -14,
+ax_anim 2, 0, 91, -15, -15, -15, -15,
+ax_anim 2, 0, 91, -16, -14, -16, -14,
+ax_anim 2, 0, 91, -15, -15, -15, -15,
+ax_anim 2, 0, 86, -7, -7, -7, -7,
+ax_anim 2, 0, 86, -3, -3, -3, -3,
+ax_anim_terminator
+sVigorothAnims_3_7:
+ax_anim 2, 0, 93, 2, 0, 2, 0,
+ax_anim 2, 0, 93, 4, 0, 4, 0,
+ax_anim 6, 0, 92, 5, 0, 5, 0,
+ax_anim 1, 2, 95, 1, 0, 1, 0,
+ax_anim 1, 0, 95, -6, 0, -6, 0,
+ax_anim 2, 0, 96, -13, 0, -13, 0,
+ax_anim 2, 1, 97, -13, 1, -13, 1,
+ax_anim 2, 0, 97, -13, 0, -13, 0,
+ax_anim 2, 0, 97, -13, 1, -13, 1,
+ax_anim 2, 0, 97, -13, 0, -13, 0,
+ax_anim 2, 0, 92, -7, 0, -7, 0,
+ax_anim 2, 0, 92, -3, 0, -3, 0,
+ax_anim_terminator
+sVigorothAnims_3_8:
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 6, 0, 98, 5, -5, 5, -5,
+ax_anim 1, 2, 101, 1, -1, 1, -1,
+ax_anim 1, 0, 101, -6, 6, -6, 6,
+ax_anim 2, 0, 102, -13, 15, -13, 15,
+ax_anim 2, 1, 103, -14, 14, -14, 14,
+ax_anim 2, 0, 103, -13, 15, -13, 15,
+ax_anim 2, 0, 103, -14, 14, -14, 14,
+ax_anim 2, 0, 103, -13, 15, -13, 15,
+ax_anim 2, 0, 98, -7, 8, -7, 8,
+ax_anim 2, 0, 98, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sVigorothAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 106, 1, 3, 1, 2,
+ax_anim 2, 0, 106, 0, 3, 0, 2,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sVigorothAnims_4_2:
+ax_anim 2, 0, 108, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 109, 3, 1, 2, 0,
+ax_anim 2, 0, 109, 2, 2, 1, 1,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sVigorothAnims_4_3:
+ax_anim 2, 0, 111, -3, 0, -3, 0,
+ax_anim 6, 2, 111, -4, 0, -4, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 4, 0, 4, 0,
+ax_anim 2, 0, 112, 4, 1, 4, 1,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 2, 0, 112, 4, 1, 4, 1,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 2, 0, 112, 4, 1, 4, 1,
+ax_anim 2, 0, 112, 4, 0, 4, 0,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sVigorothAnims_4_4:
+ax_anim 2, 0, 114, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sVigorothAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 1, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 118, 1, -3, 1, -3,
+ax_anim 2, 0, 118, 0, -3, 0, -3,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim_terminator
+sVigorothAnims_4_6:
+ax_anim 2, 0, 120, 2, 2, 2, 2,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -3, -1, -3, -1,
+ax_anim 2, 0, 121, -2, -2, -2, -2,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+sVigorothAnims_4_7:
+ax_anim 2, 0, 123, 3, 0, 3, 0,
+ax_anim 6, 2, 123, 4, 0, 4, 0,
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 1, 124, -4, 0, -4, 0,
+ax_anim 2, 0, 124, -4, 1, -4, 1,
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 2, 0, 124, -4, 1, -4, 1,
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 2, 0, 124, -4, 1, -4, 1,
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sVigorothAnims_4_8:
+ax_anim 2, 0, 126, 2, -2, 2, -2,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 1, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 127, -3, 1, -2, 0,
+ax_anim 2, 0, 127, -2, 2, -1, 1,
+ax_anim 2, 0, 125, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sVigorothAnims_5_1:
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 4, 0, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 4, 2, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 4, 0, 129, 0, -6, 0, 0,
+ax_anim 2, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -3, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_5_2:
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 2, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 4, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -3, 0, 0,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_5_3:
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 4, 0, 133, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 2, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 4, 0, 133, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -3, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_5_4:
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 4, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 4, 2, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 4, 0, 135, 0, -6, 0, 0,
+ax_anim 2, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -3, 0, 0,
+ax_anim 4, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_5_5:
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 2, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 4, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -5, 0, 0,
+ax_anim 1, 0, 137, 0, -3, 0, 0,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_5_6:
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 4, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 2, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 4, 0, 139, 0, -6, 0, 0,
+ax_anim 2, 0, 139, 0, -5, 0, 0,
+ax_anim 1, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_5_7:
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 4, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 4, 2, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 4, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 1, 0, 141, 0, -3, 0, 0,
+ax_anim 4, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_5_8:
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 4, 0, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 2, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 4, 0, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -5, 0, 0,
+ax_anim 1, 0, 143, 0, -3, 0, 0,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_6_1:
+ax_anim 30, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sVigorothAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sVigorothAnims_7_3:
+ax_anim 2, 0, 148, -4, 0, -4, 0,
+ax_anim 8, 0, 148, -5, 0, -5, 0,
+ax_anim_terminator
+sVigorothAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sVigorothAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sVigorothAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sVigorothAnims_7_7:
+ax_anim 2, 0, 152, 4, 0, 4, 0,
+ax_anim 8, 0, 152, 5, 0, 5, 0,
+ax_anim_terminator
+sVigorothAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVigorothAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 0, -4, 0, 0,
+ax_anim 2, 0, 155, 0, -6, 0, 0,
+ax_anim 6, 0, 154, 0, -5, 0, 0,
+ax_anim 4, 0, 156, 0, -6, 0, 0,
+ax_anim 4, 0, 156, 0, -4, 0, 0,
+ax_anim_terminator
+sVigorothAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -4, 0, 0,
+ax_anim 2, 0, 158, 0, -6, 0, 0,
+ax_anim 6, 0, 157, 0, -5, 0, 0,
+ax_anim 4, 0, 159, 0, -6, 0, 0,
+ax_anim 4, 0, 159, 0, -4, 0, 0,
+ax_anim_terminator
+sVigorothAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 0, -4, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, 0,
+ax_anim 6, 0, 160, 0, -5, 0, 0,
+ax_anim 4, 0, 162, 0, -6, 0, 0,
+ax_anim 4, 0, 162, 0, -4, 0, 0,
+ax_anim_terminator
+sVigorothAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -4, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, 0,
+ax_anim 6, 0, 163, 0, -5, 0, 0,
+ax_anim 4, 0, 165, 0, -6, 0, 0,
+ax_anim 4, 0, 165, 0, -4, 0, 0,
+ax_anim_terminator
+sVigorothAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, -4, 0, 0,
+ax_anim 2, 0, 167, 0, -6, 0, 0,
+ax_anim 6, 0, 166, 0, -5, 0, 0,
+ax_anim 4, 0, 168, 0, -6, 0, 0,
+ax_anim 4, 0, 168, 0, -4, 0, 0,
+ax_anim_terminator
+sVigorothAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, -4, 0, 0,
+ax_anim 2, 0, 170, 0, -6, 0, 0,
+ax_anim 6, 0, 169, 0, -5, 0, 0,
+ax_anim 4, 0, 171, 0, -6, 0, 0,
+ax_anim 4, 0, 171, 0, -4, 0, 0,
+ax_anim_terminator
+sVigorothAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, -4, 0, 0,
+ax_anim 2, 0, 173, 0, -6, 0, 0,
+ax_anim 6, 0, 172, 0, -5, 0, 0,
+ax_anim 4, 0, 174, 0, -6, 0, 0,
+ax_anim 4, 0, 174, 0, -4, 0, 0,
+ax_anim_terminator
+sVigorothAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -4, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, 0,
+ax_anim 6, 0, 175, 0, -5, 0, 0,
+ax_anim 4, 0, 177, 0, -6, 0, 0,
+ax_anim 4, 0, 177, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 9, 4, 9, 4,
+ax_anim 2, 0, 180, 12, 11, 12, 11,
+ax_anim 2, 0, 181, 10, 18, 10, 18,
+ax_anim 3, 0, 182, 0, 21, 0, 21,
+ax_anim 2, 3, 183, -10, 18, -10, 18,
+ax_anim 2, 0, 184, -12, 11, -12, 11,
+ax_anim 1, 0, 185, -9, 4, -9, 4,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 10, 2, 10, 2,
+ax_anim 2, 0, 179, 19, 7, 19, 7,
+ax_anim 2, 0, 180, 22, 14, 22, 14,
+ax_anim 3, 0, 181, 20, 21, 20, 21,
+ax_anim 2, 3, 182, 11, 21, 11, 21,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 1, 7, 1, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 9, -5, 9, -5,
+ax_anim 2, 0, 179, 15, -4, 15, -4,
+ax_anim 3, 0, 180, 18, 0, 18, 0,
+ax_anim 2, 3, 181, 18, 6, 18, 6,
+ax_anim 2, 0, 182, 12, 9, 12, 9,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 3, -8, 3, -8,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 22, -21, 22, -21,
+ax_anim 2, 3, 180, 23, -13, 23, -13,
+ax_anim 2, 0, 181, 19, -5, 19, -5,
+ax_anim 1, 0, 182, 10, -1, 10, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -5, -8, -5,
+ax_anim 2, 0, 184, -11, -10, -11, -10,
+ax_anim 2, 0, 185, -8, -18, -8, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 8, -18, 8, -18,
+ax_anim 2, 0, 180, 11, -10, 11, -10,
+ax_anim 1, 0, 181, 8, -5, 8, -5,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, -3, -8, -3, -8,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -22, -21, -22, -21,
+ax_anim 2, 3, 184, -23, -13, -23, -13,
+ax_anim 2, 0, 183, -19, -5, -19, -5,
+ax_anim 1, 0, 182, -10, -1, -10, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -9, -5, -9, -5,
+ax_anim 2, 0, 185, -15, -4, -15, -4,
+ax_anim 3, 0, 184, -18, 0, -18, 0,
+ax_anim 2, 3, 183, -18, 6, -18, 6,
+ax_anim 2, 0, 182, -12, 9, -12, 9,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -10, 2, -10, 2,
+ax_anim 2, 0, 185, -19, 7, -19, 7,
+ax_anim 2, 0, 184, -22, 14, -22, 14,
+ax_anim 3, 0, 183, -20, 21, -20, 21,
+ax_anim 2, 3, 182, -11, 21, -11, 21,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, -1, 7, -1, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -8, 0, 0,
+ax_anim 2, 0, 195, 0, -14, 0, 0,
+ax_anim 3, 0, 195, 0, -18, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -23, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_11_2:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -7, 0, 0,
+ax_anim 2, 0, 197, 0, -13, 0, 0,
+ax_anim 3, 0, 197, 0, -18, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -23, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_11_3:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -7, 0, 0,
+ax_anim 2, 0, 199, 0, -13, 0, 0,
+ax_anim 3, 0, 199, 0, -17, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -17, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_11_4:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -8, 0, 0,
+ax_anim 2, 0, 201, 0, -14, 0, 0,
+ax_anim 3, 0, 201, 0, -18, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 201, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -15, 0, 0,
+ax_anim 1, 0, 200, 0, -9, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_11_5:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -7, 0, 0,
+ax_anim 2, 0, 203, 0, -13, 0, 0,
+ax_anim 3, 0, 203, 0, -17, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -23, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_11_6:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -8, 0, 0,
+ax_anim 2, 0, 205, 0, -14, 0, 0,
+ax_anim 3, 0, 205, 0, -18, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 204, 0, -15, 0, 0,
+ax_anim 1, 0, 204, 0, -9, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_11_7:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -7, 0, 0,
+ax_anim 2, 0, 207, 0, -13, 0, 0,
+ax_anim 3, 0, 207, 0, -17, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 2, 0, 206, 0, -17, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_11_8:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -7, 0, 0,
+ax_anim 2, 0, 209, 0, -13, 0, 0,
+ax_anim 3, 0, 209, 0, -18, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -21, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVigorothAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sVigorothGfx1:
+.incbin "baserom.gba", 0x11B9DD8, 0x200
+sVigorothSprites1:
+ax_sprite sVigorothGfx1, 0x200
+ax_sprite_terminator
+sVigorothGfx2:
+.incbin "baserom.gba", 0x11B9FE8, 0x200
+sVigorothSprites2:
+ax_sprite sVigorothGfx2, 0x200
+ax_sprite_terminator
+sVigorothGfx3:
+.incbin "baserom.gba", 0x11BA1F8, 0x200
+sVigorothSprites3:
+ax_sprite sVigorothGfx3, 0x200
+ax_sprite_terminator
+sVigorothGfx4:
+.incbin "baserom.gba", 0x11BA408, 0x200
+sVigorothSprites4:
+ax_sprite sVigorothGfx4, 0x200
+ax_sprite_terminator
+sVigorothGfx5:
+.incbin "baserom.gba", 0x11BA618, 0x200
+sVigorothSprites5:
+ax_sprite sVigorothGfx5, 0x200
+ax_sprite_terminator
+sVigorothGfx6:
+.incbin "baserom.gba", 0x11BA828, 0x200
+sVigorothSprites6:
+ax_sprite sVigorothGfx6, 0x200
+ax_sprite_terminator
+sVigorothGfx7:
+.incbin "baserom.gba", 0x11BAA38, 0x200
+sVigorothSprites7:
+ax_sprite sVigorothGfx7, 0x200
+ax_sprite_terminator
+sVigorothGfx8:
+.incbin "baserom.gba", 0x11BAC48, 0x200
+sVigorothSprites8:
+ax_sprite sVigorothGfx8, 0x200
+ax_sprite_terminator
+sVigorothGfx9:
+.incbin "baserom.gba", 0x11BAE58, 0x200
+sVigorothSprites9:
+ax_sprite sVigorothGfx9, 0x200
+ax_sprite_terminator
+sVigorothGfx10:
+.incbin "baserom.gba", 0x11BB068, 0x200
+sVigorothSprites10:
+ax_sprite sVigorothGfx10, 0x200
+ax_sprite_terminator
+sVigorothGfx11:
+.incbin "baserom.gba", 0x11BB278, 0x200
+sVigorothSprites11:
+ax_sprite sVigorothGfx11, 0x200
+ax_sprite_terminator
+sVigorothGfx12:
+.incbin "baserom.gba", 0x11BB488, 0x200
+sVigorothSprites12:
+ax_sprite sVigorothGfx12, 0x200
+ax_sprite_terminator
+sVigorothGfx13:
+.incbin "baserom.gba", 0x11BB698, 0x200
+sVigorothSprites13:
+ax_sprite sVigorothGfx13, 0x200
+ax_sprite_terminator
+sVigorothGfx14:
+.incbin "baserom.gba", 0x11BB8A8, 0x200
+sVigorothSprites14:
+ax_sprite sVigorothGfx14, 0x200
+ax_sprite_terminator
+sVigorothGfx15:
+.incbin "baserom.gba", 0x11BBAB8, 0x200
+sVigorothSprites15:
+ax_sprite sVigorothGfx15, 0x200
+ax_sprite_terminator
+sVigorothGfx16:
+.incbin "baserom.gba", 0x11BBCC8, 0x20
+sVigorothGfx16_1:
+.incbin "baserom.gba", 0x11BBCE8, 0x40
+sVigorothGfx16_2:
+.incbin "baserom.gba", 0x11BBD28, 0x100
+sVigorothSprites16:
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx16, 0x20
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx16_2, 0x100
+ax_sprite_terminator
+sVigorothGfx17:
+.incbin "baserom.gba", 0x11BBE60, 0x20
+sVigorothGfx17_1:
+.incbin "baserom.gba", 0x11BBE80, 0x60
+sVigorothGfx17_2:
+.incbin "baserom.gba", 0x11BBEE0, 0x100
+sVigorothSprites17:
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx17_2, 0x100
+ax_sprite_terminator
+sVigorothGfx18:
+.incbin "baserom.gba", 0x11BC018, 0x40
+sVigorothGfx18_1:
+.incbin "baserom.gba", 0x11BC058, 0x60
+sVigorothGfx18_2:
+.incbin "baserom.gba", 0x11BC0B8, 0xE0
+sVigorothSprites18:
+ax_sprite sVigorothGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx18_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx19:
+.incbin "baserom.gba", 0x11BC1D0, 0x20
+sVigorothGfx19_1:
+.incbin "baserom.gba", 0x11BC1F0, 0x60
+sVigorothGfx19_2:
+.incbin "baserom.gba", 0x11BC250, 0x100
+sVigorothSprites19:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx19_2, 0x100
+ax_sprite_terminator
+sVigorothGfx20:
+.incbin "baserom.gba", 0x11BC388, 0x40
+sVigorothGfx20_1:
+.incbin "baserom.gba", 0x11BC3C8, 0x180
+sVigorothSprites20:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx20_1, 0x180
+ax_sprite_terminator
+sVigorothGfx21:
+.incbin "baserom.gba", 0x11BC570, 0x60
+sVigorothGfx21_1:
+.incbin "baserom.gba", 0x11BC5D0, 0x60
+sVigorothGfx21_2:
+.incbin "baserom.gba", 0x11BC630, 0x60
+sVigorothGfx21_3:
+.incbin "baserom.gba", 0x11BC690, 0x40
+sVigorothSprites21:
+ax_sprite sVigorothGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx21_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx22:
+.incbin "baserom.gba", 0x11BC718, 0x20
+sVigorothGfx22_1:
+.incbin "baserom.gba", 0x11BC738, 0x20
+sVigorothGfx22_2:
+.incbin "baserom.gba", 0x11BC758, 0x100
+sVigorothSprites22:
+ax_sprite sVigorothGfx22, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVigorothGfx22_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVigorothGfx22_2, 0x100
+ax_sprite_terminator
+sVigorothGfx23:
+.incbin "baserom.gba", 0x11BC888, 0x60
+sVigorothGfx23_1:
+.incbin "baserom.gba", 0x11BC8E8, 0x60
+sVigorothGfx23_2:
+.incbin "baserom.gba", 0x11BC948, 0x40
+sVigorothGfx23_3:
+.incbin "baserom.gba", 0x11BC988, 0x60
+sVigorothSprites23:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx23_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx23_3, 0x60
+ax_sprite_terminator
+sVigorothGfx24:
+.incbin "baserom.gba", 0x11BCA30, 0x40
+sVigorothGfx24_1:
+.incbin "baserom.gba", 0x11BCA70, 0x40
+sVigorothGfx24_2:
+.incbin "baserom.gba", 0x11BCAB0, 0x60
+sVigorothGfx24_3:
+.incbin "baserom.gba", 0x11BCB10, 0x40
+sVigorothSprites24:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx24_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx24_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx25:
+.incbin "baserom.gba", 0x11BCBA0, 0x40
+sVigorothGfx25_1:
+.incbin "baserom.gba", 0x11BCBE0, 0x20
+sVigorothGfx25_2:
+.incbin "baserom.gba", 0x11BCC00, 0x40
+sVigorothGfx25_3:
+.incbin "baserom.gba", 0x11BCC40, 0x60
+sVigorothSprites25:
+ax_sprite sVigorothGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx25_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVigorothGfx25_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx26:
+.incbin "baserom.gba", 0x11BCCE8, 0x180
+sVigorothSprites26:
+ax_sprite 0, 0x80
+ax_sprite sVigorothGfx26, 0x180
+ax_sprite_terminator
+sVigorothGfx27:
+.incbin "baserom.gba", 0x11BCE80, 0x60
+sVigorothGfx27_1:
+.incbin "baserom.gba", 0x11BCEE0, 0x160
+sVigorothSprites27:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx27_1, 0x160
+ax_sprite_terminator
+sVigorothGfx28:
+.incbin "baserom.gba", 0x11BD068, 0x40
+sVigorothGfx28_1:
+.incbin "baserom.gba", 0x11BD0A8, 0x40
+sVigorothGfx28_2:
+.incbin "baserom.gba", 0x11BD0E8, 0x20
+sVigorothGfx28_3:
+.incbin "baserom.gba", 0x11BD108, 0x60
+sVigorothSprites28:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx28_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx28_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite sVigorothGfx28_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx29:
+.incbin "baserom.gba", 0x11BD1B8, 0x40
+sVigorothGfx29_1:
+.incbin "baserom.gba", 0x11BD1F8, 0x160
+sVigorothSprites29:
+ax_sprite sVigorothGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx29_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx30:
+.incbin "baserom.gba", 0x11BD380, 0x60
+sVigorothGfx30_1:
+.incbin "baserom.gba", 0x11BD3E0, 0xE0
+sVigorothGfx30_2:
+.incbin "baserom.gba", 0x11BD4C0, 0x60
+sVigorothSprites30:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx30_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx30_2, 0x60
+ax_sprite_terminator
+sVigorothGfx31:
+.incbin "baserom.gba", 0x11BD558, 0x40
+sVigorothGfx31_1:
+.incbin "baserom.gba", 0x11BD598, 0x60
+sVigorothGfx31_2:
+.incbin "baserom.gba", 0x11BD5F8, 0xE0
+sVigorothSprites31:
+ax_sprite sVigorothGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx31_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx32:
+.incbin "baserom.gba", 0x11BD710, 0xC0
+sVigorothGfx32_1:
+.incbin "baserom.gba", 0x11BD7D0, 0x40
+sVigorothGfx32_2:
+.incbin "baserom.gba", 0x11BD810, 0x40
+sVigorothSprites32:
+ax_sprite sVigorothGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx32_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx32_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sVigorothGfx33:
+.incbin "baserom.gba", 0x11BD888, 0x40
+sVigorothGfx33_1:
+.incbin "baserom.gba", 0x11BD8C8, 0x40
+sVigorothGfx33_2:
+.incbin "baserom.gba", 0x11BD908, 0x40
+sVigorothGfx33_3:
+.incbin "baserom.gba", 0x11BD948, 0x40
+sVigorothSprites33:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx33_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx33_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx34:
+.incbin "baserom.gba", 0x11BD9D8, 0x20
+sVigorothGfx34_1:
+.incbin "baserom.gba", 0x11BD9F8, 0x60
+sVigorothGfx34_2:
+.incbin "baserom.gba", 0x11BDA58, 0x80
+sVigorothGfx34_3:
+.incbin "baserom.gba", 0x11BDAD8, 0x60
+sVigorothSprites34:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx34, 0x20
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx34_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx34_3, 0x60
+ax_sprite_terminator
+sVigorothGfx35:
+.incbin "baserom.gba", 0x11BDB80, 0x140
+sVigorothGfx35_1:
+.incbin "baserom.gba", 0x11BDCC0, 0x20
+sVigorothSprites35:
+ax_sprite sVigorothGfx35, 0x140
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx35_1, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVigorothGfx36:
+.incbin "baserom.gba", 0x11BDD08, 0x40
+sVigorothGfx36_1:
+.incbin "baserom.gba", 0x11BDD48, 0x100
+sVigorothGfx36_2:
+.incbin "baserom.gba", 0x11BDE48, 0x40
+sVigorothSprites36:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx36_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx37:
+.incbin "baserom.gba", 0x11BDEC8, 0x160
+sVigorothGfx37_1:
+.incbin "baserom.gba", 0x11BE028, 0x40
+sVigorothSprites37:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx37, 0x160
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx37_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx38:
+.incbin "baserom.gba", 0x11BE098, 0x60
+sVigorothGfx38_1:
+.incbin "baserom.gba", 0x11BE0F8, 0x60
+sVigorothGfx38_2:
+.incbin "baserom.gba", 0x11BE158, 0x60
+sVigorothGfx38_3:
+.incbin "baserom.gba", 0x11BE1B8, 0x40
+sVigorothSprites38:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx38_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx38_3, 0x40
+ax_sprite_terminator
+sVigorothGfx39:
+.incbin "baserom.gba", 0x11BE240, 0xE0
+sVigorothGfx39_1:
+.incbin "baserom.gba", 0x11BE320, 0x60
+sVigorothSprites39:
+ax_sprite 0, 0xa0
+ax_sprite sVigorothGfx39, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx39_1, 0x60
+ax_sprite_terminator
+sVigorothGfx40:
+.incbin "baserom.gba", 0x11BE3A8, 0x20
+sVigorothGfx40_1:
+.incbin "baserom.gba", 0x11BE3C8, 0x100
+sVigorothGfx40_2:
+.incbin "baserom.gba", 0x11BE4C8, 0x40
+sVigorothSprites40:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx40, 0x20
+ax_sprite 0, 0x40
+ax_sprite sVigorothGfx40_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx40_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVigorothGfx41:
+.incbin "baserom.gba", 0x11BE548, 0x60
+sVigorothGfx41_1:
+.incbin "baserom.gba", 0x11BE5A8, 0x180
+sVigorothSprites41:
+ax_sprite sVigorothGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx41_1, 0x180
+ax_sprite_terminator
+sVigorothGfx42:
+.incbin "baserom.gba", 0x11BE748, 0x60
+sVigorothGfx42_1:
+.incbin "baserom.gba", 0x11BE7A8, 0x60
+sVigorothGfx42_2:
+.incbin "baserom.gba", 0x11BE808, 0x100
+sVigorothSprites42:
+ax_sprite sVigorothGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx42_2, 0x100
+ax_sprite_terminator
+sVigorothGfx43:
+.incbin "baserom.gba", 0x11BE938, 0x60
+sVigorothGfx43_1:
+.incbin "baserom.gba", 0x11BE998, 0x160
+sVigorothSprites43:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx43_1, 0x160
+ax_sprite_terminator
+sVigorothGfx44:
+.incbin "baserom.gba", 0x11BEB20, 0x160
+sVigorothGfx44_1:
+.incbin "baserom.gba", 0x11BEC80, 0x60
+sVigorothSprites44:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx44, 0x160
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx44_1, 0x60
+ax_sprite_terminator
+sVigorothGfx45:
+.incbin "baserom.gba", 0x11BED08, 0x1E0
+sVigorothSprites45:
+ax_sprite 0, 0x20
+ax_sprite sVigorothGfx45, 0x1e0
+ax_sprite_terminator
+sVigorothGfx46:
+.incbin "baserom.gba", 0x11BEF00, 0x200
+sVigorothSprites46:
+ax_sprite sVigorothGfx46, 0x200
+ax_sprite_terminator
+sVigorothGfx47:
+.incbin "baserom.gba", 0x11BF110, 0x200
+sVigorothSprites47:
+ax_sprite sVigorothGfx47, 0x200
+ax_sprite_terminator
+sVigorothGfx48:
+.incbin "baserom.gba", 0x11BF320, 0x200
+sVigorothSprites48:
+ax_sprite sVigorothGfx48, 0x200
+ax_sprite_terminator
+sVigorothGfx49:
+.incbin "baserom.gba", 0x11BF530, 0x200
+sVigorothSprites49:
+ax_sprite sVigorothGfx49, 0x200
+ax_sprite_terminator
+sVigorothGfx50:
+.incbin "baserom.gba", 0x11BF740, 0x200
+sVigorothSprites50:
+ax_sprite sVigorothGfx50, 0x200
+ax_sprite_terminator
+sVigorothGfx51:
+.incbin "baserom.gba", 0x11BF950, 0x200
+sVigorothSprites51:
+ax_sprite sVigorothGfx51, 0x200
+ax_sprite_terminator
+sVigorothGfx52:
+.incbin "baserom.gba", 0x11BFB60, 0x80
+sVigorothSprites52:
+ax_sprite sVigorothGfx52, 0x80
+ax_sprite_terminator
+sVigorothGfx53:
+.incbin "baserom.gba", 0x11BFBF0, 0x20
+sVigorothSprites53:
+ax_sprite sVigorothGfx53, 0x20
+ax_sprite_terminator
+sVigorothGfx54:
+.incbin "baserom.gba", 0x11BFC20, 0x100
+sVigorothSprites54:
+ax_sprite sVigorothGfx54, 0x100
+ax_sprite_terminator
+sAxPosesVigoroth:
+.4byte sVigorothPose1
+.4byte sVigorothPose2
+.4byte sVigorothPose3
+.4byte sVigorothPose4
+.4byte sVigorothPose5
+.4byte sVigorothPose6
+.4byte sVigorothPose7
+.4byte sVigorothPose8
+.4byte sVigorothPose9
+.4byte sVigorothPose10
+.4byte sVigorothPose11
+.4byte sVigorothPose12
+.4byte sVigorothPose13
+.4byte sVigorothPose14
+.4byte sVigorothPose15
+.4byte sVigorothPose16
+.4byte sVigorothPose17
+.4byte sVigorothPose18
+.4byte sVigorothPose19
+.4byte sVigorothPose20
+.4byte sVigorothPose21
+.4byte sVigorothPose22
+.4byte sVigorothPose23
+.4byte sVigorothPose24
+.4byte sVigorothPose25
+.4byte sVigorothPose26
+.4byte sVigorothPose27
+.4byte sVigorothPose28
+.4byte sVigorothPose29
+.4byte sVigorothPose30
+.4byte sVigorothPose31
+.4byte sVigorothPose32
+.4byte sVigorothPose33
+.4byte sVigorothPose34
+.4byte sVigorothPose35
+.4byte sVigorothPose36
+.4byte sVigorothPose37
+.4byte sVigorothPose38
+.4byte sVigorothPose39
+.4byte sVigorothPose40
+.4byte sVigorothPose41
+.4byte sVigorothPose42
+.4byte sVigorothPose43
+.4byte sVigorothPose44
+.4byte sVigorothPose45
+.4byte sVigorothPose46
+.4byte sVigorothPose47
+.4byte sVigorothPose48
+.4byte sVigorothPose49
+.4byte sVigorothPose50
+.4byte sVigorothPose51
+.4byte sVigorothPose52
+.4byte sVigorothPose53
+.4byte sVigorothPose54
+.4byte sVigorothPose55
+.4byte sVigorothPose56
+.4byte sVigorothPose57
+.4byte sVigorothPose58
+.4byte sVigorothPose59
+.4byte sVigorothPose60
+.4byte sVigorothPose61
+.4byte sVigorothPose62
+.4byte sVigorothPose63
+.4byte sVigorothPose64
+.4byte sVigorothPose65
+.4byte sVigorothPose66
+.4byte sVigorothPose67
+.4byte sVigorothPose68
+.4byte sVigorothPose69
+.4byte sVigorothPose70
+.4byte sVigorothPose71
+.4byte sVigorothPose72
+.4byte sVigorothPose73
+.4byte sVigorothPose74
+.4byte sVigorothPose75
+.4byte sVigorothPose76
+.4byte sVigorothPose77
+.4byte sVigorothPose78
+.4byte sVigorothPose79
+.4byte sVigorothPose80
+.4byte sVigorothPose81
+.4byte sVigorothPose82
+.4byte sVigorothPose83
+.4byte sVigorothPose84
+.4byte sVigorothPose85
+.4byte sVigorothPose86
+.4byte sVigorothPose87
+.4byte sVigorothPose88
+.4byte sVigorothPose89
+.4byte sVigorothPose90
+.4byte sVigorothPose91
+.4byte sVigorothPose92
+.4byte sVigorothPose93
+.4byte sVigorothPose94
+.4byte sVigorothPose95
+.4byte sVigorothPose96
+.4byte sVigorothPose97
+.4byte sVigorothPose98
+.4byte sVigorothPose99
+.4byte sVigorothPose100
+.4byte sVigorothPose101
+.4byte sVigorothPose102
+.4byte sVigorothPose103
+.4byte sVigorothPose104
+.4byte sVigorothPose105
+.4byte sVigorothPose106
+.4byte sVigorothPose107
+.4byte sVigorothPose108
+.4byte sVigorothPose109
+.4byte sVigorothPose110
+.4byte sVigorothPose111
+.4byte sVigorothPose112
+.4byte sVigorothPose113
+.4byte sVigorothPose114
+.4byte sVigorothPose115
+.4byte sVigorothPose116
+.4byte sVigorothPose117
+.4byte sVigorothPose118
+.4byte sVigorothPose119
+.4byte sVigorothPose120
+.4byte sVigorothPose121
+.4byte sVigorothPose122
+.4byte sVigorothPose123
+.4byte sVigorothPose124
+.4byte sVigorothPose125
+.4byte sVigorothPose126
+.4byte sVigorothPose127
+.4byte sVigorothPose128
+.4byte sVigorothPose129
+.4byte sVigorothPose130
+.4byte sVigorothPose131
+.4byte sVigorothPose132
+.4byte sVigorothPose133
+.4byte sVigorothPose134
+.4byte sVigorothPose135
+.4byte sVigorothPose136
+.4byte sVigorothPose137
+.4byte sVigorothPose138
+.4byte sVigorothPose139
+.4byte sVigorothPose140
+.4byte sVigorothPose141
+.4byte sVigorothPose142
+.4byte sVigorothPose143
+.4byte sVigorothPose144
+.4byte sVigorothPose145
+.4byte sVigorothPose146
+.4byte sVigorothPose147
+.4byte sVigorothPose148
+.4byte sVigorothPose149
+.4byte sVigorothPose150
+.4byte sVigorothPose151
+.4byte sVigorothPose152
+.4byte sVigorothPose153
+.4byte sVigorothPose154
+.4byte sVigorothPose155
+.4byte sVigorothPose156
+.4byte sVigorothPose157
+.4byte sVigorothPose158
+.4byte sVigorothPose159
+.4byte sVigorothPose160
+.4byte sVigorothPose161
+.4byte sVigorothPose162
+.4byte sVigorothPose163
+.4byte sVigorothPose164
+.4byte sVigorothPose165
+.4byte sVigorothPose166
+.4byte sVigorothPose167
+.4byte sVigorothPose168
+.4byte sVigorothPose169
+.4byte sVigorothPose170
+.4byte sVigorothPose171
+.4byte sVigorothPose172
+.4byte sVigorothPose173
+.4byte sVigorothPose174
+.4byte sVigorothPose175
+.4byte sVigorothPose176
+.4byte sVigorothPose177
+.4byte sVigorothPose178
+.4byte sVigorothPose179
+.4byte sVigorothPose180
+.4byte sVigorothPose181
+.4byte sVigorothPose182
+.4byte sVigorothPose183
+.4byte sVigorothPose184
+.4byte sVigorothPose185
+.4byte sVigorothPose186
+.4byte sVigorothPose187
+.4byte sVigorothPose188
+.4byte sVigorothPose189
+.4byte sVigorothPose190
+.4byte sVigorothPose191
+.4byte sVigorothPose192
+.4byte sVigorothPose193
+.4byte sVigorothPose194
+.4byte sVigorothPose195
+.4byte sVigorothPose196
+.4byte sVigorothPose197
+.4byte sVigorothPose198
+.4byte sVigorothPose199
+.4byte sVigorothPose200
+.4byte sVigorothPose201
+.4byte sVigorothPose202
+.4byte sVigorothPose203
+.4byte sVigorothPose204
+.4byte sVigorothPose205
+.4byte sVigorothPose206
+.4byte sVigorothPose207
+.4byte sVigorothPose208
+.4byte sVigorothPose209
+.4byte sVigorothPose210
+.4byte sVigorothPose211
+.4byte sVigorothPose212
+.4byte sVigorothPose213
+.4byte sVigorothPose214
+.4byte sVigorothPose215
+.4byte sVigorothPose216
+.4byte sVigorothPose217
+.4byte sVigorothPose218
+.4byte sVigorothPose219
+.4byte sVigorothPose220
+.4byte sVigorothPose221
+.4byte sVigorothPose222
+.4byte sVigorothPose223
+.4byte sVigorothPose224
+.4byte sVigorothPose225
+.4byte sVigorothPose226
+sAxPositionsVigoroth:
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte   -2,   -6, 	 -10,    2, 	   7,   -3, 	  -2,   -8
+.2byte    0,   -6, 	  -8,   -3, 	   9,    2, 	   0,   -8
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+.2byte    5,   -7, 	  11,    0, 	  -5,   -1, 	   2,   -8
+.2byte    3,   -7, 	   8,   -6, 	   0,    2, 	   0,   -8
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    8,   -8, 	  11,   -3, 	   2,   -2, 	  -1,  -10
+.2byte    8,   -7, 	  -2,   -3, 	   8,    0, 	   1,  -10
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    3,  -12, 	   0,  -11, 	   7,   -4, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -9, 	  11,   -4, 	  -1,  -11
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    1,  -11, 	   9,   -9, 	  -8,   -5, 	   0,  -12
+.2byte   -2,  -11, 	   8,   -5, 	 -10,   -9, 	  -1,  -12
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -4,  -12, 	  -1,  -11, 	  -8,   -4, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -9, 	 -12,   -4, 	   0,  -11
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -9,   -8, 	 -12,   -3, 	  -3,   -2, 	   0,  -10
+.2byte   -9,   -7, 	   1,   -3, 	  -9,    0, 	  -2,  -10
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte   -6,   -7, 	 -12,    0, 	   4,   -1, 	  -3,   -8
+.2byte   -4,   -7, 	  -9,   -6, 	  -1,    2, 	  -1,   -8
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte   -2,   -6, 	 -10,    2, 	   7,   -3, 	  -2,   -8
+.2byte    0,   -6, 	  -8,   -3, 	   9,    2, 	   0,   -8
+.2byte   -1,   -4, 	 -13,   -1, 	  12,   -1, 	  -1,   -7
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+.2byte    5,   -7, 	  11,    0, 	  -5,   -1, 	   2,   -8
+.2byte    3,   -7, 	   8,   -6, 	   0,    2, 	   0,   -8
+.2byte    5,   -4, 	  14,   -5, 	  -7,    0, 	   2,  -10
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    8,   -8, 	  11,   -3, 	   2,   -2, 	  -1,  -10
+.2byte    8,   -7, 	  -2,   -3, 	   8,    0, 	   1,  -10
+.2byte    9,   -6, 	  13,   -6, 	   7,    3, 	   3,   -9
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    3,  -12, 	   0,  -11, 	   7,   -4, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -9, 	  11,   -4, 	  -1,  -11
+.2byte    8,  -11, 	  -6,  -10, 	  12,   -2, 	   0,  -12
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    1,  -11, 	   9,   -9, 	  -8,   -5, 	   0,  -12
+.2byte   -2,  -11, 	   8,   -5, 	 -10,   -9, 	  -1,  -12
+.2byte   -1,  -17, 	  12,   -9, 	 -13,   -9, 	  -1,  -13
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -4,  -12, 	  -1,  -11, 	  -8,   -4, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -9, 	 -12,   -4, 	   0,  -11
+.2byte   -9,  -11, 	   5,  -10, 	 -13,   -2, 	  -1,  -12
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -9,   -8, 	 -12,   -3, 	  -3,   -2, 	   0,  -10
+.2byte   -9,   -7, 	   1,   -3, 	  -9,    0, 	  -2,  -10
+.2byte  -10,   -6, 	 -14,   -6, 	  -8,    3, 	  -4,   -9
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte   -6,   -7, 	 -12,    0, 	   4,   -1, 	  -3,   -8
+.2byte   -4,   -7, 	  -9,   -6, 	  -1,    2, 	  -1,   -8
+.2byte   -6,   -4, 	 -15,   -5, 	   6,    0, 	  -3,  -10
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte   -2,   -6, 	 -10,    2, 	   7,   -3, 	  -2,   -8
+.2byte    0,   -6, 	  -8,   -3, 	   9,    2, 	   0,   -8
+.2byte   -2,   -9, 	  -6,  -23, 	   3,    2, 	   2,   -9
+.2byte    1,   -9, 	   6,    0, 	  10,  -19, 	  -1,   -8
+.2byte    1,   -9, 	   6,    0, 	  10,  -19, 	  -1,   -8
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+.2byte    5,   -7, 	  11,    0, 	  -5,   -1, 	   2,   -8
+.2byte    3,   -7, 	   8,   -6, 	   0,    2, 	   0,   -8
+.2byte    4,   -8, 	  -1,  -21, 	   3,    0, 	  -2,  -10
+.2byte    2,   -7, 	  -3,    1, 	 -12,  -15, 	   1,   -9
+.2byte    2,   -7, 	  -3,    1, 	 -12,  -15, 	   1,   -9
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    8,   -8, 	  11,   -3, 	   2,   -2, 	  -1,  -10
+.2byte    8,   -7, 	  -2,   -3, 	   8,    0, 	   1,  -10
+.2byte    2,  -12, 	  -9,  -24, 	   8,   -4, 	  -5,  -13
+.2byte    5,   -9, 	   3,    1, 	 -12,  -12, 	   0,  -10
+.2byte    5,   -9, 	   3,    1, 	 -12,  -12, 	   0,  -10
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    3,  -12, 	   0,  -11, 	   7,   -4, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -9, 	  11,   -4, 	  -1,  -11
+.2byte   -1,  -14, 	 -12,  -20, 	  11,   -6, 	  -3,  -10
+.2byte    5,  -13, 	  10,   -6, 	  -2,   -7, 	   0,  -12
+.2byte    5,  -13, 	  10,   -6, 	  -2,   -7, 	   0,  -12
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    1,  -11, 	   9,   -9, 	  -8,   -5, 	   0,  -12
+.2byte   -2,  -11, 	   8,   -5, 	 -10,   -9, 	  -1,  -12
+.2byte    0,  -13, 	   2,  -18, 	  -3,   -6, 	  -2,   -8
+.2byte   -5,  -11, 	 -11,   -8, 	  -5,   -6, 	   1,  -10
+.2byte   -5,  -11, 	 -11,   -8, 	  -5,   -6, 	   1,  -10
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -4,  -12, 	  -1,  -11, 	  -8,   -4, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -9, 	 -12,   -4, 	   0,  -11
+.2byte    0,  -14, 	  11,  -20, 	 -12,   -6, 	   2,  -10
+.2byte   -6,  -13, 	 -11,   -6, 	   1,   -7, 	  -1,  -12
+.2byte   -6,  -13, 	 -11,   -6, 	   1,   -7, 	  -1,  -12
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -9,   -8, 	 -12,   -3, 	  -3,   -2, 	   0,  -10
+.2byte   -9,   -7, 	   1,   -3, 	  -9,    0, 	  -2,  -10
+.2byte   -3,  -12, 	   8,  -24, 	  -9,   -4, 	   4,  -13
+.2byte   -6,   -9, 	  -4,    1, 	  11,  -12, 	  -1,  -10
+.2byte   -6,   -9, 	  -4,    1, 	  11,  -12, 	  -1,  -10
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte   -6,   -7, 	 -12,    0, 	   4,   -1, 	  -3,   -8
+.2byte   -4,   -7, 	  -9,   -6, 	  -1,    2, 	  -1,   -8
+.2byte   -5,   -8, 	   0,  -21, 	  -4,    0, 	   1,  -10
+.2byte   -3,   -7, 	   2,    1, 	  11,  -15, 	  -2,   -9
+.2byte   -3,   -7, 	   2,    1, 	  11,  -15, 	  -2,   -9
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte   -1,  -15, 	 -13,   -9, 	  12,   -9, 	  -1,  -13
+.2byte   -1,   -4, 	 -13,   -1, 	  12,   -1, 	  -1,   -7
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+.2byte   -2,  -15, 	  10,  -15, 	 -13,   -6, 	  -1,  -12
+.2byte    5,   -3, 	  14,   -4, 	  -7,    1, 	   2,   -9
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    0,  -14, 	   5,  -20, 	   2,   -4, 	   0,  -12
+.2byte    6,   -6, 	  10,   -6, 	   4,    3, 	   0,   -9
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    0,  -14, 	  -2,  -19, 	  10,  -11, 	  -3,   -9
+.2byte    8,  -10, 	  -6,   -9, 	  12,   -1, 	   0,  -11
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte   -1,  -13, 	  12,  -15, 	 -13,  -15, 	  -1,  -10
+.2byte   -1,  -16, 	  12,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -1,  -14, 	   1,  -19, 	 -11,  -11, 	   2,   -9
+.2byte   -9,  -10, 	   5,   -9, 	 -13,   -1, 	  -1,  -11
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -1,  -12, 	  -6,  -18, 	  -3,   -2, 	  -1,  -10
+.2byte   -7,   -6, 	 -11,   -6, 	  -5,    3, 	  -1,   -9
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte    1,  -15, 	 -11,  -15, 	  12,   -6, 	   0,  -12
+.2byte   -6,   -3, 	 -15,   -4, 	   6,    1, 	  -3,   -9
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte    2,  -12, 	 -10,  -26, 	  15,   -7, 	   0,  -12
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+.2byte   -1,  -13, 	   6,  -28, 	 -12,   -5, 	  -3,  -13
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    5,  -14, 	  -5,  -29, 	  12,   -8, 	  -3,  -15
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    2,  -15, 	 -10,  -23, 	  15,   -9, 	  -2,  -12
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    0,  -18, 	  11,  -24, 	 -14,  -14, 	  -1,  -14
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -3,  -15, 	   9,  -23, 	 -16,   -9, 	   1,  -12
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -6,  -14, 	   4,  -29, 	 -13,   -8, 	   2,  -15
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte    0,  -13, 	  -7,  -28, 	  11,   -5, 	   2,  -13
+.2byte   -1,   -2, 	 -12,   -1, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	 -12,   -1, 	   4,    2, 	  -1,   -5
+.2byte   -1,   -7, 	  -8,   -2, 	   7,   -2, 	  -1,   -9
+.2byte    2,   -8, 	   8,   -7, 	  -4,   -4, 	  -1,   -9
+.2byte    1,  -10, 	   9,  -10, 	   8,   -6, 	  -3,  -10
+.2byte    2,  -10, 	   0,  -20, 	  10,  -14, 	  -1,   -7
+.2byte   -1,  -10, 	   9,  -15, 	 -10,  -15, 	  -1,   -9
+.2byte   -3,  -10, 	  -1,  -20, 	 -11,  -14, 	   0,   -7
+.2byte   -2,  -10, 	 -10,  -10, 	  -9,   -6, 	   2,  -10
+.2byte   -3,   -8, 	  -9,   -7, 	   3,   -4, 	   0,   -9
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte   -2,   -6, 	 -10,    2, 	   7,   -3, 	  -2,   -8
+.2byte    0,   -6, 	  -8,   -3, 	   9,    2, 	   0,   -8
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+.2byte    5,   -7, 	  11,    0, 	  -5,   -1, 	   2,   -8
+.2byte    3,   -7, 	   8,   -6, 	   0,    2, 	   0,   -8
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    8,   -8, 	  11,   -3, 	   2,   -2, 	  -1,  -10
+.2byte    8,   -7, 	  -2,   -3, 	   8,    0, 	   1,  -10
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    3,  -12, 	   0,  -11, 	   7,   -4, 	  -2,  -10
+.2byte    5,  -12, 	  -7,   -9, 	  11,   -4, 	  -1,  -11
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    1,  -11, 	   9,   -9, 	  -8,   -5, 	   0,  -12
+.2byte   -2,  -11, 	   8,   -5, 	 -10,   -9, 	  -1,  -12
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -4,  -12, 	  -1,  -11, 	  -8,   -4, 	   1,  -10
+.2byte   -6,  -12, 	   6,   -9, 	 -12,   -4, 	   0,  -11
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -9,   -8, 	 -12,   -3, 	  -3,   -2, 	   0,  -10
+.2byte   -9,   -7, 	   1,   -3, 	  -9,    0, 	  -2,  -10
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte   -6,   -7, 	 -12,    0, 	   4,   -1, 	  -3,   -8
+.2byte   -4,   -7, 	  -9,   -6, 	  -1,    2, 	  -1,   -8
+.2byte   -1,   -4, 	 -13,   -1, 	  12,   -1, 	  -1,   -7
+.2byte   -5,   -3, 	 -14,   -4, 	   7,    1, 	  -2,   -9
+.2byte   -7,   -6, 	 -11,   -6, 	  -5,    3, 	  -1,   -9
+.2byte   -9,  -10, 	   5,   -9, 	 -13,   -1, 	  -1,  -11
+.2byte   -1,  -16, 	  12,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte    8,  -10, 	  -6,   -9, 	  12,   -1, 	   0,  -11
+.2byte    6,   -6, 	  10,   -6, 	   4,    3, 	   0,   -9
+.2byte    4,   -3, 	  13,   -4, 	  -8,    1, 	   1,   -9
+.2byte   -1,   -4, 	 -13,   -1, 	  12,   -1, 	  -1,   -7
+.2byte    4,   -3, 	  13,   -4, 	  -8,    1, 	   1,   -9
+.2byte    6,   -6, 	  10,   -6, 	   4,    3, 	   0,   -9
+.2byte    8,  -10, 	  -6,   -9, 	  12,   -1, 	   0,  -11
+.2byte   -1,  -16, 	  12,   -8, 	 -13,   -8, 	  -1,  -12
+.2byte   -9,  -10, 	   5,   -9, 	 -13,   -1, 	  -1,  -11
+.2byte   -7,   -6, 	 -11,   -6, 	  -5,    3, 	  -1,   -9
+.2byte   -5,   -3, 	 -14,   -4, 	   7,    1, 	  -2,   -9
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte    1,  -12, 	 -11,  -26, 	  14,   -7, 	  -1,  -12
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+.2byte    2,  -13, 	   9,  -28, 	  -9,   -5, 	   0,  -13
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    5,  -14, 	  -5,  -29, 	  12,   -8, 	  -3,  -15
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    2,  -15, 	 -10,  -23, 	  15,   -9, 	  -2,  -12
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    0,  -18, 	  11,  -24, 	 -14,  -14, 	  -1,  -14
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -3,  -15, 	   9,  -23, 	 -16,   -9, 	   1,  -12
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -6,  -14, 	   4,  -29, 	 -13,   -8, 	   2,  -15
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte   -2,  -13, 	  -9,  -28, 	   9,   -5, 	   0,  -13
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte   -3,   -9, 	  -8,   -4, 	   2,   -1, 	   0,  -10
+.2byte   -7,   -9, 	  -9,   -7, 	  -6,   -1, 	  -1,  -12
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    6,   -9, 	   8,   -7, 	   5,   -1, 	   0,  -12
+.2byte    2,   -9, 	   7,   -4, 	  -3,   -1, 	  -1,  -10
+.2byte   -1,   -8, 	  -9,   -1, 	   8,   -1, 	  -1,  -10
+.2byte   -5,   -9, 	 -10,   -4, 	   0,   -1, 	  -2,  -10
+.2byte   -8,   -9, 	 -10,   -7, 	  -7,   -1, 	  -2,  -12
+.2byte   -5,  -13, 	   4,  -11, 	  -9,   -4, 	   1,  -11
+.2byte   -1,  -12, 	   8,   -7, 	  -9,   -7, 	  -1,  -13
+.2byte    4,  -13, 	  -5,  -11, 	   8,   -4, 	  -2,  -11
+.2byte    7,   -9, 	   9,   -7, 	   6,   -1, 	   1,  -12
+.2byte    4,   -9, 	   9,   -4, 	  -1,   -1, 	   1,  -10
+sVigorothAnimTable1:
+.4byte sVigorothAnims_1_1
+.4byte sVigorothAnims_1_2
+.4byte sVigorothAnims_1_3
+.4byte sVigorothAnims_1_4
+.4byte sVigorothAnims_1_5
+.4byte sVigorothAnims_1_6
+.4byte sVigorothAnims_1_7
+.4byte sVigorothAnims_1_8
+sVigorothAnimTable2:
+.4byte sVigorothAnims_2_1
+.4byte sVigorothAnims_2_2
+.4byte sVigorothAnims_2_3
+.4byte sVigorothAnims_2_4
+.4byte sVigorothAnims_2_5
+.4byte sVigorothAnims_2_6
+.4byte sVigorothAnims_2_7
+.4byte sVigorothAnims_2_8
+sVigorothAnimTable3:
+.4byte sVigorothAnims_3_1
+.4byte sVigorothAnims_3_2
+.4byte sVigorothAnims_3_3
+.4byte sVigorothAnims_3_4
+.4byte sVigorothAnims_3_5
+.4byte sVigorothAnims_3_6
+.4byte sVigorothAnims_3_7
+.4byte sVigorothAnims_3_8
+sVigorothAnimTable4:
+.4byte sVigorothAnims_4_1
+.4byte sVigorothAnims_4_2
+.4byte sVigorothAnims_4_3
+.4byte sVigorothAnims_4_4
+.4byte sVigorothAnims_4_5
+.4byte sVigorothAnims_4_6
+.4byte sVigorothAnims_4_7
+.4byte sVigorothAnims_4_8
+sVigorothAnimTable5:
+.4byte sVigorothAnims_5_1
+.4byte sVigorothAnims_5_2
+.4byte sVigorothAnims_5_3
+.4byte sVigorothAnims_5_4
+.4byte sVigorothAnims_5_5
+.4byte sVigorothAnims_5_6
+.4byte sVigorothAnims_5_7
+.4byte sVigorothAnims_5_8
+sVigorothAnimTable6:
+.4byte sVigorothAnims_6_1
+.4byte sVigorothAnims_6_1
+.4byte sVigorothAnims_6_1
+.4byte sVigorothAnims_6_1
+.4byte sVigorothAnims_6_1
+.4byte sVigorothAnims_6_1
+.4byte sVigorothAnims_6_1
+.4byte sVigorothAnims_6_1
+sVigorothAnimTable7:
+.4byte sVigorothAnims_7_1
+.4byte sVigorothAnims_7_2
+.4byte sVigorothAnims_7_3
+.4byte sVigorothAnims_7_4
+.4byte sVigorothAnims_7_5
+.4byte sVigorothAnims_7_6
+.4byte sVigorothAnims_7_7
+.4byte sVigorothAnims_7_8
+sVigorothAnimTable8:
+.4byte sVigorothAnims_8_1
+.4byte sVigorothAnims_8_2
+.4byte sVigorothAnims_8_3
+.4byte sVigorothAnims_8_4
+.4byte sVigorothAnims_8_5
+.4byte sVigorothAnims_8_6
+.4byte sVigorothAnims_8_7
+.4byte sVigorothAnims_8_8
+sVigorothAnimTable9:
+.4byte sVigorothAnims_9_1
+.4byte sVigorothAnims_9_2
+.4byte sVigorothAnims_9_3
+.4byte sVigorothAnims_9_4
+.4byte sVigorothAnims_9_5
+.4byte sVigorothAnims_9_6
+.4byte sVigorothAnims_9_7
+.4byte sVigorothAnims_9_8
+sVigorothAnimTable10:
+.4byte sVigorothAnims_10_1
+.4byte sVigorothAnims_10_2
+.4byte sVigorothAnims_10_3
+.4byte sVigorothAnims_10_4
+.4byte sVigorothAnims_10_5
+.4byte sVigorothAnims_10_6
+.4byte sVigorothAnims_10_7
+.4byte sVigorothAnims_10_8
+sVigorothAnimTable11:
+.4byte sVigorothAnims_11_1
+.4byte sVigorothAnims_11_2
+.4byte sVigorothAnims_11_3
+.4byte sVigorothAnims_11_4
+.4byte sVigorothAnims_11_5
+.4byte sVigorothAnims_11_6
+.4byte sVigorothAnims_11_7
+.4byte sVigorothAnims_11_8
+sVigorothAnimTable12:
+.4byte sVigorothAnims_12_1
+.4byte sVigorothAnims_12_2
+.4byte sVigorothAnims_12_3
+.4byte sVigorothAnims_12_4
+.4byte sVigorothAnims_12_5
+.4byte sVigorothAnims_12_6
+.4byte sVigorothAnims_12_7
+.4byte sVigorothAnims_12_8
+sVigorothAnimTable13:
+.4byte sVigorothAnims_13_1
+.4byte sVigorothAnims_13_2
+.4byte sVigorothAnims_13_3
+.4byte sVigorothAnims_13_4
+.4byte sVigorothAnims_13_5
+.4byte sVigorothAnims_13_6
+.4byte sVigorothAnims_13_7
+.4byte sVigorothAnims_13_8
+sAxAnimationsVigoroth:
+.4byte sVigorothAnimTable1
+.4byte sVigorothAnimTable2
+.4byte sVigorothAnimTable3
+.4byte sVigorothAnimTable4
+.4byte sVigorothAnimTable5
+.4byte sVigorothAnimTable6
+.4byte sVigorothAnimTable7
+.4byte sVigorothAnimTable8
+.4byte sVigorothAnimTable9
+.4byte sVigorothAnimTable10
+.4byte sVigorothAnimTable11
+.4byte sVigorothAnimTable12
+.4byte sVigorothAnimTable13
+sAxSpritesVigoroth:
+.4byte sVigorothSprites1
+.4byte sVigorothSprites2
+.4byte sVigorothSprites3
+.4byte sVigorothSprites4
+.4byte sVigorothSprites5
+.4byte sVigorothSprites6
+.4byte sVigorothSprites7
+.4byte sVigorothSprites8
+.4byte sVigorothSprites9
+.4byte sVigorothSprites10
+.4byte sVigorothSprites11
+.4byte sVigorothSprites12
+.4byte sVigorothSprites13
+.4byte sVigorothSprites14
+.4byte sVigorothSprites15
+.4byte sVigorothSprites16
+.4byte sVigorothSprites17
+.4byte sVigorothSprites18
+.4byte sVigorothSprites19
+.4byte sVigorothSprites20
+.4byte sVigorothSprites21
+.4byte sVigorothSprites22
+.4byte sVigorothSprites23
+.4byte sVigorothSprites24
+.4byte sVigorothSprites25
+.4byte sVigorothSprites26
+.4byte sVigorothSprites27
+.4byte sVigorothSprites28
+.4byte sVigorothSprites29
+.4byte sVigorothSprites30
+.4byte sVigorothSprites31
+.4byte sVigorothSprites32
+.4byte sVigorothSprites33
+.4byte sVigorothSprites34
+.4byte sVigorothSprites35
+.4byte sVigorothSprites36
+.4byte sVigorothSprites37
+.4byte sVigorothSprites38
+.4byte sVigorothSprites39
+.4byte sVigorothSprites40
+.4byte sVigorothSprites41
+.4byte sVigorothSprites42
+.4byte sVigorothSprites43
+.4byte sVigorothSprites44
+.4byte sVigorothSprites45
+.4byte sVigorothSprites46
+.4byte sVigorothSprites47
+.4byte sVigorothSprites48
+.4byte sVigorothSprites49
+.4byte sVigorothSprites50
+.4byte sVigorothSprites51
+.4byte sVigorothSprites52
+.4byte sVigorothSprites53
+.4byte sVigorothSprites54
+sAxMainVigoroth:
+ax_main sAxPosesVigoroth, sAxAnimationsVigoroth, 13, sAxSpritesVigoroth, sAxPositionsVigoroth

--- a/data/ax/vileplume.inc
+++ b/data/ax/vileplume.inc
@@ -1,0 +1,2794 @@
+.global gAxVileplume
+gAxVileplume:
+ax_siro sAxMainVileplume
+sVileplumePose1:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose4:
+ax_pose 3, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose5:
+ax_pose 4, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose6:
+ax_pose 5, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose7:
+ax_pose 6, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose8:
+ax_pose 7, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose9:
+ax_pose 8, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose10:
+ax_pose 9, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose11:
+ax_pose 10, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose12:
+ax_pose 11, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose13:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose14:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose15:
+ax_pose 14, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose16:
+ax_pose 9, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose17:
+ax_pose 10, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose18:
+ax_pose 11, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose19:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose20:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose22:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose23:
+ax_pose 4, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose24:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose25:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose28:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose29:
+ax_pose 16, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose30:
+ax_pose 3, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose31:
+ax_pose 4, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose32:
+ax_pose 5, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose33:
+ax_pose 17, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose34:
+ax_pose 18, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sVileplumePose35:
+ax_pose 6, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose36:
+ax_pose 7, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose37:
+ax_pose 8, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose38:
+ax_pose 19, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose39:
+ax_pose 20, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sVileplumePose40:
+ax_pose 9, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose41:
+ax_pose 10, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose42:
+ax_pose 11, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose43:
+ax_pose 21, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose44:
+ax_pose 22, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVileplumePose45:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose46:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose47:
+ax_pose 14, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose48:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose49:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose50:
+ax_pose 9, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose51:
+ax_pose 10, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose52:
+ax_pose 11, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose53:
+ax_pose 21, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose54:
+ax_pose 22, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose55:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose56:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose57:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose58:
+ax_pose 19, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose59:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVileplumePose60:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose61:
+ax_pose 4, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose62:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose63:
+ax_pose 17, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose64:
+ax_pose 18, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose65:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose66:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose67:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose68:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose69:
+ax_pose 16, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose70:
+ax_pose 3, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose71:
+ax_pose 4, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose72:
+ax_pose 5, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose73:
+ax_pose 17, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose74:
+ax_pose 18, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sVileplumePose75:
+ax_pose 6, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose76:
+ax_pose 7, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose77:
+ax_pose 8, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose78:
+ax_pose 19, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose79:
+ax_pose 20, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sVileplumePose80:
+ax_pose 9, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose81:
+ax_pose 10, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose82:
+ax_pose 11, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose83:
+ax_pose 21, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose84:
+ax_pose 22, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVileplumePose85:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose86:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose87:
+ax_pose 14, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose88:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose89:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose90:
+ax_pose 9, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose91:
+ax_pose 10, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose92:
+ax_pose 11, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose93:
+ax_pose 21, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose94:
+ax_pose 22, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose95:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose96:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose97:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose98:
+ax_pose 19, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose99:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVileplumePose100:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose101:
+ax_pose 4, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose102:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose103:
+ax_pose 17, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose104:
+ax_pose 18, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose105:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose106:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose107:
+ax_pose 16, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose108:
+ax_pose 3, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose109:
+ax_pose 17, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose110:
+ax_pose 18, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sVileplumePose111:
+ax_pose 6, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose112:
+ax_pose 19, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose113:
+ax_pose 20, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sVileplumePose114:
+ax_pose 9, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose115:
+ax_pose 21, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose116:
+ax_pose 22, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVileplumePose117:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose118:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose119:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose120:
+ax_pose 9, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose121:
+ax_pose 21, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose122:
+ax_pose 22, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose123:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose124:
+ax_pose 19, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose125:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVileplumePose126:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose127:
+ax_pose 17, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose128:
+ax_pose 18, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose129:
+ax_pose 16, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose130:
+ax_pose 18, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose131:
+ax_pose 20, 0x01e8, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose132:
+ax_pose 22, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose133:
+ax_pose 24, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose134:
+ax_pose 22, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose135:
+ax_pose 20, 0x01e7, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose136:
+ax_pose 18, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose137:
+ax_pose 25, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose138:
+ax_pose 26, 0x01eb, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose139:
+ax_pose 27, 0x01e3, 0x80ef, 0x2c00
+ax_pose_terminator
+sVileplumePose140:
+ax_pose 28, 0x01e5, 0x90e8, 0x2c00
+ax_pose_terminator
+sVileplumePose141:
+ax_pose 29, 0x01e5, 0x90e8, 0x2c00
+ax_pose_terminator
+sVileplumePose142:
+ax_pose 30, 0x01e4, 0x90ea, 0x2c00
+ax_pose_terminator
+sVileplumePose143:
+ax_pose 31, 0x01e4, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose144:
+ax_pose 30, 0x01e4, 0x80f6, 0x2c00
+ax_pose_terminator
+sVileplumePose145:
+ax_pose 29, 0x01e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sVileplumePose146:
+ax_pose 28, 0x01e5, 0x80f8, 0x2c00
+ax_pose_terminator
+sVileplumePose147:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose148:
+ax_pose 1, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose149:
+ax_pose 2, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose150:
+ax_pose 3, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose151:
+ax_pose 4, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose152:
+ax_pose 5, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose153:
+ax_pose 6, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose154:
+ax_pose 7, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose155:
+ax_pose 8, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose156:
+ax_pose 9, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose157:
+ax_pose 10, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose158:
+ax_pose 11, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose159:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose160:
+ax_pose 13, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose161:
+ax_pose 14, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose162:
+ax_pose 9, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose163:
+ax_pose 10, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose164:
+ax_pose 11, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose165:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose166:
+ax_pose 7, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose167:
+ax_pose 8, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose168:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose169:
+ax_pose 4, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose170:
+ax_pose 5, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose171:
+ax_pose 16, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose172:
+ax_pose 18, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose173:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVileplumePose174:
+ax_pose 22, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose175:
+ax_pose 24, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose176:
+ax_pose 22, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVileplumePose177:
+ax_pose 20, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sVileplumePose178:
+ax_pose 18, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sVileplumePose179:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose180:
+ax_pose 17, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose181:
+ax_pose 19, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose182:
+ax_pose 21, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose183:
+ax_pose 23, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose184:
+ax_pose 21, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose185:
+ax_pose 19, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose186:
+ax_pose 17, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose187:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose188:
+ax_pose 15, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose189:
+ax_pose 16, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose190:
+ax_pose 3, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose191:
+ax_pose 17, 0x01ea, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose192:
+ax_pose 18, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sVileplumePose193:
+ax_pose 6, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose194:
+ax_pose 19, 0x01e8, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose195:
+ax_pose 20, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sVileplumePose196:
+ax_pose 9, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose197:
+ax_pose 21, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose198:
+ax_pose 22, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVileplumePose199:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose200:
+ax_pose 23, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose201:
+ax_pose 24, 0x01e7, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose202:
+ax_pose 9, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose203:
+ax_pose 21, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose204:
+ax_pose 22, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose205:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose206:
+ax_pose 19, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose207:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVileplumePose208:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose209:
+ax_pose 17, 0x01ea, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose210:
+ax_pose 18, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose211:
+ax_pose 16, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose212:
+ax_pose 18, 0x01ea, 0x80f1, 0x2c00
+ax_pose_terminator
+sVileplumePose213:
+ax_pose 20, 0x01e8, 0x80f3, 0x2c00
+ax_pose_terminator
+sVileplumePose214:
+ax_pose 22, 0x01eb, 0x80f2, 0x2c00
+ax_pose_terminator
+sVileplumePose215:
+ax_pose 24, 0x01e8, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose216:
+ax_pose 22, 0x01eb, 0x90ed, 0x2c00
+ax_pose_terminator
+sVileplumePose217:
+ax_pose 20, 0x01e8, 0x90ec, 0x2c00
+ax_pose_terminator
+sVileplumePose218:
+ax_pose 18, 0x01ea, 0x90ee, 0x2c00
+ax_pose_terminator
+sVileplumePose219:
+ax_pose 0, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose220:
+ax_pose 3, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose221:
+ax_pose 6, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose222:
+ax_pose 9, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose223:
+ax_pose 12, 0x01eb, 0x80f0, 0x2c00
+ax_pose_terminator
+sVileplumePose224:
+ax_pose 9, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose225:
+ax_pose 6, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+sVileplumePose226:
+ax_pose 3, 0x01eb, 0x90ef, 0x2c00
+ax_pose_terminator
+.align 2
+sVileplumeAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, -3, 0, -3,
+ax_anim 2, 0, 24, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 4, 0, 4,
+ax_anim 2, 2, 25, 0, 14, 0, 14,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 1, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 0, 28, 1, 19, 1, 19,
+ax_anim 2, 0, 28, 0, 19, 0, 19,
+ax_anim 2, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 24, 0, 4, 0, 4,
+ax_anim_terminator
+sVileplumeAnims_2_2:
+ax_anim 2, 0, 30, -1, -1, -1, -1,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 2, 0, 31, -2, -2, -2, -2,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 30, -3, -3, -3, -3,
+ax_anim 2, 0, 29, -3, -3, -3, -3,
+ax_anim 1, 0, 31, 4, 6, 4, 6,
+ax_anim 2, 2, 30, 11, 14, 11, 14,
+ax_anim 2, 0, 33, 17, 21, 17, 21,
+ax_anim 2, 1, 33, 18, 20, 18, 20,
+ax_anim 2, 0, 33, 17, 21, 17, 21,
+ax_anim 2, 0, 33, 18, 20, 18, 20,
+ax_anim 2, 0, 33, 17, 21, 17, 21,
+ax_anim 2, 0, 29, 10, 13, 10, 13,
+ax_anim 2, 0, 29, 4, 4, 4, 4,
+ax_anim_terminator
+sVileplumeAnims_2_3:
+ax_anim 2, 0, 35, -1, 0, -1, 0,
+ax_anim 2, 0, 34, -1, 0, -1, 0,
+ax_anim 2, 0, 36, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 35, -3, 0, -3, 0,
+ax_anim 2, 0, 34, -3, 0, -3, 0,
+ax_anim 1, 0, 36, 3, 0, 3, 0,
+ax_anim 2, 2, 35, 9, 0, 9, 0,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 1, 38, 18, -1, 18, -1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 38, 18, -1, 18, -1,
+ax_anim 2, 0, 38, 18, 0, 18, 0,
+ax_anim 2, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 34, 3, 0, 3, 0,
+ax_anim_terminator
+sVileplumeAnims_2_4:
+ax_anim 2, 0, 40, -1, 1, -1, 1,
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 2, 0, 41, -2, 2, -2, 2,
+ax_anim 2, 0, 39, -2, 2, -2, 2,
+ax_anim 2, 0, 40, -3, 3, -3, 3,
+ax_anim 2, 0, 39, -3, 3, -3, 3,
+ax_anim 1, 0, 41, 5, -6, 5, -6,
+ax_anim 2, 2, 40, 12, -14, 12, -14,
+ax_anim 2, 0, 43, 19, -21, 19, -21,
+ax_anim 2, 1, 43, 20, -20, 20, -20,
+ax_anim 2, 0, 43, 19, -21, 19, -21,
+ax_anim 2, 0, 43, 20, -20, 20, -20,
+ax_anim 2, 0, 43, 19, -21, 19, -21,
+ax_anim 2, 0, 39, 11, -12, 11, -12,
+ax_anim 2, 0, 39, 4, -4, 4, -4,
+ax_anim_terminator
+sVileplumeAnims_2_5:
+ax_anim 2, 0, 45, 0, 1, 0, 1,
+ax_anim 2, 0, 44, 0, 1, 0, 1,
+ax_anim 2, 0, 46, 0, 2, 0, 2,
+ax_anim 2, 0, 44, 0, 2, 0, 2,
+ax_anim 2, 0, 45, 0, 3, 0, 3,
+ax_anim 2, 0, 44, 0, 3, 0, 3,
+ax_anim 1, 0, 46, 0, -4, 0, -4,
+ax_anim 2, 2, 45, 0, -14, 0, -14,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 1, 48, 1, -19, 1, -19,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 0, 48, 1, -19, 1, -19,
+ax_anim 2, 0, 48, 0, -19, 0, -19,
+ax_anim 2, 0, 44, 0, -10, 0, -10,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim_terminator
+sVileplumeAnims_2_6:
+ax_anim 2, 0, 50, 1, 1, 1, 1,
+ax_anim 2, 0, 49, 1, 1, 1, 1,
+ax_anim 2, 0, 51, 2, 2, 2, 2,
+ax_anim 2, 0, 49, 2, 2, 2, 2,
+ax_anim 2, 0, 50, 3, 3, 3, 3,
+ax_anim 2, 0, 49, 3, 3, 3, 3,
+ax_anim 1, 0, 51, -5, -6, -5, -6,
+ax_anim 2, 2, 50, -12, -14, -12, -14,
+ax_anim 2, 0, 53, -19, -21, -19, -21,
+ax_anim 2, 1, 53, -20, -20, -20, -20,
+ax_anim 2, 0, 53, -19, -21, -19, -21,
+ax_anim 2, 0, 53, -20, -20, -20, -20,
+ax_anim 2, 0, 53, -19, -21, -19, -21,
+ax_anim 2, 0, 49, -11, -12, -11, -12,
+ax_anim 2, 0, 49, -4, -4, -4, -4,
+ax_anim_terminator
+sVileplumeAnims_2_7:
+ax_anim 2, 0, 55, 1, 0, 1, 0,
+ax_anim 2, 0, 54, 1, 0, 1, 0,
+ax_anim 2, 0, 56, 2, 0, 2, 0,
+ax_anim 2, 0, 54, 2, 0, 2, 0,
+ax_anim 2, 0, 55, 3, 0, 3, 0,
+ax_anim 2, 0, 54, 3, 0, 3, 0,
+ax_anim 1, 0, 56, -3, 0, -3, 0,
+ax_anim 2, 2, 55, -9, 0, -9, 0,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 1, 58, -18, -1, -18, -1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 58, -18, -1, -18, -1,
+ax_anim 2, 0, 58, -18, 0, -18, 0,
+ax_anim 2, 0, 54, -8, 0, -8, 0,
+ax_anim 2, 0, 54, -3, 0, -3, 0,
+ax_anim_terminator
+sVileplumeAnims_2_8:
+ax_anim 2, 0, 60, 1, -1, 1, -1,
+ax_anim 2, 0, 59, 1, -1, 1, -1,
+ax_anim 2, 0, 61, 2, -2, 2, -2,
+ax_anim 2, 0, 59, 2, -2, 2, -2,
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim 2, 0, 59, 3, -3, 3, -3,
+ax_anim 1, 0, 61, -4, 6, -4, 6,
+ax_anim 2, 2, 60, -11, 14, -11, 14,
+ax_anim 2, 0, 63, -17, 21, -17, 21,
+ax_anim 2, 1, 63, -18, 20, -18, 20,
+ax_anim 2, 0, 63, -17, 21, -17, 21,
+ax_anim 2, 0, 63, -18, 20, -18, 20,
+ax_anim 2, 0, 63, -17, 21, -17, 21,
+ax_anim 2, 0, 59, -10, 13, -10, 13,
+ax_anim 2, 0, 59, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_3_1:
+ax_anim 2, 0, 65, 0, -1, 0, -1,
+ax_anim 2, 0, 64, 0, -1, 0, -1,
+ax_anim 2, 0, 66, 0, -2, 0, -2,
+ax_anim 2, 0, 64, 0, -2, 0, -2,
+ax_anim 2, 0, 65, 0, -3, 0, -3,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim 1, 0, 66, 0, 4, 0, 4,
+ax_anim 2, 2, 65, 0, 14, 0, 14,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 1, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 0, 68, 1, 19, 1, 19,
+ax_anim 2, 0, 68, 0, 19, 0, 19,
+ax_anim 2, 0, 64, 0, 10, 0, 10,
+ax_anim 2, 0, 64, 0, 4, 0, 4,
+ax_anim_terminator
+sVileplumeAnims_3_2:
+ax_anim 2, 0, 70, -1, -1, -1, -1,
+ax_anim 2, 0, 69, -1, -1, -1, -1,
+ax_anim 2, 0, 71, -2, -2, -2, -2,
+ax_anim 2, 0, 69, -2, -2, -2, -2,
+ax_anim 2, 0, 70, -3, -3, -3, -3,
+ax_anim 2, 0, 69, -3, -3, -3, -3,
+ax_anim 1, 0, 71, 4, 6, 4, 6,
+ax_anim 2, 2, 70, 11, 14, 11, 14,
+ax_anim 2, 0, 73, 17, 21, 17, 21,
+ax_anim 2, 1, 73, 18, 20, 18, 20,
+ax_anim 2, 0, 73, 17, 21, 17, 21,
+ax_anim 2, 0, 73, 18, 20, 18, 20,
+ax_anim 2, 0, 73, 17, 21, 17, 21,
+ax_anim 2, 0, 69, 10, 13, 10, 13,
+ax_anim 2, 0, 69, 4, 4, 4, 4,
+ax_anim_terminator
+sVileplumeAnims_3_3:
+ax_anim 2, 0, 75, -1, 0, -1, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 2, 0, 74, -2, 0, -2, 0,
+ax_anim 2, 0, 75, -3, 0, -3, 0,
+ax_anim 2, 0, 74, -3, 0, -3, 0,
+ax_anim 1, 0, 76, 3, 0, 3, 0,
+ax_anim 2, 2, 75, 9, 0, 9, 0,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 1, 78, 18, -1, 18, -1,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 78, 18, -1, 18, -1,
+ax_anim 2, 0, 78, 18, 0, 18, 0,
+ax_anim 2, 0, 74, 8, 0, 8, 0,
+ax_anim 2, 0, 74, 3, 0, 3, 0,
+ax_anim_terminator
+sVileplumeAnims_3_4:
+ax_anim 2, 0, 80, -1, 1, -1, 1,
+ax_anim 2, 0, 79, -1, 1, -1, 1,
+ax_anim 2, 0, 81, -2, 2, -2, 2,
+ax_anim 2, 0, 79, -2, 2, -2, 2,
+ax_anim 2, 0, 80, -3, 3, -3, 3,
+ax_anim 2, 0, 79, -3, 3, -3, 3,
+ax_anim 1, 0, 81, 5, -6, 5, -6,
+ax_anim 2, 2, 80, 12, -14, 12, -14,
+ax_anim 2, 0, 83, 19, -21, 19, -21,
+ax_anim 2, 1, 83, 20, -20, 20, -20,
+ax_anim 2, 0, 83, 19, -21, 19, -21,
+ax_anim 2, 0, 83, 20, -20, 20, -20,
+ax_anim 2, 0, 83, 19, -21, 19, -21,
+ax_anim 2, 0, 79, 11, -12, 11, -12,
+ax_anim 2, 0, 79, 4, -4, 4, -4,
+ax_anim_terminator
+sVileplumeAnims_3_5:
+ax_anim 2, 0, 85, 0, 1, 0, 1,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 2, 0, 84, 0, 2, 0, 2,
+ax_anim 2, 0, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 3, 0, 3,
+ax_anim 1, 0, 86, 0, -4, 0, -4,
+ax_anim 2, 2, 85, 0, -14, 0, -14,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 1, 88, 1, -19, 1, -19,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 0, 88, 1, -19, 1, -19,
+ax_anim 2, 0, 88, 0, -19, 0, -19,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, -4, 0, -4,
+ax_anim_terminator
+sVileplumeAnims_3_6:
+ax_anim 2, 0, 90, 1, 1, 1, 1,
+ax_anim 2, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 2, 0, 89, 2, 2, 2, 2,
+ax_anim 2, 0, 90, 3, 3, 3, 3,
+ax_anim 2, 0, 89, 3, 3, 3, 3,
+ax_anim 1, 0, 91, -5, -6, -5, -6,
+ax_anim 2, 2, 90, -12, -14, -12, -14,
+ax_anim 2, 0, 93, -19, -21, -19, -21,
+ax_anim 2, 1, 93, -20, -20, -20, -20,
+ax_anim 2, 0, 93, -19, -21, -19, -21,
+ax_anim 2, 0, 93, -20, -20, -20, -20,
+ax_anim 2, 0, 93, -19, -21, -19, -21,
+ax_anim 2, 0, 89, -11, -12, -11, -12,
+ax_anim 2, 0, 89, -4, -4, -4, -4,
+ax_anim_terminator
+sVileplumeAnims_3_7:
+ax_anim 2, 0, 95, 1, 0, 1, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 2, 0, 2, 0,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 94, 3, 0, 3, 0,
+ax_anim 1, 0, 96, -3, 0, -3, 0,
+ax_anim 2, 2, 95, -9, 0, -9, 0,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 1, 98, -18, -1, -18, -1,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 0, 98, -18, -1, -18, -1,
+ax_anim 2, 0, 98, -18, 0, -18, 0,
+ax_anim 2, 0, 94, -8, 0, -8, 0,
+ax_anim 2, 0, 94, -3, 0, -3, 0,
+ax_anim_terminator
+sVileplumeAnims_3_8:
+ax_anim 2, 0, 100, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 101, 2, -2, 2, -2,
+ax_anim 2, 0, 99, 2, -2, 2, -2,
+ax_anim 2, 0, 100, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 1, 0, 101, -4, 6, -4, 6,
+ax_anim 2, 2, 100, -11, 14, -11, 14,
+ax_anim 2, 0, 103, -17, 21, -17, 21,
+ax_anim 2, 1, 103, -18, 20, -18, 20,
+ax_anim 2, 0, 103, -17, 21, -17, 21,
+ax_anim 2, 0, 103, -18, 20, -18, 20,
+ax_anim 2, 0, 103, -17, 21, -17, 21,
+ax_anim 2, 0, 99, -10, 13, -10, 13,
+ax_anim 2, 0, 99, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 0, 104, 0, -3, 0, -3,
+ax_anim 6, 2, 105, 0, -3, 0, -3,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 0, 6, 0, 6,
+ax_anim 2, 0, 106, -1, 6, -1, 6,
+ax_anim 2, 0, 106, 0, 6, 0, 6,
+ax_anim 2, 0, 106, -1, 6, -1, 6,
+ax_anim 2, 0, 106, 0, 6, 0, 6,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sVileplumeAnims_4_2:
+ax_anim 2, 0, 107, -1, -1, -1, -1,
+ax_anim 2, 0, 107, -3, -3, -3, -3,
+ax_anim 6, 2, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 1, 109, 4, 4, 6, 6,
+ax_anim 2, 0, 109, 3, 5, 5, 7,
+ax_anim 2, 0, 109, 4, 4, 6, 6,
+ax_anim 2, 0, 109, 3, 5, 5, 7,
+ax_anim 2, 0, 109, 4, 4, 6, 6,
+ax_anim 2, 0, 107, 2, 2, 2, 2,
+ax_anim_terminator
+sVileplumeAnims_4_3:
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 110, -3, 0, -3, 0,
+ax_anim 6, 2, 111, -3, 0, -3, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 4, 0, 6, 0,
+ax_anim 2, 0, 112, 4, 1, 6, 1,
+ax_anim 2, 0, 112, 4, 0, 6, 0,
+ax_anim 2, 0, 112, 4, 1, 6, 1,
+ax_anim 2, 0, 112, 4, 0, 6, 0,
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim_terminator
+sVileplumeAnims_4_4:
+ax_anim 2, 0, 113, -1, 1, -1, 1,
+ax_anim 2, 0, 113, -3, 3, -3, 3,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 4, -4, 6, -6,
+ax_anim 2, 0, 115, 3, -5, 5, -7,
+ax_anim 2, 0, 115, 4, -4, 6, -6,
+ax_anim 2, 0, 115, 3, -5, 5, -7,
+ax_anim 2, 0, 115, 4, -4, 6, -6,
+ax_anim 2, 0, 113, 2, -2, 2, -2,
+ax_anim_terminator
+sVileplumeAnims_4_5:
+ax_anim 2, 0, 116, 0, 1, 0, 1,
+ax_anim 2, 0, 116, 0, 3, 0, 3,
+ax_anim 6, 2, 117, 0, 3, 0, 3,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 0, -4, 0, -6,
+ax_anim 2, 0, 118, 1, -4, 1, -6,
+ax_anim 2, 0, 118, 0, -4, 0, -6,
+ax_anim 2, 0, 118, 1, -4, 1, -6,
+ax_anim 2, 0, 118, 0, -4, 0, -6,
+ax_anim 2, 0, 116, 0, -2, 0, -2,
+ax_anim_terminator
+sVileplumeAnims_4_6:
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 3, 3, 3, 3,
+ax_anim 6, 2, 120, 3, 3, 3, 3,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 121, -4, -4, -6, -6,
+ax_anim 2, 0, 121, -3, -5, -5, -7,
+ax_anim 2, 0, 121, -4, -4, -6, -6,
+ax_anim 2, 0, 121, -3, -5, -5, -7,
+ax_anim 2, 0, 121, -4, -4, -6, -6,
+ax_anim 2, 0, 119, -2, -2, -2, -2,
+ax_anim_terminator
+sVileplumeAnims_4_7:
+ax_anim 2, 0, 122, 1, 0, 1, 0,
+ax_anim 2, 0, 122, 3, 0, 3, 0,
+ax_anim 6, 2, 123, 3, 0, 3, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 1, 124, -4, 0, -6, 0,
+ax_anim 2, 0, 124, -4, 1, -6, 1,
+ax_anim 2, 0, 124, -4, 0, -6, 0,
+ax_anim 2, 0, 124, -4, 1, -6, 1,
+ax_anim 2, 0, 124, -4, 0, -6, 0,
+ax_anim 2, 0, 122, -2, 0, -2, 0,
+ax_anim_terminator
+sVileplumeAnims_4_8:
+ax_anim 2, 0, 125, 1, -1, 1, -1,
+ax_anim 2, 0, 125, 3, -3, 3, -3,
+ax_anim 6, 2, 126, 3, -3, 3, -3,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 127, -4, 4, -6, 6,
+ax_anim 2, 0, 127, -3, 5, -5, 7,
+ax_anim 2, 0, 127, -4, 4, -6, 6,
+ax_anim 2, 0, 127, -3, 5, -5, 7,
+ax_anim 2, 0, 127, -4, 4, -6, 6,
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_5_1:
+ax_anim 6, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim 1, 0, 135, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -5, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 2, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 1, 0, 130, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 1, 0, 134, 0, -9, 0, 0,
+ax_anim 1, 0, 133, 0, -8, 0, 0,
+ax_anim 1, 0, 132, 0, -7, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 1, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_5_2:
+ax_anim 6, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim 1, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 133, 0, -5, 0, 0,
+ax_anim 1, 0, 132, 0, -6, 0, 0,
+ax_anim 1, 2, 131, 0, -7, 0, 0,
+ax_anim 1, 0, 130, 0, -8, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 1, 0, 133, 0, -9, 0, 0,
+ax_anim 1, 0, 132, 0, -8, 0, 0,
+ax_anim 1, 0, 131, 0, -7, 0, 0,
+ax_anim 1, 0, 130, 0, -6, 0, 0,
+ax_anim 1, 1, 129, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_5_3:
+ax_anim 6, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 1, 0, 133, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -5, 0, 0,
+ax_anim 1, 0, 131, 0, -6, 0, 0,
+ax_anim 1, 2, 130, 0, -7, 0, 0,
+ax_anim 1, 0, 129, 0, -8, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 0, 135, 0, -10, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 1, 0, 132, 0, -9, 0, 0,
+ax_anim 1, 0, 131, 0, -8, 0, 0,
+ax_anim 1, 0, 130, 0, -7, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 1, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_5_4:
+ax_anim 6, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 1, 0, 132, 0, -4, 0, 0,
+ax_anim 1, 0, 131, 0, -5, 0, 0,
+ax_anim 1, 0, 130, 0, -6, 0, 0,
+ax_anim 1, 2, 129, 0, -7, 0, 0,
+ax_anim 1, 0, 128, 0, -8, 0, 0,
+ax_anim 1, 0, 135, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 1, 0, 131, 0, -9, 0, 0,
+ax_anim 1, 0, 130, 0, -8, 0, 0,
+ax_anim 1, 0, 129, 0, -7, 0, 0,
+ax_anim 1, 0, 128, 0, -6, 0, 0,
+ax_anim 1, 1, 135, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_5_5:
+ax_anim 6, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 1, 0, 131, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -5, 0, 0,
+ax_anim 1, 0, 129, 0, -6, 0, 0,
+ax_anim 1, 2, 128, 0, -7, 0, 0,
+ax_anim 1, 0, 135, 0, -8, 0, 0,
+ax_anim 1, 0, 134, 0, -9, 0, 0,
+ax_anim 1, 0, 133, 0, -10, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 1, 0, 130, 0, -9, 0, 0,
+ax_anim 1, 0, 129, 0, -8, 0, 0,
+ax_anim 1, 0, 128, 0, -7, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 1, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_5_6:
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim 1, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 129, 0, -5, 0, 0,
+ax_anim 1, 0, 128, 0, -6, 0, 0,
+ax_anim 1, 2, 135, 0, -7, 0, 0,
+ax_anim 1, 0, 134, 0, -8, 0, 0,
+ax_anim 1, 0, 133, 0, -9, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 1, 0, 129, 0, -9, 0, 0,
+ax_anim 1, 0, 128, 0, -8, 0, 0,
+ax_anim 1, 0, 135, 0, -7, 0, 0,
+ax_anim 1, 0, 134, 0, -6, 0, 0,
+ax_anim 1, 1, 133, 0, -5, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 2, 0, 131, 0, -2, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_5_7:
+ax_anim 6, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim 1, 0, 129, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -5, 0, 0,
+ax_anim 1, 0, 135, 0, -6, 0, 0,
+ax_anim 1, 2, 134, 0, -7, 0, 0,
+ax_anim 1, 0, 133, 0, -8, 0, 0,
+ax_anim 1, 0, 132, 0, -9, 0, 0,
+ax_anim 1, 0, 131, 0, -10, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, 0,
+ax_anim 1, 0, 135, 0, -8, 0, 0,
+ax_anim 1, 0, 134, 0, -7, 0, 0,
+ax_anim 1, 0, 133, 0, -6, 0, 0,
+ax_anim 1, 1, 132, 0, -5, 0, 0,
+ax_anim 2, 0, 131, 0, -4, 0, 0,
+ax_anim 2, 0, 130, 0, -2, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_5_8:
+ax_anim 6, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 1, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 135, 0, -5, 0, 0,
+ax_anim 1, 0, 134, 0, -6, 0, 0,
+ax_anim 1, 2, 133, 0, -7, 0, 0,
+ax_anim 1, 0, 132, 0, -8, 0, 0,
+ax_anim 1, 0, 131, 0, -9, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 1, 0, 129, 0, -10, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 1, 0, 135, 0, -9, 0, 0,
+ax_anim 1, 0, 134, 0, -8, 0, 0,
+ax_anim 1, 0, 133, 0, -7, 0, 0,
+ax_anim 1, 0, 132, 0, -6, 0, 0,
+ax_anim 1, 1, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_6_1:
+ax_anim 35, 0, 136, 0, 0, 0, 0,
+ax_anim 30, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_7_1:
+ax_anim 2, 0, 138, 0, -2, 0, -2,
+ax_anim 8, 0, 138, 0, -3, 0, -3,
+ax_anim_terminator
+sVileplumeAnims_7_2:
+ax_anim 2, 0, 139, -2, -2, -2, -2,
+ax_anim 8, 0, 139, -3, -3, -3, -3,
+ax_anim_terminator
+sVileplumeAnims_7_3:
+ax_anim 2, 0, 140, -2, 0, -2, 0,
+ax_anim 8, 0, 140, -3, 0, -3, 0,
+ax_anim_terminator
+sVileplumeAnims_7_4:
+ax_anim 2, 0, 141, -2, 2, -2, 2,
+ax_anim 8, 0, 141, -3, 3, -3, 3,
+ax_anim_terminator
+sVileplumeAnims_7_5:
+ax_anim 2, 0, 142, 0, 2, 0, 2,
+ax_anim 8, 0, 142, 0, 3, 0, 3,
+ax_anim_terminator
+sVileplumeAnims_7_6:
+ax_anim 2, 0, 143, 2, 2, 2, 2,
+ax_anim 8, 0, 143, 3, 3, 3, 3,
+ax_anim_terminator
+sVileplumeAnims_7_7:
+ax_anim 2, 0, 144, 2, 0, 2, 0,
+ax_anim 8, 0, 144, 3, 0, 3, 0,
+ax_anim_terminator
+sVileplumeAnims_7_8:
+ax_anim 2, 0, 145, 2, -2, 2, -2,
+ax_anim 8, 0, 145, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 147, 0, -1, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 8, 0, 147, 0, -4, 0, 0,
+ax_anim 3, 0, 147, 0, -3, 0, 0,
+ax_anim 3, 0, 147, 0, -1, 0, 0,
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim 3, 0, 148, 0, -3, 0, 0,
+ax_anim 8, 0, 148, 0, -4, 0, 0,
+ax_anim 3, 0, 148, 0, -3, 0, 0,
+ax_anim 3, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_8_2:
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 150, 0, -1, 0, 0,
+ax_anim 3, 0, 150, 0, -3, 0, 0,
+ax_anim 8, 0, 150, 0, -4, 0, 0,
+ax_anim 3, 0, 150, 0, -3, 0, 0,
+ax_anim 3, 0, 150, 0, -1, 0, 0,
+ax_anim 30, 0, 149, 0, 0, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim 3, 0, 151, 0, -3, 0, 0,
+ax_anim 8, 0, 151, 0, -4, 0, 0,
+ax_anim 3, 0, 151, 0, -3, 0, 0,
+ax_anim 3, 0, 151, 0, -1, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_8_3:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 153, 0, -1, 0, 0,
+ax_anim 3, 0, 153, 0, -3, 0, 0,
+ax_anim 8, 0, 153, 0, -4, 0, 0,
+ax_anim 3, 0, 153, 0, -3, 0, 0,
+ax_anim 3, 0, 153, 0, -1, 0, 0,
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 3, 0, 154, 0, -1, 0, 0,
+ax_anim 3, 0, 154, 0, -3, 0, 0,
+ax_anim 8, 0, 154, 0, -4, 0, 0,
+ax_anim 3, 0, 154, 0, -3, 0, 0,
+ax_anim 3, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_8_4:
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 156, 0, -1, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 8, 0, 156, 0, -4, 0, 0,
+ax_anim 3, 0, 156, 0, -3, 0, 0,
+ax_anim 3, 0, 156, 0, -1, 0, 0,
+ax_anim 30, 0, 155, 0, 0, 0, 0,
+ax_anim 3, 0, 157, 0, -1, 0, 0,
+ax_anim 3, 0, 157, 0, -3, 0, 0,
+ax_anim 8, 0, 157, 0, -4, 0, 0,
+ax_anim 3, 0, 157, 0, -3, 0, 0,
+ax_anim 3, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_8_5:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 159, 0, -1, 0, 0,
+ax_anim 3, 0, 159, 0, -3, 0, 0,
+ax_anim 8, 0, 159, 0, -4, 0, 0,
+ax_anim 3, 0, 159, 0, -3, 0, 0,
+ax_anim 3, 0, 159, 0, -1, 0, 0,
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 3, 0, 160, 0, -1, 0, 0,
+ax_anim 3, 0, 160, 0, -3, 0, 0,
+ax_anim 8, 0, 160, 0, -4, 0, 0,
+ax_anim 3, 0, 160, 0, -3, 0, 0,
+ax_anim 3, 0, 160, 0, -1, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_8_6:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 3, 0, 162, 0, -1, 0, 0,
+ax_anim 3, 0, 162, 0, -3, 0, 0,
+ax_anim 8, 0, 162, 0, -4, 0, 0,
+ax_anim 3, 0, 162, 0, -3, 0, 0,
+ax_anim 3, 0, 162, 0, -1, 0, 0,
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 3, 0, 163, 0, -1, 0, 0,
+ax_anim 3, 0, 163, 0, -3, 0, 0,
+ax_anim 8, 0, 163, 0, -4, 0, 0,
+ax_anim 3, 0, 163, 0, -3, 0, 0,
+ax_anim 3, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_8_7:
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 3, 0, 165, 0, -1, 0, 0,
+ax_anim 3, 0, 165, 0, -3, 0, 0,
+ax_anim 8, 0, 165, 0, -4, 0, 0,
+ax_anim 3, 0, 165, 0, -3, 0, 0,
+ax_anim 3, 0, 165, 0, -1, 0, 0,
+ax_anim 30, 0, 164, 0, 0, 0, 0,
+ax_anim 3, 0, 166, 0, -1, 0, 0,
+ax_anim 3, 0, 166, 0, -3, 0, 0,
+ax_anim 8, 0, 166, 0, -4, 0, 0,
+ax_anim 3, 0, 166, 0, -3, 0, 0,
+ax_anim 3, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_8_8:
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 168, 0, -1, 0, 0,
+ax_anim 3, 0, 168, 0, -3, 0, 0,
+ax_anim 8, 0, 168, 0, -4, 0, 0,
+ax_anim 3, 0, 168, 0, -3, 0, 0,
+ax_anim 3, 0, 168, 0, -1, 0, 0,
+ax_anim 30, 0, 167, 0, 0, 0, 0,
+ax_anim 3, 0, 169, 0, -1, 0, 0,
+ax_anim 3, 0, 169, 0, -3, 0, 0,
+ax_anim 8, 0, 169, 0, -4, 0, 0,
+ax_anim 3, 0, 169, 0, -3, 0, 0,
+ax_anim 3, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 16, 7, 16,
+ax_anim 3, 0, 174, 0, 20, 0, 20,
+ax_anim 2, 3, 175, -7, 16, -7, 16,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 8, 0, 8, 0,
+ax_anim 2, 0, 171, 19, 3, 19, 3,
+ax_anim 2, 0, 172, 23, 10, 23, 10,
+ax_anim 3, 0, 173, 22, 20, 22, 20,
+ax_anim 2, 3, 174, 11, 21, 11, 21,
+ax_anim 2, 0, 175, 3, 15, 3, 15,
+ax_anim 1, 0, 176, 0, 7, 0, 7,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 11, -6, 11, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 23, -2, 23, -2,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -6, -1, -6,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 12, -22, 12, -22,
+ax_anim 3, 0, 171, 21, -21, 21, -21,
+ax_anim 2, 3, 172, 22, -15, 22, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 9, 0, 9, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -14, -9, -14,
+ax_anim 2, 0, 177, -7, -18, -7, -18,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -18, 7, -18,
+ax_anim 2, 0, 172, 9, -12, 9, -12,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -6, 1, -6,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -12, -22, -12, -22,
+ax_anim 3, 0, 177, -21, -21, -21, -21,
+ax_anim 2, 3, 176, -22, -15, -22, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -9, 0, -9, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -11, -6, -11, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -23, -2, -23, -2,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -8, 0, -8, 0,
+ax_anim 2, 0, 177, -19, 3, -19, 3,
+ax_anim 2, 0, 176, -23, 10, -23, 10,
+ax_anim 3, 0, 175, -22, 20, -22, 20,
+ax_anim 2, 3, 174, -11, 21, -11, 21,
+ax_anim 2, 0, 173, -3, 15, -3, 15,
+ax_anim 1, 0, 172, 0, 7, 0, 7,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 188, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 194, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 200, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 203, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 206, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 209, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVileplumeAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sVileplumeGfx1:
+.incbin "baserom.gba", 0x6E99DC, 0x200
+sVileplumeSprites1:
+ax_sprite sVileplumeGfx1, 0x200
+ax_sprite_terminator
+sVileplumeGfx2:
+.incbin "baserom.gba", 0x6E9BEC, 0x200
+sVileplumeSprites2:
+ax_sprite sVileplumeGfx2, 0x200
+ax_sprite_terminator
+sVileplumeGfx3:
+.incbin "baserom.gba", 0x6E9DFC, 0x200
+sVileplumeSprites3:
+ax_sprite sVileplumeGfx3, 0x200
+ax_sprite_terminator
+sVileplumeGfx4:
+.incbin "baserom.gba", 0x6EA00C, 0x200
+sVileplumeSprites4:
+ax_sprite sVileplumeGfx4, 0x200
+ax_sprite_terminator
+sVileplumeGfx5:
+.incbin "baserom.gba", 0x6EA21C, 0x200
+sVileplumeSprites5:
+ax_sprite sVileplumeGfx5, 0x200
+ax_sprite_terminator
+sVileplumeGfx6:
+.incbin "baserom.gba", 0x6EA42C, 0x200
+sVileplumeSprites6:
+ax_sprite sVileplumeGfx6, 0x200
+ax_sprite_terminator
+sVileplumeGfx7:
+.incbin "baserom.gba", 0x6EA63C, 0x200
+sVileplumeSprites7:
+ax_sprite sVileplumeGfx7, 0x200
+ax_sprite_terminator
+sVileplumeGfx8:
+.incbin "baserom.gba", 0x6EA84C, 0x200
+sVileplumeSprites8:
+ax_sprite sVileplumeGfx8, 0x200
+ax_sprite_terminator
+sVileplumeGfx9:
+.incbin "baserom.gba", 0x6EAA5C, 0x200
+sVileplumeSprites9:
+ax_sprite sVileplumeGfx9, 0x200
+ax_sprite_terminator
+sVileplumeGfx10:
+.incbin "baserom.gba", 0x6EAC6C, 0x200
+sVileplumeSprites10:
+ax_sprite sVileplumeGfx10, 0x200
+ax_sprite_terminator
+sVileplumeGfx11:
+.incbin "baserom.gba", 0x6EAE7C, 0x200
+sVileplumeSprites11:
+ax_sprite sVileplumeGfx11, 0x200
+ax_sprite_terminator
+sVileplumeGfx12:
+.incbin "baserom.gba", 0x6EB08C, 0x200
+sVileplumeSprites12:
+ax_sprite sVileplumeGfx12, 0x200
+ax_sprite_terminator
+sVileplumeGfx13:
+.incbin "baserom.gba", 0x6EB29C, 0x200
+sVileplumeSprites13:
+ax_sprite sVileplumeGfx13, 0x200
+ax_sprite_terminator
+sVileplumeGfx14:
+.incbin "baserom.gba", 0x6EB4AC, 0x200
+sVileplumeSprites14:
+ax_sprite sVileplumeGfx14, 0x200
+ax_sprite_terminator
+sVileplumeGfx15:
+.incbin "baserom.gba", 0x6EB6BC, 0x200
+sVileplumeSprites15:
+ax_sprite sVileplumeGfx15, 0x200
+ax_sprite_terminator
+sVileplumeGfx16:
+.incbin "baserom.gba", 0x6EB8CC, 0x100
+sVileplumeGfx16_1:
+.incbin "baserom.gba", 0x6EB9CC, 0x40
+sVileplumeSprites16:
+ax_sprite sVileplumeGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx16_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVileplumeGfx17:
+.incbin "baserom.gba", 0x6EBA34, 0x180
+sVileplumeSprites17:
+ax_sprite sVileplumeGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVileplumeGfx18:
+.incbin "baserom.gba", 0x6EBBCC, 0x80
+sVileplumeGfx18_1:
+.incbin "baserom.gba", 0x6EBC4C, 0x60
+sVileplumeGfx18_2:
+.incbin "baserom.gba", 0x6EBCAC, 0x40
+sVileplumeGfx18_3:
+.incbin "baserom.gba", 0x6EBCEC, 0x20
+sVileplumeSprites18:
+ax_sprite sVileplumeGfx18, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx18_2, 0x40
+ax_sprite 0, 0x60
+ax_sprite sVileplumeGfx18_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVileplumeGfx19:
+.incbin "baserom.gba", 0x6EBD54, 0x60
+sVileplumeGfx19_1:
+.incbin "baserom.gba", 0x6EBDB4, 0xE0
+sVileplumeGfx19_2:
+.incbin "baserom.gba", 0x6EBE94, 0x20
+sVileplumeSprites19:
+ax_sprite sVileplumeGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx19_1, 0xe0
+ax_sprite 0, 0x60
+ax_sprite sVileplumeGfx19_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVileplumeGfx20:
+.incbin "baserom.gba", 0x6EBEEC, 0x60
+sVileplumeGfx20_1:
+.incbin "baserom.gba", 0x6EBF4C, 0x60
+sVileplumeGfx20_2:
+.incbin "baserom.gba", 0x6EBFAC, 0x60
+sVileplumeGfx20_3:
+.incbin "baserom.gba", 0x6EC00C, 0x40
+sVileplumeSprites20:
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx20_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVileplumeGfx21:
+.incbin "baserom.gba", 0x6EC09C, 0x20
+sVileplumeGfx21_1:
+.incbin "baserom.gba", 0x6EC0BC, 0x60
+sVileplumeGfx21_2:
+.incbin "baserom.gba", 0x6EC11C, 0x60
+sVileplumeGfx21_3:
+.incbin "baserom.gba", 0x6EC17C, 0x60
+sVileplumeSprites21:
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx21, 0x20
+ax_sprite 0, 0x40
+ax_sprite sVileplumeGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVileplumeGfx22:
+.incbin "baserom.gba", 0x6EC22C, 0x100
+sVileplumeGfx22_1:
+.incbin "baserom.gba", 0x6EC32C, 0x60
+sVileplumeSprites22:
+ax_sprite sVileplumeGfx22, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx22_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVileplumeGfx23:
+.incbin "baserom.gba", 0x6EC3B4, 0x60
+sVileplumeGfx23_1:
+.incbin "baserom.gba", 0x6EC414, 0x60
+sVileplumeGfx23_2:
+.incbin "baserom.gba", 0x6EC474, 0x60
+sVileplumeSprites23:
+ax_sprite sVileplumeGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVileplumeGfx24:
+.incbin "baserom.gba", 0x6EC50C, 0x180
+sVileplumeGfx24_1:
+.incbin "baserom.gba", 0x6EC68C, 0x40
+sVileplumeSprites24:
+ax_sprite sVileplumeGfx24, 0x180
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx24_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVileplumeGfx25:
+.incbin "baserom.gba", 0x6EC6F4, 0x60
+sVileplumeGfx25_1:
+.incbin "baserom.gba", 0x6EC754, 0x100
+sVileplumeGfx25_2:
+.incbin "baserom.gba", 0x6EC854, 0x40
+sVileplumeSprites25:
+ax_sprite sVileplumeGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx25_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVileplumeGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVileplumeGfx26:
+.incbin "baserom.gba", 0x6EC8CC, 0x200
+sVileplumeSprites26:
+ax_sprite sVileplumeGfx26, 0x200
+ax_sprite_terminator
+sVileplumeGfx27:
+.incbin "baserom.gba", 0x6ECADC, 0x200
+sVileplumeSprites27:
+ax_sprite sVileplumeGfx27, 0x200
+ax_sprite_terminator
+sVileplumeGfx28:
+.incbin "baserom.gba", 0x6ECCEC, 0x200
+sVileplumeSprites28:
+ax_sprite sVileplumeGfx28, 0x200
+ax_sprite_terminator
+sVileplumeGfx29:
+.incbin "baserom.gba", 0x6ECEFC, 0x200
+sVileplumeSprites29:
+ax_sprite sVileplumeGfx29, 0x200
+ax_sprite_terminator
+sVileplumeGfx30:
+.incbin "baserom.gba", 0x6ED10C, 0x200
+sVileplumeSprites30:
+ax_sprite sVileplumeGfx30, 0x200
+ax_sprite_terminator
+sVileplumeGfx31:
+.incbin "baserom.gba", 0x6ED31C, 0x200
+sVileplumeSprites31:
+ax_sprite sVileplumeGfx31, 0x200
+ax_sprite_terminator
+sVileplumeGfx32:
+.incbin "baserom.gba", 0x6ED52C, 0x200
+sVileplumeSprites32:
+ax_sprite sVileplumeGfx32, 0x200
+ax_sprite_terminator
+sAxPosesVileplume:
+.4byte sVileplumePose1
+.4byte sVileplumePose2
+.4byte sVileplumePose3
+.4byte sVileplumePose4
+.4byte sVileplumePose5
+.4byte sVileplumePose6
+.4byte sVileplumePose7
+.4byte sVileplumePose8
+.4byte sVileplumePose9
+.4byte sVileplumePose10
+.4byte sVileplumePose11
+.4byte sVileplumePose12
+.4byte sVileplumePose13
+.4byte sVileplumePose14
+.4byte sVileplumePose15
+.4byte sVileplumePose16
+.4byte sVileplumePose17
+.4byte sVileplumePose18
+.4byte sVileplumePose19
+.4byte sVileplumePose20
+.4byte sVileplumePose21
+.4byte sVileplumePose22
+.4byte sVileplumePose23
+.4byte sVileplumePose24
+.4byte sVileplumePose25
+.4byte sVileplumePose26
+.4byte sVileplumePose27
+.4byte sVileplumePose28
+.4byte sVileplumePose29
+.4byte sVileplumePose30
+.4byte sVileplumePose31
+.4byte sVileplumePose32
+.4byte sVileplumePose33
+.4byte sVileplumePose34
+.4byte sVileplumePose35
+.4byte sVileplumePose36
+.4byte sVileplumePose37
+.4byte sVileplumePose38
+.4byte sVileplumePose39
+.4byte sVileplumePose40
+.4byte sVileplumePose41
+.4byte sVileplumePose42
+.4byte sVileplumePose43
+.4byte sVileplumePose44
+.4byte sVileplumePose45
+.4byte sVileplumePose46
+.4byte sVileplumePose47
+.4byte sVileplumePose48
+.4byte sVileplumePose49
+.4byte sVileplumePose50
+.4byte sVileplumePose51
+.4byte sVileplumePose52
+.4byte sVileplumePose53
+.4byte sVileplumePose54
+.4byte sVileplumePose55
+.4byte sVileplumePose56
+.4byte sVileplumePose57
+.4byte sVileplumePose58
+.4byte sVileplumePose59
+.4byte sVileplumePose60
+.4byte sVileplumePose61
+.4byte sVileplumePose62
+.4byte sVileplumePose63
+.4byte sVileplumePose64
+.4byte sVileplumePose65
+.4byte sVileplumePose66
+.4byte sVileplumePose67
+.4byte sVileplumePose68
+.4byte sVileplumePose69
+.4byte sVileplumePose70
+.4byte sVileplumePose71
+.4byte sVileplumePose72
+.4byte sVileplumePose73
+.4byte sVileplumePose74
+.4byte sVileplumePose75
+.4byte sVileplumePose76
+.4byte sVileplumePose77
+.4byte sVileplumePose78
+.4byte sVileplumePose79
+.4byte sVileplumePose80
+.4byte sVileplumePose81
+.4byte sVileplumePose82
+.4byte sVileplumePose83
+.4byte sVileplumePose84
+.4byte sVileplumePose85
+.4byte sVileplumePose86
+.4byte sVileplumePose87
+.4byte sVileplumePose88
+.4byte sVileplumePose89
+.4byte sVileplumePose90
+.4byte sVileplumePose91
+.4byte sVileplumePose92
+.4byte sVileplumePose93
+.4byte sVileplumePose94
+.4byte sVileplumePose95
+.4byte sVileplumePose96
+.4byte sVileplumePose97
+.4byte sVileplumePose98
+.4byte sVileplumePose99
+.4byte sVileplumePose100
+.4byte sVileplumePose101
+.4byte sVileplumePose102
+.4byte sVileplumePose103
+.4byte sVileplumePose104
+.4byte sVileplumePose105
+.4byte sVileplumePose106
+.4byte sVileplumePose107
+.4byte sVileplumePose108
+.4byte sVileplumePose109
+.4byte sVileplumePose110
+.4byte sVileplumePose111
+.4byte sVileplumePose112
+.4byte sVileplumePose113
+.4byte sVileplumePose114
+.4byte sVileplumePose115
+.4byte sVileplumePose116
+.4byte sVileplumePose117
+.4byte sVileplumePose118
+.4byte sVileplumePose119
+.4byte sVileplumePose120
+.4byte sVileplumePose121
+.4byte sVileplumePose122
+.4byte sVileplumePose123
+.4byte sVileplumePose124
+.4byte sVileplumePose125
+.4byte sVileplumePose126
+.4byte sVileplumePose127
+.4byte sVileplumePose128
+.4byte sVileplumePose129
+.4byte sVileplumePose130
+.4byte sVileplumePose131
+.4byte sVileplumePose132
+.4byte sVileplumePose133
+.4byte sVileplumePose134
+.4byte sVileplumePose135
+.4byte sVileplumePose136
+.4byte sVileplumePose137
+.4byte sVileplumePose138
+.4byte sVileplumePose139
+.4byte sVileplumePose140
+.4byte sVileplumePose141
+.4byte sVileplumePose142
+.4byte sVileplumePose143
+.4byte sVileplumePose144
+.4byte sVileplumePose145
+.4byte sVileplumePose146
+.4byte sVileplumePose147
+.4byte sVileplumePose148
+.4byte sVileplumePose149
+.4byte sVileplumePose150
+.4byte sVileplumePose151
+.4byte sVileplumePose152
+.4byte sVileplumePose153
+.4byte sVileplumePose154
+.4byte sVileplumePose155
+.4byte sVileplumePose156
+.4byte sVileplumePose157
+.4byte sVileplumePose158
+.4byte sVileplumePose159
+.4byte sVileplumePose160
+.4byte sVileplumePose161
+.4byte sVileplumePose162
+.4byte sVileplumePose163
+.4byte sVileplumePose164
+.4byte sVileplumePose165
+.4byte sVileplumePose166
+.4byte sVileplumePose167
+.4byte sVileplumePose168
+.4byte sVileplumePose169
+.4byte sVileplumePose170
+.4byte sVileplumePose171
+.4byte sVileplumePose172
+.4byte sVileplumePose173
+.4byte sVileplumePose174
+.4byte sVileplumePose175
+.4byte sVileplumePose176
+.4byte sVileplumePose177
+.4byte sVileplumePose178
+.4byte sVileplumePose179
+.4byte sVileplumePose180
+.4byte sVileplumePose181
+.4byte sVileplumePose182
+.4byte sVileplumePose183
+.4byte sVileplumePose184
+.4byte sVileplumePose185
+.4byte sVileplumePose186
+.4byte sVileplumePose187
+.4byte sVileplumePose188
+.4byte sVileplumePose189
+.4byte sVileplumePose190
+.4byte sVileplumePose191
+.4byte sVileplumePose192
+.4byte sVileplumePose193
+.4byte sVileplumePose194
+.4byte sVileplumePose195
+.4byte sVileplumePose196
+.4byte sVileplumePose197
+.4byte sVileplumePose198
+.4byte sVileplumePose199
+.4byte sVileplumePose200
+.4byte sVileplumePose201
+.4byte sVileplumePose202
+.4byte sVileplumePose203
+.4byte sVileplumePose204
+.4byte sVileplumePose205
+.4byte sVileplumePose206
+.4byte sVileplumePose207
+.4byte sVileplumePose208
+.4byte sVileplumePose209
+.4byte sVileplumePose210
+.4byte sVileplumePose211
+.4byte sVileplumePose212
+.4byte sVileplumePose213
+.4byte sVileplumePose214
+.4byte sVileplumePose215
+.4byte sVileplumePose216
+.4byte sVileplumePose217
+.4byte sVileplumePose218
+.4byte sVileplumePose219
+.4byte sVileplumePose220
+.4byte sVileplumePose221
+.4byte sVileplumePose222
+.4byte sVileplumePose223
+.4byte sVileplumePose224
+.4byte sVileplumePose225
+.4byte sVileplumePose226
+sAxPositionsVileplume:
+.2byte   -1,   -4, 	  -8,   -4, 	   6,   -4, 	  -1,  -10
+.2byte   -2,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -4, 	   5,   -5, 	  -6,   -3, 	  -1,  -10
+.2byte    0,   -3, 	   3,   -4, 	  -5,   -2, 	  -1,   -9
+.2byte    0,   -3, 	   6,   -4, 	  -6,   -3, 	  -1,   -9
+.2byte    4,   -5, 	  -1,   -4, 	  -2,   -3, 	  -1,  -10
+.2byte    4,   -5, 	  -3,   -3, 	   1,   -2, 	  -1,   -9
+.2byte    4,   -3, 	   1,   -3, 	  -3,   -2, 	  -2,   -9
+.2byte    2,   -6, 	  -5,   -6, 	   4,   -5, 	  -2,  -10
+.2byte    1,   -6, 	  -6,   -5, 	   4,   -5, 	  -2,   -9
+.2byte    3,   -4, 	  -3,   -4, 	   3,   -3, 	  -2,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    0,   -6, 	   5,   -3, 	  -7,   -4, 	  -1,   -9
+.2byte   -2,   -6, 	   5,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -4,   -6, 	   3,   -6, 	  -6,   -5, 	   0,  -10
+.2byte   -3,   -6, 	   4,   -5, 	  -6,   -5, 	   0,   -9
+.2byte   -5,   -4, 	   1,   -4, 	  -5,   -3, 	   0,   -9
+.2byte   -6,   -5, 	  -1,   -4, 	   0,   -3, 	  -1,  -10
+.2byte   -6,   -5, 	   1,   -3, 	  -3,   -2, 	  -1,   -9
+.2byte   -6,   -3, 	  -3,   -3, 	   1,   -2, 	   0,   -9
+.2byte   -2,   -4, 	  -7,   -5, 	   4,   -3, 	  -1,  -10
+.2byte   -2,   -3, 	  -5,   -4, 	   3,   -2, 	  -1,   -9
+.2byte   -2,   -3, 	  -8,   -4, 	   4,   -3, 	  -1,   -9
+.2byte   -1,   -4, 	  -8,   -4, 	   6,   -4, 	  -1,  -10
+.2byte   -2,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	  -8,   -8, 	   6,   -8, 	  -1,   -9
+.2byte    0,   -9, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte    0,   -4, 	   5,   -5, 	  -6,   -3, 	  -1,  -10
+.2byte    0,   -3, 	   3,   -4, 	  -5,   -2, 	  -1,   -9
+.2byte    0,   -3, 	   6,   -4, 	  -6,   -3, 	  -1,   -9
+.2byte   -3,  -12, 	   2,  -11, 	  -7,   -8, 	  -1,   -9
+.2byte    2,  -10, 	   6,   -5, 	  -2,   -3, 	   0,   -9
+.2byte    4,   -5, 	  -1,   -4, 	  -2,   -3, 	  -1,  -10
+.2byte    4,   -5, 	  -3,   -3, 	   1,   -2, 	  -1,   -9
+.2byte    4,   -3, 	   1,   -3, 	  -3,   -2, 	  -2,   -9
+.2byte   -6,  -13, 	  -1,  -11, 	  -4,   -6, 	  -2,   -9
+.2byte    6,  -10, 	   0,   -4, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -6, 	  -5,   -6, 	   4,   -5, 	  -2,  -10
+.2byte    1,   -6, 	  -6,   -5, 	   4,   -5, 	  -2,   -9
+.2byte    3,   -4, 	  -3,   -4, 	   3,   -3, 	  -2,   -9
+.2byte   -3,  -12, 	  -7,  -13, 	   3,   -9, 	  -3,  -10
+.2byte    1,  -10, 	  -5,   -7, 	   4,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    0,   -6, 	   5,   -3, 	  -7,   -4, 	  -1,   -9
+.2byte   -2,   -6, 	   5,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -14, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -10, 	   6,   -5, 	  -8,   -5, 	  -1,  -11
+.2byte   -4,   -6, 	   3,   -6, 	  -6,   -5, 	   0,  -10
+.2byte   -3,   -6, 	   4,   -5, 	  -6,   -5, 	   0,   -9
+.2byte   -5,   -4, 	   1,   -4, 	  -5,   -3, 	   0,   -9
+.2byte    1,  -12, 	   5,  -13, 	  -5,   -9, 	   1,  -10
+.2byte   -3,  -10, 	   3,   -7, 	  -6,   -4, 	  -1,   -9
+.2byte   -6,   -5, 	  -1,   -4, 	   0,   -3, 	  -1,  -10
+.2byte   -6,   -5, 	   1,   -3, 	  -3,   -2, 	  -1,   -9
+.2byte   -6,   -3, 	  -3,   -3, 	   1,   -2, 	   0,   -9
+.2byte    4,  -13, 	  -1,  -11, 	   2,   -6, 	   0,   -9
+.2byte   -8,  -10, 	  -2,   -4, 	   1,   -3, 	  -2,   -6
+.2byte   -2,   -4, 	  -7,   -5, 	   4,   -3, 	  -1,  -10
+.2byte   -2,   -3, 	  -5,   -4, 	   3,   -2, 	  -1,   -9
+.2byte   -2,   -3, 	  -8,   -4, 	   4,   -3, 	  -1,   -9
+.2byte    1,  -12, 	  -4,  -11, 	   5,   -8, 	  -1,   -9
+.2byte   -4,  -10, 	  -8,   -5, 	   0,   -3, 	  -2,   -9
+.2byte   -1,   -4, 	  -8,   -4, 	   6,   -4, 	  -1,  -10
+.2byte   -2,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte   -1,  -12, 	  -8,   -8, 	   6,   -8, 	  -1,   -9
+.2byte    0,   -9, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte    0,   -4, 	   5,   -5, 	  -6,   -3, 	  -1,  -10
+.2byte    0,   -3, 	   3,   -4, 	  -5,   -2, 	  -1,   -9
+.2byte    0,   -3, 	   6,   -4, 	  -6,   -3, 	  -1,   -9
+.2byte   -3,  -12, 	   2,  -11, 	  -7,   -8, 	  -1,   -9
+.2byte    2,  -10, 	   6,   -5, 	  -2,   -3, 	   0,   -9
+.2byte    4,   -5, 	  -1,   -4, 	  -2,   -3, 	  -1,  -10
+.2byte    4,   -5, 	  -3,   -3, 	   1,   -2, 	  -1,   -9
+.2byte    4,   -3, 	   1,   -3, 	  -3,   -2, 	  -2,   -9
+.2byte   -6,  -13, 	  -1,  -11, 	  -4,   -6, 	  -2,   -9
+.2byte    6,  -10, 	   0,   -4, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -6, 	  -5,   -6, 	   4,   -5, 	  -2,  -10
+.2byte    1,   -6, 	  -6,   -5, 	   4,   -5, 	  -2,   -9
+.2byte    3,   -4, 	  -3,   -4, 	   3,   -3, 	  -2,   -9
+.2byte   -3,  -12, 	  -7,  -13, 	   3,   -9, 	  -3,  -10
+.2byte    1,  -10, 	  -5,   -7, 	   4,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    0,   -6, 	   5,   -3, 	  -7,   -4, 	  -1,   -9
+.2byte   -2,   -6, 	   5,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -1,  -14, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -10, 	   6,   -5, 	  -8,   -5, 	  -1,  -11
+.2byte   -4,   -6, 	   3,   -6, 	  -6,   -5, 	   0,  -10
+.2byte   -3,   -6, 	   4,   -5, 	  -6,   -5, 	   0,   -9
+.2byte   -5,   -4, 	   1,   -4, 	  -5,   -3, 	   0,   -9
+.2byte    1,  -12, 	   5,  -13, 	  -5,   -9, 	   1,  -10
+.2byte   -3,  -10, 	   3,   -7, 	  -6,   -4, 	  -1,   -9
+.2byte   -6,   -5, 	  -1,   -4, 	   0,   -3, 	  -1,  -10
+.2byte   -6,   -5, 	   1,   -3, 	  -3,   -2, 	  -1,   -9
+.2byte   -6,   -3, 	  -3,   -3, 	   1,   -2, 	   0,   -9
+.2byte    4,  -13, 	  -1,  -11, 	   2,   -6, 	   0,   -9
+.2byte   -8,  -10, 	  -2,   -4, 	   1,   -3, 	  -2,   -6
+.2byte   -2,   -4, 	  -7,   -5, 	   4,   -3, 	  -1,  -10
+.2byte   -2,   -3, 	  -5,   -4, 	   3,   -2, 	  -1,   -9
+.2byte   -2,   -3, 	  -8,   -4, 	   4,   -3, 	  -1,   -9
+.2byte    1,  -12, 	  -4,  -11, 	   5,   -8, 	  -1,   -9
+.2byte   -4,  -10, 	  -8,   -5, 	   0,   -3, 	  -2,   -9
+.2byte   -1,   -4, 	  -8,   -4, 	   6,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	  -8,   -8, 	   6,   -8, 	  -1,   -9
+.2byte    0,   -9, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte    0,   -4, 	   5,   -5, 	  -6,   -3, 	  -1,  -10
+.2byte   -3,  -12, 	   2,  -11, 	  -7,   -8, 	  -1,   -9
+.2byte    2,  -10, 	   6,   -5, 	  -2,   -3, 	   0,   -9
+.2byte    4,   -5, 	  -1,   -4, 	  -2,   -3, 	  -1,  -10
+.2byte   -6,  -13, 	  -1,  -11, 	  -4,   -6, 	  -2,   -9
+.2byte    6,  -10, 	   0,   -4, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -6, 	  -5,   -6, 	   4,   -5, 	  -2,  -10
+.2byte   -3,  -12, 	  -7,  -13, 	   3,   -9, 	  -3,  -10
+.2byte    1,  -10, 	  -5,   -7, 	   4,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -10, 	   6,   -5, 	  -8,   -5, 	  -1,  -11
+.2byte   -4,   -6, 	   3,   -6, 	  -6,   -5, 	   0,  -10
+.2byte    1,  -12, 	   5,  -13, 	  -5,   -9, 	   1,  -10
+.2byte   -3,  -10, 	   3,   -7, 	  -6,   -4, 	  -1,   -9
+.2byte   -6,   -5, 	  -1,   -4, 	   0,   -3, 	  -1,  -10
+.2byte    4,  -13, 	  -1,  -11, 	   2,   -6, 	   0,   -9
+.2byte   -8,  -10, 	  -2,   -4, 	   1,   -3, 	  -2,   -6
+.2byte   -2,   -4, 	  -7,   -5, 	   4,   -3, 	  -1,  -10
+.2byte    1,  -12, 	  -4,  -11, 	   5,   -8, 	  -1,   -9
+.2byte   -4,  -10, 	  -8,   -5, 	   0,   -3, 	  -2,   -9
+.2byte    0,   -9, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte   -5,   -9, 	  -9,   -4, 	  -1,   -2, 	  -3,   -8
+.2byte   -9,  -10, 	  -3,   -4, 	   0,   -3, 	  -3,   -6
+.2byte   -3,  -10, 	   3,   -7, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,   -9, 	   6,   -4, 	  -8,   -4, 	  -1,  -10
+.2byte    3,  -10, 	  -3,   -7, 	   6,   -4, 	   1,   -9
+.2byte    9,  -11, 	   3,   -5, 	   0,   -4, 	   3,   -7
+.2byte    3,   -9, 	   7,   -4, 	  -1,   -2, 	   1,   -8
+.2byte   -1,   -3, 	  -6,   -3, 	   5,   -2, 	   0,  -10
+.2byte   -1,   -2, 	  -6,   -2, 	   4,   -1, 	  -1,   -9
+.2byte   -1,   -7, 	  -6,  -12, 	   4,  -12, 	  -1,   -9
+.2byte    0,   -7, 	   0,  -14, 	  -6,   -9, 	  -5,  -10
+.2byte    1,   -9, 	   0,  -14, 	   0,  -13, 	  -4,   -9
+.2byte    0,   -9, 	  -5,  -13, 	   3,  -11, 	  -5,  -10
+.2byte   -1,   -8, 	   5,  -13, 	  -7,  -13, 	  -1,  -10
+.2byte   -1,   -9, 	   4,  -13, 	  -4,  -11, 	   4,  -10
+.2byte   -2,   -9, 	  -1,  -14, 	  -1,  -13, 	   3,   -9
+.2byte   -1,   -7, 	  -1,  -14, 	   5,   -9, 	   4,  -10
+.2byte   -1,   -4, 	  -8,   -4, 	   6,   -4, 	  -1,  -10
+.2byte   -2,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -3, 	  -7,   -3, 	   5,   -3, 	  -1,   -9
+.2byte    0,   -4, 	   5,   -5, 	  -6,   -3, 	  -1,  -10
+.2byte    0,   -3, 	   3,   -4, 	  -5,   -2, 	  -1,   -9
+.2byte    0,   -3, 	   6,   -4, 	  -6,   -3, 	  -1,   -9
+.2byte    4,   -5, 	  -1,   -4, 	  -2,   -3, 	  -1,  -10
+.2byte    4,   -5, 	  -3,   -3, 	   1,   -2, 	  -1,   -9
+.2byte    4,   -3, 	   1,   -3, 	  -3,   -2, 	  -2,   -9
+.2byte    2,   -6, 	  -5,   -6, 	   4,   -5, 	  -2,  -10
+.2byte    1,   -6, 	  -6,   -5, 	   4,   -5, 	  -2,   -9
+.2byte    3,   -4, 	  -3,   -4, 	   3,   -3, 	  -2,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    0,   -6, 	   5,   -3, 	  -7,   -4, 	  -1,   -9
+.2byte   -2,   -6, 	   5,   -4, 	  -7,   -3, 	  -1,   -9
+.2byte   -4,   -6, 	   3,   -6, 	  -6,   -5, 	   0,  -10
+.2byte   -3,   -6, 	   4,   -5, 	  -6,   -5, 	   0,   -9
+.2byte   -5,   -4, 	   1,   -4, 	  -5,   -3, 	   0,   -9
+.2byte   -6,   -5, 	  -1,   -4, 	   0,   -3, 	  -1,  -10
+.2byte   -6,   -5, 	   1,   -3, 	  -3,   -2, 	  -1,   -9
+.2byte   -6,   -3, 	  -3,   -3, 	   1,   -2, 	   0,   -9
+.2byte   -2,   -4, 	  -7,   -5, 	   4,   -3, 	  -1,  -10
+.2byte   -2,   -3, 	  -5,   -4, 	   3,   -2, 	  -1,   -9
+.2byte   -2,   -3, 	  -8,   -4, 	   4,   -3, 	  -1,   -9
+.2byte    0,   -9, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte   -4,  -10, 	  -8,   -5, 	   0,   -3, 	  -2,   -9
+.2byte   -8,  -10, 	  -2,   -4, 	   1,   -3, 	  -2,   -6
+.2byte   -3,  -10, 	   3,   -7, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,   -9, 	   6,   -4, 	  -8,   -4, 	  -1,  -10
+.2byte    1,  -10, 	  -5,   -7, 	   4,   -4, 	  -1,   -9
+.2byte    6,  -10, 	   0,   -4, 	  -3,   -3, 	   0,   -6
+.2byte    2,  -10, 	   6,   -5, 	  -2,   -3, 	   0,   -9
+.2byte   -1,  -12, 	  -8,   -8, 	   6,   -8, 	  -1,   -9
+.2byte   -3,  -12, 	   2,  -11, 	  -7,   -8, 	  -1,   -9
+.2byte   -6,  -13, 	  -1,  -11, 	  -4,   -6, 	  -2,   -9
+.2byte   -3,  -12, 	  -7,  -13, 	   3,   -9, 	  -3,  -10
+.2byte   -1,  -13, 	   6,  -11, 	  -8,  -11, 	  -1,  -11
+.2byte    1,  -12, 	   5,  -13, 	  -5,   -9, 	   1,  -10
+.2byte    4,  -13, 	  -1,  -11, 	   2,   -6, 	   0,   -9
+.2byte    1,  -12, 	  -4,  -11, 	   5,   -8, 	  -1,   -9
+.2byte   -1,   -4, 	  -8,   -4, 	   6,   -4, 	  -1,  -10
+.2byte   -1,  -12, 	  -8,   -8, 	   6,   -8, 	  -1,   -9
+.2byte    0,   -9, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte    0,   -4, 	   5,   -5, 	  -6,   -3, 	  -1,  -10
+.2byte   -3,  -12, 	   2,  -11, 	  -7,   -8, 	  -1,   -9
+.2byte    2,  -10, 	   6,   -5, 	  -2,   -3, 	   0,   -9
+.2byte    4,   -5, 	  -1,   -4, 	  -2,   -3, 	  -1,  -10
+.2byte   -6,  -13, 	  -1,  -11, 	  -4,   -6, 	  -2,   -9
+.2byte    6,  -10, 	   0,   -4, 	  -3,   -3, 	   0,   -6
+.2byte    2,   -6, 	  -5,   -6, 	   4,   -5, 	  -2,  -10
+.2byte   -3,  -12, 	  -7,  -13, 	   3,   -9, 	  -3,  -10
+.2byte    1,  -10, 	  -5,   -7, 	   4,   -4, 	  -1,   -9
+.2byte   -1,   -7, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte   -1,  -14, 	   6,  -12, 	  -8,  -12, 	  -1,  -12
+.2byte   -1,  -10, 	   6,   -5, 	  -8,   -5, 	  -1,  -11
+.2byte   -4,   -6, 	   3,   -6, 	  -6,   -5, 	   0,  -10
+.2byte    1,  -12, 	   5,  -13, 	  -5,   -9, 	   1,  -10
+.2byte   -3,  -10, 	   3,   -7, 	  -6,   -4, 	  -1,   -9
+.2byte   -6,   -5, 	  -1,   -4, 	   0,   -3, 	  -1,  -10
+.2byte    4,  -13, 	  -1,  -11, 	   2,   -6, 	   0,   -9
+.2byte   -8,  -10, 	  -2,   -4, 	   1,   -3, 	  -2,   -6
+.2byte   -2,   -4, 	  -7,   -5, 	   4,   -3, 	  -1,  -10
+.2byte    1,  -12, 	  -4,  -11, 	   5,   -8, 	  -1,   -9
+.2byte   -4,  -10, 	  -8,   -5, 	   0,   -3, 	  -2,   -9
+.2byte    0,   -9, 	  -6,   -4, 	   6,   -4, 	   0,   -7
+.2byte   -4,  -10, 	  -8,   -5, 	   0,   -3, 	  -2,   -9
+.2byte   -8,  -10, 	  -2,   -4, 	   1,   -3, 	  -2,   -6
+.2byte   -3,  -10, 	   3,   -7, 	  -6,   -4, 	  -1,   -9
+.2byte   -1,   -9, 	   6,   -4, 	  -8,   -4, 	  -1,  -10
+.2byte    1,  -10, 	  -5,   -7, 	   4,   -4, 	  -1,   -9
+.2byte    6,  -10, 	   0,   -4, 	  -3,   -3, 	   0,   -6
+.2byte    2,  -10, 	   6,   -5, 	  -2,   -3, 	   0,   -9
+.2byte   -1,   -4, 	  -8,   -4, 	   6,   -4, 	  -1,  -10
+.2byte   -2,   -4, 	  -7,   -5, 	   4,   -3, 	  -1,  -10
+.2byte   -6,   -5, 	  -1,   -4, 	   0,   -3, 	  -1,  -10
+.2byte   -4,   -6, 	   3,   -6, 	  -6,   -5, 	   0,  -10
+.2byte   -1,   -7, 	   6,   -5, 	  -8,   -5, 	  -1,  -10
+.2byte    2,   -6, 	  -5,   -6, 	   4,   -5, 	  -2,  -10
+.2byte    4,   -5, 	  -1,   -4, 	  -2,   -3, 	  -1,  -10
+.2byte    0,   -4, 	   5,   -5, 	  -6,   -3, 	  -1,  -10
+sVileplumeAnimTable1:
+.4byte sVileplumeAnims_1_1
+.4byte sVileplumeAnims_1_2
+.4byte sVileplumeAnims_1_3
+.4byte sVileplumeAnims_1_4
+.4byte sVileplumeAnims_1_5
+.4byte sVileplumeAnims_1_6
+.4byte sVileplumeAnims_1_7
+.4byte sVileplumeAnims_1_8
+sVileplumeAnimTable2:
+.4byte sVileplumeAnims_2_1
+.4byte sVileplumeAnims_2_2
+.4byte sVileplumeAnims_2_3
+.4byte sVileplumeAnims_2_4
+.4byte sVileplumeAnims_2_5
+.4byte sVileplumeAnims_2_6
+.4byte sVileplumeAnims_2_7
+.4byte sVileplumeAnims_2_8
+sVileplumeAnimTable3:
+.4byte sVileplumeAnims_3_1
+.4byte sVileplumeAnims_3_2
+.4byte sVileplumeAnims_3_3
+.4byte sVileplumeAnims_3_4
+.4byte sVileplumeAnims_3_5
+.4byte sVileplumeAnims_3_6
+.4byte sVileplumeAnims_3_7
+.4byte sVileplumeAnims_3_8
+sVileplumeAnimTable4:
+.4byte sVileplumeAnims_4_1
+.4byte sVileplumeAnims_4_2
+.4byte sVileplumeAnims_4_3
+.4byte sVileplumeAnims_4_4
+.4byte sVileplumeAnims_4_5
+.4byte sVileplumeAnims_4_6
+.4byte sVileplumeAnims_4_7
+.4byte sVileplumeAnims_4_8
+sVileplumeAnimTable5:
+.4byte sVileplumeAnims_5_1
+.4byte sVileplumeAnims_5_2
+.4byte sVileplumeAnims_5_3
+.4byte sVileplumeAnims_5_4
+.4byte sVileplumeAnims_5_5
+.4byte sVileplumeAnims_5_6
+.4byte sVileplumeAnims_5_7
+.4byte sVileplumeAnims_5_8
+sVileplumeAnimTable6:
+.4byte sVileplumeAnims_6_1
+.4byte sVileplumeAnims_6_1
+.4byte sVileplumeAnims_6_1
+.4byte sVileplumeAnims_6_1
+.4byte sVileplumeAnims_6_1
+.4byte sVileplumeAnims_6_1
+.4byte sVileplumeAnims_6_1
+.4byte sVileplumeAnims_6_1
+sVileplumeAnimTable7:
+.4byte sVileplumeAnims_7_1
+.4byte sVileplumeAnims_7_2
+.4byte sVileplumeAnims_7_3
+.4byte sVileplumeAnims_7_4
+.4byte sVileplumeAnims_7_5
+.4byte sVileplumeAnims_7_6
+.4byte sVileplumeAnims_7_7
+.4byte sVileplumeAnims_7_8
+sVileplumeAnimTable8:
+.4byte sVileplumeAnims_8_1
+.4byte sVileplumeAnims_8_2
+.4byte sVileplumeAnims_8_3
+.4byte sVileplumeAnims_8_4
+.4byte sVileplumeAnims_8_5
+.4byte sVileplumeAnims_8_6
+.4byte sVileplumeAnims_8_7
+.4byte sVileplumeAnims_8_8
+sVileplumeAnimTable9:
+.4byte sVileplumeAnims_9_1
+.4byte sVileplumeAnims_9_2
+.4byte sVileplumeAnims_9_3
+.4byte sVileplumeAnims_9_4
+.4byte sVileplumeAnims_9_5
+.4byte sVileplumeAnims_9_6
+.4byte sVileplumeAnims_9_7
+.4byte sVileplumeAnims_9_8
+sVileplumeAnimTable10:
+.4byte sVileplumeAnims_10_1
+.4byte sVileplumeAnims_10_2
+.4byte sVileplumeAnims_10_3
+.4byte sVileplumeAnims_10_4
+.4byte sVileplumeAnims_10_5
+.4byte sVileplumeAnims_10_6
+.4byte sVileplumeAnims_10_7
+.4byte sVileplumeAnims_10_8
+sVileplumeAnimTable11:
+.4byte sVileplumeAnims_11_1
+.4byte sVileplumeAnims_11_2
+.4byte sVileplumeAnims_11_3
+.4byte sVileplumeAnims_11_4
+.4byte sVileplumeAnims_11_5
+.4byte sVileplumeAnims_11_6
+.4byte sVileplumeAnims_11_7
+.4byte sVileplumeAnims_11_8
+sVileplumeAnimTable12:
+.4byte sVileplumeAnims_12_1
+.4byte sVileplumeAnims_12_2
+.4byte sVileplumeAnims_12_3
+.4byte sVileplumeAnims_12_4
+.4byte sVileplumeAnims_12_5
+.4byte sVileplumeAnims_12_6
+.4byte sVileplumeAnims_12_7
+.4byte sVileplumeAnims_12_8
+sVileplumeAnimTable13:
+.4byte sVileplumeAnims_13_1
+.4byte sVileplumeAnims_13_2
+.4byte sVileplumeAnims_13_3
+.4byte sVileplumeAnims_13_4
+.4byte sVileplumeAnims_13_5
+.4byte sVileplumeAnims_13_6
+.4byte sVileplumeAnims_13_7
+.4byte sVileplumeAnims_13_8
+sAxAnimationsVileplume:
+.4byte sVileplumeAnimTable1
+.4byte sVileplumeAnimTable2
+.4byte sVileplumeAnimTable3
+.4byte sVileplumeAnimTable4
+.4byte sVileplumeAnimTable5
+.4byte sVileplumeAnimTable6
+.4byte sVileplumeAnimTable7
+.4byte sVileplumeAnimTable8
+.4byte sVileplumeAnimTable9
+.4byte sVileplumeAnimTable10
+.4byte sVileplumeAnimTable11
+.4byte sVileplumeAnimTable12
+.4byte sVileplumeAnimTable13
+sAxSpritesVileplume:
+.4byte sVileplumeSprites1
+.4byte sVileplumeSprites2
+.4byte sVileplumeSprites3
+.4byte sVileplumeSprites4
+.4byte sVileplumeSprites5
+.4byte sVileplumeSprites6
+.4byte sVileplumeSprites7
+.4byte sVileplumeSprites8
+.4byte sVileplumeSprites9
+.4byte sVileplumeSprites10
+.4byte sVileplumeSprites11
+.4byte sVileplumeSprites12
+.4byte sVileplumeSprites13
+.4byte sVileplumeSprites14
+.4byte sVileplumeSprites15
+.4byte sVileplumeSprites16
+.4byte sVileplumeSprites17
+.4byte sVileplumeSprites18
+.4byte sVileplumeSprites19
+.4byte sVileplumeSprites20
+.4byte sVileplumeSprites21
+.4byte sVileplumeSprites22
+.4byte sVileplumeSprites23
+.4byte sVileplumeSprites24
+.4byte sVileplumeSprites25
+.4byte sVileplumeSprites26
+.4byte sVileplumeSprites27
+.4byte sVileplumeSprites28
+.4byte sVileplumeSprites29
+.4byte sVileplumeSprites30
+.4byte sVileplumeSprites31
+.4byte sVileplumeSprites32
+sAxMainVileplume:
+ax_main sAxPosesVileplume, sAxAnimationsVileplume, 13, sAxSpritesVileplume, sAxPositionsVileplume

--- a/data/ax/volbeat.inc
+++ b/data/ax/volbeat.inc
@@ -1,0 +1,3538 @@
+.global gAxVolbeat
+gAxVolbeat:
+ax_siro sAxMainVolbeat
+sVolbeatPose1:
+ax_pose 0, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose2:
+ax_pose 1, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose3:
+ax_pose 2, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose4:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose5:
+ax_pose 4, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose6:
+ax_pose 5, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose7:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose8:
+ax_pose 7, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose9:
+ax_pose 8, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose10:
+ax_pose 9, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose11:
+ax_pose 10, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose12:
+ax_pose 11, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose13:
+ax_pose 12, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose14:
+ax_pose 13, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose15:
+ax_pose 14, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose16:
+ax_pose 9, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose17:
+ax_pose 10, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose18:
+ax_pose 11, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose19:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose21:
+ax_pose 8, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose22:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose23:
+ax_pose 4, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose25:
+ax_pose 0, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose26:
+ax_pose 1, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose27:
+ax_pose 2, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose28:
+ax_pose 15, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose29:
+ax_pose 16, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose30:
+ax_pose 17, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose31:
+ax_pose 18, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose32:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose33:
+ax_pose 4, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose34:
+ax_pose 5, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose35:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose36:
+ax_pose 20, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose37:
+ax_pose 21, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose38:
+ax_pose 22, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose39:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose40:
+ax_pose 7, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose41:
+ax_pose 8, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose42:
+ax_pose 23, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sVolbeatPose43:
+ax_pose 24, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sVolbeatPose44:
+ax_pose 25, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose45:
+ax_pose 26, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose46:
+ax_pose 27, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose47:
+ax_pose 28, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose48:
+ax_pose 9, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose49:
+ax_pose 10, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose50:
+ax_pose 11, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose51:
+ax_pose 29, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose52:
+ax_pose 30, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose53:
+ax_pose 31, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose54:
+ax_pose 32, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose55:
+ax_pose 33, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose56:
+ax_pose 34, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose57:
+ax_pose 12, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose58:
+ax_pose 13, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose59:
+ax_pose 14, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose60:
+ax_pose 35, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose61:
+ax_pose 36, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose62:
+ax_pose 37, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose63:
+ax_pose 38, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose64:
+ax_pose 39, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose65:
+ax_pose 40, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose66:
+ax_pose 9, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose67:
+ax_pose 10, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose68:
+ax_pose 11, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose69:
+ax_pose 29, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose70:
+ax_pose 30, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose71:
+ax_pose 31, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose72:
+ax_pose 32, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose73:
+ax_pose 33, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose74:
+ax_pose 34, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose75:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose76:
+ax_pose 7, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose77:
+ax_pose 8, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose78:
+ax_pose 23, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sVolbeatPose79:
+ax_pose 24, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sVolbeatPose80:
+ax_pose 25, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose81:
+ax_pose 26, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose82:
+ax_pose 27, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose83:
+ax_pose 28, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose84:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose85:
+ax_pose 4, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose86:
+ax_pose 5, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose87:
+ax_pose 19, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose88:
+ax_pose 20, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose89:
+ax_pose 21, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose90:
+ax_pose 22, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose91:
+ax_pose 0, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose92:
+ax_pose 1, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose93:
+ax_pose 2, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose94:
+ax_pose 15, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose95:
+ax_pose 16, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose96:
+ax_pose 17, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose97:
+ax_pose 18, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose98:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose99:
+ax_pose 4, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose100:
+ax_pose 5, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose101:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose102:
+ax_pose 20, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose103:
+ax_pose 21, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose104:
+ax_pose 22, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose105:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose106:
+ax_pose 7, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose107:
+ax_pose 8, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose108:
+ax_pose 23, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sVolbeatPose109:
+ax_pose 24, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sVolbeatPose110:
+ax_pose 25, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose111:
+ax_pose 26, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose112:
+ax_pose 27, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose113:
+ax_pose 28, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose114:
+ax_pose 9, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose115:
+ax_pose 10, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose116:
+ax_pose 11, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose117:
+ax_pose 29, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose118:
+ax_pose 30, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose119:
+ax_pose 31, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose120:
+ax_pose 32, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose121:
+ax_pose 33, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose122:
+ax_pose 34, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose123:
+ax_pose 12, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose124:
+ax_pose 13, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose125:
+ax_pose 14, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose126:
+ax_pose 35, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose127:
+ax_pose 36, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose128:
+ax_pose 37, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose129:
+ax_pose 38, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose130:
+ax_pose 39, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose131:
+ax_pose 40, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose132:
+ax_pose 9, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose133:
+ax_pose 10, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose134:
+ax_pose 11, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose135:
+ax_pose 29, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose136:
+ax_pose 30, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose137:
+ax_pose 31, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose138:
+ax_pose 32, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose139:
+ax_pose 33, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose140:
+ax_pose 34, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose141:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose142:
+ax_pose 7, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose143:
+ax_pose 8, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose144:
+ax_pose 23, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sVolbeatPose145:
+ax_pose 24, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sVolbeatPose146:
+ax_pose 25, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose147:
+ax_pose 26, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose148:
+ax_pose 27, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose149:
+ax_pose 28, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose150:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose151:
+ax_pose 4, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose152:
+ax_pose 5, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose153:
+ax_pose 19, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose154:
+ax_pose 20, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose155:
+ax_pose 21, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose156:
+ax_pose 22, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose157:
+ax_pose 1, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose158:
+ax_pose 4, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose159:
+ax_pose 7, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose160:
+ax_pose 10, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose161:
+ax_pose 13, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose162:
+ax_pose 10, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose163:
+ax_pose 7, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose164:
+ax_pose 4, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose165:
+ax_pose 0, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose166:
+ax_pose 17, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose167:
+ax_pose 18, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose168:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose169:
+ax_pose 21, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose170:
+ax_pose 22, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose171:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose172:
+ax_pose 25, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose173:
+ax_pose 26, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose174:
+ax_pose 27, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose175:
+ax_pose 28, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose176:
+ax_pose 41, 0x01fb, 0x00f8, 0x3c00
+ax_pose 26, 0x01e6, 0x90f0, 0x6c01
+ax_pose_terminator
+sVolbeatPose177:
+ax_pose 28, 0x01e6, 0x90f0, 0x6c00
+ax_pose 41, 0x01fa, 0x00f7, 0x3c10
+ax_pose_terminator
+sVolbeatPose178:
+ax_pose 9, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose179:
+ax_pose 31, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose180:
+ax_pose 32, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose181:
+ax_pose 33, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose182:
+ax_pose 34, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose183:
+ax_pose 41, 0x01fc, 0x00f9, 0x3c00
+ax_pose 32, 0x01e6, 0x90f0, 0x6c01
+ax_pose_terminator
+sVolbeatPose184:
+ax_pose 41, 0x01fb, 0x00f7, 0x3c00
+ax_pose 34, 0x01e6, 0x90f0, 0x6c01
+ax_pose_terminator
+sVolbeatPose185:
+ax_pose 12, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose186:
+ax_pose 37, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose187:
+ax_pose 38, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose188:
+ax_pose 39, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose189:
+ax_pose 40, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose190:
+ax_pose 41, 0x01fd, 0x00fb, 0x3c00
+ax_pose 38, 0x01e6, 0x80ef, 0x6c01
+ax_pose_terminator
+sVolbeatPose191:
+ax_pose 41, 0x01fd, 0x00fd, 0x3c00
+ax_pose 40, 0x01e6, 0x80ef, 0x6c01
+ax_pose_terminator
+sVolbeatPose192:
+ax_pose 9, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose193:
+ax_pose 31, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose194:
+ax_pose 32, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose195:
+ax_pose 33, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose196:
+ax_pose 34, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose197:
+ax_pose 41, 0x01fc, 0x00fe, 0x3c00
+ax_pose 32, 0x01e6, 0x80ef, 0x6c01
+ax_pose_terminator
+sVolbeatPose198:
+ax_pose 41, 0x01fa, 0x0100, 0x3c00
+ax_pose 34, 0x01e6, 0x80ef, 0x6c01
+ax_pose_terminator
+sVolbeatPose199:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose200:
+ax_pose 25, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose201:
+ax_pose 26, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose202:
+ax_pose 27, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose203:
+ax_pose 28, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose204:
+ax_pose 41, 0x01fb, 0x0100, 0x3c00
+ax_pose 26, 0x01e6, 0x80ef, 0x6c01
+ax_pose_terminator
+sVolbeatPose205:
+ax_pose 28, 0x01e6, 0x80ef, 0x6c00
+ax_pose 41, 0x01f9, 0x0100, 0x3c10
+ax_pose_terminator
+sVolbeatPose206:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose207:
+ax_pose 21, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose208:
+ax_pose 22, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose209:
+ax_pose 42, 0x01e9, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose210:
+ax_pose 43, 0x01e9, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose211:
+ax_pose 44, 0x81e1, 0x40f5, 0x6c00
+ax_pose 45, 0x01d9, 0x00fd, 0x6c04
+ax_pose 46, 0x01e1, 0x00ed, 0x6c05
+ax_pose 47, 0x81e1, 0x80fd, 0x6c06
+ax_pose_terminator
+sVolbeatPose212:
+ax_pose 48, 0x01e4, 0x90ed, 0x6c00
+ax_pose_terminator
+sVolbeatPose213:
+ax_pose 49, 0x01e3, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose214:
+ax_pose 50, 0x01e4, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose215:
+ax_pose 51, 0x81e4, 0x4102, 0x6c00
+ax_pose 52, 0x01e4, 0x010a, 0x6c04
+ax_pose 53, 0x01dc, 0x00fa, 0x6c05
+ax_pose 54, 0x81e4, 0x80f2, 0x6c06
+ax_pose_terminator
+sVolbeatPose216:
+ax_pose 50, 0x01e4, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose217:
+ax_pose 49, 0x01e3, 0x80f6, 0x6c00
+ax_pose_terminator
+sVolbeatPose218:
+ax_pose 48, 0x01e4, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose219:
+ax_pose 0, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose220:
+ax_pose 17, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose221:
+ax_pose 18, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose222:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose223:
+ax_pose 21, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose224:
+ax_pose 22, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose225:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose226:
+ax_pose 26, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose227:
+ax_pose 28, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose228:
+ax_pose 9, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose229:
+ax_pose 32, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose230:
+ax_pose 34, 0x01e6, 0x90f0, 0x6c00
+ax_pose_terminator
+sVolbeatPose231:
+ax_pose 12, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose232:
+ax_pose 38, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose233:
+ax_pose 40, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose234:
+ax_pose 9, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose235:
+ax_pose 32, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose236:
+ax_pose 34, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose237:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose238:
+ax_pose 26, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose239:
+ax_pose 28, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose240:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose241:
+ax_pose 21, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose242:
+ax_pose 22, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose243:
+ax_pose 15, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose244:
+ax_pose 19, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose245:
+ax_pose 23, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sVolbeatPose246:
+ax_pose 29, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose247:
+ax_pose 35, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose248:
+ax_pose 29, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose249:
+ax_pose 23, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sVolbeatPose250:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose251:
+ax_pose 15, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose252:
+ax_pose 19, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose253:
+ax_pose 23, 0x01e6, 0x90f2, 0x6c00
+ax_pose_terminator
+sVolbeatPose254:
+ax_pose 29, 0x01e6, 0x90f1, 0x6c00
+ax_pose_terminator
+sVolbeatPose255:
+ax_pose 35, 0x01e6, 0x80ef, 0x6c00
+ax_pose_terminator
+sVolbeatPose256:
+ax_pose 29, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose257:
+ax_pose 23, 0x01e6, 0x80ed, 0x6c00
+ax_pose_terminator
+sVolbeatPose258:
+ax_pose 19, 0x01e6, 0x80ee, 0x6c00
+ax_pose_terminator
+sVolbeatPose259:
+ax_pose 0, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose260:
+ax_pose 2, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose261:
+ax_pose 1, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose262:
+ax_pose 3, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose263:
+ax_pose 5, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose264:
+ax_pose 4, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose265:
+ax_pose 6, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose266:
+ax_pose 8, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose267:
+ax_pose 7, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose268:
+ax_pose 9, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose269:
+ax_pose 11, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose270:
+ax_pose 10, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose271:
+ax_pose 12, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose272:
+ax_pose 14, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose273:
+ax_pose 13, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose274:
+ax_pose 9, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose275:
+ax_pose 11, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose276:
+ax_pose 10, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose277:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose278:
+ax_pose 8, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose279:
+ax_pose 7, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose280:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose281:
+ax_pose 5, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose282:
+ax_pose 4, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose283:
+ax_pose 1, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose284:
+ax_pose 4, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose285:
+ax_pose 7, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose286:
+ax_pose 10, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose287:
+ax_pose 13, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose288:
+ax_pose 10, 0x01e6, 0x90ea, 0x6c00
+ax_pose_terminator
+sVolbeatPose289:
+ax_pose 7, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose290:
+ax_pose 4, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose291:
+ax_pose 0, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose292:
+ax_pose 3, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose293:
+ax_pose 6, 0x01e6, 0x80f4, 0x6c00
+ax_pose_terminator
+sVolbeatPose294:
+ax_pose 9, 0x01e6, 0x80f5, 0x6c00
+ax_pose_terminator
+sVolbeatPose295:
+ax_pose 12, 0x01e6, 0x80f3, 0x6c00
+ax_pose_terminator
+sVolbeatPose296:
+ax_pose 9, 0x01e6, 0x90eb, 0x6c00
+ax_pose_terminator
+sVolbeatPose297:
+ax_pose 6, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+sVolbeatPose298:
+ax_pose 3, 0x01e6, 0x90ec, 0x6c00
+ax_pose_terminator
+.align 2
+sVolbeatAnims_1_1:
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 2,
+ax_anim 4, 0, 0, 0, 0, 0, 3,
+ax_anim 4, 0, 2, 0, 0, 0, 3,
+ax_anim 4, 0, 0, 0, -1, 0, 2,
+ax_anim 4, 0, 1, 0, -2, 0, 1,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 2, 0, -4, 0, -1,
+ax_anim_terminator
+sVolbeatAnims_1_2:
+ax_anim 4, 0, 3, 0, -3, 0, 0,
+ax_anim 4, 0, 4, 1, -3, 1, 1,
+ax_anim 4, 0, 3, 2, -4, 2, 2,
+ax_anim 4, 0, 5, 2, -5, 2, 2,
+ax_anim 4, 0, 3, 1, -6, 1, 1,
+ax_anim 4, 0, 4, 0, -5, 0, 0,
+ax_anim 4, 0, 3, -1, -4, -1, -1,
+ax_anim 4, 0, 5, -1, -3, -1, -1,
+ax_anim_terminator
+sVolbeatAnims_1_3:
+ax_anim 4, 0, 6, 0, -3, 0, 0,
+ax_anim 4, 0, 7, 1, -4, 1, 0,
+ax_anim 4, 0, 6, 2, -5, 2, 0,
+ax_anim 4, 0, 8, 2, -6, 2, 0,
+ax_anim 4, 0, 6, 1, -6, 1, 0,
+ax_anim 4, 0, 7, 0, -5, 0, 0,
+ax_anim 4, 0, 6, -1, -4, -1, 0,
+ax_anim 4, 0, 8, -1, -3, -1, 0,
+ax_anim_terminator
+sVolbeatAnims_1_4:
+ax_anim 4, 0, 9, 0, -3, 0, 0,
+ax_anim 4, 0, 10, 1, -4, 1, -1,
+ax_anim 4, 0, 9, 2, -6, 2, -2,
+ax_anim 4, 0, 11, 2, -7, 2, -2,
+ax_anim 4, 0, 9, 1, -8, 1, -1,
+ax_anim 4, 0, 10, 0, -7, 0, 0,
+ax_anim 4, 0, 9, -1, -4, -1, 1,
+ax_anim 4, 0, 11, -1, -3, -1, 1,
+ax_anim_terminator
+sVolbeatAnims_1_5:
+ax_anim 4, 0, 12, 0, -3, 0, 0,
+ax_anim 4, 0, 13, 0, -4, 0, -1,
+ax_anim 4, 0, 12, 0, -6, 0, -2,
+ax_anim 4, 0, 14, 0, -7, 0, -3,
+ax_anim 4, 0, 12, 0, -7, 0, -3,
+ax_anim 4, 0, 13, 0, -6, 0, -2,
+ax_anim 4, 0, 12, 0, -4, 0, -1,
+ax_anim 4, 0, 14, 0, -3, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_1_6:
+ax_anim 4, 0, 15, 0, -3, 0, 0,
+ax_anim 4, 0, 16, -1, -4, -1, -1,
+ax_anim 4, 0, 15, -2, -6, -2, -2,
+ax_anim 4, 0, 17, -2, -7, -2, -2,
+ax_anim 4, 0, 15, -1, -8, -1, -1,
+ax_anim 4, 0, 16, 0, -7, 0, 0,
+ax_anim 4, 0, 15, 1, -4, 1, 1,
+ax_anim 4, 0, 17, 1, -3, 1, 1,
+ax_anim_terminator
+sVolbeatAnims_1_7:
+ax_anim 4, 0, 18, 0, -3, 0, 0,
+ax_anim 4, 0, 19, -1, -4, -1, 0,
+ax_anim 4, 0, 18, -2, -5, -2, 0,
+ax_anim 4, 0, 20, -2, -6, -2, 0,
+ax_anim 4, 0, 18, -1, -6, -1, 0,
+ax_anim 4, 0, 19, 0, -5, 0, 0,
+ax_anim 4, 0, 18, 1, -4, 1, 0,
+ax_anim 4, 0, 20, 1, -3, 1, 0,
+ax_anim_terminator
+sVolbeatAnims_1_8:
+ax_anim 4, 0, 21, 0, -3, 0, 0,
+ax_anim 4, 0, 22, -1, -3, -1, 1,
+ax_anim 4, 0, 21, -2, -4, -2, 2,
+ax_anim 4, 0, 23, -2, -5, -2, 2,
+ax_anim 4, 0, 21, -1, -6, -1, 1,
+ax_anim 4, 0, 22, 0, -5, 0, 0,
+ax_anim 4, 0, 21, 1, -4, 1, -1,
+ax_anim 4, 0, 23, 1, -3, 1, -1,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, 0,
+ax_anim 2, 0, 26, 0, -3, 0, 0,
+ax_anim 2, 0, 28, 0, -4, 0, 0,
+ax_anim 2, 0, 27, 0, -4, 0, 0,
+ax_anim 2, 0, 28, 0, -4, 0, 0,
+ax_anim 2, 2, 27, 0, -4, 0, 0,
+ax_anim 1, 0, 28, 0, 7, 0, 7,
+ax_anim 1, 0, 27, 0, 14, 0, 14,
+ax_anim 2, 1, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 28, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 0, 10, 0, 10,
+ax_anim 2, 0, 28, 0, 4, 0, 4,
+ax_anim_terminator
+sVolbeatAnims_2_2:
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 2, 0, 33, 0, -2, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 0, 34, 0, -4, 0, 0,
+ax_anim 2, 0, 35, 0, -4, 0, 0,
+ax_anim 2, 2, 34, 0, -4, 0, 0,
+ax_anim 1, 0, 35, 7, 7, 7, 7,
+ax_anim 1, 0, 34, 14, 14, 14, 14,
+ax_anim 2, 1, 35, 20, 21, 20, 21,
+ax_anim 2, 0, 34, 21, 20, 21, 20,
+ax_anim 2, 0, 35, 20, 21, 20, 21,
+ax_anim 2, 0, 34, 21, 20, 21, 20,
+ax_anim 2, 0, 35, 20, 21, 20, 21,
+ax_anim 2, 0, 34, 10, 10, 10, 10,
+ax_anim 2, 0, 35, 4, 4, 4, 4,
+ax_anim_terminator
+sVolbeatAnims_2_3:
+ax_anim 2, 0, 38, 0, -1, 0, 0,
+ax_anim 2, 0, 40, 0, -2, 0, 0,
+ax_anim 2, 0, 42, 0, -4, 0, 0,
+ax_anim 2, 0, 41, 0, -4, 0, 0,
+ax_anim 2, 0, 42, 0, -4, 0, 0,
+ax_anim 2, 2, 41, 0, -4, 0, 0,
+ax_anim 1, 0, 42, 7, -3, 7, 0,
+ax_anim 1, 0, 41, 14, -2, 14, 0,
+ax_anim 2, 1, 42, 19, 0, 19, 0,
+ax_anim 2, 0, 41, 19, 1, 19, 1,
+ax_anim 2, 0, 42, 19, 0, 19, 0,
+ax_anim 2, 0, 41, 19, 1, 19, 1,
+ax_anim 2, 0, 42, 19, 0, 19, 0,
+ax_anim 2, 0, 41, 10, -2, 10, 0,
+ax_anim 2, 0, 42, 4, -1, 4, 0,
+ax_anim_terminator
+sVolbeatAnims_2_4:
+ax_anim 2, 0, 47, 0, -1, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 0, 51, 0, -4, 0, 0,
+ax_anim 2, 2, 50, 0, -4, 0, 0,
+ax_anim 1, 0, 51, 7, -7, 7, -7,
+ax_anim 1, 0, 50, 14, -14, 14, -14,
+ax_anim 2, 1, 51, 21, -17, 20, -21,
+ax_anim 2, 0, 50, 22, -16, 21, -20,
+ax_anim 2, 0, 51, 21, -17, 20, -21,
+ax_anim 2, 0, 50, 22, -16, 21, -20,
+ax_anim 2, 0, 51, 21, -17, 20, -21,
+ax_anim 2, 0, 50, 10, -10, 10, -10,
+ax_anim 2, 0, 51, 4, -4, 4, -4,
+ax_anim_terminator
+sVolbeatAnims_2_5:
+ax_anim 2, 0, 56, 0, -1, 0, 0,
+ax_anim 2, 0, 58, 0, -3, 0, 0,
+ax_anim 2, 0, 60, 0, -4, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 60, 0, -4, 0, 0,
+ax_anim 2, 2, 59, 0, -4, 0, 0,
+ax_anim 1, 0, 60, 0, -7, 0, -7,
+ax_anim 1, 0, 59, 0, -13, 0, -13,
+ax_anim 2, 1, 60, 0, -18, 0, -18,
+ax_anim 2, 0, 59, 1, -18, 1, -18,
+ax_anim 2, 0, 60, 0, -18, 0, -18,
+ax_anim 2, 0, 59, 1, -18, 1, -18,
+ax_anim 2, 0, 60, 0, -18, 0, -18,
+ax_anim 2, 0, 59, 0, -10, 0, -10,
+ax_anim 2, 0, 60, 0, -4, 0, -4,
+ax_anim_terminator
+sVolbeatAnims_2_6:
+ax_anim 2, 0, 65, 0, -1, 0, 0,
+ax_anim 2, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 2, 0, 68, 0, -4, 0, 0,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim 2, 2, 68, 0, -4, 0, 0,
+ax_anim 1, 0, 69, -7, -7, -7, -7,
+ax_anim 1, 0, 68, -14, -14, -14, -14,
+ax_anim 2, 1, 69, -21, -17, -20, -21,
+ax_anim 2, 0, 68, -22, -16, -21, -20,
+ax_anim 2, 0, 69, -21, -17, -20, -21,
+ax_anim 2, 0, 68, -22, -16, -21, -20,
+ax_anim 2, 0, 69, -21, -17, -20, -21,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 69, -4, -4, -4, -4,
+ax_anim_terminator
+sVolbeatAnims_2_7:
+ax_anim 2, 0, 74, 0, -1, 0, 0,
+ax_anim 2, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 77, 0, -4, 0, 0,
+ax_anim 2, 0, 78, 0, -4, 0, 0,
+ax_anim 2, 2, 77, 0, -4, 0, 0,
+ax_anim 1, 0, 78, -7, -3, -7, 0,
+ax_anim 1, 0, 77, -14, -2, -14, 0,
+ax_anim 2, 1, 78, -19, 0, -19, 0,
+ax_anim 2, 0, 77, -19, 1, -19, 1,
+ax_anim 2, 0, 78, -19, 0, -19, 0,
+ax_anim 2, 0, 77, -19, 1, -19, 1,
+ax_anim 2, 0, 78, -19, 0, -19, 0,
+ax_anim 2, 0, 77, -10, -2, -10, 0,
+ax_anim 2, 0, 78, -4, -1, -4, 0,
+ax_anim_terminator
+sVolbeatAnims_2_8:
+ax_anim 2, 0, 83, 0, -1, 0, 0,
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 0, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 87, 0, -4, 0, 0,
+ax_anim 2, 2, 86, 0, -4, 0, 0,
+ax_anim 1, 0, 87, -7, 7, -7, 7,
+ax_anim 1, 0, 86, -14, 14, -14, 14,
+ax_anim 2, 1, 87, -20, 21, -20, 21,
+ax_anim 2, 0, 86, -21, 20, -21, 20,
+ax_anim 2, 0, 87, -20, 21, -20, 21,
+ax_anim 2, 0, 86, -21, 20, -21, 20,
+ax_anim 2, 0, 87, -20, 21, -20, 21,
+ax_anim 2, 0, 86, -10, 10, -10, 10,
+ax_anim 2, 0, 87, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_3_1:
+ax_anim 2, 0, 90, 0, -1, 0, 0,
+ax_anim 2, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 94, 0, -4, 0, 0,
+ax_anim 2, 2, 93, 0, -4, 0, 0,
+ax_anim 1, 0, 94, 0, 10, 0, 10,
+ax_anim 1, 0, 93, 0, 23, 0, 23,
+ax_anim 2, 1, 94, 0, 44, 0, 44,
+ax_anim 2, 0, 93, 1, 44, 1, 44,
+ax_anim 2, 0, 94, 0, 44, 0, 44,
+ax_anim 2, 0, 93, 1, 44, 1, 44,
+ax_anim 2, 0, 94, 0, 44, 0, 44,
+ax_anim 2, 0, 93, 0, 20, 0, 20,
+ax_anim 2, 0, 94, 0, 8, 0, 8,
+ax_anim_terminator
+sVolbeatAnims_3_2:
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 2, 100, 0, -4, 0, 0,
+ax_anim 1, 0, 101, 10, 10, 10, 10,
+ax_anim 1, 0, 100, 23, 23, 23, 23,
+ax_anim 2, 1, 101, 45, 45, 45, 45,
+ax_anim 2, 0, 100, 46, 44, 46, 44,
+ax_anim 2, 0, 101, 45, 45, 45, 45,
+ax_anim 2, 0, 100, 46, 44, 46, 44,
+ax_anim 2, 0, 101, 45, 45, 45, 45,
+ax_anim 2, 0, 100, 20, 20, 20, 20,
+ax_anim 2, 0, 101, 8, 8, 8, 8,
+ax_anim_terminator
+sVolbeatAnims_3_3:
+ax_anim 2, 0, 104, 0, -1, 0, 0,
+ax_anim 2, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 2, 2, 107, 0, -4, 0, 0,
+ax_anim 1, 0, 108, 14, -3, 14, 0,
+ax_anim 1, 0, 107, 21, -2, 21, 0,
+ax_anim 2, 1, 108, 43, 0, 43, 0,
+ax_anim 2, 0, 107, 43, 1, 43, 1,
+ax_anim 2, 0, 108, 43, 0, 43, 0,
+ax_anim 2, 0, 107, 43, 1, 43, 1,
+ax_anim 2, 0, 108, 43, 0, 43, 0,
+ax_anim 2, 0, 107, 22, -2, 22, 0,
+ax_anim 2, 0, 108, 10, -1, 10, 0,
+ax_anim_terminator
+sVolbeatAnims_3_4:
+ax_anim 2, 0, 113, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 2, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 117, 10, -10, 10, -10,
+ax_anim 1, 0, 116, 21, -21, 21, -21,
+ax_anim 2, 1, 117, 44, -41, 44, -41,
+ax_anim 2, 0, 116, 45, -40, 45, -40,
+ax_anim 2, 0, 117, 44, -41, 44, -41,
+ax_anim 2, 0, 116, 45, -40, 45, -40,
+ax_anim 2, 0, 117, 44, -41, 44, -41,
+ax_anim 2, 0, 116, 19, -19, 19, -19,
+ax_anim 2, 0, 117, 8, -8, 8, -8,
+ax_anim_terminator
+sVolbeatAnims_3_5:
+ax_anim 2, 0, 122, 0, -1, 0, 0,
+ax_anim 2, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 2, 2, 125, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -11, 0, -11,
+ax_anim 1, 0, 125, 0, -23, 0, -23,
+ax_anim 2, 1, 126, 0, -42, 0, -42,
+ax_anim 2, 0, 125, 1, -42, 1, -42,
+ax_anim 2, 0, 126, 0, -42, 0, -42,
+ax_anim 2, 0, 125, 1, -42, 1, -42,
+ax_anim 2, 0, 126, 0, -42, 0, -42,
+ax_anim 2, 0, 125, 0, -21, 0, -21,
+ax_anim 2, 0, 126, 0, -8, 0, -8,
+ax_anim_terminator
+sVolbeatAnims_3_6:
+ax_anim 2, 0, 131, 0, -1, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim 2, 2, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 135, -10, -10, -10, -10,
+ax_anim 1, 0, 134, -21, -21, -21, -21,
+ax_anim 2, 1, 135, -44, -41, -44, -41,
+ax_anim 2, 0, 134, -45, -40, -45, -40,
+ax_anim 2, 0, 135, -44, -41, -44, -41,
+ax_anim 2, 0, 134, -45, -40, -45, -40,
+ax_anim 2, 0, 135, -44, -41, -44, -41,
+ax_anim 2, 0, 134, -19, -19, -19, -19,
+ax_anim 2, 0, 135, -8, -8, -8, -8,
+ax_anim_terminator
+sVolbeatAnims_3_7:
+ax_anim 2, 0, 140, 0, -1, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 143, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 2, 143, 0, -4, 0, 0,
+ax_anim 1, 0, 144, -14, -3, -14, 0,
+ax_anim 1, 0, 143, -21, -2, -21, 0,
+ax_anim 2, 1, 144, -43, 0, -43, 0,
+ax_anim 2, 0, 143, -43, 1, -43, 1,
+ax_anim 2, 0, 144, -43, 0, -43, 0,
+ax_anim 2, 0, 143, -43, 1, -43, 1,
+ax_anim 2, 0, 144, -43, 0, -43, 0,
+ax_anim 2, 0, 143, -22, -2, -22, 0,
+ax_anim 2, 0, 144, -10, -1, -10, 0,
+ax_anim_terminator
+sVolbeatAnims_3_8:
+ax_anim 2, 0, 149, 0, -1, 0, 0,
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 0, 152, 0, -4, 0, 0,
+ax_anim 2, 0, 153, 0, -4, 0, 0,
+ax_anim 2, 2, 152, 0, -4, 0, 0,
+ax_anim 1, 0, 153, -10, 10, -10, 10,
+ax_anim 1, 0, 152, -23, 23, -23, 23,
+ax_anim 2, 1, 153, -45, 45, -45, 45,
+ax_anim 2, 0, 152, -46, 44, -46, 44,
+ax_anim 2, 0, 153, -45, 45, -45, 45,
+ax_anim 2, 0, 152, -46, 44, -46, 44,
+ax_anim 2, 0, 153, -45, 45, -45, 45,
+ax_anim 2, 0, 152, -20, 20, -20, 20,
+ax_anim 2, 0, 153, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_4_1:
+ax_anim 2, 0, 156, 1, 0, 1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 1, 0, 1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 1, 0, 1, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 1, 0, 1, 0,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 1, 0, 1, 0,
+ax_anim 2, 1, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_4_2:
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_4_3:
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, -1, 0, -1,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_4_4:
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -1, -1, -1, -1,
+ax_anim 2, 1, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_4_5:
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 1, 0, 1, 0,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_4_6:
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 1, -1, 1, -1,
+ax_anim 2, 1, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_4_7:
+ax_anim 2, 0, 158, 0, -1, 0, -1,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, -1,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, -1,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, -1,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, -1, 0, -1,
+ax_anim 2, 1, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_4_8:
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -1, -1, -1, -1,
+ax_anim 2, 1, 157, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_5_1:
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_5_2:
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_5_3:
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_5_4:
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_5_5:
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_5_6:
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_5_7:
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_5_8:
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 1, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_6_1:
+ax_anim 30, 0, 208, 0, 0, 0, 0,
+ax_anim 35, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_7_1:
+ax_anim 2, 0, 210, 0, -2, 0, -2,
+ax_anim 8, 0, 210, 0, -3, 0, -3,
+ax_anim_terminator
+sVolbeatAnims_7_2:
+ax_anim 2, 0, 211, -2, -2, -2, -2,
+ax_anim 8, 0, 211, -3, -3, -3, -3,
+ax_anim_terminator
+sVolbeatAnims_7_3:
+ax_anim 2, 0, 212, -2, 0, -2, 0,
+ax_anim 8, 0, 212, -3, 0, -3, 0,
+ax_anim_terminator
+sVolbeatAnims_7_4:
+ax_anim 2, 0, 213, -2, 2, -2, 2,
+ax_anim 8, 0, 213, -3, 3, -3, 3,
+ax_anim_terminator
+sVolbeatAnims_7_5:
+ax_anim 2, 0, 214, 0, 2, 0, 2,
+ax_anim 8, 0, 214, 0, 3, 0, 3,
+ax_anim_terminator
+sVolbeatAnims_7_6:
+ax_anim 2, 0, 215, 2, 2, 2, 2,
+ax_anim 8, 0, 215, 3, 3, 3, 3,
+ax_anim_terminator
+sVolbeatAnims_7_7:
+ax_anim 2, 0, 216, 2, 0, 2, 0,
+ax_anim 8, 0, 216, 3, 0, 3, 0,
+ax_anim_terminator
+sVolbeatAnims_7_8:
+ax_anim 2, 0, 217, 2, -2, 2, -2,
+ax_anim 8, 0, 217, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_8_1:
+ax_anim 30, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 220, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 4, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_8_2:
+ax_anim 30, 0, 221, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 8, 0, 222, 0, 0, 0, 0,
+ax_anim 4, 0, 221, 0, 0, 0, 0,
+ax_anim 8, 0, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_8_3:
+ax_anim 30, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim 4, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 225, 0, 0, 0, 0,
+ax_anim 4, 0, 224, 0, 0, 0, 0,
+ax_anim 8, 0, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_8_4:
+ax_anim 30, 0, 227, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 8, 0, 228, 0, 0, 0, 0,
+ax_anim 4, 0, 227, 0, 0, 0, 0,
+ax_anim 8, 0, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_8_5:
+ax_anim 30, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim 4, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 231, 0, 0, 0, 0,
+ax_anim 4, 0, 230, 0, 0, 0, 0,
+ax_anim 8, 0, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_8_6:
+ax_anim 30, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 234, 0, 0, 0, 0,
+ax_anim 4, 0, 233, 0, 0, 0, 0,
+ax_anim 8, 0, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_8_7:
+ax_anim 30, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 237, 0, 0, 0, 0,
+ax_anim 4, 0, 236, 0, 0, 0, 0,
+ax_anim 8, 0, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_8_8:
+ax_anim 30, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 240, 0, 0, 0, 0,
+ax_anim 4, 0, 239, 0, 0, 0, 0,
+ax_anim 8, 0, 241, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_9_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 1, 0, 243, 7, 4, 7, 4,
+ax_anim 2, 0, 244, 10, 13, 10, 13,
+ax_anim 2, 0, 245, 7, 19, 7, 19,
+ax_anim 3, 0, 246, 0, 20, 0, 20,
+ax_anim 2, 3, 247, -7, 19, -7, 19,
+ax_anim 2, 0, 248, -10, 13, -10, 13,
+ax_anim 1, 0, 249, -7, 4, -7, 4,
+ax_anim 1, 0, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_9_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 1, 0, 242, 12, 3, 12, 3,
+ax_anim 2, 0, 243, 20, 8, 20, 8,
+ax_anim 2, 0, 244, 23, 15, 23, 15,
+ax_anim 3, 0, 245, 20, 20, 20, 20,
+ax_anim 2, 3, 246, 14, 19, 14, 19,
+ax_anim 2, 0, 247, 7, 15, 7, 15,
+ax_anim 1, 0, 248, 3, 7, 3, 7,
+ax_anim 1, 0, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_9_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 1, 0, 249, 4, -2, 4, -2,
+ax_anim 2, 0, 242, 11, -4, 11, -4,
+ax_anim 2, 0, 243, 18, -3, 18, -3,
+ax_anim 3, 0, 244, 20, 0, 20, 0,
+ax_anim 2, 3, 245, 17, 4, 17, 4,
+ax_anim 2, 0, 246, 12, 5, 12, 5,
+ax_anim 1, 0, 247, 5, 4, 5, 4,
+ax_anim 1, 0, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_9_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 1, 0, 248, 0, -8, 0, -8,
+ax_anim 2, 0, 249, 5, -16, 5, -16,
+ax_anim 2, 0, 242, 13, -21, 13, -21,
+ax_anim 3, 0, 243, 22, -20, 22, -20,
+ax_anim 2, 3, 244, 24, -14, 24, -14,
+ax_anim 2, 0, 245, 19, -5, 19, -5,
+ax_anim 1, 0, 246, 9, -1, 9, -1,
+ax_anim 1, 0, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_9_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 1, 0, 247, -8, -4, -8, -4,
+ax_anim 2, 0, 248, -11, -10, -11, -10,
+ax_anim 2, 0, 249, -8, -19, -8, -19,
+ax_anim 3, 0, 242, 0, -21, 0, -21,
+ax_anim 2, 3, 243, 8, -19, 8, -19,
+ax_anim 2, 0, 244, 11, -10, 11, -10,
+ax_anim 1, 0, 245, 8, -4, 8, -4,
+ax_anim 1, 0, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_9_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 1, 0, 244, 0, -8, 0, -8,
+ax_anim 2, 0, 243, -5, -16, -5, -16,
+ax_anim 2, 0, 242, -13, -21, -13, -21,
+ax_anim 3, 0, 249, -22, -20, -22, -20,
+ax_anim 2, 3, 248, -24, -14, -24, -14,
+ax_anim 2, 0, 247, -19, -5, -19, -5,
+ax_anim 1, 0, 246, -9, -1, -9, -1,
+ax_anim 1, 0, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_9_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 1, 0, 243, -4, -2, -4, -2,
+ax_anim 2, 0, 242, -11, -4, -11, -4,
+ax_anim 2, 0, 249, -18, -3, -18, -3,
+ax_anim 3, 0, 248, -20, 0, -20, 0,
+ax_anim 2, 3, 247, -17, 4, -17, 4,
+ax_anim 2, 0, 246, -12, 5, -12, 5,
+ax_anim 1, 0, 245, -5, 4, -5, 4,
+ax_anim 1, 0, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_9_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 1, 0, 242, -12, 3, -12, 3,
+ax_anim 2, 0, 249, -20, 8, -20, 8,
+ax_anim 2, 0, 248, -23, 15, -23, 15,
+ax_anim 3, 0, 247, -20, 20, -20, 20,
+ax_anim 2, 3, 246, -14, 20, -14, 20,
+ax_anim 2, 0, 245, -7, 15, -7, 15,
+ax_anim 1, 0, 244, -3, 7, -3, 7,
+ax_anim 1, 0, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_10_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 3, 0, 250, 13, 0, 13, 0,
+ax_anim 3, 0, 250, -13, 0, -13, 0,
+ax_anim 2, 0, 250, 12, 0, 12, 0,
+ax_anim 3, 0, 250, -12, 0, -12, 0,
+ax_anim 2, 0, 250, 10, 0, 10, 0,
+ax_anim 2, 0, 250, -10, 0, -10, 0,
+ax_anim 2, 0, 250, 6, 0, 6, 0,
+ax_anim 2, 0, 250, -6, 0, -6, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_10_2:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 3, 0, 251, 13, -13, 13, -13,
+ax_anim 3, 0, 251, -13, 13, -13, 13,
+ax_anim 2, 0, 251, 12, -12, 12, -12,
+ax_anim 3, 0, 251, -12, 12, -12, 12,
+ax_anim 2, 0, 251, 10, -10, 10, -10,
+ax_anim 2, 0, 251, -10, 10, -10, 10,
+ax_anim 2, 0, 251, 6, -6, 6, -6,
+ax_anim 2, 0, 251, -6, 6, -6, 6,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_10_3:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 3, 0, 252, 0, -13, 0, -13,
+ax_anim 3, 0, 252, 0, 13, 0, 13,
+ax_anim 2, 0, 252, 0, -12, 0, -12,
+ax_anim 3, 0, 252, 0, 12, 0, 12,
+ax_anim 2, 0, 252, 0, -10, 0, -10,
+ax_anim 2, 0, 252, 0, 10, 0, 10,
+ax_anim 2, 0, 252, 0, -6, 0, -6,
+ax_anim 2, 0, 252, 0, 6, 0, 6,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_10_4:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 3, 0, 253, -13, -13, -13, -13,
+ax_anim 3, 0, 253, 13, 13, 13, 13,
+ax_anim 2, 0, 253, -12, -12, -12, -12,
+ax_anim 3, 0, 253, 12, 12, 12, 12,
+ax_anim 2, 0, 253, -10, -10, -10, -10,
+ax_anim 2, 0, 253, 10, 10, 10, 10,
+ax_anim 2, 0, 253, -6, -6, -6, -6,
+ax_anim 2, 0, 253, 6, 6, 6, 6,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_10_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 6, 0, 6, 0,
+ax_anim 2, 0, 254, -6, 0, -6, 0,
+ax_anim 2, 0, 254, 10, 0, 10, 0,
+ax_anim 2, 0, 254, -10, 0, -10, 0,
+ax_anim 2, 0, 254, 12, 0, 12, 0,
+ax_anim 3, 0, 254, -12, 0, -12, 0,
+ax_anim 3, 0, 254, 13, 0, 13, 0,
+ax_anim 3, 0, 254, -13, 0, -13, 0,
+ax_anim 2, 0, 254, 12, 0, 12, 0,
+ax_anim 3, 0, 254, -12, 0, -12, 0,
+ax_anim 2, 0, 254, 10, 0, 10, 0,
+ax_anim 2, 0, 254, -10, 0, -10, 0,
+ax_anim 2, 0, 254, 6, 0, 6, 0,
+ax_anim 2, 0, 254, -6, 0, -6, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_10_6:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 6, -6, 6, -6,
+ax_anim 2, 0, 255, -6, 6, -6, 6,
+ax_anim 2, 0, 255, 10, -10, 10, -10,
+ax_anim 2, 0, 255, -10, 10, -10, 10,
+ax_anim 2, 0, 255, 12, -12, 12, -12,
+ax_anim 3, 0, 255, -12, 12, -12, 12,
+ax_anim 3, 0, 255, 13, -13, 13, -13,
+ax_anim 3, 0, 255, -13, 13, -13, 13,
+ax_anim 2, 0, 255, 12, -12, 12, -12,
+ax_anim 3, 0, 255, -12, 12, -12, 12,
+ax_anim 2, 0, 255, 10, -10, 10, -10,
+ax_anim 2, 0, 255, -10, 10, -10, 10,
+ax_anim 2, 0, 255, 6, -6, 6, -6,
+ax_anim 2, 0, 255, -6, 6, -6, 6,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_10_7:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, -6, 0, -6,
+ax_anim 2, 0, 256, 0, 6, 0, 6,
+ax_anim 2, 0, 256, 0, -10, 0, -10,
+ax_anim 2, 0, 256, 0, 10, 0, 10,
+ax_anim 2, 0, 256, 0, -12, 0, -12,
+ax_anim 3, 0, 256, 0, 12, 0, 12,
+ax_anim 3, 0, 256, 0, -13, 0, -13,
+ax_anim 3, 0, 256, 0, 13, 0, 13,
+ax_anim 2, 0, 256, 0, -12, 0, -12,
+ax_anim 3, 0, 256, 0, 12, 0, 12,
+ax_anim 2, 0, 256, 0, -10, 0, -10,
+ax_anim 2, 0, 256, 0, 10, 0, 10,
+ax_anim 2, 0, 256, 0, -6, 0, -6,
+ax_anim 2, 0, 256, 0, 6, 0, 6,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_10_8:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 257, -6, -6, -6, -6,
+ax_anim 2, 0, 257, 6, 6, 6, 6,
+ax_anim 2, 0, 257, -10, -10, -10, -10,
+ax_anim 2, 0, 257, 10, 10, 10, 10,
+ax_anim 2, 0, 257, -12, -12, -12, -12,
+ax_anim 3, 0, 257, 12, 12, 12, 12,
+ax_anim 3, 0, 257, -13, -13, -13, -13,
+ax_anim 3, 0, 257, 13, 13, 13, 13,
+ax_anim 2, 0, 257, -12, -12, -12, -12,
+ax_anim 3, 0, 257, 12, 12, 12, 12,
+ax_anim 2, 0, 257, -10, -10, -10, -10,
+ax_anim 2, 0, 257, 10, 10, 10, 10,
+ax_anim 2, 0, 257, -6, -6, -6, -6,
+ax_anim 2, 0, 257, 6, 6, 6, 6,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_11_1:
+ax_anim 2, 0, 258, 0, 0, 0, 0,
+ax_anim 1, 0, 259, 0, -10, 0, 0,
+ax_anim 2, 0, 259, 0, -16, 0, 0,
+ax_anim 3, 0, 259, 0, -20, 0, 0,
+ax_anim 4, 0, 259, 0, -22, 0, 0,
+ax_anim 4, 0, 258, 0, -23, 0, 0,
+ax_anim 3, 0, 260, 0, -22, 0, 0,
+ax_anim 2, 0, 260, 0, -18, 0, 0,
+ax_anim 1, 0, 260, 0, -12, 0, 0,
+ax_anim 2, 2, 258, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_11_2:
+ax_anim 2, 0, 261, 0, 0, 0, 0,
+ax_anim 1, 0, 262, 0, -10, 0, 0,
+ax_anim 2, 0, 262, 0, -16, 0, 0,
+ax_anim 3, 0, 262, 0, -20, 0, 0,
+ax_anim 4, 0, 262, 0, -22, 0, 0,
+ax_anim 4, 0, 261, 0, -24, 0, 0,
+ax_anim 3, 0, 263, 0, -22, 0, 0,
+ax_anim 2, 0, 263, 0, -18, 0, 0,
+ax_anim 1, 0, 263, 0, -12, 0, 0,
+ax_anim 2, 2, 261, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_11_3:
+ax_anim 2, 0, 264, 0, 0, 0, 0,
+ax_anim 1, 0, 265, 0, -10, 0, 0,
+ax_anim 2, 0, 265, 0, -16, 0, 0,
+ax_anim 3, 0, 265, 0, -20, 0, 0,
+ax_anim 4, 0, 265, 0, -22, 0, 0,
+ax_anim 4, 0, 264, 0, -24, 0, 0,
+ax_anim 3, 0, 266, 0, -22, 0, 0,
+ax_anim 2, 0, 266, 0, -18, 0, 0,
+ax_anim 1, 0, 266, 0, -12, 0, 0,
+ax_anim 2, 2, 264, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_11_4:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 1, 0, 268, 0, -10, 0, 0,
+ax_anim 2, 0, 268, 0, -16, 0, 0,
+ax_anim 3, 0, 268, 0, -20, 0, 0,
+ax_anim 4, 0, 268, 0, -22, 0, 0,
+ax_anim 4, 0, 267, 0, -23, 0, 0,
+ax_anim 3, 0, 269, 0, -21, 0, 0,
+ax_anim 2, 0, 269, 0, -17, 0, 0,
+ax_anim 1, 0, 269, 0, -11, 0, 0,
+ax_anim 2, 2, 267, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_11_5:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 1, 0, 271, 0, -10, 0, 0,
+ax_anim 2, 0, 271, 0, -16, 0, 0,
+ax_anim 3, 0, 271, 0, -20, 0, 0,
+ax_anim 4, 0, 271, 0, -22, 0, 0,
+ax_anim 4, 0, 270, 0, -24, 0, 0,
+ax_anim 3, 0, 272, 0, -22, 0, 0,
+ax_anim 2, 0, 272, 0, -18, 0, 0,
+ax_anim 1, 0, 272, 0, -12, 0, 0,
+ax_anim 2, 2, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_11_6:
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 274, 0, -10, 0, 0,
+ax_anim 2, 0, 274, 0, -16, 0, 0,
+ax_anim 3, 0, 274, 0, -20, 0, 0,
+ax_anim 4, 0, 274, 0, -22, 0, 0,
+ax_anim 4, 0, 273, 0, -23, 0, 0,
+ax_anim 3, 0, 275, 0, -21, 0, 0,
+ax_anim 2, 0, 275, 0, -17, 0, 0,
+ax_anim 1, 0, 275, 0, -11, 0, 0,
+ax_anim 2, 2, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_11_7:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 1, 0, 277, 0, -10, 0, 0,
+ax_anim 2, 0, 277, 0, -16, 0, 0,
+ax_anim 3, 0, 277, 0, -20, 0, 0,
+ax_anim 4, 0, 277, 0, -22, 0, 0,
+ax_anim 4, 0, 276, 0, -24, 0, 0,
+ax_anim 3, 0, 278, 0, -22, 0, 0,
+ax_anim 2, 0, 278, 0, -18, 0, 0,
+ax_anim 1, 0, 278, 0, -12, 0, 0,
+ax_anim 2, 2, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_11_8:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 1, 0, 280, 0, -10, 0, 0,
+ax_anim 2, 0, 280, 0, -16, 0, 0,
+ax_anim 3, 0, 280, 0, -20, 0, 0,
+ax_anim 4, 0, 280, 0, -22, 0, 0,
+ax_anim 4, 0, 279, 0, -24, 0, 0,
+ax_anim 3, 0, 281, 0, -22, 0, 0,
+ax_anim 2, 0, 281, 0, -18, 0, 0,
+ax_anim 1, 0, 281, 0, -12, 0, 0,
+ax_anim 2, 2, 279, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_12_1:
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 2, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 2, 0, 282, 1, 0, 1, 0,
+ax_anim 2, 1, 282, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_12_2:
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 2, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 0, 289, 0, 0, 0, 0,
+ax_anim 2, 0, 289, 1, -1, 1, -1,
+ax_anim 2, 1, 289, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_12_3:
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 2, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 2, 0, 288, 0, -1, 0, -1,
+ax_anim 2, 1, 288, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_12_4:
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 2, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 0, 287, 0, 0, 0, 0,
+ax_anim 2, 0, 287, -1, -1, -1, -1,
+ax_anim 2, 1, 287, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_12_5:
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 2, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 0, 286, 0, 0, 0, 0,
+ax_anim 2, 0, 286, 1, 0, 1, 0,
+ax_anim 2, 1, 286, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_12_6:
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 2, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 2, 0, 285, 1, -1, 1, -1,
+ax_anim 2, 1, 285, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_12_7:
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 2, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 0, 284, 0, 0, 0, 0,
+ax_anim 2, 0, 284, 0, -1, 0, -1,
+ax_anim 2, 1, 284, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_12_8:
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 2, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 0, 283, 0, 0, 0, 0,
+ax_anim 2, 0, 283, -1, -1, -1, -1,
+ax_anim 2, 1, 283, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVolbeatAnims_13_1:
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 2, 290, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_13_2:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 2, 297, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_13_3:
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 2, 296, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_13_4:
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 2, 295, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_13_5:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 2, 294, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_13_6:
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 2, 293, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_13_7:
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 2, 292, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatAnims_13_8:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 2, 0, 292, 0, 0, 0, 0,
+ax_anim 2, 0, 293, 0, 0, 0, 0,
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 2, 0, 295, 0, 0, 0, 0,
+ax_anim 2, 0, 296, 0, 0, 0, 0,
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 2, 0, 290, 0, 0, 0, 0,
+ax_anim 2, 2, 291, 0, 0, 0, 0,
+ax_anim_terminator
+sVolbeatGfx1:
+.incbin "baserom.gba", 0x12BED20, 0x200
+sVolbeatSprites1:
+ax_sprite sVolbeatGfx1, 0x200
+ax_sprite_terminator
+sVolbeatGfx2:
+.incbin "baserom.gba", 0x12BEF30, 0x200
+sVolbeatSprites2:
+ax_sprite sVolbeatGfx2, 0x200
+ax_sprite_terminator
+sVolbeatGfx3:
+.incbin "baserom.gba", 0x12BF140, 0x200
+sVolbeatSprites3:
+ax_sprite sVolbeatGfx3, 0x200
+ax_sprite_terminator
+sVolbeatGfx4:
+.incbin "baserom.gba", 0x12BF350, 0x200
+sVolbeatSprites4:
+ax_sprite sVolbeatGfx4, 0x200
+ax_sprite_terminator
+sVolbeatGfx5:
+.incbin "baserom.gba", 0x12BF560, 0x200
+sVolbeatSprites5:
+ax_sprite sVolbeatGfx5, 0x200
+ax_sprite_terminator
+sVolbeatGfx6:
+.incbin "baserom.gba", 0x12BF770, 0x200
+sVolbeatSprites6:
+ax_sprite sVolbeatGfx6, 0x200
+ax_sprite_terminator
+sVolbeatGfx7:
+.incbin "baserom.gba", 0x12BF980, 0x200
+sVolbeatSprites7:
+ax_sprite sVolbeatGfx7, 0x200
+ax_sprite_terminator
+sVolbeatGfx8:
+.incbin "baserom.gba", 0x12BFB90, 0x200
+sVolbeatSprites8:
+ax_sprite sVolbeatGfx8, 0x200
+ax_sprite_terminator
+sVolbeatGfx9:
+.incbin "baserom.gba", 0x12BFDA0, 0x200
+sVolbeatSprites9:
+ax_sprite sVolbeatGfx9, 0x200
+ax_sprite_terminator
+sVolbeatGfx10:
+.incbin "baserom.gba", 0x12BFFB0, 0x200
+sVolbeatSprites10:
+ax_sprite sVolbeatGfx10, 0x200
+ax_sprite_terminator
+sVolbeatGfx11:
+.incbin "baserom.gba", 0x12C01C0, 0x200
+sVolbeatSprites11:
+ax_sprite sVolbeatGfx11, 0x200
+ax_sprite_terminator
+sVolbeatGfx12:
+.incbin "baserom.gba", 0x12C03D0, 0x200
+sVolbeatSprites12:
+ax_sprite sVolbeatGfx12, 0x200
+ax_sprite_terminator
+sVolbeatGfx13:
+.incbin "baserom.gba", 0x12C05E0, 0x200
+sVolbeatSprites13:
+ax_sprite sVolbeatGfx13, 0x200
+ax_sprite_terminator
+sVolbeatGfx14:
+.incbin "baserom.gba", 0x12C07F0, 0x200
+sVolbeatSprites14:
+ax_sprite sVolbeatGfx14, 0x200
+ax_sprite_terminator
+sVolbeatGfx15:
+.incbin "baserom.gba", 0x12C0A00, 0x200
+sVolbeatSprites15:
+ax_sprite sVolbeatGfx15, 0x200
+ax_sprite_terminator
+sVolbeatGfx16:
+.incbin "baserom.gba", 0x12C0C10, 0x40
+sVolbeatGfx16_1:
+.incbin "baserom.gba", 0x12C0C50, 0x100
+sVolbeatGfx16_2:
+.incbin "baserom.gba", 0x12C0D50, 0x40
+sVolbeatSprites16:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx17:
+.incbin "baserom.gba", 0x12C0DD0, 0x40
+sVolbeatGfx17_1:
+.incbin "baserom.gba", 0x12C0E10, 0x100
+sVolbeatGfx17_2:
+.incbin "baserom.gba", 0x12C0F10, 0x40
+sVolbeatSprites17:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx18:
+.incbin "baserom.gba", 0x12C0F90, 0x40
+sVolbeatGfx18_1:
+.incbin "baserom.gba", 0x12C0FD0, 0x100
+sVolbeatGfx18_2:
+.incbin "baserom.gba", 0x12C10D0, 0x40
+sVolbeatSprites18:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx19:
+.incbin "baserom.gba", 0x12C1150, 0x40
+sVolbeatGfx19_1:
+.incbin "baserom.gba", 0x12C1190, 0x100
+sVolbeatGfx19_2:
+.incbin "baserom.gba", 0x12C1290, 0x40
+sVolbeatSprites19:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx19_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx19_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx20:
+.incbin "baserom.gba", 0x12C1310, 0x40
+sVolbeatGfx20_1:
+.incbin "baserom.gba", 0x12C1350, 0x100
+sVolbeatGfx20_2:
+.incbin "baserom.gba", 0x12C1450, 0x40
+sVolbeatSprites20:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx21:
+.incbin "baserom.gba", 0x12C14D0, 0x40
+sVolbeatGfx21_1:
+.incbin "baserom.gba", 0x12C1510, 0x100
+sVolbeatGfx21_2:
+.incbin "baserom.gba", 0x12C1610, 0x40
+sVolbeatSprites21:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx21_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx21_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx22:
+.incbin "baserom.gba", 0x12C1690, 0x40
+sVolbeatGfx22_1:
+.incbin "baserom.gba", 0x12C16D0, 0x100
+sVolbeatGfx22_2:
+.incbin "baserom.gba", 0x12C17D0, 0x40
+sVolbeatSprites22:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx23:
+.incbin "baserom.gba", 0x12C1850, 0x40
+sVolbeatGfx23_1:
+.incbin "baserom.gba", 0x12C1890, 0x80
+sVolbeatGfx23_2:
+.incbin "baserom.gba", 0x12C1910, 0x60
+sVolbeatGfx23_3:
+.incbin "baserom.gba", 0x12C1970, 0x40
+sVolbeatSprites23:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx23, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx23_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx23_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx24:
+.incbin "baserom.gba", 0x12C1A00, 0x40
+sVolbeatGfx24_1:
+.incbin "baserom.gba", 0x12C1A40, 0x60
+sVolbeatGfx24_2:
+.incbin "baserom.gba", 0x12C1AA0, 0x60
+sVolbeatGfx24_3:
+.incbin "baserom.gba", 0x12C1B00, 0x60
+sVolbeatSprites24:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx24, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx24_3, 0x60
+ax_sprite_terminator
+sVolbeatGfx25:
+.incbin "baserom.gba", 0x12C1BA8, 0x40
+sVolbeatGfx25_1:
+.incbin "baserom.gba", 0x12C1BE8, 0x60
+sVolbeatGfx25_2:
+.incbin "baserom.gba", 0x12C1C48, 0x60
+sVolbeatGfx25_3:
+.incbin "baserom.gba", 0x12C1CA8, 0x60
+sVolbeatSprites25:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx25_3, 0x60
+ax_sprite_terminator
+sVolbeatGfx26:
+.incbin "baserom.gba", 0x12C1D50, 0x40
+sVolbeatGfx26_1:
+.incbin "baserom.gba", 0x12C1D90, 0x60
+sVolbeatGfx26_2:
+.incbin "baserom.gba", 0x12C1DF0, 0x60
+sVolbeatGfx26_3:
+.incbin "baserom.gba", 0x12C1E50, 0x40
+sVolbeatSprites26:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx27:
+.incbin "baserom.gba", 0x12C1EE0, 0x40
+sVolbeatGfx27_1:
+.incbin "baserom.gba", 0x12C1F20, 0x60
+sVolbeatGfx27_2:
+.incbin "baserom.gba", 0x12C1F80, 0x60
+sVolbeatGfx27_3:
+.incbin "baserom.gba", 0x12C1FE0, 0x40
+sVolbeatSprites27:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx27, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx28:
+.incbin "baserom.gba", 0x12C2070, 0x40
+sVolbeatGfx28_1:
+.incbin "baserom.gba", 0x12C20B0, 0x60
+sVolbeatGfx28_2:
+.incbin "baserom.gba", 0x12C2110, 0x60
+sVolbeatGfx28_3:
+.incbin "baserom.gba", 0x12C2170, 0x40
+sVolbeatSprites28:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx29:
+.incbin "baserom.gba", 0x12C2200, 0x40
+sVolbeatGfx29_1:
+.incbin "baserom.gba", 0x12C2240, 0x60
+sVolbeatGfx29_2:
+.incbin "baserom.gba", 0x12C22A0, 0x60
+sVolbeatGfx29_3:
+.incbin "baserom.gba", 0x12C2300, 0x40
+sVolbeatSprites29:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx29, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx30:
+.incbin "baserom.gba", 0x12C2390, 0x40
+sVolbeatGfx30_1:
+.incbin "baserom.gba", 0x12C23D0, 0x60
+sVolbeatGfx30_2:
+.incbin "baserom.gba", 0x12C2430, 0x60
+sVolbeatGfx30_3:
+.incbin "baserom.gba", 0x12C2490, 0x60
+sVolbeatSprites30:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx30_3, 0x60
+ax_sprite_terminator
+sVolbeatGfx31:
+.incbin "baserom.gba", 0x12C2538, 0x40
+sVolbeatGfx31_1:
+.incbin "baserom.gba", 0x12C2578, 0x60
+sVolbeatGfx31_2:
+.incbin "baserom.gba", 0x12C25D8, 0x60
+sVolbeatGfx31_3:
+.incbin "baserom.gba", 0x12C2638, 0x60
+sVolbeatSprites31:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx31_3, 0x60
+ax_sprite_terminator
+sVolbeatGfx32:
+.incbin "baserom.gba", 0x12C26E0, 0x40
+sVolbeatGfx32_1:
+.incbin "baserom.gba", 0x12C2720, 0x60
+sVolbeatGfx32_2:
+.incbin "baserom.gba", 0x12C2780, 0x60
+sVolbeatGfx32_3:
+.incbin "baserom.gba", 0x12C27E0, 0x40
+sVolbeatSprites32:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx33:
+.incbin "baserom.gba", 0x12C2870, 0x40
+sVolbeatGfx33_1:
+.incbin "baserom.gba", 0x12C28B0, 0x60
+sVolbeatGfx33_2:
+.incbin "baserom.gba", 0x12C2910, 0x60
+sVolbeatGfx33_3:
+.incbin "baserom.gba", 0x12C2970, 0x40
+sVolbeatSprites33:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx33_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx34:
+.incbin "baserom.gba", 0x12C2A00, 0x40
+sVolbeatGfx34_1:
+.incbin "baserom.gba", 0x12C2A40, 0x60
+sVolbeatGfx34_2:
+.incbin "baserom.gba", 0x12C2AA0, 0x60
+sVolbeatGfx34_3:
+.incbin "baserom.gba", 0x12C2B00, 0x40
+sVolbeatSprites34:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx34, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx34_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx35:
+.incbin "baserom.gba", 0x12C2B90, 0x40
+sVolbeatGfx35_1:
+.incbin "baserom.gba", 0x12C2BD0, 0x60
+sVolbeatGfx35_2:
+.incbin "baserom.gba", 0x12C2C30, 0x60
+sVolbeatGfx35_3:
+.incbin "baserom.gba", 0x12C2C90, 0x40
+sVolbeatSprites35:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVolbeatGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx35_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx36:
+.incbin "baserom.gba", 0x12C2D20, 0x40
+sVolbeatGfx36_1:
+.incbin "baserom.gba", 0x12C2D60, 0x100
+sVolbeatGfx36_2:
+.incbin "baserom.gba", 0x12C2E60, 0x40
+sVolbeatSprites36:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx36, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx36_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx36_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx37:
+.incbin "baserom.gba", 0x12C2EE0, 0x40
+sVolbeatGfx37_1:
+.incbin "baserom.gba", 0x12C2F20, 0x100
+sVolbeatGfx37_2:
+.incbin "baserom.gba", 0x12C3020, 0x40
+sVolbeatSprites37:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx37, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx37_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx37_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx38:
+.incbin "baserom.gba", 0x12C30A0, 0x60
+sVolbeatGfx38_1:
+.incbin "baserom.gba", 0x12C3100, 0xE0
+sVolbeatGfx38_2:
+.incbin "baserom.gba", 0x12C31E0, 0x40
+sVolbeatSprites38:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx38_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx39:
+.incbin "baserom.gba", 0x12C3260, 0x60
+sVolbeatGfx39_1:
+.incbin "baserom.gba", 0x12C32C0, 0xE0
+sVolbeatGfx39_2:
+.incbin "baserom.gba", 0x12C33A0, 0x40
+sVolbeatSprites39:
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx39_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx39_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx40:
+.incbin "baserom.gba", 0x12C3420, 0x60
+sVolbeatGfx40_1:
+.incbin "baserom.gba", 0x12C3480, 0x100
+sVolbeatGfx40_2:
+.incbin "baserom.gba", 0x12C3580, 0x40
+sVolbeatSprites40:
+ax_sprite sVolbeatGfx40, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx40_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx40_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx41:
+.incbin "baserom.gba", 0x12C35F8, 0x60
+sVolbeatGfx41_1:
+.incbin "baserom.gba", 0x12C3658, 0x100
+sVolbeatGfx41_2:
+.incbin "baserom.gba", 0x12C3758, 0x40
+sVolbeatSprites41:
+ax_sprite sVolbeatGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx41_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sVolbeatGfx41_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sVolbeatGfx42:
+.incbin "baserom.gba", 0x12C37D0, 0x20
+sVolbeatSprites42:
+ax_sprite sVolbeatGfx42, 0x20
+ax_sprite_terminator
+sVolbeatGfx43:
+.incbin "baserom.gba", 0x12C3800, 0x200
+sVolbeatSprites43:
+ax_sprite sVolbeatGfx43, 0x200
+ax_sprite_terminator
+sVolbeatGfx44:
+.incbin "baserom.gba", 0x12C3A10, 0x200
+sVolbeatSprites44:
+ax_sprite sVolbeatGfx44, 0x200
+ax_sprite_terminator
+sVolbeatGfx45:
+.incbin "baserom.gba", 0x12C3C20, 0x80
+sVolbeatSprites45:
+ax_sprite sVolbeatGfx45, 0x80
+ax_sprite_terminator
+sVolbeatGfx46:
+.incbin "baserom.gba", 0x12C3CB0, 0x20
+sVolbeatSprites46:
+ax_sprite sVolbeatGfx46, 0x20
+ax_sprite_terminator
+sVolbeatGfx47:
+.incbin "baserom.gba", 0x12C3CE0, 0x20
+sVolbeatSprites47:
+ax_sprite sVolbeatGfx47, 0x20
+ax_sprite_terminator
+sVolbeatGfx48:
+.incbin "baserom.gba", 0x12C3D10, 0x100
+sVolbeatSprites48:
+ax_sprite sVolbeatGfx48, 0x100
+ax_sprite_terminator
+sVolbeatGfx49:
+.incbin "baserom.gba", 0x12C3E20, 0x200
+sVolbeatSprites49:
+ax_sprite sVolbeatGfx49, 0x200
+ax_sprite_terminator
+sVolbeatGfx50:
+.incbin "baserom.gba", 0x12C4030, 0x200
+sVolbeatSprites50:
+ax_sprite sVolbeatGfx50, 0x200
+ax_sprite_terminator
+sVolbeatGfx51:
+.incbin "baserom.gba", 0x12C4240, 0x200
+sVolbeatSprites51:
+ax_sprite sVolbeatGfx51, 0x200
+ax_sprite_terminator
+sVolbeatGfx52:
+.incbin "baserom.gba", 0x12C4450, 0x80
+sVolbeatSprites52:
+ax_sprite sVolbeatGfx52, 0x80
+ax_sprite_terminator
+sVolbeatGfx53:
+.incbin "baserom.gba", 0x12C44E0, 0x20
+sVolbeatSprites53:
+ax_sprite sVolbeatGfx53, 0x20
+ax_sprite_terminator
+sVolbeatGfx54:
+.incbin "baserom.gba", 0x12C4510, 0x20
+sVolbeatSprites54:
+ax_sprite sVolbeatGfx54, 0x20
+ax_sprite_terminator
+sVolbeatGfx55:
+.incbin "baserom.gba", 0x12C4540, 0x100
+sVolbeatSprites55:
+ax_sprite sVolbeatGfx55, 0x100
+ax_sprite_terminator
+sAxPosesVolbeat:
+.4byte sVolbeatPose1
+.4byte sVolbeatPose2
+.4byte sVolbeatPose3
+.4byte sVolbeatPose4
+.4byte sVolbeatPose5
+.4byte sVolbeatPose6
+.4byte sVolbeatPose7
+.4byte sVolbeatPose8
+.4byte sVolbeatPose9
+.4byte sVolbeatPose10
+.4byte sVolbeatPose11
+.4byte sVolbeatPose12
+.4byte sVolbeatPose13
+.4byte sVolbeatPose14
+.4byte sVolbeatPose15
+.4byte sVolbeatPose16
+.4byte sVolbeatPose17
+.4byte sVolbeatPose18
+.4byte sVolbeatPose19
+.4byte sVolbeatPose20
+.4byte sVolbeatPose21
+.4byte sVolbeatPose22
+.4byte sVolbeatPose23
+.4byte sVolbeatPose24
+.4byte sVolbeatPose25
+.4byte sVolbeatPose26
+.4byte sVolbeatPose27
+.4byte sVolbeatPose28
+.4byte sVolbeatPose29
+.4byte sVolbeatPose30
+.4byte sVolbeatPose31
+.4byte sVolbeatPose32
+.4byte sVolbeatPose33
+.4byte sVolbeatPose34
+.4byte sVolbeatPose35
+.4byte sVolbeatPose36
+.4byte sVolbeatPose37
+.4byte sVolbeatPose38
+.4byte sVolbeatPose39
+.4byte sVolbeatPose40
+.4byte sVolbeatPose41
+.4byte sVolbeatPose42
+.4byte sVolbeatPose43
+.4byte sVolbeatPose44
+.4byte sVolbeatPose45
+.4byte sVolbeatPose46
+.4byte sVolbeatPose47
+.4byte sVolbeatPose48
+.4byte sVolbeatPose49
+.4byte sVolbeatPose50
+.4byte sVolbeatPose51
+.4byte sVolbeatPose52
+.4byte sVolbeatPose53
+.4byte sVolbeatPose54
+.4byte sVolbeatPose55
+.4byte sVolbeatPose56
+.4byte sVolbeatPose57
+.4byte sVolbeatPose58
+.4byte sVolbeatPose59
+.4byte sVolbeatPose60
+.4byte sVolbeatPose61
+.4byte sVolbeatPose62
+.4byte sVolbeatPose63
+.4byte sVolbeatPose64
+.4byte sVolbeatPose65
+.4byte sVolbeatPose66
+.4byte sVolbeatPose67
+.4byte sVolbeatPose68
+.4byte sVolbeatPose69
+.4byte sVolbeatPose70
+.4byte sVolbeatPose71
+.4byte sVolbeatPose72
+.4byte sVolbeatPose73
+.4byte sVolbeatPose74
+.4byte sVolbeatPose75
+.4byte sVolbeatPose76
+.4byte sVolbeatPose77
+.4byte sVolbeatPose78
+.4byte sVolbeatPose79
+.4byte sVolbeatPose80
+.4byte sVolbeatPose81
+.4byte sVolbeatPose82
+.4byte sVolbeatPose83
+.4byte sVolbeatPose84
+.4byte sVolbeatPose85
+.4byte sVolbeatPose86
+.4byte sVolbeatPose87
+.4byte sVolbeatPose88
+.4byte sVolbeatPose89
+.4byte sVolbeatPose90
+.4byte sVolbeatPose91
+.4byte sVolbeatPose92
+.4byte sVolbeatPose93
+.4byte sVolbeatPose94
+.4byte sVolbeatPose95
+.4byte sVolbeatPose96
+.4byte sVolbeatPose97
+.4byte sVolbeatPose98
+.4byte sVolbeatPose99
+.4byte sVolbeatPose100
+.4byte sVolbeatPose101
+.4byte sVolbeatPose102
+.4byte sVolbeatPose103
+.4byte sVolbeatPose104
+.4byte sVolbeatPose105
+.4byte sVolbeatPose106
+.4byte sVolbeatPose107
+.4byte sVolbeatPose108
+.4byte sVolbeatPose109
+.4byte sVolbeatPose110
+.4byte sVolbeatPose111
+.4byte sVolbeatPose112
+.4byte sVolbeatPose113
+.4byte sVolbeatPose114
+.4byte sVolbeatPose115
+.4byte sVolbeatPose116
+.4byte sVolbeatPose117
+.4byte sVolbeatPose118
+.4byte sVolbeatPose119
+.4byte sVolbeatPose120
+.4byte sVolbeatPose121
+.4byte sVolbeatPose122
+.4byte sVolbeatPose123
+.4byte sVolbeatPose124
+.4byte sVolbeatPose125
+.4byte sVolbeatPose126
+.4byte sVolbeatPose127
+.4byte sVolbeatPose128
+.4byte sVolbeatPose129
+.4byte sVolbeatPose130
+.4byte sVolbeatPose131
+.4byte sVolbeatPose132
+.4byte sVolbeatPose133
+.4byte sVolbeatPose134
+.4byte sVolbeatPose135
+.4byte sVolbeatPose136
+.4byte sVolbeatPose137
+.4byte sVolbeatPose138
+.4byte sVolbeatPose139
+.4byte sVolbeatPose140
+.4byte sVolbeatPose141
+.4byte sVolbeatPose142
+.4byte sVolbeatPose143
+.4byte sVolbeatPose144
+.4byte sVolbeatPose145
+.4byte sVolbeatPose146
+.4byte sVolbeatPose147
+.4byte sVolbeatPose148
+.4byte sVolbeatPose149
+.4byte sVolbeatPose150
+.4byte sVolbeatPose151
+.4byte sVolbeatPose152
+.4byte sVolbeatPose153
+.4byte sVolbeatPose154
+.4byte sVolbeatPose155
+.4byte sVolbeatPose156
+.4byte sVolbeatPose157
+.4byte sVolbeatPose158
+.4byte sVolbeatPose159
+.4byte sVolbeatPose160
+.4byte sVolbeatPose161
+.4byte sVolbeatPose162
+.4byte sVolbeatPose163
+.4byte sVolbeatPose164
+.4byte sVolbeatPose165
+.4byte sVolbeatPose166
+.4byte sVolbeatPose167
+.4byte sVolbeatPose168
+.4byte sVolbeatPose169
+.4byte sVolbeatPose170
+.4byte sVolbeatPose171
+.4byte sVolbeatPose172
+.4byte sVolbeatPose173
+.4byte sVolbeatPose174
+.4byte sVolbeatPose175
+.4byte sVolbeatPose176
+.4byte sVolbeatPose177
+.4byte sVolbeatPose178
+.4byte sVolbeatPose179
+.4byte sVolbeatPose180
+.4byte sVolbeatPose181
+.4byte sVolbeatPose182
+.4byte sVolbeatPose183
+.4byte sVolbeatPose184
+.4byte sVolbeatPose185
+.4byte sVolbeatPose186
+.4byte sVolbeatPose187
+.4byte sVolbeatPose188
+.4byte sVolbeatPose189
+.4byte sVolbeatPose190
+.4byte sVolbeatPose191
+.4byte sVolbeatPose192
+.4byte sVolbeatPose193
+.4byte sVolbeatPose194
+.4byte sVolbeatPose195
+.4byte sVolbeatPose196
+.4byte sVolbeatPose197
+.4byte sVolbeatPose198
+.4byte sVolbeatPose199
+.4byte sVolbeatPose200
+.4byte sVolbeatPose201
+.4byte sVolbeatPose202
+.4byte sVolbeatPose203
+.4byte sVolbeatPose204
+.4byte sVolbeatPose205
+.4byte sVolbeatPose206
+.4byte sVolbeatPose207
+.4byte sVolbeatPose208
+.4byte sVolbeatPose209
+.4byte sVolbeatPose210
+.4byte sVolbeatPose211
+.4byte sVolbeatPose212
+.4byte sVolbeatPose213
+.4byte sVolbeatPose214
+.4byte sVolbeatPose215
+.4byte sVolbeatPose216
+.4byte sVolbeatPose217
+.4byte sVolbeatPose218
+.4byte sVolbeatPose219
+.4byte sVolbeatPose220
+.4byte sVolbeatPose221
+.4byte sVolbeatPose222
+.4byte sVolbeatPose223
+.4byte sVolbeatPose224
+.4byte sVolbeatPose225
+.4byte sVolbeatPose226
+.4byte sVolbeatPose227
+.4byte sVolbeatPose228
+.4byte sVolbeatPose229
+.4byte sVolbeatPose230
+.4byte sVolbeatPose231
+.4byte sVolbeatPose232
+.4byte sVolbeatPose233
+.4byte sVolbeatPose234
+.4byte sVolbeatPose235
+.4byte sVolbeatPose236
+.4byte sVolbeatPose237
+.4byte sVolbeatPose238
+.4byte sVolbeatPose239
+.4byte sVolbeatPose240
+.4byte sVolbeatPose241
+.4byte sVolbeatPose242
+.4byte sVolbeatPose243
+.4byte sVolbeatPose244
+.4byte sVolbeatPose245
+.4byte sVolbeatPose246
+.4byte sVolbeatPose247
+.4byte sVolbeatPose248
+.4byte sVolbeatPose249
+.4byte sVolbeatPose250
+.4byte sVolbeatPose251
+.4byte sVolbeatPose252
+.4byte sVolbeatPose253
+.4byte sVolbeatPose254
+.4byte sVolbeatPose255
+.4byte sVolbeatPose256
+.4byte sVolbeatPose257
+.4byte sVolbeatPose258
+.4byte sVolbeatPose259
+.4byte sVolbeatPose260
+.4byte sVolbeatPose261
+.4byte sVolbeatPose262
+.4byte sVolbeatPose263
+.4byte sVolbeatPose264
+.4byte sVolbeatPose265
+.4byte sVolbeatPose266
+.4byte sVolbeatPose267
+.4byte sVolbeatPose268
+.4byte sVolbeatPose269
+.4byte sVolbeatPose270
+.4byte sVolbeatPose271
+.4byte sVolbeatPose272
+.4byte sVolbeatPose273
+.4byte sVolbeatPose274
+.4byte sVolbeatPose275
+.4byte sVolbeatPose276
+.4byte sVolbeatPose277
+.4byte sVolbeatPose278
+.4byte sVolbeatPose279
+.4byte sVolbeatPose280
+.4byte sVolbeatPose281
+.4byte sVolbeatPose282
+.4byte sVolbeatPose283
+.4byte sVolbeatPose284
+.4byte sVolbeatPose285
+.4byte sVolbeatPose286
+.4byte sVolbeatPose287
+.4byte sVolbeatPose288
+.4byte sVolbeatPose289
+.4byte sVolbeatPose290
+.4byte sVolbeatPose291
+.4byte sVolbeatPose292
+.4byte sVolbeatPose293
+.4byte sVolbeatPose294
+.4byte sVolbeatPose295
+.4byte sVolbeatPose296
+.4byte sVolbeatPose297
+.4byte sVolbeatPose298
+sAxPositionsVolbeat:
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   1,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -4
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -3
+.2byte   -1,   -9, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,   -9, 	   5,   -2, 	  -7,   -2, 	  -1,   -5
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -3
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -3,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -8,   -5, 	   6,   -5, 	  -1,   -5
+.2byte   -1,   -7, 	  -8,   -5, 	   6,   -5, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -4, 	  -1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   1,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    3,   -8, 	   7,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    3,   -8, 	   7,   -5, 	  -6,   -4, 	   1,   -6
+.2byte    3,   -9, 	   5,   -4, 	  -7,   -4, 	   1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -2, 	   1,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    7,   -8, 	   2,   -5, 	   2,   -3, 	  -3,   -6
+.2byte    7,   -8, 	   2,   -5, 	   2,   -3, 	  -3,   -6
+.2byte    6,  -10, 	   3,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,  -10, 	   2,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,   -9, 	   3,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    6,   -9, 	   2,   -4, 	   1,   -3, 	  -1,   -2
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -4
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -3
+.2byte    4,   -9, 	  -3,   -6, 	   5,   -3, 	  -2,   -5
+.2byte    4,   -9, 	  -5,   -6, 	   5,   -3, 	  -3,   -5
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -4
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -1,   -2
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -2,   -3
+.2byte   -1,   -9, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,   -9, 	   5,   -2, 	  -7,   -2, 	  -1,   -5
+.2byte   -1,  -11, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -3
+.2byte   -6,   -9, 	   1,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -9, 	   3,   -6, 	  -7,   -3, 	   1,   -5
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	  -1,   -2
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	   0,   -3
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -9,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -6
+.2byte   -9,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -6
+.2byte   -8,  -10, 	  -5,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,  -10, 	  -4,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,   -9, 	  -5,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte   -8,   -9, 	  -4,   -4, 	  -3,   -3, 	  -1,   -2
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -3,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -5,   -8, 	  -9,   -5, 	   4,   -4, 	  -2,   -6
+.2byte   -5,   -8, 	  -9,   -5, 	   4,   -4, 	  -3,   -6
+.2byte   -5,   -9, 	  -7,   -4, 	   5,   -4, 	  -3,   -4
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -2, 	  -3,   -4
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -7, 	  -8,   -5, 	   6,   -5, 	  -1,   -5
+.2byte   -1,   -7, 	  -8,   -5, 	   6,   -5, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -4, 	  -1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   1,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    3,   -8, 	   7,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    3,   -8, 	   7,   -5, 	  -6,   -4, 	   1,   -6
+.2byte    3,   -9, 	   5,   -4, 	  -7,   -4, 	   1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -2, 	   1,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    7,   -8, 	   2,   -5, 	   2,   -3, 	  -3,   -6
+.2byte    7,   -8, 	   2,   -5, 	   2,   -3, 	  -3,   -6
+.2byte    6,  -10, 	   3,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,  -10, 	   2,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,   -9, 	   3,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    6,   -9, 	   2,   -4, 	   1,   -3, 	  -1,   -2
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -4
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -3
+.2byte    4,   -9, 	  -3,   -6, 	   5,   -3, 	  -2,   -5
+.2byte    4,   -9, 	  -5,   -6, 	   5,   -3, 	  -3,   -5
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -4
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -1,   -2
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -2,   -3
+.2byte   -1,   -9, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -1,   -9, 	   5,   -2, 	  -7,   -2, 	  -1,   -5
+.2byte   -1,  -11, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte   -1,  -11, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -3
+.2byte   -6,   -9, 	   1,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -6,   -9, 	   3,   -6, 	  -7,   -3, 	   1,   -5
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	  -1,   -2
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	   0,   -3
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -9,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -6
+.2byte   -9,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -6
+.2byte   -8,  -10, 	  -5,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,  -10, 	  -4,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,   -9, 	  -5,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte   -8,   -9, 	  -4,   -4, 	  -3,   -3, 	  -1,   -2
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -3,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -5,   -8, 	  -9,   -5, 	   4,   -4, 	  -2,   -6
+.2byte   -5,   -8, 	  -9,   -5, 	   4,   -4, 	  -3,   -6
+.2byte   -5,   -9, 	  -7,   -4, 	   5,   -4, 	  -3,   -4
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -2, 	  -3,   -4
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -4
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -4, 	  -1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -4, 	  -7,   -4, 	   1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -2, 	   1,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,  -10, 	   2,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,   -9, 	   3,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    6,   -9, 	   2,   -4, 	   1,   -3, 	  -1,   -2
+.2byte    6,  -10, 	   2,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,   -9, 	   2,   -4, 	   1,   -3, 	  -1,   -2
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -4
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -1,   -2
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -2,   -3
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -4
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -2,   -3
+.2byte   -1,   -9, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	  -1,   -2
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	   0,   -3
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	   0,   -3
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,  -10, 	  -4,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,   -9, 	  -5,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte   -8,   -9, 	  -4,   -4, 	  -3,   -3, 	  -1,   -2
+.2byte   -8,  -10, 	  -4,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,   -9, 	  -4,   -4, 	  -3,   -3, 	  -1,   -2
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -3,   -5
+.2byte   -5,   -9, 	  -7,   -4, 	   5,   -4, 	  -3,   -4
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -2, 	  -3,   -4
+.2byte   -3,   -8, 	  -6,   -5, 	   5,   -3, 	  -1,   -5
+.2byte   -3,   -9, 	  -6,   -5, 	   5,   -3, 	  -1,   -5
+.2byte    0,   -9, 	  -4,   -7, 	   4,   -7, 	   0,   -6
+.2byte    2,   -9, 	   6,  -10, 	  -2,   -7, 	   1,   -5
+.2byte    4,   -9, 	   6,   -9, 	   3,   -8, 	   0,   -4
+.2byte    4,   -9, 	   2,  -12, 	   8,  -10, 	   1,   -3
+.2byte    0,   -8, 	   6,   -6, 	  -6,   -6, 	   0,   -5
+.2byte   -5,   -9, 	  -3,  -12, 	  -9,  -10, 	  -2,   -3
+.2byte   -5,   -9, 	  -7,   -9, 	  -4,   -8, 	  -1,   -4
+.2byte   -3,   -9, 	  -7,  -10, 	   1,   -7, 	  -2,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -5, 	  -1,   -4
+.2byte   -1,   -8, 	  -8,   -5, 	   6,   -4, 	  -1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   1,   -5
+.2byte    3,   -9, 	   5,   -4, 	  -7,   -4, 	   1,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -2, 	   1,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   2,   -4, 	   0,   -3, 	   1,   -3
+.2byte    6,   -9, 	   2,   -4, 	   1,   -3, 	  -1,   -2
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -6, 	   6,   -5, 	  -1,   -4
+.2byte    4,   -9, 	  -6,   -6, 	   6,   -4, 	  -2,   -3
+.2byte   -1,   -9, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    1,   -9, 	   5,   -4, 	  -4,   -6, 	  -2,   -4
+.2byte   -5,   -9, 	   2,   -6, 	  -7,   -4, 	  -1,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -6, 	  -8,   -5, 	  -1,   -4
+.2byte   -6,   -9, 	   4,   -6, 	  -8,   -4, 	   0,   -3
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -4,   -4, 	  -2,   -3, 	  -3,   -3
+.2byte   -8,   -9, 	  -4,   -4, 	  -3,   -3, 	  -1,   -2
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -3,   -5
+.2byte   -5,   -9, 	  -7,   -4, 	   5,   -4, 	  -3,   -4
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -2, 	  -3,   -4
+.2byte   -1,   -7, 	  -8,   -5, 	   6,   -5, 	  -1,   -5
+.2byte   -5,   -8, 	  -9,   -5, 	   4,   -4, 	  -2,   -6
+.2byte   -9,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -6
+.2byte   -6,   -9, 	   1,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -1,  -11, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte    4,   -9, 	  -3,   -6, 	   5,   -3, 	  -2,   -5
+.2byte    7,   -8, 	   2,   -5, 	   2,   -3, 	  -3,   -6
+.2byte    3,   -8, 	   7,   -5, 	  -6,   -4, 	   0,   -6
+.2byte   -1,   -7, 	  -8,   -5, 	   6,   -5, 	  -1,   -5
+.2byte    3,   -8, 	   7,   -5, 	  -6,   -4, 	   0,   -6
+.2byte    7,   -8, 	   2,   -5, 	   2,   -3, 	  -3,   -6
+.2byte    4,   -9, 	  -3,   -6, 	   5,   -3, 	  -2,   -5
+.2byte   -1,  -11, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte   -6,   -9, 	   1,   -6, 	  -7,   -3, 	   0,   -5
+.2byte   -9,   -8, 	  -4,   -5, 	  -4,   -3, 	   1,   -6
+.2byte   -5,   -8, 	  -9,   -5, 	   4,   -4, 	  -2,   -6
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   1,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -1,   -3
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -3
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -4
+.2byte   -1,   -9, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   5,   -2, 	  -7,   -2, 	  -1,   -5
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	  -1,   -3
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -3
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -3,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -2,   -5
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	   0,   -4
+.2byte   -1,  -10, 	   5,   -4, 	  -7,   -4, 	  -1,   -6
+.2byte    4,  -11, 	  -5,   -5, 	   6,   -4, 	  -2,   -4
+.2byte    6,  -10, 	   3,   -5, 	   1,   -3, 	   0,   -4
+.2byte    2,   -9, 	   5,   -5, 	  -7,   -3, 	   0,   -5
+.2byte   -1,   -8, 	  -8,   -4, 	   6,   -4, 	  -1,   -5
+.2byte   -4,   -9, 	  -7,   -5, 	   5,   -3, 	  -3,   -5
+.2byte   -8,  -10, 	  -5,   -5, 	  -3,   -3, 	  -2,   -4
+.2byte   -6,  -11, 	   3,   -5, 	  -8,   -4, 	  -1,   -3
+.2byte   -1,   -9, 	   5,   -4, 	  -7,   -4, 	  -1,   -5
+.2byte    5,  -11, 	  -4,   -5, 	   7,   -4, 	   0,   -3
+.2byte    7,  -10, 	   4,   -5, 	   2,   -3, 	   1,   -4
+.2byte    3,   -9, 	   6,   -5, 	  -6,   -3, 	   2,   -5
+sVolbeatAnimTable1:
+.4byte sVolbeatAnims_1_1
+.4byte sVolbeatAnims_1_2
+.4byte sVolbeatAnims_1_3
+.4byte sVolbeatAnims_1_4
+.4byte sVolbeatAnims_1_5
+.4byte sVolbeatAnims_1_6
+.4byte sVolbeatAnims_1_7
+.4byte sVolbeatAnims_1_8
+sVolbeatAnimTable2:
+.4byte sVolbeatAnims_2_1
+.4byte sVolbeatAnims_2_2
+.4byte sVolbeatAnims_2_3
+.4byte sVolbeatAnims_2_4
+.4byte sVolbeatAnims_2_5
+.4byte sVolbeatAnims_2_6
+.4byte sVolbeatAnims_2_7
+.4byte sVolbeatAnims_2_8
+sVolbeatAnimTable3:
+.4byte sVolbeatAnims_3_1
+.4byte sVolbeatAnims_3_2
+.4byte sVolbeatAnims_3_3
+.4byte sVolbeatAnims_3_4
+.4byte sVolbeatAnims_3_5
+.4byte sVolbeatAnims_3_6
+.4byte sVolbeatAnims_3_7
+.4byte sVolbeatAnims_3_8
+sVolbeatAnimTable4:
+.4byte sVolbeatAnims_4_1
+.4byte sVolbeatAnims_4_2
+.4byte sVolbeatAnims_4_3
+.4byte sVolbeatAnims_4_4
+.4byte sVolbeatAnims_4_5
+.4byte sVolbeatAnims_4_6
+.4byte sVolbeatAnims_4_7
+.4byte sVolbeatAnims_4_8
+sVolbeatAnimTable5:
+.4byte sVolbeatAnims_5_1
+.4byte sVolbeatAnims_5_2
+.4byte sVolbeatAnims_5_3
+.4byte sVolbeatAnims_5_4
+.4byte sVolbeatAnims_5_5
+.4byte sVolbeatAnims_5_6
+.4byte sVolbeatAnims_5_7
+.4byte sVolbeatAnims_5_8
+sVolbeatAnimTable6:
+.4byte sVolbeatAnims_6_1
+.4byte sVolbeatAnims_6_1
+.4byte sVolbeatAnims_6_1
+.4byte sVolbeatAnims_6_1
+.4byte sVolbeatAnims_6_1
+.4byte sVolbeatAnims_6_1
+.4byte sVolbeatAnims_6_1
+.4byte sVolbeatAnims_6_1
+sVolbeatAnimTable7:
+.4byte sVolbeatAnims_7_1
+.4byte sVolbeatAnims_7_2
+.4byte sVolbeatAnims_7_3
+.4byte sVolbeatAnims_7_4
+.4byte sVolbeatAnims_7_5
+.4byte sVolbeatAnims_7_6
+.4byte sVolbeatAnims_7_7
+.4byte sVolbeatAnims_7_8
+sVolbeatAnimTable8:
+.4byte sVolbeatAnims_8_1
+.4byte sVolbeatAnims_8_2
+.4byte sVolbeatAnims_8_3
+.4byte sVolbeatAnims_8_4
+.4byte sVolbeatAnims_8_5
+.4byte sVolbeatAnims_8_6
+.4byte sVolbeatAnims_8_7
+.4byte sVolbeatAnims_8_8
+sVolbeatAnimTable9:
+.4byte sVolbeatAnims_9_1
+.4byte sVolbeatAnims_9_2
+.4byte sVolbeatAnims_9_3
+.4byte sVolbeatAnims_9_4
+.4byte sVolbeatAnims_9_5
+.4byte sVolbeatAnims_9_6
+.4byte sVolbeatAnims_9_7
+.4byte sVolbeatAnims_9_8
+sVolbeatAnimTable10:
+.4byte sVolbeatAnims_10_1
+.4byte sVolbeatAnims_10_2
+.4byte sVolbeatAnims_10_3
+.4byte sVolbeatAnims_10_4
+.4byte sVolbeatAnims_10_5
+.4byte sVolbeatAnims_10_6
+.4byte sVolbeatAnims_10_7
+.4byte sVolbeatAnims_10_8
+sVolbeatAnimTable11:
+.4byte sVolbeatAnims_11_1
+.4byte sVolbeatAnims_11_2
+.4byte sVolbeatAnims_11_3
+.4byte sVolbeatAnims_11_4
+.4byte sVolbeatAnims_11_5
+.4byte sVolbeatAnims_11_6
+.4byte sVolbeatAnims_11_7
+.4byte sVolbeatAnims_11_8
+sVolbeatAnimTable12:
+.4byte sVolbeatAnims_12_1
+.4byte sVolbeatAnims_12_2
+.4byte sVolbeatAnims_12_3
+.4byte sVolbeatAnims_12_4
+.4byte sVolbeatAnims_12_5
+.4byte sVolbeatAnims_12_6
+.4byte sVolbeatAnims_12_7
+.4byte sVolbeatAnims_12_8
+sVolbeatAnimTable13:
+.4byte sVolbeatAnims_13_1
+.4byte sVolbeatAnims_13_2
+.4byte sVolbeatAnims_13_3
+.4byte sVolbeatAnims_13_4
+.4byte sVolbeatAnims_13_5
+.4byte sVolbeatAnims_13_6
+.4byte sVolbeatAnims_13_7
+.4byte sVolbeatAnims_13_8
+sAxAnimationsVolbeat:
+.4byte sVolbeatAnimTable1
+.4byte sVolbeatAnimTable2
+.4byte sVolbeatAnimTable3
+.4byte sVolbeatAnimTable4
+.4byte sVolbeatAnimTable5
+.4byte sVolbeatAnimTable6
+.4byte sVolbeatAnimTable7
+.4byte sVolbeatAnimTable8
+.4byte sVolbeatAnimTable9
+.4byte sVolbeatAnimTable10
+.4byte sVolbeatAnimTable11
+.4byte sVolbeatAnimTable12
+.4byte sVolbeatAnimTable13
+sAxSpritesVolbeat:
+.4byte sVolbeatSprites1
+.4byte sVolbeatSprites2
+.4byte sVolbeatSprites3
+.4byte sVolbeatSprites4
+.4byte sVolbeatSprites5
+.4byte sVolbeatSprites6
+.4byte sVolbeatSprites7
+.4byte sVolbeatSprites8
+.4byte sVolbeatSprites9
+.4byte sVolbeatSprites10
+.4byte sVolbeatSprites11
+.4byte sVolbeatSprites12
+.4byte sVolbeatSprites13
+.4byte sVolbeatSprites14
+.4byte sVolbeatSprites15
+.4byte sVolbeatSprites16
+.4byte sVolbeatSprites17
+.4byte sVolbeatSprites18
+.4byte sVolbeatSprites19
+.4byte sVolbeatSprites20
+.4byte sVolbeatSprites21
+.4byte sVolbeatSprites22
+.4byte sVolbeatSprites23
+.4byte sVolbeatSprites24
+.4byte sVolbeatSprites25
+.4byte sVolbeatSprites26
+.4byte sVolbeatSprites27
+.4byte sVolbeatSprites28
+.4byte sVolbeatSprites29
+.4byte sVolbeatSprites30
+.4byte sVolbeatSprites31
+.4byte sVolbeatSprites32
+.4byte sVolbeatSprites33
+.4byte sVolbeatSprites34
+.4byte sVolbeatSprites35
+.4byte sVolbeatSprites36
+.4byte sVolbeatSprites37
+.4byte sVolbeatSprites38
+.4byte sVolbeatSprites39
+.4byte sVolbeatSprites40
+.4byte sVolbeatSprites41
+.4byte sVolbeatSprites42
+.4byte sVolbeatSprites43
+.4byte sVolbeatSprites44
+.4byte sVolbeatSprites45
+.4byte sVolbeatSprites46
+.4byte sVolbeatSprites47
+.4byte sVolbeatSprites48
+.4byte sVolbeatSprites49
+.4byte sVolbeatSprites50
+.4byte sVolbeatSprites51
+.4byte sVolbeatSprites52
+.4byte sVolbeatSprites53
+.4byte sVolbeatSprites54
+.4byte sVolbeatSprites55
+sAxMainVolbeat:
+ax_main sAxPosesVolbeat, sAxAnimationsVolbeat, 13, sAxSpritesVolbeat, sAxPositionsVolbeat

--- a/data/ax/voltorb.inc
+++ b/data/ax/voltorb.inc
@@ -1,0 +1,2224 @@
+.global gAxVoltorb
+gAxVoltorb:
+ax_siro sAxMainVoltorb
+sVoltorbPose1:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose2:
+ax_pose 1, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose3:
+ax_pose 2, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose4:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose5:
+ax_pose 4, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose6:
+ax_pose 5, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose7:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose8:
+ax_pose 7, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose9:
+ax_pose 8, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose10:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose11:
+ax_pose 10, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose12:
+ax_pose 11, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose13:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose14:
+ax_pose 13, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose15:
+ax_pose 14, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose16:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose17:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose18:
+ax_pose 17, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose19:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose20:
+ax_pose 19, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose21:
+ax_pose 20, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose22:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose23:
+ax_pose 22, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose24:
+ax_pose 23, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose25:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose26:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose27:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose28:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose29:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose30:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose31:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose32:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose33:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose34:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose35:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose36:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose37:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose38:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose39:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose40:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose41:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose42:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose43:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose44:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose45:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose46:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose47:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose48:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose49:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose50:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose51:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose52:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose53:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose54:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose55:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose56:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose57:
+ax_pose 24, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose58:
+ax_pose 25, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose59:
+ax_pose 26, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sVoltorbPose60:
+ax_pose 27, 0x01e8, 0x90eb, 0x5c00
+ax_pose_terminator
+sVoltorbPose61:
+ax_pose 28, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sVoltorbPose62:
+ax_pose 29, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sVoltorbPose63:
+ax_pose 30, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sVoltorbPose64:
+ax_pose 29, 0x01eb, 0x80f3, 0x5c00
+ax_pose_terminator
+sVoltorbPose65:
+ax_pose 28, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sVoltorbPose66:
+ax_pose 27, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sVoltorbPose67:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose68:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose69:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose70:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose71:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose72:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose73:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose74:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose75:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose76:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose77:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose78:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose79:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose80:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose81:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose82:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose83:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose84:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose85:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose86:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose87:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose88:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose89:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose90:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose91:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose92:
+ax_pose 2, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose93:
+ax_pose 1, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose94:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose95:
+ax_pose 5, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose96:
+ax_pose 4, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose97:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose98:
+ax_pose 8, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose99:
+ax_pose 7, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose100:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose101:
+ax_pose 11, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose102:
+ax_pose 10, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose103:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose104:
+ax_pose 14, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose105:
+ax_pose 13, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose106:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose107:
+ax_pose 17, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose108:
+ax_pose 16, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose109:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose110:
+ax_pose 20, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose111:
+ax_pose 19, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose112:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose113:
+ax_pose 23, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose114:
+ax_pose 22, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose115:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose116:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose117:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose118:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose119:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose120:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose121:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose122:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose123:
+ax_pose 0, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose124:
+ax_pose 21, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose125:
+ax_pose 18, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose126:
+ax_pose 15, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose127:
+ax_pose 12, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose128:
+ax_pose 9, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose129:
+ax_pose 6, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+sVoltorbPose130:
+ax_pose 3, 0x01f1, 0x40f8, 0x5c00
+ax_pose_terminator
+.align 2
+sVoltorbAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, -2,
+ax_anim 10, 0, 2, 0, -3, 0, -3,
+ax_anim 4, 0, 2, 0, -4, 0, -2,
+ax_anim 4, 0, 0, 0, -1, 0, 1,
+ax_anim 4, 0, 1, 0, 2, 0, 2,
+ax_anim 6, 0, 1, 0, 1, 0, 1,
+ax_anim 8, 0, 1, 0, 3, 0, 3,
+ax_anim_terminator
+sVoltorbAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, -2, -2, -2, -2,
+ax_anim 10, 0, 5, -3, -3, -3, -3,
+ax_anim 4, 0, 5, -2, -3, -2, -2,
+ax_anim 4, 0, 3, 2, 0, 2, 2,
+ax_anim 4, 0, 4, 3, 3, 3, 3,
+ax_anim 6, 0, 4, 4, 2, 4, 4,
+ax_anim 8, 0, 4, 4, 4, 4, 4,
+ax_anim_terminator
+sVoltorbAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, -3, 0, -3, 0,
+ax_anim 10, 0, 8, -4, 0, -4, 0,
+ax_anim 4, 0, 8, -2, -2, -2, 0,
+ax_anim 4, 0, 6, 2, -3, 2, 0,
+ax_anim 4, 0, 7, 3, 0, 3, 0,
+ax_anim 6, 0, 7, 4, -1, 4, 0,
+ax_anim 8, 0, 7, 4, 0, 4, 0,
+ax_anim_terminator
+sVoltorbAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, -3, 3, -3, 3,
+ax_anim 10, 0, 11, -4, 4, -4, 4,
+ax_anim 4, 0, 11, -2, 0, -2, 2,
+ax_anim 4, 0, 9, 1, -4, 1, -1,
+ax_anim 4, 0, 10, 3, -3, 3, -3,
+ax_anim 6, 0, 10, 4, -5, 4, -4,
+ax_anim 8, 0, 10, 4, -4, 4, -4,
+ax_anim_terminator
+sVoltorbAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 2, 0, 2,
+ax_anim 10, 0, 14, 0, 4, 0, 4,
+ax_anim 4, 0, 14, 0, -3, 0, 1,
+ax_anim 4, 0, 12, 0, -4, 0, -2,
+ax_anim 4, 0, 13, 0, -4, 0, -3,
+ax_anim 6, 0, 13, 0, -6, 0, -4,
+ax_anim 8, 0, 13, 0, -4, 0, -3,
+ax_anim_terminator
+sVoltorbAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 3, 3, 3, 3,
+ax_anim 10, 0, 17, 4, 4, 4, 4,
+ax_anim 4, 0, 17, 2, 0, 2, 2,
+ax_anim 4, 0, 15, -1, -4, -1, -1,
+ax_anim 4, 0, 16, -3, -3, -3, -3,
+ax_anim 6, 0, 16, -4, -5, -4, -4,
+ax_anim 8, 0, 16, -4, -4, -4, -4,
+ax_anim_terminator
+sVoltorbAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 3, 0, 3, 0,
+ax_anim 10, 0, 20, 4, 0, 4, 0,
+ax_anim 4, 0, 20, 2, -2, 2, 0,
+ax_anim 4, 0, 18, -2, -3, -2, 0,
+ax_anim 4, 0, 19, -3, 0, -3, 0,
+ax_anim 6, 0, 19, -4, -1, -4, 0,
+ax_anim 8, 0, 19, -4, 0, -4, 0,
+ax_anim_terminator
+sVoltorbAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 2, -2, 2, -2,
+ax_anim 10, 0, 23, 3, -3, 3, -3,
+ax_anim 4, 0, 23, 2, -3, 2, -2,
+ax_anim 4, 0, 21, -2, 0, -2, 2,
+ax_anim 4, 0, 22, -3, 3, -3, 3,
+ax_anim 6, 0, 22, -4, 2, -4, 4,
+ax_anim 8, 0, 22, -4, 4, -4, 4,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_2_1:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 6, 0, 29, -3, 0, -3, 0,
+ax_anim 1, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 3, 0, 3,
+ax_anim 2, 0, 24, 4, 8, 4, 8,
+ax_anim 2, 2, 25, 4, 16, 4, 16,
+ax_anim 2, 0, 26, 0, 21, 0, 21,
+ax_anim 2, 1, 27, 1, 21, 1, 21,
+ax_anim 2, 0, 28, 0, 21, 0, 21,
+ax_anim 2, 0, 29, 1, 21, 1, 21,
+ax_anim 2, 0, 30, 0, 21, 0, 21,
+ax_anim 2, 0, 31, -4, 18, -4, 18,
+ax_anim 2, 0, 24, -4, 8, -4, 8,
+ax_anim_terminator
+sVoltorbAnims_2_2:
+ax_anim 2, 0, 30, -1, 1, -1, 1,
+ax_anim 2, 0, 29, -2, 2, -2, 2,
+ax_anim 6, 0, 28, -3, 3, -3, 3,
+ax_anim 1, 0, 29, -2, 2, -2, 2,
+ax_anim 1, 0, 30, 5, 3, 5, 3,
+ax_anim 2, 0, 31, 13, 6, 13, 6,
+ax_anim 2, 2, 24, 22, 12, 22, 12,
+ax_anim 2, 0, 25, 21, 21, 21, 21,
+ax_anim 2, 1, 26, 22, 20, 22, 20,
+ax_anim 2, 0, 27, 21, 21, 21, 21,
+ax_anim 2, 0, 28, 22, 20, 22, 20,
+ax_anim 2, 0, 29, 21, 21, 21, 21,
+ax_anim 2, 0, 30, 11, 20, 11, 20,
+ax_anim 2, 0, 31, 1, 8, 1, 8,
+ax_anim_terminator
+sVoltorbAnims_2_3:
+ax_anim 2, 0, 29, 0, 1, 0, 1,
+ax_anim 2, 0, 28, 0, 2, 0, 2,
+ax_anim 6, 0, 27, 0, 3, 0, 3,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 29, 5, -4, 5, -4,
+ax_anim 2, 0, 30, 13, -4, 13, -4,
+ax_anim 2, 2, 31, 22, 0, 22, 0,
+ax_anim 2, 0, 24, 22, 1, 22, 1,
+ax_anim 2, 1, 25, 22, 0, 22, 0,
+ax_anim 2, 0, 26, 22, 1, 22, 1,
+ax_anim 2, 0, 27, 22, 0, 22, 0,
+ax_anim 2, 0, 28, 22, 1, 22, 1,
+ax_anim 2, 0, 29, 13, 4, 13, 4,
+ax_anim 2, 0, 30, 1, 4, 1, 4,
+ax_anim_terminator
+sVoltorbAnims_2_4:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 2, 0, 27, 0, 2, 0, 2,
+ax_anim 6, 0, 26, 0, 3, 0, 3,
+ax_anim 1, 0, 27, 2, -5, 2, -5,
+ax_anim 1, 0, 28, 4, -12, 4, -12,
+ax_anim 2, 0, 29, 13, -20, 13, -20,
+ax_anim 2, 2, 30, 22, -22, 22, -22,
+ax_anim 2, 0, 31, 22, -21, 22, -21,
+ax_anim 2, 1, 24, 22, -22, 22, -22,
+ax_anim 2, 0, 25, 22, -21, 22, -21,
+ax_anim 2, 0, 26, 22, -22, 22, -22,
+ax_anim 2, 0, 27, 22, -21, 22, -21,
+ax_anim 2, 0, 28, 16, -8, 16, -8,
+ax_anim 2, 0, 29, 7, -2, 7, -2,
+ax_anim_terminator
+sVoltorbAnims_2_5:
+ax_anim 2, 0, 29, -1, 0, -1, 0,
+ax_anim 2, 0, 30, -2, 0, -2, 0,
+ax_anim 6, 0, 31, -3, 0, -3, 0,
+ax_anim 1, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 29, 0, -3, 0, -3,
+ax_anim 2, 0, 28, 4, -8, 4, -8,
+ax_anim 2, 2, 27, 4, -16, 4, -16,
+ax_anim 2, 0, 26, 0, -21, 0, -21,
+ax_anim 2, 1, 25, 1, -21, 1, -21,
+ax_anim 2, 0, 24, 0, -21, 0, -21,
+ax_anim 2, 0, 31, 1, -21, 1, -21,
+ax_anim 2, 0, 30, 0, -21, 0, -21,
+ax_anim 2, 0, 29, -4, -18, -4, -18,
+ax_anim 2, 0, 28, -4, -8, -4, -8,
+ax_anim_terminator
+sVoltorbAnims_2_6:
+ax_anim 2, 0, 28, 0, 1, 0, 1,
+ax_anim 2, 0, 29, 0, 2, 0, 2,
+ax_anim 6, 0, 30, 0, 3, 0, 3,
+ax_anim 1, 0, 29, -2, -5, -2, -5,
+ax_anim 1, 0, 28, -4, -12, -4, -12,
+ax_anim 2, 0, 27, -13, -20, -13, -20,
+ax_anim 2, 2, 26, -22, -22, -22, -22,
+ax_anim 2, 0, 25, -22, -21, -22, -21,
+ax_anim 2, 1, 24, -22, -22, -22, -22,
+ax_anim 2, 0, 31, -22, -21, -22, -21,
+ax_anim 2, 0, 30, -22, -22, -22, -22,
+ax_anim 2, 0, 29, -22, -21, -22, -21,
+ax_anim 2, 0, 28, -16, -8, -16, -8,
+ax_anim 2, 0, 27, -7, -2, -7, -2,
+ax_anim_terminator
+sVoltorbAnims_2_7:
+ax_anim 2, 0, 27, 0, 1, 0, 1,
+ax_anim 2, 0, 28, 0, 2, 0, 2,
+ax_anim 6, 0, 29, 0, 3, 0, 3,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 0, 27, -5, -4, -5, -4,
+ax_anim 2, 0, 26, -13, -4, -13, -4,
+ax_anim 2, 2, 25, -22, 0, -22, 0,
+ax_anim 2, 0, 24, -22, 1, -22, 1,
+ax_anim 2, 1, 31, -22, 0, -22, 0,
+ax_anim 2, 0, 30, -22, 1, -22, 1,
+ax_anim 2, 0, 29, -22, 0, -22, 0,
+ax_anim 2, 0, 28, -22, 1, -22, 1,
+ax_anim 2, 0, 27, -13, 4, -13, 4,
+ax_anim 2, 0, 26, -1, 4, -1, 4,
+ax_anim_terminator
+sVoltorbAnims_2_8:
+ax_anim 2, 0, 26, 1, 1, 1, 1,
+ax_anim 2, 0, 27, 2, 2, 2, 2,
+ax_anim 6, 0, 28, 3, 3, 3, 3,
+ax_anim 1, 0, 27, 2, 2, 2, 2,
+ax_anim 1, 0, 26, -5, 3, -5, 3,
+ax_anim 2, 0, 25, -13, 6, -12, 6,
+ax_anim 2, 2, 24, -22, 12, -22, 12,
+ax_anim 2, 0, 31, -21, 21, -21, 21,
+ax_anim 2, 1, 30, -22, 20, -22, 20,
+ax_anim 2, 0, 29, -21, 21, -21, 21,
+ax_anim 2, 0, 28, -22, 20, -22, 20,
+ax_anim 2, 0, 27, -21, 21, -21, 21,
+ax_anim 2, 0, 26, -11, 20, -11, 18,
+ax_anim 2, 0, 25, -1, 8, -1, 8,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_3_1:
+ax_anim 2, 0, 39, -1, 0, -1, 0,
+ax_anim 2, 0, 38, -2, 0, -2, 0,
+ax_anim 6, 0, 37, -3, 0, -3, 0,
+ax_anim 1, 0, 38, -2, 0, -2, 0,
+ax_anim 1, 0, 39, 0, 3, 0, 3,
+ax_anim 2, 0, 32, 4, 8, 4, 8,
+ax_anim 2, 2, 33, 4, 16, 4, 16,
+ax_anim 2, 0, 34, 0, 21, 0, 21,
+ax_anim 2, 1, 35, 1, 21, 1, 21,
+ax_anim 2, 0, 36, 0, 21, 0, 21,
+ax_anim 2, 0, 37, 1, 21, 1, 21,
+ax_anim 2, 0, 38, 0, 21, 0, 21,
+ax_anim 2, 0, 39, -4, 18, -4, 18,
+ax_anim 2, 0, 32, -4, 8, -4, 8,
+ax_anim_terminator
+sVoltorbAnims_3_2:
+ax_anim 2, 0, 38, -1, 1, -1, 1,
+ax_anim 2, 0, 37, -2, 2, -2, 2,
+ax_anim 6, 0, 36, -3, 3, -3, 3,
+ax_anim 1, 0, 37, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 5, 3, 5, 3,
+ax_anim 2, 0, 39, 13, 6, 13, 6,
+ax_anim 2, 2, 32, 22, 12, 22, 12,
+ax_anim 2, 0, 33, 21, 21, 21, 21,
+ax_anim 2, 1, 34, 22, 20, 22, 20,
+ax_anim 2, 0, 35, 21, 21, 21, 21,
+ax_anim 2, 0, 36, 22, 20, 22, 20,
+ax_anim 2, 0, 37, 21, 21, 21, 21,
+ax_anim 2, 0, 38, 11, 20, 11, 20,
+ax_anim 2, 0, 39, 1, 8, 1, 8,
+ax_anim_terminator
+sVoltorbAnims_3_3:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 6, 0, 35, 0, 3, 0, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 37, 5, -4, 5, -4,
+ax_anim 2, 0, 38, 13, -4, 13, -4,
+ax_anim 2, 2, 39, 22, 0, 22, 0,
+ax_anim 2, 0, 32, 22, 1, 22, 1,
+ax_anim 2, 1, 33, 22, 0, 22, 0,
+ax_anim 2, 0, 34, 22, 1, 22, 1,
+ax_anim 2, 0, 35, 22, 0, 22, 0,
+ax_anim 2, 0, 36, 22, 1, 22, 1,
+ax_anim 2, 0, 37, 13, 4, 13, 4,
+ax_anim 2, 0, 38, 1, 4, 1, 4,
+ax_anim_terminator
+sVoltorbAnims_3_4:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 35, 0, 2, 0, 2,
+ax_anim 6, 0, 34, 0, 3, 0, 3,
+ax_anim 1, 0, 35, 2, -5, 2, -5,
+ax_anim 1, 0, 36, 4, -12, 4, -12,
+ax_anim 2, 0, 37, 13, -20, 13, -20,
+ax_anim 2, 2, 38, 22, -22, 22, -22,
+ax_anim 2, 0, 39, 22, -21, 22, -21,
+ax_anim 2, 1, 32, 22, -22, 22, -22,
+ax_anim 2, 0, 33, 22, -21, 22, -21,
+ax_anim 2, 0, 34, 22, -22, 22, -22,
+ax_anim 2, 0, 35, 22, -21, 22, -21,
+ax_anim 2, 0, 36, 16, -8, 16, -8,
+ax_anim 2, 0, 37, 7, -2, 7, -2,
+ax_anim_terminator
+sVoltorbAnims_3_5:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 2, 0, 38, -2, 0, -2, 0,
+ax_anim 6, 0, 39, -3, 0, -3, 0,
+ax_anim 1, 0, 38, -2, 0, -2, 0,
+ax_anim 1, 0, 37, 0, -3, 0, -3,
+ax_anim 2, 0, 36, 4, -8, 4, -8,
+ax_anim 2, 2, 35, 4, -16, 4, -16,
+ax_anim 2, 0, 34, 0, -21, 0, -21,
+ax_anim 2, 1, 33, 1, -21, 1, -21,
+ax_anim 2, 0, 32, 0, -21, 0, -21,
+ax_anim 2, 0, 39, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 0, 37, -4, -18, -4, -18,
+ax_anim 2, 0, 36, -4, -8, -4, -8,
+ax_anim_terminator
+sVoltorbAnims_3_6:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 2, 0, 37, 0, 2, 0, 2,
+ax_anim 6, 0, 38, 0, 3, 0, 3,
+ax_anim 1, 0, 37, -2, -5, -2, -5,
+ax_anim 1, 0, 36, -4, -12, -4, -12,
+ax_anim 2, 0, 35, -13, -20, -13, -20,
+ax_anim 2, 2, 34, -22, -22, -22, -22,
+ax_anim 2, 0, 33, -22, -21, -22, -21,
+ax_anim 2, 1, 32, -22, -22, -22, -22,
+ax_anim 2, 0, 39, -22, -21, -22, -21,
+ax_anim 2, 0, 38, -22, -22, -22, -22,
+ax_anim 2, 0, 37, -22, -21, -22, -21,
+ax_anim 2, 0, 36, -16, -8, -16, -8,
+ax_anim 2, 0, 35, -7, -2, -7, -2,
+ax_anim_terminator
+sVoltorbAnims_3_7:
+ax_anim 2, 0, 35, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 2, 0, 2,
+ax_anim 6, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 0, 35, -5, -4, -5, -4,
+ax_anim 2, 0, 34, -13, -4, -13, -4,
+ax_anim 2, 2, 33, -22, 0, -22, 0,
+ax_anim 2, 0, 32, -22, 1, -22, 1,
+ax_anim 2, 1, 39, -22, 0, -22, 0,
+ax_anim 2, 0, 38, -22, 1, -22, 1,
+ax_anim 2, 0, 37, -22, 0, -22, 0,
+ax_anim 2, 0, 36, -22, 1, -22, 1,
+ax_anim 2, 0, 35, -13, 4, -13, 4,
+ax_anim 2, 0, 34, -1, 4, -1, 4,
+ax_anim_terminator
+sVoltorbAnims_3_8:
+ax_anim 2, 0, 34, 1, 1, 1, 1,
+ax_anim 2, 0, 35, 2, 2, 2, 2,
+ax_anim 6, 0, 36, 3, 3, 3, 3,
+ax_anim 1, 0, 35, 2, 2, 2, 2,
+ax_anim 1, 0, 34, -5, 3, -5, 3,
+ax_anim 2, 0, 33, -13, 6, -12, 6,
+ax_anim 2, 2, 32, -22, 12, -22, 12,
+ax_anim 2, 0, 39, -21, 21, -21, 21,
+ax_anim 2, 1, 38, -22, 20, -22, 20,
+ax_anim 2, 0, 37, -21, 21, -21, 21,
+ax_anim 2, 0, 36, -22, 20, -22, 20,
+ax_anim 2, 0, 35, -21, 21, -21, 21,
+ax_anim 2, 0, 34, -11, 20, -11, 18,
+ax_anim 2, 0, 33, -1, 8, -1, 8,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_4_1:
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 2, 2, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 1, 0, 1, 0,
+ax_anim 2, 1, 40, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_4_2:
+ax_anim 2, 0, 47, 1, -1, 1, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, -1, 1, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, -1, 1, 0,
+ax_anim 2, 2, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, -1, 1, 0,
+ax_anim 2, 0, 47, 0, 0, 0, 0,
+ax_anim 2, 0, 47, 1, -1, 1, 0,
+ax_anim 2, 1, 47, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_4_3:
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 2, 2, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 46, 0, -1, 0, -1,
+ax_anim 2, 1, 46, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_4_4:
+ax_anim 2, 0, 45, -1, -1, -1, -1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, -1, -1, -1, -1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, -1, -1, -1, -1,
+ax_anim 2, 2, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, -1, -1, -1, -1,
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, -1, -1, -1, -1,
+ax_anim 2, 1, 45, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_4_5:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 2, 2, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 2, 1, 44, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_4_6:
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 2, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, 1, -1, 1, -1,
+ax_anim 2, 1, 43, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_4_7:
+ax_anim 2, 0, 42, 0, -1, 0, -1,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, -1, 0, -1,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, -1, 0, -1,
+ax_anim 2, 2, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, -1, 0, -1,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 0, -1, 0, -1,
+ax_anim 2, 1, 42, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_4_8:
+ax_anim 2, 0, 41, -1, -1, -1, -1,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, -1, -1, -1, -1,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, -1, -1, -1, -1,
+ax_anim 2, 2, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, -1, -1, -1, -1,
+ax_anim 2, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, -1, -1, -1, -1,
+ax_anim 2, 1, 41, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_5_1:
+ax_anim 1, 0, 55, 5, 0, 5, 0,
+ax_anim 1, 0, 54, 4, -2, 4, -2,
+ax_anim 1, 0, 53, 2, -4, 2, -3,
+ax_anim 1, 0, 52, 0, -4, 0, -3,
+ax_anim 1, 0, 51, -2, -5, -2, -3,
+ax_anim 1, 0, 50, -4, -4, -4, -2,
+ax_anim 1, 0, 49, -5, -3, -5, 0,
+ax_anim 1, 0, 48, -4, -1, -4, 2,
+ax_anim 1, 0, 55, -2, -1, -2, 3,
+ax_anim 1, 0, 54, 0, -1, 0, 3,
+ax_anim 1, 0, 53, 2, -2, 2, 3,
+ax_anim 1, 0, 52, 4, -3, 4, 2,
+ax_anim 1, 0, 51, 5, -6, 5, 0,
+ax_anim 1, 0, 50, 4, -8, 4, -2,
+ax_anim 1, 0, 49, 2, -10, 2, -3,
+ax_anim 6, 2, 48, 0, -10, 0, -3,
+ax_anim 1, 0, 48, 0, -8, 0, -3,
+ax_anim 1, 0, 48, 0, -4, 0, -2,
+ax_anim 3, 1, 48, 0, 0, 0, 0,
+ax_anim 1, 0, 48, 0, -2, 0, 0,
+ax_anim 1, 0, 48, 0, -3, 0, 0,
+ax_anim 1, 0, 48, 0, -2, 0, 0,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_5_2:
+ax_anim 1, 0, 54, 5, 0, 5, 0,
+ax_anim 1, 0, 53, 4, -2, 4, -2,
+ax_anim 1, 0, 52, 2, -4, 2, -3,
+ax_anim 1, 0, 51, 0, -4, 0, -3,
+ax_anim 1, 0, 50, -2, -5, -2, -3,
+ax_anim 1, 0, 49, -4, -4, -4, -2,
+ax_anim 1, 0, 48, -5, -3, -5, 0,
+ax_anim 1, 0, 55, -4, -1, -4, 2,
+ax_anim 1, 0, 54, -2, -1, -2, 3,
+ax_anim 1, 0, 53, 0, -1, 0, 3,
+ax_anim 1, 0, 52, 2, -2, 2, 3,
+ax_anim 1, 0, 51, 4, -3, 4, 2,
+ax_anim 1, 0, 50, 5, -6, 5, 0,
+ax_anim 1, 0, 49, 4, -8, 4, -2,
+ax_anim 1, 0, 48, 2, -10, 2, -3,
+ax_anim 6, 2, 55, 0, -10, 0, -3,
+ax_anim 1, 0, 55, 0, -8, 0, -3,
+ax_anim 1, 0, 55, 0, -4, 0, -2,
+ax_anim 3, 1, 55, 0, 0, 0, 0,
+ax_anim 1, 0, 55, 0, -2, 0, 0,
+ax_anim 1, 0, 55, 0, -3, 0, 0,
+ax_anim 1, 0, 55, 0, -2, 0, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_5_3:
+ax_anim 1, 0, 53, 5, 0, 5, 0,
+ax_anim 1, 0, 52, 4, -2, 4, -2,
+ax_anim 1, 0, 51, 2, -4, 2, -3,
+ax_anim 1, 0, 50, 0, -4, 0, -3,
+ax_anim 1, 0, 49, -2, -5, -2, -3,
+ax_anim 1, 0, 48, -4, -4, -4, -2,
+ax_anim 1, 0, 55, -5, -3, -5, 0,
+ax_anim 1, 0, 54, -4, -1, -4, 2,
+ax_anim 1, 0, 53, -2, -1, -2, 3,
+ax_anim 1, 0, 52, 0, -1, 0, 3,
+ax_anim 1, 0, 51, 2, -2, 2, 3,
+ax_anim 1, 0, 50, 4, -3, 4, 2,
+ax_anim 1, 0, 49, 5, -6, 5, 0,
+ax_anim 1, 0, 48, 4, -8, 4, -2,
+ax_anim 1, 0, 55, 2, -10, 2, -3,
+ax_anim 6, 2, 54, 0, -10, 0, -3,
+ax_anim 1, 0, 54, 0, -8, 0, -3,
+ax_anim 1, 0, 54, 0, -4, 0, -2,
+ax_anim 3, 1, 54, 0, 0, 0, 0,
+ax_anim 1, 0, 54, 0, -2, 0, 0,
+ax_anim 1, 0, 54, 0, -3, 0, 0,
+ax_anim 1, 0, 54, 0, -2, 0, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_5_4:
+ax_anim 1, 0, 52, 5, 0, 5, 0,
+ax_anim 1, 0, 51, 4, -2, 4, -2,
+ax_anim 1, 0, 50, 2, -4, 2, -3,
+ax_anim 1, 0, 49, 0, -4, 0, -3,
+ax_anim 1, 0, 48, -2, -5, -2, -3,
+ax_anim 1, 0, 55, -4, -4, -4, -2,
+ax_anim 1, 0, 54, -5, -3, -5, 0,
+ax_anim 1, 0, 53, -4, -1, -4, 2,
+ax_anim 1, 0, 52, -2, -1, -2, 3,
+ax_anim 1, 0, 51, 0, -1, 0, 3,
+ax_anim 1, 0, 50, 2, -2, 2, 3,
+ax_anim 1, 0, 49, 4, -3, 4, 2,
+ax_anim 1, 0, 48, 5, -6, 5, 0,
+ax_anim 1, 0, 55, 4, -8, 4, -2,
+ax_anim 1, 0, 54, 2, -10, 2, -3,
+ax_anim 6, 2, 53, 0, -10, 0, -3,
+ax_anim 1, 0, 53, 0, -8, 0, -3,
+ax_anim 1, 0, 53, 0, -4, 0, -2,
+ax_anim 3, 1, 53, 0, 0, 0, 0,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 0, 53, 0, -3, 0, 0,
+ax_anim 1, 0, 53, 0, -2, 0, 0,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_5_5:
+ax_anim 1, 0, 51, 5, 0, 5, 0,
+ax_anim 1, 0, 50, 4, -2, 4, -2,
+ax_anim 1, 0, 49, 2, -4, 2, -3,
+ax_anim 1, 0, 48, 0, -4, 0, -3,
+ax_anim 1, 0, 55, -2, -5, -2, -3,
+ax_anim 1, 0, 54, -4, -4, -4, -2,
+ax_anim 1, 0, 53, -5, -3, -5, 0,
+ax_anim 1, 0, 52, -4, -1, -4, 2,
+ax_anim 1, 0, 51, -2, -1, -2, 3,
+ax_anim 1, 0, 50, 0, -1, 0, 3,
+ax_anim 1, 0, 49, 2, -2, 2, 3,
+ax_anim 1, 0, 48, 4, -3, 4, 2,
+ax_anim 1, 0, 55, 5, -6, 5, 0,
+ax_anim 1, 0, 54, 4, -8, 4, -2,
+ax_anim 1, 0, 53, 2, -10, 2, -3,
+ax_anim 6, 2, 52, 0, -10, 0, -3,
+ax_anim 1, 0, 52, 0, -8, 0, -3,
+ax_anim 1, 0, 52, 0, -4, 0, -2,
+ax_anim 3, 1, 52, 0, 0, 0, 0,
+ax_anim 1, 0, 52, 0, -2, 0, 0,
+ax_anim 1, 0, 52, 0, -3, 0, 0,
+ax_anim 1, 0, 52, 0, -2, 0, 0,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_5_6:
+ax_anim 1, 0, 50, 5, 0, 5, 0,
+ax_anim 1, 0, 49, 4, -2, 4, -2,
+ax_anim 1, 0, 48, 2, -4, 2, -3,
+ax_anim 1, 0, 55, 0, -4, 0, -3,
+ax_anim 1, 0, 54, -2, -5, -2, -3,
+ax_anim 1, 0, 53, -4, -4, -4, -2,
+ax_anim 1, 0, 52, -5, -3, -5, 0,
+ax_anim 1, 0, 51, -4, -1, -4, 2,
+ax_anim 1, 0, 50, -2, -1, -2, 3,
+ax_anim 1, 0, 49, 0, -1, 0, 3,
+ax_anim 1, 0, 48, 2, -2, 2, 3,
+ax_anim 1, 0, 55, 4, -3, 4, 2,
+ax_anim 1, 0, 54, 5, -6, 5, 0,
+ax_anim 1, 0, 53, 4, -8, 4, -2,
+ax_anim 1, 0, 52, 2, -10, 2, -3,
+ax_anim 6, 2, 51, 0, -10, 0, -3,
+ax_anim 1, 0, 51, 0, -8, 0, -3,
+ax_anim 1, 0, 51, 0, -4, 0, -2,
+ax_anim 3, 1, 51, 0, 0, 0, 0,
+ax_anim 1, 0, 51, 0, -2, 0, 0,
+ax_anim 1, 0, 51, 0, -3, 0, 0,
+ax_anim 1, 0, 51, 0, -2, 0, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_5_7:
+ax_anim 1, 0, 49, 5, 0, 5, 0,
+ax_anim 1, 0, 48, 4, -2, 4, -2,
+ax_anim 1, 0, 55, 2, -4, 2, -3,
+ax_anim 1, 0, 54, 0, -4, 0, -3,
+ax_anim 1, 0, 53, -2, -5, -2, -3,
+ax_anim 1, 0, 52, -4, -4, -4, -2,
+ax_anim 1, 0, 51, -5, -3, -5, 0,
+ax_anim 1, 0, 50, -4, -1, -4, 2,
+ax_anim 1, 0, 49, -2, -1, -2, 3,
+ax_anim 1, 0, 48, 0, -1, 0, 3,
+ax_anim 1, 0, 55, 2, -2, 2, 3,
+ax_anim 1, 0, 54, 4, -3, 4, 2,
+ax_anim 1, 0, 53, 5, -6, 5, 0,
+ax_anim 1, 0, 52, 4, -8, 4, -2,
+ax_anim 1, 0, 51, 2, -10, 2, -3,
+ax_anim 6, 2, 50, 0, -10, 0, -3,
+ax_anim 1, 0, 50, 0, -8, 0, -3,
+ax_anim 1, 0, 50, 0, -4, 0, -2,
+ax_anim 3, 1, 50, 0, 0, 0, 0,
+ax_anim 1, 0, 50, 0, -2, 0, 0,
+ax_anim 1, 0, 50, 0, -3, 0, 0,
+ax_anim 1, 0, 50, 0, -2, 0, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_5_8:
+ax_anim 1, 0, 48, 5, 0, 5, 0,
+ax_anim 1, 0, 55, 4, -2, 4, -2,
+ax_anim 1, 0, 54, 2, -4, 2, -3,
+ax_anim 1, 0, 53, 0, -4, 0, -3,
+ax_anim 1, 0, 52, -2, -5, -2, -3,
+ax_anim 1, 0, 51, -4, -4, -4, -2,
+ax_anim 1, 0, 50, -5, -3, -5, 0,
+ax_anim 1, 0, 49, -4, -1, -4, 2,
+ax_anim 1, 0, 48, -2, -1, -2, 3,
+ax_anim 1, 0, 55, 0, -1, 0, 3,
+ax_anim 1, 0, 54, 2, -2, 2, 3,
+ax_anim 1, 0, 53, 4, -3, 4, 2,
+ax_anim 1, 0, 52, 5, -6, 5, 0,
+ax_anim 1, 0, 51, 4, -8, 4, -2,
+ax_anim 1, 0, 50, 2, -10, 2, -3,
+ax_anim 6, 2, 49, 0, -10, 0, -3,
+ax_anim 1, 0, 49, 0, -8, 0, -3,
+ax_anim 1, 0, 49, 0, -4, 0, -2,
+ax_anim 3, 1, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 49, 0, -2, 0, 0,
+ax_anim 1, 0, 49, 0, -3, 0, 0,
+ax_anim 1, 0, 49, 0, -2, 0, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_6_1:
+ax_anim 30, 0, 56, 0, 0, 0, 0,
+ax_anim 35, 0, 57, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_7_1:
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 8, 0, 58, 0, -3, 0, -3,
+ax_anim_terminator
+sVoltorbAnims_7_2:
+ax_anim 2, 0, 59, -2, -2, -2, -2,
+ax_anim 8, 0, 59, -3, -3, -3, -3,
+ax_anim_terminator
+sVoltorbAnims_7_3:
+ax_anim 2, 0, 60, -2, 0, -2, 0,
+ax_anim 8, 0, 60, -3, 0, -3, 0,
+ax_anim_terminator
+sVoltorbAnims_7_4:
+ax_anim 2, 0, 61, -2, 2, -2, 2,
+ax_anim 8, 0, 61, -3, 3, -3, 3,
+ax_anim_terminator
+sVoltorbAnims_7_5:
+ax_anim 2, 0, 62, 0, 2, 0, 2,
+ax_anim 8, 0, 62, 0, 3, 0, 3,
+ax_anim_terminator
+sVoltorbAnims_7_6:
+ax_anim 2, 0, 63, 2, 2, 2, 2,
+ax_anim 8, 0, 63, 3, 3, 3, 3,
+ax_anim_terminator
+sVoltorbAnims_7_7:
+ax_anim 2, 0, 64, 2, 0, 2, 0,
+ax_anim 8, 0, 64, 3, 0, 3, 0,
+ax_anim_terminator
+sVoltorbAnims_7_8:
+ax_anim 2, 0, 65, 2, -2, 2, -2,
+ax_anim 8, 0, 65, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_8_1:
+ax_anim 22, 0, 66, 0, 0, 0, 0,
+ax_anim 6, 0, 66, 0, -3, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, 0,
+ax_anim 6, 0, 66, 0, 0, 0, 0,
+ax_anim 6, 0, 66, 0, -1, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_8_2:
+ax_anim 22, 0, 73, 0, 0, 0, 0,
+ax_anim 6, 0, 73, 0, -3, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 6, 0, 73, 0, 0, 0, 0,
+ax_anim 6, 0, 73, 0, -1, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_8_3:
+ax_anim 22, 0, 72, 0, 0, 0, 0,
+ax_anim 6, 0, 72, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim 6, 0, 72, 0, 0, 0, 0,
+ax_anim 6, 0, 72, 0, -1, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_8_4:
+ax_anim 22, 0, 71, 0, 0, 0, 0,
+ax_anim 6, 0, 71, 0, -3, 0, 0,
+ax_anim 2, 0, 71, 0, -1, 0, 0,
+ax_anim 6, 0, 71, 0, 0, 0, 0,
+ax_anim 6, 0, 71, 0, -1, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_8_5:
+ax_anim 22, 0, 70, 0, 0, 0, 0,
+ax_anim 6, 0, 70, 0, -3, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim 6, 0, 70, 0, 0, 0, 0,
+ax_anim 6, 0, 70, 0, -1, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_8_6:
+ax_anim 22, 0, 69, 0, 0, 0, 0,
+ax_anim 6, 0, 69, 0, -3, 0, 0,
+ax_anim 2, 0, 69, 0, -1, 0, 0,
+ax_anim 6, 0, 69, 0, 0, 0, 0,
+ax_anim 6, 0, 69, 0, -1, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_8_7:
+ax_anim 22, 0, 68, 0, 0, 0, 0,
+ax_anim 6, 0, 68, 0, -3, 0, 0,
+ax_anim 2, 0, 68, 0, -1, 0, 0,
+ax_anim 6, 0, 68, 0, 0, 0, 0,
+ax_anim 6, 0, 68, 0, -1, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_8_8:
+ax_anim 22, 0, 67, 0, 0, 0, 0,
+ax_anim 6, 0, 67, 0, -3, 0, 0,
+ax_anim 2, 0, 67, 0, -1, 0, 0,
+ax_anim 6, 0, 67, 0, 0, 0, 0,
+ax_anim 6, 0, 67, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_9_1:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 6, 3, 6, 3,
+ax_anim 2, 0, 76, 8, 9, 8, 9,
+ax_anim 2, 0, 77, 7, 17, 7, 17,
+ax_anim 3, 0, 78, 0, 21, 0, 21,
+ax_anim 2, 3, 79, -7, 17, -7, 17,
+ax_anim 2, 0, 80, -8, 9, -8, 9,
+ax_anim 1, 0, 81, -6, 3, -6, 3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_9_2:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 74, 8, 0, 8, 0,
+ax_anim 2, 0, 75, 17, 3, 17, 3,
+ax_anim 2, 0, 76, 21, 10, 21, 10,
+ax_anim 3, 0, 77, 22, 21, 22, 21,
+ax_anim 2, 3, 78, 13, 21, 13, 21,
+ax_anim 2, 0, 79, 3, 15, 3, 15,
+ax_anim 1, 0, 80, 0, 7, 0, 7,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_9_3:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 3, -5, 3, -5,
+ax_anim 2, 0, 74, 11, -6, 11, -6,
+ax_anim 2, 0, 75, 18, -5, 18, -5,
+ax_anim 3, 0, 76, 22, -2, 22, -2,
+ax_anim 2, 3, 77, 18, 4, 18, 4,
+ax_anim 2, 0, 78, 12, 5, 12, 5,
+ax_anim 1, 0, 79, 4, 5, 4, 5,
+ax_anim 1, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_9_4:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 80, -1, -8, -1, -8,
+ax_anim 2, 0, 81, 4, -16, 4, -16,
+ax_anim 2, 0, 74, 13, -21, 13, -21,
+ax_anim 3, 0, 75, 22, -22, 22, -22,
+ax_anim 2, 3, 76, 22, -14, 22, -14,
+ax_anim 2, 0, 77, 17, -6, 17, -6,
+ax_anim 1, 0, 78, 7, -1, 7, -1,
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_9_5:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 0, 79, -8, -4, -8, -4,
+ax_anim 2, 0, 80, -9, -12, -9, -12,
+ax_anim 2, 0, 81, -7, -18, -7, -18,
+ax_anim 3, 0, 74, 0, -22, 0, -22,
+ax_anim 2, 3, 75, 7, -18, 7, -18,
+ax_anim 2, 0, 76, 9, -10, 9, -10,
+ax_anim 1, 0, 77, 8, -4, 8, -4,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_9_6:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 76, 1, -8, 1, -8,
+ax_anim 2, 0, 75, -4, -16, -4, -16,
+ax_anim 2, 0, 74, -13, -21, -13, -21,
+ax_anim 3, 0, 81, -22, -22, -22, -22,
+ax_anim 2, 3, 80, -22, -14, -22, -14,
+ax_anim 2, 0, 79, -17, -6, -17, -6,
+ax_anim 1, 0, 78, -7, -1, -7, -1,
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_9_7:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 1, 0, 75, -3, -5, -3, -5,
+ax_anim 2, 0, 74, -11, -6, -11, -6,
+ax_anim 2, 0, 81, -18, -5, -18, -5,
+ax_anim 3, 0, 80, -22, -2, -22, -2,
+ax_anim 2, 3, 79, -18, 4, -18, 4,
+ax_anim 2, 0, 78, -12, 5, -12, 5,
+ax_anim 1, 0, 77, -4, 5, -4, 5,
+ax_anim 1, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_9_8:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 74, -8, 0, -8, 0,
+ax_anim 2, 0, 81, -17, 3, -17, 3,
+ax_anim 2, 0, 80, -21, 10, -21, 10,
+ax_anim 3, 0, 79, -22, 21, -22, 21,
+ax_anim 2, 3, 78, -13, 21, -13, 21,
+ax_anim 2, 0, 77, -3, 15, -3, 15,
+ax_anim 1, 0, 76, 0, 7, 0, 7,
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_10_1:
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 6, 0, 6, 0,
+ax_anim 2, 0, 82, -6, 0, -6, 0,
+ax_anim 2, 0, 82, 10, 0, 10, 0,
+ax_anim 2, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 82, 12, 0, 12, 0,
+ax_anim 3, 0, 82, -12, 0, -12, 0,
+ax_anim 3, 0, 82, 13, 0, 13, 0,
+ax_anim 3, 0, 82, -13, 0, -13, 0,
+ax_anim 2, 0, 82, 12, 0, 12, 0,
+ax_anim 3, 0, 82, -12, 0, -12, 0,
+ax_anim 2, 0, 82, 10, 0, 10, 0,
+ax_anim 2, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 82, 6, 0, 6, 0,
+ax_anim 2, 0, 82, -6, 0, -6, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_10_2:
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 83, -6, 6, -6, 6,
+ax_anim 2, 0, 83, 10, -10, 10, -10,
+ax_anim 2, 0, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, 12, -12, 12, -12,
+ax_anim 3, 0, 83, -12, 12, -12, 12,
+ax_anim 3, 0, 83, 13, -13, 13, -13,
+ax_anim 3, 0, 83, -13, 13, -13, 13,
+ax_anim 2, 0, 83, 12, -12, 12, -12,
+ax_anim 3, 0, 83, -12, 12, -12, 12,
+ax_anim 2, 0, 83, 10, -10, 10, -10,
+ax_anim 2, 0, 83, -10, 10, -10, 10,
+ax_anim 2, 0, 83, 6, -6, 6, -6,
+ax_anim 2, 0, 83, -6, 6, -6, 6,
+ax_anim 2, 0, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_10_3:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim 2, 0, 84, 0, 6, 0, 6,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, 10, 0, 10,
+ax_anim 2, 0, 84, 0, -12, 0, -12,
+ax_anim 3, 0, 84, 0, 12, 0, 12,
+ax_anim 3, 0, 84, 0, -13, 0, -13,
+ax_anim 3, 0, 84, 0, 13, 0, 13,
+ax_anim 2, 0, 84, 0, -12, 0, -12,
+ax_anim 3, 0, 84, 0, 12, 0, 12,
+ax_anim 2, 0, 84, 0, -10, 0, -10,
+ax_anim 2, 0, 84, 0, 10, 0, 10,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim 2, 0, 84, 0, 6, 0, 6,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_10_4:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -6, -6, -6, -6,
+ax_anim 2, 0, 85, 6, 6, 6, 6,
+ax_anim 2, 0, 85, -10, -10, -10, -10,
+ax_anim 2, 0, 85, 10, 10, 10, 10,
+ax_anim 2, 0, 85, -12, -12, -12, -12,
+ax_anim 3, 0, 85, 12, 12, 12, 12,
+ax_anim 3, 0, 85, -13, -13, -13, -13,
+ax_anim 3, 0, 85, 13, 13, 13, 13,
+ax_anim 2, 0, 85, -12, -12, -12, -12,
+ax_anim 3, 0, 85, 12, 12, 12, 12,
+ax_anim 2, 0, 85, -10, -10, -10, -10,
+ax_anim 2, 0, 85, 10, 10, 10, 10,
+ax_anim 2, 0, 85, -6, -6, -6, -6,
+ax_anim 2, 0, 85, 6, 6, 6, 6,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_10_5:
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 86, 6, 0, 6, 0,
+ax_anim 2, 0, 86, -6, 0, -6, 0,
+ax_anim 2, 0, 86, 10, 0, 10, 0,
+ax_anim 2, 0, 86, -10, 0, -10, 0,
+ax_anim 2, 0, 86, 12, 0, 12, 0,
+ax_anim 3, 0, 86, -12, 0, -12, 0,
+ax_anim 3, 0, 86, 13, 0, 13, 0,
+ax_anim 3, 0, 86, -13, 0, -13, 0,
+ax_anim 2, 0, 86, 12, 0, 12, 0,
+ax_anim 3, 0, 86, -12, 0, -12, 0,
+ax_anim 2, 0, 86, 10, 0, 10, 0,
+ax_anim 2, 0, 86, -10, 0, -10, 0,
+ax_anim 2, 0, 86, 6, 0, 6, 0,
+ax_anim 2, 0, 86, -6, 0, -6, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_10_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 6, -6, 6, -6,
+ax_anim 2, 0, 87, -6, 6, -6, 6,
+ax_anim 2, 0, 87, 10, -10, 10, -10,
+ax_anim 2, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, 12, -12, 12, -12,
+ax_anim 3, 0, 87, -12, 12, -12, 12,
+ax_anim 3, 0, 87, 13, -13, 13, -13,
+ax_anim 3, 0, 87, -13, 13, -13, 13,
+ax_anim 2, 0, 87, 12, -12, 12, -12,
+ax_anim 3, 0, 87, -12, 12, -12, 12,
+ax_anim 2, 0, 87, 10, -10, 10, -10,
+ax_anim 2, 0, 87, -10, 10, -10, 10,
+ax_anim 2, 0, 87, 6, -6, 6, -6,
+ax_anim 2, 0, 87, -6, 6, -6, 6,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_10_7:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 88, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 0, 10, 0, 10,
+ax_anim 2, 0, 88, 0, -12, 0, -12,
+ax_anim 3, 0, 88, 0, 12, 0, 12,
+ax_anim 3, 0, 88, 0, -13, 0, -13,
+ax_anim 3, 0, 88, 0, 13, 0, 13,
+ax_anim 2, 0, 88, 0, -12, 0, -12,
+ax_anim 3, 0, 88, 0, 12, 0, 12,
+ax_anim 2, 0, 88, 0, -10, 0, -10,
+ax_anim 2, 0, 88, 0, 10, 0, 10,
+ax_anim 2, 0, 88, 0, -6, 0, -6,
+ax_anim 2, 0, 88, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_10_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 89, 6, 6, 6, 6,
+ax_anim 2, 0, 89, -10, -10, -10, -10,
+ax_anim 2, 0, 89, 10, 10, 10, 10,
+ax_anim 2, 0, 89, -12, -12, -12, -12,
+ax_anim 3, 0, 89, 12, 12, 12, 12,
+ax_anim 3, 0, 89, -13, -13, -13, -13,
+ax_anim 3, 0, 89, 13, 13, 13, 13,
+ax_anim 2, 0, 89, -12, -12, -12, -12,
+ax_anim 3, 0, 89, 12, 12, 12, 12,
+ax_anim 2, 0, 89, -10, -10, -10, -10,
+ax_anim 2, 0, 89, 10, 10, 10, 10,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim 2, 0, 89, 6, 6, 6, 6,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_11_1:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -10, 0, 0,
+ax_anim 2, 0, 91, 0, -16, 0, 0,
+ax_anim 3, 0, 91, 0, -20, 0, 0,
+ax_anim 4, 0, 91, 0, -21, 0, 0,
+ax_anim 4, 0, 90, 0, -23, 0, 0,
+ax_anim 3, 0, 92, 0, -22, 0, 0,
+ax_anim 2, 0, 92, 0, -18, 0, 0,
+ax_anim 1, 0, 92, 0, -12, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_11_2:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -10, 0, 0,
+ax_anim 2, 0, 94, 0, -16, 0, 0,
+ax_anim 3, 0, 94, 0, -20, 0, 0,
+ax_anim 4, 0, 94, 0, -21, 0, 0,
+ax_anim 4, 0, 93, 0, -23, 0, 0,
+ax_anim 3, 0, 95, 0, -22, 0, 0,
+ax_anim 2, 0, 95, 0, -18, 0, 0,
+ax_anim 1, 0, 95, 0, -12, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_11_3:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -10, 0, 0,
+ax_anim 2, 0, 97, 0, -16, 0, 0,
+ax_anim 3, 0, 97, 0, -20, 0, 0,
+ax_anim 4, 0, 97, 0, -21, 0, 0,
+ax_anim 4, 0, 96, 0, -23, 0, 0,
+ax_anim 3, 0, 98, 0, -22, 0, 0,
+ax_anim 2, 0, 98, 0, -18, 0, 0,
+ax_anim 1, 0, 98, 0, -12, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_11_4:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, -10, 0, 0,
+ax_anim 2, 0, 100, 0, -16, 0, 0,
+ax_anim 3, 0, 100, 0, -20, 0, 0,
+ax_anim 4, 0, 100, 0, -21, 0, 0,
+ax_anim 4, 0, 99, 0, -22, 0, 0,
+ax_anim 3, 0, 101, 0, -21, 0, 0,
+ax_anim 2, 0, 101, 0, -17, 0, 0,
+ax_anim 1, 0, 101, 0, -11, 0, 0,
+ax_anim 2, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_11_5:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -10, 0, 0,
+ax_anim 2, 0, 103, 0, -16, 0, 0,
+ax_anim 3, 0, 103, 0, -20, 0, 0,
+ax_anim 4, 0, 103, 0, -21, 0, 0,
+ax_anim 4, 0, 102, 0, -23, 0, 0,
+ax_anim 3, 0, 104, 0, -22, 0, 0,
+ax_anim 2, 0, 104, 0, -18, 0, 0,
+ax_anim 1, 0, 104, 0, -12, 0, 0,
+ax_anim 2, 2, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_11_6:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, -10, 0, 0,
+ax_anim 2, 0, 106, 0, -16, 0, 0,
+ax_anim 3, 0, 106, 0, -20, 0, 0,
+ax_anim 4, 0, 106, 0, -21, 0, 0,
+ax_anim 4, 0, 105, 0, -22, 0, 0,
+ax_anim 3, 0, 107, 0, -21, 0, 0,
+ax_anim 2, 0, 107, 0, -17, 0, 0,
+ax_anim 1, 0, 107, 0, -11, 0, 0,
+ax_anim 2, 2, 105, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_11_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, -10, 0, 0,
+ax_anim 2, 0, 109, 0, -16, 0, 0,
+ax_anim 3, 0, 109, 0, -20, 0, 0,
+ax_anim 4, 0, 109, 0, -21, 0, 0,
+ax_anim 4, 0, 108, 0, -23, 0, 0,
+ax_anim 3, 0, 110, 0, -22, 0, 0,
+ax_anim 2, 0, 110, 0, -18, 0, 0,
+ax_anim 1, 0, 110, 0, -12, 0, 0,
+ax_anim 2, 2, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_11_8:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, 0, -10, 0, 0,
+ax_anim 2, 0, 112, 0, -16, 0, 0,
+ax_anim 3, 0, 112, 0, -20, 0, 0,
+ax_anim 4, 0, 112, 0, -21, 0, 0,
+ax_anim 4, 0, 111, 0, -23, 0, 0,
+ax_anim 3, 0, 113, 0, -22, 0, 0,
+ax_anim 2, 0, 113, 0, -18, 0, 0,
+ax_anim 1, 0, 113, 0, -12, 0, 0,
+ax_anim 2, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_12_1:
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 1, 0, 1, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_12_2:
+ax_anim 2, 0, 121, 1, -1, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, 0,
+ax_anim 2, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, -1, 1, 0,
+ax_anim 2, 1, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_12_3:
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 2, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, -1,
+ax_anim 2, 1, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_12_4:
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_12_5:
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, 0, 1, 0,
+ax_anim 2, 1, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_12_6:
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 1, -1, 1, -1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_12_7:
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, -1,
+ax_anim 2, 1, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_12_8:
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVoltorbAnims_13_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 2, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_13_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 2, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_13_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_13_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_13_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_13_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_13_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbAnims_13_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sVoltorbGfx1:
+.incbin "baserom.gba", 0x948F04, 0x80
+sVoltorbSprites1:
+ax_sprite sVoltorbGfx1, 0x80
+ax_sprite_terminator
+sVoltorbGfx2:
+.incbin "baserom.gba", 0x948F94, 0x80
+sVoltorbSprites2:
+ax_sprite sVoltorbGfx2, 0x80
+ax_sprite_terminator
+sVoltorbGfx3:
+.incbin "baserom.gba", 0x949024, 0x80
+sVoltorbSprites3:
+ax_sprite sVoltorbGfx3, 0x80
+ax_sprite_terminator
+sVoltorbGfx4:
+.incbin "baserom.gba", 0x9490B4, 0x80
+sVoltorbSprites4:
+ax_sprite sVoltorbGfx4, 0x80
+ax_sprite_terminator
+sVoltorbGfx5:
+.incbin "baserom.gba", 0x949144, 0x80
+sVoltorbSprites5:
+ax_sprite sVoltorbGfx5, 0x80
+ax_sprite_terminator
+sVoltorbGfx6:
+.incbin "baserom.gba", 0x9491D4, 0x80
+sVoltorbSprites6:
+ax_sprite sVoltorbGfx6, 0x80
+ax_sprite_terminator
+sVoltorbGfx7:
+.incbin "baserom.gba", 0x949264, 0x80
+sVoltorbSprites7:
+ax_sprite sVoltorbGfx7, 0x80
+ax_sprite_terminator
+sVoltorbGfx8:
+.incbin "baserom.gba", 0x9492F4, 0x80
+sVoltorbSprites8:
+ax_sprite sVoltorbGfx8, 0x80
+ax_sprite_terminator
+sVoltorbGfx9:
+.incbin "baserom.gba", 0x949384, 0x80
+sVoltorbSprites9:
+ax_sprite sVoltorbGfx9, 0x80
+ax_sprite_terminator
+sVoltorbGfx10:
+.incbin "baserom.gba", 0x949414, 0x80
+sVoltorbSprites10:
+ax_sprite sVoltorbGfx10, 0x80
+ax_sprite_terminator
+sVoltorbGfx11:
+.incbin "baserom.gba", 0x9494A4, 0x80
+sVoltorbSprites11:
+ax_sprite sVoltorbGfx11, 0x80
+ax_sprite_terminator
+sVoltorbGfx12:
+.incbin "baserom.gba", 0x949534, 0x80
+sVoltorbSprites12:
+ax_sprite sVoltorbGfx12, 0x80
+ax_sprite_terminator
+sVoltorbGfx13:
+.incbin "baserom.gba", 0x9495C4, 0x80
+sVoltorbSprites13:
+ax_sprite sVoltorbGfx13, 0x80
+ax_sprite_terminator
+sVoltorbGfx14:
+.incbin "baserom.gba", 0x949654, 0x80
+sVoltorbSprites14:
+ax_sprite sVoltorbGfx14, 0x80
+ax_sprite_terminator
+sVoltorbGfx15:
+.incbin "baserom.gba", 0x9496E4, 0x80
+sVoltorbSprites15:
+ax_sprite sVoltorbGfx15, 0x80
+ax_sprite_terminator
+sVoltorbGfx16:
+.incbin "baserom.gba", 0x949774, 0x80
+sVoltorbSprites16:
+ax_sprite sVoltorbGfx16, 0x80
+ax_sprite_terminator
+sVoltorbGfx17:
+.incbin "baserom.gba", 0x949804, 0x80
+sVoltorbSprites17:
+ax_sprite sVoltorbGfx17, 0x80
+ax_sprite_terminator
+sVoltorbGfx18:
+.incbin "baserom.gba", 0x949894, 0x80
+sVoltorbSprites18:
+ax_sprite sVoltorbGfx18, 0x80
+ax_sprite_terminator
+sVoltorbGfx19:
+.incbin "baserom.gba", 0x949924, 0x80
+sVoltorbSprites19:
+ax_sprite sVoltorbGfx19, 0x80
+ax_sprite_terminator
+sVoltorbGfx20:
+.incbin "baserom.gba", 0x9499B4, 0x80
+sVoltorbSprites20:
+ax_sprite sVoltorbGfx20, 0x80
+ax_sprite_terminator
+sVoltorbGfx21:
+.incbin "baserom.gba", 0x949A44, 0x80
+sVoltorbSprites21:
+ax_sprite sVoltorbGfx21, 0x80
+ax_sprite_terminator
+sVoltorbGfx22:
+.incbin "baserom.gba", 0x949AD4, 0x80
+sVoltorbSprites22:
+ax_sprite sVoltorbGfx22, 0x80
+ax_sprite_terminator
+sVoltorbGfx23:
+.incbin "baserom.gba", 0x949B64, 0x80
+sVoltorbSprites23:
+ax_sprite sVoltorbGfx23, 0x80
+ax_sprite_terminator
+sVoltorbGfx24:
+.incbin "baserom.gba", 0x949BF4, 0x80
+sVoltorbSprites24:
+ax_sprite sVoltorbGfx24, 0x80
+ax_sprite_terminator
+sVoltorbGfx25:
+.incbin "baserom.gba", 0x949C84, 0x80
+sVoltorbSprites25:
+ax_sprite sVoltorbGfx25, 0x80
+ax_sprite_terminator
+sVoltorbGfx26:
+.incbin "baserom.gba", 0x949D14, 0x80
+sVoltorbSprites26:
+ax_sprite sVoltorbGfx26, 0x80
+ax_sprite_terminator
+sVoltorbGfx27:
+.incbin "baserom.gba", 0x949DA4, 0x200
+sVoltorbSprites27:
+ax_sprite sVoltorbGfx27, 0x200
+ax_sprite_terminator
+sVoltorbGfx28:
+.incbin "baserom.gba", 0x949FB4, 0x200
+sVoltorbSprites28:
+ax_sprite sVoltorbGfx28, 0x200
+ax_sprite_terminator
+sVoltorbGfx29:
+.incbin "baserom.gba", 0x94A1C4, 0x200
+sVoltorbSprites29:
+ax_sprite sVoltorbGfx29, 0x200
+ax_sprite_terminator
+sVoltorbGfx30:
+.incbin "baserom.gba", 0x94A3D4, 0x200
+sVoltorbSprites30:
+ax_sprite sVoltorbGfx30, 0x200
+ax_sprite_terminator
+sVoltorbGfx31:
+.incbin "baserom.gba", 0x94A5E4, 0x200
+sVoltorbSprites31:
+ax_sprite sVoltorbGfx31, 0x200
+ax_sprite_terminator
+sAxPosesVoltorb:
+.4byte sVoltorbPose1
+.4byte sVoltorbPose2
+.4byte sVoltorbPose3
+.4byte sVoltorbPose4
+.4byte sVoltorbPose5
+.4byte sVoltorbPose6
+.4byte sVoltorbPose7
+.4byte sVoltorbPose8
+.4byte sVoltorbPose9
+.4byte sVoltorbPose10
+.4byte sVoltorbPose11
+.4byte sVoltorbPose12
+.4byte sVoltorbPose13
+.4byte sVoltorbPose14
+.4byte sVoltorbPose15
+.4byte sVoltorbPose16
+.4byte sVoltorbPose17
+.4byte sVoltorbPose18
+.4byte sVoltorbPose19
+.4byte sVoltorbPose20
+.4byte sVoltorbPose21
+.4byte sVoltorbPose22
+.4byte sVoltorbPose23
+.4byte sVoltorbPose24
+.4byte sVoltorbPose25
+.4byte sVoltorbPose26
+.4byte sVoltorbPose27
+.4byte sVoltorbPose28
+.4byte sVoltorbPose29
+.4byte sVoltorbPose30
+.4byte sVoltorbPose31
+.4byte sVoltorbPose32
+.4byte sVoltorbPose33
+.4byte sVoltorbPose34
+.4byte sVoltorbPose35
+.4byte sVoltorbPose36
+.4byte sVoltorbPose37
+.4byte sVoltorbPose38
+.4byte sVoltorbPose39
+.4byte sVoltorbPose40
+.4byte sVoltorbPose41
+.4byte sVoltorbPose42
+.4byte sVoltorbPose43
+.4byte sVoltorbPose44
+.4byte sVoltorbPose45
+.4byte sVoltorbPose46
+.4byte sVoltorbPose47
+.4byte sVoltorbPose48
+.4byte sVoltorbPose49
+.4byte sVoltorbPose50
+.4byte sVoltorbPose51
+.4byte sVoltorbPose52
+.4byte sVoltorbPose53
+.4byte sVoltorbPose54
+.4byte sVoltorbPose55
+.4byte sVoltorbPose56
+.4byte sVoltorbPose57
+.4byte sVoltorbPose58
+.4byte sVoltorbPose59
+.4byte sVoltorbPose60
+.4byte sVoltorbPose61
+.4byte sVoltorbPose62
+.4byte sVoltorbPose63
+.4byte sVoltorbPose64
+.4byte sVoltorbPose65
+.4byte sVoltorbPose66
+.4byte sVoltorbPose67
+.4byte sVoltorbPose68
+.4byte sVoltorbPose69
+.4byte sVoltorbPose70
+.4byte sVoltorbPose71
+.4byte sVoltorbPose72
+.4byte sVoltorbPose73
+.4byte sVoltorbPose74
+.4byte sVoltorbPose75
+.4byte sVoltorbPose76
+.4byte sVoltorbPose77
+.4byte sVoltorbPose78
+.4byte sVoltorbPose79
+.4byte sVoltorbPose80
+.4byte sVoltorbPose81
+.4byte sVoltorbPose82
+.4byte sVoltorbPose83
+.4byte sVoltorbPose84
+.4byte sVoltorbPose85
+.4byte sVoltorbPose86
+.4byte sVoltorbPose87
+.4byte sVoltorbPose88
+.4byte sVoltorbPose89
+.4byte sVoltorbPose90
+.4byte sVoltorbPose91
+.4byte sVoltorbPose92
+.4byte sVoltorbPose93
+.4byte sVoltorbPose94
+.4byte sVoltorbPose95
+.4byte sVoltorbPose96
+.4byte sVoltorbPose97
+.4byte sVoltorbPose98
+.4byte sVoltorbPose99
+.4byte sVoltorbPose100
+.4byte sVoltorbPose101
+.4byte sVoltorbPose102
+.4byte sVoltorbPose103
+.4byte sVoltorbPose104
+.4byte sVoltorbPose105
+.4byte sVoltorbPose106
+.4byte sVoltorbPose107
+.4byte sVoltorbPose108
+.4byte sVoltorbPose109
+.4byte sVoltorbPose110
+.4byte sVoltorbPose111
+.4byte sVoltorbPose112
+.4byte sVoltorbPose113
+.4byte sVoltorbPose114
+.4byte sVoltorbPose115
+.4byte sVoltorbPose116
+.4byte sVoltorbPose117
+.4byte sVoltorbPose118
+.4byte sVoltorbPose119
+.4byte sVoltorbPose120
+.4byte sVoltorbPose121
+.4byte sVoltorbPose122
+.4byte sVoltorbPose123
+.4byte sVoltorbPose124
+.4byte sVoltorbPose125
+.4byte sVoltorbPose126
+.4byte sVoltorbPose127
+.4byte sVoltorbPose128
+.4byte sVoltorbPose129
+.4byte sVoltorbPose130
+sAxPositionsVoltorb:
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,   -1, 	  -7,   -6, 	   6,   -6, 	  -1,   -8
+.2byte   -1,   -4, 	  -7,   -8, 	   6,   -8, 	  -1,   -8
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte    3,   -2, 	  -3,   -6, 	   5,  -10, 	  -1,   -7
+.2byte    5,   -5, 	  -4,   -4, 	   4,  -10, 	  -1,   -6
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    3,   -2, 	  -1,   -5, 	   1,  -11, 	  -1,   -7
+.2byte    6,   -6, 	  -1,   -4, 	  -1,  -11, 	  -1,   -6
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    6,   -6, 	   3,   -4, 	  -1,  -10, 	  -1,   -6
+.2byte    5,  -10, 	   2,   -5, 	  -4,  -10, 	  -1,   -7
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte   -1,   -7, 	   6,   -8, 	  -6,   -9, 	  -1,   -8
+.2byte   -1,  -14, 	   5,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -3,   -7, 	   0,  -11, 	  -5,   -8, 	  -1,   -7
+.2byte   -6,  -11, 	   4,  -10, 	  -3,   -6, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -4,   -2, 	  -6,   -9, 	  -2,   -4, 	  -1,   -7
+.2byte   -6,   -6, 	  -4,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -4,   -2, 	  -5,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -5,   -5, 	  -3,  -12, 	   2,   -6, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte    0,   -2, 	  -7,   -8, 	   6,   -8, 	  -1,   -7
+.2byte    0,   -1, 	  -7,   -7, 	   6,   -7, 	   0,   -7
+.2byte   -1,   -8, 	  -7,   -7, 	   6,   -7, 	  -1,   -7
+.2byte   -1,   -8, 	   1,  -13, 	  -8,   -5, 	  -3,   -9
+.2byte    2,   -8, 	  -4,  -11, 	  -4,   -6, 	  -3,   -6
+.2byte    2,   -9, 	  -8,   -9, 	  -1,   -6, 	  -4,   -5
+.2byte   -1,   -9, 	   6,   -4, 	  -7,   -4, 	  -1,   -4
+.2byte   -3,   -9, 	   7,   -9, 	   0,   -6, 	   3,   -5
+.2byte   -3,   -8, 	   3,  -11, 	   3,   -6, 	   2,   -6
+.2byte    0,   -8, 	  -2,  -13, 	   7,   -5, 	   2,   -9
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -1,   -4, 	  -7,   -8, 	   6,   -8, 	  -1,   -8
+.2byte   -1,   -1, 	  -7,   -6, 	   6,   -6, 	  -1,   -8
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte    5,   -5, 	  -4,   -4, 	   4,  -10, 	  -1,   -6
+.2byte    3,   -2, 	  -3,   -6, 	   5,  -10, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    6,   -6, 	  -1,   -4, 	  -1,  -11, 	  -1,   -6
+.2byte    3,   -2, 	  -1,   -5, 	   1,  -11, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,  -10, 	   2,   -5, 	  -4,  -10, 	  -1,   -7
+.2byte    6,   -6, 	   3,   -4, 	  -1,  -10, 	  -1,   -6
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte   -1,  -14, 	   5,  -10, 	  -6,  -10, 	  -1,   -8
+.2byte   -1,   -7, 	   6,   -8, 	  -6,   -9, 	  -1,   -8
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -6,  -11, 	   4,  -10, 	  -3,   -6, 	  -1,   -7
+.2byte   -3,   -7, 	   0,  -11, 	  -5,   -8, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -6,   -6, 	  -4,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -4,   -2, 	  -6,   -9, 	  -2,   -4, 	  -1,   -7
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -5, 	  -3,  -12, 	   2,   -6, 	  -1,   -7
+.2byte   -4,   -2, 	  -5,   -9, 	   2,   -2, 	  -1,   -8
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+.2byte   -1,   -2, 	  -7,   -7, 	   6,   -7, 	  -1,   -8
+.2byte   -5,   -3, 	  -5,  -11, 	   2,   -3, 	  -1,   -7
+.2byte   -5,   -3, 	  -2,  -12, 	  -1,   -5, 	  -1,   -7
+.2byte   -5,  -11, 	   3,  -12, 	  -4,   -8, 	  -1,   -8
+.2byte   -1,  -11, 	   5,   -9, 	  -6,   -9, 	  -1,   -7
+.2byte    5,  -10, 	   3,   -5, 	  -2,  -12, 	  -1,   -7
+.2byte    5,   -4, 	   0,   -4, 	   0,  -11, 	  -1,   -7
+.2byte    5,   -4, 	  -3,   -4, 	   4,  -11, 	  -1,   -7
+sVoltorbAnimTable1:
+.4byte sVoltorbAnims_1_1
+.4byte sVoltorbAnims_1_2
+.4byte sVoltorbAnims_1_3
+.4byte sVoltorbAnims_1_4
+.4byte sVoltorbAnims_1_5
+.4byte sVoltorbAnims_1_6
+.4byte sVoltorbAnims_1_7
+.4byte sVoltorbAnims_1_8
+sVoltorbAnimTable2:
+.4byte sVoltorbAnims_2_1
+.4byte sVoltorbAnims_2_2
+.4byte sVoltorbAnims_2_3
+.4byte sVoltorbAnims_2_4
+.4byte sVoltorbAnims_2_5
+.4byte sVoltorbAnims_2_6
+.4byte sVoltorbAnims_2_7
+.4byte sVoltorbAnims_2_8
+sVoltorbAnimTable3:
+.4byte sVoltorbAnims_3_1
+.4byte sVoltorbAnims_3_2
+.4byte sVoltorbAnims_3_3
+.4byte sVoltorbAnims_3_4
+.4byte sVoltorbAnims_3_5
+.4byte sVoltorbAnims_3_6
+.4byte sVoltorbAnims_3_7
+.4byte sVoltorbAnims_3_8
+sVoltorbAnimTable4:
+.4byte sVoltorbAnims_4_1
+.4byte sVoltorbAnims_4_2
+.4byte sVoltorbAnims_4_3
+.4byte sVoltorbAnims_4_4
+.4byte sVoltorbAnims_4_5
+.4byte sVoltorbAnims_4_6
+.4byte sVoltorbAnims_4_7
+.4byte sVoltorbAnims_4_8
+sVoltorbAnimTable5:
+.4byte sVoltorbAnims_5_1
+.4byte sVoltorbAnims_5_2
+.4byte sVoltorbAnims_5_3
+.4byte sVoltorbAnims_5_4
+.4byte sVoltorbAnims_5_5
+.4byte sVoltorbAnims_5_6
+.4byte sVoltorbAnims_5_7
+.4byte sVoltorbAnims_5_8
+sVoltorbAnimTable6:
+.4byte sVoltorbAnims_6_1
+.4byte sVoltorbAnims_6_1
+.4byte sVoltorbAnims_6_1
+.4byte sVoltorbAnims_6_1
+.4byte sVoltorbAnims_6_1
+.4byte sVoltorbAnims_6_1
+.4byte sVoltorbAnims_6_1
+.4byte sVoltorbAnims_6_1
+sVoltorbAnimTable7:
+.4byte sVoltorbAnims_7_1
+.4byte sVoltorbAnims_7_2
+.4byte sVoltorbAnims_7_3
+.4byte sVoltorbAnims_7_4
+.4byte sVoltorbAnims_7_5
+.4byte sVoltorbAnims_7_6
+.4byte sVoltorbAnims_7_7
+.4byte sVoltorbAnims_7_8
+sVoltorbAnimTable8:
+.4byte sVoltorbAnims_8_1
+.4byte sVoltorbAnims_8_2
+.4byte sVoltorbAnims_8_3
+.4byte sVoltorbAnims_8_4
+.4byte sVoltorbAnims_8_5
+.4byte sVoltorbAnims_8_6
+.4byte sVoltorbAnims_8_7
+.4byte sVoltorbAnims_8_8
+sVoltorbAnimTable9:
+.4byte sVoltorbAnims_9_1
+.4byte sVoltorbAnims_9_2
+.4byte sVoltorbAnims_9_3
+.4byte sVoltorbAnims_9_4
+.4byte sVoltorbAnims_9_5
+.4byte sVoltorbAnims_9_6
+.4byte sVoltorbAnims_9_7
+.4byte sVoltorbAnims_9_8
+sVoltorbAnimTable10:
+.4byte sVoltorbAnims_10_1
+.4byte sVoltorbAnims_10_2
+.4byte sVoltorbAnims_10_3
+.4byte sVoltorbAnims_10_4
+.4byte sVoltorbAnims_10_5
+.4byte sVoltorbAnims_10_6
+.4byte sVoltorbAnims_10_7
+.4byte sVoltorbAnims_10_8
+sVoltorbAnimTable11:
+.4byte sVoltorbAnims_11_1
+.4byte sVoltorbAnims_11_2
+.4byte sVoltorbAnims_11_3
+.4byte sVoltorbAnims_11_4
+.4byte sVoltorbAnims_11_5
+.4byte sVoltorbAnims_11_6
+.4byte sVoltorbAnims_11_7
+.4byte sVoltorbAnims_11_8
+sVoltorbAnimTable12:
+.4byte sVoltorbAnims_12_1
+.4byte sVoltorbAnims_12_2
+.4byte sVoltorbAnims_12_3
+.4byte sVoltorbAnims_12_4
+.4byte sVoltorbAnims_12_5
+.4byte sVoltorbAnims_12_6
+.4byte sVoltorbAnims_12_7
+.4byte sVoltorbAnims_12_8
+sVoltorbAnimTable13:
+.4byte sVoltorbAnims_13_1
+.4byte sVoltorbAnims_13_2
+.4byte sVoltorbAnims_13_3
+.4byte sVoltorbAnims_13_4
+.4byte sVoltorbAnims_13_5
+.4byte sVoltorbAnims_13_6
+.4byte sVoltorbAnims_13_7
+.4byte sVoltorbAnims_13_8
+sAxAnimationsVoltorb:
+.4byte sVoltorbAnimTable1
+.4byte sVoltorbAnimTable2
+.4byte sVoltorbAnimTable3
+.4byte sVoltorbAnimTable4
+.4byte sVoltorbAnimTable5
+.4byte sVoltorbAnimTable6
+.4byte sVoltorbAnimTable7
+.4byte sVoltorbAnimTable8
+.4byte sVoltorbAnimTable9
+.4byte sVoltorbAnimTable10
+.4byte sVoltorbAnimTable11
+.4byte sVoltorbAnimTable12
+.4byte sVoltorbAnimTable13
+sAxSpritesVoltorb:
+.4byte sVoltorbSprites1
+.4byte sVoltorbSprites2
+.4byte sVoltorbSprites3
+.4byte sVoltorbSprites4
+.4byte sVoltorbSprites5
+.4byte sVoltorbSprites6
+.4byte sVoltorbSprites7
+.4byte sVoltorbSprites8
+.4byte sVoltorbSprites9
+.4byte sVoltorbSprites10
+.4byte sVoltorbSprites11
+.4byte sVoltorbSprites12
+.4byte sVoltorbSprites13
+.4byte sVoltorbSprites14
+.4byte sVoltorbSprites15
+.4byte sVoltorbSprites16
+.4byte sVoltorbSprites17
+.4byte sVoltorbSprites18
+.4byte sVoltorbSprites19
+.4byte sVoltorbSprites20
+.4byte sVoltorbSprites21
+.4byte sVoltorbSprites22
+.4byte sVoltorbSprites23
+.4byte sVoltorbSprites24
+.4byte sVoltorbSprites25
+.4byte sVoltorbSprites26
+.4byte sVoltorbSprites27
+.4byte sVoltorbSprites28
+.4byte sVoltorbSprites29
+.4byte sVoltorbSprites30
+.4byte sVoltorbSprites31
+sAxMainVoltorb:
+ax_main sAxPosesVoltorb, sAxAnimationsVoltorb, 13, sAxSpritesVoltorb, sAxPositionsVoltorb

--- a/data/ax/vulpix.inc
+++ b/data/ax/vulpix.inc
@@ -1,0 +1,2861 @@
+.global gAxVulpix
+gAxVulpix:
+ax_siro sAxMainVulpix
+sVulpixPose1:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose4:
+ax_pose 3, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose5:
+ax_pose 4, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose6:
+ax_pose 5, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose7:
+ax_pose 6, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose8:
+ax_pose 7, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose9:
+ax_pose 8, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose10:
+ax_pose 9, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose11:
+ax_pose 10, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose12:
+ax_pose 11, 0x01ea, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose15:
+ax_pose 14, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose16:
+ax_pose 9, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose17:
+ax_pose 10, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose18:
+ax_pose 11, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose19:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose20:
+ax_pose 7, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose21:
+ax_pose 8, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose22:
+ax_pose 3, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose23:
+ax_pose 4, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose24:
+ax_pose 5, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose25:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose28:
+ax_pose 15, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose29:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose30:
+ax_pose 4, 0x01ef, 0x90ea, 0x4c00
+ax_pose_terminator
+sVulpixPose31:
+ax_pose 5, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose32:
+ax_pose 16, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose33:
+ax_pose 6, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose34:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose35:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose36:
+ax_pose 17, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sVulpixPose37:
+ax_pose 9, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose38:
+ax_pose 10, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose39:
+ax_pose 11, 0x01ed, 0x90ea, 0x4c00
+ax_pose_terminator
+sVulpixPose40:
+ax_pose 18, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose42:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose43:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose44:
+ax_pose 19, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose45:
+ax_pose 9, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose46:
+ax_pose 10, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose47:
+ax_pose 11, 0x01ed, 0x80f6, 0x4c00
+ax_pose_terminator
+sVulpixPose48:
+ax_pose 18, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose49:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose50:
+ax_pose 7, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose51:
+ax_pose 8, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose52:
+ax_pose 17, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose53:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose54:
+ax_pose 4, 0x01ef, 0x80f6, 0x4c00
+ax_pose_terminator
+sVulpixPose55:
+ax_pose 5, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose56:
+ax_pose 16, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose57:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose58:
+ax_pose 1, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose59:
+ax_pose 2, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose60:
+ax_pose 15, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose61:
+ax_pose 3, 0x01ed, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose62:
+ax_pose 4, 0x01ef, 0x90ea, 0x4c00
+ax_pose_terminator
+sVulpixPose63:
+ax_pose 5, 0x01ed, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose64:
+ax_pose 16, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose65:
+ax_pose 6, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose66:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose67:
+ax_pose 8, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose68:
+ax_pose 17, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sVulpixPose69:
+ax_pose 9, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose70:
+ax_pose 10, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose71:
+ax_pose 11, 0x01ed, 0x90ea, 0x4c00
+ax_pose_terminator
+sVulpixPose72:
+ax_pose 18, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose74:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose75:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose76:
+ax_pose 19, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose77:
+ax_pose 9, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose78:
+ax_pose 10, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose79:
+ax_pose 11, 0x01ed, 0x80f6, 0x4c00
+ax_pose_terminator
+sVulpixPose80:
+ax_pose 18, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose81:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose82:
+ax_pose 7, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose83:
+ax_pose 8, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose84:
+ax_pose 17, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose85:
+ax_pose 3, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose86:
+ax_pose 4, 0x01ef, 0x80f6, 0x4c00
+ax_pose_terminator
+sVulpixPose87:
+ax_pose 5, 0x01ed, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose88:
+ax_pose 16, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose89:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose90:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose91:
+ax_pose 15, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose92:
+ax_pose 3, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose93:
+ax_pose 21, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose94:
+ax_pose 16, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose95:
+ax_pose 6, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose96:
+ax_pose 22, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose97:
+ax_pose 17, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sVulpixPose98:
+ax_pose 9, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose99:
+ax_pose 23, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose100:
+ax_pose 18, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose102:
+ax_pose 24, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose103:
+ax_pose 19, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose104:
+ax_pose 9, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose105:
+ax_pose 23, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose106:
+ax_pose 18, 0x01ec, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose107:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose108:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose109:
+ax_pose 17, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose110:
+ax_pose 3, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose111:
+ax_pose 21, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose112:
+ax_pose 16, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose113:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose114:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose115:
+ax_pose 15, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose116:
+ax_pose 25, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose117:
+ax_pose 26, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose118:
+ax_pose 3, 0x01ee, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose119:
+ax_pose 21, 0x01ee, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose120:
+ax_pose 16, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose121:
+ax_pose 27, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose122:
+ax_pose 28, 0x01ec, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose123:
+ax_pose 6, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose124:
+ax_pose 22, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose125:
+ax_pose 17, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose126:
+ax_pose 29, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose127:
+ax_pose 30, 0x01eb, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose128:
+ax_pose 9, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose129:
+ax_pose 23, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose130:
+ax_pose 18, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose131:
+ax_pose 31, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose132:
+ax_pose 32, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose133:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose134:
+ax_pose 24, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose135:
+ax_pose 19, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose136:
+ax_pose 33, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose137:
+ax_pose 34, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose138:
+ax_pose 9, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose139:
+ax_pose 23, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose140:
+ax_pose 18, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose141:
+ax_pose 31, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose142:
+ax_pose 32, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose143:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose144:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose145:
+ax_pose 17, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose146:
+ax_pose 29, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose147:
+ax_pose 30, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose148:
+ax_pose 3, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose149:
+ax_pose 21, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose150:
+ax_pose 16, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose151:
+ax_pose 27, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose152:
+ax_pose 28, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose153:
+ax_pose 35, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose154:
+ax_pose 36, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose155:
+ax_pose 37, 0x01e5, 0x80ef, 0x4c00
+ax_pose_terminator
+sVulpixPose156:
+ax_pose 38, 0x01e5, 0x90f0, 0x4c00
+ax_pose_terminator
+sVulpixPose157:
+ax_pose 39, 0x01e4, 0x90ef, 0x4c00
+ax_pose_terminator
+sVulpixPose158:
+ax_pose 40, 0x01e7, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose159:
+ax_pose 41, 0x01e8, 0x80ef, 0x4c00
+ax_pose_terminator
+sVulpixPose160:
+ax_pose 40, 0x01e7, 0x80f2, 0x4c00
+ax_pose_terminator
+sVulpixPose161:
+ax_pose 39, 0x01e4, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose162:
+ax_pose 38, 0x01e5, 0x80f0, 0x4c00
+ax_pose_terminator
+sVulpixPose163:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose164:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose165:
+ax_pose 3, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose166:
+ax_pose 21, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose167:
+ax_pose 6, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose168:
+ax_pose 22, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose169:
+ax_pose 9, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose170:
+ax_pose 23, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose171:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose172:
+ax_pose 24, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose173:
+ax_pose 9, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose174:
+ax_pose 23, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose175:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose176:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose177:
+ax_pose 3, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose178:
+ax_pose 21, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose179:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose180:
+ax_pose 21, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose181:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose182:
+ax_pose 23, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose183:
+ax_pose 24, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose184:
+ax_pose 23, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose185:
+ax_pose 22, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose186:
+ax_pose 21, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose187:
+ax_pose 15, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose188:
+ax_pose 16, 0x01ed, 0x90ed, 0x4c00
+ax_pose_terminator
+sVulpixPose189:
+ax_pose 17, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sVulpixPose190:
+ax_pose 18, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sVulpixPose191:
+ax_pose 19, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose192:
+ax_pose 18, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose193:
+ax_pose 17, 0x01eb, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose194:
+ax_pose 16, 0x01ed, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose195:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose196:
+ax_pose 1, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose197:
+ax_pose 2, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose198:
+ax_pose 3, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose199:
+ax_pose 4, 0x01ef, 0x90ea, 0x4c00
+ax_pose_terminator
+sVulpixPose200:
+ax_pose 5, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose201:
+ax_pose 6, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose202:
+ax_pose 7, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sVulpixPose203:
+ax_pose 8, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sVulpixPose204:
+ax_pose 9, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose205:
+ax_pose 10, 0x01ea, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose206:
+ax_pose 11, 0x01ea, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose207:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose208:
+ax_pose 13, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose209:
+ax_pose 14, 0x01ea, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose210:
+ax_pose 9, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose211:
+ax_pose 10, 0x01ec, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose212:
+ax_pose 11, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose213:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose214:
+ax_pose 7, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose215:
+ax_pose 8, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose216:
+ax_pose 3, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose217:
+ax_pose 4, 0x01ef, 0x80f5, 0x4c00
+ax_pose_terminator
+sVulpixPose218:
+ax_pose 5, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose219:
+ax_pose 20, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose220:
+ax_pose 21, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose221:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose222:
+ax_pose 23, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose223:
+ax_pose 24, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose224:
+ax_pose 23, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose225:
+ax_pose 22, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose226:
+ax_pose 21, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+sVulpixPose227:
+ax_pose 0, 0x01ed, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose228:
+ax_pose 3, 0x01ee, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose229:
+ax_pose 6, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sVulpixPose230:
+ax_pose 9, 0x01ec, 0x80f1, 0x4c00
+ax_pose_terminator
+sVulpixPose231:
+ax_pose 12, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sVulpixPose232:
+ax_pose 9, 0x01ec, 0x90ee, 0x4c00
+ax_pose_terminator
+sVulpixPose233:
+ax_pose 6, 0x01eb, 0x90ec, 0x4c00
+ax_pose_terminator
+sVulpixPose234:
+ax_pose 3, 0x01ee, 0x90eb, 0x4c00
+ax_pose_terminator
+.align 2
+sVulpixAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 1,
+ax_anim 4, 0, 1, 0, -2, 0, 3,
+ax_anim 4, 0, 2, 0, -2, 0, 2,
+ax_anim 6, 0, 2, 0, 2, 0, 1,
+ax_anim_terminator
+sVulpixAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 1, 1,
+ax_anim 4, 0, 4, 1, 0, 3, 3,
+ax_anim 4, 0, 5, 3, 1, 3, 3,
+ax_anim 6, 0, 5, 1, 1, 1, 1,
+ax_anim_terminator
+sVulpixAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, -1, 0, 1, 0,
+ax_anim 4, 0, 7, 1, -1, 2, 0,
+ax_anim 4, 0, 8, 2, 0, 4, 0,
+ax_anim 6, 0, 8, 0, 0, 2, 0,
+ax_anim_terminator
+sVulpixAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, -2, 0, 1, -1,
+ax_anim 4, 0, 10, 1, -2, 3, -3,
+ax_anim 4, 0, 11, 1, -1, 4, -4,
+ax_anim 6, 0, 11, -2, 2, 2, -2,
+ax_anim_terminator
+sVulpixAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, -1,
+ax_anim 4, 0, 13, 0, -2, 0, -2,
+ax_anim 4, 0, 14, 0, -3, 0, -3,
+ax_anim 6, 0, 14, 0, -1, 0, -1,
+ax_anim_terminator
+sVulpixAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 2, 0, -1, -1,
+ax_anim 4, 0, 16, -1, -2, -3, -3,
+ax_anim 4, 0, 17, -1, -1, -4, -4,
+ax_anim 6, 0, 17, 2, 2, -2, -2,
+ax_anim_terminator
+sVulpixAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 1, 0, -1, 0,
+ax_anim 4, 0, 19, -1, -1, -2, 0,
+ax_anim 4, 0, 20, -2, 0, -4, 0,
+ax_anim 6, 0, 20, 0, 0, -2, 0,
+ax_anim_terminator
+sVulpixAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, 0, -1, 1,
+ax_anim 4, 0, 22, -1, 0, -3, 3,
+ax_anim 4, 0, 23, -3, 1, -3, 3,
+ax_anim 6, 0, 23, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sVulpixAnims_2_1:
+ax_anim 4, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 6, 0, 27, 0, -3, 0, -3,
+ax_anim 1, 0, 25, 0, 0, 0, 1,
+ax_anim 1, 0, 25, 0, 4, 0, 6,
+ax_anim 2, 2, 26, 0, 10, 0, 13,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sVulpixAnims_2_2:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -2, -2, -2, -2,
+ax_anim 6, 0, 31, -5, -5, -5, -5,
+ax_anim 1, 0, 29, 2, 1, 0, 0,
+ax_anim 1, 0, 29, 7, 5, 4, 4,
+ax_anim 2, 2, 29, 12, 10, 10, 10,
+ax_anim 2, 0, 30, 21, 21, 21, 21,
+ax_anim 2, 1, 30, 22, 20, 22, 20,
+ax_anim 2, 0, 30, 21, 21, 21, 21,
+ax_anim 2, 0, 30, 22, 20, 22, 20,
+ax_anim 2, 0, 28, 10, 8, 10, 10,
+ax_anim_terminator
+sVulpixAnims_2_3:
+ax_anim 4, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 2, -1, 0,
+ax_anim 6, 0, 35, -5, 0, -5, 0,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 0, 33, 5, -1, 5, 0,
+ax_anim 2, 2, 33, 12, 0, 12, 0,
+ax_anim 2, 0, 34, 19, -1, 19, 0,
+ax_anim 2, 1, 34, 19, 0, 19, 1,
+ax_anim 2, 0, 34, 19, -1, 19, 0,
+ax_anim 2, 0, 34, 19, 0, 19, 1,
+ax_anim 2, 0, 32, 6, -2, 6, 0,
+ax_anim_terminator
+sVulpixAnims_2_4:
+ax_anim 4, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -2, 3, -1, 1,
+ax_anim 6, 0, 39, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 2, -3, 2, -2,
+ax_anim 1, 0, 37, 6, -10, 6, -6,
+ax_anim 2, 2, 37, 12, -17, 12, -12,
+ax_anim 2, 0, 38, 22, -22, 22, -22,
+ax_anim 2, 1, 38, 21, -23, 21, -23,
+ax_anim 2, 0, 38, 22, -22, 22, -22,
+ax_anim 2, 0, 38, 21, -23, 21, -23,
+ax_anim 2, 0, 36, 6, -8, 6, -6,
+ax_anim_terminator
+sVulpixAnims_2_5:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 6, 0, 43, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, -1, 0, 0,
+ax_anim 1, 0, 41, 0, -6, 0, -4,
+ax_anim 2, 2, 41, 0, -12, 0, -10,
+ax_anim 2, 0, 42, 0, -22, 0, -22,
+ax_anim 2, 1, 42, 1, -22, 1, -22,
+ax_anim 2, 0, 42, 0, -22, 0, -22,
+ax_anim 2, 0, 42, 1, -22, 1, -22,
+ax_anim 2, 0, 40, 0, -8, 0, -6,
+ax_anim_terminator
+sVulpixAnims_2_6:
+ax_anim 4, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 2, 3, 1, 1,
+ax_anim 6, 0, 47, 2, 2, 2, 2,
+ax_anim 1, 0, 45, -2, -3, -2, -2,
+ax_anim 1, 0, 45, -6, -10, -6, -6,
+ax_anim 2, 2, 45, -12, -17, -12, -12,
+ax_anim 2, 0, 46, -22, -22, -22, -22,
+ax_anim 2, 1, 46, -21, -23, -21, -23,
+ax_anim 2, 0, 46, -22, -22, -22, -22,
+ax_anim 2, 0, 46, -21, -23, -21, -23,
+ax_anim 2, 0, 44, -6, -8, -6, -6,
+ax_anim_terminator
+sVulpixAnims_2_7:
+ax_anim 4, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 2, 1, 0,
+ax_anim 6, 0, 51, 5, 0, 5, 0,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 0, 49, -5, -1, -5, 0,
+ax_anim 2, 2, 49, -12, 0, -12, 0,
+ax_anim 2, 0, 50, -19, -1, -19, 0,
+ax_anim 2, 1, 50, -19, 0, -19, 1,
+ax_anim 2, 0, 50, -19, -1, -19, 0,
+ax_anim 2, 0, 50, -19, 0, -19, 1,
+ax_anim 2, 0, 48, -6, -2, -6, 0,
+ax_anim_terminator
+sVulpixAnims_2_8:
+ax_anim 4, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 2, -2, 2, -2,
+ax_anim 6, 0, 55, 5, -5, 5, -5,
+ax_anim 1, 0, 53, -2, 1, 0, 0,
+ax_anim 1, 0, 53, -7, 5, -4, 4,
+ax_anim 2, 2, 53, -12, 10, -10, 10,
+ax_anim 2, 0, 54, -21, 21, -21, 21,
+ax_anim 2, 1, 54, -22, 20, -22, 20,
+ax_anim 2, 0, 54, -21, 21, -21, 21,
+ax_anim 2, 0, 54, -22, 20, -22, 20,
+ax_anim 2, 0, 52, -10, 8, -10, 10,
+ax_anim_terminator
+.align 2
+sVulpixAnims_3_1:
+ax_anim 4, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 6, 0, 59, 0, -3, 0, -3,
+ax_anim 1, 0, 57, 0, 0, 0, 1,
+ax_anim 1, 0, 57, 0, 4, 0, 6,
+ax_anim 2, 2, 58, 0, 10, 0, 13,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 1, 58, 1, 18, 1, 18,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 0, 58, 1, 18, 1, 18,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sVulpixAnims_3_2:
+ax_anim 4, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 61, -2, -2, -2, -2,
+ax_anim 6, 0, 63, -5, -5, -5, -5,
+ax_anim 1, 0, 61, 2, 1, 0, 0,
+ax_anim 1, 0, 61, 7, 5, 4, 4,
+ax_anim 2, 2, 61, 12, 10, 10, 10,
+ax_anim 2, 0, 62, 21, 21, 21, 21,
+ax_anim 2, 1, 62, 22, 20, 22, 20,
+ax_anim 2, 0, 62, 21, 21, 21, 21,
+ax_anim 2, 0, 62, 22, 20, 22, 20,
+ax_anim 2, 0, 60, 10, 8, 10, 10,
+ax_anim_terminator
+sVulpixAnims_3_3:
+ax_anim 4, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 65, -1, 2, -1, 0,
+ax_anim 6, 0, 67, -5, 0, -5, 0,
+ax_anim 1, 0, 65, 0, 0, 0, 0,
+ax_anim 1, 0, 65, 5, -1, 5, 0,
+ax_anim 2, 2, 65, 12, 0, 12, 0,
+ax_anim 2, 0, 66, 19, -1, 19, 0,
+ax_anim 2, 1, 66, 19, 0, 19, 1,
+ax_anim 2, 0, 66, 19, -1, 19, 0,
+ax_anim 2, 0, 66, 19, 0, 19, 1,
+ax_anim 2, 0, 64, 6, -2, 6, 0,
+ax_anim_terminator
+sVulpixAnims_3_4:
+ax_anim 4, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 69, -2, 3, -1, 1,
+ax_anim 6, 0, 71, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 2, -3, 2, -2,
+ax_anim 1, 0, 69, 6, -10, 6, -6,
+ax_anim 2, 2, 69, 12, -17, 12, -12,
+ax_anim 2, 0, 70, 22, -22, 22, -22,
+ax_anim 2, 1, 70, 21, -23, 21, -23,
+ax_anim 2, 0, 70, 22, -22, 22, -22,
+ax_anim 2, 0, 70, 21, -23, 21, -23,
+ax_anim 2, 0, 68, 6, -8, 6, -6,
+ax_anim_terminator
+sVulpixAnims_3_5:
+ax_anim 4, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 6, 0, 75, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, -1, 0, 0,
+ax_anim 1, 0, 73, 0, -6, 0, -4,
+ax_anim 2, 2, 73, 0, -12, 0, -10,
+ax_anim 2, 0, 74, 0, -22, 0, -22,
+ax_anim 2, 1, 74, 1, -22, 1, -22,
+ax_anim 2, 0, 74, 0, -22, 0, -22,
+ax_anim 2, 0, 74, 1, -22, 1, -22,
+ax_anim 2, 0, 72, 0, -8, 0, -6,
+ax_anim_terminator
+sVulpixAnims_3_6:
+ax_anim 4, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 2, 3, 1, 1,
+ax_anim 6, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 0, 77, -2, -3, -2, -2,
+ax_anim 1, 0, 77, -6, -10, -6, -6,
+ax_anim 2, 2, 77, -12, -17, -12, -12,
+ax_anim 2, 0, 78, -22, -22, -22, -22,
+ax_anim 2, 1, 78, -21, -23, -21, -23,
+ax_anim 2, 0, 78, -22, -22, -22, -22,
+ax_anim 2, 0, 78, -21, -23, -21, -23,
+ax_anim 2, 0, 76, -6, -8, -6, -6,
+ax_anim_terminator
+sVulpixAnims_3_7:
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 2, 1, 0,
+ax_anim 6, 0, 83, 5, 0, 5, 0,
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 81, -5, -1, -5, 0,
+ax_anim 2, 2, 81, -12, 0, -12, 0,
+ax_anim 2, 0, 82, -19, -1, -19, 0,
+ax_anim 2, 1, 82, -19, 0, -19, 1,
+ax_anim 2, 0, 82, -19, -1, -19, 0,
+ax_anim 2, 0, 82, -19, 0, -19, 1,
+ax_anim 2, 0, 80, -6, -2, -6, 0,
+ax_anim_terminator
+sVulpixAnims_3_8:
+ax_anim 4, 0, 86, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 2, -2, 2, -2,
+ax_anim 6, 0, 87, 5, -5, 5, -5,
+ax_anim 1, 0, 85, -2, 1, 0, 0,
+ax_anim 1, 0, 85, -7, 5, -4, 4,
+ax_anim 2, 2, 85, -12, 10, -10, 10,
+ax_anim 2, 0, 86, -21, 21, -21, 21,
+ax_anim 2, 1, 86, -22, 20, -22, 20,
+ax_anim 2, 0, 86, -21, 21, -21, 21,
+ax_anim 2, 0, 86, -22, 20, -22, 20,
+ax_anim 2, 0, 84, -10, 8, -10, 10,
+ax_anim_terminator
+.align 2
+sVulpixAnims_4_1:
+ax_anim 2, 0, 90, 0, -2, 0, -2,
+ax_anim 6, 2, 90, 0, -3, 0, -3,
+ax_anim 1, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, 0, 2, 0, 2,
+ax_anim 2, 1, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 89, 0, 3, 0, 3,
+ax_anim 2, 0, 89, 1, 3, 1, 3,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sVulpixAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 6, 2, 93, -3, -3, -3, -3,
+ax_anim 1, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 0, 92, 2, 2, 2, 2,
+ax_anim 2, 1, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 4, 2, 4, 2,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 4, 2, 4, 2,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 4, 2, 4, 2,
+ax_anim 2, 0, 92, 3, 3, 3, 3,
+ax_anim 2, 0, 92, 4, 2, 4, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sVulpixAnims_4_3:
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim 6, 2, 96, -3, 0, -3, 0,
+ax_anim 1, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 0, 95, 2, 0, 2, 0,
+ax_anim 2, 1, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, 1, 3, 1,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, 1, 3, 1,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, 1, 3, 1,
+ax_anim 2, 0, 95, 3, 0, 3, 0,
+ax_anim 2, 0, 95, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sVulpixAnims_4_4:
+ax_anim 2, 0, 99, -2, 2, -2, 2,
+ax_anim 6, 2, 99, -3, 3, -3, 3,
+ax_anim 1, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 0, 98, 2, -2, 2, -2,
+ax_anim 2, 1, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, 4, -2, 4, -2,
+ax_anim 2, 0, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, 4, -2, 4, -2,
+ax_anim 2, 0, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, 4, -2, 4, -2,
+ax_anim 2, 0, 98, 3, -3, 3, -3,
+ax_anim 2, 0, 98, 4, -2, 4, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sVulpixAnims_4_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 6, 2, 102, 0, 3, 0, 3,
+ax_anim 1, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 1, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 101, 0, -3, 0, -3,
+ax_anim 2, 0, 101, 0, -2, 0, -2,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sVulpixAnims_4_6:
+ax_anim 2, 0, 105, 2, 2, 2, 2,
+ax_anim 6, 2, 105, 3, 3, 3, 3,
+ax_anim 1, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 0, 104, -2, -2, -2, -2,
+ax_anim 2, 1, 104, -3, -3, -3, -3,
+ax_anim 2, 0, 104, -4, -2, -4, -2,
+ax_anim 2, 0, 104, -3, -3, -3, -3,
+ax_anim 2, 0, 104, -4, -2, -4, -2,
+ax_anim 2, 0, 104, -3, -3, -3, -3,
+ax_anim 2, 0, 104, -4, -2, -4, -2,
+ax_anim 2, 0, 104, -3, -3, -3, -3,
+ax_anim 2, 0, 104, -4, -2, -4, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sVulpixAnims_4_7:
+ax_anim 2, 0, 108, 2, 0, 2, 0,
+ax_anim 6, 2, 108, 3, 0, 3, 0,
+ax_anim 1, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 0, 107, -2, 0, -2, 0,
+ax_anim 2, 1, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, 1, -3, 1,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, 1, -3, 1,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, 1, -3, 1,
+ax_anim 2, 0, 107, -3, 0, -3, 0,
+ax_anim 2, 0, 107, -3, 1, -3, 1,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sVulpixAnims_4_8:
+ax_anim 2, 0, 111, 2, -2, 2, -2,
+ax_anim 6, 2, 111, 3, -3, 3, -3,
+ax_anim 1, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 0, 110, -2, 2, -2, 2,
+ax_anim 2, 1, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 110, -4, 2, -4, 2,
+ax_anim 2, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 110, -4, 2, -4, 2,
+ax_anim 2, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 110, -4, 2, -4, 2,
+ax_anim 2, 0, 110, -3, 3, -3, 3,
+ax_anim 2, 0, 110, -4, 2, -4, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sVulpixAnims_5_1:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -2, 0, 0,
+ax_anim 3, 0, 114, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 2, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 1, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_5_2:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, -2, 0, 0,
+ax_anim 3, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 119, 0, -2, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_5_3:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 3, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 2, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 3, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 1, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_5_4:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -2, 0, 0,
+ax_anim 3, 0, 129, 0, -3, 0, 0,
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_5_5:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim 3, 0, 134, 0, -3, 0, 0,
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 2, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 1, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_5_6:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, -2, 0, 0,
+ax_anim 3, 0, 139, 0, -3, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 3, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_5_7:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 3, 0, 144, 0, -3, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 2, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 3, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_5_8:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim 3, 0, 149, 0, -3, 0, 0,
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 2, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 3, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 1, 149, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVulpixAnims_6_1:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 35, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVulpixAnims_7_1:
+ax_anim 2, 0, 154, 0, -2, 0, -2,
+ax_anim 8, 0, 154, 0, -3, 0, -3,
+ax_anim_terminator
+sVulpixAnims_7_2:
+ax_anim 2, 0, 155, -3, -3, -3, -3,
+ax_anim 8, 0, 155, -4, -4, -4, -4,
+ax_anim_terminator
+sVulpixAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sVulpixAnims_7_4:
+ax_anim 2, 0, 157, -3, 3, -3, 3,
+ax_anim 8, 0, 157, -4, 4, -4, 4,
+ax_anim_terminator
+sVulpixAnims_7_5:
+ax_anim 2, 0, 158, 0, 2, 0, 2,
+ax_anim 8, 0, 158, 0, 3, 0, 3,
+ax_anim_terminator
+sVulpixAnims_7_6:
+ax_anim 2, 0, 159, 3, 3, 3, 3,
+ax_anim 8, 0, 159, 4, 4, 4, 4,
+ax_anim_terminator
+sVulpixAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sVulpixAnims_7_8:
+ax_anim 2, 0, 161, 3, -3, 3, -3,
+ax_anim 8, 0, 161, 4, -4, 4, -4,
+ax_anim_terminator
+.align 2
+sVulpixAnims_8_1:
+ax_anim 40, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim 20, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_8_2:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim 20, 0, 164, 0, 0, 0, 0,
+ax_anim 12, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_8_3:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim 20, 0, 166, 0, 0, 0, 0,
+ax_anim 12, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_8_4:
+ax_anim 40, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim 20, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_8_5:
+ax_anim 40, 0, 170, 0, 0, 0, 0,
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim 20, 0, 170, 0, 0, 0, 0,
+ax_anim 12, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_8_6:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim 20, 0, 172, 0, 0, 0, 0,
+ax_anim 12, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_8_7:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 175, 0, 0, 0, 0,
+ax_anim 20, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_8_8:
+ax_anim 40, 0, 176, 0, 0, 0, 0,
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim 20, 0, 176, 0, 0, 0, 0,
+ax_anim 12, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVulpixAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 15, 7, 15,
+ax_anim 3, 0, 182, 0, 18, 0, 18,
+ax_anim 2, 3, 183, -7, 15, -7, 15,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 19, 3, 19, 3,
+ax_anim 2, 0, 180, 23, 10, 23, 10,
+ax_anim 3, 0, 181, 22, 18, 22, 18,
+ax_anim 2, 3, 182, 11, 19, 11, 19,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 17, -7, 17, -7,
+ax_anim 3, 0, 180, 22, -2, 22, -2,
+ax_anim 2, 3, 181, 17, 4, 17, 4,
+ax_anim 2, 0, 182, 12, 5, 12, 5,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 21, -25, 21, -25,
+ax_anim 2, 3, 180, 22, -15, 22, -15,
+ax_anim 2, 0, 181, 17, -4, 17, -4,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -12, -9, -12,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -24, 0, -24,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -21, -25, -21, -25,
+ax_anim 2, 3, 184, -22, -15, -22, -15,
+ax_anim 2, 0, 183, -17, -4, -17, -4,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -17, -7, -17, -7,
+ax_anim 3, 0, 184, -22, -2, -22, -2,
+ax_anim 2, 3, 183, -17, 4, -17, 4,
+ax_anim 2, 0, 182, -12, 5, -12, 5,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -19, 3, -19, 3,
+ax_anim 2, 0, 184, -23, 10, -23, 10,
+ax_anim 3, 0, 183, -22, 18, -22, 18,
+ax_anim 2, 3, 182, -11, 19, -11, 19,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVulpixAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVulpixAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -24, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -25, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -25, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -22, 0, 0,
+ax_anim 4, 0, 211, 0, -22, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -24, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -25, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVulpixAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sVulpixAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sVulpixGfx1:
+.incbin "baserom.gba", 0x69CC2C, 0x200
+sVulpixSprites1:
+ax_sprite sVulpixGfx1, 0x200
+ax_sprite_terminator
+sVulpixGfx2:
+.incbin "baserom.gba", 0x69CE3C, 0x200
+sVulpixSprites2:
+ax_sprite sVulpixGfx2, 0x200
+ax_sprite_terminator
+sVulpixGfx3:
+.incbin "baserom.gba", 0x69D04C, 0x200
+sVulpixSprites3:
+ax_sprite sVulpixGfx3, 0x200
+ax_sprite_terminator
+sVulpixGfx4:
+.incbin "baserom.gba", 0x69D25C, 0x200
+sVulpixSprites4:
+ax_sprite sVulpixGfx4, 0x200
+ax_sprite_terminator
+sVulpixGfx5:
+.incbin "baserom.gba", 0x69D46C, 0x200
+sVulpixSprites5:
+ax_sprite sVulpixGfx5, 0x200
+ax_sprite_terminator
+sVulpixGfx6:
+.incbin "baserom.gba", 0x69D67C, 0x200
+sVulpixSprites6:
+ax_sprite sVulpixGfx6, 0x200
+ax_sprite_terminator
+sVulpixGfx7:
+.incbin "baserom.gba", 0x69D88C, 0x200
+sVulpixSprites7:
+ax_sprite sVulpixGfx7, 0x200
+ax_sprite_terminator
+sVulpixGfx8:
+.incbin "baserom.gba", 0x69DA9C, 0x200
+sVulpixSprites8:
+ax_sprite sVulpixGfx8, 0x200
+ax_sprite_terminator
+sVulpixGfx9:
+.incbin "baserom.gba", 0x69DCAC, 0x200
+sVulpixSprites9:
+ax_sprite sVulpixGfx9, 0x200
+ax_sprite_terminator
+sVulpixGfx10:
+.incbin "baserom.gba", 0x69DEBC, 0x200
+sVulpixSprites10:
+ax_sprite sVulpixGfx10, 0x200
+ax_sprite_terminator
+sVulpixGfx11:
+.incbin "baserom.gba", 0x69E0CC, 0x200
+sVulpixSprites11:
+ax_sprite sVulpixGfx11, 0x200
+ax_sprite_terminator
+sVulpixGfx12:
+.incbin "baserom.gba", 0x69E2DC, 0x200
+sVulpixSprites12:
+ax_sprite sVulpixGfx12, 0x200
+ax_sprite_terminator
+sVulpixGfx13:
+.incbin "baserom.gba", 0x69E4EC, 0x200
+sVulpixSprites13:
+ax_sprite sVulpixGfx13, 0x200
+ax_sprite_terminator
+sVulpixGfx14:
+.incbin "baserom.gba", 0x69E6FC, 0x200
+sVulpixSprites14:
+ax_sprite sVulpixGfx14, 0x200
+ax_sprite_terminator
+sVulpixGfx15:
+.incbin "baserom.gba", 0x69E90C, 0x200
+sVulpixSprites15:
+ax_sprite sVulpixGfx15, 0x200
+ax_sprite_terminator
+sVulpixGfx16:
+.incbin "baserom.gba", 0x69EB1C, 0x60
+sVulpixGfx16_1:
+.incbin "baserom.gba", 0x69EB7C, 0x60
+sVulpixGfx16_2:
+.incbin "baserom.gba", 0x69EBDC, 0x60
+sVulpixSprites16:
+ax_sprite sVulpixGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx17:
+.incbin "baserom.gba", 0x69EC74, 0x60
+sVulpixGfx17_1:
+.incbin "baserom.gba", 0x69ECD4, 0x60
+sVulpixGfx17_2:
+.incbin "baserom.gba", 0x69ED34, 0x40
+sVulpixSprites17:
+ax_sprite sVulpixGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVulpixGfx17_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx18:
+.incbin "baserom.gba", 0x69EDAC, 0x40
+sVulpixGfx18_1:
+.incbin "baserom.gba", 0x69EDEC, 0x80
+sVulpixGfx18_2:
+.incbin "baserom.gba", 0x69EE6C, 0x60
+sVulpixSprites18:
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx18_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx18_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVulpixGfx19:
+.incbin "baserom.gba", 0x69EF0C, 0x40
+sVulpixGfx19_1:
+.incbin "baserom.gba", 0x69EF4C, 0x80
+sVulpixGfx19_2:
+.incbin "baserom.gba", 0x69EFCC, 0x60
+sVulpixSprites19:
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx19_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx19_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVulpixGfx20:
+.incbin "baserom.gba", 0x69F06C, 0x60
+sVulpixGfx20_1:
+.incbin "baserom.gba", 0x69F0CC, 0x60
+sVulpixGfx20_2:
+.incbin "baserom.gba", 0x69F12C, 0x60
+sVulpixSprites20:
+ax_sprite sVulpixGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx21:
+.incbin "baserom.gba", 0x69F1C4, 0x60
+sVulpixGfx21_1:
+.incbin "baserom.gba", 0x69F224, 0x60
+sVulpixGfx21_2:
+.incbin "baserom.gba", 0x69F284, 0x60
+sVulpixSprites21:
+ax_sprite sVulpixGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx22:
+.incbin "baserom.gba", 0x69F31C, 0x60
+sVulpixGfx22_1:
+.incbin "baserom.gba", 0x69F37C, 0x60
+sVulpixGfx22_2:
+.incbin "baserom.gba", 0x69F3DC, 0x60
+sVulpixSprites22:
+ax_sprite sVulpixGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx23:
+.incbin "baserom.gba", 0x69F474, 0x60
+sVulpixGfx23_1:
+.incbin "baserom.gba", 0x69F4D4, 0x60
+sVulpixGfx23_2:
+.incbin "baserom.gba", 0x69F534, 0x60
+sVulpixSprites23:
+ax_sprite sVulpixGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx24:
+.incbin "baserom.gba", 0x69F5CC, 0x60
+sVulpixGfx24_1:
+.incbin "baserom.gba", 0x69F62C, 0x60
+sVulpixGfx24_2:
+.incbin "baserom.gba", 0x69F68C, 0x60
+sVulpixSprites24:
+ax_sprite sVulpixGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx25:
+.incbin "baserom.gba", 0x69F724, 0x60
+sVulpixGfx25_1:
+.incbin "baserom.gba", 0x69F784, 0x60
+sVulpixGfx25_2:
+.incbin "baserom.gba", 0x69F7E4, 0x60
+sVulpixSprites25:
+ax_sprite sVulpixGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx26:
+.incbin "baserom.gba", 0x69F87C, 0x60
+sVulpixGfx26_1:
+.incbin "baserom.gba", 0x69F8DC, 0x60
+sVulpixGfx26_2:
+.incbin "baserom.gba", 0x69F93C, 0x60
+sVulpixSprites26:
+ax_sprite sVulpixGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx26_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx27:
+.incbin "baserom.gba", 0x69F9D4, 0x60
+sVulpixGfx27_1:
+.incbin "baserom.gba", 0x69FA34, 0x60
+sVulpixGfx27_2:
+.incbin "baserom.gba", 0x69FA94, 0x60
+sVulpixSprites27:
+ax_sprite sVulpixGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx27_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx28:
+.incbin "baserom.gba", 0x69FB2C, 0x40
+sVulpixGfx28_1:
+.incbin "baserom.gba", 0x69FB6C, 0x60
+sVulpixGfx28_2:
+.incbin "baserom.gba", 0x69FBCC, 0x40
+sVulpixSprites28:
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx28_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVulpixGfx28_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx29:
+.incbin "baserom.gba", 0x69FC4C, 0x60
+sVulpixGfx29_1:
+.incbin "baserom.gba", 0x69FCAC, 0x60
+sVulpixGfx29_2:
+.incbin "baserom.gba", 0x69FD0C, 0x40
+sVulpixSprites29:
+ax_sprite sVulpixGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx29_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVulpixGfx29_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx30:
+.incbin "baserom.gba", 0x69FD84, 0x40
+sVulpixGfx30_1:
+.incbin "baserom.gba", 0x69FDC4, 0x60
+sVulpixGfx30_2:
+.incbin "baserom.gba", 0x69FE24, 0x60
+sVulpixSprites30:
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx30, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVulpixGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx30_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVulpixGfx31:
+.incbin "baserom.gba", 0x69FEC4, 0x40
+sVulpixGfx31_1:
+.incbin "baserom.gba", 0x69FF04, 0x60
+sVulpixGfx31_2:
+.incbin "baserom.gba", 0x69FF64, 0x40
+sVulpixSprites31:
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx31, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx31_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sVulpixGfx31_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx32:
+.incbin "baserom.gba", 0x69FFE4, 0x40
+sVulpixGfx32_1:
+.incbin "baserom.gba", 0x6A0024, 0x80
+sVulpixGfx32_2:
+.incbin "baserom.gba", 0x6A00A4, 0x60
+sVulpixSprites32:
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx32_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx32_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVulpixGfx33:
+.incbin "baserom.gba", 0x6A0144, 0x40
+sVulpixGfx33_1:
+.incbin "baserom.gba", 0x6A0184, 0x60
+sVulpixGfx33_2:
+.incbin "baserom.gba", 0x6A01E4, 0x60
+sVulpixSprites33:
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sVulpixGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx33_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sVulpixGfx34:
+.incbin "baserom.gba", 0x6A0284, 0x60
+sVulpixGfx34_1:
+.incbin "baserom.gba", 0x6A02E4, 0x60
+sVulpixGfx34_2:
+.incbin "baserom.gba", 0x6A0344, 0x60
+sVulpixSprites34:
+ax_sprite sVulpixGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx34_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx35:
+.incbin "baserom.gba", 0x6A03DC, 0x60
+sVulpixGfx35_1:
+.incbin "baserom.gba", 0x6A043C, 0x60
+sVulpixGfx35_2:
+.incbin "baserom.gba", 0x6A049C, 0x60
+sVulpixSprites35:
+ax_sprite sVulpixGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sVulpixGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sVulpixGfx36:
+.incbin "baserom.gba", 0x6A0534, 0x200
+sVulpixSprites36:
+ax_sprite sVulpixGfx36, 0x200
+ax_sprite_terminator
+sVulpixGfx37:
+.incbin "baserom.gba", 0x6A0744, 0x200
+sVulpixSprites37:
+ax_sprite sVulpixGfx37, 0x200
+ax_sprite_terminator
+sVulpixGfx38:
+.incbin "baserom.gba", 0x6A0954, 0x200
+sVulpixSprites38:
+ax_sprite sVulpixGfx38, 0x200
+ax_sprite_terminator
+sVulpixGfx39:
+.incbin "baserom.gba", 0x6A0B64, 0x200
+sVulpixSprites39:
+ax_sprite sVulpixGfx39, 0x200
+ax_sprite_terminator
+sVulpixGfx40:
+.incbin "baserom.gba", 0x6A0D74, 0x200
+sVulpixSprites40:
+ax_sprite sVulpixGfx40, 0x200
+ax_sprite_terminator
+sVulpixGfx41:
+.incbin "baserom.gba", 0x6A0F84, 0x200
+sVulpixSprites41:
+ax_sprite sVulpixGfx41, 0x200
+ax_sprite_terminator
+sVulpixGfx42:
+.incbin "baserom.gba", 0x6A1194, 0x200
+sVulpixSprites42:
+ax_sprite sVulpixGfx42, 0x200
+ax_sprite_terminator
+sAxPosesVulpix:
+.4byte sVulpixPose1
+.4byte sVulpixPose2
+.4byte sVulpixPose3
+.4byte sVulpixPose4
+.4byte sVulpixPose5
+.4byte sVulpixPose6
+.4byte sVulpixPose7
+.4byte sVulpixPose8
+.4byte sVulpixPose9
+.4byte sVulpixPose10
+.4byte sVulpixPose11
+.4byte sVulpixPose12
+.4byte sVulpixPose13
+.4byte sVulpixPose14
+.4byte sVulpixPose15
+.4byte sVulpixPose16
+.4byte sVulpixPose17
+.4byte sVulpixPose18
+.4byte sVulpixPose19
+.4byte sVulpixPose20
+.4byte sVulpixPose21
+.4byte sVulpixPose22
+.4byte sVulpixPose23
+.4byte sVulpixPose24
+.4byte sVulpixPose25
+.4byte sVulpixPose26
+.4byte sVulpixPose27
+.4byte sVulpixPose28
+.4byte sVulpixPose29
+.4byte sVulpixPose30
+.4byte sVulpixPose31
+.4byte sVulpixPose32
+.4byte sVulpixPose33
+.4byte sVulpixPose34
+.4byte sVulpixPose35
+.4byte sVulpixPose36
+.4byte sVulpixPose37
+.4byte sVulpixPose38
+.4byte sVulpixPose39
+.4byte sVulpixPose40
+.4byte sVulpixPose41
+.4byte sVulpixPose42
+.4byte sVulpixPose43
+.4byte sVulpixPose44
+.4byte sVulpixPose45
+.4byte sVulpixPose46
+.4byte sVulpixPose47
+.4byte sVulpixPose48
+.4byte sVulpixPose49
+.4byte sVulpixPose50
+.4byte sVulpixPose51
+.4byte sVulpixPose52
+.4byte sVulpixPose53
+.4byte sVulpixPose54
+.4byte sVulpixPose55
+.4byte sVulpixPose56
+.4byte sVulpixPose57
+.4byte sVulpixPose58
+.4byte sVulpixPose59
+.4byte sVulpixPose60
+.4byte sVulpixPose61
+.4byte sVulpixPose62
+.4byte sVulpixPose63
+.4byte sVulpixPose64
+.4byte sVulpixPose65
+.4byte sVulpixPose66
+.4byte sVulpixPose67
+.4byte sVulpixPose68
+.4byte sVulpixPose69
+.4byte sVulpixPose70
+.4byte sVulpixPose71
+.4byte sVulpixPose72
+.4byte sVulpixPose73
+.4byte sVulpixPose74
+.4byte sVulpixPose75
+.4byte sVulpixPose76
+.4byte sVulpixPose77
+.4byte sVulpixPose78
+.4byte sVulpixPose79
+.4byte sVulpixPose80
+.4byte sVulpixPose81
+.4byte sVulpixPose82
+.4byte sVulpixPose83
+.4byte sVulpixPose84
+.4byte sVulpixPose85
+.4byte sVulpixPose86
+.4byte sVulpixPose87
+.4byte sVulpixPose88
+.4byte sVulpixPose89
+.4byte sVulpixPose90
+.4byte sVulpixPose91
+.4byte sVulpixPose92
+.4byte sVulpixPose93
+.4byte sVulpixPose94
+.4byte sVulpixPose95
+.4byte sVulpixPose96
+.4byte sVulpixPose97
+.4byte sVulpixPose98
+.4byte sVulpixPose99
+.4byte sVulpixPose100
+.4byte sVulpixPose101
+.4byte sVulpixPose102
+.4byte sVulpixPose103
+.4byte sVulpixPose104
+.4byte sVulpixPose105
+.4byte sVulpixPose106
+.4byte sVulpixPose107
+.4byte sVulpixPose108
+.4byte sVulpixPose109
+.4byte sVulpixPose110
+.4byte sVulpixPose111
+.4byte sVulpixPose112
+.4byte sVulpixPose113
+.4byte sVulpixPose114
+.4byte sVulpixPose115
+.4byte sVulpixPose116
+.4byte sVulpixPose117
+.4byte sVulpixPose118
+.4byte sVulpixPose119
+.4byte sVulpixPose120
+.4byte sVulpixPose121
+.4byte sVulpixPose122
+.4byte sVulpixPose123
+.4byte sVulpixPose124
+.4byte sVulpixPose125
+.4byte sVulpixPose126
+.4byte sVulpixPose127
+.4byte sVulpixPose128
+.4byte sVulpixPose129
+.4byte sVulpixPose130
+.4byte sVulpixPose131
+.4byte sVulpixPose132
+.4byte sVulpixPose133
+.4byte sVulpixPose134
+.4byte sVulpixPose135
+.4byte sVulpixPose136
+.4byte sVulpixPose137
+.4byte sVulpixPose138
+.4byte sVulpixPose139
+.4byte sVulpixPose140
+.4byte sVulpixPose141
+.4byte sVulpixPose142
+.4byte sVulpixPose143
+.4byte sVulpixPose144
+.4byte sVulpixPose145
+.4byte sVulpixPose146
+.4byte sVulpixPose147
+.4byte sVulpixPose148
+.4byte sVulpixPose149
+.4byte sVulpixPose150
+.4byte sVulpixPose151
+.4byte sVulpixPose152
+.4byte sVulpixPose153
+.4byte sVulpixPose154
+.4byte sVulpixPose155
+.4byte sVulpixPose156
+.4byte sVulpixPose157
+.4byte sVulpixPose158
+.4byte sVulpixPose159
+.4byte sVulpixPose160
+.4byte sVulpixPose161
+.4byte sVulpixPose162
+.4byte sVulpixPose163
+.4byte sVulpixPose164
+.4byte sVulpixPose165
+.4byte sVulpixPose166
+.4byte sVulpixPose167
+.4byte sVulpixPose168
+.4byte sVulpixPose169
+.4byte sVulpixPose170
+.4byte sVulpixPose171
+.4byte sVulpixPose172
+.4byte sVulpixPose173
+.4byte sVulpixPose174
+.4byte sVulpixPose175
+.4byte sVulpixPose176
+.4byte sVulpixPose177
+.4byte sVulpixPose178
+.4byte sVulpixPose179
+.4byte sVulpixPose180
+.4byte sVulpixPose181
+.4byte sVulpixPose182
+.4byte sVulpixPose183
+.4byte sVulpixPose184
+.4byte sVulpixPose185
+.4byte sVulpixPose186
+.4byte sVulpixPose187
+.4byte sVulpixPose188
+.4byte sVulpixPose189
+.4byte sVulpixPose190
+.4byte sVulpixPose191
+.4byte sVulpixPose192
+.4byte sVulpixPose193
+.4byte sVulpixPose194
+.4byte sVulpixPose195
+.4byte sVulpixPose196
+.4byte sVulpixPose197
+.4byte sVulpixPose198
+.4byte sVulpixPose199
+.4byte sVulpixPose200
+.4byte sVulpixPose201
+.4byte sVulpixPose202
+.4byte sVulpixPose203
+.4byte sVulpixPose204
+.4byte sVulpixPose205
+.4byte sVulpixPose206
+.4byte sVulpixPose207
+.4byte sVulpixPose208
+.4byte sVulpixPose209
+.4byte sVulpixPose210
+.4byte sVulpixPose211
+.4byte sVulpixPose212
+.4byte sVulpixPose213
+.4byte sVulpixPose214
+.4byte sVulpixPose215
+.4byte sVulpixPose216
+.4byte sVulpixPose217
+.4byte sVulpixPose218
+.4byte sVulpixPose219
+.4byte sVulpixPose220
+.4byte sVulpixPose221
+.4byte sVulpixPose222
+.4byte sVulpixPose223
+.4byte sVulpixPose224
+.4byte sVulpixPose225
+.4byte sVulpixPose226
+.4byte sVulpixPose227
+.4byte sVulpixPose228
+.4byte sVulpixPose229
+.4byte sVulpixPose230
+.4byte sVulpixPose231
+.4byte sVulpixPose232
+.4byte sVulpixPose233
+.4byte sVulpixPose234
+sAxPositionsVulpix:
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -3, 	   3,   -3, 	  -1,   -9
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte    2,   -2, 	   4,    0, 	  -1,    2, 	  -2,   -6
+.2byte    4,   -5, 	   7,   -4, 	   2,   -2, 	  -1,   -8
+.2byte    4,    0, 	   5,    0, 	   0,    2, 	  -1,   -4
+.2byte    5,   -6, 	   3,   -1, 	   1,    0, 	  -2,   -6
+.2byte    7,   -9, 	   7,   -5, 	   5,   -5, 	   0,   -8
+.2byte    8,   -4, 	   3,   -1, 	   2,    0, 	   1,   -6
+.2byte    5,   -9, 	   0,   -3, 	   4,   -2, 	  -1,   -7
+.2byte    7,  -13, 	   4,  -10, 	   8,   -9, 	   0,  -10
+.2byte    8,  -10, 	   3,   -5, 	   7,   -4, 	   2,  -10
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte   -1,  -18, 	   3,  -12, 	  -5,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	   2,   -3, 	  -4,   -3, 	  -1,   -9
+.2byte   -7,   -9, 	  -2,   -3, 	  -6,   -2, 	  -1,   -7
+.2byte   -9,  -11, 	  -6,   -8, 	 -10,   -7, 	  -2,   -8
+.2byte  -10,   -8, 	  -5,   -3, 	  -9,   -2, 	  -4,   -8
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -9,   -9, 	  -9,   -5, 	  -7,   -5, 	  -2,   -8
+.2byte  -10,   -4, 	  -5,   -1, 	  -4,    0, 	  -3,   -6
+.2byte   -4,   -2, 	  -6,    0, 	  -1,    2, 	   0,   -6
+.2byte   -6,   -5, 	  -9,   -4, 	  -4,   -2, 	  -1,   -8
+.2byte   -6,    0, 	  -7,    0, 	  -2,    2, 	  -1,   -4
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -3, 	   3,   -3, 	  -1,   -9
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -7, 	  -1,   -8
+.2byte    3,   -3, 	   5,   -1, 	   0,    1, 	  -1,   -7
+.2byte    3,   -4, 	   6,   -3, 	   1,   -1, 	  -2,   -7
+.2byte    4,   -1, 	   5,   -1, 	   0,    1, 	  -1,   -5
+.2byte    2,  -11, 	   6,   -7, 	   0,   -7, 	  -2,   -8
+.2byte    6,   -6, 	   4,   -1, 	   2,    0, 	  -1,   -6
+.2byte    6,   -9, 	   6,   -5, 	   4,   -5, 	  -1,   -8
+.2byte    7,   -4, 	   2,   -1, 	   1,    0, 	   0,   -6
+.2byte    4,  -14, 	   6,   -8, 	   4,   -8, 	  -2,   -9
+.2byte    5,  -10, 	   0,   -4, 	   4,   -3, 	  -1,   -8
+.2byte    6,  -12, 	   3,   -9, 	   7,   -8, 	  -1,   -9
+.2byte    4,   -7, 	  -1,   -2, 	   3,   -1, 	  -2,   -7
+.2byte    2,  -13, 	  -1,  -10, 	   5,  -10, 	  -3,   -7
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte   -1,  -17, 	   3,  -11, 	  -5,  -11, 	  -1,   -9
+.2byte   -1,  -11, 	   2,   -2, 	  -4,   -2, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,   -8
+.2byte   -6,  -10, 	  -1,   -4, 	  -5,   -3, 	   0,   -8
+.2byte   -7,  -12, 	  -4,   -9, 	  -8,   -8, 	   0,   -9
+.2byte   -5,   -7, 	   0,   -2, 	  -4,   -1, 	   1,   -7
+.2byte   -3,  -13, 	   0,  -10, 	  -6,  -10, 	   2,   -7
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -7,   -9, 	  -7,   -5, 	  -5,   -5, 	   0,   -8
+.2byte   -8,   -4, 	  -3,   -1, 	  -2,    0, 	  -1,   -6
+.2byte   -5,  -14, 	  -7,   -8, 	  -5,   -8, 	   1,   -9
+.2byte   -4,   -3, 	  -6,   -1, 	  -1,    1, 	   0,   -7
+.2byte   -4,   -4, 	  -7,   -3, 	  -2,   -1, 	   1,   -7
+.2byte   -5,   -1, 	  -6,   -1, 	  -1,    1, 	   0,   -5
+.2byte   -3,  -11, 	  -7,   -7, 	  -1,   -7, 	   1,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -3, 	   3,   -3, 	  -1,   -9
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -7, 	  -1,   -8
+.2byte    3,   -3, 	   5,   -1, 	   0,    1, 	  -1,   -7
+.2byte    3,   -4, 	   6,   -3, 	   1,   -1, 	  -2,   -7
+.2byte    4,   -1, 	   5,   -1, 	   0,    1, 	  -1,   -5
+.2byte    2,  -11, 	   6,   -7, 	   0,   -7, 	  -2,   -8
+.2byte    6,   -6, 	   4,   -1, 	   2,    0, 	  -1,   -6
+.2byte    6,   -9, 	   6,   -5, 	   4,   -5, 	  -1,   -8
+.2byte    7,   -4, 	   2,   -1, 	   1,    0, 	   0,   -6
+.2byte    4,  -14, 	   6,   -8, 	   4,   -8, 	  -2,   -9
+.2byte    5,  -10, 	   0,   -4, 	   4,   -3, 	  -1,   -8
+.2byte    6,  -12, 	   3,   -9, 	   7,   -8, 	  -1,   -9
+.2byte    4,   -7, 	  -1,   -2, 	   3,   -1, 	  -2,   -7
+.2byte    2,  -13, 	  -1,  -10, 	   5,  -10, 	  -3,   -7
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte   -1,  -17, 	   3,  -11, 	  -5,  -11, 	  -1,   -9
+.2byte   -1,  -11, 	   2,   -2, 	  -4,   -2, 	  -1,   -8
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,   -8
+.2byte   -6,  -10, 	  -1,   -4, 	  -5,   -3, 	   0,   -8
+.2byte   -7,  -12, 	  -4,   -9, 	  -8,   -8, 	   0,   -9
+.2byte   -5,   -7, 	   0,   -2, 	  -4,   -1, 	   1,   -7
+.2byte   -3,  -13, 	   0,  -10, 	  -6,  -10, 	   2,   -7
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -7,   -9, 	  -7,   -5, 	  -5,   -5, 	   0,   -8
+.2byte   -8,   -4, 	  -3,   -1, 	  -2,    0, 	  -1,   -6
+.2byte   -5,  -14, 	  -7,   -8, 	  -5,   -8, 	   1,   -9
+.2byte   -4,   -3, 	  -6,   -1, 	  -1,    1, 	   0,   -7
+.2byte   -4,   -4, 	  -7,   -3, 	  -2,   -1, 	   1,   -7
+.2byte   -5,   -1, 	  -6,   -1, 	  -1,    1, 	   0,   -5
+.2byte   -3,  -11, 	  -7,   -7, 	  -1,   -7, 	   1,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,    0, 	  -5,    2, 	   3,    2, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -7, 	  -1,   -8
+.2byte    2,   -2, 	   4,    0, 	  -1,    2, 	  -2,   -6
+.2byte    3,   -1, 	   5,    1, 	  -1,    3, 	  -1,   -5
+.2byte    2,  -11, 	   6,   -7, 	   0,   -7, 	  -2,   -8
+.2byte    5,   -6, 	   3,   -1, 	   1,    0, 	  -2,   -6
+.2byte    6,   -4, 	   5,   -1, 	   3,    0, 	  -1,   -5
+.2byte    4,  -14, 	   6,   -8, 	   4,   -8, 	  -2,   -9
+.2byte    5,   -9, 	   0,   -3, 	   4,   -2, 	  -1,   -7
+.2byte    6,   -8, 	   1,   -4, 	   6,   -2, 	   0,   -6
+.2byte    2,  -13, 	  -1,  -10, 	   5,  -10, 	  -3,   -7
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -7
+.2byte   -1,  -16, 	   3,  -11, 	  -5,  -11, 	  -1,   -8
+.2byte   -7,   -9, 	  -2,   -3, 	  -6,   -2, 	  -1,   -7
+.2byte   -8,   -8, 	  -3,   -4, 	  -8,   -2, 	  -2,   -6
+.2byte   -3,  -13, 	   0,  -10, 	  -6,  -10, 	   2,   -7
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -8,   -4, 	  -7,   -1, 	  -5,    0, 	  -1,   -5
+.2byte   -5,  -14, 	  -7,   -8, 	  -5,   -8, 	   1,   -9
+.2byte   -4,   -2, 	  -6,    0, 	  -1,    2, 	   0,   -6
+.2byte   -5,   -1, 	  -7,    1, 	  -1,    3, 	  -1,   -5
+.2byte   -3,  -11, 	  -7,   -7, 	  -1,   -7, 	   1,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,    0, 	  -5,    2, 	   3,    2, 	  -1,   -7
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -7, 	  -1,   -8
+.2byte    0,   -9, 	  -4,   -7, 	   4,   -6, 	   0,   -8
+.2byte   -2,   -9, 	  -6,   -5, 	   2,   -8, 	  -2,   -8
+.2byte    3,   -2, 	   5,    0, 	   0,    2, 	  -1,   -6
+.2byte    4,   -1, 	   6,    1, 	   0,    3, 	   0,   -5
+.2byte    2,  -12, 	   6,   -8, 	   0,   -8, 	  -2,   -9
+.2byte    1,  -12, 	   5,  -10, 	  -1,   -7, 	  -2,   -9
+.2byte    3,  -12, 	   7,   -7, 	   1,   -9, 	   0,  -10
+.2byte    6,   -6, 	   4,   -1, 	   2,    0, 	  -1,   -6
+.2byte    7,   -4, 	   6,   -1, 	   4,    0, 	   0,   -5
+.2byte    3,  -13, 	   5,   -7, 	   3,   -7, 	  -3,   -8
+.2byte    2,  -12, 	   4,   -7, 	   2,   -5, 	  -4,   -7
+.2byte    4,  -13, 	   5,   -6, 	   4,   -8, 	  -2,   -8
+.2byte    5,   -9, 	   0,   -3, 	   4,   -2, 	  -1,   -7
+.2byte    6,   -8, 	   1,   -4, 	   6,   -2, 	   0,   -6
+.2byte    2,  -13, 	  -1,  -10, 	   5,  -10, 	  -3,   -7
+.2byte    3,  -13, 	   0,  -11, 	   6,   -8, 	  -2,   -7
+.2byte    1,  -13, 	  -2,  -10, 	   4,  -11, 	  -4,   -8
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -7
+.2byte   -1,  -15, 	   3,  -10, 	  -5,  -10, 	  -1,   -7
+.2byte   -3,  -15, 	   1,  -11, 	  -6,   -7, 	  -2,   -8
+.2byte    1,  -15, 	   4,   -7, 	  -3,  -11, 	   0,   -8
+.2byte   -7,   -9, 	  -2,   -3, 	  -6,   -2, 	  -1,   -7
+.2byte   -8,   -8, 	  -3,   -4, 	  -8,   -2, 	  -2,   -6
+.2byte   -4,  -13, 	  -1,  -10, 	  -7,  -10, 	   1,   -7
+.2byte   -5,  -13, 	  -2,  -11, 	  -8,   -8, 	   0,   -7
+.2byte   -3,  -13, 	   0,  -10, 	  -6,  -11, 	   2,   -8
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -8,   -4, 	  -7,   -1, 	  -5,    0, 	  -1,   -5
+.2byte   -4,  -13, 	  -6,   -7, 	  -4,   -7, 	   2,   -8
+.2byte   -3,  -12, 	  -5,   -7, 	  -3,   -5, 	   3,   -7
+.2byte   -5,  -13, 	  -6,   -6, 	  -5,   -8, 	   1,   -8
+.2byte   -4,   -2, 	  -6,    0, 	  -1,    2, 	   0,   -6
+.2byte   -5,   -1, 	  -7,    1, 	  -1,    3, 	  -1,   -5
+.2byte   -3,  -12, 	  -7,   -8, 	  -1,   -8, 	   1,   -9
+.2byte   -2,  -12, 	  -6,  -10, 	   0,   -7, 	   1,   -9
+.2byte   -4,  -12, 	  -8,   -7, 	  -2,   -9, 	  -1,  -10
+.2byte   -4,   -1, 	  -6,    0, 	  -3,    1, 	   1,   -5
+.2byte   -4,    0, 	  -6,    0, 	  -3,    1, 	   1,   -4
+.2byte   -1,   -8, 	  -8,  -13, 	   6,  -13, 	  -1,  -10
+.2byte    3,  -10, 	   5,  -13, 	  -5,  -13, 	  -1,   -8
+.2byte    3,  -12, 	  -1,  -14, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -11, 	  -4,  -12, 	   4,  -10, 	  -1,   -7
+.2byte   -1,  -14, 	   6,  -14, 	  -8,  -14, 	  -1,   -7
+.2byte   -4,  -11, 	   3,  -12, 	  -5,  -10, 	   0,   -7
+.2byte   -4,  -12, 	   0,  -14, 	   2,  -11, 	   0,   -7
+.2byte   -4,  -10, 	  -6,  -13, 	   4,  -13, 	   0,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,    0, 	  -5,    2, 	   3,    2, 	  -1,   -7
+.2byte    2,   -2, 	   4,    0, 	  -1,    2, 	  -2,   -6
+.2byte    3,   -1, 	   5,    1, 	  -1,    3, 	  -1,   -5
+.2byte    5,   -6, 	   3,   -1, 	   1,    0, 	  -2,   -6
+.2byte    6,   -4, 	   5,   -1, 	   3,    0, 	  -1,   -5
+.2byte    5,   -9, 	   0,   -3, 	   4,   -2, 	  -1,   -7
+.2byte    6,   -8, 	   1,   -4, 	   6,   -2, 	   0,   -6
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -7
+.2byte   -7,   -9, 	  -2,   -3, 	  -6,   -2, 	  -1,   -7
+.2byte   -8,   -8, 	  -3,   -4, 	  -8,   -2, 	  -2,   -6
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -8,   -4, 	  -7,   -1, 	  -5,    0, 	  -1,   -5
+.2byte   -4,   -2, 	  -6,    0, 	  -1,    2, 	   0,   -6
+.2byte   -5,   -1, 	  -7,    1, 	  -1,    3, 	  -1,   -5
+.2byte   -1,    0, 	  -5,    2, 	   3,    2, 	  -1,   -7
+.2byte   -5,   -1, 	  -7,    1, 	  -1,    3, 	  -1,   -5
+.2byte   -8,   -4, 	  -7,   -1, 	  -5,    0, 	  -1,   -5
+.2byte   -8,   -8, 	  -3,   -4, 	  -8,   -2, 	  -2,   -6
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -7
+.2byte    6,   -8, 	   1,   -4, 	   6,   -2, 	   0,   -6
+.2byte    6,   -4, 	   5,   -1, 	   3,    0, 	  -1,   -5
+.2byte    3,   -1, 	   5,    1, 	  -1,    3, 	  -1,   -5
+.2byte   -1,   -9, 	  -5,   -6, 	   3,   -7, 	  -1,   -8
+.2byte    2,  -11, 	   6,   -7, 	   0,   -7, 	  -2,   -8
+.2byte    4,  -13, 	   6,   -7, 	   4,   -7, 	  -2,   -8
+.2byte    3,  -15, 	   0,  -12, 	   6,  -12, 	  -2,   -9
+.2byte   -1,  -17, 	   3,  -12, 	  -5,  -12, 	  -1,   -9
+.2byte   -4,  -14, 	  -1,  -11, 	  -7,  -11, 	   1,   -8
+.2byte   -5,  -13, 	  -7,   -7, 	  -5,   -7, 	   1,   -8
+.2byte   -3,  -11, 	  -7,   -7, 	  -1,   -7, 	   1,   -8
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -1,   -5, 	  -5,   -3, 	   3,   -3, 	  -1,   -9
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte    2,   -2, 	   4,    0, 	  -1,    2, 	  -2,   -6
+.2byte    3,   -4, 	   6,   -3, 	   1,   -1, 	  -2,   -7
+.2byte    4,    0, 	   5,    0, 	   0,    2, 	  -1,   -4
+.2byte    5,   -6, 	   3,   -1, 	   1,    0, 	  -2,   -6
+.2byte    5,   -9, 	   5,   -5, 	   3,   -5, 	  -2,   -8
+.2byte    6,   -4, 	   1,   -1, 	   0,    0, 	  -1,   -6
+.2byte    5,   -9, 	   0,   -3, 	   4,   -2, 	  -1,   -7
+.2byte    5,  -13, 	   2,  -10, 	   6,   -9, 	  -2,  -10
+.2byte    5,  -10, 	   0,   -5, 	   4,   -4, 	  -1,  -10
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte   -1,  -18, 	   3,  -12, 	  -5,  -12, 	  -1,  -10
+.2byte   -1,  -12, 	   2,   -3, 	  -4,   -3, 	  -1,   -9
+.2byte   -7,   -9, 	  -2,   -3, 	  -6,   -2, 	  -1,   -7
+.2byte   -7,  -11, 	  -4,   -8, 	  -8,   -7, 	   0,   -8
+.2byte   -7,   -8, 	  -2,   -3, 	  -6,   -2, 	  -1,   -8
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -7,   -9, 	  -7,   -5, 	  -5,   -5, 	   0,   -8
+.2byte   -8,   -4, 	  -3,   -1, 	  -2,    0, 	  -1,   -6
+.2byte   -4,   -2, 	  -6,    0, 	  -1,    2, 	   0,   -6
+.2byte   -5,   -4, 	  -8,   -3, 	  -3,   -1, 	   0,   -7
+.2byte   -6,    0, 	  -7,    0, 	  -2,    2, 	  -1,   -4
+.2byte   -1,    0, 	  -5,    2, 	   3,    2, 	  -1,   -7
+.2byte   -5,   -1, 	  -7,    1, 	  -1,    3, 	  -1,   -5
+.2byte   -8,   -4, 	  -7,   -1, 	  -5,    0, 	  -1,   -5
+.2byte   -8,   -8, 	  -3,   -4, 	  -8,   -2, 	  -2,   -6
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -7
+.2byte    6,   -8, 	   1,   -4, 	   6,   -2, 	   0,   -6
+.2byte    6,   -4, 	   5,   -1, 	   3,    0, 	  -1,   -5
+.2byte    3,   -1, 	   5,    1, 	  -1,    3, 	  -1,   -5
+.2byte   -1,   -2, 	  -5,    1, 	   3,    1, 	  -1,   -7
+.2byte   -4,   -2, 	  -6,    0, 	  -1,    2, 	   0,   -6
+.2byte   -7,   -6, 	  -5,   -1, 	  -3,    0, 	   0,   -6
+.2byte   -7,   -9, 	  -2,   -3, 	  -6,   -2, 	  -1,   -7
+.2byte   -1,  -13, 	   2,   -5, 	  -4,   -5, 	  -1,   -7
+.2byte    5,   -9, 	   0,   -3, 	   4,   -2, 	  -1,   -7
+.2byte    5,   -6, 	   3,   -1, 	   1,    0, 	  -2,   -6
+.2byte    2,   -2, 	   4,    0, 	  -1,    2, 	  -2,   -6
+sVulpixAnimTable1:
+.4byte sVulpixAnims_1_1
+.4byte sVulpixAnims_1_2
+.4byte sVulpixAnims_1_3
+.4byte sVulpixAnims_1_4
+.4byte sVulpixAnims_1_5
+.4byte sVulpixAnims_1_6
+.4byte sVulpixAnims_1_7
+.4byte sVulpixAnims_1_8
+sVulpixAnimTable2:
+.4byte sVulpixAnims_2_1
+.4byte sVulpixAnims_2_2
+.4byte sVulpixAnims_2_3
+.4byte sVulpixAnims_2_4
+.4byte sVulpixAnims_2_5
+.4byte sVulpixAnims_2_6
+.4byte sVulpixAnims_2_7
+.4byte sVulpixAnims_2_8
+sVulpixAnimTable3:
+.4byte sVulpixAnims_3_1
+.4byte sVulpixAnims_3_2
+.4byte sVulpixAnims_3_3
+.4byte sVulpixAnims_3_4
+.4byte sVulpixAnims_3_5
+.4byte sVulpixAnims_3_6
+.4byte sVulpixAnims_3_7
+.4byte sVulpixAnims_3_8
+sVulpixAnimTable4:
+.4byte sVulpixAnims_4_1
+.4byte sVulpixAnims_4_2
+.4byte sVulpixAnims_4_3
+.4byte sVulpixAnims_4_4
+.4byte sVulpixAnims_4_5
+.4byte sVulpixAnims_4_6
+.4byte sVulpixAnims_4_7
+.4byte sVulpixAnims_4_8
+sVulpixAnimTable5:
+.4byte sVulpixAnims_5_1
+.4byte sVulpixAnims_5_2
+.4byte sVulpixAnims_5_3
+.4byte sVulpixAnims_5_4
+.4byte sVulpixAnims_5_5
+.4byte sVulpixAnims_5_6
+.4byte sVulpixAnims_5_7
+.4byte sVulpixAnims_5_8
+sVulpixAnimTable6:
+.4byte sVulpixAnims_6_1
+.4byte sVulpixAnims_6_1
+.4byte sVulpixAnims_6_1
+.4byte sVulpixAnims_6_1
+.4byte sVulpixAnims_6_1
+.4byte sVulpixAnims_6_1
+.4byte sVulpixAnims_6_1
+.4byte sVulpixAnims_6_1
+sVulpixAnimTable7:
+.4byte sVulpixAnims_7_1
+.4byte sVulpixAnims_7_2
+.4byte sVulpixAnims_7_3
+.4byte sVulpixAnims_7_4
+.4byte sVulpixAnims_7_5
+.4byte sVulpixAnims_7_6
+.4byte sVulpixAnims_7_7
+.4byte sVulpixAnims_7_8
+sVulpixAnimTable8:
+.4byte sVulpixAnims_8_1
+.4byte sVulpixAnims_8_2
+.4byte sVulpixAnims_8_3
+.4byte sVulpixAnims_8_4
+.4byte sVulpixAnims_8_5
+.4byte sVulpixAnims_8_6
+.4byte sVulpixAnims_8_7
+.4byte sVulpixAnims_8_8
+sVulpixAnimTable9:
+.4byte sVulpixAnims_9_1
+.4byte sVulpixAnims_9_2
+.4byte sVulpixAnims_9_3
+.4byte sVulpixAnims_9_4
+.4byte sVulpixAnims_9_5
+.4byte sVulpixAnims_9_6
+.4byte sVulpixAnims_9_7
+.4byte sVulpixAnims_9_8
+sVulpixAnimTable10:
+.4byte sVulpixAnims_10_1
+.4byte sVulpixAnims_10_2
+.4byte sVulpixAnims_10_3
+.4byte sVulpixAnims_10_4
+.4byte sVulpixAnims_10_5
+.4byte sVulpixAnims_10_6
+.4byte sVulpixAnims_10_7
+.4byte sVulpixAnims_10_8
+sVulpixAnimTable11:
+.4byte sVulpixAnims_11_1
+.4byte sVulpixAnims_11_2
+.4byte sVulpixAnims_11_3
+.4byte sVulpixAnims_11_4
+.4byte sVulpixAnims_11_5
+.4byte sVulpixAnims_11_6
+.4byte sVulpixAnims_11_7
+.4byte sVulpixAnims_11_8
+sVulpixAnimTable12:
+.4byte sVulpixAnims_12_1
+.4byte sVulpixAnims_12_2
+.4byte sVulpixAnims_12_3
+.4byte sVulpixAnims_12_4
+.4byte sVulpixAnims_12_5
+.4byte sVulpixAnims_12_6
+.4byte sVulpixAnims_12_7
+.4byte sVulpixAnims_12_8
+sVulpixAnimTable13:
+.4byte sVulpixAnims_13_1
+.4byte sVulpixAnims_13_2
+.4byte sVulpixAnims_13_3
+.4byte sVulpixAnims_13_4
+.4byte sVulpixAnims_13_5
+.4byte sVulpixAnims_13_6
+.4byte sVulpixAnims_13_7
+.4byte sVulpixAnims_13_8
+sAxAnimationsVulpix:
+.4byte sVulpixAnimTable1
+.4byte sVulpixAnimTable2
+.4byte sVulpixAnimTable3
+.4byte sVulpixAnimTable4
+.4byte sVulpixAnimTable5
+.4byte sVulpixAnimTable6
+.4byte sVulpixAnimTable7
+.4byte sVulpixAnimTable8
+.4byte sVulpixAnimTable9
+.4byte sVulpixAnimTable10
+.4byte sVulpixAnimTable11
+.4byte sVulpixAnimTable12
+.4byte sVulpixAnimTable13
+sAxSpritesVulpix:
+.4byte sVulpixSprites1
+.4byte sVulpixSprites2
+.4byte sVulpixSprites3
+.4byte sVulpixSprites4
+.4byte sVulpixSprites5
+.4byte sVulpixSprites6
+.4byte sVulpixSprites7
+.4byte sVulpixSprites8
+.4byte sVulpixSprites9
+.4byte sVulpixSprites10
+.4byte sVulpixSprites11
+.4byte sVulpixSprites12
+.4byte sVulpixSprites13
+.4byte sVulpixSprites14
+.4byte sVulpixSprites15
+.4byte sVulpixSprites16
+.4byte sVulpixSprites17
+.4byte sVulpixSprites18
+.4byte sVulpixSprites19
+.4byte sVulpixSprites20
+.4byte sVulpixSprites21
+.4byte sVulpixSprites22
+.4byte sVulpixSprites23
+.4byte sVulpixSprites24
+.4byte sVulpixSprites25
+.4byte sVulpixSprites26
+.4byte sVulpixSprites27
+.4byte sVulpixSprites28
+.4byte sVulpixSprites29
+.4byte sVulpixSprites30
+.4byte sVulpixSprites31
+.4byte sVulpixSprites32
+.4byte sVulpixSprites33
+.4byte sVulpixSprites34
+.4byte sVulpixSprites35
+.4byte sVulpixSprites36
+.4byte sVulpixSprites37
+.4byte sVulpixSprites38
+.4byte sVulpixSprites39
+.4byte sVulpixSprites40
+.4byte sVulpixSprites41
+.4byte sVulpixSprites42
+sAxMainVulpix:
+ax_main sAxPosesVulpix, sAxAnimationsVulpix, 13, sAxSpritesVulpix, sAxPositionsVulpix

--- a/data/ax/wailmer.inc
+++ b/data/ax/wailmer.inc
@@ -1,0 +1,2652 @@
+.global gAxWailmer
+gAxWailmer:
+ax_siro sAxMainWailmer
+sWailmerPose1:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose2:
+ax_pose 1, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose3:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose4:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose5:
+ax_pose 4, 0x01e7, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose6:
+ax_pose 5, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose7:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose8:
+ax_pose 7, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose10:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose11:
+ax_pose 10, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose12:
+ax_pose 11, 0x01ea, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose13:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose14:
+ax_pose 13, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose15:
+ax_pose 14, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose16:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose17:
+ax_pose 10, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose18:
+ax_pose 11, 0x01ea, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose19:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose20:
+ax_pose 7, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose22:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose23:
+ax_pose 4, 0x01e7, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose24:
+ax_pose 5, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose25:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose26:
+ax_pose 1, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose27:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose28:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose29:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose30:
+ax_pose 4, 0x01e7, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose31:
+ax_pose 5, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose32:
+ax_pose 16, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose33:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose34:
+ax_pose 7, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose35:
+ax_pose 8, 0x01eb, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose36:
+ax_pose 17, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sWailmerPose37:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose38:
+ax_pose 10, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose39:
+ax_pose 11, 0x01ea, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose40:
+ax_pose 18, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose41:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose42:
+ax_pose 13, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose43:
+ax_pose 14, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose44:
+ax_pose 19, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose45:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose46:
+ax_pose 10, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose47:
+ax_pose 11, 0x01ea, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose48:
+ax_pose 18, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose49:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose50:
+ax_pose 7, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose51:
+ax_pose 8, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose52:
+ax_pose 17, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sWailmerPose53:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose54:
+ax_pose 4, 0x01e7, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose55:
+ax_pose 5, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose56:
+ax_pose 16, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose57:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose58:
+ax_pose 1, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose59:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose60:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose61:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose62:
+ax_pose 4, 0x01e7, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose63:
+ax_pose 5, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose64:
+ax_pose 16, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose65:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose66:
+ax_pose 7, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose67:
+ax_pose 8, 0x01eb, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose68:
+ax_pose 17, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sWailmerPose69:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose70:
+ax_pose 10, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose71:
+ax_pose 11, 0x01ea, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose72:
+ax_pose 18, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose73:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose74:
+ax_pose 13, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose75:
+ax_pose 14, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose76:
+ax_pose 19, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose77:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose78:
+ax_pose 10, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose79:
+ax_pose 11, 0x01ea, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose80:
+ax_pose 18, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose81:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose82:
+ax_pose 7, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose83:
+ax_pose 8, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose84:
+ax_pose 17, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sWailmerPose85:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose86:
+ax_pose 4, 0x01e7, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose87:
+ax_pose 5, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose88:
+ax_pose 16, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose89:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose90:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose91:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose92:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose93:
+ax_pose 21, 0x01e9, 0x90ee, 0x9c00
+ax_pose_terminator
+sWailmerPose94:
+ax_pose 16, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose95:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose96:
+ax_pose 22, 0x01e9, 0x90f0, 0x9c00
+ax_pose_terminator
+sWailmerPose97:
+ax_pose 17, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sWailmerPose98:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose99:
+ax_pose 23, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose100:
+ax_pose 18, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose101:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose102:
+ax_pose 24, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose103:
+ax_pose 19, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose104:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose105:
+ax_pose 23, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose106:
+ax_pose 18, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose107:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose108:
+ax_pose 22, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sWailmerPose109:
+ax_pose 17, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sWailmerPose110:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose111:
+ax_pose 21, 0x01e9, 0x80f1, 0x9c00
+ax_pose_terminator
+sWailmerPose112:
+ax_pose 16, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose113:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose114:
+ax_pose 25, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose115:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose116:
+ax_pose 26, 0x01e9, 0x90ee, 0x9c00
+ax_pose_terminator
+sWailmerPose117:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose118:
+ax_pose 27, 0x01e9, 0x90f1, 0x9c00
+ax_pose_terminator
+sWailmerPose119:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose120:
+ax_pose 28, 0x01e8, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose121:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose122:
+ax_pose 29, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose123:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose124:
+ax_pose 28, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose125:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose126:
+ax_pose 27, 0x01e9, 0x80ee, 0x9c00
+ax_pose_terminator
+sWailmerPose127:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose128:
+ax_pose 26, 0x01e9, 0x80f1, 0x9c00
+ax_pose_terminator
+sWailmerPose129:
+ax_pose 30, 0x01e8, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose130:
+ax_pose 31, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose131:
+ax_pose 32, 0x01de, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose132:
+ax_pose 33, 0x01df, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose133:
+ax_pose 34, 0x01e3, 0x90ec, 0x9c00
+ax_pose_terminator
+sWailmerPose134:
+ax_pose 35, 0x01e3, 0x90ed, 0x9c00
+ax_pose_terminator
+sWailmerPose135:
+ax_pose 36, 0x01df, 0x80f1, 0x9c00
+ax_pose_terminator
+sWailmerPose136:
+ax_pose 35, 0x01e3, 0x80f3, 0x9c00
+ax_pose_terminator
+sWailmerPose137:
+ax_pose 34, 0x01e3, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose138:
+ax_pose 33, 0x01df, 0x80f5, 0x9c00
+ax_pose_terminator
+sWailmerPose139:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose140:
+ax_pose 1, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose141:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose142:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose143:
+ax_pose 4, 0x01e7, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose144:
+ax_pose 5, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose145:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose146:
+ax_pose 7, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose147:
+ax_pose 8, 0x01eb, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose148:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose149:
+ax_pose 10, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose150:
+ax_pose 11, 0x01ea, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose151:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose152:
+ax_pose 13, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose153:
+ax_pose 14, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose154:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose155:
+ax_pose 10, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose156:
+ax_pose 11, 0x01ea, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose157:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose158:
+ax_pose 7, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose159:
+ax_pose 8, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose160:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose161:
+ax_pose 4, 0x01e7, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose162:
+ax_pose 5, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose163:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose164:
+ax_pose 16, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose165:
+ax_pose 17, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWailmerPose166:
+ax_pose 18, 0x01ea, 0x80f5, 0x9c00
+ax_pose_terminator
+sWailmerPose167:
+ax_pose 19, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose168:
+ax_pose 18, 0x01ea, 0x90ea, 0x9c00
+ax_pose_terminator
+sWailmerPose169:
+ax_pose 17, 0x01ea, 0x90ec, 0x9c00
+ax_pose_terminator
+sWailmerPose170:
+ax_pose 16, 0x01ea, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose171:
+ax_pose 25, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose172:
+ax_pose 26, 0x01e9, 0x90ee, 0x9c00
+ax_pose_terminator
+sWailmerPose173:
+ax_pose 27, 0x01e9, 0x90f1, 0x9c00
+ax_pose_terminator
+sWailmerPose174:
+ax_pose 28, 0x01e8, 0x90ec, 0x9c00
+ax_pose_terminator
+sWailmerPose175:
+ax_pose 29, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose176:
+ax_pose 28, 0x01e8, 0x80f3, 0x9c00
+ax_pose_terminator
+sWailmerPose177:
+ax_pose 27, 0x01e9, 0x80ee, 0x9c00
+ax_pose_terminator
+sWailmerPose178:
+ax_pose 26, 0x01e9, 0x80f1, 0x9c00
+ax_pose_terminator
+sWailmerPose179:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose180:
+ax_pose 20, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose181:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose182:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose183:
+ax_pose 21, 0x01e9, 0x90ee, 0x9c00
+ax_pose_terminator
+sWailmerPose184:
+ax_pose 16, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose185:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose186:
+ax_pose 22, 0x01e9, 0x90f0, 0x9c00
+ax_pose_terminator
+sWailmerPose187:
+ax_pose 17, 0x01e9, 0x90ec, 0x9c00
+ax_pose_terminator
+sWailmerPose188:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose189:
+ax_pose 23, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose190:
+ax_pose 18, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose191:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose192:
+ax_pose 24, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose193:
+ax_pose 19, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose194:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose195:
+ax_pose 23, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose196:
+ax_pose 18, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose197:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose198:
+ax_pose 22, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sWailmerPose199:
+ax_pose 17, 0x01e9, 0x80f3, 0x9c00
+ax_pose_terminator
+sWailmerPose200:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose201:
+ax_pose 21, 0x01e9, 0x80f1, 0x9c00
+ax_pose_terminator
+sWailmerPose202:
+ax_pose 16, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose203:
+ax_pose 1, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose204:
+ax_pose 4, 0x01e7, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose205:
+ax_pose 7, 0x01e6, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose206:
+ax_pose 10, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose207:
+ax_pose 13, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose208:
+ax_pose 10, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose209:
+ax_pose 7, 0x01e6, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose210:
+ax_pose 4, 0x01e7, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose211:
+ax_pose 0, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose212:
+ax_pose 3, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose213:
+ax_pose 6, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWailmerPose214:
+ax_pose 9, 0x01e9, 0x80f6, 0x9c00
+ax_pose_terminator
+sWailmerPose215:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWailmerPose216:
+ax_pose 9, 0x01e9, 0x90e9, 0x9c00
+ax_pose_terminator
+sWailmerPose217:
+ax_pose 6, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+sWailmerPose218:
+ax_pose 3, 0x01e9, 0x90eb, 0x9c00
+ax_pose_terminator
+.align 2
+sWailmerAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 3, 0, 0,
+ax_anim 6, 0, 1, 0, 4, 0, 0,
+ax_anim 8, 0, 0, 0, 3, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 3, 0, 0,
+ax_anim 6, 0, 4, 0, 4, 0, 0,
+ax_anim 8, 0, 3, 0, 3, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, -1, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 3, 0, 0,
+ax_anim 6, 0, 7, 0, 4, 0, 0,
+ax_anim 8, 0, 6, 0, 3, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 3, 0, 0,
+ax_anim 6, 0, 10, 0, 4, 0, 0,
+ax_anim 8, 0, 9, 0, 3, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, -1, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 3, 0, 0,
+ax_anim 6, 0, 13, 0, 4, 0, 0,
+ax_anim 8, 0, 12, 0, 3, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 3, 0, 0,
+ax_anim 6, 0, 16, 0, 4, 0, 0,
+ax_anim 8, 0, 15, 0, 3, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, -1, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 3, 0, 0,
+ax_anim 6, 0, 19, 0, 4, 0, 0,
+ax_anim 8, 0, 18, 0, 3, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 3, 0, 0,
+ax_anim 6, 0, 22, 0, 4, 0, 0,
+ax_anim 8, 0, 21, 0, 3, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, -1, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 1,
+ax_anim 2, 2, 25, 0, 4, 0, 7,
+ax_anim 2, 0, 27, 0, 10, 0, 14,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWailmerAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 3, -1, 3, 1,
+ax_anim 2, 2, 29, 8, 2, 8, 8,
+ax_anim 2, 0, 31, 16, 10, 16, 17,
+ax_anim 2, 0, 31, 19, 21, 19, 21,
+ax_anim 2, 1, 31, 20, 20, 20, 20,
+ax_anim 2, 0, 31, 19, 21, 19, 21,
+ax_anim 2, 0, 31, 20, 20, 20, 20,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sWailmerAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 1, -3, 1, 1,
+ax_anim 2, 2, 33, 6, -4, 6, 0,
+ax_anim 2, 0, 35, 13, -4, 13, 0,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 1, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 35, 19, 0, 19, 0,
+ax_anim 2, 0, 35, 19, 1, 19, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sWailmerAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 2, -4, 2, -3,
+ax_anim 2, 2, 37, 8, -10, 8, -8,
+ax_anim 2, 0, 39, 14, -15, 14, -13,
+ax_anim 2, 0, 39, 20, -16, 20, -19,
+ax_anim 2, 1, 39, 21, -15, 21, -18,
+ax_anim 2, 0, 39, 20, -16, 20, -19,
+ax_anim 2, 0, 39, 21, -15, 21, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sWailmerAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, -2, 0, -1,
+ax_anim 2, 2, 41, 0, -7, 0, -6,
+ax_anim 2, 0, 43, 0, -15, 0, -14,
+ax_anim 2, 0, 43, 0, -18, 0, -20,
+ax_anim 2, 1, 43, 1, -18, 1, -20,
+ax_anim 2, 0, 43, 0, -18, 0, -20,
+ax_anim 2, 0, 43, 1, -18, 1, -20,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sWailmerAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, -2, -4, -2, -3,
+ax_anim 2, 2, 45, -8, -10, -8, -8,
+ax_anim 2, 0, 47, -14, -15, -14, -13,
+ax_anim 2, 0, 47, -20, -16, -20, -19,
+ax_anim 2, 1, 47, -21, -15, -21, -18,
+ax_anim 2, 0, 47, -20, -16, -20, -19,
+ax_anim 2, 0, 47, -21, -15, -21, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sWailmerAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, -1, -3, -1, 1,
+ax_anim 2, 2, 49, -6, -4, -6, 0,
+ax_anim 2, 0, 51, -13, -4, -13, 0,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 1, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 51, -19, 0, -19, 0,
+ax_anim 2, 0, 51, -19, 1, -19, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sWailmerAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, -3, -1, -3, 1,
+ax_anim 2, 2, 53, -8, 2, -8, 8,
+ax_anim 2, 0, 55, -16, 10, -16, 17,
+ax_anim 2, 0, 55, -19, 21, -19, 21,
+ax_anim 2, 1, 55, -20, 20, -20, 20,
+ax_anim 2, 0, 55, -19, 21, -19, 21,
+ax_anim 2, 0, 55, -20, 20, -20, 20,
+ax_anim 2, 0, 52, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sWailmerAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 1,
+ax_anim 2, 2, 57, 0, 4, 0, 7,
+ax_anim 2, 0, 59, 0, 10, 0, 14,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sWailmerAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 3, -1, 3, 1,
+ax_anim 2, 2, 61, 8, 2, 8, 8,
+ax_anim 2, 0, 63, 16, 10, 16, 17,
+ax_anim 2, 0, 63, 19, 21, 19, 21,
+ax_anim 2, 1, 63, 20, 20, 20, 20,
+ax_anim 2, 0, 63, 19, 21, 19, 21,
+ax_anim 2, 0, 63, 20, 20, 20, 20,
+ax_anim 2, 0, 60, 8, 8, 8, 8,
+ax_anim_terminator
+sWailmerAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 1, -3, 1, 1,
+ax_anim 2, 2, 65, 6, -4, 6, 0,
+ax_anim 2, 0, 67, 13, -4, 13, 0,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 1, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 67, 19, 0, 19, 0,
+ax_anim 2, 0, 67, 19, 1, 19, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sWailmerAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 2, -4, 2, -3,
+ax_anim 2, 2, 69, 8, -10, 8, -8,
+ax_anim 2, 0, 71, 14, -15, 14, -13,
+ax_anim 2, 0, 71, 20, -16, 20, -19,
+ax_anim 2, 1, 71, 21, -15, 21, -18,
+ax_anim 2, 0, 71, 20, -16, 20, -19,
+ax_anim 2, 0, 71, 21, -15, 21, -18,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sWailmerAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, -2, 0, -1,
+ax_anim 2, 2, 73, 0, -7, 0, -6,
+ax_anim 2, 0, 75, 0, -15, 0, -14,
+ax_anim 2, 0, 75, 0, -18, 0, -20,
+ax_anim 2, 1, 75, 1, -18, 1, -20,
+ax_anim 2, 0, 75, 0, -18, 0, -20,
+ax_anim 2, 0, 75, 1, -18, 1, -20,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sWailmerAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, -2, -4, -2, -3,
+ax_anim 2, 2, 77, -8, -10, -8, -8,
+ax_anim 2, 0, 79, -14, -15, -14, -13,
+ax_anim 2, 0, 79, -20, -16, -20, -19,
+ax_anim 2, 1, 79, -21, -15, -21, -18,
+ax_anim 2, 0, 79, -20, -16, -20, -19,
+ax_anim 2, 0, 79, -21, -15, -21, -18,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sWailmerAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, -1, -3, -1, 1,
+ax_anim 2, 2, 81, -6, -4, -6, 0,
+ax_anim 2, 0, 83, -13, -4, -13, 0,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 1, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 83, -19, 0, -19, 0,
+ax_anim 2, 0, 83, -19, 1, -19, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sWailmerAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, -3, -1, -3, 1,
+ax_anim 2, 2, 85, -8, 2, -8, 8,
+ax_anim 2, 0, 87, -16, 10, -16, 17,
+ax_anim 2, 0, 87, -19, 21, -19, 21,
+ax_anim 2, 1, 87, -20, 20, -20, 20,
+ax_anim 2, 0, 87, -19, 21, -19, 21,
+ax_anim 2, 0, 87, -20, 20, -20, 20,
+ax_anim 2, 0, 84, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sWailmerAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 1, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 90, 1, 3, 1, 2,
+ax_anim 2, 0, 90, 0, 3, 0, 2,
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim_terminator
+sWailmerAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 2, 1, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 93, 3, 1, 2, 0,
+ax_anim 2, 0, 93, 2, 2, 1, 1,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sWailmerAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 2, 1, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 96, 2, 1, 2, 1,
+ax_anim 2, 0, 96, 2, 0, 2, 0,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sWailmerAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 2, 1, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 99, 3, -1, 2, 0,
+ax_anim 2, 0, 99, 2, -2, 1, -1,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sWailmerAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 2, 1, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 102, 1, -3, 1, -2,
+ax_anim 2, 0, 102, 0, -3, 0, -2,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim_terminator
+sWailmerAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 2, 1, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 105, -3, -1, -2, 0,
+ax_anim 2, 0, 105, -2, -2, -1, -1,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sWailmerAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 2, 1, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 108, -2, 1, -2, 1,
+ax_anim 2, 0, 108, -2, 0, -2, 0,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sWailmerAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 2, 1, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 111, -3, 1, -2, 0,
+ax_anim 2, 0, 111, -2, 2, -1, 1,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sWailmerAnims_5_1:
+ax_anim 4, 0, 112, 0, -1, 0, 0,
+ax_anim 3, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 113, 0, -4, 0, 0,
+ax_anim 6, 0, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 1, -5, 1, 0,
+ax_anim 2, 2, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 1, -5, 1, 0,
+ax_anim 2, 0, 113, 0, -5, 0, 0,
+ax_anim 2, 0, 113, 1, -5, 1, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_5_2:
+ax_anim 4, 0, 114, 0, -1, 0, 0,
+ax_anim 3, 0, 114, 0, -3, 0, 0,
+ax_anim 2, 0, 115, 0, -4, 0, 0,
+ax_anim 6, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 1, -6, 1, -1,
+ax_anim 2, 2, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 1, -6, 1, -1,
+ax_anim 2, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 0, 115, 1, -6, 1, -1,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_5_3:
+ax_anim 4, 0, 116, 0, -1, 0, 0,
+ax_anim 3, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -4, 0, 0,
+ax_anim 6, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, -1,
+ax_anim 2, 2, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, -1,
+ax_anim 2, 0, 117, 0, -5, 0, 0,
+ax_anim 2, 0, 117, 0, -6, 0, -1,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_5_4:
+ax_anim 4, 0, 118, 0, -1, 0, 0,
+ax_anim 3, 0, 118, 0, -3, 0, 0,
+ax_anim 2, 0, 119, 0, -4, 0, 0,
+ax_anim 6, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, -1, -6, -1, -1,
+ax_anim 2, 2, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, -1, -6, -1, -1,
+ax_anim 2, 0, 119, 0, -5, 0, 0,
+ax_anim 2, 0, 119, -1, -6, -1, -1,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_5_5:
+ax_anim 4, 0, 120, 0, -1, 0, 0,
+ax_anim 3, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 121, 0, -4, 0, 0,
+ax_anim 6, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 1, -5, 1, 0,
+ax_anim 2, 2, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 1, -5, 1, 0,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 1, -5, 1, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_5_6:
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 3, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, 0,
+ax_anim 6, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 1, -6, 1, -1,
+ax_anim 2, 2, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 1, -6, 1, -1,
+ax_anim 2, 0, 123, 0, -5, 0, 0,
+ax_anim 2, 0, 123, 1, -6, 1, -1,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_5_7:
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 3, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 6, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, -1,
+ax_anim 2, 2, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, -1,
+ax_anim 2, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 0, 125, 0, -6, 0, -1,
+ax_anim 2, 0, 125, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_5_8:
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim 3, 0, 126, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -4, 0, 0,
+ax_anim 6, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 127, -1, -6, -1, -1,
+ax_anim 2, 2, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 127, -1, -6, -1, -1,
+ax_anim 2, 0, 127, 0, -5, 0, 0,
+ax_anim 2, 0, 127, -1, -6, -1, -1,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 126, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_6_1:
+ax_anim 16, 0, 128, 0, 0, 0, 0,
+ax_anim 12, 0, 128, 0, -1, 0, 0,
+ax_anim 16, 0, 128, 0, -2, 0, 0,
+ax_anim 16, 0, 129, 0, -2, 0, 0,
+ax_anim 12, 0, 129, 0, -1, 0, 0,
+ax_anim 16, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_7_1:
+ax_anim 2, 0, 130, 0, -4, 0, -4,
+ax_anim 8, 0, 130, 0, -5, 0, -5,
+ax_anim_terminator
+sWailmerAnims_7_2:
+ax_anim 2, 0, 131, -4, -4, -4, -4,
+ax_anim 8, 0, 131, -5, -5, -5, -5,
+ax_anim_terminator
+sWailmerAnims_7_3:
+ax_anim 2, 0, 132, -4, 0, -4, 0,
+ax_anim 8, 0, 132, -5, 0, -5, 0,
+ax_anim_terminator
+sWailmerAnims_7_4:
+ax_anim 2, 0, 133, -4, 4, -4, 4,
+ax_anim 8, 0, 133, -5, 5, -5, 5,
+ax_anim_terminator
+sWailmerAnims_7_5:
+ax_anim 2, 0, 134, 0, 4, 0, 4,
+ax_anim 8, 0, 134, 0, 5, 0, 5,
+ax_anim_terminator
+sWailmerAnims_7_6:
+ax_anim 2, 0, 135, 4, 4, 4, 4,
+ax_anim 8, 0, 135, 5, 5, 5, 5,
+ax_anim_terminator
+sWailmerAnims_7_7:
+ax_anim 2, 0, 136, 4, 0, 4, 0,
+ax_anim 8, 0, 136, 5, 0, 5, 0,
+ax_anim_terminator
+sWailmerAnims_7_8:
+ax_anim 2, 0, 137, 4, -4, 4, -4,
+ax_anim 8, 0, 137, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sWailmerAnims_8_1:
+ax_anim 16, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 139, 0, 3, 0, 0,
+ax_anim 16, 0, 139, 0, 4, 0, 0,
+ax_anim 16, 0, 138, 0, 3, 0, 0,
+ax_anim 10, 0, 140, 0, 0, 0, 0,
+ax_anim 10, 0, 140, 0, -1, 0, 0,
+ax_anim 16, 0, 140, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_8_2:
+ax_anim 16, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 142, 0, 3, 0, 0,
+ax_anim 16, 0, 142, 0, 4, 0, 0,
+ax_anim 16, 0, 141, 0, 3, 0, 0,
+ax_anim 10, 0, 143, 0, 0, 0, 0,
+ax_anim 10, 0, 143, 0, -1, 0, 0,
+ax_anim 16, 0, 143, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_8_3:
+ax_anim 16, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 145, 0, 3, 0, 0,
+ax_anim 16, 0, 145, 0, 4, 0, 0,
+ax_anim 16, 0, 144, 0, 3, 0, 0,
+ax_anim 10, 0, 146, 0, 0, 0, 0,
+ax_anim 10, 0, 146, 0, -1, 0, 0,
+ax_anim 16, 0, 146, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_8_4:
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 148, 0, 3, 0, 0,
+ax_anim 16, 0, 148, 0, 4, 0, 0,
+ax_anim 16, 0, 147, 0, 3, 0, 0,
+ax_anim 10, 0, 149, 0, 0, 0, 0,
+ax_anim 10, 0, 149, 0, -1, 0, 0,
+ax_anim 16, 0, 149, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_8_5:
+ax_anim 16, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 151, 0, 3, 0, 0,
+ax_anim 16, 0, 151, 0, 4, 0, 0,
+ax_anim 16, 0, 150, 0, 3, 0, 0,
+ax_anim 10, 0, 152, 0, 0, 0, 0,
+ax_anim 10, 0, 152, 0, -1, 0, 0,
+ax_anim 16, 0, 152, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_8_6:
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 154, 0, 3, 0, 0,
+ax_anim 16, 0, 154, 0, 4, 0, 0,
+ax_anim 16, 0, 153, 0, 3, 0, 0,
+ax_anim 10, 0, 155, 0, 0, 0, 0,
+ax_anim 10, 0, 155, 0, -1, 0, 0,
+ax_anim 16, 0, 155, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_8_7:
+ax_anim 16, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 157, 0, 3, 0, 0,
+ax_anim 16, 0, 157, 0, 4, 0, 0,
+ax_anim 16, 0, 156, 0, 3, 0, 0,
+ax_anim 10, 0, 158, 0, 0, 0, 0,
+ax_anim 10, 0, 158, 0, -1, 0, 0,
+ax_anim 16, 0, 158, 0, -2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_8_8:
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 160, 0, 3, 0, 0,
+ax_anim 16, 0, 160, 0, 4, 0, 0,
+ax_anim 16, 0, 159, 0, 3, 0, 0,
+ax_anim 10, 0, 161, 0, 0, 0, 0,
+ax_anim 10, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 161, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 12, 13, 12, 13,
+ax_anim 2, 0, 165, 8, 22, 8, 22,
+ax_anim 3, 0, 166, 0, 23, 0, 23,
+ax_anim 2, 3, 167, -8, 22, -8, 22,
+ax_anim 2, 0, 168, -12, 13, -12, 13,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 9, 1, 9, 1,
+ax_anim 2, 0, 163, 18, 8, 18, 8,
+ax_anim 2, 0, 164, 23, 16, 23, 16,
+ax_anim 3, 0, 165, 19, 24, 19, 24,
+ax_anim 2, 3, 166, 12, 23, 12, 23,
+ax_anim 2, 0, 167, 6, 17, 6, 17,
+ax_anim 1, 0, 168, 2, 9, 2, 9,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -5, 11, -5,
+ax_anim 2, 0, 163, 16, -2, 16, -2,
+ax_anim 3, 0, 164, 19, 2, 19, 0,
+ax_anim 2, 3, 165, 17, 7, 17, 7,
+ax_anim 2, 0, 166, 12, 8, 12, 8,
+ax_anim 1, 0, 167, 4, 6, 4, 6,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 1, -10, 1, -10,
+ax_anim 2, 0, 169, 6, -16, 6, -16,
+ax_anim 2, 0, 162, 13, -19, 13, -19,
+ax_anim 3, 0, 163, 21, -19, 21, -19,
+ax_anim 2, 3, 164, 25, -12, 25, -12,
+ax_anim 2, 0, 165, 19, -4, 19, -4,
+ax_anim 1, 0, 166, 9, -1, 9, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -7, -3, -7, -3,
+ax_anim 2, 0, 168, -11, -10, -11, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -20,
+ax_anim 3, 0, 162, 0, -20, 0, -23,
+ax_anim 2, 3, 163, 7, -18, 7, -20,
+ax_anim 2, 0, 164, 11, -10, 11, -10,
+ax_anim 1, 0, 165, 7, -3, 7, -3,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, -1, -9, -1, -9,
+ax_anim 2, 0, 163, -6, -16, -6, -16,
+ax_anim 2, 0, 162, -13, -19, -13, -19,
+ax_anim 3, 0, 169, -21, -19, -21, -19,
+ax_anim 2, 3, 168, -25, -12, -25, -12,
+ax_anim 2, 0, 167, -19, -4, -19, -4,
+ax_anim 1, 0, 166, -9, -1, -9, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -5, -11, -5,
+ax_anim 2, 0, 169, -16, -2, -16, -2,
+ax_anim 3, 0, 168, -19, 2, -19, 0,
+ax_anim 2, 3, 167, -17, 7, -17, 7,
+ax_anim 2, 0, 166, -12, 8, -12, 8,
+ax_anim 1, 0, 165, -4, 6, -4, 6,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -9, 1, -9, 1,
+ax_anim 2, 0, 169, -18, 8, -18, 8,
+ax_anim 2, 0, 168, -23, 16, -23, 16,
+ax_anim 3, 0, 167, -19, 24, -19, 24,
+ax_anim 2, 3, 166, -12, 23, -12, 23,
+ax_anim 2, 0, 165, -6, 17, -6, 17,
+ax_anim 1, 0, 164, -2, 9, -2, 9,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -22, 0, 0,
+ax_anim 4, 0, 178, 0, -24, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -22, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -22, 0, 0,
+ax_anim 4, 0, 184, 0, -24, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 1, 0, 0,
+ax_anim_terminator
+sWailmerAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -22, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -22, 0, 0,
+ax_anim 4, 0, 196, 0, -24, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 2, 0, 0,
+ax_anim_terminator
+sWailmerAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -22, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 201, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailmerAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sWailmerGfx1:
+.incbin "baserom.gba", 0x1308B14, 0x200
+sWailmerSprites1:
+ax_sprite sWailmerGfx1, 0x200
+ax_sprite_terminator
+sWailmerGfx2:
+.incbin "baserom.gba", 0x1308D24, 0x200
+sWailmerSprites2:
+ax_sprite sWailmerGfx2, 0x200
+ax_sprite_terminator
+sWailmerGfx3:
+.incbin "baserom.gba", 0x1308F34, 0x200
+sWailmerSprites3:
+ax_sprite sWailmerGfx3, 0x200
+ax_sprite_terminator
+sWailmerGfx4:
+.incbin "baserom.gba", 0x1309144, 0x200
+sWailmerSprites4:
+ax_sprite sWailmerGfx4, 0x200
+ax_sprite_terminator
+sWailmerGfx5:
+.incbin "baserom.gba", 0x1309354, 0x200
+sWailmerSprites5:
+ax_sprite sWailmerGfx5, 0x200
+ax_sprite_terminator
+sWailmerGfx6:
+.incbin "baserom.gba", 0x1309564, 0x200
+sWailmerSprites6:
+ax_sprite sWailmerGfx6, 0x200
+ax_sprite_terminator
+sWailmerGfx7:
+.incbin "baserom.gba", 0x1309774, 0x200
+sWailmerSprites7:
+ax_sprite sWailmerGfx7, 0x200
+ax_sprite_terminator
+sWailmerGfx8:
+.incbin "baserom.gba", 0x1309984, 0x200
+sWailmerSprites8:
+ax_sprite sWailmerGfx8, 0x200
+ax_sprite_terminator
+sWailmerGfx9:
+.incbin "baserom.gba", 0x1309B94, 0x200
+sWailmerSprites9:
+ax_sprite sWailmerGfx9, 0x200
+ax_sprite_terminator
+sWailmerGfx10:
+.incbin "baserom.gba", 0x1309DA4, 0x200
+sWailmerSprites10:
+ax_sprite sWailmerGfx10, 0x200
+ax_sprite_terminator
+sWailmerGfx11:
+.incbin "baserom.gba", 0x1309FB4, 0x200
+sWailmerSprites11:
+ax_sprite sWailmerGfx11, 0x200
+ax_sprite_terminator
+sWailmerGfx12:
+.incbin "baserom.gba", 0x130A1C4, 0x200
+sWailmerSprites12:
+ax_sprite sWailmerGfx12, 0x200
+ax_sprite_terminator
+sWailmerGfx13:
+.incbin "baserom.gba", 0x130A3D4, 0x200
+sWailmerSprites13:
+ax_sprite sWailmerGfx13, 0x200
+ax_sprite_terminator
+sWailmerGfx14:
+.incbin "baserom.gba", 0x130A5E4, 0x200
+sWailmerSprites14:
+ax_sprite sWailmerGfx14, 0x200
+ax_sprite_terminator
+sWailmerGfx15:
+.incbin "baserom.gba", 0x130A7F4, 0x200
+sWailmerSprites15:
+ax_sprite sWailmerGfx15, 0x200
+ax_sprite_terminator
+sWailmerGfx16:
+.incbin "baserom.gba", 0x130AA04, 0x180
+sWailmerGfx16_1:
+.incbin "baserom.gba", 0x130AB84, 0x40
+sWailmerSprites16:
+ax_sprite sWailmerGfx16, 0x180
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWailmerGfx17:
+.incbin "baserom.gba", 0x130ABEC, 0x60
+sWailmerGfx17_1:
+.incbin "baserom.gba", 0x130AC4C, 0xE0
+sWailmerSprites17:
+ax_sprite sWailmerGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx17_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWailmerGfx18:
+.incbin "baserom.gba", 0x130AD54, 0x60
+sWailmerGfx18_1:
+.incbin "baserom.gba", 0x130ADB4, 0x60
+sWailmerGfx18_2:
+.incbin "baserom.gba", 0x130AE14, 0x60
+sWailmerSprites18:
+ax_sprite sWailmerGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWailmerGfx19:
+.incbin "baserom.gba", 0x130AEAC, 0x60
+sWailmerGfx19_1:
+.incbin "baserom.gba", 0x130AF0C, 0x60
+sWailmerGfx19_2:
+.incbin "baserom.gba", 0x130AF6C, 0x60
+sWailmerSprites19:
+ax_sprite sWailmerGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWailmerGfx20:
+.incbin "baserom.gba", 0x130B004, 0x40
+sWailmerGfx20_1:
+.incbin "baserom.gba", 0x130B044, 0x100
+sWailmerSprites20:
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx20_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailmerGfx21:
+.incbin "baserom.gba", 0x130B174, 0x180
+sWailmerSprites21:
+ax_sprite sWailmerGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailmerGfx22:
+.incbin "baserom.gba", 0x130B30C, 0x160
+sWailmerSprites22:
+ax_sprite sWailmerGfx22, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWailmerGfx23:
+.incbin "baserom.gba", 0x130B484, 0xE0
+sWailmerGfx23_1:
+.incbin "baserom.gba", 0x130B564, 0x60
+sWailmerSprites23:
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx23, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx23_1, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailmerGfx24:
+.incbin "baserom.gba", 0x130B5F4, 0x60
+sWailmerGfx24_1:
+.incbin "baserom.gba", 0x130B654, 0x100
+sWailmerGfx24_2:
+.incbin "baserom.gba", 0x130B754, 0x20
+sWailmerSprites24:
+ax_sprite sWailmerGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx24_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx24_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWailmerGfx25:
+.incbin "baserom.gba", 0x130B7AC, 0x40
+sWailmerGfx25_1:
+.incbin "baserom.gba", 0x130B7EC, 0x100
+sWailmerSprites25:
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx25_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailmerGfx26:
+.incbin "baserom.gba", 0x130B91C, 0x160
+sWailmerSprites26:
+ax_sprite sWailmerGfx26, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWailmerGfx27:
+.incbin "baserom.gba", 0x130BA94, 0x160
+sWailmerSprites27:
+ax_sprite sWailmerGfx27, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWailmerGfx28:
+.incbin "baserom.gba", 0x130BC0C, 0x60
+sWailmerGfx28_1:
+.incbin "baserom.gba", 0x130BC6C, 0x60
+sWailmerGfx28_2:
+.incbin "baserom.gba", 0x130BCCC, 0x60
+sWailmerSprites28:
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx28_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailmerGfx29:
+.incbin "baserom.gba", 0x130BD6C, 0x1A0
+sWailmerSprites29:
+ax_sprite sWailmerGfx29, 0x1a0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sWailmerGfx30:
+.incbin "baserom.gba", 0x130BF24, 0x40
+sWailmerGfx30_1:
+.incbin "baserom.gba", 0x130BF64, 0x100
+sWailmerSprites30:
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWailmerGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailmerGfx31:
+.incbin "baserom.gba", 0x130C094, 0x200
+sWailmerSprites31:
+ax_sprite sWailmerGfx31, 0x200
+ax_sprite_terminator
+sWailmerGfx32:
+.incbin "baserom.gba", 0x130C2A4, 0x200
+sWailmerSprites32:
+ax_sprite sWailmerGfx32, 0x200
+ax_sprite_terminator
+sWailmerGfx33:
+.incbin "baserom.gba", 0x130C4B4, 0x200
+sWailmerSprites33:
+ax_sprite sWailmerGfx33, 0x200
+ax_sprite_terminator
+sWailmerGfx34:
+.incbin "baserom.gba", 0x130C6C4, 0x200
+sWailmerSprites34:
+ax_sprite sWailmerGfx34, 0x200
+ax_sprite_terminator
+sWailmerGfx35:
+.incbin "baserom.gba", 0x130C8D4, 0x200
+sWailmerSprites35:
+ax_sprite sWailmerGfx35, 0x200
+ax_sprite_terminator
+sWailmerGfx36:
+.incbin "baserom.gba", 0x130CAE4, 0x200
+sWailmerSprites36:
+ax_sprite sWailmerGfx36, 0x200
+ax_sprite_terminator
+sWailmerGfx37:
+.incbin "baserom.gba", 0x130CCF4, 0x200
+sWailmerSprites37:
+ax_sprite sWailmerGfx37, 0x200
+ax_sprite_terminator
+sAxPosesWailmer:
+.4byte sWailmerPose1
+.4byte sWailmerPose2
+.4byte sWailmerPose3
+.4byte sWailmerPose4
+.4byte sWailmerPose5
+.4byte sWailmerPose6
+.4byte sWailmerPose7
+.4byte sWailmerPose8
+.4byte sWailmerPose9
+.4byte sWailmerPose10
+.4byte sWailmerPose11
+.4byte sWailmerPose12
+.4byte sWailmerPose13
+.4byte sWailmerPose14
+.4byte sWailmerPose15
+.4byte sWailmerPose16
+.4byte sWailmerPose17
+.4byte sWailmerPose18
+.4byte sWailmerPose19
+.4byte sWailmerPose20
+.4byte sWailmerPose21
+.4byte sWailmerPose22
+.4byte sWailmerPose23
+.4byte sWailmerPose24
+.4byte sWailmerPose25
+.4byte sWailmerPose26
+.4byte sWailmerPose27
+.4byte sWailmerPose28
+.4byte sWailmerPose29
+.4byte sWailmerPose30
+.4byte sWailmerPose31
+.4byte sWailmerPose32
+.4byte sWailmerPose33
+.4byte sWailmerPose34
+.4byte sWailmerPose35
+.4byte sWailmerPose36
+.4byte sWailmerPose37
+.4byte sWailmerPose38
+.4byte sWailmerPose39
+.4byte sWailmerPose40
+.4byte sWailmerPose41
+.4byte sWailmerPose42
+.4byte sWailmerPose43
+.4byte sWailmerPose44
+.4byte sWailmerPose45
+.4byte sWailmerPose46
+.4byte sWailmerPose47
+.4byte sWailmerPose48
+.4byte sWailmerPose49
+.4byte sWailmerPose50
+.4byte sWailmerPose51
+.4byte sWailmerPose52
+.4byte sWailmerPose53
+.4byte sWailmerPose54
+.4byte sWailmerPose55
+.4byte sWailmerPose56
+.4byte sWailmerPose57
+.4byte sWailmerPose58
+.4byte sWailmerPose59
+.4byte sWailmerPose60
+.4byte sWailmerPose61
+.4byte sWailmerPose62
+.4byte sWailmerPose63
+.4byte sWailmerPose64
+.4byte sWailmerPose65
+.4byte sWailmerPose66
+.4byte sWailmerPose67
+.4byte sWailmerPose68
+.4byte sWailmerPose69
+.4byte sWailmerPose70
+.4byte sWailmerPose71
+.4byte sWailmerPose72
+.4byte sWailmerPose73
+.4byte sWailmerPose74
+.4byte sWailmerPose75
+.4byte sWailmerPose76
+.4byte sWailmerPose77
+.4byte sWailmerPose78
+.4byte sWailmerPose79
+.4byte sWailmerPose80
+.4byte sWailmerPose81
+.4byte sWailmerPose82
+.4byte sWailmerPose83
+.4byte sWailmerPose84
+.4byte sWailmerPose85
+.4byte sWailmerPose86
+.4byte sWailmerPose87
+.4byte sWailmerPose88
+.4byte sWailmerPose89
+.4byte sWailmerPose90
+.4byte sWailmerPose91
+.4byte sWailmerPose92
+.4byte sWailmerPose93
+.4byte sWailmerPose94
+.4byte sWailmerPose95
+.4byte sWailmerPose96
+.4byte sWailmerPose97
+.4byte sWailmerPose98
+.4byte sWailmerPose99
+.4byte sWailmerPose100
+.4byte sWailmerPose101
+.4byte sWailmerPose102
+.4byte sWailmerPose103
+.4byte sWailmerPose104
+.4byte sWailmerPose105
+.4byte sWailmerPose106
+.4byte sWailmerPose107
+.4byte sWailmerPose108
+.4byte sWailmerPose109
+.4byte sWailmerPose110
+.4byte sWailmerPose111
+.4byte sWailmerPose112
+.4byte sWailmerPose113
+.4byte sWailmerPose114
+.4byte sWailmerPose115
+.4byte sWailmerPose116
+.4byte sWailmerPose117
+.4byte sWailmerPose118
+.4byte sWailmerPose119
+.4byte sWailmerPose120
+.4byte sWailmerPose121
+.4byte sWailmerPose122
+.4byte sWailmerPose123
+.4byte sWailmerPose124
+.4byte sWailmerPose125
+.4byte sWailmerPose126
+.4byte sWailmerPose127
+.4byte sWailmerPose128
+.4byte sWailmerPose129
+.4byte sWailmerPose130
+.4byte sWailmerPose131
+.4byte sWailmerPose132
+.4byte sWailmerPose133
+.4byte sWailmerPose134
+.4byte sWailmerPose135
+.4byte sWailmerPose136
+.4byte sWailmerPose137
+.4byte sWailmerPose138
+.4byte sWailmerPose139
+.4byte sWailmerPose140
+.4byte sWailmerPose141
+.4byte sWailmerPose142
+.4byte sWailmerPose143
+.4byte sWailmerPose144
+.4byte sWailmerPose145
+.4byte sWailmerPose146
+.4byte sWailmerPose147
+.4byte sWailmerPose148
+.4byte sWailmerPose149
+.4byte sWailmerPose150
+.4byte sWailmerPose151
+.4byte sWailmerPose152
+.4byte sWailmerPose153
+.4byte sWailmerPose154
+.4byte sWailmerPose155
+.4byte sWailmerPose156
+.4byte sWailmerPose157
+.4byte sWailmerPose158
+.4byte sWailmerPose159
+.4byte sWailmerPose160
+.4byte sWailmerPose161
+.4byte sWailmerPose162
+.4byte sWailmerPose163
+.4byte sWailmerPose164
+.4byte sWailmerPose165
+.4byte sWailmerPose166
+.4byte sWailmerPose167
+.4byte sWailmerPose168
+.4byte sWailmerPose169
+.4byte sWailmerPose170
+.4byte sWailmerPose171
+.4byte sWailmerPose172
+.4byte sWailmerPose173
+.4byte sWailmerPose174
+.4byte sWailmerPose175
+.4byte sWailmerPose176
+.4byte sWailmerPose177
+.4byte sWailmerPose178
+.4byte sWailmerPose179
+.4byte sWailmerPose180
+.4byte sWailmerPose181
+.4byte sWailmerPose182
+.4byte sWailmerPose183
+.4byte sWailmerPose184
+.4byte sWailmerPose185
+.4byte sWailmerPose186
+.4byte sWailmerPose187
+.4byte sWailmerPose188
+.4byte sWailmerPose189
+.4byte sWailmerPose190
+.4byte sWailmerPose191
+.4byte sWailmerPose192
+.4byte sWailmerPose193
+.4byte sWailmerPose194
+.4byte sWailmerPose195
+.4byte sWailmerPose196
+.4byte sWailmerPose197
+.4byte sWailmerPose198
+.4byte sWailmerPose199
+.4byte sWailmerPose200
+.4byte sWailmerPose201
+.4byte sWailmerPose202
+.4byte sWailmerPose203
+.4byte sWailmerPose204
+.4byte sWailmerPose205
+.4byte sWailmerPose206
+.4byte sWailmerPose207
+.4byte sWailmerPose208
+.4byte sWailmerPose209
+.4byte sWailmerPose210
+.4byte sWailmerPose211
+.4byte sWailmerPose212
+.4byte sWailmerPose213
+.4byte sWailmerPose214
+.4byte sWailmerPose215
+.4byte sWailmerPose216
+.4byte sWailmerPose217
+.4byte sWailmerPose218
+sAxPositionsWailmer:
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,   -6, 	 -13,  -15, 	  10,  -15, 	  -1,  -14
+.2byte   -1,   -3, 	 -11,   -8, 	   9,   -8, 	  -1,  -11
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+.2byte    6,   -9, 	   5,  -22, 	  -9,   -9, 	  -2,  -14
+.2byte    5,   -6, 	   4,  -12, 	  -8,   -4, 	  -1,  -12
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    6,  -10, 	   0,  -24, 	  -2,   -9, 	  -2,  -14
+.2byte    7,   -8, 	   0,  -15, 	  -1,   -1, 	  -2,  -10
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    5,  -16, 	 -12,  -20, 	   4,   -8, 	  -4,  -13
+.2byte    4,  -16, 	 -13,  -13, 	   3,   -1, 	  -3,  -11
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte   -1,  -19, 	  12,  -15, 	 -14,  -15, 	  -1,  -12
+.2byte   -1,  -17, 	  11,   -7, 	 -12,   -7, 	  -1,  -11
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -7,  -16, 	  10,  -20, 	  -6,   -8, 	   2,  -13
+.2byte   -6,  -16, 	  11,  -13, 	  -5,   -1, 	   1,  -11
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -8,  -10, 	  -2,  -24, 	   0,   -9, 	   0,  -14
+.2byte   -9,   -8, 	  -2,  -15, 	  -1,   -1, 	   0,  -10
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -8,   -9, 	  -7,  -22, 	   7,   -9, 	   0,  -14
+.2byte   -7,   -6, 	  -6,  -12, 	   6,   -4, 	  -1,  -12
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,   -6, 	 -13,  -15, 	  10,  -15, 	  -1,  -14
+.2byte   -1,   -3, 	 -11,   -8, 	   9,   -8, 	  -1,  -11
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -11, 	  -1,  -12
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+.2byte    6,   -9, 	   5,  -22, 	  -9,   -9, 	  -2,  -14
+.2byte    5,   -6, 	   4,  -12, 	  -8,   -4, 	  -1,  -12
+.2byte    3,   -5, 	   4,  -20, 	 -10,   -8, 	  -1,  -11
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    6,  -10, 	   0,  -24, 	  -2,   -9, 	  -2,  -14
+.2byte    7,   -8, 	   0,  -15, 	  -1,   -1, 	  -2,  -10
+.2byte    6,   -6, 	  -4,  -22, 	  -7,   -6, 	  -1,  -13
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    5,  -16, 	 -12,  -20, 	   4,   -8, 	  -4,  -13
+.2byte    4,  -16, 	 -13,  -13, 	   3,   -1, 	  -3,  -11
+.2byte    5,  -11, 	 -11,  -18, 	   4,   -5, 	  -3,  -13
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte   -1,  -19, 	  12,  -15, 	 -14,  -15, 	  -1,  -12
+.2byte   -1,  -17, 	  11,   -7, 	 -12,   -7, 	  -1,  -11
+.2byte   -1,  -17, 	  11,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -7,  -16, 	  10,  -20, 	  -6,   -8, 	   2,  -13
+.2byte   -6,  -16, 	  11,  -13, 	  -5,   -1, 	   1,  -11
+.2byte   -7,  -11, 	   9,  -18, 	  -6,   -5, 	   1,  -13
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -8,  -10, 	  -2,  -24, 	   0,   -9, 	   0,  -14
+.2byte   -9,   -8, 	  -2,  -15, 	  -1,   -1, 	   0,  -10
+.2byte   -8,   -6, 	   2,  -22, 	   5,   -6, 	  -1,  -13
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -8,   -9, 	  -7,  -22, 	   7,   -9, 	   0,  -14
+.2byte   -7,   -6, 	  -6,  -12, 	   6,   -4, 	  -1,  -12
+.2byte   -5,   -5, 	  -6,  -20, 	   8,   -8, 	  -1,  -11
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,   -6, 	 -13,  -15, 	  10,  -15, 	  -1,  -14
+.2byte   -1,   -3, 	 -11,   -8, 	   9,   -8, 	  -1,  -11
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -11, 	  -1,  -12
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+.2byte    6,   -9, 	   5,  -22, 	  -9,   -9, 	  -2,  -14
+.2byte    5,   -6, 	   4,  -12, 	  -8,   -4, 	  -1,  -12
+.2byte    3,   -5, 	   4,  -20, 	 -10,   -8, 	  -1,  -11
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    6,  -10, 	   0,  -24, 	  -2,   -9, 	  -2,  -14
+.2byte    7,   -8, 	   0,  -15, 	  -1,   -1, 	  -2,  -10
+.2byte    6,   -6, 	  -4,  -22, 	  -7,   -6, 	  -1,  -13
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    5,  -16, 	 -12,  -20, 	   4,   -8, 	  -4,  -13
+.2byte    4,  -16, 	 -13,  -13, 	   3,   -1, 	  -3,  -11
+.2byte    5,  -11, 	 -11,  -18, 	   4,   -5, 	  -3,  -13
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte   -1,  -19, 	  12,  -15, 	 -14,  -15, 	  -1,  -12
+.2byte   -1,  -17, 	  11,   -7, 	 -12,   -7, 	  -1,  -11
+.2byte   -1,  -17, 	  11,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -7,  -16, 	  10,  -20, 	  -6,   -8, 	   2,  -13
+.2byte   -6,  -16, 	  11,  -13, 	  -5,   -1, 	   1,  -11
+.2byte   -7,  -11, 	   9,  -18, 	  -6,   -5, 	   1,  -13
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -8,  -10, 	  -2,  -24, 	   0,   -9, 	   0,  -14
+.2byte   -9,   -8, 	  -2,  -15, 	  -1,   -1, 	   0,  -10
+.2byte   -8,   -6, 	   2,  -22, 	   5,   -6, 	  -1,  -13
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -8,   -9, 	  -7,  -22, 	   7,   -9, 	   0,  -14
+.2byte   -7,   -6, 	  -6,  -12, 	   6,   -4, 	  -1,  -12
+.2byte   -5,   -5, 	  -6,  -20, 	   8,   -8, 	  -1,  -11
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -19, 	 -11,  -18, 	  10,  -18, 	  -1,  -11
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -11, 	  -1,  -12
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+.2byte    1,  -18, 	   6,  -20, 	 -13,  -15, 	   0,  -11
+.2byte    3,   -5, 	   4,  -20, 	 -10,   -8, 	  -1,  -11
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    2,  -18, 	  -9,  -20, 	 -12,  -11, 	  -2,  -10
+.2byte    6,   -6, 	  -4,  -22, 	  -7,   -6, 	  -1,  -13
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    1,  -19, 	 -14,  -13, 	   1,   -6, 	  -4,  -11
+.2byte    5,  -11, 	 -11,  -18, 	   4,   -5, 	  -3,  -13
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	  11,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -3,  -19, 	  12,  -13, 	  -3,   -6, 	   2,  -11
+.2byte   -7,  -11, 	   9,  -18, 	  -6,   -5, 	   1,  -13
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -4,  -18, 	   7,  -20, 	  10,  -11, 	   0,  -10
+.2byte   -8,   -6, 	   2,  -22, 	   5,   -6, 	  -1,  -13
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -3,  -18, 	  -8,  -20, 	  11,  -15, 	  -2,  -11
+.2byte   -5,   -5, 	  -6,  -20, 	   8,   -8, 	  -1,  -11
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -16, 	 -12,  -16, 	  11,  -16, 	  -1,  -10
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+.2byte    0,  -16, 	   7,  -18, 	 -14,  -14, 	   0,  -10
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    2,  -16, 	  -8,  -20, 	 -11,   -8, 	  -1,   -9
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    3,  -17, 	 -15,  -15, 	   5,   -7, 	  -4,  -10
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte   -1,  -18, 	  10,  -10, 	 -12,  -10, 	  -1,  -11
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -5,  -17, 	  13,  -15, 	  -7,   -7, 	   2,  -10
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -4,  -16, 	   6,  -20, 	   9,   -8, 	  -1,   -9
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -2,  -16, 	  -9,  -18, 	  12,  -14, 	  -2,  -10
+.2byte   -6,   -9, 	  -7,  -20, 	   7,   -5, 	  -1,  -10
+.2byte   -6,   -6, 	  -6,   -9, 	   6,   -3, 	   0,   -8
+.2byte    0,  -10, 	 -11,  -21, 	  13,  -21, 	   0,  -14
+.2byte    3,  -12, 	   5,  -26, 	 -11,  -17, 	  -2,  -12
+.2byte    7,  -14, 	  -6,  -25, 	  -2,  -12, 	  -3,  -14
+.2byte    6,  -17, 	 -10,  -20, 	   1,   -8, 	  -3,  -12
+.2byte    0,  -21, 	  13,  -14, 	 -12,  -14, 	   0,  -13
+.2byte   -7,  -17, 	   9,  -20, 	  -2,   -8, 	   2,  -12
+.2byte   -8,  -14, 	   5,  -25, 	   1,  -12, 	   2,  -14
+.2byte   -4,  -12, 	  -6,  -26, 	  10,  -17, 	   1,  -12
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,   -6, 	 -13,  -15, 	  10,  -15, 	  -1,  -14
+.2byte   -1,   -3, 	 -11,   -8, 	   9,   -8, 	  -1,  -11
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+.2byte    6,   -9, 	   5,  -22, 	  -9,   -9, 	  -2,  -14
+.2byte    5,   -6, 	   4,  -12, 	  -8,   -4, 	  -1,  -12
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    6,  -10, 	   0,  -24, 	  -2,   -9, 	  -2,  -14
+.2byte    7,   -8, 	   0,  -15, 	  -1,   -1, 	  -2,  -10
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    5,  -16, 	 -12,  -20, 	   4,   -8, 	  -4,  -13
+.2byte    4,  -16, 	 -13,  -13, 	   3,   -1, 	  -3,  -11
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte   -1,  -19, 	  12,  -15, 	 -14,  -15, 	  -1,  -12
+.2byte   -1,  -17, 	  11,   -7, 	 -12,   -7, 	  -1,  -11
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -7,  -16, 	  10,  -20, 	  -6,   -8, 	   2,  -13
+.2byte   -6,  -16, 	  11,  -13, 	  -5,   -1, 	   1,  -11
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -8,  -10, 	  -2,  -24, 	   0,   -9, 	   0,  -14
+.2byte   -9,   -8, 	  -2,  -15, 	  -1,   -1, 	   0,  -10
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -8,   -9, 	  -7,  -22, 	   7,   -9, 	   0,  -14
+.2byte   -7,   -6, 	  -6,  -12, 	   6,   -4, 	  -1,  -12
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -11, 	  -1,  -12
+.2byte   -5,   -4, 	  -6,  -19, 	   8,   -7, 	  -1,  -10
+.2byte   -8,   -5, 	   2,  -21, 	   5,   -5, 	  -1,  -12
+.2byte   -8,  -10, 	   8,  -17, 	  -7,   -4, 	   0,  -12
+.2byte   -1,  -17, 	  11,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte    6,  -10, 	 -10,  -17, 	   5,   -4, 	  -2,  -12
+.2byte    6,   -5, 	  -4,  -21, 	  -7,   -5, 	  -1,  -12
+.2byte    3,   -4, 	   4,  -19, 	 -10,   -7, 	  -1,  -10
+.2byte   -1,  -16, 	 -12,  -16, 	  11,  -16, 	  -1,  -10
+.2byte    0,  -16, 	   7,  -18, 	 -14,  -14, 	   0,  -10
+.2byte    2,  -16, 	  -8,  -20, 	 -11,   -8, 	  -1,   -9
+.2byte    4,  -17, 	 -14,  -15, 	   6,   -7, 	  -3,  -10
+.2byte   -1,  -17, 	  10,   -9, 	 -12,   -9, 	  -1,  -10
+.2byte   -6,  -17, 	  12,  -15, 	  -8,   -7, 	   1,  -10
+.2byte   -4,  -16, 	   6,  -20, 	   9,   -8, 	  -1,   -9
+.2byte   -2,  -16, 	  -9,  -18, 	  12,  -14, 	  -2,  -10
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -1,  -19, 	 -11,  -18, 	  10,  -18, 	  -1,  -11
+.2byte   -1,   -3, 	 -12,  -12, 	  10,  -11, 	  -1,  -12
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+.2byte    1,  -18, 	   6,  -20, 	 -13,  -15, 	   0,  -11
+.2byte    3,   -5, 	   4,  -20, 	 -10,   -8, 	  -1,  -11
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    2,  -18, 	  -9,  -20, 	 -12,  -11, 	  -2,  -10
+.2byte    6,   -6, 	  -4,  -22, 	  -7,   -6, 	  -1,  -13
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    1,  -19, 	 -14,  -13, 	   1,   -6, 	  -4,  -11
+.2byte    5,  -11, 	 -11,  -18, 	   4,   -5, 	  -3,  -13
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -4, 	  -1,   -9
+.2byte   -1,  -17, 	  11,  -12, 	 -12,  -12, 	  -1,  -10
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -3,  -19, 	  12,  -13, 	  -3,   -6, 	   2,  -11
+.2byte   -7,  -11, 	   9,  -18, 	  -6,   -5, 	   1,  -13
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -4,  -18, 	   7,  -20, 	  10,  -11, 	   0,  -10
+.2byte   -8,   -6, 	   2,  -22, 	   5,   -6, 	  -1,  -13
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -3,  -18, 	  -8,  -20, 	  11,  -15, 	  -2,  -11
+.2byte   -5,   -5, 	  -6,  -20, 	   8,   -8, 	  -1,  -11
+.2byte   -1,   -6, 	 -13,  -15, 	  10,  -15, 	  -1,  -14
+.2byte   -8,   -9, 	  -7,  -22, 	   7,   -9, 	   0,  -14
+.2byte   -8,  -10, 	  -2,  -24, 	   0,   -9, 	   0,  -14
+.2byte   -7,  -16, 	  10,  -20, 	  -6,   -8, 	   2,  -13
+.2byte   -1,  -19, 	  12,  -15, 	 -14,  -15, 	  -1,  -12
+.2byte    5,  -16, 	 -12,  -20, 	   4,   -8, 	  -4,  -13
+.2byte    6,  -10, 	   0,  -24, 	  -2,   -9, 	  -2,  -14
+.2byte    6,   -9, 	   5,  -22, 	  -9,   -9, 	  -2,  -14
+.2byte   -1,   -5, 	 -12,  -10, 	  10,  -10, 	  -1,  -11
+.2byte   -7,   -8, 	  -7,  -20, 	   7,   -6, 	  -1,  -14
+.2byte   -9,  -10, 	   0,  -22, 	  -2,   -4, 	   0,  -13
+.2byte   -5,  -18, 	   9,  -18, 	  -6,   -5, 	   0,  -13
+.2byte   -1,  -18, 	  12,  -10, 	 -13,   -9, 	  -1,  -12
+.2byte    3,  -18, 	 -11,  -18, 	   4,   -5, 	  -2,  -13
+.2byte    7,  -10, 	  -2,  -22, 	   0,   -4, 	  -2,  -13
+.2byte    5,   -8, 	   5,  -20, 	  -9,   -6, 	  -1,  -14
+sWailmerAnimTable1:
+.4byte sWailmerAnims_1_1
+.4byte sWailmerAnims_1_2
+.4byte sWailmerAnims_1_3
+.4byte sWailmerAnims_1_4
+.4byte sWailmerAnims_1_5
+.4byte sWailmerAnims_1_6
+.4byte sWailmerAnims_1_7
+.4byte sWailmerAnims_1_8
+sWailmerAnimTable2:
+.4byte sWailmerAnims_2_1
+.4byte sWailmerAnims_2_2
+.4byte sWailmerAnims_2_3
+.4byte sWailmerAnims_2_4
+.4byte sWailmerAnims_2_5
+.4byte sWailmerAnims_2_6
+.4byte sWailmerAnims_2_7
+.4byte sWailmerAnims_2_8
+sWailmerAnimTable3:
+.4byte sWailmerAnims_3_1
+.4byte sWailmerAnims_3_2
+.4byte sWailmerAnims_3_3
+.4byte sWailmerAnims_3_4
+.4byte sWailmerAnims_3_5
+.4byte sWailmerAnims_3_6
+.4byte sWailmerAnims_3_7
+.4byte sWailmerAnims_3_8
+sWailmerAnimTable4:
+.4byte sWailmerAnims_4_1
+.4byte sWailmerAnims_4_2
+.4byte sWailmerAnims_4_3
+.4byte sWailmerAnims_4_4
+.4byte sWailmerAnims_4_5
+.4byte sWailmerAnims_4_6
+.4byte sWailmerAnims_4_7
+.4byte sWailmerAnims_4_8
+sWailmerAnimTable5:
+.4byte sWailmerAnims_5_1
+.4byte sWailmerAnims_5_2
+.4byte sWailmerAnims_5_3
+.4byte sWailmerAnims_5_4
+.4byte sWailmerAnims_5_5
+.4byte sWailmerAnims_5_6
+.4byte sWailmerAnims_5_7
+.4byte sWailmerAnims_5_8
+sWailmerAnimTable6:
+.4byte sWailmerAnims_6_1
+.4byte sWailmerAnims_6_1
+.4byte sWailmerAnims_6_1
+.4byte sWailmerAnims_6_1
+.4byte sWailmerAnims_6_1
+.4byte sWailmerAnims_6_1
+.4byte sWailmerAnims_6_1
+.4byte sWailmerAnims_6_1
+sWailmerAnimTable7:
+.4byte sWailmerAnims_7_1
+.4byte sWailmerAnims_7_2
+.4byte sWailmerAnims_7_3
+.4byte sWailmerAnims_7_4
+.4byte sWailmerAnims_7_5
+.4byte sWailmerAnims_7_6
+.4byte sWailmerAnims_7_7
+.4byte sWailmerAnims_7_8
+sWailmerAnimTable8:
+.4byte sWailmerAnims_8_1
+.4byte sWailmerAnims_8_2
+.4byte sWailmerAnims_8_3
+.4byte sWailmerAnims_8_4
+.4byte sWailmerAnims_8_5
+.4byte sWailmerAnims_8_6
+.4byte sWailmerAnims_8_7
+.4byte sWailmerAnims_8_8
+sWailmerAnimTable9:
+.4byte sWailmerAnims_9_1
+.4byte sWailmerAnims_9_2
+.4byte sWailmerAnims_9_3
+.4byte sWailmerAnims_9_4
+.4byte sWailmerAnims_9_5
+.4byte sWailmerAnims_9_6
+.4byte sWailmerAnims_9_7
+.4byte sWailmerAnims_9_8
+sWailmerAnimTable10:
+.4byte sWailmerAnims_10_1
+.4byte sWailmerAnims_10_2
+.4byte sWailmerAnims_10_3
+.4byte sWailmerAnims_10_4
+.4byte sWailmerAnims_10_5
+.4byte sWailmerAnims_10_6
+.4byte sWailmerAnims_10_7
+.4byte sWailmerAnims_10_8
+sWailmerAnimTable11:
+.4byte sWailmerAnims_11_1
+.4byte sWailmerAnims_11_2
+.4byte sWailmerAnims_11_3
+.4byte sWailmerAnims_11_4
+.4byte sWailmerAnims_11_5
+.4byte sWailmerAnims_11_6
+.4byte sWailmerAnims_11_7
+.4byte sWailmerAnims_11_8
+sWailmerAnimTable12:
+.4byte sWailmerAnims_12_1
+.4byte sWailmerAnims_12_2
+.4byte sWailmerAnims_12_3
+.4byte sWailmerAnims_12_4
+.4byte sWailmerAnims_12_5
+.4byte sWailmerAnims_12_6
+.4byte sWailmerAnims_12_7
+.4byte sWailmerAnims_12_8
+sWailmerAnimTable13:
+.4byte sWailmerAnims_13_1
+.4byte sWailmerAnims_13_2
+.4byte sWailmerAnims_13_3
+.4byte sWailmerAnims_13_4
+.4byte sWailmerAnims_13_5
+.4byte sWailmerAnims_13_6
+.4byte sWailmerAnims_13_7
+.4byte sWailmerAnims_13_8
+sAxAnimationsWailmer:
+.4byte sWailmerAnimTable1
+.4byte sWailmerAnimTable2
+.4byte sWailmerAnimTable3
+.4byte sWailmerAnimTable4
+.4byte sWailmerAnimTable5
+.4byte sWailmerAnimTable6
+.4byte sWailmerAnimTable7
+.4byte sWailmerAnimTable8
+.4byte sWailmerAnimTable9
+.4byte sWailmerAnimTable10
+.4byte sWailmerAnimTable11
+.4byte sWailmerAnimTable12
+.4byte sWailmerAnimTable13
+sAxSpritesWailmer:
+.4byte sWailmerSprites1
+.4byte sWailmerSprites2
+.4byte sWailmerSprites3
+.4byte sWailmerSprites4
+.4byte sWailmerSprites5
+.4byte sWailmerSprites6
+.4byte sWailmerSprites7
+.4byte sWailmerSprites8
+.4byte sWailmerSprites9
+.4byte sWailmerSprites10
+.4byte sWailmerSprites11
+.4byte sWailmerSprites12
+.4byte sWailmerSprites13
+.4byte sWailmerSprites14
+.4byte sWailmerSprites15
+.4byte sWailmerSprites16
+.4byte sWailmerSprites17
+.4byte sWailmerSprites18
+.4byte sWailmerSprites19
+.4byte sWailmerSprites20
+.4byte sWailmerSprites21
+.4byte sWailmerSprites22
+.4byte sWailmerSprites23
+.4byte sWailmerSprites24
+.4byte sWailmerSprites25
+.4byte sWailmerSprites26
+.4byte sWailmerSprites27
+.4byte sWailmerSprites28
+.4byte sWailmerSprites29
+.4byte sWailmerSprites30
+.4byte sWailmerSprites31
+.4byte sWailmerSprites32
+.4byte sWailmerSprites33
+.4byte sWailmerSprites34
+.4byte sWailmerSprites35
+.4byte sWailmerSprites36
+.4byte sWailmerSprites37
+sAxMainWailmer:
+ax_main sAxPosesWailmer, sAxAnimationsWailmer, 13, sAxSpritesWailmer, sAxPositionsWailmer

--- a/data/ax/wailord.inc
+++ b/data/ax/wailord.inc
@@ -1,0 +1,2988 @@
+.global gAxWailord
+gAxWailord:
+ax_siro sAxMainWailord
+sWailordPose1:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose2:
+ax_pose 1, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose3:
+ax_pose 2, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose4:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose5:
+ax_pose 4, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose6:
+ax_pose 5, 0x01ce, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose7:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose8:
+ax_pose 7, 0x01d4, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose9:
+ax_pose 8, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose10:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose11:
+ax_pose 10, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose12:
+ax_pose 11, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose13:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose14:
+ax_pose 13, 0x01cf, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose15:
+ax_pose 14, 0x01cc, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose16:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose17:
+ax_pose 10, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose18:
+ax_pose 11, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose19:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose20:
+ax_pose 7, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose21:
+ax_pose 8, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose22:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose23:
+ax_pose 4, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose24:
+ax_pose 5, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose25:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose26:
+ax_pose 1, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose27:
+ax_pose 2, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose28:
+ax_pose 15, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose29:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose30:
+ax_pose 4, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose31:
+ax_pose 5, 0x01ce, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose32:
+ax_pose 16, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose33:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose34:
+ax_pose 7, 0x01d4, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose35:
+ax_pose 8, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose36:
+ax_pose 17, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose37:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose38:
+ax_pose 10, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose39:
+ax_pose 11, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose40:
+ax_pose 18, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose41:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose42:
+ax_pose 13, 0x01cf, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose43:
+ax_pose 14, 0x01cc, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose44:
+ax_pose 19, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose45:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose46:
+ax_pose 10, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose47:
+ax_pose 11, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose48:
+ax_pose 18, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose49:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose50:
+ax_pose 7, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose51:
+ax_pose 8, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose52:
+ax_pose 17, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose53:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose54:
+ax_pose 4, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose55:
+ax_pose 5, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose56:
+ax_pose 16, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose57:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose58:
+ax_pose 1, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose59:
+ax_pose 2, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose60:
+ax_pose 15, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose61:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose62:
+ax_pose 4, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose63:
+ax_pose 5, 0x01ce, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose64:
+ax_pose 16, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose65:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose66:
+ax_pose 7, 0x01d4, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose67:
+ax_pose 8, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose68:
+ax_pose 17, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose69:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose70:
+ax_pose 10, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose71:
+ax_pose 11, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose72:
+ax_pose 18, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose73:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose74:
+ax_pose 13, 0x01cf, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose75:
+ax_pose 14, 0x01cc, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose76:
+ax_pose 19, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose77:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose78:
+ax_pose 10, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose79:
+ax_pose 11, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose80:
+ax_pose 18, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose81:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose82:
+ax_pose 7, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose83:
+ax_pose 8, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose84:
+ax_pose 17, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose85:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose86:
+ax_pose 4, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose87:
+ax_pose 5, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose88:
+ax_pose 16, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose89:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose90:
+ax_pose 15, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose91:
+ax_pose 20, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose92:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose93:
+ax_pose 16, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose94:
+ax_pose 21, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose95:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose96:
+ax_pose 17, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose97:
+ax_pose 22, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose98:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose99:
+ax_pose 18, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose100:
+ax_pose 23, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose101:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose102:
+ax_pose 19, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose103:
+ax_pose 24, 0x01cd, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose104:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose105:
+ax_pose 18, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose106:
+ax_pose 23, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose107:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose108:
+ax_pose 17, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose109:
+ax_pose 22, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose110:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose111:
+ax_pose 16, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose112:
+ax_pose 21, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose113:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose114:
+ax_pose 1, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose115:
+ax_pose 2, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose116:
+ax_pose 15, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose117:
+ax_pose 20, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose118:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose119:
+ax_pose 4, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose120:
+ax_pose 5, 0x01ce, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose121:
+ax_pose 16, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose122:
+ax_pose 21, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose123:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose124:
+ax_pose 7, 0x01d4, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose125:
+ax_pose 8, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose126:
+ax_pose 17, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose127:
+ax_pose 22, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose128:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose129:
+ax_pose 10, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose130:
+ax_pose 11, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose131:
+ax_pose 18, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose132:
+ax_pose 23, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose133:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose134:
+ax_pose 13, 0x01cf, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose135:
+ax_pose 14, 0x01cc, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose136:
+ax_pose 19, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose137:
+ax_pose 24, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose138:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose139:
+ax_pose 10, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose140:
+ax_pose 11, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose141:
+ax_pose 18, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose142:
+ax_pose 23, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose143:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose144:
+ax_pose 7, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose145:
+ax_pose 8, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose146:
+ax_pose 17, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose147:
+ax_pose 22, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose148:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose149:
+ax_pose 4, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose150:
+ax_pose 5, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose151:
+ax_pose 16, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose152:
+ax_pose 21, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose153:
+ax_pose 25, 0x41d5, 0xc0e2, 0x5c00
+ax_pose 26, 0x41f5, 0x40e2, 0x5c20
+ax_pose 27, 0x41f5, 0x4102, 0x5c24
+ax_pose_terminator
+sWailordPose154:
+ax_pose 28, 0x41d6, 0xc0e2, 0x5c00
+ax_pose 29, 0x41f6, 0x40e2, 0x5c20
+ax_pose 30, 0x41f6, 0x4102, 0x5c24
+ax_pose_terminator
+sWailordPose155:
+ax_pose 31, 0x01c5, 0xc0e0, 0x5c00
+ax_pose_terminator
+sWailordPose156:
+ax_pose 32, 0x01c1, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose157:
+ax_pose 33, 0x01c1, 0xd0d4, 0x5c00
+ax_pose_terminator
+sWailordPose158:
+ax_pose 34, 0x01c5, 0xd0db, 0x5c00
+ax_pose_terminator
+sWailordPose159:
+ax_pose 35, 0x01ca, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose160:
+ax_pose 34, 0x01c5, 0xc0e5, 0x5c00
+ax_pose_terminator
+sWailordPose161:
+ax_pose 33, 0x01c3, 0xc0ea, 0x5c00
+ax_pose_terminator
+sWailordPose162:
+ax_pose 32, 0x01c1, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose163:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose164:
+ax_pose 1, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose165:
+ax_pose 2, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose166:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose167:
+ax_pose 4, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose168:
+ax_pose 5, 0x01ce, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose169:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose170:
+ax_pose 7, 0x01d4, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose171:
+ax_pose 8, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose172:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose173:
+ax_pose 10, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose174:
+ax_pose 11, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose175:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose176:
+ax_pose 13, 0x01cf, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose177:
+ax_pose 14, 0x01cc, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose178:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose179:
+ax_pose 10, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose180:
+ax_pose 11, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose181:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose182:
+ax_pose 7, 0x01d4, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose183:
+ax_pose 8, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose184:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose185:
+ax_pose 4, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose186:
+ax_pose 5, 0x01ce, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose187:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose188:
+ax_pose 3, 0x01c8, 0xc0e7, 0x5c00
+ax_pose_terminator
+sWailordPose189:
+ax_pose 6, 0x01d8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose190:
+ax_pose 9, 0x01d2, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose191:
+ax_pose 12, 0x01cd, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose192:
+ax_pose 9, 0x01d2, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose193:
+ax_pose 6, 0x01d8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose194:
+ax_pose 3, 0x01c8, 0xd0d9, 0x5c00
+ax_pose_terminator
+sWailordPose195:
+ax_pose 20, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose196:
+ax_pose 21, 0x01c7, 0xd0d9, 0x5c00
+ax_pose_terminator
+sWailordPose197:
+ax_pose 22, 0x01d6, 0xd0db, 0x5c00
+ax_pose_terminator
+sWailordPose198:
+ax_pose 23, 0x01d1, 0xd0db, 0x5c00
+ax_pose_terminator
+sWailordPose199:
+ax_pose 24, 0x01cb, 0xc0e9, 0x5c00
+ax_pose_terminator
+sWailordPose200:
+ax_pose 23, 0x01d1, 0xc0e5, 0x5c00
+ax_pose_terminator
+sWailordPose201:
+ax_pose 22, 0x01d6, 0xc0e5, 0x5c00
+ax_pose_terminator
+sWailordPose202:
+ax_pose 21, 0x01c7, 0xc0e7, 0x5c00
+ax_pose_terminator
+sWailordPose203:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose204:
+ax_pose 20, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose205:
+ax_pose 15, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose206:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose207:
+ax_pose 21, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose208:
+ax_pose 16, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+sWailordPose209:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose210:
+ax_pose 22, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose211:
+ax_pose 17, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose212:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose213:
+ax_pose 23, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose214:
+ax_pose 18, 0x01cf, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose215:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose216:
+ax_pose 24, 0x01cd, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose217:
+ax_pose 19, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose218:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose219:
+ax_pose 23, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose220:
+ax_pose 18, 0x01cf, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose221:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose222:
+ax_pose 22, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose223:
+ax_pose 17, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose224:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose225:
+ax_pose 21, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose226:
+ax_pose 16, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose227:
+ax_pose 15, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose228:
+ax_pose 16, 0x01c8, 0xc0e7, 0x5c00
+ax_pose_terminator
+sWailordPose229:
+ax_pose 17, 0x01d6, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose230:
+ax_pose 18, 0x01d1, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose231:
+ax_pose 19, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose232:
+ax_pose 18, 0x01d1, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose233:
+ax_pose 17, 0x01d6, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose234:
+ax_pose 16, 0x01c8, 0xd0d9, 0x5c00
+ax_pose_terminator
+sWailordPose235:
+ax_pose 0, 0x01c8, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose236:
+ax_pose 3, 0x01c8, 0xc0e4, 0x5c00
+ax_pose_terminator
+sWailordPose237:
+ax_pose 6, 0x01d8, 0xc0e2, 0x5c00
+ax_pose_terminator
+sWailordPose238:
+ax_pose 9, 0x01d0, 0xc0e3, 0x5c00
+ax_pose_terminator
+sWailordPose239:
+ax_pose 12, 0x01cb, 0xc0e8, 0x5c00
+ax_pose_terminator
+sWailordPose240:
+ax_pose 9, 0x01d0, 0xd0dd, 0x5c00
+ax_pose_terminator
+sWailordPose241:
+ax_pose 6, 0x01d8, 0xd0de, 0x5c00
+ax_pose_terminator
+sWailordPose242:
+ax_pose 3, 0x01c8, 0xd0dc, 0x5c00
+ax_pose_terminator
+.align 2
+sWailordAnims_1_1:
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 1, 0, 0,
+ax_anim 6, 0, 1, 0, 2, 0, 0,
+ax_anim 6, 0, 1, 0, 3, 0, 0,
+ax_anim 8, 0, 1, 0, 4, 0, 0,
+ax_anim 8, 0, 0, 0, 4, 0, 0,
+ax_anim 10, 0, 2, 0, 4, 0, 0,
+ax_anim 8, 0, 2, 0, 3, 0, 0,
+ax_anim 6, 0, 2, 0, 2, 0, 0,
+ax_anim 6, 0, 2, 0, 1, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_1_2:
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 1, 0, 0,
+ax_anim 6, 0, 4, 0, 2, 0, 0,
+ax_anim 6, 0, 4, 0, 3, 0, 0,
+ax_anim 8, 0, 4, 0, 4, 0, 0,
+ax_anim 8, 0, 3, 0, 4, 0, 0,
+ax_anim 10, 0, 5, 0, 4, 0, 0,
+ax_anim 8, 0, 5, 0, 3, 0, 0,
+ax_anim 6, 0, 5, 0, 2, 0, 0,
+ax_anim 6, 0, 5, 0, 1, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_1_3:
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 1, 0, 0,
+ax_anim 6, 0, 7, 0, 2, 0, 0,
+ax_anim 6, 0, 7, 0, 3, 0, 0,
+ax_anim 8, 0, 7, 0, 4, 0, 0,
+ax_anim 8, 0, 6, 0, 4, 0, 0,
+ax_anim 10, 0, 8, 0, 4, 0, 0,
+ax_anim 8, 0, 8, 0, 3, 0, 0,
+ax_anim 6, 0, 8, 0, 2, 0, 0,
+ax_anim 6, 0, 8, 0, 1, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_1_4:
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 1, 0, 0,
+ax_anim 6, 0, 10, 0, 2, 0, 0,
+ax_anim 6, 0, 10, 0, 3, 0, 0,
+ax_anim 8, 0, 10, 0, 4, 0, 0,
+ax_anim 8, 0, 9, 0, 4, 0, 0,
+ax_anim 10, 0, 11, 0, 4, 0, 0,
+ax_anim 8, 0, 11, 0, 3, 0, 0,
+ax_anim 6, 0, 11, 0, 2, 0, 0,
+ax_anim 6, 0, 11, 0, 1, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_1_5:
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 1, 0, 0,
+ax_anim 6, 0, 13, 0, 2, 0, 0,
+ax_anim 6, 0, 13, 0, 3, 0, 0,
+ax_anim 8, 0, 13, 0, 4, 0, 0,
+ax_anim 8, 0, 12, 0, 4, 0, 0,
+ax_anim 10, 0, 14, 0, 4, 0, 0,
+ax_anim 8, 0, 14, 0, 3, 0, 0,
+ax_anim 6, 0, 14, 0, 2, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_1_6:
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 1, 0, 0,
+ax_anim 6, 0, 16, 0, 2, 0, 0,
+ax_anim 6, 0, 16, 0, 3, 0, 0,
+ax_anim 8, 0, 16, 0, 4, 0, 0,
+ax_anim 8, 0, 15, 0, 4, 0, 0,
+ax_anim 10, 0, 17, 0, 4, 0, 0,
+ax_anim 8, 0, 17, 0, 3, 0, 0,
+ax_anim 6, 0, 17, 0, 2, 0, 0,
+ax_anim 6, 0, 17, 0, 1, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_1_7:
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 1, 0, 0,
+ax_anim 6, 0, 19, 0, 2, 0, 0,
+ax_anim 6, 0, 19, 0, 3, 0, 0,
+ax_anim 8, 0, 19, 0, 4, 0, 0,
+ax_anim 8, 0, 18, 0, 4, 0, 0,
+ax_anim 10, 0, 20, 0, 4, 0, 0,
+ax_anim 8, 0, 20, 0, 3, 0, 0,
+ax_anim 6, 0, 20, 0, 2, 0, 0,
+ax_anim 6, 0, 20, 0, 1, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_1_8:
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 1, 0, 0,
+ax_anim 6, 0, 22, 0, 2, 0, 0,
+ax_anim 6, 0, 22, 0, 3, 0, 0,
+ax_anim 8, 0, 22, 0, 4, 0, 0,
+ax_anim 8, 0, 21, 0, 4, 0, 0,
+ax_anim 10, 0, 23, 0, 4, 0, 0,
+ax_anim 8, 0, 23, 0, 3, 0, 0,
+ax_anim 6, 0, 23, 0, 2, 0, 0,
+ax_anim 6, 0, 23, 0, 1, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 1,
+ax_anim 2, 2, 25, 0, 4, 0, 7,
+ax_anim 2, 0, 27, 0, 10, 0, 14,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWailordAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 3, -1, 3, 3,
+ax_anim 2, 2, 29, 7, 2, 7, 8,
+ax_anim 2, 0, 31, 12, 10, 12, 14,
+ax_anim 2, 0, 31, 15, 21, 15, 18,
+ax_anim 2, 1, 31, 16, 20, 16, 17,
+ax_anim 2, 0, 31, 15, 21, 15, 18,
+ax_anim 2, 0, 31, 16, 20, 16, 17,
+ax_anim 2, 0, 28, 6, 9, 6, 9,
+ax_anim_terminator
+sWailordAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 33, 1, -3, 1, 0,
+ax_anim 2, 2, 33, 6, -4, 6, 0,
+ax_anim 2, 0, 35, 10, -4, 10, 0,
+ax_anim 2, 0, 35, 14, 4, 14, 0,
+ax_anim 2, 1, 35, 14, 5, 14, 1,
+ax_anim 2, 0, 35, 14, 4, 14, 0,
+ax_anim 2, 0, 35, 14, 5, 14, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sWailordAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 37, 1, -4, 1, -2,
+ax_anim 2, 2, 37, 4, -7, 4, -4,
+ax_anim 2, 0, 39, 10, -8, 10, -9,
+ax_anim 2, 0, 39, 14, -8, 15, -13,
+ax_anim 2, 1, 39, 15, -7, 16, -12,
+ax_anim 2, 0, 39, 14, -8, 15, -13,
+ax_anim 2, 0, 39, 15, -7, 16, -12,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sWailordAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, -2, 0, -2,
+ax_anim 2, 2, 41, 0, -7, 0, -7,
+ax_anim 2, 0, 43, 0, -10, 0, -11,
+ax_anim 2, 0, 43, 0, -11, 0, -15,
+ax_anim 2, 1, 43, 1, -11, 1, -15,
+ax_anim 2, 0, 43, 0, -11, 0, -15,
+ax_anim 2, 0, 43, 1, -11, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sWailordAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 45, -1, -4, -1, -2,
+ax_anim 2, 2, 45, -4, -7, -4, -4,
+ax_anim 2, 0, 47, -10, -8, -10, -9,
+ax_anim 2, 0, 47, -14, -8, -15, -13,
+ax_anim 2, 1, 47, -15, -7, -16, -12,
+ax_anim 2, 0, 47, -14, -8, -15, -13,
+ax_anim 2, 0, 47, -15, -7, -16, -12,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sWailordAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 49, -1, -3, -1, 0,
+ax_anim 2, 2, 49, -6, -4, -6, 0,
+ax_anim 2, 0, 51, -10, -4, -10, 0,
+ax_anim 2, 0, 51, -14, 4, -14, 0,
+ax_anim 2, 1, 51, -14, 5, -14, 1,
+ax_anim 2, 0, 51, -14, 4, -14, 0,
+ax_anim 2, 0, 51, -14, 5, -14, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sWailordAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 53, -3, -1, -3, 3,
+ax_anim 2, 2, 53, -7, 2, -7, 8,
+ax_anim 2, 0, 55, -12, 10, -12, 14,
+ax_anim 2, 0, 55, -15, 21, -15, 18,
+ax_anim 2, 1, 55, -16, 20, -16, 17,
+ax_anim 2, 0, 55, -15, 21, -15, 18,
+ax_anim 2, 0, 55, -16, 20, -16, 17,
+ax_anim 2, 0, 52, -6, 9, -6, 9,
+ax_anim_terminator
+.align 2
+sWailordAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 57, 0, 0, 0, 1,
+ax_anim 2, 2, 57, 0, 4, 0, 7,
+ax_anim 2, 0, 59, 0, 10, 0, 14,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sWailordAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 61, 3, -1, 3, 3,
+ax_anim 2, 2, 61, 7, 2, 7, 8,
+ax_anim 2, 0, 63, 12, 10, 12, 14,
+ax_anim 2, 0, 63, 15, 21, 15, 18,
+ax_anim 2, 1, 63, 16, 20, 16, 17,
+ax_anim 2, 0, 63, 15, 21, 15, 18,
+ax_anim 2, 0, 63, 16, 20, 16, 17,
+ax_anim 2, 0, 60, 6, 9, 6, 9,
+ax_anim_terminator
+sWailordAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 65, 1, -3, 1, 0,
+ax_anim 2, 2, 65, 6, -4, 6, 0,
+ax_anim 2, 0, 67, 10, -4, 10, 0,
+ax_anim 2, 0, 67, 14, 4, 14, 0,
+ax_anim 2, 1, 67, 14, 5, 14, 1,
+ax_anim 2, 0, 67, 14, 4, 14, 0,
+ax_anim 2, 0, 67, 14, 5, 14, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sWailordAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 69, 1, -4, 1, -2,
+ax_anim 2, 2, 69, 4, -7, 4, -4,
+ax_anim 2, 0, 71, 10, -8, 10, -9,
+ax_anim 2, 0, 71, 14, -8, 15, -13,
+ax_anim 2, 1, 71, 15, -7, 16, -12,
+ax_anim 2, 0, 71, 14, -8, 15, -13,
+ax_anim 2, 0, 71, 15, -7, 16, -12,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sWailordAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 73, 0, -2, 0, -2,
+ax_anim 2, 2, 73, 0, -7, 0, -7,
+ax_anim 2, 0, 75, 0, -10, 0, -11,
+ax_anim 2, 0, 75, 0, -11, 0, -15,
+ax_anim 2, 1, 75, 1, -11, 1, -15,
+ax_anim 2, 0, 75, 0, -11, 0, -15,
+ax_anim 2, 0, 75, 1, -11, 1, -15,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sWailordAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 77, -1, -4, -1, -2,
+ax_anim 2, 2, 77, -4, -7, -4, -4,
+ax_anim 2, 0, 79, -10, -8, -10, -9,
+ax_anim 2, 0, 79, -14, -8, -15, -13,
+ax_anim 2, 1, 79, -15, -7, -16, -12,
+ax_anim 2, 0, 79, -14, -8, -15, -13,
+ax_anim 2, 0, 79, -15, -7, -16, -12,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sWailordAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 81, -1, -3, -1, 0,
+ax_anim 2, 2, 81, -6, -4, -6, 0,
+ax_anim 2, 0, 83, -10, -4, -10, 0,
+ax_anim 2, 0, 83, -14, 4, -14, 0,
+ax_anim 2, 1, 83, -14, 5, -14, 1,
+ax_anim 2, 0, 83, -14, 4, -14, 0,
+ax_anim 2, 0, 83, -14, 5, -14, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sWailordAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 85, -3, -1, -3, 3,
+ax_anim 2, 2, 85, -7, 2, -7, 8,
+ax_anim 2, 0, 87, -12, 10, -12, 14,
+ax_anim 2, 0, 87, -15, 21, -15, 18,
+ax_anim 2, 1, 87, -16, 20, -16, 17,
+ax_anim 2, 0, 87, -15, 21, -15, 18,
+ax_anim 2, 0, 87, -16, 20, -16, 17,
+ax_anim 2, 0, 84, -6, 9, -6, 9,
+ax_anim_terminator
+.align 2
+sWailordAnims_4_1:
+ax_anim 2, 0, 89, 0, -2, 0, -2,
+ax_anim 3, 0, 89, 0, -5, 0, -5,
+ax_anim 4, 0, 89, 0, -6, 0, -6,
+ax_anim 4, 2, 89, 0, -6, 0, -6,
+ax_anim 1, 0, 90, 0, -2, 0, -2,
+ax_anim 1, 0, 90, 0, 3, 0, 3,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 1, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 90, 0, 5, 0, 5,
+ax_anim 2, 0, 90, 1, 5, 1, 5,
+ax_anim 2, 0, 88, 0, 2, 0, 2,
+ax_anim_terminator
+sWailordAnims_4_2:
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim 3, 0, 92, -5, -5, -5, -5,
+ax_anim 4, 0, 92, -6, -6, -6, -6,
+ax_anim 4, 2, 92, -6, -6, -6, -6,
+ax_anim 1, 0, 93, -2, -2, -2, -2,
+ax_anim 1, 0, 93, 2, 2, 2, 2,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 1, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 93, 4, 4, 4, 4,
+ax_anim 2, 0, 93, 5, 3, 5, 3,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sWailordAnims_4_3:
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 3, 0, 95, -5, 0, -5, 0,
+ax_anim 4, 0, 95, -6, 0, -6, 0,
+ax_anim 4, 2, 95, -6, 0, -6, 0,
+ax_anim 1, 0, 96, -3, 0, -3, 0,
+ax_anim 1, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 1, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 96, 3, 0, 3, 0,
+ax_anim 2, 0, 96, 3, 1, 3, 1,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sWailordAnims_4_4:
+ax_anim 2, 0, 98, -2, 2, -2, 2,
+ax_anim 3, 0, 98, -5, 5, -5, 5,
+ax_anim 4, 0, 98, -6, 6, -6, 6,
+ax_anim 4, 2, 98, -6, 6, -6, 6,
+ax_anim 1, 0, 99, -2, 2, -2, 2,
+ax_anim 1, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 1, 99, 4, -2, 4, -2,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 4, -2, 4, -2,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 2, 0, 99, 4, -2, 4, -2,
+ax_anim 2, 0, 97, 2, -2, 2, -2,
+ax_anim_terminator
+sWailordAnims_4_5:
+ax_anim 2, 0, 101, 0, 2, 0, 2,
+ax_anim 3, 0, 101, 0, 5, 0, 5,
+ax_anim 4, 0, 101, 0, 6, 0, 6,
+ax_anim 4, 2, 101, 0, 6, 0, 6,
+ax_anim 1, 0, 102, 0, 3, 0, 3,
+ax_anim 1, 0, 102, 0, -2, 0, -2,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 1, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 102, 0, -4, 0, -4,
+ax_anim 2, 0, 102, 1, -4, 1, -4,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sWailordAnims_4_6:
+ax_anim 2, 0, 104, 2, 2, 2, 2,
+ax_anim 3, 0, 104, 5, 5, 5, 5,
+ax_anim 4, 0, 104, 6, 6, 6, 6,
+ax_anim 4, 2, 104, 6, 6, 6, 6,
+ax_anim 1, 0, 105, 2, 2, 2, 2,
+ax_anim 1, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 1, 105, -4, -2, -4, -2,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -4, -2, -4, -2,
+ax_anim 2, 0, 105, -3, -3, -3, -3,
+ax_anim 2, 0, 105, -4, -2, -4, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sWailordAnims_4_7:
+ax_anim 2, 0, 107, 2, 0, 2, 0,
+ax_anim 3, 0, 107, 5, 0, 5, 0,
+ax_anim 4, 0, 107, 6, 0, 6, 0,
+ax_anim 4, 2, 107, 6, 0, 6, 0,
+ax_anim 1, 0, 108, 2, 0, 2, 0,
+ax_anim 1, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 1, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 108, -3, 0, -3, 0,
+ax_anim 2, 0, 108, -3, 1, -3, 1,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sWailordAnims_4_8:
+ax_anim 2, 0, 110, 2, -2, 2, -2,
+ax_anim 3, 0, 110, 5, -5, 5, -5,
+ax_anim 4, 0, 110, 6, -6, 6, -6,
+ax_anim 4, 2, 110, 6, -6, 6, -6,
+ax_anim 1, 0, 111, 2, -2, 2, -2,
+ax_anim 1, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 1, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 111, -3, 3, -3, 3,
+ax_anim 2, 0, 111, -4, 2, -4, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sWailordAnims_5_1:
+ax_anim 4, 0, 115, 0, -2, 0, 0,
+ax_anim 3, 0, 115, 0, -4, 0, 0,
+ax_anim 3, 0, 115, 0, -5, 0, 0,
+ax_anim 2, 2, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 1, -5, 1, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 1, -5, 1, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 1, -5, 1, 0,
+ax_anim 2, 1, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 1, -5, 1, 0,
+ax_anim 2, 0, 112, 0, -3, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_5_2:
+ax_anim 4, 0, 120, 0, -2, 0, 0,
+ax_anim 3, 0, 120, 0, -4, 0, 0,
+ax_anim 3, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 2, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 1, -6, 1, -1,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 1, -6, 1, -1,
+ax_anim 2, 0, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 1, -6, 1, -1,
+ax_anim 2, 1, 121, 0, -5, 0, 0,
+ax_anim 2, 0, 121, 1, -6, 1, -1,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 2, 0, 117, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_5_3:
+ax_anim 4, 0, 125, 0, -2, 0, 0,
+ax_anim 3, 0, 125, 0, -4, 0, 0,
+ax_anim 3, 0, 125, 0, -5, 0, 0,
+ax_anim 2, 2, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, -1,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, -1,
+ax_anim 2, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, -1,
+ax_anim 2, 1, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -6, 0, -1,
+ax_anim 2, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_5_4:
+ax_anim 4, 0, 130, 0, -2, 0, 0,
+ax_anim 3, 0, 130, 0, -4, 0, 0,
+ax_anim 3, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 2, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, -1, -6, -1, -1,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, -1, -6, -1, -1,
+ax_anim 2, 0, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, -1, -6, -1, -1,
+ax_anim 2, 1, 131, 0, -5, 0, 0,
+ax_anim 2, 0, 131, -1, -6, -1, -1,
+ax_anim 2, 0, 127, 0, -3, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_5_5:
+ax_anim 4, 0, 135, 0, -2, 0, 0,
+ax_anim 3, 0, 135, 0, -4, 0, 0,
+ax_anim 3, 0, 135, 0, -5, 0, 0,
+ax_anim 2, 2, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 1, -5, 1, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 1, -5, 1, 0,
+ax_anim 2, 0, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 1, -5, 1, 0,
+ax_anim 2, 1, 136, 0, -5, 0, 0,
+ax_anim 2, 0, 136, 1, -5, 1, 0,
+ax_anim 2, 0, 132, 0, -3, 0, 0,
+ax_anim 2, 0, 132, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_5_6:
+ax_anim 4, 0, 140, 0, -2, 0, 0,
+ax_anim 3, 0, 140, 0, -4, 0, 0,
+ax_anim 3, 0, 140, 0, -5, 0, 0,
+ax_anim 2, 2, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 1, -6, 1, -1,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 1, -6, 1, -1,
+ax_anim 2, 0, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 1, -6, 1, -1,
+ax_anim 2, 1, 141, 0, -5, 0, 0,
+ax_anim 2, 0, 141, 1, -6, 1, -1,
+ax_anim 2, 0, 137, 0, -3, 0, 0,
+ax_anim 2, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_5_7:
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 3, 0, 145, 0, -4, 0, 0,
+ax_anim 3, 0, 145, 0, -5, 0, 0,
+ax_anim 2, 2, 146, 0, -5, 0, 0,
+ax_anim 2, 0, 146, 0, -6, 0, -1,
+ax_anim 2, 0, 146, 0, -5, 0, 0,
+ax_anim 2, 0, 146, 0, -6, 0, -1,
+ax_anim 2, 0, 146, 0, -5, 0, 0,
+ax_anim 2, 0, 146, 0, -6, 0, -1,
+ax_anim 2, 1, 146, 0, -5, 0, 0,
+ax_anim 2, 0, 146, 0, -6, 0, -1,
+ax_anim 2, 0, 142, 0, -3, 0, 0,
+ax_anim 2, 0, 142, 0, -1, 0, 0,
+ax_anim_terminator
+sWailordAnims_5_8:
+ax_anim 4, 0, 150, 0, -2, 0, 0,
+ax_anim 3, 0, 150, 0, -4, 0, 0,
+ax_anim 3, 0, 150, 0, -5, 0, 0,
+ax_anim 2, 2, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, -1, -6, -1, -1,
+ax_anim 2, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, -1, -6, -1, -1,
+ax_anim 2, 0, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, -1, -6, -1, -1,
+ax_anim 2, 1, 151, 0, -5, 0, 0,
+ax_anim 2, 0, 151, -1, -6, -1, -1,
+ax_anim 2, 0, 147, 0, -3, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_6_1:
+ax_anim 16, 0, 152, 0, 0, 0, 0,
+ax_anim 12, 0, 152, 0, -1, 0, 0,
+ax_anim 16, 0, 152, 0, -2, 0, 0,
+ax_anim 16, 0, 153, 0, -2, 0, 0,
+ax_anim 12, 0, 153, 0, -1, 0, 0,
+ax_anim 16, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_7_1:
+ax_anim 2, 0, 154, 0, -4, 0, -4,
+ax_anim 8, 0, 154, 0, -5, 0, -5,
+ax_anim_terminator
+sWailordAnims_7_2:
+ax_anim 2, 0, 155, -4, -4, -4, -4,
+ax_anim 8, 0, 155, -5, -5, -5, -5,
+ax_anim_terminator
+sWailordAnims_7_3:
+ax_anim 2, 0, 156, -4, 0, -4, 0,
+ax_anim 8, 0, 156, -5, 0, -5, 0,
+ax_anim_terminator
+sWailordAnims_7_4:
+ax_anim 2, 0, 157, -4, 4, -4, 4,
+ax_anim 8, 0, 157, -5, 5, -5, 5,
+ax_anim_terminator
+sWailordAnims_7_5:
+ax_anim 2, 0, 158, 0, 4, 0, 4,
+ax_anim 8, 0, 158, 0, 5, 0, 5,
+ax_anim_terminator
+sWailordAnims_7_6:
+ax_anim 2, 0, 159, 4, 4, 4, 4,
+ax_anim 8, 0, 159, 5, 5, 5, 5,
+ax_anim_terminator
+sWailordAnims_7_7:
+ax_anim 2, 0, 160, 4, 0, 4, 0,
+ax_anim 8, 0, 160, 5, 0, 5, 0,
+ax_anim_terminator
+sWailordAnims_7_8:
+ax_anim 2, 0, 161, 4, -4, 4, -4,
+ax_anim 8, 0, 161, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sWailordAnims_8_1:
+ax_anim 24, 0, 162, 0, 0, 0, 0,
+ax_anim 12, 0, 163, 0, 1, 0, 0,
+ax_anim 12, 0, 163, 0, 2, 0, 0,
+ax_anim 24, 0, 163, 0, 3, 0, 0,
+ax_anim 12, 0, 162, 0, 2, 0, 0,
+ax_anim 12, 0, 162, 0, 1, 0, 0,
+ax_anim_terminator
+sWailordAnims_8_2:
+ax_anim 24, 0, 165, 0, 0, 0, 0,
+ax_anim 12, 0, 166, 0, 1, 0, 0,
+ax_anim 12, 0, 166, 0, 2, 0, 0,
+ax_anim 24, 0, 166, 0, 3, 0, 0,
+ax_anim 12, 0, 165, 0, 2, 0, 0,
+ax_anim 12, 0, 165, 0, 1, 0, 0,
+ax_anim_terminator
+sWailordAnims_8_3:
+ax_anim 24, 0, 168, 0, 0, 0, 0,
+ax_anim 12, 0, 169, 0, 1, 0, 0,
+ax_anim 12, 0, 169, 0, 2, 0, 0,
+ax_anim 24, 0, 169, 0, 3, 0, 0,
+ax_anim 12, 0, 168, 0, 2, 0, 0,
+ax_anim 12, 0, 168, 0, 1, 0, 0,
+ax_anim_terminator
+sWailordAnims_8_4:
+ax_anim 24, 0, 171, 0, 0, 0, 0,
+ax_anim 12, 0, 172, 0, 1, 0, 0,
+ax_anim 12, 0, 172, 0, 2, 0, 0,
+ax_anim 24, 0, 172, 0, 3, 0, 0,
+ax_anim 12, 0, 171, 0, 2, 0, 0,
+ax_anim 12, 0, 171, 0, 1, 0, 0,
+ax_anim_terminator
+sWailordAnims_8_5:
+ax_anim 24, 0, 174, 0, 0, 0, 0,
+ax_anim 12, 0, 175, 0, 1, 0, 0,
+ax_anim 12, 0, 175, 0, 2, 0, 0,
+ax_anim 24, 0, 175, 0, 3, 0, 0,
+ax_anim 12, 0, 174, 0, 2, 0, 0,
+ax_anim 12, 0, 174, 0, 1, 0, 0,
+ax_anim_terminator
+sWailordAnims_8_6:
+ax_anim 24, 0, 177, 0, 0, 0, 0,
+ax_anim 12, 0, 178, 0, 1, 0, 0,
+ax_anim 12, 0, 178, 0, 2, 0, 0,
+ax_anim 24, 0, 178, 0, 3, 0, 0,
+ax_anim 12, 0, 177, 0, 2, 0, 0,
+ax_anim 12, 0, 177, 0, 1, 0, 0,
+ax_anim_terminator
+sWailordAnims_8_7:
+ax_anim 24, 0, 180, 0, 0, 0, 0,
+ax_anim 12, 0, 181, 0, 1, 0, 0,
+ax_anim 12, 0, 181, 0, 2, 0, 0,
+ax_anim 24, 0, 181, 0, 3, 0, 0,
+ax_anim 12, 0, 180, 0, 2, 0, 0,
+ax_anim 12, 0, 180, 0, 1, 0, 0,
+ax_anim_terminator
+sWailordAnims_8_8:
+ax_anim 24, 0, 183, 0, 0, 0, 0,
+ax_anim 12, 0, 184, 0, 1, 0, 0,
+ax_anim 12, 0, 184, 0, 2, 0, 0,
+ax_anim 24, 0, 184, 0, 3, 0, 0,
+ax_anim 12, 0, 183, 0, 2, 0, 0,
+ax_anim 12, 0, 183, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_9_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 6, 3, 6, 3,
+ax_anim 2, 0, 188, 8, 9, 8, 9,
+ax_anim 2, 0, 189, 5, 15, 5, 15,
+ax_anim 3, 0, 190, 0, 15, 0, 15,
+ax_anim 2, 3, 191, -5, 15, -5, 15,
+ax_anim 2, 0, 192, -8, 9, -8, 9,
+ax_anim 1, 0, 193, -6, 3, -6, 3,
+ax_anim 1, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_9_2:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 6, 3, 6, 3,
+ax_anim 2, 0, 187, 9, 7, 9, 7,
+ax_anim 2, 0, 188, 9, 15, 9, 15,
+ax_anim 3, 0, 189, 8, 20, 6, 20,
+ax_anim 2, 3, 190, 2, 18, 1, 20,
+ax_anim 2, 0, 191, -5, 16, -5, 16,
+ax_anim 1, 0, 192, -5, 9, -5, 9,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_9_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 1, 1, 1, -2,
+ax_anim 2, 0, 186, 3, 2, 3, -2,
+ax_anim 2, 0, 187, 5, 4, 5, 0,
+ax_anim 3, 0, 188, 7, 8, 7, 3,
+ax_anim 2, 3, 189, 6, 9, 6, 4,
+ax_anim 2, 0, 190, 3, 9, 3, 6,
+ax_anim 1, 0, 191, 1, 6, 1, 4,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_9_4:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 1, -1, 1, -3,
+ax_anim 2, 0, 193, 3, -3, 3, -5,
+ax_anim 2, 0, 186, 7, -2, 7, -7,
+ax_anim 3, 0, 187, 10, 0, 10, -5,
+ax_anim 2, 3, 188, 10, 2, 10, -3,
+ax_anim 2, 0, 189, 9, 4, 9, -1,
+ax_anim 1, 0, 190, 4, 3, 4, 1,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_9_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, -1, 0, -1, -1,
+ax_anim 2, 0, 192, -2, 1, -2, -2,
+ax_anim 2, 0, 193, -1, 0, -1, -3,
+ax_anim 3, 0, 186, 0, 0, 0, -4,
+ax_anim 2, 3, 187, 1, 0, 1, -3,
+ax_anim 2, 0, 188, 2, 2, 2, -2,
+ax_anim 1, 0, 189, 1, 1, 1, -1,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_9_6:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 188, -1, -1, -1, -3,
+ax_anim 2, 0, 187, -3, -3, -3, -5,
+ax_anim 2, 0, 186, -7, -2, -7, -7,
+ax_anim 3, 0, 193, -10, 0, -10, -5,
+ax_anim 2, 3, 192, -10, 2, -10, -3,
+ax_anim 2, 0, 191, -9, 4, -9, -1,
+ax_anim 1, 0, 190, -4, 3, -4, 1,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_9_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 187, -1, 1, -1, -2,
+ax_anim 2, 0, 186, -3, 2, -3, -2,
+ax_anim 2, 0, 193, -5, 4, -5, 0,
+ax_anim 3, 0, 192, -7, 8, -7, 3,
+ax_anim 2, 3, 191, -6, 9, -6, 4,
+ax_anim 2, 0, 190, -3, 9, -3, 6,
+ax_anim 1, 0, 189, -1, 6, -1, 4,
+ax_anim 1, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_9_8:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 186, -6, 3, -6, 3,
+ax_anim 2, 0, 193, -9, 7, -9, 7,
+ax_anim 2, 0, 192, -9, 15, -9, 15,
+ax_anim 3, 0, 191, -8, 20, -6, 20,
+ax_anim 2, 3, 190, -2, 18, -1, 20,
+ax_anim 2, 0, 189, 5, 16, 5, 16,
+ax_anim 1, 0, 188, 5, 9, 5, 9,
+ax_anim 1, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_10_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 3, 0, 194, 13, 0, 13, 0,
+ax_anim 3, 0, 194, -13, 0, -13, 0,
+ax_anim 2, 0, 194, 12, 0, 12, 0,
+ax_anim 3, 0, 194, -12, 0, -12, 0,
+ax_anim 2, 0, 194, 10, 0, 10, 0,
+ax_anim 2, 0, 194, -10, 0, -10, 0,
+ax_anim 2, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_10_2:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 3, 0, 195, 13, -13, 13, -13,
+ax_anim 3, 0, 195, -13, 13, -13, 13,
+ax_anim 2, 0, 195, 12, -12, 12, -12,
+ax_anim 3, 0, 195, -12, 12, -12, 12,
+ax_anim 2, 0, 195, 10, -10, 10, -10,
+ax_anim 2, 0, 195, -10, 10, -10, 10,
+ax_anim 2, 0, 195, 6, -6, 6, -6,
+ax_anim 2, 0, 195, -6, 6, -6, 6,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_10_3:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 3, 0, 196, 0, -13, 0, -13,
+ax_anim 3, 0, 196, 0, 13, 0, 13,
+ax_anim 2, 0, 196, 0, -12, 0, -12,
+ax_anim 3, 0, 196, 0, 12, 0, 12,
+ax_anim 2, 0, 196, 0, -10, 0, -10,
+ax_anim 2, 0, 196, 0, 10, 0, 10,
+ax_anim 2, 0, 196, 0, -6, 0, -6,
+ax_anim 2, 0, 196, 0, 6, 0, 6,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_10_4:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 3, 0, 197, -13, -13, -13, -13,
+ax_anim 3, 0, 197, 13, 13, 13, 13,
+ax_anim 2, 0, 197, -12, -12, -12, -12,
+ax_anim 3, 0, 197, 12, 12, 12, 12,
+ax_anim 2, 0, 197, -10, -10, -10, -10,
+ax_anim 2, 0, 197, 10, 10, 10, 10,
+ax_anim 2, 0, 197, -6, -6, -6, -6,
+ax_anim 2, 0, 197, 6, 6, 6, 6,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_10_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 3, 0, 198, 13, 0, 13, 0,
+ax_anim 3, 0, 198, -13, 0, -13, 0,
+ax_anim 2, 0, 198, 12, 0, 12, 0,
+ax_anim 3, 0, 198, -12, 0, -12, 0,
+ax_anim 2, 0, 198, 10, 0, 10, 0,
+ax_anim 2, 0, 198, -10, 0, -10, 0,
+ax_anim 2, 0, 198, 6, 0, 6, 0,
+ax_anim 2, 0, 198, -6, 0, -6, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_10_6:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 3, 0, 199, 13, -13, 13, -13,
+ax_anim 3, 0, 199, -13, 13, -13, 13,
+ax_anim 2, 0, 199, 12, -12, 12, -12,
+ax_anim 3, 0, 199, -12, 12, -12, 12,
+ax_anim 2, 0, 199, 10, -10, 10, -10,
+ax_anim 2, 0, 199, -10, 10, -10, 10,
+ax_anim 2, 0, 199, 6, -6, 6, -6,
+ax_anim 2, 0, 199, -6, 6, -6, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_10_7:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 3, 0, 200, 0, -13, 0, -13,
+ax_anim 3, 0, 200, 0, 13, 0, 13,
+ax_anim 2, 0, 200, 0, -12, 0, -12,
+ax_anim 3, 0, 200, 0, 12, 0, 12,
+ax_anim 2, 0, 200, 0, -10, 0, -10,
+ax_anim 2, 0, 200, 0, 10, 0, 10,
+ax_anim 2, 0, 200, 0, -6, 0, -6,
+ax_anim 2, 0, 200, 0, 6, 0, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_10_8:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 3, 0, 201, -13, -13, -13, -13,
+ax_anim 3, 0, 201, 13, 13, 13, 13,
+ax_anim 2, 0, 201, -12, -12, -12, -12,
+ax_anim 3, 0, 201, 12, 12, 12, 12,
+ax_anim 2, 0, 201, -10, -10, -10, -10,
+ax_anim 2, 0, 201, 10, 10, 10, 10,
+ax_anim 2, 0, 201, -6, -6, -6, -6,
+ax_anim 2, 0, 201, 6, 6, 6, 6,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_11_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 204, 0, -22, 0, 0,
+ax_anim 2, 0, 204, 0, -18, 0, 0,
+ax_anim 1, 0, 204, 0, -12, 0, 0,
+ax_anim 2, 2, 202, 0, 6, 0, 0,
+ax_anim_terminator
+sWailordAnims_11_2:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -22, 0, 0,
+ax_anim 3, 0, 207, 0, -21, 0, 0,
+ax_anim 2, 0, 207, 0, -17, 0, 0,
+ax_anim 1, 0, 207, 0, -11, 0, 0,
+ax_anim 2, 2, 205, 0, 6, 0, 0,
+ax_anim_terminator
+sWailordAnims_11_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -22, 0, 0,
+ax_anim 3, 0, 210, 0, -21, 0, 0,
+ax_anim 2, 0, 210, 0, -17, 0, 0,
+ax_anim 1, 0, 210, 0, -11, 0, 0,
+ax_anim 2, 2, 208, 0, 7, 0, 0,
+ax_anim_terminator
+sWailordAnims_11_4:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -21, 0, 0,
+ax_anim 2, 0, 213, 0, -17, 0, 0,
+ax_anim 1, 0, 213, 0, -11, 0, 0,
+ax_anim 2, 2, 211, 0, 7, 0, 0,
+ax_anim_terminator
+sWailordAnims_11_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 214, 0, -21, 0, 0,
+ax_anim 2, 0, 214, 0, -17, 0, 0,
+ax_anim 1, 0, 214, 0, -11, 0, 0,
+ax_anim 2, 2, 214, 0, 7, 0, 0,
+ax_anim_terminator
+sWailordAnims_11_6:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -21, 0, 0,
+ax_anim 2, 0, 219, 0, -17, 0, 0,
+ax_anim 1, 0, 219, 0, -11, 0, 0,
+ax_anim 2, 2, 217, 0, 7, 0, 0,
+ax_anim_terminator
+sWailordAnims_11_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -22, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -17, 0, 0,
+ax_anim 1, 0, 222, 0, -11, 0, 0,
+ax_anim 2, 2, 220, 0, 7, 0, 0,
+ax_anim_terminator
+sWailordAnims_11_8:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -22, 0, 0,
+ax_anim 3, 0, 225, 0, -21, 0, 0,
+ax_anim 2, 0, 225, 0, -17, 0, 0,
+ax_anim 1, 0, 225, 0, -11, 0, 0,
+ax_anim 2, 2, 223, 0, 6, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_12_1:
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 1, 0, 1, 0,
+ax_anim 2, 1, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_12_2:
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, -1, 1, -1,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_12_3:
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, -1, 0, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_12_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_12_5:
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 1, 0, 1, 0,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_12_6:
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, -1, 1, -1,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_12_7:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_12_8:
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 227, -1, -1, -1, -1,
+ax_anim 2, 1, 227, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWailordAnims_13_1:
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_13_2:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_13_3:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_13_4:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_13_5:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_13_6:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_13_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordAnims_13_8:
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sWailordGfx1:
+.incbin "baserom.gba", 0x131283C, 0x800
+sWailordSprites1:
+ax_sprite sWailordGfx1, 0x800
+ax_sprite_terminator
+sWailordGfx2:
+.incbin "baserom.gba", 0x131304C, 0x800
+sWailordSprites2:
+ax_sprite sWailordGfx2, 0x800
+ax_sprite_terminator
+sWailordGfx3:
+.incbin "baserom.gba", 0x131385C, 0x800
+sWailordSprites3:
+ax_sprite sWailordGfx3, 0x800
+ax_sprite_terminator
+sWailordGfx4:
+.incbin "baserom.gba", 0x131406C, 0x800
+sWailordSprites4:
+ax_sprite sWailordGfx4, 0x800
+ax_sprite_terminator
+sWailordGfx5:
+.incbin "baserom.gba", 0x131487C, 0x800
+sWailordSprites5:
+ax_sprite sWailordGfx5, 0x800
+ax_sprite_terminator
+sWailordGfx6:
+.incbin "baserom.gba", 0x131508C, 0x800
+sWailordSprites6:
+ax_sprite sWailordGfx6, 0x800
+ax_sprite_terminator
+sWailordGfx7:
+.incbin "baserom.gba", 0x131589C, 0x800
+sWailordSprites7:
+ax_sprite sWailordGfx7, 0x800
+ax_sprite_terminator
+sWailordGfx8:
+.incbin "baserom.gba", 0x13160AC, 0x800
+sWailordSprites8:
+ax_sprite sWailordGfx8, 0x800
+ax_sprite_terminator
+sWailordGfx9:
+.incbin "baserom.gba", 0x13168BC, 0x800
+sWailordSprites9:
+ax_sprite sWailordGfx9, 0x800
+ax_sprite_terminator
+sWailordGfx10:
+.incbin "baserom.gba", 0x13170CC, 0x800
+sWailordSprites10:
+ax_sprite sWailordGfx10, 0x800
+ax_sprite_terminator
+sWailordGfx11:
+.incbin "baserom.gba", 0x13178DC, 0x800
+sWailordSprites11:
+ax_sprite sWailordGfx11, 0x800
+ax_sprite_terminator
+sWailordGfx12:
+.incbin "baserom.gba", 0x13180EC, 0x800
+sWailordSprites12:
+ax_sprite sWailordGfx12, 0x800
+ax_sprite_terminator
+sWailordGfx13:
+.incbin "baserom.gba", 0x13188FC, 0x800
+sWailordSprites13:
+ax_sprite sWailordGfx13, 0x800
+ax_sprite_terminator
+sWailordGfx14:
+.incbin "baserom.gba", 0x131910C, 0x800
+sWailordSprites14:
+ax_sprite sWailordGfx14, 0x800
+ax_sprite_terminator
+sWailordGfx15:
+.incbin "baserom.gba", 0x131991C, 0x800
+sWailordSprites15:
+ax_sprite sWailordGfx15, 0x800
+ax_sprite_terminator
+sWailordGfx16:
+.incbin "baserom.gba", 0x131A12C, 0x60
+sWailordGfx16_1:
+.incbin "baserom.gba", 0x131A18C, 0x60
+sWailordGfx16_2:
+.incbin "baserom.gba", 0x131A1EC, 0x80
+sWailordGfx16_3:
+.incbin "baserom.gba", 0x131A26C, 0xC0
+sWailordGfx16_4:
+.incbin "baserom.gba", 0x131A32C, 0xC0
+sWailordGfx16_5:
+.incbin "baserom.gba", 0x131A3EC, 0xA0
+sWailordGfx16_6:
+.incbin "baserom.gba", 0x131A48C, 0xA0
+sWailordGfx16_7:
+.incbin "baserom.gba", 0x131A52C, 0x80
+sWailordSprites16:
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx16, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sWailordGfx16_1, 0x60
+ax_sprite 0, 0xa0
+ax_sprite sWailordGfx16_2, 0x80
+ax_sprite 0, 0x60
+ax_sprite sWailordGfx16_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx16_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx16_5, 0xa0
+ax_sprite 0, 0x60
+ax_sprite sWailordGfx16_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx16_7, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sWailordGfx17:
+.incbin "baserom.gba", 0x131A63C, 0x40
+sWailordGfx17_1:
+.incbin "baserom.gba", 0x131A67C, 0x60
+sWailordGfx17_2:
+.incbin "baserom.gba", 0x131A6DC, 0xC0
+sWailordGfx17_3:
+.incbin "baserom.gba", 0x131A79C, 0xE0
+sWailordGfx17_4:
+.incbin "baserom.gba", 0x131A87C, 0xE0
+sWailordGfx17_5:
+.incbin "baserom.gba", 0x131A95C, 0xC0
+sWailordGfx17_6:
+.incbin "baserom.gba", 0x131AA1C, 0xC0
+sWailordGfx17_7:
+.incbin "baserom.gba", 0x131AADC, 0x80
+sWailordSprites17:
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx17, 0x40
+ax_sprite 0, 0xc0
+ax_sprite sWailordGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx17_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx17_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx17_4, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx17_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx17_6, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx17_7, 0x80
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailordGfx18:
+.incbin "baserom.gba", 0x131ABEC, 0x80
+sWailordGfx18_1:
+.incbin "baserom.gba", 0x131AC6C, 0x320
+sWailordGfx18_2:
+.incbin "baserom.gba", 0x131AF8C, 0xE0
+sWailordSprites18:
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx18, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx18_1, 0x320
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx18_2, 0xe0
+ax_sprite 0, 0x320
+ax_sprite_terminator
+sWailordGfx19:
+.incbin "baserom.gba", 0x131B0AC, 0x60
+sWailordGfx19_1:
+.incbin "baserom.gba", 0x131B10C, 0xC0
+sWailordGfx19_2:
+.incbin "baserom.gba", 0x131B1CC, 0xC0
+sWailordGfx19_3:
+.incbin "baserom.gba", 0x131B28C, 0xE0
+sWailordGfx19_4:
+.incbin "baserom.gba", 0x131B36C, 0x100
+sWailordGfx19_5:
+.incbin "baserom.gba", 0x131B46C, 0xC0
+sWailordGfx19_6:
+.incbin "baserom.gba", 0x131B52C, 0x80
+sWailordSprites19:
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx19, 0x60
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx19_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx19_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx19_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx19_4, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx19_5, 0xc0
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx19_6, 0x80
+ax_sprite 0, 0x120
+ax_sprite_terminator
+sWailordGfx20:
+.incbin "baserom.gba", 0x131B62C, 0x80
+sWailordGfx20_1:
+.incbin "baserom.gba", 0x131B6AC, 0xC0
+sWailordGfx20_2:
+.incbin "baserom.gba", 0x131B76C, 0xC0
+sWailordGfx20_3:
+.incbin "baserom.gba", 0x131B82C, 0xC0
+sWailordGfx20_4:
+.incbin "baserom.gba", 0x131B8EC, 0xA0
+sWailordGfx20_5:
+.incbin "baserom.gba", 0x131B98C, 0x80
+sWailordGfx20_6:
+.incbin "baserom.gba", 0x131BA0C, 0x80
+sWailordSprites20:
+ax_sprite 0, 0x120
+ax_sprite sWailordGfx20, 0x80
+ax_sprite 0, 0x60
+ax_sprite sWailordGfx20_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx20_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx20_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx20_4, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx20_5, 0x80
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx20_6, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sWailordGfx21:
+.incbin "baserom.gba", 0x131BB0C, 0x80
+sWailordGfx21_1:
+.incbin "baserom.gba", 0x131BB8C, 0x80
+sWailordGfx21_2:
+.incbin "baserom.gba", 0x131BC0C, 0x80
+sWailordGfx21_3:
+.incbin "baserom.gba", 0x131BC8C, 0xC0
+sWailordGfx21_4:
+.incbin "baserom.gba", 0x131BD4C, 0xC0
+sWailordGfx21_5:
+.incbin "baserom.gba", 0x131BE0C, 0xC0
+sWailordGfx21_6:
+.incbin "baserom.gba", 0x131BECC, 0xA0
+sWailordGfx21_7:
+.incbin "baserom.gba", 0x131BF6C, 0x80
+sWailordSprites21:
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx21, 0x80
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx21_1, 0x80
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx21_2, 0x80
+ax_sprite 0, 0x60
+ax_sprite sWailordGfx21_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx21_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx21_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx21_6, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx21_7, 0x80
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sWailordGfx22:
+.incbin "baserom.gba", 0x131C07C, 0x20
+sWailordGfx22_1:
+.incbin "baserom.gba", 0x131C09C, 0x80
+sWailordGfx22_2:
+.incbin "baserom.gba", 0x131C11C, 0xC0
+sWailordGfx22_3:
+.incbin "baserom.gba", 0x131C1DC, 0xE0
+sWailordGfx22_4:
+.incbin "baserom.gba", 0x131C2BC, 0xC0
+sWailordGfx22_5:
+.incbin "baserom.gba", 0x131C37C, 0xC0
+sWailordGfx22_6:
+.incbin "baserom.gba", 0x131C43C, 0xC0
+sWailordGfx22_7:
+.incbin "baserom.gba", 0x131C4FC, 0x60
+sWailordSprites22:
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx22, 0x20
+ax_sprite 0, 0xc0
+ax_sprite sWailordGfx22_1, 0x80
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx22_2, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx22_3, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx22_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx22_5, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx22_6, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sWailordGfx22_7, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWailordGfx23:
+.incbin "baserom.gba", 0x131C5EC, 0x3E0
+sWailordGfx23_1:
+.incbin "baserom.gba", 0x131C9CC, 0xC0
+sWailordSprites23:
+ax_sprite sWailordGfx23, 0x3e0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx23_1, 0xc0
+ax_sprite 0, 0x340
+ax_sprite_terminator
+sWailordGfx24:
+.incbin "baserom.gba", 0x131CAB4, 0x80
+sWailordGfx24_1:
+.incbin "baserom.gba", 0x131CB34, 0xC0
+sWailordGfx24_2:
+.incbin "baserom.gba", 0x131CBF4, 0xE0
+sWailordGfx24_3:
+.incbin "baserom.gba", 0x131CCD4, 0x200
+sWailordGfx24_4:
+.incbin "baserom.gba", 0x131CED4, 0xC0
+sWailordSprites24:
+ax_sprite sWailordGfx24, 0x80
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx24_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx24_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx24_3, 0x200
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx24_4, 0xc0
+ax_sprite 0, 0x220
+ax_sprite_terminator
+sWailordGfx25:
+.incbin "baserom.gba", 0x131CFEC, 0x80
+sWailordGfx25_1:
+.incbin "baserom.gba", 0x131D06C, 0x80
+sWailordGfx25_2:
+.incbin "baserom.gba", 0x131D0EC, 0xC0
+sWailordGfx25_3:
+.incbin "baserom.gba", 0x131D1AC, 0xC0
+sWailordGfx25_4:
+.incbin "baserom.gba", 0x131D26C, 0xC0
+sWailordGfx25_5:
+.incbin "baserom.gba", 0x131D32C, 0xA0
+sWailordGfx25_6:
+.incbin "baserom.gba", 0x131D3CC, 0x80
+sWailordSprites25:
+ax_sprite 0, 0x20
+ax_sprite sWailordGfx25, 0x80
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx25_1, 0x80
+ax_sprite 0, 0x60
+ax_sprite sWailordGfx25_2, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx25_3, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx25_4, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWailordGfx25_5, 0xa0
+ax_sprite 0, 0x80
+ax_sprite sWailordGfx25_6, 0x80
+ax_sprite 0, 0x160
+ax_sprite_terminator
+sWailordGfx26:
+.incbin "baserom.gba", 0x131D4CC, 0x400
+sWailordSprites26:
+ax_sprite sWailordGfx26, 0x400
+ax_sprite_terminator
+sWailordGfx27:
+.incbin "baserom.gba", 0x131D8DC, 0x80
+sWailordSprites27:
+ax_sprite sWailordGfx27, 0x80
+ax_sprite_terminator
+sWailordGfx28:
+.incbin "baserom.gba", 0x131D96C, 0x80
+sWailordSprites28:
+ax_sprite sWailordGfx28, 0x80
+ax_sprite_terminator
+sWailordGfx29:
+.incbin "baserom.gba", 0x131D9FC, 0x400
+sWailordSprites29:
+ax_sprite sWailordGfx29, 0x400
+ax_sprite_terminator
+sWailordGfx30:
+.incbin "baserom.gba", 0x131DE0C, 0x80
+sWailordSprites30:
+ax_sprite sWailordGfx30, 0x80
+ax_sprite_terminator
+sWailordGfx31:
+.incbin "baserom.gba", 0x131DE9C, 0x80
+sWailordSprites31:
+ax_sprite sWailordGfx31, 0x80
+ax_sprite_terminator
+sWailordGfx32:
+.incbin "baserom.gba", 0x131DF2C, 0x800
+sWailordSprites32:
+ax_sprite sWailordGfx32, 0x800
+ax_sprite_terminator
+sWailordGfx33:
+.incbin "baserom.gba", 0x131E73C, 0x800
+sWailordSprites33:
+ax_sprite sWailordGfx33, 0x800
+ax_sprite_terminator
+sWailordGfx34:
+.incbin "baserom.gba", 0x131EF4C, 0x800
+sWailordSprites34:
+ax_sprite sWailordGfx34, 0x800
+ax_sprite_terminator
+sWailordGfx35:
+.incbin "baserom.gba", 0x131F75C, 0x800
+sWailordSprites35:
+ax_sprite sWailordGfx35, 0x800
+ax_sprite_terminator
+sWailordGfx36:
+.incbin "baserom.gba", 0x131FF6C, 0x800
+sWailordSprites36:
+ax_sprite sWailordGfx36, 0x800
+ax_sprite_terminator
+sAxPosesWailord:
+.4byte sWailordPose1
+.4byte sWailordPose2
+.4byte sWailordPose3
+.4byte sWailordPose4
+.4byte sWailordPose5
+.4byte sWailordPose6
+.4byte sWailordPose7
+.4byte sWailordPose8
+.4byte sWailordPose9
+.4byte sWailordPose10
+.4byte sWailordPose11
+.4byte sWailordPose12
+.4byte sWailordPose13
+.4byte sWailordPose14
+.4byte sWailordPose15
+.4byte sWailordPose16
+.4byte sWailordPose17
+.4byte sWailordPose18
+.4byte sWailordPose19
+.4byte sWailordPose20
+.4byte sWailordPose21
+.4byte sWailordPose22
+.4byte sWailordPose23
+.4byte sWailordPose24
+.4byte sWailordPose25
+.4byte sWailordPose26
+.4byte sWailordPose27
+.4byte sWailordPose28
+.4byte sWailordPose29
+.4byte sWailordPose30
+.4byte sWailordPose31
+.4byte sWailordPose32
+.4byte sWailordPose33
+.4byte sWailordPose34
+.4byte sWailordPose35
+.4byte sWailordPose36
+.4byte sWailordPose37
+.4byte sWailordPose38
+.4byte sWailordPose39
+.4byte sWailordPose40
+.4byte sWailordPose41
+.4byte sWailordPose42
+.4byte sWailordPose43
+.4byte sWailordPose44
+.4byte sWailordPose45
+.4byte sWailordPose46
+.4byte sWailordPose47
+.4byte sWailordPose48
+.4byte sWailordPose49
+.4byte sWailordPose50
+.4byte sWailordPose51
+.4byte sWailordPose52
+.4byte sWailordPose53
+.4byte sWailordPose54
+.4byte sWailordPose55
+.4byte sWailordPose56
+.4byte sWailordPose57
+.4byte sWailordPose58
+.4byte sWailordPose59
+.4byte sWailordPose60
+.4byte sWailordPose61
+.4byte sWailordPose62
+.4byte sWailordPose63
+.4byte sWailordPose64
+.4byte sWailordPose65
+.4byte sWailordPose66
+.4byte sWailordPose67
+.4byte sWailordPose68
+.4byte sWailordPose69
+.4byte sWailordPose70
+.4byte sWailordPose71
+.4byte sWailordPose72
+.4byte sWailordPose73
+.4byte sWailordPose74
+.4byte sWailordPose75
+.4byte sWailordPose76
+.4byte sWailordPose77
+.4byte sWailordPose78
+.4byte sWailordPose79
+.4byte sWailordPose80
+.4byte sWailordPose81
+.4byte sWailordPose82
+.4byte sWailordPose83
+.4byte sWailordPose84
+.4byte sWailordPose85
+.4byte sWailordPose86
+.4byte sWailordPose87
+.4byte sWailordPose88
+.4byte sWailordPose89
+.4byte sWailordPose90
+.4byte sWailordPose91
+.4byte sWailordPose92
+.4byte sWailordPose93
+.4byte sWailordPose94
+.4byte sWailordPose95
+.4byte sWailordPose96
+.4byte sWailordPose97
+.4byte sWailordPose98
+.4byte sWailordPose99
+.4byte sWailordPose100
+.4byte sWailordPose101
+.4byte sWailordPose102
+.4byte sWailordPose103
+.4byte sWailordPose104
+.4byte sWailordPose105
+.4byte sWailordPose106
+.4byte sWailordPose107
+.4byte sWailordPose108
+.4byte sWailordPose109
+.4byte sWailordPose110
+.4byte sWailordPose111
+.4byte sWailordPose112
+.4byte sWailordPose113
+.4byte sWailordPose114
+.4byte sWailordPose115
+.4byte sWailordPose116
+.4byte sWailordPose117
+.4byte sWailordPose118
+.4byte sWailordPose119
+.4byte sWailordPose120
+.4byte sWailordPose121
+.4byte sWailordPose122
+.4byte sWailordPose123
+.4byte sWailordPose124
+.4byte sWailordPose125
+.4byte sWailordPose126
+.4byte sWailordPose127
+.4byte sWailordPose128
+.4byte sWailordPose129
+.4byte sWailordPose130
+.4byte sWailordPose131
+.4byte sWailordPose132
+.4byte sWailordPose133
+.4byte sWailordPose134
+.4byte sWailordPose135
+.4byte sWailordPose136
+.4byte sWailordPose137
+.4byte sWailordPose138
+.4byte sWailordPose139
+.4byte sWailordPose140
+.4byte sWailordPose141
+.4byte sWailordPose142
+.4byte sWailordPose143
+.4byte sWailordPose144
+.4byte sWailordPose145
+.4byte sWailordPose146
+.4byte sWailordPose147
+.4byte sWailordPose148
+.4byte sWailordPose149
+.4byte sWailordPose150
+.4byte sWailordPose151
+.4byte sWailordPose152
+.4byte sWailordPose153
+.4byte sWailordPose154
+.4byte sWailordPose155
+.4byte sWailordPose156
+.4byte sWailordPose157
+.4byte sWailordPose158
+.4byte sWailordPose159
+.4byte sWailordPose160
+.4byte sWailordPose161
+.4byte sWailordPose162
+.4byte sWailordPose163
+.4byte sWailordPose164
+.4byte sWailordPose165
+.4byte sWailordPose166
+.4byte sWailordPose167
+.4byte sWailordPose168
+.4byte sWailordPose169
+.4byte sWailordPose170
+.4byte sWailordPose171
+.4byte sWailordPose172
+.4byte sWailordPose173
+.4byte sWailordPose174
+.4byte sWailordPose175
+.4byte sWailordPose176
+.4byte sWailordPose177
+.4byte sWailordPose178
+.4byte sWailordPose179
+.4byte sWailordPose180
+.4byte sWailordPose181
+.4byte sWailordPose182
+.4byte sWailordPose183
+.4byte sWailordPose184
+.4byte sWailordPose185
+.4byte sWailordPose186
+.4byte sWailordPose187
+.4byte sWailordPose188
+.4byte sWailordPose189
+.4byte sWailordPose190
+.4byte sWailordPose191
+.4byte sWailordPose192
+.4byte sWailordPose193
+.4byte sWailordPose194
+.4byte sWailordPose195
+.4byte sWailordPose196
+.4byte sWailordPose197
+.4byte sWailordPose198
+.4byte sWailordPose199
+.4byte sWailordPose200
+.4byte sWailordPose201
+.4byte sWailordPose202
+.4byte sWailordPose203
+.4byte sWailordPose204
+.4byte sWailordPose205
+.4byte sWailordPose206
+.4byte sWailordPose207
+.4byte sWailordPose208
+.4byte sWailordPose209
+.4byte sWailordPose210
+.4byte sWailordPose211
+.4byte sWailordPose212
+.4byte sWailordPose213
+.4byte sWailordPose214
+.4byte sWailordPose215
+.4byte sWailordPose216
+.4byte sWailordPose217
+.4byte sWailordPose218
+.4byte sWailordPose219
+.4byte sWailordPose220
+.4byte sWailordPose221
+.4byte sWailordPose222
+.4byte sWailordPose223
+.4byte sWailordPose224
+.4byte sWailordPose225
+.4byte sWailordPose226
+.4byte sWailordPose227
+.4byte sWailordPose228
+.4byte sWailordPose229
+.4byte sWailordPose230
+.4byte sWailordPose231
+.4byte sWailordPose232
+.4byte sWailordPose233
+.4byte sWailordPose234
+.4byte sWailordPose235
+.4byte sWailordPose236
+.4byte sWailordPose237
+.4byte sWailordPose238
+.4byte sWailordPose239
+.4byte sWailordPose240
+.4byte sWailordPose241
+.4byte sWailordPose242
+sAxPositionsWailord:
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte    0,   -3, 	 -21,  -21, 	  19,  -22, 	  -1,  -22
+.2byte   -1,   -1, 	 -21,  -22, 	  19,  -21, 	  -1,  -22
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+.2byte   19,   -8, 	  15,  -34, 	  -9,  -12, 	   4,  -25
+.2byte   19,   -5, 	  12,  -32, 	 -11,   -8, 	   1,  -18
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   27,  -21, 	   3,  -32, 	   1,  -10, 	   2,  -23
+.2byte   28,  -19, 	   3,  -31, 	   3,   -8, 	   2,  -21
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   18,  -41, 	 -11,  -37, 	  16,  -15, 	  -1,  -29
+.2byte   19,  -37, 	  -9,  -35, 	  17,  -10, 	   2,  -23
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte   -1,  -47, 	  17,  -27, 	 -18,  -27, 	  -1,  -26
+.2byte   -1,  -42, 	  17,  -24, 	 -19,  -22, 	  -1,  -24
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte  -19,  -41, 	  10,  -37, 	 -17,  -15, 	   0,  -29
+.2byte  -20,  -37, 	   8,  -35, 	 -18,  -10, 	  -3,  -23
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -28,  -21, 	  -4,  -32, 	  -2,  -10, 	  -3,  -23
+.2byte  -29,  -19, 	  -4,  -31, 	  -4,   -8, 	  -3,  -21
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -20,   -8, 	 -16,  -34, 	   8,  -12, 	  -5,  -25
+.2byte  -20,   -5, 	 -13,  -32, 	  10,   -8, 	  -2,  -18
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte    0,   -3, 	 -21,  -21, 	  19,  -22, 	  -1,  -22
+.2byte   -1,   -1, 	 -21,  -22, 	  19,  -21, 	  -1,  -22
+.2byte   -1,    2, 	 -21,  -20, 	  19,  -20, 	   0,  -20
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+.2byte   19,   -8, 	  15,  -34, 	  -9,  -12, 	   4,  -25
+.2byte   19,   -5, 	  12,  -32, 	 -11,   -8, 	   1,  -18
+.2byte   19,   -3, 	  20,  -27, 	 -12,   -9, 	   4,  -24
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   27,  -21, 	   3,  -32, 	   1,  -10, 	   2,  -23
+.2byte   28,  -19, 	   3,  -31, 	   3,   -8, 	   2,  -21
+.2byte   26,  -15, 	   4,  -30, 	   2,   -9, 	   2,  -21
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   18,  -41, 	 -11,  -37, 	  16,  -15, 	  -1,  -29
+.2byte   19,  -37, 	  -9,  -35, 	  17,  -10, 	   2,  -23
+.2byte   19,  -38, 	  -9,  -37, 	  18,  -13, 	   1,  -27
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte   -1,  -47, 	  17,  -27, 	 -18,  -27, 	  -1,  -26
+.2byte   -1,  -42, 	  17,  -24, 	 -19,  -22, 	  -1,  -24
+.2byte   -1,  -40, 	  18,  -27, 	 -20,  -27, 	  -1,  -23
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte  -19,  -41, 	  10,  -37, 	 -17,  -15, 	   0,  -29
+.2byte  -20,  -37, 	   8,  -35, 	 -18,  -10, 	  -3,  -23
+.2byte  -20,  -38, 	   8,  -37, 	 -19,  -13, 	  -2,  -27
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -28,  -21, 	  -4,  -32, 	  -2,  -10, 	  -3,  -23
+.2byte  -29,  -19, 	  -4,  -31, 	  -4,   -8, 	  -3,  -21
+.2byte  -27,  -15, 	  -5,  -30, 	  -3,   -9, 	  -3,  -21
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -20,   -8, 	 -16,  -34, 	   8,  -12, 	  -5,  -25
+.2byte  -20,   -5, 	 -13,  -32, 	  10,   -8, 	  -2,  -18
+.2byte  -20,   -3, 	 -21,  -27, 	  11,   -9, 	  -5,  -24
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte    0,   -3, 	 -21,  -21, 	  19,  -22, 	  -1,  -22
+.2byte   -1,   -1, 	 -21,  -22, 	  19,  -21, 	  -1,  -22
+.2byte   -1,    2, 	 -21,  -20, 	  19,  -20, 	   0,  -20
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+.2byte   19,   -8, 	  15,  -34, 	  -9,  -12, 	   4,  -25
+.2byte   19,   -5, 	  12,  -32, 	 -11,   -8, 	   1,  -18
+.2byte   19,   -3, 	  20,  -27, 	 -12,   -9, 	   4,  -24
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   27,  -21, 	   3,  -32, 	   1,  -10, 	   2,  -23
+.2byte   28,  -19, 	   3,  -31, 	   3,   -8, 	   2,  -21
+.2byte   26,  -15, 	   4,  -30, 	   2,   -9, 	   2,  -21
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   18,  -41, 	 -11,  -37, 	  16,  -15, 	  -1,  -29
+.2byte   19,  -37, 	  -9,  -35, 	  17,  -10, 	   2,  -23
+.2byte   19,  -38, 	  -9,  -37, 	  18,  -13, 	   1,  -27
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte   -1,  -47, 	  17,  -27, 	 -18,  -27, 	  -1,  -26
+.2byte   -1,  -42, 	  17,  -24, 	 -19,  -22, 	  -1,  -24
+.2byte   -1,  -40, 	  18,  -27, 	 -20,  -27, 	  -1,  -23
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte  -19,  -41, 	  10,  -37, 	 -17,  -15, 	   0,  -29
+.2byte  -20,  -37, 	   8,  -35, 	 -18,  -10, 	  -3,  -23
+.2byte  -20,  -38, 	   8,  -37, 	 -19,  -13, 	  -2,  -27
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -28,  -21, 	  -4,  -32, 	  -2,  -10, 	  -3,  -23
+.2byte  -29,  -19, 	  -4,  -31, 	  -4,   -8, 	  -3,  -21
+.2byte  -27,  -15, 	  -5,  -30, 	  -3,   -9, 	  -3,  -21
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -20,   -8, 	 -16,  -34, 	   8,  -12, 	  -5,  -25
+.2byte  -20,   -5, 	 -13,  -32, 	  10,   -8, 	  -2,  -18
+.2byte  -20,   -3, 	 -21,  -27, 	  11,   -9, 	  -5,  -24
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte   -1,    2, 	 -21,  -20, 	  19,  -20, 	   0,  -20
+.2byte   -1,   -2, 	 -22,  -18, 	  20,  -17, 	  -1,  -23
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+.2byte   19,   -3, 	  20,  -27, 	 -12,   -9, 	   4,  -24
+.2byte   17,   -6, 	  21,  -26, 	 -10,   -5, 	   4,  -25
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   26,  -15, 	   4,  -30, 	   2,   -9, 	   2,  -21
+.2byte   24,  -16, 	   6,  -30, 	   4,   -6, 	   2,  -21
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   19,  -38, 	  -9,  -37, 	  18,  -13, 	   1,  -27
+.2byte   18,  -33, 	 -10,  -36, 	  19,  -13, 	   1,  -28
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte   -1,  -40, 	  18,  -27, 	 -20,  -27, 	  -1,  -23
+.2byte    0,  -42, 	  17,  -25, 	 -19,  -25, 	  -1,  -24
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte  -20,  -38, 	   8,  -37, 	 -19,  -13, 	  -2,  -27
+.2byte  -19,  -33, 	   9,  -36, 	 -20,  -13, 	  -2,  -28
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -27,  -15, 	  -5,  -30, 	  -3,   -9, 	  -3,  -21
+.2byte  -25,  -16, 	  -7,  -30, 	  -5,   -6, 	  -3,  -21
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -20,   -3, 	 -21,  -27, 	  11,   -9, 	  -5,  -24
+.2byte  -18,   -6, 	 -22,  -26, 	   9,   -5, 	  -5,  -25
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte    0,   -3, 	 -21,  -21, 	  19,  -22, 	  -1,  -22
+.2byte   -1,   -1, 	 -21,  -22, 	  19,  -21, 	  -1,  -22
+.2byte   -1,    2, 	 -21,  -20, 	  19,  -20, 	   0,  -20
+.2byte   -1,   -2, 	 -22,  -18, 	  20,  -17, 	  -1,  -23
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+.2byte   19,   -8, 	  15,  -34, 	  -9,  -12, 	   4,  -25
+.2byte   19,   -5, 	  12,  -32, 	 -11,   -8, 	   1,  -18
+.2byte   19,   -3, 	  20,  -27, 	 -12,   -9, 	   4,  -24
+.2byte   17,   -6, 	  21,  -26, 	 -10,   -5, 	   4,  -25
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   27,  -21, 	   3,  -32, 	   1,  -10, 	   2,  -23
+.2byte   28,  -19, 	   3,  -31, 	   3,   -8, 	   2,  -21
+.2byte   26,  -15, 	   4,  -30, 	   2,   -9, 	   2,  -21
+.2byte   24,  -16, 	   6,  -30, 	   4,   -6, 	   2,  -21
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   18,  -41, 	 -11,  -37, 	  16,  -15, 	  -1,  -29
+.2byte   19,  -37, 	  -9,  -35, 	  17,  -10, 	   2,  -23
+.2byte   19,  -38, 	  -9,  -37, 	  18,  -13, 	   1,  -27
+.2byte   18,  -33, 	 -10,  -36, 	  19,  -13, 	   1,  -28
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte   -1,  -47, 	  17,  -27, 	 -18,  -27, 	  -1,  -26
+.2byte   -1,  -42, 	  17,  -24, 	 -19,  -22, 	  -1,  -24
+.2byte   -1,  -40, 	  18,  -27, 	 -20,  -27, 	  -1,  -23
+.2byte    0,  -44, 	  17,  -27, 	 -19,  -27, 	  -1,  -26
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte  -19,  -41, 	  10,  -37, 	 -17,  -15, 	   0,  -29
+.2byte  -20,  -37, 	   8,  -35, 	 -18,  -10, 	  -3,  -23
+.2byte  -20,  -38, 	   8,  -37, 	 -19,  -13, 	  -2,  -27
+.2byte  -19,  -33, 	   9,  -36, 	 -20,  -13, 	  -2,  -28
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -28,  -21, 	  -4,  -32, 	  -2,  -10, 	  -3,  -23
+.2byte  -29,  -19, 	  -4,  -31, 	  -4,   -8, 	  -3,  -21
+.2byte  -27,  -15, 	  -5,  -30, 	  -3,   -9, 	  -3,  -21
+.2byte  -25,  -16, 	  -7,  -30, 	  -5,   -6, 	  -3,  -21
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -20,   -8, 	 -16,  -34, 	   8,  -12, 	  -5,  -25
+.2byte  -20,   -5, 	 -13,  -32, 	  10,   -8, 	  -2,  -18
+.2byte  -20,   -3, 	 -21,  -27, 	  11,   -9, 	  -5,  -24
+.2byte  -18,   -6, 	 -22,  -26, 	   9,   -5, 	  -5,  -25
+.2byte  -29,  -20, 	  -4,  -30, 	  -2,   -8, 	  -3,  -22
+.2byte  -29,  -20, 	  -3,  -30, 	  -1,  -12, 	  -3,  -21
+.2byte   -9,  -35, 	 -23,  -18, 	  13,  -31, 	  -4,  -22
+.2byte   12,  -39, 	  22,  -34, 	 -10,  -27, 	   3,  -16
+.2byte   -1,  -45, 	  -7,  -28, 	  -6,  -19, 	   2,  -21
+.2byte   13,  -44, 	 -13,  -32, 	  17,  -21, 	  -2,  -20
+.2byte    8,  -43, 	  21,  -22, 	 -16,  -33, 	   0,  -24
+.2byte  -14,  -44, 	  12,  -32, 	 -18,  -21, 	   1,  -20
+.2byte   -2,  -43, 	   4,  -26, 	   3,  -17, 	  -5,  -19
+.2byte  -13,  -39, 	 -23,  -34, 	   9,  -27, 	  -4,  -16
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte    0,   -3, 	 -21,  -21, 	  19,  -22, 	  -1,  -22
+.2byte   -1,   -1, 	 -21,  -22, 	  19,  -21, 	  -1,  -22
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+.2byte   19,   -8, 	  15,  -34, 	  -9,  -12, 	   4,  -25
+.2byte   19,   -5, 	  12,  -32, 	 -11,   -8, 	   1,  -18
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   27,  -21, 	   3,  -32, 	   1,  -10, 	   2,  -23
+.2byte   28,  -19, 	   3,  -31, 	   3,   -8, 	   2,  -21
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   18,  -41, 	 -11,  -37, 	  16,  -15, 	  -1,  -29
+.2byte   19,  -37, 	  -9,  -35, 	  17,  -10, 	   2,  -23
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte   -1,  -47, 	  17,  -27, 	 -18,  -27, 	  -1,  -26
+.2byte   -1,  -42, 	  17,  -24, 	 -19,  -22, 	  -1,  -24
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte  -19,  -41, 	  10,  -37, 	 -17,  -15, 	   0,  -29
+.2byte  -20,  -37, 	   8,  -35, 	 -18,  -10, 	  -3,  -23
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -28,  -21, 	  -4,  -32, 	  -2,  -10, 	  -3,  -23
+.2byte  -29,  -19, 	  -4,  -31, 	  -4,   -8, 	  -3,  -21
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -20,   -8, 	 -16,  -34, 	   8,  -12, 	  -5,  -25
+.2byte  -20,   -5, 	 -13,  -32, 	  10,   -8, 	  -2,  -18
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte  -18,   -7, 	 -10,  -33, 	  13,  -11, 	  -2,  -22
+.2byte  -26,  -20, 	  -1,  -31, 	  -1,   -8, 	  -1,  -22
+.2byte  -18,  -38, 	   9,  -33, 	 -16,  -10, 	   1,  -26
+.2byte   -1,  -43, 	  17,  -23, 	 -19,  -23, 	  -1,  -24
+.2byte   17,  -38, 	 -10,  -33, 	  15,  -10, 	  -2,  -26
+.2byte   25,  -20, 	   0,  -31, 	   0,   -8, 	   0,  -22
+.2byte   17,   -7, 	   9,  -33, 	 -14,  -11, 	   1,  -22
+.2byte   -1,   -2, 	 -22,  -18, 	  20,  -17, 	  -1,  -23
+.2byte   14,   -7, 	  18,  -27, 	 -13,   -6, 	   1,  -26
+.2byte   21,  -16, 	   3,  -30, 	   1,   -6, 	  -1,  -21
+.2byte   16,  -31, 	 -12,  -34, 	  17,  -11, 	  -1,  -26
+.2byte    1,  -44, 	  18,  -27, 	 -18,  -27, 	   0,  -26
+.2byte  -17,  -31, 	  11,  -34, 	 -18,  -11, 	   0,  -26
+.2byte  -22,  -16, 	  -4,  -30, 	  -2,   -6, 	   0,  -21
+.2byte  -15,   -7, 	 -19,  -27, 	  12,   -6, 	  -2,  -26
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte   -1,   -2, 	 -22,  -18, 	  20,  -17, 	  -1,  -23
+.2byte   -1,    2, 	 -21,  -20, 	  19,  -20, 	   0,  -20
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+.2byte   17,   -6, 	  21,  -26, 	 -10,   -5, 	   4,  -25
+.2byte   19,   -3, 	  20,  -27, 	 -12,   -9, 	   4,  -24
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   24,  -16, 	   6,  -30, 	   4,   -6, 	   2,  -21
+.2byte   26,  -15, 	   4,  -30, 	   2,   -9, 	   2,  -21
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   18,  -33, 	 -10,  -36, 	  19,  -13, 	   1,  -28
+.2byte   19,  -38, 	  -9,  -37, 	  18,  -13, 	   1,  -27
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte    0,  -42, 	  17,  -25, 	 -19,  -25, 	  -1,  -24
+.2byte   -1,  -40, 	  18,  -27, 	 -20,  -27, 	  -1,  -23
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte  -19,  -33, 	   9,  -36, 	 -20,  -13, 	  -2,  -28
+.2byte  -20,  -38, 	   8,  -37, 	 -19,  -13, 	  -2,  -27
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -25,  -16, 	  -7,  -30, 	  -5,   -6, 	  -3,  -21
+.2byte  -27,  -15, 	  -5,  -30, 	  -3,   -9, 	  -3,  -21
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -18,   -6, 	 -22,  -26, 	   9,   -5, 	  -5,  -25
+.2byte  -20,   -3, 	 -21,  -27, 	  11,   -9, 	  -5,  -24
+.2byte   -1,    2, 	 -21,  -20, 	  19,  -20, 	   0,  -20
+.2byte  -17,   -3, 	 -18,  -27, 	  14,   -9, 	  -2,  -24
+.2byte  -27,  -15, 	  -5,  -30, 	  -3,   -9, 	  -3,  -21
+.2byte  -20,  -36, 	   8,  -35, 	 -19,  -11, 	  -2,  -25
+.2byte   -1,  -40, 	  18,  -27, 	 -20,  -27, 	  -1,  -23
+.2byte   19,  -36, 	  -9,  -35, 	  18,  -11, 	   1,  -25
+.2byte   26,  -15, 	   4,  -30, 	   2,   -9, 	   2,  -21
+.2byte   16,   -3, 	  17,  -27, 	 -15,   -9, 	   1,  -24
+.2byte   -1,   -2, 	 -21,  -21, 	  20,  -22, 	  -1,  -20
+.2byte  -21,   -7, 	 -13,  -33, 	  10,  -11, 	  -5,  -22
+.2byte  -28,  -20, 	  -3,  -31, 	  -3,   -8, 	  -3,  -22
+.2byte  -19,  -40, 	   8,  -35, 	 -17,  -12, 	   0,  -28
+.2byte   -1,  -45, 	  17,  -25, 	 -19,  -25, 	  -1,  -26
+.2byte   18,  -40, 	  -9,  -35, 	  16,  -12, 	  -1,  -28
+.2byte   27,  -20, 	   2,  -31, 	   2,   -8, 	   2,  -22
+.2byte   20,   -7, 	  12,  -33, 	 -11,  -11, 	   4,  -22
+sWailordAnimTable1:
+.4byte sWailordAnims_1_1
+.4byte sWailordAnims_1_2
+.4byte sWailordAnims_1_3
+.4byte sWailordAnims_1_4
+.4byte sWailordAnims_1_5
+.4byte sWailordAnims_1_6
+.4byte sWailordAnims_1_7
+.4byte sWailordAnims_1_8
+sWailordAnimTable2:
+.4byte sWailordAnims_2_1
+.4byte sWailordAnims_2_2
+.4byte sWailordAnims_2_3
+.4byte sWailordAnims_2_4
+.4byte sWailordAnims_2_5
+.4byte sWailordAnims_2_6
+.4byte sWailordAnims_2_7
+.4byte sWailordAnims_2_8
+sWailordAnimTable3:
+.4byte sWailordAnims_3_1
+.4byte sWailordAnims_3_2
+.4byte sWailordAnims_3_3
+.4byte sWailordAnims_3_4
+.4byte sWailordAnims_3_5
+.4byte sWailordAnims_3_6
+.4byte sWailordAnims_3_7
+.4byte sWailordAnims_3_8
+sWailordAnimTable4:
+.4byte sWailordAnims_4_1
+.4byte sWailordAnims_4_2
+.4byte sWailordAnims_4_3
+.4byte sWailordAnims_4_4
+.4byte sWailordAnims_4_5
+.4byte sWailordAnims_4_6
+.4byte sWailordAnims_4_7
+.4byte sWailordAnims_4_8
+sWailordAnimTable5:
+.4byte sWailordAnims_5_1
+.4byte sWailordAnims_5_2
+.4byte sWailordAnims_5_3
+.4byte sWailordAnims_5_4
+.4byte sWailordAnims_5_5
+.4byte sWailordAnims_5_6
+.4byte sWailordAnims_5_7
+.4byte sWailordAnims_5_8
+sWailordAnimTable6:
+.4byte sWailordAnims_6_1
+.4byte sWailordAnims_6_1
+.4byte sWailordAnims_6_1
+.4byte sWailordAnims_6_1
+.4byte sWailordAnims_6_1
+.4byte sWailordAnims_6_1
+.4byte sWailordAnims_6_1
+.4byte sWailordAnims_6_1
+sWailordAnimTable7:
+.4byte sWailordAnims_7_1
+.4byte sWailordAnims_7_2
+.4byte sWailordAnims_7_3
+.4byte sWailordAnims_7_4
+.4byte sWailordAnims_7_5
+.4byte sWailordAnims_7_6
+.4byte sWailordAnims_7_7
+.4byte sWailordAnims_7_8
+sWailordAnimTable8:
+.4byte sWailordAnims_8_1
+.4byte sWailordAnims_8_2
+.4byte sWailordAnims_8_3
+.4byte sWailordAnims_8_4
+.4byte sWailordAnims_8_5
+.4byte sWailordAnims_8_6
+.4byte sWailordAnims_8_7
+.4byte sWailordAnims_8_8
+sWailordAnimTable9:
+.4byte sWailordAnims_9_1
+.4byte sWailordAnims_9_2
+.4byte sWailordAnims_9_3
+.4byte sWailordAnims_9_4
+.4byte sWailordAnims_9_5
+.4byte sWailordAnims_9_6
+.4byte sWailordAnims_9_7
+.4byte sWailordAnims_9_8
+sWailordAnimTable10:
+.4byte sWailordAnims_10_1
+.4byte sWailordAnims_10_2
+.4byte sWailordAnims_10_3
+.4byte sWailordAnims_10_4
+.4byte sWailordAnims_10_5
+.4byte sWailordAnims_10_6
+.4byte sWailordAnims_10_7
+.4byte sWailordAnims_10_8
+sWailordAnimTable11:
+.4byte sWailordAnims_11_1
+.4byte sWailordAnims_11_2
+.4byte sWailordAnims_11_3
+.4byte sWailordAnims_11_4
+.4byte sWailordAnims_11_5
+.4byte sWailordAnims_11_6
+.4byte sWailordAnims_11_7
+.4byte sWailordAnims_11_8
+sWailordAnimTable12:
+.4byte sWailordAnims_12_1
+.4byte sWailordAnims_12_2
+.4byte sWailordAnims_12_3
+.4byte sWailordAnims_12_4
+.4byte sWailordAnims_12_5
+.4byte sWailordAnims_12_6
+.4byte sWailordAnims_12_7
+.4byte sWailordAnims_12_8
+sWailordAnimTable13:
+.4byte sWailordAnims_13_1
+.4byte sWailordAnims_13_2
+.4byte sWailordAnims_13_3
+.4byte sWailordAnims_13_4
+.4byte sWailordAnims_13_5
+.4byte sWailordAnims_13_6
+.4byte sWailordAnims_13_7
+.4byte sWailordAnims_13_8
+sAxAnimationsWailord:
+.4byte sWailordAnimTable1
+.4byte sWailordAnimTable2
+.4byte sWailordAnimTable3
+.4byte sWailordAnimTable4
+.4byte sWailordAnimTable5
+.4byte sWailordAnimTable6
+.4byte sWailordAnimTable7
+.4byte sWailordAnimTable8
+.4byte sWailordAnimTable9
+.4byte sWailordAnimTable10
+.4byte sWailordAnimTable11
+.4byte sWailordAnimTable12
+.4byte sWailordAnimTable13
+sAxSpritesWailord:
+.4byte sWailordSprites1
+.4byte sWailordSprites2
+.4byte sWailordSprites3
+.4byte sWailordSprites4
+.4byte sWailordSprites5
+.4byte sWailordSprites6
+.4byte sWailordSprites7
+.4byte sWailordSprites8
+.4byte sWailordSprites9
+.4byte sWailordSprites10
+.4byte sWailordSprites11
+.4byte sWailordSprites12
+.4byte sWailordSprites13
+.4byte sWailordSprites14
+.4byte sWailordSprites15
+.4byte sWailordSprites16
+.4byte sWailordSprites17
+.4byte sWailordSprites18
+.4byte sWailordSprites19
+.4byte sWailordSprites20
+.4byte sWailordSprites21
+.4byte sWailordSprites22
+.4byte sWailordSprites23
+.4byte sWailordSprites24
+.4byte sWailordSprites25
+.4byte sWailordSprites26
+.4byte sWailordSprites27
+.4byte sWailordSprites28
+.4byte sWailordSprites29
+.4byte sWailordSprites30
+.4byte sWailordSprites31
+.4byte sWailordSprites32
+.4byte sWailordSprites33
+.4byte sWailordSprites34
+.4byte sWailordSprites35
+.4byte sWailordSprites36
+sAxMainWailord:
+ax_main sAxPosesWailord, sAxAnimationsWailord, 13, sAxSpritesWailord, sAxPositionsWailord

--- a/data/ax/walrein.inc
+++ b/data/ax/walrein.inc
@@ -1,0 +1,2739 @@
+.global gAxWalrein
+gAxWalrein:
+ax_siro sAxMainWalrein
+sWalreinPose1:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose2:
+ax_pose 1, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose3:
+ax_pose 2, 0x01ef, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose4:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose5:
+ax_pose 4, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose6:
+ax_pose 5, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose7:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose8:
+ax_pose 7, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose9:
+ax_pose 8, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose10:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose11:
+ax_pose 10, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose12:
+ax_pose 11, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose13:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose14:
+ax_pose 13, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose15:
+ax_pose 14, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose16:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose17:
+ax_pose 10, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose18:
+ax_pose 11, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose19:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose20:
+ax_pose 7, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose21:
+ax_pose 8, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose22:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose23:
+ax_pose 4, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose24:
+ax_pose 5, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose25:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose26:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose27:
+ax_pose 16, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose28:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose29:
+ax_pose 17, 0x01e9, 0x90f2, 0x5c00
+ax_pose_terminator
+sWalreinPose30:
+ax_pose 18, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose31:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose32:
+ax_pose 19, 0x81e7, 0x90fe, 0x5c00
+ax_pose 20, 0x81e7, 0x50f6, 0x5c08
+ax_pose 21, 0x81f7, 0x10ee, 0x5c0c
+ax_pose 22, 0x81ef, 0x110e, 0x5c0e
+ax_pose_terminator
+sWalreinPose33:
+ax_pose 23, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose34:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose35:
+ax_pose 24, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWalreinPose36:
+ax_pose 25, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose37:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose38:
+ax_pose 26, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose39:
+ax_pose 27, 0x81e8, 0x80f2, 0x5c00
+ax_pose 28, 0x81e8, 0x4102, 0x5c08
+ax_pose 29, 0x0208, 0x00fa, 0x5c0c
+ax_pose 30, 0x0208, 0x0102, 0x5c0d
+ax_pose 31, 0x01f8, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose40:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose41:
+ax_pose 24, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWalreinPose42:
+ax_pose 25, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose43:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose44:
+ax_pose 19, 0x81e7, 0x80f1, 0x5c00
+ax_pose 20, 0x81e7, 0x4101, 0x5c08
+ax_pose 21, 0x81f7, 0x0109, 0x5c0c
+ax_pose 22, 0x81ef, 0x00e9, 0x5c0e
+ax_pose_terminator
+sWalreinPose45:
+ax_pose 23, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose46:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose47:
+ax_pose 17, 0x01e9, 0x80ed, 0x5c00
+ax_pose_terminator
+sWalreinPose48:
+ax_pose 18, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose49:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose50:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose51:
+ax_pose 16, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose52:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose53:
+ax_pose 17, 0x01e9, 0x90f2, 0x5c00
+ax_pose_terminator
+sWalreinPose54:
+ax_pose 18, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose55:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose56:
+ax_pose 19, 0x81e7, 0x90fe, 0x5c00
+ax_pose 20, 0x81e7, 0x50f6, 0x5c08
+ax_pose 21, 0x81f7, 0x10ee, 0x5c0c
+ax_pose 22, 0x81ef, 0x110e, 0x5c0e
+ax_pose_terminator
+sWalreinPose57:
+ax_pose 23, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose58:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose59:
+ax_pose 24, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWalreinPose60:
+ax_pose 25, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose61:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose62:
+ax_pose 26, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose63:
+ax_pose 27, 0x81e8, 0x80f2, 0x5c00
+ax_pose 28, 0x81e8, 0x4102, 0x5c08
+ax_pose 29, 0x0208, 0x00fa, 0x5c0c
+ax_pose 30, 0x0208, 0x0102, 0x5c0d
+ax_pose 31, 0x01f8, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose64:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose65:
+ax_pose 24, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWalreinPose66:
+ax_pose 25, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose67:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose68:
+ax_pose 19, 0x81e7, 0x80f1, 0x5c00
+ax_pose 20, 0x81e7, 0x4101, 0x5c08
+ax_pose 21, 0x81f7, 0x0109, 0x5c0c
+ax_pose 22, 0x81ef, 0x00e9, 0x5c0e
+ax_pose_terminator
+sWalreinPose69:
+ax_pose 23, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose70:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose71:
+ax_pose 17, 0x01e9, 0x80ed, 0x5c00
+ax_pose_terminator
+sWalreinPose72:
+ax_pose 18, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose73:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose74:
+ax_pose 32, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose75:
+ax_pose 33, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose76:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose77:
+ax_pose 34, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose78:
+ax_pose 35, 0x01ea, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose79:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose80:
+ax_pose 36, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose81:
+ax_pose 37, 0x41ed, 0x10ff, 0x5c00
+ax_pose 38, 0x41f5, 0x90ef, 0x5c02
+ax_pose 39, 0x81ed, 0x110f, 0x5c0a
+ax_pose_terminator
+sWalreinPose82:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose83:
+ax_pose 40, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose84:
+ax_pose 41, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose85:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose86:
+ax_pose 42, 0x81e7, 0x80f2, 0x5c00
+ax_pose 43, 0x81e7, 0x4102, 0x5c08
+ax_pose 44, 0x0207, 0x0102, 0x5c0c
+ax_pose 45, 0x0207, 0x00fa, 0x5c0d
+ax_pose 46, 0x01f7, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose87:
+ax_pose 47, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose88:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose89:
+ax_pose 40, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose90:
+ax_pose 41, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose91:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose92:
+ax_pose 36, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose93:
+ax_pose 37, 0x41ed, 0x00f0, 0x5c00
+ax_pose 38, 0x41f5, 0x80f0, 0x5c02
+ax_pose 39, 0x81ed, 0x00e8, 0x5c0a
+ax_pose_terminator
+sWalreinPose94:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose95:
+ax_pose 34, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose96:
+ax_pose 35, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose97:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose98:
+ax_pose 16, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose99:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose100:
+ax_pose 18, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose101:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose102:
+ax_pose 23, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose103:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose104:
+ax_pose 25, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose105:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose106:
+ax_pose 27, 0x81e8, 0x80f2, 0x5c00
+ax_pose 28, 0x81e8, 0x4102, 0x5c08
+ax_pose 29, 0x0208, 0x00fa, 0x5c0c
+ax_pose 30, 0x0208, 0x0102, 0x5c0d
+ax_pose 31, 0x01f8, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose107:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose108:
+ax_pose 25, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose109:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose110:
+ax_pose 23, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose111:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose112:
+ax_pose 18, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose113:
+ax_pose 48, 0x01f0, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose114:
+ax_pose 49, 0x01f0, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose115:
+ax_pose 50, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose116:
+ax_pose 51, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sWalreinPose117:
+ax_pose 52, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWalreinPose118:
+ax_pose 53, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sWalreinPose119:
+ax_pose 54, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWalreinPose120:
+ax_pose 53, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sWalreinPose121:
+ax_pose 52, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWalreinPose122:
+ax_pose 51, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sWalreinPose123:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose124:
+ax_pose 32, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose125:
+ax_pose 16, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose126:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose127:
+ax_pose 34, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose128:
+ax_pose 18, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose129:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose130:
+ax_pose 36, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose131:
+ax_pose 23, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose132:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose133:
+ax_pose 40, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose134:
+ax_pose 25, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose135:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose136:
+ax_pose 42, 0x81e7, 0x80f2, 0x5c00
+ax_pose 43, 0x81e7, 0x4102, 0x5c08
+ax_pose 44, 0x0207, 0x0102, 0x5c0c
+ax_pose 45, 0x0207, 0x00fa, 0x5c0d
+ax_pose 46, 0x01f7, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose137:
+ax_pose 27, 0x81e8, 0x80f2, 0x5c00
+ax_pose 28, 0x81e8, 0x4102, 0x5c08
+ax_pose 29, 0x0208, 0x00fa, 0x5c0c
+ax_pose 30, 0x0208, 0x0102, 0x5c0d
+ax_pose 31, 0x01f8, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose138:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose139:
+ax_pose 40, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose140:
+ax_pose 25, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose141:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose142:
+ax_pose 36, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose143:
+ax_pose 23, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose144:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose145:
+ax_pose 34, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose146:
+ax_pose 18, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose147:
+ax_pose 16, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose148:
+ax_pose 18, 0x01eb, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose149:
+ax_pose 23, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWalreinPose150:
+ax_pose 25, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sWalreinPose151:
+ax_pose 27, 0x81e8, 0x80f2, 0x5c00
+ax_pose 28, 0x81e8, 0x4102, 0x5c08
+ax_pose 29, 0x0208, 0x00fa, 0x5c0c
+ax_pose 30, 0x0208, 0x0102, 0x5c0d
+ax_pose 31, 0x01f8, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose152:
+ax_pose 25, 0x01e8, 0x90f0, 0x5c00
+ax_pose_terminator
+sWalreinPose153:
+ax_pose 23, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWalreinPose154:
+ax_pose 18, 0x01eb, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose155:
+ax_pose 32, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose156:
+ax_pose 34, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose157:
+ax_pose 36, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose158:
+ax_pose 40, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose159:
+ax_pose 42, 0x81e7, 0x80f2, 0x5c00
+ax_pose 43, 0x81e7, 0x4102, 0x5c08
+ax_pose 44, 0x0207, 0x0102, 0x5c0c
+ax_pose 45, 0x0207, 0x00fa, 0x5c0d
+ax_pose 46, 0x01f7, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose160:
+ax_pose 40, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose161:
+ax_pose 36, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose162:
+ax_pose 34, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose163:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose164:
+ax_pose 16, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose165:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose166:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose167:
+ax_pose 18, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWalreinPose168:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWalreinPose169:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose170:
+ax_pose 23, 0x01e8, 0x90f1, 0x5c00
+ax_pose_terminator
+sWalreinPose171:
+ax_pose 19, 0x81e7, 0x90fd, 0x5c00
+ax_pose 20, 0x81e7, 0x50f5, 0x5c08
+ax_pose 21, 0x81f7, 0x10ed, 0x5c0c
+ax_pose 22, 0x81ef, 0x110d, 0x5c0e
+ax_pose_terminator
+sWalreinPose172:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose173:
+ax_pose 25, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose174:
+ax_pose 24, 0x01e9, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose175:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose176:
+ax_pose 27, 0x81e8, 0x80f2, 0x5c00
+ax_pose 28, 0x81e8, 0x4102, 0x5c08
+ax_pose 29, 0x0208, 0x00fa, 0x5c0c
+ax_pose 30, 0x0208, 0x0102, 0x5c0d
+ax_pose 31, 0x01f8, 0x010a, 0x5c0e
+ax_pose_terminator
+sWalreinPose177:
+ax_pose 26, 0x01ea, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose178:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose179:
+ax_pose 25, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose180:
+ax_pose 24, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose181:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose182:
+ax_pose 23, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWalreinPose183:
+ax_pose 19, 0x81e7, 0x80f2, 0x5c00
+ax_pose 20, 0x81e7, 0x4102, 0x5c08
+ax_pose 21, 0x81f7, 0x010a, 0x5c0c
+ax_pose 22, 0x81ef, 0x00ea, 0x5c0e
+ax_pose_terminator
+sWalreinPose184:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose185:
+ax_pose 18, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWalreinPose186:
+ax_pose 17, 0x01e9, 0x80ee, 0x5c00
+ax_pose_terminator
+sWalreinPose187:
+ax_pose 15, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose188:
+ax_pose 17, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWalreinPose189:
+ax_pose 19, 0x81e7, 0x80f2, 0x5c00
+ax_pose 20, 0x81e7, 0x4102, 0x5c08
+ax_pose 21, 0x81f7, 0x010a, 0x5c0c
+ax_pose 22, 0x81ef, 0x00ea, 0x5c0e
+ax_pose_terminator
+sWalreinPose190:
+ax_pose 24, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWalreinPose191:
+ax_pose 26, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose192:
+ax_pose 24, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWalreinPose193:
+ax_pose 19, 0x81e7, 0x90fe, 0x5c00
+ax_pose 20, 0x81e7, 0x50f6, 0x5c08
+ax_pose 21, 0x81f7, 0x10ee, 0x5c0c
+ax_pose 22, 0x81ef, 0x110e, 0x5c0e
+ax_pose_terminator
+sWalreinPose194:
+ax_pose 17, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWalreinPose195:
+ax_pose 0, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose196:
+ax_pose 3, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose197:
+ax_pose 6, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose198:
+ax_pose 9, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose199:
+ax_pose 12, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWalreinPose200:
+ax_pose 9, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose201:
+ax_pose 6, 0x01ed, 0x90ef, 0x5c00
+ax_pose_terminator
+sWalreinPose202:
+ax_pose 3, 0x01ee, 0x90ef, 0x5c00
+ax_pose_terminator
+.align 2
+sWalreinAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 2, 0, 2,
+ax_anim 6, 0, 1, 0, 5, 0, 5,
+ax_anim 6, 0, 1, 0, 7, 0, 7,
+ax_anim 6, 0, 0, 0, 3, 0, 3,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, -1, 0, -1,
+ax_anim_terminator
+sWalreinAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 4, 2, 4, 2,
+ax_anim 6, 0, 4, 6, 3, 6, 3,
+ax_anim 6, 0, 4, 7, 4, 7, 4,
+ax_anim 6, 0, 3, 2, 2, 2, 2,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim 6, 0, 5, -1, -1, -1, -1,
+ax_anim_terminator
+sWalreinAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 4, 0, 4, 0,
+ax_anim 6, 0, 7, 6, 0, 6, 0,
+ax_anim 6, 0, 7, 7, 0, 7, 0,
+ax_anim 6, 0, 6, 1, 0, 1, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim 6, 0, 8, -1, 0, -1, 0,
+ax_anim_terminator
+sWalreinAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 4, -3, 4, -3,
+ax_anim 6, 0, 10, 6, -4, 6, -4,
+ax_anim 6, 0, 10, 7, -5, 7, -5,
+ax_anim 6, 0, 9, 3, -2, 3, -2,
+ax_anim 6, 0, 11, 1, 0, 1, 0,
+ax_anim 6, 0, 11, -1, 1, -1, 1,
+ax_anim_terminator
+sWalreinAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, -3,
+ax_anim 6, 0, 13, 0, -5, 0, -5,
+ax_anim 6, 0, 13, 0, -6, 0, -6,
+ax_anim 6, 0, 12, 0, -2, 0, -2,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 1, 0, 1,
+ax_anim_terminator
+sWalreinAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -4, -3, -4, -3,
+ax_anim 6, 0, 16, -6, -4, -6, -4,
+ax_anim 6, 0, 16, -7, -5, -7, -5,
+ax_anim 6, 0, 15, -3, -2, -3, -2,
+ax_anim 6, 0, 17, -1, 0, -1, 0,
+ax_anim 6, 0, 17, 1, 1, 1, 1,
+ax_anim_terminator
+sWalreinAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -4, 0, -4, 0,
+ax_anim 6, 0, 19, -6, 0, -6, 0,
+ax_anim 6, 0, 19, -7, 0, -7, 0,
+ax_anim 6, 0, 18, -1, 0, -1, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 1, 0, 1, 0,
+ax_anim_terminator
+sWalreinAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, -4, 2, -4, 2,
+ax_anim 6, 0, 22, -6, 3, -6, 3,
+ax_anim 6, 0, 22, -7, 4, -7, 4,
+ax_anim 6, 0, 21, -2, 2, -2, 2,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 1, -1, 1, -1,
+ax_anim_terminator
+.align 2
+sWalreinAnims_2_1:
+ax_anim 2, 0, 26, 0, -1, 0, -1,
+ax_anim 6, 0, 26, 0, -2, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 16, 0, 16,
+ax_anim 2, 1, 25, 1, 16, 1, 16,
+ax_anim 2, 0, 25, 0, 16, 0, 16,
+ax_anim 2, 0, 25, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWalreinAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 6, 0, 29, -2, -2, -2, -2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 28, 9, 11, 9, 11,
+ax_anim 2, 0, 28, 14, 18, 14, 18,
+ax_anim 2, 1, 28, 15, 17, 15, 17,
+ax_anim 2, 0, 28, 14, 18, 14, 18,
+ax_anim 2, 0, 28, 15, 17, 15, 17,
+ax_anim 2, 0, 27, 5, 6, 5, 6,
+ax_anim_terminator
+sWalreinAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 31, 8, 0, 8, 0,
+ax_anim 2, 0, 31, 12, 0, 12, 0,
+ax_anim 2, 1, 31, 12, 1, 12, 1,
+ax_anim 2, 0, 31, 12, 0, 12, 0,
+ax_anim 2, 0, 31, 12, 1, 12, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sWalreinAnims_2_4:
+ax_anim 2, 0, 35, -1, 1, -1, 1,
+ax_anim 6, 0, 35, -2, 2, -2, 2,
+ax_anim 1, 0, 33, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 5, -6, 5, -6,
+ax_anim 1, 0, 34, 11, -13, 11, -13,
+ax_anim 2, 0, 34, 16, -18, 16, -18,
+ax_anim 2, 1, 34, 17, -17, 17, -17,
+ax_anim 2, 0, 34, 16, -18, 16, -18,
+ax_anim 2, 0, 34, 17, -17, 17, -17,
+ax_anim 2, 0, 33, 6, -7, 6, -7,
+ax_anim_terminator
+sWalreinAnims_2_5:
+ax_anim 2, 0, 38, 0, 1, 0, 1,
+ax_anim 6, 0, 38, 0, 2, 0, 2,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 37, 0, -9, 0, -9,
+ax_anim 2, 0, 37, 0, -15, 0, -15,
+ax_anim 2, 1, 37, 1, -15, 1, -15,
+ax_anim 2, 0, 37, 0, -15, 0, -15,
+ax_anim 2, 0, 37, 1, -15, 1, -15,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sWalreinAnims_2_6:
+ax_anim 2, 0, 41, 1, 1, 1, 1,
+ax_anim 6, 0, 41, 2, 2, 2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -5, -6, -5, -6,
+ax_anim 1, 0, 40, -11, -13, -11, -13,
+ax_anim 2, 0, 40, -16, -18, -16, -18,
+ax_anim 2, 1, 40, -17, -17, -17, -17,
+ax_anim 2, 0, 40, -16, -18, -16, -18,
+ax_anim 2, 0, 40, -17, -17, -17, -17,
+ax_anim 2, 0, 39, -6, -7, -6, -7,
+ax_anim_terminator
+sWalreinAnims_2_7:
+ax_anim 2, 0, 44, 1, 0, 1, 0,
+ax_anim 6, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 43, -8, 0, -8, 0,
+ax_anim 2, 0, 43, -12, 0, -12, 0,
+ax_anim 2, 1, 43, -12, 1, -12, 1,
+ax_anim 2, 0, 43, -12, 0, -12, 0,
+ax_anim 2, 0, 43, -12, 1, -12, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sWalreinAnims_2_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 6, 0, 47, 2, -2, 2, -2,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 46, -9, 11, -9, 11,
+ax_anim 2, 0, 46, -14, 18, -14, 18,
+ax_anim 2, 1, 46, -15, 17, -15, 17,
+ax_anim 2, 0, 46, -14, 18, -14, 18,
+ax_anim 2, 0, 46, -15, 17, -15, 17,
+ax_anim 2, 0, 45, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sWalreinAnims_3_1:
+ax_anim 2, 0, 50, 0, -1, 0, -1,
+ax_anim 6, 0, 50, 0, -2, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 49, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 16, 0, 16,
+ax_anim 2, 1, 49, 1, 16, 1, 16,
+ax_anim 2, 0, 49, 0, 16, 0, 16,
+ax_anim 2, 0, 49, 1, 16, 1, 16,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sWalreinAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 6, 0, 53, -2, -2, -2, -2,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 52, 9, 11, 9, 11,
+ax_anim 2, 0, 52, 14, 18, 14, 18,
+ax_anim 2, 1, 52, 15, 17, 15, 17,
+ax_anim 2, 0, 52, 14, 18, 14, 18,
+ax_anim 2, 0, 52, 15, 17, 15, 17,
+ax_anim 2, 0, 51, 5, 6, 5, 6,
+ax_anim_terminator
+sWalreinAnims_3_3:
+ax_anim 2, 0, 56, -1, 0, -1, 0,
+ax_anim 6, 0, 56, -2, 0, -2, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 55, 8, 0, 8, 0,
+ax_anim 2, 0, 55, 12, 0, 12, 0,
+ax_anim 2, 1, 55, 12, 1, 12, 1,
+ax_anim 2, 0, 55, 12, 0, 12, 0,
+ax_anim 2, 0, 55, 12, 1, 12, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sWalreinAnims_3_4:
+ax_anim 2, 0, 59, -1, 1, -1, 1,
+ax_anim 6, 0, 59, -2, 2, -2, 2,
+ax_anim 1, 0, 57, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 5, -6, 5, -6,
+ax_anim 1, 0, 58, 11, -13, 11, -13,
+ax_anim 2, 0, 58, 16, -18, 16, -18,
+ax_anim 2, 1, 58, 17, -17, 17, -17,
+ax_anim 2, 0, 58, 16, -18, 16, -18,
+ax_anim 2, 0, 58, 17, -17, 17, -17,
+ax_anim 2, 0, 57, 6, -7, 6, -7,
+ax_anim_terminator
+sWalreinAnims_3_5:
+ax_anim 2, 0, 62, 0, 1, 0, 1,
+ax_anim 6, 0, 62, 0, 2, 0, 2,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 61, 0, -9, 0, -9,
+ax_anim 2, 0, 61, 0, -15, 0, -15,
+ax_anim 2, 1, 61, 1, -15, 1, -15,
+ax_anim 2, 0, 61, 0, -15, 0, -15,
+ax_anim 2, 0, 61, 1, -15, 1, -15,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sWalreinAnims_3_6:
+ax_anim 2, 0, 65, 1, 1, 1, 1,
+ax_anim 6, 0, 65, 2, 2, 2, 2,
+ax_anim 1, 0, 63, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -5, -6, -5, -6,
+ax_anim 1, 0, 64, -11, -13, -11, -13,
+ax_anim 2, 0, 64, -16, -18, -16, -18,
+ax_anim 2, 1, 64, -17, -17, -17, -17,
+ax_anim 2, 0, 64, -16, -18, -16, -18,
+ax_anim 2, 0, 64, -17, -17, -17, -17,
+ax_anim 2, 0, 63, -6, -7, -6, -7,
+ax_anim_terminator
+sWalreinAnims_3_7:
+ax_anim 2, 0, 68, 1, 0, 1, 0,
+ax_anim 6, 0, 68, 2, 0, 2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 67, -8, 0, -8, 0,
+ax_anim 2, 0, 67, -12, 0, -12, 0,
+ax_anim 2, 1, 67, -12, 1, -12, 1,
+ax_anim 2, 0, 67, -12, 0, -12, 0,
+ax_anim 2, 0, 67, -12, 1, -12, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sWalreinAnims_3_8:
+ax_anim 2, 0, 71, 1, -1, 1, -1,
+ax_anim 6, 0, 71, 2, -2, 2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 70, -9, 11, -9, 11,
+ax_anim 2, 0, 70, -14, 18, -14, 18,
+ax_anim 2, 1, 70, -15, 17, -15, 17,
+ax_anim 2, 0, 70, -14, 18, -14, 18,
+ax_anim 2, 0, 70, -15, 17, -15, 17,
+ax_anim 2, 0, 69, -5, 6, -5, 6,
+ax_anim_terminator
+.align 2
+sWalreinAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sWalreinAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sWalreinAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 80, 2, 1, 2, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sWalreinAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sWalreinAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 86, 1, -3, 1, -3,
+ax_anim 2, 0, 86, 0, -3, 0, -3,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sWalreinAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sWalreinAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 92, -2, 1, -2, 1,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sWalreinAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sWalreinAnims_5_1:
+ax_anim 3, 0, 96, 0, 0, 0, 0,
+ax_anim 8, 2, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, -1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_5_2:
+ax_anim 3, 0, 98, 0, 0, 0, 0,
+ax_anim 8, 2, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_5_3:
+ax_anim 3, 0, 100, 0, 0, 0, 0,
+ax_anim 8, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, 0, -1, 0, -1,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_5_4:
+ax_anim 3, 0, 102, 0, 0, 0, 0,
+ax_anim 8, 2, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_5_5:
+ax_anim 3, 0, 104, 0, 0, 0, 0,
+ax_anim 8, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, -1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_5_6:
+ax_anim 3, 0, 106, 0, 0, 0, 0,
+ax_anim 8, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_5_7:
+ax_anim 3, 0, 108, 0, 0, 0, 0,
+ax_anim 8, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, -1,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_5_8:
+ax_anim 3, 0, 110, 0, 0, 0, 0,
+ax_anim 8, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWalreinAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWalreinAnims_7_1:
+ax_anim 2, 0, 114, 0, -4, 0, -4,
+ax_anim 8, 0, 114, 0, -5, 0, -5,
+ax_anim_terminator
+sWalreinAnims_7_2:
+ax_anim 2, 0, 115, -4, -4, -4, -4,
+ax_anim 8, 0, 115, -5, -5, -5, -5,
+ax_anim_terminator
+sWalreinAnims_7_3:
+ax_anim 2, 0, 116, -4, 0, -4, 0,
+ax_anim 8, 0, 116, -5, 0, -5, 0,
+ax_anim_terminator
+sWalreinAnims_7_4:
+ax_anim 2, 0, 117, -4, 4, -4, 4,
+ax_anim 8, 0, 117, -5, 5, -5, 5,
+ax_anim_terminator
+sWalreinAnims_7_5:
+ax_anim 2, 0, 118, 0, 4, 0, 4,
+ax_anim 8, 0, 118, 0, 5, 0, 5,
+ax_anim_terminator
+sWalreinAnims_7_6:
+ax_anim 2, 0, 119, 4, 4, 4, 4,
+ax_anim 8, 0, 119, 5, 5, 5, 5,
+ax_anim_terminator
+sWalreinAnims_7_7:
+ax_anim 2, 0, 120, 4, 0, 4, 0,
+ax_anim 8, 0, 120, 5, 0, 5, 0,
+ax_anim_terminator
+sWalreinAnims_7_8:
+ax_anim 2, 0, 121, 4, -4, 4, -4,
+ax_anim 8, 0, 121, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sWalreinAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 8, 0, 123, 0, 0, 0, 0,
+ax_anim 8, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_8_2:
+ax_anim 40, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 8, 0, 126, 0, 0, 0, 0,
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_8_3:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 8, 0, 129, 0, 0, 0, 0,
+ax_anim 8, 0, 130, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_8_4:
+ax_anim 40, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 8, 0, 133, 0, 0, 0, 0,
+ax_anim 4, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_8_5:
+ax_anim 40, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 8, 0, 135, 0, 0, 0, 0,
+ax_anim 8, 0, 136, 0, 0, 0, 0,
+ax_anim 4, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_8_6:
+ax_anim 40, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 8, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 0, 0, 0,
+ax_anim 4, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_8_7:
+ax_anim 40, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 8, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 0, 0, 0,
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_8_8:
+ax_anim 40, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 8, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWalreinAnims_9_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 6, 3, 6, 3,
+ax_anim 2, 0, 148, 8, 8, 8, 8,
+ax_anim 2, 0, 149, 7, 13, 7, 13,
+ax_anim 3, 0, 150, 0, 15, 0, 15,
+ax_anim 2, 3, 151, -7, 13, -7, 13,
+ax_anim 2, 0, 152, -8, 8, -8, 8,
+ax_anim 1, 0, 153, -6, 3, -6, 3,
+ax_anim 1, 0, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_9_2:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 146, 8, 0, 8, 0,
+ax_anim 2, 0, 147, 17, 3, 17, 3,
+ax_anim 2, 0, 148, 22, 11, 22, 11,
+ax_anim 3, 0, 149, 22, 17, 22, 17,
+ax_anim 2, 3, 150, 13, 17, 13, 17,
+ax_anim 2, 0, 151, 3, 15, 3, 15,
+ax_anim 1, 0, 152, 0, 7, 0, 7,
+ax_anim 1, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_9_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 3, -5, 3, -5,
+ax_anim 2, 0, 146, 11, -6, 11, -6,
+ax_anim 2, 0, 147, 17, -4, 17, -4,
+ax_anim 3, 0, 148, 21, 0, 21, 0,
+ax_anim 2, 3, 149, 17, 4, 17, 4,
+ax_anim 2, 0, 150, 12, 5, 12, 5,
+ax_anim 1, 0, 151, 4, 5, 4, 5,
+ax_anim 1, 0, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_9_4:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 1, 0, 152, -1, -8, -1, -8,
+ax_anim 2, 0, 153, 1, -16, 1, -16,
+ax_anim 2, 0, 146, 12, -22, 12, -22,
+ax_anim 3, 0, 147, 21, -23, 21, -23,
+ax_anim 2, 3, 148, 22, -15, 22, -15,
+ax_anim 2, 0, 149, 17, -5, 17, -5,
+ax_anim 1, 0, 150, 7, -1, 7, -1,
+ax_anim 1, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_9_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, -8, -4, -8, -4,
+ax_anim 2, 0, 152, -9, -12, -9, -12,
+ax_anim 2, 0, 153, -8, -21, -8, -21,
+ax_anim 3, 0, 146, 0, -22, 0, -22,
+ax_anim 2, 3, 147, 8, -21, 8, -21,
+ax_anim 2, 0, 148, 9, -12, 9, -12,
+ax_anim 1, 0, 149, 8, -4, 8, -4,
+ax_anim 1, 0, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_9_6:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 1, -8, 1, -8,
+ax_anim 2, 0, 147, -1, -16, -1, -16,
+ax_anim 2, 0, 146, -12, -22, -12, -22,
+ax_anim 3, 0, 153, -21, -23, -21, -23,
+ax_anim 2, 3, 152, -22, -15, -22, -15,
+ax_anim 2, 0, 151, -17, -5, -17, -5,
+ax_anim 1, 0, 150, -7, -1, -7, -1,
+ax_anim 1, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_9_7:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 147, -3, -5, -3, -5,
+ax_anim 2, 0, 146, -11, -6, -11, -6,
+ax_anim 2, 0, 153, -17, -4, -17, -4,
+ax_anim 3, 0, 152, -21, 0, -21, 0,
+ax_anim 2, 3, 151, -17, 4, -17, 4,
+ax_anim 2, 0, 150, -12, 5, -12, 5,
+ax_anim 1, 0, 149, -4, 5, -4, 5,
+ax_anim 1, 0, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_9_8:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 146, -8, 0, -8, 0,
+ax_anim 2, 0, 153, -17, 3, -17, 3,
+ax_anim 2, 0, 152, -22, 11, -22, 11,
+ax_anim 3, 0, 151, -22, 17, -22, 17,
+ax_anim 2, 3, 150, -13, 17, -13, 17,
+ax_anim 2, 0, 149, -3, 15, -3, 15,
+ax_anim 1, 0, 148, 0, 7, 0, 7,
+ax_anim 1, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWalreinAnims_10_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 3, 0, 154, 13, 0, 13, 0,
+ax_anim 3, 0, 154, -13, 0, -13, 0,
+ax_anim 2, 0, 154, 12, 0, 12, 0,
+ax_anim 3, 0, 154, -12, 0, -12, 0,
+ax_anim 2, 0, 154, 10, 0, 10, 0,
+ax_anim 2, 0, 154, -10, 0, -10, 0,
+ax_anim 2, 0, 154, 6, 0, 6, 0,
+ax_anim 2, 0, 154, -6, 0, -6, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_10_2:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 3, 0, 155, 13, -13, 13, -13,
+ax_anim 3, 0, 155, -13, 13, -13, 13,
+ax_anim 2, 0, 155, 12, -12, 12, -12,
+ax_anim 3, 0, 155, -12, 12, -12, 12,
+ax_anim 2, 0, 155, 10, -10, 10, -10,
+ax_anim 2, 0, 155, -10, 10, -10, 10,
+ax_anim 2, 0, 155, 6, -6, 6, -6,
+ax_anim 2, 0, 155, -6, 6, -6, 6,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_10_3:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 3, 0, 156, 0, -13, 0, -13,
+ax_anim 3, 0, 156, 0, 13, 0, 13,
+ax_anim 2, 0, 156, 0, -12, 0, -12,
+ax_anim 3, 0, 156, 0, 12, 0, 12,
+ax_anim 2, 0, 156, 0, -10, 0, -10,
+ax_anim 2, 0, 156, 0, 10, 0, 10,
+ax_anim 2, 0, 156, 0, -6, 0, -6,
+ax_anim 2, 0, 156, 0, 6, 0, 6,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_10_4:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 3, 0, 157, -13, -13, -13, -13,
+ax_anim 3, 0, 157, 13, 13, 13, 13,
+ax_anim 2, 0, 157, -12, -12, -12, -12,
+ax_anim 3, 0, 157, 12, 12, 12, 12,
+ax_anim 2, 0, 157, -10, -10, -10, -10,
+ax_anim 2, 0, 157, 10, 10, 10, 10,
+ax_anim 2, 0, 157, -6, -6, -6, -6,
+ax_anim 2, 0, 157, 6, 6, 6, 6,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_10_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 3, 0, 158, 13, 0, 13, 0,
+ax_anim 3, 0, 158, -13, 0, -13, 0,
+ax_anim 2, 0, 158, 12, 0, 12, 0,
+ax_anim 3, 0, 158, -12, 0, -12, 0,
+ax_anim 2, 0, 158, 10, 0, 10, 0,
+ax_anim 2, 0, 158, -10, 0, -10, 0,
+ax_anim 2, 0, 158, 6, 0, 6, 0,
+ax_anim 2, 0, 158, -6, 0, -6, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_10_6:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 3, 0, 159, 13, -13, 13, -13,
+ax_anim 3, 0, 159, -13, 13, -13, 13,
+ax_anim 2, 0, 159, 12, -12, 12, -12,
+ax_anim 3, 0, 159, -12, 12, -12, 12,
+ax_anim 2, 0, 159, 10, -10, 10, -10,
+ax_anim 2, 0, 159, -10, 10, -10, 10,
+ax_anim 2, 0, 159, 6, -6, 6, -6,
+ax_anim 2, 0, 159, -6, 6, -6, 6,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_10_7:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 3, 0, 160, 0, -13, 0, -13,
+ax_anim 3, 0, 160, 0, 13, 0, 13,
+ax_anim 2, 0, 160, 0, -12, 0, -12,
+ax_anim 3, 0, 160, 0, 12, 0, 12,
+ax_anim 2, 0, 160, 0, -10, 0, -10,
+ax_anim 2, 0, 160, 0, 10, 0, 10,
+ax_anim 2, 0, 160, 0, -6, 0, -6,
+ax_anim 2, 0, 160, 0, 6, 0, 6,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_10_8:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 3, 0, 161, -13, -13, -13, -13,
+ax_anim 3, 0, 161, 13, 13, 13, 13,
+ax_anim 2, 0, 161, -12, -12, -12, -12,
+ax_anim 3, 0, 161, 12, 12, 12, 12,
+ax_anim 2, 0, 161, -10, -10, -10, -10,
+ax_anim 2, 0, 161, 10, 10, 10, 10,
+ax_anim 2, 0, 161, -6, -6, -6, -6,
+ax_anim 2, 0, 161, 6, 6, 6, 6,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWalreinAnims_11_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 0, -10, 0, 0,
+ax_anim 2, 0, 163, 0, -16, 0, 0,
+ax_anim 3, 0, 163, 0, -20, 0, 0,
+ax_anim 4, 0, 163, 0, -21, 0, 0,
+ax_anim 4, 0, 162, 0, -22, 0, 0,
+ax_anim 3, 0, 164, 0, -22, 0, 0,
+ax_anim 2, 0, 164, 0, -18, 0, 0,
+ax_anim 1, 0, 164, 0, -12, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_11_2:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 166, 0, -10, 0, 0,
+ax_anim 2, 0, 166, 0, -16, 0, 0,
+ax_anim 3, 0, 166, 0, -20, 0, 0,
+ax_anim 4, 0, 166, 0, -21, 0, 0,
+ax_anim 4, 0, 165, 0, -23, 0, 0,
+ax_anim 3, 0, 167, 0, -22, 0, 0,
+ax_anim 2, 0, 167, 0, -18, 0, 0,
+ax_anim 1, 0, 167, 0, -12, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_11_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 0, -10, 0, 0,
+ax_anim 2, 0, 169, 0, -16, 0, 0,
+ax_anim 3, 0, 169, 0, -20, 0, 0,
+ax_anim 4, 0, 169, 0, -21, 0, 0,
+ax_anim 4, 0, 168, 0, -22, 0, 0,
+ax_anim 3, 0, 170, 0, -21, 0, 0,
+ax_anim 2, 0, 170, 0, -18, 0, 0,
+ax_anim 1, 0, 170, 0, -12, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_11_4:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -10, 0, 0,
+ax_anim 2, 0, 172, 0, -16, 0, 0,
+ax_anim 3, 0, 172, 0, -20, 0, 0,
+ax_anim 4, 0, 172, 0, -21, 0, 0,
+ax_anim 4, 0, 171, 0, -22, 0, 0,
+ax_anim 3, 0, 173, 0, -20, 0, 0,
+ax_anim 2, 0, 173, 0, -17, 0, 0,
+ax_anim 1, 0, 173, 0, -11, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_11_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 0, -10, 0, 0,
+ax_anim 2, 0, 175, 0, -16, 0, 0,
+ax_anim 3, 0, 175, 0, -20, 0, 0,
+ax_anim 4, 0, 175, 0, -21, 0, 0,
+ax_anim 4, 0, 174, 0, -22, 0, 0,
+ax_anim 3, 0, 176, 0, -20, 0, 0,
+ax_anim 2, 0, 176, 0, -16, 0, 0,
+ax_anim 1, 0, 176, 0, -10, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_11_6:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 177, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 2, 0, 179, 0, -17, 0, 0,
+ax_anim 1, 0, 179, 0, -11, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_11_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 181, 0, -10, 0, 0,
+ax_anim 2, 0, 181, 0, -16, 0, 0,
+ax_anim 3, 0, 181, 0, -20, 0, 0,
+ax_anim 4, 0, 181, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -22, 0, 0,
+ax_anim 3, 0, 182, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -12, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_11_8:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 185, 0, -22, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -12, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWalreinAnims_12_1:
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 1, 0, 1, 0,
+ax_anim 2, 1, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_12_2:
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 1, -1, 1, -1,
+ax_anim 2, 1, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_12_3:
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, -1,
+ax_anim 2, 1, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_12_4:
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, -1, -1, -1, -1,
+ax_anim 2, 1, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_12_5:
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 1, 0, 1, 0,
+ax_anim 2, 1, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_12_6:
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 1, -1, 1, -1,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_12_7:
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, -1,
+ax_anim 2, 1, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_12_8:
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, -1, -1, -1, -1,
+ax_anim 2, 1, 187, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWalreinAnims_13_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_13_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_13_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_13_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_13_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_13_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_13_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinAnims_13_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sWalreinGfx1:
+.incbin "baserom.gba", 0x15111A8, 0x200
+sWalreinSprites1:
+ax_sprite sWalreinGfx1, 0x200
+ax_sprite_terminator
+sWalreinGfx2:
+.incbin "baserom.gba", 0x15113B8, 0x200
+sWalreinSprites2:
+ax_sprite sWalreinGfx2, 0x200
+ax_sprite_terminator
+sWalreinGfx3:
+.incbin "baserom.gba", 0x15115C8, 0x200
+sWalreinSprites3:
+ax_sprite sWalreinGfx3, 0x200
+ax_sprite_terminator
+sWalreinGfx4:
+.incbin "baserom.gba", 0x15117D8, 0x200
+sWalreinSprites4:
+ax_sprite sWalreinGfx4, 0x200
+ax_sprite_terminator
+sWalreinGfx5:
+.incbin "baserom.gba", 0x15119E8, 0x200
+sWalreinSprites5:
+ax_sprite sWalreinGfx5, 0x200
+ax_sprite_terminator
+sWalreinGfx6:
+.incbin "baserom.gba", 0x1511BF8, 0x200
+sWalreinSprites6:
+ax_sprite sWalreinGfx6, 0x200
+ax_sprite_terminator
+sWalreinGfx7:
+.incbin "baserom.gba", 0x1511E08, 0x200
+sWalreinSprites7:
+ax_sprite sWalreinGfx7, 0x200
+ax_sprite_terminator
+sWalreinGfx8:
+.incbin "baserom.gba", 0x1512018, 0x200
+sWalreinSprites8:
+ax_sprite sWalreinGfx8, 0x200
+ax_sprite_terminator
+sWalreinGfx9:
+.incbin "baserom.gba", 0x1512228, 0x200
+sWalreinSprites9:
+ax_sprite sWalreinGfx9, 0x200
+ax_sprite_terminator
+sWalreinGfx10:
+.incbin "baserom.gba", 0x1512438, 0x200
+sWalreinSprites10:
+ax_sprite sWalreinGfx10, 0x200
+ax_sprite_terminator
+sWalreinGfx11:
+.incbin "baserom.gba", 0x1512648, 0x200
+sWalreinSprites11:
+ax_sprite sWalreinGfx11, 0x200
+ax_sprite_terminator
+sWalreinGfx12:
+.incbin "baserom.gba", 0x1512858, 0x200
+sWalreinSprites12:
+ax_sprite sWalreinGfx12, 0x200
+ax_sprite_terminator
+sWalreinGfx13:
+.incbin "baserom.gba", 0x1512A68, 0x200
+sWalreinSprites13:
+ax_sprite sWalreinGfx13, 0x200
+ax_sprite_terminator
+sWalreinGfx14:
+.incbin "baserom.gba", 0x1512C78, 0x200
+sWalreinSprites14:
+ax_sprite sWalreinGfx14, 0x200
+ax_sprite_terminator
+sWalreinGfx15:
+.incbin "baserom.gba", 0x1512E88, 0x200
+sWalreinSprites15:
+ax_sprite sWalreinGfx15, 0x200
+ax_sprite_terminator
+sWalreinGfx16:
+.incbin "baserom.gba", 0x1513098, 0x40
+sWalreinGfx16_1:
+.incbin "baserom.gba", 0x15130D8, 0x40
+sWalreinGfx16_2:
+.incbin "baserom.gba", 0x1513118, 0x100
+sWalreinSprites16:
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx16, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWalreinGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx16_2, 0x100
+ax_sprite_terminator
+sWalreinGfx17:
+.incbin "baserom.gba", 0x1513250, 0x60
+sWalreinGfx17_1:
+.incbin "baserom.gba", 0x15132B0, 0x180
+sWalreinSprites17:
+ax_sprite sWalreinGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx17_1, 0x180
+ax_sprite_terminator
+sWalreinGfx18:
+.incbin "baserom.gba", 0x1513450, 0x1A0
+sWalreinSprites18:
+ax_sprite 0, 0x60
+ax_sprite sWalreinGfx18, 0x1a0
+ax_sprite_terminator
+sWalreinGfx19:
+.incbin "baserom.gba", 0x1513608, 0x180
+sWalreinGfx19_1:
+.incbin "baserom.gba", 0x1513788, 0x40
+sWalreinSprites19:
+ax_sprite sWalreinGfx19, 0x180
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx19_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWalreinGfx20:
+.incbin "baserom.gba", 0x15137F0, 0xC0
+sWalreinSprites20:
+ax_sprite 0, 0x40
+ax_sprite sWalreinGfx20, 0xc0
+ax_sprite_terminator
+sWalreinGfx21:
+.incbin "baserom.gba", 0x15138C8, 0x60
+sWalreinSprites21:
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx21, 0x60
+ax_sprite_terminator
+sWalreinGfx22:
+.incbin "baserom.gba", 0x1513940, 0x40
+sWalreinSprites22:
+ax_sprite sWalreinGfx22, 0x40
+ax_sprite_terminator
+sWalreinGfx23:
+.incbin "baserom.gba", 0x1513990, 0x40
+sWalreinSprites23:
+ax_sprite sWalreinGfx23, 0x40
+ax_sprite_terminator
+sWalreinGfx24:
+.incbin "baserom.gba", 0x15139E0, 0x180
+sWalreinGfx24_1:
+.incbin "baserom.gba", 0x1513B60, 0x60
+sWalreinSprites24:
+ax_sprite sWalreinGfx24, 0x180
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx24_1, 0x60
+ax_sprite_terminator
+sWalreinGfx25:
+.incbin "baserom.gba", 0x1513BE0, 0x60
+sWalreinGfx25_1:
+.incbin "baserom.gba", 0x1513C40, 0x60
+sWalreinGfx25_2:
+.incbin "baserom.gba", 0x1513CA0, 0x100
+sWalreinSprites25:
+ax_sprite sWalreinGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx25_2, 0x100
+ax_sprite_terminator
+sWalreinGfx26:
+.incbin "baserom.gba", 0x1513DD0, 0x60
+sWalreinGfx26_1:
+.incbin "baserom.gba", 0x1513E30, 0x160
+sWalreinSprites26:
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx26_1, 0x160
+ax_sprite_terminator
+sWalreinGfx27:
+.incbin "baserom.gba", 0x1513FB8, 0x1E0
+sWalreinSprites27:
+ax_sprite sWalreinGfx27, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWalreinGfx28:
+.incbin "baserom.gba", 0x15141B0, 0x100
+sWalreinSprites28:
+ax_sprite sWalreinGfx28, 0x100
+ax_sprite_terminator
+sWalreinGfx29:
+.incbin "baserom.gba", 0x15142C0, 0x80
+sWalreinSprites29:
+ax_sprite sWalreinGfx29, 0x80
+ax_sprite_terminator
+sWalreinGfx30:
+.incbin "baserom.gba", 0x1514350, 0x20
+sWalreinSprites30:
+ax_sprite sWalreinGfx30, 0x20
+ax_sprite_terminator
+sWalreinGfx31:
+.incbin "baserom.gba", 0x1514380, 0x20
+sWalreinSprites31:
+ax_sprite sWalreinGfx31, 0x20
+ax_sprite_terminator
+sWalreinGfx32:
+.incbin "baserom.gba", 0x15143B0, 0x20
+sWalreinSprites32:
+ax_sprite sWalreinGfx32, 0x20
+ax_sprite_terminator
+sWalreinGfx33:
+.incbin "baserom.gba", 0x15143E0, 0x60
+sWalreinGfx33_1:
+.incbin "baserom.gba", 0x1514440, 0x180
+sWalreinSprites33:
+ax_sprite sWalreinGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx33_1, 0x180
+ax_sprite_terminator
+sWalreinGfx34:
+.incbin "baserom.gba", 0x15145E0, 0x40
+sWalreinGfx34_1:
+.incbin "baserom.gba", 0x1514620, 0x60
+sWalreinGfx34_2:
+.incbin "baserom.gba", 0x1514680, 0x100
+sWalreinSprites34:
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx34_2, 0x100
+ax_sprite_terminator
+sWalreinGfx35:
+.incbin "baserom.gba", 0x15147B8, 0x60
+sWalreinGfx35_1:
+.incbin "baserom.gba", 0x1514818, 0x160
+sWalreinSprites35:
+ax_sprite sWalreinGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx35_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWalreinGfx36:
+.incbin "baserom.gba", 0x15149A0, 0x1E0
+sWalreinSprites36:
+ax_sprite sWalreinGfx36, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWalreinGfx37:
+.incbin "baserom.gba", 0x1514B98, 0x60
+sWalreinGfx37_1:
+.incbin "baserom.gba", 0x1514BF8, 0x60
+sWalreinGfx37_2:
+.incbin "baserom.gba", 0x1514C58, 0x80
+sWalreinGfx37_3:
+.incbin "baserom.gba", 0x1514CD8, 0x60
+sWalreinSprites37:
+ax_sprite sWalreinGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx37_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx37_3, 0x60
+ax_sprite_terminator
+sWalreinGfx38:
+.incbin "baserom.gba", 0x1514D78, 0x40
+sWalreinSprites38:
+ax_sprite sWalreinGfx38, 0x40
+ax_sprite_terminator
+sWalreinGfx39:
+.incbin "baserom.gba", 0x1514DC8, 0x100
+sWalreinSprites39:
+ax_sprite sWalreinGfx39, 0x100
+ax_sprite_terminator
+sWalreinGfx40:
+.incbin "baserom.gba", 0x1514ED8, 0x40
+sWalreinSprites40:
+ax_sprite sWalreinGfx40, 0x40
+ax_sprite_terminator
+sWalreinGfx41:
+.incbin "baserom.gba", 0x1514F28, 0x60
+sWalreinGfx41_1:
+.incbin "baserom.gba", 0x1514F88, 0x60
+sWalreinGfx41_2:
+.incbin "baserom.gba", 0x1514FE8, 0x100
+sWalreinSprites41:
+ax_sprite sWalreinGfx41, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx41_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx41_2, 0x100
+ax_sprite_terminator
+sWalreinGfx42:
+.incbin "baserom.gba", 0x1515118, 0x60
+sWalreinGfx42_1:
+.incbin "baserom.gba", 0x1515178, 0x60
+sWalreinGfx42_2:
+.incbin "baserom.gba", 0x15151D8, 0x100
+sWalreinSprites42:
+ax_sprite sWalreinGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx42_2, 0x100
+ax_sprite_terminator
+sWalreinGfx43:
+.incbin "baserom.gba", 0x1515308, 0x100
+sWalreinSprites43:
+ax_sprite sWalreinGfx43, 0x100
+ax_sprite_terminator
+sWalreinGfx44:
+.incbin "baserom.gba", 0x1515418, 0x80
+sWalreinSprites44:
+ax_sprite sWalreinGfx44, 0x80
+ax_sprite_terminator
+sWalreinGfx45:
+.incbin "baserom.gba", 0x15154A8, 0x20
+sWalreinSprites45:
+ax_sprite sWalreinGfx45, 0x20
+ax_sprite_terminator
+sWalreinGfx46:
+.incbin "baserom.gba", 0x15154D8, 0x20
+sWalreinSprites46:
+ax_sprite sWalreinGfx46, 0x20
+ax_sprite_terminator
+sWalreinGfx47:
+.incbin "baserom.gba", 0x1515508, 0x20
+sWalreinSprites47:
+ax_sprite sWalreinGfx47, 0x20
+ax_sprite_terminator
+sWalreinGfx48:
+.incbin "baserom.gba", 0x1515538, 0xE0
+sWalreinGfx48_1:
+.incbin "baserom.gba", 0x1515618, 0xE0
+sWalreinSprites48:
+ax_sprite sWalreinGfx48, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWalreinGfx48_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWalreinGfx49:
+.incbin "baserom.gba", 0x1515720, 0x200
+sWalreinSprites49:
+ax_sprite sWalreinGfx49, 0x200
+ax_sprite_terminator
+sWalreinGfx50:
+.incbin "baserom.gba", 0x1515930, 0x200
+sWalreinSprites50:
+ax_sprite sWalreinGfx50, 0x200
+ax_sprite_terminator
+sWalreinGfx51:
+.incbin "baserom.gba", 0x1515B40, 0x200
+sWalreinSprites51:
+ax_sprite sWalreinGfx51, 0x200
+ax_sprite_terminator
+sWalreinGfx52:
+.incbin "baserom.gba", 0x1515D50, 0x200
+sWalreinSprites52:
+ax_sprite sWalreinGfx52, 0x200
+ax_sprite_terminator
+sWalreinGfx53:
+.incbin "baserom.gba", 0x1515F60, 0x200
+sWalreinSprites53:
+ax_sprite sWalreinGfx53, 0x200
+ax_sprite_terminator
+sWalreinGfx54:
+.incbin "baserom.gba", 0x1516170, 0x200
+sWalreinSprites54:
+ax_sprite sWalreinGfx54, 0x200
+ax_sprite_terminator
+sWalreinGfx55:
+.incbin "baserom.gba", 0x1516380, 0x200
+sWalreinSprites55:
+ax_sprite sWalreinGfx55, 0x200
+ax_sprite_terminator
+sAxPosesWalrein:
+.4byte sWalreinPose1
+.4byte sWalreinPose2
+.4byte sWalreinPose3
+.4byte sWalreinPose4
+.4byte sWalreinPose5
+.4byte sWalreinPose6
+.4byte sWalreinPose7
+.4byte sWalreinPose8
+.4byte sWalreinPose9
+.4byte sWalreinPose10
+.4byte sWalreinPose11
+.4byte sWalreinPose12
+.4byte sWalreinPose13
+.4byte sWalreinPose14
+.4byte sWalreinPose15
+.4byte sWalreinPose16
+.4byte sWalreinPose17
+.4byte sWalreinPose18
+.4byte sWalreinPose19
+.4byte sWalreinPose20
+.4byte sWalreinPose21
+.4byte sWalreinPose22
+.4byte sWalreinPose23
+.4byte sWalreinPose24
+.4byte sWalreinPose25
+.4byte sWalreinPose26
+.4byte sWalreinPose27
+.4byte sWalreinPose28
+.4byte sWalreinPose29
+.4byte sWalreinPose30
+.4byte sWalreinPose31
+.4byte sWalreinPose32
+.4byte sWalreinPose33
+.4byte sWalreinPose34
+.4byte sWalreinPose35
+.4byte sWalreinPose36
+.4byte sWalreinPose37
+.4byte sWalreinPose38
+.4byte sWalreinPose39
+.4byte sWalreinPose40
+.4byte sWalreinPose41
+.4byte sWalreinPose42
+.4byte sWalreinPose43
+.4byte sWalreinPose44
+.4byte sWalreinPose45
+.4byte sWalreinPose46
+.4byte sWalreinPose47
+.4byte sWalreinPose48
+.4byte sWalreinPose49
+.4byte sWalreinPose50
+.4byte sWalreinPose51
+.4byte sWalreinPose52
+.4byte sWalreinPose53
+.4byte sWalreinPose54
+.4byte sWalreinPose55
+.4byte sWalreinPose56
+.4byte sWalreinPose57
+.4byte sWalreinPose58
+.4byte sWalreinPose59
+.4byte sWalreinPose60
+.4byte sWalreinPose61
+.4byte sWalreinPose62
+.4byte sWalreinPose63
+.4byte sWalreinPose64
+.4byte sWalreinPose65
+.4byte sWalreinPose66
+.4byte sWalreinPose67
+.4byte sWalreinPose68
+.4byte sWalreinPose69
+.4byte sWalreinPose70
+.4byte sWalreinPose71
+.4byte sWalreinPose72
+.4byte sWalreinPose73
+.4byte sWalreinPose74
+.4byte sWalreinPose75
+.4byte sWalreinPose76
+.4byte sWalreinPose77
+.4byte sWalreinPose78
+.4byte sWalreinPose79
+.4byte sWalreinPose80
+.4byte sWalreinPose81
+.4byte sWalreinPose82
+.4byte sWalreinPose83
+.4byte sWalreinPose84
+.4byte sWalreinPose85
+.4byte sWalreinPose86
+.4byte sWalreinPose87
+.4byte sWalreinPose88
+.4byte sWalreinPose89
+.4byte sWalreinPose90
+.4byte sWalreinPose91
+.4byte sWalreinPose92
+.4byte sWalreinPose93
+.4byte sWalreinPose94
+.4byte sWalreinPose95
+.4byte sWalreinPose96
+.4byte sWalreinPose97
+.4byte sWalreinPose98
+.4byte sWalreinPose99
+.4byte sWalreinPose100
+.4byte sWalreinPose101
+.4byte sWalreinPose102
+.4byte sWalreinPose103
+.4byte sWalreinPose104
+.4byte sWalreinPose105
+.4byte sWalreinPose106
+.4byte sWalreinPose107
+.4byte sWalreinPose108
+.4byte sWalreinPose109
+.4byte sWalreinPose110
+.4byte sWalreinPose111
+.4byte sWalreinPose112
+.4byte sWalreinPose113
+.4byte sWalreinPose114
+.4byte sWalreinPose115
+.4byte sWalreinPose116
+.4byte sWalreinPose117
+.4byte sWalreinPose118
+.4byte sWalreinPose119
+.4byte sWalreinPose120
+.4byte sWalreinPose121
+.4byte sWalreinPose122
+.4byte sWalreinPose123
+.4byte sWalreinPose124
+.4byte sWalreinPose125
+.4byte sWalreinPose126
+.4byte sWalreinPose127
+.4byte sWalreinPose128
+.4byte sWalreinPose129
+.4byte sWalreinPose130
+.4byte sWalreinPose131
+.4byte sWalreinPose132
+.4byte sWalreinPose133
+.4byte sWalreinPose134
+.4byte sWalreinPose135
+.4byte sWalreinPose136
+.4byte sWalreinPose137
+.4byte sWalreinPose138
+.4byte sWalreinPose139
+.4byte sWalreinPose140
+.4byte sWalreinPose141
+.4byte sWalreinPose142
+.4byte sWalreinPose143
+.4byte sWalreinPose144
+.4byte sWalreinPose145
+.4byte sWalreinPose146
+.4byte sWalreinPose147
+.4byte sWalreinPose148
+.4byte sWalreinPose149
+.4byte sWalreinPose150
+.4byte sWalreinPose151
+.4byte sWalreinPose152
+.4byte sWalreinPose153
+.4byte sWalreinPose154
+.4byte sWalreinPose155
+.4byte sWalreinPose156
+.4byte sWalreinPose157
+.4byte sWalreinPose158
+.4byte sWalreinPose159
+.4byte sWalreinPose160
+.4byte sWalreinPose161
+.4byte sWalreinPose162
+.4byte sWalreinPose163
+.4byte sWalreinPose164
+.4byte sWalreinPose165
+.4byte sWalreinPose166
+.4byte sWalreinPose167
+.4byte sWalreinPose168
+.4byte sWalreinPose169
+.4byte sWalreinPose170
+.4byte sWalreinPose171
+.4byte sWalreinPose172
+.4byte sWalreinPose173
+.4byte sWalreinPose174
+.4byte sWalreinPose175
+.4byte sWalreinPose176
+.4byte sWalreinPose177
+.4byte sWalreinPose178
+.4byte sWalreinPose179
+.4byte sWalreinPose180
+.4byte sWalreinPose181
+.4byte sWalreinPose182
+.4byte sWalreinPose183
+.4byte sWalreinPose184
+.4byte sWalreinPose185
+.4byte sWalreinPose186
+.4byte sWalreinPose187
+.4byte sWalreinPose188
+.4byte sWalreinPose189
+.4byte sWalreinPose190
+.4byte sWalreinPose191
+.4byte sWalreinPose192
+.4byte sWalreinPose193
+.4byte sWalreinPose194
+.4byte sWalreinPose195
+.4byte sWalreinPose196
+.4byte sWalreinPose197
+.4byte sWalreinPose198
+.4byte sWalreinPose199
+.4byte sWalreinPose200
+.4byte sWalreinPose201
+.4byte sWalreinPose202
+sAxPositionsWalrein:
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte   -1,   -8, 	  -9,   -3, 	   8,   -3, 	  -1,   -6
+.2byte   -1,   -2, 	 -10,    4, 	   8,    4, 	  -1,   -3
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+.2byte   10,  -11, 	   3,   -6, 	  -7,   -1, 	   0,   -6
+.2byte    7,   -4, 	  10,   -1, 	  -2,    3, 	  -1,   -5
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte   12,  -15, 	   0,   -5, 	  -1,    1, 	  -1,   -5
+.2byte    8,   -9, 	   7,   -2, 	   6,    1, 	  -2,   -4
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte   11,  -16, 	  -2,   -7, 	   5,    2, 	   0,   -6
+.2byte    5,  -13, 	   0,   -8, 	   9,   -3, 	  -3,   -5
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -17, 	   9,   -1, 	 -11,   -1, 	  -1,   -5
+.2byte   -1,  -11, 	   9,   -7, 	 -11,   -7, 	  -1,   -3
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte  -13,  -16, 	   0,   -7, 	  -7,    2, 	  -2,   -6
+.2byte   -7,  -13, 	  -2,   -8, 	 -11,   -3, 	   1,   -5
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte  -14,  -15, 	  -2,   -5, 	  -1,    1, 	  -1,   -5
+.2byte  -10,   -9, 	  -9,   -2, 	  -8,    1, 	   0,   -4
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte  -12,  -11, 	  -5,   -6, 	   5,   -1, 	  -2,   -6
+.2byte   -9,   -4, 	 -12,   -1, 	   0,    3, 	  -1,   -5
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte   -1,    2, 	 -11,    2, 	   9,    2, 	  -1,   -6
+.2byte   -1,  -19, 	 -10,    1, 	   8,    1, 	  -1,   -5
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+.2byte   12,   -1, 	   6,   -5, 	  -4,    4, 	  -2,   -6
+.2byte    2,  -19, 	   8,   -2, 	  -4,    3, 	  -1,   -7
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte   16,   -7, 	   3,   -5, 	   4,    2, 	  -2,   -5
+.2byte    2,  -19, 	   2,   -5, 	   3,    1, 	  -3,   -5
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte   10,  -15, 	  -1,   -7, 	   7,    0, 	  -2,   -6
+.2byte    0,  -20, 	  -3,   -6, 	   7,   -1, 	  -5,   -5
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -21, 	   9,   -5, 	 -11,   -5, 	  -1,   -8
+.2byte   -1,  -21, 	   8,   -4, 	 -10,   -4, 	  -1,   -5
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte  -12,  -15, 	  -1,   -7, 	  -9,    0, 	   0,   -6
+.2byte   -2,  -20, 	   1,   -6, 	  -9,   -1, 	   3,   -5
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte  -18,   -7, 	  -5,   -5, 	  -6,    2, 	   0,   -5
+.2byte   -4,  -19, 	  -4,   -5, 	  -5,    1, 	   1,   -5
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte  -14,   -1, 	  -8,   -5, 	   2,    4, 	   0,   -6
+.2byte   -4,  -19, 	 -10,   -2, 	   2,    3, 	  -1,   -7
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte   -1,    2, 	 -11,    2, 	   9,    2, 	  -1,   -6
+.2byte   -1,  -19, 	 -10,    1, 	   8,    1, 	  -1,   -5
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+.2byte   12,   -1, 	   6,   -5, 	  -4,    4, 	  -2,   -6
+.2byte    2,  -19, 	   8,   -2, 	  -4,    3, 	  -1,   -7
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte   16,   -7, 	   3,   -5, 	   4,    2, 	  -2,   -5
+.2byte    2,  -19, 	   2,   -5, 	   3,    1, 	  -3,   -5
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte   10,  -15, 	  -1,   -7, 	   7,    0, 	  -2,   -6
+.2byte    0,  -20, 	  -3,   -6, 	   7,   -1, 	  -5,   -5
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -21, 	   9,   -5, 	 -11,   -5, 	  -1,   -8
+.2byte   -1,  -21, 	   8,   -4, 	 -10,   -4, 	  -1,   -5
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte  -12,  -15, 	  -1,   -7, 	  -9,    0, 	   0,   -6
+.2byte   -2,  -20, 	   1,   -6, 	  -9,   -1, 	   3,   -5
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte  -18,   -7, 	  -5,   -5, 	  -6,    2, 	   0,   -5
+.2byte   -4,  -19, 	  -4,   -5, 	  -5,    1, 	   1,   -5
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte  -14,   -1, 	  -8,   -5, 	   2,    4, 	   0,   -6
+.2byte   -4,  -19, 	 -10,   -2, 	   2,    3, 	  -1,   -7
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte   -1,  -16, 	 -10,    1, 	   9,    1, 	  -1,   -4
+.2byte   -1,    0, 	 -11,    1, 	   9,    1, 	  -1,   -6
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+.2byte    4,  -17, 	   9,   -2, 	  -5,    3, 	  -1,   -7
+.2byte   10,   -2, 	   7,   -4, 	  -5,    3, 	  -1,   -5
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte    5,  -20, 	   2,   -4, 	   4,    2, 	  -3,   -5
+.2byte   16,   -9, 	   4,   -4, 	   4,    2, 	   0,   -5
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte    2,  -22, 	  -2,   -6, 	   7,    0, 	  -4,   -5
+.2byte   10,  -17, 	   0,   -7, 	   7,    0, 	  -1,   -6
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -22, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -19, 	   9,   -4, 	 -11,   -4, 	  -1,   -8
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte   -4,  -22, 	   0,   -6, 	  -9,    0, 	   2,   -5
+.2byte  -12,  -17, 	  -2,   -7, 	  -9,    0, 	  -1,   -6
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte   -7,  -20, 	  -4,   -4, 	  -6,    2, 	   1,   -5
+.2byte  -18,   -9, 	  -6,   -4, 	  -6,    2, 	  -2,   -5
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte   -6,  -17, 	 -11,   -2, 	   3,    3, 	  -1,   -7
+.2byte  -12,   -2, 	  -9,   -4, 	   3,    3, 	  -1,   -5
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte   -1,  -19, 	 -10,    1, 	   8,    1, 	  -1,   -5
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+.2byte    2,  -19, 	   8,   -2, 	  -4,    3, 	  -1,   -7
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte    2,  -19, 	   2,   -5, 	   3,    1, 	  -3,   -5
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte    0,  -20, 	  -3,   -6, 	   7,   -1, 	  -5,   -5
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -21, 	   8,   -4, 	 -10,   -4, 	  -1,   -5
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte   -2,  -20, 	   1,   -6, 	  -9,   -1, 	   3,   -5
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte   -4,  -19, 	  -4,   -5, 	  -5,    1, 	   1,   -5
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte   -4,  -19, 	 -10,   -2, 	   2,    3, 	  -1,   -7
+.2byte  -12,   -2, 	  -5,   -5, 	   5,   -1, 	   0,   -7
+.2byte  -12,   -2, 	  -4,   -5, 	   5,    0, 	   0,   -7
+.2byte    0,  -12, 	  -9,   -5, 	  10,   -5, 	   0,   -6
+.2byte    4,  -14, 	  11,   -6, 	  -4,   -1, 	   0,   -6
+.2byte    7,  -15, 	   1,   -4, 	   2,   -1, 	  -1,   -7
+.2byte    4,  -19, 	  -1,  -11, 	  10,   -5, 	  -2,   -8
+.2byte    0,  -19, 	  10,   -8, 	 -10,   -8, 	   0,   -5
+.2byte   -5,  -19, 	   0,  -11, 	 -11,   -5, 	   1,   -8
+.2byte   -8,  -15, 	  -2,   -4, 	  -3,   -1, 	   0,   -7
+.2byte   -5,  -14, 	 -12,   -6, 	   3,   -1, 	  -1,   -6
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte   -1,  -16, 	 -10,    1, 	   9,    1, 	  -1,   -4
+.2byte   -1,  -19, 	 -10,    1, 	   8,    1, 	  -1,   -5
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+.2byte    4,  -17, 	   9,   -2, 	  -5,    3, 	  -1,   -7
+.2byte    2,  -19, 	   8,   -2, 	  -4,    3, 	  -1,   -7
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte    5,  -20, 	   2,   -4, 	   4,    2, 	  -3,   -5
+.2byte    2,  -19, 	   2,   -5, 	   3,    1, 	  -3,   -5
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte    2,  -22, 	  -2,   -6, 	   7,    0, 	  -4,   -5
+.2byte    0,  -20, 	  -3,   -6, 	   7,   -1, 	  -5,   -5
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -22, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -21, 	   8,   -4, 	 -10,   -4, 	  -1,   -5
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte   -4,  -22, 	   0,   -6, 	  -9,    0, 	   2,   -5
+.2byte   -2,  -20, 	   1,   -6, 	  -9,   -1, 	   3,   -5
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte   -7,  -20, 	  -4,   -4, 	  -6,    2, 	   1,   -5
+.2byte   -4,  -19, 	  -4,   -5, 	  -5,    1, 	   1,   -5
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte   -6,  -17, 	 -11,   -2, 	   3,    3, 	  -1,   -7
+.2byte   -4,  -19, 	 -10,   -2, 	   2,    3, 	  -1,   -7
+.2byte   -1,  -19, 	 -10,    1, 	   8,    1, 	  -1,   -5
+.2byte   -4,  -17, 	 -10,    0, 	   2,    5, 	  -1,   -5
+.2byte   -5,  -18, 	  -5,   -4, 	  -6,    2, 	   0,   -4
+.2byte   -3,  -20, 	   0,   -6, 	 -10,   -1, 	   2,   -5
+.2byte   -1,  -21, 	   8,   -4, 	 -10,   -4, 	  -1,   -5
+.2byte    1,  -20, 	  -2,   -6, 	   8,   -1, 	  -4,   -5
+.2byte    3,  -18, 	   3,   -4, 	   4,    2, 	  -2,   -4
+.2byte    2,  -17, 	   8,    0, 	  -4,    5, 	  -1,   -5
+.2byte   -1,  -16, 	 -10,    1, 	   9,    1, 	  -1,   -4
+.2byte    4,  -16, 	   9,   -1, 	  -5,    4, 	  -1,   -6
+.2byte    5,  -20, 	   2,   -4, 	   4,    2, 	  -3,   -5
+.2byte    2,  -22, 	  -2,   -6, 	   7,    0, 	  -4,   -5
+.2byte   -1,  -22, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -4,  -22, 	   0,   -6, 	  -9,    0, 	   2,   -5
+.2byte   -7,  -20, 	  -4,   -4, 	  -6,    2, 	   1,   -5
+.2byte   -6,  -16, 	 -11,   -1, 	   3,    4, 	  -1,   -6
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte   -1,  -18, 	 -10,    2, 	   8,    2, 	  -1,   -4
+.2byte   -1,    2, 	 -11,    2, 	   9,    2, 	  -1,   -6
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+.2byte    3,  -19, 	   9,   -2, 	  -3,    3, 	   0,   -7
+.2byte   11,   -1, 	   5,   -5, 	  -5,    4, 	  -3,   -6
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte    4,  -19, 	   4,   -5, 	   5,    1, 	  -1,   -5
+.2byte   15,   -7, 	   2,   -5, 	   3,    2, 	  -3,   -5
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte    0,  -20, 	  -3,   -6, 	   7,   -1, 	  -5,   -5
+.2byte    9,  -15, 	  -2,   -7, 	   6,    0, 	  -3,   -6
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte   -1,  -21, 	   8,   -4, 	 -10,   -4, 	  -1,   -5
+.2byte   -1,  -19, 	   9,   -3, 	 -11,   -3, 	  -1,   -6
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte   -2,  -20, 	   1,   -6, 	  -9,   -1, 	   3,   -5
+.2byte  -11,  -15, 	   0,   -7, 	  -8,    0, 	   1,   -6
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte   -6,  -19, 	  -6,   -5, 	  -7,    1, 	  -1,   -5
+.2byte  -17,   -7, 	  -4,   -5, 	  -5,    2, 	   1,   -5
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte   -5,  -19, 	 -11,   -2, 	   1,    3, 	  -2,   -7
+.2byte  -13,   -1, 	  -7,   -5, 	   3,    4, 	   1,   -6
+.2byte   -1,    2, 	 -11,    2, 	   9,    2, 	  -1,   -6
+.2byte  -12,   -1, 	  -6,   -5, 	   4,    4, 	   2,   -6
+.2byte  -17,   -7, 	  -4,   -5, 	  -5,    2, 	   1,   -5
+.2byte  -12,  -15, 	  -1,   -7, 	  -9,    0, 	   0,   -6
+.2byte   -1,  -21, 	   9,   -5, 	 -11,   -5, 	  -1,   -8
+.2byte   10,  -15, 	  -1,   -7, 	   7,    0, 	  -2,   -6
+.2byte   16,   -7, 	   3,   -5, 	   4,    2, 	  -2,   -5
+.2byte   10,   -1, 	   4,   -5, 	  -6,    4, 	  -4,   -6
+.2byte   -1,   -3, 	 -11,    1, 	   9,    1, 	  -1,   -5
+.2byte  -10,   -5, 	 -11,   -1, 	   2,    3, 	  -1,   -5
+.2byte  -14,  -10, 	  -5,   -5, 	  -6,    1, 	  -1,   -6
+.2byte   -9,  -15, 	   0,   -7, 	 -10,    0, 	   0,   -6
+.2byte   -1,  -16, 	   9,   -4, 	 -11,   -4, 	  -1,   -6
+.2byte    7,  -15, 	  -2,   -7, 	   8,    0, 	  -2,   -6
+.2byte   12,  -10, 	   3,   -5, 	   4,    1, 	  -1,   -6
+.2byte    8,   -5, 	   9,   -1, 	  -4,    3, 	  -1,   -5
+sWalreinAnimTable1:
+.4byte sWalreinAnims_1_1
+.4byte sWalreinAnims_1_2
+.4byte sWalreinAnims_1_3
+.4byte sWalreinAnims_1_4
+.4byte sWalreinAnims_1_5
+.4byte sWalreinAnims_1_6
+.4byte sWalreinAnims_1_7
+.4byte sWalreinAnims_1_8
+sWalreinAnimTable2:
+.4byte sWalreinAnims_2_1
+.4byte sWalreinAnims_2_2
+.4byte sWalreinAnims_2_3
+.4byte sWalreinAnims_2_4
+.4byte sWalreinAnims_2_5
+.4byte sWalreinAnims_2_6
+.4byte sWalreinAnims_2_7
+.4byte sWalreinAnims_2_8
+sWalreinAnimTable3:
+.4byte sWalreinAnims_3_1
+.4byte sWalreinAnims_3_2
+.4byte sWalreinAnims_3_3
+.4byte sWalreinAnims_3_4
+.4byte sWalreinAnims_3_5
+.4byte sWalreinAnims_3_6
+.4byte sWalreinAnims_3_7
+.4byte sWalreinAnims_3_8
+sWalreinAnimTable4:
+.4byte sWalreinAnims_4_1
+.4byte sWalreinAnims_4_2
+.4byte sWalreinAnims_4_3
+.4byte sWalreinAnims_4_4
+.4byte sWalreinAnims_4_5
+.4byte sWalreinAnims_4_6
+.4byte sWalreinAnims_4_7
+.4byte sWalreinAnims_4_8
+sWalreinAnimTable5:
+.4byte sWalreinAnims_5_1
+.4byte sWalreinAnims_5_2
+.4byte sWalreinAnims_5_3
+.4byte sWalreinAnims_5_4
+.4byte sWalreinAnims_5_5
+.4byte sWalreinAnims_5_6
+.4byte sWalreinAnims_5_7
+.4byte sWalreinAnims_5_8
+sWalreinAnimTable6:
+.4byte sWalreinAnims_6_1
+.4byte sWalreinAnims_6_1
+.4byte sWalreinAnims_6_1
+.4byte sWalreinAnims_6_1
+.4byte sWalreinAnims_6_1
+.4byte sWalreinAnims_6_1
+.4byte sWalreinAnims_6_1
+.4byte sWalreinAnims_6_1
+sWalreinAnimTable7:
+.4byte sWalreinAnims_7_1
+.4byte sWalreinAnims_7_2
+.4byte sWalreinAnims_7_3
+.4byte sWalreinAnims_7_4
+.4byte sWalreinAnims_7_5
+.4byte sWalreinAnims_7_6
+.4byte sWalreinAnims_7_7
+.4byte sWalreinAnims_7_8
+sWalreinAnimTable8:
+.4byte sWalreinAnims_8_1
+.4byte sWalreinAnims_8_2
+.4byte sWalreinAnims_8_3
+.4byte sWalreinAnims_8_4
+.4byte sWalreinAnims_8_5
+.4byte sWalreinAnims_8_6
+.4byte sWalreinAnims_8_7
+.4byte sWalreinAnims_8_8
+sWalreinAnimTable9:
+.4byte sWalreinAnims_9_1
+.4byte sWalreinAnims_9_2
+.4byte sWalreinAnims_9_3
+.4byte sWalreinAnims_9_4
+.4byte sWalreinAnims_9_5
+.4byte sWalreinAnims_9_6
+.4byte sWalreinAnims_9_7
+.4byte sWalreinAnims_9_8
+sWalreinAnimTable10:
+.4byte sWalreinAnims_10_1
+.4byte sWalreinAnims_10_2
+.4byte sWalreinAnims_10_3
+.4byte sWalreinAnims_10_4
+.4byte sWalreinAnims_10_5
+.4byte sWalreinAnims_10_6
+.4byte sWalreinAnims_10_7
+.4byte sWalreinAnims_10_8
+sWalreinAnimTable11:
+.4byte sWalreinAnims_11_1
+.4byte sWalreinAnims_11_2
+.4byte sWalreinAnims_11_3
+.4byte sWalreinAnims_11_4
+.4byte sWalreinAnims_11_5
+.4byte sWalreinAnims_11_6
+.4byte sWalreinAnims_11_7
+.4byte sWalreinAnims_11_8
+sWalreinAnimTable12:
+.4byte sWalreinAnims_12_1
+.4byte sWalreinAnims_12_2
+.4byte sWalreinAnims_12_3
+.4byte sWalreinAnims_12_4
+.4byte sWalreinAnims_12_5
+.4byte sWalreinAnims_12_6
+.4byte sWalreinAnims_12_7
+.4byte sWalreinAnims_12_8
+sWalreinAnimTable13:
+.4byte sWalreinAnims_13_1
+.4byte sWalreinAnims_13_2
+.4byte sWalreinAnims_13_3
+.4byte sWalreinAnims_13_4
+.4byte sWalreinAnims_13_5
+.4byte sWalreinAnims_13_6
+.4byte sWalreinAnims_13_7
+.4byte sWalreinAnims_13_8
+sAxAnimationsWalrein:
+.4byte sWalreinAnimTable1
+.4byte sWalreinAnimTable2
+.4byte sWalreinAnimTable3
+.4byte sWalreinAnimTable4
+.4byte sWalreinAnimTable5
+.4byte sWalreinAnimTable6
+.4byte sWalreinAnimTable7
+.4byte sWalreinAnimTable8
+.4byte sWalreinAnimTable9
+.4byte sWalreinAnimTable10
+.4byte sWalreinAnimTable11
+.4byte sWalreinAnimTable12
+.4byte sWalreinAnimTable13
+sAxSpritesWalrein:
+.4byte sWalreinSprites1
+.4byte sWalreinSprites2
+.4byte sWalreinSprites3
+.4byte sWalreinSprites4
+.4byte sWalreinSprites5
+.4byte sWalreinSprites6
+.4byte sWalreinSprites7
+.4byte sWalreinSprites8
+.4byte sWalreinSprites9
+.4byte sWalreinSprites10
+.4byte sWalreinSprites11
+.4byte sWalreinSprites12
+.4byte sWalreinSprites13
+.4byte sWalreinSprites14
+.4byte sWalreinSprites15
+.4byte sWalreinSprites16
+.4byte sWalreinSprites17
+.4byte sWalreinSprites18
+.4byte sWalreinSprites19
+.4byte sWalreinSprites20
+.4byte sWalreinSprites21
+.4byte sWalreinSprites22
+.4byte sWalreinSprites23
+.4byte sWalreinSprites24
+.4byte sWalreinSprites25
+.4byte sWalreinSprites26
+.4byte sWalreinSprites27
+.4byte sWalreinSprites28
+.4byte sWalreinSprites29
+.4byte sWalreinSprites30
+.4byte sWalreinSprites31
+.4byte sWalreinSprites32
+.4byte sWalreinSprites33
+.4byte sWalreinSprites34
+.4byte sWalreinSprites35
+.4byte sWalreinSprites36
+.4byte sWalreinSprites37
+.4byte sWalreinSprites38
+.4byte sWalreinSprites39
+.4byte sWalreinSprites40
+.4byte sWalreinSprites41
+.4byte sWalreinSprites42
+.4byte sWalreinSprites43
+.4byte sWalreinSprites44
+.4byte sWalreinSprites45
+.4byte sWalreinSprites46
+.4byte sWalreinSprites47
+.4byte sWalreinSprites48
+.4byte sWalreinSprites49
+.4byte sWalreinSprites50
+.4byte sWalreinSprites51
+.4byte sWalreinSprites52
+.4byte sWalreinSprites53
+.4byte sWalreinSprites54
+.4byte sWalreinSprites55
+sAxMainWalrein:
+ax_main sAxPosesWalrein, sAxAnimationsWalrein, 13, sAxSpritesWalrein, sAxPositionsWalrein

--- a/data/ax/wartortle.inc
+++ b/data/ax/wartortle.inc
@@ -1,0 +1,2853 @@
+.global gAxWartortle
+gAxWartortle:
+ax_siro sAxMainWartortle
+sWartortlePose1:
+ax_pose 0, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose2:
+ax_pose 1, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose3:
+ax_pose 2, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose4:
+ax_pose 3, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose5:
+ax_pose 4, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose6:
+ax_pose 5, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose7:
+ax_pose 6, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose8:
+ax_pose 7, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose9:
+ax_pose 8, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose10:
+ax_pose 9, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose11:
+ax_pose 10, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose12:
+ax_pose 11, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose16:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose17:
+ax_pose 16, 0x01ed, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose18:
+ax_pose 17, 0x01ed, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose19:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose20:
+ax_pose 19, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose21:
+ax_pose 20, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose22:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose23:
+ax_pose 22, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose24:
+ax_pose 23, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose25:
+ax_pose 0, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose26:
+ax_pose 1, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose27:
+ax_pose 2, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose28:
+ax_pose 3, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose29:
+ax_pose 4, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose30:
+ax_pose 5, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose31:
+ax_pose 6, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose32:
+ax_pose 7, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose33:
+ax_pose 8, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose34:
+ax_pose 9, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose35:
+ax_pose 10, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose36:
+ax_pose 11, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose37:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose40:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose41:
+ax_pose 16, 0x01ed, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose42:
+ax_pose 17, 0x01ed, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose43:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose44:
+ax_pose 19, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose45:
+ax_pose 20, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose46:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose47:
+ax_pose 22, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose48:
+ax_pose 23, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose49:
+ax_pose 24, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose50:
+ax_pose 25, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose51:
+ax_pose 26, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose52:
+ax_pose 27, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose53:
+ax_pose 28, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose54:
+ax_pose 27, 0x41f5, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose55:
+ax_pose 26, 0x41f5, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose56:
+ax_pose 25, 0x41f5, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose57:
+ax_pose 0, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose58:
+ax_pose 1, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose59:
+ax_pose 29, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose60:
+ax_pose 25, 0x41f5, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose61:
+ax_pose 24, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose62:
+ax_pose 25, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose63:
+ax_pose 26, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose64:
+ax_pose 27, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose65:
+ax_pose 28, 0x41f5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose66:
+ax_pose 27, 0x41f5, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose67:
+ax_pose 26, 0x41f5, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose68:
+ax_pose 3, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose69:
+ax_pose 4, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose70:
+ax_pose 30, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose71:
+ax_pose 26, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose72:
+ax_pose 25, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose73:
+ax_pose 24, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose74:
+ax_pose 25, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose75:
+ax_pose 26, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose76:
+ax_pose 27, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose77:
+ax_pose 28, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose78:
+ax_pose 27, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose79:
+ax_pose 6, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose80:
+ax_pose 7, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose81:
+ax_pose 31, 0x01eb, 0x90ee, 0x9c00
+ax_pose_terminator
+sWartortlePose82:
+ax_pose 27, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose83:
+ax_pose 26, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose84:
+ax_pose 25, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose85:
+ax_pose 24, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose86:
+ax_pose 25, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose87:
+ax_pose 26, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose88:
+ax_pose 27, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose89:
+ax_pose 28, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose90:
+ax_pose 9, 0x01eb, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose91:
+ax_pose 10, 0x01eb, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose92:
+ax_pose 32, 0x01ea, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose93:
+ax_pose 28, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose94:
+ax_pose 27, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose95:
+ax_pose 26, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose96:
+ax_pose 25, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose97:
+ax_pose 24, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose98:
+ax_pose 25, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose99:
+ax_pose 26, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose100:
+ax_pose 27, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose101:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose102:
+ax_pose 13, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose103:
+ax_pose 33, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose104:
+ax_pose 27, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose105:
+ax_pose 28, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose106:
+ax_pose 27, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose107:
+ax_pose 26, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose108:
+ax_pose 25, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose109:
+ax_pose 24, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose110:
+ax_pose 25, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose111:
+ax_pose 26, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose112:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose113:
+ax_pose 16, 0x01ed, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose114:
+ax_pose 32, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose115:
+ax_pose 26, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose116:
+ax_pose 27, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose117:
+ax_pose 28, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose118:
+ax_pose 27, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose119:
+ax_pose 26, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose120:
+ax_pose 25, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose121:
+ax_pose 24, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose122:
+ax_pose 25, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose123:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose124:
+ax_pose 19, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose125:
+ax_pose 31, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose126:
+ax_pose 25, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose127:
+ax_pose 26, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose128:
+ax_pose 27, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose129:
+ax_pose 28, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose130:
+ax_pose 27, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose131:
+ax_pose 26, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose132:
+ax_pose 25, 0x41f5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose133:
+ax_pose 24, 0x41f5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose134:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose135:
+ax_pose 22, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose136:
+ax_pose 30, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose137:
+ax_pose 0, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose138:
+ax_pose 1, 0x01ea, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose139:
+ax_pose 34, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose140:
+ax_pose 29, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose141:
+ax_pose 3, 0x01ec, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose142:
+ax_pose 4, 0x01eb, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose143:
+ax_pose 35, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose144:
+ax_pose 30, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose145:
+ax_pose 6, 0x01eb, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose146:
+ax_pose 7, 0x01eb, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose147:
+ax_pose 36, 0x01eb, 0x90ef, 0x9c00
+ax_pose_terminator
+sWartortlePose148:
+ax_pose 31, 0x01eb, 0x90ef, 0x9c00
+ax_pose_terminator
+sWartortlePose149:
+ax_pose 9, 0x01eb, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose150:
+ax_pose 11, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose151:
+ax_pose 37, 0x01ea, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose152:
+ax_pose 32, 0x01ea, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose153:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose154:
+ax_pose 13, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose155:
+ax_pose 38, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose156:
+ax_pose 33, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose157:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose158:
+ax_pose 17, 0x01ec, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose159:
+ax_pose 37, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose160:
+ax_pose 32, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose161:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose162:
+ax_pose 19, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose163:
+ax_pose 36, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose164:
+ax_pose 31, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose165:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose166:
+ax_pose 22, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose167:
+ax_pose 35, 0x01ec, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose168:
+ax_pose 30, 0x01ec, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose169:
+ax_pose 24, 0x41f4, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose170:
+ax_pose 25, 0x41f4, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose171:
+ax_pose 26, 0x41f4, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose172:
+ax_pose 27, 0x41f4, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose173:
+ax_pose 28, 0x41f4, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose174:
+ax_pose 27, 0x41f4, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose175:
+ax_pose 26, 0x41f4, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose176:
+ax_pose 25, 0x41f4, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose177:
+ax_pose 39, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose178:
+ax_pose 40, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose179:
+ax_pose 41, 0x01e6, 0x80f1, 0x9c00
+ax_pose_terminator
+sWartortlePose180:
+ax_pose 42, 0x01e8, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose181:
+ax_pose 43, 0x01e5, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose182:
+ax_pose 44, 0x01e6, 0x90ea, 0x9c00
+ax_pose_terminator
+sWartortlePose183:
+ax_pose 45, 0x01e4, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose184:
+ax_pose 44, 0x01e6, 0x80f6, 0x9c00
+ax_pose_terminator
+sWartortlePose185:
+ax_pose 43, 0x01e5, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose186:
+ax_pose 42, 0x01e8, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose187:
+ax_pose 0, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose188:
+ax_pose 21, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose189:
+ax_pose 18, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose190:
+ax_pose 15, 0x01ea, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose191:
+ax_pose 12, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose192:
+ax_pose 9, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose193:
+ax_pose 6, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose194:
+ax_pose 3, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose195:
+ax_pose 0, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose196:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose197:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose198:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose199:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose200:
+ax_pose 9, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose201:
+ax_pose 6, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose202:
+ax_pose 3, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose203:
+ax_pose 0, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose204:
+ax_pose 3, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose205:
+ax_pose 6, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose206:
+ax_pose 9, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose207:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose208:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose209:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose210:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose211:
+ax_pose 0, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose212:
+ax_pose 34, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose213:
+ax_pose 29, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose214:
+ax_pose 3, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose215:
+ax_pose 35, 0x01ec, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose216:
+ax_pose 30, 0x01ec, 0x90ed, 0x9c00
+ax_pose_terminator
+sWartortlePose217:
+ax_pose 6, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose218:
+ax_pose 36, 0x01eb, 0x90ef, 0x9c00
+ax_pose_terminator
+sWartortlePose219:
+ax_pose 31, 0x01eb, 0x90ef, 0x9c00
+ax_pose_terminator
+sWartortlePose220:
+ax_pose 9, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose221:
+ax_pose 37, 0x01ea, 0x90ee, 0x9c00
+ax_pose_terminator
+sWartortlePose222:
+ax_pose 32, 0x01ea, 0x90ee, 0x9c00
+ax_pose_terminator
+sWartortlePose223:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose224:
+ax_pose 38, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose225:
+ax_pose 33, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose226:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose227:
+ax_pose 37, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose228:
+ax_pose 32, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose229:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose230:
+ax_pose 36, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose231:
+ax_pose 31, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose232:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose233:
+ax_pose 35, 0x01ec, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose234:
+ax_pose 30, 0x01ec, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose235:
+ax_pose 34, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose236:
+ax_pose 35, 0x01ec, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose237:
+ax_pose 36, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose238:
+ax_pose 37, 0x01ea, 0x80f3, 0x9c00
+ax_pose_terminator
+sWartortlePose239:
+ax_pose 38, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose240:
+ax_pose 37, 0x01ea, 0x90ee, 0x9c00
+ax_pose_terminator
+sWartortlePose241:
+ax_pose 36, 0x01eb, 0x90ef, 0x9c00
+ax_pose_terminator
+sWartortlePose242:
+ax_pose 35, 0x01ec, 0x90ec, 0x9c00
+ax_pose_terminator
+sWartortlePose243:
+ax_pose 0, 0x01ed, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose244:
+ax_pose 21, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose245:
+ax_pose 18, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose246:
+ax_pose 15, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWartortlePose247:
+ax_pose 12, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose248:
+ax_pose 9, 0x01eb, 0x80f4, 0x9c00
+ax_pose_terminator
+sWartortlePose249:
+ax_pose 6, 0x01eb, 0x80f5, 0x9c00
+ax_pose_terminator
+sWartortlePose250:
+ax_pose 3, 0x01ec, 0x80f5, 0x9c00
+ax_pose_terminator
+.align 2
+sWartortleAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, 0, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 4, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWartortleAnims_2_2:
+ax_anim 4, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 29, 0, -1, 0, 0,
+ax_anim 2, 0, 28, 4, 4, 4, 4,
+ax_anim 2, 2, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 4, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sWartortleAnims_2_3:
+ax_anim 4, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, 0, 4, 0,
+ax_anim 2, 2, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 1, 31, 18, 1, 18, 1,
+ax_anim 2, 0, 31, 18, 0, 18, 0,
+ax_anim 2, 0, 31, 18, 1, 18, 1,
+ax_anim 4, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sWartortleAnims_2_4:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 35, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -4, 4, -4,
+ax_anim 2, 2, 35, 10, -10, 10, -10,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 1, 34, 19, -17, 19, -17,
+ax_anim 2, 0, 34, 18, -18, 18, -18,
+ax_anim 2, 0, 34, 19, -17, 19, -17,
+ax_anim 4, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sWartortleAnims_2_5:
+ax_anim 4, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 38, 0, 0, 0, 0,
+ax_anim 2, 0, 37, 0, -4, 0, -4,
+ax_anim 2, 2, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 1, 37, 1, -18, 1, -18,
+ax_anim 2, 0, 37, 0, -18, 0, -18,
+ax_anim 2, 0, 37, 1, -18, 1, -18,
+ax_anim 4, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sWartortleAnims_2_6:
+ax_anim 4, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 41, 0, 0, 0, -1,
+ax_anim 2, 0, 40, -4, -4, -4, -4,
+ax_anim 2, 2, 41, -10, -10, -10, -10,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 1, 40, -19, -17, -19, -17,
+ax_anim 2, 0, 40, -18, -18, -18, -18,
+ax_anim 2, 0, 40, -19, -17, -19, -17,
+ax_anim 4, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sWartortleAnims_2_7:
+ax_anim 4, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, 0, -4, 0,
+ax_anim 2, 2, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 1, 43, -18, 1, -18, 1,
+ax_anim 2, 0, 43, -18, 0, -18, 0,
+ax_anim 2, 0, 43, -18, 1, -18, 1,
+ax_anim 4, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sWartortleAnims_2_8:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, 0, 0, 0, 0,
+ax_anim 2, 0, 47, -4, 4, -4, 4,
+ax_anim 2, 2, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 1, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 2, 0, 46, -17, 19, -17, 19,
+ax_anim 4, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWartortleAnims_3_1:
+ax_anim 6, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 56, 0, -7, 0, 0,
+ax_anim 2, 0, 56, 0, -8, 0, 0,
+ax_anim 4, 0, 48, 0, -10, 0, 0,
+ax_anim 3, 0, 49, 0, -11, 0, 0,
+ax_anim 2, 0, 50, 0, -11, 0, 0,
+ax_anim 1, 2, 51, 0, -10, 0, 1,
+ax_anim 1, 0, 52, 0, -8, 0, 2,
+ax_anim 1, 0, 53, 0, 2, 0, 8,
+ax_anim 1, 0, 54, 0, 18, 0, 18,
+ax_anim 2, 1, 55, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 18, 0, 18,
+ax_anim 2, 0, 49, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 11, 0, 8,
+ax_anim 2, 0, 58, 0, -4, 0, 2,
+ax_anim 2, 0, 58, 0, -5, 0, 1,
+ax_anim 2, 0, 58, 0, -4, 0, 0,
+ax_anim_terminator
+sWartortleAnims_3_2:
+ax_anim 6, 0, 69, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -7, 0, 0,
+ax_anim 2, 0, 67, 0, -8, 0, 0,
+ax_anim 4, 0, 59, 0, -10, 0, 0,
+ax_anim 3, 0, 60, 1, -11, 0, 0,
+ax_anim 2, 0, 61, 2, -11, 0, 0,
+ax_anim 1, 2, 62, 3, -10, 1, 1,
+ax_anim 1, 0, 63, 6, -8, 2, 2,
+ax_anim 1, 0, 64, 10, 0, 8, 8,
+ax_anim 1, 0, 65, 18, 13, 18, 18,
+ax_anim 2, 1, 66, 19, 13, 19, 18,
+ax_anim 2, 0, 59, 18, 13, 18, 18,
+ax_anim 2, 0, 60, 19, 13, 19, 18,
+ax_anim 2, 0, 61, 8, -3, 8, 8,
+ax_anim 2, 0, 69, 2, -4, 2, 2,
+ax_anim 2, 0, 69, 1, -5, 1, 1,
+ax_anim 2, 0, 69, 0, -4, 0, 0,
+ax_anim_terminator
+sWartortleAnims_3_3:
+ax_anim 6, 0, 80, -2, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -7, 0, 0,
+ax_anim 2, 0, 78, 0, -8, 0, 0,
+ax_anim 4, 0, 70, 0, -10, 0, 0,
+ax_anim 3, 0, 71, 0, -11, 0, 0,
+ax_anim 2, 0, 72, 1, -11, 1, 0,
+ax_anim 1, 2, 73, 2, -11, 2, 0,
+ax_anim 1, 0, 74, 6, -10, 6, 0,
+ax_anim 1, 0, 75, 10, -9, 10, 0,
+ax_anim 1, 0, 76, 18, -5, 18, 0,
+ax_anim 2, 1, 77, 18, -6, 18, -1,
+ax_anim 2, 0, 70, 18, -5, 18, 0,
+ax_anim 2, 0, 71, 18, -6, 18, -1,
+ax_anim 2, 0, 72, 10, -10, 10, 0,
+ax_anim 2, 0, 80, 2, -6, 2, 0,
+ax_anim 2, 0, 80, 1, -6, 1, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim_terminator
+sWartortleAnims_3_4:
+ax_anim 6, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -7, 0, 0,
+ax_anim 4, 0, 81, 0, -10, 0, 0,
+ax_anim 3, 0, 82, 1, -11, 1, -1,
+ax_anim 2, 0, 83, 2, -12, 2, -2,
+ax_anim 1, 2, 84, 3, -13, 3, -3,
+ax_anim 1, 0, 85, 6, -15, 6, -6,
+ax_anim 1, 0, 86, 10, -19, 10, -10,
+ax_anim 1, 0, 87, 18, -26, 18, -18,
+ax_anim 2, 1, 88, 18, -27, 18, -19,
+ax_anim 2, 0, 81, 18, -26, 18, -18,
+ax_anim 2, 0, 82, 18, -27, 18, -19,
+ax_anim 2, 0, 83, 10, -19, 10, -10,
+ax_anim 2, 0, 91, 2, -11, 2, -2,
+ax_anim 2, 0, 91, 1, -10, 1, -1,
+ax_anim 2, 0, 91, 0, -6, 0, 0,
+ax_anim_terminator
+sWartortleAnims_3_5:
+ax_anim 6, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -6, 0, 0,
+ax_anim 2, 0, 100, 0, -7, 0, 0,
+ax_anim 4, 0, 92, 0, -11, 0, 0,
+ax_anim 3, 0, 93, 0, -12, 0, -1,
+ax_anim 2, 0, 94, 0, -13, 0, -2,
+ax_anim 1, 2, 95, 0, -14, 0, -3,
+ax_anim 1, 0, 96, 0, -15, 0, -6,
+ax_anim 1, 0, 97, 0, -19, 0, -10,
+ax_anim 1, 0, 98, 0, -26, 0, -18,
+ax_anim 2, 1, 99, -1, -26, -1, -18,
+ax_anim 2, 0, 92, 0, -26, 0, -18,
+ax_anim 2, 0, 93, -1, -26, -1, -18,
+ax_anim 2, 0, 94, 0, -19, 0, -10,
+ax_anim 2, 0, 102, 0, -9, 0, -2,
+ax_anim 2, 0, 102, 0, -8, 0, -1,
+ax_anim 2, 0, 102, 0, -4, 0, 0,
+ax_anim_terminator
+sWartortleAnims_3_6:
+ax_anim 6, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 111, 0, -7, 0, 0,
+ax_anim 4, 0, 103, 0, -10, 0, 0,
+ax_anim 3, 0, 104, -1, -11, -1, -1,
+ax_anim 2, 0, 105, -2, -12, -2, -2,
+ax_anim 1, 2, 106, -3, -13, -3, -3,
+ax_anim 1, 0, 107, -6, -15, -6, -6,
+ax_anim 1, 0, 108, -10, -19, -10, -10,
+ax_anim 1, 0, 109, -18, -26, -18, -18,
+ax_anim 2, 1, 110, -18, -27, -18, -19,
+ax_anim 2, 0, 103, -18, -26, -18, -18,
+ax_anim 2, 0, 104, -18, -27, -18, -19,
+ax_anim 2, 0, 105, -10, -19, -10, -10,
+ax_anim 2, 0, 113, -2, -11, -2, -2,
+ax_anim 2, 0, 113, -1, -10, -1, -1,
+ax_anim 2, 0, 113, 0, -6, 0, 0,
+ax_anim_terminator
+sWartortleAnims_3_7:
+ax_anim 6, 0, 124, 2, 0, 0, 0,
+ax_anim 2, 0, 122, 0, -7, 0, 0,
+ax_anim 2, 0, 122, 0, -8, 0, 0,
+ax_anim 4, 0, 114, 0, -10, 0, 0,
+ax_anim 3, 0, 115, 0, -11, 0, 0,
+ax_anim 2, 0, 116, -1, -11, -1, 0,
+ax_anim 1, 2, 117, -2, -11, -2, 0,
+ax_anim 1, 0, 118, -6, -10, -6, 0,
+ax_anim 1, 0, 119, -10, -9, -10, 0,
+ax_anim 1, 0, 120, -18, -5, -18, 0,
+ax_anim 2, 1, 121, -18, -6, -18, -1,
+ax_anim 2, 0, 114, -18, -5, -18, 0,
+ax_anim 2, 0, 115, -18, -6, -18, -1,
+ax_anim 2, 0, 116, -10, -10, -10, 0,
+ax_anim 2, 0, 124, -2, -6, -2, 0,
+ax_anim 2, 0, 124, -1, -6, -1, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim_terminator
+sWartortleAnims_3_8:
+ax_anim 6, 0, 135, 0, -2, 0, 0,
+ax_anim 2, 0, 133, 0, -7, 0, 0,
+ax_anim 2, 0, 133, 0, -8, 0, 0,
+ax_anim 4, 0, 125, 0, -10, 0, 0,
+ax_anim 3, 0, 126, -1, -11, 0, 0,
+ax_anim 2, 0, 127, -2, -11, 0, 0,
+ax_anim 1, 2, 128, -3, -10, -1, 1,
+ax_anim 1, 0, 129, -6, -8, -2, 2,
+ax_anim 1, 0, 130, -10, 0, -8, 8,
+ax_anim 1, 0, 131, -18, 13, -18, 18,
+ax_anim 2, 1, 132, -19, 13, -19, 18,
+ax_anim 2, 0, 125, -18, 13, -18, 18,
+ax_anim 2, 0, 126, -19, 13, -19, 18,
+ax_anim 2, 0, 127, -8, -3, -8, 8,
+ax_anim 2, 0, 135, -2, -4, -2, 2,
+ax_anim 2, 0, 135, -1, -5, -1, 1,
+ax_anim 2, 0, 135, 0, -4, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_4_1:
+ax_anim 2, 0, 137, 0, -2, 0, -2,
+ax_anim 8, 0, 137, 0, -3, 0, -3,
+ax_anim 2, 0, 136, 0, -1, 0, 0,
+ax_anim 2, 0, 138, 0, 1, 0, 1,
+ax_anim 2, 2, 139, 0, 1, 0, 1,
+ax_anim 2, 0, 139, -1, 1, 0, 1,
+ax_anim 2, 0, 139, 0, 1, 0, 1,
+ax_anim 2, 0, 139, -1, 1, 0, 1,
+ax_anim 2, 1, 138, 0, 1, 0, 1,
+ax_anim_terminator
+sWartortleAnims_4_2:
+ax_anim 2, 0, 141, -2, -2, -2, -2,
+ax_anim 8, 0, 141, -3, -3, -3, -3,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, 1, 1, 1,
+ax_anim 2, 2, 143, 1, 1, 1, 1,
+ax_anim 2, 0, 143, 2, 0, 2, 0,
+ax_anim 2, 0, 143, 1, 1, 1, 1,
+ax_anim 2, 0, 143, 2, 0, 2, 0,
+ax_anim 2, 1, 142, 1, 1, 1, 1,
+ax_anim_terminator
+sWartortleAnims_4_3:
+ax_anim 2, 0, 145, -2, 0, -2, 0,
+ax_anim 8, 0, 145, -4, 0, -4, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 0, 1, 0,
+ax_anim 2, 2, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 0, 147, 1, 0, 1, 0,
+ax_anim 2, 0, 147, 1, 1, 1, 1,
+ax_anim 2, 1, 146, 1, 0, 1, 0,
+ax_anim_terminator
+sWartortleAnims_4_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 1, -1, 1, -1,
+ax_anim 2, 2, 151, 1, -1, 1, -1,
+ax_anim 2, 0, 151, 0, -2, 0, -2,
+ax_anim 2, 0, 151, 1, -1, 1, -1,
+ax_anim 2, 0, 151, 0, -2, 0, -2,
+ax_anim 2, 1, 150, 0, 0, 1, -1,
+ax_anim_terminator
+sWartortleAnims_4_5:
+ax_anim 2, 0, 153, 0, 2, 0, 2,
+ax_anim 8, 0, 153, 0, 3, 0, 3,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -1, 0, -1,
+ax_anim 2, 2, 155, 0, -1, 0, -1,
+ax_anim 2, 0, 155, -1, -1, 0, -1,
+ax_anim 2, 0, 155, 0, -1, 0, -1,
+ax_anim 2, 0, 155, -1, -1, 0, -1,
+ax_anim 2, 1, 154, 0, -1, 0, -1,
+ax_anim_terminator
+sWartortleAnims_4_6:
+ax_anim 2, 0, 157, 2, 2, 2, 2,
+ax_anim 8, 0, 157, 3, 3, 3, 3,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 158, -1, -1, -1, -1,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 2, 159, 0, -2, 0, -2,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, -2, 0, -2,
+ax_anim 2, 0, 158, 0, 0, -1, -1,
+ax_anim_terminator
+sWartortleAnims_4_7:
+ax_anim 2, 0, 161, 2, 0, 2, 0,
+ax_anim 8, 0, 161, 4, 0, 4, 0,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 162, -1, 0, -1, 0,
+ax_anim 2, 2, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, -1, 1, -1, 1,
+ax_anim 2, 0, 163, -1, 0, -1, 0,
+ax_anim 2, 0, 163, -1, 1, -1, 1,
+ax_anim 2, 1, 162, -1, 0, -1, 0,
+ax_anim_terminator
+sWartortleAnims_4_8:
+ax_anim 2, 0, 165, 2, -2, 2, -2,
+ax_anim 8, 0, 165, 3, -3, 3, -3,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 166, -1, 1, -1, 1,
+ax_anim 2, 2, 167, -1, 1, -1, 1,
+ax_anim 2, 0, 167, -2, 0, -2, 0,
+ax_anim 2, 0, 167, -1, 1, -1, 1,
+ax_anim 2, 0, 167, -2, 0, -2, 0,
+ax_anim 2, 1, 166, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sWartortleAnims_5_1:
+ax_anim 20, 0, 168, 0, 0, 1, 0,
+ax_anim 2, 2, 168, 1, 0, 2, 0,
+ax_anim 2, 0, 168, 0, 0, 1, 0,
+ax_anim 1, 0, 168, 1, 0, 2, 0,
+ax_anim 1, 0, 168, 0, 0, 1, 0,
+ax_anim 2, 0, 168, 1, 0, 2, 0,
+ax_anim 2, 0, 168, 0, 0, 1, 0,
+ax_anim_terminator
+sWartortleAnims_5_2:
+ax_anim 20, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 1, 0, 1, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 175, 1, 0, 1, 0,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 1, 0, 1, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_5_3:
+ax_anim 20, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 1, 0, 1, 0,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_5_4:
+ax_anim 20, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 1, 0, 1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 173, 1, 0, 1, 0,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, 0, 1, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_5_5:
+ax_anim 20, 0, 172, 0, 0, 1, 0,
+ax_anim 2, 2, 172, 1, 0, 2, 0,
+ax_anim 2, 0, 172, 0, 0, 1, 0,
+ax_anim 1, 0, 172, 1, 0, 2, 0,
+ax_anim 1, 0, 172, 0, 0, 1, 0,
+ax_anim 2, 0, 172, 1, 0, 2, 0,
+ax_anim 2, 0, 172, 0, 0, 1, 0,
+ax_anim_terminator
+sWartortleAnims_5_6:
+ax_anim 20, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 1, 0, 1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 1, 0, 1, 0,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 1, 0, 1, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_5_7:
+ax_anim 20, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 1, 0, 1, 0,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_5_8:
+ax_anim 20, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 2, 169, 1, 0, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 1, 0, 1, 0,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, 0, 1, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_6_1:
+ax_anim 30, 0, 176, 0, 0, 0, 0,
+ax_anim 35, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_7_1:
+ax_anim 2, 0, 178, 0, -2, 0, -2,
+ax_anim 8, 0, 178, 0, -3, 0, -3,
+ax_anim_terminator
+sWartortleAnims_7_2:
+ax_anim 2, 0, 179, -2, -2, -2, -2,
+ax_anim 8, 0, 179, -3, -3, -3, -3,
+ax_anim_terminator
+sWartortleAnims_7_3:
+ax_anim 2, 0, 180, -2, 0, -2, 0,
+ax_anim 8, 0, 180, -3, 0, -3, 0,
+ax_anim_terminator
+sWartortleAnims_7_4:
+ax_anim 2, 0, 181, -2, 2, -2, 2,
+ax_anim 8, 0, 181, -3, 3, -3, 3,
+ax_anim_terminator
+sWartortleAnims_7_5:
+ax_anim 2, 0, 182, 0, 2, 0, 2,
+ax_anim 8, 0, 182, 0, 3, 0, 3,
+ax_anim_terminator
+sWartortleAnims_7_6:
+ax_anim 2, 0, 183, 2, 2, 2, 2,
+ax_anim 8, 0, 183, 3, 3, 3, 3,
+ax_anim_terminator
+sWartortleAnims_7_7:
+ax_anim 2, 0, 184, 2, 0, 2, 0,
+ax_anim 8, 0, 184, 3, 0, 3, 0,
+ax_anim_terminator
+sWartortleAnims_7_8:
+ax_anim 2, 0, 185, 2, -2, 2, -2,
+ax_anim 8, 0, 185, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWartortleAnims_8_1:
+ax_anim 40, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, 0,
+ax_anim 2, 0, 186, 0, -2, 0, 0,
+ax_anim 2, 0, 186, 0, -1, 0, 0,
+ax_anim_terminator
+sWartortleAnims_8_2:
+ax_anim 40, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, 0,
+ax_anim 2, 0, 193, 0, -2, 0, 0,
+ax_anim 2, 0, 193, 0, -1, 0, 0,
+ax_anim_terminator
+sWartortleAnims_8_3:
+ax_anim 40, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, 0,
+ax_anim 2, 0, 192, 0, -2, 0, 0,
+ax_anim 2, 0, 192, 0, -1, 0, 0,
+ax_anim_terminator
+sWartortleAnims_8_4:
+ax_anim 40, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, 0,
+ax_anim 2, 0, 191, 0, -2, 0, 0,
+ax_anim 2, 0, 191, 0, -1, 0, 0,
+ax_anim_terminator
+sWartortleAnims_8_5:
+ax_anim 40, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, -1, 0, 0,
+ax_anim 2, 0, 190, 0, -2, 0, 0,
+ax_anim 2, 0, 190, 0, -1, 0, 0,
+ax_anim_terminator
+sWartortleAnims_8_6:
+ax_anim 40, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, 0,
+ax_anim 2, 0, 189, 0, -2, 0, 0,
+ax_anim 2, 0, 189, 0, -1, 0, 0,
+ax_anim_terminator
+sWartortleAnims_8_7:
+ax_anim 40, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, 0,
+ax_anim 2, 0, 188, 0, -2, 0, 0,
+ax_anim 2, 0, 188, 0, -1, 0, 0,
+ax_anim_terminator
+sWartortleAnims_8_8:
+ax_anim 40, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 0, -1, 0, 0,
+ax_anim 2, 0, 187, 0, -2, 0, 0,
+ax_anim 2, 0, 187, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_9_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 6, 4, 6, 4,
+ax_anim 2, 0, 196, 8, 9, 8, 9,
+ax_anim 2, 0, 197, 7, 18, 7, 18,
+ax_anim 3, 0, 198, 1, 24, 1, 24,
+ax_anim 2, 3, 199, -4, 18, -4, 18,
+ax_anim 2, 0, 200, -5, 8, -5, 8,
+ax_anim 1, 0, 201, -4, 4, -4, 4,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_9_2:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 6, 0, 6, 0,
+ax_anim 2, 0, 195, 17, 3, 17, 3,
+ax_anim 2, 0, 196, 24, 9, 24, 9,
+ax_anim 3, 0, 197, 23, 16, 23, 16,
+ax_anim 2, 3, 198, 11, 16, 11, 16,
+ax_anim 2, 0, 199, 4, 12, 4, 12,
+ax_anim 1, 0, 200, 3, 7, 3, 7,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_9_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 3, -4, 3, -4,
+ax_anim 2, 0, 194, 11, -6, 11, -6,
+ax_anim 2, 0, 195, 19, -4, 19, -4,
+ax_anim 3, 0, 196, 21, 1, 21, 1,
+ax_anim 2, 3, 197, 19, 5, 19, 5,
+ax_anim 2, 0, 198, 12, 7, 12, 7,
+ax_anim 1, 0, 199, 4, 5, 4, 5,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_9_4:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 1, -6, 1, -6,
+ax_anim 2, 0, 201, 4, -16, 4, -16,
+ax_anim 2, 0, 194, 11, -20, 11, -20,
+ax_anim 3, 0, 195, 16, -20, 16, -20,
+ax_anim 2, 3, 196, 16, -15, 16, -15,
+ax_anim 2, 0, 197, 14, -6, 14, -6,
+ax_anim 1, 0, 198, 7, -1, 7, -1,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_9_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, -6, -4, -6, -4,
+ax_anim 2, 0, 200, -8, -9, -8, -9,
+ax_anim 2, 0, 201, -7, -16, -7, -13,
+ax_anim 3, 0, 194, -1, -18, -1, -16,
+ax_anim 2, 3, 195, 4, -17, 4, -14,
+ax_anim 2, 0, 196, 5, -8, 5, -8,
+ax_anim 1, 0, 197, 4, -4, 4, -4,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_9_6:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, -1, -6, -1, -6,
+ax_anim 2, 0, 195, -4, -16, -4, -16,
+ax_anim 2, 0, 194, -11, -20, -11, -20,
+ax_anim 3, 0, 201, -16, -20, -16, -20,
+ax_anim 2, 3, 200, -16, -15, -16, -15,
+ax_anim 2, 0, 199, -14, -6, -14, -6,
+ax_anim 1, 0, 198, -7, -1, -7, -1,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_9_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -3, -4, -3, -4,
+ax_anim 2, 0, 194, -11, -6, -11, -6,
+ax_anim 2, 0, 201, -20, -4, -20, -4,
+ax_anim 3, 0, 200, -21, 1, -21, 1,
+ax_anim 2, 3, 199, -20, 5, -20, 5,
+ax_anim 2, 0, 198, -12, 7, -12, 7,
+ax_anim 1, 0, 197, -4, 5, -4, 5,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_9_8:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -6, 0, -6, 0,
+ax_anim 2, 0, 201, -17, 3, -17, 3,
+ax_anim 2, 0, 200, -24, 9, -24, 9,
+ax_anim 3, 0, 199, -23, 16, -23, 16,
+ax_anim 2, 3, 198, -11, 16, -11, 16,
+ax_anim 2, 0, 197, -4, 12, -4, 12,
+ax_anim 1, 0, 196, -3, 7, -3, 7,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_10_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 3, 0, 202, 13, 0, 13, 0,
+ax_anim 3, 0, 202, -13, 0, -13, 0,
+ax_anim 2, 0, 202, 12, 0, 12, 0,
+ax_anim 3, 0, 202, -12, 0, -12, 0,
+ax_anim 2, 0, 202, 10, 0, 10, 0,
+ax_anim 2, 0, 202, -10, 0, -10, 0,
+ax_anim 2, 0, 202, 6, 0, 6, 0,
+ax_anim 2, 0, 202, -6, 0, -6, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_10_2:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 3, 0, 203, 13, -13, 13, -13,
+ax_anim 3, 0, 203, -13, 13, -13, 13,
+ax_anim 2, 0, 203, 12, -12, 12, -12,
+ax_anim 3, 0, 203, -12, 12, -12, 12,
+ax_anim 2, 0, 203, 10, -10, 10, -10,
+ax_anim 2, 0, 203, -10, 10, -10, 10,
+ax_anim 2, 0, 203, 6, -6, 6, -6,
+ax_anim 2, 0, 203, -6, 6, -6, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_10_3:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 3, 0, 204, 0, -13, 0, -13,
+ax_anim 3, 0, 204, 0, 13, 0, 13,
+ax_anim 2, 0, 204, 0, -12, 0, -12,
+ax_anim 3, 0, 204, 0, 12, 0, 12,
+ax_anim 2, 0, 204, 0, -10, 0, -10,
+ax_anim 2, 0, 204, 0, 10, 0, 10,
+ax_anim 2, 0, 204, 0, -6, 0, -6,
+ax_anim 2, 0, 204, 0, 6, 0, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_10_4:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 3, 0, 205, -13, -13, -13, -13,
+ax_anim 3, 0, 205, 13, 13, 13, 13,
+ax_anim 2, 0, 205, -12, -12, -12, -12,
+ax_anim 3, 0, 205, 12, 12, 12, 12,
+ax_anim 2, 0, 205, -10, -10, -10, -10,
+ax_anim 2, 0, 205, 10, 10, 10, 10,
+ax_anim 2, 0, 205, -6, -6, -6, -6,
+ax_anim 2, 0, 205, 6, 6, 6, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_10_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 3, 0, 206, 13, 0, 13, 0,
+ax_anim 3, 0, 206, -13, 0, -13, 0,
+ax_anim 2, 0, 206, 12, 0, 12, 0,
+ax_anim 3, 0, 206, -12, 0, -12, 0,
+ax_anim 2, 0, 206, 10, 0, 10, 0,
+ax_anim 2, 0, 206, -10, 0, -10, 0,
+ax_anim 2, 0, 206, 6, 0, 6, 0,
+ax_anim 2, 0, 206, -6, 0, -6, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_10_6:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 3, 0, 207, 13, -13, 13, -13,
+ax_anim 3, 0, 207, -13, 13, -13, 13,
+ax_anim 2, 0, 207, 12, -12, 12, -12,
+ax_anim 3, 0, 207, -12, 12, -12, 12,
+ax_anim 2, 0, 207, 10, -10, 10, -10,
+ax_anim 2, 0, 207, -10, 10, -10, 10,
+ax_anim 2, 0, 207, 6, -6, 6, -6,
+ax_anim 2, 0, 207, -6, 6, -6, 6,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_10_7:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 3, 0, 208, 0, -13, 0, -13,
+ax_anim 3, 0, 208, 0, 13, 0, 13,
+ax_anim 2, 0, 208, 0, -12, 0, -12,
+ax_anim 3, 0, 208, 0, 12, 0, 12,
+ax_anim 2, 0, 208, 0, -10, 0, -10,
+ax_anim 2, 0, 208, 0, 10, 0, 10,
+ax_anim 2, 0, 208, 0, -6, 0, -6,
+ax_anim 2, 0, 208, 0, 6, 0, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_10_8:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 3, 0, 209, -13, -13, -13, -13,
+ax_anim 3, 0, 209, 13, 13, 13, 13,
+ax_anim 2, 0, 209, -12, -12, -12, -12,
+ax_anim 3, 0, 209, 12, 12, 12, 12,
+ax_anim 2, 0, 209, -10, -10, -10, -10,
+ax_anim 2, 0, 209, 10, 10, 10, 10,
+ax_anim 2, 0, 209, -6, -6, -6, -6,
+ax_anim 2, 0, 209, 6, 6, 6, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_11_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 211, 0, -16, 0, 0,
+ax_anim 3, 0, 211, 0, -20, 0, 0,
+ax_anim 4, 0, 211, 0, -21, 0, 0,
+ax_anim 4, 0, 212, 0, -23, 0, 0,
+ax_anim 3, 0, 212, 0, -22, 0, 0,
+ax_anim 2, 0, 212, 0, -18, 0, 0,
+ax_anim 1, 0, 212, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_11_2:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 214, 0, -16, 0, 0,
+ax_anim 3, 0, 214, 0, -20, 0, 0,
+ax_anim 4, 0, 214, 0, -21, 0, 0,
+ax_anim 4, 0, 215, 0, -23, 0, 0,
+ax_anim 3, 0, 215, 0, -22, 0, 0,
+ax_anim 2, 0, 215, 0, -18, 0, 0,
+ax_anim 1, 0, 215, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_11_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 217, 0, -16, 0, 0,
+ax_anim 3, 0, 217, 0, -20, 0, 0,
+ax_anim 4, 0, 217, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 218, 0, -22, 0, 0,
+ax_anim 2, 0, 218, 0, -18, 0, 0,
+ax_anim 1, 0, 218, 0, -12, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_11_4:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 219, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -22, 0, 0,
+ax_anim 3, 0, 221, 0, -21, 0, 0,
+ax_anim 2, 0, 221, 0, -17, 0, 0,
+ax_anim 1, 0, 221, 0, -11, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_11_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 1, 0, 222, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 224, 0, -22, 0, 0,
+ax_anim 2, 0, 224, 0, -18, 0, 0,
+ax_anim 1, 0, 224, 0, -12, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_11_6:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 227, 0, -21, 0, 0,
+ax_anim 2, 0, 227, 0, -17, 0, 0,
+ax_anim 1, 0, 227, 0, -11, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_11_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 1, 0, 228, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 230, 0, -22, 0, 0,
+ax_anim 2, 0, 230, 0, -18, 0, 0,
+ax_anim 1, 0, 230, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_11_8:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 1, 0, 231, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -23, 0, 0,
+ax_anim 3, 0, 233, 0, -22, 0, 0,
+ax_anim 2, 0, 233, 0, -18, 0, 0,
+ax_anim 1, 0, 233, 0, -12, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_12_1:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_12_2:
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 1, -1, 1, 0,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_12_3:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_12_4:
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, -1, -1, -1, -1,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_12_5:
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, 0, 1, 0,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_12_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_12_7:
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 0, -1, 0, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_12_8:
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, -1, -1, -1, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWartortleAnims_13_1:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_13_2:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_13_3:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_13_4:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_13_5:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_13_6:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_13_7:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleAnims_13_8:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sWartortleGfx1:
+.incbin "baserom.gba", 0x56F0B4, 0x200
+sWartortleSprites1:
+ax_sprite sWartortleGfx1, 0x200
+ax_sprite_terminator
+sWartortleGfx2:
+.incbin "baserom.gba", 0x56F2C4, 0x200
+sWartortleSprites2:
+ax_sprite sWartortleGfx2, 0x200
+ax_sprite_terminator
+sWartortleGfx3:
+.incbin "baserom.gba", 0x56F4D4, 0x200
+sWartortleSprites3:
+ax_sprite sWartortleGfx3, 0x200
+ax_sprite_terminator
+sWartortleGfx4:
+.incbin "baserom.gba", 0x56F6E4, 0x200
+sWartortleSprites4:
+ax_sprite sWartortleGfx4, 0x200
+ax_sprite_terminator
+sWartortleGfx5:
+.incbin "baserom.gba", 0x56F8F4, 0x200
+sWartortleSprites5:
+ax_sprite sWartortleGfx5, 0x200
+ax_sprite_terminator
+sWartortleGfx6:
+.incbin "baserom.gba", 0x56FB04, 0x200
+sWartortleSprites6:
+ax_sprite sWartortleGfx6, 0x200
+ax_sprite_terminator
+sWartortleGfx7:
+.incbin "baserom.gba", 0x56FD14, 0x200
+sWartortleSprites7:
+ax_sprite sWartortleGfx7, 0x200
+ax_sprite_terminator
+sWartortleGfx8:
+.incbin "baserom.gba", 0x56FF24, 0x200
+sWartortleSprites8:
+ax_sprite sWartortleGfx8, 0x200
+ax_sprite_terminator
+sWartortleGfx9:
+.incbin "baserom.gba", 0x570134, 0x200
+sWartortleSprites9:
+ax_sprite sWartortleGfx9, 0x200
+ax_sprite_terminator
+sWartortleGfx10:
+.incbin "baserom.gba", 0x570344, 0x200
+sWartortleSprites10:
+ax_sprite sWartortleGfx10, 0x200
+ax_sprite_terminator
+sWartortleGfx11:
+.incbin "baserom.gba", 0x570554, 0x200
+sWartortleSprites11:
+ax_sprite sWartortleGfx11, 0x200
+ax_sprite_terminator
+sWartortleGfx12:
+.incbin "baserom.gba", 0x570764, 0x200
+sWartortleSprites12:
+ax_sprite sWartortleGfx12, 0x200
+ax_sprite_terminator
+sWartortleGfx13:
+.incbin "baserom.gba", 0x570974, 0x200
+sWartortleSprites13:
+ax_sprite sWartortleGfx13, 0x200
+ax_sprite_terminator
+sWartortleGfx14:
+.incbin "baserom.gba", 0x570B84, 0x200
+sWartortleSprites14:
+ax_sprite sWartortleGfx14, 0x200
+ax_sprite_terminator
+sWartortleGfx15:
+.incbin "baserom.gba", 0x570D94, 0x200
+sWartortleSprites15:
+ax_sprite sWartortleGfx15, 0x200
+ax_sprite_terminator
+sWartortleGfx16:
+.incbin "baserom.gba", 0x570FA4, 0x200
+sWartortleSprites16:
+ax_sprite sWartortleGfx16, 0x200
+ax_sprite_terminator
+sWartortleGfx17:
+.incbin "baserom.gba", 0x5711B4, 0x200
+sWartortleSprites17:
+ax_sprite sWartortleGfx17, 0x200
+ax_sprite_terminator
+sWartortleGfx18:
+.incbin "baserom.gba", 0x5713C4, 0x200
+sWartortleSprites18:
+ax_sprite sWartortleGfx18, 0x200
+ax_sprite_terminator
+sWartortleGfx19:
+.incbin "baserom.gba", 0x5715D4, 0x200
+sWartortleSprites19:
+ax_sprite sWartortleGfx19, 0x200
+ax_sprite_terminator
+sWartortleGfx20:
+.incbin "baserom.gba", 0x5717E4, 0x200
+sWartortleSprites20:
+ax_sprite sWartortleGfx20, 0x200
+ax_sprite_terminator
+sWartortleGfx21:
+.incbin "baserom.gba", 0x5719F4, 0x200
+sWartortleSprites21:
+ax_sprite sWartortleGfx21, 0x200
+ax_sprite_terminator
+sWartortleGfx22:
+.incbin "baserom.gba", 0x571C04, 0x200
+sWartortleSprites22:
+ax_sprite sWartortleGfx22, 0x200
+ax_sprite_terminator
+sWartortleGfx23:
+.incbin "baserom.gba", 0x571E14, 0x200
+sWartortleSprites23:
+ax_sprite sWartortleGfx23, 0x200
+ax_sprite_terminator
+sWartortleGfx24:
+.incbin "baserom.gba", 0x572024, 0x200
+sWartortleSprites24:
+ax_sprite sWartortleGfx24, 0x200
+ax_sprite_terminator
+sWartortleGfx25:
+.incbin "baserom.gba", 0x572234, 0x60
+sWartortleGfx25_1:
+.incbin "baserom.gba", 0x572294, 0x60
+sWartortleSprites25:
+ax_sprite sWartortleGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx26:
+.incbin "baserom.gba", 0x57231C, 0x60
+sWartortleGfx26_1:
+.incbin "baserom.gba", 0x57237C, 0x60
+sWartortleSprites26:
+ax_sprite sWartortleGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx27:
+.incbin "baserom.gba", 0x572404, 0x60
+sWartortleGfx27_1:
+.incbin "baserom.gba", 0x572464, 0x60
+sWartortleSprites27:
+ax_sprite sWartortleGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx28:
+.incbin "baserom.gba", 0x5724EC, 0x60
+sWartortleGfx28_1:
+.incbin "baserom.gba", 0x57254C, 0x60
+sWartortleSprites28:
+ax_sprite sWartortleGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx29:
+.incbin "baserom.gba", 0x5725D4, 0x60
+sWartortleGfx29_1:
+.incbin "baserom.gba", 0x572634, 0x60
+sWartortleSprites29:
+ax_sprite sWartortleGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx30:
+.incbin "baserom.gba", 0x5726BC, 0x60
+sWartortleGfx30_1:
+.incbin "baserom.gba", 0x57271C, 0x60
+sWartortleGfx30_2:
+.incbin "baserom.gba", 0x57277C, 0x60
+sWartortleSprites30:
+ax_sprite sWartortleGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWartortleGfx31:
+.incbin "baserom.gba", 0x572814, 0x60
+sWartortleGfx31_1:
+.incbin "baserom.gba", 0x572874, 0x60
+sWartortleGfx31_2:
+.incbin "baserom.gba", 0x5728D4, 0x60
+sWartortleSprites31:
+ax_sprite sWartortleGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWartortleGfx32:
+.incbin "baserom.gba", 0x57296C, 0x40
+sWartortleGfx32_1:
+.incbin "baserom.gba", 0x5729AC, 0x100
+sWartortleSprites32:
+ax_sprite sWartortleGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWartortleGfx32_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWartortleGfx33:
+.incbin "baserom.gba", 0x572AD4, 0x40
+sWartortleGfx33_1:
+.incbin "baserom.gba", 0x572B14, 0x100
+sWartortleGfx33_2:
+.incbin "baserom.gba", 0x572C14, 0x40
+sWartortleSprites33:
+ax_sprite sWartortleGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWartortleGfx33_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx33_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx34:
+.incbin "baserom.gba", 0x572C8C, 0x60
+sWartortleGfx34_1:
+.incbin "baserom.gba", 0x572CEC, 0x60
+sWartortleGfx34_2:
+.incbin "baserom.gba", 0x572D4C, 0x60
+sWartortleGfx34_3:
+.incbin "baserom.gba", 0x572DAC, 0x60
+sWartortleSprites34:
+ax_sprite sWartortleGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx35:
+.incbin "baserom.gba", 0x572E54, 0x60
+sWartortleGfx35_1:
+.incbin "baserom.gba", 0x572EB4, 0x60
+sWartortleGfx35_2:
+.incbin "baserom.gba", 0x572F14, 0x60
+sWartortleSprites35:
+ax_sprite sWartortleGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx35_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWartortleGfx36:
+.incbin "baserom.gba", 0x572FAC, 0x60
+sWartortleGfx36_1:
+.incbin "baserom.gba", 0x57300C, 0x60
+sWartortleGfx36_2:
+.incbin "baserom.gba", 0x57306C, 0x60
+sWartortleSprites36:
+ax_sprite sWartortleGfx36, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWartortleGfx37:
+.incbin "baserom.gba", 0x573104, 0x40
+sWartortleGfx37_1:
+.incbin "baserom.gba", 0x573144, 0x100
+sWartortleSprites37:
+ax_sprite sWartortleGfx37, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWartortleGfx37_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWartortleGfx38:
+.incbin "baserom.gba", 0x57326C, 0x60
+sWartortleGfx38_1:
+.incbin "baserom.gba", 0x5732CC, 0x100
+sWartortleGfx38_2:
+.incbin "baserom.gba", 0x5733CC, 0x40
+sWartortleSprites38:
+ax_sprite sWartortleGfx38, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx38_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx38_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx39:
+.incbin "baserom.gba", 0x573444, 0x60
+sWartortleGfx39_1:
+.incbin "baserom.gba", 0x5734A4, 0x60
+sWartortleGfx39_2:
+.incbin "baserom.gba", 0x573504, 0x60
+sWartortleGfx39_3:
+.incbin "baserom.gba", 0x573564, 0x60
+sWartortleSprites39:
+ax_sprite sWartortleGfx39, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx39_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx39_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWartortleGfx39_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWartortleGfx40:
+.incbin "baserom.gba", 0x57360C, 0x200
+sWartortleSprites40:
+ax_sprite sWartortleGfx40, 0x200
+ax_sprite_terminator
+sWartortleGfx41:
+.incbin "baserom.gba", 0x57381C, 0x200
+sWartortleSprites41:
+ax_sprite sWartortleGfx41, 0x200
+ax_sprite_terminator
+sWartortleGfx42:
+.incbin "baserom.gba", 0x573A2C, 0x200
+sWartortleSprites42:
+ax_sprite sWartortleGfx42, 0x200
+ax_sprite_terminator
+sWartortleGfx43:
+.incbin "baserom.gba", 0x573C3C, 0x200
+sWartortleSprites43:
+ax_sprite sWartortleGfx43, 0x200
+ax_sprite_terminator
+sWartortleGfx44:
+.incbin "baserom.gba", 0x573E4C, 0x200
+sWartortleSprites44:
+ax_sprite sWartortleGfx44, 0x200
+ax_sprite_terminator
+sWartortleGfx45:
+.incbin "baserom.gba", 0x57405C, 0x200
+sWartortleSprites45:
+ax_sprite sWartortleGfx45, 0x200
+ax_sprite_terminator
+sWartortleGfx46:
+.incbin "baserom.gba", 0x57426C, 0x200
+sWartortleSprites46:
+ax_sprite sWartortleGfx46, 0x200
+ax_sprite_terminator
+sAxPosesWartortle:
+.4byte sWartortlePose1
+.4byte sWartortlePose2
+.4byte sWartortlePose3
+.4byte sWartortlePose4
+.4byte sWartortlePose5
+.4byte sWartortlePose6
+.4byte sWartortlePose7
+.4byte sWartortlePose8
+.4byte sWartortlePose9
+.4byte sWartortlePose10
+.4byte sWartortlePose11
+.4byte sWartortlePose12
+.4byte sWartortlePose13
+.4byte sWartortlePose14
+.4byte sWartortlePose15
+.4byte sWartortlePose16
+.4byte sWartortlePose17
+.4byte sWartortlePose18
+.4byte sWartortlePose19
+.4byte sWartortlePose20
+.4byte sWartortlePose21
+.4byte sWartortlePose22
+.4byte sWartortlePose23
+.4byte sWartortlePose24
+.4byte sWartortlePose25
+.4byte sWartortlePose26
+.4byte sWartortlePose27
+.4byte sWartortlePose28
+.4byte sWartortlePose29
+.4byte sWartortlePose30
+.4byte sWartortlePose31
+.4byte sWartortlePose32
+.4byte sWartortlePose33
+.4byte sWartortlePose34
+.4byte sWartortlePose35
+.4byte sWartortlePose36
+.4byte sWartortlePose37
+.4byte sWartortlePose38
+.4byte sWartortlePose39
+.4byte sWartortlePose40
+.4byte sWartortlePose41
+.4byte sWartortlePose42
+.4byte sWartortlePose43
+.4byte sWartortlePose44
+.4byte sWartortlePose45
+.4byte sWartortlePose46
+.4byte sWartortlePose47
+.4byte sWartortlePose48
+.4byte sWartortlePose49
+.4byte sWartortlePose50
+.4byte sWartortlePose51
+.4byte sWartortlePose52
+.4byte sWartortlePose53
+.4byte sWartortlePose54
+.4byte sWartortlePose55
+.4byte sWartortlePose56
+.4byte sWartortlePose57
+.4byte sWartortlePose58
+.4byte sWartortlePose59
+.4byte sWartortlePose60
+.4byte sWartortlePose61
+.4byte sWartortlePose62
+.4byte sWartortlePose63
+.4byte sWartortlePose64
+.4byte sWartortlePose65
+.4byte sWartortlePose66
+.4byte sWartortlePose67
+.4byte sWartortlePose68
+.4byte sWartortlePose69
+.4byte sWartortlePose70
+.4byte sWartortlePose71
+.4byte sWartortlePose72
+.4byte sWartortlePose73
+.4byte sWartortlePose74
+.4byte sWartortlePose75
+.4byte sWartortlePose76
+.4byte sWartortlePose77
+.4byte sWartortlePose78
+.4byte sWartortlePose79
+.4byte sWartortlePose80
+.4byte sWartortlePose81
+.4byte sWartortlePose82
+.4byte sWartortlePose83
+.4byte sWartortlePose84
+.4byte sWartortlePose85
+.4byte sWartortlePose86
+.4byte sWartortlePose87
+.4byte sWartortlePose88
+.4byte sWartortlePose89
+.4byte sWartortlePose90
+.4byte sWartortlePose91
+.4byte sWartortlePose92
+.4byte sWartortlePose93
+.4byte sWartortlePose94
+.4byte sWartortlePose95
+.4byte sWartortlePose96
+.4byte sWartortlePose97
+.4byte sWartortlePose98
+.4byte sWartortlePose99
+.4byte sWartortlePose100
+.4byte sWartortlePose101
+.4byte sWartortlePose102
+.4byte sWartortlePose103
+.4byte sWartortlePose104
+.4byte sWartortlePose105
+.4byte sWartortlePose106
+.4byte sWartortlePose107
+.4byte sWartortlePose108
+.4byte sWartortlePose109
+.4byte sWartortlePose110
+.4byte sWartortlePose111
+.4byte sWartortlePose112
+.4byte sWartortlePose113
+.4byte sWartortlePose114
+.4byte sWartortlePose115
+.4byte sWartortlePose116
+.4byte sWartortlePose117
+.4byte sWartortlePose118
+.4byte sWartortlePose119
+.4byte sWartortlePose120
+.4byte sWartortlePose121
+.4byte sWartortlePose122
+.4byte sWartortlePose123
+.4byte sWartortlePose124
+.4byte sWartortlePose125
+.4byte sWartortlePose126
+.4byte sWartortlePose127
+.4byte sWartortlePose128
+.4byte sWartortlePose129
+.4byte sWartortlePose130
+.4byte sWartortlePose131
+.4byte sWartortlePose132
+.4byte sWartortlePose133
+.4byte sWartortlePose134
+.4byte sWartortlePose135
+.4byte sWartortlePose136
+.4byte sWartortlePose137
+.4byte sWartortlePose138
+.4byte sWartortlePose139
+.4byte sWartortlePose140
+.4byte sWartortlePose141
+.4byte sWartortlePose142
+.4byte sWartortlePose143
+.4byte sWartortlePose144
+.4byte sWartortlePose145
+.4byte sWartortlePose146
+.4byte sWartortlePose147
+.4byte sWartortlePose148
+.4byte sWartortlePose149
+.4byte sWartortlePose150
+.4byte sWartortlePose151
+.4byte sWartortlePose152
+.4byte sWartortlePose153
+.4byte sWartortlePose154
+.4byte sWartortlePose155
+.4byte sWartortlePose156
+.4byte sWartortlePose157
+.4byte sWartortlePose158
+.4byte sWartortlePose159
+.4byte sWartortlePose160
+.4byte sWartortlePose161
+.4byte sWartortlePose162
+.4byte sWartortlePose163
+.4byte sWartortlePose164
+.4byte sWartortlePose165
+.4byte sWartortlePose166
+.4byte sWartortlePose167
+.4byte sWartortlePose168
+.4byte sWartortlePose169
+.4byte sWartortlePose170
+.4byte sWartortlePose171
+.4byte sWartortlePose172
+.4byte sWartortlePose173
+.4byte sWartortlePose174
+.4byte sWartortlePose175
+.4byte sWartortlePose176
+.4byte sWartortlePose177
+.4byte sWartortlePose178
+.4byte sWartortlePose179
+.4byte sWartortlePose180
+.4byte sWartortlePose181
+.4byte sWartortlePose182
+.4byte sWartortlePose183
+.4byte sWartortlePose184
+.4byte sWartortlePose185
+.4byte sWartortlePose186
+.4byte sWartortlePose187
+.4byte sWartortlePose188
+.4byte sWartortlePose189
+.4byte sWartortlePose190
+.4byte sWartortlePose191
+.4byte sWartortlePose192
+.4byte sWartortlePose193
+.4byte sWartortlePose194
+.4byte sWartortlePose195
+.4byte sWartortlePose196
+.4byte sWartortlePose197
+.4byte sWartortlePose198
+.4byte sWartortlePose199
+.4byte sWartortlePose200
+.4byte sWartortlePose201
+.4byte sWartortlePose202
+.4byte sWartortlePose203
+.4byte sWartortlePose204
+.4byte sWartortlePose205
+.4byte sWartortlePose206
+.4byte sWartortlePose207
+.4byte sWartortlePose208
+.4byte sWartortlePose209
+.4byte sWartortlePose210
+.4byte sWartortlePose211
+.4byte sWartortlePose212
+.4byte sWartortlePose213
+.4byte sWartortlePose214
+.4byte sWartortlePose215
+.4byte sWartortlePose216
+.4byte sWartortlePose217
+.4byte sWartortlePose218
+.4byte sWartortlePose219
+.4byte sWartortlePose220
+.4byte sWartortlePose221
+.4byte sWartortlePose222
+.4byte sWartortlePose223
+.4byte sWartortlePose224
+.4byte sWartortlePose225
+.4byte sWartortlePose226
+.4byte sWartortlePose227
+.4byte sWartortlePose228
+.4byte sWartortlePose229
+.4byte sWartortlePose230
+.4byte sWartortlePose231
+.4byte sWartortlePose232
+.4byte sWartortlePose233
+.4byte sWartortlePose234
+.4byte sWartortlePose235
+.4byte sWartortlePose236
+.4byte sWartortlePose237
+.4byte sWartortlePose238
+.4byte sWartortlePose239
+.4byte sWartortlePose240
+.4byte sWartortlePose241
+.4byte sWartortlePose242
+.4byte sWartortlePose243
+.4byte sWartortlePose244
+.4byte sWartortlePose245
+.4byte sWartortlePose246
+.4byte sWartortlePose247
+.4byte sWartortlePose248
+.4byte sWartortlePose249
+.4byte sWartortlePose250
+sAxPositionsWartortle:
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	   0,   -6
+.2byte    0,   -3, 	  -7,   -3, 	   8,   -5, 	   0,   -5
+.2byte   -1,   -3, 	  -9,   -6, 	   6,   -3, 	  -1,   -5
+.2byte    4,   -6, 	  -1,   -4, 	   7,   -6, 	   2,   -7
+.2byte    4,   -5, 	   1,   -2, 	   6,   -5, 	   2,   -6
+.2byte    4,   -5, 	  -2,   -3, 	   8,   -4, 	   2,   -6
+.2byte    8,   -8, 	   5,   -4, 	   6,   -8, 	   1,   -7
+.2byte    8,   -7, 	   7,   -3, 	   4,   -7, 	   1,   -6
+.2byte    8,   -7, 	   4,   -3, 	   8,   -6, 	   1,   -6
+.2byte    5,  -11, 	   8,   -7, 	  -2,  -11, 	   0,   -7
+.2byte    5,  -10, 	   9,   -8, 	  -3,  -10, 	   1,   -6
+.2byte    5,  -10, 	   7,   -6, 	  -2,  -10, 	   0,   -6
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte    0,  -13, 	   6,  -11, 	  -9,   -8, 	   1,   -5
+.2byte    0,  -13, 	   7,   -8, 	  -8,  -11, 	  -1,   -5
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte   -5,  -10, 	   1,  -11, 	  -7,   -5, 	   2,   -6
+.2byte   -5,  -10, 	   4,   -9, 	  -9,   -8, 	  -1,   -6
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -7,   -6, 	  -8,   -6, 	  -4,   -3, 	   1,   -5
+.2byte   -7,   -6, 	  -5,   -6, 	  -7,   -3, 	  -1,   -5
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte   -6,   -5, 	  -9,   -4, 	   1,   -3, 	   0,   -5
+.2byte   -6,   -5, 	  -5,   -6, 	  -2,   -2, 	   1,   -5
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	   0,   -6
+.2byte    0,   -3, 	  -7,   -3, 	   8,   -5, 	   0,   -5
+.2byte   -1,   -3, 	  -9,   -6, 	   6,   -3, 	  -1,   -5
+.2byte    4,   -6, 	  -1,   -4, 	   7,   -6, 	   2,   -7
+.2byte    4,   -5, 	   1,   -2, 	   6,   -5, 	   2,   -6
+.2byte    4,   -5, 	  -2,   -3, 	   8,   -4, 	   2,   -6
+.2byte    8,   -8, 	   5,   -4, 	   6,   -8, 	   1,   -7
+.2byte    8,   -7, 	   7,   -3, 	   4,   -7, 	   1,   -6
+.2byte    8,   -7, 	   4,   -3, 	   8,   -6, 	   1,   -6
+.2byte    5,  -11, 	   8,   -7, 	  -2,  -11, 	   0,   -7
+.2byte    5,  -10, 	   9,   -8, 	  -3,  -10, 	   1,   -6
+.2byte    5,  -10, 	   7,   -6, 	  -2,  -10, 	   0,   -6
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte    0,  -13, 	   6,  -11, 	  -9,   -8, 	   1,   -5
+.2byte    0,  -13, 	   7,   -8, 	  -8,  -11, 	  -1,   -5
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte   -5,  -10, 	   1,  -11, 	  -7,   -5, 	   2,   -6
+.2byte   -5,  -10, 	   4,   -9, 	  -9,   -8, 	  -1,   -6
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -7,   -6, 	  -8,   -6, 	  -4,   -3, 	   1,   -5
+.2byte   -7,   -6, 	  -5,   -6, 	  -7,   -3, 	  -1,   -5
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte   -6,   -5, 	  -9,   -4, 	   1,   -3, 	   0,   -5
+.2byte   -6,   -5, 	  -5,   -6, 	  -2,   -2, 	   1,   -5
+.2byte    0,    0, 	  -6,   -1, 	   6,   -1, 	   0,   -5
+.2byte   -5,   -2, 	  -7,   -5, 	   0,    0, 	   0,   -5
+.2byte   -6,   -4, 	  -6,   -7, 	  -4,   -1, 	   0,   -5
+.2byte   -5,   -8, 	   1,   -9, 	  -7,   -4, 	   0,   -5
+.2byte    0,   -9, 	   5,   -8, 	  -5,   -8, 	   0,   -5
+.2byte    5,   -8, 	  -1,   -9, 	   7,   -4, 	   0,   -5
+.2byte    6,   -4, 	   6,   -7, 	   4,   -1, 	   0,   -5
+.2byte    5,   -2, 	   7,   -5, 	   0,    0, 	   0,   -5
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	   0,   -6
+.2byte    0,   -3, 	  -7,   -3, 	   8,   -5, 	   0,   -5
+.2byte    0,   -1, 	  -9,   -3, 	   8,   -1, 	   0,   -6
+.2byte    5,   -2, 	   7,   -5, 	   0,    0, 	   0,   -5
+.2byte    0,    0, 	  -6,   -1, 	   6,   -1, 	   0,   -5
+.2byte   -5,   -2, 	  -7,   -5, 	   0,    0, 	   0,   -5
+.2byte   -6,   -4, 	  -6,   -7, 	  -4,   -1, 	   0,   -5
+.2byte   -5,   -8, 	   1,   -9, 	  -7,   -4, 	   0,   -5
+.2byte    0,   -9, 	   5,   -8, 	  -5,   -8, 	   0,   -5
+.2byte    5,   -8, 	  -1,   -9, 	   7,   -4, 	   0,   -5
+.2byte    6,   -4, 	   6,   -7, 	   4,   -1, 	   0,   -5
+.2byte    4,   -6, 	  -1,   -4, 	   7,   -6, 	   2,   -7
+.2byte    4,   -5, 	   1,   -2, 	   6,   -5, 	   2,   -6
+.2byte    6,   -2, 	   8,   -4, 	  -2,   -1, 	   1,   -7
+.2byte    5,   -4, 	   5,   -7, 	   3,   -1, 	  -1,   -5
+.2byte    4,   -2, 	   6,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -1,    0, 	  -7,   -1, 	   5,   -1, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -4, 	  -7,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte   -6,   -8, 	   0,   -9, 	  -8,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -8, 	  -6,   -8, 	  -1,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   6,   -4, 	  -1,   -5
+.2byte    7,   -8, 	   4,   -4, 	   5,   -8, 	   0,   -7
+.2byte    7,   -7, 	   6,   -3, 	   3,   -7, 	   0,   -6
+.2byte   10,   -4, 	   8,   -5, 	   6,   -1, 	   2,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   6,   -4, 	  -1,   -5
+.2byte    5,   -4, 	   5,   -7, 	   3,   -1, 	  -1,   -5
+.2byte    4,   -2, 	   6,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -1,    0, 	  -7,   -1, 	   5,   -1, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -4, 	  -7,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte   -6,   -8, 	   0,   -9, 	  -8,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -8, 	  -6,   -8, 	  -1,   -5
+.2byte    4,  -11, 	   7,   -7, 	  -3,  -11, 	  -1,   -7
+.2byte    4,  -10, 	   8,   -8, 	  -4,  -10, 	   0,   -6
+.2byte    4,  -11, 	  -4,   -8, 	   8,   -4, 	  -1,   -7
+.2byte   -1,   -9, 	   4,   -8, 	  -6,   -8, 	  -1,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   6,   -4, 	  -1,   -5
+.2byte    5,   -4, 	   5,   -7, 	   3,   -1, 	  -1,   -5
+.2byte    4,   -2, 	   6,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -1,    0, 	  -7,   -1, 	   5,   -1, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -4, 	  -7,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte   -6,   -8, 	   0,   -9, 	  -8,   -4, 	  -1,   -5
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte    0,  -13, 	   6,  -11, 	  -9,   -8, 	   1,   -5
+.2byte    0,  -16, 	   9,  -10, 	 -10,   -8, 	   0,   -9
+.2byte   -6,   -8, 	   0,   -9, 	  -8,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -8, 	  -6,   -8, 	  -1,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   6,   -4, 	  -1,   -5
+.2byte    5,   -4, 	   5,   -7, 	   3,   -1, 	  -1,   -5
+.2byte    4,   -2, 	   6,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -1,    0, 	  -7,   -1, 	   5,   -1, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -4, 	  -7,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte   -5,  -10, 	   1,  -11, 	  -7,   -5, 	   2,   -6
+.2byte   -5,  -11, 	   3,   -8, 	  -9,   -4, 	   0,   -7
+.2byte   -7,   -4, 	  -7,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte   -6,   -8, 	   0,   -9, 	  -8,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -8, 	  -6,   -8, 	  -1,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   6,   -4, 	  -1,   -5
+.2byte    5,   -4, 	   5,   -7, 	   3,   -1, 	  -1,   -5
+.2byte    4,   -2, 	   6,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -1,    0, 	  -7,   -1, 	   5,   -1, 	  -1,   -5
+.2byte   -6,   -2, 	  -8,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -7,   -6, 	  -8,   -6, 	  -4,   -3, 	   1,   -5
+.2byte  -11,   -4, 	  -9,   -5, 	  -7,   -1, 	  -3,   -5
+.2byte   -6,   -2, 	  -8,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -7,   -4, 	  -7,   -7, 	  -5,   -1, 	  -1,   -5
+.2byte   -6,   -8, 	   0,   -9, 	  -8,   -4, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -8, 	  -6,   -8, 	  -1,   -5
+.2byte    4,   -8, 	  -2,   -9, 	   6,   -4, 	  -1,   -5
+.2byte    5,   -4, 	   5,   -7, 	   3,   -1, 	  -1,   -5
+.2byte    4,   -2, 	   6,   -5, 	  -1,    0, 	  -1,   -5
+.2byte   -1,    0, 	  -7,   -1, 	   5,   -1, 	  -1,   -5
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte   -6,   -5, 	  -9,   -4, 	   1,   -3, 	   0,   -5
+.2byte   -7,   -2, 	  -9,   -4, 	   1,   -1, 	  -2,   -7
+.2byte    0,   -6, 	  -8,   -7, 	   7,   -7, 	   0,   -8
+.2byte    0,   -6, 	  -7,   -6, 	   8,   -8, 	   0,   -8
+.2byte    0,   -4, 	  -9,   -4, 	   8,   -4, 	   0,   -9
+.2byte    0,   -3, 	  -9,   -5, 	   8,   -3, 	   0,   -8
+.2byte    2,   -6, 	  -3,   -4, 	   5,   -6, 	   0,   -7
+.2byte    2,   -6, 	  -1,   -3, 	   4,   -6, 	   0,   -7
+.2byte    5,   -3, 	   8,   -5, 	  -1,   -2, 	   0,   -8
+.2byte    6,   -2, 	   8,   -4, 	  -2,   -1, 	   1,   -7
+.2byte    6,   -8, 	   3,   -4, 	   4,   -8, 	  -1,   -7
+.2byte    6,   -7, 	   5,   -3, 	   2,   -7, 	  -1,   -6
+.2byte   10,   -6, 	  10,   -7, 	   7,   -2, 	   2,   -6
+.2byte   11,   -4, 	   9,   -5, 	   7,   -1, 	   3,   -5
+.2byte    4,  -11, 	   7,   -7, 	  -3,  -11, 	  -1,   -7
+.2byte    4,  -11, 	   6,   -7, 	  -3,  -11, 	  -1,   -7
+.2byte    3,  -12, 	  -4,   -9, 	   8,   -5, 	  -1,   -8
+.2byte    4,  -11, 	  -4,   -8, 	   8,   -4, 	  -1,   -7
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte    0,  -14, 	   6,  -12, 	  -9,   -9, 	   1,   -6
+.2byte    0,  -14, 	   9,   -9, 	 -10,   -9, 	   0,   -9
+.2byte    0,  -16, 	   9,  -10, 	 -10,   -8, 	   0,   -9
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte   -5,  -11, 	   4,  -10, 	  -9,   -9, 	  -1,   -7
+.2byte   -4,  -12, 	   3,   -9, 	  -9,   -5, 	   0,   -8
+.2byte   -5,  -11, 	   3,   -8, 	  -9,   -4, 	   0,   -7
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -7,   -6, 	  -8,   -6, 	  -4,   -3, 	   1,   -5
+.2byte  -10,   -6, 	 -10,   -7, 	  -7,   -2, 	  -2,   -6
+.2byte  -11,   -4, 	  -9,   -5, 	  -7,   -1, 	  -3,   -5
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte   -6,   -6, 	  -9,   -5, 	   1,   -4, 	   0,   -6
+.2byte   -7,   -3, 	 -10,   -5, 	  -1,   -2, 	  -2,   -8
+.2byte   -8,   -2, 	 -10,   -4, 	   0,   -1, 	  -3,   -7
+.2byte    0,   -1, 	  -6,   -2, 	   6,   -2, 	   0,   -6
+.2byte    5,   -3, 	   7,   -6, 	   0,   -1, 	   0,   -6
+.2byte    6,   -5, 	   6,   -8, 	   4,   -2, 	   0,   -6
+.2byte    5,   -9, 	  -1,  -10, 	   7,   -5, 	   0,   -6
+.2byte    0,  -10, 	   5,   -9, 	  -5,   -9, 	   0,   -6
+.2byte   -5,   -9, 	   1,  -10, 	  -7,   -5, 	   0,   -6
+.2byte   -6,   -5, 	  -6,   -8, 	  -4,   -2, 	   0,   -6
+.2byte   -5,   -3, 	  -7,   -6, 	   0,   -1, 	   0,   -6
+.2byte   -4,   -5, 	  -7,   -4, 	   1,   -1, 	   0,   -6
+.2byte   -5,   -4, 	  -7,   -3, 	   1,    0, 	   0,   -5
+.2byte    0,   -5, 	  -7,   -7, 	   6,   -7, 	   0,   -6
+.2byte    2,   -8, 	   4,  -12, 	  -2,   -7, 	  -1,   -8
+.2byte    2,   -9, 	   0,  -11, 	  -2,   -8, 	  -2,   -6
+.2byte    1,  -10, 	  -9,  -11, 	   1,   -9, 	  -3,   -5
+.2byte    0,  -12, 	   7,   -9, 	  -9,   -9, 	   0,   -7
+.2byte   -2,  -10, 	   8,  -11, 	  -2,   -9, 	   2,   -5
+.2byte   -3,   -9, 	  -1,  -11, 	   1,   -8, 	   1,   -6
+.2byte   -3,   -8, 	  -5,  -12, 	   1,   -7, 	   0,   -8
+.2byte    0,   -5, 	  -8,   -6, 	   7,   -6, 	   0,   -7
+.2byte   -6,   -7, 	  -7,   -8, 	   0,   -5, 	   1,   -7
+.2byte   -7,   -8, 	  -6,   -8, 	  -5,   -5, 	   0,   -7
+.2byte   -5,  -12, 	   3,  -13, 	  -8,   -8, 	   0,   -8
+.2byte    0,  -15, 	   7,  -11, 	  -9,  -11, 	   0,   -7
+.2byte    4,  -12, 	   7,   -8, 	  -3,  -12, 	  -1,   -8
+.2byte    7,   -9, 	   4,   -5, 	   5,   -9, 	   0,   -8
+.2byte    3,   -7, 	  -2,   -5, 	   6,   -7, 	   1,   -8
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	   0,   -6
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte    5,  -11, 	   8,   -7, 	  -2,  -11, 	   0,   -7
+.2byte    8,   -8, 	   5,   -4, 	   6,   -8, 	   1,   -7
+.2byte    4,   -6, 	  -1,   -4, 	   7,   -6, 	   2,   -7
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	   0,   -6
+.2byte    4,   -6, 	  -1,   -4, 	   7,   -6, 	   2,   -7
+.2byte    8,   -8, 	   5,   -4, 	   6,   -8, 	   1,   -7
+.2byte    5,  -11, 	   8,   -7, 	  -2,  -11, 	   0,   -7
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	   0,   -6
+.2byte    0,   -2, 	  -9,   -2, 	   8,   -2, 	   0,   -7
+.2byte    0,   -1, 	  -9,   -3, 	   8,   -1, 	   0,   -6
+.2byte    4,   -6, 	  -1,   -4, 	   7,   -6, 	   2,   -7
+.2byte    6,   -3, 	   9,   -5, 	   0,   -2, 	   1,   -8
+.2byte    7,   -2, 	   9,   -4, 	  -1,   -1, 	   2,   -7
+.2byte    8,   -8, 	   5,   -4, 	   6,   -8, 	   1,   -7
+.2byte   10,   -6, 	  10,   -7, 	   7,   -2, 	   2,   -6
+.2byte   11,   -4, 	   9,   -5, 	   7,   -1, 	   3,   -5
+.2byte    5,  -11, 	   8,   -7, 	  -2,  -11, 	   0,   -7
+.2byte    4,  -12, 	  -3,   -9, 	   9,   -5, 	   0,   -8
+.2byte    5,  -11, 	  -3,   -8, 	   9,   -4, 	   0,   -7
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte    0,  -14, 	   9,   -9, 	 -10,   -9, 	   0,   -9
+.2byte    0,  -16, 	   9,  -10, 	 -10,   -8, 	   0,   -9
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte   -4,  -12, 	   3,   -9, 	  -9,   -5, 	   0,   -8
+.2byte   -5,  -11, 	   3,   -8, 	  -9,   -4, 	   0,   -7
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte  -10,   -6, 	 -10,   -7, 	  -7,   -2, 	  -2,   -6
+.2byte  -11,   -4, 	  -9,   -5, 	  -7,   -1, 	  -3,   -5
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte   -7,   -3, 	 -10,   -5, 	  -1,   -2, 	  -2,   -8
+.2byte   -8,   -2, 	 -10,   -4, 	   0,   -1, 	  -3,   -7
+.2byte    0,   -2, 	  -9,   -2, 	   8,   -2, 	   0,   -7
+.2byte   -6,   -3, 	  -9,   -5, 	   0,   -2, 	  -1,   -8
+.2byte  -10,   -6, 	 -10,   -7, 	  -7,   -2, 	  -2,   -6
+.2byte   -4,  -12, 	   3,   -9, 	  -9,   -5, 	   0,   -8
+.2byte    0,  -13, 	   9,   -8, 	 -10,   -8, 	   0,   -8
+.2byte    4,  -12, 	  -3,   -9, 	   9,   -5, 	   0,   -8
+.2byte   10,   -6, 	  10,   -7, 	   7,   -2, 	   2,   -6
+.2byte    5,   -3, 	   8,   -5, 	  -1,   -2, 	   0,   -8
+.2byte    0,   -4, 	  -8,   -5, 	   7,   -5, 	   0,   -6
+.2byte   -6,   -6, 	  -7,   -7, 	   0,   -4, 	   1,   -6
+.2byte   -7,   -7, 	  -6,   -7, 	  -5,   -4, 	   0,   -6
+.2byte   -5,  -11, 	   3,  -12, 	  -8,   -7, 	   0,   -7
+.2byte    0,  -14, 	   7,  -10, 	  -9,  -10, 	   0,   -6
+.2byte    5,  -11, 	   8,   -7, 	  -2,  -11, 	   0,   -7
+.2byte    8,   -8, 	   5,   -4, 	   6,   -8, 	   1,   -7
+.2byte    4,   -6, 	  -1,   -4, 	   7,   -6, 	   2,   -7
+sWartortleAnimTable1:
+.4byte sWartortleAnims_1_1
+.4byte sWartortleAnims_1_2
+.4byte sWartortleAnims_1_3
+.4byte sWartortleAnims_1_4
+.4byte sWartortleAnims_1_5
+.4byte sWartortleAnims_1_6
+.4byte sWartortleAnims_1_7
+.4byte sWartortleAnims_1_8
+sWartortleAnimTable2:
+.4byte sWartortleAnims_2_1
+.4byte sWartortleAnims_2_2
+.4byte sWartortleAnims_2_3
+.4byte sWartortleAnims_2_4
+.4byte sWartortleAnims_2_5
+.4byte sWartortleAnims_2_6
+.4byte sWartortleAnims_2_7
+.4byte sWartortleAnims_2_8
+sWartortleAnimTable3:
+.4byte sWartortleAnims_3_1
+.4byte sWartortleAnims_3_2
+.4byte sWartortleAnims_3_3
+.4byte sWartortleAnims_3_4
+.4byte sWartortleAnims_3_5
+.4byte sWartortleAnims_3_6
+.4byte sWartortleAnims_3_7
+.4byte sWartortleAnims_3_8
+sWartortleAnimTable4:
+.4byte sWartortleAnims_4_1
+.4byte sWartortleAnims_4_2
+.4byte sWartortleAnims_4_3
+.4byte sWartortleAnims_4_4
+.4byte sWartortleAnims_4_5
+.4byte sWartortleAnims_4_6
+.4byte sWartortleAnims_4_7
+.4byte sWartortleAnims_4_8
+sWartortleAnimTable5:
+.4byte sWartortleAnims_5_1
+.4byte sWartortleAnims_5_2
+.4byte sWartortleAnims_5_3
+.4byte sWartortleAnims_5_4
+.4byte sWartortleAnims_5_5
+.4byte sWartortleAnims_5_6
+.4byte sWartortleAnims_5_7
+.4byte sWartortleAnims_5_8
+sWartortleAnimTable6:
+.4byte sWartortleAnims_6_1
+.4byte sWartortleAnims_6_1
+.4byte sWartortleAnims_6_1
+.4byte sWartortleAnims_6_1
+.4byte sWartortleAnims_6_1
+.4byte sWartortleAnims_6_1
+.4byte sWartortleAnims_6_1
+.4byte sWartortleAnims_6_1
+sWartortleAnimTable7:
+.4byte sWartortleAnims_7_1
+.4byte sWartortleAnims_7_2
+.4byte sWartortleAnims_7_3
+.4byte sWartortleAnims_7_4
+.4byte sWartortleAnims_7_5
+.4byte sWartortleAnims_7_6
+.4byte sWartortleAnims_7_7
+.4byte sWartortleAnims_7_8
+sWartortleAnimTable8:
+.4byte sWartortleAnims_8_1
+.4byte sWartortleAnims_8_2
+.4byte sWartortleAnims_8_3
+.4byte sWartortleAnims_8_4
+.4byte sWartortleAnims_8_5
+.4byte sWartortleAnims_8_6
+.4byte sWartortleAnims_8_7
+.4byte sWartortleAnims_8_8
+sWartortleAnimTable9:
+.4byte sWartortleAnims_9_1
+.4byte sWartortleAnims_9_2
+.4byte sWartortleAnims_9_3
+.4byte sWartortleAnims_9_4
+.4byte sWartortleAnims_9_5
+.4byte sWartortleAnims_9_6
+.4byte sWartortleAnims_9_7
+.4byte sWartortleAnims_9_8
+sWartortleAnimTable10:
+.4byte sWartortleAnims_10_1
+.4byte sWartortleAnims_10_2
+.4byte sWartortleAnims_10_3
+.4byte sWartortleAnims_10_4
+.4byte sWartortleAnims_10_5
+.4byte sWartortleAnims_10_6
+.4byte sWartortleAnims_10_7
+.4byte sWartortleAnims_10_8
+sWartortleAnimTable11:
+.4byte sWartortleAnims_11_1
+.4byte sWartortleAnims_11_2
+.4byte sWartortleAnims_11_3
+.4byte sWartortleAnims_11_4
+.4byte sWartortleAnims_11_5
+.4byte sWartortleAnims_11_6
+.4byte sWartortleAnims_11_7
+.4byte sWartortleAnims_11_8
+sWartortleAnimTable12:
+.4byte sWartortleAnims_12_1
+.4byte sWartortleAnims_12_2
+.4byte sWartortleAnims_12_3
+.4byte sWartortleAnims_12_4
+.4byte sWartortleAnims_12_5
+.4byte sWartortleAnims_12_6
+.4byte sWartortleAnims_12_7
+.4byte sWartortleAnims_12_8
+sWartortleAnimTable13:
+.4byte sWartortleAnims_13_1
+.4byte sWartortleAnims_13_2
+.4byte sWartortleAnims_13_3
+.4byte sWartortleAnims_13_4
+.4byte sWartortleAnims_13_5
+.4byte sWartortleAnims_13_6
+.4byte sWartortleAnims_13_7
+.4byte sWartortleAnims_13_8
+sAxAnimationsWartortle:
+.4byte sWartortleAnimTable1
+.4byte sWartortleAnimTable2
+.4byte sWartortleAnimTable3
+.4byte sWartortleAnimTable4
+.4byte sWartortleAnimTable5
+.4byte sWartortleAnimTable6
+.4byte sWartortleAnimTable7
+.4byte sWartortleAnimTable8
+.4byte sWartortleAnimTable9
+.4byte sWartortleAnimTable10
+.4byte sWartortleAnimTable11
+.4byte sWartortleAnimTable12
+.4byte sWartortleAnimTable13
+sAxSpritesWartortle:
+.4byte sWartortleSprites1
+.4byte sWartortleSprites2
+.4byte sWartortleSprites3
+.4byte sWartortleSprites4
+.4byte sWartortleSprites5
+.4byte sWartortleSprites6
+.4byte sWartortleSprites7
+.4byte sWartortleSprites8
+.4byte sWartortleSprites9
+.4byte sWartortleSprites10
+.4byte sWartortleSprites11
+.4byte sWartortleSprites12
+.4byte sWartortleSprites13
+.4byte sWartortleSprites14
+.4byte sWartortleSprites15
+.4byte sWartortleSprites16
+.4byte sWartortleSprites17
+.4byte sWartortleSprites18
+.4byte sWartortleSprites19
+.4byte sWartortleSprites20
+.4byte sWartortleSprites21
+.4byte sWartortleSprites22
+.4byte sWartortleSprites23
+.4byte sWartortleSprites24
+.4byte sWartortleSprites25
+.4byte sWartortleSprites26
+.4byte sWartortleSprites27
+.4byte sWartortleSprites28
+.4byte sWartortleSprites29
+.4byte sWartortleSprites30
+.4byte sWartortleSprites31
+.4byte sWartortleSprites32
+.4byte sWartortleSprites33
+.4byte sWartortleSprites34
+.4byte sWartortleSprites35
+.4byte sWartortleSprites36
+.4byte sWartortleSprites37
+.4byte sWartortleSprites38
+.4byte sWartortleSprites39
+.4byte sWartortleSprites40
+.4byte sWartortleSprites41
+.4byte sWartortleSprites42
+.4byte sWartortleSprites43
+.4byte sWartortleSprites44
+.4byte sWartortleSprites45
+.4byte sWartortleSprites46
+sAxMainWartortle:
+ax_main sAxPosesWartortle, sAxAnimationsWartortle, 13, sAxSpritesWartortle, sAxPositionsWartortle

--- a/data/ax/weedle.inc
+++ b/data/ax/weedle.inc
@@ -1,0 +1,2839 @@
+.global gAxWeedle
+gAxWeedle:
+ax_siro sAxMainWeedle
+sWeedlePose1:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose2:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose3:
+ax_pose 2, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose4:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose5:
+ax_pose 4, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose6:
+ax_pose 5, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose7:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose8:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose9:
+ax_pose 8, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose10:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose11:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose12:
+ax_pose 11, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose13:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose14:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose15:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose16:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose17:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose18:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose19:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose20:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose21:
+ax_pose 8, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose22:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose23:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose24:
+ax_pose 5, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose25:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose26:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose27:
+ax_pose 2, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose28:
+ax_pose 15, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose29:
+ax_pose 16, 0x81eb, 0x80f8, 0x4c00
+ax_pose 15, 0x81eb, 0x80f8, 0x4c08
+ax_pose_terminator
+sWeedlePose30:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose31:
+ax_pose 4, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose32:
+ax_pose 5, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose33:
+ax_pose 17, 0x41f5, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose34:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose35:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose36:
+ax_pose 8, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose37:
+ax_pose 18, 0x41f2, 0x90ee, 0x4c00
+ax_pose_terminator
+sWeedlePose38:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose39:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose40:
+ax_pose 11, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose41:
+ax_pose 19, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose42:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose43:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose44:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose45:
+ax_pose 20, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose46:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose47:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose48:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose49:
+ax_pose 19, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose50:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose51:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose52:
+ax_pose 8, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose53:
+ax_pose 18, 0x41f2, 0x80f1, 0x4c00
+ax_pose_terminator
+sWeedlePose54:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose55:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose56:
+ax_pose 5, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose57:
+ax_pose 17, 0x41f5, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose58:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose59:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose60:
+ax_pose 2, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose61:
+ax_pose 15, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose62:
+ax_pose 16, 0x81ed, 0x80f8, 0x4c00
+ax_pose 15, 0x81ec, 0x80f8, 0x4c08
+ax_pose_terminator
+sWeedlePose63:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose64:
+ax_pose 4, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose65:
+ax_pose 5, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose66:
+ax_pose 17, 0x41f5, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose67:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose 17, 0x41f5, 0x90ef, 0x4c10
+ax_pose_terminator
+sWeedlePose68:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose69:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose70:
+ax_pose 8, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose71:
+ax_pose 18, 0x41f2, 0x90ee, 0x4c00
+ax_pose_terminator
+sWeedlePose72:
+ax_pose 22, 0x01ea, 0x90f0, 0x4c00
+ax_pose 18, 0x41f2, 0x90ee, 0x4c10
+ax_pose_terminator
+sWeedlePose73:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose74:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose75:
+ax_pose 11, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose76:
+ax_pose 19, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose77:
+ax_pose 23, 0x01ef, 0x90f0, 0x4c00
+ax_pose 19, 0x01ef, 0x90ef, 0x4c10
+ax_pose_terminator
+sWeedlePose78:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose79:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose80:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose81:
+ax_pose 20, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose82:
+ax_pose 24, 0x81ed, 0x80f8, 0x4c00
+ax_pose 20, 0x81ee, 0x80f8, 0x4c08
+ax_pose_terminator
+sWeedlePose83:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose84:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose85:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose86:
+ax_pose 19, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose87:
+ax_pose 23, 0x01ef, 0x80ef, 0x4c00
+ax_pose 19, 0x01ef, 0x80f0, 0x4c10
+ax_pose_terminator
+sWeedlePose88:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose89:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose90:
+ax_pose 8, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose91:
+ax_pose 18, 0x41f2, 0x80f1, 0x4c00
+ax_pose_terminator
+sWeedlePose92:
+ax_pose 22, 0x01ea, 0x80ef, 0x4c00
+ax_pose 18, 0x41f2, 0x80f1, 0x4c10
+ax_pose_terminator
+sWeedlePose93:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose94:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose95:
+ax_pose 5, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose96:
+ax_pose 17, 0x41f5, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose97:
+ax_pose 21, 0x01eb, 0x80ef, 0x4c00
+ax_pose 17, 0x41f5, 0x80f0, 0x4c10
+ax_pose_terminator
+sWeedlePose98:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose99:
+ax_pose 25, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sWeedlePose100:
+ax_pose 26, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sWeedlePose101:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose102:
+ax_pose 27, 0x81ee, 0x90fb, 0x4c00
+ax_pose_terminator
+sWeedlePose103:
+ax_pose 28, 0x81ee, 0x90fb, 0x4c00
+ax_pose_terminator
+sWeedlePose104:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose105:
+ax_pose 29, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sWeedlePose106:
+ax_pose 30, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sWeedlePose107:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose108:
+ax_pose 31, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sWeedlePose109:
+ax_pose 32, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sWeedlePose110:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose111:
+ax_pose 33, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose112:
+ax_pose 34, 0x01ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose113:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose114:
+ax_pose 31, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWeedlePose115:
+ax_pose 32, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWeedlePose116:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose117:
+ax_pose 29, 0x81ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose118:
+ax_pose 30, 0x81ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose119:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose120:
+ax_pose 27, 0x81ee, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose121:
+ax_pose 28, 0x81ee, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose122:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose123:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose124:
+ax_pose 2, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose125:
+ax_pose 15, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose126:
+ax_pose 16, 0x81ed, 0x80f8, 0x4c00
+ax_pose 15, 0x81ec, 0x80f8, 0x4c08
+ax_pose_terminator
+sWeedlePose127:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose128:
+ax_pose 4, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose129:
+ax_pose 5, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose130:
+ax_pose 17, 0x41f5, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose131:
+ax_pose 21, 0x01eb, 0x90f0, 0x4c00
+ax_pose 17, 0x41f5, 0x90ef, 0x4c10
+ax_pose_terminator
+sWeedlePose132:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose133:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose134:
+ax_pose 8, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose135:
+ax_pose 18, 0x41f2, 0x90ee, 0x4c00
+ax_pose_terminator
+sWeedlePose136:
+ax_pose 22, 0x01ea, 0x90f0, 0x4c00
+ax_pose 18, 0x41f2, 0x90ee, 0x4c10
+ax_pose_terminator
+sWeedlePose137:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose138:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose139:
+ax_pose 11, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose140:
+ax_pose 19, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose141:
+ax_pose 23, 0x01ef, 0x90f0, 0x4c00
+ax_pose 19, 0x01ef, 0x90ef, 0x4c10
+ax_pose_terminator
+sWeedlePose142:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose143:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose144:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose145:
+ax_pose 20, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose146:
+ax_pose 24, 0x81ed, 0x80f8, 0x4c00
+ax_pose 20, 0x81ee, 0x80f8, 0x4c08
+ax_pose_terminator
+sWeedlePose147:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose148:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose149:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose150:
+ax_pose 19, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose151:
+ax_pose 23, 0x01ef, 0x80ef, 0x4c00
+ax_pose 19, 0x01ef, 0x80f0, 0x4c10
+ax_pose_terminator
+sWeedlePose152:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose153:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose154:
+ax_pose 8, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose155:
+ax_pose 18, 0x41f2, 0x80f1, 0x4c00
+ax_pose_terminator
+sWeedlePose156:
+ax_pose 22, 0x01ea, 0x80ef, 0x4c00
+ax_pose 18, 0x41f2, 0x80f1, 0x4c10
+ax_pose_terminator
+sWeedlePose157:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose158:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose159:
+ax_pose 5, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose160:
+ax_pose 17, 0x41f5, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose161:
+ax_pose 21, 0x01eb, 0x80ef, 0x4c00
+ax_pose 17, 0x41f5, 0x80f0, 0x4c10
+ax_pose_terminator
+sWeedlePose162:
+ax_pose 35, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sWeedlePose163:
+ax_pose 36, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sWeedlePose164:
+ax_pose 37, 0x01e1, 0x80f1, 0x4c00
+ax_pose_terminator
+sWeedlePose165:
+ax_pose 38, 0x01e2, 0x90ea, 0x4c00
+ax_pose_terminator
+sWeedlePose166:
+ax_pose 39, 0x01e2, 0x90e9, 0x4c00
+ax_pose_terminator
+sWeedlePose167:
+ax_pose 40, 0x01e5, 0x90ea, 0x4c00
+ax_pose_terminator
+sWeedlePose168:
+ax_pose 41, 0x01e6, 0x80f1, 0x4c00
+ax_pose_terminator
+sWeedlePose169:
+ax_pose 40, 0x01e5, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose170:
+ax_pose 39, 0x01e2, 0x80f7, 0x4c00
+ax_pose_terminator
+sWeedlePose171:
+ax_pose 38, 0x01e2, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose172:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose173:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose174:
+ax_pose 2, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose175:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose176:
+ax_pose 4, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose177:
+ax_pose 5, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose178:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose179:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose180:
+ax_pose 8, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose181:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose182:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose183:
+ax_pose 11, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose184:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose185:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose186:
+ax_pose 14, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose187:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose188:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose189:
+ax_pose 11, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose190:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose191:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose192:
+ax_pose 8, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose193:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose194:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose195:
+ax_pose 5, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose196:
+ax_pose 15, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose197:
+ax_pose 17, 0x41f6, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose198:
+ax_pose 18, 0x41f2, 0x80f1, 0x4c00
+ax_pose_terminator
+sWeedlePose199:
+ax_pose 19, 0x01ee, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose200:
+ax_pose 20, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose201:
+ax_pose 19, 0x01ee, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose202:
+ax_pose 18, 0x41f2, 0x90ee, 0x4c00
+ax_pose_terminator
+sWeedlePose203:
+ax_pose 17, 0x41f6, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose204:
+ax_pose 25, 0x81eb, 0x80f7, 0x4c00
+ax_pose_terminator
+sWeedlePose205:
+ax_pose 27, 0x81ee, 0x90fb, 0x4c00
+ax_pose_terminator
+sWeedlePose206:
+ax_pose 29, 0x81ec, 0x90f9, 0x4c00
+ax_pose_terminator
+sWeedlePose207:
+ax_pose 31, 0x01eb, 0x90ea, 0x4c00
+ax_pose_terminator
+sWeedlePose208:
+ax_pose 33, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose209:
+ax_pose 31, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWeedlePose210:
+ax_pose 29, 0x81ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose211:
+ax_pose 27, 0x81ee, 0x80f6, 0x4c00
+ax_pose_terminator
+sWeedlePose212:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose213:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose214:
+ax_pose 15, 0x81ed, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose215:
+ax_pose 4, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose216:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose217:
+ax_pose 17, 0x41f5, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose218:
+ax_pose 7, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose219:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose220:
+ax_pose 18, 0x41f2, 0x90ee, 0x4c00
+ax_pose_terminator
+sWeedlePose221:
+ax_pose 10, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose222:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose223:
+ax_pose 19, 0x01ef, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose224:
+ax_pose 13, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose225:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose226:
+ax_pose 20, 0x81ee, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose227:
+ax_pose 10, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose228:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose229:
+ax_pose 19, 0x01ef, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose230:
+ax_pose 7, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose231:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose232:
+ax_pose 18, 0x41f2, 0x80f1, 0x4c00
+ax_pose_terminator
+sWeedlePose233:
+ax_pose 4, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose234:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose235:
+ax_pose 17, 0x41f5, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose236:
+ax_pose 1, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose237:
+ax_pose 4, 0x01ec, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose238:
+ax_pose 7, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWeedlePose239:
+ax_pose 10, 0x01eb, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose240:
+ax_pose 13, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose241:
+ax_pose 10, 0x01eb, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose242:
+ax_pose 7, 0x01eb, 0x90eb, 0x4c00
+ax_pose_terminator
+sWeedlePose243:
+ax_pose 4, 0x01ec, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose244:
+ax_pose 0, 0x81eb, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose245:
+ax_pose 3, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose246:
+ax_pose 6, 0x01ea, 0x80f2, 0x4c00
+ax_pose_terminator
+sWeedlePose247:
+ax_pose 9, 0x01ea, 0x80f0, 0x4c00
+ax_pose_terminator
+sWeedlePose248:
+ax_pose 12, 0x81ea, 0x80f8, 0x4c00
+ax_pose_terminator
+sWeedlePose249:
+ax_pose 9, 0x01ea, 0x90ef, 0x4c00
+ax_pose_terminator
+sWeedlePose250:
+ax_pose 6, 0x01ea, 0x90ed, 0x4c00
+ax_pose_terminator
+sWeedlePose251:
+ax_pose 3, 0x01eb, 0x90ef, 0x4c00
+ax_pose_terminator
+.align 2
+sWeedleAnims_1_1:
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim 10, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_1_2:
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim 10, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_1_3:
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim 10, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_1_4:
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim 10, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_1_5:
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim 10, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_1_6:
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim 10, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_1_7:
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim 10, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_1_8:
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim 10, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeedleAnims_2_1:
+ax_anim 4, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 25, 0, 0, 0, 0,
+ax_anim 2, 0, 27, 0, 4, 0, 1,
+ax_anim 2, 2, 27, 0, 10, 0, 7,
+ax_anim 2, 0, 27, 0, 18, 0, 15,
+ax_anim 2, 1, 27, 1, 18, 1, 15,
+ax_anim 2, 0, 27, 0, 18, 0, 15,
+ax_anim 2, 0, 27, 1, 18, 1, 15,
+ax_anim 4, 0, 26, 0, 6, 0, 6,
+ax_anim_terminator
+sWeedleAnims_2_2:
+ax_anim 4, 0, 29, 0, 0, 0, 0,
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -2, -2, -2, -2,
+ax_anim 2, 0, 30, 0, -1, 0, 0,
+ax_anim 2, 0, 32, 4, 4, 4, 4,
+ax_anim 2, 2, 32, 10, 10, 10, 10,
+ax_anim 2, 0, 32, 18, 18, 18, 18,
+ax_anim 2, 1, 32, 19, 17, 19, 17,
+ax_anim 2, 0, 32, 18, 18, 18, 18,
+ax_anim 2, 0, 32, 19, 17, 19, 17,
+ax_anim 4, 0, 29, 8, 8, 6, 6,
+ax_anim_terminator
+sWeedleAnims_2_3:
+ax_anim 4, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 4, 0, 33, -2, 0, -2, 0,
+ax_anim 2, 0, 34, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 4, 0, 4, 0,
+ax_anim 2, 2, 36, 10, 0, 10, 0,
+ax_anim 2, 0, 36, 18, 0, 18, 0,
+ax_anim 2, 1, 36, 18, 1, 18, 1,
+ax_anim 2, 0, 36, 18, 0, 18, 0,
+ax_anim 2, 0, 36, 18, 1, 18, 1,
+ax_anim 4, 0, 33, 6, 0, 6, 0,
+ax_anim_terminator
+sWeedleAnims_2_4:
+ax_anim 4, 0, 37, 0, 0, 0, 0,
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -2, 2, -2, 2,
+ax_anim 2, 0, 38, 0, -1, 0, -1,
+ax_anim 2, 0, 40, 4, -4, 4, -4,
+ax_anim 2, 2, 40, 10, -10, 10, -10,
+ax_anim 2, 0, 40, 18, -18, 18, -18,
+ax_anim 2, 1, 40, 19, -17, 19, -17,
+ax_anim 2, 0, 40, 18, -18, 18, -18,
+ax_anim 2, 0, 40, 19, -17, 19, -17,
+ax_anim 4, 0, 37, 6, -6, 6, -6,
+ax_anim_terminator
+sWeedleAnims_2_5:
+ax_anim 4, 0, 41, 0, 0, 0, 0,
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 4, 0, 41, 0, 2, 0, 2,
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 0, -4, 0, -4,
+ax_anim 2, 2, 44, 0, -10, 0, -10,
+ax_anim 2, 0, 44, 0, -18, 0, -18,
+ax_anim 2, 1, 44, 1, -18, 1, -18,
+ax_anim 2, 0, 44, 0, -18, 0, -18,
+ax_anim 2, 0, 44, 1, -18, 1, -18,
+ax_anim 4, 0, 41, 0, -6, 0, -6,
+ax_anim_terminator
+sWeedleAnims_2_6:
+ax_anim 4, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 4, 0, 45, 2, 2, 2, 2,
+ax_anim 2, 0, 46, 0, 0, 0, -1,
+ax_anim 2, 0, 48, -4, -4, -4, -4,
+ax_anim 2, 2, 48, -10, -10, -10, -10,
+ax_anim 2, 0, 48, -18, -18, -18, -18,
+ax_anim 2, 1, 48, -19, -17, -19, -17,
+ax_anim 2, 0, 48, -18, -18, -18, -18,
+ax_anim 2, 0, 48, -19, -17, -19, -17,
+ax_anim 4, 0, 45, -6, -6, -6, -6,
+ax_anim_terminator
+sWeedleAnims_2_7:
+ax_anim 4, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 4, 0, 49, 2, 0, 2, 0,
+ax_anim 2, 0, 50, 0, 0, 0, 0,
+ax_anim 2, 0, 52, -4, 0, -4, 0,
+ax_anim 2, 2, 52, -10, 0, -10, 0,
+ax_anim 2, 0, 52, -18, 0, -18, 0,
+ax_anim 2, 1, 52, -18, 1, -18, 1,
+ax_anim 2, 0, 52, -18, 0, -18, 0,
+ax_anim 2, 0, 52, -18, 1, -18, 1,
+ax_anim 4, 0, 49, -6, 0, -6, 0,
+ax_anim_terminator
+sWeedleAnims_2_8:
+ax_anim 4, 0, 53, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 2, -2, 2, -2,
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 56, -4, 4, -4, 4,
+ax_anim 2, 2, 56, -10, 10, -10, 10,
+ax_anim 2, 0, 56, -17, 19, -17, 19,
+ax_anim 2, 1, 56, -18, 18, -18, 18,
+ax_anim 2, 0, 56, -17, 19, -17, 19,
+ax_anim 2, 0, 56, -17, 19, -17, 19,
+ax_anim 4, 0, 53, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWeedleAnims_3_1:
+ax_anim 4, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 4, 0, 57, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 4, 0, 1,
+ax_anim 2, 2, 61, 0, 10, 0, 7,
+ax_anim 2, 0, 60, 0, 18, 0, 15,
+ax_anim 2, 1, 61, 1, 18, 1, 15,
+ax_anim 2, 0, 60, 0, 18, 0, 15,
+ax_anim 2, 0, 60, 1, 18, 1, 15,
+ax_anim 4, 0, 59, 0, 6, 0, 6,
+ax_anim_terminator
+sWeedleAnims_3_2:
+ax_anim 4, 0, 62, 0, 0, 0, 0,
+ax_anim 2, 0, 62, -1, -1, -1, -1,
+ax_anim 4, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 63, 0, -1, 0, 0,
+ax_anim 2, 0, 65, 4, 4, 4, 4,
+ax_anim 2, 2, 66, 10, 10, 10, 10,
+ax_anim 2, 0, 65, 18, 18, 18, 18,
+ax_anim 2, 1, 66, 19, 17, 19, 17,
+ax_anim 2, 0, 65, 18, 18, 18, 18,
+ax_anim 2, 0, 65, 19, 17, 19, 17,
+ax_anim 4, 0, 62, 8, 8, 6, 6,
+ax_anim_terminator
+sWeedleAnims_3_3:
+ax_anim 4, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -1, 0, -1, 0,
+ax_anim 4, 0, 67, -2, 0, -2, 0,
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 70, 4, 0, 4, 0,
+ax_anim 2, 2, 71, 10, 0, 10, 0,
+ax_anim 2, 0, 70, 18, 0, 18, 0,
+ax_anim 2, 1, 71, 18, 1, 18, 1,
+ax_anim 2, 0, 70, 18, 0, 18, 0,
+ax_anim 2, 0, 70, 18, 1, 18, 1,
+ax_anim 4, 0, 67, 6, 0, 6, 0,
+ax_anim_terminator
+sWeedleAnims_3_4:
+ax_anim 4, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, -1, 1, -1, 1,
+ax_anim 4, 0, 72, -2, 2, -2, 2,
+ax_anim 2, 0, 73, 0, -1, 0, -1,
+ax_anim 2, 0, 75, 4, -4, 4, -4,
+ax_anim 2, 2, 76, 10, -10, 10, -10,
+ax_anim 2, 0, 75, 18, -18, 18, -18,
+ax_anim 2, 1, 76, 19, -17, 19, -17,
+ax_anim 2, 0, 75, 18, -18, 18, -18,
+ax_anim 2, 0, 75, 19, -17, 19, -17,
+ax_anim 4, 0, 72, 6, -6, 6, -6,
+ax_anim_terminator
+sWeedleAnims_3_5:
+ax_anim 4, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 1, 0, 1,
+ax_anim 4, 0, 77, 0, 2, 0, 2,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, -4,
+ax_anim 2, 2, 81, 0, -10, 0, -10,
+ax_anim 2, 0, 80, 0, -18, 0, -18,
+ax_anim 2, 1, 81, 1, -18, 1, -18,
+ax_anim 2, 0, 80, 0, -18, 0, -18,
+ax_anim 2, 0, 80, 1, -18, 1, -18,
+ax_anim 4, 0, 77, 0, -6, 0, -6,
+ax_anim_terminator
+sWeedleAnims_3_6:
+ax_anim 4, 0, 82, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 1, 1, 1, 1,
+ax_anim 4, 0, 82, 2, 2, 2, 2,
+ax_anim 2, 0, 83, 0, 0, 0, -1,
+ax_anim 2, 0, 85, -4, -4, -4, -4,
+ax_anim 2, 2, 86, -10, -10, -10, -10,
+ax_anim 2, 0, 85, -18, -18, -18, -18,
+ax_anim 2, 1, 86, -19, -17, -19, -17,
+ax_anim 2, 0, 85, -18, -18, -18, -18,
+ax_anim 2, 0, 85, -19, -17, -19, -17,
+ax_anim 4, 0, 82, -6, -6, -6, -6,
+ax_anim_terminator
+sWeedleAnims_3_7:
+ax_anim 4, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 87, 1, 0, 1, 0,
+ax_anim 4, 0, 87, 2, 0, 2, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 90, -4, 0, -4, 0,
+ax_anim 2, 2, 91, -10, 0, -10, 0,
+ax_anim 2, 0, 90, -18, 0, -18, 0,
+ax_anim 2, 1, 91, -18, 1, -18, 1,
+ax_anim 2, 0, 90, -18, 0, -18, 0,
+ax_anim 2, 0, 90, -18, 1, -18, 1,
+ax_anim 4, 0, 87, -6, 0, -6, 0,
+ax_anim_terminator
+sWeedleAnims_3_8:
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, -1,
+ax_anim 4, 0, 92, 2, -2, 2, -2,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 95, -4, 4, -4, 4,
+ax_anim 2, 2, 96, -10, 10, -10, 10,
+ax_anim 2, 0, 95, -17, 19, -17, 19,
+ax_anim 2, 1, 96, -18, 18, -18, 18,
+ax_anim 2, 0, 95, -17, 19, -17, 19,
+ax_anim 2, 0, 95, -17, 19, -17, 19,
+ax_anim 4, 0, 92, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWeedleAnims_4_1:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, -1,
+ax_anim 4, 0, 97, 0, -2, 0, -2,
+ax_anim 4, 2, 98, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 1, 99, 0, 2, 0, 1,
+ax_anim 2, 0, 99, 1, 2, 1, 1,
+ax_anim 2, 0, 99, 0, 2, 0, 1,
+ax_anim 2, 0, 99, 1, 2, 1, 1,
+ax_anim 2, 0, 99, 0, 2, 0, 1,
+ax_anim 2, 0, 99, 1, 2, 1, 1,
+ax_anim 4, 0, 97, 0, 2, 0, 0,
+ax_anim_terminator
+sWeedleAnims_4_2:
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim 2, 0, 100, -1, -1, -1, -1,
+ax_anim 4, 0, 100, -2, -2, -2, -2,
+ax_anim 4, 2, 101, -2, -2, -2, -2,
+ax_anim 2, 0, 102, -2, -2, -2, -2,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 1, 102, 2, 2, 2, 2,
+ax_anim 2, 0, 102, 1, 3, 1, 3,
+ax_anim 2, 0, 102, 2, 2, 2, 2,
+ax_anim 2, 0, 102, 1, 3, 1, 3,
+ax_anim 2, 0, 102, 2, 2, 2, 2,
+ax_anim 2, 0, 102, 1, 3, 1, 3,
+ax_anim 4, 0, 100, 2, 2, 2, 2,
+ax_anim_terminator
+sWeedleAnims_4_3:
+ax_anim 2, 0, 103, 0, 0, 0, 0,
+ax_anim 2, 0, 103, -1, 0, -1, 0,
+ax_anim 4, 0, 103, -2, 0, -2, 0,
+ax_anim 4, 2, 104, -2, 0, -2, 0,
+ax_anim 2, 0, 105, -2, 0, -2, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 1, 105, 2, 0, 2, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 2, 0, 2, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 2, 0, 2, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 4, 0, 103, 2, 0, 2, 0,
+ax_anim_terminator
+sWeedleAnims_4_4:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 106, -1, 1, -1, 1,
+ax_anim 4, 0, 106, -2, 2, -2, 2,
+ax_anim 4, 2, 107, -2, 2, -2, 2,
+ax_anim 2, 0, 108, -2, 2, -2, 2,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 1, 108, 2, -2, 2, -2,
+ax_anim 2, 0, 108, 1, -3, 1, -3,
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim 2, 0, 108, 1, -3, 1, -3,
+ax_anim 2, 0, 108, 2, -2, 2, -2,
+ax_anim 2, 0, 108, 1, -3, 1, -3,
+ax_anim 4, 0, 106, 2, -2, 2, -2,
+ax_anim_terminator
+sWeedleAnims_4_5:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 1, 0, 1,
+ax_anim 4, 0, 109, 0, 2, 0, 2,
+ax_anim 4, 2, 110, 0, 2, 0, 2,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 1, 111, 0, -2, 0, -2,
+ax_anim 2, 0, 111, 1, -2, 1, -2,
+ax_anim 2, 0, 111, 0, -2, 0, -2,
+ax_anim 2, 0, 111, 1, -2, 1, -2,
+ax_anim 2, 0, 111, 0, -2, 0, -2,
+ax_anim 2, 0, 111, 1, -2, 1, -2,
+ax_anim 4, 0, 109, 0, -1, 0, -1,
+ax_anim_terminator
+sWeedleAnims_4_6:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 1, 1, 1, 1,
+ax_anim 4, 0, 112, 2, 2, 2, 2,
+ax_anim 4, 2, 113, 2, 2, 2, 2,
+ax_anim 2, 0, 114, 2, 2, 2, 2,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 1, 114, -2, -2, -2, -2,
+ax_anim 2, 0, 114, -1, -3, -1, -3,
+ax_anim 2, 0, 114, -2, -2, -2, -2,
+ax_anim 2, 0, 114, -1, -3, -1, -3,
+ax_anim 2, 0, 114, -2, -2, -2, -2,
+ax_anim 2, 0, 114, -1, -3, -1, -3,
+ax_anim 4, 0, 112, -2, -2, -2, -2,
+ax_anim_terminator
+sWeedleAnims_4_7:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, 0, 1, 0,
+ax_anim 4, 0, 115, 2, 0, 2, 0,
+ax_anim 4, 2, 116, 2, 0, 2, 0,
+ax_anim 2, 0, 117, 2, 0, 2, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 1, 117, -2, 0, -2, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 117, -2, 0, -2, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 2, 0, 117, -2, 0, -2, 0,
+ax_anim 2, 0, 117, -1, 0, -1, 0,
+ax_anim 4, 0, 115, -2, 0, -2, 0,
+ax_anim_terminator
+sWeedleAnims_4_8:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 1, -1, 1, -1,
+ax_anim 4, 0, 118, 2, -2, 2, -2,
+ax_anim 4, 2, 119, 2, -2, 2, -2,
+ax_anim 2, 0, 120, 2, -2, 2, -2,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 1, 120, -2, 2, -2, 2,
+ax_anim 2, 0, 120, -1, 3, -1, 3,
+ax_anim 2, 0, 120, -2, 2, -2, 2,
+ax_anim 2, 0, 120, -1, 3, -1, 3,
+ax_anim 2, 0, 120, -2, 2, -2, 2,
+ax_anim 2, 0, 120, -1, 3, -1, 3,
+ax_anim 4, 0, 118, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sWeedleAnims_5_1:
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, -1,
+ax_anim 4, 0, 121, 0, -2, 0, -2,
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, 4, 0, 1,
+ax_anim 2, 2, 125, 0, 10, 0, 7,
+ax_anim 2, 0, 124, 0, 18, 0, 15,
+ax_anim 2, 1, 125, 1, 18, 1, 15,
+ax_anim 2, 0, 124, 0, 18, 0, 15,
+ax_anim 2, 0, 124, 1, 18, 1, 15,
+ax_anim 4, 0, 123, 0, 6, 0, 6,
+ax_anim_terminator
+sWeedleAnims_5_2:
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 126, -1, -1, -1, -1,
+ax_anim 4, 0, 126, -2, -2, -2, -2,
+ax_anim 2, 0, 127, 0, -1, 0, 0,
+ax_anim 2, 0, 129, 4, 4, 4, 4,
+ax_anim 2, 2, 130, 10, 10, 10, 10,
+ax_anim 2, 0, 129, 18, 18, 18, 18,
+ax_anim 2, 1, 130, 19, 17, 19, 17,
+ax_anim 2, 0, 129, 18, 18, 18, 18,
+ax_anim 2, 0, 129, 19, 17, 19, 17,
+ax_anim 4, 0, 126, 8, 8, 6, 6,
+ax_anim_terminator
+sWeedleAnims_5_3:
+ax_anim 4, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -1, 0, -1, 0,
+ax_anim 4, 0, 131, -2, 0, -2, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 4, 0, 4, 0,
+ax_anim 2, 2, 135, 10, 0, 10, 0,
+ax_anim 2, 0, 134, 18, 0, 18, 0,
+ax_anim 2, 1, 135, 18, 1, 18, 1,
+ax_anim 2, 0, 134, 18, 0, 18, 0,
+ax_anim 2, 0, 134, 18, 1, 18, 1,
+ax_anim 4, 0, 131, 6, 0, 6, 0,
+ax_anim_terminator
+sWeedleAnims_5_4:
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 1, -1, 1,
+ax_anim 4, 0, 136, -2, 2, -2, 2,
+ax_anim 2, 0, 137, 0, -1, 0, -1,
+ax_anim 2, 0, 139, 4, -4, 4, -4,
+ax_anim 2, 2, 140, 10, -10, 10, -10,
+ax_anim 2, 0, 139, 18, -18, 18, -18,
+ax_anim 2, 1, 140, 19, -17, 19, -17,
+ax_anim 2, 0, 139, 18, -18, 18, -18,
+ax_anim 2, 0, 139, 19, -17, 19, -17,
+ax_anim 4, 0, 136, 6, -6, 6, -6,
+ax_anim_terminator
+sWeedleAnims_5_5:
+ax_anim 4, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 1, 0, 1,
+ax_anim 4, 0, 141, 0, 2, 0, 2,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, -4,
+ax_anim 2, 2, 145, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, -18, 0, -18,
+ax_anim 2, 1, 145, 1, -18, 1, -18,
+ax_anim 2, 0, 144, 0, -18, 0, -18,
+ax_anim 2, 0, 144, 1, -18, 1, -18,
+ax_anim 4, 0, 141, 0, -6, 0, -6,
+ax_anim_terminator
+sWeedleAnims_5_6:
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, 1, 1, 1,
+ax_anim 4, 0, 146, 2, 2, 2, 2,
+ax_anim 2, 0, 147, 0, 0, 0, -1,
+ax_anim 2, 0, 149, -4, -4, -4, -4,
+ax_anim 2, 2, 150, -10, -10, -10, -10,
+ax_anim 2, 0, 149, -18, -18, -18, -18,
+ax_anim 2, 1, 150, -19, -17, -19, -17,
+ax_anim 2, 0, 149, -18, -18, -18, -18,
+ax_anim 2, 0, 149, -19, -17, -19, -17,
+ax_anim 4, 0, 146, -6, -6, -6, -6,
+ax_anim_terminator
+sWeedleAnims_5_7:
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 1, 0, 1, 0,
+ax_anim 4, 0, 151, 2, 0, 2, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 154, -4, 0, -4, 0,
+ax_anim 2, 2, 155, -10, 0, -10, 0,
+ax_anim 2, 0, 154, -18, 0, -18, 0,
+ax_anim 2, 1, 155, -18, 1, -18, 1,
+ax_anim 2, 0, 154, -18, 0, -18, 0,
+ax_anim 2, 0, 154, -18, 1, -18, 1,
+ax_anim 4, 0, 151, -6, 0, -6, 0,
+ax_anim_terminator
+sWeedleAnims_5_8:
+ax_anim 4, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 1, -1, 1, -1,
+ax_anim 4, 0, 156, 2, -2, 2, -2,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -4, 4, -4, 4,
+ax_anim 2, 2, 160, -10, 10, -10, 10,
+ax_anim 2, 0, 159, -17, 19, -17, 19,
+ax_anim 2, 1, 160, -18, 18, -18, 18,
+ax_anim 2, 0, 159, -17, 19, -17, 19,
+ax_anim 2, 0, 159, -17, 19, -17, 19,
+ax_anim 4, 0, 156, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWeedleAnims_6_1:
+ax_anim 30, 0, 161, 0, 0, 0, 0,
+ax_anim 35, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeedleAnims_7_1:
+ax_anim 2, 0, 163, 0, -2, 0, -2,
+ax_anim 8, 0, 163, 0, -3, 0, -3,
+ax_anim_terminator
+sWeedleAnims_7_2:
+ax_anim 2, 0, 164, -2, -2, -2, -2,
+ax_anim 8, 0, 164, -3, -3, -3, -3,
+ax_anim_terminator
+sWeedleAnims_7_3:
+ax_anim 2, 0, 165, -2, 0, -2, 0,
+ax_anim 8, 0, 165, -3, 0, -3, 0,
+ax_anim_terminator
+sWeedleAnims_7_4:
+ax_anim 2, 0, 166, -2, 2, -2, 2,
+ax_anim 8, 0, 166, -3, 3, -3, 3,
+ax_anim_terminator
+sWeedleAnims_7_5:
+ax_anim 2, 0, 167, 0, 2, 0, 2,
+ax_anim 8, 0, 167, 0, 3, 0, 3,
+ax_anim_terminator
+sWeedleAnims_7_6:
+ax_anim 2, 0, 168, 2, 2, 2, 2,
+ax_anim 8, 0, 168, 3, 3, 3, 3,
+ax_anim_terminator
+sWeedleAnims_7_7:
+ax_anim 2, 0, 169, 2, 0, 2, 0,
+ax_anim 8, 0, 169, 3, 0, 3, 0,
+ax_anim_terminator
+sWeedleAnims_7_8:
+ax_anim 2, 0, 170, 2, -2, 2, -2,
+ax_anim 8, 0, 170, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWeedleAnims_8_1:
+ax_anim 40, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim 8, 0, 171, 0, 0, 0, 0,
+ax_anim 8, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_8_2:
+ax_anim 40, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim 8, 0, 174, 0, 0, 0, 0,
+ax_anim 8, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_8_3:
+ax_anim 40, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim 8, 0, 177, 0, 0, 0, 0,
+ax_anim 8, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_8_4:
+ax_anim 40, 0, 180, 0, 0, 0, 0,
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 180, 0, 0, 0, 0,
+ax_anim 8, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_8_5:
+ax_anim 40, 0, 183, 0, 0, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim 8, 0, 183, 0, 0, 0, 0,
+ax_anim 8, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_8_6:
+ax_anim 40, 0, 186, 0, 0, 0, 0,
+ax_anim 8, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 186, 0, 0, 0, 0,
+ax_anim 8, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_8_7:
+ax_anim 40, 0, 189, 0, 0, 0, 0,
+ax_anim 8, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 189, 0, 0, 0, 0,
+ax_anim 8, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_8_8:
+ax_anim 40, 0, 192, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim 8, 0, 192, 0, 0, 0, 0,
+ax_anim 8, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeedleAnims_9_1:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 8, 2, 8, 2,
+ax_anim 2, 0, 197, 11, 11, 11, 11,
+ax_anim 2, 0, 198, 9, 15, 9, 15,
+ax_anim 3, 0, 199, 1, 16, 1, 16,
+ax_anim 2, 3, 200, -9, 15, -9, 15,
+ax_anim 2, 0, 201, -11, 11, -11, 11,
+ax_anim 1, 0, 202, -8, 2, -8, 2,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_9_2:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 8, 0, 8, 0,
+ax_anim 2, 0, 196, 20, 2, 20, 2,
+ax_anim 2, 0, 197, 24, 9, 24, 9,
+ax_anim 3, 0, 198, 23, 16, 23, 16,
+ax_anim 2, 3, 199, 11, 19, 11, 19,
+ax_anim 2, 0, 200, 1, 14, 1, 14,
+ax_anim 1, 0, 201, -1, 7, -1, 7,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_9_3:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 3, -6, 3, -4,
+ax_anim 2, 0, 195, 11, -7, 11, -6,
+ax_anim 2, 0, 196, 18, -6, 17, -4,
+ax_anim 3, 0, 197, 20, 1, 20, 1,
+ax_anim 2, 3, 198, 17, 5, 17, 5,
+ax_anim 2, 0, 199, 10, 8, 12, 7,
+ax_anim 1, 0, 200, 2, 5, 4, 5,
+ax_anim 1, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_9_4:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, -1, -6, 1, -6,
+ax_anim 2, 0, 202, 2, -16, 4, -16,
+ax_anim 2, 0, 195, 9, -20, 11, -20,
+ax_anim 3, 0, 196, 16, -20, 16, -20,
+ax_anim 2, 3, 197, 17, -13, 16, -15,
+ax_anim 2, 0, 198, 14, -6, 14, -6,
+ax_anim 1, 0, 199, 7, -1, 7, -1,
+ax_anim 1, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_9_5:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, -6, -3, -6, -3,
+ax_anim 2, 0, 201, -8, -9, -8, -8,
+ax_anim 2, 0, 202, -7, -17, -7, -15,
+ax_anim 3, 0, 195, 0, -18, 0, -16,
+ax_anim 2, 3, 196, 7, -17, 7, -15,
+ax_anim 2, 0, 197, 8, -9, 8, -8,
+ax_anim 1, 0, 198, 6, -3, 6, -3,
+ax_anim 1, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_9_6:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 1, -6, -1, -6,
+ax_anim 2, 0, 196, -2, -16, -4, -16,
+ax_anim 2, 0, 195, -9, -20, -11, -20,
+ax_anim 3, 0, 202, -16, -20, -16, -20,
+ax_anim 2, 3, 201, -17, -13, -16, -15,
+ax_anim 2, 0, 200, -14, -6, -14, -6,
+ax_anim 1, 0, 199, -7, -1, -7, -1,
+ax_anim 1, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_9_7:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 196, -3, -6, -3, -6,
+ax_anim 2, 0, 195, -11, -7, -11, -7,
+ax_anim 2, 0, 202, -18, -6, -18, -6,
+ax_anim 3, 0, 201, -20, 1, -20, 1,
+ax_anim 2, 3, 200, -17, 5, -17, 5,
+ax_anim 2, 0, 199, -10, 8, -10, 8,
+ax_anim 1, 0, 198, -2, 5, -2, 5,
+ax_anim 1, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_9_8:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -8, 0, -6, 0,
+ax_anim 2, 0, 202, -20, 2, -17, 3,
+ax_anim 2, 0, 201, -24, 9, -24, 9,
+ax_anim 3, 0, 200, -23, 16, -23, 16,
+ax_anim 2, 3, 199, -11, 19, -11, 16,
+ax_anim 2, 0, 198, -1, 14, -4, 12,
+ax_anim 1, 0, 197, 1, 7, -3, 7,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeedleAnims_10_1:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 6, 0, 6, 0,
+ax_anim 2, 0, 203, -6, 0, -6, 0,
+ax_anim 2, 0, 203, 10, 0, 10, 0,
+ax_anim 2, 0, 203, -10, 0, -10, 0,
+ax_anim 2, 0, 203, 12, 0, 12, 0,
+ax_anim 3, 0, 203, -12, 0, -12, 0,
+ax_anim 3, 0, 203, 13, 0, 13, 0,
+ax_anim 3, 0, 203, -13, 0, -13, 0,
+ax_anim 2, 0, 203, 12, 0, 12, 0,
+ax_anim 3, 0, 203, -12, 0, -12, 0,
+ax_anim 2, 0, 203, 10, 0, 10, 0,
+ax_anim 2, 0, 203, -10, 0, -10, 0,
+ax_anim 2, 0, 203, 6, 0, 6, 0,
+ax_anim 2, 0, 203, -6, 0, -6, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_10_2:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 6, -6, 6, -6,
+ax_anim 2, 0, 204, -6, 6, -6, 6,
+ax_anim 2, 0, 204, 10, -10, 10, -10,
+ax_anim 2, 0, 204, -10, 10, -10, 10,
+ax_anim 2, 0, 204, 12, -12, 12, -12,
+ax_anim 3, 0, 204, -12, 12, -12, 12,
+ax_anim 3, 0, 204, 13, -13, 13, -13,
+ax_anim 3, 0, 204, -13, 13, -13, 13,
+ax_anim 2, 0, 204, 12, -12, 12, -12,
+ax_anim 3, 0, 204, -12, 12, -12, 12,
+ax_anim 2, 0, 204, 10, -10, 10, -10,
+ax_anim 2, 0, 204, -10, 10, -10, 10,
+ax_anim 2, 0, 204, 6, -6, 6, -6,
+ax_anim 2, 0, 204, -6, 6, -6, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_10_3:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, -6, 0, -6,
+ax_anim 2, 0, 205, 0, 6, 0, 6,
+ax_anim 2, 0, 205, 0, -10, 0, -10,
+ax_anim 2, 0, 205, 0, 10, 0, 10,
+ax_anim 2, 0, 205, 0, -12, 0, -12,
+ax_anim 3, 0, 205, 0, 12, 0, 12,
+ax_anim 3, 0, 205, 0, -13, 0, -13,
+ax_anim 3, 0, 205, 0, 13, 0, 13,
+ax_anim 2, 0, 205, 0, -12, 0, -12,
+ax_anim 3, 0, 205, 0, 12, 0, 12,
+ax_anim 2, 0, 205, 0, -10, 0, -10,
+ax_anim 2, 0, 205, 0, 10, 0, 10,
+ax_anim 2, 0, 205, 0, -6, 0, -6,
+ax_anim 2, 0, 205, 0, 6, 0, 6,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_10_4:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, -6, -6, -6, -6,
+ax_anim 2, 0, 206, 6, 6, 6, 6,
+ax_anim 2, 0, 206, -10, -10, -10, -10,
+ax_anim 2, 0, 206, 10, 10, 10, 10,
+ax_anim 2, 0, 206, -12, -12, -12, -12,
+ax_anim 3, 0, 206, 12, 12, 12, 12,
+ax_anim 3, 0, 206, -13, -13, -13, -13,
+ax_anim 3, 0, 206, 13, 13, 13, 13,
+ax_anim 2, 0, 206, -12, -12, -12, -12,
+ax_anim 3, 0, 206, 12, 12, 12, 12,
+ax_anim 2, 0, 206, -10, -10, -10, -10,
+ax_anim 2, 0, 206, 10, 10, 10, 10,
+ax_anim 2, 0, 206, -6, -6, -6, -6,
+ax_anim 2, 0, 206, 6, 6, 6, 6,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_10_5:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 6, 0, 6, 0,
+ax_anim 2, 0, 207, -6, 0, -6, 0,
+ax_anim 2, 0, 207, 10, 0, 10, 0,
+ax_anim 2, 0, 207, -10, 0, -10, 0,
+ax_anim 2, 0, 207, 12, 0, 12, 0,
+ax_anim 3, 0, 207, -12, 0, -12, 0,
+ax_anim 3, 0, 207, 13, 0, 13, 0,
+ax_anim 3, 0, 207, -13, 0, -13, 0,
+ax_anim 2, 0, 207, 12, 0, 12, 0,
+ax_anim 3, 0, 207, -12, 0, -12, 0,
+ax_anim 2, 0, 207, 10, 0, 10, 0,
+ax_anim 2, 0, 207, -10, 0, -10, 0,
+ax_anim 2, 0, 207, 6, 0, 6, 0,
+ax_anim 2, 0, 207, -6, 0, -6, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_10_6:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 6, -6, 6, -6,
+ax_anim 2, 0, 208, -6, 6, -6, 6,
+ax_anim 2, 0, 208, 10, -10, 10, -10,
+ax_anim 2, 0, 208, -10, 10, -10, 10,
+ax_anim 2, 0, 208, 12, -12, 12, -12,
+ax_anim 3, 0, 208, -12, 12, -12, 12,
+ax_anim 3, 0, 208, 13, -13, 13, -13,
+ax_anim 3, 0, 208, -13, 13, -13, 13,
+ax_anim 2, 0, 208, 12, -12, 12, -12,
+ax_anim 3, 0, 208, -12, 12, -12, 12,
+ax_anim 2, 0, 208, 10, -10, 10, -10,
+ax_anim 2, 0, 208, -10, 10, -10, 10,
+ax_anim 2, 0, 208, 6, -6, 6, -6,
+ax_anim 2, 0, 208, -6, 6, -6, 6,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_10_7:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -6, 0, -6,
+ax_anim 2, 0, 209, 0, 6, 0, 6,
+ax_anim 2, 0, 209, 0, -10, 0, -10,
+ax_anim 2, 0, 209, 0, 10, 0, 10,
+ax_anim 2, 0, 209, 0, -12, 0, -12,
+ax_anim 3, 0, 209, 0, 12, 0, 12,
+ax_anim 3, 0, 209, 0, -13, 0, -13,
+ax_anim 3, 0, 209, 0, 13, 0, 13,
+ax_anim 2, 0, 209, 0, -12, 0, -12,
+ax_anim 3, 0, 209, 0, 12, 0, 12,
+ax_anim 2, 0, 209, 0, -10, 0, -10,
+ax_anim 2, 0, 209, 0, 10, 0, 10,
+ax_anim 2, 0, 209, 0, -6, 0, -6,
+ax_anim 2, 0, 209, 0, 6, 0, 6,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_10_8:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, -6, -6, -6, -6,
+ax_anim 2, 0, 210, 6, 6, 6, 6,
+ax_anim 2, 0, 210, -10, -10, -10, -10,
+ax_anim 2, 0, 210, 10, 10, 10, 10,
+ax_anim 2, 0, 210, -12, -12, -12, -12,
+ax_anim 3, 0, 210, 12, 12, 12, 12,
+ax_anim 3, 0, 210, -13, -13, -13, -13,
+ax_anim 3, 0, 210, 13, 13, 13, 13,
+ax_anim 2, 0, 210, -12, -12, -12, -12,
+ax_anim 3, 0, 210, 12, 12, 12, 12,
+ax_anim 2, 0, 210, -10, -10, -10, -10,
+ax_anim 2, 0, 210, 10, 10, 10, 10,
+ax_anim 2, 0, 210, -6, -6, -6, -6,
+ax_anim 2, 0, 210, 6, 6, 6, 6,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeedleAnims_11_1:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 213, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, -3, 0, 0,
+ax_anim_terminator
+sWeedleAnims_11_2:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 216, 0, -23, 0, 0,
+ax_anim 3, 0, 216, 0, -22, 0, 0,
+ax_anim 2, 0, 216, 0, -18, 0, 0,
+ax_anim 1, 0, 216, 0, -12, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_11_3:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 219, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_11_4:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 222, 0, -22, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -17, 0, 0,
+ax_anim 1, 0, 222, 0, -11, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_11_5:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 225, 0, -10, 0, 0,
+ax_anim 2, 0, 225, 0, -16, 0, 0,
+ax_anim 3, 0, 225, 0, -20, 0, 0,
+ax_anim 4, 0, 225, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -17, 0, 0,
+ax_anim 3, 0, 224, 0, -16, 0, 0,
+ax_anim 2, 0, 224, 0, -12, 0, 0,
+ax_anim 1, 0, 224, 0, -6, 0, 0,
+ax_anim 2, 2, 223, 0, 2, 0, 0,
+ax_anim_terminator
+sWeedleAnims_11_6:
+ax_anim 2, 0, 226, 1, 0, 0, 0,
+ax_anim 1, 0, 227, 1, -10, 0, 0,
+ax_anim 2, 0, 227, 1, -16, 0, 0,
+ax_anim 3, 0, 227, 1, -20, 0, 0,
+ax_anim 4, 0, 227, 1, -21, 0, 0,
+ax_anim 4, 0, 228, 1, -22, 0, 0,
+ax_anim 3, 0, 228, 1, -21, 0, 0,
+ax_anim 2, 0, 228, 1, -17, 0, 0,
+ax_anim 1, 0, 228, 1, -11, 0, 0,
+ax_anim 2, 2, 226, 1, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_11_7:
+ax_anim 2, 0, 229, 1, 0, 0, 0,
+ax_anim 1, 0, 230, 1, -10, 0, 0,
+ax_anim 2, 0, 230, 1, -16, 0, 0,
+ax_anim 3, 0, 230, 1, -20, 0, 0,
+ax_anim 4, 0, 230, 1, -21, 0, 0,
+ax_anim 4, 0, 231, 1, -23, 0, 0,
+ax_anim 3, 0, 231, 1, -22, 0, 0,
+ax_anim 2, 0, 231, 1, -18, 0, 0,
+ax_anim 1, 0, 231, 1, -12, 0, 0,
+ax_anim 2, 2, 229, 1, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_11_8:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 1, 0, 233, 0, -10, 0, 0,
+ax_anim 2, 0, 233, 0, -16, 0, 0,
+ax_anim 3, 0, 233, 0, -20, 0, 0,
+ax_anim 4, 0, 233, 0, -21, 0, 0,
+ax_anim 4, 0, 234, 0, -23, 0, 0,
+ax_anim 3, 0, 234, 0, -22, 0, 0,
+ax_anim 2, 0, 234, 0, -18, 0, 0,
+ax_anim 1, 0, 234, 0, -12, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeedleAnims_12_1:
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 1, 0, 1, 0,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_12_2:
+ax_anim 2, 0, 242, 1, -1, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, -1, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, -1, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, -1, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, -1, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_12_3:
+ax_anim 2, 0, 241, 0, -1, 0, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, -1, 0, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, -1, 0, -1,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, -1, 0, -1,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, -1, 0, -1,
+ax_anim 2, 1, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_12_4:
+ax_anim 2, 0, 240, -1, -1, -1, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, -1, -1, -1, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, -1, -1, -1, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, -1, -1, -1, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, -1, -1, -1, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_12_5:
+ax_anim 2, 0, 239, 1, 0, 1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, 0, 1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, 0, 1, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, 0, 1, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 1, 0, 1, 0,
+ax_anim 2, 1, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_12_6:
+ax_anim 2, 0, 238, 1, -1, 1, -1,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, -1, 1, -1,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, -1, 1, -1,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, -1, 1, -1,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 1, -1, 1, -1,
+ax_anim 2, 1, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_12_7:
+ax_anim 2, 0, 237, 0, -1, 0, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, -1, 0, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, -1, 0, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, -1, 0, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, -1, 0, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_12_8:
+ax_anim 2, 0, 236, -1, -1, -1, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, -1, -1, -1, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, -1, -1, -1, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, -1, -1, -1, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, -1, -1, -1, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeedleAnims_13_1:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_13_2:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_13_3:
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_13_4:
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_13_5:
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_13_6:
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_13_7:
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleAnims_13_8:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sWeedleGfx1:
+.incbin "baserom.gba", 0x5A1750, 0x100
+sWeedleSprites1:
+ax_sprite sWeedleGfx1, 0x100
+ax_sprite_terminator
+sWeedleGfx2:
+.incbin "baserom.gba", 0x5A1860, 0x100
+sWeedleSprites2:
+ax_sprite sWeedleGfx2, 0x100
+ax_sprite_terminator
+sWeedleGfx3:
+.incbin "baserom.gba", 0x5A1970, 0x100
+sWeedleSprites3:
+ax_sprite sWeedleGfx3, 0x100
+ax_sprite_terminator
+sWeedleGfx4:
+.incbin "baserom.gba", 0x5A1A80, 0x200
+sWeedleSprites4:
+ax_sprite sWeedleGfx4, 0x200
+ax_sprite_terminator
+sWeedleGfx5:
+.incbin "baserom.gba", 0x5A1C90, 0x200
+sWeedleSprites5:
+ax_sprite sWeedleGfx5, 0x200
+ax_sprite_terminator
+sWeedleGfx6:
+.incbin "baserom.gba", 0x5A1EA0, 0x200
+sWeedleSprites6:
+ax_sprite sWeedleGfx6, 0x200
+ax_sprite_terminator
+sWeedleGfx7:
+.incbin "baserom.gba", 0x5A20B0, 0x200
+sWeedleSprites7:
+ax_sprite sWeedleGfx7, 0x200
+ax_sprite_terminator
+sWeedleGfx8:
+.incbin "baserom.gba", 0x5A22C0, 0x200
+sWeedleSprites8:
+ax_sprite sWeedleGfx8, 0x200
+ax_sprite_terminator
+sWeedleGfx9:
+.incbin "baserom.gba", 0x5A24D0, 0x200
+sWeedleSprites9:
+ax_sprite sWeedleGfx9, 0x200
+ax_sprite_terminator
+sWeedleGfx10:
+.incbin "baserom.gba", 0x5A26E0, 0x200
+sWeedleSprites10:
+ax_sprite sWeedleGfx10, 0x200
+ax_sprite_terminator
+sWeedleGfx11:
+.incbin "baserom.gba", 0x5A28F0, 0x200
+sWeedleSprites11:
+ax_sprite sWeedleGfx11, 0x200
+ax_sprite_terminator
+sWeedleGfx12:
+.incbin "baserom.gba", 0x5A2B00, 0x200
+sWeedleSprites12:
+ax_sprite sWeedleGfx12, 0x200
+ax_sprite_terminator
+sWeedleGfx13:
+.incbin "baserom.gba", 0x5A2D10, 0x100
+sWeedleSprites13:
+ax_sprite sWeedleGfx13, 0x100
+ax_sprite_terminator
+sWeedleGfx14:
+.incbin "baserom.gba", 0x5A2E20, 0x100
+sWeedleSprites14:
+ax_sprite sWeedleGfx14, 0x100
+ax_sprite_terminator
+sWeedleGfx15:
+.incbin "baserom.gba", 0x5A2F30, 0x100
+sWeedleSprites15:
+ax_sprite sWeedleGfx15, 0x100
+ax_sprite_terminator
+sWeedleGfx16:
+.incbin "baserom.gba", 0x5A3040, 0xC0
+sWeedleSprites16:
+ax_sprite sWeedleGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx17:
+.incbin "baserom.gba", 0x5A3118, 0x20
+sWeedleGfx17_1:
+.incbin "baserom.gba", 0x5A3138, 0xC0
+sWeedleSprites17:
+ax_sprite sWeedleGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx17_1, 0xc0
+ax_sprite_terminator
+sWeedleGfx18:
+.incbin "baserom.gba", 0x5A3218, 0x60
+sWeedleGfx18_1:
+.incbin "baserom.gba", 0x5A3278, 0x60
+sWeedleSprites18:
+ax_sprite sWeedleGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeedleGfx19:
+.incbin "baserom.gba", 0x5A3300, 0x40
+sWeedleGfx19_1:
+.incbin "baserom.gba", 0x5A3340, 0x80
+sWeedleSprites19:
+ax_sprite sWeedleGfx19, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeedleGfx19_1, 0x80
+ax_sprite_terminator
+sWeedleGfx20:
+.incbin "baserom.gba", 0x5A33E0, 0x40
+sWeedleGfx20_1:
+.incbin "baserom.gba", 0x5A3420, 0x60
+sWeedleGfx20_2:
+.incbin "baserom.gba", 0x5A3480, 0x60
+sWeedleSprites20:
+ax_sprite sWeedleGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeedleGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWeedleGfx20_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWeedleGfx21:
+.incbin "baserom.gba", 0x5A3518, 0x100
+sWeedleSprites21:
+ax_sprite sWeedleGfx21, 0x100
+ax_sprite_terminator
+sWeedleGfx22:
+.incbin "baserom.gba", 0x5A3628, 0x60
+sWeedleGfx22_1:
+.incbin "baserom.gba", 0x5A3688, 0x60
+sWeedleGfx22_2:
+.incbin "baserom.gba", 0x5A36E8, 0x40
+sWeedleSprites22:
+ax_sprite 0, 0x80
+ax_sprite sWeedleGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx22_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx23:
+.incbin "baserom.gba", 0x5A3768, 0x40
+sWeedleGfx23_1:
+.incbin "baserom.gba", 0x5A37A8, 0x60
+sWeedleGfx23_2:
+.incbin "baserom.gba", 0x5A3808, 0x40
+sWeedleSprites23:
+ax_sprite sWeedleGfx23, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeedleGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx23_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sWeedleGfx24:
+.incbin "baserom.gba", 0x5A3880, 0x60
+sWeedleGfx24_1:
+.incbin "baserom.gba", 0x5A38E0, 0x60
+sWeedleGfx24_2:
+.incbin "baserom.gba", 0x5A3940, 0x60
+sWeedleSprites24:
+ax_sprite sWeedleGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx24_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeedleGfx25:
+.incbin "baserom.gba", 0x5A39D8, 0xA0
+sWeedleSprites25:
+ax_sprite sWeedleGfx25, 0xa0
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sWeedleGfx26:
+.incbin "baserom.gba", 0x5A3A90, 0xC0
+sWeedleSprites26:
+ax_sprite sWeedleGfx26, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx27:
+.incbin "baserom.gba", 0x5A3B68, 0x20
+sWeedleGfx27_1:
+.incbin "baserom.gba", 0x5A3B88, 0x80
+sWeedleGfx27_2:
+.incbin "baserom.gba", 0x5A3C08, 0x20
+sWeedleSprites27:
+ax_sprite sWeedleGfx27, 0x20
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx27_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx27_2, 0x20
+ax_sprite_terminator
+sWeedleGfx28:
+.incbin "baserom.gba", 0x5A3C58, 0xC0
+sWeedleSprites28:
+ax_sprite sWeedleGfx28, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx29:
+.incbin "baserom.gba", 0x5A3D30, 0xC0
+sWeedleSprites29:
+ax_sprite sWeedleGfx29, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx30:
+.incbin "baserom.gba", 0x5A3E08, 0xC0
+sWeedleSprites30:
+ax_sprite sWeedleGfx30, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx31:
+.incbin "baserom.gba", 0x5A3EE0, 0xC0
+sWeedleSprites31:
+ax_sprite sWeedleGfx31, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx32:
+.incbin "baserom.gba", 0x5A3FB8, 0x40
+sWeedleGfx32_1:
+.incbin "baserom.gba", 0x5A3FF8, 0x60
+sWeedleGfx32_2:
+.incbin "baserom.gba", 0x5A4058, 0x40
+sWeedleSprites32:
+ax_sprite sWeedleGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeedleGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx32_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sWeedleGfx33:
+.incbin "baserom.gba", 0x5A40D0, 0x20
+sWeedleGfx33_1:
+.incbin "baserom.gba", 0x5A40F0, 0x60
+sWeedleGfx33_2:
+.incbin "baserom.gba", 0x5A4150, 0x40
+sWeedleSprites33:
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx33, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWeedleGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx33_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sWeedleGfx34:
+.incbin "baserom.gba", 0x5A41D0, 0xC0
+sWeedleSprites34:
+ax_sprite sWeedleGfx34, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeedleGfx35:
+.incbin "baserom.gba", 0x5A42A8, 0x20
+sWeedleGfx35_1:
+.incbin "baserom.gba", 0x5A42C8, 0x60
+sWeedleGfx35_2:
+.incbin "baserom.gba", 0x5A4328, 0x40
+sWeedleSprites35:
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx35, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWeedleGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeedleGfx35_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sWeedleGfx36:
+.incbin "baserom.gba", 0x5A43A8, 0x100
+sWeedleSprites36:
+ax_sprite sWeedleGfx36, 0x100
+ax_sprite_terminator
+sWeedleGfx37:
+.incbin "baserom.gba", 0x5A44B8, 0x100
+sWeedleSprites37:
+ax_sprite sWeedleGfx37, 0x100
+ax_sprite_terminator
+sWeedleGfx38:
+.incbin "baserom.gba", 0x5A45C8, 0x200
+sWeedleSprites38:
+ax_sprite sWeedleGfx38, 0x200
+ax_sprite_terminator
+sWeedleGfx39:
+.incbin "baserom.gba", 0x5A47D8, 0x200
+sWeedleSprites39:
+ax_sprite sWeedleGfx39, 0x200
+ax_sprite_terminator
+sWeedleGfx40:
+.incbin "baserom.gba", 0x5A49E8, 0x200
+sWeedleSprites40:
+ax_sprite sWeedleGfx40, 0x200
+ax_sprite_terminator
+sWeedleGfx41:
+.incbin "baserom.gba", 0x5A4BF8, 0x200
+sWeedleSprites41:
+ax_sprite sWeedleGfx41, 0x200
+ax_sprite_terminator
+sWeedleGfx42:
+.incbin "baserom.gba", 0x5A4E08, 0x200
+sWeedleSprites42:
+ax_sprite sWeedleGfx42, 0x200
+ax_sprite_terminator
+sAxPosesWeedle:
+.4byte sWeedlePose1
+.4byte sWeedlePose2
+.4byte sWeedlePose3
+.4byte sWeedlePose4
+.4byte sWeedlePose5
+.4byte sWeedlePose6
+.4byte sWeedlePose7
+.4byte sWeedlePose8
+.4byte sWeedlePose9
+.4byte sWeedlePose10
+.4byte sWeedlePose11
+.4byte sWeedlePose12
+.4byte sWeedlePose13
+.4byte sWeedlePose14
+.4byte sWeedlePose15
+.4byte sWeedlePose16
+.4byte sWeedlePose17
+.4byte sWeedlePose18
+.4byte sWeedlePose19
+.4byte sWeedlePose20
+.4byte sWeedlePose21
+.4byte sWeedlePose22
+.4byte sWeedlePose23
+.4byte sWeedlePose24
+.4byte sWeedlePose25
+.4byte sWeedlePose26
+.4byte sWeedlePose27
+.4byte sWeedlePose28
+.4byte sWeedlePose29
+.4byte sWeedlePose30
+.4byte sWeedlePose31
+.4byte sWeedlePose32
+.4byte sWeedlePose33
+.4byte sWeedlePose34
+.4byte sWeedlePose35
+.4byte sWeedlePose36
+.4byte sWeedlePose37
+.4byte sWeedlePose38
+.4byte sWeedlePose39
+.4byte sWeedlePose40
+.4byte sWeedlePose41
+.4byte sWeedlePose42
+.4byte sWeedlePose43
+.4byte sWeedlePose44
+.4byte sWeedlePose45
+.4byte sWeedlePose46
+.4byte sWeedlePose47
+.4byte sWeedlePose48
+.4byte sWeedlePose49
+.4byte sWeedlePose50
+.4byte sWeedlePose51
+.4byte sWeedlePose52
+.4byte sWeedlePose53
+.4byte sWeedlePose54
+.4byte sWeedlePose55
+.4byte sWeedlePose56
+.4byte sWeedlePose57
+.4byte sWeedlePose58
+.4byte sWeedlePose59
+.4byte sWeedlePose60
+.4byte sWeedlePose61
+.4byte sWeedlePose62
+.4byte sWeedlePose63
+.4byte sWeedlePose64
+.4byte sWeedlePose65
+.4byte sWeedlePose66
+.4byte sWeedlePose67
+.4byte sWeedlePose68
+.4byte sWeedlePose69
+.4byte sWeedlePose70
+.4byte sWeedlePose71
+.4byte sWeedlePose72
+.4byte sWeedlePose73
+.4byte sWeedlePose74
+.4byte sWeedlePose75
+.4byte sWeedlePose76
+.4byte sWeedlePose77
+.4byte sWeedlePose78
+.4byte sWeedlePose79
+.4byte sWeedlePose80
+.4byte sWeedlePose81
+.4byte sWeedlePose82
+.4byte sWeedlePose83
+.4byte sWeedlePose84
+.4byte sWeedlePose85
+.4byte sWeedlePose86
+.4byte sWeedlePose87
+.4byte sWeedlePose88
+.4byte sWeedlePose89
+.4byte sWeedlePose90
+.4byte sWeedlePose91
+.4byte sWeedlePose92
+.4byte sWeedlePose93
+.4byte sWeedlePose94
+.4byte sWeedlePose95
+.4byte sWeedlePose96
+.4byte sWeedlePose97
+.4byte sWeedlePose98
+.4byte sWeedlePose99
+.4byte sWeedlePose100
+.4byte sWeedlePose101
+.4byte sWeedlePose102
+.4byte sWeedlePose103
+.4byte sWeedlePose104
+.4byte sWeedlePose105
+.4byte sWeedlePose106
+.4byte sWeedlePose107
+.4byte sWeedlePose108
+.4byte sWeedlePose109
+.4byte sWeedlePose110
+.4byte sWeedlePose111
+.4byte sWeedlePose112
+.4byte sWeedlePose113
+.4byte sWeedlePose114
+.4byte sWeedlePose115
+.4byte sWeedlePose116
+.4byte sWeedlePose117
+.4byte sWeedlePose118
+.4byte sWeedlePose119
+.4byte sWeedlePose120
+.4byte sWeedlePose121
+.4byte sWeedlePose122
+.4byte sWeedlePose123
+.4byte sWeedlePose124
+.4byte sWeedlePose125
+.4byte sWeedlePose126
+.4byte sWeedlePose127
+.4byte sWeedlePose128
+.4byte sWeedlePose129
+.4byte sWeedlePose130
+.4byte sWeedlePose131
+.4byte sWeedlePose132
+.4byte sWeedlePose133
+.4byte sWeedlePose134
+.4byte sWeedlePose135
+.4byte sWeedlePose136
+.4byte sWeedlePose137
+.4byte sWeedlePose138
+.4byte sWeedlePose139
+.4byte sWeedlePose140
+.4byte sWeedlePose141
+.4byte sWeedlePose142
+.4byte sWeedlePose143
+.4byte sWeedlePose144
+.4byte sWeedlePose145
+.4byte sWeedlePose146
+.4byte sWeedlePose147
+.4byte sWeedlePose148
+.4byte sWeedlePose149
+.4byte sWeedlePose150
+.4byte sWeedlePose151
+.4byte sWeedlePose152
+.4byte sWeedlePose153
+.4byte sWeedlePose154
+.4byte sWeedlePose155
+.4byte sWeedlePose156
+.4byte sWeedlePose157
+.4byte sWeedlePose158
+.4byte sWeedlePose159
+.4byte sWeedlePose160
+.4byte sWeedlePose161
+.4byte sWeedlePose162
+.4byte sWeedlePose163
+.4byte sWeedlePose164
+.4byte sWeedlePose165
+.4byte sWeedlePose166
+.4byte sWeedlePose167
+.4byte sWeedlePose168
+.4byte sWeedlePose169
+.4byte sWeedlePose170
+.4byte sWeedlePose171
+.4byte sWeedlePose172
+.4byte sWeedlePose173
+.4byte sWeedlePose174
+.4byte sWeedlePose175
+.4byte sWeedlePose176
+.4byte sWeedlePose177
+.4byte sWeedlePose178
+.4byte sWeedlePose179
+.4byte sWeedlePose180
+.4byte sWeedlePose181
+.4byte sWeedlePose182
+.4byte sWeedlePose183
+.4byte sWeedlePose184
+.4byte sWeedlePose185
+.4byte sWeedlePose186
+.4byte sWeedlePose187
+.4byte sWeedlePose188
+.4byte sWeedlePose189
+.4byte sWeedlePose190
+.4byte sWeedlePose191
+.4byte sWeedlePose192
+.4byte sWeedlePose193
+.4byte sWeedlePose194
+.4byte sWeedlePose195
+.4byte sWeedlePose196
+.4byte sWeedlePose197
+.4byte sWeedlePose198
+.4byte sWeedlePose199
+.4byte sWeedlePose200
+.4byte sWeedlePose201
+.4byte sWeedlePose202
+.4byte sWeedlePose203
+.4byte sWeedlePose204
+.4byte sWeedlePose205
+.4byte sWeedlePose206
+.4byte sWeedlePose207
+.4byte sWeedlePose208
+.4byte sWeedlePose209
+.4byte sWeedlePose210
+.4byte sWeedlePose211
+.4byte sWeedlePose212
+.4byte sWeedlePose213
+.4byte sWeedlePose214
+.4byte sWeedlePose215
+.4byte sWeedlePose216
+.4byte sWeedlePose217
+.4byte sWeedlePose218
+.4byte sWeedlePose219
+.4byte sWeedlePose220
+.4byte sWeedlePose221
+.4byte sWeedlePose222
+.4byte sWeedlePose223
+.4byte sWeedlePose224
+.4byte sWeedlePose225
+.4byte sWeedlePose226
+.4byte sWeedlePose227
+.4byte sWeedlePose228
+.4byte sWeedlePose229
+.4byte sWeedlePose230
+.4byte sWeedlePose231
+.4byte sWeedlePose232
+.4byte sWeedlePose233
+.4byte sWeedlePose234
+.4byte sWeedlePose235
+.4byte sWeedlePose236
+.4byte sWeedlePose237
+.4byte sWeedlePose238
+.4byte sWeedlePose239
+.4byte sWeedlePose240
+.4byte sWeedlePose241
+.4byte sWeedlePose242
+.4byte sWeedlePose243
+.4byte sWeedlePose244
+.4byte sWeedlePose245
+.4byte sWeedlePose246
+.4byte sWeedlePose247
+.4byte sWeedlePose248
+.4byte sWeedlePose249
+.4byte sWeedlePose250
+.4byte sWeedlePose251
+sAxPositionsWeedle:
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+.2byte    8,   -8, 	   4,   -4, 	   1,   -3, 	   2,   -5
+.2byte    7,   -9, 	   4,   -5, 	   1,   -4, 	   2,   -6
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte   11,  -11, 	   5,   -6, 	   4,   -4, 	   4,   -6
+.2byte   10,  -12, 	   5,   -7, 	   4,   -5, 	   4,   -7
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte    8,  -14, 	   3,   -6, 	   5,   -5, 	   3,   -7
+.2byte    9,  -15, 	   3,   -7, 	   5,   -6, 	   3,   -8
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte   -1,  -17, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -18, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte  -10,  -14, 	  -5,   -6, 	  -7,   -5, 	  -5,   -7
+.2byte  -11,  -15, 	  -5,   -7, 	  -7,   -6, 	  -5,   -8
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte  -13,  -11, 	  -7,   -6, 	  -6,   -4, 	  -6,   -6
+.2byte  -12,  -12, 	  -7,   -7, 	  -6,   -5, 	  -6,   -7
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte  -10,   -8, 	  -6,   -4, 	  -3,   -3, 	  -4,   -5
+.2byte   -9,   -9, 	  -6,   -5, 	  -3,   -4, 	  -4,   -6
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -6
+.2byte   -1,    3, 	  -3,   -2, 	   1,   -2, 	  -1,   -5
+.2byte   -1,    1, 	  -3,   -4, 	   1,   -4, 	  -1,   -7
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+.2byte    8,   -8, 	   4,   -4, 	   1,   -3, 	   2,   -5
+.2byte    7,   -9, 	   4,   -5, 	   1,   -4, 	   2,   -6
+.2byte    7,    2, 	   2,   -1, 	   0,    0, 	  -1,   -3
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte   11,  -11, 	   5,   -6, 	   4,   -4, 	   4,   -6
+.2byte   10,  -12, 	   5,   -7, 	   4,   -5, 	   4,   -7
+.2byte   10,   -3, 	   2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte    8,  -14, 	   3,   -6, 	   5,   -5, 	   3,   -7
+.2byte    9,  -15, 	   3,   -7, 	   5,   -6, 	   3,   -8
+.2byte   10,   -6, 	   0,   -4, 	   2,   -3, 	  -2,   -2
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte   -1,  -17, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -18, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -4
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte  -10,  -14, 	  -5,   -6, 	  -7,   -5, 	  -5,   -7
+.2byte  -11,  -15, 	  -5,   -7, 	  -7,   -6, 	  -5,   -8
+.2byte  -12,   -6, 	  -2,   -4, 	  -4,   -3, 	   0,   -2
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte  -13,  -11, 	  -7,   -6, 	  -6,   -4, 	  -6,   -6
+.2byte  -12,  -12, 	  -7,   -7, 	  -6,   -5, 	  -6,   -7
+.2byte  -12,   -3, 	  -4,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte  -10,   -8, 	  -6,   -4, 	  -3,   -3, 	  -4,   -5
+.2byte   -9,   -9, 	  -6,   -5, 	  -3,   -4, 	  -4,   -6
+.2byte   -9,    2, 	  -4,   -1, 	  -2,    0, 	  -1,   -3
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -6
+.2byte   -1,    3, 	  -3,   -2, 	   1,   -2, 	  -1,   -5
+.2byte   -1,    2, 	  -3,   -3, 	   1,   -3, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+.2byte    8,   -8, 	   4,   -4, 	   1,   -3, 	   2,   -5
+.2byte    7,   -9, 	   4,   -5, 	   1,   -4, 	   2,   -6
+.2byte    7,    2, 	   2,   -1, 	   0,    0, 	  -1,   -3
+.2byte    7,    2, 	   2,   -1, 	   0,    0, 	  -1,   -3
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte   11,  -11, 	   5,   -6, 	   4,   -4, 	   4,   -6
+.2byte   10,  -12, 	   5,   -7, 	   4,   -5, 	   4,   -7
+.2byte   10,   -3, 	   2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte   10,   -3, 	   2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte    8,  -14, 	   3,   -6, 	   5,   -5, 	   3,   -7
+.2byte    9,  -15, 	   3,   -7, 	   5,   -6, 	   3,   -8
+.2byte   10,   -6, 	   0,   -4, 	   2,   -3, 	  -2,   -2
+.2byte   10,   -6, 	   0,   -4, 	   2,   -3, 	  -2,   -2
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte   -1,  -17, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -18, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -4
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -4
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte  -10,  -14, 	  -5,   -6, 	  -7,   -5, 	  -5,   -7
+.2byte  -11,  -15, 	  -5,   -7, 	  -7,   -6, 	  -5,   -8
+.2byte  -12,   -6, 	  -2,   -4, 	  -4,   -3, 	   0,   -2
+.2byte  -12,   -6, 	  -2,   -4, 	  -4,   -3, 	   0,   -2
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte  -13,  -11, 	  -7,   -6, 	  -6,   -4, 	  -6,   -6
+.2byte  -12,  -12, 	  -7,   -7, 	  -6,   -5, 	  -6,   -7
+.2byte  -12,   -3, 	  -4,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte  -12,   -3, 	  -4,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte  -10,   -8, 	  -6,   -4, 	  -3,   -3, 	  -4,   -5
+.2byte   -9,   -9, 	  -6,   -5, 	  -3,   -4, 	  -4,   -6
+.2byte   -9,    2, 	  -4,   -1, 	  -2,    0, 	  -1,   -3
+.2byte   -9,    2, 	  -4,   -1, 	  -2,    0, 	  -1,   -3
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte    2,    1, 	  -4,   -3, 	  -1,   -3, 	   0,   -5
+.2byte    2,    3, 	  -5,   -3, 	  -2,   -3, 	  -1,   -4
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+.2byte    5,    0, 	   3,   -4, 	   1,   -3, 	   0,   -4
+.2byte    5,    2, 	   3,   -4, 	   1,   -3, 	   0,   -4
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte    7,   -5, 	  -1,   -7, 	  -2,   -5, 	  -3,   -6
+.2byte    7,   -2, 	   0,   -7, 	  -1,   -5, 	  -2,   -6
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte    7,   -7, 	  -3,   -7, 	  -1,   -6, 	  -3,   -6
+.2byte    7,   -5, 	  -3,   -6, 	  -1,   -5, 	  -3,   -5
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte   -6,  -10, 	   2,   -2, 	   0,   -3, 	   1,   -4
+.2byte   -6,   -7, 	   3,   -2, 	   1,   -3, 	   2,   -4
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte   -9,   -7, 	   1,   -7, 	  -1,   -6, 	   1,   -6
+.2byte   -9,   -5, 	   1,   -6, 	  -1,   -5, 	   1,   -5
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte   -9,   -5, 	  -1,   -7, 	   0,   -5, 	   1,   -6
+.2byte   -9,   -2, 	  -2,   -7, 	  -1,   -5, 	   0,   -6
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte   -5,    0, 	  -3,   -4, 	  -1,   -3, 	   0,   -4
+.2byte   -5,    2, 	  -3,   -4, 	  -1,   -3, 	   0,   -4
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -6
+.2byte   -1,    3, 	  -3,   -2, 	   1,   -2, 	  -1,   -5
+.2byte   -1,    2, 	  -3,   -3, 	   1,   -3, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+.2byte    8,   -8, 	   4,   -4, 	   1,   -3, 	   2,   -5
+.2byte    7,   -9, 	   4,   -5, 	   1,   -4, 	   2,   -6
+.2byte    7,    2, 	   2,   -1, 	   0,    0, 	  -1,   -3
+.2byte    7,    2, 	   2,   -1, 	   0,    0, 	  -1,   -3
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte   11,  -11, 	   5,   -6, 	   4,   -4, 	   4,   -6
+.2byte   10,  -12, 	   5,   -7, 	   4,   -5, 	   4,   -7
+.2byte   10,   -3, 	   2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte   10,   -3, 	   2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte    8,  -14, 	   3,   -6, 	   5,   -5, 	   3,   -7
+.2byte    9,  -15, 	   3,   -7, 	   5,   -6, 	   3,   -8
+.2byte   10,   -6, 	   0,   -4, 	   2,   -3, 	  -2,   -2
+.2byte   10,   -6, 	   0,   -4, 	   2,   -3, 	  -2,   -2
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte   -1,  -17, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -18, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -4
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -4
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte  -10,  -14, 	  -5,   -6, 	  -7,   -5, 	  -5,   -7
+.2byte  -11,  -15, 	  -5,   -7, 	  -7,   -6, 	  -5,   -8
+.2byte  -12,   -6, 	  -2,   -4, 	  -4,   -3, 	   0,   -2
+.2byte  -12,   -6, 	  -2,   -4, 	  -4,   -3, 	   0,   -2
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte  -13,  -11, 	  -7,   -6, 	  -6,   -4, 	  -6,   -6
+.2byte  -12,  -12, 	  -7,   -7, 	  -6,   -5, 	  -6,   -7
+.2byte  -12,   -3, 	  -4,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte  -12,   -3, 	  -4,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte  -10,   -8, 	  -6,   -4, 	  -3,   -3, 	  -4,   -5
+.2byte   -9,   -9, 	  -6,   -5, 	  -3,   -4, 	  -4,   -6
+.2byte   -9,    2, 	  -4,   -1, 	  -2,    0, 	  -1,   -3
+.2byte   -9,    2, 	  -4,   -1, 	  -2,    0, 	  -1,   -3
+.2byte   -6,   -6, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte   -7,   -5, 	   2,   -5, 	   1,   -4, 	   0,   -6
+.2byte   -1,  -12, 	  -3,   -7, 	   1,   -7, 	  -1,   -9
+.2byte    0,  -14, 	   0,  -10, 	  -2,   -8, 	  -3,   -8
+.2byte    3,  -17, 	   0,   -8, 	   0,   -7, 	  -2,   -8
+.2byte    2,  -17, 	   1,   -8, 	   2,   -7, 	  -1,   -7
+.2byte   -1,  -16, 	   1,   -5, 	  -3,   -5, 	  -1,   -6
+.2byte   -3,  -17, 	  -2,   -8, 	  -3,   -7, 	   0,   -7
+.2byte   -4,  -17, 	  -1,   -8, 	  -1,   -7, 	   1,   -8
+.2byte   -1,  -14, 	  -1,  -10, 	   1,   -8, 	   2,   -8
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -1,   -7, 	  -3,   -4, 	   1,   -4, 	  -1,   -6
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+.2byte    8,   -8, 	   4,   -4, 	   1,   -3, 	   2,   -5
+.2byte    7,   -9, 	   4,   -5, 	   1,   -4, 	   2,   -6
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte   11,  -11, 	   5,   -6, 	   4,   -4, 	   4,   -6
+.2byte   10,  -12, 	   5,   -7, 	   4,   -5, 	   4,   -7
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte    8,  -14, 	   3,   -6, 	   5,   -5, 	   3,   -7
+.2byte    9,  -15, 	   3,   -7, 	   5,   -6, 	   3,   -8
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte   -1,  -17, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -18, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte  -10,  -14, 	  -5,   -6, 	  -7,   -5, 	  -5,   -7
+.2byte  -11,  -15, 	  -5,   -7, 	  -7,   -6, 	  -5,   -8
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte  -13,  -11, 	  -7,   -6, 	  -6,   -4, 	  -6,   -6
+.2byte  -12,  -12, 	  -7,   -7, 	  -6,   -5, 	  -6,   -7
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte  -10,   -8, 	  -6,   -4, 	  -3,   -3, 	  -4,   -5
+.2byte   -9,   -9, 	  -6,   -5, 	  -3,   -4, 	  -4,   -6
+.2byte   -1,    4, 	  -3,   -1, 	   1,   -1, 	  -1,   -4
+.2byte   -9,    3, 	  -4,    0, 	  -2,    1, 	  -1,   -2
+.2byte  -12,   -3, 	  -4,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte  -12,   -7, 	  -2,   -5, 	  -4,   -4, 	   0,   -3
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -4
+.2byte   10,   -7, 	   0,   -5, 	   2,   -4, 	  -2,   -3
+.2byte   10,   -3, 	   2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    7,    3, 	   2,    0, 	   0,    1, 	  -1,   -2
+.2byte    2,    1, 	  -4,   -3, 	  -1,   -3, 	   0,   -5
+.2byte    5,    0, 	   3,   -4, 	   1,   -3, 	   0,   -4
+.2byte    7,   -5, 	  -1,   -7, 	  -2,   -5, 	  -3,   -6
+.2byte    7,   -7, 	  -3,   -7, 	  -1,   -6, 	  -3,   -6
+.2byte   -6,  -10, 	   2,   -2, 	   0,   -3, 	   1,   -4
+.2byte   -9,   -7, 	   1,   -7, 	  -1,   -6, 	   1,   -6
+.2byte   -9,   -5, 	  -1,   -7, 	   0,   -5, 	   1,   -6
+.2byte   -5,    0, 	  -3,   -4, 	  -1,   -3, 	   0,   -4
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte   -1,    3, 	  -3,   -2, 	   1,   -2, 	  -1,   -5
+.2byte    8,   -8, 	   4,   -4, 	   1,   -3, 	   2,   -5
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+.2byte    7,    2, 	   2,   -1, 	   0,    0, 	  -1,   -3
+.2byte   11,  -11, 	   5,   -6, 	   4,   -4, 	   4,   -6
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte   10,   -3, 	   2,   -4, 	   1,   -3, 	  -1,   -3
+.2byte    8,  -14, 	   3,   -6, 	   5,   -5, 	   3,   -7
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte   10,   -6, 	   0,   -4, 	   2,   -3, 	  -2,   -2
+.2byte   -1,  -17, 	   1,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte   -1,  -11, 	   1,   -5, 	  -3,   -5, 	  -1,   -4
+.2byte  -10,  -14, 	  -5,   -6, 	  -7,   -5, 	  -5,   -7
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte  -12,   -6, 	  -2,   -4, 	  -4,   -3, 	   0,   -2
+.2byte  -13,  -11, 	  -7,   -6, 	  -6,   -4, 	  -6,   -6
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte  -12,   -3, 	  -4,   -4, 	  -3,   -3, 	  -1,   -3
+.2byte  -10,   -8, 	  -6,   -4, 	  -3,   -3, 	  -4,   -5
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte   -9,    2, 	  -4,   -1, 	  -2,    0, 	  -1,   -3
+.2byte   -1,   -6, 	  -3,   -3, 	   1,   -3, 	  -1,   -5
+.2byte  -10,   -7, 	  -6,   -3, 	  -3,   -2, 	  -4,   -4
+.2byte  -11,  -10, 	  -5,   -5, 	  -4,   -3, 	  -4,   -5
+.2byte   -8,  -13, 	  -3,   -5, 	  -5,   -4, 	  -3,   -6
+.2byte   -1,  -16, 	   1,   -6, 	  -3,   -6, 	  -1,   -8
+.2byte    6,  -13, 	   1,   -5, 	   3,   -4, 	   1,   -6
+.2byte    9,  -10, 	   3,   -5, 	   2,   -3, 	   2,   -5
+.2byte    8,   -7, 	   4,   -3, 	   1,   -2, 	   2,   -4
+.2byte   -1,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -7
+.2byte   -9,  -10, 	  -6,   -6, 	  -3,   -5, 	  -4,   -7
+.2byte  -12,  -13, 	  -7,   -8, 	  -6,   -6, 	  -6,   -8
+.2byte  -10,  -16, 	  -4,   -8, 	  -7,   -7, 	  -5,   -9
+.2byte   -1,  -19, 	   1,   -9, 	  -3,   -9, 	  -1,   -9
+.2byte    8,  -16, 	   2,   -8, 	   5,   -7, 	   3,   -9
+.2byte   10,  -13, 	   5,   -8, 	   4,   -6, 	   4,   -8
+.2byte    7,  -10, 	   4,   -6, 	   1,   -5, 	   2,   -7
+sWeedleAnimTable1:
+.4byte sWeedleAnims_1_1
+.4byte sWeedleAnims_1_2
+.4byte sWeedleAnims_1_3
+.4byte sWeedleAnims_1_4
+.4byte sWeedleAnims_1_5
+.4byte sWeedleAnims_1_6
+.4byte sWeedleAnims_1_7
+.4byte sWeedleAnims_1_8
+sWeedleAnimTable2:
+.4byte sWeedleAnims_2_1
+.4byte sWeedleAnims_2_2
+.4byte sWeedleAnims_2_3
+.4byte sWeedleAnims_2_4
+.4byte sWeedleAnims_2_5
+.4byte sWeedleAnims_2_6
+.4byte sWeedleAnims_2_7
+.4byte sWeedleAnims_2_8
+sWeedleAnimTable3:
+.4byte sWeedleAnims_3_1
+.4byte sWeedleAnims_3_2
+.4byte sWeedleAnims_3_3
+.4byte sWeedleAnims_3_4
+.4byte sWeedleAnims_3_5
+.4byte sWeedleAnims_3_6
+.4byte sWeedleAnims_3_7
+.4byte sWeedleAnims_3_8
+sWeedleAnimTable4:
+.4byte sWeedleAnims_4_1
+.4byte sWeedleAnims_4_2
+.4byte sWeedleAnims_4_3
+.4byte sWeedleAnims_4_4
+.4byte sWeedleAnims_4_5
+.4byte sWeedleAnims_4_6
+.4byte sWeedleAnims_4_7
+.4byte sWeedleAnims_4_8
+sWeedleAnimTable5:
+.4byte sWeedleAnims_5_1
+.4byte sWeedleAnims_5_2
+.4byte sWeedleAnims_5_3
+.4byte sWeedleAnims_5_4
+.4byte sWeedleAnims_5_5
+.4byte sWeedleAnims_5_6
+.4byte sWeedleAnims_5_7
+.4byte sWeedleAnims_5_8
+sWeedleAnimTable6:
+.4byte sWeedleAnims_6_1
+.4byte sWeedleAnims_6_1
+.4byte sWeedleAnims_6_1
+.4byte sWeedleAnims_6_1
+.4byte sWeedleAnims_6_1
+.4byte sWeedleAnims_6_1
+.4byte sWeedleAnims_6_1
+.4byte sWeedleAnims_6_1
+sWeedleAnimTable7:
+.4byte sWeedleAnims_7_1
+.4byte sWeedleAnims_7_2
+.4byte sWeedleAnims_7_3
+.4byte sWeedleAnims_7_4
+.4byte sWeedleAnims_7_5
+.4byte sWeedleAnims_7_6
+.4byte sWeedleAnims_7_7
+.4byte sWeedleAnims_7_8
+sWeedleAnimTable8:
+.4byte sWeedleAnims_8_1
+.4byte sWeedleAnims_8_2
+.4byte sWeedleAnims_8_3
+.4byte sWeedleAnims_8_4
+.4byte sWeedleAnims_8_5
+.4byte sWeedleAnims_8_6
+.4byte sWeedleAnims_8_7
+.4byte sWeedleAnims_8_8
+sWeedleAnimTable9:
+.4byte sWeedleAnims_9_1
+.4byte sWeedleAnims_9_2
+.4byte sWeedleAnims_9_3
+.4byte sWeedleAnims_9_4
+.4byte sWeedleAnims_9_5
+.4byte sWeedleAnims_9_6
+.4byte sWeedleAnims_9_7
+.4byte sWeedleAnims_9_8
+sWeedleAnimTable10:
+.4byte sWeedleAnims_10_1
+.4byte sWeedleAnims_10_2
+.4byte sWeedleAnims_10_3
+.4byte sWeedleAnims_10_4
+.4byte sWeedleAnims_10_5
+.4byte sWeedleAnims_10_6
+.4byte sWeedleAnims_10_7
+.4byte sWeedleAnims_10_8
+sWeedleAnimTable11:
+.4byte sWeedleAnims_11_1
+.4byte sWeedleAnims_11_2
+.4byte sWeedleAnims_11_3
+.4byte sWeedleAnims_11_4
+.4byte sWeedleAnims_11_5
+.4byte sWeedleAnims_11_6
+.4byte sWeedleAnims_11_7
+.4byte sWeedleAnims_11_8
+sWeedleAnimTable12:
+.4byte sWeedleAnims_12_1
+.4byte sWeedleAnims_12_2
+.4byte sWeedleAnims_12_3
+.4byte sWeedleAnims_12_4
+.4byte sWeedleAnims_12_5
+.4byte sWeedleAnims_12_6
+.4byte sWeedleAnims_12_7
+.4byte sWeedleAnims_12_8
+sWeedleAnimTable13:
+.4byte sWeedleAnims_13_1
+.4byte sWeedleAnims_13_2
+.4byte sWeedleAnims_13_3
+.4byte sWeedleAnims_13_4
+.4byte sWeedleAnims_13_5
+.4byte sWeedleAnims_13_6
+.4byte sWeedleAnims_13_7
+.4byte sWeedleAnims_13_8
+sAxAnimationsWeedle:
+.4byte sWeedleAnimTable1
+.4byte sWeedleAnimTable2
+.4byte sWeedleAnimTable3
+.4byte sWeedleAnimTable4
+.4byte sWeedleAnimTable5
+.4byte sWeedleAnimTable6
+.4byte sWeedleAnimTable7
+.4byte sWeedleAnimTable8
+.4byte sWeedleAnimTable9
+.4byte sWeedleAnimTable10
+.4byte sWeedleAnimTable11
+.4byte sWeedleAnimTable12
+.4byte sWeedleAnimTable13
+sAxSpritesWeedle:
+.4byte sWeedleSprites1
+.4byte sWeedleSprites2
+.4byte sWeedleSprites3
+.4byte sWeedleSprites4
+.4byte sWeedleSprites5
+.4byte sWeedleSprites6
+.4byte sWeedleSprites7
+.4byte sWeedleSprites8
+.4byte sWeedleSprites9
+.4byte sWeedleSprites10
+.4byte sWeedleSprites11
+.4byte sWeedleSprites12
+.4byte sWeedleSprites13
+.4byte sWeedleSprites14
+.4byte sWeedleSprites15
+.4byte sWeedleSprites16
+.4byte sWeedleSprites17
+.4byte sWeedleSprites18
+.4byte sWeedleSprites19
+.4byte sWeedleSprites20
+.4byte sWeedleSprites21
+.4byte sWeedleSprites22
+.4byte sWeedleSprites23
+.4byte sWeedleSprites24
+.4byte sWeedleSprites25
+.4byte sWeedleSprites26
+.4byte sWeedleSprites27
+.4byte sWeedleSprites28
+.4byte sWeedleSprites29
+.4byte sWeedleSprites30
+.4byte sWeedleSprites31
+.4byte sWeedleSprites32
+.4byte sWeedleSprites33
+.4byte sWeedleSprites34
+.4byte sWeedleSprites35
+.4byte sWeedleSprites36
+.4byte sWeedleSprites37
+.4byte sWeedleSprites38
+.4byte sWeedleSprites39
+.4byte sWeedleSprites40
+.4byte sWeedleSprites41
+.4byte sWeedleSprites42
+sAxMainWeedle:
+ax_main sAxPosesWeedle, sAxAnimationsWeedle, 13, sAxSpritesWeedle, sAxPositionsWeedle

--- a/data/ax/weepinbell.inc
+++ b/data/ax/weepinbell.inc
@@ -1,0 +1,2933 @@
+.global gAxWeepinbell
+gAxWeepinbell:
+ax_siro sAxMainWeepinbell
+sWeepinbellPose1:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose4:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose5:
+ax_pose 4, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose6:
+ax_pose 5, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose7:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose8:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose9:
+ax_pose 8, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose10:
+ax_pose 9, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose11:
+ax_pose 10, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose12:
+ax_pose 11, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose13:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose16:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose17:
+ax_pose 16, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose18:
+ax_pose 17, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose19:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose20:
+ax_pose 19, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose21:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose22:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose23:
+ax_pose 22, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose24:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose25:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose26:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose27:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose28:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose29:
+ax_pose 4, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose30:
+ax_pose 5, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose31:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose32:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose33:
+ax_pose 8, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose34:
+ax_pose 9, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose35:
+ax_pose 10, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose36:
+ax_pose 11, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose37:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose38:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose39:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose40:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose41:
+ax_pose 16, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose42:
+ax_pose 17, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose43:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose44:
+ax_pose 19, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose45:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose46:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose47:
+ax_pose 22, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose48:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose49:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose50:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose51:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose52:
+ax_pose 24, 0x01ed, 0x80f0, 0x3c00
+ax_pose 25, 0x01ed, 0x80f0, 0x3c10
+ax_pose_terminator
+sWeepinbellPose53:
+ax_pose 25, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose54:
+ax_pose 26, 0x01ed, 0x80f0, 0x3c00
+ax_pose 27, 0x01ed, 0x80f0, 0x3c10
+ax_pose_terminator
+sWeepinbellPose55:
+ax_pose 27, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose56:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose57:
+ax_pose 4, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose58:
+ax_pose 5, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose59:
+ax_pose 28, 0x81ee, 0x90fa, 0x3c00
+ax_pose 29, 0x01ee, 0x90eb, 0x3c08
+ax_pose_terminator
+sWeepinbellPose60:
+ax_pose 29, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose61:
+ax_pose 30, 0x41f9, 0x90ed, 0x3c00
+ax_pose 31, 0x01ee, 0x90eb, 0x3c08
+ax_pose_terminator
+sWeepinbellPose62:
+ax_pose 31, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose63:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose64:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose65:
+ax_pose 8, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose66:
+ax_pose 32, 0x01ec, 0x90ee, 0x3c00
+ax_pose 33, 0x01ec, 0x90eb, 0x3c10
+ax_pose_terminator
+sWeepinbellPose67:
+ax_pose 33, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose68:
+ax_pose 34, 0x41f4, 0x90ee, 0x3c00
+ax_pose 35, 0x01ec, 0x90eb, 0x3c08
+ax_pose_terminator
+sWeepinbellPose69:
+ax_pose 35, 0x01ec, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose70:
+ax_pose 9, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose71:
+ax_pose 10, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose72:
+ax_pose 11, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose73:
+ax_pose 36, 0x01eb, 0x90eb, 0x3c00
+ax_pose 37, 0x01eb, 0x90eb, 0x3c10
+ax_pose_terminator
+sWeepinbellPose74:
+ax_pose 37, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose75:
+ax_pose 38, 0x81eb, 0x90fa, 0x3c00
+ax_pose 39, 0x01eb, 0x90eb, 0x3c08
+ax_pose_terminator
+sWeepinbellPose76:
+ax_pose 39, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose77:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose78:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose79:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose80:
+ax_pose 40, 0x81ec, 0x80f6, 0x3c00
+ax_pose 41, 0x01ec, 0x80f0, 0x3c08
+ax_pose_terminator
+sWeepinbellPose81:
+ax_pose 41, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose82:
+ax_pose 42, 0x01ec, 0x80f0, 0x3c00
+ax_pose 43, 0x01ec, 0x80f0, 0x3c10
+ax_pose_terminator
+sWeepinbellPose83:
+ax_pose 43, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose84:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose85:
+ax_pose 16, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose86:
+ax_pose 17, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose87:
+ax_pose 36, 0x01eb, 0x80f4, 0x3c00
+ax_pose 37, 0x01eb, 0x80f4, 0x3c10
+ax_pose_terminator
+sWeepinbellPose88:
+ax_pose 37, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose89:
+ax_pose 38, 0x81eb, 0x80f5, 0x3c00
+ax_pose 39, 0x01eb, 0x80f4, 0x3c08
+ax_pose_terminator
+sWeepinbellPose90:
+ax_pose 39, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose91:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose92:
+ax_pose 19, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose93:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose94:
+ax_pose 32, 0x01ec, 0x80f1, 0x3c00
+ax_pose 33, 0x01ec, 0x80f4, 0x3c10
+ax_pose_terminator
+sWeepinbellPose95:
+ax_pose 33, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose96:
+ax_pose 34, 0x41f4, 0x80f1, 0x3c00
+ax_pose 35, 0x01ec, 0x80f4, 0x3c08
+ax_pose_terminator
+sWeepinbellPose97:
+ax_pose 35, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose98:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose99:
+ax_pose 22, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose100:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose101:
+ax_pose 28, 0x81ee, 0x80f5, 0x3c00
+ax_pose 29, 0x01ee, 0x80f4, 0x3c08
+ax_pose_terminator
+sWeepinbellPose102:
+ax_pose 29, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose103:
+ax_pose 30, 0x41f9, 0x80f2, 0x3c00
+ax_pose 31, 0x01ee, 0x80f4, 0x3c08
+ax_pose_terminator
+sWeepinbellPose104:
+ax_pose 31, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose105:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose106:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose107:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose108:
+ax_pose 44, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose109:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose110:
+ax_pose 4, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose111:
+ax_pose 5, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose112:
+ax_pose 45, 0x01ee, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose113:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose114:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose115:
+ax_pose 8, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose116:
+ax_pose 46, 0x81ea, 0x90f9, 0x3c00
+ax_pose_terminator
+sWeepinbellPose117:
+ax_pose 9, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose118:
+ax_pose 10, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose119:
+ax_pose 11, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose120:
+ax_pose 47, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose121:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose122:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose123:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose124:
+ax_pose 48, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose125:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose126:
+ax_pose 16, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose127:
+ax_pose 17, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose128:
+ax_pose 47, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose129:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose130:
+ax_pose 19, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose131:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose132:
+ax_pose 46, 0x81ea, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose133:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose134:
+ax_pose 22, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose135:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose136:
+ax_pose 45, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose137:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose138:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose139:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose140:
+ax_pose 15, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose141:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose142:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose143:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose144:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose145:
+ax_pose 49, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose146:
+ax_pose 50, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose147:
+ax_pose 51, 0x01e3, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose148:
+ax_pose 52, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose149:
+ax_pose 53, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose150:
+ax_pose 54, 0x01e3, 0x90ea, 0x3c00
+ax_pose_terminator
+sWeepinbellPose151:
+ax_pose 55, 0x01e5, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose152:
+ax_pose 54, 0x01e3, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose153:
+ax_pose 53, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sWeepinbellPose154:
+ax_pose 52, 0x01e3, 0x80f5, 0x3c00
+ax_pose_terminator
+sWeepinbellPose155:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose156:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose157:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose158:
+ax_pose 15, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose159:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose160:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose161:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose162:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose163:
+ax_pose 44, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose164:
+ax_pose 45, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sWeepinbellPose165:
+ax_pose 46, 0x81eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sWeepinbellPose166:
+ax_pose 47, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose167:
+ax_pose 48, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose168:
+ax_pose 47, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sWeepinbellPose169:
+ax_pose 46, 0x81eb, 0x90fa, 0x3c00
+ax_pose_terminator
+sWeepinbellPose170:
+ax_pose 45, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose171:
+ax_pose 44, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose172:
+ax_pose 45, 0x01ed, 0x90eb, 0x3c00
+ax_pose_terminator
+sWeepinbellPose173:
+ax_pose 46, 0x81eb, 0x90fa, 0x3c00
+ax_pose_terminator
+sWeepinbellPose174:
+ax_pose 47, 0x01eb, 0x90ea, 0x3c00
+ax_pose_terminator
+sWeepinbellPose175:
+ax_pose 48, 0x01eb, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose176:
+ax_pose 47, 0x01eb, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose177:
+ax_pose 46, 0x81eb, 0x80f5, 0x3c00
+ax_pose_terminator
+sWeepinbellPose178:
+ax_pose 45, 0x01ed, 0x80f5, 0x3c00
+ax_pose_terminator
+sWeepinbellPose179:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose180:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose181:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose182:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose183:
+ax_pose 5, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose184:
+ax_pose 4, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose185:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose186:
+ax_pose 8, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose187:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose188:
+ax_pose 9, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose189:
+ax_pose 11, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose190:
+ax_pose 10, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose191:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose192:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose193:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose194:
+ax_pose 15, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose195:
+ax_pose 17, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose196:
+ax_pose 16, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose197:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose198:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose199:
+ax_pose 19, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose200:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose201:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose202:
+ax_pose 22, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose203:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose204:
+ax_pose 1, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose205:
+ax_pose 2, 0x01ed, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose206:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose207:
+ax_pose 4, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose208:
+ax_pose 5, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose209:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose210:
+ax_pose 7, 0x01ec, 0x80f2, 0x3c00
+ax_pose_terminator
+sWeepinbellPose211:
+ax_pose 8, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose212:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose213:
+ax_pose 10, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose214:
+ax_pose 11, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose215:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose216:
+ax_pose 13, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose217:
+ax_pose 14, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose218:
+ax_pose 15, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose219:
+ax_pose 16, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose220:
+ax_pose 17, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose221:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose222:
+ax_pose 19, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose223:
+ax_pose 20, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose224:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose225:
+ax_pose 22, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose226:
+ax_pose 23, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose227:
+ax_pose 0, 0x01ed, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose228:
+ax_pose 21, 0x01ee, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose229:
+ax_pose 18, 0x81ec, 0x80f6, 0x3c00
+ax_pose_terminator
+sWeepinbellPose230:
+ax_pose 15, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose231:
+ax_pose 12, 0x01ec, 0x80f0, 0x3c00
+ax_pose_terminator
+sWeepinbellPose232:
+ax_pose 9, 0x01ec, 0x80f4, 0x3c00
+ax_pose_terminator
+sWeepinbellPose233:
+ax_pose 6, 0x81ec, 0x80f8, 0x3c00
+ax_pose_terminator
+sWeepinbellPose234:
+ax_pose 3, 0x01ed, 0x80f2, 0x3c00
+ax_pose_terminator
+.align 2
+sWeepinbellAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 9, 0, 1, 0, 0,
+ax_anim 10, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, -3, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 15, 0, 1, 0, 0,
+ax_anim 10, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWeepinbellAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 1, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 28, 18, 18, 18, 18,
+ax_anim 2, 0, 28, 19, 17, 19, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sWeepinbellAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sWeepinbellAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 10, -13, 10, -13,
+ax_anim 2, 0, 34, 19, -23, 19, -23,
+ax_anim 2, 1, 34, 20, -22, 20, -22,
+ax_anim 2, 0, 34, 19, -23, 19, -23,
+ax_anim 2, 0, 34, 20, -22, 20, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sWeepinbellAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 1, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 0, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sWeepinbellAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -10, -13, -10, -13,
+ax_anim 2, 0, 40, -19, -23, -19, -23,
+ax_anim 2, 1, 40, -20, -22, -20, -22,
+ax_anim 2, 0, 40, -19, -23, -19, -23,
+ax_anim 2, 0, 40, -20, -22, -20, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sWeepinbellAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sWeepinbellAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 1, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 46, -18, 18, -18, 18,
+ax_anim 2, 0, 46, -19, 17, -19, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 50, 0, -3, 0, -3,
+ax_anim 4, 0, 48, 0, -4, 0, -4,
+ax_anim 1, 0, 49, 0, 1, 0, 1,
+ax_anim 2, 2, 49, 0, 12, 0, 12,
+ax_anim 2, 0, 51, 0, 15, 0, 15,
+ax_anim 2, 1, 52, 1, 15, 1, 15,
+ax_anim 2, 0, 52, 2, 12, 2, 12,
+ax_anim 2, 0, 53, 0, 15, 0, 15,
+ax_anim 2, 0, 54, -1, 16, -1, 16,
+ax_anim 2, 0, 54, -2, 16, -2, 16,
+ax_anim 2, 0, 54, -3, 13, -3, 13,
+ax_anim 2, 0, 48, 0, 5, 0, 5,
+ax_anim_terminator
+sWeepinbellAnims_3_2:
+ax_anim 2, 0, 56, -1, -1, -1, -1,
+ax_anim 2, 0, 57, -3, -3, -3, -3,
+ax_anim 4, 0, 55, -4, -4, -4, -4,
+ax_anim 1, 0, 56, 1, 1, 1, 1,
+ax_anim 2, 2, 56, 12, 12, 12, 12,
+ax_anim 2, 0, 58, 19, 15, 19, 15,
+ax_anim 2, 1, 59, 18, 15, 18, 15,
+ax_anim 2, 0, 59, 17, 12, 17, 12,
+ax_anim 2, 0, 60, 19, 15, 19, 15,
+ax_anim 2, 0, 61, 20, 15, 20, 15,
+ax_anim 2, 0, 61, 21, 14, 21, 14,
+ax_anim 2, 0, 61, 16, 9, 16, 9,
+ax_anim 2, 0, 55, 5, 5, 5, 5,
+ax_anim_terminator
+sWeepinbellAnims_3_3:
+ax_anim 2, 0, 63, -1, 0, -1, 0,
+ax_anim 2, 0, 64, -3, 0, -3, 0,
+ax_anim 4, 0, 62, -4, 0, -4, 0,
+ax_anim 1, 0, 63, 1, 0, 1, 0,
+ax_anim 2, 2, 63, 12, 0, 12, 0,
+ax_anim 2, 0, 65, 17, 0, 17, 0,
+ax_anim 2, 1, 66, 17, -1, 17, 0,
+ax_anim 2, 0, 66, 16, -2, 16, 0,
+ax_anim 2, 0, 67, 17, 0, 17, 0,
+ax_anim 2, 0, 68, 18, 0, 18, 0,
+ax_anim 2, 0, 68, 19, -2, 19, 0,
+ax_anim 2, 0, 68, 15, -3, 15, 0,
+ax_anim 2, 0, 62, 5, 0, 5, 0,
+ax_anim_terminator
+sWeepinbellAnims_3_4:
+ax_anim 2, 0, 70, -1, 1, -1, 1,
+ax_anim 2, 0, 71, -3, 3, -3, 3,
+ax_anim 4, 0, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 70, 1, -1, 1, -1,
+ax_anim 2, 2, 70, 12, -12, 12, -12,
+ax_anim 2, 0, 72, 19, -15, 19, -15,
+ax_anim 2, 1, 73, 20, -15, 20, -15,
+ax_anim 2, 0, 73, 20, -13, 20, -13,
+ax_anim 2, 0, 74, 19, -15, 19, -15,
+ax_anim 2, 0, 75, 18, -16, 18, -16,
+ax_anim 2, 0, 75, 16, -16, 16, -16,
+ax_anim 2, 0, 75, 12, -11, 12, -11,
+ax_anim 2, 0, 69, 5, -5, 5, -5,
+ax_anim_terminator
+sWeepinbellAnims_3_5:
+ax_anim 2, 0, 77, 0, 1, 0, 1,
+ax_anim 2, 0, 78, 0, 3, 0, 3,
+ax_anim 4, 0, 76, 0, 4, 0, 4,
+ax_anim 1, 0, 77, 0, -1, 0, -1,
+ax_anim 2, 2, 77, 0, -12, 0, -12,
+ax_anim 2, 0, 79, 0, -18, 0, -18,
+ax_anim 2, 1, 80, -1, -18, -1, -18,
+ax_anim 2, 0, 80, -2, -15, -2, -15,
+ax_anim 2, 0, 81, 0, -18, 0, -18,
+ax_anim 2, 0, 82, 1, -19, 1, -19,
+ax_anim 2, 0, 82, 2, -19, 2, -19,
+ax_anim 2, 0, 82, 3, -13, 3, -13,
+ax_anim 2, 0, 76, 0, -5, 0, -5,
+ax_anim_terminator
+sWeepinbellAnims_3_6:
+ax_anim 2, 0, 84, 1, 1, 1, 1,
+ax_anim 2, 0, 85, 3, 3, 3, 3,
+ax_anim 4, 0, 83, 4, 4, 4, 4,
+ax_anim 1, 0, 84, -1, -1, -1, -1,
+ax_anim 2, 2, 84, -12, -12, -12, -12,
+ax_anim 2, 0, 86, -19, -15, -19, -15,
+ax_anim 2, 1, 87, -20, -15, -20, -15,
+ax_anim 2, 0, 87, -20, -13, -20, -13,
+ax_anim 2, 0, 88, -19, -15, -19, -15,
+ax_anim 2, 0, 89, -18, -16, -18, -16,
+ax_anim 2, 0, 89, -16, -16, -16, -16,
+ax_anim 2, 0, 89, -12, -11, -12, -11,
+ax_anim 2, 0, 83, -5, -5, -5, -5,
+ax_anim_terminator
+sWeepinbellAnims_3_7:
+ax_anim 2, 0, 91, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 3, 0, 3, 0,
+ax_anim 4, 0, 90, 4, 0, 4, 0,
+ax_anim 1, 0, 91, -1, 0, -1, 0,
+ax_anim 2, 2, 91, -12, 0, -12, 0,
+ax_anim 2, 0, 93, -17, 0, -17, 0,
+ax_anim 2, 1, 94, -17, -1, -17, 0,
+ax_anim 2, 0, 94, -16, -2, -16, 0,
+ax_anim 2, 0, 95, -17, 0, -17, 0,
+ax_anim 2, 0, 96, -18, 0, -18, 0,
+ax_anim 2, 0, 96, -19, -2, -19, 0,
+ax_anim 2, 0, 96, -15, -3, -15, 0,
+ax_anim 2, 0, 90, -5, 0, -5, 0,
+ax_anim_terminator
+sWeepinbellAnims_3_8:
+ax_anim 2, 0, 98, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 3, -3, 3, -3,
+ax_anim 4, 0, 97, 4, -4, 4, -4,
+ax_anim 1, 0, 98, -1, 1, -1, 1,
+ax_anim 2, 2, 98, -12, 12, -12, 12,
+ax_anim 2, 0, 100, -19, 15, -19, 15,
+ax_anim 2, 1, 101, -18, 15, -18, 15,
+ax_anim 2, 0, 101, -17, 12, -17, 12,
+ax_anim 2, 0, 102, -19, 15, -19, 15,
+ax_anim 2, 0, 103, -20, 15, -20, 15,
+ax_anim 2, 0, 103, -21, 14, -21, 14,
+ax_anim 2, 0, 103, -16, 9, -16, 9,
+ax_anim 2, 0, 97, -5, 5, -5, 5,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_4_1:
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 104, 0, -3, 0, -3,
+ax_anim 2, 0, 106, 0, -5, 0, -5,
+ax_anim 4, 2, 104, 0, -6, 0, -6,
+ax_anim 1, 0, 107, 0, -4, 0, -4,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 1, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 107, 1, 4, 1, 4,
+ax_anim 2, 0, 107, 0, 4, 0, 4,
+ax_anim 2, 0, 104, 0, 2, 0, 2,
+ax_anim_terminator
+sWeepinbellAnims_4_2:
+ax_anim 2, 0, 109, -2, -2, -2, -2,
+ax_anim 2, 0, 108, -3, -3, -3, -3,
+ax_anim 2, 0, 110, -5, -5, -5, -5,
+ax_anim 4, 2, 108, -6, -6, -6, -6,
+ax_anim 1, 0, 111, -4, -4, -4, -4,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 2, 1, 111, 5, 3, 5, 3,
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 2, 0, 111, 5, 3, 5, 3,
+ax_anim 2, 0, 111, 4, 4, 4, 4,
+ax_anim 2, 0, 108, 2, 2, 2, 2,
+ax_anim_terminator
+sWeepinbellAnims_4_3:
+ax_anim 2, 0, 113, -2, 0, -2, 0,
+ax_anim 2, 0, 112, -3, 0, -3, 0,
+ax_anim 2, 0, 114, -5, 0, -5, 0,
+ax_anim 4, 2, 112, -6, 0, -6, 0,
+ax_anim 1, 0, 115, -4, 0, -4, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 1, 115, 5, -1, 5, -1,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 115, 5, -1, 5, -1,
+ax_anim 2, 0, 115, 5, 0, 5, 0,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim_terminator
+sWeepinbellAnims_4_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 2, 0, 116, -3, 3, -3, 3,
+ax_anim 2, 0, 118, -5, 5, -5, 5,
+ax_anim 4, 2, 116, -6, 6, -6, 6,
+ax_anim 1, 0, 119, -4, 4, -4, 4,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 2, 1, 119, 5, -3, 5, -3,
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 119, 5, -3, 5, -3,
+ax_anim 2, 0, 119, 4, -4, 4, -4,
+ax_anim 2, 0, 116, 2, -2, 2, -2,
+ax_anim_terminator
+sWeepinbellAnims_4_5:
+ax_anim 2, 0, 121, 0, 2, 0, 2,
+ax_anim 2, 0, 120, 0, 3, 0, 3,
+ax_anim 2, 0, 122, 0, 5, 0, 5,
+ax_anim 4, 2, 120, 0, 6, 0, 6,
+ax_anim 1, 0, 123, 0, 4, 0, 4,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, -4, 0, -4,
+ax_anim 2, 1, 123, 1, -4, 1, -4,
+ax_anim 2, 0, 123, 0, -4, 0, -4,
+ax_anim 2, 0, 123, 1, -4, 1, -4,
+ax_anim 2, 0, 123, 0, -4, 0, -4,
+ax_anim 2, 0, 120, 0, -2, 0, -2,
+ax_anim_terminator
+sWeepinbellAnims_4_6:
+ax_anim 2, 0, 125, 2, 2, 2, 2,
+ax_anim 2, 0, 124, 3, 3, 3, 3,
+ax_anim 2, 0, 126, 5, 5, 5, 5,
+ax_anim 4, 2, 124, 6, 6, 6, 6,
+ax_anim 1, 0, 127, 4, 4, 4, 4,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -4, -4, -4, -4,
+ax_anim 2, 1, 127, -5, -3, -5, -3,
+ax_anim 2, 0, 127, -4, -4, -4, -4,
+ax_anim 2, 0, 127, -5, -3, -5, -3,
+ax_anim 2, 0, 127, -4, -4, -4, -4,
+ax_anim 2, 0, 124, -2, -2, -2, -2,
+ax_anim_terminator
+sWeepinbellAnims_4_7:
+ax_anim 2, 0, 129, 2, 0, 2, 0,
+ax_anim 2, 0, 128, 3, 0, 3, 0,
+ax_anim 2, 0, 130, 5, 0, 5, 0,
+ax_anim 4, 2, 128, 6, 0, 6, 0,
+ax_anim 1, 0, 131, 4, 0, 4, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 1, 131, -5, -1, -5, -1,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 131, -5, -1, -5, -1,
+ax_anim 2, 0, 131, -5, 0, -5, 0,
+ax_anim 2, 0, 128, -2, 0, -2, 0,
+ax_anim_terminator
+sWeepinbellAnims_4_8:
+ax_anim 2, 0, 133, 2, -2, 2, -2,
+ax_anim 2, 0, 132, 3, -3, 3, -3,
+ax_anim 2, 0, 134, 5, -5, 5, -5,
+ax_anim 4, 2, 132, 6, -6, 6, -6,
+ax_anim 1, 0, 135, 4, -4, 4, -4,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -4, 4, -4, 4,
+ax_anim 2, 1, 135, -5, 3, -5, 3,
+ax_anim 2, 0, 135, -4, 4, -4, 4,
+ax_anim 2, 0, 135, -5, 3, -5, 3,
+ax_anim 2, 0, 135, -4, 4, -4, 4,
+ax_anim 2, 0, 132, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_5_1:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 2, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_5_2:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_5_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_5_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_5_5:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_5_6:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_5_7:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_5_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 2, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_6_1:
+ax_anim 12, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, -1, 0, 0,
+ax_anim 12, 0, 144, 0, -2, 0, 0,
+ax_anim 12, 0, 145, 0, -2, 0, 0,
+ax_anim 10, 0, 145, 0, -1, 0, 0,
+ax_anim 12, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sWeepinbellAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sWeepinbellAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sWeepinbellAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sWeepinbellAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sWeepinbellAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sWeepinbellAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sWeepinbellAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_8_1:
+ax_anim 16, 0, 154, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, -1, 0, 0,
+ax_anim 16, 0, 154, 0, -2, 0, 0,
+ax_anim 8, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_8_2:
+ax_anim 16, 0, 161, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim 16, 0, 161, 0, -2, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_8_3:
+ax_anim 16, 0, 160, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, -1, 0, 0,
+ax_anim 16, 0, 160, 0, -2, 0, 0,
+ax_anim 8, 0, 160, 0, -1, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_8_4:
+ax_anim 16, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 159, 0, -1, 0, 0,
+ax_anim 16, 0, 159, 0, -2, 0, 0,
+ax_anim 8, 0, 159, 0, -1, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_8_5:
+ax_anim 16, 0, 158, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, -1, 0, 0,
+ax_anim 16, 0, 158, 0, -2, 0, 0,
+ax_anim 8, 0, 158, 0, -1, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_8_6:
+ax_anim 16, 0, 157, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, -1, 0, 0,
+ax_anim 16, 0, 157, 0, -2, 0, 0,
+ax_anim 8, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_8_7:
+ax_anim 16, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 156, 0, -1, 0, 0,
+ax_anim 16, 0, 156, 0, -2, 0, 0,
+ax_anim 8, 0, 156, 0, -1, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_8_8:
+ax_anim 16, 0, 155, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim 16, 0, 155, 0, -2, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 21, 0, 21,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 11, 22, 11,
+ax_anim 3, 0, 165, 21, 21, 21, 21,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 19, -5, 19, -5,
+ax_anim 3, 0, 164, 24, -2, 24, -2,
+ax_anim 2, 3, 165, 19, 4, 19, 4,
+ax_anim 2, 0, 166, 12, 5, 12, 5,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 12, -22, 12, -22,
+ax_anim 3, 0, 163, 21, -22, 21, -22,
+ax_anim 2, 3, 164, 23, -13, 23, -13,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -22, 0, -22,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -10, 9, -10,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -12, -22, -12, -22,
+ax_anim 3, 0, 169, -21, -22, -21, -22,
+ax_anim 2, 3, 168, -23, -13, -23, -13,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -19, -5, -19, -5,
+ax_anim 3, 0, 168, -24, -2, -24, -2,
+ax_anim 2, 3, 167, -19, 4, -19, 4,
+ax_anim 2, 0, 166, -12, 5, -12, 5,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 11, -22, 11,
+ax_anim 3, 0, 167, -21, 21, -21, 21,
+ax_anim 2, 3, 166, -11, 21, -11, 21,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_12_1:
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 1, 0, 1, 0,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_12_2:
+ax_anim 2, 0, 206, 1, -1, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, -1, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_12_3:
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, -1, 0, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_12_4:
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, -1, -1, -1, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_12_5:
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 1, 0, 1, 0,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_12_6:
+ax_anim 2, 0, 218, 1, -1, 1, -1,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, -1,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, -1,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, -1,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, -1, 1, -1,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_12_7:
+ax_anim 2, 0, 221, 0, -1, 0, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, -1, 0, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, -1, 0, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, -1, 0, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, -1, 0, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_12_8:
+ax_anim 2, 0, 224, -1, -1, -1, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, -1, -1, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, -1, -1, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, -1, -1, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, -1, -1, -1, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeepinbellAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sWeepinbellGfx1:
+.incbin "baserom.gba", 0x80B6A8, 0x200
+sWeepinbellSprites1:
+ax_sprite sWeepinbellGfx1, 0x200
+ax_sprite_terminator
+sWeepinbellGfx2:
+.incbin "baserom.gba", 0x80B8B8, 0x200
+sWeepinbellSprites2:
+ax_sprite sWeepinbellGfx2, 0x200
+ax_sprite_terminator
+sWeepinbellGfx3:
+.incbin "baserom.gba", 0x80BAC8, 0x200
+sWeepinbellSprites3:
+ax_sprite sWeepinbellGfx3, 0x200
+ax_sprite_terminator
+sWeepinbellGfx4:
+.incbin "baserom.gba", 0x80BCD8, 0x200
+sWeepinbellSprites4:
+ax_sprite sWeepinbellGfx4, 0x200
+ax_sprite_terminator
+sWeepinbellGfx5:
+.incbin "baserom.gba", 0x80BEE8, 0x200
+sWeepinbellSprites5:
+ax_sprite sWeepinbellGfx5, 0x200
+ax_sprite_terminator
+sWeepinbellGfx6:
+.incbin "baserom.gba", 0x80C0F8, 0x200
+sWeepinbellSprites6:
+ax_sprite sWeepinbellGfx6, 0x200
+ax_sprite_terminator
+sWeepinbellGfx7:
+.incbin "baserom.gba", 0x80C308, 0x100
+sWeepinbellSprites7:
+ax_sprite sWeepinbellGfx7, 0x100
+ax_sprite_terminator
+sWeepinbellGfx8:
+.incbin "baserom.gba", 0x80C418, 0x200
+sWeepinbellSprites8:
+ax_sprite sWeepinbellGfx8, 0x200
+ax_sprite_terminator
+sWeepinbellGfx9:
+.incbin "baserom.gba", 0x80C628, 0x100
+sWeepinbellSprites9:
+ax_sprite sWeepinbellGfx9, 0x100
+ax_sprite_terminator
+sWeepinbellGfx10:
+.incbin "baserom.gba", 0x80C738, 0x200
+sWeepinbellSprites10:
+ax_sprite sWeepinbellGfx10, 0x200
+ax_sprite_terminator
+sWeepinbellGfx11:
+.incbin "baserom.gba", 0x80C948, 0x200
+sWeepinbellSprites11:
+ax_sprite sWeepinbellGfx11, 0x200
+ax_sprite_terminator
+sWeepinbellGfx12:
+.incbin "baserom.gba", 0x80CB58, 0x200
+sWeepinbellSprites12:
+ax_sprite sWeepinbellGfx12, 0x200
+ax_sprite_terminator
+sWeepinbellGfx13:
+.incbin "baserom.gba", 0x80CD68, 0x200
+sWeepinbellSprites13:
+ax_sprite sWeepinbellGfx13, 0x200
+ax_sprite_terminator
+sWeepinbellGfx14:
+.incbin "baserom.gba", 0x80CF78, 0x200
+sWeepinbellSprites14:
+ax_sprite sWeepinbellGfx14, 0x200
+ax_sprite_terminator
+sWeepinbellGfx15:
+.incbin "baserom.gba", 0x80D188, 0x200
+sWeepinbellSprites15:
+ax_sprite sWeepinbellGfx15, 0x200
+ax_sprite_terminator
+sWeepinbellGfx16:
+.incbin "baserom.gba", 0x80D398, 0x200
+sWeepinbellSprites16:
+ax_sprite sWeepinbellGfx16, 0x200
+ax_sprite_terminator
+sWeepinbellGfx17:
+.incbin "baserom.gba", 0x80D5A8, 0x200
+sWeepinbellSprites17:
+ax_sprite sWeepinbellGfx17, 0x200
+ax_sprite_terminator
+sWeepinbellGfx18:
+.incbin "baserom.gba", 0x80D7B8, 0x200
+sWeepinbellSprites18:
+ax_sprite sWeepinbellGfx18, 0x200
+ax_sprite_terminator
+sWeepinbellGfx19:
+.incbin "baserom.gba", 0x80D9C8, 0x100
+sWeepinbellSprites19:
+ax_sprite sWeepinbellGfx19, 0x100
+ax_sprite_terminator
+sWeepinbellGfx20:
+.incbin "baserom.gba", 0x80DAD8, 0x200
+sWeepinbellSprites20:
+ax_sprite sWeepinbellGfx20, 0x200
+ax_sprite_terminator
+sWeepinbellGfx21:
+.incbin "baserom.gba", 0x80DCE8, 0x100
+sWeepinbellSprites21:
+ax_sprite sWeepinbellGfx21, 0x100
+ax_sprite_terminator
+sWeepinbellGfx22:
+.incbin "baserom.gba", 0x80DDF8, 0x200
+sWeepinbellSprites22:
+ax_sprite sWeepinbellGfx22, 0x200
+ax_sprite_terminator
+sWeepinbellGfx23:
+.incbin "baserom.gba", 0x80E008, 0x200
+sWeepinbellSprites23:
+ax_sprite sWeepinbellGfx23, 0x200
+ax_sprite_terminator
+sWeepinbellGfx24:
+.incbin "baserom.gba", 0x80E218, 0x200
+sWeepinbellSprites24:
+ax_sprite sWeepinbellGfx24, 0x200
+ax_sprite_terminator
+sWeepinbellGfx25:
+.incbin "baserom.gba", 0x80E428, 0x40
+sWeepinbellGfx25_1:
+.incbin "baserom.gba", 0x80E468, 0xC0
+sWeepinbellGfx25_2:
+.incbin "baserom.gba", 0x80E528, 0x40
+sWeepinbellSprites25:
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx25_1, 0xc0
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx25_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeepinbellGfx26:
+.incbin "baserom.gba", 0x80E5A8, 0x60
+sWeepinbellGfx26_1:
+.incbin "baserom.gba", 0x80E608, 0x60
+sWeepinbellGfx26_2:
+.incbin "baserom.gba", 0x80E668, 0x60
+sWeepinbellSprites26:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx26_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWeepinbellGfx27:
+.incbin "baserom.gba", 0x80E708, 0xC0
+sWeepinbellGfx27_1:
+.incbin "baserom.gba", 0x80E7C8, 0x40
+sWeepinbellSprites27:
+ax_sprite 0, 0xc0
+ax_sprite sWeepinbellGfx27, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeepinbellGfx28:
+.incbin "baserom.gba", 0x80E838, 0x40
+sWeepinbellGfx28_1:
+.incbin "baserom.gba", 0x80E878, 0x40
+sWeepinbellGfx28_2:
+.incbin "baserom.gba", 0x80E8B8, 0x60
+sWeepinbellSprites28:
+ax_sprite sWeepinbellGfx28, 0x40
+ax_sprite 0, 0x60
+ax_sprite sWeepinbellGfx28_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx29:
+.incbin "baserom.gba", 0x80E950, 0xC0
+sWeepinbellSprites29:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx29, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeepinbellGfx30:
+.incbin "baserom.gba", 0x80EA30, 0x40
+sWeepinbellGfx30_1:
+.incbin "baserom.gba", 0x80EA70, 0x80
+sWeepinbellGfx30_2:
+.incbin "baserom.gba", 0x80EAF0, 0x40
+sWeepinbellSprites30:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx30_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx30_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx31:
+.incbin "baserom.gba", 0x80EB70, 0xE0
+sWeepinbellSprites31:
+ax_sprite sWeepinbellGfx31, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeepinbellGfx32:
+.incbin "baserom.gba", 0x80EC68, 0x60
+sWeepinbellGfx32_1:
+.incbin "baserom.gba", 0x80ECC8, 0x60
+sWeepinbellGfx32_2:
+.incbin "baserom.gba", 0x80ED28, 0x60
+sWeepinbellSprites32:
+ax_sprite sWeepinbellGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx33:
+.incbin "baserom.gba", 0x80EDC0, 0x40
+sWeepinbellGfx33_1:
+.incbin "baserom.gba", 0x80EE00, 0xC0
+sWeepinbellSprites33:
+ax_sprite sWeepinbellGfx33, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx33_1, 0xc0
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sWeepinbellGfx34:
+.incbin "baserom.gba", 0x80EEE8, 0x60
+sWeepinbellGfx34_1:
+.incbin "baserom.gba", 0x80EF48, 0xE0
+sWeepinbellSprites34:
+ax_sprite sWeepinbellGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx34_1, 0xe0
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx35:
+.incbin "baserom.gba", 0x80F050, 0x40
+sWeepinbellGfx35_1:
+.incbin "baserom.gba", 0x80F090, 0x80
+sWeepinbellSprites35:
+ax_sprite sWeepinbellGfx35, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx35_1, 0x80
+ax_sprite_terminator
+sWeepinbellGfx36:
+.incbin "baserom.gba", 0x80F130, 0x20
+sWeepinbellGfx36_1:
+.incbin "baserom.gba", 0x80F150, 0x60
+sWeepinbellGfx36_2:
+.incbin "baserom.gba", 0x80F1B0, 0x60
+sWeepinbellSprites36:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx36, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx36_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx36_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx37:
+.incbin "baserom.gba", 0x80F250, 0x40
+sWeepinbellGfx37_1:
+.incbin "baserom.gba", 0x80F290, 0x20
+sWeepinbellGfx37_2:
+.incbin "baserom.gba", 0x80F2B0, 0x20
+sWeepinbellSprites37:
+ax_sprite sWeepinbellGfx37, 0x40
+ax_sprite 0, 0x80
+ax_sprite sWeepinbellGfx37_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sWeepinbellGfx37_2, 0x20
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx38:
+.incbin "baserom.gba", 0x80F308, 0x40
+sWeepinbellGfx38_1:
+.incbin "baserom.gba", 0x80F348, 0x60
+sWeepinbellGfx38_2:
+.incbin "baserom.gba", 0x80F3A8, 0x60
+sWeepinbellSprites38:
+ax_sprite sWeepinbellGfx38, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx38_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx38_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx39:
+.incbin "baserom.gba", 0x80F440, 0xC0
+sWeepinbellGfx39_1:
+.incbin "baserom.gba", 0x80F500, 0x20
+sWeepinbellSprites39:
+ax_sprite sWeepinbellGfx39, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx39_1, 0x20
+ax_sprite_terminator
+sWeepinbellGfx40:
+.incbin "baserom.gba", 0x80F540, 0x40
+sWeepinbellGfx40_1:
+.incbin "baserom.gba", 0x80F580, 0x60
+sWeepinbellGfx40_2:
+.incbin "baserom.gba", 0x80F5E0, 0x60
+sWeepinbellSprites40:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx40, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx40_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx40_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx41:
+.incbin "baserom.gba", 0x80F680, 0x40
+sWeepinbellGfx41_1:
+.incbin "baserom.gba", 0x80F6C0, 0x20
+sWeepinbellGfx41_2:
+.incbin "baserom.gba", 0x80F6E0, 0x20
+sWeepinbellSprites41:
+ax_sprite sWeepinbellGfx41, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx41_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx41_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeepinbellGfx42:
+.incbin "baserom.gba", 0x80F738, 0x60
+sWeepinbellGfx42_1:
+.incbin "baserom.gba", 0x80F798, 0x60
+sWeepinbellGfx42_2:
+.incbin "baserom.gba", 0x80F7F8, 0x60
+sWeepinbellSprites42:
+ax_sprite sWeepinbellGfx42, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx42_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx43:
+.incbin "baserom.gba", 0x80F890, 0x60
+sWeepinbellGfx43_1:
+.incbin "baserom.gba", 0x80F8F0, 0xC0
+sWeepinbellGfx43_2:
+.incbin "baserom.gba", 0x80F9B0, 0x20
+sWeepinbellSprites43:
+ax_sprite sWeepinbellGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx43_1, 0xc0
+ax_sprite 0, 0x60
+ax_sprite sWeepinbellGfx43_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeepinbellGfx44:
+.incbin "baserom.gba", 0x80FA08, 0x40
+sWeepinbellGfx44_1:
+.incbin "baserom.gba", 0x80FA48, 0x60
+sWeepinbellGfx44_2:
+.incbin "baserom.gba", 0x80FAA8, 0x60
+sWeepinbellSprites44:
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx44_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWeepinbellGfx45:
+.incbin "baserom.gba", 0x80FB48, 0x40
+sWeepinbellGfx45_1:
+.incbin "baserom.gba", 0x80FB88, 0x80
+sWeepinbellGfx45_2:
+.incbin "baserom.gba", 0x80FC08, 0x40
+sWeepinbellGfx45_3:
+.incbin "baserom.gba", 0x80FC48, 0x40
+sWeepinbellSprites45:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx45, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx45_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx45_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx45_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeepinbellGfx46:
+.incbin "baserom.gba", 0x80FCD8, 0x40
+sWeepinbellGfx46_1:
+.incbin "baserom.gba", 0x80FD18, 0x60
+sWeepinbellGfx46_2:
+.incbin "baserom.gba", 0x80FD78, 0x60
+sWeepinbellSprites46:
+ax_sprite sWeepinbellGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeepinbellGfx46_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx46_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx47:
+.incbin "baserom.gba", 0x80FE10, 0xC0
+sWeepinbellSprites47:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx47, 0xc0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeepinbellGfx48:
+.incbin "baserom.gba", 0x80FEF0, 0x40
+sWeepinbellGfx48_1:
+.incbin "baserom.gba", 0x80FF30, 0x60
+sWeepinbellGfx48_2:
+.incbin "baserom.gba", 0x80FF90, 0x40
+sWeepinbellSprites48:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx48_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx48_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sWeepinbellGfx49:
+.incbin "baserom.gba", 0x810010, 0x40
+sWeepinbellGfx49_1:
+.incbin "baserom.gba", 0x810050, 0x80
+sWeepinbellGfx49_2:
+.incbin "baserom.gba", 0x8100D0, 0x40
+sWeepinbellSprites49:
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx49, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx49_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWeepinbellGfx49_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWeepinbellGfx50:
+.incbin "baserom.gba", 0x810150, 0x200
+sWeepinbellSprites50:
+ax_sprite sWeepinbellGfx50, 0x200
+ax_sprite_terminator
+sWeepinbellGfx51:
+.incbin "baserom.gba", 0x810360, 0x200
+sWeepinbellSprites51:
+ax_sprite sWeepinbellGfx51, 0x200
+ax_sprite_terminator
+sWeepinbellGfx52:
+.incbin "baserom.gba", 0x810570, 0x200
+sWeepinbellSprites52:
+ax_sprite sWeepinbellGfx52, 0x200
+ax_sprite_terminator
+sWeepinbellGfx53:
+.incbin "baserom.gba", 0x810780, 0x200
+sWeepinbellSprites53:
+ax_sprite sWeepinbellGfx53, 0x200
+ax_sprite_terminator
+sWeepinbellGfx54:
+.incbin "baserom.gba", 0x810990, 0x200
+sWeepinbellSprites54:
+ax_sprite sWeepinbellGfx54, 0x200
+ax_sprite_terminator
+sWeepinbellGfx55:
+.incbin "baserom.gba", 0x810BA0, 0x200
+sWeepinbellSprites55:
+ax_sprite sWeepinbellGfx55, 0x200
+ax_sprite_terminator
+sWeepinbellGfx56:
+.incbin "baserom.gba", 0x810DB0, 0x200
+sWeepinbellSprites56:
+ax_sprite sWeepinbellGfx56, 0x200
+ax_sprite_terminator
+sAxPosesWeepinbell:
+.4byte sWeepinbellPose1
+.4byte sWeepinbellPose2
+.4byte sWeepinbellPose3
+.4byte sWeepinbellPose4
+.4byte sWeepinbellPose5
+.4byte sWeepinbellPose6
+.4byte sWeepinbellPose7
+.4byte sWeepinbellPose8
+.4byte sWeepinbellPose9
+.4byte sWeepinbellPose10
+.4byte sWeepinbellPose11
+.4byte sWeepinbellPose12
+.4byte sWeepinbellPose13
+.4byte sWeepinbellPose14
+.4byte sWeepinbellPose15
+.4byte sWeepinbellPose16
+.4byte sWeepinbellPose17
+.4byte sWeepinbellPose18
+.4byte sWeepinbellPose19
+.4byte sWeepinbellPose20
+.4byte sWeepinbellPose21
+.4byte sWeepinbellPose22
+.4byte sWeepinbellPose23
+.4byte sWeepinbellPose24
+.4byte sWeepinbellPose25
+.4byte sWeepinbellPose26
+.4byte sWeepinbellPose27
+.4byte sWeepinbellPose28
+.4byte sWeepinbellPose29
+.4byte sWeepinbellPose30
+.4byte sWeepinbellPose31
+.4byte sWeepinbellPose32
+.4byte sWeepinbellPose33
+.4byte sWeepinbellPose34
+.4byte sWeepinbellPose35
+.4byte sWeepinbellPose36
+.4byte sWeepinbellPose37
+.4byte sWeepinbellPose38
+.4byte sWeepinbellPose39
+.4byte sWeepinbellPose40
+.4byte sWeepinbellPose41
+.4byte sWeepinbellPose42
+.4byte sWeepinbellPose43
+.4byte sWeepinbellPose44
+.4byte sWeepinbellPose45
+.4byte sWeepinbellPose46
+.4byte sWeepinbellPose47
+.4byte sWeepinbellPose48
+.4byte sWeepinbellPose49
+.4byte sWeepinbellPose50
+.4byte sWeepinbellPose51
+.4byte sWeepinbellPose52
+.4byte sWeepinbellPose53
+.4byte sWeepinbellPose54
+.4byte sWeepinbellPose55
+.4byte sWeepinbellPose56
+.4byte sWeepinbellPose57
+.4byte sWeepinbellPose58
+.4byte sWeepinbellPose59
+.4byte sWeepinbellPose60
+.4byte sWeepinbellPose61
+.4byte sWeepinbellPose62
+.4byte sWeepinbellPose63
+.4byte sWeepinbellPose64
+.4byte sWeepinbellPose65
+.4byte sWeepinbellPose66
+.4byte sWeepinbellPose67
+.4byte sWeepinbellPose68
+.4byte sWeepinbellPose69
+.4byte sWeepinbellPose70
+.4byte sWeepinbellPose71
+.4byte sWeepinbellPose72
+.4byte sWeepinbellPose73
+.4byte sWeepinbellPose74
+.4byte sWeepinbellPose75
+.4byte sWeepinbellPose76
+.4byte sWeepinbellPose77
+.4byte sWeepinbellPose78
+.4byte sWeepinbellPose79
+.4byte sWeepinbellPose80
+.4byte sWeepinbellPose81
+.4byte sWeepinbellPose82
+.4byte sWeepinbellPose83
+.4byte sWeepinbellPose84
+.4byte sWeepinbellPose85
+.4byte sWeepinbellPose86
+.4byte sWeepinbellPose87
+.4byte sWeepinbellPose88
+.4byte sWeepinbellPose89
+.4byte sWeepinbellPose90
+.4byte sWeepinbellPose91
+.4byte sWeepinbellPose92
+.4byte sWeepinbellPose93
+.4byte sWeepinbellPose94
+.4byte sWeepinbellPose95
+.4byte sWeepinbellPose96
+.4byte sWeepinbellPose97
+.4byte sWeepinbellPose98
+.4byte sWeepinbellPose99
+.4byte sWeepinbellPose100
+.4byte sWeepinbellPose101
+.4byte sWeepinbellPose102
+.4byte sWeepinbellPose103
+.4byte sWeepinbellPose104
+.4byte sWeepinbellPose105
+.4byte sWeepinbellPose106
+.4byte sWeepinbellPose107
+.4byte sWeepinbellPose108
+.4byte sWeepinbellPose109
+.4byte sWeepinbellPose110
+.4byte sWeepinbellPose111
+.4byte sWeepinbellPose112
+.4byte sWeepinbellPose113
+.4byte sWeepinbellPose114
+.4byte sWeepinbellPose115
+.4byte sWeepinbellPose116
+.4byte sWeepinbellPose117
+.4byte sWeepinbellPose118
+.4byte sWeepinbellPose119
+.4byte sWeepinbellPose120
+.4byte sWeepinbellPose121
+.4byte sWeepinbellPose122
+.4byte sWeepinbellPose123
+.4byte sWeepinbellPose124
+.4byte sWeepinbellPose125
+.4byte sWeepinbellPose126
+.4byte sWeepinbellPose127
+.4byte sWeepinbellPose128
+.4byte sWeepinbellPose129
+.4byte sWeepinbellPose130
+.4byte sWeepinbellPose131
+.4byte sWeepinbellPose132
+.4byte sWeepinbellPose133
+.4byte sWeepinbellPose134
+.4byte sWeepinbellPose135
+.4byte sWeepinbellPose136
+.4byte sWeepinbellPose137
+.4byte sWeepinbellPose138
+.4byte sWeepinbellPose139
+.4byte sWeepinbellPose140
+.4byte sWeepinbellPose141
+.4byte sWeepinbellPose142
+.4byte sWeepinbellPose143
+.4byte sWeepinbellPose144
+.4byte sWeepinbellPose145
+.4byte sWeepinbellPose146
+.4byte sWeepinbellPose147
+.4byte sWeepinbellPose148
+.4byte sWeepinbellPose149
+.4byte sWeepinbellPose150
+.4byte sWeepinbellPose151
+.4byte sWeepinbellPose152
+.4byte sWeepinbellPose153
+.4byte sWeepinbellPose154
+.4byte sWeepinbellPose155
+.4byte sWeepinbellPose156
+.4byte sWeepinbellPose157
+.4byte sWeepinbellPose158
+.4byte sWeepinbellPose159
+.4byte sWeepinbellPose160
+.4byte sWeepinbellPose161
+.4byte sWeepinbellPose162
+.4byte sWeepinbellPose163
+.4byte sWeepinbellPose164
+.4byte sWeepinbellPose165
+.4byte sWeepinbellPose166
+.4byte sWeepinbellPose167
+.4byte sWeepinbellPose168
+.4byte sWeepinbellPose169
+.4byte sWeepinbellPose170
+.4byte sWeepinbellPose171
+.4byte sWeepinbellPose172
+.4byte sWeepinbellPose173
+.4byte sWeepinbellPose174
+.4byte sWeepinbellPose175
+.4byte sWeepinbellPose176
+.4byte sWeepinbellPose177
+.4byte sWeepinbellPose178
+.4byte sWeepinbellPose179
+.4byte sWeepinbellPose180
+.4byte sWeepinbellPose181
+.4byte sWeepinbellPose182
+.4byte sWeepinbellPose183
+.4byte sWeepinbellPose184
+.4byte sWeepinbellPose185
+.4byte sWeepinbellPose186
+.4byte sWeepinbellPose187
+.4byte sWeepinbellPose188
+.4byte sWeepinbellPose189
+.4byte sWeepinbellPose190
+.4byte sWeepinbellPose191
+.4byte sWeepinbellPose192
+.4byte sWeepinbellPose193
+.4byte sWeepinbellPose194
+.4byte sWeepinbellPose195
+.4byte sWeepinbellPose196
+.4byte sWeepinbellPose197
+.4byte sWeepinbellPose198
+.4byte sWeepinbellPose199
+.4byte sWeepinbellPose200
+.4byte sWeepinbellPose201
+.4byte sWeepinbellPose202
+.4byte sWeepinbellPose203
+.4byte sWeepinbellPose204
+.4byte sWeepinbellPose205
+.4byte sWeepinbellPose206
+.4byte sWeepinbellPose207
+.4byte sWeepinbellPose208
+.4byte sWeepinbellPose209
+.4byte sWeepinbellPose210
+.4byte sWeepinbellPose211
+.4byte sWeepinbellPose212
+.4byte sWeepinbellPose213
+.4byte sWeepinbellPose214
+.4byte sWeepinbellPose215
+.4byte sWeepinbellPose216
+.4byte sWeepinbellPose217
+.4byte sWeepinbellPose218
+.4byte sWeepinbellPose219
+.4byte sWeepinbellPose220
+.4byte sWeepinbellPose221
+.4byte sWeepinbellPose222
+.4byte sWeepinbellPose223
+.4byte sWeepinbellPose224
+.4byte sWeepinbellPose225
+.4byte sWeepinbellPose226
+.4byte sWeepinbellPose227
+.4byte sWeepinbellPose228
+.4byte sWeepinbellPose229
+.4byte sWeepinbellPose230
+.4byte sWeepinbellPose231
+.4byte sWeepinbellPose232
+.4byte sWeepinbellPose233
+.4byte sWeepinbellPose234
+sAxPositionsWeepinbell:
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -1,   -1, 	 -10,   -9, 	   8,   -9, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -1, 	   8,    0, 	  -1,   -5
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte    3,   -1, 	 -10,   -6, 	   3,  -12, 	   0,   -6
+.2byte    2,   -1, 	  -6,    2, 	   6,   -7, 	   0,   -6
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    4,   -2, 	  -7,   -5, 	  -3,   -9, 	   0,   -6
+.2byte    4,   -2, 	  -1,    0, 	   2,   -5, 	   1,   -6
+.2byte    5,   -8, 	   6,   -4, 	  -6,  -12, 	   0,   -8
+.2byte    5,   -7, 	   1,   -6, 	  -8,  -12, 	   0,   -7
+.2byte    5,   -6, 	   8,   -3, 	  -5,  -10, 	   0,   -7
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   8,  -11, 	 -10,  -11, 	  -1,   -6
+.2byte   -1,   -7, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -6,   -8, 	   4,  -12, 	  -8,   -4, 	  -2,   -7
+.2byte   -6,   -7, 	   6,  -12, 	  -2,   -6, 	  -1,   -7
+.2byte   -7,   -7, 	   2,  -10, 	 -10,   -3, 	  -2,   -6
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -2, 	   1,   -9, 	   5,   -5, 	  -1,   -6
+.2byte   -6,   -2, 	  -5,   -6, 	  -1,    0, 	  -2,   -6
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -4,   -1, 	  -5,  -12, 	   8,   -6, 	  -1,   -6
+.2byte   -4,   -1, 	  -9,   -7, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -1,   -1, 	 -10,   -9, 	   8,   -9, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -1, 	   8,    0, 	  -1,   -5
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte    3,   -1, 	 -10,   -6, 	   3,  -12, 	   0,   -6
+.2byte    2,   -1, 	  -6,    2, 	   6,   -7, 	   0,   -6
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    4,   -2, 	  -7,   -5, 	  -3,   -9, 	   0,   -6
+.2byte    4,   -2, 	  -1,    0, 	   2,   -5, 	   1,   -6
+.2byte    5,   -8, 	   6,   -4, 	  -6,  -12, 	   0,   -8
+.2byte    5,   -7, 	   1,   -6, 	  -8,  -12, 	   0,   -7
+.2byte    5,   -6, 	   8,   -3, 	  -5,  -10, 	   0,   -7
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   8,  -11, 	 -10,  -11, 	  -1,   -6
+.2byte   -1,   -7, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -6,   -8, 	   4,  -12, 	  -8,   -4, 	  -2,   -7
+.2byte   -6,   -7, 	   6,  -12, 	  -2,   -6, 	  -1,   -7
+.2byte   -7,   -7, 	   2,  -10, 	 -10,   -3, 	  -2,   -6
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -2, 	   1,   -9, 	   5,   -5, 	  -1,   -6
+.2byte   -6,   -2, 	  -5,   -6, 	  -1,    0, 	  -2,   -6
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -4,   -1, 	  -5,  -12, 	   8,   -6, 	  -1,   -6
+.2byte   -4,   -1, 	  -9,   -7, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -1,   -1, 	 -10,   -9, 	   8,   -9, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -1, 	   8,    0, 	  -1,   -5
+.2byte    5,   -1, 	   7,  -13, 	   9,  -10, 	   2,   -6
+.2byte    5,   -1, 	   7,  -13, 	   9,  -10, 	   2,   -6
+.2byte    1,   -2, 	  -6,   -7, 	  -7,    1, 	  -1,   -6
+.2byte    1,   -2, 	  -6,   -7, 	  -7,    1, 	  -1,   -6
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte    3,   -1, 	 -10,   -6, 	   3,  -12, 	   0,   -6
+.2byte    2,   -1, 	  -6,    2, 	   6,   -7, 	   0,   -6
+.2byte   -5,   -2, 	  -5,  -14, 	 -12,   -7, 	  -4,   -6
+.2byte   -5,   -2, 	  -5,  -14, 	 -12,   -7, 	  -4,   -6
+.2byte   -3,   -4, 	  -6,  -11, 	   7,   -1, 	  -2,   -7
+.2byte   -3,   -4, 	  -6,  -11, 	   7,   -1, 	  -2,   -7
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    4,   -2, 	  -7,   -5, 	  -3,   -9, 	   0,   -6
+.2byte    4,   -2, 	  -1,    0, 	   2,   -5, 	   1,   -6
+.2byte    0,   -1, 	   2,  -13, 	 -12,   -5, 	  -2,   -6
+.2byte    0,   -1, 	   2,  -13, 	 -12,   -5, 	  -2,   -6
+.2byte    0,   -4, 	  -7,   -7, 	   7,   -7, 	  -1,   -5
+.2byte    0,   -4, 	  -7,   -7, 	   7,   -7, 	  -1,   -5
+.2byte    5,   -8, 	   6,   -4, 	  -6,  -12, 	   0,   -8
+.2byte    5,   -7, 	   1,   -6, 	  -8,  -12, 	   0,   -7
+.2byte    5,   -6, 	   8,   -3, 	  -5,  -10, 	   0,   -7
+.2byte    3,   -5, 	   7,  -13, 	  -1,    0, 	  -1,   -8
+.2byte    3,   -5, 	   7,  -13, 	  -1,    0, 	  -1,   -8
+.2byte   -2,   -7, 	 -11,   -4, 	  -2,  -15, 	  -3,   -9
+.2byte   -2,   -7, 	 -11,   -4, 	  -2,  -15, 	  -3,   -9
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   8,  -11, 	 -10,  -11, 	  -1,   -6
+.2byte   -1,   -7, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -6,   -5, 	  -9,  -14, 	 -12,   -4, 	  -3,   -8
+.2byte   -6,   -5, 	  -9,  -14, 	 -12,   -4, 	  -3,   -8
+.2byte    0,   -4, 	   6,   -1, 	   6,  -10, 	  -1,   -7
+.2byte    0,   -4, 	   6,   -1, 	   6,  -10, 	  -1,   -7
+.2byte   -6,   -8, 	   4,  -12, 	  -8,   -4, 	  -2,   -7
+.2byte   -6,   -7, 	   6,  -12, 	  -2,   -6, 	  -1,   -7
+.2byte   -7,   -7, 	   2,  -10, 	 -10,   -3, 	  -2,   -6
+.2byte   -5,   -5, 	  -9,  -13, 	  -1,    0, 	  -1,   -8
+.2byte   -5,   -5, 	  -9,  -13, 	  -1,    0, 	  -1,   -8
+.2byte    0,   -7, 	   9,   -4, 	   0,  -15, 	   1,   -9
+.2byte    0,   -7, 	   9,   -4, 	   0,  -15, 	   1,   -9
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -2, 	   1,   -9, 	   5,   -5, 	  -1,   -6
+.2byte   -6,   -2, 	  -5,   -6, 	  -1,    0, 	  -2,   -6
+.2byte   -2,   -1, 	  -4,  -13, 	  10,   -5, 	   0,   -6
+.2byte   -2,   -1, 	  -4,  -13, 	  10,   -5, 	   0,   -6
+.2byte   -2,   -4, 	   5,   -7, 	  -9,   -7, 	  -1,   -5
+.2byte   -2,   -4, 	   5,   -7, 	  -9,   -7, 	  -1,   -5
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -4,   -1, 	  -5,  -12, 	   8,   -6, 	  -1,   -6
+.2byte   -4,   -1, 	  -9,   -7, 	   4,    2, 	  -1,   -6
+.2byte    3,   -2, 	   3,  -14, 	  10,   -7, 	   2,   -6
+.2byte    3,   -2, 	   3,  -14, 	  10,   -7, 	   2,   -6
+.2byte    1,   -4, 	   4,  -11, 	  -9,   -1, 	   0,   -7
+.2byte    1,   -4, 	   4,  -11, 	  -9,   -1, 	   0,   -7
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -1,   -1, 	 -10,   -9, 	   8,   -9, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -1, 	   8,    0, 	  -1,   -5
+.2byte   -1,   -1, 	 -11,   -7, 	   9,   -7, 	  -1,   -5
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte    3,   -1, 	 -10,   -6, 	   3,  -12, 	   0,   -6
+.2byte    2,   -1, 	  -6,    2, 	   6,   -7, 	   0,   -6
+.2byte    2,   -1, 	   6,  -10, 	  -9,   -5, 	  -1,   -6
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    4,   -2, 	  -7,   -5, 	  -3,   -9, 	   0,   -6
+.2byte    4,   -2, 	  -1,    0, 	   2,   -5, 	   1,   -6
+.2byte    2,   -4, 	   4,  -12, 	  -4,   -6, 	  -2,   -8
+.2byte    5,   -8, 	   6,   -4, 	  -6,  -12, 	   0,   -8
+.2byte    5,   -7, 	   1,   -6, 	  -8,  -12, 	   0,   -7
+.2byte    5,   -6, 	   8,   -3, 	  -5,  -10, 	   0,   -7
+.2byte    4,   -7, 	  -7,  -15, 	   7,   -8, 	   0,   -7
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   8,  -11, 	 -10,  -11, 	  -1,   -6
+.2byte   -1,   -7, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	   8,  -10, 	 -10,  -10, 	  -1,   -6
+.2byte   -6,   -8, 	   4,  -12, 	  -8,   -4, 	  -2,   -7
+.2byte   -6,   -7, 	   6,  -12, 	  -2,   -6, 	  -1,   -7
+.2byte   -7,   -7, 	   2,  -10, 	 -10,   -3, 	  -2,   -6
+.2byte   -6,   -7, 	   5,  -15, 	  -9,   -8, 	  -2,   -7
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -2, 	   1,   -9, 	   5,   -5, 	  -1,   -6
+.2byte   -6,   -2, 	  -5,   -6, 	  -1,    0, 	  -2,   -6
+.2byte   -4,   -4, 	  -6,  -12, 	   2,   -6, 	   0,   -8
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -4,   -1, 	  -5,  -12, 	   8,   -6, 	  -1,   -6
+.2byte   -4,   -1, 	  -9,   -7, 	   4,    2, 	  -1,   -6
+.2byte   -4,   -1, 	  -8,  -10, 	   7,   -5, 	  -1,   -6
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -7, 	   4,  -11, 	  -8,   -3, 	  -2,   -6
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte    5,   -7, 	   6,   -3, 	  -6,  -11, 	   0,   -7
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte   -5,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -6
+.2byte   -5,   -2, 	  -6,  -10, 	   7,   -1, 	  -1,   -6
+.2byte    0,   -3, 	 -10,  -10, 	  10,  -10, 	   0,   -8
+.2byte    1,   -4, 	   1,  -15, 	 -14,   -7, 	  -4,   -9
+.2byte    2,   -4, 	  -6,  -12, 	 -11,   -4, 	  -3,   -9
+.2byte    3,   -7, 	 -12,  -11, 	   0,   -5, 	  -3,   -8
+.2byte    0,   -8, 	  10,   -7, 	 -10,   -7, 	   0,   -7
+.2byte   -4,   -7, 	  11,  -11, 	  -1,   -5, 	   2,   -8
+.2byte   -3,   -4, 	   5,  -12, 	  10,   -4, 	   2,   -9
+.2byte   -2,   -4, 	  -2,  -15, 	  13,   -7, 	   3,   -9
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -7, 	   4,  -11, 	  -8,   -3, 	  -2,   -6
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte    5,   -7, 	   6,   -3, 	  -6,  -11, 	   0,   -7
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte   -1,   -2, 	 -11,   -8, 	   9,   -8, 	  -1,   -6
+.2byte   -3,   -2, 	  -7,  -11, 	   8,   -6, 	   0,   -7
+.2byte   -5,   -3, 	  -7,  -11, 	   1,   -5, 	  -1,   -7
+.2byte   -4,   -7, 	   7,  -15, 	  -7,   -8, 	   0,   -7
+.2byte   -1,   -8, 	   8,  -11, 	 -10,  -11, 	  -1,   -7
+.2byte    3,   -7, 	  -8,  -15, 	   6,   -8, 	  -1,   -7
+.2byte    3,   -3, 	   5,  -11, 	  -3,   -5, 	  -1,   -7
+.2byte    2,   -2, 	   6,  -11, 	  -9,   -6, 	  -1,   -7
+.2byte   -1,   -2, 	 -11,   -8, 	   9,   -8, 	  -1,   -6
+.2byte    2,   -2, 	   6,  -11, 	  -9,   -6, 	  -1,   -7
+.2byte    3,   -3, 	   5,  -11, 	  -3,   -5, 	  -1,   -7
+.2byte    3,   -7, 	  -8,  -15, 	   6,   -8, 	  -1,   -7
+.2byte   -1,   -8, 	   8,  -11, 	 -10,  -11, 	  -1,   -7
+.2byte   -4,   -7, 	   7,  -15, 	  -7,   -8, 	   0,   -7
+.2byte   -5,   -3, 	  -7,  -11, 	   1,   -5, 	  -1,   -7
+.2byte   -3,   -2, 	  -7,  -11, 	   8,   -6, 	   0,   -7
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -1, 	   8,    0, 	  -1,   -5
+.2byte   -1,   -1, 	 -10,   -9, 	   8,   -9, 	  -1,   -6
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte    2,   -1, 	  -6,    2, 	   6,   -7, 	   0,   -6
+.2byte    3,   -1, 	 -10,   -6, 	   3,  -12, 	   0,   -6
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    4,   -2, 	  -1,    0, 	   2,   -5, 	   1,   -6
+.2byte    4,   -2, 	  -7,   -5, 	  -3,   -9, 	   0,   -6
+.2byte    5,   -8, 	   6,   -4, 	  -6,  -12, 	   0,   -8
+.2byte    5,   -6, 	   8,   -3, 	  -5,  -10, 	   0,   -7
+.2byte    5,   -7, 	   1,   -6, 	  -8,  -12, 	   0,   -7
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -1,   -7, 	   8,  -11, 	 -10,  -11, 	  -1,   -6
+.2byte   -6,   -8, 	   4,  -12, 	  -8,   -4, 	  -2,   -7
+.2byte   -7,   -7, 	   2,  -10, 	 -10,   -3, 	  -2,   -6
+.2byte   -6,   -7, 	   6,  -12, 	  -2,   -6, 	  -1,   -7
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -2, 	  -5,   -6, 	  -1,    0, 	  -2,   -6
+.2byte   -6,   -2, 	   1,   -9, 	   5,   -5, 	  -1,   -6
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -4,   -1, 	  -9,   -7, 	   4,    2, 	  -1,   -6
+.2byte   -4,   -1, 	  -5,  -12, 	   8,   -6, 	  -1,   -6
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -1,   -1, 	 -10,   -9, 	   8,   -9, 	  -1,   -6
+.2byte   -1,   -1, 	  -9,   -1, 	   8,    0, 	  -1,   -5
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+.2byte    3,   -1, 	 -10,   -6, 	   3,  -12, 	   0,   -6
+.2byte    2,   -1, 	  -6,    2, 	   6,   -7, 	   0,   -6
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    4,   -2, 	  -7,   -5, 	  -3,   -9, 	   0,   -6
+.2byte    4,   -2, 	  -1,    0, 	   2,   -5, 	   1,   -6
+.2byte    5,   -7, 	   6,   -3, 	  -6,  -11, 	   0,   -7
+.2byte    5,   -6, 	   1,   -5, 	  -8,  -11, 	   0,   -6
+.2byte    5,   -5, 	   8,   -2, 	  -5,   -9, 	   0,   -6
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte   -1,   -7, 	   8,  -11, 	 -10,  -11, 	  -1,   -6
+.2byte   -1,   -7, 	   7,   -3, 	  -9,   -3, 	  -1,   -6
+.2byte   -6,   -7, 	   4,  -11, 	  -8,   -3, 	  -2,   -6
+.2byte   -6,   -6, 	   6,  -11, 	  -2,   -5, 	  -1,   -6
+.2byte   -7,   -6, 	   2,   -9, 	 -10,   -2, 	  -2,   -5
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -2, 	   1,   -9, 	   5,   -5, 	  -1,   -6
+.2byte   -6,   -2, 	  -5,   -6, 	  -1,    0, 	  -2,   -6
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -4,   -1, 	  -5,  -12, 	   8,   -6, 	  -1,   -6
+.2byte   -4,   -1, 	  -9,   -7, 	   4,    2, 	  -1,   -6
+.2byte   -1,   -2, 	 -11,   -6, 	   9,   -6, 	  -1,   -6
+.2byte   -4,   -2, 	  -6,  -11, 	   7,   -2, 	  -1,   -7
+.2byte   -6,   -3, 	  -2,   -8, 	   2,   -1, 	  -2,   -7
+.2byte   -6,   -7, 	   4,  -11, 	  -8,   -3, 	  -2,   -6
+.2byte   -1,   -8, 	   9,   -7, 	 -11,   -7, 	  -1,   -7
+.2byte    5,   -7, 	   6,   -3, 	  -6,  -11, 	   0,   -7
+.2byte    4,   -3, 	  -4,   -1, 	  -1,   -8, 	   0,   -7
+.2byte    3,   -2, 	  -9,   -2, 	   4,  -11, 	   0,   -7
+sWeepinbellAnimTable1:
+.4byte sWeepinbellAnims_1_1
+.4byte sWeepinbellAnims_1_2
+.4byte sWeepinbellAnims_1_3
+.4byte sWeepinbellAnims_1_4
+.4byte sWeepinbellAnims_1_5
+.4byte sWeepinbellAnims_1_6
+.4byte sWeepinbellAnims_1_7
+.4byte sWeepinbellAnims_1_8
+sWeepinbellAnimTable2:
+.4byte sWeepinbellAnims_2_1
+.4byte sWeepinbellAnims_2_2
+.4byte sWeepinbellAnims_2_3
+.4byte sWeepinbellAnims_2_4
+.4byte sWeepinbellAnims_2_5
+.4byte sWeepinbellAnims_2_6
+.4byte sWeepinbellAnims_2_7
+.4byte sWeepinbellAnims_2_8
+sWeepinbellAnimTable3:
+.4byte sWeepinbellAnims_3_1
+.4byte sWeepinbellAnims_3_2
+.4byte sWeepinbellAnims_3_3
+.4byte sWeepinbellAnims_3_4
+.4byte sWeepinbellAnims_3_5
+.4byte sWeepinbellAnims_3_6
+.4byte sWeepinbellAnims_3_7
+.4byte sWeepinbellAnims_3_8
+sWeepinbellAnimTable4:
+.4byte sWeepinbellAnims_4_1
+.4byte sWeepinbellAnims_4_2
+.4byte sWeepinbellAnims_4_3
+.4byte sWeepinbellAnims_4_4
+.4byte sWeepinbellAnims_4_5
+.4byte sWeepinbellAnims_4_6
+.4byte sWeepinbellAnims_4_7
+.4byte sWeepinbellAnims_4_8
+sWeepinbellAnimTable5:
+.4byte sWeepinbellAnims_5_1
+.4byte sWeepinbellAnims_5_2
+.4byte sWeepinbellAnims_5_3
+.4byte sWeepinbellAnims_5_4
+.4byte sWeepinbellAnims_5_5
+.4byte sWeepinbellAnims_5_6
+.4byte sWeepinbellAnims_5_7
+.4byte sWeepinbellAnims_5_8
+sWeepinbellAnimTable6:
+.4byte sWeepinbellAnims_6_1
+.4byte sWeepinbellAnims_6_1
+.4byte sWeepinbellAnims_6_1
+.4byte sWeepinbellAnims_6_1
+.4byte sWeepinbellAnims_6_1
+.4byte sWeepinbellAnims_6_1
+.4byte sWeepinbellAnims_6_1
+.4byte sWeepinbellAnims_6_1
+sWeepinbellAnimTable7:
+.4byte sWeepinbellAnims_7_1
+.4byte sWeepinbellAnims_7_2
+.4byte sWeepinbellAnims_7_3
+.4byte sWeepinbellAnims_7_4
+.4byte sWeepinbellAnims_7_5
+.4byte sWeepinbellAnims_7_6
+.4byte sWeepinbellAnims_7_7
+.4byte sWeepinbellAnims_7_8
+sWeepinbellAnimTable8:
+.4byte sWeepinbellAnims_8_1
+.4byte sWeepinbellAnims_8_2
+.4byte sWeepinbellAnims_8_3
+.4byte sWeepinbellAnims_8_4
+.4byte sWeepinbellAnims_8_5
+.4byte sWeepinbellAnims_8_6
+.4byte sWeepinbellAnims_8_7
+.4byte sWeepinbellAnims_8_8
+sWeepinbellAnimTable9:
+.4byte sWeepinbellAnims_9_1
+.4byte sWeepinbellAnims_9_2
+.4byte sWeepinbellAnims_9_3
+.4byte sWeepinbellAnims_9_4
+.4byte sWeepinbellAnims_9_5
+.4byte sWeepinbellAnims_9_6
+.4byte sWeepinbellAnims_9_7
+.4byte sWeepinbellAnims_9_8
+sWeepinbellAnimTable10:
+.4byte sWeepinbellAnims_10_1
+.4byte sWeepinbellAnims_10_2
+.4byte sWeepinbellAnims_10_3
+.4byte sWeepinbellAnims_10_4
+.4byte sWeepinbellAnims_10_5
+.4byte sWeepinbellAnims_10_6
+.4byte sWeepinbellAnims_10_7
+.4byte sWeepinbellAnims_10_8
+sWeepinbellAnimTable11:
+.4byte sWeepinbellAnims_11_1
+.4byte sWeepinbellAnims_11_2
+.4byte sWeepinbellAnims_11_3
+.4byte sWeepinbellAnims_11_4
+.4byte sWeepinbellAnims_11_5
+.4byte sWeepinbellAnims_11_6
+.4byte sWeepinbellAnims_11_7
+.4byte sWeepinbellAnims_11_8
+sWeepinbellAnimTable12:
+.4byte sWeepinbellAnims_12_1
+.4byte sWeepinbellAnims_12_2
+.4byte sWeepinbellAnims_12_3
+.4byte sWeepinbellAnims_12_4
+.4byte sWeepinbellAnims_12_5
+.4byte sWeepinbellAnims_12_6
+.4byte sWeepinbellAnims_12_7
+.4byte sWeepinbellAnims_12_8
+sWeepinbellAnimTable13:
+.4byte sWeepinbellAnims_13_1
+.4byte sWeepinbellAnims_13_2
+.4byte sWeepinbellAnims_13_3
+.4byte sWeepinbellAnims_13_4
+.4byte sWeepinbellAnims_13_5
+.4byte sWeepinbellAnims_13_6
+.4byte sWeepinbellAnims_13_7
+.4byte sWeepinbellAnims_13_8
+sAxAnimationsWeepinbell:
+.4byte sWeepinbellAnimTable1
+.4byte sWeepinbellAnimTable2
+.4byte sWeepinbellAnimTable3
+.4byte sWeepinbellAnimTable4
+.4byte sWeepinbellAnimTable5
+.4byte sWeepinbellAnimTable6
+.4byte sWeepinbellAnimTable7
+.4byte sWeepinbellAnimTable8
+.4byte sWeepinbellAnimTable9
+.4byte sWeepinbellAnimTable10
+.4byte sWeepinbellAnimTable11
+.4byte sWeepinbellAnimTable12
+.4byte sWeepinbellAnimTable13
+sAxSpritesWeepinbell:
+.4byte sWeepinbellSprites1
+.4byte sWeepinbellSprites2
+.4byte sWeepinbellSprites3
+.4byte sWeepinbellSprites4
+.4byte sWeepinbellSprites5
+.4byte sWeepinbellSprites6
+.4byte sWeepinbellSprites7
+.4byte sWeepinbellSprites8
+.4byte sWeepinbellSprites9
+.4byte sWeepinbellSprites10
+.4byte sWeepinbellSprites11
+.4byte sWeepinbellSprites12
+.4byte sWeepinbellSprites13
+.4byte sWeepinbellSprites14
+.4byte sWeepinbellSprites15
+.4byte sWeepinbellSprites16
+.4byte sWeepinbellSprites17
+.4byte sWeepinbellSprites18
+.4byte sWeepinbellSprites19
+.4byte sWeepinbellSprites20
+.4byte sWeepinbellSprites21
+.4byte sWeepinbellSprites22
+.4byte sWeepinbellSprites23
+.4byte sWeepinbellSprites24
+.4byte sWeepinbellSprites25
+.4byte sWeepinbellSprites26
+.4byte sWeepinbellSprites27
+.4byte sWeepinbellSprites28
+.4byte sWeepinbellSprites29
+.4byte sWeepinbellSprites30
+.4byte sWeepinbellSprites31
+.4byte sWeepinbellSprites32
+.4byte sWeepinbellSprites33
+.4byte sWeepinbellSprites34
+.4byte sWeepinbellSprites35
+.4byte sWeepinbellSprites36
+.4byte sWeepinbellSprites37
+.4byte sWeepinbellSprites38
+.4byte sWeepinbellSprites39
+.4byte sWeepinbellSprites40
+.4byte sWeepinbellSprites41
+.4byte sWeepinbellSprites42
+.4byte sWeepinbellSprites43
+.4byte sWeepinbellSprites44
+.4byte sWeepinbellSprites45
+.4byte sWeepinbellSprites46
+.4byte sWeepinbellSprites47
+.4byte sWeepinbellSprites48
+.4byte sWeepinbellSprites49
+.4byte sWeepinbellSprites50
+.4byte sWeepinbellSprites51
+.4byte sWeepinbellSprites52
+.4byte sWeepinbellSprites53
+.4byte sWeepinbellSprites54
+.4byte sWeepinbellSprites55
+.4byte sWeepinbellSprites56
+sAxMainWeepinbell:
+ax_main sAxPosesWeepinbell, sAxAnimationsWeepinbell, 13, sAxSpritesWeepinbell, sAxPositionsWeepinbell

--- a/data/ax/weezing.inc
+++ b/data/ax/weezing.inc
@@ -1,0 +1,4027 @@
+.global gAxWeezing
+gAxWeezing:
+ax_siro sAxMainWeezing
+sWeezingPose1:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose2:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose3:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose4:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose5:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose6:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose7:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose8:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose9:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose10:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose11:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose12:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose13:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose14:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose15:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose16:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose17:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose18:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose19:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose20:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose21:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose22:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose23:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose24:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose25:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose26:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose27:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose28:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose29:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose30:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose31:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose32:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose33:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose34:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose35:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose36:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose37:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose38:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose39:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose40:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose41:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose42:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose43:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose44:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose45:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose46:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose47:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose48:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose49:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose50:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose51:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose52:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose53:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose54:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose55:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose56:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose57:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose58:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose59:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose60:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose61:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose62:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose63:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose64:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose65:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose66:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose67:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose68:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose69:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose70:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose71:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose72:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose73:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose74:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose75:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose76:
+ax_pose 24, 0x41e5, 0x80ec, 0x7c00
+ax_pose 25, 0x41f5, 0x40ec, 0x7c08
+ax_pose 26, 0x41fd, 0x00f1, 0x7c0c
+ax_pose 27, 0x01e5, 0x010c, 0x7c0e
+ax_pose 28, 0x01ed, 0x010c, 0x7c0f
+ax_pose_terminator
+sWeezingPose77:
+ax_pose 29, 0x01e2, 0x80e4, 0x7c00
+ax_pose 30, 0x81e2, 0x8104, 0x7c10
+ax_pose_terminator
+sWeezingPose78:
+ax_pose 31, 0x41e0, 0x80e6, 0x7c00
+ax_pose 32, 0x01e0, 0x4106, 0x7c08
+ax_pose 33, 0x41f0, 0x80e6, 0x7c0c
+ax_pose 34, 0x01f0, 0x4106, 0x7c14
+ax_pose 35, 0x01e3, 0x80ee, 0x7c18
+ax_pose_terminator
+sWeezingPose79:
+ax_pose 35, 0x01e3, 0x80ee, 0x7c00
+ax_pose_terminator
+sWeezingPose80:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose81:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose82:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose83:
+ax_pose 36, 0x01e1, 0x80ed, 0x7c00
+ax_pose_terminator
+sWeezingPose84:
+ax_pose 37, 0x01e1, 0x80ed, 0x7c00
+ax_pose 38, 0x81e1, 0x010d, 0x7c10
+ax_pose 39, 0x4201, 0x40ed, 0x7c12
+ax_pose_terminator
+sWeezingPose85:
+ax_pose 31, 0x41e0, 0x80e4, 0x7c00
+ax_pose 32, 0x01e0, 0x4104, 0x7c08
+ax_pose 33, 0x41f0, 0x80e4, 0x7c0c
+ax_pose 34, 0x01f0, 0x4104, 0x7c14
+ax_pose 40, 0x01e3, 0x80ee, 0x7c18
+ax_pose_terminator
+sWeezingPose86:
+ax_pose 40, 0x01e3, 0x80ee, 0x7c00
+ax_pose_terminator
+sWeezingPose87:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose88:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose89:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose90:
+ax_pose 41, 0x01df, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose91:
+ax_pose 42, 0x01df, 0x80ef, 0x7c00
+ax_pose 43, 0x41ff, 0x40ef, 0x7c10
+ax_pose_terminator
+sWeezingPose92:
+ax_pose 31, 0x41e0, 0x80e9, 0x7c00
+ax_pose 32, 0x01e0, 0x4109, 0x7c08
+ax_pose 33, 0x41f0, 0x80e9, 0x7c0c
+ax_pose 34, 0x01f0, 0x4109, 0x7c14
+ax_pose 44, 0x01e0, 0x80f0, 0x7c18
+ax_pose_terminator
+sWeezingPose93:
+ax_pose 44, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose94:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose95:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose96:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose97:
+ax_pose 45, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose98:
+ax_pose 46, 0x01e2, 0x80f4, 0x7c00
+ax_pose 47, 0x81e2, 0x00ec, 0x7c10
+ax_pose 48, 0x0202, 0x0104, 0x7c12
+ax_pose_terminator
+sWeezingPose99:
+ax_pose 31, 0x41df, 0x80e9, 0x7c00
+ax_pose 32, 0x01df, 0x4109, 0x7c08
+ax_pose 33, 0x41ef, 0x80e9, 0x7c0c
+ax_pose 34, 0x01ef, 0x4109, 0x7c14
+ax_pose 49, 0x01e0, 0x80ef, 0x7c18
+ax_pose_terminator
+sWeezingPose100:
+ax_pose 49, 0x01e0, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose101:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose102:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose103:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose104:
+ax_pose 50, 0x81e1, 0x80f0, 0x7c00
+ax_pose 51, 0x81e1, 0x4100, 0x7c08
+ax_pose 52, 0x01e9, 0x00e8, 0x7c0c
+ax_pose 53, 0x01e9, 0x0108, 0x7c0d
+ax_pose 54, 0x81f1, 0x0108, 0x7c0e
+ax_pose_terminator
+sWeezingPose105:
+ax_pose 55, 0x01e1, 0x80ea, 0x7c00
+ax_pose 56, 0x81e1, 0x410a, 0x7c10
+ax_pose_terminator
+sWeezingPose106:
+ax_pose 31, 0x41e0, 0x80e8, 0x7c00
+ax_pose 32, 0x01e0, 0x4108, 0x7c08
+ax_pose 33, 0x41f0, 0x80e8, 0x7c0c
+ax_pose 34, 0x01f0, 0x4108, 0x7c14
+ax_pose 57, 0x01e1, 0x80f2, 0x7c18
+ax_pose_terminator
+sWeezingPose107:
+ax_pose 57, 0x01e1, 0x80f2, 0x7c00
+ax_pose_terminator
+sWeezingPose108:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose109:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose110:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose111:
+ax_pose 58, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose112:
+ax_pose 59, 0x01e1, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose113:
+ax_pose 31, 0x41e0, 0x80e7, 0x7c00
+ax_pose 32, 0x01e0, 0x4107, 0x7c08
+ax_pose 33, 0x41f0, 0x80e7, 0x7c0c
+ax_pose 34, 0x01f0, 0x4107, 0x7c14
+ax_pose 60, 0x01e1, 0x80f1, 0x7c18
+ax_pose_terminator
+sWeezingPose114:
+ax_pose 60, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sWeezingPose115:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose116:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose117:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose118:
+ax_pose 61, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose119:
+ax_pose 62, 0x41e3, 0x80ef, 0x7c00
+ax_pose 63, 0x01f3, 0x40ef, 0x7c08
+ax_pose 64, 0x01fb, 0x00ff, 0x7c0c
+ax_pose 65, 0x01eb, 0x010f, 0x7c0d
+ax_pose 66, 0x41f3, 0x00ff, 0x7c0e
+ax_pose_terminator
+sWeezingPose120:
+ax_pose 31, 0x41e0, 0x80e8, 0x7c00
+ax_pose 32, 0x01e0, 0x4108, 0x7c08
+ax_pose 33, 0x41f0, 0x80e8, 0x7c0c
+ax_pose 34, 0x01f0, 0x4108, 0x7c14
+ax_pose 67, 0x01df, 0x80ec, 0x7c18
+ax_pose_terminator
+sWeezingPose121:
+ax_pose 67, 0x01df, 0x80ec, 0x7c00
+ax_pose_terminator
+sWeezingPose122:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose123:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose124:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose125:
+ax_pose 68, 0x41e8, 0x80ed, 0x7c00
+ax_pose 69, 0x41f8, 0x40ed, 0x7c08
+ax_pose 70, 0x01e8, 0x010d, 0x7c0c
+ax_pose 71, 0x01f0, 0x010d, 0x7c0d
+ax_pose 72, 0x01e0, 0x00f9, 0x7c0e
+ax_pose 73, 0x01e0, 0x0105, 0x7c0f
+ax_pose_terminator
+sWeezingPose126:
+ax_pose 74, 0x01e1, 0x80e5, 0x7c00
+ax_pose 75, 0x81e1, 0x8105, 0x7c10
+ax_pose_terminator
+sWeezingPose127:
+ax_pose 31, 0x41e0, 0x80e6, 0x7c00
+ax_pose 32, 0x01e0, 0x4106, 0x7c08
+ax_pose 33, 0x41f0, 0x80e6, 0x7c0c
+ax_pose 34, 0x01f0, 0x4106, 0x7c14
+ax_pose 76, 0x01e2, 0x80f0, 0x7c18
+ax_pose_terminator
+sWeezingPose128:
+ax_pose 76, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose129:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose130:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose131:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose132:
+ax_pose 24, 0x41e5, 0x80ec, 0x7c00
+ax_pose 25, 0x41f5, 0x40ec, 0x7c08
+ax_pose 26, 0x41fd, 0x00f1, 0x7c0c
+ax_pose 27, 0x01e5, 0x010c, 0x7c0e
+ax_pose 28, 0x01ed, 0x010c, 0x7c0f
+ax_pose_terminator
+sWeezingPose133:
+ax_pose 29, 0x01e2, 0x80e4, 0x7c00
+ax_pose 30, 0x81e2, 0x8104, 0x7c10
+ax_pose_terminator
+sWeezingPose134:
+ax_pose 31, 0x41e0, 0x84e6, 0x7c00
+ax_pose 32, 0x01e0, 0x4506, 0x7c08
+ax_pose 33, 0x41f0, 0x84e6, 0x7c0c
+ax_pose 34, 0x01f0, 0x4506, 0x7c14
+ax_pose 35, 0x01e3, 0x80ee, 0x7c18
+ax_pose_terminator
+sWeezingPose135:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 35, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose136:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 35, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose137:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 35, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose138:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 35, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose139:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 35, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose140:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 35, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose141:
+ax_pose 35, 0x01e3, 0x80ee, 0x7c00
+ax_pose_terminator
+sWeezingPose142:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose143:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose144:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose145:
+ax_pose 36, 0x01e1, 0x80ed, 0x7c00
+ax_pose_terminator
+sWeezingPose146:
+ax_pose 37, 0x01e1, 0x80ed, 0x7c00
+ax_pose 38, 0x81e1, 0x010d, 0x7c10
+ax_pose 39, 0x4201, 0x40ed, 0x7c12
+ax_pose_terminator
+sWeezingPose147:
+ax_pose 31, 0x41e0, 0x84e4, 0x7c00
+ax_pose 32, 0x01e0, 0x4504, 0x7c08
+ax_pose 33, 0x41f0, 0x84e4, 0x7c0c
+ax_pose 34, 0x01f0, 0x4504, 0x7c14
+ax_pose 40, 0x01e3, 0x80ee, 0x7c18
+ax_pose_terminator
+sWeezingPose148:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 40, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose149:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 40, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose150:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 40, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose151:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 40, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose152:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 40, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose153:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 40, 0x01e3, 0x80ee, 0x7c04
+ax_pose_terminator
+sWeezingPose154:
+ax_pose 40, 0x01e3, 0x80ee, 0x7c00
+ax_pose_terminator
+sWeezingPose155:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose156:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose157:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose158:
+ax_pose 41, 0x01df, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose159:
+ax_pose 42, 0x01df, 0x80ef, 0x7c00
+ax_pose 43, 0x41ff, 0x40ef, 0x7c10
+ax_pose_terminator
+sWeezingPose160:
+ax_pose 31, 0x41e0, 0x84e9, 0x7c00
+ax_pose 32, 0x01e0, 0x4509, 0x7c08
+ax_pose 33, 0x41f0, 0x84e9, 0x7c0c
+ax_pose 34, 0x01f0, 0x4509, 0x7c14
+ax_pose 44, 0x01e0, 0x80f0, 0x7c18
+ax_pose_terminator
+sWeezingPose161:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 44, 0x01e0, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose162:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 44, 0x01e0, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose163:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 44, 0x01e0, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose164:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 44, 0x01e0, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose165:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 44, 0x01e0, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose166:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 44, 0x01e0, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose167:
+ax_pose 44, 0x01e0, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose168:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose169:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose170:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose171:
+ax_pose 45, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose172:
+ax_pose 46, 0x01e2, 0x80f4, 0x7c00
+ax_pose 47, 0x81e2, 0x00ec, 0x7c10
+ax_pose 48, 0x0202, 0x0104, 0x7c12
+ax_pose_terminator
+sWeezingPose173:
+ax_pose 31, 0x41df, 0x84e9, 0x7c00
+ax_pose 32, 0x01df, 0x4509, 0x7c08
+ax_pose 33, 0x41ef, 0x84e9, 0x7c0c
+ax_pose 34, 0x01ef, 0x4509, 0x7c14
+ax_pose 49, 0x01e0, 0x80ef, 0x7c18
+ax_pose_terminator
+sWeezingPose174:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 49, 0x01e0, 0x80ef, 0x7c04
+ax_pose_terminator
+sWeezingPose175:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 49, 0x01e0, 0x80ef, 0x7c04
+ax_pose_terminator
+sWeezingPose176:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 49, 0x01e0, 0x80ef, 0x7c04
+ax_pose_terminator
+sWeezingPose177:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 49, 0x01e0, 0x80ef, 0x7c04
+ax_pose_terminator
+sWeezingPose178:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 49, 0x01e0, 0x80ef, 0x7c04
+ax_pose_terminator
+sWeezingPose179:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 49, 0x01e0, 0x80ef, 0x7c04
+ax_pose_terminator
+sWeezingPose180:
+ax_pose 49, 0x01e0, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose181:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose182:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose183:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose184:
+ax_pose 50, 0x81e1, 0x80f0, 0x7c00
+ax_pose 51, 0x81e1, 0x4100, 0x7c08
+ax_pose 52, 0x01e9, 0x00e8, 0x7c0c
+ax_pose 53, 0x01e9, 0x0108, 0x7c0d
+ax_pose 54, 0x81f1, 0x0108, 0x7c0e
+ax_pose_terminator
+sWeezingPose185:
+ax_pose 55, 0x01e1, 0x80ea, 0x7c00
+ax_pose 56, 0x81e1, 0x410a, 0x7c10
+ax_pose_terminator
+sWeezingPose186:
+ax_pose 31, 0x41e0, 0x84e8, 0x7c00
+ax_pose 32, 0x01e0, 0x4508, 0x7c08
+ax_pose 33, 0x41f0, 0x84e8, 0x7c0c
+ax_pose 34, 0x01f0, 0x4508, 0x7c14
+ax_pose 57, 0x01e1, 0x80f2, 0x7c18
+ax_pose_terminator
+sWeezingPose187:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 57, 0x01e1, 0x80f2, 0x7c04
+ax_pose_terminator
+sWeezingPose188:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 57, 0x01e1, 0x80f2, 0x7c04
+ax_pose_terminator
+sWeezingPose189:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 57, 0x01e1, 0x80f2, 0x7c04
+ax_pose_terminator
+sWeezingPose190:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 57, 0x01e1, 0x80f2, 0x7c04
+ax_pose_terminator
+sWeezingPose191:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 57, 0x01e1, 0x80f2, 0x7c04
+ax_pose_terminator
+sWeezingPose192:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 57, 0x01e1, 0x80f2, 0x7c04
+ax_pose_terminator
+sWeezingPose193:
+ax_pose 57, 0x01e1, 0x80f2, 0x7c00
+ax_pose_terminator
+sWeezingPose194:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose195:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose196:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose197:
+ax_pose 58, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose198:
+ax_pose 59, 0x01e1, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose199:
+ax_pose 31, 0x41e0, 0x84e7, 0x7c00
+ax_pose 32, 0x01e0, 0x4507, 0x7c08
+ax_pose 33, 0x41f0, 0x84e7, 0x7c0c
+ax_pose 34, 0x01f0, 0x4507, 0x7c14
+ax_pose 60, 0x01e1, 0x80f1, 0x7c18
+ax_pose_terminator
+sWeezingPose200:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 60, 0x01e1, 0x80f1, 0x7c04
+ax_pose_terminator
+sWeezingPose201:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 60, 0x01e1, 0x80f1, 0x7c04
+ax_pose_terminator
+sWeezingPose202:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 60, 0x01e1, 0x80f1, 0x7c04
+ax_pose_terminator
+sWeezingPose203:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 60, 0x01e1, 0x80f1, 0x7c04
+ax_pose_terminator
+sWeezingPose204:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 60, 0x01e1, 0x80f1, 0x7c04
+ax_pose_terminator
+sWeezingPose205:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 60, 0x01e1, 0x80f1, 0x7c04
+ax_pose_terminator
+sWeezingPose206:
+ax_pose 60, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sWeezingPose207:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose208:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose209:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose210:
+ax_pose 61, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose211:
+ax_pose 62, 0x41e3, 0x80ef, 0x7c00
+ax_pose 63, 0x01f3, 0x40ef, 0x7c08
+ax_pose 64, 0x01fb, 0x00ff, 0x7c0c
+ax_pose 65, 0x01eb, 0x010f, 0x7c0d
+ax_pose 66, 0x41f3, 0x00ff, 0x7c0e
+ax_pose_terminator
+sWeezingPose212:
+ax_pose 31, 0x41e0, 0x84e8, 0x7c00
+ax_pose 32, 0x01e0, 0x4508, 0x7c08
+ax_pose 33, 0x41f0, 0x84e8, 0x7c0c
+ax_pose 34, 0x01f0, 0x4508, 0x7c14
+ax_pose 67, 0x01df, 0x80ec, 0x7c18
+ax_pose_terminator
+sWeezingPose213:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 67, 0x01df, 0x80ec, 0x7c04
+ax_pose_terminator
+sWeezingPose214:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 67, 0x01df, 0x80ec, 0x7c04
+ax_pose_terminator
+sWeezingPose215:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 67, 0x01df, 0x80ec, 0x7c04
+ax_pose_terminator
+sWeezingPose216:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 67, 0x01df, 0x80ec, 0x7c04
+ax_pose_terminator
+sWeezingPose217:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 67, 0x01df, 0x80ec, 0x7c04
+ax_pose_terminator
+sWeezingPose218:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 67, 0x01df, 0x80ec, 0x7c04
+ax_pose_terminator
+sWeezingPose219:
+ax_pose 67, 0x01df, 0x80ec, 0x7c00
+ax_pose_terminator
+sWeezingPose220:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose221:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose222:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose223:
+ax_pose 68, 0x41e8, 0x80ed, 0x7c00
+ax_pose 69, 0x41f8, 0x40ed, 0x7c08
+ax_pose 70, 0x01e8, 0x010d, 0x7c0c
+ax_pose 71, 0x01f0, 0x010d, 0x7c0d
+ax_pose 72, 0x01e0, 0x00f9, 0x7c0e
+ax_pose 73, 0x01e0, 0x0105, 0x7c0f
+ax_pose_terminator
+sWeezingPose224:
+ax_pose 74, 0x01e1, 0x80e5, 0x7c00
+ax_pose 75, 0x81e1, 0x8105, 0x7c10
+ax_pose_terminator
+sWeezingPose225:
+ax_pose 31, 0x41e0, 0x84e6, 0x7c00
+ax_pose 32, 0x01e0, 0x4506, 0x7c08
+ax_pose 33, 0x41f0, 0x84e6, 0x7c0c
+ax_pose 34, 0x01f0, 0x4506, 0x7c14
+ax_pose 76, 0x01e2, 0x80f0, 0x7c18
+ax_pose_terminator
+sWeezingPose226:
+ax_pose 77, 0x01e1, 0x44e5, 0x7c00
+ax_pose -1, 0x01de, 0x4508, 0x7c00
+ax_pose -1, 0x01f6, 0x44e4, 0x7c00
+ax_pose -1, 0x01f4, 0x4508, 0x7c00
+ax_pose 76, 0x01e2, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose227:
+ax_pose 78, 0x01e0, 0x44e4, 0x7c00
+ax_pose -1, 0x01dd, 0x4509, 0x7c00
+ax_pose -1, 0x01f7, 0x44e3, 0x7c00
+ax_pose -1, 0x01f5, 0x4509, 0x7c00
+ax_pose 76, 0x01e2, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose228:
+ax_pose 79, 0x01de, 0x44e3, 0x7c00
+ax_pose -1, 0x01db, 0x450a, 0x7c00
+ax_pose -1, 0x01f7, 0x44e2, 0x7c00
+ax_pose -1, 0x01f5, 0x450a, 0x7c00
+ax_pose 76, 0x01e2, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose229:
+ax_pose 80, 0x01dc, 0x44e2, 0x7c00
+ax_pose -1, 0x01d9, 0x450b, 0x7c00
+ax_pose -1, 0x01f7, 0x44e1, 0x7c00
+ax_pose -1, 0x01f5, 0x450b, 0x7c00
+ax_pose 76, 0x01e2, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose230:
+ax_pose 81, 0x01da, 0x44e1, 0x7c00
+ax_pose -1, 0x01d7, 0x450c, 0x7c00
+ax_pose -1, 0x01f7, 0x44e0, 0x7c00
+ax_pose -1, 0x01f5, 0x450c, 0x7c00
+ax_pose 76, 0x01e2, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose231:
+ax_pose 82, 0x01d8, 0x44e0, 0x7c00
+ax_pose -1, 0x01d5, 0x450d, 0x7c00
+ax_pose -1, 0x01f5, 0x44df, 0x7c00
+ax_pose -1, 0x01f3, 0x450d, 0x7c00
+ax_pose 76, 0x01e2, 0x80f0, 0x7c04
+ax_pose_terminator
+sWeezingPose232:
+ax_pose 76, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose233:
+ax_pose 83, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose234:
+ax_pose 84, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose235:
+ax_pose 85, 0x01e3, 0x80f2, 0x7c00
+ax_pose_terminator
+sWeezingPose236:
+ax_pose 86, 0x01e1, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose237:
+ax_pose 87, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose238:
+ax_pose 88, 0x01e1, 0x80f1, 0x7c00
+ax_pose_terminator
+sWeezingPose239:
+ax_pose 89, 0x01e2, 0x80f1, 0x7c00
+ax_pose_terminator
+sWeezingPose240:
+ax_pose 90, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose241:
+ax_pose 91, 0x01e2, 0x80ee, 0x7c00
+ax_pose_terminator
+sWeezingPose242:
+ax_pose 92, 0x01df, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose243:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose244:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose245:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose246:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose247:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose248:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose249:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose250:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose251:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose252:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose253:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose254:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose255:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose256:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose257:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose258:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose259:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose260:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose261:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose262:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose263:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose264:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose265:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose266:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose267:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose268:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose269:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose270:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose271:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose272:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose273:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose274:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose275:
+ax_pose 24, 0x41e5, 0x80ec, 0x7c00
+ax_pose 25, 0x41f5, 0x40ec, 0x7c08
+ax_pose 26, 0x41fd, 0x00f1, 0x7c0c
+ax_pose 27, 0x01e5, 0x010c, 0x7c0e
+ax_pose 28, 0x01ed, 0x010c, 0x7c0f
+ax_pose_terminator
+sWeezingPose276:
+ax_pose 36, 0x01e1, 0x80ed, 0x7c00
+ax_pose_terminator
+sWeezingPose277:
+ax_pose 41, 0x01e0, 0x80ef, 0x7c00
+ax_pose_terminator
+sWeezingPose278:
+ax_pose 45, 0x01e2, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose279:
+ax_pose 50, 0x81e1, 0x80f0, 0x7c00
+ax_pose 51, 0x81e1, 0x4100, 0x7c08
+ax_pose 52, 0x01e9, 0x00e8, 0x7c0c
+ax_pose 53, 0x01e9, 0x0108, 0x7c0d
+ax_pose 54, 0x81f1, 0x0108, 0x7c0e
+ax_pose_terminator
+sWeezingPose280:
+ax_pose 58, 0x01e1, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose281:
+ax_pose 61, 0x01df, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose282:
+ax_pose 68, 0x41e8, 0x80ed, 0x7c00
+ax_pose 69, 0x41f8, 0x40ed, 0x7c08
+ax_pose 70, 0x01e8, 0x010d, 0x7c0c
+ax_pose 71, 0x01f0, 0x010d, 0x7c0d
+ax_pose 72, 0x01e0, 0x00f9, 0x7c0e
+ax_pose 73, 0x01e0, 0x0105, 0x7c0f
+ax_pose_terminator
+sWeezingPose283:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose284:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose285:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose286:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose287:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose288:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose289:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose290:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose291:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose292:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose293:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose294:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose295:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose296:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose297:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose298:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose299:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose300:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose301:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose302:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose303:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose304:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose305:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose306:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose307:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose308:
+ax_pose 1, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose309:
+ax_pose 2, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose310:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose311:
+ax_pose 4, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose312:
+ax_pose 5, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose313:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose314:
+ax_pose 7, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose315:
+ax_pose 8, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose316:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose317:
+ax_pose 10, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose318:
+ax_pose 11, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose319:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose320:
+ax_pose 13, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose321:
+ax_pose 14, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose322:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose323:
+ax_pose 16, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose324:
+ax_pose 17, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose325:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose326:
+ax_pose 19, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose327:
+ax_pose 20, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose328:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose329:
+ax_pose 22, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose330:
+ax_pose 23, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose331:
+ax_pose 0, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose332:
+ax_pose 21, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose333:
+ax_pose 18, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose334:
+ax_pose 15, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose335:
+ax_pose 12, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose336:
+ax_pose 9, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose337:
+ax_pose 6, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+sWeezingPose338:
+ax_pose 3, 0x01e3, 0x80f0, 0x7c00
+ax_pose_terminator
+.align 2
+sWeezingAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, -2, 0, 0,
+ax_anim 8, 0, 1, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, -2, 0, 0,
+ax_anim 8, 0, 4, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, -2, 0, 0,
+ax_anim 8, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, -2, 0, 0,
+ax_anim 8, 0, 10, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, -2, 0, 0,
+ax_anim 8, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, -2, 0, 0,
+ax_anim 8, 0, 16, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, -2, 0, 0,
+ax_anim 8, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, -2, 0, 0,
+ax_anim 8, 0, 22, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 45, 0, -4, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 24, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 23, 0, 23,
+ax_anim 1, 1, 30, 0, 23, 0, 23,
+ax_anim 1, 0, 33, 0, 23, 0, 23,
+ax_anim 1, 0, 36, 0, 23, 0, 23,
+ax_anim 1, 0, 39, 0, 23, 0, 23,
+ax_anim 2, 0, 42, 0, 12, 0, 23,
+ax_anim 2, 0, 45, 0, 3, 0, 23,
+ax_anim_terminator
+sWeezingAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 6, 0, 24, -4, -4, -4, -4,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 3, 5, 3, 5,
+ax_anim 1, 0, 27, 9, 12, 9, 12,
+ax_anim 2, 0, 30, 17, 23, 17, 23,
+ax_anim 1, 1, 33, 17, 23, 17, 23,
+ax_anim 1, 0, 36, 17, 23, 17, 23,
+ax_anim 1, 0, 39, 17, 23, 17, 23,
+ax_anim 1, 0, 42, 17, 23, 17, 23,
+ax_anim 2, 0, 45, 9, 12, 9, 12,
+ax_anim 2, 0, 24, 2, 3, 2, 3,
+ax_anim_terminator
+sWeezingAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 6, 0, 27, -4, 0, -4, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 3, 0, 3, 0,
+ax_anim 1, 0, 30, 9, 0, 9, 0,
+ax_anim 2, 0, 33, 15, 0, 15, 0,
+ax_anim 1, 1, 36, 15, 0, 15, 0,
+ax_anim 1, 0, 39, 15, 0, 15, 0,
+ax_anim 1, 0, 42, 15, 0, 15, 0,
+ax_anim 1, 0, 45, 15, 0, 15, 0,
+ax_anim 2, 0, 24, 9, 0, 9, 0,
+ax_anim 2, 0, 27, 2, 0, 2, 0,
+ax_anim_terminator
+sWeezingAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 6, 0, 30, -4, 4, -4, 4,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, -5, 4, -5,
+ax_anim 1, 0, 33, 11, -11, 11, -11,
+ax_anim 2, 0, 36, 15, -15, 15, -15,
+ax_anim 1, 1, 39, 15, -15, 15, -15,
+ax_anim 1, 0, 42, 15, -15, 15, -15,
+ax_anim 1, 0, 45, 15, -15, 15, -15,
+ax_anim 1, 0, 24, 15, -15, 15, -15,
+ax_anim 2, 0, 27, 11, -11, 11, -11,
+ax_anim 2, 0, 30, 3, -3, 3, -3,
+ax_anim_terminator
+sWeezingAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 6, 0, 33, 0, 4, 0, 4,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -5, 0, -5,
+ax_anim 1, 0, 36, 0, -11, 0, -11,
+ax_anim 2, 0, 39, 0, -15, 0, -15,
+ax_anim 1, 1, 42, 0, -15, 0, -15,
+ax_anim 1, 0, 45, 0, -15, 0, -15,
+ax_anim 1, 0, 24, 0, -15, 0, -15,
+ax_anim 1, 0, 27, 0, -15, 0, -15,
+ax_anim 2, 0, 30, 0, -11, 0, -11,
+ax_anim 2, 0, 33, 0, -3, 0, -3,
+ax_anim_terminator
+sWeezingAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 6, 0, 36, 4, 4, 4, 4,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 39, -4, -5, -4, -5,
+ax_anim 1, 0, 39, -11, -11, -11, -11,
+ax_anim 2, 0, 42, -15, -15, -15, -15,
+ax_anim 1, 1, 45, -15, -15, -15, -15,
+ax_anim 1, 0, 24, -15, -15, -15, -15,
+ax_anim 1, 0, 27, -15, -15, -15, -15,
+ax_anim 1, 0, 30, -15, -15, -15, -15,
+ax_anim 2, 0, 33, -11, -11, -11, -11,
+ax_anim 2, 0, 36, -3, -3, -3, -3,
+ax_anim_terminator
+sWeezingAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 6, 0, 39, 4, 0, 4, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -3, 0, -3, 0,
+ax_anim 1, 0, 42, -9, 0, -9, 0,
+ax_anim 2, 0, 45, -15, 0, -15, 0,
+ax_anim 1, 1, 24, -15, 0, -15, 0,
+ax_anim 1, 0, 27, -15, 0, -15, 0,
+ax_anim 1, 0, 30, -15, 0, -15, 0,
+ax_anim 1, 0, 33, -15, 0, -15, 0,
+ax_anim 2, 0, 36, -9, 0, -9, 0,
+ax_anim 2, 0, 39, -2, 0, -2, 0,
+ax_anim_terminator
+sWeezingAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 6, 0, 42, 4, -4, 4, -4,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -3, 5, -3, 5,
+ax_anim 1, 0, 45, -8, 12, -8, 12,
+ax_anim 2, 0, 24, -14, 23, -14, 23,
+ax_anim 1, 1, 27, -14, 23, -14, 23,
+ax_anim 1, 0, 30, -14, 23, -14, 23,
+ax_anim 1, 0, 33, -14, 23, -14, 23,
+ax_anim 1, 0, 36, -14, 23, -14, 23,
+ax_anim 2, 0, 39, -8, 12, -8, 12,
+ax_anim 2, 0, 42, -2, 3, -2, 3,
+ax_anim_terminator
+.align 2
+sWeezingAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 6, 0, 69, 0, -4, 0, -2,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 51, 0, 23, 0, 23,
+ax_anim 1, 1, 54, 0, 23, 0, 23,
+ax_anim 1, 0, 57, 0, 23, 0, 23,
+ax_anim 1, 0, 60, 0, 23, 0, 23,
+ax_anim 1, 0, 63, 0, 23, 0, 23,
+ax_anim 2, 0, 66, 0, 12, 0, 23,
+ax_anim 2, 0, 69, 0, 3, 0, 23,
+ax_anim_terminator
+sWeezingAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 6, 0, 48, -4, -4, -4, -4,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 3, 5, 3, 5,
+ax_anim 1, 0, 51, 9, 12, 9, 12,
+ax_anim 2, 0, 54, 17, 23, 17, 23,
+ax_anim 1, 1, 57, 17, 23, 17, 23,
+ax_anim 1, 0, 60, 17, 23, 17, 23,
+ax_anim 1, 0, 63, 17, 23, 17, 23,
+ax_anim 1, 0, 66, 17, 23, 17, 23,
+ax_anim 2, 0, 69, 9, 12, 9, 12,
+ax_anim 2, 0, 48, 2, 3, 2, 3,
+ax_anim_terminator
+sWeezingAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 6, 0, 51, -4, 0, -4, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 3, 0, 3, 0,
+ax_anim 1, 0, 54, 9, 0, 9, 0,
+ax_anim 2, 0, 57, 15, 0, 15, 0,
+ax_anim 1, 1, 60, 15, 0, 15, 0,
+ax_anim 1, 0, 63, 15, 0, 15, 0,
+ax_anim 1, 0, 66, 15, 0, 15, 0,
+ax_anim 1, 0, 69, 15, 0, 15, 0,
+ax_anim 2, 0, 48, 9, 0, 9, 0,
+ax_anim 2, 0, 51, 2, 0, 2, 0,
+ax_anim_terminator
+sWeezingAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 6, 0, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 4, -5, 4, -5,
+ax_anim 1, 0, 57, 11, -11, 11, -11,
+ax_anim 2, 0, 60, 15, -15, 15, -15,
+ax_anim 1, 1, 63, 15, -15, 15, -15,
+ax_anim 1, 0, 66, 15, -15, 15, -15,
+ax_anim 1, 0, 69, 15, -15, 15, -15,
+ax_anim 1, 0, 48, 15, -15, 15, -15,
+ax_anim 2, 0, 51, 11, -11, 11, -11,
+ax_anim 2, 0, 54, 3, -3, 3, -3,
+ax_anim_terminator
+sWeezingAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 6, 0, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -5, 0, -5,
+ax_anim 1, 0, 60, 0, -11, 0, -11,
+ax_anim 2, 0, 63, 0, -15, 0, -15,
+ax_anim 1, 1, 66, 0, -15, 0, -15,
+ax_anim 1, 0, 69, 0, -15, 0, -15,
+ax_anim 1, 0, 48, 0, -15, 0, -15,
+ax_anim 1, 0, 51, 0, -15, 0, -15,
+ax_anim 2, 0, 54, 0, -11, 0, -11,
+ax_anim 2, 0, 57, 0, -3, 0, -3,
+ax_anim_terminator
+sWeezingAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 6, 0, 60, 4, 4, 4, 4,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 63, -4, -5, -4, -5,
+ax_anim 1, 0, 63, -11, -11, -11, -11,
+ax_anim 2, 0, 66, -15, -15, -15, -15,
+ax_anim 1, 1, 69, -15, -15, -15, -15,
+ax_anim 1, 0, 48, -15, -15, -15, -15,
+ax_anim 1, 0, 51, -15, -15, -15, -15,
+ax_anim 1, 0, 54, -15, -15, -15, -15,
+ax_anim 2, 0, 57, -11, -11, -11, -11,
+ax_anim 2, 0, 60, -3, -3, -3, -3,
+ax_anim_terminator
+sWeezingAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 6, 0, 63, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -3, 0, -3, 0,
+ax_anim 1, 0, 66, -9, 0, -9, 0,
+ax_anim 2, 0, 69, -15, 0, -15, 0,
+ax_anim 1, 1, 48, -15, 0, -15, 0,
+ax_anim 1, 0, 51, -15, 0, -15, 0,
+ax_anim 1, 0, 54, -15, 0, -15, 0,
+ax_anim 1, 0, 57, -15, 0, -15, 0,
+ax_anim 2, 0, 60, -9, 0, -9, 0,
+ax_anim 2, 0, 63, -2, 0, -2, 0,
+ax_anim_terminator
+sWeezingAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 6, 0, 66, 4, -4, 4, -4,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -3, 5, -3, 5,
+ax_anim 1, 0, 69, -8, 12, -8, 12,
+ax_anim 2, 0, 48, -14, 23, -14, 23,
+ax_anim 1, 1, 51, -14, 23, -14, 23,
+ax_anim 1, 0, 54, -14, 23, -14, 23,
+ax_anim 1, 0, 57, -14, 23, -14, 23,
+ax_anim 1, 0, 60, -14, 23, -14, 23,
+ax_anim 2, 0, 63, -8, 12, -8, 12,
+ax_anim 2, 0, 66, -2, 3, -2, 3,
+ax_anim_terminator
+.align 2
+sWeezingAnims_4_1:
+ax_anim 2, 0, 72, 0, -1, 0, 0,
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 4, 0, 75, 0, -4, 0, 0,
+ax_anim 4, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 2, 76, 1, -4, 1, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 1, -4, 1, 0,
+ax_anim 2, 0, 74, 0, 2, 0, 0,
+ax_anim 2, 1, 78, 1, 4, 1, 0,
+ax_anim 2, 0, 78, 0, 4, 0, 0,
+ax_anim 2, 0, 78, 1, 4, 1, 0,
+ax_anim 2, 0, 78, 0, 4, 0, 0,
+ax_anim_terminator
+sWeezingAnims_4_2:
+ax_anim 2, 0, 79, 0, -1, 0, 0,
+ax_anim 2, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 0, 81, 0, -3, 0, 0,
+ax_anim 4, 0, 82, 0, -4, 0, 0,
+ax_anim 4, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 2, 83, 1, -5, 1, -1,
+ax_anim 2, 0, 83, 0, -4, 0, 0,
+ax_anim 2, 0, 83, 1, -5, 1, -1,
+ax_anim 2, 0, 81, 4, 0, 4, 1,
+ax_anim 2, 1, 85, 7, 1, 7, 2,
+ax_anim 2, 0, 85, 6, 2, 6, 3,
+ax_anim 2, 0, 85, 7, 1, 7, 2,
+ax_anim 2, 0, 85, 6, 2, 6, 3,
+ax_anim_terminator
+sWeezingAnims_4_3:
+ax_anim 2, 0, 86, 0, -1, 0, 0,
+ax_anim 2, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 0, 88, 0, -3, 0, 0,
+ax_anim 4, 0, 89, 0, -4, 0, 0,
+ax_anim 4, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 2, 90, 1, -4, 1, 0,
+ax_anim 2, 0, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 90, 1, -4, 1, 0,
+ax_anim 2, 0, 88, 2, -2, 2, 0,
+ax_anim 2, 1, 92, 4, -1, 4, 0,
+ax_anim 2, 0, 92, 4, -2, 4, -1,
+ax_anim 2, 0, 92, 4, -1, 4, 0,
+ax_anim 2, 0, 92, 4, -2, 4, -1,
+ax_anim_terminator
+sWeezingAnims_4_4:
+ax_anim 2, 0, 93, 0, -1, 0, 0,
+ax_anim 2, 0, 94, 0, -2, 0, 0,
+ax_anim 2, 0, 95, 0, -3, 0, 0,
+ax_anim 4, 0, 96, 0, -4, 0, 0,
+ax_anim 4, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 2, 97, 1, -3, 1, 1,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 1, -3, 1, 1,
+ax_anim 2, 0, 95, 3, -3, 3, -3,
+ax_anim 2, 1, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim 2, 0, 99, 4, -4, 4, -4,
+ax_anim 2, 0, 99, 5, -3, 5, -3,
+ax_anim_terminator
+sWeezingAnims_4_5:
+ax_anim 2, 0, 100, 0, 1, 0, 0,
+ax_anim 2, 0, 101, 0, 2, 0, 0,
+ax_anim 2, 0, 102, 0, 3, 0, 0,
+ax_anim 4, 0, 103, 0, 4, 0, 0,
+ax_anim 4, 0, 104, 0, 4, 0, 0,
+ax_anim 2, 2, 104, 1, 4, 1, 0,
+ax_anim 2, 0, 104, 0, 4, 0, 0,
+ax_anim 2, 0, 104, 1, 4, 1, 0,
+ax_anim 2, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 1, 106, 1, -4, 1, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 2, 0, 106, 1, -4, 1, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim_terminator
+sWeezingAnims_4_6:
+ax_anim 2, 0, 107, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 4, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 2, 111, -1, -3, -1, 1,
+ax_anim 2, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, -1, -3, -1, 1,
+ax_anim 2, 0, 109, -3, -3, -3, -3,
+ax_anim 2, 1, 113, -4, -4, -4, -4,
+ax_anim 2, 0, 113, -5, -3, -5, -3,
+ax_anim 2, 0, 113, -4, -4, -4, -4,
+ax_anim 2, 0, 113, -5, -3, -5, -3,
+ax_anim_terminator
+sWeezingAnims_4_7:
+ax_anim 2, 0, 114, 0, -1, 0, 0,
+ax_anim 2, 0, 115, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -3, 0, 0,
+ax_anim 4, 0, 117, 0, -4, 0, 0,
+ax_anim 4, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 2, 118, -1, -4, -1, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 2, 0, 118, -1, -4, -1, 0,
+ax_anim 2, 0, 116, -2, -2, -2, 0,
+ax_anim 2, 1, 120, -4, -1, -4, 0,
+ax_anim 2, 0, 120, -4, -2, -4, -1,
+ax_anim 2, 0, 120, -4, -1, -4, 0,
+ax_anim 2, 0, 120, -4, -2, -4, -1,
+ax_anim_terminator
+sWeezingAnims_4_8:
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim 2, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 123, 0, -3, 0, 0,
+ax_anim 4, 0, 124, 0, -4, 0, 0,
+ax_anim 4, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 2, 125, -1, -5, -1, -1,
+ax_anim 2, 0, 125, 0, -4, 0, 0,
+ax_anim 2, 0, 125, -1, -5, -1, -1,
+ax_anim 2, 0, 123, -4, 0, -4, 1,
+ax_anim 2, 1, 127, -7, 1, -7, 2,
+ax_anim 2, 0, 127, -6, 2, -6, 3,
+ax_anim 2, 0, 127, -7, 1, -7, 2,
+ax_anim 2, 0, 127, -6, 2, -6, 3,
+ax_anim_terminator
+.align 2
+sWeezingAnims_5_1:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 1, 0, 1, 0,
+ax_anim 6, 0, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 2, 134, 0, 1, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, 1, 0, 0,
+ax_anim 2, 1, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_5_2:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 1, -1, 1, -1,
+ax_anim 6, 0, 145, 0, 0, 0, 0,
+ax_anim 4, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 1, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 1, 0, 0,
+ax_anim 2, 1, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_5_3:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 6, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 2, 160, 0, 1, 0, 0,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 1, 0, 0,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_5_4:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 1, 1, 1, 1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 1, 1, 1, 1,
+ax_anim 6, 0, 171, 0, 0, 0, 0,
+ax_anim 4, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 1, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 1, 0, 0,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_5_5:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 1, 0, 1, 0,
+ax_anim 6, 0, 184, 0, 0, 0, 0,
+ax_anim 4, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 186, 0, 1, 0, 0,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, 1, 0, 0,
+ax_anim 2, 1, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_5_6:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 1, -1, 1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, -1, 1, -1, 1,
+ax_anim 6, 0, 197, 0, 0, 0, 0,
+ax_anim 4, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 2, 199, 0, 1, 0, 0,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 0, 1, 0, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_5_7:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, -1, 0, -1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, -1, 0, -1, 0,
+ax_anim 6, 0, 210, 0, 0, 0, 0,
+ax_anim 4, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 1, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 1, 0, 0,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_5_8:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 6, 0, 223, 0, 0, 0, 0,
+ax_anim 4, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 1, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 1, 0, 0,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_6_1:
+ax_anim 16, 0, 232, 0, 0, 0, 0,
+ax_anim 12, 0, 232, 0, -1, 0, 0,
+ax_anim 16, 0, 232, 0, -2, 0, 0,
+ax_anim 16, 0, 233, 0, -2, 0, 0,
+ax_anim 12, 0, 233, 0, -1, 0, 0,
+ax_anim 16, 0, 233, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_7_1:
+ax_anim 2, 0, 234, 0, -2, 0, -2,
+ax_anim 8, 0, 234, 0, -3, 0, -3,
+ax_anim_terminator
+sWeezingAnims_7_2:
+ax_anim 2, 0, 235, -2, -2, -2, -2,
+ax_anim 8, 0, 235, -3, -3, -3, -3,
+ax_anim_terminator
+sWeezingAnims_7_3:
+ax_anim 2, 0, 236, -2, 0, -2, 0,
+ax_anim 8, 0, 236, -3, 0, -3, 0,
+ax_anim_terminator
+sWeezingAnims_7_4:
+ax_anim 2, 0, 237, -2, 2, -2, 2,
+ax_anim 8, 0, 237, -3, 3, -3, 3,
+ax_anim_terminator
+sWeezingAnims_7_5:
+ax_anim 2, 0, 238, 0, 2, 0, 2,
+ax_anim 8, 0, 238, 0, 3, 0, 3,
+ax_anim_terminator
+sWeezingAnims_7_6:
+ax_anim 2, 0, 239, 2, 2, 2, 2,
+ax_anim 8, 0, 239, 3, 3, 3, 3,
+ax_anim_terminator
+sWeezingAnims_7_7:
+ax_anim 2, 0, 240, 2, 0, 2, 0,
+ax_anim 8, 0, 240, 3, 0, 3, 0,
+ax_anim_terminator
+sWeezingAnims_7_8:
+ax_anim 2, 0, 241, 2, -2, 2, -2,
+ax_anim 8, 0, 241, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWeezingAnims_8_1:
+ax_anim 12, 0, 242, 0, 0, 0, 0,
+ax_anim 12, 0, 243, 0, -1, 0, 0,
+ax_anim 12, 0, 244, 0, -2, 0, 0,
+ax_anim 12, 0, 242, 0, -3, 0, 0,
+ax_anim 12, 0, 243, 0, -4, 0, 0,
+ax_anim 12, 0, 244, 0, -5, 0, 0,
+ax_anim 12, 0, 242, 0, -5, 0, 0,
+ax_anim 12, 0, 243, 0, -4, 0, 0,
+ax_anim 12, 0, 244, 0, -3, 0, 0,
+ax_anim 12, 0, 242, 0, -2, 0, 0,
+ax_anim 12, 0, 243, 0, -1, 0, 0,
+ax_anim_terminator
+sWeezingAnims_8_2:
+ax_anim 12, 0, 245, 0, 0, 0, 0,
+ax_anim 12, 0, 246, 0, -1, 0, 0,
+ax_anim 12, 0, 247, 0, -2, 0, 0,
+ax_anim 12, 0, 245, 0, -3, 0, 0,
+ax_anim 12, 0, 246, 0, -4, 0, 0,
+ax_anim 12, 0, 247, 0, -5, 0, 0,
+ax_anim 12, 0, 245, 0, -5, 0, 0,
+ax_anim 12, 0, 246, 0, -4, 0, 0,
+ax_anim 12, 0, 247, 0, -3, 0, 0,
+ax_anim 12, 0, 245, 0, -2, 0, 0,
+ax_anim 12, 0, 246, 0, -1, 0, 0,
+ax_anim_terminator
+sWeezingAnims_8_3:
+ax_anim 12, 0, 248, 0, 0, 0, 0,
+ax_anim 12, 0, 249, 0, -1, 0, 0,
+ax_anim 12, 0, 250, 0, -2, 0, 0,
+ax_anim 12, 0, 248, 0, -3, 0, 0,
+ax_anim 12, 0, 249, 0, -4, 0, 0,
+ax_anim 12, 0, 250, 0, -5, 0, 0,
+ax_anim 12, 0, 248, 0, -5, 0, 0,
+ax_anim 12, 0, 249, 0, -4, 0, 0,
+ax_anim 12, 0, 250, 0, -3, 0, 0,
+ax_anim 12, 0, 248, 0, -2, 0, 0,
+ax_anim 12, 0, 249, 0, -1, 0, 0,
+ax_anim_terminator
+sWeezingAnims_8_4:
+ax_anim 12, 0, 251, 0, 0, 0, 0,
+ax_anim 12, 0, 252, 0, -1, 0, 0,
+ax_anim 12, 0, 253, 0, -2, 0, 0,
+ax_anim 12, 0, 251, 0, -3, 0, 0,
+ax_anim 12, 0, 252, 0, -4, 0, 0,
+ax_anim 12, 0, 253, 0, -5, 0, 0,
+ax_anim 12, 0, 251, 0, -5, 0, 0,
+ax_anim 12, 0, 252, 0, -4, 0, 0,
+ax_anim 12, 0, 253, 0, -3, 0, 0,
+ax_anim 12, 0, 251, 0, -2, 0, 0,
+ax_anim 12, 0, 252, 0, -1, 0, 0,
+ax_anim_terminator
+sWeezingAnims_8_5:
+ax_anim 12, 0, 254, 0, 0, 0, 0,
+ax_anim 12, 0, 255, 0, -1, 0, 0,
+ax_anim 12, 0, 256, 0, -2, 0, 0,
+ax_anim 12, 0, 254, 0, -3, 0, 0,
+ax_anim 12, 0, 255, 0, -4, 0, 0,
+ax_anim 12, 0, 256, 0, -5, 0, 0,
+ax_anim 12, 0, 254, 0, -5, 0, 0,
+ax_anim 12, 0, 255, 0, -4, 0, 0,
+ax_anim 12, 0, 256, 0, -3, 0, 0,
+ax_anim 12, 0, 254, 0, -2, 0, 0,
+ax_anim 12, 0, 255, 0, -1, 0, 0,
+ax_anim_terminator
+sWeezingAnims_8_6:
+ax_anim 12, 0, 257, 0, 0, 0, 0,
+ax_anim 12, 0, 258, 0, -1, 0, 0,
+ax_anim 12, 0, 259, 0, -2, 0, 0,
+ax_anim 12, 0, 257, 0, -3, 0, 0,
+ax_anim 12, 0, 258, 0, -4, 0, 0,
+ax_anim 12, 0, 259, 0, -5, 0, 0,
+ax_anim 12, 0, 257, 0, -5, 0, 0,
+ax_anim 12, 0, 258, 0, -4, 0, 0,
+ax_anim 12, 0, 259, 0, -3, 0, 0,
+ax_anim 12, 0, 257, 0, -2, 0, 0,
+ax_anim 12, 0, 258, 0, -1, 0, 0,
+ax_anim_terminator
+sWeezingAnims_8_7:
+ax_anim 12, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, -1, 0, 0,
+ax_anim 12, 0, 262, 0, -2, 0, 0,
+ax_anim 12, 0, 260, 0, -3, 0, 0,
+ax_anim 12, 0, 261, 0, -4, 0, 0,
+ax_anim 12, 0, 262, 0, -5, 0, 0,
+ax_anim 12, 0, 260, 0, -5, 0, 0,
+ax_anim 12, 0, 261, 0, -4, 0, 0,
+ax_anim 12, 0, 262, 0, -3, 0, 0,
+ax_anim 12, 0, 260, 0, -2, 0, 0,
+ax_anim 12, 0, 261, 0, -1, 0, 0,
+ax_anim_terminator
+sWeezingAnims_8_8:
+ax_anim 12, 0, 263, 0, 0, 0, 0,
+ax_anim 12, 0, 264, 0, -1, 0, 0,
+ax_anim 12, 0, 265, 0, -2, 0, 0,
+ax_anim 12, 0, 263, 0, -3, 0, 0,
+ax_anim 12, 0, 264, 0, -4, 0, 0,
+ax_anim 12, 0, 265, 0, -5, 0, 0,
+ax_anim 12, 0, 263, 0, -5, 0, 0,
+ax_anim 12, 0, 264, 0, -4, 0, 0,
+ax_anim 12, 0, 265, 0, -3, 0, 0,
+ax_anim 12, 0, 263, 0, -2, 0, 0,
+ax_anim 12, 0, 264, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_9_1:
+ax_anim 2, 0, 266, 0, 0, 0, 0,
+ax_anim 1, 0, 267, 6, 3, 6, 3,
+ax_anim 2, 0, 268, 8, 11, 8, 11,
+ax_anim 2, 0, 269, 7, 20, 7, 18,
+ax_anim 3, 0, 270, 0, 25, 0, 22,
+ax_anim 2, 3, 271, -7, 20, -7, 18,
+ax_anim 2, 0, 272, -8, 11, -8, 11,
+ax_anim 1, 0, 273, -6, 3, -6, 3,
+ax_anim 1, 0, 266, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_9_2:
+ax_anim 2, 0, 273, 0, 0, 0, 0,
+ax_anim 1, 0, 266, 8, 0, 8, 0,
+ax_anim 2, 0, 267, 17, 6, 17, 6,
+ax_anim 2, 0, 268, 20, 16, 20, 15,
+ax_anim 3, 0, 269, 21, 25, 21, 22,
+ax_anim 2, 3, 270, 11, 26, 11, 24,
+ax_anim 2, 0, 271, 3, 15, 3, 15,
+ax_anim 1, 0, 272, 0, 7, 0, 7,
+ax_anim 1, 0, 273, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_9_3:
+ax_anim 2, 0, 272, 0, 0, 0, 0,
+ax_anim 1, 0, 273, 4, -3, 4, -3,
+ax_anim 2, 0, 266, 11, -4, 11, -4,
+ax_anim 2, 0, 267, 18, -2, 18, -3,
+ax_anim 3, 0, 268, 22, 4, 22, 1,
+ax_anim 2, 3, 269, 17, 6, 17, 4,
+ax_anim 2, 0, 270, 10, 6, 10, 5,
+ax_anim 1, 0, 271, 4, 5, 4, 4,
+ax_anim 1, 0, 272, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_9_4:
+ax_anim 2, 0, 271, 0, 0, 0, 0,
+ax_anim 1, 0, 272, -1, -8, -1, -8,
+ax_anim 2, 0, 273, 4, -14, 4, -14,
+ax_anim 2, 0, 266, 14, -18, 14, -21,
+ax_anim 3, 0, 267, 21, -14, 21, -16,
+ax_anim 2, 3, 268, 20, -11, 20, -11,
+ax_anim 2, 0, 269, 17, -5, 17, -5,
+ax_anim 1, 0, 270, 7, -1, 7, -1,
+ax_anim 1, 0, 271, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_9_5:
+ax_anim 2, 0, 270, 0, 0, 0, 0,
+ax_anim 1, 0, 271, -8, -4, -8, -4,
+ax_anim 2, 0, 272, -9, -9, -9, -9,
+ax_anim 2, 0, 273, -7, -13, -7, -15,
+ax_anim 3, 0, 266, 0, -16, 0, -19,
+ax_anim 2, 3, 267, 7, -13, 7, -15,
+ax_anim 2, 0, 268, 9, -7, 9, -7,
+ax_anim 1, 0, 269, 8, -4, 8, -4,
+ax_anim 1, 0, 270, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_9_6:
+ax_anim 2, 0, 269, 0, 0, 0, 0,
+ax_anim 1, 0, 268, 1, -8, 1, -8,
+ax_anim 2, 0, 267, -4, -14, -4, -14,
+ax_anim 2, 0, 266, -14, -16, -14, -19,
+ax_anim 3, 0, 273, -21, -14, -21, -16,
+ax_anim 2, 3, 272, -20, -11, -20, -11,
+ax_anim 2, 0, 271, -17, -5, -17, -5,
+ax_anim 1, 0, 270, -7, -1, -7, -1,
+ax_anim 1, 0, 269, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_9_7:
+ax_anim 2, 0, 268, 0, 0, 0, 0,
+ax_anim 1, 0, 267, -4, -3, -4, -3,
+ax_anim 2, 0, 266, -11, -4, -11, -4,
+ax_anim 2, 0, 273, -18, -2, -18, -3,
+ax_anim 3, 0, 272, -22, 4, -22, 1,
+ax_anim 2, 3, 271, -17, 6, -17, 4,
+ax_anim 2, 0, 270, -10, 6, -10, 5,
+ax_anim 1, 0, 269, -4, 5, -4, 4,
+ax_anim 1, 0, 268, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_9_8:
+ax_anim 2, 0, 267, 0, 0, 0, 0,
+ax_anim 1, 0, 266, -8, 0, -8, 0,
+ax_anim 2, 0, 273, -17, 6, -17, 6,
+ax_anim 2, 0, 272, -20, 16, -20, 15,
+ax_anim 3, 0, 271, -21, 25, -21, 22,
+ax_anim 2, 3, 270, -11, 26, -11, 24,
+ax_anim 2, 0, 269, -3, 15, -3, 15,
+ax_anim 1, 0, 268, 0, 7, 0, 7,
+ax_anim 1, 0, 267, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_10_1:
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim 2, 0, 274, 6, 0, 6, 0,
+ax_anim 2, 0, 274, -6, 0, -6, 0,
+ax_anim 2, 0, 274, 10, 0, 10, 0,
+ax_anim 2, 0, 274, -10, 0, -10, 0,
+ax_anim 2, 0, 274, 12, 0, 12, 0,
+ax_anim 3, 0, 274, -12, 0, -12, 0,
+ax_anim 3, 0, 274, 13, 0, 13, 0,
+ax_anim 3, 0, 274, -13, 0, -13, 0,
+ax_anim 2, 0, 274, 12, 0, 12, 0,
+ax_anim 3, 0, 274, -12, 0, -12, 0,
+ax_anim 2, 0, 274, 10, 0, 10, 0,
+ax_anim 2, 0, 274, -10, 0, -10, 0,
+ax_anim 2, 0, 274, 6, 0, 6, 0,
+ax_anim 2, 0, 274, -6, 0, -6, 0,
+ax_anim 2, 0, 274, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_10_2:
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim 2, 0, 275, 6, -6, 6, -6,
+ax_anim 2, 0, 275, -6, 6, -6, 6,
+ax_anim 2, 0, 275, 10, -10, 10, -10,
+ax_anim 2, 0, 275, -10, 10, -10, 10,
+ax_anim 2, 0, 275, 12, -12, 12, -12,
+ax_anim 3, 0, 275, -12, 12, -12, 12,
+ax_anim 3, 0, 275, 13, -13, 13, -13,
+ax_anim 3, 0, 275, -13, 13, -13, 13,
+ax_anim 2, 0, 275, 12, -12, 12, -12,
+ax_anim 3, 0, 275, -12, 12, -12, 12,
+ax_anim 2, 0, 275, 10, -10, 10, -10,
+ax_anim 2, 0, 275, -10, 10, -10, 10,
+ax_anim 2, 0, 275, 6, -6, 6, -6,
+ax_anim 2, 0, 275, -6, 6, -6, 6,
+ax_anim 2, 0, 275, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_10_3:
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim 2, 0, 276, 0, -6, 0, -6,
+ax_anim 2, 0, 276, 0, 6, 0, 6,
+ax_anim 2, 0, 276, 0, -10, 0, -10,
+ax_anim 2, 0, 276, 0, 10, 0, 10,
+ax_anim 2, 0, 276, 0, -12, 0, -12,
+ax_anim 3, 0, 276, 0, 12, 0, 12,
+ax_anim 3, 0, 276, 0, -13, 0, -13,
+ax_anim 3, 0, 276, 0, 13, 0, 13,
+ax_anim 2, 0, 276, 0, -12, 0, -12,
+ax_anim 3, 0, 276, 0, 12, 0, 12,
+ax_anim 2, 0, 276, 0, -10, 0, -10,
+ax_anim 2, 0, 276, 0, 10, 0, 10,
+ax_anim 2, 0, 276, 0, -6, 0, -6,
+ax_anim 2, 0, 276, 0, 6, 0, 6,
+ax_anim 2, 0, 276, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_10_4:
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim 2, 0, 277, -6, -6, -6, -6,
+ax_anim 2, 0, 277, 6, 6, 6, 6,
+ax_anim 2, 0, 277, -10, -10, -10, -10,
+ax_anim 2, 0, 277, 10, 10, 10, 10,
+ax_anim 2, 0, 277, -12, -12, -12, -12,
+ax_anim 3, 0, 277, 12, 12, 12, 12,
+ax_anim 3, 0, 277, -13, -13, -13, -13,
+ax_anim 3, 0, 277, 13, 13, 13, 13,
+ax_anim 2, 0, 277, -12, -12, -12, -12,
+ax_anim 3, 0, 277, 12, 12, 12, 12,
+ax_anim 2, 0, 277, -10, -10, -10, -10,
+ax_anim 2, 0, 277, 10, 10, 10, 10,
+ax_anim 2, 0, 277, -6, -6, -6, -6,
+ax_anim 2, 0, 277, 6, 6, 6, 6,
+ax_anim 2, 0, 277, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_10_5:
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim 2, 0, 278, 6, 0, 6, 0,
+ax_anim 2, 0, 278, -6, 0, -6, 0,
+ax_anim 2, 0, 278, 10, 0, 10, 0,
+ax_anim 2, 0, 278, -10, 0, -10, 0,
+ax_anim 2, 0, 278, 12, 0, 12, 0,
+ax_anim 3, 0, 278, -12, 0, -12, 0,
+ax_anim 3, 0, 278, 13, 0, 13, 0,
+ax_anim 3, 0, 278, -13, 0, -13, 0,
+ax_anim 2, 0, 278, 12, 0, 12, 0,
+ax_anim 3, 0, 278, -12, 0, -12, 0,
+ax_anim 2, 0, 278, 10, 0, 10, 0,
+ax_anim 2, 0, 278, -10, 0, -10, 0,
+ax_anim 2, 0, 278, 6, 0, 6, 0,
+ax_anim 2, 0, 278, -6, 0, -6, 0,
+ax_anim 2, 0, 278, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_10_6:
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim 2, 0, 279, 6, -6, 6, -6,
+ax_anim 2, 0, 279, -6, 6, -6, 6,
+ax_anim 2, 0, 279, 10, -10, 10, -10,
+ax_anim 2, 0, 279, -10, 10, -10, 10,
+ax_anim 2, 0, 279, 12, -12, 12, -12,
+ax_anim 3, 0, 279, -12, 12, -12, 12,
+ax_anim 3, 0, 279, 13, -13, 13, -13,
+ax_anim 3, 0, 279, -13, 13, -13, 13,
+ax_anim 2, 0, 279, 12, -12, 12, -12,
+ax_anim 3, 0, 279, -12, 12, -12, 12,
+ax_anim 2, 0, 279, 10, -10, 10, -10,
+ax_anim 2, 0, 279, -10, 10, -10, 10,
+ax_anim 2, 0, 279, 6, -6, 6, -6,
+ax_anim 2, 0, 279, -6, 6, -6, 6,
+ax_anim 2, 0, 279, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_10_7:
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim 2, 0, 280, 0, -6, 0, -6,
+ax_anim 2, 0, 280, 0, 6, 0, 6,
+ax_anim 2, 0, 280, 0, -10, 0, -10,
+ax_anim 2, 0, 280, 0, 10, 0, 10,
+ax_anim 2, 0, 280, 0, -12, 0, -12,
+ax_anim 3, 0, 280, 0, 12, 0, 12,
+ax_anim 3, 0, 280, 0, -13, 0, -13,
+ax_anim 3, 0, 280, 0, 13, 0, 13,
+ax_anim 2, 0, 280, 0, -12, 0, -12,
+ax_anim 3, 0, 280, 0, 12, 0, 12,
+ax_anim 2, 0, 280, 0, -10, 0, -10,
+ax_anim 2, 0, 280, 0, 10, 0, 10,
+ax_anim 2, 0, 280, 0, -6, 0, -6,
+ax_anim 2, 0, 280, 0, 6, 0, 6,
+ax_anim 2, 0, 280, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_10_8:
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim 2, 0, 281, -6, -6, -6, -6,
+ax_anim 2, 0, 281, 6, 6, 6, 6,
+ax_anim 2, 0, 281, -10, -10, -10, -10,
+ax_anim 2, 0, 281, 10, 10, 10, 10,
+ax_anim 2, 0, 281, -12, -12, -12, -12,
+ax_anim 3, 0, 281, 12, 12, 12, 12,
+ax_anim 3, 0, 281, -13, -13, -13, -13,
+ax_anim 3, 0, 281, 13, 13, 13, 13,
+ax_anim 2, 0, 281, -12, -12, -12, -12,
+ax_anim 3, 0, 281, 12, 12, 12, 12,
+ax_anim 2, 0, 281, -10, -10, -10, -10,
+ax_anim 2, 0, 281, 10, 10, 10, 10,
+ax_anim 2, 0, 281, -6, -6, -6, -6,
+ax_anim 2, 0, 281, 6, 6, 6, 6,
+ax_anim 2, 0, 281, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_11_1:
+ax_anim 2, 0, 282, 0, 0, 0, 0,
+ax_anim 1, 0, 283, 0, -10, 0, 0,
+ax_anim 2, 0, 284, 0, -16, 0, 0,
+ax_anim 3, 0, 282, 0, -20, 0, 0,
+ax_anim 4, 0, 283, 0, -21, 0, 0,
+ax_anim 4, 0, 284, 0, -23, 0, 0,
+ax_anim 3, 0, 282, 0, -22, 0, 0,
+ax_anim 2, 0, 283, 0, -18, 0, 0,
+ax_anim 1, 0, 284, 0, -10, 0, 0,
+ax_anim 2, 2, 282, 0, 5, 0, 0,
+ax_anim_terminator
+sWeezingAnims_11_2:
+ax_anim 2, 0, 285, 0, 0, 0, 0,
+ax_anim 1, 0, 286, 0, -10, 0, 0,
+ax_anim 2, 0, 287, 0, -16, 0, 0,
+ax_anim 3, 0, 285, 0, -20, 0, 0,
+ax_anim 4, 0, 286, 0, -21, 0, 0,
+ax_anim 4, 0, 287, 0, -23, 0, 0,
+ax_anim 3, 0, 285, 0, -22, 0, 0,
+ax_anim 2, 0, 286, 0, -18, 0, 0,
+ax_anim 1, 0, 287, 0, -10, 0, 0,
+ax_anim 2, 2, 285, 0, 5, 0, 0,
+ax_anim_terminator
+sWeezingAnims_11_3:
+ax_anim 2, 0, 288, 0, 0, 0, 0,
+ax_anim 1, 0, 289, 0, -10, 0, 0,
+ax_anim 2, 0, 290, 0, -16, 0, 0,
+ax_anim 3, 0, 288, 0, -20, 0, 0,
+ax_anim 4, 0, 289, 0, -21, 0, 0,
+ax_anim 4, 0, 290, 0, -23, 0, 0,
+ax_anim 3, 0, 288, 0, -22, 0, 0,
+ax_anim 2, 0, 289, 0, -18, 0, 0,
+ax_anim 1, 0, 290, 0, -10, 0, 0,
+ax_anim 2, 2, 288, 0, 5, 0, 0,
+ax_anim_terminator
+sWeezingAnims_11_4:
+ax_anim 2, 0, 291, 0, 0, 0, 0,
+ax_anim 1, 0, 292, 0, -10, 0, 0,
+ax_anim 2, 0, 293, 0, -16, 0, 0,
+ax_anim 3, 0, 291, 0, -20, 0, 0,
+ax_anim 4, 0, 292, 0, -21, 0, 0,
+ax_anim 4, 0, 293, 0, -22, 0, 0,
+ax_anim 3, 0, 291, 0, -21, 0, 0,
+ax_anim 2, 0, 292, 0, -17, 0, 0,
+ax_anim 1, 0, 293, 0, -9, 0, 0,
+ax_anim 2, 2, 291, 0, 5, 0, 0,
+ax_anim_terminator
+sWeezingAnims_11_5:
+ax_anim 2, 0, 294, 0, 0, 0, 0,
+ax_anim 1, 0, 295, 0, -10, 0, 0,
+ax_anim 2, 0, 296, 0, -16, 0, 0,
+ax_anim 3, 0, 294, 0, -20, 0, 0,
+ax_anim 4, 0, 295, 0, -21, 0, 0,
+ax_anim 4, 0, 296, 0, -23, 0, 0,
+ax_anim 3, 0, 294, 0, -22, 0, 0,
+ax_anim 2, 0, 295, 0, -18, 0, 0,
+ax_anim 1, 0, 296, 0, -10, 0, 0,
+ax_anim 2, 2, 294, 0, 5, 0, 0,
+ax_anim_terminator
+sWeezingAnims_11_6:
+ax_anim 2, 0, 297, 0, 0, 0, 0,
+ax_anim 1, 0, 298, 0, -10, 0, 0,
+ax_anim 2, 0, 299, 0, -16, 0, 0,
+ax_anim 3, 0, 297, 0, -20, 0, 0,
+ax_anim 4, 0, 298, 0, -21, 0, 0,
+ax_anim 4, 0, 299, 0, -22, 0, 0,
+ax_anim 3, 0, 297, 0, -21, 0, 0,
+ax_anim 2, 0, 298, 0, -17, 0, 0,
+ax_anim 1, 0, 299, 0, -9, 0, 0,
+ax_anim 2, 2, 297, 0, 5, 0, 0,
+ax_anim_terminator
+sWeezingAnims_11_7:
+ax_anim 2, 0, 300, 0, 0, 0, 0,
+ax_anim 1, 0, 301, 0, -10, 0, 0,
+ax_anim 2, 0, 302, 0, -16, 0, 0,
+ax_anim 3, 0, 300, 0, -20, 0, 0,
+ax_anim 4, 0, 301, 0, -21, 0, 0,
+ax_anim 4, 0, 302, 0, -23, 0, 0,
+ax_anim 3, 0, 300, 0, -22, 0, 0,
+ax_anim 2, 0, 301, 0, -18, 0, 0,
+ax_anim 1, 0, 302, 0, -10, 0, 0,
+ax_anim 2, 2, 300, 0, 5, 0, 0,
+ax_anim_terminator
+sWeezingAnims_11_8:
+ax_anim 2, 0, 303, 0, 0, 0, 0,
+ax_anim 1, 0, 304, 0, -10, 0, 0,
+ax_anim 2, 0, 305, 0, -16, 0, 0,
+ax_anim 3, 0, 303, 0, -20, 0, 0,
+ax_anim 4, 0, 304, 0, -21, 0, 0,
+ax_anim 4, 0, 305, 0, -23, 0, 0,
+ax_anim 3, 0, 303, 0, -22, 0, 0,
+ax_anim 2, 0, 304, 0, -18, 0, 0,
+ax_anim 1, 0, 305, 0, -10, 0, 0,
+ax_anim 2, 2, 303, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_12_1:
+ax_anim 2, 0, 306, 1, 0, 1, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 1, 0, 1, 0,
+ax_anim 2, 0, 306, 0, 0, 0, 0,
+ax_anim 2, 0, 307, 1, 0, 1, 0,
+ax_anim 2, 2, 308, 0, 0, 0, 0,
+ax_anim 2, 0, 306, 1, 0, 1, 0,
+ax_anim 2, 0, 307, 0, 0, 0, 0,
+ax_anim 2, 0, 308, 1, 0, 1, 0,
+ax_anim 2, 1, 306, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_12_2:
+ax_anim 2, 0, 309, 1, -1, 1, -1,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 1, -1, 1, -1,
+ax_anim 2, 0, 309, 0, 0, 0, 0,
+ax_anim 2, 0, 310, 1, -1, 1, -1,
+ax_anim 2, 2, 311, 0, 0, 0, 0,
+ax_anim 2, 0, 309, 1, -1, 1, -1,
+ax_anim 2, 0, 310, 0, 0, 0, 0,
+ax_anim 2, 0, 311, 1, -1, 1, -1,
+ax_anim 2, 1, 309, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_12_3:
+ax_anim 2, 0, 312, 0, -1, 0, -1,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, -1, 0, -1,
+ax_anim 2, 0, 312, 0, 0, 0, 0,
+ax_anim 2, 0, 313, 0, -1, 0, -1,
+ax_anim 2, 2, 314, 0, 0, 0, 0,
+ax_anim 2, 0, 312, 0, -1, 0, -1,
+ax_anim 2, 0, 313, 0, 0, 0, 0,
+ax_anim 2, 0, 314, 0, -1, 0, -1,
+ax_anim 2, 1, 312, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_12_4:
+ax_anim 2, 0, 315, -1, -1, -1, -1,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, -1, -1, -1, -1,
+ax_anim 2, 0, 315, 0, 0, 0, 0,
+ax_anim 2, 0, 316, -1, -1, -1, -1,
+ax_anim 2, 2, 317, 0, 0, 0, 0,
+ax_anim 2, 0, 315, -1, -1, -1, -1,
+ax_anim 2, 0, 316, 0, 0, 0, 0,
+ax_anim 2, 0, 317, -1, -1, -1, -1,
+ax_anim 2, 1, 315, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_12_5:
+ax_anim 2, 0, 318, 1, 0, 1, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 1, 0, 1, 0,
+ax_anim 2, 0, 318, 0, 0, 0, 0,
+ax_anim 2, 0, 319, 1, 0, 1, 0,
+ax_anim 2, 2, 320, 0, 0, 0, 0,
+ax_anim 2, 0, 318, 1, 0, 1, 0,
+ax_anim 2, 0, 319, 0, 0, 0, 0,
+ax_anim 2, 0, 320, 1, 0, 1, 0,
+ax_anim 2, 1, 318, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_12_6:
+ax_anim 2, 0, 321, 1, -1, 1, -1,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 323, 1, -1, 1, -1,
+ax_anim 2, 0, 321, 0, 0, 0, 0,
+ax_anim 2, 0, 322, 1, -1, 1, -1,
+ax_anim 2, 2, 323, 0, 0, 0, 0,
+ax_anim 2, 0, 321, 1, -1, 1, -1,
+ax_anim 2, 0, 322, 0, 0, 0, 0,
+ax_anim 2, 0, 323, 1, -1, 1, -1,
+ax_anim 2, 1, 321, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_12_7:
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 0, -1, 0, -1,
+ax_anim 2, 0, 324, 0, 0, 0, 0,
+ax_anim 2, 0, 325, 0, -1, 0, -1,
+ax_anim 2, 2, 326, 0, 0, 0, 0,
+ax_anim 2, 0, 324, 0, -1, 0, -1,
+ax_anim 2, 0, 325, 0, 0, 0, 0,
+ax_anim 2, 0, 326, 0, -1, 0, -1,
+ax_anim 2, 1, 324, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_12_8:
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 329, -1, -1, -1, -1,
+ax_anim 2, 0, 327, 0, 0, 0, 0,
+ax_anim 2, 0, 328, -1, -1, -1, -1,
+ax_anim 2, 2, 329, 0, 0, 0, 0,
+ax_anim 2, 0, 327, -1, -1, -1, -1,
+ax_anim 2, 0, 328, 0, 0, 0, 0,
+ax_anim 2, 0, 329, -1, -1, -1, -1,
+ax_anim 2, 1, 327, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWeezingAnims_13_1:
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 2, 330, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_13_2:
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 2, 337, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_13_3:
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 2, 336, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_13_4:
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 2, 335, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_13_5:
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 2, 334, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_13_6:
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 2, 333, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_13_7:
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 2, 332, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingAnims_13_8:
+ax_anim 2, 0, 331, 0, 0, 0, 0,
+ax_anim 2, 0, 332, 0, 0, 0, 0,
+ax_anim 2, 0, 333, 0, 0, 0, 0,
+ax_anim 2, 0, 334, 0, 0, 0, 0,
+ax_anim 2, 0, 335, 0, 0, 0, 0,
+ax_anim 2, 0, 336, 0, 0, 0, 0,
+ax_anim 2, 0, 337, 0, 0, 0, 0,
+ax_anim 2, 0, 330, 0, 0, 0, 0,
+ax_anim 2, 2, 331, 0, 0, 0, 0,
+ax_anim_terminator
+sWeezingGfx1:
+.incbin "baserom.gba", 0x9C1110, 0x200
+sWeezingSprites1:
+ax_sprite sWeezingGfx1, 0x200
+ax_sprite_terminator
+sWeezingGfx2:
+.incbin "baserom.gba", 0x9C1320, 0x200
+sWeezingSprites2:
+ax_sprite sWeezingGfx2, 0x200
+ax_sprite_terminator
+sWeezingGfx3:
+.incbin "baserom.gba", 0x9C1530, 0x200
+sWeezingSprites3:
+ax_sprite sWeezingGfx3, 0x200
+ax_sprite_terminator
+sWeezingGfx4:
+.incbin "baserom.gba", 0x9C1740, 0x200
+sWeezingSprites4:
+ax_sprite sWeezingGfx4, 0x200
+ax_sprite_terminator
+sWeezingGfx5:
+.incbin "baserom.gba", 0x9C1950, 0x200
+sWeezingSprites5:
+ax_sprite sWeezingGfx5, 0x200
+ax_sprite_terminator
+sWeezingGfx6:
+.incbin "baserom.gba", 0x9C1B60, 0x200
+sWeezingSprites6:
+ax_sprite sWeezingGfx6, 0x200
+ax_sprite_terminator
+sWeezingGfx7:
+.incbin "baserom.gba", 0x9C1D70, 0x200
+sWeezingSprites7:
+ax_sprite sWeezingGfx7, 0x200
+ax_sprite_terminator
+sWeezingGfx8:
+.incbin "baserom.gba", 0x9C1F80, 0x200
+sWeezingSprites8:
+ax_sprite sWeezingGfx8, 0x200
+ax_sprite_terminator
+sWeezingGfx9:
+.incbin "baserom.gba", 0x9C2190, 0x200
+sWeezingSprites9:
+ax_sprite sWeezingGfx9, 0x200
+ax_sprite_terminator
+sWeezingGfx10:
+.incbin "baserom.gba", 0x9C23A0, 0x200
+sWeezingSprites10:
+ax_sprite sWeezingGfx10, 0x200
+ax_sprite_terminator
+sWeezingGfx11:
+.incbin "baserom.gba", 0x9C25B0, 0x200
+sWeezingSprites11:
+ax_sprite sWeezingGfx11, 0x200
+ax_sprite_terminator
+sWeezingGfx12:
+.incbin "baserom.gba", 0x9C27C0, 0x200
+sWeezingSprites12:
+ax_sprite sWeezingGfx12, 0x200
+ax_sprite_terminator
+sWeezingGfx13:
+.incbin "baserom.gba", 0x9C29D0, 0x200
+sWeezingSprites13:
+ax_sprite sWeezingGfx13, 0x200
+ax_sprite_terminator
+sWeezingGfx14:
+.incbin "baserom.gba", 0x9C2BE0, 0x200
+sWeezingSprites14:
+ax_sprite sWeezingGfx14, 0x200
+ax_sprite_terminator
+sWeezingGfx15:
+.incbin "baserom.gba", 0x9C2DF0, 0x200
+sWeezingSprites15:
+ax_sprite sWeezingGfx15, 0x200
+ax_sprite_terminator
+sWeezingGfx16:
+.incbin "baserom.gba", 0x9C3000, 0x200
+sWeezingSprites16:
+ax_sprite sWeezingGfx16, 0x200
+ax_sprite_terminator
+sWeezingGfx17:
+.incbin "baserom.gba", 0x9C3210, 0x200
+sWeezingSprites17:
+ax_sprite sWeezingGfx17, 0x200
+ax_sprite_terminator
+sWeezingGfx18:
+.incbin "baserom.gba", 0x9C3420, 0x200
+sWeezingSprites18:
+ax_sprite sWeezingGfx18, 0x200
+ax_sprite_terminator
+sWeezingGfx19:
+.incbin "baserom.gba", 0x9C3630, 0x200
+sWeezingSprites19:
+ax_sprite sWeezingGfx19, 0x200
+ax_sprite_terminator
+sWeezingGfx20:
+.incbin "baserom.gba", 0x9C3840, 0x200
+sWeezingSprites20:
+ax_sprite sWeezingGfx20, 0x200
+ax_sprite_terminator
+sWeezingGfx21:
+.incbin "baserom.gba", 0x9C3A50, 0x200
+sWeezingSprites21:
+ax_sprite sWeezingGfx21, 0x200
+ax_sprite_terminator
+sWeezingGfx22:
+.incbin "baserom.gba", 0x9C3C60, 0x200
+sWeezingSprites22:
+ax_sprite sWeezingGfx22, 0x200
+ax_sprite_terminator
+sWeezingGfx23:
+.incbin "baserom.gba", 0x9C3E70, 0x200
+sWeezingSprites23:
+ax_sprite sWeezingGfx23, 0x200
+ax_sprite_terminator
+sWeezingGfx24:
+.incbin "baserom.gba", 0x9C4080, 0x200
+sWeezingSprites24:
+ax_sprite sWeezingGfx24, 0x200
+ax_sprite_terminator
+sWeezingGfx25:
+.incbin "baserom.gba", 0x9C4290, 0x100
+sWeezingSprites25:
+ax_sprite sWeezingGfx25, 0x100
+ax_sprite_terminator
+sWeezingGfx26:
+.incbin "baserom.gba", 0x9C43A0, 0x80
+sWeezingSprites26:
+ax_sprite sWeezingGfx26, 0x80
+ax_sprite_terminator
+sWeezingGfx27:
+.incbin "baserom.gba", 0x9C4430, 0x40
+sWeezingSprites27:
+ax_sprite sWeezingGfx27, 0x40
+ax_sprite_terminator
+sWeezingGfx28:
+.incbin "baserom.gba", 0x9C4480, 0x20
+sWeezingSprites28:
+ax_sprite sWeezingGfx28, 0x20
+ax_sprite_terminator
+sWeezingGfx29:
+.incbin "baserom.gba", 0x9C44B0, 0x20
+sWeezingSprites29:
+ax_sprite sWeezingGfx29, 0x20
+ax_sprite_terminator
+sWeezingGfx30:
+.incbin "baserom.gba", 0x9C44E0, 0x160
+sWeezingGfx30_1:
+.incbin "baserom.gba", 0x9C4640, 0x60
+sWeezingSprites30:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx30, 0x160
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx30_1, 0x60
+ax_sprite_terminator
+sWeezingGfx31:
+.incbin "baserom.gba", 0x9C46C8, 0xE0
+sWeezingSprites31:
+ax_sprite sWeezingGfx31, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeezingGfx32:
+.incbin "baserom.gba", 0x9C47C0, 0xC0
+sWeezingSprites32:
+ax_sprite sWeezingGfx32, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeezingGfx33:
+.incbin "baserom.gba", 0x9C4898, 0x80
+sWeezingSprites33:
+ax_sprite sWeezingGfx33, 0x80
+ax_sprite_terminator
+sWeezingGfx34:
+.incbin "baserom.gba", 0x9C4928, 0x20
+sWeezingGfx34_1:
+.incbin "baserom.gba", 0x9C4948, 0x80
+sWeezingSprites34:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx34, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx34_1, 0x80
+ax_sprite_terminator
+sWeezingGfx35:
+.incbin "baserom.gba", 0x9C49F0, 0x80
+sWeezingSprites35:
+ax_sprite sWeezingGfx35, 0x80
+ax_sprite_terminator
+sWeezingGfx36:
+.incbin "baserom.gba", 0x9C4A80, 0x1A0
+sWeezingSprites36:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx36, 0x1a0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWeezingGfx37:
+.incbin "baserom.gba", 0x9C4C40, 0x1C0
+sWeezingSprites37:
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx37, 0x1c0
+ax_sprite_terminator
+sWeezingGfx38:
+.incbin "baserom.gba", 0x9C4E18, 0x1C0
+sWeezingSprites38:
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx38, 0x1c0
+ax_sprite_terminator
+sWeezingGfx39:
+.incbin "baserom.gba", 0x9C4FF0, 0x40
+sWeezingSprites39:
+ax_sprite sWeezingGfx39, 0x40
+ax_sprite_terminator
+sWeezingGfx40:
+.incbin "baserom.gba", 0x9C5040, 0x60
+sWeezingSprites40:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx40, 0x60
+ax_sprite_terminator
+sWeezingGfx41:
+.incbin "baserom.gba", 0x9C50B8, 0x140
+sWeezingGfx41_1:
+.incbin "baserom.gba", 0x9C51F8, 0x40
+sWeezingSprites41:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx41, 0x140
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx41_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeezingGfx42:
+.incbin "baserom.gba", 0x9C5268, 0x40
+sWeezingGfx42_1:
+.incbin "baserom.gba", 0x9C52A8, 0x180
+sWeezingSprites42:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx42_1, 0x180
+ax_sprite_terminator
+sWeezingGfx43:
+.incbin "baserom.gba", 0x9C5450, 0x60
+sWeezingGfx43_1:
+.incbin "baserom.gba", 0x9C54B0, 0x180
+sWeezingSprites43:
+ax_sprite sWeezingGfx43, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx43_1, 0x180
+ax_sprite_terminator
+sWeezingGfx44:
+.incbin "baserom.gba", 0x9C5650, 0x60
+sWeezingSprites44:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx44, 0x60
+ax_sprite_terminator
+sWeezingGfx45:
+.incbin "baserom.gba", 0x9C56C8, 0x40
+sWeezingGfx45_1:
+.incbin "baserom.gba", 0x9C5708, 0x60
+sWeezingGfx45_2:
+.incbin "baserom.gba", 0x9C5768, 0x60
+sWeezingGfx45_3:
+.incbin "baserom.gba", 0x9C57C8, 0x60
+sWeezingSprites45:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx45, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx45_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx45_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx45_3, 0x60
+ax_sprite_terminator
+sWeezingGfx46:
+.incbin "baserom.gba", 0x9C5870, 0x40
+sWeezingGfx46_1:
+.incbin "baserom.gba", 0x9C58B0, 0x100
+sWeezingGfx46_2:
+.incbin "baserom.gba", 0x9C59B0, 0x60
+sWeezingSprites46:
+ax_sprite sWeezingGfx46, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx46_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx46_2, 0x60
+ax_sprite_terminator
+sWeezingGfx47:
+.incbin "baserom.gba", 0x9C5A40, 0x40
+sWeezingGfx47_1:
+.incbin "baserom.gba", 0x9C5A80, 0x180
+sWeezingSprites47:
+ax_sprite sWeezingGfx47, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx47_1, 0x180
+ax_sprite_terminator
+sWeezingGfx48:
+.incbin "baserom.gba", 0x9C5C20, 0x40
+sWeezingSprites48:
+ax_sprite sWeezingGfx48, 0x40
+ax_sprite_terminator
+sWeezingGfx49:
+.incbin "baserom.gba", 0x9C5C70, 0x20
+sWeezingSprites49:
+ax_sprite sWeezingGfx49, 0x20
+ax_sprite_terminator
+sWeezingGfx50:
+.incbin "baserom.gba", 0x9C5CA0, 0x20
+sWeezingGfx50_1:
+.incbin "baserom.gba", 0x9C5CC0, 0x80
+sWeezingGfx50_2:
+.incbin "baserom.gba", 0x9C5D40, 0x60
+sWeezingGfx50_3:
+.incbin "baserom.gba", 0x9C5DA0, 0x60
+sWeezingSprites50:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx50, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx50_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx50_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx50_3, 0x60
+ax_sprite_terminator
+sWeezingGfx51:
+.incbin "baserom.gba", 0x9C5E48, 0x100
+sWeezingSprites51:
+ax_sprite sWeezingGfx51, 0x100
+ax_sprite_terminator
+sWeezingGfx52:
+.incbin "baserom.gba", 0x9C5F58, 0x60
+sWeezingSprites52:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx52, 0x60
+ax_sprite_terminator
+sWeezingGfx53:
+.incbin "baserom.gba", 0x9C5FD0, 0x20
+sWeezingSprites53:
+ax_sprite sWeezingGfx53, 0x20
+ax_sprite_terminator
+sWeezingGfx54:
+.incbin "baserom.gba", 0x9C6000, 0x20
+sWeezingSprites54:
+ax_sprite sWeezingGfx54, 0x20
+ax_sprite_terminator
+sWeezingGfx55:
+.incbin "baserom.gba", 0x9C6030, 0x40
+sWeezingSprites55:
+ax_sprite sWeezingGfx55, 0x40
+ax_sprite_terminator
+sWeezingGfx56:
+.incbin "baserom.gba", 0x9C6080, 0x40
+sWeezingGfx56_1:
+.incbin "baserom.gba", 0x9C60C0, 0x120
+sWeezingGfx56_2:
+.incbin "baserom.gba", 0x9C61E0, 0x60
+sWeezingSprites56:
+ax_sprite sWeezingGfx56, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx56_1, 0x120
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx56_2, 0x60
+ax_sprite_terminator
+sWeezingGfx57:
+.incbin "baserom.gba", 0x9C6270, 0x60
+sWeezingSprites57:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx57, 0x60
+ax_sprite_terminator
+sWeezingGfx58:
+.incbin "baserom.gba", 0x9C62E8, 0x40
+sWeezingGfx58_1:
+.incbin "baserom.gba", 0x9C6328, 0x100
+sWeezingGfx58_2:
+.incbin "baserom.gba", 0x9C6428, 0x40
+sWeezingSprites58:
+ax_sprite sWeezingGfx58, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx58_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx58_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeezingGfx59:
+.incbin "baserom.gba", 0x9C64A0, 0x40
+sWeezingGfx59_1:
+.incbin "baserom.gba", 0x9C64E0, 0x180
+sWeezingSprites59:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx59_1, 0x180
+ax_sprite_terminator
+sWeezingGfx60:
+.incbin "baserom.gba", 0x9C6688, 0x1E0
+sWeezingSprites60:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx60, 0x1e0
+ax_sprite_terminator
+sWeezingGfx61:
+.incbin "baserom.gba", 0x9C6880, 0x100
+sWeezingGfx61_1:
+.incbin "baserom.gba", 0x9C6980, 0x20
+sWeezingSprites61:
+ax_sprite 0, 0x80
+ax_sprite sWeezingGfx61, 0x100
+ax_sprite 0, 0x40
+ax_sprite sWeezingGfx61_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeezingGfx62:
+.incbin "baserom.gba", 0x9C69D0, 0x180
+sWeezingSprites62:
+ax_sprite 0, 0x80
+ax_sprite sWeezingGfx62, 0x180
+ax_sprite_terminator
+sWeezingGfx63:
+.incbin "baserom.gba", 0x9C6B68, 0x100
+sWeezingSprites63:
+ax_sprite sWeezingGfx63, 0x100
+ax_sprite_terminator
+sWeezingGfx64:
+.incbin "baserom.gba", 0x9C6C78, 0x80
+sWeezingSprites64:
+ax_sprite sWeezingGfx64, 0x80
+ax_sprite_terminator
+sWeezingGfx65:
+.incbin "baserom.gba", 0x9C6D08, 0x20
+sWeezingSprites65:
+ax_sprite sWeezingGfx65, 0x20
+ax_sprite_terminator
+sWeezingGfx66:
+.incbin "baserom.gba", 0x9C6D38, 0x20
+sWeezingSprites66:
+ax_sprite sWeezingGfx66, 0x20
+ax_sprite_terminator
+sWeezingGfx67:
+.incbin "baserom.gba", 0x9C6D68, 0x40
+sWeezingSprites67:
+ax_sprite sWeezingGfx67, 0x40
+ax_sprite_terminator
+sWeezingGfx68:
+.incbin "baserom.gba", 0x9C6DB8, 0x60
+sWeezingGfx68_1:
+.incbin "baserom.gba", 0x9C6E18, 0x60
+sWeezingGfx68_2:
+.incbin "baserom.gba", 0x9C6E78, 0x60
+sWeezingSprites68:
+ax_sprite 0, 0xa0
+ax_sprite sWeezingGfx68, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx68_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx68_2, 0x60
+ax_sprite_terminator
+sWeezingGfx69:
+.incbin "baserom.gba", 0x9C6F10, 0x100
+sWeezingSprites69:
+ax_sprite sWeezingGfx69, 0x100
+ax_sprite_terminator
+sWeezingGfx70:
+.incbin "baserom.gba", 0x9C7020, 0x80
+sWeezingSprites70:
+ax_sprite sWeezingGfx70, 0x80
+ax_sprite_terminator
+sWeezingGfx71:
+.incbin "baserom.gba", 0x9C70B0, 0x20
+sWeezingSprites71:
+ax_sprite sWeezingGfx71, 0x20
+ax_sprite_terminator
+sWeezingGfx72:
+.incbin "baserom.gba", 0x9C70E0, 0x20
+sWeezingSprites72:
+ax_sprite sWeezingGfx72, 0x20
+ax_sprite_terminator
+sWeezingGfx73:
+.incbin "baserom.gba", 0x9C7110, 0x20
+sWeezingSprites73:
+ax_sprite sWeezingGfx73, 0x20
+ax_sprite_terminator
+sWeezingGfx74:
+.incbin "baserom.gba", 0x9C7140, 0x20
+sWeezingSprites74:
+ax_sprite sWeezingGfx74, 0x20
+ax_sprite_terminator
+sWeezingGfx75:
+.incbin "baserom.gba", 0x9C7170, 0x1E0
+sWeezingSprites75:
+ax_sprite 0, 0x20
+ax_sprite sWeezingGfx75, 0x1e0
+ax_sprite_terminator
+sWeezingGfx76:
+.incbin "baserom.gba", 0x9C7368, 0xE0
+sWeezingSprites76:
+ax_sprite sWeezingGfx76, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeezingGfx77:
+.incbin "baserom.gba", 0x9C7460, 0x160
+sWeezingSprites77:
+ax_sprite 0, 0x80
+ax_sprite sWeezingGfx77, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWeezingGfx78:
+.incbin "baserom.gba", 0x9C75E0, 0x80
+sWeezingSprites78:
+ax_sprite sWeezingGfx78, 0x80
+ax_sprite_terminator
+sWeezingGfx79:
+.incbin "baserom.gba", 0x9C7670, 0x80
+sWeezingSprites79:
+ax_sprite sWeezingGfx79, 0x80
+ax_sprite_terminator
+sWeezingGfx80:
+.incbin "baserom.gba", 0x9C7700, 0x80
+sWeezingSprites80:
+ax_sprite sWeezingGfx80, 0x80
+ax_sprite_terminator
+sWeezingGfx81:
+.incbin "baserom.gba", 0x9C7790, 0x80
+sWeezingSprites81:
+ax_sprite sWeezingGfx81, 0x80
+ax_sprite_terminator
+sWeezingGfx82:
+.incbin "baserom.gba", 0x9C7820, 0x80
+sWeezingSprites82:
+ax_sprite sWeezingGfx82, 0x80
+ax_sprite_terminator
+sWeezingGfx83:
+.incbin "baserom.gba", 0x9C78B0, 0x80
+sWeezingSprites83:
+ax_sprite sWeezingGfx83, 0x80
+ax_sprite_terminator
+sWeezingGfx84:
+.incbin "baserom.gba", 0x9C7940, 0x200
+sWeezingSprites84:
+ax_sprite sWeezingGfx84, 0x200
+ax_sprite_terminator
+sWeezingGfx85:
+.incbin "baserom.gba", 0x9C7B50, 0x200
+sWeezingSprites85:
+ax_sprite sWeezingGfx85, 0x200
+ax_sprite_terminator
+sWeezingGfx86:
+.incbin "baserom.gba", 0x9C7D60, 0x200
+sWeezingSprites86:
+ax_sprite sWeezingGfx86, 0x200
+ax_sprite_terminator
+sWeezingGfx87:
+.incbin "baserom.gba", 0x9C7F70, 0x200
+sWeezingSprites87:
+ax_sprite sWeezingGfx87, 0x200
+ax_sprite_terminator
+sWeezingGfx88:
+.incbin "baserom.gba", 0x9C8180, 0x200
+sWeezingSprites88:
+ax_sprite sWeezingGfx88, 0x200
+ax_sprite_terminator
+sWeezingGfx89:
+.incbin "baserom.gba", 0x9C8390, 0x200
+sWeezingSprites89:
+ax_sprite sWeezingGfx89, 0x200
+ax_sprite_terminator
+sWeezingGfx90:
+.incbin "baserom.gba", 0x9C85A0, 0x200
+sWeezingSprites90:
+ax_sprite sWeezingGfx90, 0x200
+ax_sprite_terminator
+sWeezingGfx91:
+.incbin "baserom.gba", 0x9C87B0, 0x200
+sWeezingSprites91:
+ax_sprite sWeezingGfx91, 0x200
+ax_sprite_terminator
+sWeezingGfx92:
+.incbin "baserom.gba", 0x9C89C0, 0x200
+sWeezingSprites92:
+ax_sprite sWeezingGfx92, 0x200
+ax_sprite_terminator
+sWeezingGfx93:
+.incbin "baserom.gba", 0x9C8BD0, 0x200
+sWeezingSprites93:
+ax_sprite sWeezingGfx93, 0x200
+ax_sprite_terminator
+sAxPosesWeezing:
+.4byte sWeezingPose1
+.4byte sWeezingPose2
+.4byte sWeezingPose3
+.4byte sWeezingPose4
+.4byte sWeezingPose5
+.4byte sWeezingPose6
+.4byte sWeezingPose7
+.4byte sWeezingPose8
+.4byte sWeezingPose9
+.4byte sWeezingPose10
+.4byte sWeezingPose11
+.4byte sWeezingPose12
+.4byte sWeezingPose13
+.4byte sWeezingPose14
+.4byte sWeezingPose15
+.4byte sWeezingPose16
+.4byte sWeezingPose17
+.4byte sWeezingPose18
+.4byte sWeezingPose19
+.4byte sWeezingPose20
+.4byte sWeezingPose21
+.4byte sWeezingPose22
+.4byte sWeezingPose23
+.4byte sWeezingPose24
+.4byte sWeezingPose25
+.4byte sWeezingPose26
+.4byte sWeezingPose27
+.4byte sWeezingPose28
+.4byte sWeezingPose29
+.4byte sWeezingPose30
+.4byte sWeezingPose31
+.4byte sWeezingPose32
+.4byte sWeezingPose33
+.4byte sWeezingPose34
+.4byte sWeezingPose35
+.4byte sWeezingPose36
+.4byte sWeezingPose37
+.4byte sWeezingPose38
+.4byte sWeezingPose39
+.4byte sWeezingPose40
+.4byte sWeezingPose41
+.4byte sWeezingPose42
+.4byte sWeezingPose43
+.4byte sWeezingPose44
+.4byte sWeezingPose45
+.4byte sWeezingPose46
+.4byte sWeezingPose47
+.4byte sWeezingPose48
+.4byte sWeezingPose49
+.4byte sWeezingPose50
+.4byte sWeezingPose51
+.4byte sWeezingPose52
+.4byte sWeezingPose53
+.4byte sWeezingPose54
+.4byte sWeezingPose55
+.4byte sWeezingPose56
+.4byte sWeezingPose57
+.4byte sWeezingPose58
+.4byte sWeezingPose59
+.4byte sWeezingPose60
+.4byte sWeezingPose61
+.4byte sWeezingPose62
+.4byte sWeezingPose63
+.4byte sWeezingPose64
+.4byte sWeezingPose65
+.4byte sWeezingPose66
+.4byte sWeezingPose67
+.4byte sWeezingPose68
+.4byte sWeezingPose69
+.4byte sWeezingPose70
+.4byte sWeezingPose71
+.4byte sWeezingPose72
+.4byte sWeezingPose73
+.4byte sWeezingPose74
+.4byte sWeezingPose75
+.4byte sWeezingPose76
+.4byte sWeezingPose77
+.4byte sWeezingPose78
+.4byte sWeezingPose79
+.4byte sWeezingPose80
+.4byte sWeezingPose81
+.4byte sWeezingPose82
+.4byte sWeezingPose83
+.4byte sWeezingPose84
+.4byte sWeezingPose85
+.4byte sWeezingPose86
+.4byte sWeezingPose87
+.4byte sWeezingPose88
+.4byte sWeezingPose89
+.4byte sWeezingPose90
+.4byte sWeezingPose91
+.4byte sWeezingPose92
+.4byte sWeezingPose93
+.4byte sWeezingPose94
+.4byte sWeezingPose95
+.4byte sWeezingPose96
+.4byte sWeezingPose97
+.4byte sWeezingPose98
+.4byte sWeezingPose99
+.4byte sWeezingPose100
+.4byte sWeezingPose101
+.4byte sWeezingPose102
+.4byte sWeezingPose103
+.4byte sWeezingPose104
+.4byte sWeezingPose105
+.4byte sWeezingPose106
+.4byte sWeezingPose107
+.4byte sWeezingPose108
+.4byte sWeezingPose109
+.4byte sWeezingPose110
+.4byte sWeezingPose111
+.4byte sWeezingPose112
+.4byte sWeezingPose113
+.4byte sWeezingPose114
+.4byte sWeezingPose115
+.4byte sWeezingPose116
+.4byte sWeezingPose117
+.4byte sWeezingPose118
+.4byte sWeezingPose119
+.4byte sWeezingPose120
+.4byte sWeezingPose121
+.4byte sWeezingPose122
+.4byte sWeezingPose123
+.4byte sWeezingPose124
+.4byte sWeezingPose125
+.4byte sWeezingPose126
+.4byte sWeezingPose127
+.4byte sWeezingPose128
+.4byte sWeezingPose129
+.4byte sWeezingPose130
+.4byte sWeezingPose131
+.4byte sWeezingPose132
+.4byte sWeezingPose133
+.4byte sWeezingPose134
+.4byte sWeezingPose135
+.4byte sWeezingPose136
+.4byte sWeezingPose137
+.4byte sWeezingPose138
+.4byte sWeezingPose139
+.4byte sWeezingPose140
+.4byte sWeezingPose141
+.4byte sWeezingPose142
+.4byte sWeezingPose143
+.4byte sWeezingPose144
+.4byte sWeezingPose145
+.4byte sWeezingPose146
+.4byte sWeezingPose147
+.4byte sWeezingPose148
+.4byte sWeezingPose149
+.4byte sWeezingPose150
+.4byte sWeezingPose151
+.4byte sWeezingPose152
+.4byte sWeezingPose153
+.4byte sWeezingPose154
+.4byte sWeezingPose155
+.4byte sWeezingPose156
+.4byte sWeezingPose157
+.4byte sWeezingPose158
+.4byte sWeezingPose159
+.4byte sWeezingPose160
+.4byte sWeezingPose161
+.4byte sWeezingPose162
+.4byte sWeezingPose163
+.4byte sWeezingPose164
+.4byte sWeezingPose165
+.4byte sWeezingPose166
+.4byte sWeezingPose167
+.4byte sWeezingPose168
+.4byte sWeezingPose169
+.4byte sWeezingPose170
+.4byte sWeezingPose171
+.4byte sWeezingPose172
+.4byte sWeezingPose173
+.4byte sWeezingPose174
+.4byte sWeezingPose175
+.4byte sWeezingPose176
+.4byte sWeezingPose177
+.4byte sWeezingPose178
+.4byte sWeezingPose179
+.4byte sWeezingPose180
+.4byte sWeezingPose181
+.4byte sWeezingPose182
+.4byte sWeezingPose183
+.4byte sWeezingPose184
+.4byte sWeezingPose185
+.4byte sWeezingPose186
+.4byte sWeezingPose187
+.4byte sWeezingPose188
+.4byte sWeezingPose189
+.4byte sWeezingPose190
+.4byte sWeezingPose191
+.4byte sWeezingPose192
+.4byte sWeezingPose193
+.4byte sWeezingPose194
+.4byte sWeezingPose195
+.4byte sWeezingPose196
+.4byte sWeezingPose197
+.4byte sWeezingPose198
+.4byte sWeezingPose199
+.4byte sWeezingPose200
+.4byte sWeezingPose201
+.4byte sWeezingPose202
+.4byte sWeezingPose203
+.4byte sWeezingPose204
+.4byte sWeezingPose205
+.4byte sWeezingPose206
+.4byte sWeezingPose207
+.4byte sWeezingPose208
+.4byte sWeezingPose209
+.4byte sWeezingPose210
+.4byte sWeezingPose211
+.4byte sWeezingPose212
+.4byte sWeezingPose213
+.4byte sWeezingPose214
+.4byte sWeezingPose215
+.4byte sWeezingPose216
+.4byte sWeezingPose217
+.4byte sWeezingPose218
+.4byte sWeezingPose219
+.4byte sWeezingPose220
+.4byte sWeezingPose221
+.4byte sWeezingPose222
+.4byte sWeezingPose223
+.4byte sWeezingPose224
+.4byte sWeezingPose225
+.4byte sWeezingPose226
+.4byte sWeezingPose227
+.4byte sWeezingPose228
+.4byte sWeezingPose229
+.4byte sWeezingPose230
+.4byte sWeezingPose231
+.4byte sWeezingPose232
+.4byte sWeezingPose233
+.4byte sWeezingPose234
+.4byte sWeezingPose235
+.4byte sWeezingPose236
+.4byte sWeezingPose237
+.4byte sWeezingPose238
+.4byte sWeezingPose239
+.4byte sWeezingPose240
+.4byte sWeezingPose241
+.4byte sWeezingPose242
+.4byte sWeezingPose243
+.4byte sWeezingPose244
+.4byte sWeezingPose245
+.4byte sWeezingPose246
+.4byte sWeezingPose247
+.4byte sWeezingPose248
+.4byte sWeezingPose249
+.4byte sWeezingPose250
+.4byte sWeezingPose251
+.4byte sWeezingPose252
+.4byte sWeezingPose253
+.4byte sWeezingPose254
+.4byte sWeezingPose255
+.4byte sWeezingPose256
+.4byte sWeezingPose257
+.4byte sWeezingPose258
+.4byte sWeezingPose259
+.4byte sWeezingPose260
+.4byte sWeezingPose261
+.4byte sWeezingPose262
+.4byte sWeezingPose263
+.4byte sWeezingPose264
+.4byte sWeezingPose265
+.4byte sWeezingPose266
+.4byte sWeezingPose267
+.4byte sWeezingPose268
+.4byte sWeezingPose269
+.4byte sWeezingPose270
+.4byte sWeezingPose271
+.4byte sWeezingPose272
+.4byte sWeezingPose273
+.4byte sWeezingPose274
+.4byte sWeezingPose275
+.4byte sWeezingPose276
+.4byte sWeezingPose277
+.4byte sWeezingPose278
+.4byte sWeezingPose279
+.4byte sWeezingPose280
+.4byte sWeezingPose281
+.4byte sWeezingPose282
+.4byte sWeezingPose283
+.4byte sWeezingPose284
+.4byte sWeezingPose285
+.4byte sWeezingPose286
+.4byte sWeezingPose287
+.4byte sWeezingPose288
+.4byte sWeezingPose289
+.4byte sWeezingPose290
+.4byte sWeezingPose291
+.4byte sWeezingPose292
+.4byte sWeezingPose293
+.4byte sWeezingPose294
+.4byte sWeezingPose295
+.4byte sWeezingPose296
+.4byte sWeezingPose297
+.4byte sWeezingPose298
+.4byte sWeezingPose299
+.4byte sWeezingPose300
+.4byte sWeezingPose301
+.4byte sWeezingPose302
+.4byte sWeezingPose303
+.4byte sWeezingPose304
+.4byte sWeezingPose305
+.4byte sWeezingPose306
+.4byte sWeezingPose307
+.4byte sWeezingPose308
+.4byte sWeezingPose309
+.4byte sWeezingPose310
+.4byte sWeezingPose311
+.4byte sWeezingPose312
+.4byte sWeezingPose313
+.4byte sWeezingPose314
+.4byte sWeezingPose315
+.4byte sWeezingPose316
+.4byte sWeezingPose317
+.4byte sWeezingPose318
+.4byte sWeezingPose319
+.4byte sWeezingPose320
+.4byte sWeezingPose321
+.4byte sWeezingPose322
+.4byte sWeezingPose323
+.4byte sWeezingPose324
+.4byte sWeezingPose325
+.4byte sWeezingPose326
+.4byte sWeezingPose327
+.4byte sWeezingPose328
+.4byte sWeezingPose329
+.4byte sWeezingPose330
+.4byte sWeezingPose331
+.4byte sWeezingPose332
+.4byte sWeezingPose333
+.4byte sWeezingPose334
+.4byte sWeezingPose335
+.4byte sWeezingPose336
+.4byte sWeezingPose337
+.4byte sWeezingPose338
+sAxPositionsWeezing:
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -9,  -13, 	 -16,  -12, 	  16,  -19, 	   3,  -16
+.2byte  -11,  -14, 	 -19,  -14, 	  17,  -20, 	  -2,  -16
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    2,  -13, 	  -8,   -7, 	   9,  -25, 	   0,  -16
+.2byte    3,  -12, 	 -10,   -5, 	  11,  -27, 	   1,  -16
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte    8,  -16, 	   1,  -11, 	   0,  -27, 	  -1,  -17
+.2byte    9,  -16, 	   1,  -12, 	  -2,  -29, 	  -2,  -16
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte   12,  -14, 	  12,  -11, 	  -8,  -26, 	  -1,  -15
+.2byte   13,  -13, 	  13,   -9, 	  -9,  -28, 	   0,  -15
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte    8,  -18, 	  13,  -16, 	 -15,  -20, 	  -2,  -15
+.2byte    8,  -18, 	  15,  -15, 	 -19,  -21, 	  -3,  -14
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -21, 	   6,  -21, 	 -12,  -16, 	   0,  -15
+.2byte   -2,  -20, 	   7,  -20, 	 -15,  -15, 	  -1,  -14
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte  -11,  -16, 	  -6,  -21, 	   4,  -16, 	  -1,  -14
+.2byte  -14,  -15, 	  -8,  -20, 	   3,  -15, 	  -3,  -14
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte  -13,  -14, 	 -17,  -15, 	  16,  -17, 	  -1,  -14
+.2byte  -14,  -13, 	 -20,  -14, 	  17,  -19, 	  -1,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -9,  -13, 	 -16,  -12, 	  16,  -19, 	   3,  -16
+.2byte  -11,  -14, 	 -19,  -14, 	  17,  -20, 	  -2,  -16
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte   -5,   -8, 	 -12,  -10, 	  11,  -18, 	   0,  -14
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    2,  -13, 	  -8,   -7, 	   9,  -25, 	   0,  -16
+.2byte    3,  -12, 	 -10,   -5, 	  11,  -27, 	   1,  -16
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    1,   -7, 	  -8,   -7, 	   6,  -21, 	  -2,  -15
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte    8,  -16, 	   1,  -11, 	   0,  -27, 	  -1,  -17
+.2byte    9,  -16, 	   1,  -12, 	  -2,  -29, 	  -2,  -16
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte    4,   -7, 	   4,  -11, 	   1,  -23, 	   1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte   12,  -14, 	  12,  -11, 	  -8,  -26, 	  -1,  -15
+.2byte   13,  -13, 	  13,   -9, 	  -9,  -28, 	   0,  -15
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    9,  -10, 	  11,  -14, 	  -6,  -25, 	   0,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte    8,  -18, 	  13,  -16, 	 -15,  -20, 	  -2,  -15
+.2byte    8,  -18, 	  15,  -15, 	 -19,  -21, 	  -3,  -14
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte    5,  -14, 	  11,  -17, 	 -11,  -20, 	   0,  -15
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -21, 	   6,  -21, 	 -12,  -16, 	   0,  -15
+.2byte   -2,  -20, 	   7,  -20, 	 -15,  -15, 	  -1,  -14
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte    0,  -11, 	   5,  -19, 	  -9,  -18, 	   1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte  -11,  -16, 	  -6,  -21, 	   4,  -16, 	  -1,  -14
+.2byte  -14,  -15, 	  -8,  -20, 	   3,  -15, 	  -3,  -14
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -5,   -9, 	  -7,  -17, 	   4,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte  -13,  -14, 	 -17,  -15, 	  16,  -17, 	  -1,  -14
+.2byte  -14,  -13, 	 -20,  -14, 	  17,  -19, 	  -1,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -4,   -7, 	 -10,  -11, 	  13,  -16, 	   2,  -14
+.2byte   -7,   -8, 	 -14,  -10, 	  12,  -18, 	   0,  -14
+.2byte   -8,   -9, 	 -13,   -9, 	  12,  -18, 	  -1,  -13
+.2byte   -5,  -14, 	 -12,  -13, 	  14,  -19, 	   2,  -15
+.2byte    1,  -14, 	  -7,  -12, 	   8,  -23, 	   0,  -18
+.2byte    8,  -13, 	   2,  -13, 	   1,  -25, 	   0,  -18
+.2byte   12,  -13, 	   9,  -10, 	  -6,  -25, 	   0,  -17
+.2byte    8,  -18, 	  14,  -15, 	 -12,  -18, 	   0,  -15
+.2byte    0,  -18, 	   6,  -19, 	  -9,  -17, 	   0,  -15
+.2byte  -10,  -15, 	  -9,  -18, 	   8,  -17, 	  -3,  -17
+.2byte  -11,  -17, 	 -14,  -17, 	  10,  -19, 	  -2,  -17
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte   -9,  -13, 	 -16,  -12, 	  16,  -19, 	   3,  -16
+.2byte    2,  -13, 	  -8,   -7, 	   9,  -25, 	   0,  -16
+.2byte    8,  -15, 	   1,  -10, 	   0,  -26, 	  -1,  -16
+.2byte   12,  -14, 	  12,  -11, 	  -8,  -26, 	  -1,  -15
+.2byte    8,  -18, 	  13,  -16, 	 -15,  -20, 	  -2,  -15
+.2byte   -2,  -21, 	   6,  -21, 	 -12,  -16, 	   0,  -15
+.2byte  -11,  -16, 	  -6,  -21, 	   4,  -16, 	  -1,  -14
+.2byte  -13,  -14, 	 -17,  -15, 	  16,  -17, 	  -1,  -14
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -10, 	 -14,  -12, 	  12,  -18, 	   1,  -16
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+.2byte    1,  -10, 	  -6,   -9, 	   6,  -25, 	  -1,  -16
+.2byte    2,  -10, 	  -6,   -9, 	   5,  -25, 	  -1,  -16
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    8,   -9, 	   3,  -10, 	   0,  -24, 	   1,  -16
+.2byte    7,   -8, 	   4,  -10, 	   1,  -25, 	   0,  -16
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -7,  -24, 	  -1,  -15
+.2byte   10,  -13, 	   9,  -11, 	  -7,  -24, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -16
+.2byte    6,  -16, 	  12,  -16, 	 -14,  -20, 	  -1,  -16
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte   -2,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -1,  -15, 	   5,  -21, 	 -10,  -16, 	   0,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	   0,  -14
+.2byte   -6,  -10, 	  -7,  -17, 	   5,  -15, 	  -1,  -14
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -7,  -11, 	 -11,  -14, 	  12,  -16, 	   0,  -16
+.2byte   -7,  -10, 	 -12,  -14, 	  12,  -16, 	  -1,  -15
+.2byte   -6,   -9, 	 -14,  -12, 	  12,  -18, 	   1,  -15
+.2byte   -6,  -11, 	 -11,  -14, 	  12,  -16, 	  -1,  -16
+.2byte   -6,  -11, 	  -6,  -17, 	   5,  -15, 	  -1,  -15
+.2byte   -2,  -15, 	   6,  -20, 	 -10,  -16, 	   0,  -15
+.2byte    6,  -16, 	  12,  -17, 	 -14,  -20, 	  -1,  -15
+.2byte   10,  -12, 	   9,  -10, 	  -8,  -25, 	  -1,  -15
+.2byte    7,   -8, 	   2,  -10, 	   0,  -24, 	   1,  -16
+.2byte    1,  -10, 	  -7,  -10, 	   5,  -25, 	  -1,  -16
+sWeezingAnimTable1:
+.4byte sWeezingAnims_1_1
+.4byte sWeezingAnims_1_2
+.4byte sWeezingAnims_1_3
+.4byte sWeezingAnims_1_4
+.4byte sWeezingAnims_1_5
+.4byte sWeezingAnims_1_6
+.4byte sWeezingAnims_1_7
+.4byte sWeezingAnims_1_8
+sWeezingAnimTable2:
+.4byte sWeezingAnims_2_1
+.4byte sWeezingAnims_2_2
+.4byte sWeezingAnims_2_3
+.4byte sWeezingAnims_2_4
+.4byte sWeezingAnims_2_5
+.4byte sWeezingAnims_2_6
+.4byte sWeezingAnims_2_7
+.4byte sWeezingAnims_2_8
+sWeezingAnimTable3:
+.4byte sWeezingAnims_3_1
+.4byte sWeezingAnims_3_2
+.4byte sWeezingAnims_3_3
+.4byte sWeezingAnims_3_4
+.4byte sWeezingAnims_3_5
+.4byte sWeezingAnims_3_6
+.4byte sWeezingAnims_3_7
+.4byte sWeezingAnims_3_8
+sWeezingAnimTable4:
+.4byte sWeezingAnims_4_1
+.4byte sWeezingAnims_4_2
+.4byte sWeezingAnims_4_3
+.4byte sWeezingAnims_4_4
+.4byte sWeezingAnims_4_5
+.4byte sWeezingAnims_4_6
+.4byte sWeezingAnims_4_7
+.4byte sWeezingAnims_4_8
+sWeezingAnimTable5:
+.4byte sWeezingAnims_5_1
+.4byte sWeezingAnims_5_2
+.4byte sWeezingAnims_5_3
+.4byte sWeezingAnims_5_4
+.4byte sWeezingAnims_5_5
+.4byte sWeezingAnims_5_6
+.4byte sWeezingAnims_5_7
+.4byte sWeezingAnims_5_8
+sWeezingAnimTable6:
+.4byte sWeezingAnims_6_1
+.4byte sWeezingAnims_6_1
+.4byte sWeezingAnims_6_1
+.4byte sWeezingAnims_6_1
+.4byte sWeezingAnims_6_1
+.4byte sWeezingAnims_6_1
+.4byte sWeezingAnims_6_1
+.4byte sWeezingAnims_6_1
+sWeezingAnimTable7:
+.4byte sWeezingAnims_7_1
+.4byte sWeezingAnims_7_2
+.4byte sWeezingAnims_7_3
+.4byte sWeezingAnims_7_4
+.4byte sWeezingAnims_7_5
+.4byte sWeezingAnims_7_6
+.4byte sWeezingAnims_7_7
+.4byte sWeezingAnims_7_8
+sWeezingAnimTable8:
+.4byte sWeezingAnims_8_1
+.4byte sWeezingAnims_8_2
+.4byte sWeezingAnims_8_3
+.4byte sWeezingAnims_8_4
+.4byte sWeezingAnims_8_5
+.4byte sWeezingAnims_8_6
+.4byte sWeezingAnims_8_7
+.4byte sWeezingAnims_8_8
+sWeezingAnimTable9:
+.4byte sWeezingAnims_9_1
+.4byte sWeezingAnims_9_2
+.4byte sWeezingAnims_9_3
+.4byte sWeezingAnims_9_4
+.4byte sWeezingAnims_9_5
+.4byte sWeezingAnims_9_6
+.4byte sWeezingAnims_9_7
+.4byte sWeezingAnims_9_8
+sWeezingAnimTable10:
+.4byte sWeezingAnims_10_1
+.4byte sWeezingAnims_10_2
+.4byte sWeezingAnims_10_3
+.4byte sWeezingAnims_10_4
+.4byte sWeezingAnims_10_5
+.4byte sWeezingAnims_10_6
+.4byte sWeezingAnims_10_7
+.4byte sWeezingAnims_10_8
+sWeezingAnimTable11:
+.4byte sWeezingAnims_11_1
+.4byte sWeezingAnims_11_2
+.4byte sWeezingAnims_11_3
+.4byte sWeezingAnims_11_4
+.4byte sWeezingAnims_11_5
+.4byte sWeezingAnims_11_6
+.4byte sWeezingAnims_11_7
+.4byte sWeezingAnims_11_8
+sWeezingAnimTable12:
+.4byte sWeezingAnims_12_1
+.4byte sWeezingAnims_12_2
+.4byte sWeezingAnims_12_3
+.4byte sWeezingAnims_12_4
+.4byte sWeezingAnims_12_5
+.4byte sWeezingAnims_12_6
+.4byte sWeezingAnims_12_7
+.4byte sWeezingAnims_12_8
+sWeezingAnimTable13:
+.4byte sWeezingAnims_13_1
+.4byte sWeezingAnims_13_2
+.4byte sWeezingAnims_13_3
+.4byte sWeezingAnims_13_4
+.4byte sWeezingAnims_13_5
+.4byte sWeezingAnims_13_6
+.4byte sWeezingAnims_13_7
+.4byte sWeezingAnims_13_8
+sAxAnimationsWeezing:
+.4byte sWeezingAnimTable1
+.4byte sWeezingAnimTable2
+.4byte sWeezingAnimTable3
+.4byte sWeezingAnimTable4
+.4byte sWeezingAnimTable5
+.4byte sWeezingAnimTable6
+.4byte sWeezingAnimTable7
+.4byte sWeezingAnimTable8
+.4byte sWeezingAnimTable9
+.4byte sWeezingAnimTable10
+.4byte sWeezingAnimTable11
+.4byte sWeezingAnimTable12
+.4byte sWeezingAnimTable13
+sAxSpritesWeezing:
+.4byte sWeezingSprites1
+.4byte sWeezingSprites2
+.4byte sWeezingSprites3
+.4byte sWeezingSprites4
+.4byte sWeezingSprites5
+.4byte sWeezingSprites6
+.4byte sWeezingSprites7
+.4byte sWeezingSprites8
+.4byte sWeezingSprites9
+.4byte sWeezingSprites10
+.4byte sWeezingSprites11
+.4byte sWeezingSprites12
+.4byte sWeezingSprites13
+.4byte sWeezingSprites14
+.4byte sWeezingSprites15
+.4byte sWeezingSprites16
+.4byte sWeezingSprites17
+.4byte sWeezingSprites18
+.4byte sWeezingSprites19
+.4byte sWeezingSprites20
+.4byte sWeezingSprites21
+.4byte sWeezingSprites22
+.4byte sWeezingSprites23
+.4byte sWeezingSprites24
+.4byte sWeezingSprites25
+.4byte sWeezingSprites26
+.4byte sWeezingSprites27
+.4byte sWeezingSprites28
+.4byte sWeezingSprites29
+.4byte sWeezingSprites30
+.4byte sWeezingSprites31
+.4byte sWeezingSprites32
+.4byte sWeezingSprites33
+.4byte sWeezingSprites34
+.4byte sWeezingSprites35
+.4byte sWeezingSprites36
+.4byte sWeezingSprites37
+.4byte sWeezingSprites38
+.4byte sWeezingSprites39
+.4byte sWeezingSprites40
+.4byte sWeezingSprites41
+.4byte sWeezingSprites42
+.4byte sWeezingSprites43
+.4byte sWeezingSprites44
+.4byte sWeezingSprites45
+.4byte sWeezingSprites46
+.4byte sWeezingSprites47
+.4byte sWeezingSprites48
+.4byte sWeezingSprites49
+.4byte sWeezingSprites50
+.4byte sWeezingSprites51
+.4byte sWeezingSprites52
+.4byte sWeezingSprites53
+.4byte sWeezingSprites54
+.4byte sWeezingSprites55
+.4byte sWeezingSprites56
+.4byte sWeezingSprites57
+.4byte sWeezingSprites58
+.4byte sWeezingSprites59
+.4byte sWeezingSprites60
+.4byte sWeezingSprites61
+.4byte sWeezingSprites62
+.4byte sWeezingSprites63
+.4byte sWeezingSprites64
+.4byte sWeezingSprites65
+.4byte sWeezingSprites66
+.4byte sWeezingSprites67
+.4byte sWeezingSprites68
+.4byte sWeezingSprites69
+.4byte sWeezingSprites70
+.4byte sWeezingSprites71
+.4byte sWeezingSprites72
+.4byte sWeezingSprites73
+.4byte sWeezingSprites74
+.4byte sWeezingSprites75
+.4byte sWeezingSprites76
+.4byte sWeezingSprites77
+.4byte sWeezingSprites78
+.4byte sWeezingSprites79
+.4byte sWeezingSprites80
+.4byte sWeezingSprites81
+.4byte sWeezingSprites82
+.4byte sWeezingSprites83
+.4byte sWeezingSprites84
+.4byte sWeezingSprites85
+.4byte sWeezingSprites86
+.4byte sWeezingSprites87
+.4byte sWeezingSprites88
+.4byte sWeezingSprites89
+.4byte sWeezingSprites90
+.4byte sWeezingSprites91
+.4byte sWeezingSprites92
+.4byte sWeezingSprites93
+sAxMainWeezing:
+ax_main sAxPosesWeezing, sAxAnimationsWeezing, 13, sAxSpritesWeezing, sAxPositionsWeezing

--- a/data/ax/whiscash.inc
+++ b/data/ax/whiscash.inc
@@ -1,0 +1,2787 @@
+.global gAxWhiscash
+gAxWhiscash:
+ax_siro sAxMainWhiscash
+sWhiscashPose1:
+ax_pose 0, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose2:
+ax_pose 1, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose3:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose4:
+ax_pose 3, 0x01e9, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose5:
+ax_pose 4, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose6:
+ax_pose 5, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose7:
+ax_pose 6, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose8:
+ax_pose 7, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose9:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose10:
+ax_pose 9, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose11:
+ax_pose 10, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose12:
+ax_pose 11, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose13:
+ax_pose 12, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose15:
+ax_pose 14, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose16:
+ax_pose 9, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose17:
+ax_pose 10, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose18:
+ax_pose 11, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose19:
+ax_pose 6, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose20:
+ax_pose 7, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose21:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose22:
+ax_pose 3, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose23:
+ax_pose 4, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose24:
+ax_pose 5, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose25:
+ax_pose 0, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose26:
+ax_pose 1, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose27:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose28:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose29:
+ax_pose 16, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose30:
+ax_pose 3, 0x01e9, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose31:
+ax_pose 4, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose32:
+ax_pose 5, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose33:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose34:
+ax_pose 18, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose35:
+ax_pose 6, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose36:
+ax_pose 7, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose37:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose38:
+ax_pose 19, 0x01e4, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose39:
+ax_pose 20, 0x01e4, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose40:
+ax_pose 9, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose41:
+ax_pose 10, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose42:
+ax_pose 11, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose43:
+ax_pose 21, 0x01e4, 0x90f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose44:
+ax_pose 22, 0x01e4, 0x90f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose45:
+ax_pose 12, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose46:
+ax_pose 13, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose47:
+ax_pose 14, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose48:
+ax_pose 23, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose49:
+ax_pose 24, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose50:
+ax_pose 9, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose51:
+ax_pose 10, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose52:
+ax_pose 11, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose53:
+ax_pose 21, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose54:
+ax_pose 22, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose55:
+ax_pose 6, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose56:
+ax_pose 7, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose57:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose58:
+ax_pose 19, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose59:
+ax_pose 20, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose60:
+ax_pose 3, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose61:
+ax_pose 4, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose62:
+ax_pose 5, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose63:
+ax_pose 17, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose64:
+ax_pose 18, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose65:
+ax_pose 0, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose66:
+ax_pose 1, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose67:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose68:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose69:
+ax_pose 16, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose70:
+ax_pose 3, 0x01e9, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose71:
+ax_pose 4, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose72:
+ax_pose 5, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose73:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose74:
+ax_pose 18, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose75:
+ax_pose 6, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose76:
+ax_pose 7, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose77:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose78:
+ax_pose 19, 0x01e4, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose79:
+ax_pose 20, 0x01e4, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose80:
+ax_pose 9, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose81:
+ax_pose 10, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose82:
+ax_pose 11, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose83:
+ax_pose 21, 0x01e4, 0x90f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose84:
+ax_pose 22, 0x01e4, 0x90f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose85:
+ax_pose 12, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose86:
+ax_pose 13, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose87:
+ax_pose 14, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose88:
+ax_pose 23, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose89:
+ax_pose 24, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose90:
+ax_pose 9, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose91:
+ax_pose 10, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose92:
+ax_pose 11, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose93:
+ax_pose 21, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose94:
+ax_pose 22, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose95:
+ax_pose 6, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose96:
+ax_pose 7, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose97:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose98:
+ax_pose 19, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose99:
+ax_pose 20, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose100:
+ax_pose 3, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose101:
+ax_pose 4, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose102:
+ax_pose 5, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose103:
+ax_pose 17, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose104:
+ax_pose 18, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose105:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose106:
+ax_pose 15, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose107:
+ax_pose 25, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose108:
+ax_pose 5, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose109:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose110:
+ax_pose 26, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose111:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose112:
+ax_pose 19, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose113:
+ax_pose 27, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose114:
+ax_pose 11, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose115:
+ax_pose 21, 0x01e4, 0x90f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose116:
+ax_pose 28, 0x01e4, 0x90f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose117:
+ax_pose 22, 0x01e4, 0x90f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose118:
+ax_pose 14, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose119:
+ax_pose 23, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose120:
+ax_pose 29, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose121:
+ax_pose 24, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose122:
+ax_pose 11, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose123:
+ax_pose 21, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose124:
+ax_pose 28, 0x01e4, 0x80ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose125:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose126:
+ax_pose 19, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose127:
+ax_pose 27, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose128:
+ax_pose 20, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose129:
+ax_pose 5, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose130:
+ax_pose 17, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose131:
+ax_pose 26, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose132:
+ax_pose 1, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose133:
+ax_pose 15, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose134:
+ax_pose 16, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose135:
+ax_pose 4, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose136:
+ax_pose 17, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose137:
+ax_pose 18, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose138:
+ax_pose 7, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose139:
+ax_pose 19, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose140:
+ax_pose 20, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose141:
+ax_pose 10, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose142:
+ax_pose 21, 0x01e6, 0x90f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose143:
+ax_pose 22, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose144:
+ax_pose 13, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose145:
+ax_pose 23, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose146:
+ax_pose 24, 0x01e7, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose147:
+ax_pose 10, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose148:
+ax_pose 21, 0x01e6, 0x80ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose149:
+ax_pose 22, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose150:
+ax_pose 7, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose151:
+ax_pose 19, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose152:
+ax_pose 20, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose153:
+ax_pose 4, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose154:
+ax_pose 17, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose155:
+ax_pose 18, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose156:
+ax_pose 30, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose157:
+ax_pose 31, 0x01e9, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose158:
+ax_pose 32, 0x01df, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose159:
+ax_pose 33, 0x01e1, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose160:
+ax_pose 34, 0x01df, 0x90ed, 0x9c00
+ax_pose_terminator
+sWhiscashPose161:
+ax_pose 35, 0x01e0, 0x90ec, 0x9c00
+ax_pose_terminator
+sWhiscashPose162:
+ax_pose 36, 0x01e4, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose163:
+ax_pose 35, 0x01e0, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose164:
+ax_pose 34, 0x01df, 0x80f3, 0x9c00
+ax_pose_terminator
+sWhiscashPose165:
+ax_pose 33, 0x01e1, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose166:
+ax_pose 0, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose167:
+ax_pose 1, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose168:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose169:
+ax_pose 3, 0x01e9, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose170:
+ax_pose 4, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose171:
+ax_pose 5, 0x01e4, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose172:
+ax_pose 6, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose173:
+ax_pose 7, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose174:
+ax_pose 8, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose175:
+ax_pose 9, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose176:
+ax_pose 10, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose177:
+ax_pose 11, 0x01ea, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose178:
+ax_pose 12, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose179:
+ax_pose 13, 0x01ea, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose180:
+ax_pose 14, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose181:
+ax_pose 9, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose182:
+ax_pose 10, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose183:
+ax_pose 11, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose184:
+ax_pose 6, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose185:
+ax_pose 7, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose186:
+ax_pose 8, 0x01e8, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose187:
+ax_pose 3, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose188:
+ax_pose 4, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose189:
+ax_pose 5, 0x01e4, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose190:
+ax_pose 16, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose191:
+ax_pose 18, 0x01ea, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose192:
+ax_pose 20, 0x01e7, 0x80f3, 0x9c00
+ax_pose_terminator
+sWhiscashPose193:
+ax_pose 22, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose194:
+ax_pose 24, 0x01ec, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose195:
+ax_pose 22, 0x01e8, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose196:
+ax_pose 20, 0x01e7, 0x90ed, 0x9c00
+ax_pose_terminator
+sWhiscashPose197:
+ax_pose 18, 0x01ea, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose198:
+ax_pose 25, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose199:
+ax_pose 26, 0x01e9, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose200:
+ax_pose 27, 0x01e4, 0x90ed, 0x9c00
+ax_pose_terminator
+sWhiscashPose201:
+ax_pose 28, 0x01e6, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose202:
+ax_pose 29, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose203:
+ax_pose 28, 0x01e6, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose204:
+ax_pose 27, 0x01e4, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose205:
+ax_pose 26, 0x01e9, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose206:
+ax_pose 2, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose207:
+ax_pose 25, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose208:
+ax_pose 15, 0x01e6, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose209:
+ax_pose 5, 0x01e5, 0x90f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose210:
+ax_pose 26, 0x01e8, 0x90f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose211:
+ax_pose 17, 0x01e9, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose212:
+ax_pose 8, 0x01e8, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose213:
+ax_pose 27, 0x01e4, 0x90ed, 0x9c00
+ax_pose_terminator
+sWhiscashPose214:
+ax_pose 19, 0x01e5, 0x90ed, 0x9c00
+ax_pose_terminator
+sWhiscashPose215:
+ax_pose 11, 0x01eb, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose216:
+ax_pose 28, 0x01e5, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose217:
+ax_pose 21, 0x01e5, 0x90f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose218:
+ax_pose 14, 0x01ea, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose219:
+ax_pose 29, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose220:
+ax_pose 23, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose221:
+ax_pose 11, 0x01eb, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose222:
+ax_pose 28, 0x01e5, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose223:
+ax_pose 21, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose224:
+ax_pose 8, 0x01e8, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose225:
+ax_pose 27, 0x01e4, 0x80f3, 0x9c00
+ax_pose_terminator
+sWhiscashPose226:
+ax_pose 19, 0x01e5, 0x80f3, 0x9c00
+ax_pose_terminator
+sWhiscashPose227:
+ax_pose 5, 0x01e5, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose228:
+ax_pose 26, 0x01e8, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose229:
+ax_pose 17, 0x01e9, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose230:
+ax_pose 16, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose231:
+ax_pose 18, 0x01eb, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose232:
+ax_pose 20, 0x01e7, 0x80f2, 0x9c00
+ax_pose_terminator
+sWhiscashPose233:
+ax_pose 22, 0x01e8, 0x80f1, 0x9c00
+ax_pose_terminator
+sWhiscashPose234:
+ax_pose 24, 0x01eb, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose235:
+ax_pose 22, 0x01e8, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose236:
+ax_pose 20, 0x01e7, 0x90ee, 0x9c00
+ax_pose_terminator
+sWhiscashPose237:
+ax_pose 18, 0x01eb, 0x90ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose238:
+ax_pose 0, 0x01e9, 0x80f4, 0x9c00
+ax_pose_terminator
+sWhiscashPose239:
+ax_pose 3, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose240:
+ax_pose 6, 0x01ea, 0x80ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose241:
+ax_pose 9, 0x01e9, 0x80ef, 0x9c00
+ax_pose_terminator
+sWhiscashPose242:
+ax_pose 12, 0x01e9, 0x80f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose243:
+ax_pose 9, 0x01e9, 0x90f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose244:
+ax_pose 6, 0x01ea, 0x90f0, 0x9c00
+ax_pose_terminator
+sWhiscashPose245:
+ax_pose 3, 0x01e9, 0x90f0, 0x9c00
+ax_pose_terminator
+.align 2
+sWhiscashAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 1, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -3, 0, 0,
+ax_anim 8, 0, 0, 0, -3, 0, 0,
+ax_anim 8, 0, 2, 0, -3, 0, 0,
+ax_anim 6, 0, 2, 0, -2, 0, 0,
+ax_anim 8, 0, 2, 0, -1, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 4, 0, -2, 0, 0,
+ax_anim 6, 0, 4, 0, -3, 0, 0,
+ax_anim 8, 0, 3, 0, -3, 0, 0,
+ax_anim 8, 0, 5, 0, -3, 0, 0,
+ax_anim 6, 0, 5, 0, -2, 0, 0,
+ax_anim 8, 0, 5, 0, -1, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 8, 0, 6, 0, -3, 0, 0,
+ax_anim 8, 0, 8, 0, -3, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 8, 0, 8, 0, -1, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 10, 0, -2, 0, 0,
+ax_anim 6, 0, 10, 0, -3, 0, 0,
+ax_anim 8, 0, 9, 0, -3, 0, 0,
+ax_anim 8, 0, 11, 0, -3, 0, 0,
+ax_anim 6, 0, 11, 0, -2, 0, 0,
+ax_anim 8, 0, 11, 0, -1, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -3, 0, 0,
+ax_anim 8, 0, 12, 0, -3, 0, 0,
+ax_anim 8, 0, 14, 0, -3, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 8, 0, 14, 0, -1, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 16, 0, -2, 0, 0,
+ax_anim 6, 0, 16, 0, -3, 0, 0,
+ax_anim 8, 0, 15, 0, -3, 0, 0,
+ax_anim 8, 0, 17, 0, -3, 0, 0,
+ax_anim 6, 0, 17, 0, -2, 0, 0,
+ax_anim 8, 0, 17, 0, -1, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 8, 0, 18, 0, -3, 0, 0,
+ax_anim 8, 0, 20, 0, -3, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 8, 0, 20, 0, -1, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 22, 0, -2, 0, 0,
+ax_anim 6, 0, 22, 0, -3, 0, 0,
+ax_anim 8, 0, 21, 0, -3, 0, 0,
+ax_anim 8, 0, 23, 0, -3, 0, 0,
+ax_anim 6, 0, 23, 0, -2, 0, 0,
+ax_anim 8, 0, 23, 0, -1, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_2_1:
+ax_anim 2, 0, 28, 0, -1, 0, -1,
+ax_anim 6, 0, 28, 0, -3, 0, -2,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 25, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 1, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 18, 0, 18,
+ax_anim 2, 0, 27, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWhiscashAnims_2_2:
+ax_anim 2, 0, 33, -1, -1, -1, -1,
+ax_anim 6, 0, 33, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 11, 10, 11,
+ax_anim 2, 0, 32, 18, 19, 18, 19,
+ax_anim 2, 1, 32, 19, 18, 19, 18,
+ax_anim 2, 0, 32, 18, 19, 18, 19,
+ax_anim 2, 0, 32, 19, 18, 19, 18,
+ax_anim 2, 0, 29, 6, 6, 6, 6,
+ax_anim_terminator
+sWhiscashAnims_2_3:
+ax_anim 2, 0, 38, -1, 0, -1, 0,
+ax_anim 6, 0, 38, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 2, 0, 2, 0,
+ax_anim 1, 2, 35, 6, 0, 6, 0,
+ax_anim 1, 0, 35, 10, 1, 10, 0,
+ax_anim 2, 0, 37, 18, 2, 18, 0,
+ax_anim 2, 1, 37, 18, 3, 18, 1,
+ax_anim 2, 0, 37, 18, 2, 18, 0,
+ax_anim 2, 0, 37, 18, 3, 18, 1,
+ax_anim 2, 0, 34, 6, 0, 6, 0,
+ax_anim_terminator
+sWhiscashAnims_2_4:
+ax_anim 2, 0, 43, -1, 1, -1, 1,
+ax_anim 6, 0, 43, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 40, 5, -5, 5, -5,
+ax_anim 1, 0, 40, 12, -12, 12, -13,
+ax_anim 2, 0, 42, 17, -16, 19, -21,
+ax_anim 2, 1, 42, 18, -15, 20, -20,
+ax_anim 2, 0, 42, 17, -16, 19, -21,
+ax_anim 2, 0, 42, 18, -15, 20, -20,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim_terminator
+sWhiscashAnims_2_5:
+ax_anim 2, 0, 48, 0, 1, 0, 1,
+ax_anim 6, 0, 48, 0, 2, 0, 2,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 45, 0, -4, 0, -4,
+ax_anim 1, 0, 45, 0, -11, 0, -13,
+ax_anim 2, 0, 47, 0, -15, 0, -22,
+ax_anim 2, 1, 47, 1, -15, 1, -22,
+ax_anim 2, 0, 47, 0, -15, 0, -22,
+ax_anim 2, 0, 47, 1, -15, 1, -22,
+ax_anim 2, 0, 44, 0, -6, 0, -6,
+ax_anim_terminator
+sWhiscashAnims_2_6:
+ax_anim 2, 0, 53, 1, 1, 1, 1,
+ax_anim 6, 0, 53, 2, 2, 2, 2,
+ax_anim 1, 0, 49, 0, -1, 0, -1,
+ax_anim 1, 2, 50, -5, -5, -5, -5,
+ax_anim 1, 0, 50, -12, -12, -12, -13,
+ax_anim 2, 0, 52, -17, -16, -19, -21,
+ax_anim 2, 1, 52, -18, -15, -20, -20,
+ax_anim 2, 0, 52, -17, -16, -19, -21,
+ax_anim 2, 0, 52, -18, -15, -20, -20,
+ax_anim 2, 0, 49, -6, -6, -6, -6,
+ax_anim_terminator
+sWhiscashAnims_2_7:
+ax_anim 2, 0, 58, 1, 0, 1, 0,
+ax_anim 6, 0, 58, 2, 0, 2, 0,
+ax_anim 1, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 2, 55, -6, 0, -6, 0,
+ax_anim 1, 0, 55, -10, 1, -10, 0,
+ax_anim 2, 0, 57, -18, 2, -18, 0,
+ax_anim 2, 1, 57, -18, 3, -18, 1,
+ax_anim 2, 0, 57, -18, 2, -18, 0,
+ax_anim 2, 0, 57, -18, 3, -18, 1,
+ax_anim 2, 0, 54, -6, 0, -6, 0,
+ax_anim_terminator
+sWhiscashAnims_2_8:
+ax_anim 2, 0, 63, 1, -1, 1, -1,
+ax_anim 6, 0, 63, 2, -2, 2, -2,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 60, -4, 4, -4, 4,
+ax_anim 1, 0, 60, -10, 11, -10, 11,
+ax_anim 2, 0, 62, -18, 19, -18, 19,
+ax_anim 2, 1, 62, -19, 18, -19, 18,
+ax_anim 2, 0, 62, -18, 19, -18, 19,
+ax_anim 2, 0, 62, -19, 18, -19, 18,
+ax_anim 2, 0, 59, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_3_1:
+ax_anim 2, 0, 68, 0, -1, 0, -1,
+ax_anim 6, 0, 68, 0, -3, 0, -2,
+ax_anim 1, 0, 64, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 65, 0, 10, 0, 10,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 1, 67, 1, 18, 1, 18,
+ax_anim 2, 0, 67, 0, 18, 0, 18,
+ax_anim 2, 0, 67, 1, 18, 1, 18,
+ax_anim 2, 0, 64, 0, 6, 0, 6,
+ax_anim_terminator
+sWhiscashAnims_3_2:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 6, 0, 73, -2, -2, -2, -2,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, 4, 4, 4,
+ax_anim 1, 0, 70, 10, 11, 10, 11,
+ax_anim 2, 0, 72, 18, 19, 18, 19,
+ax_anim 2, 1, 72, 19, 18, 19, 18,
+ax_anim 2, 0, 72, 18, 19, 18, 19,
+ax_anim 2, 0, 72, 19, 18, 19, 18,
+ax_anim 2, 0, 69, 6, 6, 6, 6,
+ax_anim_terminator
+sWhiscashAnims_3_3:
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 6, 0, 78, -2, 0, -2, 0,
+ax_anim 1, 0, 74, 2, 0, 2, 0,
+ax_anim 1, 2, 75, 6, 0, 6, 0,
+ax_anim 1, 0, 75, 10, 1, 10, 0,
+ax_anim 2, 0, 77, 18, 2, 18, 0,
+ax_anim 2, 1, 77, 18, 3, 18, 1,
+ax_anim 2, 0, 77, 18, 2, 18, 0,
+ax_anim 2, 0, 77, 18, 3, 18, 1,
+ax_anim 2, 0, 74, 6, 0, 6, 0,
+ax_anim_terminator
+sWhiscashAnims_3_4:
+ax_anim 2, 0, 83, -1, 1, -1, 1,
+ax_anim 6, 0, 83, -2, 2, -2, 2,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 1, 2, 80, 5, -5, 5, -5,
+ax_anim 1, 0, 80, 12, -12, 12, -13,
+ax_anim 2, 0, 82, 17, -16, 19, -21,
+ax_anim 2, 1, 82, 18, -15, 20, -20,
+ax_anim 2, 0, 82, 17, -16, 19, -21,
+ax_anim 2, 0, 82, 18, -15, 20, -20,
+ax_anim 2, 0, 79, 6, -6, 6, -6,
+ax_anim_terminator
+sWhiscashAnims_3_5:
+ax_anim 2, 0, 88, 0, 1, 0, 1,
+ax_anim 6, 0, 88, 0, 2, 0, 2,
+ax_anim 1, 0, 84, 0, 0, 0, 0,
+ax_anim 1, 2, 85, 0, -4, 0, -4,
+ax_anim 1, 0, 85, 0, -11, 0, -13,
+ax_anim 2, 0, 87, 0, -15, 0, -22,
+ax_anim 2, 1, 87, 1, -15, 1, -22,
+ax_anim 2, 0, 87, 0, -15, 0, -22,
+ax_anim 2, 0, 87, 1, -15, 1, -22,
+ax_anim 2, 0, 84, 0, -6, 0, -6,
+ax_anim_terminator
+sWhiscashAnims_3_6:
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 6, 0, 93, 2, 2, 2, 2,
+ax_anim 1, 0, 89, 0, -1, 0, -1,
+ax_anim 1, 2, 90, -5, -5, -5, -5,
+ax_anim 1, 0, 90, -12, -12, -12, -13,
+ax_anim 2, 0, 92, -17, -16, -19, -21,
+ax_anim 2, 1, 92, -18, -15, -20, -20,
+ax_anim 2, 0, 92, -17, -16, -19, -21,
+ax_anim 2, 0, 92, -18, -15, -20, -20,
+ax_anim 2, 0, 89, -6, -6, -6, -6,
+ax_anim_terminator
+sWhiscashAnims_3_7:
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 6, 0, 98, 2, 0, 2, 0,
+ax_anim 1, 0, 94, -2, 0, -2, 0,
+ax_anim 1, 2, 95, -6, 0, -6, 0,
+ax_anim 1, 0, 95, -10, 1, -10, 0,
+ax_anim 2, 0, 97, -18, 2, -18, 0,
+ax_anim 2, 1, 97, -18, 3, -18, 1,
+ax_anim 2, 0, 97, -18, 2, -18, 0,
+ax_anim 2, 0, 97, -18, 3, -18, 1,
+ax_anim 2, 0, 94, -6, 0, -6, 0,
+ax_anim_terminator
+sWhiscashAnims_3_8:
+ax_anim 2, 0, 103, 1, -1, 1, -1,
+ax_anim 6, 0, 103, 2, -2, 2, -2,
+ax_anim 1, 0, 99, 0, 0, 0, 0,
+ax_anim 1, 2, 100, -4, 4, -4, 4,
+ax_anim 1, 0, 100, -10, 11, -10, 11,
+ax_anim 2, 0, 102, -18, 19, -18, 19,
+ax_anim 2, 1, 102, -19, 18, -19, 18,
+ax_anim 2, 0, 102, -18, 19, -18, 19,
+ax_anim 2, 0, 102, -19, 18, -19, 18,
+ax_anim 2, 0, 99, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_4_1:
+ax_anim 2, 0, 104, 0, -1, 0, -1,
+ax_anim 6, 2, 105, 0, -4, 0, -4,
+ax_anim 2, 0, 105, 0, -1, 0, -1,
+ax_anim 2, 1, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 106, 1, 3, 1, 3,
+ax_anim 2, 0, 106, 0, 3, 0, 3,
+ax_anim 2, 0, 104, 0, 1, 0, 1,
+ax_anim_terminator
+sWhiscashAnims_4_2:
+ax_anim 2, 0, 107, -2, -2, -2, -2,
+ax_anim 6, 2, 108, -4, -4, -3, -3,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 1, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 109, 3, 1, 3, 1,
+ax_anim 2, 0, 109, 2, 2, 2, 2,
+ax_anim 2, 0, 107, 1, 1, 1, 1,
+ax_anim_terminator
+sWhiscashAnims_4_3:
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim 6, 2, 111, -5, 0, -5, 0,
+ax_anim 2, 0, 111, -1, 0, -1, 0,
+ax_anim 2, 1, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 112, 2, 1, 2, 1,
+ax_anim 2, 0, 112, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim_terminator
+sWhiscashAnims_4_4:
+ax_anim 2, 0, 113, -2, 2, -2, 2,
+ax_anim 6, 2, 114, -3, 3, -3, 3,
+ax_anim 2, 0, 114, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -1, 3, -1,
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 113, 1, -1, 1, -1,
+ax_anim_terminator
+sWhiscashAnims_4_5:
+ax_anim 2, 0, 117, 0, 2, 0, 2,
+ax_anim 6, 2, 118, 0, 3, 0, 3,
+ax_anim 2, 0, 118, 0, 1, 0, 1,
+ax_anim 2, 1, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 119, 1, -3, 1, -3,
+ax_anim 2, 0, 119, 0, -3, 0, -3,
+ax_anim 2, 0, 117, 0, -1, 0, -1,
+ax_anim_terminator
+sWhiscashAnims_4_6:
+ax_anim 2, 0, 121, 2, 2, 2, 2,
+ax_anim 6, 2, 122, 3, 3, 3, 3,
+ax_anim 2, 0, 122, 1, 1, 1, 1,
+ax_anim 2, 1, 123, -2, -2, -2, -2,
+ax_anim 2, 0, 123, -3, -1, -3, -1,
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 2, 0, 123, -3, -1, -3, -1,
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 2, 0, 123, -3, -1, -3, -1,
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 2, 0, 121, -1, -1, -1, -1,
+ax_anim_terminator
+sWhiscashAnims_4_7:
+ax_anim 2, 0, 124, 2, 0, 2, 0,
+ax_anim 6, 2, 125, 5, 0, 5, 0,
+ax_anim 2, 0, 125, 1, 0, 1, 0,
+ax_anim 2, 1, 126, -2, 0, -2, 0,
+ax_anim 2, 0, 126, -2, 1, -2, 1,
+ax_anim 2, 0, 126, -2, 0, -2, 0,
+ax_anim 2, 0, 126, -2, 1, -2, 1,
+ax_anim 2, 0, 126, -2, 0, -2, 0,
+ax_anim 2, 0, 126, -2, 1, -2, 1,
+ax_anim 2, 0, 126, -2, 0, -2, 0,
+ax_anim 2, 0, 124, -1, 0, -1, 0,
+ax_anim_terminator
+sWhiscashAnims_4_8:
+ax_anim 2, 0, 128, 2, -2, 2, -2,
+ax_anim 6, 2, 129, 4, -4, 3, -3,
+ax_anim 2, 0, 129, 1, -1, 1, -1,
+ax_anim 2, 1, 130, -2, 2, -2, 2,
+ax_anim 2, 0, 130, -3, 1, -3, 1,
+ax_anim 2, 0, 130, -2, 2, -2, 2,
+ax_anim 2, 0, 130, -3, 1, -3, 1,
+ax_anim 2, 0, 130, -2, 2, -2, 2,
+ax_anim 2, 0, 130, -3, 1, -3, 1,
+ax_anim 2, 0, 130, -2, 2, -2, 2,
+ax_anim 2, 0, 128, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_5_1:
+ax_anim 2, 0, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 4, 0, 136, 0, -2, 0, 0,
+ax_anim 4, 2, 132, 0, 0, 0, 0,
+ax_anim 4, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_5_2:
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 4, 2, 135, 0, 0, 0, 0,
+ax_anim 4, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 135, 0, -2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_5_3:
+ax_anim 2, 0, 136, 0, -4, 0, 0,
+ax_anim 2, 0, 136, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 4, 2, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_5_4:
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -4, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 4, 2, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 141, 0, -2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_5_5:
+ax_anim 2, 0, 142, 0, -4, 0, 0,
+ax_anim 2, 0, 142, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, -4, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 4, 2, 144, 0, 2, 0, 0,
+ax_anim 4, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_5_6:
+ax_anim 2, 0, 145, 0, -4, 0, 0,
+ax_anim 2, 0, 145, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, -4, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 4, 2, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 147, 0, -2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_5_7:
+ax_anim 2, 0, 148, 0, -4, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, -4, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 4, 2, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 150, 0, -2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_5_8:
+ax_anim 2, 0, 151, 0, -4, 0, 0,
+ax_anim 2, 0, 151, 0, -2, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, -4, 0, 0,
+ax_anim 4, 0, 133, 0, -2, 0, 0,
+ax_anim 4, 2, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_6_1:
+ax_anim 20, 0, 155, 0, 0, 0, 0,
+ax_anim 12, 0, 155, 0, -1, 0, 0,
+ax_anim 12, 0, 155, 0, -2, 0, 0,
+ax_anim 20, 0, 156, 0, -2, 0, 0,
+ax_anim 12, 0, 156, 0, -1, 0, 0,
+ax_anim 12, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_7_1:
+ax_anim 2, 0, 157, 0, -4, 0, -4,
+ax_anim 8, 0, 157, 0, -5, 0, -5,
+ax_anim_terminator
+sWhiscashAnims_7_2:
+ax_anim 2, 0, 158, -4, -4, -4, -4,
+ax_anim 8, 0, 158, -5, -5, -5, -5,
+ax_anim_terminator
+sWhiscashAnims_7_3:
+ax_anim 2, 0, 159, -4, 0, -4, 0,
+ax_anim 8, 0, 159, -5, 0, -5, 0,
+ax_anim_terminator
+sWhiscashAnims_7_4:
+ax_anim 2, 0, 160, -4, 4, -4, 4,
+ax_anim 8, 0, 160, -5, 5, -5, 5,
+ax_anim_terminator
+sWhiscashAnims_7_5:
+ax_anim 2, 0, 161, 0, 4, 0, 4,
+ax_anim 8, 0, 161, 0, 5, 0, 5,
+ax_anim_terminator
+sWhiscashAnims_7_6:
+ax_anim 2, 0, 162, 4, 4, 4, 4,
+ax_anim 8, 0, 162, 5, 5, 5, 5,
+ax_anim_terminator
+sWhiscashAnims_7_7:
+ax_anim 2, 0, 163, 4, 0, 4, 0,
+ax_anim 8, 0, 163, 5, 0, 5, 0,
+ax_anim_terminator
+sWhiscashAnims_7_8:
+ax_anim 2, 0, 164, 4, -4, 4, -4,
+ax_anim 8, 0, 164, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_8_1:
+ax_anim 10, 0, 166, 0, 0, 0, 0,
+ax_anim 10, 0, 166, 0, -1, 0, 0,
+ax_anim 10, 0, 166, 0, -2, 0, 0,
+ax_anim 10, 0, 166, 0, -3, 0, 0,
+ax_anim 10, 0, 165, 0, -3, 0, 0,
+ax_anim 10, 0, 167, 0, -3, 0, 0,
+ax_anim 10, 0, 167, 0, -2, 0, 0,
+ax_anim 10, 0, 167, 0, -1, 0, 0,
+ax_anim 10, 0, 167, 0, 0, 0, 0,
+ax_anim 10, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_8_2:
+ax_anim 10, 0, 169, 0, 0, 0, 0,
+ax_anim 10, 0, 169, 0, -1, 0, 0,
+ax_anim 10, 0, 169, 0, -2, 0, 0,
+ax_anim 10, 0, 169, 0, -3, 0, 0,
+ax_anim 10, 0, 168, 0, -3, 0, 0,
+ax_anim 10, 0, 170, 0, -3, 0, 0,
+ax_anim 10, 0, 170, 0, -2, 0, 0,
+ax_anim 10, 0, 170, 0, -1, 0, 0,
+ax_anim 10, 0, 170, 0, 0, 0, 0,
+ax_anim 10, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_8_3:
+ax_anim 10, 0, 172, 0, 0, 0, 0,
+ax_anim 10, 0, 172, 0, -1, 0, 0,
+ax_anim 10, 0, 172, 0, -2, 0, 0,
+ax_anim 10, 0, 172, 0, -3, 0, 0,
+ax_anim 10, 0, 171, 0, -3, 0, 0,
+ax_anim 10, 0, 173, 0, -3, 0, 0,
+ax_anim 10, 0, 173, 0, -2, 0, 0,
+ax_anim 10, 0, 173, 0, -1, 0, 0,
+ax_anim 10, 0, 173, 0, 0, 0, 0,
+ax_anim 10, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_8_4:
+ax_anim 10, 0, 175, 0, 0, 0, 0,
+ax_anim 10, 0, 175, 0, -1, 0, 0,
+ax_anim 10, 0, 175, 0, -2, 0, 0,
+ax_anim 10, 0, 175, 0, -3, 0, 0,
+ax_anim 10, 0, 174, 0, -3, 0, 0,
+ax_anim 10, 0, 176, 0, -3, 0, 0,
+ax_anim 10, 0, 176, 0, -2, 0, 0,
+ax_anim 10, 0, 176, 0, -1, 0, 0,
+ax_anim 10, 0, 176, 0, 0, 0, 0,
+ax_anim 10, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_8_5:
+ax_anim 10, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 178, 0, -1, 0, 0,
+ax_anim 10, 0, 178, 0, -2, 0, 0,
+ax_anim 10, 0, 178, 0, -3, 0, 0,
+ax_anim 10, 0, 177, 0, -3, 0, 0,
+ax_anim 10, 0, 179, 0, -3, 0, 0,
+ax_anim 10, 0, 179, 0, -2, 0, 0,
+ax_anim 10, 0, 179, 0, -1, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 10, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_8_6:
+ax_anim 10, 0, 181, 0, 0, 0, 0,
+ax_anim 10, 0, 181, 0, -1, 0, 0,
+ax_anim 10, 0, 181, 0, -2, 0, 0,
+ax_anim 10, 0, 181, 0, -3, 0, 0,
+ax_anim 10, 0, 180, 0, -3, 0, 0,
+ax_anim 10, 0, 182, 0, -3, 0, 0,
+ax_anim 10, 0, 182, 0, -2, 0, 0,
+ax_anim 10, 0, 182, 0, -1, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_8_7:
+ax_anim 10, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 184, 0, -1, 0, 0,
+ax_anim 10, 0, 184, 0, -2, 0, 0,
+ax_anim 10, 0, 184, 0, -3, 0, 0,
+ax_anim 10, 0, 183, 0, -3, 0, 0,
+ax_anim 10, 0, 185, 0, -3, 0, 0,
+ax_anim 10, 0, 185, 0, -2, 0, 0,
+ax_anim 10, 0, 185, 0, -1, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_8_8:
+ax_anim 10, 0, 187, 0, 0, 0, 0,
+ax_anim 10, 0, 187, 0, -1, 0, 0,
+ax_anim 10, 0, 187, 0, -2, 0, 0,
+ax_anim 10, 0, 187, 0, -3, 0, 0,
+ax_anim 10, 0, 186, 0, -3, 0, 0,
+ax_anim 10, 0, 188, 0, -3, 0, 0,
+ax_anim 10, 0, 188, 0, -2, 0, 0,
+ax_anim 10, 0, 188, 0, -1, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_9_1:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 7, 4, 7, 4,
+ax_anim 2, 0, 191, 10, 12, 10, 12,
+ax_anim 2, 0, 192, 7, 17, 7, 17,
+ax_anim 3, 0, 193, 0, 19, 0, 19,
+ax_anim 2, 3, 194, -7, 17, -7, 17,
+ax_anim 2, 0, 195, -10, 12, -10, 12,
+ax_anim 1, 0, 196, -7, 4, -7, 4,
+ax_anim 1, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_9_2:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 11, -1, 11, -1,
+ax_anim 2, 0, 190, 19, 3, 19, 3,
+ax_anim 2, 0, 191, 24, 12, 24, 12,
+ax_anim 3, 0, 192, 18, 20, 18, 20,
+ax_anim 2, 3, 193, 10, 20, 10, 20,
+ax_anim 2, 0, 194, 3, 15, 3, 15,
+ax_anim 1, 0, 195, -2, 8, -2, 8,
+ax_anim 1, 0, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_9_3:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 4, -3, 4, -3,
+ax_anim 2, 0, 189, 10, -5, 10, -5,
+ax_anim 2, 0, 190, 16, -2, 16, -2,
+ax_anim 3, 0, 191, 19, 2, 19, 0,
+ax_anim 2, 3, 192, 14, 7, 14, 7,
+ax_anim 2, 0, 193, 8, 7, 8, 7,
+ax_anim 1, 0, 194, 4, 6, 4, 6,
+ax_anim 1, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_9_4:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, -2, -7, -2, -7,
+ax_anim 2, 0, 196, 2, -14, 2, -14,
+ax_anim 2, 0, 189, 11, -20, 11, -20,
+ax_anim 3, 0, 190, 20, -19, 20, -21,
+ax_anim 2, 3, 191, 24, -12, 24, -12,
+ax_anim 2, 0, 192, 20, -3, 20, -3,
+ax_anim 1, 0, 193, 13, 0, 13, 0,
+ax_anim 1, 0, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_9_5:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, -6, -4, -6, -4,
+ax_anim 2, 0, 195, -9, -11, -9, -11,
+ax_anim 2, 0, 196, -6, -17, -6, -17,
+ax_anim 3, 0, 189, 0, -20, 0, -21,
+ax_anim 2, 3, 190, 6, -17, 6, -17,
+ax_anim 2, 0, 191, 9, -11, 9, -11,
+ax_anim 1, 0, 192, 6, -4, 6, -4,
+ax_anim 1, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_9_6:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 2, -7, 2, -7,
+ax_anim 2, 0, 190, -2, -14, -2, -14,
+ax_anim 2, 0, 189, -11, -20, -11, -20,
+ax_anim 3, 0, 196, -20, -19, -20, -21,
+ax_anim 2, 3, 195, -24, -12, -24, -12,
+ax_anim 2, 0, 194, -20, -3, -20, -3,
+ax_anim 1, 0, 193, -13, 0, -13, 0,
+ax_anim 1, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_9_7:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 190, -4, -3, -4, -3,
+ax_anim 2, 0, 189, -10, -5, -10, -5,
+ax_anim 2, 0, 196, -16, -2, -16, -2,
+ax_anim 3, 0, 195, -19, 2, -19, -2,
+ax_anim 2, 3, 194, -14, 7, -14, 7,
+ax_anim 2, 0, 193, -8, 7, -8, 7,
+ax_anim 1, 0, 192, -4, 6, -4, 6,
+ax_anim 1, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_9_8:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 189, -11, -1, -11, -1,
+ax_anim 2, 0, 196, -19, 3, -19, 3,
+ax_anim 2, 0, 195, -24, 12, -24, 12,
+ax_anim 3, 0, 194, -18, 20, -18, 20,
+ax_anim 2, 3, 193, -10, 20, -10, 20,
+ax_anim 2, 0, 192, -3, 15, -3, 15,
+ax_anim 1, 0, 191, 0, 8, 0, 8,
+ax_anim 1, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_10_1:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 6, 0, 6, 0,
+ax_anim 2, 0, 197, -6, 0, -6, 0,
+ax_anim 2, 0, 197, 10, 0, 10, 0,
+ax_anim 2, 0, 197, -10, 0, -10, 0,
+ax_anim 2, 0, 197, 12, 0, 12, 0,
+ax_anim 3, 0, 197, -12, 0, -12, 0,
+ax_anim 3, 0, 197, 13, 0, 13, 0,
+ax_anim 3, 0, 197, -13, 0, -13, 0,
+ax_anim 2, 0, 197, 12, 0, 12, 0,
+ax_anim 3, 0, 197, -12, 0, -12, 0,
+ax_anim 2, 0, 197, 10, 0, 10, 0,
+ax_anim 2, 0, 197, -10, 0, -10, 0,
+ax_anim 2, 0, 197, 6, 0, 6, 0,
+ax_anim 2, 0, 197, -6, 0, -6, 0,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_10_2:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 6, -6, 6, -6,
+ax_anim 2, 0, 198, -6, 6, -6, 6,
+ax_anim 2, 0, 198, 10, -10, 10, -10,
+ax_anim 2, 0, 198, -10, 10, -10, 10,
+ax_anim 2, 0, 198, 12, -12, 12, -12,
+ax_anim 3, 0, 198, -12, 12, -12, 12,
+ax_anim 3, 0, 198, 13, -13, 13, -13,
+ax_anim 3, 0, 198, -13, 13, -13, 13,
+ax_anim 2, 0, 198, 12, -12, 12, -12,
+ax_anim 3, 0, 198, -12, 12, -12, 12,
+ax_anim 2, 0, 198, 10, -10, 10, -10,
+ax_anim 2, 0, 198, -10, 10, -10, 10,
+ax_anim 2, 0, 198, 6, -6, 6, -6,
+ax_anim 2, 0, 198, -6, 6, -6, 6,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_10_3:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, 0, -6, 0, -6,
+ax_anim 2, 0, 199, 0, 6, 0, 6,
+ax_anim 2, 0, 199, 0, -10, 0, -10,
+ax_anim 2, 0, 199, 0, 10, 0, 10,
+ax_anim 2, 0, 199, 0, -12, 0, -12,
+ax_anim 3, 0, 199, 0, 12, 0, 12,
+ax_anim 3, 0, 199, 0, -13, 0, -13,
+ax_anim 3, 0, 199, 0, 13, 0, 13,
+ax_anim 2, 0, 199, 0, -12, 0, -12,
+ax_anim 3, 0, 199, 0, 12, 0, 12,
+ax_anim 2, 0, 199, 0, -10, 0, -10,
+ax_anim 2, 0, 199, 0, 10, 0, 10,
+ax_anim 2, 0, 199, 0, -6, 0, -6,
+ax_anim 2, 0, 199, 0, 6, 0, 6,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_10_4:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, -6, -6, -6, -6,
+ax_anim 2, 0, 200, 6, 6, 6, 6,
+ax_anim 2, 0, 200, -10, -10, -10, -10,
+ax_anim 2, 0, 200, 10, 10, 10, 10,
+ax_anim 2, 0, 200, -12, -12, -12, -12,
+ax_anim 3, 0, 200, 12, 12, 12, 12,
+ax_anim 3, 0, 200, -13, -13, -13, -13,
+ax_anim 3, 0, 200, 13, 13, 13, 13,
+ax_anim 2, 0, 200, -12, -12, -12, -12,
+ax_anim 3, 0, 200, 12, 12, 12, 12,
+ax_anim 2, 0, 200, -10, -10, -10, -10,
+ax_anim 2, 0, 200, 10, 10, 10, 10,
+ax_anim 2, 0, 200, -6, -6, -6, -6,
+ax_anim 2, 0, 200, 6, 6, 6, 6,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_10_5:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 6, 0, 6, 0,
+ax_anim 2, 0, 201, -6, 0, -6, 0,
+ax_anim 2, 0, 201, 10, 0, 10, 0,
+ax_anim 2, 0, 201, -10, 0, -10, 0,
+ax_anim 2, 0, 201, 12, 0, 12, 0,
+ax_anim 3, 0, 201, -12, 0, -12, 0,
+ax_anim 3, 0, 201, 13, 0, 13, 0,
+ax_anim 3, 0, 201, -13, 0, -13, 0,
+ax_anim 2, 0, 201, 12, 0, 12, 0,
+ax_anim 3, 0, 201, -12, 0, -12, 0,
+ax_anim 2, 0, 201, 10, 0, 10, 0,
+ax_anim 2, 0, 201, -10, 0, -10, 0,
+ax_anim 2, 0, 201, 6, 0, 6, 0,
+ax_anim 2, 0, 201, -6, 0, -6, 0,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_10_6:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 6, -6, 6, -6,
+ax_anim 2, 0, 202, -6, 6, -6, 6,
+ax_anim 2, 0, 202, 10, -10, 10, -10,
+ax_anim 2, 0, 202, -10, 10, -10, 10,
+ax_anim 2, 0, 202, 12, -12, 12, -12,
+ax_anim 3, 0, 202, -12, 12, -12, 12,
+ax_anim 3, 0, 202, 13, -13, 13, -13,
+ax_anim 3, 0, 202, -13, 13, -13, 13,
+ax_anim 2, 0, 202, 12, -12, 12, -12,
+ax_anim 3, 0, 202, -12, 12, -12, 12,
+ax_anim 2, 0, 202, 10, -10, 10, -10,
+ax_anim 2, 0, 202, -10, 10, -10, 10,
+ax_anim 2, 0, 202, 6, -6, 6, -6,
+ax_anim 2, 0, 202, -6, 6, -6, 6,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_10_7:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, -6, 0, -6,
+ax_anim 2, 0, 203, 0, 6, 0, 6,
+ax_anim 2, 0, 203, 0, -10, 0, -10,
+ax_anim 2, 0, 203, 0, 10, 0, 10,
+ax_anim 2, 0, 203, 0, -12, 0, -12,
+ax_anim 3, 0, 203, 0, 12, 0, 12,
+ax_anim 3, 0, 203, 0, -13, 0, -13,
+ax_anim 3, 0, 203, 0, 13, 0, 13,
+ax_anim 2, 0, 203, 0, -12, 0, -12,
+ax_anim 3, 0, 203, 0, 12, 0, 12,
+ax_anim 2, 0, 203, 0, -10, 0, -10,
+ax_anim 2, 0, 203, 0, 10, 0, 10,
+ax_anim 2, 0, 203, 0, -6, 0, -6,
+ax_anim 2, 0, 203, 0, 6, 0, 6,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_10_8:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, -6, -6, -6, -6,
+ax_anim 2, 0, 204, 6, 6, 6, 6,
+ax_anim 2, 0, 204, -10, -10, -10, -10,
+ax_anim 2, 0, 204, 10, 10, 10, 10,
+ax_anim 2, 0, 204, -12, -12, -12, -12,
+ax_anim 3, 0, 204, 12, 12, 12, 12,
+ax_anim 3, 0, 204, -13, -13, -13, -13,
+ax_anim 3, 0, 204, 13, 13, 13, 13,
+ax_anim 2, 0, 204, -12, -12, -12, -12,
+ax_anim 3, 0, 204, 12, 12, 12, 12,
+ax_anim 2, 0, 204, -10, -10, -10, -10,
+ax_anim 2, 0, 204, 10, 10, 10, 10,
+ax_anim 2, 0, 204, -6, -6, -6, -6,
+ax_anim 2, 0, 204, 6, 6, 6, 6,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_11_1:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 207, 0, -22, 0, 0,
+ax_anim 2, 0, 207, 0, -18, 0, 0,
+ax_anim 1, 0, 207, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 2, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_11_2:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -24, 0, 0,
+ax_anim 3, 0, 210, 0, -22, 0, 0,
+ax_anim 2, 0, 210, 0, -18, 0, 0,
+ax_anim 1, 0, 210, 0, -12, 0, 0,
+ax_anim 2, 2, 210, 0, 1, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_11_3:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 1, 0, 212, 0, -10, 0, 0,
+ax_anim 2, 0, 212, 0, -16, 0, 0,
+ax_anim 3, 0, 212, 0, -20, 0, 0,
+ax_anim 4, 0, 212, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 213, 0, -22, 0, 0,
+ax_anim 2, 0, 213, 0, -18, 0, 0,
+ax_anim 1, 0, 213, 0, -12, 0, 0,
+ax_anim 2, 2, 213, 0, 3, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_11_4:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 1, 0, 215, 0, -10, 0, 0,
+ax_anim 2, 0, 215, 0, -16, 0, 0,
+ax_anim 3, 0, 215, 0, -20, 0, 0,
+ax_anim 4, 0, 215, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -22, 0, 0,
+ax_anim 3, 0, 216, 0, -21, 0, 0,
+ax_anim 2, 0, 216, 0, -17, 0, 0,
+ax_anim 1, 0, 216, 0, -11, 0, 0,
+ax_anim 2, 2, 216, 0, 5, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_11_5:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 1, 0, 218, 0, -10, 0, 0,
+ax_anim 2, 0, 218, 0, -16, 0, 0,
+ax_anim 3, 0, 218, 0, -20, 0, 0,
+ax_anim 4, 0, 218, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -12, 0, 0,
+ax_anim 2, 2, 219, 0, 7, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_11_6:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 221, 0, -10, 0, 0,
+ax_anim 2, 0, 221, 0, -16, 0, 0,
+ax_anim 3, 0, 221, 0, -20, 0, 0,
+ax_anim 4, 0, 221, 0, -21, 0, 0,
+ax_anim 4, 0, 220, 0, -22, 0, 0,
+ax_anim 3, 0, 222, 0, -21, 0, 0,
+ax_anim 2, 0, 222, 0, -17, 0, 0,
+ax_anim 1, 0, 222, 0, -11, 0, 0,
+ax_anim 2, 2, 222, 0, 5, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_11_7:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 1, 0, 224, 0, -10, 0, 0,
+ax_anim 2, 0, 224, 0, -16, 0, 0,
+ax_anim 3, 0, 224, 0, -20, 0, 0,
+ax_anim 4, 0, 224, 0, -21, 0, 0,
+ax_anim 4, 0, 223, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -12, 0, 0,
+ax_anim 2, 2, 225, 0, 3, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_11_8:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 1, 0, 227, 0, -10, 0, 0,
+ax_anim 2, 0, 227, 0, -16, 0, 0,
+ax_anim 3, 0, 227, 0, -20, 0, 0,
+ax_anim 4, 0, 227, 0, -21, 0, 0,
+ax_anim 4, 0, 226, 0, -24, 0, 0,
+ax_anim 3, 0, 228, 0, -22, 0, 0,
+ax_anim 2, 0, 228, 0, -18, 0, 0,
+ax_anim 1, 0, 228, 0, -12, 0, 0,
+ax_anim 2, 2, 228, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_12_1:
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 1, 0, 1, 0,
+ax_anim 2, 1, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_12_2:
+ax_anim 2, 0, 236, 1, -1, 1, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, -1, 1, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, -1, 1, -1,
+ax_anim 2, 2, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, -1, 1, -1,
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 2, 0, 236, 1, -1, 1, -1,
+ax_anim 2, 1, 236, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_12_3:
+ax_anim 2, 0, 235, 0, -1, 0, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, -1, 0, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, -1, 0, -1,
+ax_anim 2, 2, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, -1, 0, -1,
+ax_anim 2, 0, 235, 0, 0, 0, 0,
+ax_anim 2, 0, 235, 0, -1, 0, -1,
+ax_anim 2, 1, 235, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_12_4:
+ax_anim 2, 0, 234, -1, -1, -1, -1,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, -1, -1, -1,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, -1, -1, -1,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, -1, -1, -1,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, -1, -1, -1, -1,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_12_5:
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 1, 0, 1, 0,
+ax_anim 2, 1, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_12_6:
+ax_anim 2, 0, 232, 1, -1, 1, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 1, -1, 1, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 1, -1, 1, -1,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 1, -1, 1, -1,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 1, -1, 1, -1,
+ax_anim 2, 1, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_12_7:
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, -1, 0, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_12_8:
+ax_anim 2, 0, 230, -1, -1, -1, -1,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, -1, -1, -1,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, -1, -1, -1,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, -1, -1, -1,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 230, -1, -1, -1, -1,
+ax_anim 2, 1, 230, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhiscashAnims_13_1:
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_13_2:
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_13_3:
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_13_4:
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_13_5:
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 2, 241, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_13_6:
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_13_7:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 2, 239, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashAnims_13_8:
+ax_anim 2, 0, 238, 0, 0, 0, 0,
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 241, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 2, 238, 0, 0, 0, 0,
+ax_anim_terminator
+sWhiscashGfx1:
+.incbin "baserom.gba", 0x13E0DE8, 0x200
+sWhiscashSprites1:
+ax_sprite sWhiscashGfx1, 0x200
+ax_sprite_terminator
+sWhiscashGfx2:
+.incbin "baserom.gba", 0x13E0FF8, 0x200
+sWhiscashSprites2:
+ax_sprite sWhiscashGfx2, 0x200
+ax_sprite_terminator
+sWhiscashGfx3:
+.incbin "baserom.gba", 0x13E1208, 0x200
+sWhiscashSprites3:
+ax_sprite sWhiscashGfx3, 0x200
+ax_sprite_terminator
+sWhiscashGfx4:
+.incbin "baserom.gba", 0x13E1418, 0x200
+sWhiscashSprites4:
+ax_sprite sWhiscashGfx4, 0x200
+ax_sprite_terminator
+sWhiscashGfx5:
+.incbin "baserom.gba", 0x13E1628, 0x200
+sWhiscashSprites5:
+ax_sprite sWhiscashGfx5, 0x200
+ax_sprite_terminator
+sWhiscashGfx6:
+.incbin "baserom.gba", 0x13E1838, 0x200
+sWhiscashSprites6:
+ax_sprite sWhiscashGfx6, 0x200
+ax_sprite_terminator
+sWhiscashGfx7:
+.incbin "baserom.gba", 0x13E1A48, 0x200
+sWhiscashSprites7:
+ax_sprite sWhiscashGfx7, 0x200
+ax_sprite_terminator
+sWhiscashGfx8:
+.incbin "baserom.gba", 0x13E1C58, 0x200
+sWhiscashSprites8:
+ax_sprite sWhiscashGfx8, 0x200
+ax_sprite_terminator
+sWhiscashGfx9:
+.incbin "baserom.gba", 0x13E1E68, 0x200
+sWhiscashSprites9:
+ax_sprite sWhiscashGfx9, 0x200
+ax_sprite_terminator
+sWhiscashGfx10:
+.incbin "baserom.gba", 0x13E2078, 0x200
+sWhiscashSprites10:
+ax_sprite sWhiscashGfx10, 0x200
+ax_sprite_terminator
+sWhiscashGfx11:
+.incbin "baserom.gba", 0x13E2288, 0x200
+sWhiscashSprites11:
+ax_sprite sWhiscashGfx11, 0x200
+ax_sprite_terminator
+sWhiscashGfx12:
+.incbin "baserom.gba", 0x13E2498, 0x200
+sWhiscashSprites12:
+ax_sprite sWhiscashGfx12, 0x200
+ax_sprite_terminator
+sWhiscashGfx13:
+.incbin "baserom.gba", 0x13E26A8, 0x200
+sWhiscashSprites13:
+ax_sprite sWhiscashGfx13, 0x200
+ax_sprite_terminator
+sWhiscashGfx14:
+.incbin "baserom.gba", 0x13E28B8, 0x200
+sWhiscashSprites14:
+ax_sprite sWhiscashGfx14, 0x200
+ax_sprite_terminator
+sWhiscashGfx15:
+.incbin "baserom.gba", 0x13E2AC8, 0x200
+sWhiscashSprites15:
+ax_sprite sWhiscashGfx15, 0x200
+ax_sprite_terminator
+sWhiscashGfx16:
+.incbin "baserom.gba", 0x13E2CD8, 0x180
+sWhiscashGfx16_1:
+.incbin "baserom.gba", 0x13E2E58, 0x40
+sWhiscashSprites16:
+ax_sprite sWhiscashGfx16, 0x180
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhiscashGfx17:
+.incbin "baserom.gba", 0x13E2EC0, 0x180
+sWhiscashSprites17:
+ax_sprite sWhiscashGfx17, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWhiscashGfx18:
+.incbin "baserom.gba", 0x13E3058, 0x60
+sWhiscashGfx18_1:
+.incbin "baserom.gba", 0x13E30B8, 0x100
+sWhiscashGfx18_2:
+.incbin "baserom.gba", 0x13E31B8, 0x40
+sWhiscashSprites18:
+ax_sprite sWhiscashGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhiscashGfx19:
+.incbin "baserom.gba", 0x13E3230, 0x160
+sWhiscashSprites19:
+ax_sprite sWhiscashGfx19, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWhiscashGfx20:
+.incbin "baserom.gba", 0x13E33A8, 0x40
+sWhiscashGfx20_1:
+.incbin "baserom.gba", 0x13E33E8, 0x140
+sWhiscashSprites20:
+ax_sprite sWhiscashGfx20, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWhiscashGfx20_1, 0x140
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWhiscashGfx21:
+.incbin "baserom.gba", 0x13E3550, 0x40
+sWhiscashGfx21_1:
+.incbin "baserom.gba", 0x13E3590, 0x160
+sWhiscashSprites21:
+ax_sprite sWhiscashGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWhiscashGfx21_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhiscashGfx22:
+.incbin "baserom.gba", 0x13E3718, 0x160
+sWhiscashGfx22_1:
+.incbin "baserom.gba", 0x13E3878, 0x40
+sWhiscashSprites22:
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx22, 0x160
+ax_sprite 0, 0x40
+ax_sprite sWhiscashGfx22_1, 0x40
+ax_sprite_terminator
+sWhiscashGfx23:
+.incbin "baserom.gba", 0x13E38E0, 0x1E0
+sWhiscashSprites23:
+ax_sprite sWhiscashGfx23, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhiscashGfx24:
+.incbin "baserom.gba", 0x13E3AD8, 0x100
+sWhiscashGfx24_1:
+.incbin "baserom.gba", 0x13E3BD8, 0x40
+sWhiscashSprites24:
+ax_sprite sWhiscashGfx24, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx24_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWhiscashGfx25:
+.incbin "baserom.gba", 0x13E3C40, 0x100
+sWhiscashGfx25_1:
+.incbin "baserom.gba", 0x13E3D40, 0x40
+sWhiscashSprites25:
+ax_sprite sWhiscashGfx25, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx25_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWhiscashGfx26:
+.incbin "baserom.gba", 0x13E3DA8, 0x180
+sWhiscashGfx26_1:
+.incbin "baserom.gba", 0x13E3F28, 0x40
+sWhiscashSprites26:
+ax_sprite sWhiscashGfx26, 0x180
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx26_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhiscashGfx27:
+.incbin "baserom.gba", 0x13E3F90, 0x180
+sWhiscashGfx27_1:
+.incbin "baserom.gba", 0x13E4110, 0x20
+sWhiscashSprites27:
+ax_sprite sWhiscashGfx27, 0x180
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx27_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWhiscashGfx28:
+.incbin "baserom.gba", 0x13E4158, 0x40
+sWhiscashGfx28_1:
+.incbin "baserom.gba", 0x13E4198, 0x160
+sWhiscashSprites28:
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx28_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhiscashGfx29:
+.incbin "baserom.gba", 0x13E4328, 0x60
+sWhiscashGfx29_1:
+.incbin "baserom.gba", 0x13E4388, 0x160
+sWhiscashSprites29:
+ax_sprite sWhiscashGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx29_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhiscashGfx30:
+.incbin "baserom.gba", 0x13E4510, 0x60
+sWhiscashGfx30_1:
+.incbin "baserom.gba", 0x13E4570, 0x100
+sWhiscashSprites30:
+ax_sprite sWhiscashGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWhiscashGfx30_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWhiscashGfx31:
+.incbin "baserom.gba", 0x13E4698, 0x200
+sWhiscashSprites31:
+ax_sprite sWhiscashGfx31, 0x200
+ax_sprite_terminator
+sWhiscashGfx32:
+.incbin "baserom.gba", 0x13E48A8, 0x200
+sWhiscashSprites32:
+ax_sprite sWhiscashGfx32, 0x200
+ax_sprite_terminator
+sWhiscashGfx33:
+.incbin "baserom.gba", 0x13E4AB8, 0x200
+sWhiscashSprites33:
+ax_sprite sWhiscashGfx33, 0x200
+ax_sprite_terminator
+sWhiscashGfx34:
+.incbin "baserom.gba", 0x13E4CC8, 0x200
+sWhiscashSprites34:
+ax_sprite sWhiscashGfx34, 0x200
+ax_sprite_terminator
+sWhiscashGfx35:
+.incbin "baserom.gba", 0x13E4ED8, 0x200
+sWhiscashSprites35:
+ax_sprite sWhiscashGfx35, 0x200
+ax_sprite_terminator
+sWhiscashGfx36:
+.incbin "baserom.gba", 0x13E50E8, 0x200
+sWhiscashSprites36:
+ax_sprite sWhiscashGfx36, 0x200
+ax_sprite_terminator
+sWhiscashGfx37:
+.incbin "baserom.gba", 0x13E52F8, 0x200
+sWhiscashSprites37:
+ax_sprite sWhiscashGfx37, 0x200
+ax_sprite_terminator
+sAxPosesWhiscash:
+.4byte sWhiscashPose1
+.4byte sWhiscashPose2
+.4byte sWhiscashPose3
+.4byte sWhiscashPose4
+.4byte sWhiscashPose5
+.4byte sWhiscashPose6
+.4byte sWhiscashPose7
+.4byte sWhiscashPose8
+.4byte sWhiscashPose9
+.4byte sWhiscashPose10
+.4byte sWhiscashPose11
+.4byte sWhiscashPose12
+.4byte sWhiscashPose13
+.4byte sWhiscashPose14
+.4byte sWhiscashPose15
+.4byte sWhiscashPose16
+.4byte sWhiscashPose17
+.4byte sWhiscashPose18
+.4byte sWhiscashPose19
+.4byte sWhiscashPose20
+.4byte sWhiscashPose21
+.4byte sWhiscashPose22
+.4byte sWhiscashPose23
+.4byte sWhiscashPose24
+.4byte sWhiscashPose25
+.4byte sWhiscashPose26
+.4byte sWhiscashPose27
+.4byte sWhiscashPose28
+.4byte sWhiscashPose29
+.4byte sWhiscashPose30
+.4byte sWhiscashPose31
+.4byte sWhiscashPose32
+.4byte sWhiscashPose33
+.4byte sWhiscashPose34
+.4byte sWhiscashPose35
+.4byte sWhiscashPose36
+.4byte sWhiscashPose37
+.4byte sWhiscashPose38
+.4byte sWhiscashPose39
+.4byte sWhiscashPose40
+.4byte sWhiscashPose41
+.4byte sWhiscashPose42
+.4byte sWhiscashPose43
+.4byte sWhiscashPose44
+.4byte sWhiscashPose45
+.4byte sWhiscashPose46
+.4byte sWhiscashPose47
+.4byte sWhiscashPose48
+.4byte sWhiscashPose49
+.4byte sWhiscashPose50
+.4byte sWhiscashPose51
+.4byte sWhiscashPose52
+.4byte sWhiscashPose53
+.4byte sWhiscashPose54
+.4byte sWhiscashPose55
+.4byte sWhiscashPose56
+.4byte sWhiscashPose57
+.4byte sWhiscashPose58
+.4byte sWhiscashPose59
+.4byte sWhiscashPose60
+.4byte sWhiscashPose61
+.4byte sWhiscashPose62
+.4byte sWhiscashPose63
+.4byte sWhiscashPose64
+.4byte sWhiscashPose65
+.4byte sWhiscashPose66
+.4byte sWhiscashPose67
+.4byte sWhiscashPose68
+.4byte sWhiscashPose69
+.4byte sWhiscashPose70
+.4byte sWhiscashPose71
+.4byte sWhiscashPose72
+.4byte sWhiscashPose73
+.4byte sWhiscashPose74
+.4byte sWhiscashPose75
+.4byte sWhiscashPose76
+.4byte sWhiscashPose77
+.4byte sWhiscashPose78
+.4byte sWhiscashPose79
+.4byte sWhiscashPose80
+.4byte sWhiscashPose81
+.4byte sWhiscashPose82
+.4byte sWhiscashPose83
+.4byte sWhiscashPose84
+.4byte sWhiscashPose85
+.4byte sWhiscashPose86
+.4byte sWhiscashPose87
+.4byte sWhiscashPose88
+.4byte sWhiscashPose89
+.4byte sWhiscashPose90
+.4byte sWhiscashPose91
+.4byte sWhiscashPose92
+.4byte sWhiscashPose93
+.4byte sWhiscashPose94
+.4byte sWhiscashPose95
+.4byte sWhiscashPose96
+.4byte sWhiscashPose97
+.4byte sWhiscashPose98
+.4byte sWhiscashPose99
+.4byte sWhiscashPose100
+.4byte sWhiscashPose101
+.4byte sWhiscashPose102
+.4byte sWhiscashPose103
+.4byte sWhiscashPose104
+.4byte sWhiscashPose105
+.4byte sWhiscashPose106
+.4byte sWhiscashPose107
+.4byte sWhiscashPose108
+.4byte sWhiscashPose109
+.4byte sWhiscashPose110
+.4byte sWhiscashPose111
+.4byte sWhiscashPose112
+.4byte sWhiscashPose113
+.4byte sWhiscashPose114
+.4byte sWhiscashPose115
+.4byte sWhiscashPose116
+.4byte sWhiscashPose117
+.4byte sWhiscashPose118
+.4byte sWhiscashPose119
+.4byte sWhiscashPose120
+.4byte sWhiscashPose121
+.4byte sWhiscashPose122
+.4byte sWhiscashPose123
+.4byte sWhiscashPose124
+.4byte sWhiscashPose125
+.4byte sWhiscashPose126
+.4byte sWhiscashPose127
+.4byte sWhiscashPose128
+.4byte sWhiscashPose129
+.4byte sWhiscashPose130
+.4byte sWhiscashPose131
+.4byte sWhiscashPose132
+.4byte sWhiscashPose133
+.4byte sWhiscashPose134
+.4byte sWhiscashPose135
+.4byte sWhiscashPose136
+.4byte sWhiscashPose137
+.4byte sWhiscashPose138
+.4byte sWhiscashPose139
+.4byte sWhiscashPose140
+.4byte sWhiscashPose141
+.4byte sWhiscashPose142
+.4byte sWhiscashPose143
+.4byte sWhiscashPose144
+.4byte sWhiscashPose145
+.4byte sWhiscashPose146
+.4byte sWhiscashPose147
+.4byte sWhiscashPose148
+.4byte sWhiscashPose149
+.4byte sWhiscashPose150
+.4byte sWhiscashPose151
+.4byte sWhiscashPose152
+.4byte sWhiscashPose153
+.4byte sWhiscashPose154
+.4byte sWhiscashPose155
+.4byte sWhiscashPose156
+.4byte sWhiscashPose157
+.4byte sWhiscashPose158
+.4byte sWhiscashPose159
+.4byte sWhiscashPose160
+.4byte sWhiscashPose161
+.4byte sWhiscashPose162
+.4byte sWhiscashPose163
+.4byte sWhiscashPose164
+.4byte sWhiscashPose165
+.4byte sWhiscashPose166
+.4byte sWhiscashPose167
+.4byte sWhiscashPose168
+.4byte sWhiscashPose169
+.4byte sWhiscashPose170
+.4byte sWhiscashPose171
+.4byte sWhiscashPose172
+.4byte sWhiscashPose173
+.4byte sWhiscashPose174
+.4byte sWhiscashPose175
+.4byte sWhiscashPose176
+.4byte sWhiscashPose177
+.4byte sWhiscashPose178
+.4byte sWhiscashPose179
+.4byte sWhiscashPose180
+.4byte sWhiscashPose181
+.4byte sWhiscashPose182
+.4byte sWhiscashPose183
+.4byte sWhiscashPose184
+.4byte sWhiscashPose185
+.4byte sWhiscashPose186
+.4byte sWhiscashPose187
+.4byte sWhiscashPose188
+.4byte sWhiscashPose189
+.4byte sWhiscashPose190
+.4byte sWhiscashPose191
+.4byte sWhiscashPose192
+.4byte sWhiscashPose193
+.4byte sWhiscashPose194
+.4byte sWhiscashPose195
+.4byte sWhiscashPose196
+.4byte sWhiscashPose197
+.4byte sWhiscashPose198
+.4byte sWhiscashPose199
+.4byte sWhiscashPose200
+.4byte sWhiscashPose201
+.4byte sWhiscashPose202
+.4byte sWhiscashPose203
+.4byte sWhiscashPose204
+.4byte sWhiscashPose205
+.4byte sWhiscashPose206
+.4byte sWhiscashPose207
+.4byte sWhiscashPose208
+.4byte sWhiscashPose209
+.4byte sWhiscashPose210
+.4byte sWhiscashPose211
+.4byte sWhiscashPose212
+.4byte sWhiscashPose213
+.4byte sWhiscashPose214
+.4byte sWhiscashPose215
+.4byte sWhiscashPose216
+.4byte sWhiscashPose217
+.4byte sWhiscashPose218
+.4byte sWhiscashPose219
+.4byte sWhiscashPose220
+.4byte sWhiscashPose221
+.4byte sWhiscashPose222
+.4byte sWhiscashPose223
+.4byte sWhiscashPose224
+.4byte sWhiscashPose225
+.4byte sWhiscashPose226
+.4byte sWhiscashPose227
+.4byte sWhiscashPose228
+.4byte sWhiscashPose229
+.4byte sWhiscashPose230
+.4byte sWhiscashPose231
+.4byte sWhiscashPose232
+.4byte sWhiscashPose233
+.4byte sWhiscashPose234
+.4byte sWhiscashPose235
+.4byte sWhiscashPose236
+.4byte sWhiscashPose237
+.4byte sWhiscashPose238
+.4byte sWhiscashPose239
+.4byte sWhiscashPose240
+.4byte sWhiscashPose241
+.4byte sWhiscashPose242
+.4byte sWhiscashPose243
+.4byte sWhiscashPose244
+.4byte sWhiscashPose245
+sAxPositionsWhiscash:
+.2byte   -1,   -4, 	 -11,   -4, 	   9,   -4, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -2, 	   9,   -2, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -5, 	   9,   -5, 	  -1,  -10
+.2byte    7,   -6, 	   8,   -8, 	  -6,   -2, 	   1,  -11
+.2byte    8,   -6, 	   8,   -8, 	  -5,    0, 	   0,  -12
+.2byte    8,   -6, 	   7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte   10,  -10, 	   2,  -14, 	   0,   -2, 	   1,  -12
+.2byte   10,  -10, 	   2,  -14, 	   1,    0, 	   1,  -11
+.2byte   10,  -10, 	   2,  -15, 	   0,   -3, 	   1,  -11
+.2byte    7,  -17, 	  -3,  -16, 	  10,   -8, 	   1,  -14
+.2byte    7,  -17, 	  -3,  -16, 	   9,   -6, 	   1,  -14
+.2byte    7,  -16, 	  -1,  -16, 	  10,   -9, 	   1,  -13
+.2byte   -1,  -19, 	   9,  -12, 	 -11,  -11, 	  -1,  -14
+.2byte   -1,  -19, 	   9,  -11, 	 -10,  -11, 	  -1,  -15
+.2byte   -1,  -18, 	  10,  -13, 	 -12,  -13, 	  -1,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -12,   -8, 	  -3,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -11,   -6, 	  -3,  -14
+.2byte   -9,  -16, 	  -1,  -16, 	 -12,   -9, 	  -3,  -13
+.2byte  -12,  -10, 	  -4,  -14, 	  -2,   -2, 	  -3,  -12
+.2byte  -12,  -10, 	  -4,  -14, 	  -3,    0, 	  -3,  -11
+.2byte  -12,  -10, 	  -4,  -15, 	  -2,   -3, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,   -8, 	   4,   -2, 	  -3,  -11
+.2byte  -10,   -6, 	 -10,   -8, 	   3,    0, 	  -2,  -12
+.2byte  -10,   -6, 	  -9,   -9, 	   4,   -3, 	  -3,  -12
+.2byte   -1,   -4, 	 -11,   -4, 	   9,   -4, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -2, 	   9,   -2, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -5, 	   9,   -5, 	  -1,  -10
+.2byte   -1,    1, 	 -12,   -2, 	  10,   -2, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -7, 	  10,   -7, 	  -1,  -11
+.2byte    7,   -6, 	   8,   -8, 	  -6,   -2, 	   1,  -11
+.2byte    8,   -6, 	   8,   -8, 	  -5,    0, 	   0,  -12
+.2byte    8,   -6, 	   7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte    8,   -4, 	   8,   -7, 	  -5,    0, 	   1,  -10
+.2byte    5,  -11, 	   7,  -10, 	  -6,   -4, 	   0,  -12
+.2byte   10,  -10, 	   2,  -14, 	   0,   -2, 	   1,  -12
+.2byte   10,  -10, 	   2,  -14, 	   1,    0, 	   1,  -11
+.2byte   10,  -10, 	   2,  -15, 	   0,   -3, 	   1,  -11
+.2byte   10,   -9, 	   0,  -14, 	   0,   -4, 	   1,  -12
+.2byte   10,  -13, 	   2,  -13, 	   3,   -3, 	   0,  -11
+.2byte    7,  -17, 	  -3,  -16, 	  10,   -8, 	   1,  -14
+.2byte    7,  -17, 	  -3,  -16, 	   9,   -6, 	   1,  -14
+.2byte    7,  -16, 	  -1,  -16, 	  10,   -9, 	   1,  -13
+.2byte    6,  -17, 	  -3,  -15, 	   9,   -6, 	   1,  -14
+.2byte    8,  -19, 	  -1,  -15, 	  10,   -6, 	   2,  -14
+.2byte   -1,  -19, 	   9,  -12, 	 -11,  -11, 	  -1,  -14
+.2byte   -1,  -19, 	   9,  -11, 	 -10,  -11, 	  -1,  -15
+.2byte   -1,  -18, 	  10,  -13, 	 -12,  -13, 	  -1,  -14
+.2byte   -1,  -20, 	   9,  -13, 	 -11,  -13, 	  -1,  -16
+.2byte   -1,  -21, 	   9,  -14, 	 -11,  -14, 	  -1,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -12,   -8, 	  -3,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -11,   -6, 	  -3,  -14
+.2byte   -9,  -16, 	  -1,  -16, 	 -12,   -9, 	  -3,  -13
+.2byte   -8,  -17, 	   1,  -15, 	 -11,   -6, 	  -3,  -14
+.2byte  -10,  -19, 	  -1,  -15, 	 -12,   -6, 	  -4,  -14
+.2byte  -12,  -10, 	  -4,  -14, 	  -2,   -2, 	  -3,  -12
+.2byte  -12,  -10, 	  -4,  -14, 	  -3,    0, 	  -3,  -11
+.2byte  -12,  -10, 	  -4,  -15, 	  -2,   -3, 	  -3,  -11
+.2byte  -12,   -9, 	  -2,  -14, 	  -2,   -4, 	  -3,  -12
+.2byte  -12,  -13, 	  -4,  -13, 	  -5,   -3, 	  -2,  -11
+.2byte   -9,   -6, 	 -10,   -8, 	   4,   -2, 	  -3,  -11
+.2byte  -10,   -6, 	 -10,   -8, 	   3,    0, 	  -2,  -12
+.2byte  -10,   -6, 	  -9,   -9, 	   4,   -3, 	  -3,  -12
+.2byte  -10,   -4, 	 -10,   -7, 	   3,    0, 	  -3,  -10
+.2byte   -7,  -11, 	  -9,  -10, 	   4,   -4, 	  -2,  -12
+.2byte   -1,   -4, 	 -11,   -4, 	   9,   -4, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -2, 	   9,   -2, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -5, 	   9,   -5, 	  -1,  -10
+.2byte   -1,    1, 	 -12,   -2, 	  10,   -2, 	  -1,   -8
+.2byte   -1,   -8, 	 -12,   -7, 	  10,   -7, 	  -1,  -11
+.2byte    7,   -6, 	   8,   -8, 	  -6,   -2, 	   1,  -11
+.2byte    8,   -6, 	   8,   -8, 	  -5,    0, 	   0,  -12
+.2byte    8,   -6, 	   7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte    8,   -4, 	   8,   -7, 	  -5,    0, 	   1,  -10
+.2byte    5,  -11, 	   7,  -10, 	  -6,   -4, 	   0,  -12
+.2byte   10,  -10, 	   2,  -14, 	   0,   -2, 	   1,  -12
+.2byte   10,  -10, 	   2,  -14, 	   1,    0, 	   1,  -11
+.2byte   10,  -10, 	   2,  -15, 	   0,   -3, 	   1,  -11
+.2byte   10,   -9, 	   0,  -14, 	   0,   -4, 	   1,  -12
+.2byte   10,  -13, 	   2,  -13, 	   3,   -3, 	   0,  -11
+.2byte    7,  -17, 	  -3,  -16, 	  10,   -8, 	   1,  -14
+.2byte    7,  -17, 	  -3,  -16, 	   9,   -6, 	   1,  -14
+.2byte    7,  -16, 	  -1,  -16, 	  10,   -9, 	   1,  -13
+.2byte    6,  -17, 	  -3,  -15, 	   9,   -6, 	   1,  -14
+.2byte    8,  -19, 	  -1,  -15, 	  10,   -6, 	   2,  -14
+.2byte   -1,  -19, 	   9,  -12, 	 -11,  -11, 	  -1,  -14
+.2byte   -1,  -19, 	   9,  -11, 	 -10,  -11, 	  -1,  -15
+.2byte   -1,  -18, 	  10,  -13, 	 -12,  -13, 	  -1,  -14
+.2byte   -1,  -20, 	   9,  -13, 	 -11,  -13, 	  -1,  -16
+.2byte   -1,  -21, 	   9,  -14, 	 -11,  -14, 	  -1,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -12,   -8, 	  -3,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -11,   -6, 	  -3,  -14
+.2byte   -9,  -16, 	  -1,  -16, 	 -12,   -9, 	  -3,  -13
+.2byte   -8,  -17, 	   1,  -15, 	 -11,   -6, 	  -3,  -14
+.2byte  -10,  -19, 	  -1,  -15, 	 -12,   -6, 	  -4,  -14
+.2byte  -12,  -10, 	  -4,  -14, 	  -2,   -2, 	  -3,  -12
+.2byte  -12,  -10, 	  -4,  -14, 	  -3,    0, 	  -3,  -11
+.2byte  -12,  -10, 	  -4,  -15, 	  -2,   -3, 	  -3,  -11
+.2byte  -12,   -9, 	  -2,  -14, 	  -2,   -4, 	  -3,  -12
+.2byte  -12,  -13, 	  -4,  -13, 	  -5,   -3, 	  -2,  -11
+.2byte   -9,   -6, 	 -10,   -8, 	   4,   -2, 	  -3,  -11
+.2byte  -10,   -6, 	 -10,   -8, 	   3,    0, 	  -2,  -12
+.2byte  -10,   -6, 	  -9,   -9, 	   4,   -3, 	  -3,  -12
+.2byte  -10,   -4, 	 -10,   -7, 	   3,    0, 	  -3,  -10
+.2byte   -7,  -11, 	  -9,  -10, 	   4,   -4, 	  -2,  -12
+.2byte   -1,   -4, 	 -11,   -5, 	   9,   -5, 	  -1,  -10
+.2byte   -1,   -2, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte   -1,   -4, 	 -12,   -5, 	  10,   -5, 	  -1,   -8
+.2byte    8,   -6, 	   7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte    8,   -4, 	   8,   -7, 	  -5,    0, 	   1,  -10
+.2byte    5,   -7, 	   6,   -9, 	  -6,   -3, 	   0,  -11
+.2byte   10,  -10, 	   2,  -15, 	   0,   -3, 	   1,  -11
+.2byte   11,   -9, 	   1,  -14, 	   1,   -4, 	   2,  -12
+.2byte    9,   -9, 	   2,  -13, 	   2,   -2, 	   2,  -11
+.2byte    7,  -16, 	  -1,  -16, 	  10,   -9, 	   1,  -13
+.2byte    6,  -17, 	  -3,  -15, 	   9,   -6, 	   1,  -14
+.2byte    8,  -19, 	  -1,  -16, 	   9,   -6, 	   2,  -14
+.2byte    8,  -19, 	  -1,  -15, 	  10,   -6, 	   2,  -14
+.2byte   -1,  -18, 	  10,  -13, 	 -12,  -13, 	  -1,  -14
+.2byte   -1,  -20, 	   9,  -13, 	 -11,  -13, 	  -1,  -16
+.2byte   -1,  -21, 	   9,  -14, 	 -11,  -14, 	  -1,  -14
+.2byte   -1,  -21, 	   9,  -14, 	 -11,  -14, 	  -1,  -14
+.2byte   -9,  -16, 	  -1,  -16, 	 -12,   -9, 	  -3,  -13
+.2byte   -8,  -17, 	   1,  -15, 	 -11,   -6, 	  -3,  -14
+.2byte  -10,  -19, 	  -1,  -16, 	 -11,   -6, 	  -4,  -14
+.2byte  -12,  -10, 	  -4,  -15, 	  -2,   -3, 	  -3,  -11
+.2byte  -13,   -9, 	  -3,  -14, 	  -3,   -4, 	  -4,  -12
+.2byte  -11,   -9, 	  -4,  -13, 	  -4,   -2, 	  -4,  -11
+.2byte  -13,  -13, 	  -5,  -13, 	  -6,   -3, 	  -3,  -11
+.2byte  -10,   -6, 	  -9,   -9, 	   4,   -3, 	  -3,  -12
+.2byte  -10,   -4, 	 -10,   -7, 	   3,    0, 	  -3,  -10
+.2byte   -7,   -7, 	  -8,   -9, 	   4,   -3, 	  -2,  -11
+.2byte   -1,   -4, 	 -11,   -2, 	   9,   -2, 	  -1,  -10
+.2byte   -1,    1, 	 -12,   -2, 	  10,   -2, 	  -1,   -8
+.2byte   -1,   -6, 	 -12,   -5, 	  10,   -5, 	  -1,   -9
+.2byte    8,   -6, 	   8,   -8, 	  -5,    0, 	   0,  -12
+.2byte    8,   -4, 	   8,   -7, 	  -5,    0, 	   1,  -10
+.2byte    5,  -11, 	   7,  -10, 	  -6,   -4, 	   0,  -12
+.2byte   10,  -10, 	   2,  -14, 	   1,    0, 	   1,  -11
+.2byte   11,   -7, 	   1,  -12, 	   1,   -2, 	   2,  -10
+.2byte   11,  -11, 	   3,  -11, 	   4,   -1, 	   1,   -9
+.2byte    7,  -17, 	  -3,  -16, 	   9,   -6, 	   1,  -14
+.2byte    5,  -15, 	  -4,  -13, 	   8,   -4, 	   0,  -12
+.2byte    6,  -17, 	  -3,  -13, 	   8,   -4, 	   0,  -12
+.2byte   -1,  -19, 	   9,  -11, 	 -10,  -11, 	  -1,  -15
+.2byte   -1,  -20, 	   9,  -13, 	 -11,  -13, 	  -1,  -16
+.2byte   -1,  -21, 	   9,  -14, 	 -11,  -14, 	  -1,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -11,   -6, 	  -3,  -14
+.2byte   -7,  -15, 	   2,  -13, 	 -10,   -4, 	  -2,  -12
+.2byte   -8,  -17, 	   1,  -13, 	 -10,   -4, 	  -2,  -12
+.2byte  -12,  -10, 	  -4,  -14, 	  -3,    0, 	  -3,  -11
+.2byte  -13,   -7, 	  -3,  -12, 	  -3,   -2, 	  -4,  -10
+.2byte  -13,  -11, 	  -5,  -11, 	  -6,   -1, 	  -3,   -9
+.2byte  -10,   -6, 	 -10,   -8, 	   3,    0, 	  -2,  -12
+.2byte  -10,   -4, 	 -10,   -7, 	   3,    0, 	  -3,  -10
+.2byte   -7,  -11, 	  -9,  -10, 	   4,   -4, 	  -2,  -12
+.2byte   -8,   -7, 	  -7,   -9, 	   5,   -1, 	   0,  -11
+.2byte   -8,   -7, 	  -6,   -9, 	   6,   -2, 	   1,  -11
+.2byte   -1,   -5, 	 -11,   -8, 	   9,   -8, 	   0,  -11
+.2byte    6,   -7, 	   7,  -10, 	  -8,   -6, 	   0,  -12
+.2byte    9,  -10, 	   0,  -14, 	  -3,   -3, 	  -1,  -11
+.2byte    5,  -16, 	  -4,  -14, 	   6,   -5, 	   1,  -12
+.2byte   -1,  -18, 	   8,   -9, 	 -10,   -9, 	  -1,  -13
+.2byte   -6,  -16, 	   3,  -14, 	  -7,   -5, 	  -2,  -12
+.2byte  -10,  -10, 	  -1,  -14, 	   2,   -3, 	   0,  -11
+.2byte   -7,   -7, 	  -8,  -10, 	   7,   -6, 	  -1,  -12
+.2byte   -1,   -4, 	 -11,   -4, 	   9,   -4, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -2, 	   9,   -2, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -5, 	   9,   -5, 	  -1,  -10
+.2byte    7,   -6, 	   8,   -8, 	  -6,   -2, 	   1,  -11
+.2byte    8,   -6, 	   8,   -8, 	  -5,    0, 	   0,  -12
+.2byte    8,   -6, 	   7,   -9, 	  -6,   -3, 	   1,  -12
+.2byte   10,  -10, 	   2,  -14, 	   0,   -2, 	   1,  -12
+.2byte   10,  -10, 	   2,  -14, 	   1,    0, 	   1,  -11
+.2byte   10,  -10, 	   2,  -15, 	   0,   -3, 	   1,  -11
+.2byte    7,  -17, 	  -3,  -16, 	  10,   -8, 	   1,  -14
+.2byte    7,  -17, 	  -3,  -16, 	   9,   -6, 	   1,  -14
+.2byte    7,  -16, 	  -1,  -16, 	  10,   -9, 	   1,  -13
+.2byte   -1,  -19, 	   9,  -12, 	 -11,  -11, 	  -1,  -14
+.2byte   -1,  -19, 	   9,  -11, 	 -10,  -11, 	  -1,  -15
+.2byte   -1,  -18, 	  10,  -13, 	 -12,  -13, 	  -1,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -12,   -8, 	  -3,  -14
+.2byte   -9,  -17, 	   1,  -16, 	 -11,   -6, 	  -3,  -14
+.2byte   -9,  -16, 	  -1,  -16, 	 -12,   -9, 	  -3,  -13
+.2byte  -12,  -10, 	  -4,  -14, 	  -2,   -2, 	  -3,  -12
+.2byte  -12,  -10, 	  -4,  -14, 	  -3,    0, 	  -3,  -11
+.2byte  -12,  -10, 	  -4,  -15, 	  -2,   -3, 	  -3,  -11
+.2byte   -9,   -6, 	 -10,   -8, 	   4,   -2, 	  -3,  -11
+.2byte  -10,   -6, 	 -10,   -8, 	   3,    0, 	  -2,  -12
+.2byte  -10,   -6, 	  -9,   -9, 	   4,   -3, 	  -3,  -12
+.2byte   -1,   -6, 	 -12,   -5, 	  10,   -5, 	  -1,   -9
+.2byte   -5,   -9, 	  -7,   -8, 	   6,   -2, 	   0,  -10
+.2byte  -10,  -10, 	  -2,  -10, 	  -3,    0, 	   0,   -8
+.2byte   -6,  -15, 	   3,  -11, 	  -8,   -2, 	   0,  -10
+.2byte   -1,  -16, 	   9,   -9, 	 -11,   -9, 	  -1,   -9
+.2byte    5,  -15, 	  -4,  -11, 	   7,   -2, 	  -1,  -10
+.2byte    9,  -10, 	   1,  -10, 	   2,    0, 	  -1,   -8
+.2byte    4,   -9, 	   6,   -8, 	  -7,   -2, 	  -1,  -10
+.2byte   -1,   -4, 	 -12,   -5, 	  10,   -5, 	  -1,   -8
+.2byte    5,   -6, 	   6,   -8, 	  -6,   -2, 	   0,  -10
+.2byte    7,   -9, 	   0,  -13, 	   0,   -2, 	   0,  -11
+.2byte    6,  -17, 	  -3,  -14, 	   7,   -4, 	   0,  -12
+.2byte   -1,  -19, 	   9,  -12, 	 -11,  -12, 	  -1,  -12
+.2byte   -7,  -17, 	   2,  -14, 	  -8,   -4, 	  -1,  -12
+.2byte   -9,   -9, 	  -2,  -13, 	  -2,   -2, 	  -2,  -11
+.2byte   -6,   -6, 	  -7,   -8, 	   5,   -2, 	  -1,  -10
+.2byte   -1,   -4, 	 -11,   -5, 	   9,   -5, 	  -1,  -10
+.2byte   -1,   -4, 	 -12,   -5, 	  10,   -5, 	  -1,   -8
+.2byte   -1,   -2, 	 -12,   -5, 	  10,   -5, 	  -1,  -11
+.2byte    9,   -5, 	   8,   -8, 	  -5,   -2, 	   2,  -11
+.2byte    6,   -7, 	   7,   -9, 	  -5,   -3, 	   1,  -11
+.2byte    8,   -3, 	   8,   -6, 	  -5,    1, 	   1,   -9
+.2byte    9,  -10, 	   1,  -15, 	  -1,   -3, 	   0,  -11
+.2byte    7,   -9, 	   0,  -13, 	   0,   -2, 	   0,  -11
+.2byte    9,   -8, 	  -1,  -13, 	  -1,   -3, 	   0,  -11
+.2byte    6,  -15, 	  -2,  -15, 	   9,   -8, 	   0,  -12
+.2byte    6,  -18, 	  -3,  -15, 	   7,   -5, 	   0,  -13
+.2byte    5,  -16, 	  -4,  -14, 	   8,   -5, 	   0,  -13
+.2byte   -1,  -18, 	  10,  -13, 	 -12,  -13, 	  -1,  -14
+.2byte   -1,  -19, 	   9,  -12, 	 -11,  -12, 	  -1,  -12
+.2byte   -1,  -18, 	   9,  -11, 	 -11,  -11, 	  -1,  -14
+.2byte   -7,  -15, 	   1,  -15, 	 -10,   -8, 	  -1,  -12
+.2byte   -7,  -18, 	   2,  -15, 	  -8,   -5, 	  -1,  -13
+.2byte   -6,  -16, 	   3,  -14, 	  -9,   -5, 	  -1,  -13
+.2byte  -10,  -10, 	  -2,  -15, 	   0,   -3, 	  -1,  -11
+.2byte   -8,   -9, 	  -1,  -13, 	  -1,   -2, 	  -1,  -11
+.2byte  -10,   -8, 	   0,  -13, 	   0,   -3, 	  -1,  -11
+.2byte  -10,   -5, 	  -9,   -8, 	   4,   -2, 	  -3,  -11
+.2byte   -6,   -7, 	  -7,   -9, 	   5,   -3, 	  -1,  -11
+.2byte   -9,   -3, 	  -9,   -6, 	   4,    1, 	  -2,   -9
+.2byte   -1,   -6, 	 -12,   -5, 	  10,   -5, 	  -1,   -9
+.2byte   -6,   -8, 	  -8,   -7, 	   5,   -1, 	  -1,   -9
+.2byte  -11,  -10, 	  -3,  -10, 	  -4,    0, 	  -1,   -8
+.2byte   -7,  -15, 	   2,  -11, 	  -9,   -2, 	  -1,  -10
+.2byte   -1,  -17, 	   9,  -10, 	 -11,  -10, 	  -1,  -10
+.2byte    6,  -15, 	  -3,  -11, 	   8,   -2, 	   0,  -10
+.2byte   10,  -10, 	   2,  -10, 	   3,    0, 	   0,   -8
+.2byte    5,   -8, 	   7,   -7, 	  -6,   -1, 	   0,   -9
+.2byte   -1,   -4, 	 -11,   -4, 	   9,   -4, 	  -1,  -10
+.2byte  -10,   -6, 	 -11,   -8, 	   3,   -2, 	  -4,  -11
+.2byte  -13,  -10, 	  -5,  -14, 	  -3,   -2, 	  -4,  -12
+.2byte  -10,  -18, 	   0,  -17, 	 -13,   -9, 	  -4,  -15
+.2byte   -1,  -20, 	   9,  -13, 	 -11,  -12, 	  -1,  -15
+.2byte    8,  -18, 	  -2,  -17, 	  11,   -9, 	   2,  -15
+.2byte   11,  -10, 	   3,  -14, 	   1,   -2, 	   2,  -12
+.2byte    8,   -6, 	   9,   -8, 	  -5,   -2, 	   2,  -11
+sWhiscashAnimTable1:
+.4byte sWhiscashAnims_1_1
+.4byte sWhiscashAnims_1_2
+.4byte sWhiscashAnims_1_3
+.4byte sWhiscashAnims_1_4
+.4byte sWhiscashAnims_1_5
+.4byte sWhiscashAnims_1_6
+.4byte sWhiscashAnims_1_7
+.4byte sWhiscashAnims_1_8
+sWhiscashAnimTable2:
+.4byte sWhiscashAnims_2_1
+.4byte sWhiscashAnims_2_2
+.4byte sWhiscashAnims_2_3
+.4byte sWhiscashAnims_2_4
+.4byte sWhiscashAnims_2_5
+.4byte sWhiscashAnims_2_6
+.4byte sWhiscashAnims_2_7
+.4byte sWhiscashAnims_2_8
+sWhiscashAnimTable3:
+.4byte sWhiscashAnims_3_1
+.4byte sWhiscashAnims_3_2
+.4byte sWhiscashAnims_3_3
+.4byte sWhiscashAnims_3_4
+.4byte sWhiscashAnims_3_5
+.4byte sWhiscashAnims_3_6
+.4byte sWhiscashAnims_3_7
+.4byte sWhiscashAnims_3_8
+sWhiscashAnimTable4:
+.4byte sWhiscashAnims_4_1
+.4byte sWhiscashAnims_4_2
+.4byte sWhiscashAnims_4_3
+.4byte sWhiscashAnims_4_4
+.4byte sWhiscashAnims_4_5
+.4byte sWhiscashAnims_4_6
+.4byte sWhiscashAnims_4_7
+.4byte sWhiscashAnims_4_8
+sWhiscashAnimTable5:
+.4byte sWhiscashAnims_5_1
+.4byte sWhiscashAnims_5_2
+.4byte sWhiscashAnims_5_3
+.4byte sWhiscashAnims_5_4
+.4byte sWhiscashAnims_5_5
+.4byte sWhiscashAnims_5_6
+.4byte sWhiscashAnims_5_7
+.4byte sWhiscashAnims_5_8
+sWhiscashAnimTable6:
+.4byte sWhiscashAnims_6_1
+.4byte sWhiscashAnims_6_1
+.4byte sWhiscashAnims_6_1
+.4byte sWhiscashAnims_6_1
+.4byte sWhiscashAnims_6_1
+.4byte sWhiscashAnims_6_1
+.4byte sWhiscashAnims_6_1
+.4byte sWhiscashAnims_6_1
+sWhiscashAnimTable7:
+.4byte sWhiscashAnims_7_1
+.4byte sWhiscashAnims_7_2
+.4byte sWhiscashAnims_7_3
+.4byte sWhiscashAnims_7_4
+.4byte sWhiscashAnims_7_5
+.4byte sWhiscashAnims_7_6
+.4byte sWhiscashAnims_7_7
+.4byte sWhiscashAnims_7_8
+sWhiscashAnimTable8:
+.4byte sWhiscashAnims_8_1
+.4byte sWhiscashAnims_8_2
+.4byte sWhiscashAnims_8_3
+.4byte sWhiscashAnims_8_4
+.4byte sWhiscashAnims_8_5
+.4byte sWhiscashAnims_8_6
+.4byte sWhiscashAnims_8_7
+.4byte sWhiscashAnims_8_8
+sWhiscashAnimTable9:
+.4byte sWhiscashAnims_9_1
+.4byte sWhiscashAnims_9_2
+.4byte sWhiscashAnims_9_3
+.4byte sWhiscashAnims_9_4
+.4byte sWhiscashAnims_9_5
+.4byte sWhiscashAnims_9_6
+.4byte sWhiscashAnims_9_7
+.4byte sWhiscashAnims_9_8
+sWhiscashAnimTable10:
+.4byte sWhiscashAnims_10_1
+.4byte sWhiscashAnims_10_2
+.4byte sWhiscashAnims_10_3
+.4byte sWhiscashAnims_10_4
+.4byte sWhiscashAnims_10_5
+.4byte sWhiscashAnims_10_6
+.4byte sWhiscashAnims_10_7
+.4byte sWhiscashAnims_10_8
+sWhiscashAnimTable11:
+.4byte sWhiscashAnims_11_1
+.4byte sWhiscashAnims_11_2
+.4byte sWhiscashAnims_11_3
+.4byte sWhiscashAnims_11_4
+.4byte sWhiscashAnims_11_5
+.4byte sWhiscashAnims_11_6
+.4byte sWhiscashAnims_11_7
+.4byte sWhiscashAnims_11_8
+sWhiscashAnimTable12:
+.4byte sWhiscashAnims_12_1
+.4byte sWhiscashAnims_12_2
+.4byte sWhiscashAnims_12_3
+.4byte sWhiscashAnims_12_4
+.4byte sWhiscashAnims_12_5
+.4byte sWhiscashAnims_12_6
+.4byte sWhiscashAnims_12_7
+.4byte sWhiscashAnims_12_8
+sWhiscashAnimTable13:
+.4byte sWhiscashAnims_13_1
+.4byte sWhiscashAnims_13_2
+.4byte sWhiscashAnims_13_3
+.4byte sWhiscashAnims_13_4
+.4byte sWhiscashAnims_13_5
+.4byte sWhiscashAnims_13_6
+.4byte sWhiscashAnims_13_7
+.4byte sWhiscashAnims_13_8
+sAxAnimationsWhiscash:
+.4byte sWhiscashAnimTable1
+.4byte sWhiscashAnimTable2
+.4byte sWhiscashAnimTable3
+.4byte sWhiscashAnimTable4
+.4byte sWhiscashAnimTable5
+.4byte sWhiscashAnimTable6
+.4byte sWhiscashAnimTable7
+.4byte sWhiscashAnimTable8
+.4byte sWhiscashAnimTable9
+.4byte sWhiscashAnimTable10
+.4byte sWhiscashAnimTable11
+.4byte sWhiscashAnimTable12
+.4byte sWhiscashAnimTable13
+sAxSpritesWhiscash:
+.4byte sWhiscashSprites1
+.4byte sWhiscashSprites2
+.4byte sWhiscashSprites3
+.4byte sWhiscashSprites4
+.4byte sWhiscashSprites5
+.4byte sWhiscashSprites6
+.4byte sWhiscashSprites7
+.4byte sWhiscashSprites8
+.4byte sWhiscashSprites9
+.4byte sWhiscashSprites10
+.4byte sWhiscashSprites11
+.4byte sWhiscashSprites12
+.4byte sWhiscashSprites13
+.4byte sWhiscashSprites14
+.4byte sWhiscashSprites15
+.4byte sWhiscashSprites16
+.4byte sWhiscashSprites17
+.4byte sWhiscashSprites18
+.4byte sWhiscashSprites19
+.4byte sWhiscashSprites20
+.4byte sWhiscashSprites21
+.4byte sWhiscashSprites22
+.4byte sWhiscashSprites23
+.4byte sWhiscashSprites24
+.4byte sWhiscashSprites25
+.4byte sWhiscashSprites26
+.4byte sWhiscashSprites27
+.4byte sWhiscashSprites28
+.4byte sWhiscashSprites29
+.4byte sWhiscashSprites30
+.4byte sWhiscashSprites31
+.4byte sWhiscashSprites32
+.4byte sWhiscashSprites33
+.4byte sWhiscashSprites34
+.4byte sWhiscashSprites35
+.4byte sWhiscashSprites36
+.4byte sWhiscashSprites37
+sAxMainWhiscash:
+ax_main sAxPosesWhiscash, sAxAnimationsWhiscash, 13, sAxSpritesWhiscash, sAxPositionsWhiscash

--- a/data/ax/whismur.inc
+++ b/data/ax/whismur.inc
@@ -1,0 +1,2403 @@
+.global gAxWhismur
+gAxWhismur:
+ax_siro sAxMainWhismur
+sWhismurPose1:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose2:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose3:
+ax_pose 2, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose4:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose5:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose6:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose7:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose8:
+ax_pose 7, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose9:
+ax_pose 8, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose10:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose11:
+ax_pose 10, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose12:
+ax_pose 11, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose13:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose14:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose15:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose16:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose17:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose18:
+ax_pose 17, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose19:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose20:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose21:
+ax_pose 20, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose22:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose23:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose24:
+ax_pose 23, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose25:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose26:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose27:
+ax_pose 2, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose28:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose29:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose30:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose31:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose32:
+ax_pose 7, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose33:
+ax_pose 8, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose34:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose35:
+ax_pose 10, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose36:
+ax_pose 11, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose37:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose38:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose39:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose40:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose41:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose42:
+ax_pose 17, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose43:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose44:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose45:
+ax_pose 20, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose46:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose47:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose48:
+ax_pose 23, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose49:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose50:
+ax_pose 1, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose51:
+ax_pose 2, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose52:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose53:
+ax_pose 4, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose54:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose55:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose56:
+ax_pose 7, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose57:
+ax_pose 8, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose58:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose59:
+ax_pose 10, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose60:
+ax_pose 11, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose61:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose62:
+ax_pose 13, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose63:
+ax_pose 14, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose64:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose65:
+ax_pose 16, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose66:
+ax_pose 17, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose67:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose68:
+ax_pose 19, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose69:
+ax_pose 20, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose70:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose71:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose72:
+ax_pose 23, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose73:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose74:
+ax_pose 24, 0x81eb, 0x80f4, 0x4c00
+ax_pose 25, 0x81eb, 0x4104, 0x4c08
+ax_pose_terminator
+sWhismurPose75:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose76:
+ax_pose 26, 0x81e4, 0x90f9, 0x4c00
+ax_pose 27, 0x81ec, 0x10f1, 0x4c08
+ax_pose_terminator
+sWhismurPose77:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose78:
+ax_pose 28, 0x81e6, 0x90f9, 0x4c00
+ax_pose_terminator
+sWhismurPose79:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose80:
+ax_pose 29, 0x81e8, 0x90f8, 0x4c00
+ax_pose 30, 0x81e8, 0x10f0, 0x4c08
+ax_pose_terminator
+sWhismurPose81:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose82:
+ax_pose 31, 0x41ed, 0x80f6, 0x4c00
+ax_pose 32, 0x41fd, 0x00f6, 0x4c08
+ax_pose_terminator
+sWhismurPose83:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose84:
+ax_pose 29, 0x81e8, 0x80f9, 0x4c00
+ax_pose 30, 0x81e8, 0x0109, 0x4c08
+ax_pose_terminator
+sWhismurPose85:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose86:
+ax_pose 28, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose87:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose88:
+ax_pose 26, 0x81e4, 0x80f8, 0x4c00
+ax_pose 27, 0x81ec, 0x0108, 0x4c08
+ax_pose_terminator
+sWhismurPose89:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose90:
+ax_pose 22, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose91:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose92:
+ax_pose 17, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose93:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose94:
+ax_pose 10, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose95:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose96:
+ax_pose 5, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose97:
+ax_pose 33, 0x01ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sWhismurPose98:
+ax_pose 34, 0x01ec, 0x80f6, 0x4c00
+ax_pose_terminator
+sWhismurPose99:
+ax_pose 35, 0x01e3, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose100:
+ax_pose 36, 0x01e5, 0x90e8, 0x4c00
+ax_pose_terminator
+sWhismurPose101:
+ax_pose 37, 0x01e7, 0x90e8, 0x4c00
+ax_pose_terminator
+sWhismurPose102:
+ax_pose 38, 0x01ea, 0x90e7, 0x4c00
+ax_pose_terminator
+sWhismurPose103:
+ax_pose 39, 0x01ea, 0x80f1, 0x4c00
+ax_pose_terminator
+sWhismurPose104:
+ax_pose 38, 0x01ea, 0x80f9, 0x4c00
+ax_pose_terminator
+sWhismurPose105:
+ax_pose 37, 0x01e7, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose106:
+ax_pose 36, 0x01e5, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose107:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose108:
+ax_pose 24, 0x81eb, 0x80f4, 0x4c00
+ax_pose 25, 0x81eb, 0x4104, 0x4c08
+ax_pose_terminator
+sWhismurPose109:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose110:
+ax_pose 26, 0x81e4, 0x90f9, 0x4c00
+ax_pose 27, 0x81ec, 0x10f1, 0x4c08
+ax_pose_terminator
+sWhismurPose111:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose112:
+ax_pose 28, 0x81e6, 0x90f9, 0x4c00
+ax_pose_terminator
+sWhismurPose113:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose114:
+ax_pose 29, 0x81e8, 0x90f8, 0x4c00
+ax_pose 30, 0x81e8, 0x10f0, 0x4c08
+ax_pose_terminator
+sWhismurPose115:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose116:
+ax_pose 31, 0x41ed, 0x80f6, 0x4c00
+ax_pose 32, 0x41fd, 0x00f6, 0x4c08
+ax_pose_terminator
+sWhismurPose117:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose118:
+ax_pose 29, 0x81e8, 0x80f9, 0x4c00
+ax_pose 30, 0x81e8, 0x0109, 0x4c08
+ax_pose_terminator
+sWhismurPose119:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose120:
+ax_pose 28, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose121:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose122:
+ax_pose 26, 0x81e4, 0x80f8, 0x4c00
+ax_pose 27, 0x81ec, 0x0108, 0x4c08
+ax_pose_terminator
+sWhismurPose123:
+ax_pose 24, 0x81eb, 0x80f4, 0x4c00
+ax_pose 25, 0x81eb, 0x4104, 0x4c08
+ax_pose_terminator
+sWhismurPose124:
+ax_pose 26, 0x81e4, 0x80f8, 0x4c00
+ax_pose 27, 0x81ec, 0x0108, 0x4c08
+ax_pose_terminator
+sWhismurPose125:
+ax_pose 28, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose126:
+ax_pose 29, 0x81e8, 0x80f9, 0x4c00
+ax_pose 30, 0x81e8, 0x0109, 0x4c08
+ax_pose_terminator
+sWhismurPose127:
+ax_pose 31, 0x41ed, 0x80f6, 0x4c00
+ax_pose 32, 0x41fd, 0x00f6, 0x4c08
+ax_pose_terminator
+sWhismurPose128:
+ax_pose 29, 0x81e8, 0x90f8, 0x4c00
+ax_pose 30, 0x81e8, 0x10f0, 0x4c08
+ax_pose_terminator
+sWhismurPose129:
+ax_pose 28, 0x81e6, 0x90f9, 0x4c00
+ax_pose_terminator
+sWhismurPose130:
+ax_pose 26, 0x81e4, 0x90f9, 0x4c00
+ax_pose 27, 0x81ec, 0x10f1, 0x4c08
+ax_pose_terminator
+sWhismurPose131:
+ax_pose 24, 0x81eb, 0x80f4, 0x4c00
+ax_pose 25, 0x81eb, 0x4104, 0x4c08
+ax_pose_terminator
+sWhismurPose132:
+ax_pose 26, 0x81e4, 0x90f9, 0x4c00
+ax_pose 27, 0x81ec, 0x10f1, 0x4c08
+ax_pose_terminator
+sWhismurPose133:
+ax_pose 28, 0x81e6, 0x90f9, 0x4c00
+ax_pose_terminator
+sWhismurPose134:
+ax_pose 29, 0x81e8, 0x90f8, 0x4c00
+ax_pose 30, 0x81e8, 0x10f0, 0x4c08
+ax_pose_terminator
+sWhismurPose135:
+ax_pose 31, 0x41ed, 0x80f6, 0x4c00
+ax_pose 32, 0x41fd, 0x00f6, 0x4c08
+ax_pose_terminator
+sWhismurPose136:
+ax_pose 29, 0x81e8, 0x80f9, 0x4c00
+ax_pose 30, 0x81e8, 0x0109, 0x4c08
+ax_pose_terminator
+sWhismurPose137:
+ax_pose 28, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose138:
+ax_pose 26, 0x81e4, 0x80f8, 0x4c00
+ax_pose 27, 0x81ec, 0x0108, 0x4c08
+ax_pose_terminator
+sWhismurPose139:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose140:
+ax_pose 24, 0x81eb, 0x80f4, 0x4c00
+ax_pose 25, 0x81eb, 0x4104, 0x4c08
+ax_pose_terminator
+sWhismurPose141:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose142:
+ax_pose 26, 0x81e4, 0x90f9, 0x4c00
+ax_pose 27, 0x81ec, 0x10f1, 0x4c08
+ax_pose_terminator
+sWhismurPose143:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose144:
+ax_pose 28, 0x81e6, 0x90f9, 0x4c00
+ax_pose_terminator
+sWhismurPose145:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose146:
+ax_pose 29, 0x81e8, 0x90f8, 0x4c00
+ax_pose 30, 0x81e8, 0x10f0, 0x4c08
+ax_pose_terminator
+sWhismurPose147:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose148:
+ax_pose 31, 0x41ed, 0x80f6, 0x4c00
+ax_pose 32, 0x41fd, 0x00f6, 0x4c08
+ax_pose_terminator
+sWhismurPose149:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose150:
+ax_pose 29, 0x81e8, 0x80f9, 0x4c00
+ax_pose 30, 0x81e8, 0x0109, 0x4c08
+ax_pose_terminator
+sWhismurPose151:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose152:
+ax_pose 28, 0x81e6, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose153:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose154:
+ax_pose 26, 0x81e4, 0x80f8, 0x4c00
+ax_pose 27, 0x81ec, 0x0108, 0x4c08
+ax_pose_terminator
+sWhismurPose155:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose156:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose157:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose158:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose159:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose160:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose161:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose162:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose163:
+ax_pose 0, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose164:
+ax_pose 21, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose165:
+ax_pose 18, 0x01eb, 0x80f0, 0x4c00
+ax_pose_terminator
+sWhismurPose166:
+ax_pose 15, 0x01eb, 0x80f3, 0x4c00
+ax_pose_terminator
+sWhismurPose167:
+ax_pose 12, 0x01eb, 0x80f4, 0x4c00
+ax_pose_terminator
+sWhismurPose168:
+ax_pose 9, 0x01eb, 0x80f5, 0x4c00
+ax_pose_terminator
+sWhismurPose169:
+ax_pose 6, 0x81ec, 0x80f8, 0x4c00
+ax_pose_terminator
+sWhismurPose170:
+ax_pose 3, 0x01ec, 0x80f4, 0x4c00
+ax_pose_terminator
+.align 2
+sWhismurAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 8, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 8, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 8, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 8, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 8, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 8, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 8, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 8, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 1, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 25, 0, 19, 0, 19,
+ax_anim 2, 0, 25, 1, 19, 1, 19,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWhismurAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 12, 12, 12, 12,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 1, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 28, 20, 19, 20, 19,
+ax_anim 2, 0, 28, 21, 18, 21, 18,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sWhismurAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sWhismurAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 12, -15, 12, -15,
+ax_anim 2, 0, 34, 20, -23, 20, -23,
+ax_anim 2, 1, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 34, 20, -23, 20, -23,
+ax_anim 2, 0, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 33, 7, -8, 7, -8,
+ax_anim_terminator
+sWhismurAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 1, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 37, 0, -23, 0, -23,
+ax_anim 2, 0, 37, 1, -23, 1, -23,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sWhismurAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -12, -15, -12, -15,
+ax_anim 2, 0, 40, -20, -23, -20, -23,
+ax_anim 2, 1, 40, -21, -22, -21, -22,
+ax_anim 2, 0, 40, -20, -23, -20, -23,
+ax_anim 2, 0, 40, -21, -22, -21, -22,
+ax_anim 2, 0, 39, -7, -8, -7, -8,
+ax_anim_terminator
+sWhismurAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sWhismurAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -12, 12, -12, 12,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 1, 46, -21, 18, -21, 18,
+ax_anim 2, 0, 46, -20, 19, -20, 19,
+ax_anim 2, 0, 46, -21, 18, -21, 18,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sWhismurAnims_3_1:
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 1, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 49, 0, 19, 0, 19,
+ax_anim 2, 0, 49, 1, 19, 1, 19,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sWhismurAnims_3_2:
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 53, 0, 0, 0, 0,
+ax_anim 1, 2, 52, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 12, 12, 12, 12,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 1, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 52, 20, 19, 20, 19,
+ax_anim 2, 0, 52, 21, 18, 21, 18,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sWhismurAnims_3_3:
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 56, 0, 0, 0, 0,
+ax_anim 1, 2, 55, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 1, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 55, 20, 0, 20, 0,
+ax_anim 2, 0, 55, 20, 1, 20, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sWhismurAnims_3_4:
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 59, 0, -1, 0, -1,
+ax_anim 1, 2, 58, 4, -6, 4, -6,
+ax_anim 1, 0, 59, 12, -15, 12, -15,
+ax_anim 2, 0, 58, 20, -23, 20, -23,
+ax_anim 2, 1, 58, 21, -22, 21, -22,
+ax_anim 2, 0, 58, 20, -23, 20, -23,
+ax_anim 2, 0, 58, 21, -22, 21, -22,
+ax_anim 2, 0, 57, 7, -8, 7, -8,
+ax_anim_terminator
+sWhismurAnims_3_5:
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -11, 0, -11,
+ax_anim 2, 0, 61, 0, -23, 0, -23,
+ax_anim 2, 1, 61, 1, -23, 1, -23,
+ax_anim 2, 0, 61, 0, -23, 0, -23,
+ax_anim 2, 0, 61, 1, -23, 1, -23,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sWhismurAnims_3_6:
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 65, 0, -1, 0, -1,
+ax_anim 1, 2, 64, -4, -6, -4, -6,
+ax_anim 1, 0, 65, -12, -15, -12, -15,
+ax_anim 2, 0, 64, -20, -23, -20, -23,
+ax_anim 2, 1, 64, -21, -22, -21, -22,
+ax_anim 2, 0, 64, -20, -23, -20, -23,
+ax_anim 2, 0, 64, -21, -22, -21, -22,
+ax_anim 2, 0, 63, -7, -8, -7, -8,
+ax_anim_terminator
+sWhismurAnims_3_7:
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 68, 0, 0, 0, 0,
+ax_anim 1, 2, 67, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -10, 0, -10, 0,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 1, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 67, -20, 0, -20, 0,
+ax_anim 2, 0, 67, -20, 1, -20, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sWhismurAnims_3_8:
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 71, 0, 0, 0, 0,
+ax_anim 1, 2, 70, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -12, 12, -12, 12,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 1, 70, -21, 18, -21, 18,
+ax_anim 2, 0, 70, -20, 19, -20, 19,
+ax_anim 2, 0, 70, -21, 18, -21, 18,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sWhismurAnims_4_1:
+ax_anim 1, 0, 73, 0, 0, 0, 0,
+ax_anim 1, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 2, 73, 0, -4, 0, 0,
+ax_anim 4, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, -1, -5, -1, 0,
+ax_anim 2, 1, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, -1, -5, -1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, -1, -5, -1, 0,
+ax_anim 2, 0, 73, 0, -5, 0, 0,
+ax_anim 2, 0, 73, -1, -5, -1, 0,
+ax_anim 1, 0, 73, 0, -4, 0, 0,
+ax_anim 1, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_4_2:
+ax_anim 1, 0, 75, 0, 0, 0, 0,
+ax_anim 1, 0, 75, 0, -2, 0, 0,
+ax_anim 2, 2, 75, 0, -4, 0, 0,
+ax_anim 4, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, -1, -4, -1, 1,
+ax_anim 2, 1, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, -1, -4, -1, 1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, -1, -4, -1, 1,
+ax_anim 2, 0, 75, 0, -5, 0, 0,
+ax_anim 2, 0, 75, -1, -4, -1, 1,
+ax_anim 1, 0, 75, 0, -4, 0, 0,
+ax_anim 1, 0, 74, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_4_3:
+ax_anim 1, 0, 77, 0, 0, 0, 0,
+ax_anim 1, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 2, 77, 0, -4, 0, 0,
+ax_anim 4, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 1, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 2, 0, 77, 0, -5, 0, 0,
+ax_anim 2, 0, 77, 0, -6, 0, -1,
+ax_anim 1, 0, 77, 0, -4, 0, 0,
+ax_anim 1, 0, 76, 0, -2, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_4_4:
+ax_anim 1, 0, 79, 0, 0, 0, 0,
+ax_anim 1, 0, 79, 0, -2, 0, 0,
+ax_anim 2, 2, 79, 0, -4, 0, 0,
+ax_anim 4, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 1, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 2, 0, 79, 0, -5, 0, 0,
+ax_anim 2, 0, 79, -1, -6, -1, -1,
+ax_anim 1, 0, 79, 0, -4, 0, 0,
+ax_anim 1, 0, 78, 0, -2, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_4_5:
+ax_anim 1, 0, 81, 0, 0, 0, 0,
+ax_anim 1, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 2, 81, 0, -4, 0, 0,
+ax_anim 4, 0, 81, 0, -5, 0, 0,
+ax_anim 2, 0, 81, -1, -5, -1, 0,
+ax_anim 2, 1, 81, 0, -5, 0, 0,
+ax_anim 2, 0, 81, -1, -5, -1, 0,
+ax_anim 2, 0, 81, 0, -5, 0, 0,
+ax_anim 2, 0, 81, -1, -5, -1, 0,
+ax_anim 2, 0, 81, 0, -5, 0, 0,
+ax_anim 2, 0, 81, -1, -5, -1, 0,
+ax_anim 1, 0, 81, 0, -4, 0, 0,
+ax_anim 1, 0, 80, 0, -2, 0, 0,
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_4_6:
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 0, 83, 0, -2, 0, 0,
+ax_anim 2, 2, 83, 0, -4, 0, 0,
+ax_anim 4, 0, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 1, -6, 1, -1,
+ax_anim 2, 1, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 1, -6, 1, -1,
+ax_anim 2, 0, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 1, -6, 1, -1,
+ax_anim 2, 0, 83, 0, -5, 0, 0,
+ax_anim 2, 0, 83, 1, -6, 1, -1,
+ax_anim 1, 0, 83, 0, -4, 0, 0,
+ax_anim 1, 0, 82, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_4_7:
+ax_anim 1, 0, 85, 0, 0, 0, 0,
+ax_anim 1, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 2, 85, 0, -4, 0, 0,
+ax_anim 4, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, -1,
+ax_anim 2, 1, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, -1,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, -1,
+ax_anim 2, 0, 85, 0, -5, 0, 0,
+ax_anim 2, 0, 85, 0, -6, 0, -1,
+ax_anim 1, 0, 85, 0, -4, 0, 0,
+ax_anim 1, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_4_8:
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 0, 87, 0, -2, 0, 0,
+ax_anim 2, 2, 87, 0, -4, 0, 0,
+ax_anim 4, 0, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 1, -4, 1, 1,
+ax_anim 2, 1, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 1, -4, 1, 1,
+ax_anim 2, 0, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 1, -4, 1, 1,
+ax_anim 2, 0, 87, 0, -5, 0, 0,
+ax_anim 2, 0, 87, 1, -4, 1, 1,
+ax_anim 1, 0, 87, 0, -4, 0, 0,
+ax_anim 1, 0, 86, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_5_1:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 2, 94, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_5_2:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 2, 93, 0, -5, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_5_3:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 2, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_5_4:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 2, 91, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_5_5:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 2, 90, 0, -5, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_5_6:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -5, 0, 0,
+ax_anim 2, 2, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_5_7:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 2, 0, 91, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 2, 2, 88, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_5_8:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 2, 0, 94, 0, -5, 0, 0,
+ax_anim 2, 2, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_6_1:
+ax_anim 30, 0, 96, 0, 0, 0, 0,
+ax_anim 35, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sWhismurAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sWhismurAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sWhismurAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sWhismurAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sWhismurAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sWhismurAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sWhismurAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWhismurAnims_8_1:
+ax_anim 40, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 0, -2, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 4, 0, 107, 0, -4, 0, 0,
+ax_anim 2, 0, 107, 0, -3, 0, 0,
+ax_anim 1, 0, 107, 0, -1, 0, 0,
+ax_anim_terminator
+sWhismurAnims_8_2:
+ax_anim 40, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, -2, 0, 0,
+ax_anim 1, 0, 109, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, -4, 0, 0,
+ax_anim 2, 0, 109, 0, -3, 0, 0,
+ax_anim 1, 0, 109, 0, -1, 0, 0,
+ax_anim_terminator
+sWhismurAnims_8_3:
+ax_anim 40, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 1, 0, 111, 0, -3, 0, 0,
+ax_anim 4, 0, 111, 0, -4, 0, 0,
+ax_anim 2, 0, 111, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -1, 0, 0,
+ax_anim_terminator
+sWhismurAnims_8_4:
+ax_anim 40, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 0, -2, 0, 0,
+ax_anim 1, 0, 113, 0, -3, 0, 0,
+ax_anim 4, 0, 113, 0, -4, 0, 0,
+ax_anim 2, 0, 113, 0, -3, 0, 0,
+ax_anim 1, 0, 113, 0, -1, 0, 0,
+ax_anim_terminator
+sWhismurAnims_8_5:
+ax_anim 40, 0, 114, 0, 0, 0, 0,
+ax_anim 1, 0, 115, 0, -2, 0, 0,
+ax_anim 1, 0, 115, 0, -3, 0, 0,
+ax_anim 4, 0, 115, 0, -4, 0, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 1, 0, 115, 0, -1, 0, 0,
+ax_anim_terminator
+sWhismurAnims_8_6:
+ax_anim 40, 0, 116, 0, 0, 0, 0,
+ax_anim 1, 0, 117, 0, -2, 0, 0,
+ax_anim 1, 0, 117, 0, -3, 0, 0,
+ax_anim 4, 0, 117, 0, -4, 0, 0,
+ax_anim 2, 0, 117, 0, -3, 0, 0,
+ax_anim 1, 0, 117, 0, -1, 0, 0,
+ax_anim_terminator
+sWhismurAnims_8_7:
+ax_anim 40, 0, 118, 0, 0, 0, 0,
+ax_anim 1, 0, 119, 0, -2, 0, 0,
+ax_anim 1, 0, 119, 0, -3, 0, 0,
+ax_anim 4, 0, 119, 0, -4, 0, 0,
+ax_anim 2, 0, 119, 0, -3, 0, 0,
+ax_anim 1, 0, 119, 0, -1, 0, 0,
+ax_anim_terminator
+sWhismurAnims_8_8:
+ax_anim 40, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 121, 0, -2, 0, 0,
+ax_anim 1, 0, 121, 0, -3, 0, 0,
+ax_anim 4, 0, 121, 0, -4, 0, 0,
+ax_anim 2, 0, 121, 0, -3, 0, 0,
+ax_anim 1, 0, 121, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 6, 3, 6, 3,
+ax_anim 2, 0, 124, 10, 9, 10, 9,
+ax_anim 2, 0, 125, 7, 18, 7, 18,
+ax_anim 3, 0, 126, 0, 21, 0, 21,
+ax_anim 2, 3, 127, -7, 18, -7, 18,
+ax_anim 2, 0, 128, -10, 9, -10, 9,
+ax_anim 1, 0, 129, -6, 3, -6, 3,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 8, 0, 8, 0,
+ax_anim 2, 0, 123, 17, 3, 17, 3,
+ax_anim 2, 0, 124, 22, 10, 22, 10,
+ax_anim 3, 0, 125, 21, 20, 21, 20,
+ax_anim 2, 3, 126, 11, 21, 11, 21,
+ax_anim 2, 0, 127, 3, 15, 3, 15,
+ax_anim 1, 0, 128, 0, 7, 0, 7,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 3, -5, 3, -5,
+ax_anim 2, 0, 122, 11, -8, 11, -8,
+ax_anim 2, 0, 123, 18, -5, 18, -5,
+ax_anim 3, 0, 124, 22, -2, 22, -2,
+ax_anim 2, 3, 125, 18, 4, 18, 4,
+ax_anim 2, 0, 126, 12, 5, 12, 5,
+ax_anim 1, 0, 127, 4, 5, 4, 5,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, -1, -8, -1, -8,
+ax_anim 2, 0, 129, 4, -16, 4, -16,
+ax_anim 2, 0, 122, 12, -20, 12, -20,
+ax_anim 3, 0, 123, 19, -18, 19, -18,
+ax_anim 2, 3, 124, 21, -12, 21, -12,
+ax_anim 2, 0, 125, 17, -4, 17, -4,
+ax_anim 1, 0, 126, 8, 0, 8, 0,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -8, -4, -8, -4,
+ax_anim 2, 0, 128, -9, -12, -9, -12,
+ax_anim 2, 0, 129, -7, -18, -7, -18,
+ax_anim 3, 0, 122, 0, -20, 0, -22,
+ax_anim 2, 3, 123, 7, -18, 7, -18,
+ax_anim 2, 0, 124, 9, -10, 9, -10,
+ax_anim 1, 0, 125, 8, -4, 8, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 1, -8, 1, -8,
+ax_anim 2, 0, 123, -4, -16, -4, -16,
+ax_anim 2, 0, 122, -12, -20, -12, -20,
+ax_anim 3, 0, 129, -19, -18, -19, -18,
+ax_anim 2, 3, 128, -21, -12, -21, -12,
+ax_anim 2, 0, 127, -17, -4, -17, -4,
+ax_anim 1, 0, 126, -8, 0, -8, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -3, -5, -3, -5,
+ax_anim 2, 0, 122, -11, -8, -11, -8,
+ax_anim 2, 0, 129, -18, -5, -18, -5,
+ax_anim 3, 0, 128, -22, -2, -22, -2,
+ax_anim 2, 3, 127, -18, 4, -18, 4,
+ax_anim 2, 0, 126, -12, 5, -12, 5,
+ax_anim 1, 0, 125, -4, 5, -4, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -8, 0, -8, 0,
+ax_anim 2, 0, 129, -17, 3, -17, 3,
+ax_anim 2, 0, 128, -22, 10, -22, 10,
+ax_anim 3, 0, 127, -21, 20, -21, 20,
+ax_anim 2, 3, 126, -11, 21, -11, 21,
+ax_anim 2, 0, 125, -3, 15, -3, 15,
+ax_anim 1, 0, 124, 0, 7, 0, 7,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -22, 0, 0,
+ax_anim 3, 0, 138, 0, -21, 0, 0,
+ax_anim 2, 0, 138, 0, -18, 0, 0,
+ax_anim 1, 0, 138, 0, -12, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_11_2:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 1, 0, 141, 0, -10, 0, 0,
+ax_anim 2, 0, 141, 0, -16, 0, 0,
+ax_anim 3, 0, 141, 0, -20, 0, 0,
+ax_anim 4, 0, 141, 0, -21, 0, 0,
+ax_anim 4, 0, 140, 0, -22, 0, 0,
+ax_anim 3, 0, 140, 0, -21, 0, 0,
+ax_anim 2, 0, 140, 0, -18, 0, 0,
+ax_anim 1, 0, 140, 0, -12, 0, 0,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_11_3:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 1, 0, 143, 0, -10, 0, 0,
+ax_anim 2, 0, 143, 0, -16, 0, 0,
+ax_anim 3, 0, 143, 0, -20, 0, 0,
+ax_anim 4, 0, 143, 0, -21, 0, 0,
+ax_anim 4, 0, 142, 0, -23, 0, 0,
+ax_anim 3, 0, 142, 0, -22, 0, 0,
+ax_anim 2, 0, 142, 0, -18, 0, 0,
+ax_anim 1, 0, 142, 0, -12, 0, 0,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_11_4:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -22, 0, 0,
+ax_anim 3, 0, 144, 0, -21, 0, 0,
+ax_anim 2, 0, 144, 0, -17, 0, 0,
+ax_anim 1, 0, 144, 0, -11, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_11_5:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -23, 0, 0,
+ax_anim 3, 0, 146, 0, -22, 0, 0,
+ax_anim 2, 0, 146, 0, -18, 0, 0,
+ax_anim 1, 0, 146, 0, -12, 0, 0,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_11_6:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 1, 0, 149, 0, -10, 0, 0,
+ax_anim 2, 0, 149, 0, -16, 0, 0,
+ax_anim 3, 0, 149, 0, -20, 0, 0,
+ax_anim 4, 0, 149, 0, -21, 0, 0,
+ax_anim 4, 0, 148, 0, -22, 0, 0,
+ax_anim 3, 0, 148, 0, -21, 0, 0,
+ax_anim 2, 0, 148, 0, -17, 0, 0,
+ax_anim 1, 0, 148, 0, -11, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_11_7:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -23, 0, 0,
+ax_anim 3, 0, 150, 0, -22, 0, 0,
+ax_anim 2, 0, 150, 0, -18, 0, 0,
+ax_anim 1, 0, 150, 0, -12, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_11_8:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -22, 0, 0,
+ax_anim 3, 0, 152, 0, -21, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -12, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_12_1:
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 1, 0, 1, 0,
+ax_anim 2, 1, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_12_2:
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 2, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 161, 1, -1, 1, -1,
+ax_anim 2, 1, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_12_3:
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 2, 0, 160, 0, -1, 0, -1,
+ax_anim 2, 1, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_12_4:
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 2, 0, 159, -1, -1, -1, -1,
+ax_anim 2, 1, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_12_5:
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 2, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 158, 1, 0, 1, 0,
+ax_anim 2, 1, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_12_6:
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 2, 0, 157, 1, -1, 1, -1,
+ax_anim 2, 1, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_12_7:
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 2, 0, 156, 0, -1, 0, -1,
+ax_anim 2, 1, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_12_8:
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 2, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 155, -1, -1, -1, -1,
+ax_anim 2, 1, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWhismurAnims_13_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_13_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_13_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_13_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_13_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_13_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_13_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurAnims_13_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sWhismurGfx1:
+.incbin "baserom.gba", 0x11ED3D8, 0x200
+sWhismurSprites1:
+ax_sprite sWhismurGfx1, 0x200
+ax_sprite_terminator
+sWhismurGfx2:
+.incbin "baserom.gba", 0x11ED5E8, 0x200
+sWhismurSprites2:
+ax_sprite sWhismurGfx2, 0x200
+ax_sprite_terminator
+sWhismurGfx3:
+.incbin "baserom.gba", 0x11ED7F8, 0x200
+sWhismurSprites3:
+ax_sprite sWhismurGfx3, 0x200
+ax_sprite_terminator
+sWhismurGfx4:
+.incbin "baserom.gba", 0x11EDA08, 0x200
+sWhismurSprites4:
+ax_sprite sWhismurGfx4, 0x200
+ax_sprite_terminator
+sWhismurGfx5:
+.incbin "baserom.gba", 0x11EDC18, 0x200
+sWhismurSprites5:
+ax_sprite sWhismurGfx5, 0x200
+ax_sprite_terminator
+sWhismurGfx6:
+.incbin "baserom.gba", 0x11EDE28, 0x200
+sWhismurSprites6:
+ax_sprite sWhismurGfx6, 0x200
+ax_sprite_terminator
+sWhismurGfx7:
+.incbin "baserom.gba", 0x11EE038, 0x100
+sWhismurSprites7:
+ax_sprite sWhismurGfx7, 0x100
+ax_sprite_terminator
+sWhismurGfx8:
+.incbin "baserom.gba", 0x11EE148, 0x100
+sWhismurSprites8:
+ax_sprite sWhismurGfx8, 0x100
+ax_sprite_terminator
+sWhismurGfx9:
+.incbin "baserom.gba", 0x11EE258, 0x100
+sWhismurSprites9:
+ax_sprite sWhismurGfx9, 0x100
+ax_sprite_terminator
+sWhismurGfx10:
+.incbin "baserom.gba", 0x11EE368, 0x200
+sWhismurSprites10:
+ax_sprite sWhismurGfx10, 0x200
+ax_sprite_terminator
+sWhismurGfx11:
+.incbin "baserom.gba", 0x11EE578, 0x200
+sWhismurSprites11:
+ax_sprite sWhismurGfx11, 0x200
+ax_sprite_terminator
+sWhismurGfx12:
+.incbin "baserom.gba", 0x11EE788, 0x200
+sWhismurSprites12:
+ax_sprite sWhismurGfx12, 0x200
+ax_sprite_terminator
+sWhismurGfx13:
+.incbin "baserom.gba", 0x11EE998, 0x200
+sWhismurSprites13:
+ax_sprite sWhismurGfx13, 0x200
+ax_sprite_terminator
+sWhismurGfx14:
+.incbin "baserom.gba", 0x11EEBA8, 0x200
+sWhismurSprites14:
+ax_sprite sWhismurGfx14, 0x200
+ax_sprite_terminator
+sWhismurGfx15:
+.incbin "baserom.gba", 0x11EEDB8, 0x200
+sWhismurSprites15:
+ax_sprite sWhismurGfx15, 0x200
+ax_sprite_terminator
+sWhismurGfx16:
+.incbin "baserom.gba", 0x11EEFC8, 0x200
+sWhismurSprites16:
+ax_sprite sWhismurGfx16, 0x200
+ax_sprite_terminator
+sWhismurGfx17:
+.incbin "baserom.gba", 0x11EF1D8, 0x200
+sWhismurSprites17:
+ax_sprite sWhismurGfx17, 0x200
+ax_sprite_terminator
+sWhismurGfx18:
+.incbin "baserom.gba", 0x11EF3E8, 0x200
+sWhismurSprites18:
+ax_sprite sWhismurGfx18, 0x200
+ax_sprite_terminator
+sWhismurGfx19:
+.incbin "baserom.gba", 0x11EF5F8, 0x200
+sWhismurSprites19:
+ax_sprite sWhismurGfx19, 0x200
+ax_sprite_terminator
+sWhismurGfx20:
+.incbin "baserom.gba", 0x11EF808, 0x200
+sWhismurSprites20:
+ax_sprite sWhismurGfx20, 0x200
+ax_sprite_terminator
+sWhismurGfx21:
+.incbin "baserom.gba", 0x11EFA18, 0x200
+sWhismurSprites21:
+ax_sprite sWhismurGfx21, 0x200
+ax_sprite_terminator
+sWhismurGfx22:
+.incbin "baserom.gba", 0x11EFC28, 0x200
+sWhismurSprites22:
+ax_sprite sWhismurGfx22, 0x200
+ax_sprite_terminator
+sWhismurGfx23:
+.incbin "baserom.gba", 0x11EFE38, 0x200
+sWhismurSprites23:
+ax_sprite sWhismurGfx23, 0x200
+ax_sprite_terminator
+sWhismurGfx24:
+.incbin "baserom.gba", 0x11F0048, 0x200
+sWhismurSprites24:
+ax_sprite sWhismurGfx24, 0x200
+ax_sprite_terminator
+sWhismurGfx25:
+.incbin "baserom.gba", 0x11F0258, 0xC0
+sWhismurSprites25:
+ax_sprite sWhismurGfx25, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWhismurGfx26:
+.incbin "baserom.gba", 0x11F0330, 0x60
+sWhismurSprites26:
+ax_sprite sWhismurGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhismurGfx27:
+.incbin "baserom.gba", 0x11F03A8, 0x100
+sWhismurSprites27:
+ax_sprite sWhismurGfx27, 0x100
+ax_sprite_terminator
+sWhismurGfx28:
+.incbin "baserom.gba", 0x11F04B8, 0x40
+sWhismurSprites28:
+ax_sprite sWhismurGfx28, 0x40
+ax_sprite_terminator
+sWhismurGfx29:
+.incbin "baserom.gba", 0x11F0508, 0x100
+sWhismurSprites29:
+ax_sprite sWhismurGfx29, 0x100
+ax_sprite_terminator
+sWhismurGfx30:
+.incbin "baserom.gba", 0x11F0618, 0x100
+sWhismurSprites30:
+ax_sprite sWhismurGfx30, 0x100
+ax_sprite_terminator
+sWhismurGfx31:
+.incbin "baserom.gba", 0x11F0728, 0x40
+sWhismurSprites31:
+ax_sprite sWhismurGfx31, 0x40
+ax_sprite_terminator
+sWhismurGfx32:
+.incbin "baserom.gba", 0x11F0778, 0x60
+sWhismurGfx32_1:
+.incbin "baserom.gba", 0x11F07D8, 0x60
+sWhismurSprites32:
+ax_sprite sWhismurGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWhismurGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWhismurGfx33:
+.incbin "baserom.gba", 0x11F0860, 0x40
+sWhismurSprites33:
+ax_sprite sWhismurGfx33, 0x40
+ax_sprite_terminator
+sWhismurGfx34:
+.incbin "baserom.gba", 0x11F08B0, 0x200
+sWhismurSprites34:
+ax_sprite sWhismurGfx34, 0x200
+ax_sprite_terminator
+sWhismurGfx35:
+.incbin "baserom.gba", 0x11F0AC0, 0x200
+sWhismurSprites35:
+ax_sprite sWhismurGfx35, 0x200
+ax_sprite_terminator
+sWhismurGfx36:
+.incbin "baserom.gba", 0x11F0CD0, 0x200
+sWhismurSprites36:
+ax_sprite sWhismurGfx36, 0x200
+ax_sprite_terminator
+sWhismurGfx37:
+.incbin "baserom.gba", 0x11F0EE0, 0x200
+sWhismurSprites37:
+ax_sprite sWhismurGfx37, 0x200
+ax_sprite_terminator
+sWhismurGfx38:
+.incbin "baserom.gba", 0x11F10F0, 0x200
+sWhismurSprites38:
+ax_sprite sWhismurGfx38, 0x200
+ax_sprite_terminator
+sWhismurGfx39:
+.incbin "baserom.gba", 0x11F1300, 0x200
+sWhismurSprites39:
+ax_sprite sWhismurGfx39, 0x200
+ax_sprite_terminator
+sWhismurGfx40:
+.incbin "baserom.gba", 0x11F1510, 0x200
+sWhismurSprites40:
+ax_sprite sWhismurGfx40, 0x200
+ax_sprite_terminator
+sAxPosesWhismur:
+.4byte sWhismurPose1
+.4byte sWhismurPose2
+.4byte sWhismurPose3
+.4byte sWhismurPose4
+.4byte sWhismurPose5
+.4byte sWhismurPose6
+.4byte sWhismurPose7
+.4byte sWhismurPose8
+.4byte sWhismurPose9
+.4byte sWhismurPose10
+.4byte sWhismurPose11
+.4byte sWhismurPose12
+.4byte sWhismurPose13
+.4byte sWhismurPose14
+.4byte sWhismurPose15
+.4byte sWhismurPose16
+.4byte sWhismurPose17
+.4byte sWhismurPose18
+.4byte sWhismurPose19
+.4byte sWhismurPose20
+.4byte sWhismurPose21
+.4byte sWhismurPose22
+.4byte sWhismurPose23
+.4byte sWhismurPose24
+.4byte sWhismurPose25
+.4byte sWhismurPose26
+.4byte sWhismurPose27
+.4byte sWhismurPose28
+.4byte sWhismurPose29
+.4byte sWhismurPose30
+.4byte sWhismurPose31
+.4byte sWhismurPose32
+.4byte sWhismurPose33
+.4byte sWhismurPose34
+.4byte sWhismurPose35
+.4byte sWhismurPose36
+.4byte sWhismurPose37
+.4byte sWhismurPose38
+.4byte sWhismurPose39
+.4byte sWhismurPose40
+.4byte sWhismurPose41
+.4byte sWhismurPose42
+.4byte sWhismurPose43
+.4byte sWhismurPose44
+.4byte sWhismurPose45
+.4byte sWhismurPose46
+.4byte sWhismurPose47
+.4byte sWhismurPose48
+.4byte sWhismurPose49
+.4byte sWhismurPose50
+.4byte sWhismurPose51
+.4byte sWhismurPose52
+.4byte sWhismurPose53
+.4byte sWhismurPose54
+.4byte sWhismurPose55
+.4byte sWhismurPose56
+.4byte sWhismurPose57
+.4byte sWhismurPose58
+.4byte sWhismurPose59
+.4byte sWhismurPose60
+.4byte sWhismurPose61
+.4byte sWhismurPose62
+.4byte sWhismurPose63
+.4byte sWhismurPose64
+.4byte sWhismurPose65
+.4byte sWhismurPose66
+.4byte sWhismurPose67
+.4byte sWhismurPose68
+.4byte sWhismurPose69
+.4byte sWhismurPose70
+.4byte sWhismurPose71
+.4byte sWhismurPose72
+.4byte sWhismurPose73
+.4byte sWhismurPose74
+.4byte sWhismurPose75
+.4byte sWhismurPose76
+.4byte sWhismurPose77
+.4byte sWhismurPose78
+.4byte sWhismurPose79
+.4byte sWhismurPose80
+.4byte sWhismurPose81
+.4byte sWhismurPose82
+.4byte sWhismurPose83
+.4byte sWhismurPose84
+.4byte sWhismurPose85
+.4byte sWhismurPose86
+.4byte sWhismurPose87
+.4byte sWhismurPose88
+.4byte sWhismurPose89
+.4byte sWhismurPose90
+.4byte sWhismurPose91
+.4byte sWhismurPose92
+.4byte sWhismurPose93
+.4byte sWhismurPose94
+.4byte sWhismurPose95
+.4byte sWhismurPose96
+.4byte sWhismurPose97
+.4byte sWhismurPose98
+.4byte sWhismurPose99
+.4byte sWhismurPose100
+.4byte sWhismurPose101
+.4byte sWhismurPose102
+.4byte sWhismurPose103
+.4byte sWhismurPose104
+.4byte sWhismurPose105
+.4byte sWhismurPose106
+.4byte sWhismurPose107
+.4byte sWhismurPose108
+.4byte sWhismurPose109
+.4byte sWhismurPose110
+.4byte sWhismurPose111
+.4byte sWhismurPose112
+.4byte sWhismurPose113
+.4byte sWhismurPose114
+.4byte sWhismurPose115
+.4byte sWhismurPose116
+.4byte sWhismurPose117
+.4byte sWhismurPose118
+.4byte sWhismurPose119
+.4byte sWhismurPose120
+.4byte sWhismurPose121
+.4byte sWhismurPose122
+.4byte sWhismurPose123
+.4byte sWhismurPose124
+.4byte sWhismurPose125
+.4byte sWhismurPose126
+.4byte sWhismurPose127
+.4byte sWhismurPose128
+.4byte sWhismurPose129
+.4byte sWhismurPose130
+.4byte sWhismurPose131
+.4byte sWhismurPose132
+.4byte sWhismurPose133
+.4byte sWhismurPose134
+.4byte sWhismurPose135
+.4byte sWhismurPose136
+.4byte sWhismurPose137
+.4byte sWhismurPose138
+.4byte sWhismurPose139
+.4byte sWhismurPose140
+.4byte sWhismurPose141
+.4byte sWhismurPose142
+.4byte sWhismurPose143
+.4byte sWhismurPose144
+.4byte sWhismurPose145
+.4byte sWhismurPose146
+.4byte sWhismurPose147
+.4byte sWhismurPose148
+.4byte sWhismurPose149
+.4byte sWhismurPose150
+.4byte sWhismurPose151
+.4byte sWhismurPose152
+.4byte sWhismurPose153
+.4byte sWhismurPose154
+.4byte sWhismurPose155
+.4byte sWhismurPose156
+.4byte sWhismurPose157
+.4byte sWhismurPose158
+.4byte sWhismurPose159
+.4byte sWhismurPose160
+.4byte sWhismurPose161
+.4byte sWhismurPose162
+.4byte sWhismurPose163
+.4byte sWhismurPose164
+.4byte sWhismurPose165
+.4byte sWhismurPose166
+.4byte sWhismurPose167
+.4byte sWhismurPose168
+.4byte sWhismurPose169
+.4byte sWhismurPose170
+sAxPositionsWhismur:
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte    1,   -2, 	  -4,   -2, 	   5,   -2, 	   1,   -5
+.2byte   -1,   -2, 	  -5,   -2, 	   4,   -2, 	  -1,   -5
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+.2byte    5,   -3, 	   0,   -1, 	   7,   -5, 	   1,   -7
+.2byte    3,   -2, 	  -2,   -1, 	   6,   -3, 	   0,   -7
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    6,   -5, 	   4,   -1, 	   4,   -7, 	   1,   -6
+.2byte    6,   -3, 	   2,   -1, 	   2,   -7, 	   0,   -6
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    3,   -6, 	   6,   -5, 	  -5,   -6, 	  -1,   -6
+.2byte    1,   -7, 	   6,   -3, 	  -2,   -8, 	  -1,   -5
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte   -1,   -5, 	   5,   -7, 	  -6,   -5, 	   0,   -6
+.2byte    1,   -5, 	   5,   -5, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte   -2,   -6, 	   3,   -8, 	  -5,   -3, 	   1,   -6
+.2byte   -1,   -8, 	   5,   -7, 	  -6,   -6, 	   0,   -6
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -6,   -3, 	  -4,   -7, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -5, 	  -1,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -3,   -2, 	  -6,   -3, 	   2,   -1, 	   0,   -6
+.2byte   -5,   -3, 	  -7,   -6, 	   0,   -1, 	  -1,   -6
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte    1,   -2, 	  -4,   -2, 	   5,   -2, 	   1,   -5
+.2byte   -1,   -2, 	  -5,   -2, 	   4,   -2, 	  -1,   -5
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+.2byte    5,   -3, 	   0,   -1, 	   7,   -5, 	   1,   -7
+.2byte    3,   -2, 	  -2,   -1, 	   6,   -3, 	   0,   -7
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    6,   -5, 	   4,   -1, 	   4,   -7, 	   1,   -6
+.2byte    6,   -3, 	   2,   -1, 	   2,   -7, 	   0,   -6
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    3,   -6, 	   6,   -5, 	  -5,   -6, 	  -1,   -6
+.2byte    1,   -7, 	   6,   -3, 	  -2,   -8, 	  -1,   -5
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte   -1,   -5, 	   5,   -7, 	  -6,   -5, 	   0,   -6
+.2byte    1,   -5, 	   5,   -5, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte   -2,   -6, 	   3,   -8, 	  -5,   -3, 	   1,   -6
+.2byte   -1,   -8, 	   5,   -7, 	  -6,   -6, 	   0,   -6
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -6,   -3, 	  -4,   -7, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -5, 	  -1,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -3,   -2, 	  -6,   -3, 	   2,   -1, 	   0,   -6
+.2byte   -5,   -3, 	  -7,   -6, 	   0,   -1, 	  -1,   -6
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte    1,   -2, 	  -4,   -2, 	   5,   -2, 	   1,   -5
+.2byte   -1,   -2, 	  -5,   -2, 	   4,   -2, 	  -1,   -5
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+.2byte    5,   -3, 	   0,   -1, 	   7,   -5, 	   1,   -7
+.2byte    3,   -2, 	  -2,   -1, 	   6,   -3, 	   0,   -7
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    6,   -5, 	   4,   -1, 	   4,   -7, 	   1,   -6
+.2byte    6,   -3, 	   2,   -1, 	   2,   -7, 	   0,   -6
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    3,   -6, 	   6,   -5, 	  -5,   -6, 	  -1,   -6
+.2byte    1,   -7, 	   6,   -3, 	  -2,   -8, 	  -1,   -5
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte   -1,   -5, 	   5,   -7, 	  -6,   -5, 	   0,   -6
+.2byte    1,   -5, 	   5,   -5, 	  -6,   -7, 	   0,   -6
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte   -2,   -6, 	   3,   -8, 	  -5,   -3, 	   1,   -6
+.2byte   -1,   -8, 	   5,   -7, 	  -6,   -6, 	   0,   -6
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -6,   -3, 	  -4,   -7, 	  -2,   -1, 	  -1,   -7
+.2byte   -6,   -5, 	  -1,   -7, 	  -4,   -2, 	  -1,   -6
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -3,   -2, 	  -6,   -3, 	   2,   -1, 	   0,   -6
+.2byte   -5,   -3, 	  -7,   -6, 	   0,   -1, 	  -1,   -6
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -7, 	   6,   -7, 	   0,   -9
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+.2byte    1,   -8, 	   7,  -12, 	  -4,   -7, 	   0,  -10
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    4,   -8, 	   1,  -12, 	   1,   -7, 	   0,   -9
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte    0,   -9, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -7, 	   1,   -8
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -4,   -8, 	  -1,  -12, 	  -1,   -7, 	   0,   -9
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -1,   -8, 	  -7,  -12, 	   4,   -7, 	   0,  -10
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte   -3,   -2, 	  -6,   -3, 	   2,   -1, 	   0,   -6
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -1,   -8, 	   5,   -7, 	  -6,   -6, 	   0,   -6
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte    3,   -6, 	   6,   -5, 	  -5,   -6, 	  -1,   -6
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    3,   -2, 	  -2,   -1, 	   6,   -3, 	   0,   -7
+.2byte   -1,   -7, 	  -7,   -8, 	   1,   -2, 	   0,   -7
+.2byte   -1,   -7, 	  -7,   -9, 	   3,   -4, 	   0,   -7
+.2byte    0,   -8, 	  -5,   -7, 	   5,   -7, 	   0,  -10
+.2byte   -1,   -5, 	   3,   -8, 	  -5,   -2, 	  -3,   -7
+.2byte    1,   -5, 	   3,   -9, 	  -1,   -3, 	  -3,   -5
+.2byte    0,   -8, 	  -3,   -9, 	   3,   -7, 	  -2,   -3
+.2byte    0,   -2, 	   7,   -2, 	  -7,   -2, 	   0,   -1
+.2byte   -1,   -8, 	   2,   -9, 	  -4,   -7, 	   1,   -3
+.2byte   -2,   -5, 	  -4,   -9, 	   0,   -3, 	   2,   -5
+.2byte    0,   -5, 	  -4,   -8, 	   4,   -2, 	   2,   -7
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -7, 	   6,   -7, 	   0,   -9
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+.2byte    1,   -8, 	   7,  -12, 	  -4,   -7, 	   0,  -10
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    4,   -8, 	   1,  -12, 	   1,   -7, 	   0,   -9
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte    0,   -9, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -7, 	   1,   -8
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -4,   -8, 	  -1,  -12, 	  -1,   -7, 	   0,   -9
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -1,   -8, 	  -7,  -12, 	   4,   -7, 	   0,  -10
+.2byte    0,   -6, 	  -6,   -7, 	   6,   -7, 	   0,   -9
+.2byte   -1,   -8, 	  -7,  -12, 	   4,   -7, 	   0,  -10
+.2byte   -4,   -8, 	  -1,  -12, 	  -1,   -7, 	   0,   -9
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -7, 	   1,   -8
+.2byte    0,   -9, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -7, 	  -1,   -8
+.2byte    4,   -8, 	   1,  -12, 	   1,   -7, 	   0,   -9
+.2byte    1,   -8, 	   7,  -12, 	  -4,   -7, 	   0,  -10
+.2byte    0,   -6, 	  -6,   -7, 	   6,   -7, 	   0,   -9
+.2byte    1,   -8, 	   7,  -12, 	  -4,   -7, 	   0,  -10
+.2byte    4,   -8, 	   1,  -12, 	   1,   -7, 	   0,   -9
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -9, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -7, 	   1,   -8
+.2byte   -4,   -8, 	  -1,  -12, 	  -1,   -7, 	   0,   -9
+.2byte   -1,   -8, 	  -7,  -12, 	   4,   -7, 	   0,  -10
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte    0,   -6, 	  -6,   -7, 	   6,   -7, 	   0,   -9
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+.2byte    1,   -8, 	   7,  -12, 	  -4,   -7, 	   0,  -10
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    4,   -8, 	   1,  -12, 	   1,   -7, 	   0,   -9
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    2,   -9, 	  -4,  -11, 	   5,   -7, 	  -1,   -8
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte    0,   -9, 	   6,   -8, 	  -6,   -8, 	   0,   -8
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte   -2,   -9, 	   4,  -11, 	  -5,   -7, 	   1,   -8
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -4,   -8, 	  -1,  -12, 	  -1,   -7, 	   0,   -9
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -1,   -8, 	  -7,  -12, 	   4,   -7, 	   0,  -10
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+.2byte    0,   -3, 	  -4,   -3, 	   4,   -3, 	   0,   -6
+.2byte   -4,   -4, 	  -7,   -5, 	   1,   -2, 	  -1,   -7
+.2byte   -6,   -4, 	  -3,   -8, 	  -3,   -2, 	  -1,   -7
+.2byte   -2,   -7, 	   4,   -8, 	  -6,   -5, 	   1,   -7
+.2byte    0,   -6, 	   5,   -6, 	  -5,   -6, 	   0,   -7
+.2byte    3,   -7, 	   6,   -5, 	  -4,   -8, 	  -2,   -7
+.2byte    6,   -4, 	   3,   -2, 	   3,   -8, 	   0,   -7
+.2byte    4,   -4, 	  -1,   -2, 	   7,   -5, 	   0,   -8
+sWhismurAnimTable1:
+.4byte sWhismurAnims_1_1
+.4byte sWhismurAnims_1_2
+.4byte sWhismurAnims_1_3
+.4byte sWhismurAnims_1_4
+.4byte sWhismurAnims_1_5
+.4byte sWhismurAnims_1_6
+.4byte sWhismurAnims_1_7
+.4byte sWhismurAnims_1_8
+sWhismurAnimTable2:
+.4byte sWhismurAnims_2_1
+.4byte sWhismurAnims_2_2
+.4byte sWhismurAnims_2_3
+.4byte sWhismurAnims_2_4
+.4byte sWhismurAnims_2_5
+.4byte sWhismurAnims_2_6
+.4byte sWhismurAnims_2_7
+.4byte sWhismurAnims_2_8
+sWhismurAnimTable3:
+.4byte sWhismurAnims_3_1
+.4byte sWhismurAnims_3_2
+.4byte sWhismurAnims_3_3
+.4byte sWhismurAnims_3_4
+.4byte sWhismurAnims_3_5
+.4byte sWhismurAnims_3_6
+.4byte sWhismurAnims_3_7
+.4byte sWhismurAnims_3_8
+sWhismurAnimTable4:
+.4byte sWhismurAnims_4_1
+.4byte sWhismurAnims_4_2
+.4byte sWhismurAnims_4_3
+.4byte sWhismurAnims_4_4
+.4byte sWhismurAnims_4_5
+.4byte sWhismurAnims_4_6
+.4byte sWhismurAnims_4_7
+.4byte sWhismurAnims_4_8
+sWhismurAnimTable5:
+.4byte sWhismurAnims_5_1
+.4byte sWhismurAnims_5_2
+.4byte sWhismurAnims_5_3
+.4byte sWhismurAnims_5_4
+.4byte sWhismurAnims_5_5
+.4byte sWhismurAnims_5_6
+.4byte sWhismurAnims_5_7
+.4byte sWhismurAnims_5_8
+sWhismurAnimTable6:
+.4byte sWhismurAnims_6_1
+.4byte sWhismurAnims_6_1
+.4byte sWhismurAnims_6_1
+.4byte sWhismurAnims_6_1
+.4byte sWhismurAnims_6_1
+.4byte sWhismurAnims_6_1
+.4byte sWhismurAnims_6_1
+.4byte sWhismurAnims_6_1
+sWhismurAnimTable7:
+.4byte sWhismurAnims_7_1
+.4byte sWhismurAnims_7_2
+.4byte sWhismurAnims_7_3
+.4byte sWhismurAnims_7_4
+.4byte sWhismurAnims_7_5
+.4byte sWhismurAnims_7_6
+.4byte sWhismurAnims_7_7
+.4byte sWhismurAnims_7_8
+sWhismurAnimTable8:
+.4byte sWhismurAnims_8_1
+.4byte sWhismurAnims_8_2
+.4byte sWhismurAnims_8_3
+.4byte sWhismurAnims_8_4
+.4byte sWhismurAnims_8_5
+.4byte sWhismurAnims_8_6
+.4byte sWhismurAnims_8_7
+.4byte sWhismurAnims_8_8
+sWhismurAnimTable9:
+.4byte sWhismurAnims_9_1
+.4byte sWhismurAnims_9_2
+.4byte sWhismurAnims_9_3
+.4byte sWhismurAnims_9_4
+.4byte sWhismurAnims_9_5
+.4byte sWhismurAnims_9_6
+.4byte sWhismurAnims_9_7
+.4byte sWhismurAnims_9_8
+sWhismurAnimTable10:
+.4byte sWhismurAnims_10_1
+.4byte sWhismurAnims_10_2
+.4byte sWhismurAnims_10_3
+.4byte sWhismurAnims_10_4
+.4byte sWhismurAnims_10_5
+.4byte sWhismurAnims_10_6
+.4byte sWhismurAnims_10_7
+.4byte sWhismurAnims_10_8
+sWhismurAnimTable11:
+.4byte sWhismurAnims_11_1
+.4byte sWhismurAnims_11_2
+.4byte sWhismurAnims_11_3
+.4byte sWhismurAnims_11_4
+.4byte sWhismurAnims_11_5
+.4byte sWhismurAnims_11_6
+.4byte sWhismurAnims_11_7
+.4byte sWhismurAnims_11_8
+sWhismurAnimTable12:
+.4byte sWhismurAnims_12_1
+.4byte sWhismurAnims_12_2
+.4byte sWhismurAnims_12_3
+.4byte sWhismurAnims_12_4
+.4byte sWhismurAnims_12_5
+.4byte sWhismurAnims_12_6
+.4byte sWhismurAnims_12_7
+.4byte sWhismurAnims_12_8
+sWhismurAnimTable13:
+.4byte sWhismurAnims_13_1
+.4byte sWhismurAnims_13_2
+.4byte sWhismurAnims_13_3
+.4byte sWhismurAnims_13_4
+.4byte sWhismurAnims_13_5
+.4byte sWhismurAnims_13_6
+.4byte sWhismurAnims_13_7
+.4byte sWhismurAnims_13_8
+sAxAnimationsWhismur:
+.4byte sWhismurAnimTable1
+.4byte sWhismurAnimTable2
+.4byte sWhismurAnimTable3
+.4byte sWhismurAnimTable4
+.4byte sWhismurAnimTable5
+.4byte sWhismurAnimTable6
+.4byte sWhismurAnimTable7
+.4byte sWhismurAnimTable8
+.4byte sWhismurAnimTable9
+.4byte sWhismurAnimTable10
+.4byte sWhismurAnimTable11
+.4byte sWhismurAnimTable12
+.4byte sWhismurAnimTable13
+sAxSpritesWhismur:
+.4byte sWhismurSprites1
+.4byte sWhismurSprites2
+.4byte sWhismurSprites3
+.4byte sWhismurSprites4
+.4byte sWhismurSprites5
+.4byte sWhismurSprites6
+.4byte sWhismurSprites7
+.4byte sWhismurSprites8
+.4byte sWhismurSprites9
+.4byte sWhismurSprites10
+.4byte sWhismurSprites11
+.4byte sWhismurSprites12
+.4byte sWhismurSprites13
+.4byte sWhismurSprites14
+.4byte sWhismurSprites15
+.4byte sWhismurSprites16
+.4byte sWhismurSprites17
+.4byte sWhismurSprites18
+.4byte sWhismurSprites19
+.4byte sWhismurSprites20
+.4byte sWhismurSprites21
+.4byte sWhismurSprites22
+.4byte sWhismurSprites23
+.4byte sWhismurSprites24
+.4byte sWhismurSprites25
+.4byte sWhismurSprites26
+.4byte sWhismurSprites27
+.4byte sWhismurSprites28
+.4byte sWhismurSprites29
+.4byte sWhismurSprites30
+.4byte sWhismurSprites31
+.4byte sWhismurSprites32
+.4byte sWhismurSprites33
+.4byte sWhismurSprites34
+.4byte sWhismurSprites35
+.4byte sWhismurSprites36
+.4byte sWhismurSprites37
+.4byte sWhismurSprites38
+.4byte sWhismurSprites39
+.4byte sWhismurSprites40
+sAxMainWhismur:
+ax_main sAxPosesWhismur, sAxAnimationsWhismur, 13, sAxSpritesWhismur, sAxPositionsWhismur

--- a/data/ax/wigglytuff.inc
+++ b/data/ax/wigglytuff.inc
@@ -1,0 +1,2800 @@
+.global gAxWigglytuff
+gAxWigglytuff:
+ax_siro sAxMainWigglytuff
+sWigglytuffPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose3:
+ax_pose 2, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose4:
+ax_pose 3, 0x01e6, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose5:
+ax_pose 4, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose6:
+ax_pose 5, 0x01e6, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose7:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose8:
+ax_pose 7, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose9:
+ax_pose 8, 0x81eb, 0x90f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose10:
+ax_pose 9, 0x01ea, 0x90e8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose11:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose12:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose14:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose15:
+ax_pose 14, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose16:
+ax_pose 9, 0x01ea, 0x80f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose17:
+ax_pose 10, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose18:
+ax_pose 11, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose19:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose20:
+ax_pose 7, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose21:
+ax_pose 8, 0x81ea, 0x80f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose22:
+ax_pose 3, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose23:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose24:
+ax_pose 5, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose27:
+ax_pose 2, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose28:
+ax_pose 3, 0x01e6, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose29:
+ax_pose 4, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose30:
+ax_pose 5, 0x01e6, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose31:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose32:
+ax_pose 7, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose33:
+ax_pose 8, 0x81eb, 0x90f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose34:
+ax_pose 9, 0x01ea, 0x90e8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose35:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose36:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose37:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose38:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose39:
+ax_pose 14, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose40:
+ax_pose 9, 0x01ea, 0x80f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose41:
+ax_pose 10, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose42:
+ax_pose 11, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose43:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose44:
+ax_pose 7, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose45:
+ax_pose 8, 0x81ea, 0x80f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose46:
+ax_pose 3, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose47:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose48:
+ax_pose 5, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose49:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose51:
+ax_pose 2, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose52:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose53:
+ax_pose 3, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose54:
+ax_pose 4, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose55:
+ax_pose 5, 0x01e6, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose56:
+ax_pose 16, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose57:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose58:
+ax_pose 7, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose59:
+ax_pose 8, 0x81eb, 0x90f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose60:
+ax_pose 17, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sWigglytuffPose61:
+ax_pose 9, 0x01ea, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose62:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose63:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose64:
+ax_pose 18, 0x01ed, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose65:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose66:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose67:
+ax_pose 14, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose68:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose69:
+ax_pose 9, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose70:
+ax_pose 10, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose71:
+ax_pose 11, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose72:
+ax_pose 18, 0x01ed, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose73:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose74:
+ax_pose 7, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose75:
+ax_pose 8, 0x81ea, 0x80f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose76:
+ax_pose 17, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose77:
+ax_pose 3, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose78:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose79:
+ax_pose 5, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose80:
+ax_pose 16, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose81:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose82:
+ax_pose 1, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose83:
+ax_pose 2, 0x01eb, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose84:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose85:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose86:
+ax_pose 3, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose87:
+ax_pose 4, 0x01ea, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose88:
+ax_pose 5, 0x01e6, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose89:
+ax_pose 22, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose90:
+ax_pose 23, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose91:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose92:
+ax_pose 7, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose93:
+ax_pose 8, 0x81eb, 0x90f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose94:
+ax_pose 24, 0x01e7, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose95:
+ax_pose 25, 0x01e7, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose96:
+ax_pose 9, 0x01ea, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose97:
+ax_pose 10, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose98:
+ax_pose 11, 0x01eb, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose99:
+ax_pose 26, 0x01e8, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose100:
+ax_pose 27, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose101:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose102:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose103:
+ax_pose 14, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose104:
+ax_pose 28, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose105:
+ax_pose 29, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose106:
+ax_pose 9, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose107:
+ax_pose 10, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose108:
+ax_pose 11, 0x01eb, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose109:
+ax_pose 26, 0x01e8, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose110:
+ax_pose 27, 0x01ea, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose111:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose112:
+ax_pose 7, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose113:
+ax_pose 8, 0x81ea, 0x80f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose114:
+ax_pose 24, 0x01e7, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose115:
+ax_pose 25, 0x01e7, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose116:
+ax_pose 3, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose117:
+ax_pose 4, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose118:
+ax_pose 5, 0x01e6, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose119:
+ax_pose 22, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose120:
+ax_pose 23, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose121:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose122:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose123:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose124:
+ax_pose 3, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose125:
+ax_pose 23, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose126:
+ax_pose 22, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose127:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose128:
+ax_pose 25, 0x01e7, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose129:
+ax_pose 24, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose130:
+ax_pose 9, 0x01ea, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose131:
+ax_pose 27, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose132:
+ax_pose 26, 0x01e8, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose133:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose134:
+ax_pose 29, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose135:
+ax_pose 28, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose136:
+ax_pose 9, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose137:
+ax_pose 27, 0x01ea, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose138:
+ax_pose 26, 0x01e8, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose139:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose140:
+ax_pose 25, 0x01e7, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose141:
+ax_pose 24, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose142:
+ax_pose 3, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose143:
+ax_pose 23, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose144:
+ax_pose 22, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose145:
+ax_pose 30, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sWigglytuffPose146:
+ax_pose 31, 0x01e6, 0x80f2, 0x1c00
+ax_pose_terminator
+sWigglytuffPose147:
+ax_pose 32, 0x01e3, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose148:
+ax_pose 33, 0x01e3, 0x90ed, 0x1c00
+ax_pose_terminator
+sWigglytuffPose149:
+ax_pose 34, 0x01e3, 0x90ed, 0x1c00
+ax_pose_terminator
+sWigglytuffPose150:
+ax_pose 35, 0x01e4, 0x90ed, 0x1c00
+ax_pose_terminator
+sWigglytuffPose151:
+ax_pose 36, 0x01e4, 0x80f2, 0x1c00
+ax_pose_terminator
+sWigglytuffPose152:
+ax_pose 35, 0x01e4, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose153:
+ax_pose 34, 0x01e3, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose154:
+ax_pose 33, 0x01e3, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose155:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose156:
+ax_pose 1, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose157:
+ax_pose 2, 0x01ec, 0x80f0, 0x1c00
+ax_pose_terminator
+sWigglytuffPose158:
+ax_pose 3, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose159:
+ax_pose 4, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose160:
+ax_pose 5, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose161:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose162:
+ax_pose 7, 0x01eb, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose163:
+ax_pose 8, 0x81eb, 0x90f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose164:
+ax_pose 9, 0x01ea, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose165:
+ax_pose 10, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose166:
+ax_pose 11, 0x01eb, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose167:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose168:
+ax_pose 13, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose169:
+ax_pose 14, 0x01ea, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose170:
+ax_pose 9, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose171:
+ax_pose 10, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose172:
+ax_pose 11, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose173:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose174:
+ax_pose 7, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose175:
+ax_pose 8, 0x81ea, 0x80f8, 0x1c00
+ax_pose_terminator
+sWigglytuffPose176:
+ax_pose 3, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose177:
+ax_pose 4, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose178:
+ax_pose 5, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose179:
+ax_pose 15, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose180:
+ax_pose 16, 0x01ea, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose181:
+ax_pose 17, 0x01ec, 0x80f3, 0x1c00
+ax_pose_terminator
+sWigglytuffPose182:
+ax_pose 18, 0x01ed, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose183:
+ax_pose 19, 0x01ed, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose184:
+ax_pose 18, 0x01ed, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose185:
+ax_pose 17, 0x01ec, 0x90ed, 0x1c00
+ax_pose_terminator
+sWigglytuffPose186:
+ax_pose 16, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose187:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose188:
+ax_pose 22, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose189:
+ax_pose 24, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose190:
+ax_pose 26, 0x01e8, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose191:
+ax_pose 28, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose192:
+ax_pose 26, 0x01e8, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose193:
+ax_pose 24, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose194:
+ax_pose 22, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose195:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose196:
+ax_pose 20, 0x01e8, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose197:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose198:
+ax_pose 3, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose199:
+ax_pose 22, 0x01e7, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose200:
+ax_pose 23, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose201:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose202:
+ax_pose 24, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose203:
+ax_pose 25, 0x01e7, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose204:
+ax_pose 9, 0x01ea, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose205:
+ax_pose 26, 0x01e9, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose206:
+ax_pose 27, 0x01ea, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose207:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose208:
+ax_pose 28, 0x01e9, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose209:
+ax_pose 29, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose210:
+ax_pose 9, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose211:
+ax_pose 26, 0x01e9, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose212:
+ax_pose 27, 0x01ea, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose213:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose214:
+ax_pose 24, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose215:
+ax_pose 25, 0x01e7, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose216:
+ax_pose 3, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose217:
+ax_pose 22, 0x01e7, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose218:
+ax_pose 23, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose219:
+ax_pose 21, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose220:
+ax_pose 23, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose221:
+ax_pose 25, 0x01e7, 0x80f5, 0x1c00
+ax_pose_terminator
+sWigglytuffPose222:
+ax_pose 27, 0x01ea, 0x80f6, 0x1c00
+ax_pose_terminator
+sWigglytuffPose223:
+ax_pose 29, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose224:
+ax_pose 27, 0x01ea, 0x90ea, 0x1c00
+ax_pose_terminator
+sWigglytuffPose225:
+ax_pose 25, 0x01e7, 0x90eb, 0x1c00
+ax_pose_terminator
+sWigglytuffPose226:
+ax_pose 23, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+sWigglytuffPose227:
+ax_pose 0, 0x01eb, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose228:
+ax_pose 3, 0x01e7, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose229:
+ax_pose 6, 0x01e7, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose230:
+ax_pose 9, 0x01ea, 0x80f7, 0x1c00
+ax_pose_terminator
+sWigglytuffPose231:
+ax_pose 12, 0x01ea, 0x80f4, 0x1c00
+ax_pose_terminator
+sWigglytuffPose232:
+ax_pose 9, 0x01ea, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose233:
+ax_pose 6, 0x01e7, 0x90e9, 0x1c00
+ax_pose_terminator
+sWigglytuffPose234:
+ax_pose 3, 0x01e7, 0x90ec, 0x1c00
+ax_pose_terminator
+.align 2
+sWigglytuffAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 1, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 25, 0, 18, 0, 18,
+ax_anim 2, 0, 25, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWigglytuffAnims_2_2:
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 10, 10, 10,
+ax_anim 2, 0, 28, 19, 19, 19, 19,
+ax_anim 2, 1, 28, 20, 18, 20, 18,
+ax_anim 2, 0, 28, 19, 19, 19, 19,
+ax_anim 2, 0, 28, 20, 18, 20, 18,
+ax_anim 2, 0, 27, 8, 8, 6, 6,
+ax_anim_terminator
+sWigglytuffAnims_2_3:
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 32, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 10, 0, 10, 0,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 1, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 31, 20, 0, 20, 0,
+ax_anim 2, 0, 31, 20, 1, 20, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sWigglytuffAnims_2_4:
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 35, 0, -1, 0, -1,
+ax_anim 1, 2, 34, 4, -6, 4, -6,
+ax_anim 1, 0, 35, 11, -12, 11, -12,
+ax_anim 2, 0, 34, 20, -23, 20, -23,
+ax_anim 2, 1, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 34, 20, -23, 20, -23,
+ax_anim 2, 0, 34, 21, -22, 21, -22,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sWigglytuffAnims_2_5:
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 37, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -11, 0, -11,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 1, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 37, 0, -22, 0, -22,
+ax_anim 2, 0, 37, 1, -22, 1, -22,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sWigglytuffAnims_2_6:
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 41, 0, -1, 0, -1,
+ax_anim 1, 2, 40, -4, -6, -4, -6,
+ax_anim 1, 0, 41, -11, -12, -11, -12,
+ax_anim 2, 0, 40, -20, -23, -20, -23,
+ax_anim 2, 1, 40, -21, -22, -21, -22,
+ax_anim 2, 0, 40, -20, -23, -20, -23,
+ax_anim 2, 0, 40, -21, -22, -21, -22,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sWigglytuffAnims_2_7:
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 44, 0, 0, 0, 0,
+ax_anim 1, 2, 43, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -10, 0, -10, 0,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 1, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 43, -20, 0, -20, 0,
+ax_anim 2, 0, 43, -20, 1, -20, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sWigglytuffAnims_2_8:
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 10, -10, 10,
+ax_anim 2, 0, 46, -18, 19, -18, 19,
+ax_anim 2, 1, 46, -19, 18, -19, 18,
+ax_anim 2, 0, 46, -18, 19, -18, 19,
+ax_anim 2, 0, 46, -18, 19, -18, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 49, 0, -3, 0, -3,
+ax_anim 4, 0, 49, 0, -4, 0, -4,
+ax_anim 1, 0, 50, 0, -2, 0, -1,
+ax_anim 1, 0, 51, 0, 4, 0, 6,
+ax_anim 2, 2, 51, 0, 11, 0, 14,
+ax_anim 2, 0, 51, 0, 21, 0, 21,
+ax_anim 2, 1, 51, 1, 21, 1, 21,
+ax_anim 2, 0, 51, 0, 21, 0, 21,
+ax_anim 2, 0, 51, 1, 21, 1, 21,
+ax_anim 2, 0, 51, 0, 21, 0, 21,
+ax_anim 2, 0, 51, 1, 21, 1, 21,
+ax_anim 2, 0, 48, 0, 10, 0, 10,
+ax_anim 2, 0, 48, 0, 3, 0, 3,
+ax_anim_terminator
+sWigglytuffAnims_3_2:
+ax_anim 2, 0, 53, -1, -1, -1, -1,
+ax_anim 2, 0, 53, -3, -3, -3, -3,
+ax_anim 4, 0, 53, -4, -4, -4, -4,
+ax_anim 1, 0, 54, -1, -4, -1, -1,
+ax_anim 1, 0, 55, 6, -2, 6, 6,
+ax_anim 2, 2, 55, 14, 7, 14, 14,
+ax_anim 2, 0, 55, 20, 20, 20, 20,
+ax_anim 2, 1, 55, 21, 19, 21, 19,
+ax_anim 2, 0, 55, 20, 20, 20, 20,
+ax_anim 2, 0, 55, 21, 19, 21, 19,
+ax_anim 2, 0, 55, 20, 20, 20, 20,
+ax_anim 2, 0, 55, 21, 19, 21, 19,
+ax_anim 2, 0, 52, 10, 10, 10, 10,
+ax_anim 2, 0, 52, 3, 3, 3, 3,
+ax_anim_terminator
+sWigglytuffAnims_3_3:
+ax_anim 2, 0, 57, -1, 0, -1, 0,
+ax_anim 2, 0, 57, -3, 0, -3, 0,
+ax_anim 4, 0, 57, -4, 0, -4, 0,
+ax_anim 1, 0, 58, -1, -2, -1, 0,
+ax_anim 1, 0, 59, 6, -4, 6, 0,
+ax_anim 2, 2, 59, 14, -4, 14, 0,
+ax_anim 2, 0, 59, 20, 0, 20, 0,
+ax_anim 2, 1, 59, 20, 1, 20, 1,
+ax_anim 2, 0, 59, 20, 0, 20, 0,
+ax_anim 2, 0, 59, 20, 1, 20, 1,
+ax_anim 2, 0, 59, 20, 0, 20, 0,
+ax_anim 2, 0, 59, 20, 1, 20, 1,
+ax_anim 2, 0, 56, 10, 0, 10, 0,
+ax_anim 2, 0, 56, 3, 0, 3, 0,
+ax_anim_terminator
+sWigglytuffAnims_3_4:
+ax_anim 2, 0, 61, -1, 1, -1, 1,
+ax_anim 2, 0, 61, -3, 3, -3, 3,
+ax_anim 4, 0, 61, -4, 4, -4, 4,
+ax_anim 1, 0, 62, -1, -3, -1, 1,
+ax_anim 1, 0, 63, 6, -14, 6, -6,
+ax_anim 2, 2, 63, 14, -20, 14, -14,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 1, 63, 21, -20, 21, -20,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 0, 63, 21, -20, 21, -20,
+ax_anim 2, 0, 63, 20, -21, 20, -21,
+ax_anim 2, 0, 63, 21, -20, 21, -20,
+ax_anim 2, 0, 60, 10, -10, 10, -10,
+ax_anim 2, 0, 60, 3, -3, 3, -3,
+ax_anim_terminator
+sWigglytuffAnims_3_5:
+ax_anim 2, 0, 65, 0, 1, 0, 1,
+ax_anim 2, 0, 65, 0, 3, 0, 3,
+ax_anim 4, 0, 65, 0, 4, 0, 4,
+ax_anim 1, 0, 66, 0, -3, 0, -1,
+ax_anim 1, 0, 67, 0, -14, 0, -11,
+ax_anim 2, 2, 67, 0, -20, 0, -20,
+ax_anim 2, 0, 67, 1, -20, 1, -20,
+ax_anim 2, 1, 67, 0, -20, 0, -20,
+ax_anim 2, 0, 67, 1, -20, 1, -20,
+ax_anim 2, 0, 67, 0, -20, 0, -20,
+ax_anim 2, 0, 67, 1, -20, 1, -20,
+ax_anim 2, 0, 67, 0, -20, 0, -20,
+ax_anim 2, 0, 64, 0, -10, 0, -10,
+ax_anim 2, 0, 64, 0, -3, 0, -3,
+ax_anim_terminator
+sWigglytuffAnims_3_6:
+ax_anim 2, 0, 69, 1, 1, 1, 1,
+ax_anim 2, 0, 69, 3, 3, 3, 3,
+ax_anim 4, 0, 69, 4, 4, 4, 4,
+ax_anim 1, 0, 70, 1, -3, 1, 1,
+ax_anim 1, 0, 71, -6, -14, -6, -6,
+ax_anim 2, 2, 71, -14, -20, -14, -14,
+ax_anim 2, 0, 71, -20, -21, -20, -21,
+ax_anim 2, 1, 71, -21, -20, -21, -20,
+ax_anim 2, 0, 71, -20, -21, -20, -21,
+ax_anim 2, 0, 71, -21, -20, -21, -20,
+ax_anim 2, 0, 71, -20, -21, -20, -21,
+ax_anim 2, 0, 71, -21, -20, -21, -20,
+ax_anim 2, 0, 68, -10, -10, -10, -10,
+ax_anim 2, 0, 68, -3, -3, -3, -3,
+ax_anim_terminator
+sWigglytuffAnims_3_7:
+ax_anim 2, 0, 73, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 3, 0, 3, 0,
+ax_anim 4, 0, 73, 4, 0, 4, 0,
+ax_anim 1, 0, 74, 1, -2, 1, 0,
+ax_anim 1, 0, 75, -6, -4, -6, 0,
+ax_anim 2, 2, 75, -14, -4, -14, 0,
+ax_anim 2, 0, 75, -20, 0, -20, 0,
+ax_anim 2, 1, 75, -20, 1, -20, 1,
+ax_anim 2, 0, 75, -20, 0, -20, 0,
+ax_anim 2, 0, 75, -20, 1, -20, 1,
+ax_anim 2, 0, 75, -20, 0, -20, 0,
+ax_anim 2, 0, 75, -20, 1, -20, 1,
+ax_anim 2, 0, 72, -10, 0, -10, 0,
+ax_anim 2, 0, 72, -3, 0, -3, 0,
+ax_anim_terminator
+sWigglytuffAnims_3_8:
+ax_anim 2, 0, 77, 1, -1, 1, -1,
+ax_anim 2, 0, 77, 3, -3, 3, -3,
+ax_anim 4, 0, 77, 4, -4, 4, -4,
+ax_anim 1, 0, 78, 1, -4, 1, -1,
+ax_anim 1, 0, 79, -6, -2, -6, 6,
+ax_anim 2, 2, 79, -14, 7, -14, 14,
+ax_anim 2, 0, 79, -20, 20, -20, 20,
+ax_anim 2, 1, 79, -21, 19, -21, 19,
+ax_anim 2, 0, 79, -20, 20, -20, 20,
+ax_anim 2, 0, 79, -21, 19, -21, 19,
+ax_anim 2, 0, 79, -20, 20, -20, 20,
+ax_anim 2, 0, 79, -21, 19, -21, 19,
+ax_anim 2, 0, 76, -10, 10, -10, 10,
+ax_anim 2, 0, 76, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_4_1:
+ax_anim 2, 0, 80, 0, -2, 0, -2,
+ax_anim 2, 0, 80, 0, -3, 0, -3,
+ax_anim 6, 2, 80, 0, -4, 0, -4,
+ax_anim 1, 0, 84, 0, -2, 0, -2,
+ax_anim 1, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 83, 0, 5, 0, 5,
+ax_anim 2, 0, 83, 1, 5, 1, 5,
+ax_anim 2, 0, 83, 0, 5, 0, 5,
+ax_anim 2, 0, 83, 1, 5, 1, 5,
+ax_anim 2, 0, 83, 0, 5, 0, 5,
+ax_anim 2, 0, 83, 1, 5, 1, 5,
+ax_anim 2, 0, 83, 0, 5, 0, 5,
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim_terminator
+sWigglytuffAnims_4_2:
+ax_anim 2, 0, 85, -2, -2, -2, -2,
+ax_anim 2, 0, 85, -3, -3, -3, -3,
+ax_anim 6, 2, 85, -4, -4, -4, -4,
+ax_anim 1, 0, 89, -2, -2, -2, -2,
+ax_anim 1, 0, 89, 1, 1, 1, 1,
+ax_anim 2, 1, 88, 6, 6, 6, 6,
+ax_anim 2, 0, 88, 7, 5, 7, 5,
+ax_anim 2, 0, 88, 6, 6, 6, 6,
+ax_anim 2, 0, 88, 7, 5, 7, 5,
+ax_anim 2, 0, 88, 6, 6, 6, 6,
+ax_anim 2, 0, 88, 7, 5, 7, 5,
+ax_anim 2, 0, 88, 6, 6, 6, 6,
+ax_anim 2, 0, 85, 2, 2, 2, 2,
+ax_anim_terminator
+sWigglytuffAnims_4_3:
+ax_anim 2, 0, 90, -2, 0, -2, 0,
+ax_anim 2, 0, 90, -3, 0, -3, 0,
+ax_anim 6, 2, 90, -4, 0, -4, 0,
+ax_anim 1, 0, 94, -2, 0, -2, 0,
+ax_anim 1, 0, 94, 1, 0, 1, 0,
+ax_anim 2, 1, 93, 6, 0, 6, 0,
+ax_anim 2, 0, 93, 6, 1, 6, 1,
+ax_anim 2, 0, 93, 6, 0, 6, 0,
+ax_anim 2, 0, 93, 6, 1, 6, 1,
+ax_anim 2, 0, 93, 6, 0, 6, 0,
+ax_anim 2, 0, 93, 6, 1, 6, 1,
+ax_anim 2, 0, 93, 6, 0, 6, 0,
+ax_anim 2, 0, 90, 2, 0, 2, 0,
+ax_anim_terminator
+sWigglytuffAnims_4_4:
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 3, -3, 3,
+ax_anim 6, 2, 95, -4, 4, -4, 4,
+ax_anim 1, 0, 99, -2, 2, -2, 2,
+ax_anim 1, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 1, 98, 6, -6, 6, -6,
+ax_anim 2, 0, 98, 7, -5, 7, -5,
+ax_anim 2, 0, 98, 6, -6, 6, -6,
+ax_anim 2, 0, 98, 7, -5, 7, -5,
+ax_anim 2, 0, 98, 6, -6, 6, -6,
+ax_anim 2, 0, 98, 7, -5, 7, -5,
+ax_anim 2, 0, 98, 6, -6, 6, -6,
+ax_anim 2, 0, 95, 2, -2, 2, -2,
+ax_anim_terminator
+sWigglytuffAnims_4_5:
+ax_anim 2, 0, 100, 0, 2, 0, 2,
+ax_anim 2, 0, 100, 0, 3, 0, 3,
+ax_anim 6, 2, 100, 0, 4, 0, 4,
+ax_anim 1, 0, 104, 0, 2, 0, 2,
+ax_anim 1, 0, 104, 0, -1, 0, -1,
+ax_anim 2, 1, 103, 0, -6, 0, -6,
+ax_anim 2, 0, 103, 1, -6, 1, -6,
+ax_anim 2, 0, 103, 0, -6, 0, -6,
+ax_anim 2, 0, 103, 1, -6, 1, -6,
+ax_anim 2, 0, 103, 0, -6, 0, -6,
+ax_anim 2, 0, 103, 1, -6, 1, -6,
+ax_anim 2, 0, 103, 0, -6, 0, -6,
+ax_anim 2, 0, 100, 0, -2, 0, -2,
+ax_anim_terminator
+sWigglytuffAnims_4_6:
+ax_anim 2, 0, 105, 2, 2, 2, 2,
+ax_anim 2, 0, 105, 3, 3, 3, 3,
+ax_anim 6, 2, 105, 4, 4, 4, 4,
+ax_anim 1, 0, 109, 2, 2, 2, 2,
+ax_anim 1, 0, 109, -1, -1, -1, -1,
+ax_anim 2, 1, 108, -6, -6, -6, -6,
+ax_anim 2, 0, 108, -7, -5, -7, -5,
+ax_anim 2, 0, 108, -6, -6, -6, -6,
+ax_anim 2, 0, 108, -7, -5, -7, -5,
+ax_anim 2, 0, 108, -6, -6, -6, -6,
+ax_anim 2, 0, 108, -7, -5, -7, -5,
+ax_anim 2, 0, 108, -6, -6, -6, -6,
+ax_anim 2, 0, 105, -2, -2, -2, -2,
+ax_anim_terminator
+sWigglytuffAnims_4_7:
+ax_anim 2, 0, 110, 2, 0, 2, 0,
+ax_anim 2, 0, 110, 3, 0, 3, 0,
+ax_anim 6, 2, 110, 4, 0, 4, 0,
+ax_anim 1, 0, 114, 2, 0, 2, 0,
+ax_anim 1, 0, 114, -1, 0, -1, 0,
+ax_anim 2, 1, 113, -6, 0, -6, 0,
+ax_anim 2, 0, 113, -6, 1, -6, 1,
+ax_anim 2, 0, 113, -6, 0, -6, 0,
+ax_anim 2, 0, 113, -6, 1, -6, 1,
+ax_anim 2, 0, 113, -6, 0, -6, 0,
+ax_anim 2, 0, 113, -6, 1, -6, 1,
+ax_anim 2, 0, 113, -6, 0, -6, 0,
+ax_anim 2, 0, 110, -2, 0, -2, 0,
+ax_anim_terminator
+sWigglytuffAnims_4_8:
+ax_anim 2, 0, 115, 2, -2, 2, -2,
+ax_anim 2, 0, 115, 3, -3, 3, -3,
+ax_anim 6, 2, 115, 4, -4, 4, -4,
+ax_anim 1, 0, 119, 2, -2, 2, -2,
+ax_anim 1, 0, 119, -1, 1, -1, 1,
+ax_anim 2, 1, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 118, -7, 5, -7, 5,
+ax_anim 2, 0, 118, -6, 6, -6, 6,
+ax_anim 2, 0, 115, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_5_1:
+ax_anim 1, 0, 122, 0, -2, 0, -2,
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 4, 2, 122, 0, -4, 0, -4,
+ax_anim 2, 0, 122, 0, -3, 0, -3,
+ax_anim 1, 0, 120, 0, -2, 0, -2,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 1, 121, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim_terminator
+sWigglytuffAnims_5_2:
+ax_anim 1, 0, 125, 0, -2, 0, -2,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 4, 2, 125, 0, -4, 0, -4,
+ax_anim 2, 0, 125, 0, -3, 0, -3,
+ax_anim 1, 0, 123, 0, -2, 0, -2,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 1, 124, 1, -1, 1, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, -1, 1, -1,
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 1, -1, 1, -1,
+ax_anim_terminator
+sWigglytuffAnims_5_3:
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, -3, 0, 0,
+ax_anim 4, 2, 128, 0, -4, 0, 0,
+ax_anim 2, 0, 128, 0, -3, 0, 0,
+ax_anim 1, 0, 126, 0, -2, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 1, 127, 0, 1, 0, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 1, 0, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, 1, 0, 1,
+ax_anim_terminator
+sWigglytuffAnims_5_4:
+ax_anim 1, 0, 131, 0, -2, 0, -2,
+ax_anim 2, 0, 131, 0, -3, 0, -3,
+ax_anim 4, 2, 131, 0, -4, 0, -4,
+ax_anim 2, 0, 131, 0, -3, 0, -3,
+ax_anim 1, 0, 129, 0, -2, 0, -2,
+ax_anim 4, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 1, 130, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 1, 1, 1,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 1, 1, 1, 1,
+ax_anim_terminator
+sWigglytuffAnims_5_5:
+ax_anim 1, 0, 134, 0, -2, 0, -2,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 4, 2, 134, 0, -4, 0, -4,
+ax_anim 2, 0, 134, 0, -3, 0, -3,
+ax_anim 1, 0, 132, 0, -1, 0, -2,
+ax_anim 4, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 1, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, 0, 1, 0,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 1, 0, 1, 0,
+ax_anim_terminator
+sWigglytuffAnims_5_6:
+ax_anim 1, 0, 137, 0, -2, 0, -2,
+ax_anim 2, 0, 137, 0, -3, 0, -3,
+ax_anim 4, 2, 137, 0, -4, 0, -4,
+ax_anim 2, 0, 137, 0, -3, 0, -3,
+ax_anim 1, 0, 135, 0, -2, 0, -2,
+ax_anim 4, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 1, 136, -1, 1, -1, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 1, -1, 1,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, -1, 1, -1, 1,
+ax_anim_terminator
+sWigglytuffAnims_5_7:
+ax_anim 1, 0, 140, 0, -2, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 4, 2, 140, 0, -4, 0, 0,
+ax_anim 2, 0, 140, 0, -3, 0, 0,
+ax_anim 1, 0, 138, 0, -2, 0, 0,
+ax_anim 4, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 1, 139, 0, 1, 0, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 1, 0, 1,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 0, 1, 0, 1,
+ax_anim_terminator
+sWigglytuffAnims_5_8:
+ax_anim 1, 0, 143, 0, -2, 0, -2,
+ax_anim 2, 0, 143, 0, -3, 0, -3,
+ax_anim 4, 2, 143, 0, -4, 0, -4,
+ax_anim 2, 0, 143, 0, -3, 0, -3,
+ax_anim 1, 0, 141, 0, -2, 0, -2,
+ax_anim 4, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 1, 142, -1, -1, -1, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, -1, -1, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_6_1:
+ax_anim 35, 0, 144, 0, 0, 0, 0,
+ax_anim 35, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_7_1:
+ax_anim 2, 0, 146, 0, -2, 0, -2,
+ax_anim 8, 0, 146, 0, -3, 0, -3,
+ax_anim_terminator
+sWigglytuffAnims_7_2:
+ax_anim 2, 0, 147, -2, -2, -2, -2,
+ax_anim 8, 0, 147, -3, -3, -3, -3,
+ax_anim_terminator
+sWigglytuffAnims_7_3:
+ax_anim 2, 0, 148, -2, 0, -2, 0,
+ax_anim 8, 0, 148, -3, 0, -3, 0,
+ax_anim_terminator
+sWigglytuffAnims_7_4:
+ax_anim 2, 0, 149, -2, 2, -2, 2,
+ax_anim 8, 0, 149, -3, 3, -3, 3,
+ax_anim_terminator
+sWigglytuffAnims_7_5:
+ax_anim 2, 0, 150, 0, 2, 0, 2,
+ax_anim 8, 0, 150, 0, 3, 0, 3,
+ax_anim_terminator
+sWigglytuffAnims_7_6:
+ax_anim 2, 0, 151, 2, 2, 2, 2,
+ax_anim 8, 0, 151, 3, 3, 3, 3,
+ax_anim_terminator
+sWigglytuffAnims_7_7:
+ax_anim 2, 0, 152, 2, 0, 2, 0,
+ax_anim 8, 0, 152, 3, 0, 3, 0,
+ax_anim_terminator
+sWigglytuffAnims_7_8:
+ax_anim 2, 0, 153, 2, -2, 2, -2,
+ax_anim 8, 0, 153, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_8_1:
+ax_anim 40, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim 6, 0, 155, 0, -4, 0, 0,
+ax_anim 4, 0, 154, 0, -1, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_8_2:
+ax_anim 40, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim 6, 0, 158, 0, -4, 0, 0,
+ax_anim 4, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_8_3:
+ax_anim 40, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim 6, 0, 161, 0, -4, 0, 0,
+ax_anim 4, 0, 160, 0, -1, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_8_4:
+ax_anim 40, 0, 163, 0, 0, 0, 0,
+ax_anim 4, 0, 164, 0, -3, 0, 0,
+ax_anim 6, 0, 164, 0, -4, 0, 0,
+ax_anim 4, 0, 163, 0, -1, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_8_5:
+ax_anim 40, 0, 166, 0, 0, 0, 0,
+ax_anim 4, 0, 167, 0, -3, 0, 0,
+ax_anim 6, 0, 167, 0, -4, 0, 0,
+ax_anim 4, 0, 166, 0, -1, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_8_6:
+ax_anim 40, 0, 169, 0, 0, 0, 0,
+ax_anim 4, 0, 170, 0, -3, 0, 0,
+ax_anim 6, 0, 170, 0, -4, 0, 0,
+ax_anim 4, 0, 169, 0, -1, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_8_7:
+ax_anim 40, 0, 172, 0, 0, 0, 0,
+ax_anim 4, 0, 173, 0, -3, 0, 0,
+ax_anim 6, 0, 173, 0, -4, 0, 0,
+ax_anim 4, 0, 172, 0, -1, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_8_8:
+ax_anim 40, 0, 175, 0, 0, 0, 0,
+ax_anim 4, 0, 176, 0, -3, 0, 0,
+ax_anim 6, 0, 176, 0, -4, 0, 0,
+ax_anim 4, 0, 175, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_9_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 6, 3, 6, 3,
+ax_anim 2, 0, 180, 8, 9, 8, 9,
+ax_anim 2, 0, 181, 7, 16, 7, 16,
+ax_anim 3, 0, 182, 0, 20, 0, 20,
+ax_anim 2, 3, 183, -7, 16, -7, 16,
+ax_anim 2, 0, 184, -8, 9, -8, 9,
+ax_anim 1, 0, 185, -6, 3, -6, 3,
+ax_anim 1, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_9_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 8, 0, 8, 0,
+ax_anim 2, 0, 179, 19, 3, 19, 3,
+ax_anim 2, 0, 180, 23, 12, 23, 12,
+ax_anim 3, 0, 181, 20, 20, 20, 20,
+ax_anim 2, 3, 182, 11, 19, 11, 19,
+ax_anim 2, 0, 183, 3, 15, 3, 15,
+ax_anim 1, 0, 184, 0, 7, 0, 7,
+ax_anim 1, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_9_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 3, -5, 3, -5,
+ax_anim 2, 0, 178, 11, -6, 11, -6,
+ax_anim 2, 0, 179, 18, -5, 18, -5,
+ax_anim 3, 0, 180, 21, -2, 21, -2,
+ax_anim 2, 3, 181, 18, 4, 18, 4,
+ax_anim 2, 0, 182, 12, 5, 12, 5,
+ax_anim 1, 0, 183, 4, 5, 4, 5,
+ax_anim 1, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_9_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 1, 0, 184, -1, -6, -1, -6,
+ax_anim 2, 0, 185, 4, -16, 4, -16,
+ax_anim 2, 0, 178, 12, -22, 12, -22,
+ax_anim 3, 0, 179, 19, -21, 19, -21,
+ax_anim 2, 3, 180, 22, -15, 22, -15,
+ax_anim 2, 0, 181, 17, -4, 17, -4,
+ax_anim 1, 0, 182, 7, -1, 7, -1,
+ax_anim 1, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_9_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, -8, -4, -8, -4,
+ax_anim 2, 0, 184, -9, -12, -9, -12,
+ax_anim 2, 0, 185, -7, -18, -7, -18,
+ax_anim 3, 0, 178, 0, -22, 0, -22,
+ax_anim 2, 3, 179, 7, -18, 7, -18,
+ax_anim 2, 0, 180, 9, -10, 9, -10,
+ax_anim 1, 0, 181, 8, -4, 8, -4,
+ax_anim 1, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_9_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 1, -6, 1, -6,
+ax_anim 2, 0, 179, -4, -16, -4, -16,
+ax_anim 2, 0, 178, -12, -22, -12, -22,
+ax_anim 3, 0, 185, -19, -21, -19, -21,
+ax_anim 2, 3, 184, -22, -15, -22, -15,
+ax_anim 2, 0, 183, -17, -4, -17, -4,
+ax_anim 1, 0, 182, -7, -1, -7, -1,
+ax_anim 1, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_9_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 179, -3, -5, -3, -5,
+ax_anim 2, 0, 178, -11, -6, -11, -6,
+ax_anim 2, 0, 185, -18, -5, -18, -5,
+ax_anim 3, 0, 184, -21, -2, -21, -2,
+ax_anim 2, 3, 183, -18, 4, -18, 4,
+ax_anim 2, 0, 182, -12, 5, -12, 5,
+ax_anim 1, 0, 181, -4, 5, -4, 5,
+ax_anim 1, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_9_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 178, -8, 0, -8, 0,
+ax_anim 2, 0, 185, -19, 3, -19, 3,
+ax_anim 2, 0, 184, -23, 12, -23, 12,
+ax_anim 3, 0, 183, -20, 20, -20, 20,
+ax_anim 2, 3, 182, -11, 19, -11, 19,
+ax_anim 2, 0, 181, -3, 15, -3, 15,
+ax_anim 1, 0, 180, 0, 7, 0, 7,
+ax_anim 1, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_10_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 3, 0, 186, 13, 0, 13, 0,
+ax_anim 3, 0, 186, -13, 0, -13, 0,
+ax_anim 2, 0, 186, 12, 0, 12, 0,
+ax_anim 3, 0, 186, -12, 0, -12, 0,
+ax_anim 2, 0, 186, 10, 0, 10, 0,
+ax_anim 2, 0, 186, -10, 0, -10, 0,
+ax_anim 2, 0, 186, 6, 0, 6, 0,
+ax_anim 2, 0, 186, -6, 0, -6, 0,
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_10_2:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 3, 0, 187, 13, -13, 13, -13,
+ax_anim 3, 0, 187, -13, 13, -13, 13,
+ax_anim 2, 0, 187, 12, -12, 12, -12,
+ax_anim 3, 0, 187, -12, 12, -12, 12,
+ax_anim 2, 0, 187, 10, -10, 10, -10,
+ax_anim 2, 0, 187, -10, 10, -10, 10,
+ax_anim 2, 0, 187, 6, -6, 6, -6,
+ax_anim 2, 0, 187, -6, 6, -6, 6,
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_10_3:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 3, 0, 188, 0, -13, 0, -13,
+ax_anim 3, 0, 188, 0, 13, 0, 13,
+ax_anim 2, 0, 188, 0, -12, 0, -12,
+ax_anim 3, 0, 188, 0, 12, 0, 12,
+ax_anim 2, 0, 188, 0, -10, 0, -10,
+ax_anim 2, 0, 188, 0, 10, 0, 10,
+ax_anim 2, 0, 188, 0, -6, 0, -6,
+ax_anim 2, 0, 188, 0, 6, 0, 6,
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_10_4:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 3, 0, 189, -13, -13, -13, -13,
+ax_anim 3, 0, 189, 13, 13, 13, 13,
+ax_anim 2, 0, 189, -12, -12, -12, -12,
+ax_anim 3, 0, 189, 12, 12, 12, 12,
+ax_anim 2, 0, 189, -10, -10, -10, -10,
+ax_anim 2, 0, 189, 10, 10, 10, 10,
+ax_anim 2, 0, 189, -6, -6, -6, -6,
+ax_anim 2, 0, 189, 6, 6, 6, 6,
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_10_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 3, 0, 190, 13, 0, 13, 0,
+ax_anim 3, 0, 190, -13, 0, -13, 0,
+ax_anim 2, 0, 190, 12, 0, 12, 0,
+ax_anim 3, 0, 190, -12, 0, -12, 0,
+ax_anim 2, 0, 190, 10, 0, 10, 0,
+ax_anim 2, 0, 190, -10, 0, -10, 0,
+ax_anim 2, 0, 190, 6, 0, 6, 0,
+ax_anim 2, 0, 190, -6, 0, -6, 0,
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_10_6:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 3, 0, 191, 13, -13, 13, -13,
+ax_anim 3, 0, 191, -13, 13, -13, 13,
+ax_anim 2, 0, 191, 12, -12, 12, -12,
+ax_anim 3, 0, 191, -12, 12, -12, 12,
+ax_anim 2, 0, 191, 10, -10, 10, -10,
+ax_anim 2, 0, 191, -10, 10, -10, 10,
+ax_anim 2, 0, 191, 6, -6, 6, -6,
+ax_anim 2, 0, 191, -6, 6, -6, 6,
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_10_7:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 3, 0, 192, 0, -13, 0, -13,
+ax_anim 3, 0, 192, 0, 13, 0, 13,
+ax_anim 2, 0, 192, 0, -12, 0, -12,
+ax_anim 3, 0, 192, 0, 12, 0, 12,
+ax_anim 2, 0, 192, 0, -10, 0, -10,
+ax_anim 2, 0, 192, 0, 10, 0, 10,
+ax_anim 2, 0, 192, 0, -6, 0, -6,
+ax_anim 2, 0, 192, 0, 6, 0, 6,
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_10_8:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 3, 0, 193, -13, -13, -13, -13,
+ax_anim 3, 0, 193, 13, 13, 13, 13,
+ax_anim 2, 0, 193, -12, -12, -12, -12,
+ax_anim 3, 0, 193, 12, 12, 12, 12,
+ax_anim 2, 0, 193, -10, -10, -10, -10,
+ax_anim 2, 0, 193, 10, 10, 10, 10,
+ax_anim 2, 0, 193, -6, -6, -6, -6,
+ax_anim 2, 0, 193, 6, 6, 6, 6,
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_11_1:
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -26, 0, 0,
+ax_anim 3, 0, 196, 0, -22, 0, 0,
+ax_anim 2, 0, 196, 0, -18, 0, 0,
+ax_anim 1, 0, 196, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_11_2:
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -26, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_11_3:
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -25, 0, 0,
+ax_anim 3, 0, 202, 0, -22, 0, 0,
+ax_anim 2, 0, 202, 0, -18, 0, 0,
+ax_anim 1, 0, 202, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_11_4:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 0, -10, 0, 0,
+ax_anim 2, 0, 204, 0, -16, 0, 0,
+ax_anim 3, 0, 204, 0, -20, 0, 0,
+ax_anim 4, 0, 204, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -17, 0, 0,
+ax_anim 1, 0, 205, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_11_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, 0, -10, 0, 0,
+ax_anim 2, 0, 207, 0, -16, 0, 0,
+ax_anim 3, 0, 207, 0, -20, 0, 0,
+ax_anim 4, 0, 207, 0, -21, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_11_6:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 210, 0, -10, 0, 0,
+ax_anim 2, 0, 210, 0, -16, 0, 0,
+ax_anim 3, 0, 210, 0, -20, 0, 0,
+ax_anim 4, 0, 210, 0, -21, 0, 0,
+ax_anim 4, 0, 211, 0, -23, 0, 0,
+ax_anim 3, 0, 211, 0, -21, 0, 0,
+ax_anim 2, 0, 211, 0, -17, 0, 0,
+ax_anim 1, 0, 211, 0, -11, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_11_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 1, 0, 213, 0, -10, 0, 0,
+ax_anim 2, 0, 213, 0, -16, 0, 0,
+ax_anim 3, 0, 213, 0, -20, 0, 0,
+ax_anim 4, 0, 213, 0, -21, 0, 0,
+ax_anim 4, 0, 214, 0, -25, 0, 0,
+ax_anim 3, 0, 214, 0, -22, 0, 0,
+ax_anim 2, 0, 214, 0, -18, 0, 0,
+ax_anim 1, 0, 214, 0, -12, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_11_8:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 1, 0, 216, 0, -10, 0, 0,
+ax_anim 2, 0, 216, 0, -16, 0, 0,
+ax_anim 3, 0, 216, 0, -20, 0, 0,
+ax_anim 4, 0, 216, 0, -21, 0, 0,
+ax_anim 4, 0, 217, 0, -26, 0, 0,
+ax_anim 3, 0, 217, 0, -22, 0, 0,
+ax_anim 2, 0, 217, 0, -18, 0, 0,
+ax_anim 1, 0, 217, 0, -12, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_12_1:
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 1, 0, 1, 0,
+ax_anim 2, 1, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_12_2:
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, -1,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_12_3:
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, -1, 0, -1,
+ax_anim 2, 1, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_12_4:
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 223, -1, -1, -1, -1,
+ax_anim 2, 1, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_12_5:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_12_6:
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 1, -1, 1, -1,
+ax_anim 2, 1, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_12_7:
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, -1, 0, -1,
+ax_anim 2, 1, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_12_8:
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 219, -1, -1, -1, -1,
+ax_anim 2, 1, 219, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWigglytuffAnims_13_1:
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 2, 226, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_13_2:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 2, 233, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_13_3:
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 2, 232, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_13_4:
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_13_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 2, 230, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_13_6:
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 2, 229, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_13_7:
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffAnims_13_8:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 229, 0, 0, 0, 0,
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 232, 0, 0, 0, 0,
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 2, 0, 226, 0, 0, 0, 0,
+ax_anim 2, 2, 227, 0, 0, 0, 0,
+ax_anim_terminator
+sWigglytuffGfx1:
+.incbin "baserom.gba", 0x6BBD10, 0x200
+sWigglytuffSprites1:
+ax_sprite sWigglytuffGfx1, 0x200
+ax_sprite_terminator
+sWigglytuffGfx2:
+.incbin "baserom.gba", 0x6BBF20, 0x200
+sWigglytuffSprites2:
+ax_sprite sWigglytuffGfx2, 0x200
+ax_sprite_terminator
+sWigglytuffGfx3:
+.incbin "baserom.gba", 0x6BC130, 0x200
+sWigglytuffSprites3:
+ax_sprite sWigglytuffGfx3, 0x200
+ax_sprite_terminator
+sWigglytuffGfx4:
+.incbin "baserom.gba", 0x6BC340, 0x200
+sWigglytuffSprites4:
+ax_sprite sWigglytuffGfx4, 0x200
+ax_sprite_terminator
+sWigglytuffGfx5:
+.incbin "baserom.gba", 0x6BC550, 0x200
+sWigglytuffSprites5:
+ax_sprite sWigglytuffGfx5, 0x200
+ax_sprite_terminator
+sWigglytuffGfx6:
+.incbin "baserom.gba", 0x6BC760, 0x200
+sWigglytuffSprites6:
+ax_sprite sWigglytuffGfx6, 0x200
+ax_sprite_terminator
+sWigglytuffGfx7:
+.incbin "baserom.gba", 0x6BC970, 0x200
+sWigglytuffSprites7:
+ax_sprite sWigglytuffGfx7, 0x200
+ax_sprite_terminator
+sWigglytuffGfx8:
+.incbin "baserom.gba", 0x6BCB80, 0x200
+sWigglytuffSprites8:
+ax_sprite sWigglytuffGfx8, 0x200
+ax_sprite_terminator
+sWigglytuffGfx9:
+.incbin "baserom.gba", 0x6BCD90, 0x100
+sWigglytuffSprites9:
+ax_sprite sWigglytuffGfx9, 0x100
+ax_sprite_terminator
+sWigglytuffGfx10:
+.incbin "baserom.gba", 0x6BCEA0, 0x200
+sWigglytuffSprites10:
+ax_sprite sWigglytuffGfx10, 0x200
+ax_sprite_terminator
+sWigglytuffGfx11:
+.incbin "baserom.gba", 0x6BD0B0, 0x200
+sWigglytuffSprites11:
+ax_sprite sWigglytuffGfx11, 0x200
+ax_sprite_terminator
+sWigglytuffGfx12:
+.incbin "baserom.gba", 0x6BD2C0, 0x200
+sWigglytuffSprites12:
+ax_sprite sWigglytuffGfx12, 0x200
+ax_sprite_terminator
+sWigglytuffGfx13:
+.incbin "baserom.gba", 0x6BD4D0, 0x200
+sWigglytuffSprites13:
+ax_sprite sWigglytuffGfx13, 0x200
+ax_sprite_terminator
+sWigglytuffGfx14:
+.incbin "baserom.gba", 0x6BD6E0, 0x200
+sWigglytuffSprites14:
+ax_sprite sWigglytuffGfx14, 0x200
+ax_sprite_terminator
+sWigglytuffGfx15:
+.incbin "baserom.gba", 0x6BD8F0, 0x200
+sWigglytuffSprites15:
+ax_sprite sWigglytuffGfx15, 0x200
+ax_sprite_terminator
+sWigglytuffGfx16:
+.incbin "baserom.gba", 0x6BDB00, 0x60
+sWigglytuffGfx16_1:
+.incbin "baserom.gba", 0x6BDB60, 0x60
+sWigglytuffGfx16_2:
+.incbin "baserom.gba", 0x6BDBC0, 0x60
+sWigglytuffSprites16:
+ax_sprite sWigglytuffGfx16, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx16_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx17:
+.incbin "baserom.gba", 0x6BDC58, 0x60
+sWigglytuffGfx17_1:
+.incbin "baserom.gba", 0x6BDCB8, 0x60
+sWigglytuffGfx17_2:
+.incbin "baserom.gba", 0x6BDD18, 0x60
+sWigglytuffGfx17_3:
+.incbin "baserom.gba", 0x6BDD78, 0x20
+sWigglytuffSprites17:
+ax_sprite sWigglytuffGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx17_2, 0x60
+ax_sprite 0, 0x60
+ax_sprite sWigglytuffGfx17_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWigglytuffGfx18:
+.incbin "baserom.gba", 0x6BDDE0, 0x60
+sWigglytuffGfx18_1:
+.incbin "baserom.gba", 0x6BDE40, 0x60
+sWigglytuffGfx18_2:
+.incbin "baserom.gba", 0x6BDEA0, 0x40
+sWigglytuffSprites18:
+ax_sprite sWigglytuffGfx18, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx18_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWigglytuffGfx18_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx19:
+.incbin "baserom.gba", 0x6BDF18, 0x60
+sWigglytuffGfx19_1:
+.incbin "baserom.gba", 0x6BDF78, 0x60
+sWigglytuffGfx19_2:
+.incbin "baserom.gba", 0x6BDFD8, 0x60
+sWigglytuffSprites19:
+ax_sprite sWigglytuffGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx20:
+.incbin "baserom.gba", 0x6BE070, 0x60
+sWigglytuffGfx20_1:
+.incbin "baserom.gba", 0x6BE0D0, 0x60
+sWigglytuffGfx20_2:
+.incbin "baserom.gba", 0x6BE130, 0x60
+sWigglytuffSprites20:
+ax_sprite sWigglytuffGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx20_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx21:
+.incbin "baserom.gba", 0x6BE1C8, 0x60
+sWigglytuffGfx21_1:
+.incbin "baserom.gba", 0x6BE228, 0x60
+sWigglytuffGfx21_2:
+.incbin "baserom.gba", 0x6BE288, 0x60
+sWigglytuffGfx21_3:
+.incbin "baserom.gba", 0x6BE2E8, 0x20
+sWigglytuffGfx21_4:
+.incbin "baserom.gba", 0x6BE308, 0x20
+sWigglytuffSprites21:
+ax_sprite sWigglytuffGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx21_3, 0x20
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx21_4, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWigglytuffGfx22:
+.incbin "baserom.gba", 0x6BE380, 0x60
+sWigglytuffGfx22_1:
+.incbin "baserom.gba", 0x6BE3E0, 0x60
+sWigglytuffGfx22_2:
+.incbin "baserom.gba", 0x6BE440, 0x60
+sWigglytuffSprites22:
+ax_sprite sWigglytuffGfx22, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx22_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx23:
+.incbin "baserom.gba", 0x6BE4D8, 0x60
+sWigglytuffGfx23_1:
+.incbin "baserom.gba", 0x6BE538, 0x60
+sWigglytuffGfx23_2:
+.incbin "baserom.gba", 0x6BE598, 0x60
+sWigglytuffGfx23_3:
+.incbin "baserom.gba", 0x6BE5F8, 0x60
+sWigglytuffSprites23:
+ax_sprite sWigglytuffGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx23_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx23_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWigglytuffGfx24:
+.incbin "baserom.gba", 0x6BE6A0, 0x60
+sWigglytuffGfx24_1:
+.incbin "baserom.gba", 0x6BE700, 0x60
+sWigglytuffGfx24_2:
+.incbin "baserom.gba", 0x6BE760, 0x60
+sWigglytuffSprites24:
+ax_sprite 0, 0x80
+ax_sprite sWigglytuffGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWigglytuffGfx25:
+.incbin "baserom.gba", 0x6BE800, 0x40
+sWigglytuffGfx25_1:
+.incbin "baserom.gba", 0x6BE840, 0x60
+sWigglytuffGfx25_2:
+.incbin "baserom.gba", 0x6BE8A0, 0x60
+sWigglytuffGfx25_3:
+.incbin "baserom.gba", 0x6BE900, 0x40
+sWigglytuffSprites25:
+ax_sprite sWigglytuffGfx25, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWigglytuffGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx25_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWigglytuffGfx26:
+.incbin "baserom.gba", 0x6BE988, 0x20
+sWigglytuffGfx26_1:
+.incbin "baserom.gba", 0x6BE9A8, 0x60
+sWigglytuffGfx26_2:
+.incbin "baserom.gba", 0x6BEA08, 0x60
+sWigglytuffGfx26_3:
+.incbin "baserom.gba", 0x6BEA68, 0x40
+sWigglytuffSprites26:
+ax_sprite sWigglytuffGfx26, 0x20
+ax_sprite 0, 0x60
+ax_sprite sWigglytuffGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx26_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx26_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWigglytuffGfx27:
+.incbin "baserom.gba", 0x6BEAF0, 0x60
+sWigglytuffGfx27_1:
+.incbin "baserom.gba", 0x6BEB50, 0x60
+sWigglytuffGfx27_2:
+.incbin "baserom.gba", 0x6BEBB0, 0x60
+sWigglytuffGfx27_3:
+.incbin "baserom.gba", 0x6BEC10, 0x40
+sWigglytuffSprites27:
+ax_sprite sWigglytuffGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx27_3, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWigglytuffGfx28:
+.incbin "baserom.gba", 0x6BEC98, 0x40
+sWigglytuffGfx28_1:
+.incbin "baserom.gba", 0x6BECD8, 0x60
+sWigglytuffGfx28_2:
+.incbin "baserom.gba", 0x6BED38, 0x60
+sWigglytuffSprites28:
+ax_sprite sWigglytuffGfx28, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWigglytuffGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx28_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx29:
+.incbin "baserom.gba", 0x6BEDD0, 0x60
+sWigglytuffGfx29_1:
+.incbin "baserom.gba", 0x6BEE30, 0x60
+sWigglytuffGfx29_2:
+.incbin "baserom.gba", 0x6BEE90, 0x60
+sWigglytuffSprites29:
+ax_sprite sWigglytuffGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx29_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx30:
+.incbin "baserom.gba", 0x6BEF28, 0x60
+sWigglytuffGfx30_1:
+.incbin "baserom.gba", 0x6BEF88, 0x60
+sWigglytuffGfx30_2:
+.incbin "baserom.gba", 0x6BEFE8, 0x60
+sWigglytuffSprites30:
+ax_sprite sWigglytuffGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWigglytuffGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWigglytuffGfx31:
+.incbin "baserom.gba", 0x6BF080, 0x200
+sWigglytuffSprites31:
+ax_sprite sWigglytuffGfx31, 0x200
+ax_sprite_terminator
+sWigglytuffGfx32:
+.incbin "baserom.gba", 0x6BF290, 0x200
+sWigglytuffSprites32:
+ax_sprite sWigglytuffGfx32, 0x200
+ax_sprite_terminator
+sWigglytuffGfx33:
+.incbin "baserom.gba", 0x6BF4A0, 0x200
+sWigglytuffSprites33:
+ax_sprite sWigglytuffGfx33, 0x200
+ax_sprite_terminator
+sWigglytuffGfx34:
+.incbin "baserom.gba", 0x6BF6B0, 0x200
+sWigglytuffSprites34:
+ax_sprite sWigglytuffGfx34, 0x200
+ax_sprite_terminator
+sWigglytuffGfx35:
+.incbin "baserom.gba", 0x6BF8C0, 0x200
+sWigglytuffSprites35:
+ax_sprite sWigglytuffGfx35, 0x200
+ax_sprite_terminator
+sWigglytuffGfx36:
+.incbin "baserom.gba", 0x6BFAD0, 0x200
+sWigglytuffSprites36:
+ax_sprite sWigglytuffGfx36, 0x200
+ax_sprite_terminator
+sWigglytuffGfx37:
+.incbin "baserom.gba", 0x6BFCE0, 0x200
+sWigglytuffSprites37:
+ax_sprite sWigglytuffGfx37, 0x200
+ax_sprite_terminator
+sAxPosesWigglytuff:
+.4byte sWigglytuffPose1
+.4byte sWigglytuffPose2
+.4byte sWigglytuffPose3
+.4byte sWigglytuffPose4
+.4byte sWigglytuffPose5
+.4byte sWigglytuffPose6
+.4byte sWigglytuffPose7
+.4byte sWigglytuffPose8
+.4byte sWigglytuffPose9
+.4byte sWigglytuffPose10
+.4byte sWigglytuffPose11
+.4byte sWigglytuffPose12
+.4byte sWigglytuffPose13
+.4byte sWigglytuffPose14
+.4byte sWigglytuffPose15
+.4byte sWigglytuffPose16
+.4byte sWigglytuffPose17
+.4byte sWigglytuffPose18
+.4byte sWigglytuffPose19
+.4byte sWigglytuffPose20
+.4byte sWigglytuffPose21
+.4byte sWigglytuffPose22
+.4byte sWigglytuffPose23
+.4byte sWigglytuffPose24
+.4byte sWigglytuffPose25
+.4byte sWigglytuffPose26
+.4byte sWigglytuffPose27
+.4byte sWigglytuffPose28
+.4byte sWigglytuffPose29
+.4byte sWigglytuffPose30
+.4byte sWigglytuffPose31
+.4byte sWigglytuffPose32
+.4byte sWigglytuffPose33
+.4byte sWigglytuffPose34
+.4byte sWigglytuffPose35
+.4byte sWigglytuffPose36
+.4byte sWigglytuffPose37
+.4byte sWigglytuffPose38
+.4byte sWigglytuffPose39
+.4byte sWigglytuffPose40
+.4byte sWigglytuffPose41
+.4byte sWigglytuffPose42
+.4byte sWigglytuffPose43
+.4byte sWigglytuffPose44
+.4byte sWigglytuffPose45
+.4byte sWigglytuffPose46
+.4byte sWigglytuffPose47
+.4byte sWigglytuffPose48
+.4byte sWigglytuffPose49
+.4byte sWigglytuffPose50
+.4byte sWigglytuffPose51
+.4byte sWigglytuffPose52
+.4byte sWigglytuffPose53
+.4byte sWigglytuffPose54
+.4byte sWigglytuffPose55
+.4byte sWigglytuffPose56
+.4byte sWigglytuffPose57
+.4byte sWigglytuffPose58
+.4byte sWigglytuffPose59
+.4byte sWigglytuffPose60
+.4byte sWigglytuffPose61
+.4byte sWigglytuffPose62
+.4byte sWigglytuffPose63
+.4byte sWigglytuffPose64
+.4byte sWigglytuffPose65
+.4byte sWigglytuffPose66
+.4byte sWigglytuffPose67
+.4byte sWigglytuffPose68
+.4byte sWigglytuffPose69
+.4byte sWigglytuffPose70
+.4byte sWigglytuffPose71
+.4byte sWigglytuffPose72
+.4byte sWigglytuffPose73
+.4byte sWigglytuffPose74
+.4byte sWigglytuffPose75
+.4byte sWigglytuffPose76
+.4byte sWigglytuffPose77
+.4byte sWigglytuffPose78
+.4byte sWigglytuffPose79
+.4byte sWigglytuffPose80
+.4byte sWigglytuffPose81
+.4byte sWigglytuffPose82
+.4byte sWigglytuffPose83
+.4byte sWigglytuffPose84
+.4byte sWigglytuffPose85
+.4byte sWigglytuffPose86
+.4byte sWigglytuffPose87
+.4byte sWigglytuffPose88
+.4byte sWigglytuffPose89
+.4byte sWigglytuffPose90
+.4byte sWigglytuffPose91
+.4byte sWigglytuffPose92
+.4byte sWigglytuffPose93
+.4byte sWigglytuffPose94
+.4byte sWigglytuffPose95
+.4byte sWigglytuffPose96
+.4byte sWigglytuffPose97
+.4byte sWigglytuffPose98
+.4byte sWigglytuffPose99
+.4byte sWigglytuffPose100
+.4byte sWigglytuffPose101
+.4byte sWigglytuffPose102
+.4byte sWigglytuffPose103
+.4byte sWigglytuffPose104
+.4byte sWigglytuffPose105
+.4byte sWigglytuffPose106
+.4byte sWigglytuffPose107
+.4byte sWigglytuffPose108
+.4byte sWigglytuffPose109
+.4byte sWigglytuffPose110
+.4byte sWigglytuffPose111
+.4byte sWigglytuffPose112
+.4byte sWigglytuffPose113
+.4byte sWigglytuffPose114
+.4byte sWigglytuffPose115
+.4byte sWigglytuffPose116
+.4byte sWigglytuffPose117
+.4byte sWigglytuffPose118
+.4byte sWigglytuffPose119
+.4byte sWigglytuffPose120
+.4byte sWigglytuffPose121
+.4byte sWigglytuffPose122
+.4byte sWigglytuffPose123
+.4byte sWigglytuffPose124
+.4byte sWigglytuffPose125
+.4byte sWigglytuffPose126
+.4byte sWigglytuffPose127
+.4byte sWigglytuffPose128
+.4byte sWigglytuffPose129
+.4byte sWigglytuffPose130
+.4byte sWigglytuffPose131
+.4byte sWigglytuffPose132
+.4byte sWigglytuffPose133
+.4byte sWigglytuffPose134
+.4byte sWigglytuffPose135
+.4byte sWigglytuffPose136
+.4byte sWigglytuffPose137
+.4byte sWigglytuffPose138
+.4byte sWigglytuffPose139
+.4byte sWigglytuffPose140
+.4byte sWigglytuffPose141
+.4byte sWigglytuffPose142
+.4byte sWigglytuffPose143
+.4byte sWigglytuffPose144
+.4byte sWigglytuffPose145
+.4byte sWigglytuffPose146
+.4byte sWigglytuffPose147
+.4byte sWigglytuffPose148
+.4byte sWigglytuffPose149
+.4byte sWigglytuffPose150
+.4byte sWigglytuffPose151
+.4byte sWigglytuffPose152
+.4byte sWigglytuffPose153
+.4byte sWigglytuffPose154
+.4byte sWigglytuffPose155
+.4byte sWigglytuffPose156
+.4byte sWigglytuffPose157
+.4byte sWigglytuffPose158
+.4byte sWigglytuffPose159
+.4byte sWigglytuffPose160
+.4byte sWigglytuffPose161
+.4byte sWigglytuffPose162
+.4byte sWigglytuffPose163
+.4byte sWigglytuffPose164
+.4byte sWigglytuffPose165
+.4byte sWigglytuffPose166
+.4byte sWigglytuffPose167
+.4byte sWigglytuffPose168
+.4byte sWigglytuffPose169
+.4byte sWigglytuffPose170
+.4byte sWigglytuffPose171
+.4byte sWigglytuffPose172
+.4byte sWigglytuffPose173
+.4byte sWigglytuffPose174
+.4byte sWigglytuffPose175
+.4byte sWigglytuffPose176
+.4byte sWigglytuffPose177
+.4byte sWigglytuffPose178
+.4byte sWigglytuffPose179
+.4byte sWigglytuffPose180
+.4byte sWigglytuffPose181
+.4byte sWigglytuffPose182
+.4byte sWigglytuffPose183
+.4byte sWigglytuffPose184
+.4byte sWigglytuffPose185
+.4byte sWigglytuffPose186
+.4byte sWigglytuffPose187
+.4byte sWigglytuffPose188
+.4byte sWigglytuffPose189
+.4byte sWigglytuffPose190
+.4byte sWigglytuffPose191
+.4byte sWigglytuffPose192
+.4byte sWigglytuffPose193
+.4byte sWigglytuffPose194
+.4byte sWigglytuffPose195
+.4byte sWigglytuffPose196
+.4byte sWigglytuffPose197
+.4byte sWigglytuffPose198
+.4byte sWigglytuffPose199
+.4byte sWigglytuffPose200
+.4byte sWigglytuffPose201
+.4byte sWigglytuffPose202
+.4byte sWigglytuffPose203
+.4byte sWigglytuffPose204
+.4byte sWigglytuffPose205
+.4byte sWigglytuffPose206
+.4byte sWigglytuffPose207
+.4byte sWigglytuffPose208
+.4byte sWigglytuffPose209
+.4byte sWigglytuffPose210
+.4byte sWigglytuffPose211
+.4byte sWigglytuffPose212
+.4byte sWigglytuffPose213
+.4byte sWigglytuffPose214
+.4byte sWigglytuffPose215
+.4byte sWigglytuffPose216
+.4byte sWigglytuffPose217
+.4byte sWigglytuffPose218
+.4byte sWigglytuffPose219
+.4byte sWigglytuffPose220
+.4byte sWigglytuffPose221
+.4byte sWigglytuffPose222
+.4byte sWigglytuffPose223
+.4byte sWigglytuffPose224
+.4byte sWigglytuffPose225
+.4byte sWigglytuffPose226
+.4byte sWigglytuffPose227
+.4byte sWigglytuffPose228
+.4byte sWigglytuffPose229
+.4byte sWigglytuffPose230
+.4byte sWigglytuffPose231
+.4byte sWigglytuffPose232
+.4byte sWigglytuffPose233
+.4byte sWigglytuffPose234
+sAxPositionsWigglytuff:
+.2byte   -1,   -7, 	  -9,   -8, 	   8,   -8, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -6, 	   6,   -9, 	  -1,   -7
+.2byte    0,   -6, 	  -7,   -9, 	   8,   -6, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte    4,   -7, 	   5,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    2,   -7, 	   7,   -9, 	  -7,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -7, 	   2,   -6, 	  -1,   -8
+.2byte    5,   -7, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    3,  -12, 	  -6,   -9, 	   4,   -6, 	  -1,  -10
+.2byte    2,  -12, 	  -7,   -7, 	   7,   -7, 	  -1,   -9
+.2byte    4,  -10, 	  -4,  -10, 	   2,   -5, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    1,  -10, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -4,  -12, 	   5,   -9, 	  -5,   -6, 	   0,  -10
+.2byte   -3,  -12, 	   6,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -5,  -10, 	   3,  -10, 	  -3,   -5, 	   0,   -9
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -7,   -9, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -6, 	   0,   -9
+.2byte   -4,   -8, 	  -8,   -8, 	   5,   -6, 	   0,   -9
+.2byte   -5,   -7, 	  -6,   -7, 	   2,   -5, 	   0,   -8
+.2byte   -3,   -7, 	  -8,   -9, 	   6,   -5, 	   0,   -8
+.2byte   -1,   -7, 	  -9,   -8, 	   8,   -8, 	  -1,   -8
+.2byte   -1,   -6, 	  -9,   -6, 	   6,   -9, 	  -1,   -7
+.2byte    0,   -6, 	  -7,   -9, 	   8,   -6, 	   0,   -7
+.2byte    3,   -8, 	   7,   -8, 	  -6,   -6, 	  -1,   -9
+.2byte    4,   -7, 	   5,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    2,   -7, 	   7,   -9, 	  -7,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -7, 	   2,   -6, 	  -1,   -8
+.2byte    5,   -7, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    3,  -12, 	  -6,   -9, 	   4,   -6, 	  -1,  -10
+.2byte    2,  -12, 	  -7,   -7, 	   7,   -7, 	  -1,   -9
+.2byte    4,  -10, 	  -4,  -10, 	   2,   -5, 	  -1,   -9
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    1,  -10, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -4,  -12, 	   5,   -9, 	  -5,   -6, 	   0,  -10
+.2byte   -3,  -12, 	   6,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -5,  -10, 	   3,  -10, 	  -3,   -5, 	   0,   -9
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -7,   -9, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -6, 	   0,   -9
+.2byte   -4,   -8, 	  -8,   -8, 	   5,   -6, 	   0,   -9
+.2byte   -5,   -7, 	  -6,   -7, 	   2,   -5, 	   0,   -8
+.2byte   -3,   -7, 	  -8,   -9, 	   6,   -5, 	   0,   -8
+.2byte   -1,   -6, 	  -9,   -7, 	   8,   -7, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,   -6, 	   6,   -9, 	  -1,   -7
+.2byte    0,   -6, 	  -7,   -9, 	   8,   -6, 	   0,   -7
+.2byte   -1,   -3, 	  -9,   -7, 	   8,   -7, 	  -1,   -8
+.2byte    3,   -7, 	   7,   -7, 	  -6,   -5, 	  -1,   -8
+.2byte    4,   -7, 	   5,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    2,   -7, 	   7,   -9, 	  -7,   -5, 	  -1,   -8
+.2byte    4,   -5, 	   9,   -6, 	  -1,   -5, 	  -1,   -7
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -7, 	   2,   -6, 	  -1,   -8
+.2byte    5,   -7, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    4,   -5, 	   4,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    4,  -12, 	  -5,   -9, 	   5,   -6, 	   0,  -10
+.2byte    2,  -12, 	  -7,   -7, 	   7,   -7, 	  -1,   -9
+.2byte    4,  -10, 	  -4,  -10, 	   2,   -5, 	  -1,   -9
+.2byte    6,  -10, 	  -1,  -14, 	   8,   -9, 	   1,  -10
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    1,  -10, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -1,   -8, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte   -5,  -12, 	   4,   -9, 	  -6,   -6, 	  -1,  -10
+.2byte   -3,  -12, 	   6,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -5,  -10, 	   3,  -10, 	  -3,   -5, 	   0,   -9
+.2byte   -7,  -10, 	   0,  -14, 	  -9,   -9, 	  -2,  -10
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -7,   -9, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -6, 	   0,   -9
+.2byte   -5,   -5, 	  -5,   -7, 	  -3,   -6, 	   0,   -9
+.2byte   -4,   -7, 	  -8,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -5,   -7, 	  -6,   -7, 	   2,   -5, 	   0,   -8
+.2byte   -3,   -7, 	  -8,   -9, 	   6,   -5, 	   0,   -8
+.2byte   -5,   -5, 	 -10,   -6, 	   0,   -5, 	   0,   -7
+.2byte   -1,   -6, 	  -9,   -7, 	   8,   -7, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,   -6, 	   6,   -9, 	  -1,   -7
+.2byte    0,   -6, 	  -7,   -9, 	   8,   -6, 	   0,   -7
+.2byte   -1,   -9, 	  -6,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -4, 	  -6,   -5, 	   5,   -5, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -7, 	  -6,   -5, 	  -1,   -8
+.2byte    4,   -7, 	   5,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    2,   -7, 	   7,   -9, 	  -7,   -5, 	  -1,   -8
+.2byte    6,   -8, 	   9,  -11, 	   0,   -8, 	   1,  -10
+.2byte    3,   -5, 	   7,   -6, 	  -1,   -4, 	  -1,   -7
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -7, 	   2,   -6, 	  -1,   -8
+.2byte    5,   -7, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    8,   -8, 	   6,  -10, 	   5,   -8, 	   2,  -10
+.2byte    6,   -7, 	   5,   -7, 	   3,   -6, 	  -1,   -7
+.2byte    4,  -12, 	  -5,   -9, 	   5,   -6, 	   0,  -10
+.2byte    2,  -12, 	  -7,   -7, 	   7,   -7, 	  -1,   -9
+.2byte    4,  -10, 	  -4,  -10, 	   2,   -5, 	  -1,   -9
+.2byte    6,  -14, 	  -2,  -14, 	   8,  -12, 	   1,  -11
+.2byte    6,  -10, 	  -1,  -10, 	   8,   -7, 	   0,   -9
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    1,  -10, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -1,  -14, 	   6,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte   -1,  -10, 	   6,   -8, 	  -7,   -8, 	  -1,   -9
+.2byte   -5,  -12, 	   4,   -9, 	  -6,   -6, 	  -1,  -10
+.2byte   -3,  -12, 	   6,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -5,  -10, 	   3,  -10, 	  -3,   -5, 	   0,   -9
+.2byte   -7,  -14, 	   1,  -14, 	  -9,  -12, 	  -2,  -11
+.2byte   -7,  -10, 	   0,  -10, 	  -9,   -7, 	  -1,   -9
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -7,   -9, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -6, 	   0,   -9
+.2byte   -9,   -8, 	  -7,  -10, 	  -6,   -8, 	  -3,  -10
+.2byte   -7,   -7, 	  -6,   -7, 	  -4,   -6, 	   0,   -7
+.2byte   -4,   -7, 	  -8,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -5,   -7, 	  -6,   -7, 	   2,   -5, 	   0,   -8
+.2byte   -3,   -7, 	  -8,   -9, 	   6,   -5, 	   0,   -8
+.2byte   -7,   -8, 	 -10,  -11, 	  -1,   -8, 	  -2,  -10
+.2byte   -4,   -5, 	  -8,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -1,   -6, 	  -9,   -7, 	   8,   -7, 	  -1,   -7
+.2byte   -1,   -4, 	  -6,   -5, 	   5,   -5, 	  -1,   -7
+.2byte   -1,   -9, 	  -6,  -10, 	   5,  -10, 	  -1,  -10
+.2byte    3,   -7, 	   7,   -7, 	  -6,   -5, 	  -1,   -8
+.2byte    3,   -5, 	   7,   -6, 	  -1,   -4, 	  -1,   -7
+.2byte    4,   -8, 	   7,  -11, 	  -2,   -8, 	  -1,  -10
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    6,   -7, 	   5,   -7, 	   3,   -6, 	  -1,   -7
+.2byte    6,   -8, 	   4,  -10, 	   3,   -8, 	   0,  -10
+.2byte    4,  -12, 	  -5,   -9, 	   5,   -6, 	   0,  -10
+.2byte    6,  -10, 	  -1,  -10, 	   8,   -7, 	   0,   -9
+.2byte    6,  -14, 	  -2,  -14, 	   8,  -12, 	   1,  -11
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte   -1,  -10, 	   6,   -8, 	  -7,   -8, 	  -1,   -9
+.2byte   -1,  -14, 	   6,  -13, 	  -7,  -13, 	  -1,  -12
+.2byte   -5,  -12, 	   4,   -9, 	  -6,   -6, 	  -1,  -10
+.2byte   -7,  -10, 	   0,  -10, 	  -9,   -7, 	  -1,   -9
+.2byte   -7,  -14, 	   1,  -14, 	  -9,  -12, 	  -2,  -11
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -7,   -7, 	  -6,   -7, 	  -4,   -6, 	   0,   -7
+.2byte   -7,   -8, 	  -5,  -10, 	  -4,   -8, 	  -1,  -10
+.2byte   -4,   -7, 	  -8,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -4,   -5, 	  -8,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -5,   -8, 	  -8,  -11, 	   1,   -8, 	   0,  -10
+.2byte   -2,   -4, 	  -6,   -4, 	   4,   -2, 	   1,   -7
+.2byte   -2,   -3, 	  -6,   -4, 	   4,   -2, 	   1,   -7
+.2byte   -1,   -9, 	  -5,  -10, 	   4,  -10, 	  -1,  -10
+.2byte    1,  -10, 	   5,  -12, 	  -4,  -10, 	  -2,  -10
+.2byte    4,  -11, 	   2,  -12, 	   1,  -10, 	  -3,  -10
+.2byte    4,  -13, 	  -3,  -14, 	   7,  -12, 	   0,  -11
+.2byte   -1,  -12, 	   8,  -12, 	  -9,  -12, 	  -1,   -9
+.2byte   -5,  -13, 	   2,  -14, 	  -8,  -12, 	  -1,  -11
+.2byte   -5,  -11, 	  -3,  -12, 	  -2,  -10, 	   2,  -10
+.2byte   -2,  -10, 	  -6,  -12, 	   3,  -10, 	   1,  -10
+.2byte   -1,   -6, 	  -9,   -7, 	   8,   -7, 	  -1,   -7
+.2byte   -1,   -5, 	  -9,   -5, 	   6,   -8, 	  -1,   -6
+.2byte    0,   -5, 	  -7,   -8, 	   8,   -5, 	   0,   -6
+.2byte    3,   -7, 	   7,   -7, 	  -6,   -5, 	  -1,   -8
+.2byte    4,   -6, 	   5,   -6, 	  -3,   -4, 	  -1,   -7
+.2byte    2,   -6, 	   7,   -8, 	  -7,   -4, 	  -1,   -7
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    6,   -8, 	  -1,   -7, 	   2,   -6, 	  -1,   -8
+.2byte    5,   -7, 	   2,   -7, 	  -3,   -5, 	  -1,   -8
+.2byte    4,  -12, 	  -5,   -9, 	   5,   -6, 	   0,  -10
+.2byte    3,  -12, 	  -6,   -7, 	   8,   -7, 	   0,   -9
+.2byte    5,  -10, 	  -3,  -10, 	   3,   -5, 	   0,   -9
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    1,  -10, 	   6,   -7, 	  -7,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   7,   -7, 	  -8,   -7, 	   0,   -9
+.2byte   -5,  -12, 	   4,   -9, 	  -6,   -6, 	  -1,  -10
+.2byte   -4,  -12, 	   5,   -7, 	  -9,   -7, 	  -1,   -9
+.2byte   -6,  -10, 	   2,  -10, 	  -4,   -5, 	  -1,   -9
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -7,   -9, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -6,   -8, 	  -3,   -8, 	   2,   -6, 	   0,   -9
+.2byte   -4,   -7, 	  -8,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -5,   -6, 	  -6,   -6, 	   2,   -4, 	   0,   -7
+.2byte   -3,   -6, 	  -8,   -8, 	   6,   -4, 	   0,   -7
+.2byte   -1,   -3, 	  -9,   -7, 	   8,   -7, 	  -1,   -8
+.2byte   -4,   -5, 	  -9,   -6, 	   1,   -5, 	   1,   -7
+.2byte   -5,   -5, 	  -5,   -7, 	  -3,   -6, 	   0,   -9
+.2byte   -6,  -10, 	   1,  -14, 	  -8,   -9, 	  -1,  -10
+.2byte   -1,   -8, 	   7,  -10, 	  -9,  -10, 	  -1,   -9
+.2byte    5,  -10, 	  -2,  -14, 	   7,   -9, 	   0,  -10
+.2byte    4,   -5, 	   4,   -7, 	   2,   -6, 	  -1,   -9
+.2byte    3,   -5, 	   8,   -6, 	  -2,   -5, 	  -2,   -7
+.2byte   -1,   -9, 	  -6,  -10, 	   5,  -10, 	  -1,  -10
+.2byte    4,   -8, 	   7,  -11, 	  -2,   -8, 	  -1,  -10
+.2byte    7,   -8, 	   5,  -10, 	   4,   -8, 	   1,  -10
+.2byte    5,  -14, 	  -3,  -14, 	   7,  -12, 	   0,  -11
+.2byte   -1,  -13, 	   6,  -12, 	  -7,  -12, 	  -1,  -11
+.2byte   -6,  -14, 	   2,  -14, 	  -8,  -12, 	  -1,  -11
+.2byte   -8,   -8, 	  -6,  -10, 	  -5,   -8, 	  -2,  -10
+.2byte   -5,   -8, 	  -8,  -11, 	   1,   -8, 	   0,  -10
+.2byte   -1,   -6, 	  -9,   -7, 	   8,   -7, 	  -1,   -7
+.2byte   -1,   -9, 	  -6,  -10, 	   5,  -10, 	  -1,  -10
+.2byte   -1,   -4, 	  -6,   -5, 	   5,   -5, 	  -1,   -7
+.2byte    3,   -7, 	   7,   -7, 	  -6,   -5, 	  -1,   -8
+.2byte    4,   -8, 	   7,  -11, 	  -2,   -8, 	  -1,  -10
+.2byte    3,   -5, 	   7,   -6, 	  -1,   -4, 	  -1,   -7
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    6,   -8, 	   4,  -10, 	   3,   -8, 	   0,  -10
+.2byte    6,   -7, 	   5,   -7, 	   3,   -6, 	  -1,   -7
+.2byte    4,  -12, 	  -5,   -9, 	   5,   -6, 	   0,  -10
+.2byte    5,  -13, 	  -3,  -13, 	   7,  -11, 	   0,  -10
+.2byte    6,  -10, 	  -1,  -10, 	   8,   -7, 	   0,   -9
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte   -1,  -12, 	   6,  -11, 	  -7,  -11, 	  -1,  -10
+.2byte   -1,  -10, 	   6,   -8, 	  -7,   -8, 	  -1,   -9
+.2byte   -5,  -12, 	   4,   -9, 	  -6,   -6, 	  -1,  -10
+.2byte   -6,  -13, 	   2,  -13, 	  -8,  -11, 	  -1,  -10
+.2byte   -7,  -10, 	   0,  -10, 	  -9,   -7, 	  -1,   -9
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -7,   -8, 	  -5,  -10, 	  -4,   -8, 	  -1,  -10
+.2byte   -7,   -7, 	  -6,   -7, 	  -4,   -6, 	   0,   -7
+.2byte   -4,   -7, 	  -8,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -5,   -8, 	  -8,  -11, 	   1,   -8, 	   0,  -10
+.2byte   -4,   -5, 	  -8,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -1,   -4, 	  -6,   -5, 	   5,   -5, 	  -1,   -7
+.2byte   -4,   -5, 	  -8,   -6, 	   0,   -4, 	   0,   -7
+.2byte   -7,   -7, 	  -6,   -7, 	  -4,   -6, 	   0,   -7
+.2byte   -6,  -10, 	   1,  -10, 	  -8,   -7, 	   0,   -9
+.2byte   -1,  -10, 	   6,   -8, 	  -7,   -8, 	  -1,   -9
+.2byte    5,  -10, 	  -2,  -10, 	   7,   -7, 	  -1,   -9
+.2byte    6,   -7, 	   5,   -7, 	   3,   -6, 	  -1,   -7
+.2byte    3,   -5, 	   7,   -6, 	  -1,   -4, 	  -1,   -7
+.2byte   -1,   -6, 	  -9,   -7, 	   8,   -7, 	  -1,   -7
+.2byte   -4,   -7, 	  -8,   -7, 	   5,   -5, 	   0,   -8
+.2byte   -7,   -8, 	   0,   -6, 	   1,   -5, 	   0,   -8
+.2byte   -5,  -12, 	   4,   -9, 	  -6,   -6, 	  -1,  -10
+.2byte   -1,  -11, 	   8,   -8, 	  -9,   -8, 	  -1,   -9
+.2byte    4,  -12, 	  -5,   -9, 	   5,   -6, 	   0,  -10
+.2byte    6,   -8, 	  -1,   -6, 	  -2,   -5, 	  -1,   -8
+.2byte    3,   -7, 	   7,   -7, 	  -6,   -5, 	  -1,   -8
+sWigglytuffAnimTable1:
+.4byte sWigglytuffAnims_1_1
+.4byte sWigglytuffAnims_1_2
+.4byte sWigglytuffAnims_1_3
+.4byte sWigglytuffAnims_1_4
+.4byte sWigglytuffAnims_1_5
+.4byte sWigglytuffAnims_1_6
+.4byte sWigglytuffAnims_1_7
+.4byte sWigglytuffAnims_1_8
+sWigglytuffAnimTable2:
+.4byte sWigglytuffAnims_2_1
+.4byte sWigglytuffAnims_2_2
+.4byte sWigglytuffAnims_2_3
+.4byte sWigglytuffAnims_2_4
+.4byte sWigglytuffAnims_2_5
+.4byte sWigglytuffAnims_2_6
+.4byte sWigglytuffAnims_2_7
+.4byte sWigglytuffAnims_2_8
+sWigglytuffAnimTable3:
+.4byte sWigglytuffAnims_3_1
+.4byte sWigglytuffAnims_3_2
+.4byte sWigglytuffAnims_3_3
+.4byte sWigglytuffAnims_3_4
+.4byte sWigglytuffAnims_3_5
+.4byte sWigglytuffAnims_3_6
+.4byte sWigglytuffAnims_3_7
+.4byte sWigglytuffAnims_3_8
+sWigglytuffAnimTable4:
+.4byte sWigglytuffAnims_4_1
+.4byte sWigglytuffAnims_4_2
+.4byte sWigglytuffAnims_4_3
+.4byte sWigglytuffAnims_4_4
+.4byte sWigglytuffAnims_4_5
+.4byte sWigglytuffAnims_4_6
+.4byte sWigglytuffAnims_4_7
+.4byte sWigglytuffAnims_4_8
+sWigglytuffAnimTable5:
+.4byte sWigglytuffAnims_5_1
+.4byte sWigglytuffAnims_5_2
+.4byte sWigglytuffAnims_5_3
+.4byte sWigglytuffAnims_5_4
+.4byte sWigglytuffAnims_5_5
+.4byte sWigglytuffAnims_5_6
+.4byte sWigglytuffAnims_5_7
+.4byte sWigglytuffAnims_5_8
+sWigglytuffAnimTable6:
+.4byte sWigglytuffAnims_6_1
+.4byte sWigglytuffAnims_6_1
+.4byte sWigglytuffAnims_6_1
+.4byte sWigglytuffAnims_6_1
+.4byte sWigglytuffAnims_6_1
+.4byte sWigglytuffAnims_6_1
+.4byte sWigglytuffAnims_6_1
+.4byte sWigglytuffAnims_6_1
+sWigglytuffAnimTable7:
+.4byte sWigglytuffAnims_7_1
+.4byte sWigglytuffAnims_7_2
+.4byte sWigglytuffAnims_7_3
+.4byte sWigglytuffAnims_7_4
+.4byte sWigglytuffAnims_7_5
+.4byte sWigglytuffAnims_7_6
+.4byte sWigglytuffAnims_7_7
+.4byte sWigglytuffAnims_7_8
+sWigglytuffAnimTable8:
+.4byte sWigglytuffAnims_8_1
+.4byte sWigglytuffAnims_8_2
+.4byte sWigglytuffAnims_8_3
+.4byte sWigglytuffAnims_8_4
+.4byte sWigglytuffAnims_8_5
+.4byte sWigglytuffAnims_8_6
+.4byte sWigglytuffAnims_8_7
+.4byte sWigglytuffAnims_8_8
+sWigglytuffAnimTable9:
+.4byte sWigglytuffAnims_9_1
+.4byte sWigglytuffAnims_9_2
+.4byte sWigglytuffAnims_9_3
+.4byte sWigglytuffAnims_9_4
+.4byte sWigglytuffAnims_9_5
+.4byte sWigglytuffAnims_9_6
+.4byte sWigglytuffAnims_9_7
+.4byte sWigglytuffAnims_9_8
+sWigglytuffAnimTable10:
+.4byte sWigglytuffAnims_10_1
+.4byte sWigglytuffAnims_10_2
+.4byte sWigglytuffAnims_10_3
+.4byte sWigglytuffAnims_10_4
+.4byte sWigglytuffAnims_10_5
+.4byte sWigglytuffAnims_10_6
+.4byte sWigglytuffAnims_10_7
+.4byte sWigglytuffAnims_10_8
+sWigglytuffAnimTable11:
+.4byte sWigglytuffAnims_11_1
+.4byte sWigglytuffAnims_11_2
+.4byte sWigglytuffAnims_11_3
+.4byte sWigglytuffAnims_11_4
+.4byte sWigglytuffAnims_11_5
+.4byte sWigglytuffAnims_11_6
+.4byte sWigglytuffAnims_11_7
+.4byte sWigglytuffAnims_11_8
+sWigglytuffAnimTable12:
+.4byte sWigglytuffAnims_12_1
+.4byte sWigglytuffAnims_12_2
+.4byte sWigglytuffAnims_12_3
+.4byte sWigglytuffAnims_12_4
+.4byte sWigglytuffAnims_12_5
+.4byte sWigglytuffAnims_12_6
+.4byte sWigglytuffAnims_12_7
+.4byte sWigglytuffAnims_12_8
+sWigglytuffAnimTable13:
+.4byte sWigglytuffAnims_13_1
+.4byte sWigglytuffAnims_13_2
+.4byte sWigglytuffAnims_13_3
+.4byte sWigglytuffAnims_13_4
+.4byte sWigglytuffAnims_13_5
+.4byte sWigglytuffAnims_13_6
+.4byte sWigglytuffAnims_13_7
+.4byte sWigglytuffAnims_13_8
+sAxAnimationsWigglytuff:
+.4byte sWigglytuffAnimTable1
+.4byte sWigglytuffAnimTable2
+.4byte sWigglytuffAnimTable3
+.4byte sWigglytuffAnimTable4
+.4byte sWigglytuffAnimTable5
+.4byte sWigglytuffAnimTable6
+.4byte sWigglytuffAnimTable7
+.4byte sWigglytuffAnimTable8
+.4byte sWigglytuffAnimTable9
+.4byte sWigglytuffAnimTable10
+.4byte sWigglytuffAnimTable11
+.4byte sWigglytuffAnimTable12
+.4byte sWigglytuffAnimTable13
+sAxSpritesWigglytuff:
+.4byte sWigglytuffSprites1
+.4byte sWigglytuffSprites2
+.4byte sWigglytuffSprites3
+.4byte sWigglytuffSprites4
+.4byte sWigglytuffSprites5
+.4byte sWigglytuffSprites6
+.4byte sWigglytuffSprites7
+.4byte sWigglytuffSprites8
+.4byte sWigglytuffSprites9
+.4byte sWigglytuffSprites10
+.4byte sWigglytuffSprites11
+.4byte sWigglytuffSprites12
+.4byte sWigglytuffSprites13
+.4byte sWigglytuffSprites14
+.4byte sWigglytuffSprites15
+.4byte sWigglytuffSprites16
+.4byte sWigglytuffSprites17
+.4byte sWigglytuffSprites18
+.4byte sWigglytuffSprites19
+.4byte sWigglytuffSprites20
+.4byte sWigglytuffSprites21
+.4byte sWigglytuffSprites22
+.4byte sWigglytuffSprites23
+.4byte sWigglytuffSprites24
+.4byte sWigglytuffSprites25
+.4byte sWigglytuffSprites26
+.4byte sWigglytuffSprites27
+.4byte sWigglytuffSprites28
+.4byte sWigglytuffSprites29
+.4byte sWigglytuffSprites30
+.4byte sWigglytuffSprites31
+.4byte sWigglytuffSprites32
+.4byte sWigglytuffSprites33
+.4byte sWigglytuffSprites34
+.4byte sWigglytuffSprites35
+.4byte sWigglytuffSprites36
+.4byte sWigglytuffSprites37
+sAxMainWigglytuff:
+ax_main sAxPosesWigglytuff, sAxAnimationsWigglytuff, 13, sAxSpritesWigglytuff, sAxPositionsWigglytuff

--- a/data/ax/wingull.inc
+++ b/data/ax/wingull.inc
@@ -1,0 +1,2731 @@
+.global gAxWingull
+gAxWingull:
+ax_siro sAxMainWingull
+sWingullPose1:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose2:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose3:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose4:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sWingullPose5:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose6:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose7:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose8:
+ax_pose 7, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose9:
+ax_pose 8, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose10:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose11:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose12:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose13:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose14:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose15:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose16:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose17:
+ax_pose 10, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose18:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose19:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose20:
+ax_pose 7, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose21:
+ax_pose 8, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose22:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose23:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose24:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose25:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose26:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose27:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose28:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sWingullPose29:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose30:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose31:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose32:
+ax_pose 7, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose33:
+ax_pose 8, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose34:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose35:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose36:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose37:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose38:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose39:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose40:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose41:
+ax_pose 10, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose42:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose43:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose44:
+ax_pose 7, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose45:
+ax_pose 8, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose46:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose47:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose48:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose49:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose50:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose51:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose52:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sWingullPose53:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose54:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose55:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose56:
+ax_pose 7, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose57:
+ax_pose 8, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose58:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose59:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose60:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose61:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose62:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose63:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose64:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose65:
+ax_pose 10, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose66:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose67:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose68:
+ax_pose 7, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose69:
+ax_pose 8, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose70:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose71:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose72:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose73:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose74:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose75:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose76:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose77:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sWingullPose78:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose79:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose80:
+ax_pose 16, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose81:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose82:
+ax_pose 7, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose83:
+ax_pose 8, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose84:
+ax_pose 17, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sWingullPose85:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose86:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose87:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose88:
+ax_pose 18, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose89:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose90:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose91:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose92:
+ax_pose 19, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose93:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose94:
+ax_pose 10, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose95:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose96:
+ax_pose 18, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose97:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose98:
+ax_pose 7, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose99:
+ax_pose 8, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose100:
+ax_pose 17, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sWingullPose101:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose102:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose103:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose104:
+ax_pose 16, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose105:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose106:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose107:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose108:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sWingullPose109:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose110:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose111:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose112:
+ax_pose 7, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose113:
+ax_pose 8, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose114:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose115:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose116:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose117:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose118:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose119:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose120:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose121:
+ax_pose 10, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose122:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose123:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose124:
+ax_pose 7, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose125:
+ax_pose 8, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose126:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose127:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose128:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose129:
+ax_pose 20, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sWingullPose130:
+ax_pose 21, 0x01f0, 0x80f5, 0x5c00
+ax_pose_terminator
+sWingullPose131:
+ax_pose 22, 0x01db, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose132:
+ax_pose 23, 0x01de, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose133:
+ax_pose 24, 0x01e2, 0x90eb, 0x5c00
+ax_pose_terminator
+sWingullPose134:
+ax_pose 25, 0x01e4, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose135:
+ax_pose 26, 0x01de, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose136:
+ax_pose 25, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose137:
+ax_pose 24, 0x01e2, 0x80f5, 0x5c00
+ax_pose_terminator
+sWingullPose138:
+ax_pose 23, 0x01de, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose139:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose140:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose141:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose142:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sWingullPose143:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose144:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose145:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose146:
+ax_pose 7, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose147:
+ax_pose 8, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose148:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose149:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose150:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose151:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose152:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose153:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose154:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose155:
+ax_pose 10, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose156:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose157:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose158:
+ax_pose 7, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose159:
+ax_pose 8, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose160:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose161:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose162:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose163:
+ax_pose 15, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose164:
+ax_pose 16, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose165:
+ax_pose 17, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sWingullPose166:
+ax_pose 18, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose167:
+ax_pose 19, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose168:
+ax_pose 18, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose169:
+ax_pose 17, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sWingullPose170:
+ax_pose 16, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose171:
+ax_pose 15, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose172:
+ax_pose 16, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose173:
+ax_pose 17, 0x01e6, 0x90f1, 0x5c00
+ax_pose_terminator
+sWingullPose174:
+ax_pose 18, 0x01e6, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose175:
+ax_pose 19, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose176:
+ax_pose 18, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose177:
+ax_pose 17, 0x01e6, 0x80ef, 0x5c00
+ax_pose_terminator
+sWingullPose178:
+ax_pose 16, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose179:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose180:
+ax_pose 1, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose181:
+ax_pose 2, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose182:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+sWingullPose183:
+ax_pose 4, 0x01e6, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose184:
+ax_pose 5, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWingullPose185:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose186:
+ax_pose 7, 0x01e6, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose187:
+ax_pose 8, 0x01ea, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose188:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose189:
+ax_pose 10, 0x01e6, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose190:
+ax_pose 11, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose191:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose192:
+ax_pose 13, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose193:
+ax_pose 14, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose194:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose195:
+ax_pose 10, 0x01e6, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose196:
+ax_pose 11, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose197:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose198:
+ax_pose 7, 0x01e6, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose199:
+ax_pose 8, 0x01ea, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose200:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose201:
+ax_pose 4, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose202:
+ax_pose 5, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWingullPose203:
+ax_pose 15, 0x01e2, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose204:
+ax_pose 16, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose205:
+ax_pose 17, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sWingullPose206:
+ax_pose 18, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sWingullPose207:
+ax_pose 19, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose208:
+ax_pose 18, 0x01e7, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose209:
+ax_pose 17, 0x01e6, 0x90f2, 0x5c00
+ax_pose_terminator
+sWingullPose210:
+ax_pose 16, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sWingullPose211:
+ax_pose 0, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose212:
+ax_pose 3, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose213:
+ax_pose 6, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWingullPose214:
+ax_pose 9, 0x01e8, 0x80f3, 0x5c00
+ax_pose_terminator
+sWingullPose215:
+ax_pose 12, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWingullPose216:
+ax_pose 9, 0x01e8, 0x90ed, 0x5c00
+ax_pose_terminator
+sWingullPose217:
+ax_pose 6, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWingullPose218:
+ax_pose 3, 0x01e6, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sWingullAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, -1, 0, 0,
+ax_anim_terminator
+sWingullAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 1, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, -1, 0, 0,
+ax_anim_terminator
+sWingullAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sWingullAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 1, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, -1, 0, 0,
+ax_anim_terminator
+sWingullAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sWingullAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 1, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, -1, 0, 0,
+ax_anim_terminator
+sWingullAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sWingullAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 1, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 2, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -3, 0, -3,
+ax_anim 4, 0, 24, 0, -4, 0, -4,
+ax_anim 4, 0, 25, 0, -4, 0, -4,
+ax_anim 1, 2, 24, 0, 1, 0, 1,
+ax_anim 1, 0, 24, 0, 8, 0, 6,
+ax_anim 2, 0, 24, 0, 25, 0, 22,
+ax_anim 2, 0, 24, 1, 25, 1, 22,
+ax_anim 2, 1, 24, 0, 25, 0, 22,
+ax_anim 2, 0, 24, 1, 25, 1, 22,
+ax_anim 2, 0, 24, 0, 25, 0, 22,
+ax_anim 2, 0, 25, 0, 13, 0, 12,
+ax_anim 2, 0, 25, 0, 7, 0, 7,
+ax_anim_terminator
+sWingullAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 2, 0, 27, -2, -3, -2, -2,
+ax_anim 2, 0, 29, -3, -5, -3, -3,
+ax_anim 4, 0, 27, -4, -7, -4, -4,
+ax_anim 4, 0, 28, -4, -7, -4, -4,
+ax_anim 1, 2, 27, 1, 2, 1, 1,
+ax_anim 1, 0, 27, 8, 11, 8, 9,
+ax_anim 2, 0, 27, 19, 25, 19, 21,
+ax_anim 2, 0, 27, 20, 25, 20, 21,
+ax_anim 2, 1, 27, 19, 25, 19, 21,
+ax_anim 2, 0, 27, 20, 25, 20, 21,
+ax_anim 2, 0, 27, 19, 25, 19, 21,
+ax_anim 2, 0, 28, 11, 15, 11, 13,
+ax_anim 2, 0, 28, 5, 8, 5, 6,
+ax_anim_terminator
+sWingullAnims_2_3:
+ax_anim 2, 0, 31, -1, -1, -1, 0,
+ax_anim 2, 0, 30, -2, -2, -2, 0,
+ax_anim 2, 0, 32, -3, -3, -3, 0,
+ax_anim 4, 0, 30, -4, -4, -4, 0,
+ax_anim 4, 0, 31, -4, -4, -4, 0,
+ax_anim 1, 2, 30, 1, 0, 1, 0,
+ax_anim 1, 0, 30, 8, 2, 8, 0,
+ax_anim 2, 0, 30, 16, 4, 16, 0,
+ax_anim 2, 0, 30, 16, 3, 16, -1,
+ax_anim 2, 1, 30, 16, 4, 16, 0,
+ax_anim 2, 0, 30, 16, 3, 16, -1,
+ax_anim 2, 0, 30, 16, 4, 16, 0,
+ax_anim 2, 0, 31, 11, 3, 11, 0,
+ax_anim 2, 0, 31, 5, 0, 5, 0,
+ax_anim_terminator
+sWingullAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 2, 0, 33, -2, 1, -2, 2,
+ax_anim 2, 0, 35, -3, 1, -3, 3,
+ax_anim 4, 0, 33, -4, 1, -4, 4,
+ax_anim 4, 0, 34, -4, 1, -4, 4,
+ax_anim 1, 2, 33, 1, -2, 1, -2,
+ax_anim 1, 0, 33, 8, -8, 8, -10,
+ax_anim 2, 0, 33, 18, -17, 18, -22,
+ax_anim 2, 0, 33, 17, -18, 17, -23,
+ax_anim 2, 1, 33, 18, -17, 18, -22,
+ax_anim 2, 0, 33, 17, -18, 17, -23,
+ax_anim 2, 0, 33, 18, -17, 18, -22,
+ax_anim 2, 0, 34, 11, -10, 11, -14,
+ax_anim 2, 0, 34, 5, -5, 5, -7,
+ax_anim_terminator
+sWingullAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 2, 0, 36, 0, 2, 0, 3,
+ax_anim 2, 0, 38, 0, 3, 0, 5,
+ax_anim 4, 0, 36, 0, 4, 0, 7,
+ax_anim 4, 0, 37, 0, 4, 0, 7,
+ax_anim 1, 2, 36, 0, -2, 0, -2,
+ax_anim 1, 0, 36, 0, -8, 0, -10,
+ax_anim 2, 0, 36, 0, -17, 0, -20,
+ax_anim 2, 0, 36, 1, -17, 1, -20,
+ax_anim 2, 1, 36, 0, -17, 0, -20,
+ax_anim 2, 0, 36, 1, -17, 1, -20,
+ax_anim 2, 0, 36, 0, -17, 0, -20,
+ax_anim 2, 0, 37, 0, -10, 0, -11,
+ax_anim 2, 0, 37, 0, -5, 0, -5,
+ax_anim_terminator
+sWingullAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 2, 0, 39, 2, 1, 2, 2,
+ax_anim 2, 0, 41, 3, 1, 3, 3,
+ax_anim 4, 0, 39, 4, 1, 4, 4,
+ax_anim 4, 0, 40, 4, 1, 4, 4,
+ax_anim 1, 2, 39, -1, -2, -1, -2,
+ax_anim 1, 0, 39, -8, -8, -8, -10,
+ax_anim 2, 0, 39, -18, -17, -18, -22,
+ax_anim 2, 0, 39, -17, -18, -17, -23,
+ax_anim 2, 1, 39, -18, -17, -18, -22,
+ax_anim 2, 0, 39, -17, -18, -17, -23,
+ax_anim 2, 0, 39, -18, -17, -18, -22,
+ax_anim 2, 0, 40, -11, -10, -11, -14,
+ax_anim 2, 0, 40, -5, -5, -5, -7,
+ax_anim_terminator
+sWingullAnims_2_7:
+ax_anim 2, 0, 43, 1, -1, 1, 0,
+ax_anim 2, 0, 42, 2, -2, 2, 0,
+ax_anim 2, 0, 44, 3, -3, 3, 0,
+ax_anim 4, 0, 42, 4, -4, 4, 0,
+ax_anim 4, 0, 43, 4, -4, 4, 0,
+ax_anim 1, 2, 42, -1, 0, -1, 0,
+ax_anim 1, 0, 42, -8, 2, -8, 0,
+ax_anim 2, 0, 42, -16, 4, -16, 0,
+ax_anim 2, 0, 42, -16, 3, -16, -1,
+ax_anim 2, 1, 42, -16, 4, -16, 0,
+ax_anim 2, 0, 42, -16, 3, -16, -1,
+ax_anim 2, 0, 42, -16, 4, -16, 0,
+ax_anim 2, 0, 43, -11, 3, -11, 0,
+ax_anim 2, 0, 43, -5, 0, -5, 0,
+ax_anim_terminator
+sWingullAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 2, 0, 45, 2, -3, 2, -2,
+ax_anim 2, 0, 47, 3, -5, 3, -3,
+ax_anim 4, 0, 45, 4, -7, 4, -4,
+ax_anim 4, 0, 46, 4, -7, 4, -4,
+ax_anim 1, 2, 45, -1, 2, -1, 1,
+ax_anim 1, 0, 45, -8, 11, -8, 9,
+ax_anim 2, 0, 45, -19, 25, -19, 21,
+ax_anim 2, 0, 45, -20, 25, -20, 21,
+ax_anim 2, 1, 45, -19, 25, -19, 21,
+ax_anim 2, 0, 45, -20, 25, -20, 21,
+ax_anim 2, 0, 45, -19, 25, -19, 21,
+ax_anim 2, 0, 46, -11, 15, -11, 13,
+ax_anim 2, 0, 46, -5, 8, -5, 6,
+ax_anim_terminator
+.align 2
+sWingullAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 2, 0, 48, 0, -2, 0, -2,
+ax_anim 2, 0, 50, 0, -3, 0, -3,
+ax_anim 4, 0, 48, 0, -4, 0, -4,
+ax_anim 4, 0, 49, 0, -4, 0, -4,
+ax_anim 1, 2, 48, 0, 1, 0, 1,
+ax_anim 1, 0, 48, 0, 16, 0, 14,
+ax_anim 2, 0, 48, 0, 41, 0, 38,
+ax_anim 2, 0, 48, 1, 49, 1, 46,
+ax_anim 2, 1, 48, 0, 49, 0, 46,
+ax_anim 2, 0, 48, 1, 49, 1, 46,
+ax_anim 2, 0, 48, 0, 49, 0, 46,
+ax_anim 2, 0, 49, 0, 13, 0, 12,
+ax_anim 2, 0, 49, 0, 7, 0, 7,
+ax_anim_terminator
+sWingullAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 2, 0, 51, -2, -3, -2, -2,
+ax_anim 2, 0, 53, -3, -5, -3, -3,
+ax_anim 4, 0, 51, -4, -7, -4, -4,
+ax_anim 4, 0, 52, -4, -7, -4, -4,
+ax_anim 1, 2, 51, 1, 2, 1, 1,
+ax_anim 1, 0, 51, 16, 19, 16, 17,
+ax_anim 2, 0, 51, 35, 41, 35, 37,
+ax_anim 2, 0, 51, 44, 49, 44, 45,
+ax_anim 2, 1, 51, 43, 49, 43, 45,
+ax_anim 2, 0, 51, 44, 49, 44, 45,
+ax_anim 2, 0, 51, 43, 49, 43, 45,
+ax_anim 2, 0, 52, 11, 15, 11, 13,
+ax_anim 2, 0, 52, 5, 8, 5, 6,
+ax_anim_terminator
+sWingullAnims_3_3:
+ax_anim 2, 0, 55, -1, -1, -1, 0,
+ax_anim 2, 0, 54, -2, -2, -2, 0,
+ax_anim 2, 0, 56, -3, -3, -3, 0,
+ax_anim 4, 0, 54, -4, -4, -4, 0,
+ax_anim 4, 0, 55, -4, -4, -4, 0,
+ax_anim 1, 2, 54, 1, 0, 1, 0,
+ax_anim 1, 0, 54, 16, 2, 16, 0,
+ax_anim 2, 0, 54, 32, 4, 32, 0,
+ax_anim 2, 0, 54, 40, 3, 40, -1,
+ax_anim 2, 1, 54, 40, 4, 40, 0,
+ax_anim 2, 0, 54, 40, 3, 40, -1,
+ax_anim 2, 0, 54, 40, 4, 40, 0,
+ax_anim 2, 0, 55, 11, 3, 11, 0,
+ax_anim 2, 0, 55, 5, 0, 5, 0,
+ax_anim_terminator
+sWingullAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 2, 0, 57, -2, 1, -2, 2,
+ax_anim 2, 0, 59, -3, 1, -3, 3,
+ax_anim 4, 0, 57, -4, 1, -4, 4,
+ax_anim 4, 0, 58, -4, 1, -4, 4,
+ax_anim 1, 2, 57, 1, -2, 1, -2,
+ax_anim 1, 0, 57, 16, -16, 16, -18,
+ax_anim 2, 0, 57, 34, -33, 34, -38,
+ax_anim 2, 0, 57, 41, -42, 41, -47,
+ax_anim 2, 1, 57, 42, -41, 42, -46,
+ax_anim 2, 0, 57, 41, -42, 41, -47,
+ax_anim 2, 0, 57, 42, -41, 42, -46,
+ax_anim 2, 0, 58, 11, -10, 11, -14,
+ax_anim 2, 0, 58, 5, -5, 5, -7,
+ax_anim_terminator
+sWingullAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 2, 0, 60, 0, 2, 0, 3,
+ax_anim 2, 0, 62, 0, 3, 0, 5,
+ax_anim 4, 0, 60, 0, 4, 0, 7,
+ax_anim 4, 0, 61, 0, 4, 0, 7,
+ax_anim 1, 2, 60, 0, -2, 0, -2,
+ax_anim 1, 0, 60, 0, -16, 0, -18,
+ax_anim 2, 0, 60, 0, -33, 0, -36,
+ax_anim 2, 0, 60, 1, -41, 1, -44,
+ax_anim 2, 1, 60, 0, -41, 0, -44,
+ax_anim 2, 0, 60, 1, -41, 1, -44,
+ax_anim 2, 0, 60, 0, -41, 0, -44,
+ax_anim 2, 0, 61, 0, -10, 0, -11,
+ax_anim 2, 0, 61, 0, -5, 0, -5,
+ax_anim_terminator
+sWingullAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 2, 0, 63, 2, 1, 2, 2,
+ax_anim 2, 0, 65, 3, 1, 3, 3,
+ax_anim 4, 0, 63, 4, 1, 4, 4,
+ax_anim 4, 0, 64, 4, 1, 4, 4,
+ax_anim 1, 2, 63, -1, -2, -1, -2,
+ax_anim 1, 0, 63, -16, -16, -16, -18,
+ax_anim 2, 0, 63, -34, -33, -34, -38,
+ax_anim 2, 0, 63, -41, -42, -41, -47,
+ax_anim 2, 1, 63, -42, -41, -42, -46,
+ax_anim 2, 0, 63, -41, -42, -41, -47,
+ax_anim 2, 0, 63, -42, -41, -42, -46,
+ax_anim 2, 0, 64, -11, -10, -11, -14,
+ax_anim 2, 0, 64, -5, -5, -5, -7,
+ax_anim_terminator
+sWingullAnims_3_7:
+ax_anim 2, 0, 67, 1, -1, 1, 0,
+ax_anim 2, 0, 66, 2, -2, 2, 0,
+ax_anim 2, 0, 68, 3, -3, 3, 0,
+ax_anim 4, 0, 66, 4, -4, 4, 0,
+ax_anim 4, 0, 67, 4, -4, 4, 0,
+ax_anim 1, 2, 66, -1, 0, -1, 0,
+ax_anim 1, 0, 66, -16, 2, -16, 0,
+ax_anim 2, 0, 66, -32, 4, -32, 0,
+ax_anim 2, 0, 66, -40, 3, -40, -1,
+ax_anim 2, 1, 66, -40, 4, -40, 0,
+ax_anim 2, 0, 66, -40, 3, -40, -1,
+ax_anim 2, 0, 66, -40, 4, -40, 0,
+ax_anim 2, 0, 67, -11, 3, -11, 0,
+ax_anim 2, 0, 67, -5, 0, -5, 0,
+ax_anim_terminator
+sWingullAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 2, 0, 69, 2, -3, 2, -2,
+ax_anim 2, 0, 71, 3, -5, 3, -3,
+ax_anim 4, 0, 69, 4, -7, 4, -4,
+ax_anim 4, 0, 70, 4, -7, 4, -4,
+ax_anim 1, 2, 69, -1, 2, -1, 1,
+ax_anim 1, 0, 69, -16, 19, -16, 17,
+ax_anim 2, 0, 69, -35, 41, -35, 37,
+ax_anim 2, 0, 69, -44, 49, -44, 45,
+ax_anim 2, 1, 69, -43, 49, -43, 45,
+ax_anim 2, 0, 69, -44, 49, -44, 45,
+ax_anim 2, 0, 69, -43, 49, -43, 45,
+ax_anim 2, 0, 70, -11, 15, -11, 13,
+ax_anim 2, 0, 70, -5, 8, -5, 6,
+ax_anim_terminator
+.align 2
+sWingullAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, 0,
+ax_anim 2, 0, 74, 0, -3, 0, 0,
+ax_anim 2, 0, 72, 0, -4, 0, 0,
+ax_anim 2, 0, 73, 0, -4, 0, 0,
+ax_anim 2, 0, 72, 0, -4, 0, 0,
+ax_anim 2, 2, 74, 0, -4, 0, 0,
+ax_anim 2, 0, 72, 0, -4, 0, 0,
+ax_anim 1, 0, 75, 0, -2, 0, -2,
+ax_anim 1, 0, 75, 0, 3, 0, 3,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 1, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 75, 0, 5, 0, 5,
+ax_anim 2, 0, 75, 1, 5, 1, 5,
+ax_anim 2, 0, 72, 0, 2, 0, 2,
+ax_anim_terminator
+sWingullAnims_4_2:
+ax_anim 2, 0, 77, 0, -2, 0, 0,
+ax_anim 2, 0, 78, 0, -3, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 0, 77, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 2, 2, 78, 0, -4, 0, 0,
+ax_anim 2, 0, 76, 0, -4, 0, 0,
+ax_anim 1, 0, 79, 2, 2, 2, 2,
+ax_anim 1, 0, 79, 3, 3, 3, 3,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 1, 79, 6, 5, 6, 5,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 5, 6, 5,
+ax_anim 2, 0, 79, 5, 5, 5, 5,
+ax_anim 2, 0, 79, 6, 5, 6, 5,
+ax_anim 2, 0, 76, 2, 2, 2, 2,
+ax_anim_terminator
+sWingullAnims_4_3:
+ax_anim 2, 0, 81, 0, -2, 0, 0,
+ax_anim 2, 0, 82, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 0, 81, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 2, 2, 82, 0, -4, 0, 0,
+ax_anim 2, 0, 80, 0, -4, 0, 0,
+ax_anim 1, 0, 83, 2, 0, 2, 0,
+ax_anim 1, 0, 83, 3, 0, 3, 0,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 1, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 83, 5, 0, 5, 0,
+ax_anim 2, 0, 83, 5, 1, 5, 1,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim_terminator
+sWingullAnims_4_4:
+ax_anim 2, 0, 85, 0, -2, 0, 0,
+ax_anim 2, 0, 86, 0, -3, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 0, 85, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 2, 2, 86, 0, -4, 0, 0,
+ax_anim 2, 0, 84, 0, -4, 0, 0,
+ax_anim 1, 0, 87, 2, -2, 2, -2,
+ax_anim 1, 0, 87, 3, -3, 3, -3,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 1, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 87, 5, -5, 5, -5,
+ax_anim 2, 0, 87, 6, -4, 6, -4,
+ax_anim 2, 0, 84, 2, -2, 2, -2,
+ax_anim_terminator
+sWingullAnims_4_5:
+ax_anim 2, 0, 89, 0, -2, 0, 0,
+ax_anim 2, 0, 90, 0, -3, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 0, 89, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 2, 2, 90, 0, -4, 0, 0,
+ax_anim 2, 0, 88, 0, -4, 0, 0,
+ax_anim 1, 0, 91, 0, -2, 0, -1,
+ax_anim 1, 0, 91, 0, -3, 0, -3,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 1, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 91, 0, -5, 0, -5,
+ax_anim 2, 0, 91, 1, -5, 1, -5,
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim_terminator
+sWingullAnims_4_6:
+ax_anim 2, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 0, 94, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 0, 93, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 2, 2, 94, 0, -4, 0, 0,
+ax_anim 2, 0, 92, 0, -4, 0, 0,
+ax_anim 1, 0, 95, -2, -2, -2, -2,
+ax_anim 1, 0, 95, -3, -3, -3, -3,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 1, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 95, -5, -5, -5, -5,
+ax_anim 2, 0, 95, -6, -4, -6, -4,
+ax_anim 2, 0, 92, -2, -2, -2, -2,
+ax_anim_terminator
+sWingullAnims_4_7:
+ax_anim 2, 0, 97, 0, -2, 0, 0,
+ax_anim 2, 0, 98, 0, -3, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 0, 97, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 2, 2, 98, 0, -4, 0, 0,
+ax_anim 2, 0, 96, 0, -4, 0, 0,
+ax_anim 1, 0, 99, -2, 0, -2, 0,
+ax_anim 1, 0, 99, -3, 0, -3, 0,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 1, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 99, -5, 0, -5, 0,
+ax_anim 2, 0, 99, -5, 1, -5, 1,
+ax_anim 2, 0, 96, -2, 0, -2, 0,
+ax_anim_terminator
+sWingullAnims_4_8:
+ax_anim 2, 0, 101, 0, -2, 0, 0,
+ax_anim 2, 0, 102, 0, -3, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 0, 101, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 2, 2, 102, 0, -4, 0, 0,
+ax_anim 2, 0, 100, 0, -4, 0, 0,
+ax_anim 1, 0, 103, -2, 2, -2, 2,
+ax_anim 1, 0, 103, -3, 3, -3, 3,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 1, 103, -6, 5, -6, 5,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 5, -6, 5,
+ax_anim 2, 0, 103, -5, 5, -5, 5,
+ax_anim 2, 0, 103, -6, 5, -6, 5,
+ax_anim 2, 0, 100, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sWingullAnims_5_1:
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 1, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, -1, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 1, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 1, 0, 0,
+ax_anim 1, 0, 104, 0, 0, 0, 0,
+ax_anim 2, 1, 106, 0, -1, 0, 0,
+ax_anim 3, 0, 106, 0, -2, 0, 0,
+ax_anim 3, 0, 106, 0, -3, 0, 0,
+ax_anim 3, 0, 106, 0, -2, 0, 0,
+ax_anim_terminator
+sWingullAnims_5_2:
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 1, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, -1, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 1, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 1, 0, 0,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 1, 109, 0, -1, 0, 0,
+ax_anim 3, 0, 109, 0, -2, 0, 0,
+ax_anim 3, 0, 109, 0, -3, 0, 0,
+ax_anim 3, 0, 109, 0, -2, 0, 0,
+ax_anim_terminator
+sWingullAnims_5_3:
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 1, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, -1, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 1, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 0, 1, 0, 0,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim 2, 1, 112, 0, -1, 0, 0,
+ax_anim 3, 0, 112, 0, -2, 0, 0,
+ax_anim 3, 0, 112, 0, -3, 0, 0,
+ax_anim 3, 0, 112, 0, -2, 0, 0,
+ax_anim_terminator
+sWingullAnims_5_4:
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 1, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, -1, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 1, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, -1, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 1, 0, 0,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 1, 115, 0, -1, 0, 0,
+ax_anim 3, 0, 115, 0, -2, 0, 0,
+ax_anim 3, 0, 115, 0, -3, 0, 0,
+ax_anim 3, 0, 115, 0, -2, 0, 0,
+ax_anim_terminator
+sWingullAnims_5_5:
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, -1, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 0,
+ax_anim 1, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 1, 118, 0, -1, 0, 0,
+ax_anim 3, 0, 118, 0, -2, 0, 0,
+ax_anim 3, 0, 118, 0, -3, 0, 0,
+ax_anim 3, 0, 118, 0, -2, 0, 0,
+ax_anim_terminator
+sWingullAnims_5_6:
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, -1, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 0, -1, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, 1, 0, 0,
+ax_anim 1, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 1, 121, 0, -1, 0, 0,
+ax_anim 3, 0, 121, 0, -2, 0, 0,
+ax_anim 3, 0, 121, 0, -3, 0, 0,
+ax_anim 3, 0, 121, 0, -2, 0, 0,
+ax_anim_terminator
+sWingullAnims_5_7:
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 1, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 124, 0, -1, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 1, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 124, 0, -1, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 0, 1, 0, 0,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 1, 124, 0, -1, 0, 0,
+ax_anim 3, 0, 124, 0, -2, 0, 0,
+ax_anim 3, 0, 124, 0, -3, 0, 0,
+ax_anim 3, 0, 124, 0, -2, 0, 0,
+ax_anim_terminator
+sWingullAnims_5_8:
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, -1, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 0, -1, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 126, 0, 1, 0, 0,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 1, 127, 0, -1, 0, 0,
+ax_anim 3, 0, 127, 0, -2, 0, 0,
+ax_anim 3, 0, 127, 0, -3, 0, 0,
+ax_anim 3, 0, 127, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sWingullAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sWingullAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sWingullAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sWingullAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sWingullAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sWingullAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sWingullAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWingullAnims_8_1:
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 1, 0, 0,
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, -1, 0, 0,
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 139, 0, 1, 0, 0,
+ax_anim 6, 0, 138, 0, 0, 0, 0,
+ax_anim 8, 0, 140, 0, -1, 0, 0,
+ax_anim 10, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 138, 0, -1, 0, 0,
+ax_anim 10, 0, 138, 0, -2, 0, 0,
+ax_anim 10, 0, 138, 0, -2, 0, 0,
+ax_anim 10, 0, 138, 0, -1, 0, 0,
+ax_anim 10, 0, 138, 0, 0, 0, 0,
+ax_anim 10, 0, 138, 0, 1, 0, 0,
+ax_anim 10, 0, 138, 0, 2, 0, 0,
+ax_anim 10, 0, 138, 0, 2, 0, 0,
+ax_anim 10, 0, 138, 0, 1, 0, 0,
+ax_anim_terminator
+sWingullAnims_8_2:
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 1, 0, 0,
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, -1, 0, 0,
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 142, 0, 1, 0, 0,
+ax_anim 6, 0, 141, 0, 0, 0, 0,
+ax_anim 8, 0, 143, 0, -1, 0, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, -1, 0, 0,
+ax_anim 10, 0, 141, 0, -2, 0, 0,
+ax_anim 10, 0, 141, 0, -2, 0, 0,
+ax_anim 10, 0, 141, 0, -1, 0, 0,
+ax_anim 10, 0, 141, 0, 0, 0, 0,
+ax_anim 10, 0, 141, 0, 1, 0, 0,
+ax_anim 10, 0, 141, 0, 2, 0, 0,
+ax_anim 10, 0, 141, 0, 2, 0, 0,
+ax_anim 10, 0, 141, 0, 1, 0, 0,
+ax_anim_terminator
+sWingullAnims_8_3:
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 1, 0, 0,
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 145, 0, 1, 0, 0,
+ax_anim 6, 0, 144, 0, 0, 0, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim 10, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, -1, 0, 0,
+ax_anim 10, 0, 144, 0, -2, 0, 0,
+ax_anim 10, 0, 144, 0, -2, 0, 0,
+ax_anim 10, 0, 144, 0, -1, 0, 0,
+ax_anim 10, 0, 144, 0, 0, 0, 0,
+ax_anim 10, 0, 144, 0, 1, 0, 0,
+ax_anim 10, 0, 144, 0, 2, 0, 0,
+ax_anim 10, 0, 144, 0, 2, 0, 0,
+ax_anim 10, 0, 144, 0, 1, 0, 0,
+ax_anim_terminator
+sWingullAnims_8_4:
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 1, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 148, 0, 1, 0, 0,
+ax_anim 6, 0, 147, 0, 0, 0, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 0, -1, 0, 0,
+ax_anim 10, 0, 147, 0, -2, 0, 0,
+ax_anim 10, 0, 147, 0, -2, 0, 0,
+ax_anim 10, 0, 147, 0, -1, 0, 0,
+ax_anim 10, 0, 147, 0, 0, 0, 0,
+ax_anim 10, 0, 147, 0, 1, 0, 0,
+ax_anim 10, 0, 147, 0, 2, 0, 0,
+ax_anim 10, 0, 147, 0, 2, 0, 0,
+ax_anim 10, 0, 147, 0, 1, 0, 0,
+ax_anim_terminator
+sWingullAnims_8_5:
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 1, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 151, 0, 1, 0, 0,
+ax_anim 6, 0, 150, 0, 0, 0, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim 10, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 150, 0, -1, 0, 0,
+ax_anim 10, 0, 150, 0, -2, 0, 0,
+ax_anim 10, 0, 150, 0, -2, 0, 0,
+ax_anim 10, 0, 150, 0, -1, 0, 0,
+ax_anim 10, 0, 150, 0, 0, 0, 0,
+ax_anim 10, 0, 150, 0, 1, 0, 0,
+ax_anim 10, 0, 150, 0, 2, 0, 0,
+ax_anim 10, 0, 150, 0, 2, 0, 0,
+ax_anim 10, 0, 150, 0, 1, 0, 0,
+ax_anim_terminator
+sWingullAnims_8_6:
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 1, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 154, 0, 1, 0, 0,
+ax_anim 6, 0, 153, 0, 0, 0, 0,
+ax_anim 8, 0, 155, 0, -1, 0, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 153, 0, -1, 0, 0,
+ax_anim 10, 0, 153, 0, -2, 0, 0,
+ax_anim 10, 0, 153, 0, -2, 0, 0,
+ax_anim 10, 0, 153, 0, -1, 0, 0,
+ax_anim 10, 0, 153, 0, 0, 0, 0,
+ax_anim 10, 0, 153, 0, 1, 0, 0,
+ax_anim 10, 0, 153, 0, 2, 0, 0,
+ax_anim 10, 0, 153, 0, 2, 0, 0,
+ax_anim 10, 0, 153, 0, 1, 0, 0,
+ax_anim_terminator
+sWingullAnims_8_7:
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 1, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, -1, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 157, 0, 1, 0, 0,
+ax_anim 6, 0, 156, 0, 0, 0, 0,
+ax_anim 8, 0, 158, 0, -1, 0, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, -1, 0, 0,
+ax_anim 10, 0, 156, 0, -2, 0, 0,
+ax_anim 10, 0, 156, 0, -2, 0, 0,
+ax_anim 10, 0, 156, 0, -1, 0, 0,
+ax_anim 10, 0, 156, 0, 0, 0, 0,
+ax_anim 10, 0, 156, 0, 1, 0, 0,
+ax_anim 10, 0, 156, 0, 2, 0, 0,
+ax_anim 10, 0, 156, 0, 2, 0, 0,
+ax_anim 10, 0, 156, 0, 1, 0, 0,
+ax_anim_terminator
+sWingullAnims_8_8:
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 1, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 160, 0, 1, 0, 0,
+ax_anim 6, 0, 159, 0, 0, 0, 0,
+ax_anim 8, 0, 161, 0, -1, 0, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, -1, 0, 0,
+ax_anim 10, 0, 159, 0, -2, 0, 0,
+ax_anim 10, 0, 159, 0, -2, 0, 0,
+ax_anim 10, 0, 159, 0, -1, 0, 0,
+ax_anim 10, 0, 159, 0, 0, 0, 0,
+ax_anim 10, 0, 159, 0, 1, 0, 0,
+ax_anim 10, 0, 159, 0, 2, 0, 0,
+ax_anim 10, 0, 159, 0, 2, 0, 0,
+ax_anim 10, 0, 159, 0, 1, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 7, 5, 7, 5,
+ax_anim 2, 0, 164, 10, 13, 10, 13,
+ax_anim 2, 0, 165, 6, 21, 6, 21,
+ax_anim 3, 0, 166, 0, 24, 0, 24,
+ax_anim 2, 3, 167, -6, 21, -6, 21,
+ax_anim 2, 0, 168, -9, 13, -9, 13,
+ax_anim 1, 0, 169, -7, 5, -7, 5,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 12, -1, 12, -1,
+ax_anim 2, 0, 163, 22, 6, 22, 6,
+ax_anim 2, 0, 164, 25, 14, 25, 13,
+ax_anim 3, 0, 165, 22, 24, 22, 21,
+ax_anim 2, 3, 166, 11, 24, 11, 22,
+ax_anim 2, 0, 167, 4, 17, 4, 17,
+ax_anim 1, 0, 168, 0, 9, 0, 9,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 6, -6, 6, -6,
+ax_anim 2, 0, 162, 13, -9, 13, -9,
+ax_anim 2, 0, 163, 21, -3, 21, -5,
+ax_anim 3, 0, 164, 24, 4, 24, 0,
+ax_anim 2, 3, 165, 18, 9, 18, 5,
+ax_anim 2, 0, 166, 10, 11, 10, 8,
+ax_anim 1, 0, 167, 3, 7, 3, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 169, 3, -12, 3, -12,
+ax_anim 2, 0, 162, 11, -20, 11, -21,
+ax_anim 3, 0, 163, 21, -17, 21, -24,
+ax_anim 2, 3, 164, 23, -10, 23, -13,
+ax_anim 2, 0, 165, 19, -2, 19, -2,
+ax_anim 1, 0, 166, 9, 2, 9, 2,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -5, -2, -5, -2,
+ax_anim 2, 0, 168, -9, -9, -9, -9,
+ax_anim 2, 0, 169, -7, -16, -7, -18,
+ax_anim 3, 0, 162, 0, -20, 0, -22,
+ax_anim 2, 3, 163, 7, -16, 7, -18,
+ax_anim 2, 0, 164, 9, -9, 9, -9,
+ax_anim 1, 0, 165, 5, -2, 5, -2,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 163, -3, -12, -3, -12,
+ax_anim 2, 0, 162, -11, -20, -11, -21,
+ax_anim 3, 0, 169, -21, -17, -20, -24,
+ax_anim 2, 3, 168, -23, -10, -23, -13,
+ax_anim 2, 0, 167, -19, -2, -19, -2,
+ax_anim 1, 0, 166, -9, 2, -9, 2,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -6, -6, -6, -6,
+ax_anim 2, 0, 162, -13, -9, -13, -9,
+ax_anim 2, 0, 169, -21, -3, -21, -5,
+ax_anim 3, 0, 168, -24, 4, -24, 0,
+ax_anim 2, 3, 167, -18, 9, -18, 5,
+ax_anim 2, 0, 166, -10, 11, -10, 8,
+ax_anim 1, 0, 165, -3, 7, -3, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -12, -1, -12, -1,
+ax_anim 2, 0, 169, -22, 6, -22, 6,
+ax_anim 2, 0, 168, -25, 14, -25, 13,
+ax_anim 3, 0, 167, -22, 24, -22, 21,
+ax_anim 2, 3, 166, -11, 24, -11, 22,
+ax_anim 2, 0, 165, -4, 17, -4, 17,
+ax_anim 1, 0, 164, 0, 9, 0, 9,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 179, 0, -21, 0, 0,
+ax_anim 2, 0, 179, 0, -18, 0, 0,
+ax_anim 1, 0, 179, 0, -9, 0, 0,
+ax_anim 2, 2, 179, 0, 8, 0, 0,
+ax_anim_terminator
+sWingullAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 182, 0, -21, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -9, 0, 0,
+ax_anim 2, 2, 182, 0, 8, 0, 0,
+ax_anim_terminator
+sWingullAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 185, 0, -21, 0, 0,
+ax_anim 2, 0, 185, 0, -18, 0, 0,
+ax_anim 1, 0, 185, 0, -9, 0, 0,
+ax_anim 2, 2, 185, 0, 8, 0, 0,
+ax_anim_terminator
+sWingullAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 188, 0, -21, 0, 0,
+ax_anim 2, 0, 188, 0, -17, 0, 0,
+ax_anim 1, 0, 188, 0, -9, 0, 0,
+ax_anim 2, 2, 188, 0, 7, 0, 0,
+ax_anim_terminator
+sWingullAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 191, 0, -21, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -9, 0, 0,
+ax_anim 2, 2, 191, 0, 7, 0, 0,
+ax_anim_terminator
+sWingullAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 195, 0, -10, 0, 0,
+ax_anim 2, 0, 195, 0, -16, 0, 0,
+ax_anim 3, 0, 195, 0, -20, 0, 0,
+ax_anim 4, 0, 195, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 194, 0, -21, 0, 0,
+ax_anim 2, 0, 194, 0, -17, 0, 0,
+ax_anim 1, 0, 194, 0, -9, 0, 0,
+ax_anim 2, 2, 194, 0, 7, 0, 0,
+ax_anim_terminator
+sWingullAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 198, 0, -10, 0, 0,
+ax_anim 2, 0, 198, 0, -16, 0, 0,
+ax_anim 3, 0, 198, 0, -20, 0, 0,
+ax_anim 4, 0, 198, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -18, 0, 0,
+ax_anim 1, 0, 197, 0, -9, 0, 0,
+ax_anim 2, 2, 197, 0, 8, 0, 0,
+ax_anim_terminator
+sWingullAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 201, 0, -10, 0, 0,
+ax_anim 2, 0, 201, 0, -16, 0, 0,
+ax_anim 3, 0, 201, 0, -20, 0, 0,
+ax_anim 4, 0, 201, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -22, 0, 0,
+ax_anim 3, 0, 200, 0, -21, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -9, 0, 0,
+ax_anim 2, 2, 200, 0, 8, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWingullAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sWingullGfx1:
+.incbin "baserom.gba", 0x115E534, 0x200
+sWingullSprites1:
+ax_sprite sWingullGfx1, 0x200
+ax_sprite_terminator
+sWingullGfx2:
+.incbin "baserom.gba", 0x115E744, 0x200
+sWingullSprites2:
+ax_sprite sWingullGfx2, 0x200
+ax_sprite_terminator
+sWingullGfx3:
+.incbin "baserom.gba", 0x115E954, 0x200
+sWingullSprites3:
+ax_sprite sWingullGfx3, 0x200
+ax_sprite_terminator
+sWingullGfx4:
+.incbin "baserom.gba", 0x115EB64, 0x200
+sWingullSprites4:
+ax_sprite sWingullGfx4, 0x200
+ax_sprite_terminator
+sWingullGfx5:
+.incbin "baserom.gba", 0x115ED74, 0x200
+sWingullSprites5:
+ax_sprite sWingullGfx5, 0x200
+ax_sprite_terminator
+sWingullGfx6:
+.incbin "baserom.gba", 0x115EF84, 0x200
+sWingullSprites6:
+ax_sprite sWingullGfx6, 0x200
+ax_sprite_terminator
+sWingullGfx7:
+.incbin "baserom.gba", 0x115F194, 0x200
+sWingullSprites7:
+ax_sprite sWingullGfx7, 0x200
+ax_sprite_terminator
+sWingullGfx8:
+.incbin "baserom.gba", 0x115F3A4, 0x200
+sWingullSprites8:
+ax_sprite sWingullGfx8, 0x200
+ax_sprite_terminator
+sWingullGfx9:
+.incbin "baserom.gba", 0x115F5B4, 0x200
+sWingullSprites9:
+ax_sprite sWingullGfx9, 0x200
+ax_sprite_terminator
+sWingullGfx10:
+.incbin "baserom.gba", 0x115F7C4, 0x200
+sWingullSprites10:
+ax_sprite sWingullGfx10, 0x200
+ax_sprite_terminator
+sWingullGfx11:
+.incbin "baserom.gba", 0x115F9D4, 0x200
+sWingullSprites11:
+ax_sprite sWingullGfx11, 0x200
+ax_sprite_terminator
+sWingullGfx12:
+.incbin "baserom.gba", 0x115FBE4, 0x200
+sWingullSprites12:
+ax_sprite sWingullGfx12, 0x200
+ax_sprite_terminator
+sWingullGfx13:
+.incbin "baserom.gba", 0x115FDF4, 0x200
+sWingullSprites13:
+ax_sprite sWingullGfx13, 0x200
+ax_sprite_terminator
+sWingullGfx14:
+.incbin "baserom.gba", 0x1160004, 0x200
+sWingullSprites14:
+ax_sprite sWingullGfx14, 0x200
+ax_sprite_terminator
+sWingullGfx15:
+.incbin "baserom.gba", 0x1160214, 0x200
+sWingullSprites15:
+ax_sprite sWingullGfx15, 0x200
+ax_sprite_terminator
+sWingullGfx16:
+.incbin "baserom.gba", 0x1160424, 0x100
+sWingullGfx16_1:
+.incbin "baserom.gba", 0x1160524, 0x40
+sWingullSprites16:
+ax_sprite 0, 0x80
+ax_sprite sWingullGfx16, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWingullGfx16_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWingullGfx17:
+.incbin "baserom.gba", 0x1160594, 0x40
+sWingullGfx17_1:
+.incbin "baserom.gba", 0x11605D4, 0x100
+sWingullGfx17_2:
+.incbin "baserom.gba", 0x11606D4, 0x20
+sWingullSprites17:
+ax_sprite sWingullGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWingullGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWingullGfx17_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWingullGfx18:
+.incbin "baserom.gba", 0x116072C, 0x40
+sWingullGfx18_1:
+.incbin "baserom.gba", 0x116076C, 0x100
+sWingullSprites18:
+ax_sprite 0, 0x20
+ax_sprite sWingullGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWingullGfx18_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWingullGfx19:
+.incbin "baserom.gba", 0x116089C, 0x60
+sWingullGfx19_1:
+.incbin "baserom.gba", 0x11608FC, 0x60
+sWingullGfx19_2:
+.incbin "baserom.gba", 0x116095C, 0x60
+sWingullSprites19:
+ax_sprite sWingullGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWingullGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWingullGfx19_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWingullGfx20:
+.incbin "baserom.gba", 0x11609F4, 0x100
+sWingullGfx20_1:
+.incbin "baserom.gba", 0x1160AF4, 0x40
+sWingullSprites20:
+ax_sprite sWingullGfx20, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWingullGfx20_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWingullGfx21:
+.incbin "baserom.gba", 0x1160B5C, 0x200
+sWingullSprites21:
+ax_sprite sWingullGfx21, 0x200
+ax_sprite_terminator
+sWingullGfx22:
+.incbin "baserom.gba", 0x1160D6C, 0x200
+sWingullSprites22:
+ax_sprite sWingullGfx22, 0x200
+ax_sprite_terminator
+sWingullGfx23:
+.incbin "baserom.gba", 0x1160F7C, 0x200
+sWingullSprites23:
+ax_sprite sWingullGfx23, 0x200
+ax_sprite_terminator
+sWingullGfx24:
+.incbin "baserom.gba", 0x116118C, 0x200
+sWingullSprites24:
+ax_sprite sWingullGfx24, 0x200
+ax_sprite_terminator
+sWingullGfx25:
+.incbin "baserom.gba", 0x116139C, 0x200
+sWingullSprites25:
+ax_sprite sWingullGfx25, 0x200
+ax_sprite_terminator
+sWingullGfx26:
+.incbin "baserom.gba", 0x11615AC, 0x200
+sWingullSprites26:
+ax_sprite sWingullGfx26, 0x200
+ax_sprite_terminator
+sWingullGfx27:
+.incbin "baserom.gba", 0x11617BC, 0x200
+sWingullSprites27:
+ax_sprite sWingullGfx27, 0x200
+ax_sprite_terminator
+sAxPosesWingull:
+.4byte sWingullPose1
+.4byte sWingullPose2
+.4byte sWingullPose3
+.4byte sWingullPose4
+.4byte sWingullPose5
+.4byte sWingullPose6
+.4byte sWingullPose7
+.4byte sWingullPose8
+.4byte sWingullPose9
+.4byte sWingullPose10
+.4byte sWingullPose11
+.4byte sWingullPose12
+.4byte sWingullPose13
+.4byte sWingullPose14
+.4byte sWingullPose15
+.4byte sWingullPose16
+.4byte sWingullPose17
+.4byte sWingullPose18
+.4byte sWingullPose19
+.4byte sWingullPose20
+.4byte sWingullPose21
+.4byte sWingullPose22
+.4byte sWingullPose23
+.4byte sWingullPose24
+.4byte sWingullPose25
+.4byte sWingullPose26
+.4byte sWingullPose27
+.4byte sWingullPose28
+.4byte sWingullPose29
+.4byte sWingullPose30
+.4byte sWingullPose31
+.4byte sWingullPose32
+.4byte sWingullPose33
+.4byte sWingullPose34
+.4byte sWingullPose35
+.4byte sWingullPose36
+.4byte sWingullPose37
+.4byte sWingullPose38
+.4byte sWingullPose39
+.4byte sWingullPose40
+.4byte sWingullPose41
+.4byte sWingullPose42
+.4byte sWingullPose43
+.4byte sWingullPose44
+.4byte sWingullPose45
+.4byte sWingullPose46
+.4byte sWingullPose47
+.4byte sWingullPose48
+.4byte sWingullPose49
+.4byte sWingullPose50
+.4byte sWingullPose51
+.4byte sWingullPose52
+.4byte sWingullPose53
+.4byte sWingullPose54
+.4byte sWingullPose55
+.4byte sWingullPose56
+.4byte sWingullPose57
+.4byte sWingullPose58
+.4byte sWingullPose59
+.4byte sWingullPose60
+.4byte sWingullPose61
+.4byte sWingullPose62
+.4byte sWingullPose63
+.4byte sWingullPose64
+.4byte sWingullPose65
+.4byte sWingullPose66
+.4byte sWingullPose67
+.4byte sWingullPose68
+.4byte sWingullPose69
+.4byte sWingullPose70
+.4byte sWingullPose71
+.4byte sWingullPose72
+.4byte sWingullPose73
+.4byte sWingullPose74
+.4byte sWingullPose75
+.4byte sWingullPose76
+.4byte sWingullPose77
+.4byte sWingullPose78
+.4byte sWingullPose79
+.4byte sWingullPose80
+.4byte sWingullPose81
+.4byte sWingullPose82
+.4byte sWingullPose83
+.4byte sWingullPose84
+.4byte sWingullPose85
+.4byte sWingullPose86
+.4byte sWingullPose87
+.4byte sWingullPose88
+.4byte sWingullPose89
+.4byte sWingullPose90
+.4byte sWingullPose91
+.4byte sWingullPose92
+.4byte sWingullPose93
+.4byte sWingullPose94
+.4byte sWingullPose95
+.4byte sWingullPose96
+.4byte sWingullPose97
+.4byte sWingullPose98
+.4byte sWingullPose99
+.4byte sWingullPose100
+.4byte sWingullPose101
+.4byte sWingullPose102
+.4byte sWingullPose103
+.4byte sWingullPose104
+.4byte sWingullPose105
+.4byte sWingullPose106
+.4byte sWingullPose107
+.4byte sWingullPose108
+.4byte sWingullPose109
+.4byte sWingullPose110
+.4byte sWingullPose111
+.4byte sWingullPose112
+.4byte sWingullPose113
+.4byte sWingullPose114
+.4byte sWingullPose115
+.4byte sWingullPose116
+.4byte sWingullPose117
+.4byte sWingullPose118
+.4byte sWingullPose119
+.4byte sWingullPose120
+.4byte sWingullPose121
+.4byte sWingullPose122
+.4byte sWingullPose123
+.4byte sWingullPose124
+.4byte sWingullPose125
+.4byte sWingullPose126
+.4byte sWingullPose127
+.4byte sWingullPose128
+.4byte sWingullPose129
+.4byte sWingullPose130
+.4byte sWingullPose131
+.4byte sWingullPose132
+.4byte sWingullPose133
+.4byte sWingullPose134
+.4byte sWingullPose135
+.4byte sWingullPose136
+.4byte sWingullPose137
+.4byte sWingullPose138
+.4byte sWingullPose139
+.4byte sWingullPose140
+.4byte sWingullPose141
+.4byte sWingullPose142
+.4byte sWingullPose143
+.4byte sWingullPose144
+.4byte sWingullPose145
+.4byte sWingullPose146
+.4byte sWingullPose147
+.4byte sWingullPose148
+.4byte sWingullPose149
+.4byte sWingullPose150
+.4byte sWingullPose151
+.4byte sWingullPose152
+.4byte sWingullPose153
+.4byte sWingullPose154
+.4byte sWingullPose155
+.4byte sWingullPose156
+.4byte sWingullPose157
+.4byte sWingullPose158
+.4byte sWingullPose159
+.4byte sWingullPose160
+.4byte sWingullPose161
+.4byte sWingullPose162
+.4byte sWingullPose163
+.4byte sWingullPose164
+.4byte sWingullPose165
+.4byte sWingullPose166
+.4byte sWingullPose167
+.4byte sWingullPose168
+.4byte sWingullPose169
+.4byte sWingullPose170
+.4byte sWingullPose171
+.4byte sWingullPose172
+.4byte sWingullPose173
+.4byte sWingullPose174
+.4byte sWingullPose175
+.4byte sWingullPose176
+.4byte sWingullPose177
+.4byte sWingullPose178
+.4byte sWingullPose179
+.4byte sWingullPose180
+.4byte sWingullPose181
+.4byte sWingullPose182
+.4byte sWingullPose183
+.4byte sWingullPose184
+.4byte sWingullPose185
+.4byte sWingullPose186
+.4byte sWingullPose187
+.4byte sWingullPose188
+.4byte sWingullPose189
+.4byte sWingullPose190
+.4byte sWingullPose191
+.4byte sWingullPose192
+.4byte sWingullPose193
+.4byte sWingullPose194
+.4byte sWingullPose195
+.4byte sWingullPose196
+.4byte sWingullPose197
+.4byte sWingullPose198
+.4byte sWingullPose199
+.4byte sWingullPose200
+.4byte sWingullPose201
+.4byte sWingullPose202
+.4byte sWingullPose203
+.4byte sWingullPose204
+.4byte sWingullPose205
+.4byte sWingullPose206
+.4byte sWingullPose207
+.4byte sWingullPose208
+.4byte sWingullPose209
+.4byte sWingullPose210
+.4byte sWingullPose211
+.4byte sWingullPose212
+.4byte sWingullPose213
+.4byte sWingullPose214
+.4byte sWingullPose215
+.4byte sWingullPose216
+.4byte sWingullPose217
+.4byte sWingullPose218
+sAxPositionsWingull:
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,   -8, 	  10,   -8, 	  -1,  -12
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+.2byte    5,   -8, 	   6,  -22, 	  -9,  -11, 	   0,  -13
+.2byte    5,   -8, 	   7,  -17, 	  -8,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -23, 	  -2,   -6, 	   0,  -13
+.2byte    7,  -12, 	  -1,  -20, 	  -1,   -1, 	   0,  -13
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    6,  -17, 	  -6,  -21, 	   8,   -9, 	   0,  -13
+.2byte    6,  -17, 	  -8,  -16, 	   7,   -3, 	   0,  -13
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	  10,  -17, 	 -11,  -17, 	  -1,  -13
+.2byte   -1,  -19, 	  10,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -7,  -17, 	   5,  -21, 	  -9,   -9, 	  -1,  -13
+.2byte   -7,  -17, 	   7,  -16, 	  -8,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -23, 	   1,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   0,  -20, 	   0,   -1, 	  -1,  -13
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -6,   -8, 	  -7,  -22, 	   8,  -11, 	  -1,  -13
+.2byte   -6,   -8, 	  -8,  -17, 	   7,   -3, 	  -1,  -13
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,   -8, 	  10,   -8, 	  -1,  -12
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+.2byte    5,   -8, 	   6,  -22, 	  -9,  -11, 	   0,  -13
+.2byte    5,   -8, 	   7,  -17, 	  -8,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -23, 	  -2,   -6, 	   0,  -13
+.2byte    7,  -12, 	  -1,  -20, 	  -1,   -1, 	   0,  -13
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    6,  -17, 	  -6,  -21, 	   8,   -9, 	   0,  -13
+.2byte    6,  -17, 	  -8,  -16, 	   7,   -3, 	   0,  -13
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	  10,  -17, 	 -11,  -17, 	  -1,  -13
+.2byte   -1,  -19, 	  10,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -7,  -17, 	   5,  -21, 	  -9,   -9, 	  -1,  -13
+.2byte   -7,  -17, 	   7,  -16, 	  -8,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -23, 	   1,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   0,  -20, 	   0,   -1, 	  -1,  -13
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -6,   -8, 	  -7,  -22, 	   8,  -11, 	  -1,  -13
+.2byte   -6,   -8, 	  -8,  -17, 	   7,   -3, 	  -1,  -13
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,   -8, 	  10,   -8, 	  -1,  -12
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+.2byte    5,   -8, 	   6,  -22, 	  -9,  -11, 	   0,  -13
+.2byte    5,   -8, 	   7,  -17, 	  -8,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -23, 	  -2,   -6, 	   0,  -13
+.2byte    7,  -12, 	  -1,  -20, 	  -1,   -1, 	   0,  -13
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    6,  -17, 	  -6,  -21, 	   8,   -9, 	   0,  -13
+.2byte    6,  -17, 	  -8,  -16, 	   7,   -3, 	   0,  -13
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	  10,  -17, 	 -11,  -17, 	  -1,  -13
+.2byte   -1,  -19, 	  10,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -7,  -17, 	   5,  -21, 	  -9,   -9, 	  -1,  -13
+.2byte   -7,  -17, 	   7,  -16, 	  -8,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -23, 	   1,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   0,  -20, 	   0,   -1, 	  -1,  -13
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -6,   -8, 	  -7,  -22, 	   8,  -11, 	  -1,  -13
+.2byte   -6,   -8, 	  -8,  -17, 	   7,   -3, 	  -1,  -13
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,   -8, 	  10,   -8, 	  -1,  -12
+.2byte   -1,   -4, 	 -10,  -15, 	   9,  -15, 	  -1,  -11
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+.2byte    5,   -8, 	   6,  -22, 	  -9,  -11, 	   0,  -13
+.2byte    5,   -8, 	   7,  -17, 	  -8,   -3, 	   0,  -13
+.2byte    3,   -7, 	   6,  -22, 	 -11,  -13, 	   0,  -14
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -23, 	  -2,   -6, 	   0,  -13
+.2byte    7,  -12, 	  -1,  -20, 	  -1,   -1, 	   0,  -13
+.2byte    7,  -10, 	   0,  -22, 	  -1,   -6, 	   0,  -14
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    6,  -17, 	  -6,  -21, 	   8,   -9, 	   0,  -13
+.2byte    6,  -17, 	  -8,  -16, 	   7,   -3, 	   0,  -13
+.2byte    5,  -15, 	  -5,  -22, 	  10,  -12, 	  -1,  -14
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	  10,  -17, 	 -11,  -17, 	  -1,  -13
+.2byte   -1,  -19, 	  10,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -1,  -20, 	 -11,  -17, 	  10,  -17, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -7,  -17, 	   5,  -21, 	  -9,   -9, 	  -1,  -13
+.2byte   -7,  -17, 	   7,  -16, 	  -8,   -3, 	  -1,  -13
+.2byte   -6,  -15, 	   4,  -22, 	 -11,  -12, 	   0,  -14
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -23, 	   1,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   0,  -20, 	   0,   -1, 	  -1,  -13
+.2byte   -8,  -10, 	  -1,  -22, 	   0,   -6, 	  -1,  -14
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -6,   -8, 	  -7,  -22, 	   8,  -11, 	  -1,  -13
+.2byte   -6,   -8, 	  -8,  -17, 	   7,   -3, 	  -1,  -13
+.2byte   -4,   -7, 	  -7,  -22, 	  10,  -13, 	  -1,  -14
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,   -8, 	  10,   -8, 	  -1,  -12
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+.2byte    5,   -8, 	   6,  -22, 	  -9,  -11, 	   0,  -13
+.2byte    5,   -8, 	   7,  -17, 	  -8,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -23, 	  -2,   -6, 	   0,  -13
+.2byte    7,  -12, 	  -1,  -20, 	  -1,   -1, 	   0,  -13
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    6,  -17, 	  -6,  -21, 	   8,   -9, 	   0,  -13
+.2byte    6,  -17, 	  -8,  -16, 	   7,   -3, 	   0,  -13
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	  10,  -17, 	 -11,  -17, 	  -1,  -13
+.2byte   -1,  -19, 	  10,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -7,  -17, 	   5,  -21, 	  -9,   -9, 	  -1,  -13
+.2byte   -7,  -17, 	   7,  -16, 	  -8,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -23, 	   1,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   0,  -20, 	   0,   -1, 	  -1,  -13
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -6,   -8, 	  -7,  -22, 	   8,  -11, 	  -1,  -13
+.2byte   -6,   -8, 	  -8,  -17, 	   7,   -3, 	  -1,  -13
+.2byte   -5,   -1, 	  -6,   -9, 	   8,    0, 	  -1,   -5
+.2byte   -5,    0, 	  -7,   -6, 	   9,    2, 	  -1,   -4
+.2byte   -1,  -21, 	 -11,  -19, 	  10,  -19, 	  -1,  -16
+.2byte    2,  -19, 	   8,  -21, 	 -10,  -15, 	   0,  -14
+.2byte    4,  -20, 	  -4,  -23, 	  -5,   -5, 	   0,  -14
+.2byte    3,  -21, 	  -8,  -21, 	   7,   -7, 	   0,  -15
+.2byte   -1,  -20, 	  11,  -10, 	 -12,  -10, 	  -1,  -14
+.2byte   -4,  -21, 	   7,  -21, 	  -8,   -7, 	  -1,  -15
+.2byte   -5,  -20, 	   3,  -23, 	   4,   -5, 	  -1,  -14
+.2byte   -3,  -19, 	  -9,  -21, 	   9,  -15, 	  -1,  -14
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,   -8, 	  10,   -8, 	  -1,  -12
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+.2byte    5,   -8, 	   6,  -22, 	  -9,  -11, 	   0,  -13
+.2byte    5,   -8, 	   7,  -17, 	  -8,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -23, 	  -2,   -6, 	   0,  -13
+.2byte    7,  -12, 	  -1,  -20, 	  -1,   -1, 	   0,  -13
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    6,  -17, 	  -6,  -21, 	   8,   -9, 	   0,  -13
+.2byte    6,  -17, 	  -8,  -16, 	   7,   -3, 	   0,  -13
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	  10,  -17, 	 -11,  -17, 	  -1,  -13
+.2byte   -1,  -19, 	  10,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -7,  -17, 	   5,  -21, 	  -9,   -9, 	  -1,  -13
+.2byte   -7,  -17, 	   7,  -16, 	  -8,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -23, 	   1,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   0,  -20, 	   0,   -1, 	  -1,  -13
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -6,   -8, 	  -7,  -22, 	   8,  -11, 	  -1,  -13
+.2byte   -6,   -8, 	  -8,  -17, 	   7,   -3, 	  -1,  -13
+.2byte   -1,   -4, 	 -10,  -15, 	   9,  -15, 	  -1,  -11
+.2byte   -4,   -7, 	  -7,  -22, 	  10,  -13, 	  -1,  -14
+.2byte   -8,  -10, 	  -1,  -22, 	   0,   -6, 	  -1,  -14
+.2byte   -6,  -15, 	   4,  -22, 	 -11,  -12, 	   0,  -14
+.2byte   -1,  -20, 	 -11,  -17, 	  10,  -17, 	  -1,  -13
+.2byte    5,  -15, 	  -5,  -22, 	  10,  -12, 	  -1,  -14
+.2byte    7,  -10, 	   0,  -22, 	  -1,   -6, 	   0,  -14
+.2byte    3,   -7, 	   6,  -22, 	 -11,  -13, 	   0,  -14
+.2byte   -1,   -5, 	 -10,  -16, 	   9,  -16, 	  -1,  -12
+.2byte    3,   -7, 	   6,  -22, 	 -11,  -13, 	   0,  -14
+.2byte    6,  -10, 	  -1,  -22, 	  -2,   -6, 	  -1,  -14
+.2byte    5,  -15, 	  -5,  -22, 	  10,  -12, 	  -1,  -14
+.2byte   -1,  -20, 	 -11,  -17, 	  10,  -17, 	  -1,  -13
+.2byte   -6,  -15, 	   4,  -22, 	 -11,  -12, 	   0,  -14
+.2byte   -7,  -10, 	   0,  -22, 	   1,   -6, 	   0,  -14
+.2byte   -4,   -7, 	  -7,  -22, 	  10,  -13, 	  -1,  -14
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,  -17, 	  10,  -17, 	  -1,  -12
+.2byte   -1,   -8, 	 -11,   -8, 	  10,   -8, 	  -1,  -12
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+.2byte    5,   -8, 	   6,  -22, 	  -9,  -11, 	   0,  -13
+.2byte    5,   -8, 	   7,  -17, 	  -8,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -23, 	  -2,   -6, 	   0,  -13
+.2byte    7,  -12, 	  -1,  -20, 	  -1,   -1, 	   0,  -13
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    6,  -17, 	  -6,  -21, 	   8,   -9, 	   0,  -13
+.2byte    6,  -17, 	  -8,  -16, 	   7,   -3, 	   0,  -13
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte   -1,  -19, 	  10,  -17, 	 -11,  -17, 	  -1,  -13
+.2byte   -1,  -19, 	  10,   -8, 	 -11,   -8, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -7,  -17, 	   5,  -21, 	  -9,   -9, 	  -1,  -13
+.2byte   -7,  -17, 	   7,  -16, 	  -8,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -23, 	   1,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   0,  -20, 	   0,   -1, 	  -1,  -13
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -6,   -8, 	  -7,  -22, 	   8,  -11, 	  -1,  -13
+.2byte   -6,   -8, 	  -8,  -17, 	   7,   -3, 	  -1,  -13
+.2byte   -1,   -6, 	 -10,  -17, 	   9,  -17, 	  -1,  -13
+.2byte   -4,   -7, 	  -7,  -22, 	  10,  -13, 	  -1,  -14
+.2byte   -8,  -10, 	  -1,  -22, 	   0,   -6, 	  -1,  -14
+.2byte   -6,  -14, 	   4,  -21, 	 -11,  -11, 	   0,  -13
+.2byte   -1,  -19, 	 -11,  -16, 	  10,  -16, 	  -1,  -12
+.2byte    5,  -14, 	  -5,  -21, 	  10,  -11, 	  -1,  -13
+.2byte    7,  -10, 	   0,  -22, 	  -1,   -6, 	   0,  -14
+.2byte    3,   -7, 	   6,  -22, 	 -11,  -13, 	   0,  -14
+.2byte   -1,   -8, 	 -12,  -13, 	  11,  -13, 	  -1,  -12
+.2byte   -6,   -8, 	  -9,  -19, 	   9,   -6, 	  -1,  -13
+.2byte   -8,  -12, 	   1,  -21, 	   1,   -3, 	  -1,  -13
+.2byte   -7,  -17, 	   6,  -18, 	  -9,   -5, 	  -1,  -13
+.2byte   -1,  -19, 	  11,  -12, 	 -12,  -12, 	  -1,  -13
+.2byte    6,  -17, 	  -7,  -18, 	   8,   -5, 	   0,  -13
+.2byte    7,  -12, 	  -2,  -21, 	  -2,   -3, 	   0,  -13
+.2byte    5,   -8, 	   8,  -19, 	 -10,   -6, 	   0,  -13
+sWingullAnimTable1:
+.4byte sWingullAnims_1_1
+.4byte sWingullAnims_1_2
+.4byte sWingullAnims_1_3
+.4byte sWingullAnims_1_4
+.4byte sWingullAnims_1_5
+.4byte sWingullAnims_1_6
+.4byte sWingullAnims_1_7
+.4byte sWingullAnims_1_8
+sWingullAnimTable2:
+.4byte sWingullAnims_2_1
+.4byte sWingullAnims_2_2
+.4byte sWingullAnims_2_3
+.4byte sWingullAnims_2_4
+.4byte sWingullAnims_2_5
+.4byte sWingullAnims_2_6
+.4byte sWingullAnims_2_7
+.4byte sWingullAnims_2_8
+sWingullAnimTable3:
+.4byte sWingullAnims_3_1
+.4byte sWingullAnims_3_2
+.4byte sWingullAnims_3_3
+.4byte sWingullAnims_3_4
+.4byte sWingullAnims_3_5
+.4byte sWingullAnims_3_6
+.4byte sWingullAnims_3_7
+.4byte sWingullAnims_3_8
+sWingullAnimTable4:
+.4byte sWingullAnims_4_1
+.4byte sWingullAnims_4_2
+.4byte sWingullAnims_4_3
+.4byte sWingullAnims_4_4
+.4byte sWingullAnims_4_5
+.4byte sWingullAnims_4_6
+.4byte sWingullAnims_4_7
+.4byte sWingullAnims_4_8
+sWingullAnimTable5:
+.4byte sWingullAnims_5_1
+.4byte sWingullAnims_5_2
+.4byte sWingullAnims_5_3
+.4byte sWingullAnims_5_4
+.4byte sWingullAnims_5_5
+.4byte sWingullAnims_5_6
+.4byte sWingullAnims_5_7
+.4byte sWingullAnims_5_8
+sWingullAnimTable6:
+.4byte sWingullAnims_6_1
+.4byte sWingullAnims_6_1
+.4byte sWingullAnims_6_1
+.4byte sWingullAnims_6_1
+.4byte sWingullAnims_6_1
+.4byte sWingullAnims_6_1
+.4byte sWingullAnims_6_1
+.4byte sWingullAnims_6_1
+sWingullAnimTable7:
+.4byte sWingullAnims_7_1
+.4byte sWingullAnims_7_2
+.4byte sWingullAnims_7_3
+.4byte sWingullAnims_7_4
+.4byte sWingullAnims_7_5
+.4byte sWingullAnims_7_6
+.4byte sWingullAnims_7_7
+.4byte sWingullAnims_7_8
+sWingullAnimTable8:
+.4byte sWingullAnims_8_1
+.4byte sWingullAnims_8_2
+.4byte sWingullAnims_8_3
+.4byte sWingullAnims_8_4
+.4byte sWingullAnims_8_5
+.4byte sWingullAnims_8_6
+.4byte sWingullAnims_8_7
+.4byte sWingullAnims_8_8
+sWingullAnimTable9:
+.4byte sWingullAnims_9_1
+.4byte sWingullAnims_9_2
+.4byte sWingullAnims_9_3
+.4byte sWingullAnims_9_4
+.4byte sWingullAnims_9_5
+.4byte sWingullAnims_9_6
+.4byte sWingullAnims_9_7
+.4byte sWingullAnims_9_8
+sWingullAnimTable10:
+.4byte sWingullAnims_10_1
+.4byte sWingullAnims_10_2
+.4byte sWingullAnims_10_3
+.4byte sWingullAnims_10_4
+.4byte sWingullAnims_10_5
+.4byte sWingullAnims_10_6
+.4byte sWingullAnims_10_7
+.4byte sWingullAnims_10_8
+sWingullAnimTable11:
+.4byte sWingullAnims_11_1
+.4byte sWingullAnims_11_2
+.4byte sWingullAnims_11_3
+.4byte sWingullAnims_11_4
+.4byte sWingullAnims_11_5
+.4byte sWingullAnims_11_6
+.4byte sWingullAnims_11_7
+.4byte sWingullAnims_11_8
+sWingullAnimTable12:
+.4byte sWingullAnims_12_1
+.4byte sWingullAnims_12_2
+.4byte sWingullAnims_12_3
+.4byte sWingullAnims_12_4
+.4byte sWingullAnims_12_5
+.4byte sWingullAnims_12_6
+.4byte sWingullAnims_12_7
+.4byte sWingullAnims_12_8
+sWingullAnimTable13:
+.4byte sWingullAnims_13_1
+.4byte sWingullAnims_13_2
+.4byte sWingullAnims_13_3
+.4byte sWingullAnims_13_4
+.4byte sWingullAnims_13_5
+.4byte sWingullAnims_13_6
+.4byte sWingullAnims_13_7
+.4byte sWingullAnims_13_8
+sAxAnimationsWingull:
+.4byte sWingullAnimTable1
+.4byte sWingullAnimTable2
+.4byte sWingullAnimTable3
+.4byte sWingullAnimTable4
+.4byte sWingullAnimTable5
+.4byte sWingullAnimTable6
+.4byte sWingullAnimTable7
+.4byte sWingullAnimTable8
+.4byte sWingullAnimTable9
+.4byte sWingullAnimTable10
+.4byte sWingullAnimTable11
+.4byte sWingullAnimTable12
+.4byte sWingullAnimTable13
+sAxSpritesWingull:
+.4byte sWingullSprites1
+.4byte sWingullSprites2
+.4byte sWingullSprites3
+.4byte sWingullSprites4
+.4byte sWingullSprites5
+.4byte sWingullSprites6
+.4byte sWingullSprites7
+.4byte sWingullSprites8
+.4byte sWingullSprites9
+.4byte sWingullSprites10
+.4byte sWingullSprites11
+.4byte sWingullSprites12
+.4byte sWingullSprites13
+.4byte sWingullSprites14
+.4byte sWingullSprites15
+.4byte sWingullSprites16
+.4byte sWingullSprites17
+.4byte sWingullSprites18
+.4byte sWingullSprites19
+.4byte sWingullSprites20
+.4byte sWingullSprites21
+.4byte sWingullSprites22
+.4byte sWingullSprites23
+.4byte sWingullSprites24
+.4byte sWingullSprites25
+.4byte sWingullSprites26
+.4byte sWingullSprites27
+sAxMainWingull:
+ax_main sAxPosesWingull, sAxAnimationsWingull, 13, sAxSpritesWingull, sAxPositionsWingull

--- a/data/ax/wobbuffet.inc
+++ b/data/ax/wobbuffet.inc
@@ -1,0 +1,2620 @@
+.global gAxWobbuffet
+gAxWobbuffet:
+ax_siro sAxMainWobbuffet
+sWobbuffetPose1:
+ax_pose 0, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose2:
+ax_pose 1, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose3:
+ax_pose 2, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose4:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose5:
+ax_pose 4, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose6:
+ax_pose 5, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose7:
+ax_pose 6, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose8:
+ax_pose 7, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose9:
+ax_pose 8, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose10:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose11:
+ax_pose 10, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose12:
+ax_pose 11, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose13:
+ax_pose 12, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose16:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose17:
+ax_pose 10, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose18:
+ax_pose 11, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose19:
+ax_pose 6, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose20:
+ax_pose 7, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose21:
+ax_pose 8, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose22:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose23:
+ax_pose 4, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose24:
+ax_pose 5, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose25:
+ax_pose 0, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose26:
+ax_pose 15, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose27:
+ax_pose 16, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose28:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose29:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose30:
+ax_pose 18, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose31:
+ax_pose 6, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose32:
+ax_pose 19, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose33:
+ax_pose 20, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose34:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose35:
+ax_pose 21, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose36:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sWobbuffetPose37:
+ax_pose 12, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose38:
+ax_pose 23, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose39:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose40:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose41:
+ax_pose 21, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose42:
+ax_pose 22, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose43:
+ax_pose 6, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose44:
+ax_pose 19, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose45:
+ax_pose 20, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose46:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose47:
+ax_pose 17, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose48:
+ax_pose 18, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose49:
+ax_pose 0, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose50:
+ax_pose 15, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose51:
+ax_pose 16, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose52:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose53:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose54:
+ax_pose 18, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose55:
+ax_pose 6, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose56:
+ax_pose 19, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose57:
+ax_pose 20, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose58:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose59:
+ax_pose 21, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose60:
+ax_pose 22, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sWobbuffetPose61:
+ax_pose 12, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose62:
+ax_pose 23, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose63:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose64:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose65:
+ax_pose 21, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose66:
+ax_pose 22, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose67:
+ax_pose 6, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose68:
+ax_pose 19, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose69:
+ax_pose 20, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose70:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose71:
+ax_pose 17, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose72:
+ax_pose 18, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose73:
+ax_pose 16, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose74:
+ax_pose 18, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose75:
+ax_pose 20, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose76:
+ax_pose 22, 0x01ea, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose77:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose78:
+ax_pose 22, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose79:
+ax_pose 20, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose80:
+ax_pose 18, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose81:
+ax_pose 0, 0x81ec, 0x90f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose82:
+ax_pose 16, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose83:
+ax_pose 25, 0x01e8, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose84:
+ax_pose 26, 0x01e8, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose85:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose86:
+ax_pose 18, 0x01e8, 0x90f0, 0x5c00
+ax_pose_terminator
+sWobbuffetPose87:
+ax_pose 27, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose88:
+ax_pose 28, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose89:
+ax_pose 6, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose90:
+ax_pose 20, 0x01e7, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose91:
+ax_pose 29, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose92:
+ax_pose 30, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose93:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose94:
+ax_pose 22, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose95:
+ax_pose 31, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose96:
+ax_pose 32, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose97:
+ax_pose 12, 0x81e8, 0x90f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose98:
+ax_pose 24, 0x01eb, 0x90ed, 0x5c00
+ax_pose_terminator
+sWobbuffetPose99:
+ax_pose 33, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sWobbuffetPose100:
+ax_pose 34, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sWobbuffetPose101:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose102:
+ax_pose 22, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose103:
+ax_pose 31, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose104:
+ax_pose 32, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose105:
+ax_pose 6, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose106:
+ax_pose 20, 0x01e7, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose107:
+ax_pose 29, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose108:
+ax_pose 30, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose109:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose110:
+ax_pose 18, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sWobbuffetPose111:
+ax_pose 27, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose112:
+ax_pose 28, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose113:
+ax_pose 35, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose114:
+ax_pose 36, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose115:
+ax_pose 37, 0x01e3, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose116:
+ax_pose 38, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose117:
+ax_pose 39, 0x01e4, 0x90e9, 0x5c00
+ax_pose_terminator
+sWobbuffetPose118:
+ax_pose 40, 0x01e5, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose119:
+ax_pose 41, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose120:
+ax_pose 40, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose121:
+ax_pose 39, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sWobbuffetPose122:
+ax_pose 38, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose123:
+ax_pose 0, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose124:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose125:
+ax_pose 6, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose126:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose127:
+ax_pose 12, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose128:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose129:
+ax_pose 6, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose130:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose131:
+ax_pose 15, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose132:
+ax_pose 17, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose133:
+ax_pose 19, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose134:
+ax_pose 21, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose135:
+ax_pose 23, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose136:
+ax_pose 21, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose137:
+ax_pose 19, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose138:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose139:
+ax_pose 25, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose140:
+ax_pose 27, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose141:
+ax_pose 29, 0x01e7, 0x90f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose142:
+ax_pose 31, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose143:
+ax_pose 33, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose144:
+ax_pose 31, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose145:
+ax_pose 29, 0x01e7, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose146:
+ax_pose 27, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose147:
+ax_pose 0, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose148:
+ax_pose 15, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose149:
+ax_pose 16, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose150:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose151:
+ax_pose 17, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose152:
+ax_pose 18, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose153:
+ax_pose 6, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose154:
+ax_pose 19, 0x01e7, 0x90f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose155:
+ax_pose 20, 0x01e7, 0x90ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose156:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose157:
+ax_pose 21, 0x01e8, 0x90ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose158:
+ax_pose 22, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose159:
+ax_pose 12, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose160:
+ax_pose 23, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose161:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose162:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose163:
+ax_pose 21, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWobbuffetPose164:
+ax_pose 22, 0x01ea, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose165:
+ax_pose 6, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose166:
+ax_pose 19, 0x01e7, 0x80ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose167:
+ax_pose 20, 0x01e7, 0x80f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose168:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose169:
+ax_pose 17, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWobbuffetPose170:
+ax_pose 18, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose171:
+ax_pose 16, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose172:
+ax_pose 18, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWobbuffetPose173:
+ax_pose 20, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose174:
+ax_pose 22, 0x01ea, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose175:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWobbuffetPose176:
+ax_pose 22, 0x01ea, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose177:
+ax_pose 20, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose178:
+ax_pose 18, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWobbuffetPose179:
+ax_pose 0, 0x81ec, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose180:
+ax_pose 3, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose181:
+ax_pose 6, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWobbuffetPose182:
+ax_pose 9, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWobbuffetPose183:
+ax_pose 12, 0x81e8, 0x80f8, 0x5c00
+ax_pose_terminator
+sWobbuffetPose184:
+ax_pose 9, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWobbuffetPose185:
+ax_pose 6, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWobbuffetPose186:
+ax_pose 3, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+.align 2
+sWobbuffetAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWobbuffetAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 4, 4, 4, 4,
+ax_anim 1, 0, 29, 10, 11, 10, 11,
+ax_anim 2, 0, 29, 16, 18, 16, 18,
+ax_anim 2, 1, 29, 17, 17, 17, 17,
+ax_anim 2, 0, 29, 16, 18, 16, 18,
+ax_anim 2, 0, 29, 17, 17, 17, 17,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sWobbuffetAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 4, 0, 31, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 0, 4, 0,
+ax_anim 1, 0, 32, 8, 0, 8, 0,
+ax_anim 2, 0, 32, 13, 0, 13, 0,
+ax_anim 2, 1, 32, 13, 1, 13, 1,
+ax_anim 2, 0, 32, 13, 0, 13, 0,
+ax_anim 2, 0, 32, 13, 1, 13, 1,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sWobbuffetAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 4, 0, 34, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 1, 2, 33, 5, -6, 5, -6,
+ax_anim 1, 0, 35, 10, -11, 10, -11,
+ax_anim 2, 0, 35, 17, -18, 17, -18,
+ax_anim 2, 1, 35, 18, -17, 18, -17,
+ax_anim 2, 0, 35, 17, -18, 17, -18,
+ax_anim 2, 0, 35, 18, -17, 18, -17,
+ax_anim 2, 0, 33, 5, -6, 5, -6,
+ax_anim_terminator
+sWobbuffetAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 4, 0, 37, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 0, -4, 0, -4,
+ax_anim 1, 0, 38, 0, -10, 0, -10,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 1, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 38, 0, -18, 0, -18,
+ax_anim 2, 0, 38, 1, -18, 1, -18,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sWobbuffetAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 4, 0, 40, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 1, 2, 39, -5, -6, -5, -6,
+ax_anim 1, 0, 41, -10, -11, -10, -11,
+ax_anim 2, 0, 41, -17, -18, -17, -18,
+ax_anim 2, 1, 41, -18, -17, -18, -17,
+ax_anim 2, 0, 41, -17, -18, -17, -18,
+ax_anim 2, 0, 41, -18, -17, -18, -17,
+ax_anim 2, 0, 39, -5, -6, -5, -6,
+ax_anim_terminator
+sWobbuffetAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 4, 0, 43, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, 0, -4, 0,
+ax_anim 1, 0, 44, -8, 0, -8, 0,
+ax_anim 2, 0, 44, -13, 0, -13, 0,
+ax_anim 2, 1, 44, -13, 1, -13, 1,
+ax_anim 2, 0, 44, -13, 0, -13, 0,
+ax_anim 2, 0, 44, -13, 1, -13, 1,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sWobbuffetAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 4, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 45, -4, 4, -4, 4,
+ax_anim 1, 0, 47, -10, 11, -10, 11,
+ax_anim 2, 0, 47, -16, 18, -16, 18,
+ax_anim 2, 1, 47, -17, 17, -17, 17,
+ax_anim 2, 0, 47, -16, 18, -16, 18,
+ax_anim 2, 0, 47, -17, 17, -17, 17,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 4, 0, 49, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, 0, 0, 0,
+ax_anim 1, 2, 48, 0, 4, 0, 4,
+ax_anim 1, 0, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sWobbuffetAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 4, 0, 52, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 0, 0, 0,
+ax_anim 1, 2, 51, 4, 4, 4, 4,
+ax_anim 1, 0, 53, 10, 11, 10, 11,
+ax_anim 2, 0, 53, 16, 18, 16, 18,
+ax_anim 2, 1, 53, 17, 17, 17, 17,
+ax_anim 2, 0, 53, 16, 18, 16, 18,
+ax_anim 2, 0, 53, 17, 17, 17, 17,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sWobbuffetAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 4, 0, 55, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 54, 4, 0, 4, 0,
+ax_anim 1, 0, 56, 8, 0, 8, 0,
+ax_anim 2, 0, 56, 13, 0, 13, 0,
+ax_anim 2, 1, 56, 13, 1, 13, 1,
+ax_anim 2, 0, 56, 13, 0, 13, 0,
+ax_anim 2, 0, 56, 13, 1, 13, 1,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sWobbuffetAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 4, 0, 58, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 1, 2, 57, 5, -6, 5, -6,
+ax_anim 1, 0, 59, 10, -11, 10, -11,
+ax_anim 2, 0, 59, 17, -18, 17, -18,
+ax_anim 2, 1, 59, 18, -17, 18, -17,
+ax_anim 2, 0, 59, 17, -18, 17, -18,
+ax_anim 2, 0, 59, 18, -17, 18, -17,
+ax_anim 2, 0, 57, 5, -6, 5, -6,
+ax_anim_terminator
+sWobbuffetAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 4, 0, 61, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, 0, 0, 0,
+ax_anim 1, 2, 60, 0, -4, 0, -4,
+ax_anim 1, 0, 62, 0, -10, 0, -10,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 1, 62, 1, -18, 1, -18,
+ax_anim 2, 0, 62, 0, -18, 0, -18,
+ax_anim 2, 0, 62, 1, -18, 1, -18,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sWobbuffetAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 4, 0, 64, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 1, 2, 63, -5, -6, -5, -6,
+ax_anim 1, 0, 65, -10, -11, -10, -11,
+ax_anim 2, 0, 65, -17, -18, -17, -18,
+ax_anim 2, 1, 65, -18, -17, -18, -17,
+ax_anim 2, 0, 65, -17, -18, -17, -18,
+ax_anim 2, 0, 65, -18, -17, -18, -17,
+ax_anim 2, 0, 63, -5, -6, -5, -6,
+ax_anim_terminator
+sWobbuffetAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 4, 0, 67, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 66, -4, 0, -4, 0,
+ax_anim 1, 0, 68, -8, 0, -8, 0,
+ax_anim 2, 0, 68, -13, 0, -13, 0,
+ax_anim 2, 1, 68, -13, 1, -13, 1,
+ax_anim 2, 0, 68, -13, 0, -13, 0,
+ax_anim 2, 0, 68, -13, 1, -13, 1,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sWobbuffetAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 4, 0, 70, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 69, -4, 4, -4, 4,
+ax_anim 1, 0, 71, -10, 11, -10, 11,
+ax_anim 2, 0, 71, -16, 18, -16, 18,
+ax_anim 2, 1, 71, -17, 17, -17, 17,
+ax_anim 2, 0, 71, -16, 18, -16, 18,
+ax_anim 2, 0, 71, -17, 17, -17, 17,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_4_1:
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 1, 0, 1, 0,
+ax_anim 2, 1, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_4_2:
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, -1,
+ax_anim 2, 1, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_4_3:
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, -1, 0, -1,
+ax_anim 2, 1, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_4_4:
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 77, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_4_5:
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim 2, 1, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_4_6:
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 1, -1, 1, -1,
+ax_anim 2, 1, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_4_7:
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_4_8:
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 73, -1, -1, -1, -1,
+ax_anim 2, 1, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_5_1:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 8, 0, 80, 0, 0, 0, 0,
+ax_anim 16, 0, 82, 0, 0, 0, 0,
+ax_anim 12, 2, 83, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_5_2:
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, 0, 0, 0,
+ax_anim 2, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 0, 85, -1, 0, 0, 0,
+ax_anim 8, 0, 84, 0, 0, 0, 0,
+ax_anim 16, 0, 86, 0, 0, 0, 0,
+ax_anim 12, 2, 87, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_5_3:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 89, -1, 0, 0, 0,
+ax_anim 8, 0, 88, 0, 0, 0, 0,
+ax_anim 16, 0, 90, 0, 0, 0, 0,
+ax_anim 12, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, -1, 0, 0, 0,
+ax_anim 8, 0, 92, 0, 0, 0, 0,
+ax_anim 16, 0, 94, 0, 0, 0, 0,
+ax_anim 12, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_5_5:
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, 0, 0,
+ax_anim 2, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 0, 97, -1, 0, 0, 0,
+ax_anim 8, 0, 96, 0, 0, 0, 0,
+ax_anim 16, 0, 98, 0, 0, 0, 0,
+ax_anim 12, 2, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_5_6:
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 0, 0, 0,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 101, -1, 0, 0, 0,
+ax_anim 8, 0, 100, 0, 0, 0, 0,
+ax_anim 16, 0, 102, 0, 0, 0, 0,
+ax_anim 12, 2, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_5_7:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, 0, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, -1, 0, 0, 0,
+ax_anim 8, 0, 104, 0, 0, 0, 0,
+ax_anim 16, 0, 106, 0, 0, 0, 0,
+ax_anim 12, 2, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_5_8:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, -1, 0, 0, 0,
+ax_anim 8, 0, 108, 0, 0, 0, 0,
+ax_anim 16, 0, 110, 0, 0, 0, 0,
+ax_anim 12, 2, 111, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_6_1:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 35, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_7_1:
+ax_anim 2, 0, 114, 0, -2, 0, -2,
+ax_anim 8, 0, 114, 0, -3, 0, -3,
+ax_anim_terminator
+sWobbuffetAnims_7_2:
+ax_anim 2, 0, 115, -2, -2, -2, -2,
+ax_anim 8, 0, 115, -3, -3, -3, -3,
+ax_anim_terminator
+sWobbuffetAnims_7_3:
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 8, 0, 116, -3, 0, -3, 0,
+ax_anim_terminator
+sWobbuffetAnims_7_4:
+ax_anim 2, 0, 117, -2, 2, -2, 2,
+ax_anim 8, 0, 117, -3, 3, -3, 3,
+ax_anim_terminator
+sWobbuffetAnims_7_5:
+ax_anim 2, 0, 118, 0, 2, 0, 2,
+ax_anim 8, 0, 118, 0, 3, 0, 3,
+ax_anim_terminator
+sWobbuffetAnims_7_6:
+ax_anim 2, 0, 119, 2, 2, 2, 2,
+ax_anim 8, 0, 119, 3, 3, 3, 3,
+ax_anim_terminator
+sWobbuffetAnims_7_7:
+ax_anim 2, 0, 120, 2, 0, 2, 0,
+ax_anim 8, 0, 120, 3, 0, 3, 0,
+ax_anim_terminator
+sWobbuffetAnims_7_8:
+ax_anim 2, 0, 121, 2, -2, 2, -2,
+ax_anim 8, 0, 121, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_8_1:
+ax_anim 40, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim 4, 0, 122, 0, -1, 0, 0,
+ax_anim 4, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_8_2:
+ax_anim 40, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, -1, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, -1, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, -1, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim 4, 0, 129, 0, -1, 0, 0,
+ax_anim 4, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_8_3:
+ax_anim 40, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim 4, 0, 128, 0, -1, 0, 0,
+ax_anim 4, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_8_4:
+ax_anim 40, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim 4, 0, 127, 0, -1, 0, 0,
+ax_anim 4, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_8_5:
+ax_anim 40, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim 4, 0, 126, 0, -1, 0, 0,
+ax_anim 4, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_8_6:
+ax_anim 40, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim 4, 0, 125, 0, -1, 0, 0,
+ax_anim 4, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_8_7:
+ax_anim 40, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim 4, 0, 124, 0, -1, 0, 0,
+ax_anim 4, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_8_8:
+ax_anim 40, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, -1, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, -1, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, -1, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim 4, 0, 123, 0, -1, 0, 0,
+ax_anim 4, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_9_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 131, 6, 3, 6, 3,
+ax_anim 2, 0, 132, 8, 9, 8, 9,
+ax_anim 2, 0, 133, 7, 16, 7, 16,
+ax_anim 3, 0, 134, 0, 18, 0, 18,
+ax_anim 2, 3, 135, -7, 16, -7, 16,
+ax_anim 2, 0, 136, -8, 9, -8, 9,
+ax_anim 1, 0, 137, -6, 3, -6, 3,
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_9_2:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 9, 1, 9, 1,
+ax_anim 2, 0, 131, 20, 5, 20, 5,
+ax_anim 2, 0, 132, 23, 11, 23, 11,
+ax_anim 3, 0, 133, 21, 18, 21, 18,
+ax_anim 2, 3, 134, 14, 18, 14, 18,
+ax_anim 2, 0, 135, 4, 15, 4, 15,
+ax_anim 1, 0, 136, 0, 7, 0, 7,
+ax_anim 1, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_9_3:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 1, 0, 137, 3, -5, 3, -5,
+ax_anim 2, 0, 130, 11, -6, 11, -6,
+ax_anim 2, 0, 131, 17, -5, 17, -5,
+ax_anim 3, 0, 132, 21, -1, 21, -1,
+ax_anim 2, 3, 133, 16, 4, 16, 4,
+ax_anim 2, 0, 134, 12, 5, 12, 5,
+ax_anim 1, 0, 135, 4, 5, 4, 5,
+ax_anim 1, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_9_4:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, -1, -8, -1, -8,
+ax_anim 2, 0, 137, 3, -16, 3, -16,
+ax_anim 2, 0, 130, 12, -20, 12, -20,
+ax_anim 3, 0, 131, 21, -19, 21, -19,
+ax_anim 2, 3, 132, 22, -15, 22, -15,
+ax_anim 2, 0, 133, 18, -5, 18, -5,
+ax_anim 1, 0, 134, 7, -1, 7, -1,
+ax_anim 1, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_9_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 135, -8, -4, -8, -4,
+ax_anim 2, 0, 136, -9, -12, -9, -12,
+ax_anim 2, 0, 137, -7, -18, -7, -18,
+ax_anim 3, 0, 130, 0, -20, 0, -20,
+ax_anim 2, 3, 131, 7, -18, 7, -18,
+ax_anim 2, 0, 132, 9, -10, 9, -10,
+ax_anim 1, 0, 133, 8, -4, 8, -4,
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_9_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 1, -6, 1, -6,
+ax_anim 2, 0, 131, -3, -16, -3, -16,
+ax_anim 2, 0, 130, -12, -20, -12, -20,
+ax_anim 3, 0, 137, -21, -19, -21, -19,
+ax_anim 2, 3, 136, -22, -15, -22, -15,
+ax_anim 2, 0, 135, -18, -5, -18, -5,
+ax_anim 1, 0, 134, -7, -1, -7, -1,
+ax_anim 1, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_9_7:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 131, -3, -5, -3, -5,
+ax_anim 2, 0, 130, -11, -6, -11, -6,
+ax_anim 2, 0, 137, -17, -5, -16, -5,
+ax_anim 3, 0, 136, -21, -1, -18, -2,
+ax_anim 2, 3, 135, -16, 4, -16, 4,
+ax_anim 2, 0, 134, -12, 5, -12, 5,
+ax_anim 1, 0, 133, -4, 5, -4, 5,
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_9_8:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 130, -9, 0, -9, 0,
+ax_anim 2, 0, 137, -20, 5, -20, 5,
+ax_anim 2, 0, 136, -23, 11, -23, 11,
+ax_anim 3, 0, 135, -21, 18, -21, 18,
+ax_anim 2, 3, 134, -14, 20, -14, 20,
+ax_anim 2, 0, 133, -4, 15, -4, 15,
+ax_anim 1, 0, 132, 0, 7, 0, 7,
+ax_anim 1, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_10_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 3, 0, 138, 13, 0, 13, 0,
+ax_anim 3, 0, 138, -13, 0, -13, 0,
+ax_anim 2, 0, 138, 12, 0, 12, 0,
+ax_anim 3, 0, 138, -12, 0, -12, 0,
+ax_anim 2, 0, 138, 10, 0, 10, 0,
+ax_anim 2, 0, 138, -10, 0, -10, 0,
+ax_anim 2, 0, 138, 6, 0, 6, 0,
+ax_anim 2, 0, 138, -6, 0, -6, 0,
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_10_2:
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 3, 0, 139, 13, -13, 13, -13,
+ax_anim 3, 0, 139, -13, 13, -13, 13,
+ax_anim 2, 0, 139, 12, -12, 12, -12,
+ax_anim 3, 0, 139, -12, 12, -12, 12,
+ax_anim 2, 0, 139, 10, -10, 10, -10,
+ax_anim 2, 0, 139, -10, 10, -10, 10,
+ax_anim 2, 0, 139, 6, -6, 6, -6,
+ax_anim 2, 0, 139, -6, 6, -6, 6,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_10_3:
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 3, 0, 140, 0, -13, 0, -13,
+ax_anim 3, 0, 140, 0, 13, 0, 13,
+ax_anim 2, 0, 140, 0, -12, 0, -12,
+ax_anim 3, 0, 140, 0, 12, 0, 12,
+ax_anim 2, 0, 140, 0, -10, 0, -10,
+ax_anim 2, 0, 140, 0, 10, 0, 10,
+ax_anim 2, 0, 140, 0, -6, 0, -6,
+ax_anim 2, 0, 140, 0, 6, 0, 6,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_10_4:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 3, 0, 141, -13, -13, -13, -13,
+ax_anim 3, 0, 141, 13, 13, 13, 13,
+ax_anim 2, 0, 141, -12, -12, -12, -12,
+ax_anim 3, 0, 141, 12, 12, 12, 12,
+ax_anim 2, 0, 141, -10, -10, -10, -10,
+ax_anim 2, 0, 141, 10, 10, 10, 10,
+ax_anim 2, 0, 141, -6, -6, -6, -6,
+ax_anim 2, 0, 141, 6, 6, 6, 6,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_10_5:
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 3, 0, 142, 13, 0, 13, 0,
+ax_anim 3, 0, 142, -13, 0, -13, 0,
+ax_anim 2, 0, 142, 12, 0, 12, 0,
+ax_anim 3, 0, 142, -12, 0, -12, 0,
+ax_anim 2, 0, 142, 10, 0, 10, 0,
+ax_anim 2, 0, 142, -10, 0, -10, 0,
+ax_anim 2, 0, 142, 6, 0, 6, 0,
+ax_anim 2, 0, 142, -6, 0, -6, 0,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_10_6:
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 3, 0, 143, 13, -13, 13, -13,
+ax_anim 3, 0, 143, -13, 13, -13, 13,
+ax_anim 2, 0, 143, 12, -12, 12, -12,
+ax_anim 3, 0, 143, -12, 12, -12, 12,
+ax_anim 2, 0, 143, 10, -10, 10, -10,
+ax_anim 2, 0, 143, -10, 10, -10, 10,
+ax_anim 2, 0, 143, 6, -6, 6, -6,
+ax_anim 2, 0, 143, -6, 6, -6, 6,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_10_7:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 3, 0, 144, 0, -13, 0, -13,
+ax_anim 3, 0, 144, 0, 13, 0, 13,
+ax_anim 2, 0, 144, 0, -12, 0, -12,
+ax_anim 3, 0, 144, 0, 12, 0, 12,
+ax_anim 2, 0, 144, 0, -10, 0, -10,
+ax_anim 2, 0, 144, 0, 10, 0, 10,
+ax_anim 2, 0, 144, 0, -6, 0, -6,
+ax_anim 2, 0, 144, 0, 6, 0, 6,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_10_8:
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 3, 0, 145, -13, -13, -13, -13,
+ax_anim 3, 0, 145, 13, 13, 13, 13,
+ax_anim 2, 0, 145, -12, -12, -12, -12,
+ax_anim 3, 0, 145, 12, 12, 12, 12,
+ax_anim 2, 0, 145, -10, -10, -10, -10,
+ax_anim 2, 0, 145, 10, 10, 10, 10,
+ax_anim 2, 0, 145, -6, -6, -6, -6,
+ax_anim 2, 0, 145, 6, 6, 6, 6,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_11_1:
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 1, 0, 147, 0, -10, 0, 0,
+ax_anim 2, 0, 147, 0, -16, 0, 0,
+ax_anim 3, 0, 147, 0, -20, 0, 0,
+ax_anim 4, 0, 147, 0, -21, 0, 0,
+ax_anim 4, 0, 146, 0, -23, 0, 0,
+ax_anim 3, 0, 148, 0, -22, 0, 0,
+ax_anim 2, 0, 148, 0, -18, 0, 0,
+ax_anim 1, 0, 148, 0, -12, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_11_2:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 1, 0, 150, 0, -10, 0, 0,
+ax_anim 2, 0, 150, 0, -16, 0, 0,
+ax_anim 3, 0, 150, 0, -20, 0, 0,
+ax_anim 4, 0, 150, 0, -21, 0, 0,
+ax_anim 4, 0, 149, 0, -23, 0, 0,
+ax_anim 3, 0, 151, 0, -22, 0, 0,
+ax_anim 2, 0, 151, 0, -18, 0, 0,
+ax_anim 1, 0, 151, 0, -12, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_11_3:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 1, 0, 153, 0, -10, 0, 0,
+ax_anim 2, 0, 153, 0, -16, 0, 0,
+ax_anim 3, 0, 153, 0, -20, 0, 0,
+ax_anim 4, 0, 153, 0, -21, 0, 0,
+ax_anim 4, 0, 152, 0, -22, 0, 0,
+ax_anim 3, 0, 154, 0, -22, 0, 0,
+ax_anim 2, 0, 154, 0, -18, 0, 0,
+ax_anim 1, 0, 154, 0, -12, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_11_4:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 0, -10, 0, 0,
+ax_anim 2, 0, 156, 0, -16, 0, 0,
+ax_anim 3, 0, 156, 0, -20, 0, 0,
+ax_anim 4, 0, 156, 0, -21, 0, 0,
+ax_anim 4, 0, 155, 0, -22, 0, 0,
+ax_anim 3, 0, 157, 0, -21, 0, 0,
+ax_anim 2, 0, 157, 0, -17, 0, 0,
+ax_anim 1, 0, 157, 0, -11, 0, 0,
+ax_anim 2, 2, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_11_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, 0, -10, 0, 0,
+ax_anim 2, 0, 159, 0, -16, 0, 0,
+ax_anim 3, 0, 159, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -22, 0, 0,
+ax_anim 4, 0, 158, 0, -23, 0, 0,
+ax_anim 3, 0, 160, 0, -22, 0, 0,
+ax_anim 2, 0, 160, 0, -18, 0, 0,
+ax_anim 1, 0, 160, 0, -12, 0, 0,
+ax_anim 2, 2, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_11_6:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 0, -10, 0, 0,
+ax_anim 2, 0, 162, 0, -16, 0, 0,
+ax_anim 3, 0, 162, 0, -20, 0, 0,
+ax_anim 4, 0, 162, 0, -21, 0, 0,
+ax_anim 4, 0, 161, 0, -22, 0, 0,
+ax_anim 3, 0, 163, 0, -21, 0, 0,
+ax_anim 2, 0, 163, 0, -17, 0, 0,
+ax_anim 1, 0, 163, 0, -11, 0, 0,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_11_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 165, 0, -10, 0, 0,
+ax_anim 2, 0, 165, 0, -16, 0, 0,
+ax_anim 3, 0, 165, 0, -20, 0, 0,
+ax_anim 4, 0, 165, 0, -21, 0, 0,
+ax_anim 4, 0, 164, 0, -22, 0, 0,
+ax_anim 3, 0, 166, 0, -22, 0, 0,
+ax_anim 2, 0, 166, 0, -18, 0, 0,
+ax_anim 1, 0, 166, 0, -12, 0, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_11_8:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -10, 0, 0,
+ax_anim 2, 0, 168, 0, -16, 0, 0,
+ax_anim 3, 0, 168, 0, -20, 0, 0,
+ax_anim 4, 0, 168, 0, -21, 0, 0,
+ax_anim 4, 0, 167, 0, -23, 0, 0,
+ax_anim 3, 0, 169, 0, -22, 0, 0,
+ax_anim 2, 0, 169, 0, -18, 0, 0,
+ax_anim 1, 0, 169, 0, -12, 0, 0,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_12_1:
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 1, 0, 1, 0,
+ax_anim 2, 1, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_12_2:
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 1, -1, 1, -1,
+ax_anim 2, 1, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_12_3:
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -1, 0, -1,
+ax_anim 2, 1, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_12_4:
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, -1, -1, -1, -1,
+ax_anim 2, 1, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_12_5:
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 1, 0, 1, 0,
+ax_anim 2, 1, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_12_6:
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 1, -1, 1, -1,
+ax_anim 2, 1, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_12_7:
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -1, 0, -1,
+ax_anim 2, 1, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_12_8:
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, -1, -1, -1, -1,
+ax_anim 2, 1, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWobbuffetAnims_13_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_13_2:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_13_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_13_4:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_13_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 2, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_13_6:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_13_7:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 2, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetAnims_13_8:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sWobbuffetGfx1:
+.incbin "baserom.gba", 0xE2C3A4, 0x100
+sWobbuffetSprites1:
+ax_sprite sWobbuffetGfx1, 0x100
+ax_sprite_terminator
+sWobbuffetGfx2:
+.incbin "baserom.gba", 0xE2C4B4, 0x200
+sWobbuffetSprites2:
+ax_sprite sWobbuffetGfx2, 0x200
+ax_sprite_terminator
+sWobbuffetGfx3:
+.incbin "baserom.gba", 0xE2C6C4, 0x200
+sWobbuffetSprites3:
+ax_sprite sWobbuffetGfx3, 0x200
+ax_sprite_terminator
+sWobbuffetGfx4:
+.incbin "baserom.gba", 0xE2C8D4, 0x200
+sWobbuffetSprites4:
+ax_sprite sWobbuffetGfx4, 0x200
+ax_sprite_terminator
+sWobbuffetGfx5:
+.incbin "baserom.gba", 0xE2CAE4, 0x200
+sWobbuffetSprites5:
+ax_sprite sWobbuffetGfx5, 0x200
+ax_sprite_terminator
+sWobbuffetGfx6:
+.incbin "baserom.gba", 0xE2CCF4, 0x200
+sWobbuffetSprites6:
+ax_sprite sWobbuffetGfx6, 0x200
+ax_sprite_terminator
+sWobbuffetGfx7:
+.incbin "baserom.gba", 0xE2CF04, 0x200
+sWobbuffetSprites7:
+ax_sprite sWobbuffetGfx7, 0x200
+ax_sprite_terminator
+sWobbuffetGfx8:
+.incbin "baserom.gba", 0xE2D114, 0x200
+sWobbuffetSprites8:
+ax_sprite sWobbuffetGfx8, 0x200
+ax_sprite_terminator
+sWobbuffetGfx9:
+.incbin "baserom.gba", 0xE2D324, 0x200
+sWobbuffetSprites9:
+ax_sprite sWobbuffetGfx9, 0x200
+ax_sprite_terminator
+sWobbuffetGfx10:
+.incbin "baserom.gba", 0xE2D534, 0x200
+sWobbuffetSprites10:
+ax_sprite sWobbuffetGfx10, 0x200
+ax_sprite_terminator
+sWobbuffetGfx11:
+.incbin "baserom.gba", 0xE2D744, 0x200
+sWobbuffetSprites11:
+ax_sprite sWobbuffetGfx11, 0x200
+ax_sprite_terminator
+sWobbuffetGfx12:
+.incbin "baserom.gba", 0xE2D954, 0x200
+sWobbuffetSprites12:
+ax_sprite sWobbuffetGfx12, 0x200
+ax_sprite_terminator
+sWobbuffetGfx13:
+.incbin "baserom.gba", 0xE2DB64, 0x100
+sWobbuffetSprites13:
+ax_sprite sWobbuffetGfx13, 0x100
+ax_sprite_terminator
+sWobbuffetGfx14:
+.incbin "baserom.gba", 0xE2DC74, 0x200
+sWobbuffetSprites14:
+ax_sprite sWobbuffetGfx14, 0x200
+ax_sprite_terminator
+sWobbuffetGfx15:
+.incbin "baserom.gba", 0xE2DE84, 0x200
+sWobbuffetSprites15:
+ax_sprite sWobbuffetGfx15, 0x200
+ax_sprite_terminator
+sWobbuffetGfx16:
+.incbin "baserom.gba", 0xE2E094, 0xE0
+sWobbuffetGfx16_1:
+.incbin "baserom.gba", 0xE2E174, 0x60
+sWobbuffetGfx16_2:
+.incbin "baserom.gba", 0xE2E1D4, 0x60
+sWobbuffetSprites16:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx16, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx16_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx16_2, 0x60
+ax_sprite_terminator
+sWobbuffetGfx17:
+.incbin "baserom.gba", 0xE2E26C, 0x20
+sWobbuffetGfx17_1:
+.incbin "baserom.gba", 0xE2E28C, 0x100
+sWobbuffetGfx17_2:
+.incbin "baserom.gba", 0xE2E38C, 0x60
+sWobbuffetSprites17:
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx17, 0x20
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx17_2, 0x60
+ax_sprite_terminator
+sWobbuffetGfx18:
+.incbin "baserom.gba", 0xE2E424, 0xE0
+sWobbuffetGfx18_1:
+.incbin "baserom.gba", 0xE2E504, 0x60
+sWobbuffetGfx18_2:
+.incbin "baserom.gba", 0xE2E564, 0x40
+sWobbuffetSprites18:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx18, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx19:
+.incbin "baserom.gba", 0xE2E5E4, 0x40
+sWobbuffetGfx19_1:
+.incbin "baserom.gba", 0xE2E624, 0x60
+sWobbuffetGfx19_2:
+.incbin "baserom.gba", 0xE2E684, 0x80
+sWobbuffetGfx19_3:
+.incbin "baserom.gba", 0xE2E704, 0x40
+sWobbuffetSprites19:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx19_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx20:
+.incbin "baserom.gba", 0xE2E794, 0x40
+sWobbuffetGfx20_1:
+.incbin "baserom.gba", 0xE2E7D4, 0x60
+sWobbuffetGfx20_2:
+.incbin "baserom.gba", 0xE2E834, 0x60
+sWobbuffetGfx20_3:
+.incbin "baserom.gba", 0xE2E894, 0x60
+sWobbuffetSprites20:
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx20_3, 0x60
+ax_sprite_terminator
+sWobbuffetGfx21:
+.incbin "baserom.gba", 0xE2E93C, 0x40
+sWobbuffetGfx21_1:
+.incbin "baserom.gba", 0xE2E97C, 0x60
+sWobbuffetGfx21_2:
+.incbin "baserom.gba", 0xE2E9DC, 0x60
+sWobbuffetGfx21_3:
+.incbin "baserom.gba", 0xE2EA3C, 0x40
+sWobbuffetSprites21:
+ax_sprite sWobbuffetGfx21, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx21_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx21_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx22:
+.incbin "baserom.gba", 0xE2EAC4, 0x40
+sWobbuffetGfx22_1:
+.incbin "baserom.gba", 0xE2EB04, 0xE0
+sWobbuffetGfx22_2:
+.incbin "baserom.gba", 0xE2EBE4, 0x40
+sWobbuffetSprites22:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx22_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx23:
+.incbin "baserom.gba", 0xE2EC64, 0x60
+sWobbuffetGfx23_1:
+.incbin "baserom.gba", 0xE2ECC4, 0x60
+sWobbuffetGfx23_2:
+.incbin "baserom.gba", 0xE2ED24, 0x60
+sWobbuffetGfx23_3:
+.incbin "baserom.gba", 0xE2ED84, 0x20
+sWobbuffetSprites23:
+ax_sprite sWobbuffetGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx23_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx23_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWobbuffetGfx24:
+.incbin "baserom.gba", 0xE2EDEC, 0x20
+sWobbuffetGfx24_1:
+.incbin "baserom.gba", 0xE2EE0C, 0x60
+sWobbuffetGfx24_2:
+.incbin "baserom.gba", 0xE2EE6C, 0x60
+sWobbuffetGfx24_3:
+.incbin "baserom.gba", 0xE2EECC, 0x60
+sWobbuffetSprites24:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx24, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx24_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx24_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx25:
+.incbin "baserom.gba", 0xE2EF7C, 0x60
+sWobbuffetGfx25_1:
+.incbin "baserom.gba", 0xE2EFDC, 0x60
+sWobbuffetGfx25_2:
+.incbin "baserom.gba", 0xE2F03C, 0x60
+sWobbuffetSprites25:
+ax_sprite sWobbuffetGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWobbuffetGfx26:
+.incbin "baserom.gba", 0xE2F0D4, 0x100
+sWobbuffetGfx26_1:
+.incbin "baserom.gba", 0xE2F1D4, 0x60
+sWobbuffetGfx26_2:
+.incbin "baserom.gba", 0xE2F234, 0x60
+sWobbuffetSprites26:
+ax_sprite sWobbuffetGfx26, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx26_2, 0x60
+ax_sprite_terminator
+sWobbuffetGfx27:
+.incbin "baserom.gba", 0xE2F2C4, 0x60
+sWobbuffetGfx27_1:
+.incbin "baserom.gba", 0xE2F324, 0x60
+sWobbuffetGfx27_2:
+.incbin "baserom.gba", 0xE2F384, 0x60
+sWobbuffetGfx27_3:
+.incbin "baserom.gba", 0xE2F3E4, 0x60
+sWobbuffetSprites27:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx27_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx27_3, 0x60
+ax_sprite_terminator
+sWobbuffetGfx28:
+.incbin "baserom.gba", 0xE2F48C, 0x80
+sWobbuffetGfx28_1:
+.incbin "baserom.gba", 0xE2F50C, 0x60
+sWobbuffetGfx28_2:
+.incbin "baserom.gba", 0xE2F56C, 0x60
+sWobbuffetGfx28_3:
+.incbin "baserom.gba", 0xE2F5CC, 0x40
+sWobbuffetSprites28:
+ax_sprite sWobbuffetGfx28, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx28_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx28_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx29:
+.incbin "baserom.gba", 0xE2F654, 0x60
+sWobbuffetGfx29_1:
+.incbin "baserom.gba", 0xE2F6B4, 0x60
+sWobbuffetGfx29_2:
+.incbin "baserom.gba", 0xE2F714, 0x60
+sWobbuffetGfx29_3:
+.incbin "baserom.gba", 0xE2F774, 0x40
+sWobbuffetSprites29:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx29_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx30:
+.incbin "baserom.gba", 0xE2F804, 0x60
+sWobbuffetGfx30_1:
+.incbin "baserom.gba", 0xE2F864, 0x60
+sWobbuffetGfx30_2:
+.incbin "baserom.gba", 0xE2F8C4, 0x60
+sWobbuffetGfx30_3:
+.incbin "baserom.gba", 0xE2F924, 0x60
+sWobbuffetSprites30:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx30, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx30_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx30_3, 0x60
+ax_sprite_terminator
+sWobbuffetGfx31:
+.incbin "baserom.gba", 0xE2F9CC, 0x40
+sWobbuffetGfx31_1:
+.incbin "baserom.gba", 0xE2FA0C, 0x60
+sWobbuffetGfx31_2:
+.incbin "baserom.gba", 0xE2FA6C, 0x60
+sWobbuffetGfx31_3:
+.incbin "baserom.gba", 0xE2FACC, 0x60
+sWobbuffetSprites31:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx31_3, 0x60
+ax_sprite_terminator
+sWobbuffetGfx32:
+.incbin "baserom.gba", 0xE2FB74, 0x40
+sWobbuffetGfx32_1:
+.incbin "baserom.gba", 0xE2FBB4, 0x60
+sWobbuffetGfx32_2:
+.incbin "baserom.gba", 0xE2FC14, 0x60
+sWobbuffetGfx32_3:
+.incbin "baserom.gba", 0xE2FC74, 0x40
+sWobbuffetSprites32:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx32, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx32_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx32_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx33:
+.incbin "baserom.gba", 0xE2FD04, 0x40
+sWobbuffetGfx33_1:
+.incbin "baserom.gba", 0xE2FD44, 0x60
+sWobbuffetGfx33_2:
+.incbin "baserom.gba", 0xE2FDA4, 0x60
+sWobbuffetGfx33_3:
+.incbin "baserom.gba", 0xE2FE04, 0x40
+sWobbuffetSprites33:
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx33, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx33_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWobbuffetGfx33_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx34:
+.incbin "baserom.gba", 0xE2FE94, 0x60
+sWobbuffetGfx34_1:
+.incbin "baserom.gba", 0xE2FEF4, 0x60
+sWobbuffetGfx34_2:
+.incbin "baserom.gba", 0xE2FF54, 0x60
+sWobbuffetGfx34_3:
+.incbin "baserom.gba", 0xE2FFB4, 0x60
+sWobbuffetSprites34:
+ax_sprite sWobbuffetGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx35:
+.incbin "baserom.gba", 0xE3005C, 0x60
+sWobbuffetGfx35_1:
+.incbin "baserom.gba", 0xE300BC, 0x60
+sWobbuffetGfx35_2:
+.incbin "baserom.gba", 0xE3011C, 0x60
+sWobbuffetGfx35_3:
+.incbin "baserom.gba", 0xE3017C, 0x60
+sWobbuffetSprites35:
+ax_sprite sWobbuffetGfx35, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx35_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx35_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWobbuffetGfx35_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWobbuffetGfx36:
+.incbin "baserom.gba", 0xE30224, 0x200
+sWobbuffetSprites36:
+ax_sprite sWobbuffetGfx36, 0x200
+ax_sprite_terminator
+sWobbuffetGfx37:
+.incbin "baserom.gba", 0xE30434, 0x200
+sWobbuffetSprites37:
+ax_sprite sWobbuffetGfx37, 0x200
+ax_sprite_terminator
+sWobbuffetGfx38:
+.incbin "baserom.gba", 0xE30644, 0x200
+sWobbuffetSprites38:
+ax_sprite sWobbuffetGfx38, 0x200
+ax_sprite_terminator
+sWobbuffetGfx39:
+.incbin "baserom.gba", 0xE30854, 0x200
+sWobbuffetSprites39:
+ax_sprite sWobbuffetGfx39, 0x200
+ax_sprite_terminator
+sWobbuffetGfx40:
+.incbin "baserom.gba", 0xE30A64, 0x200
+sWobbuffetSprites40:
+ax_sprite sWobbuffetGfx40, 0x200
+ax_sprite_terminator
+sWobbuffetGfx41:
+.incbin "baserom.gba", 0xE30C74, 0x200
+sWobbuffetSprites41:
+ax_sprite sWobbuffetGfx41, 0x200
+ax_sprite_terminator
+sWobbuffetGfx42:
+.incbin "baserom.gba", 0xE30E84, 0x200
+sWobbuffetSprites42:
+ax_sprite sWobbuffetGfx42, 0x200
+ax_sprite_terminator
+sAxPosesWobbuffet:
+.4byte sWobbuffetPose1
+.4byte sWobbuffetPose2
+.4byte sWobbuffetPose3
+.4byte sWobbuffetPose4
+.4byte sWobbuffetPose5
+.4byte sWobbuffetPose6
+.4byte sWobbuffetPose7
+.4byte sWobbuffetPose8
+.4byte sWobbuffetPose9
+.4byte sWobbuffetPose10
+.4byte sWobbuffetPose11
+.4byte sWobbuffetPose12
+.4byte sWobbuffetPose13
+.4byte sWobbuffetPose14
+.4byte sWobbuffetPose15
+.4byte sWobbuffetPose16
+.4byte sWobbuffetPose17
+.4byte sWobbuffetPose18
+.4byte sWobbuffetPose19
+.4byte sWobbuffetPose20
+.4byte sWobbuffetPose21
+.4byte sWobbuffetPose22
+.4byte sWobbuffetPose23
+.4byte sWobbuffetPose24
+.4byte sWobbuffetPose25
+.4byte sWobbuffetPose26
+.4byte sWobbuffetPose27
+.4byte sWobbuffetPose28
+.4byte sWobbuffetPose29
+.4byte sWobbuffetPose30
+.4byte sWobbuffetPose31
+.4byte sWobbuffetPose32
+.4byte sWobbuffetPose33
+.4byte sWobbuffetPose34
+.4byte sWobbuffetPose35
+.4byte sWobbuffetPose36
+.4byte sWobbuffetPose37
+.4byte sWobbuffetPose38
+.4byte sWobbuffetPose39
+.4byte sWobbuffetPose40
+.4byte sWobbuffetPose41
+.4byte sWobbuffetPose42
+.4byte sWobbuffetPose43
+.4byte sWobbuffetPose44
+.4byte sWobbuffetPose45
+.4byte sWobbuffetPose46
+.4byte sWobbuffetPose47
+.4byte sWobbuffetPose48
+.4byte sWobbuffetPose49
+.4byte sWobbuffetPose50
+.4byte sWobbuffetPose51
+.4byte sWobbuffetPose52
+.4byte sWobbuffetPose53
+.4byte sWobbuffetPose54
+.4byte sWobbuffetPose55
+.4byte sWobbuffetPose56
+.4byte sWobbuffetPose57
+.4byte sWobbuffetPose58
+.4byte sWobbuffetPose59
+.4byte sWobbuffetPose60
+.4byte sWobbuffetPose61
+.4byte sWobbuffetPose62
+.4byte sWobbuffetPose63
+.4byte sWobbuffetPose64
+.4byte sWobbuffetPose65
+.4byte sWobbuffetPose66
+.4byte sWobbuffetPose67
+.4byte sWobbuffetPose68
+.4byte sWobbuffetPose69
+.4byte sWobbuffetPose70
+.4byte sWobbuffetPose71
+.4byte sWobbuffetPose72
+.4byte sWobbuffetPose73
+.4byte sWobbuffetPose74
+.4byte sWobbuffetPose75
+.4byte sWobbuffetPose76
+.4byte sWobbuffetPose77
+.4byte sWobbuffetPose78
+.4byte sWobbuffetPose79
+.4byte sWobbuffetPose80
+.4byte sWobbuffetPose81
+.4byte sWobbuffetPose82
+.4byte sWobbuffetPose83
+.4byte sWobbuffetPose84
+.4byte sWobbuffetPose85
+.4byte sWobbuffetPose86
+.4byte sWobbuffetPose87
+.4byte sWobbuffetPose88
+.4byte sWobbuffetPose89
+.4byte sWobbuffetPose90
+.4byte sWobbuffetPose91
+.4byte sWobbuffetPose92
+.4byte sWobbuffetPose93
+.4byte sWobbuffetPose94
+.4byte sWobbuffetPose95
+.4byte sWobbuffetPose96
+.4byte sWobbuffetPose97
+.4byte sWobbuffetPose98
+.4byte sWobbuffetPose99
+.4byte sWobbuffetPose100
+.4byte sWobbuffetPose101
+.4byte sWobbuffetPose102
+.4byte sWobbuffetPose103
+.4byte sWobbuffetPose104
+.4byte sWobbuffetPose105
+.4byte sWobbuffetPose106
+.4byte sWobbuffetPose107
+.4byte sWobbuffetPose108
+.4byte sWobbuffetPose109
+.4byte sWobbuffetPose110
+.4byte sWobbuffetPose111
+.4byte sWobbuffetPose112
+.4byte sWobbuffetPose113
+.4byte sWobbuffetPose114
+.4byte sWobbuffetPose115
+.4byte sWobbuffetPose116
+.4byte sWobbuffetPose117
+.4byte sWobbuffetPose118
+.4byte sWobbuffetPose119
+.4byte sWobbuffetPose120
+.4byte sWobbuffetPose121
+.4byte sWobbuffetPose122
+.4byte sWobbuffetPose123
+.4byte sWobbuffetPose124
+.4byte sWobbuffetPose125
+.4byte sWobbuffetPose126
+.4byte sWobbuffetPose127
+.4byte sWobbuffetPose128
+.4byte sWobbuffetPose129
+.4byte sWobbuffetPose130
+.4byte sWobbuffetPose131
+.4byte sWobbuffetPose132
+.4byte sWobbuffetPose133
+.4byte sWobbuffetPose134
+.4byte sWobbuffetPose135
+.4byte sWobbuffetPose136
+.4byte sWobbuffetPose137
+.4byte sWobbuffetPose138
+.4byte sWobbuffetPose139
+.4byte sWobbuffetPose140
+.4byte sWobbuffetPose141
+.4byte sWobbuffetPose142
+.4byte sWobbuffetPose143
+.4byte sWobbuffetPose144
+.4byte sWobbuffetPose145
+.4byte sWobbuffetPose146
+.4byte sWobbuffetPose147
+.4byte sWobbuffetPose148
+.4byte sWobbuffetPose149
+.4byte sWobbuffetPose150
+.4byte sWobbuffetPose151
+.4byte sWobbuffetPose152
+.4byte sWobbuffetPose153
+.4byte sWobbuffetPose154
+.4byte sWobbuffetPose155
+.4byte sWobbuffetPose156
+.4byte sWobbuffetPose157
+.4byte sWobbuffetPose158
+.4byte sWobbuffetPose159
+.4byte sWobbuffetPose160
+.4byte sWobbuffetPose161
+.4byte sWobbuffetPose162
+.4byte sWobbuffetPose163
+.4byte sWobbuffetPose164
+.4byte sWobbuffetPose165
+.4byte sWobbuffetPose166
+.4byte sWobbuffetPose167
+.4byte sWobbuffetPose168
+.4byte sWobbuffetPose169
+.4byte sWobbuffetPose170
+.4byte sWobbuffetPose171
+.4byte sWobbuffetPose172
+.4byte sWobbuffetPose173
+.4byte sWobbuffetPose174
+.4byte sWobbuffetPose175
+.4byte sWobbuffetPose176
+.4byte sWobbuffetPose177
+.4byte sWobbuffetPose178
+.4byte sWobbuffetPose179
+.4byte sWobbuffetPose180
+.4byte sWobbuffetPose181
+.4byte sWobbuffetPose182
+.4byte sWobbuffetPose183
+.4byte sWobbuffetPose184
+.4byte sWobbuffetPose185
+.4byte sWobbuffetPose186
+sAxPositionsWobbuffet:
+.2byte    0,  -11, 	  -4,   -5, 	   3,   -5, 	   0,   -8
+.2byte   -1,  -11, 	  -3,   -5, 	   3,   -6, 	  -1,   -7
+.2byte    0,  -11, 	  -4,   -6, 	   2,   -5, 	   0,   -7
+.2byte    2,  -12, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    3,  -11, 	   4,   -5, 	  -2,   -5, 	   1,   -8
+.2byte    2,  -11, 	   5,   -6, 	   0,   -4, 	   0,   -8
+.2byte    5,  -13, 	   4,   -7, 	   4,   -5, 	   0,   -9
+.2byte    5,  -14, 	   4,   -7, 	   4,   -6, 	   0,   -9
+.2byte    5,  -11, 	   4,   -9, 	   3,   -5, 	  -1,   -9
+.2byte    1,  -14, 	  -1,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    0,  -13, 	  -2,   -8, 	   3,   -8, 	  -1,   -9
+.2byte    2,  -11, 	  -2,   -8, 	   3,   -6, 	   0,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte    1,  -11, 	   3,   -6, 	  -2,   -7, 	   1,   -8
+.2byte   -2,  -11, 	   1,   -7, 	  -4,   -6, 	  -2,   -8
+.2byte   -2,  -14, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -13, 	   1,   -8, 	  -4,   -8, 	   0,   -9
+.2byte   -3,  -11, 	   1,   -8, 	  -4,   -6, 	  -1,   -9
+.2byte   -6,  -13, 	  -5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -6,  -14, 	  -5,   -7, 	  -5,   -6, 	  -1,   -9
+.2byte   -6,  -11, 	  -5,   -9, 	  -4,   -5, 	   0,   -9
+.2byte   -3,  -12, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -4,  -11, 	  -5,   -5, 	   1,   -5, 	  -2,   -8
+.2byte   -3,  -11, 	  -6,   -6, 	  -1,   -4, 	  -1,   -8
+.2byte    0,  -11, 	  -4,   -5, 	   3,   -5, 	   0,   -8
+.2byte    0,  -14, 	  -9,   -9, 	   8,   -9, 	   0,  -10
+.2byte   -1,   -2, 	 -10,   -9, 	   9,   -9, 	   0,   -7
+.2byte    2,  -12, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    0,  -14, 	   7,  -13, 	  -4,   -8, 	  -1,  -11
+.2byte   10,   -2, 	   9,  -11, 	  -3,   -7, 	   6,   -6
+.2byte    5,  -13, 	   4,   -7, 	   4,   -5, 	   0,   -9
+.2byte    0,  -14, 	   4,  -11, 	   4,  -10, 	  -4,  -10
+.2byte   13,   -6, 	   6,  -14, 	   3,  -10, 	   8,   -8
+.2byte    1,  -14, 	  -1,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    0,  -15, 	  -4,  -16, 	   7,  -13, 	  -1,  -10
+.2byte    6,  -10, 	  -4,  -15, 	  10,   -6, 	   3,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte    0,  -11, 	   7,  -13, 	  -8,  -13, 	   0,   -9
+.2byte    0,  -13, 	   8,  -10, 	  -9,  -10, 	   0,  -11
+.2byte   -2,  -14, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -15, 	   3,  -16, 	  -8,  -13, 	   0,  -10
+.2byte   -7,  -10, 	   3,  -15, 	 -11,   -6, 	  -4,   -9
+.2byte   -6,  -13, 	  -5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	  -5,  -11, 	  -5,  -10, 	   3,  -10
+.2byte  -14,   -6, 	  -7,  -14, 	  -4,  -10, 	  -9,   -8
+.2byte   -3,  -12, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -1,  -14, 	  -8,  -13, 	   3,   -8, 	   0,  -11
+.2byte  -11,   -2, 	 -10,  -11, 	   2,   -7, 	  -7,   -6
+.2byte    0,  -11, 	  -4,   -5, 	   3,   -5, 	   0,   -8
+.2byte    0,  -14, 	  -9,   -9, 	   8,   -9, 	   0,  -10
+.2byte   -1,   -2, 	 -10,   -9, 	   9,   -9, 	   0,   -7
+.2byte    2,  -12, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    0,  -14, 	   7,  -13, 	  -4,   -8, 	  -1,  -11
+.2byte   10,   -2, 	   9,  -11, 	  -3,   -7, 	   6,   -6
+.2byte    5,  -13, 	   4,   -7, 	   4,   -5, 	   0,   -9
+.2byte    0,  -14, 	   4,  -11, 	   4,  -10, 	  -4,  -10
+.2byte   13,   -6, 	   6,  -14, 	   3,  -10, 	   8,   -8
+.2byte    1,  -14, 	  -1,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    0,  -15, 	  -4,  -16, 	   7,  -13, 	  -1,  -10
+.2byte    6,  -10, 	  -4,  -15, 	  10,   -6, 	   3,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte    0,  -11, 	   7,  -13, 	  -8,  -13, 	   0,   -9
+.2byte    0,  -13, 	   8,  -10, 	  -9,  -10, 	   0,  -11
+.2byte   -2,  -14, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -15, 	   3,  -16, 	  -8,  -13, 	   0,  -10
+.2byte   -7,  -10, 	   3,  -15, 	 -11,   -6, 	  -4,   -9
+.2byte   -6,  -13, 	  -5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -1,  -14, 	  -5,  -11, 	  -5,  -10, 	   3,  -10
+.2byte  -14,   -6, 	  -7,  -14, 	  -4,  -10, 	  -9,   -8
+.2byte   -3,  -12, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -1,  -14, 	  -8,  -13, 	   3,   -8, 	   0,  -11
+.2byte  -11,   -2, 	 -10,  -11, 	   2,   -7, 	  -7,   -6
+.2byte   -1,   -2, 	 -10,   -9, 	   9,   -9, 	   0,   -7
+.2byte   -8,   -2, 	  -7,  -11, 	   5,   -7, 	  -4,   -6
+.2byte   -8,   -6, 	  -1,  -14, 	   2,  -10, 	  -3,   -8
+.2byte   -5,  -10, 	   5,  -15, 	  -9,   -6, 	  -2,   -9
+.2byte    0,  -13, 	   8,  -10, 	  -9,  -10, 	   0,  -11
+.2byte    4,  -10, 	  -6,  -15, 	   8,   -6, 	   1,   -9
+.2byte    7,   -6, 	   0,  -14, 	  -3,  -10, 	   2,   -8
+.2byte    7,   -2, 	   6,  -11, 	  -6,   -7, 	   3,   -6
+.2byte   -1,  -11, 	   3,   -5, 	  -4,   -5, 	  -1,   -8
+.2byte    0,   -3, 	   9,  -10, 	 -10,  -10, 	  -1,   -8
+.2byte   -1,  -14, 	  10,  -16, 	  -8,   -6, 	  -1,  -10
+.2byte    0,  -12, 	   3,  -19, 	  -3,   -4, 	  -1,   -8
+.2byte    2,  -12, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    9,   -3, 	   8,  -12, 	  -4,   -8, 	   5,   -7
+.2byte    1,  -14, 	   9,  -19, 	  -3,   -5, 	   0,  -10
+.2byte    1,  -11, 	   3,  -19, 	  -1,   -4, 	   0,   -9
+.2byte    5,  -13, 	   4,   -7, 	   4,   -5, 	   0,   -9
+.2byte   12,   -6, 	   5,  -14, 	   2,  -10, 	   7,   -8
+.2byte    3,  -14, 	   5,  -22, 	   2,   -6, 	  -1,  -10
+.2byte    4,  -12, 	   2,  -20, 	   5,   -4, 	   0,  -10
+.2byte    1,  -14, 	  -1,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    7,  -12, 	  -3,  -17, 	  11,   -8, 	   4,  -11
+.2byte    1,  -14, 	  -6,  -21, 	   7,   -8, 	  -1,  -11
+.2byte    1,  -13, 	  -2,  -20, 	   3,   -8, 	   0,  -10
+.2byte   -1,  -12, 	  -3,   -7, 	   2,   -7, 	   0,   -9
+.2byte   -1,  -12, 	  -9,   -9, 	   8,   -9, 	  -1,  -10
+.2byte    0,  -15, 	  -9,  -19, 	   6,   -7, 	  -1,  -10
+.2byte    0,  -13, 	  -4,  -19, 	   0,   -7, 	  -1,   -9
+.2byte   -2,  -14, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -8,  -12, 	   2,  -17, 	 -12,   -8, 	  -5,  -11
+.2byte   -2,  -14, 	   5,  -21, 	  -8,   -8, 	   0,  -11
+.2byte   -2,  -13, 	   1,  -20, 	  -4,   -8, 	  -1,  -10
+.2byte   -6,  -13, 	  -5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte  -13,   -6, 	  -6,  -14, 	  -3,  -10, 	  -8,   -8
+.2byte   -4,  -14, 	  -6,  -22, 	  -3,   -6, 	   0,  -10
+.2byte   -5,  -12, 	  -3,  -20, 	  -6,   -4, 	  -1,  -10
+.2byte   -3,  -12, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte  -10,   -3, 	  -9,  -12, 	   3,   -8, 	  -6,   -7
+.2byte   -2,  -14, 	 -10,  -19, 	   2,   -5, 	  -1,  -10
+.2byte   -2,  -11, 	  -4,  -19, 	   0,   -4, 	  -1,   -9
+.2byte   -5,   -8, 	  -7,   -4, 	  -2,   -3, 	  -4,   -8
+.2byte   -5,   -7, 	  -7,   -3, 	  -2,   -2, 	  -3,   -9
+.2byte   -1,  -14, 	 -13,  -16, 	  11,  -18, 	   0,  -11
+.2byte    0,  -14, 	   7,  -19, 	 -13,  -17, 	  -2,  -12
+.2byte    2,  -16, 	  -6,  -19, 	  -6,  -16, 	  -1,  -12
+.2byte   -3,  -14, 	 -11,  -16, 	   6,  -15, 	  -2,  -11
+.2byte    0,  -12, 	  10,  -15, 	 -11,  -13, 	   0,  -10
+.2byte    2,  -14, 	  10,  -16, 	  -7,  -15, 	   1,  -11
+.2byte   -3,  -16, 	   5,  -19, 	   5,  -16, 	   0,  -12
+.2byte   -1,  -14, 	  -8,  -19, 	  12,  -17, 	   1,  -12
+.2byte    0,  -11, 	  -4,   -5, 	   3,   -5, 	   0,   -8
+.2byte   -3,  -12, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -6,  -13, 	  -5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -2,  -14, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte    1,  -14, 	  -1,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    5,  -13, 	   4,   -7, 	   4,   -5, 	   0,   -9
+.2byte    2,  -12, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    0,  -14, 	  -9,   -9, 	   8,   -9, 	   0,  -10
+.2byte   -1,  -14, 	  -8,  -13, 	   3,   -8, 	   0,  -11
+.2byte   -1,  -14, 	  -5,  -11, 	  -5,  -10, 	   3,  -10
+.2byte   -1,  -15, 	   3,  -16, 	  -8,  -13, 	   0,  -10
+.2byte    0,  -11, 	   7,  -13, 	  -8,  -13, 	   0,   -9
+.2byte    0,  -15, 	  -4,  -16, 	   7,  -13, 	  -1,  -10
+.2byte    0,  -14, 	   4,  -11, 	   4,  -10, 	  -4,  -10
+.2byte    0,  -14, 	   7,  -13, 	  -4,   -8, 	  -1,  -11
+.2byte    0,  -14, 	 -11,  -16, 	   7,   -6, 	   0,  -10
+.2byte    1,  -14, 	   9,  -19, 	  -3,   -5, 	   0,  -10
+.2byte    3,  -14, 	   5,  -22, 	   2,   -6, 	  -1,  -10
+.2byte    1,  -14, 	  -6,  -21, 	   7,   -8, 	  -1,  -11
+.2byte   -1,  -15, 	   8,  -19, 	  -7,   -7, 	   0,  -10
+.2byte   -2,  -13, 	   5,  -20, 	  -8,   -7, 	   0,  -10
+.2byte   -4,  -14, 	  -6,  -22, 	  -3,   -6, 	   0,  -10
+.2byte   -2,  -14, 	 -10,  -19, 	   2,   -5, 	  -1,  -10
+.2byte    0,  -11, 	  -4,   -5, 	   3,   -5, 	   0,   -8
+.2byte    0,  -14, 	  -9,   -9, 	   8,   -9, 	   0,  -10
+.2byte   -1,   -2, 	 -10,   -9, 	   9,   -9, 	   0,   -7
+.2byte    2,  -12, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+.2byte    0,  -14, 	   7,  -13, 	  -4,   -8, 	  -1,  -11
+.2byte    7,   -2, 	   6,  -11, 	  -6,   -7, 	   3,   -6
+.2byte    5,  -13, 	   4,   -7, 	   4,   -5, 	   0,   -9
+.2byte    2,  -14, 	   6,  -11, 	   6,  -10, 	  -2,  -10
+.2byte    9,   -6, 	   2,  -14, 	  -1,  -10, 	   4,   -8
+.2byte    1,  -14, 	  -1,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    0,  -15, 	  -4,  -16, 	   7,  -13, 	  -1,  -10
+.2byte    4,  -10, 	  -6,  -15, 	   8,   -6, 	   1,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte    0,  -11, 	   7,  -13, 	  -8,  -13, 	   0,   -9
+.2byte    0,  -13, 	   8,  -10, 	  -9,  -10, 	   0,  -11
+.2byte   -2,  -14, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte   -1,  -15, 	   3,  -16, 	  -8,  -13, 	   0,  -10
+.2byte   -5,  -10, 	   5,  -15, 	  -9,   -6, 	  -2,   -9
+.2byte   -6,  -13, 	  -5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -3,  -14, 	  -7,  -11, 	  -7,  -10, 	   1,  -10
+.2byte  -10,   -6, 	  -3,  -14, 	   0,  -10, 	  -5,   -8
+.2byte   -3,  -12, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -1,  -14, 	  -8,  -13, 	   3,   -8, 	   0,  -11
+.2byte   -8,   -2, 	  -7,  -11, 	   5,   -7, 	  -4,   -6
+.2byte   -1,   -2, 	 -10,   -9, 	   9,   -9, 	   0,   -7
+.2byte   -8,   -2, 	  -7,  -11, 	   5,   -7, 	  -4,   -6
+.2byte   -8,   -6, 	  -1,  -14, 	   2,  -10, 	  -3,   -8
+.2byte   -5,  -10, 	   5,  -15, 	  -9,   -6, 	  -2,   -9
+.2byte    0,  -13, 	   8,  -10, 	  -9,  -10, 	   0,  -11
+.2byte    4,  -10, 	  -6,  -15, 	   8,   -6, 	   1,   -9
+.2byte    7,   -6, 	   0,  -14, 	  -3,  -10, 	   2,   -8
+.2byte    7,   -2, 	   6,  -11, 	  -6,   -7, 	   3,   -6
+.2byte    0,  -11, 	  -4,   -5, 	   3,   -5, 	   0,   -8
+.2byte   -3,  -12, 	  -5,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -6,  -13, 	  -5,   -7, 	  -5,   -5, 	  -1,   -9
+.2byte   -2,  -14, 	   0,   -8, 	  -3,   -7, 	   0,   -9
+.2byte    0,  -12, 	   2,   -7, 	  -3,   -7, 	  -1,   -9
+.2byte    1,  -14, 	  -1,   -8, 	   2,   -7, 	  -1,   -9
+.2byte    5,  -13, 	   4,   -7, 	   4,   -5, 	   0,   -9
+.2byte    2,  -12, 	   4,   -6, 	  -1,   -5, 	  -1,   -9
+sWobbuffetAnimTable1:
+.4byte sWobbuffetAnims_1_1
+.4byte sWobbuffetAnims_1_2
+.4byte sWobbuffetAnims_1_3
+.4byte sWobbuffetAnims_1_4
+.4byte sWobbuffetAnims_1_5
+.4byte sWobbuffetAnims_1_6
+.4byte sWobbuffetAnims_1_7
+.4byte sWobbuffetAnims_1_8
+sWobbuffetAnimTable2:
+.4byte sWobbuffetAnims_2_1
+.4byte sWobbuffetAnims_2_2
+.4byte sWobbuffetAnims_2_3
+.4byte sWobbuffetAnims_2_4
+.4byte sWobbuffetAnims_2_5
+.4byte sWobbuffetAnims_2_6
+.4byte sWobbuffetAnims_2_7
+.4byte sWobbuffetAnims_2_8
+sWobbuffetAnimTable3:
+.4byte sWobbuffetAnims_3_1
+.4byte sWobbuffetAnims_3_2
+.4byte sWobbuffetAnims_3_3
+.4byte sWobbuffetAnims_3_4
+.4byte sWobbuffetAnims_3_5
+.4byte sWobbuffetAnims_3_6
+.4byte sWobbuffetAnims_3_7
+.4byte sWobbuffetAnims_3_8
+sWobbuffetAnimTable4:
+.4byte sWobbuffetAnims_4_1
+.4byte sWobbuffetAnims_4_2
+.4byte sWobbuffetAnims_4_3
+.4byte sWobbuffetAnims_4_4
+.4byte sWobbuffetAnims_4_5
+.4byte sWobbuffetAnims_4_6
+.4byte sWobbuffetAnims_4_7
+.4byte sWobbuffetAnims_4_8
+sWobbuffetAnimTable5:
+.4byte sWobbuffetAnims_5_1
+.4byte sWobbuffetAnims_5_2
+.4byte sWobbuffetAnims_5_3
+.4byte sWobbuffetAnims_5_4
+.4byte sWobbuffetAnims_5_5
+.4byte sWobbuffetAnims_5_6
+.4byte sWobbuffetAnims_5_7
+.4byte sWobbuffetAnims_5_8
+sWobbuffetAnimTable6:
+.4byte sWobbuffetAnims_6_1
+.4byte sWobbuffetAnims_6_1
+.4byte sWobbuffetAnims_6_1
+.4byte sWobbuffetAnims_6_1
+.4byte sWobbuffetAnims_6_1
+.4byte sWobbuffetAnims_6_1
+.4byte sWobbuffetAnims_6_1
+.4byte sWobbuffetAnims_6_1
+sWobbuffetAnimTable7:
+.4byte sWobbuffetAnims_7_1
+.4byte sWobbuffetAnims_7_2
+.4byte sWobbuffetAnims_7_3
+.4byte sWobbuffetAnims_7_4
+.4byte sWobbuffetAnims_7_5
+.4byte sWobbuffetAnims_7_6
+.4byte sWobbuffetAnims_7_7
+.4byte sWobbuffetAnims_7_8
+sWobbuffetAnimTable8:
+.4byte sWobbuffetAnims_8_1
+.4byte sWobbuffetAnims_8_2
+.4byte sWobbuffetAnims_8_3
+.4byte sWobbuffetAnims_8_4
+.4byte sWobbuffetAnims_8_5
+.4byte sWobbuffetAnims_8_6
+.4byte sWobbuffetAnims_8_7
+.4byte sWobbuffetAnims_8_8
+sWobbuffetAnimTable9:
+.4byte sWobbuffetAnims_9_1
+.4byte sWobbuffetAnims_9_2
+.4byte sWobbuffetAnims_9_3
+.4byte sWobbuffetAnims_9_4
+.4byte sWobbuffetAnims_9_5
+.4byte sWobbuffetAnims_9_6
+.4byte sWobbuffetAnims_9_7
+.4byte sWobbuffetAnims_9_8
+sWobbuffetAnimTable10:
+.4byte sWobbuffetAnims_10_1
+.4byte sWobbuffetAnims_10_2
+.4byte sWobbuffetAnims_10_3
+.4byte sWobbuffetAnims_10_4
+.4byte sWobbuffetAnims_10_5
+.4byte sWobbuffetAnims_10_6
+.4byte sWobbuffetAnims_10_7
+.4byte sWobbuffetAnims_10_8
+sWobbuffetAnimTable11:
+.4byte sWobbuffetAnims_11_1
+.4byte sWobbuffetAnims_11_2
+.4byte sWobbuffetAnims_11_3
+.4byte sWobbuffetAnims_11_4
+.4byte sWobbuffetAnims_11_5
+.4byte sWobbuffetAnims_11_6
+.4byte sWobbuffetAnims_11_7
+.4byte sWobbuffetAnims_11_8
+sWobbuffetAnimTable12:
+.4byte sWobbuffetAnims_12_1
+.4byte sWobbuffetAnims_12_2
+.4byte sWobbuffetAnims_12_3
+.4byte sWobbuffetAnims_12_4
+.4byte sWobbuffetAnims_12_5
+.4byte sWobbuffetAnims_12_6
+.4byte sWobbuffetAnims_12_7
+.4byte sWobbuffetAnims_12_8
+sWobbuffetAnimTable13:
+.4byte sWobbuffetAnims_13_1
+.4byte sWobbuffetAnims_13_2
+.4byte sWobbuffetAnims_13_3
+.4byte sWobbuffetAnims_13_4
+.4byte sWobbuffetAnims_13_5
+.4byte sWobbuffetAnims_13_6
+.4byte sWobbuffetAnims_13_7
+.4byte sWobbuffetAnims_13_8
+sAxAnimationsWobbuffet:
+.4byte sWobbuffetAnimTable1
+.4byte sWobbuffetAnimTable2
+.4byte sWobbuffetAnimTable3
+.4byte sWobbuffetAnimTable4
+.4byte sWobbuffetAnimTable5
+.4byte sWobbuffetAnimTable6
+.4byte sWobbuffetAnimTable7
+.4byte sWobbuffetAnimTable8
+.4byte sWobbuffetAnimTable9
+.4byte sWobbuffetAnimTable10
+.4byte sWobbuffetAnimTable11
+.4byte sWobbuffetAnimTable12
+.4byte sWobbuffetAnimTable13
+sAxSpritesWobbuffet:
+.4byte sWobbuffetSprites1
+.4byte sWobbuffetSprites2
+.4byte sWobbuffetSprites3
+.4byte sWobbuffetSprites4
+.4byte sWobbuffetSprites5
+.4byte sWobbuffetSprites6
+.4byte sWobbuffetSprites7
+.4byte sWobbuffetSprites8
+.4byte sWobbuffetSprites9
+.4byte sWobbuffetSprites10
+.4byte sWobbuffetSprites11
+.4byte sWobbuffetSprites12
+.4byte sWobbuffetSprites13
+.4byte sWobbuffetSprites14
+.4byte sWobbuffetSprites15
+.4byte sWobbuffetSprites16
+.4byte sWobbuffetSprites17
+.4byte sWobbuffetSprites18
+.4byte sWobbuffetSprites19
+.4byte sWobbuffetSprites20
+.4byte sWobbuffetSprites21
+.4byte sWobbuffetSprites22
+.4byte sWobbuffetSprites23
+.4byte sWobbuffetSprites24
+.4byte sWobbuffetSprites25
+.4byte sWobbuffetSprites26
+.4byte sWobbuffetSprites27
+.4byte sWobbuffetSprites28
+.4byte sWobbuffetSprites29
+.4byte sWobbuffetSprites30
+.4byte sWobbuffetSprites31
+.4byte sWobbuffetSprites32
+.4byte sWobbuffetSprites33
+.4byte sWobbuffetSprites34
+.4byte sWobbuffetSprites35
+.4byte sWobbuffetSprites36
+.4byte sWobbuffetSprites37
+.4byte sWobbuffetSprites38
+.4byte sWobbuffetSprites39
+.4byte sWobbuffetSprites40
+.4byte sWobbuffetSprites41
+.4byte sWobbuffetSprites42
+sAxMainWobbuffet:
+ax_main sAxPosesWobbuffet, sAxAnimationsWobbuffet, 13, sAxSpritesWobbuffet, sAxPositionsWobbuffet

--- a/data/ax/wooper.inc
+++ b/data/ax/wooper.inc
@@ -1,0 +1,2643 @@
+.global gAxWooper
+gAxWooper:
+ax_siro sAxMainWooper
+sWooperPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose2:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose3:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose4:
+ax_pose 3, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose5:
+ax_pose 4, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose6:
+ax_pose 5, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose7:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose8:
+ax_pose 7, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose9:
+ax_pose 8, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose10:
+ax_pose 9, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose11:
+ax_pose 10, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose12:
+ax_pose 11, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose13:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose14:
+ax_pose 13, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose15:
+ax_pose 14, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose16:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose17:
+ax_pose 16, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose18:
+ax_pose 17, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose19:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose20:
+ax_pose 19, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose21:
+ax_pose 20, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose22:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose23:
+ax_pose 22, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose24:
+ax_pose 23, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose26:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose27:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose28:
+ax_pose 24, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose29:
+ax_pose 3, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose30:
+ax_pose 4, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose31:
+ax_pose 5, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose32:
+ax_pose 25, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose33:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose34:
+ax_pose 7, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose35:
+ax_pose 8, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose36:
+ax_pose 26, 0x81ea, 0x90f5, 0x7c00
+ax_pose_terminator
+sWooperPose37:
+ax_pose 9, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose38:
+ax_pose 10, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose39:
+ax_pose 11, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose40:
+ax_pose 27, 0x81eb, 0x90f7, 0x7c00
+ax_pose_terminator
+sWooperPose41:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose42:
+ax_pose 13, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose43:
+ax_pose 14, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose44:
+ax_pose 28, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose45:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose46:
+ax_pose 16, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose47:
+ax_pose 17, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose48:
+ax_pose 27, 0x81eb, 0x80fa, 0x7c00
+ax_pose_terminator
+sWooperPose49:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose50:
+ax_pose 19, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose51:
+ax_pose 20, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose52:
+ax_pose 26, 0x81ea, 0x80fc, 0x7c00
+ax_pose_terminator
+sWooperPose53:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose54:
+ax_pose 22, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose55:
+ax_pose 23, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose56:
+ax_pose 25, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose57:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose58:
+ax_pose 1, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose59:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose60:
+ax_pose 24, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose61:
+ax_pose 3, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose62:
+ax_pose 4, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose63:
+ax_pose 5, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose64:
+ax_pose 25, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose65:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose66:
+ax_pose 7, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose67:
+ax_pose 8, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose68:
+ax_pose 26, 0x81ea, 0x90f5, 0x7c00
+ax_pose_terminator
+sWooperPose69:
+ax_pose 9, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose70:
+ax_pose 10, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose71:
+ax_pose 11, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose72:
+ax_pose 27, 0x81eb, 0x90f7, 0x7c00
+ax_pose_terminator
+sWooperPose73:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose74:
+ax_pose 13, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose75:
+ax_pose 14, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose76:
+ax_pose 28, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose77:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose78:
+ax_pose 16, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose79:
+ax_pose 17, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose80:
+ax_pose 27, 0x81eb, 0x80fa, 0x7c00
+ax_pose_terminator
+sWooperPose81:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose82:
+ax_pose 19, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose83:
+ax_pose 20, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose84:
+ax_pose 26, 0x81ea, 0x80fc, 0x7c00
+ax_pose_terminator
+sWooperPose85:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose86:
+ax_pose 22, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose87:
+ax_pose 23, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose88:
+ax_pose 25, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose89:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose90:
+ax_pose 24, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose91:
+ax_pose 29, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose92:
+ax_pose 3, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose93:
+ax_pose 25, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose94:
+ax_pose 30, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose95:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose96:
+ax_pose 26, 0x81ea, 0x90f5, 0x7c00
+ax_pose_terminator
+sWooperPose97:
+ax_pose 31, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose98:
+ax_pose 9, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose99:
+ax_pose 27, 0x81eb, 0x90f7, 0x7c00
+ax_pose_terminator
+sWooperPose100:
+ax_pose 32, 0x81eb, 0x90fa, 0x7c00
+ax_pose_terminator
+sWooperPose101:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose102:
+ax_pose 28, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose103:
+ax_pose 33, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose104:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose105:
+ax_pose 27, 0x81eb, 0x80fa, 0x7c00
+ax_pose_terminator
+sWooperPose106:
+ax_pose 32, 0x81eb, 0x80f7, 0x7c00
+ax_pose_terminator
+sWooperPose107:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose108:
+ax_pose 26, 0x81ea, 0x80fc, 0x7c00
+ax_pose_terminator
+sWooperPose109:
+ax_pose 31, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose110:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose111:
+ax_pose 25, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose112:
+ax_pose 30, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose113:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose114:
+ax_pose 24, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose115:
+ax_pose 29, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose116:
+ax_pose 3, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose117:
+ax_pose 25, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose118:
+ax_pose 30, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose119:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose120:
+ax_pose 26, 0x81ea, 0x90f5, 0x7c00
+ax_pose_terminator
+sWooperPose121:
+ax_pose 31, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose122:
+ax_pose 9, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose123:
+ax_pose 27, 0x81eb, 0x90f7, 0x7c00
+ax_pose_terminator
+sWooperPose124:
+ax_pose 32, 0x81ec, 0x90fa, 0x7c00
+ax_pose_terminator
+sWooperPose125:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose126:
+ax_pose 28, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose127:
+ax_pose 33, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose128:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose129:
+ax_pose 27, 0x81eb, 0x80fa, 0x7c00
+ax_pose_terminator
+sWooperPose130:
+ax_pose 32, 0x81ec, 0x80f7, 0x7c00
+ax_pose_terminator
+sWooperPose131:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose132:
+ax_pose 26, 0x81ea, 0x80fc, 0x7c00
+ax_pose_terminator
+sWooperPose133:
+ax_pose 31, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose134:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose135:
+ax_pose 25, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose136:
+ax_pose 30, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose137:
+ax_pose 34, 0x01ec, 0x80f5, 0x7c00
+ax_pose_terminator
+sWooperPose138:
+ax_pose 35, 0x01ec, 0x80f5, 0x7c00
+ax_pose_terminator
+sWooperPose139:
+ax_pose 36, 0x01e9, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose140:
+ax_pose 37, 0x01e8, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose141:
+ax_pose 38, 0x01eb, 0x90ec, 0x7c00
+ax_pose_terminator
+sWooperPose142:
+ax_pose 39, 0x01eb, 0x90ee, 0x7c00
+ax_pose_terminator
+sWooperPose143:
+ax_pose 40, 0x01e7, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose144:
+ax_pose 39, 0x01eb, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose145:
+ax_pose 38, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose146:
+ax_pose 37, 0x01e8, 0x80f3, 0x7c00
+ax_pose_terminator
+sWooperPose147:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose148:
+ax_pose 1, 0x01eb, 0x80f5, 0x7c00
+ax_pose_terminator
+sWooperPose149:
+ax_pose 2, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose150:
+ax_pose 3, 0x01ea, 0x80f3, 0x7c00
+ax_pose_terminator
+sWooperPose151:
+ax_pose 4, 0x01ea, 0x80f6, 0x7c00
+ax_pose_terminator
+sWooperPose152:
+ax_pose 5, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose153:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose154:
+ax_pose 7, 0x01ea, 0x80f1, 0x7c00
+ax_pose_terminator
+sWooperPose155:
+ax_pose 8, 0x01eb, 0x80f1, 0x7c00
+ax_pose_terminator
+sWooperPose156:
+ax_pose 9, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose157:
+ax_pose 10, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose158:
+ax_pose 11, 0x01eb, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose159:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose160:
+ax_pose 13, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose161:
+ax_pose 14, 0x01eb, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose162:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose163:
+ax_pose 16, 0x01ec, 0x80f5, 0x7c00
+ax_pose_terminator
+sWooperPose164:
+ax_pose 17, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose165:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose166:
+ax_pose 19, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose167:
+ax_pose 20, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose168:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose169:
+ax_pose 22, 0x01eb, 0x80f3, 0x7c00
+ax_pose_terminator
+sWooperPose170:
+ax_pose 23, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose171:
+ax_pose 29, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose172:
+ax_pose 30, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose173:
+ax_pose 31, 0x01ea, 0x80f5, 0x7c00
+ax_pose_terminator
+sWooperPose174:
+ax_pose 32, 0x81ec, 0x80f7, 0x7c00
+ax_pose_terminator
+sWooperPose175:
+ax_pose 33, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose176:
+ax_pose 32, 0x81ec, 0x90fa, 0x7c00
+ax_pose_terminator
+sWooperPose177:
+ax_pose 31, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sWooperPose178:
+ax_pose 30, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sWooperPose179:
+ax_pose 29, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose180:
+ax_pose 30, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sWooperPose181:
+ax_pose 31, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sWooperPose182:
+ax_pose 32, 0x81ec, 0x90fa, 0x7c00
+ax_pose_terminator
+sWooperPose183:
+ax_pose 33, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose184:
+ax_pose 32, 0x81ec, 0x80f7, 0x7c00
+ax_pose_terminator
+sWooperPose185:
+ax_pose 31, 0x01ea, 0x80f5, 0x7c00
+ax_pose_terminator
+sWooperPose186:
+ax_pose 30, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose187:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose188:
+ax_pose 24, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose189:
+ax_pose 29, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose190:
+ax_pose 21, 0x01ea, 0x90ec, 0x7c00
+ax_pose_terminator
+sWooperPose191:
+ax_pose 25, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose192:
+ax_pose 30, 0x01ea, 0x90eb, 0x7c00
+ax_pose_terminator
+sWooperPose193:
+ax_pose 18, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose194:
+ax_pose 26, 0x81ea, 0x90f6, 0x7c00
+ax_pose_terminator
+sWooperPose195:
+ax_pose 31, 0x01ea, 0x90ea, 0x7c00
+ax_pose_terminator
+sWooperPose196:
+ax_pose 15, 0x01eb, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose197:
+ax_pose 27, 0x81eb, 0x90f7, 0x7c00
+ax_pose_terminator
+sWooperPose198:
+ax_pose 32, 0x81eb, 0x90f9, 0x7c00
+ax_pose_terminator
+sWooperPose199:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose200:
+ax_pose 28, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose201:
+ax_pose 33, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose202:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose203:
+ax_pose 27, 0x81eb, 0x80fa, 0x7c00
+ax_pose_terminator
+sWooperPose204:
+ax_pose 32, 0x81eb, 0x80f7, 0x7c00
+ax_pose_terminator
+sWooperPose205:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose206:
+ax_pose 26, 0x81ea, 0x80fb, 0x7c00
+ax_pose_terminator
+sWooperPose207:
+ax_pose 31, 0x01ea, 0x80f7, 0x7c00
+ax_pose_terminator
+sWooperPose208:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose209:
+ax_pose 25, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose210:
+ax_pose 30, 0x01ea, 0x80f6, 0x7c00
+ax_pose_terminator
+sWooperPose211:
+ax_pose 24, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose212:
+ax_pose 25, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose213:
+ax_pose 26, 0x81ea, 0x80fb, 0x7c00
+ax_pose_terminator
+sWooperPose214:
+ax_pose 27, 0x81ea, 0x80fa, 0x7c00
+ax_pose_terminator
+sWooperPose215:
+ax_pose 28, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose216:
+ax_pose 27, 0x81ea, 0x90f7, 0x7c00
+ax_pose_terminator
+sWooperPose217:
+ax_pose 26, 0x81ea, 0x90f5, 0x7c00
+ax_pose_terminator
+sWooperPose218:
+ax_pose 25, 0x01ea, 0x90ed, 0x7c00
+ax_pose_terminator
+sWooperPose219:
+ax_pose 0, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose220:
+ax_pose 21, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose221:
+ax_pose 18, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose222:
+ax_pose 15, 0x01eb, 0x80f4, 0x7c00
+ax_pose_terminator
+sWooperPose223:
+ax_pose 12, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose224:
+ax_pose 9, 0x01ea, 0x80f2, 0x7c00
+ax_pose_terminator
+sWooperPose225:
+ax_pose 6, 0x01ea, 0x80f0, 0x7c00
+ax_pose_terminator
+sWooperPose226:
+ax_pose 3, 0x01ea, 0x80f4, 0x7c00
+ax_pose_terminator
+.align 2
+sWooperAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 1, -1, 0, 0,
+ax_anim 6, 0, 1, 1, -2, 0, 0,
+ax_anim 6, 0, 1, 1, -1, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, -1, -1, 0, 0,
+ax_anim 6, 0, 2, -1, -2, 0, 0,
+ax_anim 6, 0, 2, -1, -1, 0, 0,
+ax_anim_terminator
+sWooperAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 1, -1, 1, -1,
+ax_anim 6, 0, 4, 1, -2, 1, -1,
+ax_anim 6, 0, 4, 1, -1, 1, -1,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, -1, -1, -1, 1,
+ax_anim 6, 0, 5, -1, -2, -1, 1,
+ax_anim 6, 0, 5, -1, -1, -1, 1,
+ax_anim_terminator
+sWooperAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 7, 0, -2, 0, 0,
+ax_anim 6, 0, 7, 0, -1, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim 6, 0, 8, 0, -2, 0, 0,
+ax_anim 6, 0, 8, 0, -1, 0, 0,
+ax_anim_terminator
+sWooperAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, -1, -1, -1, -1,
+ax_anim 6, 0, 10, -1, -2, -1, -1,
+ax_anim 6, 0, 10, -1, -1, -1, -1,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 1, -1, 1, 1,
+ax_anim 6, 0, 11, 1, -2, 1, 1,
+ax_anim 6, 0, 11, 1, -1, 1, 1,
+ax_anim_terminator
+sWooperAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 13, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 0, -2, 0, 0,
+ax_anim 6, 0, 14, 0, -1, 0, 0,
+ax_anim_terminator
+sWooperAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, -1, -1, -1, 1,
+ax_anim 6, 0, 16, -1, -2, -1, 1,
+ax_anim 6, 0, 16, -1, -1, -1, 1,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 1, -1, 1, -1,
+ax_anim 6, 0, 17, 1, -2, 1, -1,
+ax_anim 6, 0, 17, 1, -1, 1, -1,
+ax_anim_terminator
+sWooperAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 19, 0, -2, 0, 0,
+ax_anim 6, 0, 19, 0, -1, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim 6, 0, 20, 0, -2, 0, 0,
+ax_anim 6, 0, 20, 0, -1, 0, 0,
+ax_anim_terminator
+sWooperAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 1, -1, 1, 1,
+ax_anim 6, 0, 22, 1, -2, 1, 1,
+ax_anim 6, 0, 22, 1, -1, 1, 1,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, -1, -1, -1, -1,
+ax_anim 6, 0, 23, -1, -2, -1, -1,
+ax_anim 6, 0, 23, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sWooperAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 6, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWooperAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 6, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 11, 10, 11, 10,
+ax_anim 2, 0, 31, 23, 20, 23, 20,
+ax_anim 2, 1, 31, 24, 19, 24, 19,
+ax_anim 2, 0, 31, 23, 20, 23, 20,
+ax_anim 2, 0, 31, 24, 19, 24, 19,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sWooperAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 6, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 35, 24, 0, 24, 0,
+ax_anim 2, 1, 35, 24, 1, 24, 1,
+ax_anim 2, 0, 35, 24, 0, 24, 0,
+ax_anim 2, 0, 35, 24, 1, 24, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sWooperAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 6, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 4, -4, 4, -4,
+ax_anim 1, 0, 38, 10, -10, 10, -10,
+ax_anim 2, 0, 39, 22, -23, 22, -23,
+ax_anim 2, 1, 39, 23, -22, 23, -22,
+ax_anim 2, 0, 39, 22, -23, 22, -23,
+ax_anim 2, 0, 39, 23, -22, 23, -22,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sWooperAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 6, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -23, 0, -23,
+ax_anim 2, 1, 43, 1, -23, 1, -23,
+ax_anim 2, 0, 43, 0, -23, 0, -23,
+ax_anim 2, 0, 43, 1, -23, 1, -23,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sWooperAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 6, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -4, -4, -4, -4,
+ax_anim 1, 0, 46, -10, -10, -10, -10,
+ax_anim 2, 0, 47, -22, -23, -22, -23,
+ax_anim 2, 1, 47, -23, -22, -23, -22,
+ax_anim 2, 0, 47, -22, -23, -22, -23,
+ax_anim 2, 0, 47, -23, -22, -23, -22,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sWooperAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 6, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 51, -24, 0, -24, 0,
+ax_anim 2, 1, 51, -24, 1, -24, 1,
+ax_anim 2, 0, 51, -24, 0, -24, 0,
+ax_anim 2, 0, 51, -24, 1, -24, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sWooperAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 6, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -11, 10, -11, 10,
+ax_anim 2, 0, 55, -23, 20, -23, 20,
+ax_anim 2, 1, 55, -24, 19, -24, 19,
+ax_anim 2, 0, 55, -23, 20, -23, 20,
+ax_anim 2, 0, 55, -24, 19, -24, 19,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWooperAnims_3_1:
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 6, 0, 56, 0, -2, 0, -2,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 57, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sWooperAnims_3_2:
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 6, 0, 60, -2, -2, -2, -2,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 61, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 11, 10, 11, 10,
+ax_anim 2, 0, 63, 23, 20, 23, 20,
+ax_anim 2, 1, 63, 24, 19, 24, 19,
+ax_anim 2, 0, 63, 23, 20, 23, 20,
+ax_anim 2, 0, 63, 24, 19, 24, 19,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sWooperAnims_3_3:
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 6, 0, 64, -2, 0, -2, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 65, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 67, 24, 0, 24, 0,
+ax_anim 2, 1, 67, 24, 1, 24, 1,
+ax_anim 2, 0, 67, 24, 0, 24, 0,
+ax_anim 2, 0, 67, 24, 1, 24, 1,
+ax_anim 2, 0, 64, 6, 0, 6, 0,
+ax_anim_terminator
+sWooperAnims_3_4:
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 6, 0, 68, -2, 2, -2, 2,
+ax_anim 1, 0, 70, 0, -1, 0, -1,
+ax_anim 1, 2, 69, 4, -4, 4, -4,
+ax_anim 1, 0, 70, 10, -10, 10, -10,
+ax_anim 2, 0, 71, 22, -23, 22, -23,
+ax_anim 2, 1, 71, 23, -22, 23, -22,
+ax_anim 2, 0, 71, 22, -23, 22, -23,
+ax_anim 2, 0, 71, 23, -22, 23, -22,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sWooperAnims_3_5:
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 6, 0, 72, 0, 2, 0, 2,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 73, 0, -4, 0, -4,
+ax_anim 1, 0, 74, 0, -11, 0, -11,
+ax_anim 2, 0, 75, 0, -23, 0, -23,
+ax_anim 2, 1, 75, 1, -23, 1, -23,
+ax_anim 2, 0, 75, 0, -23, 0, -23,
+ax_anim 2, 0, 75, 1, -23, 1, -23,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sWooperAnims_3_6:
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 6, 0, 76, 2, 2, 2, 2,
+ax_anim 1, 0, 78, 0, -1, 0, -1,
+ax_anim 1, 2, 77, -4, -4, -4, -4,
+ax_anim 1, 0, 78, -10, -10, -10, -10,
+ax_anim 2, 0, 79, -22, -23, -22, -23,
+ax_anim 2, 1, 79, -23, -22, -23, -22,
+ax_anim 2, 0, 79, -22, -23, -22, -23,
+ax_anim 2, 0, 79, -23, -22, -23, -22,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sWooperAnims_3_7:
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 6, 0, 80, 2, 0, 2, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 81, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 83, -24, 0, -24, 0,
+ax_anim 2, 1, 83, -24, 1, -24, 1,
+ax_anim 2, 0, 83, -24, 0, -24, 0,
+ax_anim 2, 0, 83, -24, 1, -24, 1,
+ax_anim 2, 0, 80, -6, 0, -6, 0,
+ax_anim_terminator
+sWooperAnims_3_8:
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 6, 0, 84, 2, -2, 2, -2,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 85, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -11, 10, -11, 10,
+ax_anim 2, 0, 87, -23, 20, -23, 20,
+ax_anim 2, 1, 87, -24, 19, -24, 19,
+ax_anim 2, 0, 87, -23, 20, -23, 20,
+ax_anim 2, 0, 87, -24, 19, -24, 19,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWooperAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 6, 2, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 90, 0, -2, 0, -2,
+ax_anim 2, 0, 90, 0, 1, 0, 0,
+ax_anim 2, 1, 90, -1, 1, -1, 0,
+ax_anim 2, 0, 90, 0, 1, 0, 0,
+ax_anim 2, 0, 90, -1, 1, -1, 0,
+ax_anim 2, 0, 90, 0, 1, 0, 0,
+ax_anim 2, 0, 90, -1, 1, -1, 0,
+ax_anim 2, 0, 88, 0, 1, -1, 0,
+ax_anim_terminator
+sWooperAnims_4_2:
+ax_anim 2, 0, 91, -1, -1, -1, -1,
+ax_anim 6, 2, 92, -3, -3, -3, -3,
+ax_anim 1, 0, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 1, 93, 0, 2, 0, 2,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 2, 0, 93, 1, 1, 1, 1,
+ax_anim 2, 0, 93, 0, 2, 0, 2,
+ax_anim 2, 0, 91, 1, 1, 1, 1,
+ax_anim_terminator
+sWooperAnims_4_3:
+ax_anim 2, 0, 94, -1, 0, -1, 0,
+ax_anim 6, 2, 95, -3, 0, -3, 0,
+ax_anim 1, 0, 96, -2, 0, -2, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 1, 96, 1, -1, 1, -1,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 1, -1, 1, -1,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 1, -1, 1, -1,
+ax_anim 2, 0, 94, 1, 0, 1, 0,
+ax_anim_terminator
+sWooperAnims_4_4:
+ax_anim 2, 0, 97, -1, 1, -1, 1,
+ax_anim 6, 2, 98, -3, 3, -3, 3,
+ax_anim 1, 0, 99, -2, 2, -2, 2,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 1, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 99, 1, -1, 1, -1,
+ax_anim 2, 0, 99, 0, -2, 0, -2,
+ax_anim 2, 0, 97, 1, -1, 1, -1,
+ax_anim_terminator
+sWooperAnims_4_5:
+ax_anim 2, 0, 100, 0, 1, 0, 1,
+ax_anim 6, 2, 101, 0, 3, 0, 3,
+ax_anim 1, 0, 102, 0, 2, 0, 2,
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim 2, 1, 102, -1, -1, -1, 0,
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim 2, 0, 102, -1, -1, -1, 0,
+ax_anim 2, 0, 102, 0, -1, 0, 0,
+ax_anim 2, 0, 102, -1, -1, -1, 0,
+ax_anim 2, 0, 100, 0, -1, -1, 0,
+ax_anim_terminator
+sWooperAnims_4_6:
+ax_anim 2, 0, 103, 1, 1, 1, 1,
+ax_anim 6, 2, 104, 3, 3, 3, 3,
+ax_anim 1, 0, 105, 2, 2, 2, 2,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 1, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 105, -1, -1, -1, -1,
+ax_anim 2, 0, 105, 0, -2, 0, -2,
+ax_anim 2, 0, 103, -1, -1, -1, -1,
+ax_anim_terminator
+sWooperAnims_4_7:
+ax_anim 2, 0, 106, 1, 0, 1, 0,
+ax_anim 6, 2, 107, 3, 0, 3, 0,
+ax_anim 1, 0, 108, 2, 0, 2, 0,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 1, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 108, -1, 0, -1, 0,
+ax_anim 2, 0, 108, -1, -1, -1, -1,
+ax_anim 2, 0, 106, -1, 0, -1, 0,
+ax_anim_terminator
+sWooperAnims_4_8:
+ax_anim 2, 0, 109, 1, -1, 1, -1,
+ax_anim 6, 2, 110, 3, -3, 3, -3,
+ax_anim 1, 0, 111, 2, -2, 2, -2,
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 1, 111, 0, 2, 0, 2,
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 2, 0, 111, -1, 1, -1, 1,
+ax_anim 2, 0, 111, 0, 2, 0, 2,
+ax_anim 2, 0, 109, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sWooperAnims_5_1:
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 6, 2, 113, 0, -3, 0, -3,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 1, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_5_2:
+ax_anim 2, 0, 115, -1, -1, -1, -1,
+ax_anim 6, 2, 116, -3, -3, -3, -3,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 1, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_5_3:
+ax_anim 2, 0, 118, -1, 0, -1, 0,
+ax_anim 6, 2, 119, -3, 0, -3, 0,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 1, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_5_4:
+ax_anim 2, 0, 121, -1, 1, -1, 1,
+ax_anim 6, 2, 122, -3, 3, -3, 3,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 1, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_5_5:
+ax_anim 2, 0, 124, 0, 1, 0, 1,
+ax_anim 6, 2, 125, 0, 3, 0, 3,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 1, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_5_6:
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 6, 2, 128, 3, 3, 3, 3,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 1, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_5_7:
+ax_anim 2, 0, 130, 1, 0, 1, 0,
+ax_anim 6, 2, 131, 3, 0, 3, 0,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 3, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 1, 114, 0, 0, 0, 0,
+ax_anim 3, 0, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_5_8:
+ax_anim 2, 0, 133, 1, -1, 1, -1,
+ax_anim 6, 2, 134, 3, -3, 3, -3,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 3, 0, 114, 0, 0, 0, 0,
+ax_anim 3, 1, 117, 0, 0, 0, 0,
+ax_anim 3, 0, 120, 0, 0, 0, 0,
+ax_anim 3, 0, 123, 0, 0, 0, 0,
+ax_anim 3, 0, 126, 0, 0, 0, 0,
+ax_anim 3, 0, 129, 0, 0, 0, 0,
+ax_anim 3, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWooperAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWooperAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sWooperAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sWooperAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sWooperAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sWooperAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sWooperAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sWooperAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sWooperAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sWooperAnims_8_1:
+ax_anim 24, 0, 146, 0, 0, 0, 0,
+ax_anim 16, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_8_2:
+ax_anim 24, 0, 149, 0, 0, 0, 0,
+ax_anim 16, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_8_3:
+ax_anim 24, 0, 152, 0, 0, 0, 0,
+ax_anim 16, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_8_4:
+ax_anim 24, 0, 155, 0, 0, 0, 0,
+ax_anim 16, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_8_5:
+ax_anim 24, 0, 158, 0, 0, 0, 0,
+ax_anim 16, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_8_6:
+ax_anim 24, 0, 161, 0, 0, 0, 0,
+ax_anim 16, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_8_7:
+ax_anim 24, 0, 164, 0, 0, 0, 0,
+ax_anim 16, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_8_8:
+ax_anim 24, 0, 167, 0, 0, 0, 0,
+ax_anim 16, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWooperAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 6, 3, 6, 3,
+ax_anim 2, 0, 172, 8, 9, 8, 9,
+ax_anim 2, 0, 173, 7, 17, 7, 17,
+ax_anim 3, 0, 174, 0, 21, 0, 21,
+ax_anim 2, 3, 175, -7, 17, -7, 17,
+ax_anim 2, 0, 176, -8, 9, -8, 9,
+ax_anim 1, 0, 177, -6, 3, -6, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 10, 1, 10, 1,
+ax_anim 2, 0, 171, 19, 5, 19, 5,
+ax_anim 2, 0, 172, 23, 13, 23, 13,
+ax_anim 3, 0, 173, 21, 20, 21, 20,
+ax_anim 2, 3, 174, 15, 21, 15, 21,
+ax_anim 2, 0, 175, 6, 18, 6, 18,
+ax_anim 1, 0, 176, 1, 9, 1, 9,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 3, -5, 3, -5,
+ax_anim 2, 0, 170, 12, -6, 12, -6,
+ax_anim 2, 0, 171, 18, -5, 18, -5,
+ax_anim 3, 0, 172, 21, -2, 21, -2,
+ax_anim 2, 3, 173, 18, 4, 18, 4,
+ax_anim 2, 0, 174, 13, 5, 13, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, -1, -8, -1, -8,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -23, 11, -23,
+ax_anim 3, 0, 171, 21, -23, 21, -23,
+ax_anim 2, 3, 172, 22, -15, 22, -15,
+ax_anim 2, 0, 173, 17, -4, 17, -4,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -4, -8, -4,
+ax_anim 2, 0, 176, -9, -12, -9, -12,
+ax_anim 2, 0, 177, -7, -19, -7, -19,
+ax_anim 3, 0, 170, 0, -24, 0, -24,
+ax_anim 2, 3, 171, 7, -19, 7, -19,
+ax_anim 2, 0, 172, 9, -12, 9, -12,
+ax_anim 1, 0, 173, 8, -4, 8, -4,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 1, -8, 1, -8,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -23, -11, -23,
+ax_anim 3, 0, 177, -21, -23, -21, -23,
+ax_anim 2, 3, 176, -22, -15, -22, -15,
+ax_anim 2, 0, 175, -17, -4, -17, -4,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -3, -5, -3, -5,
+ax_anim 2, 0, 170, -12, -6, -12, -6,
+ax_anim 2, 0, 177, -18, -5, -18, -5,
+ax_anim 3, 0, 176, -21, -2, -21, -2,
+ax_anim 2, 3, 175, -18, 4, -18, 4,
+ax_anim 2, 0, 174, -13, 5, -13, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -10, 1, -10, 1,
+ax_anim 2, 0, 177, -19, 5, -19, 5,
+ax_anim 2, 0, 176, -23, 13, -23, 13,
+ax_anim 3, 0, 175, -21, 20, -21, 20,
+ax_anim 2, 3, 174, -15, 21, -15, 21,
+ax_anim 2, 0, 173, -6, 18, -6, 18,
+ax_anim 1, 0, 172, -1, 9, -1, 9,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWooperAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWooperAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 187, 0, -10, 0, 0,
+ax_anim 2, 0, 187, 0, -16, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 188, 0, -22, 0, 0,
+ax_anim 2, 0, 188, 0, -18, 0, 0,
+ax_anim 1, 0, 188, 0, -12, 0, 0,
+ax_anim 2, 2, 188, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -23, 0, 0,
+ax_anim 3, 0, 191, 0, -22, 0, 0,
+ax_anim 2, 0, 191, 0, -18, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 193, 0, -10, 0, 0,
+ax_anim 2, 0, 193, 0, -16, 0, 0,
+ax_anim 3, 0, 193, 0, -20, 0, 0,
+ax_anim 4, 0, 193, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 194, 0, -22, 0, 0,
+ax_anim 2, 0, 194, 0, -18, 0, 0,
+ax_anim 1, 0, 194, 0, -12, 0, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 196, 0, -10, 0, 0,
+ax_anim 2, 0, 196, 0, -16, 0, 0,
+ax_anim 3, 0, 196, 0, -20, 0, 0,
+ax_anim 4, 0, 196, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 197, 0, -21, 0, 0,
+ax_anim 2, 0, 197, 0, -17, 0, 0,
+ax_anim 1, 0, 197, 0, -11, 0, 0,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 199, 0, -10, 0, 0,
+ax_anim 2, 0, 199, 0, -16, 0, 0,
+ax_anim 3, 0, 199, 0, -20, 0, 0,
+ax_anim 4, 0, 199, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 200, 0, -22, 0, 0,
+ax_anim 2, 0, 200, 0, -18, 0, 0,
+ax_anim 1, 0, 200, 0, -12, 0, 0,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 0, -10, 0, 0,
+ax_anim 2, 0, 202, 0, -16, 0, 0,
+ax_anim 3, 0, 202, 0, -20, 0, 0,
+ax_anim 4, 0, 202, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -22, 0, 0,
+ax_anim 3, 0, 203, 0, -21, 0, 0,
+ax_anim 2, 0, 203, 0, -17, 0, 0,
+ax_anim 1, 0, 203, 0, -11, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 205, 0, -10, 0, 0,
+ax_anim 2, 0, 205, 0, -16, 0, 0,
+ax_anim 3, 0, 205, 0, -20, 0, 0,
+ax_anim 4, 0, 205, 0, -21, 0, 0,
+ax_anim 4, 0, 204, 0, -23, 0, 0,
+ax_anim 3, 0, 206, 0, -22, 0, 0,
+ax_anim 2, 0, 206, 0, -18, 0, 0,
+ax_anim 1, 0, 206, 0, -12, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, 0, -10, 0, 0,
+ax_anim 2, 0, 208, 0, -16, 0, 0,
+ax_anim 3, 0, 208, 0, -20, 0, 0,
+ax_anim 4, 0, 208, 0, -21, 0, 0,
+ax_anim 4, 0, 207, 0, -23, 0, 0,
+ax_anim 3, 0, 209, 0, -22, 0, 0,
+ax_anim 2, 0, 209, 0, -18, 0, 0,
+ax_anim 1, 0, 209, 0, -12, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWooperAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWooperAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sWooperGfx1:
+.incbin "baserom.gba", 0xD54758, 0x200
+sWooperSprites1:
+ax_sprite sWooperGfx1, 0x200
+ax_sprite_terminator
+sWooperGfx2:
+.incbin "baserom.gba", 0xD54968, 0x200
+sWooperSprites2:
+ax_sprite sWooperGfx2, 0x200
+ax_sprite_terminator
+sWooperGfx3:
+.incbin "baserom.gba", 0xD54B78, 0x200
+sWooperSprites3:
+ax_sprite sWooperGfx3, 0x200
+ax_sprite_terminator
+sWooperGfx4:
+.incbin "baserom.gba", 0xD54D88, 0x200
+sWooperSprites4:
+ax_sprite sWooperGfx4, 0x200
+ax_sprite_terminator
+sWooperGfx5:
+.incbin "baserom.gba", 0xD54F98, 0x200
+sWooperSprites5:
+ax_sprite sWooperGfx5, 0x200
+ax_sprite_terminator
+sWooperGfx6:
+.incbin "baserom.gba", 0xD551A8, 0x200
+sWooperSprites6:
+ax_sprite sWooperGfx6, 0x200
+ax_sprite_terminator
+sWooperGfx7:
+.incbin "baserom.gba", 0xD553B8, 0x200
+sWooperSprites7:
+ax_sprite sWooperGfx7, 0x200
+ax_sprite_terminator
+sWooperGfx8:
+.incbin "baserom.gba", 0xD555C8, 0x200
+sWooperSprites8:
+ax_sprite sWooperGfx8, 0x200
+ax_sprite_terminator
+sWooperGfx9:
+.incbin "baserom.gba", 0xD557D8, 0x200
+sWooperSprites9:
+ax_sprite sWooperGfx9, 0x200
+ax_sprite_terminator
+sWooperGfx10:
+.incbin "baserom.gba", 0xD559E8, 0x200
+sWooperSprites10:
+ax_sprite sWooperGfx10, 0x200
+ax_sprite_terminator
+sWooperGfx11:
+.incbin "baserom.gba", 0xD55BF8, 0x200
+sWooperSprites11:
+ax_sprite sWooperGfx11, 0x200
+ax_sprite_terminator
+sWooperGfx12:
+.incbin "baserom.gba", 0xD55E08, 0x200
+sWooperSprites12:
+ax_sprite sWooperGfx12, 0x200
+ax_sprite_terminator
+sWooperGfx13:
+.incbin "baserom.gba", 0xD56018, 0x200
+sWooperSprites13:
+ax_sprite sWooperGfx13, 0x200
+ax_sprite_terminator
+sWooperGfx14:
+.incbin "baserom.gba", 0xD56228, 0x200
+sWooperSprites14:
+ax_sprite sWooperGfx14, 0x200
+ax_sprite_terminator
+sWooperGfx15:
+.incbin "baserom.gba", 0xD56438, 0x200
+sWooperSprites15:
+ax_sprite sWooperGfx15, 0x200
+ax_sprite_terminator
+sWooperGfx16:
+.incbin "baserom.gba", 0xD56648, 0x200
+sWooperSprites16:
+ax_sprite sWooperGfx16, 0x200
+ax_sprite_terminator
+sWooperGfx17:
+.incbin "baserom.gba", 0xD56858, 0x200
+sWooperSprites17:
+ax_sprite sWooperGfx17, 0x200
+ax_sprite_terminator
+sWooperGfx18:
+.incbin "baserom.gba", 0xD56A68, 0x200
+sWooperSprites18:
+ax_sprite sWooperGfx18, 0x200
+ax_sprite_terminator
+sWooperGfx19:
+.incbin "baserom.gba", 0xD56C78, 0x200
+sWooperSprites19:
+ax_sprite sWooperGfx19, 0x200
+ax_sprite_terminator
+sWooperGfx20:
+.incbin "baserom.gba", 0xD56E88, 0x200
+sWooperSprites20:
+ax_sprite sWooperGfx20, 0x200
+ax_sprite_terminator
+sWooperGfx21:
+.incbin "baserom.gba", 0xD57098, 0x200
+sWooperSprites21:
+ax_sprite sWooperGfx21, 0x200
+ax_sprite_terminator
+sWooperGfx22:
+.incbin "baserom.gba", 0xD572A8, 0x200
+sWooperSprites22:
+ax_sprite sWooperGfx22, 0x200
+ax_sprite_terminator
+sWooperGfx23:
+.incbin "baserom.gba", 0xD574B8, 0x200
+sWooperSprites23:
+ax_sprite sWooperGfx23, 0x200
+ax_sprite_terminator
+sWooperGfx24:
+.incbin "baserom.gba", 0xD576C8, 0x200
+sWooperSprites24:
+ax_sprite sWooperGfx24, 0x200
+ax_sprite_terminator
+sWooperGfx25:
+.incbin "baserom.gba", 0xD578D8, 0x60
+sWooperGfx25_1:
+.incbin "baserom.gba", 0xD57938, 0x60
+sWooperGfx25_2:
+.incbin "baserom.gba", 0xD57998, 0x40
+sWooperSprites25:
+ax_sprite sWooperGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWooperGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWooperGfx26:
+.incbin "baserom.gba", 0xD57A10, 0x60
+sWooperGfx26_1:
+.incbin "baserom.gba", 0xD57A70, 0x60
+sWooperGfx26_2:
+.incbin "baserom.gba", 0xD57AD0, 0x40
+sWooperSprites26:
+ax_sprite sWooperGfx26, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx26_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWooperGfx26_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWooperGfx27:
+.incbin "baserom.gba", 0xD57B48, 0x100
+sWooperSprites27:
+ax_sprite sWooperGfx27, 0x100
+ax_sprite_terminator
+sWooperGfx28:
+.incbin "baserom.gba", 0xD57C58, 0x100
+sWooperSprites28:
+ax_sprite sWooperGfx28, 0x100
+ax_sprite_terminator
+sWooperGfx29:
+.incbin "baserom.gba", 0xD57D68, 0x40
+sWooperGfx29_1:
+.incbin "baserom.gba", 0xD57DA8, 0x80
+sWooperGfx29_2:
+.incbin "baserom.gba", 0xD57E28, 0x40
+sWooperGfx29_3:
+.incbin "baserom.gba", 0xD57E68, 0x20
+sWooperSprites29:
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx29, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx29_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx29_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWooperGfx29_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWooperGfx30:
+.incbin "baserom.gba", 0xD57ED8, 0x20
+sWooperGfx30_1:
+.incbin "baserom.gba", 0xD57EF8, 0x60
+sWooperGfx30_2:
+.incbin "baserom.gba", 0xD57F58, 0x60
+sWooperSprites30:
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWooperGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx30_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWooperGfx31:
+.incbin "baserom.gba", 0xD57FF8, 0x40
+sWooperGfx31_1:
+.incbin "baserom.gba", 0xD58038, 0x60
+sWooperGfx31_2:
+.incbin "baserom.gba", 0xD58098, 0x60
+sWooperSprites31:
+ax_sprite sWooperGfx31, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWooperGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx31_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWooperGfx32:
+.incbin "baserom.gba", 0xD58130, 0x40
+sWooperGfx32_1:
+.incbin "baserom.gba", 0xD58170, 0x60
+sWooperGfx32_2:
+.incbin "baserom.gba", 0xD581D0, 0x60
+sWooperSprites32:
+ax_sprite sWooperGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWooperGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWooperGfx33:
+.incbin "baserom.gba", 0xD58268, 0xC0
+sWooperSprites33:
+ax_sprite sWooperGfx33, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWooperGfx34:
+.incbin "baserom.gba", 0xD58340, 0x40
+sWooperGfx34_1:
+.incbin "baserom.gba", 0xD58380, 0x80
+sWooperGfx34_2:
+.incbin "baserom.gba", 0xD58400, 0x40
+sWooperSprites34:
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx34_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWooperGfx34_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWooperGfx35:
+.incbin "baserom.gba", 0xD58480, 0x200
+sWooperSprites35:
+ax_sprite sWooperGfx35, 0x200
+ax_sprite_terminator
+sWooperGfx36:
+.incbin "baserom.gba", 0xD58690, 0x200
+sWooperSprites36:
+ax_sprite sWooperGfx36, 0x200
+ax_sprite_terminator
+sWooperGfx37:
+.incbin "baserom.gba", 0xD588A0, 0x200
+sWooperSprites37:
+ax_sprite sWooperGfx37, 0x200
+ax_sprite_terminator
+sWooperGfx38:
+.incbin "baserom.gba", 0xD58AB0, 0x200
+sWooperSprites38:
+ax_sprite sWooperGfx38, 0x200
+ax_sprite_terminator
+sWooperGfx39:
+.incbin "baserom.gba", 0xD58CC0, 0x200
+sWooperSprites39:
+ax_sprite sWooperGfx39, 0x200
+ax_sprite_terminator
+sWooperGfx40:
+.incbin "baserom.gba", 0xD58ED0, 0x200
+sWooperSprites40:
+ax_sprite sWooperGfx40, 0x200
+ax_sprite_terminator
+sWooperGfx41:
+.incbin "baserom.gba", 0xD590E0, 0x200
+sWooperSprites41:
+ax_sprite sWooperGfx41, 0x200
+ax_sprite_terminator
+sAxPosesWooper:
+.4byte sWooperPose1
+.4byte sWooperPose2
+.4byte sWooperPose3
+.4byte sWooperPose4
+.4byte sWooperPose5
+.4byte sWooperPose6
+.4byte sWooperPose7
+.4byte sWooperPose8
+.4byte sWooperPose9
+.4byte sWooperPose10
+.4byte sWooperPose11
+.4byte sWooperPose12
+.4byte sWooperPose13
+.4byte sWooperPose14
+.4byte sWooperPose15
+.4byte sWooperPose16
+.4byte sWooperPose17
+.4byte sWooperPose18
+.4byte sWooperPose19
+.4byte sWooperPose20
+.4byte sWooperPose21
+.4byte sWooperPose22
+.4byte sWooperPose23
+.4byte sWooperPose24
+.4byte sWooperPose25
+.4byte sWooperPose26
+.4byte sWooperPose27
+.4byte sWooperPose28
+.4byte sWooperPose29
+.4byte sWooperPose30
+.4byte sWooperPose31
+.4byte sWooperPose32
+.4byte sWooperPose33
+.4byte sWooperPose34
+.4byte sWooperPose35
+.4byte sWooperPose36
+.4byte sWooperPose37
+.4byte sWooperPose38
+.4byte sWooperPose39
+.4byte sWooperPose40
+.4byte sWooperPose41
+.4byte sWooperPose42
+.4byte sWooperPose43
+.4byte sWooperPose44
+.4byte sWooperPose45
+.4byte sWooperPose46
+.4byte sWooperPose47
+.4byte sWooperPose48
+.4byte sWooperPose49
+.4byte sWooperPose50
+.4byte sWooperPose51
+.4byte sWooperPose52
+.4byte sWooperPose53
+.4byte sWooperPose54
+.4byte sWooperPose55
+.4byte sWooperPose56
+.4byte sWooperPose57
+.4byte sWooperPose58
+.4byte sWooperPose59
+.4byte sWooperPose60
+.4byte sWooperPose61
+.4byte sWooperPose62
+.4byte sWooperPose63
+.4byte sWooperPose64
+.4byte sWooperPose65
+.4byte sWooperPose66
+.4byte sWooperPose67
+.4byte sWooperPose68
+.4byte sWooperPose69
+.4byte sWooperPose70
+.4byte sWooperPose71
+.4byte sWooperPose72
+.4byte sWooperPose73
+.4byte sWooperPose74
+.4byte sWooperPose75
+.4byte sWooperPose76
+.4byte sWooperPose77
+.4byte sWooperPose78
+.4byte sWooperPose79
+.4byte sWooperPose80
+.4byte sWooperPose81
+.4byte sWooperPose82
+.4byte sWooperPose83
+.4byte sWooperPose84
+.4byte sWooperPose85
+.4byte sWooperPose86
+.4byte sWooperPose87
+.4byte sWooperPose88
+.4byte sWooperPose89
+.4byte sWooperPose90
+.4byte sWooperPose91
+.4byte sWooperPose92
+.4byte sWooperPose93
+.4byte sWooperPose94
+.4byte sWooperPose95
+.4byte sWooperPose96
+.4byte sWooperPose97
+.4byte sWooperPose98
+.4byte sWooperPose99
+.4byte sWooperPose100
+.4byte sWooperPose101
+.4byte sWooperPose102
+.4byte sWooperPose103
+.4byte sWooperPose104
+.4byte sWooperPose105
+.4byte sWooperPose106
+.4byte sWooperPose107
+.4byte sWooperPose108
+.4byte sWooperPose109
+.4byte sWooperPose110
+.4byte sWooperPose111
+.4byte sWooperPose112
+.4byte sWooperPose113
+.4byte sWooperPose114
+.4byte sWooperPose115
+.4byte sWooperPose116
+.4byte sWooperPose117
+.4byte sWooperPose118
+.4byte sWooperPose119
+.4byte sWooperPose120
+.4byte sWooperPose121
+.4byte sWooperPose122
+.4byte sWooperPose123
+.4byte sWooperPose124
+.4byte sWooperPose125
+.4byte sWooperPose126
+.4byte sWooperPose127
+.4byte sWooperPose128
+.4byte sWooperPose129
+.4byte sWooperPose130
+.4byte sWooperPose131
+.4byte sWooperPose132
+.4byte sWooperPose133
+.4byte sWooperPose134
+.4byte sWooperPose135
+.4byte sWooperPose136
+.4byte sWooperPose137
+.4byte sWooperPose138
+.4byte sWooperPose139
+.4byte sWooperPose140
+.4byte sWooperPose141
+.4byte sWooperPose142
+.4byte sWooperPose143
+.4byte sWooperPose144
+.4byte sWooperPose145
+.4byte sWooperPose146
+.4byte sWooperPose147
+.4byte sWooperPose148
+.4byte sWooperPose149
+.4byte sWooperPose150
+.4byte sWooperPose151
+.4byte sWooperPose152
+.4byte sWooperPose153
+.4byte sWooperPose154
+.4byte sWooperPose155
+.4byte sWooperPose156
+.4byte sWooperPose157
+.4byte sWooperPose158
+.4byte sWooperPose159
+.4byte sWooperPose160
+.4byte sWooperPose161
+.4byte sWooperPose162
+.4byte sWooperPose163
+.4byte sWooperPose164
+.4byte sWooperPose165
+.4byte sWooperPose166
+.4byte sWooperPose167
+.4byte sWooperPose168
+.4byte sWooperPose169
+.4byte sWooperPose170
+.4byte sWooperPose171
+.4byte sWooperPose172
+.4byte sWooperPose173
+.4byte sWooperPose174
+.4byte sWooperPose175
+.4byte sWooperPose176
+.4byte sWooperPose177
+.4byte sWooperPose178
+.4byte sWooperPose179
+.4byte sWooperPose180
+.4byte sWooperPose181
+.4byte sWooperPose182
+.4byte sWooperPose183
+.4byte sWooperPose184
+.4byte sWooperPose185
+.4byte sWooperPose186
+.4byte sWooperPose187
+.4byte sWooperPose188
+.4byte sWooperPose189
+.4byte sWooperPose190
+.4byte sWooperPose191
+.4byte sWooperPose192
+.4byte sWooperPose193
+.4byte sWooperPose194
+.4byte sWooperPose195
+.4byte sWooperPose196
+.4byte sWooperPose197
+.4byte sWooperPose198
+.4byte sWooperPose199
+.4byte sWooperPose200
+.4byte sWooperPose201
+.4byte sWooperPose202
+.4byte sWooperPose203
+.4byte sWooperPose204
+.4byte sWooperPose205
+.4byte sWooperPose206
+.4byte sWooperPose207
+.4byte sWooperPose208
+.4byte sWooperPose209
+.4byte sWooperPose210
+.4byte sWooperPose211
+.4byte sWooperPose212
+.4byte sWooperPose213
+.4byte sWooperPose214
+.4byte sWooperPose215
+.4byte sWooperPose216
+.4byte sWooperPose217
+.4byte sWooperPose218
+.4byte sWooperPose219
+.4byte sWooperPose220
+.4byte sWooperPose221
+.4byte sWooperPose222
+.4byte sWooperPose223
+.4byte sWooperPose224
+.4byte sWooperPose225
+.4byte sWooperPose226
+sAxPositionsWooper:
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte    0,   -9, 	  -9,  -14, 	   7,  -10, 	   0,   -7
+.2byte    0,   -9, 	  -8,  -10, 	   8,  -14, 	   1,   -7
+.2byte    3,   -8, 	  -6,   -9, 	   6,  -12, 	   0,   -6
+.2byte    2,  -10, 	  -6,  -12, 	   7,  -12, 	   0,   -8
+.2byte    2,  -10, 	  -7,  -10, 	   5,  -15, 	   0,   -8
+.2byte    5,   -9, 	  -3,   -6, 	   0,  -11, 	   0,   -5
+.2byte    6,  -13, 	  -2,  -12, 	   1,  -13, 	   0,   -8
+.2byte    5,  -10, 	  -3,   -8, 	   1,  -15, 	   0,   -8
+.2byte    2,  -10, 	   5,   -8, 	  -6,  -13, 	   0,   -6
+.2byte    1,  -12, 	   4,  -12, 	  -7,  -14, 	   0,   -7
+.2byte    2,  -12, 	   5,   -8, 	  -5,  -16, 	   1,   -8
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte   -1,  -13, 	   7,  -14, 	  -9,  -11, 	  -1,   -8
+.2byte    1,  -13, 	   9,  -11, 	  -7,  -14, 	   1,   -8
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte   -3,  -10, 	   5,  -16, 	  -5,   -8, 	   0,   -8
+.2byte   -1,  -11, 	   8,  -14, 	  -4,  -12, 	   1,   -8
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -5,  -10, 	   1,  -14, 	   3,   -8, 	   0,   -8
+.2byte   -6,  -13, 	  -1,  -13, 	   3,  -12, 	   0,   -8
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -2,  -10, 	  -5,  -15, 	   7,  -10, 	   1,   -8
+.2byte   -2,  -10, 	  -7,  -11, 	   6,  -12, 	   0,   -8
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte    0,   -9, 	  -9,  -14, 	   7,  -10, 	   0,   -7
+.2byte    0,   -9, 	  -8,  -10, 	   8,  -14, 	   1,   -7
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -7
+.2byte    3,   -8, 	  -6,   -9, 	   6,  -12, 	   0,   -6
+.2byte    2,  -10, 	  -6,  -12, 	   7,  -12, 	   0,   -8
+.2byte    2,  -10, 	  -7,  -10, 	   5,  -15, 	   0,   -8
+.2byte    2,  -10, 	   5,  -13, 	  -7,  -10, 	   0,   -7
+.2byte    5,   -9, 	  -3,   -6, 	   0,  -11, 	   0,   -5
+.2byte    6,  -13, 	  -2,  -12, 	   1,  -13, 	   0,   -8
+.2byte    5,  -10, 	  -3,   -8, 	   1,  -15, 	   0,   -8
+.2byte    3,  -11, 	  -4,  -12, 	  -6,   -8, 	  -2,   -7
+.2byte    2,  -10, 	   5,   -8, 	  -6,  -13, 	   0,   -6
+.2byte    1,  -12, 	   4,  -12, 	  -7,  -14, 	   0,   -7
+.2byte    2,  -12, 	   5,   -8, 	  -5,  -16, 	   1,   -8
+.2byte    1,  -10, 	  -7,  -12, 	   3,   -7, 	  -1,   -4
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte   -1,  -13, 	   7,  -14, 	  -9,  -11, 	  -1,   -8
+.2byte    1,  -13, 	   9,  -11, 	  -7,  -14, 	   1,   -8
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -5
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte   -3,  -10, 	   5,  -16, 	  -5,   -8, 	   0,   -8
+.2byte   -1,  -11, 	   8,  -14, 	  -4,  -12, 	   1,   -8
+.2byte   -1,  -10, 	   7,  -12, 	  -3,   -7, 	   1,   -4
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -5,  -10, 	   1,  -14, 	   3,   -8, 	   0,   -8
+.2byte   -6,  -13, 	  -1,  -13, 	   3,  -12, 	   0,   -8
+.2byte   -3,  -11, 	   4,  -12, 	   6,   -8, 	   2,   -7
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -2,  -10, 	  -5,  -15, 	   7,  -10, 	   1,   -8
+.2byte   -2,  -10, 	  -7,  -11, 	   6,  -12, 	   0,   -8
+.2byte   -2,  -10, 	  -5,  -13, 	   7,  -10, 	   0,   -7
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte    0,   -9, 	  -9,  -14, 	   7,  -10, 	   0,   -7
+.2byte    0,   -9, 	  -8,  -10, 	   8,  -14, 	   1,   -7
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -7
+.2byte    3,   -8, 	  -6,   -9, 	   6,  -12, 	   0,   -6
+.2byte    2,  -10, 	  -6,  -12, 	   7,  -12, 	   0,   -8
+.2byte    2,  -10, 	  -7,  -10, 	   5,  -15, 	   0,   -8
+.2byte    2,  -10, 	   5,  -13, 	  -7,  -10, 	   0,   -7
+.2byte    5,   -9, 	  -3,   -6, 	   0,  -11, 	   0,   -5
+.2byte    6,  -13, 	  -2,  -12, 	   1,  -13, 	   0,   -8
+.2byte    5,  -10, 	  -3,   -8, 	   1,  -15, 	   0,   -8
+.2byte    3,  -11, 	  -4,  -12, 	  -6,   -8, 	  -2,   -7
+.2byte    2,  -10, 	   5,   -8, 	  -6,  -13, 	   0,   -6
+.2byte    1,  -12, 	   4,  -12, 	  -7,  -14, 	   0,   -7
+.2byte    2,  -12, 	   5,   -8, 	  -5,  -16, 	   1,   -8
+.2byte    1,  -10, 	  -7,  -12, 	   3,   -7, 	  -1,   -4
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte   -1,  -13, 	   7,  -14, 	  -9,  -11, 	  -1,   -8
+.2byte    1,  -13, 	   9,  -11, 	  -7,  -14, 	   1,   -8
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -5
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte   -3,  -10, 	   5,  -16, 	  -5,   -8, 	   0,   -8
+.2byte   -1,  -11, 	   8,  -14, 	  -4,  -12, 	   1,   -8
+.2byte   -1,  -10, 	   7,  -12, 	  -3,   -7, 	   1,   -4
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -5,  -10, 	   1,  -14, 	   3,   -8, 	   0,   -8
+.2byte   -6,  -13, 	  -1,  -13, 	   3,  -12, 	   0,   -8
+.2byte   -3,  -11, 	   4,  -12, 	   6,   -8, 	   2,   -7
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -2,  -10, 	  -5,  -15, 	   7,  -10, 	   1,   -8
+.2byte   -2,  -10, 	  -7,  -11, 	   6,  -12, 	   0,   -8
+.2byte   -2,  -10, 	  -5,  -13, 	   7,  -10, 	   0,   -7
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -7
+.2byte    0,   -6, 	  -8,   -9, 	   8,   -9, 	   0,   -5
+.2byte    3,   -8, 	  -6,   -9, 	   6,  -12, 	   0,   -6
+.2byte    2,  -10, 	   5,  -13, 	  -7,  -10, 	   0,   -7
+.2byte    5,   -8, 	   9,  -11, 	  -3,   -8, 	   1,   -5
+.2byte    5,   -9, 	  -3,   -6, 	   0,  -11, 	   0,   -5
+.2byte    3,  -11, 	  -4,  -12, 	  -6,   -8, 	  -2,   -7
+.2byte    9,   -9, 	   2,  -12, 	   1,   -7, 	   2,   -6
+.2byte    2,  -10, 	   5,   -8, 	  -6,  -13, 	   0,   -6
+.2byte    1,  -10, 	  -7,  -12, 	   3,   -7, 	  -1,   -4
+.2byte    4,  -10, 	  -4,  -14, 	   6,   -9, 	   1,   -7
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -5
+.2byte    0,  -10, 	   9,  -10, 	  -8,  -10, 	  -1,   -6
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte   -1,  -10, 	   7,  -12, 	  -3,   -7, 	   1,   -4
+.2byte   -4,  -10, 	   4,  -14, 	  -6,   -9, 	  -1,   -7
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -3,  -11, 	   4,  -12, 	   6,   -8, 	   2,   -7
+.2byte   -9,   -9, 	  -2,  -12, 	  -1,   -7, 	  -2,   -6
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -2,  -10, 	  -5,  -13, 	   7,  -10, 	   0,   -7
+.2byte   -5,   -8, 	  -9,  -11, 	   3,   -8, 	  -1,   -5
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -7
+.2byte    0,   -6, 	  -8,   -9, 	   8,   -9, 	   0,   -5
+.2byte    3,   -8, 	  -6,   -9, 	   6,  -12, 	   0,   -6
+.2byte    2,  -10, 	   5,  -13, 	  -7,  -10, 	   0,   -7
+.2byte    5,   -8, 	   9,  -11, 	  -3,   -8, 	   1,   -5
+.2byte    5,   -9, 	  -3,   -6, 	   0,  -11, 	   0,   -5
+.2byte    3,  -11, 	  -4,  -12, 	  -6,   -8, 	  -2,   -7
+.2byte    9,   -9, 	   2,  -12, 	   1,   -7, 	   2,   -6
+.2byte    2,  -10, 	   5,   -8, 	  -6,  -13, 	   0,   -6
+.2byte    1,  -10, 	  -7,  -12, 	   3,   -7, 	  -1,   -4
+.2byte    4,   -9, 	  -4,  -13, 	   6,   -8, 	   1,   -6
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -5
+.2byte    0,  -10, 	   9,  -10, 	  -8,  -10, 	  -1,   -6
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte   -1,  -10, 	   7,  -12, 	  -3,   -7, 	   1,   -4
+.2byte   -4,   -9, 	   4,  -13, 	  -6,   -8, 	  -1,   -6
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -3,  -11, 	   4,  -12, 	   6,   -8, 	   2,   -7
+.2byte   -9,   -9, 	  -2,  -12, 	  -1,   -7, 	  -2,   -6
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -2,  -10, 	  -5,  -13, 	   7,  -10, 	   0,   -7
+.2byte   -5,   -8, 	  -9,  -11, 	   3,   -8, 	  -1,   -5
+.2byte   -1,   -6, 	  -6,  -10, 	   7,   -9, 	   1,   -5
+.2byte   -1,   -4, 	  -7,   -9, 	   6,   -8, 	   1,   -4
+.2byte    0,  -11, 	  -8,   -6, 	   7,   -6, 	   0,   -6
+.2byte   -6,   -7, 	   1,   -6, 	  -7,   -2, 	  -3,   -6
+.2byte   -6,  -11, 	  -5,   -6, 	  -1,   -6, 	   0,   -9
+.2byte   -1,   -9, 	  -8,   -6, 	   2,   -2, 	   1,   -7
+.2byte    0,   -7, 	   7,   -4, 	  -8,   -4, 	   0,   -9
+.2byte    0,   -9, 	   7,   -6, 	  -3,   -2, 	  -2,   -7
+.2byte    5,  -11, 	   4,   -6, 	   0,   -6, 	  -1,   -9
+.2byte    5,   -7, 	  -2,   -6, 	   6,   -2, 	   2,   -6
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte    1,   -8, 	  -8,  -13, 	   8,   -9, 	   1,   -6
+.2byte    0,   -9, 	  -8,  -10, 	   8,  -14, 	   1,   -7
+.2byte    2,   -8, 	  -7,   -9, 	   5,  -12, 	  -1,   -6
+.2byte    4,  -10, 	  -4,  -12, 	   9,  -12, 	   2,   -8
+.2byte    2,   -9, 	  -7,   -9, 	   5,  -14, 	   0,   -7
+.2byte    5,   -9, 	  -3,   -6, 	   0,  -11, 	   0,   -5
+.2byte    7,  -13, 	  -1,  -12, 	   2,  -13, 	   1,   -8
+.2byte    6,   -9, 	  -2,   -7, 	   2,  -14, 	   1,   -7
+.2byte    2,  -10, 	   5,   -8, 	  -6,  -13, 	   0,   -6
+.2byte    1,  -12, 	   4,  -12, 	  -7,  -14, 	   0,   -7
+.2byte    2,  -11, 	   5,   -7, 	  -5,  -15, 	   1,   -7
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte   -1,  -13, 	   7,  -14, 	  -9,  -11, 	  -1,   -8
+.2byte    1,  -12, 	   9,  -10, 	  -7,  -13, 	   1,   -7
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte   -2,   -9, 	   6,  -15, 	  -4,   -7, 	   1,   -7
+.2byte   -1,  -11, 	   8,  -14, 	  -4,  -12, 	   1,   -8
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -5,   -9, 	   1,  -13, 	   3,   -7, 	   0,   -7
+.2byte   -6,  -12, 	  -1,  -12, 	   3,  -11, 	   0,   -7
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -3,   -9, 	  -6,  -14, 	   6,   -9, 	   0,   -7
+.2byte   -2,  -10, 	  -7,  -11, 	   6,  -12, 	   0,   -8
+.2byte    0,   -6, 	  -8,   -9, 	   8,   -9, 	   0,   -5
+.2byte   -5,   -8, 	  -9,  -11, 	   3,   -8, 	  -1,   -5
+.2byte   -8,   -9, 	  -1,  -12, 	   0,   -7, 	  -1,   -6
+.2byte   -4,   -9, 	   4,  -13, 	  -6,   -8, 	  -1,   -6
+.2byte    0,  -10, 	   9,  -10, 	  -8,  -10, 	  -1,   -6
+.2byte    4,   -9, 	  -4,  -13, 	   6,   -8, 	   1,   -6
+.2byte    8,   -9, 	   1,  -12, 	   0,   -7, 	   1,   -6
+.2byte    4,   -8, 	   8,  -11, 	  -4,   -8, 	   0,   -5
+.2byte    0,   -6, 	  -8,   -9, 	   8,   -9, 	   0,   -5
+.2byte    4,   -8, 	   8,  -11, 	  -4,   -8, 	   0,   -5
+.2byte    8,   -9, 	   1,  -12, 	   0,   -7, 	   1,   -6
+.2byte    4,   -9, 	  -4,  -13, 	   6,   -8, 	   1,   -6
+.2byte    0,  -10, 	   9,  -10, 	  -8,  -10, 	  -1,   -6
+.2byte   -4,   -9, 	   4,  -13, 	  -6,   -8, 	  -1,   -6
+.2byte   -8,   -9, 	  -1,  -12, 	   0,   -7, 	  -1,   -6
+.2byte   -5,   -8, 	  -9,  -11, 	   3,   -8, 	  -1,   -5
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -7
+.2byte    0,   -6, 	  -8,   -9, 	   8,   -9, 	   0,   -5
+.2byte    2,   -8, 	   6,  -13, 	  -7,   -9, 	  -1,   -6
+.2byte    2,  -10, 	   5,  -13, 	  -7,  -10, 	   0,   -7
+.2byte    3,   -8, 	   7,  -11, 	  -5,   -8, 	  -1,   -5
+.2byte    6,   -9, 	   1,  -12, 	  -3,   -7, 	   0,   -6
+.2byte    4,  -11, 	  -3,  -12, 	  -5,   -8, 	  -1,   -7
+.2byte    6,   -9, 	  -1,  -12, 	  -2,   -7, 	  -1,   -6
+.2byte    3,  -10, 	  -7,  -14, 	   4,   -8, 	  -1,   -6
+.2byte    1,  -10, 	  -7,  -12, 	   3,   -7, 	  -1,   -4
+.2byte    3,  -10, 	  -5,  -14, 	   5,   -9, 	   0,   -7
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -5
+.2byte    0,  -10, 	   9,  -10, 	  -8,  -10, 	  -1,   -6
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte   -1,  -10, 	   7,  -12, 	  -3,   -7, 	   1,   -4
+.2byte   -4,  -10, 	   4,  -14, 	  -6,   -9, 	  -1,   -7
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -4,  -11, 	   3,  -12, 	   5,   -8, 	   1,   -7
+.2byte   -6,   -9, 	   1,  -12, 	   2,   -7, 	   1,   -6
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -2,  -10, 	  -5,  -13, 	   7,  -10, 	   0,   -7
+.2byte   -3,   -8, 	  -7,  -11, 	   5,   -8, 	   1,   -5
+.2byte    0,  -10, 	  -8,  -12, 	   8,  -12, 	   0,   -7
+.2byte   -2,  -10, 	  -5,  -13, 	   7,  -10, 	   0,   -7
+.2byte   -4,  -11, 	   3,  -12, 	   5,   -8, 	   1,   -7
+.2byte   -1,  -11, 	   7,  -13, 	  -3,   -8, 	   1,   -5
+.2byte    0,  -10, 	   8,  -11, 	  -8,  -11, 	   0,   -5
+.2byte    1,  -11, 	  -7,  -13, 	   3,   -8, 	  -1,   -5
+.2byte    3,  -11, 	  -4,  -12, 	  -6,   -8, 	  -2,   -7
+.2byte    2,  -10, 	   5,  -13, 	  -7,  -10, 	   0,   -7
+.2byte    0,   -8, 	  -9,  -10, 	   8,  -11, 	   0,   -6
+.2byte   -3,   -8, 	  -7,  -13, 	   6,   -9, 	   0,   -6
+.2byte   -6,   -9, 	  -1,  -12, 	   3,   -7, 	   0,   -6
+.2byte   -3,  -10, 	   7,  -14, 	  -4,   -8, 	   1,   -6
+.2byte    0,  -10, 	   8,  -10, 	  -8,  -10, 	   0,   -6
+.2byte    2,  -10, 	   5,   -8, 	  -6,  -13, 	   0,   -6
+.2byte    5,   -9, 	  -3,   -6, 	   0,  -11, 	   0,   -5
+.2byte    3,   -8, 	  -6,   -9, 	   6,  -12, 	   0,   -6
+sWooperAnimTable1:
+.4byte sWooperAnims_1_1
+.4byte sWooperAnims_1_2
+.4byte sWooperAnims_1_3
+.4byte sWooperAnims_1_4
+.4byte sWooperAnims_1_5
+.4byte sWooperAnims_1_6
+.4byte sWooperAnims_1_7
+.4byte sWooperAnims_1_8
+sWooperAnimTable2:
+.4byte sWooperAnims_2_1
+.4byte sWooperAnims_2_2
+.4byte sWooperAnims_2_3
+.4byte sWooperAnims_2_4
+.4byte sWooperAnims_2_5
+.4byte sWooperAnims_2_6
+.4byte sWooperAnims_2_7
+.4byte sWooperAnims_2_8
+sWooperAnimTable3:
+.4byte sWooperAnims_3_1
+.4byte sWooperAnims_3_2
+.4byte sWooperAnims_3_3
+.4byte sWooperAnims_3_4
+.4byte sWooperAnims_3_5
+.4byte sWooperAnims_3_6
+.4byte sWooperAnims_3_7
+.4byte sWooperAnims_3_8
+sWooperAnimTable4:
+.4byte sWooperAnims_4_1
+.4byte sWooperAnims_4_2
+.4byte sWooperAnims_4_3
+.4byte sWooperAnims_4_4
+.4byte sWooperAnims_4_5
+.4byte sWooperAnims_4_6
+.4byte sWooperAnims_4_7
+.4byte sWooperAnims_4_8
+sWooperAnimTable5:
+.4byte sWooperAnims_5_1
+.4byte sWooperAnims_5_2
+.4byte sWooperAnims_5_3
+.4byte sWooperAnims_5_4
+.4byte sWooperAnims_5_5
+.4byte sWooperAnims_5_6
+.4byte sWooperAnims_5_7
+.4byte sWooperAnims_5_8
+sWooperAnimTable6:
+.4byte sWooperAnims_6_1
+.4byte sWooperAnims_6_1
+.4byte sWooperAnims_6_1
+.4byte sWooperAnims_6_1
+.4byte sWooperAnims_6_1
+.4byte sWooperAnims_6_1
+.4byte sWooperAnims_6_1
+.4byte sWooperAnims_6_1
+sWooperAnimTable7:
+.4byte sWooperAnims_7_1
+.4byte sWooperAnims_7_2
+.4byte sWooperAnims_7_3
+.4byte sWooperAnims_7_4
+.4byte sWooperAnims_7_5
+.4byte sWooperAnims_7_6
+.4byte sWooperAnims_7_7
+.4byte sWooperAnims_7_8
+sWooperAnimTable8:
+.4byte sWooperAnims_8_1
+.4byte sWooperAnims_8_2
+.4byte sWooperAnims_8_3
+.4byte sWooperAnims_8_4
+.4byte sWooperAnims_8_5
+.4byte sWooperAnims_8_6
+.4byte sWooperAnims_8_7
+.4byte sWooperAnims_8_8
+sWooperAnimTable9:
+.4byte sWooperAnims_9_1
+.4byte sWooperAnims_9_2
+.4byte sWooperAnims_9_3
+.4byte sWooperAnims_9_4
+.4byte sWooperAnims_9_5
+.4byte sWooperAnims_9_6
+.4byte sWooperAnims_9_7
+.4byte sWooperAnims_9_8
+sWooperAnimTable10:
+.4byte sWooperAnims_10_1
+.4byte sWooperAnims_10_2
+.4byte sWooperAnims_10_3
+.4byte sWooperAnims_10_4
+.4byte sWooperAnims_10_5
+.4byte sWooperAnims_10_6
+.4byte sWooperAnims_10_7
+.4byte sWooperAnims_10_8
+sWooperAnimTable11:
+.4byte sWooperAnims_11_1
+.4byte sWooperAnims_11_2
+.4byte sWooperAnims_11_3
+.4byte sWooperAnims_11_4
+.4byte sWooperAnims_11_5
+.4byte sWooperAnims_11_6
+.4byte sWooperAnims_11_7
+.4byte sWooperAnims_11_8
+sWooperAnimTable12:
+.4byte sWooperAnims_12_1
+.4byte sWooperAnims_12_2
+.4byte sWooperAnims_12_3
+.4byte sWooperAnims_12_4
+.4byte sWooperAnims_12_5
+.4byte sWooperAnims_12_6
+.4byte sWooperAnims_12_7
+.4byte sWooperAnims_12_8
+sWooperAnimTable13:
+.4byte sWooperAnims_13_1
+.4byte sWooperAnims_13_2
+.4byte sWooperAnims_13_3
+.4byte sWooperAnims_13_4
+.4byte sWooperAnims_13_5
+.4byte sWooperAnims_13_6
+.4byte sWooperAnims_13_7
+.4byte sWooperAnims_13_8
+sAxAnimationsWooper:
+.4byte sWooperAnimTable1
+.4byte sWooperAnimTable2
+.4byte sWooperAnimTable3
+.4byte sWooperAnimTable4
+.4byte sWooperAnimTable5
+.4byte sWooperAnimTable6
+.4byte sWooperAnimTable7
+.4byte sWooperAnimTable8
+.4byte sWooperAnimTable9
+.4byte sWooperAnimTable10
+.4byte sWooperAnimTable11
+.4byte sWooperAnimTable12
+.4byte sWooperAnimTable13
+sAxSpritesWooper:
+.4byte sWooperSprites1
+.4byte sWooperSprites2
+.4byte sWooperSprites3
+.4byte sWooperSprites4
+.4byte sWooperSprites5
+.4byte sWooperSprites6
+.4byte sWooperSprites7
+.4byte sWooperSprites8
+.4byte sWooperSprites9
+.4byte sWooperSprites10
+.4byte sWooperSprites11
+.4byte sWooperSprites12
+.4byte sWooperSprites13
+.4byte sWooperSprites14
+.4byte sWooperSprites15
+.4byte sWooperSprites16
+.4byte sWooperSprites17
+.4byte sWooperSprites18
+.4byte sWooperSprites19
+.4byte sWooperSprites20
+.4byte sWooperSprites21
+.4byte sWooperSprites22
+.4byte sWooperSprites23
+.4byte sWooperSprites24
+.4byte sWooperSprites25
+.4byte sWooperSprites26
+.4byte sWooperSprites27
+.4byte sWooperSprites28
+.4byte sWooperSprites29
+.4byte sWooperSprites30
+.4byte sWooperSprites31
+.4byte sWooperSprites32
+.4byte sWooperSprites33
+.4byte sWooperSprites34
+.4byte sWooperSprites35
+.4byte sWooperSprites36
+.4byte sWooperSprites37
+.4byte sWooperSprites38
+.4byte sWooperSprites39
+.4byte sWooperSprites40
+.4byte sWooperSprites41
+sAxMainWooper:
+ax_main sAxPosesWooper, sAxAnimationsWooper, 13, sAxSpritesWooper, sAxPositionsWooper

--- a/data/ax/wurmple.inc
+++ b/data/ax/wurmple.inc
@@ -1,0 +1,2319 @@
+.global gAxWurmple
+gAxWurmple:
+ax_siro sAxMainWurmple
+sWurmplePose1:
+ax_pose 0, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose2:
+ax_pose 1, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose3:
+ax_pose 2, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose4:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose5:
+ax_pose 4, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose6:
+ax_pose 5, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose7:
+ax_pose 6, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose8:
+ax_pose 7, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose9:
+ax_pose 8, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose10:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose11:
+ax_pose 10, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose12:
+ax_pose 11, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose13:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose14:
+ax_pose 13, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose15:
+ax_pose 14, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose16:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose17:
+ax_pose 10, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose18:
+ax_pose 11, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose19:
+ax_pose 6, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose20:
+ax_pose 7, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose21:
+ax_pose 8, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose22:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose23:
+ax_pose 4, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose24:
+ax_pose 5, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose25:
+ax_pose 0, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose26:
+ax_pose 1, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose27:
+ax_pose 2, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose28:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose29:
+ax_pose 4, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose30:
+ax_pose 5, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose31:
+ax_pose 6, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose32:
+ax_pose 7, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose33:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose34:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose35:
+ax_pose 10, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose36:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose37:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose38:
+ax_pose 13, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose39:
+ax_pose 14, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose40:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose41:
+ax_pose 10, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose42:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose43:
+ax_pose 6, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose44:
+ax_pose 7, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose45:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose46:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose47:
+ax_pose 4, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose48:
+ax_pose 5, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose49:
+ax_pose 0, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose50:
+ax_pose 1, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose51:
+ax_pose 2, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose52:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose53:
+ax_pose 4, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose54:
+ax_pose 5, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose55:
+ax_pose 6, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose56:
+ax_pose 7, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose57:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose58:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose59:
+ax_pose 10, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose60:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose61:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose62:
+ax_pose 13, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose63:
+ax_pose 14, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose64:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose65:
+ax_pose 10, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose66:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose67:
+ax_pose 6, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose68:
+ax_pose 7, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose69:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose70:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose71:
+ax_pose 4, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose72:
+ax_pose 5, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose73:
+ax_pose 0, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose74:
+ax_pose 15, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose75:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose76:
+ax_pose 16, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sWurmplePose77:
+ax_pose 6, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose78:
+ax_pose 17, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWurmplePose79:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose80:
+ax_pose 18, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sWurmplePose81:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose82:
+ax_pose 19, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose83:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose84:
+ax_pose 18, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sWurmplePose85:
+ax_pose 6, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose86:
+ax_pose 17, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWurmplePose87:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose88:
+ax_pose 16, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sWurmplePose89:
+ax_pose 0, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose90:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose91:
+ax_pose 6, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose92:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose93:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose94:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose95:
+ax_pose 6, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose96:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose97:
+ax_pose 20, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose98:
+ax_pose 21, 0x01ee, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose99:
+ax_pose 22, 0x01e6, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose100:
+ax_pose 23, 0x01e5, 0x90ed, 0x5c00
+ax_pose_terminator
+sWurmplePose101:
+ax_pose 24, 0x01ea, 0x90ed, 0x5c00
+ax_pose_terminator
+sWurmplePose102:
+ax_pose 25, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sWurmplePose103:
+ax_pose 26, 0x01e6, 0x80f1, 0x5c00
+ax_pose_terminator
+sWurmplePose104:
+ax_pose 25, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sWurmplePose105:
+ax_pose 24, 0x01ea, 0x80f3, 0x5c00
+ax_pose_terminator
+sWurmplePose106:
+ax_pose 23, 0x01e5, 0x80f3, 0x5c00
+ax_pose_terminator
+sWurmplePose107:
+ax_pose 0, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose108:
+ax_pose 15, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose109:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose110:
+ax_pose 16, 0x01e8, 0x90ee, 0x5c00
+ax_pose_terminator
+sWurmplePose111:
+ax_pose 6, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose112:
+ax_pose 17, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWurmplePose113:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose114:
+ax_pose 18, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose115:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose116:
+ax_pose 19, 0x81ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose117:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose118:
+ax_pose 18, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose119:
+ax_pose 6, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose120:
+ax_pose 17, 0x01e9, 0x80f3, 0x5c00
+ax_pose_terminator
+sWurmplePose121:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose122:
+ax_pose 16, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sWurmplePose123:
+ax_pose 15, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sWurmplePose124:
+ax_pose 16, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose125:
+ax_pose 17, 0x01ea, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose126:
+ax_pose 18, 0x01ef, 0x80f6, 0x5c00
+ax_pose_terminator
+sWurmplePose127:
+ax_pose 19, 0x81ef, 0x80f7, 0x5c00
+ax_pose_terminator
+sWurmplePose128:
+ax_pose 18, 0x01ef, 0x90ea, 0x5c00
+ax_pose_terminator
+sWurmplePose129:
+ax_pose 17, 0x01ea, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose130:
+ax_pose 16, 0x01e7, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose131:
+ax_pose 1, 0x01ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose132:
+ax_pose 4, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose133:
+ax_pose 7, 0x01ee, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose134:
+ax_pose 10, 0x01ed, 0x90eb, 0x5c00
+ax_pose_terminator
+sWurmplePose135:
+ax_pose 13, 0x01ee, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose136:
+ax_pose 10, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sWurmplePose137:
+ax_pose 7, 0x01ee, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose138:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose139:
+ax_pose 0, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose140:
+ax_pose 1, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose141:
+ax_pose 2, 0x01eb, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose142:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose143:
+ax_pose 4, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose144:
+ax_pose 5, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose145:
+ax_pose 6, 0x01e9, 0x90f1, 0x5c00
+ax_pose_terminator
+sWurmplePose146:
+ax_pose 7, 0x01ed, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose147:
+ax_pose 8, 0x01ec, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose148:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose149:
+ax_pose 10, 0x01ed, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose150:
+ax_pose 11, 0x01ec, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose151:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose152:
+ax_pose 13, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose153:
+ax_pose 14, 0x01ea, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose154:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose155:
+ax_pose 10, 0x01ed, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose156:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose157:
+ax_pose 6, 0x01e9, 0x80ef, 0x5c00
+ax_pose_terminator
+sWurmplePose158:
+ax_pose 7, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose159:
+ax_pose 8, 0x01ec, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose160:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose161:
+ax_pose 4, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose162:
+ax_pose 5, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose163:
+ax_pose 15, 0x81eb, 0x80f7, 0x5c00
+ax_pose_terminator
+sWurmplePose164:
+ax_pose 16, 0x01e7, 0x80f3, 0x5c00
+ax_pose_terminator
+sWurmplePose165:
+ax_pose 17, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose166:
+ax_pose 18, 0x01ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sWurmplePose167:
+ax_pose 19, 0x81ed, 0x80f7, 0x5c00
+ax_pose_terminator
+sWurmplePose168:
+ax_pose 18, 0x01ed, 0x90ea, 0x5c00
+ax_pose_terminator
+sWurmplePose169:
+ax_pose 17, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose170:
+ax_pose 16, 0x01e7, 0x90ed, 0x5c00
+ax_pose_terminator
+sWurmplePose171:
+ax_pose 0, 0x01ed, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose172:
+ax_pose 3, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose173:
+ax_pose 6, 0x01e9, 0x80f0, 0x5c00
+ax_pose_terminator
+sWurmplePose174:
+ax_pose 9, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWurmplePose175:
+ax_pose 12, 0x01e9, 0x80f8, 0x5c00
+ax_pose_terminator
+sWurmplePose176:
+ax_pose 9, 0x01e9, 0x90ec, 0x5c00
+ax_pose_terminator
+sWurmplePose177:
+ax_pose 6, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+sWurmplePose178:
+ax_pose 3, 0x01e9, 0x90f0, 0x5c00
+ax_pose_terminator
+.align 2
+sWurmpleAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 2, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 0, 0, -4, 0, 0,
+ax_anim 4, 0, 2, 0, -1, 0, 0,
+ax_anim 2, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 2, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, -1, 0, 0,
+ax_anim 6, 0, 3, 0, -6, 0, 0,
+ax_anim 4, 0, 5, 0, -1, 0, 0,
+ax_anim 2, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 2, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, -1, 0, 0,
+ax_anim 6, 0, 6, 0, -7, 0, 0,
+ax_anim 4, 0, 8, 0, -1, 0, 0,
+ax_anim 2, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, -1, 0, 0,
+ax_anim 6, 0, 9, 0, -4, 0, 0,
+ax_anim 4, 0, 11, 0, -1, 0, 0,
+ax_anim 2, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 12, 0, -4, 0, 0,
+ax_anim 4, 0, 14, 0, -1, 0, 0,
+ax_anim 2, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 0, -1, 0, 0,
+ax_anim 6, 0, 15, 0, -4, 0, 0,
+ax_anim 4, 0, 17, 0, -1, 0, 0,
+ax_anim 2, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 0, -1, 0, 0,
+ax_anim 6, 0, 18, 0, -7, 0, 0,
+ax_anim 4, 0, 20, 0, -1, 0, 0,
+ax_anim 2, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 0, -1, 0, 0,
+ax_anim 6, 0, 21, 0, -6, 0, 0,
+ax_anim 4, 0, 23, 0, -1, 0, 0,
+ax_anim 2, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 25, 0, -2, 0, 0,
+ax_anim 2, 0, 25, 0, 4, 0, 4,
+ax_anim 2, 2, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWurmpleAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 1, 0, 28, 0, 1, 0, 1,
+ax_anim 2, 0, 28, 6, 2, 6, 6,
+ax_anim 2, 2, 29, 15, 8, 15, 15,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 1, 29, 17, 19, 17, 19,
+ax_anim 2, 0, 29, 18, 18, 18, 18,
+ax_anim 2, 0, 29, 17, 19, 17, 19,
+ax_anim 2, 0, 27, 6, 6, 6, 6,
+ax_anim_terminator
+sWurmpleAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 2, 0, 31, 4, -1, 4, 0,
+ax_anim 2, 2, 32, 10, -5, 10, 0,
+ax_anim 2, 0, 32, 18, -1, 18, -1,
+ax_anim 2, 1, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 32, 18, -1, 18, -1,
+ax_anim 2, 0, 32, 18, 0, 18, 0,
+ax_anim 2, 0, 30, 6, 0, 6, 0,
+ax_anim_terminator
+sWurmpleAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 1, 0, 34, 0, -1, 0, -1,
+ax_anim 2, 0, 34, 4, -10, 4, -4,
+ax_anim 2, 2, 35, 10, -18, 10, -11,
+ax_anim 2, 0, 35, 20, -22, 20, -22,
+ax_anim 2, 1, 35, 21, -21, 21, -21,
+ax_anim 2, 0, 35, 20, -22, 20, -22,
+ax_anim 2, 0, 35, 21, -21, 21, -21,
+ax_anim 2, 0, 33, 6, -6, 6, -6,
+ax_anim_terminator
+sWurmpleAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 1, 0, 37, 0, -3, 0, -2,
+ax_anim 2, 0, 37, 0, -9, 0, -7,
+ax_anim 2, 2, 38, 0, -18, 0, -15,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 1, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 38, 0, -21, 0, -21,
+ax_anim 2, 0, 38, 1, -21, 1, -21,
+ax_anim 2, 0, 36, 0, -6, 0, -6,
+ax_anim_terminator
+sWurmpleAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 1, 0, 40, 0, -1, 0, -1,
+ax_anim 2, 0, 40, -4, -10, -4, -4,
+ax_anim 2, 2, 41, -10, -18, -10, -11,
+ax_anim 2, 0, 41, -20, -22, -20, -22,
+ax_anim 2, 1, 41, -21, -21, -21, -21,
+ax_anim 2, 0, 41, -20, -22, -20, -22,
+ax_anim 2, 0, 41, -21, -21, -21, -21,
+ax_anim 2, 0, 39, -6, -6, -6, -6,
+ax_anim_terminator
+sWurmpleAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 2, 0, 43, -4, -1, -4, 0,
+ax_anim 2, 2, 44, -10, -5, -10, 0,
+ax_anim 2, 0, 44, -18, -1, -18, -1,
+ax_anim 2, 1, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 44, -18, -1, -18, -1,
+ax_anim 2, 0, 44, -18, 0, -18, 0,
+ax_anim 2, 0, 42, -6, 0, -6, 0,
+ax_anim_terminator
+sWurmpleAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 1, 0, 46, 0, 1, 0, 1,
+ax_anim 2, 0, 46, -6, 2, -6, 6,
+ax_anim 2, 2, 47, -15, 8, -15, 15,
+ax_anim 2, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 1, 47, -17, 19, -17, 19,
+ax_anim 2, 0, 47, -18, 18, -18, 18,
+ax_anim 2, 0, 47, -17, 19, -17, 19,
+ax_anim 2, 0, 45, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -2, 0, -2,
+ax_anim 1, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 0, 49, 0, 4, 0, 4,
+ax_anim 2, 2, 50, 0, 10, 0, 10,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 1, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 50, 0, 18, 0, 18,
+ax_anim 2, 0, 50, 1, 18, 1, 18,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sWurmpleAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 1, 0, 52, 0, 1, 0, 1,
+ax_anim 2, 0, 52, 6, 2, 6, 6,
+ax_anim 2, 2, 53, 15, 8, 15, 15,
+ax_anim 2, 0, 53, 18, 18, 18, 18,
+ax_anim 2, 1, 53, 17, 19, 17, 19,
+ax_anim 2, 0, 53, 18, 18, 18, 18,
+ax_anim 2, 0, 53, 17, 19, 17, 19,
+ax_anim 2, 0, 51, 6, 6, 6, 6,
+ax_anim_terminator
+sWurmpleAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 55, 4, -1, 4, 0,
+ax_anim 2, 2, 56, 10, -5, 10, 0,
+ax_anim 2, 0, 56, 18, -1, 18, -1,
+ax_anim 2, 1, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 56, 18, -1, 18, -1,
+ax_anim 2, 0, 56, 18, 0, 18, 0,
+ax_anim 2, 0, 54, 6, 0, 6, 0,
+ax_anim_terminator
+sWurmpleAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 1, 0, 58, 0, -1, 0, -1,
+ax_anim 2, 0, 58, 4, -10, 4, -4,
+ax_anim 2, 2, 59, 10, -18, 10, -11,
+ax_anim 2, 0, 59, 20, -22, 20, -22,
+ax_anim 2, 1, 59, 21, -21, 21, -21,
+ax_anim 2, 0, 59, 20, -22, 20, -22,
+ax_anim 2, 0, 59, 21, -21, 21, -21,
+ax_anim 2, 0, 57, 6, -6, 6, -6,
+ax_anim_terminator
+sWurmpleAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 1, 0, 61, 0, -3, 0, -2,
+ax_anim 2, 0, 61, 0, -9, 0, -7,
+ax_anim 2, 2, 62, 0, -18, 0, -15,
+ax_anim 2, 0, 62, 0, -21, 0, -21,
+ax_anim 2, 1, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 62, 0, -21, 0, -21,
+ax_anim 2, 0, 62, 1, -21, 1, -21,
+ax_anim 2, 0, 60, 0, -6, 0, -6,
+ax_anim_terminator
+sWurmpleAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 1, 0, 64, 0, -1, 0, -1,
+ax_anim 2, 0, 64, -4, -10, -4, -4,
+ax_anim 2, 2, 65, -10, -18, -10, -11,
+ax_anim 2, 0, 65, -20, -22, -20, -22,
+ax_anim 2, 1, 65, -21, -21, -21, -21,
+ax_anim 2, 0, 65, -20, -22, -20, -22,
+ax_anim 2, 0, 65, -21, -21, -21, -21,
+ax_anim 2, 0, 63, -6, -6, -6, -6,
+ax_anim_terminator
+sWurmpleAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 67, -4, -1, -4, 0,
+ax_anim 2, 2, 68, -10, -5, -10, 0,
+ax_anim 2, 0, 68, -18, -1, -18, -1,
+ax_anim 2, 1, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 68, -18, -1, -18, -1,
+ax_anim 2, 0, 68, -18, 0, -18, 0,
+ax_anim 2, 0, 66, -6, 0, -6, 0,
+ax_anim_terminator
+sWurmpleAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 1, 0, 70, 0, 1, 0, 1,
+ax_anim 2, 0, 70, -6, 2, -6, 6,
+ax_anim 2, 2, 71, -15, 8, -15, 15,
+ax_anim 2, 0, 71, -18, 18, -18, 18,
+ax_anim 2, 1, 71, -17, 19, -17, 19,
+ax_anim 2, 0, 71, -18, 18, -18, 18,
+ax_anim 2, 0, 71, -17, 19, -17, 19,
+ax_anim 2, 0, 69, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_4_1:
+ax_anim 2, 0, 72, 0, -2, 0, -2,
+ax_anim 6, 2, 72, 0, -3, 0, -3,
+ax_anim 3, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 1, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 73, -1, 3, -1, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 73, -1, 3, -1, 3,
+ax_anim 2, 0, 73, 0, 3, 0, 3,
+ax_anim 2, 0, 73, -1, 3, -1, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sWurmpleAnims_4_2:
+ax_anim 2, 0, 74, -2, -2, -2, -2,
+ax_anim 6, 2, 74, -3, -3, -3, -3,
+ax_anim 3, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 75, 3, 3, 3, 3,
+ax_anim 2, 0, 75, 4, 2, 4, 2,
+ax_anim 2, 0, 75, 3, 3, 3, 3,
+ax_anim 2, 0, 75, 4, 2, 4, 2,
+ax_anim 2, 0, 75, 3, 3, 3, 3,
+ax_anim 2, 0, 75, 4, 2, 4, 2,
+ax_anim 2, 0, 74, 1, 1, 1, 1,
+ax_anim_terminator
+sWurmpleAnims_4_3:
+ax_anim 2, 0, 76, -2, 0, -2, 0,
+ax_anim 6, 2, 76, -3, 0, -3, 0,
+ax_anim 3, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 1, 77, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 3, 0, 3, 0,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 76, 1, 0, 1, 0,
+ax_anim_terminator
+sWurmpleAnims_4_4:
+ax_anim 2, 0, 78, -2, 2, -2, 2,
+ax_anim 6, 2, 78, -3, 3, -3, 3,
+ax_anim 3, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 1, 79, 3, -3, 3, -3,
+ax_anim 2, 0, 79, 4, -2, 4, -2,
+ax_anim 2, 0, 79, 3, -3, 3, -3,
+ax_anim 2, 0, 79, 4, -2, 4, -2,
+ax_anim 2, 0, 79, 3, -3, 3, -3,
+ax_anim 2, 0, 79, 4, -2, 4, -2,
+ax_anim 2, 0, 78, 1, -1, 1, -1,
+ax_anim_terminator
+sWurmpleAnims_4_5:
+ax_anim 2, 0, 80, 0, 2, 0, 2,
+ax_anim 6, 2, 80, 0, 3, 0, 3,
+ax_anim 3, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 81, -1, -3, -1, -3,
+ax_anim 2, 0, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 81, -1, -3, -1, -3,
+ax_anim 2, 0, 81, 0, -3, 0, -3,
+ax_anim 2, 0, 81, -1, -3, -1, -3,
+ax_anim 2, 0, 80, 0, -1, 0, -1,
+ax_anim_terminator
+sWurmpleAnims_4_6:
+ax_anim 2, 0, 82, 2, 2, 2, 2,
+ax_anim 6, 2, 82, 3, 3, 3, 3,
+ax_anim 3, 0, 83, 0, 0, 0, 0,
+ax_anim 2, 1, 83, -3, -3, -3, -3,
+ax_anim 2, 0, 83, -4, -2, -4, -2,
+ax_anim 2, 0, 83, -3, -3, -3, -3,
+ax_anim 2, 0, 83, -4, -2, -4, -2,
+ax_anim 2, 0, 83, -3, -3, -3, -3,
+ax_anim 2, 0, 83, -4, -2, -4, -2,
+ax_anim 2, 0, 82, -1, -1, -1, -1,
+ax_anim_terminator
+sWurmpleAnims_4_7:
+ax_anim 2, 0, 84, 2, 0, 2, 0,
+ax_anim 6, 2, 84, 3, 0, 3, 0,
+ax_anim 3, 0, 85, 0, 0, 0, 0,
+ax_anim 2, 1, 85, -3, 0, -3, 0,
+ax_anim 2, 0, 85, -3, 1, -3, 1,
+ax_anim 2, 0, 85, -3, 0, -3, 0,
+ax_anim 2, 0, 85, -3, 1, -3, 1,
+ax_anim 2, 0, 85, -3, 0, -3, 0,
+ax_anim 2, 0, 85, -3, 1, -3, 1,
+ax_anim 2, 0, 84, -1, 0, -1, 0,
+ax_anim_terminator
+sWurmpleAnims_4_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 6, 2, 86, 3, -3, 3, -3,
+ax_anim 3, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 87, -3, 3, -3, 3,
+ax_anim 2, 0, 87, -4, 2, -4, 2,
+ax_anim 2, 0, 87, -3, 3, -3, 3,
+ax_anim 2, 0, 87, -4, 2, -4, 2,
+ax_anim 2, 0, 87, -3, 3, -3, 3,
+ax_anim 2, 0, 87, -4, 2, -4, 2,
+ax_anim 2, 0, 86, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_5_1:
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 2, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_5_2:
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 2, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_5_3:
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 2, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_5_4:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 2, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_5_5:
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 2, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_5_6:
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 2, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_5_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 2, 90, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_5_8:
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, 0, 0, 0, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, 0, 0, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, 0, 0, 0,
+ax_anim 2, 2, 89, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_6_1:
+ax_anim 30, 0, 96, 0, 0, 0, 0,
+ax_anim 35, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_7_1:
+ax_anim 2, 0, 98, 0, -2, 0, -2,
+ax_anim 8, 0, 98, 0, -3, 0, -3,
+ax_anim_terminator
+sWurmpleAnims_7_2:
+ax_anim 2, 0, 99, -2, -2, -2, -2,
+ax_anim 8, 0, 99, -3, -3, -3, -3,
+ax_anim_terminator
+sWurmpleAnims_7_3:
+ax_anim 2, 0, 100, -2, 0, -2, 0,
+ax_anim 8, 0, 100, -3, 0, -3, 0,
+ax_anim_terminator
+sWurmpleAnims_7_4:
+ax_anim 2, 0, 101, -2, 2, -2, 2,
+ax_anim 8, 0, 101, -3, 3, -3, 3,
+ax_anim_terminator
+sWurmpleAnims_7_5:
+ax_anim 2, 0, 102, 0, 2, 0, 2,
+ax_anim 8, 0, 102, 0, 3, 0, 3,
+ax_anim_terminator
+sWurmpleAnims_7_6:
+ax_anim 2, 0, 103, 2, 2, 2, 2,
+ax_anim 8, 0, 103, 3, 3, 3, 3,
+ax_anim_terminator
+sWurmpleAnims_7_7:
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 8, 0, 104, 3, 0, 3, 0,
+ax_anim_terminator
+sWurmpleAnims_7_8:
+ax_anim 2, 0, 105, 2, -2, 2, -2,
+ax_anim 8, 0, 105, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_8_1:
+ax_anim 30, 0, 106, 0, 0, 0, 0,
+ax_anim 12, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 107, -1, 0, -1, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 107, -1, 0, -1, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim 4, 0, 107, -1, 0, -1, 0,
+ax_anim 4, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_8_2:
+ax_anim 30, 0, 108, 0, 0, 0, 0,
+ax_anim 12, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 109, -1, 1, -1, 1,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 109, -1, 1, -1, 1,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 4, 0, 109, -1, 1, -1, 1,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_8_3:
+ax_anim 30, 0, 110, 0, 0, 0, 0,
+ax_anim 12, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 1, 0, 1,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 1, 0, 1,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim 4, 0, 111, 0, 1, 0, 1,
+ax_anim 4, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_8_4:
+ax_anim 30, 0, 112, 0, 0, 0, 0,
+ax_anim 12, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 113, -1, -1, -1, -1,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 113, -1, -1, -1, -1,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim 4, 0, 113, -1, -1, -1, -1,
+ax_anim 4, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_8_5:
+ax_anim 30, 0, 114, 0, 0, 0, 0,
+ax_anim 12, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 115, -1, 0, -1, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 115, -1, 0, -1, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim 4, 0, 115, -1, 0, -1, 0,
+ax_anim 4, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_8_6:
+ax_anim 30, 0, 116, 0, 0, 0, 0,
+ax_anim 12, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 1, -1, 1, -1,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 1, -1, 1, -1,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim 4, 0, 117, 1, -1, 1, -1,
+ax_anim 4, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_8_7:
+ax_anim 30, 0, 118, 0, 0, 0, 0,
+ax_anim 12, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 1, 0, 1,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 1, 0, 1,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim 4, 0, 119, 0, 1, 0, 1,
+ax_anim 4, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_8_8:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 12, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 1, 1, 1, 1,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 1, 1, 1, 1,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim 4, 0, 121, 1, 1, 1, 1,
+ax_anim 4, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_9_1:
+ax_anim 2, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 123, 7, 5, 7, 5,
+ax_anim 2, 0, 124, 10, 12, 10, 12,
+ax_anim 2, 0, 125, 9, 17, 9, 17,
+ax_anim 3, 0, 126, 1, 20, 1, 20,
+ax_anim 2, 3, 127, -9, 17, -9, 17,
+ax_anim 2, 0, 128, -10, 12, -10, 12,
+ax_anim 1, 0, 129, -7, 5, -7, 5,
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_9_2:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 9, 0, 9, 0,
+ax_anim 2, 0, 123, 20, 3, 20, 3,
+ax_anim 2, 0, 124, 25, 12, 25, 12,
+ax_anim 3, 0, 125, 23, 19, 23, 19,
+ax_anim 2, 3, 126, 14, 20, 14, 20,
+ax_anim 2, 0, 127, 3, 16, 3, 16,
+ax_anim 1, 0, 128, 0, 9, 0, 9,
+ax_anim 1, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_9_3:
+ax_anim 2, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 129, 3, -4, 3, -4,
+ax_anim 2, 0, 122, 12, -6, 12, -6,
+ax_anim 2, 0, 123, 18, -5, 18, -5,
+ax_anim 3, 0, 124, 23, 1, 23, 1,
+ax_anim 2, 3, 125, 20, 4, 20, 4,
+ax_anim 2, 0, 126, 13, 6, 13, 6,
+ax_anim 1, 0, 127, 6, 5, 6, 5,
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_9_4:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -9, 0, -9,
+ax_anim 2, 0, 129, 6, -20, 6, -20,
+ax_anim 2, 0, 122, 16, -24, 16, -24,
+ax_anim 3, 0, 123, 23, -23, 23, -23,
+ax_anim 2, 3, 124, 27, -16, 27, -16,
+ax_anim 2, 0, 125, 24, -6, 24, -6,
+ax_anim 1, 0, 126, 13, -1, 13, -1,
+ax_anim 1, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_9_5:
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 127, -10, -4, -10, -4,
+ax_anim 2, 0, 128, -13, -10, -13, -10,
+ax_anim 2, 0, 129, -10, -19, -10, -19,
+ax_anim 3, 0, 122, 0, -23, 0, -23,
+ax_anim 2, 3, 123, 10, -19, 10, -19,
+ax_anim 2, 0, 124, 13, -10, 13, -10,
+ax_anim 1, 0, 125, 10, -4, 10, -4,
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_9_6:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, -9, 0, -9,
+ax_anim 2, 0, 123, -6, -20, -6, -20,
+ax_anim 2, 0, 122, -16, -24, -16, -24,
+ax_anim 3, 0, 129, -23, -23, -23, -23,
+ax_anim 2, 3, 128, -27, -16, -27, -16,
+ax_anim 2, 0, 127, -24, -6, -24, -6,
+ax_anim 1, 0, 126, -13, -1, -13, -1,
+ax_anim 1, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_9_7:
+ax_anim 2, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 123, -3, -4, -3, -4,
+ax_anim 2, 0, 122, -12, -6, -12, -6,
+ax_anim 2, 0, 129, -18, -5, -18, -5,
+ax_anim 3, 0, 128, -23, 1, -23, 1,
+ax_anim 2, 3, 127, -20, 4, -20, 4,
+ax_anim 2, 0, 126, -13, 6, -13, 6,
+ax_anim 1, 0, 125, -6, 5, -6, 5,
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_9_8:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 122, -9, 0, -9, 0,
+ax_anim 2, 0, 129, -20, 3, -20, 3,
+ax_anim 2, 0, 128, -25, 12, -25, 12,
+ax_anim 3, 0, 127, -23, 19, -23, 19,
+ax_anim 2, 3, 126, -14, 20, -14, 20,
+ax_anim 2, 0, 125, -3, 16, -3, 16,
+ax_anim 1, 0, 124, 0, 9, 0, 9,
+ax_anim 1, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_10_1:
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 3, 0, 130, 13, 0, 13, 0,
+ax_anim 3, 0, 130, -13, 0, -13, 0,
+ax_anim 2, 0, 130, 12, 0, 12, 0,
+ax_anim 3, 0, 130, -12, 0, -12, 0,
+ax_anim 2, 0, 130, 10, 0, 10, 0,
+ax_anim 2, 0, 130, -10, 0, -10, 0,
+ax_anim 2, 0, 130, 6, 0, 6, 0,
+ax_anim 2, 0, 130, -6, 0, -6, 0,
+ax_anim 2, 0, 130, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_10_2:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 3, 0, 131, 13, -13, 13, -13,
+ax_anim 3, 0, 131, -13, 13, -13, 13,
+ax_anim 2, 0, 131, 12, -12, 12, -12,
+ax_anim 3, 0, 131, -12, 12, -12, 12,
+ax_anim 2, 0, 131, 10, -10, 10, -10,
+ax_anim 2, 0, 131, -10, 10, -10, 10,
+ax_anim 2, 0, 131, 6, -6, 6, -6,
+ax_anim 2, 0, 131, -6, 6, -6, 6,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_10_3:
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 3, 0, 132, 0, -13, 0, -13,
+ax_anim 3, 0, 132, 0, 13, 0, 13,
+ax_anim 2, 0, 132, 0, -12, 0, -12,
+ax_anim 3, 0, 132, 0, 12, 0, 12,
+ax_anim 2, 0, 132, 0, -10, 0, -10,
+ax_anim 2, 0, 132, 0, 10, 0, 10,
+ax_anim 2, 0, 132, 0, -6, 0, -6,
+ax_anim 2, 0, 132, 0, 6, 0, 6,
+ax_anim 2, 0, 132, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_10_4:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 3, 0, 133, -13, -13, -13, -13,
+ax_anim 3, 0, 133, 13, 13, 13, 13,
+ax_anim 2, 0, 133, -12, -12, -12, -12,
+ax_anim 3, 0, 133, 12, 12, 12, 12,
+ax_anim 2, 0, 133, -10, -10, -10, -10,
+ax_anim 2, 0, 133, 10, 10, 10, 10,
+ax_anim 2, 0, 133, -6, -6, -6, -6,
+ax_anim 2, 0, 133, 6, 6, 6, 6,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_10_5:
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 3, 0, 134, 13, 0, 13, 0,
+ax_anim 3, 0, 134, -13, 0, -13, 0,
+ax_anim 2, 0, 134, 12, 0, 12, 0,
+ax_anim 3, 0, 134, -12, 0, -12, 0,
+ax_anim 2, 0, 134, 10, 0, 10, 0,
+ax_anim 2, 0, 134, -10, 0, -10, 0,
+ax_anim 2, 0, 134, 6, 0, 6, 0,
+ax_anim 2, 0, 134, -6, 0, -6, 0,
+ax_anim 2, 0, 134, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_10_6:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 3, 0, 135, 13, -13, 13, -13,
+ax_anim 3, 0, 135, -13, 13, -13, 13,
+ax_anim 2, 0, 135, 12, -12, 12, -12,
+ax_anim 3, 0, 135, -12, 12, -12, 12,
+ax_anim 2, 0, 135, 10, -10, 10, -10,
+ax_anim 2, 0, 135, -10, 10, -10, 10,
+ax_anim 2, 0, 135, 6, -6, 6, -6,
+ax_anim 2, 0, 135, -6, 6, -6, 6,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_10_7:
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 3, 0, 136, 0, -13, 0, -13,
+ax_anim 3, 0, 136, 0, 13, 0, 13,
+ax_anim 2, 0, 136, 0, -12, 0, -12,
+ax_anim 3, 0, 136, 0, 12, 0, 12,
+ax_anim 2, 0, 136, 0, -10, 0, -10,
+ax_anim 2, 0, 136, 0, 10, 0, 10,
+ax_anim 2, 0, 136, 0, -6, 0, -6,
+ax_anim 2, 0, 136, 0, 6, 0, 6,
+ax_anim 2, 0, 136, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_10_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 3, 0, 137, -13, -13, -13, -13,
+ax_anim 3, 0, 137, 13, 13, 13, 13,
+ax_anim 2, 0, 137, -12, -12, -12, -12,
+ax_anim 3, 0, 137, 12, 12, 12, 12,
+ax_anim 2, 0, 137, -10, -10, -10, -10,
+ax_anim 2, 0, 137, 10, 10, 10, 10,
+ax_anim 2, 0, 137, -6, -6, -6, -6,
+ax_anim 2, 0, 137, 6, 6, 6, 6,
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_11_1:
+ax_anim 2, 0, 138, 0, 0, 0, 0,
+ax_anim 1, 0, 139, 0, -10, 0, 0,
+ax_anim 2, 0, 139, 0, -16, 0, 0,
+ax_anim 3, 0, 139, 0, -20, 0, 0,
+ax_anim 4, 0, 139, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -23, 0, 0,
+ax_anim 3, 0, 140, 0, -22, 0, 0,
+ax_anim 2, 0, 140, 0, -18, 0, 0,
+ax_anim 1, 0, 140, 0, -12, 0, 0,
+ax_anim 2, 2, 138, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_11_2:
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 1, 0, 142, 0, -10, 0, 0,
+ax_anim 2, 0, 142, 0, -16, 0, 0,
+ax_anim 3, 0, 142, 0, -20, 0, 0,
+ax_anim 4, 0, 142, 0, -21, 0, 0,
+ax_anim 4, 0, 141, 0, -23, 0, 0,
+ax_anim 3, 0, 143, 0, -22, 0, 0,
+ax_anim 2, 0, 143, 0, -18, 0, 0,
+ax_anim 1, 0, 143, 0, -12, 0, 0,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_11_3:
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 1, 0, 145, 0, -10, 0, 0,
+ax_anim 2, 0, 145, 0, -16, 0, 0,
+ax_anim 3, 0, 145, 0, -20, 0, 0,
+ax_anim 4, 0, 145, 0, -21, 0, 0,
+ax_anim 4, 0, 144, 0, -24, 0, 0,
+ax_anim 3, 0, 146, 0, -21, 0, 0,
+ax_anim 2, 0, 146, 0, -18, 0, 0,
+ax_anim 1, 0, 146, 0, -12, 0, 0,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_11_4:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 1, 0, 148, 0, -10, 0, 0,
+ax_anim 2, 0, 148, 0, -16, 0, 0,
+ax_anim 3, 0, 148, 0, -20, 0, 0,
+ax_anim 4, 0, 148, 0, -21, 0, 0,
+ax_anim 4, 0, 147, 0, -23, 0, 0,
+ax_anim 3, 0, 149, 0, -21, 0, 0,
+ax_anim 2, 0, 149, 0, -18, 0, 0,
+ax_anim 1, 0, 149, 0, -11, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_11_5:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 1, 0, 151, 0, -10, 0, 0,
+ax_anim 2, 0, 151, 0, -16, 0, 0,
+ax_anim 3, 0, 151, 0, -20, 0, 0,
+ax_anim 4, 0, 151, 0, -21, 0, 0,
+ax_anim 4, 0, 150, 0, -22, 0, 0,
+ax_anim 3, 0, 152, 0, -20, 0, 0,
+ax_anim 2, 0, 152, 0, -18, 0, 0,
+ax_anim 1, 0, 152, 0, -12, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_11_6:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 0, -10, 0, 0,
+ax_anim 2, 0, 154, 0, -16, 0, 0,
+ax_anim 3, 0, 154, 0, -20, 0, 0,
+ax_anim 4, 0, 154, 0, -21, 0, 0,
+ax_anim 4, 0, 153, 0, -23, 0, 0,
+ax_anim 3, 0, 155, 0, -21, 0, 0,
+ax_anim 2, 0, 155, 0, -18, 0, 0,
+ax_anim 1, 0, 155, 0, -11, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_11_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 157, 0, -10, 0, 0,
+ax_anim 2, 0, 157, 0, -16, 0, 0,
+ax_anim 3, 0, 157, 0, -20, 0, 0,
+ax_anim 4, 0, 157, 0, -21, 0, 0,
+ax_anim 4, 0, 156, 0, -24, 0, 0,
+ax_anim 3, 0, 158, 0, -21, 0, 0,
+ax_anim 2, 0, 158, 0, -18, 0, 0,
+ax_anim 1, 0, 158, 0, -12, 0, 0,
+ax_anim 2, 2, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_11_8:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, 0, -10, 0, 0,
+ax_anim 2, 0, 160, 0, -16, 0, 0,
+ax_anim 3, 0, 160, 0, -20, 0, 0,
+ax_anim 4, 0, 160, 0, -21, 0, 0,
+ax_anim 4, 0, 159, 0, -23, 0, 0,
+ax_anim 3, 0, 161, 0, -22, 0, 0,
+ax_anim 2, 0, 161, 0, -18, 0, 0,
+ax_anim 1, 0, 161, 0, -12, 0, 0,
+ax_anim 2, 2, 159, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_12_1:
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 2, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 1, 0,
+ax_anim 2, 1, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_12_2:
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 2, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 1, -1,
+ax_anim 2, 1, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_12_3:
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 2, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -1, 0, -1,
+ax_anim 2, 1, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_12_4:
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 2, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, -1, -1, -1, -1,
+ax_anim 2, 1, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_12_5:
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 2, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 1, 0, 1, 0,
+ax_anim 2, 1, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_12_6:
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 2, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 1, -1, 1, -1,
+ax_anim 2, 1, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_12_7:
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 2, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -1, 0, -1,
+ax_anim 2, 1, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_12_8:
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 2, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, -1, -1, -1, -1,
+ax_anim 2, 1, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWurmpleAnims_13_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 2, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_13_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 2, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_13_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 2, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_13_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 2, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_13_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 2, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_13_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 2, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_13_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 2, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleAnims_13_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 2, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sWurmpleGfx1:
+.incbin "baserom.gba", 0x10E1908, 0x200
+sWurmpleSprites1:
+ax_sprite sWurmpleGfx1, 0x200
+ax_sprite_terminator
+sWurmpleGfx2:
+.incbin "baserom.gba", 0x10E1B18, 0x200
+sWurmpleSprites2:
+ax_sprite sWurmpleGfx2, 0x200
+ax_sprite_terminator
+sWurmpleGfx3:
+.incbin "baserom.gba", 0x10E1D28, 0x200
+sWurmpleSprites3:
+ax_sprite sWurmpleGfx3, 0x200
+ax_sprite_terminator
+sWurmpleGfx4:
+.incbin "baserom.gba", 0x10E1F38, 0x200
+sWurmpleSprites4:
+ax_sprite sWurmpleGfx4, 0x200
+ax_sprite_terminator
+sWurmpleGfx5:
+.incbin "baserom.gba", 0x10E2148, 0x200
+sWurmpleSprites5:
+ax_sprite sWurmpleGfx5, 0x200
+ax_sprite_terminator
+sWurmpleGfx6:
+.incbin "baserom.gba", 0x10E2358, 0x200
+sWurmpleSprites6:
+ax_sprite sWurmpleGfx6, 0x200
+ax_sprite_terminator
+sWurmpleGfx7:
+.incbin "baserom.gba", 0x10E2568, 0x200
+sWurmpleSprites7:
+ax_sprite sWurmpleGfx7, 0x200
+ax_sprite_terminator
+sWurmpleGfx8:
+.incbin "baserom.gba", 0x10E2778, 0x200
+sWurmpleSprites8:
+ax_sprite sWurmpleGfx8, 0x200
+ax_sprite_terminator
+sWurmpleGfx9:
+.incbin "baserom.gba", 0x10E2988, 0x200
+sWurmpleSprites9:
+ax_sprite sWurmpleGfx9, 0x200
+ax_sprite_terminator
+sWurmpleGfx10:
+.incbin "baserom.gba", 0x10E2B98, 0x200
+sWurmpleSprites10:
+ax_sprite sWurmpleGfx10, 0x200
+ax_sprite_terminator
+sWurmpleGfx11:
+.incbin "baserom.gba", 0x10E2DA8, 0x200
+sWurmpleSprites11:
+ax_sprite sWurmpleGfx11, 0x200
+ax_sprite_terminator
+sWurmpleGfx12:
+.incbin "baserom.gba", 0x10E2FB8, 0x200
+sWurmpleSprites12:
+ax_sprite sWurmpleGfx12, 0x200
+ax_sprite_terminator
+sWurmpleGfx13:
+.incbin "baserom.gba", 0x10E31C8, 0x200
+sWurmpleSprites13:
+ax_sprite sWurmpleGfx13, 0x200
+ax_sprite_terminator
+sWurmpleGfx14:
+.incbin "baserom.gba", 0x10E33D8, 0x200
+sWurmpleSprites14:
+ax_sprite sWurmpleGfx14, 0x200
+ax_sprite_terminator
+sWurmpleGfx15:
+.incbin "baserom.gba", 0x10E35E8, 0x200
+sWurmpleSprites15:
+ax_sprite sWurmpleGfx15, 0x200
+ax_sprite_terminator
+sWurmpleGfx16:
+.incbin "baserom.gba", 0x10E37F8, 0xC0
+sWurmpleSprites16:
+ax_sprite sWurmpleGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWurmpleGfx17:
+.incbin "baserom.gba", 0x10E38D0, 0x60
+sWurmpleGfx17_1:
+.incbin "baserom.gba", 0x10E3930, 0x60
+sWurmpleGfx17_2:
+.incbin "baserom.gba", 0x10E3990, 0x60
+sWurmpleSprites17:
+ax_sprite 0, 0x80
+ax_sprite sWurmpleGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWurmpleGfx17_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWurmpleGfx17_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWurmpleGfx18:
+.incbin "baserom.gba", 0x10E3A30, 0x40
+sWurmpleGfx18_1:
+.incbin "baserom.gba", 0x10E3A70, 0x60
+sWurmpleGfx18_2:
+.incbin "baserom.gba", 0x10E3AD0, 0x60
+sWurmpleSprites18:
+ax_sprite 0, 0x20
+ax_sprite sWurmpleGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWurmpleGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWurmpleGfx18_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWurmpleGfx19:
+.incbin "baserom.gba", 0x10E3B70, 0x60
+sWurmpleGfx19_1:
+.incbin "baserom.gba", 0x10E3BD0, 0x60
+sWurmpleGfx19_2:
+.incbin "baserom.gba", 0x10E3C30, 0x40
+sWurmpleSprites19:
+ax_sprite sWurmpleGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWurmpleGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWurmpleGfx19_2, 0x40
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sWurmpleGfx20:
+.incbin "baserom.gba", 0x10E3CA8, 0xC0
+sWurmpleSprites20:
+ax_sprite sWurmpleGfx20, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWurmpleGfx21:
+.incbin "baserom.gba", 0x10E3D80, 0x200
+sWurmpleSprites21:
+ax_sprite sWurmpleGfx21, 0x200
+ax_sprite_terminator
+sWurmpleGfx22:
+.incbin "baserom.gba", 0x10E3F90, 0x200
+sWurmpleSprites22:
+ax_sprite sWurmpleGfx22, 0x200
+ax_sprite_terminator
+sWurmpleGfx23:
+.incbin "baserom.gba", 0x10E41A0, 0x200
+sWurmpleSprites23:
+ax_sprite sWurmpleGfx23, 0x200
+ax_sprite_terminator
+sWurmpleGfx24:
+.incbin "baserom.gba", 0x10E43B0, 0x200
+sWurmpleSprites24:
+ax_sprite sWurmpleGfx24, 0x200
+ax_sprite_terminator
+sWurmpleGfx25:
+.incbin "baserom.gba", 0x10E45C0, 0x200
+sWurmpleSprites25:
+ax_sprite sWurmpleGfx25, 0x200
+ax_sprite_terminator
+sWurmpleGfx26:
+.incbin "baserom.gba", 0x10E47D0, 0x200
+sWurmpleSprites26:
+ax_sprite sWurmpleGfx26, 0x200
+ax_sprite_terminator
+sWurmpleGfx27:
+.incbin "baserom.gba", 0x10E49E0, 0x200
+sWurmpleSprites27:
+ax_sprite sWurmpleGfx27, 0x200
+ax_sprite_terminator
+sAxPosesWurmple:
+.4byte sWurmplePose1
+.4byte sWurmplePose2
+.4byte sWurmplePose3
+.4byte sWurmplePose4
+.4byte sWurmplePose5
+.4byte sWurmplePose6
+.4byte sWurmplePose7
+.4byte sWurmplePose8
+.4byte sWurmplePose9
+.4byte sWurmplePose10
+.4byte sWurmplePose11
+.4byte sWurmplePose12
+.4byte sWurmplePose13
+.4byte sWurmplePose14
+.4byte sWurmplePose15
+.4byte sWurmplePose16
+.4byte sWurmplePose17
+.4byte sWurmplePose18
+.4byte sWurmplePose19
+.4byte sWurmplePose20
+.4byte sWurmplePose21
+.4byte sWurmplePose22
+.4byte sWurmplePose23
+.4byte sWurmplePose24
+.4byte sWurmplePose25
+.4byte sWurmplePose26
+.4byte sWurmplePose27
+.4byte sWurmplePose28
+.4byte sWurmplePose29
+.4byte sWurmplePose30
+.4byte sWurmplePose31
+.4byte sWurmplePose32
+.4byte sWurmplePose33
+.4byte sWurmplePose34
+.4byte sWurmplePose35
+.4byte sWurmplePose36
+.4byte sWurmplePose37
+.4byte sWurmplePose38
+.4byte sWurmplePose39
+.4byte sWurmplePose40
+.4byte sWurmplePose41
+.4byte sWurmplePose42
+.4byte sWurmplePose43
+.4byte sWurmplePose44
+.4byte sWurmplePose45
+.4byte sWurmplePose46
+.4byte sWurmplePose47
+.4byte sWurmplePose48
+.4byte sWurmplePose49
+.4byte sWurmplePose50
+.4byte sWurmplePose51
+.4byte sWurmplePose52
+.4byte sWurmplePose53
+.4byte sWurmplePose54
+.4byte sWurmplePose55
+.4byte sWurmplePose56
+.4byte sWurmplePose57
+.4byte sWurmplePose58
+.4byte sWurmplePose59
+.4byte sWurmplePose60
+.4byte sWurmplePose61
+.4byte sWurmplePose62
+.4byte sWurmplePose63
+.4byte sWurmplePose64
+.4byte sWurmplePose65
+.4byte sWurmplePose66
+.4byte sWurmplePose67
+.4byte sWurmplePose68
+.4byte sWurmplePose69
+.4byte sWurmplePose70
+.4byte sWurmplePose71
+.4byte sWurmplePose72
+.4byte sWurmplePose73
+.4byte sWurmplePose74
+.4byte sWurmplePose75
+.4byte sWurmplePose76
+.4byte sWurmplePose77
+.4byte sWurmplePose78
+.4byte sWurmplePose79
+.4byte sWurmplePose80
+.4byte sWurmplePose81
+.4byte sWurmplePose82
+.4byte sWurmplePose83
+.4byte sWurmplePose84
+.4byte sWurmplePose85
+.4byte sWurmplePose86
+.4byte sWurmplePose87
+.4byte sWurmplePose88
+.4byte sWurmplePose89
+.4byte sWurmplePose90
+.4byte sWurmplePose91
+.4byte sWurmplePose92
+.4byte sWurmplePose93
+.4byte sWurmplePose94
+.4byte sWurmplePose95
+.4byte sWurmplePose96
+.4byte sWurmplePose97
+.4byte sWurmplePose98
+.4byte sWurmplePose99
+.4byte sWurmplePose100
+.4byte sWurmplePose101
+.4byte sWurmplePose102
+.4byte sWurmplePose103
+.4byte sWurmplePose104
+.4byte sWurmplePose105
+.4byte sWurmplePose106
+.4byte sWurmplePose107
+.4byte sWurmplePose108
+.4byte sWurmplePose109
+.4byte sWurmplePose110
+.4byte sWurmplePose111
+.4byte sWurmplePose112
+.4byte sWurmplePose113
+.4byte sWurmplePose114
+.4byte sWurmplePose115
+.4byte sWurmplePose116
+.4byte sWurmplePose117
+.4byte sWurmplePose118
+.4byte sWurmplePose119
+.4byte sWurmplePose120
+.4byte sWurmplePose121
+.4byte sWurmplePose122
+.4byte sWurmplePose123
+.4byte sWurmplePose124
+.4byte sWurmplePose125
+.4byte sWurmplePose126
+.4byte sWurmplePose127
+.4byte sWurmplePose128
+.4byte sWurmplePose129
+.4byte sWurmplePose130
+.4byte sWurmplePose131
+.4byte sWurmplePose132
+.4byte sWurmplePose133
+.4byte sWurmplePose134
+.4byte sWurmplePose135
+.4byte sWurmplePose136
+.4byte sWurmplePose137
+.4byte sWurmplePose138
+.4byte sWurmplePose139
+.4byte sWurmplePose140
+.4byte sWurmplePose141
+.4byte sWurmplePose142
+.4byte sWurmplePose143
+.4byte sWurmplePose144
+.4byte sWurmplePose145
+.4byte sWurmplePose146
+.4byte sWurmplePose147
+.4byte sWurmplePose148
+.4byte sWurmplePose149
+.4byte sWurmplePose150
+.4byte sWurmplePose151
+.4byte sWurmplePose152
+.4byte sWurmplePose153
+.4byte sWurmplePose154
+.4byte sWurmplePose155
+.4byte sWurmplePose156
+.4byte sWurmplePose157
+.4byte sWurmplePose158
+.4byte sWurmplePose159
+.4byte sWurmplePose160
+.4byte sWurmplePose161
+.4byte sWurmplePose162
+.4byte sWurmplePose163
+.4byte sWurmplePose164
+.4byte sWurmplePose165
+.4byte sWurmplePose166
+.4byte sWurmplePose167
+.4byte sWurmplePose168
+.4byte sWurmplePose169
+.4byte sWurmplePose170
+.4byte sWurmplePose171
+.4byte sWurmplePose172
+.4byte sWurmplePose173
+.4byte sWurmplePose174
+.4byte sWurmplePose175
+.4byte sWurmplePose176
+.4byte sWurmplePose177
+.4byte sWurmplePose178
+sAxPositionsWurmple:
+.2byte    0,   -2, 	  -2,    0, 	   2,    0, 	   0,   -5
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -9
+.2byte    0,    1, 	  -3,    3, 	   3,    3, 	   0,   -5
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+.2byte    7,  -11, 	   8,   -9, 	   3,   -8, 	  -1,   -8
+.2byte    7,   -2, 	   6,    1, 	   1,    2, 	   0,   -8
+.2byte    9,   -5, 	   6,   -5, 	   5,   -2, 	  -1,   -4
+.2byte    8,  -13, 	   7,  -10, 	   6,   -9, 	   0,   -9
+.2byte   10,   -6, 	   6,   -5, 	   5,   -4, 	   1,   -7
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    8,  -14, 	   1,  -12, 	   7,  -11, 	   0,   -9
+.2byte    5,   -6, 	   1,   -6, 	   5,   -4, 	   1,   -8
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    0,  -13, 	   4,  -14, 	  -4,  -14, 	   0,  -12
+.2byte    0,   -9, 	   4,   -7, 	  -4,   -7, 	   0,  -10
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte   -9,  -14, 	  -2,  -12, 	  -8,  -11, 	  -1,   -9
+.2byte   -6,   -6, 	  -2,   -6, 	  -6,   -4, 	  -2,   -8
+.2byte  -10,   -5, 	  -7,   -5, 	  -6,   -2, 	   0,   -4
+.2byte   -9,  -13, 	  -8,  -10, 	  -7,   -9, 	  -1,   -9
+.2byte  -11,   -6, 	  -7,   -5, 	  -6,   -4, 	  -2,   -7
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte   -8,  -11, 	  -9,   -9, 	  -4,   -8, 	   0,   -8
+.2byte   -8,   -2, 	  -7,    1, 	  -2,    2, 	  -1,   -8
+.2byte    0,   -2, 	  -2,    0, 	   2,    0, 	   0,   -5
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -9
+.2byte    0,    1, 	  -3,    3, 	   3,    3, 	   0,   -5
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+.2byte    7,  -11, 	   8,   -9, 	   3,   -8, 	  -1,   -8
+.2byte    7,   -2, 	   6,    1, 	   1,    2, 	   0,   -8
+.2byte    9,   -5, 	   6,   -5, 	   5,   -2, 	  -1,   -4
+.2byte    8,  -13, 	   7,  -10, 	   6,   -9, 	   0,   -9
+.2byte   10,   -3, 	   6,   -2, 	   5,   -1, 	   1,   -4
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    8,  -14, 	   1,  -12, 	   7,  -11, 	   0,   -9
+.2byte    5,   -3, 	   1,   -3, 	   5,   -1, 	   1,   -5
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    0,  -13, 	   4,  -14, 	  -4,  -14, 	   0,  -12
+.2byte    0,   -8, 	   4,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte   -9,  -14, 	  -2,  -12, 	  -8,  -11, 	  -1,   -9
+.2byte   -6,   -3, 	  -2,   -3, 	  -6,   -1, 	  -2,   -5
+.2byte  -10,   -5, 	  -7,   -5, 	  -6,   -2, 	   0,   -4
+.2byte   -9,  -13, 	  -8,  -10, 	  -7,   -9, 	  -1,   -9
+.2byte  -11,   -3, 	  -7,   -2, 	  -6,   -1, 	  -2,   -4
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte   -8,  -11, 	  -9,   -9, 	  -4,   -8, 	   0,   -8
+.2byte   -8,   -2, 	  -7,    1, 	  -2,    2, 	  -1,   -8
+.2byte    0,   -2, 	  -2,    0, 	   2,    0, 	   0,   -5
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -9
+.2byte    0,    1, 	  -3,    3, 	   3,    3, 	   0,   -5
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+.2byte    7,  -11, 	   8,   -9, 	   3,   -8, 	  -1,   -8
+.2byte    7,   -2, 	   6,    1, 	   1,    2, 	   0,   -8
+.2byte    9,   -5, 	   6,   -5, 	   5,   -2, 	  -1,   -4
+.2byte    8,  -13, 	   7,  -10, 	   6,   -9, 	   0,   -9
+.2byte   10,   -3, 	   6,   -2, 	   5,   -1, 	   1,   -4
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    8,  -14, 	   1,  -12, 	   7,  -11, 	   0,   -9
+.2byte    5,   -3, 	   1,   -3, 	   5,   -1, 	   1,   -5
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    0,  -13, 	   4,  -14, 	  -4,  -14, 	   0,  -12
+.2byte    0,   -8, 	   4,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte   -9,  -14, 	  -2,  -12, 	  -8,  -11, 	  -1,   -9
+.2byte   -6,   -3, 	  -2,   -3, 	  -6,   -1, 	  -2,   -5
+.2byte  -10,   -5, 	  -7,   -5, 	  -6,   -2, 	   0,   -4
+.2byte   -9,  -13, 	  -8,  -10, 	  -7,   -9, 	  -1,   -9
+.2byte  -11,   -3, 	  -7,   -2, 	  -6,   -1, 	  -2,   -4
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte   -8,  -11, 	  -9,   -9, 	  -4,   -8, 	   0,   -8
+.2byte   -8,   -2, 	  -7,    1, 	  -2,    2, 	  -1,   -8
+.2byte    0,   -2, 	  -2,    0, 	   2,    0, 	   0,   -5
+.2byte    0,    3, 	  -4,    3, 	   4,    3, 	   0,   -4
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+.2byte    8,    1, 	   5,    0, 	   0,    2, 	   1,   -4
+.2byte    9,   -5, 	   6,   -5, 	   5,   -2, 	  -1,   -4
+.2byte    9,   -1, 	   2,   -5, 	   2,   -1, 	   0,   -5
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    6,   -3, 	   1,   -1, 	   4,   -1, 	   1,   -7
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    0,   -3, 	   4,   -2, 	  -4,   -2, 	   0,   -8
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte   -7,   -3, 	  -2,   -1, 	  -5,   -1, 	  -2,   -7
+.2byte  -10,   -5, 	  -7,   -5, 	  -6,   -2, 	   0,   -4
+.2byte  -10,   -1, 	  -3,   -5, 	  -3,   -1, 	  -1,   -5
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte   -9,    1, 	  -6,    0, 	  -1,    2, 	  -2,   -4
+.2byte    0,   -2, 	  -2,    0, 	   2,    0, 	   0,   -5
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte  -10,   -5, 	  -7,   -5, 	  -6,   -2, 	   0,   -4
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    9,   -5, 	   6,   -5, 	   5,   -2, 	  -1,   -4
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+.2byte   -8,    1, 	  -9,    2, 	  -4,    4, 	   1,   -6
+.2byte   -8,    1, 	  -9,    2, 	  -4,    4, 	   1,   -6
+.2byte    0,    1, 	  -5,    2, 	   5,    2, 	   0,   -5
+.2byte    5,    0, 	   3,   -2, 	  -2,    2, 	  -1,   -7
+.2byte    7,    1, 	   1,    0, 	  -1,    1, 	  -3,   -3
+.2byte    5,   -1, 	  -3,   -1, 	   4,    2, 	   0,   -4
+.2byte    0,   -5, 	   6,   -2, 	  -6,   -2, 	   0,   -4
+.2byte   -6,   -1, 	   2,   -1, 	  -5,    2, 	  -1,   -4
+.2byte   -8,    1, 	  -2,    0, 	   0,    1, 	   2,   -3
+.2byte   -6,    0, 	  -4,   -2, 	   1,    2, 	   0,   -7
+.2byte    0,   -2, 	  -2,    0, 	   2,    0, 	   0,   -5
+.2byte    0,    3, 	  -4,    3, 	   4,    3, 	   0,   -4
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+.2byte    8,    1, 	   5,    0, 	   0,    2, 	   1,   -4
+.2byte    9,   -5, 	   6,   -5, 	   5,   -2, 	  -1,   -4
+.2byte    9,   -1, 	   2,   -5, 	   2,   -1, 	   0,   -5
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    7,   -4, 	   2,   -2, 	   5,   -2, 	   2,   -8
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    0,   -3, 	   4,   -2, 	  -4,   -2, 	   0,   -8
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte   -8,   -4, 	  -3,   -2, 	  -6,   -2, 	  -3,   -8
+.2byte  -10,   -5, 	  -7,   -5, 	  -6,   -2, 	   0,   -4
+.2byte  -10,   -1, 	  -3,   -5, 	  -3,   -1, 	  -1,   -5
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte   -9,    1, 	  -6,    0, 	  -1,    2, 	  -2,   -4
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -7,    0, 	  -4,   -1, 	   1,    1, 	   0,   -5
+.2byte   -9,    0, 	  -2,   -4, 	  -2,    0, 	   0,   -4
+.2byte   -6,   -1, 	  -1,    1, 	  -4,    1, 	  -1,   -5
+.2byte   -1,   -1, 	   3,    0, 	  -5,    0, 	  -1,   -6
+.2byte    5,   -1, 	   0,    1, 	   3,    1, 	   0,   -5
+.2byte    8,    0, 	   1,   -4, 	   1,    0, 	  -1,   -4
+.2byte    6,    0, 	   3,   -1, 	  -2,    1, 	  -1,   -5
+.2byte    0,   -5, 	  -2,   -2, 	   2,   -2, 	   0,   -8
+.2byte    7,   -7, 	   8,   -5, 	   3,   -4, 	  -1,   -4
+.2byte    8,   -8, 	   7,   -5, 	   6,   -4, 	   0,   -4
+.2byte    7,  -10, 	   0,   -8, 	   6,   -7, 	  -1,   -5
+.2byte    0,   -8, 	   4,   -9, 	  -4,   -9, 	   0,   -7
+.2byte   -8,  -10, 	  -1,   -8, 	  -7,   -7, 	   0,   -5
+.2byte   -9,   -8, 	  -8,   -5, 	  -7,   -4, 	  -1,   -4
+.2byte   -8,   -7, 	  -9,   -5, 	  -4,   -4, 	   0,   -4
+.2byte    0,   -5, 	  -2,   -3, 	   2,   -3, 	   0,   -8
+.2byte    0,   -6, 	  -2,   -3, 	   2,   -3, 	   0,   -9
+.2byte    0,   -1, 	  -3,    1, 	   3,    1, 	   0,   -7
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+.2byte    7,   -7, 	   8,   -5, 	   3,   -4, 	  -1,   -4
+.2byte    7,   -2, 	   6,    1, 	   1,    2, 	   0,   -8
+.2byte   10,   -5, 	   7,   -5, 	   6,   -2, 	   0,   -4
+.2byte    8,   -9, 	   7,   -6, 	   6,   -5, 	   0,   -5
+.2byte   10,   -3, 	   6,   -2, 	   5,   -1, 	   1,   -4
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    8,  -10, 	   1,   -8, 	   7,   -7, 	   0,   -5
+.2byte    5,   -3, 	   1,   -3, 	   5,   -1, 	   1,   -5
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    0,   -9, 	   4,  -10, 	  -4,  -10, 	   0,   -8
+.2byte    0,   -8, 	   4,   -6, 	  -4,   -6, 	   0,   -9
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte   -9,  -10, 	  -2,   -8, 	  -8,   -7, 	  -1,   -5
+.2byte   -6,   -3, 	  -2,   -3, 	  -6,   -1, 	  -2,   -5
+.2byte  -11,   -5, 	  -8,   -5, 	  -7,   -2, 	  -1,   -4
+.2byte   -9,   -9, 	  -8,   -6, 	  -7,   -5, 	  -1,   -5
+.2byte  -11,   -3, 	  -7,   -2, 	  -6,   -1, 	  -2,   -4
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte   -8,   -7, 	  -9,   -5, 	  -4,   -4, 	   0,   -4
+.2byte   -8,   -2, 	  -7,    1, 	  -2,    2, 	  -1,   -8
+.2byte   -1,    1, 	  -5,    1, 	   3,    1, 	  -1,   -6
+.2byte   -8,    0, 	  -5,   -1, 	   0,    1, 	  -1,   -5
+.2byte   -9,   -1, 	  -2,   -5, 	  -2,   -1, 	   0,   -5
+.2byte   -5,   -3, 	   0,   -1, 	  -3,   -1, 	   0,   -7
+.2byte   -1,   -3, 	   3,   -2, 	  -5,   -2, 	  -1,   -8
+.2byte    5,   -3, 	   0,   -1, 	   3,   -1, 	   0,   -7
+.2byte    8,   -1, 	   1,   -5, 	   1,   -1, 	  -1,   -5
+.2byte    7,    0, 	   4,   -1, 	  -1,    1, 	   0,   -5
+.2byte    0,   -2, 	  -2,    0, 	   2,    0, 	   0,   -5
+.2byte   -8,   -4, 	  -8,   -2, 	  -4,   -1, 	   0,   -6
+.2byte  -10,   -5, 	  -7,   -5, 	  -6,   -2, 	   0,   -4
+.2byte   -9,   -7, 	  -3,   -7, 	  -8,   -5, 	  -2,   -6
+.2byte    0,  -10, 	   4,   -5, 	  -4,   -5, 	   0,   -9
+.2byte    8,   -7, 	   2,   -7, 	   7,   -5, 	   1,   -6
+.2byte    9,   -5, 	   6,   -5, 	   5,   -2, 	  -1,   -4
+.2byte    7,   -4, 	   7,   -2, 	   3,   -1, 	  -1,   -6
+sWurmpleAnimTable1:
+.4byte sWurmpleAnims_1_1
+.4byte sWurmpleAnims_1_2
+.4byte sWurmpleAnims_1_3
+.4byte sWurmpleAnims_1_4
+.4byte sWurmpleAnims_1_5
+.4byte sWurmpleAnims_1_6
+.4byte sWurmpleAnims_1_7
+.4byte sWurmpleAnims_1_8
+sWurmpleAnimTable2:
+.4byte sWurmpleAnims_2_1
+.4byte sWurmpleAnims_2_2
+.4byte sWurmpleAnims_2_3
+.4byte sWurmpleAnims_2_4
+.4byte sWurmpleAnims_2_5
+.4byte sWurmpleAnims_2_6
+.4byte sWurmpleAnims_2_7
+.4byte sWurmpleAnims_2_8
+sWurmpleAnimTable3:
+.4byte sWurmpleAnims_3_1
+.4byte sWurmpleAnims_3_2
+.4byte sWurmpleAnims_3_3
+.4byte sWurmpleAnims_3_4
+.4byte sWurmpleAnims_3_5
+.4byte sWurmpleAnims_3_6
+.4byte sWurmpleAnims_3_7
+.4byte sWurmpleAnims_3_8
+sWurmpleAnimTable4:
+.4byte sWurmpleAnims_4_1
+.4byte sWurmpleAnims_4_2
+.4byte sWurmpleAnims_4_3
+.4byte sWurmpleAnims_4_4
+.4byte sWurmpleAnims_4_5
+.4byte sWurmpleAnims_4_6
+.4byte sWurmpleAnims_4_7
+.4byte sWurmpleAnims_4_8
+sWurmpleAnimTable5:
+.4byte sWurmpleAnims_5_1
+.4byte sWurmpleAnims_5_2
+.4byte sWurmpleAnims_5_3
+.4byte sWurmpleAnims_5_4
+.4byte sWurmpleAnims_5_5
+.4byte sWurmpleAnims_5_6
+.4byte sWurmpleAnims_5_7
+.4byte sWurmpleAnims_5_8
+sWurmpleAnimTable6:
+.4byte sWurmpleAnims_6_1
+.4byte sWurmpleAnims_6_1
+.4byte sWurmpleAnims_6_1
+.4byte sWurmpleAnims_6_1
+.4byte sWurmpleAnims_6_1
+.4byte sWurmpleAnims_6_1
+.4byte sWurmpleAnims_6_1
+.4byte sWurmpleAnims_6_1
+sWurmpleAnimTable7:
+.4byte sWurmpleAnims_7_1
+.4byte sWurmpleAnims_7_2
+.4byte sWurmpleAnims_7_3
+.4byte sWurmpleAnims_7_4
+.4byte sWurmpleAnims_7_5
+.4byte sWurmpleAnims_7_6
+.4byte sWurmpleAnims_7_7
+.4byte sWurmpleAnims_7_8
+sWurmpleAnimTable8:
+.4byte sWurmpleAnims_8_1
+.4byte sWurmpleAnims_8_2
+.4byte sWurmpleAnims_8_3
+.4byte sWurmpleAnims_8_4
+.4byte sWurmpleAnims_8_5
+.4byte sWurmpleAnims_8_6
+.4byte sWurmpleAnims_8_7
+.4byte sWurmpleAnims_8_8
+sWurmpleAnimTable9:
+.4byte sWurmpleAnims_9_1
+.4byte sWurmpleAnims_9_2
+.4byte sWurmpleAnims_9_3
+.4byte sWurmpleAnims_9_4
+.4byte sWurmpleAnims_9_5
+.4byte sWurmpleAnims_9_6
+.4byte sWurmpleAnims_9_7
+.4byte sWurmpleAnims_9_8
+sWurmpleAnimTable10:
+.4byte sWurmpleAnims_10_1
+.4byte sWurmpleAnims_10_2
+.4byte sWurmpleAnims_10_3
+.4byte sWurmpleAnims_10_4
+.4byte sWurmpleAnims_10_5
+.4byte sWurmpleAnims_10_6
+.4byte sWurmpleAnims_10_7
+.4byte sWurmpleAnims_10_8
+sWurmpleAnimTable11:
+.4byte sWurmpleAnims_11_1
+.4byte sWurmpleAnims_11_2
+.4byte sWurmpleAnims_11_3
+.4byte sWurmpleAnims_11_4
+.4byte sWurmpleAnims_11_5
+.4byte sWurmpleAnims_11_6
+.4byte sWurmpleAnims_11_7
+.4byte sWurmpleAnims_11_8
+sWurmpleAnimTable12:
+.4byte sWurmpleAnims_12_1
+.4byte sWurmpleAnims_12_2
+.4byte sWurmpleAnims_12_3
+.4byte sWurmpleAnims_12_4
+.4byte sWurmpleAnims_12_5
+.4byte sWurmpleAnims_12_6
+.4byte sWurmpleAnims_12_7
+.4byte sWurmpleAnims_12_8
+sWurmpleAnimTable13:
+.4byte sWurmpleAnims_13_1
+.4byte sWurmpleAnims_13_2
+.4byte sWurmpleAnims_13_3
+.4byte sWurmpleAnims_13_4
+.4byte sWurmpleAnims_13_5
+.4byte sWurmpleAnims_13_6
+.4byte sWurmpleAnims_13_7
+.4byte sWurmpleAnims_13_8
+sAxAnimationsWurmple:
+.4byte sWurmpleAnimTable1
+.4byte sWurmpleAnimTable2
+.4byte sWurmpleAnimTable3
+.4byte sWurmpleAnimTable4
+.4byte sWurmpleAnimTable5
+.4byte sWurmpleAnimTable6
+.4byte sWurmpleAnimTable7
+.4byte sWurmpleAnimTable8
+.4byte sWurmpleAnimTable9
+.4byte sWurmpleAnimTable10
+.4byte sWurmpleAnimTable11
+.4byte sWurmpleAnimTable12
+.4byte sWurmpleAnimTable13
+sAxSpritesWurmple:
+.4byte sWurmpleSprites1
+.4byte sWurmpleSprites2
+.4byte sWurmpleSprites3
+.4byte sWurmpleSprites4
+.4byte sWurmpleSprites5
+.4byte sWurmpleSprites6
+.4byte sWurmpleSprites7
+.4byte sWurmpleSprites8
+.4byte sWurmpleSprites9
+.4byte sWurmpleSprites10
+.4byte sWurmpleSprites11
+.4byte sWurmpleSprites12
+.4byte sWurmpleSprites13
+.4byte sWurmpleSprites14
+.4byte sWurmpleSprites15
+.4byte sWurmpleSprites16
+.4byte sWurmpleSprites17
+.4byte sWurmpleSprites18
+.4byte sWurmpleSprites19
+.4byte sWurmpleSprites20
+.4byte sWurmpleSprites21
+.4byte sWurmpleSprites22
+.4byte sWurmpleSprites23
+.4byte sWurmpleSprites24
+.4byte sWurmpleSprites25
+.4byte sWurmpleSprites26
+.4byte sWurmpleSprites27
+sAxMainWurmple:
+ax_main sAxPosesWurmple, sAxAnimationsWurmple, 13, sAxSpritesWurmple, sAxPositionsWurmple

--- a/data/ax/wynaut.inc
+++ b/data/ax/wynaut.inc
@@ -1,0 +1,2765 @@
+.global gAxWynaut
+gAxWynaut:
+ax_siro sAxMainWynaut
+sWynautPose1:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose2:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose3:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose4:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose5:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose6:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose7:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose8:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose10:
+ax_pose 9, 0x81eb, 0x90f6, 0x5c00
+ax_pose_terminator
+sWynautPose11:
+ax_pose 10, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sWynautPose12:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose13:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose14:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose15:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose16:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose17:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose18:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose19:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose20:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose22:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose23:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose24:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose25:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose26:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose27:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose28:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose29:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose30:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose31:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose32:
+ax_pose 16, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose33:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose34:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose35:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose36:
+ax_pose 17, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose37:
+ax_pose 9, 0x81eb, 0x90f6, 0x5c00
+ax_pose_terminator
+sWynautPose38:
+ax_pose 10, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sWynautPose39:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose40:
+ax_pose 18, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sWynautPose41:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose42:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose43:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose44:
+ax_pose 19, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose45:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose46:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose47:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose48:
+ax_pose 18, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose49:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose50:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose51:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose52:
+ax_pose 17, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose53:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose54:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose55:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose56:
+ax_pose 16, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sWynautPose57:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose58:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose59:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose60:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose61:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose62:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose63:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose64:
+ax_pose 16, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose65:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose66:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose67:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose68:
+ax_pose 17, 0x01e3, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose69:
+ax_pose 9, 0x81eb, 0x90f6, 0x5c00
+ax_pose_terminator
+sWynautPose70:
+ax_pose 10, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sWynautPose71:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose72:
+ax_pose 18, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sWynautPose73:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose74:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose75:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose76:
+ax_pose 19, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose77:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose78:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose79:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose80:
+ax_pose 18, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose81:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose82:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose83:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose84:
+ax_pose 17, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose85:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose86:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose87:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose88:
+ax_pose 16, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sWynautPose89:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose90:
+ax_pose 20, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose91:
+ax_pose 21, 0x01ea, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose92:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose93:
+ax_pose 22, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWynautPose94:
+ax_pose 23, 0x01e9, 0x90ed, 0x5c00
+ax_pose_terminator
+sWynautPose95:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose96:
+ax_pose 24, 0x01e9, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose97:
+ax_pose 25, 0x01e9, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose98:
+ax_pose 9, 0x81eb, 0x90f6, 0x5c00
+ax_pose_terminator
+sWynautPose99:
+ax_pose 26, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWynautPose100:
+ax_pose 27, 0x01e9, 0x90ee, 0x5c00
+ax_pose_terminator
+sWynautPose101:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose102:
+ax_pose 28, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose103:
+ax_pose 29, 0x01e7, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose104:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose105:
+ax_pose 26, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose106:
+ax_pose 27, 0x01e9, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose107:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose108:
+ax_pose 24, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose109:
+ax_pose 25, 0x01e9, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose110:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose111:
+ax_pose 22, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWynautPose112:
+ax_pose 23, 0x01e9, 0x80f2, 0x5c00
+ax_pose_terminator
+sWynautPose113:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose114:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose115:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose116:
+ax_pose 16, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose117:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose118:
+ax_pose 17, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose119:
+ax_pose 9, 0x81eb, 0x90f6, 0x5c00
+ax_pose_terminator
+sWynautPose120:
+ax_pose 18, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sWynautPose121:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose122:
+ax_pose 19, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose123:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose124:
+ax_pose 18, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose125:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose126:
+ax_pose 17, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose127:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose128:
+ax_pose 16, 0x01e2, 0x80f3, 0x5c00
+ax_pose_terminator
+sWynautPose129:
+ax_pose 30, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose130:
+ax_pose 31, 0x01ed, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose131:
+ax_pose 32, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose132:
+ax_pose 33, 0x01e2, 0x90e8, 0x5c00
+ax_pose_terminator
+sWynautPose133:
+ax_pose 34, 0x01e4, 0x90e8, 0x5c00
+ax_pose_terminator
+sWynautPose134:
+ax_pose 35, 0x01e6, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose135:
+ax_pose 36, 0x01e8, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose136:
+ax_pose 35, 0x01e6, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose137:
+ax_pose 34, 0x01e4, 0x80f8, 0x5c00
+ax_pose_terminator
+sWynautPose138:
+ax_pose 33, 0x01e2, 0x80f8, 0x5c00
+ax_pose_terminator
+sWynautPose139:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose140:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose141:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose142:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose143:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose144:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose145:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose146:
+ax_pose 7, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose147:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose148:
+ax_pose 9, 0x81eb, 0x90f6, 0x5c00
+ax_pose_terminator
+sWynautPose149:
+ax_pose 10, 0x01ec, 0x90ea, 0x5c00
+ax_pose_terminator
+sWynautPose150:
+ax_pose 11, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose151:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose152:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose153:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose154:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose155:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose156:
+ax_pose 11, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose157:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose158:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose159:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose160:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose161:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose162:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose163:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose164:
+ax_pose 16, 0x01e2, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose165:
+ax_pose 17, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose166:
+ax_pose 18, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose167:
+ax_pose 19, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose168:
+ax_pose 18, 0x01e3, 0x90ee, 0x5c00
+ax_pose_terminator
+sWynautPose169:
+ax_pose 17, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose170:
+ax_pose 16, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose171:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose172:
+ax_pose 16, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose173:
+ax_pose 17, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose174:
+ax_pose 18, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sWynautPose175:
+ax_pose 19, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose176:
+ax_pose 18, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose177:
+ax_pose 17, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose178:
+ax_pose 16, 0x01e2, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose179:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose180:
+ax_pose 1, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose181:
+ax_pose 2, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose182:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose183:
+ax_pose 4, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose184:
+ax_pose 5, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose185:
+ax_pose 6, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose186:
+ax_pose 7, 0x01eb, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose187:
+ax_pose 8, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose188:
+ax_pose 9, 0x81eb, 0x90f7, 0x5c00
+ax_pose_terminator
+sWynautPose189:
+ax_pose 10, 0x01ec, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose190:
+ax_pose 11, 0x01ec, 0x90ed, 0x5c00
+ax_pose_terminator
+sWynautPose191:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose192:
+ax_pose 13, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose193:
+ax_pose 14, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose194:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose195:
+ax_pose 10, 0x01ec, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose196:
+ax_pose 11, 0x01ec, 0x80f3, 0x5c00
+ax_pose_terminator
+sWynautPose197:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose198:
+ax_pose 7, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose199:
+ax_pose 8, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose200:
+ax_pose 3, 0x01eb, 0x80f5, 0x5c00
+ax_pose_terminator
+sWynautPose201:
+ax_pose 4, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose202:
+ax_pose 5, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose203:
+ax_pose 15, 0x01e5, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose204:
+ax_pose 16, 0x01e2, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose205:
+ax_pose 17, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose206:
+ax_pose 18, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose207:
+ax_pose 19, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sWynautPose208:
+ax_pose 18, 0x01e3, 0x90ef, 0x5c00
+ax_pose_terminator
+sWynautPose209:
+ax_pose 17, 0x01e3, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose210:
+ax_pose 16, 0x01e2, 0x90ec, 0x5c00
+ax_pose_terminator
+sWynautPose211:
+ax_pose 0, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose212:
+ax_pose 3, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose213:
+ax_pose 6, 0x01eb, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose214:
+ax_pose 9, 0x81eb, 0x80f9, 0x5c00
+ax_pose_terminator
+sWynautPose215:
+ax_pose 12, 0x01ec, 0x80f4, 0x5c00
+ax_pose_terminator
+sWynautPose216:
+ax_pose 9, 0x81eb, 0x90f6, 0x5c00
+ax_pose_terminator
+sWynautPose217:
+ax_pose 6, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+sWynautPose218:
+ax_pose 3, 0x01eb, 0x90eb, 0x5c00
+ax_pose_terminator
+.align 2
+sWynautAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 2, 0, 1, 0, -2, 0, 0,
+ax_anim 10, 0, 1, 0, -3, 0, 0,
+ax_anim 2, 0, 1, 0, -2, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 2, 0, 2, 0, -2, 0, 0,
+ax_anim 10, 0, 2, 0, -3, 0, 0,
+ax_anim 2, 0, 2, 0, -2, 0, 0,
+ax_anim_terminator
+sWynautAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 2, 0, 4, 0, -2, 0, 0,
+ax_anim 10, 0, 4, 0, -3, 0, 0,
+ax_anim 2, 0, 4, 0, -2, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 2, 0, 5, 0, -2, 0, 0,
+ax_anim 10, 0, 5, 0, -3, 0, 0,
+ax_anim 2, 0, 5, 0, -2, 0, 0,
+ax_anim_terminator
+sWynautAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 2, 0, 7, 0, -2, 0, 0,
+ax_anim 10, 0, 7, 0, -3, 0, 0,
+ax_anim 2, 0, 7, 0, -2, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 2, 0, 8, 0, -2, 0, 0,
+ax_anim 10, 0, 8, 0, -3, 0, 0,
+ax_anim 2, 0, 8, 0, -2, 0, 0,
+ax_anim_terminator
+sWynautAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 10, 0, -2, 0, 0,
+ax_anim 10, 0, 10, 0, -3, 0, 0,
+ax_anim 2, 0, 10, 0, -2, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 2, 0, 11, 0, -2, 0, 0,
+ax_anim 10, 0, 11, 0, -3, 0, 0,
+ax_anim 2, 0, 11, 0, -2, 0, 0,
+ax_anim_terminator
+sWynautAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 13, 0, -2, 0, 0,
+ax_anim 10, 0, 13, 0, -3, 0, 0,
+ax_anim 2, 0, 13, 0, -2, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 2, 0, 14, 0, -2, 0, 0,
+ax_anim 10, 0, 14, 0, -3, 0, 0,
+ax_anim 2, 0, 14, 0, -2, 0, 0,
+ax_anim_terminator
+sWynautAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 16, 0, -2, 0, 0,
+ax_anim 10, 0, 16, 0, -3, 0, 0,
+ax_anim 2, 0, 16, 0, -2, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 2, 0, 17, 0, -2, 0, 0,
+ax_anim 10, 0, 17, 0, -3, 0, 0,
+ax_anim 2, 0, 17, 0, -2, 0, 0,
+ax_anim_terminator
+sWynautAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 19, 0, -2, 0, 0,
+ax_anim 10, 0, 19, 0, -3, 0, 0,
+ax_anim 2, 0, 19, 0, -2, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 2, 0, 20, 0, -2, 0, 0,
+ax_anim 10, 0, 20, 0, -3, 0, 0,
+ax_anim 2, 0, 20, 0, -2, 0, 0,
+ax_anim_terminator
+sWynautAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 22, 0, -2, 0, 0,
+ax_anim 10, 0, 22, 0, -3, 0, 0,
+ax_anim 2, 0, 22, 0, -2, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 2, 0, 23, 0, -2, 0, 0,
+ax_anim 10, 0, 23, 0, -3, 0, 0,
+ax_anim 2, 0, 23, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 2, 0, 27, 0, -4, 0, 2,
+ax_anim 2, 0, 27, 0, 0, 0, 5,
+ax_anim 2, 2, 27, 0, 8, 0, 11,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 1, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 27, 0, 20, 0, 20,
+ax_anim 2, 0, 27, 1, 20, 1, 20,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sWynautAnims_2_2:
+ax_anim 2, 0, 28, 0, 0, 0, 0,
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 2, 0, 31, 7, 1, 7, 7,
+ax_anim 2, 0, 31, 14, 5, 14, 13,
+ax_anim 2, 2, 31, 19, 11, 19, 16,
+ax_anim 2, 0, 31, 24, 20, 24, 20,
+ax_anim 2, 1, 31, 25, 19, 25, 19,
+ax_anim 2, 0, 31, 24, 20, 24, 20,
+ax_anim 2, 0, 31, 25, 19, 25, 19,
+ax_anim 2, 0, 28, 10, 8, 10, 8,
+ax_anim_terminator
+sWynautAnims_2_3:
+ax_anim 2, 0, 32, 0, 0, 0, 0,
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 2, 0, 35, 4, -3, 4, 0,
+ax_anim 2, 0, 35, 10, -5, 10, 0,
+ax_anim 2, 2, 35, 18, -5, 18, 0,
+ax_anim 2, 0, 35, 25, 0, 25, 0,
+ax_anim 2, 1, 35, 25, 1, 25, 1,
+ax_anim 2, 0, 35, 25, 0, 25, 0,
+ax_anim 2, 0, 35, 25, 1, 25, 1,
+ax_anim 2, 0, 32, 8, 0, 8, 0,
+ax_anim_terminator
+sWynautAnims_2_4:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 2, 0, 39, 3, -10, 3, -2,
+ax_anim 2, 0, 39, 8, -17, 8, -7,
+ax_anim 2, 2, 39, 14, -20, 14, -12,
+ax_anim 2, 0, 39, 22, -17, 22, -17,
+ax_anim 2, 1, 39, 23, -16, 23, -16,
+ax_anim 2, 0, 39, 22, -17, 22, -17,
+ax_anim 2, 0, 39, 23, -16, 23, -16,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sWynautAnims_2_5:
+ax_anim 2, 0, 40, 0, 0, 0, 0,
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 2, 0, 43, 0, -5, 0, -2,
+ax_anim 2, 0, 43, 0, -15, 0, -11,
+ax_anim 2, 2, 43, 0, -21, 0, -21,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 1, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 43, 0, -18, 0, -18,
+ax_anim 2, 0, 43, 1, -18, 1, -18,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sWynautAnims_2_6:
+ax_anim 2, 0, 44, 0, 0, 0, 0,
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 2, 0, 47, -3, -10, -3, -2,
+ax_anim 2, 0, 47, -8, -17, -8, -7,
+ax_anim 2, 2, 47, -14, -20, -14, -12,
+ax_anim 2, 0, 47, -22, -17, -22, -17,
+ax_anim 2, 1, 47, -23, -16, -23, -16,
+ax_anim 2, 0, 47, -22, -17, -22, -17,
+ax_anim 2, 0, 47, -23, -16, -23, -16,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sWynautAnims_2_7:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 2, 0, 51, -4, -3, -4, 0,
+ax_anim 2, 0, 51, -10, -5, -10, 0,
+ax_anim 2, 2, 51, -18, -5, -18, 0,
+ax_anim 2, 0, 51, -25, 0, -25, 0,
+ax_anim 2, 1, 51, -25, 1, -25, 1,
+ax_anim 2, 0, 51, -25, 0, -25, 0,
+ax_anim 2, 0, 51, -25, 1, -25, 1,
+ax_anim 2, 0, 48, -8, 0, -8, 0,
+ax_anim_terminator
+sWynautAnims_2_8:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 2, 0, 55, -7, 1, -7, 7,
+ax_anim 2, 0, 55, -14, 5, -14, 13,
+ax_anim 2, 2, 55, -19, 11, -19, 16,
+ax_anim 2, 0, 55, -24, 20, -24, 20,
+ax_anim 2, 1, 55, -25, 19, -25, 19,
+ax_anim 2, 0, 55, -24, 20, -24, 20,
+ax_anim 2, 0, 55, -25, 19, -25, 19,
+ax_anim 2, 0, 52, -10, 8, -10, 8,
+ax_anim_terminator
+.align 2
+sWynautAnims_3_1:
+ax_anim 2, 0, 56, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, -1,
+ax_anim 4, 0, 56, 0, -2, 0, -2,
+ax_anim 2, 0, 59, 0, -4, 0, 2,
+ax_anim 2, 0, 59, 0, 0, 0, 5,
+ax_anim 2, 2, 59, 0, 8, 0, 11,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 1, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 59, 0, 20, 0, 20,
+ax_anim 2, 0, 59, 1, 20, 1, 20,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sWynautAnims_3_2:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, -1, -1, -1, -1,
+ax_anim 4, 0, 60, -2, -2, -2, -2,
+ax_anim 2, 0, 63, 7, 1, 7, 7,
+ax_anim 2, 0, 63, 14, 5, 14, 13,
+ax_anim 2, 2, 63, 19, 11, 19, 16,
+ax_anim 2, 0, 63, 24, 20, 24, 20,
+ax_anim 2, 1, 63, 25, 19, 25, 19,
+ax_anim 2, 0, 63, 24, 20, 24, 20,
+ax_anim 2, 0, 63, 25, 19, 25, 19,
+ax_anim 2, 0, 60, 10, 8, 10, 8,
+ax_anim_terminator
+sWynautAnims_3_3:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 64, -1, 0, -1, 0,
+ax_anim 4, 0, 64, -2, 0, -2, 0,
+ax_anim 2, 0, 67, 4, -3, 4, 0,
+ax_anim 2, 0, 67, 10, -5, 10, 0,
+ax_anim 2, 2, 67, 18, -5, 18, 0,
+ax_anim 2, 0, 67, 25, 0, 25, 0,
+ax_anim 2, 1, 67, 25, 1, 25, 1,
+ax_anim 2, 0, 67, 25, 0, 25, 0,
+ax_anim 2, 0, 67, 25, 1, 25, 1,
+ax_anim 2, 0, 64, 8, 0, 8, 0,
+ax_anim_terminator
+sWynautAnims_3_4:
+ax_anim 2, 0, 68, 0, 0, 0, 0,
+ax_anim 2, 0, 68, -1, 1, -1, 1,
+ax_anim 4, 0, 68, -2, 2, -2, 2,
+ax_anim 2, 0, 71, 3, -10, 3, -2,
+ax_anim 2, 0, 71, 8, -17, 8, -7,
+ax_anim 2, 2, 71, 14, -20, 14, -12,
+ax_anim 2, 0, 71, 22, -17, 22, -17,
+ax_anim 2, 1, 71, 23, -16, 23, -16,
+ax_anim 2, 0, 71, 22, -17, 22, -17,
+ax_anim 2, 0, 71, 23, -16, 23, -16,
+ax_anim 2, 0, 68, 6, -6, 6, -6,
+ax_anim_terminator
+sWynautAnims_3_5:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim 4, 0, 72, 0, 2, 0, 2,
+ax_anim 2, 0, 75, 0, -5, 0, -2,
+ax_anim 2, 0, 75, 0, -15, 0, -11,
+ax_anim 2, 2, 75, 0, -21, 0, -21,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 1, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 75, 0, -18, 0, -18,
+ax_anim 2, 0, 75, 1, -18, 1, -18,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim_terminator
+sWynautAnims_3_6:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 1, 1, 1, 1,
+ax_anim 4, 0, 76, 2, 2, 2, 2,
+ax_anim 2, 0, 79, -3, -10, -3, -2,
+ax_anim 2, 0, 79, -8, -17, -8, -7,
+ax_anim 2, 2, 79, -14, -20, -14, -12,
+ax_anim 2, 0, 79, -22, -17, -22, -17,
+ax_anim 2, 1, 79, -23, -16, -23, -16,
+ax_anim 2, 0, 79, -22, -17, -22, -17,
+ax_anim 2, 0, 79, -23, -16, -23, -16,
+ax_anim 2, 0, 76, -6, -6, -6, -6,
+ax_anim_terminator
+sWynautAnims_3_7:
+ax_anim 2, 0, 80, 0, 0, 0, 0,
+ax_anim 2, 0, 80, 1, 0, 1, 0,
+ax_anim 4, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 83, -4, -3, -4, 0,
+ax_anim 2, 0, 83, -10, -5, -10, 0,
+ax_anim 2, 2, 83, -18, -5, -18, 0,
+ax_anim 2, 0, 83, -25, 0, -25, 0,
+ax_anim 2, 1, 83, -25, 1, -25, 1,
+ax_anim 2, 0, 83, -25, 0, -25, 0,
+ax_anim 2, 0, 83, -25, 1, -25, 1,
+ax_anim 2, 0, 80, -8, 0, -8, 0,
+ax_anim_terminator
+sWynautAnims_3_8:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 84, 1, -1, 1, -1,
+ax_anim 4, 0, 84, 2, -2, 2, -2,
+ax_anim 2, 0, 87, -7, 1, -7, 7,
+ax_anim 2, 0, 87, -14, 5, -14, 13,
+ax_anim 2, 2, 87, -19, 11, -19, 16,
+ax_anim 2, 0, 87, -24, 20, -24, 20,
+ax_anim 2, 1, 87, -25, 19, -25, 19,
+ax_anim 2, 0, 87, -24, 20, -24, 20,
+ax_anim 2, 0, 87, -25, 19, -25, 19,
+ax_anim 2, 0, 84, -10, 8, -10, 8,
+ax_anim_terminator
+.align 2
+sWynautAnims_4_1:
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 1, 0, 89, 0, -5, 0, 0,
+ax_anim 6, 0, 89, 0, -6, 0, 0,
+ax_anim 2, 0, 89, 0, -5, 0, 0,
+ax_anim 1, 0, 89, 0, -3, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim 1, 0, 88, 0, -3, 0, 0,
+ax_anim 1, 2, 90, 0, -5, 0, 0,
+ax_anim 6, 0, 90, 0, -6, 0, 0,
+ax_anim 2, 0, 90, 0, -5, 0, 0,
+ax_anim 1, 1, 90, 0, -3, 0, 0,
+ax_anim 4, 0, 88, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_4_2:
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 1, 0, 92, 0, -5, 0, 0,
+ax_anim 6, 0, 92, 0, -6, 0, 0,
+ax_anim 2, 0, 92, 0, -5, 0, 0,
+ax_anim 1, 0, 92, 0, -3, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 1, 0, 91, 0, -3, 0, 0,
+ax_anim 1, 2, 93, 0, -5, 0, 0,
+ax_anim 6, 0, 93, 0, -6, 0, 0,
+ax_anim 2, 0, 93, 0, -5, 0, 0,
+ax_anim 1, 1, 93, 0, -3, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_4_3:
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 1, 0, 95, 0, -5, 0, 0,
+ax_anim 6, 0, 95, 0, -6, 0, 0,
+ax_anim 2, 0, 95, 0, -5, 0, 0,
+ax_anim 1, 0, 95, 0, -3, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 1, 0, 94, 0, -3, 0, 0,
+ax_anim 1, 2, 96, 0, -5, 0, 0,
+ax_anim 6, 0, 96, 0, -6, 0, 0,
+ax_anim 2, 0, 96, 0, -5, 0, 0,
+ax_anim 1, 1, 96, 0, -3, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_4_4:
+ax_anim 1, 0, 97, 0, -3, 0, 0,
+ax_anim 1, 0, 98, 0, -5, 0, 0,
+ax_anim 6, 0, 98, 0, -6, 0, 0,
+ax_anim 2, 0, 98, 0, -5, 0, 0,
+ax_anim 1, 0, 98, 0, -3, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 1, 0, 97, 0, -3, 0, 0,
+ax_anim 1, 2, 99, 0, -5, 0, 0,
+ax_anim 6, 0, 99, 0, -6, 0, 0,
+ax_anim 2, 0, 99, 0, -5, 0, 0,
+ax_anim 1, 1, 99, 0, -3, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_4_5:
+ax_anim 1, 0, 100, 0, -3, 0, 0,
+ax_anim 1, 0, 101, 0, -5, 0, 0,
+ax_anim 6, 0, 101, 0, -6, 0, 0,
+ax_anim 2, 0, 101, 0, -5, 0, 0,
+ax_anim 1, 0, 101, 0, -3, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 1, 0, 100, 0, -3, 0, 0,
+ax_anim 1, 2, 102, 0, -5, 0, 0,
+ax_anim 6, 0, 102, 0, -6, 0, 0,
+ax_anim 2, 0, 102, 0, -5, 0, 0,
+ax_anim 1, 1, 102, 0, -3, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_4_6:
+ax_anim 1, 0, 103, 0, -3, 0, 0,
+ax_anim 1, 0, 104, 0, -5, 0, 0,
+ax_anim 6, 0, 104, 0, -6, 0, 0,
+ax_anim 2, 0, 104, 0, -5, 0, 0,
+ax_anim 1, 0, 104, 0, -3, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 1, 0, 103, 0, -3, 0, 0,
+ax_anim 1, 2, 105, 0, -5, 0, 0,
+ax_anim 6, 0, 105, 0, -6, 0, 0,
+ax_anim 2, 0, 105, 0, -5, 0, 0,
+ax_anim 1, 1, 105, 0, -3, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_4_7:
+ax_anim 1, 0, 106, 0, -3, 0, 0,
+ax_anim 1, 0, 107, 0, -5, 0, 0,
+ax_anim 6, 0, 107, 0, -6, 0, 0,
+ax_anim 2, 0, 107, 0, -5, 0, 0,
+ax_anim 1, 0, 107, 0, -3, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 0, -3, 0, 0,
+ax_anim 1, 2, 108, 0, -5, 0, 0,
+ax_anim 6, 0, 108, 0, -6, 0, 0,
+ax_anim 2, 0, 108, 0, -5, 0, 0,
+ax_anim 1, 1, 108, 0, -3, 0, 0,
+ax_anim 4, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_4_8:
+ax_anim 1, 0, 109, 0, -3, 0, 0,
+ax_anim 1, 0, 110, 0, -5, 0, 0,
+ax_anim 6, 0, 110, 0, -6, 0, 0,
+ax_anim 2, 0, 110, 0, -5, 0, 0,
+ax_anim 1, 0, 110, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 109, 0, -3, 0, 0,
+ax_anim 1, 2, 111, 0, -5, 0, 0,
+ax_anim 6, 0, 111, 0, -6, 0, 0,
+ax_anim 2, 0, 111, 0, -5, 0, 0,
+ax_anim 1, 1, 111, 0, -3, 0, 0,
+ax_anim 4, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_5_1:
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 3, 0, 112, 0, -6, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 6, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_5_2:
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 3, 0, 114, 0, -6, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 6, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, 1, -1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, 1, -1, 1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, 1, -1, 1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_5_3:
+ax_anim 1, 0, 116, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 3, 0, 116, 0, -6, 0, 0,
+ax_anim 2, 0, 116, 0, -5, 0, 0,
+ax_anim 1, 0, 116, 0, -3, 0, 0,
+ax_anim 6, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_5_4:
+ax_anim 1, 0, 118, 0, -3, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 3, 0, 118, 0, -6, 0, 0,
+ax_anim 2, 0, 118, 0, -5, 0, 0,
+ax_anim 1, 0, 118, 0, -3, 0, 0,
+ax_anim 6, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 1, 1, 1, 1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_5_5:
+ax_anim 1, 0, 120, 0, -3, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 3, 0, 120, 0, -6, 0, 0,
+ax_anim 2, 0, 120, 0, -5, 0, 0,
+ax_anim 1, 0, 120, 0, -3, 0, 0,
+ax_anim 6, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 2, 121, 0, 1, 0, 0,
+ax_anim 2, 0, 121, 1, 1, 1, 0,
+ax_anim 2, 0, 121, 0, 1, 0, 0,
+ax_anim 2, 0, 121, 1, 1, 1, 0,
+ax_anim 2, 1, 121, 0, 1, 0, 0,
+ax_anim 2, 0, 121, 1, 1, 1, 0,
+ax_anim 2, 0, 121, 0, 1, 0, 0,
+ax_anim_terminator
+sWynautAnims_5_6:
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 3, 0, 122, 0, -6, 0, 0,
+ax_anim 2, 0, 122, 0, -5, 0, 0,
+ax_anim 1, 0, 122, 0, -3, 0, 0,
+ax_anim 6, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, -1, 1, -1, 1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_5_7:
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 3, 0, 124, 0, -6, 0, 0,
+ax_anim 2, 0, 124, 0, -5, 0, 0,
+ax_anim 1, 0, 124, 0, -3, 0, 0,
+ax_anim 6, 0, 124, 0, 0, 0, 0,
+ax_anim 2, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 1, 0, 1,
+ax_anim 2, 1, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_5_8:
+ax_anim 1, 0, 126, 0, -2, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 3, 0, 126, 0, -6, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -2, 0, 0,
+ax_anim 6, 0, 126, 0, 0, 0, 0,
+ax_anim 2, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 1, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, 1, 1, 1, 1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_6_1:
+ax_anim 30, 0, 128, 0, 0, 0, 0,
+ax_anim 35, 0, 129, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_7_1:
+ax_anim 2, 0, 130, 0, -2, 0, -2,
+ax_anim 8, 0, 130, 0, -3, 0, -3,
+ax_anim_terminator
+sWynautAnims_7_2:
+ax_anim 2, 0, 131, -2, -2, -2, -2,
+ax_anim 8, 0, 131, -3, -3, -3, -3,
+ax_anim_terminator
+sWynautAnims_7_3:
+ax_anim 2, 0, 132, -2, 0, -2, 0,
+ax_anim 8, 0, 132, -3, 0, -3, 0,
+ax_anim_terminator
+sWynautAnims_7_4:
+ax_anim 2, 0, 133, -2, 2, -2, 2,
+ax_anim 8, 0, 133, -3, 3, -3, 3,
+ax_anim_terminator
+sWynautAnims_7_5:
+ax_anim 2, 0, 134, 0, 2, 0, 2,
+ax_anim 8, 0, 134, 0, 3, 0, 3,
+ax_anim_terminator
+sWynautAnims_7_6:
+ax_anim 2, 0, 135, 2, 2, 2, 2,
+ax_anim 8, 0, 135, 3, 3, 3, 3,
+ax_anim_terminator
+sWynautAnims_7_7:
+ax_anim 2, 0, 136, 2, 0, 2, 0,
+ax_anim 8, 0, 136, 3, 0, 3, 0,
+ax_anim_terminator
+sWynautAnims_7_8:
+ax_anim 2, 0, 137, 2, -2, 2, -2,
+ax_anim 8, 0, 137, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sWynautAnims_8_1:
+ax_anim 40, 0, 138, 0, 0, 0, 0,
+ax_anim 4, 0, 139, 0, -3, 0, 0,
+ax_anim 4, 0, 139, 0, -4, 0, 0,
+ax_anim 4, 0, 138, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -4, 0, 0,
+ax_anim 4, 0, 140, 0, -3, 0, 0,
+ax_anim_terminator
+sWynautAnims_8_2:
+ax_anim 40, 0, 141, 0, 0, 0, 0,
+ax_anim 4, 0, 142, 0, -3, 0, 0,
+ax_anim 4, 0, 142, 0, -4, 0, 0,
+ax_anim 4, 0, 141, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -4, 0, 0,
+ax_anim 4, 0, 143, 0, -3, 0, 0,
+ax_anim_terminator
+sWynautAnims_8_3:
+ax_anim 40, 0, 144, 0, 0, 0, 0,
+ax_anim 4, 0, 145, 0, -3, 0, 0,
+ax_anim 4, 0, 145, 0, -4, 0, 0,
+ax_anim 4, 0, 144, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 146, 0, -3, 0, 0,
+ax_anim_terminator
+sWynautAnims_8_4:
+ax_anim 40, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 148, 0, -3, 0, 0,
+ax_anim 4, 0, 148, 0, -4, 0, 0,
+ax_anim 4, 0, 147, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 149, 0, -3, 0, 0,
+ax_anim_terminator
+sWynautAnims_8_5:
+ax_anim 40, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -3, 0, 0,
+ax_anim 4, 0, 151, 0, -4, 0, 0,
+ax_anim 4, 0, 150, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -4, 0, 0,
+ax_anim 4, 0, 152, 0, -3, 0, 0,
+ax_anim_terminator
+sWynautAnims_8_6:
+ax_anim 40, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 154, 0, -3, 0, 0,
+ax_anim 4, 0, 154, 0, -4, 0, 0,
+ax_anim 4, 0, 153, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, -4, 0, 0,
+ax_anim 4, 0, 155, 0, -3, 0, 0,
+ax_anim_terminator
+sWynautAnims_8_7:
+ax_anim 40, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, -3, 0, 0,
+ax_anim 4, 0, 157, 0, -4, 0, 0,
+ax_anim 4, 0, 156, 0, -4, 0, 0,
+ax_anim 4, 0, 158, 0, -4, 0, 0,
+ax_anim 4, 0, 158, 0, -3, 0, 0,
+ax_anim_terminator
+sWynautAnims_8_8:
+ax_anim 40, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 160, 0, -3, 0, 0,
+ax_anim 4, 0, 160, 0, -4, 0, 0,
+ax_anim 4, 0, 159, 0, -4, 0, 0,
+ax_anim 4, 0, 161, 0, -4, 0, 0,
+ax_anim 4, 0, 161, 0, -3, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 18, 7, 18,
+ax_anim 3, 0, 166, 0, 21, 0, 21,
+ax_anim 2, 3, 167, -7, 18, -7, 18,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 22, 9, 22, 9,
+ax_anim 3, 0, 165, 22, 20, 22, 20,
+ax_anim 2, 3, 166, 13, 20, 13, 20,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 12, -8, 12, -8,
+ax_anim 2, 0, 163, 18, -5, 18, -5,
+ax_anim 3, 0, 164, 22, -1, 22, -1,
+ax_anim 2, 3, 165, 20, 4, 20, 4,
+ax_anim 2, 0, 166, 13, 6, 13, 6,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, 0, -8, 0, -8,
+ax_anim 2, 0, 169, 4, -17, 4, -17,
+ax_anim 2, 0, 162, 12, -21, 12, -21,
+ax_anim 3, 0, 163, 21, -21, 21, -21,
+ax_anim 2, 3, 164, 23, -13, 23, -13,
+ax_anim 2, 0, 165, 15, -5, 15, -5,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -13, -9, -13,
+ax_anim 2, 0, 169, -8, -18, -8, -18,
+ax_anim 3, 0, 162, 0, -21, 0, -21,
+ax_anim 2, 3, 163, 8, -18, 8, -18,
+ax_anim 2, 0, 164, 10, -11, 10, -11,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 0, -8, 0, -8,
+ax_anim 2, 0, 163, -4, -17, -4, -17,
+ax_anim 2, 0, 162, -12, -21, -12, -21,
+ax_anim 3, 0, 169, -21, -21, -21, -21,
+ax_anim 2, 3, 168, -23, -13, -23, -13,
+ax_anim 2, 0, 167, -15, -5, -15, -5,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -12, -8, -12, -8,
+ax_anim 2, 0, 169, -18, -5, -18, -5,
+ax_anim 3, 0, 168, -22, -1, -22, -1,
+ax_anim 2, 3, 167, -20, 4, -20, 4,
+ax_anim 2, 0, 166, -13, 6, -13, 6,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -22, 9, -22, 9,
+ax_anim 3, 0, 167, -22, 20, -22, 20,
+ax_anim 2, 3, 166, -13, 20, -13, 20,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -22, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 184, 0, -22, 0, 0,
+ax_anim 3, 0, 186, 0, -21, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 3, 0, 189, 0, -22, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -22, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 198, 0, -21, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, -1,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sWynautAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sWynautGfx1:
+.incbin "baserom.gba", 0x14E2670, 0x200
+sWynautSprites1:
+ax_sprite sWynautGfx1, 0x200
+ax_sprite_terminator
+sWynautGfx2:
+.incbin "baserom.gba", 0x14E2880, 0x200
+sWynautSprites2:
+ax_sprite sWynautGfx2, 0x200
+ax_sprite_terminator
+sWynautGfx3:
+.incbin "baserom.gba", 0x14E2A90, 0x200
+sWynautSprites3:
+ax_sprite sWynautGfx3, 0x200
+ax_sprite_terminator
+sWynautGfx4:
+.incbin "baserom.gba", 0x14E2CA0, 0x200
+sWynautSprites4:
+ax_sprite sWynautGfx4, 0x200
+ax_sprite_terminator
+sWynautGfx5:
+.incbin "baserom.gba", 0x14E2EB0, 0x200
+sWynautSprites5:
+ax_sprite sWynautGfx5, 0x200
+ax_sprite_terminator
+sWynautGfx6:
+.incbin "baserom.gba", 0x14E30C0, 0x200
+sWynautSprites6:
+ax_sprite sWynautGfx6, 0x200
+ax_sprite_terminator
+sWynautGfx7:
+.incbin "baserom.gba", 0x14E32D0, 0x200
+sWynautSprites7:
+ax_sprite sWynautGfx7, 0x200
+ax_sprite_terminator
+sWynautGfx8:
+.incbin "baserom.gba", 0x14E34E0, 0x200
+sWynautSprites8:
+ax_sprite sWynautGfx8, 0x200
+ax_sprite_terminator
+sWynautGfx9:
+.incbin "baserom.gba", 0x14E36F0, 0x200
+sWynautSprites9:
+ax_sprite sWynautGfx9, 0x200
+ax_sprite_terminator
+sWynautGfx10:
+.incbin "baserom.gba", 0x14E3900, 0x100
+sWynautSprites10:
+ax_sprite sWynautGfx10, 0x100
+ax_sprite_terminator
+sWynautGfx11:
+.incbin "baserom.gba", 0x14E3A10, 0x200
+sWynautSprites11:
+ax_sprite sWynautGfx11, 0x200
+ax_sprite_terminator
+sWynautGfx12:
+.incbin "baserom.gba", 0x14E3C20, 0x200
+sWynautSprites12:
+ax_sprite sWynautGfx12, 0x200
+ax_sprite_terminator
+sWynautGfx13:
+.incbin "baserom.gba", 0x14E3E30, 0x200
+sWynautSprites13:
+ax_sprite sWynautGfx13, 0x200
+ax_sprite_terminator
+sWynautGfx14:
+.incbin "baserom.gba", 0x14E4040, 0x200
+sWynautSprites14:
+ax_sprite sWynautGfx14, 0x200
+ax_sprite_terminator
+sWynautGfx15:
+.incbin "baserom.gba", 0x14E4250, 0x200
+sWynautSprites15:
+ax_sprite sWynautGfx15, 0x200
+ax_sprite_terminator
+sWynautGfx16:
+.incbin "baserom.gba", 0x14E4460, 0x40
+sWynautGfx16_1:
+.incbin "baserom.gba", 0x14E44A0, 0x100
+sWynautGfx16_2:
+.incbin "baserom.gba", 0x14E45A0, 0x40
+sWynautSprites16:
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx16_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx16_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWynautGfx17:
+.incbin "baserom.gba", 0x14E4620, 0x60
+sWynautGfx17_1:
+.incbin "baserom.gba", 0x14E4680, 0x60
+sWynautGfx17_2:
+.incbin "baserom.gba", 0x14E46E0, 0x40
+sWynautSprites17:
+ax_sprite 0, 0x80
+ax_sprite sWynautGfx17, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx17_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWynautGfx18:
+.incbin "baserom.gba", 0x14E4760, 0x20
+sWynautGfx18_1:
+.incbin "baserom.gba", 0x14E4780, 0x60
+sWynautGfx18_2:
+.incbin "baserom.gba", 0x14E47E0, 0x60
+sWynautGfx18_3:
+.incbin "baserom.gba", 0x14E4840, 0x40
+sWynautSprites18:
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx18, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx18_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx18_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx18_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWynautGfx19:
+.incbin "baserom.gba", 0x14E48D0, 0x20
+sWynautGfx19_1:
+.incbin "baserom.gba", 0x14E48F0, 0x60
+sWynautGfx19_2:
+.incbin "baserom.gba", 0x14E4950, 0x60
+sWynautGfx19_3:
+.incbin "baserom.gba", 0x14E49B0, 0x40
+sWynautSprites19:
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx19, 0x20
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx19_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx19_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx19_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWynautGfx20:
+.incbin "baserom.gba", 0x14E4A40, 0x40
+sWynautGfx20_1:
+.incbin "baserom.gba", 0x14E4A80, 0x100
+sWynautGfx20_2:
+.incbin "baserom.gba", 0x14E4B80, 0x40
+sWynautSprites20:
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx20, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx20_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx20_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWynautGfx21:
+.incbin "baserom.gba", 0x14E4C00, 0x60
+sWynautGfx21_1:
+.incbin "baserom.gba", 0x14E4C60, 0x60
+sWynautGfx21_2:
+.incbin "baserom.gba", 0x14E4CC0, 0x60
+sWynautSprites21:
+ax_sprite sWynautGfx21, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx21_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWynautGfx22:
+.incbin "baserom.gba", 0x14E4D58, 0x60
+sWynautGfx22_1:
+.incbin "baserom.gba", 0x14E4DB8, 0x60
+sWynautGfx22_2:
+.incbin "baserom.gba", 0x14E4E18, 0x60
+sWynautSprites22:
+ax_sprite sWynautGfx22, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx22_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx22_2, 0x60
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sWynautGfx23:
+.incbin "baserom.gba", 0x14E4EB0, 0x60
+sWynautGfx23_1:
+.incbin "baserom.gba", 0x14E4F10, 0x60
+sWynautGfx23_2:
+.incbin "baserom.gba", 0x14E4F70, 0x60
+sWynautSprites23:
+ax_sprite sWynautGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWynautGfx24:
+.incbin "baserom.gba", 0x14E5008, 0x60
+sWynautGfx24_1:
+.incbin "baserom.gba", 0x14E5068, 0x60
+sWynautGfx24_2:
+.incbin "baserom.gba", 0x14E50C8, 0x40
+sWynautGfx24_3:
+.incbin "baserom.gba", 0x14E5108, 0x20
+sWynautSprites24:
+ax_sprite sWynautGfx24, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx24_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx24_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWynautGfx25:
+.incbin "baserom.gba", 0x14E5170, 0x60
+sWynautGfx25_1:
+.incbin "baserom.gba", 0x14E51D0, 0x60
+sWynautGfx25_2:
+.incbin "baserom.gba", 0x14E5230, 0x60
+sWynautSprites25:
+ax_sprite sWynautGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx25_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWynautGfx26:
+.incbin "baserom.gba", 0x14E52C8, 0x40
+sWynautGfx26_1:
+.incbin "baserom.gba", 0x14E5308, 0x60
+sWynautGfx26_2:
+.incbin "baserom.gba", 0x14E5368, 0x60
+sWynautGfx26_3:
+.incbin "baserom.gba", 0x14E53C8, 0x20
+sWynautSprites26:
+ax_sprite sWynautGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx26_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWynautGfx27:
+.incbin "baserom.gba", 0x14E5430, 0x60
+sWynautGfx27_1:
+.incbin "baserom.gba", 0x14E5490, 0x60
+sWynautGfx27_2:
+.incbin "baserom.gba", 0x14E54F0, 0x40
+sWynautSprites27:
+ax_sprite sWynautGfx27, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx27_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx27_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sWynautGfx28:
+.incbin "baserom.gba", 0x14E5568, 0x60
+sWynautGfx28_1:
+.incbin "baserom.gba", 0x14E55C8, 0x60
+sWynautGfx28_2:
+.incbin "baserom.gba", 0x14E5628, 0x60
+sWynautGfx28_3:
+.incbin "baserom.gba", 0x14E5688, 0x20
+sWynautSprites28:
+ax_sprite sWynautGfx28, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx28_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sWynautGfx29:
+.incbin "baserom.gba", 0x14E56F0, 0x60
+sWynautGfx29_1:
+.incbin "baserom.gba", 0x14E5750, 0x80
+sWynautGfx29_2:
+.incbin "baserom.gba", 0x14E57D0, 0x60
+sWynautGfx29_3:
+.incbin "baserom.gba", 0x14E5830, 0x40
+sWynautSprites29:
+ax_sprite sWynautGfx29, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx29_1, 0x80
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx29_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx29_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWynautGfx30:
+.incbin "baserom.gba", 0x14E58B8, 0x40
+sWynautGfx30_1:
+.incbin "baserom.gba", 0x14E58F8, 0x60
+sWynautGfx30_2:
+.incbin "baserom.gba", 0x14E5958, 0x60
+sWynautGfx30_3:
+.incbin "baserom.gba", 0x14E59B8, 0x40
+sWynautSprites30:
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx30, 0x40
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sWynautGfx30_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sWynautGfx30_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sWynautGfx31:
+.incbin "baserom.gba", 0x14E5A48, 0x200
+sWynautSprites31:
+ax_sprite sWynautGfx31, 0x200
+ax_sprite_terminator
+sWynautGfx32:
+.incbin "baserom.gba", 0x14E5C58, 0x200
+sWynautSprites32:
+ax_sprite sWynautGfx32, 0x200
+ax_sprite_terminator
+sWynautGfx33:
+.incbin "baserom.gba", 0x14E5E68, 0x200
+sWynautSprites33:
+ax_sprite sWynautGfx33, 0x200
+ax_sprite_terminator
+sWynautGfx34:
+.incbin "baserom.gba", 0x14E6078, 0x200
+sWynautSprites34:
+ax_sprite sWynautGfx34, 0x200
+ax_sprite_terminator
+sWynautGfx35:
+.incbin "baserom.gba", 0x14E6288, 0x200
+sWynautSprites35:
+ax_sprite sWynautGfx35, 0x200
+ax_sprite_terminator
+sWynautGfx36:
+.incbin "baserom.gba", 0x14E6498, 0x200
+sWynautSprites36:
+ax_sprite sWynautGfx36, 0x200
+ax_sprite_terminator
+sWynautGfx37:
+.incbin "baserom.gba", 0x14E66A8, 0x200
+sWynautSprites37:
+ax_sprite sWynautGfx37, 0x200
+ax_sprite_terminator
+sAxPosesWynaut:
+.4byte sWynautPose1
+.4byte sWynautPose2
+.4byte sWynautPose3
+.4byte sWynautPose4
+.4byte sWynautPose5
+.4byte sWynautPose6
+.4byte sWynautPose7
+.4byte sWynautPose8
+.4byte sWynautPose9
+.4byte sWynautPose10
+.4byte sWynautPose11
+.4byte sWynautPose12
+.4byte sWynautPose13
+.4byte sWynautPose14
+.4byte sWynautPose15
+.4byte sWynautPose16
+.4byte sWynautPose17
+.4byte sWynautPose18
+.4byte sWynautPose19
+.4byte sWynautPose20
+.4byte sWynautPose21
+.4byte sWynautPose22
+.4byte sWynautPose23
+.4byte sWynautPose24
+.4byte sWynautPose25
+.4byte sWynautPose26
+.4byte sWynautPose27
+.4byte sWynautPose28
+.4byte sWynautPose29
+.4byte sWynautPose30
+.4byte sWynautPose31
+.4byte sWynautPose32
+.4byte sWynautPose33
+.4byte sWynautPose34
+.4byte sWynautPose35
+.4byte sWynautPose36
+.4byte sWynautPose37
+.4byte sWynautPose38
+.4byte sWynautPose39
+.4byte sWynautPose40
+.4byte sWynautPose41
+.4byte sWynautPose42
+.4byte sWynautPose43
+.4byte sWynautPose44
+.4byte sWynautPose45
+.4byte sWynautPose46
+.4byte sWynautPose47
+.4byte sWynautPose48
+.4byte sWynautPose49
+.4byte sWynautPose50
+.4byte sWynautPose51
+.4byte sWynautPose52
+.4byte sWynautPose53
+.4byte sWynautPose54
+.4byte sWynautPose55
+.4byte sWynautPose56
+.4byte sWynautPose57
+.4byte sWynautPose58
+.4byte sWynautPose59
+.4byte sWynautPose60
+.4byte sWynautPose61
+.4byte sWynautPose62
+.4byte sWynautPose63
+.4byte sWynautPose64
+.4byte sWynautPose65
+.4byte sWynautPose66
+.4byte sWynautPose67
+.4byte sWynautPose68
+.4byte sWynautPose69
+.4byte sWynautPose70
+.4byte sWynautPose71
+.4byte sWynautPose72
+.4byte sWynautPose73
+.4byte sWynautPose74
+.4byte sWynautPose75
+.4byte sWynautPose76
+.4byte sWynautPose77
+.4byte sWynautPose78
+.4byte sWynautPose79
+.4byte sWynautPose80
+.4byte sWynautPose81
+.4byte sWynautPose82
+.4byte sWynautPose83
+.4byte sWynautPose84
+.4byte sWynautPose85
+.4byte sWynautPose86
+.4byte sWynautPose87
+.4byte sWynautPose88
+.4byte sWynautPose89
+.4byte sWynautPose90
+.4byte sWynautPose91
+.4byte sWynautPose92
+.4byte sWynautPose93
+.4byte sWynautPose94
+.4byte sWynautPose95
+.4byte sWynautPose96
+.4byte sWynautPose97
+.4byte sWynautPose98
+.4byte sWynautPose99
+.4byte sWynautPose100
+.4byte sWynautPose101
+.4byte sWynautPose102
+.4byte sWynautPose103
+.4byte sWynautPose104
+.4byte sWynautPose105
+.4byte sWynautPose106
+.4byte sWynautPose107
+.4byte sWynautPose108
+.4byte sWynautPose109
+.4byte sWynautPose110
+.4byte sWynautPose111
+.4byte sWynautPose112
+.4byte sWynautPose113
+.4byte sWynautPose114
+.4byte sWynautPose115
+.4byte sWynautPose116
+.4byte sWynautPose117
+.4byte sWynautPose118
+.4byte sWynautPose119
+.4byte sWynautPose120
+.4byte sWynautPose121
+.4byte sWynautPose122
+.4byte sWynautPose123
+.4byte sWynautPose124
+.4byte sWynautPose125
+.4byte sWynautPose126
+.4byte sWynautPose127
+.4byte sWynautPose128
+.4byte sWynautPose129
+.4byte sWynautPose130
+.4byte sWynautPose131
+.4byte sWynautPose132
+.4byte sWynautPose133
+.4byte sWynautPose134
+.4byte sWynautPose135
+.4byte sWynautPose136
+.4byte sWynautPose137
+.4byte sWynautPose138
+.4byte sWynautPose139
+.4byte sWynautPose140
+.4byte sWynautPose141
+.4byte sWynautPose142
+.4byte sWynautPose143
+.4byte sWynautPose144
+.4byte sWynautPose145
+.4byte sWynautPose146
+.4byte sWynautPose147
+.4byte sWynautPose148
+.4byte sWynautPose149
+.4byte sWynautPose150
+.4byte sWynautPose151
+.4byte sWynautPose152
+.4byte sWynautPose153
+.4byte sWynautPose154
+.4byte sWynautPose155
+.4byte sWynautPose156
+.4byte sWynautPose157
+.4byte sWynautPose158
+.4byte sWynautPose159
+.4byte sWynautPose160
+.4byte sWynautPose161
+.4byte sWynautPose162
+.4byte sWynautPose163
+.4byte sWynautPose164
+.4byte sWynautPose165
+.4byte sWynautPose166
+.4byte sWynautPose167
+.4byte sWynautPose168
+.4byte sWynautPose169
+.4byte sWynautPose170
+.4byte sWynautPose171
+.4byte sWynautPose172
+.4byte sWynautPose173
+.4byte sWynautPose174
+.4byte sWynautPose175
+.4byte sWynautPose176
+.4byte sWynautPose177
+.4byte sWynautPose178
+.4byte sWynautPose179
+.4byte sWynautPose180
+.4byte sWynautPose181
+.4byte sWynautPose182
+.4byte sWynautPose183
+.4byte sWynautPose184
+.4byte sWynautPose185
+.4byte sWynautPose186
+.4byte sWynautPose187
+.4byte sWynautPose188
+.4byte sWynautPose189
+.4byte sWynautPose190
+.4byte sWynautPose191
+.4byte sWynautPose192
+.4byte sWynautPose193
+.4byte sWynautPose194
+.4byte sWynautPose195
+.4byte sWynautPose196
+.4byte sWynautPose197
+.4byte sWynautPose198
+.4byte sWynautPose199
+.4byte sWynautPose200
+.4byte sWynautPose201
+.4byte sWynautPose202
+.4byte sWynautPose203
+.4byte sWynautPose204
+.4byte sWynautPose205
+.4byte sWynautPose206
+.4byte sWynautPose207
+.4byte sWynautPose208
+.4byte sWynautPose209
+.4byte sWynautPose210
+.4byte sWynautPose211
+.4byte sWynautPose212
+.4byte sWynautPose213
+.4byte sWynautPose214
+.4byte sWynautPose215
+.4byte sWynautPose216
+.4byte sWynautPose217
+.4byte sWynautPose218
+sAxPositionsWynaut:
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    1,   -7, 	  -3,   -4, 	   2,   -4, 	   0,   -5
+.2byte   -2,   -7, 	  -3,   -4, 	   1,   -5, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+.2byte    0,   -8, 	   2,   -6, 	  -3,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte    3,   -8, 	   0,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte    1,   -6, 	  -1,   -5, 	  -3,   -4, 	  -2,   -5
+.2byte    3,   -9, 	  -2,   -6, 	   0,   -5, 	  -2,   -7
+.2byte    0,  -10, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte    0,   -8, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,   -9, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte   -3,   -9, 	   2,   -4, 	  -3,   -4, 	  -1,   -5
+.2byte    1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -5
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -2,   -8, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -1,   -9, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -1,   -5, 	   1,   -4, 	   0,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -2,   -5, 	   0,   -7
+.2byte   -3,   -8, 	  -4,   -5, 	   0,   -5, 	  -2,   -5
+.2byte   -2,   -8, 	  -4,   -6, 	   1,   -5, 	  -1,   -6
+.2byte   -4,   -9, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    1,   -7, 	  -3,   -4, 	   2,   -4, 	   0,   -5
+.2byte   -2,   -7, 	  -3,   -4, 	   1,   -5, 	  -1,   -5
+.2byte   -1,  -11, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+.2byte    0,   -8, 	   2,   -6, 	  -3,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte    2,  -11, 	   2,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte    3,   -8, 	   0,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte    1,   -6, 	  -1,   -5, 	  -3,   -4, 	  -2,   -5
+.2byte    3,   -9, 	  -2,   -6, 	   0,   -5, 	  -2,   -7
+.2byte    2,  -10, 	  -2,   -6, 	  -3,   -6, 	  -2,   -7
+.2byte    0,  -10, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte    0,   -8, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,   -9, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,  -12, 	  -4,   -6, 	   1,   -6, 	  -2,   -7
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte   -3,   -9, 	   2,   -4, 	  -3,   -4, 	  -1,   -5
+.2byte    1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -5
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -8
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -2,   -8, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -1,   -9, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -1,  -12, 	   2,   -6, 	  -3,   -6, 	   0,   -7
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -1,   -5, 	   1,   -4, 	   0,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -2,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   0,   -6, 	   1,   -6, 	   0,   -7
+.2byte   -3,   -8, 	  -4,   -5, 	   0,   -5, 	  -2,   -5
+.2byte   -2,   -8, 	  -4,   -6, 	   1,   -5, 	  -1,   -6
+.2byte   -4,   -9, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -6, 	  -1,   -7
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    1,   -7, 	  -3,   -4, 	   2,   -4, 	   0,   -5
+.2byte   -2,   -7, 	  -3,   -4, 	   1,   -5, 	  -1,   -5
+.2byte   -1,  -11, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+.2byte    0,   -8, 	   2,   -6, 	  -3,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte    2,  -11, 	   2,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte    3,   -8, 	   0,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte    1,   -6, 	  -1,   -5, 	  -3,   -4, 	  -2,   -5
+.2byte    3,   -9, 	  -2,   -6, 	   0,   -5, 	  -2,   -7
+.2byte    2,  -10, 	  -2,   -6, 	  -3,   -6, 	  -2,   -7
+.2byte    0,  -10, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte    0,   -8, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,   -9, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,  -12, 	  -4,   -6, 	   1,   -6, 	  -2,   -7
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte   -3,   -9, 	   2,   -4, 	  -3,   -4, 	  -1,   -5
+.2byte    1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -5
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -8
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -2,   -8, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -1,   -9, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -1,  -12, 	   2,   -6, 	  -3,   -6, 	   0,   -7
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -1,   -5, 	   1,   -4, 	   0,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -2,   -5, 	   0,   -7
+.2byte   -4,  -10, 	   0,   -6, 	   1,   -6, 	   0,   -7
+.2byte   -3,   -8, 	  -4,   -5, 	   0,   -5, 	  -2,   -5
+.2byte   -2,   -8, 	  -4,   -6, 	   1,   -5, 	  -1,   -6
+.2byte   -4,   -9, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -6, 	  -1,   -7
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -2,  -10, 	  -4,   -5, 	   2,   -6, 	  -1,   -6
+.2byte    0,  -10, 	  -4,   -6, 	   2,   -5, 	  -1,   -6
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+.2byte    1,   -9, 	   1,   -5, 	  -4,   -6, 	  -1,   -6
+.2byte    1,   -8, 	   1,   -5, 	  -4,   -4, 	  -2,   -5
+.2byte    3,   -8, 	   0,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte    2,   -8, 	  -1,   -4, 	  -3,   -5, 	  -2,   -5
+.2byte    2,   -6, 	  -1,   -4, 	  -2,   -2, 	  -2,   -4
+.2byte    0,  -10, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte   -1,  -10, 	  -4,   -5, 	   1,   -6, 	  -2,   -6
+.2byte    1,   -9, 	  -3,   -6, 	   2,   -4, 	  -1,   -5
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte    1,  -13, 	   2,   -7, 	  -3,   -7, 	   0,   -8
+.2byte   -2,  -13, 	   2,   -7, 	  -2,   -6, 	   0,   -8
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -1,  -10, 	   2,   -5, 	  -3,   -6, 	   0,   -6
+.2byte   -3,   -9, 	   1,   -6, 	  -4,   -4, 	  -1,   -5
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -4,   -8, 	  -1,   -4, 	   1,   -5, 	   0,   -5
+.2byte   -4,   -6, 	  -1,   -4, 	   0,   -2, 	   0,   -4
+.2byte   -3,   -8, 	  -4,   -5, 	   0,   -5, 	  -2,   -5
+.2byte   -3,   -9, 	  -3,   -5, 	   2,   -6, 	  -1,   -6
+.2byte   -3,   -8, 	  -3,   -5, 	   2,   -4, 	   0,   -5
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -1,  -11, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+.2byte    2,  -11, 	   2,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte    3,   -8, 	   0,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte    3,  -10, 	  -1,   -6, 	  -2,   -6, 	  -1,   -7
+.2byte    0,  -10, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte   -1,  -12, 	  -4,   -6, 	   1,   -6, 	  -2,   -7
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte   -1,  -13, 	   2,   -7, 	  -4,   -7, 	  -1,   -9
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -1,  -12, 	   2,   -6, 	  -3,   -6, 	   0,   -7
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -4,  -10, 	   0,   -6, 	   1,   -6, 	   0,   -7
+.2byte   -3,   -8, 	  -4,   -5, 	   0,   -5, 	  -2,   -5
+.2byte   -4,  -11, 	  -4,   -6, 	   1,   -6, 	  -1,   -7
+.2byte   -2,   -4, 	  -2,   -2, 	   2,   -1, 	   0,   -3
+.2byte   -3,   -4, 	  -2,   -2, 	   2,   -1, 	   0,   -3
+.2byte    0,   -9, 	  -2,   -5, 	   3,   -5, 	   0,   -6
+.2byte   -3,   -9, 	   0,   -6, 	  -4,   -5, 	  -3,   -7
+.2byte   -2,   -9, 	  -3,   -4, 	  -3,   -3, 	  -3,   -5
+.2byte   -2,   -8, 	  -4,   -2, 	   0,   -3, 	  -3,   -4
+.2byte    0,   -8, 	   4,   -1, 	  -4,   -1, 	   0,   -2
+.2byte    1,   -8, 	   3,   -2, 	  -1,   -3, 	   2,   -4
+.2byte    1,   -9, 	   2,   -4, 	   2,   -3, 	   2,   -5
+.2byte    2,   -9, 	  -1,   -6, 	   3,   -5, 	   2,   -7
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    1,   -7, 	  -3,   -4, 	   2,   -4, 	   0,   -5
+.2byte   -2,   -7, 	  -3,   -4, 	   1,   -5, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+.2byte    0,   -8, 	   2,   -6, 	  -3,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte    3,   -8, 	   0,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte    1,   -6, 	  -1,   -5, 	  -3,   -4, 	  -2,   -5
+.2byte    3,   -9, 	  -2,   -6, 	   0,   -5, 	  -2,   -7
+.2byte    0,  -10, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte    0,   -8, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,   -9, 	  -4,   -4, 	  -1,   -4, 	  -3,   -5
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte   -3,   -9, 	   2,   -4, 	  -3,   -4, 	  -1,   -5
+.2byte    1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -5
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -2,   -8, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -1,   -9, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -1,   -5, 	   1,   -4, 	   0,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -2,   -5, 	   0,   -7
+.2byte   -3,   -8, 	  -4,   -5, 	   0,   -5, 	  -2,   -5
+.2byte   -2,   -8, 	  -4,   -6, 	   1,   -5, 	  -1,   -6
+.2byte   -4,   -9, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte   -1,  -11, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte   -3,  -11, 	  -3,   -6, 	   2,   -6, 	   0,   -7
+.2byte   -4,  -10, 	   0,   -6, 	   1,   -6, 	   0,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -3,   -6, 	   0,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -8
+.2byte   -1,  -12, 	  -4,   -6, 	   1,   -6, 	  -2,   -7
+.2byte    3,  -10, 	  -1,   -6, 	  -2,   -6, 	  -1,   -7
+.2byte    2,  -11, 	   2,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte   -1,  -11, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    2,  -11, 	   2,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte    3,  -10, 	  -1,   -6, 	  -2,   -6, 	  -1,   -7
+.2byte    0,  -12, 	  -3,   -6, 	   2,   -6, 	  -1,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -8
+.2byte   -1,  -12, 	   2,   -6, 	  -3,   -6, 	   0,   -7
+.2byte   -4,  -10, 	   0,   -6, 	   1,   -6, 	   0,   -7
+.2byte   -3,  -11, 	  -3,   -6, 	   2,   -6, 	   0,   -7
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte    1,   -7, 	  -3,   -4, 	   2,   -4, 	   0,   -5
+.2byte   -2,   -7, 	  -3,   -4, 	   1,   -5, 	  -1,   -5
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+.2byte    0,   -8, 	   2,   -6, 	  -3,   -5, 	  -1,   -6
+.2byte    2,   -9, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte    4,   -8, 	   1,   -5, 	  -1,   -4, 	   0,   -6
+.2byte    2,   -6, 	   0,   -5, 	  -2,   -4, 	  -1,   -5
+.2byte    3,   -9, 	  -2,   -6, 	   0,   -5, 	  -2,   -7
+.2byte    1,  -10, 	  -2,   -5, 	   1,   -5, 	  -1,   -6
+.2byte    1,   -8, 	  -3,   -4, 	   0,   -4, 	  -2,   -5
+.2byte    1,   -9, 	  -2,   -4, 	   1,   -4, 	  -1,   -5
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte   -3,   -9, 	   2,   -4, 	  -3,   -4, 	  -1,   -5
+.2byte    1,   -9, 	   2,   -4, 	  -4,   -4, 	  -1,   -5
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -2,   -8, 	   2,   -4, 	  -1,   -4, 	   1,   -5
+.2byte   -2,   -9, 	   1,   -4, 	  -2,   -4, 	   0,   -5
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -3,   -6, 	  -1,   -5, 	   1,   -4, 	   0,   -5
+.2byte   -5,   -9, 	   0,   -6, 	  -2,   -5, 	   0,   -7
+.2byte   -2,   -8, 	  -3,   -5, 	   1,   -5, 	  -1,   -5
+.2byte   -2,   -8, 	  -4,   -6, 	   1,   -5, 	  -1,   -6
+.2byte   -4,   -9, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte   -1,  -11, 	  -4,   -6, 	   2,   -6, 	  -1,   -7
+.2byte   -3,  -11, 	  -3,   -6, 	   2,   -6, 	   0,   -7
+.2byte   -4,  -10, 	   0,   -6, 	   1,   -6, 	   0,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -3,   -6, 	   0,   -7
+.2byte   -1,  -12, 	   2,   -6, 	  -4,   -6, 	  -1,   -8
+.2byte    0,  -12, 	  -3,   -6, 	   2,   -6, 	  -1,   -7
+.2byte    3,  -10, 	  -1,   -6, 	  -2,   -6, 	  -1,   -7
+.2byte    2,  -11, 	   2,   -6, 	  -3,   -6, 	  -1,   -7
+.2byte   -1,   -8, 	  -4,   -5, 	   2,   -5, 	  -1,   -6
+.2byte   -3,   -8, 	  -4,   -5, 	   0,   -5, 	  -2,   -5
+.2byte   -5,   -8, 	  -2,   -5, 	   0,   -4, 	  -1,   -6
+.2byte   -2,  -10, 	   1,   -5, 	  -2,   -5, 	   0,   -6
+.2byte   -1,  -11, 	   2,   -5, 	  -4,   -5, 	  -1,   -6
+.2byte    0,  -10, 	  -3,   -5, 	   0,   -5, 	  -2,   -6
+.2byte    3,   -8, 	   0,   -5, 	  -2,   -4, 	  -1,   -6
+.2byte    1,   -8, 	   2,   -5, 	  -2,   -5, 	   0,   -5
+sWynautAnimTable1:
+.4byte sWynautAnims_1_1
+.4byte sWynautAnims_1_2
+.4byte sWynautAnims_1_3
+.4byte sWynautAnims_1_4
+.4byte sWynautAnims_1_5
+.4byte sWynautAnims_1_6
+.4byte sWynautAnims_1_7
+.4byte sWynautAnims_1_8
+sWynautAnimTable2:
+.4byte sWynautAnims_2_1
+.4byte sWynautAnims_2_2
+.4byte sWynautAnims_2_3
+.4byte sWynautAnims_2_4
+.4byte sWynautAnims_2_5
+.4byte sWynautAnims_2_6
+.4byte sWynautAnims_2_7
+.4byte sWynautAnims_2_8
+sWynautAnimTable3:
+.4byte sWynautAnims_3_1
+.4byte sWynautAnims_3_2
+.4byte sWynautAnims_3_3
+.4byte sWynautAnims_3_4
+.4byte sWynautAnims_3_5
+.4byte sWynautAnims_3_6
+.4byte sWynautAnims_3_7
+.4byte sWynautAnims_3_8
+sWynautAnimTable4:
+.4byte sWynautAnims_4_1
+.4byte sWynautAnims_4_2
+.4byte sWynautAnims_4_3
+.4byte sWynautAnims_4_4
+.4byte sWynautAnims_4_5
+.4byte sWynautAnims_4_6
+.4byte sWynautAnims_4_7
+.4byte sWynautAnims_4_8
+sWynautAnimTable5:
+.4byte sWynautAnims_5_1
+.4byte sWynautAnims_5_2
+.4byte sWynautAnims_5_3
+.4byte sWynautAnims_5_4
+.4byte sWynautAnims_5_5
+.4byte sWynautAnims_5_6
+.4byte sWynautAnims_5_7
+.4byte sWynautAnims_5_8
+sWynautAnimTable6:
+.4byte sWynautAnims_6_1
+.4byte sWynautAnims_6_1
+.4byte sWynautAnims_6_1
+.4byte sWynautAnims_6_1
+.4byte sWynautAnims_6_1
+.4byte sWynautAnims_6_1
+.4byte sWynautAnims_6_1
+.4byte sWynautAnims_6_1
+sWynautAnimTable7:
+.4byte sWynautAnims_7_1
+.4byte sWynautAnims_7_2
+.4byte sWynautAnims_7_3
+.4byte sWynautAnims_7_4
+.4byte sWynautAnims_7_5
+.4byte sWynautAnims_7_6
+.4byte sWynautAnims_7_7
+.4byte sWynautAnims_7_8
+sWynautAnimTable8:
+.4byte sWynautAnims_8_1
+.4byte sWynautAnims_8_2
+.4byte sWynautAnims_8_3
+.4byte sWynautAnims_8_4
+.4byte sWynautAnims_8_5
+.4byte sWynautAnims_8_6
+.4byte sWynautAnims_8_7
+.4byte sWynautAnims_8_8
+sWynautAnimTable9:
+.4byte sWynautAnims_9_1
+.4byte sWynautAnims_9_2
+.4byte sWynautAnims_9_3
+.4byte sWynautAnims_9_4
+.4byte sWynautAnims_9_5
+.4byte sWynautAnims_9_6
+.4byte sWynautAnims_9_7
+.4byte sWynautAnims_9_8
+sWynautAnimTable10:
+.4byte sWynautAnims_10_1
+.4byte sWynautAnims_10_2
+.4byte sWynautAnims_10_3
+.4byte sWynautAnims_10_4
+.4byte sWynautAnims_10_5
+.4byte sWynautAnims_10_6
+.4byte sWynautAnims_10_7
+.4byte sWynautAnims_10_8
+sWynautAnimTable11:
+.4byte sWynautAnims_11_1
+.4byte sWynautAnims_11_2
+.4byte sWynautAnims_11_3
+.4byte sWynautAnims_11_4
+.4byte sWynautAnims_11_5
+.4byte sWynautAnims_11_6
+.4byte sWynautAnims_11_7
+.4byte sWynautAnims_11_8
+sWynautAnimTable12:
+.4byte sWynautAnims_12_1
+.4byte sWynautAnims_12_2
+.4byte sWynautAnims_12_3
+.4byte sWynautAnims_12_4
+.4byte sWynautAnims_12_5
+.4byte sWynautAnims_12_6
+.4byte sWynautAnims_12_7
+.4byte sWynautAnims_12_8
+sWynautAnimTable13:
+.4byte sWynautAnims_13_1
+.4byte sWynautAnims_13_2
+.4byte sWynautAnims_13_3
+.4byte sWynautAnims_13_4
+.4byte sWynautAnims_13_5
+.4byte sWynautAnims_13_6
+.4byte sWynautAnims_13_7
+.4byte sWynautAnims_13_8
+sAxAnimationsWynaut:
+.4byte sWynautAnimTable1
+.4byte sWynautAnimTable2
+.4byte sWynautAnimTable3
+.4byte sWynautAnimTable4
+.4byte sWynautAnimTable5
+.4byte sWynautAnimTable6
+.4byte sWynautAnimTable7
+.4byte sWynautAnimTable8
+.4byte sWynautAnimTable9
+.4byte sWynautAnimTable10
+.4byte sWynautAnimTable11
+.4byte sWynautAnimTable12
+.4byte sWynautAnimTable13
+sAxSpritesWynaut:
+.4byte sWynautSprites1
+.4byte sWynautSprites2
+.4byte sWynautSprites3
+.4byte sWynautSprites4
+.4byte sWynautSprites5
+.4byte sWynautSprites6
+.4byte sWynautSprites7
+.4byte sWynautSprites8
+.4byte sWynautSprites9
+.4byte sWynautSprites10
+.4byte sWynautSprites11
+.4byte sWynautSprites12
+.4byte sWynautSprites13
+.4byte sWynautSprites14
+.4byte sWynautSprites15
+.4byte sWynautSprites16
+.4byte sWynautSprites17
+.4byte sWynautSprites18
+.4byte sWynautSprites19
+.4byte sWynautSprites20
+.4byte sWynautSprites21
+.4byte sWynautSprites22
+.4byte sWynautSprites23
+.4byte sWynautSprites24
+.4byte sWynautSprites25
+.4byte sWynautSprites26
+.4byte sWynautSprites27
+.4byte sWynautSprites28
+.4byte sWynautSprites29
+.4byte sWynautSprites30
+.4byte sWynautSprites31
+.4byte sWynautSprites32
+.4byte sWynautSprites33
+.4byte sWynautSprites34
+.4byte sWynautSprites35
+.4byte sWynautSprites36
+.4byte sWynautSprites37
+sAxMainWynaut:
+ax_main sAxPosesWynaut, sAxAnimationsWynaut, 13, sAxSpritesWynaut, sAxPositionsWynaut

--- a/data/ax/xatu.inc
+++ b/data/ax/xatu.inc
@@ -1,0 +1,3121 @@
+.global gAxXatu
+gAxXatu:
+ax_siro sAxMainXatu
+sXatuPose1:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose2:
+ax_pose 1, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose3:
+ax_pose 2, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose4:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose5:
+ax_pose 4, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose6:
+ax_pose 5, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose7:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose8:
+ax_pose 7, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose9:
+ax_pose 8, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose10:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose11:
+ax_pose 10, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose12:
+ax_pose 11, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose13:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose14:
+ax_pose 13, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose15:
+ax_pose 14, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose16:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose17:
+ax_pose 10, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose18:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose19:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose20:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose21:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose22:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose23:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose24:
+ax_pose 5, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose25:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose26:
+ax_pose 15, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sXatuPose27:
+ax_pose 16, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose28:
+ax_pose 17, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose29:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose30:
+ax_pose 18, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose31:
+ax_pose 19, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose32:
+ax_pose 20, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose33:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose34:
+ax_pose 21, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose35:
+ax_pose 22, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose36:
+ax_pose 23, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose37:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose38:
+ax_pose 24, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose39:
+ax_pose 25, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose40:
+ax_pose 26, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose41:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose42:
+ax_pose 27, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sXatuPose43:
+ax_pose 28, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose44:
+ax_pose 29, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose45:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose46:
+ax_pose 24, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose47:
+ax_pose 25, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose48:
+ax_pose 26, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose49:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose50:
+ax_pose 21, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose51:
+ax_pose 22, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose52:
+ax_pose 23, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose53:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose54:
+ax_pose 18, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose55:
+ax_pose 19, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose56:
+ax_pose 20, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose57:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose58:
+ax_pose 15, 0x81ea, 0x80f8, 0x3c00
+ax_pose_terminator
+sXatuPose59:
+ax_pose 16, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose60:
+ax_pose 17, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose61:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose62:
+ax_pose 18, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose63:
+ax_pose 19, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose64:
+ax_pose 20, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose65:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose66:
+ax_pose 21, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose67:
+ax_pose 22, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose68:
+ax_pose 23, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose69:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose70:
+ax_pose 24, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose71:
+ax_pose 25, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose72:
+ax_pose 26, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose73:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose74:
+ax_pose 27, 0x81e7, 0x80f9, 0x3c00
+ax_pose_terminator
+sXatuPose75:
+ax_pose 28, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose76:
+ax_pose 29, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose77:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose78:
+ax_pose 24, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose79:
+ax_pose 25, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose80:
+ax_pose 26, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose81:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose82:
+ax_pose 21, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose83:
+ax_pose 22, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose84:
+ax_pose 23, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose85:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose86:
+ax_pose 18, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose87:
+ax_pose 19, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose88:
+ax_pose 20, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose89:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose90:
+ax_pose 17, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose91:
+ax_pose 30, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose92:
+ax_pose 3, 0x01e4, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose93:
+ax_pose 20, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sXatuPose94:
+ax_pose 31, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sXatuPose95:
+ax_pose 6, 0x01e4, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose96:
+ax_pose 23, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose97:
+ax_pose 32, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose98:
+ax_pose 9, 0x01e4, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose99:
+ax_pose 26, 0x01e4, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose100:
+ax_pose 33, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose101:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose102:
+ax_pose 29, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose103:
+ax_pose 34, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose104:
+ax_pose 9, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sXatuPose105:
+ax_pose 26, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose106:
+ax_pose 33, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose107:
+ax_pose 6, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sXatuPose108:
+ax_pose 23, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose109:
+ax_pose 32, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose110:
+ax_pose 3, 0x01e4, 0x80f5, 0x3c00
+ax_pose_terminator
+sXatuPose111:
+ax_pose 20, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose112:
+ax_pose 31, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose113:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose114:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose115:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose116:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose117:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose118:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose119:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose120:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose121:
+ax_pose 35, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose122:
+ax_pose 36, 0x01eb, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose123:
+ax_pose 37, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose124:
+ax_pose 38, 0x01df, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose125:
+ax_pose 39, 0x01e0, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose126:
+ax_pose 40, 0x01e4, 0x90ea, 0x3c00
+ax_pose_terminator
+sXatuPose127:
+ax_pose 41, 0x01e2, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose128:
+ax_pose 40, 0x01e4, 0x80f6, 0x3c00
+ax_pose_terminator
+sXatuPose129:
+ax_pose 39, 0x01e0, 0x80f5, 0x3c00
+ax_pose_terminator
+sXatuPose130:
+ax_pose 38, 0x01df, 0x80f5, 0x3c00
+ax_pose_terminator
+sXatuPose131:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose132:
+ax_pose 15, 0x81e9, 0x80f8, 0x3c00
+ax_pose_terminator
+sXatuPose133:
+ax_pose 16, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose134:
+ax_pose 17, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose135:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose136:
+ax_pose 18, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose137:
+ax_pose 19, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose138:
+ax_pose 20, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose139:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose140:
+ax_pose 21, 0x01e6, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose141:
+ax_pose 22, 0x01e2, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose142:
+ax_pose 23, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose143:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose144:
+ax_pose 24, 0x01e4, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose145:
+ax_pose 25, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose146:
+ax_pose 26, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose147:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose148:
+ax_pose 27, 0x81e5, 0x80f9, 0x3c00
+ax_pose_terminator
+sXatuPose149:
+ax_pose 28, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose150:
+ax_pose 29, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose151:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose152:
+ax_pose 24, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose153:
+ax_pose 25, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose154:
+ax_pose 26, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose155:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose156:
+ax_pose 21, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose157:
+ax_pose 22, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose158:
+ax_pose 23, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose159:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose160:
+ax_pose 18, 0x01e6, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose161:
+ax_pose 19, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose162:
+ax_pose 20, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose163:
+ax_pose 17, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose164:
+ax_pose 20, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose165:
+ax_pose 23, 0x01e5, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose166:
+ax_pose 26, 0x01e4, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose167:
+ax_pose 29, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose168:
+ax_pose 26, 0x01e4, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose169:
+ax_pose 23, 0x01e5, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose170:
+ax_pose 20, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sXatuPose171:
+ax_pose 30, 0x01e7, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose172:
+ax_pose 31, 0x01e4, 0x90ec, 0x3c00
+ax_pose_terminator
+sXatuPose173:
+ax_pose 32, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose174:
+ax_pose 33, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose175:
+ax_pose 34, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose176:
+ax_pose 33, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose177:
+ax_pose 32, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose178:
+ax_pose 31, 0x01e4, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose179:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose180:
+ax_pose 17, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose181:
+ax_pose 16, 0x01e8, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose182:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose183:
+ax_pose 20, 0x01e4, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose184:
+ax_pose 19, 0x01e3, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose185:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose186:
+ax_pose 23, 0x01e3, 0x90ee, 0x3c00
+ax_pose_terminator
+sXatuPose187:
+ax_pose 22, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sXatuPose188:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose189:
+ax_pose 26, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose190:
+ax_pose 25, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose191:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose192:
+ax_pose 29, 0x01e7, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose193:
+ax_pose 28, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose194:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose195:
+ax_pose 26, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose196:
+ax_pose 25, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose197:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose198:
+ax_pose 23, 0x01e3, 0x80f2, 0x3c00
+ax_pose_terminator
+sXatuPose199:
+ax_pose 22, 0x01e2, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose200:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose201:
+ax_pose 20, 0x01e4, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose202:
+ax_pose 19, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose203:
+ax_pose 16, 0x01e6, 0x80f0, 0x3c00
+ax_pose_terminator
+sXatuPose204:
+ax_pose 19, 0x01e3, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose205:
+ax_pose 22, 0x01e2, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose206:
+ax_pose 25, 0x01e3, 0x80f3, 0x3c00
+ax_pose_terminator
+sXatuPose207:
+ax_pose 28, 0x01e5, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose208:
+ax_pose 25, 0x01e3, 0x90ed, 0x3c00
+ax_pose_terminator
+sXatuPose209:
+ax_pose 22, 0x01e2, 0x90ec, 0x3c00
+ax_pose_terminator
+sXatuPose210:
+ax_pose 19, 0x01e3, 0x90ec, 0x3c00
+ax_pose_terminator
+sXatuPose211:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose212:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose213:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose214:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose215:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose216:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose217:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose218:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose219:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose220:
+ax_pose 42, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose221:
+ax_pose 43, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose222:
+ax_pose 44, 0x01e7, 0x80f1, 0x3c00
+ax_pose_terminator
+sXatuPose223:
+ax_pose 0, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose224:
+ax_pose 1, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose225:
+ax_pose 2, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose226:
+ax_pose 3, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose227:
+ax_pose 4, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose228:
+ax_pose 5, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose229:
+ax_pose 6, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose230:
+ax_pose 7, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose231:
+ax_pose 8, 0x01eb, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose232:
+ax_pose 9, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose233:
+ax_pose 10, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose234:
+ax_pose 11, 0x01e5, 0x90eb, 0x3c00
+ax_pose_terminator
+sXatuPose235:
+ax_pose 12, 0x01ea, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose236:
+ax_pose 13, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose237:
+ax_pose 14, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose238:
+ax_pose 9, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose239:
+ax_pose 10, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose240:
+ax_pose 11, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose241:
+ax_pose 6, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose242:
+ax_pose 7, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose243:
+ax_pose 8, 0x01eb, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose244:
+ax_pose 3, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose245:
+ax_pose 4, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+sXatuPose246:
+ax_pose 5, 0x01e5, 0x80f4, 0x3c00
+ax_pose_terminator
+.align 2
+sXatuAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 4, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 1, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 26, 0, 18, 0, 18,
+ax_anim 2, 0, 26, 1, 18, 1, 18,
+ax_anim 2, 0, 27, 0, 6, 0, 6,
+ax_anim 2, 0, 27, 0, 3, 0, 3,
+ax_anim_terminator
+sXatuAnims_2_2:
+ax_anim 2, 0, 29, -1, -1, -1, -1,
+ax_anim 4, 0, 29, -3, -3, -3, -3,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 30, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 9, 10, 9,
+ax_anim 2, 0, 30, 22, 18, 22, 18,
+ax_anim 2, 1, 30, 23, 17, 23, 17,
+ax_anim 2, 0, 30, 22, 18, 22, 18,
+ax_anim 2, 0, 30, 23, 17, 23, 17,
+ax_anim 2, 0, 31, 6, 6, 6, 6,
+ax_anim 2, 0, 31, 3, 3, 3, 3,
+ax_anim_terminator
+sXatuAnims_2_3:
+ax_anim 2, 0, 33, -1, 0, -1, 0,
+ax_anim 4, 0, 33, -3, 0, -3, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 4, 0, 4, 0,
+ax_anim 1, 0, 34, 10, 0, 10, 0,
+ax_anim 2, 0, 34, 20, 0, 20, 0,
+ax_anim 2, 1, 34, 20, -1, 20, -1,
+ax_anim 2, 0, 34, 20, 0, 20, 0,
+ax_anim 2, 0, 34, 20, -1, 20, -1,
+ax_anim 2, 0, 35, 6, 0, 6, 0,
+ax_anim 2, 0, 35, 3, 0, 3, 0,
+ax_anim_terminator
+sXatuAnims_2_4:
+ax_anim 2, 0, 37, -1, 1, -1, 1,
+ax_anim 4, 0, 37, -3, 3, -3, 3,
+ax_anim 1, 0, 38, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, -4, 4, -4,
+ax_anim 1, 0, 38, 10, -8, 8, -6,
+ax_anim 2, 0, 38, 21, -17, 19, -15,
+ax_anim 2, 1, 38, 22, -16, 20, -14,
+ax_anim 2, 0, 38, 21, -17, 19, -15,
+ax_anim 2, 0, 38, 22, -16, 20, -14,
+ax_anim 2, 0, 39, 6, -6, 6, -6,
+ax_anim 2, 0, 39, 3, -3, 6, -6,
+ax_anim_terminator
+sXatuAnims_2_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 4, 0, 41, 0, 3, 0, 3,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 42, 0, -4, 0, -2,
+ax_anim 1, 0, 42, 0, -8, 0, -6,
+ax_anim 2, 0, 42, 0, -17, 0, -15,
+ax_anim 2, 1, 42, 1, -17, 1, -15,
+ax_anim 2, 0, 42, 0, -17, 0, -15,
+ax_anim 2, 0, 42, 1, -17, 1, -15,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim 2, 0, 43, 0, -3, 0, -3,
+ax_anim_terminator
+sXatuAnims_2_6:
+ax_anim 2, 0, 45, 1, 1, 1, 1,
+ax_anim 4, 0, 45, 3, 3, 3, 3,
+ax_anim 1, 0, 46, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -4, -4, -4, -4,
+ax_anim 1, 0, 46, -10, -8, -8, -6,
+ax_anim 2, 0, 46, -21, -17, -19, -15,
+ax_anim 2, 1, 46, -22, -16, -20, -14,
+ax_anim 2, 0, 46, -21, -17, -19, -15,
+ax_anim 2, 0, 46, -22, -16, -20, -14,
+ax_anim 2, 0, 47, -6, -6, -6, -6,
+ax_anim 2, 0, 47, -3, -3, -6, -6,
+ax_anim_terminator
+sXatuAnims_2_7:
+ax_anim 2, 0, 49, 1, 0, 1, 0,
+ax_anim 4, 0, 49, 3, 0, 3, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 50, -4, 0, -4, 0,
+ax_anim 1, 0, 50, -10, 0, -10, 0,
+ax_anim 2, 0, 50, -20, 0, -20, 0,
+ax_anim 2, 1, 50, -20, -1, -20, -1,
+ax_anim 2, 0, 50, -20, 0, -20, 0,
+ax_anim 2, 0, 50, -20, -1, -20, -1,
+ax_anim 2, 0, 51, -6, 0, -6, 0,
+ax_anim 2, 0, 51, -3, 0, -3, 0,
+ax_anim_terminator
+sXatuAnims_2_8:
+ax_anim 2, 0, 53, 1, -1, 1, -1,
+ax_anim 4, 0, 53, 3, -3, 3, -3,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 54, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 9, -10, 9,
+ax_anim 2, 0, 54, -22, 18, -22, 18,
+ax_anim 2, 1, 54, -23, 17, -23, 17,
+ax_anim 2, 0, 54, -22, 18, -22, 18,
+ax_anim 2, 0, 54, -23, 17, -23, 17,
+ax_anim 2, 0, 55, -6, 6, -6, 6,
+ax_anim 2, 0, 55, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sXatuAnims_3_1:
+ax_anim 2, 0, 57, 0, -1, 0, -1,
+ax_anim 4, 0, 57, 0, -3, 0, -3,
+ax_anim 1, 0, 58, 0, 0, 0, 0,
+ax_anim 1, 2, 58, 0, 4, 0, 4,
+ax_anim 1, 0, 58, 0, 10, 0, 10,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 1, 58, 1, 18, 1, 18,
+ax_anim 2, 0, 58, 0, 18, 0, 18,
+ax_anim 2, 0, 58, 1, 18, 1, 18,
+ax_anim 2, 0, 59, 0, 6, 0, 6,
+ax_anim 2, 0, 59, 0, 3, 0, 3,
+ax_anim_terminator
+sXatuAnims_3_2:
+ax_anim 2, 0, 61, -1, -1, -1, -1,
+ax_anim 4, 0, 61, -3, -3, -3, -3,
+ax_anim 1, 0, 62, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 4, 4, 4, 4,
+ax_anim 1, 0, 62, 10, 9, 10, 9,
+ax_anim 2, 0, 62, 22, 18, 22, 18,
+ax_anim 2, 1, 62, 23, 17, 23, 17,
+ax_anim 2, 0, 62, 22, 18, 22, 18,
+ax_anim 2, 0, 62, 23, 17, 23, 17,
+ax_anim 2, 0, 63, 6, 6, 6, 6,
+ax_anim 2, 0, 63, 3, 3, 3, 3,
+ax_anim_terminator
+sXatuAnims_3_3:
+ax_anim 2, 0, 65, -1, 0, -1, 0,
+ax_anim 4, 0, 65, -3, 0, -3, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 66, 4, 0, 4, 0,
+ax_anim 1, 0, 66, 10, 0, 10, 0,
+ax_anim 2, 0, 66, 20, 0, 20, 0,
+ax_anim 2, 1, 66, 20, -1, 20, -1,
+ax_anim 2, 0, 66, 20, 0, 20, 0,
+ax_anim 2, 0, 66, 20, -1, 20, -1,
+ax_anim 2, 0, 67, 6, 0, 6, 0,
+ax_anim 2, 0, 67, 3, 0, 3, 0,
+ax_anim_terminator
+sXatuAnims_3_4:
+ax_anim 2, 0, 69, -1, 1, -1, 1,
+ax_anim 4, 0, 69, -3, 3, -3, 3,
+ax_anim 1, 0, 70, 0, 0, 0, 0,
+ax_anim 1, 2, 70, 4, -4, 4, -4,
+ax_anim 1, 0, 70, 10, -8, 8, -6,
+ax_anim 2, 0, 70, 21, -17, 19, -15,
+ax_anim 2, 1, 70, 22, -16, 20, -14,
+ax_anim 2, 0, 70, 21, -17, 19, -15,
+ax_anim 2, 0, 70, 22, -16, 20, -14,
+ax_anim 2, 0, 71, 6, -6, 6, -6,
+ax_anim 2, 0, 71, 3, -3, 6, -6,
+ax_anim_terminator
+sXatuAnims_3_5:
+ax_anim 2, 0, 73, 0, 1, 0, 1,
+ax_anim 4, 0, 73, 0, 3, 0, 3,
+ax_anim 1, 0, 74, 0, 0, 0, 0,
+ax_anim 1, 2, 74, 0, -4, 0, -2,
+ax_anim 1, 0, 74, 0, -8, 0, -6,
+ax_anim 2, 0, 74, 0, -17, 0, -15,
+ax_anim 2, 1, 74, 1, -17, 1, -15,
+ax_anim 2, 0, 74, 0, -17, 0, -15,
+ax_anim 2, 0, 74, 1, -17, 1, -15,
+ax_anim 2, 0, 72, 0, -6, 0, -6,
+ax_anim 2, 0, 75, 0, -3, 0, -3,
+ax_anim_terminator
+sXatuAnims_3_6:
+ax_anim 2, 0, 77, 1, 1, 1, 1,
+ax_anim 4, 0, 77, 3, 3, 3, 3,
+ax_anim 1, 0, 78, 0, 0, 0, 0,
+ax_anim 1, 2, 78, -4, -4, -4, -4,
+ax_anim 1, 0, 78, -10, -8, -8, -6,
+ax_anim 2, 0, 78, -21, -17, -19, -15,
+ax_anim 2, 1, 78, -22, -16, -20, -14,
+ax_anim 2, 0, 78, -21, -17, -19, -15,
+ax_anim 2, 0, 78, -22, -16, -20, -14,
+ax_anim 2, 0, 79, -6, -6, -6, -6,
+ax_anim 2, 0, 79, -3, -3, -6, -6,
+ax_anim_terminator
+sXatuAnims_3_7:
+ax_anim 2, 0, 81, 1, 0, 1, 0,
+ax_anim 4, 0, 81, 3, 0, 3, 0,
+ax_anim 1, 0, 82, 0, 0, 0, 0,
+ax_anim 1, 2, 82, -4, 0, -4, 0,
+ax_anim 1, 0, 82, -10, 0, -10, 0,
+ax_anim 2, 0, 82, -20, 0, -20, 0,
+ax_anim 2, 1, 82, -20, -1, -20, -1,
+ax_anim 2, 0, 82, -20, 0, -20, 0,
+ax_anim 2, 0, 82, -20, -1, -20, -1,
+ax_anim 2, 0, 83, -6, 0, -6, 0,
+ax_anim 2, 0, 83, -3, 0, -3, 0,
+ax_anim_terminator
+sXatuAnims_3_8:
+ax_anim 2, 0, 85, 1, -1, 1, -1,
+ax_anim 4, 0, 85, 3, -3, 3, -3,
+ax_anim 1, 0, 86, 0, 0, 0, 0,
+ax_anim 1, 2, 86, -4, 4, -4, 4,
+ax_anim 1, 0, 86, -10, 9, -10, 9,
+ax_anim 2, 0, 86, -22, 18, -22, 18,
+ax_anim 2, 1, 86, -23, 17, -23, 17,
+ax_anim 2, 0, 86, -22, 18, -22, 18,
+ax_anim 2, 0, 86, -23, 17, -23, 17,
+ax_anim 2, 0, 87, -6, 6, -6, 6,
+ax_anim 2, 0, 87, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sXatuAnims_4_1:
+ax_anim 2, 0, 88, 0, -1, 0, 0,
+ax_anim 3, 0, 89, 0, -2, 0, 0,
+ax_anim 6, 2, 89, 0, -3, 0, 0,
+ax_anim 1, 0, 90, 0, -3, 0, 0,
+ax_anim 1, 0, 90, 0, -2, 0, 0,
+ax_anim 2, 1, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 0, 89, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_4_2:
+ax_anim 2, 0, 91, 0, -1, 0, 0,
+ax_anim 3, 0, 92, 0, -2, 0, 0,
+ax_anim 6, 2, 92, 0, -3, 0, 0,
+ax_anim 1, 0, 93, 0, -3, 0, 0,
+ax_anim 1, 0, 93, 0, -2, 0, 0,
+ax_anim 2, 1, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 93, 1, 0, 1, 0,
+ax_anim 2, 0, 92, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_4_3:
+ax_anim 2, 0, 94, 0, -1, 0, 0,
+ax_anim 3, 0, 95, 0, -3, 0, 0,
+ax_anim 6, 2, 95, 0, -4, 0, 0,
+ax_anim 1, 0, 96, 0, -3, 0, 0,
+ax_anim 1, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 1, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 96, 1, 0, 1, 0,
+ax_anim 2, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_4_4:
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 3, 0, 98, 0, -3, 0, 0,
+ax_anim 6, 2, 98, 0, -4, 0, 0,
+ax_anim 1, 0, 99, 0, -3, 0, 0,
+ax_anim 1, 0, 99, 0, -2, 0, 0,
+ax_anim 2, 1, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 99, 1, 0, 1, 0,
+ax_anim 2, 0, 98, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_4_5:
+ax_anim 2, 0, 100, 0, -1, 0, 0,
+ax_anim 3, 0, 101, 0, -6, 0, 0,
+ax_anim 6, 2, 101, 0, -7, 0, 0,
+ax_anim 1, 0, 102, 0, -3, 0, 0,
+ax_anim 1, 0, 102, 0, -2, 0, 0,
+ax_anim 2, 1, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 102, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_4_6:
+ax_anim 2, 0, 103, 0, -1, 0, 0,
+ax_anim 3, 0, 104, 0, -3, 0, 0,
+ax_anim 6, 2, 104, 0, -4, 0, 0,
+ax_anim 1, 0, 105, 0, -3, 0, 0,
+ax_anim 1, 0, 105, 0, -2, 0, 0,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 104, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_4_7:
+ax_anim 2, 0, 106, 0, -1, 0, 0,
+ax_anim 3, 0, 107, 0, -3, 0, 0,
+ax_anim 6, 2, 107, 0, -4, 0, 0,
+ax_anim 1, 0, 108, 0, -3, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 1, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 1, 0, 1, 0,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_4_8:
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 3, 0, 110, 0, -2, 0, 0,
+ax_anim 6, 2, 110, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -3, 0, 0,
+ax_anim 1, 0, 111, 0, -2, 0, 0,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, 1, 0, 1, 0,
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_5_1:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_5_2:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 2, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_5_3:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_5_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 2, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_5_5:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_5_6:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 2, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_5_8:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 113, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_7_1:
+ax_anim 2, 0, 122, 0, -4, 0, -4,
+ax_anim 8, 0, 122, 0, -5, 0, -5,
+ax_anim_terminator
+sXatuAnims_7_2:
+ax_anim 2, 0, 123, -4, -4, -4, -4,
+ax_anim 8, 0, 123, -5, -5, -5, -5,
+ax_anim_terminator
+sXatuAnims_7_3:
+ax_anim 2, 0, 124, -4, 0, -4, 0,
+ax_anim 8, 0, 124, -5, 0, -5, 0,
+ax_anim_terminator
+sXatuAnims_7_4:
+ax_anim 2, 0, 125, -4, 4, -4, 4,
+ax_anim 8, 0, 125, -5, 5, -5, 5,
+ax_anim_terminator
+sXatuAnims_7_5:
+ax_anim 2, 0, 126, 0, 4, 0, 4,
+ax_anim 8, 0, 126, 0, 5, 0, 5,
+ax_anim_terminator
+sXatuAnims_7_6:
+ax_anim 2, 0, 127, 4, 4, 4, 4,
+ax_anim 8, 0, 127, 5, 5, 5, 5,
+ax_anim_terminator
+sXatuAnims_7_7:
+ax_anim 2, 0, 128, 4, 0, 4, 0,
+ax_anim 8, 0, 128, 5, 0, 5, 0,
+ax_anim_terminator
+sXatuAnims_7_8:
+ax_anim 2, 0, 129, 4, -4, 4, -4,
+ax_anim 8, 0, 129, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sXatuAnims_8_1:
+ax_anim 30, 0, 130, 0, 0, 0, 0,
+ax_anim 30, 0, 131, 0, -1, 0, -1,
+ax_anim_terminator
+sXatuAnims_8_2:
+ax_anim 30, 0, 134, 0, 0, 0, 0,
+ax_anim 30, 0, 135, -2, -2, -2, -2,
+ax_anim_terminator
+sXatuAnims_8_3:
+ax_anim 30, 0, 138, 0, 0, 0, 0,
+ax_anim 30, 0, 139, -2, 0, -2, 0,
+ax_anim_terminator
+sXatuAnims_8_4:
+ax_anim 30, 0, 142, 0, 0, 0, 0,
+ax_anim 30, 0, 143, -2, 1, -2, 1,
+ax_anim_terminator
+sXatuAnims_8_5:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 30, 0, 147, 0, 2, 0, 2,
+ax_anim_terminator
+sXatuAnims_8_6:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 30, 0, 151, 1, 1, 1, 1,
+ax_anim_terminator
+sXatuAnims_8_7:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 30, 0, 155, 2, 0, 2, 0,
+ax_anim_terminator
+sXatuAnims_8_8:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 30, 0, 159, 2, -2, 2, -2,
+ax_anim_terminator
+.align 2
+sXatuAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 4, 6, 4,
+ax_anim 2, 0, 164, 8, 9, 8, 9,
+ax_anim 2, 0, 165, 7, 17, 7, 17,
+ax_anim 3, 0, 166, 0, 21, 0, 21,
+ax_anim 2, 3, 167, -7, 17, -7, 17,
+ax_anim 2, 0, 168, -8, 9, -8, 9,
+ax_anim 1, 0, 169, -6, 4, -6, 4,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 24, 9, 24, 9,
+ax_anim 3, 0, 165, 23, 21, 23, 21,
+ax_anim 2, 3, 166, 11, 21, 11, 21,
+ax_anim 2, 0, 167, 2, 12, 2, 12,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -4, 3, -4,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 17, -4, 17, -4,
+ax_anim 3, 0, 164, 22, 1, 22, 1,
+ax_anim 2, 3, 165, 17, 5, 17, 5,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 5, 4, 5,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -6, -1, -6,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 11, -20, 11, -20,
+ax_anim 3, 0, 163, 19, -21, 19, -21,
+ax_anim 2, 3, 164, 18, -12, 18, -12,
+ax_anim 2, 0, 165, 16, -6, 16, -6,
+ax_anim 1, 0, 166, 7, -1, 7, -1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -6, -4, -6, -4,
+ax_anim 2, 0, 168, -8, -10, -8, -10,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -21, 0, -21,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 8, -8, 8, -8,
+ax_anim 1, 0, 165, 6, -4, 6, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -6, 1, -6,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -11, -20, -11, -20,
+ax_anim 3, 0, 169, -18, -21, -18, -21,
+ax_anim 2, 3, 168, -18, -12, -18, -12,
+ax_anim 2, 0, 167, -16, -6, -16, -6,
+ax_anim 1, 0, 166, -7, -1, -7, -1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -4, -3, -4,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -17, -4, -17, -4,
+ax_anim 3, 0, 168, -22, 1, -22, 1,
+ax_anim 2, 3, 167, -17, 5, -17, 5,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 5, -4, 5,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -24, 9, -24, 9,
+ax_anim 3, 0, 167, -23, 21, -23, 16,
+ax_anim 2, 3, 166, -11, 21, -11, 16,
+ax_anim 2, 0, 165, -2, 12, -4, 12,
+ax_anim 1, 0, 164, 0, 7, -3, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 179, 0, -10, 0, 0,
+ax_anim 2, 0, 179, 0, -16, 0, 0,
+ax_anim 3, 0, 179, 0, -20, 0, 0,
+ax_anim 4, 0, 179, 0, -21, 0, 0,
+ax_anim 4, 0, 180, 0, -23, 0, 0,
+ax_anim 3, 0, 180, 0, -22, 0, 0,
+ax_anim 2, 0, 180, 0, -18, 0, 0,
+ax_anim 1, 0, 180, 0, -12, 0, 0,
+ax_anim 2, 2, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_11_2:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -23, 0, 0,
+ax_anim 3, 0, 183, 0, -22, 0, 0,
+ax_anim 2, 0, 183, 0, -18, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_11_3:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 185, 0, -10, 0, 0,
+ax_anim 2, 0, 185, 0, -16, 0, 0,
+ax_anim 3, 0, 185, 0, -20, 0, 0,
+ax_anim 4, 0, 185, 0, -21, 0, 0,
+ax_anim 4, 0, 186, 0, -23, 0, 0,
+ax_anim 3, 0, 186, 0, -22, 0, 0,
+ax_anim 2, 0, 186, 0, -18, 0, 0,
+ax_anim 1, 0, 186, 0, -12, 0, 0,
+ax_anim 2, 2, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_11_4:
+ax_anim 2, 0, 187, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -22, 0, 0,
+ax_anim 3, 0, 189, 0, -21, 0, 0,
+ax_anim 2, 0, 189, 0, -17, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_11_5:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -21, 0, 0,
+ax_anim 4, 0, 192, 0, -23, 0, 0,
+ax_anim 3, 0, 192, 0, -22, 0, 0,
+ax_anim 2, 0, 192, 0, -18, 0, 0,
+ax_anim 1, 0, 192, 0, -12, 0, 0,
+ax_anim 2, 2, 190, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_11_6:
+ax_anim 2, 0, 193, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 195, 0, -22, 0, 0,
+ax_anim 3, 0, 195, 0, -21, 0, 0,
+ax_anim 2, 0, 195, 0, -17, 0, 0,
+ax_anim 1, 0, 195, 0, -11, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_11_7:
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 198, 0, -23, 0, 0,
+ax_anim 3, 0, 198, 0, -22, 0, 0,
+ax_anim 2, 0, 198, 0, -18, 0, 0,
+ax_anim 1, 0, 198, 0, -12, 0, 0,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_11_8:
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 201, 0, -23, 0, 0,
+ax_anim 3, 0, 201, 0, -22, 0, 0,
+ax_anim 2, 0, 201, 0, -18, 0, 0,
+ax_anim 1, 0, 201, 0, -12, 0, 0,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_12_1:
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 1, 0, 1, 0,
+ax_anim 2, 1, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_12_2:
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 1, -1, 1, 0,
+ax_anim 2, 1, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_12_3:
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, -1, 0, -1,
+ax_anim 2, 1, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_12_4:
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 207, -1, -1, -1, -1,
+ax_anim 2, 1, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_12_5:
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 1, 0, 1, 0,
+ax_anim 2, 1, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_12_6:
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 1, -1, 1, -1,
+ax_anim 2, 1, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_12_7:
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, -1, 0, -1,
+ax_anim 2, 1, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_12_8:
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 203, -1, -1, -1, -1,
+ax_anim 2, 1, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_13_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_13_2:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_13_3:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_13_4:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_13_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_13_6:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_13_7:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_13_8:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_14_1:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_14_2:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_14_3:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_14_4:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_14_5:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_14_6:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_14_7:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_14_8:
+ax_anim 20, 0, 218, 0, 0, 0, 0,
+ax_anim 8, 0, 219, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 1, 0, 220, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 1, 0, 1, 0,
+ax_anim 20, 0, 220, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_15_1:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_15_2:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_15_3:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_15_4:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_15_5:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_15_6:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_15_7:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_15_8:
+ax_anim 10, 0, 221, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sXatuAnims_16_1:
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 1, 0, 1, 0,
+ax_anim 2, 1, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_16_2:
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 1, -1, 1, 0,
+ax_anim 2, 1, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_16_3:
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 2, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 0, 228, 0, 0, 0, 0,
+ax_anim 2, 0, 228, 0, -1, 0, -1,
+ax_anim 2, 1, 228, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_16_4:
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 2, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 0, 231, 0, 0, 0, 0,
+ax_anim 2, 0, 231, -1, -1, -1, -1,
+ax_anim 2, 1, 231, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_16_5:
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 2, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 0, 234, 0, 0, 0, 0,
+ax_anim 2, 0, 234, 1, 0, 1, 0,
+ax_anim 2, 1, 234, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_16_6:
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 2, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 0, 237, 0, 0, 0, 0,
+ax_anim 2, 0, 237, 1, -1, 1, -1,
+ax_anim 2, 1, 237, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_16_7:
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 2, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 0, 240, 0, 0, 0, 0,
+ax_anim 2, 0, 240, 0, -1, 0, -1,
+ax_anim 2, 1, 240, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuAnims_16_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+sXatuGfx1:
+.incbin "baserom.gba", 0xCB7828, 0x200
+sXatuSprites1:
+ax_sprite sXatuGfx1, 0x200
+ax_sprite_terminator
+sXatuGfx2:
+.incbin "baserom.gba", 0xCB7A38, 0x200
+sXatuSprites2:
+ax_sprite sXatuGfx2, 0x200
+ax_sprite_terminator
+sXatuGfx3:
+.incbin "baserom.gba", 0xCB7C48, 0x200
+sXatuSprites3:
+ax_sprite sXatuGfx3, 0x200
+ax_sprite_terminator
+sXatuGfx4:
+.incbin "baserom.gba", 0xCB7E58, 0x200
+sXatuSprites4:
+ax_sprite sXatuGfx4, 0x200
+ax_sprite_terminator
+sXatuGfx5:
+.incbin "baserom.gba", 0xCB8068, 0x200
+sXatuSprites5:
+ax_sprite sXatuGfx5, 0x200
+ax_sprite_terminator
+sXatuGfx6:
+.incbin "baserom.gba", 0xCB8278, 0x200
+sXatuSprites6:
+ax_sprite sXatuGfx6, 0x200
+ax_sprite_terminator
+sXatuGfx7:
+.incbin "baserom.gba", 0xCB8488, 0x200
+sXatuSprites7:
+ax_sprite sXatuGfx7, 0x200
+ax_sprite_terminator
+sXatuGfx8:
+.incbin "baserom.gba", 0xCB8698, 0x200
+sXatuSprites8:
+ax_sprite sXatuGfx8, 0x200
+ax_sprite_terminator
+sXatuGfx9:
+.incbin "baserom.gba", 0xCB88A8, 0x200
+sXatuSprites9:
+ax_sprite sXatuGfx9, 0x200
+ax_sprite_terminator
+sXatuGfx10:
+.incbin "baserom.gba", 0xCB8AB8, 0x200
+sXatuSprites10:
+ax_sprite sXatuGfx10, 0x200
+ax_sprite_terminator
+sXatuGfx11:
+.incbin "baserom.gba", 0xCB8CC8, 0x200
+sXatuSprites11:
+ax_sprite sXatuGfx11, 0x200
+ax_sprite_terminator
+sXatuGfx12:
+.incbin "baserom.gba", 0xCB8ED8, 0x200
+sXatuSprites12:
+ax_sprite sXatuGfx12, 0x200
+ax_sprite_terminator
+sXatuGfx13:
+.incbin "baserom.gba", 0xCB90E8, 0x200
+sXatuSprites13:
+ax_sprite sXatuGfx13, 0x200
+ax_sprite_terminator
+sXatuGfx14:
+.incbin "baserom.gba", 0xCB92F8, 0x200
+sXatuSprites14:
+ax_sprite sXatuGfx14, 0x200
+ax_sprite_terminator
+sXatuGfx15:
+.incbin "baserom.gba", 0xCB9508, 0x200
+sXatuSprites15:
+ax_sprite sXatuGfx15, 0x200
+ax_sprite_terminator
+sXatuGfx16:
+.incbin "baserom.gba", 0xCB9718, 0x100
+sXatuSprites16:
+ax_sprite sXatuGfx16, 0x100
+ax_sprite_terminator
+sXatuGfx17:
+.incbin "baserom.gba", 0xCB9828, 0x40
+sXatuGfx17_1:
+.incbin "baserom.gba", 0xCB9868, 0x100
+sXatuGfx17_2:
+.incbin "baserom.gba", 0xCB9968, 0x40
+sXatuSprites17:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx17, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx17_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx17_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx18:
+.incbin "baserom.gba", 0xCB99E8, 0x40
+sXatuGfx18_1:
+.incbin "baserom.gba", 0xCB9A28, 0x100
+sXatuGfx18_2:
+.incbin "baserom.gba", 0xCB9B28, 0x40
+sXatuSprites18:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx18, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx18_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx18_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx19:
+.incbin "baserom.gba", 0xCB9BA8, 0x40
+sXatuGfx19_1:
+.incbin "baserom.gba", 0xCB9BE8, 0x160
+sXatuSprites19:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx19, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx19_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx20:
+.incbin "baserom.gba", 0xCB9D78, 0x60
+sXatuGfx20_1:
+.incbin "baserom.gba", 0xCB9DD8, 0x60
+sXatuGfx20_2:
+.incbin "baserom.gba", 0xCB9E38, 0x60
+sXatuGfx20_3:
+.incbin "baserom.gba", 0xCB9E98, 0x60
+sXatuSprites20:
+ax_sprite sXatuGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx20_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx20_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx20_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx21:
+.incbin "baserom.gba", 0xCB9F40, 0x40
+sXatuGfx21_1:
+.incbin "baserom.gba", 0xCB9F80, 0x60
+sXatuGfx21_2:
+.incbin "baserom.gba", 0xCB9FE0, 0x60
+sXatuGfx21_3:
+.incbin "baserom.gba", 0xCBA040, 0x60
+sXatuSprites21:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx21, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx21_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx21_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx21_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx22:
+.incbin "baserom.gba", 0xCBA0F0, 0x40
+sXatuGfx22_1:
+.incbin "baserom.gba", 0xCBA130, 0x100
+sXatuGfx22_2:
+.incbin "baserom.gba", 0xCBA230, 0x40
+sXatuSprites22:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx22_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx22_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx23:
+.incbin "baserom.gba", 0xCBA2B0, 0x60
+sXatuGfx23_1:
+.incbin "baserom.gba", 0xCBA310, 0x100
+sXatuGfx23_2:
+.incbin "baserom.gba", 0xCBA410, 0x40
+sXatuSprites23:
+ax_sprite sXatuGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx23_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx23_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx24:
+.incbin "baserom.gba", 0xCBA488, 0x40
+sXatuGfx24_1:
+.incbin "baserom.gba", 0xCBA4C8, 0x60
+sXatuGfx24_2:
+.incbin "baserom.gba", 0xCBA528, 0x80
+sXatuGfx24_3:
+.incbin "baserom.gba", 0xCBA5A8, 0x60
+sXatuSprites24:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx24_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx24_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx24_3, 0x60
+ax_sprite_terminator
+sXatuGfx25:
+.incbin "baserom.gba", 0xCBA650, 0x40
+sXatuGfx25_1:
+.incbin "baserom.gba", 0xCBA690, 0x60
+sXatuGfx25_2:
+.incbin "baserom.gba", 0xCBA6F0, 0xE0
+sXatuSprites25:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx25, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx25_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx26:
+.incbin "baserom.gba", 0xCBA810, 0x40
+sXatuGfx26_1:
+.incbin "baserom.gba", 0xCBA850, 0xE0
+sXatuGfx26_2:
+.incbin "baserom.gba", 0xCBA930, 0x40
+sXatuSprites26:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx26_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sXatuGfx26_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx27:
+.incbin "baserom.gba", 0xCBA9B0, 0x40
+sXatuGfx27_1:
+.incbin "baserom.gba", 0xCBA9F0, 0x60
+sXatuGfx27_2:
+.incbin "baserom.gba", 0xCBAA50, 0x100
+sXatuSprites27:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx27, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx27_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx27_2, 0x100
+ax_sprite_terminator
+sXatuGfx28:
+.incbin "baserom.gba", 0xCBAB88, 0x20
+sXatuGfx28_1:
+.incbin "baserom.gba", 0xCBABA8, 0xC0
+sXatuSprites28:
+ax_sprite sXatuGfx28, 0x20
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx28_1, 0xc0
+ax_sprite_terminator
+sXatuGfx29:
+.incbin "baserom.gba", 0xCBAC88, 0x160
+sXatuGfx29_1:
+.incbin "baserom.gba", 0xCBADE8, 0x40
+sXatuSprites29:
+ax_sprite sXatuGfx29, 0x160
+ax_sprite 0, 0x40
+ax_sprite sXatuGfx29_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx30:
+.incbin "baserom.gba", 0xCBAE50, 0x20
+sXatuGfx30_1:
+.incbin "baserom.gba", 0xCBAE70, 0x60
+sXatuGfx30_2:
+.incbin "baserom.gba", 0xCBAED0, 0xE0
+sXatuSprites30:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx30, 0x20
+ax_sprite 0, 0x40
+ax_sprite sXatuGfx30_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx30_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx31:
+.incbin "baserom.gba", 0xCBAFF0, 0x100
+sXatuGfx31_1:
+.incbin "baserom.gba", 0xCBB0F0, 0x40
+sXatuGfx31_2:
+.incbin "baserom.gba", 0xCBB130, 0x40
+sXatuSprites31:
+ax_sprite sXatuGfx31, 0x100
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx31_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sXatuGfx31_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx32:
+.incbin "baserom.gba", 0xCBB1A8, 0x40
+sXatuGfx32_1:
+.incbin "baserom.gba", 0xCBB1E8, 0xE0
+sXatuGfx32_2:
+.incbin "baserom.gba", 0xCBB2C8, 0x60
+sXatuSprites32:
+ax_sprite sXatuGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sXatuGfx32_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx32_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx33:
+.incbin "baserom.gba", 0xCBB360, 0x20
+sXatuGfx33_1:
+.incbin "baserom.gba", 0xCBB380, 0x160
+sXatuSprites33:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx33, 0x20
+ax_sprite 0, 0x40
+ax_sprite sXatuGfx33_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx34:
+.incbin "baserom.gba", 0xCBB510, 0x40
+sXatuGfx34_1:
+.incbin "baserom.gba", 0xCBB550, 0x60
+sXatuGfx34_2:
+.incbin "baserom.gba", 0xCBB5B0, 0x60
+sXatuGfx34_3:
+.incbin "baserom.gba", 0xCBB610, 0x60
+sXatuSprites34:
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx34, 0x40
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx34_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx34_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sXatuGfx34_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx35:
+.incbin "baserom.gba", 0xCBB6C0, 0x160
+sXatuGfx35_1:
+.incbin "baserom.gba", 0xCBB820, 0x40
+sXatuSprites35:
+ax_sprite sXatuGfx35, 0x160
+ax_sprite 0, 0x40
+ax_sprite sXatuGfx35_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sXatuGfx36:
+.incbin "baserom.gba", 0xCBB888, 0x200
+sXatuSprites36:
+ax_sprite sXatuGfx36, 0x200
+ax_sprite_terminator
+sXatuGfx37:
+.incbin "baserom.gba", 0xCBBA98, 0x200
+sXatuSprites37:
+ax_sprite sXatuGfx37, 0x200
+ax_sprite_terminator
+sXatuGfx38:
+.incbin "baserom.gba", 0xCBBCA8, 0x200
+sXatuSprites38:
+ax_sprite sXatuGfx38, 0x200
+ax_sprite_terminator
+sXatuGfx39:
+.incbin "baserom.gba", 0xCBBEB8, 0x200
+sXatuSprites39:
+ax_sprite sXatuGfx39, 0x200
+ax_sprite_terminator
+sXatuGfx40:
+.incbin "baserom.gba", 0xCBC0C8, 0x200
+sXatuSprites40:
+ax_sprite sXatuGfx40, 0x200
+ax_sprite_terminator
+sXatuGfx41:
+.incbin "baserom.gba", 0xCBC2D8, 0x200
+sXatuSprites41:
+ax_sprite sXatuGfx41, 0x200
+ax_sprite_terminator
+sXatuGfx42:
+.incbin "baserom.gba", 0xCBC4E8, 0x200
+sXatuSprites42:
+ax_sprite sXatuGfx42, 0x200
+ax_sprite_terminator
+sXatuGfx43:
+.incbin "baserom.gba", 0xCBC6F8, 0x200
+sXatuSprites43:
+ax_sprite sXatuGfx43, 0x200
+ax_sprite_terminator
+sXatuGfx44:
+.incbin "baserom.gba", 0xCBC908, 0x200
+sXatuSprites44:
+ax_sprite sXatuGfx44, 0x200
+ax_sprite_terminator
+sXatuGfx45:
+.incbin "baserom.gba", 0xCBCB18, 0x200
+sXatuSprites45:
+ax_sprite sXatuGfx45, 0x200
+ax_sprite_terminator
+sAxPosesXatu:
+.4byte sXatuPose1
+.4byte sXatuPose2
+.4byte sXatuPose3
+.4byte sXatuPose4
+.4byte sXatuPose5
+.4byte sXatuPose6
+.4byte sXatuPose7
+.4byte sXatuPose8
+.4byte sXatuPose9
+.4byte sXatuPose10
+.4byte sXatuPose11
+.4byte sXatuPose12
+.4byte sXatuPose13
+.4byte sXatuPose14
+.4byte sXatuPose15
+.4byte sXatuPose16
+.4byte sXatuPose17
+.4byte sXatuPose18
+.4byte sXatuPose19
+.4byte sXatuPose20
+.4byte sXatuPose21
+.4byte sXatuPose22
+.4byte sXatuPose23
+.4byte sXatuPose24
+.4byte sXatuPose25
+.4byte sXatuPose26
+.4byte sXatuPose27
+.4byte sXatuPose28
+.4byte sXatuPose29
+.4byte sXatuPose30
+.4byte sXatuPose31
+.4byte sXatuPose32
+.4byte sXatuPose33
+.4byte sXatuPose34
+.4byte sXatuPose35
+.4byte sXatuPose36
+.4byte sXatuPose37
+.4byte sXatuPose38
+.4byte sXatuPose39
+.4byte sXatuPose40
+.4byte sXatuPose41
+.4byte sXatuPose42
+.4byte sXatuPose43
+.4byte sXatuPose44
+.4byte sXatuPose45
+.4byte sXatuPose46
+.4byte sXatuPose47
+.4byte sXatuPose48
+.4byte sXatuPose49
+.4byte sXatuPose50
+.4byte sXatuPose51
+.4byte sXatuPose52
+.4byte sXatuPose53
+.4byte sXatuPose54
+.4byte sXatuPose55
+.4byte sXatuPose56
+.4byte sXatuPose57
+.4byte sXatuPose58
+.4byte sXatuPose59
+.4byte sXatuPose60
+.4byte sXatuPose61
+.4byte sXatuPose62
+.4byte sXatuPose63
+.4byte sXatuPose64
+.4byte sXatuPose65
+.4byte sXatuPose66
+.4byte sXatuPose67
+.4byte sXatuPose68
+.4byte sXatuPose69
+.4byte sXatuPose70
+.4byte sXatuPose71
+.4byte sXatuPose72
+.4byte sXatuPose73
+.4byte sXatuPose74
+.4byte sXatuPose75
+.4byte sXatuPose76
+.4byte sXatuPose77
+.4byte sXatuPose78
+.4byte sXatuPose79
+.4byte sXatuPose80
+.4byte sXatuPose81
+.4byte sXatuPose82
+.4byte sXatuPose83
+.4byte sXatuPose84
+.4byte sXatuPose85
+.4byte sXatuPose86
+.4byte sXatuPose87
+.4byte sXatuPose88
+.4byte sXatuPose89
+.4byte sXatuPose90
+.4byte sXatuPose91
+.4byte sXatuPose92
+.4byte sXatuPose93
+.4byte sXatuPose94
+.4byte sXatuPose95
+.4byte sXatuPose96
+.4byte sXatuPose97
+.4byte sXatuPose98
+.4byte sXatuPose99
+.4byte sXatuPose100
+.4byte sXatuPose101
+.4byte sXatuPose102
+.4byte sXatuPose103
+.4byte sXatuPose104
+.4byte sXatuPose105
+.4byte sXatuPose106
+.4byte sXatuPose107
+.4byte sXatuPose108
+.4byte sXatuPose109
+.4byte sXatuPose110
+.4byte sXatuPose111
+.4byte sXatuPose112
+.4byte sXatuPose113
+.4byte sXatuPose114
+.4byte sXatuPose115
+.4byte sXatuPose116
+.4byte sXatuPose117
+.4byte sXatuPose118
+.4byte sXatuPose119
+.4byte sXatuPose120
+.4byte sXatuPose121
+.4byte sXatuPose122
+.4byte sXatuPose123
+.4byte sXatuPose124
+.4byte sXatuPose125
+.4byte sXatuPose126
+.4byte sXatuPose127
+.4byte sXatuPose128
+.4byte sXatuPose129
+.4byte sXatuPose130
+.4byte sXatuPose131
+.4byte sXatuPose132
+.4byte sXatuPose133
+.4byte sXatuPose134
+.4byte sXatuPose135
+.4byte sXatuPose136
+.4byte sXatuPose137
+.4byte sXatuPose138
+.4byte sXatuPose139
+.4byte sXatuPose140
+.4byte sXatuPose141
+.4byte sXatuPose142
+.4byte sXatuPose143
+.4byte sXatuPose144
+.4byte sXatuPose145
+.4byte sXatuPose146
+.4byte sXatuPose147
+.4byte sXatuPose148
+.4byte sXatuPose149
+.4byte sXatuPose150
+.4byte sXatuPose151
+.4byte sXatuPose152
+.4byte sXatuPose153
+.4byte sXatuPose154
+.4byte sXatuPose155
+.4byte sXatuPose156
+.4byte sXatuPose157
+.4byte sXatuPose158
+.4byte sXatuPose159
+.4byte sXatuPose160
+.4byte sXatuPose161
+.4byte sXatuPose162
+.4byte sXatuPose163
+.4byte sXatuPose164
+.4byte sXatuPose165
+.4byte sXatuPose166
+.4byte sXatuPose167
+.4byte sXatuPose168
+.4byte sXatuPose169
+.4byte sXatuPose170
+.4byte sXatuPose171
+.4byte sXatuPose172
+.4byte sXatuPose173
+.4byte sXatuPose174
+.4byte sXatuPose175
+.4byte sXatuPose176
+.4byte sXatuPose177
+.4byte sXatuPose178
+.4byte sXatuPose179
+.4byte sXatuPose180
+.4byte sXatuPose181
+.4byte sXatuPose182
+.4byte sXatuPose183
+.4byte sXatuPose184
+.4byte sXatuPose185
+.4byte sXatuPose186
+.4byte sXatuPose187
+.4byte sXatuPose188
+.4byte sXatuPose189
+.4byte sXatuPose190
+.4byte sXatuPose191
+.4byte sXatuPose192
+.4byte sXatuPose193
+.4byte sXatuPose194
+.4byte sXatuPose195
+.4byte sXatuPose196
+.4byte sXatuPose197
+.4byte sXatuPose198
+.4byte sXatuPose199
+.4byte sXatuPose200
+.4byte sXatuPose201
+.4byte sXatuPose202
+.4byte sXatuPose203
+.4byte sXatuPose204
+.4byte sXatuPose205
+.4byte sXatuPose206
+.4byte sXatuPose207
+.4byte sXatuPose208
+.4byte sXatuPose209
+.4byte sXatuPose210
+.4byte sXatuPose211
+.4byte sXatuPose212
+.4byte sXatuPose213
+.4byte sXatuPose214
+.4byte sXatuPose215
+.4byte sXatuPose216
+.4byte sXatuPose217
+.4byte sXatuPose218
+.4byte sXatuPose219
+.4byte sXatuPose220
+.4byte sXatuPose221
+.4byte sXatuPose222
+.4byte sXatuPose223
+.4byte sXatuPose224
+.4byte sXatuPose225
+.4byte sXatuPose226
+.4byte sXatuPose227
+.4byte sXatuPose228
+.4byte sXatuPose229
+.4byte sXatuPose230
+.4byte sXatuPose231
+.4byte sXatuPose232
+.4byte sXatuPose233
+.4byte sXatuPose234
+.4byte sXatuPose235
+.4byte sXatuPose236
+.4byte sXatuPose237
+.4byte sXatuPose238
+.4byte sXatuPose239
+.4byte sXatuPose240
+.4byte sXatuPose241
+.4byte sXatuPose242
+.4byte sXatuPose243
+.4byte sXatuPose244
+.4byte sXatuPose245
+.4byte sXatuPose246
+sAxPositionsXatu:
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte    1,   -9, 	  -3,   -1, 	   3,   -2, 	  -1,   -6
+.2byte   -3,   -9, 	  -5,   -2, 	   1,   -1, 	  -1,   -6
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte    4,  -10, 	   4,   -3, 	  -2,   -1, 	  -1,   -6
+.2byte    7,  -11, 	   3,   -4, 	  -2,   -2, 	  -1,   -6
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    7,  -13, 	   1,   -2, 	  -2,   -1, 	  -1,   -7
+.2byte    6,  -14, 	   3,   -3, 	   3,   -2, 	  -2,   -8
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    6,  -15, 	  -1,   -5, 	   3,   -2, 	  -2,   -8
+.2byte    5,  -16, 	  -3,   -5, 	   4,   -3, 	  -2,   -8
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -3,  -18, 	   1,   -4, 	  -4,   -3, 	  -1,   -7
+.2byte    1,  -18, 	   2,   -3, 	  -3,   -4, 	  -1,   -7
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -8,  -15, 	  -1,   -5, 	  -5,   -2, 	   0,   -8
+.2byte   -7,  -16, 	   1,   -5, 	  -6,   -3, 	   0,   -8
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -9,  -13, 	  -3,   -2, 	   0,   -1, 	  -1,   -7
+.2byte   -8,  -14, 	  -5,   -3, 	  -5,   -2, 	   0,   -8
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -6,  -10, 	  -6,   -3, 	   0,   -1, 	  -1,   -6
+.2byte   -9,  -11, 	  -5,   -4, 	   0,   -2, 	  -1,   -6
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte   -1,  -10, 	  -3,   -4, 	   1,   -4, 	  -1,   -8
+.2byte   -1,   -3, 	 -12,  -11, 	  10,  -11, 	  -1,   -7
+.2byte   -1,  -15, 	 -10,  -11, 	   8,  -11, 	  -1,   -9
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte    3,  -13, 	   2,   -6, 	  -2,   -5, 	  -2,   -9
+.2byte    7,   -9, 	   8,  -19, 	 -11,  -14, 	  -1,   -8
+.2byte    5,  -18, 	   7,  -12, 	  -1,   -9, 	   0,  -11
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    2,  -14, 	   1,   -8, 	  -1,   -5, 	  -4,   -8
+.2byte    9,  -13, 	   2,  -23, 	  -2,  -13, 	  -2,  -11
+.2byte    5,  -19, 	   4,  -13, 	   2,   -9, 	  -1,  -11
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    2,  -15, 	  -3,   -8, 	   1,   -7, 	  -4,   -7
+.2byte    3,  -18, 	  -7,  -19, 	   7,  -12, 	  -2,  -11
+.2byte    3,  -20, 	  -2,  -15, 	   6,  -10, 	  -2,   -9
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -1,  -15, 	   1,   -4, 	  -3,   -4, 	  -1,   -7
+.2byte   -1,  -18, 	   9,  -17, 	 -11,  -17, 	  -1,  -11
+.2byte    0,  -19, 	   8,   -9, 	  -8,   -9, 	   0,   -6
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -4,  -15, 	   1,   -8, 	  -3,   -7, 	   2,   -7
+.2byte   -5,  -18, 	   5,  -19, 	  -9,  -12, 	   0,  -11
+.2byte   -4,  -20, 	   1,  -15, 	  -7,  -10, 	   1,   -9
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -4,  -14, 	  -3,   -8, 	  -1,   -5, 	   2,   -8
+.2byte  -11,  -13, 	  -4,  -23, 	   0,  -13, 	   0,  -11
+.2byte   -6,  -19, 	  -5,  -13, 	  -3,   -9, 	   0,  -11
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -5,  -13, 	  -4,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -9,   -9, 	 -10,  -19, 	   9,  -14, 	  -1,   -8
+.2byte   -6,  -18, 	  -8,  -12, 	   0,   -9, 	  -1,  -11
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte   -1,  -10, 	  -3,   -4, 	   1,   -4, 	  -1,   -8
+.2byte   -1,   -3, 	 -12,  -11, 	  10,  -11, 	  -1,   -7
+.2byte   -1,  -15, 	 -10,  -11, 	   8,  -11, 	  -1,   -9
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte    3,  -13, 	   2,   -6, 	  -2,   -5, 	  -2,   -9
+.2byte    7,   -9, 	   8,  -19, 	 -11,  -14, 	  -1,   -8
+.2byte    5,  -18, 	   7,  -12, 	  -1,   -9, 	   0,  -11
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    2,  -14, 	   1,   -8, 	  -1,   -5, 	  -4,   -8
+.2byte    9,  -13, 	   2,  -23, 	  -2,  -13, 	  -2,  -11
+.2byte    5,  -19, 	   4,  -13, 	   2,   -9, 	  -1,  -11
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    2,  -15, 	  -3,   -8, 	   1,   -7, 	  -4,   -7
+.2byte    3,  -18, 	  -7,  -19, 	   7,  -12, 	  -2,  -11
+.2byte    3,  -20, 	  -2,  -15, 	   6,  -10, 	  -2,   -9
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -1,  -15, 	   1,   -4, 	  -3,   -4, 	  -1,   -7
+.2byte   -1,  -18, 	   9,  -17, 	 -11,  -17, 	  -1,  -11
+.2byte    0,  -19, 	   8,   -9, 	  -8,   -9, 	   0,   -6
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -4,  -15, 	   1,   -8, 	  -3,   -7, 	   2,   -7
+.2byte   -5,  -18, 	   5,  -19, 	  -9,  -12, 	   0,  -11
+.2byte   -4,  -20, 	   1,  -15, 	  -7,  -10, 	   1,   -9
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -4,  -14, 	  -3,   -8, 	  -1,   -5, 	   2,   -8
+.2byte  -11,  -13, 	  -4,  -23, 	   0,  -13, 	   0,  -11
+.2byte   -6,  -19, 	  -5,  -13, 	  -3,   -9, 	   0,  -11
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -5,  -13, 	  -4,   -6, 	   0,   -5, 	   0,   -9
+.2byte   -9,   -9, 	 -10,  -19, 	   9,  -14, 	  -1,   -8
+.2byte   -6,  -18, 	  -8,  -12, 	   0,   -9, 	  -1,  -11
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte   -1,  -15, 	 -10,  -11, 	   8,  -11, 	  -1,   -9
+.2byte   -1,  -10, 	 -12,  -15, 	  10,  -15, 	  -1,   -9
+.2byte    6,  -13, 	   4,   -5, 	   0,   -3, 	  -1,   -8
+.2byte    4,  -18, 	   6,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte    7,  -12, 	   7,  -18, 	 -10,  -14, 	  -1,   -8
+.2byte    7,  -16, 	   3,   -5, 	   2,   -4, 	  -1,   -9
+.2byte    5,  -17, 	   4,  -11, 	   2,   -7, 	  -1,   -9
+.2byte    8,  -15, 	  -3,  -17, 	  -4,  -11, 	  -1,   -9
+.2byte    6,  -18, 	  -2,   -6, 	   4,   -5, 	   0,   -9
+.2byte    4,  -19, 	  -1,  -14, 	   7,   -9, 	  -1,   -8
+.2byte    7,  -17, 	  -7,  -17, 	   8,  -12, 	   0,  -10
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -1,  -19, 	   7,   -9, 	  -9,   -9, 	  -1,   -6
+.2byte   -1,  -16, 	  10,  -15, 	 -12,  -15, 	  -1,   -8
+.2byte   -7,  -18, 	   1,   -6, 	  -5,   -5, 	  -1,   -9
+.2byte   -5,  -19, 	   0,  -14, 	  -8,   -9, 	   0,   -8
+.2byte   -8,  -17, 	   6,  -17, 	  -9,  -12, 	  -1,  -10
+.2byte   -8,  -16, 	  -4,   -5, 	  -3,   -4, 	   0,   -9
+.2byte   -6,  -17, 	  -5,  -11, 	  -3,   -7, 	   0,   -9
+.2byte   -9,  -15, 	   2,  -17, 	   3,  -11, 	   0,   -9
+.2byte   -7,  -13, 	  -5,   -5, 	  -1,   -3, 	   0,   -8
+.2byte   -5,  -18, 	  -7,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -8,  -12, 	  -8,  -18, 	   9,  -14, 	   0,   -8
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -8,  -10, 	  -7,   -2, 	  -2,    0, 	  -1,   -7
+.2byte   -9,   -8, 	  -6,   -3, 	  -3,   -1, 	  -1,   -7
+.2byte    0,  -17, 	 -11,  -15, 	  11,  -15, 	   0,  -11
+.2byte    3,  -20, 	   2,  -22, 	 -14,   -8, 	  -1,  -12
+.2byte    2,  -22, 	  -4,  -19, 	  -8,   -6, 	  -1,  -11
+.2byte   -1,  -21, 	 -13,  -17, 	   1,   -8, 	  -2,   -9
+.2byte    0,  -21, 	  11,  -11, 	 -11,  -11, 	   0,   -8
+.2byte    0,  -21, 	  12,  -17, 	  -2,   -8, 	   1,   -9
+.2byte   -3,  -22, 	   3,  -19, 	   7,   -6, 	   0,  -11
+.2byte   -4,  -20, 	  -3,  -22, 	  13,   -8, 	   0,  -12
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte   -1,  -11, 	  -3,   -5, 	   1,   -5, 	  -1,   -9
+.2byte   -1,   -3, 	 -12,  -11, 	  10,  -11, 	  -1,   -7
+.2byte   -1,  -15, 	 -10,  -11, 	   8,  -11, 	  -1,   -9
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte    6,  -12, 	   5,   -5, 	   1,   -4, 	   1,   -8
+.2byte    7,   -9, 	   8,  -19, 	 -11,  -14, 	  -1,   -8
+.2byte    5,  -18, 	   7,  -12, 	  -1,   -9, 	   0,  -11
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    5,  -13, 	   4,   -7, 	   2,   -4, 	  -1,   -7
+.2byte    9,  -13, 	   2,  -23, 	  -2,  -13, 	  -2,  -11
+.2byte    5,  -19, 	   4,  -13, 	   2,   -9, 	  -1,  -11
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    5,  -16, 	   0,   -9, 	   4,   -8, 	  -1,   -8
+.2byte    3,  -18, 	  -7,  -19, 	   7,  -12, 	  -2,  -11
+.2byte    3,  -20, 	  -2,  -15, 	   6,  -10, 	  -2,   -9
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -1,  -17, 	   1,   -6, 	  -3,   -6, 	  -1,   -9
+.2byte   -1,  -18, 	   9,  -17, 	 -11,  -17, 	  -1,  -11
+.2byte    0,  -19, 	   8,   -9, 	  -8,   -9, 	   0,   -6
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -6,  -16, 	  -1,   -9, 	  -5,   -8, 	   0,   -8
+.2byte   -5,  -18, 	   5,  -19, 	  -9,  -12, 	   0,  -11
+.2byte   -4,  -20, 	   1,  -15, 	  -7,  -10, 	   1,   -9
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -6,  -13, 	  -5,   -7, 	  -3,   -4, 	   0,   -7
+.2byte  -11,  -13, 	  -4,  -23, 	   0,  -13, 	   0,  -11
+.2byte   -6,  -19, 	  -5,  -13, 	  -3,   -9, 	   0,  -11
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -7,  -12, 	  -6,   -5, 	  -2,   -4, 	  -2,   -8
+.2byte   -9,   -9, 	 -10,  -19, 	   9,  -14, 	  -1,   -8
+.2byte   -6,  -18, 	  -8,  -12, 	   0,   -9, 	  -1,  -11
+.2byte   -1,  -15, 	 -10,  -11, 	   8,  -11, 	  -1,   -9
+.2byte   -5,  -18, 	  -7,  -12, 	   1,   -9, 	   0,  -11
+.2byte   -6,  -17, 	  -5,  -11, 	  -3,   -7, 	   0,   -9
+.2byte   -5,  -19, 	   0,  -14, 	  -8,   -9, 	   0,   -8
+.2byte   -1,  -19, 	   7,   -9, 	  -9,   -9, 	  -1,   -6
+.2byte    4,  -19, 	  -1,  -14, 	   7,   -9, 	  -1,   -8
+.2byte    5,  -17, 	   4,  -11, 	   2,   -7, 	  -1,   -9
+.2byte    4,  -18, 	   6,  -12, 	  -2,   -9, 	  -1,  -11
+.2byte   -1,  -10, 	 -12,  -15, 	  10,  -15, 	  -1,   -9
+.2byte    7,  -12, 	   7,  -18, 	 -10,  -14, 	  -1,   -8
+.2byte    8,  -15, 	  -3,  -17, 	  -4,  -11, 	  -1,   -9
+.2byte    7,  -17, 	  -7,  -17, 	   8,  -12, 	   0,  -10
+.2byte   -1,  -16, 	  10,  -15, 	 -12,  -15, 	  -1,   -8
+.2byte   -8,  -17, 	   6,  -17, 	  -9,  -12, 	  -1,  -10
+.2byte   -9,  -15, 	   2,  -17, 	   3,  -11, 	   0,   -9
+.2byte   -8,  -12, 	  -8,  -18, 	   9,  -14, 	   0,   -8
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte   -1,  -15, 	 -10,  -11, 	   8,  -11, 	  -1,   -9
+.2byte   -1,   -3, 	 -12,  -11, 	  10,  -11, 	  -1,   -7
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte    5,  -18, 	   7,  -12, 	  -1,   -9, 	   0,  -11
+.2byte    7,   -9, 	   8,  -19, 	 -11,  -14, 	  -1,   -8
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    5,  -19, 	   4,  -13, 	   2,   -9, 	  -1,  -11
+.2byte   10,  -13, 	   3,  -23, 	  -1,  -13, 	  -1,  -11
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    3,  -20, 	  -2,  -15, 	   6,  -10, 	  -2,   -9
+.2byte    5,  -18, 	  -5,  -19, 	   9,  -12, 	   0,  -11
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte    0,  -19, 	   8,   -9, 	  -8,   -9, 	   0,   -6
+.2byte   -1,  -18, 	   9,  -17, 	 -11,  -17, 	  -1,  -11
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -4,  -20, 	   1,  -15, 	  -7,  -10, 	   1,   -9
+.2byte   -7,  -18, 	   3,  -19, 	 -11,  -12, 	  -2,  -11
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -6,  -19, 	  -5,  -13, 	  -3,   -9, 	   0,  -11
+.2byte  -12,  -13, 	  -5,  -23, 	  -1,  -13, 	  -1,  -11
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -6,  -18, 	  -8,  -12, 	   0,   -9, 	  -1,  -11
+.2byte   -9,   -9, 	 -10,  -19, 	   9,  -14, 	  -1,   -8
+.2byte   -1,   -5, 	 -12,  -13, 	  10,  -13, 	  -1,   -9
+.2byte   -9,   -9, 	 -10,  -19, 	   9,  -14, 	  -1,   -8
+.2byte  -11,  -13, 	  -4,  -23, 	   0,  -13, 	   0,  -11
+.2byte   -6,  -18, 	   4,  -19, 	 -10,  -12, 	  -1,  -11
+.2byte   -1,  -18, 	   9,  -17, 	 -11,  -17, 	  -1,  -11
+.2byte    5,  -18, 	  -5,  -19, 	   9,  -12, 	   0,  -11
+.2byte   10,  -13, 	   3,  -23, 	  -1,  -13, 	  -1,  -11
+.2byte    8,   -9, 	   9,  -19, 	 -10,  -14, 	   0,   -8
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -1,  -17, 	   5,  -11, 	  -7,  -11, 	  -1,   -8
+.2byte   -1,  -21, 	  10,  -12, 	 -12,  -12, 	  -1,   -8
+.2byte   -1,  -23, 	   2,   -4, 	  -4,   -4, 	  -1,   -7
+.2byte   -1,  -10, 	  -4,   -2, 	   2,   -2, 	  -1,   -7
+.2byte    1,   -9, 	  -3,   -1, 	   3,   -2, 	  -1,   -6
+.2byte   -3,   -9, 	  -5,   -2, 	   1,   -1, 	  -1,   -6
+.2byte    6,  -12, 	   4,   -4, 	   0,   -2, 	  -1,   -7
+.2byte    4,  -10, 	   4,   -3, 	  -2,   -1, 	  -1,   -6
+.2byte    7,  -11, 	   3,   -4, 	  -2,   -2, 	  -1,   -6
+.2byte    7,  -15, 	   3,   -4, 	   2,   -3, 	  -1,   -8
+.2byte    7,  -13, 	   1,   -2, 	  -2,   -1, 	  -1,   -7
+.2byte    6,  -14, 	   3,   -3, 	   3,   -2, 	  -2,   -8
+.2byte    6,  -17, 	  -2,   -5, 	   4,   -4, 	   0,   -8
+.2byte    6,  -15, 	  -1,   -5, 	   3,   -2, 	  -2,   -8
+.2byte    5,  -16, 	  -3,   -5, 	   4,   -3, 	  -2,   -8
+.2byte   -1,  -19, 	   2,   -4, 	  -4,   -4, 	  -1,   -8
+.2byte   -3,  -18, 	   1,   -4, 	  -4,   -3, 	  -1,   -7
+.2byte    1,  -18, 	   2,   -3, 	  -3,   -4, 	  -1,   -7
+.2byte   -8,  -17, 	   0,   -5, 	  -6,   -4, 	  -2,   -8
+.2byte   -8,  -15, 	  -1,   -5, 	  -5,   -2, 	   0,   -8
+.2byte   -7,  -16, 	   1,   -5, 	  -6,   -3, 	   0,   -8
+.2byte   -9,  -15, 	  -5,   -4, 	  -4,   -3, 	  -1,   -8
+.2byte   -9,  -13, 	  -3,   -2, 	   0,   -1, 	  -1,   -7
+.2byte   -8,  -14, 	  -5,   -3, 	  -5,   -2, 	   0,   -8
+.2byte   -8,  -12, 	  -6,   -4, 	  -2,   -2, 	  -1,   -7
+.2byte   -6,  -10, 	  -6,   -3, 	   0,   -1, 	  -1,   -6
+.2byte   -9,  -11, 	  -5,   -4, 	   0,   -2, 	  -1,   -6
+sXatuAnimTable1:
+.4byte sXatuAnims_1_1
+.4byte sXatuAnims_1_2
+.4byte sXatuAnims_1_3
+.4byte sXatuAnims_1_4
+.4byte sXatuAnims_1_5
+.4byte sXatuAnims_1_6
+.4byte sXatuAnims_1_7
+.4byte sXatuAnims_1_8
+sXatuAnimTable2:
+.4byte sXatuAnims_2_1
+.4byte sXatuAnims_2_2
+.4byte sXatuAnims_2_3
+.4byte sXatuAnims_2_4
+.4byte sXatuAnims_2_5
+.4byte sXatuAnims_2_6
+.4byte sXatuAnims_2_7
+.4byte sXatuAnims_2_8
+sXatuAnimTable3:
+.4byte sXatuAnims_3_1
+.4byte sXatuAnims_3_2
+.4byte sXatuAnims_3_3
+.4byte sXatuAnims_3_4
+.4byte sXatuAnims_3_5
+.4byte sXatuAnims_3_6
+.4byte sXatuAnims_3_7
+.4byte sXatuAnims_3_8
+sXatuAnimTable4:
+.4byte sXatuAnims_4_1
+.4byte sXatuAnims_4_2
+.4byte sXatuAnims_4_3
+.4byte sXatuAnims_4_4
+.4byte sXatuAnims_4_5
+.4byte sXatuAnims_4_6
+.4byte sXatuAnims_4_7
+.4byte sXatuAnims_4_8
+sXatuAnimTable5:
+.4byte sXatuAnims_5_1
+.4byte sXatuAnims_5_2
+.4byte sXatuAnims_5_3
+.4byte sXatuAnims_5_4
+.4byte sXatuAnims_5_5
+.4byte sXatuAnims_5_6
+.4byte sXatuAnims_5_7
+.4byte sXatuAnims_5_8
+sXatuAnimTable6:
+.4byte sXatuAnims_6_1
+.4byte sXatuAnims_6_1
+.4byte sXatuAnims_6_1
+.4byte sXatuAnims_6_1
+.4byte sXatuAnims_6_1
+.4byte sXatuAnims_6_1
+.4byte sXatuAnims_6_1
+.4byte sXatuAnims_6_1
+sXatuAnimTable7:
+.4byte sXatuAnims_7_1
+.4byte sXatuAnims_7_2
+.4byte sXatuAnims_7_3
+.4byte sXatuAnims_7_4
+.4byte sXatuAnims_7_5
+.4byte sXatuAnims_7_6
+.4byte sXatuAnims_7_7
+.4byte sXatuAnims_7_8
+sXatuAnimTable8:
+.4byte sXatuAnims_8_1
+.4byte sXatuAnims_8_2
+.4byte sXatuAnims_8_3
+.4byte sXatuAnims_8_4
+.4byte sXatuAnims_8_5
+.4byte sXatuAnims_8_6
+.4byte sXatuAnims_8_7
+.4byte sXatuAnims_8_8
+sXatuAnimTable9:
+.4byte sXatuAnims_9_1
+.4byte sXatuAnims_9_2
+.4byte sXatuAnims_9_3
+.4byte sXatuAnims_9_4
+.4byte sXatuAnims_9_5
+.4byte sXatuAnims_9_6
+.4byte sXatuAnims_9_7
+.4byte sXatuAnims_9_8
+sXatuAnimTable10:
+.4byte sXatuAnims_10_1
+.4byte sXatuAnims_10_2
+.4byte sXatuAnims_10_3
+.4byte sXatuAnims_10_4
+.4byte sXatuAnims_10_5
+.4byte sXatuAnims_10_6
+.4byte sXatuAnims_10_7
+.4byte sXatuAnims_10_8
+sXatuAnimTable11:
+.4byte sXatuAnims_11_1
+.4byte sXatuAnims_11_2
+.4byte sXatuAnims_11_3
+.4byte sXatuAnims_11_4
+.4byte sXatuAnims_11_5
+.4byte sXatuAnims_11_6
+.4byte sXatuAnims_11_7
+.4byte sXatuAnims_11_8
+sXatuAnimTable12:
+.4byte sXatuAnims_12_1
+.4byte sXatuAnims_12_2
+.4byte sXatuAnims_12_3
+.4byte sXatuAnims_12_4
+.4byte sXatuAnims_12_5
+.4byte sXatuAnims_12_6
+.4byte sXatuAnims_12_7
+.4byte sXatuAnims_12_8
+sXatuAnimTable13:
+.4byte sXatuAnims_13_1
+.4byte sXatuAnims_13_2
+.4byte sXatuAnims_13_3
+.4byte sXatuAnims_13_4
+.4byte sXatuAnims_13_5
+.4byte sXatuAnims_13_6
+.4byte sXatuAnims_13_7
+.4byte sXatuAnims_13_8
+sXatuAnimTable14:
+.4byte sXatuAnims_14_1
+.4byte sXatuAnims_14_2
+.4byte sXatuAnims_14_3
+.4byte sXatuAnims_14_4
+.4byte sXatuAnims_14_5
+.4byte sXatuAnims_14_6
+.4byte sXatuAnims_14_7
+.4byte sXatuAnims_14_8
+sXatuAnimTable15:
+.4byte sXatuAnims_15_1
+.4byte sXatuAnims_15_2
+.4byte sXatuAnims_15_3
+.4byte sXatuAnims_15_4
+.4byte sXatuAnims_15_5
+.4byte sXatuAnims_15_6
+.4byte sXatuAnims_15_7
+.4byte sXatuAnims_15_8
+sXatuAnimTable16:
+.4byte sXatuAnims_16_1
+.4byte sXatuAnims_16_2
+.4byte sXatuAnims_16_3
+.4byte sXatuAnims_16_4
+.4byte sXatuAnims_16_5
+.4byte sXatuAnims_16_6
+.4byte sXatuAnims_16_7
+.4byte sXatuAnims_16_8
+sAxAnimationsXatu:
+.4byte sXatuAnimTable1
+.4byte sXatuAnimTable2
+.4byte sXatuAnimTable3
+.4byte sXatuAnimTable4
+.4byte sXatuAnimTable5
+.4byte sXatuAnimTable6
+.4byte sXatuAnimTable7
+.4byte sXatuAnimTable8
+.4byte sXatuAnimTable9
+.4byte sXatuAnimTable10
+.4byte sXatuAnimTable11
+.4byte sXatuAnimTable12
+.4byte sXatuAnimTable13
+.4byte sXatuAnimTable14
+.4byte sXatuAnimTable15
+.4byte sXatuAnimTable16
+sAxSpritesXatu:
+.4byte sXatuSprites1
+.4byte sXatuSprites2
+.4byte sXatuSprites3
+.4byte sXatuSprites4
+.4byte sXatuSprites5
+.4byte sXatuSprites6
+.4byte sXatuSprites7
+.4byte sXatuSprites8
+.4byte sXatuSprites9
+.4byte sXatuSprites10
+.4byte sXatuSprites11
+.4byte sXatuSprites12
+.4byte sXatuSprites13
+.4byte sXatuSprites14
+.4byte sXatuSprites15
+.4byte sXatuSprites16
+.4byte sXatuSprites17
+.4byte sXatuSprites18
+.4byte sXatuSprites19
+.4byte sXatuSprites20
+.4byte sXatuSprites21
+.4byte sXatuSprites22
+.4byte sXatuSprites23
+.4byte sXatuSprites24
+.4byte sXatuSprites25
+.4byte sXatuSprites26
+.4byte sXatuSprites27
+.4byte sXatuSprites28
+.4byte sXatuSprites29
+.4byte sXatuSprites30
+.4byte sXatuSprites31
+.4byte sXatuSprites32
+.4byte sXatuSprites33
+.4byte sXatuSprites34
+.4byte sXatuSprites35
+.4byte sXatuSprites36
+.4byte sXatuSprites37
+.4byte sXatuSprites38
+.4byte sXatuSprites39
+.4byte sXatuSprites40
+.4byte sXatuSprites41
+.4byte sXatuSprites42
+.4byte sXatuSprites43
+.4byte sXatuSprites44
+.4byte sXatuSprites45
+sAxMainXatu:
+ax_main sAxPosesXatu, sAxAnimationsXatu, 16, sAxSpritesXatu, sAxPositionsXatu

--- a/data/ax/yanma.inc
+++ b/data/ax/yanma.inc
@@ -1,0 +1,2379 @@
+.global gAxYanma
+gAxYanma:
+ax_siro sAxMainYanma
+sYanmaPose1:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose3:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose4:
+ax_pose 3, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose5:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose6:
+ax_pose 5, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose7:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose8:
+ax_pose 7, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose9:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose10:
+ax_pose 9, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose11:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose12:
+ax_pose 7, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose13:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose14:
+ax_pose 5, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose15:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose16:
+ax_pose 3, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose17:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose18:
+ax_pose 1, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose19:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose20:
+ax_pose 3, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose21:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose22:
+ax_pose 5, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose23:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose24:
+ax_pose 7, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose25:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose26:
+ax_pose 9, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose27:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose28:
+ax_pose 7, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose29:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose30:
+ax_pose 5, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose31:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose32:
+ax_pose 3, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose33:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose34:
+ax_pose 1, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose35:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose36:
+ax_pose 3, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose37:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose38:
+ax_pose 5, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose39:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose40:
+ax_pose 7, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose41:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose42:
+ax_pose 9, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose43:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose44:
+ax_pose 7, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose45:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose46:
+ax_pose 5, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose47:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose48:
+ax_pose 3, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose49:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose50:
+ax_pose 10, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose51:
+ax_pose 11, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose52:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose53:
+ax_pose 12, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sYanmaPose54:
+ax_pose 13, 0x01e6, 0x90ef, 0x3c00
+ax_pose_terminator
+sYanmaPose55:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose56:
+ax_pose 14, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sYanmaPose57:
+ax_pose 15, 0x81e7, 0x90f6, 0x3c00
+ax_pose_terminator
+sYanmaPose58:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose59:
+ax_pose 16, 0x01e6, 0x90ed, 0x3c00
+ax_pose_terminator
+sYanmaPose60:
+ax_pose 17, 0x01e6, 0x90ed, 0x3c00
+ax_pose_terminator
+sYanmaPose61:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose62:
+ax_pose 18, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose63:
+ax_pose 19, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose64:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose65:
+ax_pose 16, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sYanmaPose66:
+ax_pose 17, 0x01e6, 0x80f3, 0x3c00
+ax_pose_terminator
+sYanmaPose67:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose68:
+ax_pose 14, 0x81e7, 0x80fa, 0x3c00
+ax_pose_terminator
+sYanmaPose69:
+ax_pose 15, 0x81e7, 0x80fa, 0x3c00
+ax_pose_terminator
+sYanmaPose70:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose71:
+ax_pose 12, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sYanmaPose72:
+ax_pose 13, 0x01e6, 0x80f1, 0x3c00
+ax_pose_terminator
+sYanmaPose73:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose74:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose75:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose76:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose77:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose78:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose79:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose80:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose81:
+ax_pose 20, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose82:
+ax_pose 21, 0x01ef, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose83:
+ax_pose 22, 0x01e1, 0x80f2, 0x3c00
+ax_pose_terminator
+sYanmaPose84:
+ax_pose 23, 0x01df, 0x90ee, 0x3c00
+ax_pose_terminator
+sYanmaPose85:
+ax_pose 24, 0x01e0, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose86:
+ax_pose 25, 0x01e1, 0x90e9, 0x3c00
+ax_pose_terminator
+sYanmaPose87:
+ax_pose 26, 0x01e2, 0x80f2, 0x3c00
+ax_pose_terminator
+sYanmaPose88:
+ax_pose 25, 0x01e1, 0x80f7, 0x3c00
+ax_pose_terminator
+sYanmaPose89:
+ax_pose 24, 0x01e1, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose90:
+ax_pose 23, 0x01df, 0x80f2, 0x3c00
+ax_pose_terminator
+sYanmaPose91:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose92:
+ax_pose 1, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose93:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose94:
+ax_pose 3, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose95:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose96:
+ax_pose 5, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose97:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose98:
+ax_pose 7, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose99:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose100:
+ax_pose 9, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose101:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose102:
+ax_pose 7, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose103:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose104:
+ax_pose 5, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose105:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose106:
+ax_pose 3, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose107:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose108:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose109:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose110:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose111:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose112:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose113:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose114:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose115:
+ax_pose 10, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose116:
+ax_pose 12, 0x01e9, 0x90ef, 0x3c00
+ax_pose_terminator
+sYanmaPose117:
+ax_pose 14, 0x81e7, 0x90f7, 0x3c00
+ax_pose_terminator
+sYanmaPose118:
+ax_pose 16, 0x01e8, 0x90ee, 0x3c00
+ax_pose_terminator
+sYanmaPose119:
+ax_pose 18, 0x01e9, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose120:
+ax_pose 16, 0x01e8, 0x80f3, 0x3c00
+ax_pose_terminator
+sYanmaPose121:
+ax_pose 14, 0x81e7, 0x80fa, 0x3c00
+ax_pose_terminator
+sYanmaPose122:
+ax_pose 12, 0x01e9, 0x80f2, 0x3c00
+ax_pose_terminator
+sYanmaPose123:
+ax_pose 10, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose124:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose125:
+ax_pose 1, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose126:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose127:
+ax_pose 3, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose128:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose129:
+ax_pose 5, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose130:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose131:
+ax_pose 7, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose132:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose133:
+ax_pose 9, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose134:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose135:
+ax_pose 7, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose136:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose137:
+ax_pose 5, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose138:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose139:
+ax_pose 3, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose140:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose141:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose142:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose143:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose144:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose145:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose146:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose147:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose148:
+ax_pose 0, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose149:
+ax_pose 2, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose150:
+ax_pose 4, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose151:
+ax_pose 6, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose152:
+ax_pose 8, 0x01e7, 0x80f4, 0x3c00
+ax_pose_terminator
+sYanmaPose153:
+ax_pose 6, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose154:
+ax_pose 4, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+sYanmaPose155:
+ax_pose 2, 0x01e7, 0x90ec, 0x3c00
+ax_pose_terminator
+.align 2
+sYanmaAnims_1_1:
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, -2, 0, 0,
+ax_anim 4, 0, 0, 2, -4, 2, 0,
+ax_anim 4, 0, 1, 2, -4, 2, 0,
+ax_anim 4, 0, 0, 2, -4, 2, 0,
+ax_anim 4, 0, 1, 2, -4, 2, 0,
+ax_anim 4, 0, 0, 0, -3, 0, 0,
+ax_anim 4, 0, 1, -3, -3, -3, 0,
+ax_anim 4, 0, 0, -3, -3, -3, 0,
+ax_anim 4, 0, 1, -3, -3, -3, 0,
+ax_anim 4, 0, 0, -3, -3, -3, 0,
+ax_anim 4, 0, 1, -3, -3, -3, 0,
+ax_anim 4, 0, 0, -2, -2, -2, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim 4, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_1_2:
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 1, -3, 2, -2,
+ax_anim 4, 0, 2, 2, -6, 3, -3,
+ax_anim 4, 0, 3, 2, -6, 3, -3,
+ax_anim 4, 0, 2, 2, -6, 3, -3,
+ax_anim 4, 0, 3, 2, -6, 3, -3,
+ax_anim 4, 0, 2, 0, -5, 0, 0,
+ax_anim 4, 0, 3, -3, -2, -2, 2,
+ax_anim 4, 0, 2, -3, -2, -2, 2,
+ax_anim 4, 0, 3, -3, -2, -2, 2,
+ax_anim 4, 0, 2, -3, -2, -2, 2,
+ax_anim 4, 0, 3, -3, -2, -2, 2,
+ax_anim 4, 0, 2, -2, -1, -1, 1,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 2, 0, 0, 0, 0,
+ax_anim 4, 0, 3, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_1_3:
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, -1, -1, -1, -1,
+ax_anim 4, 0, 4, -2, -4, -2, -4,
+ax_anim 4, 0, 5, -2, -4, -2, -4,
+ax_anim 4, 0, 4, -2, -4, -2, -4,
+ax_anim 4, 0, 5, -2, -4, -2, -4,
+ax_anim 4, 0, 4, -1, -3, -1, -3,
+ax_anim 4, 0, 5, 1, -2, 1, -2,
+ax_anim 4, 0, 4, 2, -2, 2, -2,
+ax_anim 4, 0, 5, 2, -2, 2, -2,
+ax_anim 4, 0, 4, 2, -2, 2, -2,
+ax_anim 4, 0, 5, 2, -2, 2, -2,
+ax_anim 4, 0, 4, 1, -1, 1, -1,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim 4, 0, 4, 0, 0, 0, 0,
+ax_anim 4, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_1_4:
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, -1, -3, -2, -2,
+ax_anim 4, 0, 6, -2, -6, -3, -3,
+ax_anim 4, 0, 7, -2, -6, -3, -3,
+ax_anim 4, 0, 6, -2, -6, -3, -3,
+ax_anim 4, 0, 7, -2, -6, -3, -3,
+ax_anim 4, 0, 6, 0, -5, 0, 0,
+ax_anim 4, 0, 7, 3, -2, 2, 2,
+ax_anim 4, 0, 6, 3, -2, 2, 2,
+ax_anim 4, 0, 7, 3, -2, 2, 2,
+ax_anim 4, 0, 6, 3, -2, 2, 2,
+ax_anim 4, 0, 7, 3, -2, 2, 2,
+ax_anim 4, 0, 6, 2, -1, 1, 1,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim 4, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_1_5:
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, -2, 0, 0,
+ax_anim 4, 0, 8, -2, -4, -2, 0,
+ax_anim 4, 0, 9, -2, -4, -2, 0,
+ax_anim 4, 0, 8, -2, -4, -2, 0,
+ax_anim 4, 0, 9, -2, -4, -2, 0,
+ax_anim 4, 0, 8, 0, -3, 0, 0,
+ax_anim 4, 0, 9, 3, -3, 3, 0,
+ax_anim 4, 0, 8, 3, -3, 3, 0,
+ax_anim 4, 0, 9, 3, -3, 3, 0,
+ax_anim 4, 0, 8, 3, -3, 3, 0,
+ax_anim 4, 0, 9, 3, -3, 3, 0,
+ax_anim 4, 0, 8, 2, -2, 2, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 8, 0, 0, 0, 0,
+ax_anim 4, 0, 9, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_1_6:
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 1, -3, 2, -2,
+ax_anim 4, 0, 10, 2, -6, 3, -3,
+ax_anim 4, 0, 11, 2, -6, 3, -3,
+ax_anim 4, 0, 10, 2, -6, 3, -3,
+ax_anim 4, 0, 11, 2, -6, 3, -3,
+ax_anim 4, 0, 10, 0, -5, 0, 0,
+ax_anim 4, 0, 11, -3, -2, -2, 2,
+ax_anim 4, 0, 10, -3, -2, -2, 2,
+ax_anim 4, 0, 11, -3, -2, -2, 2,
+ax_anim 4, 0, 10, -3, -2, -2, 2,
+ax_anim 4, 0, 11, -3, -2, -2, 2,
+ax_anim 4, 0, 10, -2, -1, -1, 1,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim 4, 0, 10, 0, 0, 0, 0,
+ax_anim 4, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_1_7:
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, -3, 0, -2,
+ax_anim 4, 0, 12, 0, -6, 0, -3,
+ax_anim 4, 0, 13, 0, -6, 0, -3,
+ax_anim 4, 0, 12, 0, -6, 0, -3,
+ax_anim 4, 0, 13, 0, -6, 0, -3,
+ax_anim 4, 0, 12, 0, -5, 0, 0,
+ax_anim 4, 0, 13, 0, -2, 0, 2,
+ax_anim 4, 0, 12, 0, -2, 0, 2,
+ax_anim 4, 0, 13, 0, -2, 0, 2,
+ax_anim 4, 0, 12, 0, -2, 0, 2,
+ax_anim 4, 0, 13, 0, -2, 0, 2,
+ax_anim 4, 0, 12, 0, -1, 0, 1,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim 4, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_1_8:
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, -1, -3, -2, -2,
+ax_anim 4, 0, 14, -2, -6, -3, -3,
+ax_anim 4, 0, 15, -2, -6, -3, -3,
+ax_anim 4, 0, 14, -2, -6, -3, -3,
+ax_anim 4, 0, 15, -2, -6, -3, -3,
+ax_anim 4, 0, 14, 0, -5, 0, 0,
+ax_anim 4, 0, 15, 3, -2, 2, 2,
+ax_anim 4, 0, 14, 3, -2, 2, 2,
+ax_anim 4, 0, 15, 3, -2, 2, 2,
+ax_anim 4, 0, 14, 3, -2, 2, 2,
+ax_anim 4, 0, 15, 3, -2, 2, 2,
+ax_anim 4, 0, 14, 2, -1, 1, 1,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 14, 0, 0, 0, 0,
+ax_anim 4, 0, 15, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_2_1:
+ax_anim 2, 0, 17, 0, -1, 0, -1,
+ax_anim 4, 0, 16, 0, -2, 0, -2,
+ax_anim 1, 0, 17, 0, 0, 0, 0,
+ax_anim 1, 2, 16, 0, 4, 0, 4,
+ax_anim 1, 0, 17, 0, 10, 0, 10,
+ax_anim 2, 0, 16, 0, 22, 0, 22,
+ax_anim 2, 1, 17, -1, 22, -1, 22,
+ax_anim 2, 0, 16, 0, 22, 0, 22,
+ax_anim 2, 0, 17, -1, 22, -1, 22,
+ax_anim 2, 0, 16, 0, 6, 0, 6,
+ax_anim_terminator
+sYanmaAnims_2_2:
+ax_anim 2, 0, 19, -1, -1, -1, -1,
+ax_anim 4, 0, 18, -2, -2, -2, -2,
+ax_anim 1, 0, 19, 0, 0, 0, 0,
+ax_anim 1, 2, 18, 3, 5, 3, 5,
+ax_anim 1, 0, 19, 9, 12, 9, 12,
+ax_anim 2, 0, 18, 19, 23, 19, 21,
+ax_anim 2, 1, 19, 18, 23, 18, 21,
+ax_anim 2, 0, 18, 19, 23, 19, 21,
+ax_anim 2, 0, 19, 18, 23, 18, 21,
+ax_anim 2, 0, 18, 5, 7, 5, 7,
+ax_anim_terminator
+sYanmaAnims_2_3:
+ax_anim 2, 0, 21, -1, 0, -1, 0,
+ax_anim 4, 0, 20, -2, 0, -2, 0,
+ax_anim 1, 0, 21, 0, 0, 0, 0,
+ax_anim 1, 2, 20, 3, 0, 3, 0,
+ax_anim 1, 0, 21, 9, 2, 9, 0,
+ax_anim 2, 0, 20, 19, 3, 19, 0,
+ax_anim 2, 1, 21, 19, 4, 19, 1,
+ax_anim 2, 0, 20, 19, 3, 19, 0,
+ax_anim 2, 0, 21, 19, 4, 19, 1,
+ax_anim 2, 0, 20, 5, 0, 5, 0,
+ax_anim_terminator
+sYanmaAnims_2_4:
+ax_anim 2, 0, 23, -1, 1, -1, 1,
+ax_anim 4, 0, 22, -2, 2, -2, 2,
+ax_anim 1, 0, 23, 0, 0, 0, 0,
+ax_anim 1, 2, 22, 4, -4, 4, -5,
+ax_anim 1, 0, 23, 11, -10, 11, -12,
+ax_anim 2, 0, 22, 19, -17, 19, -21,
+ax_anim 2, 1, 23, 18, -17, 18, -21,
+ax_anim 2, 0, 22, 19, -17, 19, -21,
+ax_anim 2, 0, 23, 18, -17, 18, -21,
+ax_anim 2, 0, 22, 6, -6, 6, -7,
+ax_anim_terminator
+sYanmaAnims_2_5:
+ax_anim 2, 0, 25, 0, 1, 0, 1,
+ax_anim 4, 0, 24, 0, 2, 0, 2,
+ax_anim 1, 0, 25, 0, 0, 0, 0,
+ax_anim 1, 2, 24, 0, -4, 0, -4,
+ax_anim 1, 0, 25, 0, -8, 0, -10,
+ax_anim 2, 0, 24, 0, -18, 0, -22,
+ax_anim 2, 1, 25, -1, -18, -1, -22,
+ax_anim 2, 0, 24, 0, -18, 0, -22,
+ax_anim 2, 0, 25, -1, -18, -1, -22,
+ax_anim 2, 0, 24, 0, -6, 0, -6,
+ax_anim_terminator
+sYanmaAnims_2_6:
+ax_anim 2, 0, 27, 1, 1, 1, 1,
+ax_anim 4, 0, 26, 2, 2, 2, 2,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 26, -4, -4, -4, -5,
+ax_anim 1, 0, 27, -11, -10, -11, -12,
+ax_anim 2, 0, 26, -19, -17, -19, -21,
+ax_anim 2, 1, 27, -18, -17, -18, -21,
+ax_anim 2, 0, 26, -19, -17, -19, -21,
+ax_anim 2, 0, 27, -18, -17, -18, -21,
+ax_anim 2, 0, 26, -6, -6, -6, -7,
+ax_anim_terminator
+sYanmaAnims_2_7:
+ax_anim 2, 0, 29, 1, 0, 1, 0,
+ax_anim 4, 0, 28, 2, 0, 2, 0,
+ax_anim 1, 0, 29, 0, 0, 0, 0,
+ax_anim 1, 2, 28, -3, 0, -3, 0,
+ax_anim 1, 0, 29, -9, 2, -9, 0,
+ax_anim 2, 0, 28, -19, 3, -19, 0,
+ax_anim 2, 1, 29, -19, 4, -19, 1,
+ax_anim 2, 0, 28, -19, 3, -19, 0,
+ax_anim 2, 0, 29, -19, 4, -19, 1,
+ax_anim 2, 0, 28, -5, 0, -5, 0,
+ax_anim_terminator
+sYanmaAnims_2_8:
+ax_anim 2, 0, 31, 1, -1, 1, -1,
+ax_anim 4, 0, 30, 2, -2, 2, -2,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 30, -3, 5, -3, 5,
+ax_anim 1, 0, 31, -9, 12, -9, 12,
+ax_anim 2, 0, 30, -19, 23, -19, 21,
+ax_anim 2, 1, 31, -18, 23, -18, 21,
+ax_anim 2, 0, 30, -19, 23, -19, 21,
+ax_anim 2, 0, 31, -18, 23, -18, 21,
+ax_anim 2, 0, 30, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sYanmaAnims_3_1:
+ax_anim 2, 0, 33, 0, -1, 0, -1,
+ax_anim 4, 0, 32, 0, -2, 0, -2,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 0, 4, 0, 4,
+ax_anim 1, 0, 33, 0, 10, 0, 10,
+ax_anim 2, 0, 32, 0, 22, 0, 22,
+ax_anim 2, 1, 33, -1, 22, -1, 22,
+ax_anim 2, 0, 32, 0, 22, 0, 22,
+ax_anim 2, 0, 33, -1, 22, -1, 22,
+ax_anim 2, 0, 32, 0, 6, 0, 6,
+ax_anim_terminator
+sYanmaAnims_3_2:
+ax_anim 2, 0, 35, -1, -1, -1, -1,
+ax_anim 4, 0, 34, -2, -2, -2, -2,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 34, 3, 5, 3, 5,
+ax_anim 1, 0, 35, 9, 12, 9, 12,
+ax_anim 2, 0, 34, 19, 23, 19, 21,
+ax_anim 2, 1, 35, 18, 23, 18, 21,
+ax_anim 2, 0, 34, 19, 23, 19, 21,
+ax_anim 2, 0, 35, 18, 23, 18, 21,
+ax_anim 2, 0, 34, 5, 7, 5, 7,
+ax_anim_terminator
+sYanmaAnims_3_3:
+ax_anim 2, 0, 37, -1, 0, -1, 0,
+ax_anim 4, 0, 36, -2, 0, -2, 0,
+ax_anim 1, 0, 37, 0, 0, 0, 0,
+ax_anim 1, 2, 36, 3, 0, 3, 0,
+ax_anim 1, 0, 37, 9, 2, 9, 0,
+ax_anim 2, 0, 36, 19, 3, 19, 0,
+ax_anim 2, 1, 37, 19, 4, 19, 1,
+ax_anim 2, 0, 36, 19, 3, 19, 0,
+ax_anim 2, 0, 37, 19, 4, 19, 1,
+ax_anim 2, 0, 36, 5, 0, 5, 0,
+ax_anim_terminator
+sYanmaAnims_3_4:
+ax_anim 2, 0, 39, -1, 1, -1, 1,
+ax_anim 4, 0, 38, -2, 2, -2, 2,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 4, -4, 4, -5,
+ax_anim 1, 0, 39, 11, -10, 11, -12,
+ax_anim 2, 0, 38, 19, -17, 19, -21,
+ax_anim 2, 1, 39, 18, -17, 18, -21,
+ax_anim 2, 0, 38, 19, -17, 19, -21,
+ax_anim 2, 0, 39, 18, -17, 18, -21,
+ax_anim 2, 0, 38, 6, -6, 6, -7,
+ax_anim_terminator
+sYanmaAnims_3_5:
+ax_anim 2, 0, 41, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 41, 0, 0, 0, 0,
+ax_anim 1, 2, 40, 0, -4, 0, -4,
+ax_anim 1, 0, 41, 0, -8, 0, -10,
+ax_anim 2, 0, 40, 0, -18, 0, -22,
+ax_anim 2, 1, 41, -1, -18, -1, -22,
+ax_anim 2, 0, 40, 0, -18, 0, -22,
+ax_anim 2, 0, 41, -1, -18, -1, -22,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sYanmaAnims_3_6:
+ax_anim 2, 0, 43, 1, 1, 1, 1,
+ax_anim 4, 0, 42, 2, 2, 2, 2,
+ax_anim 1, 0, 43, 0, 0, 0, 0,
+ax_anim 1, 2, 42, -4, -4, -4, -5,
+ax_anim 1, 0, 43, -11, -10, -11, -12,
+ax_anim 2, 0, 42, -19, -17, -19, -21,
+ax_anim 2, 1, 43, -18, -17, -18, -21,
+ax_anim 2, 0, 42, -19, -17, -19, -21,
+ax_anim 2, 0, 43, -18, -17, -18, -21,
+ax_anim 2, 0, 42, -6, -6, -6, -7,
+ax_anim_terminator
+sYanmaAnims_3_7:
+ax_anim 2, 0, 45, 1, 0, 1, 0,
+ax_anim 4, 0, 44, 2, 0, 2, 0,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -3, 0, -3, 0,
+ax_anim 1, 0, 45, -9, 2, -9, 0,
+ax_anim 2, 0, 44, -19, 3, -19, 0,
+ax_anim 2, 1, 45, -19, 4, -19, 1,
+ax_anim 2, 0, 44, -19, 3, -19, 0,
+ax_anim 2, 0, 45, -19, 4, -19, 1,
+ax_anim 2, 0, 44, -5, 0, -5, 0,
+ax_anim_terminator
+sYanmaAnims_3_8:
+ax_anim 2, 0, 47, 1, -1, 1, -1,
+ax_anim 4, 0, 46, 2, -2, 2, -2,
+ax_anim 1, 0, 47, 0, 0, 0, 0,
+ax_anim 1, 2, 46, -3, 5, -3, 5,
+ax_anim 1, 0, 47, -9, 12, -9, 12,
+ax_anim 2, 0, 46, -19, 23, -19, 21,
+ax_anim 2, 1, 47, -18, 23, -18, 21,
+ax_anim 2, 0, 46, -19, 23, -19, 21,
+ax_anim 2, 0, 47, -18, 23, -18, 21,
+ax_anim 2, 0, 46, -5, 7, -5, 7,
+ax_anim_terminator
+.align 2
+sYanmaAnims_4_1:
+ax_anim 2, 0, 49, 0, 0, 0, 0,
+ax_anim 2, 0, 50, 0, -1, 0, 0,
+ax_anim 2, 0, 49, 0, -2, 0, 0,
+ax_anim 2, 0, 50, 0, -3, 0, 0,
+ax_anim 2, 2, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 0, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 1, 49, 0, -4, 0, 0,
+ax_anim 2, 0, 50, 0, -4, 0, 0,
+ax_anim 2, 0, 49, 0, -3, 0, 0,
+ax_anim 2, 0, 50, 0, -2, 0, 0,
+ax_anim 2, 0, 49, 0, -1, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, 0,
+ax_anim_terminator
+sYanmaAnims_4_2:
+ax_anim 2, 0, 52, 0, 0, 0, 0,
+ax_anim 2, 0, 53, 0, -1, 0, 0,
+ax_anim 2, 0, 52, 0, -2, 0, 0,
+ax_anim 2, 0, 53, 0, -3, 0, 0,
+ax_anim 2, 2, 52, 0, -4, 0, 0,
+ax_anim 2, 0, 53, 0, -4, 0, 0,
+ax_anim 2, 0, 52, 0, -4, 0, 0,
+ax_anim 2, 0, 53, 0, -4, 0, 0,
+ax_anim 2, 1, 52, 0, -4, 0, 0,
+ax_anim 2, 0, 53, 0, -4, 0, 0,
+ax_anim 2, 0, 52, 0, -3, 0, 0,
+ax_anim 2, 0, 53, 0, -2, 0, 0,
+ax_anim 2, 0, 52, 0, -1, 0, 0,
+ax_anim 2, 0, 51, 0, -1, 0, 0,
+ax_anim_terminator
+sYanmaAnims_4_3:
+ax_anim 2, 0, 55, 0, 0, 0, 0,
+ax_anim 2, 0, 56, 0, -1, 0, 0,
+ax_anim 2, 0, 55, 0, -2, 0, 0,
+ax_anim 2, 0, 56, 0, -3, 0, 0,
+ax_anim 2, 2, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 56, 0, -4, 0, 0,
+ax_anim 2, 0, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 56, 0, -4, 0, 0,
+ax_anim 2, 1, 55, 0, -4, 0, 0,
+ax_anim 2, 0, 56, 0, -4, 0, 0,
+ax_anim 2, 0, 55, 0, -3, 0, 0,
+ax_anim 2, 0, 56, 0, -2, 0, 0,
+ax_anim 2, 0, 55, 0, -1, 0, 0,
+ax_anim 2, 0, 54, 0, -1, 0, 0,
+ax_anim_terminator
+sYanmaAnims_4_4:
+ax_anim 2, 0, 58, 0, 0, 0, 0,
+ax_anim 2, 0, 59, 0, -1, 0, 0,
+ax_anim 2, 0, 58, 0, -2, 0, 0,
+ax_anim 2, 0, 59, 0, -3, 0, 0,
+ax_anim 2, 2, 58, 0, -4, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -4, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 1, 58, 0, -4, 0, 0,
+ax_anim 2, 0, 59, 0, -4, 0, 0,
+ax_anim 2, 0, 58, 0, -3, 0, 0,
+ax_anim 2, 0, 59, 0, -2, 0, 0,
+ax_anim 2, 0, 58, 0, -1, 0, 0,
+ax_anim 2, 0, 57, 0, -1, 0, 0,
+ax_anim_terminator
+sYanmaAnims_4_5:
+ax_anim 2, 0, 61, 0, 0, 0, 0,
+ax_anim 2, 0, 62, 0, -1, 0, 0,
+ax_anim 2, 0, 61, 0, -2, 0, 0,
+ax_anim 2, 0, 62, 0, -3, 0, 0,
+ax_anim 2, 2, 61, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -4, 0, 0,
+ax_anim 2, 0, 61, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -4, 0, 0,
+ax_anim 2, 1, 61, 0, -4, 0, 0,
+ax_anim 2, 0, 62, 0, -4, 0, 0,
+ax_anim 2, 0, 61, 0, -3, 0, 0,
+ax_anim 2, 0, 62, 0, -2, 0, 0,
+ax_anim 2, 0, 61, 0, -1, 0, 0,
+ax_anim 2, 0, 60, 0, -1, 0, 0,
+ax_anim_terminator
+sYanmaAnims_4_6:
+ax_anim 2, 0, 64, 0, 0, 0, 0,
+ax_anim 2, 0, 65, 0, -1, 0, 0,
+ax_anim 2, 0, 64, 0, -2, 0, 0,
+ax_anim 2, 0, 65, 0, -3, 0, 0,
+ax_anim 2, 2, 64, 0, -4, 0, 0,
+ax_anim 2, 0, 65, 0, -4, 0, 0,
+ax_anim 2, 0, 64, 0, -4, 0, 0,
+ax_anim 2, 0, 65, 0, -4, 0, 0,
+ax_anim 2, 1, 64, 0, -4, 0, 0,
+ax_anim 2, 0, 65, 0, -4, 0, 0,
+ax_anim 2, 0, 64, 0, -3, 0, 0,
+ax_anim 2, 0, 65, 0, -2, 0, 0,
+ax_anim 2, 0, 64, 0, -1, 0, 0,
+ax_anim 2, 0, 63, 0, -1, 0, 0,
+ax_anim_terminator
+sYanmaAnims_4_7:
+ax_anim 2, 0, 67, 0, 0, 0, 0,
+ax_anim 2, 0, 68, 0, -1, 0, 0,
+ax_anim 2, 0, 67, 0, -2, 0, 0,
+ax_anim 2, 0, 68, 0, -3, 0, 0,
+ax_anim 2, 2, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 68, 0, -4, 0, 0,
+ax_anim 2, 0, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 68, 0, -4, 0, 0,
+ax_anim 2, 1, 67, 0, -4, 0, 0,
+ax_anim 2, 0, 68, 0, -4, 0, 0,
+ax_anim 2, 0, 67, 0, -3, 0, 0,
+ax_anim 2, 0, 68, 0, -2, 0, 0,
+ax_anim 2, 0, 67, 0, -1, 0, 0,
+ax_anim 2, 0, 66, 0, -1, 0, 0,
+ax_anim_terminator
+sYanmaAnims_4_8:
+ax_anim 2, 0, 70, 0, 0, 0, 0,
+ax_anim 2, 0, 71, 0, -1, 0, 0,
+ax_anim 2, 0, 70, 0, -2, 0, 0,
+ax_anim 2, 0, 71, 0, -3, 0, 0,
+ax_anim 2, 2, 70, 0, -4, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -4, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 1, 70, 0, -4, 0, 0,
+ax_anim 2, 0, 71, 0, -4, 0, 0,
+ax_anim 2, 0, 70, 0, -3, 0, 0,
+ax_anim 2, 0, 71, 0, -2, 0, 0,
+ax_anim 2, 0, 70, 0, -1, 0, 0,
+ax_anim 2, 0, 69, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_5_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 2, 72, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_5_2:
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 2, 79, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_5_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 2, 78, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_5_4:
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 2, 77, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_5_5:
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 2, 76, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_5_6:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 2, 75, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_5_7:
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 2, 74, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_5_8:
+ax_anim 2, 0, 73, 0, 0, 0, 0,
+ax_anim 2, 0, 74, 0, 0, 0, 0,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, 0, 0, 0,
+ax_anim 2, 0, 77, 0, 0, 0, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 0, 0, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 2, 73, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_6_1:
+ax_anim 30, 0, 80, 0, 0, 0, 0,
+ax_anim 35, 0, 81, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_7_1:
+ax_anim 2, 0, 82, 0, -2, 0, -2,
+ax_anim 8, 0, 82, 0, -3, 0, -3,
+ax_anim_terminator
+sYanmaAnims_7_2:
+ax_anim 2, 0, 83, -2, -2, -2, -2,
+ax_anim 8, 0, 83, -3, -3, -3, -3,
+ax_anim_terminator
+sYanmaAnims_7_3:
+ax_anim 2, 0, 84, -2, 0, -2, 0,
+ax_anim 8, 0, 84, -3, 0, -3, 0,
+ax_anim_terminator
+sYanmaAnims_7_4:
+ax_anim 2, 0, 85, -2, 2, -2, 2,
+ax_anim 8, 0, 85, -3, 3, -3, 3,
+ax_anim_terminator
+sYanmaAnims_7_5:
+ax_anim 2, 0, 86, 0, 2, 0, 2,
+ax_anim 8, 0, 86, 0, 3, 0, 3,
+ax_anim_terminator
+sYanmaAnims_7_6:
+ax_anim 2, 0, 87, 2, 2, 2, 2,
+ax_anim 8, 0, 87, 3, 3, 3, 3,
+ax_anim_terminator
+sYanmaAnims_7_7:
+ax_anim 2, 0, 88, 2, 0, 2, 0,
+ax_anim 8, 0, 88, 3, 0, 3, 0,
+ax_anim_terminator
+sYanmaAnims_7_8:
+ax_anim 2, 0, 89, 2, -2, 2, -2,
+ax_anim 8, 0, 89, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sYanmaAnims_8_1:
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim 4, 0, 90, 0, -1, 0, 0,
+ax_anim 4, 0, 91, 0, -1, 0, 0,
+ax_anim 4, 0, 90, 0, -2, 0, 0,
+ax_anim 4, 0, 91, 0, -2, 0, 0,
+ax_anim 4, 0, 90, 0, -2, 0, 0,
+ax_anim 4, 0, 91, 0, -2, 0, 0,
+ax_anim 4, 0, 90, 0, -1, 0, 0,
+ax_anim 4, 0, 91, 0, -1, 0, 0,
+ax_anim 4, 0, 90, 0, 0, 0, 0,
+ax_anim 4, 0, 91, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_8_2:
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim 4, 0, 92, 0, -1, 0, 0,
+ax_anim 4, 0, 93, 0, -1, 0, 0,
+ax_anim 4, 0, 92, 0, -2, 0, 0,
+ax_anim 4, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 0, 92, 0, -2, 0, 0,
+ax_anim 4, 0, 93, 0, -2, 0, 0,
+ax_anim 4, 0, 92, 0, -1, 0, 0,
+ax_anim 4, 0, 93, 0, -1, 0, 0,
+ax_anim 4, 0, 92, 0, 0, 0, 0,
+ax_anim 4, 0, 93, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_8_3:
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim 4, 0, 94, 0, -1, 0, 0,
+ax_anim 4, 0, 95, 0, -1, 0, 0,
+ax_anim 4, 0, 94, 0, -2, 0, 0,
+ax_anim 4, 0, 95, 0, -2, 0, 0,
+ax_anim 4, 0, 94, 0, -2, 0, 0,
+ax_anim 4, 0, 95, 0, -2, 0, 0,
+ax_anim 4, 0, 94, 0, -1, 0, 0,
+ax_anim 4, 0, 95, 0, -1, 0, 0,
+ax_anim 4, 0, 94, 0, 0, 0, 0,
+ax_anim 4, 0, 95, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_8_4:
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim 4, 0, 96, 0, -1, 0, 0,
+ax_anim 4, 0, 97, 0, -1, 0, 0,
+ax_anim 4, 0, 96, 0, -2, 0, 0,
+ax_anim 4, 0, 97, 0, -2, 0, 0,
+ax_anim 4, 0, 96, 0, -2, 0, 0,
+ax_anim 4, 0, 97, 0, -2, 0, 0,
+ax_anim 4, 0, 96, 0, -1, 0, 0,
+ax_anim 4, 0, 97, 0, -1, 0, 0,
+ax_anim 4, 0, 96, 0, 0, 0, 0,
+ax_anim 4, 0, 97, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_8_5:
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim 4, 0, 98, 0, -1, 0, 0,
+ax_anim 4, 0, 99, 0, -1, 0, 0,
+ax_anim 4, 0, 98, 0, -2, 0, 0,
+ax_anim 4, 0, 99, 0, -2, 0, 0,
+ax_anim 4, 0, 98, 0, -2, 0, 0,
+ax_anim 4, 0, 99, 0, -2, 0, 0,
+ax_anim 4, 0, 98, 0, -1, 0, 0,
+ax_anim 4, 0, 99, 0, -1, 0, 0,
+ax_anim 4, 0, 98, 0, 0, 0, 0,
+ax_anim 4, 0, 99, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_8_6:
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim 4, 0, 100, 0, -1, 0, 0,
+ax_anim 4, 0, 101, 0, -1, 0, 0,
+ax_anim 4, 0, 100, 0, -2, 0, 0,
+ax_anim 4, 0, 101, 0, -2, 0, 0,
+ax_anim 4, 0, 100, 0, -2, 0, 0,
+ax_anim 4, 0, 101, 0, -2, 0, 0,
+ax_anim 4, 0, 100, 0, -1, 0, 0,
+ax_anim 4, 0, 101, 0, -1, 0, 0,
+ax_anim 4, 0, 100, 0, 0, 0, 0,
+ax_anim 4, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_8_7:
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim 4, 0, 102, 0, -1, 0, 0,
+ax_anim 4, 0, 103, 0, -1, 0, 0,
+ax_anim 4, 0, 102, 0, -2, 0, 0,
+ax_anim 4, 0, 103, 0, -2, 0, 0,
+ax_anim 4, 0, 102, 0, -2, 0, 0,
+ax_anim 4, 0, 103, 0, -2, 0, 0,
+ax_anim 4, 0, 102, 0, -1, 0, 0,
+ax_anim 4, 0, 103, 0, -1, 0, 0,
+ax_anim 4, 0, 102, 0, 0, 0, 0,
+ax_anim 4, 0, 103, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_8_8:
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim 4, 0, 104, 0, -1, 0, 0,
+ax_anim 4, 0, 105, 0, -1, 0, 0,
+ax_anim 4, 0, 104, 0, -2, 0, 0,
+ax_anim 4, 0, 105, 0, -2, 0, 0,
+ax_anim 4, 0, 104, 0, -2, 0, 0,
+ax_anim 4, 0, 105, 0, -2, 0, 0,
+ax_anim 4, 0, 104, 0, -1, 0, 0,
+ax_anim 4, 0, 105, 0, -1, 0, 0,
+ax_anim 4, 0, 104, 0, 0, 0, 0,
+ax_anim 4, 0, 105, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_9_1:
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim 1, 0, 107, 6, 3, 6, 3,
+ax_anim 2, 0, 108, 8, 11, 8, 11,
+ax_anim 2, 0, 109, 7, 20, 7, 19,
+ax_anim 3, 0, 110, 0, 25, 0, 23,
+ax_anim 2, 3, 111, -7, 20, -7, 19,
+ax_anim 2, 0, 112, -8, 11, -8, 11,
+ax_anim 1, 0, 113, -6, 3, -6, 3,
+ax_anim 1, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_9_2:
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 1, 0, 106, 8, 0, 8, 0,
+ax_anim 2, 0, 107, 17, 6, 17, 6,
+ax_anim 2, 0, 108, 20, 19, 20, 17,
+ax_anim 3, 0, 109, 20, 25, 20, 23,
+ax_anim 2, 3, 110, 11, 26, 11, 24,
+ax_anim 2, 0, 111, 4, 19, 4, 19,
+ax_anim 1, 0, 112, 0, 7, 0, 7,
+ax_anim 1, 0, 113, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_9_3:
+ax_anim 2, 0, 112, 0, 0, 0, 0,
+ax_anim 1, 0, 113, 3, -5, 3, -5,
+ax_anim 2, 0, 106, 11, -6, 11, -6,
+ax_anim 2, 0, 107, 19, -2, 19, -4,
+ax_anim 3, 0, 108, 20, 5, 20, 1,
+ax_anim 2, 3, 109, 18, 11, 18, 8,
+ax_anim 2, 0, 110, 10, 13, 10, 11,
+ax_anim 1, 0, 111, 3, 9, 3, 7,
+ax_anim 1, 0, 112, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_9_4:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 1, 0, 112, -1, -8, -1, -8,
+ax_anim 2, 0, 113, 4, -16, 4, -16,
+ax_anim 2, 0, 106, 12, -22, 12, -24,
+ax_anim 3, 0, 107, 19, -18, 19, -20,
+ax_anim 2, 3, 108, 21, -11, 21, -13,
+ax_anim 2, 0, 109, 17, -4, 17, -5,
+ax_anim 1, 0, 110, 9, 1, 9, 1,
+ax_anim 1, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_9_5:
+ax_anim 2, 0, 110, 0, 0, 0, 0,
+ax_anim 1, 0, 111, -8, -4, -8, -4,
+ax_anim 2, 0, 112, -9, -10, -9, -10,
+ax_anim 2, 0, 113, -7, -16, -7, -18,
+ax_anim 3, 0, 106, 0, -18, 0, -21,
+ax_anim 2, 3, 107, 7, -16, 7, -18,
+ax_anim 2, 0, 108, 9, -10, 9, -10,
+ax_anim 1, 0, 109, 8, -4, 8, -4,
+ax_anim 1, 0, 110, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_9_6:
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 1, 0, 108, 1, -8, 1, -8,
+ax_anim 2, 0, 107, -4, -16, -4, -16,
+ax_anim 2, 0, 106, -12, -22, -12, -24,
+ax_anim 3, 0, 113, -19, -18, -19, -20,
+ax_anim 2, 3, 112, -21, -11, -21, -13,
+ax_anim 2, 0, 111, -17, -4, -17, -5,
+ax_anim 1, 0, 110, -9, -1, -9, -1,
+ax_anim 1, 0, 109, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_9_7:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 1, 0, 107, -3, -5, -3, -5,
+ax_anim 2, 0, 106, -11, -6, -11, -6,
+ax_anim 2, 0, 113, -19, 2, -19, -4,
+ax_anim 3, 0, 112, -20, 5, -20, 1,
+ax_anim 2, 3, 111, -18, 11, -18, 8,
+ax_anim 2, 0, 110, -10, 13, -10, 11,
+ax_anim 1, 0, 109, -3, 9, -3, 7,
+ax_anim 1, 0, 108, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_9_8:
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 1, 0, 106, -8, 0, -8, 0,
+ax_anim 2, 0, 113, -17, 6, -17, 6,
+ax_anim 2, 0, 112, -20, 19, -20, 17,
+ax_anim 3, 0, 111, -20, 25, -20, 23,
+ax_anim 2, 3, 110, -11, 26, -11, 24,
+ax_anim 2, 0, 109, -4, 19, -4, 19,
+ax_anim 1, 0, 108, 0, 7, 0, 7,
+ax_anim 1, 0, 107, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_10_1:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 3, 0, 114, 13, 0, 13, 0,
+ax_anim 3, 0, 114, -13, 0, -13, 0,
+ax_anim 2, 0, 114, 12, 0, 12, 0,
+ax_anim 3, 0, 114, -12, 0, -12, 0,
+ax_anim 2, 0, 114, 10, 0, 10, 0,
+ax_anim 2, 0, 114, -10, 0, -10, 0,
+ax_anim 2, 0, 114, 6, 0, 6, 0,
+ax_anim 2, 0, 114, -6, 0, -6, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_10_2:
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 3, 0, 115, 13, -13, 13, -13,
+ax_anim 3, 0, 115, -13, 13, -13, 13,
+ax_anim 2, 0, 115, 12, -12, 12, -12,
+ax_anim 3, 0, 115, -12, 12, -12, 12,
+ax_anim 2, 0, 115, 10, -10, 10, -10,
+ax_anim 2, 0, 115, -10, 10, -10, 10,
+ax_anim 2, 0, 115, 6, -6, 6, -6,
+ax_anim 2, 0, 115, -6, 6, -6, 6,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_10_3:
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 3, 0, 116, 0, -13, 0, -13,
+ax_anim 3, 0, 116, 0, 13, 0, 13,
+ax_anim 2, 0, 116, 0, -12, 0, -12,
+ax_anim 3, 0, 116, 0, 12, 0, 12,
+ax_anim 2, 0, 116, 0, -10, 0, -10,
+ax_anim 2, 0, 116, 0, 10, 0, 10,
+ax_anim 2, 0, 116, 0, -6, 0, -6,
+ax_anim 2, 0, 116, 0, 6, 0, 6,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_10_4:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 3, 0, 117, -13, -13, -13, -13,
+ax_anim 3, 0, 117, 13, 13, 13, 13,
+ax_anim 2, 0, 117, -12, -12, -12, -12,
+ax_anim 3, 0, 117, 12, 12, 12, 12,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, 10, 10, 10, 10,
+ax_anim 2, 0, 117, -6, -6, -6, -6,
+ax_anim 2, 0, 117, 6, 6, 6, 6,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_10_5:
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 3, 0, 118, 13, 0, 13, 0,
+ax_anim 3, 0, 118, -13, 0, -13, 0,
+ax_anim 2, 0, 118, 12, 0, 12, 0,
+ax_anim 3, 0, 118, -12, 0, -12, 0,
+ax_anim 2, 0, 118, 10, 0, 10, 0,
+ax_anim 2, 0, 118, -10, 0, -10, 0,
+ax_anim 2, 0, 118, 6, 0, 6, 0,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_10_6:
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 3, 0, 119, 13, -13, 13, -13,
+ax_anim 3, 0, 119, -13, 13, -13, 13,
+ax_anim 2, 0, 119, 12, -12, 12, -12,
+ax_anim 3, 0, 119, -12, 12, -12, 12,
+ax_anim 2, 0, 119, 10, -10, 10, -10,
+ax_anim 2, 0, 119, -10, 10, -10, 10,
+ax_anim 2, 0, 119, 6, -6, 6, -6,
+ax_anim 2, 0, 119, -6, 6, -6, 6,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_10_7:
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 3, 0, 120, 0, -13, 0, -13,
+ax_anim 3, 0, 120, 0, 13, 0, 13,
+ax_anim 2, 0, 120, 0, -12, 0, -12,
+ax_anim 3, 0, 120, 0, 12, 0, 12,
+ax_anim 2, 0, 120, 0, -10, 0, -10,
+ax_anim 2, 0, 120, 0, 10, 0, 10,
+ax_anim 2, 0, 120, 0, -6, 0, -6,
+ax_anim 2, 0, 120, 0, 6, 0, 6,
+ax_anim 2, 0, 120, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_10_8:
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 3, 0, 121, -13, -13, -13, -13,
+ax_anim 3, 0, 121, 13, 13, 13, 13,
+ax_anim 2, 0, 121, -12, -12, -12, -12,
+ax_anim 3, 0, 121, 12, 12, 12, 12,
+ax_anim 2, 0, 121, -10, -10, -10, -10,
+ax_anim 2, 0, 121, 10, 10, 10, 10,
+ax_anim 2, 0, 121, -6, -6, -6, -6,
+ax_anim 2, 0, 121, 6, 6, 6, 6,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_11_1:
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, -10, 0, 0,
+ax_anim 2, 0, 123, 0, -16, 0, 0,
+ax_anim 3, 0, 124, 0, -20, 0, 0,
+ax_anim 4, 0, 123, 0, -21, 0, 0,
+ax_anim 4, 0, 124, 0, -22, 0, 0,
+ax_anim 3, 0, 123, 0, -21, 0, 0,
+ax_anim 2, 0, 124, 0, -18, 0, 0,
+ax_anim 1, 0, 123, 0, -12, 0, 0,
+ax_anim 2, 2, 124, 0, 5, 0, 0,
+ax_anim_terminator
+sYanmaAnims_11_2:
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, -10, 0, 0,
+ax_anim 2, 0, 125, 0, -16, 0, 0,
+ax_anim 3, 0, 126, 0, -20, 0, 0,
+ax_anim 4, 0, 125, 0, -21, 0, 0,
+ax_anim 4, 0, 126, 0, -22, 0, 0,
+ax_anim 3, 0, 125, 0, -21, 0, 0,
+ax_anim 2, 0, 126, 0, -18, 0, 0,
+ax_anim 1, 0, 125, 0, -12, 0, 0,
+ax_anim 2, 2, 126, 0, 5, 0, 0,
+ax_anim_terminator
+sYanmaAnims_11_3:
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -10, 0, 0,
+ax_anim 2, 0, 127, 0, -16, 0, 0,
+ax_anim 3, 0, 128, 0, -20, 0, 0,
+ax_anim 4, 0, 127, 0, -21, 0, 0,
+ax_anim 4, 0, 128, 0, -22, 0, 0,
+ax_anim 3, 0, 127, 0, -21, 0, 0,
+ax_anim 2, 0, 128, 0, -18, 0, 0,
+ax_anim 1, 0, 127, 0, -12, 0, 0,
+ax_anim 2, 2, 128, 0, 7, 0, 0,
+ax_anim_terminator
+sYanmaAnims_11_4:
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -10, 0, 0,
+ax_anim 2, 0, 129, 0, -16, 0, 0,
+ax_anim 3, 0, 130, 0, -20, 0, 0,
+ax_anim 4, 0, 129, 0, -21, 0, 0,
+ax_anim 4, 0, 130, 0, -22, 0, 0,
+ax_anim 3, 0, 129, 0, -21, 0, 0,
+ax_anim 2, 0, 130, 0, -17, 0, 0,
+ax_anim 1, 0, 129, 0, -11, 0, 0,
+ax_anim 2, 2, 130, 0, 7, 0, 0,
+ax_anim_terminator
+sYanmaAnims_11_5:
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -10, 0, 0,
+ax_anim 2, 0, 131, 0, -16, 0, 0,
+ax_anim 3, 0, 132, 0, -20, 0, 0,
+ax_anim 4, 0, 131, 0, -21, 0, 0,
+ax_anim 4, 0, 132, 0, -22, 0, 0,
+ax_anim 3, 0, 131, 0, -21, 0, 0,
+ax_anim 2, 0, 132, 0, -18, 0, 0,
+ax_anim 1, 0, 131, 0, -12, 0, 0,
+ax_anim 2, 2, 132, 0, 8, 0, 0,
+ax_anim_terminator
+sYanmaAnims_11_6:
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -10, 0, 0,
+ax_anim 2, 0, 133, 0, -16, 0, 0,
+ax_anim 3, 0, 134, 0, -20, 0, 0,
+ax_anim 4, 0, 133, 0, -21, 0, 0,
+ax_anim 4, 0, 134, 0, -22, 0, 0,
+ax_anim 3, 0, 133, 0, -21, 0, 0,
+ax_anim 2, 0, 134, 0, -17, 0, 0,
+ax_anim 1, 0, 133, 0, -11, 0, 0,
+ax_anim 2, 2, 134, 0, 7, 0, 0,
+ax_anim_terminator
+sYanmaAnims_11_7:
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 1, 0, 136, 0, -10, 0, 0,
+ax_anim 2, 0, 135, 0, -16, 0, 0,
+ax_anim 3, 0, 136, 0, -20, 0, 0,
+ax_anim 4, 0, 135, 0, -21, 0, 0,
+ax_anim 4, 0, 136, 0, -22, 0, 0,
+ax_anim 3, 0, 135, 0, -21, 0, 0,
+ax_anim 2, 0, 136, 0, -18, 0, 0,
+ax_anim 1, 0, 135, 0, -12, 0, 0,
+ax_anim 2, 2, 136, 0, 7, 0, 0,
+ax_anim_terminator
+sYanmaAnims_11_8:
+ax_anim 2, 0, 137, 0, 0, 0, 0,
+ax_anim 1, 0, 138, 0, -10, 0, 0,
+ax_anim 2, 0, 137, 0, -16, 0, 0,
+ax_anim 3, 0, 138, 0, -20, 0, 0,
+ax_anim 4, 0, 137, 0, -21, 0, 0,
+ax_anim 4, 0, 138, 0, -22, 0, 0,
+ax_anim 3, 0, 137, 0, -21, 0, 0,
+ax_anim 2, 0, 138, 0, -18, 0, 0,
+ax_anim 1, 0, 137, 0, -12, 0, 0,
+ax_anim 2, 2, 138, 0, 5, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_12_1:
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 2, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 0, 139, 0, 0, 0, 0,
+ax_anim 2, 0, 139, 1, 0, 1, 0,
+ax_anim 2, 1, 139, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_12_2:
+ax_anim 2, 0, 146, 1, -1, 1, -1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, -1, 1, -1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, -1, 1, -1,
+ax_anim 2, 2, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, -1, 1, -1,
+ax_anim 2, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 146, 1, -1, 1, -1,
+ax_anim 2, 1, 146, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_12_3:
+ax_anim 2, 0, 145, 0, -1, 0, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -1, 0, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -1, 0, -1,
+ax_anim 2, 2, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -1, 0, -1,
+ax_anim 2, 0, 145, 0, 0, 0, 0,
+ax_anim 2, 0, 145, 0, -1, 0, -1,
+ax_anim 2, 1, 145, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_12_4:
+ax_anim 2, 0, 144, -1, -1, -1, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, -1, -1, -1, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, -1, -1, -1, -1,
+ax_anim 2, 2, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, -1, -1, -1, -1,
+ax_anim 2, 0, 144, 0, 0, 0, 0,
+ax_anim 2, 0, 144, -1, -1, -1, -1,
+ax_anim 2, 1, 144, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_12_5:
+ax_anim 2, 0, 143, 1, 0, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 0, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 0, 1, 0,
+ax_anim 2, 2, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 0, 1, 0,
+ax_anim 2, 0, 143, 0, 0, 0, 0,
+ax_anim 2, 0, 143, 1, 0, 1, 0,
+ax_anim 2, 1, 143, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_12_6:
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 2, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 0, 142, 0, 0, 0, 0,
+ax_anim 2, 0, 142, 1, -1, 1, -1,
+ax_anim 2, 1, 142, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_12_7:
+ax_anim 2, 0, 141, 0, -1, 0, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, -1,
+ax_anim 2, 2, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, -1,
+ax_anim 2, 0, 141, 0, 0, 0, 0,
+ax_anim 2, 0, 141, 0, -1, 0, -1,
+ax_anim 2, 1, 141, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_12_8:
+ax_anim 2, 0, 140, -1, -1, -1, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, -1, -1, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, -1, -1, -1,
+ax_anim 2, 2, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, -1, -1, -1,
+ax_anim 2, 0, 140, 0, 0, 0, 0,
+ax_anim 2, 0, 140, -1, -1, -1, -1,
+ax_anim 2, 1, 140, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sYanmaAnims_13_1:
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 2, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_13_2:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 2, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_13_3:
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 2, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_13_4:
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 2, 152, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_13_5:
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 2, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_13_6:
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 2, 150, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_13_7:
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 2, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaAnims_13_8:
+ax_anim 2, 0, 148, 0, 0, 0, 0,
+ax_anim 2, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, 0, 0, 0, 0,
+ax_anim 2, 0, 151, 0, 0, 0, 0,
+ax_anim 2, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, 0, 0, 0, 0,
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, 0, 0, 0,
+ax_anim 2, 2, 148, 0, 0, 0, 0,
+ax_anim_terminator
+sYanmaGfx1:
+.incbin "baserom.gba", 0xD4CCEC, 0x200
+sYanmaSprites1:
+ax_sprite sYanmaGfx1, 0x200
+ax_sprite_terminator
+sYanmaGfx2:
+.incbin "baserom.gba", 0xD4CEFC, 0x200
+sYanmaSprites2:
+ax_sprite sYanmaGfx2, 0x200
+ax_sprite_terminator
+sYanmaGfx3:
+.incbin "baserom.gba", 0xD4D10C, 0x200
+sYanmaSprites3:
+ax_sprite sYanmaGfx3, 0x200
+ax_sprite_terminator
+sYanmaGfx4:
+.incbin "baserom.gba", 0xD4D31C, 0x200
+sYanmaSprites4:
+ax_sprite sYanmaGfx4, 0x200
+ax_sprite_terminator
+sYanmaGfx5:
+.incbin "baserom.gba", 0xD4D52C, 0x200
+sYanmaSprites5:
+ax_sprite sYanmaGfx5, 0x200
+ax_sprite_terminator
+sYanmaGfx6:
+.incbin "baserom.gba", 0xD4D73C, 0x200
+sYanmaSprites6:
+ax_sprite sYanmaGfx6, 0x200
+ax_sprite_terminator
+sYanmaGfx7:
+.incbin "baserom.gba", 0xD4D94C, 0x200
+sYanmaSprites7:
+ax_sprite sYanmaGfx7, 0x200
+ax_sprite_terminator
+sYanmaGfx8:
+.incbin "baserom.gba", 0xD4DB5C, 0x200
+sYanmaSprites8:
+ax_sprite sYanmaGfx8, 0x200
+ax_sprite_terminator
+sYanmaGfx9:
+.incbin "baserom.gba", 0xD4DD6C, 0x200
+sYanmaSprites9:
+ax_sprite sYanmaGfx9, 0x200
+ax_sprite_terminator
+sYanmaGfx10:
+.incbin "baserom.gba", 0xD4DF7C, 0x200
+sYanmaSprites10:
+ax_sprite sYanmaGfx10, 0x200
+ax_sprite_terminator
+sYanmaGfx11:
+.incbin "baserom.gba", 0xD4E18C, 0x40
+sYanmaGfx11_1:
+.incbin "baserom.gba", 0xD4E1CC, 0x60
+sYanmaGfx11_2:
+.incbin "baserom.gba", 0xD4E22C, 0x60
+sYanmaSprites11:
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx11, 0x40
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx11_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx11_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sYanmaGfx12:
+.incbin "baserom.gba", 0xD4E2CC, 0x40
+sYanmaGfx12_1:
+.incbin "baserom.gba", 0xD4E30C, 0x60
+sYanmaGfx12_2:
+.incbin "baserom.gba", 0xD4E36C, 0x60
+sYanmaSprites12:
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx12, 0x40
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx12_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx12_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sYanmaGfx13:
+.incbin "baserom.gba", 0xD4E40C, 0x60
+sYanmaGfx13_1:
+.incbin "baserom.gba", 0xD4E46C, 0x60
+sYanmaGfx13_2:
+.incbin "baserom.gba", 0xD4E4CC, 0x40
+sYanmaSprites13:
+ax_sprite sYanmaGfx13, 0x60
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx13_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx13_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sYanmaGfx14:
+.incbin "baserom.gba", 0xD4E544, 0x60
+sYanmaGfx14_1:
+.incbin "baserom.gba", 0xD4E5A4, 0x60
+sYanmaGfx14_2:
+.incbin "baserom.gba", 0xD4E604, 0x40
+sYanmaSprites14:
+ax_sprite sYanmaGfx14, 0x60
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx14_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx14_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sYanmaGfx15:
+.incbin "baserom.gba", 0xD4E67C, 0xC0
+sYanmaSprites15:
+ax_sprite sYanmaGfx15, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sYanmaGfx16:
+.incbin "baserom.gba", 0xD4E754, 0xC0
+sYanmaSprites16:
+ax_sprite sYanmaGfx16, 0xc0
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sYanmaGfx17:
+.incbin "baserom.gba", 0xD4E82C, 0x40
+sYanmaGfx17_1:
+.incbin "baserom.gba", 0xD4E86C, 0x40
+sYanmaGfx17_2:
+.incbin "baserom.gba", 0xD4E8AC, 0x20
+sYanmaSprites17:
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx17_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx17_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sYanmaGfx18:
+.incbin "baserom.gba", 0xD4E90C, 0x40
+sYanmaGfx18_1:
+.incbin "baserom.gba", 0xD4E94C, 0x40
+sYanmaGfx18_2:
+.incbin "baserom.gba", 0xD4E98C, 0x20
+sYanmaSprites18:
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx18, 0x40
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx18_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx18_2, 0x20
+ax_sprite 0, 0xc0
+ax_sprite_terminator
+sYanmaGfx19:
+.incbin "baserom.gba", 0xD4E9EC, 0x60
+sYanmaGfx19_1:
+.incbin "baserom.gba", 0xD4EA4C, 0x60
+sYanmaGfx19_2:
+.incbin "baserom.gba", 0xD4EAAC, 0x40
+sYanmaSprites19:
+ax_sprite sYanmaGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx19_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx19_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sYanmaGfx20:
+.incbin "baserom.gba", 0xD4EB24, 0x60
+sYanmaGfx20_1:
+.incbin "baserom.gba", 0xD4EB84, 0x60
+sYanmaGfx20_2:
+.incbin "baserom.gba", 0xD4EBE4, 0x40
+sYanmaSprites20:
+ax_sprite sYanmaGfx20, 0x60
+ax_sprite 0, 0x20
+ax_sprite sYanmaGfx20_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sYanmaGfx20_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sYanmaGfx21:
+.incbin "baserom.gba", 0xD4EC5C, 0x200
+sYanmaSprites21:
+ax_sprite sYanmaGfx21, 0x200
+ax_sprite_terminator
+sYanmaGfx22:
+.incbin "baserom.gba", 0xD4EE6C, 0x200
+sYanmaSprites22:
+ax_sprite sYanmaGfx22, 0x200
+ax_sprite_terminator
+sYanmaGfx23:
+.incbin "baserom.gba", 0xD4F07C, 0x200
+sYanmaSprites23:
+ax_sprite sYanmaGfx23, 0x200
+ax_sprite_terminator
+sYanmaGfx24:
+.incbin "baserom.gba", 0xD4F28C, 0x200
+sYanmaSprites24:
+ax_sprite sYanmaGfx24, 0x200
+ax_sprite_terminator
+sYanmaGfx25:
+.incbin "baserom.gba", 0xD4F49C, 0x200
+sYanmaSprites25:
+ax_sprite sYanmaGfx25, 0x200
+ax_sprite_terminator
+sYanmaGfx26:
+.incbin "baserom.gba", 0xD4F6AC, 0x200
+sYanmaSprites26:
+ax_sprite sYanmaGfx26, 0x200
+ax_sprite_terminator
+sYanmaGfx27:
+.incbin "baserom.gba", 0xD4F8BC, 0x200
+sYanmaSprites27:
+ax_sprite sYanmaGfx27, 0x200
+ax_sprite_terminator
+sAxPosesYanma:
+.4byte sYanmaPose1
+.4byte sYanmaPose2
+.4byte sYanmaPose3
+.4byte sYanmaPose4
+.4byte sYanmaPose5
+.4byte sYanmaPose6
+.4byte sYanmaPose7
+.4byte sYanmaPose8
+.4byte sYanmaPose9
+.4byte sYanmaPose10
+.4byte sYanmaPose11
+.4byte sYanmaPose12
+.4byte sYanmaPose13
+.4byte sYanmaPose14
+.4byte sYanmaPose15
+.4byte sYanmaPose16
+.4byte sYanmaPose17
+.4byte sYanmaPose18
+.4byte sYanmaPose19
+.4byte sYanmaPose20
+.4byte sYanmaPose21
+.4byte sYanmaPose22
+.4byte sYanmaPose23
+.4byte sYanmaPose24
+.4byte sYanmaPose25
+.4byte sYanmaPose26
+.4byte sYanmaPose27
+.4byte sYanmaPose28
+.4byte sYanmaPose29
+.4byte sYanmaPose30
+.4byte sYanmaPose31
+.4byte sYanmaPose32
+.4byte sYanmaPose33
+.4byte sYanmaPose34
+.4byte sYanmaPose35
+.4byte sYanmaPose36
+.4byte sYanmaPose37
+.4byte sYanmaPose38
+.4byte sYanmaPose39
+.4byte sYanmaPose40
+.4byte sYanmaPose41
+.4byte sYanmaPose42
+.4byte sYanmaPose43
+.4byte sYanmaPose44
+.4byte sYanmaPose45
+.4byte sYanmaPose46
+.4byte sYanmaPose47
+.4byte sYanmaPose48
+.4byte sYanmaPose49
+.4byte sYanmaPose50
+.4byte sYanmaPose51
+.4byte sYanmaPose52
+.4byte sYanmaPose53
+.4byte sYanmaPose54
+.4byte sYanmaPose55
+.4byte sYanmaPose56
+.4byte sYanmaPose57
+.4byte sYanmaPose58
+.4byte sYanmaPose59
+.4byte sYanmaPose60
+.4byte sYanmaPose61
+.4byte sYanmaPose62
+.4byte sYanmaPose63
+.4byte sYanmaPose64
+.4byte sYanmaPose65
+.4byte sYanmaPose66
+.4byte sYanmaPose67
+.4byte sYanmaPose68
+.4byte sYanmaPose69
+.4byte sYanmaPose70
+.4byte sYanmaPose71
+.4byte sYanmaPose72
+.4byte sYanmaPose73
+.4byte sYanmaPose74
+.4byte sYanmaPose75
+.4byte sYanmaPose76
+.4byte sYanmaPose77
+.4byte sYanmaPose78
+.4byte sYanmaPose79
+.4byte sYanmaPose80
+.4byte sYanmaPose81
+.4byte sYanmaPose82
+.4byte sYanmaPose83
+.4byte sYanmaPose84
+.4byte sYanmaPose85
+.4byte sYanmaPose86
+.4byte sYanmaPose87
+.4byte sYanmaPose88
+.4byte sYanmaPose89
+.4byte sYanmaPose90
+.4byte sYanmaPose91
+.4byte sYanmaPose92
+.4byte sYanmaPose93
+.4byte sYanmaPose94
+.4byte sYanmaPose95
+.4byte sYanmaPose96
+.4byte sYanmaPose97
+.4byte sYanmaPose98
+.4byte sYanmaPose99
+.4byte sYanmaPose100
+.4byte sYanmaPose101
+.4byte sYanmaPose102
+.4byte sYanmaPose103
+.4byte sYanmaPose104
+.4byte sYanmaPose105
+.4byte sYanmaPose106
+.4byte sYanmaPose107
+.4byte sYanmaPose108
+.4byte sYanmaPose109
+.4byte sYanmaPose110
+.4byte sYanmaPose111
+.4byte sYanmaPose112
+.4byte sYanmaPose113
+.4byte sYanmaPose114
+.4byte sYanmaPose115
+.4byte sYanmaPose116
+.4byte sYanmaPose117
+.4byte sYanmaPose118
+.4byte sYanmaPose119
+.4byte sYanmaPose120
+.4byte sYanmaPose121
+.4byte sYanmaPose122
+.4byte sYanmaPose123
+.4byte sYanmaPose124
+.4byte sYanmaPose125
+.4byte sYanmaPose126
+.4byte sYanmaPose127
+.4byte sYanmaPose128
+.4byte sYanmaPose129
+.4byte sYanmaPose130
+.4byte sYanmaPose131
+.4byte sYanmaPose132
+.4byte sYanmaPose133
+.4byte sYanmaPose134
+.4byte sYanmaPose135
+.4byte sYanmaPose136
+.4byte sYanmaPose137
+.4byte sYanmaPose138
+.4byte sYanmaPose139
+.4byte sYanmaPose140
+.4byte sYanmaPose141
+.4byte sYanmaPose142
+.4byte sYanmaPose143
+.4byte sYanmaPose144
+.4byte sYanmaPose145
+.4byte sYanmaPose146
+.4byte sYanmaPose147
+.4byte sYanmaPose148
+.4byte sYanmaPose149
+.4byte sYanmaPose150
+.4byte sYanmaPose151
+.4byte sYanmaPose152
+.4byte sYanmaPose153
+.4byte sYanmaPose154
+.4byte sYanmaPose155
+sAxPositionsYanma:
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   1,  -10
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    9,  -10, 	   2,  -14, 	   2,   -7, 	   1,  -11
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    0,  -16, 	   5,  -13, 	  -4,  -13, 	   0,  -12
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -5,  -10, 	   0,  -11
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte  -10,  -10, 	  -3,  -14, 	  -3,   -7, 	  -2,  -11
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -2,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   1,  -10
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    9,  -10, 	   2,  -14, 	   2,   -7, 	   1,  -11
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    0,  -16, 	   5,  -13, 	  -4,  -13, 	   0,  -12
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -5,  -10, 	   0,  -11
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte  -10,  -10, 	  -3,  -14, 	  -3,   -7, 	  -2,  -11
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -2,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   1,  -10
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    9,  -10, 	   2,  -14, 	   2,   -7, 	   1,  -11
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    0,  -16, 	   5,  -13, 	  -4,  -13, 	   0,  -12
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -5,  -10, 	   0,  -11
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte  -10,  -10, 	  -3,  -14, 	  -3,   -7, 	  -2,  -11
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -2,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    0,  -15, 	  -5,  -13, 	   5,  -13, 	   0,  -12
+.2byte    0,  -15, 	  -5,  -13, 	   5,  -13, 	   0,  -12
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    2,  -19, 	   4,  -18, 	  -3,  -15, 	   0,  -15
+.2byte    2,  -19, 	   4,  -18, 	  -3,  -15, 	  -1,  -15
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    3,  -16, 	   1,  -15, 	   3,  -13, 	  -1,  -13
+.2byte    3,  -16, 	   2,  -15, 	   3,  -13, 	  -1,  -13
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    0,  -17, 	  -3,  -19, 	   1,  -13, 	  -2,  -15
+.2byte    0,  -17, 	  -3,  -19, 	   1,  -13, 	  -3,  -15
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    0,  -16, 	   5,  -15, 	  -5,  -15, 	   0,  -13
+.2byte    0,  -15, 	   5,  -15, 	  -5,  -15, 	   0,  -13
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte   -1,  -17, 	   2,  -19, 	  -2,  -13, 	   1,  -15
+.2byte   -1,  -17, 	   2,  -19, 	  -2,  -13, 	   2,  -15
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte   -4,  -16, 	  -2,  -15, 	  -4,  -13, 	   0,  -13
+.2byte   -4,  -16, 	  -3,  -15, 	  -4,  -13, 	   0,  -13
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte   -3,  -19, 	  -5,  -18, 	   2,  -15, 	  -1,  -15
+.2byte   -3,  -19, 	  -5,  -18, 	   2,  -15, 	   0,  -15
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte   -6,    2, 	  -7,   -4, 	   0,    0, 	  -3,   -4
+.2byte   -6,    3, 	  -7,   -4, 	   0,    0, 	  -3,   -4
+.2byte    0,  -15, 	  -5,  -16, 	   5,  -17, 	   1,  -12
+.2byte    2,  -16, 	   4,  -13, 	  -3,  -12, 	  -1,  -12
+.2byte    2,  -17, 	   3,  -15, 	   3,  -13, 	  -2,  -13
+.2byte    0,  -17, 	  -3,  -16, 	   2,  -12, 	  -3,  -12
+.2byte    0,  -17, 	   4,  -12, 	  -5,  -13, 	   0,  -11
+.2byte   -1,  -17, 	   2,  -16, 	  -3,  -12, 	   2,  -12
+.2byte   -3,  -16, 	  -4,  -14, 	  -4,  -12, 	   1,  -12
+.2byte   -3,  -16, 	  -5,  -13, 	   2,  -12, 	   0,  -12
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   1,  -10
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    9,  -10, 	   2,  -14, 	   2,   -7, 	   1,  -11
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    0,  -16, 	   5,  -13, 	  -4,  -13, 	   0,  -12
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -5,  -10, 	   0,  -11
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte  -10,  -10, 	  -3,  -14, 	  -3,   -7, 	  -2,  -11
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -2,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    0,  -15, 	  -5,  -13, 	   5,  -13, 	   0,  -12
+.2byte    2,  -16, 	   4,  -15, 	  -3,  -12, 	   0,  -12
+.2byte    4,  -16, 	   2,  -15, 	   4,  -13, 	   0,  -13
+.2byte    1,  -15, 	  -2,  -17, 	   2,  -11, 	  -1,  -13
+.2byte    0,  -16, 	   5,  -15, 	  -5,  -15, 	   0,  -13
+.2byte   -1,  -15, 	   2,  -17, 	  -2,  -11, 	   1,  -13
+.2byte   -4,  -16, 	  -2,  -15, 	  -4,  -13, 	   0,  -13
+.2byte   -2,  -16, 	  -4,  -15, 	   3,  -12, 	   0,  -12
+.2byte    0,  -15, 	  -5,  -13, 	   5,  -13, 	   0,  -12
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   1,  -10
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    9,  -10, 	   2,  -14, 	   2,   -7, 	   1,  -11
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    6,  -13, 	  -3,  -14, 	   4,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    0,  -16, 	   5,  -13, 	  -4,  -13, 	   0,  -12
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte   -7,  -13, 	   2,  -14, 	  -5,  -10, 	   0,  -11
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte  -10,  -10, 	  -3,  -14, 	  -3,   -7, 	  -2,  -11
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -2,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+.2byte    0,   -3, 	  -6,   -6, 	   6,   -6, 	   0,  -10
+.2byte   -8,   -5, 	  -8,  -10, 	   0,   -5, 	  -1,  -10
+.2byte  -10,  -10, 	  -4,  -13, 	  -4,   -8, 	  -2,  -11
+.2byte   -7,  -13, 	   1,  -14, 	  -5,  -10, 	  -1,  -11
+.2byte    0,  -16, 	   5,  -14, 	  -5,  -14, 	   0,  -13
+.2byte    6,  -13, 	  -2,  -14, 	   4,  -10, 	   0,  -11
+.2byte    9,  -10, 	   3,  -13, 	   3,   -8, 	   1,  -11
+.2byte    7,   -5, 	   7,  -10, 	  -1,   -5, 	   0,  -10
+sYanmaAnimTable1:
+.4byte sYanmaAnims_1_1
+.4byte sYanmaAnims_1_2
+.4byte sYanmaAnims_1_3
+.4byte sYanmaAnims_1_4
+.4byte sYanmaAnims_1_5
+.4byte sYanmaAnims_1_6
+.4byte sYanmaAnims_1_7
+.4byte sYanmaAnims_1_8
+sYanmaAnimTable2:
+.4byte sYanmaAnims_2_1
+.4byte sYanmaAnims_2_2
+.4byte sYanmaAnims_2_3
+.4byte sYanmaAnims_2_4
+.4byte sYanmaAnims_2_5
+.4byte sYanmaAnims_2_6
+.4byte sYanmaAnims_2_7
+.4byte sYanmaAnims_2_8
+sYanmaAnimTable3:
+.4byte sYanmaAnims_3_1
+.4byte sYanmaAnims_3_2
+.4byte sYanmaAnims_3_3
+.4byte sYanmaAnims_3_4
+.4byte sYanmaAnims_3_5
+.4byte sYanmaAnims_3_6
+.4byte sYanmaAnims_3_7
+.4byte sYanmaAnims_3_8
+sYanmaAnimTable4:
+.4byte sYanmaAnims_4_1
+.4byte sYanmaAnims_4_2
+.4byte sYanmaAnims_4_3
+.4byte sYanmaAnims_4_4
+.4byte sYanmaAnims_4_5
+.4byte sYanmaAnims_4_6
+.4byte sYanmaAnims_4_7
+.4byte sYanmaAnims_4_8
+sYanmaAnimTable5:
+.4byte sYanmaAnims_5_1
+.4byte sYanmaAnims_5_2
+.4byte sYanmaAnims_5_3
+.4byte sYanmaAnims_5_4
+.4byte sYanmaAnims_5_5
+.4byte sYanmaAnims_5_6
+.4byte sYanmaAnims_5_7
+.4byte sYanmaAnims_5_8
+sYanmaAnimTable6:
+.4byte sYanmaAnims_6_1
+.4byte sYanmaAnims_6_1
+.4byte sYanmaAnims_6_1
+.4byte sYanmaAnims_6_1
+.4byte sYanmaAnims_6_1
+.4byte sYanmaAnims_6_1
+.4byte sYanmaAnims_6_1
+.4byte sYanmaAnims_6_1
+sYanmaAnimTable7:
+.4byte sYanmaAnims_7_1
+.4byte sYanmaAnims_7_2
+.4byte sYanmaAnims_7_3
+.4byte sYanmaAnims_7_4
+.4byte sYanmaAnims_7_5
+.4byte sYanmaAnims_7_6
+.4byte sYanmaAnims_7_7
+.4byte sYanmaAnims_7_8
+sYanmaAnimTable8:
+.4byte sYanmaAnims_8_1
+.4byte sYanmaAnims_8_2
+.4byte sYanmaAnims_8_3
+.4byte sYanmaAnims_8_4
+.4byte sYanmaAnims_8_5
+.4byte sYanmaAnims_8_6
+.4byte sYanmaAnims_8_7
+.4byte sYanmaAnims_8_8
+sYanmaAnimTable9:
+.4byte sYanmaAnims_9_1
+.4byte sYanmaAnims_9_2
+.4byte sYanmaAnims_9_3
+.4byte sYanmaAnims_9_4
+.4byte sYanmaAnims_9_5
+.4byte sYanmaAnims_9_6
+.4byte sYanmaAnims_9_7
+.4byte sYanmaAnims_9_8
+sYanmaAnimTable10:
+.4byte sYanmaAnims_10_1
+.4byte sYanmaAnims_10_2
+.4byte sYanmaAnims_10_3
+.4byte sYanmaAnims_10_4
+.4byte sYanmaAnims_10_5
+.4byte sYanmaAnims_10_6
+.4byte sYanmaAnims_10_7
+.4byte sYanmaAnims_10_8
+sYanmaAnimTable11:
+.4byte sYanmaAnims_11_1
+.4byte sYanmaAnims_11_2
+.4byte sYanmaAnims_11_3
+.4byte sYanmaAnims_11_4
+.4byte sYanmaAnims_11_5
+.4byte sYanmaAnims_11_6
+.4byte sYanmaAnims_11_7
+.4byte sYanmaAnims_11_8
+sYanmaAnimTable12:
+.4byte sYanmaAnims_12_1
+.4byte sYanmaAnims_12_2
+.4byte sYanmaAnims_12_3
+.4byte sYanmaAnims_12_4
+.4byte sYanmaAnims_12_5
+.4byte sYanmaAnims_12_6
+.4byte sYanmaAnims_12_7
+.4byte sYanmaAnims_12_8
+sYanmaAnimTable13:
+.4byte sYanmaAnims_13_1
+.4byte sYanmaAnims_13_2
+.4byte sYanmaAnims_13_3
+.4byte sYanmaAnims_13_4
+.4byte sYanmaAnims_13_5
+.4byte sYanmaAnims_13_6
+.4byte sYanmaAnims_13_7
+.4byte sYanmaAnims_13_8
+sAxAnimationsYanma:
+.4byte sYanmaAnimTable1
+.4byte sYanmaAnimTable2
+.4byte sYanmaAnimTable3
+.4byte sYanmaAnimTable4
+.4byte sYanmaAnimTable5
+.4byte sYanmaAnimTable6
+.4byte sYanmaAnimTable7
+.4byte sYanmaAnimTable8
+.4byte sYanmaAnimTable9
+.4byte sYanmaAnimTable10
+.4byte sYanmaAnimTable11
+.4byte sYanmaAnimTable12
+.4byte sYanmaAnimTable13
+sAxSpritesYanma:
+.4byte sYanmaSprites1
+.4byte sYanmaSprites2
+.4byte sYanmaSprites3
+.4byte sYanmaSprites4
+.4byte sYanmaSprites5
+.4byte sYanmaSprites6
+.4byte sYanmaSprites7
+.4byte sYanmaSprites8
+.4byte sYanmaSprites9
+.4byte sYanmaSprites10
+.4byte sYanmaSprites11
+.4byte sYanmaSprites12
+.4byte sYanmaSprites13
+.4byte sYanmaSprites14
+.4byte sYanmaSprites15
+.4byte sYanmaSprites16
+.4byte sYanmaSprites17
+.4byte sYanmaSprites18
+.4byte sYanmaSprites19
+.4byte sYanmaSprites20
+.4byte sYanmaSprites21
+.4byte sYanmaSprites22
+.4byte sYanmaSprites23
+.4byte sYanmaSprites24
+.4byte sYanmaSprites25
+.4byte sYanmaSprites26
+.4byte sYanmaSprites27
+sAxMainYanma:
+ax_main sAxPosesYanma, sAxAnimationsYanma, 13, sAxSpritesYanma, sAxPositionsYanma

--- a/data/ax/zangoose.inc
+++ b/data/ax/zangoose.inc
@@ -1,0 +1,3200 @@
+.global gAxZangoose
+gAxZangoose:
+ax_siro sAxMainZangoose
+sZangoosePose1:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose2:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose3:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose4:
+ax_pose 3, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose5:
+ax_pose 4, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose6:
+ax_pose 5, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose7:
+ax_pose 6, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose8:
+ax_pose 7, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose9:
+ax_pose 8, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose10:
+ax_pose 9, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose11:
+ax_pose 10, 0x01e8, 0x80ed, 0x5c00
+ax_pose_terminator
+sZangoosePose12:
+ax_pose 11, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose13:
+ax_pose 12, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose14:
+ax_pose 13, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose15:
+ax_pose 14, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose16:
+ax_pose 15, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose17:
+ax_pose 16, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose18:
+ax_pose 17, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose19:
+ax_pose 18, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose20:
+ax_pose 19, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose21:
+ax_pose 20, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose22:
+ax_pose 21, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose23:
+ax_pose 22, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose24:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose25:
+ax_pose 0, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose26:
+ax_pose 1, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose27:
+ax_pose 2, 0x01e7, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose28:
+ax_pose 24, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose29:
+ax_pose 3, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose30:
+ax_pose 4, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose31:
+ax_pose 5, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose32:
+ax_pose 25, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose33:
+ax_pose 6, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose34:
+ax_pose 7, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose35:
+ax_pose 8, 0x01e5, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose36:
+ax_pose 26, 0x41ed, 0x80ef, 0x5c00
+ax_pose 27, 0x41fd, 0x40ef, 0x5c08
+ax_pose 28, 0x01f5, 0x00e7, 0x5c0c
+ax_pose_terminator
+sZangoosePose37:
+ax_pose 9, 0x01e6, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose38:
+ax_pose 10, 0x01e8, 0x80ed, 0x5c00
+ax_pose_terminator
+sZangoosePose39:
+ax_pose 11, 0x01e8, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose40:
+ax_pose 29, 0x01e8, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose41:
+ax_pose 12, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose42:
+ax_pose 13, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose43:
+ax_pose 14, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose44:
+ax_pose 30, 0x01e6, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose45:
+ax_pose 15, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose46:
+ax_pose 16, 0x01e8, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose47:
+ax_pose 17, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose48:
+ax_pose 31, 0x01e8, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose49:
+ax_pose 18, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose50:
+ax_pose 19, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose51:
+ax_pose 20, 0x01ec, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose52:
+ax_pose 32, 0x41ed, 0x80f1, 0x5c00
+ax_pose 33, 0x41fd, 0x40f1, 0x5c08
+ax_pose 34, 0x01f5, 0x0111, 0x5c0c
+ax_pose_terminator
+sZangoosePose53:
+ax_pose 21, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose54:
+ax_pose 22, 0x01ed, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose55:
+ax_pose 23, 0x01e8, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose56:
+ax_pose 35, 0x01e7, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose57:
+ax_pose 36, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose58:
+ax_pose 37, 0x01e9, 0x80ee, 0x5c00
+ax_pose 38, 0x01e3, 0x80f1, 0x5c10
+ax_pose_terminator
+sZangoosePose59:
+ax_pose 38, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose60:
+ax_pose 37, 0x01e9, 0x90f0, 0x5c00
+ax_pose 39, 0x01e2, 0x80ef, 0x5c10
+ax_pose_terminator
+sZangoosePose61:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose62:
+ax_pose 40, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose63:
+ax_pose 41, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose64:
+ax_pose 42, 0x01e6, 0x90f3, 0x5c00
+ax_pose 43, 0x01e3, 0x80f1, 0x5c10
+ax_pose_terminator
+sZangoosePose65:
+ax_pose 43, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose66:
+ax_pose 44, 0x01e9, 0x90ef, 0x5c00
+ax_pose 45, 0x01e4, 0x80ef, 0x5c10
+ax_pose_terminator
+sZangoosePose67:
+ax_pose 45, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose68:
+ax_pose 46, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose69:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose70:
+ax_pose 48, 0x01e4, 0x90f3, 0x5c00
+ax_pose 49, 0x01e4, 0x80ee, 0x5c10
+ax_pose_terminator
+sZangoosePose71:
+ax_pose 49, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose72:
+ax_pose 50, 0x01e3, 0x90f0, 0x5c00
+ax_pose 51, 0x01e4, 0x80ec, 0x5c10
+ax_pose_terminator
+sZangoosePose73:
+ax_pose 51, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose74:
+ax_pose 52, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose75:
+ax_pose 53, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose76:
+ax_pose 54, 0x01e4, 0x80ed, 0x5c00
+ax_pose 55, 0x01e2, 0x90f1, 0x5c10
+ax_pose_terminator
+sZangoosePose77:
+ax_pose 54, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sZangoosePose78:
+ax_pose 56, 0x41e7, 0x90f2, 0x5c00
+ax_pose 57, 0x01e5, 0x80ed, 0x5c08
+ax_pose_terminator
+sZangoosePose79:
+ax_pose 57, 0x01e5, 0x80ed, 0x5c00
+ax_pose_terminator
+sZangoosePose80:
+ax_pose 58, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose81:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose82:
+ax_pose 60, 0x01e4, 0x80f3, 0x5c00
+ax_pose 61, 0x01e2, 0x80f2, 0x5c10
+ax_pose_terminator
+sZangoosePose83:
+ax_pose 60, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose84:
+ax_pose 62, 0x01e4, 0x80ed, 0x5c00
+ax_pose 61, 0x01e2, 0x90ed, 0x5c10
+ax_pose_terminator
+sZangoosePose85:
+ax_pose 62, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sZangoosePose86:
+ax_pose 63, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose87:
+ax_pose 64, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose88:
+ax_pose 65, 0x01e4, 0x80f2, 0x5c00
+ax_pose 55, 0x01e2, 0x80ee, 0x5c10
+ax_pose_terminator
+sZangoosePose89:
+ax_pose 65, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose90:
+ax_pose 56, 0x41e7, 0x80ed, 0x5c00
+ax_pose 66, 0x01e5, 0x80f2, 0x5c08
+ax_pose_terminator
+sZangoosePose91:
+ax_pose 66, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose92:
+ax_pose 67, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose93:
+ax_pose 68, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sZangoosePose94:
+ax_pose 48, 0x01e4, 0x80ec, 0x5c00
+ax_pose 69, 0x01e4, 0x80f1, 0x5c10
+ax_pose_terminator
+sZangoosePose95:
+ax_pose 69, 0x01e4, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose96:
+ax_pose 50, 0x01e3, 0x80f1, 0x5c00
+ax_pose 70, 0x01e4, 0x80f3, 0x5c10
+ax_pose_terminator
+sZangoosePose97:
+ax_pose 70, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose98:
+ax_pose 71, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose99:
+ax_pose 72, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose100:
+ax_pose 42, 0x01e6, 0x80ec, 0x5c00
+ax_pose 73, 0x01e3, 0x80ee, 0x5c10
+ax_pose_terminator
+sZangoosePose101:
+ax_pose 73, 0x01e3, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose102:
+ax_pose 44, 0x01e9, 0x80f0, 0x5c00
+ax_pose 74, 0x01e4, 0x80f0, 0x5c10
+ax_pose_terminator
+sZangoosePose103:
+ax_pose 74, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose104:
+ax_pose 75, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose105:
+ax_pose 36, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose106:
+ax_pose 40, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose107:
+ax_pose 41, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose108:
+ax_pose 46, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose109:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose110:
+ax_pose 52, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose111:
+ax_pose 53, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose112:
+ax_pose 58, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose113:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose114:
+ax_pose 63, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose115:
+ax_pose 64, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose116:
+ax_pose 67, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose117:
+ax_pose 68, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sZangoosePose118:
+ax_pose 71, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose119:
+ax_pose 72, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose120:
+ax_pose 75, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose121:
+ax_pose 36, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose122:
+ax_pose 40, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose123:
+ax_pose 41, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose124:
+ax_pose 46, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose125:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose126:
+ax_pose 52, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose127:
+ax_pose 53, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose128:
+ax_pose 58, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose129:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose130:
+ax_pose 63, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose131:
+ax_pose 64, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose132:
+ax_pose 67, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose133:
+ax_pose 68, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sZangoosePose134:
+ax_pose 71, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose135:
+ax_pose 72, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose136:
+ax_pose 75, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose137:
+ax_pose 76, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose138:
+ax_pose 77, 0x01ef, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose139:
+ax_pose 78, 0x01e1, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose140:
+ax_pose 79, 0x01e3, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose141:
+ax_pose 80, 0x01e3, 0x80eb, 0x5c00
+ax_pose_terminator
+sZangoosePose142:
+ax_pose 81, 0x01e3, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose143:
+ax_pose 82, 0x01e5, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose144:
+ax_pose 83, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose145:
+ax_pose 84, 0x01e3, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose146:
+ax_pose 85, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose147:
+ax_pose 36, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose148:
+ax_pose 40, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose149:
+ax_pose 41, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose150:
+ax_pose 46, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose151:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose152:
+ax_pose 52, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose153:
+ax_pose 53, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose154:
+ax_pose 58, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose155:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose156:
+ax_pose 63, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose157:
+ax_pose 64, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose158:
+ax_pose 67, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose159:
+ax_pose 68, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sZangoosePose160:
+ax_pose 71, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose161:
+ax_pose 72, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose162:
+ax_pose 75, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose163:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose164:
+ax_pose 74, 0x01e3, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose165:
+ax_pose 70, 0x01e3, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose166:
+ax_pose 66, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose167:
+ax_pose 62, 0x01e3, 0x80ed, 0x5c00
+ax_pose_terminator
+sZangoosePose168:
+ax_pose 54, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose169:
+ax_pose 49, 0x01e3, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose170:
+ax_pose 43, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose171:
+ax_pose 39, 0x01e2, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose172:
+ax_pose 43, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose173:
+ax_pose 49, 0x01e3, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose174:
+ax_pose 54, 0x01e4, 0x80ed, 0x5c00
+ax_pose_terminator
+sZangoosePose175:
+ax_pose 62, 0x01e3, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose176:
+ax_pose 66, 0x01e5, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose177:
+ax_pose 70, 0x01e3, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose178:
+ax_pose 74, 0x01e3, 0x80f1, 0x5c00
+ax_pose_terminator
+sZangoosePose179:
+ax_pose 36, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose180:
+ax_pose 40, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose181:
+ax_pose 41, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose182:
+ax_pose 46, 0x01e4, 0x80ec, 0x5c00
+ax_pose_terminator
+sZangoosePose183:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose184:
+ax_pose 52, 0x01e4, 0x80ea, 0x5c00
+ax_pose_terminator
+sZangoosePose185:
+ax_pose 53, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose186:
+ax_pose 58, 0x01e5, 0x80ea, 0x5c00
+ax_pose_terminator
+sZangoosePose187:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose188:
+ax_pose 63, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose189:
+ax_pose 64, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose190:
+ax_pose 67, 0x01e5, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose191:
+ax_pose 68, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sZangoosePose192:
+ax_pose 71, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose193:
+ax_pose 72, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose194:
+ax_pose 75, 0x01e4, 0x80f3, 0x5c00
+ax_pose_terminator
+sZangoosePose195:
+ax_pose 40, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose196:
+ax_pose 75, 0x01e4, 0x80f2, 0x5c00
+ax_pose_terminator
+sZangoosePose197:
+ax_pose 71, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose198:
+ax_pose 67, 0x01e4, 0x80f5, 0x5c00
+ax_pose_terminator
+sZangoosePose199:
+ax_pose 63, 0x01e8, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose200:
+ax_pose 58, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sZangoosePose201:
+ax_pose 52, 0x01e4, 0x80eb, 0x5c00
+ax_pose_terminator
+sZangoosePose202:
+ax_pose 46, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose203:
+ax_pose 36, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose204:
+ax_pose 72, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose205:
+ax_pose 68, 0x01e4, 0x80f7, 0x5c00
+ax_pose_terminator
+sZangoosePose206:
+ax_pose 64, 0x01e4, 0x80f4, 0x5c00
+ax_pose_terminator
+sZangoosePose207:
+ax_pose 59, 0x01e4, 0x80f0, 0x5c00
+ax_pose_terminator
+sZangoosePose208:
+ax_pose 53, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+sZangoosePose209:
+ax_pose 47, 0x01e4, 0x80ee, 0x5c00
+ax_pose_terminator
+sZangoosePose210:
+ax_pose 41, 0x01e4, 0x80ef, 0x5c00
+ax_pose_terminator
+.align 2
+sZangooseAnims_1_1:
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 1, 0, 0, 0, 0,
+ax_anim 8, 0, 0, 0, 0, 0, 0,
+ax_anim 10, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_1_2:
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 4, 0, 0, 0, 0,
+ax_anim 8, 0, 3, 0, 0, 0, 0,
+ax_anim 10, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_1_3:
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 7, 0, 0, 0, 0,
+ax_anim 8, 0, 6, 0, 0, 0, 0,
+ax_anim 10, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_1_4:
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 10, 0, 0, 0, 0,
+ax_anim 8, 0, 9, 0, 0, 0, 0,
+ax_anim 10, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_1_5:
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 13, 0, 0, 0, 0,
+ax_anim 8, 0, 12, 0, 0, 0, 0,
+ax_anim 10, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_1_6:
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 16, 0, 0, 0, 0,
+ax_anim 8, 0, 15, 0, 0, 0, 0,
+ax_anim 10, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_1_7:
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 19, 0, 0, 0, 0,
+ax_anim 8, 0, 18, 0, 0, 0, 0,
+ax_anim 10, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_1_8:
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 22, 0, 0, 0, 0,
+ax_anim 8, 0, 21, 0, 0, 0, 0,
+ax_anim 10, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZangooseAnims_2_1:
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -2, 0, -2,
+ax_anim 1, 0, 26, 0, 0, 0, 0,
+ax_anim 1, 2, 25, 0, 4, 0, 4,
+ax_anim 1, 0, 26, 0, 10, 0, 10,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 1, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 27, 0, 16, 0, 16,
+ax_anim 2, 0, 27, 1, 16, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sZangooseAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 4, 0, 28, -2, -2, -2, -2,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 30, 10, 10, 10, 10,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 1, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 31, 18, 19, 18, 19,
+ax_anim 2, 0, 31, 19, 18, 19, 18,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sZangooseAnims_2_3:
+ax_anim 2, 0, 32, -1, 0, -1, 0,
+ax_anim 4, 0, 32, -2, 0, -2, 0,
+ax_anim 1, 0, 34, 0, 0, 0, 0,
+ax_anim 1, 2, 33, 3, 0, 3, 0,
+ax_anim 1, 0, 34, 8, 0, 8, 0,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 1, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 35, 16, 0, 16, 0,
+ax_anim 2, 0, 35, 16, 1, 16, 1,
+ax_anim 2, 0, 32, 6, 0, 6, 0,
+ax_anim_terminator
+sZangooseAnims_2_4:
+ax_anim 2, 0, 36, -1, 1, -1, 1,
+ax_anim 4, 0, 36, -2, 2, -2, 2,
+ax_anim 1, 0, 38, 0, -1, 0, -1,
+ax_anim 1, 2, 37, 5, -5, 5, -5,
+ax_anim 1, 0, 38, 10, -11, 10, -11,
+ax_anim 2, 0, 39, 17, -19, 17, -19,
+ax_anim 2, 1, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 39, 17, -19, 17, -19,
+ax_anim 2, 0, 39, 18, -18, 18, -18,
+ax_anim 2, 0, 36, 6, -6, 6, -6,
+ax_anim_terminator
+sZangooseAnims_2_5:
+ax_anim 2, 0, 40, 0, 1, 0, 1,
+ax_anim 4, 0, 40, 0, 2, 0, 2,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 41, 0, -4, 0, -4,
+ax_anim 1, 0, 42, 0, -11, 0, -11,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 1, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 43, 0, -19, 0, -19,
+ax_anim 2, 0, 43, 1, -19, 1, -19,
+ax_anim 2, 0, 40, 0, -6, 0, -6,
+ax_anim_terminator
+sZangooseAnims_2_6:
+ax_anim 2, 0, 44, 1, 1, 1, 1,
+ax_anim 4, 0, 44, 2, 2, 2, 2,
+ax_anim 1, 0, 46, 0, -1, 0, -1,
+ax_anim 1, 2, 45, -5, -5, -5, -5,
+ax_anim 1, 0, 46, -10, -11, -10, -11,
+ax_anim 2, 0, 47, -17, -19, -17, -19,
+ax_anim 2, 1, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 47, -17, -19, -17, -19,
+ax_anim 2, 0, 47, -18, -18, -18, -18,
+ax_anim 2, 0, 44, -6, -6, -6, -6,
+ax_anim_terminator
+sZangooseAnims_2_7:
+ax_anim 2, 0, 48, 1, 0, 1, 0,
+ax_anim 4, 0, 48, 2, 0, 2, 0,
+ax_anim 1, 0, 50, 0, 0, 0, 0,
+ax_anim 1, 2, 49, -3, 0, -3, 0,
+ax_anim 1, 0, 50, -8, 0, -8, 0,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 1, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 51, -16, 0, -16, 0,
+ax_anim 2, 0, 51, -16, 1, -16, 1,
+ax_anim 2, 0, 48, -6, 0, -6, 0,
+ax_anim_terminator
+sZangooseAnims_2_8:
+ax_anim 2, 0, 52, 1, -1, 1, -1,
+ax_anim 4, 0, 52, 2, -2, 2, -2,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 53, -4, 4, -4, 4,
+ax_anim 1, 0, 54, -10, 10, -10, 10,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 1, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 55, -18, 19, -18, 19,
+ax_anim 2, 0, 55, -19, 18, -19, 18,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sZangooseAnims_3_1:
+ax_anim 2, 0, 61, 0, -2, 0, -2,
+ax_anim 4, 0, 61, 0, -4, 0, -4,
+ax_anim 4, 0, 102, 0, -6, 0, -6,
+ax_anim 1, 0, 102, 0, -3, 0, -3,
+ax_anim 1, 2, 60, 0, 3, 0, 3,
+ax_anim 1, 0, 57, 0, 16, 0, 16,
+ax_anim 2, 0, 66, 2, 16, 2, 16,
+ax_anim 4, 1, 66, 3, 15, 3, 15,
+ax_anim 2, 0, 58, 2, 17, 2, 17,
+ax_anim 1, 0, 59, -2, 18, -2, 18,
+ax_anim 2, 0, 102, -2, 17, -2, 17,
+ax_anim 2, 0, 60, -1, 15, -1, 15,
+ax_anim 2, 0, 61, 0, 11, 0, 11,
+ax_anim 2, 0, 61, 0, 3, 0, 3,
+ax_anim_terminator
+sZangooseAnims_3_2:
+ax_anim 2, 0, 67, -2, -2, -2, -2,
+ax_anim 4, 0, 67, -4, -4, -4, -4,
+ax_anim 4, 0, 60, -6, -6, -6, -6,
+ax_anim 1, 0, 60, -3, -3, -3, -3,
+ax_anim 1, 2, 64, 6, 7, 6, 7,
+ax_anim 1, 0, 65, 18, 16, 18, 16,
+ax_anim 2, 0, 72, 19, 17, 19, 17,
+ax_anim 4, 1, 72, 19, 16, 19, 16,
+ax_anim 2, 0, 66, 17, 17, 17, 17,
+ax_anim 1, 0, 63, 14, 20, 14, 20,
+ax_anim 2, 0, 60, 15, 20, 15, 20,
+ax_anim 2, 0, 64, 13, 13, 13, 13,
+ax_anim 2, 0, 67, 9, 9, 9, 9,
+ax_anim 2, 0, 67, 2, 3, 2, 3,
+ax_anim_terminator
+sZangooseAnims_3_3:
+ax_anim 2, 0, 73, -2, 0, -2, 0,
+ax_anim 4, 0, 73, -4, 0, -4, 0,
+ax_anim 4, 0, 64, -6, 0, -6, 0,
+ax_anim 1, 0, 64, -3, 0, -3, 0,
+ax_anim 1, 2, 70, 6, 0, 6, 0,
+ax_anim 1, 0, 71, 14, 0, 14, 0,
+ax_anim 2, 0, 78, 15, 1, 15, 1,
+ax_anim 4, 1, 78, 13, 1, 13, 1,
+ax_anim 2, 0, 72, 16, 0, 16, 0,
+ax_anim 1, 0, 69, 14, 0, 14, 0,
+ax_anim 2, 0, 64, 13, 1, 13, 1,
+ax_anim 2, 0, 70, 9, 0, 9, 0,
+ax_anim 2, 0, 73, 4, 0, 4, 0,
+ax_anim 2, 0, 73, 2, 0, 2, 0,
+ax_anim_terminator
+sZangooseAnims_3_4:
+ax_anim 2, 0, 79, -2, 2, -2, 2,
+ax_anim 4, 0, 79, -4, 4, -4, 4,
+ax_anim 4, 0, 70, -7, 6, -7, 6,
+ax_anim 1, 0, 70, -4, 3, -4, 3,
+ax_anim 1, 2, 76, 9, -6, 9, -6,
+ax_anim 1, 0, 77, 16, -12, 16, -12,
+ax_anim 2, 0, 82, 14, -12, 14, -12,
+ax_anim 4, 1, 82, 13, -11, 13, -11,
+ax_anim 2, 0, 78, 15, -12, 15, -12,
+ax_anim 1, 0, 75, 20, -16, 20, -16,
+ax_anim 2, 0, 70, 18, -16, 18, -16,
+ax_anim 2, 0, 76, 11, -11, 11, -11,
+ax_anim 2, 0, 79, 5, -5, 5, -5,
+ax_anim 2, 0, 79, 3, -3, 3, -3,
+ax_anim_terminator
+sZangooseAnims_3_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 4, 0, 85, 0, 4, 0, 4,
+ax_anim 4, 0, 76, 2, 6, 2, 6,
+ax_anim 1, 0, 76, 2, 3, 2, 3,
+ax_anim 1, 2, 84, 0, -6, 0, -6,
+ax_anim 1, 0, 81, -2, -12, -2, -12,
+ax_anim 2, 0, 88, -1, -13, -1, -13,
+ax_anim 4, 1, 88, -1, -12, -1, -12,
+ax_anim 2, 0, 82, -1, -14, -1, -14,
+ax_anim 1, 0, 83, 2, -15, 2, -15,
+ax_anim 2, 0, 76, 3, -13, 3, -13,
+ax_anim 2, 0, 84, 1, -8, 1, -8,
+ax_anim 2, 0, 85, 0, -5, 0, -5,
+ax_anim 2, 0, 85, 0, -1, 0, -1,
+ax_anim_terminator
+sZangooseAnims_3_6:
+ax_anim 2, 0, 91, 2, 2, 2, 2,
+ax_anim 4, 0, 91, 4, 4, 4, 4,
+ax_anim 4, 0, 84, 6, 6, 6, 6,
+ax_anim 1, 0, 84, 3, 3, 3, 3,
+ax_anim 1, 2, 90, -9, -6, -9, -6,
+ax_anim 1, 0, 87, -16, -12, -16, -12,
+ax_anim 2, 0, 94, -17, -11, -17, -11,
+ax_anim 4, 1, 94, -16, -10, -16, -10,
+ax_anim 2, 0, 88, -16, -11, -16, -11,
+ax_anim 1, 0, 89, -16, -12, -16, -12,
+ax_anim 2, 0, 84, -16, -14, -16, -14,
+ax_anim 2, 0, 90, -11, -11, -11, -11,
+ax_anim 2, 0, 91, -5, -4, -5, -4,
+ax_anim 2, 0, 91, -3, -2, -3, -2,
+ax_anim_terminator
+sZangooseAnims_3_7:
+ax_anim 2, 0, 97, 2, 0, 2, 0,
+ax_anim 4, 0, 97, 4, 0, 4, 0,
+ax_anim 4, 0, 90, 6, 0, 6, 0,
+ax_anim 1, 0, 90, 3, 0, 3, 0,
+ax_anim 1, 2, 96, -1, 0, -1, 0,
+ax_anim 1, 0, 93, -6, 0, -6, 0,
+ax_anim 2, 0, 100, -9, 2, -9, 2,
+ax_anim 4, 1, 100, -8, 2, -8, 2,
+ax_anim 2, 0, 94, -10, 0, -10, 0,
+ax_anim 1, 0, 95, -14, 0, -14, 0,
+ax_anim 2, 0, 90, -14, 0, -14, 0,
+ax_anim 2, 0, 96, -10, 0, -10, 0,
+ax_anim 2, 0, 97, -4, 0, -4, 0,
+ax_anim 2, 0, 97, -2, 0, -2, 0,
+ax_anim_terminator
+sZangooseAnims_3_8:
+ax_anim 2, 0, 103, 2, -2, 2, -2,
+ax_anim 4, 0, 103, 4, -4, 4, -4,
+ax_anim 4, 0, 96, 6, -6, 6, -6,
+ax_anim 1, 0, 96, 3, -3, 3, -3,
+ax_anim 1, 2, 102, -6, 7, -6, 7,
+ax_anim 1, 0, 99, -12, 16, -12, 16,
+ax_anim 2, 0, 58, -14, 18, -14, 18,
+ax_anim 4, 1, 58, -12, 16, -12, 16,
+ax_anim 2, 0, 100, -13, 17, -13, 17,
+ax_anim 1, 0, 101, -16, 17, -16, 17,
+ax_anim 2, 0, 96, -18, 16, -18, 16,
+ax_anim 2, 0, 102, -15, 13, -15, 13,
+ax_anim 2, 0, 103, -8, 8, -8, 8,
+ax_anim 2, 0, 103, -2, 3, -2, 3,
+ax_anim_terminator
+.align 2
+sZangooseAnims_4_1:
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 4, 0, 104, 0, -5, 0, 0,
+ax_anim 2, 0, 104, 0, -4, 0, 0,
+ax_anim 1, 0, 104, 0, -2, 0, 0,
+ax_anim 6, 2, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 1, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 105, 1, 0, 1, 0,
+ax_anim_terminator
+sZangooseAnims_4_2:
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 4, 0, 106, 0, -5, 0, 0,
+ax_anim 2, 0, 106, 0, -4, 0, 0,
+ax_anim 1, 0, 106, 0, -2, 0, 0,
+ax_anim 6, 2, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 1, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim 2, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 0, 107, 1, -1, 1, -1,
+ax_anim_terminator
+sZangooseAnims_4_3:
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 4, 0, 108, 0, -5, 0, 0,
+ax_anim 2, 0, 108, 0, -4, 0, 0,
+ax_anim 1, 0, 108, 0, -2, 0, 0,
+ax_anim 6, 2, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 1, 0, 1,
+ax_anim 2, 1, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 1, 0, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 1, 0, 1,
+ax_anim 2, 0, 109, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, 1, 0, 1,
+ax_anim_terminator
+sZangooseAnims_4_4:
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 4, 0, 110, 0, -5, 0, 0,
+ax_anim 2, 0, 110, 0, -4, 0, 0,
+ax_anim 1, 0, 110, 0, -2, 0, 0,
+ax_anim 6, 2, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 1, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 111, -1, -1, -1, -1,
+ax_anim_terminator
+sZangooseAnims_4_5:
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 4, 0, 112, 0, -5, 0, 0,
+ax_anim 2, 0, 112, 0, -4, 0, 0,
+ax_anim 1, 0, 112, 0, -2, 0, 0,
+ax_anim 6, 2, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 2, 1, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim 2, 0, 113, 0, 0, 0, 0,
+ax_anim 2, 0, 113, 1, 0, 1, 0,
+ax_anim_terminator
+sZangooseAnims_4_6:
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 4, 0, 114, 0, -5, 0, 0,
+ax_anim 2, 0, 114, 0, -4, 0, 0,
+ax_anim 1, 0, 114, 0, -2, 0, 0,
+ax_anim 6, 2, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 1, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim 2, 0, 115, 0, 0, 0, 0,
+ax_anim 2, 0, 115, 1, -1, 1, -1,
+ax_anim_terminator
+sZangooseAnims_4_7:
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 4, 0, 116, 0, -5, 0, 0,
+ax_anim 2, 0, 116, 0, -4, 0, 0,
+ax_anim 1, 0, 116, 0, -2, 0, 0,
+ax_anim 6, 2, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 1, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 117, 0, 1, 0, 1,
+ax_anim_terminator
+sZangooseAnims_4_8:
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 4, 0, 118, 0, -5, 0, 0,
+ax_anim 2, 0, 118, 0, -4, 0, 0,
+ax_anim 1, 0, 118, 0, -2, 0, 0,
+ax_anim 6, 2, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 1, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim 2, 0, 119, 0, 0, 0, 0,
+ax_anim 2, 0, 119, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sZangooseAnims_5_1:
+ax_anim 1, 0, 120, 0, 0, 0, 0,
+ax_anim 1, 0, 120, 0, -2, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 4, 0, 120, 0, -5, 0, 0,
+ax_anim 2, 0, 120, 0, -4, 0, 0,
+ax_anim 1, 0, 120, 0, -2, 0, 0,
+ax_anim 6, 2, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 2, 1, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim 2, 0, 121, 1, 0, 1, 0,
+ax_anim_terminator
+sZangooseAnims_5_2:
+ax_anim 1, 0, 122, 0, 0, 0, 0,
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 4, 0, 122, 0, -5, 0, 0,
+ax_anim 2, 0, 122, 0, -4, 0, 0,
+ax_anim 1, 0, 122, 0, -2, 0, 0,
+ax_anim 6, 2, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 1, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim 2, 0, 123, 0, 0, 0, 0,
+ax_anim 2, 0, 123, 1, -1, 1, -1,
+ax_anim_terminator
+sZangooseAnims_5_3:
+ax_anim 1, 0, 124, 0, 0, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 4, 0, 124, 0, -5, 0, 0,
+ax_anim 2, 0, 124, 0, -4, 0, 0,
+ax_anim 1, 0, 124, 0, -2, 0, 0,
+ax_anim 6, 2, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 1, 0, 1,
+ax_anim 2, 1, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 1, 0, 1,
+ax_anim 2, 0, 125, 0, 0, 0, 0,
+ax_anim 2, 0, 125, 0, 1, 0, 1,
+ax_anim_terminator
+sZangooseAnims_5_4:
+ax_anim 1, 0, 126, 0, 0, 0, 0,
+ax_anim 1, 0, 126, 0, -2, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 4, 0, 126, 0, -5, 0, 0,
+ax_anim 2, 0, 126, 0, -4, 0, 0,
+ax_anim 1, 0, 126, 0, -2, 0, 0,
+ax_anim 6, 2, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 1, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim 2, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 0, 127, -1, -1, -1, -1,
+ax_anim_terminator
+sZangooseAnims_5_5:
+ax_anim 1, 0, 128, 0, 0, 0, 0,
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 4, 0, 128, 0, -5, 0, 0,
+ax_anim 2, 0, 128, 0, -4, 0, 0,
+ax_anim 1, 0, 128, 0, -2, 0, 0,
+ax_anim 6, 2, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 1, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim 2, 0, 129, 0, 0, 0, 0,
+ax_anim 2, 0, 129, 1, 0, 1, 0,
+ax_anim_terminator
+sZangooseAnims_5_6:
+ax_anim 1, 0, 130, 0, 0, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 4, 0, 130, 0, -5, 0, 0,
+ax_anim 2, 0, 130, 0, -4, 0, 0,
+ax_anim 1, 0, 130, 0, -2, 0, 0,
+ax_anim 6, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 1, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 131, 1, -1, 1, -1,
+ax_anim_terminator
+sZangooseAnims_5_7:
+ax_anim 1, 0, 132, 0, 0, 0, 0,
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 4, 0, 132, 0, -5, 0, 0,
+ax_anim 2, 0, 132, 0, -4, 0, 0,
+ax_anim 1, 0, 132, 0, -2, 0, 0,
+ax_anim 6, 2, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 1, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim 2, 0, 133, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 1, 0, 1,
+ax_anim_terminator
+sZangooseAnims_5_8:
+ax_anim 1, 0, 134, 0, 0, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 4, 0, 134, 0, -5, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 1, 0, 134, 0, -2, 0, 0,
+ax_anim 6, 2, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 1, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim 2, 0, 135, 0, 0, 0, 0,
+ax_anim 2, 0, 135, -1, -1, -1, -1,
+ax_anim_terminator
+.align 2
+sZangooseAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZangooseAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sZangooseAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sZangooseAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sZangooseAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sZangooseAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sZangooseAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sZangooseAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sZangooseAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sZangooseAnims_8_1:
+ax_anim 30, 0, 146, 0, 0, 0, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 147, -1, 0, -1, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim 4, 0, 147, -1, 0, -1, 0,
+ax_anim 4, 0, 147, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_8_2:
+ax_anim 30, 0, 148, 0, 0, 0, 0,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, -1, 1, -1, 1,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim 4, 0, 149, -1, 1, -1, 1,
+ax_anim 4, 0, 149, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_8_3:
+ax_anim 30, 0, 150, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, -1,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim 4, 0, 151, 0, -1, 0, -1,
+ax_anim 4, 0, 151, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_8_4:
+ax_anim 30, 0, 152, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 1, 1, 1, 1,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim 4, 0, 153, 1, 1, 1, 1,
+ax_anim 4, 0, 153, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_8_5:
+ax_anim 30, 0, 154, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 1, 0, 1, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim 4, 0, 155, 1, 0, 1, 0,
+ax_anim 4, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_8_6:
+ax_anim 30, 0, 156, 0, 0, 0, 0,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 157, -1, 1, -1, 1,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim 4, 0, 157, -1, 1, -1, 1,
+ax_anim 4, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_8_7:
+ax_anim 30, 0, 158, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, -1,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 159, 0, -1, 0, -1,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_8_8:
+ax_anim 30, 0, 160, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 1, 1, 1, 1,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim 4, 0, 161, 1, 1, 1, 1,
+ax_anim 4, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZangooseAnims_9_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 1, 0, 163, 6, 3, 6, 3,
+ax_anim 2, 0, 164, 9, 9, 9, 9,
+ax_anim 2, 0, 165, 9, 16, 9, 16,
+ax_anim 3, 0, 166, 0, 20, 0, 20,
+ax_anim 2, 3, 167, -7, 15, -7, 15,
+ax_anim 2, 0, 168, -9, 9, -9, 9,
+ax_anim 1, 0, 169, -6, 3, -6, 3,
+ax_anim 1, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_9_2:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 1, 0, 162, 8, 0, 8, 0,
+ax_anim 2, 0, 163, 17, 3, 17, 3,
+ax_anim 2, 0, 164, 24, 13, 24, 13,
+ax_anim 3, 0, 165, 21, 20, 21, 20,
+ax_anim 2, 3, 166, 13, 21, 13, 21,
+ax_anim 2, 0, 167, 3, 15, 3, 15,
+ax_anim 1, 0, 168, 0, 7, 0, 7,
+ax_anim 1, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_9_3:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 1, 0, 169, 3, -5, 3, -5,
+ax_anim 2, 0, 162, 11, -6, 11, -6,
+ax_anim 2, 0, 163, 19, -5, 19, -5,
+ax_anim 3, 0, 164, 22, -1, 22, -1,
+ax_anim 2, 3, 165, 19, 4, 19, 4,
+ax_anim 2, 0, 166, 12, 7, 12, 7,
+ax_anim 1, 0, 167, 4, 4, 4, 4,
+ax_anim 1, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_9_4:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 1, 0, 168, -1, -8, -1, -8,
+ax_anim 2, 0, 169, 4, -16, 4, -16,
+ax_anim 2, 0, 162, 15, -21, 15, -21,
+ax_anim 3, 0, 163, 22, -22, 22, -22,
+ax_anim 2, 3, 164, 23, -15, 23, -15,
+ax_anim 2, 0, 165, 17, -4, 17, -4,
+ax_anim 1, 0, 166, 10, 1, 10, 1,
+ax_anim 1, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_9_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 1, 0, 167, -8, -4, -8, -4,
+ax_anim 2, 0, 168, -9, -12, -9, -12,
+ax_anim 2, 0, 169, -7, -18, -7, -18,
+ax_anim 3, 0, 162, 0, -21, 0, -21,
+ax_anim 2, 3, 163, 7, -18, 7, -18,
+ax_anim 2, 0, 164, 9, -12, 9, -12,
+ax_anim 1, 0, 165, 8, -4, 8, -4,
+ax_anim 1, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_9_6:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 1, 0, 164, 1, -8, 1, -8,
+ax_anim 2, 0, 163, -4, -16, -4, -16,
+ax_anim 2, 0, 162, -15, -21, -15, -21,
+ax_anim 3, 0, 169, -22, -22, -22, -22,
+ax_anim 2, 3, 168, -23, -15, -23, -15,
+ax_anim 2, 0, 167, -17, -4, -17, -4,
+ax_anim 1, 0, 166, -10, 1, -10, 1,
+ax_anim 1, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_9_7:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 1, 0, 163, -3, -5, -3, -5,
+ax_anim 2, 0, 162, -11, -6, -11, -6,
+ax_anim 2, 0, 169, -19, -5, -19, -5,
+ax_anim 3, 0, 168, -22, -1, -22, -1,
+ax_anim 2, 3, 167, -19, 4, -19, 4,
+ax_anim 2, 0, 166, -12, 7, -12, 7,
+ax_anim 1, 0, 165, -4, 4, -4, 4,
+ax_anim 1, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_9_8:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 1, 0, 162, -8, 0, -8, 0,
+ax_anim 2, 0, 169, -17, 3, -17, 3,
+ax_anim 2, 0, 168, -24, 13, -24, 13,
+ax_anim 3, 0, 167, -21, 20, -21, 20,
+ax_anim 2, 3, 166, -13, 21, -13, 21,
+ax_anim 2, 0, 165, -3, 15, -3, 15,
+ax_anim 1, 0, 164, 0, 7, 0, 7,
+ax_anim 1, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZangooseAnims_10_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 3, 0, 170, 13, 0, 13, 0,
+ax_anim 3, 0, 170, -13, 0, -13, 0,
+ax_anim 2, 0, 170, 12, 0, 12, 0,
+ax_anim 3, 0, 170, -12, 0, -12, 0,
+ax_anim 2, 0, 170, 10, 0, 10, 0,
+ax_anim 2, 0, 170, -10, 0, -10, 0,
+ax_anim 2, 0, 170, 6, 0, 6, 0,
+ax_anim 2, 0, 170, -6, 0, -6, 0,
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_10_2:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 3, 0, 171, 13, -13, 13, -13,
+ax_anim 3, 0, 171, -13, 13, -13, 13,
+ax_anim 2, 0, 171, 12, -12, 12, -12,
+ax_anim 3, 0, 171, -12, 12, -12, 12,
+ax_anim 2, 0, 171, 10, -10, 10, -10,
+ax_anim 2, 0, 171, -10, 10, -10, 10,
+ax_anim 2, 0, 171, 6, -6, 6, -6,
+ax_anim 2, 0, 171, -6, 6, -6, 6,
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_10_3:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 3, 0, 172, 0, -13, 0, -13,
+ax_anim 3, 0, 172, 0, 13, 0, 13,
+ax_anim 2, 0, 172, 0, -12, 0, -12,
+ax_anim 3, 0, 172, 0, 12, 0, 12,
+ax_anim 2, 0, 172, 0, -10, 0, -10,
+ax_anim 2, 0, 172, 0, 10, 0, 10,
+ax_anim 2, 0, 172, 0, -6, 0, -6,
+ax_anim 2, 0, 172, 0, 6, 0, 6,
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_10_4:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 3, 0, 173, -13, -13, -13, -13,
+ax_anim 3, 0, 173, 13, 13, 13, 13,
+ax_anim 2, 0, 173, -12, -12, -12, -12,
+ax_anim 3, 0, 173, 12, 12, 12, 12,
+ax_anim 2, 0, 173, -10, -10, -10, -10,
+ax_anim 2, 0, 173, 10, 10, 10, 10,
+ax_anim 2, 0, 173, -6, -6, -6, -6,
+ax_anim 2, 0, 173, 6, 6, 6, 6,
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_10_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 3, 0, 174, 13, 0, 13, 0,
+ax_anim 3, 0, 174, -13, 0, -13, 0,
+ax_anim 2, 0, 174, 12, 0, 12, 0,
+ax_anim 3, 0, 174, -12, 0, -12, 0,
+ax_anim 2, 0, 174, 10, 0, 10, 0,
+ax_anim 2, 0, 174, -10, 0, -10, 0,
+ax_anim 2, 0, 174, 6, 0, 6, 0,
+ax_anim 2, 0, 174, -6, 0, -6, 0,
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_10_6:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 3, 0, 175, 13, -13, 13, -13,
+ax_anim 3, 0, 175, -13, 13, -13, 13,
+ax_anim 2, 0, 175, 12, -12, 12, -12,
+ax_anim 3, 0, 175, -12, 12, -12, 12,
+ax_anim 2, 0, 175, 10, -10, 10, -10,
+ax_anim 2, 0, 175, -10, 10, -10, 10,
+ax_anim 2, 0, 175, 6, -6, 6, -6,
+ax_anim 2, 0, 175, -6, 6, -6, 6,
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_10_7:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 3, 0, 176, 0, -13, 0, -13,
+ax_anim 3, 0, 176, 0, 13, 0, 13,
+ax_anim 2, 0, 176, 0, -12, 0, -12,
+ax_anim 3, 0, 176, 0, 12, 0, 12,
+ax_anim 2, 0, 176, 0, -10, 0, -10,
+ax_anim 2, 0, 176, 0, 10, 0, 10,
+ax_anim 2, 0, 176, 0, -6, 0, -6,
+ax_anim 2, 0, 176, 0, 6, 0, 6,
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_10_8:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 3, 0, 177, -13, -13, -13, -13,
+ax_anim 3, 0, 177, 13, 13, 13, 13,
+ax_anim 2, 0, 177, -12, -12, -12, -12,
+ax_anim 3, 0, 177, 12, 12, 12, 12,
+ax_anim 2, 0, 177, -10, -10, -10, -10,
+ax_anim 2, 0, 177, 10, 10, 10, 10,
+ax_anim 2, 0, 177, -6, -6, -6, -6,
+ax_anim 2, 0, 177, 6, 6, 6, 6,
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZangooseAnims_11_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 1, 0, 178, 0, -10, 0, 0,
+ax_anim 2, 0, 178, 0, -16, 0, 0,
+ax_anim 3, 0, 178, 0, -20, 0, 0,
+ax_anim 4, 0, 178, 0, -21, 0, 0,
+ax_anim 4, 0, 179, 0, -25, 0, 0,
+ax_anim 3, 0, 179, 0, -24, 0, 0,
+ax_anim 2, 0, 179, 0, -20, 0, 0,
+ax_anim 1, 0, 179, 0, -12, 0, 0,
+ax_anim 2, 2, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_11_2:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -26, 0, 0,
+ax_anim 3, 0, 181, 0, -25, 0, 0,
+ax_anim 2, 0, 181, 0, -20, 0, 0,
+ax_anim 1, 0, 181, 0, -12, 0, 0,
+ax_anim 2, 2, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_11_3:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 182, 0, -10, 0, 0,
+ax_anim 2, 0, 182, 0, -16, 0, 0,
+ax_anim 3, 0, 182, 0, -20, 0, 0,
+ax_anim 4, 0, 182, 0, -21, 0, 0,
+ax_anim 4, 0, 183, 0, -25, 0, 0,
+ax_anim 3, 0, 183, 0, -24, 0, 0,
+ax_anim 2, 0, 183, 0, -21, 0, 0,
+ax_anim 1, 0, 183, 0, -12, 0, 0,
+ax_anim 2, 2, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_11_4:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 1, 0, 184, 0, -10, 0, 0,
+ax_anim 2, 0, 184, 0, -16, 0, 0,
+ax_anim 3, 0, 184, 0, -20, 0, 0,
+ax_anim 4, 0, 184, 0, -21, 0, 0,
+ax_anim 4, 0, 185, 0, -25, 0, 0,
+ax_anim 3, 0, 185, 0, -24, 0, 0,
+ax_anim 2, 0, 185, 0, -20, 0, 0,
+ax_anim 1, 0, 185, 0, -11, 0, 0,
+ax_anim 2, 2, 185, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_11_5:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -24, 0, 0,
+ax_anim 3, 0, 187, 0, -23, 0, 0,
+ax_anim 2, 0, 187, 0, -20, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 187, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_11_6:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -21, 0, 0,
+ax_anim 4, 0, 189, 0, -25, 0, 0,
+ax_anim 3, 0, 189, 0, -24, 0, 0,
+ax_anim 2, 0, 189, 0, -20, 0, 0,
+ax_anim 1, 0, 189, 0, -11, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_11_7:
+ax_anim 2, 0, 190, 0, 0, 0, 0,
+ax_anim 1, 0, 190, 0, -10, 0, 0,
+ax_anim 2, 0, 190, 0, -16, 0, 0,
+ax_anim 3, 0, 190, 0, -20, 0, 0,
+ax_anim 4, 0, 190, 0, -21, 0, 0,
+ax_anim 4, 0, 191, 0, -25, 0, 0,
+ax_anim 3, 0, 191, 0, -24, 0, 0,
+ax_anim 2, 0, 191, 0, -21, 0, 0,
+ax_anim 1, 0, 191, 0, -12, 0, 0,
+ax_anim 2, 2, 191, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_11_8:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -26, 0, 0,
+ax_anim 3, 0, 193, 0, -25, 0, 0,
+ax_anim 2, 0, 193, 0, -20, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 193, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZangooseAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZangooseAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sZangooseGfx1:
+.incbin "baserom.gba", 0x13ACD90, 0x200
+sZangooseSprites1:
+ax_sprite sZangooseGfx1, 0x200
+ax_sprite_terminator
+sZangooseGfx2:
+.incbin "baserom.gba", 0x13ACFA0, 0x200
+sZangooseSprites2:
+ax_sprite sZangooseGfx2, 0x200
+ax_sprite_terminator
+sZangooseGfx3:
+.incbin "baserom.gba", 0x13AD1B0, 0x200
+sZangooseSprites3:
+ax_sprite sZangooseGfx3, 0x200
+ax_sprite_terminator
+sZangooseGfx4:
+.incbin "baserom.gba", 0x13AD3C0, 0x200
+sZangooseSprites4:
+ax_sprite sZangooseGfx4, 0x200
+ax_sprite_terminator
+sZangooseGfx5:
+.incbin "baserom.gba", 0x13AD5D0, 0x200
+sZangooseSprites5:
+ax_sprite sZangooseGfx5, 0x200
+ax_sprite_terminator
+sZangooseGfx6:
+.incbin "baserom.gba", 0x13AD7E0, 0x200
+sZangooseSprites6:
+ax_sprite sZangooseGfx6, 0x200
+ax_sprite_terminator
+sZangooseGfx7:
+.incbin "baserom.gba", 0x13AD9F0, 0x200
+sZangooseSprites7:
+ax_sprite sZangooseGfx7, 0x200
+ax_sprite_terminator
+sZangooseGfx8:
+.incbin "baserom.gba", 0x13ADC00, 0x200
+sZangooseSprites8:
+ax_sprite sZangooseGfx8, 0x200
+ax_sprite_terminator
+sZangooseGfx9:
+.incbin "baserom.gba", 0x13ADE10, 0x200
+sZangooseSprites9:
+ax_sprite sZangooseGfx9, 0x200
+ax_sprite_terminator
+sZangooseGfx10:
+.incbin "baserom.gba", 0x13AE020, 0x200
+sZangooseSprites10:
+ax_sprite sZangooseGfx10, 0x200
+ax_sprite_terminator
+sZangooseGfx11:
+.incbin "baserom.gba", 0x13AE230, 0x200
+sZangooseSprites11:
+ax_sprite sZangooseGfx11, 0x200
+ax_sprite_terminator
+sZangooseGfx12:
+.incbin "baserom.gba", 0x13AE440, 0x200
+sZangooseSprites12:
+ax_sprite sZangooseGfx12, 0x200
+ax_sprite_terminator
+sZangooseGfx13:
+.incbin "baserom.gba", 0x13AE650, 0x200
+sZangooseSprites13:
+ax_sprite sZangooseGfx13, 0x200
+ax_sprite_terminator
+sZangooseGfx14:
+.incbin "baserom.gba", 0x13AE860, 0x200
+sZangooseSprites14:
+ax_sprite sZangooseGfx14, 0x200
+ax_sprite_terminator
+sZangooseGfx15:
+.incbin "baserom.gba", 0x13AEA70, 0x200
+sZangooseSprites15:
+ax_sprite sZangooseGfx15, 0x200
+ax_sprite_terminator
+sZangooseGfx16:
+.incbin "baserom.gba", 0x13AEC80, 0x200
+sZangooseSprites16:
+ax_sprite sZangooseGfx16, 0x200
+ax_sprite_terminator
+sZangooseGfx17:
+.incbin "baserom.gba", 0x13AEE90, 0x200
+sZangooseSprites17:
+ax_sprite sZangooseGfx17, 0x200
+ax_sprite_terminator
+sZangooseGfx18:
+.incbin "baserom.gba", 0x13AF0A0, 0x200
+sZangooseSprites18:
+ax_sprite sZangooseGfx18, 0x200
+ax_sprite_terminator
+sZangooseGfx19:
+.incbin "baserom.gba", 0x13AF2B0, 0x200
+sZangooseSprites19:
+ax_sprite sZangooseGfx19, 0x200
+ax_sprite_terminator
+sZangooseGfx20:
+.incbin "baserom.gba", 0x13AF4C0, 0x200
+sZangooseSprites20:
+ax_sprite sZangooseGfx20, 0x200
+ax_sprite_terminator
+sZangooseGfx21:
+.incbin "baserom.gba", 0x13AF6D0, 0x200
+sZangooseSprites21:
+ax_sprite sZangooseGfx21, 0x200
+ax_sprite_terminator
+sZangooseGfx22:
+.incbin "baserom.gba", 0x13AF8E0, 0x200
+sZangooseSprites22:
+ax_sprite sZangooseGfx22, 0x200
+ax_sprite_terminator
+sZangooseGfx23:
+.incbin "baserom.gba", 0x13AFAF0, 0x200
+sZangooseSprites23:
+ax_sprite sZangooseGfx23, 0x200
+ax_sprite_terminator
+sZangooseGfx24:
+.incbin "baserom.gba", 0x13AFD00, 0x200
+sZangooseSprites24:
+ax_sprite sZangooseGfx24, 0x200
+ax_sprite_terminator
+sZangooseGfx25:
+.incbin "baserom.gba", 0x13AFF10, 0x20
+sZangooseGfx25_1:
+.incbin "baserom.gba", 0x13AFF30, 0x60
+sZangooseGfx25_2:
+.incbin "baserom.gba", 0x13AFF90, 0x60
+sZangooseGfx25_3:
+.incbin "baserom.gba", 0x13AFFF0, 0x60
+sZangooseSprites25:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx25, 0x20
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx25_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx25_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx25_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx26:
+.incbin "baserom.gba", 0x13B00A0, 0x40
+sZangooseGfx26_1:
+.incbin "baserom.gba", 0x13B00E0, 0x100
+sZangooseGfx26_2:
+.incbin "baserom.gba", 0x13B01E0, 0x60
+sZangooseSprites26:
+ax_sprite sZangooseGfx26, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx26_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx26_2, 0x60
+ax_sprite_terminator
+sZangooseGfx27:
+.incbin "baserom.gba", 0x13B0270, 0x100
+sZangooseSprites27:
+ax_sprite sZangooseGfx27, 0x100
+ax_sprite_terminator
+sZangooseGfx28:
+.incbin "baserom.gba", 0x13B0380, 0x80
+sZangooseSprites28:
+ax_sprite sZangooseGfx28, 0x80
+ax_sprite_terminator
+sZangooseGfx29:
+.incbin "baserom.gba", 0x13B0410, 0x20
+sZangooseSprites29:
+ax_sprite sZangooseGfx29, 0x20
+ax_sprite_terminator
+sZangooseGfx30:
+.incbin "baserom.gba", 0x13B0440, 0x1C0
+sZangooseSprites30:
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx30, 0x1c0
+ax_sprite_terminator
+sZangooseGfx31:
+.incbin "baserom.gba", 0x13B0618, 0x60
+sZangooseGfx31_1:
+.incbin "baserom.gba", 0x13B0678, 0x60
+sZangooseGfx31_2:
+.incbin "baserom.gba", 0x13B06D8, 0x60
+sZangooseGfx31_3:
+.incbin "baserom.gba", 0x13B0738, 0x60
+sZangooseSprites31:
+ax_sprite sZangooseGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx31_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx31_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx31_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx32:
+.incbin "baserom.gba", 0x13B07E0, 0x40
+sZangooseGfx32_1:
+.incbin "baserom.gba", 0x13B0820, 0x180
+sZangooseSprites32:
+ax_sprite sZangooseGfx32, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx32_1, 0x180
+ax_sprite_terminator
+sZangooseGfx33:
+.incbin "baserom.gba", 0x13B09C0, 0x100
+sZangooseSprites33:
+ax_sprite sZangooseGfx33, 0x100
+ax_sprite_terminator
+sZangooseGfx34:
+.incbin "baserom.gba", 0x13B0AD0, 0x80
+sZangooseSprites34:
+ax_sprite sZangooseGfx34, 0x80
+ax_sprite_terminator
+sZangooseGfx35:
+.incbin "baserom.gba", 0x13B0B60, 0x20
+sZangooseSprites35:
+ax_sprite sZangooseGfx35, 0x20
+ax_sprite_terminator
+sZangooseGfx36:
+.incbin "baserom.gba", 0x13B0B90, 0x1A0
+sZangooseSprites36:
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx36, 0x1a0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx37:
+.incbin "baserom.gba", 0x13B0D50, 0x60
+sZangooseGfx37_1:
+.incbin "baserom.gba", 0x13B0DB0, 0x60
+sZangooseGfx37_2:
+.incbin "baserom.gba", 0x13B0E10, 0x60
+sZangooseGfx37_3:
+.incbin "baserom.gba", 0x13B0E70, 0x60
+sZangooseSprites37:
+ax_sprite sZangooseGfx37, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx37_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx37_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx37_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx38:
+.incbin "baserom.gba", 0x13B0F18, 0x20
+sZangooseGfx38_1:
+.incbin "baserom.gba", 0x13B0F38, 0x20
+sZangooseGfx38_2:
+.incbin "baserom.gba", 0x13B0F58, 0x100
+sZangooseSprites38:
+ax_sprite sZangooseGfx38, 0x20
+ax_sprite 0, 0x60
+ax_sprite sZangooseGfx38_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sZangooseGfx38_2, 0x100
+ax_sprite_terminator
+sZangooseGfx39:
+.incbin "baserom.gba", 0x13B1088, 0x180
+sZangooseSprites39:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx39, 0x180
+ax_sprite_terminator
+sZangooseGfx40:
+.incbin "baserom.gba", 0x13B1220, 0x180
+sZangooseSprites40:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx40, 0x180
+ax_sprite_terminator
+sZangooseGfx41:
+.incbin "baserom.gba", 0x13B13B8, 0x20
+sZangooseGfx41_1:
+.incbin "baserom.gba", 0x13B13D8, 0x20
+sZangooseGfx41_2:
+.incbin "baserom.gba", 0x13B13F8, 0x60
+sZangooseGfx41_3:
+.incbin "baserom.gba", 0x13B1458, 0x60
+sZangooseGfx41_4:
+.incbin "baserom.gba", 0x13B14B8, 0x60
+sZangooseSprites41:
+ax_sprite sZangooseGfx41, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx41_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx41_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx41_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx41_4, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx42:
+.incbin "baserom.gba", 0x13B1570, 0x40
+sZangooseGfx42_1:
+.incbin "baserom.gba", 0x13B15B0, 0x60
+sZangooseGfx42_2:
+.incbin "baserom.gba", 0x13B1610, 0x80
+sZangooseGfx42_3:
+.incbin "baserom.gba", 0x13B1690, 0x60
+sZangooseSprites42:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx42, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx42_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx42_2, 0x80
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx42_3, 0x60
+ax_sprite_terminator
+sZangooseGfx43:
+.incbin "baserom.gba", 0x13B1738, 0x40
+sZangooseGfx43_1:
+.incbin "baserom.gba", 0x13B1778, 0x20
+sZangooseGfx43_2:
+.incbin "baserom.gba", 0x13B1798, 0x20
+sZangooseGfx43_3:
+.incbin "baserom.gba", 0x13B17B8, 0x60
+sZangooseSprites43:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx43, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx43_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx43_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx43_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx44:
+.incbin "baserom.gba", 0x13B1868, 0x40
+sZangooseGfx44_1:
+.incbin "baserom.gba", 0x13B18A8, 0x60
+sZangooseGfx44_2:
+.incbin "baserom.gba", 0x13B1908, 0xE0
+sZangooseSprites44:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx44, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx44_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx44_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx45:
+.incbin "baserom.gba", 0x13B1A28, 0x120
+sZangooseSprites45:
+ax_sprite 0, 0xe0
+ax_sprite sZangooseGfx45, 0x120
+ax_sprite_terminator
+sZangooseGfx46:
+.incbin "baserom.gba", 0x13B1B60, 0x180
+sZangooseSprites46:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx46, 0x180
+ax_sprite_terminator
+sZangooseGfx47:
+.incbin "baserom.gba", 0x13B1CF8, 0x140
+sZangooseGfx47_1:
+.incbin "baserom.gba", 0x13B1E38, 0x60
+sZangooseSprites47:
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx47, 0x140
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx47_1, 0x60
+ax_sprite_terminator
+sZangooseGfx48:
+.incbin "baserom.gba", 0x13B1EC0, 0x40
+sZangooseGfx48_1:
+.incbin "baserom.gba", 0x13B1F00, 0x180
+sZangooseSprites48:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx48, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx48_1, 0x180
+ax_sprite_terminator
+sZangooseGfx49:
+.incbin "baserom.gba", 0x13B20A8, 0x60
+sZangooseGfx49_1:
+.incbin "baserom.gba", 0x13B2108, 0x20
+sZangooseGfx49_2:
+.incbin "baserom.gba", 0x13B2128, 0x60
+sZangooseSprites49:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx49, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx49_1, 0x20
+ax_sprite 0, 0x60
+ax_sprite sZangooseGfx49_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx50:
+.incbin "baserom.gba", 0x13B21C8, 0x100
+sZangooseGfx50_1:
+.incbin "baserom.gba", 0x13B22C8, 0x60
+sZangooseSprites50:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx50, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx50_1, 0x60
+ax_sprite_terminator
+sZangooseGfx51:
+.incbin "baserom.gba", 0x13B2350, 0xA0
+sZangooseGfx51_1:
+.incbin "baserom.gba", 0x13B23F0, 0x40
+sZangooseSprites51:
+ax_sprite 0, 0xc0
+ax_sprite sZangooseGfx51, 0xa0
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx51_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sZangooseGfx52:
+.incbin "baserom.gba", 0x13B2460, 0x180
+sZangooseSprites52:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx52, 0x180
+ax_sprite_terminator
+sZangooseGfx53:
+.incbin "baserom.gba", 0x13B25F8, 0x40
+sZangooseGfx53_1:
+.incbin "baserom.gba", 0x13B2638, 0xC0
+sZangooseGfx53_2:
+.incbin "baserom.gba", 0x13B26F8, 0x60
+sZangooseSprites53:
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx53, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx53_1, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx53_2, 0x60
+ax_sprite_terminator
+sZangooseGfx54:
+.incbin "baserom.gba", 0x13B2790, 0x40
+sZangooseGfx54_1:
+.incbin "baserom.gba", 0x13B27D0, 0x60
+sZangooseGfx54_2:
+.incbin "baserom.gba", 0x13B2830, 0x100
+sZangooseSprites54:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx54, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx54_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx54_2, 0x100
+ax_sprite_terminator
+sZangooseGfx55:
+.incbin "baserom.gba", 0x13B2968, 0x20
+sZangooseGfx55_1:
+.incbin "baserom.gba", 0x13B2988, 0x180
+sZangooseSprites55:
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx55, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx55_1, 0x180
+ax_sprite_terminator
+sZangooseGfx56:
+.incbin "baserom.gba", 0x13B2B30, 0xC0
+sZangooseGfx56_1:
+.incbin "baserom.gba", 0x13B2BF0, 0x60
+sZangooseGfx56_2:
+.incbin "baserom.gba", 0x13B2C50, 0x20
+sZangooseSprites56:
+ax_sprite sZangooseGfx56, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx56_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx56_2, 0x20
+ax_sprite 0, 0x60
+ax_sprite_terminator
+sZangooseGfx57:
+.incbin "baserom.gba", 0x13B2CA8, 0x60
+sZangooseGfx57_1:
+.incbin "baserom.gba", 0x13B2D08, 0x40
+sZangooseSprites57:
+ax_sprite sZangooseGfx57, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx57_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sZangooseGfx58:
+.incbin "baserom.gba", 0x13B2D70, 0x100
+sZangooseGfx58_1:
+.incbin "baserom.gba", 0x13B2E70, 0x60
+sZangooseGfx58_2:
+.incbin "baserom.gba", 0x13B2ED0, 0x60
+sZangooseSprites58:
+ax_sprite sZangooseGfx58, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx58_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx58_2, 0x60
+ax_sprite_terminator
+sZangooseGfx59:
+.incbin "baserom.gba", 0x13B2F60, 0x40
+sZangooseGfx59_1:
+.incbin "baserom.gba", 0x13B2FA0, 0x60
+sZangooseGfx59_2:
+.incbin "baserom.gba", 0x13B3000, 0xE0
+sZangooseSprites59:
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx59, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx59_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx59_2, 0xe0
+ax_sprite_terminator
+sZangooseGfx60:
+.incbin "baserom.gba", 0x13B3118, 0x40
+sZangooseGfx60_1:
+.incbin "baserom.gba", 0x13B3158, 0x40
+sZangooseGfx60_2:
+.incbin "baserom.gba", 0x13B3198, 0x100
+sZangooseSprites60:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx60, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx60_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx60_2, 0x100
+ax_sprite_terminator
+sZangooseGfx61:
+.incbin "baserom.gba", 0x13B32D0, 0x60
+sZangooseGfx61_1:
+.incbin "baserom.gba", 0x13B3330, 0x60
+sZangooseGfx61_2:
+.incbin "baserom.gba", 0x13B3390, 0xE0
+sZangooseSprites61:
+ax_sprite sZangooseGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx61_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx61_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx62:
+.incbin "baserom.gba", 0x13B34A8, 0xC0
+sZangooseGfx62_1:
+.incbin "baserom.gba", 0x13B3568, 0x60
+sZangooseGfx62_2:
+.incbin "baserom.gba", 0x13B35C8, 0x20
+sZangooseSprites62:
+ax_sprite sZangooseGfx62, 0xc0
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx62_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx62_2, 0x20
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sZangooseGfx63:
+.incbin "baserom.gba", 0x13B3620, 0x60
+sZangooseGfx63_1:
+.incbin "baserom.gba", 0x13B3680, 0x160
+sZangooseSprites63:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx63, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx63_1, 0x160
+ax_sprite_terminator
+sZangooseGfx64:
+.incbin "baserom.gba", 0x13B3808, 0x40
+sZangooseGfx64_1:
+.incbin "baserom.gba", 0x13B3848, 0x100
+sZangooseGfx64_2:
+.incbin "baserom.gba", 0x13B3948, 0x40
+sZangooseSprites64:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx64, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx64_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx64_2, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx65:
+.incbin "baserom.gba", 0x13B39C8, 0x60
+sZangooseGfx65_1:
+.incbin "baserom.gba", 0x13B3A28, 0x60
+sZangooseGfx65_2:
+.incbin "baserom.gba", 0x13B3A88, 0x60
+sZangooseGfx65_3:
+.incbin "baserom.gba", 0x13B3AE8, 0x60
+sZangooseSprites65:
+ax_sprite sZangooseGfx65, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx65_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx65_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx65_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx66:
+.incbin "baserom.gba", 0x13B3B90, 0x20
+sZangooseGfx66_1:
+.incbin "baserom.gba", 0x13B3BB0, 0x180
+sZangooseSprites66:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx66, 0x20
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx66_1, 0x180
+ax_sprite_terminator
+sZangooseGfx67:
+.incbin "baserom.gba", 0x13B3D58, 0x160
+sZangooseGfx67_1:
+.incbin "baserom.gba", 0x13B3EB8, 0x60
+sZangooseSprites67:
+ax_sprite sZangooseGfx67, 0x160
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx67_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx68:
+.incbin "baserom.gba", 0x13B3F40, 0x40
+sZangooseGfx68_1:
+.incbin "baserom.gba", 0x13B3F80, 0x60
+sZangooseGfx68_2:
+.incbin "baserom.gba", 0x13B3FE0, 0x60
+sZangooseGfx68_3:
+.incbin "baserom.gba", 0x13B4040, 0x80
+sZangooseSprites68:
+ax_sprite sZangooseGfx68, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx68_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx68_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx68_3, 0x80
+ax_sprite_terminator
+sZangooseGfx69:
+.incbin "baserom.gba", 0x13B4100, 0x40
+sZangooseGfx69_1:
+.incbin "baserom.gba", 0x13B4140, 0x60
+sZangooseGfx69_2:
+.incbin "baserom.gba", 0x13B41A0, 0x60
+sZangooseGfx69_3:
+.incbin "baserom.gba", 0x13B4200, 0x60
+sZangooseSprites69:
+ax_sprite sZangooseGfx69, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx69_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx69_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx69_3, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx70:
+.incbin "baserom.gba", 0x13B42A8, 0x160
+sZangooseSprites70:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx70, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx71:
+.incbin "baserom.gba", 0x13B4428, 0x180
+sZangooseSprites71:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx71, 0x180
+ax_sprite_terminator
+sZangooseGfx72:
+.incbin "baserom.gba", 0x13B45C0, 0x40
+sZangooseGfx72_1:
+.incbin "baserom.gba", 0x13B4600, 0x40
+sZangooseGfx72_2:
+.incbin "baserom.gba", 0x13B4640, 0xE0
+sZangooseSprites72:
+ax_sprite sZangooseGfx72, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx72_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx72_2, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx73:
+.incbin "baserom.gba", 0x13B4758, 0x40
+sZangooseGfx73_1:
+.incbin "baserom.gba", 0x13B4798, 0x140
+sZangooseSprites73:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx73, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx73_1, 0x140
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx74:
+.incbin "baserom.gba", 0x13B4908, 0x40
+sZangooseGfx74_1:
+.incbin "baserom.gba", 0x13B4948, 0xE0
+sZangooseGfx74_2:
+.incbin "baserom.gba", 0x13B4A28, 0x60
+sZangooseSprites74:
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx74, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx74_1, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sZangooseGfx74_2, 0x60
+ax_sprite_terminator
+sZangooseGfx75:
+.incbin "baserom.gba", 0x13B4AC0, 0x180
+sZangooseSprites75:
+ax_sprite 0, 0x80
+ax_sprite sZangooseGfx75, 0x180
+ax_sprite_terminator
+sZangooseGfx76:
+.incbin "baserom.gba", 0x13B4C58, 0x40
+sZangooseGfx76_1:
+.incbin "baserom.gba", 0x13B4C98, 0x160
+sZangooseSprites76:
+ax_sprite sZangooseGfx76, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZangooseGfx76_1, 0x160
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZangooseGfx77:
+.incbin "baserom.gba", 0x13B4E20, 0x200
+sZangooseSprites77:
+ax_sprite sZangooseGfx77, 0x200
+ax_sprite_terminator
+sZangooseGfx78:
+.incbin "baserom.gba", 0x13B5030, 0x200
+sZangooseSprites78:
+ax_sprite sZangooseGfx78, 0x200
+ax_sprite_terminator
+sZangooseGfx79:
+.incbin "baserom.gba", 0x13B5240, 0x200
+sZangooseSprites79:
+ax_sprite sZangooseGfx79, 0x200
+ax_sprite_terminator
+sZangooseGfx80:
+.incbin "baserom.gba", 0x13B5450, 0x200
+sZangooseSprites80:
+ax_sprite sZangooseGfx80, 0x200
+ax_sprite_terminator
+sZangooseGfx81:
+.incbin "baserom.gba", 0x13B5660, 0x200
+sZangooseSprites81:
+ax_sprite sZangooseGfx81, 0x200
+ax_sprite_terminator
+sZangooseGfx82:
+.incbin "baserom.gba", 0x13B5870, 0x200
+sZangooseSprites82:
+ax_sprite sZangooseGfx82, 0x200
+ax_sprite_terminator
+sZangooseGfx83:
+.incbin "baserom.gba", 0x13B5A80, 0x200
+sZangooseSprites83:
+ax_sprite sZangooseGfx83, 0x200
+ax_sprite_terminator
+sZangooseGfx84:
+.incbin "baserom.gba", 0x13B5C90, 0x200
+sZangooseSprites84:
+ax_sprite sZangooseGfx84, 0x200
+ax_sprite_terminator
+sZangooseGfx85:
+.incbin "baserom.gba", 0x13B5EA0, 0x200
+sZangooseSprites85:
+ax_sprite sZangooseGfx85, 0x200
+ax_sprite_terminator
+sZangooseGfx86:
+.incbin "baserom.gba", 0x13B60B0, 0x200
+sZangooseSprites86:
+ax_sprite sZangooseGfx86, 0x200
+ax_sprite_terminator
+sAxPosesZangoose:
+.4byte sZangoosePose1
+.4byte sZangoosePose2
+.4byte sZangoosePose3
+.4byte sZangoosePose4
+.4byte sZangoosePose5
+.4byte sZangoosePose6
+.4byte sZangoosePose7
+.4byte sZangoosePose8
+.4byte sZangoosePose9
+.4byte sZangoosePose10
+.4byte sZangoosePose11
+.4byte sZangoosePose12
+.4byte sZangoosePose13
+.4byte sZangoosePose14
+.4byte sZangoosePose15
+.4byte sZangoosePose16
+.4byte sZangoosePose17
+.4byte sZangoosePose18
+.4byte sZangoosePose19
+.4byte sZangoosePose20
+.4byte sZangoosePose21
+.4byte sZangoosePose22
+.4byte sZangoosePose23
+.4byte sZangoosePose24
+.4byte sZangoosePose25
+.4byte sZangoosePose26
+.4byte sZangoosePose27
+.4byte sZangoosePose28
+.4byte sZangoosePose29
+.4byte sZangoosePose30
+.4byte sZangoosePose31
+.4byte sZangoosePose32
+.4byte sZangoosePose33
+.4byte sZangoosePose34
+.4byte sZangoosePose35
+.4byte sZangoosePose36
+.4byte sZangoosePose37
+.4byte sZangoosePose38
+.4byte sZangoosePose39
+.4byte sZangoosePose40
+.4byte sZangoosePose41
+.4byte sZangoosePose42
+.4byte sZangoosePose43
+.4byte sZangoosePose44
+.4byte sZangoosePose45
+.4byte sZangoosePose46
+.4byte sZangoosePose47
+.4byte sZangoosePose48
+.4byte sZangoosePose49
+.4byte sZangoosePose50
+.4byte sZangoosePose51
+.4byte sZangoosePose52
+.4byte sZangoosePose53
+.4byte sZangoosePose54
+.4byte sZangoosePose55
+.4byte sZangoosePose56
+.4byte sZangoosePose57
+.4byte sZangoosePose58
+.4byte sZangoosePose59
+.4byte sZangoosePose60
+.4byte sZangoosePose61
+.4byte sZangoosePose62
+.4byte sZangoosePose63
+.4byte sZangoosePose64
+.4byte sZangoosePose65
+.4byte sZangoosePose66
+.4byte sZangoosePose67
+.4byte sZangoosePose68
+.4byte sZangoosePose69
+.4byte sZangoosePose70
+.4byte sZangoosePose71
+.4byte sZangoosePose72
+.4byte sZangoosePose73
+.4byte sZangoosePose74
+.4byte sZangoosePose75
+.4byte sZangoosePose76
+.4byte sZangoosePose77
+.4byte sZangoosePose78
+.4byte sZangoosePose79
+.4byte sZangoosePose80
+.4byte sZangoosePose81
+.4byte sZangoosePose82
+.4byte sZangoosePose83
+.4byte sZangoosePose84
+.4byte sZangoosePose85
+.4byte sZangoosePose86
+.4byte sZangoosePose87
+.4byte sZangoosePose88
+.4byte sZangoosePose89
+.4byte sZangoosePose90
+.4byte sZangoosePose91
+.4byte sZangoosePose92
+.4byte sZangoosePose93
+.4byte sZangoosePose94
+.4byte sZangoosePose95
+.4byte sZangoosePose96
+.4byte sZangoosePose97
+.4byte sZangoosePose98
+.4byte sZangoosePose99
+.4byte sZangoosePose100
+.4byte sZangoosePose101
+.4byte sZangoosePose102
+.4byte sZangoosePose103
+.4byte sZangoosePose104
+.4byte sZangoosePose105
+.4byte sZangoosePose106
+.4byte sZangoosePose107
+.4byte sZangoosePose108
+.4byte sZangoosePose109
+.4byte sZangoosePose110
+.4byte sZangoosePose111
+.4byte sZangoosePose112
+.4byte sZangoosePose113
+.4byte sZangoosePose114
+.4byte sZangoosePose115
+.4byte sZangoosePose116
+.4byte sZangoosePose117
+.4byte sZangoosePose118
+.4byte sZangoosePose119
+.4byte sZangoosePose120
+.4byte sZangoosePose121
+.4byte sZangoosePose122
+.4byte sZangoosePose123
+.4byte sZangoosePose124
+.4byte sZangoosePose125
+.4byte sZangoosePose126
+.4byte sZangoosePose127
+.4byte sZangoosePose128
+.4byte sZangoosePose129
+.4byte sZangoosePose130
+.4byte sZangoosePose131
+.4byte sZangoosePose132
+.4byte sZangoosePose133
+.4byte sZangoosePose134
+.4byte sZangoosePose135
+.4byte sZangoosePose136
+.4byte sZangoosePose137
+.4byte sZangoosePose138
+.4byte sZangoosePose139
+.4byte sZangoosePose140
+.4byte sZangoosePose141
+.4byte sZangoosePose142
+.4byte sZangoosePose143
+.4byte sZangoosePose144
+.4byte sZangoosePose145
+.4byte sZangoosePose146
+.4byte sZangoosePose147
+.4byte sZangoosePose148
+.4byte sZangoosePose149
+.4byte sZangoosePose150
+.4byte sZangoosePose151
+.4byte sZangoosePose152
+.4byte sZangoosePose153
+.4byte sZangoosePose154
+.4byte sZangoosePose155
+.4byte sZangoosePose156
+.4byte sZangoosePose157
+.4byte sZangoosePose158
+.4byte sZangoosePose159
+.4byte sZangoosePose160
+.4byte sZangoosePose161
+.4byte sZangoosePose162
+.4byte sZangoosePose163
+.4byte sZangoosePose164
+.4byte sZangoosePose165
+.4byte sZangoosePose166
+.4byte sZangoosePose167
+.4byte sZangoosePose168
+.4byte sZangoosePose169
+.4byte sZangoosePose170
+.4byte sZangoosePose171
+.4byte sZangoosePose172
+.4byte sZangoosePose173
+.4byte sZangoosePose174
+.4byte sZangoosePose175
+.4byte sZangoosePose176
+.4byte sZangoosePose177
+.4byte sZangoosePose178
+.4byte sZangoosePose179
+.4byte sZangoosePose180
+.4byte sZangoosePose181
+.4byte sZangoosePose182
+.4byte sZangoosePose183
+.4byte sZangoosePose184
+.4byte sZangoosePose185
+.4byte sZangoosePose186
+.4byte sZangoosePose187
+.4byte sZangoosePose188
+.4byte sZangoosePose189
+.4byte sZangoosePose190
+.4byte sZangoosePose191
+.4byte sZangoosePose192
+.4byte sZangoosePose193
+.4byte sZangoosePose194
+.4byte sZangoosePose195
+.4byte sZangoosePose196
+.4byte sZangoosePose197
+.4byte sZangoosePose198
+.4byte sZangoosePose199
+.4byte sZangoosePose200
+.4byte sZangoosePose201
+.4byte sZangoosePose202
+.4byte sZangoosePose203
+.4byte sZangoosePose204
+.4byte sZangoosePose205
+.4byte sZangoosePose206
+.4byte sZangoosePose207
+.4byte sZangoosePose208
+.4byte sZangoosePose209
+.4byte sZangoosePose210
+sAxPositionsZangoose:
+.2byte    0,   -5, 	  -6,    2, 	   5,    2, 	   0,   -7
+.2byte    0,   -4, 	  -5,    4, 	   4,    2, 	   0,   -6
+.2byte    0,   -4, 	  -5,    2, 	   4,    4, 	   0,   -6
+.2byte    7,   -6, 	   1,    3, 	   8,    0, 	   1,   -6
+.2byte    7,   -5, 	  -1,    3, 	  10,    2, 	   0,   -5
+.2byte    7,   -5, 	   4,    4, 	   6,    1, 	  -1,   -6
+.2byte   11,  -10, 	   5,    0, 	   4,   -3, 	  -1,   -7
+.2byte   11,   -9, 	   3,    1, 	   7,   -1, 	  -2,   -6
+.2byte   11,   -9, 	   7,    1, 	   1,   -1, 	  -2,   -5
+.2byte    6,  -14, 	   7,   -2, 	   1,   -7, 	   0,   -7
+.2byte    6,  -13, 	   6,    0, 	   2,   -4, 	   0,   -6
+.2byte    7,  -13, 	   9,   -2, 	   2,   -3, 	  -1,   -6
+.2byte    0,  -13, 	   4,  -10, 	  -3,  -10, 	   0,   -8
+.2byte    0,  -12, 	   4,  -10, 	  -3,  -10, 	   0,   -7
+.2byte    0,  -12, 	   5,   -9, 	  -2,   -8, 	   0,   -7
+.2byte   -8,  -12, 	  -1,   -4, 	  -8,   -2, 	  -1,   -7
+.2byte   -8,  -11, 	  -4,   -4, 	  -6,    1, 	  -1,   -6
+.2byte   -8,  -11, 	   0,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte  -12,  -10, 	  -5,   -2, 	  -6,    1, 	   0,   -7
+.2byte  -12,   -9, 	  -9,    0, 	  -3,    1, 	   0,   -6
+.2byte  -12,   -9, 	  -2,    0, 	  -8,    1, 	   1,   -5
+.2byte   -8,   -7, 	 -10,    1, 	  -2,    3, 	   0,   -7
+.2byte   -8,   -6, 	 -11,    3, 	   0,    2, 	   0,   -5
+.2byte   -8,   -6, 	  -7,    1, 	  -5,    5, 	   1,   -6
+.2byte    0,   -5, 	  -6,    2, 	   5,    2, 	   0,   -7
+.2byte    0,   -4, 	  -5,    4, 	   4,    2, 	   0,   -6
+.2byte    0,   -4, 	  -5,    2, 	   4,    4, 	   0,   -6
+.2byte   -1,    4, 	  -9,   -4, 	   8,   -3, 	  -1,   -6
+.2byte    7,   -6, 	   1,    3, 	   8,    0, 	   1,   -6
+.2byte    7,   -5, 	  -1,    3, 	  10,    2, 	   0,   -5
+.2byte    7,   -5, 	   4,    4, 	   6,    1, 	  -1,   -6
+.2byte    3,    1, 	  -5,   -1, 	   1,   -2, 	   0,   -8
+.2byte   11,  -10, 	   5,    0, 	   4,   -3, 	  -1,   -7
+.2byte   11,   -9, 	   3,    1, 	   7,   -1, 	  -2,   -6
+.2byte   11,   -9, 	   7,    1, 	   1,   -1, 	  -2,   -5
+.2byte    8,   -2, 	  -2,   -1, 	   0,   -2, 	   0,   -6
+.2byte    6,  -14, 	   7,   -2, 	   1,   -7, 	   0,   -7
+.2byte    6,  -13, 	   6,    0, 	   2,   -4, 	   0,   -6
+.2byte    7,  -13, 	   9,   -2, 	   2,   -3, 	  -1,   -6
+.2byte    7,  -13, 	   5,    0, 	   0,   -4, 	   1,   -8
+.2byte    0,  -13, 	   4,  -10, 	  -3,  -10, 	   0,   -8
+.2byte    0,  -12, 	   4,  -10, 	  -3,  -10, 	   0,   -7
+.2byte    0,  -12, 	   5,   -9, 	  -2,   -8, 	   0,   -7
+.2byte   -1,  -13, 	   7,   -6, 	  -8,   -5, 	  -1,   -9
+.2byte   -8,  -12, 	  -1,   -4, 	  -8,   -2, 	  -1,   -7
+.2byte   -8,  -11, 	  -4,   -4, 	  -6,    1, 	  -1,   -6
+.2byte   -8,  -11, 	   0,   -3, 	 -10,   -3, 	  -1,   -7
+.2byte   -7,  -12, 	   1,   -6, 	  -6,    0, 	  -2,   -8
+.2byte  -12,  -10, 	  -5,   -2, 	  -6,    1, 	   0,   -7
+.2byte  -12,   -9, 	  -9,    0, 	  -3,    1, 	   0,   -6
+.2byte  -12,   -9, 	  -2,    0, 	  -8,    1, 	   1,   -5
+.2byte  -10,   -2, 	  -1,   -4, 	   2,   -1, 	   0,   -7
+.2byte   -8,   -7, 	 -10,    1, 	  -2,    3, 	   0,   -7
+.2byte   -8,   -6, 	 -11,    3, 	   0,    2, 	   0,   -5
+.2byte   -8,   -6, 	  -7,    1, 	  -5,    5, 	   1,   -6
+.2byte   -4,    1, 	  -4,   -3, 	   4,   -1, 	  -1,   -8
+.2byte    0,  -13, 	 -10,   -4, 	   9,   -4, 	   0,   -7
+.2byte    3,   -8, 	   6,   -1, 	  11,  -14, 	   0,   -7
+.2byte    3,   -8, 	   6,   -1, 	  11,  -14, 	   0,   -7
+.2byte   -3,   -9, 	 -11,  -15, 	  -6,   -2, 	   0,   -7
+.2byte   -3,   -9, 	 -11,  -15, 	  -6,   -2, 	   0,   -7
+.2byte    0,   -9, 	  -9,   -7, 	   9,   -7, 	   0,   -6
+.2byte    2,  -13, 	  -6,   -3, 	   7,   -7, 	   1,   -8
+.2byte    3,   -8, 	 -10,  -15, 	  -1,   -1, 	   1,   -8
+.2byte    3,   -8, 	 -10,  -15, 	  -1,   -1, 	   1,   -8
+.2byte    5,   -6, 	   7,   -2, 	   7,  -14, 	  -2,   -7
+.2byte    5,   -6, 	   7,   -2, 	   7,  -14, 	  -2,   -7
+.2byte    6,   -8, 	  -4,   -7, 	  10,  -10, 	   2,   -8
+.2byte    4,  -15, 	  -2,   -3, 	   3,   -8, 	   0,   -9
+.2byte    6,   -6, 	  -6,  -11, 	   3,    0, 	   0,   -5
+.2byte    6,   -6, 	  -6,  -11, 	   3,    0, 	   0,   -5
+.2byte    7,   -8, 	   8,   -3, 	  -1,  -16, 	  -2,   -7
+.2byte    7,   -8, 	   8,   -3, 	  -1,  -16, 	  -2,   -7
+.2byte    8,   -9, 	   3,   -5, 	   6,   -6, 	   0,   -8
+.2byte    2,  -15, 	   6,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    5,  -13, 	   3,   -8, 	   9,   -5, 	  -1,   -9
+.2byte    5,  -13, 	   3,   -8, 	   9,   -5, 	  -1,   -9
+.2byte    0,  -14, 	   2,  -11, 	 -11,  -17, 	  -1,   -9
+.2byte    0,  -14, 	   2,  -11, 	 -11,  -17, 	  -1,   -9
+.2byte    4,  -13, 	   9,  -10, 	  -1,  -13, 	  -1,   -9
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -5, 	  -1,   -8
+.2byte   -3,  -13, 	  -8,  -11, 	 -10,   -5, 	   1,   -9
+.2byte   -3,  -13, 	  -8,  -11, 	 -10,   -5, 	   1,   -9
+.2byte    2,  -13, 	   8,   -5, 	   7,  -12, 	  -2,   -8
+.2byte    2,  -13, 	   8,   -5, 	   7,  -12, 	  -2,   -8
+.2byte   -1,  -14, 	   9,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -5,  -13, 	 -11,   -5, 	  -3,   -8, 	  -1,   -8
+.2byte   -5,  -13, 	 -11,   -5, 	  -3,   -8, 	  -1,   -8
+.2byte   -2,  -13, 	   9,  -17, 	  -2,   -9, 	   0,   -9
+.2byte   -2,  -13, 	   9,  -17, 	  -2,   -9, 	   0,   -9
+.2byte   -5,  -12, 	  -1,  -12, 	 -10,   -9, 	  -1,   -9
+.2byte   -6,  -15, 	  -3,   -7, 	   0,   -2, 	   0,   -7
+.2byte   -8,   -6, 	  -5,    0, 	   4,  -12, 	  -2,   -5
+.2byte   -8,   -6, 	  -5,    0, 	   4,  -12, 	  -2,   -5
+.2byte   -9,   -8, 	  -2,  -16, 	  -9,   -4, 	  -1,   -6
+.2byte   -9,   -8, 	  -2,  -16, 	  -9,   -4, 	  -1,   -6
+.2byte  -10,   -9, 	  -6,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -4,  -14, 	  -9,   -6, 	   4,   -2, 	  -2,   -7
+.2byte   -4,   -8, 	  -1,   -1, 	   8,  -15, 	  -2,   -7
+.2byte   -4,   -8, 	  -1,   -1, 	   8,  -15, 	  -2,   -7
+.2byte   -8,   -7, 	 -10,  -15, 	  -9,   -3, 	  -1,   -6
+.2byte   -8,   -7, 	 -10,  -15, 	  -9,   -3, 	  -1,   -6
+.2byte   -8,   -8, 	 -12,  -10, 	   2,   -7, 	  -3,   -6
+.2byte    0,  -13, 	 -10,   -4, 	   9,   -4, 	   0,   -7
+.2byte    0,   -9, 	  -9,   -7, 	   9,   -7, 	   0,   -6
+.2byte    2,  -13, 	  -6,   -3, 	   7,   -7, 	   1,   -8
+.2byte    6,   -8, 	  -4,   -7, 	  10,  -10, 	   2,   -8
+.2byte    4,  -15, 	  -2,   -3, 	   3,   -8, 	   0,   -9
+.2byte    8,   -9, 	   3,   -5, 	   6,   -6, 	   0,   -8
+.2byte    2,  -15, 	   6,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    4,  -13, 	   9,  -10, 	  -1,  -13, 	  -1,   -9
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   9,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -5,  -12, 	  -1,  -12, 	 -10,   -9, 	  -1,   -9
+.2byte   -6,  -15, 	  -3,   -7, 	   0,   -2, 	   0,   -7
+.2byte  -10,   -9, 	  -6,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -4,  -14, 	  -9,   -6, 	   4,   -2, 	  -2,   -7
+.2byte   -8,   -8, 	 -12,  -10, 	   2,   -7, 	  -3,   -6
+.2byte    0,  -13, 	 -10,   -4, 	   9,   -4, 	   0,   -7
+.2byte    0,   -9, 	  -9,   -7, 	   9,   -7, 	   0,   -6
+.2byte    2,  -13, 	  -6,   -3, 	   7,   -7, 	   1,   -8
+.2byte    6,   -8, 	  -4,   -7, 	  10,  -10, 	   2,   -8
+.2byte    4,  -15, 	  -2,   -3, 	   3,   -8, 	   0,   -9
+.2byte    8,   -9, 	   3,   -5, 	   6,   -6, 	   0,   -8
+.2byte    2,  -15, 	   6,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    4,  -13, 	   9,  -10, 	  -1,  -13, 	  -1,   -9
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   9,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -5,  -12, 	  -1,  -12, 	 -10,   -9, 	  -1,   -9
+.2byte   -6,  -15, 	  -3,   -7, 	   0,   -2, 	   0,   -7
+.2byte  -10,   -9, 	  -6,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -4,  -14, 	  -9,   -6, 	   4,   -2, 	  -2,   -7
+.2byte   -8,   -8, 	 -12,  -10, 	   2,   -7, 	  -3,   -6
+.2byte   -6,    0, 	  -7,    2, 	  -3,    3, 	   2,   -5
+.2byte   -6,    0, 	  -8,    1, 	  -3,    3, 	   2,   -5
+.2byte    0,  -13, 	  -5,  -16, 	   4,  -16, 	   0,   -9
+.2byte    1,  -13, 	  -6,  -13, 	   4,  -17, 	   1,   -9
+.2byte    1,  -14, 	  -4,  -17, 	   1,  -18, 	  -1,   -9
+.2byte    1,  -14, 	   4,  -16, 	  -4,  -18, 	  -1,   -8
+.2byte    0,  -14, 	   5,  -16, 	  -6,  -17, 	  -1,   -9
+.2byte   -1,  -14, 	   2,  -20, 	  -4,  -17, 	   0,   -9
+.2byte   -2,  -14, 	  -1,  -20, 	   2,  -16, 	   0,   -9
+.2byte   -2,  -13, 	  -4,  -17, 	   4,  -14, 	  -1,   -8
+.2byte    0,  -13, 	 -10,   -4, 	   9,   -4, 	   0,   -7
+.2byte    0,   -9, 	  -9,   -7, 	   9,   -7, 	   0,   -6
+.2byte    2,  -13, 	  -6,   -3, 	   7,   -7, 	   1,   -8
+.2byte    6,   -8, 	  -4,   -7, 	  10,  -10, 	   2,   -8
+.2byte    4,  -15, 	  -2,   -3, 	   3,   -8, 	   0,   -9
+.2byte    8,   -9, 	   3,   -5, 	   6,   -6, 	   0,   -8
+.2byte    2,  -15, 	   6,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    4,  -13, 	   9,  -10, 	  -1,  -13, 	  -1,   -9
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   9,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -5,  -12, 	  -1,  -12, 	 -10,   -9, 	  -1,   -9
+.2byte   -6,  -15, 	  -3,   -7, 	   0,   -2, 	   0,   -7
+.2byte  -10,   -9, 	  -6,   -7, 	  -5,   -4, 	  -1,   -8
+.2byte   -4,  -14, 	  -9,   -6, 	   4,   -2, 	  -2,   -7
+.2byte   -8,   -8, 	 -12,  -10, 	   2,   -7, 	  -3,   -6
+.2byte   -3,   -9, 	 -11,  -15, 	  -6,   -2, 	   0,   -7
+.2byte   -8,   -8, 	 -10,  -16, 	  -9,   -4, 	  -1,   -7
+.2byte  -10,   -9, 	  -3,  -17, 	 -10,   -5, 	  -2,   -7
+.2byte   -2,  -13, 	   9,  -17, 	  -2,   -9, 	   0,   -9
+.2byte    2,  -14, 	   8,   -6, 	   7,  -13, 	  -2,   -9
+.2byte    7,  -13, 	   5,   -8, 	  11,   -5, 	   1,   -9
+.2byte    6,   -7, 	  -6,  -12, 	   3,   -1, 	   0,   -6
+.2byte    1,   -7, 	 -12,  -14, 	  -3,    0, 	  -1,   -7
+.2byte   -3,   -9, 	 -11,  -15, 	  -6,   -2, 	   0,   -7
+.2byte    1,   -7, 	 -12,  -14, 	  -3,    0, 	  -1,   -7
+.2byte    6,   -7, 	  -6,  -12, 	   3,   -1, 	   0,   -6
+.2byte    5,  -13, 	   3,   -8, 	   9,   -5, 	  -1,   -9
+.2byte    3,  -14, 	   9,   -6, 	   8,  -13, 	  -1,   -9
+.2byte   -2,  -13, 	   9,  -17, 	  -2,   -9, 	   0,   -9
+.2byte   -8,   -9, 	  -1,  -17, 	  -8,   -5, 	   0,   -7
+.2byte   -7,   -8, 	  -9,  -16, 	  -8,   -4, 	   0,   -7
+.2byte    0,  -13, 	 -10,   -4, 	   9,   -4, 	   0,   -7
+.2byte    0,   -9, 	  -9,   -7, 	   9,   -7, 	   0,   -6
+.2byte    2,  -13, 	  -6,   -3, 	   7,   -7, 	   1,   -8
+.2byte    3,   -8, 	  -7,   -7, 	   7,  -10, 	  -1,   -8
+.2byte    4,  -15, 	  -2,   -3, 	   3,   -8, 	   0,   -9
+.2byte    6,   -9, 	   1,   -5, 	   4,   -6, 	  -2,   -8
+.2byte    2,  -15, 	   6,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    2,  -12, 	   7,   -9, 	  -3,  -12, 	  -3,   -8
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -5, 	  -1,   -8
+.2byte   -1,  -14, 	   9,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte   -4,  -15, 	   3,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -3,  -11, 	   1,  -11, 	  -8,   -8, 	   1,   -8
+.2byte   -6,  -15, 	  -3,   -7, 	   0,   -2, 	   0,   -7
+.2byte   -8,   -9, 	  -4,   -7, 	  -3,   -4, 	   1,   -8
+.2byte   -4,  -14, 	  -9,   -6, 	   4,   -2, 	  -2,   -7
+.2byte   -5,   -8, 	  -9,  -10, 	   5,   -7, 	   0,   -6
+.2byte    0,   -9, 	  -9,   -7, 	   9,   -7, 	   0,   -6
+.2byte   -6,   -8, 	 -10,  -10, 	   4,   -7, 	  -1,   -6
+.2byte   -8,   -9, 	  -4,   -7, 	  -3,   -4, 	   1,   -8
+.2byte   -3,  -12, 	   1,  -12, 	  -8,   -9, 	   1,   -9
+.2byte   -1,  -14, 	   9,  -11, 	 -10,  -11, 	  -1,   -9
+.2byte    3,  -13, 	   8,  -10, 	  -2,  -13, 	  -2,   -9
+.2byte    7,   -9, 	   2,   -5, 	   5,   -6, 	  -1,   -8
+.2byte    5,   -8, 	  -5,   -7, 	   9,  -10, 	   1,   -8
+.2byte    0,  -13, 	 -10,   -4, 	   9,   -4, 	   0,   -7
+.2byte   -4,  -14, 	  -9,   -6, 	   4,   -2, 	  -2,   -7
+.2byte   -6,  -15, 	  -3,   -7, 	   0,   -2, 	   0,   -7
+.2byte   -4,  -15, 	   3,   -8, 	  -8,   -4, 	   0,   -8
+.2byte   -1,  -15, 	  10,   -4, 	 -10,   -5, 	  -1,   -8
+.2byte    2,  -15, 	   6,   -4, 	  -3,   -9, 	   0,   -9
+.2byte    4,  -15, 	  -2,   -3, 	   3,   -8, 	   0,   -9
+.2byte    2,  -13, 	  -6,   -3, 	   7,   -7, 	   1,   -8
+sZangooseAnimTable1:
+.4byte sZangooseAnims_1_1
+.4byte sZangooseAnims_1_2
+.4byte sZangooseAnims_1_3
+.4byte sZangooseAnims_1_4
+.4byte sZangooseAnims_1_5
+.4byte sZangooseAnims_1_6
+.4byte sZangooseAnims_1_7
+.4byte sZangooseAnims_1_8
+sZangooseAnimTable2:
+.4byte sZangooseAnims_2_1
+.4byte sZangooseAnims_2_2
+.4byte sZangooseAnims_2_3
+.4byte sZangooseAnims_2_4
+.4byte sZangooseAnims_2_5
+.4byte sZangooseAnims_2_6
+.4byte sZangooseAnims_2_7
+.4byte sZangooseAnims_2_8
+sZangooseAnimTable3:
+.4byte sZangooseAnims_3_1
+.4byte sZangooseAnims_3_2
+.4byte sZangooseAnims_3_3
+.4byte sZangooseAnims_3_4
+.4byte sZangooseAnims_3_5
+.4byte sZangooseAnims_3_6
+.4byte sZangooseAnims_3_7
+.4byte sZangooseAnims_3_8
+sZangooseAnimTable4:
+.4byte sZangooseAnims_4_1
+.4byte sZangooseAnims_4_2
+.4byte sZangooseAnims_4_3
+.4byte sZangooseAnims_4_4
+.4byte sZangooseAnims_4_5
+.4byte sZangooseAnims_4_6
+.4byte sZangooseAnims_4_7
+.4byte sZangooseAnims_4_8
+sZangooseAnimTable5:
+.4byte sZangooseAnims_5_1
+.4byte sZangooseAnims_5_2
+.4byte sZangooseAnims_5_3
+.4byte sZangooseAnims_5_4
+.4byte sZangooseAnims_5_5
+.4byte sZangooseAnims_5_6
+.4byte sZangooseAnims_5_7
+.4byte sZangooseAnims_5_8
+sZangooseAnimTable6:
+.4byte sZangooseAnims_6_1
+.4byte sZangooseAnims_6_1
+.4byte sZangooseAnims_6_1
+.4byte sZangooseAnims_6_1
+.4byte sZangooseAnims_6_1
+.4byte sZangooseAnims_6_1
+.4byte sZangooseAnims_6_1
+.4byte sZangooseAnims_6_1
+sZangooseAnimTable7:
+.4byte sZangooseAnims_7_1
+.4byte sZangooseAnims_7_2
+.4byte sZangooseAnims_7_3
+.4byte sZangooseAnims_7_4
+.4byte sZangooseAnims_7_5
+.4byte sZangooseAnims_7_6
+.4byte sZangooseAnims_7_7
+.4byte sZangooseAnims_7_8
+sZangooseAnimTable8:
+.4byte sZangooseAnims_8_1
+.4byte sZangooseAnims_8_2
+.4byte sZangooseAnims_8_3
+.4byte sZangooseAnims_8_4
+.4byte sZangooseAnims_8_5
+.4byte sZangooseAnims_8_6
+.4byte sZangooseAnims_8_7
+.4byte sZangooseAnims_8_8
+sZangooseAnimTable9:
+.4byte sZangooseAnims_9_1
+.4byte sZangooseAnims_9_2
+.4byte sZangooseAnims_9_3
+.4byte sZangooseAnims_9_4
+.4byte sZangooseAnims_9_5
+.4byte sZangooseAnims_9_6
+.4byte sZangooseAnims_9_7
+.4byte sZangooseAnims_9_8
+sZangooseAnimTable10:
+.4byte sZangooseAnims_10_1
+.4byte sZangooseAnims_10_2
+.4byte sZangooseAnims_10_3
+.4byte sZangooseAnims_10_4
+.4byte sZangooseAnims_10_5
+.4byte sZangooseAnims_10_6
+.4byte sZangooseAnims_10_7
+.4byte sZangooseAnims_10_8
+sZangooseAnimTable11:
+.4byte sZangooseAnims_11_1
+.4byte sZangooseAnims_11_2
+.4byte sZangooseAnims_11_3
+.4byte sZangooseAnims_11_4
+.4byte sZangooseAnims_11_5
+.4byte sZangooseAnims_11_6
+.4byte sZangooseAnims_11_7
+.4byte sZangooseAnims_11_8
+sZangooseAnimTable12:
+.4byte sZangooseAnims_12_1
+.4byte sZangooseAnims_12_2
+.4byte sZangooseAnims_12_3
+.4byte sZangooseAnims_12_4
+.4byte sZangooseAnims_12_5
+.4byte sZangooseAnims_12_6
+.4byte sZangooseAnims_12_7
+.4byte sZangooseAnims_12_8
+sZangooseAnimTable13:
+.4byte sZangooseAnims_13_1
+.4byte sZangooseAnims_13_2
+.4byte sZangooseAnims_13_3
+.4byte sZangooseAnims_13_4
+.4byte sZangooseAnims_13_5
+.4byte sZangooseAnims_13_6
+.4byte sZangooseAnims_13_7
+.4byte sZangooseAnims_13_8
+sAxAnimationsZangoose:
+.4byte sZangooseAnimTable1
+.4byte sZangooseAnimTable2
+.4byte sZangooseAnimTable3
+.4byte sZangooseAnimTable4
+.4byte sZangooseAnimTable5
+.4byte sZangooseAnimTable6
+.4byte sZangooseAnimTable7
+.4byte sZangooseAnimTable8
+.4byte sZangooseAnimTable9
+.4byte sZangooseAnimTable10
+.4byte sZangooseAnimTable11
+.4byte sZangooseAnimTable12
+.4byte sZangooseAnimTable13
+sAxSpritesZangoose:
+.4byte sZangooseSprites1
+.4byte sZangooseSprites2
+.4byte sZangooseSprites3
+.4byte sZangooseSprites4
+.4byte sZangooseSprites5
+.4byte sZangooseSprites6
+.4byte sZangooseSprites7
+.4byte sZangooseSprites8
+.4byte sZangooseSprites9
+.4byte sZangooseSprites10
+.4byte sZangooseSprites11
+.4byte sZangooseSprites12
+.4byte sZangooseSprites13
+.4byte sZangooseSprites14
+.4byte sZangooseSprites15
+.4byte sZangooseSprites16
+.4byte sZangooseSprites17
+.4byte sZangooseSprites18
+.4byte sZangooseSprites19
+.4byte sZangooseSprites20
+.4byte sZangooseSprites21
+.4byte sZangooseSprites22
+.4byte sZangooseSprites23
+.4byte sZangooseSprites24
+.4byte sZangooseSprites25
+.4byte sZangooseSprites26
+.4byte sZangooseSprites27
+.4byte sZangooseSprites28
+.4byte sZangooseSprites29
+.4byte sZangooseSprites30
+.4byte sZangooseSprites31
+.4byte sZangooseSprites32
+.4byte sZangooseSprites33
+.4byte sZangooseSprites34
+.4byte sZangooseSprites35
+.4byte sZangooseSprites36
+.4byte sZangooseSprites37
+.4byte sZangooseSprites38
+.4byte sZangooseSprites39
+.4byte sZangooseSprites40
+.4byte sZangooseSprites41
+.4byte sZangooseSprites42
+.4byte sZangooseSprites43
+.4byte sZangooseSprites44
+.4byte sZangooseSprites45
+.4byte sZangooseSprites46
+.4byte sZangooseSprites47
+.4byte sZangooseSprites48
+.4byte sZangooseSprites49
+.4byte sZangooseSprites50
+.4byte sZangooseSprites51
+.4byte sZangooseSprites52
+.4byte sZangooseSprites53
+.4byte sZangooseSprites54
+.4byte sZangooseSprites55
+.4byte sZangooseSprites56
+.4byte sZangooseSprites57
+.4byte sZangooseSprites58
+.4byte sZangooseSprites59
+.4byte sZangooseSprites60
+.4byte sZangooseSprites61
+.4byte sZangooseSprites62
+.4byte sZangooseSprites63
+.4byte sZangooseSprites64
+.4byte sZangooseSprites65
+.4byte sZangooseSprites66
+.4byte sZangooseSprites67
+.4byte sZangooseSprites68
+.4byte sZangooseSprites69
+.4byte sZangooseSprites70
+.4byte sZangooseSprites71
+.4byte sZangooseSprites72
+.4byte sZangooseSprites73
+.4byte sZangooseSprites74
+.4byte sZangooseSprites75
+.4byte sZangooseSprites76
+.4byte sZangooseSprites77
+.4byte sZangooseSprites78
+.4byte sZangooseSprites79
+.4byte sZangooseSprites80
+.4byte sZangooseSprites81
+.4byte sZangooseSprites82
+.4byte sZangooseSprites83
+.4byte sZangooseSprites84
+.4byte sZangooseSprites85
+.4byte sZangooseSprites86
+sAxMainZangoose:
+ax_main sAxPosesZangoose, sAxAnimationsZangoose, 13, sAxSpritesZangoose, sAxPositionsZangoose

--- a/data/ax/zapdos.inc
+++ b/data/ax/zapdos.inc
@@ -1,0 +1,4949 @@
+.global gAxZapdos
+gAxZapdos:
+ax_siro sAxMainZapdos
+sZapdosPose1:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose2:
+ax_pose 5, 0x01cf, 0x80ef, 0x4c00
+ax_pose 6, 0x41ef, 0x80ef, 0x4c10
+ax_pose 7, 0x01cf, 0x010f, 0x4c18
+ax_pose 8, 0x01df, 0x010f, 0x4c19
+ax_pose_terminator
+sZapdosPose3:
+ax_pose 9, 0x01de, 0x80f0, 0x4c00
+ax_pose 10, 0x41d6, 0x00f8, 0x4c10
+ax_pose 11, 0x81e6, 0x00e8, 0x4c12
+ax_pose 12, 0x81e6, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose4:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose5:
+ax_pose 18, 0x01cf, 0x90ee, 0x4c00
+ax_pose 19, 0x41ef, 0x90ee, 0x4c10
+ax_pose 20, 0x81e7, 0x110e, 0x4c18
+ax_pose_terminator
+sZapdosPose6:
+ax_pose 21, 0x01d3, 0x90f5, 0x4c00
+ax_pose 22, 0x01f3, 0x1105, 0x4c10
+ax_pose 23, 0x41f3, 0x10f5, 0x4c11
+ax_pose 24, 0x01e3, 0x1115, 0x4c13
+ax_pose_terminator
+sZapdosPose7:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose8:
+ax_pose 28, 0x01d2, 0x90f1, 0x4c00
+ax_pose 29, 0x41f2, 0x90f1, 0x4c10
+ax_pose 30, 0x81dd, 0x10e9, 0x4c18
+ax_pose 31, 0x01ea, 0x1111, 0x4c1a
+ax_pose_terminator
+sZapdosPose9:
+ax_pose 32, 0x01d4, 0x90f4, 0x4c00
+ax_pose 33, 0x01f4, 0x50f8, 0x4c10
+ax_pose_terminator
+sZapdosPose10:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose11:
+ax_pose 39, 0x81da, 0x510a, 0x4c00
+ax_pose 40, 0x01da, 0x90ea, 0x4c04
+ax_pose 41, 0x41fa, 0x10f2, 0x4c14
+ax_pose_terminator
+sZapdosPose12:
+ax_pose 42, 0x01d5, 0x90f3, 0x4c00
+ax_pose 43, 0x41f5, 0x50f3, 0x4c10
+ax_pose 38, 0x01cd, 0x1101, 0x4c14
+ax_pose_terminator
+sZapdosPose13:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose14:
+ax_pose 48, 0x01d8, 0x80ef, 0x4c00
+ax_pose 49, 0x41f8, 0x00f7, 0x4c10
+ax_pose 50, 0x81dc, 0x010f, 0x4c12
+ax_pose_terminator
+sZapdosPose15:
+ax_pose 51, 0x01dc, 0x80f0, 0x4c00
+ax_pose 52, 0x81e4, 0x00e8, 0x4c10
+ax_pose 53, 0x81e4, 0x0110, 0x4c12
+ax_pose 54, 0x41d4, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose16:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose17:
+ax_pose 39, 0x81da, 0x40ef, 0x4c00
+ax_pose 40, 0x01da, 0x80f7, 0x4c04
+ax_pose 41, 0x41fa, 0x00ff, 0x4c14
+ax_pose_terminator
+sZapdosPose18:
+ax_pose 42, 0x01d5, 0x80ee, 0x4c00
+ax_pose 43, 0x41f5, 0x40ee, 0x4c10
+ax_pose 38, 0x01cd, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose19:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose20:
+ax_pose 28, 0x01d2, 0x80f0, 0x4c00
+ax_pose 29, 0x41f2, 0x80f0, 0x4c10
+ax_pose 30, 0x81dd, 0x0110, 0x4c18
+ax_pose 31, 0x01ea, 0x00e8, 0x4c1a
+ax_pose_terminator
+sZapdosPose21:
+ax_pose 32, 0x01d4, 0x80ed, 0x4c00
+ax_pose 33, 0x01f4, 0x40f9, 0x4c10
+ax_pose_terminator
+sZapdosPose22:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose23:
+ax_pose 18, 0x01cf, 0x80f3, 0x4c00
+ax_pose 19, 0x41ef, 0x80f3, 0x4c10
+ax_pose 20, 0x81e7, 0x00eb, 0x4c18
+ax_pose_terminator
+sZapdosPose24:
+ax_pose 21, 0x01d3, 0x80ec, 0x4c00
+ax_pose 22, 0x01f3, 0x00f4, 0x4c10
+ax_pose 23, 0x41f3, 0x00fc, 0x4c11
+ax_pose 24, 0x01e3, 0x00e4, 0x4c13
+ax_pose_terminator
+sZapdosPose25:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose26:
+ax_pose 5, 0x01cf, 0x80ef, 0x4c00
+ax_pose 6, 0x41ef, 0x80ef, 0x4c10
+ax_pose 7, 0x01cf, 0x010f, 0x4c18
+ax_pose 8, 0x01df, 0x010f, 0x4c19
+ax_pose_terminator
+sZapdosPose27:
+ax_pose 9, 0x01de, 0x80f0, 0x4c00
+ax_pose 10, 0x41d6, 0x00f8, 0x4c10
+ax_pose 11, 0x81e6, 0x00e8, 0x4c12
+ax_pose 12, 0x81e6, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose28:
+ax_pose 55, 0x01da, 0x80e8, 0x4c00
+ax_pose 56, 0x81da, 0x8108, 0x4c10
+ax_pose 57, 0x41fa, 0x00f8, 0x4c18
+ax_pose_terminator
+sZapdosPose29:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose30:
+ax_pose 18, 0x01cf, 0x90ee, 0x4c00
+ax_pose 19, 0x41ef, 0x90ee, 0x4c10
+ax_pose 20, 0x81e7, 0x110e, 0x4c18
+ax_pose_terminator
+sZapdosPose31:
+ax_pose 21, 0x01d3, 0x90f5, 0x4c00
+ax_pose 22, 0x01f3, 0x1105, 0x4c10
+ax_pose 23, 0x41f3, 0x10f5, 0x4c11
+ax_pose 24, 0x01e3, 0x1115, 0x4c13
+ax_pose_terminator
+sZapdosPose32:
+ax_pose 58, 0x01dc, 0x90f8, 0x4c00
+ax_pose 59, 0x81dc, 0x90e8, 0x4c10
+ax_pose_terminator
+sZapdosPose33:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose34:
+ax_pose 28, 0x01d2, 0x90f1, 0x4c00
+ax_pose 29, 0x41f2, 0x90f1, 0x4c10
+ax_pose 30, 0x81dd, 0x10e9, 0x4c18
+ax_pose 31, 0x01ea, 0x1111, 0x4c1a
+ax_pose_terminator
+sZapdosPose35:
+ax_pose 32, 0x01d4, 0x90f4, 0x4c00
+ax_pose 33, 0x01f4, 0x50f8, 0x4c10
+ax_pose_terminator
+sZapdosPose36:
+ax_pose 60, 0x01d9, 0x90f9, 0x4c00
+ax_pose 61, 0x81d9, 0x90e9, 0x4c10
+ax_pose 62, 0x41f9, 0x10f9, 0x4c18
+ax_pose_terminator
+sZapdosPose37:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose38:
+ax_pose 39, 0x81da, 0x510a, 0x4c00
+ax_pose 40, 0x01da, 0x90ea, 0x4c04
+ax_pose 41, 0x41fa, 0x10f2, 0x4c14
+ax_pose_terminator
+sZapdosPose39:
+ax_pose 42, 0x01d5, 0x90f3, 0x4c00
+ax_pose 43, 0x41f5, 0x50f3, 0x4c10
+ax_pose 38, 0x01cd, 0x1101, 0x4c14
+ax_pose_terminator
+sZapdosPose40:
+ax_pose 63, 0x01da, 0x90f6, 0x4c00
+ax_pose 64, 0x81da, 0x50ee, 0x4c10
+ax_pose_terminator
+sZapdosPose41:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose42:
+ax_pose 48, 0x01d8, 0x80ef, 0x4c00
+ax_pose 49, 0x41f8, 0x00f7, 0x4c10
+ax_pose 50, 0x81dc, 0x010f, 0x4c12
+ax_pose_terminator
+sZapdosPose43:
+ax_pose 51, 0x01dc, 0x80f0, 0x4c00
+ax_pose 52, 0x81e4, 0x00e8, 0x4c10
+ax_pose 53, 0x81e4, 0x0110, 0x4c12
+ax_pose 54, 0x41d4, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose44:
+ax_pose 65, 0x01da, 0x80e7, 0x4c00
+ax_pose 66, 0x81da, 0x8107, 0x4c10
+ax_pose 67, 0x01ea, 0x0117, 0x4c18
+ax_pose_terminator
+sZapdosPose45:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose46:
+ax_pose 39, 0x81da, 0x40ef, 0x4c00
+ax_pose 40, 0x01da, 0x80f7, 0x4c04
+ax_pose 41, 0x41fa, 0x00ff, 0x4c14
+ax_pose_terminator
+sZapdosPose47:
+ax_pose 42, 0x01d5, 0x80ee, 0x4c00
+ax_pose 43, 0x41f5, 0x40ee, 0x4c10
+ax_pose 38, 0x01cd, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose48:
+ax_pose 63, 0x01da, 0x80eb, 0x4c00
+ax_pose 64, 0x81da, 0x410b, 0x4c10
+ax_pose_terminator
+sZapdosPose49:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose50:
+ax_pose 28, 0x01d2, 0x80f0, 0x4c00
+ax_pose 29, 0x41f2, 0x80f0, 0x4c10
+ax_pose 30, 0x81dd, 0x0110, 0x4c18
+ax_pose 31, 0x01ea, 0x00e8, 0x4c1a
+ax_pose_terminator
+sZapdosPose51:
+ax_pose 32, 0x01d4, 0x80ed, 0x4c00
+ax_pose 33, 0x01f4, 0x40f9, 0x4c10
+ax_pose_terminator
+sZapdosPose52:
+ax_pose 60, 0x01d9, 0x80e6, 0x4c00
+ax_pose 61, 0x81d9, 0x8106, 0x4c10
+ax_pose 62, 0x41f9, 0x00f6, 0x4c18
+ax_pose_terminator
+sZapdosPose53:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose54:
+ax_pose 18, 0x01cf, 0x80f3, 0x4c00
+ax_pose 19, 0x41ef, 0x80f3, 0x4c10
+ax_pose 20, 0x81e7, 0x00eb, 0x4c18
+ax_pose_terminator
+sZapdosPose55:
+ax_pose 21, 0x01d3, 0x80ec, 0x4c00
+ax_pose 22, 0x01f3, 0x00f4, 0x4c10
+ax_pose 23, 0x41f3, 0x00fc, 0x4c11
+ax_pose 24, 0x01e3, 0x00e4, 0x4c13
+ax_pose_terminator
+sZapdosPose56:
+ax_pose 58, 0x01dc, 0x80e8, 0x4c00
+ax_pose 59, 0x81dc, 0x8108, 0x4c10
+ax_pose_terminator
+sZapdosPose57:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose58:
+ax_pose 5, 0x01cf, 0x80ef, 0x4c00
+ax_pose 6, 0x41ef, 0x80ef, 0x4c10
+ax_pose 7, 0x01cf, 0x010f, 0x4c18
+ax_pose 8, 0x01df, 0x010f, 0x4c19
+ax_pose_terminator
+sZapdosPose59:
+ax_pose 9, 0x01de, 0x80f0, 0x4c00
+ax_pose 10, 0x41d6, 0x00f8, 0x4c10
+ax_pose 11, 0x81e6, 0x00e8, 0x4c12
+ax_pose 12, 0x81e6, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose60:
+ax_pose 55, 0x01da, 0x80e8, 0x4c00
+ax_pose 56, 0x81da, 0x8108, 0x4c10
+ax_pose 57, 0x41fa, 0x00f8, 0x4c18
+ax_pose_terminator
+sZapdosPose61:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose62:
+ax_pose 18, 0x01cf, 0x90ee, 0x4c00
+ax_pose 19, 0x41ef, 0x90ee, 0x4c10
+ax_pose 20, 0x81e7, 0x110e, 0x4c18
+ax_pose_terminator
+sZapdosPose63:
+ax_pose 21, 0x01d3, 0x90f5, 0x4c00
+ax_pose 22, 0x01f3, 0x1105, 0x4c10
+ax_pose 23, 0x41f3, 0x10f5, 0x4c11
+ax_pose 24, 0x01e3, 0x1115, 0x4c13
+ax_pose_terminator
+sZapdosPose64:
+ax_pose 58, 0x01dc, 0x90f8, 0x4c00
+ax_pose 59, 0x81dc, 0x90e8, 0x4c10
+ax_pose_terminator
+sZapdosPose65:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose66:
+ax_pose 28, 0x01d2, 0x90f1, 0x4c00
+ax_pose 29, 0x41f2, 0x90f1, 0x4c10
+ax_pose 30, 0x81dd, 0x10e9, 0x4c18
+ax_pose 31, 0x01ea, 0x1111, 0x4c1a
+ax_pose_terminator
+sZapdosPose67:
+ax_pose 32, 0x01d4, 0x90f4, 0x4c00
+ax_pose 33, 0x01f4, 0x50f8, 0x4c10
+ax_pose_terminator
+sZapdosPose68:
+ax_pose 60, 0x01d9, 0x90f9, 0x4c00
+ax_pose 61, 0x81d9, 0x90e9, 0x4c10
+ax_pose 62, 0x41f9, 0x10f9, 0x4c18
+ax_pose_terminator
+sZapdosPose69:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose70:
+ax_pose 39, 0x81da, 0x510a, 0x4c00
+ax_pose 40, 0x01da, 0x90ea, 0x4c04
+ax_pose 41, 0x41fa, 0x10f2, 0x4c14
+ax_pose_terminator
+sZapdosPose71:
+ax_pose 42, 0x01d5, 0x90f3, 0x4c00
+ax_pose 43, 0x41f5, 0x50f3, 0x4c10
+ax_pose 38, 0x01cd, 0x1101, 0x4c14
+ax_pose_terminator
+sZapdosPose72:
+ax_pose 63, 0x01da, 0x90f6, 0x4c00
+ax_pose 64, 0x81da, 0x50ee, 0x4c10
+ax_pose_terminator
+sZapdosPose73:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose74:
+ax_pose 48, 0x01d8, 0x80ef, 0x4c00
+ax_pose 49, 0x41f8, 0x00f7, 0x4c10
+ax_pose 50, 0x81dc, 0x010f, 0x4c12
+ax_pose_terminator
+sZapdosPose75:
+ax_pose 51, 0x01dc, 0x80f0, 0x4c00
+ax_pose 52, 0x81e4, 0x00e8, 0x4c10
+ax_pose 53, 0x81e4, 0x0110, 0x4c12
+ax_pose 54, 0x41d4, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose76:
+ax_pose 65, 0x01da, 0x80e7, 0x4c00
+ax_pose 66, 0x81da, 0x8107, 0x4c10
+ax_pose 67, 0x01ea, 0x0117, 0x4c18
+ax_pose_terminator
+sZapdosPose77:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose78:
+ax_pose 39, 0x81da, 0x40ef, 0x4c00
+ax_pose 40, 0x01da, 0x80f7, 0x4c04
+ax_pose 41, 0x41fa, 0x00ff, 0x4c14
+ax_pose_terminator
+sZapdosPose79:
+ax_pose 42, 0x01d5, 0x80ee, 0x4c00
+ax_pose 43, 0x41f5, 0x40ee, 0x4c10
+ax_pose 38, 0x01cd, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose80:
+ax_pose 63, 0x01da, 0x80eb, 0x4c00
+ax_pose 64, 0x81da, 0x410b, 0x4c10
+ax_pose_terminator
+sZapdosPose81:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose82:
+ax_pose 28, 0x01d2, 0x80f0, 0x4c00
+ax_pose 29, 0x41f2, 0x80f0, 0x4c10
+ax_pose 30, 0x81dd, 0x0110, 0x4c18
+ax_pose 31, 0x01ea, 0x00e8, 0x4c1a
+ax_pose_terminator
+sZapdosPose83:
+ax_pose 32, 0x01d4, 0x80ed, 0x4c00
+ax_pose 33, 0x01f4, 0x40f9, 0x4c10
+ax_pose_terminator
+sZapdosPose84:
+ax_pose 60, 0x01d9, 0x80e6, 0x4c00
+ax_pose 61, 0x81d9, 0x8106, 0x4c10
+ax_pose 62, 0x41f9, 0x00f6, 0x4c18
+ax_pose_terminator
+sZapdosPose85:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose86:
+ax_pose 18, 0x01cf, 0x80f3, 0x4c00
+ax_pose 19, 0x41ef, 0x80f3, 0x4c10
+ax_pose 20, 0x81e7, 0x00eb, 0x4c18
+ax_pose_terminator
+sZapdosPose87:
+ax_pose 21, 0x01d3, 0x80ec, 0x4c00
+ax_pose 22, 0x01f3, 0x00f4, 0x4c10
+ax_pose 23, 0x41f3, 0x00fc, 0x4c11
+ax_pose 24, 0x01e3, 0x00e4, 0x4c13
+ax_pose_terminator
+sZapdosPose88:
+ax_pose 58, 0x01dc, 0x80e8, 0x4c00
+ax_pose 59, 0x81dc, 0x8108, 0x4c10
+ax_pose_terminator
+sZapdosPose89:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose90:
+ax_pose 5, 0x01cf, 0x80ef, 0x4c00
+ax_pose 6, 0x41ef, 0x80ef, 0x4c10
+ax_pose 7, 0x01cf, 0x010f, 0x4c18
+ax_pose 8, 0x01df, 0x010f, 0x4c19
+ax_pose_terminator
+sZapdosPose91:
+ax_pose 9, 0x01de, 0x80f0, 0x4c00
+ax_pose 10, 0x41d6, 0x00f8, 0x4c10
+ax_pose 11, 0x81e6, 0x00e8, 0x4c12
+ax_pose 12, 0x81e6, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose92:
+ax_pose 68, 0x01d5, 0x80e7, 0x4c00
+ax_pose 69, 0x81d5, 0x8107, 0x4c10
+ax_pose 70, 0x41f5, 0x40ef, 0x4c18
+ax_pose 71, 0x81da, 0x0117, 0x4c1c
+ax_pose 72, 0x01cd, 0x00ff, 0x4c1e
+ax_pose_terminator
+sZapdosPose93:
+ax_pose 73, 0x01d6, 0x80e8, 0x4c00
+ax_pose 74, 0x81d6, 0x8108, 0x4c10
+ax_pose 75, 0x41f6, 0x00f8, 0x4c18
+ax_pose_terminator
+sZapdosPose94:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose95:
+ax_pose 18, 0x01cf, 0x90ee, 0x4c00
+ax_pose 19, 0x41ef, 0x90ee, 0x4c10
+ax_pose 20, 0x81e7, 0x110e, 0x4c18
+ax_pose_terminator
+sZapdosPose96:
+ax_pose 21, 0x01d3, 0x90f5, 0x4c00
+ax_pose 22, 0x01f3, 0x1105, 0x4c10
+ax_pose 23, 0x41f3, 0x10f5, 0x4c11
+ax_pose 24, 0x01e3, 0x1115, 0x4c13
+ax_pose_terminator
+sZapdosPose97:
+ax_pose 76, 0x01d2, 0x90f1, 0x4c00
+ax_pose 77, 0x41f2, 0x90f1, 0x4c10
+ax_pose 78, 0x81da, 0x50e9, 0x4c18
+ax_pose 79, 0x01ca, 0x10f9, 0x4c1c
+ax_pose 80, 0x81e2, 0x10e1, 0x4c1d
+ax_pose_terminator
+sZapdosPose98:
+ax_pose 81, 0x01d4, 0x90ef, 0x4c00
+ax_pose 82, 0x41f4, 0x50f7, 0x4c10
+ax_pose 83, 0x01e3, 0x10e7, 0x4c14
+ax_pose_terminator
+sZapdosPose99:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose100:
+ax_pose 28, 0x01d2, 0x90f1, 0x4c00
+ax_pose 29, 0x41f2, 0x90f1, 0x4c10
+ax_pose 30, 0x81dd, 0x10e9, 0x4c18
+ax_pose 31, 0x01ea, 0x1111, 0x4c1a
+ax_pose_terminator
+sZapdosPose101:
+ax_pose 32, 0x01d4, 0x90f4, 0x4c00
+ax_pose 33, 0x01f4, 0x50f8, 0x4c10
+ax_pose_terminator
+sZapdosPose102:
+ax_pose 84, 0x01d4, 0x90e6, 0x4c00
+ax_pose 85, 0x81dc, 0x5106, 0x4c10
+ax_pose 86, 0x01f4, 0x50f6, 0x4c14
+ax_pose 87, 0x01cc, 0x10f6, 0x4c18
+ax_pose_terminator
+sZapdosPose103:
+ax_pose 88, 0x01d7, 0x90f1, 0x4c00
+ax_pose 89, 0x81d7, 0x50e9, 0x4c10
+ax_pose 90, 0x01ef, 0x1111, 0x4c14
+ax_pose_terminator
+sZapdosPose104:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose105:
+ax_pose 39, 0x81da, 0x510a, 0x4c00
+ax_pose 40, 0x01da, 0x90ea, 0x4c04
+ax_pose 41, 0x41fa, 0x10f2, 0x4c14
+ax_pose_terminator
+sZapdosPose106:
+ax_pose 42, 0x01d5, 0x90f3, 0x4c00
+ax_pose 43, 0x41f5, 0x50f3, 0x4c10
+ax_pose 38, 0x01cd, 0x1101, 0x4c14
+ax_pose_terminator
+sZapdosPose107:
+ax_pose 91, 0x01d6, 0x90f1, 0x4c00
+ax_pose 92, 0x41f6, 0x50f1, 0x4c10
+ax_pose 93, 0x01ce, 0x10f9, 0x4c14
+ax_pose 94, 0x81d6, 0x50e9, 0x4c15
+ax_pose_terminator
+sZapdosPose108:
+ax_pose 95, 0x01da, 0x90f6, 0x4c00
+ax_pose 96, 0x81da, 0x50ee, 0x4c10
+ax_pose 97, 0x01d2, 0x10f6, 0x4c14
+ax_pose_terminator
+sZapdosPose109:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose110:
+ax_pose 48, 0x01d8, 0x80ef, 0x4c00
+ax_pose 49, 0x41f8, 0x00f7, 0x4c10
+ax_pose 50, 0x81dc, 0x010f, 0x4c12
+ax_pose_terminator
+sZapdosPose111:
+ax_pose 51, 0x01dc, 0x80f0, 0x4c00
+ax_pose 52, 0x81e4, 0x00e8, 0x4c10
+ax_pose 53, 0x81e4, 0x0110, 0x4c12
+ax_pose 54, 0x41d4, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose112:
+ax_pose 98, 0x01d7, 0x80e8, 0x4c00
+ax_pose 99, 0x81d7, 0x8108, 0x4c10
+ax_pose 100, 0x41f7, 0x00f8, 0x4c18
+ax_pose 101, 0x41cf, 0x00f8, 0x4c1a
+ax_pose_terminator
+sZapdosPose113:
+ax_pose 102, 0x01d6, 0x80ef, 0x4c00
+ax_pose 103, 0x81d6, 0x410f, 0x4c10
+ax_pose 104, 0x41f6, 0x40f7, 0x4c14
+ax_pose_terminator
+sZapdosPose114:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose115:
+ax_pose 39, 0x81da, 0x40ef, 0x4c00
+ax_pose 40, 0x01da, 0x80f7, 0x4c04
+ax_pose 41, 0x41fa, 0x00ff, 0x4c14
+ax_pose_terminator
+sZapdosPose116:
+ax_pose 42, 0x01d5, 0x80ee, 0x4c00
+ax_pose 43, 0x41f5, 0x40ee, 0x4c10
+ax_pose 38, 0x01cd, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose117:
+ax_pose 91, 0x01d6, 0x80f0, 0x4c00
+ax_pose 92, 0x41f6, 0x40f0, 0x4c10
+ax_pose 93, 0x01ce, 0x0100, 0x4c14
+ax_pose 94, 0x81d6, 0x4110, 0x4c15
+ax_pose_terminator
+sZapdosPose118:
+ax_pose 95, 0x01da, 0x80eb, 0x4c00
+ax_pose 96, 0x81da, 0x410b, 0x4c10
+ax_pose 97, 0x01d2, 0x0103, 0x4c14
+ax_pose_terminator
+sZapdosPose119:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose120:
+ax_pose 28, 0x01d2, 0x80f0, 0x4c00
+ax_pose 29, 0x41f2, 0x80f0, 0x4c10
+ax_pose 30, 0x81dd, 0x0110, 0x4c18
+ax_pose 31, 0x01ea, 0x00e8, 0x4c1a
+ax_pose_terminator
+sZapdosPose121:
+ax_pose 32, 0x01d4, 0x80ed, 0x4c00
+ax_pose 33, 0x01f4, 0x40f9, 0x4c10
+ax_pose_terminator
+sZapdosPose122:
+ax_pose 84, 0x01d4, 0x80f9, 0x4c00
+ax_pose 85, 0x81dc, 0x40f1, 0x4c10
+ax_pose 86, 0x01f4, 0x40f9, 0x4c14
+ax_pose 87, 0x01cc, 0x0101, 0x4c18
+ax_pose_terminator
+sZapdosPose123:
+ax_pose 88, 0x01d7, 0x80ee, 0x4c00
+ax_pose 89, 0x81d7, 0x410e, 0x4c10
+ax_pose 90, 0x01ef, 0x00e6, 0x4c14
+ax_pose_terminator
+sZapdosPose124:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose125:
+ax_pose 18, 0x01cf, 0x80f3, 0x4c00
+ax_pose 19, 0x41ef, 0x80f3, 0x4c10
+ax_pose 20, 0x81e7, 0x00eb, 0x4c18
+ax_pose_terminator
+sZapdosPose126:
+ax_pose 21, 0x01d3, 0x80ec, 0x4c00
+ax_pose 22, 0x01f3, 0x00f4, 0x4c10
+ax_pose 23, 0x41f3, 0x00fc, 0x4c11
+ax_pose 24, 0x01e3, 0x00e4, 0x4c13
+ax_pose_terminator
+sZapdosPose127:
+ax_pose 76, 0x01d2, 0x80ef, 0x4c00
+ax_pose 77, 0x41f2, 0x80ef, 0x4c10
+ax_pose 78, 0x81da, 0x410f, 0x4c18
+ax_pose 79, 0x01ca, 0x00ff, 0x4c1c
+ax_pose 80, 0x81e2, 0x0117, 0x4c1d
+ax_pose_terminator
+sZapdosPose128:
+ax_pose 81, 0x01d4, 0x80f1, 0x4c00
+ax_pose 82, 0x41f4, 0x40e9, 0x4c10
+ax_pose 83, 0x01e3, 0x0111, 0x4c14
+ax_pose_terminator
+sZapdosPose129:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose130:
+ax_pose 5, 0x01cf, 0x80ef, 0x4c00
+ax_pose 6, 0x41ef, 0x80ef, 0x4c10
+ax_pose 7, 0x01cf, 0x010f, 0x4c18
+ax_pose 8, 0x01df, 0x010f, 0x4c19
+ax_pose_terminator
+sZapdosPose131:
+ax_pose 9, 0x01de, 0x80f0, 0x4c00
+ax_pose 10, 0x41d6, 0x00f8, 0x4c10
+ax_pose 11, 0x81e6, 0x00e8, 0x4c12
+ax_pose 12, 0x81e6, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose132:
+ax_pose 105, 0x81d0, 0x90e9, 0x4c00
+ax_pose 106, 0x41f0, 0x80f0, 0x4c08
+ax_pose 107, 0x81d0, 0x80f8, 0x4c10
+ax_pose -1, 0x81d0, 0x8108, 0x4c00
+ax_pose_terminator
+sZapdosPose133:
+ax_pose 108, 0x41c6, 0xc0e3, 0x4c00
+ax_pose 109, 0x41e6, 0x80e3, 0x4c20
+ax_pose 110, 0x41e6, 0x8103, 0x4c28
+ax_pose 111, 0x41f6, 0x40f3, 0x4c30
+ax_pose_terminator
+sZapdosPose134:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose135:
+ax_pose 18, 0x01cf, 0x90ee, 0x4c00
+ax_pose 19, 0x41ef, 0x90ee, 0x4c10
+ax_pose 20, 0x81e7, 0x110e, 0x4c18
+ax_pose_terminator
+sZapdosPose136:
+ax_pose 21, 0x01d3, 0x90f5, 0x4c00
+ax_pose 22, 0x01f3, 0x1105, 0x4c10
+ax_pose 23, 0x41f3, 0x10f5, 0x4c11
+ax_pose 24, 0x01e3, 0x1115, 0x4c13
+ax_pose_terminator
+sZapdosPose137:
+ax_pose 112, 0x01d0, 0x90f3, 0x4c00
+ax_pose 113, 0x81d0, 0x90e3, 0x4c10
+ax_pose 114, 0x41f0, 0x90ee, 0x4c18
+ax_pose_terminator
+sZapdosPose138:
+ax_pose 115, 0x01cd, 0x90f7, 0x4c00
+ax_pose 116, 0x81cd, 0x90e7, 0x4c10
+ax_pose 117, 0x41ed, 0x90ef, 0x4c18
+ax_pose 118, 0x41ed, 0x10df, 0x4c20
+ax_pose 119, 0x01d5, 0x50d7, 0x4c22
+ax_pose 120, 0x01c5, 0x1107, 0x4c26
+ax_pose_terminator
+sZapdosPose139:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose140:
+ax_pose 28, 0x01d2, 0x90f1, 0x4c00
+ax_pose 29, 0x41f2, 0x90f1, 0x4c10
+ax_pose 30, 0x81dd, 0x10e9, 0x4c18
+ax_pose 31, 0x01ea, 0x1111, 0x4c1a
+ax_pose_terminator
+sZapdosPose141:
+ax_pose 32, 0x01d4, 0x90f4, 0x4c00
+ax_pose 33, 0x01f4, 0x50f8, 0x4c10
+ax_pose_terminator
+sZapdosPose142:
+ax_pose 121, 0x01d0, 0x90ed, 0x4c00
+ax_pose 122, 0x41f0, 0x90ed, 0x4c10
+ax_pose 123, 0x81d8, 0x110d, 0x4c18
+ax_pose 124, 0x01d8, 0x1115, 0x4c1a
+ax_pose_terminator
+sZapdosPose143:
+ax_pose 125, 0x01d3, 0x90f7, 0x4c00
+ax_pose 126, 0x81d3, 0x90e7, 0x4c10
+ax_pose 127, 0x01d3, 0x50d7, 0x4c18
+ax_pose 128, 0x01c3, 0x50ef, 0x4c1c
+ax_pose 129, 0x41f3, 0x50ef, 0x4c20
+ax_pose 130, 0x41f3, 0x10df, 0x4c24
+ax_pose 131, 0x41fb, 0x10ef, 0x4c26
+ax_pose_terminator
+sZapdosPose144:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose145:
+ax_pose 39, 0x81da, 0x510a, 0x4c00
+ax_pose 40, 0x01da, 0x90ea, 0x4c04
+ax_pose 41, 0x41fa, 0x10f2, 0x4c14
+ax_pose_terminator
+sZapdosPose146:
+ax_pose 42, 0x01d5, 0x90f3, 0x4c00
+ax_pose 43, 0x41f5, 0x50f3, 0x4c10
+ax_pose 38, 0x01cd, 0x1101, 0x4c14
+ax_pose_terminator
+sZapdosPose147:
+ax_pose 132, 0x01d2, 0x90f1, 0x4c00
+ax_pose 133, 0x81d2, 0x50e9, 0x4c10
+ax_pose 134, 0x41f2, 0x90f1, 0x4c14
+ax_pose_terminator
+sZapdosPose148:
+ax_pose 135, 0x01d2, 0x90ee, 0x4c00
+ax_pose 136, 0x41f2, 0x90ee, 0x4c10
+ax_pose 137, 0x81d2, 0x50e6, 0x4c18
+ax_pose 138, 0x01f2, 0x10e6, 0x4c1c
+ax_pose 139, 0x01ca, 0x10ee, 0x4c1d
+ax_pose 140, 0x81dd, 0x510e, 0x4c1e
+ax_pose 141, 0x01da, 0x1116, 0x4c22
+ax_pose_terminator
+sZapdosPose149:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose150:
+ax_pose 48, 0x01d8, 0x80ef, 0x4c00
+ax_pose 49, 0x41f8, 0x00f7, 0x4c10
+ax_pose 50, 0x81dc, 0x010f, 0x4c12
+ax_pose_terminator
+sZapdosPose151:
+ax_pose 51, 0x01dc, 0x80f0, 0x4c00
+ax_pose 52, 0x81e4, 0x00e8, 0x4c10
+ax_pose 53, 0x81e4, 0x0110, 0x4c12
+ax_pose 54, 0x41d4, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose152:
+ax_pose 142, 0x01d6, 0x80e5, 0x4c00
+ax_pose 143, 0x41f6, 0x00f5, 0x4c10
+ax_pose 144, 0x81d6, 0x8105, 0x4c12
+ax_pose 145, 0x81d6, 0x4115, 0x4c1a
+ax_pose 146, 0x01f6, 0x0105, 0x4c1e
+ax_pose_terminator
+sZapdosPose153:
+ax_pose 147, 0x01cf, 0x80e0, 0x4c00
+ax_pose 148, 0x41ef, 0x80e0, 0x4c10
+ax_pose 149, 0x01cf, 0x8100, 0x4c18
+ax_pose 150, 0x41ef, 0x8100, 0x4c28
+ax_pose_terminator
+sZapdosPose154:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose155:
+ax_pose 39, 0x81da, 0x40ef, 0x4c00
+ax_pose 40, 0x01da, 0x80f7, 0x4c04
+ax_pose 41, 0x41fa, 0x00ff, 0x4c14
+ax_pose_terminator
+sZapdosPose156:
+ax_pose 42, 0x01d5, 0x80ee, 0x4c00
+ax_pose 43, 0x41f5, 0x40ee, 0x4c10
+ax_pose 38, 0x01cd, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose157:
+ax_pose 132, 0x01d2, 0x80f0, 0x4c00
+ax_pose 133, 0x81d2, 0x4110, 0x4c10
+ax_pose 134, 0x41f2, 0x80f0, 0x4c14
+ax_pose_terminator
+sZapdosPose158:
+ax_pose 135, 0x01d2, 0x80f3, 0x4c00
+ax_pose 136, 0x41f2, 0x80f3, 0x4c10
+ax_pose 137, 0x81d2, 0x4113, 0x4c18
+ax_pose 138, 0x01f2, 0x0113, 0x4c1c
+ax_pose 139, 0x01ca, 0x010b, 0x4c1d
+ax_pose 140, 0x81dd, 0x40eb, 0x4c1e
+ax_pose 141, 0x01da, 0x00e3, 0x4c22
+ax_pose_terminator
+sZapdosPose159:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose160:
+ax_pose 28, 0x01d2, 0x80f0, 0x4c00
+ax_pose 29, 0x41f2, 0x80f0, 0x4c10
+ax_pose 30, 0x81dd, 0x0110, 0x4c18
+ax_pose 31, 0x01ea, 0x00e8, 0x4c1a
+ax_pose_terminator
+sZapdosPose161:
+ax_pose 32, 0x01d4, 0x80ed, 0x4c00
+ax_pose 33, 0x01f4, 0x40f9, 0x4c10
+ax_pose_terminator
+sZapdosPose162:
+ax_pose 121, 0x01d0, 0x80f4, 0x4c00
+ax_pose 122, 0x41f0, 0x80f4, 0x4c10
+ax_pose 123, 0x81d8, 0x00ec, 0x4c18
+ax_pose 124, 0x01d8, 0x00e4, 0x4c1a
+ax_pose_terminator
+sZapdosPose163:
+ax_pose 125, 0x01d3, 0x80ea, 0x4c00
+ax_pose 126, 0x81d3, 0x810a, 0x4c10
+ax_pose 127, 0x01d3, 0x411a, 0x4c18
+ax_pose 128, 0x01c3, 0x4102, 0x4c1c
+ax_pose 129, 0x41f3, 0x40f2, 0x4c20
+ax_pose 130, 0x41f3, 0x0112, 0x4c24
+ax_pose 131, 0x41fb, 0x0102, 0x4c26
+ax_pose_terminator
+sZapdosPose164:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose165:
+ax_pose 18, 0x01cf, 0x80f3, 0x4c00
+ax_pose 19, 0x41ef, 0x80f3, 0x4c10
+ax_pose 20, 0x81e7, 0x00eb, 0x4c18
+ax_pose_terminator
+sZapdosPose166:
+ax_pose 21, 0x01d3, 0x80ec, 0x4c00
+ax_pose 22, 0x01f3, 0x00f4, 0x4c10
+ax_pose 23, 0x41f3, 0x00fc, 0x4c11
+ax_pose 24, 0x01e3, 0x00e4, 0x4c13
+ax_pose_terminator
+sZapdosPose167:
+ax_pose 112, 0x01d0, 0x80ed, 0x4c00
+ax_pose 113, 0x81d0, 0x810d, 0x4c10
+ax_pose 114, 0x41f0, 0x80f2, 0x4c18
+ax_pose_terminator
+sZapdosPose168:
+ax_pose 115, 0x01cd, 0x80ea, 0x4c00
+ax_pose 116, 0x81cd, 0x810a, 0x4c10
+ax_pose 117, 0x41ed, 0x80f2, 0x4c18
+ax_pose 118, 0x41ed, 0x0112, 0x4c20
+ax_pose 119, 0x01d5, 0x411a, 0x4c22
+ax_pose 120, 0x01c5, 0x00f2, 0x4c26
+ax_pose_terminator
+sZapdosPose169:
+ax_pose 151, 0x01e4, 0x80e9, 0x4c00
+ax_pose 152, 0x81e4, 0x4109, 0x4c10
+ax_pose 153, 0x0204, 0x00fb, 0x4c14
+ax_pose 154, 0x01fc, 0x0111, 0x4c15
+ax_pose 155, 0x81ec, 0x0111, 0x4c16
+ax_pose_terminator
+sZapdosPose170:
+ax_pose 156, 0x01e4, 0x80e9, 0x4c00
+ax_pose 157, 0x81e4, 0x4109, 0x4c10
+ax_pose 158, 0x0204, 0x00fb, 0x4c14
+ax_pose 159, 0x81ec, 0x0111, 0x4c15
+ax_pose_terminator
+sZapdosPose171:
+ax_pose 160, 0x41ce, 0x80e7, 0x4c00
+ax_pose 161, 0x81de, 0x010f, 0x4c08
+ax_pose 162, 0x41ee, 0x80f2, 0x4c0a
+ax_pose 163, 0x81ce, 0x0117, 0x4c12
+ax_pose 164, 0x01ce, 0x4107, 0x4c14
+ax_pose 165, 0x41de, 0x80ef, 0x4c18
+ax_pose_terminator
+sZapdosPose172:
+ax_pose 166, 0x81d1, 0x90f1, 0x4c00
+ax_pose 167, 0x81d1, 0x5101, 0x4c08
+ax_pose 168, 0x01f9, 0x10fc, 0x4c0c
+ax_pose 169, 0x01d9, 0x1109, 0x4c0d
+ax_pose 170, 0x81e1, 0x1109, 0x4c0e
+ax_pose 171, 0x81d1, 0x90e1, 0x4c10
+ax_pose 172, 0x41f1, 0x10ff, 0x4c18
+ax_pose 173, 0x41f1, 0x10f1, 0x4c1a
+ax_pose 174, 0x01f1, 0x50e1, 0x4c1c
+ax_pose_terminator
+sZapdosPose173:
+ax_pose 175, 0x01ce, 0x90ec, 0x4c00
+ax_pose 176, 0x01ee, 0x50ec, 0x4c10
+ax_pose 177, 0x01ee, 0x50fc, 0x4c14
+ax_pose 178, 0x81ce, 0x90dc, 0x4c18
+ax_pose_terminator
+sZapdosPose174:
+ax_pose 179, 0x01cf, 0x90de, 0x4c00
+ax_pose 180, 0x01d7, 0x50fe, 0x4c10
+ax_pose 181, 0x41e7, 0x10fe, 0x4c14
+ax_pose 182, 0x01ef, 0x1103, 0x4c16
+ax_pose 183, 0x01f7, 0x10eb, 0x4c17
+ax_pose 184, 0x01e7, 0x110e, 0x4c18
+ax_pose 185, 0x01ef, 0x110b, 0x4c19
+ax_pose 186, 0x41ef, 0x10e3, 0x4c1a
+ax_pose 187, 0x01ef, 0x50f3, 0x4c1c
+ax_pose_terminator
+sZapdosPose175:
+ax_pose 188, 0x01dc, 0x80eb, 0x4c00
+ax_pose 189, 0x01ec, 0x0113, 0x4c10
+ax_pose 190, 0x01d4, 0x010e, 0x4c11
+ax_pose 191, 0x01cc, 0x40fe, 0x4c12
+ax_pose 192, 0x01cc, 0x40eb, 0x4c16
+ax_pose 193, 0x81dc, 0x410b, 0x4c1a
+ax_pose_terminator
+sZapdosPose176:
+ax_pose 179, 0x01cf, 0x8102, 0x4c00
+ax_pose 180, 0x01d7, 0x40f2, 0x4c10
+ax_pose 181, 0x41e7, 0x00f2, 0x4c14
+ax_pose 182, 0x01ef, 0x00f5, 0x4c16
+ax_pose 183, 0x01f7, 0x010d, 0x4c17
+ax_pose 184, 0x01e7, 0x00ea, 0x4c18
+ax_pose 185, 0x01ef, 0x00ed, 0x4c19
+ax_pose 186, 0x41ef, 0x010d, 0x4c1a
+ax_pose 187, 0x01ef, 0x40fd, 0x4c1c
+ax_pose_terminator
+sZapdosPose177:
+ax_pose 175, 0x01ce, 0x80f4, 0x4c00
+ax_pose 176, 0x01ee, 0x4104, 0x4c10
+ax_pose 177, 0x01ee, 0x40f4, 0x4c14
+ax_pose 178, 0x81ce, 0x8114, 0x4c18
+ax_pose_terminator
+sZapdosPose178:
+ax_pose 166, 0x81d1, 0x80ff, 0x4c00
+ax_pose 167, 0x81d1, 0x40f7, 0x4c08
+ax_pose 168, 0x01f9, 0x00fc, 0x4c0c
+ax_pose 169, 0x01d9, 0x00ef, 0x4c0d
+ax_pose 170, 0x81e1, 0x00ef, 0x4c0e
+ax_pose 171, 0x81d1, 0x810f, 0x4c10
+ax_pose 172, 0x41f1, 0x00ef, 0x4c18
+ax_pose 173, 0x41f1, 0x00ff, 0x4c1a
+ax_pose 174, 0x01f1, 0x410f, 0x4c1c
+ax_pose_terminator
+sZapdosPose179:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose180:
+ax_pose 5, 0x01cf, 0x80ef, 0x4c00
+ax_pose 6, 0x41ef, 0x80ef, 0x4c10
+ax_pose 7, 0x01cf, 0x010f, 0x4c18
+ax_pose 8, 0x01df, 0x010f, 0x4c19
+ax_pose_terminator
+sZapdosPose181:
+ax_pose 9, 0x01de, 0x80f0, 0x4c00
+ax_pose 10, 0x41d6, 0x00f8, 0x4c10
+ax_pose 11, 0x81e6, 0x00e8, 0x4c12
+ax_pose 12, 0x81e6, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose182:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose183:
+ax_pose 18, 0x01cf, 0x90ee, 0x4c00
+ax_pose 19, 0x41ef, 0x90ee, 0x4c10
+ax_pose 20, 0x81e7, 0x110e, 0x4c18
+ax_pose_terminator
+sZapdosPose184:
+ax_pose 21, 0x01d3, 0x90f5, 0x4c00
+ax_pose 22, 0x01f3, 0x1105, 0x4c10
+ax_pose 23, 0x41f3, 0x10f5, 0x4c11
+ax_pose 24, 0x01e3, 0x1115, 0x4c13
+ax_pose_terminator
+sZapdosPose185:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose186:
+ax_pose 28, 0x01d2, 0x90f1, 0x4c00
+ax_pose 29, 0x41f2, 0x90f1, 0x4c10
+ax_pose 30, 0x81dd, 0x10e9, 0x4c18
+ax_pose 31, 0x01ea, 0x1111, 0x4c1a
+ax_pose_terminator
+sZapdosPose187:
+ax_pose 32, 0x01d4, 0x90f4, 0x4c00
+ax_pose 33, 0x01f4, 0x50f8, 0x4c10
+ax_pose_terminator
+sZapdosPose188:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose189:
+ax_pose 39, 0x81da, 0x510a, 0x4c00
+ax_pose 40, 0x01da, 0x90ea, 0x4c04
+ax_pose 41, 0x41fa, 0x10f2, 0x4c14
+ax_pose_terminator
+sZapdosPose190:
+ax_pose 42, 0x01d5, 0x90f3, 0x4c00
+ax_pose 43, 0x41f5, 0x50f3, 0x4c10
+ax_pose 38, 0x01cd, 0x1101, 0x4c14
+ax_pose_terminator
+sZapdosPose191:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose192:
+ax_pose 48, 0x01d8, 0x80ef, 0x4c00
+ax_pose 49, 0x41f8, 0x00f7, 0x4c10
+ax_pose 50, 0x81dc, 0x010f, 0x4c12
+ax_pose_terminator
+sZapdosPose193:
+ax_pose 51, 0x01dc, 0x80f0, 0x4c00
+ax_pose 52, 0x81e4, 0x00e8, 0x4c10
+ax_pose 53, 0x81e4, 0x0110, 0x4c12
+ax_pose 54, 0x41d4, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose194:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose195:
+ax_pose 39, 0x81da, 0x40ef, 0x4c00
+ax_pose 40, 0x01da, 0x80f7, 0x4c04
+ax_pose 41, 0x41fa, 0x00ff, 0x4c14
+ax_pose_terminator
+sZapdosPose196:
+ax_pose 42, 0x01d5, 0x80ee, 0x4c00
+ax_pose 43, 0x41f5, 0x40ee, 0x4c10
+ax_pose 38, 0x01cd, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose197:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose198:
+ax_pose 28, 0x01d2, 0x80f0, 0x4c00
+ax_pose 29, 0x41f2, 0x80f0, 0x4c10
+ax_pose 30, 0x81dd, 0x0110, 0x4c18
+ax_pose 31, 0x01ea, 0x00e8, 0x4c1a
+ax_pose_terminator
+sZapdosPose199:
+ax_pose 32, 0x01d4, 0x80ed, 0x4c00
+ax_pose 33, 0x01f4, 0x40f9, 0x4c10
+ax_pose_terminator
+sZapdosPose200:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose201:
+ax_pose 18, 0x01cf, 0x80f3, 0x4c00
+ax_pose 19, 0x41ef, 0x80f3, 0x4c10
+ax_pose 20, 0x81e7, 0x00eb, 0x4c18
+ax_pose_terminator
+sZapdosPose202:
+ax_pose 21, 0x01d3, 0x80ec, 0x4c00
+ax_pose 22, 0x01f3, 0x00f4, 0x4c10
+ax_pose 23, 0x41f3, 0x00fc, 0x4c11
+ax_pose 24, 0x01e3, 0x00e4, 0x4c13
+ax_pose_terminator
+sZapdosPose203:
+ax_pose 55, 0x01da, 0x80e8, 0x4c00
+ax_pose 56, 0x81da, 0x8108, 0x4c10
+ax_pose 57, 0x41fa, 0x00f8, 0x4c18
+ax_pose_terminator
+sZapdosPose204:
+ax_pose 58, 0x01dc, 0x80e8, 0x4c00
+ax_pose 59, 0x81dc, 0x8108, 0x4c10
+ax_pose_terminator
+sZapdosPose205:
+ax_pose 60, 0x01d9, 0x80e6, 0x4c00
+ax_pose 61, 0x81d9, 0x8106, 0x4c10
+ax_pose 62, 0x41f9, 0x00f6, 0x4c18
+ax_pose_terminator
+sZapdosPose206:
+ax_pose 63, 0x01da, 0x80eb, 0x4c00
+ax_pose 64, 0x81da, 0x410b, 0x4c10
+ax_pose_terminator
+sZapdosPose207:
+ax_pose 65, 0x01da, 0x80e7, 0x4c00
+ax_pose 66, 0x81da, 0x8107, 0x4c10
+ax_pose 67, 0x01ea, 0x0117, 0x4c18
+ax_pose_terminator
+sZapdosPose208:
+ax_pose 63, 0x01da, 0x90f6, 0x4c00
+ax_pose 64, 0x81da, 0x50ee, 0x4c10
+ax_pose_terminator
+sZapdosPose209:
+ax_pose 60, 0x01d9, 0x90f9, 0x4c00
+ax_pose 61, 0x81d9, 0x90e9, 0x4c10
+ax_pose 62, 0x41f9, 0x10f9, 0x4c18
+ax_pose_terminator
+sZapdosPose210:
+ax_pose 58, 0x01dc, 0x90f8, 0x4c00
+ax_pose 59, 0x81dc, 0x90e8, 0x4c10
+ax_pose_terminator
+sZapdosPose211:
+ax_pose 68, 0x01d5, 0x80e7, 0x4c00
+ax_pose 69, 0x81d5, 0x8107, 0x4c10
+ax_pose 70, 0x41f5, 0x40ef, 0x4c18
+ax_pose 71, 0x81da, 0x0117, 0x4c1c
+ax_pose 72, 0x01cd, 0x00ff, 0x4c1e
+ax_pose_terminator
+sZapdosPose212:
+ax_pose 76, 0x01d2, 0x90f1, 0x4c00
+ax_pose 77, 0x41f2, 0x90f1, 0x4c10
+ax_pose 78, 0x81da, 0x50e9, 0x4c18
+ax_pose 79, 0x01ca, 0x10f9, 0x4c1c
+ax_pose 80, 0x81e2, 0x10e1, 0x4c1d
+ax_pose_terminator
+sZapdosPose213:
+ax_pose 84, 0x01d4, 0x90e7, 0x4c00
+ax_pose 85, 0x81dc, 0x5107, 0x4c10
+ax_pose 86, 0x01f4, 0x50f7, 0x4c14
+ax_pose 87, 0x01cc, 0x10f7, 0x4c18
+ax_pose_terminator
+sZapdosPose214:
+ax_pose 91, 0x01d6, 0x90f1, 0x4c00
+ax_pose 92, 0x41f6, 0x50f1, 0x4c10
+ax_pose 93, 0x01ce, 0x10f9, 0x4c14
+ax_pose 94, 0x81d6, 0x50e9, 0x4c15
+ax_pose_terminator
+sZapdosPose215:
+ax_pose 98, 0x01d7, 0x80e8, 0x4c00
+ax_pose 99, 0x81d7, 0x8108, 0x4c10
+ax_pose 100, 0x41f7, 0x00f8, 0x4c18
+ax_pose 101, 0x41cf, 0x00f8, 0x4c1a
+ax_pose_terminator
+sZapdosPose216:
+ax_pose 91, 0x01d6, 0x80ef, 0x4c00
+ax_pose 92, 0x41f6, 0x40ef, 0x4c10
+ax_pose 93, 0x01ce, 0x00ff, 0x4c14
+ax_pose 94, 0x81d6, 0x410f, 0x4c15
+ax_pose_terminator
+sZapdosPose217:
+ax_pose 84, 0x01d4, 0x80f9, 0x4c00
+ax_pose 85, 0x81dc, 0x40f1, 0x4c10
+ax_pose 86, 0x01f4, 0x40f9, 0x4c14
+ax_pose 87, 0x01cc, 0x0101, 0x4c18
+ax_pose_terminator
+sZapdosPose218:
+ax_pose 76, 0x01d2, 0x80ef, 0x4c00
+ax_pose 77, 0x41f2, 0x80ef, 0x4c10
+ax_pose 78, 0x81da, 0x410f, 0x4c18
+ax_pose 79, 0x01ca, 0x00ff, 0x4c1c
+ax_pose 80, 0x81e2, 0x0117, 0x4c1d
+ax_pose_terminator
+sZapdosPose219:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose220:
+ax_pose 5, 0x01cf, 0x80ef, 0x4c00
+ax_pose 6, 0x41ef, 0x80ef, 0x4c10
+ax_pose 7, 0x01cf, 0x010f, 0x4c18
+ax_pose 8, 0x01df, 0x010f, 0x4c19
+ax_pose_terminator
+sZapdosPose221:
+ax_pose 9, 0x01de, 0x80f0, 0x4c00
+ax_pose 10, 0x41d6, 0x00f8, 0x4c10
+ax_pose 11, 0x81e6, 0x00e8, 0x4c12
+ax_pose 12, 0x81e6, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose222:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose223:
+ax_pose 18, 0x01cf, 0x90ec, 0x4c00
+ax_pose 19, 0x41ef, 0x90ec, 0x4c10
+ax_pose 20, 0x81e7, 0x110c, 0x4c18
+ax_pose_terminator
+sZapdosPose224:
+ax_pose 21, 0x01d3, 0x90f5, 0x4c00
+ax_pose 22, 0x01f3, 0x1105, 0x4c10
+ax_pose 23, 0x41f3, 0x10f5, 0x4c11
+ax_pose 24, 0x01e3, 0x1115, 0x4c13
+ax_pose_terminator
+sZapdosPose225:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose226:
+ax_pose 28, 0x01d2, 0x90f0, 0x4c00
+ax_pose 29, 0x41f2, 0x90f0, 0x4c10
+ax_pose 30, 0x81dd, 0x10e8, 0x4c18
+ax_pose 31, 0x01ea, 0x1110, 0x4c1a
+ax_pose_terminator
+sZapdosPose227:
+ax_pose 32, 0x01d4, 0x90f4, 0x4c00
+ax_pose 33, 0x01f4, 0x50f8, 0x4c10
+ax_pose_terminator
+sZapdosPose228:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose229:
+ax_pose 39, 0x81da, 0x510a, 0x4c00
+ax_pose 40, 0x01da, 0x90ea, 0x4c04
+ax_pose 41, 0x41fa, 0x10f2, 0x4c14
+ax_pose_terminator
+sZapdosPose230:
+ax_pose 42, 0x01d5, 0x90f3, 0x4c00
+ax_pose 43, 0x41f5, 0x50f3, 0x4c10
+ax_pose 38, 0x01cd, 0x1101, 0x4c14
+ax_pose_terminator
+sZapdosPose231:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose232:
+ax_pose 48, 0x01d8, 0x80ef, 0x4c00
+ax_pose 49, 0x41f8, 0x00f7, 0x4c10
+ax_pose 50, 0x81dc, 0x010f, 0x4c12
+ax_pose_terminator
+sZapdosPose233:
+ax_pose 51, 0x01dc, 0x80f0, 0x4c00
+ax_pose 52, 0x81e4, 0x00e8, 0x4c10
+ax_pose 53, 0x81e4, 0x0110, 0x4c12
+ax_pose 54, 0x41d4, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose234:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose235:
+ax_pose 39, 0x81da, 0x40ef, 0x4c00
+ax_pose 40, 0x01da, 0x80f7, 0x4c04
+ax_pose 41, 0x41fa, 0x00ff, 0x4c14
+ax_pose_terminator
+sZapdosPose236:
+ax_pose 42, 0x01d5, 0x80ee, 0x4c00
+ax_pose 43, 0x41f5, 0x40ee, 0x4c10
+ax_pose 38, 0x01cd, 0x00f8, 0x4c14
+ax_pose_terminator
+sZapdosPose237:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose238:
+ax_pose 28, 0x01d2, 0x80f1, 0x4c00
+ax_pose 29, 0x41f2, 0x80f1, 0x4c10
+ax_pose 30, 0x81dd, 0x0111, 0x4c18
+ax_pose 31, 0x01ea, 0x00e9, 0x4c1a
+ax_pose_terminator
+sZapdosPose239:
+ax_pose 32, 0x01d4, 0x80ed, 0x4c00
+ax_pose 33, 0x01f4, 0x40f9, 0x4c10
+ax_pose_terminator
+sZapdosPose240:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose241:
+ax_pose 18, 0x01cf, 0x80f5, 0x4c00
+ax_pose 19, 0x41ef, 0x80f5, 0x4c10
+ax_pose 20, 0x81e7, 0x00ed, 0x4c18
+ax_pose_terminator
+sZapdosPose242:
+ax_pose 21, 0x01d3, 0x80ec, 0x4c00
+ax_pose 22, 0x01f3, 0x00f4, 0x4c10
+ax_pose 23, 0x41f3, 0x00fc, 0x4c11
+ax_pose 24, 0x01e3, 0x00e4, 0x4c13
+ax_pose_terminator
+sZapdosPose243:
+ax_pose 105, 0x81d0, 0x90e9, 0x4c00
+ax_pose 106, 0x41f0, 0x80f0, 0x4c08
+ax_pose 107, 0x81d0, 0x80f8, 0x4c10
+ax_pose -1, 0x81d0, 0x8108, 0x4c00
+ax_pose_terminator
+sZapdosPose244:
+ax_pose 112, 0x01d0, 0x80ed, 0x4c00
+ax_pose 113, 0x81d0, 0x810d, 0x4c10
+ax_pose 114, 0x41f0, 0x80f2, 0x4c18
+ax_pose_terminator
+sZapdosPose245:
+ax_pose 121, 0x01d0, 0x80f4, 0x4c00
+ax_pose 122, 0x41f0, 0x80f4, 0x4c10
+ax_pose 123, 0x81d8, 0x00ec, 0x4c18
+ax_pose 124, 0x01d8, 0x00e4, 0x4c1a
+ax_pose_terminator
+sZapdosPose246:
+ax_pose 132, 0x01d1, 0x80f0, 0x4c00
+ax_pose 133, 0x81d1, 0x4110, 0x4c10
+ax_pose 134, 0x41f1, 0x80f0, 0x4c14
+ax_pose_terminator
+sZapdosPose247:
+ax_pose 142, 0x01d6, 0x80e5, 0x4c00
+ax_pose 143, 0x41f6, 0x00f5, 0x4c10
+ax_pose 144, 0x81d6, 0x8105, 0x4c12
+ax_pose 145, 0x81d6, 0x4115, 0x4c1a
+ax_pose 146, 0x01f6, 0x0105, 0x4c1e
+ax_pose_terminator
+sZapdosPose248:
+ax_pose 132, 0x01d1, 0x90f1, 0x4c00
+ax_pose 133, 0x81d1, 0x50e9, 0x4c10
+ax_pose 134, 0x41f1, 0x90f1, 0x4c14
+ax_pose_terminator
+sZapdosPose249:
+ax_pose 121, 0x01d0, 0x90ed, 0x4c00
+ax_pose 122, 0x41f0, 0x90ed, 0x4c10
+ax_pose 123, 0x81d8, 0x110d, 0x4c18
+ax_pose 124, 0x01d8, 0x1115, 0x4c1a
+ax_pose_terminator
+sZapdosPose250:
+ax_pose 112, 0x01d0, 0x90f3, 0x4c00
+ax_pose 113, 0x81d0, 0x90e3, 0x4c10
+ax_pose 114, 0x41f0, 0x90ee, 0x4c18
+ax_pose_terminator
+sZapdosPose251:
+ax_pose 0, 0x01d0, 0x80f0, 0x4c00
+ax_pose 1, 0x81d0, 0x40e8, 0x4c10
+ax_pose 2, 0x81d0, 0x4110, 0x4c14
+ax_pose 3, 0x01f0, 0x40f0, 0x4c18
+ax_pose 4, 0x01f0, 0x4100, 0x4c1c
+ax_pose_terminator
+sZapdosPose252:
+ax_pose 13, 0x01d8, 0x80f0, 0x4c00
+ax_pose 14, 0x81d8, 0x4110, 0x4c10
+ax_pose 15, 0x41f8, 0x00fd, 0x4c14
+ax_pose 16, 0x01e0, 0x0118, 0x4c16
+ax_pose 17, 0x01d0, 0x00f3, 0x4c17
+ax_pose_terminator
+sZapdosPose253:
+ax_pose 25, 0x01d0, 0x80f1, 0x4c00
+ax_pose 26, 0x41f0, 0x80f1, 0x4c10
+ax_pose 27, 0x01e8, 0x00e9, 0x4c18
+ax_pose_terminator
+sZapdosPose254:
+ax_pose 34, 0x01d8, 0x80f0, 0x4c00
+ax_pose 35, 0x81d0, 0x4110, 0x4c10
+ax_pose 36, 0x41f8, 0x0100, 0x4c14
+ax_pose 37, 0x01d0, 0x0108, 0x4c16
+ax_pose 38, 0x01d0, 0x00f8, 0x4c17
+ax_pose_terminator
+sZapdosPose255:
+ax_pose 44, 0x01d7, 0x80f0, 0x4c00
+ax_pose 45, 0x41f7, 0x00f8, 0x4c10
+ax_pose 46, 0x81dc, 0x00e8, 0x4c12
+ax_pose 47, 0x81dc, 0x0110, 0x4c14
+ax_pose_terminator
+sZapdosPose256:
+ax_pose 34, 0x01d8, 0x90f1, 0x4c00
+ax_pose 35, 0x81d0, 0x50e9, 0x4c10
+ax_pose 36, 0x41f8, 0x10f1, 0x4c14
+ax_pose 37, 0x01d0, 0x10f1, 0x4c16
+ax_pose 38, 0x01d0, 0x1101, 0x4c17
+ax_pose_terminator
+sZapdosPose257:
+ax_pose 25, 0x01d0, 0x90f0, 0x4c00
+ax_pose 26, 0x41f0, 0x90f0, 0x4c10
+ax_pose 27, 0x01e8, 0x1110, 0x4c18
+ax_pose_terminator
+sZapdosPose258:
+ax_pose 13, 0x01d8, 0x90f1, 0x4c00
+ax_pose 14, 0x81d8, 0x50e9, 0x4c10
+ax_pose 15, 0x41f8, 0x10f4, 0x4c14
+ax_pose 16, 0x01e0, 0x10e1, 0x4c16
+ax_pose 17, 0x01d0, 0x1106, 0x4c17
+ax_pose_terminator
+sZapdosPose259:
+ax_pose 194, 0x01db, 0x80e7, 0x4c00
+ax_pose 195, 0x81db, 0x8107, 0x4c10
+ax_pose 196, 0x01e3, 0x0117, 0x4c18
+ax_pose 197, 0x41fb, 0x40ef, 0x4c19
+ax_pose_terminator
+sZapdosPose260:
+ax_pose 198, 0x01e3, 0x80e7, 0x4c00
+ax_pose 199, 0x81e3, 0x8107, 0x4c10
+ax_pose 200, 0x01eb, 0x0117, 0x4c18
+ax_pose -1, 0x0203, 0x00ff, 0x4c18
+ax_pose_terminator
+sZapdosPose261:
+ax_pose 194, 0x01db, 0x80e7, 0x4c00
+ax_pose 195, 0x81db, 0x8107, 0x4c10
+ax_pose 196, 0x01e3, 0x0117, 0x4c18
+ax_pose 197, 0x41fb, 0x40ef, 0x4c19
+ax_pose_terminator
+sZapdosPose262:
+ax_pose 198, 0x01e3, 0x80e7, 0x4c00
+ax_pose 199, 0x81e3, 0x8107, 0x4c10
+ax_pose 200, 0x01eb, 0x0117, 0x4c18
+ax_pose -1, 0x0203, 0x00ff, 0x4c18
+ax_pose_terminator
+sZapdosPose263:
+ax_pose 201, 0x01dd, 0x80e7, 0x4c00
+ax_pose 202, 0x81dd, 0x8107, 0x4c10
+ax_pose 203, 0x41fd, 0x40ef, 0x4c18
+ax_pose_terminator
+sZapdosPose264:
+ax_pose 204, 0x01d5, 0x80e7, 0x4c00
+ax_pose 205, 0x81d5, 0x8107, 0x4c10
+ax_pose 206, 0x41f5, 0x80ef, 0x4c18
+ax_pose_terminator
+.align 2
+sZapdosAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, 0, 0, 0,
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 2, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, 0, 0, 0,
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 5, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 0, 0, 0, 0,
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 8, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, 0, 0, 0,
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 11, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, 0, 0, 0,
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 14, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, 0, 0, 0,
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 17, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, 0, 0, 0, 0,
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 20, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, 0, 0, 0,
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 23, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_2_1:
+ax_anim 2, 0, 26, 0, -2, 0, -2,
+ax_anim 2, 0, 26, 0, -4, 0, -4,
+ax_anim 4, 0, 26, 0, -5, 0, -5,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 27, 0, 4, 0, 2,
+ax_anim 1, 0, 27, 0, 10, 0, 5,
+ax_anim 2, 0, 27, 0, 26, 0, 16,
+ax_anim 2, 1, 27, 1, 26, 1, 16,
+ax_anim 2, 0, 27, 0, 26, 0, 16,
+ax_anim 2, 0, 27, 1, 26, 1, 16,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sZapdosAnims_2_2:
+ax_anim 2, 0, 30, -2, -2, -2, -2,
+ax_anim 2, 0, 30, -4, -4, -4, -4,
+ax_anim 4, 0, 30, -5, -5, -5, -5,
+ax_anim 1, 0, 31, 0, 0, 0, 0,
+ax_anim 1, 2, 31, 3, 6, 3, 4,
+ax_anim 1, 0, 31, 9, 17, 9, 13,
+ax_anim 2, 0, 31, 14, 27, 14, 21,
+ax_anim 2, 1, 31, 15, 26, 15, 20,
+ax_anim 2, 0, 31, 14, 27, 14, 21,
+ax_anim 2, 0, 31, 15, 26, 15, 20,
+ax_anim 2, 0, 28, 6, 6, 6, 6,
+ax_anim_terminator
+sZapdosAnims_2_3:
+ax_anim 2, 0, 34, -2, 0, -2, 0,
+ax_anim 2, 0, 34, -4, 0, -4, 0,
+ax_anim 4, 0, 34, -5, 0, -5, 0,
+ax_anim 1, 0, 35, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, 1, 4, 0,
+ax_anim 1, 0, 35, 10, 3, 10, 0,
+ax_anim 2, 0, 35, 15, 5, 15, 0,
+ax_anim 2, 1, 35, 15, 6, 15, 1,
+ax_anim 2, 0, 35, 15, 5, 15, 0,
+ax_anim 2, 0, 35, 15, 6, 15, 1,
+ax_anim 2, 0, 32, 6, 1, 6, 0,
+ax_anim_terminator
+sZapdosAnims_2_4:
+ax_anim 2, 0, 38, -2, 2, -2, 2,
+ax_anim 2, 0, 38, -4, 4, -4, 4,
+ax_anim 4, 0, 38, -5, 5, -5, 5,
+ax_anim 1, 0, 39, 0, -1, 0, -1,
+ax_anim 1, 2, 39, 4, -3, 4, -6,
+ax_anim 1, 0, 39, 10, -6, 10, -12,
+ax_anim 2, 0, 39, 14, -8, 14, -16,
+ax_anim 2, 1, 39, 15, -7, 15, -15,
+ax_anim 2, 0, 39, 14, -8, 14, -16,
+ax_anim 2, 0, 39, 15, -7, 15, -15,
+ax_anim 2, 0, 36, 6, -4, 6, -7,
+ax_anim_terminator
+sZapdosAnims_2_5:
+ax_anim 2, 0, 42, 0, 2, 0, 2,
+ax_anim 2, 0, 42, 0, 4, 0, 4,
+ax_anim 4, 0, 42, 0, 5, 0, 5,
+ax_anim 1, 0, 43, 0, 4, 0, 4,
+ax_anim 1, 2, 43, 0, 1, 0, -2,
+ax_anim 1, 0, 43, 0, -3, 0, -11,
+ax_anim 2, 0, 43, 0, -8, 0, -20,
+ax_anim 2, 1, 43, 1, -8, 1, -20,
+ax_anim 2, 0, 43, 0, -8, 0, -20,
+ax_anim 2, 0, 43, 1, -8, 1, -20,
+ax_anim 2, 0, 40, 0, -2, 0, -5,
+ax_anim_terminator
+sZapdosAnims_2_6:
+ax_anim 2, 0, 46, 2, 2, 2, 2,
+ax_anim 2, 0, 46, 4, 4, 4, 4,
+ax_anim 4, 0, 46, 5, 5, 5, 5,
+ax_anim 1, 0, 47, 0, -1, 0, -1,
+ax_anim 1, 2, 47, -4, -3, -4, -6,
+ax_anim 1, 0, 47, -10, -6, -10, -12,
+ax_anim 2, 0, 47, -14, -8, -14, -16,
+ax_anim 2, 1, 47, -15, -7, -15, -15,
+ax_anim 2, 0, 47, -14, -8, -14, -16,
+ax_anim 2, 0, 47, -15, -7, -15, -15,
+ax_anim 2, 0, 44, -6, -4, -6, -7,
+ax_anim_terminator
+sZapdosAnims_2_7:
+ax_anim 2, 0, 50, 2, 0, 2, 0,
+ax_anim 2, 0, 50, 4, 0, 4, 0,
+ax_anim 4, 0, 50, 5, 0, 5, 0,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 51, -4, 1, -4, 0,
+ax_anim 1, 0, 51, -10, 3, -10, 0,
+ax_anim 2, 0, 51, -15, 5, -15, 0,
+ax_anim 2, 1, 51, -15, 6, -15, 1,
+ax_anim 2, 0, 51, -15, 5, -15, 0,
+ax_anim 2, 0, 51, -15, 6, -15, 1,
+ax_anim 2, 0, 48, -6, 1, -6, 0,
+ax_anim_terminator
+sZapdosAnims_2_8:
+ax_anim 2, 0, 54, 2, -2, 2, -2,
+ax_anim 2, 0, 54, 4, -4, 4, -4,
+ax_anim 4, 0, 54, 5, -5, 5, -5,
+ax_anim 1, 0, 55, 0, 0, 0, 0,
+ax_anim 1, 2, 55, -3, 6, -3, 4,
+ax_anim 1, 0, 55, -9, 17, -9, 13,
+ax_anim 2, 0, 55, -14, 27, -14, 21,
+ax_anim 2, 1, 55, -15, 26, -15, 20,
+ax_anim 2, 0, 55, -14, 27, -14, 21,
+ax_anim 2, 0, 55, -15, 26, -15, 20,
+ax_anim 2, 0, 52, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sZapdosAnims_3_1:
+ax_anim 2, 0, 58, 0, -2, 0, -2,
+ax_anim 2, 0, 58, 0, -4, 0, -4,
+ax_anim 4, 0, 58, 0, -5, 0, -5,
+ax_anim 1, 0, 59, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 0, 4, 0, 2,
+ax_anim 1, 0, 59, 0, 10, 0, 5,
+ax_anim 2, 0, 59, 0, 26, 0, 16,
+ax_anim 2, 1, 59, 1, 26, 1, 16,
+ax_anim 2, 0, 59, 0, 26, 0, 16,
+ax_anim 2, 0, 59, 1, 26, 1, 16,
+ax_anim 2, 0, 56, 0, 6, 0, 6,
+ax_anim_terminator
+sZapdosAnims_3_2:
+ax_anim 2, 0, 62, -2, -2, -2, -2,
+ax_anim 2, 0, 62, -4, -4, -4, -4,
+ax_anim 4, 0, 62, -5, -5, -5, -5,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 63, 3, 6, 3, 4,
+ax_anim 1, 0, 63, 9, 17, 9, 13,
+ax_anim 2, 0, 63, 14, 27, 14, 21,
+ax_anim 2, 1, 63, 15, 26, 15, 20,
+ax_anim 2, 0, 63, 14, 27, 14, 21,
+ax_anim 2, 0, 63, 15, 26, 15, 20,
+ax_anim 2, 0, 60, 6, 6, 6, 6,
+ax_anim_terminator
+sZapdosAnims_3_3:
+ax_anim 2, 0, 66, -2, 0, -2, 0,
+ax_anim 2, 0, 66, -4, 0, -4, 0,
+ax_anim 4, 0, 66, -5, 0, -5, 0,
+ax_anim 1, 0, 67, 0, 0, 0, 0,
+ax_anim 1, 2, 67, 4, 1, 4, 0,
+ax_anim 1, 0, 67, 10, 3, 10, 0,
+ax_anim 2, 0, 67, 15, 5, 15, 0,
+ax_anim 2, 1, 67, 15, 6, 15, 1,
+ax_anim 2, 0, 67, 15, 5, 15, 0,
+ax_anim 2, 0, 67, 15, 6, 15, 1,
+ax_anim 2, 0, 64, 6, 1, 6, 0,
+ax_anim_terminator
+sZapdosAnims_3_4:
+ax_anim 2, 0, 70, -2, 2, -2, 2,
+ax_anim 2, 0, 70, -4, 4, -4, 4,
+ax_anim 4, 0, 70, -5, 5, -5, 5,
+ax_anim 1, 0, 71, 0, -1, 0, -1,
+ax_anim 1, 2, 71, 4, -3, 4, -6,
+ax_anim 1, 0, 71, 10, -6, 10, -12,
+ax_anim 2, 0, 71, 14, -8, 14, -16,
+ax_anim 2, 1, 71, 15, -7, 15, -15,
+ax_anim 2, 0, 71, 14, -8, 14, -16,
+ax_anim 2, 0, 71, 15, -7, 15, -15,
+ax_anim 2, 0, 68, 6, -4, 6, -7,
+ax_anim_terminator
+sZapdosAnims_3_5:
+ax_anim 2, 0, 74, 0, 2, 0, 2,
+ax_anim 2, 0, 74, 0, 4, 0, 4,
+ax_anim 4, 0, 74, 0, 5, 0, 5,
+ax_anim 1, 0, 75, 0, 4, 0, 4,
+ax_anim 1, 2, 75, 0, 1, 0, -2,
+ax_anim 1, 0, 75, 0, -3, 0, -11,
+ax_anim 2, 0, 75, 0, -8, 0, -20,
+ax_anim 2, 1, 75, 1, -8, 1, -20,
+ax_anim 2, 0, 75, 0, -8, 0, -20,
+ax_anim 2, 0, 75, 1, -8, 1, -20,
+ax_anim 2, 0, 72, 0, -2, 0, -5,
+ax_anim_terminator
+sZapdosAnims_3_6:
+ax_anim 2, 0, 78, 2, 2, 2, 2,
+ax_anim 2, 0, 78, 4, 4, 4, 4,
+ax_anim 4, 0, 78, 5, 5, 5, 5,
+ax_anim 1, 0, 79, 0, -1, 0, -1,
+ax_anim 1, 2, 79, -4, -3, -4, -6,
+ax_anim 1, 0, 79, -10, -6, -10, -12,
+ax_anim 2, 0, 79, -14, -8, -14, -16,
+ax_anim 2, 1, 79, -15, -7, -15, -15,
+ax_anim 2, 0, 79, -14, -8, -14, -16,
+ax_anim 2, 0, 79, -15, -7, -15, -15,
+ax_anim 2, 0, 76, -6, -4, -6, -7,
+ax_anim_terminator
+sZapdosAnims_3_7:
+ax_anim 2, 0, 82, 2, 0, 2, 0,
+ax_anim 2, 0, 82, 4, 0, 4, 0,
+ax_anim 4, 0, 82, 5, 0, 5, 0,
+ax_anim 1, 0, 83, 0, 0, 0, 0,
+ax_anim 1, 2, 83, -4, 1, -4, 0,
+ax_anim 1, 0, 83, -10, 3, -10, 0,
+ax_anim 2, 0, 83, -15, 5, -15, 0,
+ax_anim 2, 1, 83, -15, 6, -15, 1,
+ax_anim 2, 0, 83, -15, 5, -15, 0,
+ax_anim 2, 0, 83, -15, 6, -15, 1,
+ax_anim 2, 0, 80, -6, 1, -6, 0,
+ax_anim_terminator
+sZapdosAnims_3_8:
+ax_anim 2, 0, 86, 2, -2, 2, -2,
+ax_anim 2, 0, 86, 4, -4, 4, -4,
+ax_anim 4, 0, 86, 5, -5, 5, -5,
+ax_anim 1, 0, 87, 0, 0, 0, 0,
+ax_anim 1, 2, 87, -3, 6, -3, 4,
+ax_anim 1, 0, 87, -9, 17, -9, 13,
+ax_anim 2, 0, 87, -14, 27, -14, 21,
+ax_anim 2, 1, 87, -15, 26, -15, 20,
+ax_anim 2, 0, 87, -14, 27, -14, 21,
+ax_anim 2, 0, 87, -15, 26, -15, 20,
+ax_anim 2, 0, 84, -6, 6, -6, 6,
+ax_anim_terminator
+.align 2
+sZapdosAnims_4_1:
+ax_anim 2, 0, 88, 0, -2, 0, -2,
+ax_anim 2, 0, 91, 0, -4, 0, -4,
+ax_anim 2, 0, 91, 0, -6, 0, -6,
+ax_anim 6, 2, 91, 0, -7, 0, -7,
+ax_anim 1, 0, 89, 0, -3, 0, -3,
+ax_anim 1, 0, 92, 0, 5, 0, 5,
+ax_anim 2, 1, 92, 0, 10, 0, 10,
+ax_anim 2, 0, 92, -1, 10, -1, 10,
+ax_anim 2, 0, 92, 0, 10, 0, 10,
+ax_anim 2, 0, 92, -1, 10, -1, 10,
+ax_anim 2, 0, 92, 0, 10, 0, 10,
+ax_anim 2, 0, 92, -1, 10, -1, 10,
+ax_anim 2, 0, 88, 0, 6, 0, 6,
+ax_anim 2, 0, 88, 0, 3, 0, 3,
+ax_anim_terminator
+sZapdosAnims_4_2:
+ax_anim 2, 0, 93, -2, -2, -2, -2,
+ax_anim 2, 0, 96, -4, -4, -4, -4,
+ax_anim 2, 0, 96, -6, -6, -6, -6,
+ax_anim 6, 2, 96, -7, -7, -7, -7,
+ax_anim 1, 0, 94, -3, -3, -3, -3,
+ax_anim 1, 0, 97, 5, 5, 5, 5,
+ax_anim 2, 1, 97, 10, 10, 10, 10,
+ax_anim 2, 0, 97, 9, 11, 9, 11,
+ax_anim 2, 0, 97, 10, 10, 10, 10,
+ax_anim 2, 0, 97, 9, 11, 9, 11,
+ax_anim 2, 0, 97, 10, 10, 10, 10,
+ax_anim 2, 0, 97, 9, 11, 9, 11,
+ax_anim 2, 0, 93, 6, 6, 6, 6,
+ax_anim 2, 0, 93, 3, 3, 3, 3,
+ax_anim_terminator
+sZapdosAnims_4_3:
+ax_anim 2, 0, 98, -2, 0, -2, 0,
+ax_anim 2, 0, 101, -4, 0, -4, 0,
+ax_anim 2, 0, 101, -6, 0, -6, 0,
+ax_anim 6, 2, 101, -7, 0, -7, 0,
+ax_anim 1, 0, 99, -3, 0, -3, 0,
+ax_anim 1, 0, 102, 5, 0, 5, 0,
+ax_anim 2, 1, 102, 10, 0, 10, 0,
+ax_anim 2, 0, 102, 10, 1, 10, 1,
+ax_anim 2, 0, 102, 10, 0, 10, 0,
+ax_anim 2, 0, 102, 10, 1, 10, 1,
+ax_anim 2, 0, 102, 10, 0, 10, 0,
+ax_anim 2, 0, 102, 10, 1, 10, 1,
+ax_anim 2, 0, 98, 6, 0, 6, 0,
+ax_anim 2, 0, 98, 3, 0, 3, 0,
+ax_anim_terminator
+sZapdosAnims_4_4:
+ax_anim 2, 0, 103, -2, 2, -2, 2,
+ax_anim 2, 0, 106, -4, 4, -4, 4,
+ax_anim 2, 0, 106, -6, 6, -6, 6,
+ax_anim 6, 2, 106, -7, 7, -7, 7,
+ax_anim 1, 0, 104, -3, 3, -3, 3,
+ax_anim 1, 0, 107, 5, -5, 5, -5,
+ax_anim 2, 1, 107, 10, -10, 10, -10,
+ax_anim 2, 0, 107, 9, -11, 9, -11,
+ax_anim 2, 0, 107, 10, -10, 10, -10,
+ax_anim 2, 0, 107, 9, -11, 9, -11,
+ax_anim 2, 0, 107, 10, -10, 10, -10,
+ax_anim 2, 0, 107, 9, -11, 9, -11,
+ax_anim 2, 0, 103, 6, -6, 6, -6,
+ax_anim 2, 0, 103, 3, -3, 3, -3,
+ax_anim_terminator
+sZapdosAnims_4_5:
+ax_anim 2, 0, 108, 0, 2, 0, 2,
+ax_anim 2, 0, 111, 0, 4, 0, 4,
+ax_anim 2, 0, 111, 0, 6, 0, 6,
+ax_anim 6, 2, 111, 0, 7, 0, 7,
+ax_anim 1, 0, 109, 0, 3, 0, 3,
+ax_anim 1, 0, 112, 0, -5, 0, -5,
+ax_anim 2, 1, 112, 0, -10, 0, -10,
+ax_anim 2, 0, 112, -1, -10, -1, -10,
+ax_anim 2, 0, 112, 0, -10, 0, -10,
+ax_anim 2, 0, 112, -1, -10, -1, -10,
+ax_anim 2, 0, 112, 0, -10, 0, -10,
+ax_anim 2, 0, 112, -1, -10, -1, -10,
+ax_anim 2, 0, 108, 0, -6, 0, -6,
+ax_anim 2, 0, 108, 0, -3, 0, -3,
+ax_anim_terminator
+sZapdosAnims_4_6:
+ax_anim 2, 0, 113, 2, 2, 2, 2,
+ax_anim 2, 0, 116, 4, 4, 4, 4,
+ax_anim 2, 0, 116, 6, 6, 6, 6,
+ax_anim 6, 2, 116, 7, 7, 7, 7,
+ax_anim 1, 0, 114, 3, 3, 3, 3,
+ax_anim 1, 0, 117, -5, -5, -5, -5,
+ax_anim 2, 1, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, -9, -11, -9, -11,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, -9, -11, -9, -11,
+ax_anim 2, 0, 117, -10, -10, -10, -10,
+ax_anim 2, 0, 117, -9, -11, -9, -11,
+ax_anim 2, 0, 113, -6, -6, -6, -6,
+ax_anim 2, 0, 113, -3, -3, -3, -3,
+ax_anim_terminator
+sZapdosAnims_4_7:
+ax_anim 2, 0, 118, 2, 0, 2, 0,
+ax_anim 2, 0, 121, 4, 0, 4, 0,
+ax_anim 2, 0, 121, 6, 0, 6, 0,
+ax_anim 6, 2, 121, 7, 0, 7, 0,
+ax_anim 1, 0, 119, 3, 0, 3, 0,
+ax_anim 1, 0, 122, -5, 0, -5, 0,
+ax_anim 2, 1, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, -10, 1, -10, 1,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, -10, 1, -10, 1,
+ax_anim 2, 0, 122, -10, 0, -10, 0,
+ax_anim 2, 0, 122, -10, 1, -10, 1,
+ax_anim 2, 0, 118, -6, 0, -6, 0,
+ax_anim 2, 0, 118, -3, 0, -3, 0,
+ax_anim_terminator
+sZapdosAnims_4_8:
+ax_anim 2, 0, 123, 2, -2, 2, -2,
+ax_anim 2, 0, 126, 4, -4, 4, -4,
+ax_anim 2, 0, 126, 6, -6, 6, -6,
+ax_anim 6, 2, 126, 7, -7, 7, -7,
+ax_anim 1, 0, 124, 3, -3, 3, -3,
+ax_anim 1, 0, 127, -5, 5, -5, 5,
+ax_anim 2, 1, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, -9, 11, -9, 11,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, -9, 11, -9, 11,
+ax_anim 2, 0, 127, -10, 10, -10, 10,
+ax_anim 2, 0, 127, -9, 11, -9, 11,
+ax_anim 2, 0, 123, -6, 6, -6, 6,
+ax_anim 2, 0, 123, -3, 3, -3, 3,
+ax_anim_terminator
+.align 2
+sZapdosAnims_5_1:
+ax_anim 2, 0, 129, 0, -2, 0, 0,
+ax_anim 2, 0, 129, 0, -4, 0, 0,
+ax_anim 2, 0, 129, 0, -6, 0, 0,
+ax_anim 6, 2, 128, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, 0,
+ax_anim 2, 0, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 132, 0, -6, 0, 0,
+ax_anim 2, 1, 131, 0, -6, 0, 0,
+ax_anim 2, 0, 128, 0, -2, 0, 0,
+ax_anim_terminator
+sZapdosAnims_5_2:
+ax_anim 2, 0, 134, 0, -2, 0, 0,
+ax_anim 2, 0, 134, 0, -4, 0, 0,
+ax_anim 2, 0, 134, 0, -6, 0, 0,
+ax_anim 6, 2, 133, 0, -6, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 0, 136, 0, -6, 0, 0,
+ax_anim 2, 0, 137, 0, -6, 0, 0,
+ax_anim 2, 1, 136, 0, -6, 0, 0,
+ax_anim 2, 0, 133, 0, -2, 0, 0,
+ax_anim_terminator
+sZapdosAnims_5_3:
+ax_anim 2, 0, 139, 0, -2, 0, 0,
+ax_anim 2, 0, 139, 0, -4, 0, 0,
+ax_anim 2, 0, 139, 0, -6, 0, 0,
+ax_anim 6, 2, 138, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, 0,
+ax_anim 2, 0, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 142, 0, -6, 0, 0,
+ax_anim 2, 1, 141, 0, -6, 0, 0,
+ax_anim 2, 0, 138, 0, -2, 0, 0,
+ax_anim_terminator
+sZapdosAnims_5_4:
+ax_anim 2, 0, 144, 0, -2, 0, 0,
+ax_anim 2, 0, 144, 0, -4, 0, 0,
+ax_anim 2, 0, 144, 0, -6, 0, 0,
+ax_anim 6, 2, 143, 0, -6, 0, 0,
+ax_anim 2, 0, 146, 0, -6, 0, 0,
+ax_anim 2, 0, 147, 0, -6, 0, 0,
+ax_anim 2, 0, 146, 0, -6, 0, 0,
+ax_anim 2, 0, 147, 0, -6, 0, 0,
+ax_anim 2, 0, 146, 0, -6, 0, 0,
+ax_anim 2, 0, 147, 0, -6, 0, 0,
+ax_anim 2, 1, 146, 0, -6, 0, 0,
+ax_anim 2, 0, 143, 0, -2, 0, 0,
+ax_anim_terminator
+sZapdosAnims_5_5:
+ax_anim 2, 0, 149, 0, -2, 0, 0,
+ax_anim 2, 0, 149, 0, -4, 0, 0,
+ax_anim 2, 0, 149, 0, -6, 0, 0,
+ax_anim 6, 2, 148, 0, -6, 0, 0,
+ax_anim 2, 0, 151, 0, -6, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, 0,
+ax_anim 2, 0, 151, 0, -6, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, 0,
+ax_anim 2, 0, 151, 0, -6, 0, 0,
+ax_anim 2, 0, 152, 0, -6, 0, 0,
+ax_anim 2, 1, 151, 0, -6, 0, 0,
+ax_anim 2, 0, 148, 0, -2, 0, 0,
+ax_anim_terminator
+sZapdosAnims_5_6:
+ax_anim 2, 0, 154, 0, -2, 0, 0,
+ax_anim 2, 0, 154, 0, -4, 0, 0,
+ax_anim 2, 0, 154, 0, -6, 0, 0,
+ax_anim 6, 2, 153, 0, -6, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, 0,
+ax_anim 2, 0, 157, 0, -6, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, 0,
+ax_anim 2, 0, 157, 0, -6, 0, 0,
+ax_anim 2, 0, 156, 0, -6, 0, 0,
+ax_anim 2, 0, 157, 0, -6, 0, 0,
+ax_anim 2, 1, 156, 0, -6, 0, 0,
+ax_anim 2, 0, 153, 0, -2, 0, 0,
+ax_anim_terminator
+sZapdosAnims_5_7:
+ax_anim 2, 0, 159, 0, -2, 0, 0,
+ax_anim 2, 0, 159, 0, -4, 0, 0,
+ax_anim 2, 0, 159, 0, -6, 0, 0,
+ax_anim 6, 2, 158, 0, -6, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, 0,
+ax_anim 2, 0, 162, 0, -6, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, 0,
+ax_anim 2, 0, 162, 0, -6, 0, 0,
+ax_anim 2, 0, 161, 0, -6, 0, 0,
+ax_anim 2, 0, 162, 0, -6, 0, 0,
+ax_anim 2, 1, 161, 0, -6, 0, 0,
+ax_anim 2, 0, 158, 0, -2, 0, 0,
+ax_anim_terminator
+sZapdosAnims_5_8:
+ax_anim 2, 0, 164, 0, -2, 0, 0,
+ax_anim 2, 0, 164, 0, -4, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, 0,
+ax_anim 6, 2, 163, 0, -6, 0, 0,
+ax_anim 2, 0, 166, 0, -6, 0, 0,
+ax_anim 2, 0, 167, 0, -6, 0, 0,
+ax_anim 2, 0, 166, 0, -6, 0, 0,
+ax_anim 2, 0, 167, 0, -6, 0, 0,
+ax_anim 2, 0, 166, 0, -6, 0, 0,
+ax_anim 2, 0, 167, 0, -6, 0, 0,
+ax_anim 2, 1, 166, 0, -6, 0, 0,
+ax_anim 2, 0, 163, 0, -2, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_6_1:
+ax_anim 30, 0, 168, 0, 0, 0, 0,
+ax_anim 35, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_7_1:
+ax_anim 2, 0, 170, 0, -4, 0, -4,
+ax_anim 8, 0, 170, 0, -5, 0, -5,
+ax_anim_terminator
+sZapdosAnims_7_2:
+ax_anim 2, 0, 171, -4, -4, -4, -4,
+ax_anim 8, 0, 171, -5, -5, -5, -5,
+ax_anim_terminator
+sZapdosAnims_7_3:
+ax_anim 2, 0, 172, -4, 0, -4, 0,
+ax_anim 8, 0, 172, -5, 0, -5, 0,
+ax_anim_terminator
+sZapdosAnims_7_4:
+ax_anim 2, 0, 173, -4, 4, -4, 4,
+ax_anim 8, 0, 173, -5, 5, -5, 5,
+ax_anim_terminator
+sZapdosAnims_7_5:
+ax_anim 2, 0, 174, 0, 4, 0, 4,
+ax_anim 8, 0, 174, 0, 5, 0, 5,
+ax_anim_terminator
+sZapdosAnims_7_6:
+ax_anim 2, 0, 175, 4, 4, 4, 4,
+ax_anim 8, 0, 175, 5, 5, 5, 5,
+ax_anim_terminator
+sZapdosAnims_7_7:
+ax_anim 2, 0, 176, 4, 0, 4, 0,
+ax_anim 8, 0, 176, 5, 0, 5, 0,
+ax_anim_terminator
+sZapdosAnims_7_8:
+ax_anim 2, 0, 177, 4, -4, 4, -4,
+ax_anim 8, 0, 177, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sZapdosAnims_8_1:
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 179, 0, 0, 0, 0,
+ax_anim 8, 0, 178, 0, 0, 0, 0,
+ax_anim 10, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_8_2:
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 10, 0, 182, 0, 0, 0, 0,
+ax_anim 8, 0, 181, 0, 0, 0, 0,
+ax_anim 10, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_8_3:
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 185, 0, 0, 0, 0,
+ax_anim 8, 0, 184, 0, 0, 0, 0,
+ax_anim 10, 0, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_8_4:
+ax_anim 8, 0, 187, 0, 0, 0, 0,
+ax_anim 10, 0, 188, 0, 0, 0, 0,
+ax_anim 8, 0, 187, 0, 0, 0, 0,
+ax_anim 10, 0, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_8_5:
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 191, 0, 0, 0, 0,
+ax_anim 8, 0, 190, 0, 0, 0, 0,
+ax_anim 10, 0, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_8_6:
+ax_anim 8, 0, 193, 0, 0, 0, 0,
+ax_anim 10, 0, 194, 0, 0, 0, 0,
+ax_anim 8, 0, 193, 0, 0, 0, 0,
+ax_anim 10, 0, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_8_7:
+ax_anim 8, 0, 196, 0, 0, 0, 0,
+ax_anim 10, 0, 197, 0, 0, 0, 0,
+ax_anim 8, 0, 196, 0, 0, 0, 0,
+ax_anim 10, 0, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_8_8:
+ax_anim 8, 0, 199, 0, 0, 0, 0,
+ax_anim 10, 0, 200, 0, 0, 0, 0,
+ax_anim 8, 0, 199, 0, 0, 0, 0,
+ax_anim 10, 0, 201, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_9_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 6, 3, 6, 3,
+ax_anim 2, 0, 204, 10, 14, 10, 12,
+ax_anim 2, 0, 205, 7, 23, 7, 19,
+ax_anim 3, 0, 206, 0, 29, 0, 23,
+ax_anim 2, 3, 207, -7, 23, -7, 19,
+ax_anim 2, 0, 208, -10, 14, -10, 12,
+ax_anim 1, 0, 209, -6, 3, -6, 3,
+ax_anim 1, 0, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_9_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 1, 0, 202, 8, 0, 8, 0,
+ax_anim 2, 0, 203, 16, 8, 16, 8,
+ax_anim 2, 0, 204, 19, 21, 19, 16,
+ax_anim 3, 0, 205, 14, 28, 14, 20,
+ax_anim 2, 3, 206, 8, 29, 8, 22,
+ax_anim 2, 0, 207, 3, 23, 3, 21,
+ax_anim 1, 0, 208, 0, 10, 0, 10,
+ax_anim 1, 0, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_9_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 3, -4, 3, -3,
+ax_anim 2, 0, 202, 11, -3, 11, -5,
+ax_anim 2, 0, 203, 16, 3, 16, -3,
+ax_anim 3, 0, 204, 17, 10, 17, 2,
+ax_anim 2, 3, 205, 13, 13, 13, 8,
+ax_anim 2, 0, 206, 7, 12, 7, 8,
+ax_anim 1, 0, 207, 2, 7, 2, 5,
+ax_anim 1, 0, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_9_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 208, -1, -5, -1, -5,
+ax_anim 2, 0, 209, 4, -12, 4, -12,
+ax_anim 2, 0, 202, 11, -12, 11, -17,
+ax_anim 3, 0, 203, 16, -10, 16, -19,
+ax_anim 2, 3, 204, 20, -3, 20, -13,
+ax_anim 2, 0, 205, 17, 1, 17, -2,
+ax_anim 1, 0, 206, 7, 2, 7, 2,
+ax_anim 1, 0, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_9_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 1, 0, 207, -8, -2, -8, -3,
+ax_anim 2, 0, 208, -9, -6, -9, -9,
+ax_anim 2, 0, 209, -7, -9, -7, -17,
+ax_anim 3, 0, 202, 0, -10, 0, -20,
+ax_anim 2, 3, 203, 7, -9, 7, -17,
+ax_anim 2, 0, 204, 9, -6, 9, -9,
+ax_anim 1, 0, 205, 8, -2, 8, -3,
+ax_anim 1, 0, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_9_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 1, 0, 204, 1, -5, 1, -5,
+ax_anim 2, 0, 203, -4, -12, -4, -12,
+ax_anim 2, 0, 202, -11, -12, -11, -17,
+ax_anim 3, 0, 209, -16, -10, -16, -19,
+ax_anim 2, 3, 208, -20, -3, -20, -13,
+ax_anim 2, 0, 207, -17, 1, -17, -2,
+ax_anim 1, 0, 206, -7, 2, -7, 2,
+ax_anim 1, 0, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_9_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 203, -3, -4, -3, -3,
+ax_anim 2, 0, 202, -11, -3, -11, -5,
+ax_anim 2, 0, 209, -16, -3, -16, -3,
+ax_anim 3, 0, 208, -17, 10, -17, 2,
+ax_anim 2, 3, 207, -13, 13, -13, 8,
+ax_anim 2, 0, 206, -7, 12, -7, 8,
+ax_anim 1, 0, 205, -2, 7, -2, 5,
+ax_anim 1, 0, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_9_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 1, 0, 202, -8, 0, -8, 0,
+ax_anim 2, 0, 209, -16, 8, -16, 8,
+ax_anim 2, 0, 208, -19, 21, -19, 16,
+ax_anim 3, 0, 207, -14, 28, -14, 20,
+ax_anim 2, 3, 206, -8, 29, -8, 22,
+ax_anim 2, 0, 205, -3, 23, -3, 21,
+ax_anim 1, 0, 204, 0, 10, 0, 10,
+ax_anim 1, 0, 203, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_10_1:
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 3, 0, 210, 13, 0, 13, 0,
+ax_anim 3, 0, 210, -13, 0, -13, 0,
+ax_anim 2, 0, 210, 12, 0, 12, 0,
+ax_anim 3, 0, 210, -12, 0, -12, 0,
+ax_anim 2, 0, 210, 10, 0, 10, 0,
+ax_anim 2, 0, 210, -10, 0, -10, 0,
+ax_anim 2, 0, 210, 6, 0, 6, 0,
+ax_anim 2, 0, 210, -6, 0, -6, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_10_2:
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 3, 0, 211, 13, -13, 13, -13,
+ax_anim 3, 0, 211, -13, 13, -13, 13,
+ax_anim 2, 0, 211, 12, -12, 12, -12,
+ax_anim 3, 0, 211, -12, 12, -12, 12,
+ax_anim 2, 0, 211, 10, -10, 10, -10,
+ax_anim 2, 0, 211, -10, 10, -10, 10,
+ax_anim 2, 0, 211, 6, -6, 6, -6,
+ax_anim 2, 0, 211, -6, 6, -6, 6,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_10_3:
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 3, 0, 212, 0, -13, 0, -13,
+ax_anim 3, 0, 212, 0, 13, 0, 13,
+ax_anim 2, 0, 212, 0, -12, 0, -12,
+ax_anim 3, 0, 212, 0, 12, 0, 12,
+ax_anim 2, 0, 212, 0, -10, 0, -10,
+ax_anim 2, 0, 212, 0, 10, 0, 10,
+ax_anim 2, 0, 212, 0, -6, 0, -6,
+ax_anim 2, 0, 212, 0, 6, 0, 6,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_10_4:
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 3, 0, 213, -13, -13, -13, -13,
+ax_anim 3, 0, 213, 13, 13, 13, 13,
+ax_anim 2, 0, 213, -12, -12, -12, -12,
+ax_anim 3, 0, 213, 12, 12, 12, 12,
+ax_anim 2, 0, 213, -10, -10, -10, -10,
+ax_anim 2, 0, 213, 10, 10, 10, 10,
+ax_anim 2, 0, 213, -6, -6, -6, -6,
+ax_anim 2, 0, 213, 6, 6, 6, 6,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_10_5:
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 3, 0, 214, 13, 0, 13, 0,
+ax_anim 3, 0, 214, -13, 0, -13, 0,
+ax_anim 2, 0, 214, 12, 0, 12, 0,
+ax_anim 3, 0, 214, -12, 0, -12, 0,
+ax_anim 2, 0, 214, 10, 0, 10, 0,
+ax_anim 2, 0, 214, -10, 0, -10, 0,
+ax_anim 2, 0, 214, 6, 0, 6, 0,
+ax_anim 2, 0, 214, -6, 0, -6, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_10_6:
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 3, 0, 215, 13, -13, 13, -13,
+ax_anim 3, 0, 215, -13, 13, -13, 13,
+ax_anim 2, 0, 215, 12, -12, 12, -12,
+ax_anim 3, 0, 215, -12, 12, -12, 12,
+ax_anim 2, 0, 215, 10, -10, 10, -10,
+ax_anim 2, 0, 215, -10, 10, -10, 10,
+ax_anim 2, 0, 215, 6, -6, 6, -6,
+ax_anim 2, 0, 215, -6, 6, -6, 6,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_10_7:
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 3, 0, 216, 0, -13, 0, -13,
+ax_anim 3, 0, 216, 0, 13, 0, 13,
+ax_anim 2, 0, 216, 0, -12, 0, -12,
+ax_anim 3, 0, 216, 0, 12, 0, 12,
+ax_anim 2, 0, 216, 0, -10, 0, -10,
+ax_anim 2, 0, 216, 0, 10, 0, 10,
+ax_anim 2, 0, 216, 0, -6, 0, -6,
+ax_anim 2, 0, 216, 0, 6, 0, 6,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_10_8:
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 3, 0, 217, -13, -13, -13, -13,
+ax_anim 3, 0, 217, 13, 13, 13, 13,
+ax_anim 2, 0, 217, -12, -12, -12, -12,
+ax_anim 3, 0, 217, 12, 12, 12, 12,
+ax_anim 2, 0, 217, -10, -10, -10, -10,
+ax_anim 2, 0, 217, 10, 10, 10, 10,
+ax_anim 2, 0, 217, -6, -6, -6, -6,
+ax_anim 2, 0, 217, 6, 6, 6, 6,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_11_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 1, 0, 220, 0, -10, 0, 0,
+ax_anim 2, 0, 220, 0, -16, 0, 0,
+ax_anim 3, 0, 220, 0, -20, 0, 0,
+ax_anim 4, 0, 220, 0, -21, 0, 0,
+ax_anim 4, 0, 218, 0, -23, 0, 0,
+ax_anim 3, 0, 219, 0, -22, 0, 0,
+ax_anim 2, 0, 219, 0, -18, 0, 0,
+ax_anim 1, 0, 219, 0, -7, 0, 0,
+ax_anim 2, 2, 218, 0, 10, 0, 0,
+ax_anim_terminator
+sZapdosAnims_11_2:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 1, 0, 223, 0, -10, 0, 0,
+ax_anim 2, 0, 223, 0, -16, 0, 0,
+ax_anim 3, 0, 223, 0, -20, 0, 0,
+ax_anim 4, 0, 223, 0, -21, 0, 0,
+ax_anim 4, 0, 221, 0, -23, 0, 0,
+ax_anim 3, 0, 222, 0, -22, 0, 0,
+ax_anim 2, 0, 222, 0, -18, 0, 0,
+ax_anim 1, 0, 222, 0, -7, 0, 0,
+ax_anim 2, 2, 221, 0, 10, 0, 0,
+ax_anim_terminator
+sZapdosAnims_11_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 1, 0, 226, 0, -10, 0, 0,
+ax_anim 2, 0, 226, 0, -16, 0, 0,
+ax_anim 3, 0, 226, 0, -20, 0, 0,
+ax_anim 4, 0, 226, 0, -21, 0, 0,
+ax_anim 4, 0, 224, 0, -23, 0, 0,
+ax_anim 3, 0, 225, 0, -22, 0, 0,
+ax_anim 2, 0, 225, 0, -18, 0, 0,
+ax_anim 1, 0, 225, 0, -7, 0, 0,
+ax_anim 2, 2, 224, 0, 10, 0, 0,
+ax_anim_terminator
+sZapdosAnims_11_4:
+ax_anim 2, 0, 227, 0, 0, 0, 0,
+ax_anim 1, 0, 229, 0, -10, 0, 0,
+ax_anim 2, 0, 229, 0, -16, 0, 0,
+ax_anim 3, 0, 229, 0, -20, 0, 0,
+ax_anim 4, 0, 229, 0, -21, 0, 0,
+ax_anim 4, 0, 227, 0, -22, 0, 0,
+ax_anim 3, 0, 228, 0, -21, 0, 0,
+ax_anim 2, 0, 228, 0, -17, 0, 0,
+ax_anim 1, 0, 228, 0, -7, 0, 0,
+ax_anim 2, 2, 227, 0, 10, 0, 0,
+ax_anim_terminator
+sZapdosAnims_11_5:
+ax_anim 2, 0, 230, 0, 0, 0, 0,
+ax_anim 1, 0, 232, 0, -10, 0, 0,
+ax_anim 2, 0, 232, 0, -16, 0, 0,
+ax_anim 3, 0, 232, 0, -20, 0, 0,
+ax_anim 4, 0, 232, 0, -21, 0, 0,
+ax_anim 4, 0, 230, 0, -23, 0, 0,
+ax_anim 3, 0, 231, 0, -22, 0, 0,
+ax_anim 2, 0, 231, 0, -18, 0, 0,
+ax_anim 1, 0, 231, 0, -7, 0, 0,
+ax_anim 2, 2, 230, 0, 12, 0, 0,
+ax_anim_terminator
+sZapdosAnims_11_6:
+ax_anim 2, 0, 233, 0, 0, 0, 0,
+ax_anim 1, 0, 235, 0, -10, 0, 0,
+ax_anim 2, 0, 235, 0, -16, 0, 0,
+ax_anim 3, 0, 235, 0, -20, 0, 0,
+ax_anim 4, 0, 235, 0, -21, 0, 0,
+ax_anim 4, 0, 233, 0, -22, 0, 0,
+ax_anim 3, 0, 234, 0, -21, 0, 0,
+ax_anim 2, 0, 234, 0, -17, 0, 0,
+ax_anim 1, 0, 234, 0, -7, 0, 0,
+ax_anim 2, 2, 233, 0, 10, 0, 0,
+ax_anim_terminator
+sZapdosAnims_11_7:
+ax_anim 2, 0, 236, 0, 0, 0, 0,
+ax_anim 1, 0, 238, 0, -10, 0, 0,
+ax_anim 2, 0, 238, 0, -16, 0, 0,
+ax_anim 3, 0, 238, 0, -20, 0, 0,
+ax_anim 4, 0, 238, 0, -21, 0, 0,
+ax_anim 4, 0, 236, 0, -23, 0, 0,
+ax_anim 3, 0, 237, 0, -22, 0, 0,
+ax_anim 2, 0, 237, 0, -18, 0, 0,
+ax_anim 1, 0, 237, 0, -7, 0, 0,
+ax_anim 2, 2, 236, 0, 10, 0, 0,
+ax_anim_terminator
+sZapdosAnims_11_8:
+ax_anim 2, 0, 239, 0, 0, 0, 0,
+ax_anim 1, 0, 241, 0, -10, 0, 0,
+ax_anim 2, 0, 241, 0, -16, 0, 0,
+ax_anim 3, 0, 241, 0, -20, 0, 0,
+ax_anim 4, 0, 241, 0, -21, 0, 0,
+ax_anim 4, 0, 239, 0, -23, 0, 0,
+ax_anim 3, 0, 240, 0, -22, 0, 0,
+ax_anim 2, 0, 240, 0, -18, 0, 0,
+ax_anim 1, 0, 240, 0, -7, 0, 0,
+ax_anim 2, 2, 239, 0, 10, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_12_1:
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 2, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 0, 242, 0, 0, 0, 0,
+ax_anim 2, 0, 242, 1, 0, 1, 0,
+ax_anim 2, 1, 242, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_12_2:
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 2, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 0, 249, 0, 0, 0, 0,
+ax_anim 2, 0, 249, 1, -1, 1, -1,
+ax_anim 2, 1, 249, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_12_3:
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 2, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 0, 248, 0, 0, 0, 0,
+ax_anim 2, 0, 248, 0, -1, 0, -1,
+ax_anim 2, 1, 248, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_12_4:
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 2, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 0, 247, 0, 0, 0, 0,
+ax_anim 2, 0, 247, -1, -1, -1, -1,
+ax_anim 2, 1, 247, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_12_5:
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 2, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 0, 246, 0, 0, 0, 0,
+ax_anim 2, 0, 246, 1, 0, 1, 0,
+ax_anim 2, 1, 246, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_12_6:
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 2, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 0, 245, 0, 0, 0, 0,
+ax_anim 2, 0, 245, 1, -1, 1, -1,
+ax_anim 2, 1, 245, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_12_7:
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 2, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 0, 244, 0, 0, 0, 0,
+ax_anim 2, 0, 244, 0, -1, 0, -1,
+ax_anim 2, 1, 244, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_12_8:
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 2, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 0, 243, 0, 0, 0, 0,
+ax_anim 2, 0, 243, -1, -1, -1, -1,
+ax_anim 2, 1, 243, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_13_1:
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 2, 250, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_13_2:
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 2, 257, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_13_3:
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 2, 256, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_13_4:
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 2, 255, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_13_5:
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 2, 254, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_13_6:
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 2, 253, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_13_7:
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 2, 252, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_13_8:
+ax_anim 2, 0, 251, 0, 0, 0, 0,
+ax_anim 2, 0, 252, 0, 0, 0, 0,
+ax_anim 2, 0, 253, 0, 0, 0, 0,
+ax_anim 2, 0, 254, 0, 0, 0, 0,
+ax_anim 2, 0, 255, 0, 0, 0, 0,
+ax_anim 2, 0, 256, 0, 0, 0, 0,
+ax_anim 2, 0, 257, 0, 0, 0, 0,
+ax_anim 2, 0, 250, 0, 0, 0, 0,
+ax_anim 2, 2, 251, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_14_1:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_14_2:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_14_3:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_14_4:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_14_5:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_14_6:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_14_7:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_14_8:
+ax_anim 24, 0, 258, 0, 0, 0, 0,
+ax_anim 20, 0, 259, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZapdosAnims_15_1:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_15_2:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_15_3:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_15_4:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_15_5:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_15_6:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_15_7:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosAnims_15_8:
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 16, 0, 260, 0, 0, 0, 0,
+ax_anim 12, 0, 261, 0, 0, 0, 0,
+ax_anim 2, 0, 262, 0, 0, 0, 0,
+ax_anim 6, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 1, 0, 263, 1, 0, 1, 0,
+ax_anim 1, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 2, 0, 263, 0, 0, 0, 0,
+ax_anim 2, 0, 263, 1, 0, 1, 0,
+ax_anim 10, 0, 263, 0, 0, 0, 0,
+ax_anim_terminator
+sZapdosGfx1:
+.incbin "baserom.gba", 0xB46778, 0x20
+sZapdosGfx1_1:
+.incbin "baserom.gba", 0xB46798, 0x1A0
+sZapdosSprites1:
+ax_sprite sZapdosGfx1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx1_1, 0x1a0
+ax_sprite_terminator
+sZapdosGfx2:
+.incbin "baserom.gba", 0xB46958, 0x80
+sZapdosSprites2:
+ax_sprite sZapdosGfx2, 0x80
+ax_sprite_terminator
+sZapdosGfx3:
+.incbin "baserom.gba", 0xB469E8, 0x80
+sZapdosSprites3:
+ax_sprite sZapdosGfx3, 0x80
+ax_sprite_terminator
+sZapdosGfx4:
+.incbin "baserom.gba", 0xB46A78, 0x40
+sZapdosGfx4_1:
+.incbin "baserom.gba", 0xB46AB8, 0x20
+sZapdosSprites4:
+ax_sprite sZapdosGfx4, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx4_1, 0x20
+ax_sprite_terminator
+sZapdosGfx5:
+.incbin "baserom.gba", 0xB46AF8, 0x60
+sZapdosSprites5:
+ax_sprite sZapdosGfx5, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx6:
+.incbin "baserom.gba", 0xB46B70, 0x200
+sZapdosSprites6:
+ax_sprite sZapdosGfx6, 0x200
+ax_sprite_terminator
+sZapdosGfx7:
+.incbin "baserom.gba", 0xB46D80, 0x80
+sZapdosGfx7_1:
+.incbin "baserom.gba", 0xB46E00, 0x60
+sZapdosSprites7:
+ax_sprite sZapdosGfx7, 0x80
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx7_1, 0x60
+ax_sprite_terminator
+sZapdosGfx8:
+.incbin "baserom.gba", 0xB46E80, 0x20
+sZapdosSprites8:
+ax_sprite sZapdosGfx8, 0x20
+ax_sprite_terminator
+sZapdosGfx9:
+.incbin "baserom.gba", 0xB46EB0, 0x20
+sZapdosSprites9:
+ax_sprite sZapdosGfx9, 0x20
+ax_sprite_terminator
+sZapdosGfx10:
+.incbin "baserom.gba", 0xB46EE0, 0x180
+sZapdosGfx10_1:
+.incbin "baserom.gba", 0xB47060, 0x60
+sZapdosSprites10:
+ax_sprite sZapdosGfx10, 0x180
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx10_1, 0x60
+ax_sprite_terminator
+sZapdosGfx11:
+.incbin "baserom.gba", 0xB470E0, 0x40
+sZapdosSprites11:
+ax_sprite sZapdosGfx11, 0x40
+ax_sprite_terminator
+sZapdosGfx12:
+.incbin "baserom.gba", 0xB47130, 0x40
+sZapdosSprites12:
+ax_sprite sZapdosGfx12, 0x40
+ax_sprite_terminator
+sZapdosGfx13:
+.incbin "baserom.gba", 0xB47180, 0x40
+sZapdosSprites13:
+ax_sprite sZapdosGfx13, 0x40
+ax_sprite_terminator
+sZapdosGfx14:
+.incbin "baserom.gba", 0xB471D0, 0x200
+sZapdosSprites14:
+ax_sprite sZapdosGfx14, 0x200
+ax_sprite_terminator
+sZapdosGfx15:
+.incbin "baserom.gba", 0xB473E0, 0x80
+sZapdosSprites15:
+ax_sprite sZapdosGfx15, 0x80
+ax_sprite_terminator
+sZapdosGfx16:
+.incbin "baserom.gba", 0xB47470, 0x40
+sZapdosSprites16:
+ax_sprite sZapdosGfx16, 0x40
+ax_sprite_terminator
+sZapdosGfx17:
+.incbin "baserom.gba", 0xB474C0, 0x20
+sZapdosSprites17:
+ax_sprite sZapdosGfx17, 0x20
+ax_sprite_terminator
+sZapdosGfx18:
+.incbin "baserom.gba", 0xB474F0, 0x20
+sZapdosSprites18:
+ax_sprite sZapdosGfx18, 0x20
+ax_sprite_terminator
+sZapdosGfx19:
+.incbin "baserom.gba", 0xB47520, 0x60
+sZapdosGfx19_1:
+.incbin "baserom.gba", 0xB47580, 0x180
+sZapdosSprites19:
+ax_sprite sZapdosGfx19, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx19_1, 0x180
+ax_sprite_terminator
+sZapdosGfx20:
+.incbin "baserom.gba", 0xB47720, 0xE0
+sZapdosSprites20:
+ax_sprite sZapdosGfx20, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx21:
+.incbin "baserom.gba", 0xB47818, 0x40
+sZapdosSprites21:
+ax_sprite sZapdosGfx21, 0x40
+ax_sprite_terminator
+sZapdosGfx22:
+.incbin "baserom.gba", 0xB47868, 0x40
+sZapdosGfx22_1:
+.incbin "baserom.gba", 0xB478A8, 0x180
+sZapdosSprites22:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx22, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx22_1, 0x180
+ax_sprite_terminator
+sZapdosGfx23:
+.incbin "baserom.gba", 0xB47A50, 0x20
+sZapdosSprites23:
+ax_sprite sZapdosGfx23, 0x20
+ax_sprite_terminator
+sZapdosGfx24:
+.incbin "baserom.gba", 0xB47A80, 0x40
+sZapdosSprites24:
+ax_sprite sZapdosGfx24, 0x40
+ax_sprite_terminator
+sZapdosGfx25:
+.incbin "baserom.gba", 0xB47AD0, 0x20
+sZapdosSprites25:
+ax_sprite sZapdosGfx25, 0x20
+ax_sprite_terminator
+sZapdosGfx26:
+.incbin "baserom.gba", 0xB47B00, 0x40
+sZapdosGfx26_1:
+.incbin "baserom.gba", 0xB47B40, 0x180
+sZapdosSprites26:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx26, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx26_1, 0x180
+ax_sprite_terminator
+sZapdosGfx27:
+.incbin "baserom.gba", 0xB47CE8, 0x80
+sZapdosGfx27_1:
+.incbin "baserom.gba", 0xB47D68, 0x60
+sZapdosSprites27:
+ax_sprite sZapdosGfx27, 0x80
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx27_1, 0x60
+ax_sprite_terminator
+sZapdosGfx28:
+.incbin "baserom.gba", 0xB47DE8, 0x20
+sZapdosSprites28:
+ax_sprite sZapdosGfx28, 0x20
+ax_sprite_terminator
+sZapdosGfx29:
+.incbin "baserom.gba", 0xB47E18, 0x1C0
+sZapdosSprites29:
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx29, 0x1c0
+ax_sprite_terminator
+sZapdosGfx30:
+.incbin "baserom.gba", 0xB47FF0, 0x80
+sZapdosGfx30_1:
+.incbin "baserom.gba", 0xB48070, 0x40
+sZapdosSprites30:
+ax_sprite sZapdosGfx30, 0x80
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx30_1, 0x40
+ax_sprite_terminator
+sZapdosGfx31:
+.incbin "baserom.gba", 0xB480D0, 0x40
+sZapdosSprites31:
+ax_sprite sZapdosGfx31, 0x40
+ax_sprite_terminator
+sZapdosGfx32:
+.incbin "baserom.gba", 0xB48120, 0x20
+sZapdosSprites32:
+ax_sprite sZapdosGfx32, 0x20
+ax_sprite_terminator
+sZapdosGfx33:
+.incbin "baserom.gba", 0xB48150, 0x60
+sZapdosGfx33_1:
+.incbin "baserom.gba", 0xB481B0, 0x60
+sZapdosGfx33_2:
+.incbin "baserom.gba", 0xB48210, 0x100
+sZapdosSprites33:
+ax_sprite sZapdosGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx33_2, 0x100
+ax_sprite_terminator
+sZapdosGfx34:
+.incbin "baserom.gba", 0xB48340, 0x80
+sZapdosSprites34:
+ax_sprite sZapdosGfx34, 0x80
+ax_sprite_terminator
+sZapdosGfx35:
+.incbin "baserom.gba", 0xB483D0, 0x200
+sZapdosSprites35:
+ax_sprite sZapdosGfx35, 0x200
+ax_sprite_terminator
+sZapdosGfx36:
+.incbin "baserom.gba", 0xB485E0, 0x80
+sZapdosSprites36:
+ax_sprite sZapdosGfx36, 0x80
+ax_sprite_terminator
+sZapdosGfx37:
+.incbin "baserom.gba", 0xB48670, 0x40
+sZapdosSprites37:
+ax_sprite sZapdosGfx37, 0x40
+ax_sprite_terminator
+sZapdosGfx38:
+.incbin "baserom.gba", 0xB486C0, 0x20
+sZapdosSprites38:
+ax_sprite sZapdosGfx38, 0x20
+ax_sprite_terminator
+sZapdosGfx39:
+.incbin "baserom.gba", 0xB486F0, 0x20
+sZapdosSprites39:
+ax_sprite sZapdosGfx39, 0x20
+ax_sprite_terminator
+sZapdosGfx40:
+.incbin "baserom.gba", 0xB48720, 0x80
+sZapdosSprites40:
+ax_sprite sZapdosGfx40, 0x80
+ax_sprite_terminator
+sZapdosGfx41:
+.incbin "baserom.gba", 0xB487B0, 0x1E0
+sZapdosSprites41:
+ax_sprite sZapdosGfx41, 0x1e0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx42:
+.incbin "baserom.gba", 0xB489A8, 0x40
+sZapdosSprites42:
+ax_sprite sZapdosGfx42, 0x40
+ax_sprite_terminator
+sZapdosGfx43:
+.incbin "baserom.gba", 0xB489F8, 0x1E0
+sZapdosSprites43:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx43, 0x1e0
+ax_sprite_terminator
+sZapdosGfx44:
+.incbin "baserom.gba", 0xB48BF0, 0x80
+sZapdosSprites44:
+ax_sprite sZapdosGfx44, 0x80
+ax_sprite_terminator
+sZapdosGfx45:
+.incbin "baserom.gba", 0xB48C80, 0x200
+sZapdosSprites45:
+ax_sprite sZapdosGfx45, 0x200
+ax_sprite_terminator
+sZapdosGfx46:
+.incbin "baserom.gba", 0xB48E90, 0x40
+sZapdosSprites46:
+ax_sprite sZapdosGfx46, 0x40
+ax_sprite_terminator
+sZapdosGfx47:
+.incbin "baserom.gba", 0xB48EE0, 0x40
+sZapdosSprites47:
+ax_sprite sZapdosGfx47, 0x40
+ax_sprite_terminator
+sZapdosGfx48:
+.incbin "baserom.gba", 0xB48F30, 0x40
+sZapdosSprites48:
+ax_sprite sZapdosGfx48, 0x40
+ax_sprite_terminator
+sZapdosGfx49:
+.incbin "baserom.gba", 0xB48F80, 0x180
+sZapdosGfx49_1:
+.incbin "baserom.gba", 0xB49100, 0x60
+sZapdosSprites49:
+ax_sprite sZapdosGfx49, 0x180
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx49_1, 0x60
+ax_sprite_terminator
+sZapdosGfx50:
+.incbin "baserom.gba", 0xB49180, 0x40
+sZapdosSprites50:
+ax_sprite sZapdosGfx50, 0x40
+ax_sprite_terminator
+sZapdosGfx51:
+.incbin "baserom.gba", 0xB491D0, 0x40
+sZapdosSprites51:
+ax_sprite sZapdosGfx51, 0x40
+ax_sprite_terminator
+sZapdosGfx52:
+.incbin "baserom.gba", 0xB49220, 0x200
+sZapdosSprites52:
+ax_sprite sZapdosGfx52, 0x200
+ax_sprite_terminator
+sZapdosGfx53:
+.incbin "baserom.gba", 0xB49430, 0x40
+sZapdosSprites53:
+ax_sprite sZapdosGfx53, 0x40
+ax_sprite_terminator
+sZapdosGfx54:
+.incbin "baserom.gba", 0xB49480, 0x40
+sZapdosSprites54:
+ax_sprite sZapdosGfx54, 0x40
+ax_sprite_terminator
+sZapdosGfx55:
+.incbin "baserom.gba", 0xB494D0, 0x40
+sZapdosSprites55:
+ax_sprite sZapdosGfx55, 0x40
+ax_sprite_terminator
+sZapdosGfx56:
+.incbin "baserom.gba", 0xB49520, 0x160
+sZapdosGfx56_1:
+.incbin "baserom.gba", 0xB49680, 0x60
+sZapdosSprites56:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx56, 0x160
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx56_1, 0x60
+ax_sprite_terminator
+sZapdosGfx57:
+.incbin "baserom.gba", 0xB49708, 0x20
+sZapdosGfx57_1:
+.incbin "baserom.gba", 0xB49728, 0xA0
+sZapdosSprites57:
+ax_sprite sZapdosGfx57, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx57_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx58:
+.incbin "baserom.gba", 0xB497F0, 0x40
+sZapdosSprites58:
+ax_sprite sZapdosGfx58, 0x40
+ax_sprite_terminator
+sZapdosGfx59:
+.incbin "baserom.gba", 0xB49840, 0x100
+sZapdosGfx59_1:
+.incbin "baserom.gba", 0xB49940, 0xE0
+sZapdosSprites59:
+ax_sprite sZapdosGfx59, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx59_1, 0xe0
+ax_sprite_terminator
+sZapdosGfx60:
+.incbin "baserom.gba", 0xB49A40, 0x20
+sZapdosGfx60_1:
+.incbin "baserom.gba", 0xB49A60, 0xC0
+sZapdosSprites60:
+ax_sprite sZapdosGfx60, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx60_1, 0xc0
+ax_sprite_terminator
+sZapdosGfx61:
+.incbin "baserom.gba", 0xB49B40, 0x60
+sZapdosGfx61_1:
+.incbin "baserom.gba", 0xB49BA0, 0x160
+sZapdosSprites61:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx61, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx61_1, 0x160
+ax_sprite_terminator
+sZapdosGfx62:
+.incbin "baserom.gba", 0xB49D28, 0x20
+sZapdosGfx62_1:
+.incbin "baserom.gba", 0xB49D48, 0xA0
+sZapdosSprites62:
+ax_sprite sZapdosGfx62, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx62_1, 0xa0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx63:
+.incbin "baserom.gba", 0xB49E10, 0x40
+sZapdosSprites63:
+ax_sprite sZapdosGfx63, 0x40
+ax_sprite_terminator
+sZapdosGfx64:
+.incbin "baserom.gba", 0xB49E60, 0x1E0
+sZapdosSprites64:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx64, 0x1e0
+ax_sprite_terminator
+sZapdosGfx65:
+.incbin "baserom.gba", 0xB4A058, 0x80
+sZapdosSprites65:
+ax_sprite sZapdosGfx65, 0x80
+ax_sprite_terminator
+sZapdosGfx66:
+.incbin "baserom.gba", 0xB4A0E8, 0x140
+sZapdosGfx66_1:
+.incbin "baserom.gba", 0xB4A228, 0x60
+sZapdosSprites66:
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx66, 0x140
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx66_1, 0x60
+ax_sprite_terminator
+sZapdosGfx67:
+.incbin "baserom.gba", 0xB4A2B0, 0x20
+sZapdosGfx67_1:
+.incbin "baserom.gba", 0xB4A2D0, 0xC0
+sZapdosSprites67:
+ax_sprite sZapdosGfx67, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx67_1, 0xc0
+ax_sprite_terminator
+sZapdosGfx68:
+.incbin "baserom.gba", 0xB4A3B0, 0x20
+sZapdosSprites68:
+ax_sprite sZapdosGfx68, 0x20
+ax_sprite_terminator
+sZapdosGfx69:
+.incbin "baserom.gba", 0xB4A3E0, 0x200
+sZapdosSprites69:
+ax_sprite sZapdosGfx69, 0x200
+ax_sprite_terminator
+sZapdosGfx70:
+.incbin "baserom.gba", 0xB4A5F0, 0x100
+sZapdosSprites70:
+ax_sprite sZapdosGfx70, 0x100
+ax_sprite_terminator
+sZapdosGfx71:
+.incbin "baserom.gba", 0xB4A700, 0x80
+sZapdosSprites71:
+ax_sprite sZapdosGfx71, 0x80
+ax_sprite_terminator
+sZapdosGfx72:
+.incbin "baserom.gba", 0xB4A790, 0x40
+sZapdosSprites72:
+ax_sprite sZapdosGfx72, 0x40
+ax_sprite_terminator
+sZapdosGfx73:
+.incbin "baserom.gba", 0xB4A7E0, 0x20
+sZapdosSprites73:
+ax_sprite sZapdosGfx73, 0x20
+ax_sprite_terminator
+sZapdosGfx74:
+.incbin "baserom.gba", 0xB4A810, 0x160
+sZapdosGfx74_1:
+.incbin "baserom.gba", 0xB4A970, 0x60
+sZapdosSprites74:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx74, 0x160
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx74_1, 0x60
+ax_sprite_terminator
+sZapdosGfx75:
+.incbin "baserom.gba", 0xB4A9F8, 0xE0
+sZapdosSprites75:
+ax_sprite sZapdosGfx75, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx76:
+.incbin "baserom.gba", 0xB4AAF0, 0x40
+sZapdosSprites76:
+ax_sprite sZapdosGfx76, 0x40
+ax_sprite_terminator
+sZapdosGfx77:
+.incbin "baserom.gba", 0xB4AB40, 0x60
+sZapdosGfx77_1:
+.incbin "baserom.gba", 0xB4ABA0, 0x180
+sZapdosSprites77:
+ax_sprite sZapdosGfx77, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx77_1, 0x180
+ax_sprite_terminator
+sZapdosGfx78:
+.incbin "baserom.gba", 0xB4AD40, 0x80
+sZapdosGfx78_1:
+.incbin "baserom.gba", 0xB4ADC0, 0x40
+sZapdosSprites78:
+ax_sprite sZapdosGfx78, 0x80
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx78_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx79:
+.incbin "baserom.gba", 0xB4AE28, 0x80
+sZapdosSprites79:
+ax_sprite sZapdosGfx79, 0x80
+ax_sprite_terminator
+sZapdosGfx80:
+.incbin "baserom.gba", 0xB4AEB8, 0x20
+sZapdosSprites80:
+ax_sprite sZapdosGfx80, 0x20
+ax_sprite_terminator
+sZapdosGfx81:
+.incbin "baserom.gba", 0xB4AEE8, 0x40
+sZapdosSprites81:
+ax_sprite sZapdosGfx81, 0x40
+ax_sprite_terminator
+sZapdosGfx82:
+.incbin "baserom.gba", 0xB4AF38, 0x60
+sZapdosGfx82_1:
+.incbin "baserom.gba", 0xB4AF98, 0x180
+sZapdosSprites82:
+ax_sprite sZapdosGfx82, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx82_1, 0x180
+ax_sprite_terminator
+sZapdosGfx83:
+.incbin "baserom.gba", 0xB4B138, 0x60
+sZapdosSprites83:
+ax_sprite sZapdosGfx83, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx84:
+.incbin "baserom.gba", 0xB4B1B0, 0x20
+sZapdosSprites84:
+ax_sprite sZapdosGfx84, 0x20
+ax_sprite_terminator
+sZapdosGfx85:
+.incbin "baserom.gba", 0xB4B1E0, 0x60
+sZapdosGfx85_1:
+.incbin "baserom.gba", 0xB4B240, 0x180
+sZapdosSprites85:
+ax_sprite sZapdosGfx85, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx85_1, 0x180
+ax_sprite_terminator
+sZapdosGfx86:
+.incbin "baserom.gba", 0xB4B3E0, 0x60
+sZapdosSprites86:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx86, 0x60
+ax_sprite_terminator
+sZapdosGfx87:
+.incbin "baserom.gba", 0xB4B458, 0x80
+sZapdosSprites87:
+ax_sprite sZapdosGfx87, 0x80
+ax_sprite_terminator
+sZapdosGfx88:
+.incbin "baserom.gba", 0xB4B4E8, 0x20
+sZapdosSprites88:
+ax_sprite sZapdosGfx88, 0x20
+ax_sprite_terminator
+sZapdosGfx89:
+.incbin "baserom.gba", 0xB4B518, 0x1E0
+sZapdosSprites89:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx89, 0x1e0
+ax_sprite_terminator
+sZapdosGfx90:
+.incbin "baserom.gba", 0xB4B710, 0x80
+sZapdosSprites90:
+ax_sprite sZapdosGfx90, 0x80
+ax_sprite_terminator
+sZapdosGfx91:
+.incbin "baserom.gba", 0xB4B7A0, 0x20
+sZapdosSprites91:
+ax_sprite sZapdosGfx91, 0x20
+ax_sprite_terminator
+sZapdosGfx92:
+.incbin "baserom.gba", 0xB4B7D0, 0x60
+sZapdosGfx92_1:
+.incbin "baserom.gba", 0xB4B830, 0x160
+sZapdosSprites92:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx92, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx92_1, 0x160
+ax_sprite_terminator
+sZapdosGfx93:
+.incbin "baserom.gba", 0xB4B9B8, 0x80
+sZapdosSprites93:
+ax_sprite sZapdosGfx93, 0x80
+ax_sprite_terminator
+sZapdosGfx94:
+.incbin "baserom.gba", 0xB4BA48, 0x20
+sZapdosSprites94:
+ax_sprite sZapdosGfx94, 0x20
+ax_sprite_terminator
+sZapdosGfx95:
+.incbin "baserom.gba", 0xB4BA78, 0x80
+sZapdosSprites95:
+ax_sprite sZapdosGfx95, 0x80
+ax_sprite_terminator
+sZapdosGfx96:
+.incbin "baserom.gba", 0xB4BB08, 0x180
+sZapdosGfx96_1:
+.incbin "baserom.gba", 0xB4BC88, 0x40
+sZapdosSprites96:
+ax_sprite sZapdosGfx96, 0x180
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx96_1, 0x40
+ax_sprite_terminator
+sZapdosGfx97:
+.incbin "baserom.gba", 0xB4BCE8, 0x80
+sZapdosSprites97:
+ax_sprite sZapdosGfx97, 0x80
+ax_sprite_terminator
+sZapdosGfx98:
+.incbin "baserom.gba", 0xB4BD78, 0x20
+sZapdosSprites98:
+ax_sprite sZapdosGfx98, 0x20
+ax_sprite_terminator
+sZapdosGfx99:
+.incbin "baserom.gba", 0xB4BDA8, 0x180
+sZapdosGfx99_1:
+.incbin "baserom.gba", 0xB4BF28, 0x60
+sZapdosSprites99:
+ax_sprite sZapdosGfx99, 0x180
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx99_1, 0x60
+ax_sprite_terminator
+sZapdosGfx100:
+.incbin "baserom.gba", 0xB4BFA8, 0xE0
+sZapdosSprites100:
+ax_sprite sZapdosGfx100, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx101:
+.incbin "baserom.gba", 0xB4C0A0, 0x40
+sZapdosSprites101:
+ax_sprite sZapdosGfx101, 0x40
+ax_sprite_terminator
+sZapdosGfx102:
+.incbin "baserom.gba", 0xB4C0F0, 0x40
+sZapdosSprites102:
+ax_sprite sZapdosGfx102, 0x40
+ax_sprite_terminator
+sZapdosGfx103:
+.incbin "baserom.gba", 0xB4C140, 0x180
+sZapdosGfx103_1:
+.incbin "baserom.gba", 0xB4C2C0, 0x60
+sZapdosSprites103:
+ax_sprite sZapdosGfx103, 0x180
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx103_1, 0x60
+ax_sprite_terminator
+sZapdosGfx104:
+.incbin "baserom.gba", 0xB4C340, 0x60
+sZapdosSprites104:
+ax_sprite sZapdosGfx104, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx105:
+.incbin "baserom.gba", 0xB4C3B8, 0x60
+sZapdosSprites105:
+ax_sprite sZapdosGfx105, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx106:
+.incbin "baserom.gba", 0xB4C430, 0x100
+sZapdosSprites106:
+ax_sprite sZapdosGfx106, 0x100
+ax_sprite_terminator
+sZapdosGfx107:
+.incbin "baserom.gba", 0xB4C540, 0x100
+sZapdosSprites107:
+ax_sprite sZapdosGfx107, 0x100
+ax_sprite_terminator
+sZapdosGfx108:
+.incbin "baserom.gba", 0xB4C650, 0x100
+sZapdosSprites108:
+ax_sprite sZapdosGfx108, 0x100
+ax_sprite_terminator
+sZapdosGfx109:
+.incbin "baserom.gba", 0xB4C760, 0x40
+sZapdosGfx109_1:
+.incbin "baserom.gba", 0xB4C7A0, 0x20
+sZapdosGfx109_2:
+.incbin "baserom.gba", 0xB4C7C0, 0x60
+sZapdosGfx109_3:
+.incbin "baserom.gba", 0xB4C820, 0x280
+sZapdosSprites109:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx109, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx109_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx109_2, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx109_3, 0x280
+ax_sprite_terminator
+sZapdosGfx110:
+.incbin "baserom.gba", 0xB4CAE8, 0x100
+sZapdosSprites110:
+ax_sprite sZapdosGfx110, 0x100
+ax_sprite_terminator
+sZapdosGfx111:
+.incbin "baserom.gba", 0xB4CBF8, 0xE0
+sZapdosSprites111:
+ax_sprite sZapdosGfx111, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx112:
+.incbin "baserom.gba", 0xB4CCF0, 0x60
+sZapdosSprites112:
+ax_sprite sZapdosGfx112, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx113:
+.incbin "baserom.gba", 0xB4CD68, 0x200
+sZapdosSprites113:
+ax_sprite sZapdosGfx113, 0x200
+ax_sprite_terminator
+sZapdosGfx114:
+.incbin "baserom.gba", 0xB4CF78, 0x20
+sZapdosGfx114_1:
+.incbin "baserom.gba", 0xB4CF98, 0xC0
+sZapdosSprites114:
+ax_sprite sZapdosGfx114, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx114_1, 0xc0
+ax_sprite_terminator
+sZapdosGfx115:
+.incbin "baserom.gba", 0xB4D078, 0xE0
+sZapdosSprites115:
+ax_sprite sZapdosGfx115, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx116:
+.incbin "baserom.gba", 0xB4D170, 0x60
+sZapdosGfx116_1:
+.incbin "baserom.gba", 0xB4D1D0, 0x100
+sZapdosGfx116_2:
+.incbin "baserom.gba", 0xB4D2D0, 0x60
+sZapdosSprites116:
+ax_sprite sZapdosGfx116, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx116_1, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx116_2, 0x60
+ax_sprite_terminator
+sZapdosGfx117:
+.incbin "baserom.gba", 0xB4D360, 0x100
+sZapdosSprites117:
+ax_sprite sZapdosGfx117, 0x100
+ax_sprite_terminator
+sZapdosGfx118:
+.incbin "baserom.gba", 0xB4D470, 0x100
+sZapdosSprites118:
+ax_sprite sZapdosGfx118, 0x100
+ax_sprite_terminator
+sZapdosGfx119:
+.incbin "baserom.gba", 0xB4D580, 0x40
+sZapdosSprites119:
+ax_sprite sZapdosGfx119, 0x40
+ax_sprite_terminator
+sZapdosGfx120:
+.incbin "baserom.gba", 0xB4D5D0, 0x80
+sZapdosSprites120:
+ax_sprite sZapdosGfx120, 0x80
+ax_sprite_terminator
+sZapdosGfx121:
+.incbin "baserom.gba", 0xB4D660, 0x20
+sZapdosSprites121:
+ax_sprite sZapdosGfx121, 0x20
+ax_sprite_terminator
+sZapdosGfx122:
+.incbin "baserom.gba", 0xB4D690, 0x200
+sZapdosSprites122:
+ax_sprite sZapdosGfx122, 0x200
+ax_sprite_terminator
+sZapdosGfx123:
+.incbin "baserom.gba", 0xB4D8A0, 0x100
+sZapdosSprites123:
+ax_sprite sZapdosGfx123, 0x100
+ax_sprite_terminator
+sZapdosGfx124:
+.incbin "baserom.gba", 0xB4D9B0, 0x40
+sZapdosSprites124:
+ax_sprite sZapdosGfx124, 0x40
+ax_sprite_terminator
+sZapdosGfx125:
+.incbin "baserom.gba", 0xB4DA00, 0x20
+sZapdosSprites125:
+ax_sprite sZapdosGfx125, 0x20
+ax_sprite_terminator
+sZapdosGfx126:
+.incbin "baserom.gba", 0xB4DA30, 0x100
+sZapdosGfx126_1:
+.incbin "baserom.gba", 0xB4DB30, 0x60
+sZapdosGfx126_2:
+.incbin "baserom.gba", 0xB4DB90, 0x60
+sZapdosSprites126:
+ax_sprite sZapdosGfx126, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx126_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx126_2, 0x60
+ax_sprite_terminator
+sZapdosGfx127:
+.incbin "baserom.gba", 0xB4DC20, 0x100
+sZapdosSprites127:
+ax_sprite sZapdosGfx127, 0x100
+ax_sprite_terminator
+sZapdosGfx128:
+.incbin "baserom.gba", 0xB4DD30, 0x80
+sZapdosSprites128:
+ax_sprite sZapdosGfx128, 0x80
+ax_sprite_terminator
+sZapdosGfx129:
+.incbin "baserom.gba", 0xB4DDC0, 0x20
+sZapdosGfx129_1:
+.incbin "baserom.gba", 0xB4DDE0, 0x40
+sZapdosSprites129:
+ax_sprite sZapdosGfx129, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx129_1, 0x40
+ax_sprite_terminator
+sZapdosGfx130:
+.incbin "baserom.gba", 0xB4DE40, 0x80
+sZapdosSprites130:
+ax_sprite sZapdosGfx130, 0x80
+ax_sprite_terminator
+sZapdosGfx131:
+.incbin "baserom.gba", 0xB4DED0, 0x40
+sZapdosSprites131:
+ax_sprite sZapdosGfx131, 0x40
+ax_sprite_terminator
+sZapdosGfx132:
+.incbin "baserom.gba", 0xB4DF20, 0x40
+sZapdosSprites132:
+ax_sprite sZapdosGfx132, 0x40
+ax_sprite_terminator
+sZapdosGfx133:
+.incbin "baserom.gba", 0xB4DF70, 0x200
+sZapdosSprites133:
+ax_sprite sZapdosGfx133, 0x200
+ax_sprite_terminator
+sZapdosGfx134:
+.incbin "baserom.gba", 0xB4E180, 0x80
+sZapdosSprites134:
+ax_sprite sZapdosGfx134, 0x80
+ax_sprite_terminator
+sZapdosGfx135:
+.incbin "baserom.gba", 0xB4E210, 0x100
+sZapdosSprites135:
+ax_sprite sZapdosGfx135, 0x100
+ax_sprite_terminator
+sZapdosGfx136:
+.incbin "baserom.gba", 0xB4E320, 0x200
+sZapdosSprites136:
+ax_sprite sZapdosGfx136, 0x200
+ax_sprite_terminator
+sZapdosGfx137:
+.incbin "baserom.gba", 0xB4E530, 0x100
+sZapdosSprites137:
+ax_sprite sZapdosGfx137, 0x100
+ax_sprite_terminator
+sZapdosGfx138:
+.incbin "baserom.gba", 0xB4E640, 0x80
+sZapdosSprites138:
+ax_sprite sZapdosGfx138, 0x80
+ax_sprite_terminator
+sZapdosGfx139:
+.incbin "baserom.gba", 0xB4E6D0, 0x20
+sZapdosSprites139:
+ax_sprite sZapdosGfx139, 0x20
+ax_sprite_terminator
+sZapdosGfx140:
+.incbin "baserom.gba", 0xB4E700, 0x20
+sZapdosSprites140:
+ax_sprite sZapdosGfx140, 0x20
+ax_sprite_terminator
+sZapdosGfx141:
+.incbin "baserom.gba", 0xB4E730, 0x80
+sZapdosSprites141:
+ax_sprite sZapdosGfx141, 0x80
+ax_sprite_terminator
+sZapdosGfx142:
+.incbin "baserom.gba", 0xB4E7C0, 0x20
+sZapdosSprites142:
+ax_sprite sZapdosGfx142, 0x20
+ax_sprite_terminator
+sZapdosGfx143:
+.incbin "baserom.gba", 0xB4E7F0, 0x180
+sZapdosGfx143_1:
+.incbin "baserom.gba", 0xB4E970, 0x60
+sZapdosSprites143:
+ax_sprite sZapdosGfx143, 0x180
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx143_1, 0x60
+ax_sprite_terminator
+sZapdosGfx144:
+.incbin "baserom.gba", 0xB4E9F0, 0x40
+sZapdosSprites144:
+ax_sprite sZapdosGfx144, 0x40
+ax_sprite_terminator
+sZapdosGfx145:
+.incbin "baserom.gba", 0xB4EA40, 0x100
+sZapdosSprites145:
+ax_sprite sZapdosGfx145, 0x100
+ax_sprite_terminator
+sZapdosGfx146:
+.incbin "baserom.gba", 0xB4EB50, 0x60
+sZapdosSprites146:
+ax_sprite sZapdosGfx146, 0x60
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx147:
+.incbin "baserom.gba", 0xB4EBC8, 0x20
+sZapdosSprites147:
+ax_sprite sZapdosGfx147, 0x20
+ax_sprite_terminator
+sZapdosGfx148:
+.incbin "baserom.gba", 0xB4EBF8, 0x200
+sZapdosSprites148:
+ax_sprite sZapdosGfx148, 0x200
+ax_sprite_terminator
+sZapdosGfx149:
+.incbin "baserom.gba", 0xB4EE08, 0x60
+sZapdosGfx149_1:
+.incbin "baserom.gba", 0xB4EE68, 0x20
+sZapdosGfx149_2:
+.incbin "baserom.gba", 0xB4EE88, 0x20
+sZapdosSprites149:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx149, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx149_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx149_2, 0x20
+ax_sprite_terminator
+sZapdosGfx150:
+.incbin "baserom.gba", 0xB4EEE0, 0x60
+sZapdosGfx150_1:
+.incbin "baserom.gba", 0xB4EF40, 0x180
+sZapdosSprites150:
+ax_sprite sZapdosGfx150, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx150_1, 0x180
+ax_sprite_terminator
+sZapdosGfx151:
+.incbin "baserom.gba", 0xB4F0E0, 0x60
+sZapdosGfx151_1:
+.incbin "baserom.gba", 0xB4F140, 0x20
+sZapdosGfx151_2:
+.incbin "baserom.gba", 0xB4F160, 0x20
+sZapdosSprites151:
+ax_sprite sZapdosGfx151, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx151_1, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx151_2, 0x20
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx152:
+.incbin "baserom.gba", 0xB4F1B8, 0x1E0
+sZapdosSprites152:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx152, 0x1e0
+ax_sprite_terminator
+sZapdosGfx153:
+.incbin "baserom.gba", 0xB4F3B0, 0x80
+sZapdosSprites153:
+ax_sprite sZapdosGfx153, 0x80
+ax_sprite_terminator
+sZapdosGfx154:
+.incbin "baserom.gba", 0xB4F440, 0x20
+sZapdosSprites154:
+ax_sprite sZapdosGfx154, 0x20
+ax_sprite_terminator
+sZapdosGfx155:
+.incbin "baserom.gba", 0xB4F470, 0x20
+sZapdosSprites155:
+ax_sprite sZapdosGfx155, 0x20
+ax_sprite_terminator
+sZapdosGfx156:
+.incbin "baserom.gba", 0xB4F4A0, 0x40
+sZapdosSprites156:
+ax_sprite sZapdosGfx156, 0x40
+ax_sprite_terminator
+sZapdosGfx157:
+.incbin "baserom.gba", 0xB4F4F0, 0x1E0
+sZapdosSprites157:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx157, 0x1e0
+ax_sprite_terminator
+sZapdosGfx158:
+.incbin "baserom.gba", 0xB4F6E8, 0x80
+sZapdosSprites158:
+ax_sprite sZapdosGfx158, 0x80
+ax_sprite_terminator
+sZapdosGfx159:
+.incbin "baserom.gba", 0xB4F778, 0x20
+sZapdosSprites159:
+ax_sprite sZapdosGfx159, 0x20
+ax_sprite_terminator
+sZapdosGfx160:
+.incbin "baserom.gba", 0xB4F7A8, 0x40
+sZapdosSprites160:
+ax_sprite sZapdosGfx160, 0x40
+ax_sprite_terminator
+sZapdosGfx161:
+.incbin "baserom.gba", 0xB4F7F8, 0x100
+sZapdosSprites161:
+ax_sprite sZapdosGfx161, 0x100
+ax_sprite_terminator
+sZapdosGfx162:
+.incbin "baserom.gba", 0xB4F908, 0x40
+sZapdosSprites162:
+ax_sprite sZapdosGfx162, 0x40
+ax_sprite_terminator
+sZapdosGfx163:
+.incbin "baserom.gba", 0xB4F958, 0x100
+sZapdosSprites163:
+ax_sprite sZapdosGfx163, 0x100
+ax_sprite_terminator
+sZapdosGfx164:
+.incbin "baserom.gba", 0xB4FA68, 0x40
+sZapdosSprites164:
+ax_sprite sZapdosGfx164, 0x40
+ax_sprite_terminator
+sZapdosGfx165:
+.incbin "baserom.gba", 0xB4FAB8, 0x80
+sZapdosSprites165:
+ax_sprite sZapdosGfx165, 0x80
+ax_sprite_terminator
+sZapdosGfx166:
+.incbin "baserom.gba", 0xB4FB48, 0x100
+sZapdosSprites166:
+ax_sprite sZapdosGfx166, 0x100
+ax_sprite_terminator
+sZapdosGfx167:
+.incbin "baserom.gba", 0xB4FC58, 0x100
+sZapdosSprites167:
+ax_sprite sZapdosGfx167, 0x100
+ax_sprite_terminator
+sZapdosGfx168:
+.incbin "baserom.gba", 0xB4FD68, 0x80
+sZapdosSprites168:
+ax_sprite sZapdosGfx168, 0x80
+ax_sprite_terminator
+sZapdosGfx169:
+.incbin "baserom.gba", 0xB4FDF8, 0x20
+sZapdosSprites169:
+ax_sprite sZapdosGfx169, 0x20
+ax_sprite_terminator
+sZapdosGfx170:
+.incbin "baserom.gba", 0xB4FE28, 0x20
+sZapdosSprites170:
+ax_sprite sZapdosGfx170, 0x20
+ax_sprite_terminator
+sZapdosGfx171:
+.incbin "baserom.gba", 0xB4FE58, 0x40
+sZapdosSprites171:
+ax_sprite sZapdosGfx171, 0x40
+ax_sprite_terminator
+sZapdosGfx172:
+.incbin "baserom.gba", 0xB4FEA8, 0x20
+sZapdosGfx172_1:
+.incbin "baserom.gba", 0xB4FEC8, 0xC0
+sZapdosSprites172:
+ax_sprite sZapdosGfx172, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx172_1, 0xc0
+ax_sprite_terminator
+sZapdosGfx173:
+.incbin "baserom.gba", 0xB4FFA8, 0x40
+sZapdosSprites173:
+ax_sprite sZapdosGfx173, 0x40
+ax_sprite_terminator
+sZapdosGfx174:
+.incbin "baserom.gba", 0xB4FFF8, 0x40
+sZapdosSprites174:
+ax_sprite sZapdosGfx174, 0x40
+ax_sprite_terminator
+sZapdosGfx175:
+.incbin "baserom.gba", 0xB50048, 0x80
+sZapdosSprites175:
+ax_sprite sZapdosGfx175, 0x80
+ax_sprite_terminator
+sZapdosGfx176:
+.incbin "baserom.gba", 0xB500D8, 0x1E0
+sZapdosSprites176:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx176, 0x1e0
+ax_sprite_terminator
+sZapdosGfx177:
+.incbin "baserom.gba", 0xB502D0, 0x80
+sZapdosSprites177:
+ax_sprite sZapdosGfx177, 0x80
+ax_sprite_terminator
+sZapdosGfx178:
+.incbin "baserom.gba", 0xB50360, 0x80
+sZapdosSprites178:
+ax_sprite sZapdosGfx178, 0x80
+ax_sprite_terminator
+sZapdosGfx179:
+.incbin "baserom.gba", 0xB503F0, 0xC0
+sZapdosSprites179:
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx179, 0xc0
+ax_sprite_terminator
+sZapdosGfx180:
+.incbin "baserom.gba", 0xB504C8, 0x1E0
+sZapdosSprites180:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx180, 0x1e0
+ax_sprite_terminator
+sZapdosGfx181:
+.incbin "baserom.gba", 0xB506C0, 0x80
+sZapdosSprites181:
+ax_sprite sZapdosGfx181, 0x80
+ax_sprite_terminator
+sZapdosGfx182:
+.incbin "baserom.gba", 0xB50750, 0x40
+sZapdosSprites182:
+ax_sprite sZapdosGfx182, 0x40
+ax_sprite_terminator
+sZapdosGfx183:
+.incbin "baserom.gba", 0xB507A0, 0x20
+sZapdosSprites183:
+ax_sprite sZapdosGfx183, 0x20
+ax_sprite_terminator
+sZapdosGfx184:
+.incbin "baserom.gba", 0xB507D0, 0x20
+sZapdosSprites184:
+ax_sprite sZapdosGfx184, 0x20
+ax_sprite_terminator
+sZapdosGfx185:
+.incbin "baserom.gba", 0xB50800, 0x20
+sZapdosSprites185:
+ax_sprite sZapdosGfx185, 0x20
+ax_sprite_terminator
+sZapdosGfx186:
+.incbin "baserom.gba", 0xB50830, 0x20
+sZapdosSprites186:
+ax_sprite sZapdosGfx186, 0x20
+ax_sprite_terminator
+sZapdosGfx187:
+.incbin "baserom.gba", 0xB50860, 0x40
+sZapdosSprites187:
+ax_sprite sZapdosGfx187, 0x40
+ax_sprite_terminator
+sZapdosGfx188:
+.incbin "baserom.gba", 0xB508B0, 0x80
+sZapdosSprites188:
+ax_sprite sZapdosGfx188, 0x80
+ax_sprite_terminator
+sZapdosGfx189:
+.incbin "baserom.gba", 0xB50940, 0x200
+sZapdosSprites189:
+ax_sprite sZapdosGfx189, 0x200
+ax_sprite_terminator
+sZapdosGfx190:
+.incbin "baserom.gba", 0xB50B50, 0x20
+sZapdosSprites190:
+ax_sprite sZapdosGfx190, 0x20
+ax_sprite_terminator
+sZapdosGfx191:
+.incbin "baserom.gba", 0xB50B80, 0x20
+sZapdosSprites191:
+ax_sprite sZapdosGfx191, 0x20
+ax_sprite_terminator
+sZapdosGfx192:
+.incbin "baserom.gba", 0xB50BB0, 0x60
+sZapdosSprites192:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx192, 0x60
+ax_sprite_terminator
+sZapdosGfx193:
+.incbin "baserom.gba", 0xB50C28, 0x60
+sZapdosSprites193:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx193, 0x60
+ax_sprite_terminator
+sZapdosGfx194:
+.incbin "baserom.gba", 0xB50CA0, 0x80
+sZapdosSprites194:
+ax_sprite sZapdosGfx194, 0x80
+ax_sprite_terminator
+sZapdosGfx195:
+.incbin "baserom.gba", 0xB50D30, 0x40
+sZapdosGfx195_1:
+.incbin "baserom.gba", 0xB50D70, 0x180
+sZapdosSprites195:
+ax_sprite sZapdosGfx195, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZapdosGfx195_1, 0x180
+ax_sprite_terminator
+sZapdosGfx196:
+.incbin "baserom.gba", 0xB50F10, 0x100
+sZapdosSprites196:
+ax_sprite sZapdosGfx196, 0x100
+ax_sprite_terminator
+sZapdosGfx197:
+.incbin "baserom.gba", 0xB51020, 0x20
+sZapdosSprites197:
+ax_sprite sZapdosGfx197, 0x20
+ax_sprite_terminator
+sZapdosGfx198:
+.incbin "baserom.gba", 0xB51050, 0x80
+sZapdosSprites198:
+ax_sprite sZapdosGfx198, 0x80
+ax_sprite_terminator
+sZapdosGfx199:
+.incbin "baserom.gba", 0xB510E0, 0x180
+sZapdosGfx199_1:
+.incbin "baserom.gba", 0xB51260, 0x60
+sZapdosSprites199:
+ax_sprite sZapdosGfx199, 0x180
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx199_1, 0x60
+ax_sprite_terminator
+sZapdosGfx200:
+.incbin "baserom.gba", 0xB512E0, 0xE0
+sZapdosSprites200:
+ax_sprite sZapdosGfx200, 0xe0
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZapdosGfx201:
+.incbin "baserom.gba", 0xB513D8, 0x20
+sZapdosSprites201:
+ax_sprite sZapdosGfx201, 0x20
+ax_sprite_terminator
+sZapdosGfx202:
+.incbin "baserom.gba", 0xB51408, 0x200
+sZapdosSprites202:
+ax_sprite sZapdosGfx202, 0x200
+ax_sprite_terminator
+sZapdosGfx203:
+.incbin "baserom.gba", 0xB51618, 0x100
+sZapdosSprites203:
+ax_sprite sZapdosGfx203, 0x100
+ax_sprite_terminator
+sZapdosGfx204:
+.incbin "baserom.gba", 0xB51728, 0x80
+sZapdosSprites204:
+ax_sprite sZapdosGfx204, 0x80
+ax_sprite_terminator
+sZapdosGfx205:
+.incbin "baserom.gba", 0xB517B8, 0x200
+sZapdosSprites205:
+ax_sprite sZapdosGfx205, 0x200
+ax_sprite_terminator
+sZapdosGfx206:
+.incbin "baserom.gba", 0xB519C8, 0x100
+sZapdosSprites206:
+ax_sprite sZapdosGfx206, 0x100
+ax_sprite_terminator
+sZapdosGfx207:
+.incbin "baserom.gba", 0xB51AD8, 0xE0
+sZapdosSprites207:
+ax_sprite 0, 0x20
+ax_sprite sZapdosGfx207, 0xe0
+ax_sprite_terminator
+sAxPosesZapdos:
+.4byte sZapdosPose1
+.4byte sZapdosPose2
+.4byte sZapdosPose3
+.4byte sZapdosPose4
+.4byte sZapdosPose5
+.4byte sZapdosPose6
+.4byte sZapdosPose7
+.4byte sZapdosPose8
+.4byte sZapdosPose9
+.4byte sZapdosPose10
+.4byte sZapdosPose11
+.4byte sZapdosPose12
+.4byte sZapdosPose13
+.4byte sZapdosPose14
+.4byte sZapdosPose15
+.4byte sZapdosPose16
+.4byte sZapdosPose17
+.4byte sZapdosPose18
+.4byte sZapdosPose19
+.4byte sZapdosPose20
+.4byte sZapdosPose21
+.4byte sZapdosPose22
+.4byte sZapdosPose23
+.4byte sZapdosPose24
+.4byte sZapdosPose25
+.4byte sZapdosPose26
+.4byte sZapdosPose27
+.4byte sZapdosPose28
+.4byte sZapdosPose29
+.4byte sZapdosPose30
+.4byte sZapdosPose31
+.4byte sZapdosPose32
+.4byte sZapdosPose33
+.4byte sZapdosPose34
+.4byte sZapdosPose35
+.4byte sZapdosPose36
+.4byte sZapdosPose37
+.4byte sZapdosPose38
+.4byte sZapdosPose39
+.4byte sZapdosPose40
+.4byte sZapdosPose41
+.4byte sZapdosPose42
+.4byte sZapdosPose43
+.4byte sZapdosPose44
+.4byte sZapdosPose45
+.4byte sZapdosPose46
+.4byte sZapdosPose47
+.4byte sZapdosPose48
+.4byte sZapdosPose49
+.4byte sZapdosPose50
+.4byte sZapdosPose51
+.4byte sZapdosPose52
+.4byte sZapdosPose53
+.4byte sZapdosPose54
+.4byte sZapdosPose55
+.4byte sZapdosPose56
+.4byte sZapdosPose57
+.4byte sZapdosPose58
+.4byte sZapdosPose59
+.4byte sZapdosPose60
+.4byte sZapdosPose61
+.4byte sZapdosPose62
+.4byte sZapdosPose63
+.4byte sZapdosPose64
+.4byte sZapdosPose65
+.4byte sZapdosPose66
+.4byte sZapdosPose67
+.4byte sZapdosPose68
+.4byte sZapdosPose69
+.4byte sZapdosPose70
+.4byte sZapdosPose71
+.4byte sZapdosPose72
+.4byte sZapdosPose73
+.4byte sZapdosPose74
+.4byte sZapdosPose75
+.4byte sZapdosPose76
+.4byte sZapdosPose77
+.4byte sZapdosPose78
+.4byte sZapdosPose79
+.4byte sZapdosPose80
+.4byte sZapdosPose81
+.4byte sZapdosPose82
+.4byte sZapdosPose83
+.4byte sZapdosPose84
+.4byte sZapdosPose85
+.4byte sZapdosPose86
+.4byte sZapdosPose87
+.4byte sZapdosPose88
+.4byte sZapdosPose89
+.4byte sZapdosPose90
+.4byte sZapdosPose91
+.4byte sZapdosPose92
+.4byte sZapdosPose93
+.4byte sZapdosPose94
+.4byte sZapdosPose95
+.4byte sZapdosPose96
+.4byte sZapdosPose97
+.4byte sZapdosPose98
+.4byte sZapdosPose99
+.4byte sZapdosPose100
+.4byte sZapdosPose101
+.4byte sZapdosPose102
+.4byte sZapdosPose103
+.4byte sZapdosPose104
+.4byte sZapdosPose105
+.4byte sZapdosPose106
+.4byte sZapdosPose107
+.4byte sZapdosPose108
+.4byte sZapdosPose109
+.4byte sZapdosPose110
+.4byte sZapdosPose111
+.4byte sZapdosPose112
+.4byte sZapdosPose113
+.4byte sZapdosPose114
+.4byte sZapdosPose115
+.4byte sZapdosPose116
+.4byte sZapdosPose117
+.4byte sZapdosPose118
+.4byte sZapdosPose119
+.4byte sZapdosPose120
+.4byte sZapdosPose121
+.4byte sZapdosPose122
+.4byte sZapdosPose123
+.4byte sZapdosPose124
+.4byte sZapdosPose125
+.4byte sZapdosPose126
+.4byte sZapdosPose127
+.4byte sZapdosPose128
+.4byte sZapdosPose129
+.4byte sZapdosPose130
+.4byte sZapdosPose131
+.4byte sZapdosPose132
+.4byte sZapdosPose133
+.4byte sZapdosPose134
+.4byte sZapdosPose135
+.4byte sZapdosPose136
+.4byte sZapdosPose137
+.4byte sZapdosPose138
+.4byte sZapdosPose139
+.4byte sZapdosPose140
+.4byte sZapdosPose141
+.4byte sZapdosPose142
+.4byte sZapdosPose143
+.4byte sZapdosPose144
+.4byte sZapdosPose145
+.4byte sZapdosPose146
+.4byte sZapdosPose147
+.4byte sZapdosPose148
+.4byte sZapdosPose149
+.4byte sZapdosPose150
+.4byte sZapdosPose151
+.4byte sZapdosPose152
+.4byte sZapdosPose153
+.4byte sZapdosPose154
+.4byte sZapdosPose155
+.4byte sZapdosPose156
+.4byte sZapdosPose157
+.4byte sZapdosPose158
+.4byte sZapdosPose159
+.4byte sZapdosPose160
+.4byte sZapdosPose161
+.4byte sZapdosPose162
+.4byte sZapdosPose163
+.4byte sZapdosPose164
+.4byte sZapdosPose165
+.4byte sZapdosPose166
+.4byte sZapdosPose167
+.4byte sZapdosPose168
+.4byte sZapdosPose169
+.4byte sZapdosPose170
+.4byte sZapdosPose171
+.4byte sZapdosPose172
+.4byte sZapdosPose173
+.4byte sZapdosPose174
+.4byte sZapdosPose175
+.4byte sZapdosPose176
+.4byte sZapdosPose177
+.4byte sZapdosPose178
+.4byte sZapdosPose179
+.4byte sZapdosPose180
+.4byte sZapdosPose181
+.4byte sZapdosPose182
+.4byte sZapdosPose183
+.4byte sZapdosPose184
+.4byte sZapdosPose185
+.4byte sZapdosPose186
+.4byte sZapdosPose187
+.4byte sZapdosPose188
+.4byte sZapdosPose189
+.4byte sZapdosPose190
+.4byte sZapdosPose191
+.4byte sZapdosPose192
+.4byte sZapdosPose193
+.4byte sZapdosPose194
+.4byte sZapdosPose195
+.4byte sZapdosPose196
+.4byte sZapdosPose197
+.4byte sZapdosPose198
+.4byte sZapdosPose199
+.4byte sZapdosPose200
+.4byte sZapdosPose201
+.4byte sZapdosPose202
+.4byte sZapdosPose203
+.4byte sZapdosPose204
+.4byte sZapdosPose205
+.4byte sZapdosPose206
+.4byte sZapdosPose207
+.4byte sZapdosPose208
+.4byte sZapdosPose209
+.4byte sZapdosPose210
+.4byte sZapdosPose211
+.4byte sZapdosPose212
+.4byte sZapdosPose213
+.4byte sZapdosPose214
+.4byte sZapdosPose215
+.4byte sZapdosPose216
+.4byte sZapdosPose217
+.4byte sZapdosPose218
+.4byte sZapdosPose219
+.4byte sZapdosPose220
+.4byte sZapdosPose221
+.4byte sZapdosPose222
+.4byte sZapdosPose223
+.4byte sZapdosPose224
+.4byte sZapdosPose225
+.4byte sZapdosPose226
+.4byte sZapdosPose227
+.4byte sZapdosPose228
+.4byte sZapdosPose229
+.4byte sZapdosPose230
+.4byte sZapdosPose231
+.4byte sZapdosPose232
+.4byte sZapdosPose233
+.4byte sZapdosPose234
+.4byte sZapdosPose235
+.4byte sZapdosPose236
+.4byte sZapdosPose237
+.4byte sZapdosPose238
+.4byte sZapdosPose239
+.4byte sZapdosPose240
+.4byte sZapdosPose241
+.4byte sZapdosPose242
+.4byte sZapdosPose243
+.4byte sZapdosPose244
+.4byte sZapdosPose245
+.4byte sZapdosPose246
+.4byte sZapdosPose247
+.4byte sZapdosPose248
+.4byte sZapdosPose249
+.4byte sZapdosPose250
+.4byte sZapdosPose251
+.4byte sZapdosPose252
+.4byte sZapdosPose253
+.4byte sZapdosPose254
+.4byte sZapdosPose255
+.4byte sZapdosPose256
+.4byte sZapdosPose257
+.4byte sZapdosPose258
+.4byte sZapdosPose259
+.4byte sZapdosPose260
+.4byte sZapdosPose261
+.4byte sZapdosPose262
+.4byte sZapdosPose263
+.4byte sZapdosPose264
+sAxPositionsZapdos:
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte    0,  -16, 	  -8,  -36, 	   7,  -36, 	   0,  -18
+.2byte    0,  -21, 	 -11,  -22, 	  10,  -22, 	   0,  -23
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   16,  -18, 	  -5,  -30, 	   7,  -39, 	   2,  -17
+.2byte   13,  -24, 	  -1,  -24, 	  15,  -29, 	   3,  -22
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   18,  -19, 	  -6,  -27, 	  -2,  -37, 	   2,  -18
+.2byte   15,  -25, 	   5,  -23, 	  12,  -37, 	   1,  -22
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   14,  -22, 	   3,  -26, 	 -10,  -32, 	   2,  -19
+.2byte   11,  -28, 	  10,  -26, 	  -4,  -35, 	  -1,  -23
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte    0,  -27, 	   9,  -33, 	  -9,  -33, 	   0,  -23
+.2byte    0,  -35, 	  11,  -26, 	 -11,  -26, 	   0,  -24
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte  -14,  -22, 	  10,  -32, 	  -3,  -26, 	  -2,  -19
+.2byte  -11,  -28, 	   4,  -35, 	 -10,  -26, 	   1,  -23
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -18,  -19, 	   2,  -37, 	   6,  -27, 	  -2,  -18
+.2byte  -15,  -25, 	 -12,  -37, 	  -5,  -23, 	  -1,  -22
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -16,  -18, 	  -7,  -39, 	   5,  -30, 	  -2,  -17
+.2byte  -13,  -24, 	 -15,  -29, 	   1,  -24, 	  -3,  -22
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte    0,  -16, 	  -8,  -36, 	   7,  -36, 	   0,  -18
+.2byte    0,  -21, 	 -11,  -22, 	  10,  -22, 	   0,  -23
+.2byte    0,   -5, 	 -11,  -17, 	  11,  -17, 	   0,  -23
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   16,  -18, 	  -5,  -30, 	   7,  -39, 	   2,  -17
+.2byte   13,  -24, 	  -1,  -24, 	  15,  -29, 	   3,  -22
+.2byte   16,   -8, 	  -4,  -12, 	  14,  -25, 	  -2,  -23
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   18,  -19, 	  -6,  -27, 	  -2,  -37, 	   2,  -18
+.2byte   15,  -25, 	   5,  -23, 	  12,  -37, 	   1,  -22
+.2byte   20,  -15, 	   4,  -16, 	   4,  -32, 	  -1,  -23
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   14,  -22, 	   3,  -26, 	 -10,  -32, 	   2,  -19
+.2byte   11,  -28, 	  10,  -26, 	  -4,  -35, 	  -1,  -23
+.2byte   16,  -21, 	  12,  -18, 	  -1,  -31, 	  -1,  -21
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte    0,  -27, 	   9,  -33, 	  -9,  -33, 	   0,  -23
+.2byte    0,  -35, 	  11,  -26, 	 -11,  -26, 	   0,  -24
+.2byte    0,  -30, 	  11,  -25, 	 -11,  -25, 	   0,  -23
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte  -14,  -22, 	  10,  -32, 	  -3,  -26, 	  -2,  -19
+.2byte  -11,  -28, 	   4,  -35, 	 -10,  -26, 	   1,  -23
+.2byte  -16,  -21, 	   1,  -31, 	 -12,  -18, 	   1,  -21
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -18,  -19, 	   2,  -37, 	   6,  -27, 	  -2,  -18
+.2byte  -15,  -25, 	 -12,  -37, 	  -5,  -23, 	  -1,  -22
+.2byte  -22,  -15, 	  -6,  -32, 	  -6,  -16, 	  -1,  -23
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -16,  -18, 	  -7,  -39, 	   5,  -30, 	  -2,  -17
+.2byte  -13,  -24, 	 -15,  -29, 	   1,  -24, 	  -3,  -22
+.2byte  -17,   -8, 	 -15,  -25, 	   3,  -12, 	   1,  -23
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte    0,  -16, 	  -8,  -36, 	   7,  -36, 	   0,  -18
+.2byte    0,  -21, 	 -11,  -22, 	  10,  -22, 	   0,  -23
+.2byte    0,   -5, 	 -11,  -17, 	  11,  -17, 	   0,  -23
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   16,  -18, 	  -5,  -30, 	   7,  -39, 	   2,  -17
+.2byte   13,  -24, 	  -1,  -24, 	  15,  -29, 	   3,  -22
+.2byte   16,   -8, 	  -4,  -12, 	  14,  -25, 	  -2,  -23
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   18,  -19, 	  -6,  -27, 	  -2,  -37, 	   2,  -18
+.2byte   15,  -25, 	   5,  -23, 	  12,  -37, 	   1,  -22
+.2byte   20,  -15, 	   4,  -16, 	   4,  -32, 	  -1,  -23
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   14,  -22, 	   3,  -26, 	 -10,  -32, 	   2,  -19
+.2byte   11,  -28, 	  10,  -26, 	  -4,  -35, 	  -1,  -23
+.2byte   16,  -21, 	  12,  -18, 	  -1,  -31, 	  -1,  -21
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte    0,  -27, 	   9,  -33, 	  -9,  -33, 	   0,  -23
+.2byte    0,  -35, 	  11,  -26, 	 -11,  -26, 	   0,  -24
+.2byte    0,  -30, 	  11,  -25, 	 -11,  -25, 	   0,  -23
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte  -14,  -22, 	  10,  -32, 	  -3,  -26, 	  -2,  -19
+.2byte  -11,  -28, 	   4,  -35, 	 -10,  -26, 	   1,  -23
+.2byte  -16,  -21, 	   1,  -31, 	 -12,  -18, 	   1,  -21
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -18,  -19, 	   2,  -37, 	   6,  -27, 	  -2,  -18
+.2byte  -15,  -25, 	 -12,  -37, 	  -5,  -23, 	  -1,  -22
+.2byte  -22,  -15, 	  -6,  -32, 	  -6,  -16, 	  -1,  -23
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -16,  -18, 	  -7,  -39, 	   5,  -30, 	  -2,  -17
+.2byte  -13,  -24, 	 -15,  -29, 	   1,  -24, 	  -3,  -22
+.2byte  -17,   -8, 	 -15,  -25, 	   3,  -12, 	   1,  -23
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte    0,  -16, 	  -8,  -36, 	   7,  -36, 	   0,  -18
+.2byte    0,  -21, 	 -11,  -22, 	  10,  -22, 	   0,  -23
+.2byte    0,  -47, 	 -13,  -33, 	  13,  -33, 	   0,  -27
+.2byte    0,  -10, 	 -12,  -25, 	  12,  -25, 	   0,  -27
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   16,  -18, 	  -5,  -30, 	   7,  -39, 	   2,  -17
+.2byte   13,  -24, 	  -1,  -24, 	  15,  -29, 	   3,  -22
+.2byte   -2,  -46, 	 -13,  -26, 	  10,  -36, 	   0,  -26
+.2byte   15,   -9, 	  -8,  -20, 	  12,  -28, 	  -2,  -23
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   18,  -19, 	  -6,  -27, 	  -2,  -37, 	   2,  -18
+.2byte   15,  -25, 	   5,  -23, 	  12,  -37, 	   1,  -22
+.2byte   -4,  -48, 	 -12,  -24, 	 -10,  -36, 	   1,  -26
+.2byte   19,  -13, 	   0,  -30, 	   3,  -33, 	  -2,  -19
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   14,  -22, 	   3,  -26, 	 -10,  -32, 	   2,  -19
+.2byte   11,  -28, 	  10,  -26, 	  -4,  -35, 	  -1,  -23
+.2byte   -2,  -46, 	   4,  -24, 	 -14,  -29, 	  -2,  -23
+.2byte   17,  -20, 	   9,  -27, 	   1,  -33, 	   2,  -22
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte    0,  -27, 	   9,  -33, 	  -9,  -33, 	   0,  -23
+.2byte    0,  -35, 	  11,  -26, 	 -11,  -26, 	   0,  -24
+.2byte    0,  -46, 	  14,  -27, 	 -13,  -27, 	   0,  -24
+.2byte    0,  -31, 	  11,  -33, 	 -12,  -32, 	   0,  -24
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte  -14,  -22, 	  10,  -32, 	  -3,  -26, 	  -2,  -19
+.2byte  -11,  -28, 	   4,  -35, 	 -10,  -26, 	   1,  -23
+.2byte    2,  -46, 	  14,  -29, 	  -4,  -24, 	   2,  -23
+.2byte  -17,  -20, 	  -1,  -33, 	  -9,  -27, 	  -2,  -22
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -18,  -19, 	   2,  -37, 	   6,  -27, 	  -2,  -18
+.2byte  -15,  -25, 	 -12,  -37, 	  -5,  -23, 	  -1,  -22
+.2byte    2,  -48, 	   8,  -36, 	  10,  -24, 	  -3,  -26
+.2byte  -21,  -13, 	  -5,  -33, 	  -2,  -30, 	   0,  -19
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -16,  -18, 	  -7,  -39, 	   5,  -30, 	  -2,  -17
+.2byte  -13,  -24, 	 -15,  -29, 	   1,  -24, 	  -3,  -22
+.2byte    1,  -46, 	 -11,  -36, 	  12,  -26, 	  -1,  -26
+.2byte  -16,   -9, 	 -13,  -28, 	   7,  -20, 	   1,  -23
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte    0,  -16, 	  -8,  -36, 	   7,  -36, 	   0,  -18
+.2byte    0,  -21, 	 -11,  -22, 	  10,  -22, 	   0,  -23
+.2byte    0,  -23, 	  -9,  -37, 	   9,  -37, 	   0,  -20
+.2byte    0,  -23, 	 -16,  -36, 	  18,  -37, 	   0,  -20
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   16,  -18, 	  -5,  -30, 	   7,  -39, 	   2,  -17
+.2byte   13,  -24, 	  -1,  -24, 	  15,  -29, 	   3,  -22
+.2byte    9,  -27, 	 -10,  -35, 	  10,  -41, 	   0,  -20
+.2byte    9,  -25, 	 -14,  -39, 	   9,  -49, 	   1,  -20
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   18,  -19, 	  -6,  -27, 	  -2,  -37, 	   2,  -18
+.2byte   15,  -25, 	   5,  -23, 	  12,  -37, 	   1,  -22
+.2byte   12,  -33, 	  -6,  -35, 	  -4,  -42, 	   1,  -22
+.2byte   10,  -32, 	 -11,  -39, 	  -7,  -47, 	  -1,  -21
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   14,  -22, 	   3,  -26, 	 -10,  -32, 	   2,  -19
+.2byte   11,  -28, 	  10,  -26, 	  -4,  -35, 	  -1,  -23
+.2byte    8,  -34, 	   7,  -21, 	 -13,  -32, 	  -3,  -20
+.2byte    9,  -36, 	  11,  -25, 	 -14,  -37, 	  -3,  -22
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte    0,  -27, 	   9,  -33, 	  -9,  -33, 	   0,  -23
+.2byte    0,  -35, 	  11,  -26, 	 -11,  -26, 	   0,  -24
+.2byte    0,  -37, 	  16,  -31, 	 -16,  -31, 	   0,  -26
+.2byte    0,  -38, 	  16,  -32, 	 -17,  -32, 	   0,  -24
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte  -14,  -22, 	  10,  -32, 	  -3,  -26, 	  -2,  -19
+.2byte  -11,  -28, 	   4,  -35, 	 -10,  -26, 	   1,  -23
+.2byte   -8,  -34, 	  13,  -32, 	  -7,  -21, 	   3,  -20
+.2byte   -9,  -36, 	  14,  -37, 	 -11,  -25, 	   3,  -22
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -18,  -19, 	   2,  -37, 	   6,  -27, 	  -2,  -18
+.2byte  -15,  -25, 	 -12,  -37, 	  -5,  -23, 	  -1,  -22
+.2byte  -12,  -33, 	   4,  -42, 	   6,  -35, 	  -1,  -22
+.2byte  -10,  -32, 	   7,  -47, 	  11,  -39, 	   1,  -21
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -16,  -18, 	  -7,  -39, 	   5,  -30, 	  -2,  -17
+.2byte  -13,  -24, 	 -15,  -29, 	   1,  -24, 	  -3,  -22
+.2byte  -10,  -27, 	 -11,  -41, 	   9,  -35, 	  -1,  -20
+.2byte   -9,  -25, 	  -9,  -49, 	  14,  -39, 	  -1,  -20
+.2byte  -18,   -4, 	  -6,  -21, 	   2,   -7, 	   1,  -14
+.2byte  -19,   -2, 	  -7,  -19, 	   2,   -7, 	   0,  -15
+.2byte    0,  -21, 	  -7,  -35, 	   7,  -35, 	   0,  -16
+.2byte    4,  -20, 	 -12,  -31, 	  -1,  -38, 	  -4,  -21
+.2byte    6,  -24, 	  -9,  -29, 	  -5,  -36, 	  -5,  -21
+.2byte    5,  -28, 	  -1,  -24, 	 -13,  -30, 	   0,  -18
+.2byte   -1,  -35, 	   8,  -23, 	 -10,  -23, 	  -1,  -22
+.2byte   -6,  -28, 	  12,  -30, 	   0,  -24, 	  -1,  -18
+.2byte   -7,  -24, 	   4,  -36, 	   8,  -29, 	   4,  -21
+.2byte   -5,  -20, 	   0,  -38, 	  11,  -31, 	   3,  -21
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte    0,  -16, 	  -8,  -36, 	   7,  -36, 	   0,  -18
+.2byte    0,  -21, 	 -11,  -22, 	  10,  -22, 	   0,  -23
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   16,  -18, 	  -5,  -30, 	   7,  -39, 	   2,  -17
+.2byte   13,  -24, 	  -1,  -24, 	  15,  -29, 	   3,  -22
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   18,  -19, 	  -6,  -27, 	  -2,  -37, 	   2,  -18
+.2byte   15,  -25, 	   5,  -23, 	  12,  -37, 	   1,  -22
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   14,  -22, 	   3,  -26, 	 -10,  -32, 	   2,  -19
+.2byte   11,  -28, 	  10,  -26, 	  -4,  -35, 	  -1,  -23
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte    0,  -27, 	   9,  -33, 	  -9,  -33, 	   0,  -23
+.2byte    0,  -35, 	  11,  -26, 	 -11,  -26, 	   0,  -24
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte  -14,  -22, 	  10,  -32, 	  -3,  -26, 	  -2,  -19
+.2byte  -11,  -28, 	   4,  -35, 	 -10,  -26, 	   1,  -23
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -18,  -19, 	   2,  -37, 	   6,  -27, 	  -2,  -18
+.2byte  -15,  -25, 	 -12,  -37, 	  -5,  -23, 	  -1,  -22
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -16,  -18, 	  -7,  -39, 	   5,  -30, 	  -2,  -17
+.2byte  -13,  -24, 	 -15,  -29, 	   1,  -24, 	  -3,  -22
+.2byte    0,   -5, 	 -11,  -17, 	  11,  -17, 	   0,  -23
+.2byte  -17,   -8, 	 -15,  -25, 	   3,  -12, 	   1,  -23
+.2byte  -22,  -15, 	  -6,  -32, 	  -6,  -16, 	  -1,  -23
+.2byte  -16,  -21, 	   1,  -31, 	 -12,  -18, 	   1,  -21
+.2byte    0,  -30, 	  11,  -25, 	 -11,  -25, 	   0,  -23
+.2byte   16,  -21, 	  12,  -18, 	  -1,  -31, 	  -1,  -21
+.2byte   20,  -15, 	   4,  -16, 	   4,  -32, 	  -1,  -23
+.2byte   16,   -8, 	  -4,  -12, 	  14,  -25, 	  -2,  -23
+.2byte    0,  -47, 	 -13,  -33, 	  13,  -33, 	   0,  -27
+.2byte   -2,  -46, 	 -13,  -26, 	  10,  -36, 	   0,  -26
+.2byte   -3,  -48, 	 -11,  -24, 	  -9,  -36, 	   2,  -26
+.2byte   -2,  -46, 	   4,  -24, 	 -14,  -29, 	  -2,  -23
+.2byte    0,  -46, 	  14,  -27, 	 -13,  -27, 	   0,  -24
+.2byte    1,  -46, 	  13,  -29, 	  -5,  -24, 	   1,  -23
+.2byte    2,  -48, 	   8,  -36, 	  10,  -24, 	  -3,  -26
+.2byte    1,  -46, 	 -11,  -36, 	  12,  -26, 	  -1,  -26
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte    0,  -16, 	  -8,  -36, 	   7,  -36, 	   0,  -18
+.2byte    0,  -21, 	 -11,  -22, 	  10,  -22, 	   0,  -23
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   14,  -18, 	  -7,  -30, 	   5,  -39, 	   0,  -17
+.2byte   13,  -24, 	  -1,  -24, 	  15,  -29, 	   3,  -22
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   17,  -19, 	  -7,  -27, 	  -3,  -37, 	   1,  -18
+.2byte   15,  -25, 	   5,  -23, 	  12,  -37, 	   1,  -22
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   14,  -22, 	   3,  -26, 	 -10,  -32, 	   2,  -19
+.2byte   11,  -28, 	  10,  -26, 	  -4,  -35, 	  -1,  -23
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte    0,  -27, 	   9,  -33, 	  -9,  -33, 	   0,  -23
+.2byte    0,  -35, 	  11,  -26, 	 -11,  -26, 	   0,  -24
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte  -14,  -22, 	  10,  -32, 	  -3,  -26, 	  -2,  -19
+.2byte  -11,  -28, 	   4,  -35, 	 -10,  -26, 	   1,  -23
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -17,  -19, 	   3,  -37, 	   7,  -27, 	  -1,  -18
+.2byte  -15,  -25, 	 -12,  -37, 	  -5,  -23, 	  -1,  -22
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -14,  -18, 	  -5,  -39, 	   7,  -30, 	   0,  -17
+.2byte  -13,  -24, 	 -15,  -29, 	   1,  -24, 	  -3,  -22
+.2byte    0,  -23, 	  -9,  -37, 	   9,  -37, 	   0,  -20
+.2byte  -10,  -27, 	 -11,  -41, 	   9,  -35, 	  -1,  -20
+.2byte  -12,  -33, 	   4,  -42, 	   6,  -35, 	  -1,  -22
+.2byte   -8,  -35, 	  13,  -33, 	  -7,  -22, 	   3,  -21
+.2byte    0,  -37, 	  16,  -31, 	 -16,  -31, 	   0,  -26
+.2byte    8,  -35, 	   7,  -22, 	 -13,  -33, 	  -3,  -21
+.2byte   12,  -33, 	  -6,  -35, 	  -4,  -42, 	   1,  -22
+.2byte    9,  -27, 	 -10,  -35, 	  10,  -41, 	   0,  -20
+.2byte    0,  -18, 	 -11,  -33, 	  11,  -33, 	   0,  -20
+.2byte  -13,  -20, 	 -11,  -39, 	  11,  -30, 	  -2,  -20
+.2byte  -16,  -22, 	   1,  -40, 	   4,  -30, 	  -1,  -21
+.2byte  -13,  -24, 	   9,  -35, 	  -6,  -26, 	   0,  -21
+.2byte    0,  -31, 	   9,  -31, 	  -9,  -31, 	   0,  -25
+.2byte   13,  -24, 	   6,  -26, 	  -9,  -35, 	   0,  -21
+.2byte   16,  -22, 	  -4,  -30, 	  -1,  -40, 	   1,  -21
+.2byte   13,  -20, 	 -11,  -30, 	  11,  -39, 	   2,  -20
+.2byte   -1,   -3, 	  -9,  -20, 	   7,  -20, 	  -1,   -9
+.2byte   -1,    1, 	  -9,  -17, 	   7,  -17, 	  -1,   -9
+.2byte   -1,   -3, 	  -9,  -20, 	   7,  -20, 	  -1,   -9
+.2byte   -1,    1, 	  -9,  -17, 	   7,  -17, 	  -1,   -9
+.2byte   -1,   -7, 	  -9,  -23, 	   7,  -23, 	  -1,   -9
+.2byte   -1,  -11, 	  -8,  -27, 	   6,  -27, 	  -1,   -9
+sZapdosAnimTable1:
+.4byte sZapdosAnims_1_1
+.4byte sZapdosAnims_1_2
+.4byte sZapdosAnims_1_3
+.4byte sZapdosAnims_1_4
+.4byte sZapdosAnims_1_5
+.4byte sZapdosAnims_1_6
+.4byte sZapdosAnims_1_7
+.4byte sZapdosAnims_1_8
+sZapdosAnimTable2:
+.4byte sZapdosAnims_2_1
+.4byte sZapdosAnims_2_2
+.4byte sZapdosAnims_2_3
+.4byte sZapdosAnims_2_4
+.4byte sZapdosAnims_2_5
+.4byte sZapdosAnims_2_6
+.4byte sZapdosAnims_2_7
+.4byte sZapdosAnims_2_8
+sZapdosAnimTable3:
+.4byte sZapdosAnims_3_1
+.4byte sZapdosAnims_3_2
+.4byte sZapdosAnims_3_3
+.4byte sZapdosAnims_3_4
+.4byte sZapdosAnims_3_5
+.4byte sZapdosAnims_3_6
+.4byte sZapdosAnims_3_7
+.4byte sZapdosAnims_3_8
+sZapdosAnimTable4:
+.4byte sZapdosAnims_4_1
+.4byte sZapdosAnims_4_2
+.4byte sZapdosAnims_4_3
+.4byte sZapdosAnims_4_4
+.4byte sZapdosAnims_4_5
+.4byte sZapdosAnims_4_6
+.4byte sZapdosAnims_4_7
+.4byte sZapdosAnims_4_8
+sZapdosAnimTable5:
+.4byte sZapdosAnims_5_1
+.4byte sZapdosAnims_5_2
+.4byte sZapdosAnims_5_3
+.4byte sZapdosAnims_5_4
+.4byte sZapdosAnims_5_5
+.4byte sZapdosAnims_5_6
+.4byte sZapdosAnims_5_7
+.4byte sZapdosAnims_5_8
+sZapdosAnimTable6:
+.4byte sZapdosAnims_6_1
+.4byte sZapdosAnims_6_1
+.4byte sZapdosAnims_6_1
+.4byte sZapdosAnims_6_1
+.4byte sZapdosAnims_6_1
+.4byte sZapdosAnims_6_1
+.4byte sZapdosAnims_6_1
+.4byte sZapdosAnims_6_1
+sZapdosAnimTable7:
+.4byte sZapdosAnims_7_1
+.4byte sZapdosAnims_7_2
+.4byte sZapdosAnims_7_3
+.4byte sZapdosAnims_7_4
+.4byte sZapdosAnims_7_5
+.4byte sZapdosAnims_7_6
+.4byte sZapdosAnims_7_7
+.4byte sZapdosAnims_7_8
+sZapdosAnimTable8:
+.4byte sZapdosAnims_8_1
+.4byte sZapdosAnims_8_2
+.4byte sZapdosAnims_8_3
+.4byte sZapdosAnims_8_4
+.4byte sZapdosAnims_8_5
+.4byte sZapdosAnims_8_6
+.4byte sZapdosAnims_8_7
+.4byte sZapdosAnims_8_8
+sZapdosAnimTable9:
+.4byte sZapdosAnims_9_1
+.4byte sZapdosAnims_9_2
+.4byte sZapdosAnims_9_3
+.4byte sZapdosAnims_9_4
+.4byte sZapdosAnims_9_5
+.4byte sZapdosAnims_9_6
+.4byte sZapdosAnims_9_7
+.4byte sZapdosAnims_9_8
+sZapdosAnimTable10:
+.4byte sZapdosAnims_10_1
+.4byte sZapdosAnims_10_2
+.4byte sZapdosAnims_10_3
+.4byte sZapdosAnims_10_4
+.4byte sZapdosAnims_10_5
+.4byte sZapdosAnims_10_6
+.4byte sZapdosAnims_10_7
+.4byte sZapdosAnims_10_8
+sZapdosAnimTable11:
+.4byte sZapdosAnims_11_1
+.4byte sZapdosAnims_11_2
+.4byte sZapdosAnims_11_3
+.4byte sZapdosAnims_11_4
+.4byte sZapdosAnims_11_5
+.4byte sZapdosAnims_11_6
+.4byte sZapdosAnims_11_7
+.4byte sZapdosAnims_11_8
+sZapdosAnimTable12:
+.4byte sZapdosAnims_12_1
+.4byte sZapdosAnims_12_2
+.4byte sZapdosAnims_12_3
+.4byte sZapdosAnims_12_4
+.4byte sZapdosAnims_12_5
+.4byte sZapdosAnims_12_6
+.4byte sZapdosAnims_12_7
+.4byte sZapdosAnims_12_8
+sZapdosAnimTable13:
+.4byte sZapdosAnims_13_1
+.4byte sZapdosAnims_13_2
+.4byte sZapdosAnims_13_3
+.4byte sZapdosAnims_13_4
+.4byte sZapdosAnims_13_5
+.4byte sZapdosAnims_13_6
+.4byte sZapdosAnims_13_7
+.4byte sZapdosAnims_13_8
+sZapdosAnimTable14:
+.4byte sZapdosAnims_14_1
+.4byte sZapdosAnims_14_2
+.4byte sZapdosAnims_14_3
+.4byte sZapdosAnims_14_4
+.4byte sZapdosAnims_14_5
+.4byte sZapdosAnims_14_6
+.4byte sZapdosAnims_14_7
+.4byte sZapdosAnims_14_8
+sZapdosAnimTable15:
+.4byte sZapdosAnims_15_1
+.4byte sZapdosAnims_15_2
+.4byte sZapdosAnims_15_3
+.4byte sZapdosAnims_15_4
+.4byte sZapdosAnims_15_5
+.4byte sZapdosAnims_15_6
+.4byte sZapdosAnims_15_7
+.4byte sZapdosAnims_15_8
+sAxAnimationsZapdos:
+.4byte sZapdosAnimTable1
+.4byte sZapdosAnimTable2
+.4byte sZapdosAnimTable3
+.4byte sZapdosAnimTable4
+.4byte sZapdosAnimTable5
+.4byte sZapdosAnimTable6
+.4byte sZapdosAnimTable7
+.4byte sZapdosAnimTable8
+.4byte sZapdosAnimTable9
+.4byte sZapdosAnimTable10
+.4byte sZapdosAnimTable11
+.4byte sZapdosAnimTable12
+.4byte sZapdosAnimTable13
+.4byte sZapdosAnimTable14
+.4byte sZapdosAnimTable15
+sAxSpritesZapdos:
+.4byte sZapdosSprites1
+.4byte sZapdosSprites2
+.4byte sZapdosSprites3
+.4byte sZapdosSprites4
+.4byte sZapdosSprites5
+.4byte sZapdosSprites6
+.4byte sZapdosSprites7
+.4byte sZapdosSprites8
+.4byte sZapdosSprites9
+.4byte sZapdosSprites10
+.4byte sZapdosSprites11
+.4byte sZapdosSprites12
+.4byte sZapdosSprites13
+.4byte sZapdosSprites14
+.4byte sZapdosSprites15
+.4byte sZapdosSprites16
+.4byte sZapdosSprites17
+.4byte sZapdosSprites18
+.4byte sZapdosSprites19
+.4byte sZapdosSprites20
+.4byte sZapdosSprites21
+.4byte sZapdosSprites22
+.4byte sZapdosSprites23
+.4byte sZapdosSprites24
+.4byte sZapdosSprites25
+.4byte sZapdosSprites26
+.4byte sZapdosSprites27
+.4byte sZapdosSprites28
+.4byte sZapdosSprites29
+.4byte sZapdosSprites30
+.4byte sZapdosSprites31
+.4byte sZapdosSprites32
+.4byte sZapdosSprites33
+.4byte sZapdosSprites34
+.4byte sZapdosSprites35
+.4byte sZapdosSprites36
+.4byte sZapdosSprites37
+.4byte sZapdosSprites38
+.4byte sZapdosSprites39
+.4byte sZapdosSprites40
+.4byte sZapdosSprites41
+.4byte sZapdosSprites42
+.4byte sZapdosSprites43
+.4byte sZapdosSprites44
+.4byte sZapdosSprites45
+.4byte sZapdosSprites46
+.4byte sZapdosSprites47
+.4byte sZapdosSprites48
+.4byte sZapdosSprites49
+.4byte sZapdosSprites50
+.4byte sZapdosSprites51
+.4byte sZapdosSprites52
+.4byte sZapdosSprites53
+.4byte sZapdosSprites54
+.4byte sZapdosSprites55
+.4byte sZapdosSprites56
+.4byte sZapdosSprites57
+.4byte sZapdosSprites58
+.4byte sZapdosSprites59
+.4byte sZapdosSprites60
+.4byte sZapdosSprites61
+.4byte sZapdosSprites62
+.4byte sZapdosSprites63
+.4byte sZapdosSprites64
+.4byte sZapdosSprites65
+.4byte sZapdosSprites66
+.4byte sZapdosSprites67
+.4byte sZapdosSprites68
+.4byte sZapdosSprites69
+.4byte sZapdosSprites70
+.4byte sZapdosSprites71
+.4byte sZapdosSprites72
+.4byte sZapdosSprites73
+.4byte sZapdosSprites74
+.4byte sZapdosSprites75
+.4byte sZapdosSprites76
+.4byte sZapdosSprites77
+.4byte sZapdosSprites78
+.4byte sZapdosSprites79
+.4byte sZapdosSprites80
+.4byte sZapdosSprites81
+.4byte sZapdosSprites82
+.4byte sZapdosSprites83
+.4byte sZapdosSprites84
+.4byte sZapdosSprites85
+.4byte sZapdosSprites86
+.4byte sZapdosSprites87
+.4byte sZapdosSprites88
+.4byte sZapdosSprites89
+.4byte sZapdosSprites90
+.4byte sZapdosSprites91
+.4byte sZapdosSprites92
+.4byte sZapdosSprites93
+.4byte sZapdosSprites94
+.4byte sZapdosSprites95
+.4byte sZapdosSprites96
+.4byte sZapdosSprites97
+.4byte sZapdosSprites98
+.4byte sZapdosSprites99
+.4byte sZapdosSprites100
+.4byte sZapdosSprites101
+.4byte sZapdosSprites102
+.4byte sZapdosSprites103
+.4byte sZapdosSprites104
+.4byte sZapdosSprites105
+.4byte sZapdosSprites106
+.4byte sZapdosSprites107
+.4byte sZapdosSprites108
+.4byte sZapdosSprites109
+.4byte sZapdosSprites110
+.4byte sZapdosSprites111
+.4byte sZapdosSprites112
+.4byte sZapdosSprites113
+.4byte sZapdosSprites114
+.4byte sZapdosSprites115
+.4byte sZapdosSprites116
+.4byte sZapdosSprites117
+.4byte sZapdosSprites118
+.4byte sZapdosSprites119
+.4byte sZapdosSprites120
+.4byte sZapdosSprites121
+.4byte sZapdosSprites122
+.4byte sZapdosSprites123
+.4byte sZapdosSprites124
+.4byte sZapdosSprites125
+.4byte sZapdosSprites126
+.4byte sZapdosSprites127
+.4byte sZapdosSprites128
+.4byte sZapdosSprites129
+.4byte sZapdosSprites130
+.4byte sZapdosSprites131
+.4byte sZapdosSprites132
+.4byte sZapdosSprites133
+.4byte sZapdosSprites134
+.4byte sZapdosSprites135
+.4byte sZapdosSprites136
+.4byte sZapdosSprites137
+.4byte sZapdosSprites138
+.4byte sZapdosSprites139
+.4byte sZapdosSprites140
+.4byte sZapdosSprites141
+.4byte sZapdosSprites142
+.4byte sZapdosSprites143
+.4byte sZapdosSprites144
+.4byte sZapdosSprites145
+.4byte sZapdosSprites146
+.4byte sZapdosSprites147
+.4byte sZapdosSprites148
+.4byte sZapdosSprites149
+.4byte sZapdosSprites150
+.4byte sZapdosSprites151
+.4byte sZapdosSprites152
+.4byte sZapdosSprites153
+.4byte sZapdosSprites154
+.4byte sZapdosSprites155
+.4byte sZapdosSprites156
+.4byte sZapdosSprites157
+.4byte sZapdosSprites158
+.4byte sZapdosSprites159
+.4byte sZapdosSprites160
+.4byte sZapdosSprites161
+.4byte sZapdosSprites162
+.4byte sZapdosSprites163
+.4byte sZapdosSprites164
+.4byte sZapdosSprites165
+.4byte sZapdosSprites166
+.4byte sZapdosSprites167
+.4byte sZapdosSprites168
+.4byte sZapdosSprites169
+.4byte sZapdosSprites170
+.4byte sZapdosSprites171
+.4byte sZapdosSprites172
+.4byte sZapdosSprites173
+.4byte sZapdosSprites174
+.4byte sZapdosSprites175
+.4byte sZapdosSprites176
+.4byte sZapdosSprites177
+.4byte sZapdosSprites178
+.4byte sZapdosSprites179
+.4byte sZapdosSprites180
+.4byte sZapdosSprites181
+.4byte sZapdosSprites182
+.4byte sZapdosSprites183
+.4byte sZapdosSprites184
+.4byte sZapdosSprites185
+.4byte sZapdosSprites186
+.4byte sZapdosSprites187
+.4byte sZapdosSprites188
+.4byte sZapdosSprites189
+.4byte sZapdosSprites190
+.4byte sZapdosSprites191
+.4byte sZapdosSprites192
+.4byte sZapdosSprites193
+.4byte sZapdosSprites194
+.4byte sZapdosSprites195
+.4byte sZapdosSprites196
+.4byte sZapdosSprites197
+.4byte sZapdosSprites198
+.4byte sZapdosSprites199
+.4byte sZapdosSprites200
+.4byte sZapdosSprites201
+.4byte sZapdosSprites202
+.4byte sZapdosSprites203
+.4byte sZapdosSprites204
+.4byte sZapdosSprites205
+.4byte sZapdosSprites206
+.4byte sZapdosSprites207
+sAxMainZapdos:
+ax_main sAxPosesZapdos, sAxAnimationsZapdos, 15, sAxSpritesZapdos, sAxPositionsZapdos

--- a/data/ax/zigzagoon.inc
+++ b/data/ax/zigzagoon.inc
@@ -1,0 +1,2828 @@
+.global gAxZigzagoon
+gAxZigzagoon:
+ax_siro sAxMainZigzagoon
+sZigzagoonPose1:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose2:
+ax_pose 1, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose3:
+ax_pose 2, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose4:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose5:
+ax_pose 4, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose6:
+ax_pose 5, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose7:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose8:
+ax_pose 7, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose9:
+ax_pose 8, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose10:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose11:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose12:
+ax_pose 11, 0x01f1, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose13:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose14:
+ax_pose 13, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose15:
+ax_pose 14, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose16:
+ax_pose 9, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose17:
+ax_pose 10, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose18:
+ax_pose 11, 0x01f1, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose19:
+ax_pose 6, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose20:
+ax_pose 7, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose21:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose22:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose23:
+ax_pose 4, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose24:
+ax_pose 5, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose25:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose26:
+ax_pose 1, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose27:
+ax_pose 2, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose28:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose29:
+ax_pose 4, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose30:
+ax_pose 5, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose31:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose32:
+ax_pose 7, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose33:
+ax_pose 8, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose34:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose35:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose36:
+ax_pose 11, 0x01f1, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose37:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose38:
+ax_pose 13, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose39:
+ax_pose 14, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose40:
+ax_pose 9, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose41:
+ax_pose 10, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose42:
+ax_pose 11, 0x01f1, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose43:
+ax_pose 6, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose44:
+ax_pose 7, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose45:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose46:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose47:
+ax_pose 4, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose48:
+ax_pose 5, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose49:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose50:
+ax_pose 1, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose51:
+ax_pose 2, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose52:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose53:
+ax_pose 4, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose54:
+ax_pose 5, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose55:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose56:
+ax_pose 7, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose57:
+ax_pose 8, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose58:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose59:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose60:
+ax_pose 11, 0x01f1, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose61:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose62:
+ax_pose 13, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose63:
+ax_pose 14, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose64:
+ax_pose 9, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose65:
+ax_pose 10, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose66:
+ax_pose 11, 0x01f1, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose67:
+ax_pose 6, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose68:
+ax_pose 7, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose69:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose70:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose71:
+ax_pose 4, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose72:
+ax_pose 5, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose73:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose74:
+ax_pose 15, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose75:
+ax_pose 16, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose76:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose77:
+ax_pose 17, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose78:
+ax_pose 18, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose79:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose80:
+ax_pose 19, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose81:
+ax_pose 20, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose82:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose83:
+ax_pose 21, 0x01f0, 0x90ea, 0x6c00
+ax_pose_terminator
+sZigzagoonPose84:
+ax_pose 22, 0x01f0, 0x90ea, 0x6c00
+ax_pose_terminator
+sZigzagoonPose85:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose86:
+ax_pose 23, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose87:
+ax_pose 24, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose88:
+ax_pose 9, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose89:
+ax_pose 21, 0x01f0, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose90:
+ax_pose 22, 0x01f0, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose91:
+ax_pose 6, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose92:
+ax_pose 19, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose93:
+ax_pose 20, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose94:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose95:
+ax_pose 17, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose96:
+ax_pose 18, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose97:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose98:
+ax_pose 15, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose99:
+ax_pose 16, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose100:
+ax_pose 25, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose101:
+ax_pose 26, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose102:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose103:
+ax_pose 17, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose104:
+ax_pose 18, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose105:
+ax_pose 27, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose106:
+ax_pose 28, 0x01eb, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose107:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose108:
+ax_pose 19, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose109:
+ax_pose 20, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose110:
+ax_pose 29, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose111:
+ax_pose 30, 0x01ed, 0x90f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose112:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose113:
+ax_pose 21, 0x01f0, 0x90ed, 0x6c00
+ax_pose_terminator
+sZigzagoonPose114:
+ax_pose 22, 0x01f1, 0x90ea, 0x6c00
+ax_pose_terminator
+sZigzagoonPose115:
+ax_pose 31, 0x01f1, 0x90ea, 0x6c00
+ax_pose_terminator
+sZigzagoonPose116:
+ax_pose 32, 0x01f1, 0x90ea, 0x6c00
+ax_pose_terminator
+sZigzagoonPose117:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose118:
+ax_pose 23, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose119:
+ax_pose 24, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose120:
+ax_pose 33, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose121:
+ax_pose 34, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose122:
+ax_pose 9, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose123:
+ax_pose 21, 0x01f0, 0x80f2, 0x6c00
+ax_pose_terminator
+sZigzagoonPose124:
+ax_pose 22, 0x01f1, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose125:
+ax_pose 31, 0x01f1, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose126:
+ax_pose 32, 0x01f1, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose127:
+ax_pose 6, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose128:
+ax_pose 19, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose129:
+ax_pose 20, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose130:
+ax_pose 29, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose131:
+ax_pose 30, 0x01ed, 0x80ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose132:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose133:
+ax_pose 17, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose134:
+ax_pose 18, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose135:
+ax_pose 27, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose136:
+ax_pose 28, 0x01eb, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose137:
+ax_pose 35, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose138:
+ax_pose 36, 0x01ee, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose139:
+ax_pose 37, 0x01e1, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose140:
+ax_pose 38, 0x01e3, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose141:
+ax_pose 39, 0x01e5, 0x90e8, 0x6c00
+ax_pose_terminator
+sZigzagoonPose142:
+ax_pose 40, 0x01e7, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose143:
+ax_pose 41, 0x01e6, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose144:
+ax_pose 40, 0x01e7, 0x80f6, 0x6c00
+ax_pose_terminator
+sZigzagoonPose145:
+ax_pose 39, 0x01e5, 0x80f8, 0x6c00
+ax_pose_terminator
+sZigzagoonPose146:
+ax_pose 38, 0x01e3, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose147:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose148:
+ax_pose 1, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose149:
+ax_pose 2, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose150:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose151:
+ax_pose 4, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose152:
+ax_pose 5, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose153:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose154:
+ax_pose 7, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose155:
+ax_pose 8, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose156:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose157:
+ax_pose 10, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose158:
+ax_pose 11, 0x01f1, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose159:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose160:
+ax_pose 13, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose161:
+ax_pose 14, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose162:
+ax_pose 9, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose163:
+ax_pose 10, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose164:
+ax_pose 11, 0x01f1, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose165:
+ax_pose 6, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose166:
+ax_pose 7, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose167:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose168:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose169:
+ax_pose 4, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose170:
+ax_pose 5, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose171:
+ax_pose 2, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose172:
+ax_pose 5, 0x01ea, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose173:
+ax_pose 8, 0x01eb, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose174:
+ax_pose 11, 0x01f2, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose175:
+ax_pose 14, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose176:
+ax_pose 11, 0x01f2, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose177:
+ax_pose 8, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose178:
+ax_pose 5, 0x01eb, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose179:
+ax_pose 16, 0x01e9, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose180:
+ax_pose 18, 0x01eb, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose181:
+ax_pose 20, 0x01ed, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose182:
+ax_pose 22, 0x01f1, 0x90ea, 0x6c00
+ax_pose_terminator
+sZigzagoonPose183:
+ax_pose 24, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose184:
+ax_pose 22, 0x01f1, 0x80f6, 0x6c00
+ax_pose_terminator
+sZigzagoonPose185:
+ax_pose 20, 0x01ed, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose186:
+ax_pose 18, 0x01eb, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose187:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose188:
+ax_pose 15, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose189:
+ax_pose 16, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose190:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose191:
+ax_pose 17, 0x01ec, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose192:
+ax_pose 18, 0x01eb, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose193:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose194:
+ax_pose 19, 0x01ee, 0x90f2, 0x6c00
+ax_pose_terminator
+sZigzagoonPose195:
+ax_pose 20, 0x01ec, 0x90ee, 0x6c00
+ax_pose_terminator
+sZigzagoonPose196:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose197:
+ax_pose 21, 0x01f0, 0x90ed, 0x6c00
+ax_pose_terminator
+sZigzagoonPose198:
+ax_pose 22, 0x01f2, 0x90e9, 0x6c00
+ax_pose_terminator
+sZigzagoonPose199:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose200:
+ax_pose 23, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose201:
+ax_pose 24, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose202:
+ax_pose 9, 0x01ef, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose203:
+ax_pose 21, 0x01f0, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose204:
+ax_pose 22, 0x01f2, 0x80f7, 0x6c00
+ax_pose_terminator
+sZigzagoonPose205:
+ax_pose 6, 0x41f3, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose206:
+ax_pose 19, 0x01ee, 0x80ed, 0x6c00
+ax_pose_terminator
+sZigzagoonPose207:
+ax_pose 20, 0x01ec, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose208:
+ax_pose 3, 0x01ef, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose209:
+ax_pose 17, 0x01ec, 0x80f1, 0x6c00
+ax_pose_terminator
+sZigzagoonPose210:
+ax_pose 18, 0x01eb, 0x80f5, 0x6c00
+ax_pose_terminator
+sZigzagoonPose211:
+ax_pose 15, 0x01ec, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose212:
+ax_pose 17, 0x01eb, 0x80f3, 0x6c00
+ax_pose_terminator
+sZigzagoonPose213:
+ax_pose 19, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose214:
+ax_pose 21, 0x01f0, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose215:
+ax_pose 23, 0x01ed, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose216:
+ax_pose 21, 0x01f0, 0x90ec, 0x6c00
+ax_pose_terminator
+sZigzagoonPose217:
+ax_pose 19, 0x01ed, 0x90f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose218:
+ax_pose 17, 0x01eb, 0x90ed, 0x6c00
+ax_pose_terminator
+sZigzagoonPose219:
+ax_pose 0, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose220:
+ax_pose 3, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose221:
+ax_pose 6, 0x41f3, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose222:
+ax_pose 9, 0x01ef, 0x80f4, 0x6c00
+ax_pose_terminator
+sZigzagoonPose223:
+ax_pose 12, 0x01ef, 0x80f0, 0x6c00
+ax_pose_terminator
+sZigzagoonPose224:
+ax_pose 9, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+sZigzagoonPose225:
+ax_pose 6, 0x41f3, 0x90ef, 0x6c00
+ax_pose_terminator
+sZigzagoonPose226:
+ax_pose 3, 0x01ef, 0x90eb, 0x6c00
+ax_pose_terminator
+.align 2
+sZigzagoonAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 4, 0, 1, 0, 1, 0, 1,
+ax_anim 4, 0, 1, 0, -1, 0, 2,
+ax_anim 2, 0, 0, 0, -1, 0, 3,
+ax_anim 4, 0, 2, 0, 2, 0, 4,
+ax_anim 4, 0, 2, 0, 5, 0, 5,
+ax_anim 4, 0, 0, 0, 2, 0, 2,
+ax_anim_terminator
+sZigzagoonAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 4, 0, 4, -1, 1, 1, 1,
+ax_anim 4, 0, 4, 1, -1, 2, 2,
+ax_anim 2, 0, 3, 4, -3, 3, 3,
+ax_anim 4, 0, 5, 2, -1, 3, 3,
+ax_anim 4, 0, 5, 2, 2, 4, 4,
+ax_anim 4, 0, 3, 2, 2, 2, 2,
+ax_anim_terminator
+sZigzagoonAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 4, 0, 7, -1, 1, 0, 0,
+ax_anim 4, 0, 7, 1, -1, 1, 0,
+ax_anim 2, 0, 6, 4, -5, 3, 0,
+ax_anim 4, 0, 8, 2, -3, 4, 0,
+ax_anim 4, 0, 8, 2, 0, 4, 0,
+ax_anim 4, 0, 6, 2, 0, 2, 0,
+ax_anim_terminator
+sZigzagoonAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 4, 0, 10, -1, -1, 1, -1,
+ax_anim 4, 0, 10, 0, -4, 2, -2,
+ax_anim 2, 0, 9, 3, -10, 3, -3,
+ax_anim 4, 0, 11, 4, -7, 4, -4,
+ax_anim 4, 0, 11, 4, -4, 4, -4,
+ax_anim 4, 0, 9, 3, -3, 2, -2,
+ax_anim_terminator
+sZigzagoonAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 4, 0, 13, 0, 1, 0, -2,
+ax_anim 4, 0, 13, 0, -1, 0, -3,
+ax_anim 2, 0, 12, 0, -6, 0, -5,
+ax_anim 4, 0, 14, 0, -6, 0, -5,
+ax_anim 4, 0, 14, 0, -4, 0, -5,
+ax_anim 4, 0, 12, 0, -1, 0, -2,
+ax_anim_terminator
+sZigzagoonAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 4, 0, 16, 1, -1, -1, -1,
+ax_anim 4, 0, 16, 0, -4, -2, -2,
+ax_anim 2, 0, 15, -3, -10, -3, -3,
+ax_anim 4, 0, 17, -4, -7, -4, -4,
+ax_anim 4, 0, 17, -4, -4, -4, -4,
+ax_anim 4, 0, 15, -3, -3, -2, -2,
+ax_anim_terminator
+sZigzagoonAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 4, 0, 19, 1, 1, 0, 0,
+ax_anim 4, 0, 19, -1, -1, -1, 0,
+ax_anim 2, 0, 18, -4, -5, -3, 0,
+ax_anim 4, 0, 20, -2, -3, -4, 0,
+ax_anim 4, 0, 20, -2, 0, -4, 0,
+ax_anim 4, 0, 18, -2, 0, -2, 0,
+ax_anim_terminator
+sZigzagoonAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 4, 0, 22, 1, 1, -1, 1,
+ax_anim 4, 0, 22, -1, -1, -2, 2,
+ax_anim 2, 0, 21, -4, -3, -3, 3,
+ax_anim 4, 0, 23, -2, -1, -3, 3,
+ax_anim 4, 0, 23, -2, 2, -4, 4,
+ax_anim 4, 0, 21, -2, 2, -2, 2,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_2_1:
+ax_anim 2, 0, 24, 0, 0, 0, 0,
+ax_anim 2, 0, 24, 0, -1, 0, -1,
+ax_anim 4, 0, 24, 0, -3, 0, -3,
+ax_anim 2, 0, 25, 0, -3, 0, 0,
+ax_anim 2, 0, 25, 0, 1, 0, 5,
+ax_anim 2, 0, 24, 0, 4, 0, 10,
+ax_anim 2, 2, 26, 0, 11, 0, 15,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 1, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 26, 0, 17, 0, 17,
+ax_anim 2, 0, 26, 1, 17, 1, 17,
+ax_anim 2, 0, 24, 0, 6, 0, 6,
+ax_anim_terminator
+sZigzagoonAnims_2_2:
+ax_anim 2, 0, 27, 0, 0, 0, 0,
+ax_anim 2, 0, 27, -1, -1, -1, -1,
+ax_anim 4, 0, 27, -2, -2, -2, -2,
+ax_anim 2, 0, 28, 2, 0, 2, 2,
+ax_anim 2, 0, 28, 6, 1, 6, 6,
+ax_anim 2, 0, 27, 10, -1, 10, 10,
+ax_anim 2, 2, 29, 15, 7, 15, 15,
+ax_anim 2, 0, 29, 18, 14, 18, 18,
+ax_anim 2, 1, 29, 17, 15, 17, 19,
+ax_anim 2, 0, 29, 18, 14, 18, 18,
+ax_anim 2, 0, 29, 17, 15, 17, 19,
+ax_anim 2, 0, 27, 8, 8, 8, 8,
+ax_anim_terminator
+sZigzagoonAnims_2_3:
+ax_anim 2, 0, 30, 0, 0, 0, 0,
+ax_anim 2, 0, 30, -1, 0, -1, 0,
+ax_anim 4, 0, 30, -2, 0, -2, 0,
+ax_anim 2, 0, 31, 0, -1, 0, 0,
+ax_anim 2, 0, 31, 4, -4, 4, 0,
+ax_anim 2, 0, 30, 9, -9, 9, 0,
+ax_anim 2, 2, 32, 12, -5, 12, 0,
+ax_anim 2, 0, 32, 17, -1, 17, -1,
+ax_anim 2, 1, 32, 17, 0, 17, 0,
+ax_anim 2, 0, 32, 17, -1, 17, -1,
+ax_anim 2, 0, 32, 17, 0, 17, 0,
+ax_anim 2, 0, 30, 6, -1, 6, 0,
+ax_anim_terminator
+sZigzagoonAnims_2_4:
+ax_anim 2, 0, 33, 0, 0, 0, 0,
+ax_anim 2, 0, 33, -1, 1, -1, 1,
+ax_anim 4, 0, 33, -2, 2, -2, 2,
+ax_anim 2, 0, 34, 1, -1, 1, -1,
+ax_anim 2, 0, 34, 5, -7, 5, -5,
+ax_anim 2, 0, 33, 11, -18, 11, -11,
+ax_anim 2, 2, 35, 15, -20, 15, -15,
+ax_anim 2, 0, 35, 18, -21, 18, -18,
+ax_anim 2, 1, 35, 17, -22, 17, -19,
+ax_anim 2, 0, 35, 18, -21, 18, -18,
+ax_anim 2, 0, 35, 17, -22, 17, -19,
+ax_anim 2, 0, 33, 8, -8, 8, -8,
+ax_anim_terminator
+sZigzagoonAnims_2_5:
+ax_anim 2, 0, 36, 0, 0, 0, 0,
+ax_anim 2, 0, 36, 0, 1, 0, 1,
+ax_anim 4, 0, 36, 0, 2, 0, 2,
+ax_anim 2, 0, 37, 0, -1, 0, -1,
+ax_anim 2, 0, 37, 0, -7, 0, -5,
+ax_anim 2, 0, 36, 0, -18, 0, -11,
+ax_anim 2, 2, 38, 0, -21, 0, -17,
+ax_anim 2, 0, 38, 0, -23, 0, -23,
+ax_anim 2, 1, 38, 1, -23, 1, -23,
+ax_anim 2, 0, 38, 0, -23, 0, -23,
+ax_anim 2, 0, 38, 1, -23, 1, -23,
+ax_anim 2, 0, 36, 0, -8, 0, -8,
+ax_anim_terminator
+sZigzagoonAnims_2_6:
+ax_anim 2, 0, 39, 0, 0, 0, 0,
+ax_anim 2, 0, 39, 1, 1, 1, 1,
+ax_anim 4, 0, 39, 2, 2, 2, 2,
+ax_anim 2, 0, 40, -1, -1, -1, -1,
+ax_anim 2, 0, 40, -5, -7, -5, -5,
+ax_anim 2, 0, 39, -11, -18, -11, -11,
+ax_anim 2, 2, 41, -15, -20, -15, -15,
+ax_anim 2, 0, 41, -18, -21, -18, -18,
+ax_anim 2, 1, 41, -17, -22, -17, -19,
+ax_anim 2, 0, 41, -18, -21, -18, -18,
+ax_anim 2, 0, 41, -17, -22, -17, -19,
+ax_anim 2, 0, 39, -8, -8, -8, -8,
+ax_anim_terminator
+sZigzagoonAnims_2_7:
+ax_anim 2, 0, 42, 0, 0, 0, 0,
+ax_anim 2, 0, 42, 1, 0, 1, 0,
+ax_anim 4, 0, 42, 2, 0, 2, 0,
+ax_anim 2, 0, 43, 0, -1, 0, 0,
+ax_anim 2, 0, 43, -4, -4, -4, 0,
+ax_anim 2, 0, 42, -9, -9, -9, 0,
+ax_anim 2, 2, 44, -12, -5, -12, 0,
+ax_anim 2, 0, 44, -17, -1, -17, -1,
+ax_anim 2, 1, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 44, -17, -1, -17, -1,
+ax_anim 2, 0, 44, -17, 0, -17, 0,
+ax_anim 2, 0, 42, -6, -1, -6, 0,
+ax_anim_terminator
+sZigzagoonAnims_2_8:
+ax_anim 2, 0, 45, 0, 0, 0, 0,
+ax_anim 2, 0, 45, 1, -1, 1, -1,
+ax_anim 4, 0, 45, 2, -2, 2, -2,
+ax_anim 2, 0, 46, -2, 0, -2, 2,
+ax_anim 2, 0, 46, -6, 1, -6, 6,
+ax_anim 2, 0, 45, -10, -1, -10, 10,
+ax_anim 2, 2, 47, -15, 7, -15, 15,
+ax_anim 2, 0, 47, -18, 14, -18, 18,
+ax_anim 2, 1, 47, -17, 15, -17, 19,
+ax_anim 2, 0, 47, -18, 14, -18, 18,
+ax_anim 2, 0, 47, -17, 15, -17, 19,
+ax_anim 2, 0, 45, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_3_1:
+ax_anim 2, 0, 48, 0, 0, 0, 0,
+ax_anim 2, 0, 48, 0, -1, 0, -1,
+ax_anim 4, 0, 48, 0, -3, 0, -3,
+ax_anim 2, 0, 49, 0, -3, 0, 0,
+ax_anim 2, 0, 49, 0, 1, 0, 5,
+ax_anim 2, 0, 48, 0, 4, 0, 10,
+ax_anim 2, 2, 50, 0, 11, 0, 15,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 1, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 50, 0, 17, 0, 17,
+ax_anim 2, 0, 50, 1, 17, 1, 17,
+ax_anim 2, 0, 48, 0, 6, 0, 6,
+ax_anim_terminator
+sZigzagoonAnims_3_2:
+ax_anim 2, 0, 51, 0, 0, 0, 0,
+ax_anim 2, 0, 51, -1, -1, -1, -1,
+ax_anim 4, 0, 51, -2, -2, -2, -2,
+ax_anim 2, 0, 52, 2, 0, 2, 2,
+ax_anim 2, 0, 52, 6, 1, 6, 6,
+ax_anim 2, 0, 51, 10, -1, 10, 10,
+ax_anim 2, 2, 53, 15, 7, 15, 15,
+ax_anim 2, 0, 53, 18, 14, 18, 18,
+ax_anim 2, 1, 53, 17, 15, 17, 19,
+ax_anim 2, 0, 53, 18, 14, 18, 18,
+ax_anim 2, 0, 53, 17, 15, 17, 19,
+ax_anim 2, 0, 51, 8, 8, 8, 8,
+ax_anim_terminator
+sZigzagoonAnims_3_3:
+ax_anim 2, 0, 54, 0, 0, 0, 0,
+ax_anim 2, 0, 54, -1, 0, -1, 0,
+ax_anim 4, 0, 54, -2, 0, -2, 0,
+ax_anim 2, 0, 55, 0, -1, 0, 0,
+ax_anim 2, 0, 55, 4, -4, 4, 0,
+ax_anim 2, 0, 54, 9, -9, 9, 0,
+ax_anim 2, 2, 56, 12, -5, 12, 0,
+ax_anim 2, 0, 56, 17, -1, 17, -1,
+ax_anim 2, 1, 56, 17, 0, 17, 0,
+ax_anim 2, 0, 56, 17, -1, 17, -1,
+ax_anim 2, 0, 56, 17, 0, 17, 0,
+ax_anim 2, 0, 54, 6, -1, 6, 0,
+ax_anim_terminator
+sZigzagoonAnims_3_4:
+ax_anim 2, 0, 57, 0, 0, 0, 0,
+ax_anim 2, 0, 57, -1, 1, -1, 1,
+ax_anim 4, 0, 57, -2, 2, -2, 2,
+ax_anim 2, 0, 58, 1, -1, 1, -1,
+ax_anim 2, 0, 58, 5, -7, 5, -5,
+ax_anim 2, 0, 57, 11, -18, 11, -11,
+ax_anim 2, 2, 59, 15, -20, 15, -15,
+ax_anim 2, 0, 59, 18, -21, 18, -18,
+ax_anim 2, 1, 59, 17, -22, 17, -19,
+ax_anim 2, 0, 59, 18, -21, 18, -18,
+ax_anim 2, 0, 59, 17, -22, 17, -19,
+ax_anim 2, 0, 57, 8, -8, 8, -8,
+ax_anim_terminator
+sZigzagoonAnims_3_5:
+ax_anim 2, 0, 60, 0, 0, 0, 0,
+ax_anim 2, 0, 60, 0, 1, 0, 1,
+ax_anim 4, 0, 60, 0, 2, 0, 2,
+ax_anim 2, 0, 61, 0, -1, 0, -1,
+ax_anim 2, 0, 61, 0, -7, 0, -5,
+ax_anim 2, 0, 60, 0, -18, 0, -11,
+ax_anim 2, 2, 62, 0, -21, 0, -17,
+ax_anim 2, 0, 62, 0, -23, 0, -23,
+ax_anim 2, 1, 62, 1, -23, 1, -23,
+ax_anim 2, 0, 62, 0, -23, 0, -23,
+ax_anim 2, 0, 62, 1, -23, 1, -23,
+ax_anim 2, 0, 60, 0, -8, 0, -8,
+ax_anim_terminator
+sZigzagoonAnims_3_6:
+ax_anim 2, 0, 63, 0, 0, 0, 0,
+ax_anim 2, 0, 63, 1, 1, 1, 1,
+ax_anim 4, 0, 63, 2, 2, 2, 2,
+ax_anim 2, 0, 64, -1, -1, -1, -1,
+ax_anim 2, 0, 64, -5, -7, -5, -5,
+ax_anim 2, 0, 63, -11, -18, -11, -11,
+ax_anim 2, 2, 65, -15, -20, -15, -15,
+ax_anim 2, 0, 65, -18, -21, -18, -18,
+ax_anim 2, 1, 65, -17, -22, -17, -19,
+ax_anim 2, 0, 65, -18, -21, -18, -18,
+ax_anim 2, 0, 65, -17, -22, -17, -19,
+ax_anim 2, 0, 63, -8, -8, -8, -8,
+ax_anim_terminator
+sZigzagoonAnims_3_7:
+ax_anim 2, 0, 66, 0, 0, 0, 0,
+ax_anim 2, 0, 66, 1, 0, 1, 0,
+ax_anim 4, 0, 66, 2, 0, 2, 0,
+ax_anim 2, 0, 67, 0, -1, 0, 0,
+ax_anim 2, 0, 67, -4, -4, -4, 0,
+ax_anim 2, 0, 66, -9, -9, -9, 0,
+ax_anim 2, 2, 68, -12, -5, -12, 0,
+ax_anim 2, 0, 68, -17, -1, -17, -1,
+ax_anim 2, 1, 68, -17, 0, -17, 0,
+ax_anim 2, 0, 68, -17, -1, -17, -1,
+ax_anim 2, 0, 68, -17, 0, -17, 0,
+ax_anim 2, 0, 66, -6, -1, -6, 0,
+ax_anim_terminator
+sZigzagoonAnims_3_8:
+ax_anim 2, 0, 69, 0, 0, 0, 0,
+ax_anim 2, 0, 69, 1, -1, 1, -1,
+ax_anim 4, 0, 69, 2, -2, 2, -2,
+ax_anim 2, 0, 70, -2, 0, -2, 2,
+ax_anim 2, 0, 70, -6, 1, -6, 6,
+ax_anim 2, 0, 69, -10, -1, -10, 10,
+ax_anim 2, 2, 71, -15, 7, -15, 15,
+ax_anim 2, 0, 71, -18, 14, -18, 18,
+ax_anim 2, 1, 71, -17, 15, -17, 19,
+ax_anim 2, 0, 71, -18, 14, -18, 18,
+ax_anim 2, 0, 71, -17, 15, -17, 19,
+ax_anim 2, 0, 69, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_4_1:
+ax_anim 2, 0, 73, 0, -2, 0, -2,
+ax_anim 6, 2, 73, 0, -3, 0, -3,
+ax_anim 2, 0, 72, 0, -1, 0, -1,
+ax_anim 2, 1, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 74, 1, 3, 1, 3,
+ax_anim 2, 0, 74, 0, 3, 0, 3,
+ax_anim 2, 0, 72, 0, 1, 0, 1,
+ax_anim_terminator
+sZigzagoonAnims_4_2:
+ax_anim 2, 0, 76, -2, -2, -2, -2,
+ax_anim 6, 2, 76, -3, -3, -3, -3,
+ax_anim 2, 0, 75, -1, -1, -1, -1,
+ax_anim 2, 1, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 77, 3, 1, 3, 1,
+ax_anim 2, 0, 77, 2, 2, 2, 2,
+ax_anim 2, 0, 75, 1, 1, 1, 1,
+ax_anim_terminator
+sZigzagoonAnims_4_3:
+ax_anim 2, 0, 79, -2, 0, -2, 0,
+ax_anim 6, 2, 79, -3, 0, -3, 0,
+ax_anim 2, 0, 78, -1, 0, -1, 0,
+ax_anim 2, 1, 80, 2, 0, 6, 0,
+ax_anim 2, 0, 80, 2, 1, 6, 1,
+ax_anim 2, 0, 80, 2, 0, 6, 0,
+ax_anim 2, 0, 80, 2, 1, 6, 1,
+ax_anim 2, 0, 80, 2, 0, 6, 0,
+ax_anim 2, 0, 80, 2, 1, 6, 1,
+ax_anim 2, 0, 80, 2, 0, 6, 0,
+ax_anim 2, 0, 78, 1, 0, 1, 0,
+ax_anim_terminator
+sZigzagoonAnims_4_4:
+ax_anim 2, 0, 82, -2, 2, -2, 2,
+ax_anim 6, 2, 82, -3, 3, -3, 3,
+ax_anim 2, 0, 81, -1, 1, -1, 1,
+ax_anim 2, 1, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 83, 3, -1, 3, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -2,
+ax_anim 2, 0, 81, 1, -1, 1, -1,
+ax_anim_terminator
+sZigzagoonAnims_4_5:
+ax_anim 2, 0, 85, 0, 2, 0, 2,
+ax_anim 6, 2, 85, 0, 3, 0, 3,
+ax_anim 2, 0, 84, 0, 1, 0, 1,
+ax_anim 2, 1, 86, 0, -3, 0, -6,
+ax_anim 2, 0, 86, 1, -3, 1, -6,
+ax_anim 2, 0, 86, 0, -3, 0, -6,
+ax_anim 2, 0, 86, 1, -3, 1, -6,
+ax_anim 2, 0, 86, 0, -3, 0, -6,
+ax_anim 2, 0, 86, 1, -3, 1, -6,
+ax_anim 2, 0, 86, 0, -3, 0, -6,
+ax_anim 2, 0, 84, 0, -1, 0, -1,
+ax_anim_terminator
+sZigzagoonAnims_4_6:
+ax_anim 2, 0, 88, 2, 2, 2, 2,
+ax_anim 6, 2, 88, 3, 3, 3, 3,
+ax_anim 2, 0, 87, 1, 1, 1, 1,
+ax_anim 2, 1, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 89, -3, -1, -3, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -2,
+ax_anim 2, 0, 87, -1, -1, -1, -1,
+ax_anim_terminator
+sZigzagoonAnims_4_7:
+ax_anim 2, 0, 91, 2, 0, 2, 0,
+ax_anim 6, 2, 91, 3, 0, 3, 0,
+ax_anim 2, 0, 90, 1, 0, 1, 0,
+ax_anim 2, 1, 92, -2, 0, -6, 0,
+ax_anim 2, 0, 92, -2, 1, -6, 1,
+ax_anim 2, 0, 92, -2, 0, -6, 0,
+ax_anim 2, 0, 92, -2, 1, -6, 1,
+ax_anim 2, 0, 92, -2, 0, -6, 0,
+ax_anim 2, 0, 92, -2, 1, -6, 1,
+ax_anim 2, 0, 92, -2, 0, -6, 0,
+ax_anim 2, 0, 90, -1, 0, -1, 0,
+ax_anim_terminator
+sZigzagoonAnims_4_8:
+ax_anim 2, 0, 94, 2, -2, 2, -2,
+ax_anim 6, 2, 94, 3, -3, 3, -3,
+ax_anim 2, 0, 93, 1, -1, 1, -1,
+ax_anim 2, 1, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 95, -3, 1, -3, 1,
+ax_anim 2, 0, 95, -2, 2, -2, 2,
+ax_anim 2, 0, 93, -1, 1, -1, 1,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_5_1:
+ax_anim 8, 0, 97, 0, 0, 0, 0,
+ax_anim 2, 2, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 98, 0, -1, 0, 1,
+ax_anim 3, 0, 99, 0, -1, 0, 1,
+ax_anim 1, 0, 98, 0, -1, 0, 1,
+ax_anim 3, 0, 100, 0, -1, 0, 1,
+ax_anim 1, 0, 98, 0, -1, 0, 1,
+ax_anim 3, 0, 99, 0, -1, 0, 1,
+ax_anim 1, 1, 98, 0, -1, 0, 1,
+ax_anim 3, 0, 100, 0, -1, 0, 1,
+ax_anim 1, 0, 98, 0, -1, 0, 1,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_5_2:
+ax_anim 8, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 101, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 0, 0, 1, 1,
+ax_anim 3, 0, 104, 0, 0, 1, 1,
+ax_anim 1, 0, 103, 0, 0, 1, 1,
+ax_anim 3, 0, 105, 0, 0, 1, 1,
+ax_anim 1, 0, 103, 0, 0, 1, 1,
+ax_anim 3, 0, 104, 0, 0, 1, 1,
+ax_anim 1, 1, 103, 0, 0, 1, 1,
+ax_anim 3, 0, 105, 0, 0, 1, 1,
+ax_anim 1, 0, 103, 0, 0, 1, 1,
+ax_anim 2, 0, 101, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_5_3:
+ax_anim 8, 0, 107, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, 0, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 3, 0,
+ax_anim 3, 0, 109, 0, 0, 3, 0,
+ax_anim 1, 0, 108, 0, 0, 3, 0,
+ax_anim 3, 0, 110, 0, 0, 3, 0,
+ax_anim 1, 0, 108, 0, 0, 3, 0,
+ax_anim 3, 0, 109, 0, 0, 3, 0,
+ax_anim 1, 1, 108, 0, 0, 3, 0,
+ax_anim 3, 0, 110, 0, 0, 3, 0,
+ax_anim 1, 0, 108, 0, 0, 3, 0,
+ax_anim 2, 0, 106, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_5_4:
+ax_anim 8, 0, 112, 0, 0, 0, 0,
+ax_anim 2, 2, 111, 1, 0, 1, -1,
+ax_anim 2, 0, 113, 3, -1, 2, -1,
+ax_anim 3, 0, 114, 3, -1, 2, -1,
+ax_anim 1, 0, 113, 3, -1, 2, -1,
+ax_anim 3, 0, 115, 3, -1, 2, -1,
+ax_anim 1, 0, 113, 3, -1, 2, -1,
+ax_anim 3, 0, 114, 3, -1, 2, -1,
+ax_anim 1, 1, 113, 3, -1, 2, -1,
+ax_anim 3, 0, 115, 3, -1, 2, -1,
+ax_anim 1, 0, 113, 3, -1, 2, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_5_5:
+ax_anim 8, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 116, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, 0, 0, -1,
+ax_anim 3, 0, 119, 0, 0, 0, -1,
+ax_anim 1, 0, 118, 0, 0, 0, -1,
+ax_anim 3, 0, 120, 0, 0, 0, -1,
+ax_anim 1, 0, 118, 0, 0, 0, -1,
+ax_anim 3, 0, 119, 0, 0, 0, -1,
+ax_anim 1, 1, 118, 0, 0, 0, -1,
+ax_anim 3, 0, 120, 0, 0, 0, -1,
+ax_anim 1, 0, 118, 0, 0, 0, -1,
+ax_anim 2, 0, 116, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_5_6:
+ax_anim 8, 0, 122, 0, 0, 0, 0,
+ax_anim 2, 2, 121, -1, 0, -1, -1,
+ax_anim 2, 0, 123, -3, -1, -2, -1,
+ax_anim 3, 0, 124, -3, -1, -2, -1,
+ax_anim 1, 0, 123, -3, -1, -2, -1,
+ax_anim 3, 0, 125, -3, -1, -2, -1,
+ax_anim 1, 0, 123, -3, -1, -2, -1,
+ax_anim 3, 0, 124, -3, -1, -2, -1,
+ax_anim 1, 1, 123, -3, -1, -2, -1,
+ax_anim 3, 0, 125, -3, -1, -2, -1,
+ax_anim 1, 0, 123, -3, -1, -2, -1,
+ax_anim 2, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_5_7:
+ax_anim 8, 0, 127, 0, 0, 0, 0,
+ax_anim 2, 2, 126, 0, 0, 0, 0,
+ax_anim 2, 0, 128, 0, 0, -3, 0,
+ax_anim 3, 0, 129, 0, 0, -3, 0,
+ax_anim 1, 0, 128, 0, 0, -3, 0,
+ax_anim 3, 0, 130, 0, 0, -3, 0,
+ax_anim 1, 0, 128, 0, 0, -3, 0,
+ax_anim 3, 0, 129, 0, 0, -3, 0,
+ax_anim 1, 1, 128, 0, 0, -3, 0,
+ax_anim 3, 0, 130, 0, 0, -3, 0,
+ax_anim 1, 0, 128, 0, 0, -3, 0,
+ax_anim 2, 0, 126, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_5_8:
+ax_anim 8, 0, 132, 0, 0, 0, 0,
+ax_anim 2, 2, 131, 0, 0, 0, 0,
+ax_anim 2, 0, 133, 0, 0, -1, 1,
+ax_anim 3, 0, 134, 0, 0, -1, 1,
+ax_anim 1, 0, 133, 0, 0, -1, 1,
+ax_anim 3, 0, 135, 0, 0, -1, 1,
+ax_anim 1, 0, 133, 0, 0, -1, 1,
+ax_anim 3, 0, 134, 0, 0, -1, 1,
+ax_anim 1, 1, 133, 0, 0, -1, 1,
+ax_anim 3, 0, 135, 0, 0, -1, 1,
+ax_anim 1, 0, 133, 0, 0, -1, 1,
+ax_anim 2, 0, 131, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_6_1:
+ax_anim 30, 0, 136, 0, 0, 0, 0,
+ax_anim 35, 0, 137, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_7_1:
+ax_anim 2, 0, 138, 0, -4, 0, -4,
+ax_anim 8, 0, 138, 0, -5, 0, -5,
+ax_anim_terminator
+sZigzagoonAnims_7_2:
+ax_anim 2, 0, 139, -4, -4, -4, -4,
+ax_anim 8, 0, 139, -5, -5, -5, -5,
+ax_anim_terminator
+sZigzagoonAnims_7_3:
+ax_anim 2, 0, 140, -4, 0, -4, 0,
+ax_anim 8, 0, 140, -5, 0, -5, 0,
+ax_anim_terminator
+sZigzagoonAnims_7_4:
+ax_anim 2, 0, 141, -4, 4, -4, 4,
+ax_anim 8, 0, 141, -5, 5, -5, 5,
+ax_anim_terminator
+sZigzagoonAnims_7_5:
+ax_anim 2, 0, 142, 0, 4, 0, 4,
+ax_anim 8, 0, 142, 0, 5, 0, 5,
+ax_anim_terminator
+sZigzagoonAnims_7_6:
+ax_anim 2, 0, 143, 4, 4, 4, 4,
+ax_anim 8, 0, 143, 5, 5, 5, 5,
+ax_anim_terminator
+sZigzagoonAnims_7_7:
+ax_anim 2, 0, 144, 4, 0, 4, 0,
+ax_anim 8, 0, 144, 5, 0, 5, 0,
+ax_anim_terminator
+sZigzagoonAnims_7_8:
+ax_anim 2, 0, 145, 4, -4, 4, -4,
+ax_anim 8, 0, 145, 5, -5, 5, -5,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_8_1:
+ax_anim 40, 0, 146, 0, 0, 0, 0,
+ax_anim 2, 0, 147, 0, -1, 0, 0,
+ax_anim 4, 0, 147, 0, -2, 0, 0,
+ax_anim 4, 0, 146, 0, -4, 0, 0,
+ax_anim 4, 0, 148, 0, -2, 0, 0,
+ax_anim 2, 0, 148, 0, -1, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_8_2:
+ax_anim 40, 0, 149, 0, 0, 0, 0,
+ax_anim 2, 0, 150, -2, -1, 0, 0,
+ax_anim 4, 0, 150, -2, -2, 0, 0,
+ax_anim 4, 0, 149, 0, -4, 0, 0,
+ax_anim 4, 0, 151, -1, -2, 0, 0,
+ax_anim 2, 0, 151, -1, -1, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_8_3:
+ax_anim 40, 0, 152, 0, 0, 0, 0,
+ax_anim 2, 0, 153, -2, -1, 0, 0,
+ax_anim 4, 0, 153, -2, -2, 0, 0,
+ax_anim 4, 0, 152, 0, -5, 0, 0,
+ax_anim 4, 0, 154, -2, -2, 0, 0,
+ax_anim 2, 0, 154, -2, -1, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_8_4:
+ax_anim 40, 0, 155, 0, 0, 0, 0,
+ax_anim 2, 0, 156, -1, 0, 0, 0,
+ax_anim 4, 0, 156, -1, -2, 0, 0,
+ax_anim 4, 0, 156, -1, -4, 0, 0,
+ax_anim 4, 0, 157, 0, -2, 0, 0,
+ax_anim 2, 0, 157, 0, -1, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_8_5:
+ax_anim 40, 0, 158, 0, 0, 0, 0,
+ax_anim 2, 0, 159, 0, 1, 0, 0,
+ax_anim 4, 0, 159, 0, 0, 0, 0,
+ax_anim 4, 0, 158, 0, -5, 0, 0,
+ax_anim 4, 0, 160, 0, -6, 0, 0,
+ax_anim 2, 0, 160, 0, -4, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_8_6:
+ax_anim 40, 0, 161, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 1, 0, 0, 0,
+ax_anim 4, 0, 162, 1, -2, 0, 0,
+ax_anim 4, 0, 162, 1, -4, 0, 0,
+ax_anim 4, 0, 163, 1, -2, 0, 0,
+ax_anim 2, 0, 163, 1, -1, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_8_7:
+ax_anim 40, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 165, 2, -1, 0, 0,
+ax_anim 4, 0, 165, 2, -2, 0, 0,
+ax_anim 4, 0, 164, 0, -5, 0, 0,
+ax_anim 4, 0, 166, 2, -2, 0, 0,
+ax_anim 2, 0, 166, 2, -1, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_8_8:
+ax_anim 40, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 2, -1, 0, 0,
+ax_anim 4, 0, 168, 2, -2, 0, 0,
+ax_anim 4, 0, 167, 0, -4, 0, 0,
+ax_anim 4, 0, 169, 1, -2, 0, 0,
+ax_anim 2, 0, 169, 1, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_9_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 7, 3, 7, 3,
+ax_anim 2, 0, 172, 11, 10, 11, 10,
+ax_anim 2, 0, 173, 8, 17, 8, 17,
+ax_anim 3, 0, 174, 0, 19, 0, 19,
+ax_anim 2, 3, 175, -8, 17, -8, 17,
+ax_anim 2, 0, 176, -11, 10, -11, 10,
+ax_anim 1, 0, 177, -7, 3, -7, 3,
+ax_anim 1, 0, 170, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_9_2:
+ax_anim 2, 0, 177, 0, 0, 0, 0,
+ax_anim 1, 0, 170, 9, -1, 9, -1,
+ax_anim 2, 0, 171, 18, 4, 18, 4,
+ax_anim 2, 0, 172, 23, 14, 23, 14,
+ax_anim 3, 0, 173, 18, 20, 18, 20,
+ax_anim 2, 3, 174, 11, 19, 11, 19,
+ax_anim 2, 0, 175, 3, 17, 3, 17,
+ax_anim 1, 0, 176, 0, 9, 0, 9,
+ax_anim 1, 0, 177, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_9_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 4, -6, 4, -6,
+ax_anim 2, 0, 170, 11, -7, 11, -7,
+ax_anim 2, 0, 171, 16, -5, 16, -5,
+ax_anim 3, 0, 172, 21, -1, 21, -1,
+ax_anim 2, 3, 173, 19, 3, 19, 3,
+ax_anim 2, 0, 174, 12, 5, 12, 5,
+ax_anim 1, 0, 175, 4, 5, 4, 5,
+ax_anim 1, 0, 176, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_9_4:
+ax_anim 2, 0, 175, 0, 0, 0, 0,
+ax_anim 1, 0, 176, 0, -7, 0, -7,
+ax_anim 2, 0, 177, 4, -16, 4, -16,
+ax_anim 2, 0, 170, 11, -20, 11, -20,
+ax_anim 3, 0, 171, 19, -21, 19, -21,
+ax_anim 2, 3, 172, 22, -16, 22, -16,
+ax_anim 2, 0, 173, 17, -6, 17, -6,
+ax_anim 1, 0, 174, 7, -1, 7, -1,
+ax_anim 1, 0, 175, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_9_5:
+ax_anim 2, 0, 174, 0, 0, 0, 0,
+ax_anim 1, 0, 175, -8, -3, -8, -3,
+ax_anim 2, 0, 176, -11, -10, -11, -10,
+ax_anim 2, 0, 177, -7, -20, -7, -20,
+ax_anim 3, 0, 170, 0, -22, 0, -22,
+ax_anim 2, 3, 171, 7, -20, 7, -20,
+ax_anim 2, 0, 172, 11, -10, 11, -10,
+ax_anim 1, 0, 173, 8, -3, 8, -3,
+ax_anim 1, 0, 174, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_9_6:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 172, 0, -7, 0, -7,
+ax_anim 2, 0, 171, -4, -16, -4, -16,
+ax_anim 2, 0, 170, -11, -20, -11, -20,
+ax_anim 3, 0, 177, -19, -21, -19, -21,
+ax_anim 2, 3, 176, -22, -16, -22, -16,
+ax_anim 2, 0, 175, -17, -6, -17, -6,
+ax_anim 1, 0, 174, -7, -1, -7, -1,
+ax_anim 1, 0, 173, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_9_7:
+ax_anim 2, 0, 172, 0, 0, 0, 0,
+ax_anim 1, 0, 171, -4, -6, -4, -6,
+ax_anim 2, 0, 170, -11, -7, -11, -7,
+ax_anim 2, 0, 177, -16, -5, -16, -5,
+ax_anim 3, 0, 176, -21, -1, -21, -1,
+ax_anim 2, 3, 175, -19, 3, -19, 3,
+ax_anim 2, 0, 174, -12, 5, -12, 5,
+ax_anim 1, 0, 173, -4, 5, -4, 5,
+ax_anim 1, 0, 172, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_9_8:
+ax_anim 2, 0, 171, 0, 0, 0, 0,
+ax_anim 1, 0, 170, -9, 0, -9, 0,
+ax_anim 2, 0, 177, -18, 4, -18, 4,
+ax_anim 2, 0, 176, -23, 14, -23, 14,
+ax_anim 3, 0, 175, -18, 20, -18, 20,
+ax_anim 2, 3, 174, -11, 19, -11, 19,
+ax_anim 2, 0, 173, -3, 17, -3, 17,
+ax_anim 1, 0, 172, 0, 9, 0, 9,
+ax_anim 1, 0, 171, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_10_1:
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 3, 0, 178, 13, 0, 13, 0,
+ax_anim 3, 0, 178, -13, 0, -13, 0,
+ax_anim 2, 0, 178, 12, 0, 12, 0,
+ax_anim 3, 0, 178, -12, 0, -12, 0,
+ax_anim 2, 0, 178, 10, 0, 10, 0,
+ax_anim 2, 0, 178, -10, 0, -10, 0,
+ax_anim 2, 0, 178, 6, 0, 6, 0,
+ax_anim 2, 0, 178, -6, 0, -6, 0,
+ax_anim 2, 0, 178, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_10_2:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 3, 0, 179, 13, -13, 13, -13,
+ax_anim 3, 0, 179, -13, 13, -13, 13,
+ax_anim 2, 0, 179, 12, -12, 12, -12,
+ax_anim 3, 0, 179, -12, 12, -12, 12,
+ax_anim 2, 0, 179, 10, -10, 10, -10,
+ax_anim 2, 0, 179, -10, 10, -10, 10,
+ax_anim 2, 0, 179, 6, -6, 6, -6,
+ax_anim 2, 0, 179, -6, 6, -6, 6,
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_10_3:
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 3, 0, 180, 0, -13, 0, -13,
+ax_anim 3, 0, 180, 0, 13, 0, 13,
+ax_anim 2, 0, 180, 0, -12, 0, -12,
+ax_anim 3, 0, 180, 0, 12, 0, 12,
+ax_anim 2, 0, 180, 0, -10, 0, -10,
+ax_anim 2, 0, 180, 0, 10, 0, 10,
+ax_anim 2, 0, 180, 0, -6, 0, -6,
+ax_anim 2, 0, 180, 0, 6, 0, 6,
+ax_anim 2, 0, 180, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_10_4:
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 3, 0, 181, -13, -13, -13, -13,
+ax_anim 3, 0, 181, 13, 13, 13, 13,
+ax_anim 2, 0, 181, -12, -12, -12, -12,
+ax_anim 3, 0, 181, 12, 12, 12, 12,
+ax_anim 2, 0, 181, -10, -10, -10, -10,
+ax_anim 2, 0, 181, 10, 10, 10, 10,
+ax_anim 2, 0, 181, -6, -6, -6, -6,
+ax_anim 2, 0, 181, 6, 6, 6, 6,
+ax_anim 2, 0, 181, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_10_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 3, 0, 182, 13, 0, 13, 0,
+ax_anim 3, 0, 182, -13, 0, -13, 0,
+ax_anim 2, 0, 182, 12, 0, 12, 0,
+ax_anim 3, 0, 182, -12, 0, -12, 0,
+ax_anim 2, 0, 182, 10, 0, 10, 0,
+ax_anim 2, 0, 182, -10, 0, -10, 0,
+ax_anim 2, 0, 182, 6, 0, 6, 0,
+ax_anim 2, 0, 182, -6, 0, -6, 0,
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_10_6:
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 3, 0, 183, 13, -13, 13, -13,
+ax_anim 3, 0, 183, -13, 13, -13, 13,
+ax_anim 2, 0, 183, 12, -12, 12, -12,
+ax_anim 3, 0, 183, -12, 12, -12, 12,
+ax_anim 2, 0, 183, 10, -10, 10, -10,
+ax_anim 2, 0, 183, -10, 10, -10, 10,
+ax_anim 2, 0, 183, 6, -6, 6, -6,
+ax_anim 2, 0, 183, -6, 6, -6, 6,
+ax_anim 2, 0, 183, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_10_7:
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 3, 0, 184, 0, -13, 0, -13,
+ax_anim 3, 0, 184, 0, 13, 0, 13,
+ax_anim 2, 0, 184, 0, -12, 0, -12,
+ax_anim 3, 0, 184, 0, 12, 0, 12,
+ax_anim 2, 0, 184, 0, -10, 0, -10,
+ax_anim 2, 0, 184, 0, 10, 0, 10,
+ax_anim 2, 0, 184, 0, -6, 0, -6,
+ax_anim 2, 0, 184, 0, 6, 0, 6,
+ax_anim 2, 0, 184, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_10_8:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 3, 0, 185, -13, -13, -13, -13,
+ax_anim 3, 0, 185, 13, 13, 13, 13,
+ax_anim 2, 0, 185, -12, -12, -12, -12,
+ax_anim 3, 0, 185, 12, 12, 12, 12,
+ax_anim 2, 0, 185, -10, -10, -10, -10,
+ax_anim 2, 0, 185, 10, 10, 10, 10,
+ax_anim 2, 0, 185, -6, -6, -6, -6,
+ax_anim 2, 0, 185, 6, 6, 6, 6,
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_11_1:
+ax_anim 2, 0, 186, 0, 0, 0, 0,
+ax_anim 1, 0, 188, 0, -10, 0, 0,
+ax_anim 2, 0, 188, 0, -16, 0, 0,
+ax_anim 3, 0, 188, 0, -20, 0, 0,
+ax_anim 4, 0, 188, 0, -22, 0, 0,
+ax_anim 4, 0, 187, 0, -21, 0, 0,
+ax_anim 3, 0, 187, 0, -20, 0, 0,
+ax_anim 2, 0, 187, 0, -18, 0, 0,
+ax_anim 1, 0, 187, 0, -12, 0, 0,
+ax_anim 2, 2, 186, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_11_2:
+ax_anim 2, 0, 189, 0, 0, 0, 0,
+ax_anim 1, 0, 191, 0, -10, 0, 0,
+ax_anim 2, 0, 191, 0, -16, 0, 0,
+ax_anim 3, 0, 191, 0, -20, 0, 0,
+ax_anim 4, 0, 191, 0, -22, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -21, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -12, 0, 0,
+ax_anim 2, 2, 189, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_11_3:
+ax_anim 2, 0, 192, 0, 0, 0, 0,
+ax_anim 1, 0, 194, 0, -10, 0, 0,
+ax_anim 2, 0, 194, 0, -16, 0, 0,
+ax_anim 3, 0, 194, 0, -20, 0, 0,
+ax_anim 4, 0, 194, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -21, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -12, 0, 0,
+ax_anim 2, 2, 192, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_11_4:
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 1, 0, 197, 0, -10, 0, 0,
+ax_anim 2, 0, 197, 0, -16, 0, 0,
+ax_anim 3, 0, 197, 0, -20, 0, 0,
+ax_anim 4, 0, 197, 0, -21, 0, 0,
+ax_anim 4, 0, 196, 0, -22, 0, 0,
+ax_anim 3, 0, 196, 0, -21, 0, 0,
+ax_anim 2, 0, 196, 0, -17, 0, 0,
+ax_anim 1, 0, 196, 0, -11, 0, 0,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_11_5:
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 1, 0, 200, 0, -10, 0, 0,
+ax_anim 2, 0, 200, 0, -16, 0, 0,
+ax_anim 3, 0, 200, 0, -20, 0, 0,
+ax_anim 4, 0, 200, 0, -21, 0, 0,
+ax_anim 4, 0, 199, 0, -23, 0, 0,
+ax_anim 3, 0, 199, 0, -22, 0, 0,
+ax_anim 2, 0, 199, 0, -18, 0, 0,
+ax_anim 1, 0, 199, 0, -12, 0, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_11_6:
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 1, 0, 203, 0, -10, 0, 0,
+ax_anim 2, 0, 203, 0, -16, 0, 0,
+ax_anim 3, 0, 203, 0, -20, 0, 0,
+ax_anim 4, 0, 203, 0, -21, 0, 0,
+ax_anim 4, 0, 202, 0, -22, 0, 0,
+ax_anim 3, 0, 202, 0, -21, 0, 0,
+ax_anim 2, 0, 202, 0, -17, 0, 0,
+ax_anim 1, 0, 202, 0, -11, 0, 0,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_11_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 1, 0, 206, 0, -10, 0, 0,
+ax_anim 2, 0, 206, 0, -16, 0, 0,
+ax_anim 3, 0, 206, 0, -20, 0, 0,
+ax_anim 4, 0, 206, 0, -21, 0, 0,
+ax_anim 4, 0, 205, 0, -23, 0, 0,
+ax_anim 3, 0, 205, 0, -21, 0, 0,
+ax_anim 2, 0, 205, 0, -18, 0, 0,
+ax_anim 1, 0, 205, 0, -12, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_11_8:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 1, 0, 209, 0, -10, 0, 0,
+ax_anim 2, 0, 209, 0, -16, 0, 0,
+ax_anim 3, 0, 209, 0, -20, 0, 0,
+ax_anim 4, 0, 209, 0, -22, 0, 0,
+ax_anim 4, 0, 208, 0, -23, 0, 0,
+ax_anim 3, 0, 208, 0, -22, 0, 0,
+ax_anim 2, 0, 208, 0, -18, 0, 0,
+ax_anim 1, 0, 208, 0, -12, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_12_1:
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 2, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 0, 210, 0, 0, 0, 0,
+ax_anim 2, 0, 210, 1, 0, 1, 0,
+ax_anim 2, 1, 210, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_12_2:
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 2, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 0, 217, 0, 0, 0, 0,
+ax_anim 2, 0, 217, 1, -1, 1, -1,
+ax_anim 2, 1, 217, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_12_3:
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 2, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 0, 216, 0, 0, 0, 0,
+ax_anim 2, 0, 216, 0, -1, 0, -1,
+ax_anim 2, 1, 216, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_12_4:
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 2, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 0, 215, 0, 0, 0, 0,
+ax_anim 2, 0, 215, -1, -1, -1, -1,
+ax_anim 2, 1, 215, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_12_5:
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 2, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 0, 214, 0, 0, 0, 0,
+ax_anim 2, 0, 214, 1, 0, 1, 0,
+ax_anim 2, 1, 214, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_12_6:
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 2, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 0, 213, 0, 0, 0, 0,
+ax_anim 2, 0, 213, 1, -1, 1, -1,
+ax_anim 2, 1, 213, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_12_7:
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 2, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 0, 212, 0, 0, 0, 0,
+ax_anim 2, 0, 212, 0, -1, 0, -1,
+ax_anim 2, 1, 212, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_12_8:
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 2, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 0, 211, 0, 0, 0, 0,
+ax_anim 2, 0, 211, -1, -1, -1, -1,
+ax_anim 2, 1, 211, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZigzagoonAnims_13_1:
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 2, 218, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_13_2:
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 2, 225, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_13_3:
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 2, 224, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_13_4:
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 2, 223, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_13_5:
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 2, 222, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_13_6:
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 2, 221, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_13_7:
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 2, 220, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonAnims_13_8:
+ax_anim 2, 0, 219, 0, 0, 0, 0,
+ax_anim 2, 0, 220, 0, 0, 0, 0,
+ax_anim 2, 0, 221, 0, 0, 0, 0,
+ax_anim 2, 0, 222, 0, 0, 0, 0,
+ax_anim 2, 0, 223, 0, 0, 0, 0,
+ax_anim 2, 0, 224, 0, 0, 0, 0,
+ax_anim 2, 0, 225, 0, 0, 0, 0,
+ax_anim 2, 0, 218, 0, 0, 0, 0,
+ax_anim 2, 2, 219, 0, 0, 0, 0,
+ax_anim_terminator
+sZigzagoonGfx1:
+.incbin "baserom.gba", 0x10CEAEC, 0x200
+sZigzagoonSprites1:
+ax_sprite sZigzagoonGfx1, 0x200
+ax_sprite_terminator
+sZigzagoonGfx2:
+.incbin "baserom.gba", 0x10CECFC, 0x200
+sZigzagoonSprites2:
+ax_sprite sZigzagoonGfx2, 0x200
+ax_sprite_terminator
+sZigzagoonGfx3:
+.incbin "baserom.gba", 0x10CEF0C, 0x200
+sZigzagoonSprites3:
+ax_sprite sZigzagoonGfx3, 0x200
+ax_sprite_terminator
+sZigzagoonGfx4:
+.incbin "baserom.gba", 0x10CF11C, 0x200
+sZigzagoonSprites4:
+ax_sprite sZigzagoonGfx4, 0x200
+ax_sprite_terminator
+sZigzagoonGfx5:
+.incbin "baserom.gba", 0x10CF32C, 0x200
+sZigzagoonSprites5:
+ax_sprite sZigzagoonGfx5, 0x200
+ax_sprite_terminator
+sZigzagoonGfx6:
+.incbin "baserom.gba", 0x10CF53C, 0x200
+sZigzagoonSprites6:
+ax_sprite sZigzagoonGfx6, 0x200
+ax_sprite_terminator
+sZigzagoonGfx7:
+.incbin "baserom.gba", 0x10CF74C, 0x100
+sZigzagoonSprites7:
+ax_sprite sZigzagoonGfx7, 0x100
+ax_sprite_terminator
+sZigzagoonGfx8:
+.incbin "baserom.gba", 0x10CF85C, 0x200
+sZigzagoonSprites8:
+ax_sprite sZigzagoonGfx8, 0x200
+ax_sprite_terminator
+sZigzagoonGfx9:
+.incbin "baserom.gba", 0x10CFA6C, 0x200
+sZigzagoonSprites9:
+ax_sprite sZigzagoonGfx9, 0x200
+ax_sprite_terminator
+sZigzagoonGfx10:
+.incbin "baserom.gba", 0x10CFC7C, 0x200
+sZigzagoonSprites10:
+ax_sprite sZigzagoonGfx10, 0x200
+ax_sprite_terminator
+sZigzagoonGfx11:
+.incbin "baserom.gba", 0x10CFE8C, 0x200
+sZigzagoonSprites11:
+ax_sprite sZigzagoonGfx11, 0x200
+ax_sprite_terminator
+sZigzagoonGfx12:
+.incbin "baserom.gba", 0x10D009C, 0x200
+sZigzagoonSprites12:
+ax_sprite sZigzagoonGfx12, 0x200
+ax_sprite_terminator
+sZigzagoonGfx13:
+.incbin "baserom.gba", 0x10D02AC, 0x200
+sZigzagoonSprites13:
+ax_sprite sZigzagoonGfx13, 0x200
+ax_sprite_terminator
+sZigzagoonGfx14:
+.incbin "baserom.gba", 0x10D04BC, 0x200
+sZigzagoonSprites14:
+ax_sprite sZigzagoonGfx14, 0x200
+ax_sprite_terminator
+sZigzagoonGfx15:
+.incbin "baserom.gba", 0x10D06CC, 0x100
+sZigzagoonSprites15:
+ax_sprite sZigzagoonGfx15, 0x100
+ax_sprite_terminator
+sZigzagoonGfx16:
+.incbin "baserom.gba", 0x10D07DC, 0x40
+sZigzagoonGfx16_1:
+.incbin "baserom.gba", 0x10D081C, 0x60
+sZigzagoonGfx16_2:
+.incbin "baserom.gba", 0x10D087C, 0x40
+sZigzagoonGfx16_3:
+.incbin "baserom.gba", 0x10D08BC, 0x40
+sZigzagoonSprites16:
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx16, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx16_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx16_2, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx16_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZigzagoonGfx17:
+.incbin "baserom.gba", 0x10D094C, 0x40
+sZigzagoonGfx17_1:
+.incbin "baserom.gba", 0x10D098C, 0x40
+sZigzagoonGfx17_2:
+.incbin "baserom.gba", 0x10D09CC, 0x60
+sZigzagoonGfx17_3:
+.incbin "baserom.gba", 0x10D0A2C, 0x40
+sZigzagoonSprites17:
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx17, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx17_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx17_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx17_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZigzagoonGfx18:
+.incbin "baserom.gba", 0x10D0ABC, 0x140
+sZigzagoonGfx18_1:
+.incbin "baserom.gba", 0x10D0BFC, 0x20
+sZigzagoonSprites18:
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx18, 0x140
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx18_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sZigzagoonGfx19:
+.incbin "baserom.gba", 0x10D0C4C, 0x20
+sZigzagoonGfx19_1:
+.incbin "baserom.gba", 0x10D0C6C, 0xE0
+sZigzagoonGfx19_2:
+.incbin "baserom.gba", 0x10D0D4C, 0x20
+sZigzagoonSprites19:
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx19, 0x20
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx19_1, 0xe0
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx19_2, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sZigzagoonGfx20:
+.incbin "baserom.gba", 0x10D0DAC, 0xE0
+sZigzagoonGfx20_1:
+.incbin "baserom.gba", 0x10D0E8C, 0x40
+sZigzagoonSprites20:
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx20, 0xe0
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx20_1, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx21:
+.incbin "baserom.gba", 0x10D0EFC, 0x180
+sZigzagoonSprites21:
+ax_sprite sZigzagoonGfx21, 0x180
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sZigzagoonGfx22:
+.incbin "baserom.gba", 0x10D1094, 0x160
+sZigzagoonSprites22:
+ax_sprite sZigzagoonGfx22, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx23:
+.incbin "baserom.gba", 0x10D120C, 0x60
+sZigzagoonGfx23_1:
+.incbin "baserom.gba", 0x10D126C, 0x60
+sZigzagoonGfx23_2:
+.incbin "baserom.gba", 0x10D12CC, 0x60
+sZigzagoonSprites23:
+ax_sprite sZigzagoonGfx23, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx23_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx23_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx24:
+.incbin "baserom.gba", 0x10D1364, 0x40
+sZigzagoonGfx24_1:
+.incbin "baserom.gba", 0x10D13A4, 0x60
+sZigzagoonGfx24_2:
+.incbin "baserom.gba", 0x10D1404, 0x40
+sZigzagoonSprites24:
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx24, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx24_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx24_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx25:
+.incbin "baserom.gba", 0x10D1484, 0x60
+sZigzagoonGfx25_1:
+.incbin "baserom.gba", 0x10D14E4, 0x60
+sZigzagoonGfx25_2:
+.incbin "baserom.gba", 0x10D1544, 0x40
+sZigzagoonSprites25:
+ax_sprite sZigzagoonGfx25, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx25_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx25_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx26:
+.incbin "baserom.gba", 0x10D15BC, 0x20
+sZigzagoonGfx26_1:
+.incbin "baserom.gba", 0x10D15DC, 0x60
+sZigzagoonGfx26_2:
+.incbin "baserom.gba", 0x10D163C, 0x60
+sZigzagoonGfx26_3:
+.incbin "baserom.gba", 0x10D169C, 0x40
+sZigzagoonSprites26:
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx26, 0x20
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx26_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx26_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx26_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZigzagoonGfx27:
+.incbin "baserom.gba", 0x10D172C, 0x20
+sZigzagoonGfx27_1:
+.incbin "baserom.gba", 0x10D174C, 0x40
+sZigzagoonGfx27_2:
+.incbin "baserom.gba", 0x10D178C, 0x60
+sZigzagoonGfx27_3:
+.incbin "baserom.gba", 0x10D17EC, 0x40
+sZigzagoonSprites27:
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx27, 0x20
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx27_1, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx27_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx27_3, 0x40
+ax_sprite 0, 0x20
+ax_sprite_terminator
+sZigzagoonGfx28:
+.incbin "baserom.gba", 0x10D187C, 0x40
+sZigzagoonGfx28_1:
+.incbin "baserom.gba", 0x10D18BC, 0x60
+sZigzagoonGfx28_2:
+.incbin "baserom.gba", 0x10D191C, 0x60
+sZigzagoonGfx28_3:
+.incbin "baserom.gba", 0x10D197C, 0x20
+sZigzagoonSprites28:
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx28, 0x40
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx28_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx28_2, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx28_3, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sZigzagoonGfx29:
+.incbin "baserom.gba", 0x10D19EC, 0x100
+sZigzagoonGfx29_1:
+.incbin "baserom.gba", 0x10D1AEC, 0x20
+sZigzagoonSprites29:
+ax_sprite 0, 0x80
+ax_sprite sZigzagoonGfx29, 0x100
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx29_1, 0x20
+ax_sprite 0, 0x40
+ax_sprite_terminator
+sZigzagoonGfx30:
+.incbin "baserom.gba", 0x10D1B3C, 0x160
+sZigzagoonSprites30:
+ax_sprite sZigzagoonGfx30, 0x160
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx31:
+.incbin "baserom.gba", 0x10D1CB4, 0x60
+sZigzagoonGfx31_1:
+.incbin "baserom.gba", 0x10D1D14, 0x100
+sZigzagoonSprites31:
+ax_sprite sZigzagoonGfx31, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx31_1, 0x100
+ax_sprite 0, 0x80
+ax_sprite_terminator
+sZigzagoonGfx32:
+.incbin "baserom.gba", 0x10D1E3C, 0x60
+sZigzagoonGfx32_1:
+.incbin "baserom.gba", 0x10D1E9C, 0x60
+sZigzagoonGfx32_2:
+.incbin "baserom.gba", 0x10D1EFC, 0x60
+sZigzagoonSprites32:
+ax_sprite sZigzagoonGfx32, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx32_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx32_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx33:
+.incbin "baserom.gba", 0x10D1F94, 0x60
+sZigzagoonGfx33_1:
+.incbin "baserom.gba", 0x10D1FF4, 0x60
+sZigzagoonGfx33_2:
+.incbin "baserom.gba", 0x10D2054, 0x60
+sZigzagoonSprites33:
+ax_sprite sZigzagoonGfx33, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx33_1, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx33_2, 0x60
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx34:
+.incbin "baserom.gba", 0x10D20EC, 0x60
+sZigzagoonGfx34_1:
+.incbin "baserom.gba", 0x10D214C, 0x60
+sZigzagoonGfx34_2:
+.incbin "baserom.gba", 0x10D21AC, 0x40
+sZigzagoonSprites34:
+ax_sprite sZigzagoonGfx34, 0x60
+ax_sprite 0, 0x20
+ax_sprite sZigzagoonGfx34_1, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx34_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx35:
+.incbin "baserom.gba", 0x10D2224, 0x60
+sZigzagoonGfx35_1:
+.incbin "baserom.gba", 0x10D2284, 0x40
+sZigzagoonGfx35_2:
+.incbin "baserom.gba", 0x10D22C4, 0x40
+sZigzagoonSprites35:
+ax_sprite sZigzagoonGfx35, 0x60
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx35_1, 0x40
+ax_sprite 0, 0x40
+ax_sprite sZigzagoonGfx35_2, 0x40
+ax_sprite 0, 0xa0
+ax_sprite_terminator
+sZigzagoonGfx36:
+.incbin "baserom.gba", 0x10D233C, 0x200
+sZigzagoonSprites36:
+ax_sprite sZigzagoonGfx36, 0x200
+ax_sprite_terminator
+sZigzagoonGfx37:
+.incbin "baserom.gba", 0x10D254C, 0x200
+sZigzagoonSprites37:
+ax_sprite sZigzagoonGfx37, 0x200
+ax_sprite_terminator
+sZigzagoonGfx38:
+.incbin "baserom.gba", 0x10D275C, 0x200
+sZigzagoonSprites38:
+ax_sprite sZigzagoonGfx38, 0x200
+ax_sprite_terminator
+sZigzagoonGfx39:
+.incbin "baserom.gba", 0x10D296C, 0x200
+sZigzagoonSprites39:
+ax_sprite sZigzagoonGfx39, 0x200
+ax_sprite_terminator
+sZigzagoonGfx40:
+.incbin "baserom.gba", 0x10D2B7C, 0x200
+sZigzagoonSprites40:
+ax_sprite sZigzagoonGfx40, 0x200
+ax_sprite_terminator
+sZigzagoonGfx41:
+.incbin "baserom.gba", 0x10D2D8C, 0x200
+sZigzagoonSprites41:
+ax_sprite sZigzagoonGfx41, 0x200
+ax_sprite_terminator
+sZigzagoonGfx42:
+.incbin "baserom.gba", 0x10D2F9C, 0x200
+sZigzagoonSprites42:
+ax_sprite sZigzagoonGfx42, 0x200
+ax_sprite_terminator
+sAxPosesZigzagoon:
+.4byte sZigzagoonPose1
+.4byte sZigzagoonPose2
+.4byte sZigzagoonPose3
+.4byte sZigzagoonPose4
+.4byte sZigzagoonPose5
+.4byte sZigzagoonPose6
+.4byte sZigzagoonPose7
+.4byte sZigzagoonPose8
+.4byte sZigzagoonPose9
+.4byte sZigzagoonPose10
+.4byte sZigzagoonPose11
+.4byte sZigzagoonPose12
+.4byte sZigzagoonPose13
+.4byte sZigzagoonPose14
+.4byte sZigzagoonPose15
+.4byte sZigzagoonPose16
+.4byte sZigzagoonPose17
+.4byte sZigzagoonPose18
+.4byte sZigzagoonPose19
+.4byte sZigzagoonPose20
+.4byte sZigzagoonPose21
+.4byte sZigzagoonPose22
+.4byte sZigzagoonPose23
+.4byte sZigzagoonPose24
+.4byte sZigzagoonPose25
+.4byte sZigzagoonPose26
+.4byte sZigzagoonPose27
+.4byte sZigzagoonPose28
+.4byte sZigzagoonPose29
+.4byte sZigzagoonPose30
+.4byte sZigzagoonPose31
+.4byte sZigzagoonPose32
+.4byte sZigzagoonPose33
+.4byte sZigzagoonPose34
+.4byte sZigzagoonPose35
+.4byte sZigzagoonPose36
+.4byte sZigzagoonPose37
+.4byte sZigzagoonPose38
+.4byte sZigzagoonPose39
+.4byte sZigzagoonPose40
+.4byte sZigzagoonPose41
+.4byte sZigzagoonPose42
+.4byte sZigzagoonPose43
+.4byte sZigzagoonPose44
+.4byte sZigzagoonPose45
+.4byte sZigzagoonPose46
+.4byte sZigzagoonPose47
+.4byte sZigzagoonPose48
+.4byte sZigzagoonPose49
+.4byte sZigzagoonPose50
+.4byte sZigzagoonPose51
+.4byte sZigzagoonPose52
+.4byte sZigzagoonPose53
+.4byte sZigzagoonPose54
+.4byte sZigzagoonPose55
+.4byte sZigzagoonPose56
+.4byte sZigzagoonPose57
+.4byte sZigzagoonPose58
+.4byte sZigzagoonPose59
+.4byte sZigzagoonPose60
+.4byte sZigzagoonPose61
+.4byte sZigzagoonPose62
+.4byte sZigzagoonPose63
+.4byte sZigzagoonPose64
+.4byte sZigzagoonPose65
+.4byte sZigzagoonPose66
+.4byte sZigzagoonPose67
+.4byte sZigzagoonPose68
+.4byte sZigzagoonPose69
+.4byte sZigzagoonPose70
+.4byte sZigzagoonPose71
+.4byte sZigzagoonPose72
+.4byte sZigzagoonPose73
+.4byte sZigzagoonPose74
+.4byte sZigzagoonPose75
+.4byte sZigzagoonPose76
+.4byte sZigzagoonPose77
+.4byte sZigzagoonPose78
+.4byte sZigzagoonPose79
+.4byte sZigzagoonPose80
+.4byte sZigzagoonPose81
+.4byte sZigzagoonPose82
+.4byte sZigzagoonPose83
+.4byte sZigzagoonPose84
+.4byte sZigzagoonPose85
+.4byte sZigzagoonPose86
+.4byte sZigzagoonPose87
+.4byte sZigzagoonPose88
+.4byte sZigzagoonPose89
+.4byte sZigzagoonPose90
+.4byte sZigzagoonPose91
+.4byte sZigzagoonPose92
+.4byte sZigzagoonPose93
+.4byte sZigzagoonPose94
+.4byte sZigzagoonPose95
+.4byte sZigzagoonPose96
+.4byte sZigzagoonPose97
+.4byte sZigzagoonPose98
+.4byte sZigzagoonPose99
+.4byte sZigzagoonPose100
+.4byte sZigzagoonPose101
+.4byte sZigzagoonPose102
+.4byte sZigzagoonPose103
+.4byte sZigzagoonPose104
+.4byte sZigzagoonPose105
+.4byte sZigzagoonPose106
+.4byte sZigzagoonPose107
+.4byte sZigzagoonPose108
+.4byte sZigzagoonPose109
+.4byte sZigzagoonPose110
+.4byte sZigzagoonPose111
+.4byte sZigzagoonPose112
+.4byte sZigzagoonPose113
+.4byte sZigzagoonPose114
+.4byte sZigzagoonPose115
+.4byte sZigzagoonPose116
+.4byte sZigzagoonPose117
+.4byte sZigzagoonPose118
+.4byte sZigzagoonPose119
+.4byte sZigzagoonPose120
+.4byte sZigzagoonPose121
+.4byte sZigzagoonPose122
+.4byte sZigzagoonPose123
+.4byte sZigzagoonPose124
+.4byte sZigzagoonPose125
+.4byte sZigzagoonPose126
+.4byte sZigzagoonPose127
+.4byte sZigzagoonPose128
+.4byte sZigzagoonPose129
+.4byte sZigzagoonPose130
+.4byte sZigzagoonPose131
+.4byte sZigzagoonPose132
+.4byte sZigzagoonPose133
+.4byte sZigzagoonPose134
+.4byte sZigzagoonPose135
+.4byte sZigzagoonPose136
+.4byte sZigzagoonPose137
+.4byte sZigzagoonPose138
+.4byte sZigzagoonPose139
+.4byte sZigzagoonPose140
+.4byte sZigzagoonPose141
+.4byte sZigzagoonPose142
+.4byte sZigzagoonPose143
+.4byte sZigzagoonPose144
+.4byte sZigzagoonPose145
+.4byte sZigzagoonPose146
+.4byte sZigzagoonPose147
+.4byte sZigzagoonPose148
+.4byte sZigzagoonPose149
+.4byte sZigzagoonPose150
+.4byte sZigzagoonPose151
+.4byte sZigzagoonPose152
+.4byte sZigzagoonPose153
+.4byte sZigzagoonPose154
+.4byte sZigzagoonPose155
+.4byte sZigzagoonPose156
+.4byte sZigzagoonPose157
+.4byte sZigzagoonPose158
+.4byte sZigzagoonPose159
+.4byte sZigzagoonPose160
+.4byte sZigzagoonPose161
+.4byte sZigzagoonPose162
+.4byte sZigzagoonPose163
+.4byte sZigzagoonPose164
+.4byte sZigzagoonPose165
+.4byte sZigzagoonPose166
+.4byte sZigzagoonPose167
+.4byte sZigzagoonPose168
+.4byte sZigzagoonPose169
+.4byte sZigzagoonPose170
+.4byte sZigzagoonPose171
+.4byte sZigzagoonPose172
+.4byte sZigzagoonPose173
+.4byte sZigzagoonPose174
+.4byte sZigzagoonPose175
+.4byte sZigzagoonPose176
+.4byte sZigzagoonPose177
+.4byte sZigzagoonPose178
+.4byte sZigzagoonPose179
+.4byte sZigzagoonPose180
+.4byte sZigzagoonPose181
+.4byte sZigzagoonPose182
+.4byte sZigzagoonPose183
+.4byte sZigzagoonPose184
+.4byte sZigzagoonPose185
+.4byte sZigzagoonPose186
+.4byte sZigzagoonPose187
+.4byte sZigzagoonPose188
+.4byte sZigzagoonPose189
+.4byte sZigzagoonPose190
+.4byte sZigzagoonPose191
+.4byte sZigzagoonPose192
+.4byte sZigzagoonPose193
+.4byte sZigzagoonPose194
+.4byte sZigzagoonPose195
+.4byte sZigzagoonPose196
+.4byte sZigzagoonPose197
+.4byte sZigzagoonPose198
+.4byte sZigzagoonPose199
+.4byte sZigzagoonPose200
+.4byte sZigzagoonPose201
+.4byte sZigzagoonPose202
+.4byte sZigzagoonPose203
+.4byte sZigzagoonPose204
+.4byte sZigzagoonPose205
+.4byte sZigzagoonPose206
+.4byte sZigzagoonPose207
+.4byte sZigzagoonPose208
+.4byte sZigzagoonPose209
+.4byte sZigzagoonPose210
+.4byte sZigzagoonPose211
+.4byte sZigzagoonPose212
+.4byte sZigzagoonPose213
+.4byte sZigzagoonPose214
+.4byte sZigzagoonPose215
+.4byte sZigzagoonPose216
+.4byte sZigzagoonPose217
+.4byte sZigzagoonPose218
+.4byte sZigzagoonPose219
+.4byte sZigzagoonPose220
+.4byte sZigzagoonPose221
+.4byte sZigzagoonPose222
+.4byte sZigzagoonPose223
+.4byte sZigzagoonPose224
+.4byte sZigzagoonPose225
+.4byte sZigzagoonPose226
+sAxPositionsZigzagoon:
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,   -4, 	   3,   -4, 	  -1,   -8
+.2byte   -1,    3, 	  -4,    4, 	   2,    4, 	  -1,   -5
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+.2byte    8,   -7, 	  10,   -6, 	   4,   -3, 	  -1,   -9
+.2byte    8,    2, 	   8,    3, 	   3,    5, 	   1,   -5
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte   10,   -8, 	   8,  -10, 	   8,   -6, 	  -1,   -8
+.2byte   10,   -2, 	   9,   -2, 	   7,    1, 	   1,   -7
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte   10,  -11, 	   3,  -14, 	   9,   -8, 	  -1,   -9
+.2byte   10,   -6, 	   5,   -8, 	   7,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -13, 	   3,  -11, 	  -5,  -11, 	  -1,   -8
+.2byte   -1,   -7, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte  -10,   -6, 	  -3,   -9, 	  -8,   -2, 	   0,   -4
+.2byte  -10,  -11, 	  -3,  -14, 	  -9,   -8, 	   1,   -9
+.2byte  -12,   -6, 	  -7,   -8, 	  -9,   -3, 	  -1,   -8
+.2byte  -10,   -2, 	  -8,   -2, 	  -7,    1, 	  -1,   -5
+.2byte  -12,   -8, 	 -10,  -10, 	 -10,   -6, 	  -1,   -8
+.2byte  -12,   -2, 	 -11,   -2, 	  -9,    1, 	  -3,   -7
+.2byte   -8,    0, 	  -9,    1, 	  -4,    3, 	   0,   -7
+.2byte  -10,   -7, 	 -12,   -6, 	  -6,   -3, 	  -1,   -9
+.2byte  -10,    2, 	 -10,    3, 	  -5,    5, 	  -3,   -5
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,   -4, 	   3,   -4, 	  -1,   -8
+.2byte   -1,    3, 	  -4,    4, 	   2,    4, 	  -1,   -5
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+.2byte    8,   -7, 	  10,   -6, 	   4,   -3, 	  -1,   -9
+.2byte    8,    2, 	   8,    3, 	   3,    5, 	   1,   -5
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte   10,   -8, 	   8,  -10, 	   8,   -6, 	  -1,   -8
+.2byte   10,   -2, 	   9,   -2, 	   7,    1, 	   1,   -7
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte   10,  -11, 	   3,  -14, 	   9,   -8, 	  -1,   -9
+.2byte   10,   -6, 	   5,   -8, 	   7,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -13, 	   3,  -11, 	  -5,  -11, 	  -1,   -8
+.2byte   -1,   -7, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte  -10,   -6, 	  -3,   -9, 	  -8,   -2, 	   0,   -4
+.2byte  -10,  -11, 	  -3,  -14, 	  -9,   -8, 	   1,   -9
+.2byte  -12,   -6, 	  -7,   -8, 	  -9,   -3, 	  -1,   -8
+.2byte  -10,   -2, 	  -8,   -2, 	  -7,    1, 	  -1,   -5
+.2byte  -12,   -8, 	 -10,  -10, 	 -10,   -6, 	  -1,   -8
+.2byte  -12,   -2, 	 -11,   -2, 	  -9,    1, 	  -3,   -7
+.2byte   -8,    0, 	  -9,    1, 	  -4,    3, 	   0,   -7
+.2byte  -10,   -7, 	 -12,   -6, 	  -6,   -3, 	  -1,   -9
+.2byte  -10,    2, 	 -10,    3, 	  -5,    5, 	  -3,   -5
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,   -4, 	   3,   -4, 	  -1,   -8
+.2byte   -1,    3, 	  -4,    4, 	   2,    4, 	  -1,   -5
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+.2byte    8,   -7, 	  10,   -6, 	   4,   -3, 	  -1,   -9
+.2byte    8,    2, 	   8,    3, 	   3,    5, 	   1,   -5
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte   10,   -8, 	   8,  -10, 	   8,   -6, 	  -1,   -8
+.2byte   10,   -2, 	   9,   -2, 	   7,    1, 	   1,   -7
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte   10,  -11, 	   3,  -14, 	   9,   -8, 	  -1,   -9
+.2byte   10,   -6, 	   5,   -8, 	   7,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -13, 	   3,  -11, 	  -5,  -11, 	  -1,   -8
+.2byte   -1,   -7, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte  -10,   -6, 	  -3,   -9, 	  -8,   -2, 	   0,   -4
+.2byte  -10,  -11, 	  -3,  -14, 	  -9,   -8, 	   1,   -9
+.2byte  -12,   -6, 	  -7,   -8, 	  -9,   -3, 	  -1,   -8
+.2byte  -10,   -2, 	  -8,   -2, 	  -7,    1, 	  -1,   -5
+.2byte  -12,   -8, 	 -10,  -10, 	 -10,   -6, 	  -1,   -8
+.2byte  -12,   -2, 	 -11,   -2, 	  -9,    1, 	  -3,   -7
+.2byte   -8,    0, 	  -9,    1, 	  -4,    3, 	   0,   -7
+.2byte  -10,   -7, 	 -12,   -6, 	  -6,   -3, 	  -1,   -9
+.2byte  -10,    2, 	 -10,    3, 	  -5,    5, 	  -3,   -5
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -1,    1, 	  -3,    3, 	   1,    3, 	  -1,   -7
+.2byte   -1,    4, 	  -6,    2, 	   4,    2, 	  -1,   -4
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+.2byte    4,    0, 	   7,    1, 	   2,    3, 	  -2,   -8
+.2byte   10,   -2, 	   6,    1, 	   1,    3, 	   0,   -7
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte    6,   -1, 	   6,   -2, 	   5,    1, 	  -1,   -7
+.2byte   14,   -7, 	   6,   -2, 	   5,    1, 	   2,   -5
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte    0,   -4, 	  -3,   -4, 	   3,    0, 	  -3,   -6
+.2byte    8,  -12, 	  -4,   -3, 	   3,    0, 	   0,   -7
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,   -3, 	   3,   -2, 	  -5,   -2, 	  -1,   -7
+.2byte   -1,  -14, 	   3,   -2, 	  -5,   -2, 	  -1,  -10
+.2byte  -10,   -6, 	  -3,   -9, 	  -8,   -2, 	   0,   -4
+.2byte   -2,   -4, 	   1,   -4, 	  -5,    0, 	   1,   -6
+.2byte  -10,  -12, 	   2,   -3, 	  -5,    0, 	  -2,   -7
+.2byte  -10,   -2, 	  -8,   -2, 	  -7,    1, 	  -1,   -5
+.2byte   -8,   -1, 	  -8,   -2, 	  -7,    1, 	  -1,   -7
+.2byte  -16,   -7, 	  -8,   -2, 	  -7,    1, 	  -4,   -5
+.2byte   -8,    0, 	  -9,    1, 	  -4,    3, 	   0,   -7
+.2byte   -6,    0, 	  -9,    1, 	  -4,    3, 	   0,   -8
+.2byte  -12,   -2, 	  -8,    1, 	  -3,    3, 	  -2,   -7
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -1,    1, 	  -3,    3, 	   1,    3, 	  -1,   -7
+.2byte   -1,    4, 	  -6,    2, 	   4,    2, 	  -1,   -4
+.2byte   -1,    4, 	  -6,    2, 	   4,    2, 	  -1,   -2
+.2byte   -1,    4, 	  -6,    2, 	   4,    2, 	  -1,   -2
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+.2byte    4,    0, 	   7,    1, 	   2,    3, 	  -2,   -8
+.2byte   10,   -2, 	   6,    1, 	   1,    3, 	   0,   -7
+.2byte   10,   -2, 	   7,    1, 	   1,    3, 	   2,   -6
+.2byte   10,   -2, 	   6,    1, 	   1,    3, 	   0,   -6
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte    6,   -1, 	   6,   -2, 	   5,    1, 	  -1,   -7
+.2byte   14,   -7, 	   6,   -2, 	   5,    1, 	   2,   -5
+.2byte   14,   -7, 	   6,   -2, 	   5,    1, 	   3,   -5
+.2byte   14,   -7, 	   6,   -2, 	   5,    1, 	   3,   -5
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte    3,   -4, 	   0,   -4, 	   6,    0, 	   0,   -6
+.2byte    8,  -11, 	  -4,   -2, 	   3,    1, 	   0,   -6
+.2byte    8,  -11, 	  -4,   -2, 	   3,    1, 	   1,   -6
+.2byte    8,  -10, 	  -4,   -2, 	   3,    1, 	   0,   -6
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,   -3, 	   3,   -2, 	  -5,   -2, 	  -1,   -7
+.2byte   -1,  -14, 	   3,   -2, 	  -5,   -2, 	  -1,  -10
+.2byte   -1,  -13, 	   3,   -2, 	  -5,   -2, 	  -1,  -10
+.2byte   -1,  -13, 	   3,   -2, 	  -5,   -2, 	  -1,  -10
+.2byte  -10,   -6, 	  -3,   -9, 	  -8,   -2, 	   0,   -4
+.2byte   -5,   -4, 	  -2,   -4, 	  -8,    0, 	  -2,   -6
+.2byte  -10,  -11, 	   2,   -2, 	  -5,    1, 	  -2,   -6
+.2byte  -10,  -11, 	   2,   -2, 	  -5,    1, 	  -3,   -6
+.2byte  -10,  -10, 	   2,   -2, 	  -5,    1, 	  -2,   -6
+.2byte  -10,   -2, 	  -8,   -2, 	  -7,    1, 	  -1,   -5
+.2byte   -8,   -1, 	  -8,   -2, 	  -7,    1, 	  -1,   -7
+.2byte  -16,   -7, 	  -8,   -2, 	  -7,    1, 	  -4,   -5
+.2byte  -16,   -7, 	  -8,   -2, 	  -7,    1, 	  -5,   -5
+.2byte  -16,   -7, 	  -8,   -2, 	  -7,    1, 	  -5,   -5
+.2byte   -8,    0, 	  -9,    1, 	  -4,    3, 	   0,   -7
+.2byte   -6,    0, 	  -9,    1, 	  -4,    3, 	   0,   -8
+.2byte  -12,   -2, 	  -8,    1, 	  -3,    3, 	  -2,   -7
+.2byte  -12,   -2, 	  -9,    1, 	  -3,    3, 	  -4,   -6
+.2byte  -12,   -2, 	  -8,    1, 	  -3,    3, 	  -2,   -6
+.2byte   -8,    1, 	 -10,    0, 	  -6,    3, 	   1,   -7
+.2byte   -8,    1, 	 -10,    0, 	  -6,    3, 	   1,   -6
+.2byte    0,  -13, 	  -3,   -8, 	   3,   -8, 	   0,  -10
+.2byte    2,  -18, 	   6,  -11, 	   0,   -9, 	  -2,   -9
+.2byte    2,  -19, 	   4,  -14, 	   5,  -11, 	  -1,   -7
+.2byte    1,  -19, 	  -2,  -15, 	   5,  -12, 	   0,   -6
+.2byte    0,  -18, 	   4,  -10, 	  -4,  -10, 	   0,   -7
+.2byte   -1,  -19, 	   2,  -15, 	  -5,  -12, 	   0,   -6
+.2byte   -3,  -19, 	  -5,  -14, 	  -6,  -11, 	   0,   -7
+.2byte   -3,  -18, 	  -7,  -11, 	  -1,   -9, 	   1,   -9
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -1,   -5, 	  -5,   -4, 	   3,   -4, 	  -1,   -8
+.2byte   -1,    3, 	  -4,    4, 	   2,    4, 	  -1,   -5
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+.2byte    8,   -7, 	  10,   -6, 	   4,   -3, 	  -1,   -9
+.2byte    8,    2, 	   8,    3, 	   3,    5, 	   1,   -5
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte   10,   -8, 	   8,  -10, 	   8,   -6, 	  -1,   -8
+.2byte   10,   -2, 	   9,   -2, 	   7,    1, 	   1,   -7
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte   10,  -11, 	   3,  -14, 	   9,   -8, 	  -1,   -9
+.2byte   10,   -6, 	   5,   -8, 	   7,   -3, 	  -1,   -8
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,  -13, 	   3,  -11, 	  -5,  -11, 	  -1,   -8
+.2byte   -1,   -7, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte  -10,   -6, 	  -3,   -9, 	  -8,   -2, 	   0,   -4
+.2byte  -10,  -11, 	  -3,  -14, 	  -9,   -8, 	   1,   -9
+.2byte  -12,   -6, 	  -7,   -8, 	  -9,   -3, 	  -1,   -8
+.2byte  -10,   -2, 	  -8,   -2, 	  -7,    1, 	  -1,   -5
+.2byte  -12,   -8, 	 -10,  -10, 	 -10,   -6, 	  -1,   -8
+.2byte  -12,   -2, 	 -11,   -2, 	  -9,    1, 	  -3,   -7
+.2byte   -8,    0, 	  -9,    1, 	  -4,    3, 	   0,   -7
+.2byte  -10,   -7, 	 -12,   -6, 	  -6,   -3, 	  -1,   -9
+.2byte  -10,    2, 	 -10,    3, 	  -5,    5, 	  -3,   -5
+.2byte   -1,    3, 	  -4,    4, 	   2,    4, 	  -1,   -5
+.2byte   -9,    1, 	  -9,    2, 	  -4,    4, 	  -2,   -6
+.2byte  -12,   -2, 	 -11,   -2, 	  -9,    1, 	  -3,   -7
+.2byte  -11,   -5, 	  -6,   -7, 	  -8,   -2, 	   0,   -7
+.2byte   -1,   -7, 	   3,   -4, 	  -5,   -4, 	  -1,   -6
+.2byte   10,   -5, 	   5,   -7, 	   7,   -2, 	  -1,   -7
+.2byte   10,   -2, 	   9,   -2, 	   7,    1, 	   1,   -7
+.2byte    8,    2, 	   8,    3, 	   3,    5, 	   1,   -5
+.2byte   -1,    1, 	  -6,   -1, 	   4,   -1, 	  -1,   -7
+.2byte    8,   -2, 	   4,    1, 	  -1,    3, 	  -2,   -7
+.2byte   11,   -7, 	   3,   -2, 	   2,    1, 	  -1,   -5
+.2byte    8,  -11, 	  -4,   -2, 	   3,    1, 	   0,   -6
+.2byte   -1,  -12, 	   3,    0, 	  -5,    0, 	  -1,   -8
+.2byte   -9,  -11, 	   3,   -2, 	  -4,    1, 	  -1,   -6
+.2byte  -11,   -7, 	  -3,   -2, 	  -2,    1, 	   1,   -5
+.2byte   -9,   -2, 	  -5,    1, 	   0,    3, 	   1,   -7
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -1,    1, 	  -3,    3, 	   1,    3, 	  -1,   -7
+.2byte   -1,    4, 	  -6,    2, 	   4,    2, 	  -1,   -4
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+.2byte    4,    1, 	   7,    2, 	   2,    4, 	  -2,   -7
+.2byte    7,   -2, 	   3,    1, 	  -2,    3, 	  -3,   -7
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte    7,    0, 	   7,   -1, 	   6,    2, 	   0,   -6
+.2byte   11,   -8, 	   3,   -3, 	   2,    0, 	  -1,   -6
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte    3,   -4, 	   0,   -4, 	   6,    0, 	   0,   -6
+.2byte    7,  -10, 	  -5,   -1, 	   2,    2, 	  -1,   -5
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte   -1,   -3, 	   3,   -2, 	  -5,   -2, 	  -1,   -7
+.2byte   -1,  -14, 	   3,   -2, 	  -5,   -2, 	  -1,  -10
+.2byte   -9,   -6, 	  -2,   -9, 	  -7,   -2, 	   1,   -4
+.2byte   -4,   -4, 	  -1,   -4, 	  -7,    0, 	  -1,   -6
+.2byte   -8,  -10, 	   4,   -1, 	  -3,    2, 	   0,   -5
+.2byte   -9,   -2, 	  -7,   -2, 	  -6,    1, 	   0,   -5
+.2byte   -9,    0, 	  -9,   -1, 	  -8,    2, 	  -2,   -6
+.2byte  -11,   -8, 	  -3,   -3, 	  -2,    0, 	   1,   -6
+.2byte   -7,    0, 	  -8,    1, 	  -3,    3, 	   1,   -7
+.2byte   -6,    1, 	  -9,    2, 	  -4,    4, 	   0,   -7
+.2byte   -8,   -2, 	  -4,    1, 	   1,    3, 	   2,   -7
+.2byte   -1,    1, 	  -3,    3, 	   1,    3, 	  -1,   -7
+.2byte   -4,    0, 	  -7,    1, 	  -2,    3, 	   2,   -8
+.2byte   -6,   -1, 	  -6,   -2, 	  -5,    1, 	   1,   -7
+.2byte   -3,   -4, 	   0,   -4, 	  -6,    0, 	   0,   -6
+.2byte   -1,   -3, 	   3,   -2, 	  -5,   -2, 	  -1,   -7
+.2byte    2,   -4, 	  -1,   -4, 	   5,    0, 	  -1,   -6
+.2byte    5,   -1, 	   5,   -2, 	   4,    1, 	  -2,   -7
+.2byte    3,    0, 	   6,    1, 	   1,    3, 	  -3,   -8
+.2byte   -1,    2, 	  -3,    3, 	   1,    3, 	  -1,   -4
+.2byte   -8,    0, 	  -9,    1, 	  -4,    3, 	   0,   -7
+.2byte  -10,   -2, 	  -8,   -2, 	  -7,    1, 	  -1,   -5
+.2byte  -10,   -6, 	  -3,   -9, 	  -8,   -2, 	   0,   -4
+.2byte   -1,   -9, 	   4,   -3, 	  -6,   -3, 	  -1,   -4
+.2byte    8,   -6, 	   1,   -9, 	   6,   -2, 	  -2,   -4
+.2byte    8,   -2, 	   6,   -2, 	   5,    1, 	  -1,   -5
+.2byte    6,    0, 	   7,    1, 	   2,    3, 	  -2,   -7
+sZigzagoonAnimTable1:
+.4byte sZigzagoonAnims_1_1
+.4byte sZigzagoonAnims_1_2
+.4byte sZigzagoonAnims_1_3
+.4byte sZigzagoonAnims_1_4
+.4byte sZigzagoonAnims_1_5
+.4byte sZigzagoonAnims_1_6
+.4byte sZigzagoonAnims_1_7
+.4byte sZigzagoonAnims_1_8
+sZigzagoonAnimTable2:
+.4byte sZigzagoonAnims_2_1
+.4byte sZigzagoonAnims_2_2
+.4byte sZigzagoonAnims_2_3
+.4byte sZigzagoonAnims_2_4
+.4byte sZigzagoonAnims_2_5
+.4byte sZigzagoonAnims_2_6
+.4byte sZigzagoonAnims_2_7
+.4byte sZigzagoonAnims_2_8
+sZigzagoonAnimTable3:
+.4byte sZigzagoonAnims_3_1
+.4byte sZigzagoonAnims_3_2
+.4byte sZigzagoonAnims_3_3
+.4byte sZigzagoonAnims_3_4
+.4byte sZigzagoonAnims_3_5
+.4byte sZigzagoonAnims_3_6
+.4byte sZigzagoonAnims_3_7
+.4byte sZigzagoonAnims_3_8
+sZigzagoonAnimTable4:
+.4byte sZigzagoonAnims_4_1
+.4byte sZigzagoonAnims_4_2
+.4byte sZigzagoonAnims_4_3
+.4byte sZigzagoonAnims_4_4
+.4byte sZigzagoonAnims_4_5
+.4byte sZigzagoonAnims_4_6
+.4byte sZigzagoonAnims_4_7
+.4byte sZigzagoonAnims_4_8
+sZigzagoonAnimTable5:
+.4byte sZigzagoonAnims_5_1
+.4byte sZigzagoonAnims_5_2
+.4byte sZigzagoonAnims_5_3
+.4byte sZigzagoonAnims_5_4
+.4byte sZigzagoonAnims_5_5
+.4byte sZigzagoonAnims_5_6
+.4byte sZigzagoonAnims_5_7
+.4byte sZigzagoonAnims_5_8
+sZigzagoonAnimTable6:
+.4byte sZigzagoonAnims_6_1
+.4byte sZigzagoonAnims_6_1
+.4byte sZigzagoonAnims_6_1
+.4byte sZigzagoonAnims_6_1
+.4byte sZigzagoonAnims_6_1
+.4byte sZigzagoonAnims_6_1
+.4byte sZigzagoonAnims_6_1
+.4byte sZigzagoonAnims_6_1
+sZigzagoonAnimTable7:
+.4byte sZigzagoonAnims_7_1
+.4byte sZigzagoonAnims_7_2
+.4byte sZigzagoonAnims_7_3
+.4byte sZigzagoonAnims_7_4
+.4byte sZigzagoonAnims_7_5
+.4byte sZigzagoonAnims_7_6
+.4byte sZigzagoonAnims_7_7
+.4byte sZigzagoonAnims_7_8
+sZigzagoonAnimTable8:
+.4byte sZigzagoonAnims_8_1
+.4byte sZigzagoonAnims_8_2
+.4byte sZigzagoonAnims_8_3
+.4byte sZigzagoonAnims_8_4
+.4byte sZigzagoonAnims_8_5
+.4byte sZigzagoonAnims_8_6
+.4byte sZigzagoonAnims_8_7
+.4byte sZigzagoonAnims_8_8
+sZigzagoonAnimTable9:
+.4byte sZigzagoonAnims_9_1
+.4byte sZigzagoonAnims_9_2
+.4byte sZigzagoonAnims_9_3
+.4byte sZigzagoonAnims_9_4
+.4byte sZigzagoonAnims_9_5
+.4byte sZigzagoonAnims_9_6
+.4byte sZigzagoonAnims_9_7
+.4byte sZigzagoonAnims_9_8
+sZigzagoonAnimTable10:
+.4byte sZigzagoonAnims_10_1
+.4byte sZigzagoonAnims_10_2
+.4byte sZigzagoonAnims_10_3
+.4byte sZigzagoonAnims_10_4
+.4byte sZigzagoonAnims_10_5
+.4byte sZigzagoonAnims_10_6
+.4byte sZigzagoonAnims_10_7
+.4byte sZigzagoonAnims_10_8
+sZigzagoonAnimTable11:
+.4byte sZigzagoonAnims_11_1
+.4byte sZigzagoonAnims_11_2
+.4byte sZigzagoonAnims_11_3
+.4byte sZigzagoonAnims_11_4
+.4byte sZigzagoonAnims_11_5
+.4byte sZigzagoonAnims_11_6
+.4byte sZigzagoonAnims_11_7
+.4byte sZigzagoonAnims_11_8
+sZigzagoonAnimTable12:
+.4byte sZigzagoonAnims_12_1
+.4byte sZigzagoonAnims_12_2
+.4byte sZigzagoonAnims_12_3
+.4byte sZigzagoonAnims_12_4
+.4byte sZigzagoonAnims_12_5
+.4byte sZigzagoonAnims_12_6
+.4byte sZigzagoonAnims_12_7
+.4byte sZigzagoonAnims_12_8
+sZigzagoonAnimTable13:
+.4byte sZigzagoonAnims_13_1
+.4byte sZigzagoonAnims_13_2
+.4byte sZigzagoonAnims_13_3
+.4byte sZigzagoonAnims_13_4
+.4byte sZigzagoonAnims_13_5
+.4byte sZigzagoonAnims_13_6
+.4byte sZigzagoonAnims_13_7
+.4byte sZigzagoonAnims_13_8
+sAxAnimationsZigzagoon:
+.4byte sZigzagoonAnimTable1
+.4byte sZigzagoonAnimTable2
+.4byte sZigzagoonAnimTable3
+.4byte sZigzagoonAnimTable4
+.4byte sZigzagoonAnimTable5
+.4byte sZigzagoonAnimTable6
+.4byte sZigzagoonAnimTable7
+.4byte sZigzagoonAnimTable8
+.4byte sZigzagoonAnimTable9
+.4byte sZigzagoonAnimTable10
+.4byte sZigzagoonAnimTable11
+.4byte sZigzagoonAnimTable12
+.4byte sZigzagoonAnimTable13
+sAxSpritesZigzagoon:
+.4byte sZigzagoonSprites1
+.4byte sZigzagoonSprites2
+.4byte sZigzagoonSprites3
+.4byte sZigzagoonSprites4
+.4byte sZigzagoonSprites5
+.4byte sZigzagoonSprites6
+.4byte sZigzagoonSprites7
+.4byte sZigzagoonSprites8
+.4byte sZigzagoonSprites9
+.4byte sZigzagoonSprites10
+.4byte sZigzagoonSprites11
+.4byte sZigzagoonSprites12
+.4byte sZigzagoonSprites13
+.4byte sZigzagoonSprites14
+.4byte sZigzagoonSprites15
+.4byte sZigzagoonSprites16
+.4byte sZigzagoonSprites17
+.4byte sZigzagoonSprites18
+.4byte sZigzagoonSprites19
+.4byte sZigzagoonSprites20
+.4byte sZigzagoonSprites21
+.4byte sZigzagoonSprites22
+.4byte sZigzagoonSprites23
+.4byte sZigzagoonSprites24
+.4byte sZigzagoonSprites25
+.4byte sZigzagoonSprites26
+.4byte sZigzagoonSprites27
+.4byte sZigzagoonSprites28
+.4byte sZigzagoonSprites29
+.4byte sZigzagoonSprites30
+.4byte sZigzagoonSprites31
+.4byte sZigzagoonSprites32
+.4byte sZigzagoonSprites33
+.4byte sZigzagoonSprites34
+.4byte sZigzagoonSprites35
+.4byte sZigzagoonSprites36
+.4byte sZigzagoonSprites37
+.4byte sZigzagoonSprites38
+.4byte sZigzagoonSprites39
+.4byte sZigzagoonSprites40
+.4byte sZigzagoonSprites41
+.4byte sZigzagoonSprites42
+sAxMainZigzagoon:
+ax_main sAxPosesZigzagoon, sAxAnimationsZigzagoon, 13, sAxSpritesZigzagoon, sAxPositionsZigzagoon

--- a/data/ax/zubat.inc
+++ b/data/ax/zubat.inc
@@ -1,0 +1,2522 @@
+.global gAxZubat
+gAxZubat:
+ax_siro sAxMainZubat
+sZubatPose1:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose2:
+ax_pose 1, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose3:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose4:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose5:
+ax_pose 4, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose6:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose7:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose8:
+ax_pose 7, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose9:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose10:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose11:
+ax_pose 10, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose12:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose13:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose14:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose15:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose16:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose17:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose18:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose19:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose20:
+ax_pose 7, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose21:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose22:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose23:
+ax_pose 4, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose24:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose25:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose26:
+ax_pose 1, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose27:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose28:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose29:
+ax_pose 4, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose30:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose31:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose32:
+ax_pose 7, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose33:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose34:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose35:
+ax_pose 10, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose36:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose37:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose38:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose39:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose40:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose41:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose42:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose43:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose44:
+ax_pose 7, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose45:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose46:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose47:
+ax_pose 4, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose48:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose49:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose50:
+ax_pose 1, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose51:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose52:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose53:
+ax_pose 4, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose54:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose55:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose56:
+ax_pose 7, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose57:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose58:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose59:
+ax_pose 10, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose60:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose61:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose62:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose63:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose64:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose65:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose66:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose67:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose68:
+ax_pose 7, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose69:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose70:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose71:
+ax_pose 4, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose72:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose73:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose74:
+ax_pose 1, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose75:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose76:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose77:
+ax_pose 4, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose78:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose79:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose80:
+ax_pose 7, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose81:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose82:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose83:
+ax_pose 10, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose84:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose85:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose86:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose87:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose88:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose89:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose90:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose91:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose92:
+ax_pose 7, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose93:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose94:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose95:
+ax_pose 4, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose96:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose97:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose98:
+ax_pose 1, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose99:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose100:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose101:
+ax_pose 4, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose102:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose103:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose104:
+ax_pose 7, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose105:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose106:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose107:
+ax_pose 10, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose108:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose109:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose110:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose111:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose112:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose113:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose114:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose115:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose116:
+ax_pose 7, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose117:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose118:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose119:
+ax_pose 4, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose120:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose121:
+ax_pose 15, 0x41f1, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose122:
+ax_pose 16, 0x41f1, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose123:
+ax_pose 17, 0x01e6, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose124:
+ax_pose 18, 0x01e6, 0x90ee, 0x7c00
+ax_pose_terminator
+sZubatPose125:
+ax_pose 19, 0x01e5, 0x90ef, 0x7c00
+ax_pose_terminator
+sZubatPose126:
+ax_pose 20, 0x01e6, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose127:
+ax_pose 21, 0x01e9, 0x80f1, 0x7c00
+ax_pose_terminator
+sZubatPose128:
+ax_pose 20, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sZubatPose129:
+ax_pose 19, 0x01e4, 0x80f1, 0x7c00
+ax_pose_terminator
+sZubatPose130:
+ax_pose 18, 0x01e6, 0x80f3, 0x7c00
+ax_pose_terminator
+sZubatPose131:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose132:
+ax_pose 1, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose133:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose134:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose135:
+ax_pose 4, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose136:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose137:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose138:
+ax_pose 7, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose139:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose140:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose141:
+ax_pose 10, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose142:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose143:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose144:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose145:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose146:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose147:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose148:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose149:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose150:
+ax_pose 7, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose151:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose152:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose153:
+ax_pose 4, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose154:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose155:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose156:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose157:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose158:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose159:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose160:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose161:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose162:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose163:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose164:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose165:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose166:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose167:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose168:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose169:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose170:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose171:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose172:
+ax_pose 1, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose173:
+ax_pose 2, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose174:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose175:
+ax_pose 4, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose176:
+ax_pose 5, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose177:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose178:
+ax_pose 7, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose179:
+ax_pose 8, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose180:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose181:
+ax_pose 10, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose182:
+ax_pose 11, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose183:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose184:
+ax_pose 13, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose185:
+ax_pose 14, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose186:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose187:
+ax_pose 10, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose188:
+ax_pose 11, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose189:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose190:
+ax_pose 7, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose191:
+ax_pose 8, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose192:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose193:
+ax_pose 4, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose194:
+ax_pose 5, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose195:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose196:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose197:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose198:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose199:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose200:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose201:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose202:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose203:
+ax_pose 0, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose204:
+ax_pose 3, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose205:
+ax_pose 6, 0x01e4, 0x80f4, 0x7c00
+ax_pose_terminator
+sZubatPose206:
+ax_pose 9, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose207:
+ax_pose 12, 0x01e4, 0x80f0, 0x7c00
+ax_pose_terminator
+sZubatPose208:
+ax_pose 9, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+sZubatPose209:
+ax_pose 6, 0x01e4, 0x90ed, 0x7c00
+ax_pose_terminator
+sZubatPose210:
+ax_pose 3, 0x01e4, 0x90f1, 0x7c00
+ax_pose_terminator
+.align 2
+sZubatAnims_1_1:
+ax_anim 6, 0, 0, 0, 0, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, 1, 0, 1, 0,
+ax_anim 6, 0, 1, 1, -1, 1, 0,
+ax_anim 6, 0, 0, 0, -2, 0, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim 6, 0, 2, -1, 0, -1, 0,
+ax_anim 6, 0, 1, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_1_2:
+ax_anim 6, 0, 3, 0, 0, 0, 0,
+ax_anim 6, 0, 4, 0, -1, 0, -1,
+ax_anim 6, 0, 5, 2, 0, 2, 0,
+ax_anim 6, 0, 4, 2, -1, 2, -1,
+ax_anim 6, 0, 3, 1, -3, 1, -1,
+ax_anim 6, 0, 4, 2, -1, 2, -1,
+ax_anim 6, 0, 5, 1, 0, 1, 0,
+ax_anim 6, 0, 4, 0, -1, 0, -1,
+ax_anim_terminator
+sZubatAnims_1_3:
+ax_anim 6, 0, 6, 0, 0, 0, 0,
+ax_anim 6, 0, 7, 1, -1, 1, 0,
+ax_anim 6, 0, 8, 2, 0, 2, 0,
+ax_anim 6, 0, 7, 2, -1, 2, 0,
+ax_anim 6, 0, 6, 1, -2, 1, 0,
+ax_anim 6, 0, 7, 0, -3, 0, 0,
+ax_anim 6, 0, 8, 0, -1, -1, 0,
+ax_anim 6, 0, 7, 1, -2, 1, 0,
+ax_anim_terminator
+sZubatAnims_1_4:
+ax_anim 6, 0, 9, 0, 0, 0, 0,
+ax_anim 6, 0, 10, 0, -1, 0, -1,
+ax_anim 6, 0, 11, 2, -2, 2, -1,
+ax_anim 6, 0, 10, 2, -1, 2, -1,
+ax_anim 6, 0, 9, 1, -3, 1, -1,
+ax_anim 6, 0, 10, 2, -2, 2, -1,
+ax_anim 6, 0, 11, 1, 0, 1, 0,
+ax_anim 6, 0, 10, 0, -1, 0, -1,
+ax_anim_terminator
+sZubatAnims_1_5:
+ax_anim 6, 0, 12, 0, 0, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 14, 1, 0, 1, 0,
+ax_anim 6, 0, 13, 1, -1, 1, 0,
+ax_anim 6, 0, 12, 0, -2, 0, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim 6, 0, 14, -1, 0, -1, 0,
+ax_anim 6, 0, 13, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_1_6:
+ax_anim 6, 0, 15, 0, 0, 0, 0,
+ax_anim 6, 0, 16, 0, -1, 0, -1,
+ax_anim 6, 0, 17, -2, -2, -2, -1,
+ax_anim 6, 0, 16, -2, -1, -2, -1,
+ax_anim 6, 0, 15, -1, -3, -1, -1,
+ax_anim 6, 0, 16, -2, -2, -2, -1,
+ax_anim 6, 0, 17, -1, 0, -1, 0,
+ax_anim 6, 0, 16, 0, -1, 0, -1,
+ax_anim_terminator
+sZubatAnims_1_7:
+ax_anim 6, 0, 18, 0, 0, 0, 0,
+ax_anim 6, 0, 19, -1, -1, -1, 0,
+ax_anim 6, 0, 20, -2, 0, -2, 0,
+ax_anim 6, 0, 19, -2, -1, -2, 0,
+ax_anim 6, 0, 18, -1, -2, -1, 0,
+ax_anim 6, 0, 19, 0, -3, 0, 0,
+ax_anim 6, 0, 20, 1, -1, 1, 0,
+ax_anim 6, 0, 19, 0, -1, -1, 0,
+ax_anim_terminator
+sZubatAnims_1_8:
+ax_anim 6, 0, 21, 0, 0, 0, 0,
+ax_anim 6, 0, 22, 0, -1, 0, -1,
+ax_anim 6, 0, 23, -2, 0, -2, 0,
+ax_anim 6, 0, 22, -2, -1, -2, -1,
+ax_anim 6, 0, 21, -1, -3, -1, -1,
+ax_anim 6, 0, 22, -2, -1, -2, -1,
+ax_anim 6, 0, 23, -1, 0, -1, 0,
+ax_anim 6, 0, 22, 0, -1, 0, -1,
+ax_anim_terminator
+.align 2
+sZubatAnims_2_1:
+ax_anim 2, 0, 25, 0, -1, 0, -1,
+ax_anim 3, 0, 26, 0, -2, 0, -2,
+ax_anim 4, 0, 25, 0, -3, 0, -3,
+ax_anim 1, 0, 24, 0, 0, 0, 0,
+ax_anim 1, 2, 26, 0, 4, 0, 3,
+ax_anim 1, 0, 24, 0, 12, 0, 10,
+ax_anim 2, 0, 25, 0, 24, 0, 22,
+ax_anim 2, 1, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 26, 0, 24, 0, 22,
+ax_anim 2, 0, 24, 1, 24, 1, 22,
+ax_anim 2, 0, 25, 0, 8, 0, 6,
+ax_anim_terminator
+sZubatAnims_2_2:
+ax_anim 2, 0, 28, -1, -1, -1, -1,
+ax_anim 3, 0, 29, -2, -2, -2, -2,
+ax_anim 4, 0, 28, -3, -3, -3, -3,
+ax_anim 1, 0, 27, 0, 0, 0, 0,
+ax_anim 1, 2, 29, 4, 4, 4, 4,
+ax_anim 1, 0, 27, 11, 13, 11, 12,
+ax_anim 2, 0, 28, 20, 24, 20, 21,
+ax_anim 2, 1, 27, 21, 23, 21, 20,
+ax_anim 2, 0, 29, 20, 24, 20, 21,
+ax_anim 2, 0, 27, 21, 23, 21, 20,
+ax_anim 2, 0, 28, 8, 8, 8, 8,
+ax_anim_terminator
+sZubatAnims_2_3:
+ax_anim 2, 0, 31, -1, 0, -1, 0,
+ax_anim 3, 0, 32, -2, 0, -2, 0,
+ax_anim 4, 0, 31, -3, 0, -3, 0,
+ax_anim 1, 0, 30, 0, 0, 0, 0,
+ax_anim 1, 2, 32, 4, 0, 4, 0,
+ax_anim 1, 0, 30, 11, 1, 11, 0,
+ax_anim 2, 0, 31, 22, 2, 22, 0,
+ax_anim 2, 1, 30, 22, 3, 22, 1,
+ax_anim 2, 0, 32, 22, 2, 22, 0,
+ax_anim 2, 0, 30, 22, 3, 22, 1,
+ax_anim 2, 0, 31, 8, 1, 8, 0,
+ax_anim_terminator
+sZubatAnims_2_4:
+ax_anim 2, 0, 34, -1, 1, -1, 1,
+ax_anim 3, 0, 35, -2, 2, -2, 2,
+ax_anim 4, 0, 34, -3, 3, -3, 3,
+ax_anim 1, 0, 33, 0, 0, 0, 0,
+ax_anim 1, 2, 35, 4, -4, 4, -4,
+ax_anim 1, 0, 33, 13, -10, 13, -13,
+ax_anim 2, 0, 34, 20, -15, 20, -19,
+ax_anim 2, 1, 33, 21, -14, 21, -18,
+ax_anim 2, 0, 35, 20, -15, 20, -19,
+ax_anim 2, 0, 33, 21, -14, 21, -18,
+ax_anim 2, 0, 34, 8, -7, 8, -8,
+ax_anim_terminator
+sZubatAnims_2_5:
+ax_anim 2, 0, 37, 0, 1, 0, 1,
+ax_anim 3, 0, 38, 0, 2, 0, 2,
+ax_anim 4, 0, 37, 0, 3, 0, 3,
+ax_anim 1, 0, 36, 0, 0, 0, 0,
+ax_anim 1, 2, 38, 0, -4, 0, -4,
+ax_anim 1, 0, 36, 0, -10, 0, -12,
+ax_anim 2, 0, 37, 0, -15, 0, -19,
+ax_anim 2, 1, 36, -1, -15, -1, -19,
+ax_anim 2, 0, 38, 0, -15, 0, -19,
+ax_anim 2, 0, 36, -1, -15, -1, -19,
+ax_anim 2, 0, 37, 0, -7, 0, -9,
+ax_anim_terminator
+sZubatAnims_2_6:
+ax_anim 2, 0, 40, 1, 1, 1, 1,
+ax_anim 3, 0, 41, 2, 2, 2, 2,
+ax_anim 4, 0, 40, 3, 3, 3, 3,
+ax_anim 1, 0, 39, 0, 0, 0, 0,
+ax_anim 1, 2, 41, -4, -4, -4, -4,
+ax_anim 1, 0, 39, -13, -10, -13, -13,
+ax_anim 2, 0, 40, -20, -15, -20, -19,
+ax_anim 2, 1, 39, -21, -14, -21, -18,
+ax_anim 2, 0, 41, -20, -15, -20, -19,
+ax_anim 2, 0, 39, -21, -14, -21, -18,
+ax_anim 2, 0, 40, -8, -7, -8, -8,
+ax_anim_terminator
+sZubatAnims_2_7:
+ax_anim 2, 0, 43, 1, 0, 1, 0,
+ax_anim 3, 0, 44, 2, 0, 2, 0,
+ax_anim 4, 0, 43, 3, 0, 3, 0,
+ax_anim 1, 0, 42, 0, 0, 0, 0,
+ax_anim 1, 2, 44, -4, 0, -4, 0,
+ax_anim 1, 0, 42, -11, 1, -11, 0,
+ax_anim 2, 0, 43, -22, 2, -22, 0,
+ax_anim 2, 1, 42, -22, 3, -22, 1,
+ax_anim 2, 0, 44, -22, 2, -22, 0,
+ax_anim 2, 0, 42, -22, 3, -22, 1,
+ax_anim 2, 0, 43, -8, 1, -8, 0,
+ax_anim_terminator
+sZubatAnims_2_8:
+ax_anim 2, 0, 46, 1, -1, 1, -1,
+ax_anim 3, 0, 47, 2, -2, 2, -2,
+ax_anim 4, 0, 46, 3, -3, 3, -3,
+ax_anim 1, 0, 45, 0, 0, 0, 0,
+ax_anim 1, 2, 47, -4, 4, -4, 4,
+ax_anim 1, 0, 45, -11, 13, -11, 12,
+ax_anim 2, 0, 46, -20, 24, -20, 21,
+ax_anim 2, 1, 45, -21, 23, -21, 20,
+ax_anim 2, 0, 47, -20, 24, -20, 21,
+ax_anim 2, 0, 45, -21, 23, -21, 20,
+ax_anim 2, 0, 46, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sZubatAnims_3_1:
+ax_anim 2, 0, 49, 0, -1, 0, -1,
+ax_anim 3, 0, 50, 0, -2, 0, -2,
+ax_anim 4, 0, 49, 0, -3, 0, -3,
+ax_anim 1, 0, 48, 0, 0, 0, 0,
+ax_anim 1, 2, 50, 0, 4, 0, 3,
+ax_anim 1, 0, 48, 0, 12, 0, 10,
+ax_anim 2, 0, 49, 0, 24, 0, 22,
+ax_anim 2, 1, 48, 1, 24, 1, 22,
+ax_anim 2, 0, 50, 0, 24, 0, 22,
+ax_anim 2, 0, 48, 1, 24, 1, 22,
+ax_anim 2, 0, 49, 0, 8, 0, 6,
+ax_anim_terminator
+sZubatAnims_3_2:
+ax_anim 2, 0, 52, -1, -1, -1, -1,
+ax_anim 3, 0, 53, -2, -2, -2, -2,
+ax_anim 4, 0, 52, -3, -3, -3, -3,
+ax_anim 1, 0, 51, 0, 0, 0, 0,
+ax_anim 1, 2, 53, 4, 4, 4, 4,
+ax_anim 1, 0, 51, 11, 13, 11, 12,
+ax_anim 2, 0, 52, 20, 24, 20, 21,
+ax_anim 2, 1, 51, 21, 23, 21, 20,
+ax_anim 2, 0, 53, 20, 24, 20, 21,
+ax_anim 2, 0, 51, 21, 23, 21, 20,
+ax_anim 2, 0, 52, 8, 8, 8, 8,
+ax_anim_terminator
+sZubatAnims_3_3:
+ax_anim 2, 0, 55, -1, 0, -1, 0,
+ax_anim 3, 0, 56, -2, 0, -2, 0,
+ax_anim 4, 0, 55, -3, 0, -3, 0,
+ax_anim 1, 0, 54, 0, 0, 0, 0,
+ax_anim 1, 2, 56, 4, 0, 4, 0,
+ax_anim 1, 0, 54, 11, 1, 11, 0,
+ax_anim 2, 0, 55, 22, 2, 22, 0,
+ax_anim 2, 1, 54, 22, 3, 22, 1,
+ax_anim 2, 0, 56, 22, 2, 22, 0,
+ax_anim 2, 0, 54, 22, 3, 22, 1,
+ax_anim 2, 0, 55, 8, 1, 8, 0,
+ax_anim_terminator
+sZubatAnims_3_4:
+ax_anim 2, 0, 58, -1, 1, -1, 1,
+ax_anim 3, 0, 59, -2, 2, -2, 2,
+ax_anim 4, 0, 58, -3, 3, -3, 3,
+ax_anim 1, 0, 57, 0, 0, 0, 0,
+ax_anim 1, 2, 59, 4, -4, 4, -4,
+ax_anim 1, 0, 57, 13, -10, 13, -13,
+ax_anim 2, 0, 58, 20, -15, 20, -19,
+ax_anim 2, 1, 57, 21, -14, 21, -18,
+ax_anim 2, 0, 59, 20, -15, 20, -19,
+ax_anim 2, 0, 57, 21, -14, 21, -18,
+ax_anim 2, 0, 58, 8, -7, 8, -8,
+ax_anim_terminator
+sZubatAnims_3_5:
+ax_anim 2, 0, 61, 0, 1, 0, 1,
+ax_anim 3, 0, 62, 0, 2, 0, 2,
+ax_anim 4, 0, 61, 0, 3, 0, 3,
+ax_anim 1, 0, 60, 0, 0, 0, 0,
+ax_anim 1, 2, 62, 0, -4, 0, -4,
+ax_anim 1, 0, 60, 0, -10, 0, -12,
+ax_anim 2, 0, 61, 0, -15, 0, -19,
+ax_anim 2, 1, 60, -1, -15, -1, -19,
+ax_anim 2, 0, 62, 0, -15, 0, -19,
+ax_anim 2, 0, 60, -1, -15, -1, -19,
+ax_anim 2, 0, 61, 0, -7, 0, -9,
+ax_anim_terminator
+sZubatAnims_3_6:
+ax_anim 2, 0, 64, 1, 1, 1, 1,
+ax_anim 3, 0, 65, 2, 2, 2, 2,
+ax_anim 4, 0, 64, 3, 3, 3, 3,
+ax_anim 1, 0, 63, 0, 0, 0, 0,
+ax_anim 1, 2, 65, -4, -4, -4, -4,
+ax_anim 1, 0, 63, -13, -10, -13, -13,
+ax_anim 2, 0, 64, -20, -15, -20, -19,
+ax_anim 2, 1, 63, -21, -14, -21, -18,
+ax_anim 2, 0, 65, -20, -15, -20, -19,
+ax_anim 2, 0, 63, -21, -14, -21, -18,
+ax_anim 2, 0, 64, -8, -7, -8, -8,
+ax_anim_terminator
+sZubatAnims_3_7:
+ax_anim 2, 0, 67, 1, 0, 1, 0,
+ax_anim 3, 0, 68, 2, 0, 2, 0,
+ax_anim 4, 0, 67, 3, 0, 3, 0,
+ax_anim 1, 0, 66, 0, 0, 0, 0,
+ax_anim 1, 2, 68, -4, 0, -4, 0,
+ax_anim 1, 0, 66, -11, 1, -11, 0,
+ax_anim 2, 0, 67, -22, 2, -22, 0,
+ax_anim 2, 1, 66, -22, 3, -22, 1,
+ax_anim 2, 0, 68, -22, 2, -22, 0,
+ax_anim 2, 0, 66, -22, 3, -22, 1,
+ax_anim 2, 0, 67, -8, 1, -8, 0,
+ax_anim_terminator
+sZubatAnims_3_8:
+ax_anim 2, 0, 70, 1, -1, 1, -1,
+ax_anim 3, 0, 71, 2, -2, 2, -2,
+ax_anim 4, 0, 70, 3, -3, 3, -3,
+ax_anim 1, 0, 69, 0, 0, 0, 0,
+ax_anim 1, 2, 71, -4, 4, -4, 4,
+ax_anim 1, 0, 69, -11, 13, -11, 12,
+ax_anim 2, 0, 70, -20, 24, -20, 21,
+ax_anim 2, 1, 69, -21, 23, -21, 20,
+ax_anim 2, 0, 71, -20, 24, -20, 21,
+ax_anim 2, 0, 69, -21, 23, -21, 20,
+ax_anim 2, 0, 70, -8, 8, -8, 8,
+ax_anim_terminator
+.align 2
+sZubatAnims_4_1:
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 1, -1, 1, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 2, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 72, 0, 0, 0, 0,
+ax_anim 2, 1, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, 1, 0, 1, 0,
+ax_anim 2, 0, 73, 1, -1, 1, 0,
+ax_anim 2, 0, 72, 0, -2, 0, 0,
+ax_anim 2, 0, 73, 0, -1, 0, 0,
+ax_anim 2, 0, 74, -1, 0, -1, 0,
+ax_anim_terminator
+sZubatAnims_4_2:
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 0, 76, 0, -1, 0, -1,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 75, 1, -3, 1, -1,
+ax_anim 2, 2, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 77, 1, 0, 1, 0,
+ax_anim 2, 0, 76, 0, -1, 0, -1,
+ax_anim 2, 0, 75, 0, 0, 0, 0,
+ax_anim 2, 1, 76, 0, -1, 0, -1,
+ax_anim 2, 0, 77, 2, 0, 2, 0,
+ax_anim 2, 0, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 75, 1, -3, 1, -1,
+ax_anim 2, 0, 76, 2, -1, 2, -1,
+ax_anim 2, 0, 77, 1, 0, 1, 0,
+ax_anim_terminator
+sZubatAnims_4_3:
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 0, 79, 1, -1, 1, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 79, 2, -1, 2, 0,
+ax_anim 2, 0, 78, 1, -2, 1, 0,
+ax_anim 2, 2, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -1, -1, 0,
+ax_anim 2, 0, 79, 1, -2, 1, 0,
+ax_anim 2, 0, 78, 0, 0, 0, 0,
+ax_anim 2, 1, 79, 1, -1, 1, 0,
+ax_anim 2, 0, 80, 2, 0, 2, 0,
+ax_anim 2, 0, 79, 2, -1, 2, 0,
+ax_anim 2, 0, 78, 1, -2, 1, 0,
+ax_anim 2, 0, 79, 0, -3, 0, 0,
+ax_anim 2, 0, 80, 0, -1, -1, 0,
+ax_anim_terminator
+sZubatAnims_4_4:
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -1,
+ax_anim 2, 0, 82, 2, -1, 2, -1,
+ax_anim 2, 0, 81, 1, -3, 1, -1,
+ax_anim 2, 2, 82, 2, -2, 2, -1,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim 2, 0, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 81, 0, 0, 0, 0,
+ax_anim 2, 1, 82, 0, -1, 0, -1,
+ax_anim 2, 0, 83, 2, -2, 2, -1,
+ax_anim 2, 0, 82, 2, -1, 2, -1,
+ax_anim 2, 0, 81, 1, -3, 1, -1,
+ax_anim 2, 0, 82, 2, -2, 2, -1,
+ax_anim 2, 0, 83, 1, 0, 1, 0,
+ax_anim_terminator
+sZubatAnims_4_5:
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 1, -1, 1, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 2, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 84, 0, 0, 0, 0,
+ax_anim 2, 1, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, 1, 0, 1, 0,
+ax_anim 2, 0, 85, 1, -1, 1, 0,
+ax_anim 2, 0, 84, 0, -2, 0, 0,
+ax_anim 2, 0, 85, 0, -1, 0, 0,
+ax_anim 2, 0, 86, -1, 0, -1, 0,
+ax_anim_terminator
+sZubatAnims_4_6:
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -1,
+ax_anim 2, 0, 88, -2, -1, -2, -1,
+ax_anim 2, 0, 87, -1, -3, -1, -1,
+ax_anim 2, 2, 88, -2, -2, -2, -1,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim 2, 0, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 87, 0, 0, 0, 0,
+ax_anim 2, 1, 88, 0, -1, 0, -1,
+ax_anim 2, 0, 89, -2, -2, -2, -1,
+ax_anim 2, 0, 88, -2, -1, -2, -1,
+ax_anim 2, 0, 87, -1, -3, -1, -1,
+ax_anim 2, 0, 88, -2, -2, -2, -1,
+ax_anim 2, 0, 89, -1, 0, -1, 0,
+ax_anim_terminator
+sZubatAnims_4_7:
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 0, 91, -1, -1, -1, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -2, -1, -2, 0,
+ax_anim 2, 0, 90, -1, -2, -1, 0,
+ax_anim 2, 2, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, 0,
+ax_anim 2, 0, 91, 0, -1, -1, 0,
+ax_anim 2, 0, 90, 0, 0, 0, 0,
+ax_anim 2, 1, 91, -1, -1, -1, 0,
+ax_anim 2, 0, 92, -2, 0, -2, 0,
+ax_anim 2, 0, 91, -2, -1, -2, 0,
+ax_anim 2, 0, 90, -1, -2, -1, 0,
+ax_anim 2, 0, 91, 0, -3, 0, 0,
+ax_anim 2, 0, 92, 1, -1, 1, 0,
+ax_anim_terminator
+sZubatAnims_4_8:
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 93, -1, -3, -1, -1,
+ax_anim 2, 2, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim 2, 0, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 93, 0, 0, 0, 0,
+ax_anim 2, 1, 94, 0, -1, 0, -1,
+ax_anim 2, 0, 95, -2, 0, -2, 0,
+ax_anim 2, 0, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 93, -1, -3, -1, -1,
+ax_anim 2, 0, 94, -2, -1, -2, -1,
+ax_anim 2, 0, 95, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_5_1:
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 2, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 96, 0, 0, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 98, 1, 0, 1, 0,
+ax_anim 2, 0, 97, 1, -1, 1, 0,
+ax_anim 2, 0, 96, 0, -2, 0, 0,
+ax_anim 2, 0, 97, 0, -1, 0, 0,
+ax_anim 2, 0, 98, -1, 0, -1, 0,
+ax_anim_terminator
+sZubatAnims_5_2:
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 100, 2, -1, 2, -1,
+ax_anim 2, 0, 99, 1, -3, 1, -1,
+ax_anim 2, 0, 100, 2, -1, 2, -1,
+ax_anim 2, 0, 101, 1, 0, 1, 0,
+ax_anim 2, 0, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 99, 0, 0, 0, 0,
+ax_anim 2, 2, 100, 0, -1, 0, -1,
+ax_anim 2, 0, 101, 2, 0, 2, 0,
+ax_anim 2, 0, 100, 2, -1, 2, -1,
+ax_anim 2, 1, 99, 1, -3, 1, -1,
+ax_anim 2, 0, 100, 2, -1, 2, -1,
+ax_anim 2, 0, 101, 1, 0, 1, 0,
+ax_anim_terminator
+sZubatAnims_5_3:
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 0, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 103, 2, -1, 2, 0,
+ax_anim 2, 0, 102, 1, -2, 1, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -1, -1, 0,
+ax_anim 2, 0, 103, 1, -2, 1, 0,
+ax_anim 2, 0, 102, 0, 0, 0, 0,
+ax_anim 2, 2, 103, 1, -1, 1, 0,
+ax_anim 2, 0, 104, 2, 0, 2, 0,
+ax_anim 2, 0, 103, 2, -1, 2, 0,
+ax_anim 2, 1, 102, 1, -2, 1, 0,
+ax_anim 2, 0, 103, 0, -3, 0, 0,
+ax_anim 2, 0, 104, 0, -1, -1, 0,
+ax_anim_terminator
+sZubatAnims_5_4:
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -1,
+ax_anim 2, 0, 106, 2, -1, 2, -1,
+ax_anim 2, 0, 105, 1, -3, 1, -1,
+ax_anim 2, 0, 106, 2, -2, 2, -1,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim 2, 0, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 105, 0, 0, 0, 0,
+ax_anim 2, 2, 106, 0, -1, 0, -1,
+ax_anim 2, 0, 107, 2, -2, 2, -1,
+ax_anim 2, 0, 106, 2, -1, 2, -1,
+ax_anim 2, 1, 105, 1, -3, 1, -1,
+ax_anim 2, 0, 106, 2, -2, 2, -1,
+ax_anim 2, 0, 107, 1, 0, 1, 0,
+ax_anim_terminator
+sZubatAnims_5_5:
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 1, -1, 1, 0,
+ax_anim 2, 0, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 108, 0, 0, 0, 0,
+ax_anim 2, 2, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 110, 1, 0, 1, 0,
+ax_anim 2, 0, 109, 1, -1, 1, 0,
+ax_anim 2, 1, 108, 0, -2, 0, 0,
+ax_anim 2, 0, 109, 0, -1, 0, 0,
+ax_anim 2, 0, 110, -1, 0, -1, 0,
+ax_anim_terminator
+sZubatAnims_5_6:
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -1,
+ax_anim 2, 0, 112, -2, -1, -2, -1,
+ax_anim 2, 0, 111, -1, -3, -1, -1,
+ax_anim 2, 0, 112, -2, -2, -2, -1,
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim 2, 0, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 111, 0, 0, 0, 0,
+ax_anim 2, 2, 112, 0, -1, 0, -1,
+ax_anim 2, 0, 113, -2, -2, -2, -1,
+ax_anim 2, 0, 112, -2, -1, -2, -1,
+ax_anim 2, 1, 111, -1, -3, -1, -1,
+ax_anim 2, 0, 112, -2, -2, -2, -1,
+ax_anim 2, 0, 113, -1, 0, -1, 0,
+ax_anim_terminator
+sZubatAnims_5_7:
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 0, 115, -1, -1, -1, 0,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -2, -1, -2, 0,
+ax_anim 2, 0, 114, -1, -2, -1, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 1, -1, 1, 0,
+ax_anim 2, 0, 115, 0, -1, -1, 0,
+ax_anim 2, 0, 114, 0, 0, 0, 0,
+ax_anim 2, 2, 115, -1, -1, -1, 0,
+ax_anim 2, 0, 116, -2, 0, -2, 0,
+ax_anim 2, 0, 115, -2, -1, -2, 0,
+ax_anim 2, 1, 114, -1, -2, -1, 0,
+ax_anim 2, 0, 115, 0, -3, 0, 0,
+ax_anim 2, 0, 116, 1, -1, 1, 0,
+ax_anim_terminator
+sZubatAnims_5_8:
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 119, -2, 0, -2, 0,
+ax_anim 2, 0, 118, -2, -1, -2, -1,
+ax_anim 2, 0, 117, -1, -3, -1, -1,
+ax_anim 2, 0, 118, -2, -1, -2, -1,
+ax_anim 2, 0, 119, -1, 0, -1, 0,
+ax_anim 2, 0, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 117, 0, 0, 0, 0,
+ax_anim 2, 2, 118, 0, -1, 0, -1,
+ax_anim 2, 0, 119, -2, 0, -2, 0,
+ax_anim 2, 0, 118, -2, -1, -2, -1,
+ax_anim 2, 1, 117, -1, -3, -1, -1,
+ax_anim 2, 0, 118, -2, -1, -2, -1,
+ax_anim 2, 0, 119, -1, 0, -1, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_6_1:
+ax_anim 30, 0, 120, 0, 0, 0, 0,
+ax_anim 35, 0, 121, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_7_1:
+ax_anim 2, 0, 122, 0, -2, 0, -2,
+ax_anim 8, 0, 122, 0, -3, 0, -3,
+ax_anim_terminator
+sZubatAnims_7_2:
+ax_anim 2, 0, 123, -2, -2, -2, -2,
+ax_anim 8, 0, 123, -3, -3, -3, -3,
+ax_anim_terminator
+sZubatAnims_7_3:
+ax_anim 2, 0, 124, -2, 0, -2, 0,
+ax_anim 8, 0, 124, -3, 0, -3, 0,
+ax_anim_terminator
+sZubatAnims_7_4:
+ax_anim 2, 0, 125, -2, 2, -2, 2,
+ax_anim 8, 0, 125, -3, 3, -3, 3,
+ax_anim_terminator
+sZubatAnims_7_5:
+ax_anim 2, 0, 126, 0, 2, 0, 2,
+ax_anim 8, 0, 126, 0, 3, 0, 3,
+ax_anim_terminator
+sZubatAnims_7_6:
+ax_anim 2, 0, 127, 2, 2, 2, 2,
+ax_anim 8, 0, 127, 3, 3, 3, 3,
+ax_anim_terminator
+sZubatAnims_7_7:
+ax_anim 2, 0, 128, 2, 0, 2, 0,
+ax_anim 8, 0, 128, 3, 0, 3, 0,
+ax_anim_terminator
+sZubatAnims_7_8:
+ax_anim 2, 0, 129, 2, -2, 2, -2,
+ax_anim 8, 0, 129, 3, -3, 3, -3,
+ax_anim_terminator
+.align 2
+sZubatAnims_8_1:
+ax_anim 10, 0, 130, 0, 0, 0, 0,
+ax_anim 6, 0, 132, 0, 1, 0, 0,
+ax_anim 6, 0, 132, 0, 2, 1, 0,
+ax_anim 6, 0, 132, 0, 3, 1, 0,
+ax_anim 6, 0, 130, 0, 4, 0, 0,
+ax_anim 6, 0, 131, 0, 3, 0, 0,
+ax_anim 6, 0, 132, 0, 1, -1, 0,
+ax_anim 8, 0, 131, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_8_2:
+ax_anim 10, 0, 133, 0, 0, 0, 0,
+ax_anim 6, 0, 135, 0, 1, 0, 0,
+ax_anim 6, 0, 135, 0, 2, 1, 0,
+ax_anim 6, 0, 135, 0, 3, 1, 0,
+ax_anim 6, 0, 133, 0, 4, 0, 0,
+ax_anim 6, 0, 134, 0, 3, 0, 0,
+ax_anim 6, 0, 135, 0, 1, -1, 0,
+ax_anim 8, 0, 134, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_8_3:
+ax_anim 10, 0, 136, 0, 0, 0, 0,
+ax_anim 6, 0, 138, 0, 1, 0, 0,
+ax_anim 6, 0, 138, 0, 2, 1, 0,
+ax_anim 6, 0, 138, 0, 3, 1, 0,
+ax_anim 6, 0, 136, 0, 4, 0, 0,
+ax_anim 6, 0, 137, 0, 3, 0, 0,
+ax_anim 6, 0, 138, 0, 1, -1, 0,
+ax_anim 8, 0, 137, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_8_4:
+ax_anim 10, 0, 139, 0, 0, 0, 0,
+ax_anim 6, 0, 141, 0, 1, 0, 0,
+ax_anim 6, 0, 141, 0, 2, 1, 0,
+ax_anim 6, 0, 141, 0, 3, 1, 0,
+ax_anim 6, 0, 139, 0, 4, 0, 0,
+ax_anim 6, 0, 140, 0, 3, 0, 0,
+ax_anim 6, 0, 141, 0, 1, -1, 0,
+ax_anim 8, 0, 140, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_8_5:
+ax_anim 10, 0, 142, 0, 0, 0, 0,
+ax_anim 6, 0, 144, 0, 1, 0, 0,
+ax_anim 6, 0, 144, 0, 2, 1, 0,
+ax_anim 6, 0, 144, 0, 3, 1, 0,
+ax_anim 6, 0, 142, 0, 4, 0, 0,
+ax_anim 6, 0, 143, 0, 3, 0, 0,
+ax_anim 6, 0, 144, 0, 1, -1, 0,
+ax_anim 8, 0, 143, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_8_6:
+ax_anim 10, 0, 145, 0, 0, 0, 0,
+ax_anim 6, 0, 147, 0, 1, 0, 0,
+ax_anim 6, 0, 147, 0, 2, 1, 0,
+ax_anim 6, 0, 147, 0, 3, 1, 0,
+ax_anim 6, 0, 145, 0, 4, 0, 0,
+ax_anim 6, 0, 146, 0, 3, 0, 0,
+ax_anim 6, 0, 147, 0, 1, -1, 0,
+ax_anim 8, 0, 146, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_8_7:
+ax_anim 10, 0, 148, 0, 0, 0, 0,
+ax_anim 6, 0, 150, 0, 1, 0, 0,
+ax_anim 6, 0, 150, 0, 2, 1, 0,
+ax_anim 6, 0, 150, 0, 3, 1, 0,
+ax_anim 6, 0, 148, 0, 4, 0, 0,
+ax_anim 6, 0, 149, 0, 3, 0, 0,
+ax_anim 6, 0, 150, 0, 1, -1, 0,
+ax_anim 8, 0, 149, 0, -1, 0, 0,
+ax_anim_terminator
+sZubatAnims_8_8:
+ax_anim 10, 0, 151, 0, 0, 0, 0,
+ax_anim 6, 0, 153, 0, 1, 0, 0,
+ax_anim 6, 0, 153, 0, 2, 1, 0,
+ax_anim 6, 0, 153, 0, 3, 1, 0,
+ax_anim 6, 0, 151, 0, 4, 0, 0,
+ax_anim 6, 0, 152, 0, 3, 0, 0,
+ax_anim 6, 0, 153, 0, 1, -1, 0,
+ax_anim 8, 0, 152, 0, -1, 0, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_9_1:
+ax_anim 2, 0, 154, 0, 0, 0, 0,
+ax_anim 1, 0, 155, 6, 3, 6, 3,
+ax_anim 2, 0, 156, 8, 9, 8, 9,
+ax_anim 2, 0, 157, 7, 21, 7, 16,
+ax_anim 3, 0, 158, 0, 27, 0, 20,
+ax_anim 2, 3, 159, -7, 21, -7, 16,
+ax_anim 2, 0, 160, -8, 9, -8, 9,
+ax_anim 1, 0, 161, -6, 3, -6, 3,
+ax_anim 1, 0, 154, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_9_2:
+ax_anim 2, 0, 161, 0, 0, 0, 0,
+ax_anim 1, 0, 154, 8, 0, 8, 0,
+ax_anim 2, 0, 155, 14, 3, 14, 3,
+ax_anim 2, 0, 156, 19, 10, 19, 8,
+ax_anim 3, 0, 157, 19, 26, 19, 21,
+ax_anim 2, 3, 158, 11, 28, 11, 23,
+ax_anim 2, 0, 159, 3, 19, 3, 17,
+ax_anim 1, 0, 160, 0, 7, 0, 7,
+ax_anim 1, 0, 161, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_9_3:
+ax_anim 2, 0, 160, 0, 0, 0, 0,
+ax_anim 1, 0, 161, 3, -5, 3, -5,
+ax_anim 2, 0, 154, 11, -6, 11, -6,
+ax_anim 2, 0, 155, 16, -2, 16, -3,
+ax_anim 3, 0, 156, 19, 4, 19, 0,
+ax_anim 2, 3, 157, 18, 8, 18, 5,
+ax_anim 2, 0, 158, 12, 10, 12, 7,
+ax_anim 1, 0, 159, 4, 5, 4, 3,
+ax_anim 1, 0, 160, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_9_4:
+ax_anim 2, 0, 159, 0, 0, 0, 0,
+ax_anim 1, 0, 160, -1, -6, -1, -6,
+ax_anim 2, 0, 161, 4, -16, 4, -16,
+ax_anim 2, 0, 154, 12, -20, 12, -20,
+ax_anim 3, 0, 155, 19, -17, 19, -20,
+ax_anim 2, 3, 156, 20, -10, 20, -13,
+ax_anim 2, 0, 157, 17, -4, 17, -5,
+ax_anim 1, 0, 158, 7, -1, 7, -1,
+ax_anim 1, 0, 159, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_9_5:
+ax_anim 2, 0, 158, 0, 0, 0, 0,
+ax_anim 1, 0, 159, -8, -4, -8, -4,
+ax_anim 2, 0, 160, -9, -12, -9, -12,
+ax_anim 2, 0, 161, -7, -16, -7, -18,
+ax_anim 3, 0, 154, 0, -18, 0, -22,
+ax_anim 2, 3, 155, 7, -16, 7, -18,
+ax_anim 2, 0, 156, 9, -10, 9, -10,
+ax_anim 1, 0, 157, 8, -4, 8, -4,
+ax_anim 1, 0, 158, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_9_6:
+ax_anim 2, 0, 157, 0, 0, 0, 0,
+ax_anim 1, 0, 156, 1, -6, 1, -6,
+ax_anim 2, 0, 155, -4, -16, -4, -16,
+ax_anim 2, 0, 154, -12, -20, -12, -20,
+ax_anim 3, 0, 161, -19, -17, -19, -20,
+ax_anim 2, 3, 160, -20, -10, -20, -13,
+ax_anim 2, 0, 159, -17, -4, -17, -5,
+ax_anim 1, 0, 158, -7, -1, -7, -1,
+ax_anim 1, 0, 157, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_9_7:
+ax_anim 2, 0, 156, 0, 0, 0, 0,
+ax_anim 1, 0, 155, -3, -5, -3, -5,
+ax_anim 2, 0, 154, -11, -6, -11, -6,
+ax_anim 2, 0, 161, -16, -2, -16, -3,
+ax_anim 3, 0, 160, -19, 4, -19, 0,
+ax_anim 2, 3, 159, -18, 8, -18, 5,
+ax_anim 2, 0, 158, -12, 10, -12, 7,
+ax_anim 1, 0, 157, -4, 5, -4, 3,
+ax_anim 1, 0, 156, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_9_8:
+ax_anim 2, 0, 155, 0, 0, 0, 0,
+ax_anim 1, 0, 154, -8, 0, -8, 0,
+ax_anim 2, 0, 161, -14, 3, -14, 3,
+ax_anim 2, 0, 160, -19, 10, -19, 8,
+ax_anim 3, 0, 159, -19, 26, -19, 21,
+ax_anim 2, 3, 158, -11, 28, -11, 23,
+ax_anim 2, 0, 157, -3, 19, -3, 17,
+ax_anim 1, 0, 156, 0, 7, 0, 7,
+ax_anim 1, 0, 155, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_10_1:
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 3, 0, 162, 13, 0, 13, 0,
+ax_anim 3, 0, 162, -13, 0, -13, 0,
+ax_anim 2, 0, 162, 12, 0, 12, 0,
+ax_anim 3, 0, 162, -12, 0, -12, 0,
+ax_anim 2, 0, 162, 10, 0, 10, 0,
+ax_anim 2, 0, 162, -10, 0, -10, 0,
+ax_anim 2, 0, 162, 6, 0, 6, 0,
+ax_anim 2, 0, 162, -6, 0, -6, 0,
+ax_anim 2, 0, 162, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_10_2:
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 3, 0, 163, 13, -13, 13, -13,
+ax_anim 3, 0, 163, -13, 13, -13, 13,
+ax_anim 2, 0, 163, 12, -12, 12, -12,
+ax_anim 3, 0, 163, -12, 12, -12, 12,
+ax_anim 2, 0, 163, 10, -10, 10, -10,
+ax_anim 2, 0, 163, -10, 10, -10, 10,
+ax_anim 2, 0, 163, 6, -6, 6, -6,
+ax_anim 2, 0, 163, -6, 6, -6, 6,
+ax_anim 2, 0, 163, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_10_3:
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 3, 0, 164, 0, -13, 0, -13,
+ax_anim 3, 0, 164, 0, 13, 0, 13,
+ax_anim 2, 0, 164, 0, -12, 0, -12,
+ax_anim 3, 0, 164, 0, 12, 0, 12,
+ax_anim 2, 0, 164, 0, -10, 0, -10,
+ax_anim 2, 0, 164, 0, 10, 0, 10,
+ax_anim 2, 0, 164, 0, -6, 0, -6,
+ax_anim 2, 0, 164, 0, 6, 0, 6,
+ax_anim 2, 0, 164, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_10_4:
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 3, 0, 165, -13, -13, -13, -13,
+ax_anim 3, 0, 165, 13, 13, 13, 13,
+ax_anim 2, 0, 165, -12, -12, -12, -12,
+ax_anim 3, 0, 165, 12, 12, 12, 12,
+ax_anim 2, 0, 165, -10, -10, -10, -10,
+ax_anim 2, 0, 165, 10, 10, 10, 10,
+ax_anim 2, 0, 165, -6, -6, -6, -6,
+ax_anim 2, 0, 165, 6, 6, 6, 6,
+ax_anim 2, 0, 165, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_10_5:
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 3, 0, 166, 13, 0, 13, 0,
+ax_anim 3, 0, 166, -13, 0, -13, 0,
+ax_anim 2, 0, 166, 12, 0, 12, 0,
+ax_anim 3, 0, 166, -12, 0, -12, 0,
+ax_anim 2, 0, 166, 10, 0, 10, 0,
+ax_anim 2, 0, 166, -10, 0, -10, 0,
+ax_anim 2, 0, 166, 6, 0, 6, 0,
+ax_anim 2, 0, 166, -6, 0, -6, 0,
+ax_anim 2, 0, 166, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_10_6:
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 3, 0, 167, 13, -13, 13, -13,
+ax_anim 3, 0, 167, -13, 13, -13, 13,
+ax_anim 2, 0, 167, 12, -12, 12, -12,
+ax_anim 3, 0, 167, -12, 12, -12, 12,
+ax_anim 2, 0, 167, 10, -10, 10, -10,
+ax_anim 2, 0, 167, -10, 10, -10, 10,
+ax_anim 2, 0, 167, 6, -6, 6, -6,
+ax_anim 2, 0, 167, -6, 6, -6, 6,
+ax_anim 2, 0, 167, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_10_7:
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 3, 0, 168, 0, -13, 0, -13,
+ax_anim 3, 0, 168, 0, 13, 0, 13,
+ax_anim 2, 0, 168, 0, -12, 0, -12,
+ax_anim 3, 0, 168, 0, 12, 0, 12,
+ax_anim 2, 0, 168, 0, -10, 0, -10,
+ax_anim 2, 0, 168, 0, 10, 0, 10,
+ax_anim 2, 0, 168, 0, -6, 0, -6,
+ax_anim 2, 0, 168, 0, 6, 0, 6,
+ax_anim 2, 0, 168, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_10_8:
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 3, 0, 169, -13, -13, -13, -13,
+ax_anim 3, 0, 169, 13, 13, 13, 13,
+ax_anim 2, 0, 169, -12, -12, -12, -12,
+ax_anim 3, 0, 169, 12, 12, 12, 12,
+ax_anim 2, 0, 169, -10, -10, -10, -10,
+ax_anim 2, 0, 169, 10, 10, 10, 10,
+ax_anim 2, 0, 169, -6, -6, -6, -6,
+ax_anim 2, 0, 169, 6, 6, 6, 6,
+ax_anim 2, 0, 169, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_11_1:
+ax_anim 2, 0, 170, 0, 0, 0, 0,
+ax_anim 1, 0, 171, 0, -10, 0, 0,
+ax_anim 2, 0, 171, 0, -16, 0, 0,
+ax_anim 3, 0, 171, 0, -20, 0, 0,
+ax_anim 4, 0, 171, 0, -21, 0, 0,
+ax_anim 4, 0, 172, 0, -23, 0, 0,
+ax_anim 3, 0, 172, 0, -22, 0, 0,
+ax_anim 2, 0, 172, 0, -18, 0, 0,
+ax_anim 1, 0, 172, 0, -9, 0, 0,
+ax_anim 2, 2, 170, 0, 6, 0, 0,
+ax_anim_terminator
+sZubatAnims_11_2:
+ax_anim 2, 0, 173, 0, 0, 0, 0,
+ax_anim 1, 0, 174, 0, -10, 0, 0,
+ax_anim 2, 0, 174, 0, -16, 0, 0,
+ax_anim 3, 0, 174, 0, -20, 0, 0,
+ax_anim 4, 0, 174, 0, -21, 0, 0,
+ax_anim 4, 0, 175, 0, -23, 0, 0,
+ax_anim 3, 0, 175, 0, -22, 0, 0,
+ax_anim 2, 0, 175, 0, -18, 0, 0,
+ax_anim 1, 0, 175, 0, -9, 0, 0,
+ax_anim 2, 2, 173, 0, 6, 0, 0,
+ax_anim_terminator
+sZubatAnims_11_3:
+ax_anim 2, 0, 176, 0, 0, 0, 0,
+ax_anim 1, 0, 177, 0, -10, 0, 0,
+ax_anim 2, 0, 177, 0, -16, 0, 0,
+ax_anim 3, 0, 177, 0, -20, 0, 0,
+ax_anim 4, 0, 177, 0, -21, 0, 0,
+ax_anim 4, 0, 178, 0, -23, 0, 0,
+ax_anim 3, 0, 178, 0, -22, 0, 0,
+ax_anim 2, 0, 178, 0, -18, 0, 0,
+ax_anim 1, 0, 178, 0, -9, 0, 0,
+ax_anim 2, 2, 176, 0, 6, 0, 0,
+ax_anim_terminator
+sZubatAnims_11_4:
+ax_anim 2, 0, 179, 0, 0, 0, 0,
+ax_anim 1, 0, 180, 0, -10, 0, 0,
+ax_anim 2, 0, 180, 0, -16, 0, 0,
+ax_anim 3, 0, 180, 0, -20, 0, 0,
+ax_anim 4, 0, 180, 0, -21, 0, 0,
+ax_anim 4, 0, 181, 0, -22, 0, 0,
+ax_anim 3, 0, 181, 0, -21, 0, 0,
+ax_anim 2, 0, 181, 0, -17, 0, 0,
+ax_anim 1, 0, 181, 0, -8, 0, 0,
+ax_anim 2, 2, 179, 0, 7, 0, 0,
+ax_anim_terminator
+sZubatAnims_11_5:
+ax_anim 2, 0, 182, 0, 0, 0, 0,
+ax_anim 1, 0, 183, 0, -10, 0, 0,
+ax_anim 2, 0, 183, 0, -16, 0, 0,
+ax_anim 3, 0, 183, 0, -20, 0, 0,
+ax_anim 4, 0, 183, 0, -21, 0, 0,
+ax_anim 4, 0, 182, 0, -23, 0, 0,
+ax_anim 3, 0, 182, 0, -22, 0, 0,
+ax_anim 2, 0, 182, 0, -18, 0, 0,
+ax_anim 1, 0, 182, 0, -9, 0, 0,
+ax_anim 2, 2, 182, 0, 7, 0, 0,
+ax_anim_terminator
+sZubatAnims_11_6:
+ax_anim 2, 0, 185, 0, 0, 0, 0,
+ax_anim 1, 0, 186, 0, -10, 0, 0,
+ax_anim 2, 0, 186, 0, -16, 0, 0,
+ax_anim 3, 0, 186, 0, -20, 0, 0,
+ax_anim 4, 0, 186, 0, -21, 0, 0,
+ax_anim 4, 0, 187, 0, -22, 0, 0,
+ax_anim 3, 0, 187, 0, -21, 0, 0,
+ax_anim 2, 0, 187, 0, -17, 0, 0,
+ax_anim 1, 0, 187, 0, -8, 0, 0,
+ax_anim 2, 2, 185, 0, 7, 0, 0,
+ax_anim_terminator
+sZubatAnims_11_7:
+ax_anim 2, 0, 188, 0, 0, 0, 0,
+ax_anim 1, 0, 189, 0, -10, 0, 0,
+ax_anim 2, 0, 189, 0, -16, 0, 0,
+ax_anim 3, 0, 189, 0, -20, 0, 0,
+ax_anim 4, 0, 189, 0, -21, 0, 0,
+ax_anim 4, 0, 190, 0, -23, 0, 0,
+ax_anim 3, 0, 190, 0, -22, 0, 0,
+ax_anim 2, 0, 190, 0, -18, 0, 0,
+ax_anim 1, 0, 190, 0, -9, 0, 0,
+ax_anim 2, 2, 188, 0, 6, 0, 0,
+ax_anim_terminator
+sZubatAnims_11_8:
+ax_anim 2, 0, 191, 0, 0, 0, 0,
+ax_anim 1, 0, 192, 0, -10, 0, 0,
+ax_anim 2, 0, 192, 0, -16, 0, 0,
+ax_anim 3, 0, 192, 0, -20, 0, 0,
+ax_anim 4, 0, 192, 0, -21, 0, 0,
+ax_anim 4, 0, 193, 0, -23, 0, 0,
+ax_anim 3, 0, 193, 0, -22, 0, 0,
+ax_anim 2, 0, 193, 0, -18, 0, 0,
+ax_anim 1, 0, 193, 0, -9, 0, 0,
+ax_anim 2, 2, 191, 0, 6, 0, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_12_1:
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 2, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 0, 194, 0, 0, 0, 0,
+ax_anim 2, 0, 194, 1, 0, 1, 0,
+ax_anim 2, 1, 194, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_12_2:
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 2, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 0, 201, 0, 0, 0, 0,
+ax_anim 2, 0, 201, 1, -1, 1, -1,
+ax_anim 2, 1, 201, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_12_3:
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 2, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 0, 200, 0, 0, 0, 0,
+ax_anim 2, 0, 200, 0, -1, 0, -1,
+ax_anim 2, 1, 200, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_12_4:
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 2, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 0, 199, 0, 0, 0, 0,
+ax_anim 2, 0, 199, -1, -1, -1, -1,
+ax_anim 2, 1, 199, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_12_5:
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 2, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 0, 198, 0, 0, 0, 0,
+ax_anim 2, 0, 198, 1, 0, 1, 0,
+ax_anim 2, 1, 198, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_12_6:
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 2, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 0, 197, 0, 0, 0, 0,
+ax_anim 2, 0, 197, 1, -1, 1, -1,
+ax_anim 2, 1, 197, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_12_7:
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 2, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 0, 196, 0, 0, 0, 0,
+ax_anim 2, 0, 196, 0, -1, 0, -1,
+ax_anim 2, 1, 196, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_12_8:
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 2, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 0, 195, 0, 0, 0, 0,
+ax_anim 2, 0, 195, -1, -1, -1, -1,
+ax_anim 2, 1, 195, 0, 0, 0, 0,
+ax_anim_terminator
+.align 2
+sZubatAnims_13_1:
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 2, 202, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_13_2:
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 2, 209, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_13_3:
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 2, 208, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_13_4:
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 2, 207, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_13_5:
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 2, 206, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_13_6:
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 2, 205, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_13_7:
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 2, 204, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatAnims_13_8:
+ax_anim 2, 0, 203, 0, 0, 0, 0,
+ax_anim 2, 0, 204, 0, 0, 0, 0,
+ax_anim 2, 0, 205, 0, 0, 0, 0,
+ax_anim 2, 0, 206, 0, 0, 0, 0,
+ax_anim 2, 0, 207, 0, 0, 0, 0,
+ax_anim 2, 0, 208, 0, 0, 0, 0,
+ax_anim 2, 0, 209, 0, 0, 0, 0,
+ax_anim 2, 0, 202, 0, 0, 0, 0,
+ax_anim 2, 2, 203, 0, 0, 0, 0,
+ax_anim_terminator
+sZubatGfx1:
+.incbin "baserom.gba", 0x6C5758, 0x200
+sZubatSprites1:
+ax_sprite sZubatGfx1, 0x200
+ax_sprite_terminator
+sZubatGfx2:
+.incbin "baserom.gba", 0x6C5968, 0x200
+sZubatSprites2:
+ax_sprite sZubatGfx2, 0x200
+ax_sprite_terminator
+sZubatGfx3:
+.incbin "baserom.gba", 0x6C5B78, 0x200
+sZubatSprites3:
+ax_sprite sZubatGfx3, 0x200
+ax_sprite_terminator
+sZubatGfx4:
+.incbin "baserom.gba", 0x6C5D88, 0x200
+sZubatSprites4:
+ax_sprite sZubatGfx4, 0x200
+ax_sprite_terminator
+sZubatGfx5:
+.incbin "baserom.gba", 0x6C5F98, 0x200
+sZubatSprites5:
+ax_sprite sZubatGfx5, 0x200
+ax_sprite_terminator
+sZubatGfx6:
+.incbin "baserom.gba", 0x6C61A8, 0x200
+sZubatSprites6:
+ax_sprite sZubatGfx6, 0x200
+ax_sprite_terminator
+sZubatGfx7:
+.incbin "baserom.gba", 0x6C63B8, 0x200
+sZubatSprites7:
+ax_sprite sZubatGfx7, 0x200
+ax_sprite_terminator
+sZubatGfx8:
+.incbin "baserom.gba", 0x6C65C8, 0x200
+sZubatSprites8:
+ax_sprite sZubatGfx8, 0x200
+ax_sprite_terminator
+sZubatGfx9:
+.incbin "baserom.gba", 0x6C67D8, 0x200
+sZubatSprites9:
+ax_sprite sZubatGfx9, 0x200
+ax_sprite_terminator
+sZubatGfx10:
+.incbin "baserom.gba", 0x6C69E8, 0x200
+sZubatSprites10:
+ax_sprite sZubatGfx10, 0x200
+ax_sprite_terminator
+sZubatGfx11:
+.incbin "baserom.gba", 0x6C6BF8, 0x200
+sZubatSprites11:
+ax_sprite sZubatGfx11, 0x200
+ax_sprite_terminator
+sZubatGfx12:
+.incbin "baserom.gba", 0x6C6E08, 0x200
+sZubatSprites12:
+ax_sprite sZubatGfx12, 0x200
+ax_sprite_terminator
+sZubatGfx13:
+.incbin "baserom.gba", 0x6C7018, 0x200
+sZubatSprites13:
+ax_sprite sZubatGfx13, 0x200
+ax_sprite_terminator
+sZubatGfx14:
+.incbin "baserom.gba", 0x6C7228, 0x200
+sZubatSprites14:
+ax_sprite sZubatGfx14, 0x200
+ax_sprite_terminator
+sZubatGfx15:
+.incbin "baserom.gba", 0x6C7438, 0x200
+sZubatSprites15:
+ax_sprite sZubatGfx15, 0x200
+ax_sprite_terminator
+sZubatGfx16:
+.incbin "baserom.gba", 0x6C7648, 0x100
+sZubatSprites16:
+ax_sprite sZubatGfx16, 0x100
+ax_sprite_terminator
+sZubatGfx17:
+.incbin "baserom.gba", 0x6C7758, 0x100
+sZubatSprites17:
+ax_sprite sZubatGfx17, 0x100
+ax_sprite_terminator
+sZubatGfx18:
+.incbin "baserom.gba", 0x6C7868, 0x200
+sZubatSprites18:
+ax_sprite sZubatGfx18, 0x200
+ax_sprite_terminator
+sZubatGfx19:
+.incbin "baserom.gba", 0x6C7A78, 0x200
+sZubatSprites19:
+ax_sprite sZubatGfx19, 0x200
+ax_sprite_terminator
+sZubatGfx20:
+.incbin "baserom.gba", 0x6C7C88, 0x200
+sZubatSprites20:
+ax_sprite sZubatGfx20, 0x200
+ax_sprite_terminator
+sZubatGfx21:
+.incbin "baserom.gba", 0x6C7E98, 0x200
+sZubatSprites21:
+ax_sprite sZubatGfx21, 0x200
+ax_sprite_terminator
+sZubatGfx22:
+.incbin "baserom.gba", 0x6C80A8, 0x200
+sZubatSprites22:
+ax_sprite sZubatGfx22, 0x200
+ax_sprite_terminator
+sAxPosesZubat:
+.4byte sZubatPose1
+.4byte sZubatPose2
+.4byte sZubatPose3
+.4byte sZubatPose4
+.4byte sZubatPose5
+.4byte sZubatPose6
+.4byte sZubatPose7
+.4byte sZubatPose8
+.4byte sZubatPose9
+.4byte sZubatPose10
+.4byte sZubatPose11
+.4byte sZubatPose12
+.4byte sZubatPose13
+.4byte sZubatPose14
+.4byte sZubatPose15
+.4byte sZubatPose16
+.4byte sZubatPose17
+.4byte sZubatPose18
+.4byte sZubatPose19
+.4byte sZubatPose20
+.4byte sZubatPose21
+.4byte sZubatPose22
+.4byte sZubatPose23
+.4byte sZubatPose24
+.4byte sZubatPose25
+.4byte sZubatPose26
+.4byte sZubatPose27
+.4byte sZubatPose28
+.4byte sZubatPose29
+.4byte sZubatPose30
+.4byte sZubatPose31
+.4byte sZubatPose32
+.4byte sZubatPose33
+.4byte sZubatPose34
+.4byte sZubatPose35
+.4byte sZubatPose36
+.4byte sZubatPose37
+.4byte sZubatPose38
+.4byte sZubatPose39
+.4byte sZubatPose40
+.4byte sZubatPose41
+.4byte sZubatPose42
+.4byte sZubatPose43
+.4byte sZubatPose44
+.4byte sZubatPose45
+.4byte sZubatPose46
+.4byte sZubatPose47
+.4byte sZubatPose48
+.4byte sZubatPose49
+.4byte sZubatPose50
+.4byte sZubatPose51
+.4byte sZubatPose52
+.4byte sZubatPose53
+.4byte sZubatPose54
+.4byte sZubatPose55
+.4byte sZubatPose56
+.4byte sZubatPose57
+.4byte sZubatPose58
+.4byte sZubatPose59
+.4byte sZubatPose60
+.4byte sZubatPose61
+.4byte sZubatPose62
+.4byte sZubatPose63
+.4byte sZubatPose64
+.4byte sZubatPose65
+.4byte sZubatPose66
+.4byte sZubatPose67
+.4byte sZubatPose68
+.4byte sZubatPose69
+.4byte sZubatPose70
+.4byte sZubatPose71
+.4byte sZubatPose72
+.4byte sZubatPose73
+.4byte sZubatPose74
+.4byte sZubatPose75
+.4byte sZubatPose76
+.4byte sZubatPose77
+.4byte sZubatPose78
+.4byte sZubatPose79
+.4byte sZubatPose80
+.4byte sZubatPose81
+.4byte sZubatPose82
+.4byte sZubatPose83
+.4byte sZubatPose84
+.4byte sZubatPose85
+.4byte sZubatPose86
+.4byte sZubatPose87
+.4byte sZubatPose88
+.4byte sZubatPose89
+.4byte sZubatPose90
+.4byte sZubatPose91
+.4byte sZubatPose92
+.4byte sZubatPose93
+.4byte sZubatPose94
+.4byte sZubatPose95
+.4byte sZubatPose96
+.4byte sZubatPose97
+.4byte sZubatPose98
+.4byte sZubatPose99
+.4byte sZubatPose100
+.4byte sZubatPose101
+.4byte sZubatPose102
+.4byte sZubatPose103
+.4byte sZubatPose104
+.4byte sZubatPose105
+.4byte sZubatPose106
+.4byte sZubatPose107
+.4byte sZubatPose108
+.4byte sZubatPose109
+.4byte sZubatPose110
+.4byte sZubatPose111
+.4byte sZubatPose112
+.4byte sZubatPose113
+.4byte sZubatPose114
+.4byte sZubatPose115
+.4byte sZubatPose116
+.4byte sZubatPose117
+.4byte sZubatPose118
+.4byte sZubatPose119
+.4byte sZubatPose120
+.4byte sZubatPose121
+.4byte sZubatPose122
+.4byte sZubatPose123
+.4byte sZubatPose124
+.4byte sZubatPose125
+.4byte sZubatPose126
+.4byte sZubatPose127
+.4byte sZubatPose128
+.4byte sZubatPose129
+.4byte sZubatPose130
+.4byte sZubatPose131
+.4byte sZubatPose132
+.4byte sZubatPose133
+.4byte sZubatPose134
+.4byte sZubatPose135
+.4byte sZubatPose136
+.4byte sZubatPose137
+.4byte sZubatPose138
+.4byte sZubatPose139
+.4byte sZubatPose140
+.4byte sZubatPose141
+.4byte sZubatPose142
+.4byte sZubatPose143
+.4byte sZubatPose144
+.4byte sZubatPose145
+.4byte sZubatPose146
+.4byte sZubatPose147
+.4byte sZubatPose148
+.4byte sZubatPose149
+.4byte sZubatPose150
+.4byte sZubatPose151
+.4byte sZubatPose152
+.4byte sZubatPose153
+.4byte sZubatPose154
+.4byte sZubatPose155
+.4byte sZubatPose156
+.4byte sZubatPose157
+.4byte sZubatPose158
+.4byte sZubatPose159
+.4byte sZubatPose160
+.4byte sZubatPose161
+.4byte sZubatPose162
+.4byte sZubatPose163
+.4byte sZubatPose164
+.4byte sZubatPose165
+.4byte sZubatPose166
+.4byte sZubatPose167
+.4byte sZubatPose168
+.4byte sZubatPose169
+.4byte sZubatPose170
+.4byte sZubatPose171
+.4byte sZubatPose172
+.4byte sZubatPose173
+.4byte sZubatPose174
+.4byte sZubatPose175
+.4byte sZubatPose176
+.4byte sZubatPose177
+.4byte sZubatPose178
+.4byte sZubatPose179
+.4byte sZubatPose180
+.4byte sZubatPose181
+.4byte sZubatPose182
+.4byte sZubatPose183
+.4byte sZubatPose184
+.4byte sZubatPose185
+.4byte sZubatPose186
+.4byte sZubatPose187
+.4byte sZubatPose188
+.4byte sZubatPose189
+.4byte sZubatPose190
+.4byte sZubatPose191
+.4byte sZubatPose192
+.4byte sZubatPose193
+.4byte sZubatPose194
+.4byte sZubatPose195
+.4byte sZubatPose196
+.4byte sZubatPose197
+.4byte sZubatPose198
+.4byte sZubatPose199
+.4byte sZubatPose200
+.4byte sZubatPose201
+.4byte sZubatPose202
+.4byte sZubatPose203
+.4byte sZubatPose204
+.4byte sZubatPose205
+.4byte sZubatPose206
+.4byte sZubatPose207
+.4byte sZubatPose208
+.4byte sZubatPose209
+.4byte sZubatPose210
+sAxPositionsZubat:
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte    0,  -15, 	  -7,  -14, 	   7,  -14, 	   0,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    4,  -16, 	   9,  -17, 	  -1,  -12, 	   0,  -15
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    6,  -17, 	   5,  -17, 	   3,  -11, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    3,  -20, 	  -3,  -21, 	   7,  -15, 	   1,  -19
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    0,  -20, 	   7,  -18, 	  -7,  -18, 	   0,  -18
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte   -3,  -20, 	   3,  -21, 	  -7,  -15, 	  -1,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -6,  -17, 	  -5,  -17, 	  -3,  -11, 	   0,  -16
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -4,  -16, 	  -9,  -17, 	   1,  -12, 	   0,  -15
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte    0,  -15, 	  -7,  -14, 	   7,  -14, 	   0,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    4,  -16, 	   9,  -17, 	  -1,  -12, 	   0,  -15
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    6,  -17, 	   5,  -17, 	   3,  -11, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    3,  -20, 	  -3,  -21, 	   7,  -15, 	   1,  -19
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    0,  -20, 	   7,  -18, 	  -7,  -18, 	   0,  -18
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte   -3,  -20, 	   3,  -21, 	  -7,  -15, 	  -1,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -6,  -17, 	  -5,  -17, 	  -3,  -11, 	   0,  -16
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -4,  -16, 	  -9,  -17, 	   1,  -12, 	   0,  -15
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte    0,  -15, 	  -7,  -14, 	   7,  -14, 	   0,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    4,  -16, 	   9,  -17, 	  -1,  -12, 	   0,  -15
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    6,  -17, 	   5,  -17, 	   3,  -11, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    3,  -20, 	  -3,  -21, 	   7,  -15, 	   1,  -19
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    0,  -20, 	   7,  -18, 	  -7,  -18, 	   0,  -18
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte   -3,  -20, 	   3,  -21, 	  -7,  -15, 	  -1,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -6,  -17, 	  -5,  -17, 	  -3,  -11, 	   0,  -16
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -4,  -16, 	  -9,  -17, 	   1,  -12, 	   0,  -15
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte    0,  -15, 	  -7,  -14, 	   7,  -14, 	   0,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    4,  -16, 	   9,  -17, 	  -1,  -12, 	   0,  -15
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    6,  -17, 	   5,  -17, 	   3,  -11, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    3,  -20, 	  -3,  -21, 	   7,  -15, 	   1,  -19
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    0,  -20, 	   7,  -18, 	  -7,  -18, 	   0,  -18
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte   -3,  -20, 	   3,  -21, 	  -7,  -15, 	  -1,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -6,  -17, 	  -5,  -17, 	  -3,  -11, 	   0,  -16
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -4,  -16, 	  -9,  -17, 	   1,  -12, 	   0,  -15
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte    0,  -15, 	  -7,  -14, 	   7,  -14, 	   0,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    4,  -16, 	   9,  -17, 	  -1,  -12, 	   0,  -15
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    6,  -17, 	   5,  -17, 	   3,  -11, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    3,  -20, 	  -3,  -21, 	   7,  -15, 	   1,  -19
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    0,  -20, 	   7,  -18, 	  -7,  -18, 	   0,  -18
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte   -3,  -20, 	   3,  -21, 	  -7,  -15, 	  -1,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -6,  -17, 	  -5,  -17, 	  -3,  -11, 	   0,  -16
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -4,  -16, 	  -9,  -17, 	   1,  -12, 	   0,  -15
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,   -6, 	  -7,   -3, 	   7,   -3, 	   0,   -5
+.2byte    0,   -4, 	  -8,   -3, 	   8,   -3, 	   0,   -5
+.2byte    1,    2, 	  -9,   -9, 	   5,  -12, 	   0,   -4
+.2byte    3,    1, 	   5,  -12, 	  -4,  -16, 	   1,   -4
+.2byte    5,    0, 	   3,  -12, 	  -1,  -14, 	   0,   -4
+.2byte    3,   -1, 	  -5,  -12, 	   7,  -16, 	  -1,   -5
+.2byte    0,   -5, 	   6,   -6, 	  -6,  -12, 	   0,   -4
+.2byte   -4,   -1, 	   4,  -12, 	  -8,  -16, 	   0,   -5
+.2byte   -6,   -1, 	  -4,  -13, 	   0,  -15, 	  -1,   -5
+.2byte   -3,    1, 	  -5,  -12, 	   4,  -16, 	  -1,   -4
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte    0,  -15, 	  -7,  -14, 	   7,  -14, 	   0,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    4,  -16, 	   9,  -17, 	  -1,  -12, 	   0,  -15
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    6,  -17, 	   5,  -17, 	   3,  -11, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    3,  -20, 	  -3,  -21, 	   7,  -15, 	   1,  -19
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    0,  -20, 	   7,  -18, 	  -7,  -18, 	   0,  -18
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte   -3,  -20, 	   3,  -21, 	  -7,  -15, 	  -1,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -6,  -17, 	  -5,  -17, 	  -3,  -11, 	   0,  -16
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -4,  -16, 	  -9,  -17, 	   1,  -12, 	   0,  -15
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte    0,  -15, 	  -7,  -14, 	   7,  -14, 	   0,  -16
+.2byte    0,  -15, 	  -8,  -23, 	   8,  -23, 	   0,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    4,  -16, 	   9,  -17, 	  -1,  -12, 	   0,  -15
+.2byte    4,  -16, 	   4,  -25, 	  -7,  -22, 	   0,  -16
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    6,  -17, 	   5,  -17, 	   3,  -11, 	   0,  -16
+.2byte    6,  -17, 	  -2,  -25, 	  -2,  -20, 	   0,  -16
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    3,  -20, 	  -3,  -21, 	   7,  -15, 	   1,  -19
+.2byte    3,  -20, 	  -6,  -26, 	   6,  -20, 	   1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    0,  -20, 	   7,  -18, 	  -7,  -18, 	   0,  -18
+.2byte    0,  -20, 	   7,  -24, 	  -7,  -24, 	   0,  -19
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte   -3,  -20, 	   3,  -21, 	  -7,  -15, 	  -1,  -19
+.2byte   -3,  -20, 	   6,  -26, 	  -6,  -20, 	  -1,  -19
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -6,  -17, 	  -5,  -17, 	  -3,  -11, 	   0,  -16
+.2byte   -6,  -17, 	   2,  -25, 	   2,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -4,  -16, 	  -9,  -17, 	   1,  -12, 	   0,  -15
+.2byte   -4,  -16, 	  -4,  -25, 	   7,  -22, 	   0,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+.2byte    0,  -15, 	  -9,  -20, 	   9,  -20, 	   0,  -16
+.2byte   -4,  -16, 	  -8,  -22, 	   6,  -17, 	  -1,  -16
+.2byte   -6,  -17, 	   0,  -24, 	   0,  -15, 	  -1,  -16
+.2byte   -3,  -20, 	   3,  -25, 	  -8,  -18, 	  -1,  -19
+.2byte    0,  -20, 	   9,  -22, 	  -9,  -22, 	   0,  -19
+.2byte    3,  -20, 	  -3,  -25, 	   8,  -18, 	   1,  -19
+.2byte    6,  -17, 	   0,  -24, 	   0,  -15, 	   1,  -16
+.2byte    4,  -16, 	   8,  -22, 	  -6,  -17, 	   1,  -16
+sZubatAnimTable1:
+.4byte sZubatAnims_1_1
+.4byte sZubatAnims_1_2
+.4byte sZubatAnims_1_3
+.4byte sZubatAnims_1_4
+.4byte sZubatAnims_1_5
+.4byte sZubatAnims_1_6
+.4byte sZubatAnims_1_7
+.4byte sZubatAnims_1_8
+sZubatAnimTable2:
+.4byte sZubatAnims_2_1
+.4byte sZubatAnims_2_2
+.4byte sZubatAnims_2_3
+.4byte sZubatAnims_2_4
+.4byte sZubatAnims_2_5
+.4byte sZubatAnims_2_6
+.4byte sZubatAnims_2_7
+.4byte sZubatAnims_2_8
+sZubatAnimTable3:
+.4byte sZubatAnims_3_1
+.4byte sZubatAnims_3_2
+.4byte sZubatAnims_3_3
+.4byte sZubatAnims_3_4
+.4byte sZubatAnims_3_5
+.4byte sZubatAnims_3_6
+.4byte sZubatAnims_3_7
+.4byte sZubatAnims_3_8
+sZubatAnimTable4:
+.4byte sZubatAnims_4_1
+.4byte sZubatAnims_4_2
+.4byte sZubatAnims_4_3
+.4byte sZubatAnims_4_4
+.4byte sZubatAnims_4_5
+.4byte sZubatAnims_4_6
+.4byte sZubatAnims_4_7
+.4byte sZubatAnims_4_8
+sZubatAnimTable5:
+.4byte sZubatAnims_5_1
+.4byte sZubatAnims_5_2
+.4byte sZubatAnims_5_3
+.4byte sZubatAnims_5_4
+.4byte sZubatAnims_5_5
+.4byte sZubatAnims_5_6
+.4byte sZubatAnims_5_7
+.4byte sZubatAnims_5_8
+sZubatAnimTable6:
+.4byte sZubatAnims_6_1
+.4byte sZubatAnims_6_1
+.4byte sZubatAnims_6_1
+.4byte sZubatAnims_6_1
+.4byte sZubatAnims_6_1
+.4byte sZubatAnims_6_1
+.4byte sZubatAnims_6_1
+.4byte sZubatAnims_6_1
+sZubatAnimTable7:
+.4byte sZubatAnims_7_1
+.4byte sZubatAnims_7_2
+.4byte sZubatAnims_7_3
+.4byte sZubatAnims_7_4
+.4byte sZubatAnims_7_5
+.4byte sZubatAnims_7_6
+.4byte sZubatAnims_7_7
+.4byte sZubatAnims_7_8
+sZubatAnimTable8:
+.4byte sZubatAnims_8_1
+.4byte sZubatAnims_8_2
+.4byte sZubatAnims_8_3
+.4byte sZubatAnims_8_4
+.4byte sZubatAnims_8_5
+.4byte sZubatAnims_8_6
+.4byte sZubatAnims_8_7
+.4byte sZubatAnims_8_8
+sZubatAnimTable9:
+.4byte sZubatAnims_9_1
+.4byte sZubatAnims_9_2
+.4byte sZubatAnims_9_3
+.4byte sZubatAnims_9_4
+.4byte sZubatAnims_9_5
+.4byte sZubatAnims_9_6
+.4byte sZubatAnims_9_7
+.4byte sZubatAnims_9_8
+sZubatAnimTable10:
+.4byte sZubatAnims_10_1
+.4byte sZubatAnims_10_2
+.4byte sZubatAnims_10_3
+.4byte sZubatAnims_10_4
+.4byte sZubatAnims_10_5
+.4byte sZubatAnims_10_6
+.4byte sZubatAnims_10_7
+.4byte sZubatAnims_10_8
+sZubatAnimTable11:
+.4byte sZubatAnims_11_1
+.4byte sZubatAnims_11_2
+.4byte sZubatAnims_11_3
+.4byte sZubatAnims_11_4
+.4byte sZubatAnims_11_5
+.4byte sZubatAnims_11_6
+.4byte sZubatAnims_11_7
+.4byte sZubatAnims_11_8
+sZubatAnimTable12:
+.4byte sZubatAnims_12_1
+.4byte sZubatAnims_12_2
+.4byte sZubatAnims_12_3
+.4byte sZubatAnims_12_4
+.4byte sZubatAnims_12_5
+.4byte sZubatAnims_12_6
+.4byte sZubatAnims_12_7
+.4byte sZubatAnims_12_8
+sZubatAnimTable13:
+.4byte sZubatAnims_13_1
+.4byte sZubatAnims_13_2
+.4byte sZubatAnims_13_3
+.4byte sZubatAnims_13_4
+.4byte sZubatAnims_13_5
+.4byte sZubatAnims_13_6
+.4byte sZubatAnims_13_7
+.4byte sZubatAnims_13_8
+sAxAnimationsZubat:
+.4byte sZubatAnimTable1
+.4byte sZubatAnimTable2
+.4byte sZubatAnimTable3
+.4byte sZubatAnimTable4
+.4byte sZubatAnimTable5
+.4byte sZubatAnimTable6
+.4byte sZubatAnimTable7
+.4byte sZubatAnimTable8
+.4byte sZubatAnimTable9
+.4byte sZubatAnimTable10
+.4byte sZubatAnimTable11
+.4byte sZubatAnimTable12
+.4byte sZubatAnimTable13
+sAxSpritesZubat:
+.4byte sZubatSprites1
+.4byte sZubatSprites2
+.4byte sZubatSprites3
+.4byte sZubatSprites4
+.4byte sZubatSprites5
+.4byte sZubatSprites6
+.4byte sZubatSprites7
+.4byte sZubatSprites8
+.4byte sZubatSprites9
+.4byte sZubatSprites10
+.4byte sZubatSprites11
+.4byte sZubatSprites12
+.4byte sZubatSprites13
+.4byte sZubatSprites14
+.4byte sZubatSprites15
+.4byte sZubatSprites16
+.4byte sZubatSprites17
+.4byte sZubatSprites18
+.4byte sZubatSprites19
+.4byte sZubatSprites20
+.4byte sZubatSprites21
+.4byte sZubatSprites22
+sAxMainZubat:
+ax_main sAxPosesZubat, sAxAnimationsZubat, 13, sAxSpritesZubat, sAxPositionsZubat

--- a/include/structs/axdata.h
+++ b/include/structs/axdata.h
@@ -64,7 +64,7 @@ typedef struct axdata
     /* 0x8 */ axdata1 sub1;
     /* 0x28 */ ax_anim *nextAnimData; // next animation data (if flags&0x1000)
     /* 0x2C */ ax_anim *activeAnimData; // current animation data
-    /* 0x30 */ void *paletteData; // ?
+    /* 0x30 */ DungeonPos *positions;
     /* 0x34 */ ax_pose **poseData;
     /* 0x38 */ UnkSpriteMem **spriteData;
 } axdata;
@@ -75,8 +75,8 @@ typedef struct axmain
     /* 0x0 */ ax_pose **poses;
     /* 0x4 */ ax_anim ***animations;
     /* 0x8 */ u32 animCount;
-    /* 0xC */ void *spriteData; // ?
-    /* 0x10 */ void *palettes; // ?
+    /* 0xC */ UnkSpriteMem **spriteData;
+    /* 0x10 */ DungeonPos *positions;
 } axmain;
 
 // size: 0x4C

--- a/include/structs/axdata.h
+++ b/include/structs/axdata.h
@@ -38,7 +38,7 @@ typedef struct __attribute__((packed, aligned(2))) ax_pose_unk2
 typedef struct __attribute__((packed, aligned(2))) ax_pose
 {
     /* 0x0 */ s16 sprite;
-    /* 0x2 */ ax_pose_unk2 unk2; // Always {0, 0} in red (except for end markers which are {0xFF, 0xFF})
+    /* 0x2 */ ax_pose_unk2 unk2; // Always {0, 0} in red (except for end markers {0xFF, 0xFF} and Latios Pose189...)
     /* 0x4 */ u16 flags1;
     /* 0x6 */ u16 flags2;
     /* 0x8 */ u16 flags3;

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -74,10 +74,10 @@ void sub_800569C(DungeonPos *a0, struct axObject *a1, u8 a2)
     if (!(a1->axdata.flags >> 15) || a2 >= 4)
         return;
 
-    if (a1->axdata.paletteData != NULL) {
-        ptr = &((DungeonPos*)a1->axdata.paletteData)[a1->axdata.sub1.poseId * 4];
+    if (a1->axdata.positions != NULL) {
+        ptr = &(a1->axdata.positions)[a1->axdata.sub1.poseId * 4];
         ptr2 = &ptr[a2];
-        if (*&ptr2->x == 99 && *&ptr2->y == 99) {
+        if (*&ptr2->x == 99 && ptr2->y == 99) {
             a0->x = 99;
             a0->y = 99;
         }
@@ -96,21 +96,21 @@ void sub_800569C(DungeonPos *a0, struct axObject *a1, u8 a2)
 void sub_8005700(DungeonPos *a0, struct axObject *a1)
 {
     s32 i;
-    DungeonPos *ptr;
 
     if (!(a1->axdata.flags >> 15))
         return;
 
-    if (a1->axdata.paletteData != NULL) {
-        ptr = &((DungeonPos*)a1->axdata.paletteData)[a1->axdata.sub1.poseId * 4];
+    if (a1->axdata.positions != NULL) {
+        DungeonPos *positions = &(a1->axdata.positions)[a1->axdata.sub1.poseId * 4];
         for (i = 0; i < 4; i++) {
-            if (*&ptr[i].x == 99 && *&ptr[i].y == 99) {
+            s32 x = positions[i].x;
+            if (x == 99 && positions[i].y == 99) {
                 a0->x = 99;
                 a0->y = 99;
             }
             else {
-                a0->x = a1->axdata.sub1.offset.x + ptr[i].x;
-                a0->y = a1->axdata.sub1.offset.y + ptr[i].y;
+                a0->x = a1->axdata.sub1.offset.x + positions[i].x;
+                a0->y = a1->axdata.sub1.offset.y + positions[i].y;
             }
             a0++;
         }

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -487,7 +487,7 @@ void AxResInit(axdata *a0, axmain *a1, u32 a2, u32 direction, u32 a4, u32 sprite
     a0->activeAnimData = a0->nextAnimData;
     a0->poseData = a1->poses;
     a0->spriteData = a1->spriteData;
-    a0->paletteData = a1->palettes;
+    a0->positions = a1->positions;
 }
 
 void AxResInitUnorientedFile(axdata *a0, OpenedFile *a1, u32 a2, u32 a3, u32 spriteAnimIndex, bool8 a5)
@@ -514,7 +514,7 @@ static void AxResInitUnoriented(axdata *a0, axmain *a1, u32 a2, u32 a3, u32 spri
     a0->nextAnimData = a1->animations[a2][0];
     a0->activeAnimData = a0->nextAnimData;
     a0->poseData = a1->poses;
-    a0->paletteData = 0;
+    a0->positions = NULL;
 }
 
 static inline s16 check_flag_for_80054BC(u16 flags) {


### PR DESCRIPTION
All incbins are gone except for graphics...The gfx could be dumped already, but I think it'd better to have them as sprite sheets with all mon sprites in one pic, instead of 70 separate pics for one mon.

Now this should bump the percentage of documented symbols quite a bit.